### PR TITLE
Add SDL_{Read,Write}PixelValue() functions (was Fix a number of OOB/Alignment/Endianness issues with reading/writing pixels)

### DIFF
--- a/include/SDL_pixels.h
+++ b/include/SDL_pixels.h
@@ -627,6 +627,57 @@ extern DECLSPEC void SDLCALL SDL_GetRGBA(Uint32 pixel,
  */
 extern DECLSPEC void SDLCALL SDL_CalculateGammaRamp(float gamma, Uint16 * ramp);
 
+/**
+ * Read one pixel's worth of data for a given pixel format.
+ *
+ * This is probably not the function you're looking for for general purpose
+ * rendering! Use SDL_Renderer or the SDL_Surface functions instead if you can:
+ * they'll be much faster, and are harder to misuse.
+ *
+ * If you're using this function to read from an SDL_Surface, you'll want to
+ * lock the surface first with SDL_LockSurface, and calculate the pointer to
+ * the pixel you wish to read from the pixel's coordinates, the surface pitch
+ * and the surface format's BytesPerPixel.
+ * The return value of this should usually be passed to SDL_GetRGB or
+ * SDL_GetRGBA. 
+ *
+ * \param data a pointer to the pixel's data
+ * \param format an SDL_PixelFormat structure describing the format of the pixel
+ * \returns a pixel value suitable for passing to SDL_GetRGB or SDL_GetRGBA
+ *
+ * \since This function is available since SDL 2.0.18
+ *
+ * \sa SDL_WritePixelValue
+ * \sa SDL_GetRGB
+ * \sa SDL_GetRGBA
+ */
+extern DECLSPEC Uint32 SDLCALL SDL_ReadPixelValue(void *data, SDL_PixelFormat *format);
+
+/**
+ * Write one pixel's worth of data for a given pixel format.
+ *
+ * This is probably not the function you're looking for for general purpose
+ * rendering! Use SDL_Renderer or the SDL_Surface functions instead if you can:
+ * they'll be much faster, and are harder to misuse.
+ *
+ * If you're using this function to write to an SDL_Surface, you'll want to
+ * lock the surface first with SDL_LockSurface, and calculate the pointer to
+ * the pixel you wish to read from the pixel's coordinates, the surface pitch
+ * and the surface format's BytesPerPixel.
+ * The value passed to this function should usually be calculated with
+ * SDL_MapRGB or SDL_MapRGBA.
+ *
+ * \param data a pointer to the memory where the pixel data is to be written
+ * \param format an SDL_PixelFormat structure describing the format of the pixel
+ * \param value a pixel value in the format you'd get from SDL_MapRGB or SDL_MapRGBA
+ *
+ * \since This function is available since SDL 2.0.18
+ *
+ * \sa SDL_ReadPixelValue
+ * \sa SDL_MapRGB
+ * \sa SDL_MapRGBA
+ */
+extern DECLSPEC void SDLCALL SDL_WritePixelValue(void *data, SDL_PixelFormat *format, Uint32 value);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -825,3 +825,5 @@
 #define SDL_GetWindowICCProfile SDL_GetWindowICCProfile_REAL
 #define SDL_GetTicks64 SDL_GetTicks64_REAL
 #define SDL_LinuxSetThreadPriorityAndPolicy SDL_LinuxSetThreadPriorityAndPolicy_REAL
+#define SDL_ReadPixelValue SDL_ReadPixelValue_REAL
+#define SDL_WritePixelValue SDL_WritePixelValue_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -894,3 +894,5 @@ SDL_DYNAPI_PROC(Uint64,SDL_GetTicks64,(void),(),return)
 #ifdef __LINUX__
 SDL_DYNAPI_PROC(int,SDL_LinuxSetThreadPriorityAndPolicy,(Sint64 a, int b, int c),(a,b,c),return)
 #endif
+SDL_DYNAPI_PROC(Uint32,SDL_ReadPixelValue,(void *a, SDL_PixelFormat *b),(a,b),return)
+SDL_DYNAPI_PROC(void,SDL_WritePixelValue,(void *a, SDL_PixelFormat *b, Uint32 c),(a,b,c),)

--- a/src/test/SDL_test_compare.c
+++ b/src/test/SDL_test_compare.c
@@ -42,6 +42,7 @@ int SDLTest_CompareSurfaces(SDL_Surface *surface, SDL_Surface *referenceSurface,
    int i,j;
    int bpp, bpp_reference;
    Uint8 *p, *p_reference;
+   Uint32 p_value = 0, p_reference_value = 0;
    int dist;
    int sampleErrorX = 0, sampleErrorY = 0, sampleDist = 0;
    Uint8 R, G, B, A;
@@ -75,9 +76,15 @@ int SDLTest_CompareSurfaces(SDL_Surface *surface, SDL_Surface *referenceSurface,
       for (i=0; i<surface->w; i++) {
          p  = (Uint8 *)surface->pixels + j * surface->pitch + i * bpp;
          p_reference = (Uint8 *)referenceSurface->pixels + j * referenceSurface->pitch + i * bpp_reference;
+         
+         /* Read a pixel from surface (p) */
+         p_value = SDL_ReadPixelValue(p, surface->format);
 
-         SDL_GetRGBA(*(Uint32*)p, surface->format, &R, &G, &B, &A);
-         SDL_GetRGBA(*(Uint32*)p_reference, referenceSurface->format, &Rd, &Gd, &Bd, &Ad);
+         /* Read a pixel from referenceSurface (p_reference) */
+         p_reference_value = SDL_ReadPixelValue(p_reference, referenceSurface->format);
+
+         SDL_GetRGBA(p_value, surface->format, &R, &G, &B, &A);
+         SDL_GetRGBA(p_reference_value, referenceSurface->format, &Rd, &Gd, &Bd, &Ad);
 
          dist = 0;
          dist += (R-Rd)*(R-Rd);

--- a/src/video/SDL_pixels.c
+++ b/src/video/SDL_pixels.c
@@ -1227,6 +1227,59 @@ SDL_CalculateGammaRamp(float gamma, Uint16 * ramp)
     }
 }
 
+Uint32
+SDL_ReadPixelValue(void *data, SDL_PixelFormat *format)
+{
+    Uint8 *src_px = (Uint8 *)data;
+
+    /* Return the correct number of bytes in the correct endianness */
+    switch(format->BytesPerPixel) {
+        case 1:
+            return *src_px;
+        case 2:
+            return *(Uint16*)src_px;
+        case 3:
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+            return ((Uint32)src_px[0] << 16) | ((Uint32)src_px[1] << 8) | ((Uint32)src_px[2] << 0);
+#else
+            return ((Uint32)src_px[2] << 16) | ((Uint32)src_px[1] << 8) | ((Uint32)src_px[0] << 0);
+#endif
+        case 4:
+            return *(Uint32*)src_px;
+    }
+
+    /* Invalid pixel format. */
+    return 0;
+}
+
+void
+SDL_WritePixelValue(void *data, SDL_PixelFormat *format, Uint32 value)
+{
+    Uint8 *pixmem = (Uint8 *)data;
+    switch(format->BytesPerPixel) {
+        case 1:
+            *pixmem = value;
+            break;
+        case 2:
+            *(Uint16*)pixmem = value;
+            break;
+        case 3:
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+            pixmem[0] = (value >> 16) & 0xFF;
+            pixmem[1] = (value >> 8) & 0xFF;
+            pixmem[2] = (value >> 0) & 0xFF;
+#else
+            pixmem[2] = (value >> 16) & 0xFF;
+            pixmem[1] = (value >> 8) & 0xFF;
+            pixmem[0] = (value >> 0) & 0xFF;
+#endif
+            break;
+        case 4:
+            *(Uint32*)pixmem = value;
+            break;
+    }
+}
+
 /* Creates a copy of an ARGB8888-format surface's pixels with premultiplied alpha */
 void
 SDL_PremultiplySurfaceAlphaToARGB8888(SDL_Surface *src, Uint32 *dst)

--- a/src/video/SDL_pixels.c
+++ b/src/video/SDL_pixels.c
@@ -1291,10 +1291,14 @@ SDL_PremultiplySurfaceAlphaToARGB8888(SDL_Surface *src, Uint32 *dst)
         SDL_LockSurface(src);
 
     for (y = 0; y < src->h; ++y) {
-        Uint32 *src_px = (Uint32*)((Uint8 *)src->pixels + (y * src->pitch));
+        Uint8 *src_px = (Uint8 *)src->pixels + (y * src->pitch);
         for (x = 0; x < src->w; ++x) {
+            /* Get the next pixel's value. */
+            Uint32 pixel_value = SDL_ReadPixelValue(src_px, src->format);
+            src_px += src->format->BytesPerPixel;
+
             /* Component bytes extraction. */
-            SDL_GetRGBA(*src_px++, src->format, &R, &G, &B, &A);
+            SDL_GetRGBA(pixel_value, src->format, &R, &G, &B, &A);
 
             /* Alpha pre-multiplication of each component. */
             R = ((Uint32)A * R) / 255;

--- a/src/video/SDL_shape.c
+++ b/src/video/SDL_shape.c
@@ -83,22 +83,8 @@ SDL_CalculateShapeBitmap(SDL_WindowShapeMode mode,SDL_Surface *shape,Uint8* bitm
         bitmap_scanline = bitmap + y * bytes_per_scanline;
         for(x=0;x<shape->w;x++) {
             alpha = 0;
-            pixel_value = 0;
             pixel = (Uint8 *)(shape->pixels) + (y*shape->pitch) + (x*shape->format->BytesPerPixel);
-            switch(shape->format->BytesPerPixel) {
-                case(1):
-                    pixel_value = *pixel;
-                    break;
-                case(2):
-                    pixel_value = *(Uint16*)pixel;
-                    break;
-                case(3):
-                    pixel_value = *(Uint32*)pixel & (~shape->format->Amask);
-                    break;
-                case(4):
-                    pixel_value = *(Uint32*)pixel;
-                    break;
-            }
+            pixel_value = SDL_ReadPixelValue(pixel, shape->format);
             SDL_GetRGBA(pixel_value,shape->format,&r,&g,&b,&alpha);
             switch(mode.mode) {
                 case(ShapeModeDefault):

--- a/test/testgesture.c
+++ b/test/testgesture.c
@@ -58,7 +58,7 @@ static Knob knob = { 0.0f, 0.1f, { 0.0f, 0.0f } };
 static void
 setpix(SDL_Surface *screen, float _x, float _y, unsigned int col)
 {
-    Uint32 *pixmem32;
+    Uint8 *pixmem;
     Uint32 colour;
     Uint8 r, g, b;
     const int x = (int)_x;
@@ -69,9 +69,9 @@ setpix(SDL_Surface *screen, float _x, float _y, unsigned int col)
         return;
     }
 
-    pixmem32 = (Uint32 *) screen->pixels + y * screen->pitch / BPP + x;
+    pixmem = (Uint8 *) screen->pixels + y * screen->pitch + x * screen->format->BytesPerPixel;
 
-    SDL_memcpy(&colour, pixmem32, screen->format->BytesPerPixel);
+    colour = SDL_ReadPixelValue(pixmem, screen->format);
 
     SDL_GetRGB(colour,screen->format,&r,&g,&b);
 
@@ -87,7 +87,7 @@ setpix(SDL_Surface *screen, float _x, float _y, unsigned int col)
     b = (Uint8) (b * (1 - a) + ((col >> 0) & 0xFF) * a);
     colour = SDL_MapRGB(screen->format, r, g, b);
 
-    *pixmem32 = colour;
+    SDL_WritePixelValue(pixmem, screen->format, colour);
 }
 
 #if 0 /* unused */


### PR DESCRIPTION
As @0x1F9F1 pointed out for ``SDL_PremultiplySurfaceAlphaToARGB8888()`` [here](https://github.com/libsdl-org/SDL/commit/84808ea4bbd12ac212ff7a4ef82d426f6d771e99#commitcomment-58499396), it's not correct to read a pixel from a non-32bit surface by taking a pointer to the pixel, casting it to a ``Uint32*``, dereferencing it, and using ``SDL_GetRGBA()``.

This is for three reasons:
- It could read beyond the bounds of the surface data for the last few pixels.
- Reads may not be 32-bit aligned, which can fault (or at least have performance problems) on some architectures.
- On big-endian systems, the correct pixel may be loaded into the higher-order bits of the ``Uint32``, which would lead to the wrong value being returned (either an adjacent pixel or garbage).

This wasn't actually causing any serious problems for ``SDL_PremultiplySurfaceAlphaToARGB8888()``, as the input is always ARGB8888 anyway, but it's worth having it be correct if we can. There also were a few other places in SDL (and, more particularly, the test programs), which had similar issues. This PR fixes all of the ones I found, by copying (and improving the 24-bit case of) the implementation in ``SDL_CalculateShapeBitmap()``.

There's probably a pretty good case for having some (probably user-accessible) PSet/PGet functions which do this for you, as it's quite easy to get wrong, and this code is now duplicated several times. This hopefully should do for now, though.