### PR TITLE
Have HIDAPI skip MFI supported HID devices on macOS to avoid duplicate devices

### DIFF
--- a/src/hidapi/mac/hid.c
+++ b/src/hidapi/mac/hid.c
@@ -488,6 +488,13 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 			continue;
 		}
 
+		#if defined(SDL_JOYSTICK_MFI) && defined(__MACOSX__)
+		extern SDL_bool IOS_SupportedHIDDevice(IOHIDDeviceRef device);
+		if (IOS_SupportedHIDDevice(dev)) {
+			continue;
+		}
+		#endif
+
 		dev_vid = get_vendor_id(dev);
 		dev_pid = get_product_id(dev);
 		


### PR DESCRIPTION
HIDAPI needs to ignore devices supported by Apple's Game Controller framework in the same way IOKit joystick does to avoid duplicate devices.

There's probably a few ways to handle this, but this seems to be the simplest patch to make.