### PR TITLE
Add missing "SDL_platform.h" includes

### DIFF
--- a/src/core/linux/SDL_threadprio.c
+++ b/src/core/linux/SDL_threadprio.c
@@ -20,6 +20,8 @@
 */
 #include "../../SDL_internal.h"
 
+#include "SDL_platform.h"
+
 #ifdef __LINUX__
 
 #include "SDL_error.h"

--- a/src/thread/pthread/SDL_systhread.c
+++ b/src/thread/pthread/SDL_systhread.c
@@ -20,6 +20,7 @@
 */
 #include "../../SDL_internal.h"
 
+#include "SDL_platform.h"
 #include "SDL_system.h"
 #include "SDL_hints.h"
 


### PR DESCRIPTION
These includes are needed for the ```__LINUX__``` and similar macros to be
available in the source files.

This fixes the build under Linux.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>