### PR TITLE
[Android] Limit WRITE_EXTERNAL_STORAGE to SDK 22-

### DIFF
--- a/android-project/app/src/main/AndroidManifest.xml
+++ b/android-project/app/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
         android:name="android.hardware.microphone"
         android:required="false" /> -->
 
-    <!-- Allow downloading to external storage -->
+    <!-- Allow downloading to the external storage on Android 5.1 and older -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="22" />
     <!-- Allow access to Bluetooth devices -->
     <uses-permission android:name="android.permission.BLUETOOTH" />

--- a/android-project/app/src/main/AndroidManifest.xml
+++ b/android-project/app/src/main/AndroidManifest.xml
@@ -38,8 +38,8 @@
         android:name="android.hardware.microphone"
         android:required="false" /> -->
 
-    <!-- Allow writing to external storage -->
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <!-- Allow downloading to external storage -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="22" />
     <!-- Allow access to Bluetooth devices -->
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <!-- Allow access to the vibrator -->


### PR DESCRIPTION
Limit WRITE_EXTERNAL_STORAGE permission to Android SDK 22 and below

## Description
Direct access to the external storage is no longer allowed as of SDK 30. But on older version of Android you will still need WRITE_EXTERNAL_STORAGE in order to request the Download Manager to download files to your external file folder.