### PR TITLE
Ensure that libgcc is linked statically on Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3870,7 +3870,7 @@ case "$host" in
         else
             LIBUUID=-luuid
         fi
-        EXTRA_LDFLAGS="$EXTRA_LDFLAGS -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lsetupapi -lversion $LIBUUID -static-libgcc"
+        EXTRA_LDFLAGS="$EXTRA_LDFLAGS -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lsetupapi -lversion $LIBUUID -Wc,-static-libgcc"
         # The Windows platform requires special setup
         VERSION_SOURCES="$srcdir/src/main/windows/*.rc"
         SDLMAIN_SOURCES="$srcdir/src/main/windows/*.c"


### PR DESCRIPTION
## Description
Prefixing `-static-libgcc` with `-Wc,` is required to prevent it from being stripped out by libtool.

https://www.gnu.org/software/libtool/manual/html_node/Stripped-link-flags.html#Stripped-link-flags

## Existing Issue(s)
#1622