### PR TITLE
Don't make psp eboot for testoffscreen

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -189,7 +189,6 @@ if(PSP)
     # Build EBOOT files if building for PSP
     set(BUILD_EBOOT
         ${NEEDS_RESOURCES}
-        testoffscreen
         testbounds
         testgl2
         testsem


### PR DESCRIPTION
Since offscreen rendering is not supported on the PSP, this test does not to be build into an eboot.
