### PR TITLE
Fix Main Thread Checker warning on macOS

### DIFF
--- a/src/video/cocoa/SDL_cocoaevents.m
+++ b/src/video/cocoa/SDL_cocoaevents.m
@@ -549,13 +549,11 @@ Cocoa_PumpEvents(_THIS)
 void Cocoa_SendWakeupEvent(_THIS, SDL_Window *window)
 { @autoreleasepool
 {
-    NSWindow *nswindow = ((__bridge SDL_WindowData *) window->driverdata).nswindow;
-
     NSEvent* event = [NSEvent otherEventWithType: NSEventTypeApplicationDefined
                                     location: NSMakePoint(0,0)
                                modifierFlags: 0
                                    timestamp: 0.0
-                                windowNumber: nswindow.windowNumber
+                                windowNumber: ((__bridge SDL_WindowData *) window->driverdata).window_number
                                      context: nil
                                      subtype: 0
                                        data1: 0

--- a/src/video/cocoa/SDL_cocoawindow.h
+++ b/src/video/cocoa/SDL_cocoawindow.h
@@ -126,6 +126,7 @@ typedef enum
     @property (nonatomic) NSMutableArray *nscontexts;
     @property (nonatomic) SDL_bool created;
     @property (nonatomic) SDL_bool inWindowFullscreenTransition;
+    @property (nonatomic) NSInteger window_number;
     @property (nonatomic) NSInteger flash_request;
     @property (nonatomic) Cocoa_WindowListener *listener;
     @property (nonatomic) SDL_VideoData *videodata;

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -1615,6 +1615,7 @@ SetupWindowData(_THIS, SDL_Window * window, NSWindow *nswindow, NSView *nsview, 
     data.nswindow = nswindow;
     data.created = created;
     data.videodata = videodata;
+    data.window_number = nswindow.windowNumber;
     data.nscontexts = [[NSMutableArray alloc] init];
     data.sdlContentView = nsview;
 


### PR DESCRIPTION
Cache off NSWindow's windowNumber in SDL_WindowData on setup and use that in `Cocoa_SendWakeupEvent` to prevent accessing windowNumber off the main thread.

## Description
Documentation seems to imply that the windowNumber value is unique per window, which implies to me that it won't change over the lifetime of the window, so caching it on create should be safe.

## Existing Issue(s)
#5796
