### PR TITLE
Wayland: Emulate mouse warp using relative mouse mode

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -1702,6 +1702,23 @@ extern "C" {
 #define SDL_HINT_VIDEO_WAYLAND_MODE_EMULATION "SDL_VIDEO_WAYLAND_MODE_EMULATION"
 
 /**
+ *  \brief  Enable or disable mouse pointer warp emulation, needed by some older games.
+ *
+ *  When this hint is set, any SDL will emulate mouse warps using relative mouse mode.
+ *  This is required for some older games (such as Source engine games), which warp the
+ *  mouse to the centre of the screen rather than using relative mouse motion. Note that
+ *  relative mouse mode may have different mouse acceleration behaviour than pointer warps.
+ *
+ *  This variable can be set to the following values:
+ *    "0"       - All mouse warps fail, as mouse warping is not available under wayland.
+ *    "1"       - Some mouse warps will be emulated by forcing relative mouse mode.
+ *
+ *  If not set, this is automatically enabled unless an application uses relative mouse
+ *  mode directly.
+ */
+#define SDL_HINT_VIDEO_WAYLAND_EMULATE_MOUSE_WARP "SDL_VIDEO_WAYLAND_EMULATE_MOUSE_WARP"
+
+/**
 *  \brief  A variable that is the address of another SDL_Window* (as a hex string formatted with "%p").
 *  
 *  If this hint is set before SDL_CreateWindowFrom() and the SDL_Window* it is set to has

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -2615,6 +2615,10 @@ int Wayland_input_confine_pointer(struct SDL_WaylandInput *input, SDL_Window *wi
     if (d->relative_mouse_mode)
         return 0;
 
+    /* Don't confine the pointer if it shouldn't be confined. */
+    if (SDL_RectEmpty(&window->mouse_rect) && !(window->flags & SDL_WINDOW_MOUSE_GRABBED))
+        return 0;
+
     if (SDL_RectEmpty(&window->mouse_rect)) {
         confine_rect = NULL;
     } else {

--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -131,6 +131,11 @@ struct SDL_WaylandInput {
     SDL_WaylandKeyboardRepeat keyboard_repeat;
 
     struct SDL_WaylandTabletInput* tablet;
+
+    /* are we forcing relative mouse mode? */
+    SDL_bool cursor_visible;
+    SDL_bool relative_mode_override;
+    SDL_bool warp_emulation_prohibited;
 };
 
 extern void Wayland_PumpEvents(_THIS);


### PR DESCRIPTION
Several games (including Source and GoldSrc games, and Bioshock Infinite) attempt to "fake" relative mouse mode by repeatedly warping the cursor to the centre of the screen. Since mouse warping is not supported under Wayland, the viewport ends up "stuck" in a rectangular area.

Detect this case (mouse warp while the cursor is not visible), and enable relative mouse mode, which tracks the cursor position
independently, and so can Warp successfully.

This is behind the ``SDL_HINT_VIDEO_WAYLAND_EMULATE_MOUSE_WARP`` hint, which is enabled by default.

Note that there is a behavioural difference, in that relative mouse mode typically doesn't take mouse acceleration into account, but the repeated-warping technique does, so mouse movement can seem very slow with this (unless the game has its own mouse acceleration option, such as in Portal 2).
