### PR TITLE
configuration updates for dlopen:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,13 +303,11 @@ if(EMSCRIPTEN)
   set(SDL_ATOMIC_ENABLED_BY_DEFAULT OFF)
   set(SDL_LOADSO_ENABLED_BY_DEFAULT OFF)
   set(SDL_CPUINFO_ENABLED_BY_DEFAULT OFF)
-  set(SDL_DLOPEN_ENABLED_BY_DEFAULT OFF)
 endif()
 
 if(VITA)
   set(SDL_SHARED_ENABLED_BY_DEFAULT OFF)
   set(SDL_LOADSO_ENABLED_BY_DEFAULT OFF)
-  set(SDL_DLOPEN_ENABLED_BY_DEFAULT OFF)
 endif()
 
 # When defined, respect CMake's BUILD_SHARED_LIBS setting:
@@ -365,7 +363,6 @@ set_option(VIDEO_OPENGL        "Include OpenGL support" ON)
 set_option(VIDEO_OPENGLES      "Include OpenGL ES support" ON)
 set_option(PTHREADS            "Use POSIX threads for multi-threading" ${SDL_PTHREADS_ENABLED_BY_DEFAULT})
 dep_option(PTHREADS_SEM        "Use pthread semaphores" ON "PTHREADS" OFF)
-set_option(SDL_DLOPEN          "Use dlopen for shared object loading" ${SDL_DLOPEN_ENABLED_BY_DEFAULT})
 dep_option(OSS                 "Support the OSS audio API" ON "UNIX_SYS OR RISCOS" OFF)
 set_option(ALSA                "Support the ALSA audio API" ${UNIX_SYS})
 dep_option(ALSA_SHARED         "Dynamically load ALSA audio support" ON "ALSA" OFF)
@@ -926,11 +923,6 @@ if(SDL_HAPTIC)
 endif()
 
 
-# TODO: in configure.ac, the test for LOADSO and SDL_DLOPEN is a bit weird:
-# if LOADSO is not wanted, SDL_LOADSO_DISABLED is set
-# If however on Unix or APPLE dlopen() is detected via CheckDLOPEN(),
-# SDL_LOADSO_DISABLED will not be set, regardless of the LOADSO settings
-
 # General SDL subsystem options, valid for all platforms
 if(SDL_AUDIO)
   # CheckDummyAudio/CheckDiskAudio - valid for all platforms
@@ -948,10 +940,15 @@ if(SDL_AUDIO)
   endif()
 endif()
 
-if(SDL_DLOPEN)
+if(UNIX OR APPLE)
   # Relevant for Unix/Darwin only
