### PR TITLE
Fix mismatch between Init and Quit

### DIFF
--- a/src/SDL.c
+++ b/src/SDL.c
@@ -407,6 +407,9 @@ SDL_QuitSubSystem(Uint32 flags)
 
 #if !SDL_AUDIO_DISABLED
     if ((flags & SDL_INIT_AUDIO)) {
+        /* audio implies events */
+        flags |= SDL_INIT_EVENTS;
+
         if (SDL_PrivateShouldQuitSubsystem(SDL_INIT_AUDIO)) {
             SDL_AudioQuit();
         }


### PR DESCRIPTION
Init says that audio implies events (line 195), Quit was missing the implication.

https://github.com/libsdl-org/SDL/blob/b9e1d1b4de713c031353ec300113bd776961625c/src/SDL.c#L194-L196

(Just noticed this as I was reading the code on Github, I don't have an example where this causes a bug.)