### PR TITLE
Make the gbm_init flag a viddata member to avoid GBM re-init when several displays are connected.

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmopengles.c
+++ b/src/video/kmsdrm/SDL_kmsdrmopengles.c
@@ -93,7 +93,7 @@ KMSDRM_GLES_SwapWindow(_THIS, SDL_Window * window) {
     KMSDRM_FBInfo *fb_info;
     int ret = 0;
 
-    /* Always wait for the previous issued flip before issing a new one,
+    /* Always wait for the previous issued flip before issuing a new one,
        even if you do async flips. */
     uint32_t flip_flags = DRM_MODE_PAGE_FLIP_EVENT;
 

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -1079,7 +1079,7 @@ KMSDRM_DestroyWindow(_THIS, SDL_Window *window)
         return;
     }
 
-    if ( !is_vulkan && viddata->gbm_init ) {
+    if ( !is_vulkan && viddata->gbm_init) {
 
         /* Destroy the window display's cursor GBM BO. */
         KMSDRM_DestroyCursorBO(_this, SDL_GetDisplayForWindow(window));
@@ -1087,14 +1087,18 @@ KMSDRM_DestroyWindow(_THIS, SDL_Window *window)
         /* Destroy GBM surface and buffers. */
         KMSDRM_DestroySurfaces(_this, window);
 
-        /* Unload EGL/GL library and free egl_data.  */
-        if (_this->egl_data) {
-            SDL_EGL_UnloadLibrary(_this);
-            _this->gl_config.driver_loaded = 0;
-        }
+        /* Unload library and deinit GBM, but only if this is the last remaining window.*/
+        if (viddata->num_windows < 2) {
 
-        /* Free display plane, and destroy GBM device. */
-        KMSDRM_GBMDeinit(_this, dispdata);
+	    /* Unload EGL/GL library and free egl_data.  */
+	    if (_this->egl_data) {
+		SDL_EGL_UnloadLibrary(_this);
+		_this->gl_config.driver_loaded = 0;
+	    }
+
+	    /* Free display plane, and destroy GBM device. */
+	    KMSDRM_GBMDeinit(_this, dispdata);
+	}
 
     } else {
 

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -1158,6 +1158,10 @@ KMSDRM_CreateWindow(_THIS, SDL_Window * window)
 
     if (!is_vulkan && !vulkan_mode) { /* NON-Vulkan block. */
 
+        /* Maybe you didn't ask for an OPENGL window, but that's what you will get.
+           See following comments on why. */
+        window->flags |= SDL_WINDOW_OPENGL;
+
         if (!(viddata->gbm_init)) {
 
             /* After SDL_CreateWindow, most SDL2 programs will do SDL_CreateRenderer(),
@@ -1172,10 +1176,6 @@ KMSDRM_CreateWindow(_THIS, SDL_Window * window)
                don't be shy to debug GL_CreateRenderer() or GLES2_CreateRenderer()
                to find out why!
              */
-
-            /* Maybe you didn't ask for an OPENGL window, but that's what you will get.
-               See previous comment on why. */
-            window->flags |= SDL_WINDOW_OPENGL;
 
             /* Reopen FD, create gbm dev, setup display plane, etc,.
                but only when we come here for the first time,

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -532,7 +532,6 @@ void KMSDRM_AddDisplay (_THIS, drmModeConnector *connector, drmModeRes *resource
 
     /* Initialize some of the members of the new display's driverdata
        to sane values. */
-    dispdata->gbm_init = SDL_FALSE;
     dispdata->modeset_pending = SDL_FALSE;
     dispdata->cursor_bo = NULL;
 
@@ -787,7 +786,7 @@ KMSDRM_GBMInit (_THIS, SDL_DisplayData *dispdata)
         ret = SDL_SetError("Couldn't create gbm device.");
     }
 
-    dispdata->gbm_init = SDL_TRUE;
+    viddata->gbm_init = SDL_TRUE;
 
     return ret;
 }
@@ -811,7 +810,7 @@ KMSDRM_GBMDeinit (_THIS, SDL_DisplayData *dispdata)
         viddata->drm_fd = -1;
     }
 
-    dispdata->gbm_init = SDL_FALSE;
+    viddata->gbm_init = SDL_FALSE;
 }
 
 void
@@ -955,6 +954,7 @@ KMSDRM_VideoInit(_THIS)
     SDL_LogDebug(SDL_LOG_CATEGORY_VIDEO, "KMSDRM_VideoInit()");
 
     viddata->video_init = SDL_FALSE;
+    viddata->gbm_init = SDL_FALSE;
 
     /* Get KMSDRM resources info and store what we need. Getting and storing
        this info isn't a problem for VK compatibility.
@@ -1079,7 +1079,7 @@ KMSDRM_DestroyWindow(_THIS, SDL_Window *window)
         return;
     }
 
-    if ( !is_vulkan && dispdata->gbm_init ) {
+    if ( !is_vulkan && viddata->gbm_init ) {
 
         /* Destroy the window display's cursor GBM BO. */
         KMSDRM_DestroyCursorBO(_this, SDL_GetDisplayForWindow(window));
@@ -1158,7 +1158,7 @@ KMSDRM_CreateWindow(_THIS, SDL_Window * window)
 
     if (!is_vulkan && !vulkan_mode) { /* NON-Vulkan block. */
 
-        if (!(dispdata->gbm_init)) {
+        if (!(viddata->gbm_init)) {
 
             /* After SDL_CreateWindow, most SDL2 programs will do SDL_CreateRenderer(),
                which will in turn call GL_CreateRenderer() or GLES2_CreateRenderer().

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -1088,7 +1088,7 @@ KMSDRM_DestroyWindow(_THIS, SDL_Window *window)
         KMSDRM_DestroySurfaces(_this, window);
 
         /* Unload library and deinit GBM, but only if this is the last remaining window.*/
-        if (viddata->num_windows < 2) {
+        if ((viddata->num_windows - 1) == 0) {
 
 	    /* Unload EGL/GL library and free egl_data.  */
 	    if (_this->egl_data) {

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.h
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.h
@@ -48,6 +48,11 @@ typedef struct SDL_VideoData
     SDL_Window **windows;
     int max_windows;
     int num_windows;
+
+    /* Even if we have several displays, we only have to
+       open 1 FD and create 1 gbm device. */
+    SDL_bool gbm_init;
+
 } SDL_VideoData;
 
 
@@ -66,8 +71,6 @@ typedef struct SDL_DisplayData
     drmModeModeInfo next_mode; /* New mode to be set on the CRTC. */
 
     drmModeCrtc *saved_crtc;    /* CRTC to restore on quit */
-
-    SDL_bool gbm_init;
 
     /* DRM & GBM cursor stuff lives here, not in an SDL_Cursor's driverdata struct,
        because setting/unsetting up these is done on window creation/destruction,


### PR DESCRIPTION
## Description
Moved the `gbm_init` flag from `dispdata` (the display driverdata) to `viddata` (the general video driverdata).
Having `gbm_init` flag in dispdata means that each display has it's own copy of `gbm_init`, **which makes NO SENSE AT ALL** because, even if he have several displays, `KMSDRM_GBMInit()` must never be run more than 1 time.

## Existing Issue(s)
Before this change, KMSDRM_GBMInit() was being run everytime a new window was created on a different display, which in turn took the FD master from window 1 to window 2, and thus window 1 wouldn't be able to display anything.
