### PR TITLE
wayland: Reuse KeySymToUcs4 to replicate X11 keymap behavior

### DIFF
--- a/src/events/imKStoUCS.c
+++ b/src/events/imKStoUCS.c
@@ -24,10 +24,9 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 */
 
-#include "../../SDL_internal.h"
+#include "../SDL_internal.h"
 
-#if SDL_VIDEO_DRIVER_X11
-#include <X11/X.h>
+#if SDL_VIDEO_DRIVER_X11 || SDL_VIDEO_DRIVER_WAYLAND
 #include "imKStoUCS.h"
 
 static unsigned short const keysym_to_unicode_1a1_1ff[] = {
@@ -294,7 +293,7 @@ static unsigned short const keysym_to_unicode_20a0_20ac[] = {
 };
 
 unsigned int
-X11_KeySymToUcs4(KeySym keysym)
+SDL_KeySymToUcs4(Uint32 keysym)
 {
     /* 'Unicode keysym' */
     if ((keysym & 0xff000000) == 0x01000000)

--- a/src/events/imKStoUCS.h
+++ b/src/events/imKStoUCS.h
@@ -27,6 +27,6 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 */
 
-extern unsigned int X11_KeySymToUcs4(KeySym keysym);
+extern unsigned int SDL_KeySymToUcs4(Uint32 keysym);
 
 #endif /* _imKStoUCS_h */

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -60,6 +60,7 @@
 #include <unistd.h>
 #include <xkbcommon/xkbcommon.h>
 #include <xkbcommon/xkbcommon-compose.h>
+#include "../../events/imKStoUCS.h"
 
 /* Weston uses a ratio of 10 units per scroll tick */
 #define WAYLAND_WHEEL_AXIS_UNIT 10
@@ -870,7 +871,7 @@ Wayland_keymap_iter(struct xkb_keymap *keymap, xkb_keycode_t key, void *data)
         }
 
         if (WAYLAND_xkb_keymap_key_get_syms_by_level(keymap, key, sdlKeymap->layout, 0, &syms) > 0) {
-            uint32_t keycode = WAYLAND_xkb_keysym_to_utf32(syms[0]);
+            uint32_t keycode = SDL_KeySymToUcs4(syms[0]);
             if (keycode) {
                 sdlKeymap->keymap[scancode] = keycode;
             } else {

--- a/src/video/x11/SDL_x11keyboard.c
+++ b/src/video/x11/SDL_x11keyboard.c
@@ -31,7 +31,7 @@
 #include <X11/keysym.h>
 #include <X11/XKBlib.h>
 
-#include "imKStoUCS.h"
+#include "../../events/imKStoUCS.h"
 
 #ifdef X_HAVE_UTF8_STRING
 #include <locale.h>
@@ -205,7 +205,7 @@ X11_KeyCodeToUcs4(_THIS, KeyCode keycode, unsigned char group)
         return 0;
     }
 
-    return X11_KeySymToUcs4(keysym);
+    return SDL_KeySymToUcs4(keysym);
 }
 
 KeySym


### PR DESCRIPTION
Another Wayland patch that's a lot smaller than it seems... but I'm uneasy about one thing: @slouken, should we just put imKStoUCS.c somewhere else so both Wayland and X11 can use the same file? Where should I put it if so?

Fixes #4666.
Fixes #4642.