### PR TITLE
wayland: Use the output descriptions from xdg-output when available

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -354,6 +354,16 @@ static void
 xdg_output_handle_description(void *data, struct zxdg_output_v1 *xdg_output,
                               const char *description)
 {
+    SDL_WaylandOutputData* driverdata = data;
+
+    if (driverdata->index == -1) {
+        /* xdg-output descriptions, if available, supersede wl-output model names. */
+        if (driverdata->placeholder.name != NULL) {
+            SDL_free(driverdata->placeholder.name);
+        }
+
+        driverdata->placeholder.name = SDL_strdup(description);
+    }
 }
 
 static const struct zxdg_output_v1_listener xdg_output_listener = {
@@ -477,7 +487,9 @@ display_handle_geometry(void *data,
     }
     driverdata->physical_width = physical_width;
     driverdata->physical_height = physical_height;
-    if (driverdata->index == -1) {
+
+    /* The output name is only set if xdg-output hasn't provided a description. */
+    if (driverdata->index == -1 && driverdata->placeholder.name == NULL) {
         driverdata->placeholder.name = SDL_strdup(model);
     }
 


### PR DESCRIPTION
Some compositors will provide 'nicer' / 'human readable' output descriptions via the xdg-output protocol. Use these description strings, when available, instead of the model name provided by wl-output.  On compositors such as GNOME where this is provided, the display names provided to applications by SDL will now match those in the desktop display settings panel.  On compositors where this data isn't provided, the old behavior of using the model string provided by wl-output will remain unchanged.

Additionally, per the protocol spec, information provided by xdg-output should supersede that provided by wl-output, so this is the recommended behavior in general.
