### PR TITLE
Fix "Passed a NULL mutex" error in RawInput joystick driver

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -1131,8 +1131,8 @@ SDL_JoystickQuit(void)
         SDL_JoystickClose(SDL_joysticks);
     }
 
-    /* Quit the joystick setup */
-    for (i = 0; i < SDL_arraysize(SDL_joystick_drivers); ++i) {
+    /* Quit drivers in reverse order to avoid breaking dependencies between drivers */
+    for (i = SDL_arraysize(SDL_joystick_drivers) - 1; i >= 0; --i) {
        SDL_joystick_drivers[i]->Quit();
     }
 

--- a/src/joystick/windows/SDL_rawinputjoystick.c
+++ b/src/joystick/windows/SDL_rawinputjoystick.c
@@ -1857,9 +1857,9 @@ RAWINPUT_WindowProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
     LRESULT result = -1;
 
-    SDL_LockMutex(SDL_RAWINPUT_mutex);
-
     if (SDL_RAWINPUT_inited) {
+        SDL_LockMutex(SDL_RAWINPUT_mutex);
+
         switch (msg) {
             case WM_INPUT_DEVICE_CHANGE:
             {
@@ -1903,9 +1903,9 @@ RAWINPUT_WindowProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
             result = 0;
             break;
         }
-    }
 
-    SDL_UnlockMutex(SDL_RAWINPUT_mutex);
+        SDL_UnlockMutex(SDL_RAWINPUT_mutex);
+    }
 
     if (result >= 0) {
         return result;
@@ -1920,8 +1920,6 @@ RAWINPUT_JoystickQuit(void)
         return;
     }
 
-    SDL_LockMutex(SDL_RAWINPUT_mutex);
-
     while (SDL_RAWINPUT_devices) {
         RAWINPUT_DelDevice(SDL_RAWINPUT_devices, SDL_FALSE);
     }
@@ -1932,7 +1930,6 @@ RAWINPUT_JoystickQuit(void)
 
     SDL_RAWINPUT_inited = SDL_FALSE;
 
-    SDL_UnlockMutex(SDL_RAWINPUT_mutex);
     SDL_DestroyMutex(SDL_RAWINPUT_mutex);
     SDL_RAWINPUT_mutex = NULL;
 }


### PR DESCRIPTION
## Description
The RawInput joystick driver depends on a window and notifications registered by the Windows joystick driver. On joystick init, we ensure that the Windows joystick driver is initialized after RawInput to prevent invoking RawInput before it's ready. However, joystick quit happens in the same order as initialization. This creates a race condition where the Windows joystick driver can still invoke `RAWINPUT_WindowProc()` during/after `RAWINPUT_JoystickQuit()` has been called. There are also similar race conditions in WGI, XInput, and RawInput related to `DevicePresent()` functions being called after their respective `JoystickQuit()` functions that are all resolved by reversing the order of quitting the joystick drivers.

With deinitialization in reverse order, we can now simplify the locking in the RawInput driver and resolve #4978 

## Existing Issue(s)
Fixes #4978 
