### PR TITLE
test: Use install(1) more portably

### DIFF
--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -103,9 +103,11 @@ generatetestmeta:
 	done
 
 install: all
-	install -D -t $(DESTDIR)$(installedtestsdir) $(TARGETS)
-	install -m644 -D -t $(DESTDIR)$(installedtestsdir) $(DATA)
-	install -m644 -D -t $(DESTDIR)$(installedtestsmetadir) *.test
+	install -d $(DESTDIR)$(installedtestsdir)
+	install $(TARGETS) $(DESTDIR)$(installedtestsdir)
+	install -m644 $(DATA) $(DESTDIR)$(installedtestsdir)
+	install -d $(DESTDIR)$(installedtestsmetadir)
+	install -m644 *.test $(DESTDIR)$(installedtestsmetadir)
 
 Makefile: $(srcdir)/Makefile.in
 	$(SHELL) config.status $@


### PR DESCRIPTION
I had assumed that only Linux users would be interested in GNOME-style
installed-tests, but in principle there's no reason why they can't be
used on non-Linux.

---

Prompted by SDL_image CI leaving installed-tests enabled on macOS, which has a different and less featureful install(1).