### PR TITLE
testgl2: explicitely request a Core context on initialization

### DIFF
--- a/test/testgl2.c
+++ b/test/testgl2.c
@@ -262,6 +262,9 @@ main(int argc, char *argv[])
     state->gl_blue_size = 5;
     state->gl_depth_size = 16;
     state->gl_double_buffer = 1;
+    state->gl_major_version = 2;
+    state->gl_minor_version = 0;
+    state->gl_profile_mask = SDL_GL_CONTEXT_PROFILE_CORE;
     if (fsaa) {
         state->gl_multisamplebuffers = 1;
         state->gl_multisamplesamples = fsaa;


### PR DESCRIPTION
## Description
Prevents the issue of initializing a GLES context when the system supports both Core/ES and ES is preferred.
See issue [#5348](https://github.com/libsdl-org/SDL/issues/5348) for such a situation: compiling the RPI video driver enables GLES as the preferred context, but this breaks `testgl2`.

## Existing Issue(s)
Fixes #5348
