### PR TITLE
include: Document timing issue with SDL_GetWindowBordersSize

### DIFF
--- a/include/SDL_video.h
+++ b/include/SDL_video.h
@@ -893,6 +893,12 @@ extern DECLSPEC void SDLCALL SDL_GetWindowSize(SDL_Window * window, int *w,
  * initialized to 0, 0, 0, 0 (if a non-NULL pointer is provided), as if the
  * window in question was borderless.
  *
+ * Note: This function may fail on systems where the window has not yet been
+ * decorated by the display server (for example, immediately after calling
+ * SDL_CreateWindow). It is recommended that you wait at least until the
+ * window has been presented and composited, so that the window system has a
+ * chance to decorate the window and provide the border dimensions to SDL.
+ *
  * This function also returns -1 if getting the information is not supported.
  *
  * \param window the window to query the size values of the border


### PR DESCRIPTION
This adds a note to SDL_GetWindowBordersSize that explains the timing issue involved with SDL's query and the target display server; it's recommended to hold off on calling this function until the window system has a chance to actually _make_ the borders so it can tell us what the dimensions really are.

Fixes #3853.