### PR TITLE
wayland: Fix build when not using the shared Wayland libraries

### DIFF
--- a/src/video/wayland/SDL_waylanddyn.h
+++ b/src/video/wayland/SDL_waylanddyn.h
@@ -166,6 +166,13 @@ void SDL_WAYLAND_UnloadSymbols(void);
 
 #else /* SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC */
 
+/*
+ * These must be included before libdecor.h, otherwise the libdecor header
+ * pulls in the system Wayland protocol headers instead of ours.
+ */
+#include "wayland-client-protocol.h"
+#include "wayland-egl.h"
+
 #ifdef HAVE_LIBDECOR_H
 #include <libdecor.h>
 #endif


### PR DESCRIPTION
Explicitly include the Wayland protocol headers when statically linking against the Wayland libraries, or older system headers might be used instead of the locally generated versions.

Should fix #6589

I say should as I can't replicate their exact build error, but this fixes a header discrepancy between the shared/non-shared library code paths, and the header in question contains the object and function definitions that their build said were missing.