### PR TITLE
wayland: Only call libdecor_dispatch() if we've loaded libdecor

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -295,7 +295,9 @@ Wayland_WaitEventTimeout(_THIS, int timeout)
     }
 
 #ifdef HAVE_LIBDECOR_H
-    libdecor_dispatch(d->shell.libdecor, timeout);
+    if (d->shell.libdecor) {
+        libdecor_dispatch(d->shell.libdecor, timeout);
+    }
 #endif
 
     /* wl_display_prepare_read() will return -1 if the default queue is not empty.


### PR DESCRIPTION
As of #5703, we call libdecor_dispatch() in Wayland_WaitEventTimeout(),
but this will crash if we don't load libdecor, as
SDL_VideoData::shell.libdecor will be NULL.

Since we don't load libdecor if we don't intend to use it (i.e., if
should_use_libdecor returns false), this results in a crash under KDE in
almost all circumstances.
