### PR TITLE
wayland: Call the Wayland hide/show functions directly when changing decoration modes

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -777,6 +777,7 @@ handle_configure_zxdg_decoration(void *data,
 {
     SDL_Window *window = (SDL_Window *) data;
     SDL_WindowData *driverdata = (SDL_WindowData *) window->driverdata;
+    SDL_VideoDevice *device = SDL_GetVideoDevice();
 
     /* If the compositor tries to force CSD anyway, bail on direct XDG support
      * and fall back to libdecor, it will handle these events from then on.
@@ -793,9 +794,13 @@ handle_configure_zxdg_decoration(void *data,
             return;
         }
         WAYLAND_wl_display_roundtrip(driverdata->waylandData->display);
-        SDL_HideWindow(window);
+
+        Wayland_HideWindow(device, window);
         driverdata->shell_surface_type = WAYLAND_SURFACE_LIBDECOR;
-        SDL_ShowWindow(window);
+
+        if (!window->is_hiding && !(window->flags & SDL_WINDOW_HIDDEN)) {
+            Wayland_ShowWindow(device, window);
+        }
     }
 }
 


### PR DESCRIPTION
Calling SDL_HideWindow() to destroy the window is a NOP if the SDL_WINDOW_SHOWN flag was never set. Bypass it and call the Wayland-specific function directly to ensure that the window is always destroyed before switching from server-side to client-side decorations, even if it hasn't been shown yet.

Likewise, call Wayland_ShowWindow() directly when the window isn't explicitly hidden to ensure that it is always recreated since the SDL_WINDOW_SHOWN flag won't be cleared, which, when set, renders SDL_ShowWindow() a NOP.

Fixes #6284
