### PR TITLE
wayland: keyboard: Cache text input parameters.

### DIFF
--- a/src/video/wayland/SDL_waylandkeyboard.h
+++ b/src/video/wayland/SDL_waylandkeyboard.h
@@ -28,6 +28,7 @@ typedef struct SDL_WaylandTextInput
     struct zwp_text_input_v3 *text_input;
     SDL_Rect cursor_rect;
     SDL_bool has_preedit;
+    SDL_bool is_enabled;
 } SDL_WaylandTextInput;
 
 extern int Wayland_InitKeyboard(_THIS);


### PR DESCRIPTION
Some applications (and embarrassingly, testime is one of them) call SDL_StartTextInput() or SDL_SetTextInputRect() every frame. On KDE/KWin with fcitx5, this causes there to be several preedit events every frame (particularly given some of the workarounds in Wayland_StartTextInput), which slows testime down to an unusable crawl.

Instead, make SDL_StartTextInput() a no-op if text input is already enabled, and cache the input rect, only changing it when the new rect is actually different.

With these changes, we only get preedit events (and hence SDL_TEXTEDITING events) when the preedit string actually changes. This matches the behaviour under XWayland, and works very smoothly.
