### PR TITLE
test: Correct invalid enum length.

### DIFF
--- a/test/testautomation_hints.c
+++ b/test/testautomation_hints.c
@@ -8,7 +8,6 @@
 #include "SDL_test.h"
 
 
-const int _numHintsEnum = 25;
 const char* _HintsEnum[] =
   {
     SDL_HINT_ACCELEROMETER_AS_JOYSTICK,
@@ -62,6 +61,9 @@ const char* _HintsVerbose[] =
     "SDL_XINPUT_ENABLED"
   };
 
+SDL_COMPILE_TIME_ASSERT(HintsEnum, SDL_arraysize(_HintsEnum) == SDL_arraysize(_HintsVerbose));
+
+const int _numHintsEnum = SDL_arraysize(_HintsEnum);
 
 /* Test case functions */
 


### PR DESCRIPTION
Corrects the following warning (GCC 11.3.0), due to the length not matching the actual number of members of the enums.

```
testautomation_hints.c: In function 'hints_getHint':
testautomation_hints.c:79:15: warning: iteration 23 invokes undefined behavior [-Waggressive-loop-optimizations]
   79 |     result1 = SDL_GetHint(_HintsEnum[i]);
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~
testautomation_hints.c:78:14: note: within this loop
   78 |   for (i=0; i<_numHintsEnum; i++) {
      |             ~^~~~~~~~~~~~~~
testautomation_hints.c: In function 'hints_setHint':
testautomation_hints.c:134:14: warning: iteration 23 invokes undefined behavior [-Waggressive-loop-optimizations]
  134 |     result = SDL_SetHint(_HintsEnum[i], originalValue);
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
testautomation_hints.c:108:14: note: within this loop
  108 |   for (i=0; i<_numHintsEnum; i++) {
      |             ~^~~~~~~~~~~~~~
```