### PR TITLE
Fix building with SDL_DISABLE_WINDOWS_IME

### DIFF
--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -54,6 +54,7 @@ static SDL_bool IME_IsTextInputShown(SDL_VideoData* videodata);
 void
 WIN_InitKeyboard(_THIS)
 {
+#ifndef SDL_DISABLE_WINDOWS_IME
     SDL_VideoData *data = (SDL_VideoData *) _this->driverdata;
 
     data->ime_com_initialized = SDL_FALSE;
@@ -101,6 +102,7 @@ WIN_InitKeyboard(_THIS)
     data->ime_convmodesinkcookie = TF_INVALID_COOKIE;
     data->ime_uielemsink = 0;
     data->ime_ippasink = 0;
+#endif /* !SDL_DISABLE_WINDOWS_IME */
 
     WIN_UpdateKeymap(SDL_FALSE);
 
@@ -162,12 +164,12 @@ WIN_QuitKeyboard(_THIS)
 
 #ifndef SDL_DISABLE_WINDOWS_IME
     IME_Quit(data);
-#endif
 
     if (data->ime_composition) {
         SDL_free(data->ime_composition);
         data->ime_composition = NULL;
     }
+#endif /* !SDL_DISABLE_WINDOWS_IME */
 }
 
 void
@@ -252,6 +254,7 @@ WIN_SetTextInputRect(_THIS, const SDL_Rect *rect)
         return;
     }
 
+#ifndef SDL_DISABLE_WINDOWS_IME
     videodata->ime_rect = *rect;
 
     himc = ImmGetContext(videodata->ime_hwnd_current);
@@ -281,6 +284,7 @@ WIN_SetTextInputRect(_THIS, const SDL_Rect *rect)
 
         ImmReleaseContext(videodata->ime_hwnd_current, himc);
     }
+#endif /* !SDL_DISABLE_WINDOWS_IME */
 }
 
 


### PR DESCRIPTION
Regression of https://github.com/libsdl-org/SDL/commit/f317d619ccd22e60cebf1b09d716d3985359c981#diff-bff8f3e638d51e86cb6f0f42e2c527549d649951b7aa5ec4a539e865a5b57027R398

Tested on Visual Studio 2019