### PR TITLE
Fix memory leaks in WIN_CreateBlankCursor function

### DIFF
--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -177,7 +177,9 @@ WIN_CreateBlankCursor()
 {
     SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormat(0, 32, 32, 32, SDL_PIXELFORMAT_ARGB8888);
     if (surface) {
-        return WIN_CreateCursor(surface, 0, 0);
+        SDL_Cursor* cursor = WIN_CreateCursor(surface, 0, 0);
+        SDL_FreeSurface(surface);
+        return cursor;
     }
     return NULL;
 }

--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -373,6 +373,7 @@ WIN_QuitMouse(_THIS)
 
     if (SDL_blank_cursor) {
         SDL_FreeCursor(SDL_blank_cursor);
+        SDL_free(SDL_blank_cursor);
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
My changes include 2 fixes of memory leaks in SDL_windowsmouse.c for the windows platform.

## Description
All the leaks occur in the function WIN_CreateBlankCursor. 
The main one is a SDL_Surface that is not freed.
https://github.com/libsdl-org/SDL/blob/dca281e810263f1fbf9420c2988932b7700be1d4/src/video/windows/SDL_windowsmouse.c#L175-L183


The second one is the SDL_blank_cursor variable but I'm not sure how to deal with it
Inside the WIN_CreateCursor there is:

https://github.com/libsdl-org/SDL/blob/dca281e810263f1fbf9420c2988932b7700be1d4/src/video/windows/SDL_windowsmouse.c#L163-L173

So SDL_blank_cursor variable is set by the return of this allocation: SDL_calloc

At the end of the program:
https://github.com/libsdl-org/SDL/blob/dca281e810263f1fbf9420c2988932b7700be1d4/src/video/windows/SDL_windowsmouse.c#L364-L375

BUT inside the SDL_FreeCursor function there is no free for the argument passed.
I don't know exactly if SDL_FreeCursor is supposed to free the function argument too or not. 
I supposed that no, and put a SDL_free after the SDL_FreeCursor function call.
