### PR TITLE
mac/iOS: allow Metal in windows created without an explicit backend

### DIFF
--- a/src/render/metal/SDL_render_metal.m
+++ b/src/render/metal/SDL_render_metal.m
@@ -1674,7 +1674,7 @@ METAL_CreateRenderer(SDL_Window * window, Uint32 flags)
     }
 
     window_flags = SDL_GetWindowFlags(window);
-    if (!(window_flags & (SDL_WINDOW_METAL|SDL_WINDOW_OPENGL))) {
+    if (!(window_flags & SDL_WINDOW_METAL)) {
         changed_window = SDL_TRUE;
         if (SDL_RecreateWindow(window, (window_flags & ~(SDL_WINDOW_VULKAN | SDL_WINDOW_OPENGL)) | SDL_WINDOW_METAL) < 0) {
             return NULL;

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1106,7 +1106,7 @@ SDLTest_CommonInit(SDLTest_CommonState * state)
 
             if (!state->skip_renderer
                 && (state->renderdriver
-                    || !(state->window_flags & (SDL_WINDOW_OPENGL | SDL_WINDOW_VULKAN)))) {
+                    || !(state->window_flags & (SDL_WINDOW_OPENGL | SDL_WINDOW_VULKAN | SDL_WINDOW_METAL)))) {
                 m = -1;
                 if (state->renderdriver) {
                     SDL_RendererInfo info;


### PR DESCRIPTION
As per https://github.com/libsdl-org/SDL/issues/3991#issuecomment-778849521 , SDL_Render is failing to choose the Metal backend when the window isn't explicitly created with `SDL_WINDOW_METAL`. I believe the most idiomatic fix is to make windows created without an explicit backend allow creation of metal views on macOS/iOS – SDL already behaves that way with OpenGL. This also avoids what was happening in the original bug report with the window getting destroyed and recreated.

This wasn't a problem until SDL 2.0.14, since SDL 2.0.12 had metal support without the `SDL_WINDOW_METAL` window flag (the flag only adds validation / error checking, it doesn't cause any sort of Metal view to be created on its own - `SDL_Metal_CreateView` is what does that).