### PR TITLE
autotools: Detect SDL_JOYSTICK_MFI for macOS + Weak link with CoreHaptics

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2977,6 +2977,8 @@ dnl     Work around that we don't have Objective-C support in autoconf
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[
           #include <AvailabilityMacros.h>
           #include <TargetConditionals.h>
+          #import <Foundation/Foundation.h>
+          #import <CoreHaptics/CoreHaptics.h>
           #import <GameController/GameController.h>
         ]], [[
           #if MAC_OS_X_VERSION_MIN_REQUIRED < 1080
@@ -4341,6 +4343,7 @@ dnl BeOS support removed after SDL 2.0.1. Haiku still works.  --ryan.
         EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-framework,AudioToolbox"
         EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-framework,CoreAudio"
         EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-framework,CoreGraphics"
+        EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-framework,CoreHaptics"
         EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-framework,CoreMotion"
         EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-framework,Foundation"
         EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-framework,GameController"


### PR DESCRIPTION
Only enable MFI if we also have CoreHaptics to ensure rumble works. See:
 - cmake: Detect SDL_JOYSTICK_MFI for macOS (bc409163a81e5f440399926774202dd2da3e37c3)
 - cmake: Weak link with CoreHaptics (401f485490c68d91b8444f23f61b08e162ef04fb)

WARNING: I have no idea what I'm doing, just trying to sync cmake and configure.