### PR TITLE
cmake: Enable CET compatibility for x86/x64 targets using VS 16.7+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,6 +688,11 @@ if(MSVC)
   target_compile_definitions(sdl-build-options INTERFACE "-D_CRT_SECURE_NO_DEPRECATE")
   target_compile_definitions(sdl-build-options INTERFACE "-D_CRT_NONSTDC_NO_DEPRECATE")
   target_compile_definitions(sdl-build-options INTERFACE "-D_CRT_SECURE_NO_WARNINGS")
+
+  # CET support was added in VS 16.7
+  if(MSVC_VERSION GREATER 1926 AND NOT CMAKE_GENERATOR_PLATFORM MATCHES ARM)
+    list(APPEND EXTRA_LDFLAGS_BUILD "-CETCOMPAT")
+  endif()
 endif()
 
 if(MSVC)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,6 +47,11 @@ if(WINDOWS)
         link_libraries(mingw32)
     endif()
 
+    # CET support was added in VS 16.7
+    if(MSVC_VERSION GREATER 1926 AND NOT CMAKE_GENERATOR_PLATFORM MATCHES ARM)
+        link_libraries(-CETCOMPAT)
+    endif()
+
     # FIXME: Parent directory CMakeLists.txt only sets these for mingw/cygwin,
     # but we need them for VS as well.
     link_libraries(SDL2main)


### PR DESCRIPTION
## Description
This PR enables CET Shadow Stack compatibility for CMake builds using VS 16.7 or later. CET Shadow Stack protection helps protect against exploitation by detecting unexpected control flow changes caused by ROP attacks. CET is supported on Windows 10 20H2 and later when running on Intel Tiger Lake and AMD Zen 3 CPUs and newer.

The `/CETCOMPAT` flag sets a bit in the PE header that indicates to Windows that the binary can safely run with CET Shadow Stack protection which helps protect against ROP attacks. It is backwards compatible with older OSes and non-CET compatible CPUs.

Since it's just setting a bit in the PE header, it doesn't result in less efficient code generation (unlike Control Flow Guard), so it should be safe to use by default. It also is only enabled for the process if the main executable supports it, so it will not break existing applications that are not yet CET compatible.

Useful links for info about CET:
https://docs.microsoft.com/en-us/cpp/build/reference/cetcompat?view=msvc-170
https://techcommunity.microsoft.com/t5/windows-kernel-internals-blog/understanding-hardware-enforced-stack-protection/ba-p/1247815