### PR TITLE
Use CMAKE_CURRENT_BINARY_DIR instead of CMAKE_BINARY_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+if(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
   message(FATAL_ERROR "Prevented in-tree built. Please create a build directory outside of the SDL source code and call cmake from there")
 endif()
 


### PR DESCRIPTION
This PR allows for building with cmake's [add_subdirectory](https://cmake.org/cmake/help/latest/command/add_subdirectory.html#command:add_subdirectory) function, like so:
```cmake
# Build and include SDL in main project
add_subdirectory(lib/SDL2 lib/SDL2_BIN EXCLUDE_FROM_ALL)
target_link_libraries(main PRIVATE SDL2)
```
As far as I know (and tested), that is the only change this commit makes; in-tree building is still prevented.