### PR TITLE
Improve PSP renderer

### DIFF
--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -659,7 +659,7 @@ PSP_QueueCopy(SDL_Renderer * renderer, SDL_RenderCommand *cmd, SDL_Texture * tex
 
         cmd->data.draw.count = count;
 
-        verts = (VertTV *) SDL_AllocateRenderVertices(renderer, count * sizeof (VertTV), 4, &cmd->data.draw.first);
+        verts = (VertTV *) SDL_AllocateRenderVertices(renderer, count * 2 * sizeof (VertTV), 4, &cmd->data.draw.first);
         if (!verts) {
             return -1;
         }
@@ -677,6 +677,7 @@ PSP_QueueCopy(SDL_Renderer * renderer, SDL_RenderCommand *cmd, SDL_Texture * tex
             verts->x = curX;
             verts->y = y;
             verts->z = 0;
+            verts++;
 
             curU += sourceWidth;
             curX += polyWidth;
@@ -686,6 +687,7 @@ PSP_QueueCopy(SDL_Renderer * renderer, SDL_RenderCommand *cmd, SDL_Texture * tex
             verts->x = curX;
             verts->y = (y + height);
             verts->z = 0;
+            verts++;
         }
     }
 


### PR DESCRIPTION
At the moment the PSP version of SDL2 has issues rendering textures bigger than 64x64. This also affects fonts used with SDL2_ttf.

This PR backports a portion of a commit made by @stdgregwar in the downstream SDL2 port for PSP which addresses these issues. It's not a complete fix for all rendering related issues, but it gets us a long way there.

Here is an example where you see the background texture and the fonts not rendering correctly:

![20211207_175932](https://user-images.githubusercontent.com/5042659/145079083-0b13dfdc-4e8f-4ff4-9f5a-bc719671a62c.jpg)

With this change the same screen looks like this:

![20211207_183626](https://user-images.githubusercontent.com/5042659/145079130-3d79a215-a030-45f7-b748-16fa4b5624c8.jpg)
