### PR TITLE
linux: remove x11/wayland d-bus lazy init code

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -578,10 +578,6 @@ Wayland_VideoInit(_THIS)
 
     Wayland_InitKeyboard(_this);
 
-#if SDL_USE_LIBDBUS
-    SDL_DBus_Init();
-#endif
-
     return 0;
 }
 

--- a/src/video/wayland/SDL_waylandvideo.h
+++ b/src/video/wayland/SDL_waylandvideo.h
@@ -29,7 +29,6 @@
 #include "wayland-util.h"
 
 #include "../SDL_sysvideo.h"
-#include "../../core/linux/SDL_dbus.h"
 #include "../../core/linux/SDL_ime.h"
 
 struct xkb_context;

--- a/src/video/x11/SDL_x11video.c
+++ b/src/video/x11/SDL_x11video.c
@@ -453,10 +453,6 @@ X11_VideoInit(_THIS)
 
     X11_InitTouch(_this);
 
-#if SDL_USE_LIBDBUS
-    SDL_DBus_Init();
-#endif
-
     return 0;
 }
 

--- a/src/video/x11/SDL_x11video.h
+++ b/src/video/x11/SDL_x11video.h
@@ -56,7 +56,6 @@
 #include <X11/extensions/xf86vmode.h>
 #endif
 
-#include "../../core/linux/SDL_dbus.h"
 #include "../../core/linux/SDL_ime.h"
 
 #include "SDL_x11dyn.h"


### PR DESCRIPTION
## Description
This lazy init logic is dead code since dbdbae4, so we can drop it after 2.0.16.

## Existing Issue(s)
#4587
