### PR TITLE
Adding Generic Trigger Effect to Joystick

### DIFF
--- a/include/SDL_gamecontroller.h
+++ b/include/SDL_gamecontroller.h
@@ -781,19 +781,41 @@ extern DECLSPEC int SDLCALL SDL_GameControllerGetSensorData(SDL_GameController *
 extern DECLSPEC int SDLCALL SDL_GameControllerRumble(SDL_GameController *gamecontroller, Uint16 low_frequency_rumble, Uint16 high_frequency_rumble, Uint32 duration_ms);
 
 /**
- * Start a rumble effect in the game controller's triggers.
+ * Start an effect in the controller's triggers
  *
- * Each call to this function cancels any previous trigger rumble effect, and
- * calling it with 0 intensity stops any rumbling.
+ * Each call to this function cancels any previous trigger effect unless the
+ * parameter is null, in which case the previous effect is left untouched.
  *
- * Note that this is rumbling of the _triggers_ and not the game controller as
- * a whole. The first controller to offer this feature was the PlayStation 5's
- * DualShock 5.
+ * \param gamecontroller The game controller to perform the effect
+ * \param left_effect A pointer to the description of the trigger effect for the
+ *                     left trigger
+ * \param right_effect A pointer to the description of the trigger effect for the
+ *                     right trigger
+ * \param duration_ms The duration of the effect, in milliseconds. 
+                       SDL_JOYSTICK_TRIGGER_NO_EFFECT is applied after this time.
+ *
+ * \returns 0, or -1 if this trigger effect isn't supported on this controller
+ */
+extern DECLSPEC int SDLCALL SDL_GameControllerSetTriggerEffect(SDL_GameController *gamecontroller, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect, Uint32 duration_ms);
+
+/**
+ * Start a rumble effect in the controller's triggers
+ *
+ * Each call to this function cancels any previous trigger effect,
+ * and calling it with 0 intensity stops any rumbling.
+ *
+ * Note that this function is for _trigger_ rumble; the first controller to
+ * support this was the Xbox One controller. If you want
+ * the (more common) whole-controller rumble, use SDL_JoystickRumble() instead.
+ * 
+ * Under the hood, this function calls SDL_JoystickSetTriggerEffect with 
+ * SDL_JOYSTICK_TRIGGER_RUMBLE as the mode.
  *
  * \param gamecontroller The controller to vibrate
  * \param left_rumble The intensity of the left trigger rumble motor, from 0
  *                    to 0xFFFF
- * \param right_rumble The intensity of the right trigger rumble motor, from 0 to 0xFFFF
+ * \param right_rumble The intensity of the right trigger rumble motor, from 0
+ *                     to 0xFFFF
  * \param duration_ms The duration of the rumble effect, in milliseconds
  *
  * \returns 0, or -1 if trigger rumble isn't supported on this controller

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -812,3 +812,5 @@
 #define SDL_TLSCleanup SDL_TLSCleanup_REAL
 #define SDL_SetWindowAlwaysOnTop SDL_SetWindowAlwaysOnTop_REAL
 #define SDL_FlashWindow SDL_FlashWindow_REAL
+#define SDL_GameControllerSetTriggerEffect SDL_GameControllerSetTriggerEffect_REAL
+#define SDL_JoystickSetTriggerEffect SDL_JoystickSetTriggerEffect_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -877,3 +877,5 @@ SDL_DYNAPI_PROC(int,SDL_GetAudioDeviceSpec,(int a, int b, SDL_AudioSpec *c),(a,b
 SDL_DYNAPI_PROC(void,SDL_TLSCleanup,(void),(),)
 SDL_DYNAPI_PROC(void,SDL_SetWindowAlwaysOnTop,(SDL_Window *a, SDL_bool b),(a,b),)
 SDL_DYNAPI_PROC(int,SDL_FlashWindow,(SDL_Window *a, Uint32 b),(a, b),return)
+SDL_DYNAPI_PROC(int,SDL_GameControllerSetTriggerEffect,(SDL_GameController *a, const SDL_JoystickTriggerEffect *b, const SDL_JoystickTriggerEffect *c, Uint32 d),(a,b,c,d),return)
+SDL_DYNAPI_PROC(int,SDL_JoystickSetTriggerEffect,(SDL_Joystick *a, const SDL_JoystickTriggerEffect *b, const SDL_JoystickTriggerEffect *c, Uint32 d),(a,b,c,d),return)

--- a/src/joystick/SDL_gamecontroller.c
+++ b/src/joystick/SDL_gamecontroller.c
@@ -2381,11 +2381,16 @@ SDL_GameControllerButtonBind SDL_GameControllerGetBindForButton(SDL_GameControll
     return bind;
 }
 
-
 int
 SDL_GameControllerRumble(SDL_GameController *gamecontroller, Uint16 low_frequency_rumble, Uint16 high_frequency_rumble, Uint32 duration_ms)
 {
     return SDL_JoystickRumble(SDL_GameControllerGetJoystick(gamecontroller), low_frequency_rumble, high_frequency_rumble, duration_ms);
+}
+
+int
+SDL_GameControllerSetTriggerEffect(SDL_GameController *gamecontroller, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect, Uint32 duration_ms)
+{
+    return SDL_JoystickSetTriggerEffect(SDL_GameControllerGetJoystick(gamecontroller), left_effect, right_effect, duration_ms);
 }
 
 int

--- a/src/joystick/SDL_sysjoystick.h
+++ b/src/joystick/SDL_sysjoystick.h
@@ -92,9 +92,9 @@ struct _SDL_Joystick
     Uint16 high_frequency_rumble;
     Uint32 rumble_expiration;
 
-    Uint16 left_trigger_rumble;
-    Uint16 right_trigger_rumble;
-    Uint32 trigger_rumble_expiration;
+    SDL_JoystickTriggerEffect left_trigger_effect;
+    SDL_JoystickTriggerEffect right_trigger_effect;
+    Uint32 trigger_effect_expiration;
 
     Uint8 led_red;
     Uint8 led_green;
@@ -160,7 +160,7 @@ typedef struct _SDL_JoystickDriver
 
     /* Rumble functionality */
     int (*Rumble)(SDL_Joystick *joystick, Uint16 low_frequency_rumble, Uint16 high_frequency_rumble);
-    int (*RumbleTriggers)(SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble);
+    int (*TriggerEffect)(SDL_Joystick *joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect);
 
     /* LED functionality */
     SDL_bool (*HasLED)(SDL_Joystick *joystick);

--- a/src/joystick/android/SDL_sysjoystick.c
+++ b/src/joystick/android/SDL_sysjoystick.c
@@ -611,7 +611,7 @@ ANDROID_JoystickRumble(SDL_Joystick * joystick, Uint16 low_frequency_rumble, Uin
 }
 
 static int
-ANDROID_JoystickRumbleTriggers(SDL_Joystick * joystick, Uint16 left_rumble, Uint16 right_rumble)
+ANDROID_JoystickSetTriggerEffect(SDL_Joystick * joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
     return SDL_Unsupported();
 }
@@ -712,7 +712,7 @@ SDL_JoystickDriver SDL_ANDROID_JoystickDriver =
     ANDROID_JoystickGetDeviceInstanceID,
     ANDROID_JoystickOpen,
     ANDROID_JoystickRumble,
-    ANDROID_JoystickRumbleTriggers,
+    ANDROID_JoystickSetTriggerEffect,
     ANDROID_JoystickHasLED,
     ANDROID_JoystickSetLED,
     ANDROID_JoystickSetSensorsEnabled,

--- a/src/joystick/bsd/SDL_bsdjoystick.c
+++ b/src/joystick/bsd/SDL_bsdjoystick.c
@@ -766,7 +766,7 @@ BSD_JoystickRumble(SDL_Joystick *joystick, Uint16 low_frequency_rumble, Uint16 h
 }
 
 static int
-BSD_JoystickRumbleTriggers(SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble)
+BSD_JoystickSetTriggerEffect(SDL_Joystick *joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
     return SDL_Unsupported();
 }
@@ -807,7 +807,7 @@ SDL_JoystickDriver SDL_BSD_JoystickDriver =
     BSD_JoystickGetDeviceInstanceID,
     BSD_JoystickOpen,
     BSD_JoystickRumble,
-    BSD_JoystickRumbleTriggers,
+    BSD_JoystickSetTriggerEffect,
     BSD_JoystickHasLED,
     BSD_JoystickSetLED,
     BSD_JoystickSetSensorsEnabled,

--- a/src/joystick/darwin/SDL_iokitjoystick.c
+++ b/src/joystick/darwin/SDL_iokitjoystick.c
@@ -934,7 +934,7 @@ DARWIN_JoystickRumble(SDL_Joystick * joystick, Uint16 low_frequency_rumble, Uint
 }
 
 static int
-DARWIN_JoystickRumbleTriggers(SDL_Joystick * joystick, Uint16 left_rumble, Uint16 right_rumble)
+DARWIN_JoystickSetTriggerEffect(SDL_Joystick * joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
     return SDL_Unsupported();
 }
@@ -1104,7 +1104,7 @@ SDL_JoystickDriver SDL_DARWIN_JoystickDriver =
     DARWIN_JoystickGetDeviceInstanceID,
     DARWIN_JoystickOpen,
     DARWIN_JoystickRumble,
-    DARWIN_JoystickRumbleTriggers,
+    DARWIN_JoystickSetTriggerEffect,
     DARWIN_JoystickHasLED,
     DARWIN_JoystickSetLED,
     DARWIN_JoystickSetSensorsEnabled,

--- a/src/joystick/dummy/SDL_sysjoystick.c
+++ b/src/joystick/dummy/SDL_sysjoystick.c
@@ -90,7 +90,7 @@ DUMMY_JoystickRumble(SDL_Joystick *joystick, Uint16 low_frequency_rumble, Uint16
 }
 
 static int
-DUMMY_JoystickRumbleTriggers(SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble)
+DUMMY_JoystickSetTriggerEffect(SDL_Joystick *joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
     return SDL_Unsupported();
 }
@@ -146,7 +146,7 @@ SDL_JoystickDriver SDL_DUMMY_JoystickDriver =
     DUMMY_JoystickGetDeviceInstanceID,
     DUMMY_JoystickOpen,
     DUMMY_JoystickRumble,
-    DUMMY_JoystickRumbleTriggers,
+    DUMMY_JoystickSetTriggerEffect,
     DUMMY_JoystickHasLED,
     DUMMY_JoystickSetLED,
     DUMMY_JoystickSetSensorsEnabled,

--- a/src/joystick/emscripten/SDL_sysjoystick.c
+++ b/src/joystick/emscripten/SDL_sysjoystick.c
@@ -403,7 +403,7 @@ EMSCRIPTEN_JoystickRumble(SDL_Joystick *joystick, Uint16 low_frequency_rumble, U
 }
 
 static int
-EMSCRIPTEN_JoystickRumbleTriggers(SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble)
+EMSCRIPTEN_JoystickSetTriggerEffect(SDL_Joystick *joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
     return SDL_Unsupported();
 }
@@ -444,7 +444,7 @@ SDL_JoystickDriver SDL_EMSCRIPTEN_JoystickDriver =
     EMSCRIPTEN_JoystickGetDeviceInstanceID,
     EMSCRIPTEN_JoystickOpen,
     EMSCRIPTEN_JoystickRumble,
-    EMSCRIPTEN_JoystickRumbleTriggers,
+    EMSCRIPTEN_JoystickSetTriggerEffect,
     EMSCRIPTEN_JoystickHasLED,
     EMSCRIPTEN_JoystickSetLED,
     EMSCRIPTEN_JoystickSetSensorsEnabled,

--- a/src/joystick/haiku/SDL_haikujoystick.cc
+++ b/src/joystick/haiku/SDL_haikujoystick.cc
@@ -260,7 +260,7 @@ extern "C"
     }
 
 
