### PR TITLE
waylandevents: prevent segfault if xkb compose table is not found

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -793,7 +793,7 @@ keyboard_input_get_text(char text[8], const struct SDL_WaylandInput *input, uint
     }
 #endif
 
-    if (WAYLAND_xkb_compose_state_feed(input->xkb.compose_state, sym) == XKB_COMPOSE_FEED_ACCEPTED) {
+    if (input->xkb.compose_state && WAYLAND_xkb_compose_state_feed(input->xkb.compose_state, sym) == XKB_COMPOSE_FEED_ACCEPTED) {
         switch(WAYLAND_xkb_compose_state_get_status(input->xkb.compose_state)) {
             case XKB_COMPOSE_COMPOSING:
                 *handled_by_ime = SDL_TRUE;


### PR DESCRIPTION
This can happen e.g. on pure wayland system where there is no X11 locales for xkbcommon to find.

## Description
On a pure Wayland system, completely without X, libxkbcommon would not be able to find locales in /usr/share/X11/locale/ (which are installed by libx11 if X is present), so input->xkb.compose_table and input->xkb.compose_state will be NULL. In this case check input->xkb.compose_state for NULL before using it.

## Existing Issue(s)
-