### PR TITLE
Avoid depending on libwayland 1.20 unnecessarily

### DIFF
--- a/src/video/wayland/SDL_waylanddyn.h
+++ b/src/video/wayland/SDL_waylanddyn.h
@@ -52,6 +52,14 @@ enum libdecor_window_state;
 #include "xkbcommon/xkbcommon.h"
 #include "xkbcommon/xkbcommon-compose.h"
 
+/* Must be included before our #defines, see Bugzilla #4957 */
+#include "wayland-client-core.h"
+
+#define SDL_WAYLAND_CHECK_VERSION(x, y, z) \
+  (WAYLAND_VERSION_MAJOR > x || \
+   (WAYLAND_VERSION_MAJOR == x && WAYLAND_VERSION_MINOR > y) || \
+   (WAYLAND_VERSION_MAJOR == x && WAYLAND_VERSION_MINOR == y && WAYLAND_VERSION_MICRO >= z))
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -70,9 +78,6 @@ void SDL_WAYLAND_UnloadSymbols(void);
 #ifdef __cplusplus
 }
 #endif
-
-/* Must be included before our #defines, see Bugzilla #4957 */
-#include "wayland-client-core.h"
 
 #ifdef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC
 

--- a/src/video/wayland/SDL_waylandsym.h
+++ b/src/video/wayland/SDL_waylandsym.h
@@ -77,13 +77,14 @@ SDL_WAYLAND_SYM(struct wl_proxy *, wl_proxy_marshal_constructor_versioned, (stru
 SDL_WAYLAND_SYM(void, wl_proxy_set_tag, (struct wl_proxy *, const char * const *))
 SDL_WAYLAND_SYM(const char * const *, wl_proxy_get_tag, (struct wl_proxy *))
 
-/* These were introduced in 1.20 and introduce a handful of build issues.
- * See GitHub #5376 and #4636
- * -flibit
- */
-SDL_WAYLAND_MODULE(WAYLAND_CLIENT_1_20)
+#if SDL_WAYLAND_CHECK_VERSION(1, 20, 0)
+/* wayland-scanner 1.20 generates code that will call these, so these are
+ * non-optional when we are compiling against Wayland 1.20. We don't
+ * explicitly call them ourselves, though, so if we are only compiling
+ * against Wayland 1.18, they're unnecessary. */
 SDL_WAYLAND_SYM(struct wl_proxy*, wl_proxy_marshal_flags, (struct wl_proxy *proxy, uint32_t opcode, const struct wl_interface *interfac, uint32_t version, uint32_t flags, ...))
 SDL_WAYLAND_SYM(struct wl_proxy*, wl_proxy_marshal_array_flags, (struct wl_proxy *proxy, uint32_t opcode, const struct wl_interface *interface, uint32_t version,  uint32_t flags, union wl_argument *args))
+#endif
 
 SDL_WAYLAND_INTERFACE(wl_seat_interface)
 SDL_WAYLAND_INTERFACE(wl_surface_interface)


### PR DESCRIPTION
## Description

When using shared linking (linking in the normal way with
-lwayland-client) rather than loading Wayland libraries dynamically at
runtime, listing symbols that don't exist in the current version results
in a build failure. We don't actually call wl_proxy_marshal_flags() or
wl_proxy_marshal_array_flags() directly; the reason we need them is
that they're called by the code generated by wayland-scanner >= 1.20.

If we're building against an older Wayland library, then we'll have its
corresponding version of wayland-scanner (mismatched versions are not
supported), so we won't need those two symbols, and can avoid generating
a dependency on them.

Conversely, if we're building against a newer Wayland library, the
generated code will call them unconditionally, so we cannot treat them as
optional and gracefully fall back: that would result in a crash. Instead,
treat them as a mandatory part of the Wayland library, so that if they
are not found at runtime, we can fall back to X11 without crashing.

libwayland 1.18 is in several LTS distributions (Ubuntu 20.04,
Debian 11, RHEL 8) so avoiding a hard dependency on 1.20 is quite
useful.

## Existing Issue(s)

Resolves: https://github.com/libsdl-org/SDL/issues/5376

Helps: #4636