### PR TITLE
[PS2] SDL_main - General improvements

### DIFF
--- a/docs/README-ps2.md
+++ b/docs/README-ps2.md
@@ -16,6 +16,22 @@ cmake --build build
 cmake --install build
 ```
 
+## Notes
+If you trying to debug a SDL app through [ps2client](https://github.com/ps2dev/ps2client) you need to avoid the IOP reset, otherwise you will lose the conection with your computer.
+So to avoid the reset of the IOP CPU, you need to call to the macro `SDL_PS2_SKIP_IOP_RESET();`.
+It could be something similar as:
+```c
+.....
+
+SDL_PS2_SKIP_IOP_RESET();
+
+int main(int argc, char *argv[])
+{
+.....
+```
+For a release binary is recommendable to reset the IOP always. 
+
+Remember to do a clean compilation everytime you enable or disable the `SDL_PS2_SKIP_IOP_RESET` otherwise the change won't be reflected.
 
 ## Getting PS2 Dev
 [Installing PS2 Dev](https://github.com/ps2dev/ps2dev)
@@ -28,7 +44,4 @@ cmake --install build
 ## To Do
 - PS2 Screen Keyboard
 - Dialogs
-- Audio
-- Video
-- Controllers
 - Others

--- a/include/SDL_main.h
+++ b/include/SDL_main.h
@@ -104,6 +104,10 @@
 #elif defined(__PS2__)
 #define SDL_MAIN_AVAILABLE
 
+#define SDL_PS2_SKIP_IOP_RESET() \
+   void reset_IOP(); \
+   void reset_IOP() {}
+
 #endif
 #endif /* SDL_MAIN_HANDLED */
 

--- a/src/main/ps2/SDL_ps2_main.c
+++ b/src/main/ps2/SDL_ps2_main.c
@@ -19,23 +19,25 @@
 #include <sbv_patches.h>
 #include <ps2_fileXio_driver.h>
 #include <ps2_memcard_driver.h>
+#include <ps2_usb_driver.h>
 
 #ifdef main
     #undef main
 #endif
 
+__attribute__((weak))
+void reset_IOP() {
+    SifInitRpc(0);
+    while(!SifIopReset(NULL, 0)){};
+    while(!SifIopSync()){};
+}
+
 static void prepare_IOP()
 {
+    reset_IOP();
     SifInitRpc(0);
-    // #if !defined(DEBUG) || defined(BUILD_FOR_PCSX2)
-    /* Comment this line if you don't wanna debug the output */
-    while(!SifIopReset(NULL, 0)){};
-    // #endif
-
-    while(!SifIopSync()){};
-   SifInitRpc(0);
-   sbv_patch_enable_lmb();
-   sbv_patch_disable_prefix_check();
+    sbv_patch_enable_lmb();
+    sbv_patch_disable_prefix_check();
 }
 
 static void init_drivers() {
@@ -52,18 +54,17 @@ static void deinit_drivers() {
 
 static void waitUntilDeviceIsReady(char *path)
 {
-   struct stat buffer;
-   int ret = -1;
-   int retries = 50;
+    struct stat buffer;
+    int ret = -1;
+    int retries = 50;
 
-   while(ret != 0 && retries > 0)
-   {
-      ret = stat(path, &buffer);
-      /* Wait untill the device is ready */
-      nopdelay();
+    while(ret != 0 && retries > 0) {
+        ret = stat(path, &buffer);
+        /* Wait untill the device is ready */
+        nopdelay();
 
-      retries--;
-   }
+        retries--;
+    }
 }
 
 int main(int argc, char *argv[])
@@ -84,6 +85,6 @@ int main(int argc, char *argv[])
     return res;
 }
 
-#endif /* _EE */
+#endif /* _PS2 */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/main/ps2/SDL_ps2_main.c
+++ b/src/main/ps2/SDL_ps2_main.c
@@ -9,6 +9,11 @@
 #include "SDL_main.h"
 #include "SDL_error.h"
 
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <kernel.h>
 #include <sifrpc.h>
 #include <iopcontrol.h>
 #include <sbv_patches.h>
@@ -21,6 +26,13 @@
 
 static void prepare_IOP()
 {
+    SifInitRpc(0);
+    // #if !defined(DEBUG) || defined(BUILD_FOR_PCSX2)
+    /* Comment this line if you don't wanna debug the output */
+    while(!SifIopReset(NULL, 0)){};
+    // #endif
+
+    while(!SifIopSync()){};
    SifInitRpc(0);
    sbv_patch_enable_lmb();
    sbv_patch_disable_prefix_check();
@@ -29,18 +41,41 @@ static void prepare_IOP()
 static void init_drivers() {
     init_fileXio_driver();
     init_memcard_driver(true);
+    init_usb_driver(true);
 }
 
 static void deinit_drivers() {
+    deinit_usb_driver(true);
     deinit_memcard_driver(true);
     deinit_fileXio_driver();
+}
+
+static void waitUntilDeviceIsReady(char *path)
+{
+   struct stat buffer;
+   int ret = -1;
+   int retries = 50;
+
+   while(ret != 0 && retries > 0)
+   {
+      ret = stat(path, &buffer);
+      /* Wait untill the device is ready */
+      nopdelay();
+
+      retries--;
+   }
 }
 
 int main(int argc, char *argv[])
 {
     int res;
+    char cwd[FILENAME_MAX];
+
     prepare_IOP();
     init_drivers();
+    
+    getcwd(cwd, sizeof(cwd));
+    waitUntilDeviceIsReady(cwd);
 
     res = SDL_main(argc, argv);
 


### PR DESCRIPTION
## Description
This PR includes:
- Add USB filesystem support to the `SDL_main`
- Offer the possibility of avoiding the reset of the IOP CPU. That's is useful in the case that a user is debugging the PS2 app through `ps2link/ps2client`, if we reset IOP, we lose the connection with the console.
- Create a macro to make it easier for the developers to avoid resetting the IOP.
- Updated the readme with that specific functionality as an additional note.
