### PR TITLE
timer: Added SDL_GetTicks64(), for a timer that doesn't wrap every ~49 days.

### DIFF
--- a/include/SDL_timer.h
+++ b/include/SDL_timer.h
@@ -42,24 +42,26 @@ extern "C" {
  *
  * This value wraps if the program runs for more than ~49 days.
  *
- * \deprecated This function is deprecated as of SDL 2.0.18; use
- *             SDL_GetTicks64() instead, where the value doesn't wrap
- *             every ~49 days.
+ * This function is not recommended as of SDL 2.0.18; use SDL_GetTicks64()
+ * instead, where the value doesn't wrap every ~49 days. There are places in
+ * SDL where we provide a 32-bit timestamp that can not change without
+ * breaking binary compatibility, though, so this function isn't officially
+ * deprecated.
  *
  * \returns an unsigned 32-bit value representing the number of milliseconds
  *          since the SDL library initialized.
  *
  * \sa SDL_TICKS_PASSED
  */
-extern SDL_DEPRECATED DECLSPEC Uint32 SDLCALL SDL_GetTicks(void);
+extern DECLSPEC Uint32 SDLCALL SDL_GetTicks(void);
 
 /**
  * Get the number of milliseconds since SDL library initialization.
  *
  * Note that you should not use the SDL_TICKS_PASSED macro with values
  * returned by this function, as that macro does clever math to compensate
- * for the 32-bit overflow every ~49 days. 64-bit values can just be safely
- * compared directly.
+ * for the 32-bit overflow every ~49 days that SDL_GetTicks() suffers from.
+ * 64-bit values from this function can be safely compared directly.
  *
  * For example, if you want to wait 100 ms, you could do this:
  *
@@ -83,7 +85,8 @@ extern DECLSPEC Uint64 SDLCALL SDL_GetTicks64(void);
  * days, but should _not_ be used with SDL_GetTicks64(), which does not have
  * that problem.
  *
- * For example, if you want to wait 100 ms, you could do this:
+ * For example, with SDL_GetTicks(), if you want to wait 100 ms, you could
+ * do this:
  *
  * ```c
  * const Uint32 timeout = SDL_GetTicks() + 100;

--- a/include/SDL_timer.h
+++ b/include/SDL_timer.h
@@ -42,20 +42,51 @@ extern "C" {
  *
  * This value wraps if the program runs for more than ~49 days.
  *
+ * \deprecated This function is deprecated as of SDL 2.0.18; use
+ *             SDL_GetTicks64() instead, where the value doesn't wrap
+ *             every ~49 days.
+ *
  * \returns an unsigned 32-bit value representing the number of milliseconds
  *          since the SDL library initialized.
  *
  * \sa SDL_TICKS_PASSED
  */
-extern DECLSPEC Uint32 SDLCALL SDL_GetTicks(void);
+extern SDL_DEPRECATED DECLSPEC Uint32 SDLCALL SDL_GetTicks(void);
 
 /**
- * Compare SDL ticks values, and return true if `A` has passed `B`.
+ * Get the number of milliseconds since SDL library initialization.
+ *
+ * Note that you should not use the SDL_TICKS_PASSED macro with values
+ * returned by this function, as that macro does clever math to compensate
+ * for the 32-bit overflow every ~49 days. 64-bit values can just be safely
+ * compared directly.
  *
  * For example, if you want to wait 100 ms, you could do this:
  *
- * ```c++
- * Uint32 timeout = SDL_GetTicks() + 100;
+ * ```c
+ * const Uint64 timeout = SDL_GetTicks64() + 100;
+ * while (SDL_GetTicks64() < timeout) {
+ *     // ... do work until timeout has elapsed
+ * }
+ * ```
+ *
+ * \returns an unsigned 64-bit value representing the number of milliseconds
+ *          since the SDL library initialized.
+ */
+extern DECLSPEC Uint64 SDLCALL SDL_GetTicks64(void);
+
+/**
+ * Compare 32-bit SDL ticks values, and return true if `A` has passed `B`.
+ *
+ * This should be used with results from SDL_GetTicks(), as this macro
+ * attempts to deal with the 32-bit counter wrapping back to zero every ~49
+ * days, but should _not_ be used with SDL_GetTicks64(), which does not have
+ * that problem.
+ *
+ * For example, if you want to wait 100 ms, you could do this:
+ *
+ * ```c
+ * const Uint32 timeout = SDL_GetTicks() + 100;
  * while (!SDL_TICKS_PASSED(SDL_GetTicks(), timeout)) {
  *     // ... do work until timeout has elapsed
  * }

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -823,3 +823,4 @@
 #define SDL_asprintf SDL_asprintf_REAL
 #define SDL_vasprintf SDL_vasprintf_REAL
 #define SDL_GetWindowICCProfile SDL_GetWindowICCProfile_REAL
+#define SDL_GetTicks64 SDL_GetTicks64_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -890,3 +890,4 @@ SDL_DYNAPI_PROC(int,SDL_asprintf,(char **a, SDL_PRINTF_FORMAT_STRING const char 
 #endif
 SDL_DYNAPI_PROC(int,SDL_vasprintf,(char **a, const char *b, va_list c),(a,b,c),return)
 SDL_DYNAPI_PROC(void*,SDL_GetWindowICCProfile,(SDL_Window *a, size_t *b),(a,b),return)
+SDL_DYNAPI_PROC(Uint64,SDL_GetTicks64,(void),(),return)

--- a/src/timer/SDL_timer.c
+++ b/src/timer/SDL_timer.c
@@ -370,4 +370,14 @@ SDL_RemoveTimer(SDL_TimerID id)
     return canceled;
 }
 
+/* This is a legacy support function; SDL_GetTicks() returns a Uint32,
+   which wraps back to zero every ~49 days. The newer SDL_GetTicks64()
+   doesn't have this problem, so we just wrap that function and clamp to
+   the low 32-bits for binary compatibility. */
+Uint32
+SDL_GetTicks(void)
+{
+    return (Uint32) (SDL_GetTicks64() & 0xFFFFFFFF);
+}
+
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/timer/dummy/SDL_systimer.c
+++ b/src/timer/dummy/SDL_systimer.c
@@ -41,8 +41,8 @@ SDL_TicksQuit(void)
     ticks_started = SDL_FALSE;
 }
 
