### PR TITLE
joystick: Add missing comma in joystick drivers list

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -96,7 +96,7 @@ static SDL_JoystickDriver *SDL_joystick_drivers[] = {
     &SDL_VIRTUAL_JoystickDriver,
 #endif
 #ifdef SDL_JOYSTICK_VITA
-    &SDL_VITA_JoystickDriver
+    &SDL_VITA_JoystickDriver,
 #endif
 #if defined(SDL_JOYSTICK_DUMMY) || defined(SDL_JOYSTICK_DISABLED)
     &SDL_DUMMY_JoystickDriver


### PR DESCRIPTION
Without this comma it is impossible to enable both the Vita and Dummy
drivers at the same time.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>