### PR TITLE
testvulkan: Clamp the drawable size to the allowed range

### DIFF
--- a/test/testvulkan.c
+++ b/test/testvulkan.c
@@ -719,8 +719,17 @@ static SDL_bool createSwapchain(void)
 
     // get size
     SDL_Vulkan_GetDrawableSize(state->windows[0], &w, &h);
-    vulkanContext.swapchainSize.width = w;
-    vulkanContext.swapchainSize.height = h;
+
+    // Clamp the size to the allowable image extent.
+    // SDL_Vulkan_GetDrawableSize()'s result it not always in this range (bug #3287)
+    vulkanContext.swapchainSize.width = SDL_max(vulkanContext.surfaceCapabilities.minImageExtent.width,
+                                                SDL_min(w,
+                                                        vulkanContext.surfaceCapabilities.maxImageExtent.width));
+
+    vulkanContext.swapchainSize.height = SDL_max(vulkanContext.surfaceCapabilities.minImageExtent.height,
+                                                SDL_min(h,
+                                                        vulkanContext.surfaceCapabilities.maxImageExtent.height));
+
     if(w == 0 || h == 0)
         return SDL_FALSE;
 


### PR DESCRIPTION
``SDL_Vulkan_GetDrawableSize()`` doesn't always return a size which is within the Vulkan swapchain's allowed image extent range.

(This happens on X11 a lot when resizing, which is bug #3287)

Clamp the value we get back from ``SDL_Vulkan_GetDrawableSize()`` to this range. Given the range usually is just a single value, this is almost always equivalent to just using the min or max image extent, but this seems logically most correct.

Without this change, ``testvulkan --resizable`` gives a lot of warnings when resized on X11:
```
VUID-VkSwapchainCreateInfoKHR-imageExtent-01274(ERROR / SPEC): msgNum: 2094043421 - Validation Error: [ VUID-VkSwapchainCreateInfoKHR-imageExtent-01274 ] Object 0: handle = 0xcff5f0, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x7cd0911d | vkCreateSwapchainKHR() called with imageExtent = (593,379), which is outside the bounds returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR(): currentExtent = (568,351), minImageExtent = (568,351), maxImageExtent = (568,351). The Vulkan spec states: imageExtent must be between minImageExtent and maxImageExtent, inclusive, where minImageExtent and maxImageExtent are members of the VkSurfaceCapabilitiesKHR structure returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR for the surface (https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VUID-VkSwapchainCreateInfoKHR-imageExtent-01274)
```

With this change, that warning no longer appears (the hang mentioned in issue #4595 is not fixed by this, though — it also appears on Wayland, which doesn't show this issue).