### PR TITLE
[KMSDRM] Better error handling: no more segfaults on window creation failure.

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmmouse.c
+++ b/src/video/kmsdrm/SDL_kmsdrmmouse.c
@@ -477,17 +477,8 @@ KMSDRM_InitMouse(_THIS, SDL_VideoDisplay *display)
     mouse->WarpMouse = KMSDRM_WarpMouse;
     mouse->WarpMouseGlobal = KMSDRM_WarpMouseGlobal;
 
-    /* SDL expects to set the default cursor of the display when we init the mouse,
-       but since we have moved the KMSDRM_InitMouse() call to KMSDRM_CreateWindow(),
-       we end up calling KMSDRM_InitMouse() every time we create a window, so we
-       have to prevent this from being done every time a new window is created.
-       If we don't, new default cursors would stack up on mouse->cursors and SDL
-       would have to hide and delete them at quit, not to mention the memory leak... */
-
-    if(dispdata->set_default_cursor_pending) { 
-        SDL_SetDefaultCursor(KMSDRM_CreateDefaultCursor());
-        dispdata->set_default_cursor_pending = SDL_FALSE;
-    }
+    SDL_SetDefaultCursor(KMSDRM_CreateDefaultCursor());
+    dispdata->set_default_cursor_pending = SDL_FALSE;
 }
 
 void


### PR DESCRIPTION
## Description
I did some adjustments in KMSDRM_CreateWindow() it's error handling now makes sense: I was tired of seeing uninformative segfaults when something went wrong, so I decided to put an end to that.
Now, KMSDRM_CreateWindow() returns an error value as expected when something goes wrong, and doesn't call SDL_DestroyWindow() by itself, because that's SDL_CreateWindow()'s job when KMSDRM_CreateWindow() returns an error code.
 
Also, the condition for cursor initialization on a display is moved from SDL_kmsdrmmouse.c to KMSDRM_CreateWindow() because cursor creation is done on a per-display basis.

## Existing Issue(s)
Before this, SDL would do an ugly segfault when KMSDRM window creation failed. Now, it lands gracefully with a proper error on the console.