### PR TITLE
audio: pipewire: Set PW_KEY_NODE_RATE to suggest a rate.

### DIFF
--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -31,6 +31,14 @@
 #include <pipewire/extensions/metadata.h>
 #include <spa/param/audio/format-utils.h>
 
+/* Older versions of Pipewire may not define this, but it's safe to pass at
+ * runtime even if older installations don't recognize it.
+ * Taken from src/pipewire/keys.h
+ */
+#ifndef PW_KEY_NODE_RATE
+#define PW_KEY_NODE_RATE "node.rate"
+#endif
+
 /*
  * These seem to be sane limits as Pipewire
  * uses them in several of it's own modules.
@@ -1110,6 +1118,7 @@ PIPEWIRE_OpenDevice(_THIS, void *handle, const char *devname, int iscapture)
     PIPEWIRE_pw_properties_set(props, PW_KEY_NODE_NAME, stream_name);
     PIPEWIRE_pw_properties_set(props, PW_KEY_NODE_DESCRIPTION, stream_name);
     PIPEWIRE_pw_properties_setf(props, PW_KEY_NODE_LATENCY, "%u/%i", adjusted_samples, this->spec.freq);
+    PIPEWIRE_pw_properties_setf(props, PW_KEY_NODE_RATE, "1/%u", this->spec.freq);
     PIPEWIRE_pw_properties_set(props, PW_KEY_NODE_ALWAYS_PROCESS, "true");
 
     /*


### PR DESCRIPTION
This can be used by recent pipewire to avoid resampling.

For more info see the following pipewire commits:
https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/1ff208875cfd18f35ae6821328c236e21d348c84
https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/bf66a3b2362093dbcc3a35dffe4d6bea2a896c67
https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/7846687df869d99d95701b419080234450fd6d8d
