### PR TITLE
Add function to query window content scale

### DIFF
--- a/VisualC/SDL.sln
+++ b/VisualC/SDL.sln
@@ -1,5 +1,7 @@
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32922.545
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{D69D5741-611F-4E14-8541-1FEE94F50B5A}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SDL2", "SDL\SDL.vcxproj", "{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}"
@@ -57,6 +59,8 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "testsensor", "tests\testsensor\testsensor.vcxproj", "{C4E04D18-EF76-4B42-B4C2-16A1BACDC0A4}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "testsurround", "tests\testsurround\testsurround.vcxproj", "{70B894A9-E306-49E8-ABC2-932A952A5E5F}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "testdpi", "tests\testdpi\testdpi.vcxproj", "{4DE46041-98E0-44C7-89FB-BBD1CAC46EC5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -290,6 +294,14 @@ Global
 		{70B894A9-E306-49E8-ABC2-932A952A5E5F}.Release|Win32.Build.0 = Release|Win32
 		{70B894A9-E306-49E8-ABC2-932A952A5E5F}.Release|x64.ActiveCfg = Release|x64
 		{70B894A9-E306-49E8-ABC2-932A952A5E5F}.Release|x64.Build.0 = Release|x64
+		{4DE46041-98E0-44C7-89FB-BBD1CAC46EC5}.Debug|Win32.ActiveCfg = Debug|Win32
+		{4DE46041-98E0-44C7-89FB-BBD1CAC46EC5}.Debug|Win32.Build.0 = Debug|Win32
+		{4DE46041-98E0-44C7-89FB-BBD1CAC46EC5}.Debug|x64.ActiveCfg = Debug|x64
+		{4DE46041-98E0-44C7-89FB-BBD1CAC46EC5}.Debug|x64.Build.0 = Debug|x64
+		{4DE46041-98E0-44C7-89FB-BBD1CAC46EC5}.Release|Win32.ActiveCfg = Release|Win32
+		{4DE46041-98E0-44C7-89FB-BBD1CAC46EC5}.Release|Win32.Build.0 = Release|Win32
+		{4DE46041-98E0-44C7-89FB-BBD1CAC46EC5}.Release|x64.ActiveCfg = Release|x64
+		{4DE46041-98E0-44C7-89FB-BBD1CAC46EC5}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -320,6 +332,7 @@ Global
 		{40FB7794-D3C3-4CFE-BCF4-A80C97635682} = {D69D5741-611F-4E14-8541-1FEE94F50B5A}
 		{C4E04D18-EF76-4B42-B4C2-16A1BACDC0A4} = {D69D5741-611F-4E14-8541-1FEE94F50B5A}
 		{70B894A9-E306-49E8-ABC2-932A952A5E5F} = {D69D5741-611F-4E14-8541-1FEE94F50B5A}
+		{4DE46041-98E0-44C7-89FB-BBD1CAC46EC5} = {D69D5741-611F-4E14-8541-1FEE94F50B5A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C320C9F2-1A8F-41D7-B02B-6338F872BCAD}

