### PR TITLE
wayland: Avoid spurious resize events

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -84,6 +84,7 @@ typedef struct {
     int num_outputs;
 
     float scale_factor;
+    SDL_bool needs_resize_event;
 } SDL_WindowData;
 
 extern void Wayland_ShowWindow(_THIS, SDL_Window *window);


### PR DESCRIPTION
## Description
This adds tracking (particularly useful for the non-libdecor case) when actual resize has occurred to let us know when we need to generate `SDL_WINDOWEVENT_RESIZED`. The libdecor case is fairly simple because we update to the new dimensions and call `Wayland_HandleResize()` in the same callback.

For non-libdecor, it's more complex because we update the dimensions in `handle_configure_xdg_toplevel()` but call `Wayland_HandleResize()` in `handle_configure_xdg_shell_surface()`, so the window dimensions will already be changed by the time `Wayland_HandleResize()` is called. Since checking `window->w != width` etc. in `Wayland_HandleResize()` won't work in this case, we need a separate variable to track a "pending resize" to ensure the event is generated.

The Wayland resize logic is pretty complicated, so I'd appreciate a review from some other folks to be sure I didn't miss anything.

## Existing Issue(s)
Fixes #5231
