### PR TITLE
Fix refcounting in SDL_hid_exit

### DIFF
--- a/src/hidapi/SDL_hidapi.c
+++ b/src/hidapi/SDL_hidapi.c
@@ -1084,8 +1084,8 @@ int SDL_hid_exit(void)
     if (SDL_hidapi_refcount == 0) {
         return 0;
     }
+    --SDL_hidapi_refcount;
     if (SDL_hidapi_refcount > 0) {
-        --SDL_hidapi_refcount;
         return 0;
     }
     SDL_hidapi_refcount = 0;


### PR DESCRIPTION
## Description
Body of `SDL_hid_exit` is never executed.

## Existing Issue(s)
None