-Uint32
-SDL_GetTicks(void)
+Uint64
+SDL_GetTicks64(void)
 {
     if (!ticks_started) {
         SDL_TicksInit();

--- a/src/timer/haiku/SDL_systimer.c
+++ b/src/timer/haiku/SDL_systimer.c
@@ -47,14 +47,14 @@ SDL_TicksQuit(void)
     ticks_started = SDL_FALSE;
 }
 
-Uint32
-SDL_GetTicks(void)
+Uint64
+SDL_GetTicks64(void)
 {
     if (!ticks_started) {
         SDL_TicksInit();
     }
 
-    return ((system_time() - start) / 1000);
+    return (Uint64) ((system_time() - start) / 1000);
 }
 
 Uint64

--- a/src/timer/os2/SDL_systimer.c
+++ b/src/timer/os2/SDL_systimer.c
@@ -40,25 +40,31 @@
 typedef unsigned long long  ULLONG;
 
 static ULONG    ulTmrFreq = 0;
-static ULLONG   ullTmrStart;
+static ULLONG   ullTmrStart = 0;
+
+/* 32-bit counter fallback...not used if DosTmrQuery* is functioning. */
+static ULONG    ulPrevTmr = 0;
+static Uint64   ui64TmrStartOffset = 0;  /* Used if 32-bit counter overflows. */
 
 void
 SDL_TicksInit(void)
 {
-    ULONG   ulRC;
-
-    ulRC = DosTmrQueryFreq(&ulTmrFreq);
+    ULONG ulTmrStart;  /* for 32-bit fallback. */
+    ULONG ulRC = DosTmrQueryFreq(&ulTmrFreq);
     if (ulRC != NO_ERROR) {
         debug_os2("DosTmrQueryFreq() failed, rc = %u", ulRC);
     } else {
         ulRC = DosTmrQueryTime((PQWORD)&ullTmrStart);
-        if (ulRC == NO_ERROR)
+        if (ulRC == NO_ERROR) {
             return;
+        }
         debug_os2("DosTmrQueryTime() failed, rc = %u", ulRC);
     }
 
     ulTmrFreq = 0; /* Error - use DosQuerySysInfo() for timer. */
-    DosQuerySysInfo(QSV_MS_COUNT, QSV_MS_COUNT, (PULONG)&ullTmrStart, sizeof(ULONG));
+    DosQuerySysInfo(QSV_MS_COUNT, QSV_MS_COUNT, &ulTmrStart, sizeof (ULONG));
+    ullTmrStart = (ULLONG) ulTmrStart;
+    ulPrevTmr = ulTmrStart;
 }
 
 void
@@ -66,24 +72,32 @@ SDL_TicksQuit(void)
 {
 }
 
-Uint32
-SDL_GetTicks(void)
+Uint64
+SDL_GetTicks64(void)
 {
-    ULONG   ulResult;
-    ULLONG  ullTmrNow;
+    Uint64 ui64Result;
+    ULLONG ullTmrNow;
 
-    if (ulTmrFreq == 0) /* Was not initialized. */
+    if (ulTmrFreq == 0) { /* Was not initialized. */
         SDL_TicksInit();
+    }
 
     if (ulTmrFreq != 0) {
         DosTmrQueryTime((PQWORD)&ullTmrNow);
-        ulResult = (ullTmrNow - ullTmrStart) * 1000 / ulTmrFreq;
+        ui64Result = (ullTmrNow - ullTmrStart) * 1000 / ulTmrFreq;
     } else {
-        DosQuerySysInfo(QSV_MS_COUNT, QSV_MS_COUNT, (PULONG)&ullTmrNow, sizeof(ULONG));
-        ulResult = (ULONG)ullTmrNow - (ULONG)ullTmrStart;
+        ULONG ulTmrNow;
+        DosQuerySysInfo(QSV_MS_COUNT, QSV_MS_COUNT, &ulTmrNow, sizeof (ULONG));
+        if ( ((ULLONG) ulTmrNow) < ulPrevTmr ) {  /* have we overflowed the 32-bit counter since last check? */
+            /* Note that this is incorrect if you went more than ~98 days between calls to SDL_GetTicks64(). */
+            /* One could query QSV_TIME_HIGH and QSV_TIME_LOW here to verify, but it's probably not worth it. */
+            ui64TmrStartOffset += 0xFFFFFFFF;
+        }
+        ui64Result = (((Uint64) ulTmrNow) - ullTmrStart) + ui64TmrStartOffset;
+        ulPrevTmr = ulTmrNow;
     }
 
-    return ulResult;
+    return ui64Result;
 }
 
 Uint64
@@ -92,7 +106,7 @@ SDL_GetPerformanceCounter(void)
     QWORD   qwTmrNow;
 
     if (ulTmrFreq == 0 || (DosTmrQueryTime(&qwTmrNow) != NO_ERROR))
-        return SDL_GetTicks();
+        return SDL_GetTicks64();
 
     return *((Uint64 *)&qwTmrNow);
 }

