### PR TITLE
Build warning fixes for gcc-11.3

### DIFF
--- a/test/testautomation_rect.c
+++ b/test/testautomation_rect.c
@@ -707,7 +707,7 @@ int rect_testIntersectRectEmpty (void *arg)
 int rect_testIntersectRectParam(void *arg)
 {
     SDL_Rect rectA;
-    SDL_Rect rectB;
+    SDL_Rect rectB = {0};
     SDL_Rect result;
     SDL_bool intersection;
 
@@ -962,7 +962,7 @@ int rect_testHasIntersectionEmpty (void *arg)
 int rect_testHasIntersectionParam(void *arg)
 {
     SDL_Rect rectA;
-    SDL_Rect rectB;
+    SDL_Rect rectB = {0};
     SDL_bool intersection;
 
     /* invalid parameter combinations */

--- a/test/testautomation_surface.c
+++ b/test/testautomation_surface.c
@@ -178,6 +178,10 @@ void _testBlitBlendMode(int mode)
                 bmode = SDL_BLENDMODE_ADD;
             } else if (nmode==3) {
                 bmode = SDL_BLENDMODE_MOD;
+            } else {
+                /* Should be impossible, but some static checkers are too imprecise and will complain */
+                SDLTest_LogError("Invalid: nmode=%d", nmode);
+                return;
             }
             ret = SDL_SetSurfaceBlendMode( face, bmode );
             if (ret != 0) checkFailCount4++;

--- a/test/testautomation_video.c
+++ b/test/testautomation_video.c
@@ -1372,7 +1372,8 @@ video_getSetWindowMinimumSize(void *arg)
   int wVariation, hVariation;
   int referenceW, referenceH;
   int currentW, currentH;
-  int desiredW, desiredH;
+  int desiredW = 1;
+  int desiredH = 1;
 
   /* Get display bounds for size range */
   result = SDL_GetDisplayBounds(0, &display);


### PR DESCRIPTION
## Description

Eliminate trivial warnings issued by gcc-11.3 due to limitations in its static checkers by
adding extra initialisation and (in one case) by diverting a control flow edge that is only taken on impossible control flow paths.
These warnings break `cmake` release builds on my Debian/amd64 setup.