--- a/VisualC/tests/testdpi/testdpi.vcxproj
+++ b/VisualC/tests/testdpi/testdpi.vcxproj
@@ -1,0 +1,210 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{4DE46041-98E0-44C7-89FB-BBD1CAC46EC5}</ProjectGuid>
+    <RootNamespace>testdpi</RootNamespace>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' != '10.0'">$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' != '10.0'">$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' != '10.0'">$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' != '10.0'">$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC70.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC70.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC70.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC70.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(Platform)\$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(Platform)\$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(Platform)\$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(Platform)\$(Configuration)\</IntDir>
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Midl>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TargetEnvironment>Win32</TargetEnvironment>
+      <TypeLibraryName>.\Debug/testdpi.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(SolutionDir)/../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Midl>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TargetEnvironment>X64</TargetEnvironment>
+      <TypeLibraryName>.\Debug/testdpi.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(SolutionDir)/../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Midl>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TargetEnvironment>Win32</TargetEnvironment>
+      <TypeLibraryName>.\Release/testdpi.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(SolutionDir)/../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Midl>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MkTypLibCompatible>true</MkTypLibCompatible>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TargetEnvironment>X64</TargetEnvironment>
+      <TypeLibraryName>.\Release/testdpi.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(SolutionDir)/../include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\SDL\SDL.vcxproj">
+      <Project>{81ce8daf-ebb2-4761-8e45-b71abcca8c68}</Project>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="..\..\SDLmain\SDLmain.vcxproj">
+      <Project>{da956fd3-e142-46f2-9dd5-c78bebb56b7a}</Project>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="..\..\SDLtest\SDLtest.vcxproj">
+      <Project>{da956fd3-e143-46f2-9fe5-c77bebc56b1a}</Project>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\test\testdpi.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/include/SDL_video.h
+++ b/include/SDL_video.h
@@ -1132,6 +1132,36 @@ extern DECLSPEC void SDLCALL SDL_GetWindowMaximumSize(SDL_Window * window,
                                                       int *w, int *h);
 
 /**
+ * Get the OS-provided scale factor to apply to the contents of the window.
+ * 
+ * The content scale is how much larger the OS wants us to draw elements
+ * like text to match the user's preferences 
+ * (usually based on DPI of the monitor).
+ * 
+ * SDL_GetWindowSizeInPixels() divided by SDL_GetWindowSize() is approximately
+ * equivalent to these values, differing slightly due to rounding behaviors.
+ * 
+ * This value can change if the user changes the scaling settings on the OS, 
+ * or if they have multiple monitors with different scaling settings and drag
+ * the window between them.
+ * The `SDL_WINDOWEVENT_SIZE_CHANGED` window event is raised when this happens.
+ *
+ * \param window the window to query
+ * \param h a pointer filled in with the horizontal content scale of the 
+ *          window, may be NULL
+ * \param v a pointer filled in with the vertical content scale of the
+ *          window, may be NULL
+ *
+ * \since This function is available since SDL 2.25.0.
+ *
+ * \sa SDL_GetWindowSizeInPixels
+ * \sa SDL_GetWindowSize
+ */
+extern DECLSPEC void SDLCALL SDL_GetWindowContentScale(SDL_Window * window, 
+                                                       float * h, float * v);
+
+
+/**
  * Set the border state of a window.
  *
  * This will add or remove the window's `SDL_WINDOW_BORDERLESS` flag and add

--- a/src/dynapi/SDL2.exports
+++ b/src/dynapi/SDL2.exports
@@ -867,3 +867,4 @@
 ++'_SDL_SensorGetDataWithTimestamp'.'SDL2.dll'.'SDL_SensorGetDataWithTimestamp'
 ++'_SDL_ResetHints'.'SDL2.dll'.'SDL_ResetHints'
 ++'_SDL_strcasestr'.'SDL2.dll'.'SDL_strcasestr'
+++'_SDL_GetWindowContentScale'.'SDL2.dll'.'SDL_GetWindowContentScale'

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -893,3 +893,4 @@
 #define SDL_SensorGetDataWithTimestamp SDL_SensorGetDataWithTimestamp_REAL
 #define SDL_ResetHints SDL_ResetHints_REAL
 #define SDL_strcasestr SDL_strcasestr_REAL
+#define SDL_GetWindowContentScale SDL_GetWindowContentScale_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -976,3 +976,4 @@ SDL_DYNAPI_PROC(int,SDL_GameControllerGetSensorDataWithTimestamp,(SDL_GameContro
 SDL_DYNAPI_PROC(int,SDL_SensorGetDataWithTimestamp,(SDL_Sensor *a, Uint64 *b, float *c, int d),(a,b,c,d),return)
 SDL_DYNAPI_PROC(void,SDL_ResetHints,(void),(),)
 SDL_DYNAPI_PROC(char*,SDL_strcasestr,(const char *a, const char *b),(a,b),return)
+SDL_DYNAPI_PROC(void,SDL_GetWindowContentScale,(SDL_Window *a, float *b, float *c),(a,b,c),)

--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -228,6 +228,7 @@ struct SDL_VideoDevice
     void (*SetWindowMaximumSize) (_THIS, SDL_Window * window);
     int (*GetWindowBordersSize) (_THIS, SDL_Window * window, int *top, int *left, int *bottom, int *right);
     void (*GetWindowSizeInPixels)(_THIS, SDL_Window *window, int *w, int *h);
+    void (*GetWindowContentScale)(_THIS, SDL_Window *window, float *h, float *v);
     int (*SetWindowOpacity) (_THIS, SDL_Window * window, float opacity);
     int (*SetWindowModalFor) (_THIS, SDL_Window * modal_window, SDL_Window * parent_window);
     int (*SetWindowInputFocus) (_THIS, SDL_Window * window);

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2495,6 +2495,27 @@ SDL_GetWindowMaximumSize(SDL_Window * window, int *max_w, int *max_h)
 }
 
 void
+SDL_GetWindowContentScale(SDL_Window *window, float *h, float *v)
+{
+    CHECK_WINDOW_MAGIC(window,);
+
+    if (_this->GetWindowContentScale) {
+        _this->GetWindowContentScale(_this, window, h, v);
+    } else {
+        int width, height, pixWidth, pixHeight;
+
+        SDL_GetWindowSize(window, &width, &height);
+        SDL_GetWindowSizeInPixels(window, &pixWidth, &pixHeight);
+
+        if (h)
+            *h = pixWidth / (float) width;
+
+        if (v)
+            *v = pixHeight / (float) height;
+    }
+}
+
+void
 SDL_ShowWindow(SDL_Window * window)
 {
     CHECK_WINDOW_MAGIC(window,);

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -210,6 +210,7 @@ WIN_CreateDevice(void)
     device->SetWindowHitTest = WIN_SetWindowHitTest;
     device->AcceptDragAndDrop = WIN_AcceptDragAndDrop;
     device->FlashWindow = WIN_FlashWindow;
+    device->GetWindowContentScale = WIN_GetWindowContentScale;
 
     device->shape_driver.CreateShaper = Win32_CreateShaper;
     device->shape_driver.SetWindowShape = Win32_SetWindowShape;

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -1504,6 +1504,19 @@ WIN_FlashWindow(_THIS, SDL_Window * window, SDL_FlashOperation operation)
 }
 #endif /*!defined(__XBOXONE__) && !defined(__XBOXSERIES__)*/
 
