### PR TITLE
netbsdaudio: Handle ioctls failing

### DIFF
--- a/src/audio/netbsd/SDL_netbsdaudio.c
+++ b/src/audio/netbsd/SDL_netbsdaudio.c
@@ -295,9 +295,13 @@ NETBSDAUDIO_OpenDevice(_THIS, void *handle, const char *devname, int iscapture)
 
     info.hiwat = 5;
     info.lowat = 3;
-    (void) ioctl(this->hidden->audio_fd, AUDIO_SETINFO, &info);
+    if (ioctl(this->hidden->audio_fd, AUDIO_SETINFO, &info) < 0) {
+        return SDL_SetError("AUDIO_SETINFO failed for %s: %s", devname, strerror(errno));
+    }
 
-    (void) ioctl(this->hidden->audio_fd, AUDIO_GETINFO, &info);
+    if (ioctl(this->hidden->audio_fd, AUDIO_GETINFO, &info) < 0) {
+        return SDL_SetError("AUDIO_GETINFO failed for %s: %s", devname, strerror(errno));
+    }
 
     /* Final spec used for the device. */
     this->spec.format = format;


### PR DESCRIPTION
A user reported that the mpv video player hangs after attempting to set an unsupported number of channels with the SDL audio output, because it thinks it's successfully opened the device. This makes the failure graceful.

I also wonder whether we should force the format to stereo if this fails - does SDL handle that gracefully?