### PR TITLE
atomic: detect clang separately

### DIFF
--- a/src/atomic/SDL_atomic.c
+++ b/src/atomic/SDL_atomic.c
@@ -36,20 +36,18 @@
 #endif
 
 /* The __atomic_load_n() intrinsic showed up in different times for different compilers. */
-#if defined(HAVE_GCC_ATOMICS)
-# if defined(__clang__)
-#   if __has_builtin(__atomic_load_n)
-      /* !!! FIXME: this advertises as available in the NDK but uses an external symbol we don't have.
-         It might be in a later NDK or we might need an extra library? --ryan. */
-#     if !defined(__ANDROID__)
-#       define HAVE_ATOMIC_LOAD_N 1
-#     endif
-#   endif
-# elif defined(__GNUC__)
+#if defined(__clang__)
+#  if __has_builtin(__atomic_load_n) || defined(HAVE_GCC_ATOMICS)
+     /* !!! FIXME: this advertises as available in the NDK but uses an external symbol we don't have.
+        It might be in a later NDK or we might need an extra library? --ryan. */
+#    if !defined(__ANDROID__)
+#      define HAVE_ATOMIC_LOAD_N 1
+#    endif
+#  endif
+#elif defined(__GNUC__)
 #   if (__GNUC__ >= 5)
 #     define HAVE_ATOMIC_LOAD_N 1
 #   endif
-# endif
 #endif
 
 #if defined(__WATCOMC__) && defined(__386__)


### PR DESCRIPTION
## Description
Original code was assuming that Clang is linked to `libatomic` from GCC, which's not always the case – Clang can use atomic implementation from its own `compiler-rt` library [1].

For example, such explicit usage of "native" atomic implementation for Clang is present on Gentoo [2] – in this case, it's possible to create completely GCC-free toolchain. Proposed change should allow such systems to fully utilize atomics from compiler-rt.

Also I think it can fix Android bug mentioned in the comment, since according to [3] and [4], they've slated GCC for removal in v18; while support for required `#ifdef` is _kinda_ there [5], I guess it'll be safe to remove `if !defined(__ANDROID__)` altogether.


[1] https://clang.llvm.org/docs/Toolchain.html#atomics-library
[2] https://github.com/gentoo/gentoo/blob/master/sys-libs/libcxx/libcxx-12.0.1.ebuild#L134
[3] https://developer.android.com/ndk/downloads/revision_history
[4] https://en.wikipedia.org/wiki/Android_NDK
[5] https://github.com/android/ndk/issues/1029