### PR TITLE
fix compilation error SDL_coreaudio mixing declarations and code

### DIFF
--- a/src/audio/coreaudio/SDL_coreaudio.m
+++ b/src/audio/coreaudio/SDL_coreaudio.m
@@ -1177,6 +1177,7 @@ COREAUDIO_GetDefaultAudioInfo(char **name, SDL_AudioSpec *spec, int iscapture)
     char *devname;
     int usable;
     double sampleRate;
+    CFIndex len;
 
     AudioObjectPropertyAddress addr = {
         iscapture ? kAudioHardwarePropertyDefaultInputDevice
@@ -1222,7 +1223,7 @@ COREAUDIO_GetDefaultAudioInfo(char **name, SDL_AudioSpec *spec, int iscapture)
             return SDL_SetError("%s: Default Device Name not found", "coreaudio");
         }
 
-        CFIndex len = CFStringGetMaximumSizeForEncoding(CFStringGetLength(cfstr),
+        len = CFStringGetMaximumSizeForEncoding(CFStringGetLength(cfstr),
                                                         kCFStringEncodingUTF8);
         devname = (char *) SDL_malloc(len + 1);
         usable = ((devname != NULL) &&


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Compilation error on MacOS with CMake

```
SDL/src/audio/coreaudio/SDL_coreaudio.m:1225:17: error: mixing declarations and code is incompatible with standards before C99 [-Werror,-Wdeclaration-after-statement]
        CFIndex len = CFStringGetMaximumSizeForEncoding(CFStringGetLength(cfstr),
```

## Description
Move the declaration of `len` outside code.

## Existing Issue(s)
Related issue: https://github.com/libsdl-org/SDL/issues/6330

Fixes #6330