### PR TITLE
SDL2 thread proxying fixes

### DIFF
--- a/src/video/emscripten/SDL_emscriptenframebuffer.c
+++ b/src/video/emscripten/SDL_emscriptenframebuffer.c
@@ -26,6 +26,8 @@
 #include "SDL_emscriptenframebuffer.h"
 #include "SDL_hints.h"
 
+#include <emscripten/threading.h>
+
 
 int Emscripten_CreateWindowFramebuffer(_THIS, SDL_Window * window, Uint32 * format, void ** pixels, int *pitch)
 {
@@ -57,18 +59,8 @@ int Emscripten_CreateWindowFramebuffer(_THIS, SDL_Window * window, Uint32 * form
     return 0;
 }
 
-int Emscripten_UpdateWindowFramebuffer(_THIS, SDL_Window * window, const SDL_Rect * rects, int numrects)
+static void Emscripten_UpdateWindowFramebufferWorker(SDL_Surface *surface)
 {
-    SDL_Surface *surface;
-
-    SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
-    surface = data->surface;
-    if (!surface) {
-        return SDL_SetError("Couldn't find framebuffer surface for window");
-    }
-
-    /* Send the data to the display */
-
     EM_ASM_INT({
         var w = $0;
         var h = $1;
@@ -156,6 +148,29 @@ int Emscripten_UpdateWindowFramebuffer(_THIS, SDL_Window * window, const SDL_Rec
         SDL2.ctx.putImageData(SDL2.image, 0, 0);
         return 0;
     }, surface->w, surface->h, surface->pixels);
+}
+
+int Emscripten_UpdateWindowFramebuffer(_THIS, SDL_Window * window, const SDL_Rect * rects, int numrects)
+{
+    SDL_Surface *surface;
+
+    SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
+    surface = data->surface;
+    if (!surface) {
+        return SDL_SetError("Couldn't find framebuffer surface for window");
+    }
+
+    /* Send the data to the display */
+
+    if (emscripten_is_main_runtime_thread()) {
+        Emscripten_UpdateWindowFramebufferWorker(surface);
+    } else {
+        emscripten_sync_run_in_main_runtime_thread(
+            EM_FUNC_SIG_VI,
+            Emscripten_UpdateWindowFramebufferWorker,
+            (uint32_t)surface
+        );
+    }
 
     if (emscripten_has_asyncify() && SDL_GetHintBoolean(SDL_HINT_EMSCRIPTEN_ASYNCIFY, SDL_TRUE)) {
         /* give back control to browser for screen refresh */

--- a/src/video/emscripten/SDL_emscriptenframebuffer.c
+++ b/src/video/emscripten/SDL_emscriptenframebuffer.c
@@ -59,7 +59,8 @@ int Emscripten_CreateWindowFramebuffer(_THIS, SDL_Window * window, Uint32 * form
     return 0;
 }
 
-static void Emscripten_UpdateWindowFramebufferWorker(SDL_Surface *surface)
+static void
+Emscripten_UpdateWindowFramebufferWorker(SDL_Surface* surface)
 {
     EM_ASM_INT({
         var w = $0;

--- a/src/video/emscripten/SDL_emscriptenmouse.c
+++ b/src/video/emscripten/SDL_emscriptenmouse.c
@@ -63,7 +63,8 @@ Emscripten_CreateDefaultCursor()
     return Emscripten_CreateCursorFromString("default", SDL_FALSE);
 }
 
-static const char *Emscripten_GetCursorUrl(int w, int h, int hot_x, int hot_y, int pixels)
+static const char*
+Emscripten_GetCursorUrl(int w, int h, int hot_x, int hot_y, void* pixels)
 {
     return (const char *)EM_ASM_INT({
         var w = $0;
@@ -137,7 +138,7 @@ Emscripten_CreateCursor(SDL_Surface* surface, int hot_x, int hot_y)
             conv_surf->pixels
         );
     } else {
-        cursor_url = emscripten_sync_run_in_main_runtime_thread(
+        cursor_url = (const char *)emscripten_sync_run_in_main_runtime_thread(
             EM_FUNC_SIG_IIIIIII,
             Emscripten_GetCursorUrl,
             surface->w,

--- a/src/video/emscripten/SDL_emscriptenmouse.c
+++ b/src/video/emscripten/SDL_emscriptenmouse.c
@@ -230,7 +230,7 @@ Emscripten_ShowCursor(SDL_Cursor* cursor)
             curdata = (Emscripten_CursorData *) cursor->driverdata;
 
             if(curdata->system_cursor) {
-                MAIN_THREAD_EM_ASM_INT({
+                MAIN_THREAD_EM_ASM({
                     if (Module['canvas']) {
                         Module['canvas'].style['cursor'] = UTF8ToString($0);
                     }
@@ -239,7 +239,7 @@ Emscripten_ShowCursor(SDL_Cursor* cursor)
             }
         }
         else {
-            MAIN_THREAD_EM_ASM_INT(
+            MAIN_THREAD_EM_ASM(
                 if (Module['canvas']) {
                     Module['canvas'].style['cursor'] = 'none';
                 }

--- a/src/video/emscripten/SDL_emscriptenmouse.c
+++ b/src/video/emscripten/SDL_emscriptenmouse.c
@@ -235,7 +235,6 @@ Emscripten_ShowCursor(SDL_Cursor* cursor)
                     if (Module['canvas']) {
                         Module['canvas'].style['cursor'] = UTF8ToString($0);
                     }
-                    return 0;
                 }, curdata->system_cursor);
             }
         }

--- a/src/video/emscripten/SDL_emscriptenmouse.c
+++ b/src/video/emscripten/SDL_emscriptenmouse.c
@@ -24,6 +24,7 @@
 
 #include <emscripten/emscripten.h>
 #include <emscripten/html5.h>
+#include <emscripten/threading.h>
 
 #include "SDL_emscriptenmouse.h"
 #include "SDL_emscriptenvideo.h"
@@ -62,19 +63,9 @@ Emscripten_CreateDefaultCursor()
     return Emscripten_CreateCursorFromString("default", SDL_FALSE);
 }
 
-static SDL_Cursor*
-Emscripten_CreateCursor(SDL_Surface* surface, int hot_x, int hot_y)
+static const char *Emscripten_GetCursorUrl(int w, int h, int hot_x, int hot_y, int pixels)
 {
-    const char *cursor_url = NULL;
-    SDL_Surface *conv_surf;
-
-    conv_surf = SDL_ConvertSurfaceFormat(surface, SDL_PIXELFORMAT_ABGR8888, 0);
-
-    if (!conv_surf) {
-        return NULL;
-    }
-
-    cursor_url = (const char *)EM_ASM_INT({
+    return (const char *)EM_ASM_INT({
         var w = $0;
         var h = $1;
         var hot_x = $2;
@@ -122,7 +113,40 @@ Emscripten_CreateCursor(SDL_Surface* surface, int hot_x, int hot_y)
         stringToUTF8(url, urlBuf, url.length + 1);
 
         return urlBuf;
-    }, surface->w, surface->h, hot_x, hot_y, conv_surf->pixels);
+    }, w, h, hot_x, hot_y, pixels);
+}
+
+static SDL_Cursor*
+Emscripten_CreateCursor(SDL_Surface* surface, int hot_x, int hot_y)
+{
+    const char *cursor_url = NULL;
+    SDL_Surface *conv_surf;
+
+    conv_surf = SDL_ConvertSurfaceFormat(surface, SDL_PIXELFORMAT_ABGR8888, 0);
+
+    if (!conv_surf) {
+        return NULL;
+    }
+
+    if (emscripten_is_main_runtime_thread()) {
+        cursor_url = Emscripten_GetCursorUrl(
+            surface->w,
+            surface->h,
+            hot_x,
+            hot_y,
+            conv_surf->pixels
+        );
+    } else {
+        cursor_url = emscripten_sync_run_in_main_runtime_thread(
+            EM_FUNC_SIG_IIIIIII,
+            Emscripten_GetCursorUrl,
+            surface->w,
+            surface->h,
+            hot_x,
+            hot_y,
+            conv_surf->pixels
+        );
+    }
 
     SDL_FreeSurface(conv_surf);
 
@@ -206,7 +230,7 @@ Emscripten_ShowCursor(SDL_Cursor* cursor)
             curdata = (Emscripten_CursorData *) cursor->driverdata;
 
             if(curdata->system_cursor) {
-                EM_ASM_INT({
+                MAIN_THREAD_EM_ASM_INT({
                     if (Module['canvas']) {
                         Module['canvas'].style['cursor'] = UTF8ToString($0);
                     }
@@ -215,7 +239,7 @@ Emscripten_ShowCursor(SDL_Cursor* cursor)
             }
         }
         else {
-            EM_ASM(
+            MAIN_THREAD_EM_ASM_INT(
                 if (Module['canvas']) {
                     Module['canvas'].style['cursor'] = 'none';
                 }


### PR DESCRIPTION
## Description

This PR uses new APIs added in [emscripten-core/emscripten#9336](https://github.com/emscripten-core/emscripten/pull/9336) to improve compatibility with USE_PTHREADS=1.

Original PR: https://github.com/emscripten-ports/SDL2/pull/127
By: @jakogut
Reviewed by: @Daft-Freak

This fix enables me to compile an executable using `-s USE_PTHREADS=1 -s USE_SDL=2` and not get the following error in the chromuim debug console
```
Uncought TypeError: Cannot read properties of undefined (reading 'CreateImageData')
```
![Uncought TypeError CreateImageData](https://user-images.githubusercontent.com/9076163/155602571-05b502e0-2ee9-482b-b4dd-90a608a6ee75.png)

With the current patch applied the [InfiniSim Simulator](https://github.com/InfiniTimeOrg/InfiniSim) works :tada: 

![InfiniSim wasm working](https://user-images.githubusercontent.com/9076163/155602646-0a42919c-fb89-4a5d-96a3-dc6a53a970a5.png)



 

## Existing Issue(s)
- https://github.com/emscripten-core/emscripten/issues/6009