### PR TITLE
Improve WSCONS backend

### DIFF
--- a/src/core/openbsd/SDL_wscons_kbd.c
+++ b/src/core/openbsd/SDL_wscons_kbd.c
@@ -255,6 +255,7 @@ static struct wscons_keycode_to_SDL {
     {KS_Num_Lock, SDL_SCANCODE_NUMLOCKCLEAR},
     {KS_Caps_Lock, SDL_SCANCODE_CAPSLOCK},
     {KS_BackSpace, SDL_SCANCODE_BACKSPACE},
+    {KS_space, SDL_SCANCODE_SPACE},
     {KS_Delete, SDL_SCANCODE_BACKSPACE},
     {KS_Home, SDL_SCANCODE_HOME},
     {KS_End, SDL_SCANCODE_END},

--- a/src/core/openbsd/SDL_wscons_mouse.c
+++ b/src/core/openbsd/SDL_wscons_mouse.c
@@ -103,12 +103,12 @@ void updateMouse(SDL_WSCONS_mouse_input_data* inputData)
                 break;
             case WSCONS_EVENT_MOUSE_DELTA_X:
                 {
-                    SDL_SendMouseMotion(mouse->focus, mouse->mouseID, 1, events[i].value * 2, 0);
+                    SDL_SendMouseMotion(mouse->focus, mouse->mouseID, 1, events[i].value, 0);
                     break;
                 }
             case WSCONS_EVENT_MOUSE_DELTA_Y:
                 {
-                    SDL_SendMouseMotion(mouse->focus, mouse->mouseID, 1, 0, -events[i].value * 2);
+                    SDL_SendMouseMotion(mouse->focus, mouse->mouseID, 1, 0, -events[i].value);
                     break;
                 }
             case WSCONS_EVENT_MOUSE_DELTA_W:


### PR DESCRIPTION
## Description
This PR improves WSCONS backend.

1. Adds missing Space key to WSCONS-to-SDL conversion table.
2. Removes WSCONS mouse scaling.
