### PR TITLE
audio: Set error message on dsp init failure.

### DIFF
--- a/src/audio/dsp/SDL_dspaudio.c
+++ b/src/audio/dsp/SDL_dspaudio.c
@@ -308,6 +308,7 @@ DSP_Init(SDL_AudioDriverImpl * impl)
     InitTimeDevicesExist = SDL_FALSE;
     SDL_EnumUnixAudioDevices(0, look_for_devices_test);
     if (!InitTimeDevicesExist) {
+        SDL_SetError("dsp: No such audio device");
         return SDL_FALSE;  /* maybe try a different backend. */
     }
 


### PR DESCRIPTION
In the 'dsp' audio driver, if we fail to find any devices, set an error message on the exit path.

Without this, `SDL_Init()` can fail without any message available in `SDL_GetError()`.

## Description

I built SDL on a relatively new OS install, and didn't realize I was missing some audio libs.

```bash
$ ./sdlgetaudiodriver 
Driver 0: dsp
Driver 1: disk
Driver 2: dummy
```

Only `dsp` is not "demand only". It fails to init on my system, when `SDL_EnumUnixAudioDevices()` finds no devices.

This in turn means `SDL_Init()` fails, but without any error message available, making it harder to know where to start troubleshooting.