### PR TITLE
[UIKit] handle app lifecycle events in a custom object instead of AppDelegate

### DIFF
--- a/src/video/uikit/SDL_uikitappdelegate.m
+++ b/src/video/uikit/SDL_uikitappdelegate.m
@@ -434,43 +434,6 @@ SDL_LoadLaunchImageNamed(NSString *name, int screenh)
     /* Do nothing. */
 }
 
-#if !TARGET_OS_TV
-- (void)application:(UIApplication *)application didChangeStatusBarOrientation:(UIInterfaceOrientation)oldStatusBarOrientation
-{
-    SDL_OnApplicationDidChangeStatusBarOrientation();
-}
-#endif
-
-- (void)applicationWillTerminate:(UIApplication *)application
-{
-    SDL_OnApplicationWillTerminate();
-}
-
-- (void)applicationDidReceiveMemoryWarning:(UIApplication *)application
-{
-    SDL_OnApplicationDidReceiveMemoryWarning();
-}
-
-- (void)applicationWillResignActive:(UIApplication*)application
-{
-    SDL_OnApplicationWillResignActive();
-}
-
-- (void)applicationDidEnterBackground:(UIApplication*)application
-{
-    SDL_OnApplicationDidEnterBackground();
-}
-
-- (void)applicationWillEnterForeground:(UIApplication*)application
-{
-    SDL_OnApplicationWillEnterForeground();
-}
-
-- (void)applicationDidBecomeActive:(UIApplication*)application
-{
-    SDL_OnApplicationDidBecomeActive();
-}
-
 - (void)sendDropFileForURL:(NSURL *)url
 {
     NSURL *fileURL = url.filePathURL;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removes the need to call SDL counterparts manually when custom AppDelegate is used in the app.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
