### PR TITLE
Improve rendering on PSP

### DIFF
--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -1108,7 +1108,6 @@ PSP_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *verti
 
             case SDL_RENDERCMD_SETVIEWPORT: {
                 SDL_Rect *viewport = &cmd->data.viewport.rect;
-                /* Viewport */
                 sceGuOffset(2048 - (viewport->w >> 1), 2048 - (viewport->h >> 1));
                 sceGuViewport(2048, 2048, viewport->w, viewport->h);
                 sceGuScissor(viewport->x, viewport->y, viewport->w, viewport->h);
@@ -1117,7 +1116,6 @@ PSP_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *verti
 
             case SDL_RENDERCMD_SETCLIPRECT: {
                 const SDL_Rect *rect = &cmd->data.cliprect.rect;
-                /* Scissoring */
                 if(cmd->data.cliprect.enabled){
                     sceGuEnable(GU_SCISSOR_TEST);
                     sceGuScissor(rect->x, rect->y, rect->w, rect->h);
@@ -1382,7 +1380,7 @@ PSP_CreateRenderer(SDL_Window * window, Uint32 flags)
     renderer->info.flags = (SDL_RENDERER_ACCELERATED | SDL_RENDERER_TARGETTEXTURE);
     renderer->driverdata = data;
     renderer->window = window;
-    
+
     if (data->initialized != SDL_FALSE)
         return 0;
     data->initialized = SDL_TRUE;
@@ -1402,14 +1400,10 @@ PSP_CreateRenderer(SDL_Window * window, Uint32 flags)
         case GU_PSM_4444:
         case GU_PSM_5650:
         case GU_PSM_5551:
-            //data->frontbuffer = (unsigned int *)(PSP_FRAME_BUFFER_SIZE<<1);
-            //data->backbuffer =  (unsigned int *)(0);
             data->bpp = 2;
             data->psm = pixelformat;
             break;
         default:
-            //data->frontbuffer = (unsigned int *)(PSP_FRAME_BUFFER_SIZE<<2);
-            //data->backbuffer =  (unsigned int *)(0);
             data->bpp = 4;
             data->psm = GU_PSM_8888;
             break;

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -56,6 +56,12 @@ static unsigned int __attribute__((aligned(16))) DisplayList[262144];
 #define COL4444(r,g,b,a)    ((r>>4) | ((g>>4)<<4) | ((b>>4)<<8) | ((a>>4)<<12))
 #define COL8888(r,g,b,a)    ((r) | ((g)<<8) | ((b)<<16) | ((a)<<24))
 
+//#define LOGGING
+#ifdef LOGGING
+#define LOG(...) printf(__VA_ARGS__)
+#else
+#define LOG(...)
+#endif
 /**
  * Holds psp specific texture data
  *
@@ -220,37 +226,31 @@ LRUTargetRelink(PSP_TextureData* psp_texture) {
     }
 }
 
-static void
+/*static void
 LRUTargetFixTail(PSP_RenderData* data, PSP_TextureData* psp_texture) {
     if(data->least_recent_target == psp_texture) {
         data->least_recent_target = psp_texture->prevhotw;
     } else if(!data->least_recent_target) {
         data->least_recent_target = psp_texture;
     }
-}
+}*/
 
 static void
 LRUTargetPushFront(PSP_RenderData* data, PSP_TextureData* psp_texture) {
+    LOG("Pushing %p (%dKB) front.\n", (void*)psp_texture, psp_texture->size / 1024);
     psp_texture->nexthotw = data->most_recent_target;
     if(data->most_recent_target) {
         data->most_recent_target->prevhotw = psp_texture;
     }
-    LRUTargetFixTail(data, psp_texture);
-}
-
-static void
-LRUTargetBringFront(PSP_RenderData* data, PSP_TextureData* psp_texture) {
-    if(data->most_recent_target == psp_texture) {
-        return; //nothing to do
+    data->most_recent_target = psp_texture;
+    if(!data->least_recent_target) {
+        data->least_recent_target = psp_texture;
     }
-    LRUTargetRelink(psp_texture);
-    psp_texture->prevhotw = NULL;
-    psp_texture->nexthotw = NULL;
-    LRUTargetPushFront(data, psp_texture);
 }
 
 static void
 LRUTargetRemove(PSP_RenderData* data, PSP_TextureData* psp_texture) {
+    LOG("Removing %p (%dKB).\n", (void*)psp_texture, psp_texture->size/1024);
     LRUTargetRelink(psp_texture);
     if(data->most_recent_target == psp_texture) {
         data->most_recent_target = psp_texture->nexthotw;
@@ -261,6 +261,37 @@ LRUTargetRemove(PSP_RenderData* data, PSP_TextureData* psp_texture) {
     psp_texture->prevhotw = NULL;
     psp_texture->nexthotw = NULL;
 }
+
+static void
+LRUTargetBringFront(PSP_RenderData* data, PSP_TextureData* psp_texture) {
+    LOG("Bringing %p (%dKB) front.\n", (void*)psp_texture, psp_texture->size/1024);
+    if(data->most_recent_target == psp_texture) {
+        return; //nothing to do
+    }
+    //LRUTargetRelink(psp_texture);
+    LRUTargetRemove(data, psp_texture);
+    LRUTargetPushFront(data, psp_texture);
+}
+
+#ifdef LOGGING
+static void
+LRUWalk(PSP_RenderData* data) {
+    PSP_TextureData* tex = data->most_recent_target;
+    LOG("================\nLRU STATE:\n");
+    size_t size = 0;
+    while(tex) {
+        LOG("Tex %p (%dKB)\n", (void*)tex, tex->size/1024);
+        size+= tex->size;
+        if(tex->nexthotw && tex->nexthotw->prevhotw != tex) {
+            LOG("Spurious link!\n");
+        }
+        tex = tex->nexthotw;
+    }
+    LOG("Total Size : %dKB\n", size/1024);
+    size_t latest_size = data->least_recent_target ? data->least_recent_target->size : 0;
+    LOG("Least recent %p (%dKB)\n================\n", data->least_recent_target, latest_size / 1024);
+}
+#endif
 
 static void
 TextureStorageFree(void* storage) {
@@ -436,13 +467,20 @@ TexturePromoteToVram(PSP_RenderData* data, PSP_TextureData* psp_texture, SDL_boo
 }
 
 static int
-TextureSpillLRU(PSP_RenderData* data) {
+TextureSpillLRU(PSP_RenderData* data, size_t wanted) {
     PSP_TextureData* lru = data->least_recent_target;
     if(lru) {
         if(TextureSpillToSram(data, lru) < 0) {
             return -1;
         }
+        LOG("Spilled %p (%dKB) to ram", (void*)lru, lru->size/1024);
         LRUTargetRemove(data, lru);
+        #ifdef LOGGING
+        LRUWalk(data);
+        #endif
+    } else {
+        SDL_SetError("Could not spill more VRAM to system memory. VRAM : %dKB,(%dKB), wanted %dKB", vmemavail()/1024, vlargestblock()/1024, wanted/1024);
+        return -1; //Asked to spill but there nothing to spill
     }
     return 0;
 }
@@ -451,7 +489,7 @@ static int
 TextureSpillTargetsForSpace(PSP_RenderData* data, size_t size)
 {
     while(vlargestblock() < size) {
-        if(TextureSpillLRU(data) < 0) {
+        if(TextureSpillLRU(data, size) < 0) {
             return -1;
         }
     }
@@ -470,6 +508,9 @@ TextureBindAsTarget(PSP_RenderData* data, PSP_TextureData* psp_texture) {
         }
     }
     LRUTargetBringFront(data, psp_texture);
+    #ifdef LOGGING
+    LRUWalk(data);
+    #endif
     sceGuDrawBufferList(psp_texture->format, vrelptr(psp_texture->data), psp_texture->textureWidth);
     return 0;
 }

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -56,7 +56,7 @@ static unsigned int __attribute__((aligned(16))) DisplayList[262144];
 #define COL4444(r,g,b,a)    ((r>>4) | ((g>>4)<<4) | ((b>>4)<<8) | ((a>>4)<<12))
 #define COL8888(r,g,b,a)    ((r) | ((g)<<8) | ((b)<<16) | ((a)<<24))
 
-#define LOGGING
+//#define LOGGING
 #ifdef LOGGING
 #define LOG(...) printf(__VA_ARGS__)
 #else
@@ -232,15 +232,6 @@ LRUTargetRelink(PSP_TextureData* psp_texture) {
     }
 }
 
-/*static void
-LRUTargetFixTail(PSP_RenderData* data, PSP_TextureData* psp_texture) {
-    if(data->least_recent_target == psp_texture) {
-        data->least_recent_target = psp_texture->prevhotw;
-    } else if(!data->least_recent_target) {
-        data->least_recent_target = psp_texture;
-    }
-}*/
-
 static void
 LRUTargetPushFront(PSP_RenderData* data, PSP_TextureData* psp_texture) {
     LOG("Pushing %p (%dKB) front.\n", (void*)psp_texture, psp_texture->size / 1024);
@@ -274,7 +265,6 @@ LRUTargetBringFront(PSP_RenderData* data, PSP_TextureData* psp_texture) {
     if(data->most_recent_target == psp_texture) {
         return; //nothing to do
     }
-    //LRUTargetRelink(psp_texture);
     LRUTargetRemove(data, psp_texture);
     LRUTargetPushFront(data, psp_texture);
 }
@@ -1016,7 +1006,7 @@ StartDrawing(SDL_Renderer * renderer)
     if(!data->displayListAvail) {
         sceGuStart(GU_DIRECT, DisplayList);
         data->displayListAvail = SDL_TRUE;
-        ResetBlendState(&data->blendState);
+        //ResetBlendState(&data->blendState);
     }
 
     // Check if we need a draw buffer change
@@ -1427,7 +1417,6 @@ PSP_CreateRenderer(SDL_Window * window, Uint32 flags)
     doublebuffer = valloc(PSP_FRAME_BUFFER_SIZE*data->bpp*2);
     data->backbuffer = doublebuffer;
     data->frontbuffer = ((uint8_t*)doublebuffer)+PSP_FRAME_BUFFER_SIZE*data->bpp;
-    memset(&data->blendState, 0, sizeof(PSP_BlendState));
 
     sceGuInit();
     /* setup GU */
@@ -1453,16 +1442,8 @@ PSP_CreateRenderer(SDL_Window * window, Uint32 flags)
     sceGuEnable(GU_CULL_FACE);
     */
 
-    /* Texturing */
-    sceGuEnable(GU_TEXTURE_2D);
-    sceGuShadeModel(GU_SMOOTH);
-    sceGuTexWrap(GU_REPEAT, GU_REPEAT);
-
-    /* Blending */
-    //sceGuEnable(GU_BLEND);
-    //sceGuBlendFunc(GU_ADD, GU_SRC_ALPHA, GU_ONE_MINUS_SRC_ALPHA, 0, 0);
-
-    sceGuTexFilter(GU_LINEAR,GU_LINEAR);
+    //Setup initial blend state
+    ResetBlendState(&data->blendState);
 
     sceGuFinish();
     sceGuSync(0,0);

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -1201,10 +1201,18 @@ PSP_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *verti
                     sceGuEnable(GU_TEXTURE_2D);
                 } else {
                     const VertTCV *verts = (VertTCV *) (gpumem + cmd->data.draw.first);
+                    const Uint8 a = cmd->data.draw.a;
+                    const Uint8 r = cmd->data.draw.r;
+                    const Uint8 g = cmd->data.draw.g;
+                    const Uint8 b = cmd->data.draw.b;
+                    PSP_BlendState state = {
+                        .color = GU_RGBA(r,g,b,a),
+                        .texture = NULL,
+                        .mode = cmd->data.draw.blend,
+                        .shadeModel = GU_FLAT
+                    };
                     TextureActivate(cmd->data.draw.texture);
-                    /* Need to force refresh of blending mode, probably something to FIXME */
-                    PSP_SetBlendMode(renderer, SDL_BLENDMODE_INVALID);
-                    PSP_SetBlendMode(renderer, cmd->data.draw.blend);
+                    PSP_SetBlendState(renderer, &state);
                     sceGuDrawArray(GU_TRIANGLES, GU_TEXTURE_32BITF|GU_COLOR_8888|GU_VERTEX_32BITF|GU_TRANSFORM_2D, count, 0, verts);
                 }
                 break;

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -534,7 +534,7 @@ PSP_CreateTexture(SDL_Renderer * renderer, SDL_Texture * texture)
     PSP_TextureData* psp_texture = (PSP_TextureData*) SDL_calloc(1, sizeof(*psp_texture));
 
     if(!psp_texture)
-        return -1;
+        return SDL_OutOfMemory();
 
     psp_texture->swizzled = SDL_FALSE;
     psp_texture->width = texture->w;
@@ -1295,6 +1295,7 @@ PSP_DestroyTexture(SDL_Renderer * renderer, SDL_Texture * texture)
     if(psp_texture == 0)
         return;
 
+    LRUTargetRemove(renderdata, psp_texture);
     TextureStorageFree(psp_texture->data);
     SDL_free(psp_texture);
     texture->driverdata = NULL;

--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -173,7 +173,7 @@ PSP_VideoInit(_THIS)
     display.current_mode = current_mode;
     SDL_AddDisplayMode(&display, &current_mode);
 
-    SDL_AddVideoDisplay(&display);
+    SDL_AddVideoDisplay(&display, SDL_FALSE);
     return 1;
 }
 

--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -158,7 +158,6 @@ PSP_VideoInit(_THIS)
     current_mode.refresh_rate = 60;
     /* 32 bpp for default */
     current_mode.format = SDL_PIXELFORMAT_ABGR8888;
-
     current_mode.driverdata = NULL;
 
     SDL_zero(display);
@@ -166,8 +165,15 @@ PSP_VideoInit(_THIS)
     display.current_mode = current_mode;
     display.driverdata = NULL;
 
-    SDL_AddVideoDisplay(&display, SDL_FALSE);
+    SDL_AddDisplayMode(&display, &current_mode);
 
+    /* 16 bpp secondary mode */
+    current_mode.format = SDL_PIXELFORMAT_BGR565;
+    display.desktop_mode = current_mode;
+    display.current_mode = current_mode;
+    SDL_AddDisplayMode(&display, &current_mode);
+
+    SDL_AddVideoDisplay(&display);
     return 1;
 }
 


### PR DESCRIPTION
Add support for the following features in the PSP port:
- Rendering to a target texture
- Storing render target in system memory if there is not enough space in vram
- 16 bit color mode
- Color and alpha modulation

## Description
This cherry picks all the commit from a PR in the downstream PSP SDL2 port which were not yet upstreamed: https://github.com/joel16/SDL2/pull/5

I also made sure to clean it up a little bit, make it work with cmake and tested it.

It still has some issues when rendering to a texture. There is some minor artifacting found when rendering to a texture if the texture is deleted before the screen is refreshed and rendering to texture is still a bit slow, but I do think it's worth merging. Without these changes trying to render to a texture results in a black screen. We are still looking into improvements for which we will make PRs in the coming days.

Thanks @stdgregwar for his work on this.

This PR should bring upstream to the point where the downstream port is no longer needed.