### PR TITLE
[CMake] aclocal install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2801,7 +2801,7 @@ if(NOT (WINDOWS OR CYGWIN) OR MINGW)
   endif()
   install(PROGRAMS ${SDL2_BINARY_DIR}/sdl2-config DESTINATION "${CMAKE_INSTALL_BINDIR}")
   # TODO: what about the .spec file? Is it only needed for RPM creation?
-  install(FILES "${SDL2_SOURCE_DIR}/sdl2.m4" DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/aclocal")
+  install(FILES "${SDL2_SOURCE_DIR}/sdl2.m4" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/aclocal")
 endif()
 
 ##### Uninstall target #####


### PR DESCRIPTION
Installing `aclocal` with an absolute path prevents `CMAKE_STAGING_PREFIX` from working as expected.  This PR changes `aclocal` to not use absolute path, so that `CMAKE_STAGING_PREFIX` works correctly.

Example usage:  https://github.com/meta-flutter/filament/blob/8a0b3e83d6e129b64dd95021716379ceb6f6d893/third_party/libsdl2/tnt/CMakeLists.txt

## Description
Changes absolute path install to enable usage of CMAKE_STAGING_PREFIX.  If you want to stage the install location, this change is required.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/4875
