### PR TITLE
autotools: relax soname pattern for dynamic loading

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,11 @@ AC_PROG_EGREP
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 PKG_PROG_PKG_CONFIG
+AC_PROG_AWK
+
+if test -z "$AWK"; then
+    AC_MSG_ERROR([*** Required awk tool not found!])
+fi
 
 dnl 64-bit file offsets if possible unless --disable-largefile is specified
 AC_SYS_LARGEFILE
@@ -181,7 +186,7 @@ find_lib()
         host_lib_path="/usr/$base_libdir /usr/local/$base_libdir"
     fi
     for path in $env_lib_path $gcc_bin_path $gcc_lib_path $host_lib_path; do
-        lib=[`ls -- $path/$1 2>/dev/null | sed -e '/\.so\..*\./d' -e 's,.*/,,' | sort | tail -1`]
+        lib=[`ls -- $path/$1 2>/dev/null | sed -e 's,.*/,,' | $AWK '{print length() " " $0;}' | sort -n -r | tail -1 | sed 's/^[0-9]\+ //'`]
         if test x$lib != x; then
             echo $lib
             return


### PR DESCRIPTION
## Description
SDL makes assumption that each dynamically loaded library must have
SONAME matching pattern <libname>.so.<digit>+ hence it discards any file
that has two (or more) digits after ".so". in practice however SONAME
might be in the form of ie <libname>.so.<major>.<minor>.

as a solution keep requirement for dynamically loaded files to be named
<libname>.so.* but consider all the possibilities and prefer the shortest
one.

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/libsdl-org/SDL_image/issues/289