### PR TITLE
autotools: Require GNU sort

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,6 +70,9 @@ if [ test -z "$AWK" ]; then
     AC_MSG_ERROR([*** awk not found, aborting])
 fi
 
+AC_CHECK_PROGS([SORT], [gsort sort], [false])
+AS_IF([! "$SORT" -V </dev/null >/dev/null], [AC_MSG_ERROR([GNU sort(1) is required])])
+
 dnl 64-bit file offsets if possible unless --disable-largefile is specified
 AC_SYS_LARGEFILE
 
@@ -186,7 +189,7 @@ find_lib()
         host_lib_path="/usr/$base_libdir /usr/local/$base_libdir"
     fi
     for path in $env_lib_path $gcc_bin_path $gcc_lib_path $host_lib_path; do
-        lib=[`ls -- $path/$1 2>/dev/null | sed 's,.*/,,' | sort -V -r | $AWK 'BEGIN{FS="."}{ print NF, $0 }' | sort -n -s | sed 's,[0-9]* ,,' | head -1`]
+        lib=[`ls -- $path/$1 2>/dev/null | sed 's,.*/,,' | "$SORT" -V -r | $AWK 'BEGIN{FS="."}{ print NF, $0 }' | "$SORT" -n -s | sed 's,[0-9]* ,,' | head -1`]
         if test x$lib != x; then
             echo $lib
             return


### PR DESCRIPTION
find_lib() uses sort -V, which is a GNU extension. Users of non-GNU
operating systems should either install GNU coreutils (assumed to
provide a gsort executable), or use the CMake build system.

Resolves: https://github.com/libsdl-org/SDL/issues/6106
