### PR TITLE
Cap maximum wait time if sensor or joystick subsystems are active

### DIFF
--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -881,19 +881,20 @@ SDL_WaitEventTimeout_Device(_THIS, SDL_Window *wakeup_window, SDL_Event * event,
     return 0;
 }
 
-static int
+static SDL_bool
 SDL_events_need_polling() {
     SDL_bool need_polling = SDL_FALSE;
 
 #if !SDL_JOYSTICK_DISABLED
-    need_polling = \
-        (!SDL_disabled_events[SDL_JOYAXISMOTION >> 8] || SDL_JoystickEventState(SDL_QUERY)) \
-        && (SDL_NumJoysticks() > 0);
+    need_polling =
+        SDL_WasInit(SDL_INIT_JOYSTICK) &&
+        (!SDL_disabled_events[SDL_JOYAXISMOTION >> 8] || SDL_JoystickEventState(SDL_QUERY)) &&
+        (SDL_NumJoysticks() > 0);
 #endif
 
 #if !SDL_SENSOR_DISABLED
-    need_polling = need_polling || (!SDL_disabled_events[SDL_SENSORUPDATE >> 8] && \
-        (SDL_NumSensors() > 0));
+    need_polling = need_polling ||
+        (SDL_WasInit(SDL_INIT_SENSOR) && !SDL_disabled_events[SDL_SENSORUPDATE >> 8] && (SDL_NumSensors() > 0));
 #endif
 
     return need_polling;


### PR DESCRIPTION
Implements the simple fix described in #4881

## Description
This PR caps the maximum time that can be spent waiting in `WaitEventTimeout()` to 3 seconds if joystick or sensor subsystems are active. This ensures we can enumerate new devices in a timely manner, even if no OS or SDL events are being generated at the time.

I also added `SDL_WasInit()` checks to the existing `SDL_events_need_polling()` function to avoid calls to `SDL_NumJoysticks()` or `SDL_NumSensors()` if the joystick or sensor subsystems aren't even initialized.

## Existing Issue(s)
Fixes #4881
