### PR TITLE
IAudioClient::SetEventHandle  Parameter eventHandle should not be NULL

### DIFF
--- a/src/audio/wasapi/SDL_wasapi.c
+++ b/src/audio/wasapi/SDL_wasapi.c
@@ -425,7 +425,6 @@ ReleaseWasapiDevice(_THIS)
 {
     if (this->hidden->client) {
         IAudioClient_Stop(this->hidden->client);
-        IAudioClient_SetEventHandle(this->hidden->client, NULL);
         IAudioClient_Release(this->hidden->client);
         this->hidden->client = NULL;
     }


### PR DESCRIPTION

IAudioClient::SetEventHandle  Parameter eventHandle should not be NULL

After call IAudioClient_SetEventHandle(this->hidden->client, NULL);
We will receive such an error message
"avcore\audiocore\client\audioclient\audioclientcore.cpp(1869)\AUDIOSES.DLL!00007FF8CD2E5FD4: (caller: 00007FF86CA53F12) ReturnHr(1) tid(31a8) 80070057 The parameter is incorrect."

https://docs.microsoft.com/en-us/windows/win32/api/audioclient/nf-audioclient-iaudioclient-seteventhandle

<html><body>
<!--StartFragment--><h2 id="parameters" class="heading-anchor">Parameters</h2>
<p><code>[in] eventHandle</code></p>
<p>The event handle.</p>
<h2 id="return-value" class="heading-anchor"><a class="anchor-link docon docon-link" href="https://docs.microsoft.com/en-us/windows/win32/api/audioclient/nf-audioclient-iaudioclient-seteventhandle#return-value" aria-labelledby="return-value"></a>Return value</h2>
<p>If the method succeeds, it returns S_OK. If it fails, possible return
 codes include, but are not limited to, the values shown in the 
following table.</p>
<div class="table-scroll-wrapper has-inner-focus" tabindex="0" role="group" aria-label="Horizontally scrollable data">

Return code | Description
-- | --
E_INVALIDARG | Parameter eventHandle is NULL or an invalid handle.

</div><!--EndFragment-->
</body>
</html>


