### PR TITLE
vita: Drop memcmp redirect to sceClibMemcmp.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2495,7 +2495,6 @@ elseif(VITA)
   target_compile_definitions(sdl-build-options INTERFACE "-Dmemcpy=sceClibMemcpy")
   target_compile_definitions(sdl-build-options INTERFACE "-Dmemset=sceClibMemset")
   target_compile_definitions(sdl-build-options INTERFACE "-Dmemmove=sceClibMemmove")
-  target_compile_definitions(sdl-build-options INTERFACE "-Dmemcmp=sceClibMemcmp")
 
 #  CheckPTHREAD()
 


### PR DESCRIPTION
sceClibMemcmp is not a safe replacement to newlib memcmp.
In real use test cases it has been proven to be more error prone (in particular when NULL ptrs are involved seemingly).
Some good example cases are World of Goo Vita ( https://github.com/Rinnegatamante/goo_vita/blob/main/loader/main.c#L545 ), max-vita ( https://github.com/fgsfdsfgs/max_vita/blob/1d6fa3cf249e1435ff35f3aa191371e3925ccc87/imports.c#L557 ) and YoYo Loader ( https://github.com/Rinnegatamante/yoyoloader_vita/blob/main/loader/main.c#L1694 ).
The first two if compiled with sceClibMemcmp will crash at boot (whilst running fine with memcmp) and the second will have a lot of games crashing in memcmp calls.

sceClibMemcmp is a good speedy replacement for memcmp only in use cases where it's proven to run just fine (and having such replacement in SDL is surely not ideal).
