### PR TITLE
Render all sides when drawing rect on PSP

### DIFF
--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -774,14 +774,13 @@ PSP_QueueFillRects(SDL_Renderer * renderer, SDL_RenderCommand *cmd, const SDL_FR
 
     cmd->data.draw.count = count;
     for (i = 0; i < count; i++, rects++) {
-        const SDL_FRect *rect = &rects[i];
-        verts->x = rect->x;
-        verts->y = rect->y;
+        verts->x = rects->x;
+        verts->y = rects->y;
         verts->z = 0.0f;
         verts++;
 
-        verts->x = rect->x + rect->w;
-        verts->y = rect->y + rect->h;
+        verts->x = rects->x + rects->w + 0.5f;
+        verts->y = rects->y + rects->h + 0.5f;
         verts->z = 0.0f;
         verts++;
     }


### PR DESCRIPTION
At the moment using SDL_RenderDrawRect will result into only 2 of the 4 lines of the rectangle being drawn on the PSP. This PR resolves that

## Description

Without this fix:

![before](https://user-images.githubusercontent.com/5042659/153252775-f0777a70-a50a-4156-b1b5-6cc3f3c0e6f2.png)

With this fix:

![after](https://user-images.githubusercontent.com/5042659/153252840-fc81d51a-9588-4695-a0bd-c2dfeaf1a663.png)

I made sure to add 0.5 to the end so the last pixel is also drawn.
