### PR TITLE
(OpenBSD) Exe Path: Use PWD instead of CWD and use CWD as fallback

### DIFF
--- a/src/filesystem/unix/SDL_sysfilesystem.c
+++ b/src/filesystem/unix/SDL_sysfilesystem.c
@@ -172,13 +172,31 @@ SDL_GetBasePath(void)
         sysctl(mib, 4, cmdline, &len, NULL, 0);
 
         exe = cmdline[0];
+        char *pwddst = NULL;
         if (SDL_strchr(exe, '/') == NULL) {  /* not a relative or absolute path, check $PATH for it */
             exe = search_path_for_binary(cmdline[0]);
+        } else {
+            if (exe && *exe == '.') {
+                const char *pwd = SDL_getenv("PWD");
+                if (pwd && *pwd) {
+                    pwddst = (char *) SDL_malloc(PATH_MAX + 1);
+                    strcpy(pwddst, pwd);
+                    strcat(pwddst, "/");
+                    strcat(pwddst, exe);
+                }
+            }
         }
 
         if (exe) {
-            if (realpath(exe, realpathbuf) != NULL) {
-                retval = realpathbuf;
+            if (pwddst == NULL) {
+                if (realpath(exe, realpathbuf) != NULL) {
+                    retval = realpathbuf;
+                }
+            } else {
+                if (realpath(pwddst, realpathbuf) != NULL) {
+                    retval = realpathbuf;
+                }
+                SDL_free(pwddst);
             }
 
             if (exe != cmdline[0]) {


### PR DESCRIPTION
Hey look! I did one commit this time instead of like 10+...

## Description

The PWD environment variable is the initial CWD when the process is first launched, and does not change after its initial state even when the CWD is changed at any point in time after process execution. The only time PWD will not be the path we want afaik is when the environment variable is changed manually by the user in their code or by the shell, which most users and software will not likely do that. This should be more accurate than the CWD.

Tested with `~/main,cpp` below:

```
#include <cstdio>
#include <unistd.h>
#include <SDL_filesystem.h>

int main() {
    chdir("/");
    printf("%s\n", SDL_GetBasePath());
    return 0;
}
```

```
git clone -b patch-1 https://github.com/time-killer-games/SDL ~/SDL
mkdir ~/build && cd ~/build && cmake -S ~/SDL -B . && make
clang++ libSDL2.a ~/main.cpp -I../SDL/include -o ~/main && ../main
```