### PR TITLE
Renderer backends use SDL_Color instead of int for geometry colors.

### DIFF
--- a/include/SDL_pixels.h
+++ b/include/SDL_pixels.h
@@ -301,6 +301,11 @@ typedef enum
         SDL_DEFINE_PIXELFOURCC('O', 'E', 'S', ' ')
 } SDL_PixelFormatEnum;
 
+/**
+ * The bits of this structure can be directly reinterpreted as an integer-packed
+ * color which uses the SDL_PIXELFORMAT_RGBA32 format (SDL_PIXELFORMAT_ABGR8888
+ * on little-endian systems and SDL_PIXELFORMAT_RGBA8888 on big-endian systems).
+ */
 typedef struct SDL_Color
 {
     Uint8 r;

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -545,7 +545,6 @@ QueueCmdFillRects(SDL_Renderer *renderer, const SDL_FRect * rects, const int cou
                 const int num_indices = 6 * count;
                 const int size_indices = 4;
                 int cur_indice = 0;
-                int color = (renderer->color.r << 0) | (renderer->color.g << 8) | (renderer->color.b << 16) | ((Uint32)renderer->color.a << 24);
 
                 for (i = 0; i < count; ++i) {
                     float minx, miny, maxx, maxy;
@@ -574,7 +573,7 @@ QueueCmdFillRects(SDL_Renderer *renderer, const SDL_FRect * rects, const int cou
                 }
 
                 retval = renderer->QueueGeometry(renderer, cmd, NULL,
-                        xy, xy_stride, &color, 0 /* color_stride */, NULL, 0,
+                        xy, xy_stride, &renderer->color, 0 /* color_stride */, NULL, 0,
                         num_vertices, indices, num_indices, size_indices,
                         1.0f, 1.0f);
 
@@ -640,7 +639,7 @@ QueueCmdGeometry(SDL_Renderer *renderer, SDL_Texture *texture,
     if (cmd != NULL) {
         retval = renderer->QueueGeometry(renderer, cmd, texture,
                 xy, xy_stride,
-                (const int *)color, color_stride, uv, uv_stride,
+                color, color_stride, uv, uv_stride,
                 num_vertices, indices, num_indices, size_indices,
                 scale_x, scale_y);
         if (retval < 0) {

--- a/src/render/SDL_sysrender.h
+++ b/src/render/SDL_sysrender.h
@@ -130,7 +130,7 @@ struct SDL_Renderer
                         const SDL_Rect * srcquad, const SDL_FRect * dstrect,
                         const double angle, const SDL_FPoint *center, const SDL_RendererFlip flip);
     int (*QueueGeometry) (SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Texture *texture,
-                          const float *xy, int xy_stride, const int *color, int color_stride, const float *uv, int uv_stride,
+                          const float *xy, int xy_stride, const SDL_Color *color, int color_stride, const float *uv, int uv_stride,
                           int num_vertices, const void *indices, int num_indices, int size_indices,
                           float scale_x, float scale_y);
 

--- a/src/render/direct3d/SDL_render_d3d.c
+++ b/src/render/direct3d/SDL_render_d3d.c
@@ -833,7 +833,7 @@ D3D_QueueDrawPoints(SDL_Renderer * renderer, SDL_RenderCommand *cmd, const SDL_F
 
 static int
 D3D_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Texture *texture,
-        const float *xy, int xy_stride, const int *color, int color_stride, const float *uv, int uv_stride,
+        const float *xy, int xy_stride, const SDL_Color *color, int color_stride, const float *uv, int uv_stride,
         int num_vertices, const void *indices, int num_indices, int size_indices,
         float scale_x, float scale_y)
 {

--- a/src/render/direct3d11/SDL_render_d3d11.c
+++ b/src/render/direct3d11/SDL_render_d3d11.c
@@ -1615,12 +1615,11 @@ D3D11_QueueDrawPoints(SDL_Renderer * renderer, SDL_RenderCommand *cmd, const SDL
 {
     VertexPositionColor *verts = (VertexPositionColor *) SDL_AllocateRenderVertices(renderer, count * sizeof (VertexPositionColor), 0, &cmd->data.draw.first);
     int i;
-    const SDL_Color color = {
-        .r = cmd->data.draw.r,
-        .g = cmd->data.draw.g,
-        .b = cmd->data.draw.b,
-        .a = cmd->data.draw.a
-    };
+    SDL_Color color;
+    color.r = cmd->data.draw.r;
+    color.g = cmd->data.draw.g;
+    color.b = cmd->data.draw.b;
+    color.a = cmd->data.draw.a;
 
     if (!verts) {
         return -1;
@@ -1642,7 +1641,7 @@ D3D11_QueueDrawPoints(SDL_Renderer * renderer, SDL_RenderCommand *cmd, const SDL
 
 static int
 D3D11_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Texture *texture,
-                    const float *xy, int xy_stride, const int *color, int color_stride, const float *uv, int uv_stride,
+                    const float *xy, int xy_stride, const SDL_Color *color, int color_stride, const float *uv, int uv_stride,
                     int num_vertices, const void *indices, int num_indices, int size_indices,
                     float scale_x, float scale_y)
 {

--- a/src/render/opengl/SDL_render_gl.c
+++ b/src/render/opengl/SDL_render_gl.c
@@ -981,7 +981,7 @@ GL_QueueDrawLines(SDL_Renderer * renderer, SDL_RenderCommand *cmd, const SDL_FPo
 
 static int
 GL_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Texture *texture,
-        const float *xy, int xy_stride, const int *color, int color_stride, const float *uv, int uv_stride,
+        const float *xy, int xy_stride, const SDL_Color *color, int color_stride, const float *uv, int uv_stride,
         int num_vertices, const void *indices, int num_indices, int size_indices,
         float scale_x, float scale_y)
 {

--- a/src/render/opengles/SDL_render_gles.c
+++ b/src/render/opengles/SDL_render_gles.c
@@ -603,7 +603,7 @@ GLES_QueueDrawLines(SDL_Renderer * renderer, SDL_RenderCommand *cmd, const SDL_F
 
 static int
 GLES_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Texture *texture,
-        const float *xy, int xy_stride, const int *color, int color_stride, const float *uv, int uv_stride,
+        const float *xy, int xy_stride, const SDL_Color *color, int color_stride, const float *uv, int uv_stride,
         int num_vertices, const void *indices, int num_indices, int size_indices,
         float scale_x, float scale_y)
 {

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -112,16 +112,16 @@ typedef struct
 
 typedef struct
 {
-    int     col;
-    float   x, y, z;
+    SDL_Color col;
+    float     x, y, z;
 } VertCV;
 
 
 typedef struct
 {
-    float   u, v;
-    int     col;
-    float   x, y, z;
+    float     u, v;
+    SDL_Color col;
+    float     x, y, z;
 } VertTCV;
 
 #define PI   3.14159265358979f
@@ -492,7 +492,7 @@ PSP_QueueDrawPoints(SDL_Renderer * renderer, SDL_RenderCommand *cmd, const SDL_F
 
 static int
 PSP_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Texture *texture,
-        const float *xy, int xy_stride, const int *color, int color_stride, const float *uv, int uv_stride,
+        const float *xy, int xy_stride, const SDL_Color *color, int color_stride, const float *uv, int uv_stride,
         int num_vertices, const void *indices, int num_indices, int size_indices,
         float scale_x, float scale_y)
 {
@@ -512,7 +512,7 @@ PSP_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Texture *t
         for (i = 0; i < count; i++) {
             int j;
             float *xy_;
-            int col_;
+            SDL_Color col_;
             if (size_indices == 4) {
                 j = ((const Uint32 *)indices)[i];
             } else if (size_indices == 2) {
@@ -524,7 +524,7 @@ PSP_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Texture *t
             }
 
             xy_ = (float *)((char*)xy + j * xy_stride);
-            col_ = *(int *)((char*)color + j * color_stride);
+            col_ = *(SDL_Color *)((char*)color + j * color_stride);
 
             verts->x = xy_[0] * scale_x;
             verts->y = xy_[1] * scale_y;
@@ -545,7 +545,7 @@ PSP_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Texture *t
         for (i = 0; i < count; i++) {
             int j;
             float *xy_;
-            int col_;
+            SDL_Color col_;
             float *uv_;
 
             if (size_indices == 4) {
@@ -559,7 +559,7 @@ PSP_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Texture *t
             }
 
             xy_ = (float *)((char*)xy + j * xy_stride);
-            col_ = *(int *)((char*)color + j * color_stride);
+            col_ = *(SDL_Color *)((char*)color + j * color_stride);
             uv_ = (float *)((char*)uv + j * uv_stride);
 
             verts->x = xy_[0] * scale_x;

--- a/src/render/software/SDL_render_sw.c
+++ b/src/render/software/SDL_render_sw.c
@@ -545,7 +545,7 @@ typedef struct GeometryCopyData
 
 static int
 SW_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Texture *texture,
-        const float *xy, int xy_stride, const int *color, int color_stride, const float *uv, int uv_stride,
+        const float *xy, int xy_stride, const SDL_Color *color, int color_stride, const float *uv, int uv_stride,
         int num_vertices, const void *indices, int num_indices, int size_indices,
         float scale_x, float scale_y)
 {

--- a/src/render/vitagxm/SDL_render_vita_gxm.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm.c
@@ -83,7 +83,7 @@ static int VITA_GXM_QueueDrawLines(SDL_Renderer * renderer, SDL_RenderCommand *c
 
 static int
 VITA_GXM_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Texture *texture,
-        const float *xy, int xy_stride, const int *color, int color_stride, const float *uv, int uv_stride,
+        const float *xy, int xy_stride, const SDL_Color *color, int color_stride, const float *uv, int uv_stride,
         int num_vertices, const void *indices, int num_indices, int size_indices,
         float scale_x, float scale_y);
 
@@ -442,11 +442,10 @@ VITA_GXM_QueueSetDrawColor(SDL_Renderer * renderer, SDL_RenderCommand *cmd)
 {
     VITA_GXM_RenderData *data = (VITA_GXM_RenderData *) renderer->driverdata;
 
-    const Uint8 r = cmd->data.color.r;
-    const Uint8 g = cmd->data.color.g;
-    const Uint8 b = cmd->data.color.b;
-    const Uint8 a = cmd->data.color.a;
-    data->drawstate.color = (((Uint32)a << 24) | (b << 16) | (g << 8) | r);
+    data->drawstate.color.r = cmd->data.color.r;
+    data->drawstate.color.g = cmd->data.color.g;
+    data->drawstate.color.b = cmd->data.color.b;
+    data->drawstate.color.a = cmd->data.color.a;
 
     return 0;
 }
@@ -456,7 +455,7 @@ VITA_GXM_QueueDrawPoints(SDL_Renderer * renderer, SDL_RenderCommand *cmd, const 
 {
     VITA_GXM_RenderData *data = (VITA_GXM_RenderData *) renderer->driverdata;
 
-    int color = data->drawstate.color;
+    SDL_Color color = data->drawstate.color;
 
     color_vertex *vertex = (color_vertex *)pool_malloc(
         data,
@@ -480,7 +479,7 @@ static int
 VITA_GXM_QueueDrawLines(SDL_Renderer * renderer, SDL_RenderCommand *cmd, const SDL_FPoint * points, int count)
 {
     VITA_GXM_RenderData *data = (VITA_GXM_RenderData *) renderer->driverdata;
-    int color = data->drawstate.color;
+    SDL_Color color = data->drawstate.color;
 
     color_vertex *vertex = (color_vertex *)pool_malloc(
         data,
@@ -506,7 +505,7 @@ VITA_GXM_QueueDrawLines(SDL_Renderer * renderer, SDL_RenderCommand *cmd, const S
 
 static int
 VITA_GXM_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Texture *texture,
-        const float *xy, int xy_stride, const int *color, int color_stride, const float *uv, int uv_stride,
+        const float *xy, int xy_stride, const SDL_Color *color, int color_stride, const float *uv, int uv_stride,
         int num_vertices, const void *indices, int num_indices, int size_indices,
         float scale_x, float scale_y)
 {
@@ -533,7 +532,7 @@ VITA_GXM_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Textu
             int j;
             float *xy_;
             float *uv_;
-            int col_;
+            SDL_Color col_;
             if (size_indices == 4) {
                 j = ((const Uint32 *)indices)[i];
             } else if (size_indices == 2) {
@@ -545,7 +544,7 @@ VITA_GXM_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Textu
             }
 
             xy_ = (float *)((char*)xy + j * xy_stride);
-            col_ = *(int *)((char*)color + j * color_stride);
+            col_ = *(SDL_Color *)((char*)color + j * color_stride);
             uv_ = (float *)((char*)uv + j * uv_stride);
 
             vertices[i].x = xy_[0] * scale_x;
@@ -572,7 +571,7 @@ VITA_GXM_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Textu
         for (i = 0; i < count; i++) {
             int j;
             float *xy_;
-            int col_;
+            SDL_Color col_;
             if (size_indices == 4) {
                 j = ((const Uint32 *)indices)[i];
             } else if (size_indices == 2) {
@@ -584,7 +583,7 @@ VITA_GXM_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Textu
             }
 
             xy_ = (float *)((char*)xy + j * xy_stride);
-            col_ = *(int *)((char*)color + j * color_stride);
+            col_ = *(SDL_Color *)((char*)color + j * color_stride);
 
             vertices[i].x = xy_[0] * scale_x;
             vertices[i].y = xy_[1] * scale_y;

--- a/src/render/vitagxm/SDL_render_vita_gxm_tools.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm_tools.c
@@ -216,19 +216,31 @@ set_stencil_mask(VITA_GXM_RenderData *data, float x, float y, float w, float h)
 
     vertices[0].x = x;
     vertices[0].y = y;
-    vertices[0].color = 0;
+    vertices[0].color.r = 0;
+    vertices[0].color.g = 0;
+    vertices[0].color.b = 0;
+    vertices[0].color.a = 0;
 
     vertices[1].x = x + w;
     vertices[1].y = y;
-    vertices[1].color = 0;
+    vertices[1].color.r = 0;
+    vertices[1].color.g = 0;
+    vertices[1].color.b = 0;
+    vertices[1].color.a = 0;
 
     vertices[2].x = x;
     vertices[2].y = y + h;
-    vertices[2].color = 0;
+    vertices[2].color.r = 0;
+    vertices[2].color.g = 0;
+    vertices[2].color.b = 0;
+    vertices[2].color.a = 0;
 
     vertices[3].x = x + w;
     vertices[3].y = y + h;
-    vertices[3].color = 0;
+    vertices[3].color.r = 0;
+    vertices[3].color.g = 0;
+    vertices[3].color.b = 0;
+    vertices[3].color.a = 0;
 
     data->drawstate.fragment_program = data->colorFragmentProgram;
     data->drawstate.vertex_program = data->colorVertexProgram;

--- a/src/render/vitagxm/SDL_render_vita_gxm_types.h
+++ b/src/render/vitagxm/SDL_render_vita_gxm_types.h
@@ -61,7 +61,7 @@ typedef struct clear_vertex {
 typedef struct color_vertex {
     float x;
     float y;
-    unsigned int color;
+    SDL_Color color;
 } color_vertex;
 
 typedef struct texture_vertex {
@@ -69,7 +69,7 @@ typedef struct texture_vertex {
     float y;
     float u;
     float v;
-    unsigned int color;
+    SDL_Color color;
 } texture_vertex;
 
 typedef struct gxm_texture {
@@ -100,7 +100,7 @@ typedef struct
     SDL_bool viewport_dirty;
     SDL_Texture *texture;
     SDL_Texture *target;
-    Uint32 color;
+    SDL_Color color;
     SceGxmFragmentProgram *fragment_program;
     SceGxmVertexProgram *vertex_program;
     int last_command;
@@ -110,7 +110,7 @@ typedef struct
     SDL_bool cliprect_dirty;
     SDL_Rect cliprect;
     SDL_bool texturing;
-    Uint32 clear_color;
+    SDL_Color clear_color;
     int drawablew;
     int drawableh;
 } gxm_drawstate_cache;

--- a/src/video/directfb/SDL_DirectFB_render.c
+++ b/src/video/directfb/SDL_DirectFB_render.c
@@ -633,7 +633,7 @@ DirectFB_QueueDrawPoints(SDL_Renderer * renderer, SDL_RenderCommand *cmd, const 
 
 static int
 DirectFB_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_Texture *texture,
-        const float *xy, int xy_stride, const int *color, int color_stride, const float *uv, int uv_stride,
+        const float *xy, int xy_stride, const SDL_Color *color, int color_stride, const float *uv, int uv_stride,
         int num_vertices, const void *indices, int num_indices, int size_indices,
         float scale_x, float scale_y)
 {


### PR DESCRIPTION
## Description
This changes SDL_Render backend code to match the higher level SDL_RenderGeometry/QueueGeometry code's use of `SDL_Color *` instead of `int *`.

## Existing Issue(s)
#5093 and #5087 deal with this topic.
