### PR TITLE
cocoa: Opt-in to secure state restoration

### DIFF
--- a/src/video/cocoa/SDL_cocoaevents.m
+++ b/src/video/cocoa/SDL_cocoaevents.m
@@ -308,6 +308,11 @@ static void Cocoa_DispatchEvent(NSEvent *theEvent)
     SDL_SendDropComplete(NULL);
 }
 
+- (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app
+{
+    return YES;
+}
+
 @end
 
 static SDLAppDelegate *appDelegate = nil;


### PR DESCRIPTION
Opt-in to secure state restoration in the `SDLAppDelegate`

## Description
Reference: [Process injection: breaking all macOS security layers with a single vulnerability](https://sector7.computest.nl/post/2022-08-process-injection-breaking-all-macos-security-layers-with-a-single-vulnerability/)

Support the new (optional) [`applicationSupportsSecureRestorableState`](https://developer.apple.com/documentation/appkit/nsapplicationdelegate/3762521-applicationsupportssecurerestora) in `SDLAppDelegate` by default.

(This is automatically added in the new Xcode template in Xcode 13.2+)