### PR TITLE
Check build-time SDK in LoadMainMenuNibIfAvailable

### DIFF
--- a/src/video/cocoa/SDL_cocoaevents.m
+++ b/src/video/cocoa/SDL_cocoaevents.m
@@ -333,6 +333,7 @@ GetApplicationName(void)
 static bool
 LoadMainMenuNibIfAvailable(void)
 {
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1080
     NSDictionary *infoDict;
     NSString *mainNibFileName;
     bool success = false;
@@ -350,6 +351,9 @@ LoadMainMenuNibIfAvailable(void)
     }
     
     return success;
+#else
+    return false;
+#endif
 }
 
 static void


### PR DESCRIPTION
Fixes building against OS X 10.7 SDK.
