### PR TITLE
Audio: Pipewire cleanups and fixes

### DIFF
--- a/src/SDL_dataqueue.h
+++ b/src/SDL_dataqueue.h
@@ -29,6 +29,7 @@ typedef struct SDL_DataQueue SDL_DataQueue;
 SDL_DataQueue *SDL_NewDataQueue(const size_t packetlen, const size_t initialslack);
 void SDL_FreeDataQueue(SDL_DataQueue *queue);
 void SDL_ClearDataQueue(SDL_DataQueue *queue, const size_t slack);
+size_t SDL_RemoveFromDataQueue(SDL_DataQueue *queue, const size_t len);
 int SDL_WriteToDataQueue(SDL_DataQueue *queue, const void *data, const size_t len);
 size_t SDL_ReadFromDataQueue(SDL_DataQueue *queue, void *buf, const size_t len);
 size_t SDL_PeekIntoDataQueue(SDL_DataQueue *queue, void *buf, const size_t len);

--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -418,16 +418,12 @@ static void
 core_events_hotplug_init_callback(void *object, uint32_t id, int seq)
 {
     if (id == PW_ID_CORE && seq == hotplug_init_seq_val) {
-        PIPEWIRE_pw_thread_loop_lock(hotplug_loop);
-
         /* This core listener is no longer needed. */
         spa_hook_remove(&hotplug_core_listener);
 
         /* Signal that the initial I/O list is populated */
         SDL_AtomicSet(&hotplug_init_complete, 1);
         PIPEWIRE_pw_thread_loop_signal(hotplug_loop, false);
-
-        PIPEWIRE_pw_thread_loop_unlock(hotplug_loop);
     }
 }
 

--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -984,8 +984,23 @@ input_callback(void *data)
     PIPEWIRE_pw_stream_queue_buffer(stream, pw_buf);
 }
 
-static const struct pw_stream_events stream_output_events = { PW_VERSION_STREAM_EVENTS, .process = output_callback };
-static const struct pw_stream_events stream_input_events  = { PW_VERSION_STREAM_EVENTS, .process = input_callback };
+static void
+stream_state_changed_callback(void *data, enum pw_stream_state old, enum pw_stream_state state, const char *error)
+{
+    _THIS = data;
+
+    if (state == PW_STREAM_STATE_STREAMING || state == PW_STREAM_STATE_ERROR) {
+        SDL_AtomicSet(&this->hidden->stream_initialized, 1);
+        PIPEWIRE_pw_thread_loop_signal(this->hidden->loop, false);
+    }
+}
+
+static const struct pw_stream_events stream_output_events = { PW_VERSION_STREAM_EVENTS,
+                                                              .state_changed = stream_state_changed_callback,
+                                                              .process       = output_callback };
+static const struct pw_stream_events stream_input_events  = { PW_VERSION_STREAM_EVENTS,
+                                                             .state_changed = stream_state_changed_callback,
+                                                             .process       = input_callback };
 
 static int
 PIPEWIRE_OpenDevice(_THIS, void *handle, const char *devname, int iscapture)
@@ -1006,7 +1021,7 @@ PIPEWIRE_OpenDevice(_THIS, void *handle, const char *devname, int iscapture)
     const struct spa_pod *       params   = NULL;
     struct SDL_PrivateAudioData *priv;
     struct pw_properties *       props;
-    const char *                 app_name, *stream_name, *stream_role;
+    const char *                 app_name, *stream_name, *stream_role, *error;
     const Uint32                 node_id = this->handle == NULL ? PW_ID_ANY : PW_HANDLE_TO_ID(this->handle);
     enum pw_stream_state         state;
     int                          res;
@@ -1122,14 +1137,17 @@ PIPEWIRE_OpenDevice(_THIS, void *handle, const char *devname, int iscapture)
     }
 
     /* Wait until the stream is either running or failed */
-    do {
-        const char *error;
-        state = PIPEWIRE_pw_stream_get_state(priv->stream, &error);
+    PIPEWIRE_pw_thread_loop_lock(priv->loop);
+    if (!SDL_AtomicGet(&priv->stream_initialized)) {
+        PIPEWIRE_pw_thread_loop_wait(priv->loop);
+    }
+    PIPEWIRE_pw_thread_loop_unlock(priv->loop);
 
-        if (state == PW_STREAM_STATE_ERROR) {
-            return SDL_SetError("Pipewire: Stream error: %s", error);
-        }
-    } while (state != PW_STREAM_STATE_STREAMING);
+    state = PIPEWIRE_pw_stream_get_state(priv->stream, &error);
+
+    if (state == PW_STREAM_STATE_ERROR) {
+        return SDL_SetError("Pipewire: Stream error: %s", error);
+    }
 
     return 0;
 }

--- a/src/audio/pipewire/SDL_pipewire.h
+++ b/src/audio/pipewire/SDL_pipewire.h
@@ -37,6 +37,7 @@ struct SDL_PrivateAudioData
     struct pw_context     *context;
     struct SDL_DataQueue  *buffer;
 
+    Uint32 packet_size;
     Sint32 stride; /* Bytes-per-frame */
 };
 

--- a/src/audio/pipewire/SDL_pipewire.h
+++ b/src/audio/pipewire/SDL_pipewire.h
@@ -37,8 +37,9 @@ struct SDL_PrivateAudioData
     struct pw_context     *context;
     struct SDL_DataQueue  *buffer;
 
-    Uint32 packet_size;
-    Sint32 stride; /* Bytes-per-frame */
+    Uint32       packet_size;
+    Sint32       stride; /* Bytes-per-frame */
+    SDL_atomic_t stream_initialized;
 };
 
 #endif /* SDL_pipewire_h_ */


### PR DESCRIPTION
A few Pipewire fixes and cleanups, including a fix for a race condition.

Since Pipewire starts it's own processing threads, we can wind up in the processing callbacks before all of the members of SDL_AudioDevice (callbackspec, work_buffer and stream) are actually allocated/initialized, as they aren't initialized until after the call to the driver's OpenDevice() function returns.  We don't want to touch any of these until the device state is set to unpaused, which can only happen once initialization is fully complete.

Other than that, some redundant locks were removed and stream creation now blocks instead of spinning until the stream state is ready or failed, as creating streams can sometimes take quite a bit of time and busy waiting for many milliseconds isn't ideal.