### PR TITLE
Fix race condition that can lead to ENTER/LEAVE window events never firing

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -783,8 +783,16 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
                     }
                }
             }
-            SDL_SetMouseFocus(NULL);
         }
+
+        /* When WM_MOUSELEAVE is fired we can be assured that the cursor has left the window.
+           Regardless of relative mode, it is important that mouse focus is reset as there is a potential
+           race condition when in the process of leaving/entering relative mode, resulting in focus never
+           being lost. This then causes a cascading failure where SDL_WINDOWEVENT_ENTER / SDL_WINDOWEVENT_LEAVE
+           can stop firing permanently, due to the focus being in the wrong state and TrackMouseEvent never
+           resubscribing. */
+        SDL_SetMouseFocus(NULL);
+
         returnCode = 0;
         break;
 #endif /* WM_MOUSELEAVE */


### PR DESCRIPTION
## Summary

On windows, when toggling the state of RelativeMode rapidly, there is a high chance that `SDL_WINDOWEVENT_ENTER` / `SDL_WINDOWEVENT_LEAVE` events will stop firing indefinitely.

This aims to resolve that shortcoming by ensuring mouse focus state is correctly updated via `WM_MOUSELEAVE` events arriving via the windows event hook.

## Testing

I have tested this using the following code (built on top of my test project for reporting https://github.com/libsdl-org/SDL/issues/4165. Apologies for writing it in c#, my development environment is not set up completely for c++ development.

```csharp

using System;
using System.Diagnostics;
using SDL2;

namespace SDL2IsolatedRelativeModeTest
{
    class Program
    {
        static bool relative;

        static void Main(string[] args)
        {
            SDL.SDL_Init(SDL.SDL_INIT_VIDEO);

            SDL.SDL_CreateWindow("test window", 100, 100, 500, 500, SDL.SDL_WindowFlags.SDL_WINDOW_RESIZABLE);

            var stopwatch = new Stopwatch();
            stopwatch.Start();

            while (stopwatch.ElapsedMilliseconds < 10000)
            {
                while (SDL.SDL_PollEvent(out var e) > 0)
                {
                    switch (e.type)
                    {
                        case SDL.SDL_EventType.SDL_WINDOWEVENT:
                            switch (e.window.windowEvent)
                            {
                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_ENTER:
                                    Console.WriteLine($"SDL_WINDOWEVENT_ENTER");
                                    break;

                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_LEAVE:
                                    Console.WriteLine($"SDL_WINDOWEVENT_LEAVE");
                                    break;
                            }

                            break;

                        case SDL.SDL_EventType.SDL_MOUSEMOTION:
                            // switch relative mode every time an input event is received.
                            relative = !relative;
                            SDL.SDL_SetRelativeMouseMode(relative ? SDL.SDL_bool.SDL_TRUE : SDL.SDL_bool.SDL_FALSE);
                            break;
                    }
                }
            }
        }
    }
}


```

Due to the rapid toggling of relative mode, it takes only a second or two to reproduce the issue.

Current behaviour (on master):

https://user-images.githubusercontent.com/191335/113247580-4a3c2d80-92f6-11eb-9861-4702e79c5f08.mp4

Note that with almost no effort I can break the flow of window `ENTER`/`LEAVE` events.

Expected behaviour (on this branch):

https://user-images.githubusercontent.com/191335/113247826-bae34a00-92f6-11eb-97c7-69ed64fb1056.mp4

Note that the events continue to fire even after a lot of movement.

## Compatibility

As this change is contained within windows (and more specifically, `#ifdef WM_MOUSELEAVE`), I have tested on the latest Windows 10 insiders release. From a compatibility perspective, `WM_MOUSELEAVE` has been a thing [since Windows 2000](https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-mouseleave) so I'm not sure how far back requires regression testing.

I am working on testing against Windows 7 as an extra data point, and will update this issue when I can done so.

This aims to resolve https://github.com/ppy/osu/issues/12169.