### PR TITLE
Added include: libkern/OSAtomic.h

### DIFF
--- a/src/atomic/SDL_spinlock.c
+++ b/src/atomic/SDL_spinlock.c
@@ -44,6 +44,10 @@
 #include <kernel.h>
 #endif
 
+#if !defined(HAVE_GCC_ATOMICS) && defined(__MACOSX__)
+#include <libkern/OSAtomic.h>
+#endif
+
 #if defined(__WATCOMC__) && defined(__386__)
 SDL_COMPILE_TIME_ASSERT(locksize, 4==sizeof(SDL_SpinLock));
 extern __inline int _SDL_xchg_watcom(volatile int *a, int v);


### PR DESCRIPTION
When building on macOS without gcc (e.g. clang) where HAVE_GCC_ATOMICS
is not defined, `SDL_AtomicTryLock` will call
`OSAtomicCompareAndSwap32Barrier` which is not yet declared.
Including OSAtomic.h on OSX resolves this error/warning:

    SDL_spinlock.c:125:12: error: implicit declaration of function
      'OSAtomicCompareAndSwap32Barrier' is invalid in
      C99 [-Werror,-Wimplicit-function-declaration]
        return OSAtomicCompareAndSwap32Barrier(0, 1, lock);

This was reported in issue #3885 but marked Invalid and closed - possibly
because the default CMake build uses gcc instead of clang.
