### PR TITLE
Update lenght after shortening string

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -1759,6 +1759,7 @@ SDL_CreateJoystickName(Uint16 vendor, Uint16 product, const char *vendor_name, c
             size_t replacementlen = SDL_strlen(replacements[i].replacement);
             SDL_memcpy(name, replacements[i].replacement, replacementlen);
             SDL_memmove(name+replacementlen, name+prefixlen, (len-prefixlen+1));
+            len -= prefixlen - replacementlen;
             break;
         }
     }
@@ -1768,11 +1769,11 @@ SDL_CreateJoystickName(Uint16 vendor, Uint16 product, const char *vendor_name, c
         int matchlen = PrefixMatch(name, &name[i]);
         if (matchlen > 0 && name[matchlen-1] == ' ') {
             SDL_memmove(name, name+matchlen, len-matchlen+1);
-            len -= matchlen;
+            /* len -= matchlen; */
             break;
         } else if (matchlen > 0 && name[matchlen] == ' ') {
             SDL_memmove(name, name+matchlen+1, len-matchlen);
-            len -= (matchlen + 1);
+            /* len -= (matchlen + 1); */
             break;
         }
     }


### PR DESCRIPTION
## Description
When performing manufacturer replacement in `SDL_CreateJoystickName`, string `name` is shortened but variable`len` is not updated.
When removing duplicate name, `len` is updated but never read. I commented out theses assignments instead of removing them, so that if someone add more string manipulation or reorder these operations, he will not forget to re-enable them.

## Existing Issue(s)
Related to #4600