### PR TITLE
Make SDL_VIDEO_OPENGL_EGL optional on Android

### DIFF
--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -1009,6 +1009,7 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeSurfaceChanged)(JNIEnv *env, j
 {
     SDL_LockMutex(Android_ActivityMutex);
 
+#if SDL_VIDEO_OPENGL_EGL
     if (Android_Window)
     {
         SDL_VideoDevice *_this = SDL_GetVideoDevice();
@@ -1021,6 +1022,7 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeSurfaceChanged)(JNIEnv *env, j
 
         /* GL Context handling is done in the event loop because this function is run from the Java thread */
     }
+#endif
 
     SDL_UnlockMutex(Android_ActivityMutex);
 }
@@ -1051,10 +1053,12 @@ retry:
             }
         }
 
+#if SDL_VIDEO_OPENGL_EGL
         if (data->egl_surface != EGL_NO_SURFACE) {
             SDL_EGL_DestroySurface(_this, data->egl_surface);
             data->egl_surface = EGL_NO_SURFACE;
         }
+#endif
 
         if (data->native_window) {
             ANativeWindow_release(data->native_window);

--- a/src/video/android/SDL_androidevents.c
+++ b/src/video/android/SDL_androidevents.c
@@ -67,6 +67,7 @@ SDL_NumberOfEvents(Uint32 type)
     return SDL_PeepEvents(NULL, 0, SDL_PEEKEVENT, type, type);
 }
 
+#if SDL_VIDEO_OPENGL_EGL
 static void
 android_egl_context_restore(SDL_Window *window)
 {
@@ -96,7 +97,7 @@ android_egl_context_backup(SDL_Window *window)
         data->backup_done = 1;
     }
 }
-
+#endif
 
 /*
  * Android_ResumeSem and Android_PauseSem are signaled from Java_org_libsdl_app_SDLActivity_nativePause and Java_org_libsdl_app_SDLActivity_nativeResume
@@ -113,12 +114,14 @@ Android_PumpEvents_Blocking(_THIS)
     if (videodata->isPaused) {
         SDL_bool isContextExternal = SDL_IsVideoContextExternal();
 
+#if SDL_VIDEO_OPENGL_EGL
         /* Make sure this is the last thing we do before pausing */
         if (!isContextExternal) {
             SDL_LockMutex(Android_ActivityMutex);
             android_egl_context_backup(Android_Window);
             SDL_UnlockMutex(Android_ActivityMutex);
         }
+#endif
 
         ANDROIDAUDIO_PauseDevices();
         openslES_PauseDevices();
@@ -138,11 +141,13 @@ Android_PumpEvents_Blocking(_THIS)
             aaudio_ResumeDevices();
 
             /* Restore the GL Context from here, as this operation is thread dependent */
+#if SDL_VIDEO_OPENGL_EGL
             if (!isContextExternal && !SDL_HasEvent(SDL_QUIT)) {
                 SDL_LockMutex(Android_ActivityMutex);
                 android_egl_context_restore(Android_Window);
                 SDL_UnlockMutex(Android_ActivityMutex);
             }
