### PR TITLE
Added support for simulated vsync in the renderer

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -4575,6 +4575,7 @@ SDL_RenderSetVSync(SDL_Renderer * renderer, int vsync)
     }
 
     renderer->wanted_vsync = vsync ? SDL_TRUE : SDL_FALSE;
+    renderer->last_present = 0;
 
     if (!renderer->SetVSync ||
         renderer->SetVSync(renderer, vsync) < 0) {

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -4288,11 +4288,12 @@ SDL_RenderSimulateVSync(SDL_Renderer * renderer)
         now = SDL_GetTicks();
     }
 
-    if (renderer->last_present) {
-        elapsed = (now - renderer->last_present);
-        renderer->last_present += (elapsed / interval) * interval;
-    } else {
+    elapsed = (now - renderer->last_present);
+    if (!renderer->last_present || elapsed > 1000) {
+        /* It's been too long, reset the presentation timeline */
         renderer->last_present = now;
+    } else {
+        renderer->last_present += (elapsed / interval) * interval;
     }
 }
 
@@ -4575,7 +4576,6 @@ SDL_RenderSetVSync(SDL_Renderer * renderer, int vsync)
     }
 
     renderer->wanted_vsync = vsync ? SDL_TRUE : SDL_FALSE;
-    renderer->last_present = 0;
 
     if (!renderer->SetVSync ||
         renderer->SetVSync(renderer, vsync) < 0) {

--- a/src/render/SDL_sysrender.h
+++ b/src/render/SDL_sysrender.h
@@ -188,7 +188,7 @@ struct SDL_Renderer
     int (*SetRenderTarget) (SDL_Renderer * renderer, SDL_Texture * texture);
     int (*RenderReadPixels) (SDL_Renderer * renderer, const SDL_Rect * rect,
                              Uint32 format, void * pixels, int pitch);
-    void (*RenderPresent) (SDL_Renderer * renderer);
+    int (*RenderPresent) (SDL_Renderer * renderer);
     void (*DestroyTexture) (SDL_Renderer * renderer, SDL_Texture * texture);
 
     void (*DestroyRenderer) (SDL_Renderer * renderer);
@@ -207,6 +207,11 @@ struct SDL_Renderer
     /* The window associated with the renderer */
     SDL_Window *window;
     SDL_bool hidden;
+
+    /* Whether we should simulate vsync */
+    SDL_bool wanted_vsync;
+    SDL_bool simulate_vsync;
+    Uint32 last_present;
 
     /* The logical resolution for rendering */
     int logical_w;

--- a/src/render/SDL_sysrender.h
+++ b/src/render/SDL_sysrender.h
@@ -211,6 +211,7 @@ struct SDL_Renderer
     /* Whether we should simulate vsync */
     SDL_bool wanted_vsync;
     SDL_bool simulate_vsync;
+    Uint32 simulate_vsync_interval;
     Uint32 last_present;
 
     /* The logical resolution for rendering */

--- a/src/render/direct3d/SDL_render_d3d.c
+++ b/src/render/direct3d/SDL_render_d3d.c
@@ -1384,7 +1384,7 @@ D3D_RenderReadPixels(SDL_Renderer * renderer, const SDL_Rect * rect,
     return status;
 }
 
-static void
+static int
 D3D_RenderPresent(SDL_Renderer * renderer)
 {
     D3D_RenderData *data = (D3D_RenderData *) renderer->driverdata;
@@ -1398,15 +1398,16 @@ D3D_RenderPresent(SDL_Renderer * renderer)
     result = IDirect3DDevice9_TestCooperativeLevel(data->device);
     if (result == D3DERR_DEVICELOST) {
         /* We'll reset later */
-        return;
+        return -1;
     }
     if (result == D3DERR_DEVICENOTRESET) {
         D3D_Reset(renderer);
     }
     result = IDirect3DDevice9_Present(data->device, NULL, NULL, NULL, NULL);
     if (FAILED(result)) {
-        D3D_SetError("Present()", result);
+        return D3D_SetError("Present()", result);
     }
+    return 0;
 }
 
 static void

--- a/src/render/direct3d11/SDL_render_d3d11.c
+++ b/src/render/direct3d11/SDL_render_d3d11.c
@@ -2288,7 +2288,7 @@ done:
     return status;
 }
 
-static void
+static int
 D3D11_RenderPresent(SDL_Renderer * renderer)
 {
     D3D11_RenderData *data = (D3D11_RenderData *) renderer->driverdata;
@@ -2334,7 +2334,7 @@ D3D11_RenderPresent(SDL_Renderer * renderer)
          *
          * TODO, WinRT: consider throwing an exception if D3D11_RenderPresent fails, especially if there is a way to salvage debug info from users' machines
          */
-        if ( result == DXGI_ERROR_DEVICE_REMOVED ) {
+        if (result == DXGI_ERROR_DEVICE_REMOVED) {
             D3D11_HandleDeviceLost(renderer);
         } else if (result == DXGI_ERROR_INVALID_CALL) {
             /* We probably went through a fullscreen <-> windowed transition */
@@ -2342,7 +2342,9 @@ D3D11_RenderPresent(SDL_Renderer * renderer)
         } else {
             WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGISwapChain::Present"), result);
         }
+        return -1;
     }
+    return 0;
 }
 
 #if WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP

