### PR TITLE
Add `SDL_RendererInfoEx`

### DIFF
--- a/include/SDL_render.h
+++ b/include/SDL_render.h
@@ -73,7 +73,7 @@ typedef enum
 } SDL_RendererFlags;
 
 /**
- * Information on the capabilities of a render driver or context.
+ * Information on the capabilities of a render driver or context (legacy version).
  */
 typedef struct SDL_RendererInfo
 {
@@ -84,6 +84,19 @@ typedef struct SDL_RendererInfo
     int max_texture_width;      /**< The maximum texture width */
     int max_texture_height;     /**< The maximum texture height */
 } SDL_RendererInfo;
+
+/**
+ * Information on the capabilities of a render driver or context.
+ */
+typedef struct SDL_RendererInfoEx
+{
+    const char *name;              /**< The name of the renderer */
+    Uint32 flags;                  /**< Supported ::SDL_RendererFlags */
+    Uint32 num_texture_formats;    /**< The number of available texture formats */
+    const Uint32 *texture_formats; /**< The available texture formats */
+    int max_texture_width;         /**< The maximum texture width */
+    int max_texture_height;        /**< The maximum texture height */
+} SDL_RendererInfoEx;
 
 /**
  *  Vertex structure
@@ -165,11 +178,15 @@ typedef struct SDL_Texture SDL_Texture;
  *
  * \sa SDL_CreateRenderer
  * \sa SDL_GetRenderDriverInfo
+ * \sa SDL_GetRenderDriverInfoEx
  */
 extern DECLSPEC int SDLCALL SDL_GetNumRenderDrivers(void);
 
 /**
  * Get info about a specific 2D rendering driver for the current display.
+ *
+ * This has been deprecated in favor of SDL_GetRenderDriverInfoEx(), as this
+ * function can only list up to 16 texture formats.
  *
  * \param index the index of the driver to query information about
  * \param info an SDL_RendererInfo structure to be filled with information on
@@ -181,9 +198,31 @@ extern DECLSPEC int SDLCALL SDL_GetNumRenderDrivers(void);
  *
  * \sa SDL_CreateRenderer
  * \sa SDL_GetNumRenderDrivers
+ * \sa SDL_GetRenderDriverInfoEx
  */
 extern DECLSPEC int SDLCALL SDL_GetRenderDriverInfo(int index,
                                                     SDL_RendererInfo * info);
+
+/**
+ * Get info about a specific 2D rendering driver for the current display.
+ *
+ * This function replaces SDL_GetRenderDriverInfo(), allowing more than 16
+ * supported texture formats to be listed.
+ *
+ * \param index the index of the driver to query information about
+ * \param info an SDL_RendererInfoEx structure to be filled with information on
+ *             the rendering driver
+ * \returns 0 on success or a negative error code on failure; call
+ *          SDL_GetError() for more information.
+ *
+ * \since This function is available since SDL 2.26.0.
+ *
+ * \sa SDL_CreateRenderer
+ * \sa SDL_GetNumRenderDrivers
+ * \sa SDL_GetRenderDriverInfo
+ */
+extern DECLSPEC int SDLCALL SDL_GetRenderDriverInfoEx(int index,
+                                                      SDL_RendererInfoEx * info);
 
 /**
  * Create a window and default renderer.
@@ -223,6 +262,7 @@ extern DECLSPEC int SDLCALL SDL_CreateWindowAndRenderer(
  * \sa SDL_DestroyRenderer
  * \sa SDL_GetNumRenderDrivers
  * \sa SDL_GetRendererInfo
+ * \sa SDL_GetRendererInfoEx
  */
 extern DECLSPEC SDL_Renderer * SDLCALL SDL_CreateRenderer(SDL_Window * window,
                                                int index, Uint32 flags);
@@ -275,6 +315,9 @@ extern DECLSPEC SDL_Window * SDLCALL SDL_RenderGetWindow(SDL_Renderer *renderer)
 /**
  * Get information about a rendering context.
  *
+ * This has been deprecated in favor of SDL_GetRendererInfoEx(), as this
+ * function can only list up to 16 texture formats.
+ *
  * \param renderer the rendering context
  * \param info an SDL_RendererInfo structure filled with information about the
  *             current renderer
@@ -287,6 +330,25 @@ extern DECLSPEC SDL_Window * SDLCALL SDL_RenderGetWindow(SDL_Renderer *renderer)
  */
 extern DECLSPEC int SDLCALL SDL_GetRendererInfo(SDL_Renderer * renderer,
                                                 SDL_RendererInfo * info);
