### PR TITLE
Fix some minor memory leaks on Linux

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -391,6 +391,7 @@ display_handle_done(void *data,
 
     driverdata->placeholder.driverdata = driverdata;
     SDL_AddVideoDisplay(&driverdata->placeholder, SDL_FALSE);
+    SDL_free(driverdata->placeholder.name);
     SDL_zero(driverdata->placeholder);
 }
 


### PR DESCRIPTION
## Description
Just some stuff I found when running Taisei under ASan. The first commit fixes a leak of cached joystick mappings, allocated at: https://github.com/libsdl-org/SDL/blob/44a76710d1a4f2bbcee47b14d4bdd8d75263d094/src/joystick/linux/SDL_sysjoystick.c#L1625
It also streamlines some divergent duplicate code to avoid similar issues in the future. 

The second commit fixes a leak of Wayland output names, allocated at: https://github.com/libsdl-org/SDL/blob/44a76710d1a4f2bbcee47b14d4bdd8d75263d094/src/video/wayland/SDL_waylandvideo.c#L302