### PR TITLE
Add Return Key support to Vita On-Screen Keyboard

### DIFF
--- a/src/video/vita/SDL_vitavideo.c
+++ b/src/video/vita/SDL_vitavideo.c
@@ -414,9 +414,16 @@ static void utf16_to_utf8(const uint16_t *src, uint8_t *dst) {
   *dst = '\0';
 }
 
+static SDL_bool reset_enter = SDL_FALSE;
 void VITA_PumpEvents(_THIS)
 {
     SDL_VideoData *videodata = (SDL_VideoData *)_this->driverdata;
+
+    // Little fix for adding proper enter key emulation
+    if (reset_enter == SDL_TRUE) {
+        SDL_SendKeyboardKey(SDL_RELEASED, SDL_SCANCODE_RETURN);
+        reset_enter = SDL_FALSE;
+    }
 
     VITA_PollTouch();
     VITA_PollKeyboard();
@@ -435,8 +442,14 @@ void VITA_PumpEvents(_THIS)
             // Convert UTF16 to UTF8
             utf16_to_utf8(videodata->ime_buffer, utf8_buffer);
 
-            // send sdl event
+            // Send SDL event
             SDL_SendKeyboardText((const char*)utf8_buffer);
+
+            // Send enter key only on enter
+            if (result.button == SCE_IME_DIALOG_BUTTON_ENTER) {
+                SDL_SendKeyboardKey(SDL_PRESSED, SDL_SCANCODE_RETURN);
+                reset_enter = SDL_TRUE;
+            }
 
             sceImeDialogTerm();
 

--- a/src/video/vita/SDL_vitavideo.c
+++ b/src/video/vita/SDL_vitavideo.c
@@ -414,16 +414,10 @@ static void utf16_to_utf8(const uint16_t *src, uint8_t *dst) {
   *dst = '\0';
 }
 
-static SDL_bool reset_enter = SDL_FALSE;
 void VITA_PumpEvents(_THIS)
 {
     SDL_VideoData *videodata = (SDL_VideoData *)_this->driverdata;
 
-    // Little fix for adding proper enter key emulation
-    if (reset_enter == SDL_TRUE) {
-        SDL_SendKeyboardKey(SDL_RELEASED, SDL_SCANCODE_RETURN);
-        reset_enter = SDL_FALSE;
-    }
 
     VITA_PollTouch();
     VITA_PollKeyboard();
@@ -446,10 +440,8 @@ void VITA_PumpEvents(_THIS)
             SDL_SendKeyboardText((const char*)utf8_buffer);
 
             // Send enter key only on enter
-            if (result.button == SCE_IME_DIALOG_BUTTON_ENTER) {
-                SDL_SendKeyboardKey(SDL_PRESSED, SDL_SCANCODE_RETURN);
-                reset_enter = SDL_TRUE;
-            }
+            if (result.button == SCE_IME_DIALOG_BUTTON_ENTER)
+                SDL_SendKeyboardKeyAutoRelease(SDL_SCANCODE_RETURN);
 
             sceImeDialogTerm();
 
@@ -462,3 +454,4 @@ void VITA_PumpEvents(_THIS)
 #endif /* SDL_VIDEO_DRIVER_VITA */
 
 /* vi: set ts=4 sw=4 expandtab: */
+


### PR DESCRIPTION
Adds a Return Key press emulation when a user hits the enter key.

## Description
`sceImeDialogGetResult` returns 3 values for the resulting button that was pressed. `SCE_IME_DIALOG_BUTTON_NONE`, `SCE_IME_DIALOG_BUTTON_CLOSE` and `SCE_IME_DIALOG_BUTTON_ENTER`. 

Typically when a user hits enter, they would expect it to have the same effect as pressing the return key, but a check for that case was missing. This creates issues for some software that uses SDL for keyboard input (Namely Ren'Py) as they will check for a return key press for confirmation. 

I added an `SDL_SendKeyboardKeyAutoRelease` call to handle simulating a return key input when a user closes the keyboard using the enter key to fix this issue.
