### PR TITLE
Set ALT_OGL to libOpenGL.so.0 instead of libOpenGL.so.1

### DIFF
--- a/src/video/SDL_egl.c
+++ b/src/video/SDL_egl.c
@@ -84,7 +84,7 @@
 /* Desktop Linux/Unix-like */
 #define DEFAULT_OGL "libGL.so.1"
 #define DEFAULT_EGL "libEGL.so.1"
-#define ALT_OGL "libOpenGL.so.1"
+#define ALT_OGL "libOpenGL.so.0"
 #define DEFAULT_OGL_ES2 "libGLESv2.so.2"
 #define DEFAULT_OGL_ES_PVR "libGLES_CM.so.1"
 #define DEFAULT_OGL_ES "libGLESv1_CM.so.1"


### PR DESCRIPTION
Fixes: https://github.com/libsdl-org/SDL/issues/4158

faba1be07dc57ced6dc1fb929b029253dde5bef4 has a typo.

With this patch applied I confirm it to be working in a libX11-less setup.