### PR TITLE
cmake: Sync build config options with autotools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,10 +395,10 @@ dep_option(SDL_FUSIONSOUND_SHARED  "Dynamically load fusionsound audio support" 
 set_option(SDL_LIBSAMPLERATE       "Use libsamplerate for audio rate conversion" ${UNIX_SYS})
 dep_option(SDL_LIBSAMPLERATE_SHARED "Dynamically load libsamplerate" ON "SDL_LIBSAMPLERATE" OFF)
 set_option(SDL_RPATH               "Use an rpath when linking SDL" ${UNIX_SYS})
-set_option(SDL_CLOCK_GETTIME       "Use clock_gettime() instead of gettimeofday()" OFF)
+set_option(SDL_CLOCK_GETTIME       "Use clock_gettime() instead of gettimeofday()" ${UNIX_SYS})
 set_option(SDL_X11                 "Use X11 video driver" ${UNIX_SYS})
 dep_option(SDL_X11_SHARED          "Dynamically load X11 support" ON "SDL_X11" OFF)
-set(SDL_X11_OPTIONS Xcursor Xinerama XInput Xfixes Xrandr Xscrnsaver XShape Xvm)
+set(SDL_X11_OPTIONS Xcursor Xdbe Xinerama XInput Xfixes Xrandr Xscrnsaver XShape Xvm)
 foreach(_SUB ${SDL_X11_OPTIONS})
   string(TOUPPER "SDL_X11_${_SUB}" _OPT)
   dep_option(${_OPT}               "Enable ${_SUB} support" ON "SDL_X11" OFF)
@@ -836,7 +836,7 @@ if(SDL_LIBC)
     set(HAVE_LIBC TRUE)
     check_include_file(sys/types.h HAVE_SYS_TYPES_H)
     foreach(_HEADER
-            stdio.h stdlib.h stddef.h stdarg.h malloc.h memory.h string.h limits.h
+            stdio.h stdlib.h stddef.h stdarg.h malloc.h memory.h string.h limits.h float.h
             strings.h wchar.h inttypes.h stdint.h ctype.h math.h iconv.h signal.h libunwind.h)
       string(TOUPPER "HAVE_${_HEADER}" _UPPER)
       string(REPLACE "." "_" _HAVE_H ${_UPPER})
@@ -1319,8 +1319,7 @@ elseif(UNIX AND NOT APPLE AND NOT ANDROID AND NOT RISCOS AND NOT HAIKU)
       endif()
 
       if (HAVE_IBUS_IBUS_H OR HAVE_FCITX)
-        set(SDL_USE_IME TRUE)
-        target_compile_definitions(sdl-build-options INTERFACE "-DSDL_USE_IME")   # !!! FIXME: why isn't this a definition and not in SDL_config.h.cmake?
+        set(SDL_USE_IME 1)
       endif()
 
       if(FREEBSD AND NOT HAVE_INOTIFY)

--- a/cmake/sdlchecks.cmake
+++ b/cmake/sdlchecks.cmake
@@ -414,6 +414,7 @@ macro(CheckX11)
     check_include_file(X11/extensions/Xrender.h HAVE_XRENDER_H)
     check_include_file(X11/extensions/scrnsaver.h HAVE_XSS_H)
     check_include_file(X11/extensions/shape.h HAVE_XSHAPE_H)
+    check_include_files("X11/Xlib.h;X11/extensions/Xdbe.h" HAVE_XDBE_H)
     check_include_files("X11/Xlib.h;X11/extensions/xf86vmode.h" HAVE_XF86VM_H)
     check_include_files("X11/Xlib.h;X11/Xproto.h;X11/extensions/Xext.h" HAVE_XEXT_H)
 
@@ -485,6 +486,11 @@ macro(CheckX11)
           list(APPEND EXTRA_LIBS ${XCURSOR_LIB})
         endif()
         set(SDL_VIDEO_DRIVER_X11_XCURSOR 1)
+      endif()
+
+      if(SDL_X11_XDBE AND HAVE_XDBE_H)
+        set(HAVE_X11_XDBE TRUE)
+        set(SDL_VIDEO_DRIVER_X11_XDBE 1)
       endif()
 
       if(SDL_X11_XINERAMA AND HAVE_XINERAMA_H)
@@ -963,7 +969,13 @@ macro(CheckPTHREAD)
       check_include_files("pthread.h" HAVE_PTHREAD_H)
       check_include_files("pthread_np.h" HAVE_PTHREAD_NP_H)
       if (HAVE_PTHREAD_H)
-        check_symbol_exists(pthread_setname_np "pthread.h" HAVE_PTHREAD_SETNAME_NP)
+        check_c_source_compiles("
+            #define _GNU_SOURCE 1
+            #include <pthread.h>
+            int main(int argc, char **argv) {
+              pthread_setname_np(pthread_self(), \"\");
+              return 0;
+            }" HAVE_PTHREAD_SETNAME_NP)
         if (HAVE_PTHREAD_NP_H)
           check_symbol_exists(pthread_set_name_np "pthread.h;pthread_np.h" HAVE_PTHREAD_SET_NAME_NP)
         endif()

--- a/include/SDL_config.h.cmake
+++ b/include/SDL_config.h.cmake
@@ -494,6 +494,9 @@
 /* Enable dynamic libsamplerate support */
 #cmakedefine SDL_LIBSAMPLERATE_DYNAMIC @SDL_LIBSAMPLERATE_DYNAMIC@
 
+/* Enable ime support */
+#cmakedefine SDL_USE_IME @SDL_USE_IME@
+
 /* Platform specific definitions */
 #cmakedefine SDL_IPHONE_KEYBOARD @SDL_IPHONE_KEYBOARD@
 #cmakedefine SDL_IPHONE_LAUNCHSCREEN @SDL_IPHONE_LAUNCHSCREEN@


### PR DESCRIPTION
## Description
I found these by diffing SDL_config.h generated from CMake vs the configure script. I would have just checked this in, but I wanted to get confirmation that none of these were intentional deviations from Autotools.

Changes:
- `SDL_CLOCK_GETTIME` now defaults to ON for Unix to match autotools build
- Add detection of `float.h` and `Xdbe`
- Fix detection of `pthread_setname_np()` (requires `_GNU_SOURCE` defined)
- Move `SDL_USE_IME` definition into `SDL_config.h.cmake`

