### PR TITLE
Allow Foreign Windows to call SDL_Vulkan_CreateSurface on MacOS

### DIFF
--- a/src/video/cocoa/SDL_cocoavulkan.m
+++ b/src/video/cocoa/SDL_cocoavulkan.m
@@ -233,6 +233,8 @@ static SDL_bool Cocoa_Vulkan_CreateSurfaceViaMetalView(_THIS,
      * a subview of the window.) If we release the view here to make it +1, it
      * will be destroyed when the window is destroyed. */
     CFBridgingRelease(metalview);
+    
+    return SDL_TRUE;
 }
 
 SDL_bool Cocoa_Vulkan_CreateSurface(_THIS,


### PR DESCRIPTION
## Description

### Background
I've been working on creating some tests/examples for rendering into Qt windows using various Gfx apis with SDL as a bridge, and ran into an issue where my Vulkan renderer wouldn't present to the screen. After some investigating I found that I was getting a bogus extent for my Swapchain, which led to investigation of Surface creation. 

It seems that `Cocoa_Metal_CreateView` (called inside of `Cocoa_Vulkan_CreateSurface`) simply doesn't do the correct dance to create a CAMetalLayer capable view underneath the Window when SDL didn't itself create the Window. For context, Qt needs to be informed if you plan to render inside the window and create it appropriately. When created with Vulkan in mind, Qt will create a view with a CAMetalLayer set up. SDL currently ignores the Windows current state and attempts to add a subView of it's own creation. This leads to the aforementioned non-presenting Window. You can still render, but it's to a surface with a bogus extent (160x160) and won't present.

### Fix
Before calling `Cocoa_Metal_CreateView`, we detect to see if we're working with a Foreign Window, and if so, detect if the Window has an sdlContentView with a Metal capable layer already. If so, we use that to create the Surface.

### Remaining Issue
Even after the change laid out above, I'm unable to create a Window from Qt that _is not_ set up as a Vulkan window, and have SDL correctly create a subview with a `CAMetalLayer` capable View. There's likely something eluding me about that case, or maybe that codepath (Foreign Window, no existing `CAMetalLayer`) needs it's own bespoke setup beyond the one added here, and the existing `Cocoa_Metal_CreateView` code paths.

I'm not particularly experienced with Apple, so please let me know if anything I'm doing is silly, or if the change should be restructured. I considered trying to make this change inside `Cocoa_Metal_CreateView` but it seemed it would be convoluted to handle both cases in the various `SDL_MetalView` functions