### PR TITLE
Update android sdk version, because preferMinimalPostProcessing not found

### DIFF
--- a/android-project/app/build.gradle
+++ b/android-project/app/build.gradle
@@ -8,13 +8,13 @@ else {
 }
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 30
     defaultConfig {
         if (buildAsApplication) {
             applicationId "org.libsdl.app"
         }
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         externalNativeBuild {


### PR DESCRIPTION
It is necessary to raise the version of the Android SDK used during the assembly, since AndroidManifest.xml requires the preferMinimalPostProcessing attribute, and it appeared only with API 30: 
https://developer.android.com/reference/android/R.attr#preferMinimalPostProcessing

Without this, we will receive an error during assembly:
error: attribute android:preferMinimalPostProcessing not found.
