### PR TITLE
wayland: Set the libdecor app ID after visibility calls

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -1217,6 +1217,7 @@ void Wayland_ShowWindow(_THIS, SDL_Window *window)
         if (data->shell_surface.libdecor.frame) {
             /* If the frame already exists, just set the visibility. */
             libdecor_frame_set_visibility(data->shell_surface.libdecor.frame, true);
+            libdecor_frame_set_app_id(data->shell_surface.libdecor.frame, c->classname);
         } else {
             data->shell_surface.libdecor.frame = libdecor_decorate(c->shell.libdecor,
                                                                    data->surface,
@@ -1416,6 +1417,7 @@ void Wayland_HideWindow(_THIS, SDL_Window *window)
     if (WINDOW_IS_LIBDECOR(data, window)) {
         if (wind->shell_surface.libdecor.frame) {
             libdecor_frame_set_visibility(wind->shell_surface.libdecor.frame, false);
+            libdecor_frame_set_app_id(wind->shell_surface.libdecor.frame, data->classname);
         }
     } else
 #endif


### PR DESCRIPTION
Set the frame app ID after toggling visibility or the name displayed in window manager task switchers may not display correctly.

Edit: This is a regression bugfix for 2.24 if possible.