### PR TITLE
Fix wayland reconnection paths

### DIFF
--- a/src/video/wayland/SDL_waylandmouse.c
+++ b/src/video/wayland/SDL_waylandmouse.c
@@ -620,10 +620,9 @@ Wayland_RecreateCursor(SDL_Cursor *cursor, SDL_VideoData *vdata)
         create_buffer_from_shm(cdata, cdata->w, cdata->h, WL_SHM_FORMAT_ARGB8888);
 
         SDL_memcpy(cdata->shm_data, old_data_pointer, stride * cdata->h);
-
-        cdata->surface = wl_compositor_create_surface(vdata->compositor);
-        wl_surface_set_user_data(cdata->surface, NULL);
     }
+    cdata->surface = wl_compositor_create_surface(vdata->compositor);
+    wl_surface_set_user_data(cdata->surface, NULL);
 }
 
 void
@@ -691,7 +690,9 @@ Wayland_FiniMouse(SDL_VideoData *data)
     for (i = 0; i < data->num_cursor_themes; i += 1) {
         WAYLAND_wl_cursor_theme_destroy(data->cursor_themes[i].theme);
     }
+    data->num_cursor_themes = 0;
     SDL_free(data->cursor_themes);
+    data->cursor_themes = NULL;
 
     SDL_DelHintCallback(SDL_HINT_VIDEO_WAYLAND_EMULATE_MOUSE_WARP, 
                         Wayland_EmulateMouseWarpChanged, input);

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -1053,6 +1053,7 @@ Wayland_VideoCleanup(_THIS)
         display->desktop_mode.driverdata = NULL;
         SDL_DelVideoDisplay(i);
     }
+    data->output_list = NULL;
 
     Wayland_display_destroy_input(data);
     Wayland_display_destroy_pointer_constraints(data);


### PR DESCRIPTION
571ff1a3a96f03a3c1e2e01479077c5d61eadfa0 introduces an experimental patch for handling compositor restarts. A few minor parts were missed out.

## Description
- For mouse cursors we have a wl_surface for both system and custom cursors which needs recreating.
- The other patch is about nullification after deletions

## Existing Issue(s)
Most this code is disabled behind #if statements for now so this makes no difference to the end user.