### PR TITLE
Reimplement wayland message box function with execvp. 

### DIFF
--- a/src/video/wayland/SDL_waylandmessagebox.c
+++ b/src/video/wayland/SDL_waylandmessagebox.c
@@ -167,7 +167,7 @@ Wayland_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonid)
                     for (i = 0; i < messageboxdata->numbuttons; i += 1) {
                         if (messageboxdata->buttons[i].text != NULL) {
                             if (SDL_strcmp(output, messageboxdata->buttons[i].text) == 0) {
-                                *buttonid = i;
+                                *buttonid = messageboxdata->buttons[i].buttonid;
                                 break;
                             }
                         }

--- a/src/video/wayland/SDL_waylandmessagebox.c
+++ b/src/video/wayland/SDL_waylandmessagebox.c
@@ -48,9 +48,9 @@ Wayland_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonid)
 
     pid1 = fork();
     if (pid1 == 0) {  /* child process */
-        int argc = 4, i;
-        const char* argv[4 + 2/* icon name */ + 2/* title */ + 2/* message */ + 2*MAX_BUTTONS + 1/* NULL */] = {
-            "zenity", "--question", "--switch", "--no-wrap",
+        int argc = 5, i;
+        const char* argv[5 + 2/* icon name */ + 2/* title */ + 2/* message */ + 2*MAX_BUTTONS + 1/* NULL */] = {
+            "zenity", "--question", "--switch", "--no-wrap", "--no-markup"
         };
 
         close(fd_pipe[0]); /* no reading from pipe */

--- a/src/video/wayland/SDL_waylandmessagebox.c
+++ b/src/video/wayland/SDL_waylandmessagebox.c
@@ -25,9 +25,10 @@
 
 #include "SDL.h"
 #include <stdlib.h> /* fgets */
-#include <stdio.h>
-#include <unistd.h>
-#include <sys/wait.h>
+#include <stdio.h> /* FILE, STDOUT_FILENO, fdopen, fclose */
+#include <unistd.h> /* pid_t, pipe, fork, close, dup2, execvp, _exit, EXIT_FAILURE */
+#include <sys/wait.h> /* waitpid, WIFEXITED, WEXITSTATUS */
+#include <string.h> /* strerr */
 #include <errno.h>
 
 #define MAX_BUTTONS             8       /* Maximum number of buttons supported */
@@ -62,14 +63,14 @@ Wayland_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonid)
         argv[argc++] = "--icon-name";
         switch (messageboxdata->flags) {
         case SDL_MESSAGEBOX_ERROR:
-            argv[argc++] = "error";
+            argv[argc++] = "dialog-error";
             break;
         case SDL_MESSAGEBOX_WARNING:
-            argv[argc++] = "warning";
+            argv[argc++] = "dialog-warning";
             break;
         case SDL_MESSAGEBOX_INFORMATION:
         default:
-            argv[argc++] = "information";
+            argv[argc++] = "dialog-information";
             break;
         }
 
@@ -100,7 +101,7 @@ Wayland_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonid)
         /* const casting argv is fine:
          * https://pubs.opengroup.org/onlinepubs/9699919799/functions/fexecve.html -> rational
          */
-        execvp("zenity", argv);
+        execvp("zenity", (char **)argv);
         _exit(EXIT_FAILURE);
     } else if (pid1 < 0) {
         close(fd_pipe[0]);


### PR DESCRIPTION
Previous version used `popen` which required to sanitize user-provided text. Not sanitizing text could cause failure if it included a `"` or command injection with \`cmd\`.

This new version launches zenity with `execvp` so we don't need to sanitize. It then reads pressed button from a pipe.

Fix #4308