### PR TITLE
Add support for libusb device whitelisting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,14 +137,6 @@ else()
   set(SDL_HIDAPI_LIBUSB_AVAILABLE TRUE)
 endif()
 
-# On the other hand, *BSD specifically uses libusb only, so we make a special
-#  case just for them.
-if(FREEBSD OR NETBSD OR OPENBSD OR BSDI)
-  set(SDL_HIDAPI_LIBUSB_DEFAULT TRUE)
-else()
-  set(SDL_HIDAPI_LIBUSB_DEFAULT FALSE)
-endif()
-
 set(SDL_ASSEMBLY_DEFAULT OFF)
 if(USE_CLANG OR USE_GCC OR USE_INTELCC OR MSVC_VERSION GREATER 1400)
   set(SDL_ASSEMBLY_DEFAULT ON)
@@ -349,7 +341,7 @@ set_option(SDL_OFFSCREEN           "Use offscreen video driver" ON)
 option_string(SDL_BACKGROUNDING_SIGNAL "number to use for magic backgrounding signal or 'OFF'" OFF)
 option_string(SDL_FOREGROUNDING_SIGNAL "number to use for magic foregrounding signal or 'OFF'" OFF)
 dep_option(SDL_HIDAPI              "Enable the HIDAPI subsystem" ON "NOT VISIONOS" OFF)
-dep_option(SDL_HIDAPI_LIBUSB       "Use libusb for low level joystick drivers" ${SDL_HIDAPI_LIBUSB_DEFAULT} "SDL_HIDAPI;${SDL_HIDAPI_LIBUSB_AVAILABLE}" OFF)
+dep_option(SDL_HIDAPI_LIBUSB       "Use libusb for low level joystick drivers" ON SDL_HIDAPI_LIBUSB_AVAILABLE OFF)
 dep_option(SDL_HIDAPI_JOYSTICK     "Use HIDAPI for low level joystick drivers" ON SDL_HIDAPI OFF)
 dep_option(SDL_VIRTUAL_JOYSTICK    "Enable the virtual-joystick driver" ON SDL_HIDAPI OFF)
 set_option(SDL_LIBUDEV             "Enable libudev support" ON)

--- a/src/hidapi/SDL_hidapi.c
+++ b/src/hidapi/SDL_hidapi.c
@@ -873,6 +873,41 @@ typedef struct LIBUSB_hid_device_ LIBUSB_hid_device;
 #undef read_thread
 #undef return_data
 
+/* If the platform has any backend other than libusb, try to avoid using
+ * libusb as the main backend for devices, since it detaches drivers and
+ * therefore makes devices inaccessible to the rest of the OS.
+ *
+ * We do this by whitelisting devices we know to be accessible _exclusively_
+ * via libusb; these are typically devices that look like HIDs but have a
+ * quirk that requires direct access to the hardware.
+ */
+static const struct {
+    Uint16 vendor;
+    Uint16 product;
+} SDL_libusb_whitelist[] = {
+    { 0x057e, 0x0337 } /* Nintendo WUP-028, Wii U/Switch GameCube Adapter */
+};
+
+static SDL_bool
+IsInWhitelist(Uint16 vendor, Uint16 product)
+{
+    int i;
+    for (i = 0; i < SDL_arraysize(SDL_libusb_whitelist); i += 1) {
+        if (vendor == SDL_libusb_whitelist[i].vendor &&
+            product == SDL_libusb_whitelist[i].product) {
+            return SDL_TRUE;
+        }
+    }
+    return SDL_FALSE;
+}
+
+#if HAVE_PLATFORM_BACKEND || HAVE_DRIVER_BACKEND
+static const SDL_bool use_libusb_whitelist_default = SDL_TRUE;
+#else
+static const SDL_bool use_libusb_whitelist_default = SDL_FALSE;
+#endif /* HAVE_PLATFORM_BACKEND || HAVE_DRIVER_BACKEND */
+static SDL_bool use_libusb_whitelist = use_libusb_whitelist_default;
+
 #endif /* HAVE_LIBUSB */
 
 #endif /* !SDL_HIDAPI_DISABLED */
@@ -1118,6 +1153,8 @@ int SDL_hid_init(void)
 #endif
 
 #ifdef HAVE_LIBUSB
+    use_libusb_whitelist = SDL_GetHintBoolean("SDL_HIDAPI_LIBUSB_WHITELIST",
+                                              use_libusb_whitelist_default);
     if (SDL_getenv("SDL_HIDAPI_DISABLE_LIBUSB") != NULL) {
         SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
                      "libusb disabled by SDL_HIDAPI_DISABLE_LIBUSB");
@@ -1308,6 +1345,16 @@ struct SDL_hid_device_info *SDL_hid_enumerate(unsigned short vendor_id, unsigned
         SDL_Log("libusb devices found:");
 #endif
         for (usb_dev = usb_devs; usb_dev; usb_dev = usb_dev->next) {
+            if (use_libusb_whitelist) {
+                if (!IsInWhitelist(usb_dev->vendor_id, usb_dev->product_id)) {
+#ifdef DEBUG_HIDAPI
+                    SDL_Log("Device was not in libusb whitelist: %ls %ls 0x%.4hx 0x%.4hx",
+                            usb_dev->manufacturer_string, usb_dev->product_string,
+                            usb_dev->vendor_id, usb_dev->product_id);
+#endif /* DEBUG_HIDAPI */
+                    continue;
+                }
+            }
             new_dev = (struct SDL_hid_device_info *)SDL_malloc(sizeof(struct SDL_hid_device_info));
             if (new_dev == NULL) {
                 LIBUSB_hid_free_enumeration(usb_devs);


### PR DESCRIPTION
When combining both libusb and an OS backend for SDL_hidapi, we want to ensure that libusb is only used when absolutely necessary. At the same time, we don't want to interfere with platforms that _only_ have libusb. So, implement a whitelist but only use it when another backend exists.

With this in place, it should now be safe to enable libusb support by default.

Affects SDL_hidapi (Sam), configure.ac (Ozkan), and CMake (Anon).

Fixes #6005