### PR TITLE
Wayland general refactoring and fixes

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -1509,6 +1509,21 @@ extern "C" {
 #define SDL_HINT_VIDEO_WAYLAND_PREFER_LIBDECOR "SDL_VIDEO_WAYLAND_PREFER_LIBDECOR"
 
 /**
+ *  \brief  A variable controlling whether video mode emulation is enabled under Wayland.
+ *
+ *  When this hint is set, a standard set of emulated CVT video modes will be exposed for use by the application.
+ *  If it is disabled, the only modes exposed will be the logical desktop size and, in the case of a scaled
+ *  desktop, the native display resolution.
+ *
+ *  This variable can be set to the following values:
+ *    "0"       - Video mode emulation is disabled.
+ *    "1"       - Video mode emulation is enabled.
+ *
+ *  By default video mode emulation is enabled.
+ */
+#define SDL_HINT_VIDEO_WAYLAND_MODE_EMULATION "SDL_VIDEO_WAYLAND_MODE_EMULATION"
+
+/**
 *  \brief  A variable that is the address of another SDL_Window* (as a hex string formatted with "%p").
 *  
 *  If this hint is set before SDL_CreateWindowFrom() and the SDL_Window* it is set to has

--- a/src/video/wayland/SDL_waylandopengles.c
+++ b/src/video/wayland/SDL_waylandopengles.c
@@ -140,9 +140,9 @@ Wayland_GLES_SwapWindow(_THIS, SDL_Window *window)
 
             /* wl_display_prepare_read_queue() will return -1 if the event queue is not empty.
              * If the event queue is empty, it will prepare us for our SDL_IOReady() call. */
-            if (WAYLAND_wl_display_prepare_read_queue(display, data->frame_event_queue) != 0) {
+            if (WAYLAND_wl_display_prepare_read_queue(display, data->gles_swap_frame_event_queue) != 0) {
                 /* We have some pending events. Check if the frame callback happened. */
-                WAYLAND_wl_display_dispatch_queue_pending(display, data->frame_event_queue);
+                WAYLAND_wl_display_dispatch_queue_pending(display, data->gles_swap_frame_event_queue);
                 continue;
             }
 
@@ -163,7 +163,7 @@ Wayland_GLES_SwapWindow(_THIS, SDL_Window *window)
 
             /* We have events. Read and dispatch them. */
             WAYLAND_wl_display_read_events(display);
-            WAYLAND_wl_display_dispatch_queue_pending(display, data->frame_event_queue);
+            WAYLAND_wl_display_dispatch_queue_pending(display, data->gles_swap_frame_event_queue);
         }
         SDL_AtomicSet(&data->swap_interval_ready, 0);
     }

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -545,6 +545,7 @@ display_handle_done(void *data,
     SDL_VideoData* video = driverdata->videodata;
     SDL_DisplayMode native_mode, desktop_mode;
     SDL_VideoDisplay *dpy;
+    const SDL_bool mode_emulation_enabled = SDL_GetHintBoolean(SDL_HINT_VIDEO_WAYLAND_MODE_EMULATION, SDL_TRUE);
 
     /*
      * When using xdg-output, two wl-output.done events will be emitted:
@@ -597,8 +598,8 @@ display_handle_done(void *data,
     desktop_mode.driverdata = driverdata->output;
 
     /*
-     * The native display mode is only exposed separately from the desktop size if:
-     * the desktop is scaled and the wp_viewporter protocol is supported.
+     * The native display mode is only exposed separately from the desktop size if the
+     * desktop is scaled and the wp_viewporter protocol is supported.
      */
     if (driverdata->scale_factor > 1.0f && video->viewporter != NULL) {
         if (driverdata->index > -1) {
@@ -643,8 +644,8 @@ display_handle_done(void *data,
     SDL_SetCurrentDisplayMode(dpy, &desktop_mode);
     SDL_SetDesktopDisplayMode(dpy, &desktop_mode);
 
-    /* Add emulated modes if wp_viewporter is supported. */
-    if (video->viewporter) {
+    /* Add emulated modes if wp_viewporter is supported and mode emulation is enabled. */
+    if (video->viewporter && mode_emulation_enabled) {
         AddEmulatedModes(dpy, (driverdata->transform & WL_OUTPUT_TRANSFORM_90) != 0);
     }
 

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -578,8 +578,9 @@ display_handle_done(void *data,
     SDL_zero(desktop_mode);
     desktop_mode.format = SDL_PIXELFORMAT_RGB888;
 
-    /* Scale the desktop coordinates, if xdg-output isn't present */
-    if (!driverdata->has_logical_size) {
+    if (driverdata->has_logical_size) { /* If xdg-output is present, calculate the true scale of the desktop */
+        driverdata->scale_factor = (float)native_mode.w / (float)driverdata->width;
+    } else  { /* Scale the desktop coordinates, if xdg-output isn't present */
         driverdata->width /= driverdata->scale_factor;
         driverdata->height /= driverdata->scale_factor;
     }

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -42,9 +42,10 @@ typedef struct {
     SDL_Window *sdlwindow;
     SDL_VideoData *waylandData;
     struct wl_surface *surface;
-    struct wl_callback *frame_callback;
-    struct wl_event_queue *frame_event_queue;
-    struct wl_surface *frame_surface_wrapper;
+    struct wl_callback *gles_swap_frame_callback;
+    struct wl_event_queue *gles_swap_frame_event_queue;
+    struct wl_surface *gles_swap_frame_surface_wrapper;
+    struct wl_callback *surface_damage_frame_callback;
 
     union {
 #ifdef HAVE_LIBDECOR_H

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -85,7 +85,7 @@ typedef struct {
     struct zwp_keyboard_shortcuts_inhibitor_v1 *key_inhibitor;
     struct zwp_idle_inhibitor_v1 *idle_inhibitor;
     struct xdg_activation_token_v1 *activation_token;
-    struct wp_viewport *viewport;
+    struct wp_viewport *draw_viewport;
 
     /* floating dimensions for restoring from maximized and fullscreen */
     int floating_width, floating_height;
@@ -103,7 +103,7 @@ typedef struct {
     float pointer_scale_x;
     float pointer_scale_y;
     int drawable_width, drawable_height;
-    SDL_Rect damage_region;
+    SDL_Rect viewport_rect;
     SDL_bool needs_resize_event;
     SDL_bool floating_resize_pending;
 } SDL_WindowData;


### PR DESCRIPTION
Some general Wayland refactoring and bug fixes, some of which are just rebased from the now closed #5534.  Outside of the rework of scale factor handling, there isn't anything new in the way of overall functionality or behavior here.

- Refactors the fullscreen and viewport logic to compartmentalize the fullscreen mode emulation blocks and unify the fullscreen/windowed viewport logic.
- Consolidates some duplicate code.
- Adds a hint to disable video mode emulation.
- Fixes a bug where emulated video modes weren't swapping the width/height in all cases where they should be.
- Refactors the scaling code to unify the integer and fractional cases.  This improves the behavior when using multiple displays with different scale factors, particularly when a window is moved between or straddles outputs with different scale factors.  It also lays the groundwork for supporting the forthcoming [Wayland fractional scaling protocol](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/143), support for which will be trivial to add with these changes.

@flibitijibibo 