### PR TITLE
Update README-riscos.md to reflect that atomic functions have been fixed

### DIFF
--- a/docs/README-riscos.md
+++ b/docs/README-riscos.md
@@ -16,15 +16,17 @@ Currently, SDL for RISC OS only supports compiling with GCCSDK under Linux. Both
 
 The following commands can be used to build SDL for RISC OS using autoconf:
 
-    ./configure --host=arm-unknown-riscos --prefix=$GCCSDK_INSTALL_ENV --disable-gcc-atomics
+    ./configure --host=arm-unknown-riscos --prefix=$GCCSDK_INSTALL_ENV
     make
     make install
 
 The following commands can be used to build SDL for RISC OS using CMake:
 
-    cmake -Bbuild-riscos -DCMAKE_TOOLCHAIN_FILE=$GCCSDK_INSTALL_ENV/toolchain-riscos.cmake -DRISCOS=ON -DCMAKE_INSTALL_PREFIX=$GCCSDK_INSTALL_ENV -DCMAKE_BUILD_TYPE=Release -DSDL_GCC_ATOMICS=OFF
+    cmake -Bbuild-riscos -DCMAKE_TOOLCHAIN_FILE=$GCCSDK_INSTALL_ENV/toolchain-riscos.cmake -DRISCOS=ON -DCMAKE_INSTALL_PREFIX=$GCCSDK_INSTALL_ENV -DCMAKE_BUILD_TYPE=Release
     cmake --build build-riscos
     cmake --build build-riscos --target install
+
+When using GCCSDK 4.7.4 release 6 or earlier versions, the builtin atomic functions are broken, meaning it's currently necessary to compile with `--disable-gcc-atomics` using autotools or `-DSDL_GCC_ATOMICS=OFF` using CMake. Newer versions of GCCSDK don't have this problem.
 
 
 Current level of implementation
@@ -35,7 +37,5 @@ The video driver currently provides full screen video support with keyboard and 
 The filesystem APIs return either Unix-style paths or RISC OS-style paths based on the value of the `__riscosify_control` symbol, as is standard for UnixLib functions.
 
 The audio, loadso, thread and timer APIs are currently provided by UnixLib.
-
-GCC atomics are currently broken on some platforms, meaning it's currently necessary to compile with `--disable-gcc-atomics` using autotools or `-DSDL_GCC_ATOMICS=OFF` using CMake.
 
 The joystick, locale and power APIs are not yet implemented.


### PR DESCRIPTION
The builtin atomic functions were fixed in GCCSDK [r7724](https://www.riscos.info/websvn/comp.php?repname=gccsdk&compare[]=/trunk/gcc4/@7723&compare[]=/trunk/gcc4/@7724).