### PR TITLE
Fixes made in response to running a static code analyzer under MS Windows.

### DIFF
--- a/src/SDL.c
+++ b/src/SDL.c
@@ -125,8 +125,9 @@ static void
 SDL_PrivateSubsystemRefCountIncr(Uint32 subsystem)
 {
     int subsystem_index = SDL_MostSignificantBitIndex32(subsystem);
-    SDL_assert(SDL_SubsystemRefCount[subsystem_index] < 255);
-    ++SDL_SubsystemRefCount[subsystem_index];
+    SDL_assert(subsystem_index < 0 || SDL_SubsystemRefCount[subsystem_index] < 255);
+    if (subsystem_index >= 0)
+        ++SDL_SubsystemRefCount[subsystem_index];
 }
 
 /* Private helper to decrement a subsystem's ref counter. */
@@ -134,7 +135,7 @@ static void
 SDL_PrivateSubsystemRefCountDecr(Uint32 subsystem)
 {
     int subsystem_index = SDL_MostSignificantBitIndex32(subsystem);
-    if (SDL_SubsystemRefCount[subsystem_index] > 0) {
+    if (subsystem_index >= 0 && SDL_SubsystemRefCount[subsystem_index] > 0) {
         --SDL_SubsystemRefCount[subsystem_index];
     }
 }
@@ -144,22 +145,22 @@ static SDL_bool
 SDL_PrivateShouldInitSubsystem(Uint32 subsystem)
 {
     int subsystem_index = SDL_MostSignificantBitIndex32(subsystem);
-    SDL_assert(SDL_SubsystemRefCount[subsystem_index] < 255);
-    return (SDL_SubsystemRefCount[subsystem_index] == 0) ? SDL_TRUE : SDL_FALSE;
+    SDL_assert(subsystem_index < 0 || SDL_SubsystemRefCount[subsystem_index] < 255);
+    return (subsystem_index >= 0 && SDL_SubsystemRefCount[subsystem_index] == 0) ? SDL_TRUE : SDL_FALSE;
 }
 
 /* Private helper to check if a system needs to be quit. */
 static SDL_bool
 SDL_PrivateShouldQuitSubsystem(Uint32 subsystem) {
     int subsystem_index = SDL_MostSignificantBitIndex32(subsystem);
-    if (SDL_SubsystemRefCount[subsystem_index] == 0) {
+    if (subsystem_index >= 0 && SDL_SubsystemRefCount[subsystem_index] == 0) {
       return SDL_FALSE;
     }
 
     /* If we're in SDL_Quit, we shut down every subsystem, even if refcount
      * isn't zero.
      */
-    return (SDL_SubsystemRefCount[subsystem_index] == 1 || SDL_bInMainQuit) ? SDL_TRUE : SDL_FALSE;
+    return ((subsystem_index >= 0 && SDL_SubsystemRefCount[subsystem_index] == 1) || SDL_bInMainQuit) ? SDL_TRUE : SDL_FALSE;
 }
 
 void

--- a/src/SDL_hints.c
+++ b/src/SDL_hints.c
@@ -112,7 +112,7 @@ SDL_ResetHint(const char *name)
         if (SDL_strcmp(name, hint->name) == 0) {
             if ((env == NULL && hint->value != NULL) ||
                 (env != NULL && hint->value == NULL) ||
-                (env && SDL_strcmp(env, hint->value) != 0)) {
+                (env != NULL && SDL_strcmp(env, hint->value) != 0)) {
                 for (entry = hint->callbacks; entry; ) {
                     /* Save the next entry in case this one is deleted */
                     SDL_HintWatch *next = entry->next;
@@ -140,7 +140,7 @@ SDL_ResetHints(void)
         env = SDL_getenv(hint->name);
         if ((env == NULL && hint->value != NULL) ||
             (env != NULL && hint->value == NULL) ||
-            (env && SDL_strcmp(env, hint->value) != 0)) {
+            (env != NULL && SDL_strcmp(env, hint->value) != 0)) {
             for (entry = hint->callbacks; entry; ) {
                 /* Save the next entry in case this one is deleted */
                 SDL_HintWatch *next = entry->next;
@@ -169,7 +169,7 @@ SDL_GetHint(const char *name)
     env = SDL_getenv(name);
     for (hint = SDL_hints; hint; hint = hint->next) {
         if (SDL_strcmp(name, hint->name) == 0) {
-            if (!env || hint->priority == SDL_HINT_OVERRIDE) {
+            if (env == NULL || hint->priority == SDL_HINT_OVERRIDE) {
                 return hint->value;
             }
             break;

--- a/src/audio/SDL_audiocvt.c
+++ b/src/audio/SDL_audiocvt.c
@@ -403,7 +403,8 @@ SDL_BuildAudioTypeCVTFromFloat(SDL_AudioCVT *cvt, const SDL_AudioFormat dst_fmt)
             cvt->len_mult *= mult;
             cvt->len_ratio *= mult;
         } else if (src_bitsize > dst_bitsize) {
-            cvt->len_ratio /= (src_bitsize / dst_bitsize);
+            const int div = (src_bitsize / dst_bitsize);
+            cvt->len_ratio /= div;
         }
         retval = 1;  /* added a converter. */
     }

--- a/src/core/windows/SDL_immdevice.c
+++ b/src/core/windows/SDL_immdevice.c
@@ -399,7 +399,9 @@ static int SDLCALL sort_endpoints(const void *_a, const void *_b)
 {
     LPWSTR a = ((const EndpointItem *)_a)->devid;
     LPWSTR b = ((const EndpointItem *)_b)->devid;
-    if (!a && b) {
+    if (!a && !b) {
+        return 0;
+    } else if (!a && b) {
         return -1;
     } else if (a && !b) {
         return 1;

--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -147,7 +147,7 @@ SDL_AutoUpdateSensorsChanged(void *userdata, const char *name, const char *oldVa
 static void SDLCALL
 SDL_PollSentinelChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
 {
-    SDL_EventState(SDL_POLLSENTINEL, SDL_GetStringBoolean(hint, SDL_TRUE) ? SDL_ENABLE : SDL_DISABLE);
+    (void)SDL_EventState(SDL_POLLSENTINEL, SDL_GetStringBoolean(hint, SDL_TRUE) ? SDL_ENABLE : SDL_DISABLE);
 }
 
 /**
@@ -564,12 +564,12 @@ SDL_StartEventLoop(void)
 #endif /* !SDL_THREADS_DISABLED */
 
     /* Process most event types */
-    SDL_EventState(SDL_TEXTINPUT, SDL_DISABLE);
-    SDL_EventState(SDL_TEXTEDITING, SDL_DISABLE);
-    SDL_EventState(SDL_SYSWMEVENT, SDL_DISABLE);
+    (void)SDL_EventState(SDL_TEXTINPUT, SDL_DISABLE);
+    (void)SDL_EventState(SDL_TEXTEDITING, SDL_DISABLE);
+    (void)SDL_EventState(SDL_SYSWMEVENT, SDL_DISABLE);
 #if 0 /* Leave these events enabled so apps can respond to items being dragged onto them at startup */
-    SDL_EventState(SDL_DROPFILE, SDL_DISABLE);
-    SDL_EventState(SDL_DROPTEXT, SDL_DISABLE);
+    (void)SDL_EventState(SDL_DROPFILE, SDL_DISABLE);
+    (void)SDL_EventState(SDL_DROPTEXT, SDL_DISABLE);
 #endif
 
     SDL_AtomicSet(&SDL_EventQ.active, 1);

--- a/src/joystick/SDL_gamecontroller.c
+++ b/src/joystick/SDL_gamecontroller.c
@@ -3004,7 +3004,7 @@ SDL_GameControllerEventState(int state)
         break;
     default:
         for (i = 0; i < SDL_arraysize(event_list); ++i) {
-            SDL_EventState(event_list[i], state);
+            (void)SDL_EventState(event_list[i], state);
         }
         break;
     }

--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -1771,7 +1771,7 @@ SDL_JoystickEventState(int state)
         break;
     default:
         for (i = 0; i < SDL_arraysize(event_list); ++i) {
-            SDL_EventState(event_list[i], state);
+            (void)SDL_EventState(event_list[i], state);
         }
         break;
     }

--- a/src/joystick/hidapi/SDL_hidapi_shield.c
+++ b/src/joystick/hidapi/SDL_hidapi_shield.c
@@ -158,7 +158,8 @@ HIDAPI_DriverShield_SendCommand(SDL_HIDAPI_Device *device, Uint8 cmd, const void
     }
 
     /* Zero unused data in the payload */
-    SDL_memset(&cmd_pkt.payload[size], 0, sizeof(cmd_pkt.payload) - size);
+    if (size != sizeof(cmd_pkt.payload))
+        SDL_memset(&cmd_pkt.payload[size], 0, sizeof(cmd_pkt.payload) - size);
 
     if (SDL_HIDAPI_SendRumbleAndUnlock(device, (Uint8*)&cmd_pkt, sizeof(cmd_pkt)) != sizeof(cmd_pkt)) {
         return SDL_SetError("Couldn't send command packet");

--- a/src/joystick/windows/SDL_dinputjoystick.c
+++ b/src/joystick/windows/SDL_dinputjoystick.c
@@ -329,6 +329,7 @@ QueryDeviceInfo(LPDIRECTINPUTDEVICE8 device, Uint16* vendor_id, Uint16* product_
     dipdw.diph.dwHeaderSize = sizeof(dipdw.diph);
     dipdw.diph.dwObj = 0;
     dipdw.diph.dwHow = DIPH_DEVICE;
+    dipdw.dwData = 0;
 
     if (FAILED(IDirectInputDevice8_GetProperty(device, DIPROP_VIDPID, &dipdw.diph))) {
         return SDL_FALSE;

--- a/src/render/software/SDL_render_sw.c
+++ b/src/render/software/SDL_render_sw.c
@@ -733,7 +733,7 @@ SW_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *vertic
                 SetDrawState(surface, &drawstate);
 
                 /* Apply viewport */
-                if (drawstate.viewport->x || drawstate.viewport->y) {
+                if (drawstate.viewport != NULL && (drawstate.viewport->x || drawstate.viewport->y)) {
                     int i;
                     for (i = 0; i < count; i++) {
                         verts[i].x += drawstate.viewport->x;
@@ -760,7 +760,7 @@ SW_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *vertic
                 SetDrawState(surface, &drawstate);
 
                 /* Apply viewport */
-                if (drawstate.viewport->x || drawstate.viewport->y) {
+                if (drawstate.viewport != NULL && (drawstate.viewport->x || drawstate.viewport->y)) {
                     int i;
                     for (i = 0; i < count; i++) {
                         verts[i].x += drawstate.viewport->x;
@@ -787,7 +787,7 @@ SW_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *vertic
                 SetDrawState(surface, &drawstate);
 
                 /* Apply viewport */
-                if (drawstate.viewport->x || drawstate.viewport->y) {
+                if (drawstate.viewport != NULL && (drawstate.viewport->x || drawstate.viewport->y)) {
                     int i;
                     for (i = 0; i < count; i++) {
                         verts[i].x += drawstate.viewport->x;
@@ -815,7 +815,7 @@ SW_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *vertic
                 PrepTextureForCopy(cmd);
 
                 /* Apply viewport */
-                if (drawstate.viewport->x || drawstate.viewport->y) {
+                if (drawstate.viewport != NULL && (drawstate.viewport->x || drawstate.viewport->y)) {
                     dstrect->x += drawstate.viewport->x;
                     dstrect->y += drawstate.viewport->y;
                 }
@@ -873,7 +873,7 @@ SW_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *vertic
                 PrepTextureForCopy(cmd);
 
                 /* Apply viewport */
-                if (drawstate.viewport->x || drawstate.viewport->y) {
+                if (drawstate.viewport != NULL && (drawstate.viewport->x || drawstate.viewport->y)) {
                     copydata->dstrect.x += drawstate.viewport->x;
                     copydata->dstrect.y += drawstate.viewport->y;
                 }
@@ -901,7 +901,7 @@ SW_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *vertic
                     PrepTextureForCopy(cmd);
 
                     /* Apply viewport */
-                    if (drawstate.viewport->x || drawstate.viewport->y) {
+                    if (drawstate.viewport != NULL && (drawstate.viewport->x || drawstate.viewport->y)) {
                         SDL_Point vp;
                         vp.x = drawstate.viewport->x;
                         vp.y = drawstate.viewport->y;
@@ -924,7 +924,7 @@ SW_RunCommandQueue(SDL_Renderer * renderer, SDL_RenderCommand *cmd, void *vertic
                     GeometryFillData *ptr = (GeometryFillData *) verts;
 
                     /* Apply viewport */
-                    if (drawstate.viewport->x || drawstate.viewport->y) {
+                    if (drawstate.viewport != NULL && (drawstate.viewport->x || drawstate.viewport->y)) {
                         SDL_Point vp;
                         vp.x = drawstate.viewport->x;
                         vp.y = drawstate.viewport->y;

--- a/src/stdlib/SDL_malloc.c
+++ b/src/stdlib/SDL_malloc.c
@@ -2580,7 +2580,7 @@ init_mparams(void)
 #else /* (FOOTERS && !INSECURE) */
         s = (size_t) 0x58585858U;
 #endif /* (FOOTERS && !INSECURE) */
-        ACQUIRE_MAGIC_INIT_LOCK();
+        (void)ACQUIRE_MAGIC_INIT_LOCK();
         if (mparams.magic == 0) {
             mparams.magic = s;
             /* Set up lock for main malloc area */

--- a/src/video/SDL_pixels.c
+++ b/src/video/SDL_pixels.c
@@ -436,6 +436,7 @@ SDL_MasksToPixelFormatEnum(int bpp, Uint32 Rmask, Uint32 Gmask, Uint32 Bmask,
             return SDL_PIXELFORMAT_RGB24;
 #endif
         }
+        break;
     case 32:
         if (Rmask == 0) {
             return SDL_PIXELFORMAT_RGB888;

--- a/src/video/SDL_rect_impl.h
+++ b/src/video/SDL_rect_impl.h
@@ -400,9 +400,11 @@ SDL_INTERSECTRECTANDLINE(const RECTTYPE * rect, SCALARTYPE *X1, SCALARTYPE *Y1, 
             outcode1 = COMPUTEOUTCODE(rect, x, y);
         } else {
             if (outcode2 & CODE_TOP) {
+                SDL_assert(y2 != y1);  /* if equal: division by zero. */
                 y = recty1;
                 x = x1 + ((x2 - x1) * (y - y1)) / (y2 - y1);
             } else if (outcode2 & CODE_BOTTOM) {
+                SDL_assert(y2 != y1);  /* if equal: division by zero. */
                 y = recty2;
                 x = x1 + ((x2 - x1) * (y - y1)) / (y2 - y1);
             } else if (outcode2 & CODE_LEFT) {

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -4311,8 +4311,8 @@ SDL_StartTextInput(void)
     SDL_Window *window;
 
     /* First, enable text events */
-    SDL_EventState(SDL_TEXTINPUT, SDL_ENABLE);
-    SDL_EventState(SDL_TEXTEDITING, SDL_ENABLE);
+    (void)SDL_EventState(SDL_TEXTINPUT, SDL_ENABLE);
+    (void)SDL_EventState(SDL_TEXTEDITING, SDL_ENABLE);
 
     /* Then show the on-screen keyboard, if any */
     window = SDL_GetFocusWindow();
@@ -4367,8 +4367,8 @@ SDL_StopTextInput(void)
     }
 
     /* Finally disable text events */
-    SDL_EventState(SDL_TEXTINPUT, SDL_DISABLE);
-    SDL_EventState(SDL_TEXTEDITING, SDL_DISABLE);
+    (void)SDL_EventState(SDL_TEXTINPUT, SDL_DISABLE);
+    (void)SDL_EventState(SDL_TEXTEDITING, SDL_DISABLE);
 }
 
 void

--- a/src/video/SDL_yuv.c
+++ b/src/video/SDL_yuv.c
@@ -601,9 +601,10 @@ SDL_ConvertPixels_ARGB8888_to_YUV(int width, int height, const void *src, int sr
             Uint8 *plane_interleaved_uv;
             Uint32 y_stride, uv_stride, y_skip, uv_skip;
 
-            GetYUVPlanes(width, height, dst_format, dst, dst_pitch,
-                         (const Uint8 **)&plane_y, (const Uint8 **)&plane_u, (const Uint8 **)&plane_v,
-                         &y_stride, &uv_stride);
+            if (GetYUVPlanes(width, height, dst_format, dst, dst_pitch,
+                             (const Uint8 **)&plane_y, (const Uint8 **)&plane_u, (const Uint8 **)&plane_v,
+                             &y_stride, &uv_stride) != 0)
+                return -1;
             plane_interleaved_uv = (plane_y + height * y_stride);
             y_skip = (y_stride - width);
 

--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -389,13 +389,21 @@ WIN_ShouldShowNativeUI()
 static void
 IME_Init(SDL_VideoData *videodata, HWND hwnd)
 {
+    HRESULT hResult = S_OK;
+
     if (videodata->ime_initialized)
         return;
 
     videodata->ime_hwnd_main = hwnd;
     if (SUCCEEDED(WIN_CoInitialize())) {
         videodata->ime_com_initialized = SDL_TRUE;
-        CoCreateInstance(&CLSID_TF_ThreadMgr, NULL, CLSCTX_INPROC_SERVER, &IID_ITfThreadMgr, (LPVOID *)&videodata->ime_threadmgr);
+        hResult = CoCreateInstance(&CLSID_TF_ThreadMgr, NULL, CLSCTX_INPROC_SERVER, &IID_ITfThreadMgr, (LPVOID *)&videodata->ime_threadmgr);
+        if (hResult != S_OK)
+        {
+            videodata->ime_available = SDL_FALSE;
+            SDL_SetError("CoCreateInstance() failed, HRESULT is %08X", (unsigned int)hResult);
+            return;
+        }
     }
     videodata->ime_initialized = SDL_TRUE;
     videodata->ime_himm32 = SDL_LoadObject("imm32.dll");

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -738,15 +738,18 @@ WIN_GetWindowBordersSize(_THIS, SDL_Window * window, int *top, int *left, int *b
 
     /* rcClient stores the size of the inner window, while rcWindow stores the outer size relative to the top-left
      * screen position; so the top/left values of rcClient are always {0,0} and bottom/right are {height,width} */
-    GetClientRect(hwnd, &rcClient);
-    GetWindowRect(hwnd, &rcWindow);
+    if (!GetClientRect(hwnd, &rcClient))
+        SDL_SetError("GetClientRect() failed, error %08X", (unsigned int)GetLastError());
+    if (!GetWindowRect(hwnd, &rcWindow))
+        SDL_SetError("GetWindowRect() failed, error %08X", (unsigned int)GetLastError());
 
     /* convert the top/left values to make them relative to
      * the window; they will end up being slightly negative */
     ptDiff.y = rcWindow.top;
     ptDiff.x = rcWindow.left;
 
-    ScreenToClient(hwnd, &ptDiff);
+    if (!ScreenToClient(hwnd, &ptDiff))
+        SDL_SetError("ScreenToClient() failed, error %08X", (unsigned int)GetLastError());
 
     rcWindow.top  = ptDiff.y;
     rcWindow.left = ptDiff.x;
@@ -756,7 +759,8 @@ WIN_GetWindowBordersSize(_THIS, SDL_Window * window, int *top, int *left, int *b
     ptDiff.y = rcWindow.bottom;
     ptDiff.x = rcWindow.right;
 
-    ScreenToClient(hwnd, &ptDiff);
+    if (!ScreenToClient(hwnd, &ptDiff))
+        SDL_SetError("ScreenToClient() failed, error %08X", (unsigned int)GetLastError());
 
     rcWindow.bottom = ptDiff.y;
     rcWindow.right  = ptDiff.x;


### PR DESCRIPTION
Most of these are probably harmless, but the changes to SDL_immdevice.c and SDL_pixels.c appear to have fixed genuine bugs.

SDL_audiocvt.c: By separating the calculation of the divisor, I got rid of the suspicion that dividing a double by an integer led to loss of precision.
SDL_immdevice.c: Added a missing test, one that could have otherwise led to dereferencing a null pointer.
SDL_events.c, SDL_gamecontroller.c, SDL_joystick.c, SDL_malloc.c, SDL_video.c: Made it clear the return values weren't used.
SDL_hidapi_shield.c: The size is zero, so nothing bad would have happened, but the SDL_memset() was still being given an address outside of the array's range.
SDL_dinputjoystick.c: Initialize local data, just in case IDirectInputDevice8_GetProperty() isn't guaranteed to write to it.
SDL_render_sw.c: drawstate.viewport could be null (as seen on line 691).
SDL.c: SDL_MostSignificantBitIndex32() could return -1, though I don't know if you want to cope with that (what I did) or SDL_assert() that it can't happen.
SDL_hints.c: Replaced boolean tests on pointer values with comparisons to NULL.
SDL_pixels.c: Looks like the switch is genuinely missing a break!
SDL_rect_impl.h: The MacOS static checker pointed out issues with the X comparisons that were handled by assertions; I added assertions for the Y comparisons.
SDL_yuv.c, SDL_windowskeyboard.c, SDL_windowswindow.c: Checked error-result returns.

Here are the reported errors that I couldn't fix:

SDL_hidapi_wii.c, line 686: ParseExtensionIdentifyResponse()'s return value isn't checked, like it is for 4 out of the other 5 uses of it
SDL_render_d3d11.c, lines 978 and 987: it complains that data->swapChain might be NULL, given that it was tested for NULL on line 929.
SDL_windowswindow.c, line 184: it complains that videodata might be NULL, given that it could be on line 127.
SDL_render_d3d.c, lines 1266 and 1275: it complains that vertices might be NULL, given that it was tested for NULL on line 1153.
e_sqrt.c: it thinks the right shift on line 116 might go over 31 bits, but that could just be the wild coding style.
k_rem_pio2.c: it thinks there are several overruns in __kernel_rem_pio2(), but that could just be the wild coding style.
SDL_windowskeyboard.c, line 712: hime is loaded, but never unloaded. Maybe unload it in IME_Quit()?
SDL_egl.c, lines 329, 342, and 348: does it matter that the DLLs loaded by SDL_LoadObject() here are never freed?
SDL_keyboard.c, line 953: the code tests if text is NULL, but the code above assumes it's not.
SDL_render_sw.c, line 151: "surface->format->BytesPerPixel" with type "Uint8" (8 bits, unsigned) is promoted in "rect->w * surface->format->BytesPerPixel" to type "int" (32 bits, signed), then sign-extended to type "unsigned long long" (64 bits, unsigned). If "rect->w * surface->format->BytesPerPixel" is greater than 0x7FFFFFFF, the upper bits of the result will all be 1. This seems unlikely, but I wanted to share it anyway.

The rest of the issues it pointed out appeared to be false positives.