### PR TITLE
Add a new env var to specify a video index

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -490,6 +490,7 @@ SDL_VideoInit(const char *driver_name)
     SDL_bool init_keyboard = SDL_FALSE;
     SDL_bool init_mouse = SDL_FALSE;
     SDL_bool init_touch = SDL_FALSE;
+    const char *env_device_index = SDL_getenv("SDL_VIDEO_DEVICE_INDEX");
 
     /* Check to make sure we don't overwrite '_this' */
     if (_this != NULL) {
@@ -523,6 +524,11 @@ SDL_VideoInit(const char *driver_name)
     video = NULL;
     if (driver_name == NULL) {
         driver_name = SDL_getenv("SDL_VIDEODRIVER");
+    }
+    /* Check first if the user specified a card index */
+    if(env_device_index) {
+        /* Will be 0 anyway if the string is not integer */
+        index = SDL_strtol(env_device_index, NULL, 0);
     }
     if (driver_name != NULL && *driver_name != 0) {
         const char *driver_attempt = driver_name;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Following issue #5160

## Description
<!--- Describe your changes in detail -->
Set SDL_VIDEO_DEVICE_INDEX to the device index you wish SDL to display on. KMSDRM is the only video backend that supports displaying on a specific video device as of now. This selects a device, not a gfx card connector.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
