### PR TITLE
fix: allow builtins for all archs

### DIFF
--- a/include/SDL_endian.h
+++ b/include/SDL_endian.h
@@ -106,7 +106,7 @@ extern "C" {
 
 #if HAS_BUILTIN_BSWAP16
 #define SDL_Swap16(x) __builtin_bswap16(x)
-#elif defined(__i386__) && !HAS_BROKEN_BSWAP \
+#elif defined(__i386__) && !HAS_BROKEN_BSWAP
 SDL_FORCE_INLINE Uint16
 SDL_Swap16(Uint16 x)
 {

--- a/include/SDL_endian.h
+++ b/include/SDL_endian.h
@@ -91,25 +91,36 @@ extern "C" {
 /**
  *  \file SDL_endian.h
  */
-#if (_SDL_HAS_BUILTIN(__builtin_bswap16)) || \
+
+/* various modern compilers may have builtin swap */
+#define HAS_BUILTIN_BSWAP16 (_SDL_HAS_BUILTIN(__builtin_bswap16)) || \
     (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)))
+#define HAS_BUILTIN_BSWAP32 (_SDL_HAS_BUILTIN(__builtin_bswap32)) || \
+    (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)))
+#define HAS_BUILTIN_BSWAP64 (_SDL_HAS_BUILTIN(__builtin_bswap64)) || \
+    (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)))
+
+/* this one is broken */
+#define HAS_BROKEN_BSWAP (defined(__GNUC__) && \
+    (__GNUC__ == 2 && __GNUC_MINOR__ <= 95))
+
+#if HAS_BUILTIN_BSWAP16
 #define SDL_Swap16(x) __builtin_bswap16(x)
-#elif defined(__GNUC__) && defined(__i386__) && \
-   !(__GNUC__ == 2 && __GNUC_MINOR__ <= 95 /* broken gcc version */)
+#elif defined(__i386__) && !HAS_BROKEN_BSWAP \
 SDL_FORCE_INLINE Uint16
 SDL_Swap16(Uint16 x)
 {
   __asm__("xchgb %b0,%h0": "=q"(x):"0"(x));
     return x;
 }
-#elif defined(__GNUC__) && defined(__x86_64__)
+#elif defined(__x86_64__)
 SDL_FORCE_INLINE Uint16
 SDL_Swap16(Uint16 x)
 {
   __asm__("xchgb %b0,%h0": "=Q"(x):"0"(x));
     return x;
 }
-#elif defined(__GNUC__) && (defined(__powerpc__) || defined(__ppc__))
+#elif (defined(__powerpc__) || defined(__ppc__))
 SDL_FORCE_INLINE Uint16
 SDL_Swap16(Uint16 x)
 {
@@ -118,14 +129,14 @@ SDL_Swap16(Uint16 x)
   __asm__("rlwimi %0,%2,8,16,23": "=&r"(result):"0"(x >> 8), "r"(x));
     return (Uint16)result;
 }
-#elif defined(__GNUC__) && defined(__aarch64__)
+#elif defined(__aarch64__)
 SDL_FORCE_INLINE Uint16
 SDL_Swap16(Uint16 x)
 {
   __asm__("rev16 %w1, %w0" : "=r"(x) : "r"(x));
   return x;
 }
-#elif defined(__GNUC__) && (defined(__m68k__) && !defined(__mcoldfire__))
+#elif (defined(__m68k__) && !defined(__mcoldfire__))
 SDL_FORCE_INLINE Uint16
 SDL_Swap16(Uint16 x)
 {
@@ -149,25 +160,23 @@ SDL_Swap16(Uint16 x)
 }
 #endif
 
-#if (_SDL_HAS_BUILTIN(__builtin_bswap32)) || \
-    (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)))
+#if HAS_BUILTIN_BSWAP32
 #define SDL_Swap32(x) __builtin_bswap32(x)
-#elif defined(__GNUC__) && defined(__i386__) && \
-   !(__GNUC__ == 2 && __GNUC_MINOR__ <= 95 /* broken gcc version */)
+#elif defined(__i386__) && !HAS_BROKEN_BSWAP
 SDL_FORCE_INLINE Uint32
 SDL_Swap32(Uint32 x)
 {
   __asm__("bswap %0": "=r"(x):"0"(x));
     return x;
 }
-#elif defined(__GNUC__) && defined(__x86_64__)
+#elif defined(__x86_64__)
 SDL_FORCE_INLINE Uint32
 SDL_Swap32(Uint32 x)
 {
   __asm__("bswapl %0": "=r"(x):"0"(x));
     return x;
 }
-#elif defined(__GNUC__) && (defined(__powerpc__) || defined(__ppc__))
+#elif (defined(__powerpc__) || defined(__ppc__))
 SDL_FORCE_INLINE Uint32
 SDL_Swap32(Uint32 x)
 {
@@ -178,14 +187,14 @@ SDL_Swap32(Uint32 x)
   __asm__("rlwimi %0,%2,24,0,7"  : "=&r"(result): "0" (result), "r"(x));
     return result;
 }
-#elif defined(__GNUC__) && defined(__aarch64__)
+#elif defined(__aarch64__)
 SDL_FORCE_INLINE Uint32
 SDL_Swap32(Uint32 x)
 {
   __asm__("rev %w1, %w0": "=r"(x):"r"(x));
   return x;
 }
-#elif defined(__GNUC__) && (defined(__m68k__) && !defined(__mcoldfire__))
+#elif (defined(__m68k__) && !defined(__mcoldfire__))
 SDL_FORCE_INLINE Uint32
 SDL_Swap32(Uint32 x)
 {
@@ -210,11 +219,9 @@ SDL_Swap32(Uint32 x)
 }
 #endif
 
-#if (_SDL_HAS_BUILTIN(__builtin_bswap64)) || \
-    (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)))
+#if HAS_BUILTIN_BSWAP64
 #define SDL_Swap64(x) __builtin_bswap64(x)
-#elif defined(__GNUC__) && defined(__i386__) && \
-   !(__GNUC__ == 2 && __GNUC_MINOR__ <= 95 /* broken gcc version */)
+#elif defined(__i386__) && !HAS_BROKEN_BSWAP
 SDL_FORCE_INLINE Uint64
 SDL_Swap64(Uint64 x)
 {
@@ -230,7 +237,7 @@ SDL_Swap64(Uint64 x)
           : "0" (v.s.a),  "1"(v.s.b));
     return v.u;
 }
-#elif defined(__GNUC__) && defined(__x86_64__)
+#elif defined(__x86_64__)
 SDL_FORCE_INLINE Uint64
 SDL_Swap64(Uint64 x)
 {
@@ -278,6 +285,11 @@ SDL_SwapFloat(float x)
     return swapper.f;
 }
 
+/* remove extra macros */
+#undef HAS_BROKEN_BSWAP
+#undef HAS_BUILTIN_BSWAP16
+#undef HAS_BUILTIN_BSWAP32
+#undef HAS_BUILTIN_BSWAP64
 
 /**
  *  \name Swap to native


### PR DESCRIPTION
## Description
- Existing code for relying on compiler-provided builtins was used only for x86/amd64 arch;
- `__GNUC__` macro effectively removed anything beyond GCC/MSVC/Watcom (at least Clang)