### PR TITLE
video: wayland: Set the surface damage region when using fullscreen viewports

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -90,6 +90,7 @@ typedef struct {
     float pointer_scale_x;
     float pointer_scale_y;
     int drawable_width, drawable_height;
+    SDL_Rect damage_region;
     SDL_bool needs_resize_event;
     SDL_bool floating_resize_pending;
 } SDL_WindowData;


### PR DESCRIPTION
I was noticing some occasional flickering and artifacts when using the emulated display modes.  Looking at the Wayland debug output, the surface damage region was being automatically calculated from the backbuffer size.  When the backbuffer is smaller than the scaled viewport area, only part of the viewport region the size of the output buffer was being marked as damaged and visual artifacts could result in the region outside of this area.  This manually sets the surface damage region to the entire output area in the frame callback when using a fullscreen viewport to fix this.

@flibitijibibo 