### PR TITLE
Added new hint: SDL_HINT_EMSCRIPTEN_CANVAS_ELEMENT

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -367,6 +367,18 @@ extern "C" {
 #define SDL_HINT_EMSCRIPTEN_ASYNCIFY   "SDL_EMSCRIPTEN_ASYNCIFY"
 
 /**
+ *  \brief override the canvas element for Emscripten builds
+ *
+ * This hint only applies to the emscripten platform
+ * and must be set before calling SDL_CreateWindow()
+ *
+ * The variable can be set to a string valid for
+ * document.querySelector(), e.g. #canvas
+ *
+ */
+#define SDL_HINT_EMSCRIPTEN_CANVAS_ELEMENT   "SDL_EMSCRIPTEN_CANVAS_ELEMENT"
+
+/**
  *  \brief override the binding element for keyboard inputs for Emscripten builds
  *
  * This hint only applies to the emscripten platform

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -218,6 +218,7 @@ Emscripten_CreateWindow(_THIS, SDL_Window * window)
     SDL_WindowData *wdata;
     double scaled_w, scaled_h;
     double css_w, css_h;
+    const char *canvasElement = SDL_GetHint(SDL_HINT_EMSCRIPTEN_CANVAS_ELEMENT);
 
     /* Allocate window internal data */
     wdata = (SDL_WindowData *) SDL_calloc(1, sizeof(SDL_WindowData));
@@ -225,7 +226,11 @@ Emscripten_CreateWindow(_THIS, SDL_Window * window)
         return SDL_OutOfMemory();
     }
 
-    wdata->canvas_id = SDL_strdup("#canvas");
+    if (canvasElement) {
+        wdata->canvas_id = SDL_strdup(canvasElement);
+    } else {
+        wdata->canvas_id = SDL_strdup("#canvas");
+    }
 
     if (window->flags & SDL_WINDOW_ALLOW_HIGHDPI) {
         wdata->pixel_ratio = emscripten_get_device_pixel_ratio();


### PR DESCRIPTION
This helps emscripten to find the canvas HTML element

## Description
This patch add the possibility to specify the canvas using a new hint SDL_HINT_EMSCRIPTEN_CANVAS_ELEMENT

## Existing Issue(s)
fixes #5260

Non related, a strange side effect while testing the patch, calling `SDL_CreateWindow` with an overside dimension takes the path (I've added an fprintf before):

```c
    /* Some platforms blow up if the windows are too large. Raise it later? */
    if ((w > 16384) || (h > 16384)) {
        SDL_SetError("Window is too large.");
        return NULL;
    }
```

but `SDL_GetError()` returns `SDL not built with thread support`, that is the output of `SDL_CreateSemaphore()` in `src/thread/generic/SDL_syssem.c`, I don't known who calls it, perhaps I may make a PR that prefixes the name of the function called in that file

The only possible caller looks like `SDL_TimerInit()`, but

```c
#if !defined(__EMSCRIPTEN__) || !SDL_THREADS_DISABLED
```
that shouldn't be compiled in