### PR TITLE
Fix candidate list size for Windows IME

### DIFF
--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -1559,7 +1559,7 @@ IME_RenderCandidateList(SDL_VideoData *videodata, HDC hdc)
     SIZE candsizes[MAX_CANDLIST];
     SIZE maxcandsize = {0};
     HBITMAP hbm = NULL;
-    const int candcount = SDL_min(SDL_min(MAX_CANDLIST, videodata->ime_candcount), videodata->ime_candpgsize);
+    int candcount = SDL_min(SDL_min(MAX_CANDLIST, videodata->ime_candcount), videodata->ime_candpgsize);
     SDL_bool vertical = videodata->ime_candvertical;
 
     const int listborder = 1;
@@ -1591,8 +1591,10 @@ IME_RenderCandidateList(SDL_VideoData *videodata, HDC hdc)
 
     for (i = 0; i < candcount; ++i) {
         const WCHAR *s = &videodata->ime_candidates[i * MAX_CANDLENGTH];
-        if (!*s)
+        if (!*s) {
+            candcount = i;
             break;
+        }
 
         GetTextExtentPoint32W(hdc, s, (int)SDL_wcslen(s), &candsizes[i]);
         maxcandsize.cx = SDL_max(maxcandsize.cx, candsizes[i].cx);
@@ -1654,8 +1656,6 @@ IME_RenderCandidateList(SDL_VideoData *videodata, HDC hdc)
     for (i = 0; i < candcount; ++i) {
         const WCHAR *s = &videodata->ime_candidates[i * MAX_CANDLENGTH];
         int left, top, right, bottom;
-        if (!*s)
-            break;
 
         if (vertical) {
             left = listborder + listpadding + candmargin;


### PR DESCRIPTION
## Description

Adjust candidate count so list is not draw bigger that needed. This also fix potential uninitialised read of variable `candsize[i]` if `vertical` is false on line 1631.
I did not test this and i am not sure how a candidate could be an empty string.

## Existing Issue(s)
None
