### PR TITLE
Alias SDL2::SDL2 to SDL2::SDL2-static on static-only builds

### DIFF
--- a/SDL2Config.cmake
+++ b/SDL2Config.cmake
@@ -1,5 +1,14 @@
 include("${CMAKE_CURRENT_LIST_DIR}/SDL2Targets.cmake")
 
+# on static-only builds create an alias
+if(NOT TARGET SDL2::SDL2 AND TARGET SDL2::SDL2-static)
+  if(CMAKE_VERSION VERSION_LESS "3.18")
+      # Aliasing local targets is not supported on CMake < 3.18, so make it global.
+      set_target_properties(SDL2::SDL2-static PROPERTIES IMPORTED_GLOBAL TRUE)
+  endif()
+  add_library(SDL2::SDL2 ALIAS SDL2::SDL2-static)
+endif()
+
 # provide ${SDL2_LIBRARIES}, ${SDL2_INCLUDE_DIRS} etc, like sdl2-config.cmake does,
 # for compatibility between SDL2 built with autotools and SDL2 built with CMake
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Create `SDL2::SDL2` aliased target on static-only build.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/4501