--- a/src/timer/psp/SDL_systimer.c
+++ b/src/timer/psp/SDL_systimer.c
@@ -51,24 +51,23 @@ SDL_TicksQuit(void)
     ticks_started = SDL_FALSE;
 }
 
-Uint32 SDL_GetTicks(void)
+Uint64
+SDL_GetTicks64(void)
 {
+    struct timeval now;
+
     if (!ticks_started) {
         SDL_TicksInit();
     }
 
-    struct timeval now;
-    Uint32 ticks;
-
     gettimeofday(&now, NULL);
-    ticks=(now.tv_sec-start.tv_sec)*1000+(now.tv_usec-start.tv_usec)/1000;
-    return(ticks);
+    return (((Uint64)(now.tv_sec-start.tv_sec)) * 1000) + (((Uint64) (now.tv_usec-start.tv_usec)) / 1000);
 }
 
 Uint64
 SDL_GetPerformanceCounter(void)
 {
-    return SDL_GetTicks();
+    return SDL_GetTicks64();
 }
 
 Uint64

--- a/src/timer/unix/SDL_systimer.c
+++ b/src/timer/unix/SDL_systimer.c
@@ -105,7 +105,7 @@ SDL_TicksQuit(void)
 }
 
 Uint64
-SDL_GetTicks(void)
+SDL_GetTicks64(void)
 {
     struct timeval now;
 

--- a/src/timer/unix/SDL_systimer.c
+++ b/src/timer/unix/SDL_systimer.c
@@ -104,10 +104,11 @@ SDL_TicksQuit(void)
     ticks_started = SDL_FALSE;
 }
 
