### PR TITLE
Make full OpenGL work with the KMSDRM backend, using GLVND instead of X11-bound GLX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2387,7 +2387,7 @@ CheckOpenGLX11()
 dnl Find KMSDRM OpenGL (GLVND, NOT GLX and it's huge dependencies.)
 CheckOpenGLKMSDRM()
 {
-    if test x$enable_video = xyes -a x$enable_video_opengl = xyes; then 
+    if test x$enable_video = xyes -a x$enable_video_opengl = xyes -a x$enable_video_kmsdrm = xyes; then
         AC_MSG_CHECKING(for OpenGL (GLVND) support)
         video_opengl=no
         AC_TRY_COMPILE([

--- a/configure.ac
+++ b/configure.ac
@@ -2384,6 +2384,28 @@ CheckOpenGLX11()
     fi
 }
 
+dnl Find KMSDRM OpenGL (GLVND, NOT GLX and it's huge dependencies.)
+CheckOpenGLKMSDRM()
+{
+    if test x$enable_video = xyes -a x$enable_video_opengl = xyes; then 
+        AC_MSG_CHECKING(for OpenGL (GLVND) support)
+        video_opengl=no
+        AC_TRY_COMPILE([
+         #include <GL/gl.h>
+        ],[  
+        ],[  
+        video_opengl=yes
+        ])   
+        AC_MSG_RESULT($video_opengl)
+        if test x$video_opengl = xyes; then 
+            AC_DEFINE(SDL_VIDEO_OPENGL, 1, [ ]) 
+            AC_DEFINE(SDL_VIDEO_OPENGL_GLVND, 1, [ ]) 
+            AC_DEFINE(SDL_VIDEO_RENDER_OGL, 1, [ ]) 
+            SUMMARY_video="${SUMMARY_video} opengl"
+        fi   
+    fi   
+}
+
 dnl Check to see if OpenGL ES support is desired
 AC_ARG_ENABLE(video-opengles,
 [AS_HELP_STRING([--enable-video-opengles], [include OpenGL ES support [default=yes]])],
@@ -3656,6 +3678,7 @@ case "$host" in
         # Need to check for EGL first because KMSDRM depends on it.
         CheckEGLKMSDRM
         CheckKMSDRM
+        CheckOpenGLKMSDRM
         CheckOpenGLX11
         CheckOpenGLESX11
         CheckVulkan

--- a/src/video/SDL_egl.c
+++ b/src/video/SDL_egl.c
@@ -79,6 +79,15 @@
 #define DEFAULT_OGL_ES_PVR "libGLES_CM.so"
 #define DEFAULT_OGL_ES "libGLESv1_CM.so"
 
+#elif SDL_VIDEO_DRIVER_KMSDRM
+/* Non-desktop Linux must NOT depend on X11/GLX for FULL OpenGL,
+   it must use GLVND instead so it's libOpenGL.so instead of libGL.so. */
+#define DEFAULT_OGL "libOpenGL.so"
+#define DEFAULT_EGL "libEGL.so"
+#define DEFAULT_OGL_ES2 "libGLESv2.so"
+#define DEFAULT_OGL_ES_PVR "libGLES_CM.so"
+#define DEFAULT_OGL_ES "libGLESv1_CM.so"
+
 #else
 /* Desktop Linux */
 #define DEFAULT_OGL "libGL.so.1"


### PR DESCRIPTION
The KMSDRM backend should not depend on X11 libraries, yet it should have full OpenGL support (aside from OpenGL_ES and Vulkan).

Traditionally, full (fixed) OpenGL on GNU/Linux depends on X11, but that does not make sense in an X-less enviroment like KMSDRM.
So what this PR does is to get full OpenGL working with the KMSDRM backend without depending on X11 or X11 libraries.
And for that, instead of GLX, which is the X11-bound full OpenGL implementation, this PR teaches SDL2 to use libglvnd when KMSDRM+Full OpenGL are enabled. 

## Description
-Added the CheckOpenGLKMSDR method in configure.ac, so we can check for GL.h (provided by libglvnd) when KMSDRM + Full OpenGL are enabled.
-Added definitions for the specific library names in src/video/SDL_egl.c. This is needed because, if we build MESA with libglvnd support, OpenGL dll is not called libGL.so but libOpenGL.so
These definitions only affect KMSDRM, of course.