### PR TITLE
build: Fix the LINKER variable.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,10 +84,10 @@ esac
 dnl use CXX for linker on Haiku
 case "$host" in
     *-*-haiku*)
-        LINKER=CXX
+        LINKER='$(CXX)'
         ;;
     *)
-        LINKER=CC
+        LINKER='$(CC)'
         ;;
 esac
 AC_SUBST(LINKER)


### PR DESCRIPTION
The `LINKER` variable is set to a literal `CC` or `CXX` instead of the appropriate `make(1)` variable.

## Description
The `LINKER` variable is set in configure.ac as either 'CC' or 'CXX' where it is then passed to the created Makefile. This fails with
slibtool which can't find the 'CC' file and can be fixed by correctly setting the LINKER variable to an actual Makefile variable like '$(CC)' or '$(CXX)' instead. Presumably GNU libtool does some magic here to hide the issue.


## Existing Issue(s)
Introduced in: https://github.com/libsdl-org/SDL/commit/761d38379b8d5eabc02327f8363baeda52316939 https://github.com/libsdl-org/SDL/pull/4537
