### PR TITLE
Fix potential memory leak in QueueCmdFillRects

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -580,10 +580,10 @@ QueueCmdFillRects(SDL_Renderer *renderer, const SDL_FRect * rects, const int cou
                 if (retval < 0) {
                     cmd->command = SDL_RENDERCMD_NO_OP;
                 }
-
-                SDL_small_free(xy, isstack1);
-                SDL_small_free(indices, isstack2);
             }
+            SDL_small_free(xy, isstack1);
+            SDL_small_free(indices, isstack2);
+            
         } else {
             retval = renderer->QueueFillRects(renderer, cmd, rects, count);
             if (retval < 0) {


### PR DESCRIPTION
## Description
This leak is similar to the one fixed in commit 4fe7b2cbd1a15ae2fe174e189153bb3d0750b5c8 in `SDL_RenderDrawLinesF()`.

## Existing Issue(s)
None
