### PR TITLE
Add back X11 legacy WM_NAME encodings

### DIFF
--- a/src/video/x11/SDL_x11messagebox.c
+++ b/src/video/x11/SDL_x11messagebox.c
@@ -404,11 +404,10 @@ X11_MessageBoxCreateWindow( SDL_MessageBoxDataX11 *data )
     int x, y;
     XSizeHints *sizehints;
     XSetWindowAttributes wnd_attr;
-    Atom _NET_WM_WINDOW_TYPE, _NET_WM_WINDOW_TYPE_DIALOG, _NET_WM_NAME;
+    Atom _NET_WM_WINDOW_TYPE, _NET_WM_WINDOW_TYPE_DIALOG;
     Display *display = data->display;
     SDL_WindowData *windowdata = NULL;
     const SDL_MessageBoxData *messageboxdata = data->messageboxdata;
-    char *title_locale = NULL;
 
     if ( messageboxdata->window ) {
         SDL_DisplayData *displaydata =
@@ -452,32 +451,7 @@ X11_MessageBoxCreateWindow( SDL_MessageBoxDataX11 *data )
         X11_XSetTransientForHint( display, data->window, windowdata->xwindow );
     }
 
-    X11_XStoreName( display, data->window, messageboxdata->title );
-    _NET_WM_NAME = X11_XInternAtom(display, "_NET_WM_NAME", False);
-
-    title_locale = SDL_iconv_utf8_locale(messageboxdata->title);
-    if (title_locale) {
-        XTextProperty titleprop;
-        Status status = X11_XStringListToTextProperty(&title_locale, 1, &titleprop);
-        SDL_free(title_locale);
-        if (status) {
-            X11_XSetTextProperty(display, data->window, &titleprop, XA_WM_NAME);
-            X11_XFree(titleprop.value);
-        }
-    }
-
-#ifdef X_HAVE_UTF8_STRING
-    if (SDL_X11_HAVE_UTF8) {
-        XTextProperty titleprop;
-        Status status = X11_Xutf8TextListToTextProperty(display, (char **) &messageboxdata->title, 1,
-                                            XUTF8StringStyle, &titleprop);
-        if (status == Success) {
-            X11_XSetTextProperty(display, data->window, &titleprop,
-                                 _NET_WM_NAME);
-            X11_XFree(titleprop.value);
-        }
-    }
-#endif
+    SDL_X11_SetWindowTitle(display, data->window, (char*)messageboxdata->title);
 
     /* Let the window manager know this is a dialog box */
     _NET_WM_WINDOW_TYPE = X11_XInternAtom(display, "_NET_WM_WINDOW_TYPE", False);

