### PR TITLE
SDL_cpuinfo.h: Fix compiling for ARM architectures with MinGW.

### DIFF
--- a/include/SDL_cpuinfo.h
+++ b/include/SDL_cpuinfo.h
@@ -56,7 +56,14 @@
 #endif
 #endif /* __clang__ */
 #elif defined(__MINGW64_VERSION_MAJOR)
-#include <intrin.h>
+#    if defined(__i386__) || defined(__x86_64__)
+#        include <intrin.h>
+#    elif defined(__arm__) || defined(__aarch64__)
+#        include <arm_neon.h>
+#        define __ARM_NEON 1
+#    else
+#        error "Target CPU architecture is not supported."
+#    endif
 #else
 /* altivec.h redefining bool causes a number of problems, see bugs 3993 and 4392, so you need to explicitly define SDL_ENABLE_ALTIVEC_H to have it included. */
 #if defined(HAVE_ALTIVEC_H) && defined(__ALTIVEC__) && !defined(__APPLE_ALTIVEC__) && defined(SDL_ENABLE_ALTIVEC_H)

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -26,6 +26,9 @@
 
 #if defined(__WIN32__) || defined(__WINRT__)
 #include "../core/windows/SDL_windows.h"
+#    ifdef __MINGW32__
+#        include <_mingw.h>
+#    endif
 #endif
 #if defined(__OS2__)
 #undef HAVE_SYSCTLBYNAME


### PR DESCRIPTION
* Include arm_neon.h for arm and aarch64 architectures.
* Define __ARM_NEON for them also.
