### PR TITLE
joystick: Fix redetection of HIDAPI joysticks after reinitializing

### DIFF
--- a/src/joystick/hidapi/SDL_hidapijoystick.c
+++ b/src/joystick/hidapi/SDL_hidapijoystick.c
@@ -1076,6 +1076,7 @@ HIDAPI_JoystickQuit(void)
 
     SDL_hid_exit();
 
+    SDL_HIDAPI_change_count = 0;
     shutting_down = SDL_FALSE;
     initialized = SDL_FALSE;
 }


### PR DESCRIPTION
## Description
The HIDAPI joystick driver doesn't properly reset the change counter it uses to track if re-enumeration is needed when the joystick subsystem is quit and then reinitialized.

The first SDL_Init(SDL_INIT_JOYSTICK) will result in the expected HIDAPI joysticks appearing, but subsequent calls will result in no joysticks being enumerated until another HIDAPI joystick is added or removed from the system.

This issue impacted Moonlight on the Steam Link and was reported downstream as https://github.com/moonlight-stream/moonlight-qt/issues/816
