### PR TITLE
Check also for __ARM_ARCH in SDL_atomic.h

### DIFF
--- a/include/SDL_atomic.h
+++ b/include/SDL_atomic.h
@@ -240,7 +240,7 @@ typedef void (*SDL_KernelMemoryBarrierFunc)();
 /* "REP NOP" is PAUSE, coded for tools that don't know it by that name. */
 #if (defined(__GNUC__) || defined(__clang__)) && (defined(__i386__) || defined(__x86_64__))
     #define SDL_CPUPauseInstruction() __asm__ __volatile__("pause\n")  /* Some assemblers can't do REP NOP, so go with PAUSE. */
-#elif (defined(__arm__) && __ARM_ARCH >= 7) || defined(__aarch64__)
+#elif (defined(__arm__) && (__ARM_ARCH__ >= 7 || __ARM_ARCH >= 7)) || defined(__aarch64__)
     #define SDL_CPUPauseInstruction() __asm__ __volatile__("yield" ::: "memory")
 #elif (defined(__powerpc__) || defined(__powerpc64__))
     #define SDL_CPUPauseInstruction() __asm__ __volatile__("or 27,27,27");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Otherwise building openrct2 on FreeBSD/armv7 fails with:
`In file included from /usr/ports/games/openrct2/work/OpenRCT2-0.4.1/src/openrct2-ui/CursorRepository.h:12: In file included from /usr/local/include/SDL2/SDL.h:35: /usr/local/include/SDL2/SDL_atomic.h:243:28: error: '__ARM_ARCH__' is not defined, evaluates to 0 [-Werror,-Wundef] #elif (defined(__arm__) && __ARM_ARCH__ >= 7) || defined(__aarch64__)`
## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
