### PR TITLE
pulseaudio: Initialize fragsize to fix mic recording

### DIFF
--- a/src/audio/pulseaudio/SDL_pulseaudio.c
+++ b/src/audio/pulseaudio/SDL_pulseaudio.c
@@ -600,6 +600,7 @@ PULSEAUDIO_OpenDevice(_THIS, void *handle, const char *devname, int iscapture)
 
     /* Reduced prebuffering compared to the defaults. */
 #ifdef PA_STREAM_ADJUST_LATENCY
+    paattr.fragsize = this->spec.size;
     /* 2x original requested bufsize */
     paattr.tlength = h->mixlen * 4;
     paattr.prebuf = -1;
@@ -608,6 +609,7 @@ PULSEAUDIO_OpenDevice(_THIS, void *handle, const char *devname, int iscapture)
     paattr.minreq = h->mixlen;
     flags = PA_STREAM_ADJUST_LATENCY;
 #else
+    paattr.fragsize = this->spec.size;
     paattr.tlength = h->mixlen*2;
     paattr.prebuf = h->mixlen*2;
     paattr.maxlength = h->mixlen*2;


### PR DESCRIPTION
## Description

PC config
* Debian Buster
* Pulseaudio enabled

I setup a recording with the following params :
```
SDL_AudioSpec want;

SDL_zero(want);
want.freq = 48000;
want.format = AUDIO_S16;
want.channels = 2;
want.samples = 960;
```

I expect to get a 3840 bytes buffer every 20 ms. Instead, sometimes I get a bulk of 3840 bytes buffer every ~2 seconds.

The behavior can change, depending of the platform. Sometime the first record works, and then the next one fails. Sometimes it never works.

## Modification description

fragsize wasn't initialized, and it is used for recording according to pulseaudio description.

If the value is 0 or -1, pulseaudio configures it itself (with a different strategy). But sometimes we can get a random (and large) value that makes pulseaudio give us large sample at a very low frequency.

## Refs

* https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/blob/v13.0/src/pulse/def.h#L453
* https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/blob/v13.0/src/pulsecore/protocol-native.c#L409

## Comments

Not sure if this is the correct fix, but according to pulseaudio doc, the field `fragsize` must be initialized. But when I initialize it, I have no more issue on my PC.
