### PR TITLE
macOS: remove dead code for supporting 10.6 at runtime.

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -1469,9 +1469,7 @@ extern "C" {
  *                SDL_WINDOW_RESIZABLE windows will offer the "fullscreen"
  *                button on their titlebars).
  *
- *  The default value is "1". Spaces are disabled regardless of this hint if
- *   the OS isn't at least Mac OS X Lion (10.7). This hint must be set before
- *   any windows are created.
+ *  The default value is "1". This hint must be set before any windows are created.
  */
 #define SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES    "SDL_VIDEO_MAC_FULLSCREEN_SPACES"
 

--- a/src/video/cocoa/SDL_cocoaevents.m
+++ b/src/video/cocoa/SDL_cocoaevents.m
@@ -424,15 +424,13 @@ CreateApplicationMenus(void)
 
     [windowMenu addItemWithTitle:@"Zoom" action:@selector(performZoom:) keyEquivalent:@""];
     
-    /* Add the fullscreen toggle menu option, if supported */
-    if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6) {
-        /* Cocoa should update the title to Enter or Exit Full Screen automatically.
-         * But if not, then just fallback to Toggle Full Screen.
-         */
-        menuItem = [[NSMenuItem alloc] initWithTitle:@"Toggle Full Screen" action:@selector(toggleFullScreen:) keyEquivalent:@"f"];
-        [menuItem setKeyEquivalentModifierMask:NSEventModifierFlagControl | NSEventModifierFlagCommand];
-        [windowMenu addItem:menuItem];
-    }
+    /* Add the fullscreen toggle menu option. */
+    /* Cocoa should update the title to Enter or Exit Full Screen automatically.
+     * But if not, then just fallback to Toggle Full Screen.
+     */
+    menuItem = [[NSMenuItem alloc] initWithTitle:@"Toggle Full Screen" action:@selector(toggleFullScreen:) keyEquivalent:@"f"];
+    [menuItem setKeyEquivalentModifierMask:NSEventModifierFlagControl | NSEventModifierFlagCommand];
+    [windowMenu addItem:menuItem];
 
     /* Put menu into the menubar */
     menuItem = [[NSMenuItem alloc] initWithTitle:@"Window" action:nil keyEquivalent:@""];
