### PR TITLE
Fix read of uninitialised variable

### DIFF
--- a/src/core/linux/SDL_fcitx.c
+++ b/src/core/linux/SDL_fcitx.c
@@ -105,6 +105,7 @@ Fcitx_GetPreeditString(SDL_DBusContext *dbus,
         dbus->message_iter_recurse(&iter, &array);
         while (dbus->message_iter_get_arg_type(&array) == DBUS_TYPE_STRUCT) {
             dbus->message_iter_recurse(&array, &sub);
+            subtext = NULL;
             if (dbus->message_iter_get_arg_type(&sub) == DBUS_TYPE_STRING) {
                 dbus->message_iter_get_basic(&sub, &subtext);
                 if (subtext && *subtext) {


### PR DESCRIPTION
## Description

If the condition `(dbus->message_iter_get_arg_type(&sub) == DBUS_TYPE_STRING)` is false, subtext is not initialised. Then it is read on line 131.

You need to initialise it in the loop, otherwise you could add the length of the same `substring` to `pos` several times.

## Existing Issue(s)
None
