### PR TITLE
The Jackbox Wayland Pack

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -62,6 +62,8 @@ static void
 Wayland_GetDisplayModes(_THIS, SDL_VideoDisplay *sdl_display);
 static int
 Wayland_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode);
+static int
+Wayland_GetDisplayBounds(_THIS, SDL_VideoDisplay *display, SDL_Rect *rect);
 
 static void
 Wayland_VideoQuit(_THIS);
@@ -179,6 +181,7 @@ Wayland_CreateDevice(int devindex)
     device->VideoQuit = Wayland_VideoQuit;
     device->SetDisplayMode = Wayland_SetDisplayMode;
     device->GetDisplayModes = Wayland_GetDisplayModes;
+    device->GetDisplayBounds = Wayland_GetDisplayBounds;
     device->GetWindowWMInfo = Wayland_GetWindowWMInfo;
     device->SuspendScreenSaver = Wayland_SuspendScreenSaver;
 
@@ -251,6 +254,8 @@ display_handle_geometry(void *data,
 {
     SDL_WaylandOutputData *driverdata = data;
 
+    driverdata->x = x;
+    driverdata->y = y;
     driverdata->placeholder.name = SDL_strdup(model);
     driverdata->transform = transform;
 }
@@ -511,6 +516,17 @@ static int
 Wayland_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode)
 {
     return SDL_Unsupported();
+}
+
+static int
+Wayland_GetDisplayBounds(_THIS, SDL_VideoDisplay *display, SDL_Rect *rect)
+{
+    SDL_WaylandOutputData *driverdata = (SDL_WaylandOutputData *)display->driverdata;
+    rect->x = driverdata->x;
+    rect->y = driverdata->y;
+    rect->w = display->current_mode.w;
+    rect->h = display->current_mode.h;
+    return 0;
 }
 
 void

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -205,6 +205,7 @@ Wayland_CreateDevice(int devindex)
     device->SetWindowSize = Wayland_SetWindowSize;
     device->SetWindowMinimumSize = Wayland_SetWindowMinimumSize;
     device->SetWindowMaximumSize = Wayland_SetWindowMaximumSize;
+    device->SetWindowModalFor = Wayland_SetWindowModalFor;
     device->SetWindowTitle = Wayland_SetWindowTitle;
     device->DestroyWindow = Wayland_DestroyWindow;
     device->SetWindowHitTest = Wayland_SetWindowHitTest;

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -58,10 +58,6 @@
 static int
 Wayland_VideoInit(_THIS);
 
-static void
-Wayland_GetDisplayModes(_THIS, SDL_VideoDisplay *sdl_display);
-static int
-Wayland_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode);
 static int
 Wayland_GetDisplayBounds(_THIS, SDL_VideoDisplay *display, SDL_Rect *rect);
 
@@ -179,8 +175,6 @@ Wayland_CreateDevice(int devindex)
     /* Set the function pointers */
     device->VideoInit = Wayland_VideoInit;
     device->VideoQuit = Wayland_VideoQuit;
-    device->SetDisplayMode = Wayland_SetDisplayMode;
-    device->GetDisplayModes = Wayland_GetDisplayModes;
     device->GetDisplayBounds = Wayland_GetDisplayBounds;
     device->GetWindowWMInfo = Wayland_GetWindowWMInfo;
     device->SuspendScreenSaver = Wayland_SuspendScreenSaver;
@@ -503,19 +497,6 @@ Wayland_VideoInit(_THIS)
 #endif
 
     return 0;
-}
-
-static void
-Wayland_GetDisplayModes(_THIS, SDL_VideoDisplay *sdl_display)
-{
-    // Nothing to do here, everything was already done in the wl_output
-    // callbacks.
-}
-
-static int
-Wayland_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode)
-{
-    return SDL_Unsupported();
 }
 
 static int

