### PR TITLE
Don't require sort -V on Darwin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,7 +71,7 @@ if [ test -z "$AWK" ]; then
 fi
 
 AC_CHECK_PROGS([SORT], [gsort sort], [false])
-AS_IF([! "$SORT" -V </dev/null >/dev/null], [AC_MSG_ERROR([GNU sort(1) is required])])
+AS_IF([echo "$host_os" | grep -qv ^darwin && ! "$SORT" -V </dev/null >/dev/null], [AC_MSG_ERROR([GNU sort(1) is required])])
 
 dnl 64-bit file offsets if possible unless --disable-largefile is specified
 AC_SYS_LARGEFILE


### PR DESCRIPTION
It's only used by the find_lib function, which doesn't work on Darwin anyway.
