### PR TITLE
dbus: Use xdg-desktop-portal Inhibit when running under Flatpak or Snap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1495,6 +1495,7 @@ elseif(UNIX AND NOT APPLE AND NOT RISCOS AND NOT HAIKU)
     # Always compiled for Linux, unconditionally:
     list(APPEND SOURCE_FILES "${SDL2_SOURCE_DIR}/src/core/linux/SDL_evdev_capabilities.c")
     list(APPEND SOURCE_FILES "${SDL2_SOURCE_DIR}/src/core/linux/SDL_threadprio.c")
+    list(APPEND SOURCE_FILES "${SDL2_SOURCE_DIR}/src/core/linux/SDL_sandbox.c")
 
     # src/core/unix/*.c is included in a generic if(UNIX) section, elsewhere.
   endif()

--- a/configure
+++ b/configure
@@ -28536,6 +28536,7 @@ printf "%s\n" "#define SDL_TIMER_UNIX 1" >>confdefs.h
         # Set up other core UNIX files
         SOURCES="$SOURCES $srcdir/src/core/linux/SDL_evdev_capabilities.c"
         SOURCES="$SOURCES $srcdir/src/core/linux/SDL_threadprio.c"
+        SOURCES="$SOURCES $srcdir/src/core/linux/SDL_sandbox.c"
         SOURCES="$SOURCES $srcdir/src/core/unix/*.c"
         ;;
     *-*-cygwin* | *-*-mingw*)

--- a/configure.ac
+++ b/configure.ac
@@ -3952,6 +3952,7 @@ case "$host" in
         # Set up other core UNIX files
         SOURCES="$SOURCES $srcdir/src/core/linux/SDL_evdev_capabilities.c"
         SOURCES="$SOURCES $srcdir/src/core/linux/SDL_threadprio.c"
+        SOURCES="$SOURCES $srcdir/src/core/linux/SDL_sandbox.c"
         SOURCES="$SOURCES $srcdir/src/core/unix/*.c"
         ;;
     *-*-cygwin* | *-*-mingw*)

--- a/src/core/linux/SDL_dbus.c
+++ b/src/core/linux/SDL_dbus.c
@@ -22,6 +22,7 @@
 #include "SDL_hints.h"
 #include "SDL_dbus.h"
 #include "SDL_atomic.h"
+#include "SDL_sandbox.h"
 #include "../../stdlib/SDL_vacopy.h"
 
 #if SDL_USE_LIBDBUS
@@ -29,6 +30,7 @@
 #include "SDL_loadso.h"
 static const char *dbus_library = "libdbus-1.so.3";
 static void *dbus_handle = NULL;
+static char *inhibit_handle = NULL;
 static unsigned int screensaver_cookie = 0;
 static SDL_DBusContext dbus;
 
@@ -192,6 +194,8 @@ SDL_DBus_Quit(void)
 #endif
     SDL_zero(dbus);
     UnloadDBUSLibrary();
+    SDL_free(inhibit_handle);
+    inhibit_handle = NULL;
 }
 
 SDL_DBusContext *
