### PR TITLE
wayland: use libdecor resize edge enums for libdecor

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -479,8 +479,12 @@ ProcessHitTest(struct SDL_WaylandInput *input, uint32_t serial)
         };
 
 #ifdef HAVE_LIBDECOR_H
-        /* ditto for libdecor. */
-        const uint32_t *directions_libdecor = directions;
+        static const uint32_t directions_libdecor[] = {
+            LIBDECOR_RESIZE_EDGE_TOP_LEFT, LIBDECOR_RESIZE_EDGE_TOP,
+            LIBDECOR_RESIZE_EDGE_TOP_RIGHT, LIBDECOR_RESIZE_EDGE_RIGHT,
+            LIBDECOR_RESIZE_EDGE_BOTTOM_RIGHT, LIBDECOR_RESIZE_EDGE_BOTTOM,
+            LIBDECOR_RESIZE_EDGE_BOTTOM_LEFT, LIBDECOR_RESIZE_EDGE_LEFT
+        };
 #endif
 
         switch (rc) {


### PR DESCRIPTION
This PR makes SDL pass the correct `libdecor_resize_edge` enums instead of `xdg_toplevel_resize_edge` enums to `libdecor_frame_resize()`.

## Description

`libdecor_resize_edge` and `xdg_toplevel_resize_edge` are **not interchangeable**. `xdg_toplevel_resize_edge` enums are machine generated via the wayland-protocol XMLs and can be different than what is initially thought.

## Existing Issue(s)
closes #5801 
