### PR TITLE
Replace "echo -en" with "printf" in autoconf script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4597,6 +4597,6 @@ if test x$WARN_ABOUT_ARM_NEON_ASM_MIT = xyes; then
     SUMMARY="${SUMMARY}\n    --disable-arm-neon\n"
 fi
 
-AC_CONFIG_COMMANDS([summary], [echo -en "$SUMMARY"], [SUMMARY="$SUMMARY"])
+AC_CONFIG_COMMANDS([summary], [printf "$SUMMARY"], [SUMMARY="$SUMMARY"])
 
 AC_OUTPUT


### PR DESCRIPTION
## Description
The "-e" parameter to the echo utility is not recognised on some shells as it is non-standard. This PR replaces usage of "echo -en" with "printf" which is standardized.

Fixes summary output on FreeBSD.