+
+/**
+ * Get information about a rendering context.
+ *
+ * This function replaces SDL_GetRendererInfo(), allowing more than 16
+ * supported texture formats to be listed.
+ *
+ * \param renderer the rendering context
+ * \param info an SDL_RendererInfoEx structure filled with information about
+ *             the current renderer
+ * \returns 0 on success or a negative error code on failure; call
+ *          SDL_GetError() for more information.
+ *
+ * \since This function is available since SDL 2.26.0.
+ *
+ * \sa SDL_CreateRenderer
+ */
+extern DECLSPEC int SDLCALL SDL_GetRendererInfoEx(SDL_Renderer * renderer,
+                                                  SDL_RendererInfoEx * info);
 
 /**
  * Get the output size in pixels of a rendering context.
@@ -758,8 +820,8 @@ extern DECLSPEC SDL_bool SDLCALL SDL_RenderTargetSupported(SDL_Renderer *rendere
  * Set a texture as the current rendering target.
  *
  * Before using this function, you should check the
- * `SDL_RENDERER_TARGETTEXTURE` bit in the flags of SDL_RendererInfo to see if
- * render targets are supported.
+ * `SDL_RENDERER_TARGETTEXTURE` bit in the flags of SDL_RendererInfoEx to see
+ * if render targets are supported.
  *
  * The default render target is the window for which the renderer was created.
  * To stop rendering to a texture and render to the window again, call this

--- a/src/dynapi/SDL2.exports
+++ b/src/dynapi/SDL2.exports
@@ -863,3 +863,5 @@
 ++'_SDL_SetPrimarySelectionText'.'SDL2.dll'.'SDL_SetPrimarySelectionText'
 ++'_SDL_GetPrimarySelectionText'.'SDL2.dll'.'SDL_GetPrimarySelectionText'
 ++'_SDL_HasPrimarySelectionText'.'SDL2.dll'.'SDL_HasPrimarySelectionText'
+++'_SDL_GetRenderDriverInfoEx'.'SDL2.dll'.'SDL_GetRenderDriverInfoEx'
+++'_SDL_GetRendererInfoEx'.'SDL2.dll'.'SDL_GetRendererInfoEx'

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -889,3 +889,5 @@
 #define SDL_SetPrimarySelectionText SDL_SetPrimarySelectionText_REAL
 #define SDL_GetPrimarySelectionText SDL_GetPrimarySelectionText_REAL
 #define SDL_HasPrimarySelectionText SDL_HasPrimarySelectionText_REAL
+#define SDL_GetRenderDriverInfoEx SDL_GetRenderDriverInfoEx_REAL
+#define SDL_GetRendererInfoEx SDL_GetRendererInfoEx_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -972,3 +972,5 @@ SDL_DYNAPI_PROC(void,SDL_GetJoystickGUIDInfo,(SDL_JoystickGUID a, Uint16 *b, Uin
 SDL_DYNAPI_PROC(int,SDL_SetPrimarySelectionText,(const char *a),(a),return)
 SDL_DYNAPI_PROC(char*,SDL_GetPrimarySelectionText,(void),(),return)
 SDL_DYNAPI_PROC(SDL_bool,SDL_HasPrimarySelectionText,(void),(),return)
+SDL_DYNAPI_PROC(int,SDL_GetRenderDriverInfoEx,(int a, SDL_RendererInfoEx *b),(a,b),return)
+SDL_DYNAPI_PROC(int,SDL_GetRendererInfoEx,(SDL_Renderer *a, SDL_RendererInfoEx *b),(a,b),return)

--- a/src/render/SDL_sysrender.h
+++ b/src/render/SDL_sysrender.h
@@ -202,7 +202,7 @@ struct SDL_Renderer
     void *(*GetMetalCommandEncoder) (SDL_Renderer * renderer);
 
     /* The current renderer info */
-    SDL_RendererInfo info;
+    SDL_RendererInfoEx info;
 
     /* The window associated with the renderer */
     SDL_Window *window;
@@ -281,7 +281,7 @@ struct SDL_RenderDriver
     SDL_Renderer *(*CreateRenderer) (SDL_Window * window, Uint32 flags);
 
     /* Info about the renderer capabilities */
-    SDL_RendererInfo info;
+    SDL_RendererInfoEx info;
 };
 
 /* Not all of these are available in a given build. Use #ifdefs, etc. */

--- a/src/render/direct3d/SDL_render_d3d.c
+++ b/src/render/direct3d/SDL_render_d3d.c
@@ -1749,10 +1749,9 @@ D3D_CreateRenderer(SDL_Window * window, Uint32 flags)
                 D3D_SetError("CreatePixelShader()", result);
             }
         }
-        if (data->shaders[SHADER_YUV_JPEG] && data->shaders[SHADER_YUV_BT601] && data->shaders[SHADER_YUV_BT709]) {
-            renderer->info.texture_formats[renderer->info.num_texture_formats++] = SDL_PIXELFORMAT_YV12;
-            renderer->info.texture_formats[renderer->info.num_texture_formats++] = SDL_PIXELFORMAT_IYUV;
-        }
+        /* Disable YUV texture support if the shaders couldn't be compiled */
+        if (!data->shaders[SHADER_YUV_JPEG] || !data->shaders[SHADER_YUV_BT601] || !data->shaders[SHADER_YUV_BT709])
+            renderer->info.num_texture_formats -= 2;
     }
 #endif
     data->drawstate.viewport_dirty = SDL_TRUE;
