### PR TITLE
Include ShellScalingApi.h when targeting Windows 8.1+ SDKs

### DIFF
--- a/src/video/windows/SDL_windowsvideo.h
+++ b/src/video/windows/SDL_windowsvideo.h
@@ -85,6 +85,8 @@ typedef enum MONITOR_DPI_TYPE {
     MDT_DEFAULT = MDT_EFFECTIVE_DPI
 } MONITOR_DPI_TYPE;
 
+#else
+#include <shellscalingapi.h>
 #endif /* WINVER < 0x0603 */
 
 typedef BOOL  (*PFNSHFullScreen)(HWND, DWORD);


### PR DESCRIPTION
According to Microsoft's documentation for [`MONITOR_DPI_TYPE`](https://docs.microsoft.com/en-us/windows/win32/api/shellscalingapi/ne-shellscalingapi-monitor_dpi_type), it is introduced in Windows 8.1 and defined in `ShellScalingApi.h`, which is never automatically included by `Windows.h`. However, there are no references to `ShellScalingApi.h` anywhere in the SDL codebase.

In `src/windows/video/SDL_windowsvideo.h` there is a copypasted definition for `MONITOR_DPI_TYPE` for when the Windows SDK version is less than Windows 8.1 (`#if WINVER < 0x0603`). However, there is no accompanying `#else` clause to `#include <ShellScalingApi.h>` when the header would be available. Thus, when compiling against a Windows SDK version of 8.1 or above, the code fails to compile due to the missing `MONITOR_DPI_TYPE` definition.

This has apparently been an issue that people have been [manually working around](https://forums.xamarin.com/discussion/comment/314180/#Comment_314180) for years. The copypasted definition was introduced in https://github.com/libsdl-org/SDL/commit/61c7415071479c20297612b0598253a186b453ae#diff-bff8f3e638d51e86cb6f0f42e2c527549d649951b7aa5ec4a539e865a5b57027R79-R88