### PR TITLE
wayland: Add mappings for the Escape and NumLock keys

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -73,6 +73,8 @@ static const struct {
     xkb_keysym_t keysym;
     SDL_KeyCode keycode;
 } KeySymToSDLKeyCode[] = {
+    { XKB_KEY_Escape, SDLK_ESCAPE },
+    { XKB_KEY_Num_Lock, SDLK_NUMLOCKCLEAR },
     { XKB_KEY_Shift_L, SDLK_LSHIFT },
     { XKB_KEY_Shift_R, SDLK_RSHIFT },
     { XKB_KEY_Control_L, SDLK_LCTRL },


### PR DESCRIPTION
The XKB keysym to SDL keycode mappings were missing for the Escape and NumLock keys, which prevented them from being remapped. Add them to the table so that the remapping of these keys will work.

Fixes #6256