### PR TITLE
[Wayland] Explicitly set min/max size for xdg-shell

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -206,6 +206,8 @@ Wayland_CreateDevice(int devindex)
     device->SetWindowBordered = Wayland_SetWindowBordered;
     device->SetWindowResizable = Wayland_SetWindowResizable;
     device->SetWindowSize = Wayland_SetWindowSize;
+    device->SetWindowMinimumSize = Wayland_SetWindowMinimumSize;
+    device->SetWindowMaximumSize = Wayland_SetWindowMaximumSize;
     device->SetWindowTitle = Wayland_SetWindowTitle;
     device->DestroyWindow = Wayland_DestroyWindow;
     device->SetWindowHitTest = Wayland_SetWindowHitTest;

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -98,6 +98,8 @@ extern void Wayland_SetWindowBordered(_THIS, SDL_Window * window, SDL_bool borde
 extern void Wayland_SetWindowResizable(_THIS, SDL_Window * window, SDL_bool resizable);
 extern int Wayland_CreateWindow(_THIS, SDL_Window *window);
 extern void Wayland_SetWindowSize(_THIS, SDL_Window * window);
+extern void Wayland_SetWindowMinimumSize(_THIS, SDL_Window * window);
+extern void Wayland_SetWindowMaximumSize(_THIS, SDL_Window * window);
 extern void Wayland_SetWindowTitle(_THIS, SDL_Window * window);
 extern void Wayland_DestroyWindow(_THIS, SDL_Window *window);
 extern void Wayland_SuspendScreenSaver(_THIS);


### PR DESCRIPTION
This is a Git-based replacement for #4047.

As a refresher: Wayland desktops currently have no way of knowing that our window is fixed-size; while we do ignore resize events in our callbacks, the desktop will still provide resize UI and a maximize button that can mess with the window in unintended ways. This patch is meant to address this, though on KDE the fix doesn't work until you toggle the border. If anyone familiar with KDE's implementation of server-side decorations we could use some help with this one...