### PR TITLE
Always send SDL_WINDOWEVENT_SIZE_CHANGED when window is resized

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2273,12 +2273,14 @@ SDL_SetWindowSize(SDL_Window * window, int w, int h)
             SDL_UpdateFullscreenMode(window, SDL_TRUE);
         }
     } else {
+        int old_w = window->w;
+        int old_h = window->h;
         window->w = w;
         window->h = h;
         if (_this->SetWindowSize) {
             _this->SetWindowSize(_this, window);
         }
-        if (window->w == w && window->h == h) {
+        if (window->w != old_w || window->h != old_h) {
             /* We didn't get a SDL_WINDOWEVENT_RESIZED event (by design) */
             SDL_OnWindowResized(window);
         }


### PR DESCRIPTION
SDL_WINDOWEVENT_SIZE_CHANGED is now sent even if the resulting size of the window does not match the requested size.

## Description
When calling `SDL_SetWindowSize()`, the window may be resized to a different size than what was requested (for example on X11: https://github.com/libsdl-org/SDL/blob/main/src/video/x11/SDL_x11window.c#L956). In this case `SDL_WINDOWEVENT_SIZE_CHANGED` is not sent.

This patch check if the resulting window size is different from the original size to send the `SDL_WINDOWEVENT_SIZE_CHANGED`.

This bug can easily be triggered by requesting a size bigger than the screen size.

## Existing Issue(s)
Fix #2782
