### PR TITLE
wayland: Always trigger a resize when handling a configure event.

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -1219,7 +1219,7 @@ Wayland_HandlePendingResize(SDL_Window *window)
 
     if (data->resize.pending) {
         struct wl_region *region;
-        if (data->scale_factor != data->resize.scale_factor) {
+        if (data->scale_factor != data->resize.scale_factor || data->resize.configure) {
             window->w = 0;
             window->h = 0;
         }


### PR DESCRIPTION
When we removed the OpenGL resize workaround it introduced a problem for fullscreen windows in particular: When leaving fullscreen we tried to send a resize event, but UpdateFullscreenMode would send a SIZE_CHANGED immediately after, deleting our resize event and causing the following configure event's resize to be ignored. This timing issue resulted in fullscreen windows not being resized at all when becoming a floating window.

By always forcing resize events from configure events, we ensure that RESIZED always makes it through. SetWindowSize-type changes should be unaffected as they do not fire configure events.

Fixes toggling fullscreen for games like Super Hexagon (again).