### PR TITLE
Use SDLCALL for callbacks in public APIs

### DIFF
--- a/include/SDL_config_os2.h
+++ b/include/SDL_config_os2.h
@@ -102,8 +102,11 @@
 #define HAVE_GETENV 1
 #define HAVE_SETENV 1
 #define HAVE_PUTENV 1
+/* OpenWatcom requires specific calling conventions for qsort and bsearch */
+#ifndef __WATCOMC__
 #define HAVE_QSORT 1
 #define HAVE_BSEARCH 1
+#endif
 #define HAVE_ABS 1
 #define HAVE_BCOPY 1
 #define HAVE_MEMSET 1

--- a/include/SDL_joystick.h
+++ b/include/SDL_joystick.h
@@ -373,12 +373,12 @@ typedef struct SDL_VirtualJoystickDesc
     const char *name;   /**< the name of the joystick */
 
     void *userdata;     /**< User data pointer passed to callbacks */
-    void (*Update)(void *userdata); /**< Called when the joystick state should be updated */
-    void (*SetPlayerIndex)(void *userdata, int player_index); /**< Called when the player index is set */
-    int (*Rumble)(void *userdata, Uint16 low_frequency_rumble, Uint16 high_frequency_rumble); /**< Implements SDL_JoystickRumble() */
-    int (*RumbleTriggers)(void *userdata, Uint16 left_rumble, Uint16 right_rumble); /**< Implements SDL_JoystickRumbleTriggers() */
-    int (*SetLED)(void *userdata, Uint8 red, Uint8 green, Uint8 blue); /**< Implements SDL_JoystickSetLED() */
-    int (*SendEffect)(void *userdata, const void *data, int size); /**< Implements SDL_JoystickSendEffect() */
+    void (SDLCALL *Update)(void *userdata); /**< Called when the joystick state should be updated */
+    void (SDLCALL *SetPlayerIndex)(void *userdata, int player_index); /**< Called when the player index is set */
+    int (SDLCALL *Rumble)(void *userdata, Uint16 low_frequency_rumble, Uint16 high_frequency_rumble); /**< Implements SDL_JoystickRumble() */
+    int (SDLCALL *RumbleTriggers)(void *userdata, Uint16 left_rumble, Uint16 right_rumble); /**< Implements SDL_JoystickRumbleTriggers() */
+    int (SDLCALL *SetLED)(void *userdata, Uint8 red, Uint8 green, Uint8 blue); /**< Implements SDL_JoystickSetLED() */
+    int (SDLCALL *SendEffect)(void *userdata, const void *data, int size); /**< Implements SDL_JoystickSendEffect() */
 
 } SDL_VirtualJoystickDesc;
 

--- a/include/SDL_stdinc.h
+++ b/include/SDL_stdinc.h
@@ -468,8 +468,8 @@ extern DECLSPEC int SDLCALL SDL_GetNumAllocations(void);
 extern DECLSPEC char *SDLCALL SDL_getenv(const char *name);
 extern DECLSPEC int SDLCALL SDL_setenv(const char *name, const char *value, int overwrite);
 
-extern DECLSPEC void SDLCALL SDL_qsort(void *base, size_t nmemb, size_t size, int (*compare) (const void *, const void *));
-extern DECLSPEC void * SDLCALL SDL_bsearch(const void *key, const void *base, size_t nmemb, size_t size, int (*compare) (const void *, const void *));
+extern DECLSPEC void SDLCALL SDL_qsort(void *base, size_t nmemb, size_t size, int (SDLCALL *compare) (const void *, const void *));
+extern DECLSPEC void * SDLCALL SDL_bsearch(const void *key, const void *base, size_t nmemb, size_t size, int (SDLCALL *compare) (const void *, const void *));
 
 extern DECLSPEC int SDLCALL SDL_abs(int x);
 

