### PR TITLE
Update 2.0.18 release notes with CMake prefix change

### DIFF
--- a/WhatsNew.txt
+++ b/WhatsNew.txt
@@ -8,6 +8,7 @@ This is a list of major changes in SDL's version history.
 General:
 * The SDL wiki documentation and development headers are automatically kept in sync
 * Each function has information about in which version of SDL it was introduced
+* SDL-specific CMake options are now prefixed with 'SDL_'. Be sure to update your CMake build scripts accordingly!
 * Added the hint SDL_HINT_APP_NAME to let SDL know the name of your application for various places it might show up in system information
 * Added SDL_RenderGeometry() and SDL_RenderGeometryRaw() to allow rendering of arbitrary shapes using the SDL 2D render API
 * Added SDL_SetTextureUserData() and SDL_GetTextureUserData() to associate application data with an SDL texture


### PR DESCRIPTION
## Description
Adds documentation for CMake change in 7850d0cf6fa1b2e7d8999d0506bb907ae071f497 to release notes for 2.0.18.

## Existing Issue(s)
#5057
