### PR TITLE
video/uikit: Do not use setNeedsUpdateOfPrefersPointerLocked on iOS SDKs older than 14

### DIFF
--- a/src/video/uikit/SDL_uikitwindow.m
+++ b/src/video/uikit/SDL_uikitwindow.m
@@ -324,6 +324,7 @@ void
 UIKit_SetWindowMouseGrab(_THIS, SDL_Window * window, SDL_bool grabbed)
 {
 #if !TARGET_OS_TV
+#if defined(__IPHONE_14_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0
     @autoreleasepool {
         SDL_WindowData *data = (__bridge SDL_WindowData *) window->driverdata;
         SDL_uikitviewcontroller *viewcontroller = data.viewcontroller;
@@ -331,6 +332,7 @@ UIKit_SetWindowMouseGrab(_THIS, SDL_Window * window, SDL_bool grabbed)
             [viewcontroller setNeedsUpdateOfPrefersPointerLocked];
         }
     }
+#endif /* defined(__IPHONE_14_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0 */
 #endif /* !TARGET_OS_TV */
 }
 


### PR DESCRIPTION

## Description

Do not use `setNeedsUpdateOfPrefersPointerLocked` on iOS SDKs older than 14.  
This allows SDL2 to compile on older SDK/Xcode versions e.g. 10.0 for iPhone 5.  

This will fix the following error when building on older SDK/Xcode versions:
```
No visible @interface for 'SDL_uikitviewcontroller' declares the selector 'setNeedsUpdateOfPrefersPointerLocked'
```
