### PR TITLE
Release UDEV ressources

### DIFF
--- a/src/hidapi/SDL_hidapi.c
+++ b/src/hidapi/SDL_hidapi.c
@@ -1098,6 +1098,9 @@ int SDL_hid_exit(void)
     if (udev_ctx) {
         result |= PLATFORM_hid_exit();
     }
+#if __LINUX__
+    SDL_UDEV_ReleaseUdevSyms();
+#endif /* __LINUX __ */
 #endif /* HAVE_PLATFORM_BACKEND */
 
 #ifdef SDL_LIBUSB_DYNAMIC


### PR DESCRIPTION
Valgrind report reachable blocks when quitting an application.
It seems  UDEV isn't fully released.

```
==46884== 328 bytes in 1 blocks are still reachable in loss record 174 of 225
==46884==    at 0x4843839: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==46884==    by 0x8B21384: ??? (in /usr/lib/x86_64-linux-gnu/libudev.so.1.7.1)
==46884==    by 0x8B11EA7: udev_monitor_new_from_netlink (in /usr/lib/x86_64-linux-gnu/libudev.so.1.7.1)
==46884==    by 0x4B17927: SDL_UDEV_Init (SDL_udev.c:141)
==46884==    by 0x4B189EB: SDL_UDEV_GetUdevSyms (SDL_udev.c:569)
==46884==    by 0x48DEBF6: SDL_hid_init_REAL (SDL_hidapi.c:1065)
==46884==    by 0x4B0C41F: HIDAPI_JoystickInit (SDL_hidapijoystick.c:311)
==46884==    by 0x48E50F9: SDL_JoystickInit (SDL_joystick.c:247)
==46884==    by 0x48A4330: SDL_InitSubSystem_REAL (SDL.c:261)
==46884==    by 0x48A4430: SDL_Init_REAL (SDL.c:330)
==46884==    by 0x48C359D: SDL_Init (SDL_dynapi_procs.h:85)
```