### PR TITLE
Fix build without dlfcn.h

### DIFF
--- a/src/dynapi/SDL_dynapi.h
+++ b/src/dynapi/SDL_dynapi.h
@@ -43,7 +43,9 @@
 #include "TargetConditionals.h"
 #endif
 
-#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE  /* probably not useful on iOS. */
+#if (defined(__MACOSX__) || defined(__IPHONEOS__) || defined(__LINUX__)) && !defined(SDL_LOADSO_DLOPEN) /* can't be used if the toolchain does not support dlfcn.h. */
+#define SDL_DYNAMIC_API 0
+#elif defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE  /* probably not useful on iOS. */
 #define SDL_DYNAMIC_API 0
 #elif defined(__native_client__) && __native_client__  /* probably not useful on NACL. */
 #define SDL_DYNAMIC_API 0

--- a/src/thread/pthread/SDL_systhread.c
+++ b/src/thread/pthread/SDL_systhread.c
@@ -41,7 +41,7 @@
 #include "../../core/linux/SDL_dbus.h"
 #endif /* __LINUX__ */
 
-#if defined(__LINUX__) || defined(__MACOSX__) || defined(__IPHONEOS__)
+#if (defined(__LINUX__) || defined(__MACOSX__) || defined(__IPHONEOS__)) && defined(SDL_LOADSO_DLOPEN)
 #include <dlfcn.h>
 #ifndef RTLD_DEFAULT
 #define RTLD_DEFAULT NULL
@@ -78,10 +78,10 @@ RunThread(void *data)
     return NULL;
 }
 
-#if defined(__MACOSX__) || defined(__IPHONEOS__)
+#if (defined(__MACOSX__) || defined(__IPHONEOS__)) && defined(SDL_LOADSO_DLOPEN)
 static SDL_bool checked_setname = SDL_FALSE;
 static int (*ppthread_setname_np)(const char*) = NULL;
-#elif defined(__LINUX__)
+#elif defined(__LINUX__) && defined(SDL_LOADSO_DLOPEN)
 static SDL_bool checked_setname = SDL_FALSE;
 static int (*ppthread_setname_np)(pthread_t, const char*) = NULL;
 #endif
@@ -91,7 +91,7 @@ SDL_SYS_CreateThread(SDL_Thread * thread)
     pthread_attr_t type;
 
     /* do this here before any threads exist, so there's no race condition. */
-    #if defined(__MACOSX__) || defined(__IPHONEOS__) || defined(__LINUX__)
+    #if (defined(__MACOSX__) || defined(__IPHONEOS__) || defined(__LINUX__)) && defined(SDL_LOADSO_DLOPEN)
     if (!checked_setname) {
         void *fn = dlsym(RTLD_DEFAULT, "pthread_setname_np");
         #if defined(__MACOSX__) || defined(__IPHONEOS__)
@@ -131,7 +131,7 @@ SDL_SYS_SetupThread(const char *name)
 #endif /* !__NACL__ */
 
     if (name != NULL) {
-        #if defined(__MACOSX__) || defined(__IPHONEOS__) || defined(__LINUX__)
+        #if defined(__MACOSX__) || defined(__IPHONEOS__) || defined(__LINUX__) && defined(SDL_LOADSO_DLOPEN)
         SDL_assert(checked_setname);
         if (ppthread_setname_np != NULL) {
             #if defined(__MACOSX__) || defined(__IPHONEOS__)


### PR DESCRIPTION
Fix the following build failures when `dlfcn.h` is not available on the toolchain (e.g. uclibc toolchain configured without dynamic library support):

```
sdl2-2.0.14/src/dynapi/SDL_dynapi.c:234:10: fatal error: dlfcn.h: No such file or directory
  234 | #include <dlfcn.h>
      |          ^~~~~~~~~

sdl2-2.0.14/src/thread/pthread/SDL_systhread.c:45:10: fatal error: dlfcn.h: No such file or directory
   45 | #include <dlfcn.h>
      |          ^~~~~~~~~
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>