### PR TITLE
Add SDL_GetAudioDeviceSpec

### DIFF
--- a/include/SDL_audio.h
+++ b/include/SDL_audio.h
@@ -359,6 +359,25 @@ extern DECLSPEC int SDLCALL SDL_GetNumAudioDevices(int iscapture);
 extern DECLSPEC const char *SDLCALL SDL_GetAudioDeviceName(int index,
                                                            int iscapture);
 
+/**
+ *  Get the audio format of a specific audio device.
+ *  Must be a value between 0 and (number of audio devices-1).
+ *  Only valid after a successfully initializing the audio subsystem.
+ *  The values returned by this function reflect the latest call to
+ *  SDL_GetNumAudioDevices(); recall that function to redetect available
+ *  hardware.
+ *
+ *  The spec will be filled with the sample rate, sample format, and channel
+ *  count. All other values in the structure are filled with 0. When the
+ *  supported struct members are 0, SDL was unable to get the property from the
+ *  backend.
+ *
+ *  \return 0 on success, nonzero on error
+ */
+extern DECLSPEC int SDLCALL SDL_GetAudioDeviceSpec(int index,
+                                                   int iscapture,
+                                                   SDL_AudioSpec *spec);
+
 
 /**
  *  Open a specific audio device. Passing in a device name of NULL requests

--- a/src/audio/SDL_audiodev.c
+++ b/src/audio/SDL_audiodev.c
@@ -59,7 +59,13 @@ test_device(const int iscapture, const char *fname, int flags, int (*test) (int 
                 static size_t dummyhandle = 0;
                 dummyhandle++;
                 SDL_assert(dummyhandle != 0);
-                SDL_AddAudioDevice(iscapture, fname, (void *) dummyhandle);
+
+                /* Note that spec is NULL; while we are opening the device
+                 * endpoint here, the endpoint does not provide any mix format
+                 * information,  making this information inaccessible at
+                 * enumeration time
+                 */
+                SDL_AddAudioDevice(iscapture, fname, NULL, (void *) dummyhandle);
             }
         }
     }

--- a/src/audio/SDL_sysaudio.h
+++ b/src/audio/SDL_sysaudio.h
@@ -39,7 +39,7 @@ typedef struct SDL_AudioDevice SDL_AudioDevice;
 /* Audio targets should call this as devices are added to the system (such as
    a USB headset being plugged in), and should also be called for
    for every device found during DetectDevices(). */
-extern void SDL_AddAudioDevice(const int iscapture, const char *name, void *handle);
+extern void SDL_AddAudioDevice(const int iscapture, const char *name, SDL_AudioSpec *spec, void *handle);
 
 /* Audio targets should call this as devices are removed, so SDL can update
    its list of available devices. */
@@ -99,6 +99,7 @@ typedef struct SDL_AudioDeviceItem
     void *handle;
     char *name;
     char *original_name;
+    SDL_AudioSpec spec;
     int dupenum;
     struct SDL_AudioDeviceItem *next;
 } SDL_AudioDeviceItem;

--- a/src/audio/alsa/SDL_alsa_audio.c
+++ b/src/audio/alsa/SDL_alsa_audio.c
@@ -765,7 +765,11 @@ add_device(const int iscapture, const char *name, void *hint, ALSA_Device **pSee
         return;
     }
 
-    SDL_AddAudioDevice(iscapture, desc, handle);
+    /* Note that spec is NULL, because we are required to open the device before
+     * acquiring the mix format, making this information inaccessible at
+     * enumeration time
+     */
+    SDL_AddAudioDevice(iscapture, desc, NULL, handle);
     if (hint)
         free(desc);
     dev->name = handle;

--- a/src/audio/directsound/SDL_directsound.c
+++ b/src/audio/directsound/SDL_directsound.c
@@ -163,7 +163,12 @@ FindAllDevs(LPGUID guid, LPCWSTR desc, LPCWSTR module, LPVOID data)
         if (str != NULL) {
             LPGUID cpyguid = (LPGUID) SDL_malloc(sizeof (GUID));
             SDL_memcpy(cpyguid, guid, sizeof (GUID));
-            SDL_AddAudioDevice(iscapture, str, cpyguid);
+
+            /* Note that spec is NULL, because we are required to connect to the
+             * device before getting the channel mask and output format, making
+             * this information inaccessible at enumeration time
+             */
+            SDL_AddAudioDevice(iscapture, str, NULL, cpyguid);
             SDL_free(str);  /* addfn() makes a copy of this string. */
         }
     }

