### PR TITLE
Enabling SDL_WERROR on Homebrew platforms.

### DIFF
--- a/.github/workflows/ps2.yaml
+++ b/.github/workflows/ps2.yaml
@@ -24,8 +24,9 @@ jobs:
 
     - name: Configure (CMake)
       run: |
-        cmake -S . -B build -G Ninja\
+        cmake -S . -B build -G Ninja \
           -DCMAKE_TOOLCHAIN_FILE=$PS2DEV/ps2sdk/ps2dev.cmake \
+          -DSDL_WERROR=ON \
           -DSDL_TESTS=ON \
           -DCMAKE_INSTALL_PREFIX=cmake_prefix \
           -DCMAKE_BUILD_TYPE=Release

--- a/.github/workflows/psp.yaml
+++ b/.github/workflows/psp.yaml
@@ -16,6 +16,7 @@ jobs:
       run: |
         cmake -S . -B build \
           -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake \
+          -DSDL_WERROR=ON \
           -DSDL_TESTS=ON \
           -DSDL_INSTALL_TESTS=ON \
           -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/vita.yaml
+++ b/.github/workflows/vita.yaml
@@ -21,6 +21,7 @@ jobs:
       run: |
         cmake -S . -B build -G Ninja \
           -DCMAKE_TOOLCHAIN_FILE=${VITASDK}/share/vita.toolchain.cmake \
+          -DSDL_ERRORS=ON \
           -DSDL_TESTS=ON \
           -DSDL_INSTALL_TESTS=ON \
           -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/vita.yaml
+++ b/.github/workflows/vita.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Install build requirements
       run: |
         apk update 
-        apk add cmake ninja pkgconf
+        apk add cmake ninja pkgconf bash
     - name: Configure CMake
       run: |
         cmake -S . -B build -G Ninja \

--- a/src/render/ps2/SDL_render_ps2.c
+++ b/src/render/ps2/SDL_render_ps2.c
@@ -30,7 +30,11 @@
 #include <gsKit.h>
 #include <dmaKit.h>
 #include <gsToolkit.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
 #include <gsInline.h>
+#pragma GCC diagnostic pop
 
 /* turn black GS Screen */
 #define GS_BLACK GS_SETREG_RGBA(0x00, 0x00, 0x00, 0x80)

--- a/src/thread/psp/SDL_sysmutex.c
+++ b/src/thread/psp/SDL_sysmutex.c
@@ -57,7 +57,7 @@ SDL_CreateMutex(void)
         );
 
         if (res < 0) {
-            SDL_SetError("Error trying to create mutex: %x", res);
+            SDL_SetError("Error trying to create mutex: %lx", res);
         }
     } else {
         SDL_OutOfMemory();
@@ -96,7 +96,7 @@ SDL_TryLockMutex(SDL_mutex * mutex)
             return SDL_MUTEX_TIMEDOUT;
             break;
         default:
-            return SDL_SetError("Error trying to lock mutex: %x", res);
+            return SDL_SetError("Error trying to lock mutex: %lx", res);
             break;
     }
 
@@ -119,7 +119,7 @@ SDL_mutexP(SDL_mutex * mutex)
 
     res = sceKernelLockLwMutex(&mutex->lock, 1, NULL);
     if (res != SCE_KERNEL_ERROR_OK) {
-        return SDL_SetError("Error trying to lock mutex: %x", res);
+        return SDL_SetError("Error trying to lock mutex: %lx", res);
     }
 
     return 0;
@@ -141,7 +141,7 @@ SDL_mutexV(SDL_mutex * mutex)
 
     res = sceKernelUnlockLwMutex(&mutex->lock, 1);
     if (res != 0) {
-        return SDL_SetError("Error trying to unlock mutex: %x", res);
+        return SDL_SetError("Error trying to unlock mutex: %lx", res);
     }
 
     return 0;

