### PR TITLE
Fixing WM_CHAR event handling for Unicode characters outside the Basic Multilingual Plane

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -898,7 +898,8 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
             }
             data->high_surrogate = 0;
         } else {
-            /* The code point is in the Basic Multilingual Plane */
+            /* The code point is in the Basic Multilingual Plane.
+               It's numerically equal to UTF-32. */
             char text[5];
             if (WIN_ConvertUTF32toUTF8((UINT32)wParam, text)) {
                 SDL_SendKeyboardText(text);

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -186,6 +186,7 @@ SetupWindowData(_THIS, SDL_Window * window, HWND hwnd, HWND parent, SDL_bool cre
     data->hdc = GetDC(hwnd);
     data->hinstance = (HINSTANCE) GetWindowLongPtr(hwnd, GWLP_HINSTANCE);
     data->created = created;
+    data->high_surrogate = 0;
     data->mouse_button_flags = 0;
     data->last_pointer_update = (LPARAM)-1;
     data->videodata = videodata;

--- a/src/video/windows/SDL_windowswindow.h
+++ b/src/video/windows/SDL_windowswindow.h
@@ -41,6 +41,7 @@ typedef struct
     SDL_bool created;
     WPARAM mouse_button_flags;
     LPARAM last_pointer_update;
+    WCHAR high_surrogate;
     SDL_bool initializing;
     SDL_bool expected_resize;
     SDL_bool in_border_change;


### PR DESCRIPTION
This PR addresses an issue where SDL2 is mishandling `WM_CHAR` events for Unicode characters from Supplementary Planes. The issue is when a code point from a Supplementary Plane is entered, Windows sends two separate `WM_CHAR` messages back to back: The first message includes the UTF-16 High Surrogate and the second the UTF-16 Low Surrogate. The problem is SDL is converting both high and low surrogates individually to UTF-8 as they are received. The user is then sent two separate `SDL_TEXTINPUT` events both containing invalid UTF-8. The problem can be corrected by collecting both surrogates, performing conversion, and sending one `SDL_TEXTINPUT` with valid UTF-8.

This bug has likely gone unnoticed because most modern languages are defined in the Basic Multilingual Plane (BMP). Additionally, UTF-16 characters within the BMP are valid UTF-32 which explains why the existing implementation is working for those characters. However, there are _some_ modern non-Latin Asian, Middle-Eastern, and African scripts that fall outside the BMP, as do most emoji characters. I myself caught this bug when attempting to input emoji.

You can verify this PR addresses the issue by running the `checkkeys` test application and entering an emoji, like [Grinning Face (U+1F600)](https://www.compart.com/en/unicode/U+1F600). The current implementation, without the fix, will produce the following output (notice it's printing the high and low surrogates individually as invalid UTF-8):

```
INFO: INPUT Text (\xed\xa0\xbd): "�"
INFO: INPUT Text (\xed\xb8\x80): "�"
```

The correct output (with the fix) looks like this:

```
INFO: INPUT Text (\xf0\x9f\x98\x80): "😀"
```
