### PR TITLE
Include arm_neon.h in mingw targeting ARM Windows.

### DIFF
--- a/include/SDL_cpuinfo.h
+++ b/include/SDL_cpuinfo.h
@@ -57,6 +57,9 @@
 #endif /* __clang__ */
 #elif defined(__MINGW64_VERSION_MAJOR)
 #include <intrin.h>
+#if !defined(SDL_DISABLE_ARM_NEON_H) && defined(__ARM_NEON)
+#  include <arm_neon.h>
+#endif
 #else
 /* altivec.h redefining bool causes a number of problems, see bugs 3993 and 4392, so you need to explicitly define SDL_ENABLE_ALTIVEC_H to have it included. */
 #if defined(HAVE_ALTIVEC_H) && defined(__ALTIVEC__) && !defined(__APPLE_ALTIVEC__) && defined(SDL_ENABLE_ALTIVEC_H)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The llvm-mingw project includes cross-compilers targeting ARM: https://github.com/mstorsjo/llvm-mingw/releases

Currently, compilation fails with this configuration, because neon features are used as long as __ARM_NEON is defined, but arm_neon.h was not included. It's normally included by SDL_cpuinfo.h, so it seems appropriate to add it there.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
