### PR TITLE
renderer: Don't reset viewport on window move

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -738,7 +738,7 @@ SDL_RendererEventWatch(void *userdata, SDL_Event *event)
                     SDL_bool flush_viewport_cmd = SDL_TRUE;
 #endif
                     UpdateLogicalSize(renderer, flush_viewport_cmd);
-                } else {
+                } else if (event->window.event != SDL_WINDOWEVENT_MOVED) {
                     /* Window was resized, reset viewport */
                     int w, h;
 


### PR DESCRIPTION
Stop resetting the viewport on window move

Fixes #5949