@@ -1763,13 +1762,19 @@ D3D_CreateRenderer(SDL_Window * window, Uint32 flags)
     return renderer;
 }
 
+static const Uint32 D3D_TextureFormats[] = {
+    SDL_PIXELFORMAT_ARGB8888,
+    SDL_PIXELFORMAT_YV12,
+    SDL_PIXELFORMAT_IYUV
+};
+
 SDL_RenderDriver D3D_RenderDriver = {
     D3D_CreateRenderer,
     {
      "direct3d",
      (SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_TARGETTEXTURE),
-     1,
-     {SDL_PIXELFORMAT_ARGB8888},
+     SDL_arraysize(D3D_TextureFormats),
+     D3D_TextureFormats,
      0,
      0}
 };

--- a/src/render/direct3d11/SDL_render_d3d11.c
+++ b/src/render/direct3d11/SDL_render_d3d11.c
@@ -2448,6 +2448,15 @@ D3D11_CreateRenderer(SDL_Window * window, Uint32 flags)
     return renderer;
 }
 
+static const Uint32 D3D11_TextureFormats[] = {
+    SDL_PIXELFORMAT_ARGB8888,
+    SDL_PIXELFORMAT_RGB888,
+    SDL_PIXELFORMAT_YV12,
+    SDL_PIXELFORMAT_IYUV,
+    SDL_PIXELFORMAT_NV12,
+    SDL_PIXELFORMAT_NV21
+};
+
 SDL_RenderDriver D3D11_RenderDriver = {
     D3D11_CreateRenderer,
     {
@@ -2456,18 +2465,11 @@ SDL_RenderDriver D3D11_RenderDriver = {
             SDL_RENDERER_ACCELERATED |
             SDL_RENDERER_PRESENTVSYNC |
             SDL_RENDERER_TARGETTEXTURE
-        ),                          /* flags.  see SDL_RendererFlags */
-        6,                          /* num_texture_formats */
-        {                           /* texture_formats */
-            SDL_PIXELFORMAT_ARGB8888,
-            SDL_PIXELFORMAT_RGB888,
-            SDL_PIXELFORMAT_YV12,
-            SDL_PIXELFORMAT_IYUV,
-            SDL_PIXELFORMAT_NV12,
-            SDL_PIXELFORMAT_NV21
-        },
-        0,                          /* max_texture_width: will be filled in later */
-        0                           /* max_texture_height: will be filled in later */
+        ),                                   /* flags.  see SDL_RendererFlags */
+        SDL_arraysize(D3D11_TextureFormats), /* num_texture_formats */
+        D3D11_TextureFormats,                /* texture_formats */
+        0,                                   /* max_texture_width: will be filled in later */
+        0                                    /* max_texture_height: will be filled in later */
     }
 };
 

--- a/src/render/direct3d12/SDL_render_d3d12.c
+++ b/src/render/direct3d12/SDL_render_d3d12.c
@@ -3097,6 +3097,15 @@ D3D12_CreateRenderer(SDL_Window * window, Uint32 flags)
     return renderer;
 }
 
+static const Uint32 D3D12_TextureFormats[] = {
+    SDL_PIXELFORMAT_ARGB8888,
+    SDL_PIXELFORMAT_RGB888,
+    SDL_PIXELFORMAT_YV12,
+    SDL_PIXELFORMAT_IYUV,
+    SDL_PIXELFORMAT_NV12,
+    SDL_PIXELFORMAT_NV21
+};
+
 SDL_RenderDriver D3D12_RenderDriver = {
     D3D12_CreateRenderer,
     {
@@ -3105,18 +3114,11 @@ SDL_RenderDriver D3D12_RenderDriver = {
             SDL_RENDERER_ACCELERATED |
             SDL_RENDERER_PRESENTVSYNC |
             SDL_RENDERER_TARGETTEXTURE
-        ),                          /* flags.  see SDL_RendererFlags */
-        6,                          /* num_texture_formats */
-        {                           /* texture_formats */
-            SDL_PIXELFORMAT_ARGB8888,
-            SDL_PIXELFORMAT_RGB888,
-            SDL_PIXELFORMAT_YV12,
-            SDL_PIXELFORMAT_IYUV,
-            SDL_PIXELFORMAT_NV12,
-            SDL_PIXELFORMAT_NV21
-        },
-        16384,                          /* max_texture_width */
-        16384                           /* max_texture_height */
+        ),                                   /* flags.  see SDL_RendererFlags */
+        SDL_arraysize(D3D12_TextureFormats), /* num_texture_formats */
+        D3D12_TextureFormats,                /* texture_formats */
+        16384,                               /* max_texture_width */
+        16384                                /* max_texture_height */
     }
 };
 

