### PR TITLE
wayland: Avoid a pointer→TouchID cast warning

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -955,13 +955,13 @@ seat_handle_capabilities(void *data, struct wl_seat *seat,
     }
 
     if ((caps & WL_SEAT_CAPABILITY_TOUCH) && !input->touch) {
-        SDL_AddTouch((SDL_TouchID)seat, SDL_TOUCH_DEVICE_DIRECT, "wayland_touch");
+        SDL_AddTouch((SDL_TouchID)(intptr_t)seat, SDL_TOUCH_DEVICE_DIRECT, "wayland_touch");
         input->touch = wl_seat_get_touch(seat);
         wl_touch_set_user_data(input->touch, input);
         wl_touch_add_listener(input->touch, &touch_listener,
                                  input);
     } else if (!(caps & WL_SEAT_CAPABILITY_TOUCH) && input->touch) {
-        SDL_DelTouch((SDL_TouchID)seat);
+        SDL_DelTouch((SDL_TouchID)(intptr_t)seat);
         wl_touch_destroy(input->touch);
         input->touch = NULL;
     }


### PR DESCRIPTION
As of [1], SDL now compiles with a warning in ``SDL_waylandevents.c`` on
32-bit systems under gcc 10.3.0:
```
/tmp/SDL/src/video/wayland/SDL_waylandevents.c: In function 'seat_handle_capabilities':
/tmp/SDL/src/video/wayland/SDL_waylandevents.c:958:22: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  958 |         SDL_AddTouch((SDL_TouchID)seat, SDL_TOUCH_DEVICE_DIRECT, "wayland_touch");
      |                      ^
/tmp/SDL/src/video/wayland/SDL_waylandevents.c:964:22: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  964 |         SDL_DelTouch((SDL_TouchID)seat);
      |                      ^
```

This is due to ``SDL_TouchID`` always being 32-bit, but seat being a pointer
which is (obviously) only 32-bit on 32-bit systems. The conversion is
therefore harmless, so silence it with an extra cast via ``intptr_t``.

This is what the cocoa backend does (and is similar to what the Win32 backend does, except with size_t).

Fixes: 03c19efbd1 ("Added support for multiple seats with touch input on Wayland")

[1]: https://github.com/libsdl-org/SDL/commit/03c19efbd17f72f70ee021de6d2549eb0be3bb56
