### PR TITLE
CI: added github actions for build and for publishing the docs

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -2,7 +2,7 @@ name: GitHub Pages
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,18 @@
+name: GitHub Pages
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v1
+
+      - name: Deploy docs
+        uses: mhausenblas/mkdocs-deploy-gh-pages@1.14
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,46 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+    mac:
+        runs-on: macos-latest
+        steps:
+        - uses: actions/checkout@v1
+
+        - name: Build
+          run: |
+            mkdir build
+            cd build
+            cmake ..
+            cmake --build .
+
+    linux:
+        runs-on: ubuntu-20.04
+        steps:
+        - uses: actions/checkout@v1
+
+        - name: Setup
+          run: |
+            sudo apt-get update
+            sudo apt-get install wayland-protocols pkg-config ninja-build
+
+        - name: Linux
+          run: |
+            mkdir build
+            cd build
+            cmake .. -GNinja
+            cmake --build .
+
+    windows:
+        runs-on: windows-latest
+
+        steps:
+        - uses: actions/checkout@v1
+
+        - name: Build
+          run: |
+            mkdir build
+            cd build
+            cmake ..
+            cmake --build .

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: SDL
+site_author: Sam Lantinga slouken@libsdl.org
 site_description: Simple Direct Media Layer
 docs_dir: docs
 site_dir: build/docs
@@ -15,29 +16,30 @@ markdown_extensions:
       toc_depth: 2
 
 nav:
-  - README.md
-  - README-android.md
-  - README-cmake.md
-  - README-directfb.md
-  - README-dynapi.md
-  - README-emscripten.md
-  - README-gesture.md
-  - README-git.md
-  - README-hg.md
-  - README-ios.md
-  - README-kmsbsd.md
-  - README-linux.md
-  - README-macosx.md
-  - README.md
-  - README-nacl.md
-  - README-os2.md
-  - README-pandora.md
-  - README-platforms.md
-  - README-porting.md
-  - README-psp.md
-  - README-raspberrypi.md
-  - README-touch.md
-  - README-visualc.md
-  - README-wince.md
-  - README-windows.md
-  - README-winrt.md
+  - Home: README.md
+  - General:
+    - CMake: README-cmake.md
+    - Git: README-git.md
+    - HG: README-hg.md
+    - VisualC: README-visualc.md
+    - KMSDRN: README-kmsbsd.md
+    - Porting: README-porting.md
+    - DirectFB: README-directfb.md
+    - DynAPI: README-dynapi.md
+    - Gestures: README-gesture.md
+    - Touch: README-touch.md
+  - Platform:
+    - Overview: README-platforms.md
+    - Android: README-android.md
+    - Empscripten: README-emscripten.md
+    - Linux: README-linux.md
+    - OS X: README-macosx.md
+    - iOS: README-ios.md
+    - NativeClient: README-nacl.md
+    - OS2: README-os2.md
+    - Pandora: README-pandora.md
+    - PSP: README-psp.md
+    - Raspberry Pi: README-raspberrypi.md
+    - WinCE: README-wince.md
+    - Windows: README-windows.md
+    - WinRT: README-winrt.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,43 @@
+site_name: SDL
+site_description: Simple Direct Media Layer
+docs_dir: docs
+site_dir: build/docs
+repo_url: https://github.com/libsdl-org/SDL
+repo_name: GitHub
+
+theme:
+  name: readthedocs
+  highlightjs: true
+  hljs_languages: [c]
+
+markdown_extensions:
+  - toc:
+      toc_depth: 2
+
+nav:
+  - README.md
+  - README-android.md
+  - README-cmake.md
+  - README-directfb.md
+  - README-dynapi.md
+  - README-emscripten.md
+  - README-gesture.md
+  - README-git.md
+  - README-hg.md
+  - README-ios.md
+  - README-kmsbsd.md
+  - README-linux.md
+  - README-macosx.md
+  - README.md
+  - README-nacl.md
+  - README-os2.md
+  - README-pandora.md
+  - README-platforms.md
+  - README-porting.md
+  - README-psp.md
+  - README-raspberrypi.md
+  - README-touch.md
+  - README-visualc.md
+  - README-wince.md
+  - README-windows.md
+  - README-winrt.md


### PR DESCRIPTION
Added github actions for building sdl for the three major systems (linux, windows and osx)

the build currently fails for windows. There is some unresolved symbol - it already works for linux and macosx.
```
  SDL_xinputhaptic.c
  Generating Code...
     Creating library D:/a/SDL/SDL/build/Debug/SDL2d.lib and object D:/a/SDL/SDL/build/Debug/SDL2d.exp
SDL_hidapijoystick.obj : error LNK2019: unresolved external symbol close referenced in function HIDAPI_IsEquivalentToDevice [D:\a\SDL\SDL\build\SDL2.vcxproj]
D:\a\SDL\SDL\build\Debug\SDL2d.dll : fatal error LNK1120: 1 unresolved externals [D:\a\SDL\SDL\build\SDL2.vcxproj]
  Building Custom Rule D:/a/SDL/SDL/CMakeLists.txt
  SDL.c
```

I'm using cmake for the build at the moment. If there is interest in e.g. configure && make let me know.

Also included is a build job to publish the markdown from docs/ to github pages. See the following screenshot. I would also opt-in to cleanup the markdown... just let me know if this is desired. This is just published for the `main` branch. Should be available on https://libsdl-org.github.io/sdl/

![Bildschirmfoto von 2021-02-21 14-16-55](https://user-images.githubusercontent.com/577713/108626253-7dfe7a80-744f-11eb-9c1f-77b992c08b29.png)
