### PR TITLE
Fix #3596, call `SDL_TLSCleanup` to clean up the TLS memory when closing the application

### DIFF
--- a/include/SDL_thread.h
+++ b/include/SDL_thread.h
@@ -435,6 +435,10 @@ extern DECLSPEC void * SDLCALL SDL_TLSGet(SDL_TLSID id);
  */
 extern DECLSPEC int SDLCALL SDL_TLSSet(SDL_TLSID id, const void *value, void (SDLCALL *destructor)(void*));
 
+/**
+ *  \brief Cleanup all TLS data for this thread.
+ */
+extern DECLSPEC void SDLCALL SDL_TLSCleanup(void);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -809,3 +809,4 @@
 #define SDL_isgraph SDL_isgraph_REAL
 #define SDL_AndroidShowToast SDL_AndroidShowToast_REAL
 #define SDL_GetAudioDeviceSpec SDL_GetAudioDeviceSpec_REAL
+#define SDL_TLSCleanup SDL_TLSCleanup_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -874,3 +874,4 @@ SDL_DYNAPI_PROC(int,SDL_isgraph,(int a),(a),return)
 SDL_DYNAPI_PROC(int,SDL_AndroidShowToast,(const char *a, int b, int c, int d, int e),(a,b,c,d,e),return)
 #endif
 SDL_DYNAPI_PROC(int,SDL_GetAudioDeviceSpec,(int a, int b, SDL_AudioSpec *c),(a,b,c),return)
+SDL_DYNAPI_PROC(void,SDL_TLSCleanup,(void),(),)

--- a/src/thread/SDL_thread.c
+++ b/src/thread/SDL_thread.c
@@ -82,7 +82,7 @@ SDL_TLSSet(SDL_TLSID id, const void *value, void (SDLCALL *destructor)(void *))
     return 0;
 }
 
-static void
+void
 SDL_TLSCleanup()
 {
     SDL_TLSData *storage;


### PR DESCRIPTION
commit 6b8f933589aa3925978a23e77a305a7e89c6ae4a
Author: Xing Ji <jixingcn@gmail.com>
Date:   Wed Mar 24 22:31:29 2021 +0800

    update the dynapi by `gendynapi.pl`

commit ebd1790c19983b652713f40ab1e139e485e1a2b7
Author: Xing Ji <jixingcn@gmail.com>
Date:   Wed Mar 24 22:17:48 2021 +0800

    revert the change in src/dynapi

commit 734b5f85c1613070081e39238e84198128971b53
Merge: 5a56e5a8 5ac6bd54
Author: Xing Ji <jixingcn@gmail.com>
Date:   Wed Mar 24 22:14:40 2021 +0800

    Merge remote-tracking branch 'libsdl/main' into jixingcn

commit 5a56e5a8227d9cff6b497b681c618a76bec1cae1
Author: Xing Ji <jixingcn@gmail.com>
Date:   Mon Mar 22 23:55:10 2021 +0800

    Fix #3596, can call the `SDL_TLSCleanup` to cleanup the TLS data when closing the application

Allow calling `SDL_TLSCleanup` explicitly by the application to avoid the memory leak report by the leak detector.

## Description

After this request, the memory leak detector will not report any leak if you call `SDL_TLSCleanup` in the end.

## Existing Issue(s)

[https://github.com/libsdl-org/SDL/issues/3596](https://github.com/libsdl-org/SDL/issues/3596)

Actually, you don't have to deal with the issue - #3596. Because the system will release the memory that the leak detector report when closing the application.

Reference: [https://github.com/libsdl-org/SDL/pull/4192#issuecomment-800728277](https://github.com/libsdl-org/SDL/pull/4192#issuecomment-800728277)
