### PR TITLE
Add SDL_GetDefaultAudioInfo

### DIFF
--- a/include/SDL_audio.h
+++ b/include/SDL_audio.h
@@ -487,6 +487,7 @@ extern DECLSPEC int SDLCALL SDL_GetNumAudioDevices(int iscapture);
  * \since This function is available since SDL 2.0.0.
  *
  * \sa SDL_GetNumAudioDevices
+ * \sa SDL_GetDefaultAudioInfo
  */
 extern DECLSPEC const char *SDLCALL SDL_GetAudioDeviceName(int index,
                                                            int iscapture);
@@ -512,10 +513,46 @@ extern DECLSPEC const char *SDLCALL SDL_GetAudioDeviceName(int index,
  * \since This function is available since SDL 2.0.16.
  *
  * \sa SDL_GetNumAudioDevices
+ * \sa SDL_GetDefaultAudioInfo
  */
 extern DECLSPEC int SDLCALL SDL_GetAudioDeviceSpec(int index,
                                                    int iscapture,
                                                    SDL_AudioSpec *spec);
+
+
+/**
+ * Get the name and preferred format of the default audio device.
+ *
+ * Some (but not all!) platforms have an isolated mechanism to get information
+ * about the "default" device. This can actually be a completely different
+ * device that's not in the list you get from SDL_GetAudioDeviceSpec(). It can
+ * even be a network address! (This is discussed in SDL_OpenAudioDevice().)
+ *
+ * As a result, this call is not guaranteed to be performant, as it can query
+ * the sound server directly every time, unlike the other query functions. You
+ * should call this function sparingly!
+ *
+ * `spec` will be filled with the sample rate, sample format, and channel
+ * count, if a default device exists on the system. If `name` is provided, will
+ * be filled with either a dynamically-allocated UTF-8 string or NULL.
+ *
+ * \param name A pointer to be filled with the name of the default device (can
+               be NULL). Please call SDL_free() when you are done with this
+               pointer!
+ * \param spec The SDL_AudioSpec to be initialized by this function.
+ * \param iscapture non-zero to query the default recording device, zero to
+ *                  query the default output device.
+ * \returns 0 on success, nonzero on error
+ *
+ * \since This function is available since SDL 2.24.0.
+ *
+ * \sa SDL_GetAudioDeviceName
+ * \sa SDL_GetAudioDeviceSpec
+ * \sa SDL_OpenAudioDevice
+ */
+extern DECLSPEC int SDLCALL SDL_GetDefaultAudioInfo(char **name,
+                                                    SDL_AudioSpec *spec,
+                                                    int iscapture);
 
 
 /**

--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -1154,6 +1154,24 @@ SDL_GetAudioDeviceSpec(int index, int iscapture, SDL_AudioSpec *spec)
 }
 
 
+int
+SDL_GetDefaultAudioInfo(char **name, SDL_AudioSpec *spec, int iscapture)
+{
+    if (spec == NULL) {
+        return SDL_InvalidParamError("spec");
+    }
+
+    if (!SDL_GetCurrentAudioDriver()) {
+        return SDL_SetError("Audio subsystem is not initialized");
+    }
+
+    if (current_audio.impl.GetDefaultAudioInfo == NULL) {
+        return SDL_Unsupported();
+    }
+    return current_audio.impl.GetDefaultAudioInfo(name, spec, iscapture);
+}
+
+
 static void
 close_audio_device(SDL_AudioDevice * device)
 {

--- a/src/audio/SDL_sysaudio.h
+++ b/src/audio/SDL_sysaudio.h
@@ -78,6 +78,7 @@ typedef struct SDL_AudioDriverImpl
     void (*UnlockDevice) (_THIS);
     void (*FreeDeviceHandle) (void *handle);  /**< SDL is done with handle from SDL_AddAudioDevice() */
     void (*Deinitialize) (void);
+    int (*GetDefaultAudioInfo) (char **name, SDL_AudioSpec *spec, int iscapture);
 
     /* !!! FIXME: add pause(), so we can optimize instead of mixing silence. */
 

--- a/src/audio/directsound/SDL_directsound.c
+++ b/src/audio/directsound/SDL_directsound.c
@@ -156,6 +156,17 @@ DSOUND_FreeDeviceHandle(void *handle)
     SDL_free(handle);
 }
 
