### PR TITLE
build: Use the correct __linux__ define.

### DIFF
--- a/include/SDL_atomic.h
+++ b/include/SDL_atomic.h
@@ -184,7 +184,7 @@ extern DECLSPEC void SDLCALL SDL_MemoryBarrierAcquireFunction(void);
 #define SDL_MemoryBarrierRelease()   __asm__ __volatile__ ("dmb ish" : : : "memory")
 #define SDL_MemoryBarrierAcquire()   __asm__ __volatile__ ("dmb ish" : : : "memory")
 #elif defined(__GNUC__) && defined(__arm__)
-#if 0 /* defined(__LINUX__) || defined(__ANDROID__) */
+#if 0 /* defined(__linux__) || defined(__ANDROID__) */
 /* Information from:
    https://chromium.googlesource.com/chromium/chromium/+/trunk/base/atomicops_internals_arm_gcc.h#19
 
@@ -216,7 +216,7 @@ typedef void (*SDL_KernelMemoryBarrierFunc)();
 #else
 #define SDL_MemoryBarrierRelease()   __asm__ __volatile__ ("" : : : "memory")
 #define SDL_MemoryBarrierAcquire()   __asm__ __volatile__ ("" : : : "memory")
-#endif /* __LINUX__ || __ANDROID__ */
+#endif /* __linux__ || __ANDROID__ */
 #endif /* __GNUC__ && __arm__ */
 #else
 #if (defined(__SUNPRO_C) && (__SUNPRO_C >= 0x5120))

--- a/include/SDL_platform.h
+++ b/include/SDL_platform.h
@@ -57,12 +57,12 @@
 #define __IRIX__    1
 #endif
 #if (defined(linux) || defined(__linux) || defined(__linux__))
-#undef __LINUX__
-#define __LINUX__   1
+#undef __linux__
+#define __linux__   1
 #endif
 #if defined(ANDROID) || defined(__ANDROID__)
 #undef __ANDROID__
-#undef __LINUX__ /* do we need to do this? */
+#undef __linux__ /* do we need to do this? */
 #define __ANDROID__ 1
 #endif
 
@@ -163,12 +163,12 @@
  * Ref: http://www.chromium.org/nativeclient/pnacl/stability-of-the-pnacl-bitcode-abi
  */
 #if defined(__native_client__)
-#undef __LINUX__
+#undef __linux__
 #undef __NACL__
 #define __NACL__ 1
 #endif
 #if defined(__pnacl__)
-#undef __LINUX__
+#undef __linux__
 #undef __PNACL__
 #define __PNACL__ 1
 /* PNACL with newlib supports static linking only */

--- a/include/SDL_stdinc.h
+++ b/include/SDL_stdinc.h
@@ -231,7 +231,7 @@ typedef uint64_t Uint64;
 #define SDL_PRIs64 PRIs64
 #elif defined(__WIN32__)
 #define SDL_PRIs64 "I64d"
-#elif defined(__LINUX__) && defined(__LP64__)
+#elif defined(__linux__) && defined(__LP64__)
 #define SDL_PRIs64 "ld"
 #else
 #define SDL_PRIs64 "lld"
@@ -242,7 +242,7 @@ typedef uint64_t Uint64;
 #define SDL_PRIu64 PRIu64
 #elif defined(__WIN32__)
 #define SDL_PRIu64 "I64u"
-#elif defined(__LINUX__) && defined(__LP64__)
+#elif defined(__linux__) && defined(__LP64__)
 #define SDL_PRIu64 "lu"
 #else
 #define SDL_PRIu64 "llu"
@@ -253,7 +253,7 @@ typedef uint64_t Uint64;
 #define SDL_PRIx64 PRIx64
 #elif defined(__WIN32__)
 #define SDL_PRIx64 "I64x"
-#elif defined(__LINUX__) && defined(__LP64__)
+#elif defined(__linux__) && defined(__LP64__)
 #define SDL_PRIx64 "lx"
 #else
 #define SDL_PRIx64 "llx"
@@ -264,7 +264,7 @@ typedef uint64_t Uint64;
 #define SDL_PRIX64 PRIX64
 #elif defined(__WIN32__)
 #define SDL_PRIX64 "I64X"
