### PR TITLE
audio: pipewire: Reset hotplug atomic variables on deinit.

### DIFF
--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -730,6 +730,9 @@ hotplug_loop_destroy()
     pending_list_clear();
     io_list_clear();
 
+    SDL_AtomicSet(&hotplug_init_complete, 0);
+    SDL_AtomicSet(&hotplug_events_enabled, 0);
+
     if (hotplug_registry) {
         PIPEWIRE_pw_proxy_destroy((struct pw_proxy *)hotplug_registry);
     }


### PR DESCRIPTION
This fixes audio with the pipewire backend in The Evil Within (running on FAudio).