### PR TITLE
Inhibit input devices when the accompanying hidraw device is opened

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_ps5.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps5.c
@@ -559,6 +559,11 @@ HIDAPI_DriverPS5_OpenJoystick(SDL_HIDAPI_Device *device, SDL_Joystick *joystick)
         SDL_SetError("Couldn't open %s", device->path);
         return SDL_FALSE;
     }
+
+#ifdef __LINUX__
+    HIDAPI_InhibitInput(device->path, SDL_TRUE);
+#endif
+
     device->context = ctx;
 
     /* Read a report to see what mode we're in */
@@ -1085,6 +1090,9 @@ HIDAPI_DriverPS5_CloseJoystick(SDL_HIDAPI_Device *device, SDL_Joystick *joystick
 
     SDL_LockMutex(device->dev_lock);
     {
+#ifdef __LINUX__
+        HIDAPI_InhibitInput(device->path, SDL_FALSE);
+#endif
         SDL_hid_close(device->dev);
         device->dev = NULL;
 

--- a/src/joystick/hidapi/SDL_hidapijoystick_c.h
+++ b/src/joystick/hidapi/SDL_hidapijoystick_c.h
@@ -134,6 +134,10 @@ extern void HIDAPI_DumpPacket(const char *prefix, Uint8 *data, int size);
 
 extern float HIDAPI_RemapVal(float val, float val_min, float val_max, float output_min, float output_max);
 
+#ifdef __LINUX__
+extern void HIDAPI_InhibitInput(const char *hidraw, SDL_bool inhibit);
+#endif
+
 #endif /* SDL_JOYSTICK_HIDAPI_H */
 
 /* vi: set ts=4 sw=4 expandtab: */


### PR DESCRIPTION
## Description
This adds a way to inhibit the associated input nodes when a hidraw node is opened, but only on Linux and only if the `inhibited` node is writable. At current, this is only added to the DualSense driver, though I'm unsure if there's any reason it couldn't be added globally when using hidraw nodes. Further, the `inhibited` node isn't generally group-writable and will likely require udev rules for whomever wishes to use this. One potential problem is if the process crashes or is otherwise uncleanly killed, the input nodes will not be uninhibited unless the program is re-run and exits cleanly.

I'm marking this as draft atm since some feedback will almost certainly be needed on how to handle the issues presented.