### PR TITLE
wayland: Expose xdg_toplevel to SysWM

### DIFF
--- a/include/SDL_syswm.h
+++ b/include/SDL_syswm.h
@@ -292,6 +292,7 @@ struct SDL_SysWMinfo
             void *shell_surface;                    /**< DEPRECATED Wayland shell_surface (window manager handle) */
             struct wl_egl_window *egl_window;       /**< Wayland EGL window (native window) */
             struct xdg_surface *xdg_surface;        /**< Wayland xdg surface (window manager handle) */
+            struct xdg_toplevel *xdg_toplevel;      /**< Wayland xdg toplevel role */
         } wl;
 #endif
 #if defined(SDL_VIDEO_DRIVER_MIR)  /* no longer available, left for API/ABI compatibility. Remove in 2.1! */

--- a/src/video/wayland/SDL_waylanddyn.h
+++ b/src/video/wayland/SDL_waylanddyn.h
@@ -140,6 +140,7 @@ void SDL_WAYLAND_UnloadSymbols(void);
 #define libdecor_frame_is_floating (*WAYLAND_libdecor_frame_is_floating)
 #define libdecor_frame_set_parent (*WAYLAND_libdecor_frame_set_parent)
 #define libdecor_frame_get_xdg_surface (*WAYLAND_libdecor_frame_get_xdg_surface)
+#define libdecor_frame_get_xdg_toplevel (*WAYLAND_libdecor_frame_get_xdg_toplevel)
 #define libdecor_frame_map (*WAYLAND_libdecor_frame_map)
 #define libdecor_state_new (*WAYLAND_libdecor_state_new)
 #define libdecor_state_free (*WAYLAND_libdecor_state_free)

--- a/src/video/wayland/SDL_waylandsym.h
+++ b/src/video/wayland/SDL_waylandsym.h
@@ -182,6 +182,7 @@ SDL_WAYLAND_SYM(bool, libdecor_frame_is_floating, (struct libdecor_frame *))
 SDL_WAYLAND_SYM(void, libdecor_frame_set_parent, (struct libdecor_frame *,\
                                                   struct libdecor_frame *))
 SDL_WAYLAND_SYM(struct xdg_surface *, libdecor_frame_get_xdg_surface, (struct libdecor_frame *))
+SDL_WAYLAND_SYM(struct xdg_toplevel *, libdecor_frame_get_xdg_toplevel, (struct libdecor_frame *))
 SDL_WAYLAND_SYM(void, libdecor_frame_map, (struct libdecor_frame *))
 SDL_WAYLAND_SYM(struct libdecor_state *, libdecor_state_new, (int, int))
 SDL_WAYLAND_SYM(void, libdecor_state_free, (struct libdecor_state *))

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -639,12 +639,19 @@ Wayland_GetWindowWMInfo(_THIS, SDL_Window * window, SDL_SysWMinfo * info)
 #ifdef HAVE_LIBDECOR_H
         if (viddata->shell.libdecor && data->shell_surface.libdecor.frame != NULL) {
             info->info.wl.xdg_surface = libdecor_frame_get_xdg_surface(data->shell_surface.libdecor.frame);
+            if (version >= SDL_VERSIONNUM(2, 0, 17)) {
+                info->info.wl.xdg_toplevel = libdecor_frame_get_xdg_toplevel(data->shell_surface.libdecor.frame);
+            }
         } else
 #endif
         if (viddata->shell.xdg && data->shell_surface.xdg.surface != NULL) {
             info->info.wl.xdg_surface = data->shell_surface.xdg.surface;
+            if (version >= SDL_VERSIONNUM(2, 0, 17)) {
+                info->info.wl.xdg_toplevel = data->shell_surface.xdg.roleobj.toplevel;
+            }
         } else {
             info->info.wl.xdg_surface = NULL;
+            info->info.wl.xdg_toplevel = NULL;
         }
     }
 


### PR DESCRIPTION
## Description
This PR exposes the `xdg_toplevel` object to SysWM, which, most importantly, allows SDL2 applications to set parents for the surfaces to another non-SDL2 Wayland window with a `xdg_toplevel`.