### PR TITLE
Force color diagnostics when applicable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -557,6 +557,15 @@ if(USE_GCC OR USE_CLANG)
       list(APPEND EXTRA_LDFLAGS "-Wl,--no-undefined")
     endif()
   endif()
+
+  # Force color diagnostics when one of these conditions are met
+  if(DEFINED ENV{CI} OR DEFINED ENV{USE_CCACHE} OR CMAKE_GENERATOR MATCHES Ninja)
+    if(EMSCRIPTEN OR (USE_GCC AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.9))
+      list(APPEND EXTRA_CFLAGS -fdiagnostics-color=always)
+    elseif(USE_CLANG AND NOT CMAKE_C_COMPILER_ID MATCHES AppleClang)
+      list(APPEND EXTRA_CFLAGS -fcolor-diagnostics)
+    endif()
+  endif()
 endif()
 
 if(ASSEMBLY)


### PR DESCRIPTION
Although GCC and Clang automatically generate color diagnostics on terminal output, they do not do so when the compiler output is piped through another process, like in the case for ninja-build and ccache.

Similarly, it would also be nice to be able to see the color diagnostics on the CI build log in the web interface provided by the CI providers.
