### PR TITLE
fix SDL_SendEditingText when long composition text is enabled and strlen(text) == SDL_TEXTEDITINGEVENT_TEXT_SIZE

### DIFF
--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -1058,7 +1058,7 @@ SDL_SendEditingText(const char *text, int start, int length)
         SDL_utf8strlcpy(event.edit.text, text, SDL_arraysize(event.edit.text));
 
         if (SDL_GetHintBoolean(SDL_HINT_IME_SUPPORT_EXTENDED_TEXT, SDL_FALSE) &&
-            SDL_strlen(text) > SDL_arraysize(event.text.text)) {
+            SDL_strlen(text) >= SDL_arraysize(event.text.text)) {
             event.editExt.type = SDL_TEXTEDITING_EXT;
             event.editExt.windowID = keyboard->focus ? keyboard->focus->id : 0;
             event.editExt.text = text ? SDL_strdup(text) : NULL;


### PR DESCRIPTION
## Description
fixes #6408 
