### PR TITLE
render: Fix -Wmaybe-uninitialized warning in RenderDrawLinesWithRects{,F}

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -2666,7 +2666,9 @@ RenderDrawLinesWithRects(SDL_Renderer * renderer,
         }
     }
 
-    retval += QueueCmdFillRects(renderer, frects, nrects);
+    if (nrects) {
+        retval += QueueCmdFillRects(renderer, frects, nrects);
+    }
 
     SDL_small_free(frects, isstack);
 
@@ -2721,7 +2723,9 @@ RenderDrawLinesWithRectsF(SDL_Renderer * renderer,
         }
     }
 
-    retval += QueueCmdFillRects(renderer, frects, nrects);
+    if (nrects) {
+        retval += QueueCmdFillRects(renderer, frects, nrects);
+    }
 
     SDL_small_free(frects, isstack);
 


### PR DESCRIPTION
The ``RenderDrawLinesWithRects()`` and ``RenderDrawLinesWithRectsF()`` functions can sometimes call ``QueueCmdFillRects()`` with the data pointed to by ``frects`` uninitialised. This can occur if none of the lines can be replaced with rects, in which case the ``frects`` array is empty, and ``nrects`` is 0.

gcc 10.3.0 will detect this possibility, and print a warning like:
```
/home/david/Development/SDL/src/render/SDL_render.c: In function 'RenderDrawLinesWithRectsF':
/home/david/Development/SDL/src/render/SDL_render.c:2725:15: warning: '<unknown>' may be used uninitialized [-Wmaybe-uninitialized]
 2725 |     retval += QueueCmdFillRects(renderer, frects, nrects);
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/david/Development/SDL/src/render/SDL_render.c:499:1: note: by argument 2 of type 'const SDL_FRect *' to 'QueueCmdFillRects' declared here
  499 | QueueCmdFillRects(SDL_Renderer *renderer, const SDL_FRect * rects, const int count)
      | ^~~~~~~~~~~~~~~~~
```

This is harmless, because when this is uninitialised, ``nrects`` is always 0, so ``QueueCmdFillRects()`` does nothing anyway. We therefore can work around this by only calling ``QueueCmdFillRects()`` when ``nrects`` is nonzero.
Somewhat impressively, gcc recognises that this is now safe.