--- a/src/video/wayland/SDL_waylandvideo.h
+++ b/src/video/wayland/SDL_waylandvideo.h
@@ -93,7 +93,7 @@ typedef struct {
 typedef struct {
     struct wl_output *output;
     float scale_factor;
-    int width, height, refresh, transform;
+    int x, y, width, height, refresh, transform;
     SDL_VideoDisplay placeholder;
     SDL_bool done;
 } SDL_WaylandOutputData;

--- a/src/video/wayland/SDL_waylandvideo.h
+++ b/src/video/wayland/SDL_waylandvideo.h
@@ -94,6 +94,8 @@ typedef struct {
     struct wl_output *output;
     float scale_factor;
     int x, y, width, height, refresh, transform;
+    int physical_width, physical_height;
+    float ddpi, hdpi, vdpi;
     SDL_VideoDisplay placeholder;
     SDL_bool done;
 } SDL_WaylandOutputData;

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -681,8 +681,11 @@ Wayland_RestoreWindow(_THIS, SDL_Window * window)
     SDL_WindowData *wind = window->driverdata;
     const SDL_VideoData *viddata = (const SDL_VideoData *) _this->driverdata;
 
+    /* Note that xdg-shell does NOT provide a way to unset minimize! */
     if (viddata->shell.xdg) {
+        xdg_toplevel_unset_maximized(wind->shell_surface.xdg.roleobj.toplevel);
     } else if (viddata->shell.zxdg) {
+        zxdg_toplevel_v6_unset_maximized(wind->shell_surface.zxdg.roleobj.toplevel);
     } else {
         wl_shell_surface_set_toplevel(wind->shell_surface.wl);
     }

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -595,6 +595,27 @@ Wayland_SetWindowHitTest(SDL_Window *window, SDL_bool enabled)
     return 0;  /* just succeed, the real work is done elsewhere. */
 }
 
+int
+Wayland_SetWindowModalFor(_THIS, SDL_Window *modal_window, SDL_Window *parent_window)
+{
+    const SDL_VideoData *viddata = (const SDL_VideoData *) _this->driverdata;
+    SDL_WindowData *modal_data = modal_window->driverdata;
+    SDL_WindowData *parent_data = parent_window->driverdata;
+
+    if (viddata->shell.xdg) {
+        xdg_toplevel_set_parent(modal_data->shell_surface.xdg.roleobj.toplevel,
+                                parent_data->shell_surface.xdg.roleobj.toplevel);
+    } else if (viddata->shell.zxdg) {
+        zxdg_toplevel_v6_set_parent(modal_data->shell_surface.zxdg.roleobj.toplevel,
+                                    parent_data->shell_surface.zxdg.roleobj.toplevel);
+    } else {
+        return SDL_Unsupported();
+    }
+
+    WAYLAND_wl_display_flush( ((SDL_VideoData*)_this->driverdata)->display );
+    return 0;
+}
+
 void Wayland_ShowWindow(_THIS, SDL_Window *window)
 {
     SDL_WaylandOutputData *driverdata = (SDL_WaylandOutputData *) SDL_GetDisplayForWindow(window)->driverdata;

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -99,6 +99,7 @@ extern int Wayland_CreateWindow(_THIS, SDL_Window *window);
 extern void Wayland_SetWindowSize(_THIS, SDL_Window * window);
 extern void Wayland_SetWindowMinimumSize(_THIS, SDL_Window * window);
 extern void Wayland_SetWindowMaximumSize(_THIS, SDL_Window * window);
+extern int Wayland_SetWindowModalFor(_THIS, SDL_Window * modal_window, SDL_Window * parent_window);
 extern void Wayland_SetWindowTitle(_THIS, SDL_Window * window);
 extern void Wayland_DestroyWindow(_THIS, SDL_Window *window);
 extern void Wayland_SuspendScreenSaver(_THIS);


### PR DESCRIPTION
A random grab bag of commits for Wayland:

- GetDisplayBounds and GetDisplayDPI implemented (they were literally passed right to us, woops)
- Found a couple functions that SDL_video.c doesn't need from us, stripped those out
- RestoreWindow was a stub for some reason, fixed that for maximize windows (minimized windows, we're screwed)
- Threw in SetWindowModalFor because it turns out toplevel makes this easy to do

Nothing to see here, unlike HideWindow which will be a gigantic refactor (which is why I'm doing this now).