### PR TITLE
include/SDL_video.h: Remove a comma at end of enumerator list

### DIFF
--- a/include/SDL_video.h
+++ b/include/SDL_video.h
@@ -207,7 +207,7 @@ typedef enum
 {
     SDL_FLASH_CANCEL,                   /**< Cancel any window flash state */
     SDL_FLASH_BRIEFLY,                  /**< Flash the window briefly to get attention */
-    SDL_FLASH_UNTIL_FOCUSED,            /**< Flash the window until it gets focus */
+    SDL_FLASH_UNTIL_FOCUSED             /**< Flash the window until it gets focus */
 } SDL_FlashOperation;
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I removed a comma at end of enumerator list in the `include/SDL_video.h` file to fix a compilation problem with GCC.

## Description
<!--- Describe your changes in detail -->
Here is the code to compile with GCC:
```
#include <SDL.h> /* for SDL_Init */
int main()
{
	if(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO) != 0)
	{
		SDL_Log("Unable to initialize SDL: %s", SDL_GetError());
		return 1;
	}
	SDL_Quit();
	return 0;
}
```
Here is the result:
```
gcc -std=c89 -pedantic -Wall -Werror -g `pkg-config sdl2 --cflags` -o main.out main.c `pkg-config sdl2 --libs-only-L` `pkg-config sdl2 --libs-only-l`
In file included from /usr/include/SDL2/SDL_events.h:33,
                 from /usr/include/SDL2/SDL.h:41,
                 from main.c:1:
/usr/include/SDL2/SDL_video.h:210:28: error: comma at end of enumerator list [-Werror=pedantic]
     SDL_FLASH_UNTIL_FOCUSED,            /**< Flash the window until it gets focus */
                            ^
cc1: all warnings being treated as errors
make: *** [main.out] Error 1
```
So, using GCC 8.2.0 and the above options, compiling this code is a failure.
In order to fix that, there is a comma to remove in the `SDL_video.h` header.
With this fix, here is the new result:
```
gcc -std=c89 -pedantic -Wall -Werror -g `pkg-config sdl2 --cflags` -o main.out main.c `pkg-config sdl2 --libs-only-L` `pkg-config sdl2 --libs-only-l`
```
Compiling this code is now a success!