### PR TITLE
Avoid trying to use texture framebuffers on emscripten

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2507,6 +2507,11 @@ SDL_CreateWindowFramebuffer(SDL_Window * window)
             attempt_texture_framebuffer = SDL_FALSE;
         }
         #endif
+        #if defined(__EMSCRIPTEN__)
+        else {
+            attempt_texture_framebuffer = SDL_FALSE;
+        }
+        #endif
 
         if (attempt_texture_framebuffer) {
             if (SDL_CreateWindowTexture(_this, window, &format, &pixels, &pitch) == -1) {


### PR DESCRIPTION
I'm testing emscripten with newer (unreleased) SDL and getting a few test failures due to webgl now being used when it wasn't before. Looks like this might be related to the changes to creating texture framebuffers. I've disabled trying entirely here because:

- We used to use the backend's framebuffer support in previous releases
- There doesn't seem to be a huge performance difference between using `putImageData` and going through gl (sub-millisecond)
- Doing this drops > 200k of wasm from things that don't otherwise use the renderer API