### PR TITLE
Consistent behaviour of SDL_TextEditingEvent

### DIFF
--- a/include/SDL_events.h
+++ b/include/SDL_events.h
@@ -238,6 +238,7 @@ typedef struct SDL_TextEditingEvent
     char text[SDL_TEXTEDITINGEVENT_TEXT_SIZE];  /**< The editing text */
     Sint32 start;                               /**< The start cursor of selected editing text */
     Sint32 length;                              /**< The length of selected editing text */
+    SDL_bool first;                             /**< Whether the input was the first of a new set of events, since multiple are sent when more than 31 bytes are contained in the IME preview */
 } SDL_TextEditingEvent;
 
 

--- a/include/SDL_stdinc.h
+++ b/include/SDL_stdinc.h
@@ -541,6 +541,7 @@ extern DECLSPEC char *SDLCALL SDL_strrchr(const char *str, int c);
 extern DECLSPEC char *SDLCALL SDL_strstr(const char *haystack, const char *needle);
 extern DECLSPEC char *SDLCALL SDL_strtokr(char *s1, const char *s2, char **saveptr);
 extern DECLSPEC size_t SDLCALL SDL_utf8strlen(const char *str);
+extern DECLSPEC size_t SDLCALL SDL_utf8strllen(const char *str, size_t maxlen);
 
 extern DECLSPEC char *SDLCALL SDL_itoa(int value, char *str, int radix);
 extern DECLSPEC char *SDLCALL SDL_uitoa(unsigned int value, char *str, int radix);

--- a/src/core/linux/SDL_ibus.c
+++ b/src/core/linux/SDL_ibus.c
@@ -117,8 +117,8 @@ IBus_MessageHandler(DBusConnection *conn, DBusMessage *msg, void *user_data)
         const char *text;
 
         dbus->message_iter_init(msg, &iter);
-        
         text = IBus_GetVariantText(conn, &iter, dbus);
+
         if (text && *text) {
             char buf[SDL_TEXTINPUTEVENT_TEXT_SIZE];
             size_t text_bytes = SDL_strlen(text), i = 0;
@@ -144,16 +144,18 @@ IBus_MessageHandler(DBusConnection *conn, DBusMessage *msg, void *user_data)
         if (text) {
             char buf[SDL_TEXTEDITINGEVENT_TEXT_SIZE];
             size_t text_bytes = SDL_strlen(text), i = 0;
-            size_t cursor = 0;
+            int start;
+
+            dbus->message_iter_next(&iter);
+            dbus->message_iter_get_basic(&iter, &start);
             
             do {
                 const size_t sz = SDL_utf8strlcpy(buf, text+i, sizeof(buf));
-                const size_t chars = SDL_utf8strlen(buf);
                 
-                SDL_SendEditingText(buf, cursor, chars);
+                if (i == 0) SDL_SendEditingText(buf, start, 0);
+                else SDL_SendExtendedEditingText(buf, start, 0);
 
                 i += sz;
-                cursor += chars;
             } while (i < text_bytes);
         }
         

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -822,3 +822,4 @@
 #define SDL_RenderSetVSync SDL_RenderSetVSync_REAL
 #define SDL_asprintf SDL_asprintf_REAL
 #define SDL_vasprintf SDL_vasprintf_REAL
+#define SDL_utf8strllen SDL_utf8strllen_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -889,3 +889,4 @@ SDL_DYNAPI_PROC(int,SDL_RenderSetVSync,(SDL_Renderer *a, int b),(a,b),return)
 SDL_DYNAPI_PROC(int,SDL_asprintf,(char **a, SDL_PRINTF_FORMAT_STRING const char *b, ...),(a,b),return)
 #endif
 SDL_DYNAPI_PROC(int,SDL_vasprintf,(char **a, const char *b, va_list c),(a,b,c),return)
+SDL_DYNAPI_PROC(size_t,SDL_utf8strllen,(const char *a, size_t b),(a,b),return)

--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -876,8 +876,7 @@ SDL_SendKeyboardText(const char *text)
 }
 
 int
-SDL_SendEditingText(const char *text, int start, int length)
-{
+SDL_SendEditingText_F(const char *text, int start, int length, SDL_bool first) {
     SDL_Keyboard *keyboard = &SDL_keyboard;
     int posted;
 
@@ -889,11 +888,27 @@ SDL_SendEditingText(const char *text, int start, int length)
         event.edit.windowID = keyboard->focus ? keyboard->focus->id : 0;
         event.edit.start = start;
         event.edit.length = length;
+        event.edit.first = first;
         SDL_utf8strlcpy(event.edit.text, text, SDL_arraysize(event.edit.text));
         posted = (SDL_PushEvent(&event) > 0);
     }
     return (posted);
 }
+
+/* backwards-compatible function to send the first event */
+int
+SDL_SendEditingText(const char *text, int start, int length)
+{
+    return SDL_SendEditingText_F(text, start, length, SDL_TRUE);
+}
+
+/* new function to mark event as an extension to the previous one */
+int
+SDL_SendExtendedEditingText(const char *text, int start, int length)
+{
+    return SDL_SendEditingText_F(text, start, length, SDL_FALSE);
+}
+
 
 void
 SDL_KeyboardQuit(void)

