### PR TITLE
[PSP] Make sure GetPrefPath also works without org

### DIFF
--- a/src/filesystem/psp/SDL_sysfilesystem.c
+++ b/src/filesystem/psp/SDL_sysfilesystem.c
@@ -56,6 +56,9 @@ SDL_GetPrefPath(const char *org, const char *app)
     SDL_InvalidParamError("app");
     return NULL;
   }
+  if(!org) {
+    org = "";
+  }
 
   len = SDL_strlen(base) + SDL_strlen(org) + SDL_strlen(app) + 4;
   retval = (char *) SDL_malloc(len);
@@ -71,6 +74,6 @@ SDL_GetPrefPath(const char *org, const char *app)
   return retval;
 }
 
-#endif /* SDL_FILESYSTEM_DUMMY || SDL_FILESYSTEM_DISABLED */
+#endif /* SDL_FILESYSTEM_PSP */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/filesystem/psp/SDL_sysfilesystem.c
+++ b/src/filesystem/psp/SDL_sysfilesystem.c
@@ -64,9 +64,9 @@ SDL_GetPrefPath(const char *org, const char *app)
   retval = (char *) SDL_malloc(len);
     
   if (*org) {
-    SDL_snprintf(retval, len, "%s/%s/%s/", base, org, app);
+    SDL_snprintf(retval, len, "%s%s/%s/", base, org, app);
   } else {
-    SDL_snprintf(retval, len, "%s/%s/", base, app);
+    SDL_snprintf(retval, len, "%s%s/", base, app);
   }
   free(base);
 


### PR DESCRIPTION
At the moment GetPrefPath does work on the PSP, but only if org is set. This resolves that with the same workaround found in the Vita port.

This is the output of testfilesystem on PSP with this change:

```
host0:/sdl-testfilesystem/> ./testfilesystem.prx 
Load/Start host0:/sdl-testfilesystem/testfilesystem.prx UID: 0x04290A7D Name: SDL App
host0:/sdl-testfilesystem/> INFO: base path: 'host0:/sdl-testfilesystem/'
INFO: pref path: 'host0:/sdl-testfilesystem//libsdl/testfilesystem/'
INFO: pref path: 'host0:/sdl-testfilesystem//testfilesystem/'
```

Before this change it would crash.