--- a/src/render/direct3d12/SDL_render_d3d12.c
+++ b/src/render/direct3d12/SDL_render_d3d12.c
@@ -2931,7 +2931,7 @@ done:
     return status;
 }
 
-static void
+static int
 D3D12_RenderPresent(SDL_Renderer * renderer)
 {
     D3D12_RenderData *data = (D3D12_RenderData *) renderer->driverdata;
@@ -2981,6 +2981,7 @@ D3D12_RenderPresent(SDL_Renderer * renderer)
         } else {
             WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGISwapChain::Present"), result);
         }
+        return -1;
     } else {
         /* Wait for the GPU and move to the next frame */
         result = D3D_CALL(data->commandQueue, Signal, data->fence, data->fenceValue);
@@ -3012,6 +3013,7 @@ D3D12_RenderPresent(SDL_Renderer * renderer)
 #if defined(__XBOXONE__) || defined(__XBOXSERIES__)
         D3D12_XBOX_StartFrame(data->d3dDevice, &data->frameToken);
 #endif
+        return 0;
     }
 }
 

--- a/src/render/metal/SDL_render_metal.m
+++ b/src/render/metal/SDL_render_metal.m
@@ -1497,7 +1497,7 @@ METAL_RenderReadPixels(SDL_Renderer * renderer, const SDL_Rect * rect,
     return status;
 }}
 
-static void
+static int
 METAL_RenderPresent(SDL_Renderer * renderer)
 { @autoreleasepool {
     METAL_RenderData *data = (__bridge METAL_RenderData *) renderer->driverdata;
@@ -1528,6 +1528,11 @@ METAL_RenderPresent(SDL_Renderer * renderer)
     data.mtlcmdencoder = nil;
     data.mtlcmdbuffer = nil;
     data.mtlbackbuffer = nil;
+
+    if (!ready) {
+        return -1;
+    }
+    return 0;
 }}
 
 static void

--- a/src/render/opengl/SDL_render_gl.c
+++ b/src/render/opengl/SDL_render_gl.c
@@ -22,6 +22,7 @@
 
 #if SDL_VIDEO_RENDER_OGL && !SDL_RENDER_DISABLED
 #include "SDL_hints.h"
+#include "../../video/SDL_sysvideo.h" /* For SDL_GL_SwapWindowWithResult */
 #include "SDL_opengl.h"
 #include "../SDL_sysrender.h"
 #include "SDL_shaders_gl.h"
@@ -1502,12 +1503,12 @@ GL_RenderReadPixels(SDL_Renderer * renderer, const SDL_Rect * rect,
     return status;
 }
 
-static void
+static int
 GL_RenderPresent(SDL_Renderer * renderer)
 {
     GL_ActivateRenderer(renderer);
 
-    SDL_GL_SwapWindow(renderer->window);
+    return SDL_GL_SwapWindowWithResult(renderer->window);
 }
 
 static void

--- a/src/render/opengles/SDL_render_gles.c
+++ b/src/render/opengles/SDL_render_gles.c
@@ -23,6 +23,7 @@
 #if SDL_VIDEO_RENDER_OGL_ES && !SDL_RENDER_DISABLED
 
 #include "SDL_hints.h"
+#include "../../video/SDL_sysvideo.h" /* For SDL_GL_SwapWindowWithResult */
 #include "SDL_opengles.h"
 #include "../SDL_sysrender.h"
 #include "../../SDL_utils_c.h"
@@ -948,12 +949,12 @@ GLES_RenderReadPixels(SDL_Renderer * renderer, const SDL_Rect * rect,
     return status;
 }
 
-static void
+static int
 GLES_RenderPresent(SDL_Renderer * renderer)
 {
     GLES_ActivateRenderer(renderer);
 
-    SDL_GL_SwapWindow(renderer->window);
+    return SDL_GL_SwapWindowWithResult(renderer->window);
 }
 
 static void

--- a/src/render/opengles2/SDL_render_gles2.c
+++ b/src/render/opengles2/SDL_render_gles2.c
@@ -23,6 +23,7 @@
 #if SDL_VIDEO_RENDER_OGL_ES2 && !SDL_RENDER_DISABLED
 
 #include "SDL_hints.h"
+#include "../../video/SDL_sysvideo.h" /* For SDL_GL_SwapWindowWithResult */
 #include "SDL_opengles2.h"
 #include "../SDL_sysrender.h"
 #include "../../video/SDL_blit.h"
@@ -1963,11 +1964,11 @@ GLES2_RenderReadPixels(SDL_Renderer * renderer, const SDL_Rect * rect,
     return status;
 }
 
-static void
+static int
 GLES2_RenderPresent(SDL_Renderer *renderer)
 {
     /* Tell the video driver to swap buffers */
-    SDL_GL_SwapWindow(renderer->window);
+    return SDL_GL_SwapWindowWithResult(renderer->window);
 }
 
 static int

