### PR TITLE
wayland: Avoid duplicate resize events when entering fullscreen

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -631,14 +631,12 @@ handle_configure_xdg_toplevel(void *data,
          * UPDATE: Nope, sure enough a compositor sends 0,0. This is a known bug:
          * https://bugs.kde.org/show_bug.cgi?id=444962
          */
-        if (!FullscreenModeEmulation(window)) {
-            if (width != 0 && height != 0 && (window->w != width || window->h != height)) {
-                window->w = width;
-                window->h = height;
-                wind->needs_resize_event = SDL_TRUE;
-            }
-        } else {
-            GetFullScreenDimensions(window, &window->w, &window->h, NULL, NULL);
+        if (FullscreenModeEmulation(window)) {
+            GetFullScreenDimensions(window, &width, &height, NULL, NULL);
+        }
+        if (width != 0 && height != 0 && (window->w != width || window->h != height)) {
+            window->w = width;
+            window->h = height;
             wind->needs_resize_event = SDL_TRUE;
         }
 
@@ -833,8 +831,6 @@ decoration_frame_configure(struct libdecor_frame *frame,
         } else {
             GetFullScreenDimensions(window, &width, &height, NULL, NULL);
         }
-
-        wind->needs_resize_event = SDL_TRUE;
 
         /* This part is good though. */
         if (window->flags & SDL_WINDOW_ALLOW_HIGHDPI) {


### PR DESCRIPTION
## Description
#5450 reintroduced some duplicate `SDL_WINDOWEVENT_SIZE_CHANGED` and `SDL_WINDOWEVENT_RESIZED` events that I had addressed in #5232.

This can be noted when running `testgl2` on Wayland with `SDL_EVENT_LOGGING=1` and pressing Alt+Enter to enter fullscreen.

Before this fix:
```
INFO: SDL EVENT: SDL_WINDOWEVENT (timestamp=675237 windowid=1 event=SDL_WINDOWEVENT_SIZE_CHANGED data1=1503 data2=1002)
INFO: SDL EVENT: SDL_WINDOWEVENT (timestamp=675237 windowid=1 event=SDL_WINDOWEVENT_RESIZED data1=1503 data2=1002)
INFO: SDL EVENT: SDL_WINDOWEVENT (timestamp=675240 windowid=1 event=SDL_WINDOWEVENT_SIZE_CHANGED data1=1503 data2=1002)
INFO: SDL EVENT: SDL_WINDOWEVENT (timestamp=675240 windowid=1 event=SDL_WINDOWEVENT_RESIZED data1=1503 data2=1002
```

After the fix:
```
INFO: SDL EVENT: SDL_WINDOWEVENT (timestamp=1678 windowid=1 event=SDL_WINDOWEVENT_SIZE_CHANGED data1=1503 data2=1002)
INFO: SDL EVENT: SDL_WINDOWEVENT (timestamp=1678 windowid=1 event=SDL_WINDOWEVENT_RESIZED data1=1503 data2=1002)
```

@Kontrabant for review