### PR TITLE
Allow software renderer to simulate vsync

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -1118,7 +1118,7 @@ SDL_CreateSoftwareRenderer(SDL_Surface * surface)
 #if !SDL_RENDER_DISABLED && SDL_VIDEO_RENDER_SW
     SDL_Renderer *renderer;
 
-    renderer = SW_CreateRendererForSurface(surface);
+    renderer = SW_CreateRendererForSurface(surface, SDL_FALSE);
 
     if (renderer) {
         VerifyDrawQueueFunctions(renderer);

--- a/src/render/SDL_sysrender.h
+++ b/src/render/SDL_sysrender.h
@@ -290,6 +290,18 @@ struct SDL_RenderDriver
     SDL_RendererInfo info;
 };
 
+/* Support for framebuffer emulation using an accelerated renderer */
+
+#define SDL_WINDOWTEXTUREDATA   "_SDL_WindowTextureData"
+
+typedef struct {
+    SDL_Renderer *renderer;
+    SDL_Texture *texture;
+    void *pixels;
+    int pitch;
+    int bytes_per_pixel;
+} SDL_WindowTextureData;
+
 /* Not all of these are available in a given build. Use #ifdefs, etc. */
 extern SDL_RenderDriver D3D_RenderDriver;
 extern SDL_RenderDriver D3D11_RenderDriver;

--- a/src/render/software/SDL_render_sw_c.h
+++ b/src/render/software/SDL_render_sw_c.h
@@ -22,7 +22,7 @@
 #ifndef SDL_render_sw_c_h_
 #define SDL_render_sw_c_h_
 
-extern SDL_Renderer * SW_CreateRendererForSurface(SDL_Surface * surface);
+extern SDL_Renderer * SW_CreateRendererForSurface(SDL_Surface * surface, SDL_bool simulate_vsync);
 
 #endif /* SDL_render_sw_c_h_ */
 

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -19,6 +19,7 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 #include "../SDL_internal.h"
+#include "../render/SDL_sysrender.h"
 
 /* The high-level video driver subsystem */
 
@@ -183,18 +184,6 @@ DisableUnsetFullscreenOnMinimize(_THIS)
 }
 
 /* Support for framebuffer emulation using an accelerated renderer */
-
-#define SDL_WINDOWTEXTUREDATA   "_SDL_WindowTextureData"
-
-typedef struct {
-    SDL_Renderer *renderer;
-    SDL_Texture *texture;
-    void *pixels;
-    int pitch;
-    int bytes_per_pixel;
-} SDL_WindowTextureData;
-
-
 static int
 SDL_CreateWindowTexture(SDL_VideoDevice *_this, SDL_Window * window, Uint32 * format, void ** pixels, int *pitch)
 {


### PR DESCRIPTION
Vsync was enabled in the software renderer but it only gave a hint to apply to a potential hardware accelerated framebuffer.

This adds a check to see if we are on a full software path (or otherwise didn't get vsync) and simulate it if the application requests vsync.

Let me know if that WindowTextureData declaration needs to go somewhere else.  Wasn't really sure what header to put it in.

Some history I dug up if you're interested.  Issue and commit for enabling vsync in software (last year):
#4612
fcfd19db862b60159577720f46d31a35a03e7888

Issue and commit for the simulated vsync (just last month):
#5134
d744aafb0587f8a4917287df8d2e891871e0b324