### PR TITLE
Update install directory to match generated

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -24,20 +24,34 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Configure CMake
-      run: cmake -S . -B build `
+    - name: Create CMake project using SDL as a subproject
+      shell: python
+      run: |
+        import os
+        import textwrap
+        srcdir = r"${{ github.workspace }}".replace("\\", "/")
+        builddir = f"{ srcdir }/build"
+        os.makedirs(builddir)
+        with open(f"{ builddir }/CMakeLists.txt", "w") as f:
+          f.write(textwrap.dedent(f"""\
+            cmake_minimum_required(VERSION 3.0)
+            project(sdl_user)
+            add_subdirectory("{ srcdir }" SDL)
+          """))
+    - name: Configure (CMake)
+      run: cmake -S build -B build `
         -DSDL_TESTS=ON `
         -DSDL_INSTALL_TESTS=ON `
         ${{ matrix.platform.flags }} `
         -DCMAKE_INSTALL_PREFIX=prefix
-    - name: Build CMake
+    - name: Build (CMake)
       run: cmake --build build/ --config Release --parallel
     - name: Run build-time tests
       if: "! contains(matrix.platform.name, 'ARM')"
       run: |
         $env:SDL_TESTS_QUICK=1
         ctest -VV --test-dir build/ -C Release
-    - name: Install CMake
+    - name: Install (CMake)
       run: |
         echo "SDL2_DIR=$Env:GITHUB_WORKSPACE/prefix" >> $Env:GITHUB_ENV
         cmake --install build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3162,7 +3162,7 @@ if(NOT SDL2_DISABLE_INSTALL)
 
   install(
     FILES
-      ${CMAKE_CURRENT_BINARY_DIR}/SDL2Config.cmake
+      ${CMAKE_BINARY_DIR}/SDL2Config.cmake
       ${CMAKE_BINARY_DIR}/SDL2ConfigVersion.cmake
     DESTINATION ${PKG_PREFIX}
     COMPONENT Devel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3119,11 +3119,11 @@ if(NOT SDL2_DISABLE_INSTALL)
   endif ()
 
   include(CMakePackageConfigHelpers)
-  configure_package_config_file(SDL2Config.cmake.in "${CMAKE_BINARY_DIR}/SDL2Config.cmake"
+  configure_package_config_file(SDL2Config.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/SDL2Config.cmake"
     PATH_VARS CMAKE_INSTALL_PREFIX CMAKE_INSTALL_FULL_BINDIR CMAKE_INSTALL_FULL_INCLUDEDIR CMAKE_INSTALL_FULL_LIBDIR
     INSTALL_DESTINATION ${PKG_PREFIX}
   )
-  write_basic_package_version_file("${CMAKE_BINARY_DIR}/SDL2ConfigVersion.cmake"
+  write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/SDL2ConfigVersion.cmake"
     VERSION ${SDL_VERSION}
     COMPATIBILITY AnyNewerVersion
   )
@@ -3162,8 +3162,8 @@ if(NOT SDL2_DISABLE_INSTALL)
 
   install(
     FILES
-      ${CMAKE_BINARY_DIR}/SDL2Config.cmake
-      ${CMAKE_BINARY_DIR}/SDL2ConfigVersion.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/SDL2Config.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/SDL2ConfigVersion.cmake
     DESTINATION ${PKG_PREFIX}
     COMPONENT Devel
   )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
[<!--- Describe your changes in detail -->](https://github.com/libsdl-org/SDL/blob/main/CMakeLists.txt#L3122
Sets `SDL2Config.cmake` to `CMAKE_BINARY_DIR`, whereas the install file tries to find it from a different location.)

This fixes problems with trying to `cmake install` about `SDL2Config.cmake` not existing. 

Seems to occur from
https://github.com/libsdl-org/SDL/commit/5ec2d46f476f5019d1d0bb8345b7f6f79222d0c1

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
