### PR TITLE
Check for presence of M_PI macro in math.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -925,7 +925,7 @@ if(SDL_LIBC)
       set(HAVE_${_UPPER} 1)
     endforeach()
     set(HAVE_ALLOCA 1)
-    set(HAVE_M_PI 1)
+    check_symbol_exists(M_PI math.h HAVE_M_PI)
     target_compile_definitions(sdl-build-options INTERFACE "-D_USE_MATH_DEFINES") # needed for M_PI
     set(STDC_HEADERS 1)
   else()


### PR DESCRIPTION
This fixes the following error when building with `SDL_LIBC` enabled:
SDL\test\testautomation_math.c(1965): error C2065: 'M_PI': undeclared identifier

Part of #5969, but committed separately