--- a/src/render/metal/SDL_render_metal.m
+++ b/src/render/metal/SDL_render_metal.m
@@ -1932,20 +1932,22 @@ METAL_CreateRenderer(SDL_Window * window, Uint32 flags)
     return renderer;
 }}
 
+static const Uint32 METAL_TextureFormats[] = {
+    SDL_PIXELFORMAT_ARGB8888,
+    SDL_PIXELFORMAT_ABGR8888,
+    SDL_PIXELFORMAT_YV12,
+    SDL_PIXELFORMAT_IYUV,
+    SDL_PIXELFORMAT_NV12,
+    SDL_PIXELFORMAT_NV21
+};
+
 SDL_RenderDriver METAL_RenderDriver = {
     METAL_CreateRenderer,
     {
         "metal",
         (SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_TARGETTEXTURE),
-        6,
-        {
-            SDL_PIXELFORMAT_ARGB8888,
-            SDL_PIXELFORMAT_ABGR8888,
-            SDL_PIXELFORMAT_YV12,
-            SDL_PIXELFORMAT_IYUV,
-            SDL_PIXELFORMAT_NV12,
-            SDL_PIXELFORMAT_NV21
-        },
+        SDL_arraysize(METAL_TextureFormats),
+        METAL_TextureFormats,
     0, 0,
     }
 };

--- a/src/render/opengl/SDL_render_gl.c
+++ b/src/render/opengl/SDL_render_gl.c
@@ -1916,19 +1916,12 @@ GL_CreateRenderer(SDL_Window * window, Uint32 flags)
                 data->shaders ? "ENABLED" : "DISABLED");
 #if SDL_HAVE_YUV
     /* We support YV12 textures using 3 textures and a shader */
-    if (data->shaders && data->num_texture_units >= 3) {
-        renderer->info.texture_formats[renderer->info.num_texture_formats++] = SDL_PIXELFORMAT_YV12;
-        renderer->info.texture_formats[renderer->info.num_texture_formats++] = SDL_PIXELFORMAT_IYUV;
-    }
+    if (!data->shaders || data->num_texture_units < 3)
+        renderer->info.num_texture_formats -= 2;
 
     /* We support NV12 textures using 2 textures and a shader */
-    if (data->shaders && data->num_texture_units >= 2) {
-        renderer->info.texture_formats[renderer->info.num_texture_formats++] = SDL_PIXELFORMAT_NV12;
-        renderer->info.texture_formats[renderer->info.num_texture_formats++] = SDL_PIXELFORMAT_NV21;
-    }
-#endif
-#ifdef __MACOSX__
-    renderer->info.texture_formats[renderer->info.num_texture_formats++] = SDL_PIXELFORMAT_UYVY;
+    if (!data->shaders || data->num_texture_units < 2)
+        renderer->info.num_texture_formats -= 2;
 #endif
 
     if (SDL_GL_ExtensionSupported("GL_EXT_framebuffer_object")) {
@@ -1977,19 +1970,27 @@ error:
     return NULL;
 }
 
+static const Uint32 GL_TextureFormats[8] = {
+    SDL_PIXELFORMAT_ARGB8888,
+    SDL_PIXELFORMAT_ABGR8888,
+    SDL_PIXELFORMAT_RGB888,
+    SDL_PIXELFORMAT_BGR888,
+#ifdef __MACOSX__
+    SDL_PIXELFORMAT_UYVY,
+#endif
+    SDL_PIXELFORMAT_NV12,
+    SDL_PIXELFORMAT_NV21,
+    SDL_PIXELFORMAT_YV12,
+    SDL_PIXELFORMAT_IYUV
+};
 
 SDL_RenderDriver GL_RenderDriver = {
     GL_CreateRenderer,
     {
      "opengl",
      (SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_TARGETTEXTURE),
-     4,
-     {
-         SDL_PIXELFORMAT_ARGB8888,
-         SDL_PIXELFORMAT_ABGR8888,
-         SDL_PIXELFORMAT_RGB888,
-         SDL_PIXELFORMAT_BGR888
-     },
+     SDL_arraysize(GL_TextureFormats),
+     GL_TextureFormats,
      0,
      0}
 };

--- a/src/render/opengles/SDL_render_gles.c
+++ b/src/render/opengles/SDL_render_gles.c
@@ -1208,13 +1208,17 @@ error:
     return NULL;
 }
 