-Uint32
+Uint64
 SDL_GetTicks(void)
 {
-    Uint32 ticks;
+    struct timeval now;
+
     if (!ticks_started) {
         SDL_TicksInit();
     }
@@ -116,21 +117,18 @@ SDL_GetTicks(void)
 #if HAVE_CLOCK_GETTIME
         struct timespec now;
         clock_gettime(SDL_MONOTONIC_CLOCK, &now);
-        ticks = (Uint32)((now.tv_sec - start_ts.tv_sec) * 1000 + (now.tv_nsec - start_ts.tv_nsec) / 1000000);
+        ticks = (((Uint64) (now.tv_sec - start_ts.tv_sec)) * 1000) + (((Uint64) (now.tv_nsec - start_ts.tv_nsec)) / 1000000);
 #elif defined(__APPLE__)
-        uint64_t now = mach_absolute_time();
-        ticks = (Uint32)((((now - start_mach) * mach_base_info.numer) / mach_base_info.denom) / 1000000);
+        const uint64_t now = mach_absolute_time();
+        return (Uint64) ((((now - start_mach) * mach_base_info.numer) / mach_base_info.denom) / 1000000);
 #else
         SDL_assert(SDL_FALSE);
-        ticks = 0;
+        return 0;
 #endif
-    } else {
-        struct timeval now;
-
-        gettimeofday(&now, NULL);
-        ticks = (Uint32)((now.tv_sec - start_tv.tv_sec) * 1000 + (now.tv_usec - start_tv.tv_usec) / 1000);
     }
-    return (ticks);
+
+    gettimeofday(&now, NULL);
+    return (((Uint64) (now.tv_sec - start_tv.tv_sec)) * 1000) + (((Uint64) (now.tv_usec - start_tv.tv_usec)) / 1000);
 }
 
 Uint64
@@ -203,7 +201,7 @@ SDL_Delay(Uint32 ms)
     struct timespec elapsed, tv;
 #else
     struct timeval tv;
-    Uint32 then, now, elapsed;
+    Uint64 then, now, elapsed;
 #endif
 
     /* Set the timeout interval */
@@ -211,7 +209,7 @@ SDL_Delay(Uint32 ms)
     elapsed.tv_sec = ms / 1000;
     elapsed.tv_nsec = (ms % 1000) * 1000000;
 #else
