### PR TITLE
kmsdrm regression fixes

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmopengles.c
+++ b/src/video/kmsdrm/SDL_kmsdrmopengles.c
@@ -97,6 +97,11 @@ KMSDRM_GLES_SwapWindow(_THIS, SDL_Window * window) {
        even if you do async flips. */
     uint32_t flip_flags = DRM_MODE_PAGE_FLIP_EVENT;
 
+    /* Recreate the GBM / EGL surfaces if the display mode has changed */
+    if (windata->egl_surface_dirty) {
+        KMSDRM_CreateSurfaces(_this, window);
+    }
+
     /* Wait for confirmation that the next front buffer has been flipped, at which
        point the previous front buffer can be released */
     if (!KMSDRM_WaitPageflip(_this, windata)) {

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -953,6 +953,8 @@ KMSDRM_CreateSurfaces(_THIS, SDL_Window * window)
     egl_context = (EGLContext)SDL_GL_GetCurrentContext();
     ret = SDL_EGL_MakeCurrent(_this, windata->egl_surface, egl_context);
 
+    windata->egl_surface_dirty = SDL_FALSE;
+
 cleanup:
 
     if (ret) {
@@ -1075,10 +1077,11 @@ KMSDRM_SetDisplayMode(_THIS, SDL_VideoDisplay * display, SDL_DisplayMode * mode)
 
     for (i = 0; i < viddata->num_windows; i++) {
         SDL_Window *window = viddata->windows[i];
+        SDL_WindowData *windata = (SDL_WindowData *)window->driverdata;
 
-        if (KMSDRM_CreateSurfaces(_this, window)) {
-            return -1;
-        }
+        /* Can't recreate EGL surfaces right now, need to wait until SwapWindow
+           so the correct thread-local surface and context state are available */
+        windata->egl_surface_dirty = SDL_TRUE;
 
         /* Tell app about the window resize */
         SDL_SendWindowEvent(window, SDL_WINDOWEVENT_RESIZED, mode->w, mode->h);

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -551,7 +551,6 @@ void KMSDRM_AddDisplay (_THIS, drmModeConnector *connector, drmModeRes *resource
 
     /* Initialize some of the members of the new display's driverdata
        to sane values. */
-    dispdata->modeset_pending = SDL_FALSE;
     dispdata->cursor_bo = NULL;
 
     /* Since we create and show the default cursor on KMSDRM_InitMouse(),
@@ -1073,7 +1072,6 @@ KMSDRM_SetDisplayMode(_THIS, SDL_VideoDisplay * display, SDL_DisplayMode * mode)
     /* Take note of the new mode to be set, and leave the CRTC modeset pending
        so it's done in SwapWindow. */
     dispdata->mode = conn->modes[modedata->mode_index];
-    dispdata->modeset_pending = SDL_TRUE; 
 
     for (i = 0; i < viddata->num_windows; i++) {
         SDL_Window *window = viddata->windows[i];
@@ -1256,9 +1254,6 @@ KMSDRM_CreateWindow(_THIS, SDL_Window * window)
             dispdata->mode = dispdata->original_mode;
         }
 
-        /* Take note to do the modesettng on the CRTC in SwapWindow. */
-        dispdata->modeset_pending = SDL_TRUE;
-
         /* Create the window surfaces with the size we have just chosen.
            Needs the window diverdata in place. */
         if ((ret = KMSDRM_CreateSurfaces(_this, window))) {
@@ -1348,7 +1343,6 @@ KMSDRM_ReconfigureWindow( _THIS, SDL_Window * window)
     /* Recreate the GBM (and EGL) surfaces, and mark the CRTC mode/fb setting
        as pending so it's done on SwapWindow.  */
     KMSDRM_CreateSurfaces(_this, window);
-    dispdata->modeset_pending = SDL_TRUE;
 
     /* Tell app about the size we have determined for the window,
        so SDL pre-scales to that size for us. */

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -1312,29 +1312,23 @@ KMSDRM_ReconfigureWindow( _THIS, SDL_Window * window)
 {
     SDL_VideoDisplay *display = SDL_GetDisplayForWindow(window);
     SDL_DisplayData *dispdata = display->driverdata;
-    uint32_t refresh_rate = 0;
 
-    if ((window->flags & SDL_WINDOW_FULLSCREEN_DESKTOP) ==
-                         SDL_WINDOW_FULLSCREEN_DESKTOP)
+    if ((window->flags & SDL_WINDOW_FULLSCREEN) ==
+                         SDL_WINDOW_FULLSCREEN)
     {
-
+        /* Nothing to do, honor the most recent mode requested by the user */
+    }
+    else if ((window->flags & SDL_WINDOW_FULLSCREEN_DESKTOP) ==
+                              SDL_WINDOW_FULLSCREEN_DESKTOP)
+    {
         /* Update the current mode to the desktop mode. */
         dispdata->mode = dispdata->original_mode;
-
     } else {
-
         drmModeModeInfo *mode;
-
-        /* Refresh rate is only important for fullscreen windows. */
-        if ((window->flags & SDL_WINDOW_FULLSCREEN) ==
-                             SDL_WINDOW_FULLSCREEN)
-        {
-            refresh_rate = (uint32_t)window->fullscreen_mode.refresh_rate;
-        }
 
         /* Try to find a valid video mode matching the size of the window. */
         mode = KMSDRM_GetClosestDisplayMode(display,
-          window->windowed.w, window->windowed.h, refresh_rate );
+          window->windowed.w, window->windowed.h, 0);
 
         if (mode) {
             /* If matching mode found, recreate the GBM surface with the size
@@ -1346,11 +1340,6 @@ KMSDRM_ReconfigureWindow( _THIS, SDL_Window * window)
                and setup that mode on the CRTC. */
             dispdata->mode = dispdata->original_mode;
         }
-
-        /* Tell app about the size we have determined for the window,
-           so SDL pre-scales to that size for us. */
-        SDL_SendWindowEvent(window, SDL_WINDOWEVENT_RESIZED,
-                            dispdata->mode.hdisplay, dispdata->mode.vdisplay);
     }
 
     /* Recreate the GBM (and EGL) surfaces, and mark the CRTC mode/fb setting

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.h
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.h
@@ -100,12 +100,6 @@ typedef struct SDL_WindowData
 
     EGLSurface egl_surface;
 
-    /* The size we chose for the GBM surface. REMEMBER that the CRTC must always have
-       a mode with the same size configured before trying to flip to a buffer of that
-       surface or drmModePageFlip() will return -28. */
-    uint32_t surface_w;
-    uint32_t surface_h;
-
 } SDL_WindowData;
 
 typedef struct KMSDRM_FBInfo

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.h
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.h
@@ -99,7 +99,7 @@ typedef struct SDL_WindowData
     SDL_bool double_buffer;
 
     EGLSurface egl_surface;
-
+    SDL_bool egl_surface_dirty;
 } SDL_WindowData;
 
 typedef struct KMSDRM_FBInfo

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.h
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.h
@@ -80,8 +80,6 @@ typedef struct SDL_DisplayData
     uint64_t cursor_w, cursor_h;
 
     SDL_bool default_cursor_init;
-    SDL_bool modeset_pending;
-
 } SDL_DisplayData;
 
 typedef struct SDL_WindowData


### PR DESCRIPTION
Hi,

I last updated SDL at commit 850d9c8c0daff485a07f065846ef0b00d067b258 at which point the KMSDRM backend was working well for my use case (https://redream.io). However, after updating to the latest I was having a number of issues:

* The mode requested in KMSDRM_SetDisplayMode wasn't updating the new surface_w / surface_h variables which caused the surface being created to be out of sync with the mode set. This fix is fairly straight forward.
* The mode requested in KMSDRM_SetDisplayMode wasn't being honored when calling SDL_SetWindowFullscreen(..., SDL_WINDOW_FULLSCREEN). KMSDRM_ReconfigureWindow was using the previous window size to find a mode and overriding the requested mode with that. My patch contains a fix for my particular case, but as mentioned in the commit message I'm still worried by the behavior of overriding the user's requested mode in other cases. AFAIK you should be able to toggle fullscreen with SDL_SetWindowFullscreen without having to call into SDL_SetWindowDisplayMode on other backends.
* There was previously code in KMSDRM_SetDisplayMode to defer the surface creation until the surface was first presented so that calls to SDL_GL_GetCurrentContext and SDL_EGL_MakeCurrent were accessing the correct thread-local state in the case of multiple threads / contexts. This was removed which was causing multi-threaded rendering to implode. The commit that removed it was somewhat vague, so I'm not sure of the correct fix here. My commit reverts the removal of this code, but there may need to be some more work to split up the creation of the surfaces / binding of the context in case the surfaces truly do need to be created immediately inside of KMSDRM_SetDisplayMode.

There are more notes in each commit message tracking the changes that led to each regression. While these commits fix my particular use case, there's likely some discussion to be had regarding how to correctly address all use cases.