### PR TITLE
render: Batch similar draw calls

### DIFF
--- a/src/render/opengles2/SDL_render_gles2.c
+++ b/src/render/opengles2/SDL_render_gles2.c
@@ -790,7 +790,7 @@ GLES2_QueueCopy(SDL_Renderer * renderer, SDL_RenderCommand *cmd, SDL_Texture * t
     int color;
     GLfloat minx, miny, maxx, maxy;
     GLfloat minu, maxu, minv, maxv;
-    const size_t vertlen = 4 * (2 * sizeof (float) + sizeof (int) + 2 * sizeof (float));
+    const size_t vertlen = 6 * (2 * sizeof (float) + sizeof (int) + 2 * sizeof (float));
     GLfloat *verts = (GLfloat *) SDL_AllocateRenderVertices(renderer, vertlen, 0, &cmd->data.draw.first);
 
     if (!verts) {
@@ -815,11 +815,28 @@ GLES2_QueueCopy(SDL_Renderer * renderer, SDL_RenderCommand *cmd, SDL_Texture * t
     minv = (GLfloat) srcrect->y / texture->h;
     maxv = (GLfloat) (srcrect->y + srcrect->h) / texture->h;
 
+    /* set these up as GL_TRIANGLES instead of GL_TRIANGLE_STRIP; it's more
+       vertices, but we can then draw unconnected pieces in a single draw
+       call if there are several draws in a row using the same texture
+       (such as a particle system or texture atlas). */
     *(verts++) = minx;
     *(verts++) = miny;
     *((int *)verts++) = color;
     *(verts++) = minu;
     *(verts++) = minv;
+
+    *(verts++) = maxx;
+    *(verts++) = miny;
+    *((int *)verts++) = color;
+    *(verts++) = maxu;
+    *(verts++) = minv;
+
+    *(verts++) = minx;
+    *(verts++) = maxy;
+    *((int *)verts++) = color;
+    *(verts++) = minu;
+    *(verts++) = maxv;
+
 
     *(verts++) = maxx;
     *(verts++) = miny;
@@ -857,7 +874,7 @@ GLES2_QueueCopyEx(SDL_Renderer * renderer, SDL_RenderCommand *cmd, SDL_Texture *
     const GLfloat centery = center->y + dstrect->y;
     GLfloat minx, miny, maxx, maxy;
     GLfloat minu, maxu, minv, maxv;
-    const size_t vertlen = 4 * (2 * sizeof (float) + sizeof (int) + (2 + 2 + 2) * sizeof (float));
+    const size_t vertlen = 6 * (2 * sizeof (float) + sizeof (int) + (2 + 2 + 2) * sizeof (float));
     GLfloat *verts = (GLfloat *) SDL_AllocateRenderVertices(renderer, vertlen, 0, &cmd->data.draw.first);
 
     if (!verts) {
@@ -891,14 +908,38 @@ GLES2_QueueCopyEx(SDL_Renderer * renderer, SDL_RenderCommand *cmd, SDL_Texture *
     minv = ((GLfloat) srcquad->y) / ((GLfloat) texture->h);
     maxv = ((GLfloat) (srcquad->y + srcquad->h)) / ((GLfloat) texture->h);
 
-
     cmd->data.draw.count = 1;
+
+    /* set these up as GL_TRIANGLES instead of GL_TRIANGLE_STRIP; it's more
+       vertices, but we can then draw unconnected pieces in a single draw
+       call if there are several draws in a row using the same texture
+       (such as a particle system or texture atlas). */
 
     *(verts++) = minx;
     *(verts++) = miny;
     *((int *)verts++) = color;
     *(verts++) = minu;
     *(verts++) = minv;
+    *(verts++) = s;
+    *(verts++) = c;
+    *(verts++) = centerx;
+    *(verts++) = centery;
+
+    *(verts++) = maxx;
+    *(verts++) = miny;
+    *((int *)verts++) = color;
+    *(verts++) = maxu;
+    *(verts++) = minv;
+    *(verts++) = s;
+    *(verts++) = c;
+    *(verts++) = centerx;
+    *(verts++) = centery;
+
+    *(verts++) = minx;
+    *(verts++) = maxy;
+    *((int *)verts++) = color;
+    *(verts++) = minu;
+    *(verts++) = maxv;
     *(verts++) = s;
     *(verts++) = c;
     *(verts++) = centerx;
@@ -1377,9 +1418,34 @@ GLES2_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *ver
 
             case SDL_RENDERCMD_COPY:
             case SDL_RENDERCMD_COPY_EX: {
-                if (SetCopyState(renderer, cmd) == 0) {
-                    data->glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+                /* as long as we have the same copy command in a row, with the
+                   same texture, we can combine them all into a single draw call. */
+                SDL_Texture *thistexture = cmd->data.draw.texture;
+                const SDL_RenderCommandType thiscmdtype = cmd->command;
+                SDL_RenderCommand *finalcmd = cmd;
+                SDL_RenderCommand *nextcmd = cmd->next;
+                int quads = 1;
+                while (nextcmd != NULL) {
+                    const SDL_RenderCommandType nextcmdtype = nextcmd->command;
+                    if (nextcmdtype != thiscmdtype) {
+                        /* SETDRAWCOLOR commands are safe because copy color is set in the vbo per-vertex. */
+                        if ((nextcmdtype != SDL_RENDERCMD_SETDRAWCOLOR) && (nextcmdtype != SDL_RENDERCMD_NO_OP)) {
+                            break;  /* can't go any further on this draw call, different render command up next. */
+                        }
+                    } else if (nextcmd->data.draw.texture != thistexture) {
+                        break;  /* can't go any further on this draw call, different texture copy up next. */
+                    } else {
+                        finalcmd = nextcmd;  /* we can combine copy operations here. Mark this one as the furthest okay command. */
+                        quads++;
+                    }
+                    nextcmd = nextcmd->next;
                 }
+
+                if (SetCopyState(renderer, cmd) == 0) {
+                    data->glDrawArrays(GL_TRIANGLES, 0, quads * 6);
+                }
+
+                cmd = finalcmd;  /* skip any copy commands we just combined in here. */
                 break;
             }
 


### PR DESCRIPTION
This is a work-in-progress, do not merge.

So a place we are leaving a lot of performance on the table in the renderer backends is in draw calls. We got a lot of performance by batching up render operations into a list of commands and only changing render states when necessary, but eventually each SDL_RenderCopy() makes a seperate call to glDrawArrays to draw a single quad.

If we have multiple draw calls in a row that use the same texture, though, we can do a single glDrawArrays call that hands them all off to the GPU in a single blast.

This is a common scenario for particle systems, that might draw hundreds or thousands of copies of the same texture in a row. It's also super-common for games that use texture atlases. This is an obvious win when drawing text, as each glyph is generally packed into one texture and drawn in sequence, but it's also not impossible that a fairly complex scene could all live on one texture atlas and thus become a single draw call per frame.

Or heck, even just Super Mario Bros drawing all its sprites might happen to do a few brick textures in a row and get a little performance win.

As a pathological case, testsprite2 just renders the same sprite over and over every frame, so I started there to see if this is viable.

This patch takes the GLES2 renderer and, when processing a COPY or COPY_EX command, tries to combine as many as possible into a single draw call. Since the sprites can render anywhere, this moved from using GL_TRIANGLE_STRIP to GL_TRIANGLES, which increases VBO size but adds the ability to render disconnected quads. We already store per-vertex color in the VBO, so we can combine draws across an SDL_SetRenderDrawColor() call too.

On my laptop with GLES2 (GL_RENDERER is "Mesa DRI Intel(R) UHD Graphics (Comet Lake 3x8 GT2)"), running testsprite2 with 50,000 sprites (`SDL_RENDER_DRIVER=opengles2 SDL_RENDER_BATCHING=1 ./testsprite2 --info render 50000`) limps along at 16 or 17 fps.

With this change, it's around 65 to 75 fps. A _huge_ improvement, especially for the size of the patch.

The TODO list of this looks like:
- We need to implement this for other backends.
- We need to implement this for the RenderGeometry codepath.
- We probably need to do this for the non-textured draw calls too (fillrect, etc).
- We probably should move the "figure out how many render commands I can cover with one draw call" code (the bulk of this patch) to a common function.
- We might need to put a glDrawArrays path in the OpenGL renderer, as this is what most Desktop Linux users would land on and it's still using immediate mode draw calls! Without that, it can't benefit from this effort.

I've got other pressing render API bugs to fix, and I confess this was an irresistible distraction from that work, so I'll be coming back to this later, but soon.