### PR TITLE
cmake: Fix static linking to dependencies with "-" in library name

### DIFF
--- a/sdl2-config.cmake.in
+++ b/sdl2-config.cmake.in
@@ -53,12 +53,12 @@ set(_sdl2_libraries "@SDL_LIBS@")
 set(_sdl2_static_private_libs "@SDL_STATIC_LIBS@")
 
 # Convert _sdl2_libraries to list and keep only libraries
-string(REGEX MATCHALL "-[lm]([a-zA-Z0-9._]+)" _sdl2_libraries "${_sdl2_libraries}")
+string(REGEX MATCHALL "-[lm]([-a-zA-Z0-9._]+)" _sdl2_libraries "${_sdl2_libraries}")
 string(REGEX REPLACE "^-l" "" _sdl2_libraries "${_sdl2_libraries}")
 string(REGEX REPLACE ";-l" ";" _sdl2_libraries "${_sdl2_libraries}")
 
 # Convert _sdl2_static_private_libs to list and keep only libraries
-string(REGEX MATCHALL "(-[lm]([a-zA-Z0-9._]+))|(-Wl,[^ ]*framework[^ ]*)" _sdl2_static_private_libs "${_sdl2_static_private_libs}")
+string(REGEX MATCHALL "(-[lm]([-a-zA-Z0-9._]+))|(-Wl,[^ ]*framework[^ ]*)" _sdl2_static_private_libs "${_sdl2_static_private_libs}")
 string(REGEX REPLACE "^-l" "" _sdl2_static_private_libs "${_sdl2_static_private_libs}")
 string(REGEX REPLACE ";-l" ";" _sdl2_static_private_libs "${_sdl2_static_private_libs}")
 


### PR DESCRIPTION
When SDL is built with Wayland support on Linux, and Wayland libraries
are linked as dependencies instead of being loaded with dlopen(), its
dependencies will include libraries whose names contain a dash, like
`-lwayland-client` and `-ldecor-0`. Don't replace such libraries with
`-lwayland` and `-ldecor`: those don't exist and linking them will fail.

---

To reproduce the bug that this fixes:

* build with Autotools, as is done in Debian
* `--enable-video-wayland --disable-wayland-shared`, as is done in Debian
* run Debian's "as-installed" test-case https://sources.debian.org/src/libsdl2/2.0.22%2Bdfsg-5/debian/tests/cmake/, which links a trivial executable using https://sources.debian.org/src/libsdl2/2.0.22%2Bdfsg-5/debian/tests/cmake-static/CMakeLists.txt/

Discovered while updating the git snapshot in Debian experimental. Regression somewhere between 3c3c025 and bdf1413, most likely in 246f3ba. cc @madebr 