### PR TITLE
Add missing backslashes in README-linux.md command

### DIFF
--- a/docs/README-linux.md
+++ b/docs/README-linux.md
@@ -28,8 +28,8 @@ Fedora 35, all available features enabled:
     alsa-lib-devel pulseaudio-libs-devel nas-devel pipewire-devel \
     libX11-devel libXext-devel libXrandr-devel libXcursor-devel libXfixes-devel \
     libXi-devel libXScrnSaver-devel dbus-devel ibus-devel fcitx-devel \
-    systemd-devel mesa-libGL-devel libxkbcommon-devel mesa-libGLES-devel
-    mesa-libEGL-devel vulkan-devel wayland-devel wayland-protocols-devel
+    systemd-devel mesa-libGL-devel libxkbcommon-devel mesa-libGLES-devel \
+    mesa-libEGL-devel vulkan-devel wayland-devel wayland-protocols-devel \
     libdrm-devel mesa-libgbm-devel libusb-devel libdecor-devel \
     libsamplerate-devel pipewire-jack-audio-connection-kit-devel \
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Just a small fix to add some missing backslashes in the Linux README.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
