### PR TITLE
cmake: fix Metal detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1966,9 +1966,7 @@ elseif(APPLE)
     endif()
 
     if(SDL_VULKAN OR SDL_METAL OR SDL_RENDER_METAL)
-      set(ORIG_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
-      set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -ObjC")
-      check_c_source_compiles("
+      check_objc_source_compiles("
         #include <AvailabilityMacros.h>
         #import <Metal/Metal.h>
         #import <QuartzCore/CAMetalLayer.h>
@@ -1976,11 +1974,7 @@ elseif(APPLE)
         #if (!TARGET_CPU_X86_64 && !TARGET_CPU_ARM64)
         #error Metal doesn't work on this configuration
         #endif
-        int main(void) {
-            return 0;
-        }
-        " HAVE_FRAMEWORK_METAL)
-      set(CMAKE_REQUIRED_FLAGS ${ORIG_CMAKE_REQUIRED_FLAGS})
+        int main(void) {}" HAVE_FRAMEWORK_METAL)
       if(HAVE_FRAMEWORK_METAL)
         set(SDL_FRAMEWORK_METAL 1)
         set(SDL_FRAMEWORK_QUARTZCORE 1)


### PR DESCRIPTION
## Description

Without this change, I was getting errors about ObjC syntax from headers being used in the test program which was being compiled as C.

Confirmed to work on:
macOS 10.15.7
XCode Version 12.4 (12D4e)
Xcode generator (`cmake -GXcode ..`)

## Existing Issue(s)

Fixes #5010
(I think) fixes #3893