### PR TITLE
fix blend mode for converted surface with alpha

### DIFF
--- a/src/video/SDL_surface.c
+++ b/src/video/SDL_surface.c
@@ -1298,7 +1298,7 @@ SDL_ConvertSurface(SDL_Surface * surface, const SDL_PixelFormat * format,
 
     /* Enable alpha blending by default if the new surface has an
      * alpha channel or alpha modulation */
-    if ((surface->format->Amask && format->Amask) ||
+    if ((convert->format->Amask && format->Amask) ||
         (palette_has_alpha && format->Amask) ||
         (copy_flags & SDL_COPY_MODULATE_ALPHA)) {
         SDL_SetSurfaceBlendMode(convert, SDL_BLENDMODE_BLEND);


### PR DESCRIPTION
When we convert from non-alpha surface to surface with alpha, blend mode wrongly doesn't set.