### PR TITLE
Various fixes for Wayland clipboard support

### DIFF
--- a/src/video/wayland/SDL_waylandclipboard.c
+++ b/src/video/wayland/SDL_waylandclipboard.c
@@ -42,7 +42,7 @@ Wayland_SetClipboardText(_THIS, const char *text)
             if (text[0] != '\0') {
                 SDL_WaylandDataSource* source = Wayland_data_source_create(_this);
                 Wayland_data_source_add_data(source, TEXT_MIME, text,
-                                             strlen(text) + 1);
+                                             SDL_strlen(text) + 1);
 
                 status = Wayland_data_device_set_selection(data_device, source);
                 if (status != 0) {

--- a/src/video/wayland/SDL_waylandclipboard.c
+++ b/src/video/wayland/SDL_waylandclipboard.c
@@ -80,7 +80,8 @@ Wayland_GetClipboardText(_THIS)
                 if (length > 0) {
                     text = (char*) buffer;
                 }
-            } else if (data_device->selection_source != NULL) {
+            }
+            if (length == 0 && data_device->selection_source != NULL) {
                 buffer = Wayland_data_source_get_data(data_device->selection_source,
                                                       &length, TEXT_MIME, SDL_TRUE);
                 if (length > 0) {

--- a/src/video/wayland/SDL_waylandclipboard.c
+++ b/src/video/wayland/SDL_waylandclipboard.c
@@ -30,9 +30,9 @@ Wayland_SetClipboardText(_THIS, const char *text)
 {
     SDL_VideoData *video_data = NULL;
     SDL_WaylandDataDevice *data_device = NULL;
-    
+
     int status = 0;
- 
+
     if (_this == NULL || _this->driverdata == NULL) {
         status = SDL_SetError("Video driver uninitialized");
     } else {
@@ -67,7 +67,7 @@ Wayland_GetClipboardText(_THIS)
 
     void *buffer = NULL;
     size_t length = 0;
- 
+
     if (_this == NULL || _this->driverdata == NULL) {
         SDL_SetError("Video driver uninitialized");
     } else {
@@ -103,7 +103,7 @@ Wayland_HasClipboardText(_THIS)
     SDL_VideoData *video_data = NULL;
     SDL_WaylandDataDevice *data_device = NULL;
 
-    SDL_bool result = SDL_FALSE;    
+    SDL_bool result = SDL_FALSE;
     if (_this == NULL || _this->driverdata == NULL) {
         SDL_SetError("Video driver uninitialized");
     } else {

--- a/src/video/wayland/SDL_waylanddatamanager.c
+++ b/src/video/wayland/SDL_waylanddatamanager.c
@@ -204,7 +204,7 @@ mime_data_list_add(struct wl_list* list,
         } else {
             WAYLAND_wl_list_insert(list, &(mime_data->link));
 
-            mime_type_length = strlen(mime_type) + 1;
+            mime_type_length = SDL_strlen(mime_type) + 1;
             mime_data->mime_type = SDL_malloc(mime_type_length);
             if (mime_data->mime_type == NULL) {
                 status = SDL_OutOfMemory();

--- a/src/video/wayland/SDL_waylanddatamanager.c
+++ b/src/video/wayland/SDL_waylanddatamanager.c
@@ -36,6 +36,11 @@
 
 #include "SDL_waylanddyn.h"
 
+/* FIXME: This is arbitrary, but we want this to be less than a frame because
+ * any longer can potentially spin an infinite loop of PumpEvents (!)
+ */
+#define PIPE_MS_TIMEOUT 10
+
 static ssize_t
 write_pipe(int fd, const void* buffer, size_t total_length, size_t *pos)
 {
@@ -47,7 +52,7 @@ write_pipe(int fd, const void* buffer, size_t total_length, size_t *pos)
     sigset_t old_sig_set;
     struct timespec zerotime = {0};
 
-    ready = SDL_IOReady(fd, SDL_TRUE, 1 * 1000);
+    ready = SDL_IOReady(fd, SDL_TRUE, PIPE_MS_TIMEOUT);
 
     sigemptyset(&sig_set);
     sigaddset(&sig_set, SIGPIPE);  
@@ -93,7 +98,7 @@ read_pipe(int fd, void** buffer, size_t* total_length, SDL_bool null_terminate)
     ssize_t bytes_read = 0;
     size_t pos = 0;
 
-    ready = SDL_IOReady(fd, SDL_FALSE, 1 * 1000);
+    ready = SDL_IOReady(fd, SDL_FALSE, PIPE_MS_TIMEOUT);
   
     if (ready == 0) {
         bytes_read = SDL_SetError("Pipe timeout");

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -1192,15 +1192,6 @@ void Wayland_display_destroy_input(SDL_VideoData *d)
     d->input = NULL;
 }
 
-SDL_WaylandDataDevice* Wayland_get_data_device(struct SDL_WaylandInput *input)
-{
-    if (input == NULL) {
-        return NULL;
-    }
-
-    return input->data_device;
-}
-
 /* !!! FIXME: just merge these into display_handle_global(). */
 void Wayland_display_add_relative_pointer_manager(SDL_VideoData *d, uint32_t id)
 {

--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -85,8 +85,6 @@ extern void Wayland_add_data_device_manager(SDL_VideoData *d, uint32_t id, uint3
 extern void Wayland_display_add_input(SDL_VideoData *d, uint32_t id, uint32_t version);
 extern void Wayland_display_destroy_input(SDL_VideoData *d);
 
-extern SDL_WaylandDataDevice* Wayland_get_data_device(struct SDL_WaylandInput *input);
-
 extern void Wayland_display_add_pointer_constraints(SDL_VideoData *d, uint32_t id);
 extern void Wayland_display_destroy_pointer_constraints(SDL_VideoData *d);
 

--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -80,6 +80,8 @@ struct SDL_WaylandInput {
 
 extern void Wayland_PumpEvents(_THIS);
 
+extern void Wayland_add_data_device_manager(SDL_VideoData *d, uint32_t id, uint32_t version);
+
 extern void Wayland_display_add_input(SDL_VideoData *d, uint32_t id, uint32_t version);
 extern void Wayland_display_destroy_input(SDL_VideoData *d);
 

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -423,7 +423,7 @@ display_handle_global(void *data, struct wl_registry *registry, uint32_t id,
     } else if (strcmp(interface, "zwp_idle_inhibit_manager_v1") == 0) {
         d->idle_inhibit_manager = wl_registry_bind(d->registry, id, &zwp_idle_inhibit_manager_v1_interface, 1);
     } else if (strcmp(interface, "wl_data_device_manager") == 0) {
-        d->data_device_manager = wl_registry_bind(d->registry, id, &wl_data_device_manager_interface, SDL_min(3, version));
+        Wayland_add_data_device_manager(d, id, version);
     } else if (strcmp(interface, "zxdg_decoration_manager_v1") == 0) {
         d->decoration_manager = wl_registry_bind(d->registry, id, &zxdg_decoration_manager_v1_interface, 1);
 


### PR DESCRIPTION
This is mostly a preparation patchset for fixing Wayland clipboard support. 

For reasons I don't fully understand, this fixes #3724. I could see it passing 2 '\0' chars before, and now it doesn't? Valgrind revealed no sign of uninitialized memory before or after the patchset.

EDIT: Figured out what Wayland's deal was, now also fixes #3725.