### PR TITLE
SDL_OpenURL (macOS): try to open path if the url cannot be opened

### DIFF
--- a/src/misc/macosx/SDL_sysurl.m
+++ b/src/misc/macosx/SDL_sysurl.m
@@ -27,16 +27,10 @@ int
 SDL_SYS_OpenURL(const char *url)
 { @autoreleasepool
 {
-    NSString *nsstr = [NSString stringWithUTF8String:url];
-    NSURL *nsurl = [NSURL URLWithString:nsstr];
-    int res = [[NSWorkspace sharedWorkspace] openURL:nsurl] ? 0 : -1;
-
-    if (res == -1) {
-        NSURL *nsurlpath = [NSURL fileURLWithPath:nsstr];
-        return [[NSWorkspace sharedWorkspace] openURL:nsurlpath] ? 0 : -1;
-    }
-
-    return res;
+	CFURLRef cfurl = CFURLCreateWithBytes(NULL, (UInt8 *) url, SDL_strlen(url), kCFStringEncodingUTF8,  NULL);
+	OSStatus status = LSOpenCFURLRef(cfurl, NULL);
+	CFRelease(cfurl);
+	return status == noErr ? 0 : -1;
 }}
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/misc/macosx/SDL_sysurl.m
+++ b/src/misc/macosx/SDL_sysurl.m
@@ -27,10 +27,10 @@ int
 SDL_SYS_OpenURL(const char *url)
 { @autoreleasepool
 {
-	CFURLRef cfurl = CFURLCreateWithBytes(NULL, (UInt8 *) url, SDL_strlen(url), kCFStringEncodingUTF8,  NULL);
-	OSStatus status = LSOpenCFURLRef(cfurl, NULL);
-	CFRelease(cfurl);
-	return status == noErr ? 0 : -1;
+    CFURLRef cfurl = CFURLCreateWithBytes(NULL, (const UInt8 *) url, SDL_strlen(url), kCFStringEncodingUTF8,  NULL);
+    OSStatus status = LSOpenCFURLRef(cfurl, NULL);
+    CFRelease(cfurl);
+    return status == noErr ? 0 : -1;
 }}
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/misc/macosx/SDL_sysurl.m
+++ b/src/misc/macosx/SDL_sysurl.m
@@ -29,8 +29,14 @@ SDL_SYS_OpenURL(const char *url)
 {
     NSString *nsstr = [NSString stringWithUTF8String:url];
     NSURL *nsurl = [NSURL URLWithString:nsstr];
-    return [[NSWorkspace sharedWorkspace] openURL:nsurl] ? 0 : -1;
+    int res = [[NSWorkspace sharedWorkspace] openURL:nsurl] ? 0 : -1;
+
+    if (res == -1) {
+        NSURL *nsurlpath = [NSURL fileURLWithPath:nsstr];
+        return [[NSWorkspace sharedWorkspace] openURL:nsurlpath] ? 0 : -1;
+    }
+
+    return res;
 }}
 
 /* vi: set ts=4 sw=4 expandtab: */
-


### PR DESCRIPTION
Hello,

This MR updates macOS implementation of SDL_OpenURL so that we can also open paths like "/Users/Bob/Documents".

## Description

Current implementation of macOS SDL_OpenURL can only open URLs such as `https://www.libsdl.org`, `scheme://something` or `file:///Users/Bob/Documents`.

However, some libraries for Mac (for example, PHYSFS) return Unix paths like `/Users/Bob/Documents`. A simple concatenation `"file://" + path` cannot work be cause we can end up with an invalid URL, for example when the path has a space in it (we would end up with `file:///Users/Bob/Library/Application Support/MyApp`).

In this MR, if the url cannot be opened, we try to open the path using another method: creating the NSURL with "fileURLWithPath" (which is [available since macOS 10.0](https://developer.apple.com/documentation/foundation/nsurl/1410828-fileurlwithpath)).

## Existing Issue(s)
