### PR TITLE
Vita: Reset/re-apply viewport on frame start/target change. 

### DIFF
--- a/src/render/vitagxm/SDL_render_vita_gxm.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm.c
@@ -157,6 +157,7 @@ StartDrawing(SDL_Renderer *renderer)
     data->drawstate.fragment_program = NULL;
     data->drawstate.last_command = -1;
     data->drawstate.texture_color = 0xFFFFFFFF;
+    data->drawstate.viewport_dirty = SDL_TRUE;
 
     // reset blend mode
 //    data->currentBlendMode = SDL_BLENDMODE_BLEND;
@@ -379,7 +380,10 @@ VITA_GXM_SetTextureScaleMode(SDL_Renderer * renderer, SDL_Texture * texture, SDL
 static int
 VITA_GXM_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    return 0; // nothing to do here
+    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *) renderer->driverdata;
+
+    data->drawstate.viewport_dirty = SDL_TRUE;
+    return 0;
 }
 
 static void
@@ -417,7 +421,7 @@ VITA_GXM_SetBlendMode(VITA_GXM_RenderData *data, int blendMode)
 static int
 VITA_GXM_QueueSetViewport(SDL_Renderer * renderer, SDL_RenderCommand *cmd)
 {
-    return 0; // TODO
+    return 0;
 }
 
 static int

--- a/src/render/vitagxm/SDL_render_vita_gxm.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm.c
@@ -380,9 +380,6 @@ VITA_GXM_SetTextureScaleMode(SDL_Renderer * renderer, SDL_Texture * texture, SDL
 static int
 VITA_GXM_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *) renderer->driverdata;
-
-    data->drawstate.viewport_dirty = SDL_TRUE;
     return 0;
 }
 


### PR DESCRIPTION
## Description
Fixes SDL_RenderSetLogicalSize on PSVita. GXM resets viewport each frame, so we need to re-apply viewport settings prior to drawing.
