### PR TITLE
Fix use after free when removing Windows audio device

### DIFF
--- a/src/audio/wasapi/SDL_wasapi_winrt.cpp
+++ b/src/audio/wasapi/SDL_wasapi_winrt.cpp
@@ -396,8 +396,9 @@ WASAPI_RemoveDevice(const SDL_bool iscapture, LPCWSTR devid)
             SDL_RemoveAudioDevice(iscapture, i->str);
             SDL_free(i->str);
             SDL_free(i);
+        } else {
+            prev = i;
         }
-        prev = i;
     }
 }
 

--- a/src/core/windows/SDL_immdevice.c
+++ b/src/core/windows/SDL_immdevice.c
@@ -108,8 +108,9 @@ SDL_IMMDevice_Remove(const SDL_bool iscapture, LPCWSTR devid, SDL_bool useguid)
             SDL_RemoveAudioDevice(iscapture, useguid ? ((void *) i->guid) : ((void *) i->str));
             SDL_free(i->str);
             SDL_free(i);
+        } else {
+            prev = i;
         }
-        prev = i;
     }
 }
 


### PR DESCRIPTION
## Description
I am not sure if `devid` is unique so I made this patch.
If they are unique, you could return after finding the right device, instead of using this patch.

## Existing Issue(s)
None