+static const Uint32 GLES_TextureFormats[] = {
+    SDL_PIXELFORMAT_ABGR8888
+};
+
 SDL_RenderDriver GLES_RenderDriver = {
     GLES_CreateRenderer,
     {
      "opengles",
      (SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC),
-     1,
-     {SDL_PIXELFORMAT_ABGR8888},
+     SDL_arraysize(GLES_TextureFormats),
+     GLES_TextureFormats,
      0,
      0
     }

--- a/src/render/opengles2/SDL_render_gles2.c
+++ b/src/render/opengles2/SDL_render_gles2.c
@@ -2202,15 +2202,6 @@ GLES2_CreateRenderer(SDL_Window *window, Uint32 flags)
     renderer->SetVSync            = GLES2_SetVSync;
     renderer->GL_BindTexture      = GLES2_BindTexture;
     renderer->GL_UnbindTexture    = GLES2_UnbindTexture;
-#if SDL_HAVE_YUV
-    renderer->info.texture_formats[renderer->info.num_texture_formats++] = SDL_PIXELFORMAT_YV12;
-    renderer->info.texture_formats[renderer->info.num_texture_formats++] = SDL_PIXELFORMAT_IYUV;
-    renderer->info.texture_formats[renderer->info.num_texture_formats++] = SDL_PIXELFORMAT_NV12;
-    renderer->info.texture_formats[renderer->info.num_texture_formats++] = SDL_PIXELFORMAT_NV21;
-#endif
-#ifdef GL_TEXTURE_EXTERNAL_OES
-    renderer->info.texture_formats[renderer->info.num_texture_formats++] = SDL_PIXELFORMAT_EXTERNAL_OES;
-#endif
 
     /* Set up parameters for rendering */
     data->glActiveTexture(GL_TEXTURE0);
@@ -2243,18 +2234,29 @@ error:
     return NULL;
 }
 
+static const Uint32 GLES2_TextureFormats[] = {
+    SDL_PIXELFORMAT_ARGB8888,
+    SDL_PIXELFORMAT_ABGR8888,
+    SDL_PIXELFORMAT_RGB888,
+    SDL_PIXELFORMAT_BGR888,
+#if SDL_HAVE_YUV
+    SDL_PIXELFORMAT_YV12,
+    SDL_PIXELFORMAT_IYUV,
+    SDL_PIXELFORMAT_NV12,
+    SDL_PIXELFORMAT_NV21,
+#endif
+#ifdef GL_TEXTURE_EXTERNAL_OES
+    SDL_PIXELFORMAT_EXTERNAL_OES,
+#endif
+};
+
 SDL_RenderDriver GLES2_RenderDriver = {
     GLES2_CreateRenderer,
     {
         "opengles2",
         (SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_TARGETTEXTURE),
-        4,
-        {
-        SDL_PIXELFORMAT_ARGB8888,
-        SDL_PIXELFORMAT_ABGR8888,
-        SDL_PIXELFORMAT_RGB888,
-        SDL_PIXELFORMAT_BGR888
-        },
+        SDL_arraysize(GLES2_TextureFormats),
+        GLES2_TextureFormats,
         0,
         0
     }

--- a/src/render/ps2/SDL_render_ps2.c
+++ b/src/render/ps2/SDL_render_ps2.c
@@ -815,16 +815,18 @@ PS2_CreateRenderer(SDL_Window * window, Uint32 flags)
     return renderer;
 }
 
+static const Uint32 PS2_TextureFormats[] = {
+    SDL_PIXELFORMAT_ABGR1555,
+    SDL_PIXELFORMAT_ABGR8888
+};
+
 SDL_RenderDriver PS2_RenderDriver = {
     .CreateRenderer = PS2_CreateRenderer,
     .info = {
         .name = "PS2 gsKit",
         .flags = SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_TARGETTEXTURE,
-        .num_texture_formats = 2,
-        .texture_formats = { 
-            [0] = SDL_PIXELFORMAT_ABGR1555,
-            [1] = SDL_PIXELFORMAT_ABGR8888,
-        },
+        .num_texture_formats = SDL_arraysize(PS2_TextureFormats),
+        .texture_formats = PS2_TextureFormats,
         .max_texture_width = 1024,
         .max_texture_height = 1024,
     }

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -1442,17 +1442,20 @@ PSP_CreateRenderer(SDL_Window * window, Uint32 flags)
     return renderer;
 }
 
+static const Uint32 PSP_TextureFormats[] = {
+    SDL_PIXELFORMAT_BGR565,
+    SDL_PIXELFORMAT_ABGR1555,
+    SDL_PIXELFORMAT_ABGR4444,
+    SDL_PIXELFORMAT_ABGR8888
+};
+
 SDL_RenderDriver PSP_RenderDriver = {
     .CreateRenderer = PSP_CreateRenderer,
     .info = {
         .name = "PSP",
         .flags = SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_TARGETTEXTURE,
-        .num_texture_formats = 4,
-        .texture_formats = { [0] = SDL_PIXELFORMAT_BGR565,
-                                                 [1] = SDL_PIXELFORMAT_ABGR1555,
-                                                 [2] = SDL_PIXELFORMAT_ABGR4444,
-                                                 [3] = SDL_PIXELFORMAT_ABGR8888,
-        },
+        .num_texture_formats = SDL_arraysize(PSP_TextureFormats),
+        .texture_formats = PSP_TextureFormats,
         .max_texture_width = 512,
         .max_texture_height = 512,
      }

--- a/src/render/software/SDL_render_sw.c
+++ b/src/render/software/SDL_render_sw.c
@@ -1097,22 +1097,24 @@ SW_CreateRenderer(SDL_Window * window, Uint32 flags)
     return SW_CreateRendererForSurface(surface);
 }
 