@@ -363,20 +367,108 @@ SDL_DBus_QueryProperty(const char *node, const char *path, const char *interface
 void
 SDL_DBus_ScreensaverTickle(void)
 {
-    if (screensaver_cookie == 0) {  /* no need to tickle if we're inhibiting. */
+    if (screensaver_cookie == 0 && inhibit_handle == NULL) {  /* no need to tickle if we're inhibiting. */
         /* org.gnome.ScreenSaver is the legacy interface, but it'll either do nothing or just be a second harmless tickle on newer systems, so we leave it for now. */
         SDL_DBus_CallVoidMethod("org.gnome.ScreenSaver", "/org/gnome/ScreenSaver", "org.gnome.ScreenSaver", "SimulateUserActivity", DBUS_TYPE_INVALID);
         SDL_DBus_CallVoidMethod("org.freedesktop.ScreenSaver", "/org/freedesktop/ScreenSaver", "org.freedesktop.ScreenSaver", "SimulateUserActivity", DBUS_TYPE_INVALID);
     }
 }
 
+static SDL_bool
+SDL_DBus_AppendDictWithKeyValue(DBusMessageIter *iterInit, const char *key, const char *value)
+{
+    DBusMessageIter iterDict, iterEntry, iterValue;
+
+    if (!dbus.message_iter_open_container(iterInit, DBUS_TYPE_ARRAY, "{sv}", &iterDict))
+        goto failed;
+
+    if (!dbus.message_iter_open_container(&iterDict, DBUS_TYPE_DICT_ENTRY, NULL, &iterEntry))
+        goto failed;
+
+    if (!dbus.message_iter_append_basic(&iterEntry, DBUS_TYPE_STRING, &key))
+        goto failed;
+
+    if (!dbus.message_iter_open_container(&iterEntry, DBUS_TYPE_VARIANT, DBUS_TYPE_STRING_AS_STRING, &iterValue))
+        goto failed;
+
+    if (!dbus.message_iter_append_basic(&iterValue, DBUS_TYPE_STRING, &value))
+        goto failed;
+
+    if (!dbus.message_iter_close_container(&iterEntry, &iterValue)
+        || !dbus.message_iter_close_container(&iterDict, &iterEntry)
+        || !dbus.message_iter_close_container(iterInit, &iterDict)) {
+        goto failed;
+    }
+
+    return SDL_TRUE;
+
+failed:
+    /* message_iter_abandon_container_if_open() and message_iter_abandon_container() might be
+     * missing if libdbus is too old. Instead, we just return without cleaning up any eventual
+     * open container */
+    return SDL_FALSE;
+}
+
 SDL_bool
 SDL_DBus_ScreensaverInhibit(SDL_bool inhibit)
 {
-    if ( (inhibit && (screensaver_cookie != 0)) || (!inhibit && (screensaver_cookie == 0)) ) {
+    const char *default_inhibit_reason = "Playing a game";
+
+    if ( (inhibit && (screensaver_cookie != 0 || inhibit_handle != NULL))
+        || (!inhibit && (screensaver_cookie == 0 && inhibit_handle == NULL)) ) {
         return SDL_TRUE;
+    }
+
+    if (SDL_DetectSandbox() != SDL_SANDBOX_NONE) {
+        const char *bus_name = "org.freedesktop.portal.Desktop";
+        const char *path = "/org/freedesktop/portal/desktop";
+        const char *interface = "org.freedesktop.portal.Inhibit";
+        const char *window = ""; /* As a future improvement we could gather the X11 XID or Wayland surface identifier */
+        static const unsigned int INHIBIT_IDLE = 8; /* Taken from the portal API reference */
+        DBusMessageIter iterInit;
+
+        if (inhibit) {
+            DBusMessage *msg;
+            SDL_bool retval = SDL_FALSE;
+            const char *key = "reason";
+            const char *reply = NULL;
+            const char *reason = SDL_GetHint(SDL_HINT_SCREENSAVER_INHIBIT_ACTIVITY_NAME);
+            if (!reason || !reason[0]) {
+                reason = default_inhibit_reason;
+            }
+
+            msg = dbus.message_new_method_call(bus_name, path, interface, "Inhibit");
+            if (!msg) {
+                return SDL_FALSE;
+            }
+
+            if (!dbus.message_append_args(msg, DBUS_TYPE_STRING, &window, DBUS_TYPE_UINT32, &INHIBIT_IDLE, DBUS_TYPE_INVALID)) {
+                dbus.message_unref(msg);
+                return SDL_FALSE;
+            }
+
+            dbus.message_iter_init_append(msg, &iterInit);
+            if (!SDL_DBus_AppendDictWithKeyValue(&iterInit, key, reason)) {
+                dbus.message_unref(msg);
+                return SDL_FALSE;
+            }
+
+            if (SDL_DBus_CallWithBasicReply(dbus.session_conn, msg, DBUS_TYPE_OBJECT_PATH, &reply)) {
+                inhibit_handle = SDL_strdup(reply);
+                retval = SDL_TRUE;
+            }
+
+            dbus.message_unref(msg);
+            return retval;
+        } else {
+            if (!SDL_DBus_CallVoidMethod(bus_name, inhibit_handle, "org.freedesktop.portal.Request", "Close", DBUS_TYPE_INVALID)) {
+                return SDL_FALSE;
+            }
+            SDL_free(inhibit_handle);
+            inhibit_handle = NULL;
+        }
     } else {
-        const char *node = "org.freedesktop.ScreenSaver";
+        const char *bus_name = "org.freedesktop.ScreenSaver";
         const char *path = "/org/freedesktop/ScreenSaver";
         const char *interface = "org.freedesktop.ScreenSaver";
 
@@ -387,17 +479,17 @@ SDL_DBus_ScreensaverInhibit(SDL_bool inhibit)
                app  = "My SDL application";
             }
             if (!reason || !reason[0]) {
-                reason = "Playing a game";
+                reason = default_inhibit_reason;
             }
 
-            if (!SDL_DBus_CallMethod(node, path, interface, "Inhibit",
+            if (!SDL_DBus_CallMethod(bus_name, path, interface, "Inhibit",
                     DBUS_TYPE_STRING, &app, DBUS_TYPE_STRING, &reason, DBUS_TYPE_INVALID,
                     DBUS_TYPE_UINT32, &screensaver_cookie, DBUS_TYPE_INVALID)) {
                 return SDL_FALSE;
             }
             return (screensaver_cookie != 0) ? SDL_TRUE : SDL_FALSE;
         } else {
-            if (!SDL_DBus_CallVoidMethod(node, path, interface, "UnInhibit", DBUS_TYPE_UINT32, &screensaver_cookie, DBUS_TYPE_INVALID)) {
+            if (!SDL_DBus_CallVoidMethod(bus_name, path, interface, "UnInhibit", DBUS_TYPE_UINT32, &screensaver_cookie, DBUS_TYPE_INVALID)) {
                 return SDL_FALSE;
             }
             screensaver_cookie = 0;

--- a/src/core/linux/SDL_sandbox.c
+++ b/src/core/linux/SDL_sandbox.c
@@ -1,0 +1,50 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2022 Sam Lantinga <slouken@libsdl.org>
+  Copyright (C) 2022 Collabora Ltd.
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+
+#include "../../SDL_internal.h"
+#include "SDL_sandbox.h"
+
+#include <unistd.h>
+
+SDL_Sandbox SDL_DetectSandbox(void)
+{
+    if (access("/.flatpak-info", F_OK) == 0) {
+        return SDL_SANDBOX_FLATPAK;
+    }
+
+    /* For Snap, we check multiple variables because they might be set for
+     * unrelated reasons. This is the same thing WebKitGTK does. */
+    if (SDL_getenv("SNAP") != NULL
+        && SDL_getenv("SNAP_NAME") != NULL
+        && SDL_getenv("SNAP_REVISION") != NULL) {
+        return SDL_SANDBOX_SNAP;
+    }
+
+    if (access("/run/host/container-runtime", F_OK) == 0) {
+        return SDL_SANDBOX_UNKNOWN_CONTAINER;
+    }
+
+    return SDL_SANDBOX_NONE;
+}
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/src/core/linux/SDL_sandbox.h
+++ b/src/core/linux/SDL_sandbox.h
@@ -1,0 +1,39 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2022 Sam Lantinga <slouken@libsdl.org>
+  Copyright (C) 2022 Collabora Ltd.
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDL_SANDBOX_H
+#define SDL_SANDBOX_H
+
+typedef enum
+{
+    SDL_SANDBOX_NONE = 0,
+    SDL_SANDBOX_UNKNOWN_CONTAINER,
+    SDL_SANDBOX_FLATPAK,
+    SDL_SANDBOX_SNAP,
+} SDL_Sandbox;
+
+/* Return the sandbox type currently in use, if any */
+SDL_Sandbox SDL_DetectSandbox(void);
+
+#endif /* SDL_SANDBOX_H */
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/src/hidapi/SDL_hidapi.c
+++ b/src/hidapi/SDL_hidapi.c
@@ -53,6 +53,7 @@
 #ifdef SDL_USE_LIBUDEV
 #include <poll.h>
 #include <unistd.h>
+#include "../core/linux/SDL_sandbox.h"
 #endif
 
 #ifdef HAVE_INOTIFY
@@ -1018,11 +1019,7 @@ int SDL_hid_init(void)
         SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
                      "udev disabled by SDL_HIDAPI_JOYSTICK_DISABLE_UDEV");
         linux_enumeration_method = ENUMERATION_FALLBACK;
-    } else if (access("/.flatpak-info", F_OK) == 0
-               || access("/run/host/container-manager", F_OK) == 0) {
-        /* Explicitly check `/.flatpak-info` because, for old versions of
-         * Flatpak, this was the only available way to tell if we were in
-         * a Flatpak container. */
+    } else if (SDL_DetectSandbox() != SDL_SANDBOX_NONE) {
         SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
                      "Container detected, disabling HIDAPI udev integration");
         linux_enumeration_method = ENUMERATION_FALLBACK;

--- a/src/joystick/hidapi/SDL_hidapijoystick.c
+++ b/src/joystick/hidapi/SDL_hidapijoystick.c
@@ -36,6 +36,9 @@
 #include "../windows/SDL_rawinputjoystick_c.h"
 #endif
 
+#ifdef SDL_USE_LIBUDEV
+#include "../../core/linux/SDL_sandbox.h"
+#endif
 
 struct joystick_hwdata
 {
@@ -395,11 +398,7 @@ HIDAPI_JoystickInit(void)
             SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
                          "udev disabled by SDL_HIDAPI_JOYSTICK_DISABLE_UDEV");
             linux_enumeration_method = ENUMERATION_FALLBACK;
-        } else if (access("/.flatpak-info", F_OK) == 0
-                   || access("/run/host/container-manager", F_OK) == 0) {
-            /* Explicitly check `/.flatpak-info` because, for old versions of
-             * Flatpak, this was the only available way to tell if we were in
-             * a Flatpak container. */
+        } else if (SDL_DetectSandbox() != SDL_SANDBOX_NONE) {
             SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
                          "Container detected, disabling HIDAPI udev integration");
             linux_enumeration_method = ENUMERATION_FALLBACK;

--- a/src/joystick/linux/SDL_sysjoystick.c
+++ b/src/joystick/linux/SDL_sysjoystick.c
@@ -77,6 +77,7 @@
 
 #include "../../core/linux/SDL_evdev_capabilities.h"
 #include "../../core/linux/SDL_udev.h"
+#include "../../core/linux/SDL_sandbox.h"
 
 #if 0
 #define DEBUG_INPUT_EVENTS 1
@@ -772,12 +773,7 @@ LINUX_JoystickInit(void)
             SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
                          "udev disabled by SDL_JOYSTICK_DISABLE_UDEV");
             enumeration_method = ENUMERATION_FALLBACK;
-
-        } else if (access("/.flatpak-info", F_OK) == 0
-                 || access("/run/host/container-manager", F_OK) == 0) {
-            /* Explicitly check `/.flatpak-info` because, for old versions of
-             * Flatpak, this was the only available way to tell if we were in
-             * a Flatpak container. */
+        } else if (SDL_DetectSandbox() != SDL_SANDBOX_NONE) {
             SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
                          "Container detected, disabling udev integration");
             enumeration_method = ENUMERATION_FALLBACK;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In order to inhibit the screen saver, SDL currently uses
`org.freedesktop.ScreenSaver.Inhibit()` and, as a fallback, a protocol
specific method for X11 or Wayland.

Accessing `org.freedesktop.ScreenSaver` is usually not allowed when
inside a sandbox like Flatpak, unless the permission has been explicitly
granted to the application.

Another issue is that the Wayland protocol "Idle inhibit" is relatively
new and not yet widely adopted. For example Mutter still doesn't support
it.

For those reasons, when running under Flatpak or Snap, we should try to
inhibit the screen saver by using xdg-desktop-portal instead. This
should give us an higher chance of success.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/6075

/cc @smcv 
