### PR TITLE
more kmsdrm regression fixes

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmvideo.h
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.h
@@ -68,7 +68,7 @@ typedef struct SDL_DisplayData
     drmModeCrtc *crtc;
     drmModeModeInfo mode;
     drmModeModeInfo original_mode;
-    drmModeModeInfo next_mode; /* New mode to be set on the CRTC. */
+    drmModeModeInfo fullscreen_mode;
 
     drmModeCrtc *saved_crtc;    /* CRTC to restore on quit */
 


### PR DESCRIPTION
Change 270cd3a79e49a18f3658eb8b7a1877a3840effad fixed an issue with the KMSDRM backend when using SDL_SetWindowDisplayMode -> SDL_SetWindowFullscreen to perform a mode set, but it unfortunately broke other use cases for two reasons:

* The KMSDRM backend would early out when SDL_video.c called KMSDRM_SetDisplayMode with the desktop mode. This had been worked around by having KMSDRM_ReconfigureWindow check window->flags for SDL_WINDOW_FULLSCREEN_DESKTOP. When I added the conditional in there to check for SDL_WINDOW_FULLSCREEN it unintentionally caused this workaround to fall apart. I've fixed this in 9bbf0bbf072e2203a330d1dc5d51e9970157a222 by setting the driverdata field on the desktop_mode so KMSDRM_SetDisplayMode works correctly with it, and the workaround is no longer necessary (as far as I understand, SDL_video.c is responsible for handling desktop fullscreen state, the backend is just concerned with doing a mode set if requested).
* The logic in SDL_video.c tracking the current mode would get out of sync with the KMSDRM backend. The KMSDRM backend was previously always overriding the mode requested by KMSDRM_SetDisplayMode by finding whatever mode was closest to the window size which often produced reasonable results, but broke explicit mode sets. When I disabled this logic for fullscreen windows, you could then perform an explicit mode set, but it may not occur due to this state getting out of sync:
  1. SDL adds the display, it's resolution defaults to 1024x768 (which is stored in display->desktop_mode and display->current_mode).
  2. A window is created (with fullscreen desktop flags but a width and height of 640x480) and the KMSDRM backend mode sets to 640x480.
  3. SDL calls SDL_UpdateFullscreenMode which calls SDL_SetDisplayModeForDisplay. This code compares display->desktop-p_mode and display->current_mode but decides not to mode set because they match. However, SDL_UpdateFullscreenMode then [submits an event](https://github.com/libsdl-org/SDL/blob/main/src/video/SDL_video.c#L1357) acting as if the mode set did occur.

  I'm really not sure if this change is sane, but in ae1272c81ae5b56fc5650c47f1c1ddf875c9330a I resorted to hulk-smashing the display's current_mode field inside of KMSDRM_RecreateSurfaces to keep this field in sync so mode set requests don't get ignored.

In addition to those changes, I added d55b0f8d31ec7dc45831bbb8bef01bcf7e09228e to defer surface creation in all cases to avoid issues with multiple contexts and 777bef4ab5203499332d529394ae8835117dffbd to avoid ever overriding the user's requested fullscreen mode.

These fixes should close out https://github.com/libsdl-org/SDL/issues/4417.