### PR TITLE
Fix invalid UTF-8 handling of extra bytes

### DIFF
--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -537,27 +537,12 @@ SDL_UCS4ToUTF8(Uint32 ch, char *dst)
         p[1] = 0x80 | (Uint8) ((ch >> 6) & 0x3F);
         p[2] = 0x80 | (Uint8) (ch & 0x3F);
         dst += 3;
-    } else if (ch <= 0x1FFFFF) {
+    } else {
         p[0] = 0xF0 | (Uint8) ((ch >> 18) & 0x07);
         p[1] = 0x80 | (Uint8) ((ch >> 12) & 0x3F);
         p[2] = 0x80 | (Uint8) ((ch >> 6) & 0x3F);
         p[3] = 0x80 | (Uint8) (ch & 0x3F);
         dst += 4;
-    } else if (ch <= 0x3FFFFFF) {
-        p[0] = 0xF8 | (Uint8) ((ch >> 24) & 0x03);
-        p[1] = 0x80 | (Uint8) ((ch >> 18) & 0x3F);
-        p[2] = 0x80 | (Uint8) ((ch >> 12) & 0x3F);
-        p[3] = 0x80 | (Uint8) ((ch >> 6) & 0x3F);
-        p[4] = 0x80 | (Uint8) (ch & 0x3F);
-        dst += 5;
-    } else {
-        p[0] = 0xFC | (Uint8) ((ch >> 30) & 0x01);
-        p[1] = 0x80 | (Uint8) ((ch >> 24) & 0x3F);
-        p[2] = 0x80 | (Uint8) ((ch >> 18) & 0x3F);
-        p[3] = 0x80 | (Uint8) ((ch >> 12) & 0x3F);
-        p[4] = 0x80 | (Uint8) ((ch >> 6) & 0x3F);
-        p[5] = 0x80 | (Uint8) (ch & 0x3F);
-        dst += 6;
     }
     return dst;
 }

--- a/src/stdlib/SDL_iconv.c
+++ b/src/stdlib/SDL_iconv.c
@@ -369,33 +369,7 @@ SDL_iconv(SDL_iconv_t cd,
                 Uint8 *p = (Uint8 *) src;
                 size_t left = 0;
                 SDL_bool overlong = SDL_FALSE;
-                if (p[0] >= 0xFC) {
-                    if ((p[0] & 0xFE) != 0xFC) {
-                        /* Skip illegal sequences
-                           return SDL_ICONV_EILSEQ;
-                         */
-                        ch = UNKNOWN_UNICODE;
-                    } else {
-                        if (p[0] == 0xFC && srclen > 1 && (p[1] & 0xFC) == 0x80) {
-                            overlong = SDL_TRUE;
-                        }
-                        ch = (Uint32) (p[0] & 0x01);
-                        left = 5;
-                    }
-                } else if (p[0] >= 0xF8) {
-                    if ((p[0] & 0xFC) != 0xF8) {
-                        /* Skip illegal sequences
-                           return SDL_ICONV_EILSEQ;
-                         */
-                        ch = UNKNOWN_UNICODE;
-                    } else {
-                        if (p[0] == 0xF8 && srclen > 1 && (p[1] & 0xF8) == 0x80) {
-                            overlong = SDL_TRUE;
-                        }
-                        ch = (Uint32) (p[0] & 0x03);
-                        left = 4;
-                    }
-                } else if (p[0] >= 0xF0) {
+                if (p[0] >= 0xF0) {
                     if ((p[0] & 0xF8) != 0xF0) {
                         /* Skip illegal sequences
                            return SDL_ICONV_EILSEQ;
@@ -670,7 +644,7 @@ SDL_iconv(SDL_iconv_t cd,
                     p[2] = 0x80 | (Uint8) (ch & 0x3F);
                     dst += 3;
                     dstlen -= 3;
-                } else if (ch <= 0x1FFFFF) {
+                } else {
                     if (dstlen < 4) {
                         return SDL_ICONV_E2BIG;
                     }
@@ -680,29 +654,6 @@ SDL_iconv(SDL_iconv_t cd,
                     p[3] = 0x80 | (Uint8) (ch & 0x3F);
                     dst += 4;
                     dstlen -= 4;
-                } else if (ch <= 0x3FFFFFF) {
-                    if (dstlen < 5) {
-                        return SDL_ICONV_E2BIG;
-                    }
-                    p[0] = 0xF8 | (Uint8) ((ch >> 24) & 0x03);
-                    p[1] = 0x80 | (Uint8) ((ch >> 18) & 0x3F);
-                    p[2] = 0x80 | (Uint8) ((ch >> 12) & 0x3F);
-                    p[3] = 0x80 | (Uint8) ((ch >> 6) & 0x3F);
-                    p[4] = 0x80 | (Uint8) (ch & 0x3F);
-                    dst += 5;
-                    dstlen -= 5;
-                } else {
-                    if (dstlen < 6) {
-                        return SDL_ICONV_E2BIG;
-                    }
-                    p[0] = 0xFC | (Uint8) ((ch >> 30) & 0x01);
-                    p[1] = 0x80 | (Uint8) ((ch >> 24) & 0x3F);
-                    p[2] = 0x80 | (Uint8) ((ch >> 18) & 0x3F);
-                    p[3] = 0x80 | (Uint8) ((ch >> 12) & 0x3F);
-                    p[4] = 0x80 | (Uint8) ((ch >> 6) & 0x3F);
-                    p[5] = 0x80 | (Uint8) (ch & 0x3F);
-                    dst += 6;
-                    dstlen -= 6;
                 }
             }
             break;


### PR DESCRIPTION
## Description
I just happened to observe that the UTF-8 hander function in `SDL_keyboard.c` happens to be handling invalid UTF-8 as valid UTF-8. The function tries to interpret extra bytes in the source string, that are normally considered illegal UTF-8 encodings and out of the specs for the encoding system. Also fixed the same issue, on another file.

Ref: https://en.wikipedia.org/wiki/UTF-8 
For the UTF-8 encoding specs