-#elif defined(__LINUX__) && defined(__LP64__)
+#elif defined(__linux__) && defined(__LP64__)
 #define SDL_PRIX64 "lX"
 #else
 #define SDL_PRIX64 "llX"

--- a/include/SDL_system.h
+++ b/include/SDL_system.h
@@ -122,7 +122,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_DXGIGetOutputInfo( int displayIndex, int *a
 
 
 /* Platform specific functions for Linux */
-#ifdef __LINUX__
+#ifdef __linux__
 
 /**
  * Sets the UNIX nice value for a thread.
@@ -135,7 +135,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_DXGIGetOutputInfo( int displayIndex, int *a
  */
 extern DECLSPEC int SDLCALL SDL_LinuxSetThreadPriority(Sint64 threadID, int priority);
  
-#endif /* __LINUX__ */
+#endif /* __linux__ */
 	
 /* Platform specific functions for iOS */
 #ifdef __IPHONEOS__

--- a/src/SDL.c
+++ b/src/SDL.c
@@ -504,7 +504,7 @@ SDL_GetPlatform()
     return "HP-UX";
 #elif __IRIX__
     return "Irix";
-#elif __LINUX__
+#elif __linux__
     return "Linux";
 #elif __MINT__
     return "Atari MiNT";

--- a/src/audio/esd/SDL_esdaudio.c
+++ b/src/audio/esd/SDL_esdaudio.c
@@ -185,7 +185,7 @@ static char *
 get_progname(void)
 {
     char *progname = NULL;
-#ifdef __LINUX__
+#ifdef __linux__
     FILE *fp;
     static char temp[BUFSIZ];
 

--- a/src/core/linux/SDL_fcitx.c
+++ b/src/core/linux/SDL_fcitx.c
@@ -58,13 +58,13 @@ static FcitxClient fcitx_client;
 static char*
 GetAppName()
 {
-#if defined(__LINUX__) || defined(__FREEBSD__)
+#if defined(__linux__) || defined(__FREEBSD__)
     char *spot;
     char procfile[1024];
     char linkfile[1024];
     int linksize;
 
-#if defined(__LINUX__)
+#if defined(__linux__)
     SDL_snprintf(procfile, sizeof(procfile), "/proc/%d/exe", getpid());
 #elif defined(__FREEBSD__)
     SDL_snprintf(procfile, sizeof(procfile), "/proc/%d/file", getpid());
@@ -79,7 +79,7 @@ GetAppName()
             return SDL_strdup(linkfile);
         }
     }
-#endif /* __LINUX__ || __FREEBSD__ */
+#endif /* __linux__ || __FREEBSD__ */
 
     return SDL_strdup("SDL_App");
 }

--- a/src/core/linux/SDL_threadprio.c
+++ b/src/core/linux/SDL_threadprio.c
@@ -20,7 +20,7 @@
 */
 #include "../../SDL_internal.h"
 
-#ifdef __LINUX__
+#ifdef __linux__
 
 #include "SDL_error.h"
 #include "SDL_stdinc.h"
@@ -294,6 +294,6 @@ SDL_LinuxSetThreadPriorityAndPolicy(Sint64 threadID, int sdlPriority, int schedP
 #endif
 }
 
-#endif  /* __LINUX__ */
+#endif  /* __linux__ */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -63,7 +63,7 @@
 #include <sys/syspage.h>
 #endif
 
-#if (defined(__LINUX__) || defined(__ANDROID__)) && defined(__arm__)
+#if (defined(__linux__) || defined(__ANDROID__)) && defined(__arm__)
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -354,7 +354,7 @@ CPU_haveARMSIMD(void)
 	return 0;
 }
 
-#elif defined(__LINUX__)
+#elif defined(__linux__)
 static int
 CPU_haveARMSIMD(void)
 {
@@ -410,7 +410,7 @@ CPU_haveARMSIMD(void)
 }
 #endif
 
