### PR TITLE
Adjust gradle dependencies so build can position assets for APK

### DIFF
--- a/android-project/app/build.gradle
+++ b/android-project/app/build.gradle
@@ -35,6 +35,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    applicationVariants.all { variant ->
+        tasks["merge${variant.name.capitalize()}Assets"]
+            .dependsOn("externalNativeBuild${variant.name.capitalize()}")
+    }
     if (!project.hasProperty('EXCLUDE_NATIVE_LIBS')) {
         sourceSets.main {
             jniLibs.srcDir 'libs'


### PR DESCRIPTION
This change causes the `mergeDebugAssets` task to depend on the `externalNativeBuildDebug` task--and all similar tasks for any other build variants besides Debug will have similar dependencies.

We discovered recently in DevilutionX that the assets we created at build time weren't being included in the APK produced by CI. It seems the gradle task for merging assets runs before the CMake build, so the assets that were being generated by our build process weren't being included in the APK.