### PR TITLE
wayland: Raise wl_seat maximum version to 8

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -2350,7 +2350,7 @@ Wayland_display_add_input(SDL_VideoData *d, uint32_t id, uint32_t version)
         return;
 
     input->display = d;
-    input->seat = wl_registry_bind(d->registry, id, &wl_seat_interface, SDL_min(5, version));
+    input->seat = wl_registry_bind(d->registry, id, &wl_seat_interface, SDL_min(8, version));
     input->sx_w = wl_fixed_from_int(0);
     input->sy_w = wl_fixed_from_int(0);
     input->xkb.current_group = ~0;


### PR DESCRIPTION
Version 8 is required for supporting axis_value120 high-resolution scroll events.