-    then = SDL_GetTicks();
+    then = SDL_GetTicks64();
 #endif
     do {
         errno = 0;
@@ -222,13 +220,13 @@ SDL_Delay(Uint32 ms)
         was_error = nanosleep(&tv, &elapsed);
 #else
         /* Calculate the time interval left (in case of interrupt) */
-        now = SDL_GetTicks();
+        now = SDL_GetTicks64();
         elapsed = (now - then);
         then = now;
-        if (elapsed >= ms) {
+        if (elapsed >= ((Uint64) ms)) {
             break;
         }
-        ms -= elapsed;
+        ms -= (Uint32) elapsed;
         tv.tv_sec = ms / 1000;
         tv.tv_usec = (ms % 1000) * 1000;
 

--- a/src/timer/unix/SDL_systimer.c
+++ b/src/timer/unix/SDL_systimer.c
@@ -117,7 +117,7 @@ SDL_GetTicks64(void)
 #if HAVE_CLOCK_GETTIME
         struct timespec now;
         clock_gettime(SDL_MONOTONIC_CLOCK, &now);
-        ticks = (((Uint64) (now.tv_sec - start_ts.tv_sec)) * 1000) + (((Uint64) (now.tv_nsec - start_ts.tv_nsec)) / 1000000);
+        return (((Uint64) (now.tv_sec - start_ts.tv_sec)) * 1000) + (((Uint64) (now.tv_nsec - start_ts.tv_nsec)) / 1000000);
 #elif defined(__APPLE__)
         const uint64_t now = mach_absolute_time();
         return (Uint64) ((((now - start_mach) * mach_base_info.numer) / mach_base_info.denom) / 1000000);

--- a/src/timer/vita/SDL_systimer.c
+++ b/src/timer/vita/SDL_systimer.c
@@ -51,18 +51,17 @@ SDL_TicksQuit(void)
     ticks_started = SDL_FALSE;
 }
 
-Uint32 SDL_GetTicks(void)
+Uint64
+SDL_GetTicks64(void)
 {
     uint64_t now;
-    Uint32 ticks;
 
     if (!ticks_started) {
         SDL_TicksInit();
     }
 
     now = sceKernelGetProcessTimeWide();
-    ticks = (now - start)/1000;
-    return (ticks);
+    return (Uint64) ((now - start) / 1000);
 }
 
 Uint64

--- a/test/testtimer.c
+++ b/test/testtimer.c
@@ -42,6 +42,7 @@ main(int argc, char *argv[])
 {
     int i, desired;
     SDL_TimerID t1, t2, t3;
+    Uint64 start64, now64;
     Uint32 start32, now32;
     Uint64 start, now;
 
@@ -108,12 +109,14 @@ main(int argc, char *argv[])
     SDL_Log("1 million iterations of ticktock took %f ms\n", (double)((now - start)*1000) / SDL_GetPerformanceFrequency());
 
     SDL_Log("Performance counter frequency: %"SDL_PRIu64"\n", SDL_GetPerformanceFrequency());
+    start64 = SDL_GetTicks64();
     start32 = SDL_GetTicks();
     start = SDL_GetPerformanceCounter();
     SDL_Delay(1000);
     now = SDL_GetPerformanceCounter();
+    now64 = SDL_GetTicks64();
     now32 = SDL_GetTicks();
-    SDL_Log("Delay 1 second = %d ms in ticks, %f ms according to performance counter\n", (now32-start32), (double)((now - start)*1000) / SDL_GetPerformanceFrequency());
+    SDL_Log("Delay 1 second = %d ms in ticks, %d ms in ticks64, %f ms according to performance counter\n", (int) (now32-start32), (int) (now64-start64), (double)((now - start)*1000) / SDL_GetPerformanceFrequency());
 
     SDL_Quit();
     return (0);


### PR DESCRIPTION
Note that this removes the timeGetTime() fallback on Windows; it is a
32-bit counter and SDL2 should never choose to use it, as it only is needed
if QueryPerformanceCounter() isn't available, and QPC is _always_ available
on Windows XP and later.

OS/2 has a similar situation, but since it isn't clear to me that similar
promises can be made about DosTmrQueryTime() even in modern times, I decided
to leave the fallback in, with some heroic measures added to try to provide a
true 64-bit tick counter despite the 49-day wraparound. That approach can
migrate to Windows too, if we discover some truly broken install that doesn't
have QPC and still depends on timeGetTime().

Fixes #4870.

CC @sezero, who might want to make sure I didn't screw up the OS/2 patch.