### PR TITLE
Fix: Use WIN_ClientPointToSDL for converting additional mouse coordinate events (for DPI scaling)

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -428,9 +428,13 @@ WIN_UpdateFocus(SDL_Window *window, SDL_bool expect_focus)
 
         /* In relative mode we are guaranteed to have mouse focus if we have keyboard focus */
         if (!SDL_GetMouse()->relative_mode) {
+            SDL_Point point;
             GetCursorPos(&cursorPos);
             ScreenToClient(hwnd, &cursorPos);
-            SDL_SendMouseMotion(window, 0, 0, cursorPos.x, cursorPos.y);
+            point.x = cursorPos.x;
+            point.y = cursorPos.y;
+            WIN_ClientPointToSDL(data->window, &point.x, &point.y);
+            SDL_SendMouseMotion(window, 0, 0, point.x, point.y);
         }
 
         WIN_CheckAsyncMouseRelease(data);
@@ -909,17 +913,21 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
             if (SDL_GetMouseFocus() == data->window && !SDL_GetMouse()->relative_mode && !IsIconic(hwnd)) {
                 SDL_Mouse *mouse;
                 POINT cursorPos;
+                SDL_Point point;
                 GetCursorPos(&cursorPos);
                 ScreenToClient(hwnd, &cursorPos);
+                point.x = cursorPos.x;
+                point.y = cursorPos.y;
+                WIN_ClientPointToSDL(data->window, &point.x, &point.y);
                 mouse = SDL_GetMouse();
                 if (!mouse->was_touch_mouse_events) { /* we're not a touch handler causing a mouse leave? */
-                    SDL_SendMouseMotion(data->window, 0, 0, cursorPos.x, cursorPos.y);
+                    SDL_SendMouseMotion(data->window, 0, 0, point.x, point.y);
                 } else { /* touch handling? */
                     mouse->was_touch_mouse_events = SDL_FALSE; /* not anymore */
                     if (mouse->touch_mouse_events) { /* convert touch to mouse events */
-                        SDL_SendMouseMotion(data->window, SDL_TOUCH_MOUSEID, 0, cursorPos.x, cursorPos.y);
+                        SDL_SendMouseMotion(data->window, SDL_TOUCH_MOUSEID, 0, point.x, point.y);
                     } else { /* normal handling */
-                        SDL_SendMouseMotion(data->window, 0, 0, cursorPos.x, cursorPos.y);
+                        SDL_SendMouseMotion(data->window, 0, 0, point.x, point.y);
                     }
                }
             }
@@ -1679,13 +1687,17 @@ static void WIN_UpdateMouseCapture()
         SDL_WindowData *data = (SDL_WindowData *) focusWindow->driverdata;
 
         if (!data->mouse_tracked) {
-            POINT pt;
+            POINT cursorPos;
 
-            if (GetCursorPos(&pt) && ScreenToClient(data->hwnd, &pt)) {
+            if (GetCursorPos(&cursorPos) && ScreenToClient(data->hwnd, &cursorPos)) {
                 SDL_bool swapButtons = GetSystemMetrics(SM_SWAPBUTTON) != 0;
                 SDL_MouseID mouseID = SDL_GetMouse()->mouseID;
+                SDL_Point point;
+                point.x = cursorPos.x;
+                point.y = cursorPos.y;
+                WIN_ClientPointToSDL(data->window, &point.x, &point.y);
 
-                SDL_SendMouseMotion(data->window, mouseID, 0, (int)pt.x, (int)pt.y);
+                SDL_SendMouseMotion(data->window, mouseID, 0, point.x, point.y);
                 SDL_SendMouseButton(data->window, mouseID, GetAsyncKeyState(VK_LBUTTON) & 0x8000 ? SDL_PRESSED : SDL_RELEASED, !swapButtons ? SDL_BUTTON_LEFT : SDL_BUTTON_RIGHT);
                 SDL_SendMouseButton(data->window, mouseID, GetAsyncKeyState(VK_RBUTTON) & 0x8000 ? SDL_PRESSED : SDL_RELEASED, !swapButtons ? SDL_BUTTON_RIGHT : SDL_BUTTON_LEFT);
                 SDL_SendMouseButton(data->window, mouseID, GetAsyncKeyState(VK_MBUTTON) & 0x8000 ? SDL_PRESSED : SDL_RELEASED, SDL_BUTTON_MIDDLE);


### PR DESCRIPTION
This PR adds `WIN_ClientPointToSDL` conversion to other mouse motion events triggered by `WM_MOUSELEAVE`, `WIN_UpdateFocus`, and `WIN_UpdateMouseCapture`.

## Description
<!--- Describe your changes in detail -->

Since https://github.com/libsdl-org/SDL/commit/ab81a559f43abc0858c96788f8e00bbb352287e8, SDL has supported the `SDL_WINDOWS_DPI_SCALING`, which changes the SDL coordinate system units to be DPI-scaled points.

In that commit, `WIN_ClientPointToSDL` was used to convert mouse positions to SDL coordinate system units (before passing them to `SDL_SendMouseMotion`).

However, a few places were missed, which could result in unexpected / incorrect mouse position values when using `SDL_WINDOWS_DPI_SCALING` on a system with a high DPI mode in certain cases (like that triggered by `WM_MOUSELEAVE`).

This PR adds `WIN_ClientPointToSDL` conversion to other mouse motion events triggered by `WM_MOUSELEAVE`, `WIN_UpdateFocus`, and `WIN_UpdateMouseCapture`.

## Existing Issue(s)
Fixes #6261
