### PR TITLE
video: Add a hint to allow Vulkan surfaces on foreign windows

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -1420,6 +1420,17 @@ extern "C" {
 #define SDL_HINT_VIDEO_WINDOW_SHARE_PIXEL_FORMAT    "SDL_VIDEO_WINDOW_SHARE_PIXEL_FORMAT"
 
 /**
+ *  \brief  When calling SDL_CreateWindowFrom(), make the window compatible with Vulkan.
+ *
+ * This variable can be set to the following values:
+ * "0" - Don't add any graphics flags to the SDL_WindowFlags
+ * "1" - Add SDL_WINDOW_VULKAN to the SDL_WindowFlags
+ *
+ * By default SDL will not make the foreign window compatible with Vulkan.
+ */
+#define SDL_HINT_VIDEO_FOREIGN_WINDOW_VULKAN "SDL_VIDEO_FOREIGN_WINDOW_VULKAN"
+
+/**
 *  \brief  A variable specifying which shader compiler to preload when using the Chrome ANGLE binaries
 *
 *  SDL has EGL and OpenGL ES2 support on Windows via the ANGLE project. It

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1801,6 +1801,16 @@ SDL_CreateWindowFrom(const void *data)
     }
     _this->windows = window;
 
+#if SDL_VIDEO_VULKAN
+    if (SDL_GetHintBoolean(SDL_HINT_VIDEO_FOREIGN_WINDOW_VULKAN, SDL_FALSE)) {
+        window->flags |= SDL_WINDOW_VULKAN;
+        if (SDL_Vulkan_LoadLibrary(NULL) < 0) {
+            SDL_DestroyWindow(window);
+            return NULL;
+        }
+    }
+#endif
+
     if (_this->CreateSDLWindowFrom(_this, window, data) < 0) {
         SDL_DestroyWindow(window);
         return NULL;


### PR DESCRIPTION
This is a patch I wrote to make it so foreign windows could create Vulkan surfaces... an example of this would be a C# WinForm that is passed to SDL_CreateWindowFrom so that it can be presented to via FNA3D's Vulkan renderer.

This is a draft for two reasons:
1. I couldn't come up with a good name for the hint ._.
2. Is this something that could potentially be in SDL_video.c instead? AFAIK the only thing the `VULKAN` flag does on all platforms is call SDL_Vulkan_LoadLibrary and that's it, so there's nothing stopping anyone from just hacking the flag in arbitrarily, the Vulkan surfaces are far less coupled to the window than they are in OpenGL.