### PR TITLE
Cleanup of SDL_SetError that already return -1 value

### DIFF
--- a/src/core/gdk/SDL_gdk.cpp
+++ b/src/core/gdk/SDL_gdk.cpp
@@ -42,8 +42,7 @@ SDL_GDKGetTaskQueue(XTaskQueueHandle * outTaskQueue)
             &GDK_GlobalTaskQueue
             );
         if (FAILED(hr)) {
-            SDL_SetError("[GDK] Could not create global task queue");
-            return -1;
+            return SDL_SetError("[GDK] Could not create global task queue");
         }
 
         /* The initial call gets the non-duplicated handle so they can clean it up */
@@ -51,8 +50,7 @@ SDL_GDKGetTaskQueue(XTaskQueueHandle * outTaskQueue)
     } else {
         /* Duplicate the global task queue handle into outTaskQueue */
         if (FAILED(XTaskQueueDuplicateHandle(GDK_GlobalTaskQueue, outTaskQueue))) {
-            SDL_SetError("[GDK] Unable to acquire global task queue");
-            return -1;
+            return SDL_SetError("[GDK] Unable to acquire global task queue");
         }
     }
 

--- a/src/thread/ngage/SDL_sysmutex.cpp
+++ b/src/thread/ngage/SDL_sysmutex.cpp
@@ -92,8 +92,7 @@ SDL_LockMutex(SDL_mutex * mutex)
 {
     if (mutex == NULL)
     {
-        SDL_SetError("Passed a NULL mutex.");
-        return -1;
+        return SDL_SetError("Passed a NULL mutex.");
     }
 
     RMutex rmutex;
@@ -109,8 +108,7 @@ SDL_UnlockMutex(SDL_mutex * mutex)
 {
     if ( mutex == NULL )
     {
-        SDL_SetError("Passed a NULL mutex.");
-        return -1;
+        return SDL_SetError("Passed a NULL mutex.");
     }
 
     RMutex rmutex;

--- a/src/thread/ngage/SDL_syssem.cpp
+++ b/src/thread/ngage/SDL_syssem.cpp
@@ -119,8 +119,7 @@ SDL_SemWaitTimeout(SDL_sem * sem, Uint32 timeout)
 {
     if (! sem)
     {
-        SDL_SetError("Passed a NULL sem");
-        return -1;
+        return SDL_SetError("Passed a NULL sem");
     }
 
     if (timeout == SDL_MUTEX_MAXWAIT)
@@ -182,8 +181,7 @@ SDL_SemPost(SDL_sem * sem)
 {
     if (! sem)
     {
-        SDL_SetError("Passed a NULL sem.");
-        return -1;
+        return SDL_SetError("Passed a NULL sem.");
     }
     sem->count++;
     RSemaphore sema;

--- a/src/video/haiku/SDL_bopengl.cc
+++ b/src/video/haiku/SDL_bopengl.cc
@@ -94,8 +94,7 @@ int HAIKU_GL_MakeCurrent(_THIS, SDL_Window * window, SDL_GLContext context) {
     // printf("HAIKU_GL_MakeCurrent(%llx), win = %llx, thread = %d\n", (uint64)context, (uint64)window, find_thread(NULL));
     if (glView != NULL) {
         if ((glView->Window() == NULL) || (window == NULL) || (_ToBeWin(window)->GetGLView() != glView)) {
-            SDL_SetError("MakeCurrent failed");
-            return -1;
+            return SDL_SetError("MakeCurrent failed");
         }
     }
     _GetBeApp()->SetCurrentContext(glView);


### PR DESCRIPTION
Cleanup of SDL_SetError that already return -1 value
eg: 

```
          -  SDL_SetError("[GDK] Could not create global task queue");
          -  return -1;
          +  return SDL_SetError("[GDK] Could not create global task queue");
```