### PR TITLE
Compatible with including as <SDL2/SDL.h>

### DIFF
--- a/sdl2.pc.in
+++ b/sdl2.pc.in
@@ -11,4 +11,4 @@ Version: @SDL_VERSION@
 Requires:
 Conflicts:
 Libs: -L${libdir} @SDL_RLD_FLAGS@ @SDL_LIBS@ @PKGCONFIG_LIBS_PRIV@ @SDL_STATIC_LIBS@
-Cflags: -I${includedir}/SDL2 @SDL_CFLAGS@
+Cflags: -I${includedir} -I${includedir}/SDL2 @SDL_CFLAGS@


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

There are a lot of programs that use `SDL2` by explicitly including <SDL2/SDL.h>. On most platforms, this may not be the problem, as `${includedir}` should has already been included by the compiler somewhere, e.g. `/usr/include` or `/usr/local/include`. But on the new M1 macOS, `/opt/homebrew/include` has not been(at least for now) such a standard directory to include by compiler or environment.

I think we can support including SDL2 by `<SDL2/SDL.h>`.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
