### PR TITLE
cocoa: Add keyboard grab support

### DIFF
--- a/src/video/cocoa/SDL_cocoakeyboard.h
+++ b/src/video/cocoa/SDL_cocoakeyboard.h
@@ -31,6 +31,8 @@ extern void Cocoa_StartTextInput(_THIS);
 extern void Cocoa_StopTextInput(_THIS);
 extern void Cocoa_SetTextInputRect(_THIS, SDL_Rect *rect);
 
+extern void Cocoa_SetWindowKeyboardGrab(_THIS, SDL_Window * window, SDL_bool grabbed);
+
 #endif /* SDL_cocoakeyboard_h_ */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/cocoa/SDL_cocoakeyboard.m
+++ b/src/video/cocoa/SDL_cocoakeyboard.m
@@ -602,6 +602,23 @@ Cocoa_QuitKeyboard(_THIS)
 {
 }
 
+typedef int CGSConnection;
+typedef enum {
+    CGSGlobalHotKeyEnable = 0,
+    CGSGlobalHotKeyDisable = 1,
+} CGSGlobalHotKeyOperatingMode;
+
+extern CGSConnection _CGSDefaultConnection(void);
+extern CGError CGSSetGlobalHotKeyOperatingMode(CGSConnection connection, CGSGlobalHotKeyOperatingMode mode);
+
+void
+Cocoa_SetWindowKeyboardGrab(_THIS, SDL_Window * window, SDL_bool grabbed)
+{
+#if SDL_MAC_NO_SANDBOX
+    CGSSetGlobalHotKeyOperatingMode(_CGSDefaultConnection(), grabbed ? CGSGlobalHotKeyDisable : CGSGlobalHotKeyEnable);
+#endif
+}
+
 #endif /* SDL_VIDEO_DRIVER_COCOA */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/cocoa/SDL_cocoavideo.m
+++ b/src/video/cocoa/SDL_cocoavideo.m
@@ -103,6 +103,7 @@ Cocoa_CreateDevice(int devindex)
     device->SetWindowGammaRamp = Cocoa_SetWindowGammaRamp;
     device->GetWindowGammaRamp = Cocoa_GetWindowGammaRamp;
     device->SetWindowMouseGrab = Cocoa_SetWindowMouseGrab;
+    device->SetWindowKeyboardGrab = Cocoa_SetWindowKeyboardGrab;
     device->DestroyWindow = Cocoa_DestroyWindow;
     device->GetWindowWMInfo = Cocoa_GetWindowWMInfo;
     device->SetWindowHitTest = Cocoa_SetWindowHitTest;


### PR DESCRIPTION
## Description
This PR adds support for keyboard grab on macOS using the `CGSSetGlobalHotKeyOperatingMode()` API. It suppresses system key combos to allow the application to handle them itself.

This function is not a public API (and thus, not permitted for App Store apps), so we will not compile this in by default. Instead, we'll use `SDL_MAC_NO_SANDBOX` (like the Cocoa mouse tap removed in 2fdbae22cb2f75643447c34d2dab7f15305e3567 did) to enable the compilation of this code using private APIs.

This feature is not compiled in by default so it should be safe, but I don't mind waiting until after 2.0.16 if needed.