### PR TITLE
Addition of clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -72,5 +72,15 @@ SpaceInEmptyParentheses: false
 
 UseCRLF: false
 UseTab: Never
+
+ForEachMacros:
+  [
+    "spa_list_for_each",
+    "spa_list_for_each_safe",
+    "wl_list_for_each",
+    "wl_array_for_each",
+    "udev_list_entry_foreach",
+  ]
+
 ---
 

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,76 @@
+---
+AlignConsecutiveMacros: Consecutive
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Right
+AlignOperands: Align
+AlignTrailingComments: true
+
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse
+AllowShortLoopsOnASingleLine: false
+
+AlwaysBreakAfterDefinitionReturnType: All
+AlwaysBreakAfterReturnType: AllDefinitions
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+
+# Custom brace breaking
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: Never
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: false
+  BeforeElse: false
+  BeforeWhile: true
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+
+# Make the closing brace of container literals go to a new line
+Cpp11BracedListStyle: false
+
+# Never format includes
+IncludeBlocks: Preserve
+SortIncludes: Never
+
+# No length limit, in case it breaks macros, you can
+# disable it with /* clang-format off/on */ comments
+ColumnLimit: 0
+
+IndentWidth: 4
+ContinuationIndentWidth: 4
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: NoIndent
+
+SpaceAfterCStyleCast: true
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeParens: ControlStatements
+SpaceAroundPointerQualifiers: Default
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+
+UseCRLF: false
+UseTab: Never
+---
+

--- a/src/audio/netbsd/SDL_netbsdaudio.c
+++ b/src/audio/netbsd/SDL_netbsdaudio.c
@@ -56,7 +56,7 @@ static void
 NETBSDAUDIO_Status(_THIS)
 {
 #ifdef DEBUG_AUDIO
-    /* *INDENT-OFF* */
+    /* *INDENT-OFF* */ /* clang-format off */
     audio_info_t info;
     const struct audio_prinfo *prinfo;
 
@@ -118,7 +118,7 @@ NETBSDAUDIO_Status(_THIS)
             "",
             this->spec.format,
             this->spec.size);
-    /* *INDENT-ON* */
+    /* *INDENT-ON* */ /* clang-format on */
 #endif /* DEBUG_AUDIO */
 }
 

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -130,7 +130,7 @@ CPU_haveCPUID(void)
 {
     int has_CPUID = 0;
 
-/* *INDENT-OFF* */
+/* *INDENT-OFF* */ /* clang-format off */
 #ifndef SDL_CPUINFO_DISABLED
 #if (defined(__GNUC__) || defined(__llvm__)) && defined(__i386__)
     __asm__ (
@@ -219,7 +219,7 @@ done:
     );
 #endif
 #endif
-/* *INDENT-ON* */
+/* *INDENT-ON* */ /* clang-format on */
     return has_CPUID;
 }
 

--- a/src/events/scancodes_darwin.h
+++ b/src/events/scancodes_darwin.h
@@ -25,7 +25,7 @@
    - Apple USB keyboard driver source <http://darwinsource.opendarwin.org/10.4.6.ppc/IOHIDFamily-172.8/IOHIDFamily/Cosmo_USB2ADB.c>
    - experimentation on various ADB and USB ISO keyboards and one ADB ANSI keyboard
 */
