### PR TITLE
Fix "SDL_TRUE is not defined" runtime error for emscripten.

### DIFF
--- a/src/audio/emscripten/SDL_emscriptenaudio.c
+++ b/src/audio/emscripten/SDL_emscriptenaudio.c
@@ -361,9 +361,9 @@ EMSCRIPTENAUDIO_Init(SDL_AudioDriverImpl * impl)
     /* check availability */
     available = EM_ASM_INT_V({
         if (typeof(AudioContext) !== 'undefined') {
-            return SDL_TRUE;
+            return true;
         } else if (typeof(webkitAudioContext) !== 'undefined') {
-            return SDL_TRUE;
+            return true;
         }
         return SDL_FALSE;
     });
@@ -374,9 +374,9 @@ EMSCRIPTENAUDIO_Init(SDL_AudioDriverImpl * impl)
 
     capture_available = available && EM_ASM_INT_V({
         if ((typeof(navigator.mediaDevices) !== 'undefined') && (typeof(navigator.mediaDevices.getUserMedia) !== 'undefined')) {
-            return SDL_TRUE;
+            return true;
         } else if (typeof(navigator.webkitGetUserMedia) !== 'undefined') {
-            return SDL_TRUE;
+            return true;
         }
         return SDL_FALSE;
     });


### PR DESCRIPTION
Commit 0dda8a7f4cdbcdccc78979ec808777b027645ac6 in #5248 erroneously also added the `SDL_*` constants to Javascript code where this constant isn't defined. This then causes an  "SDL_TRUE is not defined" exception at runtime for any emscripten app using audio. 

This PR reverses that change.