### PR TITLE
wayland: Try to avoid committing before the window is shown

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -42,7 +42,7 @@
 #endif
 
 static void
-CommitMinMaxDimensions(SDL_Window *window)
+SetMinMaxDimensions(SDL_Window *window, SDL_bool commit)
 {
     SDL_WindowData *wind = window->driverdata;
     SDL_VideoData *viddata = wind->waylandData;
@@ -88,12 +88,14 @@ CommitMinMaxDimensions(SDL_Window *window)
         xdg_toplevel_set_max_size(wind->shell_surface.xdg.roleobj.toplevel,
                                   max_width,
                                   max_height);
-        wl_surface_commit(wind->surface);
+        if (commit) {
+            wl_surface_commit(wind->surface);
+        }
     }
 }
 
 static void
-SetFullscreen(SDL_Window *window, struct wl_output *output)
+SetFullscreen(SDL_Window *window, struct wl_output *output, SDL_bool commit)
 {
     SDL_WindowData *wind = window->driverdata;
     SDL_VideoData *viddata = wind->waylandData;
@@ -101,7 +103,7 @@ SetFullscreen(SDL_Window *window, struct wl_output *output)
     /* The desktop may try to enforce min/max sizes here, so turn them off for
      * fullscreen and on (if applicable) for windowed
      */
-    CommitMinMaxDimensions(window);
+    SetMinMaxDimensions(window, SDL_FALSE);
 
 #ifdef HAVE_LIBDECOR_H
     if (viddata->shell.libdecor) {
@@ -133,6 +135,9 @@ SetFullscreen(SDL_Window *window, struct wl_output *output)
             xdg_toplevel_set_fullscreen(wind->shell_surface.xdg.roleobj.toplevel, output);
         } else {
             xdg_toplevel_unset_fullscreen(wind->shell_surface.xdg.roleobj.toplevel);
+        }
+        if (commit) {
+            wl_surface_commit(wind->surface);
         }
     }
 }
@@ -215,7 +220,7 @@ handle_configure_xdg_toplevel(void *data,
     if (!fullscreen) {
         if (window->flags & SDL_WINDOW_FULLSCREEN) {
             /* We might need to re-enter fullscreen after being restored from minimized */
-            SetFullscreen(window, driverdata->output);
+            SetFullscreen(window, driverdata->output, SDL_FALSE);
 
             /* Foolishly do what the compositor says here. If it's wrong, don't
              * blame us, we were explicitly instructed to do this.
@@ -364,7 +369,7 @@ decoration_frame_configure(struct libdecor_frame *frame,
     if (!fullscreen) {
         if (window->flags & SDL_WINDOW_FULLSCREEN) {
             /* We might need to re-enter fullscreen after being restored from minimized */
-            SetFullscreen(window, driverdata->output);
+            SetFullscreen(window, driverdata->output, SDL_FALSE);
             fullscreen = SDL_TRUE;
             floating = SDL_FALSE;
         }
@@ -779,7 +784,7 @@ void Wayland_ShowWindow(_THIS, SDL_Window *window)
          * -flibit
          */
         SDL_WaylandOutputData *odata = SDL_GetDisplayForWindow(window)->driverdata;
-        SetFullscreen(window, (window->flags & SDL_WINDOW_FULLSCREEN) ? odata->output : NULL);
+        SetFullscreen(window, (window->flags & SDL_WINDOW_FULLSCREEN) ? odata->output : NULL, SDL_TRUE);
         if (data->shell_surface.xdg.surface) {
             while (!data->shell_surface.xdg.initial_configure_seen) {
                 WAYLAND_wl_display_flush(c->display);
@@ -791,6 +796,9 @@ void Wayland_ShowWindow(_THIS, SDL_Window *window)
         if (data->shell_surface.xdg.roleobj.toplevel && c->decoration_manager) {
             data->server_decoration = zxdg_decoration_manager_v1_get_toplevel_decoration(c->decoration_manager, data->shell_surface.xdg.roleobj.toplevel);
         }
+    } else {
+        /* Nothing to see here, just commit. */
+        wl_surface_commit(data->surface);
     }
 
     /* Unlike the rest of window state we have to set this _after_ flushing the
@@ -1053,7 +1061,7 @@ Wayland_SetWindowFullscreen(_THIS, SDL_Window * window,
 {
     struct wl_output *output = ((SDL_WaylandOutputData*) _display->driverdata)->output;
     SDL_VideoData *viddata = (SDL_VideoData *) _this->driverdata;
-    SetFullscreen(window, fullscreen ? output : NULL);
+    SetFullscreen(window, fullscreen ? output : NULL, SDL_TRUE);
 
     WAYLAND_wl_display_flush(viddata->display);
 }
@@ -1125,7 +1133,7 @@ Wayland_SetWindowResizable(_THIS, SDL_Window * window, SDL_bool resizable)
     } else
 #endif
     {
-        CommitMinMaxDimensions(window);
+        SetMinMaxDimensions(window, SDL_TRUE);
     }
 }
 
@@ -1338,7 +1346,7 @@ int Wayland_CreateWindow(_THIS, SDL_Window *window)
         Wayland_input_lock_pointer(c->input);
     }
 
-    wl_surface_commit(data->surface);
+    /* Moved this call to ShowWindow: wl_surface_commit(data->surface); */
     WAYLAND_wl_display_flush(c->display);
 
     /* We may need to create an idle inhibitor for this new window */
@@ -1393,13 +1401,13 @@ Wayland_HandleResize(SDL_Window *window, int width, int height, float scale)
 void
 Wayland_SetWindowMinimumSize(_THIS, SDL_Window * window)
 {
-    CommitMinMaxDimensions(window);
+    SetMinMaxDimensions(window, SDL_TRUE);
 }
 
 void
 Wayland_SetWindowMaximumSize(_THIS, SDL_Window * window)
 {
-    CommitMinMaxDimensions(window);
+    SetMinMaxDimensions(window, SDL_TRUE);
 }
 
 void Wayland_SetWindowSize(_THIS, SDL_Window * window)


### PR DESCRIPTION
Per a suggestion from the KWin maintainers...

https://bugs.kde.org/show_bug.cgi?id=448856

This is an attempt to clean up the large pile of wl_surface_commit calls that can happen early in an app's life. This mostly affects the XDG path. The shell-less path only gets one moved commit call (from CreateWindow to ShowWindow) and libdecor just doesn't have a commit at all anymore (libdecor does that for us anyway, I think).

For XDG, however, we do our best to buffer commits in such a way that only one commit happens by the time ShowWindow is done. After that, the call stream should be the same, we commit as much as we did before (but with slightly saner timing).

Marked as a draft for 3 reasons:
- Needs a lot of testing, moving commits is scary
- ~See the added FIXME in the changeset~ Nevermind, fixed it...
- Might accidentally fix ~SNIP~? CC @dos1