### PR TITLE
haptic: Fix SDL_MouseIsHaptic() always return SDL_TRUE on Android

### DIFF
--- a/src/haptic/android/SDL_syshaptic.c
+++ b/src/haptic/android/SDL_syshaptic.c
@@ -155,7 +155,7 @@ SDL_SYS_HapticOpen(SDL_Haptic *haptic)
 int
 SDL_SYS_HapticMouse(void)
 {
-    return 0;
+    return -1;
 }
 
 


### PR DESCRIPTION
@slouken okay for 2.0.18?

## Existing Issue(s)
Fixes #5018
