### PR TITLE
d3d11 renderer: reduce vertex bandwidth and calculations.

### DIFF
--- a/src/render/direct3d11/SDL_render_d3d11.c
+++ b/src/render/direct3d11/SDL_render_d3d11.c
@@ -63,8 +63,8 @@ extern ISwapChainBackgroundPanelNative * WINRT_GlobalSwapChainBackgroundPanelNat
 #define SAFE_RELEASE(X) if ((X)) { IUnknown_Release(SDL_static_cast(IUnknown*, X)); X = NULL; }
 
 
-/* !!! FIXME: vertex buffer bandwidth could be significantly lower; move color to a uniform, only use UV coords
-   !!! FIXME:  when textures are needed, and don't ever pass Z, since it's always zero. */
+/* !!! FIXME: vertex buffer bandwidth could be lower; only use UV coords when
+   !!! FIXME:  textures are needed. */
 
 /* Vertex shader, common values */
 typedef struct
@@ -76,9 +76,9 @@ typedef struct
 /* Per-vertex data */
 typedef struct
 {
-    Float3 pos;
+    Float2 pos;
     Float2 tex;
-    Float4 color;
+    SDL_Color color;
 } VertexPositionColor;
 
 /* Per-texture data */
@@ -1614,11 +1614,13 @@ static int
 D3D11_QueueDrawPoints(SDL_Renderer * renderer, SDL_RenderCommand *cmd, const SDL_FPoint * points, int count)
 {
     VertexPositionColor *verts = (VertexPositionColor *) SDL_AllocateRenderVertices(renderer, count * sizeof (VertexPositionColor), 0, &cmd->data.draw.first);
-    const float r = (float)(cmd->data.draw.r / 255.0f);
-    const float g = (float)(cmd->data.draw.g / 255.0f);
-    const float b = (float)(cmd->data.draw.b / 255.0f);
-    const float a = (float)(cmd->data.draw.a / 255.0f);
     int i;
+    const SDL_Color color = {
+        .r = cmd->data.draw.r,
+        .g = cmd->data.draw.g,
+        .b = cmd->data.draw.b,
+        .a = cmd->data.draw.a
+    };
 
     if (!verts) {
         return -1;
@@ -1629,13 +1631,9 @@ D3D11_QueueDrawPoints(SDL_Renderer * renderer, SDL_RenderCommand *cmd, const SDL
     for (i = 0; i < count; i++) {
         verts->pos.x = points[i].x + 0.5f;
         verts->pos.y = points[i].y + 0.5f;
-        verts->pos.z = 0.0f;
         verts->tex.x = 0.0f;
         verts->tex.y = 0.0f;
-        verts->color.x = r;
-        verts->color.y = g;
-        verts->color.z = b;
-        verts->color.w = a;
+        verts->color = color;
         verts++;
     }
 
@@ -1662,7 +1660,6 @@ D3D11_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Texture 
     for (i = 0; i < count; i++) {
         int j;
         float *xy_;
-        SDL_Color col_;
         if (size_indices == 4) {
             j = ((const Uint32 *)indices)[i];
         } else if (size_indices == 2) {
@@ -1674,15 +1671,10 @@ D3D11_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Texture 
         }
 
         xy_ = (float *)((char*)xy + j * xy_stride);
-        col_ = *(SDL_Color *)((char*)color + j * color_stride);
 
         verts->pos.x = xy_[0] * scale_x;
         verts->pos.y = xy_[1] * scale_y;
-        verts->pos.z = 0.0f;
-        verts->color.x = col_.r / 255.0f;
-        verts->color.y = col_.g / 255.0f;
-        verts->color.z = col_.b / 255.0f;
-        verts->color.w = col_.a / 255.0f;
+        verts->color = *(SDL_Color*)((char*)color + j * color_stride);
 
         if (texture) {
             float *uv_ = (float *)((char*)uv + j * uv_stride);

--- a/src/render/direct3d11/SDL_shaders_d3d11.c
+++ b/src/render/direct3d11/SDL_shaders_d3d11.c
@@ -1905,9 +1905,9 @@ int D3D11_CreateVertexShader(ID3D11Device1 *d3dDevice, ID3D11VertexShader **vert
     /* Declare how the input layout for SDL's vertex shader will be setup: */
     const D3D11_INPUT_ELEMENT_DESC vertexDesc[] = 
     {
-        { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-        { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-        { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 20, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+        { "POSITION", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+        { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 8, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+        { "COLOR", 0, DXGI_FORMAT_R8G8B8A8_UNORM, 0, 16, D3D11_INPUT_PER_VERTEX_DATA, 0 },
     };
     HRESULT result;
 


### PR DESCRIPTION
## Description
This changes the D3D11 renderer's common vertex struct to replace float color components with unorm8, and to eliminate an unused z position component. It makes the d3d11 backend a bit more performant and a little simpler.

## Existing Issue(s)
This is one (small) part of the cleanup mentioned in https://github.com/libsdl-org/SDL/issues/5093#issuecomment-992872412.
