### PR TITLE
wayland: Only call wl_egl_window_resize in SwapWindow

### DIFF
--- a/src/video/wayland/SDL_waylandopengles.c
+++ b/src/video/wayland/SDL_waylandopengles.c
@@ -172,6 +172,15 @@ Wayland_GLES_SwapWindow(_THIS, SDL_Window *window)
         return SDL_EGL_SetError("unable to show color buffer in an OS-native window", "eglSwapBuffers");
     }
 
+    /* Resize the egl window if required. */
+    if (SDL_AtomicGet(&data->pending_egl_resize)) {
+        WAYLAND_wl_egl_window_resize(data->egl_window,
+                                        window->w * data->scale_factor,
+                                        window->h * data->scale_factor,
+                                        0, 0);
+        SDL_AtomicSet(&data->pending_egl_resize, 0);
+    }
+
     WAYLAND_wl_display_flush( data->waylandData->display );
 
     return 0;

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -1310,10 +1310,7 @@ Wayland_HandleResize(SDL_Window *window, int width, int height, float scale)
     wl_surface_set_buffer_scale(data->surface, data->scale_factor);
 
     if (data->egl_window) {
-        WAYLAND_wl_egl_window_resize(data->egl_window,
-                                        window->w * data->scale_factor,
-                                        window->h * data->scale_factor,
-                                        0, 0);
+        SDL_AtomicSet(&data->pending_egl_resize, 1);
     }
 
     region = wl_compositor_create_region(data->waylandData->compositor);

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -1307,11 +1307,12 @@ Wayland_HandleResize(SDL_Window *window, int width, int height, float scale)
     window->h = height;
     data->scale_factor = scale;
 
-    wl_surface_set_buffer_scale(data->surface, data->scale_factor);
-
     if (data->egl_window) {
         SDL_AtomicSet(&data->pending_egl_resize, 1);
+        return;
     }
+
+    wl_surface_set_buffer_scale(data->surface, data->scale_factor);
 
     region = wl_compositor_create_region(data->waylandData->compositor);
     wl_region_add(region, 0, 0, window->w, window->h);
@@ -1358,14 +1359,12 @@ void Wayland_SetWindowSize(_THIS, SDL_Window * window)
     }
 #endif
 
-    wl_surface_set_buffer_scale(wind->surface, wind->scale_factor);
-
     if (wind->egl_window) {
-        WAYLAND_wl_egl_window_resize(wind->egl_window,
-                                     window->w * wind->scale_factor,
-                                     window->h * wind->scale_factor,
-                                     0, 0);
+        SDL_AtomicSet(&wind->pending_egl_resize, 1);
+        return;
     }
+
+    wl_surface_set_buffer_scale(wind->surface, wind->scale_factor);
 
 #ifdef HAVE_LIBDECOR_H
     if (data->shell.libdecor && wind->shell_surface.libdecor.frame) {

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -74,6 +74,7 @@ typedef struct {
     int floating_width, floating_height;
 
     SDL_atomic_t swap_interval_ready;
+    SDL_atomic_t pending_egl_resize;
 
 #ifdef SDL_VIDEO_DRIVER_WAYLAND_QT_TOUCH
     struct qt_extended_surface *extended_surface;


### PR DESCRIPTION
This is a slightly hacky change to get multithreaded SDL applications working under nVidia's wayland implementation. It feels vaguely related to #4563 — ultimately it's about deferring resizes until there's a new frame.

On nVidia's EGLStreams wayland implementation (at least under KDE/KWin), some applications will hang on window creation or resize. This seems to be the result of wl_egl_window_resize() being called in the middle of a frame (or possibly from another thread).

Instead, only apply the new window size immediately after SwapBuffers, which seems to work better. There's probably more to be done to avoid any mismatches in window size everywhere, but with this change, Impostor Factory now works consistently under nVidia/Wayland, and Transistor at least starts, before hitting its usual bugs.

Ultimately, there's probably a better solution here which defers more of the resize to the correct point in SwapWindow, à la https://github.com/libsdl-org/SDL/commit/785dfdfbe2633c203c1fe74445c98019cb8052dc — that patch on its own doesn't fix anything on nVidia, however. I'm not sure how Vulkan will work, either: this at least doesn't break Vulkan on Mesa, though.