### PR TITLE
macOS: Discard the IME Candidate Window immediately when Escape is pressed

### DIFF
--- a/src/video/cocoa/SDL_cocoakeyboard.m
+++ b/src/video/cocoa/SDL_cocoakeyboard.m
@@ -180,6 +180,13 @@
     return [NSArray array];
 }
 
+// Discard the IME Candidate Window
+- (void)cancelOperation:(id)sender
+{
+    [[self inputContext] discardMarkedText];
+    [self unmarkText];
+}
+
 @end
 
 static void
@@ -408,6 +415,11 @@ Cocoa_HandleKeyEvent(_THIS, NSEvent *event)
             SDL_Log("The key you just pressed is not recognized by SDL. To help get this fixed, report this to the SDL forums/mailing list <https://discourse.libsdl.org/> or to Christian Walther <cwalther@gmx.ch>. Mac virtual key code is %d.\n", scancode);
         }
 #endif
+        /* Discard the IME Candidate Window immediately */
+        if (code == SDL_SCANCODE_ESCAPE) {
+            [data.fieldEdit cancelOperation:NULL];
+        }
+
         if (SDL_EventState(SDL_TEXTINPUT, SDL_QUERY)) {
             /* FIXME CW 2007-08-16: only send those events to the field editor for which we actually want text events, not e.g. esc or function keys. Arrow keys in particular seem to produce crashes sometimes. */
             [data.fieldEdit interpretKeyEvents:[NSArray arrayWithObject:event]];


### PR DESCRIPTION
Fixes the issue that you need to double press the Escape key to dismiss the IME Candidate Window

Before: Candidate Window is discarded on the second Escape key press
![Nov-06-2022 05-07-31](https://user-images.githubusercontent.com/602245/200141372-f50597f8-cdaf-4c17-9766-d7d1edb13945.gif)

After: Candidate Window is discarded immediately
![Nov-06-2022 05-07-43](https://user-images.githubusercontent.com/602245/200141370-0c40d485-6a4b-4a71-81d9-54717942aa87.gif)

(Please ignore that I'm not printing the `SDL_TEXTEDITING` event)
