### PR TITLE
Don't disable clang avx instrinsics on win32 if __AVX__ is defined.

### DIFF
--- a/src/audio/SDL_audiocvt.c
+++ b/src/audio/SDL_audiocvt.c
@@ -47,7 +47,10 @@
 #define HAVE_AVX_INTRINSICS 1
 #endif
 #if defined __clang__
-# if (__clang_major__ < 5) || defined(_MSC_VER) || defined(__SCE__)
+# if (__clang_major__ < 5)
+#   undef HAVE_AVX_INTRINSICS
+# endif
+# if (defined(_MSC_VER) || defined(__SCE__)) && !defined(__AVX__)
 #   undef HAVE_AVX_INTRINSICS
 # endif
 #elif defined __GNUC__


### PR DESCRIPTION
C.f.: https://github.com/libsdl-org/SDL/issues/4533

The user _should_ still be able to enable avx (e.g. by `-mavx` or something)
@slouken, @jbsolomon: please verify this.