### PR TITLE
events: eliminate redundant code in SDL_SendEditingText

### DIFF
--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -1058,11 +1058,6 @@ SDL_SendEditingText(const char *text, int start, int length)
     posted = 0;
     if (SDL_GetEventState(SDL_TEXTEDITING) == SDL_ENABLE) {
         SDL_Event event;
-        event.edit.type = SDL_TEXTEDITING;
-        event.edit.windowID = keyboard->focus ? keyboard->focus->id : 0;
-        event.edit.start = start;
-        event.edit.length = length;
-        SDL_utf8strlcpy(event.edit.text, text, SDL_arraysize(event.edit.text));
 
         if (SDL_GetHintBoolean(SDL_HINT_IME_SUPPORT_EXTENDED_TEXT, SDL_FALSE) &&
             SDL_strlen(text) >= SDL_arraysize(event.text.text)) {


### PR DESCRIPTION
As discussed in #6164, these lines are redundant. Most probably just an artifact from a bad merge when going from https://github.com/libsdl-org/SDL/pull/5378 to https://github.com/libsdl-org/SDL/pull/5398.

Thanks @Guldoman.