### PR TITLE
Fix ToggleRawInput result when RawInput is not supported

### DIFF
--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -31,7 +31,7 @@ HCURSOR SDL_cursor = NULL;
 
 static int rawInputEnableCount = 0;
 
-static int 
+static int
 ToggleRawInput(SDL_bool enabled)
 {
     RAWINPUTDEVICE rawMouse = { 0x01, 0x02, 0, NULL }; /* Mouse: UsagePage = 1, Usage = 2 */
@@ -57,6 +57,9 @@ ToggleRawInput(SDL_bool enabled)
 
     /* (Un)register raw input for mice */
     if (RegisterRawInputDevices(&rawMouse, 1, sizeof(RAWINPUTDEVICE)) == FALSE) {
+        /* Reset the enable count, otherwise subsequent enable calls will
+           believe raw input is enabled */
+        rawInputEnableCount = 0;
 
         /* Only return an error when registering. If we unregister and fail,
            then it's probably that we unregistered twice. That's OK. */


### PR DESCRIPTION
When `RegisterRawInputDevices` fails, reset `rawInputEnableCount` back to 0.

## Description
When `ToggleRawInput(SDL_TRUE)` is called twice, the second time will return 0 (success), even if it failed the first time.

This is an issue, since `SDL_SetRelativeMouseMode` assumes if the SetRelativeMouseMode backend failed, it does not need to be disabled afterwards.
https://github.com/libsdl-org/SDL/blob/32e736d2603e0c15dc69a717d7f0921a0c0abe69/src/events/SDL_mouse.c#L804-L816

The code responsible is unchanged since the reference counting was added, so this is likely just an oversight.
https://github.com/spurious/SDL-mirror/blob/be872bff15966a60d2358972ab083b3e565b61ee/src/video/windows/SDL_windowsmouse.c#L36

## Example
```
// WIN_SetRelativeMouseMode returns SDL_Unsupported, causing a fallback to relative_mode_warp, but rawInputEnableCount == 1.
SDL_SetRelativeMouseMode(SDL_TRUE);

// Since relative_mode_warp is enabled, this just sets relative_mode_warp = SDL_FALSE, and doesn't call SetRelativeMouseMode(SDL_FALSE).
SDL_SetRelativeMouseMode(SDL_FALSE);

// Since rawInputEnableCount == 1, WIN_SetRelativeMouseMode returns 0 and raw input is incorrectly assumed to be enabled.
SDL_SetRelativeMouseMode(SDL_TRUE);
```

## Existing Issue(s)
I couldn't find any open issues, but someone was having this problem and this change fixed it.