### PR TITLE
Added missing parenthesis around SDL_clamp

### DIFF
--- a/include/SDL_stdinc.h
+++ b/include/SDL_stdinc.h
@@ -444,7 +444,7 @@ extern DECLSPEC int SDLCALL SDL_abs(int x);
 /* NOTE: these double-evaluate their arguments, so you should never have side effects in the parameters */
 #define SDL_min(x, y) (((x) < (y)) ? (x) : (y))
 #define SDL_max(x, y) (((x) > (y)) ? (x) : (y))
-#define SDL_clamp(x, a, b) ((x) < (a)) ? (a) : (((x) > (b)) ? (b) : (x))
+#define SDL_clamp(x, a, b) (((x) < (a)) ? (a) : (((x) > (b)) ? (b) : (x)))
 
 extern DECLSPEC int SDLCALL SDL_isalpha(int x);
 extern DECLSPEC int SDLCALL SDL_isalnum(int x);


### PR DESCRIPTION
SDL_clamp was missing parenthesis around the whole expression, causing issues with operator precedence.