### PR TITLE
video: wayland: Don't switch to libdecor path for borderless windows

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -730,6 +730,10 @@ handle_configure_zxdg_decoration(void *data,
      * To do this we have to fully unmap, then map with libdecor loaded.
      */
     if (mode == ZXDG_TOPLEVEL_DECORATION_V1_MODE_CLIENT_SIDE) {
+        if (window->flags & SDL_WINDOW_BORDERLESS) {
+            /* borderless windows do request CSD, so we got what we wanted */
+            return;
+        }
         if (!Wayland_LoadLibdecor(driverdata->waylandData, SDL_TRUE)) {
             /* libdecor isn't available, so no borders for you... oh well */
             return;


### PR DESCRIPTION
We actually request CSD mode with xdg-decoration for borderless
windows, so we get what we wanted there and there's no point in going
into fallback paths.