-/* *INDENT-OFF* */
+/* *INDENT-OFF* */ /* clang-format off */
 static const SDL_Scancode darwin_scancode_table[] = {
     /*   0 */   SDL_SCANCODE_A,
     /*   1 */   SDL_SCANCODE_S,
@@ -156,4 +156,4 @@ static const SDL_Scancode darwin_scancode_table[] = {
     /* 126 */   SDL_SCANCODE_UP,
     /* 127 */   SDL_SCANCODE_POWER
 };
-/* *INDENT-ON* */
+/* *INDENT-ON* */ /* clang-format on */

--- a/src/events/scancodes_linux.h
+++ b/src/events/scancodes_linux.h
@@ -24,7 +24,7 @@
    Sources:
    - Linux kernel source input.h
 */
-/* *INDENT-OFF* */
+/* *INDENT-OFF* */ /* clang-format off */
 static SDL_Scancode const linux_scancode_table[] = {
     /*  0 */    SDL_SCANCODE_UNKNOWN,
     /*  1 */    SDL_SCANCODE_ESCAPE,
@@ -260,4 +260,4 @@ static SDL_Scancode const linux_scancode_table[] = {
     /*  235 */    SDL_SCANCODE_UNKNOWN, /* KEY_DOCUMENTS */
     /*  236 */    SDL_SCANCODE_UNKNOWN, /* KEY_BATTERY */
 };
-/* *INDENT-ON* */
+/* *INDENT-ON* */ /* clang-format on */

--- a/src/events/scancodes_windows.h
+++ b/src/events/scancodes_windows.h
@@ -23,7 +23,7 @@
 /* Windows scancode to SDL scancode mapping table */
 /* derived from Microsoft scan code document, http://download.microsoft.com/download/1/6/1/161ba512-40e2-4cc9-843a-923143f3456c/scancode.doc */
 
-/* *INDENT-OFF* */
+/* *INDENT-OFF* */ /* clang-format off */
 static const SDL_Scancode windows_scancode_table[] = 
 { 
 	/*	0						1							2							3							4						5							6							7 */
@@ -52,4 +52,4 @@ static const SDL_Scancode windows_scancode_table[] =
 	SDL_SCANCODE_INTERNATIONAL2,		SDL_SCANCODE_UNKNOWN,		SDL_SCANCODE_UNKNOWN,		SDL_SCANCODE_INTERNATIONAL1,		SDL_SCANCODE_UNKNOWN,	SDL_SCANCODE_UNKNOWN,		SDL_SCANCODE_UNKNOWN,		SDL_SCANCODE_UNKNOWN,	/* 7 */
 	SDL_SCANCODE_UNKNOWN,		SDL_SCANCODE_INTERNATIONAL4,		SDL_SCANCODE_UNKNOWN,		SDL_SCANCODE_INTERNATIONAL5,		SDL_SCANCODE_UNKNOWN,	SDL_SCANCODE_INTERNATIONAL3,		SDL_SCANCODE_UNKNOWN,		SDL_SCANCODE_UNKNOWN	/* 7 */
 };
-/* *INDENT-ON* */
+/* *INDENT-ON* */ /* clang-format on */

--- a/src/events/scancodes_xfree86.h
+++ b/src/events/scancodes_xfree86.h
@@ -28,7 +28,7 @@
    Sources:
    - atKeyNames.h from XFree86 source code
 */
-/* *INDENT-OFF* */
+/* *INDENT-OFF* */ /* clang-format off */
 static const SDL_Scancode xfree86_scancode_table[] = {
     /*  0 */    SDL_SCANCODE_UNKNOWN,
     /*  1 */    SDL_SCANCODE_ESCAPE,
@@ -509,4 +509,4 @@ static const SDL_Scancode xvnc_scancode_table[] = {
 
 #endif /* scancodes_xfree86_h_ */
 
-/* *INDENT-ON* */
+/* *INDENT-ON* */ /* clang-format on */

--- a/src/stdlib/SDL_iconv.c
+++ b/src/stdlib/SDL_iconv.c
@@ -126,7 +126,7 @@ static struct
     const char *name;
     int format;
 } encodings[] = {
-/* *INDENT-OFF* */
+/* *INDENT-OFF* */ /* clang-format off */
     { "ASCII", ENCODING_ASCII },
     { "US-ASCII", ENCODING_ASCII },
     { "8859-1", ENCODING_LATIN1 },
@@ -160,7 +160,7 @@ static struct
     { "UCS-4LE", ENCODING_UCS4LE },
     { "UCS-4BE", ENCODING_UCS4BE },
     { "UCS-4-INTERNAL", ENCODING_UCS4NATIVE },
-/* *INDENT-ON* */
+/* *INDENT-ON* */ /* clang-format on */
 };
 
 static const char *

--- a/src/video/SDL_blit_1.c
+++ b/src/video/SDL_blit_1.c
@@ -50,7 +50,7 @@ Blit1to1(SDL_BlitInfo * info)
 
     while (height--) {
 #ifdef USE_DUFFS_LOOP
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
             {
               *dst = map[*src];
@@ -58,7 +58,7 @@ Blit1to1(SDL_BlitInfo * info)
             dst++;
             src++;
         , width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
 #else
         for (c = width; c; --c) {
             *dst = map[*src];
@@ -103,14 +103,14 @@ Blit1to2(SDL_BlitInfo * info)
 
 #ifdef USE_DUFFS_LOOP
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
         {
             *(Uint16 *)dst = map[*src++];
             dst += 2;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src += srcskip;
         dst += dstskip;
     }
@@ -210,7 +210,7 @@ Blit1to3(SDL_BlitInfo * info)
 
     while (height--) {
 #ifdef USE_DUFFS_LOOP
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
             {
                 o = *src * 4;
@@ -221,7 +221,7 @@ Blit1to3(SDL_BlitInfo * info)
             src++;
             dst += 3;
         , width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
 #else
         for (c = width; c; --c) {
             o = *src * 4;
@@ -259,11 +259,11 @@ Blit1to4(SDL_BlitInfo * info)
 
     while (height--) {
 #ifdef USE_DUFFS_LOOP
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
             *dst++ = map[*src++];
         , width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
 #else
         for (c = width / 4; c; --c) {
             *dst++ = map[*src++];
@@ -299,7 +299,7 @@ Blit1to1Key(SDL_BlitInfo * info)
 
     if (palmap) {
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
             {
                 if ( *src != ckey ) {
@@ -309,13 +309,13 @@ Blit1to1Key(SDL_BlitInfo * info)
                 src++;
             },
             width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             src += srcskip;
             dst += dstskip;
         }
     } else {
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
             {
                 if ( *src != ckey ) {
@@ -325,7 +325,7 @@ Blit1to1Key(SDL_BlitInfo * info)
                 src++;
             },
             width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             src += srcskip;
             dst += dstskip;
         }
@@ -348,7 +348,7 @@ Blit1to2Key(SDL_BlitInfo * info)
     dstskip /= 2;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
         {
             if ( *src != ckey ) {
@@ -358,7 +358,7 @@ Blit1to2Key(SDL_BlitInfo * info)
             dstp++;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src += srcskip;
         dstp += dstskip;
     }
@@ -378,7 +378,7 @@ Blit1to3Key(SDL_BlitInfo * info)
     int o;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
         {
             if ( *src != ckey ) {
@@ -391,7 +391,7 @@ Blit1to3Key(SDL_BlitInfo * info)
             dst += 3;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src += srcskip;
         dst += dstskip;
     }
@@ -413,7 +413,7 @@ Blit1to4Key(SDL_BlitInfo * info)
     dstskip /= 4;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
         {
             if ( *src != ckey ) {
@@ -423,7 +423,7 @@ Blit1to4Key(SDL_BlitInfo * info)
             dstp++;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src += srcskip;
         dstp += dstskip;
     }
@@ -450,7 +450,7 @@ Blit1toNAlpha(SDL_BlitInfo * info)
     dstbpp = dstfmt->BytesPerPixel;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP4(
         {
             sR = srcpal[*src].r;
@@ -463,7 +463,7 @@ Blit1toNAlpha(SDL_BlitInfo * info)
             dst += dstbpp;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src += srcskip;
         dst += dstskip;
     }
@@ -491,7 +491,7 @@ Blit1toNAlphaKey(SDL_BlitInfo * info)
     dstbpp = dstfmt->BytesPerPixel;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
         {
             if ( *src != ckey ) {
@@ -506,7 +506,7 @@ Blit1toNAlphaKey(SDL_BlitInfo * info)
             dst += dstbpp;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src += srcskip;
         dst += dstskip;
     }

--- a/src/video/SDL_blit_A.c
+++ b/src/video/SDL_blit_A.c
@@ -47,7 +47,7 @@ BlitNto1SurfaceAlpha(SDL_BlitInfo * info)
     const unsigned A = info->a;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP4(
         {
         DISEMBLE_RGB(src, srcbpp, srcfmt, Pixel, sR, sG, sB);
@@ -68,7 +68,7 @@ BlitNto1SurfaceAlpha(SDL_BlitInfo * info)
         src += srcbpp;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src += srcskip;
         dst += dstskip;
     }
@@ -93,7 +93,7 @@ BlitNto1PixelAlpha(SDL_BlitInfo * info)
     unsigned dR, dG, dB;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP4(
         {
         DISEMBLE_RGBA(src,srcbpp,srcfmt,Pixel,sR,sG,sB,sA);
@@ -114,7 +114,7 @@ BlitNto1PixelAlpha(SDL_BlitInfo * info)
         src += srcbpp;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src += srcskip;
         dst += dstskip;
     }
@@ -141,7 +141,7 @@ BlitNto1SurfaceAlphaKey(SDL_BlitInfo * info)
     const unsigned A = info->a;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
         {
         DISEMBLE_RGB(src, srcbpp, srcfmt, Pixel, sR, sG, sB);
@@ -164,7 +164,7 @@ BlitNto1SurfaceAlphaKey(SDL_BlitInfo * info)
         src += srcbpp;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src += srcskip;
         dst += dstskip;
     }
@@ -348,7 +348,7 @@ BlitRGBtoRGBPixelAlphaMMX(SDL_BlitInfo * info)
     multmask2 = 0x00FF00FF00FF00FFULL;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP4({
         Uint32 alpha = *srcp & amask;
         if (alpha == 0) {
@@ -382,7 +382,7 @@ BlitRGBtoRGBPixelAlphaMMX(SDL_BlitInfo * info)
         ++srcp;
         ++dstp;
         }, width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         srcp += srcskip;
         dstp += dstskip;
     }
@@ -467,14 +467,14 @@ BlitRGBtoRGBSurfaceAlpha128(SDL_BlitInfo * info)
     int dstskip = info->dst_skip >> 2;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP4({
             Uint32 s = *srcp++;
             Uint32 d = *dstp;
             *dstp++ = ((((s & 0x00fefefe) + (d & 0x00fefefe)) >> 1)
                    + (s & d & 0x00010101)) | 0xff000000;
         }, width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         srcp += srcskip;
         dstp += dstskip;
     }
@@ -500,7 +500,7 @@ BlitRGBtoRGBSurfaceAlpha(SDL_BlitInfo * info)
         Uint32 d1;
 
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP4({
                 s = *srcp;
                 d = *dstp;
@@ -515,7 +515,7 @@ BlitRGBtoRGBSurfaceAlpha(SDL_BlitInfo * info)
                 ++srcp;
                 ++dstp;
             }, width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             srcp += srcskip;
             dstp += dstskip;
         }
@@ -534,7 +534,7 @@ BlitRGBtoRGBPixelAlpha(SDL_BlitInfo * info)
     int dstskip = info->dst_skip >> 2;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP4({
         Uint32 dalpha;
         Uint32 d;
@@ -569,7 +569,7 @@ BlitRGBtoRGBPixelAlpha(SDL_BlitInfo * info)
         ++srcp;
         ++dstp;
         }, width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         srcp += srcskip;
         dstp += dstskip;
     }
@@ -587,7 +587,7 @@ BlitRGBtoBGRPixelAlpha(SDL_BlitInfo * info)
     int dstskip = info->dst_skip >> 2;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP4({
         Uint32 dalpha;
         Uint32 d;
@@ -624,7 +624,7 @@ BlitRGBtoBGRPixelAlpha(SDL_BlitInfo * info)
         ++srcp;
         ++dstp;
         }, width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         srcp += srcskip;
         dstp += dstskip;
     }
@@ -654,7 +654,7 @@ BlitRGBtoRGBPixelAlphaMMX3DNOW(SDL_BlitInfo * info)
     multmask2 = 0x00FF00FF00FF00FFULL;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP4({
         Uint32 alpha;
 
@@ -694,7 +694,7 @@ BlitRGBtoRGBPixelAlphaMMX3DNOW(SDL_BlitInfo * info)
         ++srcp;
         ++dstp;
         }, width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         srcp += srcskip;
         dstp += dstskip;
     }
@@ -848,7 +848,7 @@ Blit565to565SurfaceAlphaMMX(SDL_BlitInfo * info)
         bmask = _mm_set_pi32(0x001F001F, 0x001F001F);   /* MASKBLUE -> bmask */
 
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP_124(
             {
                 s = *srcp++;
@@ -944,7 +944,7 @@ Blit565to565SurfaceAlphaMMX(SDL_BlitInfo * info)
                 srcp += 4;
                 dstp += 4;
             }, width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             srcp += srcskip;
             dstp += dstskip;
         }
@@ -986,7 +986,7 @@ Blit555to555SurfaceAlphaMMX(SDL_BlitInfo * info)
         bmask = _mm_set_pi32(0x001F001F, 0x001F001F);   /* MASKBLUE -> bmask */
 
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP_124(
             {
                 s = *srcp++;
@@ -1082,7 +1082,7 @@ Blit555to555SurfaceAlphaMMX(SDL_BlitInfo * info)
                 srcp += 4;
                 dstp += 4;
             }, width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             srcp += srcskip;
             dstp += dstskip;
         }
@@ -1109,7 +1109,7 @@ Blit565to565SurfaceAlpha(SDL_BlitInfo * info)
         alpha >>= 3;            /* downscale alpha to 5 bits */
 
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP4({
                 Uint32 s = *srcp++;
                 Uint32 d = *dstp;
@@ -1124,7 +1124,7 @@ Blit565to565SurfaceAlpha(SDL_BlitInfo * info)
                 d &= 0x07e0f81f;
                 *dstp++ = (Uint16)(d | d >> 16);
             }, width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             srcp += srcskip;
             dstp += dstskip;
         }
@@ -1148,7 +1148,7 @@ Blit555to555SurfaceAlpha(SDL_BlitInfo * info)
         alpha >>= 3;            /* downscale alpha to 5 bits */
 
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP4({
                 Uint32 s = *srcp++;
                 Uint32 d = *dstp;
@@ -1163,7 +1163,7 @@ Blit555to555SurfaceAlpha(SDL_BlitInfo * info)
                 d &= 0x03e07c1f;
                 *dstp++ = (Uint16)(d | d >> 16);
             }, width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             srcp += srcskip;
             dstp += dstskip;
         }
@@ -1182,7 +1182,7 @@ BlitARGBto565PixelAlpha(SDL_BlitInfo * info)
     int dstskip = info->dst_skip >> 1;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP4({
         Uint32 s = *srcp;
         unsigned alpha = s >> 27; /* downscale alpha to 5 bits */
@@ -1210,7 +1210,7 @@ BlitARGBto565PixelAlpha(SDL_BlitInfo * info)
         srcp++;
         dstp++;
         }, width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         srcp += srcskip;
         dstp += dstskip;
     }
@@ -1228,7 +1228,7 @@ BlitARGBto555PixelAlpha(SDL_BlitInfo * info)
     int dstskip = info->dst_skip >> 1;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP4({
         unsigned alpha;
         Uint32 s = *srcp;
@@ -1257,7 +1257,7 @@ BlitARGBto555PixelAlpha(SDL_BlitInfo * info)
         srcp++;
         dstp++;
         }, width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         srcp += srcskip;
         dstp += dstskip;
     }
@@ -1284,7 +1284,7 @@ BlitNtoNSurfaceAlpha(SDL_BlitInfo * info)
 
     if (sA) {
         while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP4(
         {
         DISEMBLE_RGB(src, srcbpp, srcfmt, Pixel, sR, sG, sB);
@@ -1295,7 +1295,7 @@ BlitNtoNSurfaceAlpha(SDL_BlitInfo * info)
         dst += dstbpp;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
             src += srcskip;
             dst += dstskip;
         }
@@ -1323,7 +1323,7 @@ BlitNtoNSurfaceAlphaKey(SDL_BlitInfo * info)
     const unsigned sA = info->a;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP4(
         {
         RETRIEVE_RGB_PIXEL(src, srcbpp, Pixel);
@@ -1337,7 +1337,7 @@ BlitNtoNSurfaceAlphaKey(SDL_BlitInfo * info)
         dst += dstbpp;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src += srcskip;
         dst += dstskip;
     }
@@ -1366,7 +1366,7 @@ BlitNtoNPixelAlpha(SDL_BlitInfo * info)
     dstbpp = dstfmt->BytesPerPixel;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP4(
         {
         DISEMBLE_RGBA(src, srcbpp, srcfmt, Pixel, sR, sG, sB, sA);
@@ -1379,7 +1379,7 @@ BlitNtoNPixelAlpha(SDL_BlitInfo * info)
         dst += dstbpp;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src += srcskip;
         dst += dstskip;
     }

--- a/src/video/SDL_blit_N.c
+++ b/src/video/SDL_blit_N.c
@@ -1008,11 +1008,11 @@ Blit_RGB888_index8(SDL_BlitInfo * info)
     if (map == NULL) {
         while (height--) {
 #ifdef USE_DUFFS_LOOP
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
                 RGB888_RGB332(*dst++, *src);
             , width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
 #else
             for (c = width / 4; c; --c) {
                 /* Pack RGB into 8bit pixel */
@@ -1044,13 +1044,13 @@ Blit_RGB888_index8(SDL_BlitInfo * info)
 
         while (height--) {
 #ifdef USE_DUFFS_LOOP
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
                 RGB888_RGB332(Pixel, *src);
                 *dst++ = map[Pixel];
                 ++src;
             , width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
 #else
             for (c = width / 4; c; --c) {
                 /* Pack RGB into 8bit pixel */
@@ -1118,11 +1118,11 @@ Blit_RGB101010_index8(SDL_BlitInfo * info)
     if (map == NULL) {
         while (height--) {
 #ifdef USE_DUFFS_LOOP
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
                 RGB101010_RGB332(*dst++, *src);
             , width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
 #else
             for (c = width / 4; c; --c) {
                 /* Pack RGB into 8bit pixel */
@@ -1154,13 +1154,13 @@ Blit_RGB101010_index8(SDL_BlitInfo * info)
 
         while (height--) {
 #ifdef USE_DUFFS_LOOP
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
                 RGB101010_RGB332(Pixel, *src);
                 *dst++ = map[Pixel];
                 ++src;
             , width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
 #else
             for (c = width / 4; c; --c) {
                 /* Pack RGB into 8bit pixel */
@@ -1235,13 +1235,13 @@ Blit_RGB888_RGB555(SDL_BlitInfo * info)
 
 #ifdef USE_DUFFS_LOOP
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
             RGB888_RGB555(dst, src);
             ++src;
             ++dst;
         , width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src += srcskip;
         dst += dstskip;
     }
@@ -1361,13 +1361,13 @@ Blit_RGB888_RGB565(SDL_BlitInfo * info)
 
 #ifdef USE_DUFFS_LOOP
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
             RGB888_RGB565(dst, src);
             ++src;
             ++dst;
         , width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src += srcskip;
         dst += dstskip;
     }
@@ -1476,14 +1476,14 @@ Blit_RGB565_32(SDL_BlitInfo * info, const Uint32 * map)
 
 #ifdef USE_DUFFS_LOOP
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
         {
             *dst++ = RGB565_32(dst, src, map);
             src += 2;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src += srcskip;
         dst += dstskip;
     }
@@ -2088,7 +2088,7 @@ Blit_RGB555_ARGB1555(SDL_BlitInfo * info)
     Uint16 mask = ((Uint32)info->a >> dstfmt->Aloss) << dstfmt->Ashift;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
         {
             *dst = *src | mask;
@@ -2096,7 +2096,7 @@ Blit_RGB555_ARGB1555(SDL_BlitInfo * info)
             ++src;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src = (Uint16 *) ((Uint8 *) src + srcskip);
         dst = (Uint16 *) ((Uint8 *) dst + dstskip);
     }
@@ -2132,7 +2132,7 @@ BlitNto1(SDL_BlitInfo * info)
     if (map == NULL) {
         while (height--) {
 #ifdef USE_DUFFS_LOOP
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
                 DISEMBLE_RGB(src, srcbpp, srcfmt, Pixel,
                                 sR, sG, sB);
@@ -2145,7 +2145,7 @@ BlitNto1(SDL_BlitInfo * info)
                 dst++;
                 src += srcbpp;
             , width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
 #else
             for (c = width; c; --c) {
                 DISEMBLE_RGB(src, srcbpp, srcfmt, Pixel, sR, sG, sB);
@@ -2164,7 +2164,7 @@ BlitNto1(SDL_BlitInfo * info)
     } else {
         while (height--) {
 #ifdef USE_DUFFS_LOOP
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
                 DISEMBLE_RGB(src, srcbpp, srcfmt, Pixel,
                                 sR, sG, sB);
@@ -2177,7 +2177,7 @@ BlitNto1(SDL_BlitInfo * info)
                 dst++;
                 src += srcbpp;
             , width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
 #else
             for (c = width; c; --c) {
                 DISEMBLE_RGB(src, srcbpp, srcfmt, Pixel, sR, sG, sB);
@@ -2214,7 +2214,7 @@ Blit4to4MaskAlpha(SDL_BlitInfo * info)
         Uint32 mask = ((Uint32)info->a >> dstfmt->Aloss) << dstfmt->Ashift;
 
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
             {
                 *dst = *src | mask;
@@ -2222,7 +2222,7 @@ Blit4to4MaskAlpha(SDL_BlitInfo * info)
                 ++src;
             },
             width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             src = (Uint32 *) ((Uint8 *) src + srcskip);
             dst = (Uint32 *) ((Uint8 *) dst + dstskip);
         }
@@ -2231,7 +2231,7 @@ Blit4to4MaskAlpha(SDL_BlitInfo * info)
         Uint32 mask = srcfmt->Rmask | srcfmt->Gmask | srcfmt->Bmask;
 
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
             {
                 *dst = *src & mask;
@@ -2239,7 +2239,7 @@ Blit4to4MaskAlpha(SDL_BlitInfo * info)
                 ++src;
             },
             width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             src = (Uint32 *) ((Uint8 *) src + srcskip);
             dst = (Uint32 *) ((Uint8 *) dst + dstskip);
         }
@@ -2259,7 +2259,7 @@ Blit4to4CopyAlpha(SDL_BlitInfo * info)
 
     /* RGBA->RGBA, COPY_ALPHA */
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
         {
             *dst = *src;
@@ -2267,7 +2267,7 @@ Blit4to4CopyAlpha(SDL_BlitInfo * info)
             ++src;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src = (Uint32 *) ((Uint8 *) src + srcskip);
         dst = (Uint32 *) ((Uint8 *) dst + dstskip);
     }
@@ -2380,7 +2380,7 @@ BlitNtoN(SDL_BlitInfo * info)
         get_permutation(srcfmt, dstfmt, &p0, &p1, &p2, &p3, &alpha_channel);
 
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
             {
                 dst[0] = src[p0];
@@ -2391,7 +2391,7 @@ BlitNtoN(SDL_BlitInfo * info)
                 src += 4;
                 dst += 4;
             }, width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             src += srcskip;
             dst += dstskip;
         }
@@ -2408,7 +2408,7 @@ BlitNtoN(SDL_BlitInfo * info)
         get_permutation(srcfmt, dstfmt, &p0, &p1, &p2, &p3, NULL);
 
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
             {
                 dst[0] = src[p0];
@@ -2417,7 +2417,7 @@ BlitNtoN(SDL_BlitInfo * info)
                 src += 4;
                 dst += 3;
             }, width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             src += srcskip;
             dst += dstskip;
         }
@@ -2434,7 +2434,7 @@ BlitNtoN(SDL_BlitInfo * info)
         get_permutation(srcfmt, dstfmt, &p0, &p1, &p2, &p3, &alpha_channel);
 
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
             {
                 dst[0] = src[p0];
@@ -2445,7 +2445,7 @@ BlitNtoN(SDL_BlitInfo * info)
                 src += 3;
                 dst += 4;
             }, width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             src += srcskip;
             dst += dstskip;
         }
@@ -2454,7 +2454,7 @@ BlitNtoN(SDL_BlitInfo * info)
 #endif
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
         {
             Uint32 Pixel;
@@ -2467,7 +2467,7 @@ BlitNtoN(SDL_BlitInfo * info)
             src += srcbpp;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src += srcskip;
         dst += dstskip;
     }
@@ -2499,7 +2499,7 @@ BlitNtoNCopyAlpha(SDL_BlitInfo * info)
         get_permutation(srcfmt, dstfmt, &p0, &p1, &p2, &p3, NULL);
 
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
             {
                 dst[0] = src[p0];
@@ -2509,7 +2509,7 @@ BlitNtoNCopyAlpha(SDL_BlitInfo * info)
                 src += 4;
                 dst += 4;
             }, width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             src += srcskip;
             dst += dstskip;
         }
@@ -2554,7 +2554,7 @@ BlitNto1Key(SDL_BlitInfo * info)
 
     if (palmap == NULL) {
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
             {
                 DISEMBLE_RGB(src, srcbpp, srcfmt, Pixel,
@@ -2569,13 +2569,13 @@ BlitNto1Key(SDL_BlitInfo * info)
                 src += srcbpp;
             },
             width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             src += srcskip;
             dst += dstskip;
         }
     } else {
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
             {
                 DISEMBLE_RGB(src, srcbpp, srcfmt, Pixel,
@@ -2590,7 +2590,7 @@ BlitNto1Key(SDL_BlitInfo * info)
                 src += srcbpp;
             },
             width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             src += srcskip;
             dst += dstskip;
         }
@@ -2615,7 +2615,7 @@ Blit2to2Key(SDL_BlitInfo * info)
     ckey &= rgbmask;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
         {
             if ( (*srcp & rgbmask) != ckey ) {
@@ -2625,7 +2625,7 @@ Blit2to2Key(SDL_BlitInfo * info)
             srcp++;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         srcp += srcskip;
         dstp += dstskip;
     }
@@ -2662,7 +2662,7 @@ BlitNtoNKey(SDL_BlitInfo * info)
             /* RGB->RGBA, SET_ALPHA */
             Uint32 mask = ((Uint32)info->a) << dstfmt->Ashift;
             while (height--) {
-                /* *INDENT-OFF* */
+                /* *INDENT-OFF* */ /* clang-format off */
                 DUFFS_LOOP(
                 {
                     if ((*src32 & rgbmask) != ckey) {
@@ -2671,7 +2671,7 @@ BlitNtoNKey(SDL_BlitInfo * info)
                     ++dst32;
                     ++src32;
                 }, width);
-                /* *INDENT-ON* */
+                /* *INDENT-ON* */ /* clang-format on */
                 src32 = (Uint32 *) ((Uint8 *) src32 + srcskip);
                 dst32 = (Uint32 *) ((Uint8 *) dst32 + dstskip);
             }
@@ -2680,7 +2680,7 @@ BlitNtoNKey(SDL_BlitInfo * info)
             /* RGBA->RGB, NO_ALPHA */
             Uint32 mask = srcfmt->Rmask | srcfmt->Gmask | srcfmt->Bmask;
             while (height--) {
-                /* *INDENT-OFF* */
+                /* *INDENT-OFF* */ /* clang-format off */
                 DUFFS_LOOP(
                 {
                     if ((*src32 & rgbmask) != ckey) {
@@ -2689,7 +2689,7 @@ BlitNtoNKey(SDL_BlitInfo * info)
                     ++dst32;
                     ++src32;
                 }, width);
-                /* *INDENT-ON* */
+                /* *INDENT-ON* */ /* clang-format on */
                 src32 = (Uint32 *) ((Uint8 *) src32 + srcskip);
                 dst32 = (Uint32 *) ((Uint8 *) dst32 + dstskip);
             }
@@ -2708,7 +2708,7 @@ BlitNtoNKey(SDL_BlitInfo * info)
         get_permutation(srcfmt, dstfmt, &p0, &p1, &p2, &p3, &alpha_channel);
 
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
             {
                 Uint32 *src32 = (Uint32*)src;
@@ -2723,7 +2723,7 @@ BlitNtoNKey(SDL_BlitInfo * info)
                 src += 4;
                 dst += 4;
             }, width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             src += srcskip;
             dst += dstskip;
         }
@@ -2746,7 +2746,7 @@ BlitNtoNKey(SDL_BlitInfo * info)
 #endif
 
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
             {
                 Uint8 s0 = src[0];
@@ -2762,7 +2762,7 @@ BlitNtoNKey(SDL_BlitInfo * info)
                 dst += 3;
             },
             width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             src += srcskip;
             dst += dstskip;
         }
@@ -2784,7 +2784,7 @@ BlitNtoNKey(SDL_BlitInfo * info)
 #endif
 
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
             {
                 Uint8 s0 = src[0];
@@ -2800,7 +2800,7 @@ BlitNtoNKey(SDL_BlitInfo * info)
                 dst += 3;
             },
             width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             src += srcskip;
             dst += dstskip;
         }
@@ -2816,7 +2816,7 @@ BlitNtoNKey(SDL_BlitInfo * info)
         get_permutation(srcfmt, dstfmt, &p0, &p1, &p2, &p3, NULL);
 
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
             {
                 Uint32 *src32 = (Uint32*)src;
@@ -2828,7 +2828,7 @@ BlitNtoNKey(SDL_BlitInfo * info)
                 src += 4;
                 dst += 3;
             }, width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             src += srcskip;
             dst += dstskip;
         }
@@ -2855,7 +2855,7 @@ BlitNtoNKey(SDL_BlitInfo * info)
         get_permutation(srcfmt, dstfmt, &p0, &p1, &p2, &p3, &alpha_channel);
 
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
             {
                 Uint8 s0 = src[0];
@@ -2872,7 +2872,7 @@ BlitNtoNKey(SDL_BlitInfo * info)
                 src += 3;
                 dst += 4;
             }, width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             src += srcskip;
             dst += dstskip;
         }
@@ -2881,7 +2881,7 @@ BlitNtoNKey(SDL_BlitInfo * info)
 #endif
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
         {
             Uint32 Pixel;
@@ -2897,7 +2897,7 @@ BlitNtoNKey(SDL_BlitInfo * info)
             src += srcbpp;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src += srcskip;
         dst += dstskip;
     }
@@ -2938,7 +2938,7 @@ BlitNtoNKeyCopyAlpha(SDL_BlitInfo * info)
             Uint32 *src32 = (Uint32*)src;
             Uint32 *dst32 = (Uint32*)dst;
             while (height--) {
-                /* *INDENT-OFF* */
+                /* *INDENT-OFF* */ /* clang-format off */
                 DUFFS_LOOP(
                 {
                     if ((*src32 & rgbmask) != ckey) {
@@ -2948,7 +2948,7 @@ BlitNtoNKeyCopyAlpha(SDL_BlitInfo * info)
                     ++dst32;
                 },
                 width);
-                /* *INDENT-ON* */
+                /* *INDENT-ON* */ /* clang-format on */
                 src32 = (Uint32 *)((Uint8 *)src32 + srcskip);
                 dst32 = (Uint32 *)((Uint8 *)dst32 + dstskip);
             }
@@ -2967,7 +2967,7 @@ BlitNtoNKeyCopyAlpha(SDL_BlitInfo * info)
         get_permutation(srcfmt, dstfmt, &p0, &p1, &p2, &p3, NULL);
 
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
             {
                 Uint32 *src32 = (Uint32*)src;
@@ -2980,7 +2980,7 @@ BlitNtoNKeyCopyAlpha(SDL_BlitInfo * info)
                 src += 4;
                 dst += 4;
             }, width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             src += srcskip;
             dst += dstskip;
         }
@@ -2989,7 +2989,7 @@ BlitNtoNKeyCopyAlpha(SDL_BlitInfo * info)
 #endif
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
         {
             DISEMBLE_RGBA(src, srcbpp, srcfmt, Pixel, sR, sG, sB, sA);
@@ -3000,7 +3000,7 @@ BlitNtoNKeyCopyAlpha(SDL_BlitInfo * info)
             src += srcbpp;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src += srcskip;
         dst += dstskip;
     }
@@ -3022,7 +3022,7 @@ Blit2101010toN(SDL_BlitInfo * info)
     unsigned sR, sG, sB, sA;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
         {
             Pixel = *(Uint32 *)src;
@@ -3032,7 +3032,7 @@ Blit2101010toN(SDL_BlitInfo * info)
             src += 4;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src += srcskip;
         dst += dstskip;
     }
@@ -3054,7 +3054,7 @@ BlitNto2101010(SDL_BlitInfo * info)
     unsigned sR, sG, sB, sA;
 
     while (height--) {
-        /* *INDENT-OFF* */
+        /* *INDENT-OFF* */ /* clang-format off */
         DUFFS_LOOP(
         {
             DISEMBLE_RGBA(src, srcbpp, srcfmt, Pixel, sR, sG, sB, sA);
@@ -3064,7 +3064,7 @@ BlitNto2101010(SDL_BlitInfo * info)
             src += srcbpp;
         },
         width);
-        /* *INDENT-ON* */
+        /* *INDENT-ON* */ /* clang-format on */
         src += srcskip;
         dst += dstskip;
     }
@@ -3096,7 +3096,7 @@ Blit_3or4_to_3or4__same_rgb(SDL_BlitInfo * info)
         int i2 = srcbpp - 1 - 2;
 #endif
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
             {
                 Uint32 *dst32 = (Uint32*)dst;
@@ -3107,7 +3107,7 @@ Blit_3or4_to_3or4__same_rgb(SDL_BlitInfo * info)
                 dst += 4;
                 src += srcbpp;
             }, width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             src += srcskip;
             dst += dstskip;
         }
@@ -3125,7 +3125,7 @@ Blit_3or4_to_3or4__same_rgb(SDL_BlitInfo * info)
         int j2 = dstbpp - 1 - 2;
 #endif
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
             {
                 Uint8 s0 = src[i0];
@@ -3137,7 +3137,7 @@ Blit_3or4_to_3or4__same_rgb(SDL_BlitInfo * info)
                 dst += dstbpp;
                 src += srcbpp;
             }, width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             src += srcskip;
             dst += dstskip;
         }
@@ -3169,7 +3169,7 @@ Blit_3or4_to_3or4__inversed_rgb(SDL_BlitInfo * info)
 #else
                 int i0 = 3, i1 = 2, i2 = 1, i3 = 0;
 #endif
-                /* *INDENT-OFF* */
+                /* *INDENT-OFF* */ /* clang-format off */
                 DUFFS_LOOP(
                 {
                     Uint32 *dst32 = (Uint32*)dst;
@@ -3182,7 +3182,7 @@ Blit_3or4_to_3or4__inversed_rgb(SDL_BlitInfo * info)
                     dst += 4;
                     src += 4;
                 }, width);
-                /* *INDENT-ON* */
+                /* *INDENT-ON* */ /* clang-format on */
                 src += srcskip;
                 dst += dstskip;
             }
@@ -3197,7 +3197,7 @@ Blit_3or4_to_3or4__inversed_rgb(SDL_BlitInfo * info)
             int i2 = srcbpp - 1 - 2;
 #endif
             while (height--) {
-                /* *INDENT-OFF* */
+                /* *INDENT-OFF* */ /* clang-format off */
                 DUFFS_LOOP(
                 {
                     Uint32 *dst32 = (Uint32*)dst;
@@ -3209,7 +3209,7 @@ Blit_3or4_to_3or4__inversed_rgb(SDL_BlitInfo * info)
                     dst += 4;
                     src += srcbpp;
                 }, width);
-                /* *INDENT-ON* */
+                /* *INDENT-ON* */ /* clang-format on */
                 src += srcskip;
                 dst += dstskip;
             }
@@ -3228,7 +3228,7 @@ Blit_3or4_to_3or4__inversed_rgb(SDL_BlitInfo * info)
         int j2 = dstbpp - 1 - 0;
 #endif
         while (height--) {
-            /* *INDENT-OFF* */
+            /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP(
             {
                 Uint8 s0 = src[i0];
@@ -3241,7 +3241,7 @@ Blit_3or4_to_3or4__inversed_rgb(SDL_BlitInfo * info)
                 dst += dstbpp;
                 src += srcbpp;
             }, width);
-            /* *INDENT-ON* */
+            /* *INDENT-ON* */ /* clang-format on */
             src += srcskip;
             dst += dstskip;
         }

--- a/src/video/SDL_blit_auto.c
+++ b/src/video/SDL_blit_auto.c
@@ -23,7 +23,7 @@
 
 #if SDL_HAVE_BLIT_AUTO
 
-/* *INDENT-OFF* */
+/* *INDENT-OFF* */ /* clang-format off */
 
 #include "SDL_video.h"
 #include "SDL_blit.h"
@@ -7014,7 +7014,7 @@ SDL_BlitFuncEntry SDL_GeneratedBlitFuncTable[] = {
     { 0, 0, 0, 0, NULL }
 };
 
-/* *INDENT-ON* */
+/* *INDENT-ON* */ /* clang-format on */
 
 #endif /* SDL_HAVE_BLIT_AUTO */
 

--- a/src/video/SDL_fillrect.c
+++ b/src/video/SDL_fillrect.c
@@ -26,7 +26,7 @@
 
 
 #ifdef __SSE__
-/* *INDENT-OFF* */
+/* *INDENT-OFF* */ /* clang-format off */
 
 #if defined(_MSC_VER) && !defined(__clang__)
 #define SSE_BEGIN \
@@ -128,7 +128,7 @@ SDL_FillRect1SSE(Uint8 *pixels, int pitch, Uint32 color, int w, int h)
 DEFINE_SSE_FILLRECT(2, Uint16)
 DEFINE_SSE_FILLRECT(4, Uint32)
 
-/* *INDENT-ON* */
+/* *INDENT-ON* */ /* clang-format on */
 #endif /* __SSE__ */
 
 static void

--- a/src/video/kmsdrm/SDL_kmsdrmsym.h
+++ b/src/video/kmsdrm/SDL_kmsdrmsym.h
@@ -19,7 +19,7 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-/* *INDENT-OFF* */
+/* *INDENT-OFF* */ /* clang-format off */
 
 #ifndef SDL_KMSDRM_MODULE
 #define SDL_KMSDRM_MODULE(modname)
@@ -125,6 +125,6 @@ SDL_KMSDRM_SYM(void,gbm_surface_release_buffer,(struct gbm_surface *surf, struct
 #undef SDL_KMSDRM_SYM
 #undef SDL_KMSDRM_SYM_CONST
 
-/* *INDENT-ON* */
+/* *INDENT-ON* */ /* clang-format on */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/riscos/scancodes_riscos.h
+++ b/src/video/riscos/scancodes_riscos.h
@@ -24,7 +24,7 @@
    Sources:
    - https://www.riscosopen.org/wiki/documentation/show/Keyboard Scan Codes
 */
-/* *INDENT-OFF* */
+/* *INDENT-OFF* */ /* clang-format off */
 static SDL_Scancode const riscos_scancode_table[] = {
      /*   0 */   SDL_SCANCODE_UNKNOWN,   /* Shift */
      /*   1 */   SDL_SCANCODE_UNKNOWN,   /* Ctrl */
@@ -155,4 +155,4 @@ static SDL_Scancode const riscos_scancode_table[] = {
      /* 126 */   SDL_SCANCODE_RGUI,
      /* 127 */   SDL_SCANCODE_MENU
 };
-/* *INDENT-ON* */
+/* *INDENT-ON* */ /* clang-format on */

--- a/src/video/sdlgenblit.pl
+++ b/src/video/sdlgenblit.pl
@@ -114,7 +114,7 @@ sub open_file {
 
 #if SDL_HAVE_BLIT_AUTO
 
-/* *INDENT-OFF* */
+/* *INDENT-OFF* */ /* clang-format off */
 
 __EOF__
 }
@@ -122,7 +122,7 @@ __EOF__
 sub close_file {
     my $name = shift;
     print FILE <<__EOF__;
-/* *INDENT-ON* */
+/* *INDENT-ON* */ /* clang-format on */
 
 #endif /* SDL_HAVE_BLIT_AUTO */
 

--- a/src/video/wayland/SDL_waylandsym.h
+++ b/src/video/wayland/SDL_waylandsym.h
@@ -19,7 +19,7 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-/* *INDENT-OFF* */
+/* *INDENT-OFF* */ /* clang-format off */
 
 #ifndef SDL_WAYLAND_MODULE
 #define SDL_WAYLAND_MODULE(modname)
@@ -210,6 +210,6 @@ SDL_WAYLAND_SYM(bool, libdecor_configuration_get_window_state, (struct libdecor_
 #undef SDL_WAYLAND_SYM
 #undef SDL_WAYLAND_INTERFACE
 
-/* *INDENT-ON* */
+/* *INDENT-ON* */ /* clang-format on */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/x11/SDL_x11keyboard.c
+++ b/src/video/x11/SDL_x11keyboard.c
@@ -37,7 +37,7 @@
 #include <locale.h>
 #endif
 
-/* *INDENT-OFF* */
+/* *INDENT-OFF* */ /* clang-format off */
 static const struct {
     KeySym keysym;
     SDL_Scancode scancode;
@@ -160,7 +160,7 @@ static const struct
     { xfree86_scancode_table2, SDL_arraysize(xfree86_scancode_table2) },
     { xvnc_scancode_table, SDL_arraysize(xvnc_scancode_table) },
 };
-/* *INDENT-OFF* */
+/* *INDENT-OFF* */ /* clang-format off */
 
 /* This function only works for keyboards in US QWERTY layout */
 static SDL_Scancode

--- a/src/video/x11/SDL_x11sym.h
+++ b/src/video/x11/SDL_x11sym.h
@@ -19,7 +19,7 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-/* *INDENT-OFF* */
+/* *INDENT-OFF* */ /* clang-format off */
 
 #ifndef SDL_X11_MODULE
 #define SDL_X11_MODULE(modname)
@@ -315,6 +315,6 @@ SDL_X11_SYM(void,XShapeCombineMask,(Display *dpy,Window dest,int dest_kind,int x
 #undef SDL_X11_MODULE
 #undef SDL_X11_SYM
 
-/* *INDENT-ON* */
+/* *INDENT-ON* */ /* clang-format on */
 
 /* vi: set ts=4 sw=4 expandtab: */


### PR DESCRIPTION
## Description

This PR adds a clang-format file at the top-level. The reasoning behind its addition was discussed in the linked issue.

These settings try to emulate the most widely used format currently in place. But let me know if there are any changes that should be made.

<details>
<summary> Here is a code sample with the format applied to it </summary>

```cpp
#include <assert.h>
#include <stdlib.h>

#include "SDL.h"

#define SIZE        24
#define LONGER_SIZE 2400

#define SEPARATED_SIZE 5

#define TEST_X(x)               \
    if (NULL == x) {            \
        SDL_Log("X is null\n"); \
        return -1;              \
    }

#ifdef __cplusplus
extern "C" {
#endif

extern foo(int x, char *y);

#ifdef __cplusplus
};
#endif

enum E
{
    LEFT,  /* Left direction */
    RIGHT, /* Right direction */
    UP,    /* Up direction */
    DOWN,  /* Down direction */
    X      /* Reserved */
};

typedef struct
{
    int a;
    enum E b;
    char c;
} S;

static const arrayOfS[] = {
    { 1, UP, 'W' },
    { 12, LEFT, 'A' },
    { 64, DOWN, 'S' },
    { -32, RIGHT, 'D' }
};

/**
 * Very important documentation
 *
 * About the ins and outs of this function
 */
static S *
copy(S *in)
{
    assert(NULL != in);
    S *out = (S *) malloc(sizeof(S));

    if (NULL == out) {
        return NULL;
    }

    *out = { in->a, in->b, in->c };
    return out;
}

```

</details>

~~The second commit removes every Modeline comments in the current codebase (hence the large number of deletions). As all of the comments were always at the bottom of the source files, this should not cause any merge conflict with existing PRs. But this can easily be reverted if the change is too big.~~

## Existing Issue(s)

This addresses one of the points brought up in #5610 about code styling.