### PR TITLE
use SDL's functions version inplace of libc version

### DIFF
--- a/Xcode-iOS/Demos/src/accelerometer.c
+++ b/Xcode-iOS/Demos/src/accelerometer.c
@@ -58,7 +58,7 @@ render(SDL_Renderer *renderer, int w, int h, double deltaTime)
         ay * SDL_IPHONE_MAX_GFORCE / SINT16_MAX * GRAVITY_CONSTANT *
         deltaMilliseconds;
 
-    speed = sqrt(shipData.vx * shipData.vx + shipData.vy * shipData.vy);
+    speed = SDL_sqrt(shipData.vx * shipData.vx + shipData.vy * shipData.vy);
 
     if (speed > 0) {
         /* compensate for friction */

--- a/Xcode-iOS/Demos/src/fireworks.c
+++ b/Xcode-iOS/Demos/src/fireworks.c
@@ -109,7 +109,7 @@ stepParticles(double deltaTime)
                 }
             } else {
                 float speed =
-                    sqrt(curr->xvel * curr->xvel + curr->yvel * curr->yvel);
+                    SDL_sqrt(curr->xvel * curr->xvel + curr->yvel * curr->yvel);
                 /*      if wind resistance is not powerful enough to stop us completely,
                    then apply winde resistance, otherwise just stop us completely */
                 if (WIND_RESISTANCE * deltaMilliseconds < speed) {
@@ -194,15 +194,15 @@ explodeEmitter(struct particle *emitter)
         /* come up with a random angle and speed for new particle */
         float theta = randomFloat(0, 2.0f * 3.141592);
         float exponent = 3.0f;
-        float speed = randomFloat(0.00, powf(0.17, exponent));
-        speed = powf(speed, 1.0f / exponent);
+        float speed = randomFloat(0.00, SDL_powf(0.17, exponent));
+        speed = SDL_powf(speed, 1.0f / exponent);
 
         /* select the particle at the end of our array */
         struct particle *p = &particles[num_active_particles];
 
         /* set the particles properties */
-        p->xvel = speed * cos(theta);
-        p->yvel = speed * sin(theta);
+        p->xvel = speed * SDL_cos(theta);
+        p->yvel = speed * SDL_sin(theta);
         p->x = emitter->x + emitter->xvel;
         p->y = emitter->y + emitter->yvel;
         p->isActive = 1;
@@ -297,7 +297,7 @@ spawnEmitterParticle(GLfloat x, GLfloat y)
     p->y = screen_h;
     /* set velocity so that terminal point is (x,y) */
     p->xvel = 0;
-    p->yvel = -sqrt(2 * ACCEL * (screen_h - y));
+    p->yvel = -SDL_sqrt(2 * ACCEL * (screen_h - y));
     /* set other attributes */
     p->size = 10 * pointSizeScale;
     p->type = emitter;

--- a/Xcode-iOS/Demos/src/mixer.c
+++ b/Xcode-iOS/Demos/src/mixer.c
@@ -111,7 +111,7 @@ loadSound(const char *file, struct sound *s)
         if (SDL_ConvertAudio(&cvt) == -1) {     /* convert the sound */
             fatalError("could not convert .wav");
         }
-        SDL_free(s->buffer);    /* free the original (unconverted) buffer */
+        SDL_free(s->buffer);    /* Free the original (unconverted) buffer */
         s->buffer = cvt.buf;    /* point sound buffer to converted buffer */
         s->length = cvt.len_cvt;        /* set sound buffer's new length */
     }

--- a/Xcode-iOS/Demos/src/touch.c
+++ b/Xcode-iOS/Demos/src/touch.c
@@ -21,7 +21,7 @@ void
 drawLine(SDL_Renderer *renderer, float startx, float starty, float dx, float dy)
 {
 
-    float distance = sqrt(dx * dx + dy * dy);   /* length of line segment (pythagoras) */
+    float distance = SDL_sqrt(dx * dx + dy * dy);   /* length of line segment (pythagoras) */
     int iterations = distance / PIXELS_PER_ITERATION + 1;       /* number of brush sprites to draw for the line */
     float dx_prime = dx / iterations;   /* x-shift per iteration */
     float dy_prime = dy / iterations;   /* y-shift per iteration */

--- a/src/SDL_dataqueue.c
+++ b/src/SDL_dataqueue.c
@@ -121,7 +121,7 @@ SDL_ClearDataQueue(SDL_DataQueue *queue, const size_t slack)
     queue->queued_bytes = 0;
     queue->pool = packet;
 
-    /* Optionally keep some slack in the pool to reduce malloc pressure. */
+    /* Optionally keep some slack in the pool to reduce memory allocation pressure. */
     for (i = 0; packet && (i < slackpackets); i++) {
         prev = packet;
         packet = packet->next;

--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -687,7 +687,7 @@ SDL_ClearQueuedAudio(SDL_AudioDeviceID devid)
     /* Blank out the device and release the mutex. Free it afterwards. */
     current_audio.impl.LockDevice(device);
 
-    /* Keep up to two packets in the pool to reduce future malloc pressure. */
+    /* Keep up to two packets in the pool to reduce future memory allocation pressure. */
     SDL_ClearDataQueue(device->buffer_queue, SDL_AUDIOBUFFERQUEUE_PACKETLEN * 2);
 
     current_audio.impl.UnlockDevice(device);

--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -1753,7 +1753,7 @@ SDL_SilenceValueForFormat(const SDL_AudioFormat format)
 {
     switch (format) {
         /* !!! FIXME: 0x80 isn't perfect for U16, but we can't fit 0x8000 in a
-           !!! FIXME:  byte for memset() use. This is actually 0.1953 percent
+           !!! FIXME:  byte for SDL_memset() use. This is actually 0.1953 percent
            !!! FIXME:  off from silence. Maybe just don't use U16. */
         case AUDIO_U16LSB:
         case AUDIO_U16MSB:

--- a/src/audio/SDL_wave.c
+++ b/src/audio/SDL_wave.c
@@ -313,7 +313,7 @@ WaveDebugDumpFormat(WaveFile *file, Uint32 rifflen, Uint32 fmtlen, Uint32 datale
 
     SDL_LogDebug(SDL_LOG_CATEGORY_AUDIO, "%s", dumpstr);
 
-    free(dumpstr);
+    SDL_free(dumpstr);
 }
 #endif
 

--- a/src/audio/SDL_wave.h
+++ b/src/audio/SDL_wave.h
@@ -96,7 +96,7 @@ typedef struct WaveChunk
     Uint32 fourcc;   /* FOURCC of the chunk. */
     Uint32 length;   /* Size of the chunk data. */
     Sint64 position; /* Position of the data in the stream. */
-    Uint8 *data;     /* When allocated, this points to the chunk data. length is used for the malloc size. */
+    Uint8 *data;     /* When allocated, this points to the chunk data. length is used for the memory allocation size. */
     size_t size;     /* Number of bytes in data that could be read from the stream. Can be smaller than length. */
 } WaveChunk;
 

--- a/src/audio/alsa/SDL_alsa_audio.c
+++ b/src/audio/alsa/SDL_alsa_audio.c
@@ -779,7 +779,7 @@ add_device(const int iscapture, const char *name, void *hint, ALSA_Device **pSee
     /* some strings have newlines, like "HDA NVidia, HDMI 0\nHDMI Audio Output".
        just chop the extra lines off, this seems to get a reasonable device
        name without extra details. */
-    if ((ptr = strchr(desc, '\n')) != NULL) {
+    if ((ptr = SDL_strchr(desc, '\n')) != NULL) {
         *ptr = '\0';
     }
 

--- a/src/audio/psp/SDL_pspaudio.c
+++ b/src/audio/psp/SDL_pspaudio.c
@@ -25,7 +25,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <malloc.h>
 
 #include "SDL_audio.h"
 #include "SDL_error.h"

--- a/src/audio/psp/SDL_pspaudio.c
+++ b/src/audio/psp/SDL_pspaudio.c
@@ -90,7 +90,7 @@ PSPAUDIO_OpenDevice(_THIS, void *handle, const char *devname, int iscapture)
         return SDL_SetError("Couldn't reserve hardware channel");
     }
 
-    memset(this->hidden->rawbuf, 0, mixlen);
+    SDL_memset(this->hidden->rawbuf, 0, mixlen);
     for (i = 0; i < NUM_BUFFERS; i++) {
         this->hidden->mixbufs[i] = &this->hidden->rawbuf[i * this->spec.size];
     }

--- a/src/audio/vita/SDL_vitaaudio.c
+++ b/src/audio/vita/SDL_vitaaudio.c
@@ -100,7 +100,7 @@ VITAAUD_OpenDevice(_THIS, void *handle, const char *devname, int iscapture)
 
     sceAudioOutSetVolume(this->hidden->channel, SCE_AUDIO_VOLUME_FLAG_L_CH|SCE_AUDIO_VOLUME_FLAG_R_CH, vols);
 
-    memset(this->hidden->rawbuf, 0, mixlen);
+    SDL_memset(this->hidden->rawbuf, 0, mixlen);
     for (i = 0; i < NUM_BUFFERS; i++) {
         this->hidden->mixbufs[i] = &this->hidden->rawbuf[i * this->spec.size];
     }

--- a/src/audio/vita/SDL_vitaaudio.c
+++ b/src/audio/vita/SDL_vitaaudio.c
@@ -25,7 +25,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <malloc.h>
 
 #include "SDL_audio.h"
 #include "SDL_error.h"

--- a/src/core/freebsd/SDL_evdev_kbd_freebsd.c
+++ b/src/core/freebsd/SDL_evdev_kbd_freebsd.c
@@ -268,7 +268,7 @@ SDL_EVDEV_kbd_init(void)
             kbd->key_map = &keymap_default_us_acc;
         }
         /* Allow inhibiting keyboard mute with env. variable for debugging etc. */
-        if (getenv("SDL_INPUT_FREEBSD_KEEP_KBD") == NULL) {
+        if (SDL_getenv("SDL_INPUT_FREEBSD_KEEP_KBD") == NULL) {
             /* Take keyboard from console and open the actual keyboard device.
              * Ensures that the keystrokes do not leak through to the console.
              */

--- a/src/core/openbsd/SDL_wscons_kbd.c
+++ b/src/core/openbsd/SDL_wscons_kbd.c
@@ -509,7 +509,7 @@ static void put_utf8(SDL_WSCONS_input_data* input, uint c)
 static void Translate_to_text(SDL_WSCONS_input_data* input, keysym_t ksym)
 {
     if (KS_GROUP(ksym) == KS_GROUP_Keypad) {
-        if (isprint(ksym & 0xFF)) ksym &= 0xFF;
+        if (SDL_isprint(ksym & 0xFF)) ksym &= 0xFF;
     }
     switch(ksym) {
     case KS_Escape:
@@ -526,7 +526,7 @@ static void Translate_to_text(SDL_WSCONS_input_data* input, keysym_t ksym)
     if (input->text_len > 0) {
         input->text[input->text_len] = '\0';
         SDL_SendKeyboardText(input->text);
-        /*memset(input->text, 0, sizeof(input->text));*/
+        /*SDL_memset(input->text, 0, sizeof(input->text));*/
         input->text_len = 0;
         input->text[0] = 0;
     }

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -1063,7 +1063,7 @@ SDL_SIMDAlloc(const size_t len)
     Uint8 *retval = NULL;
     Uint8 *ptr = (Uint8 *) SDL_malloc(padded + alignment + sizeof (void *));
     if (ptr) {
-        /* store the actual malloc pointer right before our aligned pointer. */
+        /* store the actual allocated pointer right before our aligned pointer. */
         retval = ptr + sizeof (void *);
         retval += alignment - (((size_t) retval) % alignment);
         *(((void **) retval) - 1) = ptr;
@@ -1097,7 +1097,7 @@ SDL_SIMDRealloc(void *mem, const size_t len)
         return NULL; /* Out of memory, bail! */
     }
 
-    /* Store the actual malloc pointer right before our aligned pointer. */
+    /* Store the actual allocated pointer right before our aligned pointer. */
     retval = ptr + sizeof (void *);
     retval += alignment - (((size_t) retval) % alignment);
 
@@ -1115,7 +1115,7 @@ SDL_SIMDRealloc(void *mem, const size_t len)
         }
     }
 
-    /* Actually store the malloc pointer, finally. */
+    /* Actually store the allocated pointer, finally. */
     *(((void **) retval) - 1) = ptr;
     return retval;
 }

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -377,8 +377,8 @@ CPU_haveARMSIMD(void)
             {
                 const char *plat = (const char *) aux.a_un.a_val;
                 if (plat) {
-                    arm_simd = strncmp(plat, "v6l", 3) == 0 ||
-                               strncmp(plat, "v7l", 3) == 0;
+                    arm_simd = SDL_strncmp(plat, "v6l", 3) == 0 ||
+                               SDL_strncmp(plat, "v7l", 3) == 0;
                 }
             }
         }

--- a/src/events/SDL_gesture.c
+++ b/src/events/SDL_gesture.c
@@ -32,7 +32,7 @@
 #include <stdio.h>
 */
 
-/* TODO: Replace with malloc */
+/* TODO: Replace with SDL_malloc */
 
 #define MAXPATHSIZE 1024
 

--- a/src/events/SDL_quit.c
+++ b/src/events/SDL_quit.c
@@ -54,7 +54,7 @@ SDL_HandleSIG(int sig)
     signal(sig, SDL_HandleSIG);
 
     /* Send a quit event next time the event loop pumps. */
-    /* We can't send it in signal handler; malloc() might be interrupted! */
+    /* We can't send it in signal handler; SDL_malloc() might be interrupted! */
     if ((sig == SIGINT) || (sig == SIGTERM)) {
         send_quit_pending = SDL_TRUE;
     }

--- a/src/filesystem/riscos/SDL_sysfilesystem.c
+++ b/src/filesystem/riscos/SDL_sysfilesystem.c
@@ -181,7 +181,7 @@ SDL_GetPrefPath(const char *org, const char *app)
     dir = (char *) SDL_malloc(len);
     if (!dir) {
         SDL_OutOfMemory();
-        free(canon);
+        SDL_free(canon);
         return NULL;
     }
 

--- a/src/filesystem/riscos/SDL_sysfilesystem.c
+++ b/src/filesystem/riscos/SDL_sysfilesystem.c
@@ -37,7 +37,7 @@
 static char *
 SDL_unixify_std(const char *ro_path, char *buffer, size_t buf_len, int filetype)
 {
-    const char *const in_buf = buffer; /* = NULL if we malloc the buffer.  */
+    const char *const in_buf = buffer; /* = NULL if we allocate the buffer.  */
 
     if (!buffer) {
         /* This matches the logic in __unixify, with an additional byte for the

--- a/src/filesystem/unix/SDL_sysfilesystem.c
+++ b/src/filesystem/unix/SDL_sysfilesystem.c
@@ -82,7 +82,7 @@ readSymLink(const char *path)
 #if defined(__OPENBSD__)
 static char *search_path_for_binary(const char *bin)
 {
-    char *envr = getenv("PATH");
+    char *envr = SDL_getenv("PATH");
     size_t alloc_size;
     char *exe = NULL;
     char *start = envr;

--- a/src/haptic/linux/SDL_syshaptic.c
+++ b/src/haptic/linux/SDL_syshaptic.c
@@ -35,7 +35,6 @@
 #include <fcntl.h>              /* O_RDWR */
 #include <limits.h>             /* INT_MAX */
 #include <errno.h>              /* errno, strerror */
-#include <math.h>               /* atan2 */
 #include <sys/stat.h>           /* stat */
 
 /* Just in case. */
@@ -713,10 +712,10 @@ SDL_SYS_ToDirection(Uint16 *dest, SDL_HapticDirection * src)
         else {
             float f = SDL_atan2(src->dir[1], src->dir[0]);    /* Ideally we'd use fixed point math instead of floats... */
                     /*
-                      atan2 takes the parameters: Y-axis-value and X-axis-value (in that order)
+                      SDL_atan2 takes the parameters: Y-axis-value and X-axis-value (in that order)
                        - Y-axis-value is the second coordinate (from center to SOUTH)
                        - X-axis-value is the first coordinate (from center to EAST)
-                        We add 36000, because atan2 also returns negative values. Then we practically
+                        We add 36000, because SDL_atan2 also returns negative values. Then we practically
                         have the first spherical value. Therefore we proceed as in case
                         SDL_HAPTIC_SPHERICAL and add another 9000 to get the polar value.
                       --> add 45000 in total

--- a/src/hidapi/android/hid.cpp
+++ b/src/hidapi/android/hid.cpp
@@ -53,7 +53,6 @@
 #include <pthread.h>
 #include <errno.h>	// For ETIMEDOUT and ECONNRESET
 #include <stdlib.h> // For malloc() and free()
-#include <string.h>	// For memcpy()
 
 #define TAG "hidapi"
 
@@ -196,7 +195,7 @@ public:
 		}
 
 		m_nSize = nSize;
-		memcpy( m_pData, pData, nSize );
+		SDL_memcpy( m_pData, pData, nSize );
 	}
 
 	void clear()
@@ -313,7 +312,7 @@ static jbyteArray NewByteArray( JNIEnv* env, const uint8_t *pData, size_t nDataL
 {
 	jbyteArray array = env->NewByteArray( (jsize)nDataLen );
 	jbyte *pBuf = env->GetByteArrayElements( array, NULL );
-	memcpy( pBuf, pData, nDataLen );
+	SDL_memcpy( pBuf, pData, nDataLen );
 	env->ReleaseByteArrayElements( array, pBuf, 0 );
 
 	return array;
@@ -324,7 +323,7 @@ static char *CreateStringFromJString( JNIEnv *env, const jstring &sString )
 	size_t nLength = env->GetStringUTFLength( sString );
 	const char *pjChars = env->GetStringUTFChars( sString, NULL );
 	char *psString = (char*)malloc( nLength + 1 );
-	memcpy( psString, pjChars, nLength );
+	SDL_memcpy( psString, pjChars, nLength );
 	psString[ nLength ] = '\0';
 	env->ReleaseStringUTFChars( sString, pjChars );
 	return psString;
@@ -347,9 +346,9 @@ static wchar_t *CreateWStringFromJString( JNIEnv *env, const jstring &sString )
 
 static wchar_t *CreateWStringFromWString( const wchar_t *pwSrc )
 {
-	size_t nLength = wcslen( pwSrc );
+	size_t nLength = SDL_wcslen( pwSrc );
 	wchar_t *pwString = (wchar_t*)malloc( ( nLength + 1 ) * sizeof( wchar_t ) );
-	memcpy( pwString, pwSrc, nLength * sizeof( wchar_t ) );
+	SDL_memcpy( pwString, pwSrc, nLength * sizeof( wchar_t ) );
 	pwString[ nLength ] = '\0';
 	return pwString;
 }
@@ -358,7 +357,7 @@ static hid_device_info *CopyHIDDeviceInfo( const hid_device_info *pInfo )
 {
 	hid_device_info *pCopy = new hid_device_info;
 	*pCopy = *pInfo;
-	pCopy->path = strdup( pInfo->path );
+	pCopy->path = SDL_strdup( pInfo->path );
 	pCopy->product_string = CreateWStringFromWString( pInfo->product_string );
 	pCopy->manufacturer_string = CreateWStringFromWString( pInfo->manufacturer_string );
 	pCopy->serial_number = CreateWStringFromWString( pInfo->serial_number );
@@ -579,12 +578,12 @@ public:
 		if ( m_bIsBLESteamController )
 		{
 			data[0] = 0x03;
-			memcpy( data + 1, buffer.data(), nDataLen );
+			SDL_memcpy( data + 1, buffer.data(), nDataLen );
 			++nDataLen;
 		}
 		else
 		{
-			memcpy( data, buffer.data(), nDataLen );
+			SDL_memcpy( data, buffer.data(), nDataLen );
 		}
 		m_vecData.pop_front();
 
@@ -721,7 +720,7 @@ public:
 			}
 
 			size_t uBytesToCopy = m_featureReport.size() > nDataLen ? nDataLen : m_featureReport.size();
-			memcpy( pData, m_featureReport.data(), uBytesToCopy );
+			SDL_memcpy( pData, m_featureReport.data(), uBytesToCopy );
 			m_featureReport.clear();
 			LOGV( "=== Got %u bytes", uBytesToCopy );
 
@@ -921,7 +920,7 @@ JNIEXPORT void JNICALL HID_DEVICE_MANAGER_JAVA_INTERFACE(HIDDeviceConnected)(JNI
 	LOGV( "HIDDeviceConnected() id=%d VID/PID = %.4x/%.4x, interface %d\n", nDeviceID, nVendorId, nProductId, nInterface );
 
 	hid_device_info *pInfo = new hid_device_info;
-	memset( pInfo, 0, sizeof( *pInfo ) );
+	SDL_memset( pInfo, 0, sizeof( *pInfo ) );
 	pInfo->path = CreateStringFromJString( env, sIdentifier );
 	pInfo->vendor_id = nVendorId;
 	pInfo->product_id = nProductId;
@@ -1120,7 +1119,7 @@ HID_API_EXPORT hid_device * HID_API_CALL hid_open_path(const char *path, int bEx
 		hid_mutex_guard l( &g_DevicesMutex );
 		for ( hid_device_ref<CHIDDevice> pCurr = g_Devices; pCurr; pCurr = pCurr->next )
 		{
-			if ( strcmp( pCurr->GetDeviceInfo()->path, path ) == 0 ) 
+			if ( SDL_strcmp( pCurr->GetDeviceInfo()->path, path ) == 0 ) 
 			{
 				hid_device *pValue = pCurr->GetDevice();
 				if ( pValue )

--- a/src/joystick/bsd/SDL_bsdjoystick.c
+++ b/src/joystick/bsd/SDL_bsdjoystick.c
@@ -552,7 +552,7 @@ BSD_JoystickUpdate(SDL_Joystick *joy)
 
     if (joy->hwdata->type == BSDJOY_JOY) {
         while (read(joy->hwdata->fd, &gameport, sizeof gameport) == sizeof gameport) {
-            if (abs(x - gameport.x) > 8) {
+            if (SDL_abs(x - gameport.x) > 8) {
                 x = gameport.x;
                 if (x < xmin) {
                     xmin = x;
@@ -569,7 +569,7 @@ BSD_JoystickUpdate(SDL_Joystick *joy)
                 v *= 32768 / ((xmax - xmin + 1) / 2);
                 SDL_PrivateJoystickAxis(joy, 0, v);
             }
-            if (abs(y - gameport.y) > 8) {
+            if (SDL_abs(y - gameport.y) > 8) {
                 y = gameport.y;
                 if (y < ymin) {
                     ymin = y;

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -190,7 +190,7 @@ typedef struct
 
 
 // Wireless firmware quirk: the firmware intentionally signals "failure" when performing
-// SET_FEATURE / GET_FEATURE when it actually means "pending radio round-trip". The only
+// SET_FEATURE / GET_FEATURE when it actually means "pending radio roundtrip". The only
 // way to make SET_FEATURE / GET_FEATURE work is to loop several times with a sleep. If
 // it takes more than 50ms to get the response for SET_FEATURE / GET_FEATURE, we assume
 // that the controller has failed.

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -220,7 +220,7 @@ static void hexdump( const uint8_t *ptr, int len )
 
 static void ResetSteamControllerPacketAssembler( SteamControllerPacketAssembler *pAssembler )
 {
-    memset( pAssembler->uBuffer, 0, sizeof( pAssembler->uBuffer ) );
+    SDL_memset( pAssembler->uBuffer, 0, sizeof( pAssembler->uBuffer ) );
     pAssembler->nExpectedSegmentNumber = 0;
 }
 
@@ -279,7 +279,7 @@ static int WriteSegmentToSteamControllerPacketAssembler( SteamControllerPacketAs
             }
         }
         
-        memcpy( pAssembler->uBuffer + nSegmentNumber * MAX_REPORT_SEGMENT_PAYLOAD_SIZE,
+        SDL_memcpy( pAssembler->uBuffer + nSegmentNumber * MAX_REPORT_SEGMENT_PAYLOAD_SIZE,
                pSegment + 2, // ignore header and report number
                MAX_REPORT_SEGMENT_PAYLOAD_SIZE );
         
@@ -294,7 +294,7 @@ static int WriteSegmentToSteamControllerPacketAssembler( SteamControllerPacketAs
     else
     {
         // Just pass through
-        memcpy( pAssembler->uBuffer,
+        SDL_memcpy( pAssembler->uBuffer,
                pSegment,
                nSegmentLength );
         return nSegmentLength;
@@ -331,10 +331,10 @@ static int SetFeatureReport( SDL_hid_device *dev, unsigned char uBuffer[65], int
             nActualDataLen -= nBytesInPacket;
 
             // Construct packet
-            memset( uPacketBuffer, 0, sizeof( uPacketBuffer ) );
+            SDL_memset( uPacketBuffer, 0, sizeof( uPacketBuffer ) );
             uPacketBuffer[ 0 ] = BLE_REPORT_NUMBER;
             uPacketBuffer[ 1 ] = GetSegmentHeader( nSegmentNumber, nActualDataLen == 0 );
-            memcpy( &uPacketBuffer[ 2 ], pBufferPtr, nBytesInPacket );
+            SDL_memcpy( &uPacketBuffer[ 2 ], pBufferPtr, nBytesInPacket );
             
             pBufferPtr += nBytesInPacket;
             nSegmentNumber++;
@@ -364,7 +364,7 @@ static int GetFeatureReport( SDL_hid_device *dev, unsigned char uBuffer[65] )
         
         while( nRetries < BLE_MAX_READ_RETRIES )
         {
-            memset( uSegmentBuffer, 0, sizeof( uSegmentBuffer ) );
+            SDL_memset( uSegmentBuffer, 0, sizeof( uSegmentBuffer ) );
             uSegmentBuffer[ 0 ] = BLE_REPORT_NUMBER;
             nRet = SDL_hid_get_feature_report( dev, uSegmentBuffer, sizeof( uSegmentBuffer ) );
             DPRINTF( "GetFeatureReport ble ret=%d\n", nRet );
@@ -386,7 +386,7 @@ static int GetFeatureReport( SDL_hid_device *dev, unsigned char uBuffer[65] )
                 {
                     // Leave space for "report number"
                     uBuffer[ 0 ] = 0;
-                    memcpy( uBuffer + 1, assembler.uBuffer, nPacketLength );
+                    SDL_memcpy( uBuffer + 1, assembler.uBuffer, nPacketLength );
                     return nPacketLength;
                 }
             }
@@ -500,7 +500,7 @@ static bool ResetSteamController( SDL_hid_device *dev, bool bSuppressErrorSpew, 
     }
     
     // Reset the default settings
-    memset( buf, 0, 65 );
+    SDL_memset( buf, 0, 65 );
     buf[1] = ID_LOAD_DEFAULT_SETTINGS;
     buf[2] = 0;
     res = SetFeatureReport( dev, buf, 3 );
@@ -518,7 +518,7 @@ buf[3+nSettings*3+1] = ((uint16_t)VALUE)&0xFF; \
 buf[3+nSettings*3+2] = ((uint16_t)VALUE)>>8; \
 ++nSettings;
     
-    memset( buf, 0, 65 );
+    SDL_memset( buf, 0, 65 );
     buf[1] = ID_SET_SETTINGS_VALUES;
     ADD_SETTING( SETTING_WIRELESS_PACKET_VERSION, 2 );
     ADD_SETTING( SETTING_LEFT_TRACKPAD_MODE, TRACKPAD_NONE );
@@ -547,7 +547,7 @@ buf[3+nSettings*3+2] = ((uint16_t)VALUE)>>8; \
     int iRetry;
     for ( iRetry = 0; iRetry < 2; ++iRetry )
     {
-        memset( buf, 0, 65 );
+        SDL_memset( buf, 0, 65 );
         buf[1] = ID_GET_DIGITAL_MAPPINGS;
         buf[2] = 1; // one byte - requesting from index 0
         buf[3] = 0;
@@ -580,7 +580,7 @@ buf[3+nSettings*3+2] = ((uint16_t)VALUE)>>8; \
     }
     
     // Set our new mappings
-    memset( buf, 0, 65 );
+    SDL_memset( buf, 0, 65 );
     buf[1] = ID_SET_DIGITAL_MAPPINGS;
     buf[2] = 6; // 2 settings x 3 bytes
     buf[3] = IO_DIGITAL_BUTTON_RIGHT_TRIGGER;
@@ -608,7 +608,7 @@ buf[3+nSettings*3+2] = ((uint16_t)VALUE)>>8; \
 //---------------------------------------------------------------------------
 static int ReadSteamController( SDL_hid_device *dev, uint8_t *pData, int nDataSize )
 {
-    memset( pData, 0, nDataSize );
+    SDL_memset( pData, 0, nDataSize );
     pData[ 0 ] = BLE_REPORT_NUMBER; // hid_read will also overwrite this with the same value, 0x03
     return SDL_hid_read( dev, pData, nDataSize );
 }
@@ -624,18 +624,18 @@ static void CloseSteamController( SDL_hid_device *dev )
     int nSettings = 0;
     
     // Reset digital button mappings
-    memset( buf, 0, 65 );
+    SDL_memset( buf, 0, 65 );
     buf[1] = ID_SET_DEFAULT_DIGITAL_MAPPINGS;
     SetFeatureReport( dev, buf, 2 );
 
     // Reset the default settings
-    memset( buf, 0, 65 );
+    SDL_memset( buf, 0, 65 );
     buf[1] = ID_LOAD_DEFAULT_SETTINGS;
     buf[2] = 0;
     SetFeatureReport( dev, buf, 3 );
 
     // Reset mouse mode for lizard mode
-    memset( buf, 0, 65 );
+    SDL_memset( buf, 0, 65 );
     buf[1] = ID_SET_SETTINGS_VALUES;
     ADD_SETTING( SETTING_RIGHT_TRACKPAD_MODE, TRACKPAD_ABSOLUTE_MOUSE );
     buf[2] = nSettings*3;
@@ -695,14 +695,14 @@ static void FormatStatePacketUntilGyro( SteamControllerStateInternal_t *pState, 
     // 15 degrees in rad
     const float flRotationAngle = 0.261799f;
 
-    memset(pState, 0, offsetof(SteamControllerStateInternal_t, sBatteryLevel));
+    SDL_memset(pState, 0, offsetof(SteamControllerStateInternal_t, sBatteryLevel));
 
     //pState->eControllerType = m_eControllerType;
     pState->eControllerType = 2; // k_eControllerType_SteamController;
     pState->unPacketNum = pStatePacket->unPacketNum;
 
     // We have a chunk of trigger data in the packet format here, so zero it out afterwards
-    memcpy(&pState->ulButtons, &pStatePacket->ButtonTriggerData.ulButtons, 8);
+    SDL_memcpy(&pState->ulButtons, &pStatePacket->ButtonTriggerData.ulButtons, 8);
     pState->ulButtons &= ~0xFFFF000000LL;
 
     // The firmware uses this bit to tell us what kind of data is packed into the left two axises
@@ -822,7 +822,7 @@ static bool UpdateBLESteamControllerState( const uint8_t *pData, int nDataSize, 
     ucOptionDataMask |= (uint32_t)(*pData++) << 8;
     if ( ucOptionDataMask & k_EBLEButtonChunk1 )
     {
-        memcpy( &pState->ulButtons, pData, 3 );
+        SDL_memcpy( &pState->ulButtons, pData, 3 );
         pData += 3;
     }
     if ( ucOptionDataMask & k_EBLEButtonChunk2 )
@@ -844,14 +844,14 @@ static bool UpdateBLESteamControllerState( const uint8_t *pData, int nDataSize, 
         // This doesn't handle any of the special headcrab stuff for raw joystick which is OK for now since that FW doesn't support
         // this protocol yet either
         int nLength = sizeof( pState->sLeftStickX ) + sizeof( pState->sLeftStickY );
-        memcpy( &pState->sLeftStickX, pData, nLength );
+        SDL_memcpy( &pState->sLeftStickX, pData, nLength );
         pData += nLength;
     }
     if ( ucOptionDataMask & k_EBLELeftTrackpadChunk )
     {
         int nLength = sizeof( pState->sLeftPadX ) + sizeof( pState->sLeftPadY );
         int nPadOffset;
-        memcpy( &pState->sLeftPadX, pData, nLength );
+        SDL_memcpy( &pState->sLeftPadX, pData, nLength );
         if ( pState->ulButtons & STEAM_LEFTPAD_FINGERDOWN_MASK )
             nPadOffset = 1000;
         else
@@ -867,7 +867,7 @@ static bool UpdateBLESteamControllerState( const uint8_t *pData, int nDataSize, 
         int nLength = sizeof( pState->sRightPadX ) + sizeof( pState->sRightPadY );
         int nPadOffset = 0;
 
-        memcpy( &pState->sRightPadX, pData, nLength );
+        SDL_memcpy( &pState->sRightPadX, pData, nLength );
 
         if ( pState->ulButtons & STEAM_RIGHTPAD_FINGERDOWN_MASK )
             nPadOffset = 1000;
@@ -882,19 +882,19 @@ static bool UpdateBLESteamControllerState( const uint8_t *pData, int nDataSize, 
     if ( ucOptionDataMask & k_EBLEIMUAccelChunk )
     {
         int nLength = sizeof( pState->sAccelX ) + sizeof( pState->sAccelY ) + sizeof( pState->sAccelZ );
-        memcpy( &pState->sAccelX, pData, nLength );
+        SDL_memcpy( &pState->sAccelX, pData, nLength );
         pData += nLength;
     }
     if ( ucOptionDataMask & k_EBLEIMUGyroChunk )
     {
         int nLength = sizeof( pState->sAccelX ) + sizeof( pState->sAccelY ) + sizeof( pState->sAccelZ );
-        memcpy( &pState->sGyroX, pData, nLength );
+        SDL_memcpy( &pState->sGyroX, pData, nLength );
         pData += nLength;
     }
     if ( ucOptionDataMask & k_EBLEIMUQuatChunk )
     {
         int nLength = sizeof( pState->sGyroQuatW ) + sizeof( pState->sGyroQuatX ) + sizeof( pState->sGyroQuatY ) + sizeof( pState->sGyroQuatZ );
-        memcpy( &pState->sGyroQuatW, pData, nLength );
+        SDL_memcpy( &pState->sGyroQuatW, pData, nLength );
         pData += nLength;
     }
     return true;
@@ -1122,7 +1122,7 @@ HIDAPI_DriverSteam_SetSensorsEnabled(SDL_HIDAPI_Device *device, SDL_Joystick *jo
     unsigned char buf[65];
     int nSettings = 0;
 
-    memset( buf, 0, 65 );
+    SDL_memset( buf, 0, 65 );
     buf[1] = ID_SET_SETTINGS_VALUES;
     if (enabled) {
         ADD_SETTING( SETTING_GYRO_MODE, 0x18 /* SETTING_GYRO_SEND_RAW_ACCEL | SETTING_GYRO_MODE_SEND_RAW_GYRO */ );

--- a/src/joystick/windows/SDL_dinputjoystick.c
+++ b/src/joystick/windows/SDL_dinputjoystick.c
@@ -432,7 +432,7 @@ SDL_DINPUT_JoystickInit(void)
 static BOOL CALLBACK
 EnumJoystickDetectCallback(LPCDIDEVICEINSTANCE pDeviceInstance, LPVOID pContext)
 {
-#define CHECK(exp) { if(!(exp)) goto err; }
+#define CHECK(expression) { if(!(expression)) goto err; }
     JoyStick_DeviceData *pNewJoystick = NULL;
     JoyStick_DeviceData *pPrevJoystick = NULL;
     Uint16 *guid16;
@@ -553,7 +553,7 @@ typedef struct
 static BOOL CALLBACK
 EnumJoystickPresentCallback(LPCDIDEVICEINSTANCE pDeviceInstance, LPVOID pContext)
 {
-#define CHECK(exp) { if(!(exp)) goto err; }
+#define CHECK(expression) { if(!(expression)) goto err; }
     Joystick_PresentData *pData = (Joystick_PresentData *)pContext;
     Uint16 vendor = 0;
     Uint16 product = 0;

--- a/src/joystick/windows/SDL_rawinputjoystick.c
+++ b/src/joystick/windows/SDL_rawinputjoystick.c
@@ -679,7 +679,7 @@ RAWINPUT_DeviceFromHandle(HANDLE hDevice)
 static void
 RAWINPUT_AddDevice(HANDLE hDevice)
 {
-#define CHECK(exp) { if(!(exp)) goto err; }
+#define CHECK(expression) { if(!(expression)) goto err; }
     SDL_RAWINPUT_Device *device = NULL;
     SDL_RAWINPUT_Device *curr, *last;
     RID_DEVICE_INFO rdi;

--- a/src/locale/SDL_locale.c
+++ b/src/locale/SDL_locale.c
@@ -45,7 +45,7 @@ build_locales_from_csv_string(char *csv)
 
     num_locales++;  /* one more for terminator */
 
-    slen = ((size_t) (ptr - csv)) + 1;  /* strlen(csv) + 1 */
+    slen = ((size_t) (ptr - csv)) + 1;  /* SDL_strlen(csv) + 1 */
     alloclen = slen + (num_locales * sizeof (SDL_Locale));
 
     loc = retval = (SDL_Locale *) SDL_calloc(1, alloclen);

--- a/src/misc/vita/SDL_sysurl.c
+++ b/src/misc/vita/SDL_sysurl.c
@@ -35,7 +35,7 @@ SDL_SYS_OpenURL(const char *url)
     sceAppUtilInit(&init_param, &boot_param);
     SDL_zero(browser_param);
     browser_param.str = url;
-    browser_param.strlen = strlen(url);
+    browser_param.strlen = SDL_strlen(url);
     sceAppUtilLaunchWebBrowser(&browser_param);
     return 0;
 }

--- a/src/power/haiku/SDL_syspower.c
+++ b/src/power/haiku/SDL_syspower.c
@@ -59,7 +59,7 @@ SDL_GetPowerInfo_Haiku(SDL_PowerState * state, int *seconds, int *percent)
         return SDL_FALSE;       /* maybe some other method will work? */
     }
 
-    memset(regs, '\0', sizeof(regs));
+    SDL_memset(regs, '\0', sizeof(regs));
     regs[0] = APM_FUNC_OFFSET + APM_FUNC_GET_POWER_STATUS;
     regs[1] = APM_DEVICE_ALL;
     rc = ioctl(fd, APM_BIOS_CALL, regs);

--- a/src/power/linux/SDL_syspower.c
+++ b/src/power/linux/SDL_syspower.c
@@ -51,7 +51,7 @@ open_power_file(const char *base, const char *node, const char *key)
         return -1;  /* oh well. */
     }
 
-    snprintf(path, pathlen, "%s/%s/%s", base, node, key);
+    SDL_snprintf(path, pathlen, "%s/%s/%s", base, node, key);
     fd = open(path, O_RDONLY | O_CLOEXEC);
     SDL_stack_free(path);
     return fd;

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -766,15 +766,15 @@ SDL_RendererEventWatch(void *userdata, SDL_Event *event)
                 event->motion.y = (int)(event->motion.y / (scale.y * renderer->dpi_scale.y));
                 if (event->motion.xrel != 0 && renderer->relative_scaling) {
                     float rel = renderer->xrel + event->motion.xrel / (scale.x * renderer->dpi_scale.x);
-                    float trunc = SDL_truncf(rel);
-                    renderer->xrel = rel - trunc;
-                    event->motion.xrel = (Sint32) trunc;
+                    float truncated = SDL_truncf(rel);
+                    renderer->xrel = rel - truncated;
+                    event->motion.xrel = (Sint32) truncated;
                 }
                 if (event->motion.yrel != 0 && renderer->relative_scaling) {
                     float rel = renderer->yrel + event->motion.yrel / (scale.y * renderer->dpi_scale.y);
-                    float trunc = SDL_truncf(rel);
-                    renderer->yrel = rel - trunc;
-                    event->motion.yrel = (Sint32) trunc;
+                    float truncated = SDL_truncf(rel);
+                    renderer->yrel = rel - truncated;
+                    event->motion.yrel = (Sint32) truncated;
                 }
             }
         }

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -221,7 +221,7 @@ TextureSwizzle(PSP_TextureData *psp_texture)
     unsigned int *src = (unsigned int*) psp_texture->data;
 
     unsigned char *data = NULL;
-    data = malloc(psp_texture->size);
+    data = SDL_malloc(psp_texture->size);
 
     int j;
 
@@ -246,7 +246,7 @@ TextureSwizzle(PSP_TextureData *psp_texture)
             blockaddress += rowblocksadd;
     }
 
-    free(psp_texture->data);
+    SDL_free(psp_texture->data);
     psp_texture->data = data;
     psp_texture->swizzled = SDL_TRUE;
 
@@ -272,7 +272,7 @@ int TextureUnswizzle(PSP_TextureData *psp_texture)
 
     unsigned char *data = NULL;
 
-    data = malloc(psp_texture->size);
+    data = SDL_malloc(psp_texture->size);
 
     if(!data)
         return 0;
@@ -308,7 +308,7 @@ int TextureUnswizzle(PSP_TextureData *psp_texture)
         ydst += dstrow;
     }
 
-    free(psp_texture->data);
+    SDL_free(psp_texture->data);
 
     psp_texture->data = data;
 

--- a/src/render/software/SDL_rotate.c
+++ b/src/render/software/SDL_rotate.c
@@ -184,7 +184,7 @@ computeSourceIncrements90(SDL_Surface * src, int bpp, int angle, int flipx, int 
     if (signy < 0) sp += (src->h-1)*src->pitch;                                                             \
                                                                                                             \
     for (dy = 0; dy < dst->h; sp += sincy, dp += dincy, dy++) {                                             \
-        if (sincx == sizeof(pixelType)) { /* if advancing src and dest equally, use memcpy */               \
+        if (sincx == sizeof(pixelType)) { /* if advancing src and dest equally, use SDL_memcpy */           \
             SDL_memcpy(dp, sp, dst->w*sizeof(pixelType));                                                   \
             sp += dst->w*sizeof(pixelType);                                                                 \
             dp += dst->w*sizeof(pixelType);                                                                 \
@@ -439,7 +439,7 @@ SDLgfx_rotateSurface(SDL_Surface * src, double angle, int centerx, int centery, 
     if (!(is8bit || (src->format->BitsPerPixel == 32 && src->format->Amask)))
         return NULL;
 
-    /* Calculate target factors from sin/cos and zoom */
+    /* Calculate target factors from sine/cosine and zoom */
     sangleinv = sangle*65536.0;
     cangleinv = cangle*65536.0;
 

--- a/src/render/vitagxm/SDL_render_vita_gxm_tools.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm_tools.c
@@ -925,7 +925,7 @@ void gxm_finish(SDL_Renderer *renderer)
         sceGxmSyncObjectDestroy(data->displayBufferSync[i]);
     }
 
-    // free the depth and stencil buffer
+    // Free the depth and stencil buffer
     mem_gpu_free(data->depthBufferUid);
     mem_gpu_free(data->stencilBufferUid);
 
@@ -1040,7 +1040,7 @@ create_gxm_texture(VITA_GXM_RenderData *data, unsigned int w, unsigned int h, Sc
     }
 
     if (!texture_data) {
-        free(texture);
+        SDL_free(texture);
         return NULL;
     }
 

--- a/src/render/vitagxm/SDL_render_vita_gxm_tools.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm_tools.c
@@ -475,7 +475,7 @@ gxm_init(SDL_Renderer *renderer)
             SCE_GXM_MEMORY_ATTRIB_READ | SCE_GXM_MEMORY_ATTRIB_WRITE,
             &data->displayBufferUid[i]);
 
-        // memset the buffer to black
+        // SDL_memset the buffer to black
         for (y = 0; y < VITA_GXM_SCREEN_HEIGHT; y++) {
             unsigned int *row = (unsigned int *)data->displayBufferData[i] + y * VITA_GXM_SCREEN_STRIDE;
             for (x = 0; x < VITA_GXM_SCREEN_WIDTH; x++) {
@@ -1104,7 +1104,7 @@ create_gxm_texture(VITA_GXM_RenderData *data, unsigned int w, unsigned int h, Sc
 
             // set up parameters
             SceGxmRenderTargetParams renderTargetParams;
-            memset(&renderTargetParams, 0, sizeof(SceGxmRenderTargetParams));
+            SDL_memset(&renderTargetParams, 0, sizeof(SceGxmRenderTargetParams));
             renderTargetParams.flags = 0;
             renderTargetParams.width = w;
             renderTargetParams.height = h;

--- a/src/thread/psp/SDL_syssem.c
+++ b/src/thread/psp/SDL_syssem.c
@@ -43,13 +43,13 @@ SDL_sem *SDL_CreateSemaphore(Uint32 initial_value)
 {
     SDL_sem *sem;
 
-    sem = (SDL_sem *) malloc(sizeof(*sem));
+    sem = (SDL_sem *) SDL_malloc(sizeof(*sem));
     if (sem != NULL) {
         /* TODO: Figure out the limit on the maximum value. */
         sem->semid = sceKernelCreateSema("SDL sema", 0, initial_value, 255, NULL);
         if (sem->semid < 0) {
             SDL_SetError("Couldn't create semaphore");
-            free(sem);
+            SDL_free(sem);
             sem = NULL;
         }
     } else {
@@ -68,7 +68,7 @@ void SDL_DestroySemaphore(SDL_sem *sem)
             sem->semid = 0;
         }
 
-        free(sem);
+        SDL_free(sem);
     }
 }
 

--- a/src/thread/vita/SDL_syssem.c
+++ b/src/thread/vita/SDL_syssem.c
@@ -44,13 +44,13 @@ SDL_sem *SDL_CreateSemaphore(Uint32 initial_value)
 {
     SDL_sem *sem;
 
-    sem = (SDL_sem *) malloc(sizeof(*sem));
+    sem = (SDL_sem *) SDL_malloc(sizeof(*sem));
     if (sem != NULL) {
         /* TODO: Figure out the limit on the maximum value. */
         sem->semid = sceKernelCreateSema("SDL sema", 0, initial_value, 255, NULL);
         if (sem->semid < 0) {
             SDL_SetError("Couldn't create semaphore");
-            free(sem);
+            SDL_free(sem);
             sem = NULL;
         }
     } else {
@@ -69,7 +69,7 @@ void SDL_DestroySemaphore(SDL_sem *sem)
             sem->semid = 0;
         }
 
-        free(sem);
+        SDL_free(sem);
     }
 }
 

--- a/src/video/SDL_RLEaccel.c
+++ b/src/video/SDL_RLEaccel.c
@@ -1227,7 +1227,7 @@ RLEAlphaSurface(SDL_Surface * surface)
         surface->flags &= ~SDL_SIMD_ALIGNED;
     }
 
-    /* realloc the buffer to release unused memory */
+    /* reallocate the buffer to release unused memory */
     {
         Uint8 *p = SDL_realloc(rlebuf, dst - rlebuf);
         if (!p)
@@ -1391,9 +1391,9 @@ RLEColorkeySurface(SDL_Surface * surface)
         surface->flags &= ~SDL_SIMD_ALIGNED;
     }
 
-    /* realloc the buffer to release unused memory */
+    /* reallocate the buffer to release unused memory */
     {
-        /* If realloc returns NULL, the original block is left intact */
+        /* If SDL_realloc returns NULL, the original block is left intact */
         Uint8 *p = SDL_realloc(rlebuf, dst - rlebuf);
         if (!p)
             p = rlebuf;

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -347,7 +347,7 @@ SDL_CreateWindowTexture(SDL_VideoDevice *unused, SDL_Window * window, Uint32 * f
     data->pitch = (((window->w * data->bytes_per_pixel) + 3) & ~3);
 
     {
-        /* Make static analysis happy about potential malloc(0) calls. */
+        /* Make static analysis happy about potential SDL_malloc(0) calls. */
         const size_t allocsize = window->h * data->pitch;
         data->pixels = SDL_malloc((allocsize > 0) ? allocsize : 1);
         if (!data->pixels) {

--- a/src/video/directfb/SDL_DirectFB_events.c
+++ b/src/video/directfb/SDL_DirectFB_events.c
@@ -683,7 +683,7 @@ EnumKeyboards(DFBInputDeviceID device_id,
 #endif
         devdata->keyboard[devdata->num_keyboard].id = device_id;
         devdata->keyboard[devdata->num_keyboard].is_generic = 0;
-        if (!strncmp("X11", desc.name, 3))
+        if (!SDL_strncmp("X11", desc.name, 3))
         {
             devdata->keyboard[devdata->num_keyboard].map = xfree86_scancode_table2;
             devdata->keyboard[devdata->num_keyboard].map_size = SDL_arraysize(xfree86_scancode_table2);

--- a/src/video/directfb/SDL_DirectFB_mouse.c
+++ b/src/video/directfb/SDL_DirectFB_mouse.c
@@ -164,7 +164,7 @@ DirectFB_CreateCursor(SDL_Surface * surface, int hot_x, int hot_y)
 
     p = surface->pixels;
     for (i = 0; i < surface->h; i++)
-        memcpy((char *) dest + i * pitch,
+        SDL_memcpy((char *) dest + i * pitch,
                (char *) p + i * surface->pitch, 4 * surface->w);
 
     curdata->surf->Unlock(curdata->surf);

--- a/src/video/directfb/SDL_DirectFB_shape.c
+++ b/src/video/directfb/SDL_DirectFB_shape.c
@@ -34,7 +34,7 @@ DirectFB_CreateShaper(SDL_Window* window) {
     SDL_ShapeData* data;
     int resized_properly;
 
-    result = malloc(sizeof(SDL_WindowShaper));
+    result = SDL_malloc(sizeof(SDL_WindowShaper));
     result->window = window;
     result->mode.mode = ShapeModeDefault;
     result->mode.parameters.binarizationCutoff = 1;

--- a/src/video/directfb/SDL_DirectFB_video.c
+++ b/src/video/directfb/SDL_DirectFB_video.c
@@ -201,7 +201,7 @@ static int readBoolEnv(const char *env_name, int def_val)
 
     stemp = SDL_getenv(env_name);
     if (stemp)
-        return atoi(stemp);
+        return SDL_atoi(stemp);
     else
         return def_val;
 }

--- a/src/video/directfb/SDL_DirectFB_window.c
+++ b/src/video/directfb/SDL_DirectFB_window.c
@@ -227,7 +227,7 @@ DirectFB_SetWindowIcon(_THIS, SDL_Window * window, SDL_Surface * icon)
 
         p = surface->pixels;
         for (i = 0; i < surface->h; i++)
-            memcpy((char *) dest + i * pitch,
+            SDL_memcpy((char *) dest + i * pitch,
                    (char *) p + i * surface->pitch, 4 * surface->w);
 
         SDL_DFB_CHECK(windata->icon->Unlock(windata->icon));

--- a/src/video/emscripten/SDL_emscriptenframebuffer.c
+++ b/src/video/emscripten/SDL_emscriptenframebuffer.c
@@ -119,7 +119,7 @@ int Emscripten_UpdateWindowFramebuffer(_THIS, SDL_Window * window, const SDL_Rec
             //      }
             // the following code is faster though, because
             // .set() is almost free - easily 10x faster due to
-            // native memcpy efficiencies, and the remaining loop
+            // native SDL_memcpy efficiencies, and the remaining loop
             // just stores, not load + store, so it is faster
             data32.set(HEAP32.subarray(src, src + num));
             var data8 = SDL2.data8;

--- a/src/video/haiku/SDL_BWin.h
+++ b/src/video/haiku/SDL_BWin.h
@@ -124,7 +124,7 @@ class SDL_BWin:public BDirectWindow
 #ifdef DRAWTHREAD
         wait_for_thread(_draw_thread_id, &result);
 #endif
-        free(_clips);
+        SDL_free(_clips);
         delete _buffer_locker;
     }
 
@@ -184,14 +184,14 @@ class SDL_BWin:public BDirectWindow
             if (info->clip_list_count > _num_clips)
             {
                 if(_clips) {
-                    free(_clips);
+                    SDL_free(_clips);
                     _clips = NULL;
                 }
             }
 
             _num_clips = info->clip_list_count;
             if (_clips == NULL)
-                _clips = (clipping_rect *)malloc(_num_clips*sizeof(clipping_rect));
+                _clips = (clipping_rect *)SDL_malloc(_num_clips*sizeof(clipping_rect));
             if(_clips) {
                 SDL_memcpy(_clips, info->clip_list,
                     _num_clips*sizeof(clipping_rect));

--- a/src/video/haiku/SDL_BWin.h
+++ b/src/video/haiku/SDL_BWin.h
@@ -193,7 +193,7 @@ class SDL_BWin:public BDirectWindow
             if (_clips == NULL)
                 _clips = (clipping_rect *)malloc(_num_clips*sizeof(clipping_rect));
             if(_clips) {
-                memcpy(_clips, info->clip_list,
+                SDL_memcpy(_clips, info->clip_list,
                     _num_clips*sizeof(clipping_rect));
 
                 _bits = (uint8*) info->bits;

--- a/src/video/haiku/SDL_bmodes.cc
+++ b/src/video/haiku/SDL_bmodes.cc
@@ -281,7 +281,7 @@ void HAIKU_GetDisplayModes(_THIS, SDL_VideoDisplay *display) {
             SDL_AddDisplayMode(display, &mode);
         }
     }
-    free(bmodes);
+    free(bmodes); /* This should not be SDL_free() */
 }
 
 
@@ -313,7 +313,7 @@ int HAIKU_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode
         return SDL_SetError("Bad video mode");
     }
     
-    free(bmode_list);
+    free(bmode_list); /* This should not be SDL_free() */
     
 #if SDL_VIDEO_OPENGL
     /* FIXME: Is there some way to reboot the OpenGL context?  This doesn't

--- a/src/video/pandora/SDL_pandora.c
+++ b/src/video/pandora/SDL_pandora.c
@@ -612,7 +612,7 @@ PND_gl_createcontext(_THIS, SDL_Window * window)
 
 #ifdef WIZ_GLES_LITE
     if( !hNativeWnd ) {
-    hNativeWnd = (NativeWindowType)malloc(16*1024);
+    hNativeWnd = (NativeWindowType)SDL_malloc(16*1024);
 
     if(!hNativeWnd)
         printf( "Error: Wiz framebuffer allocatation failed\n" );
@@ -819,7 +819,7 @@ PND_gl_deletecontext(_THIS, SDL_GLContext context)
 #ifdef WIZ_GLES_LITE
     if( hNativeWnd != 0 )
     {
-      free(hNativeWnd);
+      SDL_free(hNativeWnd);
       hNativeWnd = 0;
       printf( "SDL: Wiz framebuffer released\n" );
     }

--- a/src/video/qnx/gl.c
+++ b/src/video/qnx/gl.c
@@ -85,7 +85,7 @@ glGetConfig(EGLConfig *pconf, int *pformat)
     }
 
     // Allocate enough memory for all configurations.
-    egl_configs = malloc(egl_num_configs * sizeof(*egl_configs));
+    egl_configs = SDL_malloc(egl_num_configs * sizeof(*egl_configs));
     if (egl_configs == NULL) {
         return -1;
     }
@@ -94,7 +94,7 @@ glGetConfig(EGLConfig *pconf, int *pformat)
     rc = eglGetConfigs(egl_disp, egl_configs, egl_num_configs,
                        &egl_num_configs);
     if (rc != EGL_TRUE) {
-        free(egl_configs);
+        SDL_free(egl_configs);
         return -1;
     }
 
@@ -119,7 +119,7 @@ glGetConfig(EGLConfig *pconf, int *pformat)
         break;
     }
 
-    free(egl_configs);
+    SDL_free(egl_configs);
     *pconf = egl_conf;
     *pformat = chooseFormat(egl_conf);
 

--- a/src/video/vita/SDL_vitaframebuffer.c
+++ b/src/video/vita/SDL_vitaframebuffer.c
@@ -74,7 +74,7 @@ int VITA_CreateWindowFramebuffer(_THIS, SDL_Window * window, Uint32 * format, vo
         &data->buffer_uid
     );
 
-    // memset the buffer to black
+    // SDL_memset the buffer to black
     SDL_memset(data->buffer, 0x0, SCREEN_W*SCREEN_H*4);
 
     SDL_memset(&framebuf, 0x00, sizeof(SceDisplayFrameBuf));

--- a/src/video/vita/SDL_vitatouch.c
+++ b/src/video/vita/SDL_vitatouch.c
@@ -90,7 +90,7 @@ VITA_PollTouch(void)
     if (Vita_Window == NULL)
         return;
 
-    memcpy(touch_old, touch, sizeof(touch_old));
+    SDL_memcpy(touch_old, touch, sizeof(touch_old));
 
     for(port = 0; port < SCE_TOUCH_PORT_MAX_NUM; port++) {
         /** Skip polling of Touch Device if environment variable is set **/

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -220,7 +220,7 @@ Wayland_SendWakeupEvent(_THIS, SDL_Window *window)
 {
     SDL_VideoData *d = _this->driverdata;
 
-    /* TODO: Maybe use a pipe to avoid the compositor round trip? */
+    /* TODO: Maybe use a pipe to avoid the compositor roundtrip? */
     wl_display_sync(d->display);
     WAYLAND_wl_display_flush(d->display);
 }

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -601,7 +601,7 @@ display_handle_global(void *data, struct wl_registry *registry, uint32_t id,
         d->idle_inhibit_manager = wl_registry_bind(d->registry, id, &zwp_idle_inhibit_manager_v1_interface, 1);
     } else if (SDL_strcmp(interface, "xdg_activation_v1") == 0) {
         d->activation_manager = wl_registry_bind(d->registry, id, &xdg_activation_v1_interface, 1);
-    } else if (strcmp(interface, "zwp_text_input_manager_v3") == 0) {
+    } else if (SDL_strcmp(interface, "zwp_text_input_manager_v3") == 0) {
         Wayland_add_text_input_manager(d, id, version);
     } else if (SDL_strcmp(interface, "wl_data_device_manager") == 0) {
         Wayland_add_data_device_manager(d, id, version);

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -270,19 +270,19 @@ static char* X11_URIToLocal(char* uri) {
     char *file = NULL;
     SDL_bool local;
 
-    if (memcmp(uri,"file:/",6) == 0) uri += 6;      /* local file? */
-    else if (strstr(uri,":/") != NULL) return file; /* wrong scheme */
+    if (SDL_memcmp(uri,"file:/",6) == 0) uri += 6;      /* local file? */
+    else if (SDL_strstr(uri,":/") != NULL) return file; /* wrong scheme */
 
     local = uri[0] != '/' || (uri[0] != '\0' && uri[1] == '/');
 
     /* got a hostname? */
     if (!local && uri[0] == '/' && uri[2] != '/') {
-      char* hostname_end = strchr(uri+1, '/');
+      char* hostname_end = SDL_strchr(uri+1, '/');
       if (hostname_end != NULL) {
           char hostname[ 257 ];
           if (gethostname(hostname, 255) == 0) {
             hostname[ 256 ] = '\0';
-            if (memcmp(uri+1, hostname, hostname_end - (uri+1)) == 0) {
+            if (SDL_memcmp(uri+1, hostname, hostname_end - (uri+1)) == 0) {
                 uri = hostname_end + 1;
                 local = SDL_TRUE;
             }
@@ -1186,7 +1186,7 @@ X11_DispatchEvent(_THIS, XEvent *xevent)
 
 
                 /* reply with status */
-                memset(&m, 0, sizeof(XClientMessageEvent));
+                SDL_memset(&m, 0, sizeof(XClientMessageEvent));
                 m.type = ClientMessage;
                 m.display = xevent->xclient.display;
                 m.window = xevent->xclient.data.l[0];
@@ -1204,7 +1204,7 @@ X11_DispatchEvent(_THIS, XEvent *xevent)
             else if(xevent->xclient.message_type == videodata->XdndDrop) {
                 if (data->xdnd_req == None) {
                     /* say again - not interested! */
-                    memset(&m, 0, sizeof(XClientMessageEvent));
+                    SDL_memset(&m, 0, sizeof(XClientMessageEvent));
                     m.type = ClientMessage;
                     m.display = xevent->xclient.display;
                     m.window = xevent->xclient.data.l[0];
@@ -1583,7 +1583,7 @@ X11_SendWakeupEvent(_THIS, SDL_Window *window)
     Window xwindow = ((SDL_WindowData *) window->driverdata)->xwindow;
     XClientMessageEvent event;
 
-    memset(&event, 0, sizeof(XClientMessageEvent));
+    SDL_memset(&event, 0, sizeof(XClientMessageEvent));
     event.type = ClientMessage;
     event.display = req_display;
     event.send_event = True;

--- a/src/video/x11/SDL_x11modes.c
+++ b/src/video/x11/SDL_x11modes.c
@@ -322,7 +322,7 @@ SetXRandRDisplayName(Display *dpy, Atom EDID, char *name, const size_t namelen, 
                     dump_monitor_info(info);
 #endif
                     SDL_strlcpy(name, info->dsc_product_name, namelen);
-                    free(info);
+                    SDL_free(info);
                 }
                 X11_XFree(prop);
             }

--- a/src/video/x11/SDL_x11modes.c
+++ b/src/video/x11/SDL_x11modes.c
@@ -358,7 +358,7 @@ GetXftDPI(Display* dpy)
     }
 
     /*
-     * It's possible for SDL_atoi to call strtol, if it fails due to a
+     * It's possible for SDL_atoi to call SDL_strtol, if it fails due to a
      * overflow or an underflow, it will return LONG_MAX or LONG_MIN and set
      * errno to ERANGE. So we need to check for this so we dont get crazy dpi
      * values

--- a/src/video/x11/SDL_x11shape.c
+++ b/src/video/x11/SDL_x11shape.c
@@ -35,7 +35,7 @@ X11_CreateShaper(SDL_Window* window) {
 
 #if SDL_VIDEO_DRIVER_X11_XSHAPE
     if (SDL_X11_HAVE_XSHAPE) {  /* Make sure X server supports it. */
-        result = malloc(sizeof(SDL_WindowShaper));
+        result = SDL_malloc(sizeof(SDL_WindowShaper));
         result->window = window;
         result->mode.mode = ShapeModeDefault;
         result->mode.parameters.binarizationCutoff = 1;
@@ -65,8 +65,8 @@ X11_ResizeWindowShape(SDL_Window* window) {
     if(data->bitmapsize != bitmapsize || data->bitmap == NULL) {
         data->bitmapsize = bitmapsize;
         if(data->bitmap != NULL)
-            free(data->bitmap);
-        data->bitmap = malloc(data->bitmapsize);
+            SDL_free(data->bitmap);
+        data->bitmap = SDL_malloc(data->bitmapsize);
         if(data->bitmap == NULL) {
             return SDL_SetError("Could not allocate memory for shaped-window bitmap.");
         }

--- a/src/video/x11/SDL_x11shape.c
+++ b/src/video/x11/SDL_x11shape.c
@@ -71,7 +71,7 @@ X11_ResizeWindowShape(SDL_Window* window) {
             return SDL_SetError("Could not allocate memory for shaped-window bitmap.");
         }
     }
-    memset(data->bitmap,0,data->bitmapsize);
+    SDL_memset(data->bitmap,0,data->bitmapsize);
 
     window->shaper->userx = window->x;
     window->shaper->usery = window->y;

--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -737,9 +737,9 @@ X11_SetWindowTitle(_THIS, SDL_Window * window)
     Atom _NET_WM_NAME = data->videodata->_NET_WM_NAME;
     Atom WM_NAME = data->videodata->WM_NAME;
 
-    X11_XChangeProperty(display, data->xwindow, WM_NAME, UTF8_STRING, 8, 0, (const unsigned char *) title, strlen(title));
+    X11_XChangeProperty(display, data->xwindow, WM_NAME, UTF8_STRING, 8, 0, (const unsigned char *) title, SDL_strlen(title));
 
-    status = X11_XChangeProperty(display, data->xwindow, _NET_WM_NAME, UTF8_STRING, 8, 0, (const unsigned char *) title, strlen(title));
+    status = X11_XChangeProperty(display, data->xwindow, _NET_WM_NAME, UTF8_STRING, 8, 0, (const unsigned char *) title, SDL_strlen(title));
 
     if (status != 1) {
         char *x11_error = NULL;

--- a/src/video/x11/edid-parse.c
+++ b/src/video/x11/edid-parse.c
@@ -50,7 +50,7 @@ get_bits (int in, int begin, int end)
 static int
 decode_header (const uchar *edid)
 {
-    if (memcmp (edid, "\x00\xff\xff\xff\xff\xff\xff\x00", 8) == 0)
+    if (SDL_memcmp (edid, "\x00\xff\xff\xff\xff\xff\xff\x00", 8) == 0)
 	return TRUE;
     return FALSE;
 }

--- a/src/video/x11/edid-parse.c
+++ b/src/video/x11/edid-parse.c
@@ -522,7 +522,7 @@ decode_check_sum (const uchar *edid,
 MonitorInfo *
 decode_edid (const uchar *edid)
 {
-    MonitorInfo *info = calloc (1, sizeof (MonitorInfo));
+    MonitorInfo *info = SDL_calloc (1, sizeof (MonitorInfo));
 
     decode_check_sum (edid, info);
     
@@ -534,8 +534,8 @@ decode_edid (const uchar *edid)
         !decode_established_timings (edid, info) ||
         !decode_standard_timings (edid, info) ||
         !decode_descriptors (edid, info)) {
-        free(info);
-	return NULL;
+        SDL_free(info);
+        return NULL;
     }
     
     return info;

--- a/test/checkkeysthreads.c
+++ b/test/checkkeysthreads.c
@@ -210,7 +210,7 @@ static int SDLCALL ping_thread(void *ptr)
 {
     int cnt;
     SDL_Event sdlevent;
-    memset(&sdlevent, 0 , sizeof(SDL_Event));
+    SDL_memset(&sdlevent, 0 , sizeof(SDL_Event));
     for (cnt = 0; cnt < 10; ++cnt) {
         fprintf(stderr, "sending event (%d/%d) from thread.\n", cnt + 1, 10); fflush(stderr);
         sdlevent.type = SDL_KEYDOWN;

--- a/test/testautomation_sdltest.c
+++ b/test/testautomation_sdltest.c
@@ -1131,7 +1131,7 @@ sdltest_randomAsciiString(void *arg)
      SDLTest_AssertCheck(len >= 1 && len <= 255, "Validate that result length; expected: len=[1,255], got: %d", (int) len);
      nonAsciiCharacters = 0;
      for (i=0; i<len; i++) {
-       if (iscntrl(result[i])) {
+       if (SDL_iscntrl(result[i])) {
          nonAsciiCharacters++;
        }
      }
@@ -1169,7 +1169,7 @@ sdltest_randomAsciiStringWithMaximumLength(void *arg)
      SDLTest_AssertCheck(len >= 1 && len <= targetLen, "Validate that result length; expected: len=[1,%d], got: %d", (int) targetLen, (int) len);
      nonAsciiCharacters = 0;
      for (i=0; i<len; i++) {
-       if (iscntrl(result[i])) {
+       if (SDL_iscntrl(result[i])) {
          nonAsciiCharacters++;
        }
      }
@@ -1223,7 +1223,7 @@ sdltest_randomAsciiStringOfSize(void *arg)
      SDLTest_AssertCheck(len == targetLen, "Validate that result length; expected: len=%d, got: %d", (int) targetLen, (int) len);
      nonAsciiCharacters = 0;
      for (i=0; i<len; i++) {
-       if (iscntrl(result[i])) {
+       if (SDL_iscntrl(result[i])) {
          nonAsciiCharacters++;
        }
      }

--- a/test/testevdev.c
+++ b/test/testevdev.c
@@ -961,11 +961,11 @@ run_test(void)
 
         printf("%s...\n", t->name);
 
-        memset(&caps, '\0', sizeof(caps));
-        memcpy(caps.ev, t->ev, sizeof(t->ev));
-        memcpy(caps.keys, t->keys, sizeof(t->keys));
-        memcpy(caps.abs, t->abs, sizeof(t->abs));
-        memcpy(caps.rel, t->rel, sizeof(t->rel));
+        SDL_memset(&caps, '\0', sizeof(caps));
+        SDL_memcpy(caps.ev, t->ev, sizeof(t->ev));
+        SDL_memcpy(caps.keys, t->keys, sizeof(t->keys));
+        SDL_memcpy(caps.abs, t->abs, sizeof(t->abs));
+        SDL_memcpy(caps.rel, t->rel, sizeof(t->rel));
 
         for (j = 0; j < SDL_arraysize(caps.ev); j++) {
             caps.ev[j] = SwapLongLE(caps.ev[j]);

--- a/test/testgl2.c
+++ b/test/testgl2.c
@@ -238,10 +238,10 @@ main(int argc, char *argv[])
         consumed = SDLTest_CommonArg(state, i);
         if (consumed == 0) {
             if (SDL_strcasecmp(argv[i], "--fsaa") == 0 && i+1 < argc) {
-                fsaa = atoi(argv[i+1]);
+                fsaa = SDL_atoi(argv[i+1]);
                 consumed = 2;
             } else if (SDL_strcasecmp(argv[i], "--accel") == 0 && i+1 < argc) {
-                accel = atoi(argv[i+1]);
+                accel = SDL_atoi(argv[i+1]);
                 consumed = 2;
             } else {
                 consumed = -1;

--- a/test/testgles2_sdf.c
+++ b/test/testgles2_sdf.c
@@ -163,11 +163,10 @@ process_shader(GLuint *shader, const char * source, GLint shader_type)
 }
 
 /* Notes on a_angle:
-   * It is a vector containing sine and cosine for rotation matrix
-   * To get correct rotation for most cases when a_angle is disabled SDL_cos
-     value is decremented by 1.0 to get proper output with 0.0 which is
-     default value
-*/
+ * It is a vector containing sine and cosine for rotation matrix
+ * To get correct rotation for most cases when a_angle is disabled cosine
+ * value is decremented by 1.0 to get proper output with 0.0 which is default value
+ */
 static const Uint8 GLES2_VertexSrc_Default_[] = " \
     uniform mat4 u_projection; \
     attribute vec2 a_position; \

--- a/test/testgles2_sdf.c
+++ b/test/testgles2_sdf.c
@@ -163,8 +163,8 @@ process_shader(GLuint *shader, const char * source, GLint shader_type)
 }
 
 /* Notes on a_angle:
-   * It is a vector containing sin and cos for rotation matrix
-   * To get correct rotation for most cases when a_angle is disabled cos
+   * It is a vector containing sine and cosine for rotation matrix
+   * To get correct rotation for most cases when a_angle is disabled SDL_cos
      value is decremented by 1.0 to get proper output with 0.0 which is
      default value
 */

--- a/test/testhaptic.c
+++ b/test/testhaptic.c
@@ -14,10 +14,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 /*
  * includes
  */
-#include <stdlib.h>
-#include <string.h>             /* strstr */
-#include <ctype.h>              /* isdigit */
-
 #include "SDL.h"
 
 #ifndef SDL_HAPTIC_DISABLED
@@ -55,7 +51,7 @@ main(int argc, char **argv)
     index = -1;
     if (argc > 1) {
         name = argv[1];
-        if ((strcmp(name, "--help") == 0) || (strcmp(name, "-h") == 0)) {
+        if ((SDL_strcmp(name, "--help") == 0) || (SDL_strcmp(name, "-h") == 0)) {
             SDL_Log("USAGE: %s [device]\n"
                    "If device is a two-digit number it'll use it as an index, otherwise\n"
                    "it'll use it as if it were part of the device's name.\n",
@@ -63,9 +59,9 @@ main(int argc, char **argv)
             return 0;
         }
 
-        i = strlen(name);
-        if ((i < 3) && isdigit(name[0]) && ((i == 1) || isdigit(name[1]))) {
-            index = atoi(name);
+        i = SDL_strlen(name);
+        if ((i < 3) && SDL_isdigit(name[0]) && ((i == 1) || SDL_isdigit(name[1]))) {
+            index = SDL_atoi(name);
             name = NULL;
         }
     }
@@ -82,7 +78,7 @@ main(int argc, char **argv)
         /* Try to find matching device */
         else {
             for (i = 0; i < SDL_NumHaptics(); i++) {
-                if (strstr(SDL_HapticName(i), name) != NULL)
+                if (SDL_strstr(SDL_HapticName(i), name) != NULL)
                     break;
             }
 
@@ -110,7 +106,7 @@ main(int argc, char **argv)
     SDL_ClearError();
 
     /* Create effects. */
-    memset(&efx, 0, sizeof(efx));
+    SDL_memset(&efx, 0, sizeof(efx));
     nefx = 0;
     supported = SDL_HapticQuery(haptic);
 

--- a/test/testime.c
+++ b/test/testime.c
@@ -648,12 +648,12 @@ int main(int argc, char *argv[])
     }
     for (argc--, argv++; argc > 0; argc--, argv++)
     {
-        if (strcmp(argv[0], "--help") == 0) {
+        if (SDL_strcmp(argv[0], "--help") == 0) {
             usage();
             return 0;
         }
 
-        else if (strcmp(argv[0], "--font") == 0)
+        else if (SDL_strcmp(argv[0], "--font") == 0)
         {
             argc--;
             argv++;

--- a/test/testloadso.c
+++ b/test/testloadso.c
@@ -44,7 +44,7 @@ main(int argc, char *argv[])
         return 2;
     }
 
-    if (strcmp(argv[1], "--hello") == 0) {
+    if (SDL_strcmp(argv[1], "--hello") == 0) {
         hello = 1;
         libname = argv[2];
         symname = "puts";

--- a/test/testrumble.c
+++ b/test/testrumble.c
@@ -25,10 +25,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 /*
  * includes
  */
-#include <stdlib.h>
-#include <string.h>             /* strstr */
-#include <ctype.h>              /* isdigit */
-
 #include "SDL.h"
 
 #ifndef SDL_HAPTIC_DISABLED
@@ -56,7 +52,7 @@ main(int argc, char **argv)
     if (argc > 1) {
         size_t l;
         name = argv[1];
-        if ((strcmp(name, "--help") == 0) || (strcmp(name, "-h") == 0)) {
+        if ((SDL_strcmp(name, "--help") == 0) || (SDL_strcmp(name, "-h") == 0)) {
             SDL_Log("USAGE: %s [device]\n"
                    "If device is a two-digit number it'll use it as an index, otherwise\n"
                    "it'll use it as if it were part of the device's name.\n",
@@ -83,7 +79,7 @@ main(int argc, char **argv)
         /* Try to find matching device */
         else {
             for (i = 0; i < SDL_NumHaptics(); i++) {
-                if (strstr(SDL_HapticName(i), name) != NULL)
+                if (SDL_strstr(SDL_HapticName(i), name) != NULL)
                     break;
             }
 

--- a/test/testsem.c
+++ b/test/testsem.c
@@ -262,7 +262,7 @@ main(int argc, char **argv)
     signal(SIGTERM, killed);
     signal(SIGINT, killed);
 
-    init_sem = atoi(argv[1]);
+    init_sem = SDL_atoi(argv[1]);
     if (init_sem > 0) {
         TestRealWorld(init_sem);
     }

--- a/test/testtimer.c
+++ b/test/testtimer.c
@@ -72,7 +72,7 @@ main(int argc, char *argv[])
     /* Start the timer */
     desired = 0;
     if (argv[1]) {
-        desired = atoi(argv[1]);
+        desired = SDL_atoi(argv[1]);
     }
     if (desired == 0) {
         desired = DEFAULT_RESOLUTION;

--- a/test/testyuv_cvt.c
+++ b/test/testyuv_cvt.c
@@ -31,9 +31,9 @@ static void RGBtoYUV(Uint8 * rgb, int *yuv, SDL_YUV_CONVERSION_MODE mode, int mo
         // This formula is from Microsoft's documentation:
         // https://msdn.microsoft.com/en-us/library/windows/desktop/dd206750(v=vs.85).aspx
         // L = Kr * R + Kb * B + (1 - Kr - Kb) * G
-        // Y =                   floor(2^(M-8) * (219*(L-Z)/S + 16) + 0.5);
-        // U = clip3(0, (2^M)-1, floor(2^(M-8) * (112*(B-L) / ((1-Kb)*S) + 128) + 0.5));
-        // V = clip3(0, (2^M)-1, floor(2^(M-8) * (112*(R-L) / ((1-Kr)*S) + 128) + 0.5));
+        // Y =                   SDL_floor(2^(M-8) * (219*(L-Z)/S + 16) + 0.5);
+        // U = clip3(0, (2^M)-1, SDL_floor(2^(M-8) * (112*(B-L) / ((1-Kb)*S) + 128) + 0.5));
+        // V = clip3(0, (2^M)-1, SDL_floor(2^(M-8) * (112*(R-L) / ((1-Kr)*S) + 128) + 0.5));
         float S, Z, R, G, B, L, Kr, Kb, Y, U, V;
 
         if (mode == SDL_YUV_CONVERSION_BT709) {

--- a/visualtest/src/action_configparser.c
+++ b/visualtest/src/action_configparser.c
@@ -54,7 +54,7 @@ SDLVisualTest_EnqueueAction(SDLVisualTest_ActionQueue* queue,
                                       sizeof(SDLVisualTest_ActionNode));
     if(!node)
     {
-        SDLTest_LogError("malloc() failed");
+        SDLTest_LogError("SDL_malloc() failed");
         return 0;
     }
     node->action = action;
@@ -220,10 +220,10 @@ SDLVisualTest_InsertIntoActionQueue(SDLVisualTest_ActionQueue* queue,
         return 1;
     }
 
-    newnode = (SDLVisualTest_ActionNode*)malloc(sizeof(SDLVisualTest_ActionNode));
+    newnode = (SDLVisualTest_ActionNode*)SDL_malloc(sizeof(SDLVisualTest_ActionNode));
     if(!newnode)
     {
-        SDLTest_LogError("malloc() failed");
+        SDLTest_LogError("SDL_malloc() failed");
         return 0;
     }
     newnode->action = action;
@@ -344,7 +344,7 @@ SDLVisualTest_ParseActionConfig(char* file, SDLVisualTest_ActionQueue* queue)
             path = (char*)SDL_malloc(sizeof(char) * (len + 1));
             if(!path)
             {
-                SDLTest_LogError("malloc() failed");
+                SDLTest_LogError("SDL_malloc() failed");
                 SDLVisualTest_EmptyActionQueue(queue);
                 SDL_RWclose(rw);
                 return 0;
@@ -358,7 +358,7 @@ SDLVisualTest_ParseActionConfig(char* file, SDLVisualTest_ActionQueue* queue)
                 args = (char*)SDL_malloc(sizeof(char) * (len + 1));
                 if(!args)
                 {
-                    SDLTest_LogError("malloc() failed");
+                    SDLTest_LogError("SDL_malloc() failed");
                     SDL_free(path);
                     SDLVisualTest_EmptyActionQueue(queue);
                     SDL_RWclose(rw);

--- a/visualtest/src/harness_argparser.c
+++ b/visualtest/src/harness_argparser.c
@@ -234,7 +234,7 @@ ParseConfig(char* file, SDLVisualTest_HarnessState* state)
         argv = (char**)SDL_malloc((num_params + 1) * sizeof(char*));
         if(!argv)
         {
-            SDLTest_LogError("malloc() failed.");
+            SDLTest_LogError("SDL_malloc() failed.");
             SDL_RWclose(rw);
             return 0;
         }

--- a/visualtest/src/parsehelper.c
+++ b/visualtest/src/parsehelper.c
@@ -96,7 +96,7 @@ TokenizeHelper(char* str, char** tokens, int num_tokens, int max_token_len)
         if(!tokens[index])
         {
             int i;
-            SDLTest_LogError("malloc() failed.");
+            SDLTest_LogError("SDL_malloc() failed.");
             for(i = 0; i < index; i++)
                 SDL_free(tokens[i]);
             return 0;
@@ -215,7 +215,7 @@ SDLVisualTest_ParseArgsToArgv(char* args)
     argv = (char**)SDL_malloc((num_tokens + 2) * sizeof(char*));
     if(!argv)
     {
-        SDLTest_LogError("malloc() failed.");
+        SDLTest_LogError("SDL_malloc() failed.");
         return NULL;
     }
 

--- a/visualtest/src/screenshot.c
+++ b/visualtest/src/screenshot.c
@@ -48,7 +48,7 @@ SDLVisualTest_VerifyScreenshots(char* args, char* test_dir, char* verify_dir)
     verify_path = (char*)SDL_malloc(verify_len * sizeof(char));
     if(!verify_path)
     {
-        SDLTest_LogError("malloc() failed");
+        SDLTest_LogError("SDL_malloc() failed");
         return_code = -1;
         goto verifyscreenshots_cleanup_generic;
     }
@@ -78,7 +78,7 @@ SDLVisualTest_VerifyScreenshots(char* args, char* test_dir, char* verify_dir)
     test_path = (char*)SDL_malloc(test_len * sizeof(char));
     if(!test_path)
     {
-        SDLTest_LogError("malloc() failed");
+        SDLTest_LogError("SDL_malloc() failed");
         return_code = -1;
         goto verifyscreenshots_cleanup_verifybmp;
     }

--- a/visualtest/src/sut_configparser.c
+++ b/visualtest/src/sut_configparser.c
@@ -61,7 +61,7 @@ SDLVisualTest_ParseSUTConfig(char* file, SDLVisualTest_SUTConfig* config)
                       sizeof(SDLVisualTest_SUTOption));
     if(!config->options)
     {
-        SDLTest_LogError("malloc() failed");
+        SDLTest_LogError("SDL_malloc() failed");
         SDL_RWclose(rw);
         return 0;
     }

--- a/visualtest/src/variator_common.c
+++ b/visualtest/src/variator_common.c
@@ -189,7 +189,7 @@ SDLVisualTest_InitVariation(SDLVisualTest_Variation* variation,
                      sizeof(SDLVisualTest_SUTOptionValue));
     if(!variation->vars)
     {
-        SDLTest_LogError("malloc() failed");
+        SDLTest_LogError("SDL_malloc() failed");
         return 0;
     }
     variation->num_vars = config->num_options;

--- a/visualtest/src/windows/windows_process.c
+++ b/visualtest/src/windows/windows_process.c
@@ -61,7 +61,7 @@ SDL_LaunchProcess(char* file, char* args, SDL_ProcessInfo* pinfo)
     working_directory = (char*)SDL_malloc(path_length + 1);
     if(!working_directory)
     {
-        SDLTest_LogError("Could not allocate working_directory - malloc() failed.");
+        SDLTest_LogError("Could not allocate working_directory - SDL_malloc() failed.");
         return 0;
     }
 
@@ -80,7 +80,7 @@ SDL_LaunchProcess(char* file, char* args, SDL_ProcessInfo* pinfo)
     command_line = (char*)SDL_malloc(path_length + args_length + 2);
     if(!command_line)
     {
-        SDLTest_LogError("Could not allocate command_line - malloc() failed.");
+        SDLTest_LogError("Could not allocate command_line - SDL_malloc() failed.");
         return 0;
     }
     SDL_memcpy(command_line, file, path_length);

--- a/visualtest/src/windows/windows_screenshot.c
+++ b/visualtest/src/windows/windows_screenshot.c
@@ -241,7 +241,7 @@ ScreenshotWindow(HWND hwnd, char* filename, SDL_bool only_client_area)
         goto screenshotwindow_cleanup_capturebitmap;
     }
 
-    /* free resources */
+    /* Free resources */
 
 screenshotwindow_cleanup_capturebitmap:
     if(!DeleteObject(capturebitmap))
@@ -297,7 +297,7 @@ ScreenshotHwnd(HWND hwnd, LPARAM lparam)
     filename = (char*)SDL_malloc(len * sizeof(char));
     if(!filename)
     {
-        SDLTest_LogError("malloc() failed");
+        SDLTest_LogError("SDL_malloc() failed");
         return FALSE;
     }
 


### PR DESCRIPTION
In case we really want to use SDL function in place of libc versions...
here's the replacement of : 

 acos acosf asin asinf asprintf atan atan2 atan2f atanf atof atoi
  ceil ceilf copysign copysignf cos cosf expf fabs fabsf floor floorf
  fmod fmodf getenv isalnum isalpha isblank iscntrl isdigit isgraph islower
  isprint ispunct isspace isupper isxdigit itoa lltoa log10 log10f logf lround
  lroundf ltoa memcmp memcpy memcpy4 memmove memset pow powf qsort roundf
  scalbn scalbnf setenv sin sinf snprintf sqrt sqrtf sscanf strcasecmp strchr
  strcmp strdup strlcat strlcpy strlen strlwr strncasecmp strncmp strrchr strrev
  strstr strtod strtokr strtol strtoll strtoul strupr tan tanf tolower toupper
  truncf uitoa ulltoa ultoa utf8strlcpy utf8strlen vasprintf vsnprintf
  vsscanf wcscasecmp wcscmp wcsdup wcslcat wcslcpy wcslen wcsncasecmp wcsncmp
  wcsstr


I've excluded:
  free malloc realloc calloc  printf abs crc32 log roundexp trunc snprintf

and files
 include/*
 src/stdlib/*
 src/libm/*
 src/*/hid.c
 src/*/*/hid.c
 src/video/khronos/vulkan/vk_sdk_platform.h
 src/core/os2/geniconv/os2iconv.c
 src/core/os2/geniconv/os2cp.c
 src/audio/wasapi/SDL_wasapi_win32.c
 src/video/khronos/vulkan/vk_sdk_platform.h
 src/hidapi/testgui/test.cpp
 src/core/os2/geniconv/test.c
 src/hidapi/hidtest/hidtest.cpp




