### PR TITLE
Add SDL_HINT_WINDOWS_MINIMIZABLE_FULLSCREEN

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -1626,6 +1626,17 @@ extern "C" {
 #define SDL_HINT_WINDOWS_INTRESOURCE_ICON_SMALL "SDL_WINDOWS_INTRESOURCE_ICON_SMALL"
 
 /**
+ *  \brief Tell SDL to include WS_MINIMIZEBOX in the fullscreen window style.
+ *         This makes it possible to minimize fullscreen windows, e.g.
+ *         using Win+Down or clicking the window name in the taskbar.
+ *
+ * The variable can be set to the following values:
+ *   "0"       - Don't include WS_MINIMIZEBOX. (default)
+ *   "1"       - Do include WS_MINIMIZEBOX.
+ */
+#define SDL_HINT_WINDOWS_MINIMIZABLE_FULLSCREEN "SDL_WINDOWS_MINIMIZABLE_FULLSCREEN"
+
+/**
  *  \brief Tell SDL not to generate window-close events for Alt+F4 on Windows.
  *
  * The variable can be set to the following values:

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -60,6 +60,7 @@ static ATOM SDL_HelperWindowClass = 0;
 
 #define STYLE_BASIC         (WS_CLIPSIBLINGS | WS_CLIPCHILDREN)
 #define STYLE_FULLSCREEN    (WS_POPUP)
+#define STYLE_MINIMIZABLE_FULLSCREEN (WS_POPUP | WS_MINIMIZEBOX)
 #define STYLE_BORDERLESS    (WS_POPUP)
 #define STYLE_BORDERLESS_WINDOWED (WS_POPUP | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX)
 #define STYLE_NORMAL        (WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX)
@@ -72,7 +73,11 @@ GetWindowStyle(SDL_Window * window)
     DWORD style = 0;
 
     if (window->flags & SDL_WINDOW_FULLSCREEN) {
-        style |= STYLE_FULLSCREEN;
+        if (SDL_GetHintBoolean("SDL_HINT_WINDOWS_MINIMIZABLE_FULLSCREEN", SDL_FALSE)) {
+            style |= STYLE_MINIMIZABLE_FULLSCREEN;
+        } else {
+            style |= STYLE_FULLSCREEN;
+        }
     } else {
         if (window->flags & SDL_WINDOW_BORDERLESS) {
             /* SDL 2.1:

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -73,7 +73,7 @@ GetWindowStyle(SDL_Window * window)
     DWORD style = 0;
 
     if (window->flags & SDL_WINDOW_FULLSCREEN) {
-        if (SDL_GetHintBoolean("SDL_HINT_WINDOWS_MINIMIZABLE_FULLSCREEN", SDL_FALSE)) {
+        if (SDL_GetHintBoolean(SDL_HINT_WINDOWS_MINIMIZABLE_FULLSCREEN, SDL_FALSE)) {
             style |= STYLE_MINIMIZABLE_FULLSCREEN;
         } else {
             style |= STYLE_FULLSCREEN;


### PR DESCRIPTION
This makes it possible to minimize fullscreen windows, e.g. using Win+Down or clicking the window name in the taskbar.