### PR TITLE
Add differentiation between the two full OpenGL implementations in video summary.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2379,7 +2379,7 @@ CheckOpenGLX11()
             AC_DEFINE(SDL_VIDEO_OPENGL, 1, [ ])
             AC_DEFINE(SDL_VIDEO_OPENGL_GLX, 1, [ ])
             AC_DEFINE(SDL_VIDEO_RENDER_OGL, 1, [ ])
-            SUMMARY_video="${SUMMARY_video} opengl"
+            SUMMARY_video="${SUMMARY_video} opengl(glx)"
         fi
     fi
 }
@@ -2400,7 +2400,7 @@ CheckOpenGLKMSDRM()
         if test x$video_opengl = xyes; then 
             AC_DEFINE(SDL_VIDEO_OPENGL, 1, [ ]) 
             AC_DEFINE(SDL_VIDEO_RENDER_OGL, 1, [ ]) 
-            SUMMARY_video="${SUMMARY_video} opengl"
+            SUMMARY_video="${SUMMARY_video} opengl(glvnd)"
         fi   
     fi   
 }

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -3288,9 +3288,22 @@ SDL_GL_ResetAttributes()
     _this->gl_config.accelerated = -1;  /* accelerated or not, both are fine */
 
 #if SDL_VIDEO_OPENGL
-    _this->gl_config.major_version = 2;
-    _this->gl_config.minor_version = 1;
-    _this->gl_config.profile_mask = 0;
+
+#if SDL_VIDEO_DRIVER_KMSDRM
+    /* Even if full OpenGL works with the KMSDRM backend, GLES2 renderer is still preferred. */
+    if (SDL_strcmp(_this->name, "KMSDRM") == 0) {
+        _this->gl_config.major_version = 2;
+        _this->gl_config.minor_version = 0;
+        _this->gl_config.profile_mask = SDL_GL_CONTEXT_PROFILE_ES;
+    } else
+#endif
+    {
+        _this->gl_config.major_version = 2;
+        _this->gl_config.minor_version = 1;
+        _this->gl_config.profile_mask = 0;
+    }
+#endif
+
 #elif SDL_VIDEO_OPENGL_ES2
     _this->gl_config.major_version = 2;
     _this->gl_config.minor_version = 0;


### PR DESCRIPTION
This is simply a cosmetic change so the make build system reports the OpenGL implementation detection with precision.  This way, if we have both GLX and GLVND full OpenGL implementations present, the cmake build system will report "opengl(glx) opengl(glvnd)", which is nice, instead of simply reporting "opengl" twice. 