### PR TITLE
Use SDL_calloc for allocation of gxm_texture

### DIFF
--- a/src/render/vitagxm/SDL_render_vita_gxm_tools.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm_tools.c
@@ -1011,7 +1011,7 @@ gxm_texture_get_datap(const gxm_texture *texture)
 gxm_texture *
 create_gxm_texture(VITA_GXM_RenderData *data, unsigned int w, unsigned int h, SceGxmTextureFormat format, unsigned int isRenderTarget)
 {
-    gxm_texture *texture = SDL_malloc(sizeof(gxm_texture));
+    gxm_texture *texture = SDL_calloc(1, sizeof(gxm_texture));
     const int tex_size =  ((w + 7) & ~ 7) * h * tex_format_to_bytespp(format);
     void *texture_data;
 


### PR DESCRIPTION
Use SDL_calloc for allocation of gxm_texture on PS Vita

## Description
Use SDL_calloc instead of SDL_malloc for allocation of gxm_texture struct. In some rare cases newly created struct may contain a pointer to the main render target, which may lead to crash on texture destruction.
