### PR TITLE
Rename folder created in test_filesystem

### DIFF
--- a/test/testfilesystem.c
+++ b/test/testfilesystem.c
@@ -37,7 +37,7 @@ main(int argc, char *argv[])
         SDL_free(base_path);
     }
 
-    pref_path = SDL_GetPrefPath("libsdl", "testfilesystem");
+    pref_path = SDL_GetPrefPath("libsdl", "test_filesystem");
     if(pref_path == NULL){
       SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't find pref path: %s\n",
                    SDL_GetError());
@@ -46,7 +46,7 @@ main(int argc, char *argv[])
         SDL_free(pref_path);
     }
 
-    pref_path = SDL_GetPrefPath(NULL, "testfilesystem");
+    pref_path = SDL_GetPrefPath(NULL, "test_filesystem");
     if(pref_path == NULL){
       SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't find pref path without organization: %s\n",
                    SDL_GetError());


### PR DESCRIPTION
## Description
The binary generated for the `testfilesystem.c` file is called `testfilesystem` (if it has no extension as the `PS2` ones).
The test checks if the `filesystem` driver works fine by creating some folders.

The thing is that the line:
```c
pref_path = SDL_GetPrefPath(NULL, "testfilesystem");
``` 
Could create a folder called `testfilesystem` in the same folder where the binary `testfilesystem` is (`PS2` and other platforms uses `cwd` as the base path), generating an error. 
It is not possible to have in the same folder a filename without an extension and a folder with the same "name"

This PR changes the name of the folder created, to assure that it won't fail for this specific error.

Cheer