### PR TITLE
WGI: Add workaround for delayed callbacks after WGI_JoystickQuit()

### DIFF
--- a/src/joystick/windows/SDL_windows_gaming_input.c
+++ b/src/joystick/windows/SDL_windows_gaming_input.c
@@ -166,6 +166,12 @@ static HRESULT STDMETHODCALLTYPE IEventHandler_CRawGameControllerVtbl_InvokeAdde
     HRESULT hr;
     __x_ABI_CWindows_CGaming_CInput_CIRawGameController *controller = NULL;
 
+    /* We can get delayed calls to InvokeAdded() after WGI_JoystickQuit(). Do nothing if WGI is deinitialized.
+     * FIXME: Can we tell if WGI has been quit and reinitialized prior to a delayed callback? */
+    if (wgi.statics == NULL) {
+        return S_OK;
+    }
+
     hr = IUnknown_QueryInterface((IUnknown *)e, &IID_IRawGameController, (void **)&controller);
     if (SUCCEEDED(hr)) {
         char *name = NULL;


### PR DESCRIPTION
## Description
This is a workaround to catch the case where a delayed WGI device add callback leads to a crash due to having uninitialized the joystick subsystem.

Ideally we would be able to flush these callbacks prior to returning from `WGI_JoystickQuit()`, but I couldn't find a way that worked reliably. Even calling `SDL_PumpEvents()` after unregistering the callback doesn't seem to be enough.

If nobody comes up with anything smarter than this before 2.0.18, we should probably get this in.

## Existing Issue(s)
#4915