### PR TITLE
Use `SDL_TEXTEDITING_EXT` in linux IME and provide useful cursor info

### DIFF
--- a/include/SDL_stdinc.h
+++ b/include/SDL_stdinc.h
@@ -561,6 +561,7 @@ extern DECLSPEC char *SDLCALL SDL_strrchr(const char *str, int c);
 extern DECLSPEC char *SDLCALL SDL_strstr(const char *haystack, const char *needle);
 extern DECLSPEC char *SDLCALL SDL_strtokr(char *s1, const char *s2, char **saveptr);
 extern DECLSPEC size_t SDLCALL SDL_utf8strlen(const char *str);
+extern DECLSPEC size_t SDLCALL SDL_utf8strnlen(const char *str, size_t bytes);
 
 extern DECLSPEC char *SDLCALL SDL_itoa(int value, char *str, int radix);
 extern DECLSPEC char *SDLCALL SDL_uitoa(unsigned int value, char *str, int radix);

--- a/src/core/linux/SDL_ibus.c
+++ b/src/core/linux/SDL_ibus.c
@@ -22,6 +22,7 @@
 
 #ifdef HAVE_IBUS_IBUS_H
 #include "SDL.h"
+#include "SDL_hints.h"
 #include "SDL_syswm.h"
 #include "SDL_ibus.h"
 #include "SDL_dbus.h"
@@ -66,107 +67,217 @@ IBus_ModState(void)
     return ibus_mods;
 }
 
