### PR TITLE
Upload Windows artifacts from GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,5 +62,16 @@ jobs:
     - name: Configure CMake
       run: cmake -B build ${{ matrix.platform.flags }}
     - name: Build
-      run: cmake --build build/
+      run: cmake --build build/ --config Release
+    - name: Copy artifacts (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        cd ..
+        SDL\build-scripts\windows-buildbot-zipper.bat build SDL SDL2
+    - name: Upload artifacts (Windows)
+      if: runner.os == 'Windows'
+      uses: actions/upload-artifact@v1
+      with:
+        name: SDL2-${{ matrix.platform.name }}
+        path: ..\zipper
 

--- a/build-scripts/windows-buildbot-zipper.bat
+++ b/build-scripts/windows-buildbot-zipper.bat
@@ -13,16 +13,10 @@ IF EXIST zipper GOTO zippermade
 mkdir zipper
 :zippermade
 mkdir zipper\SDL
-mkdir zipper\SDL\include
 mkdir zipper\SDL\lib
-copy include\*.h include\
 copy %2\%1\Release\SDL2.dll zipper\SDL\lib\
 copy %2\%1\Release\SDL2.lib zipper\SDL\lib\
 copy %2\%1\Release\SDL2main.lib zipper\SDL\lib\
-cd zipper
-zip -9r ..\%3 SDL
-cd ..
-erase /q /f /s zipper
 
 :done
 


### PR DESCRIPTION
It's pretty simple to upload artifacts once a CI workflow is done.

I modified the buildbot script a little bit to accomodate. Artifacts automatically get put in a zip file, so we don't need to make a zip file ourselves. I removed the include stuff because they seem to be pointing to the wrong directories anyway, not sure how important they are.

Fixes #4504.