### PR TITLE
Properly position the IME window(s) on Windows when using `SDL_SetTextInputRect`

### DIFF
--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -249,15 +249,23 @@ WIN_SetTextInputRect(_THIS, SDL_Rect *rect)
         COMPOSITIONFORM cof;
         CANDIDATEFORM caf;
 
-        cof.dwStyle = CFS_FORCE_POSITION;
+        cof.dwStyle = CFS_RECT;
         cof.ptCurrentPos.x = videodata->ime_rect.x;
         cof.ptCurrentPos.y = videodata->ime_rect.y;
+        cof.rcArea.left = videodata->ime_rect.x;
+        cof.rcArea.right = videodata->ime_rect.x + videodata->ime_rect.w;
+        cof.rcArea.top = videodata->ime_rect.y;
+        cof.rcArea.bottom = videodata->ime_rect.y + videodata->ime_rect.h;
         ImmSetCompositionWindow(himc, &cof);
 
         caf.dwIndex = 0;
-        caf.dwStyle = CFS_CANDIDATEPOS;
+        caf.dwStyle = CFS_EXCLUDE;
         caf.ptCurrentPos.x = videodata->ime_rect.x;
         caf.ptCurrentPos.y = videodata->ime_rect.y;
+        caf.rcArea.left = videodata->ime_rect.x;
+        caf.rcArea.right = videodata->ime_rect.x + videodata->ime_rect.w;
+        caf.rcArea.top = videodata->ime_rect.y;
+        caf.rcArea.bottom = videodata->ime_rect.y + videodata->ime_rect.h;
         ImmSetCandidateWindow(himc, &caf);
 
         ImmReleaseContext(videodata->ime_hwnd_current, himc);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR uses the better Win32 API, which gives the IME more information on how to properly position the candidate window.
The attached images speak for themselves.

Setting both `ptCurrentPos` and `rcArea` is required, as without the `ptCurrentPos` the window will appear in the wrong spot if it's close to display edge.


Microsoft docs for: [CANDIDATEFORM](https://docs.microsoft.com/en-us/windows/win32/api/imm/ns-imm-candidateform) and [COMPOSITIONFORM](https://docs.microsoft.com/en-us/windows/win32/api/imm/ns-imm-compositionform).


## `SDL_SetTextInputRect()` in action:

For reference, I'm setting the `rect` to roughly the red box here:

![image](https://user-images.githubusercontent.com/16479013/140818645-a37c6bc4-f7b6-45c8-b1e5-f28ec61bd4e0.png)


### Current `main`:

Normal look |  IME close to display edge
:--:|:--:
![image](https://user-images.githubusercontent.com/16479013/140819040-ac8383e1-c376-4142-acfd-81c144304b7e.png) | ![image](https://user-images.githubusercontent.com/16479013/140819087-ebaf1810-3ddc-4d6f-a07f-2c75d8a0e5a4.png)


### This PR:

Normal look |  IME close to display edge
:--:|:--:
![image](https://user-images.githubusercontent.com/16479013/140819250-1cfe86d8-5aa8-4b5d-89f9-053a766e1eb1.png) | ![image](https://user-images.githubusercontent.com/16479013/140819259-336454b8-e63a-436c-945c-b080037c53a2.png)



## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->

None.