### PR TITLE
wayland: Refactor toplevel mapping, implement HideWindow

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -331,11 +331,21 @@ ProcessHitTest(struct SDL_WaylandInput *input, uint32_t serial)
         switch (rc) {
             case SDL_HITTEST_DRAGGABLE:
                 if (input->display->shell.xdg) {
-                    xdg_toplevel_move(window_data->shell_surface.xdg.roleobj.toplevel, input->seat, serial);
+                    if (window_data->shell_surface.xdg.roleobj.toplevel) {
+                        xdg_toplevel_move(window_data->shell_surface.xdg.roleobj.toplevel,
+                                          input->seat,
+                                          serial);
+                    }
                 } else if (input->display->shell.zxdg) {
-                    zxdg_toplevel_v6_move(window_data->shell_surface.zxdg.roleobj.toplevel, input->seat, serial);
+                    if (window_data->shell_surface.zxdg.roleobj.toplevel) {
+                        zxdg_toplevel_v6_move(window_data->shell_surface.zxdg.roleobj.toplevel,
+                                              input->seat,
+                                              serial);
+                    }
                 } else {
-                    wl_shell_surface_move(window_data->shell_surface.wl, input->seat, serial);
+                    if (window_data->shell_surface.wl) {
+                        wl_shell_surface_move(window_data->shell_surface.wl, input->seat, serial);
+                    }
                 }
                 return SDL_TRUE;
 
@@ -348,11 +358,23 @@ ProcessHitTest(struct SDL_WaylandInput *input, uint32_t serial)
             case SDL_HITTEST_RESIZE_BOTTOMLEFT:
             case SDL_HITTEST_RESIZE_LEFT:
                 if (input->display->shell.xdg) {
-                    xdg_toplevel_resize(window_data->shell_surface.xdg.roleobj.toplevel, input->seat, serial, directions_zxdg[rc - SDL_HITTEST_RESIZE_TOPLEFT]);
+                    if (window_data->shell_surface.xdg.roleobj.toplevel) {
+                        xdg_toplevel_resize(window_data->shell_surface.xdg.roleobj.toplevel,
+                                            input->seat,
+                                            serial,
+                                            directions_zxdg[rc - SDL_HITTEST_RESIZE_TOPLEFT]);
+                    }
                 } else if (input->display->shell.zxdg) {
-                    zxdg_toplevel_v6_resize(window_data->shell_surface.zxdg.roleobj.toplevel, input->seat, serial, directions_zxdg[rc - SDL_HITTEST_RESIZE_TOPLEFT]);
+                    if (window_data->shell_surface.zxdg.roleobj.toplevel) {
+                        zxdg_toplevel_v6_resize(window_data->shell_surface.zxdg.roleobj.toplevel,
+                                                input->seat,
+                                                serial,
+                                                directions_zxdg[rc - SDL_HITTEST_RESIZE_TOPLEFT]);
+                    }
                 } else {
-                    wl_shell_surface_resize(window_data->shell_surface.wl, input->seat, serial, directions_wl[rc - SDL_HITTEST_RESIZE_TOPLEFT]);
+                    if (window_data->shell_surface.wl) {
+                        wl_shell_surface_resize(window_data->shell_surface.wl, input->seat, serial, directions_wl[rc - SDL_HITTEST_RESIZE_TOPLEFT]);
+                    }
                 }
                 return SDL_TRUE;
 

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -198,6 +198,7 @@ Wayland_CreateDevice(int devindex)
 
     device->CreateSDLWindow = Wayland_CreateWindow;
     device->ShowWindow = Wayland_ShowWindow;
+    device->HideWindow = Wayland_HideWindow;
     device->SetWindowFullscreen = Wayland_SetWindowFullscreen;
     device->MaximizeWindow = Wayland_MaximizeWindow;
     device->MinimizeWindow = Wayland_MinimizeWindow;

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -85,6 +85,7 @@ typedef struct {
 } SDL_WindowData;
 
 extern void Wayland_ShowWindow(_THIS, SDL_Window *window);
+extern void Wayland_HideWindow(_THIS, SDL_Window *window);
 extern void Wayland_SetWindowFullscreen(_THIS, SDL_Window * window,
                                         SDL_VideoDisplay * _display,
                                         SDL_bool fullscreen);


### PR DESCRIPTION
This moves around the xdg_toplevel management in a way that allows us to implement HideWindow/ShowWindow properly.

For the most part this actually ended up being isolated from the rest of the driver; we have some early returns when the toplevel hasn't been made yet but it turns out it's more robust to just push all window state at ShowWindow time anyway. As a result this is really just changing the location and not really changing core functionality. The one exception is an extremely annoying behavior in the Wayland protocol where you have to manually detach any buffers from the wl_surface when creating the toplevel a second time, even though unmapping is supposed to be a full reset.

This was tested in both windowed/fullscreen mode on GNOME and Plasma and behavior was consistent.