### PR TITLE
[SDL3] build: Simplify library name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
         ctest -VV --test-dir build/
         if test "${{ runner.os }}" = "Linux"; then
           # This should show us the SDL_REVISION
-          strings build/libSDL3-3.0.so.0 | grep SDL-
+          strings build/libSDL3.so.0 | grep SDL-
         fi
     - name: Install (CMake)
       if: "! matrix.platform.autotools"
@@ -147,7 +147,7 @@ jobs:
         make -j"${parallel}" -C build-autotools/test check LD_LIBRARY_PATH="${curdir}/build-autotools/build/.libs"
         if test "${{ runner.os }}" = "Linux"; then
           # This should show us the SDL_REVISION
-          strings "${curdir}/build-autotools/build/.libs/libSDL3-3.0.so.0" | grep SDL-
+          strings "${curdir}/build-autotools/build/.libs/libSDL3.so.0" | grep SDL-
         fi
     - name: Install (Autotools)
       if: matrix.platform.autotools

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3332,13 +3332,6 @@ if(NOT SDL3_DISABLE_INSTALL)
       "${SDL3_BINARY_DIR}/include-config-$<LOWER_CASE:$<CONFIG>>/SDL_config.h"
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/SDL3)
 
-  string(TOUPPER "${CMAKE_BUILD_TYPE}" UPPER_BUILD_TYPE)
-  if (UPPER_BUILD_TYPE MATCHES DEBUG)
-    set(SOPOSTFIX "${SDL_CMAKE_DEBUG_POSTFIX}")
-  else()
-    set(SOPOSTFIX "")
-  endif()
-
   install(FILES "LICENSE.txt" DESTINATION "${LICENSES_PREFIX}")
   if(FREEBSD)
     # FreeBSD uses ${PREFIX}/libdata/pkgconfig
@@ -3348,17 +3341,6 @@ if(NOT SDL3_DISABLE_INSTALL)
             DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
   endif()
   if(NOT (WINDOWS OR CYGWIN) OR MINGW)
-    if(SDL_SHARED)
-      set(SOEXT ${CMAKE_SHARED_LIBRARY_SUFFIX}) # ".so", ".dylib", etc.
-      get_target_property(SONAME SDL3 OUTPUT_NAME)
-      if(NOT ANDROID AND NOT MINGW)
-          install(CODE "
-            execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-              \"lib${SONAME}${SOPOSTFIX}${SOEXT}\" \"libSDL3${SOPOSTFIX}${SOEXT}\"
-              WORKING_DIRECTORY \"${SDL3_BINARY_DIR}\")")
-          install(FILES ${SDL3_BINARY_DIR}/libSDL3${SOPOSTFIX}${SOEXT} DESTINATION "${CMAKE_INSTALL_LIBDIR}")
-      endif()
-    endif()
     install(PROGRAMS ${SDL3_BINARY_DIR}/sdl3-config DESTINATION "${CMAKE_INSTALL_BINDIR}")
     # TODO: what about the .spec file? Is it only needed for RPM creation?
     install(FILES "${SDL3_SOURCE_DIR}/sdl3.m4" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/aclocal")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,11 +107,6 @@ set(LT_MAJOR "0")
 math(EXPR LT_AGE "${SDL_BINARY_AGE} - ${SDL_INTERFACE_AGE}")
 math(EXPR LT_CURRENT "${LT_MAJOR} + ${LT_AGE}")
 set(LT_REVISION "${SDL_INTERFACE_AGE}")
-# For historical reasons, the library name redundantly includes the major
-# version twice: libSDL3-3.0.so.0.
-# TODO: in SDL 3, set the OUTPUT_NAME to plain SDL3, which will simplify
-# it to libSDL3.so.0
-set(LT_RELEASE "3.0")
 set(LT_VERSION "${LT_MAJOR}.${LT_AGE}.${LT_REVISION}")
 
 # The following should match the versions in the Xcode project file.
@@ -127,7 +122,7 @@ set(DYLIB_COMPATIBILITY_VERSION "${DYLIB_CURRENT_VERSION_MAJOR}.0.0")
 # To avoid generating them twice, these are added to a dummy target on which all sdl targets depend.
 set(SDL_GENERATED_HEADERS)
 
-#message(STATUS "${LT_VERSION} :: ${LT_AGE} :: ${LT_REVISION} :: ${LT_CURRENT} :: ${LT_RELEASE}")
+#message(STATUS "${LT_VERSION} :: ${LT_AGE} :: ${LT_REVISION} :: ${LT_CURRENT}")
 
 # General settings & flags
 set(LIBRARY_OUTPUT_DIRECTORY "build")
@@ -3133,13 +3128,11 @@ if(SDL_SHARED)
     # FIXME: Remove SOVERSION in SDL3
     set_target_properties(SDL3 PROPERTIES
       MACOSX_RPATH 1
-      SOVERSION 0
-      OUTPUT_NAME "SDL3-${LT_RELEASE}")
+      SOVERSION 0)
   elseif(UNIX AND NOT ANDROID)
     set_target_properties(SDL3 PROPERTIES
       VERSION ${LT_VERSION}
-      SOVERSION ${LT_MAJOR}
-      OUTPUT_NAME "SDL3-${LT_RELEASE}")
+      SOVERSION ${LT_MAJOR})
   else()
     if(WINDOWS OR CYGWIN)
       set_target_properties(SDL3 PROPERTIES
@@ -3147,8 +3140,7 @@ if(SDL_SHARED)
     endif()
     set_target_properties(SDL3 PROPERTIES
       VERSION ${SDL_VERSION}
-      SOVERSION ${LT_REVISION}
-      OUTPUT_NAME "SDL3")
+      SOVERSION ${LT_REVISION})
   endif()
   # Note: The clang toolset for Visual Studio does not support /NODEFAULTLIB.
   if(MSVC AND NOT SDL_LIBC AND NOT MSVC_CLANG AND NOT CMAKE_GENERATOR_PLATFORM STREQUAL "ARM")

