### PR TITLE
Fix the erroneous generation of mouse-down events from touch-move events

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -732,8 +732,8 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
                 }
             }
         }
-        /* don't break here, fall through to check the wParam like the button presses */
-        SDL_FALLTHROUGH;
+        break;
+
     case WM_LBUTTONUP:
     case WM_RBUTTONUP:
     case WM_MBUTTONUP:


### PR DESCRIPTION
The issue is that MS Windows synthesizes a mouse-move event in response to touch-move events, and those mouse-move events are _not_ labeled as coming from a touch (e.g. `GetMouseMessageSource()` will not return `SDL_MOUSE_EVENT_SOURCE_TOUCH` for those synthesized mouse-move events).

In addition, there seems to be no way to prevent this from happening; [this article](https://gist.github.com/vbfox/1339671) claims to demonstrate a technique to prevent it, but in my experience, it doesn't work.

Because of this, the "fallthrough" case can't test that the synthesized mouse-move came from a touch-move, and starts erroneously pressing down the mouse-button, leading to massive confusion in the client application.

So what was the purpose of the original fallthrough? git history stops at a hard discontinuity on 6/21/2015, probably the result of a flawed import from a different version-control database.