### PR TITLE
[KMSDRM] Minor Vulkan code adjustments regarding pointers and display index.

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -1015,7 +1015,7 @@ KMSDRM_GetDisplayModes(_THIS, SDL_VideoDisplay * display)
         SDL_DisplayModeData *modedata = SDL_calloc(1, sizeof(SDL_DisplayModeData));
 
         if (modedata) {
-          modedata->mode_index = i;
+            modedata->mode_index = i;
         }
 
         mode.w = conn->modes[i].hdisplay;


### PR DESCRIPTION
## Description
Made some small adjustments to KMSDRM Vulkan surface creation code.
-display_mode is already a pointer, so no need to use a pointer-to-pointer here.
-Get the display index from the display being used by the window, as we do in normal KMSDRM/GLES/OpenGL operation to support multiple displays, instead of always using display index 0.
-Some spacing was corrected here and there.

## Existing Issue(s)
I don't think this fixes any issue, but it's aimed to improve the quality of the code a bit.