### PR TITLE
.editorconfig: Automatically configure multiple text editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,77 @@
+# For format see editorconfig.org
+# Copyright 2022 Collabora Ltd.
+# SPDX-License-Identifier: Zlib
+
+root = true
+
+[*.{c,cg,cpp,gradle,h,java,m,metal,pl,py,S,sh,txt}]
+indent_size = 4
+indent_style = space
+
+[*.{html,js,json,m4,yml,yaml,vcxproj,vcxproj.filters}]
+indent_size = 2
+indent_style = space
+
+[*.xml]
+indent_size = 4
+indent_style = space
+
+[{CMakeLists.txt,sdl2-config*.cmake.in,cmake/*.cmake}]
+indent_size = 2
+indent_style = space
+
+[{cmake_uninstall.cmake.in,test/CMakeLists.txt}]
+indent_size = 4
+indent_style = space
+
+[configure.ac]
+# Inconsistently 2-, 4- or occasionally 3-space indented, but mostly 4,
+# so let's use 4 for new code
+indent_size = 4
+indent_style = space
+
+[{Makefile.*,*.mk,*.sln,*.pbxproj,*.plist}]
+indent_size = 8
+indent_style = tab
+tab_width = 8
+
+[Makefile.os2]
+indent_size = 4
+indent_style = space
+
+[test/Makefile.os2]
+indent_size = 2
+indent_style = space
+
+[{src/core/os2/geniconv/makefile,src/core/os2/geniconv/os2cp.c}]
+indent_size = 2
+indent_style = space
+
+[src/joystick/controller_type.h]
+indent_style = tab
+
+[src/joystick/hidapi/steam/*.h]
+indent_style = tab
+
+[src/libm/*.c]
+indent_style = tab
+
+[src/test/SDL_test_{crc32,md5,random}.c]
+indent_size = 2
+indent_style = space
+
+[src/video/yuv2rgb/*.{c,h}]
+indent_style = tab
+
+[src/wayland-protocols/*.xml]
+indent_size = 2
+indent_style = space
+
+[*.{markdown,md}]
+indent_size = 4
+indent_style = space
+# Markdown syntax treats tabs as 4 spaces
+tab_width = 4
+
+[{*.bat,*.rc}]
+end_of_line = crlf


### PR DESCRIPTION
See editorconfig.org for details of the format, which is understood by
multiple text editors, either directly or via plugins.

This is not comprehensive, but should cover most of the SDL codebase.
Please extend as needed.