### PR TITLE
Add Xbox Series X controller bluetooth profile

### DIFF
--- a/src/joystick/SDL_gamecontrollerdb.h
+++ b/src/joystick/SDL_gamecontrollerdb.h
@@ -804,6 +804,7 @@ static const char *s_ControllerMappings [] =
     "050000006964726f69643a636f6e0000,idroid:con,a:b1,b:b2,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b4,leftstick:b10,lefttrigger:b6,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:b7,rightx:a2,righty:a3,start:b9,x:b0,y:b3,",
     "03000000b50700001503000010010000,impact,a:b2,b:b3,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b4,leftstick:b10,lefttrigger:b5,leftx:a0,lefty:a1,rightshoulder:b6,rightstick:b11,righttrigger:b7,rightx:a3,righty:a2,start:b9,x:b0,y:b1,",
     "030000009b2800000300000001010000,raphnet.net 4nes4snes v1.5,a:b0,b:b4,back:b2,leftshoulder:b6,leftx:a0,lefty:a1,rightshoulder:b7,start:b3,x:b1,y:b5,",
+    "050000005e040000130b000009050000,Xbox Series X Controller,a:b0,b:b1,x:b3,y:b4,back:b10,guide:b12,start:b11,leftstick:b13,rightstick:b14,leftshoulder:b6,rightshoulder:b7,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,misc1:b15,leftx:a0,lefty:a1,rightx:a3,righty:a4,lefttrigger:a2,righttrigger:a5,",
 #endif
 #if defined(__ANDROID__)
     "05000000c82d000006500000ffff3f00,8BitDo M30 Gamepad,a:b0,b:b1,back:b4,guide:b17,leftshoulder:b9,lefttrigger:a5,leftx:a0,lefty:a1,rightshoulder:b10,righttrigger:a4,start:b6,x:b2,y:b3,hint:SDL_GAMECONTROLLER_USE_BUTTON_LABELS:=1,",


### PR DESCRIPTION
My Xbox Series X controller has a different guid then the existsing SDL entry which means the buttons are mappend wrong. 

## Description

My Xbox series X controller runs the latest firmware and the only difference is the last part of the guid:

Existing entry's guid: 050000005e040000130b000011050000
My guid:                    050000005e040000130b000009050000

This mapping requires a [kernel patch](https://github.com/jelly/linux/commit/4f00ccbac0f641fd34457567f3bad2bb9d86e853) to be applied as well as it fixes the mapping of some axes so they are correctly displayed in evemu-record. I haven't sent the patch upstream yet as it most likely will break the existing SDL entry and I would love to figure out what the difference is between the existing and my guid.

