### PR TITLE
macOS: Fix implicit integer downcast warnings

### DIFF
--- a/src/video/cocoa/SDL_cocoawindow.h
+++ b/src/video/cocoa/SDL_cocoawindow.h
@@ -48,7 +48,7 @@ typedef enum
     BOOL inFullscreenTransition;
     PendingWindowOperation pendingWindowOperation;
     BOOL isMoving;
-    int focusClickPending;
+    NSInteger focusClickPending;
     int pendingWindowWarpX, pendingWindowWarpY;
     BOOL isDragAreaRunning;
 }
@@ -64,8 +64,8 @@ typedef enum
 
 -(BOOL) isMoving;
 -(BOOL) isMovingOrFocusClickPending;
--(void) setFocusClickPending:(int) button;
--(void) clearFocusClickPending:(int) button;
+-(void) setFocusClickPending:(NSInteger) button;
+-(void) clearFocusClickPending:(NSInteger) button;
 -(void) setPendingMoveX:(int)x Y:(int)y;
 -(void) windowDidFinishMoving;
 -(void) onMovingOrFocusClickPendingStateCleared;

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -515,12 +515,12 @@ SetWindowStyle(SDL_Window * window, NSUInteger style)
     return isMoving || (focusClickPending != 0);
 }
 
--(void) setFocusClickPending:(int) button
+-(void) setFocusClickPending:(NSInteger) button
 {
     focusClickPending |= (1 << button);
 }
 
--(void) clearFocusClickPending:(int) button
+-(void) clearFocusClickPending:(NSInteger) button
 {
     if ((focusClickPending & (1 << button)) != 0) {
         focusClickPending &= ~(1 << button);


### PR DESCRIPTION
These focusClickPending functions are called by passing in `[NSEvent buttonNumber]`, which returns NSInteger (64 bit) rather than int. I don't believe it's causing any real problems in practice, though.