+static const Uint32 SW_TextureFormats[] = {
+    SDL_PIXELFORMAT_ARGB8888,
+    SDL_PIXELFORMAT_ABGR8888,
+    SDL_PIXELFORMAT_RGBA8888,
+    SDL_PIXELFORMAT_BGRA8888,
+    SDL_PIXELFORMAT_RGB888,
+    SDL_PIXELFORMAT_BGR888,
+    SDL_PIXELFORMAT_RGB565,
+    SDL_PIXELFORMAT_RGB555
+};
+
 SDL_RenderDriver SW_RenderDriver = {
     SW_CreateRenderer,
     {
      "software",
      SDL_RENDERER_SOFTWARE | SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_TARGETTEXTURE,
-     8,
-     {
-      SDL_PIXELFORMAT_ARGB8888,
-      SDL_PIXELFORMAT_ABGR8888,
-      SDL_PIXELFORMAT_RGBA8888,
-      SDL_PIXELFORMAT_BGRA8888,
-      SDL_PIXELFORMAT_RGB888,
-      SDL_PIXELFORMAT_BGR888,
-      SDL_PIXELFORMAT_RGB565,
-      SDL_PIXELFORMAT_RGB555
-     },
+     SDL_arraysize(SW_TextureFormats),
+     SW_TextureFormats,
      0,
      0}
 };

--- a/src/render/vitagxm/SDL_render_vita_gxm.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm.c
@@ -104,23 +104,24 @@ static void VITA_GXM_RenderPresent(SDL_Renderer *renderer);
 static void VITA_GXM_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture);
 static void VITA_GXM_DestroyRenderer(SDL_Renderer *renderer);
 
+static const Uint32 VITA_GXM_TextureFormats[] = {
+    SDL_PIXELFORMAT_ABGR8888,
+    SDL_PIXELFORMAT_ARGB8888,
+    SDL_PIXELFORMAT_RGB565,
+    SDL_PIXELFORMAT_BGR565,
+    SDL_PIXELFORMAT_YV12,
+    SDL_PIXELFORMAT_IYUV,
+    SDL_PIXELFORMAT_NV12,
+    SDL_PIXELFORMAT_NV21
+};
 
 SDL_RenderDriver VITA_GXM_RenderDriver = {
     .CreateRenderer = VITA_GXM_CreateRenderer,
     .info = {
         .name = "VITA gxm",
         .flags = SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_TARGETTEXTURE,
-        .num_texture_formats = 8,
-        .texture_formats = {
-            [0] = SDL_PIXELFORMAT_ABGR8888,
-            [1] = SDL_PIXELFORMAT_ARGB8888,
-            [2] = SDL_PIXELFORMAT_RGB565,
-            [3] = SDL_PIXELFORMAT_BGR565,
-            [4] = SDL_PIXELFORMAT_YV12,
-            [5] = SDL_PIXELFORMAT_IYUV,
-            [6] = SDL_PIXELFORMAT_NV12,
-            [7] = SDL_PIXELFORMAT_NV21,
-        },
+        .num_texture_formats = SDL_arraysize(VITA_GXM_TextureFormats),
+        .texture_formats = VITA_GXM_TextureFormats,
         .max_texture_width = 4096,
         .max_texture_height = 4096,
      }

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -962,7 +962,7 @@ SDLTest_PrintPixelFormat(char *text, size_t maxlen, Uint32 format)
 }
 
 static void
