### PR TITLE
dbus: guard against uninitialized D-Bus

### DIFF
--- a/src/core/linux/SDL_dbus.c
+++ b/src/core/linux/SDL_dbus.c
@@ -419,6 +419,12 @@ SDL_DBus_ScreensaverInhibit(SDL_bool inhibit)
         return SDL_TRUE;
     }
 
+    if (!dbus.session_conn) {
+        /* We either lost connection to the session bus or were not able to
+         * load the D-Bus library at all. */
+        return SDL_FALSE;
+    }
+
     if (SDL_DetectSandbox() != SDL_SANDBOX_NONE) {
         const char *bus_name = "org.freedesktop.portal.Desktop";
         const char *path = "/org/freedesktop/portal/desktop";


### PR DESCRIPTION
Before calling any DBus related methods we should first ensure that they were correctly loaded.

In the event where `LoadDBUSLibrary()` was not able to load the DBus library, we should just return early, signalling with SDL_FALSE that we were unable to inhibit the Screensaver.

Helps: https://github.com/ValveSoftware/steam-for-linux/issues/8815

