### PR TITLE
`SDL_RenderSetVSync()`: Restrict `vsync` to 0 or 1

### DIFF
--- a/include/SDL_render.h
+++ b/include/SDL_render.h
@@ -1698,7 +1698,7 @@ extern DECLSPEC void *SDLCALL SDL_RenderGetMetalCommandEncoder(SDL_Renderer * re
  * Toggle VSync of the given renderer.
  *
  * \param renderer The renderer to toggle
- * \param vsync Non-zero for on, zero for off
+ * \param vsync 1 for on, 0 for off. All other values are reserved
  * \returns a 0 int on success, or non-zero on failure
  */
 extern DECLSPEC int SDLCALL SDL_RenderSetVSync(SDL_Renderer* renderer, int vsync);

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -4129,6 +4129,10 @@ SDL_RenderSetVSync(SDL_Renderer * renderer, int vsync)
 {
     CHECK_RENDERER_MAGIC(renderer, -1);
 
+    if (vsync != 0 && vsync != 1) {
+        return SDL_Unsupported();
+    }
+
     if (renderer->SetVSync) {
         return renderer->SetVSync(renderer, vsync);
     }


### PR DESCRIPTION
Followup to #4157.

In the future, we might want to support special swap intervals. To prevent applications from expecting nonzero values of `vsync` to be the same as "on", fail with `SDL_Unsupported()` if the value passed is neither 0 nor 1.