### PR TITLE
X11_WaitEventTimeout: remove unreachable return

### DIFF
--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -1602,10 +1602,6 @@ X11_WaitEventTimeout(_THIS, int timeout)
     SDL_VideoData *videodata = (SDL_VideoData *) _this->driverdata;
     Display *display;
     XEvent xevent;
-
-    if (!videodata) {
-        return 0;
-    }
     display = videodata->display;
 
     SDL_zero(xevent);


### PR DESCRIPTION
Removes a (seemingly) unreachable return path.

## Description
`_this` is the `SDL_VideoDevice`, as initialized in [`X11_CreateDevice`](https://github.com/libsdl-org/SDL/blob/d0de4c625ad26ef5401665ca26b5f2c0fb76e91b/src/video/x11/SDL_x11video.c#L152), which always initializes the `driverdata` field to non-`NULL`. It is also not reset to `NULL` in [X11_DeleteDevice](https://github.com/libsdl-org/SDL/blob/d0de4c625ad26ef5401665ca26b5f2c0fb76e91b/src/video/x11/SDL_x11video.c#L99).
Thus, this code path seems unreachable to me.

The return value in this code path is also wrong: It should be negative to indicate that waiting for the timeout failed.
Otherwise [`SDL_WaitEventTimeout`](https://github.com/libsdl-org/SDL/blob/d0de4c625ad26ef5401665ca26b5f2c0fb76e91b/src/events/SDL_events.c#L984) would incorrectly return early (instead of falling back to manual polling).

Alternatively to removal, if the defensive check is preferred, the return value should be corrected.
Similar checks are also absent from the other backends' implementations: [Wayland_WaitEventTimeout](https://github.com/libsdl-org/SDL/blob/d0de4c625ad26ef5401665ca26b5f2c0fb76e91b/src/video/wayland/SDL_waylandevents.c#L261), [WIN_WaitEventTimeout](https://github.com/libsdl-org/SDL/blob/d0de4c625ad26ef5401665ca26b5f2c0fb76e91b/src/video/windows/SDL_windowsevents.c#L1433), [Cocoa_WaitEventTimeout](https://github.com/libsdl-org/SDL/blob/d0de4c625ad26ef5401665ca26b5f2c0fb76e91b/src/video/cocoa/SDL_cocoaevents.m#L554).

All other return values in all video-`WaitEvent` implementations seemed correct to me (that is, return 0 only if waiting succeeded and < 0 if waiting failed).

## Existing Issue(s)
None that I know of.
