### PR TITLE
Do not pass NULL to memcpy

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_switch.c
+++ b/src/joystick/hidapi/SDL_hidapi_switch.c
@@ -493,7 +493,9 @@ static void ConstructSubcommand(SDL_DriverSwitch_Context *ctx, ESwitchSubcommand
     SDL_memcpy(outPacket->commonData.rumbleData, ctx->m_RumblePacket.rumbleData, sizeof(ctx->m_RumblePacket.rumbleData));
 
     outPacket->ucSubcommandID = ucCommandID;
-    SDL_memcpy(outPacket->rgucSubcommandData, pBuf, ucLen);
+    if (pBuf) {
+        SDL_memcpy(outPacket->rgucSubcommandData, pBuf, ucLen);
+    }
 
     ctx->m_nCommandNumber = (ctx->m_nCommandNumber + 1) & 0xF;
 }


### PR DESCRIPTION
## Description

ReadJoyConControllerType calls WriteSubcommandSync with pbuf=NULL.

Full callstack:
line 1027 in: ReadJoyConControllerType(SDL_HIDAPI_Device *device)
line 1041 calling: WriteSubcommandSync(ctx, k_eSwitchSubcommandIDs_RequestDeviceInfo, NULL, 0, &reply); // 3rd parameter 'pBuf' is NULL
line 568  calling: ConstructSubcommand(ctx, ucCommandID, pBuf, ucLen, &commandPacket); // 'pBuf' is NULL
line 496: SDL_memcpy(outPacket->rgucSubcommandData, pBuf, ucLen); // 'pBuf' is NULL

## Existing Issue(s)
None
