### PR TITLE
[PS2] Decrease audio thread priority when created

### DIFF
--- a/src/audio/ps2/SDL_ps2audio.c
+++ b/src/audio/ps2/SDL_ps2audio.c
@@ -130,7 +130,7 @@ static void PS2AUDIO_ThreadInit(_THIS)
     ee_thread_status_t status;
     thid = GetThreadId();
     if (ReferThreadStatus(GetThreadId(), &status) == 0) {
-        ChangeThreadPriority(thid, status.current_priority);
+        ChangeThreadPriority(thid, status.current_priority - 1);
     }
 }
 


### PR DESCRIPTION
## Description
Currently, the audio thread has the same priority as the main thread, with this PR we follow the same approach as other platforms, where we are setting a lower priority when the audio thread is created.