### PR TITLE
wayland: Clean up Wayland_HandlePendingResize

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -77,13 +77,6 @@ typedef struct {
     struct qt_extended_surface *extended_surface;
 #endif /* SDL_VIDEO_DRIVER_WAYLAND_QT_TOUCH */
 
-    struct {
-        SDL_bool pending, configure;
-        uint32_t serial;
-        int width, height;
-        float scale_factor;
-    } resize;
-
     SDL_WaylandOutputData **outputs;
     int num_outputs;
 


### PR DESCRIPTION
Commit 871c11191bfc7214061a3da37c112522a102ddf5 removed delayed resize handling, but it left the whole structure untouched that now became unnecessary. To help with code clarity, get rid of the structure where pending resize state used to be stored and pass all the data directly to `Wayland_HandlePendingResize` (now renamed to `Wayland_HandleResize`, since it's not "pending" anymore but applied immediately)

/cc @flibitijibibo @icculus - this shouldn't change the behavior in any way (neither positive nor negative) since the logic stays the same - but that's assuming I did not make a mistake, so some additional testing will be appreciated 