### PR TITLE
Report differentiated glx and glvnd OpenGL implementations.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2379,7 +2379,7 @@ CheckOpenGLX11()
             AC_DEFINE(SDL_VIDEO_OPENGL, 1, [ ])
             AC_DEFINE(SDL_VIDEO_OPENGL_GLX, 1, [ ])
             AC_DEFINE(SDL_VIDEO_RENDER_OGL, 1, [ ])
-            SUMMARY_video="${SUMMARY_video} opengl"
+            SUMMARY_video="${SUMMARY_video} opengl(glx)"
         fi
     fi
 }
@@ -2400,7 +2400,7 @@ CheckOpenGLKMSDRM()
         if test x$video_opengl = xyes; then 
             AC_DEFINE(SDL_VIDEO_OPENGL, 1, [ ]) 
             AC_DEFINE(SDL_VIDEO_RENDER_OGL, 1, [ ]) 
-            SUMMARY_video="${SUMMARY_video} opengl"
+            SUMMARY_video="${SUMMARY_video} opengl(glvnd)"
         fi   
     fi   
 }


### PR DESCRIPTION
This simply modifies configure.ac (related to the classic "make" build system) so when the resulting configure script is run, it reports differentiated GLX and GLVND OpenGL implementations.

For example: without this commit, "opengl" will be reported twice if both GLX and GLVND OpenGL implementations are present, which is confusing and not nice.
With this, "opengl(glx)" and "opengl(glvnd)" would be reported.