### PR TITLE
Build the offscreen video driver by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,7 +497,7 @@ dep_option(SDL_VULKAN              "Enable Vulkan support" ON "ANDROID OR APPLE 
 set_option(SDL_METAL               "Enable Metal support" ${APPLE})
 set_option(SDL_KMSDRM              "Use KMS DRM video driver" ${UNIX_SYS})
 dep_option(SDL_KMSDRM_SHARED       "Dynamically load KMS DRM support" ON "SDL_KMSDRM" OFF)
-set_option(SDL_OFFSCREEN           "Use offscreen video driver" OFF)
+set_option(SDL_OFFSCREEN           "Use offscreen video driver" ON)
 option_string(SDL_BACKGROUNDING_SIGNAL "number to use for magic backgrounding signal or 'OFF'" OFF)
 option_string(SDL_FOREGROUNDING_SIGNAL "number to use for magic foregrounding signal or 'OFF'" OFF)
 set_option(SDL_HIDAPI              "Enable the HIDAPI subsystem" ON)

--- a/configure.ac
+++ b/configure.ac
@@ -2398,8 +2398,8 @@ CheckDummyVideo()
 CheckOffscreenVideo()
 {
     AC_ARG_ENABLE(video-offscreen,
-[AS_HELP_STRING([--enable-video-offscreen], [use offscreen video driver [default=no]])],
-                  , enable_video_offscreen=no)
+[AS_HELP_STRING([--enable-video-offscreen], [use offscreen video driver [default=yes]])],
+                  , enable_video_offscreen=yes)
     if test x$enable_video_offscreen = xyes; then
         AC_DEFINE(SDL_VIDEO_DRIVER_OFFSCREEN, 1, [ ])
         SOURCES="$SOURCES $srcdir/src/video/offscreen/*.c"


### PR DESCRIPTION
## Description

The offscreen video driver is pretty useful for automated tests, however because it isn't built by default some (most?) distros don't bother enabling it. This PR simply builds it by default to avoid building SDL from source if you want to use the offscreen driver.

## Existing Issue(s)

None that I can find.
