### PR TITLE
Fix macOS cursor jumping to corner on first titlebar click

### DIFF
--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -465,6 +465,7 @@ Cocoa_UpdateClipCursor(SDL_Window * window)
     pendingWindowOperation = PENDING_OPERATION_NONE;
     isMoving = NO;
     isDragAreaRunning = NO;
+    pendingWindowWarpX = pendingWindowWarpY = INT_MAX;
 
     center = [NSNotificationCenter defaultCenter];
 


### PR DESCRIPTION
Fixes #5111 by initializing `pendingWindowWarpX`/`Y` to INT_MAX on construction.

## Description
When the titlebar is first clicked, a call tree from `Cocoa_HandleTitleButtonEvent` -> `clearFocusClickPending` -> `onMovingOrFocusClickPendingStateCleared` -> `mouse->WarpMouseGlobal(pendingWindowWarpX, pendingWindowWarpY)` is triggered.

I'm not really 100% on what the purpose of `pendingWindowWarpX`/`Y` is or if there's some deeper issue that should have prevented the `WarpMouseGlobal` call from happening in the first place, but I think it's sensible to make sure that any mouse warps have to be explicitly asked for post-construction.

## Existing Issue(s)
#5111 
