### PR TITLE
Wayland key repeat fixes (fix infinite loop on ticks overflow + fix spurious repeats when not pumping events)

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -210,7 +210,7 @@ keyboard_repeat_handle(SDL_WaylandKeyboardRepeat* repeat_info, uint32_t now)
     if (!repeat_info->is_key_down || !repeat_info->is_initialized) {
         return ret;
     }
-    while (repeat_info->next_repeat_ms <= now) {
+    while ((now - repeat_info->next_repeat_ms) < 0x80000000U) {
         if (repeat_info->scancode != SDL_SCANCODE_UNKNOWN) {
             SDL_SendKeyboardKey(SDL_PRESSED, repeat_info->scancode);
         }

--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -36,6 +36,7 @@ typedef struct {
     SDL_bool is_initialized;
 
     SDL_bool is_key_down;
+    uint32_t wl_press_time; // Key press time as reported by the Wayland API
     uint32_t sdl_press_time; // Key press time expressed in SDL ticks
     uint32_t next_repeat_ms;
     uint32_t scancode;

--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -36,6 +36,7 @@ typedef struct {
     SDL_bool is_initialized;
 
     SDL_bool is_key_down;
+    uint32_t sdl_press_time; // Key press time expressed in SDL ticks
     uint32_t next_repeat_ms;
     uint32_t scancode;
     char text[8];


### PR DESCRIPTION
This fixes two bugs related to handling of key repeats (i.e. sequences of key presses generated by pressing and holding a key)  on Wayland.

One is related to the handling of an overflow on a 32-bit ticks counter (could result in either a very high number of iterations or an infinite loop if a key repeat event happens near the ~49 days `SDL_GetTicks` overflow) and the other fixes a bug where spurious repeat key presses can be generated if the application is not calling `SDL_PumpEvents` for some seconds.

Each fix is in a separate commit, plus one refactorization commit as groundwork for one of the fixes.

## Description
1.  **wayland: Avoid infinite loop in keyboard_repeat_handle**

     If `repeat_info->next_repeat_ms` overflows, many key presses will be generated. In the worst case, `now = 0xFFFFFFFFU` and the loop will never terminate.

     Rearrange the comparison in order to gracefully handle the overflow case.

2. **wayland: Avoid spurious key repeats when not pumping events**

     Previous to this commit, key repeats events were typically generated when pumping events, based on the time of when the events are pumped. However, if an application doesn't call `SDL_PumpEvents` for some seconds, this time can be multiple seconds in the future compared to the actual key up event time, and generates key repeats even if a key was pressed only for an instant.

     In practice, this can happen when the user presses a key which causes the application to do something without pumping events (e.g. load a level). In Crispy Doom & PrBoom+, when the user presses the key bound to "Restart level/demo", the game doesn't pump events during the "screen melt" effect, and the level is restarted multiple times due to spurious repeats.

     To fix this, if the key up event is among the events to be pumped, we generate the key repeats there, since in the Wayland callback we receive the time when the key up event happened. Otherwise, we know no key up event happened and we can generate as many repeats as necessary after pumping.

## Existing Issue(s)
No open issues

## Test app.

You can use this simple program to test "wayland: Avoid spurious key repeats when not pumping events":

```c
#include <SDL2/SDL.h>
#include <stdio.h>

int main(int argc, char* args[]) {
	if (SDL_Init(SDL_INIT_VIDEO) < 0)
		return 1;

	SDL_Window* window = SDL_CreateWindow("test",
		SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 100, 100, SDL_WINDOW_SHOWN);
	if (window == NULL)
		return 1;

	SDL_Surface* screenSurface = SDL_GetWindowSurface(window);
	SDL_FillRect(screenSurface, NULL, SDL_MapRGB(screenSurface->format, 0xFF, 0xFF, 0xFF));
	SDL_UpdateWindowSurface(window);

	SDL_Event e;
	while (1) {
		while (SDL_PollEvent(&e) != 0)
		{
			if (e.type == SDL_QUIT)
				goto quit;

			if (e.type == SDL_KEYDOWN || e.type == SDL_KEYUP) {
				printf("[%u] %s key=%s repeat=%d\n", e.key.timestamp,
					e.type == SDL_KEYDOWN ? "KEYDOWN" : "KEYUP",
					SDL_GetKeyName(e.key.keysym.sym), e.key.repeat);
			}

			if (e.type == SDL_KEYDOWN && e.key.keysym.sym == SDLK_SPACE) {
				// Simulate work (e.g. load resources) without pumping events
				SDL_Delay(5000);
			}
		}
	}

quit:
	SDL_DestroyWindow(window);
	SDL_Quit();
	return 0;
}
```

On Wayland, compile and open the application, focus the window, and press space and release instantly.

Sample bad output (PR not merged):
```
[1013] KEYDOWN key=Space repeat=0
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[6014] KEYDOWN key=Space repeat=1
[...]
```

Sample good output (PR merged):
```
[800] KEYDOWN key=Space repeat=0
[5800] KEYUP key=Space repeat=0
```