### PR TITLE
Fix crash when reading background events for MFi controllers on macOS

### DIFF
--- a/src/joystick/iphoneos/SDL_mfijoystick.m
+++ b/src/joystick/iphoneos/SDL_mfijoystick.m
@@ -180,6 +180,10 @@ IsControllerXbox(GCController *controller)
 static BOOL
 IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCController *controller)
 {
+    if ((@available(macOS 11.3, *)) && !GCController.shouldMonitorBackgroundEvents) {
+        GCController.shouldMonitorBackgroundEvents = YES;
+    }
+
     Uint16 *guid16 = (Uint16 *)device->guid.data;
     Uint16 vendor = 0;
     Uint16 product = 0;
@@ -586,10 +590,6 @@ IOS_JoystickInit(void)
         /* GameController.framework was added in iOS 7. */
         if (![GCController class]) {
             return 0;
-        }
-
-        if (@available(macOS 11.3, iOS 14.5, tvOS 14.5, *)) {
-            GCController.shouldMonitorBackgroundEvents = YES;
         }
 
         /* For whatever reason, this always returns an empty array on


### PR DESCRIPTION
## Description
Enabling GCController.shouldMonitorBackgroundEvents to read background events for MFi controllers before receiving the first GCControllerDidConnectNotification is apparently a no-go on macOS (12.3.1 for me), and would crash on attempt.
Apple's documentation is... not great, and doesn't point this out.

This waits for IOS_AddMFIJoystickDevice() to get called down the chain from GCControllerDidConnectNotification, and enables GCController.shouldMonitorBackgroundEvents if it hadn't been already.

On iOS and tvOS, GCController.shouldMonitorBackgroundEvents is ignored, so there's no need to check their versions.