### PR TITLE
wayland: Tag/Check wl_output objects as well, fixes crashes when libdecor is in use

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -127,6 +127,39 @@ get_classname()
     return SDL_strdup("SDL_App");
 }
 
+static const char *SDL_WAYLAND_surface_tag = "sdl-window";
+static const char *SDL_WAYLAND_output_tag = "sdl-output";
+
+void SDL_WAYLAND_register_surface(struct wl_surface *surface)
+{
+    if (SDL_WAYLAND_HAVE_WAYLAND_CLIENT_1_18) {
+        wl_proxy_set_tag((struct wl_proxy *)surface, &SDL_WAYLAND_surface_tag);
+    }
+}
+
+void SDL_WAYLAND_register_output(struct wl_output *output)
+{
+    if (SDL_WAYLAND_HAVE_WAYLAND_CLIENT_1_18) {
+        wl_proxy_set_tag((struct wl_proxy *)output, &SDL_WAYLAND_output_tag);
+    }
+}
+
+SDL_bool SDL_WAYLAND_own_surface(struct wl_surface *surface)
+{
+    if (SDL_WAYLAND_HAVE_WAYLAND_CLIENT_1_18) {
+        return wl_proxy_get_tag((struct wl_proxy *) surface) == &SDL_WAYLAND_surface_tag;
+    }
+    return SDL_TRUE; /* For older clients we have to assume this is us... */
+}
+
+SDL_bool SDL_WAYLAND_own_output(struct wl_output *output)
+{
+    if (SDL_WAYLAND_HAVE_WAYLAND_CLIENT_1_18) {
+        return wl_proxy_get_tag((struct wl_proxy *) output) == &SDL_WAYLAND_output_tag;
+    }
+    return SDL_TRUE; /* For older clients we have to assume this is us... */
+}
+
 static void
 Wayland_DeleteDevice(SDL_VideoDevice *device)
 {
@@ -392,6 +425,7 @@ Wayland_add_display(SDL_VideoData *d, uint32_t id)
     data->scale_factor = 1.0;
 
     wl_output_add_listener(output, &output_listener, data);
+    SDL_WAYLAND_register_output(output);
 }
 
 #ifdef SDL_VIDEO_DRIVER_WAYLAND_QT_TOUCH

--- a/src/video/wayland/SDL_waylandvideo.h
+++ b/src/video/wayland/SDL_waylandvideo.h
@@ -91,6 +91,11 @@ typedef struct {
     SDL_bool done;
 } SDL_WaylandOutputData;
 
+extern void SDL_WAYLAND_register_surface(struct wl_surface *surface);
+extern void SDL_WAYLAND_register_output(struct wl_output *output);
+extern SDL_bool SDL_WAYLAND_own_surface(struct wl_surface *surface);
+extern SDL_bool SDL_WAYLAND_own_output(struct wl_output *output);
+
 #endif /* SDL_waylandvideo_h_ */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -114,8 +114,6 @@ Wayland_GetWindowWMInfo(_THIS, SDL_Window * window, SDL_SysWMinfo * info);
 extern int Wayland_SetWindowHitTest(SDL_Window *window, SDL_bool enabled);
 extern int Wayland_FlashWindow(_THIS, SDL_Window * window, SDL_FlashOperation operation);
 
-extern SDL_bool SDL_WAYLAND_own_surface(struct wl_surface *surface);
-
 #endif /* SDL_waylandwindow_h_ */
 
 /* vi: set ts=4 sw=4 expandtab: */


### PR DESCRIPTION
Ugh, okay, so to add on to #4541, it turns out that in addition to surfaces not being ours, we can also get outputs that aren't ours as well. Kind of bummed that the pointers don't match for a single output, but that's what we're left with.

Fixes high-DPI with libdecor support (for real this time).