### PR TITLE
threads: fix build on linux

### DIFF
--- a/src/core/linux/SDL_threadprio.c
+++ b/src/core/linux/SDL_threadprio.c
@@ -19,6 +19,7 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 #include "../../SDL_internal.h"
+#include "SDL_platform.h"
 
 #ifdef __LINUX__
 

--- a/src/thread/pthread/SDL_systhread.c
+++ b/src/thread/pthread/SDL_systhread.c
@@ -19,6 +19,7 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 #include "../../SDL_internal.h"
+#include "SDL_platform.h"
 
 #include "SDL_system.h"
 #include "SDL_hints.h"
@@ -48,7 +49,6 @@
 #endif
 #endif
 
-#include "SDL_platform.h"
 #include "SDL_thread.h"
 #include "../SDL_thread_c.h"
 #include "../SDL_systhread.h"


### PR DESCRIPTION
`SDL_platform.h` must be included before any use of `__LINUX__` or headers such as `dlfcn.h` won't be included resulting in the following build failure:

```
/home/fabrice/buildroot/output/build/sdl2-2.0.14/src/thread/pthread/SDL_systhread.c: In function ‘SDL_SYS_CreateThread’:
/home/fabrice/buildroot/output/build/sdl2-2.0.14/src/thread/pthread/SDL_systhread.c:97:20: warning: implicit declaration of function ‘dlsym’ [-Wimplicit-function-declaration]
         void *fn = dlsym(RTLD_DEFAULT, "pthread_setname_np");
                    ^~~~~
/home/fabrice/buildroot/output/build/sdl2-2.0.14/src/thread/pthread/SDL_systhread.c:97:26: error: ‘RTLD_DEFAULT’ undeclared (first use in this function); did you mean ‘SDL_HINT_DEFAULT’?
         void *fn = dlsym(RTLD_DEFAULT, "pthread_setname_np");
                          ^~~~~~~~~~~~
                          SDL_HINT_DEFAULT
/home/fabrice/buildroot/output/build/sdl2-2.0.14/src/thread/pthread/SDL_systhread.c:97:26: note: each undeclared identifier is reported only once for each function it appears in
/home/fabrice/buildroot/output/build/sdl2-2.0.14/src/thread/pthread/SDL_systhread.c: In function ‘SDL_SYS_SetThreadPriority’:
/home/fabrice/buildroot/output/build/sdl2-2.0.14/src/thread/pthread/SDL_systhread.c:261:26: warning: implicit declaration of function ‘syscall’; did you mean ‘scalbl’? [-Wimplicit-function-declaration]
         pid_t linuxTid = syscall(SYS_gettid);
                          ^~~~~~~
                          scalbl
/home/fabrice/buildroot/output/build/sdl2-2.0.14/src/thread/pthread/SDL_systhread.c:261:34: error: ‘SYS_gettid’ undeclared (first use in this function); did you mean ‘SDL_getenv’?
         pid_t linuxTid = syscall(SYS_gettid);
                                  ^~~~~~~~~~
                                  SDL_getenv
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>
