### PR TITLE
Support repeating textures with SDL_RenderGeometry

### DIFF
--- a/include/SDL_render.h
+++ b/include/SDL_render.h
@@ -136,6 +136,15 @@ typedef enum
 } SDL_RendererFlip;
 
 /**
+ * The wrapping mode for a texture.
+ */
+typedef enum
+{
+    SDL_WRAPMODE_CLAMP, /**< Clamp */
+    SDL_WRAPMODE_REPEAT /**< Repeat */
+} SDL_WrapMode;
+
+/**
  * A structure representing rendering state
  */
 struct SDL_Renderer;
@@ -553,6 +562,35 @@ extern DECLSPEC int SDLCALL SDL_SetTextureUserData(SDL_Texture * texture,
  * \sa SDL_SetTextureUserData
  */
 extern DECLSPEC void * SDLCALL SDL_GetTextureUserData(SDL_Texture * texture);
+
+/**
+ * Set the wrap mode used for texture wrapping operations.
+ *
+ * \param texture the texture to update.
+ * \param wrapMode the SDL_WrapMode to use for texture wrapping.
+ * \returns 0 on success, or -1 if the texture is not valid or the wrap mode is
+ *          unsupported.
+ *
+ * \since This function is available since SDL 2.0.22.
+ *
+ * \sa SDL_GetTextureWrapMode
+ */
+extern DECLSPEC int SDLCALL SDL_SetTextureWrapMode(SDL_Texture * texture,
+                                                   SDL_WrapMode wrapMode);
+
+/**
+ * Get the wrap mode used for texture wrapping operations.
+ *
+ * \param texture the texture to query.
+ * \param wrapMode a pointer filled in with the current wrap mode.
+ * \return 0 on success, or -1 if the texture is not valid.
+ *
+ * \since This function is available since SDL 2.0.22.
+ *
+ * \sa SDL_SetTextureWrapMode
+ */
+extern DECLSPEC int SDLCALL SDL_GetTextureWrapMode(SDL_Texture * texture,
+                                                   SDL_WrapMode * wrapMode);
 
 /**
  * Update the given texture rectangle with new pixel data.
@@ -1002,29 +1040,29 @@ extern DECLSPEC void SDLCALL SDL_RenderGetScale(SDL_Renderer * renderer,
  * \sa SDL_RenderGetLogicalSize
  * \sa SDL_RenderSetLogicalSize
  */
-extern DECLSPEC void SDLCALL SDL_RenderWindowToLogical(SDL_Renderer * renderer, 
-                                                            int windowX, int windowY, 
+extern DECLSPEC void SDLCALL SDL_RenderWindowToLogical(SDL_Renderer * renderer,
+                                                            int windowX, int windowY,
                                                             float *logicalX, float *logicalY);
-                                                  
+
                                                   /**
  * Get real coordinates of point in window when given logical coordinates of point in renderer.
  * Logical coordinates will differ from real coordinates when render is scaled and logical renderer size set
- * 
+ *
  * \param renderer the renderer from which the window coordinates should be calculated
  * \param logicalX the logical x coordinate
  * \param logicalY the logical y coordinate
  * \param windowX the pointer filled with the real X coordinate in the window
  * \param windowY the pointer filled with the real Y coordinate in the window
- 
- *  
+
+ *
  * \since This function is available since SDL 2.0.18.
- * 
+ *
  * \sa SDL_RenderGetScale
  * \sa SDL_RenderSetScale
  * \sa SDL_RenderGetLogicalSize
  * \sa SDL_RenderSetLogicalSize
  */
-extern DECLSPEC void SDLCALL SDL_RenderLogicalToWindow(SDL_Renderer * renderer, 
+extern DECLSPEC void SDLCALL SDL_RenderLogicalToWindow(SDL_Renderer * renderer,
                                                             float logicalX, float logicalY,
                                                             int *windowX, int *windowY);
 

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -857,3 +857,5 @@
 #define SDL_PremultiplyAlpha SDL_PremultiplyAlpha_REAL
 #define SDL_AndroidSendMessage SDL_AndroidSendMessage_REAL
 #define SDL_GetTouchName SDL_GetTouchName_REAL
+#define SDL_SetTextureWrapMode SDL_SetTextureWrapMode_REAL
+#define SDL_GetTextureWrapMode SDL_GetTextureWrapMode_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -928,3 +928,5 @@ SDL_DYNAPI_PROC(int,SDL_PremultiplyAlpha,(int a, int b, Uint32 c, const void *d,
 SDL_DYNAPI_PROC(int,SDL_AndroidSendMessage,(Uint32 a, int b),(a,b),return)
 #endif
 SDL_DYNAPI_PROC(const char*,SDL_GetTouchName,(int a),(a),return)
+SDL_DYNAPI_PROC(int,SDL_SetTextureWrapMode,(SDL_Texture *a, SDL_WrapMode b),(a,b),return)
+SDL_DYNAPI_PROC(int,SDL_GetTextureWrapMode,(SDL_Texture *a, SDL_WrapMode *b),(a,b),return)

--- a/src/render/SDL_sysrender.h
+++ b/src/render/SDL_sysrender.h
@@ -43,6 +43,7 @@ struct SDL_Texture
     int modMode;                /**< The texture modulation mode */
     SDL_BlendMode blendMode;    /**< The texture blend mode */
     SDL_ScaleMode scaleMode;    /**< The texture scale mode */
+    SDL_WrapMode wrapMode;      /**< The texture wrap mode */
     SDL_Color color;            /**< Texture modulation values */
 
     SDL_Renderer *renderer;
@@ -168,6 +169,8 @@ struct SDL_Renderer
                         const SDL_Rect * rect, void **pixels, int *pitch);
     void (*UnlockTexture) (SDL_Renderer * renderer, SDL_Texture * texture);
     void (*SetTextureScaleMode) (SDL_Renderer * renderer, SDL_Texture * texture, SDL_ScaleMode scaleMode);
+    void (*SetTextureWrapMode) (SDL_Renderer * renderer, SDL_Texture * texture, SDL_WrapMode wrapMode);
+    SDL_bool (*SupportsWrapMode)(SDL_Renderer * renderer, SDL_WrapMode wrapMode);
     int (*SetRenderTarget) (SDL_Renderer * renderer, SDL_Texture * texture);
     int (*RenderReadPixels) (SDL_Renderer * renderer, const SDL_Rect * rect,
                              Uint32 format, void * pixels, int pitch);

--- a/src/render/opengl/SDL_render_gl.c
+++ b/src/render/opengl/SDL_render_gl.c
@@ -30,8 +30,8 @@
 #include <OpenGL/OpenGL.h>
 #endif
 
-/* To prevent unnecessary window recreation, 
- * these should match the defaults selected in SDL_GL_ResetAttributes 
+/* To prevent unnecessary window recreation,
+ * these should match the defaults selected in SDL_GL_ResetAttributes
  */
 
 #define RENDERER_CONTEXT_MAJOR 2
@@ -879,6 +879,37 @@ GL_SetTextureScaleMode(SDL_Renderer * renderer, SDL_Texture * texture, SDL_Scale
         renderdata->glTexParameteri(textype, GL_TEXTURE_MAG_FILTER, glScaleMode);
     }
 #endif
+}
+
+static GLint
+GL_ConvertWrapMode(SDL_WrapMode wrapMode)
+{
+    switch (wrapMode) {
+    case SDL_WRAPMODE_CLAMP:
+        return GL_CLAMP_TO_EDGE;
+    case SDL_WRAPMODE_REPEAT:
+        return GL_REPEAT;
+    }
+    return GL_INVALID_VALUE;
+}
+
+static SDL_bool
+GL_SupportsWrapMode(SDL_Renderer * renderer, SDL_WrapMode wrapMode)
+{
+    return GL_ConvertWrapMode(wrapMode) != GL_INVALID_VALUE;
+}
+
+static void
+GL_SetTextureWrapMode(SDL_Renderer * renderer, SDL_Texture * texture, SDL_WrapMode wrapMode)
+{
+    GL_RenderData *renderdata = (GL_RenderData *) renderer->driverdata;
+    const GLenum textype = renderdata->textype;
+    GL_TextureData *data = (GL_TextureData *) texture->driverdata;
+    GLint glWrapMode = GL_ConvertWrapMode(wrapMode);
+
+    renderdata->glBindTexture(textype, data->texture);
+    renderdata->glTexParameteri(textype, GL_TEXTURE_WRAP_S, glWrapMode);
+    renderdata->glTexParameteri(textype, GL_TEXTURE_WRAP_T, glWrapMode);
 }
 
 static int
@@ -1771,6 +1802,8 @@ GL_CreateRenderer(SDL_Window * window, Uint32 flags)
     renderer->LockTexture = GL_LockTexture;
     renderer->UnlockTexture = GL_UnlockTexture;
     renderer->SetTextureScaleMode = GL_SetTextureScaleMode;
+    renderer->SetTextureWrapMode = GL_SetTextureWrapMode;
+    renderer->SupportsWrapMode = GL_SupportsWrapMode;
     renderer->SetRenderTarget = GL_SetRenderTarget;
     renderer->QueueSetViewport = GL_QueueSetViewport;
     renderer->QueueSetDrawColor = GL_QueueSetViewport;  /* SetViewport and SetDrawColor are (currently) no-ops. */


### PR DESCRIPTION
This pull request is in a draft state to solicit feedback from the maintainers on the overall design.

## Description

This pull request would allow `SDL_RenderGeometry` to draw repeating texture patterns. The default clamped behavior is unchanged, but the user can enable repetition with `SDL_SetTextureWrapMode(texture, SDL_WRAPMODE_REPEAT)`.

My editor also automatically trimmed some trailing white space in the files I updated.

### TODO

- [ ] Decide if wrap mode should be per-axis.
- [ ] Add a test for exercising the new functionality.
- [ ] Add wrap mode support to the renderers I am capable of testing (probably GLES and software).
- [ ] Beef up documentation so it's clear that wrap mode only applies to `SDL_RenderGeometry` for now.

## Existing Issue(s)

This would partially implement #4820.
