### PR TITLE
Wayland: Dedupe window geometry calls and other optimizations/improvements

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -849,7 +849,7 @@ display_handle_global(void *data, struct wl_registry *registry, uint32_t id,
     /*printf("WAYLAND INTERFACE: %s\n", interface);*/
 
     if (SDL_strcmp(interface, "wl_compositor") == 0) {
-        d->compositor = wl_registry_bind(d->registry, id, &wl_compositor_interface, SDL_min(3, version));
+        d->compositor = wl_registry_bind(d->registry, id, &wl_compositor_interface, SDL_min(4, version));
     } else if (SDL_strcmp(interface, "wl_output") == 0) {
         Wayland_add_display(d, id);
     } else if (SDL_strcmp(interface, "wl_seat") == 0) {

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -992,6 +992,7 @@ Wayland_VideoInit(_THIS)
     WAYLAND_wl_display_flush(data->display);
 
     Wayland_InitKeyboard(_this);
+    Wayland_InitWin(data);
 
     data->initializing = SDL_FALSE;
 
@@ -1033,6 +1034,7 @@ Wayland_VideoQuit(_THIS)
     SDL_VideoData *data = _this->driverdata;
     int i, j;
 
+    Wayland_QuitWin(data);
     Wayland_FiniMouse(data);
 
     for (i = 0; i < _this->num_displays; ++i) {

--- a/src/video/wayland/SDL_waylandvideo.h
+++ b/src/video/wayland/SDL_waylandvideo.h
@@ -95,6 +95,7 @@ typedef struct {
     char *classname;
 
     int relative_mouse_mode;
+    SDL_bool egl_transparency_enabled;
 } SDL_VideoData;
 
 struct SDL_WaylandOutputData {

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -474,7 +474,6 @@ UpdateWindowFullscreen(SDL_Window *window, SDL_bool fullscreen)
             wind->in_fullscreen_transition = SDL_TRUE;
             SDL_SetWindowFullscreen(window, wind->fullscreen_flags);
             wind->in_fullscreen_transition = SDL_FALSE;
-            SetMinMaxDimensions(window, SDL_FALSE);
         }
     } else {
         /* Don't change the fullscreen flags if the window is hidden or being hidden. */

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -522,9 +522,17 @@ surface_damage_frame_done(void *data, struct wl_callback *cb, uint32_t time)
 {
     SDL_WindowData *wind = (SDL_WindowData *)data;
 
-    /* Set the damage region. */
-    wl_surface_damage(wind->surface, 0, 0,
-                      wind->window_width, wind->window_height);
+    /*
+     * wl_surface.damage_buffer is the preferred method of setting the damage region
+     * on compositor version 4 and above.
+     */
+    if (wl_compositor_get_version(wind->waylandData->compositor) >= 4) {
+        wl_surface_damage_buffer(wind->surface, 0, 0,
+                                 wind->drawable_width, wind->drawable_height);
+    } else {
+        wl_surface_damage(wind->surface, 0, 0,
+                          wind->window_width, wind->window_height);
+    }
 
     wl_callback_destroy(cb);
     wind->surface_damage_frame_callback = wl_surface_frame(wind->surface);

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -32,12 +32,6 @@
 
 struct SDL_WaylandInput;
 
-/* TODO: Remove these helpers, they're from before we had shell_surface_type */
-#define WINDOW_IS_XDG_POPUP(window) \
-    (((SDL_WindowData*) window->driverdata)->shell_surface_type == WAYLAND_SURFACE_XDG_POPUP)
-#define WINDOW_IS_LIBDECOR(ignoreme, window) \
-    (((SDL_WindowData*) window->driverdata)->shell_surface_type == WAYLAND_SURFACE_LIBDECOR)
-
 typedef struct {
     SDL_Window *sdlwindow;
     SDL_VideoData *waylandData;

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -142,6 +142,9 @@ Wayland_GetWindowWMInfo(_THIS, SDL_Window * window, SDL_SysWMinfo * info);
 extern int Wayland_SetWindowHitTest(SDL_Window *window, SDL_bool enabled);
 extern int Wayland_FlashWindow(_THIS, SDL_Window * window, SDL_FlashOperation operation);
 
+extern void Wayland_InitWin(SDL_VideoData *data);
+extern void Wayland_QuitWin(SDL_VideoData *data);
+
 #endif /* SDL_waylandwindow_h_ */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -105,7 +105,7 @@ typedef struct {
     float pointer_scale_y;
     int drawable_width, drawable_height;
     int fs_output_width, fs_output_height;
-    SDL_Rect viewport_rect;
+    int window_width, window_height;
     SDL_bool needs_resize_event;
     SDL_bool floating_resize_pending;
     SDL_bool is_fullscreen;


### PR DESCRIPTION
Another small batch of Wayland improvements, the big one being deduplicating calls to set the EGL window size, viewport and surface opaque region in `ConfigureWindowGeometry()`.  This further reduces redundant Wayland state calls and can close #6006, as the point of that was to achieve the same goal. It also allowed for some code removal in `Wayland_CreateWindow()`, the elimination of the window size helper functions, and for the streamlining of the logic when setting the damage region since it now always has the 'true' window size stored.

The other changes include using wl_surface.damage_buffer to set the damage region, as this is the preferred method if the wl_compositor version is ≥ 4, caching the EGL transparency hint at startup and registering a notification callback, so that if it is changed during runtime, window opaque regions will be set or cleared appropriately, and it addresses a TODO by removing the surface type macros, which were remnants of a time when the surface type wasn't explicitly store and they are no longer needed now.

Regarding the last point, while it involves no functional changes, it does touch a lot of lines and I looked over the diff many times to make sure no mistakes were made, but extra sets of eyes are always welcome, so please check things over if you can.