### PR TITLE
WhatsNew.txt: Document changed default video driver priority

### DIFF
--- a/WhatsNew.txt
+++ b/WhatsNew.txt
@@ -30,6 +30,7 @@ Windows:
 * Added support for SDL_BLENDOPERATION_MINIMUM and SDL_BLENDOPERATION_MAXIMUM to the D3D9 renderer
 
 Linux:
+* Compiling with Wayland support requires libwayland-client version 1.18.0 or later
 * Added the hint SDL_HINT_X11_WINDOW_TYPE to specify the _NET_WM_WINDOW_TYPE of SDL windows
 * Added the hint SDL_HINT_VIDEO_WAYLAND_PREFER_LIBDECOR to allow using libdecor with compositors that support xdg-decoration
 

--- a/WhatsNew.txt
+++ b/WhatsNew.txt
@@ -30,6 +30,7 @@ Windows:
 * Added support for SDL_BLENDOPERATION_MINIMUM and SDL_BLENDOPERATION_MAXIMUM to the D3D9 renderer
 
 Linux:
+* When using Wayland, the native Wayland video driver is now higher-priority than X11 via Xwayland. SDL_VIDEODRIVER=x11 can be used to force use of X11 via Xwayland.
 * Compiling with Wayland support requires libwayland-client version 1.18.0 or later
 * Added the hint SDL_HINT_X11_WINDOW_TYPE to specify the _NET_WM_WINDOW_TYPE of SDL windows
 * Added the hint SDL_HINT_VIDEO_WAYLAND_PREFER_LIBDECOR to allow using libdecor with compositors that support xdg-decoration


### PR DESCRIPTION
See commit 8ceba27d "video: Prefer Wayland over X11".

---

If the change from 8ceba27d is kept, this seems like an important thing to mention in the release notes.

Conversely, if regressions like the ones described in #5527 are considered too severe and 8ceba27d is reverted, then this commit should also be reverted (or not applied at all).

This commit is based on #5530, which I hope is uncontroversial.