### PR TITLE
wayland: Implement basic window move events via wl_surface_listener.

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.h
+++ b/src/video/wayland/SDL_waylandvideo.h
@@ -39,6 +39,7 @@
 #include <EGL/egl.h>
 #include "wayland-util.h"
 
+#include "../SDL_sysvideo.h"
 #include "../../core/linux/SDL_dbus.h"
 #include "../../core/linux/SDL_ime.h"
 
@@ -93,6 +94,7 @@ typedef struct {
     struct wl_output *output;
     float scale_factor;
     int width, height, refresh, transform;
+    SDL_VideoDisplay placeholder;
     SDL_bool done;
 } SDL_WaylandOutputData;
 


### PR DESCRIPTION
This unearthed an unspeakably large amount of bugs in the wl_output enumerator,
notably the fact that the wl_output user pointer was to temporary memory!
This was "fixed" in e862856, and was then pointed out as a leak in 4183211,
which was undone in d9ba204. The busted fix was correct that the malloc was an
issue, but wrong about _why_; SDL_AddVideoDisplay copies by value and does not
reuse the pointer, so generally you want your VideoDisplay to be on the stack,
but of course the callbacks don't allow that, so a malloc was a workaround. But
we can do better and just host our temporary display inside WaylandOutputData
because that will be persistent while also not leaking.

Wait, wasn't I talking about move events? Right, that: wl_surface_listener does
at least give us the ability to know what monitor we're on, even though we have
no idea where we are on the monitor. All we need to do is check the wl_output
against the display list and then push a move event that both indicates the
correct display while also not being _too_ much of a lie (but enough of a lie
to where our event doesn't get discarded as "undefined" or whatever). The index
check for the video display is what spawned the great nightmare you see before
you; aside from the bugfix this is actually a really basic patch.

Fixes #4038 by eliminating the leak.
Fixes #3549 by ensuring that fullscreen sets are consistent with window monitor position.
Fixes #3736 because we _really_ need to use wl_output for fullscreen.