### PR TITLE
video: x11: Set XImage's byte_order field (fix #5081)

### DIFF
--- a/src/video/x11/SDL_x11framebuffer.c
+++ b/src/video/x11/SDL_x11framebuffer.c
@@ -115,6 +115,7 @@ X11_CreateWindowFramebuffer(_THIS, SDL_Window * window, Uint32 * format,
                 shmdt(shminfo->shmaddr);
             } else {
                 /* Done! */
+                data->ximage->byte_order = (SDL_BYTEORDER == SDL_BIG_ENDIAN) ? MSBFirst : LSBFirst;
                 data->use_mitshm = SDL_TRUE;
                 *pixels = shminfo->shmaddr;
                 return 0;
@@ -135,6 +136,7 @@ X11_CreateWindowFramebuffer(_THIS, SDL_Window * window, Uint32 * format,
         SDL_free(*pixels);
         return SDL_SetError("Couldn't create XImage");
     }
+    data->ximage->byte_order = (SDL_BYTEORDER == SDL_BIG_ENDIAN) ? MSBFirst : LSBFirst;
     return 0;
 }
 


### PR DESCRIPTION
If the X server's byte order is different from the client, things might display in the wrong colour.

Apparently we can just set the byte_order field to the client's byte order, and the X server will adjust everything automatically:
https://xorg.freedesktop.narkive.com/GbSD1aPq/ximage-s-byte-order-field