--- a/src/thread/psp/SDL_syssem.c
+++ b/src/thread/psp/SDL_syssem.c
@@ -101,7 +101,7 @@ int SDL_SemWaitTimeout(SDL_sem *sem, Uint32 timeout)
         pTimeout = &timeout;
     }
 
-    res = sceKernelWaitSema(sem->semid, 1, pTimeout);
+    res = sceKernelWaitSema(sem->semid, 1, (SceUInt *) pTimeout);
        switch (res) {
                case SCE_KERNEL_ERROR_OK:
                        return 0;

--- a/src/video/ps2/SDL_ps2video.h
+++ b/src/video/ps2/SDL_ps2video.h
@@ -31,7 +31,11 @@
 #include <dmaKit.h>
 
 #include <gsToolkit.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
 #include <gsInline.h>
+#pragma GCC diagnostic pop
 
 #endif /* SDL_ps2video_h_ */
 

--- a/src/video/psp/SDL_pspevents.c
+++ b/src/video/psp/SDL_pspevents.c
@@ -62,16 +62,17 @@ static struct {
     { PSP_HPRM_HOLD,      SDLK_F15 }
 };
 
-int EventUpdate(void *data)
+int
+EventUpdate(void *data)
 {
     while (running) {
-                SDL_SemWait(event_sem);
-                                sceHprmPeekCurrentKey(&hprm);
-                SDL_SemPost(event_sem);
-                /* Delay 1/60th of a second */
-                sceKernelDelayThread(1000000 / 60);
-        }
-        return 0;
+        SDL_SemWait(event_sem);
+        sceHprmPeekCurrentKey((u32 *) &hprm);
+        SDL_SemPost(event_sem);
+        /* Delay 1/60th of a second */
+        sceKernelDelayThread(1000000 / 60);
+    }
+    return 0;
 }
 
 void PSP_PumpEvents(_THIS)
@@ -80,7 +81,6 @@ void PSP_PumpEvents(_THIS)
     enum PspHprmKeys keys;
     enum PspHprmKeys changed;
     static enum PspHprmKeys old_keys = 0;
-    SDL_Keysym sym;
 
     SDL_SemWait(event_sem);
     keys = hprm;

--- a/src/video/psp/SDL_pspevents.c
+++ b/src/video/psp/SDL_pspevents.c
@@ -92,14 +92,6 @@ void PSP_PumpEvents(_THIS)
     if(changed) {
         for(i=0; i<sizeof(keymap_psp)/sizeof(keymap_psp[0]); i++) {
             if(changed & keymap_psp[i].id) {
-                sym.scancode = keymap_psp[i].id;
-                sym.sym = keymap_psp[i].sym;
-
-                /* out of date
-                SDL_PrivateKeyboard((keys & keymap_psp[i].id) ?
-                            SDL_PRESSED : SDL_RELEASED,
-                            &sym);
-        */
                 SDL_SendKeyboardKey((keys & keymap_psp[i].id) ?
                                     SDL_PRESSED : SDL_RELEASED, SDL_GetScancodeFromKey(keymap_psp[i].sym));
             }

--- a/test/testgl2.c
+++ b/test/testgl2.c
@@ -302,7 +302,7 @@ main(int argc, char *argv[])
     }
 
     SDL_GetCurrentDisplayMode(0, &mode);
-    SDL_Log("Screen BPP    : %d\n", SDL_BITSPERPIXEL(mode.format));
+    SDL_Log("Screen BPP    : %" SDL_PRIu32 "\n", SDL_BITSPERPIXEL(mode.format));
     SDL_Log("Swap Interval : %d\n", SDL_GL_GetSwapInterval());
     SDL_GetWindowSize(state->windows[0], &dw, &dh);
     SDL_Log("Window Size   : %d,%d\n", dw, dh);


### PR DESCRIPTION
## Description

- Fixes the remaining warnings for the PS2 and PSP toolchains.
- Turns on `SDL_WERROR` in CI for PS2, PSP, and PS Vita.


## Existing Issue

Mentioned by @madebr in https://github.com/libsdl-org/SDL/pull/6251#issuecomment-1273518688
