### PR TITLE
audio: pipewire: Cleanups in preparation for session detection

### DIFF
--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -57,7 +57,7 @@
  * This seems to be a sane lower limit as Pipewire
  * uses it in several of it's own modules.
  */
-#define PW_MIN_SAMPLES     32   /* About 0.67ms at 48kHz */
+#define PW_MIN_SAMPLES     32 /* About 0.67ms at 48kHz */
 #define PW_BASE_CLOCK_RATE 48000
 
 #define PW_POD_BUFFER_LENGTH         1024
@@ -109,7 +109,7 @@ static int (*PIPEWIRE_pw_properties_setf)(struct pw_properties *, const char *, 
 #ifdef SDL_AUDIO_DRIVER_PIPEWIRE_DYNAMIC
 
 static const char *pipewire_library = SDL_AUDIO_DRIVER_PIPEWIRE_DYNAMIC;
-static void *      pipewire_handle  = NULL;
+static void       *pipewire_handle  = NULL;
 
 static int
 pipewire_dlsym(const char *fn, void **addr)
@@ -254,9 +254,9 @@ struct io_node
 
 /* The global hotplug thread and associated objects. */
 static struct pw_thread_loop *hotplug_loop;
-static struct pw_core *       hotplug_core;
-static struct pw_context *    hotplug_context;
-static struct pw_registry *   hotplug_registry;
+static struct pw_core        *hotplug_core;
+static struct pw_context     *hotplug_context;
+static struct pw_registry    *hotplug_registry;
 static struct spa_hook        hotplug_registry_listener;
 static struct spa_hook        hotplug_core_listener;
 static struct spa_list        hotplug_pending_list;
@@ -398,7 +398,7 @@ pending_list_clear()
 static void *
 node_object_new(Uint32 id, const char *type, Uint32 version, const void *funcs, const struct pw_core_events *core_events)
 {
-    struct pw_proxy *   proxy;
+    struct pw_proxy    *proxy;
     struct node_object *node;
 
     /* Create the proxy object */
@@ -442,7 +442,7 @@ static void
 core_events_interface_callback(void *object, uint32_t id, int seq)
 {
     struct node_object *node = object;
-    struct io_node *    io   = node->userdata;
+    struct io_node     *io   = node->userdata;
 
     if (id == PW_ID_CORE && seq == node->seq) {
         /*
@@ -492,7 +492,7 @@ static SDL_bool
 get_range_param(const struct spa_pod *param, Uint32 key, int *def, int *min, int *max)
 {
     const struct spa_pod_prop *prop;
-    struct spa_pod *           value;
+    struct spa_pod            *value;
     Uint32                     n_values, choice;
 
     prop = spa_pod_find_prop(param, NULL, key);
@@ -546,8 +546,8 @@ static void
 node_event_info(void *object, const struct pw_node_info *info)
 {
     struct node_object *node = object;
-    struct io_node *    io   = node->userdata;
-    const char *        prop_val;
+    struct io_node     *io   = node->userdata;
+    const char         *prop_val;
     Uint32              i;
 
     if (info) {
@@ -569,7 +569,7 @@ static void
 node_event_param(void *object, int seq, uint32_t id, uint32_t index, uint32_t next, const struct spa_pod *param)
 {
     struct node_object *node = object;
-    struct io_node *    io   = node->userdata;
+    struct io_node     *io   = node->userdata;
 
     /* Get the default frequency */
     if (io->spec.freq == 0) {
@@ -622,7 +622,7 @@ registry_event_global_callback(void *object, uint32_t id, uint32_t permissions, 
         const char *media_class = spa_dict_lookup(props, PW_KEY_MEDIA_CLASS);
 
         if (media_class) {
-            const char *    node_desc;
+            const char     *node_desc;
             struct io_node *io;
             SDL_bool        is_capture;
             int             str_buffer_len;
@@ -800,14 +800,14 @@ static const enum spa_audio_channel PIPEWIRE_channel_map_4[] = { SPA_AUDIO_CHANN
                                                                  SPA_AUDIO_CHANNEL_RR };
 static const enum spa_audio_channel PIPEWIRE_channel_map_5[] = { SPA_AUDIO_CHANNEL_FL, SPA_AUDIO_CHANNEL_FR, SPA_AUDIO_CHANNEL_FC,
                                                                  SPA_AUDIO_CHANNEL_RL, SPA_AUDIO_CHANNEL_RR };
-static const enum spa_audio_channel PIPEWIRE_channel_map_6[] = { SPA_AUDIO_CHANNEL_FL,  SPA_AUDIO_CHANNEL_FR, SPA_AUDIO_CHANNEL_FC,
+static const enum spa_audio_channel PIPEWIRE_channel_map_6[] = { SPA_AUDIO_CHANNEL_FL, SPA_AUDIO_CHANNEL_FR, SPA_AUDIO_CHANNEL_FC,
                                                                  SPA_AUDIO_CHANNEL_LFE, SPA_AUDIO_CHANNEL_RL, SPA_AUDIO_CHANNEL_RR };
-static const enum spa_audio_channel PIPEWIRE_channel_map_7[] = { SPA_AUDIO_CHANNEL_FL,  SPA_AUDIO_CHANNEL_FR, SPA_AUDIO_CHANNEL_FC,
+static const enum spa_audio_channel PIPEWIRE_channel_map_7[] = { SPA_AUDIO_CHANNEL_FL, SPA_AUDIO_CHANNEL_FR, SPA_AUDIO_CHANNEL_FC,
                                                                  SPA_AUDIO_CHANNEL_LFE, SPA_AUDIO_CHANNEL_RC, SPA_AUDIO_CHANNEL_RL,
                                                                  SPA_AUDIO_CHANNEL_RR };
-static const enum spa_audio_channel PIPEWIRE_channel_map_8[] = { SPA_AUDIO_CHANNEL_FL,  SPA_AUDIO_CHANNEL_FR, SPA_AUDIO_CHANNEL_FC,
+static const enum spa_audio_channel PIPEWIRE_channel_map_8[] = { SPA_AUDIO_CHANNEL_FL, SPA_AUDIO_CHANNEL_FR, SPA_AUDIO_CHANNEL_FC,
                                                                  SPA_AUDIO_CHANNEL_LFE, SPA_AUDIO_CHANNEL_RL, SPA_AUDIO_CHANNEL_RR,
-                                                                 SPA_AUDIO_CHANNEL_SL,  SPA_AUDIO_CHANNEL_SR };
+                                                                 SPA_AUDIO_CHANNEL_SL, SPA_AUDIO_CHANNEL_SR };
 
 #define COPY_CHANNEL_MAP(c) SDL_memcpy(info->position, PIPEWIRE_channel_map_##c, sizeof(PIPEWIRE_channel_map_##c))
 
@@ -882,9 +882,9 @@ initialize_spa_info(const SDL_AudioSpec *spec, struct spa_audio_info_raw *info)
 static void
 output_callback(void *data)
 {
-    struct pw_buffer * pw_buf;
+    struct pw_buffer  *pw_buf;
     struct spa_buffer *spa_buf;
-    Uint8 *            dst;
+    Uint8             *dst;
 
     _THIS                    = (SDL_AudioDevice *)data;
     struct pw_stream *stream = this->hidden->stream;
@@ -951,9 +951,9 @@ output_callback(void *data)
 static void
 input_callback(void *data)
 {
-    struct pw_buffer * pw_buf;
+    struct pw_buffer  *pw_buf;
     struct spa_buffer *spa_buf;
-    Uint8 *            src;
+    Uint8             *src;
     _THIS                    = (SDL_AudioDevice *)data;
     struct pw_stream *stream = this->hidden->stream;
 
@@ -1015,8 +1015,8 @@ stream_add_buffer_callback(void *data, struct pw_buffer *buffer)
          * If they exceed the maximum size of the Pipewire buffer, double buffering will be used.
          */
         if (this->spec.size > buffer->buffer->datas[0].maxsize) {
-           this->spec.samples = buffer->buffer->datas[0].maxsize / this->hidden->stride;
-           this->spec.size    = buffer->buffer->datas[0].maxsize;
+            this->spec.samples = buffer->buffer->datas[0].maxsize / this->hidden->stride;
+            this->spec.size    = buffer->buffer->datas[0].maxsize;
         }
     } else if (this->hidden->buffer == NULL) {
         /*
@@ -1054,9 +1054,9 @@ static const struct pw_stream_events stream_output_events = { PW_VERSION_STREAM_
                                                               .add_buffer    = stream_add_buffer_callback,
                                                               .process       = output_callback };
 static const struct pw_stream_events stream_input_events  = { PW_VERSION_STREAM_EVENTS,
-                                                             .state_changed = stream_state_changed_callback,
-                                                             .add_buffer    = stream_add_buffer_callback,
-                                                             .process       = input_callback };
+                                                              .state_changed = stream_state_changed_callback,
+                                                              .add_buffer    = stream_add_buffer_callback,
+                                                              .process       = input_callback };
 
 static int
 PIPEWIRE_OpenDevice(_THIS, const char *devname)
@@ -1074,10 +1074,10 @@ PIPEWIRE_OpenDevice(_THIS, const char *devname)
     Uint8                        pod_buffer[PW_POD_BUFFER_LENGTH];
     struct spa_pod_builder       b        = SPA_POD_BUILDER_INIT(pod_buffer, sizeof(pod_buffer));
     struct spa_audio_info_raw    spa_info = { 0 };
-    const struct spa_pod *       params   = NULL;
+    const struct spa_pod        *params   = NULL;
     struct SDL_PrivateAudioData *priv;
-    struct pw_properties *       props;
-    const char *                 app_name, *stream_name, *stream_role, *error;
+    struct pw_properties        *props;
+    const char                  *app_name, *stream_name, *stream_role, *error;
     const Uint32                 node_id   = this->handle == NULL ? PW_ID_ANY : PW_HANDLE_TO_ID(this->handle);
     SDL_bool                     iscapture = this->iscapture;
     int                          res;
@@ -1089,7 +1089,7 @@ PIPEWIRE_OpenDevice(_THIS, const char *devname)
     app_name = SDL_GetHint(SDL_HINT_AUDIO_DEVICE_APP_NAME);
     if (!app_name || *app_name == '\0') {
         app_name = SDL_GetHint(SDL_HINT_APP_NAME);
-        if (!app_name || *app_name == '\0') {   
+        if (!app_name || *app_name == '\0') {
             app_name = "SDL Application";
         }
     }

--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -744,20 +744,27 @@ hotplug_loop_destroy()
     hotplug_init_complete  = SDL_FALSE;
     hotplug_events_enabled = SDL_FALSE;
 
+    pipewire_default_sink_id   = SPA_ID_INVALID;
+    pipewire_default_source_id = SPA_ID_INVALID;
+
     if (hotplug_registry) {
         PIPEWIRE_pw_proxy_destroy((struct pw_proxy *)hotplug_registry);
+        hotplug_registry = NULL;
     }
 
     if (hotplug_core) {
         PIPEWIRE_pw_core_disconnect(hotplug_core);
+        hotplug_core = NULL;
     }
 
     if (hotplug_context) {
         PIPEWIRE_pw_context_destroy(hotplug_context);
+        hotplug_context = NULL;
     }
 
     if (hotplug_loop) {
         PIPEWIRE_pw_thread_loop_destroy(hotplug_loop);
+        hotplug_loop = NULL;
     }
 }
 

--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -275,8 +275,6 @@ io_list_check_add(struct io_node *node)
     struct io_node *n;
     SDL_bool        ret = SDL_TRUE;
 
-    PIPEWIRE_pw_thread_loop_lock(hotplug_loop);
-
     /* See if the node is already in the list */
     spa_list_for_each (n, &hotplug_io_list, link) {
         if (n->id == node->id) {
@@ -294,8 +292,6 @@ io_list_check_add(struct io_node *node)
 
 dup_found:
 
-    PIPEWIRE_pw_thread_loop_unlock(hotplug_loop);
-
     return ret;
 }
 
@@ -303,8 +299,6 @@ static void
 io_list_remove(Uint32 id)
 {
     struct io_node *n, *temp;
-
-    PIPEWIRE_pw_thread_loop_lock(hotplug_loop);
 
     /* Find and remove the node from the list */
     spa_list_for_each_safe (n, temp, &hotplug_io_list, link) {
@@ -320,8 +314,6 @@ io_list_remove(Uint32 id)
             break;
         }
     }
-
-    PIPEWIRE_pw_thread_loop_unlock(hotplug_loop);
 }
 
 static void
@@ -329,8 +321,6 @@ io_list_sort()
 {
     struct io_node *default_sink = NULL, *default_source = NULL;
     struct io_node *n, *temp;
-
-    PIPEWIRE_pw_thread_loop_lock(hotplug_loop);
 
     /* Find and move the default nodes to the beginning of the list */
     spa_list_for_each_safe (n, temp, &hotplug_io_list, link) {
@@ -350,8 +340,6 @@ io_list_sort()
     if (default_sink) {
         spa_list_prepend(&hotplug_io_list, &default_sink->link);
     }
-
-    PIPEWIRE_pw_thread_loop_unlock(hotplug_loop);
 }
 
 static void


### PR DESCRIPTION
While starting to implement the session detection code, I went though and made a few additional cleanups:

- The hotplug conditional variables are guarded by the Pipewire hotplug loop mutex in every case, so they don't need to be atomic.
- Some redundant locks when dealing with the IO device node list were removed.
- The global hotplug object pointers weren't nulled on shutdown, so if the audio system was started, shutdown, restarted and the restart failed halfway though, some object pointers could be double freed.
- Fixed up some cosmetic formatting issues.

@flibitijibibo 