### PR TITLE
Remove redundant sizeof "size_t" check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,6 @@ include(CheckCSourceCompiles)
 include(CheckCSourceRuns)
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
-include(CheckTypeSize)
 include(CheckStructHasMember)
 include(CMakeDependentOption)
 include(FindPkgConfig)
@@ -824,7 +823,6 @@ if(LIBC)
 
     set(STDC_HEADER_NAMES "stddef.h;stdarg.h;stdlib.h;string.h;stdio.h;wchar.h;float.h")
     check_include_files("${STDC_HEADER_NAMES}" STDC_HEADERS)
-    check_type_size("size_t" SIZEOF_SIZE_T)
     check_symbol_exists(M_PI math.h HAVE_M_PI)
     # TODO: refine the mprotect check
     check_c_source_compiles("#include <sys/types.h>


### PR DESCRIPTION
The result variables: HAVE_${VARIABLE}, ${VARIABLE}, ${VARIABLE}_CODE, etc. do not seem to be referenced anywhere in the CMake build script. Unless I was mistaken on how the check is being used.

The motivation for me to have the redundant check removed is because otherwise it would cause an error in my SDL initial build tree generation with my own custom `Emscripten.cmake` toolchain file. My custom CMake toolchain file is much simpler version than the official one provided by EMSDK, which does not provide the "hack" version of the `CheckTypeSize.cmake`.

But in any case, there should be no harm to have this redundant check removed for other use cases.

My Web CI build can be found here: https://github.com/alpha-scorpii-b/SDL/runs/3383479743?check_suite_focus=true