### PR TITLE
Support for intrinsics in MSW + Clang scenario.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -768,11 +768,6 @@ if(ASSEMBLY)
     set(HAVE_SSE3 TRUE)
     set(SDL_ASSEMBLY_ROUTINES 1)
   endif()
-# TODO:
-#else()
-#  if(USE_GCC OR USE_CLANG)
-#    list(APPEND EXTRA_CFLAGS "-mno-sse" "-mno-sse2" "-mno-sse3" "-mno-mmx")
-#  endif()
 endif()
 
 # TODO: Can't deactivate on FreeBSD? w/o LIBC, SDL_stdinc.h can't define
@@ -2511,7 +2506,11 @@ if (ASAN)
   asan_check_add_debug_flag("undefined")
   asan_check_add_debug_flag("vla-bound")
   asan_check_add_debug_flag("leak")
-  asan_check_add_debug_flag("object-size")
+  # The object size sanitizer has no effect on unoptimized builds on Clang,
+  # but causes warnings.
+  if((NOT USE_CLANG) OR (CMAKE_BUILD_TYPE STREQUAL ""))
+    asan_check_add_debug_flag("object-size")
+  endif()
 endif()
 
 ##### Tests #####

--- a/include/SDL_endian.h
+++ b/include/SDL_endian.h
@@ -30,7 +30,23 @@
 
 #include "SDL_stdinc.h"
 
-#if defined(_MSC_VER) && !defined(__clang__)
+#ifdef _MSC_VER
+/* As of Clang 11, '_m_prefetchw' is conflicting with the winnt.h's version,
+   so we define the needed '_m_prefetch' here as a pseudo-header, until the issue is fixed. */
+
+#ifdef __clang__
+#ifndef __PRFCHWINTRIN_H
+#define __PRFCHWINTRIN_H
+
+static __inline__ void __attribute__((__always_inline__, __nodebug__))
+_m_prefetch(void *__P)
+{
+  __builtin_prefetch (__P, 0, 3 /* _MM_HINT_T0 */);
+}
+
+#endif /* __PRFCHWINTRIN_H */
+#endif /* __clang__ */
+
 #include <intrin.h>
 #endif
 


### PR DESCRIPTION
This should be it. Utility polyfill is provided, removed the no-longer-needed conditionals. The linkage warning is also silenced.
