### PR TITLE
Report differentiated GLX and GLVND OpenGL implementation detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2379,7 +2379,7 @@ CheckOpenGLX11()
             AC_DEFINE(SDL_VIDEO_OPENGL, 1, [ ])
             AC_DEFINE(SDL_VIDEO_OPENGL_GLX, 1, [ ])
             AC_DEFINE(SDL_VIDEO_RENDER_OGL, 1, [ ])
-            SUMMARY_video="${SUMMARY_video} opengl"
+            SUMMARY_video="${SUMMARY_video} opengl(glx)"
         fi
     fi
 }
@@ -2400,7 +2400,7 @@ CheckOpenGLKMSDRM()
         if test x$video_opengl = xyes; then 
             AC_DEFINE(SDL_VIDEO_OPENGL, 1, [ ]) 
             AC_DEFINE(SDL_VIDEO_RENDER_OGL, 1, [ ]) 
-            SUMMARY_video="${SUMMARY_video} opengl"
+            SUMMARY_video="${SUMMARY_video} opengl(glvnd)"
         fi   
     fi   
 }

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -838,28 +838,6 @@ SDL_CreateRenderer(SDL_Window * window, int index, Uint32 flags)
             }
         }
 
-#if SDL_VIDEO_DRIVER_KMSDRM
-
-    /* Even if full OpenGL works with the KMSDRM backend, GLES2 renderer is still preferred. */
-    if ((SDL_strcmp(SDL_GetCurrentVideoDriver(), "KMSDRM") == 0) && (!renderer)) {
-
-        for (index = 0; index < n; ++index) {
-
-            const SDL_RenderDriver *driver = render_drivers[index];
-
-            if ((SDL_strcmp(driver->info.name, "opengles2") == 0) && (!renderer)) {
-                /* Create a new renderer instance */
-                renderer = driver->CreateRenderer(window, flags);
-                if (renderer) {
-                    /* Got an OpenGL_ES2 renderer as expected for KMSDRM by default. */
-                    break;
-                }
-            }
-        }
-    }
-
-#endif
-
         if (!renderer) {
             for (index = 0; index < n; ++index) {
                 const SDL_RenderDriver *driver = render_drivers[index];


### PR DESCRIPTION
This simply modifies configure.ac (related to the classic "make" build system) so when the resulting configure script is run, it reports differentiated GLX and GLVND OpenGL implementations.

For example: without this commit, "opengl" will be reported twice if both GLX and GLVND OpenGL implementations are present, which is confusing and not nice.
With this, "opengl(glx)" and "opengl(glvnd)" would be reported.