### PR TITLE
Restore previous behavior of empty SDL_AUDIODRIVER trying all drivers.

### DIFF
--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -972,7 +972,7 @@ SDL_AudioInit(const char *driver_name)
         driver_name = SDL_getenv("SDL_AUDIODRIVER");
     }
 
-    if (driver_name != NULL) {
+    if (driver_name != NULL && *driver_name != 0) {
         const char *driver_attempt = driver_name;
         while (driver_attempt != NULL && *driver_attempt != 0 && !initialized) {
             const char *driver_attempt_end = SDL_strchr(driver_attempt, ',');

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -489,7 +489,7 @@ SDL_VideoInit(const char *driver_name)
     if (driver_name == NULL) {
         driver_name = SDL_getenv("SDL_VIDEODRIVER");
     }
-    if (driver_name != NULL) {
+    if (driver_name != NULL && *driver_name != 0) {
         const char *driver_attempt = driver_name;
         while(driver_attempt != NULL && *driver_attempt != 0 && video == NULL) {
             const char* driver_attempt_end = SDL_strchr(driver_attempt, ',');


### PR DESCRIPTION
The recent change to make SDL_AUDIODRIVER support comma-separated lists
broke the previous behavior where an SDL_AUDIODRIVER that was empty
behaved the same as if it was not set at all. This old behavior was
necessary to paper over differences in platforms where SDL_setenv may
or may not actually delete the env var if an empty string is specified.
This patch just adds a simple check to ensure SDL_AUDIODRIVER is not
empty before using it, restoring the old interpretation of the empty
var. This also adds a similar fix for SDL_VIDEODRIVER.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
