### PR TITLE
src/thread/pthread/SDL_systhread.c: drop include of SDL_platform.h

### DIFF
--- a/src/thread/pthread/SDL_systhread.c
+++ b/src/thread/pthread/SDL_systhread.c
@@ -48,7 +48,6 @@
 #endif
 #endif
 
-#include "SDL_platform.h"
 #include "SDL_thread.h"
 #include "../SDL_thread_c.h"
 #include "../SDL_systhread.h"


### PR DESCRIPTION
Drop include of `SDL_platform.h` as `SDL_plaform.h` is already included by `SDL_internal.h` -> `SDL_config.h` -> `SDL_platform.h`

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>