### PR TITLE
video: wayland: Use wp-viewporter for fullscreen with fractional scaling

### DIFF
--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -345,6 +345,7 @@ struct SDL_VideoDevice
     Uint32 next_object_id;
     char *clipboard_text;
     SDL_bool setting_display_mode;
+    SDL_bool disable_display_mode_switching;
 
     /* * * */
     /* Data used by the GL drivers */

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1339,14 +1339,17 @@ SDL_UpdateFullscreenMode(SDL_Window * window, SDL_bool fullscreen)
                     resized = SDL_FALSE;
                 }
 
-                /* only do the mode change if we want exclusive fullscreen */
-                if ((window->flags & SDL_WINDOW_FULLSCREEN_DESKTOP) != SDL_WINDOW_FULLSCREEN_DESKTOP) {
-                    if (SDL_SetDisplayModeForDisplay(display, &fullscreen_mode) < 0) {
-                        return -1;
-                    }
-                } else {
-                    if (SDL_SetDisplayModeForDisplay(display, NULL) < 0) {
-                        return -1;
+                /* Don't try to change the display mode if the driver doesn't want it. */
+                if (_this->disable_display_mode_switching == SDL_FALSE) {
+                    /* only do the mode change if we want exclusive fullscreen */
+                    if ((window->flags & SDL_WINDOW_FULLSCREEN_DESKTOP) != SDL_WINDOW_FULLSCREEN_DESKTOP) {
+                        if (SDL_SetDisplayModeForDisplay(display, &fullscreen_mode) < 0) {
+                            return -1;
+                        }
+                    } else {
+                        if (SDL_SetDisplayModeForDisplay(display, NULL) < 0) {
+                            return -1;
+                        }
                     }
                 }
 

--- a/src/video/wayland/SDL_waylandopengles.c
+++ b/src/video/wayland/SDL_waylandopengles.c
@@ -205,11 +205,11 @@ Wayland_GLES_GetDrawableSize(_THIS, SDL_Window * window, int * w, int * h)
         data = (SDL_WindowData *) window->driverdata;
 
         if (w) {
-            *w = window->w * data->scale_factor;
+            *w = data->drawable_width;
         }
 
         if (h) {
-            *h = window->h * data->scale_factor;
+            *h = data->drawable_height;
         }
     }
 }

--- a/src/video/wayland/SDL_waylandvideo.h
+++ b/src/video/wayland/SDL_waylandvideo.h
@@ -74,6 +74,7 @@ typedef struct {
     struct xdg_activation_v1 *activation_manager;
     struct zwp_text_input_manager_v3 *text_input_manager;
     struct zxdg_output_manager_v1 *xdg_output_manager;
+    struct wp_viewporter *viewporter;
 
     EGLDisplay edpy;
     EGLContext context;
@@ -101,6 +102,7 @@ struct SDL_WaylandOutputData {
     struct zxdg_output_v1 *xdg_output;
     uint32_t registry_id;
     float scale_factor;
+    int native_width, native_height;
     int x, y, width, height, refresh, transform;
     SDL_DisplayOrientation orientation;
     int physical_width, physical_height;

--- a/src/video/wayland/SDL_waylandvulkan.c
+++ b/src/video/wayland/SDL_waylandvulkan.c
@@ -139,11 +139,11 @@ void Wayland_Vulkan_GetDrawableSize(_THIS, SDL_Window *window, int *w, int *h)
         data = (SDL_WindowData *) window->driverdata;
 
         if (w) {
-            *w = window->w * data->scale_factor;
+            *w = data->drawable_width;
         }
 
         if (h) {
-            *h = window->h * data->scale_factor;
+            *h = data->drawable_height;
         }
     }
 }

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -36,10 +36,214 @@
 #include "xdg-decoration-unstable-v1-client-protocol.h"
 #include "idle-inhibit-unstable-v1-client-protocol.h"
 #include "xdg-activation-v1-client-protocol.h"
+#include "viewporter-client-protocol.h"
 
 #ifdef HAVE_LIBDECOR_H
 #include <libdecor.h>
 #endif
