### PR TITLE
wayland: Drop SwapWindow calls for hidden windows

### DIFF
--- a/src/video/wayland/SDL_waylandopengles.c
+++ b/src/video/wayland/SDL_waylandopengles.c
@@ -114,6 +114,18 @@ Wayland_GLES_SwapWindow(_THIS, SDL_Window *window)
     SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
     const int swap_interval = _this->egl_data->egl_swapinterval;
 
+    /* For windows that we know are hidden, skip swaps entirely, if we don't do
+     * this compositors will intentionally stall us indefinitely and there's no
+     * way for an end user to show the window, unlike other situations (i.e.
+     * the window is minimized, behind another window, etc.).
+     *
+     * FIXME: Request EGL_WAYLAND_swap_buffers_with_timeout.
+     * -flibit
+     */
+    if (window->flags & SDL_WINDOW_HIDDEN) {
+        return 0;
+    }
+
     /* Control swap interval ourselves. See comments on Wayland_GLES_SetSwapInterval */
     if (swap_interval != 0) {
         struct wl_display *display = ((SDL_VideoData *)_this->driverdata)->display;


### PR DESCRIPTION
Who could have guessed that Wayland SwapWindow would still be problematic???

In doing more testing with larger titles, I've found that some applications will call SwapWindow once or more during startup, before the window has been shown. Unlike _after_ startup this affects every compositor I could get my hands on including GNOME, so at this point I'm just putting this function out of its misery and skipping it entirely when we know the window is completely hidden from the user.

A proper fix would be to introduce a timeout extension that acts the same way as vkAcquireNextImageKHR, but this is easier and involves a lot less paperwork.

Fixes Source 1 games at minimum (though they crash later in Miles for some unknown reason).