### PR TITLE
testiconv: Print the total number of errors at the end

### DIFF
--- a/test/testiconv.c
+++ b/test/testiconv.c
@@ -86,5 +86,7 @@ main(int argc, char *argv[])
         SDL_free(test[0]);
     }
     fclose(file);
+
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Total errors: %d\n", errors);
     return (errors ? errors + 1 : 0);
 }


### PR DESCRIPTION
This helps make it more clear at a glance whether or not testiconv succeeded or not.

This change is based on libsdl-org/SDL-1.2#868 and libsdl-org/sdl12-compat#219.
