### PR TITLE
CI: Update to actions/checkout@v3.

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,7 +15,7 @@ jobs:
           - { name: CMake, cmake: 1, android_abi: "arm64-v8a", android_platform: 23, arch: "aarch64" }
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: nttld/setup-ndk@v1
         id: setup_ndk
         with:

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -6,7 +6,7 @@ jobs:
   emscripten:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: mymindstorm/setup-emsdk@v10
         with:
           version: 2.0.32

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,6 +15,6 @@ jobs:
         - { name: tvOS, target: Static Library-tvOS, sdk: appletvos }
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build
         run: xcodebuild -project Xcode/SDL/SDL.xcodeproj -target '${{ matrix.platform.target }}' -configuration Release -sdk ${{ matrix.platform.sdk }} clean build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
       run: |
         brew install \
           ninja
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check that versioning is consistent
       # We only need to run this once: arbitrarily use the Linux/CMake build
       if: "runner.os == 'Linux' && ! matrix.platform.autotools"

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -23,7 +23,7 @@ jobs:
             project: VisualC-WinRT/SDL-UWP.sln, projectflags: '/p:Platform=x64 /p:WindowsTargetPlatformVersion=10.0.17763.0' }
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Create CMake project using SDL as a subproject
       shell: python
       run: |

--- a/.github/workflows/n3ds.yml
+++ b/.github/workflows/n3ds.yml
@@ -8,7 +8,7 @@ jobs:
     container:
       image: devkitpro/devkitarm:latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install build requirements
         run: |
           apt update

--- a/.github/workflows/ps2.yaml
+++ b/.github/workflows/ps2.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ps2dev/ps2dev:latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup dependencies
       run: |
         apk update 

--- a/.github/workflows/psp.yaml
+++ b/.github/workflows/psp.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     container: pspdev/pspdev:latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup dependencies
       run: |
         apk update 

--- a/.github/workflows/riscos.yml
+++ b/.github/workflows/riscos.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - name: Setup dependencies
       run: apt-get update && apt-get install -y cmake ninja-build
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Configure (autotools)
       if: ${{ contains(matrix.platform.name, 'autotools') }}
       run: |

--- a/.github/workflows/vita.yaml
+++ b/.github/workflows/vita.yaml
@@ -12,7 +12,7 @@ jobs:
     container: 
       image: vitasdk/vitasdk:latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install build requirements
       run: |
         apk update 

--- a/.github/workflows/vmactions.yml
+++ b/.github/workflows/vmactions.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-12
     name: FreeBSD
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build
       uses: vmactions/freebsd-vm@v0
       with:

--- a/.github/workflows/watcom.yml
+++ b/.github/workflows/watcom.yml
@@ -14,7 +14,7 @@ jobs:
         - { name: OS/2,    makefile: Makefile.os2 }
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: open-watcom/setup-watcom@v0
       - name: Build SDL2
         run: |


### PR DESCRIPTION
## Description

This fixes the `Node.js 12 actions are deprecated.` warnings in CI.

Functionally, v3 does not change anything other than running on Node 16 rather than 12.

## Existing Issue(s)

See the `Annotations` section of [recent CI runs](https://github.com/libsdl-org/SDL/actions/runs/3236271203)

