### PR TITLE
Add SDL_HINT_DIRECTINPUT_ENABLED

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -2001,6 +2001,15 @@ extern "C" {
  */
 #define SDL_HINT_XINPUT_ENABLED "SDL_XINPUT_ENABLED"
 
+ /**
+  *  \brief  A variable that lets you disable the detection and use of DirectInput gamepad devices
+  *
+  *  The variable can be set to the following values:
+  *    "0"       - Disable DirectInput detection (only uses XInput)
+  *    "1"       - Enable DirectInput detection (the default)
+  */
+#define SDL_HINT_DIRECTINPUT_ENABLED "SDL_DIRECTINPUT_ENABLED"
+
 /**
  *  \brief  A variable that causes SDL to use the old axis and button mapping for XInput devices.
  *

--- a/src/haptic/windows/SDL_dinputhaptic.c
+++ b/src/haptic/windows/SDL_dinputhaptic.c
@@ -27,6 +27,7 @@
 
 #if SDL_HAPTIC_DINPUT
 
+#include "SDL_hints.h"
 #include "SDL_stdinc.h"
 #include "SDL_timer.h"
 #include "SDL_windowshaptic_c.h"
@@ -75,6 +76,11 @@ SDL_DINPUT_HapticInit(void)
 
     if (dinput != NULL) {       /* Already open. */
         return SDL_SetError("Haptic: SubSystem already open.");
+    }
+
+    if (!SDL_GetHintBoolean(SDL_HINT_DIRECTINPUT_ENABLED, SDL_TRUE)) {
+        /* In some environments, IDirectInput8_Initialize / _EnumDevices can take a minute even with no controllers. */
+        return 0;
     }
 
     ret = WIN_CoInitialize();

--- a/src/joystick/windows/SDL_dinputjoystick.c
+++ b/src/joystick/windows/SDL_dinputjoystick.c
@@ -24,6 +24,7 @@
 
 #if SDL_JOYSTICK_DINPUT
 
+#include "SDL_hints.h"
 #include "SDL_windowsjoystick_c.h"
 #include "SDL_dinputjoystick_c.h"
 #include "SDL_rawinputjoystick_c.h"
@@ -397,6 +398,12 @@ SDL_DINPUT_JoystickInit(void)
     HRESULT result;
     HINSTANCE instance;
 
+    if (!SDL_GetHintBoolean(SDL_HINT_DIRECTINPUT_ENABLED, SDL_TRUE)) {
+        /* In some environments, IDirectInput8_Initialize / _EnumDevices can take a minute even with no controllers. */
+        dinput = NULL;
+        return 0;
+    }
+
     result = WIN_CoInitialize();
     if (FAILED(result)) {
         return SetDIerror("CoInitialize", result);
@@ -539,6 +546,10 @@ err:
 void
 SDL_DINPUT_JoystickDetect(JoyStick_DeviceData **pContext)
 {
+    if (dinput == NULL) {
+        return;
+    }
+
     IDirectInput8_EnumDevices(dinput, DI8DEVCLASS_GAMECTRL, EnumJoystickDetectCallback, pContext, DIEDFL_ATTACHEDONLY);
 }
 


### PR DESCRIPTION
It's what it says on the tin: Add `SDL_HINT_DIRECTINPUT_ENABLED`, which behaves like `SDL_HINT_XINPUT_ENABLED` but for DirectInput / DInput.

I've tried to stay close to the existing checking behavior in the XInput implementation, but checking against `dinput != NULL` instead of a new bool variable. This also matches existing parts of the DirectInput haptic implementation.

As to why I'm submitting this PR: In some environments, `IDirectInput8_Initialize` / `_EnumDevices` can take a minute even with no controllers plugged in. It's suspected that this might be caused by faulty drivers, but given how it's easier to live with XInput only, than to deal with wontfix user reports about buggy drivers, I've bit the bullet and am now submitting this PR.  
It's already possible to compile SDL2 without DirectInput, but turning this into a hint such as the existing XInput hint lowers the barrier of entry, especially in situations where a game framework might already be bundling prebuilt dependencies.

I've tested my changes using testjoystick and everything seems to be working fine for me. I'd be happy about any additional eyes glancing over / testing this though, and hope that I haven't missed adding any `dinput != NULL` checks anywhere important.

## Existing Issue(s)
The only other reported instance of DirectInput hanging that I was able to find was this: https://github.com/ppy/SDL2-CS/issues/44
