### PR TITLE
Xcode-iOS Demos: Add CFBundleShortVersionString to Info.plist

### DIFF
--- a/Xcode-iOS/Demos/Info.plist
+++ b/Xcode-iOS/Demos/Info.plist
@@ -16,6 +16,8 @@
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.0</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleSignature</key>


### PR DESCRIPTION
## Description
Xcode 13.0 appears to require this key to be present in the Info.plist to be able to run the compiled code.


