### PR TITLE
wayland: Don't overwrite error message from SDL_EGL_CreateSurface

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -1325,7 +1325,7 @@ int Wayland_CreateWindow(_THIS, SDL_Window *window)
         data->egl_surface = SDL_EGL_CreateSurface(_this, (NativeWindowType) data->egl_window);
 
         if (data->egl_surface == EGL_NO_SURFACE) {
-            return SDL_SetError("failed to create an EGL window surface");
+            return -1;    /* SDL_EGL_CreateSurface should have set error */
         }
 #endif
     }


### PR DESCRIPTION
SDL_EGL_CreateSurface sets a more specific error message, so overwriting
it would lose information.

---

Discovered while trying to test SDL Wayland support on Ubuntu 21.10 with the NVIDIA proprietary driver (which doesn't seem to work, perhaps not enough stars have aligned yet).