### PR TITLE
emscriptenaudio: proxy calls to main thread

### DIFF
--- a/src/audio/emscripten/SDL_emscriptenaudio.c
+++ b/src/audio/emscripten/SDL_emscriptenaudio.c
@@ -32,7 +32,7 @@ static void
 FeedAudioDevice(_THIS, const void *buf, const int buflen)
 {
     const int framelen = (SDL_AUDIO_BITSIZE(this->spec.format) / 8) * this->spec.channels;
-    EM_ASM_ARGS({
+    MAIN_THREAD_EM_ASM({
         var SDL2 = Module['SDL2'];
         var numChannels = SDL2.audio.currentOutputBuffer['numberOfChannels'];
         for (var c = 0; c < numChannels; ++c) {
@@ -101,7 +101,7 @@ HandleCaptureProcess(_THIS)
         return;
     }
 
-    EM_ASM_ARGS({
+    MAIN_THREAD_EM_ASM({
         var SDL2 = Module['SDL2'];
         var numChannels = SDL2.capture.currentCaptureBuffer.numberOfChannels;
         for (var c = 0; c < numChannels; ++c) {
@@ -147,7 +147,7 @@ HandleCaptureProcess(_THIS)
 static void
 EMSCRIPTENAUDIO_CloseDevice(_THIS)
 {
-    EM_ASM_({
+    MAIN_THREAD_EM_ASM({
         var SDL2 = Module['SDL2'];
         if ($0) {
             if (SDL2.capture.silenceTimer !== undefined) {
@@ -201,7 +201,7 @@ EMSCRIPTENAUDIO_OpenDevice(_THIS, const char *devname)
     /* based on parts of library_sdl.js */
 
     /* create context */
-    result = EM_ASM_INT({
+    result = MAIN_THREAD_EM_ASM_INT({
         if(typeof(Module['SDL2']) === 'undefined') {
             Module['SDL2'] = {};
         }
@@ -280,7 +280,7 @@ EMSCRIPTENAUDIO_OpenDevice(_THIS, const char *devname)
            feels like it's a pretty inefficient tapdance in similar ways,
            to be honest. */
 
-        EM_ASM_({
+        MAIN_THREAD_EM_ASM({
             var SDL2 = Module['SDL2'];
             var have_microphone = function(stream) {
                 //console.log('SDL audio capture: we have a microphone! Replacing silence callback.');
@@ -323,7 +323,7 @@ EMSCRIPTENAUDIO_OpenDevice(_THIS, const char *devname)
         }, this->spec.channels, this->spec.samples, HandleCaptureProcess, this);
     } else {
         /* setup a ScriptProcessorNode */
-        EM_ASM_ARGS({
+        MAIN_THREAD_EM_ASM({
             var SDL2 = Module['SDL2'];
             SDL2.audio.scriptProcessorNode = SDL2.audioContext['createScriptProcessor']($1, 0, $0);
             SDL2.audio.scriptProcessorNode['onaudioprocess'] = function (e) {
@@ -359,7 +359,7 @@ EMSCRIPTENAUDIO_Init(SDL_AudioDriverImpl * impl)
     impl->ProvidesOwnCallbackThread = SDL_TRUE;
 
     /* check availability */
-    available = EM_ASM_INT_V({
+    available = MAIN_THREAD_EM_ASM_INT({
         if (typeof(AudioContext) !== 'undefined') {
             return true;
         } else if (typeof(webkitAudioContext) !== 'undefined') {
@@ -372,7 +372,7 @@ EMSCRIPTENAUDIO_Init(SDL_AudioDriverImpl * impl)
         SDL_SetError("No audio context available");
     }
 
-    capture_available = available && EM_ASM_INT_V({
+    capture_available = available && MAIN_THREAD_EM_ASM_INT({
         if ((typeof(navigator.mediaDevices) !== 'undefined') && (typeof(navigator.mediaDevices.getUserMedia) !== 'undefined')) {
             return true;
         } else if (typeof(navigator.webkitGetUserMedia) !== 'undefined') {


### PR DESCRIPTION
While attempting to build an SDL application with pthreads enabled, the first issue I came across was the audio subsystem failing to initialize because the call to init was on a worker thread (using PROXY_TO_PTHREAD) and workers don't have access to the web audio APIs.

I wasn't able to progress in getting an example application to run with PROXY_TO_PTHREAD (for other reasons, and I haven't the time to dig into them yet but possibly will later), but thought I should at least upstream this fix.