### PR TITLE
Vita: Fix typo in CI CMake command.

### DIFF
--- a/.github/workflows/vita.yaml
+++ b/.github/workflows/vita.yaml
@@ -21,7 +21,7 @@ jobs:
       run: |
         cmake -S . -B build -G Ninja \
           -DCMAKE_TOOLCHAIN_FILE=${VITASDK}/share/vita.toolchain.cmake \
-          -DSDL_ERRORS=ON \
+          -DSDL_WERROR=ON \
           -DSDL_TESTS=ON \
           -DSDL_INSTALL_TESTS=ON \
           -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
## Description

`SDL_WERROR` was misspelled in the PS Vita workflow.

## Existing Issue(s)

https://github.com/libsdl-org/SDL/pull/6372#discussion_r992374463
