### PR TITLE
[Wayland] Handle 0×0 xdg_toplevel_configure in fullscreen

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -290,8 +290,10 @@ handle_configure_xdg_toplevel(void *data,
         /* For fullscreen, foolishly do what the compositor says. If it's wrong,
          * don't blame us, we were explicitly instructed to do this.
          */
-        window->w = width;
-        window->h = height;
+        if (width != 0 && height != 0) {
+            window->w = width;
+            window->h = height;
+        }
 
         /* This part is good though. */
         if (window->flags & SDL_WINDOW_ALLOW_HIGHDPI) {


### PR DESCRIPTION
tl;dr: Wayland fullscreen is broken under KDE Plasma 5.23.4, and crashes with the message:
```
xdg_surface@28: error -1: invalid window geometry size (0x0)
```

The xdg_shell spec seems to state[1] that ``xdg_toplevel_configure`` events can always provide a 0×0 width/height to signal that the compositor doesn't care. SDL previously assumed the provided width/height was always valid for fullscreen windows, and so applied it as-is.

This broke SDL applications on KDE/KWin 5.23, which now sends 0×0 configure events (and, in 5.23.3, 1×1 events for some reason), breaking all SDL applications in fullscreen[2], when ``SDL_VIDEODRIVER=wayland``

See also the mention of the 1×1 window issue in https://github.com/libsdl-org/SDL/pull/4306#issuecomment-976272935

[1]: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/issues/6
[2]: https://bugs.kde.org/show_bug.cgi?id=444962#c6
