### PR TITLE
SDL_render_gl.c: GL_RunCommandQueue: always set viewport_dirty on macOS

### DIFF
--- a/src/render/opengl/SDL_render_gl.c
+++ b/src/render/opengl/SDL_render_gl.c
@@ -1169,6 +1169,12 @@ GL_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *vertic
         }
     }
 
+#ifdef __MACOSX__
+    // On macOS, moving the window seems to invalidate the OpenGL viewport state,
+    // so don't bother trying to persist it across frames; always reset it.
+    // Workaround for: https://github.com/libsdl-org/SDL/issues/1504
+    data->drawstate.viewport_dirty = SDL_TRUE;
+#endif
 
     while (cmd) {
         switch (cmd->command) {


### PR DESCRIPTION
## Description

Without this, moving the window changes the viewport and causes contents to render stretched.

## Existing Issue(s)

Fixes #1504 
