### PR TITLE
iOS: remove dead pre-iOS 8 codepaths.

### DIFF
--- a/docs/README-ios.md
+++ b/docs/README-ios.md
@@ -293,7 +293,7 @@ e.g.
 Deploying to older versions of iOS
 ==============================================================================
 
-SDL supports deploying to older versions of iOS than are supported by the latest version of Xcode, all the way back to iOS 6.1
+SDL supports deploying to older versions of iOS than are supported by the latest version of Xcode, all the way back to iOS 8.0
 
 In order to do that you need to download an older version of Xcode:
 https://developer.apple.com/download/more/?name=Xcode

--- a/src/video/uikit/SDL_uikitappdelegate.m
+++ b/src/video/uikit/SDL_uikitappdelegate.m
@@ -141,10 +141,9 @@ SDL_LoadLaunchImageNamed(NSString *name, int screenh)
 
     NSString *screenname = nibNameOrNil;
     NSBundle *bundle = nibBundleOrNil;
-    BOOL atleastiOS8 = UIKit_IsSystemVersionAtLeast(8.0);
 
-    /* Launch screens were added in iOS 8. Otherwise we use launch images. */
-    if (screenname && atleastiOS8) {
+    /* A launch screen may not exist. Fall back to launch images in that case. */
+    if (screenname) {
         @try {
             self.view = [bundle loadNibNamed:screenname owner:self options:nil][0];
         }
@@ -241,9 +240,9 @@ SDL_LoadLaunchImageNamed(NSString *name, int screenh)
             UIImageOrientation imageorient = UIImageOrientationUp;
 
 #if !TARGET_OS_TV
-            /* Bugs observed / workaround tested in iOS 8.3, 7.1, and 6.1. */
+            /* Bugs observed / workaround tested in iOS 8.3. */
             if (UIInterfaceOrientationIsLandscape(curorient)) {
-                if (atleastiOS8 && image.size.width < image.size.height) {
+                if (image.size.width < image.size.height) {
                     /* On iOS 8, portrait launch images displayed in forced-
                      * landscape mode (e.g. a standard Default.png on an iPhone
                      * when Info.plist only supports landscape orientations) need
@@ -252,15 +251,6 @@ SDL_LoadLaunchImageNamed(NSString *name, int screenh)
                         imageorient = UIImageOrientationRight;
                     } else if (curorient == UIInterfaceOrientationLandscapeRight) {
                         imageorient = UIImageOrientationLeft;
-                    }
-                } else if (!atleastiOS8 && image.size.width > image.size.height) {
-                    /* On iOS 7 and below, landscape launch images displayed in
-                     * landscape mode (e.g. landscape iPad launch images) need
-                     * to be rotated to display in the expected orientation. */
-                    if (curorient == UIInterfaceOrientationLandscapeLeft) {
-                        imageorient = UIImageOrientationLeft;
-                    } else if (curorient == UIInterfaceOrientationLandscapeRight) {
-                        imageorient = UIImageOrientationRight;
                     }
                 }
             }
@@ -378,7 +368,7 @@ SDL_LoadLaunchImageNamed(NSString *name, int screenh)
 #if !TARGET_OS_TV
     screenname = [bundle objectForInfoDictionaryKey:@"UILaunchStoryboardName"];
 
-    if (screenname && UIKit_IsSystemVersionAtLeast(8.0)) {
+    if (screenname) {
         @try {
             /* The launch storyboard is actually a nib in some older versions of
              * Xcode. We'll try to load it as a storyboard first, as it's more

--- a/src/video/uikit/SDL_uikitmessagebox.m
+++ b/src/video/uikit/SDL_uikitmessagebox.m
@@ -124,86 +124,16 @@ UIKit_ShowMessageBoxAlertController(const SDL_MessageBoxData *messageboxdata, in
     return YES;
 }
 
-/* UIAlertView is deprecated in iOS 8+ in favor of UIAlertController. */
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < 80000
-@interface SDLAlertViewDelegate : NSObject <UIAlertViewDelegate>
-
-@property (nonatomic, assign) int *clickedIndex;
-
-@end
-
-@implementation SDLAlertViewDelegate
-
-- (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex
-{
-    if (_clickedIndex != NULL) {
-        *_clickedIndex = (int) buttonIndex;
-    }
-}
-
-@end
-#endif /* __IPHONE_OS_VERSION_MIN_REQUIRED < 80000 */
-
-static BOOL
-UIKit_ShowMessageBoxAlertView(const SDL_MessageBoxData *messageboxdata, int *buttonid)
-{
-    /* UIAlertView is deprecated in iOS 8+ in favor of UIAlertController. */
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < 80000
-    int i;
-    int clickedindex = messageboxdata->numbuttons;
-    UIAlertView *alert = [[UIAlertView alloc] init];
-    SDLAlertViewDelegate *delegate = [[SDLAlertViewDelegate alloc] init];
-
-    alert.delegate = delegate;
-    alert.title = @(messageboxdata->title);
-    alert.message = @(messageboxdata->message);
-
-    for (i = 0; i < messageboxdata->numbuttons; i++) {
-        const SDL_MessageBoxButtonData *sdlButton;
-        if (messageboxdata->flags & SDL_MESSAGEBOX_BUTTONS_RIGHT_TO_LEFT) {
-            sdlButton = &messageboxdata->buttons[messageboxdata->numbuttons - 1 - i];
-        } else {
-            sdlButton = &messageboxdata->buttons[i];
-        }
-        [alert addButtonWithTitle:@(sdlButton->text)];
-    }
-
-    delegate.clickedIndex = &clickedindex;
-
-    [alert show];
-
-    UIKit_WaitUntilMessageBoxClosed(messageboxdata, &clickedindex);
-
-    alert.delegate = nil;
-
-    if (messageboxdata->flags & SDL_MESSAGEBOX_BUTTONS_RIGHT_TO_LEFT) {
-        clickedindex = messageboxdata->numbuttons - 1 - clickedindex;
-    }
-    *buttonid = messageboxdata->buttons[clickedindex].buttonid;
-    return YES;
-#else
-    return NO;
-#endif /* __IPHONE_OS_VERSION_MIN_REQUIRED < 80000 */
-}
-
 static void
 UIKit_ShowMessageBoxImpl(const SDL_MessageBoxData *messageboxdata, int *buttonid, int *returnValue)
+{ @autoreleasepool
 {
-    BOOL success = NO;
-
-    @autoreleasepool {
-        success = UIKit_ShowMessageBoxAlertController(messageboxdata, buttonid);
-        if (!success) {
-            success = UIKit_ShowMessageBoxAlertView(messageboxdata, buttonid);
-        }
-    }
-
-    if (!success) {
-        *returnValue = SDL_SetError("Could not show message box.");
-    } else {
+    if (UIKit_ShowMessageBoxAlertController(messageboxdata, buttonid)) {
         *returnValue = 0;
+    } else {
+        *returnValue = SDL_SetError("Could not show message box.");
     }
-}
+}}
 
 int
 UIKit_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonid)

--- a/src/video/uikit/SDL_uikitmetalview.m
+++ b/src/video/uikit/SDL_uikitmetalview.m
@@ -87,11 +87,7 @@ UIKit_Metal_CreateView(_THIS, SDL_Window * window)
          * dimensions of the screen rather than the dimensions in points
          * yielding high resolution on retine displays.
          */
-        if ([data.uiwindow.screen respondsToSelector:@selector(nativeScale)]) {
-            scale = data.uiwindow.screen.nativeScale;
-        } else {
-            scale = data.uiwindow.screen.scale;
-        }
+        scale = data.uiwindow.screen.nativeScale;
     }
 
     metalview = [[SDL_uikitmetalview alloc] initWithFrame:data.uiwindow.bounds

--- a/src/video/uikit/SDL_uikitmodes.m
+++ b/src/video/uikit/SDL_uikitmodes.m
@@ -150,11 +150,7 @@
              * Estimate the DPI based on the screen scale multiplied by the base DPI for the device
              * type (e.g. based on iPhone 1 and iPad 1)
              */
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 80000
             float scale = (float)screen.nativeScale;
-    #else
-            float scale = (float)screen.scale;
-    #endif
             float defaultDPI;
             if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
                 defaultDPI = 132.0f;
@@ -502,12 +498,6 @@ UIKit_GetDisplayUsableBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect)
         if (SDL_GetDisplayBounds(displayIndex, rect) < 0) {
             return -1;
         }
-
-#if !TARGET_OS_TV && __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_7_0
-        if (!UIKit_IsSystemVersionAtLeast(7.0)) {
-            frame = [data.uiscreen applicationFrame];
-        }
-#endif
 
         rect->x += frame.origin.x;
         rect->y += frame.origin.y;

--- a/src/video/uikit/SDL_uikitopengles.m
+++ b/src/video/uikit/SDL_uikitopengles.m
@@ -150,9 +150,8 @@ UIKit_GL_CreateContext(_THIS, SDL_Window * window)
          * versions. */
         EAGLRenderingAPI api = major;
 
-        /* iOS currently doesn't support GLES >3.0. iOS 6 also only supports up
-         * to GLES 2.0. */
-        if (major > 3 || (major == 3 && (minor > 0 || !UIKit_IsSystemVersionAtLeast(7.0)))) {
+        /* iOS currently doesn't support GLES >3.0. */
+        if (major > 3 || (major == 3 && minor > 0)) {
             SDL_SetError("OpenGL ES %d.%d context could not be created", major, minor);
             return NULL;
         }
@@ -170,11 +169,7 @@ UIKit_GL_CreateContext(_THIS, SDL_Window * window)
             /* Set the scale to the natural scale factor of the screen - the
              * backing dimensions of the OpenGL view will match the pixel
              * dimensions of the screen rather than the dimensions in points. */
-            if ([data.uiwindow.screen respondsToSelector:@selector(nativeScale)]) {
-                scale = data.uiwindow.screen.nativeScale;
-            } else {
-                scale = data.uiwindow.screen.scale;
-            }
+            scale = data.uiwindow.screen.nativeScale;
         }
 
         context = [[SDLEAGLContext alloc] initWithAPI:api sharegroup:sharegroup];

--- a/src/video/uikit/SDL_uikitopenglview.m
+++ b/src/video/uikit/SDL_uikitopenglview.m
@@ -93,14 +93,8 @@
         }
 
         if (sRGB) {
-            /* sRGB EAGL drawable support was added in iOS 7. */
-            if (UIKit_IsSystemVersionAtLeast(7.0)) {
-                colorFormat = kEAGLColorFormatSRGBA8;
-                colorBufferFormat = GL_SRGB8_ALPHA8;
-            } else {
-                SDL_SetError("sRGB drawables are not supported.");
-                return nil;
-            }
+            colorFormat = kEAGLColorFormatSRGBA8;
+            colorBufferFormat = GL_SRGB8_ALPHA8;
         } else if (rBits >= 8 || gBits >= 8 || bBits >= 8 || aBits > 0) {
             /* if user specifically requests rbg888 or some color format higher than 16bpp */
             colorFormat = kEAGLColorFormatRGBA8;

--- a/src/video/uikit/SDL_uikitvideo.m
+++ b/src/video/uikit/SDL_uikitvideo.m
@@ -209,15 +209,6 @@ UIKit_ComputeViewFrame(SDL_Window *window, UIScreen *screen)
         frame = data.uiwindow.bounds;
     }
 
-#if !TARGET_OS_TV && (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_7_0)
-    BOOL hasiOS7 = UIKit_IsSystemVersionAtLeast(7.0);
-
-    /* The view should always show behind the status bar in iOS 7+. */
-    if (!hasiOS7 && !(window->flags & (SDL_WINDOW_BORDERLESS|SDL_WINDOW_FULLSCREEN))) {
-        frame = screen.applicationFrame;
-    }
-#endif
-
 #if !TARGET_OS_TV
     /* iOS 10 seems to have a bug where, in certain conditions, putting the
      * device to sleep with the a landscape-only app open, re-orienting the
@@ -227,18 +218,16 @@ UIKit_ComputeViewFrame(SDL_Window *window, UIScreen *screen)
      * https://bugzilla.libsdl.org/show_bug.cgi?id=3505
      * https://bugzilla.libsdl.org/show_bug.cgi?id=3465
      * https://forums.developer.apple.com/thread/65337 */
-    if (UIKit_IsSystemVersionAtLeast(8.0)) {
-        UIInterfaceOrientation orient = [UIApplication sharedApplication].statusBarOrientation;
-        BOOL landscape = UIInterfaceOrientationIsLandscape(orient);
-        BOOL fullscreen = CGRectEqualToRect(screen.bounds, frame);
+    UIInterfaceOrientation orient = [UIApplication sharedApplication].statusBarOrientation;
+    BOOL landscape = UIInterfaceOrientationIsLandscape(orient);
+    BOOL fullscreen = CGRectEqualToRect(screen.bounds, frame);
 
-        /* The orientation flip doesn't make sense when the window is smaller
-         * than the screen (iPad Split View, for example). */
-        if (fullscreen && (landscape != (frame.size.width > frame.size.height))) {
-            float height = frame.size.width;
-            frame.size.width = frame.size.height;
-            frame.size.height = height;
-        }
+    /* The orientation flip doesn't make sense when the window is smaller
+     * than the screen (iPad Split View, for example). */
+    if (fullscreen && (landscape != (frame.size.width > frame.size.height))) {
+        float height = frame.size.width;
+        frame.size.width = frame.size.height;
+        frame.size.height = height;
     }
 #endif
 

--- a/src/video/uikit/SDL_uikitviewcontroller.m
+++ b/src/video/uikit/SDL_uikitviewcontroller.m
@@ -204,13 +204,6 @@ SDL_HideHomeIndicatorHintChanged(void *userdata, const char *name, const char *o
     return UIKit_GetSupportedOrientations(window);
 }
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_7_0
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)orient
-{
-    return ([self supportedInterfaceOrientations] & (1 << orient)) != 0;
-}
-#endif
-
 - (BOOL)prefersStatusBarHidden
 {
     BOOL hidden = (window->flags & (SDL_WINDOW_FULLSCREEN|SDL_WINDOW_BORDERLESS)) != 0;
@@ -334,8 +327,6 @@ SDL_HideHomeIndicatorHintChanged(void *userdata, const char *name, const char *o
     }
 }
 
-/* willRotateToInterfaceOrientation and didRotateFromInterfaceOrientation are deprecated in iOS 8+ in favor of viewWillTransitionToSize */
-#if TARGET_OS_TV || __IPHONE_OS_VERSION_MIN_REQUIRED >= 80000
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
@@ -345,17 +336,6 @@ SDL_HideHomeIndicatorHintChanged(void *userdata, const char *name, const char *o
         self->rotatingOrientation = NO;
     }];
 }
-#else
-- (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
-    [super willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
-    rotatingOrientation = YES;
-}
-
-- (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {
-    [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
-    rotatingOrientation = NO;
-}
-#endif /* TARGET_OS_TV || __IPHONE_OS_VERSION_MIN_REQUIRED >= 80000 */
 
 - (void)deinitKeyboard
 {

--- a/src/video/uikit/SDL_uikitwindow.m
+++ b/src/video/uikit/SDL_uikitwindow.m
@@ -286,10 +286,7 @@ UIKit_UpdateWindowBorder(_THIS, SDL_Window * window)
             [UIApplication sharedApplication].statusBarHidden = NO;
         }
 
-        /* iOS 7+ won't update the status bar until we tell it to. */
-        if ([viewcontroller respondsToSelector:@selector(setNeedsStatusBarAppearanceUpdate)]) {
-            [viewcontroller setNeedsStatusBarAppearanceUpdate];
-        }
+        [viewcontroller setNeedsStatusBarAppearanceUpdate];
     }
 
     /* Update the view's frame to account for the status bar change. */
@@ -427,7 +424,7 @@ UIKit_GetSupportedOrientations(SDL_Window * window)
          * us, we get the orientations from Info.plist via UIApplication. */
         if ([app.delegate respondsToSelector:@selector(application:supportedInterfaceOrientationsForWindow:)]) {
             validOrientations = [app.delegate application:app supportedInterfaceOrientationsForWindow:data.uiwindow];
-        } else if ([app respondsToSelector:@selector(supportedInterfaceOrientationsForWindow:)]) {
+        } else {
             validOrientations = [app supportedInterfaceOrientationsForWindow:data.uiwindow];
         }
 


### PR DESCRIPTION
## Description
SDL hasn't supported those older iOS versions for a little while now (e.g. https://github.com/libsdl-org/SDL/commit/f789bc7d5f33911671f30438a5c4980a269cee38).

## Existing Issue(s)
None.
