### PR TITLE
audio: pipewire: Remove hardcoded upper sample limits

### DIFF
--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -1012,7 +1012,7 @@ stream_state_changed_callback(void *data, enum pw_stream_state old, enum pw_stre
     _THIS = data;
 
     if (state == PW_STREAM_STATE_STREAMING || state == PW_STREAM_STATE_ERROR) {
-        SDL_AtomicSet(&this->hidden->stream_initialized, 1);
+        this->hidden->stream_initialized = 1;
         PIPEWIRE_pw_thread_loop_signal(this->hidden->loop, false);
     }
 }
@@ -1167,7 +1167,7 @@ PIPEWIRE_OpenDevice(_THIS, const char *devname)
 
     /* Wait until the stream is either running or failed */
     PIPEWIRE_pw_thread_loop_lock(priv->loop);
-    if (!SDL_AtomicGet(&priv->stream_initialized)) {
+    if (!priv->stream_initialized) {
         PIPEWIRE_pw_thread_loop_wait(priv->loop);
     }
     PIPEWIRE_pw_thread_loop_unlock(priv->loop);

--- a/src/audio/pipewire/SDL_pipewire.h
+++ b/src/audio/pipewire/SDL_pipewire.h
@@ -37,9 +37,9 @@ struct SDL_PrivateAudioData
     struct pw_context     *context;
     struct SDL_DataQueue  *buffer;
 
-    size_t buffer_period_size;
+    size_t input_buffer_packet_size;
     Sint32 stride; /* Bytes-per-frame */
-    int    stream_initialized;
+    int    stream_init_status;
 };
 
 #endif /* SDL_pipewire_h_ */

--- a/src/audio/pipewire/SDL_pipewire.h
+++ b/src/audio/pipewire/SDL_pipewire.h
@@ -37,9 +37,9 @@ struct SDL_PrivateAudioData
     struct pw_context     *context;
     struct SDL_DataQueue  *buffer;
 
-    size_t       buffer_period_size;
-    Sint32       stride; /* Bytes-per-frame */
-    SDL_atomic_t stream_initialized;
+    size_t buffer_period_size;
+    Sint32 stride; /* Bytes-per-frame */
+    int    stream_initialized;
 };
 
 #endif /* SDL_pipewire_h_ */


### PR DESCRIPTION
This removes the previously hard coded 8192 upper sample limit when dealing with Pipewire buffers and latency and instead uses the buffer size set by Pipewire to clamp the spec.samples/spec.size values in addition to calculating the intermediate input buffer packet size.  This can allow the backend to avoid double-buffering in the output path when a higher latency is requested by the application as the output is only double buffered if the Pipewire buffer is too small, and the input path can avoid having to allocate extra packets in the data queue if Pipewire's new "clock.force-quantum" setting is used to increase buffer sizes, which can dramatically increase the amount of data delivered in the input callback.

The first patch in this series is just a minor bit of prep work as the stream initialization condition variable need not be atomic since it is guarded by a mutex, and converting it to a standard int makes using it with bitflags in the following commit a bit easier.