### PR TITLE
Fallback to LPDDR in case of failed CDRAM texture allocation on Vita

### DIFF
--- a/src/render/vitagxm/SDL_render_vita_gxm_tools.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm_tools.c
@@ -1056,6 +1056,7 @@ create_gxm_texture(VITA_GXM_RenderData *data, unsigned int w, unsigned int h, Sc
         const uint32_t alignedHeight = ALIGN(h, SCE_GXM_TILE_SIZEY);
         uint32_t sampleCount = alignedWidth*alignedHeight;
         uint32_t depthStrideInSamples = alignedWidth;
+        const uint32_t alignedColorSurfaceStride = ALIGN(w, 8);
 
         int err = sceGxmColorSurfaceInit(
             &texture->gxm_colorsurface,
@@ -1065,7 +1066,7 @@ create_gxm_texture(VITA_GXM_RenderData *data, unsigned int w, unsigned int h, Sc
             SCE_GXM_OUTPUT_REGISTER_SIZE_32BIT,
             w,
             h,
-            w,
+            alignedColorSurfaceStride,
             texture_data
         );
 

--- a/src/render/vitagxm/SDL_render_vita_gxm_tools.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm_tools.c
@@ -1027,6 +1027,18 @@ create_gxm_texture(VITA_GXM_RenderData *data, unsigned int w, unsigned int h, Sc
         &texture->data_UID
     );
 
+    /* Try SCE_KERNEL_MEMBLOCK_TYPE_USER_RW_UNCACHE in case we're out of VRAM */
+    if (!texture_data) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_RENDER, "CDRAM texture allocation failed\n");
+        texture_data = mem_gpu_alloc(
+            SCE_KERNEL_MEMBLOCK_TYPE_USER_RW_UNCACHE,
+            tex_size,
+            SCE_GXM_TEXTURE_ALIGNMENT,
+            SCE_GXM_MEMORY_ATTRIB_READ | SCE_GXM_MEMORY_ATTRIB_WRITE,
+            &texture->data_UID
+        );
+    }
+
     if (!texture_data) {
         free(texture);
         return NULL;


### PR DESCRIPTION
@isage Fallback to LPDDR in case of failed CDRAM texture allocation on Vita

## Description
Texture allocations will fail if we're out of VRAM on PS Vita. This PR tries allocating the texture with `SCE_KERNEL_MEMBLOCK_TYPE_USER_RW_UNCACHE` `SceKernelMemBlockType` in case of failed `SCE_KERNEL_MEMBLOCK_TYPE_USER_CDRAM_RW` allocation.

Additionally it's using aligned stride in `sceGxmColorSurfaceInit`. `sceGxmColorSurfaceInit` will result in a crash if stride is not aligned by 2. It will also result in visual bugs during rendering to render target if it's not aligned by 8.