### PR TITLE
test: Fix path used in AC_CONFIG_AUX_DIR

### DIFF
--- a/test/configure.ac
+++ b/test/configure.ac
@@ -3,7 +3,7 @@ AC_INIT
 AC_CONFIG_SRCDIR([loopwave.c])
 
 dnl Detect the canonical build and host environments
-AC_CONFIG_AUX_DIRS($srcdir/../build-scripts)
+AC_CONFIG_AUX_DIR([../build-scripts])
 AC_CANONICAL_HOST
 
 dnl Check for tools


### PR DESCRIPTION
AC_CONFIG_AUX_DIRS is an undocumented, internal version of
AC_CONFIG_AUX_DIR that takes a whitespace-separated list, instead of a
single path to add to the list. It also does not automatically treat
the given path as being relative to the $srcdir, unlike the documented
AC_CONFIG_AUX_DIR.

Newer versions of autoconf treat the argument to AC_CONFIG_AUX_DIRS
as being literal (they do not expand the shell variable), causing
autoreconf to fail if $srcdir is explicitly specified. The argument to
AC_CONFIG_AUX_DIR is checked  relative to $srcdir anyway, so there is no
need to specify $srcdir a second time.

Resolves: https://github.com/libsdl-org/SDL/issues/4719