### PR TITLE
SDL_audiocvt: Respct the SDL_HINT_AUDIO_RESAMPLING_MODE hint

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -278,10 +278,7 @@ extern "C" {
  *  If this hint isn't specified to a valid setting, or libsamplerate isn't
  *  available, SDL will use the default, internal resampling algorithm.
  *
- *  Note that this is currently only applicable to resampling audio that is
- *  being written to a device for playback or audio being read from a device
- *  for capture. SDL_AudioCVT always uses the default resampler (although this
- *  might change for SDL 2.1).
+ *  As of SDL 2.26, SDL_AudioCVT now respects this hint.
  *
  *  This hint is currently only checked at audio subsystem initialization.
  *

--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -144,6 +144,7 @@ int (*SRC_src_process)(SRC_STATE *state, SRC_DATA *data) = NULL;
 int (*SRC_src_reset)(SRC_STATE *state) = NULL;
 SRC_STATE* (*SRC_src_delete)(SRC_STATE *state) = NULL;
 const char* (*SRC_src_strerror)(int error) = NULL;
+int (*SRC_src_simple)(SRC_DATA *data, int converter_type, int channels) = NULL;
 
 static SDL_bool
 LoadLibSampleRate(void)
@@ -178,8 +179,9 @@ LoadLibSampleRate(void)
     SRC_src_reset = (int(*)(SRC_STATE *state))SDL_LoadFunction(SRC_lib, "src_reset");
     SRC_src_delete = (SRC_STATE* (*)(SRC_STATE *state))SDL_LoadFunction(SRC_lib, "src_delete");
     SRC_src_strerror = (const char* (*)(int error))SDL_LoadFunction(SRC_lib, "src_strerror");
+    SRC_src_simple = (int(*)(SRC_DATA *data, int converter_type, int channels))SDL_LoadFunction(SRC_lib, "src_simple");
 
-    if (!SRC_src_new || !SRC_src_process || !SRC_src_reset || !SRC_src_delete || !SRC_src_strerror) {
+    if (!SRC_src_new || !SRC_src_process || !SRC_src_reset || !SRC_src_delete || !SRC_src_strerror || !SRC_src_simple) {
         SDL_UnloadObject(SRC_lib);
         SRC_lib = NULL;
         return SDL_FALSE;
@@ -190,6 +192,7 @@ LoadLibSampleRate(void)
     SRC_src_reset = src_reset;
     SRC_src_delete = src_delete;
     SRC_src_strerror = src_strerror;
+    SRC_src_simple = src_simple;
 #endif
 
     SRC_available = SDL_TRUE;

--- a/src/audio/SDL_audio_c.h
+++ b/src/audio/SDL_audio_c.h
@@ -45,6 +45,7 @@ extern int (*SRC_src_process)(SRC_STATE *state, SRC_DATA *data);
 extern int (*SRC_src_reset)(SRC_STATE *state);
 extern SRC_STATE* (*SRC_src_delete)(SRC_STATE *state);
 extern const char* (*SRC_src_strerror)(int error);
+extern int (*SRC_src_simple)(SRC_DATA *data, int converter_type, int channels);
 #endif
 
 /* Functions to get a list of "close" audio formats */


### PR DESCRIPTION
Hi, first time PR.  I was digging around in the audio code while debugging #6391 (did not find a real solution for that sadly.)  I saw that libsamplerate is a library already being used for the AudioStreams API but wasn't yet implemented for the Audio_CVT API.  I thought it would be more consistent if this was applied universally.

It's basically just a function pointer that gets set if the hint is set (off by default) and the user has libsamplerate available on their system.  I used the src_simple API which doesn't require any init/de-init.  It just converts the entire buffer in much the same way as SDL's internal conversion function does.

I wasn't sure what to do if the library reports an error.  It doesn't look like the AudioStreams API handles libsamplerate failures in any special way (as far as I could tell) so I just logged it.