### PR TITLE
Fix fallback implementations of SDL_strchr and SDL_strrchr for '\0'

### DIFF
--- a/src/stdlib/SDL_string.c
+++ b/src/stdlib/SDL_string.c
@@ -695,6 +695,9 @@ SDL_strchr(const char *string, int c)
         }
         ++string;
     }
+    if (c == '\0') {
+        return (char *) string;
+    }
     return NULL;
 #endif /* HAVE_STRCHR */
 }
@@ -707,7 +710,7 @@ SDL_strrchr(const char *string, int c)
 #elif defined(HAVE_RINDEX)
     return SDL_const_cast(char*,rindex(string, c));
 #else
-    const char *bufp = string + SDL_strlen(string) - 1;
+    const char *bufp = string + SDL_strlen(string);
     while (bufp >= string) {
         if (*bufp == c) {
             return (char *) bufp;


### PR DESCRIPTION
## Description
`strchr` and `strrchr` return a pointer to the first/last occurrence of a character in a string, or `NULL` if the character is not found. According to the C standard, the final null terminator is part of the string, and it should thus be possible to get a pointer to the final null with these functions. The fallback implementations of `SDL_strchr` and `SDL_strrchr` would always return `NULL` if trying to find `'\0'`, and this commit fixes that.