### PR TITLE
GDK: Updated MicrosoftGame.config files to use placeholder identifiers

### DIFF
--- a/VisualC-GDK/tests/testgamecontroller/wingdk/MicrosoftGame.config
+++ b/VisualC-GDK/tests/testgamecontroller/wingdk/MicrosoftGame.config
@@ -2,9 +2,9 @@
 <Game configVersion="1">
 
 	<!-- Set these to the correct identifiers from Partner Center -->
-	<Identity Name="41336MicrosoftATG.ATGSimpleLiveSample"
+	<Identity Name="SDL"
 		Version="1.0.0.0"
-		Publisher="CN=A4954634-DF4B-47C7-AB70-D3215D246AF1"/>
+		Publisher="CN=Publisher"/>
 
 	<ExecutableList>
 		<Executable Name="testgamecontroller.exe"
@@ -19,8 +19,8 @@
 	</DesktopRegistration>
 
 	<!-- Set these to the correct values from Partner Center -->
-	<TitleId>7325F784</TitleId>
-	<MSAAppId>0000000000000000</MSAAppId>
+	<MSAAppId>PleaseChangeMe</MSAAppId>
+	<TitleId>FFFFFFFF</TitleId>
 
 	<ShellVisuals DefaultDisplayName="testgamecontroller"
 					PublisherDisplayName="SDL"

--- a/VisualC-GDK/tests/testgamecontroller/xboxone/MicrosoftGame.config
+++ b/VisualC-GDK/tests/testgamecontroller/xboxone/MicrosoftGame.config
@@ -2,9 +2,9 @@
 <Game configVersion="1">
 
 	<!-- Set these to the correct identifiers from Partner Center -->
-	<Identity Name="41336MicrosoftATG.ATGSimpleLiveSample"
+	<Identity Name="SDL"
 		Version="1.0.0.0"
-		Publisher="CN=A4954634-DF4B-47C7-AB70-D3215D246AF1"/>
+		Publisher="CN=Publisher"/>
 
 	<ExecutableList>
 		<Executable Name="testgamecontroller.exe"
@@ -12,15 +12,9 @@
 					Id="Game" />
 	</ExecutableList>
 
-	<DesktopRegistration>
-		<DependencyList>
-			<KnownDependency Name="VC14"/>
-		</DependencyList>
-	</DesktopRegistration>
-
 	<!-- Set these to the correct values from Partner Center -->
-	<TitleId>7325F784</TitleId>
-	<MSAAppId>0000000000000000</MSAAppId>
+	<MSAAppId>PleaseChangeMe</MSAAppId>
+	<TitleId>FFFFFFFF</TitleId>
 
 	<ShellVisuals DefaultDisplayName="testgamecontroller"
 					PublisherDisplayName="SDL"

--- a/VisualC-GDK/tests/testgamecontroller/xboxseries/MicrosoftGame.config
+++ b/VisualC-GDK/tests/testgamecontroller/xboxseries/MicrosoftGame.config
@@ -2,9 +2,9 @@
 <Game configVersion="1">
 
 	<!-- Set these to the correct identifiers from Partner Center -->
-	<Identity Name="41336MicrosoftATG.ATGSimpleLiveSample"
+	<Identity Name="SDL"
 		Version="1.0.0.0"
-		Publisher="CN=A4954634-DF4B-47C7-AB70-D3215D246AF1"/>
+		Publisher="CN=Publisher"/>
 
 	<ExecutableList>
 		<Executable Name="testgamecontroller.exe"
@@ -13,8 +13,8 @@
 	</ExecutableList>
 
 	<!-- Set these to the correct values from Partner Center -->
-	<TitleId>7325F784</TitleId>
-	<MSAAppId>0000000000000000</MSAAppId>
+	<MSAAppId>PleaseChangeMe</MSAAppId>
+	<TitleId>FFFFFFFF</TitleId>
 
 	<ShellVisuals DefaultDisplayName="testgamecontroller"
 					PublisherDisplayName="SDL"

