### PR TITLE
Fix signal handling while blocking in SDL_WaitEvent() on X11/Wayland

### DIFF
--- a/src/audio/paudio/SDL_paudio.c
+++ b/src/audio/paudio/SDL_paudio.c
@@ -156,7 +156,7 @@ PAUDIO_WaitDevice(_THIS)
 #ifdef DEBUG_AUDIO
         fprintf(stderr, "Waiting for audio to get ready\n");
 #endif
-        if (SDL_IOReady(this->hidden->audio_fd, SDL_TRUE, timeoutMS) <= 0) {
+        if (SDL_IOReady(this->hidden->audio_fd, SDL_IOR_WRITE, timeoutMS) <= 0) {
             /*
              * In general we should never print to the screen,
              * but in this case we have no other way of letting

--- a/src/audio/qsa/SDL_qsa_audio.c
+++ b/src/audio/qsa/SDL_qsa_audio.c
@@ -120,7 +120,9 @@ QSA_WaitDevice(_THIS)
     /* If timeout occured than something wrong with hardware or driver    */
     /* For example, Vortex 8820 audio driver stucks on second DAC because */
     /* it doesn't exist !                                                 */
-    result = SDL_IOReady(this->hidden->audio_fd, !this->hidden->iscapture, 2 * 1000);
+    result = SDL_IOReady(this->hidden->audio_fd,
+                         this->hidden->iscapture ? SDL_IOR_READ : SDL_IOR_WRITE,
+                         2 * 1000);
     switch (result) {
     case -1:
         SDL_SetError("QSA: SDL_IOReady() failed: %s", strerror(errno));

--- a/src/audio/sun/SDL_sunaudio.c
+++ b/src/audio/sun/SDL_sunaudio.c
@@ -98,7 +98,7 @@ SUNAUDIO_WaitDevice(_THIS)
         }
     }
 #else
-    SDL_IOReady(this->hidden->audio_fd, SDL_TRUE, -1);
+    SDL_IOReady(this->hidden->audio_fd, SDL_IOR_WRITE, -1);
 #endif
 }
 

--- a/src/core/unix/SDL_poll.c
+++ b/src/core/unix/SDL_poll.c
@@ -34,9 +34,11 @@
 
 
 int
-SDL_IOReady(int fd, SDL_bool forWrite, int timeoutMS)
+SDL_IOReady(int fd, int flags, int timeoutMS)
 {
     int result;
+
+    SDL_assert(flags & (SDL_IOR_READ | SDL_IOR_WRITE));
 
     /* Note: We don't bother to account for elapsed time if we get EINTR */
     do
@@ -45,10 +47,12 @@ SDL_IOReady(int fd, SDL_bool forWrite, int timeoutMS)
         struct pollfd info;
 
         info.fd = fd;
-        if (forWrite) {
-            info.events = POLLOUT;
-        } else {
-            info.events = POLLIN | POLLPRI;
+        info.events = 0;
+        if (flags & SDL_IOR_READ) {
+            info.events |= POLLIN | POLLPRI;
+        }
+        if (flags & SDL_IOR_WRITE) {
+            info.events |= POLLOUT;
         }
         result = poll(&info, 1, timeoutMS);
 #else
@@ -59,14 +63,15 @@ SDL_IOReady(int fd, SDL_bool forWrite, int timeoutMS)
         /* If this assert triggers we'll corrupt memory here */
         SDL_assert(fd >= 0 && fd < FD_SETSIZE);
 
-        if (forWrite) {
-            FD_ZERO(&wfdset);
-            FD_SET(fd, &wfdset);
-            wfdp = &wfdset;
-        } else {
+        if (flags & SDL_IOR_READ) {
             FD_ZERO(&rfdset);
             FD_SET(fd, &rfdset);
             rfdp = &rfdset;
+        }
+        if (flags & SDL_IOR_WRITE) {
+            FD_ZERO(&wfdset);
+            FD_SET(fd, &wfdset);
+            wfdp = &wfdset;
         }
 
         if (timeoutMS >= 0) {

--- a/src/core/unix/SDL_poll.c
+++ b/src/core/unix/SDL_poll.c
@@ -83,7 +83,7 @@ SDL_IOReady(int fd, int flags, int timeoutMS)
         result = select(fd + 1, rfdp, wfdp, NULL, tvp);
 #endif /* HAVE_POLL */
 
-    } while ( result < 0 && errno == EINTR );
+    } while ( result < 0 && errno == EINTR && !(flags & SDL_IOR_NO_RETRY));
 
     return result;
 }

--- a/src/core/unix/SDL_poll.h
+++ b/src/core/unix/SDL_poll.h
@@ -28,6 +28,7 @@
 
 #define SDL_IOR_READ           0x1
 #define SDL_IOR_WRITE          0x2
+#define SDL_IOR_NO_RETRY       0x4
 
 extern int SDL_IOReady(int fd, int flags, int timeoutMS);
 

--- a/src/core/unix/SDL_poll.h
+++ b/src/core/unix/SDL_poll.h
@@ -26,8 +26,10 @@
 
 #include "SDL_stdinc.h"
 
+#define SDL_IOR_READ           0x1
+#define SDL_IOR_WRITE          0x2
 
-extern int SDL_IOReady(int fd, SDL_bool forWrite, int timeoutMS);
+extern int SDL_IOReady(int fd, int flags, int timeoutMS);
 
 #endif /* SDL_poll_h_ */
 

--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -827,6 +827,7 @@ SDL_WaitEventTimeout_Device(_THIS, SDL_Window *wakeup_window, SDL_Event * event,
            a) All pending events are batch processed after waking up from a wait
            b) Waiting can be completely skipped if events are already available to be pumped
            c) Periodic processing that takes place in some platform PumpEvents() functions happens
