### PR TITLE
wayland: Add support for SDL_DisplayOrientation

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.h
+++ b/src/video/wayland/SDL_waylandvideo.h
@@ -92,8 +92,10 @@ typedef struct {
     struct wl_output *output;
     float scale_factor;
     int x, y, width, height, refresh, transform;
+    SDL_DisplayOrientation orientation;
     int physical_width, physical_height;
     float ddpi, hdpi, vdpi;
+    int index;
     SDL_VideoDisplay placeholder;
     SDL_bool done;
 } SDL_WaylandOutputData;


### PR DESCRIPTION
Tested and known to work on Plasma, just needs a second pair of eyes to verify correctness. Functionally it's the same as before, but once we've initialized the display we write directly to the "real" VideoDisplay instead of the placeholder we use when starting up the video subsystem, with the addition of an orientation event at the end of the `done` event.

Fixes #4878 but may actually fix another bug where the Wayland output transform value was interpreted as bitflags and not a linear enum.