### PR TITLE
Psp rendercopyex

### DIFF
--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -904,16 +904,16 @@ PSP_QueueCopyEx(SDL_Renderer * renderer, SDL_RenderCommand *cmd, SDL_Texture * t
 
     cmd->data.draw.count = 1;
 
-    MathSincos(degToRad(angle), &s, &c);
+    MathSincos(degToRad(360-angle), &s, &c);
 
-    cw1 = c * width;
-    sw1 = s * width;
-    ch1 = c * height;
-    sh1 = s * height;
-    cw2 = c * -centerx;
-    sw2 = s * -centerx;
-    ch2 = c * -centery;
-    sh2 = s * -centery;
+    cw1 = c * -centerx;
+    sw1 = s * -centerx;
+    ch1 = c * -centery;
+    sh1 = s * -centery;
+    cw2 = c * width;
+    sw2 = s * width;
+    ch2 = c * height;
+    sh2 = s * height;
 
     if (flip & SDL_FLIP_VERTICAL) {
         Swap(&v0, &v1);

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -891,14 +891,12 @@ PSP_QueueCopyEx(SDL_Renderer * renderer, SDL_RenderCommand *cmd, SDL_Texture * t
     const float width = dstrect->w - centerx;
     const float height = dstrect->h - centery;
     float s, c;
-    float cw, sw, ch, sh;
+    float cw1, sw1, ch1, sh1, cw2, sw2, ch2, sh2;
 
     float u0 = srcrect->x;
     float v0 = srcrect->y;
     float u1 = srcrect->x + srcrect->w;
     float v1 = srcrect->y + srcrect->h;
-
-
 
     if (!verts) {
         return -1;
@@ -908,10 +906,14 @@ PSP_QueueCopyEx(SDL_Renderer * renderer, SDL_RenderCommand *cmd, SDL_Texture * t
 
     MathSincos(degToRad(angle), &s, &c);
 
-    cw = c * width;
-    sw = s * width;
-    ch = c * height;
-    sh = s * height;
+    cw1 = c * width;
+    sw1 = s * width;
+    ch1 = c * height;
+    sh1 = s * height;
+    cw2 = c * -centerx;
+    sw2 = s * -centerx;
+    ch2 = c * -centery;
+    sh2 = s * -centery;
 
     if (flip & SDL_FLIP_VERTICAL) {
         Swap(&v0, &v1);
@@ -923,29 +925,29 @@ PSP_QueueCopyEx(SDL_Renderer * renderer, SDL_RenderCommand *cmd, SDL_Texture * t
 
     verts->u = u0;
     verts->v = v0;
-    verts->x = x - cw + sh;
-    verts->y = y - sw - ch;
+    verts->x = x + cw1 + sh1;
+    verts->y = y - sw1 + ch1;
     verts->z = 0;
     verts++;
 
     verts->u = u0;
     verts->v = v1;
-    verts->x = x - cw - sh;
-    verts->y = y - sw + ch;
+    verts->x = x + cw1 + sh2;
+    verts->y = y - sw1 + ch2;
     verts->z = 0;
     verts++;
 
     verts->u = u1;
     verts->v = v1;
-    verts->x = x + cw - sh;
-    verts->y = y + sw + ch;
+    verts->x = x + cw2 + sh2;
+    verts->y = y - sw2 + ch2;
     verts->z = 0;
     verts++;
 
     verts->u = u1;
     verts->v = v0;
-    verts->x = x + cw + sh;
-    verts->y = y + sw - ch;
+    verts->x = x + cw2 + sh1;
+    verts->y = y - sw2 + ch1;
     verts->z = 0;
     verts++;
 


### PR DESCRIPTION
This fixes RenderCopyEx on the PSP not correctly.

## Description
Before this change, the images in the demo provided in #5329 would just rotate around the middle of the image, one even at the wrong aspect ratio. This PR fixes that. To proof it I've provided and image which shows how it looks now.

![proof](https://user-images.githubusercontent.com/5042659/153043380-ac884424-d1e1-4778-8086-679e839194e4.png)

My solution is less efficient than the one used before, but it does work, which the previous solution didn't.

## Existing Issue(s)
This resolves #5329
