### PR TITLE
video: x11: Fix an invalid SDL_LogError() call

### DIFF
--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -717,8 +717,8 @@ X11_GetWindowTitle(_THIS, Window xwindow)
                     0L, 8192L, False, XA_STRING, &real_type, &real_format,
                     &items_read, &items_left, &propdata);
         if (status == Success && propdata) {
-            SDL_LogDebug(SDL_LOG_CATEGORY_VIDEO, "Failed to convert WM_NAME title expecting UTF8! Title: %s", title);
             title = SDL_iconv_string("UTF-8", "", SDL_static_cast(char*, propdata), items_read+1);
+            SDL_LogDebug(SDL_LOG_CATEGORY_VIDEO, "Failed to convert WM_NAME title expecting UTF8! Title: %s", title);
             X11_XFree(propdata);
         } else {
             SDL_LogDebug(SDL_LOG_CATEGORY_VIDEO, "Could not get any window title response from Xorg, returning empty string!");


### PR DESCRIPTION
This fixes a compile warning — and possible invalid memory read — introduced in 9c03d255 ("Add back X11 legacy WM_NAME encodings"), which was part of PR #5029, fixing Bug #4924.

The issue is with one of the added warnings in ``X11_GetWindowTitle()``. Basically, the "title" variable passed to SDL_LogError() hasn't been initialised yet: we could pass propdata in directly, but it's better to move the SDL_LogError() call until after title is set, IMHO.

This fixes the following warning from gcc (SUSE Linux) 11.2.1:
```
In file included from /home/david/Development/SDL/src/video/x11/../../SDL_internal.h:45,
                 from /home/david/Development/SDL/src/video/x11/SDL_x11window.c:21:
/home/david/Development/SDL/src/video/x11/SDL_x11window.c: In function 'X11_GetWindowTitle':
/home/david/Development/SDL/src/video/x11/../../dynapi/SDL_dynapi_overrides.h:33:22: warning: '%s' directive argument is null [-Wformat-overflow=]
   33 | #define SDL_LogDebug SDL_LogDebug_REAL
/home/david/Development/SDL/src/video/x11/SDL_x11window.c:720:13: note: in expansion of macro 'SDL_LogDebug'
  720 |             SDL_LogDebug(SDL_LOG_CATEGORY_VIDEO, "Failed to convert WM_NAME title expecting UTF8! Title: %s", title);
      |             ^~~~~~~~~~~~
```