### PR TITLE
Fixes to support CHERI/Morello

### DIFF
--- a/include/SDL_audio.h
+++ b/include/SDL_audio.h
@@ -214,9 +214,12 @@ typedef void (SDLCALL * SDL_AudioFilter) (struct SDL_AudioCVT * cvt,
  *  set both its (buf) field to a pointer that is aligned to 16 bytes, and its
  *  (len) field to something that's a multiple of 16, if possible.
  */
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__CHERI_PURE_CAPABILITY__)
 /* This structure is 84 bytes on 32-bit architectures, make sure GCC doesn't
    pad it out to 88 bytes to guarantee ABI compatibility between compilers.
+   This is not a concern on CHERI architectures, where pointers must be stored
+   at aligned locations otherwise they will become invalid, and thus structs
+   containing pointers cannot be packed without giving a warning or error.
    vvv
    The next time we rev the ABI, make sure to size the ints and add padding.
 */

--- a/include/SDL_events.h
+++ b/include/SDL_events.h
@@ -620,18 +620,24 @@ typedef union SDL_Event
     SDL_DollarGestureEvent dgesture;        /**< Gesture event data */
     SDL_DropEvent drop;                     /**< Drag and drop event data */
 
-    /* This is necessary for ABI compatibility between Visual C++ and GCC
-       Visual C++ will respect the push pack pragma and use 52 bytes for
-       this structure, and GCC will use the alignment of the largest datatype
-       within the union, which is 8 bytes.
+    /* This is necessary for ABI compatibility between Visual C++ and GCC.
+       Visual C++ will respect the push pack pragma and use 52 bytes (size of
+       SDL_TextEditingEvent, the largest structure for 32-bit and 64-bit
+       architectures) for this union, and GCC will use the alignment of the
+       largest datatype within the union, which is 8 bytes on 64-bit
+       architectures.
 
        So... we'll add padding to force the size to be 56 bytes for both.
+
+       On architectures where pointers are 16 bytes, this needs rounding up to
+       the next multiple of 16, 64, and on architectures where pointers are
+       even larger the size of SDL_UserEvent will dominate as being 3 pointers.
     */
-    Uint8 padding[56];
+    Uint8 padding[sizeof(void *) <= 8 ? 56 : sizeof(void *) == 16 ? 64 : 3 * sizeof(void *)];
 } SDL_Event;
 
 /* Make sure we haven't broken binary compatibility */
-SDL_COMPILE_TIME_ASSERT(SDL_Event, sizeof(SDL_Event) == 56);
+SDL_COMPILE_TIME_ASSERT(SDL_Event, sizeof(SDL_Event) == sizeof(((SDL_Event *)NULL)->padding));
 
 
 /* Function prototypes */

