### PR TITLE
Add SDL_SetModalLoopCallback, SDL_SetModalLoopResizeCallback and SDL_SetModalLoopMoveCallback functions

### DIFF
--- a/include/SDL_events.h
+++ b/include/SDL_events.h
@@ -1151,6 +1151,60 @@ extern DECLSPEC Uint8 SDLCALL SDL_EventState(Uint32 type, int state);
  */
 extern DECLSPEC Uint32 SDLCALL SDL_RegisterEvents(int numevents);
 
+typedef void (SDLCALL * SDL_ModalLoopCallback)(void*);
+
+/**
+ * Set a callback to be called during a window modal loop.
+ *
+ * This can be used to run some logic and keep the app running when it is stuck
+ * in a modal loop.
+ *
+ * \param callback the function to call in the window modal loop
+ * \param userdata a pointer that is passed to `callback`
+ *
+ * \since This function is available since SDL 2.24.0.
+ *
+ * \sa SDL_SetModalLoopResizeCallback
+ * \sa SDL_SetModalLoopMoveCallback
+ */
+extern DECLSPEC void SDLCALL SDL_SetModalLoopCallback(SDL_ModalLoopCallback callback, void* userdata);
+
+typedef void (SDLCALL * SDL_ModalLoopResizeCallback)(SDL_Window*, int, int, void*);
+
+/**
+ * Set a callback to be called when a window is resized in a modal loop.
+ *
+ * During a modal loop, you won't get any SDL events, so in order to handle
+ * the window resizing in this case, use this function.
+ *
+ * \param callback the function to call when the window is resized in the modal loop
+ * \param userdata a pointer that is passed to `callback`
+ *
+ * \since This function is available since SDL 2.24.0.
+ *
+ * \sa SDL_SetModalLoopCallback
+ * \sa SDL_SetModalLoopMoveCallback
+ */
+extern DECLSPEC void SDLCALL SDL_SetModalLoopResizeCallback(SDL_ModalLoopResizeCallback resize_callback, void* userdata);
+
+typedef void (SDLCALL * SDL_ModalLoopMoveCallback)(SDL_Window*, int, int, void*);
+
+/**
+ * Set a callback to be called when a window is moved in a modal loop.
+ *
+ * During a modal loop, you won't get any SDL events, so in order to handle
+ * the window move in this case, use this function.
+ *
+ * \param callback the function to call when the window is moved in the modal loop
+ * \param userdata a pointer that is passed to `callback`
+ *
+ * \since This function is available since SDL 2.24.0.
+ *
+ * \sa SDL_SetModalLoopCallback
+ * \sa SDL_SetModalLoopResizeCallback
+ */
+extern DECLSPEC void SDLCALL SDL_SetModalLoopMoveCallback(SDL_ModalLoopMoveCallback move_callback, void* userdata);
+
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus
 }

--- a/src/dynapi/SDL2.exports
+++ b/src/dynapi/SDL2.exports
@@ -849,3 +849,6 @@
 ++'_SDL_HasLASX'.'SDL2.dll'.'SDL_HasLASX'
 ++'_SDL_RenderGetD3D12Device'.'SDL2.dll'.'SDL_RenderGetD3D12Device'
 ++'_SDL_utf8strnlen'.'SDL2.dll'.'SDL_utf8strnlen'
+++'_SDL_SetModalLoopCallback'.'SDL2.dll'.'SDL_SetModalLoopCallback'
+++'_SDL_SetModalLoopResizeCallback'.'SDL2.dll'.'SDL_SetModalLoopResizeCallback'
+++'_SDL_SetModalLoopMoveCallback'.'SDL2.dll'.'SDL_SetModalLoopMoveCallback'

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -875,3 +875,6 @@
 #define SDL_HasLASX SDL_HasLASX_REAL
 #define SDL_RenderGetD3D12Device SDL_RenderGetD3D12Device_REAL
 #define SDL_utf8strnlen SDL_utf8strnlen_REAL
