### PR TITLE
Use the System C library when building/using a static SDL2, on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3096,6 +3096,7 @@ if(SDL_STATIC)
     set_target_properties(SDL2-static PROPERTIES OUTPUT_NAME "SDL2")
   endif()
   set_target_properties(SDL2-static PROPERTIES POSITION_INDEPENDENT_CODE "${SDL_STATIC_PIC}")
+  target_compile_definitions(SDL2-static PRIVATE SDL_STATIC_LIB)
   # TODO: Win32 platforms keep the same suffix .lib for import and static
   # libraries - do we need to consider this?
   target_link_libraries(SDL2-static PRIVATE ${EXTRA_LIBS} ${EXTRA_LDFLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3096,12 +3096,6 @@ if(SDL_STATIC)
     set_target_properties(SDL2-static PROPERTIES OUTPUT_NAME "SDL2")
   endif()
   set_target_properties(SDL2-static PROPERTIES POSITION_INDEPENDENT_CODE "${SDL_STATIC_PIC}")
-  # Note: The clang toolset for Visual Studio does not support /NODEFAULTLIB.
-  if(MSVC AND NOT SDL_LIBC AND NOT MSVC_CLANG AND NOT CMAKE_GENERATOR_PLATFORM STREQUAL "ARM")
-    set_target_properties(SDL2-static PROPERTIES LINK_FLAGS_RELEASE "/NODEFAULTLIB")
-    set_target_properties(SDL2-static PROPERTIES LINK_FLAGS_DEBUG "/NODEFAULTLIB")
-    set_target_properties(SDL2-static PROPERTIES STATIC_LIBRARY_FLAGS "/NODEFAULTLIB")
-  endif()
   # TODO: Win32 platforms keep the same suffix .lib for import and static
   # libraries - do we need to consider this?
   target_link_libraries(SDL2-static PRIVATE ${EXTRA_LIBS} ${EXTRA_LDFLAGS})

--- a/include/SDL_config.h.cmake
+++ b/include/SDL_config.h.cmake
@@ -64,6 +64,7 @@
 #cmakedefine HAVE_MEMORY_H 1
 #cmakedefine HAVE_SIGNAL_H 1
 #cmakedefine HAVE_STDARG_H 1
+#cmakedefine HAVE_STDDEF_H 1
 #cmakedefine HAVE_STDINT_H 1
 #cmakedefine HAVE_STDIO_H 1
 #cmakedefine HAVE_STDLIB_H 1

--- a/src/stdlib/SDL_mslibc.c
+++ b/src/stdlib/SDL_mslibc.c
@@ -27,7 +27,8 @@
 
 /* This file contains SDL replacements for functions in the C library */
 
-#ifndef HAVE_LIBC
+#if !defined(HAVE_LIBC) && !defined(SDL_STATIC_LIB)
+
 /* These are some C runtime intrinsics that need to be defined */
 
 #if defined(_MSC_VER)
@@ -712,6 +713,6 @@ RETZERO:
 
 #endif /* MSC_VER */
 
-#endif /* !HAVE_LIBC */
+#endif /* !HAVE_LIBC && !SDL_STATIC_LIB */
 
 /* vi: set ts=4 sw=4 expandtab: */


### PR DESCRIPTION
Fixes https://github.com/libsdl-org/SDL/issues/5156
Fixes https://github.com/libsdl-org/SDL/issues/1685

https://github.com/libsdl-org/SDL/issues/5156#issuecomment-1195884090 explains it all:

- ~Group all functions, normally part of the C library, and possibly emitted by the compiler into a dedicated source and disable LTO on that.~ => moved to #5974
- Always use the system C library when using the static SDL2 library.