### PR TITLE
Fix PSP texure artifacts

### DIFF
--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -259,6 +259,7 @@ TextureSwizzle(PSP_TextureData *psp_texture)
     psp_texture->data = data;
     psp_texture->swizzled = SDL_TRUE;
 
+    sceKernelDcacheWritebackRange(psp_texture->data, psp_texture->size);
     return 1;
 }
 int TextureUnswizzle(PSP_TextureData *psp_texture)
@@ -290,8 +291,6 @@ int TextureUnswizzle(PSP_TextureData *psp_texture)
 
     if(!data)
         return 0;
-
-    sceKernelDcacheWritebackAll();
 
     ydst = (unsigned char *)data;
 
@@ -326,6 +325,7 @@ int TextureUnswizzle(PSP_TextureData *psp_texture)
 
     psp_texture->swizzled = SDL_FALSE;
 
+    sceKernelDcacheWritebackRange(psp_texture->data, psp_texture->size);
     return 1;
 }
 


### PR DESCRIPTION
At the moment artifacts are visible on textures after they have just been changed on the PSP. This persist for a few frames. This PR fixes that.

## Description
Before this fix:

![before](https://user-images.githubusercontent.com/5042659/146283957-523a30a0-3eee-4cdc-9ebd-31ec55ee8191.png)

After this fix:

![after](https://user-images.githubusercontent.com/5042659/146283940-bb3261c8-3228-4bbc-a0df-dd7486da9214.png)

The image below is what this example should look like. It's a simple test to see if SDL can scale images or show parts of them on the PSP. That's why it looks a bit weird.
