### PR TITLE
WGI: fix interop with applications that have their own WGI code

### DIFF
--- a/src/joystick/windows/SDL_windows_gaming_input.c
+++ b/src/joystick/windows/SDL_windows_gaming_input.c
@@ -32,6 +32,7 @@
 #define COBJMACROS
 #include "windows.gaming.input.h"
 #include <cfgmgr32.h>
+#include <objidlbase.h>
 #include <roapi.h>
 
 
@@ -213,11 +214,15 @@ static HRESULT STDMETHODCALLTYPE IEventHandler_CRawGameControllerVtbl_QueryInter
     }
 
     *ppvObject = NULL;
-    if (WIN_IsEqualIID(riid, &IID_IUnknown) || WIN_IsEqualIID(riid, &IID_IEventHandler_RawGameController)) {
+    if (WIN_IsEqualIID(riid, &IID_IUnknown) || WIN_IsEqualIID(riid, &IID_IAgileObject) || WIN_IsEqualIID(riid, &IID_IEventHandler_RawGameController)) {
         *ppvObject = This;
         return S_OK;
+    } else if (WIN_IsEqualIID(riid, &IID_IMarshal)) {
+        // This seems complicated. Let's hope it doesn't happen.
+        return E_OUTOFMEMORY;
+    } else {
+        return E_NOINTERFACE;
     }
-    return E_NOINTERFACE;
 }
 
 static ULONG STDMETHODCALLTYPE IEventHandler_CRawGameControllerVtbl_AddRef(__FIEventHandler_1_Windows__CGaming__CInput__CRawGameController * This)


### PR DESCRIPTION
## Description
QI for Added/Removed events need to handle IAgileObject

## Existing Issue(s)
The app (dolphin emulator) has its own WGI code which also registers Added/Removed event handlers. Without this change, the events stop firing after the first one for both dolphin's WGI code and SDL's WGI code. Generally, device detection stops working (even if event handlers aren't explicitly used).

