### PR TITLE
Fix OS cursor unexpectedly returning to center on toggling relative mode

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -819,11 +819,10 @@ SDL_SetRelativeMouseMode(SDL_bool enabled)
     mouse->scale_accum_y = 0.0f;
 
     if (enabled && focusWindow) {
-        /* Center it in the focused window to prevent clicks from going through
-         * to background windows.
-         */
         SDL_SetMouseFocus(focusWindow);
-        SDL_WarpMouseInWindow(focusWindow, focusWindow->w/2, focusWindow->h/2);
+
+        if (mouse->relative_mode_warp)
+            SDL_WarpMouseInWindow(focusWindow, focusWindow->w/2, focusWindow->h/2);
     }
 
     if (mouse->focus) {

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -980,33 +980,12 @@ WIN_UpdateClipCursor(SDL_Window *window)
 
     if ((mouse->relative_mode || (window->flags & SDL_WINDOW_MOUSE_GRABBED)) &&
         (window->flags & SDL_WINDOW_INPUT_FOCUS)) {
-        if (mouse->relative_mode && !mouse->relative_mode_warp) {
-            if (GetWindowRect(data->hwnd, &rect)) {
-                LONG cx, cy;
-
-                cx = (rect.left + rect.right) / 2;
-                cy = (rect.top + rect.bottom) / 2;
-
-                /* Make an absurdly small clip rect */
-                rect.left = cx - 1;
-                rect.right = cx + 1;
-                rect.top = cy - 1;
-                rect.bottom = cy + 1;
-
-                if (SDL_memcmp(&rect, &clipped_rect, sizeof(rect)) != 0) {
-                    if (ClipCursor(&rect)) {
-                        data->cursor_clipped_rect = rect;
-                    }
-                }
-            }
-        } else {
-            if (GetClientRect(data->hwnd, &rect) && !IsRectEmpty(&rect)) {
-                ClientToScreen(data->hwnd, (LPPOINT) & rect);
-                ClientToScreen(data->hwnd, (LPPOINT) & rect + 1);
-                if (SDL_memcmp(&rect, &clipped_rect, sizeof(rect)) != 0) {
-                    if (ClipCursor(&rect)) {
-                        data->cursor_clipped_rect = rect;
-                    }
+        if (GetClientRect(data->hwnd, &rect) && !IsRectEmpty(&rect)) {
+            ClientToScreen(data->hwnd, (LPPOINT) & rect);
+            ClientToScreen(data->hwnd, (LPPOINT) & rect + 1);
+            if (SDL_memcmp(&rect, &clipped_rect, sizeof(rect)) != 0) {
+                if (ClipCursor(&rect)) {
+                    data->cursor_clipped_rect = rect;
                 }
             }
         }

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -162,7 +162,7 @@ WIN_SetWindowPositionInternal(_THIS, SDL_Window * window, UINT flags)
         top = HWND_NOTOPMOST;
     }
 
-    WIN_AdjustWindowRect(window, &x, &y, &w, &h, SDL_TRUE);    
+    WIN_AdjustWindowRect(window, &x, &y, &w, &h, SDL_TRUE);
 
     data->expected_resize = SDL_TRUE;
     SetWindowPos(hwnd, top, x, y, w, h, flags);
@@ -364,7 +364,7 @@ WIN_CreateWindow(_THIS, SDL_Window * window)
         return 0;
 #else
         return SDL_SetError("Could not create GLES window surface (EGL support not configured)");
-#endif /* SDL_VIDEO_OPENGL_EGL */ 
+#endif /* SDL_VIDEO_OPENGL_EGL */
     }
 #endif /* SDL_VIDEO_OPENGL_ES2 */
 
@@ -559,7 +559,7 @@ WIN_ShowWindow(_THIS, SDL_Window * window)
     DWORD style;
     HWND hwnd;
     int nCmdShow;
-    
+
     hwnd = ((SDL_WindowData *)window->driverdata)->hwnd;
     nCmdShow = SW_SHOW;
     style = GetWindowLong(hwnd, GWL_EXSTYLE);


### PR DESCRIPTION
## Summary

This aims to remove all cases of the cursor being "warped" to the center of the window when entering relative mode without `relative_mode_warp` being set. The goal here is to solve a race condition where the centering of the cursor can occasionally be accepted as a user input, causing the mouse to "jump" in position and cause an unexpected large delta. As mentioned in the issue. this only happens with high frequency toggling.

Please see each individual commit message for further rationale on the changes.

Closes https://github.com/libsdl-org/SDL/issues/4165.

## Testing

```csharp
using System;
using SDL2;

namespace SDL2IsolatedRelativeModeTest
{
    class Program
    {
        static bool relative;

        static void Main(string[] args)
        {
            SDL.SDL_Init(SDL.SDL_INIT_VIDEO);
            SDL.SDL_SetHint(SDL.SDL_HINT_EVENT_LOGGING, "2");

            SDL.SDL_CreateWindow("test window", 100, 100, 500, 500, SDL.SDL_WindowFlags.SDL_WINDOW_RESIZABLE);

            while (true)
            {
                while (SDL.SDL_PollEvent(out var e) > 0)
                {
                    if (e.type == SDL.SDL_EventType.SDL_MOUSEMOTION)
                    {
                        // switch relative mode every time an input event is received.
                        relative = !relative;
                        SDL.SDL_SetRelativeMouseMode(relative ? SDL.SDL_bool.SDL_TRUE : SDL.SDL_bool.SDL_FALSE);
                        Console.WriteLine($"Relative mode {relative}");
                    }
                }
            }
        }
    }
}
```

Before:


https://user-images.githubusercontent.com/191335/113379242-f001a200-93b3-11eb-9c45-03295232a005.mp4

After:


https://user-images.githubusercontent.com/191335/113379291-0c9dda00-93b4-11eb-9493-d49f3a7cc484.mp4

Note that I have only tested on windows so far. We will be deploying this (and #4264) to our live released over the coming week to get a better idea of whether this regresses in any edge case platform/software setups.