### PR TITLE
wayland: Add unscaled resolutions to the display mode list

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -309,8 +309,8 @@ display_handle_done(void *data,
     SDL_zero(mode);
     mode.format = SDL_PIXELFORMAT_RGB888;
     if (driverdata->transform & WL_OUTPUT_TRANSFORM_90) {
-       mode.w = driverdata->height / driverdata->scale_factor;
-       mode.h = driverdata->width / driverdata->scale_factor;
+        mode.w = driverdata->height / driverdata->scale_factor;
+        mode.h = driverdata->width / driverdata->scale_factor;
     } else {
         mode.w = driverdata->width / driverdata->scale_factor;
         mode.h = driverdata->height / driverdata->scale_factor;


### PR DESCRIPTION
This adds an SDL_AddDisplayMode call to make the Wayland resolution list similar to macOS; the desktop mode should be scaled but we also want to provide unscaled resolutions provided by the server so that clients can do proper high-DPI support by targeting the display mode dimensions as drawable sizes, rather than window sizes.