+static int
+DSOUND_GetDefaultAudioInfo(char **name, SDL_AudioSpec *spec, int iscapture)
+{
+#if HAVE_MMDEVICEAPI_H
+    if (SupportsIMMDevice) {
+        return SDL_IMMDevice_GetDefaultAudioInfo(name, spec, iscapture);
+    }
+#endif /* HAVE_MMDEVICEAPI_H */
+    return SDL_Unsupported();
+}
+
 static BOOL CALLBACK
 FindAllDevs(LPGUID guid, LPCWSTR desc, LPCWSTR module, LPVOID data)
 {
@@ -615,6 +626,7 @@ DSOUND_Init(SDL_AudioDriverImpl * impl)
     impl->CloseDevice = DSOUND_CloseDevice;
     impl->FreeDeviceHandle = DSOUND_FreeDeviceHandle;
     impl->Deinitialize = DSOUND_Deinitialize;
+    impl->GetDefaultAudioInfo = DSOUND_GetDefaultAudioInfo;
 
     impl->HasCaptureSupport = SDL_TRUE;
 

--- a/src/audio/wasapi/SDL_wasapi.c
+++ b/src/audio/wasapi/SDL_wasapi.c
@@ -634,6 +634,7 @@ WASAPI_Init(SDL_AudioDriverImpl * impl)
     impl->FlushCapture = WASAPI_FlushCapture;
     impl->CloseDevice = WASAPI_CloseDevice;
     impl->Deinitialize = WASAPI_Deinitialize;
+    impl->GetDefaultAudioInfo = WASAPI_GetDefaultAudioInfo;
     impl->HasCaptureSupport = SDL_TRUE;
 
     return SDL_TRUE;   /* this audio target is available. */

--- a/src/audio/wasapi/SDL_wasapi.h
+++ b/src/audio/wasapi/SDL_wasapi.h
@@ -64,6 +64,7 @@ void WASAPI_UnrefDevice(_THIS);
 int WASAPI_PlatformInit(void);
 void WASAPI_PlatformDeinit(void);
 void WASAPI_EnumerateEndpoints(void);
+int WASAPI_GetDefaultAudioInfo(char **name, SDL_AudioSpec *spec, int iscapture);
 int WASAPI_ActivateDevice(_THIS, const SDL_bool isrecovery);
 void WASAPI_PlatformThreadInit(_THIS);
 void WASAPI_PlatformThreadDeinit(_THIS);

--- a/src/audio/wasapi/SDL_wasapi_win32.c
+++ b/src/audio/wasapi/SDL_wasapi_win32.c
@@ -145,6 +145,12 @@ WASAPI_EnumerateEndpoints(void)
     SDL_IMMDevice_EnumerateEndpoints(SDL_FALSE);
 }
 
+int
+WASAPI_GetDefaultAudioInfo(char **name, SDL_AudioSpec *spec, int iscapture)
+{
+    return SDL_IMMDevice_GetDefaultAudioInfo(name, spec, iscapture);
+}
+
 void
 WASAPI_PlatformDeleteActivationHandler(void *handler)
 {

--- a/src/audio/wasapi/SDL_wasapi_winrt.cpp
+++ b/src/audio/wasapi/SDL_wasapi_winrt.cpp
@@ -244,6 +244,12 @@ WASAPI_PlatformDeleteActivationHandler(void *handler)
 }
 
 int
+WASAPI_GetDefaultAudioInfo(char **name, SDL_AudioSpec *spec, int iscapture)
+{
+    return SDL_Unsupported();
+}
+
+int
 WASAPI_ActivateDevice(_THIS, const SDL_bool isrecovery)
 {
     LPCWSTR devid = _this->hidden->devid;

--- a/src/core/windows/SDL_immdevice.h
+++ b/src/core/windows/SDL_immdevice.h
@@ -33,6 +33,7 @@ int SDL_IMMDevice_Init(void);
 void SDL_IMMDevice_Quit(void);
 int SDL_IMMDevice_Get(LPCWSTR devid, IMMDevice **device, SDL_bool iscapture);
 void SDL_IMMDevice_EnumerateEndpoints(SDL_bool useguid);
+int SDL_IMMDevice_GetDefaultAudioInfo(char **name, SDL_AudioSpec *spec, int iscapture);
 
 SDL_AudioFormat WaveFormatToSDLFormat(WAVEFORMATEX *waveformat);
 

--- a/src/dynapi/SDL2.exports
+++ b/src/dynapi/SDL2.exports
@@ -853,3 +853,4 @@
 # ++'_SDL_GDKRunApp'.'SDL2.dll'.'SDL_GDKRunApp'
 ++'_SDL_GetOriginalMemoryFunctions'.'SDL2.dll'.'SDL_GetOriginalMemoryFunctions'
 ++'_SDL_ResetKeyboard'.'SDL2.dll'.'SDL_ResetKeyboard'
+++'_SDL_GetDefaultAudioInfo'.'SDL2.dll'.'SDL_GetDefaultAudioInfo'

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -879,3 +879,4 @@
 #define SDL_GDKRunApp SDL_GDKRunApp_REAL
 #define SDL_GetOriginalMemoryFunctions SDL_GetOriginalMemoryFunctions_REAL
 #define SDL_ResetKeyboard SDL_ResetKeyboard_REAL
+#define SDL_GetDefaultAudioInfo SDL_GetDefaultAudioInfo_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -962,3 +962,4 @@ SDL_DYNAPI_PROC(int,SDL_GDKRunApp,(SDL_main_func a, void *b),(a,b),return)
 #endif
 SDL_DYNAPI_PROC(void,SDL_GetOriginalMemoryFunctions,(SDL_malloc_func *a, SDL_calloc_func *b, SDL_realloc_func *c, SDL_free_func *d),(a,b,c,d),)
 SDL_DYNAPI_PROC(void,SDL_ResetKeyboard,(void),(),)
+SDL_DYNAPI_PROC(int,SDL_GetDefaultAudioInfo,(char **a, SDL_AudioSpec *b, int c),(a,b,c),return)


### PR DESCRIPTION
Currently this is supported on pipewire, pulseaudio, and wasapi.

~~This is flagrantly untested!~~ Also, I haven't looked at CoreAudio, but I probably won't since I'm pretty far removed from Apple stuff at this point.

Fixes #5866