### PR TITLE
Fixed microphone randomly stop working

### DIFF
--- a/src/audio/wasapi/SDL_wasapi.c
+++ b/src/audio/wasapi/SDL_wasapi.c
@@ -306,8 +306,14 @@ WASAPI_WaitDevice(_THIS)
             UINT32 padding = 0;
             if (!WasapiFailed(this, IAudioClient_GetCurrentPadding(this->hidden->client, &padding))) {
                 /*SDL_Log("WASAPI EVENT! padding=%u maxpadding=%u", (unsigned int)padding, (unsigned int)maxpadding);*/
-                if (padding <= maxpadding) {
-                    break;
+                if (this->iscapture) {
+                    if (padding > 0) {
+                        break;
+                    }
+                } else {
+                    if (padding <= maxpadding) {
+                        break;
+                    }
                 }
             }
         } else if (waitResult != WAIT_TIMEOUT) {


### PR DESCRIPTION
WASAPI_WaitDevice is used for audio playback and capture, but needs to
behave slighty different.
For playback `GetCurrentPadding` returns the padding which is already
queued, so WaitDevice should return when buffer length falls below the
buffer threshold (`maxpadding`).
For capture `GetCurrentPadding` returns the available data which can be
read, so WaitDevice can return as soon as any data is available.

In the old implementation WaitDevice could suddenly hang. This is
because on many capture devices the buffer (`padding`) wasn't filled
fast enough to surpass `maxpadding`. But if at one point (due to unlucky
timing) more than maxpadding frames were available, WaitDevice would not
return anymore.

## Existing Issue(s)
Issue #3234 is probably related to this.
