### PR TITLE
video: Prefer Wayland over X11

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -61,11 +61,11 @@ static VideoBootStrap *bootstrap[] = {
 #if SDL_VIDEO_DRIVER_COCOA
     &COCOA_bootstrap,
 #endif
-#if SDL_VIDEO_DRIVER_X11
-    &X11_bootstrap,
-#endif
 #if SDL_VIDEO_DRIVER_WAYLAND
     &Wayland_bootstrap,
+#endif
+#if SDL_VIDEO_DRIVER_X11
+    &X11_bootstrap,
 #endif
 #if SDL_VIDEO_DRIVER_VIVANTE
     &VIVANTE_bootstrap,
@@ -4247,11 +4247,11 @@ SDL_IsScreenKeyboardShown(SDL_Window *window)
 #if SDL_VIDEO_DRIVER_UIKIT
 #include "uikit/SDL_uikitmessagebox.h"
 #endif
-#if SDL_VIDEO_DRIVER_X11
-#include "x11/SDL_x11messagebox.h"
-#endif
 #if SDL_VIDEO_DRIVER_WAYLAND
 #include "wayland/SDL_waylandmessagebox.h"
+#endif
+#if SDL_VIDEO_DRIVER_X11
+#include "x11/SDL_x11messagebox.h"
 #endif
 #if SDL_VIDEO_DRIVER_HAIKU
 #include "haiku/SDL_bmessagebox.h"
@@ -4360,17 +4360,17 @@ SDL_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonid)
         retval = 0;
     }
 #endif
-#if SDL_VIDEO_DRIVER_X11
-    if (retval == -1 &&
-        SDL_MessageboxValidForDriver(messageboxdata, SDL_SYSWM_X11) &&
-        X11_ShowMessageBox(messageboxdata, buttonid) == 0) {
-        retval = 0;
-    }
-#endif
 #if SDL_VIDEO_DRIVER_WAYLAND
     if (retval == -1 &&
         SDL_MessageboxValidForDriver(messageboxdata, SDL_SYSWM_WAYLAND) &&
         Wayland_ShowMessageBox(messageboxdata, buttonid) == 0) {
+        retval = 0;
+    }
+#endif
+#if SDL_VIDEO_DRIVER_X11
+    if (retval == -1 &&
+        SDL_MessageboxValidForDriver(messageboxdata, SDL_SYSWM_X11) &&
+        X11_ShowMessageBox(messageboxdata, buttonid) == 0) {
         retval = 0;
     }
 #endif


### PR DESCRIPTION
This is a ~~draft~~ patch that will (at last) prioritize the Wayland video driver over X11. This is here purely for internal testing only and is NOT meant for wider community testing; to test SDL Wayland support you should set `SDL_VIDEODRIVER=wayland` instead.

Click [here](https://github.com/libsdl-org/SDL/issues?q=assignee%3Aflibitijibibo+is%3Aopen) for the SDL Wayland bug tracker.

The Big List of Annoying Things That Aren't SDL's Fault:
- [Event queue overflow issues (server-side, also affects Xwayland)](https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/188)
- [Steam overlay support](https://github.com/ValveSoftware/steam-for-linux/issues/8020)
- [NVIDIA doesn't support native Wayland Vulkan yet](https://forums.developer.nvidia.com/t/vulkaninfo-crashes-in-wayland-session-with-driver-470-42-01/181757)

The Big List of EGL Stuff That Might Be a Problem:

- [SwapBuffers timeout support](https://gitlab.freedesktop.org/mesa/mesa/-/issues/4932)

This Big List of Things in X11 That Wayland Might Also Want but It's Not a Huge Deal:

- [XCURSOR_THEME/SIZE protocol](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/21) (we still use the environment variables)
- GetDisplayUsableBounds - [xdg-shell v4?](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/41)
- SetWindowIcon - xdg-decoration/libdecor?
- GetWindowBordersSize - xdg-decoration/libdecor?

Known Issues:
- [GNOME 40.3 doesn't toggle fullscreen correctly with CSD](https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/1795)

Fixes #2710. Fixes #4988.