### PR TITLE
cmake: only add -Wl,--undefined=WinMain when building an executable

### DIFF
--- a/sdl2-config.cmake.in
+++ b/sdl2-config.cmake.in
@@ -80,12 +80,12 @@ if(EXISTS "${_sdl2main_library}")
       if(CMAKE_SIZEOF_VOID_P EQUAL 4)
         set_target_properties(SDL2::SDL2main
           PROPERTIES
-            INTERFACE_LINK_OPTIONS "-Wl,--undefined=_WinMain@16"
+            INTERFACE_LINK_OPTIONS "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:-Wl,--undefined=_WinMain@16>"
         )
       else()
         set_target_properties(SDL2::SDL2main
           PROPERTIES
-            INTERFACE_LINK_OPTIONS "-Wl,--undefined=WinMain"
+            INTERFACE_LINK_OPTIONS "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:-Wl,--undefined=WinMain>"
         )
       endif()
     endif()


### PR DESCRIPTION
Same as https://github.com/libsdl-org/SDL/pull/6260 but for the autotools build system

It looks like autotools for MinGW is not tested on CI.
Is this intentional?