### PR TITLE
cmake: freebsd: Fix -Wformat warning during tests build

### DIFF
--- a/include/SDL_config_minimal.h
+++ b/include/SDL_config_minimal.h
@@ -49,6 +49,7 @@ typedef unsigned long long uint64_t;
 typedef unsigned long uintptr_t;
 #else
 #define HAVE_STDINT_H 1
+#define HAVE_INTTYPES_H 1
 #endif /* Visual Studio 2008 */
 
 #ifdef __GNUC__


### PR DESCRIPTION
Without using <inttypes.h>, SDL_PRIx64 will expand to llx, but on 64-bit
FreeBSD platforms (u)int64_t is `(unsigned) long`:
```
SDL_test_memory.c:261:77: error: format specifies type 'unsigned long long' but the argument has type 'Uint64' (aka 'unsigned long') [-Werror,-Wformat]
```

This commit updates config_minimal.h to also assume presence of inttypes.h
for everything except old MSVC.