### PR TITLE
Fix compiler warnings in testvulkan.c

### DIFF
--- a/test/testvulkan.c
+++ b/test/testvulkan.c
@@ -653,11 +653,11 @@ static SDL_bool createSwapchain(void)
 
     // Clamp the size to the allowable image extent.
     // SDL_Vulkan_GetDrawableSize()'s result it not always in this range (bug #3287)
-    vulkanContext->swapchainSize.width = SDL_clamp(w,
+    vulkanContext->swapchainSize.width = SDL_clamp((uint32_t) w,
                                                   vulkanContext->surfaceCapabilities.minImageExtent.width,
                                                   vulkanContext->surfaceCapabilities.maxImageExtent.width);
 
-    vulkanContext->swapchainSize.height = SDL_clamp(h,
+    vulkanContext->swapchainSize.height = SDL_clamp((uint32_t) h,
                                                    vulkanContext->surfaceCapabilities.minImageExtent.height,
                                                    vulkanContext->surfaceCapabilities.maxImageExtent.height);
 


### PR DESCRIPTION
MSVC gives the following warnings when compiling testvulkan.c
```
testvulkan.c(656,1): warning C4018: '<': signed/unsigned mismatch
testvulkan.c(656,1): warning C4018: '>': signed/unsigned mismatch
testvulkan.c(660,1): warning C4018: '<': signed/unsigned mismatch
testvulkan.c(660,1): warning C4018: '>': signed/unsigned mismatch
```