### PR TITLE
PSVita: send initial SDL_JOYDEVICEADDED events

### DIFF
--- a/src/joystick/vita/SDL_sysjoystick.c
+++ b/src/joystick/vita/SDL_sysjoystick.c
@@ -147,7 +147,7 @@ int VITA_JoystickInit(void)
     // after the app has already started.
 
     SDL_numjoysticks = 1;
-
+    SDL_PrivateJoystickAdded(0);
     // How many additional paired controllers are there?
     sceCtrlGetControllerPortInfo(&myPortInfo);
 
@@ -157,6 +157,7 @@ int VITA_JoystickInit(void)
     {
         if (myPortInfo.port[i]!=SCE_CTRL_TYPE_UNPAIRED)
         {
+            SDL_PrivateJoystickAdded(SDL_numjoysticks);
             SDL_numjoysticks++;
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As far as i understand, joystick subsystem should send SDL_JOYDEVICEADDED events for all connected joysticks on init.
This fixes it on PSVita.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
