### PR TITLE
Fixes for fullscreen mode

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1589,6 +1589,22 @@ SDL_CreateWindow(const char *title, int x, int y, int w, int h, Uint32 flags)
         displayIndex = SDL_GetIndexOfDisplay(display);
         SDL_GetDisplayBounds(displayIndex, &bounds);
 
+        /* for real fullscreen we might switch the resolution, so get width and height
+         * from closest supported mode and use that instead of current resolution
+         */
+        if ((flags & SDL_WINDOW_FULLSCREEN_DESKTOP) != SDL_WINDOW_FULLSCREEN_DESKTOP
+              && (bounds.w != w || bounds.h != h)) {
+            SDL_DisplayMode fullscreen_mode, closest_mode;
+            SDL_zero(fullscreen_mode);
+            fullscreen_mode.w = w;
+            fullscreen_mode.h = h;
+            if(SDL_GetClosestDisplayModeForDisplay(display, &fullscreen_mode, &closest_mode) != NULL) {
+                bounds.w = closest_mode.w;
+                bounds.h = closest_mode.h;
+            }
+        }
+        window->fullscreen_mode.w = bounds.w;
+        window->fullscreen_mode.h = bounds.h;
         window->x = bounds.x;
         window->y = bounds.y;
         window->w = bounds.w;

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1154,6 +1154,12 @@ SDL_SetWindowDisplayMode(SDL_Window * window, const SDL_DisplayMode * mode)
         SDL_DisplayMode fullscreen_mode;
         if (SDL_GetWindowDisplayMode(window, &fullscreen_mode) == 0) {
             SDL_SetDisplayModeForDisplay(SDL_GetDisplayForWindow(window), &fullscreen_mode);
+            /* make sure the window size (and internals like window-surface size) are adjusted */
+            if (window->w != fullscreen_mode.w || window->h != fullscreen_mode.h) {
+                window->w = fullscreen_mode.w;
+                window->h = fullscreen_mode.h;
+                SDL_OnWindowResized(window);
+            }
         }
     }
     return 0;


### PR DESCRIPTION
SDL_CreateWindow() with SDL_WINDOW_FULLSCREEN didn't work on Windows if resolution is higher than desktop resolution.

SDL_SetWindowDisplayMode() on a fullscreen window switches the display resolution, but didn't set `window->w` and `window->h` and doesn't adjust the size of the window-surface either.

## Description
Setting `window->fullscreen.w` and `.h` to a resolution as close as possible to the requested one (using SDL_GetClosestDisplayModeForDisplay()) in SDL_CreateWindow() (if called with SDL_WINDOW_FULLSCREEN) fixes the first issue.

The second issue is fixed by setting `window->w` and `->h` and after setting the new display mode in SDL_SetWindowDisplayMode(), and then calling SDL_OnWindowResized() to make sure it's applied.
(I hope this is the correct/best way?)

## Existing Issue(s)
Fixes #3313
