### PR TITLE
Fix #3596, free all TLS data at the end of `SDL_Quit` to avoid memory leak

### DIFF
--- a/src/SDL.c
+++ b/src/SDL.c
@@ -447,6 +447,9 @@ SDL_Quit(void)
      */
     SDL_memset( SDL_SubsystemRefCount, 0x0, sizeof(SDL_SubsystemRefCount) );
 
+    /* Cleanup all TLS data */
+    SDL_Generic_CleanupAllTLSData();
+
     SDL_bInMainQuit = SDL_FALSE;
 }
 

--- a/src/thread/SDL_thread.c
+++ b/src/thread/SDL_thread.c
@@ -200,6 +200,12 @@ SDL_Generic_SetTLSData(SDL_TLSData *storage)
     return 0;
 }
 
+void
+SDL_Generic_CleanupAllTLSData(void)
+{
+    SDL_TLSCleanup();
+}
+
 /* Routine to get the thread-specific error variable */
 SDL_error *
 SDL_GetErrBuf(void)

--- a/src/thread/SDL_thread_c.h
+++ b/src/thread/SDL_thread_c.h
@@ -97,6 +97,9 @@ extern SDL_TLSData *SDL_Generic_GetTLSData(void);
  */
 extern int SDL_Generic_SetTLSData(SDL_TLSData *data);
 
+/* Cleanup all TLS data for this thread. */
+extern void SDL_Generic_CleanupAllTLSData(void);
+
 #endif /* SDL_thread_c_h_ */
 
 /* vi: set ts=4 sw=4 expandtab: */


### PR DESCRIPTION
Prevent leak memory, specially allocate the memory in the function `SDL_GetErrBuf`.
And free all TLS(thread-local-storage) data when users close the SDL application.

**Notice: The SDL library is compiled with SDL_THREADS.**

## Description

Many leak detectors report some memories are not freed after close the SDL application.

A memory leak is caused by the function - `SDL_GetErrBuf`. In the function, it uses `SDL_malloc` to allocate a block of memory as the error buffer, but no place to free it. So I insert an internal function `SDL_Generic_CleanupAllTLSData` to call `SDL_TLSCleanup` at the end of `SDL_Quit`.

After that, my memory detector doesn't report any memory leak. :smile:

## Existing Issue(s)

[https://github.com/libsdl-org/SDL/issues/3596](https://github.com/libsdl-org/SDL/issues/3596)

## By the way

* **Don't call `SDL_SetError` in `SDL_TLSData::destructor` or your `SDL_free`**
* `SDL_TLSSet` has a potential memory leak when calling it with the same `SDL_TLSID` more than once
