### PR TITLE
Add SDL_asprintf and SDL_vasprintf

### DIFF
--- a/include/SDL_stdinc.h
+++ b/include/SDL_stdinc.h
@@ -566,6 +566,8 @@ extern DECLSPEC int SDLCALL SDL_sscanf(const char *text, SDL_SCANF_FORMAT_STRING
 extern DECLSPEC int SDLCALL SDL_vsscanf(const char *text, const char *fmt, va_list ap);
 extern DECLSPEC int SDLCALL SDL_snprintf(SDL_OUT_Z_CAP(maxlen) char *text, size_t maxlen, SDL_PRINTF_FORMAT_STRING const char *fmt, ... ) SDL_PRINTF_VARARG_FUNC(3);
 extern DECLSPEC int SDLCALL SDL_vsnprintf(SDL_OUT_Z_CAP(maxlen) char *text, size_t maxlen, const char *fmt, va_list ap);
+extern DECLSPEC int SDLCALL SDL_asprintf(char **strp, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(2);
+extern DECLSPEC int SDLCALL SDL_vasprintf(char **strp, const char *fmt, va_list ap);
 
 #ifndef HAVE_M_PI
 #ifndef M_PI

--- a/src/core/freebsd/SDL_evdev_kbd_freebsd.c
+++ b/src/core/freebsd/SDL_evdev_kbd_freebsd.c
@@ -273,7 +273,7 @@ SDL_EVDEV_kbd_init(void)
              * Ensures that the keystrokes do not leak through to the console.
              */
             ioctl(kbd->console_fd, CONS_RELKBD, 1ul);
-            asprintf(&devicePath, "/dev/kbd%d", kbd->kbInfo->kb_index);         
+            SDL_asprintf(&devicePath, "/dev/kbd%d", kbd->kbInfo->kb_index);
             kbd->keyboard_fd = open(devicePath, O_WRONLY | O_CLOEXEC);
             if (kbd->keyboard_fd == -1)
             {
@@ -288,7 +288,7 @@ SDL_EVDEV_kbd_init(void)
             if (!SDL_GetHintBoolean(SDL_HINT_NO_SIGNAL_HANDLERS, SDL_FALSE)) {
                 kbd_register_emerg_cleanup(kbd);
             }
-            free(devicePath);
+            SDL_free(devicePath);
         }
         else kbd->keyboard_fd = kbd->console_fd;
     }

--- a/src/dynapi/SDL_dynapi.c
+++ b/src/dynapi/SDL_dynapi.c
@@ -89,6 +89,12 @@ static void SDL_InitDynamicAPI(void);
         va_end(ap); \
         return retval; \
     } \
+    _static int SDLCALL SDL_asprintf##name(char **strp, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) { \
+        int retval; va_list ap; initcall; va_start(ap, fmt); \
+        retval = jump_table.SDL_vasprintf(strp, fmt, ap); \
+        va_end(ap); \
+        return retval; \
+    } \
     _static void SDLCALL SDL_Log##name(SDL_PRINTF_FORMAT_STRING const char *fmt, ...) { \
         va_list ap; initcall; va_start(ap, fmt); \
         jump_table.SDL_LogMessageV(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO, fmt, ap); \

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -820,3 +820,5 @@
 #define SDL_RenderGeometry SDL_RenderGeometry_REAL
 #define SDL_RenderGeometryRaw SDL_RenderGeometryRaw_REAL
 #define SDL_RenderSetVSync SDL_RenderSetVSync_REAL
+#define SDL_asprintf SDL_asprintf_REAL
+#define SDL_vasprintf SDL_vasprintf_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -885,3 +885,7 @@ SDL_DYNAPI_PROC(void*,SDL_GetTextureUserData,(SDL_Texture *a),(a),return)
 SDL_DYNAPI_PROC(int,SDL_RenderGeometry,(SDL_Renderer *a, SDL_Texture *b, const SDL_Vertex *c, int d, const int *e, int f),(a,b,c,d,e,f),return)
 SDL_DYNAPI_PROC(int,SDL_RenderGeometryRaw,(SDL_Renderer *a, SDL_Texture *b, const float *c, int d, const int *e, int f, const float *g, int h, int i, const void *j, int k, int l),(a,b,c,d,e,f,g,h,i,j,k,l),return)
 SDL_DYNAPI_PROC(int,SDL_RenderSetVSync,(SDL_Renderer *a, int b),(a,b),return)
+#if !SDL_DYNAPI_PROC_NO_VARARGS
+SDL_DYNAPI_PROC(int,SDL_asprintf,(char **a, SDL_PRINTF_FORMAT_STRING const char *b, ...),(a,b),return)
+#endif
+SDL_DYNAPI_PROC(int,SDL_vasprintf,(char **a, const char *b, va_list c),(a,b,c),return)

--- a/src/joystick/bsd/SDL_bsdjoystick.c
+++ b/src/joystick/bsd/SDL_bsdjoystick.c
@@ -426,7 +426,7 @@ BSD_JoystickOpen(SDL_Joystick *joy, int device_index)
             str[i] = UGETW(usd.usd_desc.bString[i]);
         }
         str[i] = '\0';
-        asprintf(&new_name, "%s @ %s", str, path);
+        SDL_asprintf(&new_name, "%s @ %s", str, path);
         if (new_name != NULL) {
             SDL_free(joydevnames[numjoysticks]);
             joydevnames[numjoysticks] = new_name;


### PR DESCRIPTION
The implementation is based on the `make_message` function from [here](https://linux.die.net/man/3/sprintf), which should work with `snprintf` implementations that aren't fully C99 compliant.