### PR TITLE
x11: add support for precision/pixel scrolling

### DIFF
--- a/src/video/x11/SDL_x11xinput2.c
+++ b/src/video/x11/SDL_x11xinput2.c
@@ -28,9 +28,11 @@
 #include "../../events/SDL_touch_c.h"
 
 #define MAX_AXIS 16
+#define MAX_SCROLLABLE_DEVICES 8
 
 #if SDL_VIDEO_DRIVER_X11_XINPUT2
 static int xinput2_initialized = 0;
+static int xinput2_precise_scroll_supported = 0;
 
 #if SDL_VIDEO_DRIVER_X11_XINPUT2_SUPPORTS_MULTITOUCH
 static int xinput2_multitouch_supported = 0;
@@ -41,6 +43,18 @@ static int xinput2_multitouch_supported = 0;
  * to know that the event came from
  * this extension */
 static int xinput2_opcode;
+
+typedef struct {
+    /* -1 if not present */
+    int source_id;
+    /* 0 = horizontal, 1 = vertical */
+    int axis_id[2];
+    double prev_coord[2];
+    /* specifies the amount of coordinate change to scroll one line */
+    double line_unit[2];
+} scrollable_device;
+
+static scrollable_device scrollable_devices[MAX_SCROLLABLE_DEVICES];
 
 static void parse_valuators(const double *input_values, const unsigned char *mask,int mask_len,
                             double *output_values,int output_values_len) {
@@ -121,7 +135,7 @@ X11_InitXinput2(_THIS)
     int version = 0;
     XIEventMask eventmask;
     unsigned char mask[3] = { 0,0,0 };
-    int event, err;
+    int event, err, i;
 
     /*
     * Initialize XInput 2
@@ -144,6 +158,59 @@ X11_InitXinput2(_THIS)
     }
 
     xinput2_initialized = 1;
+    xinput2_precise_scroll_supported = xinput2_version_atleast(version, 2, 1);
+
+    SDL_memset(scrollable_devices, 0, sizeof(scrollable_devices));
+    for (i = 0; i<MAX_SCROLLABLE_DEVICES; i++) {
+        scrollable_devices[i].source_id = -1;
+    }
+
+    if (xinput2_precise_scroll_supported) {
+        XIDeviceInfo *info;
+        int ndevices,i,j,k,dev_i=0;
+
+        info = X11_XIQueryDevice(data->display, XIAllDevices, &ndevices);
+
+        /* find scroll classes */
+        for (i = 0; i < ndevices && dev_i < MAX_SCROLLABLE_DEVICES; i++) {
+            scroll_device *sd = scrollable_devices[dev_i];
+            XIDeviceInfo *dev = &info[i];
+            for (j = 0; j < dev->num_classes; j++) {
+                XIAnyClassInfo *class = dev->classes[j];
+                XIScrollClassInfo *s = (XIScrollClassInfo*)class;
+
+                if (class->type != XIScrollClass)
+                    continue;
+
+                int dir = s->scroll_type == XIScrollTypeVertical;
+                sd->source_id = s->sourceid;
+                sd->axis_id[dir] = s->number;
+                sd->line_unit[dir] = s->increment;
+            }
+
+            if (scrollable_devices[dev_i].source_id == -1)
+                continue;
+
+            /* find valuator info for each scroll class */
+            for (j = 0; j < dev->num_classes; j++) {
+                XIAnyClassInfo *class = dev->classes[j];
+                XIValuatorClassInfo *v = (XIValuatorClassInfo*)class;
+
+                if (class->type != XIValuatorClass)
+                    continue;
+
+                for (k=0; k<2; k++) {
+                    if (sd->axis_id[k] == v->number) {
+                        sd->prev_coord[k] = v->value;
+                    }
+                }
+            }
+
+            dev_i++;
+        }
+
+        X11_XIFreeDeviceInfo(info);
+    }
 
 #if SDL_VIDEO_DRIVER_X11_XINPUT2_SUPPORTS_MULTITOUCH  /* Multitouch needs XInput 2.2 */
     xinput2_multitouch_supported = xinput2_version_atleast(version, 2, 2);
