### PR TITLE
cmake: assembly fixes 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -962,7 +962,7 @@ if(SDL_ASSEMBLY)
     endif()
 
     if(SDL_ARMNEON)
-      set(ORIG_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+      cmake_push_check_state()
       set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -x assembler-with-cpp")
       check_c_source_compiles("
         .text
@@ -978,7 +978,7 @@ if(SDL_ASSEMBLY)
         pld [r0]
         vmovn.u16 d0, q0
       " ARMNEON_FOUND)
-      set(CMAKE_REQUIRED_FLAGS "${ORIG_CMAKE_REQUIRED_FLAGS}")
+      cmake_pop_check_state()
 
       if(ARMNEON_FOUND)
         set(HAVE_ARMNEON TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,7 +261,7 @@ endif()
 # Compiler info
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
   set(USE_CLANG TRUE)
-  set(OPT_DEF_ASM TRUE)
+  set(SDL_ASSEMBLY_DEFAULT TRUE)
   # Visual Studio 2019 v16.2 added support for Clang/LLVM.
   # Check if a Visual Studio project is being generated with the Clang toolset.
   if(MSVC)
@@ -269,12 +269,12 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang")
   endif()
 elseif(CMAKE_COMPILER_IS_GNUCC)
   set(USE_GCC TRUE)
-  set(OPT_DEF_ASM TRUE)
+  set(SDL_ASSEMBLY_DEFAULT TRUE)
 elseif(MSVC_VERSION GREATER 1400) # VisualStudio 8.0+
-  set(OPT_DEF_ASM TRUE)
+  set(SDL_ASSEMBLY_DEFAULT TRUE)
   #set(CMAKE_C_FLAGS "/ZI /WX- /
 else()
-  set(OPT_DEF_ASM FALSE)
+  set(SDL_ASSEMBLY_DEFAULT FALSE)
 endif()
 
 if(USE_GCC OR USE_CLANG)
@@ -377,7 +377,7 @@ if(EMSCRIPTEN)
   # SDL_THREADS_ENABLED_BY_DEFAULT now defaults to ON, but pthread support might be disabled by default.
   # !!! FIXME: most of these subsystems should default to ON if there are dummy implementations to be used.
 
-  set(OPT_DEF_ASM FALSE)
+  set(SDL_ASSEMBLY_DEFAULT FALSE)
   set(SDL_SHARED_ENABLED_BY_DEFAULT OFF)
   set(SDL_ATOMIC_ENABLED_BY_DEFAULT OFF)
   set(SDL_LOADSO_ENABLED_BY_DEFAULT OFF)
@@ -432,7 +432,7 @@ set_option(SDL3_DISABLE_UNINSTALL  "Disable uninstallation of SDL3" OFF)
 
 option_string(SDL_ASSERTIONS "Enable internal sanity checks (auto/disabled/release/enabled/paranoid)" "auto")
 #set_option(SDL_DEPENDENCY_TRACKING "Use gcc -MMD -MT dependency tracking" ON)
-set_option(SDL_ASSEMBLY            "Enable assembly routines" ${OPT_DEF_ASM})
+set_option(SDL_ASSEMBLY            "Enable assembly routines" ${SDL_ASSEMBLY_DEFAULT})
 dep_option(SDL_SSEMATH             "Allow GCC to use SSE floating point math" ON "SDL_ASSEMBLY;SDL_CPU_X86 OR SDL_CPU_X64" OFF)
 dep_option(SDL_SSE                 "Use SSE assembly routines" ON "SDL_ASSEMBLY;SDL_CPU_X86 OR SDL_CPU_X64" OFF)
 dep_option(SDL_SSE2                "Use SSE2 assembly routines" ON "SDL_ASSEMBLY;SDL_CPU_X86 OR SDL_CPU_X64" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -783,8 +783,9 @@ if(SDL_ASSEMBLY)
             void *p = 0;
             _m_prefetch(p);
             return 0;
-          }" HAVE_3DNOW)
-      if(HAVE_3DNOW)
+          }" CPU_SUPPORTS_3DNOW)
+      if(CPU_SUPPORTS_3DNOW)
+        set(HAVE_3DNOW TRUE)
         list(APPEND EXTRA_CFLAGS "-m3dnow")
       endif()
       set(CMAKE_REQUIRED_FLAGS ${ORIG_CMAKE_REQUIRED_FLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
-  message(FATAL_ERROR "Prevented in-tree build. Please create a build directory outside of the SDL source code and run \"cmake -S ${CMAKE_SOURCE_DIR} -B .\" from there")
+ message(FATAL_ERROR "Prevented in-tree build. Please create a build directory outside of the SDL source code and run \"cmake -S ${CMAKE_SOURCE_DIR} -B .\" from there")
 endif()
 
 cmake_minimum_required(VERSION 3.0.0)
@@ -992,7 +992,7 @@ if(SDL_ASSEMBLY)
   elseif(MSVC_VERSION GREATER 1500)
     # TODO: SDL_cpuinfo.h needs to support the user's configuration wish
     # for MSVC - right now it is always activated
-    if(NOT ARCH_64)
+    if(SDL_CPU_X86)
       if(SDL_MMX)
         set(HAVE_MMX TRUE)
       endif()
@@ -1736,7 +1736,7 @@ elseif(WINDOWS)
   if(MSVC AND NOT SDL_LIBC)
     # Prevent codegen that would use the VC runtime libraries.
     set_property(DIRECTORY . APPEND PROPERTY COMPILE_OPTIONS "/GS-")
-    if(NOT ARCH_64 AND NOT CMAKE_GENERATOR_PLATFORM STREQUAL "ARM")
+    if(SDL_CPU_X86)
       set_property(DIRECTORY . APPEND PROPERTY COMPILE_OPTIONS "/arch:SSE")
     endif()
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -806,8 +806,9 @@ if(SDL_ASSEMBLY)
           #ifndef __SSE__
           #error Assembler CPP flag not enabled
           #endif
-          int main(int argc, char **argv) { return 0; }" HAVE_SSE)
-      if(HAVE_SSE)
+          int main(int argc, char **argv) { return 0; }" CPU_SUPPORTS_SSE)
+      if(CPU_SUPPORTS_SSE)
+        set(HAVE_SSE ON)
         list(APPEND EXTRA_CFLAGS "-msse")
       endif()
       set(CMAKE_REQUIRED_FLAGS ${ORIG_CMAKE_REQUIRED_FLAGS})


### PR DESCRIPTION
- Avoid caching `HAVE_xx` options: cached variables spoil the configuration result when reconfiguring CMake with `-DSDL_ASSEMBLY=OFF` after `-DSDL_ASSEMBLY=ON`.
- Use `SDL_ARCH_xx` variables for enabling/disabling options
- Use `CMakePushCheckState` for handling check states