### PR TITLE
Fix timeval/timespec delta calculations

### DIFF
--- a/src/timer/psp/SDL_systimer.c
+++ b/src/timer/psp/SDL_systimer.c
@@ -61,7 +61,7 @@ SDL_GetTicks64(void)
     }
 
     gettimeofday(&now, NULL);
-    return (((Uint64)(now.tv_sec-start.tv_sec)) * 1000) + (((Uint64) (now.tv_usec-start.tv_usec)) / 1000);
+    return (Uint64) (((Sint64) (now.tv_sec - start.tv_sec) * 1000) + ((now.tv_usec - start.tv_usec) / 1000));
 }
 
 Uint64

--- a/src/timer/unix/SDL_systimer.c
+++ b/src/timer/unix/SDL_systimer.c
@@ -117,7 +117,7 @@ SDL_GetTicks64(void)
 #if HAVE_CLOCK_GETTIME
         struct timespec now;
         clock_gettime(SDL_MONOTONIC_CLOCK, &now);
-        return (((Uint64) (now.tv_sec - start_ts.tv_sec)) * 1000) + (((Uint64) (now.tv_nsec - start_ts.tv_nsec)) / 1000000);
+        return (Uint64) (((Sint64) (now.tv_sec - start_ts.tv_sec) * 1000) + ((now.tv_nsec - start_ts.tv_nsec) / 1000000));
 #elif defined(__APPLE__)
         const uint64_t now = mach_absolute_time();
         return (Uint64) ((((now - start_mach) * mach_base_info.numer) / mach_base_info.denom) / 1000000);
@@ -128,7 +128,7 @@ SDL_GetTicks64(void)
     }
 
     gettimeofday(&now, NULL);
-    return (((Uint64) (now.tv_sec - start_tv.tv_sec)) * 1000) + (((Uint64) (now.tv_usec - start_tv.tv_usec)) / 1000);
+    return (Uint64) (((Sint64) (now.tv_sec - start_tv.tv_sec) * 1000) + ((now.tv_usec - start_tv.tv_usec) / 1000));
 }
 
 Uint64


### PR DESCRIPTION
Fixes the timeval/timespec delta calcuations in unix and psp SDL_GetTicks64 to avoid sign mismatches.

## Description
As mentioned in https://github.com/libsdl-org/SDL/pull/4872#issuecomment-957073495, the move to SDL_GetTicks64 added Uint64 casts to the usec/nsec deltas, which is incorrect as those values can be negative, causing incorrect tick count calculation.