### PR TITLE
Remove two gcc-11 warnings

### DIFF
--- a/test/testautomation_rect.c
+++ b/test/testautomation_rect.c
@@ -1231,7 +1231,7 @@ int rect_testEnclosePointsParam(void *arg)
 {
     SDL_Point points[1];
     int count;
-    SDL_Rect clip;
+    SDL_Rect clip = { 0 };
     SDL_Rect result;
     SDL_bool anyEnclosed;
 
@@ -1457,7 +1457,7 @@ int rect_testUnionRectInside(void *arg)
  */
 int rect_testUnionRectParam(void *arg)
 {
-    SDL_Rect rectA, rectB;
+    SDL_Rect rectA, rectB = { 0 };
     SDL_Rect result;
 
     /* invalid parameter combinations */


### PR DESCRIPTION
## Description

gcc-11 warns about two uninitialised fields being used.  To my understanding, the tests in question do not actually depend on the contents of those fields, but gcc's analysis is not able to see that.  This patch initialises those fields to dummy values to remove those warnings.