### PR TITLE
Revert `6fe6946` "Fixed relative mode mouse events stopping if you click on the title bar"

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -773,9 +773,6 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
                         SDL_SendMouseMotion(data->window, 0, 0, center_x, center_y);
                     }
                 }
-            } else {
-                /* We still need to update focus */
-                SDL_SetMouseFocus(data->window);
             }
         }
         /* don't break here, fall through to check the wParam like the button presses */


### PR DESCRIPTION
6fe6946 has been better fixed by b28ed02 or another related relative mouse mode change of @slouken in SDL 2.0.17 and as such can be reverted to reduce unneeded processing in WM_MOUSEMOVE

Existing Issue:
I originally reported this issue within #3330 (not the original bug at the top but rather if you scroll down in the conversation). After reverting https://github.com/libsdl-org/SDL/commit/6fe6946a2fceca155a6a706805c1027c3152b135 the bug still seems to be fixed in a better way now.