### PR TITLE
libdecor: commit after setting/unsetting limits

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -113,6 +113,7 @@ SetFullscreen(SDL_Window *window, struct wl_output *output)
             if (!(window->flags & SDL_WINDOW_RESIZABLE)) {
                 /* ensure that window is resizable before going into fullscreen */
                 libdecor_frame_set_capabilities(wind->shell_surface.libdecor.frame, LIBDECOR_ACTION_RESIZE);
+                wl_surface_commit(wind->surface);
             }
             libdecor_frame_set_fullscreen(wind->shell_surface.libdecor.frame, output);
         } else {
@@ -120,6 +121,7 @@ SetFullscreen(SDL_Window *window, struct wl_output *output)
             if (!(window->flags & SDL_WINDOW_RESIZABLE)) {
                 /* restore previous RESIZE capability */
                 libdecor_frame_unset_capabilities(wind->shell_surface.libdecor.frame, LIBDECOR_ACTION_RESIZE);
+                wl_surface_commit(wind->surface);
             }
         }
     } else


### PR DESCRIPTION
This adds a surface commit after setting/unsetting capabilities.

## Description
The libdecor code path in function `SetFullscreen` sets/unsets the `LIBDECOR_ACTION_RESIZE` capability before/after setting fullscreen. This internally sets/unsets min/max limits and tells the client to commit its main surface via `libdecor_frame_toplevel_commit`, which in turn calls a client-provided callback. In SDL's case, this is calls `SDL_SendWindowEvent`.

In an earlier implementation of `libdecor_frame_toplevel_commit`, we indeed committed the surface via `wl_surface_commit` but this causes interference with OpenGL and Vulkan that commit the surface on their own. However, the "xdg" code paths use `CommitMinMaxDimensions` which in turn uses `wl_surface_commit` to commit the min/max limits without issues. So it seems to be safe to do the same for the libdecor code path.

## Existing Issue(s)
I was too lazy to create a separate issue. The description above should suffice.

Edit: Actually, this fixes the issue when transitioning in Capsized from floating to fullscreen in GNOME Shell. But this additionally also requires the current development version of `mutter` (i.e. will be fixed in the next GNOME Shell release).
