### PR TITLE
simplify SDL_GetBasePath on windows

### DIFF
--- a/src/filesystem/windows/SDL_sysfilesystem.c
+++ b/src/filesystem/windows/SDL_sysfilesystem.c
@@ -35,39 +35,23 @@
 char *
 SDL_GetBasePath(void)
 {
-    typedef DWORD (WINAPI *GetModuleFileNameExW_t)(HANDLE, HMODULE, LPWSTR, DWORD);
-    GetModuleFileNameExW_t pGetModuleFileNameExW;
     DWORD buflen = 128;
     WCHAR *path = NULL;
-    HANDLE psapi = LoadLibrary(TEXT("psapi.dll"));
     char *retval = NULL;
     DWORD len = 0;
     int i;
-
-    if (!psapi) {
-        WIN_SetError("Couldn't load psapi.dll");
-        return NULL;
-    }
-
-    pGetModuleFileNameExW = (GetModuleFileNameExW_t)GetProcAddress(psapi, "GetModuleFileNameExW");
-    if (!pGetModuleFileNameExW) {
-        WIN_SetError("Couldn't find GetModuleFileNameExW");
-        FreeLibrary(psapi);
-        return NULL;
-    }
 
     while (SDL_TRUE) {
         void *ptr = SDL_realloc(path, buflen * sizeof (WCHAR));
         if (!ptr) {
             SDL_free(path);
-            FreeLibrary(psapi);
             SDL_OutOfMemory();
             return NULL;
         }
 
         path = (WCHAR *) ptr;
 
-        len = pGetModuleFileNameExW(GetCurrentProcess(), NULL, path, buflen);
+        len = GetModuleFileName(NULL, path, buflen);
         /* if it truncated, then len >= buflen - 1 */
         /* if there was enough room (or failure), len < buflen - 1 */
         if (len < buflen - 1) {
@@ -77,8 +61,6 @@ SDL_GetBasePath(void)
         /* buffer too small? Try again. */
         buflen *= 2;
     }
-
-    FreeLibrary(psapi);
 
     if (len == 0) {
         SDL_free(path);

--- a/src/filesystem/windows/SDL_sysfilesystem.c
+++ b/src/filesystem/windows/SDL_sysfilesystem.c
@@ -51,7 +51,7 @@ SDL_GetBasePath(void)
 
         path = (WCHAR *) ptr;
 
-        len = GetModuleFileName(NULL, path, buflen);
+        len = GetModuleFileNameW(NULL, path, buflen);
         /* if it truncated, then len >= buflen - 1 */
         /* if there was enough room (or failure), len < buflen - 1 */
         if (len < buflen - 1) {


### PR DESCRIPTION
use GetModuleFileName directly (as recommended)
