### PR TITLE
configure.ac: mkdir $(objects)/ when building wayland protocols

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4383,6 +4383,7 @@ if test x$video_wayland = xyes; then
         printf '%s\n' "	\\$(RUN_CMD_GEN)\\$(WAYLAND_SCANNER) \\$(WAYLAND_SCANNER_CODE_MODE) \\$< \\$@" ;\
         echo ;\
         printf '%s\n' "\\$(objects)/\$p-protocol.lo: \\$(gen)/\$p-protocol.c \\$(gen)/\$p-client-protocol.h" ;\
+        printf '%s\n' "	@\\$(SHELL) \\$(auxdir)/mkinstalldirs \\$(objects)" ;\
         printf '%s\n' "	\\$(RUN_CMD_CC)\\$(LIBTOOL) --tag=CC --mode=compile \\$(CC) \\$(CFLAGS) \\$(EXTRA_CFLAGS) $DEPENDENCY_TRACKING_OPTIONS -c \\$< -o \\$@" ;\
         done ;\
         echo ;\


### PR DESCRIPTION
The ``$(objects)`` directory (usually ``build/``) may not have been created by the time the ``wayland-scanner`` protocol files are being compiled. The ``$(gen)`` directory is explicitly made with ``mkinstalldir``, but the final object file (and gcc dependency files) need to go into ``$(objects)``.

For whatever reason, this only ever seemed to occur if ``--disable-shared`` was set.

Note that this PR doesn't regenerate ``./configure`, as there were a few unexplained, unrelated differences my version of ``autoconf`` created, as as an autotools novice, I didn't want to poke that bear just yet.

This hopefully should fix #3689