### PR TITLE
Silence Fn/XF86WakeUp key messages on some Lenovo keyboards

### DIFF
--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -28,6 +28,8 @@
 #include <unistd.h>
 #include <limits.h> /* For INT_MAX */
 
+#include <X11/XF86keysym.h> /* For XF86XK_WakeUp */
+
 #include "SDL_x11video.h"
 #include "SDL_x11touch.h"
 #include "SDL_x11xinput2.h"
@@ -1051,10 +1053,13 @@ X11_DispatchEvent(_THIS, XEvent *xevent)
                 int min_keycode, max_keycode;
                 X11_XDisplayKeycodes(display, &min_keycode, &max_keycode);
                 keysym = X11_KeyCodeToSym(_this, keycode, xevent->xkey.state >> 13);
-                fprintf(stderr,
-                        "The key you just pressed is not recognized by SDL. To help get this fixed, please report this to the SDL forums/mailing list <https://discourse.libsdl.org/> X11 KeyCode %d (%d), X11 KeySym 0x%lX (%s).\n",
-                        keycode, keycode - min_keycode, keysym,
-                        X11_XKeysymToString(keysym));
+                /* Some Lenovo keyboards have an Fn key which registers as XF86WakeUp and spams this message... */
+                if (keysym != XF86XK_WakeUp) {
+                    fprintf(stderr,
+                            "The key you just pressed is not recognized by SDL. To help get this fixed, please report this to the SDL forums/mailing list <https://discourse.libsdl.org/> X11 KeyCode %d (%d), X11 KeySym 0x%lX (%s).\n",
+                            keycode, keycode - min_keycode, keysym,
+                            X11_XKeysymToString(keysym));
+                }
             }
 #endif
             /* */


### PR DESCRIPTION
## Description
I have a Lenovo ThinkPad E15 Gen 2 running Xubuntu 22.04. For almost two years now, whenever I press the Fn key on an SDL window, the following message would appear twice in the console, right in the middle of the app's own console output:

```
The key you just pressed is not recognized by SDL. To help get this fixed, please report this to the SDL forums/mailing list <https://discourse.libsdl.org/> X11 KeyCode 151 (143), X11 KeySym 0x1008FF2B (XF86WakeUp).
```

This key being visible to SDL is probably Lenovo's fault instead of SDL's, but this message is pretty annoying since I regularly use this key while changing the volume, brightness, etc (Fn+F2 for example) and every time I do that while an app that uses SDL is focused, four or six lines are visibly added to the console (each message being long enough that it wraps to two or three lines).

This issue has been reported several times before:
- #3113
- #3793
- https://discourse.libsdl.org/t/key-not-recognised-by-sdl/24181

Thus far, my solution has been to manually comment out the `fprintf` line in `src/video/x11/SDL_x11events.c` that prints the warning before compiling SDL. This is annoying to have to do every time I download a new version of SDL, only solves the problem for myself and not for anyone else, and also doesn't fix it for me when I use an AppImage that bundles SDL. So I decided to try making a somewhat better solution that could be merged upstream.

The message appears because in `src/events/scancodes_xfree86.h`, `xfree86_scancode_table2[143]` is set to `SDL_SCANCODE_UNKNOWN`. One solution would have been to set it to some other scancode (from `SDL_scancode.h`), but I don't think there's any appropriate scancode, and I don't know if I can arbitrarily define a new scancode myself. So instead, I just silence the warning if the key symbol is `XF86XK_WakeUp`. If there's a better way to solve this, please let me know.

## Existing Issue(s)
- #3113
- #3793
