### PR TITLE
Fix the wrong int size for fcitx capability.

### DIFF
--- a/src/core/linux/SDL_fcitx.c
+++ b/src/core/linux/SDL_fcitx.c
@@ -205,7 +205,7 @@ Fcitx_SetCapabilities(void *data,
         const char *internal_editing)
 {
     FcitxClient *client = (FcitxClient *)data;
-    Uint32 caps = 0;
+    Uint64 caps = 0;
     if (!client->ic_path) {
         return;
     }


### PR DESCRIPTION
## Description
The integer in the message should be 64bit instead of 32.