### PR TITLE
Android: Handle menu button press from controllers

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLControllerManager.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLControllerManager.java
@@ -319,6 +319,7 @@ class SDLJoystickHandler_API19 extends SDLJoystickHandler_API16 {
             KeyEvent.KEYCODE_BUTTON_X,
             KeyEvent.KEYCODE_BUTTON_Y,
             KeyEvent.KEYCODE_BACK,
+            KeyEvent.KEYCODE_MENU,
             KeyEvent.KEYCODE_BUTTON_MODE,
             KeyEvent.KEYCODE_BUTTON_START,
             KeyEvent.KEYCODE_BUTTON_THUMBL,
@@ -360,6 +361,7 @@ class SDLJoystickHandler_API19 extends SDLJoystickHandler_API16 {
             (1 << 2),   // X -> X
             (1 << 3),   // Y -> Y
             (1 << 4),   // BACK -> BACK
+            (1 << 6),   // MENU -> START
             (1 << 5),   // MODE -> GUIDE
             (1 << 6),   // START -> START
             (1 << 7),   // THUMBL -> LEFTSTICK

--- a/src/joystick/android/SDL_sysjoystick.c
+++ b/src/joystick/android/SDL_sysjoystick.c
@@ -103,6 +103,7 @@ keycode_to_SDL(int keycode)
         case AKEYCODE_BUTTON_THUMBR:
             button = SDL_CONTROLLER_BUTTON_RIGHTSTICK;
             break;
+        case AKEYCODE_MENU:
         case AKEYCODE_BUTTON_START:
             button = SDL_CONTROLLER_BUTTON_START;
             break;


### PR DESCRIPTION
When running on a Fire TV, Amazon Fire TV controllers do not have a start button mapped. The closest alternative would be the menu button. SDL isn't detecting menu button presses from controllers. They are currently detected as keyboard events. These changes allow menu button presses from controllers to be detected as start button presses.
