### PR TITLE
Initialise scandir argument

### DIFF
--- a/src/joystick/linux/SDL_sysjoystick.c
+++ b/src/joystick/linux/SDL_sysjoystick.c
@@ -610,7 +610,7 @@ static int get_event_joystick_index(int event)
 {
     int joystick_index = -1;
     int i, count;
-    struct dirent **entries;
+    struct dirent **entries = NULL;
     char path[PATH_MAX];
 
     SDL_snprintf(path, SDL_arraysize(path), "/sys/class/input/event%d/device", event);
@@ -679,7 +679,7 @@ LINUX_FallbackJoystickDetect(void)
         /* Opening input devices can generate synchronous device I/O, so avoid it if we can */
         if (stat("/dev/input", &sb) == 0 && sb.st_mtime != last_input_dir_mtime) {
             int i, count;
-            struct dirent **entries;
+            struct dirent **entries = NULL;
             char path[PATH_MAX];
 
             count = scandir("/dev/input", &entries, filter_entries, sort_entries);


### PR DESCRIPTION
## Description
In case of error `scandir` does not initialise `entries` and this uninitialised pointer is freed. 

## Existing Issue(s)
None
