### PR TITLE
windows: do not activate the window on SDL_ShowWindow

### DIFF
--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -556,17 +556,8 @@ WIN_GetWindowBordersSize(_THIS, SDL_Window * window, int *top, int *left, int *b
 void
 WIN_ShowWindow(_THIS, SDL_Window * window)
 {
-    DWORD style;
-    HWND hwnd;
-    int nCmdShow;
-    
-    hwnd = ((SDL_WindowData *)window->driverdata)->hwnd;
-    nCmdShow = SW_SHOW;
-    style = GetWindowLong(hwnd, GWL_EXSTYLE);
-    if (style & WS_EX_NOACTIVATE) {
-        nCmdShow = SW_SHOWNOACTIVATE;
-    }
-    ShowWindow(hwnd, nCmdShow);
+    HWND hwnd = ((SDL_WindowData *) window->driverdata)->hwnd;
+    ShowWindow(hwnd, SW_SHOWNA);
 }
 
 void


### PR DESCRIPTION
When calling SDL_ShowWindow on the Windows platform, the window is also activated. Sometimes, it can be undesirable as we only want to show the window without activating it, like for example in the [ImGUI SDL docking backend](https://github.com/ocornut/imgui/blob/docking/backends/imgui_impl_sdl.cpp) :


```
#if defined(_WIN32)
    [...]
    // SDL hack: SDL always activate/focus windows :/
    if (viewport->Flags & ImGuiViewportFlags_NoFocusOnAppearing)
    {
      ::ShowWindow(hwnd, SW_SHOWNA);
      return;
    }
#endif

SDL_ShowWindow(data->Window);
```

If the user need to activate the window, he can simply call SDL_RaiseWindow right after SDL_ShowWindow.