### PR TITLE
video: wayland: Support displays with a 0 refresh rate (fix #4785)

### DIFF
--- a/src/video/wayland/SDL_waylandopengles.c
+++ b/src/video/wayland/SDL_waylandopengles.c
@@ -129,7 +129,9 @@ Wayland_GLES_SwapWindow(_THIS, SDL_Window *window)
     if (swap_interval != 0) {
         struct wl_display *display = ((SDL_VideoData *)_this->driverdata)->display;
         SDL_VideoDisplay *sdldisplay = SDL_GetDisplayForWindow(window);
-        const Uint32 max_wait = SDL_GetTicks() + (10000 / sdldisplay->current_mode.refresh_rate);  /* ~10 frames, so we'll progress even if throttled to zero. */
+        /* ~10 frames (or 1 sec), so we'll progress even if throttled to zero. */
+        const Uint32 max_wait = SDL_GetTicks() + (sdldisplay->current_mode.refresh_rate ?
+                                                  (10000 / sdldisplay->current_mode.refresh_rate) : 1000);
         while (SDL_AtomicGet(&data->swap_interval_ready) == 0) {
             Uint32 now;
 


### PR DESCRIPTION
Some wayland compositors report the refresh rate as 0. Since we want to force a minimum refresh rate of 10 frames worth, we were dividing by the reported refresh rate, causing a divide-by-zero.

If the refresh rate is 0, instead force a frame every second if no frame callbacks are received. This value (1000ms) could be changed if that seems necessary: it's a bit longer than the 667ms you'd get with a 60fps output.

This fixes bug #4785 — I've tested it with sway and supertux2, and could reproduce the issue without this patch, and the game ran smoothly with it.

CC: @flibitijibibo for general wayland brokenness.