### PR TITLE
Add [NSWindow windowNumber] Access in SDL_syswm

### DIFF
--- a/include/SDL_syswm.h
+++ b/include/SDL_syswm.h
@@ -86,6 +86,7 @@ struct SDL_SysWMinfo;
 #else
 typedef struct _NSWindow NSWindow;
 #endif
+typedef CGWindowID unsigned int;
 #endif
 
 #if defined(SDL_VIDEO_DRIVER_UIKIT)
@@ -270,6 +271,7 @@ struct SDL_SysWMinfo
 #else
             NSWindow *window;                     /**< The Cocoa window */
 #endif
+            CGWindowID windowNumber;              /**< The CoreGraphics Window ID */
         } cocoa;
 #endif
 #if defined(SDL_VIDEO_DRIVER_UIKIT)

--- a/include/SDL_syswm.h
+++ b/include/SDL_syswm.h
@@ -86,7 +86,7 @@ struct SDL_SysWMinfo;
 #else
 typedef struct _NSWindow NSWindow;
 #endif
-typedef CGWindowID unsigned int;
+typedef unsigned int CGWindowID;
 #endif
 
 #if defined(SDL_VIDEO_DRIVER_UIKIT)


### PR DESCRIPTION
WIP. If I am doing something wrong in this pr or not how you guys prefer, please let me know while i progress to save time.

....

Notes:

A window number can be retrieved for the current app from a next step window with: `[(NSWindow *)window windowNumber]`. A next step window can be retrieved for the current app from a window number with: `[NSApp windowWithWindowNumber:(NSWindow *)window]`. To get a specific window number from a foreign app running on your current session, it can be guessed with `CGWindowListCopyWindowInfo(...)`. This can be useful for IPC interfacing with windows from two different apps or processes. Yes, this has been tested and verified.

And yes, Apple's documentation is incorrect and misleading. A `CGWindowID` is the exact same thing as a "windowNumber" and they are a global window id which can be used to identify a specific window in the window server. I don't know why Apple would deliberately lie about an OS-level feature they openly provide and expose to developers, while also nullifying any usefulness it would otherwise have if they just told us these things and were upfront about it.

I used to assume a `CGWindowID` was an `unsigned long` due that's what an Xlib window is, but since CoreGraphics and Xlib aren't the same thing it was no surprise that the compiler complained and told me it wanted to be fed an `unsigned int` for the `CGWindowID` typedef. Which is odd because iirc `windowNumber` actually returns an `unsigned long` so it looks like due to some oversight and/or bad programming they wasted on some excess precision underneath-the-hood.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
