### PR TITLE
Fixed: Whitespace being striped from the end of IME strings incorrectly + Regression with SDL_SetTextInputRect

### DIFF
--- a/VisualC/SDL/SDL.vcxproj
+++ b/VisualC/SDL/SDL.vcxproj
@@ -212,10 +212,6 @@
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
-    <PostBuildEvent>
-      <Command>
-      </Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\begin_code.h" />

--- a/VisualC/SDL/SDL.vcxproj
+++ b/VisualC/SDL/SDL.vcxproj
@@ -212,6 +212,9 @@
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
+    <PostBuildEvent>
+      <Command>copy /B /Y $(SolutionDir)$(Platform)\$(Configuration)\SDL2.dll "X:\YoYoStudio\IDE\YoYoStudio\bin\x64\Debug\SDL2.dll"</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\begin_code.h" />

--- a/VisualC/SDL/SDL.vcxproj
+++ b/VisualC/SDL/SDL.vcxproj
@@ -213,7 +213,8 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
     <PostBuildEvent>
-      <Command>copy /B /Y $(SolutionDir)$(Platform)\$(Configuration)\SDL2.dll "X:\YoYoStudio\IDE\YoYoStudio\bin\x64\Debug\SDL2.dll"</Command>
+      <Command>
+      </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -247,12 +247,13 @@ WIN_SetTextInputRect(_THIS, SDL_Rect *rect)
     if (himc)
     {
         COMPOSITIONFORM cof;
+        CANDIDATEFORM caf;
+
         cof.dwStyle = CFS_FORCE_POSITION;
         cof.ptCurrentPos.x = videodata->ime_rect.x;
         cof.ptCurrentPos.y = videodata->ime_rect.y;
         ImmSetCompositionWindow(himc, &cof);
 
-        CANDIDATEFORM caf;
         caf.dwIndex = 0;
         caf.dwStyle = CFS_CANDIDATEPOS;
         caf.ptCurrentPos.x = videodata->ime_rect.x;

--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -173,7 +173,6 @@ WIN_ResetDeadKeys()
 
     GetKeyboardState(keyboardState);
 
-
     keycode = VK_SPACE;
     scancode = MapVirtualKey(keycode, MAPVK_VK_TO_VSC);
     if (scancode == 0) {

--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -173,6 +173,7 @@ WIN_ResetDeadKeys()
 
     GetKeyboardState(keyboardState);
 
+
     keycode = VK_SPACE;
     scancode = MapVirtualKey(keycode, MAPVK_VK_TO_VSC);
     if (scancode == 0) {
@@ -246,13 +247,19 @@ WIN_SetTextInputRect(_THIS, SDL_Rect *rect)
     himc = ImmGetContext(videodata->ime_hwnd_current);
     if (himc)
     {
-        CANDIDATEFORM cf;
-        cf.dwIndex = 0;
-        cf.dwStyle = CFS_POINT;
-        cf.ptCurrentPos.x = videodata->ime_rect.x;
-        cf.ptCurrentPos.y = videodata->ime_rect.y;
-        
-        ImmSetCandidateWindow(himc, &cf);
+        COMPOSITIONFORM cof;
+        cof.dwStyle = CFS_FORCE_POSITION;
+        cof.ptCurrentPos.x = videodata->ime_rect.x;
+        cof.ptCurrentPos.y = videodata->ime_rect.y;
+        ImmSetCompositionWindow(himc, &cof);
+
+        CANDIDATEFORM caf;
+        caf.dwIndex = 0;
+        caf.dwStyle = CFS_POINT;
+        caf.ptCurrentPos.x = videodata->ime_rect.x;
+        caf.ptCurrentPos.y = videodata->ime_rect.y;
+        ImmSetCandidateWindow(himc, &caf);
+
         ImmReleaseContext(videodata->ime_hwnd_current, himc);
     }
 }
@@ -748,13 +755,16 @@ IME_GetCompositionString(SDL_VideoData *videodata, HIMC himc, DWORD string)
 
     length /= sizeof(videodata->ime_composition[0]);
     videodata->ime_cursor = LOWORD(ImmGetCompositionStringW(himc, GCS_CURSORPOS, 0, 0));
-    if (videodata->ime_cursor < SDL_arraysize(videodata->ime_composition) && videodata->ime_composition[videodata->ime_cursor] == 0x3000) {
+    if (videodata->ime_cursor > 0 &&
+        videodata->ime_cursor < SDL_arraysize(videodata->ime_composition) &&
+        videodata->ime_composition[videodata->ime_cursor] == 0x3000) {
         int i;
         for (i = videodata->ime_cursor + 1; i < length; ++i)
             videodata->ime_composition[i - 1] = videodata->ime_composition[i];
 
         --length;
     }
+
     videodata->ime_composition[length] = 0;
 }
 

--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -255,7 +255,7 @@ WIN_SetTextInputRect(_THIS, SDL_Rect *rect)
 
         CANDIDATEFORM caf;
         caf.dwIndex = 0;
-        caf.dwStyle = CFS_POINT;
+        caf.dwStyle = CFS_CANDIDATEPOS;
         caf.ptCurrentPos.x = videodata->ime_rect.x;
         caf.ptCurrentPos.y = videodata->ime_rect.y;
         ImmSetCandidateWindow(himc, &caf);


### PR DESCRIPTION
Fixes an issue where IME Text that has trailing whitespace U+12288 is incorrectly striped when the candidate that was issued was explicitly a U+12288 character. The intention appears to be that U+12288 gets striped as trailing whitespace to a string, not prevent U+12288 from being issued as the IME_TEXT as a whole.
Additionally, a minor fix for a previous fix (PR #4707) to the candidate window not positioning correctly (SDL_SetTextInputRect).

## Description
Retains previous trailing whitespace strip code with the addition that the string length must be larger than 1 character long.
ImmSetCompositionWindow called along side ImmSetCandidateWindow to address a regression with #4707.

## Existing Issue(s)
None
