### PR TITLE
[KMSDRM] For Vulkan, use a mode with the same exact size as the window, if possible, or create a new one.

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -722,7 +722,7 @@ int KMSDRM_InitDisplays (_THIS) {
                an SDL Display representing it. KMSDRM_AddDisplay() is purposely void,
                so if it fails (no encoder for connector, no valid video mode for
                connector etc...) we can keep looking for connected connectors. */
-            KMSDRM_AddDisplay (_this, connector, resources);
+            KMSDRM_AddDisplay(_this, connector, resources);
         }
         else {
             /* If it's not, free it now. */

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -965,7 +965,7 @@ KMSDRM_VideoInit(_THIS)
        For VK-incompatible initializations we have KMSDRM_GBMInit(), which is
        called on window creation, and only when we know it's not a VK window. */
     if (KMSDRM_InitDisplays(_this)) {
-        ret = SDL_SetError("error getting KMS/DRM information");
+        ret = SDL_SetError("error getting KMSDRM displays information");
     }
 
 #ifdef SDL_INPUT_LINUXEV

--- a/src/video/kmsdrm/SDL_kmsdrmvulkan.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvulkan.c
@@ -367,14 +367,15 @@ SDL_bool KMSDRM_Vulkan_CreateSurface(_THIS,
     planes_props = SDL_malloc(sizeof(VkDisplayPlanePropertiesKHR) * plane_count);
     vkGetPhysicalDeviceDisplayPlanePropertiesKHR(gpu, &plane_count, planes_props);
 
-    /* Get a video mode equal or smaller than the window size. REMEMBER:
-       We have to get a small enough videomode for the window size,
+    /* Get a video mode equal to the window size among the predefined ones,
+       if possible.
+       REMEMBER: We have to get a small enough videomode for the window size,
        because videomode determines how big the scanout region is and we can't
        scanout a region bigger than the window (we would be reading past the
        buffer, and Vulkan would give us a confusing VK_ERROR_SURFACE_LOST_KHR). */
     for (i = 0; i < mode_count; i++) {
-        if (modes_props[i].parameters.visibleRegion.width <= window->w &&
-            modes_props[i].parameters.visibleRegion.height <= window->h)
+        if (modes_props[i].parameters.visibleRegion.width == window->w &&
+            modes_props[i].parameters.visibleRegion.height == window->h)
         {
             display_mode_props = modes_props[i];
             mode_found = SDL_TRUE;


### PR DESCRIPTION
## Description
Made some small changes in SDL_kmsdrmvulkan.c so we chose an exact video mode if available (instead of looking for a small-enough one: what was I thinking?), or create a new mode if it's not possible to find a matching mode.

## Existing Issue(s)
GZDoom would only display a part of the screen before this (because we were simply chosing a small enough video mode, instead of a matching one).
This is fixed now.