### PR TITLE
Added a hint SDL_HINT_MOUSE_RELATIVE_SYSTEM_SCALE to control whether …

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -1107,6 +1107,17 @@ extern "C" {
 #define SDL_HINT_MOUSE_RELATIVE_SPEED_SCALE    "SDL_MOUSE_RELATIVE_SPEED_SCALE"
 
 /**
+ *  \brief  A variable controlling whether the system mouse acceleration curve is used for relative mouse motion.
+ *
+ *  This variable can be set to the following values:
+ *    "0"       - Relative mouse motion will be unscaled (the default)
+ *    "1"       - Relative mouse motion will be scaled using the system mouse acceleration curve.
+ *
+ *    If SDL_HINT_MOUSE_RELATIVE_SPEED_SCALE is set, that will override the system speed scale.
+ */
+#define SDL_HINT_MOUSE_RELATIVE_SYSTEM_SCALE    "SDL_MOUSE_RELATIVE_SYSTEM_SCALE"
+
+/**
  *  \brief  A variable controlling whether a motion event should be generated for mouse warping in relative mode.
  *
  *  This variable can be set to the following values:

--- a/src/events/SDL_mouse_c.h
+++ b/src/events/SDL_mouse_c.h
@@ -92,8 +92,13 @@ typedef struct
     SDL_bool relative_mode;
     SDL_bool relative_mode_warp;
     SDL_bool relative_mode_warp_motion;
+    SDL_bool enable_normal_speed_scale;
     float normal_speed_scale;
+    SDL_bool enable_relative_speed_scale;
     float relative_speed_scale;
+    SDL_bool enable_relative_system_scale;
+    int num_system_scale_values;
+    float *system_scale_values;
     float scale_accum_x;
     float scale_accum_y;
     Uint32 double_click_time;
@@ -140,6 +145,9 @@ extern void SDL_SetMouseFocus(SDL_Window * window);
 
 /* Update the mouse capture window */
 extern int SDL_UpdateMouseCapture(SDL_bool force_release);
+
+/* You can set either a single scale, or a set of {speed, scale} values in sorted order */
+extern int SDL_SetMouseSystemScale(int num_values, const float *values);
 
 /* Send a mouse motion event */
 extern int SDL_SendMouseMotion(SDL_Window * window, SDL_MouseID mouseID, int relative, int x, int y);

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1628,6 +1628,13 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
             return 0;
         }
         break;
+
+    case WM_SETTINGCHANGE:
+        if (wParam == SPI_SETMOUSE || wParam == SPI_SETMOUSESPEED) {
+            WIN_UpdateMouseSystemScale();
+        }
+        break;
+
 #endif /*!defined(__XBOXONE__) && !defined(__XBOXSERIES__)*/
     }
 

--- a/src/video/windows/SDL_windowsmouse.h
+++ b/src/video/windows/SDL_windowsmouse.h
@@ -29,6 +29,7 @@ extern HCURSOR SDL_cursor;
 extern void WIN_InitMouse(_THIS);
 extern void WIN_QuitMouse(_THIS);
 extern void WIN_SetCursorPos(int x, int y);
+extern void WIN_UpdateMouseSystemScale();
 
 #endif /* SDL_windowsmouse_h_ */
 


### PR DESCRIPTION
…to use system mouse acceleration on raw relative motion.

This is currently only implemented on Windows, and "Enhanced pointer
precision" mode is not quite correct.
