### PR TITLE
wayland: Initial text input and IME support

### DIFF
--- a/src/video/wayland/SDL_waylandkeyboard.c
+++ b/src/video/wayland/SDL_waylandkeyboard.c
@@ -1,0 +1,75 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2021 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+#include "../../SDL_internal.h"
+
+#if SDL_VIDEO_DRIVER_WAYLAND
+
+#include "../SDL_sysvideo.h"
+#include "SDL_waylandvideo.h"
+
+int
+Wayland_InitKeyboard(_THIS)
+{
+#ifdef SDL_USE_IME
+    SDL_IME_Init();
+#endif
+
+    return 0;
+}
+
+void
+Wayland_QuitKeyboard(_THIS)
+{
+#ifdef SDL_USE_IME
+    SDL_IME_Quit();
+#endif
+}
+
+void
+Wayland_StartTextInput(_THIS)
+{
+    /* No-op */
+}
+
+void
+Wayland_StopTextInput(_THIS)
+{
+#ifdef SDL_USE_IME
+    SDL_IME_Reset();
+#endif
+}
+
+void
+Wayland_SetTextInputRect(_THIS, SDL_Rect *rect)
+{
+    if (!rect) {
+        SDL_InvalidParamError("rect");
+        return;
+    }
+       
+#ifdef SDL_USE_IME
+    SDL_IME_UpdateTextRect(rect);
+#endif
+}
+
+#endif /* SDL_VIDEO_DRIVER_WAYLAND */
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/wayland/SDL_waylandkeyboard.h
+++ b/src/video/wayland/SDL_waylandkeyboard.h
@@ -1,0 +1,34 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2021 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+#include "../../SDL_internal.h"
+
+#ifndef SDL_waylandkeyboard_h_
+#define SDL_waylandkeyboard_h_
+
+extern int Wayland_InitKeyboard(_THIS);
+extern void Wayland_QuitKeyboard(_THIS);
+extern void Wayland_StartTextInput(_THIS);
+extern void Wayland_StopTextInput(_THIS);
+extern void Wayland_SetTextInputRect(_THIS, SDL_Rect *rect);
+
+#endif /* SDL_waylandkeyboard_h_ */
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -33,6 +33,7 @@
 #include "SDL_waylandwindow.h"
 #include "SDL_waylandopengles.h"
 #include "SDL_waylandmouse.h"
+#include "SDL_waylandkeyboard.h"
 #include "SDL_waylandtouch.h"
 #include "SDL_waylandclipboard.h"
 #include "SDL_waylandvulkan.h"
@@ -215,6 +216,9 @@ Wayland_CreateDevice(int devindex)
     device->SetClipboardText = Wayland_SetClipboardText;
     device->GetClipboardText = Wayland_GetClipboardText;
     device->HasClipboardText = Wayland_HasClipboardText;
+    device->StartTextInput = Wayland_StartTextInput;
+    device->StopTextInput = Wayland_StopTextInput;
+    device->SetTextInputRect = Wayland_SetTextInputRect;
 
 #if SDL_VIDEO_VULKAN
     device->Vulkan_LoadLibrary = Wayland_Vulkan_LoadLibrary;
@@ -478,6 +482,8 @@ Wayland_VideoInit(_THIS)
 
     WAYLAND_wl_display_flush(data->display);
 
+    Wayland_InitKeyboard(_this);
+
 #if SDL_USE_LIBDBUS
     SDL_DBus_Init();
 #endif
@@ -566,6 +572,8 @@ Wayland_VideoQuit(_THIS)
 
     if (data->registry)
         wl_registry_destroy(data->registry);
+
+    Wayland_QuitKeyboard(_this);
 
 /* !!! FIXME: other subsystems use D-Bus, so we shouldn't quit it here;
        have SDL.c do this at a higher level, or add refcounting. */

--- a/src/video/wayland/SDL_waylandvideo.h
+++ b/src/video/wayland/SDL_waylandvideo.h
@@ -40,6 +40,7 @@
 #include "wayland-util.h"
 
 #include "../../core/linux/SDL_dbus.h"
+#include "../../core/linux/SDL_ime.h"
 
 struct xkb_context;
 struct SDL_WaylandInput;


### PR DESCRIPTION
Note that this is purely to make it possible to enter text that requires
composition - for example, before this commit Kanji input didn't work at all.
~XWayland does not appear to support our X implementation~, so this is critical
to have implemented in some form. EDIT: #4248 fixes XWayland.

The big problem this still has is that we need the window position, and this is
still not implemented. Once we have this information we can do the equivalent
of XTranslateCoordinates to put the rectangle where we want it.