### PR TITLE
Fix D3D12 support check in CMakeLists.txt/configure builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1596,7 +1596,12 @@ elseif(WINDOWS)
 
     check_include_file(d3d9.h HAVE_D3D_H)
     check_include_file(d3d11_1.h HAVE_D3D11_H)
-    check_include_file(d3d12.h HAVE_D3D12_H)
+    check_c_source_compiles("
+      #include <winsdkver.h>
+      #include <sdkddkver.h>
+      #if WDK_NTDDI_VERSION > 0x0A000008
+      int main(int argc, char **argv) { return 0; }
+      #endif" HAVE_D3D12_H)
     check_include_file(ddraw.h HAVE_DDRAW_H)
     check_include_file(dsound.h HAVE_DSOUND_H)
     check_include_file(dinput.h HAVE_DINPUT_H)

--- a/configure
+++ b/configure
@@ -25090,7 +25090,7 @@ $as_echo_n "checking for d3d12 Windows SDK version... " >&6; }
 
 #include <winsdkver.h>
 #include <sdkddkver.h>
-#if WDK_NTDDI_VERSION < 0x0A000008
+#if WDK_NTDDI_VERSION <= 0x0A000008
 asdf
 #endif
 

--- a/configure
+++ b/configure
@@ -25083,12 +25083,31 @@ if test "x$ac_cv_header_d3d11_1_h" = xyes; then :
 fi
 
 
-        ac_fn_c_check_header_mongrel "$LINENO" "d3d12.h" "ac_cv_header_d3d12_h" "$ac_includes_default"
-if test "x$ac_cv_header_d3d12_h" = xyes; then :
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for d3d12 Windows SDK version" >&5
+$as_echo_n "checking for d3d12 Windows SDK version... " >&6; }
+        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <winsdkver.h>
+#include <sdkddkver.h>
+#if WDK_NTDDI_VERSION < 0x0A000008
+asdf
+#endif
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
   have_d3d12=yes
 fi
-
-
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: have_d3d12" >&5
+$as_echo "have_d3d12" >&6; }
         ac_fn_c_check_header_mongrel "$LINENO" "ddraw.h" "ac_cv_header_ddraw_h" "$ac_includes_default"
 if test "x$ac_cv_header_ddraw_h" = xyes; then :
   have_ddraw=yes

--- a/configure.ac
+++ b/configure.ac
@@ -3268,7 +3268,7 @@ CheckDIRECTX()
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <winsdkver.h>
 #include <sdkddkver.h>
-#if WDK_NTDDI_VERSION < 0x0A000008
+#if WDK_NTDDI_VERSION <= 0x0A000008
 asdf
 #endif
             ]],[])], [have_d3d12=yes],[])

--- a/configure.ac
+++ b/configure.ac
@@ -3264,7 +3264,15 @@ CheckDIRECTX()
     if test x$enable_directx = xyes; then
         AC_CHECK_HEADER(d3d9.h, have_d3d=yes)
         AC_CHECK_HEADER(d3d11_1.h, have_d3d11=yes)
-        AC_CHECK_HEADER(d3d12.h, have_d3d12=yes)
+        AC_MSG_CHECKING(for d3d12 Windows SDK version)
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <winsdkver.h>
+#include <sdkddkver.h>
+#if WDK_NTDDI_VERSION < 0x0A000008
+asdf
+#endif
+            ]],[])], [have_d3d12=yes],[])
+        AC_MSG_RESULT(have_d3d12)
         AC_CHECK_HEADER(ddraw.h, have_ddraw=yes)
         AC_CHECK_HEADER(dsound.h, have_dsound=yes)
         AC_CHECK_HEADER(dinput.h, have_dinput=yes)

--- a/src/render/direct3d12/SDL_render_d3d12.c
+++ b/src/render/direct3d12/SDL_render_d3d12.c
@@ -713,13 +713,13 @@ D3D12_CreateDeviceResources(SDL_Renderer* renderer)
             goto done;
         }
 
-        result = DXGIGetDebugInterfaceFunc(0, &SDL_IID_IDXGIDebug1, &data->dxgiDebug);
+        result = DXGIGetDebugInterfaceFunc(0, &SDL_IID_IDXGIDebug1, (void **)&data->dxgiDebug);
         if (FAILED(result)) {
             WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("DXGIGetDebugInterface1"), result);
             goto done;
         }
 
