### PR TITLE
CI: Fix CMake workflow.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         - { name: Windows (mingw64+clang),  os: windows-latest, shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64, cc: clang }
         - { name: Linux (CMake),            os: ubuntu-20.04,   shell: sh }
         - { name: Linux (autotools),        os: ubuntu-20.04,   shell: sh,    autotools: true }
-        - { name: MacOS (CMake),            os: macos-latest,   shell: sh }
+        - { name: MacOS (CMake),            os: macos-latest,   shell: sh,    cmake: '-DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"' }
         - { name: MacOS (autotools),        os: macos-latest,   shell: sh,    autotools: true }
 
     steps:
@@ -109,7 +109,7 @@ jobs:
         -DSDL_INSTALL_TESTS=ON \
         -DCMAKE_INSTALL_PREFIX=cmake_prefix \
         -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64
+        ${{ matrix.platform.cmake }}
     - name: Build (CMake)
       if: "! matrix.platform.autotools"
       run: |


### PR DESCRIPTION
## Description

- Add quotes around the CMAKE_OSX_ARCHITECTURES list (reason why CI currently fails).
- Extract the flag to the platform matrix.

## Existing Issue

Follow-up to #5578 