### PR TITLE
windows: fix monitor name enumeration

### DIFF
--- a/src/video/windows/SDL_windowsmodes.c
+++ b/src/video/windows/SDL_windowsmodes.c
@@ -256,6 +256,7 @@ WIN_GetDisplayNameVista(const WCHAR *deviceName)
             sourceName.header.adapterId = paths[i].targetInfo.adapterId;
             sourceName.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME;
             sourceName.header.size = sizeof (sourceName);
+            sourceName.header.id = paths[i].sourceInfo.id;
             rc = pDisplayConfigGetDeviceInfo(&sourceName.header);
             if (rc != ERROR_SUCCESS) {
                 break;


### PR DESCRIPTION
This was getting the wrong monitor's name because the source identifier was not being included in the DisplayConfigGetDeviceInfo request.

In my case, this ended up showing my first monitor's name twice, instead of showing two different monitor names.