### PR TITLE
Wayland: Implement WaitEventTimeout() and SendWakeupEvent()

### DIFF
--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -83,6 +83,8 @@ struct SDL_WaylandInput {
 };
 
 extern void Wayland_PumpEvents(_THIS);
+extern void Wayland_SendWakeupEvent(_THIS, SDL_Window *window);
+extern int Wayland_WaitEventTimeout(_THIS, int timeout);
 
 extern void Wayland_add_data_device_manager(SDL_VideoData *d, uint32_t id, uint32_t version);
 extern void Wayland_add_text_input_manager(SDL_VideoData *d, uint32_t id, uint32_t version);

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -169,6 +169,9 @@ Wayland_DeleteDevice(SDL_VideoDevice *device)
         WAYLAND_wl_display_flush(data->display);
         WAYLAND_wl_display_disconnect(data->display);
     }
+    if (device->wakeup_lock) {
+        SDL_DestroyMutex(device->wakeup_lock);
+    }
     SDL_free(data);
     SDL_free(device);
     SDL_WAYLAND_UnloadSymbols();
@@ -212,6 +215,7 @@ Wayland_CreateDevice(int devindex)
     }
 
     device->driverdata = data;
+    device->wakeup_lock = SDL_CreateMutex();
 
     /* Set the function pointers */
     device->VideoInit = Wayland_VideoInit;
@@ -222,6 +226,8 @@ Wayland_CreateDevice(int devindex)
     device->SuspendScreenSaver = Wayland_SuspendScreenSaver;
 
     device->PumpEvents = Wayland_PumpEvents;
+    device->WaitEventTimeout = Wayland_WaitEventTimeout;
+    device->SendWakeupEvent = Wayland_SendWakeupEvent;
 
     device->GL_SwapWindow = Wayland_GLES_SwapWindow;
     device->GL_GetSwapInterval = Wayland_GLES_GetSwapInterval;


### PR DESCRIPTION
## Description
This implements `WaitEventTimeout()` and `SendWakeupEvent()` to enable the Wayland backend to wait for events without polling to reduce CPU usage and achieve parity with the X11 backend.

The way that Wayland handles key repeat makes this a little more complicated than it would otherwise be, but it's not too bad.

I'm using `wl_display_sync()` to wake up the waiting thread. This could theoretically result in higher wakeup latency due the compositor round trip, but it was always sub-1ms in my testing. We could also create a pipe to use for waking up the waiting thread, but that would make the code more complicated (requiring a new `SDL_IOReady2()` function or something). I'm all ears if anyone has any more clever ideas on how to do the wakeup.

I believe most games are using `SDL_PollEvent()` rather than `SDL_WaitEvent()` and `SDL_WaitEventTimeout()` but maybe @flibitijibibo knows some that we can test this against.