### PR TITLE
[PS2] Main Driver - Disable `fileXio` and patch `fio`

### DIFF
--- a/src/main/ps2/SDL_ps2_main.c
+++ b/src/main/ps2/SDL_ps2_main.c
@@ -38,10 +38,10 @@ static void prepare_IOP()
     SifInitRpc(0);
     sbv_patch_enable_lmb();
     sbv_patch_disable_prefix_check();
+    sbv_patch_fileio();
 }
 
 static void init_drivers() {
-    init_fileXio_driver();
     init_memcard_driver(true);
     init_usb_driver(true);
 }
@@ -49,7 +49,6 @@ static void init_drivers() {
 static void deinit_drivers() {
     deinit_usb_driver(true);
     deinit_memcard_driver(true);
-    deinit_fileXio_driver();
 }
 
 static void waitUntilDeviceIsReady(char *path)


### PR DESCRIPTION
I have decided for now to disable `fileXio` because it is unstable and has some issues in the PS2 toolchain that need to be fixed, so for now we are going to use `fio` meanwhile issues in the toolchain are fixed.