### PR TITLE
linux: Fix ibus support on Wayland/XWayland

### DIFF
--- a/src/core/linux/SDL_ibus.c
+++ b/src/core/linux/SDL_ibus.c
@@ -257,7 +257,12 @@ IBus_GetDBusAddressFilename(void)
     }
     
     if (!*host) {
-        host = "unix";
+        const char *session = SDL_getenv("XDG_SESSION_TYPE");
+        if (session != NULL && SDL_strcmp(session, "wayland") == 0) {
+            host = "unix-wayland";
+        } else {
+            host = "unix";
+        }
     }
         
     SDL_memset(config_dir, 0, sizeof(config_dir));


### PR DESCRIPTION
As the title says. On Wayland, attempts to connect to `unix` handles instead of `unix-wayland` will be refused, meaning IME support won't work at all. This actually affects XWayland as well!

Spun off of #4246.