### PR TITLE
Use project(VERSION) to determine current SDL version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ if(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
 endif()
 
 cmake_minimum_required(VERSION 3.0.0)
-project(SDL2 C CXX)
+project(SDL2 LANGUAGES C CXX VERSION 2.24.2)
 
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
   set(SDL2_SUBPROJECT OFF)
@@ -2933,36 +2933,7 @@ set(EXTRA_CFLAGS ${_EXTRA_CFLAGS})
 
 # Compat helpers for the configuration files
 
-if(EXISTS "${PROJECT_SOURCE_DIR}/VERSION")
-  file(READ "${PROJECT_SOURCE_DIR}/VERSION" SDL_SOURCE_VERSION)
-endif()
-
-find_package(Git)
-if(Git_FOUND)
-  execute_process(COMMAND
-    "${GIT_EXECUTABLE}" describe --always --tags --long
-    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-    RESULT_VARIABLE GIT_REVISION_STATUS
-    OUTPUT_VARIABLE GIT_REVISION
-    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-else()
-  set(GIT_REVISION_STATUS 1)
-  set(GIT_REVISION "")
-endif()
-
-if(SDL_SOURCE_VERSION)
-  set(SDL_REVISION "SDL-${SDL_SOURCE_VERSION}")
-elseif(GIT_REVISION_STATUS EQUAL 0)
-  if(GIT_REVISION MATCHES "^[0-9a-f]+$")
-    # Just a truncated sha1, so prefix it with the version number
-    set(SDL_REVISION "SDL-${SDL_VERSION}-g${GIT_REVISION}")
-  else()
-    # e.g. release-2.24.0-542-g96361fc47
-    set(SDL_REVISION "SDL-${GIT_REVISION}")
-  endif()
-else()
-  set(SDL_REVISION "SDL-${SDL_VERSION}-no-vcs")
-endif()
+set(SDL_REVISION "SDL-${PROJECT_VERSION}")
 
 configure_file("${SDL2_SOURCE_DIR}/include/SDL_revision.h.cmake"
   "${SDL2_BINARY_DIR}/include/SDL_revision.h")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,14 @@ if(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
   message(FATAL_ERROR "Prevented in-tree build. Please create a build directory outside of the SDL source code and run \"cmake -S ${CMAKE_SOURCE_DIR} -B .\" from there")
 endif()
 
+# See docs/release_checklist.md
+set(SDL_MAJOR_VERSION 2)
+set(SDL_MINOR_VERSION 25)
+set(SDL_MICRO_VERSION 0)
+set(SDL_VERSION "${SDL_MAJOR_VERSION}.${SDL_MINOR_VERSION}.${SDL_MICRO_VERSION}")
+
 cmake_minimum_required(VERSION 3.0.0)
-project(SDL2 LANGUAGES C CXX VERSION 2.24.2)
+project(SDL2 LANGUAGES C CXX VERSION "${SDL_VERSION}")
 
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
   set(SDL2_SUBPROJECT OFF)
@@ -80,12 +86,6 @@ check_symbol_exists("__GLIBC__" "stdlib.h" LIBC_IS_GLIBC)
 if (LIBC_IS_GLIBC AND CMAKE_SIZEOF_VOID_P EQUAL 4)
     add_definitions(-D_FILE_OFFSET_BITS=64)
 endif()
-
-# See docs/release_checklist.md
-set(SDL_MAJOR_VERSION 2)
-set(SDL_MINOR_VERSION 25)
-set(SDL_MICRO_VERSION 0)
-set(SDL_VERSION "${SDL_MAJOR_VERSION}.${SDL_MINOR_VERSION}.${SDL_MICRO_VERSION}")
 
 # Set defaults preventing destination file conflicts
 set(SDL_CMAKE_DEBUG_POSTFIX "d"


### PR DESCRIPTION
Replace version check via Git with setting the version in `project()`

## Description

The disadvantage with using Git to determine the current version is that one has to be in a Git repository which is not the case e.g. when using SDL2 via a package manager like vcpkg. If Git is not found `SDL_REVISION` is empty.

I changed this behavior to define the current version in `project()`. IMO the advantage that you no longer need to run Git to get the current version outweighs the disadvantage that the Git commit hash is no longer part of `SDL_REVISION` but I don't think this is a meaningful change [If you think it is, I will change the PR to use Git only for the commit ID].
