### PR TITLE
WGI: move check against HIDAPI after WINDOWS

### DIFF
--- a/src/joystick/windows/SDL_windows_gaming_input.c
+++ b/src/joystick/windows/SDL_windows_gaming_input.c
@@ -320,12 +320,6 @@ static HRESULT STDMETHODCALLTYPE IEventHandler_CRawGameControllerVtbl_InvokeAdde
         /* FIXME: Is there any way to tell whether this is a Bluetooth device? */
         guid = SDL_CreateJoystickGUID(SDL_HARDWARE_BUS_USB, vendor, product, version, name, 'w', (Uint8)type);
 
-#ifdef SDL_JOYSTICK_HIDAPI
-        if (!ignore_joystick && HIDAPI_IsDevicePresent(vendor, product, version, name)) {
-            ignore_joystick = SDL_TRUE;
-        }
-#endif
-
 #ifdef SDL_JOYSTICK_RAWINPUT
         if (!ignore_joystick && RAWINPUT_IsDevicePresent(vendor, product, version, name)) {
             ignore_joystick = SDL_TRUE;
@@ -339,6 +333,12 @@ static HRESULT STDMETHODCALLTYPE IEventHandler_CRawGameControllerVtbl_InvokeAdde
         if (!ignore_joystick && SDL_IsXInputDevice(vendor, product)) {
             ignore_joystick = SDL_TRUE;
         }
+
+#ifdef SDL_JOYSTICK_HIDAPI
+        if (!ignore_joystick && HIDAPI_IsDevicePresent(vendor, product, version, name)) {
+            ignore_joystick = SDL_TRUE;
+        }
+#endif
 
         if (!ignore_joystick && SDL_ShouldIgnoreJoystick(name, guid)) {
             ignore_joystick = SDL_TRUE;


### PR DESCRIPTION
WINDOWS driver may have already added a joystick
for a given device, and HIDAPI_IsDevicePresent
will add it again.

## Description
I ran into a problem where SDL_JOYDEVICEADDED would be emitted twice when plugging in a device. It turned out this is because the WINDOWS joystick driver would first do so, followed by HIDAPI driver (from the WGI path).

I'm not sure if this is a proper fix (i.e. if there is some reason for the order of the existing IsPresent checks), but it seems to work.
