### PR TITLE
[KMSDRM] Free some memory I had forgotten on Vulkan surface creation.

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmvulkan.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvulkan.c
@@ -438,6 +438,8 @@ SDL_bool KMSDRM_Vulkan_CreateSurface(_THIS,
 clean:
     if (physical_devices)
         SDL_free (physical_devices);
+    if (device_props)
+        SDL_free (device_props);
     if (displays_props)
         SDL_free (displays_props);
     if (planes_props)


### PR DESCRIPTION
## Description
Simply add a missing SDL_free() call to free the physical device struct memory that is allocated in that function.