### PR TITLE
PS Vita build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2402,6 +2402,7 @@ elseif(VITA)
       SceDisplay_stub
       SceCtrl_stub
       SceAppMgr_stub
+      SceAppUtil_stub
       SceAudio_stub
       SceAudioIn_stub
       SceSysmodule_stub

--- a/src/test/SDL_test_harness.c
+++ b/src/test/SDL_test_harness.c
@@ -349,7 +349,7 @@ static void SDLTest_LogTestSuiteSummary(SDLTest_TestSuiteReference *testSuites)
 /* Gets a timer value in seconds */
 static float GetClock()
 {
-    float currentClock = clock() / (float) CLOCKS_PER_SEC;
+    float currentClock = SDL_GetPerformanceCounter() / (float) SDL_GetPerformanceFrequency();
     return currentClock;
 }
 

--- a/src/test/SDL_test_random.c
+++ b/src/test/SDL_test_random.c
@@ -70,7 +70,7 @@ void SDLTest_RandomInitTime(SDLTest_RandomContext * rndContext)
 
   srand((unsigned int)time(NULL));
   a=rand();
-  srand((unsigned int)clock());
+  srand((unsigned int)SDL_GetPerformanceCounter());
   b=rand();
   SDLTest_RandomInit(rndContext, a, b);
 }


### PR DESCRIPTION
These are needed when building with `-DSDL_TEST=ON`.