### PR TITLE
Add SDL_GetWindow() API to get the window associated with a renderer

### DIFF
--- a/include/SDL_render.h
+++ b/include/SDL_render.h
@@ -262,6 +262,15 @@ extern DECLSPEC SDL_Renderer * SDLCALL SDL_CreateSoftwareRenderer(SDL_Surface * 
 extern DECLSPEC SDL_Renderer * SDLCALL SDL_GetRenderer(SDL_Window * window);
 
 /**
+ * Get the window associated with a renderer.
+ *
+ * \param renderer the renderer to query
+ * \returns the window on success or NULL on failure; call
+ *          SDL_GetError() for more information.
+ */
+extern DECLSPEC SDL_Window * SDLCALL SDL_GetWindow(SDL_Renderer *renderer);
+
+/**
  * Get information about a rendering context.
  *
  * \param renderer the rendering context

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -864,3 +864,4 @@
 #define SDL_UnionFRect SDL_UnionFRect_REAL
 #define SDL_EncloseFPoints SDL_EncloseFPoints_REAL
 #define SDL_IntersectFRectAndLine SDL_IntersectFRectAndLine_REAL
+#define SDL_GetWindow SDL_GetWindow_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -935,3 +935,4 @@ SDL_DYNAPI_PROC(SDL_bool,SDL_IntersectFRect,(const SDL_FRect *a, const SDL_FRect
 SDL_DYNAPI_PROC(void,SDL_UnionFRect,(const SDL_FRect *a, const SDL_FRect *b, SDL_FRect *c),(a,b,c),)
 SDL_DYNAPI_PROC(SDL_bool,SDL_EncloseFPoints,(const SDL_FPoint *a, int b, const SDL_FRect *c, SDL_FRect *d),(a,b,c,d),return)
 SDL_DYNAPI_PROC(SDL_bool,SDL_IntersectFRectAndLine,(const SDL_FRect *a, float *b, float *c, float *d, float *e),(a,b,c,d,e),return)
+SDL_DYNAPI_PROC(SDL_Window*,SDL_GetWindow,(SDL_Renderer *a),(a),return)

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -1095,6 +1095,13 @@ SDL_GetRenderer(SDL_Window * window)
     return (SDL_Renderer *)SDL_GetWindowData(window, SDL_WINDOWRENDERDATA);
 }
 
+SDL_Window *
+SDL_GetWindow(SDL_Renderer *renderer)
+{
+    CHECK_RENDERER_MAGIC(renderer, NULL);
+    return renderer->window;
+}
+
 int
 SDL_GetRendererInfo(SDL_Renderer * renderer, SDL_RendererInfo * info)
 {


### PR DESCRIPTION
Proposal to add an API to get the SDL_Window associated with a SDL_Renderer.

(maybe, a naming SDL_GetWindowFromRenderer() would be more precised ..)