### PR TITLE
Event loop fixes

### DIFF
--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -903,13 +903,12 @@ SDL_events_need_periodic_poll() {
 
 #if !SDL_JOYSTICK_DISABLED
     need_periodic_poll =
-        SDL_WasInit(SDL_INIT_JOYSTICK) &&
-        (!SDL_disabled_events[SDL_JOYAXISMOTION >> 8] || SDL_JoystickEventState(SDL_QUERY));
+        SDL_WasInit(SDL_INIT_JOYSTICK) && SDL_update_joysticks;
 #endif
 
 #if !SDL_SENSOR_DISABLED
     need_periodic_poll = need_periodic_poll ||
-        (SDL_WasInit(SDL_INIT_SENSOR) && !SDL_disabled_events[SDL_SENSORUPDATE >> 8]);
+        (SDL_WasInit(SDL_INIT_SENSOR) && SDL_update_sensors);
 #endif
 
     return need_periodic_poll;
@@ -994,13 +993,13 @@ SDL_events_need_polling() {
 #if !SDL_JOYSTICK_DISABLED
     need_polling =
         SDL_WasInit(SDL_INIT_JOYSTICK) &&
-        (!SDL_disabled_events[SDL_JOYAXISMOTION >> 8] || SDL_JoystickEventState(SDL_QUERY)) &&
+        SDL_update_joysticks &&
         (SDL_NumJoysticks() > 0);
 #endif
 
 #if !SDL_SENSOR_DISABLED
     need_polling = need_polling ||
-        (SDL_WasInit(SDL_INIT_SENSOR) && !SDL_disabled_events[SDL_SENSORUPDATE >> 8] && (SDL_NumSensors() > 0));
+        (SDL_WasInit(SDL_INIT_SENSOR) && SDL_update_sensors && (SDL_NumSensors() > 0));
 #endif
 
     return need_polling;

--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -102,9 +102,9 @@ static struct
 static SDL_bool SDL_update_joysticks = SDL_TRUE;
 
 static void
-SDL_CalculateShouldUpdateJoysticks()
+SDL_CalculateShouldUpdateJoysticks(SDL_bool hint_value)
 {
-    if (SDL_GetHintBoolean(SDL_HINT_AUTO_UPDATE_JOYSTICKS, SDL_TRUE) &&
+    if (hint_value &&
         (!SDL_disabled_events[SDL_JOYAXISMOTION >> 8] || SDL_JoystickEventState(SDL_QUERY))) {
         SDL_update_joysticks = SDL_TRUE;
     } else {
@@ -115,7 +115,7 @@ SDL_CalculateShouldUpdateJoysticks()
 static void SDLCALL
 SDL_AutoUpdateJoysticksChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
 {
-    SDL_CalculateShouldUpdateJoysticks();
+    SDL_CalculateShouldUpdateJoysticks(SDL_GetStringBoolean(hint, SDL_TRUE));
 }
 
 #endif /* !SDL_JOYSTICK_DISABLED */
@@ -126,9 +126,9 @@ SDL_AutoUpdateJoysticksChanged(void *userdata, const char *name, const char *old
 static SDL_bool SDL_update_sensors = SDL_TRUE;
 
 static void
-SDL_CalculateShouldUpdateSensors()
+SDL_CalculateShouldUpdateSensors(SDL_bool hint_value)
 {
-    if (SDL_GetHintBoolean(SDL_HINT_AUTO_UPDATE_SENSORS, SDL_TRUE) &&
+    if (hint_value &&
         !SDL_disabled_events[SDL_SENSORUPDATE >> 8]) {
         SDL_update_sensors = SDL_TRUE;
     } else {
@@ -139,7 +139,7 @@ SDL_CalculateShouldUpdateSensors()
 static void SDLCALL
 SDL_AutoUpdateSensorsChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
 {
-    SDL_CalculateShouldUpdateSensors();
+    SDL_CalculateShouldUpdateSensors(SDL_GetStringBoolean(hint, SDL_TRUE));
 }
 
 #endif /* !SDL_SENSOR_DISABLED */
@@ -1306,10 +1306,10 @@ SDL_EventState(Uint32 type, int state)
         }
 
 #if !SDL_JOYSTICK_DISABLED
-        SDL_CalculateShouldUpdateJoysticks();
+        SDL_CalculateShouldUpdateJoysticks(SDL_GetHintBoolean(SDL_HINT_AUTO_UPDATE_JOYSTICKS, SDL_TRUE));
 #endif
 #if !SDL_SENSOR_DISABLED
-        SDL_CalculateShouldUpdateSensors();
+        SDL_CalculateShouldUpdateSensors(SDL_GetHintBoolean(SDL_HINT_AUTO_UPDATE_SENSORS, SDL_TRUE));
 #endif
     }
 


### PR DESCRIPTION
Improves the behavior of `SDL_HINT_AUTO_UPDATE_JOYSTICKS` and `SDL_HINT_AUTO_UPDATE_SENSORS` to properly respond to changes and allow for them to control if the event loop is forced into a polling mode or not.

## Description
`SDL_HINT_AUTO_UPDATE_JOYSTICKS` and `SDL_HINT_AUTO_UPDATE_SENSORS` are supposed to help control the values of `SDL_update_joysticks` and `SDL_update_sensors` respectively, but due to an order of operations issue changing just a hint value was not enough to change the update variables. This change fixes that bug.

Additionally, the values of `SDL_update_joysticks` and `SDL_update_sensors` are used to determine if `SDL_JoystickUpdate()` and `SDL_SensorUpdate()` should be called by the event loop. In order to call these functions, the event loop will use a less efficient polling mode in which it looks for events for a brief period of time, pumps these sub systems then sleeps for a millisecond. Without this change, if an application decides to pump the sub systems manually, the event loop thread will still poll instead of properly going to sleep until an event comes in. With this change, an application can have the event loop thread sleep until events arrive and have joystick/sensor support as long as they manually pump the subsystems, leading to better performance and less cycles wasted.