### PR TITLE
wayland: Disable key repeat when repeat rate equals 0

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -199,7 +199,7 @@ keyboard_repeat_clear(SDL_WaylandKeyboardRepeat* repeat_info) {
 static void
 keyboard_repeat_set(SDL_WaylandKeyboardRepeat* repeat_info,
                     uint32_t scancode, SDL_bool has_text, char text[8]) {
-    if (!repeat_info->is_initialized) {
+    if (!repeat_info->is_initialized || !repeat_info->repeat_rate) {
         return;
     }
     repeat_info->is_key_down = SDL_TRUE;


### PR DESCRIPTION
This fixes a crash on pressing keyboard button when compositor sends
zero as repeat rate, indicating that key repeat should be disabled.

From Wayland protocol spec:

> Negative values for either rate or delay are illegal. A rate of zero
> will disable any repeating (regardless of the value of delay).