### PR TITLE
cmake: sdlchecks.cmake: pass cflags to the appropriate cmake variable

### DIFF
--- a/cmake/sdlchecks.cmake
+++ b/cmake/sdlchecks.cmake
@@ -817,8 +817,7 @@ endmacro()
 macro(CheckEGL)
   if (SDL_OPENGL OR SDL_OPENGLES)
     pkg_check_modules(EGL egl)
-    string(REPLACE "-D_THREAD_SAFE;" "-D_THREAD_SAFE=1;" EGL_CFLAGS "${EGL_CFLAGS}")
-    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${EGL_CFLAGS}")
+    set(CMAKE_REQUIRED_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS} ${EGL_CFLAGS}")
     check_c_source_compiles("
         #define EGL_API_FB
         #define MESA_EGL_NO_X11_HEADERS


### PR DESCRIPTION
If egl.pc sets at least two macros as the i.MX Vivante driver does, e.g.:
| Cflags: -I${includedir} -DLINUX -DWL_EGL_PLATFORM

then we get the following error during configuration:

| -- Performing Test HAVE_OPENGL_EGL
| CMake Error: Parse error in command line argument: WL_EGL_PLATFORM
|  Should be: VAR:type=value

If one changes to add a value to the macro, e.g.
| Cflags: -I${includedir} -DLINUX=1 -DWL_EGL_PLATFORM=1
then cmake does not error out but the macro is not passed to the
C compiler.

CMAKE_REQUIRED_FLAGS is the wrong variable to pass the CFLAGS in,
CMAKE_REQUIRED_DEFINITIONS should be used.

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
