### PR TITLE
events: Remove X and XKB keysym constants and headers

### DIFF
--- a/src/events/SDL_keysym_to_scancode.c
+++ b/src/events/SDL_keysym_to_scancode.c
@@ -26,60 +26,28 @@
 #include "SDL_keyboard_c.h"
 #include "SDL_scancode_tables_c.h"
 
-#if SDL_VIDEO_DRIVER_WAYLAND
-#include <xkbcommon/xkbcommon.h>
-
-typedef xkb_keysym_t SDL_xkb_keysym_t;
-#else
-#include <X11/keysym.h>
-#include <X11/XKBlib.h>
-
-typedef KeySym SDL_xkb_keysym_t;
-#endif
-
-
 /* *INDENT-OFF* */ /* clang-format off */
 static const struct {
-    SDL_xkb_keysym_t  keysym;
+    Uint32       keysym;
     SDL_Scancode scancode;
 } KeySymToSDLScancode[] = {
-#if SDL_VIDEO_DRIVER_WAYLAND
-    { XKB_KEY_KP_End, SDL_SCANCODE_KP_1 },
-    { XKB_KEY_KP_Down, SDL_SCANCODE_KP_2 },
-    { XKB_KEY_KP_Next, SDL_SCANCODE_KP_3 },
-    { XKB_KEY_KP_Left, SDL_SCANCODE_KP_4 },
-    { XKB_KEY_KP_Begin, SDL_SCANCODE_KP_5 },
-    { XKB_KEY_KP_Right, SDL_SCANCODE_KP_6 },
-    { XKB_KEY_KP_Home, SDL_SCANCODE_KP_7 },
-    { XKB_KEY_KP_Up, SDL_SCANCODE_KP_8 },
-    { XKB_KEY_KP_Prior, SDL_SCANCODE_KP_9 },
-    { XKB_KEY_KP_Insert, SDL_SCANCODE_KP_0 },
-    { XKB_KEY_KP_Delete, SDL_SCANCODE_KP_PERIOD },
-    { XKB_KEY_Execute, SDL_SCANCODE_EXECUTE },
-    { XKB_KEY_Hyper_R, SDL_SCANCODE_APPLICATION },
-    { XKB_KEY_ISO_Level3_Shift, SDL_SCANCODE_RALT },
-    { XKB_KEY_Super_L, SDL_SCANCODE_LGUI },
-    { XKB_KEY_Super_R, SDL_SCANCODE_RGUI },
-    { XKB_KEY_Mode_switch, SDL_SCANCODE_MODE },
-#else
-    { XK_KP_End, SDL_SCANCODE_KP_1 },
-    { XK_KP_Down, SDL_SCANCODE_KP_2 },
-    { XK_KP_Next, SDL_SCANCODE_KP_3 },
-    { XK_KP_Left, SDL_SCANCODE_KP_4 },
-    { XK_KP_Begin, SDL_SCANCODE_KP_5 },
-    { XK_KP_Right, SDL_SCANCODE_KP_6 },
-    { XK_KP_Home, SDL_SCANCODE_KP_7 },
-    { XK_KP_Up, SDL_SCANCODE_KP_8 },
-    { XK_KP_Prior, SDL_SCANCODE_KP_9 },
-    { XK_KP_Insert, SDL_SCANCODE_KP_0 },
-    { XK_KP_Delete, SDL_SCANCODE_KP_PERIOD },
-    { XK_Execute, SDL_SCANCODE_EXECUTE },
-    { XK_Hyper_R, SDL_SCANCODE_APPLICATION },
-    { XK_ISO_Level3_Shift, SDL_SCANCODE_RALT },
-    { XK_Super_L, SDL_SCANCODE_LGUI },
-    { XK_Super_R, SDL_SCANCODE_RGUI },
-    { XK_Mode_switch, SDL_SCANCODE_MODE },
-#endif
+    { 0xFF9C, SDL_SCANCODE_KP_1 },  /* XK_KP_End */
+    { 0xFF99, SDL_SCANCODE_KP_2 },  /* XK_KP_Down */
+    { 0xFF9B, SDL_SCANCODE_KP_3 },  /* XK_KP_Next */
+    { 0xFF96, SDL_SCANCODE_KP_4 },  /* XK_KP_Left */
+    { 0xFF9D, SDL_SCANCODE_KP_5 },  /* XK_KP_Begin */
+    { 0xFF98, SDL_SCANCODE_KP_6 },  /* XK_KP_Right */
+    { 0xFF95, SDL_SCANCODE_KP_7 },  /* XK_KP_Home */
+    { 0xFF97, SDL_SCANCODE_KP_8 },  /* XK_KP_Up */
+    { 0xFF9A, SDL_SCANCODE_KP_9 },  /* XK_KP_Prior */
+    { 0xFF9E, SDL_SCANCODE_KP_0 },  /* XK_KP_Insert */
+    { 0xFF9F, SDL_SCANCODE_KP_PERIOD },  /* XK_KP_Delete */
+    { 0xFF62, SDL_SCANCODE_EXECUTE },  /* XK_Execute */
+    { 0xFFEE, SDL_SCANCODE_APPLICATION },  /* XK_Hyper_R */
+    { 0xFE03, SDL_SCANCODE_RALT },  /* XK_ISO_Level3_Shift */
+    { 0xFFEB, SDL_SCANCODE_LGUI },  /* XK_Super_L */
+    { 0xFFEC, SDL_SCANCODE_RGUI },  /* XK_Super_R */
+    { 0xFF7E, SDL_SCANCODE_MODE },  /* XK_Mode_switch */
     { 0x1008FF65, SDL_SCANCODE_MENU },  /* XF86MenuKB */
     { 0x1008FF81, SDL_SCANCODE_F13 },   /* XF86Tools */
     { 0x1008FF45, SDL_SCANCODE_F14 },   /* XF86Launch5 */
@@ -90,7 +58,7 @@ static const struct {
 };
 
 /* This is a mapping from X keysym to Linux keycode */
-static const SDL_xkb_keysym_t LinuxKeycodeKeysyms[] = {
+static const Uint32 LinuxKeycodeKeysyms[] = {
     /*   0, 0x000 */    0x0, /* NoSymbol */
     /*   1, 0x001 */    0xFF1B, /* Escape */
     /*   2, 0x002 */    0x31, /* 1 */
@@ -358,7 +326,7 @@ done
 #endif
 
 static const struct {
-    SDL_xkb_keysym_t keysym;
+    Uint32 keysym;
     int linux_keycode;
 } ExtendedLinuxKeycodeKeysyms[] = {
     { 0x1008FF2C, 0x0a2 },    /* XF86XK_Eject */


### PR DESCRIPTION
The XKB_KEY_* and XK_* macros resolve to the same constant values, so use the raw values and note what keys they correspond to in the comments, as is done for the other keysym values in this file.

This completely eliminates the need for any X or XKB system headers along with the if/else defines.