### PR TITLE
hide SDL_GenerateAssertionReport in case SDL_ASSERT_LEVEL is 0

### DIFF
--- a/src/SDL_assert.c
+++ b/src/SDL_assert.c
@@ -384,6 +384,7 @@ SDL_ReportAssertion(SDL_assert_data *data, const char *func, const char *file,
 
 void SDL_AssertionsQuit(void)
 {
+#if SDL_ASSERT_LEVEL > 0
     SDL_GenerateAssertionReport();
 #ifndef SDL_THREADS_DISABLED
     if (assertion_mutex != NULL) {
@@ -391,6 +392,7 @@ void SDL_AssertionsQuit(void)
         assertion_mutex = NULL;
     }
 #endif
+#endif /* SDL_ASSERT_LEVEL > 0 */
 }
 
 void SDL_SetAssertionHandler(SDL_AssertionHandler handler, void *userdata)


### PR DESCRIPTION
otherwise SDL_PromptAssertion (and SDL_GenerateAssertionReport) can not be eliminated