### PR TITLE
In x11, GetDisplayDPI can give incorrect or unusable DPI information.…

### DIFF
--- a/src/video/x11/SDL_x11modes.c
+++ b/src/video/x11/SDL_x11modes.c
@@ -440,7 +440,7 @@ X11_InitModes_XRandR(_THIS)
                 RRMode modeID;
                 RRCrtc output_crtc;
                 XRRCrtcInfo *crtc;
-                float xft_dpi;
+                int xft_dpi = 0;
 
                 /* The primary output _should_ always be sorted first, but just in case... */
                 if ((looking_for_primary && (res->outputs[output] != primary)) ||
@@ -497,10 +497,10 @@ X11_InitModes_XRandR(_THIS)
                 displaydata->ddpi = SDL_ComputeDiagonalDPI(mode.w, mode.h, ((float) display_mm_width) / 25.4f,((float) display_mm_height) / 25.4f);
 
                 /* if xft dpi is available we will use this over xrandr */
-                xft_dpi = (float)GetXftDPI(dpy);
+                xft_dpi = GetXftDPI(dpy);
                 if(xft_dpi > 0) {
-                    displaydata->hdpi = xft_dpi;
-                    displaydata->vdpi = xft_dpi;
+                    displaydata->hdpi = (float)xft_dpi;
+                    displaydata->vdpi = (float)xft_dpi;
                 }
 
                 displaydata->scanline_pad = scanline_pad;

--- a/src/video/x11/SDL_x11sym.h
+++ b/src/video/x11/SDL_x11sym.h
@@ -138,6 +138,7 @@ SDL_X11_SYM(int,XWarpPointer,(Display* a,Window b,Window c,int d,int e,unsigned 
 SDL_X11_SYM(int,XWindowEvent,(Display* a,Window b,long c,XEvent* d),(a,b,c,d),return)
 SDL_X11_SYM(Status,XWithdrawWindow,(Display* a,Window b,int c),(a,b,c),return)
 SDL_X11_SYM(VisualID,XVisualIDFromVisual,(Visual* a),(a),return)
+SDL_X11_SYM(char*,XGetDefault,(Display* a,char* b, char* c),(a,b,c),return)
 #if SDL_VIDEO_DRIVER_X11_CONST_PARAM_XEXTADDDISPLAY
 SDL_X11_SYM(XExtDisplayInfo*,XextAddDisplay,(XExtensionInfo* a,Display* b,_Xconst char* c,XExtensionHooks* d,int e,XPointer f),(a,b,c,d,e,f),return)
 #else


### PR DESCRIPTION
Adding call to X11 XGetDefault to retrieve the xft dpi and using that as the dpi value if it's available.

<!--- Provide a general summary of your changes in the Title above -->

## Description
The X11 implementation of GetDisplayDPI currently returns the physical dpi and in some cases the incorrect dpi. This happens if the xrandr extension is used. Using XGetDefault will give us the xft dpi when available which is the useful virtual dpi and would allow users to determine what the scale factor is and possibly use features like hidpi.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
This could be helpful for issues such as #4176