### PR TITLE
vulkan_metal.h: Make compatible with ObjC ARC

### DIFF
--- a/src/video/khronos/vulkan/vulkan_metal.h
+++ b/src/video/khronos/vulkan/vulkan_metal.h
@@ -26,6 +26,14 @@ extern "C" {
 typedef void CAMetalLayer;
 #endif
 
+#define SDL_UNSAFE_UNRETAINED
+#if defined(__OBJC__) && defined(__has_feature)
+#if __has_feature(objc_arc)
+#undef SDL_UNSAFE_UNRETAINED
+#define SDL_UNSAFE_UNRETAINED __unsafe_unretained
+#endif
+#endif
+
 #define VK_EXT_METAL_SURFACE_SPEC_VERSION 1
 #define VK_EXT_METAL_SURFACE_EXTENSION_NAME "VK_EXT_metal_surface"
 typedef VkFlags VkMetalSurfaceCreateFlagsEXT;
@@ -33,7 +41,7 @@ typedef struct VkMetalSurfaceCreateInfoEXT {
     VkStructureType                 sType;
     const void*                     pNext;
     VkMetalSurfaceCreateFlagsEXT    flags;
-    const CAMetalLayer*             pLayer;
+    const CAMetalLayer SDL_UNSAFE_UNRETAINED *pLayer;
 } VkMetalSurfaceCreateInfoEXT;
 
 typedef VkResult (VKAPI_PTR *PFN_vkCreateMetalSurfaceEXT)(VkInstance instance, const VkMetalSurfaceCreateInfoEXT* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface);
@@ -111,27 +119,27 @@ typedef struct VkExportMetalObjectsInfoEXT {
 typedef struct VkExportMetalDeviceInfoEXT {
     VkStructureType    sType;
     const void*        pNext;
-    MTLDevice_id       mtlDevice;
+    MTLDevice_id SDL_UNSAFE_UNRETAINED mtlDevice;
 } VkExportMetalDeviceInfoEXT;
 
 typedef struct VkExportMetalCommandQueueInfoEXT {
     VkStructureType       sType;
     const void*           pNext;
     VkQueue               queue;
-    MTLCommandQueue_id    mtlCommandQueue;
+    MTLCommandQueue_id SDL_UNSAFE_UNRETAINED mtlCommandQueue;
 } VkExportMetalCommandQueueInfoEXT;
 
 typedef struct VkExportMetalBufferInfoEXT {
     VkStructureType    sType;
     const void*        pNext;
     VkDeviceMemory     memory;
-    MTLBuffer_id       mtlBuffer;
+    MTLBuffer_id SDL_UNSAFE_UNRETAINED mtlBuffer;
 } VkExportMetalBufferInfoEXT;
 
 typedef struct VkImportMetalBufferInfoEXT {
     VkStructureType    sType;
     const void*        pNext;
-    MTLBuffer_id       mtlBuffer;
+    MTLBuffer_id SDL_UNSAFE_UNRETAINED mtlBuffer;
 } VkImportMetalBufferInfoEXT;
 
 typedef struct VkExportMetalTextureInfoEXT {
@@ -141,14 +149,14 @@ typedef struct VkExportMetalTextureInfoEXT {
     VkImageView              imageView;
     VkBufferView             bufferView;
     VkImageAspectFlagBits    plane;
-    MTLTexture_id            mtlTexture;
+    MTLTexture_id SDL_UNSAFE_UNRETAINED mtlTexture;
 } VkExportMetalTextureInfoEXT;
 
 typedef struct VkImportMetalTextureInfoEXT {
     VkStructureType          sType;
     const void*              pNext;
     VkImageAspectFlagBits    plane;
-    MTLTexture_id            mtlTexture;
+    MTLTexture_id SDL_UNSAFE_UNRETAINED mtlTexture;
 } VkImportMetalTextureInfoEXT;
 
 typedef struct VkExportMetalIOSurfaceInfoEXT {
@@ -169,13 +177,13 @@ typedef struct VkExportMetalSharedEventInfoEXT {
     const void*          pNext;
     VkSemaphore          semaphore;
     VkEvent              event;
-    MTLSharedEvent_id    mtlSharedEvent;
+    MTLSharedEvent_id SDL_UNSAFE_UNRETAINED mtlSharedEvent;
 } VkExportMetalSharedEventInfoEXT;
 
 typedef struct VkImportMetalSharedEventInfoEXT {
     VkStructureType      sType;
     const void*          pNext;
-    MTLSharedEvent_id    mtlSharedEvent;
+    MTLSharedEvent_id SDL_UNSAFE_UNRETAINED mtlSharedEvent;
 } VkImportMetalSharedEventInfoEXT;
 
 typedef void (VKAPI_PTR *PFN_vkExportMetalObjectsEXT)(VkDevice device, VkExportMetalObjectsInfoEXT* pMetalObjectsInfo);


### PR DESCRIPTION
Fixes #6598

## Description
ARC, at least with older compilers and/or SDKs, doesn't allow Objective-C objects in structs without declaring them `__unsafe_unretained`.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/6598