### PR TITLE
 Added a hint for joysticks on Linux

### DIFF
--- a/test/testgamecontroller.c
+++ b/test/testgamecontroller.c
@@ -530,6 +530,7 @@ main(int argc, char *argv[])
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, "1");
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, "1");
     SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+    SDL_SetHint(SDL_HINT_LINUX_JOYSTICK_DEADZONES, "1");
 
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);


### PR DESCRIPTION
Stabilizing the analog stick events for Sixaxis, & Dualshock controllers.

## Description
Fixing an issue I had here: https://discourse.libsdl.org/t/playstation-controllers-analog-sticks-dont-work-properly-on-sdl2/33688/2. At the very least the game controller test program should work with these controllers as expected.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
