### PR TITLE
build-scripts/iosbuild.sh arm64 iOS sim

### DIFF
--- a/build-scripts/iosbuild.sh
+++ b/build-scripts/iosbuild.sh
@@ -20,6 +20,7 @@ fi
 
 BUILD_I386_IOSSIM=YES
 BUILD_X86_64_IOSSIM=YES
+BUILD_ARM64_IOSSIM=YES
 
 BUILD_IOS_ARMV7=YES
 BUILD_IOS_ARMV7S=YES
@@ -55,6 +56,7 @@ echo "PREFIX ..................... ${PREFIX}"
 echo "BUILD_MACOSX_X86_64 ........ ${BUILD_MACOSX_X86_64}"
 echo "BUILD_I386_IOSSIM .......... ${BUILD_I386_IOSSIM}"
 echo "BUILD_X86_64_IOSSIM ........ ${BUILD_X86_64_IOSSIM}"
+echo "BUILD_ARM64_IOSSIM ......... ${BUILD_ARM64_IOSSIM}"
 echo "BUILD_IOS_ARMV7 ............ ${BUILD_IOS_ARMV7}"
 echo "BUILD_IOS_ARMV7S ........... ${BUILD_IOS_ARMV7S}"
 echo "BUILD_IOS_ARM64 ............ ${BUILD_IOS_ARM64}"
@@ -107,6 +109,24 @@ then
         cd ${PREFIX}
         make clean
         ../configure --build=x86_64-apple-${DARWIN} --host=x86_64-ios-${DARWIN} --disable-shared --prefix=${PREFIX}/platform/x86_64-sim "CC=${CC}" "CFLAGS=${CFLAGS} -mios-simulator-version-min=${MIN_SDK_VERSION} -arch x86_64 -isysroot ${IPHONESIMULATOR_SYSROOT}" "CXX=${CXX}" "CXXFLAGS=${CXXFLAGS} -mios-simulator-version-min=${MIN_SDK_VERSION} -arch x86_64 -isysroot ${IPHONESIMULATOR_SYSROOT}" LDFLAGS="-arch x86_64 -mios-simulator-version-min=${MIN_SDK_VERSION} ${LDFLAGS} -L${IPHONESIMULATOR_SYSROOT}/usr/lib/ -L${IPHONESIMULATOR_SYSROOT}/usr/lib/system" || exit 2
+        cp $SRC_DIR/include/SDL_config_iphoneos.h include/SDL_config.h
+        make -j$NJOB || exit 3
+        make install
+    ) || exit $?
+fi
+
+echo "$(tput setaf 2)"
+echo "#############################"
+echo "# arm64 for iPhone Simulator"
+echo "#############################"
+echo "$(tput sgr0)"
+
+if [ "${BUILD_ARM64_IOSSIM}" == "YES" ]
+then
+    (
+        cd ${PREFIX}
+        make clean
+        ../configure --build=x86_64-apple-${DARWIN} --host=arm-ios-${DARWIN} --disable-shared --prefix=${PREFIX}/platform/arm64-sim "CC=${CC}" "CFLAGS=${CFLAGS} -mios-simulator-version-min=${MIN_SDK_VERSION} -arch arm64 -isysroot ${IPHONESIMULATOR_SYSROOT}" "CXX=${CXX}" "CXXFLAGS=${CXXFLAGS} -mios-simulator-version-min=${MIN_SDK_VERSION} -arch arm64 -isysroot ${IPHONESIMULATOR_SYSROOT}" LDFLAGS="-arch arm64 -mios-simulator-version-min=${MIN_SDK_VERSION} ${LDFLAGS} -L${IPHONESIMULATOR_SYSROOT}/usr/lib/ -L${IPHONESIMULATOR_SYSROOT}/usr/lib/system" || exit 2
         cp $SRC_DIR/include/SDL_config_iphoneos.h include/SDL_config.h
         make -j$NJOB || exit 3
         make install


### PR DESCRIPTION
## Description

* Adds arm64 build of simulator for Apple Silicon (M1) Macs

---

This actually raises more questions that probably should be worked out before merging. (I hope you don't mind me adding a bit of discussion here, if you want me to instead move discussion elsewhere please direct me. And/or if this simply just not a priority for anybody to look at, I won't be upset):

- [ ] 1. At the end of this pre-existing script it creates a Fat library using `lipo`. This was fine until Apple introduced arm64 Macs but no longer works (if you wish to allow arm64 simulator) as you cannot have a single binary containing arm64 for iOS and arm64 for iOS Simulator. My understanding is Apple's latest recommendation is to use `XCFramework` bundles. 3 possible solutions I can see:
  * Keep arm64 simulators out of the fat build (I don't know if this script needs to retain backwards compatibility?)
  * Create 2 Fat libraries, one for each platform (less than ideal for the developer using the libraries but simpler here)
  * Combine into a single `XCFramework`. This essentially just a bundle directory containing 2 Fat libraries, 3 plist files and the headers.

- [ ] 2. Each individual platform builds a `libSDL2.a`, `libSDL2main.a`, and `libSDL2_test.a`. Only the `libSDL2.a` is used at all in terms of creating a fat library. Is `libSDL2main.a` supposed to be no longer relevant, or should that also be made Fat (or XCFramework)? 

- [ ] 3. I'm not actually entirely sure the resulting library actually works, but that might be entirely my fault with my Xcode project file / could be unrelated to this PR completely, but is hard for me to tell. I'm trying to use a plain Xcode project with only `main.m` containing `rectangles.c`. I'm hoping clarification on question 2 might help clarify to some degree as to which direction to try to further debug.
  * When not including `libSDL2main.a`, I get `ld: entry point (_main) undefined. for architecture arm64`
  * When including `libSDL2main.a`, it compiles and runs, the launch screen storyboard shows but never fades and the user-defined `main` is never executed.
  * When including `libSDL2main.a` and removing the launch screen storyboard, user-defined `main` does get called but black screen shows and I get the error `Could not initialize SDL: Application didn't initialize properly, did you include SDL_main.h in the file containing your main() function?`. Adding `#include "SDL_main.h"` makes no difference.

---

[edit]

FYI, depending on answers on how you want this handled, it may be worth switching the script to simply use `xcodebuild` rather than through `make`, although I'm not going to pretend to understand the full build process here, so maybe that's exactly what it does already, or maybe there's other reasons against that. Running:

```sh
cd Xcode/SDL && \
xcodebuild archive \
 -scheme "Framework-iOS" \
 -archivePath "$PWD/simulator" \
 -sdk iphonesimulator \
 SKIP_INSTALL=NO
```

yields a fat library including arm64 already

```
> lipo -info Xcode/SDL/simulator.xcarchive/Products/Library/Frameworks/SDL2.framework/SDL2 
Architectures in the fat file: Xcode/SDL/simulator.xcarchive/Products/Library/Frameworks/SDL2.framework/SDL2 are: x86_64 i386 arm64 
```

When using this, it would be easy to convert to xcframework through an additional `xcodebuild` command