### PR TITLE
wayland: Minor whitespace fix

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -928,7 +928,7 @@ void Wayland_SetWindowTitle(_THIS, SDL_Window * window)
 {
     SDL_WindowData *wind = window->driverdata;
     SDL_VideoData *viddata = (SDL_VideoData *) _this->driverdata;
-    
+
     if (window->title != NULL) {
         if (viddata->shell.xdg) {
             xdg_toplevel_set_title(wind->shell_surface.xdg.roleobj.toplevel, window->title);


### PR DESCRIPTION
This is a Git-based replacement for a patch in #3739.

Not much to see here, just some trailing whitespace in one of the Wayland files.