### PR TITLE
X11: apply XRandR scaling to returned display modes

### DIFF
--- a/src/video/x11/SDL_x11sym.h
+++ b/src/video/x11/SDL_x11sym.h
@@ -309,6 +309,7 @@ SDL_X11_SYM(XRRPropertyInfo*,XRRQueryOutputProperty,(Display *dpy,RROutput outpu
 SDL_X11_SYM(int,XRRGetOutputProperty,(Display *dpy,RROutput output, Atom property, long offset, long length, Bool _delete, Bool pending, Atom req_type, Atom *actual_type, int *actual_format, unsigned long *nitems, unsigned long *bytes_after, unsigned char **prop),(dpy,output,property,offset,length, _delete, pending, req_type, actual_type, actual_format, nitems, bytes_after, prop),return)
 SDL_X11_SYM(RROutput,XRRGetOutputPrimary,(Display *dpy,Window window),(dpy,window),return)
 SDL_X11_SYM(void,XRRSelectInput,(Display *dpy, Window window, int mask),(dpy,window,mask),)
+SDL_X11_SYM(Status,XRRGetCrtcTransform,(Display *dpy,RRCrtc crtc,XRRCrtcTransformAttributes **attributes),(dpy,crtc,attributes),return)
 #endif
 
 /* MIT-SCREEN-SAVER support */


### PR DESCRIPTION
## Description

XRandR supports applying transformations to an output's picture including changes to scale. Such scaling is used by some desktop environments under feature names such as "fractional scaling" to accommodate HiDPI devices. Alternatively, such scaling can be enabled by a command such as the following:
    
xrandr --output DP1 --scale 0.5x0.5 --filter nearest
    
XRandR scaling has no "HiDPI awareness" or other way for an application to signal that it wants to work with physical display pixels, and so all we do in these changes is scale SDL's returned display modes so that applications receive the number of usable pixels that they expect. For instance, when XRandR is applying a 0.5x0.5 scale, a full screen application will only receive a quarter of the pixels that it is expecting, and only a single quadrant of the application may be visible. By scaling SDL's returned display modes, we preclude such a mismatch.

## Existing Issue(s)

This touches on issue #4176, although X11 desktop environments often implement two different kinds of HiDPI support: "fractional scaling", as implemented by XRandR scaling, and "UI scaling", which signals to compliant applications to render fonts, icons, and other UI elements at larger sizes.  The changes here relate to XRandR scaling.