### PR TITLE
video: wayland: Remove excessive SetFullscreen calls

### DIFF
--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -149,6 +149,12 @@ struct SDL_SysWMinfo;
 /* Define the SDL video driver structure */
 #define _THIS   SDL_VideoDevice *_this
 
+/* Video device flags */
+typedef enum {
+    VIDEO_DEVICE_QUIRK_DISABLE_DISPLAY_MODE_SWITCHING       = 0x01,
+    VIDEO_DEVICE_QUIRK_DISABLE_UNSET_FULLSCREEN_ON_MINIMIZE = 0x02,
+} DeviceQuirkFlags;
+
 struct SDL_VideoDevice
 {
     /* * * */
@@ -347,7 +353,7 @@ struct SDL_VideoDevice
     Uint32 next_object_id;
     char *clipboard_text;
     SDL_bool setting_display_mode;
-    SDL_bool disable_display_mode_switching;
+    Uint32 quirk_flags;
 
     /* * * */
     /* Data used by the GL drivers */

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -279,7 +279,7 @@ Wayland_CreateDevice(void)
 
     device->free = Wayland_DeleteDevice;
 
-    device->disable_display_mode_switching = SDL_TRUE;
+    device->quirk_flags = VIDEO_DEVICE_QUIRK_DISABLE_DISPLAY_MODE_SWITCHING;
 
     return device;
 }

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -279,7 +279,8 @@ Wayland_CreateDevice(void)
 
     device->free = Wayland_DeleteDevice;
 
-    device->quirk_flags = VIDEO_DEVICE_QUIRK_DISABLE_DISPLAY_MODE_SWITCHING;
+    device->quirk_flags = VIDEO_DEVICE_QUIRK_DISABLE_DISPLAY_MODE_SWITCHING |
+                          VIDEO_DEVICE_QUIRK_DISABLE_UNSET_FULLSCREEN_ON_MINIMIZE;
 
     return device;
 }

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -107,7 +107,6 @@ typedef struct {
     SDL_Rect viewport_rect;
     SDL_bool needs_resize_event;
     SDL_bool floating_resize_pending;
-    SDL_bool needs_roundtrip;
 } SDL_WindowData;
 
 extern void Wayland_ShowWindow(_THIS, SDL_Window *window);


### PR DESCRIPTION
Eliminate excessive calls to `SetFullscreen` by removing the calls in the libdecor and xdg-toplevel config callbacks.

These calls were being made there in case something explicitly called the window minimization function from within SDL, which unsets fullscreen, and as minimizing a window in Wayland is just a suggestion to the compositor and doesn't actually change the window state or communicate anything back to the application, it was necessary to call SetFullscreen in every call to the config functions just in case something minimized a window via `SDL_MinimizeWindow()` and later needed to restore it.  GNOME in particular had issues with strange behavior when fullscreen set/unset operations were being hammered and commits were being performed on surfaces while switching to fullscreen.

With the new video system flag to disable unsetting fullscreen when minimizing a window, these calls in the configuration functions are no longer needed and can be removed. This significantly reduces calls to the `SetFullscreen` function, reverts #6044 for a more proper fix, and fixes a similar problem when hiding and showing a window initially created with fullscreen flags.

Draft for now, as, while this works well from my testing and eliminates a huge amount of fullscreen set/unset calls and commits, I'd like more eyes on it to make sure I'm not missing anything here.

@flibitijibibo 
@dos1 