### PR TITLE
SDL_windowsmouse.c: Remove LR_COPYDELETEORG flag

### DIFF
--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -154,8 +154,9 @@ WIN_CreateCursor(SDL_Surface * surface, int hot_x, int hot_y)
     /* The cursor returned by CreateIconIndirect does not respect system cursor size
         preference, use CopyImage to duplicate the cursor with desired sizes */
     hcursor = CopyImage(hicon, IMAGE_CURSOR, 0, 0, LR_DEFAULTSIZE);
+    DestroyIcon(hicon);
+
     if (!hcursor) {
-        DestroyIcon(hicon);
         WIN_SetError("CopyImage()");
         return NULL;
     }

--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -153,7 +153,7 @@ WIN_CreateCursor(SDL_Surface * surface, int hot_x, int hot_y)
 
     /* The cursor returned by CreateIconIndirect does not respect system cursor size
         preference, use CopyImage to duplicate the cursor with desired sizes */
-    hcursor = CopyImage(hicon, IMAGE_CURSOR, 0, 0, LR_COPYDELETEORG | LR_DEFAULTSIZE);
+    hcursor = CopyImage(hicon, IMAGE_CURSOR, 0, 0, LR_DEFAULTSIZE);
     if (!hcursor) {
         DestroyIcon(hicon);
         WIN_SetError("CopyImage()");


### PR DESCRIPTION
## Description

It turns out the `LR_COPYDELETEORG` flag introduced in #4927 would cause the cursor to disappear. This PR fixes the problem. I tested it on Windows 10 19043.1288.