### PR TITLE
d3d11: Respect SDL_HINT_RENDER_DIRECT3D_THREADSAFE when creating device

### DIFF
--- a/src/render/direct3d11/SDL_render_d3d11.c
+++ b/src/render/direct3d11/SDL_render_d3d11.c
@@ -487,6 +487,11 @@ D3D11_CreateDeviceResources(SDL_Renderer * renderer)
         creationFlags |= D3D11_CREATE_DEVICE_DEBUG;
     }
 
+    /* Create a single-threaded device unless the app requests otherwise. */
+    if (!SDL_GetHintBoolean(SDL_HINT_RENDER_DIRECT3D_THREADSAFE, SDL_FALSE)) {
+        creationFlags |= D3D11_CREATE_DEVICE_SINGLETHREADED;
+    }
+
     /* Create the Direct3D 11 API device object and a corresponding context. */
     result = D3D11CreateDeviceFunc(
         data->dxgiAdapter,


### PR DESCRIPTION
## Description
The D3D9 backend uses `SDL_HINT_RENDER_DIRECT3D_THREADSAFE` to determine whether or not to set `D3DCREATE_MULTITHREADED` when creating the device. This PR applies the same logic to the D3D11 backend.