### PR TITLE
Ensure that SDL_InitSubSystem quits subsystems after an error.

### DIFF
--- a/src/SDL.c
+++ b/src/SDL.c
@@ -154,7 +154,7 @@ SDL_InitSubSystem(Uint32 flags)
     
     if (!SDL_MainIsReady) {
         SDL_SetError("Application didn't initialize properly, did you include SDL_main.h in the file containing your main() function?");
-        return (-1);
+        return -1;
     }
 
     /* Clear the error message */


### PR DESCRIPTION
## Description
When `SDL_InitSubSystem` fails it will call `SDL_SubSystemQuit` on those subsystems that were initialized prior to the error.

## Existing Issue(s)
#4826
