### PR TITLE
android: fix some compiler warnings

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_wii.c
+++ b/src/joystick/hidapi/SDL_hidapi_wii.c
@@ -730,7 +730,6 @@ UpdateDeviceIdentity(SDL_HIDAPI_Device *device)
         case k_eWiiExtensionControllerType_Gamepad:
             name = "Nintendo Wii Remote with Classic Controller";
             break;
-            break;
         case k_eWiiExtensionControllerType_WiiUPro:
             name = "Nintendo Wii U Pro Controller";
             break;

--- a/src/render/opengles2/SDL_shaders_gles2.h
+++ b/src/render/opengles2/SDL_shaders_gles2.h
@@ -63,7 +63,7 @@ typedef enum
 
 const Uint8 *GLES2_GetShader(GLES2_ShaderType type);
 const Uint8 *GLES2_GetShaderInclude(GLES2_ShaderIncludeType type);
-GLES2_ShaderIncludeType GLES2_GetTexCoordPrecisionEnumFromHint();
+GLES2_ShaderIncludeType GLES2_GetTexCoordPrecisionEnumFromHint(void);
 
 #endif /* SDL_VIDEO_RENDER_OGL_ES2 */
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed two warnings which occurs in android build process
```
src/joystick/hidapi/SDL_hidapi_wii.c:733:13: warning: 'break' will never be executed [-Wunreachable-code-break]
            break;
            ^~~~~
src/render/opengles2/SDL_shaders_gles2.h:66:63: warning: this function declaration is not a prototype [-Wstrict-prototypes]
GLES2_ShaderIncludeType GLES2_GetTexCoordPrecisionEnumFromHint();
                                                              ^
                                                               void
```

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
