### PR TITLE
wasapi: Remove assert added by 67e8522d

### DIFF
--- a/src/audio/wasapi/SDL_wasapi.c
+++ b/src/audio/wasapi/SDL_wasapi.c
@@ -100,7 +100,6 @@ WaveFormatToSDLFormat(WAVEFORMATEX *waveformat)
             return AUDIO_S32SYS;
         }
     }
-    SDL_assert(0 && "Unrecognized wFormatTag!");
     return 0;
 }
 


### PR DESCRIPTION
When I implemented GetAudioDeviceSpec I reused a format conversion that already existed, and as part of moving it to a standalone function I added an assert, worried that I would run into some critical formats that would need to be added for the new feature. It turns out I was half right, there is a common format used on Windows for sound devices, unfortunately the format is 24-bit PCM.

This assert ended up just being annoying more than anything, and we documented in the API that 0 for format means the format wasn't recognized, so just forget I added this...

Fixes #4239, #4223