### PR TITLE
Small Wayland cleanups

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -668,15 +668,15 @@ Wayland_PopupWatch(void *data, SDL_Event *event)
 {
     if (event->type == SDL_MOUSEMOTION) {
         SDL_Window *window = (SDL_Window *) data;
-        SDL_WindowData *data = window->driverdata;
+        SDL_WindowData *wind = window->driverdata;
 
         /* Coordinates might be relative to the popup, which we don't want */
-        if (event->motion.windowID == data->shell_surface.xdg.roleobj.popup.parentID) {
-            xdg_positioner_set_offset(data->shell_surface.xdg.roleobj.popup.positioner,
+        if (event->motion.windowID == wind->shell_surface.xdg.roleobj.popup.parentID) {
+            xdg_positioner_set_offset(wind->shell_surface.xdg.roleobj.popup.positioner,
                                       event->motion.x + TOOLTIP_CURSOR_OFFSET,
                                       event->motion.y + TOOLTIP_CURSOR_OFFSET);
-            xdg_popup_reposition(data->shell_surface.xdg.roleobj.popup.popup,
-                                 data->shell_surface.xdg.roleobj.popup.positioner,
+            xdg_popup_reposition(wind->shell_surface.xdg.roleobj.popup.popup,
+                                 wind->shell_surface.xdg.roleobj.popup.positioner,
                                  0);
         }
     }

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -128,7 +128,6 @@ extern int Wayland_SetWindowModalFor(_THIS, SDL_Window * modal_window, SDL_Windo
 extern void Wayland_SetWindowTitle(_THIS, SDL_Window * window);
 extern void Wayland_DestroyWindow(_THIS, SDL_Window *window);
 extern void Wayland_SuspendScreenSaver(_THIS);
-extern int Wayland_SetDisplayMode(_THIS, SDL_VideoDisplay * display, SDL_DisplayMode * mode);
 
 extern SDL_bool
 Wayland_GetWindowWMInfo(_THIS, SDL_Window * window, SDL_SysWMinfo * info);


### PR DESCRIPTION
Fixes a -Wshadow warning and removes an unused function prototype (my fault, I deleted the function body, but accidentally left this in when prototyping the viewport/scaling code).

@flibitijibibo 