### PR TITLE
test/versioning.sh also tests configure

### DIFF
--- a/test/versioning.sh
+++ b/test/versioning.sh
@@ -34,6 +34,17 @@ else
     not_ok "configure.ac $version disagrees with SDL_version.h $ref_version"
 fi
 
+major=$(sed -ne 's/^SDL_MAJOR_VERSION=//p' configure)
+minor=$(sed -ne 's/^SDL_MINOR_VERSION=//p' configure)
+micro=$(sed -ne 's/^SDL_MICRO_VERSION=//p' configure)
+version="${major}.${minor}.${micro}"
+
+if [ "$ref_version" = "$version" ]; then
+    ok "configure $version"
+else
+    not_ok "configure $version disagrees with SDL_version.h $ref_version"
+fi
+
 major=$(sed -ne 's/^set(SDL_MAJOR_VERSION \([0-9]*\))$/\1/p' CMakeLists.txt)
 minor=$(sed -ne 's/^set(SDL_MINOR_VERSION \([0-9]*\))$/\1/p' CMakeLists.txt)
 micro=$(sed -ne 's/^set(SDL_MICRO_VERSION \([0-9]*\))$/\1/p' CMakeLists.txt)


### PR DESCRIPTION
also tests for configure script version.

## Description
According to [docs/release_checklist.md](https://github.com/libsdl-org/SDL/blob/main/docs/release_checklist.md#new-feature-release), configure has to be regenerated, so if it's, it will have the correct versioning.

Since version changes in from release->development in one commit, checking this version can help to remind to regenerate the configure script.