### PR TITLE
video: wayland: Expose more resolutions for mode emulation

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -391,8 +391,8 @@ pointer_handle_motion(void *data, struct wl_pointer *pointer,
     if (input->pointer_focus) {
         const float sx_f = (float)wl_fixed_to_double(sx_w);
         const float sy_f = (float)wl_fixed_to_double(sy_w);
-        const int   sx   = (int)SDL_lroundf(sx_f * window->pointer_scale);
-        const int   sy   = (int)SDL_lroundf(sy_f * window->pointer_scale);
+        const int   sx   = (int)SDL_lroundf(sx_f * window->pointer_scale_x);
+        const int   sy   = (int)SDL_lroundf(sy_f * window->pointer_scale_y);
         SDL_SendMouseMotion(window->sdlwindow, 0, 0, sx, sy);
     }
 }
@@ -719,8 +719,8 @@ touch_handler_down(void *data, struct wl_touch *touch, unsigned int serial,
                    int id, wl_fixed_t fx, wl_fixed_t fy)
 {
     SDL_WindowData *window_data = (SDL_WindowData *)wl_surface_get_user_data(surface);
-    const double dblx = wl_fixed_to_double(fx) * window_data->pointer_scale;
-    const double dbly = wl_fixed_to_double(fy) * window_data->pointer_scale;
+    const double dblx = wl_fixed_to_double(fx) * window_data->pointer_scale_x;
+    const double dbly = wl_fixed_to_double(fy) * window_data->pointer_scale_y;
     const float x = dblx / window_data->sdlwindow->w;
     const float y = dbly / window_data->sdlwindow->h;
 
@@ -752,8 +752,8 @@ touch_handler_motion(void *data, struct wl_touch *touch, unsigned int timestamp,
                      int id, wl_fixed_t fx, wl_fixed_t fy)
 {
     SDL_WindowData *window_data = (SDL_WindowData *)wl_surface_get_user_data(touch_surface(id));
-    const double dblx = wl_fixed_to_double(fx) * window_data->pointer_scale;
-    const double dbly = wl_fixed_to_double(fy) * window_data->pointer_scale;
+    const double dblx = wl_fixed_to_double(fx) * window_data->pointer_scale_x;
+    const double dbly = wl_fixed_to_double(fy) * window_data->pointer_scale_y;
     const float x = dblx / window_data->sdlwindow->w;
     const float y = dbly / window_data->sdlwindow->h;
 
@@ -1821,8 +1821,8 @@ tablet_tool_handle_motion(void* data, struct zwp_tablet_tool_v2* tool, wl_fixed_
     if (input->tool_focus) {
         const float sx_f = (float)wl_fixed_to_double(sx_w);
         const float sy_f = (float)wl_fixed_to_double(sy_w);
-        const int   sx   = (int)SDL_lroundf(sx_f * window->pointer_scale);
-        const int   sy   = (int)SDL_lroundf(sy_f * window->pointer_scale);
+        const int   sx   = (int)SDL_lroundf(sx_f * window->pointer_scale_x);
+        const int   sy   = (int)SDL_lroundf(sy_f * window->pointer_scale_y);
         SDL_SendMouseMotion(window->sdlwindow, 0, 0, sx, sy);
     }
 }
@@ -2351,10 +2351,10 @@ int Wayland_input_confine_pointer(struct SDL_WaylandInput *input, SDL_Window *wi
     } else {
         SDL_Rect scaled_mouse_rect;
 
-        scaled_mouse_rect.x = (int)SDL_floorf((float)window->mouse_rect.x / w->pointer_scale);
-        scaled_mouse_rect.y = (int)SDL_floorf((float)window->mouse_rect.y / w->pointer_scale);
-        scaled_mouse_rect.w = (int)SDL_ceilf((float)window->mouse_rect.w / w->pointer_scale);
-        scaled_mouse_rect.h = (int)SDL_ceilf((float)window->mouse_rect.h / w->pointer_scale);
+        scaled_mouse_rect.x = (int)SDL_floorf((float)window->mouse_rect.x / w->pointer_scale_x);
+        scaled_mouse_rect.y = (int)SDL_floorf((float)window->mouse_rect.y / w->pointer_scale_y);
+        scaled_mouse_rect.w = (int)SDL_ceilf((float)window->mouse_rect.w / w->pointer_scale_x);
+        scaled_mouse_rect.h = (int)SDL_ceilf((float)window->mouse_rect.h / w->pointer_scale_y);
 
         confine_rect = wl_compositor_create_region(d->compositor);
         wl_region_add(confine_rect,

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -374,35 +374,7 @@ AddEmulatedModes(SDL_VideoDisplay *dpy, SDL_bool rot_90)
     };
 
     /* Resolution lists courtesy of XWayland */
-    const struct EmulatedMode modes_4x3[] = {
-        /* 4:3 (1.33) */
-        { 2048, 1536 },
-        { 1920, 1440 },
-        { 1600, 1200 },
-        { 1440, 1080 },
-        { 1400, 1050 },
-        { 1280, 1024 },
-        { 1280, 960 },
-        { 1152, 864 },
-        { 1024, 768 },
-        { 800, 600 },
-        { 640, 480 },
-        { 320, 240 }
-    };
-
-    const struct EmulatedMode modes_16x10[] = {
-        /* 16:10 (1.6) */
-        { 2560, 1600 },
-        { 1920, 1200 },
-        { 1680, 1050 },
-        { 1440, 900 },
-        { 1280, 800 },
-        { 720, 480 },
-        { 640, 400 },
-        { 320, 200 }
-    };
-
-    const struct EmulatedMode modes_16x9[] = {
+    const struct EmulatedMode mode_list[] = {
         /* 16:9 (1.77) */
         { 7680, 4320 },
         { 6144, 3160 },
@@ -417,33 +389,37 @@ AddEmulatedModes(SDL_VideoDisplay *dpy, SDL_bool rot_90)
         { 1600, 900 },
         { 1368, 768 },
         { 1280, 720 },
-        { 1024, 768 },
         { 864, 486 },
-        { 720, 400 },
-        { 640, 350 }
+
+        /* 16:10 (1.6) */
+        { 2560, 1600 },
+        { 1920, 1200 },
+        { 1680, 1050 },
+        { 1440, 900 },
+        { 1280, 800 },
+
+        /* 3:2 (1.5) */
+        { 720, 480 },
+
+        /* 4:3 (1.33) */
+        { 2048, 1536 },
+        { 1920, 1440 },
+        { 1600, 1200 },
+        { 1440, 1080 },
+        { 1400, 1050 },
+        { 1280, 1024 },
+        { 1280, 960 },
+        { 1152, 864 },
+        { 1024, 768 },
+        { 800, 600 },
+        { 640, 480 }
     };
 
     int i;
-    const struct EmulatedMode *mode_list  = NULL;
-    int                        mode_list_size;
-    const int                  native_width  = (float)dpy->display_modes->w;
-    const int                  native_height = (float)dpy->display_modes->h;
-    const float                aspect        = (float)native_width / (float)native_height;
+    const int native_width  = dpy->display_modes->w;
+    const int native_height = dpy->display_modes->h;
 
-    if (aspect >= 1.7f) { /* 16x9 (1.77) */
-        mode_list      = modes_16x9;
-        mode_list_size = SDL_arraysize(modes_16x9);
-    } else if (aspect >= 1.5f) { /* 16x10 (1.6) */
-        mode_list      = modes_16x10;
-        mode_list_size = SDL_arraysize(modes_16x10);
-    } else if (aspect >= 1.3f) { /* 4x3 (1.33) */
-        mode_list      = modes_4x3;
-        mode_list_size = SDL_arraysize(modes_4x3);
-    } else {
-        return; /* Some weird aspect we don't support */
-    }
-
-    for (i = 0; i < mode_list_size; ++i) {
+    for (i = 0; i < SDL_arraysize(mode_list); ++i) {
         /* Only add modes that are smaller than the native mode */
         if ((mode_list[i].w < native_width && mode_list[i].h < native_height) ||
             (mode_list[i].w < native_width && mode_list[i].h == native_height)) {

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -204,7 +204,8 @@ ConfigureViewport(SDL_Window *window)
         GetFullScreenDimensions(window, &fs_width, &fs_height, &src_width, &src_height);
         SetViewport(window, src_width, src_height, output->width, output->height);
 
-        data->pointer_scale = (float)fs_width / (float)output->width;
+        data->pointer_scale_x = (float)fs_width / (float)output->width;
+        data->pointer_scale_y = (float)fs_height / (float)output->height;
 
         /*
          * If mouse_rect is not empty, re-create the confinement region with the new scale value.
@@ -216,7 +217,8 @@ ConfigureViewport(SDL_Window *window)
         }
     } else {
         UnsetViewport(window);
-        data->pointer_scale = 1.0f;
+        data->pointer_scale_x = 1.0f;
+        data->pointer_scale_y = 1.0f;
 
         /* Re-scale the pointer confinement region */
         if (!SDL_RectEmpty(&window->mouse_rect)) {
@@ -1485,7 +1487,8 @@ int Wayland_CreateWindow(_THIS, SDL_Window *window)
     data->sdlwindow = window;
 
     data->scale_factor = 1.0f;
-    data->pointer_scale = 1.0f;
+    data->pointer_scale_x = 1.0f;
+    data->pointer_scale_y = 1.0f;
 
     if (window->flags & SDL_WINDOW_ALLOW_HIGHDPI) {
         int i;

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -87,7 +87,8 @@ typedef struct {
     int num_outputs;
 
     float scale_factor;
-    float pointer_scale;
+    float pointer_scale_x;
+    float pointer_scale_y;
     int drawable_width, drawable_height;
     SDL_bool needs_resize_event;
     SDL_bool floating_resize_pending;


### PR DESCRIPTION
Given that the main goal of mode emulation is legacy compatibility, we should expose as many emulated display modes as possible.  They will currently display stretched to the display's native desktop dimensions, but if an application requires a specific hardcoded resolution, it will work at the very least.  Perhaps at some point in the future we can look into displaying non-native aspect ratios correctly, either by masking the desktop ourselves with subsurfaces or getting compositors to do it automatically.

This also prunes the emulated mode list and drops some of the really low resolutions. Anything with a horizontal width below 800 is gone, with the exceptions of 720x480 (NTSC) and 640x480 (VGA).  The old lists had resolutions as low as 320x240 and 320x200 (mode X and 13h), which I don't think were ever relevant once you moved past DOS.

Aside from rearranging the emulated display mode list, the Wayland event handling code had to be slightly modified to support separate scaling factors for the x and y axes to accommodate mapping between different aspect ratios.

@flibitijibibo 