### PR TITLE
wayland: Don't roundtrip in ShowWindow unless restoring a hidden window

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -1370,7 +1370,10 @@ void Wayland_ShowWindow(_THIS, SDL_Window *window)
      * Roundtrip required to avoid a possible protocol violation when
      * HideWindow was called immediately before ShowWindow.
      */
-    WAYLAND_wl_display_roundtrip(c->display);
+    if (data->needs_roundtrip) {
+        data->needs_roundtrip = SDL_FALSE;
+        WAYLAND_wl_display_roundtrip(c->display);
+    }
 }
 
 static void
@@ -1447,6 +1450,7 @@ void Wayland_HideWindow(_THIS, SDL_Window *window)
      * Roundtrip required to avoid a possible protocol violation when
      * ShowWindow is called immediately after HideWindow.
      */
+    wind->needs_roundtrip = SDL_TRUE;
     WAYLAND_wl_display_roundtrip(data->display);
 }
 

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -107,6 +107,7 @@ typedef struct {
     SDL_Rect viewport_rect;
     SDL_bool needs_resize_event;
     SDL_bool floating_resize_pending;
+    SDL_bool needs_roundtrip;
 } SDL_WindowData;
 
 extern void Wayland_ShowWindow(_THIS, SDL_Window *window);


### PR DESCRIPTION
Don't call the roundtrip in ShowWindow unless restoring a previously hidden window.  This fixes a regression in GNOME when creating a window with the fullscreen flag set, as the fullscreen window will be offset down the screen the height of the top bar if the window is made fullscreen on the primary display and the roundtrip is called when initially displaying the window.