### PR TITLE
Update expectations for testevdev to match more recent SDL

### DIFF
--- a/test/testevdev.c
+++ b/test/testevdev.c
@@ -595,7 +595,7 @@ static const GuessTest guess_tests[] =
        * to the arrow, page up and page down keys, so it's a joystick
        * with a subset of a keyboard attached. */
       /* TODO: Should this be JOYSTICK, or even JOYSTICK|KEYBOARD? */
-      .expected = SDL_UDEV_DEVICE_UNKNOWN,
+      .expected = SDL_UDEV_DEVICE_KEYBOARD,
       /* SYN, KEY */
       .ev = { 0x03 },
       .keys = {
@@ -607,7 +607,7 @@ static const GuessTest guess_tests[] =
           /* BTN_1, BTN_2, BTN_A, BTN_B, BTN_MODE */
           /* 0x100 */ 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x10,
           /* 0x140 */ ZEROx8,
-          /* next, previous */
+          /* next (keyboard page down), previous (keyboard page up) */
           /* 0x180 */ 0x00, 0x00, 0x80, 0x10, ZEROx4,
       },
     },
@@ -658,7 +658,7 @@ static const GuessTest guess_tests[] =
       .name = "Wiimote - Classic Controller",
       /* TODO: Should this be JOYSTICK, or maybe JOYSTICK|KEYBOARD?
        * It's unusual in the same ways as the Wiimote */
-      .expected = SDL_UDEV_DEVICE_UNKNOWN,
+      .expected = SDL_UDEV_DEVICE_KEYBOARD,
       /* SYN, KEY, ABS */
       .ev = { 0x0b },
       /* Hat 1-3 */
@@ -672,7 +672,7 @@ static const GuessTest guess_tests[] =
           /* A, B, X, Y, MODE, TL, TL2, TR, TR2 */
           /* 0x100 */ ZEROx4, 0x00, 0x13, 0xdb, 0x10,
           /* 0x140 */ ZEROx8,
-          /* next, previous */
+          /* next (keyboard page down), previous (keyboard page up) */
           /* 0x180 */ 0x00, 0x00, 0x80, 0x10, ZEROx4,
       },
     },
@@ -753,7 +753,8 @@ static const GuessTest guess_tests[] =
     },
     {
       .name = "Thinkpad ACPI buttons",
-      .expected = SDL_UDEV_DEVICE_UNKNOWN,
+      /* SDL treats this as a keyboard because it has a power button */
+      .expected = SDL_UDEV_DEVICE_KEYBOARD,
       /* SYN, KEY, MSC, SW */
       .ev = { 0x33 },
       .keys = {
@@ -812,7 +813,8 @@ static const GuessTest guess_tests[] =
       .vendor_id = 0x0000,
       .product_id = 0x0003,
       .version = 0x0000,
-      .expected = SDL_UDEV_DEVICE_UNKNOWN,
+      /* SDL treats KEY_SLEEP as indicating a keyboard */
+      .expected = SDL_UDEV_DEVICE_KEYBOARD,
       /* SYN, KEY */
       .ev = { 0x03 },
       .keys = {
@@ -838,7 +840,8 @@ static const GuessTest guess_tests[] =
       .vendor_id = 0x0000,
       .product_id = 0x0001,
       .version = 0x0000,
-      .expected = SDL_UDEV_DEVICE_UNKNOWN,
+      /* SDL treats KEY_POWER as indicating a keyboard */
+      .expected = SDL_UDEV_DEVICE_KEYBOARD,
       /* SYN, KEY */
       .ev = { 0x03 },
       .keys = {
@@ -853,7 +856,8 @@ static const GuessTest guess_tests[] =
       .vendor_id = 0x0000,
       .product_id = 0x0006,
       .version = 0x0000,
-      .expected = SDL_UDEV_DEVICE_UNKNOWN,
+      /* SDL treats brightness control, etc. as keyboard keys */
+      .expected = SDL_UDEV_DEVICE_KEYBOARD,
       /* SYN, KEY */
       .ev = { 0x03 },
       .keys = {
@@ -870,7 +874,7 @@ static const GuessTest guess_tests[] =
       .vendor_id = 0x17aa,
       .product_id = 0x5054,
       .version = 0x4101,
-      .expected = SDL_UDEV_DEVICE_UNKNOWN,
+      .expected = SDL_UDEV_DEVICE_KEYBOARD,
       /* SYN, KEY */
       .ev = { 0x03 },
       .keys = {
@@ -908,9 +912,8 @@ static const GuessTest guess_tests[] =
       .product_id = 0x6009,
       /* For some reason the special keys like mute and wlan toggle
        * show up here instead of, or in addition to, as part of
-       * the keyboard - so udev reports this as having keys too.
-       * SDL currently doesn't. */
-      .expected = SDL_UDEV_DEVICE_MOUSE,
+       * the keyboard - so both udev and SDL report this as having keys too. */
+      .expected = SDL_UDEV_DEVICE_MOUSE | SDL_UDEV_DEVICE_KEYBOARD,
       /* SYN, KEY, REL, MSC, LED */
       .ev = { 0x17, 0x00, 0x02 },
       /* X, Y */

--- a/test/testevdev.c
+++ b/test/testevdev.c
@@ -41,6 +41,7 @@ static const struct
     CLS(SOUND),
     CLS(TOUCHSCREEN),
     CLS(ACCELEROMETER),
+    CLS(TOUCHPAD),
 #undef CLS
     { 0, NULL }
 };
@@ -185,9 +186,7 @@ static const GuessTest guess_tests[] =
       .bus_type = 0x0003,
       .vendor_id = 0x054c,
       .product_id = 0x09cc,
-      /* TODO: Should this be MOUSE? That's what it most closely
-       * resembles */
-      .expected = SDL_UDEV_DEVICE_UNKNOWN,
+      .expected = SDL_UDEV_DEVICE_TOUCHPAD,
       /* SYN, KEY, ABS */
       .ev = { 0x0b },
       /* X, Y, multitouch */
@@ -718,9 +717,7 @@ static const GuessTest guess_tests[] =
       .vendor_id = 0x06cb,
       .product_id = 0x0000,
       .version = 0x0000,
-      /* TODO: Should this be MOUSE? That's what it most closely
-       * resembles */
-      .expected = SDL_UDEV_DEVICE_UNKNOWN,
+      .expected = SDL_UDEV_DEVICE_TOUCHPAD,
       /* SYN, KEY, ABS */
       .ev = { 0x0b },
       /* X, Y, pressure, multitouch */


### PR DESCRIPTION
The testevdev automated test needs some updates for changes to SDL since I contributed it, otherwise it will fail.

* testevdev: Recognise touchpads as such
    
    At the time I contributed this unit test, SDL didn't understand Linux
    touchpads, but now it does.
    
    Fixes: 373216ae "Added support for touchpads in the Linux evdev code"

* testevdev: Adapt to a broader definition of keyboards
    
    At the time I contributed this unit test, SDL had a relatively narrow
    definition of what is a keyboard, approximately matching udev
    ID_INPUT_KEYBOARD. Now it uses the equivalent of udev ID_INPUT_KEY,
    which matches anything with keyboard keys, and not just reasonably
    complete alphanumeric keyboards.
    
    Fixes: 040bd7a9 "Fix udev not detecting ID_INPUT_KEY devices when udev is not running"