### PR TITLE
Fix NULL dereference in SDL_UpdateMouseCapture() while mouse is grabbed

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -1007,9 +1007,11 @@ SDL_UpdateMouseCapture(SDL_bool force_release)
 
     if (capture_window != mouse->capture_window) {
         if (mouse->capture_window) {
-            mouse->CaptureMouse(NULL);
-            mouse->capture_window->flags &= ~SDL_WINDOW_MOUSE_CAPTURE;
-            mouse->capture_window = NULL;
+            mouse->CaptureMouse(NULL); /* May clear mouse->capture_window */
+            if (mouse->capture_window) {
+                mouse->capture_window->flags &= ~SDL_WINDOW_MOUSE_CAPTURE;
+                mouse->capture_window = NULL;
+            }
         }
 
         if (capture_window) {


### PR DESCRIPTION
This fixes a crash introduced in 86acb1a347fb232f (did a git bisect and this was the guilty commit).
On my system (win10-x64/msvc19) `mouse->CaptureMouse()` (aka `WIN_CaptureMouse()`) could set `mouse->capture_window = NULL`, causing a crash.

I'm not sure if this fix is 100% correct, an alternative might be to move
```
mouse->capture_window->flags &= ~SDL_WINDOW_MOUSE_CAPTURE;
```
before
```
mouse->CaptureMouse(NULL);
```
but then we lose the SDL_WINDOW_MOUSE_CAPTURE flag (is this a problem? probably.)

This issue manifested during work on [Aquaria](https://github.com/AquariaOSE/Aquaria), after multiple calls to win32 MessageBox() and two subsequent map changes while holding a mouse button.
`SDL_SetWindowGrab()` was enabled on startup and stayed on all the time.
The crash is a bit elusive but was 100% reproducible after I figured out a reliable way to trigger this.
Seems that the msgbox interferes with focus handling and thus has an influence on the grab data but i'm not sure about this.
