### PR TITLE
test: Use a static pattern rule to copy data to $(builddir)

### DIFF
--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -336,26 +336,24 @@ distclean: clean
 	rm -f config.status config.cache config.log
 	rm -rf $(srcdir)/autom4te*
 
+DATA = \
+	axis.bmp \
+	button.bmp \
+	controllermap.bmp \
+	controllermap_back.bmp \
+	icon.bmp \
+	moose.dat \
+	sample.bmp \
+	sample.wav \
+	testgles2_sdf_img_normal.bmp \
+	testgles2_sdf_img_sdf.bmp \
+	testyuv.bmp \
+	$(NULL)
+
 ifneq ($(srcdir), .)
-%.bmp: $(srcdir)/%.bmp
-	cp $< $@
-
-%.wav: $(srcdir)/%.wav
-	cp $< $@
-
-%.dat: $(srcdir)/%.dat
+$(DATA) : %: $(srcdir)/% Makefile
 	cp $< $@
 endif
 
-copydatafiles: copybmpfiles copywavfiles copydatfiles
+copydatafiles: $(DATA)
 .PHONY : copydatafiles
-
-copybmpfiles: $(foreach bmp,$(wildcard $(srcdir)/*.bmp),$(notdir $(bmp)))
-.PHONY : copybmpfiles
-
-copywavfiles: $(foreach wav,$(wildcard $(srcdir)/*.wav),$(notdir $(wav)))
-.PHONY : copywavfiles
-
-copydatfiles: $(foreach dat,$(wildcard $(srcdir)/*.dat),$(notdir $(dat)))
-.PHONY : copydatfiles
-


### PR DESCRIPTION
## Description

The version with an implicit pattern rule tended to fail if test/
was built in an "out-of-tree" build directory not below test/, for
example:

    cd SDL
    mkdir _build-test
    ( cd _build-test; ../test/configure )
    make -C _build-test

as a result of the pattern rule first checking for axis.bmp, then for
../test/axis.bmp, then ../test/../test/axis.bmp, and so on until the
maximum path length was reached.

Note that this requires GNU make. The FreeBSD ports file for SDL seems
to use GNU make (gmake) already, so presumably SDL's build system is
already relying on GNU make extensions.

## Existing Issue(s)

https://github.com/libsdl-org/SDL/pull/4720#issuecomment-913576524