### PR TITLE
x11: Don't unload libGL.so to prevent a crash in XCloseDisplay()

### DIFF
--- a/src/video/x11/SDL_x11opengl.c
+++ b/src/video/x11/SDL_x11opengl.c
@@ -247,11 +247,6 @@ X11_GL_LoadLibrary(_THIS, const char *path)
         X11_GL_UseEGL(_this) ) {
 #if SDL_VIDEO_OPENGL_EGL
         X11_GL_UnloadLibrary(_this);
-        /* Better avoid conflicts! */
-        if (_this->gl_config.dll_handle != NULL ) {
-            GL_UnloadObject(_this->gl_config.dll_handle);
-            _this->gl_config.dll_handle = NULL;
-        }
         _this->GL_LoadLibrary = X11_GLES_LoadLibrary;
         _this->GL_GetProcAddress = X11_GLES_GetProcAddress;
         _this->GL_UnloadLibrary = X11_GLES_UnloadLibrary;


### PR DESCRIPTION
## Description
libGL.so may register callbacks that can be invoked upon XCloseDisplay(). If XCloseDisplay() is called after libGL.so is unloaded, the callback pointer will point at freed memory and invoking it will crash.

The texture framebuffer check optimized out in f37e4a9 was causing libGL.so to never be unloaded as a side-effect. Skipping it exposed this bug by allowing libGL.so to actually unload.

This should probably be reviewed for correctness by someone more familiar with X11 and/or GLX. #5484 has more detailed analysis. 

## Existing Issue(s)
Fixes #5484