+           d) Signals received in WaitEventTimeout() are turned into SDL events
         */
         SDL_PumpEvents();
 
@@ -847,7 +848,6 @@ SDL_WaitEventTimeout_Device(_THIS, SDL_Window *wakeup_window, SDL_Event * event,
             }
             if (status > 0) {
                 /* There is an event, we can return. */
-                SDL_SendPendingSignalEvents();  /* in case we had a signal handler fire, etc. */
                 return 1;
             }
             /* No events found in the queue, call WaitEventTimeout to wait for an event. */

--- a/src/video/wayland/SDL_waylanddatamanager.c
+++ b/src/video/wayland/SDL_waylanddatamanager.c
@@ -50,7 +50,7 @@ write_pipe(int fd, const void* buffer, size_t total_length, size_t *pos)
     sigset_t old_sig_set;
     struct timespec zerotime = {0};
 
-    ready = SDL_IOReady(fd, SDL_TRUE, PIPE_MS_TIMEOUT);
+    ready = SDL_IOReady(fd, SDL_IOR_WRITE, PIPE_MS_TIMEOUT);
 
     sigemptyset(&sig_set);
     sigaddset(&sig_set, SIGPIPE);  
@@ -96,7 +96,7 @@ read_pipe(int fd, void** buffer, size_t* total_length, SDL_bool null_terminate)
     ssize_t bytes_read = 0;
     size_t pos = 0;
 
-    ready = SDL_IOReady(fd, SDL_FALSE, PIPE_MS_TIMEOUT);
+    ready = SDL_IOReady(fd, SDL_IOR_READ, PIPE_MS_TIMEOUT);
   
     if (ready == 0) {
         bytes_read = SDL_SetError("Pipe timeout");

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -259,7 +259,7 @@ Wayland_WaitEventTimeout(_THIS, int timeout)
     /* wl_display_prepare_read() will return -1 if the default queue is not empty.
      * If the default queue is empty, it will prepare us for our SDL_IOReady() call. */
     if (WAYLAND_wl_display_prepare_read(d->display) == 0) {
-        if (SDL_IOReady(WAYLAND_wl_display_get_fd(d->display), SDL_FALSE, timeout) > 0) {
+        if (SDL_IOReady(WAYLAND_wl_display_get_fd(d->display), SDL_IOR_READ, timeout) > 0) {
             /* There are new events available to read */
             WAYLAND_wl_display_read_events(d->display);
             WAYLAND_wl_display_dispatch_pending(d->display);
@@ -308,7 +308,7 @@ Wayland_PumpEvents(_THIS)
     /* wl_display_prepare_read() will return -1 if the default queue is not empty.
      * If the default queue is empty, it will prepare us for our SDL_IOReady() call. */
     if (WAYLAND_wl_display_prepare_read(d->display) == 0) {
-        if (SDL_IOReady(WAYLAND_wl_display_get_fd(d->display), SDL_FALSE, 0) > 0) {
+        if (SDL_IOReady(WAYLAND_wl_display_get_fd(d->display), SDL_IOR_READ, 0) > 0) {
             WAYLAND_wl_display_read_events(d->display);
         } else {
             WAYLAND_wl_display_cancel_read(d->display);

--- a/src/video/wayland/SDL_waylandopengles.c
+++ b/src/video/wayland/SDL_waylandopengles.c
@@ -155,7 +155,7 @@ Wayland_GLES_SwapWindow(_THIS, SDL_Window *window)
                 break;
             }
 
-            if (SDL_IOReady(WAYLAND_wl_display_get_fd(display), SDL_FALSE, max_wait - now) <= 0) {
+            if (SDL_IOReady(WAYLAND_wl_display_get_fd(display), SDL_IOR_READ, max_wait - now) <= 0) {
                 /* Error or timeout expired without any events for us. Cancel the read. */
                 WAYLAND_wl_display_cancel_read(display);
                 break;

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -1536,7 +1536,7 @@ X11_Pending(Display * display)
     }
 
     /* More drastic measures are required -- see if X is ready to talk */
-    if (SDL_IOReady(ConnectionNumber(display), SDL_FALSE, 0)) {
+    if (SDL_IOReady(ConnectionNumber(display), SDL_IOR_READ, 0)) {
         return (X11_XPending(display));
     }
 
@@ -1586,7 +1586,7 @@ X11_WaitEventTimeout(_THIS, int timeout)
             return 0;
         }
     } else if (timeout > 0) {
-        if (SDL_IOReady(ConnectionNumber(display), SDL_FALSE, timeout) > 0) {
+        if (SDL_IOReady(ConnectionNumber(display), SDL_IOR_READ, timeout) > 0) {
             X11_XNextEvent(display, &xevent);
         } else {
             return 0;


### PR DESCRIPTION

## Description
`WaitEventTimeout()` on X11 and Wayland backends use `SDL_IOReady()` which automatically retries `poll()` on `EINTR`. If someone sends a signal to our process, we'll get the signal and set `send_quit_pending` in the signal handler but never wake the waiter inside `SDL_WaitEvent()`. To fix this, avoid suppressing `EINTR` when calling `SDL_IOReady()` from our `WaitEventTimeout()` implementations.

When we get an `EINTR` error in `WaitEventTimeout()`, we'll return 1 to indicate that a new event may have been generated. This will cause the event core to call `SDL_PumpEvents()` which calls `SDL_SendPendingSignalEvents()` to generate the `SDL_QUIT` event if the signal was `SIGINT` or `SIGTERM`.

To add the additional option to `SDL_IOReady()`, I converted the second parameter to a `flags` option and did a tree-wide conversion of existing callers to the new flags.