+
+static void
+GetFullScreenDimensions(SDL_Window *window, int *width, int *height, int *drawable_width, int *drawable_height)
+{
+    SDL_WaylandOutputData *output = (SDL_WaylandOutputData *)SDL_GetDisplayForWindow(window)->driverdata;
+
+    int fs_width, fs_height;
+    int buf_width, buf_height;
+
+    /*
+     * Fullscreen desktop mandates a desktop sized window, so that's what applications will get.
+     * If the application is DPI aware, it will need to handle the transformations between the
+     * differently sized window and backbuffer spaces on its own.
+     */
+    if ((window->flags & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP) {
+        fs_width  = output->width;
+        fs_height = output->height;
+
+        /* If the application is DPI aware, we can expose the true backbuffer size */
+        if (window->flags & SDL_WINDOW_ALLOW_HIGHDPI) {
+            buf_width  = output->native_width;
+            buf_height = output->native_height;
+        } else {
+            buf_width  = fs_width;
+            buf_height = fs_height;
+        }
+    } else {
+        /*
+         * If a mode was set, use it, otherwise use the native resolution
+         * for DPI aware apps and the desktop size for legacy apps.
+         */
+        if (window->fullscreen_mode.w != 0 && window->fullscreen_mode.h != 0) {
+            fs_width  = window->fullscreen_mode.w;
+            fs_height = window->fullscreen_mode.h;
+        } else if (window->flags & SDL_WINDOW_ALLOW_HIGHDPI) {
+            fs_width  = output->native_width;
+            fs_height = output->native_height;
+        } else {
+            fs_width  = output->width;
+            fs_height = output->height;
+        }
+
+        buf_width  = fs_width;
+        buf_height = fs_height;
+    }
+
+    if (width) {
+        *width = fs_width;
+    }
+    if (height) {
+        *height = fs_height;
+    }
+    if (drawable_width) {
+        *drawable_width = buf_width;
+    }
+    if (drawable_height) {
+        *drawable_height = buf_height;
+    }
+}
+
+static inline SDL_bool
+DesktopIsScaled(SDL_Window *window)
+{
+    SDL_WindowData *data = window->driverdata;
+
+    return data->scale_factor != 1.0f;
+}
+
+static inline SDL_bool
+DesktopIsFractionalScaled(SDL_Window *window)
+{
+    SDL_WindowData        *data   = window->driverdata;
+    SDL_WaylandOutputData *output = (SDL_WaylandOutputData *)SDL_GetDisplayForWindow(window)->driverdata;
+
+    if ((output->native_width != (output->width * data->scale_factor) ||
+         output->native_height != (output->height * data->scale_factor))) {
+        return SDL_TRUE;
+    }
+
+    return SDL_FALSE;
+}
+
+static SDL_bool
+NeedFullscreenViewport(SDL_Window *window)
+{
+    SDL_WindowData        *data   = window->driverdata;
+    SDL_VideoData         *video  = data->waylandData;
+    SDL_WaylandOutputData *output = (SDL_WaylandOutputData *)SDL_GetDisplayForWindow(window)->driverdata;
+
+    int fs_width, fs_height;
+
+    GetFullScreenDimensions(window, &fs_width, &fs_height, NULL, NULL);
+
+    /*
+     * Fullscreen needs a viewport:
+     *  - If the desktop uses fractional scaling
+     *    - Fullscreen desktop was not requested OR the window is DPI aware
+     *
+     *  - The desktop uses non-fractional scaling
+     *    - Fullscreen desktop was NOT requested
+     *
+     *  - The desktop is not scaled
+     *    - A non-native fullscreen mode was explicitly set by the client
+     */
+    if (video->viewporter != NULL && (window->flags & SDL_WINDOW_FULLSCREEN)) {
+        if (DesktopIsFractionalScaled(window)) {
+            if ((window->flags & SDL_WINDOW_FULLSCREEN_DESKTOP) != SDL_WINDOW_FULLSCREEN_DESKTOP ||
+                (window->flags & SDL_WINDOW_ALLOW_HIGHDPI)) {
+                return SDL_TRUE;
+            }
+        } else if (DesktopIsScaled(window)) {
+            if ((window->flags & SDL_WINDOW_FULLSCREEN_DESKTOP) != SDL_WINDOW_FULLSCREEN_DESKTOP) {
+                return SDL_TRUE;
+            }
+        } else if (fs_width != output->native_width && fs_height != output->native_height) {
+            return SDL_TRUE;
+        }
+    }
+
+    return SDL_FALSE;
+}
+
+static void
+SetViewport(SDL_Window *window, int src_width, int src_height, int dst_width, int dst_height)
+{
+    SDL_WindowData *wind  = window->driverdata;
+    SDL_VideoData  *video = wind->waylandData;
+
+    if (video->viewporter) {
+        if (wind->viewport == NULL) {
+            wind->viewport = wp_viewporter_get_viewport(video->viewporter, wind->surface);
+        }
+
+        wp_viewport_set_source(wind->viewport, wl_fixed_from_int(0), wl_fixed_from_int(0), wl_fixed_from_int(src_width), wl_fixed_from_int(src_height));
+        wp_viewport_set_destination(wind->viewport, dst_width, dst_height);
+    }
+}
+
+static void
+UnsetViewport(SDL_Window *window)
+{
+    SDL_WindowData *wind = window->driverdata;
+
+    if (wind->viewport) {
+        wp_viewport_destroy(wind->viewport);
+        wind->viewport = NULL;
+    }
+}
+
+static void
+ConfigureViewport(SDL_Window *window)
+{
+    SDL_WindowData        *data    = window->driverdata;
+    SDL_VideoData         *viddata = data->waylandData;
+    SDL_WaylandOutputData *output  = (SDL_WaylandOutputData *)SDL_GetDisplayForWindow(window)->driverdata;
+
+    if ((window->flags & SDL_WINDOW_FULLSCREEN) && NeedFullscreenViewport(window)) {
+        int fs_width, fs_height;
+        int src_width, src_height;
+
+        GetFullScreenDimensions(window, &fs_width, &fs_height, &src_width, &src_height);
+        SetViewport(window, src_width, src_height, output->width, output->height);
+
+        data->pointer_scale = (float)fs_width / (float)output->width;
+
+        /*
+         * If mouse_rect is not empty, re-create the confinement region with the new scale value.
+         * If the pointer is locked to the general surface with unspecified coordinates, it will
+         * be confined to the viewport region, so no update is required.
+         */
+        if (!SDL_RectEmpty(&window->mouse_rect)) {
+            Wayland_input_confine_pointer(viddata->input, window);
+        }
+    } else {
+        UnsetViewport(window);
+        data->pointer_scale = 1.0f;
+
+        /* Re-scale the pointer confinement region */
+        if (!SDL_RectEmpty(&window->mouse_rect)) {
+            Wayland_input_confine_pointer(viddata->input, window);
+        }
+    }
+}
+
+static void
+SetDrawScale(SDL_Window *window)
+{
+    SDL_WindowData *data = window->driverdata;
+
+    if ((window->flags & SDL_WINDOW_FULLSCREEN) && NeedFullscreenViewport(window)) {
+        int fs_width, fs_height;
+
+        GetFullScreenDimensions(window, &fs_width, &fs_height, &data->drawable_width, &data->drawable_height);
+
+        /* Set the buffer scale to 1 since a viewport will be used. */
+        wl_surface_set_buffer_scale(data->surface, 1);
+    } else {
+        data->drawable_width  = window->w * data->scale_factor;
+        data->drawable_height = window->h * data->scale_factor;
+
+        wl_surface_set_buffer_scale(data->surface, (int32_t)data->scale_factor);
+    }
+}
 
 static void
 SetMinMaxDimensions(SDL_Window *window, SDL_bool commit)
@@ -303,9 +507,14 @@ handle_configure_xdg_toplevel(void *data,
          * UPDATE: Nope, sure enough a compositor sends 0,0. This is a known bug:
          * https://bugs.kde.org/show_bug.cgi?id=444962
          */
-        if (width != 0 && height != 0 && (window->w != width || window->h != height)) {
-            window->w = width;
-            window->h = height;
+        if (!NeedFullscreenViewport(window)) {
+            if (width != 0 && height != 0 && (window->w != width || window->h != height)) {
+                window->w = width;
+                window->h = height;
+                wind->needs_resize_event = SDL_TRUE;
+            }
+        } else {
+            GetFullScreenDimensions(window, &window->w, &window->h, NULL, NULL);
             wind->needs_resize_event = SDL_TRUE;
         }
 
@@ -399,16 +608,22 @@ decoration_frame_configure(struct libdecor_frame *frame,
      * Always assume the configure is wrong.
      */
     if (fullscreen) {
-        /* FIXME: We have been explicitly told to respect the fullscreen size
-         * parameters here, even though they are known to be wrong on GNOME at
-         * bare minimum. If this is wrong, don't blame us, we were explicitly
-         * told to do this.
-         */
-        if (!libdecor_configuration_get_content_size(configuration, frame,
-                                                     &width, &height)) {
-            width = window->w;
-            height = window->h;
+        if (!NeedFullscreenViewport(window)) {
+            /* FIXME: We have been explicitly told to respect the fullscreen size
+             * parameters here, even though they are known to be wrong on GNOME at
+             * bare minimum. If this is wrong, don't blame us, we were explicitly
+             * told to do this.
+             */
+            if (!libdecor_configuration_get_content_size(configuration, frame,
+                                                         &width, &height)) {
+                width  = window->w;
+                height = window->h;
+            }
+        } else {
+            GetFullScreenDimensions(window, &width, &height, NULL, NULL);
         }
+
+        wind->needs_resize_event = SDL_TRUE;
 
         /* This part is good though. */
         if (window->flags & SDL_WINDOW_ALLOW_HIGHDPI) {
@@ -1269,7 +1484,8 @@ int Wayland_CreateWindow(_THIS, SDL_Window *window)
     data->waylandData = c;
     data->sdlwindow = window;
 
-    data->scale_factor = 1.0;
+    data->scale_factor = 1.0f;
+    data->pointer_scale = 1.0f;
 
     if (window->flags & SDL_WINDOW_ALLOW_HIGHDPI) {
         int i;
@@ -1316,9 +1532,11 @@ int Wayland_CreateWindow(_THIS, SDL_Window *window)
     }
 #endif /* SDL_VIDEO_DRIVER_WAYLAND_QT_TOUCH */
 
+    data->drawable_width = window->w * data->scale_factor;
+    data->drawable_height = window->h * data->scale_factor;
+
     if (window->flags & SDL_WINDOW_OPENGL) {
-        data->egl_window = WAYLAND_wl_egl_window_create(data->surface,
-                                            window->w * data->scale_factor, window->h * data->scale_factor);
+        data->egl_window = WAYLAND_wl_egl_window_create(data->surface, data->drawable_width, data->drawable_height);
 
 #if SDL_VIDEO_OPENGL_EGL
         /* Create the GLES window surface */
@@ -1375,12 +1593,13 @@ Wayland_HandleResize(SDL_Window *window, int width, int height, float scale)
         data->needs_resize_event = SDL_FALSE;
     }
 
-    wl_surface_set_buffer_scale(data->surface, data->scale_factor);
+    /* Configure the backbuffer size and scale factors */
+    SetDrawScale(window);
 
     if (data->egl_window) {
         WAYLAND_wl_egl_window_resize(data->egl_window,
-                                        window->w * data->scale_factor,
-                                        window->h * data->scale_factor,
+                                        data->drawable_width,
+                                        data->drawable_height,
                                         0, 0);
     }
 
@@ -1397,6 +1616,9 @@ Wayland_HandleResize(SDL_Window *window, int width, int height, float scale)
     if (viddata->shell.xdg && data->shell_surface.xdg.surface) {
        xdg_surface_set_window_geometry(data->shell_surface.xdg.surface, 0, 0, window->w, window->h);
     }
+
+    /* Update the viewport */
+    ConfigureViewport(window);
 }
 
 void
@@ -1431,12 +1653,12 @@ void Wayland_SetWindowSize(_THIS, SDL_Window * window)
     }
 #endif
 
-    wl_surface_set_buffer_scale(wind->surface, wind->scale_factor);
+    SetDrawScale(window);
 
     if (wind->egl_window) {
         WAYLAND_wl_egl_window_resize(wind->egl_window,
-                                     window->w * wind->scale_factor,
-                                     window->h * wind->scale_factor,
+                                     wind->drawable_width,
+                                     wind->drawable_height,
                                      0, 0);
     }
 
@@ -1547,6 +1769,10 @@ void Wayland_DestroyWindow(_THIS, SDL_Window *window)
 
         if (wind->activation_token) {
             xdg_activation_token_v1_destroy(wind->activation_token);
+        }
+
+        if (wind->viewport) {
+            wp_viewport_destroy(wind->viewport);
         }
 
         SDL_free(wind->outputs);

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -72,6 +72,7 @@ typedef struct {
     struct zwp_keyboard_shortcuts_inhibitor_v1 *key_inhibitor;
     struct zwp_idle_inhibitor_v1 *idle_inhibitor;
     struct xdg_activation_token_v1 *activation_token;
+    struct wp_viewport *viewport;
 
     /* floating dimensions for restoring from maximized and fullscreen */
     int floating_width, floating_height;
@@ -86,6 +87,8 @@ typedef struct {
     int num_outputs;
 
     float scale_factor;
+    float pointer_scale;
+    int drawable_width, drawable_height;
     SDL_bool needs_resize_event;
     SDL_bool floating_resize_pending;
 } SDL_WindowData;
@@ -112,6 +115,7 @@ extern int Wayland_SetWindowModalFor(_THIS, SDL_Window * modal_window, SDL_Windo
 extern void Wayland_SetWindowTitle(_THIS, SDL_Window * window);
 extern void Wayland_DestroyWindow(_THIS, SDL_Window *window);
 extern void Wayland_SuspendScreenSaver(_THIS);
+extern int Wayland_SetDisplayMode(_THIS, SDL_VideoDisplay * display, SDL_DisplayMode * mode);
 
 extern SDL_bool
 Wayland_GetWindowWMInfo(_THIS, SDL_Window * window, SDL_SysWMinfo * info);

--- a/wayland-protocols/viewporter.xml
+++ b/wayland-protocols/viewporter.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="viewporter">
+
+  <copyright>
+    Copyright © 2013-2016 Collabora, Ltd.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="wp_viewporter" version="1">
+    <description summary="surface cropping and scaling">
+      The global interface exposing surface cropping and scaling
+      capabilities is used to instantiate an interface extension for a
+      wl_surface object. This extended interface will then allow
+      cropping and scaling the surface contents, effectively
+      disconnecting the direct relationship between the buffer and the
+      surface size.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="unbind from the cropping and scaling interface">
+	Informs the server that the client will not be using this
+	protocol object anymore. This does not affect any other objects,
+	wp_viewport objects included.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="viewport_exists" value="0"
+             summary="the surface already has a viewport object associated"/>
+    </enum>
+
+    <request name="get_viewport">
+      <description summary="extend surface interface for crop and scale">
+	Instantiate an interface extension for the given wl_surface to
+	crop and scale its content. If the given wl_surface already has
+	a wp_viewport object associated, the viewport_exists
+	protocol error is raised.
+      </description>
+      <arg name="id" type="new_id" interface="wp_viewport"
+           summary="the new viewport interface id"/>
+      <arg name="surface" type="object" interface="wl_surface"
+           summary="the surface"/>
+    </request>
+  </interface>
+
+  <interface name="wp_viewport" version="1">
+    <description summary="crop and scale interface to a wl_surface">
+      An additional interface to a wl_surface object, which allows the
+      client to specify the cropping and scaling of the surface
+      contents.
+
+      This interface works with two concepts: the source rectangle (src_x,
+      src_y, src_width, src_height), and the destination size (dst_width,
+      dst_height). The contents of the source rectangle are scaled to the
+      destination size, and content outside the source rectangle is ignored.
+      This state is double-buffered, and is applied on the next
+      wl_surface.commit.
+
+      The two parts of crop and scale state are independent: the source
+      rectangle, and the destination size. Initially both are unset, that
+      is, no scaling is applied. The whole of the current wl_buffer is
+      used as the source, and the surface size is as defined in
+      wl_surface.attach.
+
+      If the destination size is set, it causes the surface size to become
+      dst_width, dst_height. The source (rectangle) is scaled to exactly
+      this size. This overrides whatever the attached wl_buffer size is,
+      unless the wl_buffer is NULL. If the wl_buffer is NULL, the surface
+      has no content and therefore no size. Otherwise, the size is always
+      at least 1x1 in surface local coordinates.
+
+      If the source rectangle is set, it defines what area of the wl_buffer is
+      taken as the source. If the source rectangle is set and the destination
+      size is not set, then src_width and src_height must be integers, and the
+      surface size becomes the source rectangle size. This results in cropping
+      without scaling. If src_width or src_height are not integers and
+      destination size is not set, the bad_size protocol error is raised when
+      the surface state is applied.
+
+      The coordinate transformations from buffer pixel coordinates up to
+      the surface-local coordinates happen in the following order:
+        1. buffer_transform (wl_surface.set_buffer_transform)
+        2. buffer_scale (wl_surface.set_buffer_scale)
+        3. crop and scale (wp_viewport.set*)
+      This means, that the source rectangle coordinates of crop and scale
+      are given in the coordinates after the buffer transform and scale,
+      i.e. in the coordinates that would be the surface-local coordinates
+      if the crop and scale was not applied.
+
+      If src_x or src_y are negative, the bad_value protocol error is raised.
+      Otherwise, if the source rectangle is partially or completely outside of
+      the non-NULL wl_buffer, then the out_of_buffer protocol error is raised
+      when the surface state is applied. A NULL wl_buffer does not raise the
+      out_of_buffer error.
+
+      The x, y arguments of wl_surface.attach are applied as normal to
+      the surface. They indicate how many pixels to remove from the
+      surface size from the left and the top. In other words, they are
+      still in the surface-local coordinate system, just like dst_width
+      and dst_height are.
+
+      If the wl_surface associated with the wp_viewport is destroyed,
+      all wp_viewport requests except 'destroy' raise the protocol error
+      no_surface.
+
+      If the wp_viewport object is destroyed, the crop and scale
+      state is removed from the wl_surface. The change will be applied
+      on the next wl_surface.commit.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="remove scaling and cropping from the surface">
+	The associated wl_surface's crop and scale state is removed.
+	The change is applied on the next wl_surface.commit.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="bad_value" value="0"
+	     summary="negative or zero values in width or height"/>
+      <entry name="bad_size" value="1"
+	     summary="destination size is not integer"/>
+      <entry name="out_of_buffer" value="2"
+	     summary="source rectangle extends outside of the content area"/>
+      <entry name="no_surface" value="3"
+	     summary="the wl_surface was destroyed"/>
+    </enum>
+
+    <request name="set_source">
+      <description summary="set the source rectangle for cropping">
+	Set the source rectangle of the associated wl_surface. See
+	wp_viewport for the description, and relation to the wl_buffer
+	size.
+
+	If all of x, y, width and height are -1.0, the source rectangle is
+	unset instead. Any other set of values where width or height are zero
+	or negative, or x or y are negative, raise the bad_value protocol
+	error.
+
+	The crop and scale state is double-buffered state, and will be
+	applied on the next wl_surface.commit.
+      </description>
+      <arg name="x" type="fixed" summary="source rectangle x"/>
+      <arg name="y" type="fixed" summary="source rectangle y"/>
+      <arg name="width" type="fixed" summary="source rectangle width"/>
+      <arg name="height" type="fixed" summary="source rectangle height"/>
+    </request>
+
+    <request name="set_destination">
+      <description summary="set the surface size for scaling">
+	Set the destination size of the associated wl_surface. See
+	wp_viewport for the description, and relation to the wl_buffer
+	size.
+
+	If width is -1 and height is -1, the destination size is unset
+	instead. Any other pair of values for width and height that
+	contains zero or negative values raises the bad_value protocol
+	error.
+
+	The crop and scale state is double-buffered state, and will be
+	applied on the next wl_surface.commit.
+      </description>
+      <arg name="width" type="int" summary="surface width"/>
+      <arg name="height" type="int" summary="surface height"/>
+    </request>
+  </interface>
+
+</protocol>


### PR DESCRIPTION
Desktops with fractional scaling need special handling to avoid significant overdraw as desktop-sized windows can have backbuffers significantly larger than the native resolution, which then have to be downscaled for final output.  This uses the wp_viewporter protocol, when available, to allow for the use of the native display resolution in fullscreen applications and, potentially, direct scanout by compositors.

Desktops with fractional scaling that don't support viewports are still stuck rendering to oversized backbuffers, but there's nothing we can do about this (do any even exist?)

Needless to say, this needs testing on as many desktops as possible.  It works well on GNOME 41 with Vulkan, GL and the software blitter, but I haven't had a chance to test it on desktops like KDE or Sway.  My main concern is if setting the window to larger than the desktop will have any adverse effects.  This wasn't necessary for Vulkan and GL, but the SDL software blitter, for instance, still uses the window size to set the surface dimensions and having mismatched window and backbuffer sizes caused incorrect output.  If it's a problem, it can be reverted and a different solution can be found.

There are also other possibilities opened up now that viewports are usable, mainly the possibility of allowing emulated display modes (i.e. an envvar to force a specific fullscreen resolution).