--- a/VisualC-GDK/tests/testgdk/wingdk/MicrosoftGame.config
+++ b/VisualC-GDK/tests/testgdk/wingdk/MicrosoftGame.config
@@ -2,9 +2,9 @@
 <Game configVersion="1">
 
 	<!-- Set these to the correct identifiers from Partner Center -->
-	<Identity Name="41336MicrosoftATG.ATGSimpleLiveSample"
+	<Identity Name="SDL"
 		Version="1.0.0.0"
-		Publisher="CN=A4954634-DF4B-47C7-AB70-D3215D246AF1"/>
+		Publisher="CN=Publisher"/>
 
 	<ExecutableList>
 		<Executable Name="testgdk.exe"
@@ -19,8 +19,8 @@
 	</DesktopRegistration>
 
 	<!-- Set these to the correct values from Partner Center -->
-	<TitleId>7325F784</TitleId>
-	<MSAAppId>0000000000000000</MSAAppId>
+	<MSAAppId>PleaseChangeMe</MSAAppId>
+	<TitleId>FFFFFFFF</TitleId>
 
 	<ShellVisuals DefaultDisplayName="testgdk"
 					PublisherDisplayName="SDL"

--- a/VisualC-GDK/tests/testgdk/xboxone/MicrosoftGame.config
+++ b/VisualC-GDK/tests/testgdk/xboxone/MicrosoftGame.config
@@ -2,9 +2,9 @@
 <Game configVersion="1">
 
 	<!-- Set these to the correct identifiers from Partner Center -->
-	<Identity Name="41336MicrosoftATG.ATGSimpleLiveSample"
+	<Identity Name="SDL"
 		Version="1.0.0.0"
-		Publisher="CN=A4954634-DF4B-47C7-AB70-D3215D246AF1"/>
+		Publisher="CN=Publisher"/>
 
 	<ExecutableList>
 		<Executable Name="testgdk.exe"
@@ -13,8 +13,8 @@
 	</ExecutableList>
 
 	<!-- Set these to the correct values from Partner Center -->
-	<TitleId>7325F784</TitleId>
-	<MSAAppId>0000000000000000</MSAAppId>
+	<MSAAppId>PleaseChangeMe</MSAAppId>
+	<TitleId>FFFFFFFF</TitleId>
 
 	<ShellVisuals DefaultDisplayName="testgdk"
 					PublisherDisplayName="SDL"

--- a/VisualC-GDK/tests/testgdk/xboxseries/MicrosoftGame.config
+++ b/VisualC-GDK/tests/testgdk/xboxseries/MicrosoftGame.config
@@ -2,9 +2,9 @@
 <Game configVersion="1">
 
 	<!-- Set these to the correct identifiers from Partner Center -->
-	<Identity Name="41336MicrosoftATG.ATGSimpleLiveSample"
+	<Identity Name="SDL"
 		Version="1.0.0.0"
-		Publisher="CN=A4954634-DF4B-47C7-AB70-D3215D246AF1"/>
+		Publisher="CN=Publisher"/>
 
 	<ExecutableList>
 		<Executable Name="testgdk.exe"
@@ -13,8 +13,8 @@
 	</ExecutableList>
 
 	<!-- Set these to the correct values from Partner Center -->
-	<TitleId>7325F784</TitleId>
-	<MSAAppId>0000000000000000</MSAAppId>
+	<MSAAppId>PleaseChangeMe</MSAAppId>
+	<TitleId>FFFFFFFF</TitleId>
 
 	<ShellVisuals DefaultDisplayName="testgdk"
 					PublisherDisplayName="SDL"

--- a/VisualC-GDK/tests/testsprite2/wingdk/MicrosoftGame.config
+++ b/VisualC-GDK/tests/testsprite2/wingdk/MicrosoftGame.config
@@ -2,9 +2,9 @@
 <Game configVersion="1">
 
 	<!-- Set these to the correct identifiers from Partner Center -->
