### PR TITLE
fix a bug if XINPUTGETBATTERYINFORMATION is nullptr

### DIFF
--- a/src/joystick/windows/SDL_rawinputjoystick.c
+++ b/src/joystick/windows/SDL_rawinputjoystick.c
@@ -338,7 +338,9 @@ RAWINPUT_UpdateXInput()
                     xinput_state[user_index].connected = SDL_FALSE;
                 }
                 xinput_state[user_index].battery.BatteryType = BATTERY_TYPE_UNKNOWN;
-                XINPUTGETBATTERYINFORMATION(user_index, BATTERY_DEVTYPE_GAMEPAD, &xinput_state[user_index].battery);
+                if (XINPUTGETBATTERYINFORMATION) {
+                    XINPUTGETBATTERYINFORMATION(user_index, BATTERY_DEVTYPE_GAMEPAD, &xinput_state[user_index].battery);
+                }
             }
         }
     }


### PR DESCRIPTION
Hi, I found a bug if XINPUTGETBATTERYINFORMATION is nullptr. My game found a crash in `XINPUTGETBATTERYINFORMATION(user_index, BATTERY_DEVTYPE_GAMEPAD, &xinput_state[user_index].battery);`

