### PR TITLE
Fix CMake test build issues and start building tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
         sudo meson install -C build
     - uses: actions/checkout@v2
     - name: Configure CMake
-      run: cmake -B build ${{ matrix.platform.flags }}
+      run: cmake -B build -DSDL_TEST=ON ${{ matrix.platform.flags }}
     - name: Build
       run: cmake --build build/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2738,6 +2738,8 @@ endif()
 ##### Tests #####
 
 if(SDL_TEST)
+  include_directories(BEFORE "${SDL2_BINARY_DIR}/include")
+  include_directories(AFTER "${SDL2_SOURCE_DIR}/include")
   file(GLOB TEST_SOURCES ${SDL2_SOURCE_DIR}/src/test/*.c)
   add_library(SDL2_test STATIC ${TEST_SOURCES})
   add_subdirectory(test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -105,21 +105,8 @@ target_link_libraries(testshader OpenGL::GL)
 target_link_libraries(testgl2 OpenGL::GL)
 endif()
 
-# HACK: Dummy target to cause the resource files to be copied to the build directory.
-# Need to make it an executable so we can use the TARGET_FILE_DIR generator expression.
-# This is needed so they get copied to the correct Debug/Release subdirectory in Xcode.
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/resources_dummy.c "int main(int argc, const char **argv){ return 1; }\n")
-add_executable(SDL2_test_resources ${CMAKE_CURRENT_BINARY_DIR}/resources_dummy.c)
-
 file(GLOB RESOURCE_FILES *.bmp *.wav *.hex moose.dat utf8.txt)
-foreach(RESOURCE_FILE ${RESOURCE_FILES})
-    add_custom_command(TARGET SDL2_test_resources POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy_if_different ${RESOURCE_FILE} $<TARGET_FILE_DIR:SDL2_test_resources>)
-endforeach(RESOURCE_FILE)
-
 file(COPY ${RESOURCE_FILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-
-# TODO: Might be easier to make all targets depend on the resources...?
-
 set(NEEDS_RESOURCES
     testscale
     testrendercopyex
@@ -141,7 +128,9 @@ set(NEEDS_RESOURCES
     testmultiaudio
 )
 foreach(APP IN LISTS NEEDS_RESOURCES)
-    add_dependencies(${APP} SDL2_test_resources)
+    foreach(RESOURCE_FILE ${RESOURCE_FILES})
+        add_custom_command(TARGET ${APP} POST_BUILD COMMAND ${CMAKE_COMMAND} ARGS -E copy_if_different ${RESOURCE_FILE} $<TARGET_FILE_DIR:${APP}>)
+    endforeach(RESOURCE_FILE)
     if(APPLE)
         # Make sure resource files get installed into macOS/iOS .app bundles.  
         target_sources(${APP} PRIVATE "${RESOURCE_FILES}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,10 @@ if(WINDOWS)
     add_definitions(-Dmain=SDL_main)
 endif()
 
-find_package(OpenGL)
+# CMake incorrectly detects opengl32.lib being present on MSVC ARM64
+if(NOT MSVC OR NOT CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64")
+    find_package(OpenGL)
+endif()
 
 if (OPENGL_FOUND)
 add_definitions(-DHAVE_OPENGL)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,9 +6,14 @@ project(SDL2 C)
 remove_definitions(-DUSING_GENERATED_CONFIG_H)
 link_libraries(SDL2_test SDL2-static)
 
-# FIXME: Parent directory CMakeLists.txt only sets these for mingw/cygwin,
-# but we need them for VS as well.
 if(WINDOWS)
+    # mingw32 must come before SDL2main to link successfully
+    if(MINGW OR CYGWIN)
+        link_libraries(mingw32)
+    endif()
+
+    # FIXME: Parent directory CMakeLists.txt only sets these for mingw/cygwin,
+    # but we need them for VS as well.
     link_libraries(SDL2main)
     add_definitions(-Dmain=SDL_main)
 endif()


### PR DESCRIPTION
This PR enables `SDL_TEST=ON` in CI and fixes a couple of build errors encountered during the test build.

## Description
The interesting changes in this PR are the CMake changes I had to make to get `SDL_TEST=ON` build to work. I'd appreciate a review from someone who can sanity check the CMake stuff before merging.