### PR TITLE
Wayland MessageBox fixes

### DIFF
--- a/src/video/wayland/SDL_waylandmessagebox.c
+++ b/src/video/wayland/SDL_waylandmessagebox.c
@@ -76,10 +76,17 @@ Wayland_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonid)
         }
     ADD_ARGUMENT(title_len, title)
     ADD_ARGUMENT(message_len, message)
-    for (i = 0; i < messageboxdata->numbuttons; i += 1) {
-        ADD_ARGUMENT(extrabutton_len, buttons[i].text)
-    }
     #undef ADD_ARGUMENT
+    for (i = 0; i < messageboxdata->numbuttons; i += 1) {
+        command_len += extrabutton_len + 3; /* Two " and a space */
+        if (messageboxdata->buttons[i].text != NULL) {
+            const size_t button_len = SDL_strlen(messageboxdata->buttons[i].text);
+            command_len += button_len;
+            if (button_len > output_len) {
+                output_len = button_len;
+            }
+        }
+    }
 
     /* Don't forget null terminators! */
     command_len += 1;

--- a/src/video/wayland/SDL_waylandmessagebox.c
+++ b/src/video/wayland/SDL_waylandmessagebox.c
@@ -32,7 +32,7 @@ Wayland_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonid)
     #define ZENITY_CONST(name, str) \
         const char *name = str; \
         const size_t name##_len = SDL_strlen(name);
-    ZENITY_CONST(zenity, "zenity --question --switch --icon-name=dialog-")
+    ZENITY_CONST(zenity, "zenity --question --switch --no-wrap --icon-name=dialog-")
     ZENITY_CONST(title, "--title=")
     ZENITY_CONST(message, "--text=")
     ZENITY_CONST(extrabutton, "--extra-button=")


### PR DESCRIPTION
A copypasting mishap caused a block to go not-updated... without this block the output_len never gets assigned, meaning button string comparisons will never happen.

I also added --no-wrap to work around a Zenity issue. Now dialogs look a lot better!

Part of #4227