### PR TITLE
Android: fixes build NDK 21d

### DIFF
--- a/src/audio/aaudio/SDL_aaudio.h
+++ b/src/audio/aaudio/SDL_aaudio.h
@@ -24,6 +24,7 @@
 #define _SDL_aaudio_h
 
 #include "../SDL_sysaudio.h"
+#include <stdbool.h>
 #include <aaudio/AAudio.h>
 
 /* Hidden "this" pointer for the audio functions */


### PR DESCRIPTION
Adds `stdbool.h` header to prevent build error with NDK 21d.

## Description
Currently with NDK 21d I am hitting 
```
  In file included from _deps/sdl2_content-src/src/audio/aaudio/SDL_aaudio.c:29:
  In file included from _deps/sdl2_content-src/src/audio/aaudio/SDL_aaudio.h:27:
  /opt/android-sdk-linux/ndk/21.3.6528147/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/aaudio/AAudio.h:809:9: error: unknown type name 'bool'
          bool privacySensitive) __INTRODUCED_IN(30);
          ^
  /opt/android-sdk-linux/ndk/21.3.6528147/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/aaudio/AAudio.h:1527:12: error: unknown type name 'bool'
  AAUDIO_API bool AAudioStream_isPrivacySensitive(AAudioStream* stream)
```

This appears to be a bug in NDK itself. It's currently possible to workaround by adding the header here in this PR.

## Existing Issue(s)
https://github.com/android/ndk/issues/1281
