### PR TITLE
[PS2] Fix memory leak when destroying texture

### DIFF
--- a/src/render/ps2/SDL_render_ps2.c
+++ b/src/render/ps2/SDL_render_ps2.c
@@ -678,9 +678,20 @@ static void
 PS2_DestroyTexture(SDL_Renderer * renderer, SDL_Texture * texture)
 {
     GSTEXTURE *ps2_texture = (GSTEXTURE *) texture->driverdata;
+    PS2_RenderData *data = (PS2_RenderData *)renderer->driverdata;
 
+    if (data == 0)
+        return;
+
+    if(ps2_texture == 0)
+        return;
+
+    // Free from vram
+    gsKit_TexManager_free(data->gsGlobal, ps2_texture);
+    
     SDL_free(ps2_texture->Mem);
     SDL_free(ps2_texture);
+    texture->driverdata = NULL;
 }
 
 static void


### PR DESCRIPTION
## Description
Be sure that we are deallocating the VRAM memory when destroying texture.
Additionally, also be sure that we are setting the driverdata from the texture to NULL
 `texture->driverdata = NULL;` 

Cheers