### PR TITLE
CI: Add Windows ARM64 builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,9 @@ jobs:
     strategy:
       matrix:
         platform:
-        - { name: Windows (x64), os: windows-latest }
+        - { name: Windows (x64), os: windows-latest, flags: -A x64 }
         - { name: Windows (x86), os: windows-latest, flags: -A Win32 }
+        - { name: Windows (ARM64), os: windows-latest, flags: -A ARM64 }
         - { name: Linux,   os: ubuntu-20.04, flags: -GNinja }
         - { name: MacOS,   os: macos-latest }
     steps:


### PR DESCRIPTION
This PR adds a `-A ARM64` CMake build the GitHub Actions to ensure new PRs compile properly on ARM64.

## Description
SDL has been compiling and running successfully on Windows ARM64 for a while. Let's keep it that way 😉 

## Existing Issue(s)
N/A
