### PR TITLE
Add Steam Virtual Gamepad and Xbox 360 Wired Controller defines instead of magic values

### DIFF
--- a/src/joystick/SDL_gamecontroller.c
+++ b/src/joystick/SDL_gamecontroller.c
@@ -1779,11 +1779,12 @@ SDL_bool SDL_ShouldIgnoreGameController(const char *name, SDL_JoystickGUID guid)
 
     if (SDL_GetHintBoolean("SDL_GAMECONTROLLER_ALLOW_STEAM_VIRTUAL_GAMEPAD", SDL_FALSE)) {
         /* We shouldn't ignore Steam's virtual gamepad since it's using the hints to filter out the real controllers so it can remap input for the virtual controller */
+        /* https://partner.steamgames.com/doc/features/steam_controller/steam_input_gamepad_emulation_bestpractices */
         SDL_bool bSteamVirtualGamepad = SDL_FALSE;
 #if defined(__LINUX__)
-        bSteamVirtualGamepad = (vendor == 0x28DE && product == 0x11FF);
+        bSteamVirtualGamepad = (vendor == USB_VENDOR_VALVE && product == USB_PRODUCT_STEAM_VIRTUAL_GAMEPAD);
 #elif defined(__MACOSX__)
-        bSteamVirtualGamepad = (vendor == 0x045E && product == 0x028E && version == 1);
+        bSteamVirtualGamepad = (vendor == USB_VENDOR_MICROSOFT && product == USB_PRODUCT_XBOX360_WIRED_CONTROLLER && version == 1);
 #elif defined(__WIN32__)
         /* We can't tell on Windows, but Steam will block others in input hooks */
         bSteamVirtualGamepad = SDL_TRUE;

--- a/src/joystick/usb_ids.h
+++ b/src/joystick/usb_ids.h
@@ -52,6 +52,7 @@
 #define USB_PRODUCT_SONY_DS4_SLIM                       0x09cc
 #define USB_PRODUCT_SONY_DS5                            0x0ce6
 #define USB_PRODUCT_XBOX360_XUSB_CONTROLLER             0x02a1    /* XUSB driver software PID */
+#define USB_PRODUCT_XBOX360_WIRED_CONTROLLER            0x028e
 #define USB_PRODUCT_XBOX360_WIRELESS_RECEIVER           0x0719
 #define USB_PRODUCT_XBOX_ONE_ELITE_SERIES_1             0x02e3
 #define USB_PRODUCT_XBOX_ONE_ELITE_SERIES_2             0x0b00
@@ -67,6 +68,7 @@
 #define USB_PRODUCT_XBOX_SERIES_X_POWERA_FUSION_PRO2    0x4001
 #define USB_PRODUCT_XBOX_ONE_XBOXGIP_CONTROLLER         0x02ff    /* XBOXGIP driver software PID */
 #define USB_PRODUCT_XBOX_ONE_XINPUT_CONTROLLER          0x02fe    /* Made up product ID for XInput */
+#define USB_PRODUCT_STEAM_VIRTUAL_GAMEPAD               0x11ff
 
 /* USB usage pages */
 #define USB_USAGEPAGE_GENERIC_DESKTOP   0x0001

--- a/src/joystick/windows/SDL_dinputjoystick.c
+++ b/src/joystick/windows/SDL_dinputjoystick.c
@@ -245,7 +245,7 @@ SDL_IsXInputDevice(Uint16 vendor_id, Uint16 product_id, const char* hidPath)
     type = SDL_GetJoystickGameControllerType("", vendor_id, product_id, -1, 0, 0, 0);
     if (type == SDL_CONTROLLER_TYPE_XBOX360 ||
         type == SDL_CONTROLLER_TYPE_XBOXONE ||
-        (vendor_id == 0x28DE && product_id == 0x11FF)) {
+        (vendor_id == USB_VENDOR_VALVE && product_id == USB_PRODUCT_STEAM_VIRTUAL_GAMEPAD)) {
         return SDL_TRUE;
     }
 


### PR DESCRIPTION
See  https://partner.steamgames.com/doc/features/steam_controller/steam_input_gamepad_emulation_bestpractices for details on what is Steam Virtual Gamepad.
