### PR TITLE
cmake: Fix SDL_LIBUSB_DYNAMIC soname

### DIFF
--- a/cmake/sdlchecks.cmake
+++ b/cmake/sdlchecks.cmake
@@ -1174,7 +1174,7 @@ macro(CheckHIDAPI)
         else()
           # libusb is loaded dynamically, so don't add it to EXTRA_LIBS
           FindLibraryAndSONAME("usb-1.0")
-          set(SDL_LIBUSB_DYNAMIC "\"${USB_LIB_SONAME}\"")
+          set(SDL_LIBUSB_DYNAMIC "\"${USB_1.0_LIB_SONAME}\"")
         endif()
       endif()
     endif()


### PR DESCRIPTION
`FindLibraryAndSONAME` ends up producing a variable named `USB_1.0_LIB_SONAME`, rather than `USB_LIB_SONAME`.

This fixes `SDL_LIBUSB_DYNAMIC` being defined to an empty string.