### PR TITLE
Malloc string that will be freed

### DIFF
--- a/src/joystick/windows/SDL_windows_gaming_input.c
+++ b/src/joystick/windows/SDL_windows_gaming_input.c
@@ -285,7 +285,8 @@ static HRESULT STDMETHODCALLTYPE IEventHandler_CRawGameControllerVtbl_InvokeAdde
             __x_ABI_CWindows_CGaming_CInput_CIRawGameController2_Release(controller2);
         }
         if (!name) {
-            name = "";
+            name = (char *) SDL_malloc(1);
+            name[0] = '\0';
         }
 
         hr = __x_ABI_CWindows_CGaming_CInput_CIRawGameController_QueryInterface(controller, &IID_IGameController, (void **)&gamecontroller);


### PR DESCRIPTION
If ignore_joystick gets set to true, the name string will be freed. This caused an exception if there was no name string and a static "" string was used. Changed this case to malloc a single character empty string.

This issue was found by having a Tartarus Pro connected in Windows 10 with Razer Synapse 3.7.228.22817 installed. At least one RawGameController is created for the Tartarus Pro is created without a name string.