--- a/src/audio/disk/SDL_diskaudio.c
+++ b/src/audio/disk/SDL_diskaudio.c
@@ -173,8 +173,8 @@ DISKAUDIO_OpenDevice(_THIS, void *handle, const char *devname, int iscapture)
 static void
 DISKAUDIO_DetectDevices(void)
 {
-    SDL_AddAudioDevice(SDL_FALSE, DEFAULT_OUTPUT_DEVNAME, (void *) 0x1);
-    SDL_AddAudioDevice(SDL_TRUE, DEFAULT_INPUT_DEVNAME, (void *) 0x2);
+    SDL_AddAudioDevice(SDL_FALSE, DEFAULT_OUTPUT_DEVNAME, NULL, (void *) 0x1);
+    SDL_AddAudioDevice(SDL_TRUE, DEFAULT_INPUT_DEVNAME, NULL, (void *) 0x2);
 }
 
 static int

--- a/src/audio/os2/SDL_os2audio.c
+++ b/src/audio/os2/SDL_os2audio.c
@@ -160,9 +160,9 @@ static void OS2_DetectDevices(void)
         }
 
         ulHandle++;
-        SDL_AddAudioDevice(0, stLogDevice.szProductInfo, (void *)(ulHandle));
+        SDL_AddAudioDevice(0, stLogDevice.szProductInfo, NULL, (void *)(ulHandle));
         ulHandle++;
-        SDL_AddAudioDevice(1, stLogDevice.szProductInfo, (void *)(ulHandle));
+        SDL_AddAudioDevice(1, stLogDevice.szProductInfo, NULL, (void *)(ulHandle));
     }
 }
 

--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -262,7 +262,7 @@ io_list_check_add(struct io_node *node)
     spa_list_append(&hotplug_io_list, &node->link);
 
     if (SDL_AtomicGet(&hotplug_events_enabled)) {
-        SDL_AddAudioDevice(node->is_capture, node->name, PW_ID_TO_HANDLE(node->id));
+        SDL_AddAudioDevice(node->is_capture, node->name, &node->spec, PW_ID_TO_HANDLE(node->id));
     }
 
 dup_found:
@@ -765,7 +765,7 @@ PIPEWIRE_DetectDevices()
     io_list_sort();
 
     spa_list_for_each (io, &hotplug_io_list, link) {
-        SDL_AddAudioDevice(io->is_capture, io->name, PW_ID_TO_HANDLE(io->id));
+        SDL_AddAudioDevice(io->is_capture, io->name, &io->spec, PW_ID_TO_HANDLE(io->id));
     }
 
     SDL_AtomicSet(&hotplug_events_enabled, 1);

