### PR TITLE
wayland: Set the keymap in keyboard_handle_modifiers

### DIFF
--- a/src/video/wayland/SDL_waylandsym.h
+++ b/src/video/wayland/SDL_waylandsym.h
@@ -118,6 +118,13 @@ SDL_WAYLAND_SYM(enum xkb_state_component, xkb_state_update_mask, (struct xkb_sta
                       xkb_layout_index_t depressed_layout,\
                       xkb_layout_index_t latched_layout,\
                       xkb_layout_index_t locked_layout) )
+SDL_WAYLAND_SYM(void, xkb_keymap_key_for_each, (struct xkb_keymap *, xkb_keymap_key_iter_t, void*) )
+SDL_WAYLAND_SYM(int, xkb_keymap_key_get_syms_by_level, (struct xkb_keymap *,
+                                                        xkb_keycode_t,
+                                                        xkb_layout_index_t,
+                                                        xkb_layout_index_t,
+                                                        const xkb_keysym_t **) )
+SDL_WAYLAND_SYM(uint32_t, xkb_keysym_to_utf32, (xkb_keysym_t) )
 
 #undef SDL_WAYLAND_MODULE
 #undef SDL_WAYLAND_SYM


### PR DESCRIPTION
Wayland keyboard layouts are passed via the `group` parameter in `keyboard_handle_modifiers`, and map to `xkb_layout_index_t` in xkbcommon. This patch supports both initial and live-updated keyboard layouts. The translation in Wayland_keymap_iter is mostly ripped off the X11 backend.

Fixes #3471, fixes #4142. Partially addresses #4187, X11 still doesn't support live updates AFAIK.