### PR TITLE
Add NSBluetoothAlwaysUsageDescription to iOS sample

### DIFF
--- a/Xcode-iOS/Template/SDL iOS Application/Info.plist
+++ b/Xcode-iOS/Template/SDL iOS Application/Info.plist
@@ -24,5 +24,7 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<false/>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Steam Link would like to use Bluetooth controllers for input.</string>
 </dict>
 </plist>


### PR DESCRIPTION
With out NSBluetoothAlwaysUsageDescription the app will crash on a real device. On a simulator the call is NOP and will not indicate an issue.

## Description
This was observed using SDL 2.0.16, I admittedly haven't tested with latest master.
