### PR TITLE
Assure SDL_SENSOR_DISABLED disables all code paths

### DIFF
--- a/src/sensor/SDL_sensor.c
+++ b/src/sensor/SDL_sensor.c
@@ -32,19 +32,19 @@
 #endif
 
 static SDL_SensorDriver *SDL_sensor_drivers[] = {
-#ifdef SDL_SENSOR_ANDROID
+#if defined(SDL_SENSOR_ANDROID) && !defined(SDL_SENSOR_DISABLED)
     &SDL_ANDROID_SensorDriver,
 #endif
-#ifdef SDL_SENSOR_COREMOTION
+#if defined(SDL_SENSOR_COREMOTION) && !defined(SDL_SENSOR_DISABLED)
     &SDL_COREMOTION_SensorDriver,
 #endif
-#ifdef SDL_SENSOR_WINDOWS
+#if defined(SDL_SENSOR_WINDOWS) && !defined(SDL_SENSOR_DISABLED)
     &SDL_WINDOWS_SensorDriver,
 #endif
 #if defined(SDL_SENSOR_DUMMY) || defined(SDL_SENSOR_DISABLED)
     &SDL_DUMMY_SensorDriver
 #endif
-#if defined(SDL_SENSOR_VITA)
+#if defined(SDL_SENSOR_VITA) && !defined(SDL_SENSOR_DISABLED)
     &SDL_VITA_SensorDriver
 #endif
 };

--- a/src/sensor/android/SDL_androidsensor.c
+++ b/src/sensor/android/SDL_androidsensor.c
@@ -22,7 +22,7 @@
 
 #include "SDL_config.h"
 
-#ifdef SDL_SENSOR_ANDROID
+#if defined(SDL_SENSOR_ANDROID) && !defined(SDL_SENSOR_DISABLED)
 
 /* This is the system specific header for the SDL sensor API */
 #include <android/sensor.h>
@@ -215,6 +215,6 @@ SDL_SensorDriver SDL_ANDROID_SensorDriver =
     SDL_ANDROID_SensorQuit,
 };
 
-#endif /* SDL_SENSOR_ANDROID */
+#endif /* SDL_SENSOR_ANDROID && !SDL_SENSOR_DISABLED */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/sensor/coremotion/SDL_coremotionsensor.m
+++ b/src/sensor/coremotion/SDL_coremotionsensor.m
@@ -21,7 +21,7 @@
 
 #include "SDL_config.h"
 
-#ifdef SDL_SENSOR_COREMOTION
+#if defined(SDL_SENSOR_COREMOTION) && !defined(SDL_SENSOR_DISABLED)
 
 /* This is the system specific header for the SDL sensor API */
 #include <CoreMotion/CoreMotion.h>
@@ -229,6 +229,6 @@ SDL_SensorDriver SDL_COREMOTION_SensorDriver =
     SDL_COREMOTION_SensorQuit,
 };
 
-#endif /* SDL_SENSOR_COREMOTION */
+#endif /* SDL_SENSOR_COREMOTION && !SDL_SENSOR_DISABLED */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/sensor/vita/SDL_vitasensor.c
+++ b/src/sensor/vita/SDL_vitasensor.c
@@ -21,7 +21,7 @@
 
 #include "SDL_config.h"
 
-#if defined(SDL_SENSOR_VITA)
+#if defined(SDL_SENSOR_VITA) && !defined(SDL_SENSOR_DISABLED)
 
 #include "SDL_error.h"
 #include "SDL_sensor.h"
@@ -214,6 +214,6 @@ SDL_SensorDriver SDL_VITA_SensorDriver =
     SDL_VITA_SensorQuit,
 };
 
-#endif /* SDL_SENSOR_VITA */
+#endif /* SDL_SENSOR_VITA && !SDL_SENSOR_DISABLED */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/sensor/windows/SDL_windowssensor.c
+++ b/src/sensor/windows/SDL_windowssensor.c
@@ -22,7 +22,7 @@
 
 #include "SDL_config.h"
 
-#if defined(SDL_SENSOR_WINDOWS)
+#if defined(SDL_SENSOR_WINDOWS) && !defined(SDL_SENSOR_DISABLED)
 
 #include "SDL_error.h"
 #include "SDL_mutex.h"
@@ -482,6 +482,6 @@ SDL_SensorDriver SDL_WINDOWS_SensorDriver =
     SDL_WINDOWS_SensorQuit,
 };
 
-#endif /* SDL_SENSOR_WINDOWS */
+#endif /* SDL_SENSOR_WINDOWS !SDL_SENSOR_DISABLED */
 
 /* vi: set ts=4 sw=4 expandtab: */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
SDL_SENSOR_DISABLED should take precedence over any platform specific sensor capabilities.

Previously,  SDL_SENSOR_DISABLED  forced enablement of the dummy sensor logic, but then platform includes needed to be adjusted to still avoid the platform sensor code.