--- a/src/video/x11/SDL_x11sym.h
+++ b/src/video/x11/SDL_x11sym.h
@@ -156,6 +156,9 @@ SDL_X11_SYM(SDL_X11_XESetWireToEventRetType,XESetWireToEvent,(Display* a,int b,S
 SDL_X11_SYM(SDL_X11_XESetEventToWireRetType,XESetEventToWire,(Display* a,int b,SDL_X11_XESetEventToWireRetType c),(a,b,c),return)
 SDL_X11_SYM(void,XRefreshKeyboardMapping,(XMappingEvent *a),(a),)
 SDL_X11_SYM(int,XQueryTree,(Display* a,Window b,Window* c,Window* d,Window** e,unsigned int* f),(a,b,c,d,e,f),return)
+SDL_X11_SYM(Bool,XSupportsLocale,(void),(),return)
+SDL_X11_SYM(void,XSetWMName,(Display* a,Window b,XTextProperty* c),(a,b,c),return)
+SDL_X11_SYM(Status,XmbTextListToTextProperty,(Display* a,char** b,int c,XICCEncodingStyle d,XTextProperty* e),(a,b,c,d,e),return)
 
 #if SDL_VIDEO_DRIVER_X11_XFIXES
 SDL_X11_MODULE(XFIXES)

--- a/src/video/x11/SDL_x11sym.h
+++ b/src/video/x11/SDL_x11sym.h
@@ -157,7 +157,6 @@ SDL_X11_SYM(SDL_X11_XESetEventToWireRetType,XESetEventToWire,(Display* a,int b,S
 SDL_X11_SYM(void,XRefreshKeyboardMapping,(XMappingEvent *a),(a),)
 SDL_X11_SYM(int,XQueryTree,(Display* a,Window b,Window* c,Window* d,Window** e,unsigned int* f),(a,b,c,d,e,f),return)
 SDL_X11_SYM(Bool,XSupportsLocale,(void),(),return)
-SDL_X11_SYM(void,XSetWMName,(Display* a,Window b,XTextProperty* c),(a,b,c),return)
 SDL_X11_SYM(Status,XmbTextListToTextProperty,(Display* a,char** b,int c,XICCEncodingStyle d,XTextProperty* e),(a,b,c,d,e),return)
 
 #if SDL_VIDEO_DRIVER_X11_XFIXES

--- a/src/video/x11/SDL_x11video.c
+++ b/src/video/x11/SDL_x11video.c
@@ -460,6 +460,14 @@ X11_VideoInit(_THIS)
     X11_InitXfixes(_this);
 #endif /* SDL_VIDEO_DRIVER_X11_XFIXES */
 
+#ifndef X_HAVE_UTF8_STRING
+    SDL_LogError(SDL_LOG_CATEGORY_VIDEO, "X server doesn't support UTF8_STRING, a feature introduced in 2000! This is likely to become a hard error in a future libSDL2.");
+#endif
+
+    if (X11_XSupportsLocale() != True) {
+        return SDL_SetError("Current locale not supported by X server, cannot continue.");
+    }
+
     if (X11_InitKeyboard(_this) != 0) {
         return -1;
     }

--- a/src/video/x11/SDL_x11video.c
+++ b/src/video/x11/SDL_x11video.c
@@ -461,12 +461,8 @@ X11_VideoInit(_THIS)
 #endif /* SDL_VIDEO_DRIVER_X11_XFIXES */
 
 #ifndef X_HAVE_UTF8_STRING
-    SDL_LogError(SDL_LOG_CATEGORY_VIDEO, "X server doesn't support UTF8_STRING, a feature introduced in 2000! This is likely to become a hard error in a future libSDL2.");
+#warning X server does not support UTF8_STRING, a feature introduced in 2000! This is likely to become a hard error in a future libSDL2.
 #endif
-
-    if (X11_XSupportsLocale() != True) {
-        return SDL_SetError("Current locale not supported by X server, cannot continue.");
-    }
 
     if (X11_InitKeyboard(_this) != 0) {
         return -1;

--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -1885,10 +1885,10 @@ int SDL_X11_SetWindowTitle(Display* display, Window xwindow, char* title) {
     if (conv == 0) {
         X11_XSetTextProperty(display, xwindow, &titleprop, XA_WM_NAME);
         X11_XFree(titleprop.value);
-    // we know this can't be a locale error as we checked X locale validity
+    /* we know this can't be a locale error as we checked X locale validity */
     } else if (conv < 0) {
         return SDL_OutOfMemory();
-    } else { // conv > 0
+    } else { /* conv > 0 */
         SDL_LogDebug(SDL_LOG_CATEGORY_VIDEO, "%d characters were not convertable to the current locale!", conv);
         return 0;
     }

--- a/src/video/x11/SDL_x11window.h
+++ b/src/video/x11/SDL_x11window.h
@@ -117,6 +117,8 @@ extern int X11_SetWindowHitTest(SDL_Window *window, SDL_bool enabled);
 extern void X11_AcceptDragAndDrop(SDL_Window * window, SDL_bool accept);
 extern int X11_FlashWindow(_THIS, SDL_Window * window, SDL_FlashOperation operation);
 
+bool SDL_X11_SetWindowTitle(Display* display, Window xwindow, char* string);
+
 #endif /* SDL_x11window_h_ */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/x11/SDL_x11window.h
+++ b/src/video/x11/SDL_x11window.h
@@ -117,7 +117,7 @@ extern int X11_SetWindowHitTest(SDL_Window *window, SDL_bool enabled);
 extern void X11_AcceptDragAndDrop(SDL_Window * window, SDL_bool accept);
 extern int X11_FlashWindow(_THIS, SDL_Window * window, SDL_FlashOperation operation);
 
-bool SDL_X11_SetWindowTitle(Display* display, Window xwindow, char* string);
+int SDL_X11_SetWindowTitle(Display* display, Window xwindow, char* string);
 
 #endif /* SDL_x11window_h_ */
 


### PR DESCRIPTION
Closes #4924.

Based on patches of the past, such as this work by James Cloos in July 2010: https://github.com/exg/rxvt-unicode/commit/d7d98751b7385416ad1694b5f1fde6c312ba20d5, as well as code comments in the Perl module X11::Protocol::WM (https://metacpan.org/pod/X11::Protocol::WM) and even the code to Xlib itself, which taught me that we should never have been using `XStoreName`, all it does is call `XChangeProperty`, hardcoded to `XA_STRING`!

What can I say, when the task is old school, the sources are too 😂

cc @morgant @slouken 

Sorry for any problems caused to y'all's release cycle, I would've never caused any on purpose. I still believe I'm right per the spec (as Qt once believed in 2014), but seven years later is still too late. I wonder who will be trying again in 2028? Not me again that's for sure.