--- a/src/audio/SDL_audiocvt.c
+++ b/src/audio/SDL_audiocvt.c
@@ -955,8 +955,8 @@ SDL_BuildAudioResampleCVT(SDL_AudioCVT * cvt, const int dst_channels,
     if (cvt->filter_index >= (SDL_AUDIOCVT_MAX_FILTERS-2)) {
         return SDL_SetError("Too many filters needed for conversion, exceeded maximum of %d", SDL_AUDIOCVT_MAX_FILTERS-2);
     }
-    cvt->filters[SDL_AUDIOCVT_MAX_FILTERS-1] = (SDL_AudioFilter) (size_t) src_rate;
-    cvt->filters[SDL_AUDIOCVT_MAX_FILTERS] = (SDL_AudioFilter) (size_t) dst_rate;
+    cvt->filters[SDL_AUDIOCVT_MAX_FILTERS-1] = (SDL_AudioFilter) (uintptr_t) src_rate;
+    cvt->filters[SDL_AUDIOCVT_MAX_FILTERS] = (SDL_AudioFilter) (uintptr_t) dst_rate;
 
     if (src_rate < dst_rate) {
         const double mult = ((double) dst_rate) / ((double) src_rate);

--- a/src/audio/SDL_audiodev.c
+++ b/src/audio/SDL_audiodev.c
@@ -65,7 +65,7 @@ test_device(const int iscapture, const char *fname, int flags, int (*test) (int 
                  * information,  making this information inaccessible at
                  * enumeration time
                  */
-                SDL_AddAudioDevice(iscapture, fname, NULL, (void *) dummyhandle);
+                SDL_AddAudioDevice(iscapture, fname, NULL, (void *) (uintptr_t) dummyhandle);
             }
         }
     }

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -1087,9 +1087,6 @@ SDL_SIMDRealloc(void *mem, const size_t len)
 
     ptr = (Uint8 *) SDL_realloc(mem, padded + alignment + sizeof (void *));
 
-    if (ptr == mem) {
-        return retval; /* Pointer didn't change, nothing to do */
-    }
     if (ptr == NULL) {
         return NULL; /* Out of memory, bail! */
     }
@@ -1102,7 +1099,7 @@ SDL_SIMDRealloc(void *mem, const size_t len)
     if (mem) {
         ptrdiff = ((size_t) retval) - ((size_t) ptr);
         if (memdiff != ptrdiff) { /* Delta has changed, copy to new offset! */
-            oldmem = (void*) (((size_t) ptr) + memdiff);
+            oldmem = (void*) (((uintptr_t) ptr) + memdiff);
 
             /* Even though the data past the old `len` is undefined, this is the
              * only length value we have, and it guarantees that we copy all the

--- a/src/render/opengles2/SDL_render_gles2.c
+++ b/src/render/opengles2/SDL_render_gles2.c
@@ -961,7 +961,7 @@ SetDrawState(GLES2_RenderData *data, const SDL_RenderCommand *cmd, const GLES2_I
     }
 
     if (texture) {
-        data->glVertexAttribPointer(GLES2_ATTRIBUTE_TEXCOORD, 2, GL_FLOAT, GL_FALSE, 0, (const GLvoid *) (cmd->data.draw.first + (sizeof (GLfloat) * 8)));
+        data->glVertexAttribPointer(GLES2_ATTRIBUTE_TEXCOORD, 2, GL_FLOAT, GL_FALSE, 0, (const GLvoid *) (uintptr_t) (cmd->data.draw.first + (sizeof (GLfloat) * 8)));
     }
 
     if (GLES2_SelectProgram(data, imgsrc, texture ? texture->w : 0, texture ? texture->h : 0) < 0) {
@@ -1004,7 +1004,7 @@ SetDrawState(GLES2_RenderData *data, const SDL_RenderCommand *cmd, const GLES2_I
     }
 
     /* all drawing commands use this */
-    data->glVertexAttribPointer(GLES2_ATTRIBUTE_POSITION, 2, GL_FLOAT, GL_FALSE, 0, (const GLvoid *) cmd->data.draw.first);
+    data->glVertexAttribPointer(GLES2_ATTRIBUTE_POSITION, 2, GL_FLOAT, GL_FALSE, 0, (const GLvoid *) (uintptr_t) cmd->data.draw.first);
 
     if (is_copy_ex != was_copy_ex) {
         if (is_copy_ex) {
@@ -1018,8 +1018,8 @@ SetDrawState(GLES2_RenderData *data, const SDL_RenderCommand *cmd, const GLES2_I
     }
 
     if (is_copy_ex) {
-        data->glVertexAttribPointer(GLES2_ATTRIBUTE_ANGLE, 2, GL_FLOAT, GL_FALSE, 0, (const GLvoid *) (cmd->data.draw.first + (sizeof (GLfloat) * 16)));
-        data->glVertexAttribPointer(GLES2_ATTRIBUTE_CENTER, 2, GL_FLOAT, GL_FALSE, 0, (const GLvoid *) (cmd->data.draw.first + (sizeof (GLfloat) * 24)));
+        data->glVertexAttribPointer(GLES2_ATTRIBUTE_ANGLE, 2, GL_FLOAT, GL_FALSE, 0, (const GLvoid *) (uintptr_t) (cmd->data.draw.first + (sizeof (GLfloat) * 16)));
+        data->glVertexAttribPointer(GLES2_ATTRIBUTE_CENTER, 2, GL_FLOAT, GL_FALSE, 0, (const GLvoid *) (uintptr_t) (cmd->data.draw.first + (sizeof (GLfloat) * 24)));
     }
 
     return 0;

--- a/src/stdlib/SDL_iconv.c
+++ b/src/stdlib/SDL_iconv.c
@@ -55,13 +55,13 @@ SDL_COMPILE_TIME_ASSERT(iconv_t, sizeof (iconv_t) <= sizeof (SDL_iconv_t));
 SDL_iconv_t
 SDL_iconv_open(const char *tocode, const char *fromcode)
 {
-    return (SDL_iconv_t) ((size_t) iconv_open(tocode, fromcode));
+    return (SDL_iconv_t) ((uintptr_t) iconv_open(tocode, fromcode));
 }
 
 int
 SDL_iconv_close(SDL_iconv_t cd)
 {
-    return iconv_close((iconv_t) ((size_t) cd));
+    return iconv_close((iconv_t) ((uintptr_t) cd));
 }
 
 size_t
@@ -71,9 +71,9 @@ SDL_iconv(SDL_iconv_t cd,
 {
     size_t retCode;
 #ifdef ICONV_INBUF_NONCONST
-    retCode = iconv((iconv_t) ((size_t) cd), (char **) inbuf, inbytesleft, outbuf, outbytesleft);
+    retCode = iconv((iconv_t) ((uintptr_t) cd), (char **) inbuf, inbytesleft, outbuf, outbytesleft);
 #else
-    retCode = iconv((iconv_t) ((size_t) cd), inbuf, inbytesleft, outbuf, outbytesleft);
+    retCode = iconv((iconv_t) ((uintptr_t) cd), inbuf, inbytesleft, outbuf, outbytesleft);
 #endif
     if (retCode == (size_t) - 1) {
         switch (errno) {

--- a/src/video/SDL_egl.c
+++ b/src/video/SDL_egl.c
@@ -507,12 +507,12 @@ SDL_EGL_LoadLibrary(_THIS, const char *egl_path, NativeDisplayType native_displa
         }
 
         if (_this->egl_data->eglGetPlatformDisplay) {
-            _this->egl_data->egl_display = _this->egl_data->eglGetPlatformDisplay(platform, (void *)(size_t)native_display, NULL);
+            _this->egl_data->egl_display = _this->egl_data->eglGetPlatformDisplay(platform, (void *)(uintptr_t)native_display, NULL);
         } else {
             if (SDL_EGL_HasExtension(_this, SDL_EGL_CLIENT_EXTENSION, "EGL_EXT_platform_base")) {
                 _this->egl_data->eglGetPlatformDisplayEXT = SDL_EGL_GetProcAddress(_this, "eglGetPlatformDisplayEXT");
                 if (_this->egl_data->eglGetPlatformDisplayEXT) {
-                    _this->egl_data->egl_display = _this->egl_data->eglGetPlatformDisplayEXT(platform, (void *)(size_t)native_display, NULL);
+                    _this->egl_data->egl_display = _this->egl_data->eglGetPlatformDisplayEXT(platform, (void *)(uintptr_t)native_display, NULL);
                 }
             }
         }

--- a/src/video/x11/SDL_x11mouse.c
+++ b/src/video/x11/SDL_x11mouse.c
@@ -77,7 +77,7 @@ X11_CreateDefaultCursor()
     cursor = SDL_calloc(1, sizeof(*cursor));
     if (cursor) {
         /* None is used to indicate the default cursor */
-        cursor->driverdata = (void*)None;
+        cursor->driverdata = (void*)(uintptr_t)None;
     } else {
         SDL_OutOfMemory();
     }
@@ -216,7 +216,7 @@ X11_CreateCursor(SDL_Surface * surface, int hot_x, int hot_y)
         if (x11_cursor == None) {
             x11_cursor = X11_CreatePixmapCursor(surface, hot_x, hot_y);
         }
-        cursor->driverdata = (void*)x11_cursor;
+        cursor->driverdata = (void*)(uintptr_t)x11_cursor;
     } else {
         SDL_OutOfMemory();
     }
@@ -257,7 +257,7 @@ X11_CreateSystemCursor(SDL_SystemCursor id)
 
         x11_cursor = X11_XCreateFontCursor(GetDisplay(), shape);
 
-        cursor->driverdata = (void*)x11_cursor;
+        cursor->driverdata = (void*)(uintptr_t)x11_cursor;
     } else {
         SDL_OutOfMemory();
     }


### PR DESCRIPTION
This is needed to support CHERI, and thus Arm's experimental Morello prototype, where pointers are implemented using unforgeable capabilities that include bounds and permissions metadata to provide fine-grained spatial and referential memory safety, as well as revocation by sweeping memory to provide heap temporal memory safety.

The issues addressed fall into several categories:

1. Pointer provenance: integers and pointers are not the same, and casting to a virtual address-sized integer is a lossy operation, so it is vital to use (u)intptr_t rather than size_t or similar in pointer->integer casts that will be later cast back to a pointer and dereferenced, and for stuffing integers into `void *` or similar using (u)intptr_t in the casts suppresses warnings that alert the developer to possible loss-of-provenance issues. Pointers also have bounds, so realloc uses need extra care to conform to the C standard to the letter rather than what most existing implementations let you get away with.
2. Pointer size: pointers are now twice the size that they were before (8 bytes on 32-bit architectures, 16 bytes on 64-bit architectures) due to also storing additional metadata, which affects struct layout assumptions.
3. Pointer alignment: in order to not waste large amounts of memory, validity tags for in-memory capabilities are only present at aligned addresses, meaning pointers cannot be stored at unaligned addresses, and thus pointer-containing structs cannot be packed.

The final commit to fix point 3 (which also has information in its commit message that is probably of interest) is likely the most contentious due to the check for `__CHERI_PURE_CAPABILITY__`, which is the macro CHERI (including Morello) compilers define to indicate that the code is being compiled with pointers implemented as capabilities. The alternative would be to add a configure flag to disable the struct packing, which provides flexibility, but is a little dangerous as it would break ABI for existing architectures when using GCC/Clang if enabled, and has the downside that when compiling for CHERI you would have to remember to enable it (unless you auto-enable it, at which point you're still checking for `__CHERI_PURE_CAPABILITY__` so might as well just use the macro in the header unless the additional flexibility is desired).

There are likely more issues in code that I have not yet enabled, or have enabled but not exercised, but this is sufficient to be able to run Chocolate Doom using the X11 backend.