### PR TITLE
tests: Add SDL_GetError() check to testsprite2 main loop.

### DIFF
--- a/test/testsprite2.c
+++ b/test/testsprite2.c
@@ -401,6 +401,7 @@ loop()
     Uint32 now;
     int i;
     SDL_Event event;
+    const char *sdlerror;
 
     /* Check for events */
     while (SDL_PollEvent(&event)) {
@@ -428,6 +429,12 @@ loop()
         frames = 0;
     }
 
+    /* Check for errors */
+    sdlerror = SDL_GetError();
+    if (sdlerror && *sdlerror) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", sdlerror);
+        quit(3);
+    }
 }
 
 int


### PR DESCRIPTION
## Description

Before this change, `./testsprite2 --renderer opengles2` would
happily go on to render a blank screen, even though the GLES2
shader code does not compile.

After this change, instead the test terminates with

```bash
$ ./testsprite2 --renderer opengles2
ERROR: Failed to load the shader: 0(2) : error C0105: Syntax error in #if
0(2) : error C0105: Syntax error in #if
```

Perhaps something like this should instead be done as part of some
common test code for even broader coverage, but I'll leave that
to the maintainers to decide.

## Existing Issue(s)

Relates to #6166
