### PR TITLE
Add visualisation for mouse wheel testing to test/testmouse

### DIFF
--- a/test/testmouse.c
+++ b/test/testmouse.c
@@ -39,6 +39,11 @@ static Line *active = NULL;
 static Line *lines = NULL;
 static int buttons = 0;
 
+static SDL_bool wheel_x_active = SDL_FALSE;
+static SDL_bool wheel_y_active = SDL_FALSE;
+static float wheel_x = SCREEN_WIDTH * 0.5f;
+static float wheel_y = SCREEN_HEIGHT * 0.5f;
+
 static SDL_bool done = SDL_FALSE;
 
 void
@@ -81,6 +86,25 @@ loop(void *arg)
     /* Check for events */
     while (SDL_PollEvent(&event)) {
         switch (event.type) {
+        case SDL_MOUSEWHEEL:
+                if (event.wheel.direction == SDL_MOUSEWHEEL_FLIPPED) {
+                        event.wheel.preciseX *= -1.0f;
+                        event.wheel.preciseY *= -1.0f;
+                        event.wheel.x *= -1;
+                        event.wheel.y *= -1;
+                }
+                if (event.wheel.preciseX != 0.0f) {
+                        wheel_x_active = SDL_TRUE;
+                        /* "positive to the right and negative to the left"  */
+                        wheel_x += event.wheel.preciseX * 10.0f;
+                }
+                if (event.wheel.preciseY != 0.0f) {
+                        wheel_y_active = SDL_TRUE;
+                        /* "positive away from the user and negative towards the user" */
+                        wheel_y -= event.wheel.preciseY * 10.0f;
+                }
+                break;
+
         case SDL_MOUSEMOTION:
             if (!active)
                 break;
@@ -134,6 +158,16 @@ loop(void *arg)
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
     SDL_RenderClear(renderer);
 
+    /* Mouse wheel */
+    SDL_SetRenderDrawColor(renderer, 0, 255, 128, 255);
+    if (wheel_x_active) {
+            SDL_RenderDrawLine(renderer, wheel_x, 0, wheel_x, SCREEN_HEIGHT);
+    }
+    if (wheel_y_active) {
+            SDL_RenderDrawLine(renderer, 0, wheel_y, SCREEN_WIDTH, wheel_y);
+    }
+
+    /* Lines from mouse clicks */
     DrawLines(renderer);
     if (active)
         DrawLine(renderer, active);


### PR DESCRIPTION
Using a scroll wheel in `testmouse` will now show and move move horizontal/vertical lines.

## Description

`testmouse` now checks for `SDL_MOUSEWHEEL` and visualises `preciseX` and `preciseY` updates.

## Existing Issue(s)

- Intent: help avoid XInput2 bugs during development in #5481
- May also be useful for testing #5382

Submitting as a standalone PR since this has no impact on `libsdl2` clients.

NB: horizontal mouse wheel behaviour seems to be flipped wrt what the docs say (XInput2, both with and without #5382 ), cf. the comment in line 98 (from https://wiki.libsdl.org/SDL_MouseWheelEvent).
Am I misreading the docs or should I file a separate issue or PR against XInput2?