### PR TITLE
Ask for videomode on the correct display when creating a window

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -469,7 +469,7 @@ uint32_t width, uint32_t height, uint32_t refresh_rate){
     target.refresh_rate = refresh_rate;
     target.driverdata = 0; /* Initialize to 0 */
 
-    if (!SDL_GetClosestDisplayMode(0, &target, &closest)) {
+    if (!SDL_GetClosestDisplayMode(SDL_atoi(display->name), &target, &closest)) {
         return NULL;
     } else {
         SDL_DisplayModeData *modedata = (SDL_DisplayModeData *)closest.driverdata;
@@ -512,7 +512,7 @@ void KMSDRM_DeinitDisplays (_THIS) {
 }
 
 /* Gets a DRM connector, builds an SDL_Display with it, and adds it to the
-   list of SDL Displays.  */
+   list of SDL Displays in _this->displays[]  */
 void KMSDRM_AddDisplay (_THIS, drmModeConnector *connector, drmModeRes *resources) {
 
     SDL_VideoData *viddata = ((SDL_VideoData *)_this->driverdata);


### PR DESCRIPTION
## Description
I did a small adjustment in KMSDRM_GetClosestDisplayMode() so the video mode is searched on the right display, instead of always being searched on the display with index 0 (this was accidentally hardcoded from the old days when KMSDRM backend wouldn't support more than 1 connected display).

## Existing Issue(s)
Previously, dual display setups wouldn't work with KMSDRM because searching for a video mode on the wrong display is not a good idea and leads to odd results.

With this small fix it's possible to create two windows, one in each display. Nice!