### PR TITLE
video: Prefer Wayland over X11 (take 2!)

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -61,11 +61,11 @@ static VideoBootStrap *bootstrap[] = {
 #if SDL_VIDEO_DRIVER_COCOA
     &COCOA_bootstrap,
 #endif
-#if SDL_VIDEO_DRIVER_X11
-    &X11_bootstrap,
-#endif
 #if SDL_VIDEO_DRIVER_WAYLAND
     &Wayland_bootstrap,
+#endif
+#if SDL_VIDEO_DRIVER_X11
+    &X11_bootstrap,
 #endif
 #if SDL_VIDEO_DRIVER_VIVANTE
     &VIVANTE_bootstrap,
@@ -4418,11 +4418,11 @@ SDL_GetMessageBoxCount(void)
 #if SDL_VIDEO_DRIVER_UIKIT
 #include "uikit/SDL_uikitmessagebox.h"
 #endif
-#if SDL_VIDEO_DRIVER_X11
-#include "x11/SDL_x11messagebox.h"
-#endif
 #if SDL_VIDEO_DRIVER_WAYLAND
 #include "wayland/SDL_waylandmessagebox.h"
+#endif
+#if SDL_VIDEO_DRIVER_X11
+#include "x11/SDL_x11messagebox.h"
 #endif
 #if SDL_VIDEO_DRIVER_HAIKU
 #include "haiku/SDL_bmessagebox.h"
@@ -4531,17 +4531,17 @@ SDL_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonid)
         retval = 0;
     }
 #endif
-#if SDL_VIDEO_DRIVER_X11
-    if (retval == -1 &&
-        SDL_MessageboxValidForDriver(messageboxdata, SDL_SYSWM_X11) &&
-        X11_ShowMessageBox(messageboxdata, buttonid) == 0) {
-        retval = 0;
-    }
-#endif
 #if SDL_VIDEO_DRIVER_WAYLAND
     if (retval == -1 &&
         SDL_MessageboxValidForDriver(messageboxdata, SDL_SYSWM_WAYLAND) &&
         Wayland_ShowMessageBox(messageboxdata, buttonid) == 0) {
+        retval = 0;
+    }
+#endif
+#if SDL_VIDEO_DRIVER_X11
+    if (retval == -1 &&
+        SDL_MessageboxValidForDriver(messageboxdata, SDL_SYSWM_X11) &&
+        X11_ShowMessageBox(messageboxdata, buttonid) == 0) {
         retval = 0;
     }
 #endif


### PR DESCRIPTION
Right, let's try this again...

It's been about a year and a half since the first attempt, and we've had some good progress on the Wayland driver in that time. In particular, the Fedora project and most (maybe even all?) Flatpaks have enforced Wayland by default, which has forced a lot of developers to dogfood the new backend a bit more. With all the improvements (and with the scariest bug now resolved) let's track this one more time.

I'm still out for the rest of the year and the next deadline is less than 3 weeks away, so at the absolute best this is going to be a 2.28 task.

In any case, the tracker!

Fractional Scaling Stuff:
- #5892
- #6707

External Stuff Involving Us:
- #6531
    - Blocked by https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/283

External Stuff Not Involving Us:
- #5536
    - Blocked by https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/188
- https://github.com/ValveSoftware/steam-for-linux/issues/8020

Nice-to-Have:
- #5344
    - #5481