### PR TITLE
End Scene on RunCommandQueue on Vita

### DIFF
--- a/src/render/vitagxm/SDL_render_vita_gxm.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm.c
@@ -1084,6 +1084,9 @@ VITA_GXM_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *
         cmd = cmd->next;
     }
 
+    sceGxmEndScene(data->gxm_context, NULL, NULL);
+    data->drawing = SDL_FALSE;
+
     return 0;
 }
 
@@ -1179,11 +1182,8 @@ VITA_GXM_RenderPresent(SDL_Renderer *renderer)
     VITA_GXM_RenderData *data = (VITA_GXM_RenderData *) renderer->driverdata;
     SceCommonDialogUpdateParam updateParam;
 
-    if (data->drawing) {
-        sceGxmEndScene(data->gxm_context, NULL, NULL);
-        if (data->displayData.wait_vblank) {
-            sceGxmFinish(data->gxm_context);
-        }
+    if (data->displayData.wait_vblank) {
+        sceGxmFinish(data->gxm_context);
     }
 
     data->displayData.address = data->displayBufferData[data->backBufferIndex];
@@ -1222,8 +1222,6 @@ VITA_GXM_RenderPresent(SDL_Renderer *renderer)
     data->pool_index = 0;
 
     data->current_pool = (data->current_pool + 1) % 2;
-
-    data->drawing = SDL_FALSE;
 }
 
 static void
@@ -1241,16 +1239,7 @@ VITA_GXM_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture)
     if(vita_texture->tex == 0)
         return;
 
-    // make sure that texture isn't used
-    if (data->drawing) {
-        sceGxmEndScene(data->gxm_context, NULL, NULL);
-        data->drawing = SDL_FALSE;
-        sceGxmFinish(data->gxm_context);
-        StartDrawing(renderer);
-    }
-    else {
-        sceGxmFinish(data->gxm_context);
-    }
+    sceGxmFinish(data->gxm_context);
 
     free_gxm_texture(vita_texture->tex);
 


### PR DESCRIPTION
Run `sceGxmEndScene` on `VITA_GXM_RunCommandQueue` on PS Vita

## Description
End the scene at the end of the RunCommandQueue. Eliminates the need of checking if the scene is active on texture destruction, rendertarget switching and probably some other places too.