### PR TITLE
ignore vs2019 meta folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ xcuserdata
 *.xcworkspace
 
 # for Visual C++
+.vs
 Debug
 Release
 *.user


### PR DESCRIPTION
- ignore the `.vs` folder generated by VS2019