-    static int HAIKU_JoystickRumbleTriggers(SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble)
+    static int HAIKU_JoystickSetTriggerEffect(SDL_Joystick *joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
     {
         return SDL_Unsupported();
     }
@@ -298,7 +298,7 @@ extern "C"
         HAIKU_JoystickGetDeviceInstanceID,
         HAIKU_JoystickOpen,
         HAIKU_JoystickRumble,
-        HAIKU_JoystickRumbleTriggers,
+        HAIKU_JoystickSetTriggerEffect,
         HAIKU_JoystickHasLED,
         HAIKU_JoystickSetLED,
         HAIKU_JoystickSetSensorsEnabled,

--- a/src/joystick/hidapi/SDL_hidapi_gamecube.c
+++ b/src/joystick/hidapi/SDL_hidapi_gamecube.c
@@ -459,7 +459,7 @@ HIDAPI_DriverGameCube_RumbleJoystick(SDL_HIDAPI_Device *device, SDL_Joystick *jo
 }
 
 static int
-HIDAPI_DriverGameCube_RumbleJoystickTriggers(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble)
+HIDAPI_DriverGameCube_SetTriggerEffect(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
     return SDL_Unsupported();
 }
@@ -525,7 +525,7 @@ SDL_HIDAPI_DeviceDriver SDL_HIDAPI_DriverGameCube =
     HIDAPI_DriverGameCube_UpdateDevice,
     HIDAPI_DriverGameCube_OpenJoystick,
     HIDAPI_DriverGameCube_RumbleJoystick,
-    HIDAPI_DriverGameCube_RumbleJoystickTriggers,
+    HIDAPI_DriverGameCube_SetTriggerEffect,
     HIDAPI_DriverGameCube_HasJoystickLED,
     HIDAPI_DriverGameCube_SetJoystickLED,
     HIDAPI_DriverGameCube_SetJoystickSensorsEnabled,

--- a/src/joystick/hidapi/SDL_hidapi_ps4.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps4.c
@@ -626,7 +626,7 @@ HIDAPI_DriverPS4_RumbleJoystick(SDL_HIDAPI_Device *device, SDL_Joystick *joystic
 }
 
 static int
-HIDAPI_DriverPS4_RumbleJoystickTriggers(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble)
+HIDAPI_DriverPS4_SetTriggerEffect(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
     return SDL_Unsupported();
 }
@@ -918,7 +918,7 @@ SDL_HIDAPI_DeviceDriver SDL_HIDAPI_DriverPS4 =
     HIDAPI_DriverPS4_UpdateDevice,
     HIDAPI_DriverPS4_OpenJoystick,
     HIDAPI_DriverPS4_RumbleJoystick,
-    HIDAPI_DriverPS4_RumbleJoystickTriggers,
+    HIDAPI_DriverPS4_SetTriggerEffect,
     HIDAPI_DriverPS4_HasJoystickLED,
     HIDAPI_DriverPS4_SetJoystickLED,
     HIDAPI_DriverPS4_SetJoystickSensorsEnabled,

--- a/src/joystick/hidapi/SDL_hidapi_stadia.c
+++ b/src/joystick/hidapi/SDL_hidapi_stadia.c
@@ -124,7 +124,7 @@ HIDAPI_DriverStadia_RumbleJoystick(SDL_HIDAPI_Device *device, SDL_Joystick *joys
 }
 
 static int
-HIDAPI_DriverStadia_RumbleJoystickTriggers(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble)
+HIDAPI_DriverStadia_SetTriggerEffect(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
     return SDL_Unsupported();
 }
@@ -311,7 +311,7 @@ SDL_HIDAPI_DeviceDriver SDL_HIDAPI_DriverStadia =
     HIDAPI_DriverStadia_UpdateDevice,
     HIDAPI_DriverStadia_OpenJoystick,
     HIDAPI_DriverStadia_RumbleJoystick,
-    HIDAPI_DriverStadia_RumbleJoystickTriggers,
+    HIDAPI_DriverStadia_SetTriggerEffect,
     HIDAPI_DriverStadia_HasJoystickLED,
     HIDAPI_DriverStadia_SetJoystickLED,
     HIDAPI_DriverStadia_SetJoystickSensorsEnabled,

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1039,7 +1039,7 @@ HIDAPI_DriverSteam_RumbleJoystick(SDL_HIDAPI_Device *device, SDL_Joystick *joyst
 }
 
 static int
-HIDAPI_DriverSteam_RumbleJoystickTriggers(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble)
+HIDAPI_DriverSteam_SetTriggerEffect(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
     return SDL_Unsupported();
 }
@@ -1204,7 +1204,7 @@ SDL_HIDAPI_DeviceDriver SDL_HIDAPI_DriverSteam =
     HIDAPI_DriverSteam_UpdateDevice,
     HIDAPI_DriverSteam_OpenJoystick,
     HIDAPI_DriverSteam_RumbleJoystick,
-    HIDAPI_DriverSteam_RumbleJoystickTriggers,
+    HIDAPI_DriverSteam_SetTriggerEffect,
     HIDAPI_DriverSteam_HasJoystickLED,
     HIDAPI_DriverSteam_SetJoystickLED,
     HIDAPI_DriverSteam_SetSensorsEnabled,

--- a/src/joystick/hidapi/SDL_hidapi_switch.c
+++ b/src/joystick/hidapi/SDL_hidapi_switch.c
@@ -1034,7 +1034,7 @@ HIDAPI_DriverSwitch_RumbleJoystick(SDL_HIDAPI_Device *device, SDL_Joystick *joys
 }
 
 static int
-HIDAPI_DriverSwitch_RumbleJoystickTriggers(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble)
+HIDAPI_DriverSwitch_SetTriggerEffect(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
     return SDL_Unsupported();
 }
@@ -1494,7 +1494,7 @@ SDL_HIDAPI_DeviceDriver SDL_HIDAPI_DriverSwitch =
     HIDAPI_DriverSwitch_UpdateDevice,
     HIDAPI_DriverSwitch_OpenJoystick,
     HIDAPI_DriverSwitch_RumbleJoystick,
-    HIDAPI_DriverSwitch_RumbleJoystickTriggers,
+    HIDAPI_DriverSwitch_SetTriggerEffect,
     HIDAPI_DriverSwitch_HasJoystickLED,
     HIDAPI_DriverSwitch_SetJoystickLED,
     HIDAPI_DriverSwitch_SetJoystickSensorsEnabled,

--- a/src/joystick/hidapi/SDL_hidapi_xbox360.c
+++ b/src/joystick/hidapi/SDL_hidapi_xbox360.c
@@ -198,7 +198,7 @@ HIDAPI_DriverXbox360_RumbleJoystick(SDL_HIDAPI_Device *device, SDL_Joystick *joy
 }
 
 static int
-HIDAPI_DriverXbox360_RumbleJoystickTriggers(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble)
+HIDAPI_DriverXbox360_SetTriggerEffect(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
     return SDL_Unsupported();
 }
@@ -339,7 +339,7 @@ SDL_HIDAPI_DeviceDriver SDL_HIDAPI_DriverXbox360 =
     HIDAPI_DriverXbox360_UpdateDevice,
     HIDAPI_DriverXbox360_OpenJoystick,
     HIDAPI_DriverXbox360_RumbleJoystick,
-    HIDAPI_DriverXbox360_RumbleJoystickTriggers,
+    HIDAPI_DriverXbox360_SetTriggerEffect,
     HIDAPI_DriverXbox360_HasJoystickLED,
     HIDAPI_DriverXbox360_SetJoystickLED,
     HIDAPI_DriverXbox360_SetJoystickSensorsEnabled,

--- a/src/joystick/hidapi/SDL_hidapi_xbox360w.c
+++ b/src/joystick/hidapi/SDL_hidapi_xbox360w.c
@@ -168,7 +168,7 @@ HIDAPI_DriverXbox360W_RumbleJoystick(SDL_HIDAPI_Device *device, SDL_Joystick *jo
 }
 
 static int
-HIDAPI_DriverXbox360W_RumbleJoystickTriggers(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble)
+HIDAPI_DriverXbox360W_SetTriggerEffect(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
     return SDL_Unsupported();
 }
@@ -336,7 +336,7 @@ SDL_HIDAPI_DeviceDriver SDL_HIDAPI_DriverXbox360W =
     HIDAPI_DriverXbox360W_UpdateDevice,
     HIDAPI_DriverXbox360W_OpenJoystick,
     HIDAPI_DriverXbox360W_RumbleJoystick,
-    HIDAPI_DriverXbox360W_RumbleJoystickTriggers,
+    HIDAPI_DriverXbox360W_SetTriggerEffect,
     HIDAPI_DriverXbox360W_HasJoystickLED,
     HIDAPI_DriverXbox360W_SetJoystickLED,
     HIDAPI_DriverXbox360W_SetJoystickSensorsEnabled,

--- a/src/joystick/hidapi/SDL_hidapijoystick.c
+++ b/src/joystick/hidapi/SDL_hidapijoystick.c
@@ -1309,14 +1309,14 @@ HIDAPI_JoystickRumble(SDL_Joystick * joystick, Uint16 low_frequency_rumble, Uint
 }
 
 static int
-HIDAPI_JoystickRumbleTriggers(SDL_Joystick * joystick, Uint16 left_rumble, Uint16 right_rumble)
+HIDAPI_JoystickSetTriggerEffect(SDL_Joystick * joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
     int result;
 
     if (joystick->hwdata) {
         SDL_HIDAPI_Device *device = joystick->hwdata->device;
 
-        result = device->driver->RumbleJoystickTriggers(device, joystick, left_rumble, right_rumble);
+        result = device->driver->TriggerEffect(device, joystick, left_effect, right_effect);
     } else {
         SDL_SetError("Rumble failed, device disconnected");
         result = -1;
@@ -1464,7 +1464,7 @@ SDL_JoystickDriver SDL_HIDAPI_JoystickDriver =
     HIDAPI_JoystickGetDeviceInstanceID,
     HIDAPI_JoystickOpen,
     HIDAPI_JoystickRumble,
-    HIDAPI_JoystickRumbleTriggers,
+    HIDAPI_JoystickSetTriggerEffect,
     HIDAPI_JoystickHasLED,
     HIDAPI_JoystickSetLED,
     HIDAPI_JoystickSetSensorsEnabled,

--- a/src/joystick/hidapi/SDL_hidapijoystick_c.h
+++ b/src/joystick/hidapi/SDL_hidapijoystick_c.h
@@ -95,7 +95,7 @@ typedef struct _SDL_HIDAPI_DeviceDriver
     SDL_bool (*UpdateDevice)(SDL_HIDAPI_Device *device);
     SDL_bool (*OpenJoystick)(SDL_HIDAPI_Device *device, SDL_Joystick *joystick);
     int (*RumbleJoystick)(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, Uint16 low_frequency_rumble, Uint16 high_frequency_rumble);
-    int (*RumbleJoystickTriggers)(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble);
+    int (*TriggerEffect)(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect);
     SDL_bool (*HasJoystickLED)(SDL_HIDAPI_Device *device, SDL_Joystick *joystick);
     int (*SetJoystickLED)(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, Uint8 red, Uint8 green, Uint8 blue);
     int (*SetJoystickSensorsEnabled)(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, SDL_bool enabled);

--- a/src/joystick/linux/SDL_sysjoystick.c
+++ b/src/joystick/linux/SDL_sysjoystick.c
@@ -1072,7 +1072,7 @@ LINUX_JoystickRumble(SDL_Joystick *joystick, Uint16 low_frequency_rumble, Uint16
 }
 
 static int
-LINUX_JoystickRumbleTriggers(SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble)
+LINUX_JoystickSetTriggerEffect(SDL_Joystick *joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
     return SDL_Unsupported();
 }
@@ -1600,7 +1600,7 @@ SDL_JoystickDriver SDL_LINUX_JoystickDriver =
     LINUX_JoystickGetDeviceInstanceID,
     LINUX_JoystickOpen,
     LINUX_JoystickRumble,
-    LINUX_JoystickRumbleTriggers,
+    LINUX_JoystickSetTriggerEffect,
     LINUX_JoystickHasLED,
     LINUX_JoystickSetLED,
     LINUX_JoystickSetSensorsEnabled,

--- a/src/joystick/os2/SDL_os2joystick.c
+++ b/src/joystick/os2/SDL_os2joystick.c
@@ -469,7 +469,7 @@ static int OS2_JoystickRumble(SDL_Joystick *joystick, Uint16 low_frequency_rumbl
 	return SDL_Unsupported();
 }
 
-static int OS2_JoystickRumbleTriggers(SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble)
+static int OS2_JoystickSetTriggerEffect(SDL_Joystick *joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
 	return SDL_Unsupported();
 }
@@ -774,7 +774,7 @@ SDL_JoystickDriver SDL_OS2_JoystickDriver =
 	OS2_JoystickGetDeviceInstanceID,
 	OS2_JoystickOpen,
 	OS2_JoystickRumble,
-	OS2_JoystickRumbleTriggers,
+	OS2_JoystickSetTriggerEffect,
 	OS2_JoystickHasLED,
 	OS2_JoystickSetLED,
 	OS2_JoystickSetSensorsEnabled,

--- a/src/joystick/psp/SDL_sysjoystick.c
+++ b/src/joystick/psp/SDL_sysjoystick.c
@@ -204,7 +204,7 @@ PSP_JoystickRumble(SDL_Joystick *joystick, Uint16 low_frequency_rumble, Uint16 h
 }
 
 static int
-PSP_JoystickRumbleTriggers(SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble)
+PSP_JoystickSetTriggerEffect(SDL_Joystick *joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
     return SDL_Unsupported();
 }
@@ -304,7 +304,7 @@ SDL_JoystickDriver SDL_PSP_JoystickDriver =
     PSP_JoystickGetDeviceInstanceID,
     PSP_JoystickOpen,
     PSP_JoystickRumble,
-    PSP_JoystickRumbleTriggers,
+    PSP_JoystickSetTriggerEffect,
     PSP_JoystickHasLED,
     PSP_JoystickSetLED,
     PSP_JoystickSetSensorsEnabled,

--- a/src/joystick/virtual/SDL_virtualjoystick.c
+++ b/src/joystick/virtual/SDL_virtualjoystick.c
@@ -339,7 +339,7 @@ VIRTUAL_JoystickRumble(SDL_Joystick * joystick, Uint16 low_frequency_rumble, Uin
 }
 
 static int
-VIRTUAL_JoystickRumbleTriggers(SDL_Joystick * joystick, Uint16 left_rumble, Uint16 right_rumble)
+VIRTUAL_JoystickSetTriggerEffect(SDL_Joystick * joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
     return SDL_Unsupported();
 }
@@ -435,7 +435,7 @@ SDL_JoystickDriver SDL_VIRTUAL_JoystickDriver =
     VIRTUAL_JoystickGetDeviceInstanceID,
     VIRTUAL_JoystickOpen,
     VIRTUAL_JoystickRumble,
-    VIRTUAL_JoystickRumbleTriggers,
+    VIRTUAL_JoystickSetTriggerEffect,
     VIRTUAL_JoystickHasLED,
     VIRTUAL_JoystickSetLED,
     VIRTUAL_JoystickSetSensorsEnabled,

--- a/src/joystick/vita/SDL_sysjoystick.c
+++ b/src/joystick/vita/SDL_sysjoystick.c
@@ -360,7 +360,7 @@ VITA_JoystickRumble(SDL_Joystick * joystick, Uint16 low_frequency_rumble, Uint16
 }
 
 static int
-VITA_JoystickRumbleTriggers(SDL_Joystick * joystick, Uint16 left, Uint16 right)
+VITA_JoystickSetTriggerEffect(SDL_Joystick * joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
     return SDL_Unsupported();
 }
@@ -401,7 +401,7 @@ SDL_JoystickDriver SDL_VITA_JoystickDriver =
     VITA_JoystickOpen,
 
     VITA_JoystickRumble,
-    VITA_JoystickRumbleTriggers,
+    VITA_JoystickSetTriggerEffect,
 
     VITA_JoystickHasLED,
     VITA_JoystickSetLED,

--- a/src/joystick/windows/SDL_mmjoystick.c
+++ b/src/joystick/windows/SDL_mmjoystick.c
@@ -329,7 +329,7 @@ WINMM_JoystickRumble(SDL_Joystick *joystick, Uint16 low_frequency_rumble, Uint16
 }
 
 static int
-WINMM_JoystickRumbleTriggers(SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble)
+WINMM_JoystickSetTriggerEffect(SDL_Joystick *joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
     return SDL_Unsupported();
 }
@@ -493,7 +493,7 @@ SDL_JoystickDriver SDL_WINMM_JoystickDriver =
     WINMM_JoystickGetDeviceInstanceID,
     WINMM_JoystickOpen,
     WINMM_JoystickRumble,
-    WINMM_JoystickRumbleTriggers,
+    WINMM_JoystickSetTriggerEffect,
     WINMM_JoystickHasLED,
     WINMM_JoystickSetLED,
     WINMM_JoystickSetSensorsEnabled,

--- a/src/joystick/windows/SDL_windowsjoystick.c
+++ b/src/joystick/windows/SDL_windowsjoystick.c
@@ -562,7 +562,7 @@ WINDOWS_JoystickRumble(SDL_Joystick * joystick, Uint16 low_frequency_rumble, Uin
 }
 
 static int
-WINDOWS_JoystickRumbleTriggers(SDL_Joystick * joystick, Uint16 left_rumble, Uint16 right_rumble)
+WINDOWS_JoystickSetTriggerEffect(SDL_Joystick * joystick, const SDL_JoystickTriggerEffect *left_effect, const SDL_JoystickTriggerEffect *right_effect)
 {
     return SDL_Unsupported();
 }
@@ -656,7 +656,7 @@ SDL_JoystickDriver SDL_WINDOWS_JoystickDriver =
     WINDOWS_JoystickGetDeviceInstanceID,
     WINDOWS_JoystickOpen,
     WINDOWS_JoystickRumble,
-    WINDOWS_JoystickRumbleTriggers,
+    WINDOWS_JoystickSetTriggerEffect,
     WINDOWS_JoystickHasLED,
     WINDOWS_JoystickSetLED,
     WINDOWS_JoystickSetSensorsEnabled,


### PR DESCRIPTION
Adds a generic trigger effect feature for joysticks and gamepads

## Description
This PR builds upon the existing trigger rumble to generalize the effect that can be done on triggers.
The previous function function TriggerRumble still exists to rpeserve legacy, but the backend is completely replaced by the SetTriggerEffect nomenclature.
The effect is described as a struct to fill up by the caller and passing its pointer. The struct can then be expanded as necessary without changing the signature of the interface.
The different effects are identified in an exposed enum (such as rumble, constant or segment) in which the numeric value currently matches the Dualsense mode identifier (since it is the only controller handling more than a single effect).

## Existing Issue(s)
Need to test on Xbox One controller, since I don't have one.
Need to find Dualsense rumbling values to match Xbox One Impulse Trigger Rumbling

I currently use these changes in JoyShockMapper
