### PR TITLE
docs: Don't let Doxygen expand HOME environment variable

### DIFF
--- a/docs/README-macos.md
+++ b/docs/README-macos.md
@@ -239,8 +239,8 @@ Some of you won't want to use the Stationary so I'll give some tips:
 * Remove "main.m" from your project
 * Remove "MainMenu.xib" from your project
 * Remove "AppDelegates.*" from your project
-* Add "$(HOME)/Library/Frameworks/SDL.framework/Headers" to include path
-* Add "$(HOME)/Library/Frameworks" to the frameworks search path
+* Add "\$(HOME)/Library/Frameworks/SDL.framework/Headers" to include path
+* Add "\$(HOME)/Library/Frameworks" to the frameworks search path
 * Add "-framework SDL -framework Foundation -framework AppKit" to "OTHER_LDFLAGS"
 * Add your files
 * Clean and build


### PR DESCRIPTION
Otherwise, the API documentation will encode the home directory of the
user or autobuilder that built SDL, instead of telling the user to use
the literal string $(HOME) as intended.

See also <https://github.com/doxygen/doxygen/issues/7073>.
