### PR TITLE
Additional fixes for wait/wakeup code

### DIFF
--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -596,6 +596,9 @@ SDL_SendWakeupEvent()
     if (!_this->wakeup_lock || SDL_LockMutex(_this->wakeup_lock) == 0) {
         if (_this->wakeup_window) {
             _this->SendWakeupEvent(_this, _this->wakeup_window);
+
+            /* No more wakeup events needed until we enter a new wait */
+            _this->wakeup_window = NULL;
         }
         if (_this->wakeup_lock) {
             SDL_UnlockMutex(_this->wakeup_lock);

--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -788,10 +788,14 @@ SDL_PollEvent(SDL_Event * event)
 static int
 SDL_WaitEventTimeout_Device(_THIS, SDL_Window *wakeup_window, SDL_Event * event, int timeout)
 {
-    /* Release any keys held down from last frame */
-    SDL_ReleaseAutoReleaseKeys();
-
     for (;;) {
+        /* Pump events on entry and each time we wake to ensure:
+           a) All pending events are batch processed after waking up from a wait
+           b) Waiting can be completely skipped if events are already available to be pumped
+           c) Periodic processing that takes place in some platform PumpEvents() functions happens
+        */
+        SDL_PumpEvents();
+
         if (!_this->wakeup_lock || SDL_LockMutex(_this->wakeup_lock) == 0) {
             int status = SDL_PeepEvents(event, 1, SDL_GETEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT);
             /* If status == 0 we are going to block so wakeup will be needed. */


### PR DESCRIPTION
## Description
This PR contains 2 bugfixes for the new event wake/wake code.

b77db48 improves performance by avoiding queuing redundant wakeup events and preventing spurious wakeups due to those additional wakeup events.

417c0bc2 fixes issues originating from the lack of calls to `SDL_PumpEvents()`. Win32 and X11 backends perform additional processing in their `PumpEvents()` handler that handles things like updating the cursor clip region and tickling the screensaver, so it needs to run regularly. `PumpEvents()` also performs batch event processing rather than one-at-a-time like `WaitEventTimeout()` does, so it is more efficient to process events this way.