### PR TITLE
workflows: Fix CI after #5602

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -11,6 +11,6 @@ jobs:
         with:
           version: 2.0.27
       - name: Configure CMake
-        run: emcmake cmake -B build
+        run: emcmake cmake -B build -DCMAKE_VERBOSE_MAKEFILE=ON
       - name: Build
-        run: cmake -v --build build/
+        run: cmake --build build/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,7 @@ jobs:
     - name: Build
       run: cmake --build build/ --config Release
     - name: Install
+      if: matrix.platform.shell == 'sh'
       run: |
         set -eu
         rm -fr DESTDIR-cmake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,6 @@ jobs:
     - name: Install
       run: |
         set -eu
-        cmake -v --build build/ --config Release
         rm -fr DESTDIR-cmake
         DESTDIR=$(pwd)/DESTDIR-cmake cmake -v --install build/ --config Release
         ( cd DESTDIR-cmake; find ) | LC_ALL=C sort -u

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,14 +82,14 @@ jobs:
       if: runner.os == 'Linux'
       run: ./test/versioning.sh
     - name: Configure CMake
-      run: cmake -B build -DSDL_TEST=ON ${{ matrix.platform.flags }}
+      run: cmake -B build -DSDL_TEST=ON -DCMAKE_VERBOSE_MAKEFILE=ON ${{ matrix.platform.flags }}
     - name: Build
-      run: cmake -v --build build/ --config Release
+      run: cmake --build build/ --config Release
     - name: Install
       run: |
         set -eu
         rm -fr DESTDIR-cmake
-        DESTDIR=$(pwd)/DESTDIR-cmake cmake -v --install build/ --config Release
+        DESTDIR=$(pwd)/DESTDIR-cmake cmake --install build/ --config Release
         ( cd DESTDIR-cmake; find ) | LC_ALL=C sort -u
     - name: Configure Autotools
       if: runner.os == 'Linux'

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Configure CMake
       run: cmake -B build -DSDL_TEST=ON ${{ matrix.platform.flags }}
     - name: Build CMake
-      run: cmake -v --build build/ --config Release --parallel
+      run: cmake --build build/ --config Release --parallel
 
     - name: Add msbuild to PATH
       if: ${{ matrix.platform.project != '' }}

--- a/.github/workflows/riscos.yml
+++ b/.github/workflows/riscos.yml
@@ -23,6 +23,6 @@ jobs:
       run: apt-get update && apt-get install -y cmake ninja-build
     - uses: actions/checkout@v2
     - name: Configure CMake
-      run: cmake -S. -Bbuild -G Ninja -DCMAKE_TOOLCHAIN_FILE=/home/riscos/env/toolchain-riscos.cmake -DRISCOS=ON -DSDL_GCC_ATOMICS=OFF -DCMAKE_BUILD_TYPE=Release
+      run: cmake -S. -Bbuild -G Ninja -DCMAKE_TOOLCHAIN_FILE=/home/riscos/env/toolchain-riscos.cmake -DRISCOS=ON -DSDL_GCC_ATOMICS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=ON
     - name: Build
-      run: cmake -v --build build
+      run: cmake --build build


### PR DESCRIPTION
* workflows: Remove redundant `cmake --build`

* workflows: Change how we make CMake verbose
    
    Some CI workers don't seem to understand `cmake -v`, and Windows' shell
    doesn't understand `VERBOSE=1 cmake`.

* workflows: Only run `cmake --install` on Unix platforms
    
    The syntax used in this step assumes a Unix shell.