### PR TITLE
Added information about SDL_Quit cause

### DIFF
--- a/include/SDL_events.h
+++ b/include/SDL_events.h
@@ -578,6 +578,7 @@ typedef struct SDL_QuitEvent
 {
     Uint32 type;        /**< ::SDL_QUIT */
     Uint32 timestamp;   /**< In milliseconds, populated using SDL_GetTicks() */
+    Uint32 quitTrigger; /**< Trigger for the quit event */
 } SDL_QuitEvent;
 
 /**

--- a/include/SDL_video.h
+++ b/include/SDL_video.h
@@ -149,6 +149,21 @@ typedef enum
             (((X)&0xFFFF0000) == SDL_WINDOWPOS_CENTERED_MASK)
 
 /**
+*  \brief Enumerates the possible triggers for the window close event
+*/
+typedef enum
+{
+    SDL_WINDOWCLOSETRIGGER_CLOSE,               /**< The default window close event. Available on all back-ends */
+    SDL_WINDOWCLOSETRIGGER_SIGNAL,              /**< Window has been closed by a signal event such as that triggered 
+                                                     by Ctrl+C from the launching terminal. Available on Unix-like 
+                                                     back-ends*/
+    SDL_WINDOWCLOSETRIGGER_KEYBOARD_SHORTCUT,   /**< Window has been closed with a keyboard shortcut such as Alt+F4. 
+                                                     Available with Windows and os2 back-ends*/
+    SDL_WINDOWCLOSETRIGGER_ERROR_STATE          /**< An error state has necessitated a window close. Available with 
+                                                     Wayland back-end*/
+} SDL_WindowCloseTrigger;
+
+/**
  *  \brief Event subtype for window events
  */
 typedef enum
@@ -178,6 +193,7 @@ typedef enum
     SDL_WINDOWEVENT_ICCPROF_CHANGED,/**< The ICC profile of the window's display has changed. */
     SDL_WINDOWEVENT_DISPLAY_CHANGED /**< Window has been moved to display data1. */
 } SDL_WindowEventID;
+
 
 /**
  *  \brief Event subtype for display events

--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -1184,7 +1184,7 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(nativeSendQuit)(
      * events other than SDL_QUIT and SDL_APP_TERMINATING should fire */
     SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT);
     /* Inject a SDL_QUIT event */
