### PR TITLE
testwm2: Add clickable mode list for testing SDL_SetWindowDisplayMode

### DIFF
--- a/include/SDL_test_common.h
+++ b/include/SDL_test_common.h
@@ -215,9 +215,10 @@ void SDLTest_CommonQuit(SDLTest_CommonState * state);
  *
  * \param renderer The renderer to draw to.
  * \param window The window whose information should be displayed.
+ * \param usedHeight Returns the height used, so the caller can draw more below.
  *
  */
-void SDLTest_CommonDrawWindowInfo(SDL_Renderer * renderer, SDL_Window * window);
+void SDLTest_CommonDrawWindowInfo(SDL_Renderer * renderer, SDL_Window * window, int * usedHeight);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -2192,7 +2192,7 @@ SDLTest_CommonQuit(SDLTest_CommonState * state)
 }
 
 void
-SDLTest_CommonDrawWindowInfo(SDL_Renderer * renderer, SDL_Window * window)
+SDLTest_CommonDrawWindowInfo(SDL_Renderer * renderer, SDL_Window * window, int * usedHeight)
 {
     char text[1024];
     int textY = 0;
@@ -2203,8 +2203,33 @@ SDLTest_CommonDrawWindowInfo(SDL_Renderer * renderer, SDL_Window * window)
     float ddpi, hdpi, vdpi;
     Uint32 flags;
     const int windowDisplayIndex = SDL_GetWindowDisplayIndex(window);
+    SDL_RendererInfo info;
+
+    /* Video */
+
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+    SDLTest_DrawString(renderer, 0, textY, "-- Video --");
+    textY += lineHeight;
+
+    SDL_SetRenderDrawColor(renderer, 170, 170, 170, 255);
+
+    SDL_snprintf(text, sizeof(text), "SDL_GetCurrentVideoDriver: %s", SDL_GetCurrentVideoDriver());
+    SDLTest_DrawString(renderer, 0, textY, text);
+    textY += lineHeight;
 
     /* Renderer */
+
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+    SDLTest_DrawString(renderer, 0, textY, "-- Renderer --");
+    textY += lineHeight;
+
+    SDL_SetRenderDrawColor(renderer, 170, 170, 170, 255);
+
+    if (0 == SDL_GetRendererInfo(renderer, &info)) {
+        SDL_snprintf(text, sizeof(text), "SDL_GetRendererInfo: name: %s", info.name);
+        SDLTest_DrawString(renderer, 0, textY, text);
+        textY += lineHeight;
+    }
 
     if (0 == SDL_GetRendererOutputSize(renderer, &w, &h)) {
         SDL_snprintf(text, sizeof(text), "SDL_GetRendererOutputSize: %dx%d", w, h);
@@ -2220,8 +2245,11 @@ SDLTest_CommonDrawWindowInfo(SDL_Renderer * renderer, SDL_Window * window)
 
     /* Window */
 
-    SDLTest_DrawString(renderer, 0, textY, "----");
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+    SDLTest_DrawString(renderer, 0, textY, "-- Window --");
     textY += lineHeight;
+
+    SDL_SetRenderDrawColor(renderer, 170, 170, 170, 255);
 
     SDL_GetWindowPosition(window, &x, &y);
     SDL_snprintf(text, sizeof(text), "SDL_GetWindowPosition: %d,%d", x, y);
@@ -2238,10 +2266,20 @@ SDLTest_CommonDrawWindowInfo(SDL_Renderer * renderer, SDL_Window * window)
     SDLTest_DrawString(renderer, 0, textY, text);
     textY += lineHeight;
 
+    if (0 == SDL_GetWindowDisplayMode(window, &mode)) {
+        SDL_snprintf(text, sizeof(text), "SDL_GetWindowDisplayMode: %dx%d@%dHz (%s)",
+            mode.w, mode.h, mode.refresh_rate, SDL_GetPixelFormatName(mode.format));
+        SDLTest_DrawString(renderer, 0, textY, text);
+        textY += lineHeight;
+    }
+
     /* Display */
 
-    SDLTest_DrawString(renderer, 0, textY, "----");
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+    SDLTest_DrawString(renderer, 0, textY, "-- Display --");
     textY += lineHeight;
+
+    SDL_SetRenderDrawColor(renderer, 170, 170, 170, 255);
 
     SDL_snprintf(text, sizeof(text), "SDL_GetWindowDisplayIndex: %d", windowDisplayIndex);
     SDLTest_DrawString(renderer, 0, textY, text);
@@ -2286,8 +2324,11 @@ SDLTest_CommonDrawWindowInfo(SDL_Renderer * renderer, SDL_Window * window)
 
     /* Mouse */
 
-    SDLTest_DrawString(renderer, 0, textY, "----");
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+    SDLTest_DrawString(renderer, 0, textY, "-- Mouse --");
     textY += lineHeight;
+
+    SDL_SetRenderDrawColor(renderer, 170, 170, 170, 255);
 
     flags = SDL_GetMouseState(&x, &y);
     SDL_snprintf(text, sizeof(text), "SDL_GetMouseState: %d,%d ", x, y);
@@ -2300,6 +2341,10 @@ SDLTest_CommonDrawWindowInfo(SDL_Renderer * renderer, SDL_Window * window)
     SDLTest_PrintButtonMask(text, sizeof(text), flags);
     SDLTest_DrawString(renderer, 0, textY, text);
     textY += lineHeight;
+
+    if (usedHeight) {
+        *usedHeight = textY;
+    }
 }
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/test/SDL_test_font.c
+++ b/src/test/SDL_test_font.c
@@ -3109,10 +3109,16 @@ static unsigned char SDLTest_FontData[SDL_TESTFONTDATAMAX] = {
 
 /* ---- Character */
 
+struct SDLTest_CharTextureCache {
+    SDL_Renderer* renderer;
+    SDL_Texture* charTextureCache[256];
+    struct SDLTest_CharTextureCache* next;
+};
+
 /*!
-\brief Global cache for 8x8 pixel font textures created at runtime.
+\brief List of per-renderer caches for 8x8 pixel font textures created at runtime.
 */
-static SDL_Texture *SDLTest_CharTextureCache[256];
+static SDL_Texture *SDLTest_CharTextureCacheList;
 
 int SDLTest_DrawCharacter(SDL_Renderer *renderer, int x, int y, char c)
 {
@@ -3131,6 +3137,7 @@ int SDLTest_DrawCharacter(SDL_Renderer *renderer, int x, int y, char c)
     SDL_Surface *character;
     Uint32 ci;
     Uint8 r, g, b, a;
+    struct SDLTest_CharTextureCache *cache;
 
     /*
      * Setup source rectangle
@@ -3151,10 +3158,25 @@ int SDLTest_DrawCharacter(SDL_Renderer *renderer, int x, int y, char c)
     /* Character index in cache */
     ci = (unsigned char)c;
 
+    /* Search for this renderer's cache */
+    for (cache = SDLTest_CharTextureCacheList; cache != NULL; cache = cache->next) {
+        if (cache->renderer == renderer) {
+            break;
+        }
+    }
+
+    /* Allocate a new cache for this renderer if needed */
+    if (cache == NULL) {        
+        cache = (struct SDLTest_CharTextureCache*)SDL_calloc(1, sizeof(struct SDLTest_CharTextureCache));
+        cache->renderer = renderer;
+        cache->next = SDLTest_CharTextureCacheList;
+        SDLTest_CharTextureCacheList = cache;
+    }
+
     /*
      * Create new charWidth x charHeight bitmap surface if not already present.
      */
-    if (SDLTest_CharTextureCache[ci] == NULL) {
+    if (cache->charTextureCache[ci] == NULL) {
         /*
          * Redraw character into surface
          */
@@ -3191,14 +3213,15 @@ int SDLTest_DrawCharacter(SDL_Renderer *renderer, int x, int y, char c)
             linepos += pitch;
         }
 
+
         /* Convert temp surface into texture */
-        SDLTest_CharTextureCache[ci] = SDL_CreateTextureFromSurface(renderer, character);
+        cache->charTextureCache[ci] = SDL_CreateTextureFromSurface(renderer, character);
         SDL_FreeSurface(character);
 
         /*
          * Check pointer
          */
-        if (SDLTest_CharTextureCache[ci] == NULL) {
+        if (cache->charTextureCache[ci] == NULL) {
             return (-1);
         }
     }
@@ -3208,13 +3231,13 @@ int SDLTest_DrawCharacter(SDL_Renderer *renderer, int x, int y, char c)
      */
     result = 0;
     result |= SDL_GetRenderDrawColor(renderer, &r, &g, &b, &a);
-    result |= SDL_SetTextureColorMod(SDLTest_CharTextureCache[ci], r, g, b);
-    result |= SDL_SetTextureAlphaMod(SDLTest_CharTextureCache[ci], a);
+    result |= SDL_SetTextureColorMod(cache->charTextureCache[ci], r, g, b);
+    result |= SDL_SetTextureAlphaMod(cache->charTextureCache[ci], a);
 
     /*
      * Draw texture onto destination
      */
-    result |= SDL_RenderCopy(renderer, SDLTest_CharTextureCache[ci], &srect, &drect);
+    result |= SDL_RenderCopy(renderer, cache->charTextureCache[ci], &srect, &drect);
 
     return (result);
 }
@@ -3239,12 +3262,23 @@ int SDLTest_DrawString(SDL_Renderer * renderer, int x, int y, const char *s)
 void SDLTest_CleanupTextDrawing(void)
 {
     unsigned int i;
-    for (i = 0; i < SDL_arraysize(SDLTest_CharTextureCache); ++i) {
-        if (SDLTest_CharTextureCache[i]) {
-            SDL_DestroyTexture(SDLTest_CharTextureCache[i]);
-            SDLTest_CharTextureCache[i] = NULL;
+    struct SDLTest_CharTextureCache* cache, *next;
+
+    cache = SDLTest_CharTextureCacheList;
+    do {
+        for (i = 0; i < SDL_arraysize(cache->charTextureCache); ++i) {
+            if (cache->charTextureCache[i]) {
+                SDL_DestroyTexture(cache->charTextureCache[i]);
+                cache->charTextureCache[i] = NULL;
+            }
         }
-    }
+
+        next = cache->next;
+        SDL_free(cache);
+        cache = next;
+    } while (cache);
+
+    SDLTest_CharTextureCacheList = NULL;
 }
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/test/SDL_test_font.c
+++ b/src/test/SDL_test_font.c
@@ -3118,7 +3118,7 @@ struct SDLTest_CharTextureCache {
 /*!
 \brief List of per-renderer caches for 8x8 pixel font textures created at runtime.
 */
-static SDL_Texture *SDLTest_CharTextureCacheList;
+static struct SDLTest_CharTextureCache *SDLTest_CharTextureCacheList;
 
 int SDLTest_DrawCharacter(SDL_Renderer *renderer, int x, int y, char c)
 {

--- a/test/testwm2.c
+++ b/test/testwm2.c
@@ -18,6 +18,7 @@
 #endif
 
 #include "SDL_test_common.h"
+#include "SDL_test_font.h"
 
 static SDLTest_CommonState *state;
 int done;
@@ -39,6 +40,7 @@ static const char *cursorNames[] = {
 int system_cursor = -1;
 SDL_Cursor *cursor = NULL;
 SDL_bool relative_mode = SDL_FALSE;
+int highlighted_mode = -1;
 
 /* Call this instead of exit(), so we can clean up SDL: atexit() is evil. */
 static void
@@ -46,6 +48,92 @@ quit(int rc)
 {
     SDLTest_CommonQuit(state);
     exit(rc);
+}
+
+/* Draws the modes menu, and stores the mode index under the mouse in highlighted_mode */
+static void
+draw_modes_menu(SDL_Window* window, SDL_Renderer* renderer, SDL_Rect viewport)
+{
+    SDL_DisplayMode mode;
+    char text[1024];
+    const int lineHeight = 10;
+    const int display_index = SDL_GetWindowDisplayIndex(window);
+    const int num_modes = SDL_GetNumDisplayModes(display_index);
+    int i;
+    int column_chars = 0;
+    int text_length;
+    int x, y;
+    int table_top;
+    SDL_Point mouse_pos = { -1, -1 };
+
+    /* Get mouse position */
+    if (SDL_GetMouseFocus() == window) {
+        SDL_GetMouseState(&mouse_pos.x, &mouse_pos.y);
+    }
+
+    x = 0;
+    y = viewport.y;
+
+    y += lineHeight;
+
+    SDL_snprintf(text, sizeof(text), "Click on a mode to set it with SDL_SetWindowDisplayMode");
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+    SDLTest_DrawString(renderer, x, y, text);
+    y += lineHeight;
+
+    SDL_snprintf(text, sizeof(text), "Press Ctrl+Enter to toggle SDL_WINDOW_FULLSCREEN");
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+    SDLTest_DrawString(renderer, x, y, text);
+    y += lineHeight;
+
+    table_top = y;
+
+    /* Clear the cached mode under the mouse */
+    if (window == SDL_GetMouseFocus()) {
+        highlighted_mode = -1;
+    }
+
+    for (i = 0; i < num_modes; ++i) {
+        SDL_Rect cell_rect;
+
+        if (0 != SDL_GetDisplayMode(display_index, i, &mode)) {
+            return;
+        }
+
+        SDL_snprintf(text, sizeof(text), "%d: %dx%d@%dHz",
+            i, mode.w, mode.h, mode.refresh_rate);
+
+        /* Update column width */
+        text_length = (int)SDL_strlen(text);
+        column_chars = SDL_max(column_chars, text_length);
+
+        /* Check if under mouse */        
+        cell_rect.x = x;
+        cell_rect.y = y;
+        cell_rect.w = text_length * FONT_CHARACTER_SIZE;
+        cell_rect.h = lineHeight;
+
+        if (SDL_PointInRect(&mouse_pos, &cell_rect)) {
+            SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+
+            /* Update cached mode under the mouse */
+            if (window == SDL_GetMouseFocus()) {
+                highlighted_mode = i;
+            }
+        } else {
+            SDL_SetRenderDrawColor(renderer, 170, 170, 170, 255);
+        }
+
+        SDLTest_DrawString(renderer, x, y, text);
+        y += lineHeight;
+
+        if (y + lineHeight > (viewport.y + viewport.h)) {
+            /* Advance to next column */
+            x += (column_chars + 1) * FONT_CHARACTER_SIZE;
+            y = table_top;
+            column_chars = 0;
+        }
+    }
 }
 
 void
@@ -112,16 +200,40 @@ loop()
                     SDL_SetCursor(cursor);
                 }
             }
+            if (event.type == SDL_MOUSEBUTTONUP) {
+                SDL_Window* window = SDL_GetMouseFocus();
+                if (highlighted_mode != -1 && window != NULL) {
+                    const int display_index = SDL_GetWindowDisplayIndex(window);
+                    SDL_DisplayMode mode;
+                    if (0 != SDL_GetDisplayMode(display_index, highlighted_mode, &mode)) {
+                        SDL_Log("Couldn't get display mode");
+                    } else {
+                        SDL_SetWindowDisplayMode(window, &mode);
+                    }
+                }
+            }
         }
 
         for (i = 0; i < state->num_windows; ++i) {
+            SDL_Window* window = state->windows[i];
             SDL_Renderer *renderer = state->renderers[i];
-            if (renderer != NULL) {
+            if (window != NULL && renderer != NULL) {
+                int y = 0;
+                SDL_Rect viewport, menurect;
+
+                SDL_RenderGetViewport(renderer, &viewport);
+
                 SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
                 SDL_RenderClear(renderer);
 
                 SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
-                SDLTest_CommonDrawWindowInfo(renderer, state->windows[i]);
+                SDLTest_CommonDrawWindowInfo(renderer, state->windows[i], &y);
+
+                menurect.x = 0;
+                menurect.y = y;
+                menurect.w = viewport.w;
+                menurect.h = viewport.h - y;
+                draw_modes_menu(window, renderer, menurect);
 
                 SDL_RenderPresent(renderer);
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a clickable mode list to testwm2 - clicking a mode calls SDL_SetWindowDisplayMode. 

![image](https://user-images.githubusercontent.com/239161/140637126-e609618d-6463-43cd-8ef5-f3dde7aef682.png)

This will enable testing 2 scenarios that weren't really possible with the SDLTest apps:
- going from windowed to a specific fullscreen display mode
- going from one fullscreen mode to another

Also draws a few more bits of information in testwm2 (video driver name, renderer name, window's current display mode).

The first commit adjusts `SDLTest_DrawString` to support drawing on more than one SDL_Renderer. Previously, if you launched `testwm2 --windows 2`, only one of the windows would get the on-screen info text.



