### PR TITLE
keyboard: Fix default keymap inconsistency and remove no-op SDL_SetKeymap() calls

### DIFF
--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -560,11 +560,9 @@ SDL_UCS4ToUTF8(Uint32 ch, char *dst)
 int
 SDL_KeyboardInit(void)
 {
-    SDL_Keyboard *keyboard = &SDL_keyboard;
-
     /* Set the default keymap */
-    SDL_memcpy(keyboard->keymap, SDL_default_keymap, sizeof(SDL_default_keymap));
-    return (0);
+    SDL_SetKeymap(0, SDL_default_keymap, SDL_NUM_SCANCODES, SDL_FALSE);
+    return 0;
 }
 
 void
@@ -590,7 +588,7 @@ SDL_GetDefaultKeymap(SDL_Keycode * keymap)
 }
 
 void
-SDL_SetKeymap(int start, SDL_Keycode * keys, int length, SDL_bool send_event)
+SDL_SetKeymap(int start, const SDL_Keycode * keys, int length, SDL_bool send_event)
 {
     SDL_Keyboard *keyboard = &SDL_keyboard;
     SDL_Scancode scancode;

--- a/src/events/SDL_keyboard_c.h
+++ b/src/events/SDL_keyboard_c.h
@@ -33,7 +33,7 @@ extern int SDL_KeyboardInit(void);
 extern void SDL_GetDefaultKeymap(SDL_Keycode * keymap);
 
 /* Set the mapping of scancode to key codes */
-extern void SDL_SetKeymap(int start, SDL_Keycode * keys, int length, SDL_bool send_event);
+extern void SDL_SetKeymap(int start, const SDL_Keycode * keys, int length, SDL_bool send_event);
 
 /* Set a platform-dependent key name, overriding the default platform-agnostic
    name. Encoded as UTF-8. The string is not copied, thus the pointer given to

--- a/src/video/android/SDL_androidkeyboard.c
+++ b/src/video/android/SDL_androidkeyboard.c
@@ -30,15 +30,6 @@
 
 #include "../../core/android/SDL_android.h"
 
-void Android_InitKeyboard(void)
-{
-    SDL_Keycode keymap[SDL_NUM_SCANCODES];
-
-    /* Add default scancode to key mapping */
-    SDL_GetDefaultKeymap(keymap);
-    SDL_SetKeymap(0, keymap, SDL_NUM_SCANCODES, SDL_FALSE);
-}
-
 static SDL_Scancode Android_Keycodes[] = {
     SDL_SCANCODE_UNKNOWN, /* AKEYCODE_UNKNOWN */
     SDL_SCANCODE_SOFTLEFT, /* AKEYCODE_SOFT_LEFT */

--- a/src/video/android/SDL_androidkeyboard.h
+++ b/src/video/android/SDL_androidkeyboard.h
@@ -22,7 +22,6 @@
 
 #include "SDL_androidvideo.h"
 
-extern void Android_InitKeyboard(void);
 extern int Android_OnKeyDown(int keycode);
 extern int Android_OnKeyUp(int keycode);
 

--- a/src/video/android/SDL_androidvideo.c
+++ b/src/video/android/SDL_androidvideo.c
@@ -201,8 +201,6 @@ Android_VideoInit(_THIS)
 
     SDL_AddDisplayMode(&_this->displays[0], &mode);
 
-    Android_InitKeyboard();
-
     Android_InitTouch();
 
     Android_InitMouse();

--- a/src/video/directfb/SDL_DirectFB_events.c
+++ b/src/video/directfb/SDL_DirectFB_events.c
@@ -661,7 +661,6 @@ EnumKeyboards(DFBInputDeviceID device_id,
 #if USE_MULTI_API
     SDL_Keyboard keyboard;
 #endif
-    SDL_Keycode keymap[SDL_NUM_SCANCODES];
 
     if (!cb->sys_kbd) {
         if (cb->sys_ids) {
@@ -696,12 +695,6 @@ EnumKeyboards(DFBInputDeviceID device_id,
 
         SDL_DFB_LOG("Keyboard %d - %s\n", device_id, desc.name);
 
-        SDL_GetDefaultKeymap(keymap);
-#if USE_MULTI_API
-        SDL_SetKeymap(devdata->num_keyboard, 0, keymap, SDL_NUM_SCANCODES, SDL_FALSE);
-#else
-        SDL_SetKeymap(0, keymap, SDL_NUM_SCANCODES, SDL_FALSE);
-#endif
         devdata->num_keyboard++;
 
         if (cb->sys_kbd)


### PR DESCRIPTION
## Description
During my work on #5984, I discovered that there is a subtle mapping inconsistency created by the [AZERTY fixup](https://github.com/libsdl-org/SDL/blob/8b438f7b51013a6494f385e26dd061e050a65f68/src/events/SDL_keyboard.c#L605-L612) that `SDL_SetKeymap()` performs. Since `SDL_KeyboardInit()` copies the default keymap directly, that fixup doesn't happen for video backends that never call `SDL_SetKeymap()` (even if they just pass the default keymap). Fixing that allows us to eliminate redundant calls to `SDL_SetKeymap()` that pass the unmodified default keymap.

I'm not sure if the AZERTY thing is necessarily a good idea (see comment thread in #5127), but if we're going to do it, we should probably at least do it consistently.