@@ -155,6 +222,7 @@ X11_InitXinput2(_THIS)
     eventmask.mask = mask;
 
     XISetMask(mask, XI_RawMotion);
+    XISetMask(mask, XI_Motion);
     XISetMask(mask, XI_RawButtonPress);
     XISetMask(mask, XI_RawButtonRelease);
 
@@ -205,11 +273,39 @@ X11_HandleXinput2Event(SDL_VideoData *videodata,XGenericEventCookie *cookie)
             videodata->global_mouse_changed = SDL_TRUE;
             break;
 
-#if SDL_VIDEO_DRIVER_X11_XINPUT2_SUPPORTS_MULTITOUCH
-         /* With multitouch, register to receive XI_Motion (which desctivates MotionNotify),
-          * so that we can distinguish real mouse motions from synthetic one.  */
         case XI_Motion: {
             const XIDeviceEvent *xev = (const XIDeviceEvent *) cookie->data;
+            SDL_Mouse *mouse = SDL_GetMouse();
+            int i,j,k;
+
+            /* detect scrolling */
+            for (i=0; i<MAX_SCROLLABLE_DEVICES; i++) {
+                scrollable_device *sd = &scrollable_devices[i];
+                if (xev->sourceid == sd->source_id) {
+                    int values_i=0;
+                    for (j=0; j<xev->valuators.mask_len*8; j++) {
+                        if (!XIMaskIsSet(xev->valuators.mask, j))
+                            continue;
+
+                        for (k = 0; k<2; k++) {
+                            if (sd->axis_id[k] == j) {
+                                double current_val = xev->valuators.values[values_i];
+                                double delta = (sd->prev_coord[k] - current_val)/sd->line_unit[k];
+                                double x = k == 0 ? delta : 0;
+                                double y = k == 1 ? delta : 0;
+                                SDL_SendMouseWheel(mouse->focus,mouse->mouseID, x, y, SDL_MOUSEWHEEL_NORMAL);
+                                sd->prev_coord[k] = current_val;
+                            }
+                        }
+
+                        values_i++;
+                    }
+                }
+            }
+
+#if SDL_VIDEO_DRIVER_X11_XINPUT2_SUPPORTS_MULTITOUCH
+            /* With multitouch, register to receive XI_Motion (which desctivates MotionNotify),
+            * so that we can distinguish real mouse motions from synthetic one.  */
             int pointer_emulated = (xev->flags & XIPointerEmulated);
 
             if (! pointer_emulated) {
@@ -221,10 +317,12 @@ X11_HandleXinput2Event(SDL_VideoData *videodata,XGenericEventCookie *cookie)
                     }
                 }
             }
+#endif
             return 1;
             }
             break;
 
+#if SDL_VIDEO_DRIVER_X11_XINPUT2_SUPPORTS_MULTITOUCH
         case XI_TouchBegin: {
             const XIDeviceEvent *xev = (const XIDeviceEvent *) cookie->data;
             float x, y;


### PR DESCRIPTION

This patch adds support for pixel scrolling for the x11 backend for xinput2.
## Description
This patch will automatically detect precision scroll devices using xinput2, allowing for SDL applications to detect scrolling changes smaller than one line, allowing for smooth scrolling on devices with touchpads, trackpoints, and trackballs.

There are a few things about this patch I'm not certain about:

* Should there be a define to enable this? It requires xinput 2.1 (2011) to compile.
* Currently the state to track the xinput devices is allocated statically, with a maximum of 8 devices.
  * Should this automatically allocate for the number of devices present? I don't have a good feel for SDL2's stance on allocation.
  * Should this state be stored somewhere else? I couldn't find a better place to put it, as I'm not very familiar with the codebase, but maybe it would be better off in the private x11 data struct or the private mouse data (if there is any for mice, that is).

## Existing Issue(s)
When precision scrolling was originally added to SDL, the X11 backend was left out:

https://github.com/libsdl-org/SDL/issues/1267
On 2016-06-01 16:12:29 +0000, Martijn Courteaux wrote:
> Note that this doesn't fix it for X11. I'm a X11 noob, but I think that SDL doesn't use xinput2, since @r.kreis said that.
