### PR TITLE
cmake: Remove libunwind-generic as hard dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1365,7 +1365,7 @@ elseif(UNIX AND NOT APPLE AND NOT ANDROID AND NOT RISCOS AND NOT HAIKU)
       if(HAVE_LIBUNWIND_H)
         # We've already found the header, so REQUIRE the lib to be present
         pkg_search_module(UNWIND REQUIRED libunwind)
-        pkg_search_module(UNWIND_GENERIC REQUIRED libunwind-generic)
+        pkg_search_module(UNWIND_GENERIC libunwind-generic)
         list(APPEND EXTRA_LIBS ${UNWIND_LIBRARIES} ${UNWIND_GENERIC_LIBRARIES})
       endif()
     endif()


### PR DESCRIPTION
when using alternate unwind implementations like LLVM libunwind
this library is not provided yet the libunwind features are fully
implemented in main libunwind, making this hard dependency assumes
a particular libunwind implementation, this patch makes it optional
which makes the builds to work with llvm libunwind

Signed-off-by: Khem Raj <raj.khem@gmail.com>

