### PR TITLE
KMSDRM: Center mouse cursor after creating window

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -1348,6 +1348,10 @@ KMSDRM_ReconfigureWindow( _THIS, SDL_Window * window) {
        so SDL pre-scales to that size for us. */
     SDL_SendWindowEvent(window, SDL_WINDOWEVENT_RESIZED,
                         windata->surface_w, windata->surface_h);
+    if (!is_vulkan)
+    {
+        SDL_WarpMouseGlobal(windata->surface_w / 2, windata->surface_h / 2);
+    }
 }
 
 int

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -1264,7 +1264,10 @@ KMSDRM_CreateWindow(_THIS, SDL_Window * window)
 
     /* If we have just created a Vulkan window, establish that we are in Vulkan mode now. */
     viddata->vulkan_mode = is_vulkan;
-
+    if (!is_vulkan)
+    {
+        SDL_WarpMouseGlobal(windata->surface_w / 2, windata->surface_h / 2);
+    }
     /* Focus on the newly created window */
     SDL_SetMouseFocus(window);
     SDL_SetKeyboardFocus(window);

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -1348,10 +1348,9 @@ KMSDRM_ReconfigureWindow( _THIS, SDL_Window * window) {
        so SDL pre-scales to that size for us. */
     SDL_SendWindowEvent(window, SDL_WINDOWEVENT_RESIZED,
                         windata->surface_w, windata->surface_h);
-    if (!is_vulkan)
-    {
-        SDL_WarpMouseGlobal(windata->surface_w / 2, windata->surface_h / 2);
-    }
+
+    SDL_WarpMouseGlobal(windata->surface_w / 2, windata->surface_h / 2);
+
 }
 
 int


### PR DESCRIPTION
Removes an odd oddity with the KMSDRM backend always setting the cursor at top-left when creating the window.