### PR TITLE
wayland: Always call Wayland_SetWindowBordered when showing the window

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -756,12 +756,9 @@ void Wayland_ShowWindow(_THIS, SDL_Window *window)
 
     /* Unlike the rest of window state we have to set this _after_ flushing the
      * display, because we need to create the decorations before possibly hiding
-     * them immediately afterward. But don't call it redundantly, the protocol
-     * may not interpret a redundant call nicely and cause weird stuff to happen
+     * them immediately afterward.
      */
-    if (window->flags & SDL_WINDOW_BORDERLESS) {
-        Wayland_SetWindowBordered(_this, window, SDL_FALSE);
-    }
+    Wayland_SetWindowBordered(_this, window, !(window->flags & SDL_WINDOW_BORDERLESS));
 
     /* We're finally done putting the window together, raise if possible */
     if (c->activation_manager) {


### PR DESCRIPTION
Otherwise our windows have no window decoration on compositors that support *xdg-decoration-unstable-v1*, but default to client-side mode.

Contrary to what the comment was stating, there is nothing in the protocol that would make redundant calls to [`zxdg_toplevel_decoration_v1::set_mode`](https://wayland.app/protocols/xdg-decoration-unstable-v1#zxdg_toplevel_decoration_v1:request:set_mode) problematic.
