### PR TITLE
Revert #4494 to avoid regressions

### DIFF
--- a/src/video/x11/SDL_x11modes.c
+++ b/src/video/x11/SDL_x11modes.c
@@ -1057,10 +1057,9 @@ X11_SetDisplayMode(_THIS, SDL_VideoDisplay * sdl_display, SDL_DisplayMode * mode
            for now we cheat and just catch the X11 error and carry on, which
            is likely to cause subtle issues but is better than outright
            crashing */
-        X11_XSync(display, False);
         PreXRRSetScreenSizeErrorHandler = X11_XSetErrorHandler(SDL_XRRSetScreenSizeErrHandler);
         X11_XRRSetScreenSize(display, RootWindow(display, data->screen), mode->w, mode->h, mm_width, mm_height);
-        X11_XSync(display, False);
+        X11_XSync(display, False);  /* hopefully force any protocol errors to process with this handler. */
         X11_XSetErrorHandler(PreXRRSetScreenSizeErrorHandler);
 
         status = X11_XRRSetCrtcConfig (display, res, output_info->crtc, CurrentTime,

--- a/src/video/x11/SDL_x11modes.c
+++ b/src/video/x11/SDL_x11modes.c
@@ -1059,7 +1059,6 @@ X11_SetDisplayMode(_THIS, SDL_VideoDisplay * sdl_display, SDL_DisplayMode * mode
            crashing */
         PreXRRSetScreenSizeErrorHandler = X11_XSetErrorHandler(SDL_XRRSetScreenSizeErrHandler);
         X11_XRRSetScreenSize(display, RootWindow(display, data->screen), mode->w, mode->h, mm_width, mm_height);
-        X11_XSync(display, False);  /* hopefully force any protocol errors to process with this handler. */
         X11_XSetErrorHandler(PreXRRSetScreenSizeErrorHandler);
 
         status = X11_XRRSetCrtcConfig (display, res, output_info->crtc, CurrentTime,

--- a/src/video/x11/SDL_x11modes.c
+++ b/src/video/x11/SDL_x11modes.c
@@ -1002,7 +1002,6 @@ X11_SetDisplayMode(_THIS, SDL_VideoDisplay * sdl_display, SDL_DisplayMode * mode
     Display *display = viddata->display;
     SDL_DisplayData *data = (SDL_DisplayData *) sdl_display->driverdata;
     SDL_DisplayModeData *modedata = (SDL_DisplayModeData *)mode->driverdata;
-    int mm_width, mm_height;
 
     viddata->last_mode_change_deadline = SDL_GetTicks() + (PENDING_FOCUS_TIME * 2);
 
@@ -1031,23 +1030,10 @@ X11_SetDisplayMode(_THIS, SDL_VideoDisplay * sdl_display, SDL_DisplayMode * mode
             return SDL_SetError("Couldn't get XRandR crtc info");
         }
 
-        X11_XGrabServer(display);
-        status = X11_XRRSetCrtcConfig(display, res, output_info->crtc, CurrentTime,
-          0, 0, None, crtc->rotation, NULL, 0);
-        if (status != Success) {
-            goto setCrtcError;
-        }
-
-        mm_width = mode->w * DisplayWidthMM(display, data->screen) / DisplayWidth(display, data->screen);
-        mm_height = mode->h * DisplayHeightMM(display, data->screen) / DisplayHeight(display, data->screen);
-        X11_XRRSetScreenSize(display, RootWindow(display, data->screen), mode->w, mode->h, mm_width, mm_height);
-
         status = X11_XRRSetCrtcConfig (display, res, output_info->crtc, CurrentTime,
           crtc->x, crtc->y, modedata->xrandr_mode, crtc->rotation,
           &data->xrandr_output, 1);
 
-setCrtcError:
-        X11_XUngrabServer(display);
         X11_XRRFreeCrtcInfo(crtc);
         X11_XRRFreeOutputInfo(output_info);
         X11_XRRFreeScreenResources(res);

--- a/src/video/x11/SDL_x11modes.c
+++ b/src/video/x11/SDL_x11modes.c
@@ -995,15 +995,6 @@ X11_GetDisplayModes(_THIS, SDL_VideoDisplay * sdl_display)
     }
 }
 
-/* This catches an error from XRRSetScreenSize, as a workaround for now. */
-/* !!! FIXME: remove this later when we have a better solution. */
-static int (*PreXRRSetScreenSizeErrorHandler)(Display *, XErrorEvent *) = NULL;
-static int
-SDL_XRRSetScreenSizeErrHandler(Display *d, XErrorEvent *e)
-{
-    return (e->error_code == BadMatch) ? 0 : PreXRRSetScreenSizeErrorHandler(d, e);
-}
-
 int
 X11_SetDisplayMode(_THIS, SDL_VideoDisplay * sdl_display, SDL_DisplayMode * mode)
 {
@@ -1049,17 +1040,7 @@ X11_SetDisplayMode(_THIS, SDL_VideoDisplay * sdl_display, SDL_DisplayMode * mode
 
         mm_width = mode->w * DisplayWidthMM(display, data->screen) / DisplayWidth(display, data->screen);
         mm_height = mode->h * DisplayHeightMM(display, data->screen) / DisplayHeight(display, data->screen);
-
-        /* !!! FIXME: this can get into a problem scenario when a window is
-           bigger than a physical monitor in a configuration where one screen
-           spans multiple physical monitors. A detailed reproduction case is
-           discussed at https://github.com/libsdl-org/SDL/issues/4561 ...
-           for now we cheat and just catch the X11 error and carry on, which
-           is likely to cause subtle issues but is better than outright
-           crashing */
-        PreXRRSetScreenSizeErrorHandler = X11_XSetErrorHandler(SDL_XRRSetScreenSizeErrHandler);
         X11_XRRSetScreenSize(display, RootWindow(display, data->screen), mode->w, mode->h, mm_width, mm_height);
-        X11_XSetErrorHandler(PreXRRSetScreenSizeErrorHandler);
 
         status = X11_XRRSetCrtcConfig (display, res, output_info->crtc, CurrentTime,
           crtc->x, crtc->y, modedata->xrandr_mode, crtc->rotation,


### PR DESCRIPTION
Merging #4494 triggered #4561 (which has been worked around, but not fully fixed?) and #4630. It might be better to revert those changes until this can be figured out.

I don't know whether SDL maintainers will want to actually merge this - as much as anything else, I'm opening this PR so that I have a record of what I have tested while trying to get SDL 2.0.16 into Debian.

## Description
This reverts commits b033cd0, 4c7825f, d0effad and 16e3bfe.

## Existing Issue(s)
* #4561
* #4630