### PR TITLE
Fix non-working N-Gage port.

### DIFF
--- a/src/video/ngage/SDL_ngagevideo.h
+++ b/src/video/ngage/SDL_ngagevideo.h
@@ -30,16 +30,7 @@
 #include <e32svr.h>
 #include <bitdev.h>
 #include <w32std.h>
-
-class CFbsDrawDevice : public CBase
-{
-public:
-public:
-    IMPORT_C static CFbsDrawDevice* NewScreenDeviceL(TScreenInfoV01 aInfo,TDisplayMode aDispMode);
-public:
-    virtual void Update() {}
-    virtual void UpdateRegion(const TRect&) {}
-};
+#include "bitdraw.h" // CFbsDrawDevice
 
 #define _THIS SDL_VideoDevice *_this
 


### PR DESCRIPTION
Fix non-working N-Gage port.

## Description
I messed something up in my test workflow.
The bitdraw.h include can't replaced by a stub class. This PR basically reverts the commit and keeps the cleanup.

I apologise for the slip-up.

## Existing Issue(s)
#6610 