-    SDL_SendQuit();
+    SDL_SendQuit(SDL_WINDOWCLOSETRIGGER_CLOSE);
     SDL_SendAppEvent(SDL_APP_TERMINATING);
     /* Robustness: clear any pending Pause */
     while (SDL_SemTryWait(Android_PauseSem) == 0) {

--- a/src/events/SDL_events_c.h
+++ b/src/events/SDL_events_c.h
@@ -48,7 +48,7 @@ extern int SDL_SendSysWMEvent(SDL_SysWMmsg * message);
 extern int SDL_SendKeymapChangedEvent(void);
 extern int SDL_SendLocaleChangedEvent(void);
 
-extern int SDL_SendQuit(void);
+extern int SDL_SendQuit(int quitTrigger);
 
 extern int SDL_EventsInit(void);
 extern void SDL_EventsQuit(void);

--- a/src/events/SDL_quit.c
+++ b/src/events/SDL_quit.c
@@ -176,7 +176,7 @@ SDL_SendPendingSignalEvents(void)
 {
 #ifdef HAVE_SIGNAL_SUPPORT
     if (send_quit_pending) {
-        SDL_SendQuit();
+        SDL_SendQuit(SDL_WINDOWCLOSETRIGGER_SIGNAL);
         SDL_assert(!send_quit_pending);
     }
 
@@ -198,12 +198,21 @@ SDL_SendPendingSignalEvents(void)
 
 /* This function returns 1 if it's okay to close the application window */
 int
-SDL_SendQuit(void)
+SDL_SendQuit(int quitTrigger)
 {
+    int posted;
 #ifdef HAVE_SIGNAL_SUPPORT
     send_quit_pending = SDL_FALSE;
 #endif
-    return SDL_SendAppEvent(SDL_QUIT);
+
+    posted = 0;
+    if (SDL_GetEventState(SDL_QUIT) == SDL_ENABLE) {
+        SDL_Event event;
+        event.type = SDL_QUIT;
+        event.quit.quitTrigger = quitTrigger;
+        posted = (SDL_PushEvent(&event) > 0);
+    }
+    return (posted);
 }
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/events/SDL_windowevents.c
+++ b/src/events/SDL_windowevents.c
@@ -225,7 +225,7 @@ SDL_SendWindowEvent(SDL_Window * window, Uint8 windowevent, int data1,
     if (windowevent == SDL_WINDOWEVENT_CLOSE) {
         if ( !window->prev && !window->next ) {
             if (SDL_GetHintBoolean(SDL_HINT_QUIT_ON_LAST_WINDOW_CLOSE, SDL_TRUE)) {
-                SDL_SendQuit();  /* This is the last window in the list so send the SDL_QUIT event */
+                SDL_SendQuit(data1);  /* This is the last window in the list so send the SDL_QUIT event */
             }
         }
     }

--- a/src/video/cocoa/SDL_cocoaevents.m
+++ b/src/video/cocoa/SDL_cocoaevents.m
@@ -68,7 +68,7 @@ static SDL_Window *FindSDLWindowForNSWindow(NSWindow *win)
 // Override terminate to handle Quit and System Shutdown smoothly.
 - (void)terminate:(id)sender
 {
-    SDL_SendQuit();
+    SDL_SendQuit(SDL_WINDOWCLOSETRIGGER_CLOSE);
 }
 
 static SDL_bool s_bShouldHandleEventsInSDLApplication = SDL_FALSE;

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -724,7 +724,7 @@ Cocoa_UpdateClipCursor(SDL_Window * window)
 
 - (BOOL)windowShouldClose:(id)sender
 {
-    SDL_SendWindowEvent(_data.window, SDL_WINDOWEVENT_CLOSE, 0, 0);
+    SDL_SendWindowEvent(_data.window, SDL_WINDOWEVENT_CLOSE, SDL_WINDOWCLOSETRIGGER_CLOSE, 0);
     return NO;
 }
 

--- a/src/video/directfb/SDL_DirectFB_WM.c
+++ b/src/video/directfb/SDL_DirectFB_WM.c
@@ -306,7 +306,7 @@ DirectFB_WM_ProcessEvent(_THIS, SDL_Window * window, DFBWindowEvent * evt)
                 return 0;
             case WM_POS_CLOSE:
                 windata->wm_grab = WM_POS_NONE;
-                SDL_SendWindowEvent(window, SDL_WINDOWEVENT_CLOSE, 0,
+                SDL_SendWindowEvent(window, SDL_WINDOWEVENT_CLOSE, SDL_WINDOWCLOSETRIGGER_CLOSE,
                                     0);
                 return 1;
             case WM_POS_MAX:

--- a/src/video/directfb/SDL_DirectFB_events.c
+++ b/src/video/directfb/SDL_DirectFB_events.c
@@ -271,7 +271,7 @@ ProcessWindowEvent(_THIS, SDL_Window *sdlwin, DFBWindowEvent * evt)
                                 evt->w, evt->h);
             break;
         case DWET_CLOSE:
-            SDL_SendWindowEvent(sdlwin, SDL_WINDOWEVENT_CLOSE, 0, 0);
+            SDL_SendWindowEvent(sdlwin, SDL_WINDOWEVENT_CLOSE, SDL_WINDOWCLOSETRIGGER_CLOSE, 0);
             break;
         case DWET_GOTFOCUS:
             DirectFB_SetContext(_this, sdlwin);

--- a/src/video/os2/SDL_os2video.c
+++ b/src/video/os2/SDL_os2video.c
@@ -312,7 +312,7 @@ static VOID _wmChar(WINDATA *pWinData, MPARAM mp1, MPARAM mp2)
 
     if (((ulFlags & (KC_VIRTUALKEY | KC_KEYUP | KC_ALT)) == (KC_VIRTUALKEY | KC_ALT)) &&
         (ulVirtualKey == VK_F4)) {
-        SDL_SendWindowEvent(pWinData->window, SDL_WINDOWEVENT_CLOSE, 0, 0);
+        SDL_SendWindowEvent(pWinData->window, SDL_WINDOWEVENT_CLOSE, SDL_WINDOWCLOSETRIGGER_KEYBOARD_SHORTCUT, 0);
     }
 
     if ((ulFlags & KC_SCANCODE) != 0) {
@@ -564,7 +564,7 @@ static MRESULT EXPENTRY wndProc(HWND hwnd, ULONG msg, MPARAM mp1, MPARAM mp2)
     switch (msg) {
     case WM_CLOSE:
     case WM_QUIT:
-        SDL_SendWindowEvent(pWinData->window, SDL_WINDOWEVENT_CLOSE, 0, 0);
+        SDL_SendWindowEvent(pWinData->window, SDL_WINDOWEVENT_CLOSE, SDL_WINDOWCLOSETRIGGER_CLOSE, 0);
         if (pWinData->fnUserWndProc == NULL)
             return (MRESULT)FALSE;
         break;

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -437,7 +437,7 @@ Wayland_PumpEvents(_THIS)
             /* Only send a single quit message, as application shutdown might call
              * SDL_PumpEvents
              */
-            SDL_SendQuit();
+            SDL_SendQuit(SDL_WINDOWCLOSETRIGGER_ERROR_STATE);
         }
     }
 }

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -804,7 +804,7 @@ windowmanager_hints(void *data, struct qt_windowmanager *qt_windowmanager,
 static void
 windowmanager_quit(void *data, struct qt_windowmanager *qt_windowmanager)
 {
-    SDL_SendQuit();
+    SDL_SendQuit(SDL_WINDOWCLOSETRIGGER_ERROR_STATE);
 }
 
 static const struct qt_windowmanager_listener windowmanager_listener = {

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -685,7 +685,7 @@ static void
 handle_close_xdg_toplevel(void *data, struct xdg_toplevel *xdg_toplevel)
 {
     SDL_WindowData *window = (SDL_WindowData *)data;
-    SDL_SendWindowEvent(window->sdlwindow, SDL_WINDOWEVENT_CLOSE, 0, 0);
+    SDL_SendWindowEvent(window->sdlwindow, SDL_WINDOWEVENT_CLOSE, SDL_WINDOWCLOSETRIGGER_CLOSE, 0);
 }
 
 static const struct xdg_toplevel_listener toplevel_listener_xdg = {
@@ -708,7 +708,7 @@ static void
 handle_done_xdg_popup(void *data, struct xdg_popup *xdg_popup)
 {
     SDL_WindowData *window = (SDL_WindowData *)data;
-    SDL_SendWindowEvent(window->sdlwindow, SDL_WINDOWEVENT_CLOSE, 0, 0);
+    SDL_SendWindowEvent(window->sdlwindow, SDL_WINDOWEVENT_CLOSE, SDL_WINDOWCLOSETRIGGER_CLOSE, 0);
 }
 
 static void
@@ -926,7 +926,7 @@ decoration_frame_configure(struct libdecor_frame *frame,
 static void
 decoration_frame_close(struct libdecor_frame *frame, void *user_data)
 {
-    SDL_SendWindowEvent(((SDL_WindowData *)user_data)->sdlwindow, SDL_WINDOWEVENT_CLOSE, 0, 0);
+    SDL_SendWindowEvent(((SDL_WindowData *)user_data)->sdlwindow, SDL_WINDOWEVENT_CLOSE, SDL_WINDOWCLOSETRIGGER_CLOSE, 0);
 }
 
 static void
@@ -962,7 +962,7 @@ static void
 handle_close(void *data, struct qt_extended_surface *qt_extended_surface)
 {
     SDL_WindowData *window = (SDL_WindowData *)data;
-    SDL_SendWindowEvent(window->sdlwindow, SDL_WINDOWEVENT_CLOSE, 0, 0);
+    SDL_SendWindowEvent(window->sdlwindow, SDL_WINDOWEVENT_CLOSE, SDL_WINDOWCLOSETRIGGER_CLOSE, 0);
 }
 
 static const struct qt_extended_surface_listener extended_surface_listener = {

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -955,7 +955,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
             if (keyboardState[SDL_SCANCODE_LALT] == SDL_PRESSED || keyboardState[SDL_SCANCODE_RALT] == SDL_PRESSED) {
                 /* ALT+F4: Close window */
                 if (code == SDL_SCANCODE_F4 && ShouldGenerateWindowCloseOnAltF4()) {
-                    SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_CLOSE, 0, 0);
+                    SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_CLOSE, SDL_WINDOWCLOSETRIGGER_KEYBOARD_SHORTCUT, 0);
                 }
             }
 
@@ -1303,7 +1303,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
     case WM_CLOSE:
         {
-            SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_CLOSE, 0, 0);
+            SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_CLOSE, SDL_WINDOWCLOSETRIGGER_CLOSE, 0);
         }
         returnCode = 0;
         break;

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -1276,7 +1276,7 @@ X11_DispatchEvent(_THIS, XEvent *xevent)
 #ifdef DEBUG_XEVENTS
                 printf("window %p: WM_DELETE_WINDOW\n", data);
 #endif
-                SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_CLOSE, 0, 0);
+                SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_CLOSE, SDL_WINDOWCLOSETRIGGER_CLOSE, 0);
                 break;
             }
             else if ((xevent->xclient.message_type == videodata->WM_PROTOCOLS) &&


### PR DESCRIPTION
I've added functionality so that a user can get more information about the source of an SDL_Quit event. 

## Description
I've defined four distinct types of window close triggers:
- SDL_WINDOWCLOSETRIGGER_CLOSE covers the general case when no more info is available
- SDL_WINDOWCLOSETRIGGER_SIGNAL covers the case when a signal has generated a close
- SDL_WINDOWCLOSETRIGGER_KEYBOARD_SHORTCUT covers the case where a shortcut such as Alt + F4 is the trigger
- SDL_WINDOWCLOSETRIGGER_ERROR_STATE covers the case when an error necessitates a shutdown

There's a bit of a limitation that I'd like to fix: the _KEYBOARD_SHORTCUT trigger won't be reported when exiting with Alt + F4 in Linux on both the x11 and Wayland back-ends. When Alt is held the F4 keypress isn't captured on the client side. I played around with the x11 back-end and attempted to query the keyboard state using XQueryKeymap before SDL_WINDOWEVENT_CLOSE is posted. I found that there's no consistency in the keymap produced by this function across distributions - what I tried worked on Ubuntu but not on Fedora. 

I'm not particularly familiar with x11 or Wayland development, so any suggestions on how I could approach this would be much appreciated as I'm happy to continue working on this.

Also worth noting is that I haven't done anything to capture Command + Q on Mac as the original issue mentioned. I don't have a device to develop and test this on sadly.

## Existing Issue(s)
The issue addressed is here: https://github.com/libsdl-org/SDL/issues/2348