### PR TITLE
video: wayland: Resize the window before sending the SDL_RESIZE event (Fix #5899)

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -1964,8 +1964,16 @@ Wayland_HandleResize(SDL_Window *window, int width, int height, float scale)
 {
     SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
     SDL_VideoData *viddata = data->waylandData;
+    int old_w = window->w, old_h = window->h;
+    float old_scale = scale;
 
-    if (data->needs_resize_event || window->w != width || window->h != height || !FloatEqual(data->scale_factor, scale)) {
+    /* Update the window geometry. */
+    window->w = width;
+    window->h = height;
+    data->scale_factor = scale;
+    ConfigureWindowGeometry(window);
+
+    if (data->needs_resize_event || old_w != width || old_h != height || !FloatEqual(data->scale_factor, old_scale)) {
         /* We may have already updated window w/h (or only adjusted scale factor),
          * so we must override the deduplication logic in the video core */
         window->w = 0;
@@ -1973,12 +1981,8 @@ Wayland_HandleResize(SDL_Window *window, int width, int height, float scale)
         SDL_SendWindowEvent(window, SDL_WINDOWEVENT_RESIZED, width, height);
         window->w = width;
         window->h = height;
-        data->scale_factor = scale;
         data->needs_resize_event = SDL_FALSE;
     }
-
-    /* Update the window geometry. */
-    ConfigureWindowGeometry(window);
 
     /* XXX: This workarounds issues with commiting buffers with old size after
      * already acknowledging the new size, which can cause protocol violations.


### PR DESCRIPTION
Currently, the ``SDL_WINDOWEVENT_RESIZED`` event is sent before the actual window is resized (and various internal state, such as the desired GL/Vulkan backbuffer size, are updated). This makes sense, as SDL will discard a no-op resize, which would be the case if we had resized before sending the event (indeed, there are existing hacks to prevent this).

However, this means that ``SDL_{GL,Vulkan}_GetDrawableSize()`` will still use the old size in the ``SDL_WINDOWEVENT_RESIZED`` handler. In the case of ``SDL_Renderer``, this means the drawable size it uses will be wrong, and the viewport will get "updated" to the old value.

This then results in bug #5899.
