### PR TITLE
[KMSDRM] Improve cursor management.

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmvideo.h
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.h
@@ -79,7 +79,7 @@ typedef struct SDL_DisplayData
     struct gbm_bo *cursor_bo;
     uint64_t cursor_w, cursor_h;
 
-    SDL_bool set_default_cursor_pending;
+    SDL_bool default_cursor_init;
     SDL_bool modeset_pending;
 
 } SDL_DisplayData;


### PR DESCRIPTION
## Description
Made some adjustments in the video and mouse units to improve how default cursor is 
created and managed. It was a little confusing.
Also, since SDL_SetMouseFocus() seems to cause a KMSDRM_ShowMouse() call on it's own, there's no need for me to manually re-show the cursor of a display when I create a new window, so I removed the code that did that.

## Existing Issue(s)
I had accidentally disabled default cursor creation and display because of the confusing logic I was using.
This fixes that, too.