### PR TITLE
Remove `SDL_HINT_IME_SUPPORT_EXTENDED_TEXT` and use `SDL_GetEventState` to enable/disable it instead

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -595,17 +595,6 @@ extern "C" {
 #define SDL_HINT_IME_SHOW_UI "SDL_IME_SHOW_UI"
 
 /**
- * \brief A variable to control if extended IME text support is enabled.
- * If enabled then SDL_TextEditingExtEvent will be issued if the text would be truncated otherwise.
- * Additionally SDL_TextInputEvent will be dispatched multiple times so that it is not truncated.
- *
- * The variable can be set to the following values:
- *   "0"       - Legacy behavior. Text can be truncated, no heap allocations. (default)
- *   "1"       - Modern behavior.
- */
-#define SDL_HINT_IME_SUPPORT_EXTENDED_TEXT "SDL_IME_SUPPORT_EXTENDED_TEXT"
-
-/**
  * \brief  A variable controlling whether the home indicator bar on iPhone X
  *         should be hidden.
  *

--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -568,6 +568,7 @@ SDL_StartEventLoop(void)
     /* Process most event types */
     (void)SDL_EventState(SDL_TEXTINPUT, SDL_DISABLE);
     (void)SDL_EventState(SDL_TEXTEDITING, SDL_DISABLE);
+    (void)SDL_EventState(SDL_TEXTEDITING_EXT, SDL_DISABLE); /* Disabled by default since `SDL_TextEditingExtEvent.text` needs to be freed by the application */
     (void)SDL_EventState(SDL_SYSWMEVENT, SDL_DISABLE);
 #if 0 /* Leave these events enabled so apps can respond to items being dragged onto them at startup */
     (void)SDL_EventState(SDL_DROPFILE, SDL_DISABLE);

--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -1059,7 +1059,7 @@ SDL_SendEditingText(const char *text, int start, int length)
     if (SDL_GetEventState(SDL_TEXTEDITING) == SDL_ENABLE) {
         SDL_Event event;
 
-        if (SDL_GetHintBoolean(SDL_HINT_IME_SUPPORT_EXTENDED_TEXT, SDL_FALSE) &&
+        if (SDL_GetEventState(SDL_TEXTEDITING_EXT) == SDL_ENABLE &&
             SDL_strlen(text) >= SDL_arraysize(event.edit.text)) {
             event.editExt.type = SDL_TEXTEDITING_EXT;
             event.editExt.windowID = keyboard->focus ? keyboard->focus->id : 0;

--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -1060,7 +1060,7 @@ SDL_SendEditingText(const char *text, int start, int length)
         SDL_Event event;
 
         if (SDL_GetHintBoolean(SDL_HINT_IME_SUPPORT_EXTENDED_TEXT, SDL_FALSE) &&
-            SDL_strlen(text) >= SDL_arraysize(event.text.text)) {
+            SDL_strlen(text) >= SDL_arraysize(event.edit.text)) {
             event.editExt.type = SDL_TEXTEDITING_EXT;
             event.editExt.windowID = keyboard->focus ? keyboard->focus->id : 0;
             event.editExt.text = text ? SDL_strdup(text) : NULL;

--- a/test/checkkeys.c
+++ b/test/checkkeys.c
@@ -247,14 +247,14 @@ main(int argc, char *argv[])
     /* Disable mouse emulation */
     SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
 
-    /* Enable extended text editing events */
-    SDL_SetHint(SDL_HINT_IME_SUPPORT_EXTENDED_TEXT, "1");
-
     /* Initialize SDL */
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
         return (1);
     }
+
+    /* Enable extended text editing events */
+    SDL_EventState(SDL_TEXTEDITING_EXT, SDL_ENABLE);
 
     /* Set 640x480 video mode */
     window = SDL_CreateWindow("CheckKeys Test",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Removes the hint `SDL_HINT_IME_SUPPORT_EXTENDED_TEXT`.
Instead applications can use `SDL_EventState(SDL_TEXTEDITING_EXT, SDL_ENABLE)` to enable extended text editing events.

Keep in mind that `SDL_EventState` needs to be called after `SDL_Init`, as the default value is set during initialisation.

I find it a bit strange that defaults for events get set in `SDL_StartEventLoop`. I would expect them to be set in `SDL_EventsInit`.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->

- Discussed in https://github.com/libsdl-org/SDL/issues/6573#issuecomment-1325574683

## Migration for those using `SDL_HINT_IME_SUPPORT_EXTENDED_TEXT`

```diff
-    /* Enable extended text editing events */
-    SDL_SetHint(SDL_HINT_IME_SUPPORT_EXTENDED_TEXT, "1");

     /* Initialize SDL */
     SDL_Init(...);

+    /* Enable extended text editing events */
+    SDL_EventState(SDL_TEXTEDITING_EXT, SDL_ENABLE);
```