### PR TITLE
Return capabitlities from RawInput joystick

### DIFF
--- a/src/joystick/windows/SDL_rawinputjoystick.c
+++ b/src/joystick/windows/SDL_rawinputjoystick.c
@@ -1308,7 +1308,7 @@ RAWINPUT_JoystickGetCapabilities(SDL_Joystick *joystick)
     }
 #endif
 
-    return 0;
+    return result;
 }
 
 static int


### PR DESCRIPTION
## Description
`RAWINPUT_JoystickGetCapabilities()` always returns 0 instead of actual joystick capabilities.

## Existing Issue(s)
None.