+#define SDL_SetModalLoopCallback SDL_SetModalLoopCallback_REAL
+#define SDL_SetModalLoopResizeCallback SDL_SetModalLoopResizeCallback_REAL
+#define SDL_SetModalLoopMoveCallback SDL_SetModalLoopMoveCallback_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -952,3 +952,6 @@ SDL_DYNAPI_PROC(SDL_bool,SDL_HasLASX,(void),(),return)
 SDL_DYNAPI_PROC(ID3D12Device*,SDL_RenderGetD3D12Device,(SDL_Renderer *a),(a),return)
 #endif
 SDL_DYNAPI_PROC(size_t,SDL_utf8strnlen,(const char *a, size_t b),(a,b),return)
+SDL_DYNAPI_PROC(void,SDL_SetModalLoopCallback,(SDL_ModalLoopCallback a, void *b),(a,b),)
+SDL_DYNAPI_PROC(void,SDL_SetModalLoopResizeCallback,(SDL_ModalLoopResizeCallback a, void *b),(a,b),)
+SDL_DYNAPI_PROC(void,SDL_SetModalLoopMoveCallback,(SDL_ModalLoopMoveCallback a, void *b),(a,b),)

--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -1415,4 +1415,59 @@ SDL_EventsQuit(void)
 #endif
 }
 
+static SDL_ModalLoopCallback SDL_modal_loop_callback = NULL;
+static void* SDL_modal_loop_userdata = NULL;
+
+void
+SDL_SetModalLoopCallback(SDL_ModalLoopCallback callback, void* userdata)
+{
+    SDL_modal_loop_callback = callback;
+    SDL_modal_loop_userdata = userdata;
+}
+
+void
+SDL_ExecuteModalLoopCallback(void)
+{
+    if (SDL_modal_loop_callback) {
+        SDL_modal_loop_callback(SDL_modal_loop_userdata);
+    }
+}
+
+static SDL_ModalLoopResizeCallback SDL_modal_loop_resize_callback = NULL;
+static void* SDL_modal_loop_resize_userdata = NULL;
+
+void
+SDL_SetModalLoopResizeCallback(SDL_ModalLoopResizeCallback resizeCallback, void* userdata)
+{
+    SDL_modal_loop_resize_callback = resizeCallback;
+    SDL_modal_loop_resize_userdata = userdata;
+}
+
+extern void
+SDL_ExecuteModalLoopResizeCallback(SDL_Window* window, int w, int h)
+{
+    if (SDL_modal_loop_resize_callback) {
+        SDL_modal_loop_resize_callback(window, w, h, SDL_modal_loop_resize_userdata);
+    }
+}
+
+static SDL_ModalLoopMoveCallback SDL_modal_loop_move_callback = NULL;
+static void* SDL_modal_loop_move_userdata = NULL;
+
+void
+SDL_SetModalLoopMoveCallback(SDL_ModalLoopMoveCallback moveCallback, void* userdata)
+{
+    SDL_modal_loop_move_callback = moveCallback;
+    SDL_modal_loop_move_userdata = userdata;
+}
+
+extern void
+SDL_ExecuteModalLoopMoveCallback(SDL_Window* window, int x, int y)
+{
+    if (SDL_modal_loop_move_callback) {
+        SDL_modal_loop_move_callback(window, x, y, SDL_modal_loop_move_userdata);
+    }
+}
+
+
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/events/SDL_events_c.h
+++ b/src/events/SDL_events_c.h
@@ -58,6 +58,10 @@ extern void SDL_SendPendingSignalEvents(void);
 extern int SDL_QuitInit(void);
 extern void SDL_QuitQuit(void);
 
+extern void SDL_ExecuteModalLoopCallback(void);
+extern void SDL_ExecuteModalLoopResizeCallback(SDL_Window* window, int w, int h);
+extern void SDL_ExecuteModalLoopMoveCallback(SDL_Window* window, int x, int y);
+
 #endif /* SDL_events_c_h_ */
 
 /* vi: set ts=4 sw=4 expandtab: */


### PR DESCRIPTION
Add three functions to set callbacks to be called during a window modal loop, allowing the user to keep his app running when it happens.

The message handling require more work to ensure it is robust enough and that there's no corner case left out.

Fix https://github.com/libsdl-org/SDL/issues/1059