### PR TITLE
fix assertion failure in sndio audio caused by the recent hotplugging support

### DIFF
--- a/src/audio/sndio/SDL_sndioaudio.c
+++ b/src/audio/sndio/SDL_sndioaudio.c
@@ -350,6 +350,13 @@ SNDIO_Deinitialize(void)
     UnloadSNDIOLibrary();
 }
 
+static void
+SNDIO_DetectDevices(void)
+{
+	SDL_AddAudioDevice(SDL_FALSE, DEFAULT_OUTPUT_DEVNAME, NULL, (void *) 0x1);
+	SDL_AddAudioDevice(SDL_TRUE, DEFAULT_INPUT_DEVNAME, NULL, (void *) 0x2);
+}
+
 static int
 SNDIO_Init(SDL_AudioDriverImpl * impl)
 {
@@ -366,6 +373,7 @@ SNDIO_Init(SDL_AudioDriverImpl * impl)
     impl->CaptureFromDevice = SNDIO_CaptureFromDevice;
     impl->FlushCapture = SNDIO_FlushCapture;
     impl->Deinitialize = SNDIO_Deinitialize;
+    impl->DetectDevices = SNDIO_DetectDevices;
 
     impl->AllowsArbitraryDeviceNames = 1;
     impl->HasCaptureSupport = SDL_TRUE;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
With the 2.0.18 update on OpenBSD, the sndio audio backend runs into 2 assertion failures on start of several applications. These include ppsspp, scummvm, hashlink, teeworlds. 

```
WARN:                                                                                     
                                                                                          Assertion failure at SDL_AudioDetectDevices_Default (/usr/ports/pobj/sdl2-2.0.18/SDL2-2.0.
18/src/audio/SDL_audio.c:229), triggered 1 time:                                            'current_audio.impl.OnlyHasDefaultOutputDevice'                                         
                                                                                          Abort/Break/Retry/Ignore/AlwaysIgnore? [abriA] : A                                        
WARN:                                                                                     
                                                                                          
Assertion failure at SDL_AudioDetectDevices_Default (/usr/ports/pobj/sdl2-2.0.18/SDL2-2.0.
18/src/audio/SDL_audio.c:230), triggered 1 time:                                          
  'current_audio.impl.OnlyHasDefaultCaptureDevice || !current_audio.impl.HasCaptureSupport'                                                                                         
                                                                                          Abort/Break/Retry/Ignore/AlwaysIgnore? [abriA] : A
```

Sound still works after `A` pressed twice (only tested with output).

## Description
<!--- Describe your changes in detail -->
This diff implements the same changes as for diskaudio (see https://github.com/libsdl-org/SDL/issues/1901 and https://github.com/libsdl-org/SDL/commit/4986563d2f10185e519f6db34ecb0c4a9c81c277 and https://github.com/libsdl-org/SDL/blob/main/src/audio/disk/SDL_diskaudio.c#L173) for sndio.

Tested on OpenBSD with an update to 2.0.18 and the problem is gone, while audio output still works as expected (tested with scummvm).

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
-