### PR TITLE
joystick: Fix endianness issues in Xbox HIDAPI drivers

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_xbox360.c
+++ b/src/joystick/hidapi/SDL_hidapi_xbox360.c
@@ -263,16 +263,16 @@ HIDAPI_DriverXbox360_HandleStatePacket(SDL_Joystick *joystick, SDL_DriverXbox360
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_TRIGGERLEFT, axis);
     axis = ((int)data[5] * 257) - 32768;
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_TRIGGERRIGHT, axis);
-    axis = *(Sint16*)(&data[6]);
+    axis = SDL_SwapLE16(*(Sint16*)(&data[6]));
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_LEFTX, axis);
-    axis = *(Sint16*)(&data[8]);
+    axis = SDL_SwapLE16(*(Sint16*)(&data[8]));
     if (invert_y_axes) {
         axis = ~axis;
     }
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_LEFTY, axis);
-    axis = *(Sint16*)(&data[10]);
+    axis = SDL_SwapLE16(*(Sint16*)(&data[10]));
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_RIGHTX, axis);
-    axis = *(Sint16*)(&data[12]);
+    axis = SDL_SwapLE16(*(Sint16*)(&data[12]));
     if (invert_y_axes) {
         axis = ~axis;
     }

--- a/src/joystick/hidapi/SDL_hidapi_xbox360w.c
+++ b/src/joystick/hidapi/SDL_hidapi_xbox360w.c
@@ -229,16 +229,16 @@ HIDAPI_DriverXbox360W_HandleStatePacket(SDL_Joystick *joystick, SDL_hid_device *
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_TRIGGERLEFT, axis);
     axis = ((int)data[5] * 257) - 32768;
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_TRIGGERRIGHT, axis);
-    axis = *(Sint16*)(&data[6]);
+    axis = SDL_SwapLE16(*(Sint16*)(&data[6]));
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_LEFTX, axis);
-    axis = *(Sint16*)(&data[8]);
+    axis = SDL_SwapLE16(*(Sint16*)(&data[8]));
     if (invert_y_axes) {
         axis = ~axis;
     }
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_LEFTY, axis);
-    axis = *(Sint16*)(&data[10]);
+    axis = SDL_SwapLE16(*(Sint16*)(&data[10]));
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_RIGHTX, axis);
-    axis = *(Sint16*)(&data[12]);
+    axis = SDL_SwapLE16(*(Sint16*)(&data[12]));
     if (invert_y_axes) {
         axis = ~axis;
     }

--- a/src/joystick/hidapi/SDL_hidapi_xboxone.c
+++ b/src/joystick/hidapi/SDL_hidapi_xboxone.c
@@ -605,7 +605,7 @@ HIDAPI_DriverXboxOne_HandleStatePacket(SDL_Joystick *joystick, SDL_DriverXboxOne
         }
     }
 
-    axis = ((int)*(Sint16*)(&data[6]) * 64) - 32768;
+    axis = ((int)SDL_SwapLE16(*(Sint16*)(&data[6])) * 64) - 32768;
     if (axis == 32704) {
         axis = 32767;
     }
@@ -614,7 +614,7 @@ HIDAPI_DriverXboxOne_HandleStatePacket(SDL_Joystick *joystick, SDL_DriverXboxOne
     }
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_TRIGGERLEFT, axis);
 
-    axis = ((int)*(Sint16*)(&data[8]) * 64) - 32768;
+    axis = ((int)SDL_SwapLE16(*(Sint16*)(&data[8])) * 64) - 32768;
     if (axis == -32768 && size == 30 && (data[22] & 0x40) != 0) {
         axis = 32767;
     }
@@ -623,13 +623,13 @@ HIDAPI_DriverXboxOne_HandleStatePacket(SDL_Joystick *joystick, SDL_DriverXboxOne
     }
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_TRIGGERRIGHT, axis);
 
-    axis = *(Sint16*)(&data[10]);
+    axis = SDL_SwapLE16(*(Sint16*)(&data[10]));
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_LEFTX, axis);
-    axis = *(Sint16*)(&data[12]);
+    axis = SDL_SwapLE16(*(Sint16*)(&data[12]));
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_LEFTY, ~axis);
-    axis = *(Sint16*)(&data[14]);
+    axis = SDL_SwapLE16(*(Sint16*)(&data[14]));
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_RIGHTX, axis);
-    axis = *(Sint16*)(&data[16]);
+    axis = SDL_SwapLE16(*(Sint16*)(&data[16]));
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_RIGHTY, ~axis);
 
     SDL_memcpy(ctx->last_state, data, SDL_min(size, sizeof(ctx->last_state)));
@@ -826,25 +826,25 @@ HIDAPI_DriverXboxOneBluetooth_HandleStatePacket(SDL_Joystick *joystick, SDL_Driv
         SDL_PrivateJoystickButton(joystick, SDL_CONTROLLER_BUTTON_DPAD_LEFT, dpad_left);
     }
 
-    axis = ((int)*(Sint16*)(&data[9]) * 64) - 32768;
+    axis = ((int)SDL_SwapLE16(*(Sint16*)(&data[9])) * 64) - 32768;
     if (axis == 32704) {
         axis = 32767;
     }
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_TRIGGERLEFT, axis);
 
-    axis = ((int)*(Sint16*)(&data[11]) * 64) - 32768;
+    axis = ((int)SDL_SwapLE16(*(Sint16*)(&data[11])) * 64) - 32768;
     if (axis == 32704) {
         axis = 32767;
     }
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_TRIGGERRIGHT, axis);
 
-    axis = (int)*(Uint16*)(&data[1]) - 0x8000;
+    axis = (int)SDL_SwapLE16(*(Uint16*)(&data[1])) - 0x8000;
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_LEFTX, axis);
-    axis = (int)*(Uint16*)(&data[3]) - 0x8000;
+    axis = (int)SDL_SwapLE16(*(Uint16*)(&data[3])) - 0x8000;
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_LEFTY, axis);
-    axis = (int)*(Uint16*)(&data[5]) - 0x8000;
+    axis = (int)SDL_SwapLE16(*(Uint16*)(&data[5])) - 0x8000;
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_RIGHTX, axis);
-    axis = (int)*(Uint16*)(&data[7]) - 0x8000;
+    axis = (int)SDL_SwapLE16(*(Uint16*)(&data[7])) - 0x8000;
     SDL_PrivateJoystickAxis(joystick, SDL_CONTROLLER_AXIS_RIGHTY, axis);
 
     SDL_memcpy(ctx->last_state, data, SDL_min(size, sizeof(ctx->last_state)));


### PR DESCRIPTION
## Description
The Xbox 360/360W/One HIDAPI drivers don't work properly on big-endian architectures because they don't byteswap the LE 16-bit axis values they read.

Thanks to @sezero for pointing this out in #5900.