### PR TITLE
Make relative mouse mode inactive when window/keyboard focus is lost

### DIFF
--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -23,6 +23,7 @@
 /* General keyboard handling code for SDL */
 
 #include "SDL_hints.h"
+#include "SDL_mouse.h"
 #include "SDL_timer.h"
 #include "SDL_events.h"
 #include "SDL_events_c.h"
@@ -623,10 +624,17 @@ void
 SDL_SetKeyboardFocus(SDL_Window * window)
 {
     SDL_Keyboard *keyboard = &SDL_keyboard;
+    SDL_Mouse *mouse = SDL_GetMouse();
 
     if (keyboard->focus && !window) {
         /* We won't get anymore keyboard messages, so reset keyboard state */
         SDL_ResetKeyboard();
+
+        /* if the mouse was relative, save this state and disable relative mouse mode */
+        if (mouse->relative_mode) {
+            SDL_SetRelativeMouseMode(SDL_FALSE);
+            mouse->had_relative_mode = SDL_TRUE;
+        }
     }
 
     /* See if the current window has lost focus */
@@ -664,6 +672,12 @@ SDL_SetKeyboardFocus(SDL_Window * window)
             if (video && video->StartTextInput) {
                 video->StartTextInput(video);
             }
+        }
+
+        /* if the mouse was not relative, but had it before restore this mode */
+        if (!mouse->relative_mode && mouse->had_relative_mode) {
+            SDL_SetRelativeMouseMode(SDL_TRUE);
+            mouse->had_relative_mode = SDL_FALSE;
         }
     }
 }

--- a/src/events/SDL_mouse_c.h
+++ b/src/events/SDL_mouse_c.h
@@ -84,6 +84,7 @@ typedef struct
     float accumulated_wheel_y;
     Uint32 buttonstate;
     SDL_bool has_position;
+    SDL_bool had_relative_mode; /* to save if the mouse had relative mouse mode enabled on focus change */
     SDL_bool relative_mode;
     SDL_bool relative_mode_warp;
     float normal_speed_scale;
@@ -115,6 +116,13 @@ extern int SDL_MouseInit(void);
 
 /* Get the mouse state structure */
 SDL_Mouse *SDL_GetMouse(void);
+
+/**
+* Check if the mouse is currently in relative mouse mode.
+* In contrast to @see SDL_GetRelativeMouseMode this does return the actual internal state.
+* E.g. if the window is not focused and mouse mode is disabled internally.
+*/
+SDL_bool SDL_IsMouseInRelativeMode(void);
 
 /* Set the default mouse cursor */
 extern void SDL_SetDefaultCursor(SDL_Cursor * cursor);

--- a/src/main/haiku/SDL_BApp.h
+++ b/src/main/haiku/SDL_BApp.h
@@ -235,13 +235,13 @@ private:
         win = GetSDLWindow(winID);
 
 		// Simple relative mode support for mouse.