--- a/include/SDL_system.h
+++ b/include/SDL_system.h
@@ -195,7 +195,7 @@ extern DECLSPEC int SDLCALL SDL_LinuxSetThreadPriorityAndPolicy(Sint64 threadID,
  *
  * \sa SDL_iPhoneSetEventPump
  */
-extern DECLSPEC int SDLCALL SDL_iPhoneSetAnimationCallback(SDL_Window * window, int interval, void (*callback)(void*), void *callbackParam);
+extern DECLSPEC int SDLCALL SDL_iPhoneSetAnimationCallback(SDL_Window * window, int interval, void (SDLCALL *callback)(void*), void *callbackParam);
 
 #define SDL_iOSSetEventPump(enabled) SDL_iPhoneSetEventPump(enabled)
 

--- a/src/audio/wasapi/SDL_wasapi_win32.c
+++ b/src/audio/wasapi/SDL_wasapi_win32.c
@@ -362,7 +362,7 @@ typedef struct
     WAVEFORMATEXTENSIBLE fmt;
 } EndpointItem;
 
-static int sort_endpoints(const void *_a, const void *_b)
+static int SDLCALL sort_endpoints(const void *_a, const void *_b)
 {
     LPWSTR a = ((const EndpointItem *) _a)->devid;
     LPWSTR b = ((const EndpointItem *) _b)->devid;

--- a/src/joystick/hidapi/SDL_hidapi_rumble.c
+++ b/src/joystick/hidapi/SDL_hidapi_rumble.c
@@ -53,7 +53,7 @@ typedef struct SDL_HIDAPI_RumbleContext
 
 static SDL_HIDAPI_RumbleContext rumble_context;
 
-static int SDL_HIDAPI_RumbleThread(void *data)
+static int SDLCALL SDL_HIDAPI_RumbleThread(void *data)
 {
     SDL_HIDAPI_RumbleContext *ctx = (SDL_HIDAPI_RumbleContext *)data;
 

--- a/src/joystick/windows/SDL_dinputjoystick.c
+++ b/src/joystick/windows/SDL_dinputjoystick.c
@@ -683,7 +683,7 @@ EnumDevObjectsCallback(LPCDIDEVICEOBJECTINSTANCE pDeviceObject, LPVOID pContext)
 /* Sort using the data offset into the DInput struct.
  * This gives a reasonable ordering for the inputs.
  */
-static int
+static int SDLCALL
 SortDevFunc(const void *a, const void *b)
 {
     const input_t *inputA = (const input_t*)a;

--- a/src/joystick/windows/SDL_rawinputjoystick.c
+++ b/src/joystick/windows/SDL_rawinputjoystick.c
@@ -1069,7 +1069,7 @@ RAWINPUT_JoystickGetDeviceInstanceID(int device_index)
     return RAWINPUT_GetDeviceByIndex(device_index)->joystick_id;
 }
 
-static int
+static int SDLCALL
 RAWINPUT_SortValueCaps(const void *A, const void *B)
 {
     HIDP_VALUE_CAPS *capsA = (HIDP_VALUE_CAPS *)A;

--- a/src/joystick/windows/SDL_windowsjoystick.c
+++ b/src/joystick/windows/SDL_windowsjoystick.c
@@ -330,7 +330,7 @@ SDL_WaitForDeviceNotification(SDL_DeviceNotificationData *data, SDL_mutex *mutex
 static SDL_DeviceNotificationData s_notification_data;
 
 /* Function/thread to scan the system for joysticks. */
-static int
+static int SDLCALL
 SDL_JoystickThread(void *_data)
 {
 #if SDL_JOYSTICK_XINPUT

--- a/src/stdlib/SDL_malloc.c
+++ b/src/stdlib/SDL_malloc.c
@@ -733,7 +733,7 @@ extern "C"
   maximum supported value of n differs across systems, but is in all
   cases less than the maximum representable value of a size_t.
 */
-    void *dlmalloc(size_t);
+    void * SDLCALL dlmalloc(size_t);
 
 /*
   free(void* p)
@@ -742,14 +742,14 @@ extern "C"
   It has no effect if p is null. If p was not malloced or already
   freed, free(p) will by default cause the current program to abort.
 */
-    void dlfree(void *);
+    void SDLCALL dlfree(void *);
 
 /*
   calloc(size_t n_elements, size_t element_size);
   Returns a pointer to n_elements * element_size bytes, with all locations
   set to zero.
 */
-    void *dlcalloc(size_t, size_t);
+    void * SDLCALL dlcalloc(size_t, size_t);
 
 /*
   realloc(void* p, size_t n)
@@ -774,7 +774,7 @@ extern "C"
   to be used as an argument to realloc is not supported.
 */
 
-    void *dlrealloc(void *, size_t);
+    void * SDLCALL dlrealloc(void *, size_t);
 
 /*
   memalign(size_t alignment, size_t n);

--- a/src/test/SDL_test_harness.c
+++ b/src/test/SDL_test_harness.c
@@ -169,7 +169,7 @@ SDLTest_GenerateExecKey(const char *runSeed, const char *suiteName, const char *
 * \return Timer id or -1 on failure.
 */
 static SDL_TimerID
-SDLTest_SetTestTimeout(int timeout, void (*callback)(void))
+SDLTest_SetTestTimeout(int timeout, void (SDLCALL *callback)(void))
 {
     Uint32 timeoutInMilliseconds;
     SDL_TimerID timerID;
@@ -209,7 +209,7 @@ SDLTest_SetTestTimeout(int timeout, void (*callback)(void))
 #if defined(__WATCOMC__)
 #pragma aux SDLTest_BailOut aborts;
 #endif
-static SDL_NORETURN void
+static SDL_NORETURN void SDLCALL
 SDLTest_BailOut(void)
 {
     SDLTest_LogError("TestCaseTimeout timer expired. Aborting test run.");

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -341,7 +341,7 @@ SDL_DestroyWindowTexture(SDL_VideoDevice *unused, SDL_Window * window)
     SDL_free(data);
 }
 
-static int
+static int SDLCALL
 cmpmodes(const void *A, const void *B)
 {
     const SDL_DisplayMode *a = (const SDL_DisplayMode *) A;

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -29,6 +29,7 @@
 #include "SDL_timer.h"
 #include "SDL_vkeys.h"
 #include "SDL_hints.h"
+#include "SDL_main.h"
 #include "../../events/SDL_events_c.h"
 #include "../../events/SDL_touch_c.h"
 #include "../../events/scancodes_windows.h"

--- a/test/testgamecontroller.c
+++ b/test/testgamecontroller.c
@@ -312,24 +312,24 @@ static SDL_bool ShowingFront()
     return showing_front;
 }
 
-static void VirtualControllerSetPlayerIndex(void *userdata, int player_index)
+static void SDLCALL VirtualControllerSetPlayerIndex(void *userdata, int player_index)
 {
     SDL_Log("Virtual Controller: player index set to %d\n", player_index);
 }
 
-static int VirtualControllerRumble(void *userdata, Uint16 low_frequency_rumble, Uint16 high_frequency_rumble)
+static int SDLCALL VirtualControllerRumble(void *userdata, Uint16 low_frequency_rumble, Uint16 high_frequency_rumble)
 {
     SDL_Log("Virtual Controller: rumble set to %d/%d\n", low_frequency_rumble, high_frequency_rumble);
     return 0;
 }
 
-static int VirtualControllerRumbleTriggers(void *userdata, Uint16 left_rumble, Uint16 right_rumble)
+static int SDLCALL VirtualControllerRumbleTriggers(void *userdata, Uint16 left_rumble, Uint16 right_rumble)
 {
     SDL_Log("Virtual Controller: trigger rumble set to %d/%d\n", left_rumble, right_rumble);
     return 0;
 }
 
-static int VirtualControllerSetLED(void *userdata, Uint8 red, Uint8 green, Uint8 blue)
+static int SDLCALL VirtualControllerSetLED(void *userdata, Uint8 red, Uint8 green, Uint8 blue)
 {
     SDL_Log("Virtual Controller: LED set to RGB %d,%d,%d\n", red, green, blue);
     return 0;

--- a/test/testqsort.c
+++ b/test/testqsort.c
@@ -12,7 +12,7 @@
 
 #include "SDL_test.h"
 
-static int
+static int SDLCALL
 num_compare(const void *_a, const void *_b)
 {
     const int a = *((const int *) _a);


### PR DESCRIPTION
This is needed for OpenWatcom on Windows to match DLLs built with other compilers, since it uses different calling conventions by default. This may result in an ABI change for OS/2 builds, but shouldn't affect other builds.