### PR TITLE
Minor fixes to Wayland SwapWindow patch

### DIFF
--- a/src/video/wayland/SDL_waylandopengles.c
+++ b/src/video/wayland/SDL_waylandopengles.c
@@ -116,8 +116,9 @@ Wayland_GLES_SwapWindow(_THIS, SDL_Window *window)
 
     /* Control swap interval ourselves. See comments on Wayland_GLES_SetSwapInterval */
     if (swap_interval != 0) {
-        const Uint32 max_wait = SDL_GetTicks() + 100;  /* ~10 fps, so we'll progress even if throttled to zero. */
         struct wl_display *display = ((SDL_VideoData *)_this->driverdata)->display;
+        SDL_VideoDisplay *sdldisplay = SDL_GetDisplayForWindow(window);
+        const Uint32 max_wait = SDL_GetTicks() + (10000 / sdldisplay->current_mode.refresh_rate);  /* ~10 frames, so we'll progress even if throttled to zero. */
         while ((SDL_AtomicGet(&data->swap_interval_ready) == 0) && (!SDL_TICKS_PASSED(SDL_GetTicks(), max_wait))) {
             /* !!! FIXME: this is just the crucial piece of Wayland_PumpEvents */
             WAYLAND_wl_display_flush(display);

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -1012,8 +1012,14 @@ int Wayland_CreateWindow(_THIS, SDL_Window *window)
         wl_compositor_create_surface(c->compositor);
     wl_surface_add_listener(data->surface, &surface_listener, data);
 
-    /* fire a callback when the compositor wants a new frame rendered. */
-    wl_callback_add_listener(wl_surface_frame(data->surface), &surface_frame_listener, data);
+    /* Fire a callback when the compositor wants a new frame rendered.
+     * Right now this only matters for OpenGL; we use this callback to add a
+     * wait timeout that avoids getting deadlocked by the compositor when the
+     * window isn't visible.
+     */
+    if (window->flags & SDL_WINDOW_OPENGL) {
+        wl_callback_add_listener(wl_surface_frame(data->surface), &surface_frame_listener, data);
+    }
 
 #ifdef SDL_VIDEO_DRIVER_WAYLAND_QT_TOUCH
     if (c->surface_extension) {


### PR DESCRIPTION
This fixes a couple issues I had with the original patch:

- The 100ms timeout is largely arbitrary and doesn't make sense for every scenario - in particular, we can assume that higher refresh rates don't need to wait as long because the callback should fire way sooner than it would elsewhere, so we can reduce the wait time as a result.
- The callback added only works for OpenGL, so let's run less code for Vulkan windows that aren't helped by this patch.