### PR TITLE
Remove unused macro definition in SDL_error

### DIFF
--- a/src/SDL_error.c
+++ b/src/SDL_error.c
@@ -25,8 +25,6 @@
 #include "SDL_error.h"
 #include "SDL_error_c.h"
 
-#define SDL_ERRBUFIZE   1024
-
 int
 SDL_SetError(SDL_PRINTF_FORMAT_STRING const char *fmt, ...)
 {


### PR DESCRIPTION
## Description
Remove unused `#define SDL_ERRBUFIZE`.