### PR TITLE
Wayland: send normalized coordinates in touch inputs events

### DIFF
--- a/src/video/wayland/SDL_waylandtouch.c
+++ b/src/video/wayland/SDL_waylandtouch.c
@@ -73,8 +73,8 @@ touch_handle_touch(void *data,
      **/
 
     float FIXED_TO_FLOAT = 1. / 10000.;
-    float xf = FIXED_TO_FLOAT * x;
-    float yf = FIXED_TO_FLOAT * y;
+    float xf = FIXED_TO_FLOAT * normalized_x;
+    float yf = FIXED_TO_FLOAT * normalized_y;
 
     float PRESSURE_TO_FLOAT = 1. / 255.;
     float pressuref = PRESSURE_TO_FLOAT * pressure;


### PR DESCRIPTION
On wayland systems, this will send x,y coordinates in `SDL_TouchFingerEvent` normalised to [0..1] instead of window coordinates.

## Description
According to https://wiki.libsdl.org/SDL_TouchFingerEvent, the `SDL_TouchFingerEvent`, the x,y coordinates should be normalised to [0..1]. This wasn't the case on wayland clients. Therefore, this merge request fixes that.

Games and applications using SDL, running with a wayland compositor and working around this issue will break on touch input if this gets merged. I haven't accounted for that within this merge request, I don't know if I should and I don't know how I should. Suggestions are welcome.

Tested on SailfishOS running the Lipstick wayland compositor. Could anyone verify this on other wayland compositors with touch input?

## Existing Issue(s)
Resolves #4361
