### PR TITLE
workaround for libmali gbm_device_get_fd()

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmsym.h
+++ b/src/video/kmsdrm/SDL_kmsdrmsym.h
@@ -95,7 +95,6 @@ SDL_KMSDRM_SYM(int,drmModeSetPlane,(int fd, uint32_t plane_id, uint32_t crtc_id,
 /* Planes stuff ends. */
 
 SDL_KMSDRM_MODULE(GBM)
-SDL_KMSDRM_SYM(int,gbm_device_get_fd,(struct gbm_device *gbm))
 SDL_KMSDRM_SYM(int,gbm_device_is_format_supported,(struct gbm_device *gbm,
                                                    uint32_t format, uint32_t usage))
 SDL_KMSDRM_SYM(void,gbm_device_destroy,(struct gbm_device *gbm))

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -555,6 +555,7 @@ KMSDRM_AddDisplay (_THIS, drmModeConnector *connector, drmModeRes *resources) {
     /* Initialize some of the members of the new display's driverdata
        to sane values. */
     dispdata->cursor_bo = NULL;
+    dispdata->cursor_bo_drm_fd = -1;
 
     /* Since we create and show the default cursor on KMSDRM_InitMouse(),
        and we call KMSDRM_InitMouse() when we create a window, we have to know

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.h
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.h
@@ -77,6 +77,7 @@ typedef struct SDL_DisplayData
        where we may not have an SDL_Cursor at all (so no SDL_Cursor driverdata).
        There's only one cursor GBM BO because we only support one cursor. */
     struct gbm_bo *cursor_bo;
+    int cursor_bo_drm_fd;
     uint64_t cursor_w, cursor_h;
 
     SDL_bool default_cursor_init;


### PR DESCRIPTION
`gbm_device_get_fd()` in at least some libmali versions duplicate handle.
See https://discourse.libsdl.org/t/handle-leak-in-sdl-kmsdrmmouse-c/33750/5 for details!
Other implementations do not do duplication. To prevent handle leak save drm_fd in `SDL_DisplayData` structure.

## Description
This PR should provide graphics libraries agnostic fix. Please review change in `KMSDRM_CreateCursorBO()` thoroughly - I am not sure whether the handle saved in `dispdata->cursor_bo_drm_fd` always will be the correct one!

## Existing Issue(s)
Currently on devices with libmali versions duplicating the handle there is a handle leak. At least in some situations it leads to major issues (e.g. https://github.com/batocera-linux/batocera.linux/issues/5005 - this particular issue was solved by https://github.com/batocera-linux/batocera.linux/pull/5149/files#diff-155bd67352b7d172caf277b1bcc5f981208d4a736a5b97a8c2d3bd05be65f46f that closes the handle and would cause issues on devices that don't do handle duplication inside `gbm_device_get_fd()`).