+static SDL_bool
+IBus_EnterVariant(DBusConnection *conn, DBusMessageIter *iter, SDL_DBusContext *dbus,
+                  DBusMessageIter *inside, const char * struct_id, size_t id_size)
+{
+    DBusMessageIter sub;
+    if (dbus->message_iter_get_arg_type(iter) != DBUS_TYPE_VARIANT) {
+        return SDL_FALSE;
+    }
+
+    dbus->message_iter_recurse(iter, &sub);
+
+    if (dbus->message_iter_get_arg_type(&sub) != DBUS_TYPE_STRUCT) {
+        return SDL_FALSE;
+    }
+
+    dbus->message_iter_recurse(&sub, inside);
+
+    if (dbus->message_iter_get_arg_type(inside) != DBUS_TYPE_STRING) {
+        return SDL_FALSE;
+    }
+
+    dbus->message_iter_get_basic(inside, &struct_id);
+    if (!struct_id || SDL_strncmp(struct_id, struct_id, id_size) != 0) {
+        return SDL_FALSE;
+    }
+    return SDL_TRUE;
+}
+
+static SDL_bool
+IBus_GetDecorationPosition(DBusConnection *conn, DBusMessageIter *iter, SDL_DBusContext *dbus,
+                           Uint32 *start_pos, Uint32 *end_pos)
+{
+    DBusMessageIter sub1, sub2, array;
+
+    if (!IBus_EnterVariant(conn, iter, dbus, &sub1, "IBusText", sizeof("IBusText"))) {
+        return SDL_FALSE;
+    }
+
+    dbus->message_iter_next(&sub1);
+    dbus->message_iter_next(&sub1);
+    dbus->message_iter_next(&sub1);
+
+    if (!IBus_EnterVariant(conn, &sub1, dbus, &sub2, "IBusAttrList", sizeof("IBusAttrList"))) {
+        return SDL_FALSE;
+    }
+
+    dbus->message_iter_next(&sub2);
+    dbus->message_iter_next(&sub2);
+
+    if (dbus->message_iter_get_arg_type(&sub2) != DBUS_TYPE_ARRAY) {
+        return SDL_FALSE;
+    }
+
+    dbus->message_iter_recurse(&sub2, &array);
+
+    while (dbus->message_iter_get_arg_type(&array) == DBUS_TYPE_VARIANT) {
+        DBusMessageIter sub;
+        if (IBus_EnterVariant(conn, &array, dbus, &sub, "IBusAttribute", sizeof("IBusAttribute"))) {
+            Uint32 type;
+
+            dbus->message_iter_next(&sub);
+            dbus->message_iter_next(&sub);
+
+            /* From here on, the structure looks like this:                    */
+            /* Uint32 type: 1=underline, 2=foreground, 3=background            */
+            /* Uint32 value: for underline it's 0=NONE, 1=SINGLE, 2=DOUBLE,    */
+            /*                                    3=LOW,  4=ERROR              */
+            /*                 for foreground and background it's a color      */
+            /* Uint32 start_index: starting position for the style (utf8-char) */
+            /* Uint32 end_index: end position for the style (utf8-char)        */
+
+            dbus->message_iter_get_basic(&sub, &type);
+            /* We only use the background type to determine the selection */
+            if (type == 3) {
+                Uint32 start = -1;
+                dbus->message_iter_next(&sub);
+                dbus->message_iter_next(&sub);
+                if (dbus->message_iter_get_arg_type(&sub) == DBUS_TYPE_UINT32) {
+                    dbus->message_iter_get_basic(&sub, &start);
+                    dbus->message_iter_next(&sub);
+                    if (dbus->message_iter_get_arg_type(&sub) == DBUS_TYPE_UINT32) {
+                        dbus->message_iter_get_basic(&sub, end_pos);
+                        *start_pos = start;
+                        return SDL_TRUE;
+                    }
+                }
+            }
+        }
+        dbus->message_iter_next(&array);
+    }
+    return SDL_FALSE;
+}
+
 static const char *
 IBus_GetVariantText(DBusConnection *conn, DBusMessageIter *iter, SDL_DBusContext *dbus)
 {
     /* The text we need is nested weirdly, use dbus-monitor to see the structure better */
     const char *text = NULL;
-    const char *struct_id = NULL;
-    DBusMessageIter sub1, sub2;
+    DBusMessageIter sub;
 
-    if (dbus->message_iter_get_arg_type(iter) != DBUS_TYPE_VARIANT) {
+    if (!IBus_EnterVariant(conn, iter, dbus, &sub, "IBusText", sizeof("IBusText"))) {
         return NULL;
     }
-    
-    dbus->message_iter_recurse(iter, &sub1);
-    
-    if (dbus->message_iter_get_arg_type(&sub1) != DBUS_TYPE_STRUCT) {
+
+    dbus->message_iter_next(&sub);
+    dbus->message_iter_next(&sub);
+
+    if (dbus->message_iter_get_arg_type(&sub) != DBUS_TYPE_STRING) {
         return NULL;
     }
-    
-    dbus->message_iter_recurse(&sub1, &sub2);
-    
-    if (dbus->message_iter_get_arg_type(&sub2) != DBUS_TYPE_STRING) {
-        return NULL;
-    }
-    
-    dbus->message_iter_get_basic(&sub2, &struct_id);
-    if (!struct_id || SDL_strncmp(struct_id, "IBusText", sizeof("IBusText")) != 0) {
-        return NULL;
-    }
-    
-    dbus->message_iter_next(&sub2);
-    dbus->message_iter_next(&sub2);
-    
-    if (dbus->message_iter_get_arg_type(&sub2) != DBUS_TYPE_STRING) {
-        return NULL;
-    }
-    
-    dbus->message_iter_get_basic(&sub2, &text);
-    
+    dbus->message_iter_get_basic(&sub, &text);
+
     return text;
+}
+
+static SDL_bool
+IBus_GetVariantCursorPos(DBusConnection *conn, DBusMessageIter *iter, SDL_DBusContext *dbus,
+                         Uint32 *pos)
+{
+    dbus->message_iter_next(iter);
+
+    if (dbus->message_iter_get_arg_type(iter) != DBUS_TYPE_UINT32) {
+        return SDL_FALSE;
+    }
+
+    dbus->message_iter_get_basic(iter, pos);
+
+    return SDL_TRUE;
 }
 
 static DBusHandlerResult
 IBus_MessageHandler(DBusConnection *conn, DBusMessage *msg, void *user_data)
 {
     SDL_DBusContext *dbus = (SDL_DBusContext *)user_data;
-        
+
     if (dbus->message_is_signal(msg, IBUS_INPUT_INTERFACE, "CommitText")) {
         DBusMessageIter iter;
         const char *text;
 
         dbus->message_iter_init(msg, &iter);
-        
         text = IBus_GetVariantText(conn, &iter, dbus);
+
         if (text && *text) {
             char buf[SDL_TEXTINPUTEVENT_TEXT_SIZE];
             size_t text_bytes = SDL_strlen(text), i = 0;
-            
+
             while (i < text_bytes) {
                 size_t sz = SDL_utf8strlcpy(buf, text+i, sizeof(buf));
                 SDL_SendKeyboardText(buf);
-                
+
                 i += sz;
             }
         }
-        
+
         return DBUS_HANDLER_RESULT_HANDLED;
     }
-    
+
     if (dbus->message_is_signal(msg, IBUS_INPUT_INTERFACE, "UpdatePreeditText")) {
         DBusMessageIter iter;
         const char *text;
 
         dbus->message_iter_init(msg, &iter);
         text = IBus_GetVariantText(conn, &iter, dbus);
-        
-        if (text) {
-            char buf[SDL_TEXTEDITINGEVENT_TEXT_SIZE];
-            size_t text_bytes = SDL_strlen(text), i = 0;
-            size_t cursor = 0;
-            
-            do {
-                const size_t sz = SDL_utf8strlcpy(buf, text+i, sizeof(buf));
-                const size_t chars = SDL_utf8strlen(buf);
-                
-                SDL_SendEditingText(buf, cursor, chars);
 
-                i += sz;
-                cursor += chars;
-            } while (i < text_bytes);
+        if (text) {
+            if (SDL_GetHintBoolean(SDL_HINT_IME_SUPPORT_EXTENDED_TEXT, SDL_FALSE)) {
+                Uint32 pos, start_pos, end_pos;
+                SDL_bool has_pos = SDL_FALSE;
+                SDL_bool has_dec_pos = SDL_FALSE;
+
+                dbus->message_iter_init(msg, &iter);
+                has_dec_pos = IBus_GetDecorationPosition(conn, &iter, dbus, &start_pos, &end_pos);
+                if (!has_dec_pos)
+                {
+                    dbus->message_iter_init(msg, &iter);
+                    has_pos = IBus_GetVariantCursorPos(conn, &iter, dbus, &pos);
+                }
+
+                if(has_dec_pos) {
+                    SDL_SendEditingText(text, start_pos, end_pos - start_pos);
+                } else if (has_pos) {
+                    SDL_SendEditingText(text, pos, -1);
+                } else {
+                    SDL_SendEditingText(text, -1, -1);
+                }
+            } else {
+                char buf[SDL_TEXTEDITINGEVENT_TEXT_SIZE];
+                size_t text_bytes = SDL_strlen(text), i = 0;
+                size_t cursor = 0;
+
+                do {
+                    const size_t sz = SDL_utf8strlcpy(buf, text+i, sizeof(buf));
+                    const size_t chars = SDL_utf8strlen(buf);
+
+                    SDL_SendEditingText(buf, cursor, chars);
+                    i += sz;
+                    cursor += chars;
+                } while (i < text_bytes);
+            }
         }
-        
+
         SDL_IBus_UpdateTextRect(NULL);
-        
+
         return DBUS_HANDLER_RESULT_HANDLED;
     }
-    
+
     if (dbus->message_is_signal(msg, IBUS_INPUT_INTERFACE, "HidePreeditText")) {
         SDL_SendEditingText("", 0, 0);
         return DBUS_HANDLER_RESULT_HANDLED;
     }
-    
+
     return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 }
 

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -874,3 +874,4 @@
 #define SDL_HasLSX SDL_HasLSX_REAL
 #define SDL_HasLASX SDL_HasLASX_REAL
 #define SDL_RenderGetD3D12Device SDL_RenderGetD3D12Device_REAL
+#define SDL_utf8strnlen SDL_utf8strnlen_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -951,3 +951,4 @@ SDL_DYNAPI_PROC(SDL_bool,SDL_HasLASX,(void),(),return)
 #ifdef __WIN32__
 SDL_DYNAPI_PROC(ID3D12Device*,SDL_RenderGetD3D12Device,(SDL_Renderer *a),(a),return)
 #endif
+SDL_DYNAPI_PROC(size_t,SDL_utf8strnlen,(const char *a, size_t b),(a,b),return)

--- a/src/stdlib/SDL_string.c
+++ b/src/stdlib/SDL_string.c
@@ -676,6 +676,23 @@ SDL_utf8strlen(const char *str)
 }
 
 size_t
+SDL_utf8strnlen(const char *str, size_t bytes)
+{
+    size_t retval = 0;
+    const char *p = str;
+    unsigned char ch;
+
+    while ((ch = *(p++)) != 0 && bytes-- > 0) {
+        /* if top two bits are 1 and 0, it's a continuation byte. */
+        if ((ch & 0xc0) != 0x80) {
+            retval++;
+        }
+    }
+
+    return retval;
+}
+
+size_t
 SDL_strlcat(SDL_INOUT_Z_CAP(maxlen) char *dst, const char *src, size_t maxlen)
 {
 #if defined(HAVE_STRLCAT)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The linux IME backends use a workaround to avoid the byte limit of `SDL_TEXTEDITING`. That is, they split the preedit string in multiple chunks.
With the introduction of `SDL_TEXTEDITING_EXT`, the workaround is no longer needed. Moreover, because of the workaround, the new event isn't actually used.

With this PR, if `SDL_HINT_IME_SUPPORT_EXTENDED_TEXT` is `true`, we send the whole preedit string at once.

If the hint is `true` we now also retrieve the cursor position and selection size (in utf-8 characters, not bytes) for all backends.

In iBus and Fcitx there is no simple way to obtain the selection size as they don't specify it directly, but only declare how to decorate (highlight, underline, ...) each character/section of the preedit string.
Because of this, I decided to extract the selection position and size by looking at the first highlighted section. If this is not found, we read the position the "normal" way.

If the hint is `false` the old behavior is kept to avoid breaking existing clients.