### PR TITLE
Use __ARM_ARCH instead of __ARM_ARCH__

### DIFF
--- a/include/SDL_atomic.h
+++ b/include/SDL_atomic.h
@@ -240,7 +240,7 @@ typedef void (*SDL_KernelMemoryBarrierFunc)();
 /* "REP NOP" is PAUSE, coded for tools that don't know it by that name. */
 #if (defined(__GNUC__) || defined(__clang__)) && (defined(__i386__) || defined(__x86_64__))
     #define SDL_CPUPauseInstruction() __asm__ __volatile__("pause\n")  /* Some assemblers can't do REP NOP, so go with PAUSE. */
-#elif (defined(__arm__) && __ARM_ARCH__ >= 7) || defined(__aarch64__)
+#elif (defined(__arm__) && __ARM_ARCH >= 7) || defined(__aarch64__)
     #define SDL_CPUPauseInstruction() __asm__ __volatile__("yield" ::: "memory")
 #elif (defined(__powerpc__) || defined(__powerpc64__))
     #define SDL_CPUPauseInstruction() __asm__ __volatile__("or 27,27,27");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Neither modern gcc:

```
$ gcc -mfpu=neon-vfpv4 -dM -E -x c /dev/null | grep -i -E ARM
#define __ARM_SIZEOF_WCHAR_T 32
#define __ARM_FEATURE_SAT 1
#define __ARM_ARCH_ISA_ARM 1
#define __ARMEL__ 1
#define __ARM_FEATURE_UNALIGNED 1
#define __ARM_FP 14
#define __ARM_NEON_FP 6
#define __ARM_SIZEOF_MINIMAL_ENUM 4
#define __ARM_PCS_VFP 1
#define __ARM_FEATURE_LDREX 4
#define __ARM_FEATURE_QBIT 1
#define __ARM_FEATURE_FMA 1
#define __ARM_NEON__ 1
#define __ARM_ARCH_6__ 1
#define __ARM_32BIT_STATE 1
#define __ARM_FEATURE_CLZ 1
#define __ARM_ARCH_ISA_THUMB 1
#define __ARM_ARCH 6
#define __arm__ 1
#define __ARM_FEATURE_SIMD32 1
#define __ARM_NEON 1
#define __ARM_EABI__ 1
#define __ARM_FEATURE_DSP 1
```

nor modern clang:

```
$ clang -march=armv7 -dM -E -x c /dev/null | grep -i -E ARM 
#define __ARMEL__ 1
#define __ARM_32BIT_STATE 1
#define __ARM_ACLE 200
#define __ARM_ARCH 7
#define __ARM_ARCH_7A__ 1
#define __ARM_ARCH_ISA_ARM 1
#define __ARM_ARCH_ISA_THUMB 2
#define __ARM_ARCH_PROFILE 'A'
#define __ARM_EABI__ 1
#define __ARM_NEON 1
#define __ARM_NEON__ 1
#define __ARM_PCS 1
#define __ARM_PCS_VFP 1
#define __ARM_SIZEOF_MINIMAL_ENUM 4
#define __ARM_SIZEOF_WCHAR_T 4
#define __ARM_VFPV3__ 1
#define __arm 1
#define __arm__ 1
```

define the obsolete `__ARM_ARCH__` symbol. The `__ARM_ARCH` [should be used](https://gcc.gnu.org/legacy-ml/gcc-patches/2018-06/msg00928.html) instead. Using the `__ARM_ARCH__` symbol in the `SDL_atomic.h` breaks projects that use SDL on ARM (which can be detected with `-Werror=undef`).