### PR TITLE
Restore KMOD_RESERVED for backward compatibility

### DIFF
--- a/include/SDL_keycode.h
+++ b/include/SDL_keycode.h
@@ -343,7 +343,9 @@ typedef enum
     KMOD_CTRL = KMOD_LCTRL | KMOD_RCTRL,
     KMOD_SHIFT = KMOD_LSHIFT | KMOD_RSHIFT,
     KMOD_ALT = KMOD_LALT | KMOD_RALT,
-    KMOD_GUI = KMOD_LGUI | KMOD_RGUI
+    KMOD_GUI = KMOD_LGUI | KMOD_RGUI,
+
+    KMOD_RESERVED = KMOD_SCROLL /* This is for source-level compatibility with SDL 2.0.0. */
 } SDL_Keymod;
 
 #endif /* SDL_keycode_h_ */


### PR DESCRIPTION
## Description
Some applications check for KMOD_RESERVED when printing set key modifiers but it was replaced with KMOD_SCROLL in https://github.com/libsdl-org/SDL/commit/cb1e20b058f1de55b98f32b7d16cff1f896f88dd. Those applications fail to compile against the latest SDL headers / 2.0.17 due to missing KMOD_RESERVED.

It [affected ioquake3](https://github.com/ioquake/ioq3/blob/bc8737d707595aebd7cc11d6d5a5d65ede750f59/code/sdl/sdl_input.c#L76-L87) (now [fixed](https://github.com/ioquake/ioq3/commit/77d6cde137d9dca0ac4f2473d25c278bc65e34d9)) but it still affects past versions and many derivatives.

Patch restores KMOD_RESERVED for source-level compatibility with SDL 2.0.0.