### PR TITLE
x11/wayland: fix screensaver suspension via D-Bus

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.h
+++ b/src/video/wayland/SDL_waylandvideo.h
@@ -29,6 +29,7 @@
 #include "wayland-util.h"
 
 #include "../SDL_sysvideo.h"
+#include "../../core/linux/SDL_dbus.h"
 #include "../../core/linux/SDL_ime.h"
 
 struct xkb_context;

--- a/src/video/x11/SDL_x11video.h
+++ b/src/video/x11/SDL_x11video.h
@@ -56,6 +56,7 @@
 #include <X11/extensions/xf86vmode.h>
 #endif
 
+#include "../../core/linux/SDL_dbus.h"
 #include "../../core/linux/SDL_ime.h"
 
 #include "SDL_x11dyn.h"


### PR DESCRIPTION
b08b1bde introduced a subtle bug. Despite not using D-Bus types directly, the code used the `SDL_USE_LIBDBUS` definition set by `SDL_dbus.h` to conditionally compile calls `SDL_DBus_ScreensaverTickle()` and `SDL_DBus_ScreensaverInhibit()`. As a result, it still compiled without `SDL_dbus.h` included, but screensaver suspension silently failed to work.

The D-Bus stuff could probably use some tweaks to be harder to accidentally break, but for now just restore the header includes.
