### PR TITLE
haiku: Fix SDL_GetWindowSurface always failing when screen color depth was 24 bits

### DIFF
--- a/src/video/haiku/SDL_bmodes.cc
+++ b/src/video/haiku/SDL_bmodes.cc
@@ -148,6 +148,10 @@ int32 HAIKU_ColorSpaceToSDLPxFormat(uint32 colorspace)
     case B_RGB16_BIG:
         return SDL_PIXELFORMAT_RGB565;
         break;
+    case B_RGB24:
+    case B_RGB24_BIG:
+        return SDL_PIXELFORMAT_BGR24;
+        break;
     case B_RGB32:
     case B_RGBA32:
     case B_RGB32_BIG:


### PR DESCRIPTION
## Description
Before, `HAIKU_ColorSpaceToSDLPxFormat` was returning `0` for 24 bit screen colorspaces, which would ultimately lead to `SDL_GetWindowSurface` failing with 'Unknown pixel format' error

---

To trigger this bug, just open the Screen app and change color depth to 24 bits, then run an SDL application that uses SDL_GetWindowSurface 
![image](https://user-images.githubusercontent.com/6509348/191887149-b2038b5f-bcfa-4754-a84e-28097bd76275.png)

