### PR TITLE
wayland: restore floating states

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -68,6 +68,9 @@ typedef struct {
     struct zwp_idle_inhibitor_v1 *idle_inhibitor;
     struct xdg_activation_token_v1 *activation_token;
 
+    /* floating dimensions for restoring from maximized and fullscreen */
+    int floating_width, floating_height;
+
     SDL_atomic_t swap_interval_ready;
 
 #ifdef SDL_VIDEO_DRIVER_WAYLAND_QT_TOUCH


### PR DESCRIPTION
Store and restore floating dimensions when restoring from maximised/fullscreen to floating state. This affects the xdg and libdecor implementations.

## Description
We now store the window size if the window is in a floating mode (not fullscreen/maxmised/tiled) so that when we have to restore from a  fullscreen/maxmised/tiled state to a floating state, we use our previous floating dimensions.

I added a dedicated "floating_*" set of variables and did not reuse the `windowed` that seem to have a similar use. This is because `windowed` is only used for fullscreen and is in a more global scope, whose changes might have some undesired effects. The new "floating" variables are only used within Wayland and should not affect the public SDL API.

There are remaining issues with transitioning from between non-floating states (e.g. floating -> maximised -> fullscreen -> maximised) which only work with libdecor, but not with the xdg baseline.

## Existing Issue(s)
Fixes #4562
