### PR TITLE
Fix for code generating -Wmaybe-uninitialized warning.

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -2670,11 +2670,16 @@ static int
 RenderDrawPointsWithRects(SDL_Renderer * renderer,
                           const SDL_Point * points, const int count)
 {
-    int retval = -1;
+    int retval;
     SDL_bool isstack;
-    SDL_FRect *frects = SDL_small_alloc(SDL_FRect, count, &isstack);
+    SDL_FRect *frects;
     int i;
 
+    if (count < 1) {
+        return 0;
+    }
+
+    frects = SDL_small_alloc(SDL_FRect, count, &isstack);
     if (!frects) {
         return SDL_OutOfMemory();
     }
@@ -2686,9 +2691,7 @@ RenderDrawPointsWithRects(SDL_Renderer * renderer,
         frects[i].h = renderer->scale.y;
     }
 
-    if (count) {
-        retval = QueueCmdFillRects(renderer, frects, count);
-    }
+    retval = QueueCmdFillRects(renderer, frects, count);
 
     SDL_small_free(frects, isstack);
 
@@ -2743,11 +2746,16 @@ static int
 RenderDrawPointsWithRectsF(SDL_Renderer * renderer,
                            const SDL_FPoint * fpoints, const int count)
 {
-    int retval = -1;
+    int retval;
     SDL_bool isstack;
-    SDL_FRect *frects = SDL_small_alloc(SDL_FRect, count, &isstack);
+    SDL_FRect *frects;
     int i;
 
+    if (count < 1) {
+        return 0;
+    }
+
+    frects = SDL_small_alloc(SDL_FRect, count, &isstack);
     if (!frects) {
         return SDL_OutOfMemory();
     }
@@ -2759,9 +2767,7 @@ RenderDrawPointsWithRectsF(SDL_Renderer * renderer,
         frects[i].h = renderer->scale.y;
     }
 
-    if (count) {
-        retval = QueueCmdFillRects(renderer, frects, count);
-    }
+    retval = QueueCmdFillRects(renderer, frects, count);
 
     SDL_small_free(frects, isstack);
 


### PR DESCRIPTION
Rearranging the code like this, specifically checking that we're not allocating 0 things,
silences a warning raised by GCC 12.0.1

Fixes #5587
