### PR TITLE
Fix memory leak of children for combined JoyCon

### DIFF
--- a/src/joystick/hidapi/SDL_hidapijoystick.c
+++ b/src/joystick/hidapi/SDL_hidapijoystick.c
@@ -706,6 +706,7 @@ HIDAPI_DelDevice(SDL_HIDAPI_Device *device)
             SDL_free(device->serial);
             SDL_free(device->name);
             SDL_free(device->path);
+            SDL_free(device->children);
             SDL_free(device);
             return;
         }
@@ -761,6 +762,9 @@ HIDAPI_CreateCombinedJoyCons()
             if (combined && combined->driver) {
                 return SDL_TRUE;
             } else {
+                if (!combined) {
+                    SDL_free(children);
+                }
                 return SDL_FALSE;
             }
         }


### PR DESCRIPTION
## Description

`device->children` is never freed.
In `HIDAPI_CreateCombinedJoyCons()`, `children` need to be freed in case of error.

## Existing Issue(s)
None
