### PR TITLE
Commenting a false alarm in WIN_GLES_SetupWindow.

### DIFF
--- a/src/video/windows/SDL_windowsopengles.c
+++ b/src/video/windows/SDL_windowsopengles.c
@@ -108,7 +108,9 @@ WIN_GLES_SetupWindow(_THIS, SDL_Window * window)
     SDL_GLContext current_ctx = SDL_GL_GetCurrentContext();
 
     if (_this->egl_data == NULL) {
-        SDL_assert(!_this->gl_config.driver_loaded);
+        // When hint SDL_HINT_OPENGL_ES_DRIVER is set to "1" (e.g. for ANGLE support),
+        // _this->gl_config.driver_loaded can be 0, while the below lines function.
+        // SDL_assert(!_this->gl_config.driver_loaded);
         if (SDL_EGL_LoadLibrary(_this, NULL, EGL_DEFAULT_DISPLAY, 0) < 0) {
             SDL_EGL_UnloadLibrary(_this);
             return -1;


### PR DESCRIPTION
## Description
When hint SDL_HINT_OPENGL_ES_DRIVER is set to "1" (e.g. for ANGLE support), assertion due to !_this->gl_config.driver_loaded can be causes while EGL is available. So, commenting SDL_assert(!_this->gl_config.driver_loaded).

## Existing Issue(s)
#4177