--- a/src/audio/qsa/SDL_qsa_audio.c
+++ b/src/audio/qsa/SDL_qsa_audio.c
@@ -528,7 +528,11 @@ QSA_DetectDevices(void)
                             devices;
                         status = snd_pcm_close(handle);
                         if (status == EOK) {
-                            SDL_AddAudioDevice(SDL_FALSE, qsa_playback_device[qsa_playback_devices].name, &qsa_playback_device[qsa_playback_devices]);
+                            /* Note that spec is NULL, because we are required to open the device before
+                             * acquiring the mix format, making this information inaccessible at
+                             * enumeration time
+                             */
+                            SDL_AddAudioDevice(SDL_FALSE, qsa_playback_device[qsa_playback_devices].name, NULL, &qsa_playback_device[qsa_playback_devices]);
                             qsa_playback_devices++;
                         }
                     } else {
@@ -586,7 +590,11 @@ QSA_DetectDevices(void)
                             devices;
                         status = snd_pcm_close(handle);
                         if (status == EOK) {
-                            SDL_AddAudioDevice(SDL_TRUE, qsa_capture_device[qsa_capture_devices].name, &qsa_capture_device[qsa_capture_devices]);
+                            /* Note that spec is NULL, because we are required to open the device before
+                             * acquiring the mix format, making this information inaccessible at
+                             * enumeration time
+                             */
+                            SDL_AddAudioDevice(SDL_TRUE, qsa_capture_device[qsa_capture_devices].name, NULL, &qsa_capture_device[qsa_capture_devices]);
                             qsa_capture_devices++;
                         }
                     } else {

--- a/src/audio/wasapi/SDL_wasapi.h
+++ b/src/audio/wasapi/SDL_wasapi.h
@@ -63,7 +63,7 @@ extern SDL_atomic_t WASAPI_DefaultCaptureGeneration;
 int WASAPI_PrepDevice(_THIS, const SDL_bool updatestream);
 void WASAPI_RefDevice(_THIS);
 void WASAPI_UnrefDevice(_THIS);
-void WASAPI_AddDevice(const SDL_bool iscapture, const char *devname, LPCWSTR devid);
+void WASAPI_AddDevice(const SDL_bool iscapture, const char *devname, WAVEFORMATEXTENSIBLE *fmt, LPCWSTR devid);
 void WASAPI_RemoveDevice(const SDL_bool iscapture, LPCWSTR devid);
 
 /* These are functions that are implemented differently for Windows vs WinRT. */

--- a/src/audio/wasapi/SDL_wasapi_win32.c
+++ b/src/audio/wasapi/SDL_wasapi_win32.c
@@ -65,26 +65,31 @@ static const IID SDL_IID_IMMNotificationClient = { 0x7991eec9, 0x7e89, 0x4d85,{ 
 static const IID SDL_IID_IMMEndpoint = { 0x1be09788, 0x6894, 0x4089,{ 0x85, 0x86, 0x9a, 0x2a, 0x6c, 0x26, 0x5a, 0xc5 } };
 static const IID SDL_IID_IAudioClient = { 0x1cb9ad4c, 0xdbfa, 0x4c32,{ 0xb1, 0x78, 0xc2, 0xf5, 0x68, 0xa7, 0x03, 0xb2 } };
 static const PROPERTYKEY SDL_PKEY_Device_FriendlyName = { { 0xa45c254e, 0xdf1c, 0x4efd,{ 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0, } }, 14 };
+static const PROPERTYKEY SDL_PKEY_AudioEngine_DeviceFormat = { { 0xf19f064d, 0x82c, 0x4e27,{ 0xbc, 0x73, 0x68, 0x82, 0xa1, 0xbb, 0x8e, 0x4c, } }, 0 };
 
 
-static char *
-GetWasapiDeviceName(IMMDevice *device)
+static void
+GetWasapiDeviceInfo(IMMDevice *device, char **utf8dev, WAVEFORMATEXTENSIBLE *fmt)
 {
     /* PKEY_Device_FriendlyName gives you "Speakers (SoundBlaster Pro)" which drives me nuts. I'd rather it be
        "SoundBlaster Pro (Speakers)" but I guess that's developers vs users. Windows uses the FriendlyName in
        its own UIs, like Volume Control, etc. */
-    char *utf8dev = NULL;
     IPropertyStore *props = NULL;
+    *utf8dev = NULL;
+    SDL_zerop(fmt);
     if (SUCCEEDED(IMMDevice_OpenPropertyStore(device, STGM_READ, &props))) {
         PROPVARIANT var;
         PropVariantInit(&var);
         if (SUCCEEDED(IPropertyStore_GetValue(props, &SDL_PKEY_Device_FriendlyName, &var))) {
-            utf8dev = WIN_StringToUTF8W(var.pwszVal);
+            *utf8dev = WIN_StringToUTF8W(var.pwszVal);
+        }
+        PropVariantClear(&var);
+        if (SUCCEEDED(IPropertyStore_GetValue(props, &SDL_PKEY_AudioEngine_DeviceFormat, &var))) {
+            SDL_memcpy(fmt, var.blob.pBlobData, SDL_min(var.blob.cbSize, sizeof(WAVEFORMATEXTENSIBLE)));
         }
         PropVariantClear(&var);
         IPropertyStore_Release(props);
     }
-    return utf8dev;
 }
 
 
@@ -194,9 +199,11 @@ SDLMMNotificationClient_OnDeviceStateChanged(IMMNotificationClient *ithis, LPCWS
             if (SUCCEEDED(IMMEndpoint_GetDataFlow(endpoint, &flow))) {
                 const SDL_bool iscapture = (flow == eCapture);
                 if (dwNewState == DEVICE_STATE_ACTIVE) {
-                    char *utf8dev = GetWasapiDeviceName(device);
+                    char *utf8dev;
+                    WAVEFORMATEXTENSIBLE fmt;
+                    GetWasapiDeviceInfo(device, &utf8dev, &fmt);
                     if (utf8dev) {
-                        WASAPI_AddDevice(iscapture, utf8dev, pwstrDeviceId);
+                        WASAPI_AddDevice(iscapture, utf8dev, &fmt, pwstrDeviceId);
                         SDL_free(utf8dev);
                     }
                 } else {
@@ -352,6 +359,7 @@ typedef struct
 {
     LPWSTR devid;
     char *devname;
+    WAVEFORMATEXTENSIBLE fmt;
 } EndpointItem;
 
 static int sort_endpoints(const void *_a, const void *_b)
@@ -408,7 +416,7 @@ WASAPI_EnumerateEndpointsForFlow(const SDL_bool iscapture)
         IMMDevice *device = NULL;
         if (SUCCEEDED(IMMDeviceCollection_Item(collection, i, &device))) {
             if (SUCCEEDED(IMMDevice_GetId(device, &item->devid))) {
-                item->devname = GetWasapiDeviceName(device);
+                GetWasapiDeviceInfo(device, &item->devname, &item->fmt);
             }
             IMMDevice_Release(device);
         }
@@ -421,7 +429,7 @@ WASAPI_EnumerateEndpointsForFlow(const SDL_bool iscapture)
     for (i = 0; i < total; i++) {
         EndpointItem *item = items + i;
         if ((item->devid) && (item->devname)) {
-            WASAPI_AddDevice(iscapture, item->devname, item->devid);
+            WASAPI_AddDevice(iscapture, item->devname, &item->fmt, item->devid);
         }
         SDL_free(item->devname);
         CoTaskMemFree(item->devid);

--- a/src/audio/wasapi/SDL_wasapi_winrt.cpp
+++ b/src/audio/wasapi/SDL_wasapi_winrt.cpp
@@ -32,6 +32,7 @@
 #include <windows.devices.enumeration.h>
 #include <windows.media.devices.h>
 #include <wrl/implements.h>
+#include <collection.h>
 
 extern "C" {
 #include "../../core/windows/SDL_windows.h"
@@ -51,6 +52,8 @@ using namespace Windows::Devices::Enumeration;
 using namespace Windows::Media::Devices;
 using namespace Windows::Foundation;
 using namespace Microsoft::WRL;
+
+static Platform::String^ SDL_PKEY_AudioEngine_DeviceFormat = L"{f19f064d-082c-4e27-bc73-6882a1bb8e4c} 0";
 
 class SDL_WasapiDeviceEventHandler
 {
@@ -78,9 +81,16 @@ private:
 SDL_WasapiDeviceEventHandler::SDL_WasapiDeviceEventHandler(const SDL_bool _iscapture)
     : iscapture(_iscapture)
     , completed(SDL_CreateSemaphore(0))
-    , watcher(DeviceInformation::CreateWatcher(_iscapture ? DeviceClass::AudioCapture : DeviceClass::AudioRender))
 {
-    if (!watcher || !completed)
+    if (!completed)
+        return;  // uhoh.
+
+    Platform::String^ selector = _iscapture ? MediaDevice::GetAudioCaptureSelector() :
+                                              MediaDevice::GetAudioRenderSelector();
+    Platform::Collections::Vector<Platform::String^> properties;
+    properties.Append(SDL_PKEY_AudioEngine_DeviceFormat);
+    watcher = DeviceInformation::CreateWatcher(selector, properties.GetView());
+    if (!watcher)
         return;  // uhoh.
 
     // !!! FIXME: this doesn't need a lambda here, I think, if I make SDL_WasapiDeviceEventHandler a proper C++/CX class. --ryan.
@@ -124,7 +134,18 @@ SDL_WasapiDeviceEventHandler::OnDeviceAdded(DeviceWatcher^ sender, DeviceInforma
     SDL_assert(sender == this->watcher);
     char *utf8dev = WIN_StringToUTF8(info->Name->Data());
     if (utf8dev) {
-        WASAPI_AddDevice(this->iscapture, utf8dev, info->Id->Data());
+        WAVEFORMATEXTENSIBLE fmt;
+        Platform::Object^ obj = info->Properties->Lookup(SDL_PKEY_AudioEngine_DeviceFormat);
+        if (obj) {
+            IPropertyValue^ property = (IPropertyValue^) obj;
+            Platform::Array<unsigned char>^ data;
+            property->GetUInt8Array(&data);
+            SDL_memcpy(&fmt, data->Data, SDL_min(data->Length, sizeof(WAVEFORMATEXTENSIBLE)));
+        } else {
+            SDL_zero(fmt);
+        }
+
+        WASAPI_AddDevice(this->iscapture, utf8dev, &fmt, info->Id->Data());
         SDL_free(utf8dev);
     }
 }

--- a/src/audio/winmm/SDL_winmm.c
+++ b/src/audio/winmm/SDL_winmm.c
@@ -75,12 +75,19 @@ static void DetectWave##typ##Devs(void) { \
     const UINT iscapture = iscap ? 1 : 0; \
     const UINT devcount = wave##typ##GetNumDevs(); \
     capstyp##2W caps; \
+    SDL_AudioSpec spec; \
     UINT i; \
+    SDL_zero(spec); \
     for (i = 0; i < devcount; i++) { \
         if (wave##typ##GetDevCaps(i,(LP##capstyp##W)&caps,sizeof(caps))==MMSYSERR_NOERROR) { \
             char *name = WIN_LookupAudioDeviceName(caps.szPname,&caps.NameGuid); \
             if (name != NULL) { \
-                SDL_AddAudioDevice((int) iscapture, name, (void *) ((size_t) i+1)); \
+                /* Note that freq/format are not filled in, as this information \
+                 * is not provided by the caps struct! At best, we get possible \
+                 * sample formats, but not an _active_ format. \
+                 */ \
+                spec.channels = caps.wChannels; \
+                SDL_AddAudioDevice((int) iscapture, name, &spec, (void *) ((size_t) i+1)); \
                 SDL_free(name); \
             } \
         } \

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -808,3 +808,4 @@
 #define SDL_isprint SDL_isprint_REAL
 #define SDL_isgraph SDL_isgraph_REAL
 #define SDL_AndroidShowToast SDL_AndroidShowToast_REAL
+#define SDL_GetAudioDeviceSpec SDL_GetAudioDeviceSpec_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -873,3 +873,4 @@ SDL_DYNAPI_PROC(int,SDL_isgraph,(int a),(a),return)
 #ifdef __ANDROID__
 SDL_DYNAPI_PROC(int,SDL_AndroidShowToast,(const char *a, int b, int c, int d, int e),(a,b,c,d,e),return)
 #endif
+SDL_DYNAPI_PROC(int,SDL_GetAudioDeviceSpec,(int a, int b, SDL_AudioSpec *c),(a,b,c),return)


### PR DESCRIPTION
This is a Git version of the patch found in #2911.

Life-or-Death Backends:
- [x] Pipewire
- [x] PulseAudio
- [x] CoreAudio
- [x] WASAPI
    - [x] Win32
    - [x] WinRT
- [x] Disk (no defaults available, just return 0s)

Pretty Important Backends:
- [x] ALSA
- [x] DirectSound
- [x] WinMM

Bonus Points:
- [x] OS/2
- [x] QSA
- [x] SDL_audiodev.c