### PR TITLE
Support evdev-only psuedo-device with no video.

### DIFF
--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -454,6 +454,7 @@ extern VideoBootStrap RPI_bootstrap;
 extern VideoBootStrap KMSDRM_bootstrap;
 extern VideoBootStrap KMSDRM_LEGACY_bootstrap;
 extern VideoBootStrap DUMMY_bootstrap;
+extern VideoBootStrap DUMMY_evdev_bootstrap;
 extern VideoBootStrap Wayland_bootstrap;
 extern VideoBootStrap NACL_bootstrap;
 extern VideoBootStrap VIVANTE_bootstrap;

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -130,6 +130,9 @@ static VideoBootStrap *bootstrap[] = {
 #endif
 #if SDL_VIDEO_DRIVER_DUMMY
     &DUMMY_bootstrap,
+#if SDL_INPUT_LINUXEV
+    &DUMMY_evdev_bootstrap,
+#endif
 #endif
     NULL
 };

--- a/src/video/dummy/SDL_nullvideo.c
+++ b/src/video/dummy/SDL_nullvideo.c
@@ -49,11 +49,17 @@
 #include "SDL_hints.h"
 
 #define DUMMYVID_DRIVER_NAME "dummy"
+#define DUMMYVID_DRIVER_EVDEV_NAME "evdev"
 
 /* Initialization/Query functions */
 static int DUMMY_VideoInit(_THIS);
 static int DUMMY_SetDisplayMode(_THIS, SDL_VideoDisplay * display, SDL_DisplayMode * mode);
 static void DUMMY_VideoQuit(_THIS);
+
+#if SDL_INPUT_LINUXEV
+static int evdev = 0;
+static void DUMMY_EVDEV_Poll(_THIS);
+#endif
 
 /* DUMMY driver bootstrap functions */
 
@@ -61,11 +67,18 @@ static int
 DUMMY_Available(void)
 {
     const char *envr = SDL_GetHint(SDL_HINT_VIDEODRIVER);
-    if ((envr) && (SDL_strcmp(envr, DUMMYVID_DRIVER_NAME) == 0)) {
-        return (1);
+    if (envr) {
+        if (SDL_strcmp(envr, DUMMYVID_DRIVER_NAME) == 0) {
+            return 1;
+        }
+        #if SDL_INPUT_LINUXEV
+        if (SDL_strcmp(envr, DUMMYVID_DRIVER_EVDEV_NAME) == 0) {
+            evdev = 1;
+            return 1;
+        }
+        #endif
     }
-
-    return (0);
+    return 0;
 }
 
 static void
@@ -96,6 +109,11 @@ DUMMY_CreateDevice(void)
     device->VideoQuit = DUMMY_VideoQuit;
     device->SetDisplayMode = DUMMY_SetDisplayMode;
     device->PumpEvents = DUMMY_PumpEvents;
+    #if SDL_INPUT_LINUXEV
+    if (evdev) {
+        device->PumpEvents = DUMMY_EVDEV_Poll;
+    }
+    #endif
     device->CreateWindowFramebuffer = SDL_DUMMY_CreateWindowFramebuffer;
     device->UpdateWindowFramebuffer = SDL_DUMMY_UpdateWindowFramebuffer;
     device->DestroyWindowFramebuffer = SDL_DUMMY_DestroyWindowFramebuffer;
@@ -110,6 +128,19 @@ VideoBootStrap DUMMY_bootstrap = {
     DUMMY_CreateDevice
 };
 
+#if SDL_INPUT_LINUXEV
+VideoBootStrap DUMMY_evdev_bootstrap = {
+    DUMMYVID_DRIVER_EVDEV_NAME, "SDL dummy video driver with evdev",
+    DUMMY_CreateDevice
+};
+void SDL_EVDEV_Init(void);
+void SDL_EVDEV_Poll();
+void SDL_EVDEV_Quit(void);
+static void DUMMY_EVDEV_Poll(_THIS) {
+    (void) _this;
+    SDL_EVDEV_Poll();
+}
+#endif
 
 int
 DUMMY_VideoInit(_THIS)
@@ -129,6 +160,10 @@ DUMMY_VideoInit(_THIS)
 
     SDL_AddDisplayMode(&_this->displays[0], &mode);
 
+    #if SDL_INPUT_LINUXEV
+    SDL_EVDEV_Init();
+    #endif
+
     /* We're done! */
     return 0;
 }
@@ -139,9 +174,13 @@ DUMMY_SetDisplayMode(_THIS, SDL_VideoDisplay * display, SDL_DisplayMode * mode)
     return 0;
 }
 
+
 void
 DUMMY_VideoQuit(_THIS)
 {
+    #if SDL_INPUT_LINUXEV
+    SDL_EVDEV_Quit();
+    #endif
 }
 
 #endif /* SDL_VIDEO_DRIVER_DUMMY */


### PR DESCRIPTION
## Description

Specifying `SDL_VIDEODRIVER=evdev` in the environment (or via hints) enables a device akin to the original "dummy" video device but with evdev support such that `SDL_WaitEvent` will capture input events without a window or graphics context.
