### PR TITLE
Differentiate between Windows Ink (pen) and regular touch input

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -99,6 +99,9 @@
 #ifndef WM_GETDPISCALEDSIZE
 #define WM_GETDPISCALEDSIZE 0x02E4
 #endif
+#ifndef TOUCHEVENTF_PEN
+#define TOUCHEVENTF_PEN 0x0040
+#endif
 
 #ifndef IS_HIGH_SURROGATE
 #define IS_HIGH_SURROGATE(x)   (((x) >= 0xd800) && ((x) <= 0xdbff))

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1338,7 +1338,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
                     /* TODO: Can we use GetRawInputDeviceInfo and HID info to
                        determine if this is a direct or indirect touch device?
                      */
-                    if (SDL_AddTouch(touchId, SDL_TOUCH_DEVICE_DIRECT, "") < 0) {
+                    if (SDL_AddTouch(touchId, SDL_TOUCH_DEVICE_DIRECT, (input->dwFlags & TOUCHEVENTF_PEN) == TOUCHEVENTF_PEN ? "pen" : "touch") < 0) {
                         continue;
                     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allows consumers to differentiate pen from touch input.

Windows will send `WM_TOUCH` messages for both regular touch input, and for pen/tablet PC/Windows Ink input.
Pen events will have the `TOUCHEVENTF_PEN` flag is set in [`TOUCHINPUT.dwFlags`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-touchinput#remarks).

Consumers can use `SDL_GetTouchName` to get the device type (`"pen"` or `"touch"`) for a `SDL_TouchFingerEvent`:
```c
SDL_Event event; // from event loop
int index = -1;

for (int i = 0; i < SDL_GetNumTouchDevices(); i++) {
    if (event.tfinger.touchId == SDL_GetTouchDevice(i)) {
        index = i;
        break;
    }
}

if (SDL_strncmp(SDL_GetTouchName(index), "pen", 3) == 0) {
    // pen/tablet handling
} else {
    // touchscreen handling
}
```

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
- https://github.com/ppy/osu/issues/19150

## Testing
I've tested this on a Windows Ink compatible drawing tablet. Not tested on a touchscreen, but I have faith in the flags set by windows.

## Wiki
If this goes trough, I will add the above code and a short description to https://wiki.libsdl.org/SDL_TouchFingerEvent/