### PR TITLE
PSVita: Add missing lib dependencies for gl-enabled build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2180,6 +2180,15 @@ elseif(VITA)
       SceMotion_stub
       m
     )
+    if(HAVE_VIDEO_VITA_PIB)
+        list(PREPEND EXTRA_LIBS
+          pib
+          libScePiglet_stub
+          SceShaccCg_stub
+          taihen_stub
+        )
+    endif()
+
   endif()
 
   set(HAVE_ARMSIMD TRUE)


### PR DESCRIPTION
## Description

Adds missing libs to pkgconfig/cmake configs, that are required to be linked with app with gl-enabled build onf SDL2