### PR TITLE
Build tests for all CMake platforms on CI

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -13,10 +13,17 @@ jobs:
       - name: Configure CMake
         run: |
           emcmake cmake -S . -B build \
+            -DSDL_TESTS=ON \
+            -DSDL_INSTALL_TESTS=ON \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=prefix
       - name: Build
         run: cmake --build build/ --verbose
+      - name: Run build-time tests
+        run: |
+          set -eu
+          export SDL_TESTS_QUICK=1
+          ctest -VV --test-dir build/
       - name: Install
         run: |
           echo "SDL2_DIR=$(pwd)/prefix" >> $GITHUB_ENV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
       run: |
         cmake --build build/ --config Release --verbose --parallel
     - name: Run build-time tests (CMake)
-      if: "matrix.platform.shell == 'sh' && ! matrix.platform.autotools"
+      if: "! matrix.platform.autotools"
       run: |
         set -eu
         export SDL_TESTS_QUICK=1

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -27,10 +27,16 @@ jobs:
     - name: Configure CMake
       run: cmake -S . -B build `
         -DSDL_TESTS=ON `
+        -DSDL_INSTALL_TESTS=ON `
         ${{ matrix.platform.flags }} `
         -DCMAKE_INSTALL_PREFIX=prefix
     - name: Build CMake
       run: cmake --build build/ --config Release --parallel
+    - name: Run build-time tests
+      if: "! contains(matrix.platform.name, 'ARM')"
+      run: |
+        $env:SDL_TESTS_QUICK=1
+        ctest -VV --test-dir build/ -C Release
     - name: Install CMake
       run: |
         echo "SDL2_DIR=$Env:GITHUB_WORKSPACE/prefix" >> $Env:GITHUB_ENV

--- a/.github/workflows/psp.yaml
+++ b/.github/workflows/psp.yaml
@@ -17,6 +17,7 @@ jobs:
         cmake -S . -B build \
           -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake \
           -DSDL_TESTS=ON \
+          -DSDL_INSTALL_TESTS=ON \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=prefix
     - name: Build

--- a/.github/workflows/riscos.yml
+++ b/.github/workflows/riscos.yml
@@ -44,6 +44,8 @@ jobs:
           -DCMAKE_TOOLCHAIN_FILE=/home/riscos/env/toolchain-riscos.cmake \
           -DRISCOS=ON \
           -DSDL_GCC_ATOMICS=OFF \
+          -DSDL_TESTS=ON \
+          -DSDL_INSTALL_TESTS=ON \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/prefix_cmake
     - name: Build (CMake)

--- a/.github/workflows/vita.yaml
+++ b/.github/workflows/vita.yaml
@@ -21,6 +21,8 @@ jobs:
       run: |
         cmake -S . -B build -G Ninja \
           -DCMAKE_TOOLCHAIN_FILE=${VITASDK}/share/vita.toolchain.cmake \
+          -DSDL_TESTS=ON \
+          -DSDL_INSTALL_TESTS=ON \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=prefix
     - name: Build


### PR DESCRIPTION
This is currently a draft because some tests aren't building properly with Emscripten and I'm not sure how to fix it.

Includes changes from #5635 and #5636. See also issue #5634.