### PR TITLE
CMake: Support uniform link target names regardless if find_package() or sub-project is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2214,6 +2214,8 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_CFLAGS}")
 # Always build SDLmain
 if(NOT WINDOWS_STORE)
 add_library(SDL2main STATIC ${SDLMAIN_SOURCES})
+# alias target for in-tree builds
+add_library(SDL2::SDL2main ALIAS SDL2main)
 target_include_directories(SDL2main PUBLIC "$<BUILD_INTERFACE:${SDL2_SOURCE_DIR}/include>" $<INSTALL_INTERFACE:include> $<INSTALL_INTERFACE:include/SDL2>)
 set(_INSTALL_LIBS "SDL2main")
 if (NOT ANDROID)
@@ -2227,6 +2229,8 @@ endif()
 
 if(SDL_SHARED)
   add_library(SDL2 SHARED ${SOURCE_FILES} ${VERSION_SOURCES})
+  # alias target for in-tree builds
+  add_library(SDL2::SDL2 ALIAS SDL2)
   if(APPLE)
     set_target_properties(SDL2 PROPERTIES
       MACOSX_RPATH 1
@@ -2269,6 +2273,8 @@ endif()
 if(ANDROID)
   if(HAVE_HIDAPI)
     add_library(hidapi SHARED ${SDL2_SOURCE_DIR}/src/hidapi/android/hid.cpp)
+    # alias target for in-tree builds
+    add_library(SDL2::hidapi ALIAS hidapi)
   endif()
 
   if(MSVC AND NOT LIBC)
@@ -2285,6 +2291,8 @@ endif()
 if(SDL_STATIC)
   set (BUILD_SHARED_LIBS FALSE)
   add_library(SDL2-static STATIC ${SOURCE_FILES})
+  # alias target for in-tree builds
+  add_library(SDL2::SDL2-static ALIAS SDL2-static)
   if (NOT SDL_SHARED OR NOT WIN32)
     set_target_properties(SDL2-static PROPERTIES OUTPUT_NAME "SDL2")
     # Note: Apparently, OUTPUT_NAME must really be unique; even when


### PR DESCRIPTION
I have had some success applying this change in my fork and would like to propose it for merge.

### Rationale

The current CMake setup in SDL already allows including SDL as a dependency of other CMake projects not only with `find_package()` but also using the [`FetchContent()`](https://cmake.org/cmake/help/latest/module/FetchContent.html) API and [`add_subdirectory()`](https://cmake.org/cmake/help/latest/command/add_subdirectory.html), both of which I understand are known as "sub projects" and are distinct from the `find_package()` method (which is used for finding _installed_ libraries).

With the current setup, there is a discrepancy between the targets SDL exports depending on what method is used to acquire SDL:
- `find_package()` exports targets in the `SDL2::` namespace such as `SDL2::SDL2`, `SDL2::SDL2-static`, etc...
- Sub-project methods export targets that are not namespaced (`SDL2`, `SDL2-static`, etc...)

This makes it difficult to interchange the two methods of inclusion, such as with third-party scripts like [CPM](https://github.com/cpm-cmake/CPM.cmake) which use either of `FetchContent()` or `find_package()` depending on availability, because a differently-named target must be linked to in either case.

### Changes

A simple solution to this issue which has been used by some other projects using CMake is to create an additional `ALIAS` target for each target exported by the project. These simply alias the plain target names to namespaced versions matching those that would be exported by CMake if the project was installed.

### Testing

I have applied these changes to all the exported targets I could find in SDL's CMake file and have tested this against multiple OSes and different methods of inclusion (`find_package()`, `FetchContent()`, `CPM`, git-submodule) in a separate repo (https://github.com/saxbophone/SDL-cmake-subproject-test/tree/master).

- CI build log demonstrating modified SDL importable by these different methods: https://github.com/saxbophone/SDL-cmake-subproject-test/actions/runs/563264808
- Counter-example build log showing why alias targets are necessary for uniform link interface: https://github.com/saxbophone/SDL-cmake-subproject-test/actions/runs/563286958

I haven't been able to test this with CMake 3.0, however ALIAS targets are available in that version too so I am confident this will not break dependents using that version.

This change is related to #2010 however I do not believe this change affects the problems mentioned in it, which I have not yet been able to reproduce.

> Further reading:
> - https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1#using-a-library-defined-in-the-same-cmake-tree-should-look-the-same-as-using-an-external-library
> - https://cliutils.gitlab.io/modern-cmake/chapters/install.html#add-subproject