### PR TITLE
testtimer: Add basic sanity check for SDL_GetTicks*()

### DIFF
--- a/test/testtimer.c
+++ b/test/testtimer.c
@@ -54,6 +54,23 @@ main(int argc, char *argv[])
         return (1);
     }
 
+    /* Verify SDL_GetTicks* acts monotonically increasing, and not erratic. */
+    SDL_Log("Sanity-checking GetTicks\n");
+    for (i = 0; i < 1000; ++i) {
+        start64 = SDL_GetTicks64();
+        start32 = SDL_GetTicks();
+        SDL_Delay(1);
+        now64 = SDL_GetTicks64();
+        now32 = SDL_GetTicks();
+        Uint32 dt32 = now32-start32;
+        Uint64 dt64 = now64-start64;
+        if (dt32 > 100 || dt64 > 100) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "testtimer.c: Delta time erratic at iter %d. Delay 1ms = %d ms in ticks, %d ms in ticks64\n", i, (int)dt32, (int)dt64);
+            SDL_Quit();
+            return 1;
+        }
+    }
+
     /* Start the timer */
     desired = 0;
     if (argv[1]) {

--- a/test/testtimer.c
+++ b/test/testtimer.c
@@ -60,12 +60,10 @@ main(int argc, char *argv[])
         start64 = SDL_GetTicks64();
         start32 = SDL_GetTicks();
         SDL_Delay(1);
-        now64 = SDL_GetTicks64();
-        now32 = SDL_GetTicks();
-        Uint32 dt32 = now32-start32;
-        Uint64 dt64 = now64-start64;
-        if (dt32 > 100 || dt64 > 100) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "testtimer.c: Delta time erratic at iter %d. Delay 1ms = %d ms in ticks, %d ms in ticks64\n", i, (int)dt32, (int)dt64);
+        now64 = SDL_GetTicks64() - start64;
+        now32 = SDL_GetTicks() - start32;
+        if (now32 > 100 || now64 > 100) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "testtimer.c: Delta time erratic at iter %d. Delay 1ms = %d ms in ticks, %d ms in ticks64\n", i, (int)now32, (int)now64);
             SDL_Quit();
             return 1;
         }


### PR DESCRIPTION
## Description

Add a one second long loop that checks that time deltas are not totally unreasonable.

## Existing Issue(s)

Mention #4872
 