### PR TITLE
Compile with recursive mutexes for emscripten

### DIFF
--- a/include/SDL_config_emscripten.h
+++ b/include/SDL_config_emscripten.h
@@ -185,6 +185,7 @@
 /* Enable various threading systems */
 #ifdef __EMSCRIPTEN_PTHREADS__
 #define SDL_THREAD_PTHREAD 1
+#define SDL_THREAD_PTHREAD_RECURSIVE_MUTEX 1
 #endif
 
 /* Enable various timer systems */


### PR DESCRIPTION
Emscripten actually does support recursive mutexes, so no need to use SDL's fake recursive code.

Background: #5428, #5479