+void
+WIN_GetWindowContentScale(_THIS, SDL_Window *window, float *h, float *v)
+{
+    const SDL_WindowData *data = ((SDL_WindowData *) window->driverdata);
+   
+    float scale = data->scaling_dpi / 96.0f;
+
+    if (h)
+        *h = scale;
+    if (v)
+        *v = scale;
+}
+
 #endif /* SDL_VIDEO_DRIVER_WINDOWS */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/windows/SDL_windowswindow.h
+++ b/src/video/windows/SDL_windowswindow.h
@@ -110,6 +110,7 @@ extern void WIN_ClientPointToSDL(const SDL_Window *window, int *w, int *h);
 extern void WIN_ClientPointFromSDL(const SDL_Window *window, int *w, int *h);
 extern void WIN_AcceptDragAndDrop(SDL_Window * window, SDL_bool accept);
 extern int WIN_FlashWindow(_THIS, SDL_Window * window, SDL_FlashOperation operation);
+extern void WIN_GetWindowContentScale(_THIS, SDL_Window *window, float *h, float *v);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -170,6 +170,7 @@ add_executable(testcustomcursor testcustomcursor.c)
 add_executable(controllermap controllermap.c testutils.c)
 add_executable(testvulkan testvulkan.c)
 add_executable(testoffscreen testoffscreen.c)
+add_executable(testdpi testdpi.c)
 
 cmake_push_check_state(RESET)
 

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -80,6 +80,7 @@ TARGETS = \
 	testvulkan$(EXE) \
 	testwm2$(EXE) \
 	testyuv$(EXE) \
+	testdpi$(EXE) \
 	torturethread$(EXE) \
 
 
@@ -353,6 +354,9 @@ testmessage$(EXE): $(srcdir)/testmessage.c
 	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
 
 testdisplayinfo$(EXE): $(srcdir)/testdisplayinfo.c
+	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
+
+testdpi$(EXE): $(srcdir)/testdpi.c
 	$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
 
 testqsort$(EXE): $(srcdir)/testqsort.c

