### PR TITLE
Incorrect assumption that mouse button is released when new window is allocated

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -374,7 +374,7 @@ WIN_CheckAsyncMouseRelease(SDL_WindowData *data)
     if (!(keyState & 0x8000)) {
         WIN_CheckWParamMouseButton(SDL_FALSE, mouseFlags, swapButtons, data, SDL_BUTTON_X2, 0);
     }
-    data->mouse_button_flags = 0;
+    data->mouse_button_flags = (WPARAM)-1;
 }
 
 static void

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -187,7 +187,7 @@ SetupWindowData(_THIS, SDL_Window * window, HWND hwnd, HWND parent, SDL_bool cre
     data->hinstance = (HINSTANCE) GetWindowLongPtr(hwnd, GWLP_HINSTANCE);
     data->created = created;
     data->high_surrogate = 0;
-    data->mouse_button_flags = 0;
+    data->mouse_button_flags = (WPARAM)-1;
     data->last_pointer_update = (LPARAM)-1;
     data->videodata = videodata;
     data->initializing = SDL_TRUE;


### PR DESCRIPTION
## Description
If a user creates a new window via tearing off a tab - as you would do in a browser, for instance - the mouse button is still held at this point.
Upon releasing the mouse button, an event was not thrown because the default state of mouse_button_flags is set to 0.
Setting the initial mouse_button_flags to an invalid state fixes this.

