### PR TITLE
kmsdrm: only negative devindex's are not allowed

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -236,7 +236,7 @@ KMSDRM_CreateDevice(void)
 
     devindex = get_driindex();
     if (devindex < 0) {
-        SDL_SetError("devindex (%d) must be between 0 and 99.", devindex);
+        SDL_SetError("devindex (%d) must not be negative.", devindex);
         return NULL;
     }
 


### PR DESCRIPTION
ad874536 removed an unnecessary limit as we *can* have a devindex greater than 99, this error message does not reflect the support for values greater than 99.
