### PR TITLE
CMake: Make SDL_SHARED/STATIC/TEST options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,9 +507,9 @@ dep_option(SDL_HIDAPI_JOYSTICK     "Use HIDAPI for low level joystick drivers" O
 dep_option(SDL_VIRTUAL_JOYSTICK    "Enable the virtual-joystick driver" ON SDL_HIDAPI OFF)
 set_option(SDL_ASAN                "Use AddressSanitizer to detect memory errors" OFF)
 
-set(SDL_SHARED ${SDL_SHARED_ENABLED_BY_DEFAULT} CACHE BOOL "Build a shared version of the library")
-set(SDL_STATIC ${SDL_STATIC_ENABLED_BY_DEFAULT} CACHE BOOL "Build a static version of the library")
-set(SDL_TEST   ${SDL_TEST_ENABLED_BY_DEFAULT} CACHE BOOL "Build the SDL2_test library")
+option(SDL_SHARED "Build a shared version of the library" ${SDL_SHARED_ENABLED_BY_DEFAULT})
+option(SDL_STATIC "Build a static version of the library" ${SDL_STATIC_ENABLED_BY_DEFAULT})
+option(SDL_TEST   "Build the SDL2_test library" ${SDL_TEST_ENABLED_BY_DEFAULT})
 
 dep_option(SDL_STATIC_PIC      "Static version of the library should be built with Position Independent Code" "${CMAKE_POSITION_INDEPENDENT_CODE}" "SDL_STATIC" OFF)
 dep_option(SDL_TESTS           "Build the test directory" OFF SDL_TEST OFF)


### PR DESCRIPTION
This makes it easier to set these options when SDL is used as a subproject.
Since CMake v3.13+, one can simply `set(SDL_TEST OFF)` before include the SDL2 subproject because options do not override existing variables. (https://cmake.org/cmake/help/latest/policy/CMP0077.html)
This is also true for `set(CACHE)` commands but only in CMake v3.21+ (https://cmake.org/cmake/help/latest/policy/CMP0126.html).