### PR TITLE
macOS: Calculate correct DPI by not using backingScaleFactor

### DIFF
--- a/src/video/cocoa/SDL_cocoamodes.m
+++ b/src/video/cocoa/SDL_cocoamodes.m
@@ -454,28 +454,70 @@ Cocoa_GetDisplayDPI(_THIS, SDL_VideoDisplay * display, float * ddpi, float * hdp
     /* we need the backingScaleFactor for Retina displays, which is only exposed through NSScreen, not CGDisplay, afaik, so find our screen... */
     CGFloat scaleFactor = 1.0f;
     NSArray *screens = [NSScreen screens];
+    NSSize displayNativeSize;
+    displayNativeSize.width = (int) CGDisplayPixelsWide(data->display);
+    displayNativeSize.height = (int) CGDisplayPixelsHigh(data->display);
+    
     for (NSScreen *screen in screens) {
         const CGDirectDisplayID dpyid = (const CGDirectDisplayID ) [[[screen deviceDescription] objectForKey:@"NSScreenNumber"] unsignedIntValue];
         if (dpyid == data->display) {
-            if ([screen respondsToSelector:@selector(backingScaleFactor)]) {  // Mac OS X 10.7 and later
+        
+            /* Neither CGDisplayScreenSize(description's NSScreenNumber) nor [NSScreen backingScaleFactor] can calculate the correct dpi in macOS. E.g. backingScaleFactor is always 2 in all display modes for rMBP 16" */
+            if (@available(macOS 10.8, *)) {
+                CFStringRef dmKeys[1] = { kCGDisplayShowDuplicateLowResolutionModes };
+                CFBooleanRef dmValues[1] = { kCFBooleanTrue };
+                CFDictionaryRef dmOptions = CFDictionaryCreate(kCFAllocatorDefault, (const void**) dmKeys, (const void**) dmValues, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks );
+                CFArrayRef allDisplayModes = CGDisplayCopyAllDisplayModes(dpyid, dmOptions);
+                CFIndex n = CFArrayGetCount(allDisplayModes);
+                for(CFIndex i = 0; i < n; ++i) {
+                    CGDisplayModeRef m = (CGDisplayModeRef)CFArrayGetValueAtIndex(allDisplayModes, i);
+                    CGFloat width = CGDisplayModeGetPixelWidth(m);
+                    CGFloat height = CGDisplayModeGetPixelHeight(m);
+                    CGFloat HiDPIWidth = CGDisplayModeGetWidth(m);
+                    
+                    BOOL isNative = (CGDisplayModeGetIOFlags(m) & kDisplayModeNativeFlag) ? true : false;
+                    CFRelease(m);
+                    
+                    //Only check 1x mode
+                    if(width == HiDPIWidth) {
+                        if(isNative) {
+                            displayNativeSize.width = width;
+                            displayNativeSize.height = height;
+                            break;
+                        }
+                        
+                        //Get the largest size even if kDisplayModeNativeFlag is not present e.g. iMac 27-Inch with 5K Retina
+                        if(width > displayNativeSize.width) {
+                            displayNativeSize.width = width;
+                            displayNativeSize.height = height;
+                        }
+                    }
+                }
+                CFRelease(allDisplayModes);
+                CFRelease(dmOptions);
+            } else if (@available(macOS 10.7, *)) {
+                // fallback for 10.7
                 scaleFactor = [screen backingScaleFactor];
+                displayNativeSize.width = displayNativeSize.width * scaleFactor;
+                displayNativeSize.height = displayNativeSize.height * scaleFactor;
                 break;
             }
+            
         }
     }
 
     const CGSize displaySize = CGDisplayScreenSize(data->display);
-    const int pixelWidth =  (int) CGDisplayPixelsWide(data->display);
-    const int pixelHeight = (int) CGDisplayPixelsHigh(data->display);
+    const int pixelWidth =  displayNativeSize.width;
+    const int pixelHeight = displayNativeSize.height;
 
     if (ddpi) {
-        *ddpi = (SDL_ComputeDiagonalDPI(pixelWidth, pixelHeight, displaySize.width / MM_IN_INCH, displaySize.height / MM_IN_INCH)) * scaleFactor;
+        *ddpi = (SDL_ComputeDiagonalDPI(pixelWidth, pixelHeight, displaySize.width / MM_IN_INCH, displaySize.height / MM_IN_INCH));
     }
     if (hdpi) {
-        *hdpi = (pixelWidth * MM_IN_INCH / displaySize.width) * scaleFactor;
+        *hdpi = (pixelWidth * MM_IN_INCH / displaySize.width);
     }
     if (vdpi) {
-        *vdpi = (pixelHeight * MM_IN_INCH / displaySize.height) * scaleFactor;
+        *vdpi = (pixelHeight * MM_IN_INCH / displaySize.height);
     }
 
     return 0;

--- a/src/video/cocoa/SDL_cocoamodes.m
+++ b/src/video/cocoa/SDL_cocoamodes.m
@@ -475,12 +475,9 @@ Cocoa_GetDisplayDPI(_THIS, SDL_VideoDisplay * display, float * ddpi, float * hdp
                     CGFloat height = CGDisplayModeGetPixelHeight(m);
                     CGFloat HiDPIWidth = CGDisplayModeGetWidth(m);
                     
-                    BOOL isNative = (CGDisplayModeGetIOFlags(m) & kDisplayModeNativeFlag) ? true : false;
-                    CFRelease(m);
-                    
                     //Only check 1x mode
                     if(width == HiDPIWidth) {
-                        if(isNative) {
+                        if (CGDisplayModeGetIOFlags(m) & kDisplayModeNativeFlag) {
                             displayNativeSize.width = width;
                             displayNativeSize.height = height;
                             break;


### PR DESCRIPTION
Since backingScaleFactor is "locked" to 1.0 / 2.0 / 3.0, it does not reflect the actual resolution scaling.

E.g. on Intel MBP 16", the native resolution is 3072x1920 with 226 dpi.

With the current implementation, the DPI is fluctuating:

For scaled resolution 1792x1120, SDL_GetDisplayDPI returns ddpi=264.279755

For scaled resolution 2048x1280, SDL_GetDisplayDPI returns ddpi=302.000000

For scaled resolution 3072x1920, SDL_GetDisplayDPI returns ddpi=226.279556

The proposed DPI calculation implementation was first tested in [Flycast #33](https://github.com/flyinghead/flycast/pull/33) since Jan 2020 and improved in [Flycast #181](https://github.com/flyinghead/flycast/pull/181) on Feb 2021.

Actual implementation in Flycast:
https://github.com/vkedwardli/flycast/blob/b56c5b1c51657ab7335dcef4eac523beef8da9d5/shell/apple/emulator-osx/emulator-osx/osx-main.mm#L180-L222

The idea is to just calculate DPI using `Native Resolution (px) / Physical size (mm) * 25.4f`,  instead of `HiDPI resolution * backingScaleFactor / Physical size (mm) * 25.4f`

The trick to get the native resolution is by reading all display modes (with `kCGDisplayShowDuplicateLowResolutionModes`), then find the native display mode with `kDisplayModeNativeFlag`. 

There is still a possibility when there isn't any native display mode returned by API, e.g. iMac 27-Inch with 5K Retina does not have any `kDisplayModeNativeFlag` set.
We can still use the largest resolution fetched from `CGDisplayModeGetPixelWidth` and compare it with the older `CGDisplayModeGetWidth` (when they are the same, macOS is running native @ 1x mode without retina scale)
(The method is further improved in [Flycast #234](https://github.com/flyinghead/flycast/pull/234) on May 2021)


Below are some screen captures demonstrating the wrong dpi causing the scaling cannot be sync with the system setting (Text should be smaller when "More Space" is selected, and text should be larger when "Larger Text" is selected)

![image](https://user-images.githubusercontent.com/602245/147371357-ece874a4-0ba8-4cc6-a103-f263e76097db.png)

![image](https://user-images.githubusercontent.com/602245/147371219-5a663a74-a4a6-4494-973a-defb93e2cbeb.png)

![image](https://user-images.githubusercontent.com/602245/147371260-2ab490af-a74b-46c2-8be6-f8deef7d5eee.png)

You can compare the text scaling between Finder and the 2 Flycast app
