### PR TITLE
Batch of Wayland improvements and fixes.

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1030,6 +1030,11 @@ SDL_SetDisplayModeForDisplay(SDL_VideoDisplay * display, const SDL_DisplayMode *
     SDL_DisplayMode current_mode;
     int result;
 
+    /* Mode switching disabled via driver quirk flag, nothing to do and cannot fail. */
+    if (DisableDisplayModeSwitching(_this)) {
+        return 0;
+    }
+
     if (mode) {
         display_mode = *mode;
 
@@ -1430,17 +1435,14 @@ SDL_UpdateFullscreenMode(SDL_Window * window, SDL_bool fullscreen)
                     resized = SDL_FALSE;
                 }
 
-                /* Don't try to change the display mode if the driver doesn't want it. */
-                if (DisableDisplayModeSwitching(_this) == SDL_FALSE) {
-                    /* only do the mode change if we want exclusive fullscreen */
-                    if ((window->flags & SDL_WINDOW_FULLSCREEN_DESKTOP) != SDL_WINDOW_FULLSCREEN_DESKTOP) {
-                        if (SDL_SetDisplayModeForDisplay(display, &fullscreen_mode) < 0) {
-                            return -1;
-                        }
-                    } else {
-                        if (SDL_SetDisplayModeForDisplay(display, NULL) < 0) {
-                            return -1;
-                        }
+                /* only do the mode change if we want exclusive fullscreen */
+                if ((window->flags & SDL_WINDOW_FULLSCREEN_DESKTOP) != SDL_WINDOW_FULLSCREEN_DESKTOP) {
+                    if (SDL_SetDisplayModeForDisplay(display, &fullscreen_mode) < 0) {
+                        return -1;
+                    }
+                } else {
+                    if (SDL_SetDisplayModeForDisplay(display, NULL) < 0) {
+                        return -1;
                     }
                 }
 

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -385,7 +385,7 @@ SetMinMaxDimensions(SDL_Window *window, SDL_bool commit)
 }
 
 static void
-SetFullscreen(SDL_Window *window, struct wl_output *output, SDL_bool commit)
+SetFullscreen(SDL_Window *window, struct wl_output *output)
 {
     SDL_WindowData *wind = window->driverdata;
     SDL_VideoData *viddata = wind->waylandData;
@@ -393,9 +393,7 @@ SetFullscreen(SDL_Window *window, struct wl_output *output, SDL_bool commit)
     /* Pop-ups don't get to be fullscreened */
     if (WINDOW_IS_XDG_POPUP(window)) {
         /* ... but we still want to commit, particularly for ShowWindow */
-        if (commit) {
-            wl_surface_commit(wind->surface);
-        }
+        wl_surface_commit(wind->surface);
         return;
     }
 
@@ -416,7 +414,7 @@ SetFullscreen(SDL_Window *window, struct wl_output *output, SDL_bool commit)
                  */
                 libdecor_frame_set_capabilities(wind->shell_surface.libdecor.frame, LIBDECOR_ACTION_RESIZE);
                 wl_surface_commit(wind->surface);
-            } else if (commit) {
+            } else {
                 struct libdecor_state *state = libdecor_state_new(GetWindowWidth(window), GetWindowHeight(window));
                 libdecor_frame_commit(wind->shell_surface.libdecor.frame, state, NULL);
                 libdecor_state_free(state);
@@ -431,7 +429,7 @@ SetFullscreen(SDL_Window *window, struct wl_output *output, SDL_bool commit)
                 /* restore previous RESIZE capability */
                 libdecor_frame_unset_capabilities(wind->shell_surface.libdecor.frame, LIBDECOR_ACTION_RESIZE);
                 wl_surface_commit(wind->surface);
-            } else if (commit) {
+            } else {
                 struct libdecor_state *state = libdecor_state_new(GetWindowWidth(window), GetWindowHeight(window));
                 libdecor_frame_commit(wind->shell_surface.libdecor.frame, state, NULL);
                 libdecor_state_free(state);
@@ -444,9 +442,9 @@ SetFullscreen(SDL_Window *window, struct wl_output *output, SDL_bool commit)
         if (wind->shell_surface.xdg.roleobj.toplevel == NULL) {
             return; /* Can't do anything yet, wait for ShowWindow */
         }
-        if (commit) {
-            wl_surface_commit(wind->surface);
-        }
+
+        wl_surface_commit(wind->surface);
+
         if (output) {
             xdg_toplevel_set_fullscreen(wind->shell_surface.xdg.roleobj.toplevel, output);
         } else {
@@ -1755,7 +1753,7 @@ Wayland_SetWindowFullscreen(_THIS, SDL_Window * window,
     /* Don't send redundant fullscreen set/unset events. */
     if (wind->is_fullscreen != fullscreen) {
         wind->is_fullscreen = fullscreen;
-        SetFullscreen(window, fullscreen ? output : NULL, SDL_TRUE);
+        SetFullscreen(window, fullscreen ? output : NULL);
 
         /* Roundtrip required to receive the updated window dimensions */
         WAYLAND_wl_display_roundtrip(viddata->display);

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -2156,11 +2156,7 @@ Wayland_SetWindowMaximumSize(_THIS, SDL_Window * window)
 
 void Wayland_SetWindowSize(_THIS, SDL_Window * window)
 {
-    SDL_VideoData *data = _this->driverdata;
     SDL_WindowData *wind = window->driverdata;
-#ifdef HAVE_LIBDECOR_H
-    struct libdecor_state *state;
-#endif
 
 #ifdef HAVE_LIBDECOR_H
     /* we must not resize the window while we have a static (non-floating) size */
@@ -2175,29 +2171,11 @@ void Wayland_SetWindowSize(_THIS, SDL_Window * window)
 
     /* Update the window geometry. */
     ConfigureWindowGeometry(window);
-
-#ifdef HAVE_LIBDECOR_H
-    if (WINDOW_IS_LIBDECOR(data, window) && wind->shell_surface.libdecor.frame) {
-        state = libdecor_state_new(GetWindowWidth(window), GetWindowHeight(window));
-        libdecor_frame_commit(wind->shell_surface.libdecor.frame, state, NULL);
-        libdecor_state_free(state);
-    }
-#endif
+    CommitWindowGeometry(window);
 
     /* windowed is unconditionally set, so we can trust it here */
     wind->floating_width = window->windowed.w;
     wind->floating_height = window->windowed.h;
-
-    /* Update the geometry which may have been set by a hack in Wayland_HandleResize */
-    if (
-#ifdef HAVE_LIBDECOR_H
-        !WINDOW_IS_LIBDECOR(data, window) &&
-#endif
-        data->shell.xdg &&
-        wind->shell_surface.xdg.surface) {
-        xdg_surface_set_window_geometry(wind->shell_surface.xdg.surface, 0, 0,
-                                        GetWindowWidth(window), GetWindowHeight(window));
-    }
 }
 
 void Wayland_GetWindowSizeInPixels(_THIS, SDL_Window * window, int *w, int *h)

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -2109,7 +2109,7 @@ Wayland_HandleResize(SDL_Window *window, int width, int height, float scale)
     SDL_WindowData *data = (SDL_WindowData *) window->driverdata;
     SDL_VideoData *viddata = data->waylandData;
     int old_w = window->w, old_h = window->h;
-    float old_scale = scale;
+    float old_scale = data->scale_factor;
 
     /* Update the window geometry. */
     window->w = width;

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -897,8 +897,15 @@ decoration_frame_configure(struct libdecor_frame *frame,
         height = window->windowed.h;
         wind->floating_resize_pending = SDL_FALSE;
     } else {
+        /*
+         * XXX: When hiding a floating window, libdecor can send bogus content sizes that
+         *      are +/- the height of the title bar, which distorts the window size.
+         *      Ignore any values from libdecor when hiding a floating window.
+         */
+        const SDL_bool use_cached_size = (window->is_hiding || !!(window->flags & SDL_WINDOW_HIDDEN));
+
         /* This will never set 0 for width/height unless the function returns false */
-        if (!libdecor_configuration_get_content_size(configuration, frame, &width, &height)) {
+        if (use_cached_size || !libdecor_configuration_get_content_size(configuration, frame, &width, &height)) {
             if (floating) {
                 /* This usually happens when we're being restored from a
                  * non-floating state, so use the cached floating size here.

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -132,7 +132,7 @@ FullscreenModeEmulation(SDL_Window *window)
            ((window->flags & SDL_WINDOW_FULLSCREEN_DESKTOP) != SDL_WINDOW_FULLSCREEN_DESKTOP);
 }
 
-SDL_bool
+static SDL_bool
 NeedViewport(SDL_Window *window)
 {
     SDL_WindowData        *wind   = window->driverdata;
@@ -448,7 +448,7 @@ SetFullscreen(SDL_Window *window, struct wl_output *output, SDL_bool commit)
     }
 }
 
-const struct wl_callback_listener surface_damage_frame_listener;
+static const struct wl_callback_listener surface_damage_frame_listener;
 
 static void
 surface_damage_frame_done(void *data, struct wl_callback *cb, uint32_t time)
@@ -466,7 +466,7 @@ surface_damage_frame_done(void *data, struct wl_callback *cb, uint32_t time)
     wl_callback_add_listener(wind->surface_damage_frame_callback, &surface_damage_frame_listener, data);
 }
 
-const struct wl_callback_listener surface_damage_frame_listener = {
+static const struct wl_callback_listener surface_damage_frame_listener = {
     surface_damage_frame_done
 };
 

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -107,6 +107,9 @@ typedef struct {
     SDL_Rect viewport_rect;
     SDL_bool needs_resize_event;
     SDL_bool floating_resize_pending;
+    SDL_bool is_fullscreen;
+    SDL_bool in_fullscreen_transition;
+    Uint32 fullscreen_flags;
 } SDL_WindowData;
 
 extern void Wayland_ShowWindow(_THIS, SDL_Window *window);

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -104,6 +104,7 @@ typedef struct {
     float pointer_scale_x;
     float pointer_scale_y;
     int drawable_width, drawable_height;
+    int fs_output_width, fs_output_height;
     SDL_Rect viewport_rect;
     SDL_bool needs_resize_event;
     SDL_bool floating_resize_pending;


### PR DESCRIPTION
A batch of Wayland improvements and fixes.

The big changes are additional refactoring to fullscreen handling in order to properly handle the compositor initiating a fullscreen enter/leave event, or when the compositor moves a fullscreen window between displays.  Previously, SDL's internal state wasn't being updated with these events, so the SDL window state could get out of sync with the actual window state and lead to unexpected behavior (similar to what was reported in #6153 on x11). SDL's internal fullscreen state tracking is now properly updated with externally initiated window state changes, and things like toggling fullscreen or moving fullscreen windows between displays via a desktop hotkey will now behave properly.

Aside from that, there are other small fixes:

- Add some missing `static` qualifiers.
- Commit in the Wayland backend when changing the fullscreen flags or parameters so the changes take immediate effect.
- Work around a [libdecor bug](https://gitlab.gnome.org/jadahl/libdecor/-/issues/40) that could result in a window size change when hiding a floating window.
- Fix a bug that prevented a resize event from being generated when the display scale changed.
- A change to silence some errant log messages in the video core when mode switching is disabled.
- Some other minor code cleanup in the Wayland backend (a function parameter was no longer needed and some common code was moved to a separate function).