### PR TITLE
Fix tests configuration and building when only GLVND full OpenGL implementation is present

### DIFF
--- a/test/configure.ac
+++ b/test/configure.ac
@@ -80,7 +80,15 @@ case "$host" in
         ISUNIX="true"
         EXE=""
         MATHLIB="-lm"
+        dnl Use the new libOpenGL if present.
+        have_glvnd=no
+        AC_CHECK_LIB(OpenGL, glBegin,
+        [   
+        dnl have_glvnd=yes
+        SYS_GL_LIBS="-lOpenGL"
+        ],[ 
         SYS_GL_LIBS="-lGL"
+        ])  
         ;;
 esac
 AC_SUBST(EXE)


### PR DESCRIPTION
**PREVIOUS  ISSUE**

Many of the tests in /tests wouldn't link if only the modern full OpenGL implementation (GLVND) is present on the system. This commit fixes that.

**WHAT THIS COMMIT DOES**

What this commit does is enable the `libOpenGL.so` detection in `tests/configure.ac`.
So if `libOpenGL.so` is present test programs will be linked against `-lOpenGL` instead of `-lGL`.

-If both `libGL.so` and `libOpenGL.so` are present, `libOpenGL.so` is preferred as it's a modern and vendor-neutral implementation, vs the old and X11-bound `libGL.so`
-If only `libGL.so` is present, libGL.so will be used.
-If only `libOpenGL.so` is present it will be used.