### PR TITLE
Added T500RS to known wheel list

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -2063,6 +2063,7 @@ static SDL_bool SDL_IsJoystickProductWheel(Uint32 vidpid)
         MAKE_VIDPID(0x044f, 0xb66d),    /* Thrustmaster Wheel FFB */
         MAKE_VIDPID(0x044f, 0xb677),    /* Thrustmaster T150 */
         MAKE_VIDPID(0x044f, 0xb66e),    /* Thrustmaster T300RS */
+        MAKE_VIDPID(0x044f, 0xb65e),    /* Thrustmaster T500RS */
         MAKE_VIDPID(0x044f, 0xb664),    /* Thrustmaster TX (initial mode) */
         MAKE_VIDPID(0x044f, 0xb669),    /* Thrustmaster TX (active mode) */
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the T500RS to the list of known wheels when querying the device type.

lsusb: `Bus 003 Device 005: ID 044f:b65e ThrustMaster, Inc. TRS Racing wheel`

dmesg after plugging in the device using https://github.com/cazzoo/hid-tmff2 / https://github.com/scarburato/hid-tminit/
```
[  924.442276] usb 3-6.2: new full-speed USB device number 4 using xhci_hcd
[  924.540297] usb 3-6.2: New USB device found, idVendor=044f, idProduct=b65d, bcdDevice= 1.00
[  924.540304] usb 3-6.2: New USB device strings: Mfr=1, Product=2, SerialNumber=0
[  924.540307] usb 3-6.2: Product: Thrustmaster FFB Wheel
[  924.540309] usb 3-6.2: Manufacturer: Thrustmaster
[  924.628496] input: Thrustmaster Thrustmaster FFB Wheel as /devices/pci0000:00/0000:00:01.2/0000:20:00.0/0000:21:08.0/0000:2a:00.3/usb3/3-6/3-6.2/3-6.2:1.0/0003:044F:B65D.0007/input/input17
[  924.628595] hid-generic 0003:044F:B65D.0007: input,hidraw6: USB HID v1.00 Gamepad [Thrustmaster Thrustmaster FFB Wheel] on usb-0000:2a:00.3-6.2/input0
[  924.660420] input: Thrustmaster Thrustmaster FFB Wheel as /devices/pci0000:00/0000:00:01.2/0000:20:00.0/0000:21:08.0/0000:2a:00.3/usb3/3-6/3-6.2/3-6.2:1.0/0003:044F:B65D.0007/input/input18
[  924.660486] hid-tminit 0003:044F:B65D.0007: input,hidraw6: USB HID v1.00 Gamepad [Thrustmaster Thrustmaster FFB Wheel] on usb-0000:2a:00.3-6.2/input0
[  924.681297] hid-tminit 0003:044F:B65D.0007: Wheel with model id 0x2 is a Thrustmaster T500RS
[  924.683489] hid-tminit 0003:044F:B65D.0007: Success?! The wheel should have been initialized!
[  924.813160] usb 3-6.2: USB disconnect, device number 4
[  925.017272] usb 3-6.2: new full-speed USB device number 5 using xhci_hcd
[  925.120295] usb 3-6.2: New USB device found, idVendor=044f, idProduct=b65e, bcdDevice= 1.00
[  925.120301] usb 3-6.2: New USB device strings: Mfr=1, Product=2, SerialNumber=0
[  925.120304] usb 3-6.2: Product: TRS Racing wheel
[  925.120306] usb 3-6.2: Manufacturer: Thrustmaster
[  925.205507] input: Thrustmaster TRS Racing wheel as /devices/pci0000:00/0000:00:01.2/0000:20:00.0/0000:21:08.0/0000:2a:00.3/usb3/3-6/3-6.2/3-6.2:1.0/0003:044F:B65E.0008/input/input19
[  925.205598] hid-generic 0003:044F:B65E.0008: input,hidraw6: USB HID v1.11 Joystick [Thrustmaster TRS Racing wheel] on usb-0000:2a:00.3-6.2/input0
[  925.241472] input: Thrustmaster TRS Racing wheel as /devices/pci0000:00/0000:00:01.2/0000:20:00.0/0000:21:08.0/0000:2a:00.3/usb3/3-6/3-6.2/3-6.2:1.0/0003:044F:B65E.0008/input/input20
[  925.241556] t500rs 0003:044F:B65E.0008: input,hidraw6: USB HID v1.11 Joystick [Thrustmaster TRS Racing wheel] on usb-0000:2a:00.3-6.2/input0
[  925.243315] t500rs 0003:044F:B65E.0008: force feedback for t500rs
```
and see it being switched from initial mode
`[  924.540297] usb 3-6.2: New USB device found, idVendor=044f, idProduct=b65d, bcdDevice= 1.00`
to
`[  925.120295] usb 3-6.2: New USB device found, idVendor=044f, idProduct=b65e, bcdDevice= 1.00`

## Existing Issue(s)
n/a