-        result = DXGIGetDebugInterfaceFunc(0, &SDL_IID_IDXGIInfoQueue, &dxgiInfoQueue);
+        result = DXGIGetDebugInterfaceFunc(0, &SDL_IID_IDXGIInfoQueue, (void **)&dxgiInfoQueue);
         if (FAILED(result)) {
             WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("DXGIGetDebugInterface1"), result);
             goto done;
@@ -1019,16 +1019,12 @@ done:
     return result;
 }
 
-#ifdef __WIN32__
-
 static DXGI_MODE_ROTATION
 D3D12_GetCurrentRotation()
 {
     /* FIXME */
     return DXGI_MODE_ROTATION_IDENTITY;
 }
-
-#endif /* __WIN32__ */
 
 static BOOL
 D3D12_IsDisplayRotated90Degrees(DXGI_MODE_ROTATION rotation)
@@ -1143,7 +1139,7 @@ D3D12_CreateSwapChain(SDL_Renderer * renderer, int w, int h)
 
     IDXGIFactory_MakeWindowAssociation(data->dxgiFactory, windowinfo.info.win.window, DXGI_MWA_NO_WINDOW_CHANGES);
 
-    result = IDXGISwapChain1_QueryInterface(swapChain, &SDL_IID_IDXGISwapChain4, &data->swapChain);
+    result = IDXGISwapChain1_QueryInterface(swapChain, &SDL_IID_IDXGISwapChain4, (void **)&data->swapChain);
     if (FAILED(result)) {
         WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGISwapChain1::QueryInterface"), result);
         goto done;
@@ -1267,7 +1263,7 @@ D3D12_CreateWindowSizeDependentResources(SDL_Renderer * renderer)
             data->swapChain,
             i,
             &SDL_IID_ID3D12Resource,
-            &data->renderTargets[i]
+            (void **) &data->renderTargets[i]
             );
         if (FAILED(result)) {
             WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGISwapChain4::GetBuffer"), result);
@@ -1664,7 +1660,7 @@ D3D12_UpdateTextureInternal(D3D12_RenderData * rendererData, ID3D12Resource * te
     result = ID3D12Resource_Map(rendererData->uploadBuffers[rendererData->currentUploadBuffer],
         0,
         NULL,
-        &textureMemory
+        (void **)&textureMemory
         );
     if (FAILED(result)) {
         SAFE_RELEASE(rendererData->uploadBuffers[rendererData->currentUploadBuffer]);
@@ -1926,7 +1922,7 @@ D3D12_LockTexture(SDL_Renderer * renderer, SDL_Texture * texture,
     result = ID3D12Resource_Map(textureData->stagingBuffer,
         0,
         NULL,
-        &textureMemory
+        (void **)&textureMemory
     );
     if (FAILED(result)) {
         SAFE_RELEASE(rendererData->uploadBuffers[rendererData->currentUploadBuffer]);
@@ -2182,7 +2178,6 @@ D3D12_UpdateVertexBuffer(SDL_Renderer *renderer,
     HRESULT result = S_OK;
     const int vbidx = rendererData->currentVertexBuffer;
     const UINT stride = sizeof(VertexPositionColor);
-    const UINT offset = 0;
     UINT8* vertexBufferData = NULL;
     D3D12_RANGE range;
 
@@ -2205,7 +2200,7 @@ D3D12_UpdateVertexBuffer(SDL_Renderer *renderer,
         return E_FAIL;
     }
 
-    result = ID3D12Resource_Map(rendererData->vertexBuffers[vbidx].resource, 0, &range, &vertexBufferData);
+    result = ID3D12Resource_Map(rendererData->vertexBuffers[vbidx].resource, 0, &range, (void **)&vertexBufferData);
     if (FAILED(result)) {
         return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Resource::Map [vertex buffer]"), result);
     }
@@ -2810,7 +2805,7 @@ D3D12_RenderReadPixels(SDL_Renderer * renderer, const SDL_Rect * rect,
     result = ID3D12Resource_Map(readbackBuffer,
         0,
         NULL,
-        &textureMemory
+        (void **)&textureMemory
     );
     if (FAILED(result)) {
         SAFE_RELEASE(readbackBuffer);


### PR DESCRIPTION
In the original PR in #5761, CMakeLists.txt and configure simply tested for the d3d12.h header. However, this is not a sufficient check as older versions of the Windows 10 SDK will not successfully compile the d3d12 renderer. This PR adds C source checks to the CMakeLists.txt/configure workflows to confirm that the WDK_NTDDI_VERSION is high enough to enable the d3d12 renderer.

It also fixes `-Wincompatible-pointer-types` warnings in some configurations.