### PR TITLE
audio: Prefer PipeWire over PulseAudio

### DIFF
--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -35,6 +35,9 @@ static SDL_AudioDevice *open_devices[16];
 
 /* Available audio drivers */
 static const AudioBootStrap *const bootstrap[] = {
+#if SDL_AUDIO_DRIVER_PIPEWIRE
+    &PIPEWIRE_bootstrap,
+#endif
 #if SDL_AUDIO_DRIVER_PULSEAUDIO
     &PULSEAUDIO_bootstrap,
 #endif
@@ -106,9 +109,6 @@ static const AudioBootStrap *const bootstrap[] = {
 #endif
 #if SDL_AUDIO_DRIVER_JACK
     &JACK_bootstrap,
-#endif
-#if SDL_AUDIO_DRIVER_PIPEWIRE
-    &PIPEWIRE_bootstrap,
 #endif
 #if SDL_AUDIO_DRIVER_OSS
     &DSP_bootstrap,


### PR DESCRIPTION
Since we had a Wayland tracker, makes sense to have a PipeWire tracker as well... main difference is, we only have one issue and it happens to be the blocker:

https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/1835

Once PipeWire exposes a way for us to detect that a session is actually running (vs. someone using Pulse but with the PW libs installed) this should be a perfectly safe change; we can fall back to Pulse when the session isn't started or the system doesn't expose the metadata described in the linked issue.

Like with Wayland this branch is for internal testing only; end user testing should use `SDL_AUDIODRIVER=pipewire`.