### PR TITLE
Fix horizontal wheel scroll event direction

### DIFF
--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -1228,7 +1228,7 @@ X11_DispatchEvent(_THIS, XEvent *xevent)
             printf("window %p: ButtonPress (X11 button = %d)\n", data, xevent->xbutton.button);
 #endif
             if (X11_IsWheelEvent(display,xevent,&xticks, &yticks)) {
-                SDL_SendMouseWheel(data->window, 0, (float) xticks, (float) yticks, SDL_MOUSEWHEEL_NORMAL);
+                SDL_SendMouseWheel(data->window, 0, (float) -xticks, (float) yticks, SDL_MOUSEWHEEL_NORMAL);
             } else {
                 SDL_bool ignore_click = SDL_FALSE;
                 int button = xevent->xbutton.button;


### PR DESCRIPTION
Horizontal scroll direction is mixed up on X11.

Docs say "the amount scrolled horizontally, positive to the right and negative to the left". My tests show:
```
OS is configred so scrollbar moves to the direction of wheel.

Linux
Left         = +0 +1
Right        = +0 -1

Windows
Left         = +0 -1
Right        = +0 +1
```

For reference GLFW already does this: https://github.com/glfw/glfw/blob/22b586b3d87c91581074cc2a47fe5eba6f10bf0d/src/win32_window.c#L939

Given note in GLFW repository, i suspect MacOS events also need inverting. I am waiting for someone with hardware to test. When i get test data I will amend this PR if needed.