### PR TITLE
Add new verbosity level for logging of `SDL_SysWMEvent`s

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -392,13 +392,14 @@ extern "C" {
 #define SDL_HINT_ENABLE_STEAM_CONTROLLERS "SDL_ENABLE_STEAM_CONTROLLERS"
 
 /**
- *  \brief  A variable controlling whether SDL logs all events pushed onto its internal queue.
+ *  \brief  A variable controlling verbosity of the logging of SDL events pushed onto the internal queue.
  *
- *  This variable can be set to the following values:
+ *  This variable can be set to the following values, from least to most verbose:
  *
  *    "0"     - Don't log any events (default)
- *    "1"     - Log all events except mouse and finger motion, which are pretty spammy.
- *    "2"     - Log all events.
+ *    "1"     - Log most events (other than the really spammy ones).
+ *    "2"     - Include mouse and finger motion events.
+ *    "3"     - Include SDL_SysWMEvent events.
  *
  *  This is generally meant to be used to debug SDL itself, but can be useful
  *  for application developers that need better visibility into what is going


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adds a new verbosity level (3) for logging of `SDL_SYSWMEVENT` events. This complements the current verbosity levels that are available with `SDL_HINT_EVENT_LOGGING`.

The hint description is updated to accommodate the change.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->

When enabled, `SDL_SYSWMEVENT` are really spammy, even more so mouse motion events. So it makes sense to hide them under the most verbose logging level. Additionally, the events don't provide much useful info (so even less incentive to have them logged):

```cs
INFO: SDL EVENT: SDL_SYSWMEVENT (timestamp=2134)
INFO: SDL EVENT: SDL_SYSWMEVENT (timestamp=2134)
INFO: SDL EVENT: SDL_SYSWMEVENT (timestamp=2136)
```