### PR TITLE
loadso, dlsym, SDL_LoadFunction: cleanup the underscored name path.

### DIFF
--- a/src/loadso/dlopen/SDL_sysloadso.c
+++ b/src/loadso/dlopen/SDL_sysloadso.c
@@ -60,12 +60,12 @@ SDL_LoadFunction(void *handle, const char *name)
 {
     void *symbol = dlsym(handle, name);
     if (symbol == NULL) {
-        /* append an underscore for platforms that need that. */
+        /* prepend an underscore for platforms that need that. */
         SDL_bool isstack;
-        size_t len = 1 + SDL_strlen(name) + 1;
-        char *_name = SDL_small_alloc(char, len, &isstack);
+        size_t len = SDL_strlen(name) + 1;
+        char *_name = SDL_small_alloc(char, len + 1, &isstack);
         _name[0] = '_';
-        SDL_strlcpy(&_name[1], name, len);
+        SDL_memcpy(&_name[1], name, len);
         symbol = dlsym(handle, _name);
         SDL_small_free(_name, isstack);
         if (symbol == NULL) {


### PR DESCRIPTION
- strlcpy was passed a wrong buffer length parameter. has worked so far by luck.
- use memcpy instead of strlcpy for simplicity.
- 'append' has been a typo: should be 'prepend'.
