### PR TITLE
(OpenBSD) Exe Path: Use PWD instead of CWD and use CWD as fallback

### DIFF
--- a/src/filesystem/unix/SDL_sysfilesystem.c
+++ b/src/filesystem/unix/SDL_sysfilesystem.c
@@ -150,7 +150,7 @@ SDL_GetBasePath(void)
     }
 #endif
 #if defined(__OPENBSD__)
-    /* Please note that this will fail if the process was launched with a relative path and the cwd has changed, or argv is altered. So don't do that. Or add a new sysctl to OpenBSD. */
+    /* Please note that this will fail if the process was launched with a relative path and $PWD + the cwd have changed, or argv is altered. So don't do that. Or add a new sysctl to OpenBSD. */
     char **cmdline;
     size_t len;
     const int mib[] = { CTL_KERN, KERN_PROC_ARGS, getpid(), KERN_PROC_ARGV };
@@ -172,13 +172,28 @@ SDL_GetBasePath(void)
         sysctl(mib, 4, cmdline, &len, NULL, 0);
 
         exe = cmdline[0];
+        char *pwddst = NULL;
         if (SDL_strchr(exe, '/') == NULL) {  /* not a relative or absolute path, check $PATH for it */
             exe = search_path_for_binary(cmdline[0]);
+        } else {
+            if (exe && *exe == '.') {
+                const char *pwd = SDL_getenv("PWD");
+                if (pwd && *pwd) {
+                    SDL_asprintf(&pwddst, "%s/%s", pwd, exe); 
+                }
+            }
         }
 
         if (exe) {
-            if (realpath(exe, realpathbuf) != NULL) {
-                retval = realpathbuf;
+            if (pwddst == NULL) {
+                if (realpath(exe, realpathbuf) != NULL) {
+                    retval = realpathbuf;
+                }
+            } else {
+                if (realpath(pwddst, realpathbuf) != NULL) {
+                    retval = realpathbuf;
+                }
+                SDL_free(pwddst);
             }
 
             if (exe != cmdline[0]) {


### PR DESCRIPTION
## Description

The PWD environment variable is the initial CWD when the process is first launched, and does not change after its initial state even when the CWD is changed at any point in time after process execution. The only time PWD will not be the path we want afaik is when the environment variable is changed manually by the user in their code or by the shell, which most users and software will not likely do that. This should be more accurate than the CWD.

Tested with `~/main.cpp` below:

```
#include <cstdio>
#include <unistd.h>
#include <SDL_filesystem.h>
#include <SDL_stdinc.h>

char *data_path = nullptr;

void InitializeDataPath() {
    char *base_path = SDL_GetBasePath();
    if (base_path) {
        /* works if argv[0] is a relative path and 
        $PWD is correctly set, exe found in $PATH,
        or argv[0] is an absolute exe pathname. */
        data_path = base_path;
    } else {
        /* fallback as specified by the wiki
        we shouldn't do this for the user */
        data_path = SDL_strdup("./");
    }
}

void test() {
    InitializeDataPath();
    printf("%s\n", data_path);
    SDL_free(data_path);
    data_path = nullptr;
}

int main() {
    test(); // if relative argv[0], PWD works, CWD works
    chdir("/"); // test CWD instead of PWD by 'env PWD='
    test(); // if relative argv[0], PWD works, CWD fails
    return 0;
}
```

```
#!/bin/sh
git clone -b openbsd-pwdfix-for-exepath https://github.com/time-killer-games/SDL ~/SDL
mkdir ~/build && cd ~/build && cmake -S ~/SDL -B . && make
clang++ libSDL2.a ~/main.cpp -I../SDL/include -o ~/main
cd  ~/ && echo "test #1" &&  ./main && echo "test #2" && env PWD= ./main
```