### PR TITLE
Undo SDL_CreateRenderer() modifications aimed at create opengles2 when KMSDRM is in use.

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -838,28 +838,6 @@ SDL_CreateRenderer(SDL_Window * window, int index, Uint32 flags)
             }
         }
 
-#if SDL_VIDEO_DRIVER_KMSDRM
-
-    /* Even if full OpenGL works with the KMSDRM backend, GLES2 renderer is still preferred. */
-    if ((SDL_strcmp(SDL_GetCurrentVideoDriver(), "KMSDRM") == 0) && (!renderer)) {
-
-        for (index = 0; index < n; ++index) {
-
-            const SDL_RenderDriver *driver = render_drivers[index];
-
-            if ((SDL_strcmp(driver->info.name, "opengles2") == 0) && (!renderer)) {
-                /* Create a new renderer instance */
-                renderer = driver->CreateRenderer(window, flags);
-                if (renderer) {
-                    /* Got an OpenGL_ES2 renderer as expected for KMSDRM by default. */
-                    break;
-                }
-            }
-        }
-    }
-
-#endif
-
         if (!renderer) {
             for (index = 0; index < n; ++index) {
                 const SDL_RenderDriver *driver = render_drivers[index];


### PR DESCRIPTION
I noticed that this is only a half-solution and harmful too, because it causes a window recreation in `GLES2_CreateRenderer()` caused by the fact that `SDL_GL_ResetAttributes()` in `SDL_video.c` is hardcoded to set full OPENGL `profile_mask, major, minor` parameters instead of GLES2 ones.
That's just wrong, and could theorically be fixed easily: but modifying `SDL_GL_ResetAttributes()` to make it set the right GLES `profile_mask, major, minor` parameters, full OPENGL programs don't work anymore becauses (I suspect) of the MANY hardcoded codepaths in  `SDL_video.c`.

So, unless `SDL_video.c` (and maybe other places where things are hardcoded via `#if SDL_VIDEO_OPENGL` directives) has a major rewrite, enforcing an opengles2 renderer when KMSDRM is being used is not possible without damaging `GLES2_CreateRenderer()` or breaking full OPENGL programs.

Being a "pick your poison" situation, I think it's better not to enfoce opengles2 renderer when KMSDRM is being used until major changes are made to SDL2 internals.