### PR TITLE
wayland: Don't create zxdg toplevel decoration twice

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -638,11 +638,6 @@ void Wayland_ShowWindow(_THIS, SDL_Window *window)
         xdg_toplevel_add_listener(data->shell_surface.xdg.roleobj.toplevel, &toplevel_listener_xdg, data);
     }
 
-    /* Create the window decorations */
-    if (c->decoration_manager) {
-        data->server_decoration = zxdg_decoration_manager_v1_get_toplevel_decoration(c->decoration_manager, data->shell_surface.xdg.roleobj.toplevel);
-    }
-
     /* Restore state that was set prior to this call */
     Wayland_SetWindowTitle(_this, window);
     if (window->flags & SDL_WINDOW_MAXIMIZED) {


### PR DESCRIPTION
Each window can have at most one zxdg toplevel decoration, but as of #4323, we accidentally create two. (If libdecor is not in use). This causes wayland windows with server-side decorations (e.g. on KDE/KWin) to crash with the message:
```
zxdg_decoration_manager_v1@7: error 1: decoration has been already constructed
```

This extra ``zxdg_decoration_manager_v1.get_toplevel_decoration()`` call was introduced while [deprecating wl-shell and xdg-shell-stable support](https://github.com/libsdl-org/SDL/pull/4323), and possibly was a bad interaction with #4374, which moved the decoration creation around.

Fixes: 6aae5b44f8 ("Remove wl-shell and xdg-shell-unstable-v6 support (#4323)")