### PR TITLE
wayland: Rewrite update_scale_factor to always use the current display scale

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -81,7 +81,7 @@ typedef struct {
         float scale_factor;
     } resize;
 
-    struct wl_output **outputs;
+    SDL_WaylandOutputData **outputs;
     int num_outputs;
 
     float scale_factor;


### PR DESCRIPTION
This fixes some crashes on startup I had when in high-DPI mode - for some reason this affected one setup and not the others, which is why this wasn't caught until now.