### PR TITLE
Set POSITION_INDEPENDENT_CODE property on SDL2 for CMake 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2934,6 +2934,7 @@ if(SDL_SHARED)
   add_library(SDL2 SHARED ${SOURCE_FILES} ${VERSION_SOURCES})
   # alias target for in-tree builds
   add_library(SDL2::SDL2 ALIAS SDL2)
+  set_target_properties(SDL2 PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
   if(APPLE)
     set_target_properties(SDL2 PROPERTIES
       MACOSX_RPATH 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2996,7 +2996,7 @@ if(SDL_STATIC)
   else()
     set_target_properties(SDL2-static PROPERTIES OUTPUT_NAME "SDL2")
   endif()
-  set_target_properties(SDL2-static PROPERTIES POSITION_INDEPENDENT_CODE ${SDL_STATIC_PIC})
+  set_target_properties(SDL2-static PROPERTIES POSITION_INDEPENDENT_CODE "${SDL_STATIC_PIC}")
   # Note: The clang toolset for Visual Studio does not support /NODEFAULTLIB.
   if(MSVC AND NOT SDL_LIBC AND NOT MSVC_CLANG AND NOT CMAKE_GENERATOR_PLATFORM STREQUAL "ARM")
     set_target_properties(SDL2-static PROPERTIES LINK_FLAGS_RELEASE "/NODEFAULTLIB")


### PR DESCRIPTION
Force shared SDL2 building with `POSITION_INDEPENDENT_CODE` enabled, even when `CMAKE_POSITION_INDEPENDENT_CODE` is false.
Looks like recent CMake versions behave different then older ones.

Fixes https://github.com/libsdl-org/SDL/issues/5769
