### PR TITLE
[Feature] Add new SDL_clamp() macro

### DIFF
--- a/include/SDL_stdinc.h
+++ b/include/SDL_stdinc.h
@@ -444,6 +444,7 @@ extern DECLSPEC int SDLCALL SDL_abs(int x);
 /* NOTE: these double-evaluate their arguments, so you should never have side effects in the parameters */
 #define SDL_min(x, y) (((x) < (y)) ? (x) : (y))
 #define SDL_max(x, y) (((x) > (y)) ? (x) : (y))
+#define SDL_clamp(x, a, b) ((x) < (a)) ? (a) : (((x) > (b)) ? (b) : (x))
 
 extern DECLSPEC int SDLCALL SDL_isalpha(int x);
 extern DECLSPEC int SDLCALL SDL_isalnum(int x);

--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -146,7 +146,7 @@ static int SDL_DoEventLogging = 0;
 static void SDLCALL
 SDL_EventLoggingChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
 {
-    SDL_DoEventLogging = (hint && *hint) ? SDL_max(SDL_min(SDL_atoi(hint), 2), 0) : 0;
+    SDL_DoEventLogging = (hint && *hint) ? SDL_clamp(SDL_atoi(hint), 0, 2) : 0;
 }
 
 static void

--- a/src/joystick/iphoneos/SDL_mfijoystick.m
+++ b/src/joystick/iphoneos/SDL_mfijoystick.m
@@ -783,9 +783,9 @@ IOS_AccelerometerUpdate(SDL_Joystick *joystick)
      */
 
     /* clamp the data */
-    accel.x = SDL_min(SDL_max(accel.x, -maxgforce), maxgforce);
-    accel.y = SDL_min(SDL_max(accel.y, -maxgforce), maxgforce);
-    accel.z = SDL_min(SDL_max(accel.z, -maxgforce), maxgforce);
+    accel.x = SDL_clamp(accel.x, -maxgforce, maxgforce);
+    accel.y = SDL_clamp(accel.y, -maxgforce, maxgforce);
+    accel.z = SDL_clamp(accel.z, -maxgforce, maxgforce);
 
     /* pass in data mapped to range of SInt16 */
     SDL_PrivateJoystickAxis(joystick, 0,  (accel.x / maxgforce) * maxsint16);

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -925,7 +925,7 @@ keyboard_handle_repeat_info(void *data, struct wl_keyboard *wl_keyboard,
                             int32_t rate, int32_t delay)
 {
     struct SDL_WaylandInput *input = data;
-    input->keyboard_repeat.repeat_rate = SDL_max(0, SDL_min(rate, 1000));
+    input->keyboard_repeat.repeat_rate = SDL_clamp(rate, 0, 1000);
     input->keyboard_repeat.repeat_delay = delay;
     input->keyboard_repeat.is_initialized = SDL_TRUE;
 }

--- a/test/testvulkan.c
+++ b/test/testvulkan.c
@@ -722,13 +722,13 @@ static SDL_bool createSwapchain(void)
 
     // Clamp the size to the allowable image extent.
     // SDL_Vulkan_GetDrawableSize()'s result it not always in this range (bug #3287)
-    vulkanContext.swapchainSize.width = SDL_max(vulkanContext.surfaceCapabilities.minImageExtent.width,
-                                                SDL_min(w,
-                                                        vulkanContext.surfaceCapabilities.maxImageExtent.width));
+    vulkanContext.swapchainSize.width = SDL_clamp(w,
+                                                  vulkanContext.surfaceCapabilities.minImageExtent.width,
+                                                  vulkanContext.surfaceCapabilities.maxImageExtent.width);
 
-    vulkanContext.swapchainSize.height = SDL_max(vulkanContext.surfaceCapabilities.minImageExtent.height,
-                                                SDL_min(h,
-                                                        vulkanContext.surfaceCapabilities.maxImageExtent.height));
+    vulkanContext.swapchainSize.height = SDL_clamp(h,
+                                                   vulkanContext.surfaceCapabilities.minImageExtent.height,
+                                                   vulkanContext.surfaceCapabilities.maxImageExtent.height);
 
     if(w == 0 || h == 0)
         return SDL_FALSE;


### PR DESCRIPTION
Add a function to clamp a value to a range.

``SDL_clamp(x, a, b)`` is equivalent to ``SDL_min(a, SDL_max(x, b))``: it ensures that ``x`` is neither smaller than ``a``, nor larger than ``b``. This is implemented as a macro, alongside the ``SDL_min()`` and ``SDL_max()`` macros. It similarly can evaluate its inputs more than once, so isn't safe to use if its arguments are expressions with side effects.

Note that, as far as I can tell, ``clamp()`` is even less standardised than ``min()`` and ``max()``, so I'd understand if having it in ``SDL_stdinc.h`` doesn't seem like the best fit.

Thoughts?