### PR TITLE
testmessage: Create a renderer for window display on Wayland

### DIFF
--- a/test/testmessage.c
+++ b/test/testmessage.c
@@ -189,6 +189,12 @@ main(int argc, char *argv[])
         SDL_Event event;
         SDL_Window *window = SDL_CreateWindow("Test", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 640, 480, 0);
 
+        /* On wayland, no window will actually show until something has
+           actually been displayed.
+        */
+        SDL_Renderer *renderer = SDL_CreateRenderer(window, -1, 0);
+        SDL_RenderPresent(renderer);
+
         success = SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
                     "Simple MessageBox",
                     "This is a simple error MessageBox with a parent window",


### PR DESCRIPTION
## Description
On Wayland -- or at least on some Wayland implementations -- windows aren't shown until something has been rendered into them. For the 'testmessage' test program, this means that the final messagebox (a modal one) is blocking an "invisible window", which can then be difficult to close.

By creating a renderer and presenting once, the window is properly displayed, and the test behaves as it does under X11  including XWayland).

## Futher notes
The zenity based implementation of ``SDL_ShowMessageBox()`` added in #4227 is only used if either XWayland isn't available or a Wayland-using window handle is passed in (for a modal dialog). Otherwise, the X11 implementation has priority. This probably makes sense — since the zenity implementation is less complete — but it means that, if XWayland is present, only the final test in ``testmessage`` uses the new zenity implementation.

It is possible that there are similar issues in other tests — I haven't looked into them thoroughly. Equally maybe it makes more sense to work around this in SDL itself (or indeed it could be something the wayland compositors should fix).

## Expected behaviour

Without this patch, running ``testmessage`` with ``SDL_VIDEODRIVER=wayland`` will result in no window appearing beneath the final message box. The program will not exit on a keypress as no window is there to receive the KEYUP message, but rather needs a Ctrl+C in the terminal running it.

With this patch, a window appears behind the zenity message box, and the program quits on a keypress, similarly to the X11 version.

## Environment notes

This issue was seen on KDE Plasma 5.21.3 under a Wayland session on OpenSUSE Tumbleweed 20210325.