### PR TITLE
egl: Reject attempts to set negative swap intervals

### DIFF
--- a/src/video/SDL_egl.c
+++ b/src/video/SDL_egl.c
@@ -1087,6 +1087,13 @@ SDL_EGL_SetSwapInterval(_THIS, int interval)
     if (!_this->egl_data) {
         return SDL_SetError("EGL not initialized");
     }
+
+    /* FIXME: Revisit this check when EGL_EXT_swap_control_tear is published:
+     * https://github.com/KhronosGroup/EGL-Registry/pull/113
+     */
+    if (interval < 0) {
+        return SDL_SetError("Late swap tearing currently unsupported");
+    }
     
     status = _this->egl_data->eglSwapInterval(_this->egl_data->egl_display, interval);
     if (status == EGL_TRUE) {


### PR DESCRIPTION
This is similar to the check we have in the Cocoa video driver, where we have to catch attempts to go below 0 in SDL_GL_SetSwapInterval. Without this, some doofus working on an XNA reimplementation might accidentally pass -1 to eglSwapInterval where the spec silently clamps the input value to EGL_MIN_SWAP_INTERVAL and returns success, leading all GLES and Wayland contexts to run without vsync on for several years totally unnoticed.

I'm helping with an EGL_EXT_swap_control_tear extension, but it's still under review. We can add support for that when it's done.