### PR TITLE
Don't make eboot files for all test on psp

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -165,27 +165,34 @@ endif()
 if(PSP)
     # Build EBOOT files if building for PSP
     set(BUILD_EBOOT
-        ${NEEDS_RESOURCES}
+        testscale
+        testrendercopyex
+        controllermap
+        testyuv
+        testgamecontroller
+        testshape
+        testshader
+        testspriteminimal
+        testautomation
+        testrendertarget
+        testsprite2
+        loopwave
+        loopwavequeue
+        testresample
+        testaudiohotplug
+        testmultiaudio
         testoffscreen
-        testvulkan
         testbounds
-        testhotplug
-        testgles2
-        testhaptic
-        testrelative
         testgl2
         testsem
         testdisplayinfo
-        testgles
         teststreaming
         testgeometry
         testgesture
         testfile
-        testdropfile
         testdraw2
         testviewport
         testhittesting
-        checkkeys
         testoverlay2
         testver
         testdrawchessboard
@@ -196,19 +203,14 @@ if(PSP)
         testerror
         testatomic
         testjoystick
-        testrumble
         testiconv
         testfilesystem
         testplatform
         testthread
-        testkeys
         testloadso
-        testmouse
         testqsort
-        testime
         testaudioinfo
         testlock
-        checkkeysthreads
         testtimer
         testpower
         testwm2

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -134,37 +134,8 @@ endif()
 
 file(GLOB RESOURCE_FILES *.bmp *.wav *.hex moose.dat utf8.txt)
 file(COPY ${RESOURCE_FILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-set(NEEDS_RESOURCES
-    testscale
-    testrendercopyex
-    controllermap
-    testyuv
-    testgamecontroller
-    testshape
-    testshader
-    testspriteminimal
-    testautomation
-    testcustomcursor
-    testrendertarget
-    testsprite2
-    loopwave
-    loopwavequeue
-    testresample
-    testaudiohotplug
-    testmultiaudio
-    testime
-    testiconv
-    testoverlay2
-    teststreaming
-    testviewport
-)
-if(NOT PSP)
-    set(NEEDS_RESOURCES ${NEEDS_RESOURCES} testnative)
-endif()
-
 if(PSP)
-    # Build EBOOT files if building for PSP
-    set(BUILD_EBOOT
+    set(NEEDS_RESOURCES
         testscale
         testrendercopyex
         controllermap
@@ -181,6 +152,43 @@ if(PSP)
         testresample
         testaudiohotplug
         testmultiaudio
+        testiconv
+        testoverlay2
+        teststreaming
+        testviewport
+    )
+else()
+    set(NEEDS_RESOURCES
+        testscale
+        testrendercopyex
+        controllermap
+        testyuv
+        testgamecontroller
+        testshape
+        testshader
+        testspriteminimal
+        testautomation
+        testcustomcursor
+        testrendertarget
+        testsprite2
+        loopwave
+        loopwavequeue
+        testresample
+        testaudiohotplug
+        testmultiaudio
+        testime
+        testnative
+        testiconv
+        testoverlay2
+        teststreaming
+        testviewport
+    )
+endif()
+
+if(PSP)
+    # Build EBOOT files if building for PSP
+    set(BUILD_EBOOT
+        ${NEEDS_RESOURCES}
         testoffscreen
         testbounds
         testgl2

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -152,6 +152,11 @@ set(NEEDS_RESOURCES
     testresample
     testaudiohotplug
     testmultiaudio
+    testime
+    testiconv
+    testoverlay2
+    teststreaming
+    testviewport
 )
 if(NOT PSP)
     set(NEEDS_RESOURCES ${NEEDS_RESOURCES} testnative)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -196,7 +196,6 @@ if(PSP)
         testdisplayinfo
         teststreaming
         testgeometry
-        testgesture
         testfile
         testdraw2
         testviewport


### PR DESCRIPTION
Some tests do not need to be run on PSP, because they test features the PSP does not have. There were also some tests which were missing from NEEDS_RESOURCES and were reporting errors on PSP because of it.

## Description

I think it's useful that all tests are build for PSP, but they do not all need to be packaged in EBOOT.PBP files to allow them to be launched on PSP. This PR makes this not happen for a couple of test which are clearly not useful for the PSP. They are the following:

- checkkeys (requires keyboard support)
- checkkeysthread (requires keyboard support)
- testcustomcursor (requires mouse support)
- dropfile(requires drag and drop support)
- testgesture (requires touch pad support)
- testgles (requires OpenGL ES support)
- testgles2 (requires OpenGL ES support)
- testhaptic (requires haptic support)
- testhotplug (requires joystick hotplugging support)
- testime (requires keyboard support)
- testkeys (requires keyboard support)
- testmouse (requires mouse support)
- testrelative (requires mouse support)
- testrumble (requires rumble support)
- testvulkan (requires vulkan support)

I also found the following require resources which were not copied yet:

- testime (requires unifont-13.0.06.hex)
- testiconv (requires utf8.txt)
- testoverlay2 (requires moose.dat)
- teststreaming (requires moose.dat)
- testviewport (requires icon.bmp)

There are probably more examples which are not really useful on the PSP, but that will require some more communication and testing. I'll try to also make an issue for tests which should work on PSP, but don't.