-  if(UNIX OR APPLE)
-    CheckDLOPEN()
+  set(DYNAPI_NEEDS_DLOPEN 1)
+  CheckDLOPEN()
+  if(SDL_LOADSO AND HAVE_DLOPEN)
+    set(SDL_LOADSO_DLOPEN 1)
+    file(GLOB DLOPEN_SOURCES ${SDL2_SOURCE_DIR}/src/loadso/dlopen/*.c)
+    set(SOURCE_FILES ${SOURCE_FILES} ${DLOPEN_SOURCES})
+    set(HAVE_SDL_LOADSO TRUE)
   endif()
 endif()
 

--- a/cmake/sdlchecks.cmake
+++ b/cmake/sdlchecks.cmake
@@ -32,15 +32,12 @@ endmacro()
 macro(CheckDLOPEN)
   check_symbol_exists(dlopen "dlfcn.h" HAVE_DLOPEN)
   if(NOT HAVE_DLOPEN)
-    foreach(_LIBNAME dl tdl)
-      check_library_exists("${_LIBNAME}" "dlopen" "" DLOPEN_LIB)
-      if(DLOPEN_LIB)
-        list(APPEND EXTRA_LIBS ${_LIBNAME})
-        set(_DLLIB ${_LIBNAME})
-        set(HAVE_DLOPEN TRUE)
-        break()
-      endif()
-    endforeach()
+    check_library_exists(dl dlopen "" DLOPEN_LIB)
+    if(DLOPEN_LIB)
+      list(APPEND EXTRA_LIBS dl)
+      set(_DLLIB dl)
+      set(HAVE_DLOPEN TRUE)
+    endif()
   endif()
 
   if(HAVE_DLOPEN)
@@ -54,14 +51,6 @@ macro(CheckDLOPEN)
          const char *loaderror = (char *) dlerror();
        }" HAVE_DLOPEN)
     set(CMAKE_REQUIRED_LIBRARIES)
-  endif()
-
-  if (HAVE_DLOPEN)
-    set(SDL_LOADSO_DLOPEN 1)
-    set(HAVE_SDL_DLOPEN TRUE)
-    file(GLOB DLOPEN_SOURCES ${SDL2_SOURCE_DIR}/src/loadso/dlopen/*.c)
-    set(SOURCE_FILES ${SOURCE_FILES} ${DLOPEN_SOURCES})
-    set(HAVE_SDL_LOADSO TRUE)
   endif()
 endmacro()
 
@@ -100,7 +89,7 @@ endmacro()
 # - n/a
 # Optional:
 # - ALSA_SHARED opt
-# - HAVE_DLOPEN opt
+# - HAVE_SDL_LOADSO opt
 macro(CheckALSA)
   if(ALSA)
     CHECK_INCLUDE_FILE(alsa/asoundlib.h HAVE_ASOUNDLIB_H)
@@ -113,7 +102,7 @@ macro(CheckALSA)
       set(SOURCE_FILES ${SOURCE_FILES} ${ALSA_SOURCES})
       set(SDL_AUDIO_DRIVER_ALSA 1)
       if(ALSA_SHARED)
-        if(NOT HAVE_DLOPEN)
+        if(NOT HAVE_SDL_LOADSO)
           message_warn("You must have SDL_LoadObject() support for dynamic ALSA loading")
         else()
           FindLibraryAndSONAME("asound")
@@ -132,7 +121,7 @@ endmacro()
 # - PkgCheckModules
 # Optional:
 # - PIPEWIRE_SHARED opt
-# - HAVE_DLOPEN opt
+# - HAVE_SDL_LOADSO opt
 macro(CheckPipewire)
     if(PIPEWIRE)
         pkg_check_modules(PKG_PIPEWIRE libpipewire-0.3>=0.3.20)
@@ -143,7 +132,7 @@ macro(CheckPipewire)
             set(SDL_AUDIO_DRIVER_PIPEWIRE 1)
             list(APPEND EXTRA_CFLAGS ${PKG_PIPEWIRE_CFLAGS})
             if(PIPEWIRE_SHARED)
-                if(NOT HAVE_DLOPEN)
+                if(NOT HAVE_SDL_LOADSO)
                     message_warn("You must have SDL_LoadObject() support for dynamic Pipewire loading")
                 else()
                     FindLibraryAndSONAME("pipewire-0.3")
@@ -163,7 +152,7 @@ endmacro()
 # - PkgCheckModules
 # Optional:
 # - PULSEAUDIO_SHARED opt
-# - HAVE_DLOPEN opt
+# - HAVE_SDL_LOADSO opt
 macro(CheckPulseAudio)
   if(PULSEAUDIO)
     pkg_check_modules(PKG_PULSEAUDIO libpulse-simple)
@@ -174,7 +163,7 @@ macro(CheckPulseAudio)
       set(SDL_AUDIO_DRIVER_PULSEAUDIO 1)
       list(APPEND EXTRA_CFLAGS ${PKG_PULSEAUDIO_CFLAGS})
       if(PULSEAUDIO_SHARED)
-        if(NOT HAVE_DLOPEN)
+        if(NOT HAVE_SDL_LOADSO)
           message_warn("You must have SDL_LoadObject() support for dynamic PulseAudio loading")
         else()
           FindLibraryAndSONAME("pulse-simple")
@@ -193,7 +182,7 @@ endmacro()
 # - PkgCheckModules
 # Optional:
 # - JACK_SHARED opt
-# - HAVE_DLOPEN opt
+# - HAVE_SDL_LOADSO opt
 macro(CheckJACK)
   if(JACK)
     pkg_check_modules(PKG_JACK jack)
@@ -204,7 +193,7 @@ macro(CheckJACK)
       set(SDL_AUDIO_DRIVER_JACK 1)
       list(APPEND EXTRA_CFLAGS ${PKG_JACK_CFLAGS})
       if(JACK_SHARED)
-        if(NOT HAVE_DLOPEN)
+        if(NOT HAVE_SDL_LOADSO)
           message_warn("You must have SDL_LoadObject() support for dynamic JACK audio loading")
         else()
           FindLibraryAndSONAME("jack")
@@ -223,7 +212,7 @@ endmacro()
 # - PkgCheckModules
 # Optional:
 # - ESD_SHARED opt
-# - HAVE_DLOPEN opt
+# - HAVE_SDL_LOADSO opt
 macro(CheckESD)
   if(ESD)
     pkg_check_modules(PKG_ESD esound)
@@ -234,7 +223,7 @@ macro(CheckESD)
       set(SDL_AUDIO_DRIVER_ESD 1)
       list(APPEND EXTRA_CFLAGS ${PKG_ESD_CFLAGS})
       if(ESD_SHARED)
-        if(NOT HAVE_DLOPEN)
+        if(NOT HAVE_SDL_LOADSO)
           message_warn("You must have SDL_LoadObject() support for dynamic ESD loading")
         else()
           FindLibraryAndSONAME(esd)
@@ -253,7 +242,7 @@ endmacro()
 # - n/a
 # Optional:
 # - ARTS_SHARED opt
-# - HAVE_DLOPEN opt
+# - HAVE_SDL_LOADSO opt
 macro(CheckARTS)
   if(ARTS)
     find_program(ARTS_CONFIG arts-config)
@@ -268,7 +257,7 @@ macro(CheckARTS)
       set(SDL_AUDIO_DRIVER_ARTS 1)
       set(HAVE_ARTS TRUE)
       if(ARTS_SHARED)
-        if(NOT HAVE_DLOPEN)
+        if(NOT HAVE_SDL_LOADSO)
           message_warn("You must have SDL_LoadObject() support for dynamic ARTS loading")
         else()
           # TODO
@@ -288,7 +277,7 @@ endmacro()
 # - n/a
 # Optional:
 # - NAS_SHARED opt
-# - HAVE_DLOPEN opt
+# - HAVE_SDL_LOADSO opt
 macro(CheckNAS)
   if(NAS)
     # TODO: set include paths properly, so the NAS headers are found
@@ -300,7 +289,7 @@ macro(CheckNAS)
       set(SOURCE_FILES ${SOURCE_FILES} ${NAS_SOURCES})
       set(SDL_AUDIO_DRIVER_NAS 1)
       if(NAS_SHARED)
-        if(NOT HAVE_DLOPEN)
+        if(NOT HAVE_SDL_LOADSO)
           message_warn("You must have SDL_LoadObject() support for dynamic NAS loading")
         else()
           FindLibraryAndSONAME("audio")
@@ -319,7 +308,7 @@ endmacro()
 # - n/a
 # Optional:
 # - SNDIO_SHARED opt
-# - HAVE_DLOPEN opt
+# - HAVE_SDL_LOADSO opt
 macro(CheckSNDIO)
   if(SNDIO)
     # TODO: set include paths properly, so the sndio headers are found
@@ -331,7 +320,7 @@ macro(CheckSNDIO)
       set(SOURCE_FILES ${SOURCE_FILES} ${SNDIO_SOURCES})
       set(SDL_AUDIO_DRIVER_SNDIO 1)
       if(SNDIO_SHARED)
-        if(NOT HAVE_DLOPEN)
+        if(NOT HAVE_SDL_LOADSO)
           message_warn("You must have SDL_LoadObject() support for dynamic sndio loading")
         else()
           FindLibraryAndSONAME("sndio")
@@ -350,7 +339,7 @@ endmacro()
 # - PkgCheckModules
 # Optional:
 # - FUSIONSOUND_SHARED opt
-# - HAVE_DLOPEN opt
+# - HAVE_SDL_LOADSO opt
 macro(CheckFusionSound)
   if(FUSIONSOUND)
     pkg_check_modules(PKG_FUSIONSOUND fusionsound>=1.0.0)
@@ -361,7 +350,7 @@ macro(CheckFusionSound)
       set(SDL_AUDIO_DRIVER_FUSIONSOUND 1)
       list(APPEND EXTRA_CFLAGS ${PKG_FUSIONSOUND_CFLAGS})
       if(FUSIONSOUND_SHARED)
-        if(NOT HAVE_DLOPEN)
+        if(NOT HAVE_SDL_LOADSO)
           message_warn("You must have SDL_LoadObject() support for dynamic FusionSound loading")
         else()
           FindLibraryAndSONAME("fusionsound")
@@ -380,14 +369,14 @@ endmacro()
 # - LIBSAMPLERATE
 # Optional:
 # - LIBSAMPLERATE_SHARED opt
-# - HAVE_DLOPEN opt
+# - HAVE_SDL_LOADSO opt
 macro(CheckLibSampleRate)
   if(LIBSAMPLERATE)
     check_include_file(samplerate.h HAVE_LIBSAMPLERATE_H)
     if(HAVE_LIBSAMPLERATE_H)
       set(HAVE_LIBSAMPLERATE TRUE)
       if(LIBSAMPLERATE_SHARED)
-        if(NOT HAVE_DLOPEN)
+        if(NOT HAVE_SDL_LOADSO)
           message_warn("You must have SDL_LoadObject() support for dynamic libsamplerate loading")
         else()
           FindLibraryAndSONAME("samplerate")
@@ -405,7 +394,7 @@ endmacro()
 # - n/a
 # Optional:
 # - X11_SHARED opt
-# - HAVE_DLOPEN opt
+# - HAVE_SDL_LOADSO opt
 macro(CheckX11)
   if(VIDEO_X11)
     foreach(_LIB X11 Xext Xcursor Xinerama Xi Xrandr Xrender Xss Xxf86vm)
@@ -468,7 +457,7 @@ macro(CheckX11)
       endif()
 
       if(X11_SHARED)
-        if(NOT HAVE_DLOPEN)
+        if(NOT HAVE_SDL_LOADSO)
           message_warn("You must have SDL_LoadObject() support for dynamic X11 loading")
           set(HAVE_X11_SHARED FALSE)
         else()
@@ -625,7 +614,7 @@ endmacro()
 # - PkgCheckModules
 # Optional:
 # - WAYLAND_SHARED opt
-# - HAVE_DLOPEN opt
+# - HAVE_SDL_LOADSO opt
 macro(CheckWayland)
   if(VIDEO_WAYLAND)
     pkg_check_modules(WAYLAND wayland-client wayland-scanner wayland-egl wayland-cursor egl xkbcommon)
@@ -680,7 +669,7 @@ macro(CheckWayland)
       endif()
 
       if(WAYLAND_SHARED)
-        if(NOT HAVE_DLOPEN)
+        if(NOT HAVE_SDL_LOADSO)
           message_warn("You must have SDL_LoadObject() support for dynamic Wayland loading")
         else()
           FindLibraryAndSONAME(wayland-client)
@@ -705,7 +694,7 @@ macro(CheckWayland)
             link_directories(${LIBDECOR_LIBRARY_DIRS})
             include_directories(${LIBDECOR_INCLUDE_DIRS})
             if(LIBDECOR_SHARED)
-              if(NOT HAVE_DLOPEN)
+              if(NOT HAVE_SDL_LOADSO)
                 message_warn("You must have SDL_LoadObject() support for dynamic libdecor loading")
               else()
                 set(HAVE_LIBDECOR_SHARED TRUE)
@@ -745,7 +734,7 @@ endmacro()
 # - PkgCheckModules
 # Optional:
 # - DIRECTFB_SHARED opt
-# - HAVE_DLOPEN opt
+# - HAVE_SDL_LOADSO opt
 macro(CheckDirectFB)
   if(VIDEO_DIRECTFB)
     pkg_check_modules(PKG_DIRECTFB directfb>=1.0.0)
@@ -757,7 +746,7 @@ macro(CheckDirectFB)
       set(SDL_VIDEO_RENDER_DIRECTFB 1)
       list(APPEND EXTRA_CFLAGS ${PKG_DIRECTFB_CFLAGS})
       if(DIRECTFB_SHARED)
-        if(NOT HAVE_DLOPEN)
+        if(NOT HAVE_SDL_LOADSO)
           message_warn("You must have SDL_LoadObject() support for dynamic DirectFB loading")
         else()
           FindLibraryAndSONAME("directfb")
@@ -1232,7 +1221,7 @@ endmacro(CheckRPI)
 # - PkgCheckModules
 # Optional:
 # - KMSDRM_SHARED opt
-# - HAVE_DLOPEN opt
+# - HAVE_SDL_LOADSO opt
 macro(CheckKMSDRM)
   if(VIDEO_KMSDRM)
     pkg_check_modules(KMSDRM libdrm gbm egl)
@@ -1254,7 +1243,7 @@ macro(CheckKMSDRM)
       set(SDL_VIDEO_DRIVER_KMSDRM 1)
 
       if(KMSDRM_SHARED)
-        if(NOT HAVE_DLOPEN)
+        if(NOT HAVE_SDL_LOADSO)
           message_warn("You must have SDL_LoadObject() support for dynamic KMS/DRM loading")
         else()
           FindLibraryAndSONAME(drm)

--- a/configure
+++ b/configure
@@ -902,7 +902,6 @@ enable_pthread_sem
 enable_directx
 enable_xinput
 enable_wasapi
-enable_sdl_dlopen
 enable_hidapi
 enable_hidapi_libusb
 enable_clock_gettime
@@ -1696,7 +1695,6 @@ Optional Features:
   --enable-directx        use DirectX for Windows audio/video [default=yes]
   --enable-xinput         use Xinput for Windows [default=yes]
   --enable-wasapi         use the Windows WASAPI audio driver [default=yes]
-  --enable-sdl-dlopen     use dlopen for shared object loading [default=yes]
   --enable-hidapi         use HIDAPI for low level joystick drivers
                           [default=yes]
   --enable-hidapi-libusb  use libusb for low level joystick drivers
@@ -24136,42 +24134,20 @@ fi
 
 CheckDLOPEN()
 {
-    # Check whether --enable-sdl-dlopen was given.
-if test "${enable_sdl_dlopen+set}" = set; then :
-  enableval=$enable_sdl_dlopen;
+    $as_echo "#define DYNAPI_NEEDS_DLOPEN 1" >>confdefs.h
+
+
+    ac_fn_c_check_header_mongrel "$LINENO" "dlfcn.h" "ac_cv_header_dlfcn_h" "$ac_includes_default"
+if test "x$ac_cv_header_dlfcn_h" = xyes; then :
+  have_dlfcn_h=yes
 else
-  enable_sdl_dlopen=yes
+  have_dlfcn_h=no
 fi
 
-    if test x$enable_sdl_dlopen = xyes; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen" >&5
-$as_echo_n "checking for dlopen... " >&6; }
-        have_dlopen=no
-        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
 
-         #include <dlfcn.h>
 
-int
-main ()
-{
-
-         void *handle = dlopen("", RTLD_NOW);
-         const char *loaderror = (char *) dlerror();
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  have_dlopen=yes
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_dlopen" >&5
-$as_echo "$have_dlopen" >&6; }
-
-        if test x$have_dlopen = xyes; then
-            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -lc" >&5
+    have_dlopen=no
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -lc" >&5
 $as_echo_n "checking for dlopen in -lc... " >&6; }
 if ${ac_cv_lib_c_dlopen+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -24208,7 +24184,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_c_dlopen" >&5
 $as_echo "$ac_cv_lib_c_dlopen" >&6; }
 if test "x$ac_cv_lib_c_dlopen" = xyes; then :
-  EXTRA_LDFLAGS="$EXTRA_LDFLAGS"
+  have_dlopen=yes
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
 $as_echo_n "checking for dlopen in -ldl... " >&6; }
@@ -24247,58 +24223,25 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dl_dlopen" >&5
 $as_echo "$ac_cv_lib_dl_dlopen" >&6; }
 if test "x$ac_cv_lib_dl_dlopen" = xyes; then :
-  EXTRA_LDFLAGS="$EXTRA_LDFLAGS -ldl"
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -lltdl" >&5
-$as_echo_n "checking for dlopen in -lltdl... " >&6; }
-if ${ac_cv_lib_ltdl_dlopen+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lltdl  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-#ifdef __cplusplus
-extern "C"
-#endif
-char dlopen ();
-int
-main ()
-{
-return dlopen ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_ltdl_dlopen=yes
-else
-  ac_cv_lib_ltdl_dlopen=no
-fi
-rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_ltdl_dlopen" >&5
-$as_echo "$ac_cv_lib_ltdl_dlopen" >&6; }
-if test "x$ac_cv_lib_ltdl_dlopen" = xyes; then :
-  EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lltdl"
+  have_dlopen=yes; EXTRA_LDFLAGS="$EXTRA_LDFLAGS -ldl"
 fi
 
 fi
 
-fi
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen" >&5
+$as_echo_n "checking for dlopen... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_dlopen" >&5
+$as_echo "$have_dlopen" >&6; }
 
+    if test x$have_dlfcn_h = xyes -a x$have_dlopen = xyes; then
+       $as_echo "#define HAVE_DLOPEN 1" >>confdefs.h
 
-$as_echo "#define SDL_LOADSO_DLOPEN 1" >>confdefs.h
+       if test x$enable_loadso = xyes; then
+          $as_echo "#define SDL_LOADSO_DLOPEN 1" >>confdefs.h
 
-            SOURCES="$SOURCES $srcdir/src/loadso/dlopen/*.c"
-            have_loadso=yes
-        fi
+          SOURCES="$SOURCES $srcdir/src/loadso/dlopen/*.c"
+          have_loadso=yes
+       fi
     fi
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -3224,30 +3224,26 @@ XINPUT_STATE_EX s1;
 }
 
 dnl Check for the dlfcn.h interface for dynamically loading objects
+dnl NOTE: CheckDLOPEN is called only for relevant platforms
 CheckDLOPEN()
 {
-    AC_ARG_ENABLE(sdl-dlopen,
-[AS_HELP_STRING([--enable-sdl-dlopen], [use dlopen for shared object loading [default=yes]])],
-                  , enable_sdl_dlopen=yes)
-    if test x$enable_sdl_dlopen = xyes; then
-        AC_MSG_CHECKING(for dlopen)
-        have_dlopen=no
-        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-         #include <dlfcn.h>
-        ]], [[
-         void *handle = dlopen("", RTLD_NOW);
-         const char *loaderror = (char *) dlerror();
-        ]])], [have_dlopen=yes],[])
-        AC_MSG_RESULT($have_dlopen)
+    AC_DEFINE(DYNAPI_NEEDS_DLOPEN,1,[])
 
-        if test x$have_dlopen = xyes; then
-            AC_CHECK_LIB(c, dlopen, EXTRA_LDFLAGS="$EXTRA_LDFLAGS",
-               AC_CHECK_LIB(dl, dlopen, EXTRA_LDFLAGS="$EXTRA_LDFLAGS -ldl",
-                  AC_CHECK_LIB(ltdl, dlopen, EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lltdl")))
-            AC_DEFINE(SDL_LOADSO_DLOPEN, 1, [ ])
-            SOURCES="$SOURCES $srcdir/src/loadso/dlopen/*.c"
-            have_loadso=yes
-        fi
+    AC_CHECK_HEADER(dlfcn.h,have_dlfcn_h=yes,have_dlfcn_h=no)
+
+    have_dlopen=no
+    AC_CHECK_LIB(c, dlopen, have_dlopen=yes,
+       AC_CHECK_LIB(dl, dlopen, [have_dlopen=yes; EXTRA_LDFLAGS="$EXTRA_LDFLAGS -ldl"]))
+    AC_MSG_CHECKING(for dlopen)
+    AC_MSG_RESULT($have_dlopen)
+
+    if test x$have_dlfcn_h = xyes -a x$have_dlopen = xyes; then
+       AC_DEFINE(HAVE_DLOPEN,1,[])
+       if test x$enable_loadso = xyes; then
+          AC_DEFINE(SDL_LOADSO_DLOPEN,1,[])
+          SOURCES="$SOURCES $srcdir/src/loadso/dlopen/*.c"
+          have_loadso=yes
+       fi
     fi
 }
 

--- a/include/SDL_config.h.cmake
+++ b/include/SDL_config.h.cmake
@@ -75,6 +75,7 @@
 #cmakedefine HAVE_LIBUNWIND_H 1
 
 /* C library functions */
+#cmakedefine HAVE_DLOPEN 1
 #cmakedefine HAVE_MALLOC 1
 #cmakedefine HAVE_CALLOC 1
 #cmakedefine HAVE_REALLOC 1
@@ -468,6 +469,9 @@
 #cmakedefine SDL_ALTIVEC_BLITTERS @SDL_ALTIVEC_BLITTERS@
 #cmakedefine SDL_ARM_SIMD_BLITTERS @SDL_ARM_SIMD_BLITTERS@
 #cmakedefine SDL_ARM_NEON_BLITTERS @SDL_ARM_NEON_BLITTERS@
+
+/* Whether SDL_DYNAMIC_API needs dlopen */
+#cmakedefine DYNAPI_NEEDS_DLOPEN  @DYNAPI_NEEDS_DLOPEN@
 
 /* Enable dynamic libsamplerate support */
 #cmakedefine SDL_LIBSAMPLERATE_DYNAMIC @SDL_LIBSAMPLERATE_DYNAMIC@

--- a/include/SDL_config.h.in
+++ b/include/SDL_config.h.in
@@ -79,6 +79,7 @@
 #undef HAVE_LIBUNWIND_H
 
 /* C library functions */
+#undef HAVE_DLOPEN
 #undef HAVE_MALLOC
 #undef HAVE_CALLOC
 #undef HAVE_REALLOC
@@ -451,6 +452,9 @@
 #undef SDL_ALTIVEC_BLITTERS
 #undef SDL_ARM_SIMD_BLITTERS
 #undef SDL_ARM_NEON_BLITTERS
+
+/* Whether SDL_DYNAMIC_API needs dlopen() */
+#undef DYNAPI_NEEDS_DLOPEN
 
 /* Enable ime support */
 #undef SDL_USE_IME

--- a/include/SDL_config_android.h
+++ b/include/SDL_config_android.h
@@ -48,6 +48,7 @@
 #define HAVE_SYS_TYPES_H    1
 
 /* C library functions */
+#define HAVE_DLOPEN 1
 #define HAVE_MALLOC 1
 #define HAVE_CALLOC 1
 #define HAVE_REALLOC    1

--- a/include/SDL_config_iphoneos.h
+++ b/include/SDL_config_iphoneos.h
@@ -48,6 +48,7 @@
 /* #undef HAVE_LIBUNWIND_H */
 
 /* C library functions */
+#define HAVE_DLOPEN 1
 #define HAVE_MALLOC 1
 #define HAVE_CALLOC 1
 #define HAVE_REALLOC    1

--- a/include/SDL_config_macosx.h
+++ b/include/SDL_config_macosx.h
@@ -52,6 +52,7 @@
 #define HAVE_LIBUNWIND_H    1
 
 /* C library functions */
+#define HAVE_DLOPEN 1
 #define HAVE_MALLOC 1
 #define HAVE_CALLOC 1
 #define HAVE_REALLOC    1

--- a/include/SDL_config_os2.h
+++ b/include/SDL_config_os2.h
@@ -80,6 +80,7 @@
 #define HAVE_FLOAT_H 1
 #define HAVE_SIGNAL_H 1
 
+/* #undef HAVE_DLOPEN */
 #define HAVE_MALLOC 1
 #define HAVE_CALLOC 1
 #define HAVE_REALLOC 1

--- a/include/SDL_config_pandora.h
+++ b/include/SDL_config_pandora.h
@@ -54,6 +54,7 @@
 #define HAVE_STRING_H 1
 #define HAVE_SYS_TYPES_H 1
 
+#define HAVE_DLOPEN 1
 #define HAVE_MALLOC 1
 #define HAVE_CALLOC 1
 #define HAVE_REALLOC 1

--- a/include/SDL_config_wiz.h
+++ b/include/SDL_config_wiz.h
@@ -48,6 +48,7 @@
 #define HAVE_STRING_H 1
 #define HAVE_SYS_TYPES_H 1
 
+#define HAVE_DLOPEN 1
 #define HAVE_MALLOC 1
 #define HAVE_CALLOC 1
 #define HAVE_REALLOC 1

--- a/src/dynapi/SDL_dynapi.h
+++ b/src/dynapi/SDL_dynapi.h
@@ -59,6 +59,8 @@
 #define SDL_DYNAMIC_API 0  /* Turn off for static analysis, so reports are more clear. */
 #elif defined(__VITA__)
 #define SDL_DYNAMIC_API 0  /* vitasdk doesn't support dynamic linking */
+#elif defined(DYNAPI_NEEDS_DLOPEN) && !defined(HAVE_DLOPEN)
+#define SDL_DYNAMIC_API 0  /* we need dlopen(), but don't have it.... */
 #endif
 
 /* everyone else. This is where we turn on the API if nothing forced it off. */

--- a/src/thread/pthread/SDL_systhread.c
+++ b/src/thread/pthread/SDL_systhread.c
@@ -41,7 +41,7 @@
 #include "../../core/linux/SDL_dbus.h"
 #endif /* __LINUX__ */
 
-#if defined(__LINUX__) || defined(__MACOSX__) || defined(__IPHONEOS__)
+#if (defined(__LINUX__) || defined(__MACOSX__) || defined(__IPHONEOS__)) && defined(HAVE_DLOPEN)
 #include <dlfcn.h>
 #ifndef RTLD_DEFAULT
 #define RTLD_DEFAULT NULL
@@ -78,10 +78,10 @@ RunThread(void *data)
     return NULL;
 }
 
