### PR TITLE
SDL_cocoaopengl.h: ensure CVDisplayLinkRef is defined

### DIFF
--- a/src/video/cocoa/SDL_cocoaopengl.h
+++ b/src/video/cocoa/SDL_cocoaopengl.h
@@ -27,6 +27,7 @@
 
 #include "SDL_atomic.h"
 #import <Cocoa/Cocoa.h>
+#import <QuartzCore/CVDisplayLink.h>
 
 /* We still support OpenGL as long as Apple offers it, deprecated or not, so disable deprecation warnings about it. */
 #ifdef __clang__


### PR DESCRIPTION
The typedef seems to be pulled in coincidentally with newer SDKs, but older ones need to import the header explicitly.
