### PR TITLE
Fix URL Event Handler on MacOS

### DIFF
--- a/src/video/cocoa/SDL_cocoaevents.m
+++ b/src/video/cocoa/SDL_cocoaevents.m
@@ -145,6 +145,12 @@ static void Cocoa_DispatchEvent(NSEvent *theEvent)
                    selector:@selector(localeDidChange:)
                        name:NSCurrentLocaleDidChangeNotification
                      object:nil];
+
+        [[NSAppleEventManager sharedAppleEventManager]
+            setEventHandler:self
+                andSelector:@selector(handleURLEvent:withReplyEvent:)
+            forEventClass:kInternetEventClass
+                andEventID:kAEGetURL];
     }
 
     return self;
@@ -261,12 +267,6 @@ static void Cocoa_DispatchEvent(NSEvent *theEvent)
         SDL_Delay(300);  /* !!! FIXME: this isn't right. */
         [NSApp activateIgnoringOtherApps:YES];
     }
-
-    [[NSAppleEventManager sharedAppleEventManager]
-    setEventHandler:self
-        andSelector:@selector(handleURLEvent:withReplyEvent:)
-      forEventClass:kInternetEventClass
-         andEventID:kAEGetURL];
 
     /* If we call this before NSApp activation, macOS might print a complaint
      * about ApplePersistenceIgnoreState. */


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
On MacOS, if an application is not already running and it is opened via a custom URL/Protocol, the SDL_DROPFILE event is not invoked as expected.

If the application is already running, SDL_DROPFILE is invoked as expected. 

The solution is to set the event handler earlier on, I've moved it to init.