--- a/src/events/SDL_keyboard_c.h
+++ b/src/events/SDL_keyboard_c.h
@@ -63,6 +63,9 @@ extern int SDL_SendKeyboardText(const char *text);
 /* Send editing text for selected range from start to end */
 extern int SDL_SendEditingText(const char *text, int start, int end);
 
+/* Send editing text for selected range from start to end, as an extension to the one previously sent */
+extern int SDL_SendExtendedEditingText(const char *text, int start, int end);
+
 /* Shutdown the keyboard subsystem */
 extern void SDL_KeyboardQuit(void);
 

--- a/src/stdlib/SDL_string.c
+++ b/src/stdlib/SDL_string.c
@@ -681,6 +681,35 @@ SDL_utf8strlen(const char *str)
 }
 
 size_t
+SDL_utf8strllen(const char *str, size_t maxlen)
+{
+    size_t retval = 0;
+    size_t pos = 1;
+    const char *p = str;
+    char ch;
+
+    while ((ch = *(p++)) != 0) {
+        /* if top two bits are 1 and 0, it's a continuation byte. */
+        if ((ch & 0xc0) != 0x80) {
+            retval++;
+        }
+
+        /* if maxlen reached, check if the next byte is a continuation byte */
+        /* if it is, the last UTF-8 character is not complete, so -1 from retval */
+        if (pos == maxlen) {
+            if ((*(p++) & 0xc0) == 0x80) {
+                retval--;
+            }
+            break;
+        }
+
+        pos++;
+    }
+    
+    return retval;
+}
+
+size_t
 SDL_strlcat(SDL_INOUT_Z_CAP(maxlen) char *dst, const char *src, size_t maxlen)
 {
 #if defined(HAVE_STRLCAT)

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -1255,16 +1255,21 @@ text_input_preedit_string(void *data,
     char buf[SDL_TEXTEDITINGEVENT_TEXT_SIZE];
     if (text) {
         size_t text_bytes = SDL_strlen(text), i = 0;
-        size_t cursor = 0;
+        int start = 0, length = 0;
+
+        /* calculate utf8 start and length, simulate behaviour of ibus and Windows */
+        if (cursor_begin != -1 && cursor_end != -1) {
+            start = SDL_utf8strllen(text, cursor_begin);
+            length = SDL_utf8strllen(text + cursor_begin, cursor_end);
+        }
 
         do {
             const size_t sz = SDL_utf8strlcpy(buf, text+i, sizeof(buf));
-            const size_t chars = SDL_utf8strlen(buf);
 
-            SDL_SendEditingText(buf, cursor, chars);
+            if (i == 0) SDL_SendEditingText(buf, start, length);
+            else SDL_SendExtendedEditingText(buf, start, length);
 
             i += sz;
-            cursor += chars;
         } while (i < text_bytes);
     } else {
         buf[0] = '\0';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The data inside the `SDL_TextEditingEvent` struct is clearly defined in `include/SDL_events.h`.
```c
typedef struct SDL_TextEditingEvent
{
    Uint32 type;                                /**< ::SDL_TEXTEDITING */
    Uint32 timestamp;                           /**< In milliseconds, populated using SDL_GetTicks() */
    Uint32 windowID;                            /**< The window with keyboard focus, if any */
    char text[SDL_TEXTEDITINGEVENT_TEXT_SIZE];  /**< The editing text */
    Sint32 start;                               /**< The start cursor of selected editing text */
    Sint32 length;                              /**< The length of selected editing text */
} SDL_TextEditingEvent;
```
On Windows and other platforms, the data inside the `SDL_TextEditingEvent` struct correspond to the description provided. The data contained are as follows:
- `start` contains the number of Unicode characters until the position of the cursor, or the start of the selection, if any.
- `length` contains the number of Unicode characters selected.

However when using Linux, data from all 3 IME protocols (IBus, Fcitx and the experimental Wayland one) are incorrectly transferred into the struct the following:
- `start` contains the number of Unicode characters that came before this event (as in, previous events that are chained to send more than 32 bytes).
- `length` contains the number of Unicode characters `text` contains.

This expectedly causes issues when a user is handling IME inputs on Linux, as the data is different from Windows. Even if they work around this, the application still has no way of determining the current cursor position or selection.

## Solution
Data contained in the event when using the Linux protocols have been changed to match the behaviour on Windows.

However, because `start` no longer contains the number of Unicode characters that came before, there is now no way of knowing whether the event is a part of a chain to send more than 32 bytes as the IME text preview.
This is solved by adding a `first` field, which is set to `true` whenever a new chain is started, and `false` otherwise.

To facilitate this, the function `SDL_SendExtendedEditingText` is added, which sends a `SDL_TextEditingEvent` with `first` set to `false`. The old function, `SDL_SendEditingText` sends the event with `first` set to `true`. This should retain behaviour of any existing code that calls `SDL_SendEditingText`.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
Implements a proper solution for solving #1879.