### PR TITLE
log: Check for integer overflow.

### DIFF
--- a/src/SDL_log.c
+++ b/src/SDL_log.c
@@ -293,7 +293,8 @@ SDL_LogMessageV(int category, SDL_LogPriority priority, const char *fmt, va_list
 {
     char *message = NULL;
     char stack_buf[SDL_MAX_LOG_MESSAGE_STACK];
-    size_t len;
+    size_t len_plus_term;
+    int len;
     va_list aq;
 
     /* Nothing to do if we don't have an output function */
@@ -321,14 +322,17 @@ SDL_LogMessageV(int category, SDL_LogPriority priority, const char *fmt, va_list
     len = SDL_vsnprintf(stack_buf, sizeof(stack_buf), fmt, aq);
     va_end(aq);
 
+    if (len < 0)
+        return;
+
     /* If message truncated, allocate and re-render */
-    if (len >= sizeof(stack_buf)) {
+    if (len >= sizeof(stack_buf) && SDL_size_add_overflow(len, 1, &len_plus_term) == 0) {
         /* Allocate exactly what we need, including the zero-terminator */
-        message = (char *)SDL_malloc(len + 1);
+        message = (char *)SDL_malloc(len_plus_term);
         if (!message)
             return;
         va_copy(aq, ap);
-        len = SDL_vsnprintf(message, len + 1, fmt, aq);
+        len = SDL_vsnprintf(message, len_plus_term, fmt, aq);
         va_end(aq);
     } else {
         message = stack_buf;


### PR DESCRIPTION
Builds on #5643 to ensure that the `malloc()` path isn't taken if the allocation size would overflow. In this case we'll just log whatever made it into the smaller buffer instead.