--- a/Makefile.in
+++ b/Makefile.in
@@ -134,9 +134,8 @@ SDLTEST_HDRS = $(shell ls $(srcdir)/include | fgrep SDL_test)
 
 LT_AGE      = @LT_AGE@
 LT_CURRENT  = @LT_CURRENT@
-LT_RELEASE  = @LT_RELEASE@
 LT_REVISION = @LT_REVISION@
-LT_LDFLAGS  = -no-undefined -rpath $(libdir) -release $(LT_RELEASE) -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)
+LT_LDFLAGS  = -no-undefined -rpath $(libdir) -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)
 
 all: $(srcdir)/configure Makefile $(objects)/$(TARGET) $(objects)/$(SDLMAIN_TARGET) $(objects)/$(SDLTEST_TARGET)
 

--- a/configure.ac
+++ b/configure.ac
@@ -36,10 +36,6 @@ AC_SUBST(SDL_VERSION)
 LT_INIT([win32-dll])
 LT_LANG([Windows Resource])
 
-# For historical reasons, the library name redundantly includes the major
-# version twice: libSDL3-3.0.so.0.
-# TODO: in SDL 3, stop using -release, which will simplify it to libSDL3.so.0
-LT_RELEASE=3.0
 # Increment this if there is an incompatible change - but if that happens,
 # we should rename the library from SDL2 to SDL3, at which point this would
 # reset to 0 anyway.
@@ -49,7 +45,6 @@ LT_CURRENT=`expr $LT_MAJOR + $LT_AGE`
 LT_REVISION=$SDL_INTERFACE_AGE
 m4_pattern_allow([^LT_])
 
-AC_SUBST(LT_RELEASE)
 AC_SUBST(LT_CURRENT)
 AC_SUBST(LT_REVISION)
 AC_SUBST(LT_AGE)


### PR DESCRIPTION
We want the library to come out as libSDL3.so.0 on Unix, or something similar on other platforms. There's no need to have libSDL3-3.0.so.0, because next time we intentionally break the API it should become libSDL4 anyway.

Partially implements #5626.

---

Autotools: changed here

CMake: changed here

Android.mk: already used the simpler name

Makefile.minimal: already used the simpler name

XCode: TODO, I have no idea how this works (maybe it uses the simpler name already)

Visual Studio: TODO, I have no idea how this works (maybe it uses the simpler name already)

android-project{,-ant}: TODO, I have no idea how this works (maybe it uses the simpler name already)