### PR TITLE
windows: Fix GUI key state when grabbing the keyboard

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1476,6 +1476,7 @@ WIN_PumpEvents(_THIS)
     MSG msg;
     DWORD end_ticks = GetTickCount() + 1;
     int new_messages = 0;
+    SDL_Window *focusWindow;
 
     if (g_WindowsEnableMessageLoop) {
         while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
@@ -1523,12 +1524,18 @@ WIN_PumpEvents(_THIS)
     if ((keystate[SDL_SCANCODE_RSHIFT] == SDL_PRESSED) && !(GetKeyState(VK_RSHIFT) & 0x8000)) {
         SDL_SendKeyboardKey(SDL_RELEASED, SDL_SCANCODE_RSHIFT);
     }
-    /* The Windows key state gets lost when using Windows+Space or Windows+G shortcuts */
-    if ((keystate[SDL_SCANCODE_LGUI] == SDL_PRESSED) && !(GetKeyState(VK_LWIN) & 0x8000)) {
-        SDL_SendKeyboardKey(SDL_RELEASED, SDL_SCANCODE_LGUI);
-    }
-    if ((keystate[SDL_SCANCODE_RGUI] == SDL_PRESSED) && !(GetKeyState(VK_RWIN) & 0x8000)) {
-        SDL_SendKeyboardKey(SDL_RELEASED, SDL_SCANCODE_RGUI);
+
+    /* The Windows key state gets lost when using Windows+Space or Windows+G shortcuts and
+       not grabbing the keyboard. Note: If we *are* grabbing the keyboard, GetKeyState()
+       will return inaccurate results for VK_LWIN and VK_RWIN but we don't need it anyway. */
+    focusWindow = SDL_GetKeyboardFocus();
+    if (!focusWindow || !(focusWindow->flags & SDL_WINDOW_KEYBOARD_GRABBED)) {
+        if ((keystate[SDL_SCANCODE_LGUI] == SDL_PRESSED) && !(GetKeyState(VK_LWIN) & 0x8000)) {
+            SDL_SendKeyboardKey(SDL_RELEASED, SDL_SCANCODE_LGUI);
+        }
+        if ((keystate[SDL_SCANCODE_RGUI] == SDL_PRESSED) && !(GetKeyState(VK_RWIN) & 0x8000)) {
+            SDL_SendKeyboardKey(SDL_RELEASED, SDL_SCANCODE_RGUI);
+        }
     }
 
     /* Update the clipping rect in case someone else has stolen it */


### PR DESCRIPTION
## Description
The Windows key up event loss workaround added in 3b85e3fdfce01c528a6ebf9ac537bdc106ba4963 breaks holding down the Windows key while keyboard grab is active. The fix is simply not to do the workaround when keyboard grab is enabled (since keyboard grab ensures we don't lose the key up event in the first place).

When our keyboard grab hook is installed, GetKeyState() will return 0 for the GUI keys even when they are pressed. This leads to spurious key up events when holding down the GUI keys and the inability to use any key combos involving those modifier keys.

Holding Windows key down in `testgl2 --keyboard-grab` without the fix:
```
INFO: SDL EVENT: SDL_KEYDOWN (timestamp=3000 windowid=1 state=pressed repeat=false scancode=227 keycode=1073742051 mod=1024)
INFO: SDL EVENT: SDL_KEYUP (timestamp=3000 windowid=1 state=released repeat=false scancode=227 keycode=1073742051 mod=0)
INFO: SDL EVENT: SDL_KEYDOWN (timestamp=3032 windowid=1 state=pressed repeat=false scancode=227 keycode=1073742051 mod=1024)
INFO: SDL EVENT: SDL_KEYUP (timestamp=3033 windowid=1 state=released repeat=false scancode=227 keycode=1073742051 mod=0)
INFO: SDL EVENT: SDL_KEYDOWN (timestamp=3065 windowid=1 state=pressed repeat=false scancode=227 keycode=1073742051 mod=1024)
INFO: SDL EVENT: SDL_KEYUP (timestamp=3065 windowid=1 state=released repeat=false scancode=227 keycode=1073742051 mod=0)
INFO: SDL EVENT: SDL_KEYDOWN (timestamp=3096 windowid=1 state=pressed repeat=false scancode=227 keycode=1073742051 mod=1024)
INFO: SDL EVENT: SDL_KEYUP (timestamp=3096 windowid=1 state=released repeat=false scancode=227 keycode=1073742051 mod=0)
INFO: SDL EVENT: SDL_KEYDOWN (timestamp=3142 windowid=1 state=pressed repeat=false scancode=227 keycode=1073742051 mod=1024)
INFO: SDL EVENT: SDL_KEYUP (timestamp=3143 windowid=1 state=released repeat=false scancode=227 keycode=1073742051 mod=0)
INFO: SDL EVENT: SDL_KEYDOWN (timestamp=3175 windowid=1 state=pressed repeat=false scancode=227 keycode=1073742051 mod=1024)
INFO: SDL EVENT: SDL_KEYUP (timestamp=3176 windowid=1 state=released repeat=false scancode=227 keycode=1073742051 mod=0)
INFO: SDL EVENT: SDL_KEYDOWN (timestamp=3207 windowid=1 state=pressed repeat=false scancode=227 keycode=1073742051 mod=1024)
```

Holding Windows key down in  `testgl2 --keyboard-grab` with the fix:
```
INFO: SDL EVENT: SDL_KEYDOWN (timestamp=95713 windowid=1 state=pressed repeat=true scancode=227 keycode=1073742051 mod=1024)
INFO: SDL EVENT: SDL_KEYDOWN (timestamp=95746 windowid=1 state=pressed repeat=true scancode=227 keycode=1073742051 mod=1024)
INFO: SDL EVENT: SDL_KEYDOWN (timestamp=95777 windowid=1 state=pressed repeat=true scancode=227 keycode=1073742051 mod=1024)
INFO: SDL EVENT: SDL_KEYDOWN (timestamp=95809 windowid=1 state=pressed repeat=true scancode=227 keycode=1073742051 mod=1024)
INFO: SDL EVENT: SDL_KEYDOWN (timestamp=95841 windowid=1 state=pressed repeat=true scancode=227 keycode=1073742051 mod=1024)
INFO: SDL EVENT: SDL_KEYDOWN (timestamp=95872 windowid=1 state=pressed repeat=true scancode=227 keycode=1073742051 mod=1024)
INFO: SDL EVENT: SDL_KEYDOWN (timestamp=95903 windowid=1 state=pressed repeat=true scancode=227 keycode=1073742051 mod=1024)
INFO: SDL EVENT: SDL_KEYDOWN (timestamp=95934 windowid=1 state=pressed repeat=true scancode=227 keycode=1073742051 mod=1024)
INFO: SDL EVENT: SDL_KEYDOWN (timestamp=95966 windowid=1 state=pressed repeat=true scancode=227 keycode=1073742051 mod=1024)
```