### PR TITLE
Deprecate sdl2-config and AM_PATH_SDL2

### DIFF
--- a/sdl2-config.in
+++ b/sdl2-config.in
@@ -19,6 +19,11 @@ if test $# -eq 0; then
       exit 1
 fi
 
+echo "sdl2-config: This script is deprecated" >&2
+echo "sdl2-config: In Autotools builds, use PKG_CHECK_MODULES([SDL], [sdl2 >= 2.x.y])" >&2
+echo "sdl2-config: In CMake builds, use find_package(SDL2 CONFIG)" >&2
+echo "sdl2-config: In other build systems, look for 'sdl2' with pkg-config(1) or pkgconf(1)" >&2
+
 while test $# -gt 0; do
   case "$1" in
   -*=*) optarg=`echo "$1" | sed 's/[-_a-zA-Z0-9]*=//'` ;;

--- a/sdl2.m4
+++ b/sdl2.m4
@@ -10,7 +10,7 @@
 # * removed HP/UX 9 support.
 # * updated for newer autoconf.
 
-# serial 2
+# serial 3
 
 dnl AM_PATH_SDL2([MINIMUM-VERSION, [ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND]]])
 dnl Test for SDL, and define SDL_CFLAGS and SDL_LIBS
@@ -19,6 +19,7 @@ AC_DEFUN([AM_PATH_SDL2],
 [dnl
 dnl Get the cflags and libraries from the sdl2-config script
 dnl
+AC_MSG_WARN([[$0 is deprecated, please use PKG_CHECK_MODULES([SDL], [sdl2 >= MINIMUM_VERSION]) instead]])
 AC_ARG_WITH(sdl-prefix,[  --with-sdl-prefix=PFX   Prefix where SDL is installed (optional)],
             sdl_prefix="$withval", sdl_prefix="")
 AC_ARG_WITH(sdl-exec-prefix,[  --with-sdl-exec-prefix=PFX Exec prefix where SDL is installed (optional)],


### PR DESCRIPTION
If we deprecate these in SDL 2.x, then developers of dependent projects will have had some advance warning before they're removed in SDL 3 (which I think should only install `${libdir}/pkgconfig/sdl3.pc` and `${libdir}/cmake/SDL3/*.cmake`, with no replacement for `${bindir}/sdl2-config` or `${datadir}/aclocal/sdl2.m4`).

* sdl2-config.in: Deprecate sdl2-config
    
    Library-specific foo-config scripts duplicate very similar logic across
    various different projects, and tend to break cross-compiling, multilib
    (gcc -m32), Debian/Ubuntu multiarch and so on by only being able to have
    one sdl2-config at a time as the first one in the PATH.
    
    The direct replacement is pkg-config(1) or a compatible reimplementation
    like pkgconf(1), which relies on each library installing declarative
    metadata, like SDL's sdl2.pc (available since at least 2.0.0) and
    centralizes the logic into the pkg-config/pkgconf tool.
    
    Most uses of `sdl2-config --foo` can be replaced by something similar
    to `${PKG_CONFIG:-pkg-config} --foo sdl2`. Instead of adding a custom
    sdl2-config to the PATH or using its --prefix or --exec-prefix options,
    users of a custom installation prefix can use any of pkg-config's
    non-SDL-specific ways to influence the result, for example setting
    PKG_CONFIG_PATH, PKG_CONFIG_SYSROOT_DIR or PKG_CONFIG_LIBDIR environment
    variables, or setting the PKG_CONFIG environment variable to point to
    a wrapper script.
    
    For Autotools specifically, the replacement for AM_PATH_SDL2 (which
    will be officially deprecated in a subsequent commit) is
    PKG_CHECK_MODULES.
    
    CMake has its own semi-declarative mechanism for dependency discovery,
    "config packages", and the SDL build already installs a config
    package. There's a good example of using a config package to discover
    SDL in `cmake/test/`.
    
    Meson natively supports pkg-config, and already uses it in preference
    to sdl2-config.
    
    Other build systems can run pkg-config instead of sdl2-config,
    preferably checking the PKG_CONFIG environment variable first.
    https://github.com/ioquake/ioq3 is a good example of a project doing
    this correctly.
    
    Helps: #6140, #3516

* sdl2.m4: Deprecate AM_PATH_SDL2 in favour of PKG_CHECK_MODULES
    
    AM_PATH_SDL2 doesn't add much beyond PKG_CHECK_MODULES, and having a
    special m4 macro for every library that you might depend on scales
    poorly.
    
    The macro does add special support for macOS frameworks, but that feature
    was broken for around 6 years without anyone noticing (#6141), and is
    likely to be only rarely useful according to comments on #6141.
    
    Resolves: #6140

## Existing Issue(s)

#6140 