### PR TITLE
Audio: Pipewire cleanups and fixes

### DIFF
--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -418,16 +418,12 @@ static void
 core_events_hotplug_init_callback(void *object, uint32_t id, int seq)
 {
     if (id == PW_ID_CORE && seq == hotplug_init_seq_val) {
-        PIPEWIRE_pw_thread_loop_lock(hotplug_loop);
-
         /* This core listener is no longer needed. */
         spa_hook_remove(&hotplug_core_listener);
 
         /* Signal that the initial I/O list is populated */
         SDL_AtomicSet(&hotplug_init_complete, 1);
         PIPEWIRE_pw_thread_loop_signal(hotplug_loop, false);
-
-        PIPEWIRE_pw_thread_loop_unlock(hotplug_loop);
     }
 }
 

--- a/src/audio/pipewire/SDL_pipewire.h
+++ b/src/audio/pipewire/SDL_pipewire.h
@@ -37,8 +37,9 @@ struct SDL_PrivateAudioData
     struct pw_context     *context;
     struct SDL_DataQueue  *buffer;
 
-    size_t buffer_period_size;
-    Sint32 stride; /* Bytes-per-frame */
+    size_t       buffer_period_size;
+    Sint32       stride; /* Bytes-per-frame */
+    SDL_atomic_t stream_initialized;
 };
 
 #endif /* SDL_pipewire_h_ */

--- a/src/audio/pipewire/SDL_pipewire.h
+++ b/src/audio/pipewire/SDL_pipewire.h
@@ -37,6 +37,7 @@ struct SDL_PrivateAudioData
     struct pw_context     *context;
     struct SDL_DataQueue  *buffer;
 
+    size_t buffer_period_size;
     Sint32 stride; /* Bytes-per-frame */
 };
 


### PR DESCRIPTION
A few Pipewire fixes and cleanups, including a fix for a race condition.

Since Pipewire starts it's own processing threads, we can wind up in the processing callbacks before all of the members of SDL_AudioDevice (callbackspec, work_buffer and stream) are allocated/initialized, as they aren't initialized until after the call to the driver's OpenDevice() function returns. We don't want to touch any of these variables in the callbacks until the device state is set to unpaused, which can only happen once initialization is fully complete.

Other than that, some redundant locks were removed and stream creation now blocks instead of spinning until the stream state is either ready or failed, as creating streams can sometimes take a bit of time and busy waiting for many milliseconds isn't ideal.