### PR TITLE
cocoa: change Shape data to use ObjC objects instead of C structs.

### DIFF
--- a/src/video/cocoa/SDL_cocoashape.h
+++ b/src/video/cocoa/SDL_cocoashape.h
@@ -29,12 +29,11 @@
 #include "SDL_shape.h"
 #include "../SDL_shape_internals.h"
 
-typedef struct {
-    NSGraphicsContext* context;
-    SDL_bool saved;
-
-    SDL_ShapeTree* shape;
-} SDL_ShapeData;
+@interface SDL_ShapeData : NSObject
+    @property (nonatomic) NSGraphicsContext* context;
+    @property (nonatomic) SDL_bool saved;
+    @property (nonatomic) SDL_ShapeTree* shape;
+@end
 
 extern SDL_WindowShaper* Cocoa_CreateShaper(SDL_Window* window);
 extern int Cocoa_SetWindowShape(SDL_WindowShaper *shaper,SDL_Surface *shape,SDL_WindowShapeMode *shape_mode);

--- a/src/video/cocoa/SDL_cocoashape.m
+++ b/src/video/cocoa/SDL_cocoashape.m
@@ -27,6 +27,18 @@
 #include "SDL_cocoashape.h"
 #include "../SDL_sysvideo.h"
 
+@implementation SDL_ShapeData
+@end
+
+@interface SDL_CocoaClosure : NSObject
+    @property (nonatomic) NSView* view;
+    @property (nonatomic) NSBezierPath* path;
+    @property (nonatomic) SDL_Window* window;
+@end
+
+@implementation SDL_CocoaClosure
+@end
+
 SDL_WindowShaper*
 Cocoa_CreateShaper(SDL_Window* window)
 { @autoreleasepool
@@ -46,30 +58,26 @@ Cocoa_CreateShaper(SDL_Window* window)
     result->userx = result->usery = 0;
     window->shaper = result;
 
-    data = (SDL_ShapeData *)SDL_malloc(sizeof(SDL_ShapeData));
-    result->driverdata = data;
-    data->context = [windata.nswindow graphicsContext];
-    data->saved = SDL_FALSE;
-    data->shape = NULL;
+    data = [[SDL_ShapeData alloc] init];
+    data.context = [windata.nswindow graphicsContext];
+    data.saved = SDL_FALSE;
+    data.shape = NULL;
+
+    /* TODO: There's no place to release this... */
+    result->driverdata = (void*) CFBridgingRetain(data);
 
     resized_properly = Cocoa_ResizeWindowShape(window);
     SDL_assert(resized_properly == 0);
     return result;
 }}
 
-typedef struct {
-    NSView* view;
-    NSBezierPath* path;
-    SDL_Window* window;
-} SDL_CocoaClosure;
-
 void
 ConvertRects(SDL_ShapeTree* tree, void* closure)
 {
-    SDL_CocoaClosure* data = (SDL_CocoaClosure*)closure;
+    SDL_CocoaClosure* data = (__bridge SDL_CocoaClosure*)closure;
     if(tree->kind == OpaqueShape) {
-        NSRect rect = NSMakeRect(tree->data.shape.x,data->window->h - tree->data.shape.y,tree->data.shape.w,tree->data.shape.h);
-        [data->path appendBezierPathWithRect:[data->view convertRect:rect toView:nil]];
+        NSRect rect = NSMakeRect(tree->data.shape.x, data.window->h - tree->data.shape.y, tree->data.shape.w, tree->data.shape.h);
+        [data.path appendBezierPathWithRect:[data.view convertRect:rect toView:nil]];
     }
 }
 
@@ -77,26 +85,28 @@ int
 Cocoa_SetWindowShape(SDL_WindowShaper *shaper, SDL_Surface *shape, SDL_WindowShapeMode *shape_mode)
 { @autoreleasepool
 {
-    SDL_ShapeData* data = (SDL_ShapeData*)shaper->driverdata;
+    SDL_ShapeData* data = (__bridge SDL_ShapeData*)shaper->driverdata;
     SDL_WindowData* windata = (__bridge SDL_WindowData*)shaper->window->driverdata;
-    SDL_CocoaClosure closure;
-    if(data->saved == SDL_TRUE) {
-        [data->context restoreGraphicsState];
-        data->saved = SDL_FALSE;
+    SDL_CocoaClosure* closure;
+    if(data.saved == SDL_TRUE) {
+        [data.context restoreGraphicsState];
+        data.saved = SDL_FALSE;
     }
 
-    /*[data->context saveGraphicsState];*/
-    /*data->saved = SDL_TRUE;*/
-    [NSGraphicsContext setCurrentContext:data->context];
+    /*[data.context saveGraphicsState];*/
+    /*data.saved = SDL_TRUE;*/
+    [NSGraphicsContext setCurrentContext:data.context];
 
     [[NSColor clearColor] set];
     NSRectFill([windata.sdlContentView frame]);
-    data->shape = SDL_CalculateShapeTree(*shape_mode,shape);
+    data.shape = SDL_CalculateShapeTree(*shape_mode, shape);
+
+    closure = [[SDL_CocoaClosure alloc] init];
 
     closure.view = windata.sdlContentView;
     closure.path = [NSBezierPath bezierPath];
     closure.window = shaper->window;
-    SDL_TraverseShapeTree(data->shape,&ConvertRects,&closure);
+    SDL_TraverseShapeTree(data.shape, &ConvertRects, (__bridge void*)closure);
     [closure.path addClip];
 
     return 0;
@@ -104,11 +114,11 @@ Cocoa_SetWindowShape(SDL_WindowShaper *shaper, SDL_Surface *shape, SDL_WindowSha
 
 int
 Cocoa_ResizeWindowShape(SDL_Window *window)
-{
-    SDL_ShapeData* data = window->shaper->driverdata;
+{ @autoreleasepool {
+    SDL_ShapeData* data = (__bridge SDL_ShapeData*)window->shaper->driverdata;
     SDL_assert(data != NULL);
     return 0;
-}
+}}
 
 #endif /* SDL_VIDEO_DRIVER_COCOA */
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Objective-C with ARC works best when Objective-C objects have direct references in other ObjC objects instead of in C structs. In #5632 I changed most of the Cocoa backend code to use this convention but missed the shaped window code. Apparently this caused compilation problems on some systems, but not on mine.

## Existing Issue(s)
Fixes #6089
I also think I discovered #6104 while making this change.