-#if defined(__LINUX__) && defined(__arm__) && !defined(HAVE_GETAUXVAL)
+#if defined(__linux__) && defined(__arm__) && !defined(HAVE_GETAUXVAL)
 static int
 readProcAuxvForNeon(void)
 {
@@ -468,9 +468,9 @@ CPU_haveNEON(void)
     return ((hasneon & HWCAP_NEON) == HWCAP_NEON);
 #elif defined(__QNXNTO__)
     return SYSPAGE_ENTRY(cpuinfo)->flags & ARM_CPU_FLAG_NEON;
-#elif (defined(__LINUX__) || defined(__ANDROID__)) && defined(HAVE_GETAUXVAL)
+#elif (defined(__linux__) || defined(__ANDROID__)) && defined(HAVE_GETAUXVAL)
     return ((getauxval(AT_HWCAP) & HWCAP_NEON) == HWCAP_NEON);
-#elif defined(__LINUX__)
+#elif defined(__linux__)
     return readProcAuxvForNeon();
 #elif defined(__ANDROID__)
     /* Use NDK cpufeatures to read either /proc/self/auxv or /proc/cpuinfo */

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -708,7 +708,7 @@ SDL_DYNAPI_PROC(SDL_bool,SDL_IsAndroidTV,(void),(),return)
 SDL_DYNAPI_PROC(double,SDL_log10,(double a),(a),return)
 SDL_DYNAPI_PROC(float,SDL_log10f,(float a),(a),return)
 SDL_DYNAPI_PROC(char*,SDL_GameControllerMappingForDeviceIndex,(int a),(a),return)
-#ifdef __LINUX__
+#ifdef __linux__
 SDL_DYNAPI_PROC(int,SDL_LinuxSetThreadPriority,(Sint64 a, int b),(a,b),return)
 #endif
 SDL_DYNAPI_PROC(SDL_bool,SDL_HasAVX512F,(void),(),return)

--- a/src/hidapi/SDL_hidapi.c
+++ b/src/hidapi/SDL_hidapi.c
@@ -65,7 +65,7 @@
 #define read_thread                     PLATFORM_read_thread
 
 #undef HIDAPI_H__
-#if __LINUX__
+#if __linux__
 
 #include "../../core/linux/SDL_udev.h"
 #if SDL_USE_LIBUDEV
@@ -608,9 +608,9 @@ int HID_API_EXPORT HID_API_CALL hid_init(void)
 
 #if HAVE_PLATFORM_BACKEND
     ++attempts;
-#if __LINUX__
+#if __linux__
     udev_ctx = SDL_UDEV_GetUdevSyms();
-#endif /* __LINUX __ */
+#endif /* __linux__ */
     if (udev_ctx && PLATFORM_hid_init() == 0) {
         ++success;
     }

--- a/src/joystick/SDL_gamecontroller.c
+++ b/src/joystick/SDL_gamecontroller.c
@@ -1148,7 +1148,7 @@ static ControllerMapping_t *SDL_PrivateGetControllerMappingForNameAndGUID(const 
     ControllerMapping_t *mapping;
 
     mapping = SDL_PrivateGetControllerMappingForGUID(guid, SDL_FALSE);
-#ifdef __LINUX__
+#ifdef __linux__
     if (!mapping && name) {
         if (SDL_strstr(name, "Xbox 360 Wireless Receiver")) {
             /* The Linux driver xpad.c maps the wireless dpad to buttons */
@@ -1158,7 +1158,7 @@ static ControllerMapping_t *SDL_PrivateGetControllerMappingForNameAndGUID(const 
                           &existing, SDL_CONTROLLER_MAPPING_PRIORITY_DEFAULT);
         }
     }
-#endif /* __LINUX__ */
+#endif /* __linux__ */
 
     if (!mapping && name && !SDL_IsJoystickWGI(guid)) {
         if (SDL_strstr(name, "Xbox") || SDL_strstr(name, "X-Box") || SDL_strstr(name, "XBOX")) {
@@ -1763,7 +1763,7 @@ SDL_bool SDL_ShouldIgnoreGameController(const char *name, SDL_JoystickGUID guid)
     Uint16 version;
     Uint32 vidpid;
 
-#if defined(__LINUX__)
+#if defined(__linux__)
     if (name && SDL_strstr(name, "Motion Sensors")) {
         /* Don't treat the PS3 and PS4 motion controls as a separate game controller */
         return SDL_TRUE;
@@ -1780,7 +1780,7 @@ SDL_bool SDL_ShouldIgnoreGameController(const char *name, SDL_JoystickGUID guid)
     if (SDL_GetHintBoolean("SDL_GAMECONTROLLER_ALLOW_STEAM_VIRTUAL_GAMEPAD", SDL_FALSE)) {
         /* We shouldn't ignore Steam's virtual gamepad since it's using the hints to filter out the real controllers so it can remap input for the virtual controller */
         SDL_bool bSteamVirtualGamepad = SDL_FALSE;
-#if defined(__LINUX__)
+#if defined(__linux__)
         bSteamVirtualGamepad = (vendor == 0x28DE && product == 0x11FF);
 #elif defined(__MACOSX__)
         bSteamVirtualGamepad = (vendor == 0x045E && product == 0x028E && version == 1);

--- a/src/joystick/SDL_gamecontrollerdb.h
+++ b/src/joystick/SDL_gamecontrollerdb.h
@@ -480,7 +480,7 @@ static const char *s_ControllerMappings [] =
     "03000000830500006020000000010000,iBuffalo SNES Controller,a:b1,b:b0,back:b6,dpdown:+a1,dpleft:-a0,dpright:+a0,dpup:-a1,leftshoulder:b4,rightshoulder:b5,start:b7,x:b3,y:b2,hint:!SDL_GAMECONTROLLER_USE_BUTTON_LABELS:=1,",
     "03000000830500006020000000000000,iBuffalo USB 2-axis 8-button Gamepad,a:b1,b:b0,back:b6,leftshoulder:b4,leftx:a0,lefty:a1,rightshoulder:b5,start:b7,x:b3,y:b2,",
 #endif
-#if defined(__LINUX__)
+#if defined(__linux__)
     "03000000c82d00000090000011010000,8BitDo FC30 Pro,a:b0,b:b1,back:b10,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b6,leftstick:b13,lefttrigger:a4,leftx:a0,lefty:a1,rightshoulder:b7,rightstick:b14,righttrigger:a5,rightx:a2,righty:a3,start:b11,x:b3,y:b4,hint:SDL_GAMECONTROLLER_USE_BUTTON_LABELS:=1,",
     "03000000c82d00000090000011010000,8BitDo FC30 Pro,a:b1,b:b0,back:b10,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b6,leftstick:b13,lefttrigger:a4,leftx:a0,lefty:a1,rightshoulder:b7,rightstick:b14,righttrigger:a5,rightx:a2,righty:a3,start:b11,x:b4,y:b3,hint:!SDL_GAMECONTROLLER_USE_BUTTON_LABELS:=1,",
     "05000000c82d00001038000000010000,8BitDo FC30 Pro,a:b0,b:b1,back:b10,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b6,leftstick:b13,lefttrigger:a5,leftx:a0,lefty:a1,rightshoulder:b7,rightstick:b14,righttrigger:a4,rightx:a2,righty:a3,start:b11,x:b3,y:b4,hint:SDL_GAMECONTROLLER_USE_BUTTON_LABELS:=1,",

--- a/src/joystick/hidapi/SDL_hidapi_xboxone.c
+++ b/src/joystick/hidapi/SDL_hidapi_xboxone.c
@@ -270,7 +270,7 @@ SendControllerInit(SDL_HIDAPI_Device *device, SDL_DriverXboxOne_Context *ctx)
 static SDL_bool
 HIDAPI_DriverXboxOne_IsSupportedDevice(const char *name, SDL_GameControllerType type, Uint16 vendor_id, Uint16 product_id, Uint16 version, int interface_number, int interface_class, int interface_subclass, int interface_protocol)
 {
-#ifdef __LINUX__
+#ifdef __linux__
     if (vendor_id == USB_VENDOR_POWERA && product_id == 0x541a) {
         /* The PowerA Mini controller, model 1240245-01, blocks while writing feature reports */
         return SDL_FALSE;

--- a/src/joystick/hidapi/SDL_hidapijoystick.c
+++ b/src/joystick/hidapi/SDL_hidapijoystick.c
@@ -47,7 +47,7 @@
 #include <IOKit/usb/USBSpec.h>
 #endif
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 #include "../../core/linux/SDL_udev.h"
 #ifdef SDL_USE_LIBUDEV
 #include <poll.h>

--- a/src/thread/pthread/SDL_systhread.c
+++ b/src/thread/pthread/SDL_systhread.c
@@ -31,7 +31,7 @@
 
 #include <signal.h>
 
-#ifdef __LINUX__
+#ifdef __linux__
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <sys/syscall.h>
@@ -39,9 +39,9 @@
 #include <errno.h>
 
 #include "../../core/linux/SDL_dbus.h"
-#endif /* __LINUX__ */
+#endif /* __linux__ */
 
-#if defined(__LINUX__) || defined(__MACOSX__) || defined(__IPHONEOS__)
+#if defined(__linux__) || defined(__MACOSX__) || defined(__IPHONEOS__)
 #include <dlfcn.h>
 #ifndef RTLD_DEFAULT
 #define RTLD_DEFAULT NULL
@@ -81,7 +81,7 @@ RunThread(void *data)
 #if defined(__MACOSX__) || defined(__IPHONEOS__)
 static SDL_bool checked_setname = SDL_FALSE;
 static int (*ppthread_setname_np)(const char*) = NULL;
-#elif defined(__LINUX__)
+#elif defined(__linux__)
 static SDL_bool checked_setname = SDL_FALSE;
 static int (*ppthread_setname_np)(pthread_t, const char*) = NULL;
 #endif
@@ -91,12 +91,12 @@ SDL_SYS_CreateThread(SDL_Thread * thread)
     pthread_attr_t type;
 
     /* do this here before any threads exist, so there's no race condition. */
-    #if defined(__MACOSX__) || defined(__IPHONEOS__) || defined(__LINUX__)
+    #if defined(__MACOSX__) || defined(__IPHONEOS__) || defined(__linux__)
     if (!checked_setname) {
         void *fn = dlsym(RTLD_DEFAULT, "pthread_setname_np");
         #if defined(__MACOSX__) || defined(__IPHONEOS__)
         ppthread_setname_np = (int(*)(const char*)) fn;
-        #elif defined(__LINUX__)
+        #elif defined(__linux__)
         ppthread_setname_np = (int(*)(pthread_t, const char*)) fn;
         #endif
         checked_setname = SDL_TRUE;
@@ -131,12 +131,12 @@ SDL_SYS_SetupThread(const char *name)
 #endif /* !__NACL__ */
 
     if (name != NULL) {
-        #if defined(__MACOSX__) || defined(__IPHONEOS__) || defined(__LINUX__)
+        #if defined(__MACOSX__) || defined(__IPHONEOS__) || defined(__linux__)
         SDL_assert(checked_setname);
         if (ppthread_setname_np != NULL) {
             #if defined(__MACOSX__) || defined(__IPHONEOS__)
             ppthread_setname_np(name);
-            #elif defined(__LINUX__)
+            #elif defined(__linux__)
             ppthread_setname_np(pthread_self(), name);
             #endif
         }
@@ -183,7 +183,7 @@ SDL_ThreadID(void)
     return ((SDL_threadID) pthread_self());
 }
 
-#if __LINUX__
+#if __linux__
 /**
    \brief Sets the SDL priority (not nice level) for a thread, using setpriority() if appropriate, and RealtimeKit if available.
    Differs from SDL_LinuxSetThreadPriority in also taking the desired scheduler policy,
@@ -255,7 +255,7 @@ SDL_SYS_SetThreadPriority(SDL_ThreadPriority priority)
         policy = pri_policy;
     }
 
-#if __LINUX__
+#if __linux__
     {
         pid_t linuxTid = syscall(SYS_gettid);
         return SDL_LinuxSetThreadPriorityAndPolicy(linuxTid, priority, policy);

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -215,7 +215,7 @@ ShouldUseTextureFramebuffer()
     /* Mac OS X uses OpenGL as the native fast path (for cocoa and X11) */
     return SDL_TRUE;
 
-#elif defined(__LINUX__)
+#elif defined(__linux__)
     /* Properly configured OpenGL drivers are faster than MIT-SHM */
 #if SDL_VIDEO_OPENGL
     /* Ugh, find a way to cache this value! */

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -79,7 +79,7 @@ get_classname()
     the application's .desktop file as the class." */
 
     char *spot;
-#if defined(__LINUX__) || defined(__FREEBSD__)
+#if defined(__linux__) || defined(__FREEBSD__)
     char procfile[1024];
     char linkfile[1024];
     int linksize;
@@ -98,8 +98,8 @@ get_classname()
     }
 
     /* Next look at the application's executable name */
-#if defined(__LINUX__) || defined(__FREEBSD__)
-#if defined(__LINUX__)
+#if defined(__linux__) || defined(__FREEBSD__)
+#if defined(__linux__)
     SDL_snprintf(procfile, SDL_arraysize(procfile), "/proc/%d/exe", getpid());
 #elif defined(__FREEBSD__)
     SDL_snprintf(procfile, SDL_arraysize(procfile), "/proc/%d/file",
@@ -117,7 +117,7 @@ get_classname()
             return SDL_strdup(linkfile);
         }
     }
-#endif /* __LINUX__ || __FREEBSD__ */
+#endif /* __linux__ || __FREEBSD__ */
 
     /* Finally use the default we've used forever */
     return SDL_strdup("SDL_App");

--- a/src/video/x11/SDL_x11video.c
+++ b/src/video/x11/SDL_x11video.c
@@ -52,7 +52,7 @@ static char *
 get_classname()
 {
     char *spot;
-#if defined(__LINUX__) || defined(__FREEBSD__)
+#if defined(__linux__) || defined(__FREEBSD__)
     char procfile[1024];
     char linkfile[1024];
     int linksize;
@@ -65,8 +65,8 @@ get_classname()
     }
 
     /* Next look at the application's executable name */
-#if defined(__LINUX__) || defined(__FREEBSD__)
-#if defined(__LINUX__)
+#if defined(__linux__) || defined(__FREEBSD__)
+#if defined(__linux__)
     SDL_snprintf(procfile, SDL_arraysize(procfile), "/proc/%d/exe", getpid());
 #elif defined(__FREEBSD__)
     SDL_snprintf(procfile, SDL_arraysize(procfile), "/proc/%d/file",
@@ -84,7 +84,7 @@ get_classname()
             return SDL_strdup(linkfile);
         }
     }
-#endif /* __LINUX__ || __FREEBSD__ */
+#endif /* __linux__ || __FREEBSD__ */
 
     /* Finally use the default we've used forever */
     return SDL_strdup("SDL_App");

--- a/test/testgles2.c
+++ b/test/testgles2.c
@@ -21,7 +21,7 @@
 #include "SDL_test_common.h"
 
 #if defined(__IPHONEOS__) || defined(__ANDROID__) || defined(__EMSCRIPTEN__) || defined(__NACL__) \
-    || defined(__WINDOWS__) || defined(__LINUX__)
+    || defined(__WINDOWS__) || defined(__linux__)
 #define HAVE_OPENGLES2
 #endif
 

--- a/test/testgles2_sdf.c
+++ b/test/testgles2_sdf.c
@@ -21,7 +21,7 @@
 #include "SDL_test_common.h"
 
 #if defined(__IPHONEOS__) || defined(__ANDROID__) || defined(__EMSCRIPTEN__) || defined(__NACL__) \
-    || defined(__WINDOWS__) || defined(__LINUX__)
+    || defined(__WINDOWS__) || defined(__linux__)
 #define HAVE_OPENGLES2
 #endif
 

--- a/visualtest/include/SDL_visualtest_process.h
+++ b/visualtest/include/SDL_visualtest_process.h
@@ -10,7 +10,7 @@
 #if defined(__WIN32__)
 #include <Windows.h>
 #include <Shlwapi.h>
-#elif defined(__LINUX__)
+#elif defined(__linux__)
 #include <unistd.h>
 #else
 #error "Unsupported platform."
@@ -33,7 +33,7 @@ typedef struct SDL_ProcessInfo
 #if defined(__WIN32__)
     PROCESS_INFORMATION pi;
 //#elif defined(__linux__)
-#elif defined(__LINUX__)
+#elif defined(__linux__)
     int pid;
 #endif
 } SDL_ProcessInfo;

--- a/visualtest/src/linux/linux_process.c
+++ b/visualtest/src/linux/linux_process.c
@@ -17,7 +17,7 @@
 #include "SDL_visualtest_harness_argparser.h"
 #include "SDL_visualtest_parsehelper.h"
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 static void
 LogLastError(char* str)

--- a/visualtest/src/testharness.c
+++ b/visualtest/src/testharness.c
@@ -19,7 +19,7 @@
 #include <direct.h>
 #elif defined(__WIN32__) && defined(__CYGWIN__)
 #include <signal.h>
-#elif defined(__LINUX__)
+#elif defined(__linux__)
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <signal.h>
@@ -63,7 +63,7 @@ usage()
 }
 
 /* register Ctrl+C handlers */
-#if defined(__LINUX__) || defined(__CYGWIN__)
+#if defined(__linux__) || defined(__CYGWIN__)
 static void
 CtrlCHandlerCallback(int signum)
 {
@@ -405,7 +405,7 @@ main(int argc, char* argv[])
         goto cleanup_generic;
     }
 
-#if defined(__LINUX__) || defined(__CYGWIN__)
+#if defined(__linux__) || defined(__CYGWIN__)
     signal(SIGINT, CtrlCHandlerCallback);
 #endif
 
@@ -428,7 +428,7 @@ main(int argc, char* argv[])
     }
 
     /* create an output directory if none exists */
-#if defined(__LINUX__) || defined(__CYGWIN__)
+#if defined(__linux__) || defined(__CYGWIN__)
     mkdir(state.output_dir, 0777);
 #elif defined(__WIN32__)
     _mkdir(state.output_dir);


### PR DESCRIPTION
The correct define is `__linux__`, not `__LINUX__`.

## Description

When building SDL from the repo the build fails when `__LINUX__` is not defined, this is because the correct define is `__linux__` as I confirmed on both gentoo and slackware.
```
$ gcc -dM -E - < /dev/null | grep -i __LINUX__
#define __linux__ 1

$ clang -dM -E - < /dev/null | grep -i __LINUX__
#define __linux__ 1
```
On gentoo I see this in the ebuild:
```
# libsdl2-2.0.14 build regression. Please check if still needed
append-flags -D__LINUX__
```
https://gitweb.gentoo.org/repo/gentoo.git/tree/media-libs/libsdl2/libsdl2-2.0.14-r2.ebuild?id=5f6375e53e17b51ce1f6617b7f4069cc508b6627#n114

## Existing Issue(s)
```
libtool: compile:  gcc -g -O3 -DUSING_GENERATED_CONFIG_H -Iinclude -I/tmp/SDL/include -idirafter /tmp/SDL/src/video/khronos -mmmx -m3dnow -msse -msse2 -msse3 -Wall -fno-strict-aliasing -fvisibility=hidden -Wdeclaration-after-statement -Werror=declaration-after-statement -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include -I/tmp/SDL/src/hidapi/hidapi -D_REENTRANT -DHAVE_LINUX_VERSION_H -MMD -MT build/SDL_systhread.lo -c /tmp/SDL/src/thread/pthread/SDL_systhread.c  -fPIC -DPIC -o build/.libs/SDL_systhread.o
/tmp/SDL/src/thread/pthread/SDL_systhread.c: In function ‘SDL_SYS_CreateThread’:
/tmp/SDL/src/thread/pthread/SDL_systhread.c:96:20: warning: implicit declaration of function ‘dlsym’ [-Wimplicit-function-declaration]
   96 |         void *fn = dlsym(RTLD_DEFAULT, "pthread_setname_np");
      |                    ^~~~~
/tmp/SDL/src/thread/pthread/SDL_systhread.c:96:26: error: ‘RTLD_DEFAULT’ undeclared (first use in this function)
   96 |         void *fn = dlsym(RTLD_DEFAULT, "pthread_setname_np");
      |                          ^~~~~~~~~~~~
/tmp/SDL/src/thread/pthread/SDL_systhread.c:96:26: note: each undeclared identifier is reported only once for each function it appears in
/tmp/SDL/src/thread/pthread/SDL_systhread.c: In function ‘SDL_SYS_SetThreadPriority’:
/tmp/SDL/src/thread/pthread/SDL_systhread.c:260:26: warning: implicit declaration of function ‘syscall’ [-Wimplicit-function-declaration]
  260 |         pid_t linuxTid = syscall(SYS_gettid);
      |                          ^~~~~~~
/tmp/SDL/src/thread/pthread/SDL_systhread.c:260:34: error: ‘SYS_gettid’ undeclared (first use in this function)
  260 |         pid_t linuxTid = syscall(SYS_gettid);
      |                                  ^~~~~~~~~~
make: *** [Makefile:714: build/SDL_systhread.lo] Error 1
/bin/sh build-scripts/updaterev.sh
/bin/sh ./libtool --tag=CC --mode=compile gcc -g -O3 -DUSING_GENERATED_CONFIG_H -Iinclude -I/tmp/SDL/include -idirafter /tmp/SDL/src/video/khronos  -mmmx -m3dnow -msse -msse2 -msse3 -Wall -fno-strict-aliasing -fvisibility=hidden -Wdeclaration-after-statement -Werror=declaration-after-statement   -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include  -I/tmp/SDL/src/hidapi/hidapi -D_REENTRANT -DHAVE_LINUX_VERSION_H -MMD -MT build/SDL_systhread.lo -c /tmp/SDL/src/thread/pthread/SDL_systhread.c -o build/SDL_systhread.lo
libtool: compile:  gcc -g -O3 -DUSING_GENERATED_CONFIG_H -Iinclude -I/tmp/SDL/include -idirafter /tmp/SDL/src/video/khronos -mmmx -m3dnow -msse -msse2 -msse3 -Wall -fno-strict-aliasing -fvisibility=hidden -Wdeclaration-after-statement -Werror=declaration-after-statement -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include -I/tmp/SDL/src/hidapi/hidapi -D_REENTRANT -DHAVE_LINUX_VERSION_H -MMD -MT build/SDL_systhread.lo -c /tmp/SDL/src/thread/pthread/SDL_systhread.c  -fPIC -DPIC -o build/.libs/SDL_systhread.o
/tmp/SDL/src/thread/pthread/SDL_systhread.c: In function ‘SDL_SYS_CreateThread’:
/tmp/SDL/src/thread/pthread/SDL_systhread.c:96:20: warning: implicit declaration of function ‘dlsym’ [-Wimplicit-function-declaration]
   96 |         void *fn = dlsym(RTLD_DEFAULT, "pthread_setname_np");
      |                    ^~~~~
/tmp/SDL/src/thread/pthread/SDL_systhread.c:96:26: error: ‘RTLD_DEFAULT’ undeclared (first use in this function)
   96 |         void *fn = dlsym(RTLD_DEFAULT, "pthread_setname_np");
      |                          ^~~~~~~~~~~~
/tmp/SDL/src/thread/pthread/SDL_systhread.c:96:26: note: each undeclared identifier is reported only once for each function it appears in
/tmp/SDL/src/thread/pthread/SDL_systhread.c: In function ‘SDL_SYS_SetThreadPriority’:
/tmp/SDL/src/thread/pthread/SDL_systhread.c:260:26: warning: implicit declaration of function ‘syscall’ [-Wimplicit-function-declaration]
  260 |         pid_t linuxTid = syscall(SYS_gettid);
      |                          ^~~~~~~
/tmp/SDL/src/thread/pthread/SDL_systhread.c:260:34: error: ‘SYS_gettid’ undeclared (first use in this function)
  260 |         pid_t linuxTid = syscall(SYS_gettid);
      |                                  ^~~~~~~~~~
make: *** [Makefile:714: build/SDL_systhread.lo] Error 1
```
