### PR TITLE
Vita: restore sceClibMemcmp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2492,10 +2492,6 @@ elseif(VITA)
 #  set_property(SOURCE ${SDL2_SOURCE_DIR}/src/video/arm/pixman-arm-neon-asm.S PROPERTY LANGUAGE C)
 
   target_compile_definitions(sdl-build-options INTERFACE "-D__VITA__")
-  target_compile_definitions(sdl-build-options INTERFACE "-Dmemcpy=sceClibMemcpy")
-  target_compile_definitions(sdl-build-options INTERFACE "-Dmemset=sceClibMemset")
-  target_compile_definitions(sdl-build-options INTERFACE "-Dmemmove=sceClibMemmove")
-  target_compile_definitions(sdl-build-options INTERFACE "-Dmemcmp=sceClibMemcmp")
 
 #  CheckPTHREAD()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2495,6 +2495,7 @@ elseif(VITA)
   target_compile_definitions(sdl-build-options INTERFACE "-Dmemcpy=sceClibMemcpy")
   target_compile_definitions(sdl-build-options INTERFACE "-Dmemset=sceClibMemset")
   target_compile_definitions(sdl-build-options INTERFACE "-Dmemmove=sceClibMemmove")
+  target_compile_definitions(sdl-build-options INTERFACE "-Dmemcmp=sceClibMemcmp")
 
 #  CheckPTHREAD()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Revert #6218 with additional check to make it linux/bsd - compatible.

Additionally drop other mem redefines, since we have them in libc now.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
