### PR TITLE
Add note to GDK docs about XCurl.dll

### DIFF
--- a/docs/README-gdk.md
+++ b/docs/README-gdk.md
@@ -56,7 +56,7 @@ In your game's existing Visual Studio Solution, go to Build > Configuration Mana
 
 ### 2. Build SDL2 and SDL2main for GDK ###
 
-Open `VisualC-GDK/SDL.sln` in Visual Studio, you need to build the SDL2 and SDL2main targets (Release is recommended). You will need to copy/keep track of the `SDL2.dll`, `SDL2.lib`, and `SDL2main.lib` output files for your game project.
+Open `VisualC-GDK/SDL.sln` in Visual Studio, you need to build the SDL2 and SDL2main targets (Release is recommended). You will need to copy/keep track of the `SDL2.dll`, `XCurl.dll` (which is output by Gaming.Desktop.x64), `SDL2.lib`, and `SDL2main.lib` output files for your game project.
 
 *Alternatively*, you could setup your solution file to instead reference the SDL2/SDL2main project file targets from the SDL source, and add those projects as a dependency. This would mean that SDL2 and SDL2main would both be built when your game is built. 
 
@@ -83,6 +83,7 @@ The game will not launch in the debugger unless required DLLs are included in th
 
 * Your SDL2.dll
 * "$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.141.GDK.C.Thunks.dll"
+* XCurl.dll
 
 You can either copy these in a post-build step, or you can add the dlls into the project and set its Configuration Properties > General > Item type to "Copy file," which will also copy them into the output directory.
 


### PR DESCRIPTION
There is an additional .dll file that needs to be in the exe directory for GDK projects to work. See #5856.