@@ -505,19 +503,6 @@ Cocoa_RegisterApp(void)
 int
 Cocoa_PumpEventsUntilDate(_THIS, NSDate *expiration, bool accumulate)
 {
-#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
-    /* Update activity every 30 seconds to prevent screensaver */
-    SDL_VideoData *data = (SDL_VideoData *)_this->driverdata;
-    if (_this->suspend_screensaver && !data->screensaver_use_iopm) {
-        Uint32 now = SDL_GetTicks();
-        if (!data->screensaver_activity ||
-            SDL_TICKS_PASSED(now, data->screensaver_activity + 30000)) {
-            UpdateSystemActivity(UsrActivity);
-            data->screensaver_activity = now;
-        }
-    }
-#endif
-
     for ( ; ; ) {
         NSEvent *event = [NSApp nextEventMatchingMask:NSEventMaskAny untilDate:expiration inMode:NSDefaultRunLoopMode dequeue:YES ];
         if ( event == nil ) {
@@ -583,10 +568,6 @@ Cocoa_SuspendScreenSaver(_THIS)
 { @autoreleasepool
 {
     SDL_VideoData *data = (__bridge SDL_VideoData *)_this->driverdata;
-
-    if (!data.screensaver_use_iopm) {
-        return;
-    }
 
     if (data.screensaver_assertion) {
         IOPMAssertionRelease(data.screensaver_assertion);

--- a/src/video/cocoa/SDL_cocoakeyboard.m
+++ b/src/video/cocoa/SDL_cocoakeyboard.m
@@ -140,14 +140,7 @@
             aRange.location, aRange.length, windowHeight,
             NSStringFromRect(rect));
 
-#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
-    if (![window respondsToSelector:@selector(convertRectToScreen:)]) {
-        rect.origin = [window convertBaseToScreen:rect.origin];
-    } else
-#endif
-    {
-        rect = [window convertRectToScreen:rect];
-    }
+    rect = [window convertRectToScreen:rect];
 
     return rect;
 }

--- a/src/video/cocoa/SDL_cocoametalview.m
+++ b/src/video/cocoa/SDL_cocoametalview.m
@@ -187,11 +187,8 @@ Cocoa_Metal_GetDrawableSize(_THIS, SDL_Window * window, int * w, int * h)
         /* Fall back to the viewport size. */
         NSRect viewport = [contentView bounds];
         if (window->flags & SDL_WINDOW_ALLOW_HIGHDPI) {
-            /* This gives us the correct viewport for a Retina-enabled view, only
-             * supported on 10.7+. */
-            if ([contentView respondsToSelector:@selector(convertRectToBacking:)]) {
-                viewport = [contentView convertRectToBacking:viewport];
-            }
+            /* This gives us the correct viewport for a Retina-enabled view. */
+            viewport = [contentView convertRectToBacking:viewport];
         }
         if (w) {
             *w = viewport.size.width;

--- a/src/video/cocoa/SDL_cocoamodes.m
+++ b/src/video/cocoa/SDL_cocoamodes.m
@@ -31,9 +31,6 @@
 #include <CoreVideo/CVBase.h>
 #include <CoreVideo/CVDisplayLink.h>
 
-/* we need this for ShowMenuBar() and HideMenuBar(). */
-#include <Carbon/Carbon.h>
-
 /* This gets us MAC_OS_X_VERSION_MIN_REQUIRED... */
 #include <AvailabilityMacros.h>
 
@@ -44,23 +41,6 @@
 #define kDisplayModeNativeFlag 0x02000000
 #endif
 
-
-static void
-Cocoa_ToggleMenuBar(const BOOL show)
-{
-    /* !!! FIXME: keep an eye on this.
-     * ShowMenuBar/HideMenuBar is officially unavailable for 64-bit binaries.
-     *  It happens to work, as of 10.7, but we're going to see if
-     *  we can just simply do without it on newer OSes...
-     */
-#if (MAC_OS_X_VERSION_MIN_REQUIRED < 1070) && !defined(__LP64__)
-    if (show) {
-        ShowMenuBar();
-    } else {
-        HideMenuBar();
-    }
-#endif
-}
 
 static int
 CG_SetError(const char *prefix, CGDisplayErr result)
@@ -497,7 +477,7 @@ Cocoa_GetDisplayDPI(_THIS, SDL_VideoDisplay * display, float * ddpi, float * hdp
                 CFRelease(dmOptions);
             } else
 #endif
-            if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6) {
+            {
                 // fallback for 10.7
                 scaleFactor = [screen backingScaleFactor];
                 displayNativeSize.width = displayNativeSize.width * scaleFactor;
@@ -646,10 +626,6 @@ Cocoa_SetDisplayMode(_THIS, SDL_VideoDisplay * display, SDL_DisplayMode * mode)
         } else {
             CGDisplayRelease(displaydata->display);
         }
-
-        if (CGDisplayIsMain(displaydata->display)) {
-            Cocoa_ToggleMenuBar(YES);
-        }
     } else {
         /* Put up the blanking window (a window above all other windows) */
         if (CGDisplayIsMain(displaydata->display)) {
@@ -668,11 +644,6 @@ Cocoa_SetDisplayMode(_THIS, SDL_VideoDisplay * display, SDL_DisplayMode * mode)
         if (result != kCGErrorSuccess) {
             CG_SetError("CGDisplaySwitchToMode()", result);
             goto ERR_NO_SWITCH;
-        }
-
-        /* Hide the menu bar so it doesn't intercept events */
-        if (CGDisplayIsMain(displaydata->display)) {
-            Cocoa_ToggleMenuBar(NO);
         }
     }
 
@@ -720,7 +691,6 @@ Cocoa_QuitModes(_THIS)
             CFRelease(mode->modes);
         }
     }
-    Cocoa_ToggleMenuBar(YES);
 }
 
 #endif /* SDL_VIDEO_DRIVER_COCOA */

--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -461,15 +461,13 @@ Cocoa_HandleMouseWheel(SDL_Window *window, NSEvent *event)
     CGFloat y = [event deltaY];
     SDL_MouseWheelDirection direction = SDL_MOUSEWHEEL_NORMAL;
 
-    if ([event respondsToSelector:@selector(isDirectionInvertedFromDevice)]) {
-        if ([event isDirectionInvertedFromDevice] == YES) {
-            direction = SDL_MOUSEWHEEL_FLIPPED;
-        }
+    if ([event isDirectionInvertedFromDevice] == YES) {
+        direction = SDL_MOUSEWHEEL_FLIPPED;
     }
 
     /* For discrete scroll events from conventional mice, always send a full tick.
        For continuous scroll events from trackpads, send fractional deltas for smoother scrolling. */
-    if (![event respondsToSelector:@selector(hasPreciseScrollingDeltas)] || ![event hasPreciseScrollingDeltas]) {
+    if (![event hasPreciseScrollingDeltas]) {
         if (x > 0) {
             x = SDL_ceil(x);
         } else if (x < 0) {

--- a/src/video/cocoa/SDL_cocoavideo.h
+++ b/src/video/cocoa/SDL_cocoavideo.h
@@ -103,8 +103,6 @@ DECLARE_ALERT_STYLE(Critical);
     @property (nonatomic) void *key_layout;
     @property (nonatomic) SDLTranslatorResponder *fieldEdit;
     @property (nonatomic) NSInteger clipboard_count;
-    @property (nonatomic) Uint32 screensaver_activity;
-    @property (nonatomic) BOOL screensaver_use_iopm;
     @property (nonatomic) IOPMAssertionID screensaver_assertion;
     @property (nonatomic) SDL_mutex *swaplock;
 @end

--- a/src/video/cocoa/SDL_cocoavideo.m
+++ b/src/video/cocoa/SDL_cocoavideo.m
@@ -196,10 +196,7 @@ Cocoa_VideoInit(_THIS)
         return -1;
     }
 
-    data.allow_spaces = ((floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6) && SDL_GetHintBoolean(SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES, SDL_TRUE));
-
-    /* The IOPM assertion API can disable the screensaver as of 10.7. */
-    data.screensaver_use_iopm = floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6;
+    data.allow_spaces = SDL_GetHintBoolean(SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES, SDL_TRUE);
 
     data.swaplock = SDL_CreateMutex();
     if (!data.swaplock) {

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -1713,8 +1713,6 @@ Cocoa_CreateWindow(_THIS, SDL_Window * window)
 #endif
 
     if (videodata.allow_spaces) {
-        SDL_assert(floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6);
-        SDL_assert([nswindow respondsToSelector:@selector(toggleFullScreen:)]);
         /* we put FULLSCREEN_DESKTOP windows in their own Space, without a toggle button or menubar, later */
         if (window->flags & SDL_WINDOW_RESIZABLE) {
             /* resizable windows are Spaces-friendly: they get the "go fullscreen" toggle button on their titlebar. */
@@ -1738,10 +1736,8 @@ Cocoa_CreateWindow(_THIS, SDL_Window * window)
     #endif
     /* Note: as of the macOS 10.15 SDK, this defaults to YES instead of NO when
      * the NSHighResolutionCapable boolean is set in Info.plist. */
-    if ([contentView respondsToSelector:@selector(setWantsBestResolutionOpenGLSurface:)]) {
-        BOOL highdpi = (window->flags & SDL_WINDOW_ALLOW_HIGHDPI) != 0;
-        [contentView setWantsBestResolutionOpenGLSurface:highdpi];
-    }
+    BOOL highdpi = (window->flags & SDL_WINDOW_ALLOW_HIGHDPI) != 0;
+    [contentView setWantsBestResolutionOpenGLSurface:highdpi];
     #ifdef __clang__
     #pragma clang diagnostic pop
     #endif
@@ -1813,10 +1809,8 @@ Cocoa_CreateWindowFrom(_THIS, SDL_Window * window, const void *data)
     #endif
     /* Note: as of the macOS 10.15 SDK, this defaults to YES instead of NO when
      * the NSHighResolutionCapable boolean is set in Info.plist. */
-    if ([nsview respondsToSelector:@selector(setWantsBestResolutionOpenGLSurface:)]) {
-        BOOL highdpi = (window->flags & SDL_WINDOW_ALLOW_HIGHDPI) != 0;
-        [nsview setWantsBestResolutionOpenGLSurface:highdpi];
-    }
+    BOOL highdpi = (window->flags & SDL_WINDOW_ALLOW_HIGHDPI) != 0;
+    [nsview setWantsBestResolutionOpenGLSurface:highdpi];
     #ifdef __clang__
     #pragma clang diagnostic pop
     #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Now that macOS 10.7 is the minimum supported runtime version, some code that was supporting 10.6 can be removed (including one of the two remaining uses of Carbon).

## Existing Issue(s)
#5632
