### PR TITLE
Fix bugs in IMU calibration loading for Nintendo Controllers

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_switch.c
+++ b/src/joystick/hidapi/SDL_hidapi_switch.c
@@ -821,13 +821,13 @@ static SDL_bool LoadIMUCalibration(SDL_DriverSwitch_Context* ctx)
     /* IMU scale gives us multipliers for converting raw values to real world values */
     pIMUScale = reply->spiReadData.rgucReadData;
 
-    sAccelRawX = ((pIMUScale[1] << 8) & 0xF00) | pIMUScale[0];
-    sAccelRawY = ((pIMUScale[3] << 8) & 0xF00) | pIMUScale[2];
-    sAccelRawZ = ((pIMUScale[5] << 8) & 0xF00) | pIMUScale[4];
+    sAccelRawX = ((pIMUScale[1] << 8) & 0xFF00) | pIMUScale[0];
+    sAccelRawY = ((pIMUScale[3] << 8) & 0xFF00) | pIMUScale[2];
+    sAccelRawZ = ((pIMUScale[5] << 8) & 0xFF00) | pIMUScale[4];
 
-    sGyroRawX = ((pIMUScale[13] << 8) & 0xF00) | pIMUScale[12];
-    sGyroRawY = ((pIMUScale[15] << 8) & 0xF00) | pIMUScale[14];
-    sGyroRawZ = ((pIMUScale[17] << 8) & 0xF00) | pIMUScale[16];
+    sGyroRawX = ((pIMUScale[13] << 8) & 0xFF00) | pIMUScale[12];
+    sGyroRawY = ((pIMUScale[15] << 8) & 0xFF00) | pIMUScale[14];
+    sGyroRawZ = ((pIMUScale[17] << 8) & 0xFF00) | pIMUScale[16];
 
     /* Check for user calibration data. If it's present and set, it'll override the factory settings */
     readParams.unAddress = k_unSPIIMUUserScaleStartOffset;
@@ -835,13 +835,13 @@ static SDL_bool LoadIMUCalibration(SDL_DriverSwitch_Context* ctx)
     if (WriteSubcommand(ctx, k_eSwitchSubcommandIDs_SPIFlashRead, (uint8_t*)&readParams, sizeof(readParams), &reply) && (pIMUScale[0] | pIMUScale[1] << 8) == 0xA1B2) {
         pIMUScale = reply->spiReadData.rgucReadData;
         
-        sAccelRawX = ((pIMUScale[3] << 8) & 0xF00) | pIMUScale[2];
-        sAccelRawY = ((pIMUScale[5] << 8) & 0xF00) | pIMUScale[4];
-        sAccelRawZ = ((pIMUScale[7] << 8) & 0xF00) | pIMUScale[6];
+        sAccelRawX = ((pIMUScale[3] << 8) & 0xFF00) | pIMUScale[2];
+        sAccelRawY = ((pIMUScale[5] << 8) & 0xFF00) | pIMUScale[4];
+        sAccelRawZ = ((pIMUScale[7] << 8) & 0xFF00) | pIMUScale[6];
 
-        sGyroRawX = ((pIMUScale[15] << 8) & 0xF00) | pIMUScale[14];
-        sGyroRawY = ((pIMUScale[17] << 8) & 0xF00) | pIMUScale[16];
-        sGyroRawZ = ((pIMUScale[19] << 8) & 0xF00) | pIMUScale[18];
+        sGyroRawX = ((pIMUScale[15] << 8) & 0xFF00) | pIMUScale[14];
+        sGyroRawY = ((pIMUScale[17] << 8) & 0xFF00) | pIMUScale[16];
+        sGyroRawZ = ((pIMUScale[19] << 8) & 0xFF00) | pIMUScale[18];
     }
 
     /* Accelerometer scale */


### PR DESCRIPTION
## Description
When I test the sensors of my Nintendo controllers, I find:
> For Pro Controller, accel_x is about 1.3 times of the normal value
> For Joy-Con(L) in mini-pad mode, accel_y and accel_z are about 1.3 times of the normal value

I'm not sure if the cause is the mistake in the bitwise operations in LoadIMUCalibration. Anyway, after I changed 0xF00 to 0xFF00 in the code, the sensor data became normal. So, please have a check.