### PR TITLE
SDL_endian.h: Apply endianess check for gcc/clang

### DIFF
--- a/include/SDL_endian.h
+++ b/include/SDL_endian.h
@@ -65,6 +65,15 @@ _m_prefetch(void *__P)
 #elif defined(__FreeBSD__) || defined(__NetBSD__)
 #include <sys/endian.h>
 #define SDL_BYTEORDER  BYTE_ORDER
+/* predefs from newer gcc and clang versions: */
+#elif defined(__ORDER_LITTLE_ENDIAN__) && defined(__ORDER_BIG_ENDIAN__) && defined(__BYTE_ORDER__)
+#if (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#define SDL_BYTEORDER   SDL_LIL_ENDIAN
+#elif (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#define SDL_BYTEORDER   SDL_BIG_ENDIAN
+#else
+#error Unsupported endianness
+#endif /**/
 #else
 #if defined(__hppa__) || \
     defined(__m68k__) || defined(mc68000) || defined(_M_M68K) || \


### PR DESCRIPTION
@sezero's patch on adding more checks for GCC and Clang compilers
https://github.com/libsdl-org/SDL_mixer/commit/02c94d7644faff05936f6bd51e1cef2f67dd863c

## Description
Resolves problem when byte order wasn't properly detected (at my case, on big-endian machine, SDL2's headers reported me little-endian order)

## Existing Issue(s)
https://github.com/libsdl-org/SDL_mixer/issues/374
