### PR TITLE
Fixes for new wait/wakeup code

### DIFF
--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -594,7 +594,7 @@ SDL_SendWakeupEvent()
         return 0;
     }
     if (!_this->wakeup_lock || SDL_LockMutex(_this->wakeup_lock) == 0) {
-        if (_this->wakeup_window && _this->blocking_thread_id != 0 && _this->blocking_thread_id != SDL_ThreadID()) {
+        if (_this->wakeup_window) {
             _this->SendWakeupEvent(_this, _this->wakeup_window);
         }
         if (_this->wakeup_lock) {
@@ -794,10 +794,8 @@ SDL_WaitEventTimeout_Device(_THIS, SDL_Window *wakeup_window, SDL_Event * event,
             /* If status == 0 we are going to block so wakeup will be needed. */
             if (status == 0) {
                 _this->wakeup_window = wakeup_window;
-                _this->blocking_thread_id = SDL_ThreadID();
             } else {
                 _this->wakeup_window = NULL;
-                _this->blocking_thread_id = 0;
             }
             if (_this->wakeup_lock) {
                 SDL_UnlockMutex(_this->wakeup_lock);

--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -328,7 +328,6 @@ struct SDL_VideoDevice
     SDL_bool is_dummy;
     SDL_bool suspend_screensaver;
     SDL_Window *wakeup_window;
-    SDL_threadID blocking_thread_id;
     SDL_mutex *wakeup_lock; /* Initialized only if WaitEventTimeout/SendWakeupEvent are supported */
     int num_displays;
     SDL_VideoDisplay *displays;

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1303,9 +1303,13 @@ WIN_WaitEventTimeout(_THIS, int timeout)
             TranslateMessage(&msg);
             DispatchMessage(&msg);
             return 1;
+        } else {
+            return 0;
         }
+    } else {
+        /* Fail the wait so the caller falls back to polling */
+        return -1;
     }
-    return 0;
 }
 
 void


### PR DESCRIPTION
This PR contains several bugfixes and an optimization for the recently merged PR #4419 after kicking the tires on the new code a bit.

At least a couple of these are probably 2.0.16 blockers (breaking `SDL_PeepEvent(SDL_ADDEVENT)` wakeup and windows keyboard grab).

## Description
2e4cc77 fixes the case where an SDL application may use `SDL_PeepEvent(SDL_ADDEVENT)` to add an event to the queue. That would not trigger a wakeup of a waiting `SDL_WaitEvent()` call, potentially leading the application to deadlock.

212ac69 fixes the `SDL_HINT_WINDOWS_ENABLE_MESSAGELOOP=0` case where we would never wait at all if no event was already pending for us. In that case, `SDL_WaitEvent()` and `SDL_WaitEventTimeout()` would always immediately return 0, potentially leading to an unintended busy loop. The fix is simply to fall back to polling in that case.

f120c0e avoids doing all the wait setup if the caller itself just wanted to poll once (`SDL_PollEvent()`). I also moved the conditions around a bit to avoid having to call `SDL_events_need_polling()` on every invocation of `SDL_WaitEventTimeout()` if the backend doesn't support waiting.

14f3946 addresses a breakage with win32 keyboard grab (and possibly other cases that I haven't encountered) where we avoid generating the wakeup event if we're running on the same thread that is waiting. The problem with this is that it's not necessarily guaranteed that a callback running on that waiting thread means the wait will end. In particular, this is not the case when handling window hooks. I'm curious to know from @franko whether avoiding the wakeup in this case was just an optimization or actually solved some problem.