### PR TITLE
Add SDL_GetDisplayDPI implementation on Emscripten

### DIFF
--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -43,6 +43,7 @@ static int Emscripten_VideoInit(_THIS);
 static int Emscripten_SetDisplayMode(_THIS, SDL_VideoDisplay * display, SDL_DisplayMode * mode);
 static void Emscripten_VideoQuit(_THIS);
 static int Emscripten_GetDisplayUsableBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect);
+static int Emscripten_GetDisplayDPI(_THIS, SDL_VideoDisplay * display, float * ddpi, float * hdpi, float * vdpi);
 
 static int Emscripten_CreateWindow(_THIS, SDL_Window * window);
 static void Emscripten_SetWindowSize(_THIS, SDL_Window * window);
@@ -82,6 +83,7 @@ Emscripten_CreateDevice(int devindex)
     device->VideoInit = Emscripten_VideoInit;
     device->VideoQuit = Emscripten_VideoQuit;
     device->GetDisplayUsableBounds = Emscripten_GetDisplayUsableBounds;
+    device->GetDisplayDPI = Emscripten_GetDisplayDPI;
     device->SetDisplayMode = Emscripten_SetDisplayMode;
 
 
@@ -179,6 +181,27 @@ Emscripten_GetDisplayUsableBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * 
             return window.innerHeight;
         });
     }
+    return 0;
+}
+
+static int
+Emscripten_GetDisplayDPI(_THIS, SDL_VideoDisplay * display, float * ddpi_out, float * hdpi_out, float * vdpi_out)
+{
+    const float dpi_reference = 96.0f;
+    float dpi;
+
+    dpi = (float)emscripten_get_device_pixel_ratio() * dpi_reference;
+
+    if (ddpi_out) {
+        *ddpi_out = dpi;
+    }
+    if (hdpi_out) {
+        *hdpi_out = dpi;
+    }
+    if (vdpi_out) {
+        *vdpi_out = dpi;
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
## Description
Adds support for SDL_GetDisplayDPI on Emscripten.

## Existing Issue(s)
As stated in issue #5381.
