### PR TITLE
(Windows) Fix mouse focus being set to null when a captured mouse cursor leaves the window

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -979,7 +979,9 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
            being lost. This then causes a cascading failure where SDL_WINDOWEVENT_ENTER / SDL_WINDOWEVENT_LEAVE
            can stop firing permanently, due to the focus being in the wrong state and TrackMouseEvent never
            resubscribing. */
-        SDL_SetMouseFocus(NULL);
+        const SDL_bool isCapture = ((data->window->flags & SDL_WINDOW_MOUSE_CAPTURE) != 0);
+        if (!isCapture)
+            SDL_SetMouseFocus(NULL);
 
         returnCode = 0;
         break;


### PR DESCRIPTION
On the Windows platform, when a mouse cursor captured with SDL_CaptureMouse leaves the window client area, the SDL fire a SDL_WINDOWEVENT_LEAVE event followed immediately by a SDL_WINDOWEVENT_ENTER event on every cursor movement. As a side effect, the reported relative motion is always 0.
```
// The captured mouse cursor leaves the window
SDL_WINDOWEVENT_LEAVE
SDL_WINDOWEVENT_ENTER
SDL_MOUSEMOTION X=-1 Y=149 XRel=0 YRel=0

SDL_WINDOWEVENT_LEAVE
SDL_WINDOWEVENT_ENTER
SDL_MOUSEMOTION X=-3 Y=150 XRel=0 YRel=0

SDL_WINDOWEVENT_LEAVE
SDL_WINDOWEVENT_ENTER
SDL_MOUSEMOTION X=-4 Y=151 XRel=0 YRel=0

SDL_WINDOWEVENT_LEAVE
SDL_WINDOWEVENT_ENTER
SDL_MOUSEMOTION X=-5 Y=152 XRel=0 YRel=0

SDL_WINDOWEVENT_LEAVE
SDL_WINDOWEVENT_ENTER
SDL_MOUSEMOTION X=-6 Y=153 XRel=0 YRel=0

SDL_WINDOWEVENT_LEAVE
SDL_WINDOWEVENT_ENTER
SDL_MOUSEMOTION X=-7 Y=154 XRel=0 YRel=0

// SDL_CaptureMouse is disabled
SDL_WINDOWEVENT_LEAVE
```
The fix is to not set the mouse focus to null if the mouse cursor is captured when it leaves the window client area.

Fix https://github.com/libsdl-org/SDL/issues/2385 and may help with https://github.com/libsdl-org/SDL/issues/4789

The minimal code to test it :
```
#include "SDL.h"

int main(int, char**)
{
	SDL_Init(SDL_INIT_VIDEO);
	SDL_Window* window = SDL_CreateWindow("Window", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 800, 600, SDL_WINDOW_RESIZABLE);

	bool run = true;
	while (run)
	{
		SDL_Event event;
		while (SDL_PollEvent(&event))
		{
			switch (event.type)
			{
			case SDL_MOUSEBUTTONDOWN:
				if (event.button.button & SDL_BUTTON_LEFT)
					SDL_CaptureMouse(SDL_TRUE);
				break;
			case SDL_MOUSEBUTTONUP:
				if (event.button.button & SDL_BUTTON_LEFT)
					SDL_CaptureMouse(SDL_FALSE);
				break;
			case SDL_MOUSEMOTION:
				SDL_Log("SDL_MOUSEMOTION X=%d Y=%d XRel=%d YRel=%d", event.motion.x, event.motion.y, event.motion.xrel, event.motion.yrel);
				break;
			case SDL_WINDOWEVENT:
				if (event.window.event == SDL_WINDOWEVENT_ENTER)
					SDL_Log("SDL_WINDOWEVENT_ENTER");
				if (event.window.event == SDL_WINDOWEVENT_LEAVE)
					SDL_Log("SDL_WINDOWEVENT_LEAVE");
				break;
			case SDL_QUIT:
				run = false;
				break;
			}
		}
	}

	SDL_DestroyWindow(window);
	SDL_Quit();

	return 0;
}
```