### PR TITLE
cmake: add library directories & pthread to imported targets of sdl2-config.cmake

### DIFF
--- a/sdl2-config.cmake.in
+++ b/sdl2-config.cmake.in
@@ -39,18 +39,25 @@ unset(bindir)
 unset(libdir)
 unset(includedir)
 
-set(_sdl2_libraries "@SDL_LIBS@")
-set(_sdl2_static_private_libs "@SDL_STATIC_LIBS@")
+set(_sdl2_libraries_in "@SDL_LIBS@")
+set(_sdl2_static_private_libs_in "@SDL_STATIC_LIBS@")
 
-# Convert _sdl2_libraries to list and keep only libraries
-string(REGEX MATCHALL "-[lm]([-a-zA-Z0-9._]+)" _sdl2_libraries "${_sdl2_libraries}")
+# Convert _sdl2_libraries to list and keep only libraries + library directories
+string(REGEX MATCHALL "-[lm]([-a-zA-Z0-9._]+)" _sdl2_libraries "${_sdl2_libraries_in}")
 string(REGEX REPLACE "^-l" "" _sdl2_libraries "${_sdl2_libraries}")
 string(REGEX REPLACE ";-l" ";" _sdl2_libraries "${_sdl2_libraries}")
+string(REGEX MATCHALL "-L([-a-zA-Z0-9._/]+)" _sdl2_libdirs "${_sdl2_libraries_in}")
+string(REGEX REPLACE "^-L" "" _sdl2_libdirs "${_sdl2_libdirs}")
+string(REGEX REPLACE ";-L" ";" _sdl2_libdirs "${_sdl2_libdirs}")
+list(APPEND _sdl2_libdirs "${SDL2_LIBDIR}")
 
-# Convert _sdl2_static_private_libs to list and keep only libraries
-string(REGEX MATCHALL "(-[lm]([-a-zA-Z0-9._]+))|(-Wl,[^ ]*framework[^ ]*)" _sdl2_static_private_libs "${_sdl2_static_private_libs}")
+# Convert _sdl2_static_private_libs to list and keep only libraries + library directories
+string(REGEX MATCHALL "(-[lm]([-a-zA-Z0-9._]+))|(-Wl,[^ ]*framework[^ ]*)|(-pthread)" _sdl2_static_private_libs "${_sdl2_static_private_libs_in}")
 string(REGEX REPLACE "^-l" "" _sdl2_static_private_libs "${_sdl2_static_private_libs}")
 string(REGEX REPLACE ";-l" ";" _sdl2_static_private_libs "${_sdl2_static_private_libs}")
+string(REGEX MATCHALL "-L([-a-zA-Z0-9._/]+)" _sdl2_static_private_libdirs "${_sdl2_static_private_libs_in}")
+string(REGEX REPLACE "^-L" "" _sdl2_static_private_libdirs "${_sdl2_static_private_libdirs}")
+string(REGEX REPLACE ";-L" ";" _sdl2_static_private_libdirs "${_sdl2_static_private_libdirs}")
 
 if(_sdl2_libraries MATCHES ".*SDL2main.*")
   list(INSERT SDL2_LIBRARIES 0 SDL2::SDL2main)
@@ -103,6 +110,7 @@ if(WIN32)
       set_target_properties(SDL2::SDL2 PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIR}"
         INTERFACE_LINK_LIBRARIES "${_sdl2_link_libraries}"
+        INTERFACE_LINK_DIRECTORIES "${_sdl2_libdirs}"
         IMPORTED_LINK_INTERFACE_LANGUAGES "C"
         IMPORTED_IMPLIB "${_sdl2_implib}"
         IMPORTED_LOCATION "${_sdl2_dll}"
@@ -122,6 +130,7 @@ else()
       set_target_properties(SDL2::SDL2 PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIR}"
         INTERFACE_LINK_LIBRARIES "${_sdl2_link_libraries}"
+        INTERFACE_LINK_DIRECTORIES "${_sdl2_libdirs}"
         IMPORTED_LINK_INTERFACE_LANGUAGES "C"
         IMPORTED_LOCATION "${_sdl2_shared}"
       )
@@ -142,6 +151,7 @@ if(EXISTS "${_sdl2_static}")
         IMPORTED_LOCATION "${_sdl2_static}"
         INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIR}"
         INTERFACE_LINK_LIBRARIES "${_sdl2_link_libraries};${_sdl2_static_private_libs}"
+        INTERFACE_LINK_DIRECTORIES "${_sdl2_libdirs};${_sdl2_static_private_libdirs}"
         IMPORTED_LINK_INTERFACE_LANGUAGES "C"
     )
   endif()


### PR DESCRIPTION
The static `libSDL2.a` library might require external libraries, which might be located in non-standard locations.
The patch of this pr extracts these paths from the exported autotools variables and adds them to appropriate properties of the imported targets.
`pthread` also needs special care.


Fixes https://github.com/libsdl-org/SDL/issues/6094


Candidate for 2.24.1 (is there a label for this?)