--- a/src/render/ps2/SDL_render_ps2.c
+++ b/src/render/ps2/SDL_render_ps2.c
@@ -654,7 +654,7 @@ PS2_RenderReadPixels(SDL_Renderer * renderer, const SDL_Rect * rect,
     return SDL_Unsupported();
 }
 
-static void
+static int
 PS2_RenderPresent(SDL_Renderer * renderer)
 {
     PS2_RenderData *data = (PS2_RenderData *) renderer->driverdata;
@@ -676,6 +676,7 @@ PS2_RenderPresent(SDL_Renderer * renderer)
 	}
 	gsKit_TexManager_nextFrame(data->gsGlobal);
     gsKit_clear(data->gsGlobal, GS_BLACK);
+    return 0;
 }
 
 static void

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -1250,12 +1250,13 @@ PSP_RenderReadPixels(SDL_Renderer * renderer, const SDL_Rect * rect,
     return SDL_Unsupported();
 }
 
-static void
+static int
 PSP_RenderPresent(SDL_Renderer * renderer)
 {
     PSP_RenderData *data = (PSP_RenderData *) renderer->driverdata;
-    if(!data->displayListAvail)
-        return;
+    if (!data->displayListAvail) {
+        return -1;
+    }
 
     data->displayListAvail = SDL_FALSE;
     sceGuFinish();
@@ -1268,6 +1269,7 @@ PSP_RenderPresent(SDL_Renderer * renderer)
     data->backbuffer = data->frontbuffer;
     data->frontbuffer = vabsptr(sceGuSwapBuffers());
 
+    return 0;
 }
 
 static void

--- a/src/render/software/SDL_render_sw.c
+++ b/src/render/software/SDL_render_sw.c
@@ -983,14 +983,15 @@ SW_RenderReadPixels(SDL_Renderer * renderer, const SDL_Rect * rect,
                              format, pixels, pitch);
 }
 
-static void
+static int
 SW_RenderPresent(SDL_Renderer * renderer)
 {
     SDL_Window *window = renderer->window;
 
-    if (window) {
-        SDL_UpdateWindowSurface(window);
+    if (!window) {
+        return -1;
     }
+    return SDL_UpdateWindowSurface(window);
 }
 
 static void

--- a/src/render/vitagxm/SDL_render_vita_gxm.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm.c
@@ -100,7 +100,7 @@ static int VITA_GXM_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rect *rec
     Uint32 pixel_format, void *pixels, int pitch);
 
 
-static void VITA_GXM_RenderPresent(SDL_Renderer *renderer);
+static int VITA_GXM_RenderPresent(SDL_Renderer *renderer);
 static void VITA_GXM_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture);
 static void VITA_GXM_DestroyRenderer(SDL_Renderer *renderer);
 
@@ -1185,7 +1185,7 @@ VITA_GXM_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rect *rect,
 }
 
 
-static void
+static int
 VITA_GXM_RenderPresent(SDL_Renderer *renderer)
 {
     VITA_GXM_RenderData *data = (VITA_GXM_RenderData *) renderer->driverdata;
@@ -1227,6 +1227,7 @@ VITA_GXM_RenderPresent(SDL_Renderer *renderer)
     data->pool_index = 0;
 
     data->current_pool = (data->current_pool + 1) % 2;
+    return 0;
 }
 
 static void

--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -519,6 +519,8 @@ extern void SDL_ToggleDragAndDropSupport(void);
 
 extern int SDL_GetPointDisplayIndex(const SDL_Point * point);
 
+extern int SDL_GL_SwapWindowWithResult(SDL_Window * window);
+
 #endif /* SDL_sysvideo_h_ */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -4152,22 +4152,26 @@ SDL_GL_GetSwapInterval(void)
     }
 }
 
-void
-SDL_GL_SwapWindow(SDL_Window * window)
+int
+SDL_GL_SwapWindowWithResult(SDL_Window * window)
 {
-    CHECK_WINDOW_MAGIC(window,);
+    CHECK_WINDOW_MAGIC(window, -1);
 
     if (!(window->flags & SDL_WINDOW_OPENGL)) {
-        SDL_SetError("The specified window isn't an OpenGL window");
-        return;
+        return SDL_SetError("The specified window isn't an OpenGL window");
     }
 
     if (SDL_GL_GetCurrentWindow() != window) {
-        SDL_SetError("The specified window has not been made current");
-        return;
+        return SDL_SetError("The specified window has not been made current");
     }
 
-    _this->GL_SwapWindow(_this, window);
+    return _this->GL_SwapWindow(_this, window);
+}
+
+void
+SDL_GL_SwapWindow(SDL_Window * window)
+{
+    SDL_GL_SwapWindowWithResult(window);
 }
 
 void


### PR DESCRIPTION
This kicks in if the platform doesn't support vsync directly, or if the present fails for some reason (e.g. minimized on some platforms)

Fixes https://github.com/libsdl-org/SDL/issues/5134