### PR TITLE
Add mouse4/mouse5 support to X11_GetGlobalMouseState

### DIFF
--- a/src/video/x11/SDL_x11mouse.c
+++ b/src/video/x11/SDL_x11mouse.c
@@ -406,6 +406,8 @@ X11_GetGlobalMouseState(int *x, int *y)
                     buttons |= (mask & Button1Mask) ? SDL_BUTTON_LMASK : 0;
                     buttons |= (mask & Button2Mask) ? SDL_BUTTON_MMASK : 0;
                     buttons |= (mask & Button3Mask) ? SDL_BUTTON_RMASK : 0;
+                    buttons |= (mask & Button4Mask) ? SDL_BUTTON_X1MASK : 0;
+                    buttons |= (mask & Button5Mask) ? SDL_BUTTON_X2MASK : 0;
                     /* SDL_DisplayData->x,y point to screen origin, and adding them to mouse coordinates relative to root window doesn't do the right thing
                      * (observed on dual monitor setup with primary display being the rightmost one - mouse was offset to the right).
                      *


### PR DESCRIPTION
Adds missing mouse4/mouse5 checks to X11_GetGlobalMouseState.

## Description
Makes X11_GetGlobalMouseState set the X1/X2MASK button flags if x11 reports button4/button5 being pressed.