### PR TITLE
Minor improvements for CPU detection on ARM

### DIFF
--- a/test/testplatform.c
+++ b/test/testplatform.c
@@ -381,6 +381,7 @@ TestCPUInfo(SDL_bool verbose)
         SDL_Log("AVX %s\n", SDL_HasAVX()? "detected" : "not detected");
         SDL_Log("AVX2 %s\n", SDL_HasAVX2()? "detected" : "not detected");
         SDL_Log("AVX-512F %s\n", SDL_HasAVX512F()? "detected" : "not detected");
+        SDL_Log("ARM SIMD %s\n", SDL_HasARMSIMD()? "detected" : "not detected");
         SDL_Log("NEON %s\n", SDL_HasNEON()? "detected" : "not detected");
         SDL_Log("System RAM %d MB\n", SDL_GetSystemRAM());
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR makes the following changes:
- `readProcAuxvForNeon` has been changed to use `Elf32_auxv_t`, the SIMD and SDL1 detection code. It is also only built on 32--bit ARM, since it was unused with AArch64.
- The non-ARM check is prioritized over the OpenBSD and `elf_aux_info` checks.
- SDL_HasARMSIMD is now tested in `testplatform`.

## Existing Issue(s)
Fixes #4095.
