### PR TITLE
Vita: Remove 'support' for rgb/bgr textures, that was causing issues with them

### DIFF
--- a/src/render/vitagxm/SDL_render_vita_gxm.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm.c
@@ -115,14 +115,12 @@ SDL_RenderDriver VITA_GXM_RenderDriver = {
     .info = {
         .name = "VITA gxm",
         .flags = SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_TARGETTEXTURE,
-        .num_texture_formats = 6,
+        .num_texture_formats = 4,
         .texture_formats = {
             [0] = SDL_PIXELFORMAT_ABGR8888,
             [1] = SDL_PIXELFORMAT_ARGB8888,
-            [2] = SDL_PIXELFORMAT_RGB888,
-            [3] = SDL_PIXELFORMAT_BGR888,
-            [4] = SDL_PIXELFORMAT_RGB565,
-            [5] = SDL_PIXELFORMAT_BGR565
+            [2] = SDL_PIXELFORMAT_RGB565,
+            [3] = SDL_PIXELFORMAT_BGR565
         },
         .max_texture_width = 4096,
         .max_texture_height = 4096,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Do not announce support for RGB/BGR textures in vita renderer and allow sdl to upconvert them to ARGB/ABGR.
That was causing issues, because internally RGB textures are ARGB in sdl, with alpha channel nulled, and current shader wouldn't draw them with blending enabled.
There were two solutions: 1) this one (e.g. remove support) and 2) provide different shaders for them, that explicitly set alpha to 1 (like gles2 renderer does). But providing different shaders would cause increase in shader switching = more updates to context state, and as there's no memory gain from supporting RGB/BGR i decided to go with 1.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
