### PR TITLE
NULL passed to strcmp in Wayland_ShowMessageBox

### DIFF
--- a/src/video/wayland/SDL_waylandmessagebox.c
+++ b/src/video/wayland/SDL_waylandmessagebox.c
@@ -150,9 +150,11 @@ Wayland_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonid)
 
     /* Check which button got pressed */
     for (i = 0; i < messageboxdata->numbuttons; i += 1) {
-        if (SDL_strcmp(output, messageboxdata->buttons[i].text) == 0) {
-            *buttonid = i;
-            break;
+        if (messageboxdata->buttons[i].text != NULL) {
+            if (SDL_strcmp(output, messageboxdata->buttons[i].text) == 0) {
+                *buttonid = i;
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Check `messageboxdata->buttons[i].text` for NULL before passing it to `strcmp`.
It is checked in a previous loop (line 82), it should be checked here too.