### PR TITLE
Wayland fixes for window boundaries and pointer scaling

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -391,8 +391,8 @@ pointer_handle_motion(void *data, struct wl_pointer *pointer,
     if (input->pointer_focus) {
         const float sx_f = (float)wl_fixed_to_double(sx_w);
         const float sy_f = (float)wl_fixed_to_double(sy_w);
-        const int   sx   = (int)SDL_lroundf(sx_f * window->pointer_scale_x);
-        const int   sy   = (int)SDL_lroundf(sy_f * window->pointer_scale_y);
+        const int   sx   = (int)SDL_floorf(sx_f * window->pointer_scale_x);
+        const int   sy   = (int)SDL_floorf(sy_f * window->pointer_scale_y);
         SDL_SendMouseMotion(window->sdlwindow, 0, 0, sx, sy);
     }
 }
@@ -1826,8 +1826,8 @@ tablet_tool_handle_motion(void* data, struct zwp_tablet_tool_v2* tool, wl_fixed_
     if (input->tool_focus) {
         const float sx_f = (float)wl_fixed_to_double(sx_w);
         const float sy_f = (float)wl_fixed_to_double(sy_w);
-        const int   sx   = (int)SDL_lroundf(sx_f * window->pointer_scale_x);
-        const int   sy   = (int)SDL_lroundf(sy_f * window->pointer_scale_y);
+        const int   sx   = (int)SDL_floorf(sx_f * window->pointer_scale_x);
+        const int   sy   = (int)SDL_floorf(sy_f * window->pointer_scale_y);
         SDL_SendMouseMotion(window->sdlwindow, 0, 0, sx, sy);
     }
 }


### PR DESCRIPTION
A couple of quick Wayland fixes.  Clamps the fullscreen window dimensions to the desktop and adjusts the rounding when scaling pointer coordinates so they don't exceed the window boundaries.  Should fix #5539.

@flibitijibibo 