### PR TITLE
Fix build when inotify not available (broken by inotify/HIDAPI changes)

### DIFF
--- a/src/joystick/hidapi/SDL_hidapijoystick.c
+++ b/src/joystick/hidapi/SDL_hidapijoystick.c
@@ -57,8 +57,8 @@
 #include <fcntl.h>
 #include <limits.h>             /* For the definition of NAME_MAX */
 #include <sys/inotify.h>
-#include <unistd.h>
 #endif
+#include <unistd.h>
 #endif
 
 typedef enum


### PR DESCRIPTION
The recent inotify/HIDAPI pull request (#4098) broke building when inotify is not available, as <unistd.h> is not included properly.

This is a pretty niche case (I can't imagine there being any systems without inotify), but it does cause a compile error due to missing definitions of acces(), close(), and F_OK:
```
…/SDL/src/joystick/hidapi/SDL_hidapijoystick.c: In function 'HIDAPI_JoystickInit':
…/SDL/src/joystick/hidapi/SDL_hidapijoystick.c:743:20: warning: implicit declaration of function 'access' [-Wimplicit-function-declaration]
  743 |         } else if (access("/.flatpak-info", F_OK) == 0
      |                    ^~~~~~
…/SDL/src/joystick/hidapi/SDL_hidapijoystick.c:743:45: error: 'F_OK' undeclared (first use in this function)
  743 |         } else if (access("/.flatpak-info", F_OK) == 0
      |                                             ^~~~
…/SDL/src/joystick/hidapi/SDL_hidapijoystick.c:743:45: note: each undeclared identifier is reported only once for each function it appears in
…/SDL/src/joystick/hidapi/SDL_hidapijoystick.c: In function 'HIDAPI_JoystickQuit':
…/SDL/src/joystick/hidapi/SDL_hidapijoystick.c:1415:9: warning: implicit declaration of function 'close'; did you mean 'pclose'? [-Wimplicit-function-declaration]
 1415 |         close(inotify_fd);
      |         ^~~~~
      |         pclose
```

This change simply moves the `#include <unistd.h>` line down until it's outside the `#ifdef HAVE_INOTIFY`. Of course, it could equally be moved elsewhere, or the code in question also wrapped in `#ifdef HAVE_INOTIFY` if that makes more sense.