### PR TITLE
wayland: Fall back to X on old wl_shell-only systems

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.h
+++ b/src/video/wayland/SDL_waylandvideo.h
@@ -61,6 +61,7 @@ typedef struct {
 #ifdef HAVE_LIBDECOR_H
         struct libdecor *libdecor;
 #endif
+        SDL_bool has_wl_shell;
     } shell;
     struct zwp_relative_pointer_manager_v1 *relative_pointer_manager;
     struct zwp_pointer_constraints_v1 *pointer_constraints;


### PR DESCRIPTION
Basic framework for the wl_shell issue. Does not destroy anything so this is a massive leak, if anyone wants to tackle this today it's completely free to grab.

Fixes #5416.