### PR TITLE
Remove D3D9 workarounds for Watcom.

### DIFF
--- a/src/render/direct3d/SDL_render_d3d.c
+++ b/src/render/direct3d/SDL_render_d3d.c
@@ -41,13 +41,6 @@
 
 #include "SDL_shaders_d3d.h"
 
-#ifdef __WATCOMC__
-/* FIXME: Remove this once https://github.com/open-watcom/open-watcom-v2/pull/868 is merged */
-#define D3DBLENDOP_REVSUBTRACT 3
-/* FIXME: Remove this once https://github.com/open-watcom/open-watcom-v2/pull/869 is merged */
-#define D3DERR_UNSUPPORTEDCOLOROPERATION MAKE_D3DHRESULT( 2073 )
-#endif
-
 typedef struct
 {
     SDL_Rect viewport;


### PR DESCRIPTION
## Description

The two linked PRs have been merged since May. Build and tests pass in CI without the workaround. 

## Existing Issue(s)

Aforementioned PRs:
- open-watcom/open-watcom-v2#868
- open-watcom/open-watcom-v2#869
