### PR TITLE
iOS >= 10.0 silence CBCentralManagerState deprecation warnings

### DIFF
--- a/src/hidapi/ios/hid.m
+++ b/src/hidapi/ios/hid.m
@@ -58,6 +58,17 @@
 typedef uint32_t uint32;
 typedef uint64_t uint64;
 
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED <= __IPHONE_9_3 
+#define CBManagerState CBCentralManagerState 
+#define CBManagerStateUnknown CBCentralManagerStateUnknown 
+#define CBManagerStateResetting CBCentralManagerStateResetting 
+#define CBManagerStateUnsupported CBCentralManagerStateUnsupported 
+#define CBManagerStateUnauthorized CBCentralManagerStateUnauthorized 
+#define CBManagerStatePoweredOff CBCentralManagerStatePoweredOff 
+#define CBManagerStatePoweredOn CBCentralManagerStatePoweredOn 
+#endif
+
 // enables detailed NSLog logging of feature reports
 #define FEATURE_REPORT_LOGGING	0
 


### PR DESCRIPTION
## Description
In iOS >= 10.0 CBCentralManagerState is deprecated. This way these warnings are silenced. Not sure if this is the way you want the MAX_ALLOWED to be defined, though.
