### PR TITLE
wayland: Always use integer scaling for cursors.

### DIFF
--- a/src/video/wayland/SDL_waylandmouse.c
+++ b/src/video/wayland/SDL_waylandmouse.c
@@ -199,8 +199,10 @@ wayland_get_system_cursor(SDL_VideoData *vdata, Wayland_CursorData *cdata, float
         return SDL_FALSE;
     }
     focusdata = focus->driverdata;
-    *scale = focusdata->scale_factor;
-    size *= focusdata->scale_factor;
+
+    /* Cursors use integer scaling. */
+    *scale = SDL_ceilf(focusdata->scale_factor);
+    size *= *scale;
     for (i = 0; i < vdata->num_cursor_themes; i += 1) {
         if (vdata->cursor_themes[i].size == size) {
             theme = vdata->cursor_themes[i].theme;


### PR DESCRIPTION
Cursors don't get fractionally scaled, so always scale system cursor sizes to the next whole integer and return the rounded scale value.

Fixes #6526 