### PR TITLE
If Android version >= API 23 PendingIntent.FLAGIMMUTABLE

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/HIDDeviceManager.java
+++ b/android-project/app/src/main/java/org/libsdl/app/HIDDeviceManager.java
@@ -584,7 +584,14 @@ public class HIDDeviceManager {
         if (usbDevice != null && !mUsbManager.hasPermission(usbDevice)) {
             HIDDeviceOpenPending(deviceID);
             try {
-                mUsbManager.requestPermission(usbDevice, PendingIntent.getBroadcast(mContext, 0, new Intent(HIDDeviceManager.ACTION_USB_PERMISSION), 0));
+                int flags;
+                if (Build.VERSION.SDK_INT >= 23) {
+                    flags = PendingIntent.FLAG_IMMUTABLE;
+                }
+                else {
+                    flags = 0;
+                }
+                mUsbManager.requestPermission(usbDevice, PendingIntent.getBroadcast(mContext, 0, new Intent(HIDDeviceManager.ACTION_USB_PERMISSION), flags));
             } catch (Exception e) {
                 Log.v(TAG, "Couldn't request permission for USB device " + usbDevice);
                 HIDDeviceOpenResult(deviceID, false);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
"If your app targets Android 12, you must specify the mutability of each PendingIntent object that your app creates. This additional requirement improves your app's security."
"Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if  some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles."
https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability

FLAG_IMMUTABLE was added in API 23. 
https://developer.android.com/reference/android/app/PendingIntent#FLAG_IMMUTABLE

Using API 30 would also fix the Android 12 issue. Alternatively if PendingIntents should be mutable you could change it to "FLAG_MUTABLE". Prior to Android 12 PendingsIntents were mutable by default.

From my testing on an Android 12 device, prior to this change plugging in a controller resulted in it not being recognised, but after the change it is recognised and functions correctly.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/4668