### PR TITLE
N3DS: Fixes and improvements

### DIFF
--- a/docs/README-n3ds.md
+++ b/docs/README-n3ds.md
@@ -24,3 +24,4 @@ cmake --install build
 -   Currently only software rendering is supported.
 -   SDL2main should be used to ensure ROMFS is enabled.
 -   By default, the extra L2 cache and higher clock speeds of the New 2/3DS lineup are enabled. If you wish to turn it off, use `osSetSpeedupEnable(false)` in your main function.
+-   `SDL_GetBasePath` returns the romfs root instead of the executable's directory.

--- a/include/SDL_filesystem.h
+++ b/include/SDL_filesystem.h
@@ -60,6 +60,10 @@ extern "C" {
  * - `parent`: the containing directory of the bundle. For example:
  *   `/Applications/SDLApp/`
  *
+ * **Nintendo 3DS Specific Functionality**: This function returns "romfs"
+ * directory of the application as it is uncommon to store resources
+ * outside the executable. As such it is not a writable directory.
+ *
  * The returned path is guaranteed to end with a path separator ('\' on
  * Windows, '/' on most other platforms).
  *

--- a/src/SDL_log.c
+++ b/src/SDL_log.c
@@ -487,10 +487,10 @@ SDL_LogOutput(void *userdata, int category, SDL_LogPriority priority,
     }
 #elif defined(__3DS__)
     {
-        FILE*        pFile;
-        pFile = fopen ("/SDL_Log.txt", "a");
+        FILE *pFile;
+        pFile = fopen("sdmc:/3ds/SDL_Log.txt", "a");
         fprintf(pFile, "%s: %s\n", SDL_priority_prefixes[priority], message);
-        fclose (pFile);
+        fclose(pFile);
     }
 #endif
 #if HAVE_STDIO_H && \

--- a/src/file/n3ds/SDL_rwopsromfs.c
+++ b/src/file/n3ds/SDL_rwopsromfs.c
@@ -22,6 +22,15 @@
 #include "SDL_rwopsromfs.h"
 #include "SDL_error.h"
 
+/* Checks if the mode is a kind of reading */
+SDL_FORCE_INLINE SDL_bool IsReadMode(const char *mode);
+
+/* Checks if the file starts with the given prefix */
+SDL_FORCE_INLINE SDL_bool HasPrefix(const char *file, const char *prefix);
+
+SDL_FORCE_INLINE FILE *TryOpenFile(const char *file, const char *mode);
+SDL_FORCE_INLINE FILE *TryOpenInRomfs(const char *file, const char *mode);
+
 /* Nintendo 3DS applications may embed resources in the executable. The
   resources are stored in a special read-only partition prefixed with
   'romfs:/'. As such, when opening a file, we should first try the romfs
@@ -30,31 +39,58 @@
 FILE *
 N3DS_FileOpen(const char *file, const char *mode)
 {
-    FILE *fp = NULL;
-    char *romfs_path;
-
     /* romfs are read-only */
-    if (SDL_strchr(mode, 'r') == NULL) {
+    if (!IsReadMode(mode)) {
         return fopen(file, mode);
     }
 
     /* If the path has an explicit prefix, we skip the guess work */
-    if (SDL_strncmp("romfs:/", file, 7) == 0 ||
-        SDL_strncmp("sdmc:/", file, 6) == 0) {
+    if (HasPrefix(file, "romfs:/") || HasPrefix(file, "sdmc:/")) {
         return fopen(file, mode);
     }
 
-    if (SDL_asprintf(&romfs_path, "romfs:/%s", file) < 0) {
-        SDL_OutOfMemory();
-        return NULL;
-    }
+    return TryOpenFile(file, mode);
+}
 
-    fp = fopen(romfs_path, mode);
+SDL_FORCE_INLINE SDL_bool
+IsReadMode(const char *mode)
+{
+    return SDL_strchr(mode, 'r') != NULL;
+}
+
+SDL_FORCE_INLINE SDL_bool
+HasPrefix(const char *file, const char *prefix)
+{
+    return SDL_strncmp(prefix, file, SDL_strlen(prefix)) == 0;
+}
+
+SDL_FORCE_INLINE FILE *
+TryOpenFile(const char *file, const char *mode)
+{
+    FILE *fp = NULL;
+
+    fp = TryOpenInRomfs(file, mode);
     if (fp == NULL) {
         fp = fopen(file, mode);
     }
 
-    SDL_free(romfs_path);
+    return fp;
+}
+
+SDL_FORCE_INLINE FILE *
+TryOpenInRomfs(const char *file, const char *mode)
+{
+    FILE *fp = NULL;
+    char *prefixed_filepath = NULL;
+
+    if (SDL_asprintf(&prefixed_filepath, "romfs:/%s", file) < 0) {
+        SDL_OutOfMemory();
+        return NULL;
+    }
+
+    fp = fopen(prefixed_filepath, mode);
+
+    SDL_free(prefixed_filepath);
     return fp;
 }
 

--- a/src/filesystem/n3ds/SDL_sysfilesystem.c
+++ b/src/filesystem/n3ds/SDL_sysfilesystem.c
@@ -68,7 +68,7 @@ SDL_FORCE_INLINE char *
 MakePrefPath(const char *app)
 {
     char *pref_path;
-    if (SDL_asprintf(&pref_path, "/3ds/%s/", app) < 0) {
+    if (SDL_asprintf(&pref_path, "sdmc:/3ds/%s/", app) < 0) {
         SDL_OutOfMemory();
         return NULL;
     }

--- a/src/joystick/n3ds/SDL_sysjoystick.c
+++ b/src/joystick/n3ds/SDL_sysjoystick.c
@@ -279,26 +279,26 @@ N3DS_JoystickSendEffect(SDL_Joystick *joystick, const void *data, int size)
 }
 
 SDL_JoystickDriver SDL_N3DS_JoystickDriver = {
-    N3DS_JoystickInit,
-    N3DS_JoystickGetCount,
-    N3DS_JoystickDetect,
-    N3DS_JoystickGetDeviceName,
-    N3DS_JoystickGetDevicePath,
-    N3DS_JoystickGetDevicePlayerIndex,
-    N3DS_JoystickSetDevicePlayerIndex,
-    N3DS_JoystickGetDeviceGUID,
-    N3DS_JoystickGetDeviceInstanceID,
-    N3DS_JoystickOpen,
-    N3DS_JoystickRumble,
-    N3DS_JoystickRumbleTriggers,
-    N3DS_JoystickGetCapabilities,
-    N3DS_JoystickSetLED,
-    N3DS_JoystickSendEffect,
-    N3DS_JoystickSetSensorsEnabled,
-    N3DS_JoystickUpdate,
-    N3DS_JoystickClose,
-    N3DS_JoystickQuit,
-    N3DS_JoystickGetGamepadMapping
+    .Init = N3DS_JoystickInit,
+    .GetCount = N3DS_JoystickGetCount,
+    .Detect = N3DS_JoystickDetect,
+    .GetDeviceName = N3DS_JoystickGetDeviceName,
+    .GetDevicePath = N3DS_JoystickGetDevicePath,
+    .GetDevicePlayerIndex = N3DS_JoystickGetDevicePlayerIndex,
+    .SetDevicePlayerIndex = N3DS_JoystickSetDevicePlayerIndex,
+    .GetDeviceGUID = N3DS_JoystickGetDeviceGUID,
+    .GetDeviceInstanceID = N3DS_JoystickGetDeviceInstanceID,
+    .Open = N3DS_JoystickOpen,
+    .Rumble = N3DS_JoystickRumble,
+    .RumbleTriggers = N3DS_JoystickRumbleTriggers,
+    .GetCapabilities = N3DS_JoystickGetCapabilities,
+    .SetLED = N3DS_JoystickSetLED,
+    .SendEffect = N3DS_JoystickSendEffect,
+    .SetSensorsEnabled = N3DS_JoystickSetSensorsEnabled,
+    .Update = N3DS_JoystickUpdate,
+    .Close = N3DS_JoystickClose,
+    .Quit = N3DS_JoystickQuit,
+    .GetGamepadMapping = N3DS_JoystickGetGamepadMapping
 };
 
 #endif /* SDL_JOYSTICK_N3DS */

--- a/src/sensor/n3ds/SDL_n3dssensor.c
+++ b/src/sensor/n3ds/SDL_n3dssensor.c
@@ -200,17 +200,17 @@ N3DS_SensorQuit(void)
 }
 
 SDL_SensorDriver SDL_N3DS_SensorDriver = {
-    N3DS_SensorInit,
-    N3DS_SensorGetCount,
-    N3DS_SensorDetect,
-    N3DS_SensorGetDeviceName,
-    N3DS_SensorGetDeviceType,
-    N3DS_SensorGetDeviceNonPortableType,
-    N3DS_SensorGetDeviceInstanceID,
-    N3DS_SensorOpen,
-    N3DS_SensorUpdate,
-    N3DS_SensorClose,
-    N3DS_SensorQuit,
+    .Init = N3DS_SensorInit,
+    .GetCount = N3DS_SensorGetCount,
+    .Detect = N3DS_SensorDetect,
+    .GetDeviceName = N3DS_SensorGetDeviceName,
+    .GetDeviceType = N3DS_SensorGetDeviceType,
+    .GetDeviceNonPortableType = N3DS_SensorGetDeviceNonPortableType,
+    .GetDeviceInstanceID = N3DS_SensorGetDeviceInstanceID,
+    .Open = N3DS_SensorOpen,
+    .Update = N3DS_SensorUpdate,
+    .Close = N3DS_SensorClose,
+    .Quit = N3DS_SensorQuit,
 };
 
 #endif /* SDL_SENSOR_N3DS */

--- a/src/video/n3ds/SDL_n3dsvideo.c
+++ b/src/video/n3ds/SDL_n3dsvideo.c
@@ -178,6 +178,7 @@ N3DS_CreateWindow(_THIS, SDL_Window *window)
     display_data = (DisplayDriverData *) SDL_GetDisplayDriverData(window->display_index);
     window_data->screen = display_data->screen;
     window->driverdata = window_data;
+    SDL_SetKeyboardFocus(window);
     return 0;
 }
 


### PR DESCRIPTION
## Description

This PR brings various small tweaks and fixes to the Nintendo 3DS port, most notably:

- Fix an subtle issue with GameController/Joystick polling where the events would be ignored if `SDL_SetKeyboardFoxus` wasn't called when creating the window.
- Move the location of `SDL_Log.txt` to the `/3ds/` directory. This is the recommended directory for homebrew applications.

## Existing Issue(s)
N/A
