### PR TITLE
Update wiki.libsdl.org urls to libsdl-org/SDL/wiki

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -5,7 +5,7 @@ To compile and install SDL:
         * Read VisualC.html
 
         Windows with gcc, either native or cross-compiling:
-        * Read the FAQ at https://wiki.libsdl.org/moin.fcg/FAQWindows
+        * Read the FAQ at https://github.com/libsdl-org/SDL/wiki/moin.fcg/FAQWindows
         * Run './configure; make; make install'
 
         Mac OS X with Xcode:
@@ -27,7 +27,7 @@ To compile and install SDL:
         * Read docs/README-cmake.md
 
     2.  Look at the example programs in ./test, and check out the online
-        documentation at https://wiki.libsdl.org/
+        documentation at https://github.com/libsdl-org/SDL/wiki/
 
     3.  Join the SDL developer mailing list by sending E-mail to
     	sdl-request@libsdl.org

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -5,7 +5,7 @@ To compile and install SDL:
         * Read VisualC.html
 
         Windows with gcc, either native or cross-compiling:
-        * Read the FAQ at https://github.com/libsdl-org/SDL/wiki/moin.fcg/FAQWindows
+        * Read the FAQ at https://github.com/libsdl-org/SDL/wiki/FAQWindows
         * Run './configure; make; make install'
 
         Mac OS X with Xcode:

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,5 +1,5 @@
 Future work roadmap:
- * http://wiki.libsdl.org/moin.cgi/Roadmap
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/Roadmap
 
  * Check 1.2 revisions:
 	3554 - Need to resolve semantics for locking keys on different platforms

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,5 +1,5 @@
 Future work roadmap:
- * http://github.com/libsdl-org/SDL/wiki/Roadmap
+ * https://github.com/libsdl-org/SDL/wiki/Roadmap
 
  * Check 1.2 revisions:
 	3554 - Need to resolve semantics for locking keys on different platforms

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,5 +1,5 @@
 Future work roadmap:
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/Roadmap
+ * http://github.com/libsdl-org/SDL/wiki/Roadmap
 
  * Check 1.2 revisions:
 	3554 - Need to resolve semantics for locking keys on different platforms

--- a/docs/README-git.md
+++ b/docs/README-git.md
@@ -15,5 +15,5 @@ If you are building SDL via configure, you will need to run autogen.sh
 before running configure.
 
 There is a web interface to the Git repository at:
-	http://github.com/libsdl-org/SDL/
+	https://github.com/libsdl-org/SDL/
 

--- a/docs/README-platforms.md
+++ b/docs/README-platforms.md
@@ -4,5 +4,5 @@ Platforms
 We maintain the list of supported platforms on our wiki now, and how to
 build and install SDL for those platforms:
 
-    https://wiki.libsdl.org/Installation
+    https://github.com/libsdl-org/SDL/wiki/Installation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ The best way to learn how to use SDL is to check out the header files in
 the "include" subdirectory and the programs in the "test" subdirectory.
 The header files and test programs are well commented and always up to date.
 
