### PR TITLE
.editorconfig: Use correct path for wayland-protocols

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -63,7 +63,7 @@ indent_style = space
 [src/video/yuv2rgb/*.{c,h}]
 indent_style = tab
 
-[src/wayland-protocols/*.xml]
+[wayland-protocols/*.xml]
 indent_size = 2
 indent_style = space
 


### PR DESCRIPTION
The Wayland protocol XML files are stored in the root directory of SDL
and not in `src`.

---

This is just a minor fix for editconfig.
