### PR TITLE
[PS2] Render Driver - Fix Streaming Textures

### DIFF
--- a/src/render/ps2/SDL_render_ps2.c
+++ b/src/render/ps2/SDL_render_ps2.c
@@ -158,6 +158,15 @@ PS2_LockTexture(SDL_Renderer * renderer, SDL_Texture * texture,
     return 0;
 }
 
+static void
+PS2_UnlockTexture(SDL_Renderer * renderer, SDL_Texture * texture)
+{
+    GSTEXTURE *ps2_texture = (GSTEXTURE *) texture->driverdata;
+    PS2_RenderData *data = (PS2_RenderData *) renderer->driverdata;
+
+    gsKit_TexManager_invalidate(data->gsGlobal, ps2_texture);
+}
+
 static int
 PS2_UpdateTexture(SDL_Renderer * renderer, SDL_Texture * texture,
                    const SDL_Rect * rect, const void *pixels, int pitch)
@@ -181,14 +190,9 @@ PS2_UpdateTexture(SDL_Renderer * renderer, SDL_Texture * texture,
         }
     }
 
-    gsKit_TexManager_invalidate(data->gsGlobal, ps2_texture);
+    PS2_UnlockTexture(renderer, texture);
 
     return 0;
-}
-
-static void
-PS2_UnlockTexture(SDL_Renderer * renderer, SDL_Texture * texture)
-{
 }
 
 static void


### PR DESCRIPTION
## Description
Currently, the PS2 render driver wasn't able to make it work properly with the examples `testoverlay2` and `teststreaming`, it was showing an static image.
In this PR we solve the problem by invalidating the texture in the UnlockTextureMethod.

Cheers

