### PR TITLE
wayland: Cleanup some SDL_TryLockMutex() calls (fixup for PR #4802)

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -234,7 +234,7 @@ Wayland_PumpEvents(_THIS)
     /* If we're trying to dispatch the display in another thread,
      * we could trigger a race condition and end up blocking
      * in wl_display_dispatch() */
-    if (SDL_TryLockMutex(d->display_dispatch_lock)) {
+    if (SDL_TryLockMutex(d->display_dispatch_lock) != 0) {
         return;
     }
 

--- a/src/video/wayland/SDL_waylandopengles.c
+++ b/src/video/wayland/SDL_waylandopengles.c
@@ -151,7 +151,7 @@ Wayland_GLES_SwapWindow(_THIS, SDL_Window *window)
 
             /* Make sure we're not competing with SDL_PumpEvents() for any new
              * events, or one of us may end up blocking in wl_display_dispatch */
-            if (SDL_TryLockMutex(videodata->display_dispatch_lock)) {
+            if (SDL_TryLockMutex(videodata->display_dispatch_lock) != 0) {
                 continue;
             }
 


### PR DESCRIPTION
Check the result of these against 0 explicitly, so that it's obvious
we're bailing out on failure, not success.

This is a fixup for commit 25f9e32 from pull request #4802.