### PR TITLE
Fix building w/ MSVC static CRT

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -13,6 +13,8 @@ jobs:
         platform:
         - { name: Windows (x64),          flags: -A x64,   project: VisualC/SDL.sln, projectflags: '/p:Platform=x64' }
         - { name: Windows (x86),          flags: -A Win32, project: VisualC/SDL.sln, projectflags: '/p:Platform=Win32' }
+        - { name: Windows static VCRT (x64), flags: -A x64 -DSDL_FORCE_STATIC_VCRT=ON }
+        - { name: Windows static VCRT (x86), flags: -A Win32 -DSDL_FORCE_STATIC_VCRT=ON }
         - { name: Windows (clang-cl x64), flags: -T ClangCL -A x64 }
         - { name: Windows (clang-cl x86), flags: -T ClangCL -A Win32 }
         - { name: Windows (ARM64),        flags: -A ARM64 }

--- a/src/stdlib/SDL_stdlib.c
+++ b/src/stdlib/SDL_stdlib.c
@@ -549,8 +549,9 @@ int SDL_isblank(int x) { return ((x) == ' ') || ((x) == '\t'); }
 __declspec(selectany) int _fltused = 1;
 #endif
 
-/* The optimizer on Visual Studio 2005 and later generates memcpy() and memset() calls */
-#if _MSC_VER >= 1400
+/* The optimizer on Visual Studio 2005 and later generates memcpy() and memset() calls.
+   Always provide it for the SDL2 DLL, but skip it when building static lib w/ static runtime. */
+#if (_MSC_VER >= 1400) && (!defined(_MT) || defined(DLL_EXPORT))
 extern void *memcpy(void* dst, const void* src, size_t len);
 #pragma intrinsic(memcpy)
 
@@ -570,7 +571,7 @@ memset(void *dst, int c, size_t len)
 {
     return SDL_memset(dst, c, len);
 }
-#endif /* _MSC_VER >= 1400 */
+#endif /* (_MSC_VER >= 1400) && (!defined(_MT) || defined(DLL_EXPORT)) */
 
 #ifdef _M_IX86
 


### PR DESCRIPTION
Adjusts the preprocessor condition controlling whether `memset()`, `memcpy()` is defined on MSVC builds.

## Description
SDL2 provided definitions of `memset()`, `memcpy()`; however, these may clash with the definitions from the compiler runtime, notably when statically linking that runtime.

## Existing Issue(s)
#3662, #5156, #4258
