### PR TITLE
video: wayland: Roundtrip after falling back to libdecor in xdg-decoration handler

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -734,6 +734,7 @@ handle_configure_zxdg_decoration(void *data,
             /* libdecor isn't available, so no borders for you... oh well */
             return;
         }
+        WAYLAND_wl_display_roundtrip(driverdata->waylandData->display);
         SDL_HideWindow(window);
         driverdata->shell_surface_type = WAYLAND_SURFACE_LIBDECOR;
         SDL_ShowWindow(window);


### PR DESCRIPTION
Otherwise libdecor doesn't have a chance to acquire xdg-toplevel after
libdecor_new before we attempt to use it in Wayland_ShowWindow.

Fixes #5952