### PR TITLE
checkkeys: Create a renderer for window display on Wayland

### DIFF
--- a/test/checkkeys.c
+++ b/test/checkkeys.c
@@ -201,6 +201,7 @@ int
 main(int argc, char *argv[])
 {
     SDL_Window *window;
+    SDL_Renderer *renderer;
 
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
@@ -220,6 +221,12 @@ main(int argc, char *argv[])
                 SDL_GetError());
         quit(2);
     }
+
+    /* On wayland, no window will actually show until something has
+       actually been displayed.
+    */
+    renderer = SDL_CreateRenderer(window, -1, 0);
+    SDL_RenderPresent(renderer);
 
 #if __IPHONEOS__
     /* Creating the context creates the view, which we need to show keyboard */


### PR DESCRIPTION
On Wayland -- or at least on some Wayland implementations -- windows
aren't shown until something has been rendered into them. For the
'checkkeys' test program, this means that keyboard input isn't
registered, making the program rather useless.

By creating a renderer and presenting once, the window is properly
displayed, and the test behaves as it does under X11 (including
XWayland).

The exact same thing was done with testmessge in 1cd97e2695 (PR #4252)