-	<Identity Name="41336MicrosoftATG.ATGSimpleLiveSample"
+	<Identity Name="SDL"
 		Version="1.0.0.0"
-		Publisher="CN=A4954634-DF4B-47C7-AB70-D3215D246AF1"/>
+		Publisher="CN=Publisher"/>
 
 	<ExecutableList>
 		<Executable Name="testsprite2.exe"
@@ -19,8 +19,8 @@
 	</DesktopRegistration>
 
 	<!-- Set these to the correct values from Partner Center -->
-	<TitleId>7325F784</TitleId>
-	<MSAAppId>0000000000000000</MSAAppId>
+	<MSAAppId>PleaseChangeMe</MSAAppId>
+	<TitleId>FFFFFFFF</TitleId>
 
 	<ShellVisuals DefaultDisplayName="testsprite2"
 					PublisherDisplayName="SDL"

--- a/VisualC-GDK/tests/testsprite2/xboxone/MicrosoftGame.config
+++ b/VisualC-GDK/tests/testsprite2/xboxone/MicrosoftGame.config
@@ -2,9 +2,9 @@
 <Game configVersion="1">
 
 	<!-- Set these to the correct identifiers from Partner Center -->
-	<Identity Name="41336MicrosoftATG.ATGSimpleLiveSample"
+	<Identity Name="SDL"
 		Version="1.0.0.0"
-		Publisher="CN=A4954634-DF4B-47C7-AB70-D3215D246AF1"/>
+		Publisher="CN=Publisher"/>
 
 	<ExecutableList>
 		<Executable Name="testsprite2.exe"
@@ -13,8 +13,8 @@
 	</ExecutableList>
 
 	<!-- Set these to the correct values from Partner Center -->
-	<TitleId>7325F784</TitleId>
-	<MSAAppId>0000000000000000</MSAAppId>
+	<MSAAppId>PleaseChangeMe</MSAAppId>
+	<TitleId>FFFFFFFF</TitleId>
 
 	<ShellVisuals DefaultDisplayName="testsprite2"
 					PublisherDisplayName="SDL"

--- a/VisualC-GDK/tests/testsprite2/xboxseries/MicrosoftGame.config
+++ b/VisualC-GDK/tests/testsprite2/xboxseries/MicrosoftGame.config
@@ -2,9 +2,9 @@
 <Game configVersion="1">
 
 	<!-- Set these to the correct identifiers from Partner Center -->
-	<Identity Name="41336MicrosoftATG.ATGSimpleLiveSample"
+	<Identity Name="SDL"
 		Version="1.0.0.0"
-		Publisher="CN=A4954634-DF4B-47C7-AB70-D3215D246AF1"/>
+		Publisher="CN=Publisher"/>
 
 	<ExecutableList>
 		<Executable Name="testsprite2.exe"
@@ -13,8 +13,8 @@
 	</ExecutableList>
 
 	<!-- Set these to the correct values from Partner Center -->
-	<TitleId>7325F784</TitleId>
-	<MSAAppId>0000000000000000</MSAAppId>
+	<MSAAppId>PleaseChangeMe</MSAAppId>
+	<TitleId>FFFFFFFF</TitleId>
 
 	<ShellVisuals DefaultDisplayName="testsprite2"
 					PublisherDisplayName="SDL"


### PR DESCRIPTION
## Description
Previously we were using the Microsoft sample identifiers which @walbourn asked us not to. This now uses the identifiers which are used in the GDK templates (`PleaseChangeMe` and `FFFFFFFF`).

Also there was a minor issue that testgamecontroller/xboxone/MicrosoftGame.config was referencing DesktopRegistration dependencies, which aren't used on Xbox.

## Existing Issue(s)
Fixes reopen of #4519
