### PR TITLE
Silence spurious `-Wmaybe-uninitialized` warnings in tests.

### DIFF
--- a/test/controllermap.c
+++ b/test/controllermap.c
@@ -611,7 +611,7 @@ WatchJoystick(SDL_Joystick * joystick)
                 SDL_GameControllerButton eButton = (SDL_GameControllerButton)iIndex;
                 SDL_strlcat(mapping, SDL_GameControllerGetStringForButton(eButton), SDL_arraysize(mapping));
             } else {
-                const char *pszAxisName;
+                const char *pszAxisName = NULL;
                 switch (iIndex - SDL_CONTROLLER_BUTTON_MAX) {
                 case SDL_CONTROLLER_BINDING_AXIS_LEFTX_NEGATIVE:
                     if (!BMergeAxisBindings(iIndex)) {
@@ -660,7 +660,9 @@ WatchJoystick(SDL_Joystick * joystick)
                     pszAxisName = SDL_GameControllerGetStringForAxis(SDL_CONTROLLER_AXIS_TRIGGERRIGHT);
                     break;
                 }
-                SDL_strlcat(mapping, pszAxisName, SDL_arraysize(mapping));
+                if (pszAxisName) {
+                    SDL_strlcat(mapping, pszAxisName, SDL_arraysize(mapping));
+                }
             }
             SDL_strlcat(mapping, ":", SDL_arraysize(mapping));
 

--- a/test/testautomation_pixels.c
+++ b/test/testautomation_pixels.c
@@ -330,6 +330,7 @@ pixels_allocFreePalette(void *arg)
   for (variation = 1; variation <= 3; variation++) {
     switch (variation) {
       /* Just one color */
+      default:
       case 1:
         ncolors = 1;
         break;
@@ -426,6 +427,7 @@ pixels_calcGammaRamp(void *arg)
   for (variation = 0; variation < 4; variation++) {
     switch (variation) {
       /* gamma = 0 all black */
+      default:
       case 0:
         gamma = 0.0f;
         break;

--- a/test/testautomation_rwops.c
+++ b/test/testautomation_rwops.c
@@ -616,6 +616,7 @@ rwops_testFileWriteReadEndian(void)
 
      /* Create test data */
      switch (mode) {
+       default:
        case 0:
         SDLTest_Log("All 0 values");
         BE16value = 0;

--- a/test/testautomation_video.c
+++ b/test/testautomation_video.c
@@ -123,6 +123,7 @@ video_createWindowVariousPositions(void *arg)
   for (xVariation = 0; xVariation < 6; xVariation++) {
    for (yVariation = 0; yVariation < 6; yVariation++) {
     switch(xVariation) {
+     default:
      case 0:
       /* Zero X Position */
       x = 0;
@@ -150,6 +151,7 @@ video_createWindowVariousPositions(void *arg)
     }
 
     switch(yVariation) {
+     default:
      case 0:
       /* Zero X Position */
       y = 0;
@@ -267,6 +269,7 @@ video_createWindowVariousFlags(void *arg)
 
   for (fVariation = 0; fVariation < 14; fVariation++) {
     switch(fVariation) {
+     default:
      case 0:
       flags = SDL_WINDOW_FULLSCREEN;
       /* Skip - blanks screen; comment out next line to run test */
@@ -1074,6 +1077,7 @@ video_getSetWindowPosition(void *arg)
   for (xVariation = 0; xVariation < 4; xVariation++) {
    for (yVariation = 0; yVariation < 4; yVariation++) {
     switch(xVariation) {
+     default:
      case 0:
       /* Zero X Position */
       desiredX = 0;
@@ -1093,6 +1097,7 @@ video_getSetWindowPosition(void *arg)
     }
 
     switch(yVariation) {
+     default:
      case 0:
       /* Zero X Position */
       desiredY = 0;
@@ -1236,6 +1241,7 @@ video_getSetWindowSize(void *arg)
   for (wVariation = 0; wVariation < maxwVariation; wVariation++) {
    for (hVariation = 0; hVariation < maxhVariation; hVariation++) {
     switch(wVariation) {
+     default:
      case 0:
       /* 1 Pixel Wide */
       desiredW = 1;
@@ -1259,6 +1265,7 @@ video_getSetWindowSize(void *arg)
     }
 
     switch(hVariation) {
+     default:
      case 0:
       /* 1 Pixel High */
       desiredH = 1;


### PR DESCRIPTION
## Description

Using this configuration:
- DevkitARM R59 GCC 12.2.0 (3DS toolchain)
- Build type: Debug
- `SDL_TESTS=ON`
- `SDL_WERROR=ON`

Build fails from `-Wmaybe-uninitialized` (part of `-Wall`) warnings in some tests.

The warnings are most likely false positives as the switch statements are only called with the listed values, so a default is added.

I was not able to reproduce the warning in Release mode, or when making a native Linux build with GCC 12.2.0.

## Existing Issue(s)
N/A
