### PR TITLE
cocoa: Don't round scroll deltas from trackpads

### DIFF
--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -473,15 +473,19 @@ Cocoa_HandleMouseWheel(SDL_Window *window, NSEvent *event)
         }
     }
 
-    if (x > 0) {
-        x = SDL_ceil(x);
-    } else if (x < 0) {
-        x = SDL_floor(x);
-    }
-    if (y > 0) {
-        y = SDL_ceil(y);
-    } else if (y < 0) {
-        y = SDL_floor(y);
+    /* For discrete scroll events from conventional mice, always send a full tick.
+       For continuous scroll events from trackpads, send fractional deltas for smoother scrolling. */
+    if (![event respondsToSelector:@selector(hasPreciseScrollingDeltas)] || ![event hasPreciseScrollingDeltas]) {
+        if (x > 0) {
+            x = SDL_ceil(x);
+        } else if (x < 0) {
+            x = SDL_floor(x);
+        }
+        if (y > 0) {
+            y = SDL_ceil(y);
+        } else if (y < 0) {
+            y = SDL_floor(y);
+        }
     }
 
     SDL_SendMouseWheel(window, mouseID, x, y, direction);


### PR DESCRIPTION
## Description
Rounding the scroll deltas from trackpads causes jerky scrolling behavior by artificially amplifying the effects of very small scroll movements.

We should only round events from devices with discrete scroll wheels, because we know the smallest unit of movement there is a single tick.

## Future Work
The Cocoa mouse wheel code could still use some more love from someone with the time and expertise to poke around with a bunch of different input devices. I took a look at Qt, wxWidgets, GLFW, and QEMU for examples of how they were handling these scroll events and every one of them did it a little differently than the others. Some capped discrete scroll events at 1 tick, some scaled deltas by various factors determined by "feel", using `NSEvent.deltaY` vs. `NSEvent.scrollingDeltaY` vs. `NSEvent.deviceDeltaY`, etc.

WebKit might be the most promising of references since Apple themselves maintain it. They've got some pretty complex logic using private APIs like `_unacceleratedScrollingDeltaY` and reading the raw HID reports (!) in [here](https://github.com/WebKit/WebKit/blob/08823cd0dfd76df9c0cdbc08ba606fc9a9b79839/Source/WebKit/Shared/mac/WebEventFactory.mm#L368-L444).