### PR TITLE
Test with MinGW clang + always create SDL2::SDL2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Windows (mingw32),      os: windows-latest, shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686 }
-        - { name: Windows (mingw64),      os: windows-latest, shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64 }
-        - { name: Linux (CMake),          os: ubuntu-20.04,   shell: sh,    flags: true }
-        - { name: Linux (autotools),      os: ubuntu-20.04,   shell: sh,    autotools: true }
-        - { name: MacOS (CMake),          os: macos-latest,   shell: sh }
-        - { name: MacOS (autotools),      os: macos-latest,   shell: sh,    autotools: true }
+        - { name: Windows (mingw32),        os: windows-latest, shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686, cc: gcc }
+        - { name: Windows (mingw64+clang),  os: windows-latest, shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64, cc: clang }
+        - { name: Linux (CMake),            os: ubuntu-20.04,   shell: sh,    flags: true }
+        - { name: Linux (autotools),        os: ubuntu-20.04,   shell: sh,    autotools: true }
+        - { name: MacOS (CMake),            os: macos-latest,   shell: sh }
+        - { name: MacOS (autotools),        os: macos-latest,   shell: sh,    autotools: true }
 
     steps:
     - name: Set up MSYS2
@@ -29,10 +29,21 @@ jobs:
       with:
         msystem: ${{ matrix.platform.msystem }}
         install: >-
-          ${{ matrix.platform.msys-env }}-gcc
+          ${{ matrix.platform.msys-env }}-${{ matrix.platform.cc }}
           ${{ matrix.platform.msys-env }}-cmake
           ${{ matrix.platform.msys-env }}-ninja
           ${{ matrix.platform.msys-env }}-pkg-config
+    - name: Configure MSYS2 compiler
+      if: matrix.platform.shell == 'msys2 {0}'
+      run: |
+        if test x${{ matrix.platform.cc}} == xgcc; then
+          echo "CC=gcc" >> $GITHUB_ENV
+          echo "CXX=g++" >> $GITHUB_ENV
+        fi
+        if test x${{ matrix.platform.cc}} == xclang; then
+          echo "CC=clang" >> $GITHUB_ENV
+          echo "CXX=clang++" >> $GITHUB_ENV
+        fi
 
     - name: Setup Linux dependencies
       if: runner.os == 'Linux'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3195,3 +3195,8 @@ endif()
 
 ##### Fix Objective C builds #####
 set(CMAKE_OBJC_FLAGS "${CMAKE_OBJC_FLAGS} ${CMAKE_C_FLAGS}")
+
+# Make sure SDL2::SDL2 always exists
+if(TARGET SDL2::SDL2-static AND NOT TARGET SDL2::SDL2)
+  add_library(SDL2::SDL2 ALIAS SDL2-static)
+endif()

--- a/SDL2Config.cmake.in
+++ b/SDL2Config.cmake.in
@@ -30,12 +30,14 @@ endif()
 check_required_components(SDL2)
 
 # Create SDL2::SDL2 alias for static-only builds
-if(NOT TARGET SDL2::SDL2 AND TARGET SDL2::SDL2-static)
+if(TARGET SDL2::SDL2-static AND NOT TARGET SDL2::SDL2)
   if(CMAKE_VERSION VERSION_LESS "3.18")
-    # Aliasing local targets is not supported on CMake < 3.18, so make it global.
-    set_target_properties(SDL2::SDL2-static PROPERTIES IMPORTED_GLOBAL TRUE)
+    # FIXME: Aliasing local targets is not supported on CMake < 3.18, so make it global.
+    add_library(SDL2::SDL2 INTERFACE IMPORTED)
+    set_target_properties(SDL2::SDL2 PROPERTIES INTERFACE_LINK_LIBRARIES "SDL2::SDL2-static")
+  else()
+    add_library(SDL2::SDL2 ALIAS SDL2::SDL2-static)
   endif()
-  add_library(SDL2::SDL2 ALIAS SDL2::SDL2-static)
 endif()
 
 # For compatibility with autotools sdl2-config.cmake, provide SDL2_* variables.

--- a/sdl2-config.cmake.in
+++ b/sdl2-config.cmake.in
@@ -192,3 +192,14 @@ macro(check_required_components _NAME)
 endmacro()
 
 check_required_components(SDL2)
+
+# Create SDL2::SDL2 alias for static-only builds
+if(TARGET SDL2::SDL2-static AND NOT TARGET SDL2::SDL2)
+  if(CMAKE_VERSION VERSION_LESS "3.18")
+    # FIXME: Aliasing local targets is not supported on CMake < 3.18, so make it global.
+    add_library(SDL2::SDL2 INTERFACE IMPORTED)
+    set_target_properties(SDL2::SDL2 PROPERTIES INTERFACE_LINK_LIBRARIES "SDL2::SDL2-static")
+  else()
+    add_library(SDL2::SDL2 ALIAS SDL2::SDL2-static)
+  endif()
+endif()


### PR DESCRIPTION
- Always create a `SDL2::SDL2` target.
By default it will be the shared library. When that library is not built, not installed or not available on a platform.
`SDL2::SDL2` will then be equivalent to `SDL2::SDL2-static`.
    Fixes #2010
- Build SDL2 with MinGW clang on CI