### PR TITLE
wayland: Only clear the key repeat flag when the repeated key is released

### DIFF
--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -71,6 +71,7 @@ typedef struct {
     SDL_bool is_initialized;
 
     SDL_bool is_key_down;
+    uint32_t key;
     uint32_t wl_press_time; // Key press time as reported by the Wayland API
     uint32_t sdl_press_time; // Key press time expressed in SDL ticks
     uint32_t next_repeat_ms;


### PR DESCRIPTION
If multiple keys were simultaneously depressed and one was being repeated, the repeat flag was being cleared when any of the pressed keys were released, even if the released key wasn't the one being repeated.

This tracks the key currently being repeated and only clears the repeat flag when the particular key being repeated is released.

Fixes #6267