### PR TITLE
emscripten: Remove use of EM_ASM from SDL_timer code.

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: mymindstorm/setup-emsdk@v10
         with:
-          version: 2.0.31
+          version: 2.0.32
       - name: Configure CMake
         run: |
           emcmake cmake -S . -B build \


### PR DESCRIPTION
Instead use the native emscripten timer API.

See https://github.com/emscripten-core/emscripten/issues/17941