-		if (SDL_GetMouse()->relative_mode) {
+		if (SDL_IsMouseInRelativeMode()) {
 			int winWidth, winHeight, winPosX, winPosY;
 			SDL_GetWindowSize(win, &winWidth, &winHeight);
 			SDL_GetWindowPosition(win, &winPosX, &winPosY);
 			int dx = x - (winWidth / 2);
 			int dy = y - (winHeight / 2);
-			SDL_SendMouseMotion(win, 0, SDL_GetMouse()->relative_mode, dx, dy);
+			SDL_SendMouseMotion(win, 0, SDL_IsMouseInRelativeMode(), dx, dy);
 			set_mouse_position((winPosX + winWidth / 2), (winPosY + winHeight / 2));
 			if (!be_app->IsCursorHidden())
 				be_app->HideCursor();

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2715,7 +2715,7 @@ SDL_UpdateWindowGrab(SDL_Window * window)
     SDL_bool keyboard_grabbed, mouse_grabbed;
 
     if (window->flags & SDL_WINDOW_INPUT_FOCUS) {
-        if (SDL_GetMouse()->relative_mode || (window->flags & SDL_WINDOW_MOUSE_GRABBED)) {
+        if (SDL_IsMouseInRelativeMode() || (window->flags & SDL_WINDOW_MOUSE_GRABBED)) {
             mouse_grabbed = SDL_TRUE;
         } else {
             mouse_grabbed = SDL_FALSE;
@@ -2927,6 +2927,7 @@ SDL_OnWindowFocusGained(SDL_Window * window)
         _this->SetWindowGammaRamp(_this, window, window->gamma);
     }
 
+    // TODO: this looks useless now
     if (mouse && mouse->relative_mode) {
         SDL_SetMouseFocus(window);
         if (mouse->relative_mode_warp) {

--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -231,14 +231,14 @@ Cocoa_WarpMouseGlobal(int x, int y)
      * Calling this directly after. CGSetLocalEventsSuppressionInterval can also
      * prevent it, but it's deprecated as of OS X 10.6.
      */
-    if (!mouse->relative_mode) {
+    if (!SDL_IsMouseInRelativeMode()) {
         CGAssociateMouseAndMouseCursorPosition(YES);
     }
 
     /* CGWarpMouseCursorPosition doesn't generate a window event, unlike our
      * other implementations' APIs. Send what's appropriate.
      */
-    if (!mouse->relative_mode) {
+    if (!SDL_IsMouseInRelativeMode()) {
         SDL_Window *win = SDL_FindWindowAtPoint(x, y);
         SDL_SetMouseFocus(win);
         if (win) {
@@ -429,7 +429,7 @@ Cocoa_HandleMouseEvent(_THIS, NSEvent *event)
     DLog("Last seen mouse: (%g, %g)", location.x, location.y);
 
     /* Non-relative movement is handled in -[Cocoa_WindowListener mouseMoved:] */
-    if (!mouse->relative_mode) {
+    if (!SDL_IsMouseInRelativeMode()) {
         return;
     }
 

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -552,7 +552,7 @@ SetWindowStyle(SDL_Window * window, NSUInteger style)
             mouse->WarpMouseGlobal(pendingWindowWarpX, pendingWindowWarpY);
             pendingWindowWarpX = pendingWindowWarpY = INT_MAX;
         }
-        if (mouse->relative_mode && !mouse->relative_mode_warp && mouse->focus == _data->window) {
+        if (SDL_IsMouseInRelativeMode() && !mouse->relative_mode_warp && mouse->focus == _data->window) {
             /* Move the cursor to the nearest point in the window */
             {
                 int x, y;
@@ -684,12 +684,12 @@ SetWindowStyle(SDL_Window * window, NSUInteger style)
     /* This needs to be done before restoring the relative mouse mode. */
     SDL_SetKeyboardFocus(window);
 
-    if (mouse->relative_mode && !mouse->relative_mode_warp && ![self isMovingOrFocusClickPending]) {
+    if (SDL_IsMouseInRelativeMode() && !mouse->relative_mode_warp && ![self isMovingOrFocusClickPending]) {
         mouse->SetRelativeMouseMode(SDL_TRUE);
     }
 
     /* If we just gained focus we need the updated mouse position */
-    if (!mouse->relative_mode) {
+    if (!SDL_IsMouseInRelativeMode()) {
         NSPoint point;
         int x, y;
 
@@ -717,7 +717,7 @@ SetWindowStyle(SDL_Window * window, NSUInteger style)
 - (void)windowDidResignKey:(NSNotification *)aNotification
 {
     SDL_Mouse *mouse = SDL_GetMouse();
-    if (mouse->relative_mode && !mouse->relative_mode_warp) {
+    if (SDL_IsMouseInRelativeMode() && !mouse->relative_mode_warp) {
         mouse->SetRelativeMouseMode(SDL_FALSE);
     }
 
@@ -1148,7 +1148,7 @@ SetWindowStyle(SDL_Window * window, NSUInteger style)
         return;  /* dragging, drop event. */
     }
 
-    if (mouse->relative_mode) {
+    if (SDL_IsMouseInRelativeMode()) {
         return;
     }
 
@@ -1390,7 +1390,7 @@ SetWindowStyle(SDL_Window * window, NSUInteger style)
     [super resetCursorRects];
     SDL_Mouse *mouse = SDL_GetMouse();
 
-    if (mouse->cursor_shown && mouse->cur_cursor && !mouse->relative_mode) {
+    if (mouse->cursor_shown && mouse->cur_cursor && !SDL_IsMouseInRelativeMode()) {
         [self addCursorRect:[self bounds]
                      cursor:mouse->cur_cursor->driverdata];
     } else {

--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -362,7 +362,7 @@ Emscripten_HandleMouseButton(int eventType, const EmscriptenMouseEvent *mouseEve
     }
 
     if (eventType == EMSCRIPTEN_EVENT_MOUSEDOWN) {
-        if (SDL_GetMouse()->relative_mode && !window_data->has_pointer_lock) {
+        if (SDL_IsMouseInRelativeMode() && !window_data->has_pointer_lock) {
             emscripten_request_pointerlock(window_data->canvas_id, 0);  /* try to regrab lost pointer lock. */
         }
         sdl_button_state = SDL_PRESSED;

--- a/src/video/os2/SDL_os2video.c
+++ b/src/video/os2/SDL_os2video.c
@@ -183,7 +183,7 @@ static VOID _mouseCheck(WINDATA *pWinData)
 {
     SDL_Mouse *pSDLMouse = SDL_GetMouse();
 
-    if ((pSDLMouse->relative_mode || (pWinData->window->flags & SDL_WINDOW_MOUSE_GRABBED) != 0) &&
+    if ((SDL_IsMouseInRelativeMode() || (pWinData->window->flags & SDL_WINDOW_MOUSE_GRABBED) != 0) &&
         ((pWinData->window->flags & SDL_WINDOW_INPUT_FOCUS) != 0)) {
         /* We will make a real capture in _wmMouseButton() */
     } else {
@@ -230,8 +230,8 @@ static VOID _wmMouseMove(WINDATA *pWinData, SHORT lX, SHORT lY)
     POINTL  pointl;
     BOOL    fWinActive = (pWinData->window->flags & SDL_WINDOW_INPUT_FOCUS) != 0;
 
-    if (!pSDLMouse->relative_mode || pSDLMouse->relative_mode_warp) {
-        if (!pSDLMouse->relative_mode && fWinActive &&
+    if (!SDL_IsMouseInRelativeMode() || pSDLMouse->relative_mode_warp) {
+        if (!SDL_IsMouseInRelativeMode() && fWinActive &&
             ((pWinData->window->flags & SDL_WINDOW_MOUSE_GRABBED) != 0) &&
             (WinQueryCapture(HWND_DESKTOP) == pWinData->hwnd)) {
 
@@ -281,11 +281,11 @@ static VOID _wmMouseButton(WINDATA *pWinData, ULONG ulButton, BOOL fDown)
                                       SDL_BUTTON_MIDDLE };
     SDL_Mouse *pSDLMouse = SDL_GetMouse();
 
-    if ((pSDLMouse->relative_mode || ((pWinData->window->flags & SDL_WINDOW_MOUSE_GRABBED) != 0)) &&
+    if ((SDL_IsMouseInRelativeMode() || ((pWinData->window->flags & SDL_WINDOW_MOUSE_GRABBED) != 0)) &&
         ((pWinData->window->flags & SDL_WINDOW_INPUT_FOCUS) != 0) &&
         (WinQueryCapture(HWND_DESKTOP) != pWinData->hwnd)) {
         /* Mouse should be captured. */
-        if (pSDLMouse->relative_mode && !pSDLMouse->relative_mode_warp) {
+        if (SDL_IsMouseInRelativeMode() && !pSDLMouse->relative_mode_warp) {
             POINTL  pointl;
 
             pointl.x = pWinData->window->w / 2;

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -404,7 +404,7 @@ WIN_UpdateFocus(SDL_Window *window)
         SDL_SetKeyboardFocus(window);
 
         /* In relative mode we are guaranteed to have mouse focus if we have keyboard focus */
-        if (!SDL_GetMouse()->relative_mode) {
+        if (!SDL_IsMouseInRelativeMode()) {
             GetCursorPos(&cursorPos);
             ScreenToClient(hwnd, &cursorPos);
             SDL_SendMouseMotion(window, 0, 0, cursorPos.x, cursorPos.y);
@@ -720,7 +720,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
                 }
             }
 
-            if (!mouse->relative_mode || mouse->relative_mode_warp) {
+            if (!SDL_IsMouseInRelativeMode() || mouse->relative_mode_warp) {
                 /* Only generate mouse events for real mouse */
                 if (GetMouseMessageSource() != SDL_MOUSE_EVENT_SOURCE_TOUCH &&
                     lParam != data->last_pointer_update) {
@@ -743,7 +743,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
     case WM_XBUTTONDBLCLK:
         {
             SDL_Mouse *mouse = SDL_GetMouse();
-            if (!mouse->relative_mode || mouse->relative_mode_warp) {
+            if (!SDL_IsMouseInRelativeMode() || mouse->relative_mode_warp) {
                 if (GetMouseMessageSource() != SDL_MOUSE_EVENT_SOURCE_TOUCH &&
                     lParam != data->last_pointer_update) {
                     WIN_CheckWParamMouseButtons(wParam, data, 0);
@@ -760,7 +760,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
             UINT size = sizeof(inp);
 
             /* We only use raw mouse input in relative mode */
-            if (!mouse->relative_mode || mouse->relative_mode_warp) {
+            if (!SDL_IsMouseInRelativeMode() || mouse->relative_mode_warp) {
                 break;
             }
 
@@ -875,7 +875,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
     case WM_MOUSELEAVE:
         if (!(data->window->flags & SDL_WINDOW_MOUSE_CAPTURE)) {
-            if (SDL_GetMouseFocus() == data->window && !SDL_GetMouse()->relative_mode && !IsIconic(hwnd)) {
+            if (SDL_GetMouseFocus() == data->window && !SDL_IsMouseInRelativeMode() && !IsIconic(hwnd)) {
                 SDL_Mouse *mouse;
                 POINT cursorPos;
                 GetCursorPos(&cursorPos);

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -998,9 +998,9 @@ WIN_UpdateClipCursor(SDL_Window *window)
         return;
     }
 
-    if ((mouse->relative_mode || (window->flags & SDL_WINDOW_MOUSE_GRABBED)) &&
+    if ((SDL_IsMouseInRelativeMode() || (window->flags & SDL_WINDOW_MOUSE_GRABBED)) &&
         (window->flags & SDL_WINDOW_INPUT_FOCUS)) {
-        if (mouse->relative_mode && !mouse->relative_mode_warp) {
+        if (SDL_IsMouseInRelativeMode() && !mouse->relative_mode_warp) {
             if (GetWindowRect(data->hwnd, &rect)) {
                 LONG cx, cy;
 

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -869,7 +869,7 @@ X11_DispatchEvent(_THIS, XEvent *xevent)
             mouse->last_x = xevent->xcrossing.x;
             mouse->last_y = xevent->xcrossing.y;
 
-            if (!mouse->relative_mode) {
+            if (!SDL_IsMouseInRelativeMode()) {
                 SDL_SendMouseMotion(data->window, 0, 0, xevent->xcrossing.x, xevent->xcrossing.y);
             }
 
@@ -889,7 +889,7 @@ X11_DispatchEvent(_THIS, XEvent *xevent)
             if (xevent->xcrossing.mode == NotifyUngrab)
                 printf("Mode: NotifyUngrab\n");
 #endif
-            if (!SDL_GetMouse()->relative_mode) {
+            if (!SDL_IsMouseInRelativeMode()) {
                 SDL_SendMouseMotion(data->window, 0, 0, xevent->xcrossing.x, xevent->xcrossing.y);
             }
 
@@ -1237,7 +1237,7 @@ X11_DispatchEvent(_THIS, XEvent *xevent)
 
     case MotionNotify:{
             SDL_Mouse *mouse = SDL_GetMouse();
-            if(!mouse->relative_mode || mouse->relative_mode_warp) {
+            if(!SDL_IsMouseInRelativeMode() || mouse->relative_mode_warp) {
 #ifdef DEBUG_MOTION
                 printf("window %p: X11 motion: %d,%d\n", data, xevent->xmotion.x, xevent->xmotion.y);
 #endif

--- a/src/video/x11/SDL_x11xinput2.c
+++ b/src/video/x11/SDL_x11xinput2.c
@@ -181,7 +181,7 @@ X11_HandleXinput2Event(SDL_VideoData *videodata,XGenericEventCookie *cookie)
 
             videodata->global_mouse_changed = SDL_TRUE;
 
-            if (!mouse->relative_mode || mouse->relative_mode_warp) {
+            if (!SDL_IsMouseInRelativeMode() || mouse->relative_mode_warp) {
                 return 0;
             }
 
@@ -214,7 +214,7 @@ X11_HandleXinput2Event(SDL_VideoData *videodata,XGenericEventCookie *cookie)
 
             if (! pointer_emulated) {
                 SDL_Mouse *mouse = SDL_GetMouse();
-                if(!mouse->relative_mode || mouse->relative_mode_warp) {
+                if(!SDL_IsMouseInRelativeMode() || mouse->relative_mode_warp) {
                     SDL_Window *window = xinput2_get_sdlwindow(videodata, xev->event);
                     if (window) {
                         SDL_SendMouseMotion(window, 0, 0, xev->event_x, xev->event_y);


### PR DESCRIPTION
## Description
Automatically deactivates relative mouse when keyboard focus is lost.

No idea if this is a good idea at the keyboard event. But I guess it kinda is related to it in a relative mode
Or should it be added to every single backend manually on focus change?
I cannot really imagine when keyboard focus is lost else.

Anyway I tested it under windows and KDE

## Existing Issue(s)
fixes #4474
