### PR TITLE
Fixed mouse warp after resizing window on macOS.

### DIFF
--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -790,6 +790,11 @@ Cocoa_UpdateClipCursor(SDL_Window * window)
         return;
     }
 
+    if (focusClickPending) {
+        focusClickPending = 0;
+        [self onMovingOrFocusClickPendingStateCleared];
+    }
+
     window = _data.window;
     nswindow = _data.nswindow;
     rect = [nswindow contentRectForFrameRect:[nswindow frame]];


### PR DESCRIPTION
Mouse warp can be broken on macOS for at least two ways.

1. If you resize a window while mouse is already slightly outside of the window rather than inside of it (after mouse leave event).
2. When you use maximize window button on titlebar.

In both cases it executes the Cocoa_HandleTitleButtonEvent() function but only for mouse down event. It never receives mouse up event, so that SDL is constantly in FocusClickPending state and it breaks mouse warp functions.

An easy fix is to reset this state when resizing window is finished. Something similar is already done in windowDidMiniaturize().