### PR TITLE
Fix crash in SDL_DINPUT_JoystickPresent()

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -56,11 +56,11 @@ static SDL_JoystickDriver *SDL_joystick_drivers[] = {
 #ifdef SDL_JOYSTICK_RAWINPUT /* Before WINDOWS_ driver, as WINDOWS wants to check if this driver is handling things */
     &SDL_RAWINPUT_JoystickDriver,
 #endif
+#if defined(SDL_JOYSTICK_DINPUT) || defined(SDL_JOYSTICK_XINPUT) /* Before WGI driver, as WGI wants to check if this driver is handling things */
+    &SDL_WINDOWS_JoystickDriver,
+#endif
 #if defined(SDL_JOYSTICK_WGI)
     &SDL_WGI_JoystickDriver,
-#endif
-#if defined(SDL_JOYSTICK_DINPUT) || defined(SDL_JOYSTICK_XINPUT)
-    &SDL_WINDOWS_JoystickDriver,
 #endif
 #if defined(SDL_JOYSTICK_WINMM)
     &SDL_WINMM_JoystickDriver,

--- a/src/joystick/windows/SDL_dinputjoystick.c
+++ b/src/joystick/windows/SDL_dinputjoystick.c
@@ -585,6 +585,10 @@ SDL_DINPUT_JoystickPresent(Uint16 vendor_id, Uint16 product_id, Uint16 version_n
 {
     Joystick_PresentData data;
 
+    if (dinput == NULL) {
+        return SDL_FALSE;
+    }
+
     data.vendor = vendor_id;
     data.product = product_id;
     data.present = SDL_FALSE;


### PR DESCRIPTION
## Description
WGI's `IEventHandler_CRawGameControllerVtbl_InvokeAdded()` callback calls `SDL_DINPUT_JoystickPresent()` but DInput is not initialized until after WGI. This leaves a window where WGI can invoke DInput while `dinput == NULL`, causing the application to crash. Fix this by initializing WGI after DInput (and the joystick core will deinitialize them in reverse order).

While I was looking at this, I also found that `dinput == NULL` could happen if `SDL_DINPUT_JoystickInit()` failed, so fix that too.

I have no idea what conditions cause this race to manifest so reliably, but it seems to happen every time for one Moonlight user.

## Existing Issue(s)
Downstream issue: https://github.com/moonlight-stream/moonlight-qt/issues/700
