### PR TITLE
Add extra XInput structures and defines for older SDKs

### DIFF
--- a/src/core/windows/SDL_xinput.c
+++ b/src/core/windows/SDL_xinput.c
@@ -23,8 +23,6 @@
 #include "SDL_xinput.h"
 
 
-#ifdef HAVE_XINPUT_H
-
 XInputGetState_t SDL_XInputGetState = NULL;
 XInputSetState_t SDL_XInputSetState = NULL;
 XInputGetCapabilities_t SDL_XInputGetCapabilities = NULL;
@@ -137,6 +135,5 @@ WIN_UnloadXInputDLL(void)
 }
 
 #endif /* __WINRT__ */
-#endif /* HAVE_XINPUT_H */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/core/windows/SDL_xinput.h
+++ b/src/core/windows/SDL_xinput.h
@@ -23,10 +23,11 @@
 #ifndef SDL_xinput_h_
 #define SDL_xinput_h_
 
-#ifdef HAVE_XINPUT_H
-
 #include "SDL_windows.h"
+
+#ifdef HAVE_XINPUT_H
 #include <xinput.h>
+#endif /* HAVE_XINPUT_H */
 
 #ifndef XUSER_MAX_COUNT
 #define XUSER_MAX_COUNT 4
@@ -70,6 +71,53 @@
 #endif
 #ifndef XINPUT_DEVSUBTYPE_ARCADE_PAD
 #define XINPUT_DEVSUBTYPE_ARCADE_PAD 0x13
+#endif
+
+#ifndef XINPUT_FLAG_GAMEPAD
+#define XINPUT_FLAG_GAMEPAD 0x01
+#endif
+
+#ifndef XINPUT_GAMEPAD_DPAD_UP
+#define XINPUT_GAMEPAD_DPAD_UP 0x0001
+#endif
+#ifndef XINPUT_GAMEPAD_DPAD_DOWN
+#define XINPUT_GAMEPAD_DPAD_DOWN 0x0002
+#endif
+#ifndef XINPUT_GAMEPAD_DPAD_LEFT
+#define XINPUT_GAMEPAD_DPAD_LEFT 0x0004
+#endif
+#ifndef XINPUT_GAMEPAD_DPAD_RIGHT
+#define XINPUT_GAMEPAD_DPAD_RIGHT 0x0008
+#endif
+#ifndef XINPUT_GAMEPAD_START
+#define XINPUT_GAMEPAD_START 0x0010
+#endif
+#ifndef XINPUT_GAMEPAD_BACK
+#define XINPUT_GAMEPAD_BACK 0x0020
+#endif
+#ifndef XINPUT_GAMEPAD_LEFT_THUMB
+#define XINPUT_GAMEPAD_LEFT_THUMB 0x0040
+#endif
+#ifndef XINPUT_GAMEPAD_RIGHT_THUMB
+#define XINPUT_GAMEPAD_RIGHT_THUMB 0x0080
+#endif
+#ifndef XINPUT_GAMEPAD_LEFT_SHOULDER
+#define XINPUT_GAMEPAD_LEFT_SHOULDER 0x0100
+#endif
+#ifndef XINPUT_GAMEPAD_RIGHT_SHOULDER
+#define XINPUT_GAMEPAD_RIGHT_SHOULDER 0x0200
+#endif
+#ifndef XINPUT_GAMEPAD_A
+#define XINPUT_GAMEPAD_A 0x1000
+#endif
+#ifndef XINPUT_GAMEPAD_B
+#define XINPUT_GAMEPAD_B 0x2000
+#endif
+#ifndef XINPUT_GAMEPAD_X
+#define XINPUT_GAMEPAD_X 0x4000
+#endif
+#ifndef XINPUT_GAMEPAD_Y
+#define XINPUT_GAMEPAD_Y 0x8000
 #endif
 
 #ifndef XINPUT_GAMEPAD_GUIDE
@@ -129,6 +177,36 @@ typedef struct
     BYTE BatteryLevel;
 } XINPUT_BATTERY_INFORMATION_EX;
 
+#ifndef HAVE_XINPUT_H
+
+typedef struct
+{
+    WORD wButtons;
+    BYTE bLeftTrigger;
+    BYTE bRightTrigger;
+    SHORT sThumbLX;
+    SHORT sThumbLY;
+    SHORT sThumbRX;
+    SHORT sThumbRY;
+} XINPUT_GAMEPAD;
+
+typedef struct
+{
+    WORD wLeftMotorSpeed;
+    WORD wRightMotorSpeed;
+} XINPUT_VIBRATION;
+
+typedef struct
+{
+    BYTE Type;
+    BYTE SubType;
+    WORD Flags;
+    XINPUT_GAMEPAD Gamepad;
+    XINPUT_VIBRATION Vibration;
+} XINPUT_CAPABILITIES;
+
+#endif /* HAVE_XINPUT_H */
+
 /* Forward decl's for XInput API's we load dynamically and use if available */
 typedef DWORD (WINAPI *XInputGetState_t)
     (
@@ -169,8 +247,6 @@ extern DWORD SDL_XInputVersion;  /* ((major << 16) & 0xFF00) | (minor & 0xFF) */
 #define XINPUTSETSTATE          SDL_XInputSetState
 #define XINPUTGETCAPABILITIES   SDL_XInputGetCapabilities
 #define XINPUTGETBATTERYINFORMATION   SDL_XInputGetBatteryInformation
-
-#endif /* HAVE_XINPUT_H */
 
 #endif /* SDL_xinput_h_ */
 


### PR DESCRIPTION
This was originally done for OpenWatcom, but may be useful for other toolchains that lack `xinput.h` as well.