### PR TITLE
cocoa: Reset IME when sending composed text

### DIFF
--- a/src/video/cocoa/SDL_cocoakeyboard.m
+++ b/src/video/cocoa/SDL_cocoakeyboard.m
@@ -66,6 +66,11 @@
         str = [aString UTF8String];
     }
 
+    /* We're likely sending the composed text, so we reset the IME status. */
+    if ([self hasMarkedText]) {
+        [self unmarkText];
+    }
+
     SDL_SendKeyboardText(str);
 }
 
@@ -114,7 +119,7 @@
                         (int) selectedRange.location, (int) selectedRange.length);
 
     DEBUG_IME(@"setMarkedText: %@, (%d, %d)", _markedText,
-          selRange.location, selRange.length);
+          selectedRange.location, selectedRange.length);
 }
 
 - (void)unmarkText


### PR DESCRIPTION
This will send an empty `TEXTEDITING` event to signal the end of the composition, the same way that is done on other platforms.