### PR TITLE
Relocatable sdl2-config + fix `sdl2-config --static-libs`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2697,6 +2697,7 @@ configure_file("${SDL2_SOURCE_DIR}/include/SDL_revision.h.cmake"
 if(NOT WINDOWS OR CYGWIN OR MINGW)
 
   set(prefix ${CMAKE_INSTALL_PREFIX})
+  file(RELATIVE_PATH bin_prefix_relpath "${CMAKE_INSTALL_FULL_BINDIR}" "${CMAKE_INSTALL_PREFIX}")
 
   set(exec_prefix "\${prefix}")
   set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")

--- a/configure
+++ b/configure
@@ -653,6 +653,7 @@ SDL_RLD_FLAGS
 SDL_STATIC_LIBS
 SDL_LIBS
 SDL_CFLAGS
+bin_prefix_relpath
 cmake_prefix_relpath
 INSTALL_SDL2_CONFIG
 LIBUSB_LIBS
@@ -27056,6 +27057,10 @@ SDL_STATIC_LIBS="$EXTRA_LDFLAGS"
 eval pkg_prefix=$prefix
 eval pkg_cmakedir=$libdir/cmake/SDL2
 cmake_prefix_relpath="$(echo -n "$pkg_cmakedir" | sed -E "s#^$pkg_prefix##" | sed -E "s#[A-Za-z0-9_ .-]+#..#g" )"
+
+
+eval pkg_bindir=$bindir
+bin_prefix_relpath="$(echo -n "pkg_bindir" | sed -E "s#^$pkg_prefix##" | sed -E "s#[A-Za-z0-9_ .-]+#..#g" )"
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -4694,6 +4694,11 @@ eval pkg_cmakedir=$libdir/cmake/SDL2
 cmake_prefix_relpath="$(echo -n "$pkg_cmakedir" | sed -E "s#^$pkg_prefix##" | sed -E "s#[A-Za-z0-9_ .-]+#..#g" )"
 AC_SUBST([cmake_prefix_relpath])
 
+dnl Calculate the location of the prefix, relative to bindir
+eval pkg_bindir=$bindir
+bin_prefix_relpath="$(echo -n "pkg_bindir" | sed -E "s#^$pkg_prefix##" | sed -E "s#[A-Za-z0-9_ .-]+#..#g" )"
+AC_SUBST([bin_prefix_relpath])
+
 dnl Expand the cflags and libraries needed by apps using SDL
 AC_SUBST(SDL_CFLAGS)
 AC_SUBST(SDL_LIBS)

--- a/sdl2-config.in
+++ b/sdl2-config.in
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-prefix=@prefix@
+# Get the canonical path of the folder containing this script
+bindir=$(cd -P -- "$(dirname -- "$0")" && printf '%s\n' "$(pwd -P)")
+
+# Calculate the canonical path of the prefix, relative to the folder of this script
+prefix=$(cd -P -- "$bindir/@bin_prefix_relpath@" && printf '%s\n' "$(pwd -P)")
 exec_prefix=@exec_prefix@
 exec_prefix_set=no
 libdir=@libdir@

--- a/sdl2-config.in
+++ b/sdl2-config.in
@@ -53,7 +53,8 @@ while test $# -gt 0; do
 @ENABLE_SHARED_TRUE@      ;;
 @ENABLE_STATIC_TRUE@@ENABLE_SHARED_TRUE@    --static-libs)
 @ENABLE_STATIC_TRUE@@ENABLE_SHARED_FALSE@    --libs|--static-libs)
-@ENABLE_STATIC_TRUE@      echo -L@libdir@ @SDL_LIBS@ @SDL_STATIC_LIBS@
+@ENABLE_STATIC_TRUE@      sdl_static_libs=$(echo "@SDL_LIBS@ @SDL_STATIC_LIBS@" | sed -E "s#-lSDL2[ $]#-Wl,-Bstatic -lSDL2 -Wl,-Bdynamic #g")
+@ENABLE_STATIC_TRUE@      echo -L@libdir@ $sdl_static_libs
 @ENABLE_STATIC_TRUE@      ;;
     *)
       echo "${usage}" 1>&2


### PR DESCRIPTION
This pr:
- makes sdl2-config relocatable by calculating the sdl2 prefix relative to the binary directory
    (I don't think `sdl2.pc` and the libtool `.la` files can be made relocatable)
- fixes `sdl2-config --static-libs`.
    Before, the output of `sdl2-config --static-libs` was:
    **linux**:
    ```
    -L/tmp/buildautotools/prefix/lib -lSDL2 -lm -ldl -lpthread -lrt
    ```
    **mingw**:
    ```
    -L/tmp/buildmingw32/prefix/lib -lmingw32 -lSDL2main -lSDL2 -mwindows -Wl,--dynamicbase -Wl,--nxcompat -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lsetupapi -lversion -luuid
    ```
    
    This pr replaces every case of `-lSDL2` with `-Wl,-Bstatic -lSDL2 -Wl,-Bdynamic` so the above outputs become:
    **linux**:
    ```
    -L/tmp/buildautotools/prefix/lib -Wl,-Bstatic -lSDL2 -Wl,-Bdynamic -lm -ldl -lpthread -lrt
    ```
    and
    **mingw**
    ```
    -L/tmp/buildmingw32/prefix/lib -lmingw32 -lSDL2main -Wl,-Bstatic -lSDL2 -Wl,-Bdynamic -mwindows -Wl,--dynamicbase -Wl,--nxcompat -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lsetupapi -lversion -luuid
    ```

    Because the change is to `sdl2-config.in` only, it also fixes `sdl2-config` generated by CMake.

