### PR TITLE
macOS: Add hint for blocking thread on OpenGL context update dispatch

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -927,6 +927,18 @@ extern "C" {
 #define SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK "SDL_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK"
 
 /**
+ *  \brief   A variable controlling whether dispatching OpenGL context updates should block the dispatching thread until the main thread finishes processing
+ *
+ *  This variable can be set to the following values:
+ *    "0"       - Dispatching OpenGL context updates will allow the dispatching thread to continue execution.
+ *    "1"       - Dispatching OpenGL context updates will block the dispatching thread until the main thread finishes processing.
+ *
+ *  This hint only applies to Mac OS X
+ *
+ */
+#define SDL_HINT_MAC_OPENGL_SYNC_DISPATCH "SDL_MAC_OPENGL_SYNC_DISPATCH"
+
+/**
  *  \brief  A variable setting the double click radius, in pixels.
  */
 #define SDL_HINT_MOUSE_DOUBLE_CLICK_RADIUS    "SDL_MOUSE_DOUBLE_CLICK_RADIUS"

--- a/src/video/cocoa/SDL_cocoaopengl.m
+++ b/src/video/cocoa/SDL_cocoaopengl.m
@@ -31,6 +31,7 @@
 #include <OpenGL/OpenGL.h>
 #include <OpenGL/CGLRenderers.h>
 
+#include "SDL_hints.h"
 #include "SDL_loadso.h"
 #include "SDL_opengl.h"
 
@@ -135,7 +136,11 @@
     if ([NSThread isMainThread]) {
         [super update];
     } else {
-        dispatch_async(dispatch_get_main_queue(), ^{ [super update]; });
+        if (SDL_GetHintBoolean(SDL_HINT_MAC_OPENGL_SYNC_DISPATCH, SDL_FALSE)) {
+            dispatch_sync(dispatch_get_main_queue(), ^{ [super update]; });
+        } else {
+            dispatch_async(dispatch_get_main_queue(), ^{ [super update]; });
+        }
     }
 }
 

--- a/src/video/cocoa/SDL_cocoaopengl.m
+++ b/src/video/cocoa/SDL_cocoaopengl.m
@@ -34,6 +34,7 @@
 #include "SDL_hints.h"
 #include "SDL_loadso.h"
 #include "SDL_opengl.h"
+#include "../../SDL_hints_c.h"
 
 #define DEFAULT_OPENGL  "/System/Library/Frameworks/OpenGL.framework/Libraries/libGL.dylib"
 
@@ -48,11 +49,7 @@ static SDL_bool SDL_opengl_sync_dispatch = SDL_FALSE;
 static void SDLCALL
 SDL_OpenGLSyncDispatchChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
 {
-    if (hint && *hint == '1') {
-        SDL_opengl_sync_dispatch = SDL_TRUE;
-    } else {
-        SDL_opengl_sync_dispatch = SDL_FALSE;
-    }
+    SDL_opengl_sync_dispatch = SDL_GetStringBoolean(hint, SDL_FALSE);
 }
 
 @implementation SDLOpenGLContext : NSOpenGLContext

--- a/src/video/cocoa/SDL_cocoaopengl.m
+++ b/src/video/cocoa/SDL_cocoaopengl.m
@@ -155,6 +155,11 @@ SDL_OpenGLSyncDispatchChanged(void *userdata, const char *name, const char *oldV
     }
 }
 
+- (void)dealloc
+{
+    SDL_DelHintCallback(SDL_HINT_MAC_OPENGL_SYNC_DISPATCH, SDL_OpenGLSyncDispatchChanged, NULL);
+}
+
 @end
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Since https://github.com/libsdl-org/SDL/pull/4242, context updates get dispatched without blocking the current thread. And while that works fine with OpenGL drivers on intel-powered mac GPUs, it doesn't play well on M1, which uses a OpenGL-to-Metal wrapper driver (`AppleMetalGLRenderer`), thus failing with the error seen in #5203:
```
-[AGXG13XFamilyCommandBuffer renderCommandEncoderWithDescriptor:]:380: failed assertion `A command encoder is already encoding to this command buffer'
```

I haven't investigated through the issue with the M1's wrapper in detail, but I'm opening this PR in the interim to workaround it, as this has been quite annoying in my workflow as an M1 user.

I have considered forcing `dispatch_sync` on M1 machines rather than a hint, but it would mean bringing back https://github.com/libsdl-org/SDL/issues/3680 for those machines, especially if Apple considers resolving the underlying issue with the M1's driver. Therefore I've went with a hint for simplicity, with the default value satisfying https://github.com/libsdl-org/SDL/issues/3680.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
 - Workaround for #5203 (setting `SDL_HINT_MAC_OPENGL_SYNC_DISPATCH=1` should fix)