### PR TITLE
GLES2 cast with SDL_Vertex and SDL_VertexSolid

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -3585,11 +3585,11 @@ SDL_RenderGeometry(SDL_Renderer *renderer,
                                const int *indices, int num_indices)
 {
     if (vertices) {
-        const float *xy = &vertices->position;
+        const float *xy = &vertices->position.x;
         int xy_stride = sizeof (SDL_Vertex);
         const SDL_Color *color = &vertices->color;
         int color_stride = sizeof (SDL_Vertex);
-        const float *uv = &vertices->tex_coord;
+        const float *uv = &vertices->tex_coord.x;
         int uv_stride = sizeof (SDL_Vertex);
         int size_indices = 4;
         return SDL_RenderGeometryRaw(renderer, texture, xy, xy_stride, color, color_stride, uv, uv_stride, num_vertices, indices, num_indices, size_indices);

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -3585,11 +3585,11 @@ SDL_RenderGeometry(SDL_Renderer *renderer,
                                const int *indices, int num_indices)
 {
     if (vertices) {
-        const float *xy = &vertices[0].position.x;
+        const float *xy = &vertices->position;
         int xy_stride = sizeof (SDL_Vertex);
-        const SDL_Color *color = &vertices[0].color;
+        const SDL_Color *color = &vertices->color;
         int color_stride = sizeof (SDL_Vertex);
-        const float *uv = &vertices[0].tex_coord.x;
+        const float *uv = &vertices->tex_coord;
         int uv_stride = sizeof (SDL_Vertex);
         int size_indices = 4;
         return SDL_RenderGeometryRaw(renderer, texture, xy, xy_stride, color, color_stride, uv, uv_stride, num_vertices, indices, num_indices, size_indices);

--- a/src/render/SDL_sysrender.h
+++ b/src/render/SDL_sysrender.h
@@ -107,6 +107,13 @@ typedef struct SDL_RenderCommand
 } SDL_RenderCommand;
 
 
+typedef struct SDL_VertexSolid
+{
+    SDL_FPoint position;
+    SDL_Color  color;
+} SDL_VertexSolid;
+
+
 /* Define the SDL renderer structure */
 struct SDL_Renderer
 {


### PR DESCRIPTION
Stride computation and Queuing data are cleaner

This avoid doing `*((SDL_Color *)verts++) = col_;` which triggers an aliasing warning 