### PR TITLE
add libdecor_dispatch

### DIFF
--- a/src/video/wayland/SDL_waylanddyn.h
+++ b/src/video/wayland/SDL_waylanddyn.h
@@ -153,6 +153,7 @@ void SDL_WAYLAND_UnloadSymbols(void);
 #define libdecor_state_free (*WAYLAND_libdecor_state_free)
 #define libdecor_configuration_get_content_size (*WAYLAND_libdecor_configuration_get_content_size)
 #define libdecor_configuration_get_window_state (*WAYLAND_libdecor_configuration_get_window_state)
+#define libdecor_dispatch (*WAYLAND_libdecor_dispatch)
 #endif
 
 #else /* SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC */

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -294,6 +294,10 @@ Wayland_WaitEventTimeout(_THIS, int timeout)
         }
     }
 
+#ifdef HAVE_LIBDECOR_H
+    libdecor_dispatch(d->shell.libdecor, timeout);
+#endif
+
     /* wl_display_prepare_read() will return -1 if the default queue is not empty.
      * If the default queue is empty, it will prepare us for our SDL_IOReady() call. */
     if (WAYLAND_wl_display_prepare_read(d->display) == 0) {

--- a/src/video/wayland/SDL_waylandsym.h
+++ b/src/video/wayland/SDL_waylandsym.h
@@ -204,6 +204,7 @@ SDL_WAYLAND_SYM(bool, libdecor_configuration_get_content_size, (struct libdecor_
                                                                 int *))
 SDL_WAYLAND_SYM(bool, libdecor_configuration_get_window_state, (struct libdecor_configuration *,\
                                                                 enum libdecor_window_state *))
+SDL_WAYLAND_SYM(bool, libdecor_dispatch, (struct libdecor *, int))
 #endif
 
 #undef SDL_WAYLAND_MODULE


### PR DESCRIPTION
As noted by @jadahl, we were missing `libdecor_dispatch` in SDL. Most of the dispatching work that needs to be done in the current cairo plugin, is already done in `Wayland_WaitEventTimeout`. But any more complex plugin, e.g. the hopefully future GTK plugin, will need additional iterations of their own event loop. This PR adds the `libdecor_dispatch` function.

However, now we are duplicating the dispatching. Most of the dispatching is done in `libdecor_dispatch` now. Everything that follows is repeating this with some additional key-repeat logic.

Any thoughts on this? Should the dispatching be divided in "wayland" dispatching and SDL-specific dispatching? I actually think that key-repeat stuff should be handled in the wayland key handlers and not the `Wayland_WaitEventTimeout`.