### PR TITLE
win32: support DWM dark mode opt-in for SDL windows

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -2082,6 +2082,20 @@ extern "C" {
 #define SDL_HINT_WINDOWS_DPI_SCALING "SDL_WINDOWS_DPI_SCALING"
 
 /**
+ * \brief Allows windows to use the system light/dark mode configuration.
+ *
+ *  By default, Windows does not opt any applications into adhering to the dark
+ *  mode color scheme for title bars/borders. This hint tells Windows to use
+ *  the appropriate dark/light mode colors for created SDL windows.
+ *
+ *  This variable can be set to the following values:
+ *    "0"       - Windows will always use the light mode color scheme.
+ *    "1"       - Windows will follow the user light/dark mode preference and use
+ *                dark title bar and window borders when appropriate.
+ */
+#define SDL_HINT_WINDOWS_HONOR_DARK_MODE "SDL_WINDOWS_HONOR_DARK_MODE"
+
+/**
  *  \brief  A variable controlling whether the window frame and title bar are interactive when the cursor is hidden 
  *
  *  This variable can be set to the following values:

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -49,6 +49,12 @@
 #define SWP_NOCOPYBITS 0
 #endif
 
+/* Dark mode support */
+#ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
+#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
+#endif
+typedef HRESULT(WINAPI *pfnDwmSetWindowAttribute)(HWND hwnd, DWORD dwAttribute, LPCVOID pvAttribute, DWORD cbAttribute);
+
 /* #define HIGHDPI_DEBUG */
 
 /* Fake window to help with DirectInput events. */
@@ -517,6 +523,18 @@ WIN_CreateWindow(_THIS, SDL_Window * window)
                      SDL_Instance, NULL);
     if (!hwnd) {
         return WIN_SetError("Couldn't create window");
+    }
+
+    if (SDL_GetHintBoolean(SDL_HINT_WINDOWS_HONOR_DARK_MODE, SDL_FALSE)) {
+        void *pDwmApiDll = SDL_LoadObject("dwmapi.dll");
+        if (pDwmApiDll) {
+            pfnDwmSetWindowAttribute pDwmSetWindowAttribute = SDL_LoadFunction(pDwmApiDll, "DwmSetWindowAttribute");
+            if (pDwmSetWindowAttribute) {
+                BOOL value = TRUE;
+                pDwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &value, sizeof(value));
+            }
+            SDL_UnloadObject(pDwmApiDll);
+        }
     }
 
     WIN_PumpEvents(_this);


### PR DESCRIPTION
This makes windowed mode use a dark window frame when the system is configured to use a dark mode theme. The hint defaults to SDL_TRUE, so it will try to respect the system-wide preference by default As far as I can tell, there is no way to explicitly set the window borders to dark; there's only a way to opt in to respecting the system theme. Kind of annoying, but whatever.