### PR TITLE
Add SDL2main to EXTRA_LIBS on PSP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2467,6 +2467,7 @@ elseif(PSP)
       pspaudio
       pspvram
       GL
+      SDL2main
     )
 
 elseif(OS2)


### PR DESCRIPTION
This changes only the CMakeLists.txt file. It results in pkg-config also returning SDL2main when using the ``--libs`` option in the PSP homebrew SDK.

## Description

This doesn't seem standard, but the PSP version needs SDL2main to be linked, so it makes sense that pkg-config would know this. Is this the way to go about implementing this?