### PR TITLE
wayland: Support xdg_decoration requesting client-side decorations

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -476,19 +476,16 @@ ProcessHitTest(struct SDL_WaylandInput *input, uint32_t serial)
         const uint32_t *directions_libdecor = directions;
 #endif
 
-        /* Hit tests shouldn't apply to xdg_popups, right? */
-        SDL_assert(!WINDOW_IS_XDG_POPUP(window));
-
         switch (rc) {
             case SDL_HITTEST_DRAGGABLE:
 #ifdef HAVE_LIBDECOR_H
-                if (input->display->shell.libdecor) {
+                if (window_data->shell_surface_type == WAYLAND_SURFACE_LIBDECOR) {
                     if (window_data->shell_surface.libdecor.frame) {
                         libdecor_frame_move(window_data->shell_surface.libdecor.frame, input->seat, serial);
                     }
                 } else
 #endif
-                if (input->display->shell.xdg) {
+                if (window_data->shell_surface_type == WAYLAND_SURFACE_XDG_TOPLEVEL) {
                     if (window_data->shell_surface.xdg.roleobj.toplevel) {
                         xdg_toplevel_move(window_data->shell_surface.xdg.roleobj.toplevel,
                                           input->seat,
@@ -506,13 +503,13 @@ ProcessHitTest(struct SDL_WaylandInput *input, uint32_t serial)
             case SDL_HITTEST_RESIZE_BOTTOMLEFT:
             case SDL_HITTEST_RESIZE_LEFT:
 #ifdef HAVE_LIBDECOR_H
-                if (input->display->shell.libdecor) {
+                if (window_data->shell_surface_type == WAYLAND_SURFACE_LIBDECOR) {
                     if (window_data->shell_surface.libdecor.frame) {
                         libdecor_frame_resize(window_data->shell_surface.libdecor.frame, input->seat, serial, directions_libdecor[rc - SDL_HITTEST_RESIZE_TOPLEFT]);
                     }
                 } else
 #endif
-                if (input->display->shell.xdg) {
+                if (window_data->shell_surface_type == WAYLAND_SURFACE_XDG_TOPLEVEL) {
                     if (window_data->shell_surface.xdg.roleobj.toplevel) {
                         xdg_toplevel_resize(window_data->shell_surface.xdg.roleobj.toplevel,
                                             input->seat,

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -878,7 +878,7 @@ static const struct wl_registry_listener registry_listener = {
 };
  
 #ifdef HAVE_LIBDECOR_H
-static SDL_bool should_use_libdecor(SDL_VideoData *data)
+static SDL_bool should_use_libdecor(SDL_VideoData *data, SDL_bool ignore_xdg)
 {
     if (!SDL_WAYLAND_HAVE_WAYLAND_LIBDECOR) {
         return SDL_FALSE;
@@ -892,6 +892,10 @@ static SDL_bool should_use_libdecor(SDL_VideoData *data)
         return SDL_TRUE;
     }
 
+    if (ignore_xdg) {
+        return SDL_TRUE;
+    }
+
     if (data->decoration_manager) {
         return SDL_FALSE;
     }
@@ -899,6 +903,18 @@ static SDL_bool should_use_libdecor(SDL_VideoData *data)
     return SDL_TRUE;
 }
 #endif
+
+SDL_bool
+Wayland_LoadLibdecor(SDL_VideoData *data, SDL_bool ignore_xdg)
+{
+#ifdef HAVE_LIBDECOR_H
+    if (should_use_libdecor(data, ignore_xdg)) {
+        data->shell.libdecor = libdecor_new(data->display, &libdecor_interface);
+        return data->shell.libdecor != NULL;
+    }
+#endif
+    return SDL_FALSE;
+}
 
 int
 Wayland_VideoInit(_THIS)
@@ -920,12 +936,8 @@ Wayland_VideoInit(_THIS)
     // First roundtrip to receive all registry objects.
     WAYLAND_wl_display_roundtrip(data->display);
 
-#ifdef HAVE_LIBDECOR_H
-    /* Don't have server-side decorations? Try client-side instead. */
-    if (should_use_libdecor(data)) {
-        data->shell.libdecor = libdecor_new(data->display, &libdecor_interface);
-    }
-#endif
+    /* Now that we have all the protocols, load libdecor if applicable */
+    Wayland_LoadLibdecor(data, SDL_FALSE);
 
     // Second roundtrip to receive all output events.
     WAYLAND_wl_display_roundtrip(data->display);

--- a/src/video/wayland/SDL_waylandvideo.h
+++ b/src/video/wayland/SDL_waylandvideo.h
@@ -122,6 +122,8 @@ extern void SDL_WAYLAND_register_output(struct wl_output *output);
 extern SDL_bool SDL_WAYLAND_own_surface(struct wl_surface *surface);
 extern SDL_bool SDL_WAYLAND_own_output(struct wl_output *output);
 
+extern SDL_bool Wayland_LoadLibdecor(SDL_VideoData *data, SDL_bool ignore_xdg);
+
 #endif /* SDL_waylandvideo_h_ */
 
 /* vi: set ts=4 sw=4 expandtab: */


### PR DESCRIPTION
Don't be fooled by the diff size - this ended up being a big refactor of the shell surface management, masked only by some helper macros I wrote for the popup support.

This change makes it so when xdg_decoration is supported, but CSD is requested, the system bails on xdg support entirely and resets all the windows to use libdecor instead. This transition isn't pretty, but once it's done it will be smooth if decorations are an OS toggle since libdecor will take things from there.

In hindsight, we really should have designed libdecor to be passed a toplevel, having it manage that for us keeps causing major refactors for _every_ change.

Fixes #5653