### PR TITLE
wayland: Use MAP_PRIVATE when mapping the keyboard keymap file descriptor

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -922,7 +922,7 @@ keyboard_handle_keymap(void *data, struct wl_keyboard *keyboard,
         return;
     }
 
-    map_str = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
+    map_str = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
     if (map_str == MAP_FAILED) {
         close(fd);
         return;


### PR DESCRIPTION
Per the Wayland spec, this must be mapped with MAP_PRIVATE in version 7 of the protocol and higher.

Fixes #6392 