+#endif
 
             /* Make sure SW Keyboard is restored when an app becomes foreground */
             if (SDL_IsTextInputActive()) {
@@ -188,11 +193,13 @@ Android_PumpEvents_NonBlocking(_THIS)
         SDL_bool isContextExternal = SDL_IsVideoContextExternal();
         if (backup_context) {
 
+#if SDL_VIDEO_OPENGL_EGL
             if (!isContextExternal) {
                 SDL_LockMutex(Android_ActivityMutex);
                 android_egl_context_backup(Android_Window);
                 SDL_UnlockMutex(Android_ActivityMutex);
             }
+#endif
 
             if (videodata->pauseAudio) {
                 ANDROIDAUDIO_PauseDevices();
@@ -219,12 +226,14 @@ Android_PumpEvents_NonBlocking(_THIS)
                 aaudio_ResumeDevices();
             }
 
+#if SDL_VIDEO_OPENGL_EGL
             /* Restore the GL Context from here, as this operation is thread dependent */
             if (!isContextExternal && !SDL_HasEvent(SDL_QUIT)) {
                 SDL_LockMutex(Android_ActivityMutex);
                 android_egl_context_restore(Android_Window);
                 SDL_UnlockMutex(Android_ActivityMutex);
             }
+#endif
 
             /* Make sure SW Keyboard is restored when an app becomes foreground */
             if (SDL_IsTextInputActive()) {

--- a/src/video/android/SDL_androidgl.c
+++ b/src/video/android/SDL_androidgl.c
@@ -20,7 +20,7 @@
 */
 #include "../../SDL_internal.h"
 
-#if SDL_VIDEO_DRIVER_ANDROID
+#if SDL_VIDEO_DRIVER_ANDROID && SDL_VIDEO_OPENGL_EGL
 
 /* Android SDL video driver implementation */
 

--- a/src/video/android/SDL_androidvideo.c
+++ b/src/video/android/SDL_androidvideo.c
@@ -128,6 +128,7 @@ Android_CreateDevice(int devindex)
     device->free = Android_DeleteDevice;
 
     /* GL pointers */
+#if SDL_VIDEO_OPENGL_EGL
     device->GL_LoadLibrary = Android_GLES_LoadLibrary;
     device->GL_GetProcAddress = Android_GLES_GetProcAddress;
     device->GL_UnloadLibrary = Android_GLES_UnloadLibrary;
@@ -137,6 +138,7 @@ Android_CreateDevice(int devindex)
     device->GL_GetSwapInterval = Android_GLES_GetSwapInterval;
     device->GL_SwapWindow = Android_GLES_SwapWindow;
     device->GL_DeleteContext = Android_GLES_DeleteContext;
+#endif
 
 #if SDL_VIDEO_VULKAN
     device->Vulkan_LoadLibrary = Android_Vulkan_LoadLibrary;

--- a/src/video/android/SDL_androidwindow.c
+++ b/src/video/android/SDL_androidwindow.c
@@ -81,6 +81,7 @@ Android_CreateWindow(_THIS, SDL_Window * window)
 
     /* Do not create EGLSurface for Vulkan window since it will then make the window
        incompatible with vkCreateAndroidSurfaceKHR */
+#if SDL_VIDEO_OPENGL_EGL
     if ((window->flags & SDL_WINDOW_OPENGL) != 0) {
         data->egl_surface = SDL_EGL_CreateSurface(_this, (NativeWindowType) data->native_window);
 
@@ -91,6 +92,7 @@ Android_CreateWindow(_THIS, SDL_Window * window)
             goto endfunction;
         }
     }
+#endif
 
     window->driverdata = data;
     Android_Window = window;
@@ -175,9 +177,13 @@ Android_DestroyWindow(_THIS, SDL_Window *window)
 
         if (window->driverdata) {
             SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
+
+#if SDL_VIDEO_OPENGL_EGL
             if (data->egl_surface != EGL_NO_SURFACE) {
                 SDL_EGL_DestroySurface(_this, data->egl_surface);
             }
+#endif
+
             if (data->native_window) {
                 ANativeWindow_release(data->native_window);
             }
@@ -198,7 +204,11 @@ Android_GetWindowWMInfo(_THIS, SDL_Window *window, SDL_SysWMinfo *info)
         info->version.minor == SDL_MINOR_VERSION) {
         info->subsystem = SDL_SYSWM_ANDROID;
         info->info.android.window = data->native_window;
+
+#if SDL_VIDEO_OPENGL_EGL
         info->info.android.surface = data->egl_surface;
+#endif
+
         return SDL_TRUE;
     } else {
         SDL_SetError("Application not compiled with SDL %d.%d",

--- a/src/video/android/SDL_androidwindow.h
+++ b/src/video/android/SDL_androidwindow.h
@@ -37,8 +37,10 @@ extern SDL_Window *Android_Window;
 
 typedef struct
 {
+#if SDL_VIDEO_OPENGL_EGL
     EGLSurface egl_surface;
     EGLContext egl_context; /* We use this to preserve the context when losing focus */
+#endif
     SDL_bool   backup_done;
     ANativeWindow *native_window;
     


### PR DESCRIPTION
I'm currently using SDL for windowing/input only with a custom vulkan renderer.
Building with: `-DSDL_RENDER_DISABLED=ON -DSDL_OPENGLES=OFF`

SDL seems to always link to some GLES functionality which I'd like to avoid so I don't have to link against the OpenGL libraries.

These changes add `#if SDL_VIDEO_OPENGL_EGL` around the blocks referencing opengl functions.