### PR TITLE
Synthesize a missing touch-up event

### DIFF
--- a/src/events/SDL_touch.c
+++ b/src/events/SDL_touch.c
@@ -302,8 +302,9 @@ SDL_SendTouch(SDL_TouchID id, SDL_FingerID fingerid, SDL_Window * window,
     finger = SDL_GetFinger(touch, fingerid);
     if (down) {
         if (finger) {
-            /* This finger is already down */
-            return 0;
+            /* This finger is already down.
+               Assume the finger-up for the previous touch was lost, and send it. */
+            SDL_SendTouch(id, fingerid, window, SDL_FALSE, x, y, pressure);
         }
 
         if (SDL_AddFinger(touch, fingerid, x, y, pressure) < 0) {


### PR DESCRIPTION
If a touch-down event is received for an existing touch-ID, that probably means the operating system lost it, and that the missing touch-up should be synthesized, to keep the client state coherent.

In my experience, MS Windows does not produce a consistent stream of user-interaction events.
The giant legacy application I'm porting to Linux has been doing the equivalent for ages.