--- a/test/testdpi.c
+++ b/test/testdpi.c
@@ -1,0 +1,150 @@
+/*
+  Copyright (C) 1997-2022 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely.
+*/
+
+/* Test of window content scale/DPI handling. */
+
+#include "SDL.h"
+#include <math.h>
+
+#include "SDL_test.h"
+#include "SDL_test_common.h"
+
+static SDLTest_CommonState *state;
+static int quitting = 0;
+
+static void 
+dump_info(SDL_Window* window)
+{
+    int w, h, pix_w, pix_h, window_id;
+    float scale_h, scale_v;
+
+    SDL_GetWindowSize(window, &w, &h);
+    SDL_GetWindowSizeInPixels(window, &pix_w, &pix_h);
+    SDL_GetWindowContentScale(window, &scale_h, &scale_v);
+    window_id = SDL_GetWindowID(window);
+
+    SDL_Log("Window: %d\n", window_id);
+    SDL_Log("Size: %dx%d \n", w, h);
+    SDL_Log("Pixel Size: %dx%d \n", pix_w, pix_h);
+    SDL_Log("Content Scale: %fx%f \n", scale_h, scale_v);
+}
+
+static void
+process_event(SDL_Event event)
+{
+    SDLTest_CommonEvent(state, &event, &quitting);
+
+    switch (event.type) {
+    case SDL_WINDOWEVENT: {
+        SDL_Window* window = SDL_GetWindowFromID(event.window.windowID);
+
+        switch (event.window.event) {
+        case SDL_WINDOWEVENT_SIZE_CHANGED:
+            SDL_Log("Size changed, dumping info:\n");
+            dump_info(window);
+            break;
+        }
+        break;
+    }
+    }
+}
+
+static void
+loop(void)
+{
+    SDL_Event event;
+    int i;
+
+    for (i = 0; i < state->num_windows; ++i) {
+        SDL_Renderer *renderer;
+        SDL_Window *window;
+        float scale_h, scale_v;
+        int mouse_x, mouse_y;
+        int size_h, size_v;
+        SDL_Rect mouse_rect;
+
+        if (!state->renderers[i]) {
+            continue;
+        }
+
+        /* Render a red square under the cursor, properly scaled of course. */
+        renderer = state->renderers[i];
+        window = state->windows[i];
+
+        SDL_GetWindowContentScale(window, &scale_h, &scale_v);
+
+        SDL_GetMouseState(&mouse_x, &mouse_y);
+
+        mouse_x = (int) (mouse_x * scale_h);
+        mouse_y = (int) (mouse_y * scale_v);
+
+        size_h = (int) (30 * scale_h);
+        size_v = (int) (30 * scale_v);
+
+        mouse_rect.x = mouse_x - size_h / 2;
+        mouse_rect.y = mouse_y - size_v / 2;
+        mouse_rect.w = size_h;
+        mouse_rect.h = size_v;
+
+        SDL_SetRenderDrawColor(renderer, 0xA0, 0xA0, 0xA0, 0xFF);
+        SDL_RenderClear(renderer);
+
+        SDL_SetRenderDrawColor(renderer, 0xFF, 0x00, 0x00, 0xFF);
+        SDL_RenderFillRect(renderer, &mouse_rect);
+
+        SDL_RenderPresent(renderer);
+    }
+
+    if (SDL_WaitEventTimeout(&event, 10)) {
+        process_event(event);
+    }
+
+    while (SDL_PollEvent(&event)) {
+        process_event(event);
+    }
+}
+
+int
+main(int argc, char *argv[])
+{
+    int i;
+   
+    SDL_SetHint("SDL_WINDOWS_DPI_SCALING", "1");
+
+    state = SDLTest_CommonCreateState(argv, SDL_INIT_VIDEO);
+    if (!state) {
+        return 1;
+    }
+
+    state->window_title = "DPI test";
+    state->window_w = 1280;
+    state->window_h = 720;
+    state->window_flags |= SDL_WINDOW_RESIZABLE;
+
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv) || !SDLTest_CommonInit(state)) {
+        SDLTest_CommonQuit(state);
+        return 1;
+    }
+
+    for (i = 0; i < state->num_windows; ++i) {
+        dump_info(state->windows[i]);
+    }
+
+    while (!quitting) {
+        loop();
+    }
+
+    SDLTest_CommonQuit(state);
+    return 0;
+}
+
+/* end of testdpi.c ... */

--- a/test/watcom.mif
+++ b/test/watcom.mif
@@ -7,7 +7,7 @@ LIBS    = SDL2.lib SDL2test.lib testutils.lib
 
 CFLAGS+= $(INCPATH)
 
-TARGETS = testatomic.exe testdisplayinfo.exe testbounds.exe testdraw2.exe &
+TARGETS = testatomic.exe testdisplayinfo.exe testdpi.exe testbounds.exe testdraw2.exe &
           testdrawchessboard.exe testdropfile.exe testerror.exe testfile.exe &
           testfilesystem.exe testgamecontroller.exe testgeometry.exe testgesture.exe &
           testhittesting.exe testhotplug.exe testiconv.exe testime.exe testlocale.exe &
@@ -44,6 +44,7 @@ needs_audio = &
 
 needs_display = &
 	testbounds.exe &
+  testdpi.exe &
 	testdisplayinfo.exe
 
 TESTS = $(noninteractive) $(needs_audio) $(needs_display)


### PR DESCRIPTION
## Description
Analogous to glfwGetWindowContentScale(). Gets you the raw intended DPI scale from the OS, without jumping through hoops by dividing drawable size by window size: 
![image](https://user-images.githubusercontent.com/8107459/174512544-5a83fa3d-d540-407d-92ed-e28e07151d1d.png)

I only implemented a proper driver function on Windows, all other platforms guess by dividing drawable size by window size. At least on Wayland and macOS this should be exact since they only have integer scaling currently anyways.

## Existing Issue(s)
See comments on #5778
