### PR TITLE
Use XIWarpPointer if compiled with xinput2

### DIFF
--- a/src/video/x11/SDL_x11mouse.c
+++ b/src/video/x11/SDL_x11mouse.c
@@ -315,7 +315,16 @@ WarpMouseInternal(Window xwindow, const int x, const int y)
 {
     SDL_VideoData *videodata = (SDL_VideoData *) SDL_GetVideoDevice()->driverdata;
     Display *display = videodata->display;
-    X11_XWarpPointer(display, None, xwindow, 0, 0, 0, 0, x, y);
+#if SDL_VIDEO_DRIVER_X11_XINPUT2
+    int deviceid = 0;
+    X11_XIGetClientPointer(display, None, &deviceid);
+    if (deviceid != 0) {
+        X11_XIWarpPointer(display, deviceid, None, xwindow, 0.0, 0.0, 0, 0, (double)x, (double)y);
+    } else
+#endif
+    {
+        X11_XWarpPointer(display, None, xwindow, 0, 0, 0, 0, x, y);
+    }
     X11_XSync(display, False);
     videodata->global_mouse_changed = SDL_TRUE;
 }

--- a/src/video/x11/SDL_x11sym.h
+++ b/src/video/x11/SDL_x11sym.h
@@ -166,7 +166,7 @@ SDL_X11_SYM(Status, XFixesQueryVersion,(Display* a, int* b, int* c), (a,b,c), re
 
 #if SDL_VIDEO_DRIVER_X11_SUPPORTS_GENERIC_EVENTS
 SDL_X11_SYM(Bool,XGetEventData,(Display* a,XGenericEventCookie* b),(a,b),return)
-SDL_X11_SYM(void,XFreeEventData,(Display* a,XGenericEventCookie* b),(a,b),)    
+SDL_X11_SYM(void,XFreeEventData,(Display* a,XGenericEventCookie* b),(a,b),)
 #endif
 
 #if SDL_VIDEO_DRIVER_X11_HAS_XKBKEYCODETOKEYSYM
@@ -270,6 +270,8 @@ SDL_X11_SYM(int,XIGrabTouchBegin,(Display *a,int b,Window c,int d,XIEventMask *e
 SDL_X11_SYM(int,XIUngrabTouchBegin, (Display *a,int b,Window c, int d,XIGrabModifiers *e),(a, b, c, d, e),return)
 SDL_X11_SYM(Status,XIQueryVersion,(Display *a,int *b,int *c),(a,b,c),return)
 SDL_X11_SYM(XIEventMask*,XIGetSelectedEvents,(Display *a,Window b,int *c),(a,b,c),return)
+SDL_X11_SYM(Bool,XIGetClientPointer,(Display *a,Window b,int *c),(a,b,c),return)
+SDL_X11_SYM(Bool,XIWarpPointer,(Display *a,int b,Window c,Window d,double e,double f,int g,int h,double i,double j),(a,b,c,d,e,f,g,h,i,j),return)
 #endif
 
 /* XRandR support */


### PR DESCRIPTION
Fixes #6275.

## Description

If a coordinate transformation is set, the cursor jumps when moving after `XWarpPointer` is called. This doesn't happen with `XIWarpPointer` (which is the same, but takes the pointer device explicitly (according to man page)).

## Existing Issue(s)

Fixes #6275.

cc @ndren
