### PR TITLE
testgles2: Fix typo in help text

### DIFF
--- a/test/testgles2.c
+++ b/test/testgles2.c
@@ -583,7 +583,7 @@ main(int argc, char *argv[])
             }
         }
         if (consumed < 0) {
-            static const char *options[] = { "[--fsaa]", "[--accel]", "[--zdepth %d], [--threaded]", NULL };
+            static const char *options[] = { "[--fsaa]", "[--accel]", "[--zdepth %d]", "[--threaded]", NULL };
             SDLTest_CommonLogUsage(state, argv[0], options);
             quit(1);
         }


### PR DESCRIPTION
## Description
Fixes a typo in #6065 that led to help text for `--threaded` being printed incorrectly