### PR TITLE
remove warnings from Wundef in SDL_config.h.cmake

### DIFF
--- a/include/SDL_config.h.cmake
+++ b/include/SDL_config.h.cmake
@@ -204,7 +204,7 @@
 #cmakedefine HAVE_POLL 1
 #cmakedefine HAVE__EXIT 1
 
-#elif __WIN32__
+#elif defined(__WIN32__)
 #cmakedefine HAVE_STDARG_H 1
 #cmakedefine HAVE_STDDEF_H 1
 #cmakedefine HAVE_FLOAT_H 1


### PR DESCRIPTION
I get a bunch of warnings, one for each time SDL_config.h gets included like below (I am building with `-Wundef`)
```
SDL2/SDL_config.h:206:7: warning: "__WIN32__" is not defined [-Wundef]
 #elif __WIN32__
       ^
```

This commit removes them