### PR TITLE
stdlib improvements

### DIFF
--- a/src/stdlib/SDL_getenv.c
+++ b/src/stdlib/SDL_getenv.c
@@ -48,7 +48,7 @@ int
 SDL_setenv(const char *name, const char *value, int overwrite)
 {
     /* Input validation */
-    if (!name || SDL_strlen(name) == 0 || SDL_strchr(name, '=') != NULL || !value) {
+    if (!name || *name == '\0' || SDL_strchr(name, '=') != NULL || !value) {
         return (-1);
     }
     
@@ -59,7 +59,7 @@ int
 SDL_setenv(const char *name, const char *value, int overwrite)
 {
     /* Input validation */
-    if (!name || SDL_strlen(name) == 0 || SDL_strchr(name, '=') != NULL || !value) {
+    if (!name || *name == '\0' || SDL_strchr(name, '=') != NULL || !value) {
         return (-1);
     }
     
@@ -82,7 +82,7 @@ SDL_setenv(const char *name, const char *value, int overwrite)
     char *new_variable;
 
     /* Input validation */
-    if (!name || SDL_strlen(name) == 0 || SDL_strchr(name, '=') != NULL || !value) {
+    if (!name || *name == '\0' || SDL_strchr(name, '=') != NULL || !value) {
         return (-1);
     }
     
@@ -115,7 +115,7 @@ SDL_setenv(const char *name, const char *value, int overwrite)
     char *new_variable;
 
     /* Input validation */
-    if (!name || SDL_strlen(name) == 0 || SDL_strchr(name, '=') != NULL || !value) {
+    if (!name || *name == '\0' || SDL_strchr(name, '=') != NULL || !value) {
         return (-1);
     }
 
@@ -181,7 +181,7 @@ SDL_getenv(const char *name)
 #endif
 
     /* Input validation */
-    if (!name || !*name) {
+    if (!name || *name == '\0') {
         return NULL;
     }
 
@@ -194,7 +194,7 @@ SDL_getenv(const char *name)
     size_t bufferlen;
 
     /* Input validation */
-    if (!name || SDL_strlen(name)==0) {
+    if (!name || *name == '\0') {
         return NULL;
     }
     
@@ -222,7 +222,7 @@ SDL_getenv(const char *name)
     char *value;
 
     /* Input validation */
-    if (!name || SDL_strlen(name)==0) {
+    if (!name || *name == '\0') {
         return NULL;
     }
     

--- a/src/stdlib/SDL_string.c
+++ b/src/stdlib/SDL_string.c
@@ -1120,8 +1120,8 @@ SDL_strcasecmp(const char *str1, const char *str2)
         ++str1;
         ++str2;
     }
-    a = SDL_toupper(*str1);
-    b = SDL_toupper(*str2);
+    a = SDL_toupper((unsigned char) *str1);
+    b = SDL_toupper((unsigned char) *str2);
     return (int) ((unsigned char) a - (unsigned char) b);
 #endif /* HAVE_STRCASECMP */
 }

--- a/src/stdlib/SDL_string.c
+++ b/src/stdlib/SDL_string.c
@@ -1072,13 +1072,16 @@ SDL_strcmp(const char *str1, const char *str2)
 #if defined(HAVE_STRCMP)
     return strcmp(str1, str2);
 #else
-    while (*str1 && *str2) {
-        if (*str1 != *str2)
+    int result;
+
+    while(1) {
+        result = (int)((unsigned char) *str1 - (unsigned char) *str2);
+        if (result != 0 || (*str1 == '\0'/* && *str2 == '\0'*/))
             break;
         ++str1;
         ++str2;
     }
-    return (int)((unsigned char) *str1 - (unsigned char) *str2);
+    return result;
 #endif /* HAVE_STRCMP */
 }
 
@@ -1088,17 +1091,20 @@ SDL_strncmp(const char *str1, const char *str2, size_t maxlen)
 #if defined(HAVE_STRNCMP)
     return strncmp(str1, str2, maxlen);
 #else
-    while (*str1 && *str2 && maxlen) {
-        if (*str1 != *str2)
+    int result;
+
+    while (maxlen) {
+        result = (int) (unsigned char) *str1 - (unsigned char) *str2;
+        if (result != 0 || *str1 == '\0'/* && *str2 == '\0'*/)
             break;
         ++str1;
         ++str2;
         --maxlen;
     }
     if (!maxlen) {
-        return 0;
+        result = 0;
     }
-    return (int) ((unsigned char) *str1 - (unsigned char) *str2);
+    return result;
 #endif /* HAVE_STRNCMP */
 }
 
@@ -1110,19 +1116,18 @@ SDL_strcasecmp(const char *str1, const char *str2)
 #elif defined(HAVE__STRICMP)
     return _stricmp(str1, str2);
 #else
-    char a = 0;
-    char b = 0;
-    while (*str1 && *str2) {
+    int a, b, result;
+
+    while (1) {
         a = SDL_toupper((unsigned char) *str1);
         b = SDL_toupper((unsigned char) *str2);
-        if (a != b)
+        result = a - b;
+        if (result != 0 || a == 0 /*&& b == 0*/)
             break;
         ++str1;
         ++str2;
     }
-    a = SDL_toupper((unsigned char) *str1);
-    b = SDL_toupper((unsigned char) *str2);
-    return (int) ((unsigned char) a - (unsigned char) b);
+    return result;
 #endif /* HAVE_STRCASECMP */
 }
 
@@ -1134,24 +1139,21 @@ SDL_strncasecmp(const char *str1, const char *str2, size_t maxlen)
 #elif defined(HAVE__STRNICMP)
     return _strnicmp(str1, str2, maxlen);
 #else
-    char a = 0;
-    char b = 0;
-    while (*str1 && *str2 && maxlen) {
+    int a, b, result;
+
+    while (maxlen) {
         a = SDL_tolower((unsigned char) *str1);
         b = SDL_tolower((unsigned char) *str2);
-        if (a != b)
+        result = a - b;
+        if (result != 0 || a == 0 /*&& b == 0*/)
             break;
         ++str1;
         ++str2;
         --maxlen;
     }
-    if (maxlen == 0) {
-        return 0;
-    } else {
-        a = SDL_tolower((unsigned char) *str1);
-        b = SDL_tolower((unsigned char) *str2);
-        return (int) ((unsigned char) a - (unsigned char) b);
-    }
+    if (maxlen == 0)
+        result = 0;
+    return result;
 #endif /* HAVE_STRNCASECMP */
 }
 


### PR DESCRIPTION
1. use simple comparison instead of SDL_strlen if the only question is whether the string is empty (SDL_getenv.c)
2. call SDL_toupper with unsigned char values instead of char, otherwise the result might be undefined according to the standard (SDL_string.c I.)
3. reduce the number of checks and the code size in the SDL_str(case)cmp functions (SDL_string.c II.)