### PR TITLE
hidapi: Wrap CopyHIDDeviceInfo in define checks.

### DIFF
--- a/src/hidapi/SDL_hidapi.c
+++ b/src/hidapi/SDL_hidapi.c
@@ -951,6 +951,7 @@ DeleteHIDDeviceWrapper(SDL_hid_device *device)
     }
 
 #if !SDL_HIDAPI_DISABLED
+#if HAVE_PLATFORM_BACKEND || HAVE_DRIVER_BACKEND || defined(SDL_LIBUSB_DYNAMIC)
 
 #define COPY_IF_EXISTS(var) \
     if (pSrc->var != NULL) { \
@@ -987,6 +988,7 @@ CopyHIDDeviceInfo(struct SDL_hid_device_info *pSrc, struct SDL_hid_device_info *
 #undef COPY_IF_EXISTS
 #undef WCOPY_IF_EXISTS
 
+#endif /* HAVE_PLATFORM_BACKEND || HAVE_DRIVER_BACKEND || SDL_LIBUSB_DYNAMIC */
 #endif /* !SDL_HIDAPI_DISABLED */
 
 static int SDL_hidapi_refcount = 0;


### PR DESCRIPTION
Silence unused function warning when building SDL.

```
...src/hidapi/SDL_hidapi.c:969:1: warning: 'CopyHIDDeviceInfo' defined but not used [-Wunused-function]
  969 | CopyHIDDeviceInfo(struct SDL_hid_device_info *pSrc, struct SDL_hid_device_info *pDst)
```

I checked the defines it's used within:
line 1199: SDL_LIBUSB_DYNAMIC  
line 1220: HAVE_DRIVER_BACKEND
line 1277: HAVE_PLATFORM_BACKEND

These match those of `CreateHIDDeviceWrapper` which already has this define-guard. Given this precedent, I simply copied it.

I could have moved the code up instead, but there are a lot of additional defines/undefine and stuff around this code that IMO makes that even harder to read and maintain.