-SDLTest_PrintRenderer(SDL_RendererInfo * info)
+SDLTest_PrintRenderer(SDL_RendererInfoEx * info)
 {
     int i, count;
     char text[1024];
@@ -1213,7 +1213,7 @@ SDLTest_CommonInit(SDLTest_CommonState * state)
         }
 
         if (state->verbose & VERBOSE_RENDER) {
-            SDL_RendererInfo info;
+            SDL_RendererInfoEx info;
 
             n = SDL_GetNumRenderDrivers();
             if (n == 0) {
@@ -1221,7 +1221,7 @@ SDLTest_CommonInit(SDLTest_CommonState * state)
             } else {
                 SDL_Log("Built-in render drivers:\n");
                 for (i = 0; i < n; ++i) {
-                    SDL_GetRenderDriverInfo(i, &info);
+                    SDL_GetRenderDriverInfoEx(i, &info);
                     SDLTest_PrintRenderer(&info);
                 }
             }
@@ -1331,10 +1331,10 @@ SDLTest_CommonInit(SDLTest_CommonState * state)
                     || !(state->window_flags & (SDL_WINDOW_OPENGL | SDL_WINDOW_VULKAN | SDL_WINDOW_METAL)))) {
                 m = -1;
                 if (state->renderdriver) {
-                    SDL_RendererInfo info;
+                    SDL_RendererInfoEx info;
                     n = SDL_GetNumRenderDrivers();
                     for (j = 0; j < n; ++j) {
-                        SDL_GetRenderDriverInfo(j, &info);
+                        SDL_GetRenderDriverInfoEx(j, &info);
                         if (SDL_strcasecmp(info.name, state->renderdriver) == 0) {
                             m = j;
                             break;
@@ -1359,10 +1359,10 @@ SDLTest_CommonInit(SDLTest_CommonState * state)
                     SDL_RenderSetScale(state->renderers[i], state->scale, state->scale);
                 }
                 if (state->verbose & VERBOSE_RENDER) {
-                    SDL_RendererInfo info;
+                    SDL_RendererInfoEx info;
 
                     SDL_Log("Current renderer:\n");
-                    SDL_GetRendererInfo(state->renderers[i], &info);
+                    SDL_GetRendererInfoEx(state->renderers[i], &info);
                     SDLTest_PrintRenderer(&info);
                 }
             }
@@ -2247,7 +2247,7 @@ SDLTest_CommonDrawWindowInfo(SDL_Renderer * renderer, SDL_Window * window, int *
     float scaleX, scaleY;
     Uint32 flags;
     const int windowDisplayIndex = SDL_GetWindowDisplayIndex(window);
-    SDL_RendererInfo info;
+    SDL_RendererInfoEx info;
 
     /* Video */
 
@@ -2269,7 +2269,7 @@ SDLTest_CommonDrawWindowInfo(SDL_Renderer * renderer, SDL_Window * window, int *
 
     SDL_SetRenderDrawColor(renderer, 170, 170, 170, 255);
 
-    if (0 == SDL_GetRendererInfo(renderer, &info)) {
+    if (0 == SDL_GetRendererInfoEx(renderer, &info)) {
         SDL_snprintf(text, sizeof(text), "SDL_GetRendererInfo: name: %s", info.name);
         SDLTest_DrawString(renderer, 0, textY, text);
         textY += lineHeight;

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -195,7 +195,7 @@ typedef struct {
 static int
 SDL_CreateWindowTexture(SDL_VideoDevice *_this, SDL_Window * window, Uint32 * format, void ** pixels, int *pitch)
 {
-    SDL_RendererInfo info;
+    SDL_RendererInfoEx info;
     SDL_WindowTextureData *data = SDL_GetWindowData(window, SDL_WINDOWTEXTUREDATA);
     int i;
 
@@ -212,23 +212,23 @@ SDL_CreateWindowTexture(SDL_VideoDevice *_this, SDL_Window * window, Uint32 * fo
         /* Check to see if there's a specific driver requested */
         if (specific_accelerated_renderer) {
             for (i = 0; i < SDL_GetNumRenderDrivers(); ++i) {
-                SDL_GetRenderDriverInfo(i, &info);
+                SDL_GetRenderDriverInfoEx(i, &info);
                 if (SDL_strcasecmp(info.name, hint) == 0) {
                     renderer = SDL_CreateRenderer(window, i, 0);
                     break;
                 }
             }
-            if (!renderer || (SDL_GetRendererInfo(renderer, &info) == -1)) {
+            if (!renderer || (SDL_GetRendererInfoEx(renderer, &info) == -1)) {
                 if (renderer) { SDL_DestroyRenderer(renderer); }
                 return SDL_SetError("Requested renderer for " SDL_HINT_FRAMEBUFFER_ACCELERATION " is not available");
             }
             /* if it was specifically requested, even if SDL_RENDERER_ACCELERATED isn't set, we'll accept this renderer. */
         } else {
             for (i = 0; i < SDL_GetNumRenderDrivers(); ++i) {
-                SDL_GetRenderDriverInfo(i, &info);
+                SDL_GetRenderDriverInfoEx(i, &info);
                 if (SDL_strcmp(info.name, "software") != 0) {
                     renderer = SDL_CreateRenderer(window, i, 0);
-                    if (renderer && (SDL_GetRendererInfo(renderer, &info) == 0) && (info.flags & SDL_RENDERER_ACCELERATED)) {
+                    if (renderer && (SDL_GetRendererInfoEx(renderer, &info) == 0) && (info.flags & SDL_RENDERER_ACCELERATED)) {
                         break;  /* this will work. */
                     }
                     if (renderer) {  /* wasn't accelerated, etc, skip it. */
@@ -254,7 +254,7 @@ SDL_CreateWindowTexture(SDL_VideoDevice *_this, SDL_Window * window, Uint32 * fo
 
         data->renderer = renderer;
     } else {
-        if (SDL_GetRendererInfo(data->renderer, &info) == -1) {
+        if (SDL_GetRendererInfoEx(data->renderer, &info) == -1) {
             return -1;
         }
     }

--- a/src/video/directfb/SDL_DirectFB_render.c
+++ b/src/video/directfb/SDL_DirectFB_render.c
@@ -1224,8 +1224,6 @@ DirectFB_CreateRenderer(SDL_Window * window, Uint32 flags)
         renderer->info.flags |= SDL_RENDERER_SINGLEBUFFER;
 #endif
 
-    DirectFB_SetSupportedPixelFormats(&renderer->info);
-
 #if 0
     /* Set up a palette watch on the display palette */
     if (display-> palette) {
@@ -1241,6 +1239,31 @@ DirectFB_CreateRenderer(SDL_Window * window, Uint32 flags)
     return NULL;
 }
 
+static const Uint32 DirectFB_TextureFormats[] = {
+    SDL_PIXELFORMAT_RGB888,
+    SDL_PIXELFORMAT_ARGB8888,
+    SDL_PIXELFORMAT_RGB565,
+    SDL_PIXELFORMAT_RGB332,
+    SDL_PIXELFORMAT_ARGB4444,
+    SDL_PIXELFORMAT_ARGB1555,
+    SDL_PIXELFORMAT_RGB24,
+    SDL_PIXELFORMAT_RGB444,
+    SDL_PIXELFORMAT_YV12,
+    SDL_PIXELFORMAT_IYUV,
+    SDL_PIXELFORMAT_YUY2,
+    SDL_PIXELFORMAT_UYVY,
+    SDL_PIXELFORMAT_RGB555,
+#if (DFB_VERSION_ATLEAST(1,5,0))
+    SDL_PIXELFORMAT_ABGR8888,
+#endif
+#if (ENABLE_LUT8)
+    SDL_PIXELFORMAT_INDEX8,
+#endif
+
+#if (DFB_VERSION_ATLEAST(1,2,0))
+    SDL_PIXELFORMAT_BGR555,
+#endif
+};
 
 SDL_RenderDriver DirectFB_RenderDriver = {
     DirectFB_CreateRenderer,
@@ -1253,10 +1276,8 @@ SDL_RenderDriver DirectFB_RenderDriver = {
       SDL_BLENDMODE_ADD | SDL_BLENDMODE_MOD),
      (SDL_SCALEMODE_NONE | SDL_SCALEMODE_FAST |
       SDL_SCALEMODE_SLOW | SDL_SCALEMODE_BEST), */
-     0,
-     {
-             /* formats filled in later */
-     },
+     SDL_arraysize(DirectFB_TextureFormats),
+     DirectFB_TextureFormats,
      0,
      0}
 };

--- a/src/video/directfb/SDL_DirectFB_video.c
+++ b/src/video/directfb/SDL_DirectFB_video.c
@@ -405,14 +405,4 @@ DirectFB_SDLToDFBPixelFormat(Uint32 format)
     return DSPF_UNKNOWN;
 }
 
-void DirectFB_SetSupportedPixelFormats(SDL_RendererInfo* ri)
-{
-    int i, j;
-
-    for (i=0, j=0; pixelformat_tab[i].dfb != DSPF_UNKNOWN; i++)
-        if (pixelformat_tab[i].sdl != SDL_PIXELFORMAT_UNKNOWN)
-            ri->texture_formats[j++] = pixelformat_tab[i].sdl;
-    ri->num_texture_formats = j;
-}
-
 #endif /* SDL_VIDEO_DRIVER_DIRECTFB */

--- a/src/video/directfb/SDL_DirectFB_video.h
+++ b/src/video/directfb/SDL_DirectFB_video.h
@@ -159,7 +159,6 @@ struct _DFB_DeviceData
 
 Uint32 DirectFB_DFBToSDLPixelFormat(DFBSurfacePixelFormat pixelformat);
 DFBSurfacePixelFormat DirectFB_SDLToDFBPixelFormat(Uint32 format);
-void DirectFB_SetSupportedPixelFormats(SDL_RendererInfo *ri);
 
 
 #endif /* SDL_DirectFB_video_h_ */


### PR DESCRIPTION
Hi. The original `SDL_RendererInfo` is arbitrarily limited to 16 supported texture formats, which is an issue for drivers which support more than that. I bumped into this issue with the Wii U, which supports a huge variety of texture formats natively. The new `SDL_RendererInfoEx` should support up to 4,294,967,295 formats, which is surely more than enough.

Some new public functions have been added to the API for retrieving an `SDL_RendererInfoEx` instead of an `SDL_RendererInfo`. `SDL_test_common.c` has been modified to use these instead of the now-deprecated functions.