### PR TITLE
SDL_Rect: Disable -wfloat-equal for SDL_FRectEquals()

### DIFF
--- a/include/SDL_rect.h
+++ b/include/SDL_rect.h
@@ -238,14 +238,25 @@ SDL_FORCE_INLINE SDL_bool SDL_FRectEmpty(const SDL_FRect *r)
     return ((!r) || (r->w <= 0.0f) || (r->h <= 0.0f)) ? SDL_TRUE : SDL_FALSE;
 }
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+
 /**
  * Returns true if the two rectangles are equal.
+ *
+ * \warning Compares floats for equality using '==', without an epsilon.
  */
 SDL_FORCE_INLINE SDL_bool SDL_FRectEquals(const SDL_FRect *a, const SDL_FRect *b)
 {
     return (a && b && (a->x == b->x) && (a->y == b->y) &&
             (a->w == b->w) && (a->h == b->h)) ? SDL_TRUE : SDL_FALSE;
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 /**
  * Determine whether two rectangles intersect with float precision.


### PR DESCRIPTION
Disable `-Wfloat-equal` for this specific function since it's ugly and breaks client code building with both it and `-Werror`, e.g:

```bash
cc -std=c11 -O3 -fomit-frame-pointer -fstrict-aliasing -march=x86-64-v3 -mtune=native -msse4.2 \
-mavx2 -fno-math-errno -Wstrict-prototypes -Wmissing-prototypes -Wall -Wextra -Wshadow \
-Wstrict-aliasing -Wcast-qual -Wcast-align -Wpointer-arith -Wredundant-decls -Wfloat-equal \
-Wswitch-enum -fstack-protector -fvisibility=hidden -DNDEBUG -Werror \
-I/home/eddy/local/include/SDL2 -D_REENTRANT -c bitmap_font.c -o bitmap_font.o
In file included from /home/eddy/local/include/SDL2/SDL_video.h:33,
                 from /home/eddy/local/include/SDL2/SDL_events.h:33,
                 from /home/eddy/local/include/SDL2/SDL.h:41,
                 from bitmap_font.h:6,
                 from bitmap_font.c:3:
/home/eddy/local/include/SDL2/SDL_rect.h: In function 'SDL_FRectEquals':
/home/eddy/local/include/SDL2/SDL_rect.h:246:29: error: comparing floating-point with '==' or '!=' is unsafe [-Werror=float-equal]
  246 |     return (a && b && (a->x == b->x) && (a->y == b->y) &&
      |                             ^~
/home/eddy/local/include/SDL2/SDL_rect.h:246:47: error: comparing floating-point with '==' or '!=' is unsafe [-Werror=float-equal]
  246 |     return (a && b && (a->x == b->x) && (a->y == b->y) &&
      |                                               ^~
/home/eddy/local/include/SDL2/SDL_rect.h:247:19: error: comparing floating-point with '==' or '!=' is unsafe [-Werror=float-equal]
  247 |             (a->w == b->w) && (a->h == b->h)) ? SDL_TRUE : SDL_FALSE;
      |                   ^~
/home/eddy/local/include/SDL2/SDL_rect.h:247:37: error: comparing floating-point with '==' or '!=' is unsafe [-Werror=float-equal]
  247 |             (a->w == b->w) && (a->h == b->h)) ? SDL_TRUE : SDL_FALSE;
      |                                     ^~
cc1: all warnings being treated as errors
make: *** [Makefile:73: bitmap_font.o] Error 1
```

I looked around for a hot minute and couldn't find any previous discussion on this particular warning, but I may have missed it. 

Whatever else we could do here, this seems strictly better than keeping the warning around.