### PR TITLE
GL renderer uses glDrawArrays instead of glBegin/glEnd.

### DIFF
--- a/src/render/opengl/SDL_glfuncs.h
+++ b/src/render/opengl/SDL_glfuncs.h
@@ -73,7 +73,7 @@ SDL_PROC_UNUSED(void, glColor4i, (GLint, GLint, GLint, GLint))
 SDL_PROC_UNUSED(void, glColor4iv, (const GLint *))
 SDL_PROC_UNUSED(void, glColor4s, (GLshort, GLshort, GLshort, GLshort))
 SDL_PROC_UNUSED(void, glColor4sv, (const GLshort *))
-SDL_PROC_UNUSED(void, glColor4ub,
+SDL_PROC(void, glColor4ub,
                 (GLubyte red, GLubyte green, GLubyte blue, GLubyte alpha))
 SDL_PROC_UNUSED(void, glColor4ubv, (const GLubyte * v))
 SDL_PROC_UNUSED(void, glColor4ui,
@@ -86,7 +86,7 @@ SDL_PROC_UNUSED(void, glColorMask,
                 (GLboolean red, GLboolean green, GLboolean blue,
                  GLboolean alpha))
 SDL_PROC_UNUSED(void, glColorMaterial, (GLenum face, GLenum mode))
-SDL_PROC_UNUSED(void, glColorPointer,
+SDL_PROC(void, glColorPointer,
                 (GLint size, GLenum type, GLsizei stride,
                  const GLvoid * pointer))
 SDL_PROC_UNUSED(void, glCopyPixels,
@@ -111,8 +111,8 @@ SDL_PROC(void, glDepthFunc, (GLenum func))
 SDL_PROC_UNUSED(void, glDepthMask, (GLboolean flag))
 SDL_PROC_UNUSED(void, glDepthRange, (GLclampd zNear, GLclampd zFar))
 SDL_PROC(void, glDisable, (GLenum cap))
-SDL_PROC_UNUSED(void, glDisableClientState, (GLenum array))
-SDL_PROC_UNUSED(void, glDrawArrays, (GLenum mode, GLint first, GLsizei count))
+SDL_PROC(void, glDisableClientState, (GLenum array))
+SDL_PROC(void, glDrawArrays, (GLenum mode, GLint first, GLsizei count))
 SDL_PROC_UNUSED(void, glDrawBuffer, (GLenum mode))
 SDL_PROC_UNUSED(void, glDrawElements,
                 (GLenum mode, GLsizei count, GLenum type,
@@ -125,7 +125,7 @@ SDL_PROC_UNUSED(void, glEdgeFlagPointer,
                 (GLsizei stride, const GLvoid * pointer))
 SDL_PROC_UNUSED(void, glEdgeFlagv, (const GLboolean * flag))
 SDL_PROC(void, glEnable, (GLenum cap))
-SDL_PROC_UNUSED(void, glEnableClientState, (GLenum array))
+SDL_PROC(void, glEnableClientState, (GLenum array))
 SDL_PROC(void, glEnd, (void))
 SDL_PROC_UNUSED(void, glEndList, (void))
 SDL_PROC_UNUSED(void, glEvalCoord1d, (GLdouble u))
@@ -401,7 +401,7 @@ SDL_PROC_UNUSED(void, glTexCoord4iv, (const GLint * v))
 SDL_PROC_UNUSED(void, glTexCoord4s,
                 (GLshort s, GLshort t, GLshort r, GLshort q))
 SDL_PROC_UNUSED(void, glTexCoord4sv, (const GLshort * v))
-SDL_PROC_UNUSED(void, glTexCoordPointer,
+SDL_PROC(void, glTexCoordPointer,
                 (GLint size, GLenum type, GLsizei stride,
                  const GLvoid * pointer))
 SDL_PROC(void, glTexEnvf, (GLenum target, GLenum pname, GLfloat param))
@@ -470,7 +470,7 @@ SDL_PROC_UNUSED(void, glVertex4iv, (const GLint * v))
 SDL_PROC_UNUSED(void, glVertex4s,
                 (GLshort x, GLshort y, GLshort z, GLshort w))
 SDL_PROC_UNUSED(void, glVertex4sv, (const GLshort * v))
-SDL_PROC_UNUSED(void, glVertexPointer,
+SDL_PROC(void, glVertexPointer,
                 (GLint size, GLenum type, GLsizei stride,
                  const GLvoid * pointer))
 SDL_PROC(void, glViewport, (GLint x, GLint y, GLsizei width, GLsizei height))


### PR DESCRIPTION
With this change the OpenGL renderer backend uses glDrawArrays instead of glBegin/glEnd, and its internal vertex arrays use 32 bit (8 bit per component) colors instead of 128 bit (32 bit per component) colors for improved performance and less memory usage.

## Description
This isn't very important for short draws, but ones with a lot of vertices have overhead in glBegin and with the large float color values which this change reduces. The color values were already being converted from 8 bits per component to floats before being sent to GL, so sending them natively as 8 bit per component values eliminates some conversion code without losing any precision.

Very short draws might get a little slower than before in the GL backend (because drivers tend to optimize glBegin/glEnd for those cases), but the separate draw call batching change will alleviate that.

## Existing Issue(s)
This is related to #5061 because some performance overhead was discovered via proposed changes, which this reduces somewhat. I think it also supersedes #5089.
