### PR TITLE
testevdev: Fix detection of word size

### DIFF
--- a/test/testevdev.c
+++ b/test/testevdev.c
@@ -935,12 +935,8 @@ static const GuessTest guess_tests[] =
     }
 };
 
-#if ULONG_MAX == 0xFFFFFFFFUL
-#   define SwapLongLE(X) SDL_SwapLE32(X)
-#else
-    /* assume 64-bit */
-#   define SwapLongLE(X) SDL_SwapLE64(X)
-#endif
+#define SwapLongLE(X) \
+	((sizeof(unsigned long) == 4) ? SDL_SwapLE32(X) : SDL_SwapLE64(X))
 
 static int
 run_test(void)


### PR DESCRIPTION
From: Helge Deller

The check for whether to use a 32- or 64-bit swap for an array of long values always took the 64-bit path, because <limits.h> wasn't included and therefore ULONG_MAX wasn't defined. Turn this into a runtime check, which a reasonable compiler will optimize into a constant.

This fixes testevdev failures on 32-bit big-endian platforms such as hppa and older powerpc. Little-endian and/or 64-bit platforms are unaffected.

[smcv: Added commit message]  
Bug-Debian: https://bugs.debian.org/1021310  
Co-authored-by: @smcv