### PR TITLE
test: Fix building with libunwind under autotools

### DIFF
--- a/src/test/SDL_test_memory.c
+++ b/src/test/SDL_test_memory.c
@@ -26,6 +26,7 @@
 #include "SDL_test_memory.h"
 
 #ifdef HAVE_LIBUNWIND_H
+#define UNW_LOCAL_ONLY
 #include <libunwind.h>
 #endif
 

--- a/test/configure.ac
+++ b/test/configure.ac
@@ -192,6 +192,13 @@ if test x$have_SDL_ttf = xyes; then
 fi
 AC_SUBST(SDL_TTF_LIB)
 
+dnl Really, SDL2_test should be linking against libunwind (if it found
+dnl libunwind.h when configured), but SDL2_test is a static library, so
+dnl there's no way for it to link against it. We could make SDL2 depend on
+dnl it, but we don't want all SDL2 build to suddenly gain an extra dependency,
+dnl so just assume that if it's here now, SDL2_test was probably built with it.
+PKG_CHECK_MODULES(libunwind, libunwind, [LIBS="$LIBS $libunwind_LIBS"])
+
 dnl Finally create all the generated files
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
There are two issues which are stopping the SDL tests from building on
my machine:
- libunwind is not being linked
- Even if it is, it is missing several symbols.

The first is fixed by having the test programs link against libunwind if
available. Technically, SDL2_test should be linking against it, as it's
used in SDL_test_memory.c, but as SDL2_test is a static library, it
can't itself import libunwind. We just assume that if it's present on
the system, we should link it directly to the test programs. This should
strictly be an improvement, as the only case where this'd fail is if
SDL2 was compiled when libunwind was present, but the tests are being
compiled without it, and that'd fail anyway.

The second is fixed by #define-ing UNW_LOCAL_ONLY before including
libunwind.h: this is required to make libunwind link to predicatable
symbols, in what can only be described as a bit of a farce. There are a
few more details in the libunwind man page, but the gist of it is that
it disables support for "remote unwinding": unwinding stack frames in a
different process (and possibly from a different architecture?):
http://www.nongnu.org/libunwind/man/libunwind(3).html

Note that I haven't tried this with CMake: I suspect that it'll work,
though, as the CMakeLists.txt seems to have SDL2 link against libunwind if
it's present. This adds an ugly extra dependency to SDL2, but does mean
that issue 1 isn't present. The UNW_LOCAL_ONLY change shouldn't be
build-system-specific.
