### PR TITLE
WIP: Add SDL_GetSchedulerPrecision

### DIFF
--- a/include/SDL_timer.h
+++ b/include/SDL_timer.h
@@ -90,6 +90,15 @@ extern DECLSPEC Uint64 SDLCALL SDL_GetPerformanceCounter(void);
 extern DECLSPEC Uint64 SDLCALL SDL_GetPerformanceFrequency(void);
 
 /**
+ * Gets the precision of the system scheduler.
+ *
+ * \returns the precision of the system scheduler in microseconds, or 0 on failure.
+ *
+ * \sa SDL_GetSchedulerPrecision
+ */
+extern DECLSPEC Uint32 SDLCALL SDL_GetSchedulerPrecision(void);
+
+/**
  * Wait a specified number of milliseconds before returning.
  *
  * This function waits a specified number of milliseconds before returning. It

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -814,3 +814,4 @@
 #define SDL_FlashWindow SDL_FlashWindow_REAL
 #define SDL_GameControllerSendEffect SDL_GameControllerSendEffect_REAL
 #define SDL_JoystickSendEffect SDL_JoystickSendEffect_REAL
+#define SDL_GetSchedulerPrecision SDL_GetSchedulerPrecision_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -879,3 +879,4 @@ SDL_DYNAPI_PROC(void,SDL_SetWindowAlwaysOnTop,(SDL_Window *a, SDL_bool b),(a,b),
 SDL_DYNAPI_PROC(int,SDL_FlashWindow,(SDL_Window *a, Uint32 b),(a, b),return)
 SDL_DYNAPI_PROC(int,SDL_GameControllerSendEffect,(SDL_GameController *a, const void *b, int c),(a,b,c),return)
 SDL_DYNAPI_PROC(int,SDL_JoystickSendEffect,(SDL_Joystick *a, const void *b, int c),(a,b,c),return)
+SDL_DYNAPI_PROC(Uint32,SDL_GetSchedulerPrecision,(void),(),return)

--- a/src/timer/dummy/SDL_systimer.c
+++ b/src/timer/dummy/SDL_systimer.c
@@ -64,6 +64,13 @@ SDL_GetPerformanceFrequency(void)
     return 1000;
 }
 
+Uint32
+SDL_GetSchedulerPrecision(void)
+{
+	SDL_Unsupported();
+	return 0;
+}
+
 void
 SDL_Delay(Uint32 ms)
 {

--- a/src/timer/haiku/SDL_systimer.c
+++ b/src/timer/haiku/SDL_systimer.c
@@ -69,6 +69,13 @@ SDL_GetPerformanceFrequency(void)
     return 1000000;
 }
 
+Uint32
+SDL_GetSchedulerPrecision(void)
+{
+	SDL_Unsupported();
+	return 0;
+}
+
 void
 SDL_Delay(Uint32 ms)
 {

--- a/src/timer/os2/SDL_systimer.c
+++ b/src/timer/os2/SDL_systimer.c
@@ -103,6 +103,13 @@ SDL_GetPerformanceFrequency(void)
     return (ulTmrFreq == 0)? 1000 : (Uint64)ulTmrFreq;
 }
 
+Uint32
+SDL_GetSchedulerPrecision(void)
+{
+	SDL_Unsupported();
+	return 0;
+}
+
 void
 SDL_Delay(Uint32 ms)
 {

--- a/src/timer/vita/SDL_systimer.c
+++ b/src/timer/vita/SDL_systimer.c
@@ -77,6 +77,13 @@ SDL_GetPerformanceFrequency(void)
     return 1000000;
 }
 
+Uint32
+SDL_GetSchedulerPrecision(void)
+{
+	SDL_Unsupported();
+	return 0;
+}
+
 void SDL_Delay(Uint32 ms)
 {
     const Uint32 max_delay = 0xffffffffUL / 1000;

--- a/src/timer/windows/SDL_systimer.c
+++ b/src/timer/windows/SDL_systimer.c
@@ -31,7 +31,7 @@
 
 /* The first (low-resolution) ticks value of the application */
 static DWORD start = 0;
-static BOOL ticks_started = FALSE; 
+static BOOL ticks_started = FALSE;
 
 /* Store if a high-resolution performance counter exists on the system */
 static BOOL hires_timer_available;
@@ -163,6 +163,17 @@ SDL_GetPerformanceFrequency(void)
         return 1000;
     }
     return frequency.QuadPart;
+}
+
+Uint32
+SDL_GetSchedulerPrecision(void)
+{
+#ifndef __WINRT__
+	return timer_period * 1000;
+#else
+	SDL_Unsupported();
+	return 0;
+#endif
 }
 
 void

--- a/src/timer/windows/SDL_systimer.c
+++ b/src/timer/windows/SDL_systimer.c
@@ -33,6 +33,10 @@
 static DWORD start = 0;
 static BOOL ticks_started = FALSE;
 
+#ifndef __WINRT__
+    static UINT timer_period = 0;
+#endif
+
 /* Store if a high-resolution performance counter exists on the system */
 static BOOL hires_timer_available;
 /* The first high-resolution ticks value of the application */
@@ -44,8 +48,6 @@ static void
 SDL_SetSystemTimerResolution(const UINT uPeriod)
 {
 #ifndef __WINRT__
-    static UINT timer_period = 0;
-
     if (uPeriod != timer_period) {
         if (timer_period) {
             timeEndPeriod(timer_period);


### PR DESCRIPTION
This PR adds a new SDL function, `SDL_GetSchedulerPrecision`, to aid in frame timing. This function returns a scheduler precision time value in microseconds.

## Description
I am a contributer to the FNA project. We recently received reports of input latency on a game, and this latency does not exist in the XNA version. I was able to narrow the issue down to the fact that in fixed timestep scenarios, we request a sleep for the remaining time until the next timestep should occur. On Windows, the scheduler is undersleeping the thread, which causes us to request a new sleep time that is smaller than the scheduler precision, so we end up oversleeping. On Linux the scheduler tends to oversleep the thread, so in both situations we are oversleeping.

We don't want to busywait until the next timestep, so we really want to be able to sleep the thread as much as possible without overshooting, and then busywait within the precision threshold. The cross-platform solution for us is to find the scheduler precision and request a sleep time consisting of the remaining amount of time until the next timestep minus the scheduler precision, this way we will undersleep a small amount on both Windows and Linux. At the moment there isn't really a nice way for us to query this precision value, and I thought it would be useful for SDL to provide a way to do this so developers can easily support this frame timing scenario and save on CPU cycles. 

Some outstanding concerns with this patchset:
- Linux does not provide an API call to query scheduler timing resolution. Grepping the boot config for the CONFIG_HZ value is the best solution I could find, but I'm not particularly happy about it.
- It seems that the Linux kernel sets CONFIG_HZ to 250 by default, so we may be able to get away with returning 4000 for Linux as a default if we can't find the boot config value instead of returning 0.
- I stubbed out the function as Unsupported on most platforms other than Windows, MacOS, and Linux because I am unfamiliar with these systems. Perhaps a maintainer with knowledge of this could help?
- WinRT doesn't use the same scheduler system as regular Windows. Is there a way to query this, or is it a fixed value?