### PR TITLE
Windows: Fix SDL_GetBasePath() truncating paths

### DIFF
--- a/src/filesystem/windows/SDL_sysfilesystem.c
+++ b/src/filesystem/windows/SDL_sysfilesystem.c
@@ -68,7 +68,9 @@ SDL_GetBasePath(void)
         path = (WCHAR *) ptr;
 
         len = pGetModuleFileNameExW(GetCurrentProcess(), NULL, path, buflen);
-        if (len != buflen) {
+        /* if it truncated, then len >= buflen - 1 */
+        /* if there was enough room (or failure), len < buflen - 1 */
+        if (len < buflen - 1) {
             break;
         }
 


### PR DESCRIPTION
Tested on Windows 10 x64, versions 19041 and 10586.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`SDL_GetBasePath` tries to reallocate its temporary buffer for long paths, but `GetModuleFileNameExW` always truncates and succeeds, so `len` was always equal to `buflen - 1` which is 127.

Easily fixed by checking for `buflen - 1` instead of `buflen`.

For paths longer than MAX_PATH, this problem sometimes got hidden by Windows path shortening (`C:\PROGRA~1\` etc.).

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
~~No issue for this bug AFAICT.~~

**EDIT: Fixes https://github.com/libsdl-org/SDL/issues/4439.**

Originally caused by the patch written for https://github.com/libsdl-org/SDL/issues/1390.