### PR TITLE
cocoa: Return an error if GetWindowDisplayIndex() is called too early

### DIFF
--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -2230,7 +2230,7 @@ Cocoa_GetWindowDisplayIndex(_THIS, SDL_Window * window)
 
     /* Not recognized via CHECK_WINDOW_MAGIC */
     if (data == nil) {
-        return 0;
+        return SDL_SetError("Window data not set");
     }
 
     /* NSWindow.screen may be nil when the window is off-screen. */


### PR DESCRIPTION
## Description
76afb8583b39305cf73191664c0015a8ee2400d4 introduced a regression when creating a new window on a secondary display using `SDL_WINDOWPOS_CENTERED_DISPLAY()`. Windows created this way are always placed on display 0 instead of where the caller wanted.

`SDL_CreateWindow()` may call `GetWindowDisplayIndex()` to compute the position of a new window that the caller has requested to be placed on a certain display. Since we haven't fully constructed the window yet, our driverdata will be nil and we will fail to get the NSScreen (which is fine). However, we need to return an error (not 0, which is a valid display index) for `SDL_GetWindowDisplayIndex()` to know to figure out the display index itself.

We should probably do something to avoid calling `GetWindowDisplayIndex()` before window initialization is complete, but this minimal fix works for 2.24.0.

cc: @misl6 @peppy for review


