### PR TITLE
[KMSDRM] Fix segmentation fault

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -1071,13 +1071,15 @@ KMSDRM_DestroyWindow(_THIS, SDL_Window *window)
 {
     SDL_WindowData *windata = (SDL_WindowData *) window->driverdata;
     SDL_DisplayData *dispdata = (SDL_DisplayData *) SDL_GetDisplayForWindow(window)->driverdata;
-    SDL_VideoData *viddata = windata->viddata;
+    SDL_VideoData *viddata;
     SDL_bool is_vulkan = window->flags & SDL_WINDOW_VULKAN; /* Is this a VK window? */
     unsigned int i, j;
 
     if (!windata) {
         return;
     }
+
+    viddata = windata->viddata;
 
     if ( !is_vulkan && viddata->gbm_init) {
 


### PR DESCRIPTION
Deference the windata pointer *after* checking that it's non-NULL.

## Description

Fix a segfault. Happens for instance with PPSSPP.