-#if defined(__MACOSX__) || defined(__IPHONEOS__)
+#if (defined(__MACOSX__) || defined(__IPHONEOS__)) && defined(HAVE_DLOPEN)
 static SDL_bool checked_setname = SDL_FALSE;
 static int (*ppthread_setname_np)(const char*) = NULL;
-#elif defined(__LINUX__)
+#elif defined(__LINUX__) && defined(HAVE_DLOPEN)
 static SDL_bool checked_setname = SDL_FALSE;
 static int (*ppthread_setname_np)(pthread_t, const char*) = NULL;
 #endif
@@ -91,7 +91,7 @@ SDL_SYS_CreateThread(SDL_Thread * thread)
     pthread_attr_t type;
 
     /* do this here before any threads exist, so there's no race condition. */
-    #if defined(__MACOSX__) || defined(__IPHONEOS__) || defined(__LINUX__)
+    #if (defined(__MACOSX__) || defined(__IPHONEOS__) || defined(__LINUX__)) && defined(HAVE_DLOPEN)
     if (!checked_setname) {
         void *fn = dlsym(RTLD_DEFAULT, "pthread_setname_np");
         #if defined(__MACOSX__) || defined(__IPHONEOS__)
@@ -131,7 +131,7 @@ SDL_SYS_SetupThread(const char *name)
 #endif /* !__NACL__ */
 
     if (name != NULL) {
-        #if defined(__MACOSX__) || defined(__IPHONEOS__) || defined(__LINUX__)
+        #if (defined(__MACOSX__) || defined(__IPHONEOS__) || defined(__LINUX__)) && defined(HAVE_DLOPEN)
         SDL_assert(checked_setname);
         if (ppthread_setname_np != NULL) {
             #if defined(__MACOSX__) || defined(__IPHONEOS__)

--- a/src/video/directfb/SDL_DirectFB_opengl.c
+++ b/src/video/directfb/SDL_DirectFB_opengl.c
@@ -47,7 +47,7 @@ struct SDL_GLDriverData
 };
 
 #define OPENGL_REQUIRS_DLOPEN
-#if defined(OPENGL_REQUIRS_DLOPEN) && defined(SDL_LOADSO_DLOPEN)
+#if defined(OPENGL_REQUIRS_DLOPEN) && defined(HAVE_DLOPEN)
 #include <dlfcn.h>
 #define GL_LoadObject(X)    dlopen(X, (RTLD_NOW|RTLD_GLOBAL))
 #define GL_LoadFunction     dlsym

--- a/src/video/nacl/SDL_naclopengles.c
+++ b/src/video/nacl/SDL_naclopengles.c
@@ -27,7 +27,7 @@
 #include "SDL_video.h"
 #include "SDL_naclvideo.h"
 
-#if SDL_LOADSO_DLOPEN
+#ifdef HAVE_DLOPEN
 #include "dlfcn.h"
 #endif
 
@@ -45,7 +45,7 @@ NACL_GLES_LoadLibrary(_THIS, const char *path)
 void *
 NACL_GLES_GetProcAddress(_THIS, const char *proc)
 {
-#if SDL_LOADSO_DLOPEN
+#ifdef HAVE_DLOPEN
     return dlsym( 0 /* RTLD_DEFAULT */, proc);
 #else
     return NULL;

--- a/src/video/x11/SDL_x11opengl.c
+++ b/src/video/x11/SDL_x11opengl.c
@@ -142,7 +142,7 @@ typedef GLXContext(*PFNGLXCREATECONTEXTATTRIBSARBPROC) (Display * dpy,
 #endif
 
 #define OPENGL_REQUIRES_DLOPEN
-#if defined(OPENGL_REQUIRES_DLOPEN) && defined(SDL_LOADSO_DLOPEN)
+#if defined(OPENGL_REQUIRES_DLOPEN) && defined(HAVE_DLOPEN)
 #include <dlfcn.h>
 #define GL_LoadObject(X)    dlopen(X, (RTLD_NOW|RTLD_GLOBAL))
 #define GL_LoadFunction     dlsym
@@ -174,7 +174,7 @@ X11_GL_LoadLibrary(_THIS, const char *path)
     }
     _this->gl_config.dll_handle = GL_LoadObject(path);
     if (!_this->gl_config.dll_handle) {
-#if defined(OPENGL_REQUIRES_DLOPEN) && defined(SDL_LOADSO_DLOPEN)
+#if defined(OPENGL_REQUIRES_DLOPEN) && defined(HAVE_DLOPEN)
         SDL_SetError("Failed loading %s: %s", path, dlerror());
 #endif
         return -1;


### PR DESCRIPTION
- cmake, configure (CheckDLOPEN): --enable-sdl-dlopen is now history..
  detach the dl api discovery from SDL_LOADSO_DLOPEN functionality.
  define HAVE_DLOPEN. also define DYNAPI_NEEDS_DLOPEN (CheckDLOPEN is
  called only for relevant platforms.)
- update SDL_config.in and SDL_config.cmake accordingly.
- SDL_dynapi.h: set SDL_DYNAMIC_API to 0 if DYNAPI_NEEDS_DLOPEN is
  defined, but HAVE_DLOPEN is not.
- pthread/SDL_systhread.c: conditionalize dl api use to HAVE_DLOPEN
- SDL_x11opengl.c, SDL_DirectFB_opengl.c, SDL_naclopengles.c: rely
  on HAVE_DLOPEN, not SDL_LOADSO_DLOPEN.
- SDL_config_android.h, SDL_config_iphoneos.h, SDL_config_macosx.h,
  SDL_config_pandora.h, and SDL_config_wiz.h: define HAVE_DLOPEN.

Closes: https://github.com/libsdl-org/SDL/pull/4351
