### PR TITLE
os/2 loadso improvements

### DIFF
--- a/src/hidapi/SDL_hidapi.c
+++ b/src/hidapi/SDL_hidapi.c
@@ -1075,13 +1075,8 @@ int SDL_hid_init(void)
         if (libusb_ctx.libhandle != NULL) {
             SDL_bool loaded = SDL_TRUE;
 #ifdef SDL_LIBUSB_DYNAMIC
-            #ifdef __OS2__
-            #define LOAD_LIBUSB_SYMBOL(func) \
-                if (!(libusb_ctx.func = SDL_LoadFunction(libusb_ctx.libhandle,"_libusb_" #func))) {loaded = SDL_FALSE;}
-            #else
             #define LOAD_LIBUSB_SYMBOL(func) \
                 if (!(libusb_ctx.func = SDL_LoadFunction(libusb_ctx.libhandle, "libusb_" #func))) {loaded = SDL_FALSE;}
-            #endif
 #else
             #define LOAD_LIBUSB_SYMBOL(func) \
                 libusb_ctx.func = libusb_##func;

--- a/src/loadso/os2/SDL_sysloadso.c
+++ b/src/loadso/os2/SDL_sysloadso.c
@@ -47,11 +47,20 @@ SDL_LoadObject(const char *sofile)
 
     pszModName = OS2_UTF8ToSys(sofile);
     ulRC = DosLoadModule(acError, sizeof(acError), pszModName, &hModule);
-    SDL_free(pszModName);
+
+    if (ulRC != NO_ERROR && !SDL_strrchr(pszModName, '\\') && !SDL_strrchr(pszModName, '/')) {
+        /* strip .dll extension and retry only if name has no path. */
+        size_t len = SDL_strlen(pszModName);
+        if (len > 4 && SDL_strcasecmp(&pszModName[len - 4], ".dll") == 0) {
+            pszModName[len - 4] = '\0';
+            ulRC = DosLoadModule(acError, sizeof(acError), pszModName, &hModule);
+        }
+    }
     if (ulRC != NO_ERROR) {
         SDL_SetError("Failed loading %s: %s (E%u)", sofile, acError, ulRC);
-        return NULL;
+        hModule = NULLHANDLE;
     }
+    SDL_free(pszModName);
 
     return (void *)hModule;
 }
@@ -63,6 +72,16 @@ SDL_LoadFunction(void *handle, const char *name)
     PFN     pFN;
 
     ulRC = DosQueryProcAddr((HMODULE)handle, 0, name, &pFN);
+    if (ulRC != NO_ERROR) {
+        /* retry with an underscore prepended, e.g. for gcc-built dlls. */
+        SDL_bool isstack;
+        size_t len = SDL_strlen(name) + 1;
+        char *_name = SDL_small_alloc(char, len + 1, &isstack);
+        _name[0] = '_';
+        SDL_memcpy(&_name[1], name, len);
+        ulRC = DosQueryProcAddr((HMODULE)handle, 0, _name, &pFN);
+        SDL_small_free(_name, isstack);
+    }
     if (ulRC != NO_ERROR) {
         SDL_SetError("Failed loading procedure %s (E%u)", name, ulRC);
         return NULL;


### PR DESCRIPTION
- SDL_LoadObject: upon failure, strip the .dll extension and retry,
  but only if module name has no path.
  (See, e.g.: http://www.edm2.com/index.php/DosLoadModule#Gotchas)
- SDL_LoadFunction: upon failure, retry with an underscore prepended,
  e.g. for gcc-built dlls.
- hidapi, libusb: remove os/2 symbol load hack after these updates.

CC: @SilvanScherrer
