### PR TITLE
[PSP] Fix wrong value for thread priorities following official PSP Docs

### DIFF
--- a/src/thread/psp/SDL_systhread.c
+++ b/src/thread/psp/SDL_systhread.c
@@ -95,13 +95,13 @@ int SDL_SYS_SetThreadPriority(SDL_ThreadPriority priority)
     int value;
 
     if (priority == SDL_THREAD_PRIORITY_LOW) {
-        value = 19;
+        value = 111;
     } else if (priority == SDL_THREAD_PRIORITY_HIGH) {
-        value = -10;
+        value = 32;
     } else if (priority == SDL_THREAD_PRIORITY_TIME_CRITICAL) {
-        value = -20;
+        value = 16;
     } else {
-        value = 0;
+        value = 50;
     }
 
     return sceKernelChangeThreadPriority(sceKernelGetThreadId(),value);


### PR DESCRIPTION
## Description
This PR fixes wrong values in the thread priorities for `PSP`
