### PR TITLE
[Apple][CMake] fail Metal test immediately only on 32-bit macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2101,7 +2101,7 @@ elseif(APPLE)
         #import <Metal/Metal.h>
         #import <QuartzCore/CAMetalLayer.h>
 
-        #if (!TARGET_CPU_X86_64 && !TARGET_CPU_ARM64)
+        #if (TARGET_OS_OSX && !TARGET_CPU_X86_64 && !TARGET_CPU_ARM64)
         #error Metal doesn't work on this configuration
         #endif
         int main(int argc, char **argv) { return 0; }" HAVE_FRAMEWORK_METAL)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Metal is around for ~8 years already in Apple SDKs - since iOS 8 / macOS 10.11.

For example, Metal support will be unavailable if you build for iOS with `-D CMAKE_OSX_ARCHITECTURES="armv7;arm64"`, the only solution would be to build for those archs separately and `lipo` in the end. Note that in Xcode project Metal support is always available. Besides, [the iOS config file](https://github.com/libsdl-org/SDL/blob/main/include/SDL_config_iphoneos.h) already has proper condition to enable Metal.