### PR TITLE
Removed duplicate SDL_AtomicGet()

### DIFF
--- a/src/audio/coreaudio/SDL_coreaudio.m
+++ b/src/audio/coreaudio/SDL_coreaudio.m
@@ -601,7 +601,7 @@ inputCallback(void *inUserData, AudioQueueRef inAQ, AudioQueueBufferRef inBuffer
     }
 
     /* ignore unless we're active. */
-    if (!SDL_AtomicGet(&this->paused) && SDL_AtomicGet(&this->enabled) && !SDL_AtomicGet(&this->paused)) {
+    if (!SDL_AtomicGet(&this->paused) && SDL_AtomicGet(&this->enabled)) {
         const Uint8 *ptr = (const Uint8 *) inBuffer->mAudioData;
         UInt32 remaining = inBuffer->mAudioDataByteSize;
         while (remaining > 0) {


### PR DESCRIPTION
Removed duplicate SDL_AtomicGet() for the paused value.

Not sure if there was a reason for putting two of them in the if-clause since it could theoretically matter if it is important that the second check for paused is always done last. But in that case you could remove the first instance instead.