### PR TITLE
SDL_cocoamouse.m: SetRelativeMouseMode even if window out of focus/being moved

### DIFF
--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -263,9 +263,12 @@ Cocoa_SetRelativeMouseMode(SDL_bool enabled)
     if (enabled) {
         DLog("Turning on.");
         result = CGAssociateMouseAndMouseCursorPosition(NO);
-        if (result != kCGErrorSuccess) {
-            return SDL_SetError("CGAssociateMouseAndMouseCursorPosition() failed");
-        }
+    } else {
+        DLog("Turning off.");
+        result = CGAssociateMouseAndMouseCursorPosition(YES);
+    }
+    if (result != kCGErrorSuccess) {
+        return SDL_SetError("CGAssociateMouseAndMouseCursorPosition() failed");
     }
 
     /* We will re-apply the non-relative mode when the window gets focus, if it
@@ -283,15 +286,6 @@ Cocoa_SetRelativeMouseMode(SDL_bool enabled)
     if ([data->listener isMovingOrFocusClickPending]) {
         return 0;
     }
-
-    if (!enabled) {
-        DLog("Turning off.");
-        result = CGAssociateMouseAndMouseCursorPosition(YES);
-        if (result != kCGErrorSuccess) {
-            return SDL_SetError("CGAssociateMouseAndMouseCursorPosition() failed");
-        }
-    }
-
 
     /* The hide/unhide calls are redundant most of the time, but they fix
      * https://bugzilla.libsdl.org/show_bug.cgi?id=2550


### PR DESCRIPTION
## Description

`SDL_SetRelativeMouseMode(SDL_TRUE)` fails on macOS when called following an event like window maximization. This is a common use case on mac since the only way to create a maximized window with cursor capture is to first initialize it in windowed mode without cursor capture, maximize the window using the cursor by pressing the green button in the menu bar, then turn on relative mouse mode afterwards.

Maximizing a window using the 3rd green button on the menu bar briefly causes the window to move and go out of focus, causing the current code in `Cocoa_SetRelativeMouseMode` to return early and never call `CGAssociateMouseAndMouseCursorPosition()`. Moving the call to `CGAssociateMouseAndMouseCursorPosition(NO)` before checking the window's status allows the flag to be set. This issue does not seem to effect turning OFF relative mouse mode (in my tests), so leaving that after the window status checks is ok.

## Existing Issue(s)

Should fix the macOS issues in #1116 and #3087.