### PR TITLE
winrt: Fix support for multiple simultaneous mouse button presses

### DIFF
--- a/src/core/winrt/SDL_winrtapp_direct3d.cpp
+++ b/src/core/winrt/SDL_winrtapp_direct3d.cpp
@@ -729,15 +729,18 @@ void SDL_WinRTApp::OnExiting(Platform::Object^ sender, Platform::Object^ args)
 static void
 WINRT_LogPointerEvent(const char * header, Windows::UI::Core::PointerEventArgs ^ args, Windows::Foundation::Point transformedPoint)
 {
+    Uint8 button, pressed;
     Windows::UI::Input::PointerPoint ^ pt = args->CurrentPoint;
-    SDL_Log("%s: Position={%f,%f}, Transformed Pos={%f, %f}, MouseWheelDelta=%d, FrameId=%d, PointerId=%d, SDL button=%d\n",
+    WINRT_GetSDLButtonForPointerPoint(pt, &button, &pressed);
+    SDL_Log("%s: Position={%f,%f}, Transformed Pos={%f, %f}, MouseWheelDelta=%d, FrameId=%d, PointerId=%d, SDL button=%d pressed=%d\n",
         header,
         pt->Position.X, pt->Position.Y,
         transformedPoint.X, transformedPoint.Y,
         pt->Properties->MouseWheelDelta,
         pt->FrameId,
         pt->PointerId,
-        WINRT_GetSDLButtonForPointerPoint(pt));
+        button,
+        pressed);
 }
 
 void SDL_WinRTApp::OnPointerPressed(CoreWindow^ sender, PointerEventArgs^ args)

