### PR TITLE
Remove evdev SetRelativeMouseMode stub

### DIFF
--- a/src/core/linux/SDL_evdev.c
+++ b/src/core/linux/SDL_evdev.c
@@ -129,14 +129,6 @@ static Uint8 EVDEV_MouseButtons[] = {
     SDL_BUTTON_X2 + 3           /*  BTN_TASK        0x117 */
 };
 
-static int
-SDL_EVDEV_SetRelativeMouseMode(SDL_bool enabled)
-{
-    /* Mice already send relative events through this interface */
-    return 0;
-}
-
-
 int
 SDL_EVDEV_Init(void)
 {
@@ -169,9 +161,7 @@ SDL_EVDEV_Init(void)
 
         _this->kbd = SDL_EVDEV_kbd_init();
     }
-
-    SDL_GetMouse()->SetRelativeMouseMode = SDL_EVDEV_SetRelativeMouseMode;
-
+  
     _this->ref_count += 1;
 
     return 0;

--- a/src/video/vivante/SDL_vivantevideo.c
+++ b/src/video/vivante/SDL_vivantevideo.c
@@ -127,6 +127,12 @@ VideoBootStrap VIVANTE_bootstrap = {
 /*****************************************************************************/
 
 static int
+VIVANTE_SetRelativeMouseMode(SDL_bool enabled)
+{
+    return 0;
+}
+
+static int
 VIVANTE_AddVideoDisplays(_THIS)
 {
     SDL_VideoData *videodata = _this->driverdata;
@@ -221,6 +227,7 @@ VIVANTE_VideoInit(_THIS)
     if (SDL_EVDEV_Init() < 0) {
         return -1;
     }
+    SDL_GetMouse()->SetRelativeMouseMode = VIVANTE_SetRelativeMouseMode;
 #endif
 
     return 0;


### PR DESCRIPTION
## Description
This PR removes the evdev SetRelativeMouseMode stub.

## Existing Issue(s)
Fixes mouse being centered when SDL_SetRelativeMouseMode is called with the evdev input backend active, reverting to behaviour consistent with other video backends not utilizing the evdev input backend.
