### PR TITLE
Rename variables in SDL_egl.c to be more intuitive

### DIFF
--- a/src/video/SDL_egl_c.h
+++ b/src/video/SDL_egl_c.h
@@ -33,7 +33,7 @@
 
 typedef struct SDL_EGL_VideoData
 {
-    void *egl_dll_handle, *dll_handle;
+    void *opengl_dll_handle, *egl_dll_handle;
     EGLDisplay egl_display;
     EGLConfig egl_config;
     int egl_swapinterval;

--- a/src/video/winrt/SDL_winrtopengles.cpp
+++ b/src/video/winrt/SDL_winrtopengles.cpp
@@ -63,7 +63,7 @@ WINRT_GLES_LoadLibrary(_THIS, const char *path)
     }
 
     /* Load ANGLE/WinRT-specific functions */
-    CreateWinrtEglWindow_Old_Function CreateWinrtEglWindow = (CreateWinrtEglWindow_Old_Function) SDL_LoadFunction(_this->egl_data->egl_dll_handle, "CreateWinrtEglWindow");
+    CreateWinrtEglWindow_Old_Function CreateWinrtEglWindow = (CreateWinrtEglWindow_Old_Function) SDL_LoadFunction(_this->egl_data->opengl_dll_handle, "CreateWinrtEglWindow");
     if (CreateWinrtEglWindow) {
         /* 'CreateWinrtEglWindow' was found, which means that an an older
          * version of ANGLE/WinRT is being used.  Continue setting up EGL,


### PR DESCRIPTION
Previously, `egl_dll_handle` actually referred to the OpenGL shared object, while `dll_handle` referred to the EGL shared object.