### PR TITLE
Vulkan does not contain a internal id -> string vendor translation

### DIFF
--- a/include/SDL_vulkan.h
+++ b/include/SDL_vulkan.h
@@ -162,6 +162,18 @@ extern DECLSPEC SDL_bool SDLCALL SDL_Vulkan_GetInstanceExtensions(SDL_Window *wi
                                                                   const char **pNames);
 
 /**
+ * Get the device driver's string representation.
+ *
+ * \param id The id of the device
+ * \returns the device's name
+ *
+ * \since This function is available since SDL 2.0.23.
+ *
+ * \sa SDL_Vulkan_GetDriverVendorString
+ */
+extern DECLSPEC const char *SDLCALL SDL_Vulkan_GetDriverVendorString(uint32_t id);
+
+/**
  * Create a Vulkan rendering surface for a window.
  *
  * The `window` must have been created with the `SDL_WINDOW_VULKAN` flag and

--- a/include/SDL_vulkan.h
+++ b/include/SDL_vulkan.h
@@ -162,10 +162,10 @@ extern DECLSPEC SDL_bool SDLCALL SDL_Vulkan_GetInstanceExtensions(SDL_Window *wi
                                                                   const char **pNames);
 
 /**
- * Get the device driver's string representation.
+ * Translates the VkPhysicalDevice's "vendorID" (for example, a PCI vendor ID) to a human-readable string.
  *
- * \param id The id of the device
- * \returns the device's name
+ * \param id The vendorID field of VkPhysicalDeviceProperties
+ * \returns The vendor's human-readable name
  *
  * \since This function is available since SDL 2.0.23.
  *

--- a/src/video/SDL_vulkan_utils.c
+++ b/src/video/SDL_vulkan_utils.c
@@ -117,6 +117,42 @@ const char *SDL_Vulkan_GetResultString(VkResult result)
     return "VK_<Unknown>";
 }
 
+const char *SDL_Vulkan_GetDriverVendorString(uint32_t id)
+{
+    switch (id) {
+        case 0x1002:
+            return "AMD";
+        case 0x1010:
+            return "ImgTec";
+        case 0x106B:
+            return "Apple";
+        case 0x10DE:
+            return "NVIDIA";
+        case 0x13B5:
+            return "ARM";
+        case 0x14E4:
+            return "Broadcom";
+        case 0x5143:
+            return "Qualcomm";
+        case 0x8086:
+            return "Intel";
+        case 0x10001:
+            return "VIV";
+        case 0x10002:
+            return "VSI";
+        case 0x10003:
+            return "Kazan";
+        case 0x10004:
+            return "Codeplay";
+        case 0x10005:
+            return "Mesa";
+        case 0x10006:
+            return "POCL";
+        default:
+            return "UNKNOWN";
+    }
+}
+
 VkExtensionProperties *SDL_Vulkan_CreateInstanceExtensionsList(
     PFN_vkEnumerateInstanceExtensionProperties vkEnumerateInstanceExtensionProperties,
     Uint32 *extensionCount)


### PR DESCRIPTION
 so every app has their own "database", proposing a public helper.