### PR TITLE
Don't use "renderer->viewport" in back-ends

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -356,7 +356,10 @@ QueueCmdSetViewport(SDL_Renderer *renderer)
         if (cmd != NULL) {
             cmd->command = SDL_RENDERCMD_SETVIEWPORT;
             cmd->data.viewport.first = 0;  /* render backend will fill this in. */
-            SDL_memcpy(&cmd->data.viewport.rect, &renderer->viewport, sizeof (renderer->viewport));
+            cmd->data.viewport.rect.x = renderer->viewport.x;
+            cmd->data.viewport.rect.y = renderer->viewport.y;
+            cmd->data.viewport.rect.w = renderer->viewport.w;
+            cmd->data.viewport.rect.h = renderer->viewport.h;
             retval = renderer->QueueSetViewport(renderer, cmd);
             if (retval < 0) {
                 cmd->command = SDL_RENDERCMD_NO_OP;
@@ -382,7 +385,10 @@ QueueCmdSetClipRect(SDL_Renderer *renderer)
         } else {
             cmd->command = SDL_RENDERCMD_SETCLIPRECT;
             cmd->data.cliprect.enabled = renderer->clipping_enabled;
-            SDL_memcpy(&cmd->data.cliprect.rect, &renderer->clip_rect, sizeof (cmd->data.cliprect.rect));
+            cmd->data.cliprect.rect.x = renderer->clip_rect.x;
+            cmd->data.cliprect.rect.y = renderer->clip_rect.y;
+            cmd->data.cliprect.rect.w = renderer->clip_rect.w;
+            cmd->data.cliprect.rect.h = renderer->clip_rect.h;
             SDL_memcpy(&renderer->last_queued_cliprect, &renderer->clip_rect, sizeof (SDL_Rect));
             renderer->last_queued_cliprect_enabled = renderer->clipping_enabled;
             renderer->cliprect_queued = SDL_TRUE;
@@ -667,7 +673,7 @@ SDL_GetRenderDriverInfo(int index, SDL_RendererInfo * info)
 #endif
 }
 
-static void GetWindowViewportValues(SDL_Renderer *renderer, int *logical_w, int *logical_h, SDL_Rect *viewport, SDL_FPoint *scale)
+static void GetWindowViewportValues(SDL_Renderer *renderer, int *logical_w, int *logical_h, SDL_FRect *viewport, SDL_FPoint *scale)
 {
     SDL_LockMutex(renderer->target_mutex);
     *logical_w = renderer->target ? renderer->logical_w_backup : renderer->logical_w;
@@ -756,7 +762,7 @@ SDL_RendererEventWatch(void *userdata, SDL_Event *event)
         SDL_Window *window = SDL_GetWindowFromID(event->motion.windowID);
         if (window == renderer->window) {
             int logical_w, logical_h;
-            SDL_Rect viewport;
+            SDL_FRect viewport;
             SDL_FPoint scale;
             GetWindowViewportValues(renderer, &logical_w, &logical_h, &viewport, &scale);
             if (logical_w) {
@@ -783,7 +789,7 @@ SDL_RendererEventWatch(void *userdata, SDL_Event *event)
         SDL_Window *window = SDL_GetWindowFromID(event->button.windowID);
         if (window == renderer->window) {
             int logical_w, logical_h;
-            SDL_Rect viewport;
+            SDL_FRect viewport;
             SDL_FPoint scale;
             GetWindowViewportValues(renderer, &logical_w, &logical_h, &viewport, &scale);
             if (logical_w) {
@@ -798,7 +804,7 @@ SDL_RendererEventWatch(void *userdata, SDL_Event *event)
                event->type == SDL_FINGERMOTION) {
         int logical_w, logical_h;
         float physical_w, physical_h;
-        SDL_Rect viewport;
+        SDL_FRect viewport;
         SDL_FPoint scale;
         GetWindowViewportValues(renderer, &logical_w, &logical_h, &viewport, &scale);
 
@@ -2183,8 +2189,8 @@ SDL_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
     }
 
     if (texture) {
-        renderer->viewport.x = 0;
-        renderer->viewport.y = 0;
+        renderer->viewport.x = 0.0f;
+        renderer->viewport.y = 0.0f;
         renderer->viewport.w = texture->w;
         renderer->viewport.h = texture->h;
         SDL_zero(renderer->clip_rect);
@@ -2393,16 +2399,19 @@ SDL_RenderSetViewport(SDL_Renderer * renderer, const SDL_Rect * rect)
     CHECK_RENDERER_MAGIC(renderer, -1);
 
     if (rect) {
-        renderer->viewport.x = (int)SDL_floor(rect->x * renderer->scale.x);
-        renderer->viewport.y = (int)SDL_floor(rect->y * renderer->scale.y);
-        renderer->viewport.w = (int)SDL_floor(rect->w * renderer->scale.x);
-        renderer->viewport.h = (int)SDL_floor(rect->h * renderer->scale.y);
+        renderer->viewport.x = rect->x * renderer->scale.x;
+        renderer->viewport.y = rect->y * renderer->scale.y;
+        renderer->viewport.w = rect->w * renderer->scale.x;
+        renderer->viewport.h = rect->h * renderer->scale.y;
     } else {
-        renderer->viewport.x = 0;
-        renderer->viewport.y = 0;
-        if (SDL_GetRendererOutputSize(renderer, &renderer->viewport.w, &renderer->viewport.h) < 0) {
+        int w, h;
+        renderer->viewport.x = 0.0f;
+        renderer->viewport.y = 0.0f;
+        if (SDL_GetRendererOutputSize(renderer, &w, &h) < 0) {
             return -1;
         }
+        renderer->viewport.w = w;
+        renderer->viewport.h = h;
     }
     retval = QueueCmdSetViewport(renderer);
     return retval < 0 ? retval : FlushRenderCommandsIfNotBatching(renderer);
@@ -2414,10 +2423,10 @@ SDL_RenderGetViewport(SDL_Renderer * renderer, SDL_Rect * rect)
     CHECK_RENDERER_MAGIC(renderer, );
 
     if (rect) {
-        rect->x = (int)(renderer->viewport.x / renderer->scale.x);
-        rect->y = (int)(renderer->viewport.y / renderer->scale.y);
-        rect->w = (int)(renderer->viewport.w / renderer->scale.x);
-        rect->h = (int)(renderer->viewport.h / renderer->scale.y);
+        rect->x = renderer->viewport.x / renderer->scale.x;
+        rect->y = renderer->viewport.y / renderer->scale.y;
+        rect->w = renderer->viewport.w / renderer->scale.x;
+        rect->h = renderer->viewport.h / renderer->scale.y;
     }
 }
 
@@ -2438,10 +2447,10 @@ SDL_RenderSetClipRect(SDL_Renderer * renderer, const SDL_Rect * rect)
 
     if (rect) {
         renderer->clipping_enabled = SDL_TRUE;
-        renderer->clip_rect.x = (int)SDL_floor(rect->x * renderer->scale.x);
-        renderer->clip_rect.y = (int)SDL_floor(rect->y * renderer->scale.y);
-        renderer->clip_rect.w = (int)SDL_floor(rect->w * renderer->scale.x);
-        renderer->clip_rect.h = (int)SDL_floor(rect->h * renderer->scale.y);
+        renderer->clip_rect.x = rect->x * renderer->scale.x;
+        renderer->clip_rect.y = rect->y * renderer->scale.y;
+        renderer->clip_rect.w = rect->w * renderer->scale.x;
+        renderer->clip_rect.h = rect->h * renderer->scale.y;
     } else {
         renderer->clipping_enabled = SDL_FALSE;
         SDL_zero(renderer->clip_rect);
@@ -2457,10 +2466,10 @@ SDL_RenderGetClipRect(SDL_Renderer * renderer, SDL_Rect * rect)
     CHECK_RENDERER_MAGIC(renderer, )
 
     if (rect) {
-        rect->x = (int)(renderer->clip_rect.x / renderer->scale.x);
-        rect->y = (int)(renderer->clip_rect.y / renderer->scale.y);
-        rect->w = (int)(renderer->clip_rect.w / renderer->scale.x);
-        rect->h = (int)(renderer->clip_rect.h / renderer->scale.y);
+        rect->x = renderer->clip_rect.x / renderer->scale.x;
+        rect->y = renderer->clip_rect.y / renderer->scale.y;
+        rect->w = renderer->clip_rect.w / renderer->scale.x;
+        rect->h = renderer->clip_rect.h / renderer->scale.y;
     }
 }
 

--- a/src/render/SDL_sysrender.h
+++ b/src/render/SDL_sysrender.h
@@ -186,12 +186,12 @@ struct SDL_Renderer
     SDL_bool integer_scale;
 
     /* The drawable area within the window */
-    SDL_Rect viewport;
-    SDL_Rect viewport_backup;
+    SDL_FRect viewport;
+    SDL_FRect viewport_backup;
 
     /* The clip rectangle within the window */
-    SDL_Rect clip_rect;
-    SDL_Rect clip_rect_backup;
+    SDL_FRect clip_rect;
+    SDL_FRect clip_rect_backup;
 
     /* Wether or not the clipping rectangle is used. */
     SDL_bool clipping_enabled;
@@ -226,8 +226,8 @@ struct SDL_Renderer
     SDL_RenderCommand *render_commands_pool;
     Uint32 render_command_generation;
     Uint32 last_queued_color;
-    SDL_Rect last_queued_viewport;
-    SDL_Rect last_queued_cliprect;
+    SDL_FRect last_queued_viewport;
+    SDL_FRect last_queued_cliprect;
     SDL_bool last_queued_cliprect_enabled;
     SDL_bool color_queued;
     SDL_bool viewport_queued;

--- a/src/render/direct3d11/SDL_render_d3d11.c
+++ b/src/render/direct3d11/SDL_render_d3d11.c
@@ -700,7 +700,10 @@ D3D11_GetRotationForCurrentRenderTarget(SDL_Renderer * renderer)
 static int
 D3D11_GetViewportAlignedD3DRect(SDL_Renderer * renderer, const SDL_Rect * sdlRect, D3D11_RECT * outRect, BOOL includeViewportOffset)
 {
+    D3D11_RenderData *data = (D3D11_RenderData *) renderer->driverdata;
     const int rotation = D3D11_GetRotationForCurrentRenderTarget(renderer);
+    const SDL_Rect *viewport = &data->currentViewport;
+
     switch (rotation) {
         case DXGI_MODE_ROTATION_IDENTITY:
             outRect->left = sdlRect->x;
@@ -708,27 +711,27 @@ D3D11_GetViewportAlignedD3DRect(SDL_Renderer * renderer, const SDL_Rect * sdlRec
             outRect->top = sdlRect->y;
             outRect->bottom = sdlRect->y + sdlRect->h;
             if (includeViewportOffset) {
-                outRect->left += renderer->viewport.x;
-                outRect->right += renderer->viewport.x;
-                outRect->top += renderer->viewport.y;
-                outRect->bottom += renderer->viewport.y;
+                outRect->left += viewport->x;
+                outRect->right += viewport->x;
+                outRect->top += viewport->y;
+                outRect->bottom += viewport->y;
             }
             break;
         case DXGI_MODE_ROTATION_ROTATE270:
             outRect->left = sdlRect->y;
             outRect->right = sdlRect->y + sdlRect->h;
-            outRect->top = renderer->viewport.w - sdlRect->x - sdlRect->w;
-            outRect->bottom = renderer->viewport.w - sdlRect->x;
+            outRect->top = viewport->w - sdlRect->x - sdlRect->w;
+            outRect->bottom = viewport->w - sdlRect->x;
             break;
         case DXGI_MODE_ROTATION_ROTATE180:
-            outRect->left = renderer->viewport.w - sdlRect->x - sdlRect->w;
-            outRect->right = renderer->viewport.w - sdlRect->x;
-            outRect->top = renderer->viewport.h - sdlRect->y - sdlRect->h;
-            outRect->bottom = renderer->viewport.h - sdlRect->y;
+            outRect->left = viewport->w - sdlRect->x - sdlRect->w;
+            outRect->right = viewport->w - sdlRect->x;
+            outRect->top = viewport->h - sdlRect->y - sdlRect->h;
+            outRect->bottom = viewport->h - sdlRect->y;
             break;
         case DXGI_MODE_ROTATION_ROTATE90:
-            outRect->left = renderer->viewport.h - sdlRect->y - sdlRect->h;
-            outRect->right = renderer->viewport.h - sdlRect->y;
+            outRect->left = viewport->h - sdlRect->y - sdlRect->h;
+            outRect->right = viewport->h - sdlRect->y;
             outRect->top = sdlRect->x;
             outRect->bottom = sdlRect->x + sdlRect->h;
             break;

--- a/src/render/software/SDL_render_sw.c
+++ b/src/render/software/SDL_render_sw.c
@@ -214,18 +214,9 @@ SW_QueueDrawPoints(SDL_Renderer * renderer, SDL_RenderCommand *cmd, const SDL_FP
 
     cmd->data.draw.count = count;
 
-    if (renderer->viewport.x || renderer->viewport.y) {
-        const int x = renderer->viewport.x;
-        const int y = renderer->viewport.y;
-        for (i = 0; i < count; i++, verts++, points++) {
-            verts->x = (int)(x + points->x);
-            verts->y = (int)(y + points->y);
-        }
-    } else {
-        for (i = 0; i < count; i++, verts++, points++) {
-            verts->x = (int)points->x;
-            verts->y = (int)points->y;
-        }
+    for (i = 0; i < count; i++, verts++, points++) {
+        verts->x = (int)points->x;
+        verts->y = (int)points->y;
     }
 
     return 0;
@@ -243,23 +234,11 @@ SW_QueueFillRects(SDL_Renderer * renderer, SDL_RenderCommand *cmd, const SDL_FRe
 
     cmd->data.draw.count = count;
 
-    if (renderer->viewport.x || renderer->viewport.y) {
-        const int x = renderer->viewport.x;
-        const int y = renderer->viewport.y;
-
-        for (i = 0; i < count; i++, verts++, rects++) {
-            verts->x = (int)(x + rects->x);
-            verts->y = (int)(y + rects->y);
-            verts->w = SDL_max((int)rects->w, 1);
-            verts->h = SDL_max((int)rects->h, 1);
-        }
-    } else {
-        for (i = 0; i < count; i++, verts++, rects++) {
-            verts->x = (int)rects->x;
-            verts->y = (int)rects->y;
-            verts->w = SDL_max((int)rects->w, 1);
-            verts->h = SDL_max((int)rects->h, 1);
-        }
+    for (i = 0; i < count; i++, verts++, rects++) {
+        verts->x = (int)rects->x;
+        verts->y = (int)rects->y;
+        verts->w = SDL_max((int)rects->w, 1);
+        verts->h = SDL_max((int)rects->h, 1);
     }
 
     return 0;
@@ -280,13 +259,8 @@ SW_QueueCopy(SDL_Renderer * renderer, SDL_RenderCommand *cmd, SDL_Texture * text
     SDL_memcpy(verts, srcrect, sizeof (SDL_Rect));
     verts++;
 
-    if (renderer->viewport.x || renderer->viewport.y) {
-        verts->x = (int)(renderer->viewport.x + dstrect->x);
-        verts->y = (int)(renderer->viewport.y + dstrect->y);
-    } else {
-        verts->x = (int)dstrect->x;
-        verts->y = (int)dstrect->y;
-    }
+    verts->x = (int)dstrect->x;
+    verts->y = (int)dstrect->y;
     verts->w = (int)dstrect->w;
     verts->h = (int)dstrect->h;
 
@@ -317,13 +291,8 @@ SW_QueueCopyEx(SDL_Renderer * renderer, SDL_RenderCommand *cmd, SDL_Texture * te
 
     SDL_memcpy(&verts->srcrect, srcrect, sizeof (SDL_Rect));
 
-    if (renderer->viewport.x || renderer->viewport.y) {
-        verts->dstrect.x = (int)(renderer->viewport.x + dstrect->x);
-        verts->dstrect.y = (int)(renderer->viewport.y + dstrect->y);
-    } else {
-        verts->dstrect.x = (int)dstrect->x;
-        verts->dstrect.y = (int)dstrect->y;
-    }
+    verts->dstrect.x = (int)dstrect->x;
+    verts->dstrect.y = (int)dstrect->y;
     verts->dstrect.w = (int)dstrect->w;
     verts->dstrect.h = (int)dstrect->h;
     verts->angle = angle;
@@ -618,8 +587,8 @@ SW_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Texture *te
             ptr->src.x = (int)(uv_[0] * texture->w);
             ptr->src.y = (int)(uv_[1] * texture->h);
 
-            ptr->dst.x = (int)(xy_[0] * scale_x + renderer->viewport.x);
-            ptr->dst.y = (int)(xy_[1] * scale_y + renderer->viewport.y);
+            ptr->dst.x = (int)(xy_[0] * scale_x);
+            ptr->dst.y = (int)(xy_[1] * scale_y);
             trianglepoint_2_fixedpoint(&ptr->dst);
 
             ptr->color = col_;
@@ -646,8 +615,8 @@ SW_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Texture *te
             xy_ = (float *)((char*)xy + j * xy_stride);
             col_ = *(SDL_Color *)((char*)color + j * color_stride);
 
-            ptr->dst.x = (int)(xy_[0] * scale_x + renderer->viewport.x);
-            ptr->dst.y = (int)(xy_[1] * scale_y + renderer->viewport.y);
+            ptr->dst.x = (int)(xy_[0] * scale_x);
+            ptr->dst.y = (int)(xy_[1] * scale_y);
             trianglepoint_2_fixedpoint(&ptr->dst);
 
             ptr->color = col_;
@@ -755,9 +724,19 @@ SW_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *vertic
                 const Uint8 b = cmd->data.draw.b;
                 const Uint8 a = cmd->data.draw.a;
                 const int count = (int) cmd->data.draw.count;
-                const SDL_Point *verts = (SDL_Point *) (((Uint8 *) vertices) + cmd->data.draw.first);
+                SDL_Point *verts = (SDL_Point *) (((Uint8 *) vertices) + cmd->data.draw.first);
                 const SDL_BlendMode blend = cmd->data.draw.blend;
                 SetDrawState(surface, &drawstate);
+
+                /* Apply viewport */
+                if (drawstate.viewport->x || drawstate.viewport->y) {
+                    int i;
+                    for (i = 0; i < count; i++) {
+                        verts[i].x += drawstate.viewport->x;
+                        verts[i].y += drawstate.viewport->y;
+                    }
+                }
+
                 if (blend == SDL_BLENDMODE_NONE) {
                     SDL_DrawPoints(surface, verts, count, SDL_MapRGBA(surface->format, r, g, b, a));
                 } else {
@@ -772,9 +751,19 @@ SW_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *vertic
                 const Uint8 b = cmd->data.draw.b;
                 const Uint8 a = cmd->data.draw.a;
                 const int count = (int) cmd->data.draw.count;
-                const SDL_Point *verts = (SDL_Point *) (((Uint8 *) vertices) + cmd->data.draw.first);
+                SDL_Point *verts = (SDL_Point *) (((Uint8 *) vertices) + cmd->data.draw.first);
                 const SDL_BlendMode blend = cmd->data.draw.blend;
                 SetDrawState(surface, &drawstate);
+
+                /* Apply viewport */
+                if (drawstate.viewport->x || drawstate.viewport->y) {
+                    int i;
+                    for (i = 0; i < count; i++) {
+                        verts[i].x += drawstate.viewport->x;
+                        verts[i].y += drawstate.viewport->y;
+                    }
+                }
+
                 if (blend == SDL_BLENDMODE_NONE) {
                     SDL_DrawLines(surface, verts, count, SDL_MapRGBA(surface->format, r, g, b, a));
                 } else {
@@ -789,9 +778,19 @@ SW_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *vertic
                 const Uint8 b = cmd->data.draw.b;
                 const Uint8 a = cmd->data.draw.a;
                 const int count = (int) cmd->data.draw.count;
-                const SDL_Rect *verts = (SDL_Rect *) (((Uint8 *) vertices) + cmd->data.draw.first);
+                SDL_Rect *verts = (SDL_Rect *) (((Uint8 *) vertices) + cmd->data.draw.first);
                 const SDL_BlendMode blend = cmd->data.draw.blend;
                 SetDrawState(surface, &drawstate);
+
+                /* Apply viewport */
+                if (drawstate.viewport->x || drawstate.viewport->y) {
+                    int i;
+                    for (i = 0; i < count; i++) {
+                        verts[i].x += drawstate.viewport->x;
+                        verts[i].y += drawstate.viewport->y;
+                    }
+                }
+
                 if (blend == SDL_BLENDMODE_NONE) {
                     SDL_FillRects(surface, verts, count, SDL_MapRGBA(surface->format, r, g, b, a));
                 } else {
@@ -811,6 +810,12 @@ SW_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *vertic
 
                 PrepTextureForCopy(cmd);
 
+                /* Apply viewport */
+                if (drawstate.viewport->x || drawstate.viewport->y) {
+                    dstrect->x += drawstate.viewport->x;
+                    dstrect->y += drawstate.viewport->y;
+                }
+
                 if ( srcrect->w == dstrect->w && srcrect->h == dstrect->h ) {
                     SDL_BlitSurface(src, srcrect, surface, dstrect);
                 } else {
@@ -824,9 +829,16 @@ SW_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *vertic
             }
 
             case SDL_RENDERCMD_COPY_EX: {
-                const CopyExData *copydata = (CopyExData *) (((Uint8 *) vertices) + cmd->data.draw.first);
+                CopyExData *copydata = (CopyExData *) (((Uint8 *) vertices) + cmd->data.draw.first);
                 SetDrawState(surface, &drawstate);
                 PrepTextureForCopy(cmd);
+
+                /* Apply viewport */
+                if (drawstate.viewport->x || drawstate.viewport->y) {
+                    copydata->dstrect.x += drawstate.viewport->x;
+                    copydata->dstrect.y += drawstate.viewport->y;
+                }
+
                 SW_RenderCopyEx(renderer, surface, cmd->data.draw.texture, &copydata->srcrect,
                                 &copydata->dstrect, copydata->angle, &copydata->center, copydata->flip);
                 break;
@@ -847,6 +859,20 @@ SW_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *vertic
                     GeometryCopyData *ptr = (GeometryCopyData *) verts;
 
                     PrepTextureForCopy(cmd);
+
+                    /* Apply viewport */
+                    if (drawstate.viewport->x || drawstate.viewport->y) {
+                        int i;
+                        SDL_Point vp;
+                        vp.x = drawstate.viewport->x;
+                        vp.y = drawstate.viewport->y;
+                        trianglepoint_2_fixedpoint(&vp);
+                        for (i = 0; i < count; i++) {
+                            ptr[i].dst.x += vp.x;
+                            ptr[i].dst.y += vp.y;
+                        }
+                    }
+
                     for (i = 0; i < count; i += 3, ptr += 3) {
                         SDL_SW_BlitTriangle(
                                 src,
@@ -857,6 +883,20 @@ SW_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *vertic
                     }
                 } else {
                     GeometryFillData *ptr = (GeometryFillData *) verts;
+
+                    /* Apply viewport */
+                    if (drawstate.viewport->x || drawstate.viewport->y) {
+                        int i;
+                        SDL_Point vp;
+                        vp.x = drawstate.viewport->x;
+                        vp.y = drawstate.viewport->y;
+                        trianglepoint_2_fixedpoint(&vp);
+                        for (i = 0; i < count; i++) {
+                            ptr[i].dst.x += vp.x;
+                            ptr[i].dst.y += vp.y;
+                        }
+                    }
+
                     for (i = 0; i < count; i += 3, ptr += 3) {
                         SDL_SW_FillTriangle(surface, &(ptr[0].dst), &(ptr[1].dst), &(ptr[2].dst), blend, ptr[0].color, ptr[1].color, ptr[2].color);
                     }


### PR DESCRIPTION
Before some future modification to viewport  / cliprect, some "simplication".
Don't use "renderer->viewport" in back-ends but use the one that comes from SETVIEWPORT cmd

- tested for the software renderer.
- not tested for D3D11
