### PR TITLE
hints: Make SDL_VIDEODRIVER and SDL_AUDIODRIVER formal hints.

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -1980,6 +1980,53 @@ extern "C" {
 
 
 /**
+ *  \brief  A variable that decides what video backend to use.
+ *
+ *  By default, SDL will try all available video backends in a reasonable
+ *  order until it finds one that can work, but this hint allows the app
+ *  or user to force a specific target, such as "x11" if, say, you are
+ *  on Wayland but want to try talking to the X server instead.
+ *
+ *  This functionality has existed since SDL 2.0.0 (indeed, before that)
+ *  but before 2.0.22 this was an environment variable only. In 2.0.22,
+ *  it was upgraded to a full SDL hint, so you can set the environment
+ *  variable as usual or programatically set the hint with SDL_SetHint,
+ *  which won't propagate to child processes.
+ *
+ *  The default value is unset, in which case SDL will try to figure out
+ *  the best video backend on your behalf. This hint needs to be set
+ *  before SDL_Init() is called to be useful.
+ *
+ *  This hint is available since SDL 2.0.22. Before then, you could set
+ *  the environment variable to get the same effect.
+ */
+#define SDL_HINT_VIDEODRIVER "SDL_VIDEODRIVER"
+
+/**
+ *  \brief  A variable that decides what audio backend to use.
+ *
+ *  By default, SDL will try all available audio backends in a reasonable
+ *  order until it finds one that can work, but this hint allows the app
+ *  or user to force a specific target, such as "alsa" if, say, you are
+ *  on PulseAudio but want to try talking to the lower level instead.
+ *
+ *  This functionality has existed since SDL 2.0.0 (indeed, before that)
+ *  but before 2.0.22 this was an environment variable only. In 2.0.22,
+ *  it was upgraded to a full SDL hint, so you can set the environment
+ *  variable as usual or programatically set the hint with SDL_SetHint,
+ *  which won't propagate to child processes.
+ *
+ *  The default value is unset, in which case SDL will try to figure out
+ *  the best audio backend on your behalf. This hint needs to be set
+ *  before SDL_Init() is called to be useful.
+ *
+ *  This hint is available since SDL 2.0.22. Before then, you could set
+ *  the environment variable to get the same effect.
+ */
+#define SDL_HINT_AUDIODRIVER "SDL_AUDIODRIVER"
+
+
+/**
  *  \brief  An enumeration of hint priorities
  */
 typedef enum

--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -936,7 +936,7 @@ SDL_AudioInit(const char *driver_name)
 
     /* Select the proper audio driver */
     if (driver_name == NULL) {
-        driver_name = SDL_getenv("SDL_AUDIODRIVER");
+        driver_name = SDL_GetHint(SDL_HINT_AUDIODRIVER);
     }
 
     if (driver_name != NULL && *driver_name != 0) {

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -425,7 +425,7 @@ SDL_VideoInit(const char *driver_name)
     i = index = 0;
     video = NULL;
     if (driver_name == NULL) {
-        driver_name = SDL_getenv("SDL_VIDEODRIVER");
+        driver_name = SDL_GetHint(SDL_HINT_VIDEODRIVER);
     }
     if (driver_name != NULL && *driver_name != 0) {
         const char *driver_attempt = driver_name;

--- a/src/video/dummy/SDL_nullvideo.c
+++ b/src/video/dummy/SDL_nullvideo.c
@@ -46,6 +46,7 @@
 #include "SDL_nullvideo.h"
 #include "SDL_nullevents_c.h"
 #include "SDL_nullframebuffer_c.h"
+#include "SDL_hints.h"
 
 #define DUMMYVID_DRIVER_NAME "dummy"
 
@@ -59,7 +60,7 @@ static void DUMMY_VideoQuit(_THIS);
 static int
 DUMMY_Available(void)
 {
-    const char *envr = SDL_getenv("SDL_VIDEODRIVER");
+    const char *envr = SDL_GetHint(SDL_HINT_VIDEODRIVER);
     if ((envr) && (SDL_strcmp(envr, DUMMYVID_DRIVER_NAME) == 0)) {
         return (1);
     }


### PR DESCRIPTION
They were just environment variables before.

Fixes #5528.

This seems safe enough to merge, but we're in the 2.0.22 window, so I'm putting it into a pull request in case we want to wait for 2.0.24.