-More documentation and FAQs are available online at [the wiki](http://wiki.libsdl.org/)
+More documentation and FAQs are available online at [the wiki](http://github.com/libsdl-org/SDL/wiki/)
 
 - [Android](README-android.md)
 - [CMake](README-cmake.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ The best way to learn how to use SDL is to check out the header files in
 the "include" subdirectory and the programs in the "test" subdirectory.
 The header files and test programs are well commented and always up to date.
 
-More documentation and FAQs are available online at [the wiki](http://github.com/libsdl-org/SDL/wiki/)
+More documentation and FAQs are available online at [the wiki](https://github.com/libsdl-org/SDL/wiki/)
 
 - [Android](README-android.md)
 - [CMake](README-cmake.md)

--- a/test/testautomation_audio.c
+++ b/test/testautomation_audio.c
@@ -59,8 +59,8 @@ void SDLCALL _audio_testCallback(void *userdata, Uint8 *stream, int len)
 /**
  * \brief Stop and restart audio subsystem
  *
- * \sa https://wiki.libsdl.org/SDL_QuitSubSystem
- * \sa https://wiki.libsdl.org/SDL_InitSubSystem
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_QuitSubSystem
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_InitSubSystem
  */
 int audio_quitInitAudioSubSystem()
 {
@@ -77,8 +77,8 @@ int audio_quitInitAudioSubSystem()
 /**
  * \brief Start and stop audio directly
  *
- * \sa https://wiki.libsdl.org/SDL_InitAudio
- * \sa https://wiki.libsdl.org/SDL_QuitAudio
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_InitAudio
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_QuitAudio
  */
 int audio_initQuitAudio()
 {
@@ -131,10 +131,10 @@ int audio_initQuitAudio()
 /**
  * \brief Start, open, close and stop audio
  *
- * \sa https://wiki.libsdl.org/SDL_InitAudio
- * \sa https://wiki.libsdl.org/SDL_OpenAudio
- * \sa https://wiki.libsdl.org/SDL_CloseAudio
- * \sa https://wiki.libsdl.org/SDL_QuitAudio
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_InitAudio
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_OpenAudio
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_CloseAudio
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_QuitAudio
  */
 int audio_initOpenCloseQuitAudio()
 {
@@ -220,7 +220,7 @@ int audio_initOpenCloseQuitAudio()
 /**
  * \brief Pause and unpause audio
  *
- * \sa https://wiki.libsdl.org/SDL_PauseAudio
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_PauseAudio
  */
 int audio_pauseUnpauseAudio()
 {
@@ -340,8 +340,8 @@ int audio_pauseUnpauseAudio()
 /**
  * \brief Enumerate and name available audio devices (output and capture).
  *
- * \sa https://wiki.libsdl.org/SDL_GetNumAudioDevices
- * \sa https://wiki.libsdl.org/SDL_GetAudioDeviceName
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_GetNumAudioDevices
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_GetAudioDeviceName
  */
 int audio_enumerateAndNameAudioDevices()
 {
@@ -398,8 +398,8 @@ int audio_enumerateAndNameAudioDevices()
 /**
  * \brief Negative tests around enumeration and naming of audio devices.
  *
- * \sa https://wiki.libsdl.org/SDL_GetNumAudioDevices
- * \sa https://wiki.libsdl.org/SDL_GetAudioDeviceName
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_GetNumAudioDevices
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_GetAudioDeviceName
  */
 int audio_enumerateAndNameAudioDevicesNegativeTests()
 {
@@ -445,8 +445,8 @@ int audio_enumerateAndNameAudioDevicesNegativeTests()
 /**
  * \brief Checks available audio driver names.
  *
- * \sa https://wiki.libsdl.org/SDL_GetNumAudioDrivers
- * \sa https://wiki.libsdl.org/SDL_GetAudioDriver
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_GetNumAudioDrivers
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_GetAudioDriver
  */
 int audio_printAudioDrivers()
 {
@@ -478,7 +478,7 @@ int audio_printAudioDrivers()
 /**
  * \brief Checks current audio driver name with initialized audio.
  *
- * \sa https://wiki.libsdl.org/SDL_GetCurrentAudioDriver
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_GetCurrentAudioDriver
  */
 int audio_printCurrentAudioDriver()
 {
@@ -510,7 +510,7 @@ int _audioFrequencies[] = { 11025, 22050, 44100, 48000 };
 /**
  * \brief Builds various audio conversion structures
  *
- * \sa https://wiki.libsdl.org/SDL_BuildAudioCVT
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_BuildAudioCVT
  */
 int audio_buildAudioCVT()
 {
@@ -574,7 +574,7 @@ int audio_buildAudioCVT()
 /**
  * \brief Checkes calls with invalid input to SDL_BuildAudioCVT
  *
- * \sa https://wiki.libsdl.org/SDL_BuildAudioCVT
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_BuildAudioCVT
  */
 int audio_buildAudioCVTNegative()
 {
@@ -669,7 +669,7 @@ int audio_buildAudioCVTNegative()
 /**
  * \brief Checks current audio status.
  *
- * \sa https://wiki.libsdl.org/SDL_GetAudioStatus
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_GetAudioStatus
  */
 int audio_getAudioStatus()
 {
@@ -690,7 +690,7 @@ int audio_getAudioStatus()
 /**
  * \brief Opens, checks current audio status, and closes a device.
  *
- * \sa https://wiki.libsdl.org/SDL_GetAudioStatus
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_GetAudioStatus
  */
 int audio_openCloseAndGetAudioStatus()
 {
@@ -748,8 +748,8 @@ int audio_openCloseAndGetAudioStatus()
 /**
  * \brief Locks and unlocks open audio device.
  *
- * \sa https://wiki.libsdl.org/SDL_LockAudioDevice
- * \sa https://wiki.libsdl.org/SDL_UnlockAudioDevice
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_LockAudioDevice
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_UnlockAudioDevice
  */
 int audio_lockUnlockOpenAudioDevice()
 {
@@ -811,8 +811,8 @@ int audio_lockUnlockOpenAudioDevice()
 /**
  * \brief Convert audio using various conversion structures
  *
- * \sa https://wiki.libsdl.org/SDL_BuildAudioCVT
- * \sa https://wiki.libsdl.org/SDL_ConvertAudio
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_BuildAudioCVT
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_ConvertAudio
  */
 int audio_convertAudio()
 {
@@ -910,7 +910,7 @@ int audio_convertAudio()
 /**
  * \brief Opens, checks current connected status, and closes a device.
  *
- * \sa https://wiki.libsdl.org/SDL_AudioDeviceConnected
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_AudioDeviceConnected
  */
 int audio_openCloseAudioDeviceConnected()
 {

--- a/test/testautomation_clipboard.c
+++ b/test/testautomation_clipboard.c
@@ -16,7 +16,7 @@
  * \brief Check call to SDL_HasClipboardText
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasClipboardText
+ * http://github.com/libsdl-org/SDL/wiki/SDL_HasClipboardText
  */
 int
 clipboard_testHasClipboardText(void *arg)
@@ -32,7 +32,7 @@ clipboard_testHasClipboardText(void *arg)
  * \brief Check call to SDL_GetClipboardText
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetClipboardText
+ * http://github.com/libsdl-org/SDL/wiki/SDL_GetClipboardText
  */
 int
 clipboard_testGetClipboardText(void *arg)
@@ -49,7 +49,7 @@ clipboard_testGetClipboardText(void *arg)
 /**
  * \brief Check call to SDL_SetClipboardText
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetClipboardText
+ * http://github.com/libsdl-org/SDL/wiki/SDL_SetClipboardText
  */
 int
 clipboard_testSetClipboardText(void *arg)
@@ -78,9 +78,9 @@ clipboard_testSetClipboardText(void *arg)
 /**
  * \brief End-to-end test of SDL_xyzClipboardText functions
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasClipboardText
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetClipboardText
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetClipboardText
+ * http://github.com/libsdl-org/SDL/wiki/SDL_HasClipboardText
+ * http://github.com/libsdl-org/SDL/wiki/SDL_GetClipboardText
+ * http://github.com/libsdl-org/SDL/wiki/SDL_SetClipboardText
  */
 int
 clipboard_testClipboardTextFunctions(void *arg)

--- a/test/testautomation_clipboard.c
+++ b/test/testautomation_clipboard.c
@@ -16,7 +16,7 @@
  * \brief Check call to SDL_HasClipboardText
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_HasClipboardText
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasClipboardText
  */
 int
 clipboard_testHasClipboardText(void *arg)
@@ -32,7 +32,7 @@ clipboard_testHasClipboardText(void *arg)
  * \brief Check call to SDL_GetClipboardText
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_GetClipboardText
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetClipboardText
  */
 int
 clipboard_testGetClipboardText(void *arg)
@@ -49,7 +49,7 @@ clipboard_testGetClipboardText(void *arg)
 /**
  * \brief Check call to SDL_SetClipboardText
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_SetClipboardText
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetClipboardText
  */
 int
 clipboard_testSetClipboardText(void *arg)
@@ -78,9 +78,9 @@ clipboard_testSetClipboardText(void *arg)
 /**
  * \brief End-to-end test of SDL_xyzClipboardText functions
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_HasClipboardText
- * http://wiki.libsdl.org/moin.cgi/SDL_GetClipboardText
- * http://wiki.libsdl.org/moin.cgi/SDL_SetClipboardText
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasClipboardText
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetClipboardText
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetClipboardText
  */
 int
 clipboard_testClipboardTextFunctions(void *arg)

--- a/test/testautomation_clipboard.c
+++ b/test/testautomation_clipboard.c
@@ -16,7 +16,7 @@
  * \brief Check call to SDL_HasClipboardText
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_HasClipboardText
+ * https://github.com/libsdl-org/SDL/wiki/SDL_HasClipboardText
  */
 int
 clipboard_testHasClipboardText(void *arg)
@@ -32,7 +32,7 @@ clipboard_testHasClipboardText(void *arg)
  * \brief Check call to SDL_GetClipboardText
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_GetClipboardText
+ * https://github.com/libsdl-org/SDL/wiki/SDL_GetClipboardText
  */
 int
 clipboard_testGetClipboardText(void *arg)
@@ -49,7 +49,7 @@ clipboard_testGetClipboardText(void *arg)
 /**
  * \brief Check call to SDL_SetClipboardText
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_SetClipboardText
+ * https://github.com/libsdl-org/SDL/wiki/SDL_SetClipboardText
  */
 int
 clipboard_testSetClipboardText(void *arg)
@@ -78,9 +78,9 @@ clipboard_testSetClipboardText(void *arg)
 /**
  * \brief End-to-end test of SDL_xyzClipboardText functions
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_HasClipboardText
- * http://github.com/libsdl-org/SDL/wiki/SDL_GetClipboardText
- * http://github.com/libsdl-org/SDL/wiki/SDL_SetClipboardText
+ * https://github.com/libsdl-org/SDL/wiki/SDL_HasClipboardText
+ * https://github.com/libsdl-org/SDL/wiki/SDL_GetClipboardText
+ * https://github.com/libsdl-org/SDL/wiki/SDL_SetClipboardText
  */
 int
 clipboard_testClipboardTextFunctions(void *arg)

--- a/test/testautomation_events.c
+++ b/test/testautomation_events.c
@@ -42,8 +42,8 @@ int SDLCALL _events_sampleNullEventFilter(void *userdata, SDL_Event *event)
 /**
  * @brief Test pumping and peeking events.
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_PumpEvents
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_PollEvent
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_PumpEvents
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_PollEvent
  */
 int
 events_pushPumpAndPollUserevent(void *arg)
@@ -76,8 +76,8 @@ events_pushPumpAndPollUserevent(void *arg)
 /**
  * @brief Adds and deletes an event watch function with NULL userdata
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_AddEventWatch
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_DelEventWatch
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_AddEventWatch
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_DelEventWatch
  *
  */
 int
@@ -126,8 +126,8 @@ events_addDelEventWatch(void *arg)
 /**
  * @brief Adds and deletes an event watch function with userdata
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_AddEventWatch
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_DelEventWatch
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_AddEventWatch
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_DelEventWatch
  *
  */
 int

--- a/test/testautomation_events.c
+++ b/test/testautomation_events.c
@@ -42,8 +42,8 @@ int SDLCALL _events_sampleNullEventFilter(void *userdata, SDL_Event *event)
 /**
  * @brief Test pumping and peeking events.
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_PumpEvents
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_PollEvent
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_PumpEvents
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_PollEvent
  */
 int
 events_pushPumpAndPollUserevent(void *arg)
@@ -76,8 +76,8 @@ events_pushPumpAndPollUserevent(void *arg)
 /**
  * @brief Adds and deletes an event watch function with NULL userdata
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_AddEventWatch
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_DelEventWatch
+ * @sa http://github.com/libsdl-org/SDL/SDL_AddEventWatch
+ * @sa http://github.com/libsdl-org/SDL/SDL_DelEventWatch
  *
  */
 int
@@ -126,8 +126,8 @@ events_addDelEventWatch(void *arg)
 /**
  * @brief Adds and deletes an event watch function with userdata
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_AddEventWatch
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_DelEventWatch
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_AddEventWatch
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_DelEventWatch
  *
  */
 int

--- a/test/testautomation_events.c
+++ b/test/testautomation_events.c
@@ -42,8 +42,8 @@ int SDLCALL _events_sampleNullEventFilter(void *userdata, SDL_Event *event)
 /**
  * @brief Test pumping and peeking events.
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_PumpEvents
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_PollEvent
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_PumpEvents
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_PollEvent
  */
 int
 events_pushPumpAndPollUserevent(void *arg)
@@ -76,8 +76,8 @@ events_pushPumpAndPollUserevent(void *arg)
 /**
  * @brief Adds and deletes an event watch function with NULL userdata
  *
- * @sa http://github.com/libsdl-org/SDL/SDL_AddEventWatch
- * @sa http://github.com/libsdl-org/SDL/SDL_DelEventWatch
+ * @sa https://github.com/libsdl-org/SDL/SDL_AddEventWatch
+ * @sa https://github.com/libsdl-org/SDL/SDL_DelEventWatch
  *
  */
 int
@@ -126,8 +126,8 @@ events_addDelEventWatch(void *arg)
 /**
  * @brief Adds and deletes an event watch function with userdata
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_AddEventWatch
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_DelEventWatch
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_AddEventWatch
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_DelEventWatch
  *
  */
 int

--- a/test/testautomation_keyboard.c
+++ b/test/testautomation_keyboard.c
@@ -16,7 +16,7 @@
 /**
  * @brief Check call to SDL_GetKeyboardState with and without numkeys reference.
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_GetKeyboardState
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetKeyboardState
  */
 int
 keyboard_getKeyboardState(void *arg)
@@ -42,7 +42,7 @@ keyboard_getKeyboardState(void *arg)
 /**
  * @brief Check call to SDL_GetKeyboardFocus
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_GetKeyboardFocus
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetKeyboardFocus
  */
 int
 keyboard_getKeyboardFocus(void *arg)
@@ -59,7 +59,7 @@ keyboard_getKeyboardFocus(void *arg)
 /**
  * @brief Check call to SDL_GetKeyFromName for known, unknown and invalid name.
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_GetKeyFromName
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetKeyFromName
  */
 int
 keyboard_getKeyFromName(void *arg)
@@ -126,7 +126,7 @@ _checkInvalidScancodeError()
 /**
  * @brief Check call to SDL_GetKeyFromScancode
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_GetKeyFromScancode
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetKeyFromScancode
  */
 int
 keyboard_getKeyFromScancode(void *arg)
@@ -165,7 +165,7 @@ keyboard_getKeyFromScancode(void *arg)
 /**
  * @brief Check call to SDL_GetKeyName
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_GetKeyName
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetKeyName
  */
 int
 keyboard_getKeyName(void *arg)
@@ -221,7 +221,7 @@ keyboard_getKeyName(void *arg)
 /**
  * @brief SDL_GetScancodeName negative cases
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_GetScancodeName
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetScancodeName
  */
 int
 keyboard_getScancodeNameNegative(void *arg)
@@ -248,7 +248,7 @@ keyboard_getScancodeNameNegative(void *arg)
 /**
  * @brief SDL_GetKeyName negative cases
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_GetKeyName
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetKeyName
  */
 int
 keyboard_getKeyNameNegative(void *arg)
@@ -285,8 +285,8 @@ keyboard_getKeyNameNegative(void *arg)
 /**
  * @brief Check call to SDL_GetModState and SDL_SetModState
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_GetModState
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_SetModState
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetModState
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetModState
  */
 int
 keyboard_getSetModState(void *arg)
@@ -346,8 +346,8 @@ keyboard_getSetModState(void *arg)
 /**
  * @brief Check call to SDL_StartTextInput and SDL_StopTextInput
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_StartTextInput
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_StopTextInput
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_StartTextInput
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_StopTextInput
  */
 int
 keyboard_startStopTextInput(void *arg)
@@ -393,7 +393,7 @@ void _testSetTextInputRect(SDL_Rect refRect)
 /**
  * @brief Check call to SDL_SetTextInputRect
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_SetTextInputRect
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextInputRect
  */
 int
 keyboard_setTextInputRect(void *arg)
@@ -473,7 +473,7 @@ keyboard_setTextInputRect(void *arg)
 /**
  * @brief Check call to SDL_SetTextInputRect with invalid data
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_SetTextInputRect
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextInputRect
  */
 int
 keyboard_setTextInputRectNegative(void *arg)
@@ -511,8 +511,8 @@ keyboard_setTextInputRectNegative(void *arg)
 /**
  * @brief Check call to SDL_GetScancodeFromKey
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_GetScancodeFromKey
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_Keycode
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetScancodeFromKey
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_Keycode
  */
 int
 keyboard_getScancodeFromKey(void *arg)
@@ -535,8 +535,8 @@ keyboard_getScancodeFromKey(void *arg)
 /**
  * @brief Check call to SDL_GetScancodeFromName
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_GetScancodeFromName
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_Keycode
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetScancodeFromName
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_Keycode
  */
 int
 keyboard_getScancodeFromName(void *arg)
@@ -608,8 +608,8 @@ _checkInvalidNameError()
 /**
  * @brief Check call to SDL_GetScancodeFromName with invalid data
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_GetScancodeFromName
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_Keycode
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetScancodeFromName
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_Keycode
  */
 int
 keyboard_getScancodeFromNameNegative(void *arg)

--- a/test/testautomation_keyboard.c
+++ b/test/testautomation_keyboard.c
@@ -16,7 +16,7 @@
 /**
  * @brief Check call to SDL_GetKeyboardState with and without numkeys reference.
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetKeyboardState
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetKeyboardState
  */
 int
 keyboard_getKeyboardState(void *arg)
@@ -42,7 +42,7 @@ keyboard_getKeyboardState(void *arg)
 /**
  * @brief Check call to SDL_GetKeyboardFocus
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetKeyboardFocus
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetKeyboardFocus
  */
 int
 keyboard_getKeyboardFocus(void *arg)
@@ -59,7 +59,7 @@ keyboard_getKeyboardFocus(void *arg)
 /**
  * @brief Check call to SDL_GetKeyFromName for known, unknown and invalid name.
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetKeyFromName
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetKeyFromName
  */
 int
 keyboard_getKeyFromName(void *arg)
@@ -126,7 +126,7 @@ _checkInvalidScancodeError()
 /**
  * @brief Check call to SDL_GetKeyFromScancode
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetKeyFromScancode
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetKeyFromScancode
  */
 int
 keyboard_getKeyFromScancode(void *arg)
@@ -165,7 +165,7 @@ keyboard_getKeyFromScancode(void *arg)
 /**
  * @brief Check call to SDL_GetKeyName
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetKeyName
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetKeyName
  */
 int
 keyboard_getKeyName(void *arg)
@@ -221,7 +221,7 @@ keyboard_getKeyName(void *arg)
 /**
  * @brief SDL_GetScancodeName negative cases
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetScancodeName
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetScancodeName
  */
 int
 keyboard_getScancodeNameNegative(void *arg)
@@ -248,7 +248,7 @@ keyboard_getScancodeNameNegative(void *arg)
 /**
  * @brief SDL_GetKeyName negative cases
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetKeyName
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetKeyName
  */
 int
 keyboard_getKeyNameNegative(void *arg)
@@ -285,8 +285,8 @@ keyboard_getKeyNameNegative(void *arg)
 /**
  * @brief Check call to SDL_GetModState and SDL_SetModState
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetModState
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetModState
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetModState
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetModState
  */
 int
 keyboard_getSetModState(void *arg)
@@ -346,8 +346,8 @@ keyboard_getSetModState(void *arg)
 /**
  * @brief Check call to SDL_StartTextInput and SDL_StopTextInput
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_StartTextInput
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_StopTextInput
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_StartTextInput
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_StopTextInput
  */
 int
 keyboard_startStopTextInput(void *arg)
@@ -393,7 +393,7 @@ void _testSetTextInputRect(SDL_Rect refRect)
 /**
  * @brief Check call to SDL_SetTextInputRect
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextInputRect
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetTextInputRect
  */
 int
 keyboard_setTextInputRect(void *arg)
@@ -473,7 +473,7 @@ keyboard_setTextInputRect(void *arg)
 /**
  * @brief Check call to SDL_SetTextInputRect with invalid data
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextInputRect
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetTextInputRect
  */
 int
 keyboard_setTextInputRectNegative(void *arg)
@@ -511,8 +511,8 @@ keyboard_setTextInputRectNegative(void *arg)
 /**
  * @brief Check call to SDL_GetScancodeFromKey
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetScancodeFromKey
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_Keycode
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetScancodeFromKey
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_Keycode
  */
 int
 keyboard_getScancodeFromKey(void *arg)
@@ -535,8 +535,8 @@ keyboard_getScancodeFromKey(void *arg)
 /**
  * @brief Check call to SDL_GetScancodeFromName
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetScancodeFromName
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_Keycode
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetScancodeFromName
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_Keycode
  */
 int
 keyboard_getScancodeFromName(void *arg)
@@ -608,8 +608,8 @@ _checkInvalidNameError()
 /**
  * @brief Check call to SDL_GetScancodeFromName with invalid data
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetScancodeFromName
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_Keycode
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetScancodeFromName
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_Keycode
  */
 int
 keyboard_getScancodeFromNameNegative(void *arg)

--- a/test/testautomation_keyboard.c
+++ b/test/testautomation_keyboard.c
@@ -16,7 +16,7 @@
 /**
  * @brief Check call to SDL_GetKeyboardState with and without numkeys reference.
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetKeyboardState
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetKeyboardState
  */
 int
 keyboard_getKeyboardState(void *arg)
@@ -42,7 +42,7 @@ keyboard_getKeyboardState(void *arg)
 /**
  * @brief Check call to SDL_GetKeyboardFocus
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetKeyboardFocus
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetKeyboardFocus
  */
 int
 keyboard_getKeyboardFocus(void *arg)
@@ -59,7 +59,7 @@ keyboard_getKeyboardFocus(void *arg)
 /**
  * @brief Check call to SDL_GetKeyFromName for known, unknown and invalid name.
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetKeyFromName
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetKeyFromName
  */
 int
 keyboard_getKeyFromName(void *arg)
@@ -126,7 +126,7 @@ _checkInvalidScancodeError()
 /**
  * @brief Check call to SDL_GetKeyFromScancode
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetKeyFromScancode
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetKeyFromScancode
  */
 int
 keyboard_getKeyFromScancode(void *arg)
@@ -165,7 +165,7 @@ keyboard_getKeyFromScancode(void *arg)
 /**
  * @brief Check call to SDL_GetKeyName
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetKeyName
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetKeyName
  */
 int
 keyboard_getKeyName(void *arg)
@@ -221,7 +221,7 @@ keyboard_getKeyName(void *arg)
 /**
  * @brief SDL_GetScancodeName negative cases
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetScancodeName
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetScancodeName
  */
 int
 keyboard_getScancodeNameNegative(void *arg)
@@ -248,7 +248,7 @@ keyboard_getScancodeNameNegative(void *arg)
 /**
  * @brief SDL_GetKeyName negative cases
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetKeyName
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetKeyName
  */
 int
 keyboard_getKeyNameNegative(void *arg)
@@ -285,8 +285,8 @@ keyboard_getKeyNameNegative(void *arg)
 /**
  * @brief Check call to SDL_GetModState and SDL_SetModState
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetModState
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetModState
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetModState
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_SetModState
  */
 int
 keyboard_getSetModState(void *arg)
@@ -346,8 +346,8 @@ keyboard_getSetModState(void *arg)
 /**
  * @brief Check call to SDL_StartTextInput and SDL_StopTextInput
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_StartTextInput
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_StopTextInput
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_StartTextInput
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_StopTextInput
  */
 int
 keyboard_startStopTextInput(void *arg)
@@ -393,7 +393,7 @@ void _testSetTextInputRect(SDL_Rect refRect)
 /**
  * @brief Check call to SDL_SetTextInputRect
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetTextInputRect
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_SetTextInputRect
  */
 int
 keyboard_setTextInputRect(void *arg)
@@ -473,7 +473,7 @@ keyboard_setTextInputRect(void *arg)
 /**
  * @brief Check call to SDL_SetTextInputRect with invalid data
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetTextInputRect
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_SetTextInputRect
  */
 int
 keyboard_setTextInputRectNegative(void *arg)
@@ -511,8 +511,8 @@ keyboard_setTextInputRectNegative(void *arg)
 /**
  * @brief Check call to SDL_GetScancodeFromKey
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetScancodeFromKey
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_Keycode
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetScancodeFromKey
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_Keycode
  */
 int
 keyboard_getScancodeFromKey(void *arg)
@@ -535,8 +535,8 @@ keyboard_getScancodeFromKey(void *arg)
 /**
  * @brief Check call to SDL_GetScancodeFromName
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetScancodeFromName
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_Keycode
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetScancodeFromName
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_Keycode
  */
 int
 keyboard_getScancodeFromName(void *arg)
@@ -608,8 +608,8 @@ _checkInvalidNameError()
 /**
  * @brief Check call to SDL_GetScancodeFromName with invalid data
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetScancodeFromName
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_Keycode
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetScancodeFromName
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_Keycode
  */
 int
 keyboard_getScancodeFromNameNegative(void *arg)

--- a/test/testautomation_main.c
+++ b/test/testautomation_main.c
@@ -13,8 +13,8 @@
 /* !
  * \brief Tests SDL_Init() and SDL_Quit() of Joystick and Haptic subsystems
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_Init
- * http://github.com/libsdl-org/SDL/wiki/SDL_Quit
+ * https://github.com/libsdl-org/SDL/wiki/SDL_Init
+ * https://github.com/libsdl-org/SDL/wiki/SDL_Quit
  */
 static int main_testInitQuitJoystickHaptic (void *arg)
 {
@@ -41,8 +41,8 @@ static int main_testInitQuitJoystickHaptic (void *arg)
 /* !
  * \brief Tests SDL_InitSubSystem() and SDL_QuitSubSystem()
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_Init
- * http://github.com/libsdl-org/SDL/wiki/SDL_Quit
+ * https://github.com/libsdl-org/SDL/wiki/SDL_Init
+ * https://github.com/libsdl-org/SDL/wiki/SDL_Quit
  */
 static int main_testInitQuitSubSystem (void *arg)
 {

--- a/test/testautomation_main.c
+++ b/test/testautomation_main.c
@@ -13,8 +13,8 @@
 /* !
  * \brief Tests SDL_Init() and SDL_Quit() of Joystick and Haptic subsystems
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_Init
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_Quit
+ * http://github.com/libsdl-org/SDL/wiki/SDL_Init
+ * http://github.com/libsdl-org/SDL/wiki/SDL_Quit
  */
 static int main_testInitQuitJoystickHaptic (void *arg)
 {
@@ -41,8 +41,8 @@ static int main_testInitQuitJoystickHaptic (void *arg)
 /* !
  * \brief Tests SDL_InitSubSystem() and SDL_QuitSubSystem()
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_Init
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_Quit
+ * http://github.com/libsdl-org/SDL/wiki/SDL_Init
+ * http://github.com/libsdl-org/SDL/wiki/SDL_Quit
  */
 static int main_testInitQuitSubSystem (void *arg)
 {

--- a/test/testautomation_main.c
+++ b/test/testautomation_main.c
@@ -13,8 +13,8 @@
 /* !
  * \brief Tests SDL_Init() and SDL_Quit() of Joystick and Haptic subsystems
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_Init
- * http://wiki.libsdl.org/moin.cgi/SDL_Quit
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_Init
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_Quit
  */
 static int main_testInitQuitJoystickHaptic (void *arg)
 {
@@ -41,8 +41,8 @@ static int main_testInitQuitJoystickHaptic (void *arg)
 /* !
  * \brief Tests SDL_InitSubSystem() and SDL_QuitSubSystem()
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_Init
- * http://wiki.libsdl.org/moin.cgi/SDL_Quit
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_Init
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_Quit
  */
 static int main_testInitQuitSubSystem (void *arg)
 {

--- a/test/testautomation_mouse.c
+++ b/test/testautomation_mouse.c
@@ -192,8 +192,8 @@ static SDL_Cursor *_initArrowCursor(const char *image[])
 /**
  * @brief Check call to SDL_CreateCursor and SDL_FreeCursor
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_CreateCursor
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_FreeCursor
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_CreateCursor
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_FreeCursor
  */
 int
 mouse_createFreeCursor(void *arg)
@@ -218,8 +218,8 @@ mouse_createFreeCursor(void *arg)
 /**
  * @brief Check call to SDL_CreateColorCursor and SDL_FreeCursor
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_CreateColorCursor
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_FreeCursor
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_CreateColorCursor
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_FreeCursor
  */
 int
 mouse_createFreeColorCursor(void *arg)
@@ -275,7 +275,7 @@ void _changeCursorVisibility(int state)
 /**
  * @brief Check call to SDL_ShowCursor
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_ShowCursor
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_ShowCursor
  */
 int
 mouse_showCursor(void *arg)
@@ -305,7 +305,7 @@ mouse_showCursor(void *arg)
 /**
  * @brief Check call to SDL_SetCursor
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetCursor
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetCursor
  */
 int
 mouse_setCursor(void *arg)
@@ -338,7 +338,7 @@ mouse_setCursor(void *arg)
 /**
  * @brief Check call to SDL_GetCursor
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetCursor
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetCursor
  */
 int
 mouse_getCursor(void *arg)
@@ -356,8 +356,8 @@ mouse_getCursor(void *arg)
 /**
  * @brief Check call to SDL_GetRelativeMouseMode and SDL_SetRelativeMouseMode
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetRelativeMouseMode
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetRelativeMouseMode
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetRelativeMouseMode
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetRelativeMouseMode
  */
 int
 mouse_getSetRelativeMouseMode(void *arg)
@@ -440,7 +440,7 @@ void _destroyMouseSuiteTestWindow(SDL_Window *window)
 /**
  * @brief Check call to SDL_WarpMouseInWindow
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_WarpMouseInWindow
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_WarpMouseInWindow
  */
 int
 mouse_warpMouseInWindow(void *arg)
@@ -502,7 +502,7 @@ mouse_warpMouseInWindow(void *arg)
 /**
  * @brief Check call to SDL_GetMouseFocus
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetMouseFocus
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetMouseFocus
  */
 int
 mouse_getMouseFocus(void *arg)

--- a/test/testautomation_mouse.c
+++ b/test/testautomation_mouse.c
@@ -192,8 +192,8 @@ static SDL_Cursor *_initArrowCursor(const char *image[])
 /**
  * @brief Check call to SDL_CreateCursor and SDL_FreeCursor
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_CreateCursor
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_FreeCursor
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_CreateCursor
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_FreeCursor
  */
 int
 mouse_createFreeCursor(void *arg)
@@ -218,8 +218,8 @@ mouse_createFreeCursor(void *arg)
 /**
  * @brief Check call to SDL_CreateColorCursor and SDL_FreeCursor
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_CreateColorCursor
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_FreeCursor
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_CreateColorCursor
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_FreeCursor
  */
 int
 mouse_createFreeColorCursor(void *arg)
@@ -275,7 +275,7 @@ void _changeCursorVisibility(int state)
 /**
  * @brief Check call to SDL_ShowCursor
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_ShowCursor
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_ShowCursor
  */
 int
 mouse_showCursor(void *arg)
@@ -305,7 +305,7 @@ mouse_showCursor(void *arg)
 /**
  * @brief Check call to SDL_SetCursor
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_SetCursor
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetCursor
  */
 int
 mouse_setCursor(void *arg)
@@ -338,7 +338,7 @@ mouse_setCursor(void *arg)
 /**
  * @brief Check call to SDL_GetCursor
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_GetCursor
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetCursor
  */
 int
 mouse_getCursor(void *arg)
@@ -356,8 +356,8 @@ mouse_getCursor(void *arg)
 /**
  * @brief Check call to SDL_GetRelativeMouseMode and SDL_SetRelativeMouseMode
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_GetRelativeMouseMode
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_SetRelativeMouseMode
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetRelativeMouseMode
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetRelativeMouseMode
  */
 int
 mouse_getSetRelativeMouseMode(void *arg)
@@ -440,7 +440,7 @@ void _destroyMouseSuiteTestWindow(SDL_Window *window)
 /**
  * @brief Check call to SDL_WarpMouseInWindow
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_WarpMouseInWindow
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_WarpMouseInWindow
  */
 int
 mouse_warpMouseInWindow(void *arg)
@@ -502,7 +502,7 @@ mouse_warpMouseInWindow(void *arg)
 /**
  * @brief Check call to SDL_GetMouseFocus
  *
- * @sa http://wiki.libsdl.org/moin.cgi/SDL_GetMouseFocus
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetMouseFocus
  */
 int
 mouse_getMouseFocus(void *arg)

--- a/test/testautomation_mouse.c
+++ b/test/testautomation_mouse.c
@@ -192,8 +192,8 @@ static SDL_Cursor *_initArrowCursor(const char *image[])
 /**
  * @brief Check call to SDL_CreateCursor and SDL_FreeCursor
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_CreateCursor
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_FreeCursor
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_CreateCursor
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_FreeCursor
  */
 int
 mouse_createFreeCursor(void *arg)
@@ -218,8 +218,8 @@ mouse_createFreeCursor(void *arg)
 /**
  * @brief Check call to SDL_CreateColorCursor and SDL_FreeCursor
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_CreateColorCursor
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_FreeCursor
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_CreateColorCursor
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_FreeCursor
  */
 int
 mouse_createFreeColorCursor(void *arg)
@@ -275,7 +275,7 @@ void _changeCursorVisibility(int state)
 /**
  * @brief Check call to SDL_ShowCursor
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_ShowCursor
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_ShowCursor
  */
 int
 mouse_showCursor(void *arg)
@@ -305,7 +305,7 @@ mouse_showCursor(void *arg)
 /**
  * @brief Check call to SDL_SetCursor
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetCursor
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_SetCursor
  */
 int
 mouse_setCursor(void *arg)
@@ -338,7 +338,7 @@ mouse_setCursor(void *arg)
 /**
  * @brief Check call to SDL_GetCursor
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetCursor
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetCursor
  */
 int
 mouse_getCursor(void *arg)
@@ -356,8 +356,8 @@ mouse_getCursor(void *arg)
 /**
  * @brief Check call to SDL_GetRelativeMouseMode and SDL_SetRelativeMouseMode
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetRelativeMouseMode
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetRelativeMouseMode
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetRelativeMouseMode
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_SetRelativeMouseMode
  */
 int
 mouse_getSetRelativeMouseMode(void *arg)
@@ -440,7 +440,7 @@ void _destroyMouseSuiteTestWindow(SDL_Window *window)
 /**
  * @brief Check call to SDL_WarpMouseInWindow
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_WarpMouseInWindow
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_WarpMouseInWindow
  */
 int
 mouse_warpMouseInWindow(void *arg)
@@ -502,7 +502,7 @@ mouse_warpMouseInWindow(void *arg)
 /**
  * @brief Check call to SDL_GetMouseFocus
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetMouseFocus
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetMouseFocus
  */
 int
 mouse_getMouseFocus(void *arg)

--- a/test/testautomation_pixels.c
+++ b/test/testautomation_pixels.c
@@ -121,8 +121,8 @@ char* _invalidPixelFormatsVerbose[] =
 /**
  * @brief Call to SDL_AllocFormat and SDL_FreeFormat
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_AllocFormat
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_FreeFormat
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_AllocFormat
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_FreeFormat
  */
 int
 pixels_allocFreeFormat(void *arg)
@@ -228,7 +228,7 @@ pixels_allocFreeFormat(void *arg)
 /**
  * @brief Call to SDL_GetPixelFormatName
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetPixelFormatName
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetPixelFormatName
  */
 int
 pixels_getPixelFormatName(void *arg)
@@ -312,8 +312,8 @@ pixels_getPixelFormatName(void *arg)
 /**
  * @brief Call to SDL_AllocPalette and SDL_FreePalette
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_AllocPalette
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_FreePalette
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_AllocPalette
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_FreePalette
  */
 int
 pixels_allocFreePalette(void *arg)
@@ -402,7 +402,7 @@ pixels_allocFreePalette(void *arg)
 /**
  * @brief Call to SDL_CalculateGammaRamp
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_CalculateGammaRamp
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_CalculateGammaRamp
  */
 int
 pixels_calcGammaRamp(void *arg)

--- a/test/testautomation_pixels.c
+++ b/test/testautomation_pixels.c
@@ -121,8 +121,8 @@ char* _invalidPixelFormatsVerbose[] =
 /**
  * @brief Call to SDL_AllocFormat and SDL_FreeFormat
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_AllocFormat
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_FreeFormat
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_AllocFormat
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_FreeFormat
  */
 int
 pixels_allocFreeFormat(void *arg)
@@ -228,7 +228,7 @@ pixels_allocFreeFormat(void *arg)
 /**
  * @brief Call to SDL_GetPixelFormatName
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetPixelFormatName
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetPixelFormatName
  */
 int
 pixels_getPixelFormatName(void *arg)
@@ -312,8 +312,8 @@ pixels_getPixelFormatName(void *arg)
 /**
  * @brief Call to SDL_AllocPalette and SDL_FreePalette
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_AllocPalette
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_FreePalette
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_AllocPalette
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_FreePalette
  */
 int
 pixels_allocFreePalette(void *arg)
@@ -402,7 +402,7 @@ pixels_allocFreePalette(void *arg)
 /**
  * @brief Call to SDL_CalculateGammaRamp
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_CalculateGammaRamp
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_CalculateGammaRamp
  */
 int
 pixels_calcGammaRamp(void *arg)

--- a/test/testautomation_pixels.c
+++ b/test/testautomation_pixels.c
@@ -121,8 +121,8 @@ char* _invalidPixelFormatsVerbose[] =
 /**
  * @brief Call to SDL_AllocFormat and SDL_FreeFormat
  *
- * @sa http://wiki.libsdl.org/moin.fcg/SDL_AllocFormat
- * @sa http://wiki.libsdl.org/moin.fcg/SDL_FreeFormat
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_AllocFormat
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_FreeFormat
  */
 int
 pixels_allocFreeFormat(void *arg)
@@ -228,7 +228,7 @@ pixels_allocFreeFormat(void *arg)
 /**
  * @brief Call to SDL_GetPixelFormatName
  *
- * @sa http://wiki.libsdl.org/moin.fcg/SDL_GetPixelFormatName
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetPixelFormatName
  */
 int
 pixels_getPixelFormatName(void *arg)
@@ -312,8 +312,8 @@ pixels_getPixelFormatName(void *arg)
 /**
  * @brief Call to SDL_AllocPalette and SDL_FreePalette
  *
- * @sa http://wiki.libsdl.org/moin.fcg/SDL_AllocPalette
- * @sa http://wiki.libsdl.org/moin.fcg/SDL_FreePalette
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_AllocPalette
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_FreePalette
  */
 int
 pixels_allocFreePalette(void *arg)
@@ -402,7 +402,7 @@ pixels_allocFreePalette(void *arg)
 /**
  * @brief Call to SDL_CalculateGammaRamp
  *
- * @sa http://wiki.libsdl.org/moin.fcg/SDL_CalculateGammaRamp
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_CalculateGammaRamp
  */
 int
 pixels_calcGammaRamp(void *arg)

--- a/test/testautomation_platform.c
+++ b/test/testautomation_platform.c
@@ -101,11 +101,11 @@ int platform_testEndianessAndSwap(void *arg)
 /* !
  * \brief Tests SDL_GetXYZ() functions
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_GetPlatform
- * http://wiki.libsdl.org/moin.cgi/SDL_GetCPUCount
- * http://wiki.libsdl.org/moin.cgi/SDL_GetCPUCacheLineSize
- * http://wiki.libsdl.org/moin.cgi/SDL_GetRevision
- * http://wiki.libsdl.org/moin.cgi/SDL_GetRevisionNumber
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetPlatform
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetCPUCount
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetCPUCacheLineSize
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetRevision
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetRevisionNumber
  */
 int platform_testGetFunctions (void *arg)
 {
@@ -147,16 +147,16 @@ int platform_testGetFunctions (void *arg)
 /* !
  * \brief Tests SDL_HasXYZ() functions
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_Has3DNow
- * http://wiki.libsdl.org/moin.cgi/SDL_HasAltiVec
- * http://wiki.libsdl.org/moin.cgi/SDL_HasMMX
- * http://wiki.libsdl.org/moin.cgi/SDL_HasRDTSC
- * http://wiki.libsdl.org/moin.cgi/SDL_HasSSE
- * http://wiki.libsdl.org/moin.cgi/SDL_HasSSE2
- * http://wiki.libsdl.org/moin.cgi/SDL_HasSSE3
- * http://wiki.libsdl.org/moin.cgi/SDL_HasSSE41
- * http://wiki.libsdl.org/moin.cgi/SDL_HasSSE42
- * http://wiki.libsdl.org/moin.cgi/SDL_HasAVX
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_Has3DNow
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasAltiVec
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasMMX
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasRDTSC
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasSSE
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasSSE2
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasSSE3
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasSSE41
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasSSE42
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasAVX
  */
 int platform_testHasFunctions (void *arg)
 {
@@ -200,7 +200,7 @@ int platform_testHasFunctions (void *arg)
 /* !
  * \brief Tests SDL_GetVersion
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_GetVersion
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetVersion
  */
 int platform_testGetVersion(void *arg)
 {
@@ -270,9 +270,9 @@ int platform_testDefaultInit(void *arg)
 /* !
  * \brief Tests SDL_Get/Set/ClearError
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_GetError
- * http://wiki.libsdl.org/moin.cgi/SDL_SetError
- * http://wiki.libsdl.org/moin.cgi/SDL_ClearError
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetError
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetError
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_ClearError
  */
 int platform_testGetSetClearError(void *arg)
 {
@@ -324,7 +324,7 @@ int platform_testGetSetClearError(void *arg)
 /* !
  * \brief Tests SDL_SetError with empty input
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_SetError
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetError
  */
 int platform_testSetErrorEmptyInput(void *arg)
 {
@@ -362,7 +362,7 @@ int platform_testSetErrorEmptyInput(void *arg)
 /* !
  * \brief Tests SDL_SetError with invalid input
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_SetError
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetError
  */
 int platform_testSetErrorInvalidInput(void *arg)
 {
@@ -445,7 +445,7 @@ int platform_testSetErrorInvalidInput(void *arg)
 /* !
  * \brief Tests SDL_GetPowerInfo
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_GetPowerInfo
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetPowerInfo
  */
 int platform_testGetPowerInfo(void *arg)
 {

--- a/test/testautomation_platform.c
+++ b/test/testautomation_platform.c
@@ -101,11 +101,11 @@ int platform_testEndianessAndSwap(void *arg)
 /* !
  * \brief Tests SDL_GetXYZ() functions
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_GetPlatform
- * http://github.com/libsdl-org/SDL/wiki/SDL_GetCPUCount
- * http://github.com/libsdl-org/SDL/wiki/SDL_GetCPUCacheLineSize
- * http://github.com/libsdl-org/SDL/wiki/SDL_GetRevision
- * http://github.com/libsdl-org/SDL/wiki/SDL_GetRevisionNumber
+ * https://github.com/libsdl-org/SDL/wiki/SDL_GetPlatform
+ * https://github.com/libsdl-org/SDL/wiki/SDL_GetCPUCount
+ * https://github.com/libsdl-org/SDL/wiki/SDL_GetCPUCacheLineSize
+ * https://github.com/libsdl-org/SDL/wiki/SDL_GetRevision
+ * https://github.com/libsdl-org/SDL/wiki/SDL_GetRevisionNumber
  */
 int platform_testGetFunctions (void *arg)
 {
@@ -147,16 +147,16 @@ int platform_testGetFunctions (void *arg)
 /* !
  * \brief Tests SDL_HasXYZ() functions
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_Has3DNow
- * http://github.com/libsdl-org/SDL/wiki/SDL_HasAltiVec
- * http://github.com/libsdl-org/SDL/wiki/SDL_HasMMX
- * http://github.com/libsdl-org/SDL/wiki/SDL_HasRDTSC
- * http://github.com/libsdl-org/SDL/wiki/SDL_HasSSE
- * http://github.com/libsdl-org/SDL/wiki/SDL_HasSSE2
- * http://github.com/libsdl-org/SDL/wiki/SDL_HasSSE3
- * http://github.com/libsdl-org/SDL/wiki/SDL_HasSSE41
- * http://github.com/libsdl-org/SDL/wiki/SDL_HasSSE42
- * http://github.com/libsdl-org/SDL/wiki/SDL_HasAVX
+ * https://github.com/libsdl-org/SDL/wiki/SDL_Has3DNow
+ * https://github.com/libsdl-org/SDL/wiki/SDL_HasAltiVec
+ * https://github.com/libsdl-org/SDL/wiki/SDL_HasMMX
+ * https://github.com/libsdl-org/SDL/wiki/SDL_HasRDTSC
+ * https://github.com/libsdl-org/SDL/wiki/SDL_HasSSE
+ * https://github.com/libsdl-org/SDL/wiki/SDL_HasSSE2
+ * https://github.com/libsdl-org/SDL/wiki/SDL_HasSSE3
+ * https://github.com/libsdl-org/SDL/wiki/SDL_HasSSE41
+ * https://github.com/libsdl-org/SDL/wiki/SDL_HasSSE42
+ * https://github.com/libsdl-org/SDL/wiki/SDL_HasAVX
  */
 int platform_testHasFunctions (void *arg)
 {
@@ -200,7 +200,7 @@ int platform_testHasFunctions (void *arg)
 /* !
  * \brief Tests SDL_GetVersion
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_GetVersion
+ * https://github.com/libsdl-org/SDL/wiki/SDL_GetVersion
  */
 int platform_testGetVersion(void *arg)
 {
@@ -270,9 +270,9 @@ int platform_testDefaultInit(void *arg)
 /* !
  * \brief Tests SDL_Get/Set/ClearError
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_GetError
- * http://github.com/libsdl-org/SDL/wiki/SDL_SetError
- * http://github.com/libsdl-org/SDL/wiki/SDL_ClearError
+ * https://github.com/libsdl-org/SDL/wiki/SDL_GetError
+ * https://github.com/libsdl-org/SDL/wiki/SDL_SetError
+ * https://github.com/libsdl-org/SDL/wiki/SDL_ClearError
  */
 int platform_testGetSetClearError(void *arg)
 {
@@ -324,7 +324,7 @@ int platform_testGetSetClearError(void *arg)
 /* !
  * \brief Tests SDL_SetError with empty input
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_SetError
+ * https://github.com/libsdl-org/SDL/wiki/SDL_SetError
  */
 int platform_testSetErrorEmptyInput(void *arg)
 {
@@ -362,7 +362,7 @@ int platform_testSetErrorEmptyInput(void *arg)
 /* !
  * \brief Tests SDL_SetError with invalid input
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_SetError
+ * https://github.com/libsdl-org/SDL/wiki/SDL_SetError
  */
 int platform_testSetErrorInvalidInput(void *arg)
 {
@@ -445,7 +445,7 @@ int platform_testSetErrorInvalidInput(void *arg)
 /* !
  * \brief Tests SDL_GetPowerInfo
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_GetPowerInfo
+ * https://github.com/libsdl-org/SDL/wiki/SDL_GetPowerInfo
  */
 int platform_testGetPowerInfo(void *arg)
 {

--- a/test/testautomation_platform.c
+++ b/test/testautomation_platform.c
@@ -101,11 +101,11 @@ int platform_testEndianessAndSwap(void *arg)
 /* !
  * \brief Tests SDL_GetXYZ() functions
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetPlatform
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetCPUCount
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetCPUCacheLineSize
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetRevision
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetRevisionNumber
+ * http://github.com/libsdl-org/SDL/wiki/SDL_GetPlatform
+ * http://github.com/libsdl-org/SDL/wiki/SDL_GetCPUCount
+ * http://github.com/libsdl-org/SDL/wiki/SDL_GetCPUCacheLineSize
+ * http://github.com/libsdl-org/SDL/wiki/SDL_GetRevision
+ * http://github.com/libsdl-org/SDL/wiki/SDL_GetRevisionNumber
  */
 int platform_testGetFunctions (void *arg)
 {
@@ -147,16 +147,16 @@ int platform_testGetFunctions (void *arg)
 /* !
  * \brief Tests SDL_HasXYZ() functions
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_Has3DNow
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasAltiVec
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasMMX
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasRDTSC
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasSSE
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasSSE2
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasSSE3
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasSSE41
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasSSE42
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasAVX
+ * http://github.com/libsdl-org/SDL/wiki/SDL_Has3DNow
+ * http://github.com/libsdl-org/SDL/wiki/SDL_HasAltiVec
+ * http://github.com/libsdl-org/SDL/wiki/SDL_HasMMX
+ * http://github.com/libsdl-org/SDL/wiki/SDL_HasRDTSC
+ * http://github.com/libsdl-org/SDL/wiki/SDL_HasSSE
+ * http://github.com/libsdl-org/SDL/wiki/SDL_HasSSE2
+ * http://github.com/libsdl-org/SDL/wiki/SDL_HasSSE3
+ * http://github.com/libsdl-org/SDL/wiki/SDL_HasSSE41
+ * http://github.com/libsdl-org/SDL/wiki/SDL_HasSSE42
+ * http://github.com/libsdl-org/SDL/wiki/SDL_HasAVX
  */
 int platform_testHasFunctions (void *arg)
 {
@@ -200,7 +200,7 @@ int platform_testHasFunctions (void *arg)
 /* !
  * \brief Tests SDL_GetVersion
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetVersion
+ * http://github.com/libsdl-org/SDL/wiki/SDL_GetVersion
  */
 int platform_testGetVersion(void *arg)
 {
@@ -270,9 +270,9 @@ int platform_testDefaultInit(void *arg)
 /* !
  * \brief Tests SDL_Get/Set/ClearError
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetError
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetError
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_ClearError
+ * http://github.com/libsdl-org/SDL/wiki/SDL_GetError
+ * http://github.com/libsdl-org/SDL/wiki/SDL_SetError
+ * http://github.com/libsdl-org/SDL/wiki/SDL_ClearError
  */
 int platform_testGetSetClearError(void *arg)
 {
@@ -324,7 +324,7 @@ int platform_testGetSetClearError(void *arg)
 /* !
  * \brief Tests SDL_SetError with empty input
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetError
+ * http://github.com/libsdl-org/SDL/wiki/SDL_SetError
  */
 int platform_testSetErrorEmptyInput(void *arg)
 {
@@ -362,7 +362,7 @@ int platform_testSetErrorEmptyInput(void *arg)
 /* !
  * \brief Tests SDL_SetError with invalid input
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetError
+ * http://github.com/libsdl-org/SDL/wiki/SDL_SetError
  */
 int platform_testSetErrorInvalidInput(void *arg)
 {
@@ -445,7 +445,7 @@ int platform_testSetErrorInvalidInput(void *arg)
 /* !
  * \brief Tests SDL_GetPowerInfo
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetPowerInfo
+ * http://github.com/libsdl-org/SDL/wiki/SDL_GetPowerInfo
  */
 int platform_testGetPowerInfo(void *arg)
 {

--- a/test/testautomation_rect.c
+++ b/test/testautomation_rect.c
@@ -43,7 +43,7 @@ void _validateIntersectRectAndLineResults(
  * \brief Tests SDL_IntersectRectAndLine() clipping cases
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRectAndLine
+ * https://github.com/libsdl-org/SDL/wiki/SDL_IntersectRectAndLine
  */
 int
 rect_testIntersectRectAndLine (void *arg)
@@ -114,7 +114,7 @@ rect_testIntersectRectAndLine (void *arg)
  * \brief Tests SDL_IntersectRectAndLine() non-clipping case line inside
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRectAndLine
+ * https://github.com/libsdl-org/SDL/wiki/SDL_IntersectRectAndLine
  */
 int
 rect_testIntersectRectAndLineInside (void *arg)
@@ -181,7 +181,7 @@ rect_testIntersectRectAndLineInside (void *arg)
  * \brief Tests SDL_IntersectRectAndLine() non-clipping cases outside
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRectAndLine
+ * https://github.com/libsdl-org/SDL/wiki/SDL_IntersectRectAndLine
  */
 int
 rect_testIntersectRectAndLineOutside (void *arg)
@@ -236,7 +236,7 @@ rect_testIntersectRectAndLineOutside (void *arg)
  * \brief Tests SDL_IntersectRectAndLine() with empty rectangle
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRectAndLine
+ * https://github.com/libsdl-org/SDL/wiki/SDL_IntersectRectAndLine
  */
 int
 rect_testIntersectRectAndLineEmpty (void *arg)
@@ -271,7 +271,7 @@ rect_testIntersectRectAndLineEmpty (void *arg)
  * \brief Negative tests against SDL_IntersectRectAndLine() with invalid parameters
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRectAndLine
+ * https://github.com/libsdl-org/SDL/wiki/SDL_IntersectRectAndLine
  */
 int
 rect_testIntersectRectAndLineParam (void *arg)
@@ -412,7 +412,7 @@ void _validateRectEqualsResults(
  * \brief Tests SDL_IntersectRect() with B fully inside A
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRect
+ * https://github.com/libsdl-org/SDL/wiki/SDL_IntersectRect
  */
 int rect_testIntersectRectInside (void *arg)
 {
@@ -440,7 +440,7 @@ int rect_testIntersectRectInside (void *arg)
  * \brief Tests SDL_IntersectRect() with B fully outside A
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRect
+ * https://github.com/libsdl-org/SDL/wiki/SDL_IntersectRect
  */
 int rect_testIntersectRectOutside (void *arg)
 {
@@ -468,7 +468,7 @@ int rect_testIntersectRectOutside (void *arg)
  * \brief Tests SDL_IntersectRect() with B partially intersecting A
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRect
+ * https://github.com/libsdl-org/SDL/wiki/SDL_IntersectRect
  */
 int rect_testIntersectRectPartial (void *arg)
 {
@@ -557,7 +557,7 @@ int rect_testIntersectRectPartial (void *arg)
  * \brief Tests SDL_IntersectRect() with 1x1 pixel sized rectangles
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRect
+ * https://github.com/libsdl-org/SDL/wiki/SDL_IntersectRect
  */
 int rect_testIntersectRectPoint (void *arg)
 {
@@ -604,7 +604,7 @@ int rect_testIntersectRectPoint (void *arg)
  * \brief Tests SDL_IntersectRect() with empty rectangles
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRect
+ * https://github.com/libsdl-org/SDL/wiki/SDL_IntersectRect
  */
 int rect_testIntersectRectEmpty (void *arg)
 {
@@ -676,7 +676,7 @@ int rect_testIntersectRectEmpty (void *arg)
  * \brief Negative tests against SDL_IntersectRect() with invalid parameters
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRect
+ * https://github.com/libsdl-org/SDL/wiki/SDL_IntersectRect
  */
 int rect_testIntersectRectParam(void *arg)
 {
@@ -706,7 +706,7 @@ int rect_testIntersectRectParam(void *arg)
  * \brief Tests SDL_HasIntersection() with B fully inside A
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_HasIntersection
+ * https://github.com/libsdl-org/SDL/wiki/SDL_HasIntersection
  */
 int rect_testHasIntersectionInside (void *arg)
 {
@@ -733,7 +733,7 @@ int rect_testHasIntersectionInside (void *arg)
  * \brief Tests SDL_HasIntersection() with B fully outside A
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_HasIntersection
+ * https://github.com/libsdl-org/SDL/wiki/SDL_HasIntersection
  */
 int rect_testHasIntersectionOutside (void *arg)
 {
@@ -760,7 +760,7 @@ int rect_testHasIntersectionOutside (void *arg)
  * \brief Tests SDL_HasIntersection() with B partially intersecting A
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_HasIntersection
+ * https://github.com/libsdl-org/SDL/wiki/SDL_HasIntersection
  */
 int rect_testHasIntersectionPartial (void *arg)
 {
@@ -827,7 +827,7 @@ int rect_testHasIntersectionPartial (void *arg)
  * \brief Tests SDL_HasIntersection() with 1x1 pixel sized rectangles
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_HasIntersection
+ * https://github.com/libsdl-org/SDL/wiki/SDL_HasIntersection
  */
 int rect_testHasIntersectionPoint (void *arg)
 {
@@ -873,7 +873,7 @@ int rect_testHasIntersectionPoint (void *arg)
  * \brief Tests SDL_HasIntersection() with empty rectangles
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_HasIntersection
+ * https://github.com/libsdl-org/SDL/wiki/SDL_HasIntersection
  */
 int rect_testHasIntersectionEmpty (void *arg)
 {
@@ -931,7 +931,7 @@ int rect_testHasIntersectionEmpty (void *arg)
  * \brief Negative tests against SDL_HasIntersection() with invalid parameters
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_HasIntersection
+ * https://github.com/libsdl-org/SDL/wiki/SDL_HasIntersection
  */
 int rect_testHasIntersectionParam(void *arg)
 {
@@ -954,7 +954,7 @@ int rect_testHasIntersectionParam(void *arg)
  * \brief Test SDL_EnclosePoints() without clipping
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_EnclosePoints
+ * https://github.com/libsdl-org/SDL/wiki/SDL_EnclosePoints
  */
 int rect_testEnclosePoints(void *arg)
 {
@@ -1024,7 +1024,7 @@ int rect_testEnclosePoints(void *arg)
  * \brief Test SDL_EnclosePoints() with repeated input points
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_EnclosePoints
+ * https://github.com/libsdl-org/SDL/wiki/SDL_EnclosePoints
  */
 int rect_testEnclosePointsRepeatedInput(void *arg)
 {
@@ -1100,7 +1100,7 @@ int rect_testEnclosePointsRepeatedInput(void *arg)
  * \brief Test SDL_EnclosePoints() with clipping
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_EnclosePoints
+ * https://github.com/libsdl-org/SDL/wiki/SDL_EnclosePoints
  */
 int rect_testEnclosePointsWithClipping(void *arg)
 {
@@ -1199,7 +1199,7 @@ int rect_testEnclosePointsWithClipping(void *arg)
  * \brief Negative tests against SDL_EnclosePoints() with invalid parameters
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_EnclosePoints
+ * https://github.com/libsdl-org/SDL/wiki/SDL_EnclosePoints
  */
 int rect_testEnclosePointsParam(void *arg)
 {
@@ -1227,7 +1227,7 @@ int rect_testEnclosePointsParam(void *arg)
  * \brief Tests SDL_UnionRect() where rect B is outside rect A
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_UnionRect
+ * https://github.com/libsdl-org/SDL/wiki/SDL_UnionRect
  */
 int rect_testUnionRectOutside(void *arg)
 {
@@ -1298,7 +1298,7 @@ int rect_testUnionRectOutside(void *arg)
  * \brief Tests SDL_UnionRect() where rect A or rect B are empty
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_UnionRect
+ * https://github.com/libsdl-org/SDL/wiki/SDL_UnionRect
  */
 int rect_testUnionRectEmpty(void *arg)
 {
@@ -1363,7 +1363,7 @@ int rect_testUnionRectEmpty(void *arg)
  * \brief Tests SDL_UnionRect() where rect B is inside rect A
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_UnionRect
+ * https://github.com/libsdl-org/SDL/wiki/SDL_UnionRect
  */
 int rect_testUnionRectInside(void *arg)
 {
@@ -1427,7 +1427,7 @@ int rect_testUnionRectInside(void *arg)
  * \brief Negative tests against SDL_UnionRect() with invalid parameters
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_UnionRect
+ * https://github.com/libsdl-org/SDL/wiki/SDL_UnionRect
  */
 int rect_testUnionRectParam(void *arg)
 {
@@ -1455,7 +1455,7 @@ int rect_testUnionRectParam(void *arg)
  * \brief Tests SDL_RectEmpty() with various inputs
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_RectEmpty
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RectEmpty
  */
 int rect_testRectEmpty(void *arg)
 {
@@ -1498,7 +1498,7 @@ int rect_testRectEmpty(void *arg)
  * \brief Negative tests against SDL_RectEmpty() with invalid parameters
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_RectEmpty
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RectEmpty
  */
 int rect_testRectEmptyParam(void *arg)
 {
@@ -1515,7 +1515,7 @@ int rect_testRectEmptyParam(void *arg)
  * \brief Tests SDL_RectEquals() with various inputs
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_RectEquals
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RectEquals
  */
 int rect_testRectEquals(void *arg)
 {
@@ -1545,7 +1545,7 @@ int rect_testRectEquals(void *arg)
  * \brief Negative tests against SDL_RectEquals() with invalid parameters
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_RectEquals
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RectEquals
  */
 int rect_testRectEqualsParam(void *arg)
 {
@@ -1678,7 +1678,7 @@ static const SDLTest_TestCaseReference rectTest29 =
  * \brief Sequence of Rect test cases; functions that handle simple rectangles including overlaps and merges.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/CategoryRect
+ * https://github.com/libsdl-org/SDL/wiki/CategoryRect
  */
 static const SDLTest_TestCaseReference *rectTests[] =  {
     &rectTest1, &rectTest2, &rectTest3, &rectTest4, &rectTest5, &rectTest6, &rectTest7, &rectTest8, &rectTest9, &rectTest10, &rectTest11, &rectTest12, &rectTest13, &rectTest14,

--- a/test/testautomation_rect.c
+++ b/test/testautomation_rect.c
@@ -43,7 +43,7 @@ void _validateIntersectRectAndLineResults(
  * \brief Tests SDL_IntersectRectAndLine() clipping cases
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_IntersectRectAndLine
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRectAndLine
  */
 int
 rect_testIntersectRectAndLine (void *arg)
@@ -114,7 +114,7 @@ rect_testIntersectRectAndLine (void *arg)
  * \brief Tests SDL_IntersectRectAndLine() non-clipping case line inside
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_IntersectRectAndLine
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRectAndLine
  */
 int
 rect_testIntersectRectAndLineInside (void *arg)
@@ -181,7 +181,7 @@ rect_testIntersectRectAndLineInside (void *arg)
  * \brief Tests SDL_IntersectRectAndLine() non-clipping cases outside
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_IntersectRectAndLine
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRectAndLine
  */
 int
 rect_testIntersectRectAndLineOutside (void *arg)
@@ -236,7 +236,7 @@ rect_testIntersectRectAndLineOutside (void *arg)
  * \brief Tests SDL_IntersectRectAndLine() with empty rectangle
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_IntersectRectAndLine
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRectAndLine
  */
 int
 rect_testIntersectRectAndLineEmpty (void *arg)
@@ -271,7 +271,7 @@ rect_testIntersectRectAndLineEmpty (void *arg)
  * \brief Negative tests against SDL_IntersectRectAndLine() with invalid parameters
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_IntersectRectAndLine
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRectAndLine
  */
 int
 rect_testIntersectRectAndLineParam (void *arg)
@@ -412,7 +412,7 @@ void _validateRectEqualsResults(
  * \brief Tests SDL_IntersectRect() with B fully inside A
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_IntersectRect
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRect
  */
 int rect_testIntersectRectInside (void *arg)
 {
@@ -440,7 +440,7 @@ int rect_testIntersectRectInside (void *arg)
  * \brief Tests SDL_IntersectRect() with B fully outside A
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_IntersectRect
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRect
  */
 int rect_testIntersectRectOutside (void *arg)
 {
@@ -468,7 +468,7 @@ int rect_testIntersectRectOutside (void *arg)
  * \brief Tests SDL_IntersectRect() with B partially intersecting A
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_IntersectRect
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRect
  */
 int rect_testIntersectRectPartial (void *arg)
 {
@@ -557,7 +557,7 @@ int rect_testIntersectRectPartial (void *arg)
  * \brief Tests SDL_IntersectRect() with 1x1 pixel sized rectangles
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_IntersectRect
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRect
  */
 int rect_testIntersectRectPoint (void *arg)
 {
@@ -604,7 +604,7 @@ int rect_testIntersectRectPoint (void *arg)
  * \brief Tests SDL_IntersectRect() with empty rectangles
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_IntersectRect
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRect
  */
 int rect_testIntersectRectEmpty (void *arg)
 {
@@ -676,7 +676,7 @@ int rect_testIntersectRectEmpty (void *arg)
  * \brief Negative tests against SDL_IntersectRect() with invalid parameters
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_IntersectRect
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRect
  */
 int rect_testIntersectRectParam(void *arg)
 {
@@ -706,7 +706,7 @@ int rect_testIntersectRectParam(void *arg)
  * \brief Tests SDL_HasIntersection() with B fully inside A
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_HasIntersection
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasIntersection
  */
 int rect_testHasIntersectionInside (void *arg)
 {
@@ -733,7 +733,7 @@ int rect_testHasIntersectionInside (void *arg)
  * \brief Tests SDL_HasIntersection() with B fully outside A
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_HasIntersection
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasIntersection
  */
 int rect_testHasIntersectionOutside (void *arg)
 {
@@ -760,7 +760,7 @@ int rect_testHasIntersectionOutside (void *arg)
  * \brief Tests SDL_HasIntersection() with B partially intersecting A
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_HasIntersection
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasIntersection
  */
 int rect_testHasIntersectionPartial (void *arg)
 {
@@ -827,7 +827,7 @@ int rect_testHasIntersectionPartial (void *arg)
  * \brief Tests SDL_HasIntersection() with 1x1 pixel sized rectangles
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_HasIntersection
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasIntersection
  */
 int rect_testHasIntersectionPoint (void *arg)
 {
@@ -873,7 +873,7 @@ int rect_testHasIntersectionPoint (void *arg)
  * \brief Tests SDL_HasIntersection() with empty rectangles
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_HasIntersection
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasIntersection
  */
 int rect_testHasIntersectionEmpty (void *arg)
 {
@@ -931,7 +931,7 @@ int rect_testHasIntersectionEmpty (void *arg)
  * \brief Negative tests against SDL_HasIntersection() with invalid parameters
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_HasIntersection
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasIntersection
  */
 int rect_testHasIntersectionParam(void *arg)
 {
@@ -954,7 +954,7 @@ int rect_testHasIntersectionParam(void *arg)
  * \brief Test SDL_EnclosePoints() without clipping
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_EnclosePoints
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_EnclosePoints
  */
 int rect_testEnclosePoints(void *arg)
 {
@@ -1024,7 +1024,7 @@ int rect_testEnclosePoints(void *arg)
  * \brief Test SDL_EnclosePoints() with repeated input points
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_EnclosePoints
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_EnclosePoints
  */
 int rect_testEnclosePointsRepeatedInput(void *arg)
 {
@@ -1100,7 +1100,7 @@ int rect_testEnclosePointsRepeatedInput(void *arg)
  * \brief Test SDL_EnclosePoints() with clipping
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_EnclosePoints
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_EnclosePoints
  */
 int rect_testEnclosePointsWithClipping(void *arg)
 {
@@ -1199,7 +1199,7 @@ int rect_testEnclosePointsWithClipping(void *arg)
  * \brief Negative tests against SDL_EnclosePoints() with invalid parameters
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_EnclosePoints
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_EnclosePoints
  */
 int rect_testEnclosePointsParam(void *arg)
 {
@@ -1227,7 +1227,7 @@ int rect_testEnclosePointsParam(void *arg)
  * \brief Tests SDL_UnionRect() where rect B is outside rect A
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_UnionRect
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_UnionRect
  */
 int rect_testUnionRectOutside(void *arg)
 {
@@ -1298,7 +1298,7 @@ int rect_testUnionRectOutside(void *arg)
  * \brief Tests SDL_UnionRect() where rect A or rect B are empty
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_UnionRect
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_UnionRect
  */
 int rect_testUnionRectEmpty(void *arg)
 {
@@ -1363,7 +1363,7 @@ int rect_testUnionRectEmpty(void *arg)
  * \brief Tests SDL_UnionRect() where rect B is inside rect A
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_UnionRect
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_UnionRect
  */
 int rect_testUnionRectInside(void *arg)
 {
@@ -1427,7 +1427,7 @@ int rect_testUnionRectInside(void *arg)
  * \brief Negative tests against SDL_UnionRect() with invalid parameters
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_UnionRect
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_UnionRect
  */
 int rect_testUnionRectParam(void *arg)
 {
@@ -1455,7 +1455,7 @@ int rect_testUnionRectParam(void *arg)
  * \brief Tests SDL_RectEmpty() with various inputs
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_RectEmpty
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RectEmpty
  */
 int rect_testRectEmpty(void *arg)
 {
@@ -1498,7 +1498,7 @@ int rect_testRectEmpty(void *arg)
  * \brief Negative tests against SDL_RectEmpty() with invalid parameters
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_RectEmpty
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RectEmpty
  */
 int rect_testRectEmptyParam(void *arg)
 {
@@ -1515,7 +1515,7 @@ int rect_testRectEmptyParam(void *arg)
  * \brief Tests SDL_RectEquals() with various inputs
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_RectEquals
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RectEquals
  */
 int rect_testRectEquals(void *arg)
 {
@@ -1545,7 +1545,7 @@ int rect_testRectEquals(void *arg)
  * \brief Negative tests against SDL_RectEquals() with invalid parameters
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_RectEquals
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RectEquals
  */
 int rect_testRectEqualsParam(void *arg)
 {
@@ -1678,7 +1678,7 @@ static const SDLTest_TestCaseReference rectTest29 =
  * \brief Sequence of Rect test cases; functions that handle simple rectangles including overlaps and merges.
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/CategoryRect
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/CategoryRect
  */
 static const SDLTest_TestCaseReference *rectTests[] =  {
     &rectTest1, &rectTest2, &rectTest3, &rectTest4, &rectTest5, &rectTest6, &rectTest7, &rectTest8, &rectTest9, &rectTest10, &rectTest11, &rectTest12, &rectTest13, &rectTest14,

--- a/test/testautomation_rect.c
+++ b/test/testautomation_rect.c
@@ -43,7 +43,7 @@ void _validateIntersectRectAndLineResults(
  * \brief Tests SDL_IntersectRectAndLine() clipping cases
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRectAndLine
+ * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRectAndLine
  */
 int
 rect_testIntersectRectAndLine (void *arg)
@@ -114,7 +114,7 @@ rect_testIntersectRectAndLine (void *arg)
  * \brief Tests SDL_IntersectRectAndLine() non-clipping case line inside
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRectAndLine
+ * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRectAndLine
  */
 int
 rect_testIntersectRectAndLineInside (void *arg)
@@ -181,7 +181,7 @@ rect_testIntersectRectAndLineInside (void *arg)
  * \brief Tests SDL_IntersectRectAndLine() non-clipping cases outside
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRectAndLine
+ * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRectAndLine
  */
 int
 rect_testIntersectRectAndLineOutside (void *arg)
@@ -236,7 +236,7 @@ rect_testIntersectRectAndLineOutside (void *arg)
  * \brief Tests SDL_IntersectRectAndLine() with empty rectangle
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRectAndLine
+ * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRectAndLine
  */
 int
 rect_testIntersectRectAndLineEmpty (void *arg)
@@ -271,7 +271,7 @@ rect_testIntersectRectAndLineEmpty (void *arg)
  * \brief Negative tests against SDL_IntersectRectAndLine() with invalid parameters
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRectAndLine
+ * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRectAndLine
  */
 int
 rect_testIntersectRectAndLineParam (void *arg)
@@ -412,7 +412,7 @@ void _validateRectEqualsResults(
  * \brief Tests SDL_IntersectRect() with B fully inside A
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRect
+ * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRect
  */
 int rect_testIntersectRectInside (void *arg)
 {
@@ -440,7 +440,7 @@ int rect_testIntersectRectInside (void *arg)
  * \brief Tests SDL_IntersectRect() with B fully outside A
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRect
+ * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRect
  */
 int rect_testIntersectRectOutside (void *arg)
 {
@@ -468,7 +468,7 @@ int rect_testIntersectRectOutside (void *arg)
  * \brief Tests SDL_IntersectRect() with B partially intersecting A
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRect
+ * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRect
  */
 int rect_testIntersectRectPartial (void *arg)
 {
@@ -557,7 +557,7 @@ int rect_testIntersectRectPartial (void *arg)
  * \brief Tests SDL_IntersectRect() with 1x1 pixel sized rectangles
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRect
+ * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRect
  */
 int rect_testIntersectRectPoint (void *arg)
 {
@@ -604,7 +604,7 @@ int rect_testIntersectRectPoint (void *arg)
  * \brief Tests SDL_IntersectRect() with empty rectangles
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRect
+ * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRect
  */
 int rect_testIntersectRectEmpty (void *arg)
 {
@@ -676,7 +676,7 @@ int rect_testIntersectRectEmpty (void *arg)
  * \brief Negative tests against SDL_IntersectRect() with invalid parameters
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_IntersectRect
+ * http://github.com/libsdl-org/SDL/wiki/SDL_IntersectRect
  */
 int rect_testIntersectRectParam(void *arg)
 {
@@ -706,7 +706,7 @@ int rect_testIntersectRectParam(void *arg)
  * \brief Tests SDL_HasIntersection() with B fully inside A
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasIntersection
+ * http://github.com/libsdl-org/SDL/wiki/SDL_HasIntersection
  */
 int rect_testHasIntersectionInside (void *arg)
 {
@@ -733,7 +733,7 @@ int rect_testHasIntersectionInside (void *arg)
  * \brief Tests SDL_HasIntersection() with B fully outside A
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasIntersection
+ * http://github.com/libsdl-org/SDL/wiki/SDL_HasIntersection
  */
 int rect_testHasIntersectionOutside (void *arg)
 {
@@ -760,7 +760,7 @@ int rect_testHasIntersectionOutside (void *arg)
  * \brief Tests SDL_HasIntersection() with B partially intersecting A
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasIntersection
+ * http://github.com/libsdl-org/SDL/wiki/SDL_HasIntersection
  */
 int rect_testHasIntersectionPartial (void *arg)
 {
@@ -827,7 +827,7 @@ int rect_testHasIntersectionPartial (void *arg)
  * \brief Tests SDL_HasIntersection() with 1x1 pixel sized rectangles
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasIntersection
+ * http://github.com/libsdl-org/SDL/wiki/SDL_HasIntersection
  */
 int rect_testHasIntersectionPoint (void *arg)
 {
@@ -873,7 +873,7 @@ int rect_testHasIntersectionPoint (void *arg)
  * \brief Tests SDL_HasIntersection() with empty rectangles
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasIntersection
+ * http://github.com/libsdl-org/SDL/wiki/SDL_HasIntersection
  */
 int rect_testHasIntersectionEmpty (void *arg)
 {
@@ -931,7 +931,7 @@ int rect_testHasIntersectionEmpty (void *arg)
  * \brief Negative tests against SDL_HasIntersection() with invalid parameters
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_HasIntersection
+ * http://github.com/libsdl-org/SDL/wiki/SDL_HasIntersection
  */
 int rect_testHasIntersectionParam(void *arg)
 {
@@ -954,7 +954,7 @@ int rect_testHasIntersectionParam(void *arg)
  * \brief Test SDL_EnclosePoints() without clipping
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_EnclosePoints
+ * http://github.com/libsdl-org/SDL/wiki/SDL_EnclosePoints
  */
 int rect_testEnclosePoints(void *arg)
 {
@@ -1024,7 +1024,7 @@ int rect_testEnclosePoints(void *arg)
  * \brief Test SDL_EnclosePoints() with repeated input points
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_EnclosePoints
+ * http://github.com/libsdl-org/SDL/wiki/SDL_EnclosePoints
  */
 int rect_testEnclosePointsRepeatedInput(void *arg)
 {
@@ -1100,7 +1100,7 @@ int rect_testEnclosePointsRepeatedInput(void *arg)
  * \brief Test SDL_EnclosePoints() with clipping
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_EnclosePoints
+ * http://github.com/libsdl-org/SDL/wiki/SDL_EnclosePoints
  */
 int rect_testEnclosePointsWithClipping(void *arg)
 {
@@ -1199,7 +1199,7 @@ int rect_testEnclosePointsWithClipping(void *arg)
  * \brief Negative tests against SDL_EnclosePoints() with invalid parameters
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_EnclosePoints
+ * http://github.com/libsdl-org/SDL/wiki/SDL_EnclosePoints
  */
 int rect_testEnclosePointsParam(void *arg)
 {
@@ -1227,7 +1227,7 @@ int rect_testEnclosePointsParam(void *arg)
  * \brief Tests SDL_UnionRect() where rect B is outside rect A
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_UnionRect
+ * http://github.com/libsdl-org/SDL/wiki/SDL_UnionRect
  */
 int rect_testUnionRectOutside(void *arg)
 {
@@ -1298,7 +1298,7 @@ int rect_testUnionRectOutside(void *arg)
  * \brief Tests SDL_UnionRect() where rect A or rect B are empty
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_UnionRect
+ * http://github.com/libsdl-org/SDL/wiki/SDL_UnionRect
  */
 int rect_testUnionRectEmpty(void *arg)
 {
@@ -1363,7 +1363,7 @@ int rect_testUnionRectEmpty(void *arg)
  * \brief Tests SDL_UnionRect() where rect B is inside rect A
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_UnionRect
+ * http://github.com/libsdl-org/SDL/wiki/SDL_UnionRect
  */
 int rect_testUnionRectInside(void *arg)
 {
@@ -1427,7 +1427,7 @@ int rect_testUnionRectInside(void *arg)
  * \brief Negative tests against SDL_UnionRect() with invalid parameters
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_UnionRect
+ * http://github.com/libsdl-org/SDL/wiki/SDL_UnionRect
  */
 int rect_testUnionRectParam(void *arg)
 {
@@ -1455,7 +1455,7 @@ int rect_testUnionRectParam(void *arg)
  * \brief Tests SDL_RectEmpty() with various inputs
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RectEmpty
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RectEmpty
  */
 int rect_testRectEmpty(void *arg)
 {
@@ -1498,7 +1498,7 @@ int rect_testRectEmpty(void *arg)
  * \brief Negative tests against SDL_RectEmpty() with invalid parameters
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RectEmpty
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RectEmpty
  */
 int rect_testRectEmptyParam(void *arg)
 {
@@ -1515,7 +1515,7 @@ int rect_testRectEmptyParam(void *arg)
  * \brief Tests SDL_RectEquals() with various inputs
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RectEquals
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RectEquals
  */
 int rect_testRectEquals(void *arg)
 {
@@ -1545,7 +1545,7 @@ int rect_testRectEquals(void *arg)
  * \brief Negative tests against SDL_RectEquals() with invalid parameters
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RectEquals
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RectEquals
  */
 int rect_testRectEqualsParam(void *arg)
 {
@@ -1678,7 +1678,7 @@ static const SDLTest_TestCaseReference rectTest29 =
  * \brief Sequence of Rect test cases; functions that handle simple rectangles including overlaps and merges.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/CategoryRect
+ * http://github.com/libsdl-org/SDL/wiki/CategoryRect
  */
 static const SDLTest_TestCaseReference *rectTests[] =  {
     &rectTest1, &rectTest2, &rectTest3, &rectTest4, &rectTest5, &rectTest6, &rectTest7, &rectTest8, &rectTest9, &rectTest10, &rectTest11, &rectTest12, &rectTest13, &rectTest14,

--- a/test/testautomation_render.c
+++ b/test/testautomation_render.c
@@ -83,7 +83,7 @@ void CleanupDestroyRenderer(void *arg)
  * @brief Tests call to SDL_GetNumRenderDrivers
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetNumRenderDrivers
+ * http://github.com/libsdl-org/SDL/wiki/SDL_GetNumRenderDrivers
  */
 int
 render_testGetNumRenderDrivers(void *arg)
@@ -99,9 +99,9 @@ render_testGetNumRenderDrivers(void *arg)
  * @brief Tests the SDL primitives for rendering.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetRenderDrawColor
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderFillRect
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderDrawLine
+ * http://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawColor
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RenderFillRect
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RenderDrawLine
  *
  */
 int render_testPrimitives (void *arg)
@@ -206,9 +206,9 @@ int render_testPrimitives (void *arg)
  * @brief Tests the SDL primitives with alpha for rendering.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetRenderDrawColor
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetRenderDrawBlendMode
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderFillRect
+ * http://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawColor
+ * http://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawBlendMode
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RenderFillRect
  */
 int render_testPrimitivesBlend (void *arg)
 {
@@ -355,8 +355,8 @@ int render_testPrimitivesBlend (void *arg)
  * @brief Tests some blitting routines.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderCopy
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_DestroyTexture
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RenderCopy
+ * http://github.com/libsdl-org/SDL/wiki/SDL_DestroyTexture
  */
 int
 render_testBlit(void *arg)
@@ -424,9 +424,9 @@ render_testBlit(void *arg)
  * @brief Blits doing color tests.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextureColorMod
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderCopy
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_DestroyTexture
+ * http://github.com/libsdl-org/SDL/wiki/SDL_SetTextureColorMod
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RenderCopy
+ * http://github.com/libsdl-org/SDL/wiki/SDL_DestroyTexture
  */
 int
 render_testBlitColor (void *arg)
@@ -498,9 +498,9 @@ render_testBlitColor (void *arg)
  * @brief Tests blitting with alpha.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextureAlphaMod
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderCopy
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_DestroyTexture
+ * http://github.com/libsdl-org/SDL/wiki/SDL_SetTextureAlphaMod
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RenderCopy
+ * http://github.com/libsdl-org/SDL/wiki/SDL_DestroyTexture
  */
 int
 render_testBlitAlpha (void *arg)
@@ -576,8 +576,8 @@ render_testBlitAlpha (void *arg)
  * @brief Tests a blend mode.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextureBlendMode
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderCopy
+ * http://github.com/libsdl-org/SDL/wiki/SDL_SetTextureBlendMode
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RenderCopy
  */
 static void
 _testBlitBlendMode( SDL_Texture * tface, int mode )
@@ -626,10 +626,10 @@ _testBlitBlendMode( SDL_Texture * tface, int mode )
  * @brief Tests some more blitting routines.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextureColorMod
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextureAlphaMod
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextureBlendMode
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_DestroyTexture
+ * http://github.com/libsdl-org/SDL/wiki/SDL_SetTextureColorMod
+ * http://github.com/libsdl-org/SDL/wiki/SDL_SetTextureAlphaMod
+ * http://github.com/libsdl-org/SDL/wiki/SDL_SetTextureBlendMode
+ * http://github.com/libsdl-org/SDL/wiki/SDL_DestroyTexture
  */
 int
 render_testBlitBlend (void *arg)
@@ -779,8 +779,8 @@ _isSupported( int code )
  * @brief Test to see if we can vary the draw color. Helper function.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetRenderDrawColor
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetRenderDrawColor
+ * http://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawColor
+ * http://github.com/libsdl-org/SDL/wiki/SDL_GetRenderDrawColor
  */
 static int
 _hasDrawColor (void)
@@ -817,8 +817,8 @@ _hasDrawColor (void)
  * @brief Test to see if we can vary the blend mode. Helper function.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetRenderDrawBlendMode
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetRenderDrawBlendMode
+ * http://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawBlendMode
+ * http://github.com/libsdl-org/SDL/wiki/SDL_GetRenderDrawBlendMode
  */
 static int
 _hasBlendModes (void)
@@ -874,7 +874,7 @@ _hasBlendModes (void)
  * @brief Loads the test image 'Face' as texture. Helper function.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_CreateTextureFromSurface
+ * http://github.com/libsdl-org/SDL/wiki/SDL_CreateTextureFromSurface
  */
 static SDL_Texture *
 _loadTestFace(void)
@@ -902,9 +902,9 @@ _loadTestFace(void)
  * @brief Test to see if can set texture color mode. Helper function.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextureColorMod
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetTextureColorMod
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_DestroyTexture
+ * http://github.com/libsdl-org/SDL/wiki/SDL_SetTextureColorMod
+ * http://github.com/libsdl-org/SDL/wiki/SDL_GetTextureColorMod
+ * http://github.com/libsdl-org/SDL/wiki/SDL_DestroyTexture
  */
 static int
 _hasTexColor (void)
@@ -942,9 +942,9 @@ _hasTexColor (void)
  * @brief Test to see if we can vary the alpha of the texture. Helper function.
  *
  * \sa
- *  http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextureAlphaMod
- *  http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetTextureAlphaMod
- *  http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_DestroyTexture
+ *  http://github.com/libsdl-org/SDL/wiki/SDL_SetTextureAlphaMod
+ *  http://github.com/libsdl-org/SDL/wiki/SDL_GetTextureAlphaMod
+ *  http://github.com/libsdl-org/SDL/wiki/SDL_DestroyTexture
  */
 static int
 _hasTexAlpha(void)
@@ -984,9 +984,9 @@ _hasTexAlpha(void)
  * @param s Image to compare against.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderReadPixels
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_CreateRGBSurfaceFrom
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_FreeSurface
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RenderReadPixels
+ * http://github.com/libsdl-org/SDL/wiki/SDL_CreateRGBSurfaceFrom
+ * http://github.com/libsdl-org/SDL/wiki/SDL_FreeSurface
  */
 static void
 _compare(SDL_Surface *referenceSurface, int allowable_error)
@@ -1027,10 +1027,10 @@ _compare(SDL_Surface *referenceSurface, int allowable_error)
  * @brief Clears the screen. Helper function.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetRenderDrawColor
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderClear
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderPresent
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetRenderDrawBlendMode
+ * http://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawColor
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RenderClear
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RenderPresent
+ * http://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawBlendMode
  */
 static int
 _clearScreen(void)

--- a/test/testautomation_render.c
+++ b/test/testautomation_render.c
@@ -83,7 +83,7 @@ void CleanupDestroyRenderer(void *arg)
  * @brief Tests call to SDL_GetNumRenderDrivers
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_GetNumRenderDrivers
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetNumRenderDrivers
  */
 int
 render_testGetNumRenderDrivers(void *arg)
@@ -99,9 +99,9 @@ render_testGetNumRenderDrivers(void *arg)
  * @brief Tests the SDL primitives for rendering.
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_SetRenderDrawColor
- * http://wiki.libsdl.org/moin.cgi/SDL_RenderFillRect
- * http://wiki.libsdl.org/moin.cgi/SDL_RenderDrawLine
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetRenderDrawColor
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderFillRect
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderDrawLine
  *
  */
 int render_testPrimitives (void *arg)
@@ -206,9 +206,9 @@ int render_testPrimitives (void *arg)
  * @brief Tests the SDL primitives with alpha for rendering.
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_SetRenderDrawColor
- * http://wiki.libsdl.org/moin.cgi/SDL_SetRenderDrawBlendMode
- * http://wiki.libsdl.org/moin.cgi/SDL_RenderFillRect
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetRenderDrawColor
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetRenderDrawBlendMode
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderFillRect
  */
 int render_testPrimitivesBlend (void *arg)
 {
@@ -355,8 +355,8 @@ int render_testPrimitivesBlend (void *arg)
  * @brief Tests some blitting routines.
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_RenderCopy
- * http://wiki.libsdl.org/moin.cgi/SDL_DestroyTexture
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderCopy
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_DestroyTexture
  */
 int
 render_testBlit(void *arg)
@@ -424,9 +424,9 @@ render_testBlit(void *arg)
  * @brief Blits doing color tests.
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_SetTextureColorMod
- * http://wiki.libsdl.org/moin.cgi/SDL_RenderCopy
- * http://wiki.libsdl.org/moin.cgi/SDL_DestroyTexture
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextureColorMod
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderCopy
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_DestroyTexture
  */
 int
 render_testBlitColor (void *arg)
@@ -498,9 +498,9 @@ render_testBlitColor (void *arg)
  * @brief Tests blitting with alpha.
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_SetTextureAlphaMod
- * http://wiki.libsdl.org/moin.cgi/SDL_RenderCopy
- * http://wiki.libsdl.org/moin.cgi/SDL_DestroyTexture
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextureAlphaMod
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderCopy
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_DestroyTexture
  */
 int
 render_testBlitAlpha (void *arg)
@@ -576,8 +576,8 @@ render_testBlitAlpha (void *arg)
  * @brief Tests a blend mode.
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_SetTextureBlendMode
- * http://wiki.libsdl.org/moin.cgi/SDL_RenderCopy
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextureBlendMode
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderCopy
  */
 static void
 _testBlitBlendMode( SDL_Texture * tface, int mode )
@@ -626,10 +626,10 @@ _testBlitBlendMode( SDL_Texture * tface, int mode )
  * @brief Tests some more blitting routines.
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_SetTextureColorMod
- * http://wiki.libsdl.org/moin.cgi/SDL_SetTextureAlphaMod
- * http://wiki.libsdl.org/moin.cgi/SDL_SetTextureBlendMode
- * http://wiki.libsdl.org/moin.cgi/SDL_DestroyTexture
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextureColorMod
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextureAlphaMod
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextureBlendMode
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_DestroyTexture
  */
 int
 render_testBlitBlend (void *arg)
@@ -779,8 +779,8 @@ _isSupported( int code )
  * @brief Test to see if we can vary the draw color. Helper function.
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_SetRenderDrawColor
- * http://wiki.libsdl.org/moin.cgi/SDL_GetRenderDrawColor
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetRenderDrawColor
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetRenderDrawColor
  */
 static int
 _hasDrawColor (void)
@@ -817,8 +817,8 @@ _hasDrawColor (void)
  * @brief Test to see if we can vary the blend mode. Helper function.
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_SetRenderDrawBlendMode
- * http://wiki.libsdl.org/moin.cgi/SDL_GetRenderDrawBlendMode
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetRenderDrawBlendMode
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetRenderDrawBlendMode
  */
 static int
 _hasBlendModes (void)
@@ -874,7 +874,7 @@ _hasBlendModes (void)
  * @brief Loads the test image 'Face' as texture. Helper function.
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_CreateTextureFromSurface
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_CreateTextureFromSurface
  */
 static SDL_Texture *
 _loadTestFace(void)
@@ -902,9 +902,9 @@ _loadTestFace(void)
  * @brief Test to see if can set texture color mode. Helper function.
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_SetTextureColorMod
- * http://wiki.libsdl.org/moin.cgi/SDL_GetTextureColorMod
- * http://wiki.libsdl.org/moin.cgi/SDL_DestroyTexture
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextureColorMod
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetTextureColorMod
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_DestroyTexture
  */
 static int
 _hasTexColor (void)
@@ -942,9 +942,9 @@ _hasTexColor (void)
  * @brief Test to see if we can vary the alpha of the texture. Helper function.
  *
  * \sa
- *  http://wiki.libsdl.org/moin.cgi/SDL_SetTextureAlphaMod
- *  http://wiki.libsdl.org/moin.cgi/SDL_GetTextureAlphaMod
- *  http://wiki.libsdl.org/moin.cgi/SDL_DestroyTexture
+ *  http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetTextureAlphaMod
+ *  http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_GetTextureAlphaMod
+ *  http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_DestroyTexture
  */
 static int
 _hasTexAlpha(void)
@@ -984,9 +984,9 @@ _hasTexAlpha(void)
  * @param s Image to compare against.
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_RenderReadPixels
- * http://wiki.libsdl.org/moin.cgi/SDL_CreateRGBSurfaceFrom
- * http://wiki.libsdl.org/moin.cgi/SDL_FreeSurface
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderReadPixels
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_CreateRGBSurfaceFrom
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_FreeSurface
  */
 static void
 _compare(SDL_Surface *referenceSurface, int allowable_error)
@@ -1027,10 +1027,10 @@ _compare(SDL_Surface *referenceSurface, int allowable_error)
  * @brief Clears the screen. Helper function.
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_SetRenderDrawColor
- * http://wiki.libsdl.org/moin.cgi/SDL_RenderClear
- * http://wiki.libsdl.org/moin.cgi/SDL_RenderPresent
- * http://wiki.libsdl.org/moin.cgi/SDL_SetRenderDrawBlendMode
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetRenderDrawColor
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderClear
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RenderPresent
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_SetRenderDrawBlendMode
  */
 static int
 _clearScreen(void)

--- a/test/testautomation_render.c
+++ b/test/testautomation_render.c
@@ -83,7 +83,7 @@ void CleanupDestroyRenderer(void *arg)
  * @brief Tests call to SDL_GetNumRenderDrivers
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_GetNumRenderDrivers
+ * https://github.com/libsdl-org/SDL/wiki/SDL_GetNumRenderDrivers
  */
 int
 render_testGetNumRenderDrivers(void *arg)
@@ -99,9 +99,9 @@ render_testGetNumRenderDrivers(void *arg)
  * @brief Tests the SDL primitives for rendering.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawColor
- * http://github.com/libsdl-org/SDL/wiki/SDL_RenderFillRect
- * http://github.com/libsdl-org/SDL/wiki/SDL_RenderDrawLine
+ * https://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawColor
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RenderFillRect
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RenderDrawLine
  *
  */
 int render_testPrimitives (void *arg)
@@ -206,9 +206,9 @@ int render_testPrimitives (void *arg)
  * @brief Tests the SDL primitives with alpha for rendering.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawColor
- * http://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawBlendMode
- * http://github.com/libsdl-org/SDL/wiki/SDL_RenderFillRect
+ * https://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawColor
+ * https://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawBlendMode
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RenderFillRect
  */
 int render_testPrimitivesBlend (void *arg)
 {
@@ -355,8 +355,8 @@ int render_testPrimitivesBlend (void *arg)
  * @brief Tests some blitting routines.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_RenderCopy
- * http://github.com/libsdl-org/SDL/wiki/SDL_DestroyTexture
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RenderCopy
+ * https://github.com/libsdl-org/SDL/wiki/SDL_DestroyTexture
  */
 int
 render_testBlit(void *arg)
@@ -424,9 +424,9 @@ render_testBlit(void *arg)
  * @brief Blits doing color tests.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_SetTextureColorMod
- * http://github.com/libsdl-org/SDL/wiki/SDL_RenderCopy
- * http://github.com/libsdl-org/SDL/wiki/SDL_DestroyTexture
+ * https://github.com/libsdl-org/SDL/wiki/SDL_SetTextureColorMod
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RenderCopy
+ * https://github.com/libsdl-org/SDL/wiki/SDL_DestroyTexture
  */
 int
 render_testBlitColor (void *arg)
@@ -498,9 +498,9 @@ render_testBlitColor (void *arg)
  * @brief Tests blitting with alpha.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_SetTextureAlphaMod
- * http://github.com/libsdl-org/SDL/wiki/SDL_RenderCopy
- * http://github.com/libsdl-org/SDL/wiki/SDL_DestroyTexture
+ * https://github.com/libsdl-org/SDL/wiki/SDL_SetTextureAlphaMod
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RenderCopy
+ * https://github.com/libsdl-org/SDL/wiki/SDL_DestroyTexture
  */
 int
 render_testBlitAlpha (void *arg)
@@ -576,8 +576,8 @@ render_testBlitAlpha (void *arg)
  * @brief Tests a blend mode.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_SetTextureBlendMode
- * http://github.com/libsdl-org/SDL/wiki/SDL_RenderCopy
+ * https://github.com/libsdl-org/SDL/wiki/SDL_SetTextureBlendMode
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RenderCopy
  */
 static void
 _testBlitBlendMode( SDL_Texture * tface, int mode )
@@ -626,10 +626,10 @@ _testBlitBlendMode( SDL_Texture * tface, int mode )
  * @brief Tests some more blitting routines.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_SetTextureColorMod
- * http://github.com/libsdl-org/SDL/wiki/SDL_SetTextureAlphaMod
- * http://github.com/libsdl-org/SDL/wiki/SDL_SetTextureBlendMode
- * http://github.com/libsdl-org/SDL/wiki/SDL_DestroyTexture
+ * https://github.com/libsdl-org/SDL/wiki/SDL_SetTextureColorMod
+ * https://github.com/libsdl-org/SDL/wiki/SDL_SetTextureAlphaMod
+ * https://github.com/libsdl-org/SDL/wiki/SDL_SetTextureBlendMode
+ * https://github.com/libsdl-org/SDL/wiki/SDL_DestroyTexture
  */
 int
 render_testBlitBlend (void *arg)
@@ -779,8 +779,8 @@ _isSupported( int code )
  * @brief Test to see if we can vary the draw color. Helper function.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawColor
- * http://github.com/libsdl-org/SDL/wiki/SDL_GetRenderDrawColor
+ * https://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawColor
+ * https://github.com/libsdl-org/SDL/wiki/SDL_GetRenderDrawColor
  */
 static int
 _hasDrawColor (void)
@@ -817,8 +817,8 @@ _hasDrawColor (void)
  * @brief Test to see if we can vary the blend mode. Helper function.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawBlendMode
- * http://github.com/libsdl-org/SDL/wiki/SDL_GetRenderDrawBlendMode
+ * https://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawBlendMode
+ * https://github.com/libsdl-org/SDL/wiki/SDL_GetRenderDrawBlendMode
  */
 static int
 _hasBlendModes (void)
@@ -874,7 +874,7 @@ _hasBlendModes (void)
  * @brief Loads the test image 'Face' as texture. Helper function.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_CreateTextureFromSurface
+ * https://github.com/libsdl-org/SDL/wiki/SDL_CreateTextureFromSurface
  */
 static SDL_Texture *
 _loadTestFace(void)
@@ -902,9 +902,9 @@ _loadTestFace(void)
  * @brief Test to see if can set texture color mode. Helper function.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_SetTextureColorMod
- * http://github.com/libsdl-org/SDL/wiki/SDL_GetTextureColorMod
- * http://github.com/libsdl-org/SDL/wiki/SDL_DestroyTexture
+ * https://github.com/libsdl-org/SDL/wiki/SDL_SetTextureColorMod
+ * https://github.com/libsdl-org/SDL/wiki/SDL_GetTextureColorMod
+ * https://github.com/libsdl-org/SDL/wiki/SDL_DestroyTexture
  */
 static int
 _hasTexColor (void)
@@ -942,9 +942,9 @@ _hasTexColor (void)
  * @brief Test to see if we can vary the alpha of the texture. Helper function.
  *
  * \sa
- *  http://github.com/libsdl-org/SDL/wiki/SDL_SetTextureAlphaMod
- *  http://github.com/libsdl-org/SDL/wiki/SDL_GetTextureAlphaMod
- *  http://github.com/libsdl-org/SDL/wiki/SDL_DestroyTexture
+ *  https://github.com/libsdl-org/SDL/wiki/SDL_SetTextureAlphaMod
+ *  https://github.com/libsdl-org/SDL/wiki/SDL_GetTextureAlphaMod
+ *  https://github.com/libsdl-org/SDL/wiki/SDL_DestroyTexture
  */
 static int
 _hasTexAlpha(void)
@@ -984,9 +984,9 @@ _hasTexAlpha(void)
  * @param s Image to compare against.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_RenderReadPixels
- * http://github.com/libsdl-org/SDL/wiki/SDL_CreateRGBSurfaceFrom
- * http://github.com/libsdl-org/SDL/wiki/SDL_FreeSurface
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RenderReadPixels
+ * https://github.com/libsdl-org/SDL/wiki/SDL_CreateRGBSurfaceFrom
+ * https://github.com/libsdl-org/SDL/wiki/SDL_FreeSurface
  */
 static void
 _compare(SDL_Surface *referenceSurface, int allowable_error)
@@ -1027,10 +1027,10 @@ _compare(SDL_Surface *referenceSurface, int allowable_error)
  * @brief Clears the screen. Helper function.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawColor
- * http://github.com/libsdl-org/SDL/wiki/SDL_RenderClear
- * http://github.com/libsdl-org/SDL/wiki/SDL_RenderPresent
- * http://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawBlendMode
+ * https://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawColor
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RenderClear
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RenderPresent
+ * https://github.com/libsdl-org/SDL/wiki/SDL_SetRenderDrawBlendMode
  */
 static int
 _clearScreen(void)

--- a/test/testautomation_rwops.c
+++ b/test/testautomation_rwops.c
@@ -88,8 +88,8 @@ RWopsTearDown(void *arg)
  * @brief Makes sure parameters work properly. Local helper function.
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_RWseek
- * http://wiki.libsdl.org/moin.cgi/SDL_RWread
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWseek
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWread
  */
 void
 _testGenericRWopsValidations(SDL_RWops *rw, int write)
@@ -168,7 +168,7 @@ _testGenericRWopsValidations(SDL_RWops *rw, int write)
 /* !
  * Negative test for SDL_RWFromFile parameters
  *
- * \sa http://wiki.libsdl.org/moin.cgi/SDL_RWFromFile
+ * \sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromFile
  *
  */
 int
@@ -215,8 +215,8 @@ rwops_testParamNegative (void)
 /**
  * @brief Tests opening from memory.
  *
- * \sa http://wiki.libsdl.org/moin.cgi/SDL_RWFromMem
- * \sa http://wiki.libsdl.org/moin.cgi/SDL_RWClose
+ * \sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromMem
+ * \sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWClose
  */
 int
 rwops_testMem (void)
@@ -255,8 +255,8 @@ rwops_testMem (void)
  * @brief Tests opening from memory.
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_RWFromConstMem
- * http://wiki.libsdl.org/moin.cgi/SDL_RWClose
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromConstMem
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWClose
  */
 int
 rwops_testConstMem (void)
@@ -291,8 +291,8 @@ rwops_testConstMem (void)
  * @brief Tests reading from file.
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_RWFromFile
- * http://wiki.libsdl.org/moin.cgi/SDL_RWClose
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromFile
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWClose
  */
 int
 rwops_testFileRead(void)
@@ -338,8 +338,8 @@ rwops_testFileRead(void)
  * @brief Tests writing from file.
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_RWFromFile
- * http://wiki.libsdl.org/moin.cgi/SDL_RWClose
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromFile
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWClose
  */
 int
 rwops_testFileWrite(void)
@@ -386,8 +386,8 @@ rwops_testFileWrite(void)
  * @brief Tests reading from file handle
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_RWFromFP
- * http://wiki.libsdl.org/moin.cgi/SDL_RWClose
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromFP
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWClose
  *
  */
 int
@@ -436,8 +436,8 @@ rwops_testFPRead(void)
  * @brief Tests writing to file handle
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_RWFromFP
- * http://wiki.libsdl.org/moin.cgi/SDL_RWClose
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromFP
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWClose
  *
  */
 int
@@ -484,8 +484,8 @@ rwops_testFPWrite(void)
 /**
  * @brief Tests alloc and free RW context.
  *
- * \sa http://wiki.libsdl.org/moin.cgi/SDL_AllocRW
- * \sa http://wiki.libsdl.org/moin.cgi/SDL_FreeRW
+ * \sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_AllocRW
+ * \sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_FreeRW
  */
 int
 rwops_testAllocFree (void)
@@ -511,8 +511,8 @@ rwops_testAllocFree (void)
 /**
  * @brief Compare memory and file reads
  *
- * \sa http://wiki.libsdl.org/moin.cgi/SDL_RWFromMem
- * \sa http://wiki.libsdl.org/moin.cgi/SDL_RWFromFile
+ * \sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromMem
+ * \sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromFile
  */
 int
 rwops_testCompareRWFromMemWithRWFromFile(void)
@@ -578,10 +578,10 @@ rwops_testCompareRWFromMemWithRWFromFile(void)
  * @brief Tests writing and reading from file using endian aware functions.
  *
  * \sa
- * http://wiki.libsdl.org/moin.cgi/SDL_RWFromFile
- * http://wiki.libsdl.org/moin.cgi/SDL_RWClose
- * http://wiki.libsdl.org/moin.cgi/SDL_ReadBE16
- * http://wiki.libsdl.org/moin.cgi/SDL_WriteBE16
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromFile
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWClose
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_ReadBE16
+ * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_WriteBE16
  */
 int
 rwops_testFileWriteReadEndian(void)

--- a/test/testautomation_rwops.c
+++ b/test/testautomation_rwops.c
@@ -88,8 +88,8 @@ RWopsTearDown(void *arg)
  * @brief Makes sure parameters work properly. Local helper function.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_RWseek
- * http://github.com/libsdl-org/SDL/wiki/SDL_RWread
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RWseek
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RWread
  */
 void
 _testGenericRWopsValidations(SDL_RWops *rw, int write)
@@ -168,7 +168,7 @@ _testGenericRWopsValidations(SDL_RWops *rw, int write)
 /* !
  * Negative test for SDL_RWFromFile parameters
  *
- * \sa http://github.com/libsdl-org/SDL/wiki/SDL_RWFromFile
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_RWFromFile
  *
  */
 int
@@ -215,8 +215,8 @@ rwops_testParamNegative (void)
 /**
  * @brief Tests opening from memory.
  *
- * \sa http://github.com/libsdl-org/SDL/wiki/SDL_RWFromMem
- * \sa http://github.com/libsdl-org/SDL/wiki/SDL_RWClose
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_RWFromMem
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_RWClose
  */
 int
 rwops_testMem (void)
@@ -255,8 +255,8 @@ rwops_testMem (void)
  * @brief Tests opening from memory.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_RWFromConstMem
- * http://github.com/libsdl-org/SDL/wiki/SDL_RWClose
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RWFromConstMem
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RWClose
  */
 int
 rwops_testConstMem (void)
@@ -291,8 +291,8 @@ rwops_testConstMem (void)
  * @brief Tests reading from file.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_RWFromFile
- * http://github.com/libsdl-org/SDL/wiki/SDL_RWClose
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RWFromFile
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RWClose
  */
 int
 rwops_testFileRead(void)
@@ -338,8 +338,8 @@ rwops_testFileRead(void)
  * @brief Tests writing from file.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_RWFromFile
- * http://github.com/libsdl-org/SDL/wiki/SDL_RWClose
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RWFromFile
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RWClose
  */
 int
 rwops_testFileWrite(void)
@@ -386,8 +386,8 @@ rwops_testFileWrite(void)
  * @brief Tests reading from file handle
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_RWFromFP
- * http://github.com/libsdl-org/SDL/wiki/SDL_RWClose
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RWFromFP
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RWClose
  *
  */
 int
@@ -436,8 +436,8 @@ rwops_testFPRead(void)
  * @brief Tests writing to file handle
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_RWFromFP
- * http://github.com/libsdl-org/SDL/wiki/SDL_RWClose
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RWFromFP
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RWClose
  *
  */
 int
@@ -484,8 +484,8 @@ rwops_testFPWrite(void)
 /**
  * @brief Tests alloc and free RW context.
  *
- * \sa http://github.com/libsdl-org/SDL/wiki/SDL_AllocRW
- * \sa http://github.com/libsdl-org/SDL/wiki/SDL_FreeRW
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_AllocRW
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_FreeRW
  */
 int
 rwops_testAllocFree (void)
@@ -511,8 +511,8 @@ rwops_testAllocFree (void)
 /**
  * @brief Compare memory and file reads
  *
- * \sa http://github.com/libsdl-org/SDL/wiki/SDL_RWFromMem
- * \sa http://github.com/libsdl-org/SDL/wiki/SDL_RWFromFile
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_RWFromMem
+ * \sa https://github.com/libsdl-org/SDL/wiki/SDL_RWFromFile
  */
 int
 rwops_testCompareRWFromMemWithRWFromFile(void)
@@ -578,10 +578,10 @@ rwops_testCompareRWFromMemWithRWFromFile(void)
  * @brief Tests writing and reading from file using endian aware functions.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/SDL_RWFromFile
- * http://github.com/libsdl-org/SDL/wiki/SDL_RWClose
- * http://github.com/libsdl-org/SDL/wiki/SDL_ReadBE16
- * http://github.com/libsdl-org/SDL/wiki/SDL_WriteBE16
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RWFromFile
+ * https://github.com/libsdl-org/SDL/wiki/SDL_RWClose
+ * https://github.com/libsdl-org/SDL/wiki/SDL_ReadBE16
+ * https://github.com/libsdl-org/SDL/wiki/SDL_WriteBE16
  */
 int
 rwops_testFileWriteReadEndian(void)

--- a/test/testautomation_rwops.c
+++ b/test/testautomation_rwops.c
@@ -88,8 +88,8 @@ RWopsTearDown(void *arg)
  * @brief Makes sure parameters work properly. Local helper function.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWseek
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWread
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RWseek
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RWread
  */
 void
 _testGenericRWopsValidations(SDL_RWops *rw, int write)
@@ -168,7 +168,7 @@ _testGenericRWopsValidations(SDL_RWops *rw, int write)
 /* !
  * Negative test for SDL_RWFromFile parameters
  *
- * \sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromFile
+ * \sa http://github.com/libsdl-org/SDL/wiki/SDL_RWFromFile
  *
  */
 int
@@ -215,8 +215,8 @@ rwops_testParamNegative (void)
 /**
  * @brief Tests opening from memory.
  *
- * \sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromMem
- * \sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWClose
+ * \sa http://github.com/libsdl-org/SDL/wiki/SDL_RWFromMem
+ * \sa http://github.com/libsdl-org/SDL/wiki/SDL_RWClose
  */
 int
 rwops_testMem (void)
@@ -255,8 +255,8 @@ rwops_testMem (void)
  * @brief Tests opening from memory.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromConstMem
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWClose
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RWFromConstMem
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RWClose
  */
 int
 rwops_testConstMem (void)
@@ -291,8 +291,8 @@ rwops_testConstMem (void)
  * @brief Tests reading from file.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromFile
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWClose
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RWFromFile
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RWClose
  */
 int
 rwops_testFileRead(void)
@@ -338,8 +338,8 @@ rwops_testFileRead(void)
  * @brief Tests writing from file.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromFile
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWClose
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RWFromFile
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RWClose
  */
 int
 rwops_testFileWrite(void)
@@ -386,8 +386,8 @@ rwops_testFileWrite(void)
  * @brief Tests reading from file handle
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromFP
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWClose
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RWFromFP
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RWClose
  *
  */
 int
@@ -436,8 +436,8 @@ rwops_testFPRead(void)
  * @brief Tests writing to file handle
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromFP
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWClose
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RWFromFP
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RWClose
  *
  */
 int
@@ -484,8 +484,8 @@ rwops_testFPWrite(void)
 /**
  * @brief Tests alloc and free RW context.
  *
- * \sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_AllocRW
- * \sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_FreeRW
+ * \sa http://github.com/libsdl-org/SDL/wiki/SDL_AllocRW
+ * \sa http://github.com/libsdl-org/SDL/wiki/SDL_FreeRW
  */
 int
 rwops_testAllocFree (void)
@@ -511,8 +511,8 @@ rwops_testAllocFree (void)
 /**
  * @brief Compare memory and file reads
  *
- * \sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromMem
- * \sa http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromFile
+ * \sa http://github.com/libsdl-org/SDL/wiki/SDL_RWFromMem
+ * \sa http://github.com/libsdl-org/SDL/wiki/SDL_RWFromFile
  */
 int
 rwops_testCompareRWFromMemWithRWFromFile(void)
@@ -578,10 +578,10 @@ rwops_testCompareRWFromMemWithRWFromFile(void)
  * @brief Tests writing and reading from file using endian aware functions.
  *
  * \sa
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWFromFile
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_RWClose
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_ReadBE16
- * http://github.com/libsdl-org/SDL/wiki/moin.cgi/SDL_WriteBE16
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RWFromFile
+ * http://github.com/libsdl-org/SDL/wiki/SDL_RWClose
+ * http://github.com/libsdl-org/SDL/wiki/SDL_ReadBE16
+ * http://github.com/libsdl-org/SDL/wiki/SDL_WriteBE16
  */
 int
 rwops_testFileWriteReadEndian(void)

--- a/test/testautomation_video.c
+++ b/test/testautomation_video.c
@@ -511,7 +511,7 @@ video_getClosestDisplayModeRandomResolution(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowBrightness
  *
-* @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowBrightness
+* @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetWindowBrightness
  */
 int
 video_getWindowBrightness(void *arg)
@@ -537,7 +537,7 @@ video_getWindowBrightness(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowBrightness with invalid input
  *
-* @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowBrightness
+* @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetWindowBrightness
  */
 int
 video_getWindowBrightnessNegative(void *arg)
@@ -566,7 +566,7 @@ video_getWindowBrightnessNegative(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowDisplayMode
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowDisplayMode
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetWindowDisplayMode
  */
 int
 video_getWindowDisplayMode(void *arg)
@@ -620,7 +620,7 @@ void _checkInvalidWindowError()
 /**
  * @brief Tests call to SDL_GetWindowDisplayMode with invalid input
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowDisplayMode
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetWindowDisplayMode
  */
 int
 video_getWindowDisplayModeNegative(void *arg)
@@ -664,7 +664,7 @@ video_getWindowDisplayModeNegative(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowGammaRamp
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowGammaRamp
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetWindowGammaRamp
  */
 int
 video_getWindowGammaRamp(void *arg)
@@ -725,7 +725,7 @@ video_getWindowGammaRamp(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowGammaRamp with invalid input
  *
-* @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowGammaRamp
+* @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetWindowGammaRamp
  */
 int
 video_getWindowGammaRampNegative(void *arg)
@@ -822,8 +822,8 @@ _setAndCheckWindowKeyboardGrabState(SDL_Window* window, SDL_bool desiredState)
 /**
  * @brief Tests keyboard and mouse grab support
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowGrab
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetWindowGrab
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetWindowGrab
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_SetWindowGrab
  */
 int
 video_getSetWindowGrab(void *arg)
@@ -965,8 +965,8 @@ video_getSetWindowGrab(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowID and SDL_GetWindowFromID
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowID
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetWindowFromID
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetWindowID
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_SetWindowFromID
  */
 int
 video_getWindowId(void *arg)
@@ -1021,7 +1021,7 @@ video_getWindowId(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowPixelFormat
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowPixelFormat
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetWindowPixelFormat
  */
 int
 video_getWindowPixelFormat(void *arg)
@@ -1055,8 +1055,8 @@ video_getWindowPixelFormat(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowPosition and SDL_SetWindowPosition
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowPosition
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetWindowPosition
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetWindowPosition
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_SetWindowPosition
  */
 int
 video_getSetWindowPosition(void *arg)
@@ -1198,8 +1198,8 @@ void _checkInvalidParameterError()
 /**
  * @brief Tests call to SDL_GetWindowSize and SDL_SetWindowSize
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowSize
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetWindowSize
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetWindowSize
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_SetWindowSize
  */
 int
 video_getSetWindowSize(void *arg)
@@ -1637,8 +1637,8 @@ video_getSetWindowMaximumSize(void *arg)
 /**
  * @brief Tests call to SDL_SetWindowData and SDL_GetWindowData
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetWindowData
- * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowData
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_SetWindowData
+ * @sa https://github.com/libsdl-org/SDL/wiki/SDL_GetWindowData
  */
 int
 video_getSetWindowData(void *arg)

--- a/test/testautomation_video.c
+++ b/test/testautomation_video.c
@@ -511,7 +511,7 @@ video_getClosestDisplayModeRandomResolution(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowBrightness
  *
-* @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowBrightness
+* @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowBrightness
  */
 int
 video_getWindowBrightness(void *arg)
@@ -537,7 +537,7 @@ video_getWindowBrightness(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowBrightness with invalid input
  *
-* @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowBrightness
+* @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowBrightness
  */
 int
 video_getWindowBrightnessNegative(void *arg)
@@ -566,7 +566,7 @@ video_getWindowBrightnessNegative(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowDisplayMode
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowDisplayMode
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowDisplayMode
  */
 int
 video_getWindowDisplayMode(void *arg)
@@ -620,7 +620,7 @@ void _checkInvalidWindowError()
 /**
  * @brief Tests call to SDL_GetWindowDisplayMode with invalid input
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowDisplayMode
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowDisplayMode
  */
 int
 video_getWindowDisplayModeNegative(void *arg)
@@ -664,7 +664,7 @@ video_getWindowDisplayModeNegative(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowGammaRamp
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowGammaRamp
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowGammaRamp
  */
 int
 video_getWindowGammaRamp(void *arg)
@@ -725,7 +725,7 @@ video_getWindowGammaRamp(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowGammaRamp with invalid input
  *
-* @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowGammaRamp
+* @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowGammaRamp
  */
 int
 video_getWindowGammaRampNegative(void *arg)
@@ -965,8 +965,8 @@ video_getSetWindowGrab(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowID and SDL_GetWindowFromID
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowID
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_SetWindowFromID
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowID
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetWindowFromID
  */
 int
 video_getWindowId(void *arg)
@@ -1021,7 +1021,7 @@ video_getWindowId(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowPixelFormat
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowPixelFormat
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowPixelFormat
  */
 int
 video_getWindowPixelFormat(void *arg)
@@ -1055,8 +1055,8 @@ video_getWindowPixelFormat(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowPosition and SDL_SetWindowPosition
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowPosition
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_SetWindowPosition
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowPosition
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetWindowPosition
  */
 int
 video_getSetWindowPosition(void *arg)
@@ -1198,8 +1198,8 @@ void _checkInvalidParameterError()
 /**
  * @brief Tests call to SDL_GetWindowSize and SDL_SetWindowSize
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowSize
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_SetWindowSize
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowSize
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetWindowSize
  */
 int
 video_getSetWindowSize(void *arg)
@@ -1637,8 +1637,8 @@ video_getSetWindowMaximumSize(void *arg)
 /**
  * @brief Tests call to SDL_SetWindowData and SDL_GetWindowData
  *
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_SetWindowData
- * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowData
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetWindowData
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowData
  */
 int
 video_getSetWindowData(void *arg)

--- a/test/testautomation_video.c
+++ b/test/testautomation_video.c
@@ -511,7 +511,7 @@ video_getClosestDisplayModeRandomResolution(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowBrightness
  *
-* @sa http://wiki.libsdl.org/moin.fcg/SDL_GetWindowBrightness
+* @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowBrightness
  */
 int
 video_getWindowBrightness(void *arg)
@@ -537,7 +537,7 @@ video_getWindowBrightness(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowBrightness with invalid input
  *
-* @sa http://wiki.libsdl.org/moin.fcg/SDL_GetWindowBrightness
+* @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowBrightness
  */
 int
 video_getWindowBrightnessNegative(void *arg)
@@ -566,7 +566,7 @@ video_getWindowBrightnessNegative(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowDisplayMode
  *
- * @sa http://wiki.libsdl.org/moin.fcg/SDL_GetWindowDisplayMode
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowDisplayMode
  */
 int
 video_getWindowDisplayMode(void *arg)
@@ -620,7 +620,7 @@ void _checkInvalidWindowError()
 /**
  * @brief Tests call to SDL_GetWindowDisplayMode with invalid input
  *
- * @sa http://wiki.libsdl.org/moin.fcg/SDL_GetWindowDisplayMode
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowDisplayMode
  */
 int
 video_getWindowDisplayModeNegative(void *arg)
@@ -664,7 +664,7 @@ video_getWindowDisplayModeNegative(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowGammaRamp
  *
- * @sa http://wiki.libsdl.org/moin.fcg/SDL_GetWindowGammaRamp
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowGammaRamp
  */
 int
 video_getWindowGammaRamp(void *arg)
@@ -725,7 +725,7 @@ video_getWindowGammaRamp(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowGammaRamp with invalid input
  *
-* @sa http://wiki.libsdl.org/moin.fcg/SDL_GetWindowGammaRamp
+* @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowGammaRamp
  */
 int
 video_getWindowGammaRampNegative(void *arg)
@@ -822,8 +822,8 @@ _setAndCheckWindowKeyboardGrabState(SDL_Window* window, SDL_bool desiredState)
 /**
  * @brief Tests keyboard and mouse grab support
  *
- * @sa http://wiki.libsdl.org/SDL_GetWindowGrab
- * @sa http://wiki.libsdl.org/SDL_SetWindowGrab
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_GetWindowGrab
+ * @sa http://github.com/libsdl-org/SDL/wiki/SDL_SetWindowGrab
  */
 int
 video_getSetWindowGrab(void *arg)
@@ -965,8 +965,8 @@ video_getSetWindowGrab(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowID and SDL_GetWindowFromID
  *
- * @sa http://wiki.libsdl.org/moin.fcg/SDL_GetWindowID
- * @sa http://wiki.libsdl.org/moin.fcg/SDL_SetWindowFromID
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowID
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_SetWindowFromID
  */
 int
 video_getWindowId(void *arg)
@@ -1021,7 +1021,7 @@ video_getWindowId(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowPixelFormat
  *
- * @sa http://wiki.libsdl.org/moin.fcg/SDL_GetWindowPixelFormat
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowPixelFormat
  */
 int
 video_getWindowPixelFormat(void *arg)
@@ -1055,8 +1055,8 @@ video_getWindowPixelFormat(void *arg)
 /**
  * @brief Tests call to SDL_GetWindowPosition and SDL_SetWindowPosition
  *
- * @sa http://wiki.libsdl.org/moin.fcg/SDL_GetWindowPosition
- * @sa http://wiki.libsdl.org/moin.fcg/SDL_SetWindowPosition
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowPosition
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_SetWindowPosition
  */
 int
 video_getSetWindowPosition(void *arg)
@@ -1198,8 +1198,8 @@ void _checkInvalidParameterError()
 /**
  * @brief Tests call to SDL_GetWindowSize and SDL_SetWindowSize
  *
- * @sa http://wiki.libsdl.org/moin.fcg/SDL_GetWindowSize
- * @sa http://wiki.libsdl.org/moin.fcg/SDL_SetWindowSize
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowSize
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_SetWindowSize
  */
 int
 video_getSetWindowSize(void *arg)
@@ -1637,8 +1637,8 @@ video_getSetWindowMaximumSize(void *arg)
 /**
  * @brief Tests call to SDL_SetWindowData and SDL_GetWindowData
  *
- * @sa http://wiki.libsdl.org/moin.fcg/SDL_SetWindowData
- * @sa http://wiki.libsdl.org/moin.fcg/SDL_GetWindowData
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_SetWindowData
+ * @sa http://github.com/libsdl-org/SDL/wiki/moin.fcg/SDL_GetWindowData
  */
 int
 video_getSetWindowData(void *arg)


### PR DESCRIPTION
spawned by issue - https://github.com/libsdl-org/SDL/issues/4064

- Updated url references to the shiny new `libsdl-org/SDL/wiki`
- Cleaned up the `moin.fcg` and `moin.cgi` references
- Updated urls from `http:` to `https:`