### PR TITLE
Fix SDL2main on PSP

### DIFF
--- a/include/SDL_main.h
+++ b/include/SDL_main.h
@@ -83,6 +83,15 @@
 */
 #define SDL_MAIN_NEEDED
 
+#elif defined(__PSP__)
+/* On PSP SDL provides a main function that sets the module info,
+   activates the GPU and starts the thread required to be able to exit
+   the software.
+
+   If you provide this yourself, you may define SDL_MAIN_HANDLED
+ */
+#define SDL_MAIN_AVAILABLE
+
 #endif
 #endif /* SDL_MAIN_HANDLED */
 

--- a/src/main/psp/SDL_psp_main.c
+++ b/src/main/psp/SDL_psp_main.c
@@ -7,10 +7,7 @@
 
 #include "SDL_main.h"
 #include <pspkernel.h>
-#include <pspsdk.h>
 #include <pspthreadman.h>
-#include <stdlib.h>
-#include <stdio.h>
 
 #ifdef main
     #undef main

--- a/src/main/psp/SDL_psp_main.c
+++ b/src/main/psp/SDL_psp_main.c
@@ -7,11 +7,14 @@
 
 #include "SDL_main.h"
 #include <pspkernel.h>
-#include <pspdebug.h>
 #include <pspsdk.h>
 #include <pspthreadman.h>
 #include <stdlib.h>
 #include <stdio.h>
+
+#ifdef main
+    #undef main
+#endif
 
 /* If application's main() is redefined as SDL_main, and libSDLmain is
    linked, then this file will create the standard exit callback,
@@ -23,7 +26,7 @@
    PSP_MAIN_THREAD_STACK_SIZE, etc.
 */
 
-PSP_MODULE_INFO("SDL App", 0, 1, 1);
+PSP_MODULE_INFO("SDL App", 0, 1, 0);
 
 int sdl_psp_exit_callback(int arg1, int arg2, void *common)
 {
@@ -53,11 +56,7 @@ int sdl_psp_setup_callbacks(void)
 
 int main(int argc, char *argv[])
 {
-    pspDebugScreenInit();
     sdl_psp_setup_callbacks();
-
-    /* Register sceKernelExitGame() to be called when we exit */
-    atexit(sceKernelExitGame);
 
     SDL_SetMainReady();
 

--- a/src/main/psp/SDL_psp_main.c
+++ b/src/main/psp/SDL_psp_main.c
@@ -29,7 +29,7 @@ PSP_MAIN_THREAD_ATTR(THREAD_ATTR_VFPU | THREAD_ATTR_USER);
 
 int sdl_psp_exit_callback(int arg1, int arg2, void *common)
 {
-    exit(0);
+    sceKernelExitGame();
     return 0;
 }
 

--- a/src/main/psp/SDL_psp_main.c
+++ b/src/main/psp/SDL_psp_main.c
@@ -24,6 +24,7 @@
 */
 
 PSP_MODULE_INFO("SDL App", 0, 1, 0);
+PSP_MAIN_THREAD_ATTR(THREAD_ATTR_VFPU | THREAD_ATTR_USER);
 
 int sdl_psp_exit_callback(int arg1, int arg2, void *common)
 {

--- a/src/main/psp/SDL_psp_main.c
+++ b/src/main/psp/SDL_psp_main.c
@@ -8,6 +8,7 @@
 #include "SDL_main.h"
 #include <pspkernel.h>
 #include <pspthreadman.h>
+#include <stdlib.h>
 
 #ifdef main
     #undef main


### PR DESCRIPTION
SDL2main was not working for PSP, because it wasn't being activated and
it wasn't unsetting the main. Besides that a debug screen being started
was causing issues with joystick input and the sceKernelExitGame call
is no longer needed with the current PSPDEV SDK.