### PR TITLE
cmake: Split SDL2-static into its own target export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2826,7 +2826,6 @@ if(SDL_STATIC)
   endif()
   # TODO: Win32 platforms keep the same suffix .lib for import and static
   # libraries - do we need to consider this?
-  set(_INSTALL_LIBS "SDL2-static" ${_INSTALL_LIBS})
   target_link_libraries(SDL2-static PRIVATE ${EXTRA_LIBS} ${EXTRA_LDFLAGS})
   target_include_directories(SDL2-static BEFORE PRIVATE "${SDL2_BINARY_DIR}/include")
   target_include_directories(SDL2-static PUBLIC "$<BUILD_INTERFACE:${SDL2_SOURCE_DIR}/include>" $<INSTALL_INTERFACE:include> $<INSTALL_INTERFACE:include/SDL2>)
@@ -2853,6 +2852,13 @@ install(TARGETS ${_INSTALL_LIBS} EXPORT SDL2Targets
   ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
   RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
+if(SDL_STATIC)
+  install(TARGETS SDL2-static EXPORT SDL2staticTargets
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+endif()
+
 ##### Export files #####
 if (WINDOWS AND NOT MINGW)
   set(PKG_PREFIX "cmake")
@@ -2871,6 +2877,15 @@ install(EXPORT SDL2Targets
   NAMESPACE SDL2::
   DESTINATION ${PKG_PREFIX}
 )
+
+if(SDL_STATIC)
+  install(EXPORT SDL2staticTargets
+    FILE SDL2staticTargets.cmake
+    NAMESPACE SDL2::
+    DESTINATION ${PKG_PREFIX}
+  )
+endif()
+
 install(
   FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/SDL2Config.cmake


### PR DESCRIPTION
This makes it so that the generated targets are not interdependent,
which allows Linux distributions to split libraries into the
appropriate subpackages as needed.

Inspired by PR #5711:
7393bdae7 ("cmake: Split SDL2-static and SDL2main into their own target exports", 2022-01-04)

Note that SDL_main() is provided by the static libSDL2main only, and
that SDL2Config.cmake expects the corresponding target to be defined.
Therefore, the static libSDL2main belongs into devel packages and the
definition into the main target definition export.
