### PR TITLE
SDL_mfijoystick.m: fix build with Xcode < 9

### DIFF
--- a/src/joystick/iphoneos/SDL_mfijoystick.m
+++ b/src/joystick/iphoneos/SDL_mfijoystick.m
@@ -639,11 +639,16 @@ static int
 IOS_JoystickInit(void)
 {
 #if defined(__MACOSX__)
+#if _SDL_HAS_BUILTIN(__builtin_available)
     if (@available(macOS 10.16, *)) {
         /* Continue with initialization on macOS 11+ */
     } else {
         return 0;
     }
+#else
+    /* No @available, must be an older macOS version */
+    return 0;
+#endif
 #endif
 
     @autoreleasepool {


### PR DESCRIPTION
Fixes #6601.

## Description
`@available` is not available in Xcode versions older than 9.0, so check for it before using.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/6601