### PR TITLE
unix: OpenURL: Move unsetenv above vfork

### DIFF
--- a/src/misc/unix/SDL_sysurl.c
+++ b/src/misc/unix/SDL_sysurl.c
@@ -33,11 +33,12 @@ SDL_SYS_OpenURL(const char *url)
 {
     const pid_t pid1 = fork();
     if (pid1 == 0) {  /* child process */
+        pid_t pid2;
+        /* Clear LD_PRELOAD so Chrome opens correctly when this application is launched by Steam */
+        unsetenv("LD_PRELOAD");
         /* Notice this is vfork and not fork! */
-        const pid_t pid2 = vfork();
+        pid2 = vfork();
         if (pid2 == 0) {  /* Grandchild process will try to launch the url */
-            /* Clear LD_PRELOAD so Chrome opens correctly when this application is launched by Steam */
-            unsetenv("LD_PRELOAD");
             execlp("xdg-open", "xdg-open", url, NULL);
             _exit(EXIT_FAILURE);
         } else if (pid2 < 0) {   /* There was an error forking */


### PR DESCRIPTION
From the vfork manpage:

> The  vfork()  function has the same effect as fork(2), except that
> the behavior is undefined if the process created by vfork() either
> modifies any data other than a variable of type pid_t used to store
> the return value from vfork(), or returns from the function in which
> vfork() was called, or calls any other function before successfully
> calling _exit(2) or one of the exec(3) family of functions.

unsetenv is still called inside a child process, so it does not influence the rest of the application.

Fixes 9b7b928765ce732ca3024a42d0281fea7192ecaf