--- a/src/video/winrt/SDL_winrtevents_c.h
+++ b/src/video/winrt/SDL_winrtevents_c.h
@@ -53,7 +53,7 @@ typedef enum {
 extern Windows::Foundation::Point WINRT_TransformCursorPosition(SDL_Window * window,
                                                                 Windows::Foundation::Point rawPosition,
                                                                 WINRT_CursorNormalizationType normalization);
-extern Uint8 WINRT_GetSDLButtonForPointerPoint(Windows::UI::Input::PointerPoint ^pt);
+extern SDL_bool WINRT_GetSDLButtonForPointerPoint(Windows::UI::Input::PointerPoint ^pt, Uint8 *button, Uint8 *pressed);
 extern void WINRT_ProcessPointerPressedEvent(SDL_Window *window, Windows::UI::Input::PointerPoint ^pointerPoint);
 extern void WINRT_ProcessPointerMovedEvent(SDL_Window *window, Windows::UI::Input::PointerPoint ^pointerPoint);
 extern void WINRT_ProcessPointerReleasedEvent(SDL_Window *window, Windows::UI::Input::PointerPoint ^pointerPoint);

--- a/src/video/winrt/SDL_winrtpointerinput.cpp
+++ b/src/video/winrt/SDL_winrtpointerinput.cpp
@@ -116,8 +116,8 @@ WINRT_TransformCursorPosition(SDL_Window * window,
     return outputPosition;
 }
 
-Uint8
-WINRT_GetSDLButtonForPointerPoint(Windows::UI::Input::PointerPoint ^pt)
+SDL_bool
+WINRT_GetSDLButtonForPointerPoint(Windows::UI::Input::PointerPoint ^pt, Uint8 *button, Uint8 *pressed)
 {
     using namespace Windows::UI::Input;
 
@@ -128,30 +128,42 @@ WINRT_GetSDLButtonForPointerPoint(Windows::UI::Input::PointerPoint ^pt)
     {
         case PointerUpdateKind::LeftButtonPressed:
         case PointerUpdateKind::LeftButtonReleased:
-            return SDL_BUTTON_LEFT;
+            *button = SDL_BUTTON_LEFT;
+            *pressed = (pt->Properties->PointerUpdateKind == PointerUpdateKind::LeftButtonPressed);
+            return SDL_TRUE;
 
         case PointerUpdateKind::RightButtonPressed:
         case PointerUpdateKind::RightButtonReleased:
-            return SDL_BUTTON_RIGHT;
+            *button = SDL_BUTTON_RIGHT;
+            *pressed = (pt->Properties->PointerUpdateKind == PointerUpdateKind::RightButtonPressed);
+            return SDL_TRUE;
 
         case PointerUpdateKind::MiddleButtonPressed:
         case PointerUpdateKind::MiddleButtonReleased:
-            return SDL_BUTTON_MIDDLE;
+            *button = SDL_BUTTON_MIDDLE;
+            *pressed = (pt->Properties->PointerUpdateKind == PointerUpdateKind::MiddleButtonPressed);
+            return SDL_TRUE;
 
         case PointerUpdateKind::XButton1Pressed:
         case PointerUpdateKind::XButton1Released:
-            return SDL_BUTTON_X1;
+            *button = SDL_BUTTON_X1;
+            *pressed = (pt->Properties->PointerUpdateKind == PointerUpdateKind::XButton1Pressed);
+            return SDL_TRUE;
 
         case PointerUpdateKind::XButton2Pressed:
         case PointerUpdateKind::XButton2Released:
-            return SDL_BUTTON_X2;
+            *button = SDL_BUTTON_X2;
+            *pressed = (pt->Properties->PointerUpdateKind == PointerUpdateKind::XButton2Pressed);
+            return SDL_TRUE;
 
         default:
             break;
     }
 #endif
 
-    return 0;
+    *button = 0;
+    *pressed = 0;
+    return SDL_FALSE;
 }
 
 //const char *
@@ -211,9 +223,10 @@ void WINRT_ProcessPointerPressedEvent(SDL_Window *window, Windows::UI::Input::Po
         return;
     }
 
-    Uint8 button = WINRT_GetSDLButtonForPointerPoint(pointerPoint);
-
     if ( ! WINRT_IsTouchEvent(pointerPoint)) {
+        Uint8 button, pressed;
+        WINRT_GetSDLButtonForPointerPoint(pointerPoint, &button, &pressed);
+        SDL_assert(pressed == 1);
         SDL_SendMouseButton(window, 0, SDL_PRESSED, button);
     } else {
         Windows::Foundation::Point normalizedPoint = WINRT_TransformCursorPosition(window, pointerPoint->Position, NormalizeZeroToOne);
@@ -241,6 +254,12 @@ WINRT_ProcessPointerMovedEvent(SDL_Window *window, Windows::UI::Input::PointerPo
     Windows::Foundation::Point windowPoint = WINRT_TransformCursorPosition(window, pointerPoint->Position, TransformToSDLWindowSize);
 
     if ( ! WINRT_IsTouchEvent(pointerPoint)) {
+        /* For some odd reason Moved events are used for multiple mouse buttons */
+        Uint8 button, pressed;
+        if (WINRT_GetSDLButtonForPointerPoint(pointerPoint, &button, &pressed)) {
+            SDL_SendMouseButton(window, 0, pressed, button);
+        }
+
         SDL_SendMouseMotion(window, 0, 0, (int)windowPoint.X, (int)windowPoint.Y);
     } else {
         SDL_SendTouchMotion(
@@ -259,9 +278,10 @@ void WINRT_ProcessPointerReleasedEvent(SDL_Window *window, Windows::UI::Input::P
         return;
     }
 
-    Uint8 button = WINRT_GetSDLButtonForPointerPoint(pointerPoint);
-
     if (!WINRT_IsTouchEvent(pointerPoint)) {
+        Uint8 button, pressed;
+        WINRT_GetSDLButtonForPointerPoint(pointerPoint, &button, &pressed);
+        SDL_assert(pressed == 0);
         SDL_SendMouseButton(window, 0, SDL_RELEASED, button);
     } else {
         Windows::Foundation::Point normalizedPoint = WINRT_TransformCursorPosition(window, pointerPoint->Position, NormalizeZeroToOne);


### PR DESCRIPTION
Today in "we swear we didn't slap together a mouse API based on an earlier touch API," it appears the reason UWP couldn't process multiple mouse buttons at the same time is because rather than fire a press event for each one, it fires a press for the first event and then treats all other presses as _move_ events. No, I'm not totally sure why either. The good news is that while the event API is junk, the structure passed in the event gives us enough information to simulate the events within SDL's event queue. The result: Press/Release events are exactly as they were before, while move events check for secret press/release events hidden inside the PointerPoint.

Fixes #3908, https://github.com/FNA-XNA/FNA/issues/338

CC @PumpkinPaul