### PR TITLE
configure.ac: fix configure tests broken with Clang 15 (implicit func…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2728,6 +2728,7 @@ CheckInputKD()
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
       #include <linux/kd.h>
       #include <linux/keyboard.h>
+      #include <sys/ioctl.h>
     ]], [[
         struct kbentry kbe;
         kbe.kb_table = KG_CTRL;


### PR DESCRIPTION
…tion declarations)

## Description
Clang 15 makes implicit function declarations fatal by default which leads to some configure tests silently failing/returning the wrong result.
