### PR TITLE
Finish current scene when destroying the texture on Vita

### DIFF
--- a/src/render/vitagxm/SDL_render_vita_gxm.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm.c
@@ -1241,7 +1241,16 @@ VITA_GXM_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture)
     if(vita_texture->tex == 0)
         return;
 
-    sceGxmFinish(data->gxm_context);
+    // make sure that texture isn't used
+    if (data->drawing) {
+        sceGxmEndScene(data->gxm_context, NULL, NULL);
+        data->drawing = SDL_FALSE;
+        sceGxmFinish(data->gxm_context);
+        StartDrawing(renderer);
+    }
+    else {
+        sceGxmFinish(data->gxm_context);
+    }
 
     free_gxm_texture(vita_texture->tex);
 


### PR DESCRIPTION
@isage Finish current scene when destroying the texture on Vita

## Description
Make sure that we've ended the current scene before running `sceGxmFinish` and destroying the texture. Might fix some crashes with destroyed SDL_Texture before GXM rendering is finished.
Some kind of delayed garbage collection might be a faster solution, but I guess this should work for now.