### PR TITLE
wayland: Use the cached window size when switching from non-floating to floating window state

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -102,6 +102,7 @@ typedef struct {
     int window_width, window_height;
     SDL_bool needs_resize_event;
     SDL_bool floating_resize_pending;
+    SDL_bool was_floating;
     SDL_bool is_fullscreen;
     SDL_bool in_fullscreen_transition;
     Uint32 fullscreen_flags;


### PR DESCRIPTION
When changing the window state from non-floating to floating (e.g. leaving fullscreen), libdecor can send bogus content sizes that are +/- the height of the window title bar and start 'walking' the window height in one direction or the other with every transition.

The floating window size is known, so use the cached value instead of the size reported by libdecor when restoring the floating state.

This is a known libdecor issue: https://gitlab.gnome.org/jadahl/libdecor/-/issues/40

Previously I only observed this when hiding a window, but after installing the latest libdecor/mutter/gnome-shell updates I observed it happening when leaving desktop fullscreen mode as well.  Every time fullscreen mode was entered/exited the window content area would be taller by the height of the title bar.
