### PR TITLE
emscripten: fix undefined symbol errors in non-threaded builds

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -22,7 +22,6 @@ jobs:
           echo "SDL2_DIR=$(pwd)/prefix" >> $GITHUB_ENV
           cmake --install build/
       - name: Verify CMake configuration files
-        if: ${{ false }}  # FIXME: cmake/test/CMakeLists.txt should support emscripten
         run: |
           emcmake cmake -S cmake/test -B cmake_config_build \
             -DCMAKE_BUILD_TYPE=Release \

--- a/src/video/emscripten/SDL_emscriptenframebuffer.c
+++ b/src/video/emscripten/SDL_emscriptenframebuffer.c
@@ -59,10 +59,19 @@ int Emscripten_CreateWindowFramebuffer(_THIS, SDL_Window * window, Uint32 * form
     return 0;
 }
 
-static void
-Emscripten_UpdateWindowFramebufferWorker(SDL_Surface* surface)
+int Emscripten_UpdateWindowFramebuffer(_THIS, SDL_Window * window, const SDL_Rect * rects, int numrects)
 {
-    EM_ASM_INT({
+    SDL_Surface *surface;
+
+    SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
+    surface = data->surface;
+    if (!surface) {
+        return SDL_SetError("Couldn't find framebuffer surface for window");
+    }
+
+    /* Send the data to the display */
+
+    MAIN_THREAD_EM_ASM({
         var w = $0;
         var h = $1;
         var pixels = $2;
@@ -147,31 +156,7 @@ Emscripten_UpdateWindowFramebufferWorker(SDL_Surface* surface)
         }
 
         SDL2.ctx.putImageData(SDL2.image, 0, 0);
-        return 0;
     }, surface->w, surface->h, surface->pixels);
-}
-
-int Emscripten_UpdateWindowFramebuffer(_THIS, SDL_Window * window, const SDL_Rect * rects, int numrects)
-{
-    SDL_Surface *surface;
-
-    SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
-    surface = data->surface;
-    if (!surface) {
-        return SDL_SetError("Couldn't find framebuffer surface for window");
-    }
-
-    /* Send the data to the display */
-
-    if (emscripten_is_main_runtime_thread()) {
-        Emscripten_UpdateWindowFramebufferWorker(surface);
-    } else {
-        emscripten_sync_run_in_main_runtime_thread(
-            EM_FUNC_SIG_VI,
-            Emscripten_UpdateWindowFramebufferWorker,
-            (uint32_t)surface
-        );
-    }
 
     if (emscripten_has_asyncify() && SDL_GetHintBoolean(SDL_HINT_EMSCRIPTEN_ASYNCIFY, SDL_TRUE)) {
         /* give back control to browser for screen refresh */

--- a/src/video/emscripten/SDL_emscriptenmouse.c
+++ b/src/video/emscripten/SDL_emscriptenmouse.c
@@ -63,10 +63,20 @@ Emscripten_CreateDefaultCursor()
     return Emscripten_CreateCursorFromString("default", SDL_FALSE);
 }
 
-static const char*
-Emscripten_GetCursorUrl(int w, int h, int hot_x, int hot_y, void* pixels)
+
+static SDL_Cursor*
+Emscripten_CreateCursor(SDL_Surface* surface, int hot_x, int hot_y)
 {
-    return (const char *)EM_ASM_INT({
+    const char *cursor_url = NULL;
+    SDL_Surface *conv_surf;
+
+    conv_surf = SDL_ConvertSurfaceFormat(surface, SDL_PIXELFORMAT_ABGR8888, 0);
+
+    if (!conv_surf) {
+        return NULL;
+    }
+
+    cursor_url = (const char *)MAIN_THREAD_EM_ASM_INT({
         var w = $0;
         var h = $1;
         var hot_x = $2;
@@ -114,40 +124,7 @@ Emscripten_GetCursorUrl(int w, int h, int hot_x, int hot_y, void* pixels)
         stringToUTF8(url, urlBuf, url.length + 1);
 
         return urlBuf;
-    }, w, h, hot_x, hot_y, pixels);
-}
-
-static SDL_Cursor*
-Emscripten_CreateCursor(SDL_Surface* surface, int hot_x, int hot_y)
-{
-    const char *cursor_url = NULL;
-    SDL_Surface *conv_surf;
-
-    conv_surf = SDL_ConvertSurfaceFormat(surface, SDL_PIXELFORMAT_ABGR8888, 0);
-
-    if (!conv_surf) {
-        return NULL;
-    }
-
-    if (emscripten_is_main_runtime_thread()) {
-        cursor_url = Emscripten_GetCursorUrl(
-            surface->w,
-            surface->h,
-            hot_x,
-            hot_y,
-            conv_surf->pixels
-        );
-    } else {
-        cursor_url = (const char *)emscripten_sync_run_in_main_runtime_thread(
-            EM_FUNC_SIG_IIIIIII,
-            Emscripten_GetCursorUrl,
-            surface->w,
-            surface->h,
-            hot_x,
-            hot_y,
-            conv_surf->pixels
-        );
-    }
+    }, surface->w, surface->h, hot_x, hot_y, conv_surf->pixels);
 
     SDL_FreeSurface(conv_surf);
 


### PR DESCRIPTION
## Description
Changes the framebuffer/cursor proxying code to use `MAIN_THREAD_EM_ASM` instead of `emscripten_sync_run_in_main_runtime_thread` with a function wrapping the `EM_ASM`. This is how everything else was handled.

Fixes this error
`error: undefined symbol: emscripten_sync_run_in_main_runtime_thread_`
caused by the proxying changes (caught while trying to update Emscripten to the latest release(https://github.com/emscripten-core/emscripten/pull/16916)).