### PR TITLE
Use translationInView for mouse wheel event on iOS

### DIFF
--- a/src/video/uikit/SDL_uikitview.m
+++ b/src/video/uikit/SDL_uikitview.m
@@ -455,25 +455,36 @@ extern int SDL_AppleTVRemoteOpenedAsJoystick;
 
 #endif /* TARGET_OS_TV || defined(__IPHONE_9_1) */
 
+static CGPoint translation_old = (CGPoint){ 0.0, 0.0 };
+
 -(void)mouseWheelGesture:(UIPanGestureRecognizer *)gesture
 {
     if (gesture.state == UIGestureRecognizerStateBegan ||
-        gesture.state == UIGestureRecognizerStateChanged ||
-        gesture.state == UIGestureRecognizerStateEnded) {
-        CGPoint velocity = [gesture velocityInView:self];
+        gesture.state == UIGestureRecognizerStateChanged) {
 
-        if (velocity.x > 0.0f) {
-            velocity.x = -1.0;
-        } else if (velocity.x < 0.0f) {
-            velocity.x = 1.0f;
+        CGPoint translation = [gesture translationInView:self];
+        CGPoint mouse_wheel = translation;
+
+        if (gesture.state == UIGestureRecognizerStateChanged) {
+            mouse_wheel.x -= translation_old.x;
+            mouse_wheel.y -= translation_old.y;
         }
-        if (velocity.y > 0.0f) {
-            velocity.y = -1.0;
-        } else if (velocity.y < 0.0f) {
-            velocity.y = 1.0f;
+
+        translation_old = translation;
+
+        if (mouse_wheel.x > 0.0f) {
+            mouse_wheel.x = 1.0;
+        } else if (mouse_wheel.x < 0.0f) {
+            mouse_wheel.x = -1.0f;
         }
-        if (velocity.x != 0.0f || velocity.y != 0.0f) {
-            SDL_SendMouseWheel(sdlwindow, 0, velocity.x, velocity.y, SDL_MOUSEWHEEL_NORMAL);
+        if (mouse_wheel.y > 0.0f) {
+            mouse_wheel.y = 1.0;
+        } else if (mouse_wheel.y < 0.0f) {
+            mouse_wheel.y = -1.0f;
+        }
+
+        if (mouse_wheel.x != 0.0f || mouse_wheel.y != 0.0f) {
+            SDL_SendMouseWheel(sdlwindow, 0, mouse_wheel.x, mouse_wheel.y, SDL_MOUSEWHEEL_NORMAL);
         }
     }
 }


### PR DESCRIPTION
The velocityInView causes issues on iPad with external mouse. For first event in gesture velocity is always 0, so that you have to use your scroll wheel twice to generate actual scroll event in SDL. Other issue is that when you scroll up and down quickly, then velocity is still positive for some time before to changes sign to negative, so that you get scroll events for incorrect direction.

translationInView gives position in pixels, so that if I subtract it from value from previous event, then I should always get correct direction.

Note that this patch is not 100% correct because I always set SDL_MOUSEWHEEL_NORMAL. I don't know how to read from system if mouse scrolling is inverted.

And btw. with translationInView it should be possible to make some kind of smooth scroll because if you scroll faster, then you get higher values in pixels.