### PR TITLE
Fix Debug-only builds with CMake

### DIFF
--- a/SDL2Config.cmake
+++ b/SDL2Config.cmake
@@ -68,10 +68,10 @@ if( sdl2implib AND sdl2mainimplib AND sdl2implibdbg AND sdl2mainimplibdbg )
 	set(SDL2_LIBRARIES $<IF:$<CONFIG:Debug>,${sdl2mainimplibdbg},${sdl2mainimplib}>   $<IF:$<CONFIG:Debug>,${sdl2implibdbg},${sdl2implib}>)
 else()
 	if( (NOT sdl2implib) AND sdl2implibdbg ) # if we only have a debug version of the lib
-		set(sdl2implib sdl2implibdbg)
+		set(sdl2implib ${sdl2implibdbg})
 	endif()
 	if( (NOT sdl2mainimplib) AND sdl2mainimplibdbg ) # if we only have a debug version of the lib
-		set(sdl2mainimplib sdl2mainimplibdbg)
+		set(sdl2mainimplib ${sdl2mainimplibdbg})
 	endif()
 
 	if( sdl2implib AND sdl2mainimplib )


### PR DESCRIPTION
"get_filename_component(SDL2_LIBDIR ${sdl2implib} PATH)" failed if sdl2implib was set from sdl2implibdbg instead of ${sdl2implibdbg}

I thought I tested this case, but apparently I didn't.

Thanks to seyuup for pointing this out in https://discourse.libsdl.org/t/how-is-sdl2-supposed-to-be-used-with-cmake/31275/14
