### PR TITLE
Don't call pthread_join on zombie threads

### DIFF
--- a/src/thread/pthread/SDL_systhread.c
+++ b/src/thread/pthread/SDL_systhread.c
@@ -291,7 +291,7 @@ SDL_SYS_WaitThread(SDL_Thread * thread)
     }
 }
 
-void 
+void
 SDL_SYS_DetachThread(SDL_Thread * thread)
 {
     pthread_detach(thread->handle);

--- a/src/thread/pthread/SDL_systhread.c
+++ b/src/thread/pthread/SDL_systhread.c
@@ -291,7 +291,8 @@ SDL_SYS_WaitThread(SDL_Thread * thread)
     }
 }
 
-void SDL_SYS_DetachThread(SDL_Thread * thread)
+void 
+SDL_SYS_DetachThread(SDL_Thread * thread)
 {
     pthread_detach(thread->handle);
 }

--- a/src/thread/pthread/SDL_systhread.c
+++ b/src/thread/pthread/SDL_systhread.c
@@ -286,7 +286,7 @@ SDL_SYS_SetThreadPriority(SDL_ThreadPriority priority)
 void
 SDL_SYS_WaitThread(SDL_Thread * thread)
 {
-    if (thread->state.value != SDL_THREAD_STATE_ZOMBIE) {
+    if (SDL_AtomicGet(&thread->state) != SDL_THREAD_STATE_ZOMBIE) {
         pthread_join(thread->handle, 0);
     }
 }

--- a/src/thread/pthread/SDL_systhread.c
+++ b/src/thread/pthread/SDL_systhread.c
@@ -286,11 +286,12 @@ SDL_SYS_SetThreadPriority(SDL_ThreadPriority priority)
 void
 SDL_SYS_WaitThread(SDL_Thread * thread)
 {
-    pthread_join(thread->handle, 0);
+    if (thread->state.value != SDL_THREAD_STATE_ZOMBIE) {
+        pthread_join(thread->handle, 0);
+    }
 }
 
-void
-SDL_SYS_DetachThread(SDL_Thread * thread)
+void SDL_SYS_DetachThread(SDL_Thread * thread)
 {
     pthread_detach(thread->handle);
 }


### PR DESCRIPTION
## Description
The `SDL_SYS_WaitThread` function is patched to ignore threads in zombie state. This is to prevent segmentation faults.

## Existing Issue(s)
#4950 
