### PR TITLE
Vita: fix VIDEO_VITA_PVR flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2310,10 +2310,10 @@ elseif(VITA)
         list(APPEND EXTRA_LIBS
           pib
         )
-        set(HAVE_VITA_PIB ON)
+        set(HAVE_VIDEO_VITA_PIB ON)
         set(SDL_VIDEO_VITA_PIB 1)
       else()
-        set(HAVE_VITA_PIB OFF)
+        set(HAVE_VIDEO_VITA_PIB OFF)
       endif()
     endif()
 
@@ -2334,7 +2334,7 @@ elseif(VITA)
           libIMGEGL_stub_weak
         )
 
-        set(HAVE_VITA_PVR ON)
+        set(HAVE_VIDEO_VITA_PVR ON)
         set(SDL_VIDEO_VITA_PVR 1)
 
         if(HAVE_GL4ES_H)
@@ -2346,7 +2346,7 @@ elseif(VITA)
         endif()
 
       else()
-        set(HAVE_VITA_PVR OFF)
+        set(HAVE_VIDEO_VITA_PVR OFF)
       endif()
     endif()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
After https://github.com/libsdl-org/SDL/commit/7850d0cf6fa1b2e7d8999d0506bb907ae071f497 commit (autoreplace gone wrong?), vita PVR support was being incorrectly reported as Off even when enabled due to flag names mismatch

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
