### PR TITLE
Cocoa_GetDisplayUsableBounds: Remove SDL_assert?

### DIFF
--- a/src/video/cocoa/SDL_cocoamodes.m
+++ b/src/video/cocoa/SDL_cocoamodes.m
@@ -415,7 +415,6 @@ Cocoa_GetDisplayUsableBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect)
         }
     }
 
-    SDL_assert(screen != nil);  /* didn't find it?! */
     if (screen == nil) {
         return -1;
     }


### PR DESCRIPTION
I'm not entirely sure why this `SDL_assert` call is here (possibly left-over from some debugging?), but this is getting triggered on my test system - despite the fact that the parent SDL calls handle a failure return code from Cocoa_GetDisplayUsableBounds properly. (And the public `SDL_GetDisplayUsableBounds` function also returns success / failure.)

Regardless of why this assert is getting hit, it doesn't seem like there should be an assert here, given everything that calls this is supposed to handle success / failure or return a success / failure value?