### PR TITLE
Remove SDL_config.h from the public headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,6 @@ endif()
 #cmake_policy(SET CMP0042 OLD)
 
 include(CheckLibraryExists)
-include(CheckIncludeFiles)
 include(CheckIncludeFile)
 include(CheckLanguage)
 include(CheckSymbolExists)
@@ -1038,7 +1037,6 @@ if(SDL_LIBC)
       set(HAVE_${_UPPER} 1)
     endforeach()
     set(HAVE_ALLOCA 1)
-    set(STDC_HEADERS 1)
   else()
     set(HAVE_LIBC TRUE)
     set(headers_to_check
@@ -1072,7 +1070,6 @@ if(SDL_LIBC)
     check_include_file(linux/input.h HAVE_LINUX_INPUT_H)
 
     set(STDC_HEADER_NAMES "stddef.h;stdarg.h;stdlib.h;string.h;stdio.h;wchar.h;float.h")
-    check_include_files("${STDC_HEADER_NAMES}" STDC_HEADERS)
     # TODO: refine the mprotect check
     check_c_source_compiles("#include <sys/types.h>
                              #include <sys/mman.h>
@@ -2897,17 +2894,18 @@ endif()
 #   endif()
 # endif()
 
-# config variables may contain generator expression, so we need to generate SDL_config.h in 2 steps:
+# config variables may contain generator expression, so we need to generate SDL_build_config.h in 2 steps:
 # 1. replace all `#cmakedefine`'s and `@abc@`
-configure_file("${SDL3_SOURCE_DIR}/include/SDL_config.h.cmake"
-  "${SDL3_BINARY_DIR}/SDL_config.h.intermediate")
+configure_file("${SDL3_SOURCE_DIR}/include/build_config/SDL_build_config.h.cmake"
+  "${SDL3_BINARY_DIR}/SDL_build_config.h.intermediate")
 # 2. Create the "include-config-${CMAKE_BUILD_TYPE}" folder (fails on older CMake versions when it does not exist)
 string(TOLOWER "${CMAKE_BUILD_TYPE}" lower_build_type)
 execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/include-config-${lower_build_type}")
-# 3. generate SDL_config in an build_type-dependent folder (which should be first in the include search path)
+execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/include-config-${lower_build_type}/build_config")
+# 3. generate SDL_build_config.h in an build_type-dependent folder (which should be first in the include search path)
 file(GENERATE
-    OUTPUT "${SDL3_BINARY_DIR}/include-config-$<LOWER_CASE:$<CONFIG>>/SDL_config.h"
-    INPUT "${SDL3_BINARY_DIR}/SDL_config.h.intermediate")
+    OUTPUT "${SDL3_BINARY_DIR}/include-config-$<LOWER_CASE:$<CONFIG>>/build_config/SDL_build_config.h"
+    INPUT "${SDL3_BINARY_DIR}/SDL_build_config.h.intermediate")
 
 # Prepare the flags and remove duplicates
 if(EXTRA_LDFLAGS)
@@ -2960,11 +2958,11 @@ configure_file("${SDL3_SOURCE_DIR}/include/SDL_revision.h.cmake"
   "${SDL3_BINARY_DIR}/include/SDL_revision.h")
 
 # Copy all non-generated headers to "${SDL3_BINARY_DIR}/include"
-# This is done to avoid the inclusion of a pre-generated SDL_config.h
+# This is done to avoid the inclusion of a pre-generated SDL_build_config.h
 file(GLOB SDL3_INCLUDE_FILES ${SDL3_SOURCE_DIR}/include/*.h)
 set(SDL3_COPIED_INCLUDE_FILES)
 foreach(_hdr IN LISTS SDL3_INCLUDE_FILES)
-  if(_hdr MATCHES ".*(SDL_config|SDL_revision).*")
+  if(_hdr MATCHES ".*SDL_revision.h")
     list(REMOVE_ITEM SDL3_INCLUDE_FILES "${_hdr}")
   else()
     get_filename_component(_name "${_hdr}" NAME)
@@ -3455,7 +3453,6 @@ if(NOT SDL3_DISABLE_INSTALL)
     FILES
       ${SDL3_INCLUDE_FILES}
       "${SDL3_BINARY_DIR}/include/SDL_revision.h"
-      "${SDL3_BINARY_DIR}/include-config-$<LOWER_CASE:$<CONFIG>>/SDL_config.h"
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/SDL3)
 
   install(FILES "LICENSE.txt" DESTINATION "${LICENSES_PREFIX}")

--- a/VisualC-GDK/SDL/SDL.vcxproj
+++ b/VisualC-GDK/SDL/SDL.vcxproj
@@ -299,8 +299,6 @@
     <ClInclude Include="..\..\include\SDL_bits.h" />
     <ClInclude Include="..\..\include\SDL_blendmode.h" />
     <ClInclude Include="..\..\include\SDL_clipboard.h" />
-    <ClInclude Include="..\..\include\SDL_config.h" />
-    <ClInclude Include="..\..\include\SDL_config_wingdk.h" />
     <ClInclude Include="..\..\include\SDL_copying.h" />
     <ClInclude Include="..\..\include\SDL_cpuinfo.h" />
     <ClInclude Include="..\..\include\SDL_egl.h" />

--- a/VisualC-GDK/SDL/SDL.vcxproj.filters
+++ b/VisualC-GDK/SDL/SDL.vcxproj.filters
@@ -201,9 +201,6 @@
     <ClInclude Include="..\..\include\SDL_clipboard.h">
       <Filter>API Headers</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\include\SDL_config.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\include\SDL_copying.h">
       <Filter>API Headers</Filter>
     </ClInclude>
@@ -824,9 +821,6 @@
       <Filter>render\direct3d12</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\hidapi\SDL_hidapi_c.h" />
-    <ClInclude Include="..\..\include\SDL_config_wingdk.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\src\core\gdk\SDL_gdk.h">
       <Filter>core\gdk</Filter>
     </ClInclude>

--- a/VisualC-WinRT/SDL-UWP.vcxproj
+++ b/VisualC-WinRT/SDL-UWP.vcxproj
@@ -43,9 +43,6 @@
     <ClInclude Include="..\include\SDL_audio.h" />
     <ClInclude Include="..\include\SDL_blendmode.h" />
     <ClInclude Include="..\include\SDL_clipboard.h" />
-    <ClInclude Include="..\include\SDL_config.h" />
-    <ClInclude Include="..\include\SDL_config_minimal.h" />
-    <ClInclude Include="..\include\SDL_config_winrt.h" />
     <ClInclude Include="..\include\SDL_copying.h" />
     <ClInclude Include="..\include\SDL_cpuinfo.h" />
     <ClInclude Include="..\include\SDL_egl.h" />

--- a/VisualC-WinRT/SDL-UWP.vcxproj.filters
+++ b/VisualC-WinRT/SDL-UWP.vcxproj.filters
@@ -33,15 +33,6 @@
     <ClInclude Include="..\include\SDL_clipboard.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\include\SDL_config.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\include\SDL_config_minimal.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="..\include\SDL_config_winrt.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\include\SDL_copying.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/VisualC/SDL/SDL.vcxproj
+++ b/VisualC/SDL/SDL.vcxproj
@@ -223,8 +223,6 @@
     <ClInclude Include="..\..\include\SDL_bits.h" />
     <ClInclude Include="..\..\include\SDL_blendmode.h" />
     <ClInclude Include="..\..\include\SDL_clipboard.h" />
-    <ClInclude Include="..\..\include\SDL_config.h" />
-    <ClInclude Include="..\..\include\SDL_config_windows.h" />
     <ClInclude Include="..\..\include\SDL_copying.h" />
     <ClInclude Include="..\..\include\SDL_cpuinfo.h" />
     <ClInclude Include="..\..\include\SDL_egl.h" />

--- a/VisualC/SDL/SDL.vcxproj.filters
+++ b/VisualC/SDL/SDL.vcxproj.filters
@@ -198,12 +198,6 @@
     <ClInclude Include="..\..\include\SDL_clipboard.h">
       <Filter>API Headers</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\include\SDL_config.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL_config_windows.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\include\SDL_copying.h">
       <Filter>API Headers</Filter>
     </ClInclude>

--- a/WhatsNew.txt
+++ b/WhatsNew.txt
@@ -18,3 +18,4 @@ General:
 	* SDL_RWFromFP()
 	* SDL_SetWindowBrightness()
 	* SDL_SetWindowGammaRamp()
+* SDL_stdinc.h no longer includes stdio.h, stdlib.h, etc., it only provides the SDL C runtime functionality

--- a/Xcode/SDL/SDL.xcodeproj/project.pbxproj
+++ b/Xcode/SDL/SDL.xcodeproj/project.pbxproj
@@ -167,7 +167,6 @@
 		A75FCD1723E25AB700529352 /* SDL_clipboard.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CD1595D4D800BBD41B /* SDL_clipboard.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A75FCD1823E25AB700529352 /* SDL_dataqueue.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D8A57023E2513D00DCD162 /* SDL_dataqueue.h */; };
 		A75FCD1923E25AB700529352 /* SDL_error_c.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D8A57523E2513D00DCD162 /* SDL_error_c.h */; };
-		A75FCD1B23E25AB700529352 /* SDL_config.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CF1595D4D800BBD41B /* SDL_config.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A75FCD1C23E25AB700529352 /* SDL_d3dmath.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D8A8DC23E2514000DCD162 /* SDL_d3dmath.h */; };
 		A75FCD1F23E25AB700529352 /* SDL_egl_c.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D8A60423E2513D00DCD162 /* SDL_egl_c.h */; };
 		A75FCD2023E25AB700529352 /* SDL_copying.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557D01595D4D800BBD41B /* SDL_copying.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -543,7 +542,6 @@
 		A75FCED023E25AC700529352 /* SDL_clipboard.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CD1595D4D800BBD41B /* SDL_clipboard.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A75FCED123E25AC700529352 /* SDL_dataqueue.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D8A57023E2513D00DCD162 /* SDL_dataqueue.h */; };
 		A75FCED223E25AC700529352 /* SDL_error_c.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D8A57523E2513D00DCD162 /* SDL_error_c.h */; };
-		A75FCED423E25AC700529352 /* SDL_config.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CF1595D4D800BBD41B /* SDL_config.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A75FCED523E25AC700529352 /* SDL_d3dmath.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D8A8DC23E2514000DCD162 /* SDL_d3dmath.h */; };
 		A75FCED823E25AC700529352 /* SDL_egl_c.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D8A60423E2513D00DCD162 /* SDL_egl_c.h */; };
 		A75FCED923E25AC700529352 /* SDL_copying.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557D01595D4D800BBD41B /* SDL_copying.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -896,12 +894,6 @@
 		A75FDAC023E28B8000529352 /* CoreMotion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A75FDABF23E28B8000529352 /* CoreMotion.framework */; };
 		A75FDAC223E28B9600529352 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A75FDAC123E28B9600529352 /* CoreGraphics.framework */; };
 		A75FDAC423E28BA700529352 /* CoreBluetooth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A75FDAC323E28BA700529352 /* CoreBluetooth.framework */; };
-		A75FDAF623E35EC400529352 /* SDL_config_ios.h in Headers */ = {isa = PBXBuildFile; fileRef = A75FDAF523E35EC400529352 /* SDL_config_ios.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A75FDAF723E35EC400529352 /* SDL_config_ios.h in Headers */ = {isa = PBXBuildFile; fileRef = A75FDAF523E35EC400529352 /* SDL_config_ios.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A75FDAF823E35ED500529352 /* SDL_config_ios.h in Headers */ = {isa = PBXBuildFile; fileRef = A75FDAF523E35EC400529352 /* SDL_config_ios.h */; };
-		A75FDAF923E35ED500529352 /* SDL_config_ios.h in Headers */ = {isa = PBXBuildFile; fileRef = A75FDAF523E35EC400529352 /* SDL_config_ios.h */; };
-		A75FDAFA23E35ED600529352 /* SDL_config_ios.h in Headers */ = {isa = PBXBuildFile; fileRef = A75FDAF523E35EC400529352 /* SDL_config_ios.h */; };
-		A75FDAFB23E35ED700529352 /* SDL_config_ios.h in Headers */ = {isa = PBXBuildFile; fileRef = A75FDAF523E35EC400529352 /* SDL_config_ios.h */; };
 		A75FDB5823E39E6100529352 /* hidapi.h in Headers */ = {isa = PBXBuildFile; fileRef = A75FDB5723E39E6100529352 /* hidapi.h */; };
 		A75FDB5923E39E6100529352 /* hidapi.h in Headers */ = {isa = PBXBuildFile; fileRef = A75FDB5723E39E6100529352 /* hidapi.h */; };
 		A75FDB5A23E39E6100529352 /* hidapi.h in Headers */ = {isa = PBXBuildFile; fileRef = A75FDB5723E39E6100529352 /* hidapi.h */; };
@@ -1257,7 +1249,6 @@
 		A7D88A1F23E2437C00DCD162 /* SDL_blendmode.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CC1595D4D800BBD41B /* SDL_blendmode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A7D88A2023E2437C00DCD162 /* SDL_egl.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C2EF7001FC9EF0F003F5197 /* SDL_egl.h */; };
 		A7D88A2123E2437C00DCD162 /* SDL_clipboard.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CD1595D4D800BBD41B /* SDL_clipboard.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A7D88A2323E2437C00DCD162 /* SDL_config.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CF1595D4D800BBD41B /* SDL_config.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A7D88A2523E2437C00DCD162 /* SDL_copying.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557D01595D4D800BBD41B /* SDL_copying.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A7D88A2623E2437C00DCD162 /* SDL_cpuinfo.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557D11595D4D800BBD41B /* SDL_cpuinfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A7D88A2723E2437C00DCD162 /* SDL_endian.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557D21595D4D800BBD41B /* SDL_endian.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1325,7 +1316,6 @@
 		A7D88BD623E24BED00DCD162 /* SDL_blendmode.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CC1595D4D800BBD41B /* SDL_blendmode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A7D88BD723E24BED00DCD162 /* SDL_egl.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C2EF7001FC9EF0F003F5197 /* SDL_egl.h */; };
 		A7D88BD823E24BED00DCD162 /* SDL_clipboard.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CD1595D4D800BBD41B /* SDL_clipboard.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A7D88BDA23E24BED00DCD162 /* SDL_config.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CF1595D4D800BBD41B /* SDL_config.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A7D88BDC23E24BED00DCD162 /* SDL_copying.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557D01595D4D800BBD41B /* SDL_copying.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A7D88BDD23E24BED00DCD162 /* SDL_cpuinfo.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557D11595D4D800BBD41B /* SDL_cpuinfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A7D88BDE23E24BED00DCD162 /* SDL_endian.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557D21595D4D800BBD41B /* SDL_endian.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -3250,8 +3240,6 @@
 		AA7558021595D4D800BBD41B /* SDL_audio.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CB1595D4D800BBD41B /* SDL_audio.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA7558041595D4D800BBD41B /* SDL_blendmode.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CC1595D4D800BBD41B /* SDL_blendmode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA7558061595D4D800BBD41B /* SDL_clipboard.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CD1595D4D800BBD41B /* SDL_clipboard.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AA7558081595D4D800BBD41B /* SDL_config_macos.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CE1595D4D800BBD41B /* SDL_config_macos.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AA75580A1595D4D800BBD41B /* SDL_config.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CF1595D4D800BBD41B /* SDL_config.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA75580C1595D4D800BBD41B /* SDL_copying.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557D01595D4D800BBD41B /* SDL_copying.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA75580E1595D4D800BBD41B /* SDL_cpuinfo.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557D11595D4D800BBD41B /* SDL_cpuinfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA7558101595D4D800BBD41B /* SDL_endian.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557D21595D4D800BBD41B /* SDL_endian.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -3315,8 +3303,6 @@
 		DB313FCC17554B71006C0E22 /* SDL_audio.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CB1595D4D800BBD41B /* SDL_audio.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB313FCD17554B71006C0E22 /* SDL_blendmode.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CC1595D4D800BBD41B /* SDL_blendmode.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB313FCE17554B71006C0E22 /* SDL_clipboard.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CD1595D4D800BBD41B /* SDL_clipboard.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DB313FCF17554B71006C0E22 /* SDL_config_macos.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CE1595D4D800BBD41B /* SDL_config_macos.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DB313FD017554B71006C0E22 /* SDL_config.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557CF1595D4D800BBD41B /* SDL_config.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB313FD117554B71006C0E22 /* SDL_copying.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557D01595D4D800BBD41B /* SDL_copying.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB313FD217554B71006C0E22 /* SDL_cpuinfo.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557D11595D4D800BBD41B /* SDL_cpuinfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB313FD317554B71006C0E22 /* SDL_endian.h in Headers */ = {isa = PBXBuildFile; fileRef = AA7557D21595D4D800BBD41B /* SDL_endian.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -3713,7 +3699,6 @@
 		A75FDABF23E28B8000529352 /* CoreMotion.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMotion.framework; path = System/Library/Frameworks/CoreMotion.framework; sourceTree = SDKROOT; };
 		A75FDAC123E28B9600529352 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		A75FDAC323E28BA700529352 /* CoreBluetooth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreBluetooth.framework; path = System/Library/Frameworks/CoreBluetooth.framework; sourceTree = SDKROOT; };
-		A75FDAF523E35EC400529352 /* SDL_config_ios.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_config_ios.h; sourceTree = "<group>"; };
 		A75FDB5723E39E6100529352 /* hidapi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = hidapi.h; path = hidapi/hidapi.h; sourceTree = "<group>"; };
 		A75FDB9223E4C8DB00529352 /* hid.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = hid.c; sourceTree = "<group>"; };
 		A75FDBA323E4CB6F00529352 /* LICENSE-bsd.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "LICENSE-bsd.txt"; sourceTree = "<group>"; };
@@ -4047,8 +4032,6 @@
 		AA7557CB1595D4D800BBD41B /* SDL_audio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_audio.h; sourceTree = "<group>"; };
 		AA7557CC1595D4D800BBD41B /* SDL_blendmode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_blendmode.h; sourceTree = "<group>"; };
 		AA7557CD1595D4D800BBD41B /* SDL_clipboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_clipboard.h; sourceTree = "<group>"; };
-		AA7557CE1595D4D800BBD41B /* SDL_config_macos.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_config_macos.h; sourceTree = "<group>"; };
-		AA7557CF1595D4D800BBD41B /* SDL_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_config.h; sourceTree = "<group>"; };
 		AA7557D01595D4D800BBD41B /* SDL_copying.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_copying.h; sourceTree = "<group>"; };
 		AA7557D11595D4D800BBD41B /* SDL_cpuinfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_cpuinfo.h; sourceTree = "<group>"; };
 		AA7557D21595D4D800BBD41B /* SDL_endian.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_endian.h; sourceTree = "<group>"; };
@@ -4318,9 +4301,6 @@
 				AADA5B8616CCAB3000107CF7 /* SDL_bits.h */,
 				AA7557CC1595D4D800BBD41B /* SDL_blendmode.h */,
 				AA7557CD1595D4D800BBD41B /* SDL_clipboard.h */,
-				A75FDAF523E35EC400529352 /* SDL_config_ios.h */,
-				AA7557CE1595D4D800BBD41B /* SDL_config_macos.h */,
-				AA7557CF1595D4D800BBD41B /* SDL_config.h */,
 				AA7557D01595D4D800BBD41B /* SDL_copying.h */,
 				AA7557D11595D4D800BBD41B /* SDL_cpuinfo.h */,
 				5C2EF7001FC9EF0F003F5197 /* SDL_egl.h */,
@@ -5415,7 +5395,6 @@
 				A75FCD1723E25AB700529352 /* SDL_clipboard.h in Headers */,
 				A75FCD1823E25AB700529352 /* SDL_dataqueue.h in Headers */,
 				A75FCD1923E25AB700529352 /* SDL_error_c.h in Headers */,
-				A75FCD1B23E25AB700529352 /* SDL_config.h in Headers */,
 				A75FCD1C23E25AB700529352 /* SDL_d3dmath.h in Headers */,
 				A75FCD1F23E25AB700529352 /* SDL_egl_c.h in Headers */,
 				A75FCD2023E25AB700529352 /* SDL_copying.h in Headers */,
@@ -5502,7 +5481,6 @@
 				A75FCD7323E25AB700529352 /* SDL_yuv_c.h in Headers */,
 				A75FCD7423E25AB700529352 /* scancodes_xfree86.h in Headers */,
 				A75FCD7523E25AB700529352 /* SDL_syspower.h in Headers */,
-				A75FDAFA23E35ED600529352 /* SDL_config_ios.h in Headers */,
 				A75FCD7723E25AB700529352 /* SDL_name.h in Headers */,
 				A75FCD7823E25AB700529352 /* eglext.h in Headers */,
 				A75FCD7923E25AB700529352 /* SDL_events_c.h in Headers */,
@@ -5644,7 +5622,6 @@
 				A75FCED023E25AC700529352 /* SDL_clipboard.h in Headers */,
 				A75FCED123E25AC700529352 /* SDL_dataqueue.h in Headers */,
 				A75FCED223E25AC700529352 /* SDL_error_c.h in Headers */,
-				A75FCED423E25AC700529352 /* SDL_config.h in Headers */,
 				A75FCED523E25AC700529352 /* SDL_d3dmath.h in Headers */,
 				A75FCED823E25AC700529352 /* SDL_egl_c.h in Headers */,
 				A75FCED923E25AC700529352 /* SDL_copying.h in Headers */,
@@ -5731,7 +5708,6 @@
 				A75FCF2C23E25AC700529352 /* SDL_yuv_c.h in Headers */,
 				A75FCF2D23E25AC700529352 /* scancodes_xfree86.h in Headers */,
 				A75FCF2E23E25AC700529352 /* SDL_syspower.h in Headers */,
-				A75FDAFB23E35ED700529352 /* SDL_config_ios.h in Headers */,
 				A75FCF3023E25AC700529352 /* SDL_name.h in Headers */,
 				A75FCF3123E25AC700529352 /* eglext.h in Headers */,
 				A75FCF3223E25AC700529352 /* SDL_events_c.h in Headers */,
@@ -5927,7 +5903,6 @@
 				A769B0FB23E259AE00872273 /* SDL_yuv_c.h in Headers */,
 				A769B0FC23E259AE00872273 /* scancodes_xfree86.h in Headers */,
 				A769B0FD23E259AE00872273 /* SDL_syspower.h in Headers */,
-				A75FDAF923E35ED500529352 /* SDL_config_ios.h in Headers */,
 				A769B10023E259AE00872273 /* eglext.h in Headers */,
 				A769B10123E259AE00872273 /* SDL_events_c.h in Headers */,
 				A769B10223E259AE00872273 /* math_private.h in Headers */,
@@ -6046,8 +6021,6 @@
 				A7D8AF0123E2514100DCD162 /* SDL_cocoavideo.h in Headers */,
 				A7D8AEE923E2514100DCD162 /* SDL_cocoavulkan.h in Headers */,
 				A7D8AEFB23E2514100DCD162 /* SDL_cocoawindow.h in Headers */,
-				A7D88A2323E2437C00DCD162 /* SDL_config.h in Headers */,
-				A75FDAF623E35EC400529352 /* SDL_config_ios.h in Headers */,
 				A7D88A2523E2437C00DCD162 /* SDL_copying.h in Headers */,
 				A7D8B8CD23E2514400DCD162 /* SDL_coreaudio.h in Headers */,
 				A7D8A97023E2514000DCD162 /* SDL_coremotionsensor.h in Headers */,
@@ -6280,8 +6253,6 @@
 				A7D8AF0223E2514100DCD162 /* SDL_cocoavideo.h in Headers */,
 				A7D8AEEA23E2514100DCD162 /* SDL_cocoavulkan.h in Headers */,
 				A7D8AEFC23E2514100DCD162 /* SDL_cocoawindow.h in Headers */,
-				A7D88BDA23E24BED00DCD162 /* SDL_config.h in Headers */,
-				A75FDAF723E35EC400529352 /* SDL_config_ios.h in Headers */,
 				A7D88BDC23E24BED00DCD162 /* SDL_copying.h in Headers */,
 				A7D8B8CE23E2514400DCD162 /* SDL_coreaudio.h in Headers */,
 				A7D8A97123E2514000DCD162 /* SDL_coremotionsensor.h in Headers */,
@@ -6564,7 +6535,6 @@
 				A7D8B3B423E2514200DCD162 /* SDL_yuv_c.h in Headers */,
 				A7D8BBA323E2514500DCD162 /* scancodes_xfree86.h in Headers */,
 				A7D8B5D923E2514300DCD162 /* SDL_syspower.h in Headers */,
-				A75FDAF823E35ED500529352 /* SDL_config_ios.h in Headers */,
 				A7D8B24623E2514200DCD162 /* eglext.h in Headers */,
 				A7D8BBA923E2514500DCD162 /* SDL_events_c.h in Headers */,
 				A7D8BAC523E2514500DCD162 /* math_private.h in Headers */,
@@ -6683,8 +6653,6 @@
 				A7D8AF0023E2514100DCD162 /* SDL_cocoavideo.h in Headers */,
 				A7D8AEE823E2514100DCD162 /* SDL_cocoavulkan.h in Headers */,
 				A7D8AEFA23E2514100DCD162 /* SDL_cocoawindow.h in Headers */,
-				AA75580A1595D4D800BBD41B /* SDL_config.h in Headers */,
-				AA7558081595D4D800BBD41B /* SDL_config_macos.h in Headers */,
 				AA75580C1595D4D800BBD41B /* SDL_copying.h in Headers */,
 				A7D8B8CC23E2514400DCD162 /* SDL_coreaudio.h in Headers */,
 				A7D8A96F23E2514000DCD162 /* SDL_coremotionsensor.h in Headers */,
@@ -7082,9 +7050,7 @@
 				DB313FCE17554B71006C0E22 /* SDL_clipboard.h in Headers */,
 				A7D8A94A23E2514000DCD162 /* SDL_dataqueue.h in Headers */,
 				A7D8A96223E2514000DCD162 /* SDL_error_c.h in Headers */,
-				DB313FD017554B71006C0E22 /* SDL_config.h in Headers */,
 				A7D8B98523E2514400DCD162 /* SDL_d3dmath.h in Headers */,
-				DB313FCF17554B71006C0E22 /* SDL_config_macos.h in Headers */,
 				A7D8ABDE23E2514100DCD162 /* SDL_egl_c.h in Headers */,
 				DB313FD117554B71006C0E22 /* SDL_copying.h in Headers */,
 				F382338B2738EB8600F7F527 /* SDL_hidapi.h in Headers */,
@@ -9546,10 +9512,11 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
-					/usr/X11R6/include,
-					"$(VULKAN_SDK)/include",
-					../../src/video/khronos,
+					../../include,
 					../../src/hidapi/hidapi,
+					../../src/video/khronos,
+					"$(VULKAN_SDK)/include",
+					/usr/X11R6/include,
 				);
 				INFOPLIST_FILE = "Info-Framework.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -9631,10 +9598,11 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
-					/usr/X11R6/include,
-					"$(VULKAN_SDK)/include",
-					../../src/video/khronos,
+					../../include,
 					../../src/hidapi/hidapi,
+					../../src/video/khronos,
+					"$(VULKAN_SDK)/include",
+					/usr/X11R6/include,
 				);
 				INFOPLIST_FILE = "Info-Framework.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;

--- a/build-scripts/android-prefab.sh
+++ b/build-scripts/android-prefab.sh
@@ -204,8 +204,6 @@ create_shared_sdl_module() {
 EOF
         mkdir -p "${sdl_moduleworkdir}/include"
         cp -r "${abi_build_prefix}/include/SDL${sdl_major}/"* "${sdl_moduleworkdir}/include/"
-        rm "${sdl_moduleworkdir}/include/SDL_config.h"
-        cp "$sdl_root/include/SDL_config.h" "$sdl_root/include/SDL_config_android.h" "${sdl_moduleworkdir}/include/"
 
         abi_sdllibdir="${sdl_moduleworkdir}/libs/android.${android_abi}"
         mkdir -p "${abi_sdllibdir}"
@@ -238,8 +236,6 @@ create_static_sdl_module() {
 EOF
         mkdir -p "${sdl_moduleworkdir}/include"
         cp -r "${abi_build_prefix}/include/SDL${sdl_major}/"* "${sdl_moduleworkdir}/include"
-        rm "${sdl_moduleworkdir}/include/SDL_config.h"
-        cp "$sdl_root/include/SDL_config.h" "$sdl_root/include/SDL_config_android.h" "${sdl_moduleworkdir}/include/"
 
         abi_sdllibdir="${sdl_moduleworkdir}/libs/android.${android_abi}"
         mkdir -p "${abi_sdllibdir}"

--- a/cmake/sdlchecks.cmake
+++ b/cmake/sdlchecks.cmake
@@ -834,8 +834,8 @@ macro(CheckPTHREAD)
         endif()
       endif()
 
-      check_include_files("pthread.h" HAVE_PTHREAD_H)
-      check_include_files("pthread_np.h" HAVE_PTHREAD_NP_H)
+      check_include_file(pthread.h HAVE_PTHREAD_H)
+      check_include_file(pthread_np.h HAVE_PTHREAD_NP_H)
       if (HAVE_PTHREAD_H)
         check_c_source_compiles("
             #define _GNU_SOURCE 1

--- a/docs/README-cmake.md
+++ b/docs/README-cmake.md
@@ -105,7 +105,7 @@ When using a recent version of CMake (3.14+), it should be possible to:
 
 - build SDL for iOS, both static and dynamic
 - build SDL test apps (as iOS/tvOS .app bundles)
-- generate a working SDL_config.h for iOS (using SDL_config.h.cmake as a basis)
+- generate a working SDL_build_config.h for iOS (using SDL_build_config.h.cmake as a basis)
 
 To use, set the following CMake variables when running CMake's configuration stage:
 

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -130,6 +130,7 @@ SDL_RWFromFP(void *fp, SDL_bool autoclose)
 
 ## SDL_stdinc.h
 
+The standard C headers like stdio.h and stdlib.h are no longer included, you should include them directly in your project if you use non-SDL C runtime functions.
 M_PI is no longer defined in SDL_stdinc.h, you can use the new symbols SDL_PI_D (double) and SDL_PI_F (float) instead.
 
 

--- a/docs/README-porting.md
+++ b/docs/README-porting.md
@@ -23,10 +23,7 @@ There are two basic ways of building SDL at the moment:
 
 2. Using an IDE:
 
-   If you're using an IDE or other non-configure build system, you'll probably
-   want to create a custom SDL_config.h for your platform.  Edit SDL_config.h,
-   add a section for your platform, and create a custom SDL_config_{platform}.h,
-   based on SDL_config_minimal.h and SDL_config.h.in
+   If you're using an IDE or other non-configure build system, you'll probably want to create a custom `SDL_build_config.h` for your platform.  Edit `include/build_config/SDL_build_config.h`, add a section for your platform, and create a custom `SDL_build_config_{platform}.h`, based on `SDL_build_config_minimal.h` and `SDL_build_config.h.cmake`
 
    Add the top level include directory to the header search path, and then add
    the following sources to the project:

--- a/include/SDL_endian.h
+++ b/include/SDL_endian.h
@@ -55,7 +55,7 @@ _m_prefetch(void *__P)
 #define SDL_BIG_ENDIAN  4321
 /* @} */
 
-#ifndef SDL_BYTEORDER           /* Not defined in SDL_config.h? */
+#ifndef SDL_BYTEORDER
 #ifdef __linux__
 #include <endian.h>
 #define SDL_BYTEORDER  __BYTE_ORDER
@@ -87,7 +87,7 @@ _m_prefetch(void *__P)
 #endif /* __linux__ */
 #endif /* !SDL_BYTEORDER */
 
-#ifndef SDL_FLOATWORDORDER           /* Not defined in SDL_config.h? */
+#ifndef SDL_FLOATWORDORDER
 /* predefs from newer gcc versions: */
 #if defined(__ORDER_LITTLE_ENDIAN__) && defined(__ORDER_BIG_ENDIAN__) && defined(__FLOAT_WORD_ORDER__)
 #if (__FLOAT_WORD_ORDER__ == __ORDER_LITTLE_ENDIAN__)

--- a/include/SDL_opengl.h
+++ b/include/SDL_opengl.h
@@ -35,7 +35,7 @@
 #ifndef SDL_opengl_h_
 #define SDL_opengl_h_
 
-#include "SDL_config.h"
+#include "SDL_platform.h"
 
 #ifndef __IOS__  /* No OpenGL on iOS. */
 

--- a/include/SDL_opengles.h
+++ b/include/SDL_opengles.h
@@ -24,7 +24,7 @@
  *
  *  This is a simple file to encapsulate the OpenGL ES 1.X API headers.
  */
-#include "SDL_config.h"
+#include "SDL_platform.h"
 
 #ifdef __IOS__
 #include <OpenGLES/ES1/gl.h>

--- a/include/SDL_opengles2.h
+++ b/include/SDL_opengles2.h
@@ -24,7 +24,7 @@
  *
  *  This is a simple file to encapsulate the OpenGL ES 2.0 API headers.
  */
-#include "SDL_config.h"
+#include "SDL_platform.h"
 
 #if !defined(_MSC_VER) && !defined(SDL_USE_BUILTIN_OPENGL_DEFINITIONS)
 

--- a/include/SDL_platform.h
+++ b/include/SDL_platform.h
@@ -98,7 +98,8 @@
 #if TARGET_OS_TV
 #undef __TVOS__
 #define __TVOS__ 1
-#elif TARGET_OS_IPHONE
+#endif
+#if TARGET_OS_IPHONE
 #undef __IOS__
 #define __IOS__ 1
 #else

--- a/include/build_config/SDL_build_config.h
+++ b/include/build_config/SDL_build_config.h
@@ -19,41 +19,41 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-#ifndef SDL_config_h_
-#define SDL_config_h_
+#ifndef SDL_build_config_h_
+#define SDL_build_config_h_
 
 #include "SDL_platform.h"
 
 /**
- *  \file SDL_config.h
+ *  \file SDL_build_config.h
  */
 
 /* Add any platform that doesn't build using the configure system. */
 #if defined(__WIN32__)
-#include "SDL_config_windows.h"
+#include "SDL_build_config_windows.h"
 #elif defined(__WINRT__)
-#include "SDL_config_winrt.h"
+#include "SDL_build_config_winrt.h"
 #elif defined(__WINGDK__)
-#include "SDL_config_wingdk.h"
+#include "SDL_build_config_wingdk.h"
 #elif defined(__XBOXONE__) || defined(__XBOXSERIES__)
-#include "SDL_config_xbox.h"
+#include "SDL_build_config_xbox.h"
 #elif defined(__MACOS__)
-#include "SDL_config_macos.h"
+#include "SDL_build_config_macos.h"
 #elif defined(__IOS__)
-#include "SDL_config_ios.h"
+#include "SDL_build_config_ios.h"
 #elif defined(__ANDROID__)
-#include "SDL_config_android.h"
+#include "SDL_build_config_android.h"
 #elif defined(__EMSCRIPTEN__)
-#include "SDL_config_emscripten.h"
+#include "SDL_build_config_emscripten.h"
 #elif defined(__NGAGE__)
-#include "SDL_config_ngage.h"
+#include "SDL_build_config_ngage.h"
 #else
 /* This is a minimal configuration just to get SDL running on new platforms. */
-#include "SDL_config_minimal.h"
+#include "SDL_build_config_minimal.h"
 #endif /* platform config */
 
 #ifdef USING_GENERATED_CONFIG_H
-#error Wrong SDL_config.h, check your include path?
+#error Wrong SDL_build_config.h, check your include path?
 #endif
 
-#endif /* SDL_config_h_ */
+#endif /* SDL_build_config_h_ */

--- a/include/build_config/SDL_build_config.h.cmake
+++ b/include/build_config/SDL_build_config.h.cmake
@@ -19,11 +19,11 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-#ifndef SDL_config_h_
-#define SDL_config_h_
+#ifndef SDL_build_config_h_
+#define SDL_build_config_h_
 
 /**
- *  \file SDL_config.h.in
+ *  \file SDL_build_config.h.in
  *
  *  This is a set of defines to configure the SDL features
  */
@@ -539,4 +539,4 @@ typedef unsigned int uintptr_t;
 #endif /* Visual Studio 2008 */
 #endif /* !_STDINT_H_ && !HAVE_STDINT_H */
 
-#endif /* SDL_config_h_ */
+#endif /* SDL_build_config_h_ */

--- a/include/build_config/SDL_build_config_android.h
+++ b/include/build_config/SDL_build_config_android.h
@@ -19,33 +19,37 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-#ifndef SDL_config_ios_h_
-#define SDL_config_ios_h_
-#define SDL_config_h_
+#ifndef SDL_build_config_android_h_
+#define SDL_build_config_android_h_
+#define SDL_build_config_h_
 
 #include "SDL_platform.h"
 
-#ifdef __LP64__
-#define SIZEOF_VOIDP 8
-#else
-#define SIZEOF_VOIDP 4
-#endif
+/**
+ *  \file SDL_build_config_android.h
+ *
+ *  This is a configuration that can be used to build SDL for Android
+ */
+
+#include <stdarg.h>
 
 #define HAVE_GCC_ATOMICS    1
 
-#define STDC_HEADERS    1
-#define HAVE_ALLOCA_H       1
-#define HAVE_CTYPE_H    1
+#define HAVE_ALLOCA_H 1
+#define HAVE_CTYPE_H 1
+#define HAVE_FLOAT_H 1
 #define HAVE_INTTYPES_H 1
-#define HAVE_LIMITS_H   1
+#define HAVE_LIMITS_H 1
 #define HAVE_MATH_H 1
-#define HAVE_SIGNAL_H   1
-#define HAVE_STDINT_H   1
-#define HAVE_STDIO_H    1
-#define HAVE_STRING_H   1
-#define HAVE_SYS_TYPES_H    1
-/* The libunwind functions are only available on x86 */
-/* #undef HAVE_LIBUNWIND_H */
+#define HAVE_SIGNAL_H 1
+#define HAVE_STDARG_H 1
+#define HAVE_STDDEF_H 1
+#define HAVE_STDINT_H 1
+#define HAVE_STDIO_H 1
+#define HAVE_STDLIB_H 1
+#define HAVE_STRING_H 1
+#define HAVE_SYS_TYPES_H 1
+#define HAVE_WCHAR_H 1
 
 /* C library functions */
 #define HAVE_DLOPEN 1
@@ -80,7 +84,7 @@
 #define HAVE_STRTOULL   1
 #define HAVE_STRTOD 1
 #define HAVE_ATOI   1
-#define HAVE_ATOF   1
+#define HAVE_ATOF 1
 #define HAVE_STRCMP 1
 #define HAVE_STRNCMP    1
 #define HAVE_STRCASECMP 1
@@ -128,38 +132,31 @@
 #define HAVE_SQRTF  1
 #define HAVE_TAN    1
 #define HAVE_TANF   1
-#define HAVE_TRUNC  1
-#define HAVE_TRUNCF 1
-#define HAVE_SIGACTION  1
+#define HAVE_TRUNC    1
+#define HAVE_TRUNCF   1
+#define HAVE_SIGACTION 1
 #define HAVE_SETJMP 1
 #define HAVE_NANOSLEEP  1
 #define HAVE_SYSCONF    1
-#define HAVE_SYSCTLBYNAME 1
-#define HAVE_O_CLOEXEC 1
+#define HAVE_CLOCK_GETTIME  1
 
-/* enable iPhone version of Core Audio driver */
-#define SDL_AUDIO_DRIVER_COREAUDIO 1
-/* Enable the dummy audio driver (src/audio/dummy/\*.c) */
+/* Enable various audio drivers */
+#define SDL_AUDIO_DRIVER_ANDROID    1
+#define SDL_AUDIO_DRIVER_OPENSLES   1
+#define SDL_AUDIO_DRIVER_AAUDIO     1
 #define SDL_AUDIO_DRIVER_DUMMY  1
 
-/* Enable the stub haptic driver (src/haptic/dummy/\*.c) */
-#define SDL_HAPTIC_DUMMY 1
-
-/* Enable joystick support */
-/* Only enable HIDAPI support if you want to support Steam Controllers on iOS and tvOS */
-/*#define SDL_JOYSTICK_HIDAPI 1*/
-#define SDL_JOYSTICK_MFI 1
+/* Enable various input drivers */
+#define SDL_JOYSTICK_ANDROID    1
+#define SDL_JOYSTICK_HIDAPI     1
 #define SDL_JOYSTICK_VIRTUAL    1
+#define SDL_HAPTIC_ANDROID  1
 
-#ifdef __TVOS__
-#define SDL_SENSOR_DUMMY    1
-#else
-/* Enable the CoreMotion sensor driver */
-#define SDL_SENSOR_COREMOTION   1
-#endif
+/* Enable sensor driver */
+#define SDL_SENSOR_ANDROID  1
 
-/* Enable Unix style SO loading */
-#define SDL_LOADSO_DLOPEN 1
+/* Enable various shared object loading systems */
+#define SDL_LOADSO_DLOPEN   1
 
 /* Enable various threading systems */
 #define SDL_THREAD_PTHREAD  1
@@ -168,49 +165,28 @@
 /* Enable various timer systems */
 #define SDL_TIMER_UNIX  1
 
-/* Supported video drivers */
-#define SDL_VIDEO_DRIVER_UIKIT  1
-#define SDL_VIDEO_DRIVER_DUMMY  1
+/* Enable various video drivers */
+#define SDL_VIDEO_DRIVER_ANDROID 1
 
 /* Enable OpenGL ES */
-#if !TARGET_OS_MACCATALYST
-#define SDL_VIDEO_OPENGL_ES2 1
 #define SDL_VIDEO_OPENGL_ES 1
+#define SDL_VIDEO_OPENGL_ES2 1
+#define SDL_VIDEO_OPENGL_EGL 1
 #define SDL_VIDEO_RENDER_OGL_ES 1
 #define SDL_VIDEO_RENDER_OGL_ES2    1
-#endif
 
-/* Metal supported on 64-bit devices running iOS 8.0 and tvOS 9.0 and newer
-   Also supported in simulator from iOS 13.0 and tvOS 13.0
- */
-#if (TARGET_OS_SIMULATOR && ((__IPHONE_OS_VERSION_MIN_REQUIRED >= 130000) || (__TV_OS_VERSION_MIN_REQUIRED >= 130000))) || (!TARGET_CPU_ARM && ((__IPHONE_OS_VERSION_MIN_REQUIRED >= 80000) || (__TV_OS_VERSION_MIN_REQUIRED >= 90000)))
-#define SDL_PLATFORM_SUPPORTS_METAL	1
+/* Enable Vulkan support */
+/* Android does not support Vulkan in native code using the "armeabi" ABI. */
+#if defined(__ARM_ARCH) && __ARM_ARCH < 7
+#define SDL_VIDEO_VULKAN 0
 #else
-#define SDL_PLATFORM_SUPPORTS_METAL	0
-#endif
-
-#if SDL_PLATFORM_SUPPORTS_METAL
-#define SDL_VIDEO_RENDER_METAL  1
-#endif
-
-#if SDL_PLATFORM_SUPPORTS_METAL
 #define SDL_VIDEO_VULKAN 1
 #endif
 
-#if SDL_PLATFORM_SUPPORTS_METAL
-#define SDL_VIDEO_METAL 1
-#endif
-
 /* Enable system power support */
-#define SDL_POWER_UIKIT 1
+#define SDL_POWER_ANDROID 1
 
-/* enable iPhone keyboard support */
-#define SDL_IPHONE_KEYBOARD 1
+/* Enable the filesystem driver */
+#define SDL_FILESYSTEM_ANDROID   1
 
-/* enable iOS extended launch screen */
-#define SDL_IPHONE_LAUNCHSCREEN 1
-
-/* enable filesystem support */
-#define SDL_FILESYSTEM_COCOA   1
-
-#endif /* SDL_config_ios_h_ */
+#endif /* SDL_build_config_android_h_ */

--- a/include/build_config/SDL_build_config_emscripten.h
+++ b/include/build_config/SDL_build_config_emscripten.h
@@ -19,28 +19,23 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-#ifndef _SDL_config_emscripten_h_
-#define _SDL_config_emscripten_h_
+#ifndef _SDL_build_config_emscripten_h_
+#define _SDL_build_config_emscripten_h_
 
 #include "SDL_platform.h"
 
 /**
- *  \file SDL_config_emscripten.h
+ *  \file SDL_build_config_emscripten.h
  *
  *  This is a configuration that can be used to build SDL for Emscripten.
  */
 
-#ifdef __LP64__
-#define SIZEOF_VOIDP 8
-#else
-#define SIZEOF_VOIDP 4
-#endif
 #define HAVE_GCC_ATOMICS 1
 
 /* Useful headers */
-#define STDC_HEADERS 1
 #define HAVE_ALLOCA_H 1
 #define HAVE_CTYPE_H 1
+#define HAVE_FLOAT_H 1
 #define HAVE_ICONV_H 1
 #define HAVE_INTTYPES_H 1
 #define HAVE_LIMITS_H 1
@@ -49,6 +44,7 @@
 #define HAVE_MEMORY_H 1
 #define HAVE_SIGNAL_H 1
 #define HAVE_STDARG_H 1
+#define HAVE_STDDEF_H 1
 #define HAVE_STDINT_H 1
 #define HAVE_STDIO_H 1
 #define HAVE_STDLIB_H 1
@@ -214,4 +210,4 @@
 /* Enable system filesystem support */
 #define SDL_FILESYSTEM_EMSCRIPTEN 1
 
-#endif /* _SDL_config_emscripten_h_ */
+#endif /* _SDL_build_config_emscripten_h_ */

--- a/include/build_config/SDL_build_config_ios.h
+++ b/include/build_config/SDL_build_config_ios.h
@@ -19,33 +19,31 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-#ifndef SDL_config_android_h_
-#define SDL_config_android_h_
-#define SDL_config_h_
+#ifndef SDL_build_config_ios_h_
+#define SDL_build_config_ios_h_
+#define SDL_build_config_h_
 
 #include "SDL_platform.h"
 
-/**
- *  \file SDL_config_android.h
- *
- *  This is a configuration that can be used to build SDL for Android
- */
-
-#include <stdarg.h>
-
 #define HAVE_GCC_ATOMICS    1
 
-#define STDC_HEADERS    1
-#define HAVE_ALLOCA_H       1
-#define HAVE_CTYPE_H    1
+#define HAVE_ALLOCA_H 1
+#define HAVE_CTYPE_H 1
+#define HAVE_FLOAT_H 1
 #define HAVE_INTTYPES_H 1
-#define HAVE_LIMITS_H   1
+#define HAVE_LIMITS_H 1
 #define HAVE_MATH_H 1
 #define HAVE_SIGNAL_H 1
-#define HAVE_STDINT_H   1
-#define HAVE_STDIO_H    1
-#define HAVE_STRING_H   1
-#define HAVE_SYS_TYPES_H    1
+#define HAVE_STDARG_H 1
+#define HAVE_STDDEF_H 1
+#define HAVE_STDINT_H 1
+#define HAVE_STDIO_H 1
+#define HAVE_STDLIB_H 1
+#define HAVE_STRING_H 1
+#define HAVE_SYS_TYPES_H 1
+#define HAVE_WCHAR_H 1
+/* The libunwind functions are only available on x86 */
+/* #undef HAVE_LIBUNWIND_H */
 
 /* C library functions */
 #define HAVE_DLOPEN 1
@@ -80,7 +78,7 @@
 #define HAVE_STRTOULL   1
 #define HAVE_STRTOD 1
 #define HAVE_ATOI   1
-#define HAVE_ATOF 1
+#define HAVE_ATOF   1
 #define HAVE_STRCMP 1
 #define HAVE_STRNCMP    1
 #define HAVE_STRCASECMP 1
@@ -128,37 +126,38 @@
 #define HAVE_SQRTF  1
 #define HAVE_TAN    1
 #define HAVE_TANF   1
-#define HAVE_TRUNC    1
-#define HAVE_TRUNCF   1
-#define HAVE_SIGACTION 1
+#define HAVE_TRUNC  1
+#define HAVE_TRUNCF 1
+#define HAVE_SIGACTION  1
 #define HAVE_SETJMP 1
 #define HAVE_NANOSLEEP  1
 #define HAVE_SYSCONF    1
-#define HAVE_CLOCK_GETTIME  1
+#define HAVE_SYSCTLBYNAME 1
+#define HAVE_O_CLOEXEC 1
 
-#ifdef __LP64__
-#define SIZEOF_VOIDP 8
-#else
-#define SIZEOF_VOIDP 4
-#endif
-
-/* Enable various audio drivers */
-#define SDL_AUDIO_DRIVER_ANDROID    1
-#define SDL_AUDIO_DRIVER_OPENSLES   1
-#define SDL_AUDIO_DRIVER_AAUDIO     1
+/* enable iPhone version of Core Audio driver */
+#define SDL_AUDIO_DRIVER_COREAUDIO 1
+/* Enable the dummy audio driver (src/audio/dummy/\*.c) */
 #define SDL_AUDIO_DRIVER_DUMMY  1
 
-/* Enable various input drivers */
-#define SDL_JOYSTICK_ANDROID    1
-#define SDL_JOYSTICK_HIDAPI     1
+/* Enable the stub haptic driver (src/haptic/dummy/\*.c) */
+#define SDL_HAPTIC_DUMMY 1
+
+/* Enable joystick support */
+/* Only enable HIDAPI support if you want to support Steam Controllers on iOS and tvOS */
+/*#define SDL_JOYSTICK_HIDAPI 1*/
+#define SDL_JOYSTICK_MFI 1
 #define SDL_JOYSTICK_VIRTUAL    1
-#define SDL_HAPTIC_ANDROID  1
 
-/* Enable sensor driver */
-#define SDL_SENSOR_ANDROID  1
+#ifdef __TVOS__
+#define SDL_SENSOR_DUMMY    1
+#else
+/* Enable the CoreMotion sensor driver */
+#define SDL_SENSOR_COREMOTION   1
+#endif
 
-/* Enable various shared object loading systems */
-#define SDL_LOADSO_DLOPEN   1
+/* Enable Unix style SO loading */
+#define SDL_LOADSO_DLOPEN 1
 
 /* Enable various threading systems */
 #define SDL_THREAD_PTHREAD  1
@@ -167,28 +166,49 @@
 /* Enable various timer systems */
 #define SDL_TIMER_UNIX  1
 
-/* Enable various video drivers */
-#define SDL_VIDEO_DRIVER_ANDROID 1
+/* Supported video drivers */
+#define SDL_VIDEO_DRIVER_UIKIT  1
+#define SDL_VIDEO_DRIVER_DUMMY  1
 
 /* Enable OpenGL ES */
-#define SDL_VIDEO_OPENGL_ES 1
+#if !TARGET_OS_MACCATALYST
 #define SDL_VIDEO_OPENGL_ES2 1
-#define SDL_VIDEO_OPENGL_EGL 1
+#define SDL_VIDEO_OPENGL_ES 1
 #define SDL_VIDEO_RENDER_OGL_ES 1
 #define SDL_VIDEO_RENDER_OGL_ES2    1
+#endif
 
-/* Enable Vulkan support */
-/* Android does not support Vulkan in native code using the "armeabi" ABI. */
-#if defined(__ARM_ARCH) && __ARM_ARCH < 7
-#define SDL_VIDEO_VULKAN 0
+/* Metal supported on 64-bit devices running iOS 8.0 and tvOS 9.0 and newer
+   Also supported in simulator from iOS 13.0 and tvOS 13.0
+ */
+#if (TARGET_OS_SIMULATOR && ((__IPHONE_OS_VERSION_MIN_REQUIRED >= 130000) || (__TV_OS_VERSION_MIN_REQUIRED >= 130000))) || (!TARGET_CPU_ARM && ((__IPHONE_OS_VERSION_MIN_REQUIRED >= 80000) || (__TV_OS_VERSION_MIN_REQUIRED >= 90000)))
+#define SDL_PLATFORM_SUPPORTS_METAL	1
 #else
+#define SDL_PLATFORM_SUPPORTS_METAL	0
+#endif
+
+#if SDL_PLATFORM_SUPPORTS_METAL
+#define SDL_VIDEO_RENDER_METAL  1
+#endif
+
+#if SDL_PLATFORM_SUPPORTS_METAL
 #define SDL_VIDEO_VULKAN 1
 #endif
 
+#if SDL_PLATFORM_SUPPORTS_METAL
+#define SDL_VIDEO_METAL 1
+#endif
+
 /* Enable system power support */
-#define SDL_POWER_ANDROID 1
+#define SDL_POWER_UIKIT 1
 
-/* Enable the filesystem driver */
-#define SDL_FILESYSTEM_ANDROID   1
+/* enable iPhone keyboard support */
+#define SDL_IPHONE_KEYBOARD 1
 
-#endif /* SDL_config_android_h_ */
+/* enable iOS extended launch screen */
+#define SDL_IPHONE_LAUNCHSCREEN 1
+
+/* enable filesystem support */
+#define SDL_FILESYSTEM_COCOA   1
+
+#endif /* SDL_build_config_ios_h_ */

--- a/include/build_config/SDL_build_config_macos.h
+++ b/include/build_config/SDL_build_config_macos.h
@@ -19,9 +19,9 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-#ifndef SDL_config_macos_h_
-#define SDL_config_macos_h_
-#define SDL_config_h_
+#ifndef SDL_build_config_macos_h_
+#define SDL_build_config_macos_h_
+#define SDL_build_config_h_
 
 #include "SDL_platform.h"
 
@@ -30,26 +30,23 @@
 
 /* This is a set of defines to configure the SDL features */
 
-#ifdef __LP64__
-    #define SIZEOF_VOIDP 8
-#else
-    #define SIZEOF_VOIDP 4
-#endif
-
 /* Useful headers */
-#define STDC_HEADERS    1
-#define HAVE_ALLOCA_H       1
-#define HAVE_CTYPE_H    1
-#define HAVE_FLOAT_H    1
+#define HAVE_ALLOCA_H 1
+#define HAVE_CTYPE_H 1
+#define HAVE_FLOAT_H 1
 #define HAVE_INTTYPES_H 1
-#define HAVE_LIMITS_H   1
+#define HAVE_LIBUNWIND_H 1
+#define HAVE_LIMITS_H 1
 #define HAVE_MATH_H 1
-#define HAVE_SIGNAL_H   1
-#define HAVE_STDINT_H   1
-#define HAVE_STDIO_H    1
-#define HAVE_STRING_H   1
-#define HAVE_SYS_TYPES_H    1
-#define HAVE_LIBUNWIND_H    1
+#define HAVE_SIGNAL_H 1
+#define HAVE_STDARG_H 1
+#define HAVE_STDDEF_H 1
+#define HAVE_STDINT_H 1
+#define HAVE_STDIO_H 1
+#define HAVE_STDLIB_H 1
+#define HAVE_STRING_H 1
+#define HAVE_SYS_TYPES_H 1
+#define HAVE_WCHAR_H 1
 
 /* C library functions */
 #define HAVE_DLOPEN 1
@@ -273,4 +270,4 @@
 #define SDL_ALTIVEC_BLITTERS    1
 #endif
 
-#endif /* SDL_config_macos_h_ */
+#endif /* SDL_build_config_macos_h_ */

--- a/include/build_config/SDL_build_config_minimal.h
+++ b/include/build_config/SDL_build_config_minimal.h
@@ -19,51 +19,48 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-#ifndef SDL_config_ngage_h_
-#define SDL_config_ngage_h_
-#define SDL_config_h_
+#ifndef SDL_build_config_minimal_h_
+#define SDL_build_config_minimal_h_
+#define SDL_build_config_h_
 
 #include "SDL_platform.h"
 
-typedef signed char        int8_t;
-typedef unsigned char      uint8_t;
-typedef signed short       int16_t;
-typedef unsigned short     uint16_t;
-typedef signed int         int32_t;
-typedef unsigned int       uint32_t;
-typedef signed long long   int64_t;
-typedef unsigned long long uint64_t;
-typedef unsigned long      uintptr_t;
+/**
+ *  \file SDL_build_config_minimal.h
+ *
+ *  This is the minimal configuration that can be used to build SDL.
+ */
 
-#define HAVE_STDARG_H    1
-#define HAVE_STDDEF_H    1
-#define HAVE_STDIO_H     1
-#define HAVE_STDLIB_H    1
-#define HAVE_MATH_H      1
-#define HAVE_CEIL        1
-#define HAVE_COPYSIGN    1
-#define HAVE_COS         1
-#define HAVE_EXP         1
-#define HAVE_FABS        1
-#define HAVE_FLOOR       1
-#define HAVE_LOG         1
-#define HAVE_LOG10       1
-#define HAVE_SCALBN      1
-#define HAVE_SIN         1
-#define HAVE_SQRT        1
-#define HAVE_TAN         1
-#define HAVE_MALLOC      1
-#define SDL_MAIN_NEEDED  1
-#define LACKS_SYS_MMAN_H 1
+#define HAVE_STDARG_H   1
+#define HAVE_STDDEF_H   1
 
-/* Enable the N-Gage thread support (src/thread/ngage/\*.c) */
-#define SDL_THREAD_NGAGE 1
+#if !defined(_STDINT_H_) && (!defined(HAVE_STDINT_H) || !_HAVE_STDINT_H)
+/* Most everything except Visual Studio 2008 and earlier has stdint.h now */
+#if defined(_MSC_VER) && (_MSC_VER < 1600)
+typedef signed __int8 int8_t;
+typedef unsigned __int8 uint8_t;
+typedef signed __int16 int16_t;
+typedef unsigned __int16 uint16_t;
+typedef signed __int32 int32_t;
+typedef unsigned __int32 uint32_t;
+typedef signed __int64 int64_t;
+typedef unsigned __int64 uint64_t;
+#ifndef _UINTPTR_T_DEFINED
+#ifdef  _WIN64
+typedef unsigned __int64 uintptr_t;
+#else
+typedef unsigned int uintptr_t;
+#endif
+#define _UINTPTR_T_DEFINED
+#endif
+#else
+#define HAVE_STDINT_H 1
+#endif /* Visual Studio 2008 */
+#endif /* !_STDINT_H_ && !HAVE_STDINT_H */
 
-/* Enable the N-Gage timer support (src/timer/ngage/\*.c) */
-#define SDL_TIMER_NGAGE  1
-
-/* Enable the N-Gage video driver (src/video/ngage/\*.c) */
-#define SDL_VIDEO_DRIVER_NGAGE 1
+#ifdef __GNUC__
+#define HAVE_GCC_SYNC_LOCK_TEST_AND_SET 1
+#endif
 
 /* Enable the dummy audio driver (src/audio/dummy/\*.c) */
 #define SDL_AUDIO_DRIVER_DUMMY  1
@@ -83,7 +80,16 @@ typedef unsigned long      uintptr_t;
 /* Enable the stub shared object loader (src/loadso/dummy/\*.c) */
 #define SDL_LOADSO_DISABLED 1
 
-/* Enable the dummy filesystem driver (src/filesystem/dummy/\*.c) */
-#define SDL_FILESYSTEM_DUMMY 1
+/* Enable the stub thread support (src/thread/generic/\*.c) */
+#define SDL_THREADS_DISABLED    1
 
-#endif /* SDL_config_ngage_h_ */
+/* Enable the stub timer support (src/timer/dummy/\*.c) */
+#define SDL_TIMERS_DISABLED 1
+
+/* Enable the dummy video driver (src/video/dummy/\*.c) */
+#define SDL_VIDEO_DRIVER_DUMMY  1
+
+/* Enable the dummy filesystem driver (src/filesystem/dummy/\*.c) */
+#define SDL_FILESYSTEM_DUMMY  1
+
+#endif /* SDL_build_config_minimal_h_ */

--- a/include/build_config/SDL_build_config_ngage.h
+++ b/include/build_config/SDL_build_config_ngage.h
@@ -19,48 +19,51 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-#ifndef SDL_config_minimal_h_
-#define SDL_config_minimal_h_
-#define SDL_config_h_
+#ifndef SDL_build_config_ngage_h_
+#define SDL_build_config_ngage_h_
+#define SDL_build_config_h_
 
 #include "SDL_platform.h"
 
-/**
- *  \file SDL_config_minimal.h
- *
- *  This is the minimal configuration that can be used to build SDL.
- */
+typedef signed char        int8_t;
+typedef unsigned char      uint8_t;
+typedef signed short       int16_t;
+typedef unsigned short     uint16_t;
+typedef signed int         int32_t;
+typedef unsigned int       uint32_t;
+typedef signed long long   int64_t;
+typedef unsigned long long uint64_t;
+typedef unsigned long      uintptr_t;
 
-#define HAVE_STDARG_H   1
-#define HAVE_STDDEF_H   1
+#define HAVE_STDARG_H    1
+#define HAVE_STDDEF_H    1
+#define HAVE_STDIO_H     1
+#define HAVE_STDLIB_H    1
+#define HAVE_MATH_H      1
+#define HAVE_CEIL        1
+#define HAVE_COPYSIGN    1
+#define HAVE_COS         1
+#define HAVE_EXP         1
+#define HAVE_FABS        1
+#define HAVE_FLOOR       1
+#define HAVE_LOG         1
+#define HAVE_LOG10       1
+#define HAVE_SCALBN      1
+#define HAVE_SIN         1
+#define HAVE_SQRT        1
+#define HAVE_TAN         1
+#define HAVE_MALLOC      1
+#define SDL_MAIN_NEEDED  1
+#define LACKS_SYS_MMAN_H 1
 
-#if !defined(_STDINT_H_) && (!defined(HAVE_STDINT_H) || !_HAVE_STDINT_H)
-/* Most everything except Visual Studio 2008 and earlier has stdint.h now */
-#if defined(_MSC_VER) && (_MSC_VER < 1600)
-typedef signed __int8 int8_t;
-typedef unsigned __int8 uint8_t;
-typedef signed __int16 int16_t;
-typedef unsigned __int16 uint16_t;
-typedef signed __int32 int32_t;
-typedef unsigned __int32 uint32_t;
-typedef signed __int64 int64_t;
-typedef unsigned __int64 uint64_t;
-#ifndef _UINTPTR_T_DEFINED
-#ifdef  _WIN64
-typedef unsigned __int64 uintptr_t;
-#else
-typedef unsigned int uintptr_t;
-#endif
-#define _UINTPTR_T_DEFINED
-#endif
-#else
-#define HAVE_STDINT_H 1
-#endif /* Visual Studio 2008 */
-#endif /* !_STDINT_H_ && !HAVE_STDINT_H */
+/* Enable the N-Gage thread support (src/thread/ngage/\*.c) */
+#define SDL_THREAD_NGAGE 1
 
-#ifdef __GNUC__
-#define HAVE_GCC_SYNC_LOCK_TEST_AND_SET 1
-#endif
+/* Enable the N-Gage timer support (src/timer/ngage/\*.c) */
+#define SDL_TIMER_NGAGE  1
+
+/* Enable the N-Gage video driver (src/video/ngage/\*.c) */
+#define SDL_VIDEO_DRIVER_NGAGE 1
 
 /* Enable the dummy audio driver (src/audio/dummy/\*.c) */
 #define SDL_AUDIO_DRIVER_DUMMY  1
@@ -80,16 +83,7 @@ typedef unsigned int uintptr_t;
 /* Enable the stub shared object loader (src/loadso/dummy/\*.c) */
 #define SDL_LOADSO_DISABLED 1
 
-/* Enable the stub thread support (src/thread/generic/\*.c) */
-#define SDL_THREADS_DISABLED    1
-
-/* Enable the stub timer support (src/timer/dummy/\*.c) */
-#define SDL_TIMERS_DISABLED 1
-
-/* Enable the dummy video driver (src/video/dummy/\*.c) */
-#define SDL_VIDEO_DRIVER_DUMMY  1
-
 /* Enable the dummy filesystem driver (src/filesystem/dummy/\*.c) */
-#define SDL_FILESYSTEM_DUMMY  1
+#define SDL_FILESYSTEM_DUMMY 1
 
-#endif /* SDL_config_minimal_h_ */
+#endif /* SDL_build_config_ngage_h_ */

--- a/include/build_config/SDL_build_config_windows.h
+++ b/include/build_config/SDL_build_config_windows.h
@@ -19,9 +19,9 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-#ifndef SDL_config_windows_h_
-#define SDL_config_windows_h_
-#define SDL_config_h_
+#ifndef SDL_build_config_windows_h_
+#define SDL_build_config_windows_h_
+#define SDL_build_config_h_
 
 #include "SDL_platform.h"
 
@@ -76,12 +76,6 @@ typedef unsigned int uintptr_t;
 #endif /* Visual Studio 2008 */
 #endif /* !_STDINT_H_ && !HAVE_STDINT_H */
 
-#ifdef _WIN64
-# define SIZEOF_VOIDP 8
-#else
-# define SIZEOF_VOIDP 4
-#endif
-
 #ifdef __clang__
 # define HAVE_GCC_ATOMICS 1
 #endif
@@ -119,14 +113,17 @@ typedef unsigned int uintptr_t;
 /* This is disabled by default to avoid C runtime dependencies and manifest requirements */
 #ifdef HAVE_LIBC
 /* Useful headers */
-#define STDC_HEADERS 1
 #define HAVE_CTYPE_H 1
 #define HAVE_FLOAT_H 1
 #define HAVE_LIMITS_H 1
 #define HAVE_MATH_H 1
 #define HAVE_SIGNAL_H 1
+#define HAVE_STDARG_H 1
+#define HAVE_STDDEF_H 1
 #define HAVE_STDIO_H 1
+#define HAVE_STDLIB_H 1
 #define HAVE_STRING_H 1
+#define HAVE_WCHAR_H 1
 
 /* C library functions */
 #define HAVE_MALLOC 1
@@ -306,6 +303,6 @@ typedef unsigned int uintptr_t;
 /* Enable filesystem support */
 #define SDL_FILESYSTEM_WINDOWS  1
 
-#endif /* SDL_config_windows_h_ */
+#endif /* SDL_build_config_windows_h_ */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/include/build_config/SDL_build_config_wingdk.h
+++ b/include/build_config/SDL_build_config_wingdk.h
@@ -19,17 +19,14 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-#ifndef SDL_config_wingdk_h_
-#define SDL_config_wingdk_h_
-#define SDL_config_h_
+#ifndef SDL_build_config_wingdk_h_
+#define SDL_build_config_wingdk_h_
+#define SDL_build_config_h_
 
 #include "SDL_platform.h"
 
 /* Windows GDK does not need Windows SDK version checks because it requires
  * a recent version of the Windows 10 SDK. */
-
-/* GDK only supports 64-bit */
-# define SIZEOF_VOIDP 8
 
 #ifdef __clang__
 # define HAVE_GCC_ATOMICS 1
@@ -61,15 +58,18 @@
 /* This is disabled by default to avoid C runtime dependencies and manifest requirements */
 #ifdef HAVE_LIBC
 /* Useful headers */
-#define STDC_HEADERS 1
 #define HAVE_CTYPE_H 1
 #define HAVE_FLOAT_H 1
 #define HAVE_LIMITS_H 1
 #define HAVE_MATH_H 1
 #define HAVE_SIGNAL_H 1
+#define HAVE_STDARG_H 1
+#define HAVE_STDDEF_H 1
 #define HAVE_STDINT_H 1
 #define HAVE_STDIO_H 1
+#define HAVE_STDLIB_H 1
 #define HAVE_STRING_H 1
+#define HAVE_WCHAR_H 1
 
 /* C library functions */
 #define HAVE_MALLOC 1
@@ -243,6 +243,6 @@
 /* Enable filesystem support */
 #define SDL_FILESYSTEM_WINDOWS  1
 
-#endif /* SDL_config_wingdk_h_ */
+#endif /* SDL_build_config_wingdk_h_ */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/include/build_config/SDL_build_config_winrt.h
+++ b/include/build_config/SDL_build_config_winrt.h
@@ -19,9 +19,9 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-#ifndef SDL_config_winrt_h_
-#define SDL_config_winrt_h_
-#define SDL_config_h_
+#ifndef SDL_build_config_winrt_h_
+#define SDL_build_config_winrt_h_
+#define SDL_build_config_h_
 
 #include "SDL_platform.h"
 
@@ -42,12 +42,6 @@
 
 /* This is a set of defines to configure the SDL features */
 
-#ifdef _WIN64
-# define SIZEOF_VOIDP 8
-#else
-# define SIZEOF_VOIDP 4
-#endif
-
 #ifdef __clang__
 # define HAVE_GCC_ATOMICS 1
 #endif
@@ -63,15 +57,18 @@
 #define HAVE_TPCSHRD_H 1
 
 #define HAVE_LIBC 1
-#define STDC_HEADERS 1
 #define HAVE_CTYPE_H 1
 #define HAVE_FLOAT_H 1
 #define HAVE_LIMITS_H 1
 #define HAVE_MATH_H 1
 #define HAVE_SIGNAL_H 1
+#define HAVE_STDARG_H 1
+#define HAVE_STDDEF_H 1
 #define HAVE_STDINT_H 1
 #define HAVE_STDIO_H 1
+#define HAVE_STDLIB_H 1
 #define HAVE_STRING_H 1
+#define HAVE_WCHAR_H 1
 
 /* C library functions */
 #define HAVE_MALLOC 1
@@ -216,4 +213,4 @@
 /* Enable system power support */
 #define SDL_POWER_WINRT 1
 
-#endif /* SDL_config_winrt_h_ */
+#endif /* SDL_build_config_winrt_h_ */

--- a/include/build_config/SDL_build_config_xbox.h
+++ b/include/build_config/SDL_build_config_xbox.h
@@ -19,17 +19,14 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-#ifndef SDL_config_wingdk_h_
-#define SDL_config_wingdk_h_
-#define SDL_config_h_
+#ifndef SDL_build_config_wingdk_h_
+#define SDL_build_config_wingdk_h_
+#define SDL_build_config_h_
 
 #include "SDL_platform.h"
 
 /* Windows GDK does not need Windows SDK version checks because it requires
  * a recent version of the Windows 10 SDK. */
-
-/* GDK only supports 64-bit */
-# define SIZEOF_VOIDP 8
 
 #ifdef __clang__
 # define HAVE_GCC_ATOMICS 1
@@ -61,15 +58,18 @@
 /* This is disabled by default to avoid C runtime dependencies and manifest requirements */
 #ifdef HAVE_LIBC
 /* Useful headers */
-#define STDC_HEADERS 1
 #define HAVE_CTYPE_H 1
 #define HAVE_FLOAT_H 1
 #define HAVE_LIMITS_H 1
 #define HAVE_MATH_H 1
 #define HAVE_SIGNAL_H 1
+#define HAVE_STDARG_H 1
+#define HAVE_STDDEF_H 1
 #define HAVE_STDINT_H 1
 #define HAVE_STDIO_H 1
+#define HAVE_STDLIB_H 1
 #define HAVE_STRING_H 1
+#define HAVE_WCHAR_H 1
 
 /* C library functions */
 #define HAVE_MALLOC 1
@@ -225,6 +225,6 @@
 /* Disable IME as not supported yet (TODO: Xbox IME?) */
 #define SDL_DISABLE_WINDOWS_IME 1
 
-#endif /* SDL_config_wingdk_h_ */
+#endif /* SDL_build_config_wingdk_h_ */
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/SDL_assert.c
+++ b/src/SDL_assert.c
@@ -36,9 +36,6 @@
 #ifndef WS_OVERLAPPEDWINDOW
 #define WS_OVERLAPPEDWINDOW 0
 #endif
-#else  /* fprintf, etc. */
-#include <stdio.h>
-#include <stdlib.h>
 #endif
 
 #if defined(__EMSCRIPTEN__)

--- a/src/SDL_assert_c.h
+++ b/src/SDL_assert_c.h
@@ -18,6 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
+#include "./SDL_internal.h"
 
 #ifndef SDL_assert_c_h_
 #define SDL_assert_c_h_

--- a/src/SDL_internal.h
+++ b/src/SDL_internal.h
@@ -48,7 +48,59 @@
 #define DECLSPEC
 #endif
 
-#include "SDL_config.h"
+#include "build_config/SDL_build_config.h"
+
+#ifdef __APPLE__
+#ifndef _DARWIN_C_SOURCE
+#define _DARWIN_C_SOURCE 1 /* for memset_pattern4() */
+#endif
+#endif
+
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_STDIO_H
+#include <stdio.h>
+#endif
+#if defined(HAVE_STDLIB_H)
+# include <stdlib.h>
+#elif defined(HAVE_MALLOC_H)
+# include <malloc.h>
+#endif
+#if defined(HAVE_STDDEF_H)
+# include <stddef.h>
+#endif
+#if defined(HAVE_STDARG_H)
+# include <stdarg.h>
+#endif
+#ifdef HAVE_STRING_H
+# if !defined(STDC_HEADERS) && defined(HAVE_MEMORY_H)
+#  include <memory.h>
+# endif
+# include <string.h>
+#endif
+#ifdef HAVE_STRINGS_H
+# include <strings.h>
+#endif
+#ifdef HAVE_WCHAR_H
+# include <wchar.h>
+#endif
+#if defined(HAVE_INTTYPES_H)
+# include <inttypes.h>
+#elif defined(HAVE_STDINT_H)
+# include <stdint.h>
+#endif
+#ifdef HAVE_CTYPE_H
+# include <ctype.h>
+#endif
+#ifdef HAVE_MATH_H
+# include <math.h>
+#endif
+#ifdef HAVE_FLOAT_H
+# include <float.h>
+#endif
+
+#include "SDL_stdinc.h"
 
 /* If you run into a warning that O_CLOEXEC is redefined, update the SDL configuration header for your platform to add HAVE_O_CLOEXEC */
 #ifndef HAVE_O_CLOEXEC

--- a/src/SDL_utils_c.h
+++ b/src/SDL_utils_c.h
@@ -18,6 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
+#include "./SDL_internal.h"
 
 #ifndef SDL_utils_h_
 #define SDL_utils_h_

--- a/src/core/winrt/SDL_winrtapp_common.h
+++ b/src/core/winrt/SDL_winrtapp_common.h
@@ -18,7 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
+#include "../../SDL_internal.h"
 
 #ifndef SDL_winrtapp_common_h_
 #define SDL_winrtapp_common_h_

--- a/src/core/winrt/SDL_winrtapp_xaml.h
+++ b/src/core/winrt/SDL_winrtapp_xaml.h
@@ -18,7 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
+#include "../../SDL_internal.h"
 
 #ifndef SDL_winrtapp_xaml_h_
 #define SDL_winrtapp_xaml_h_

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -18,9 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#ifdef TEST_MAIN
-#include "SDL_config.h"
-#else
+#ifndef TEST_MAIN
 #include "../SDL_internal.h"
 #endif
 

--- a/src/dynapi/SDL_dynapi.c
+++ b/src/dynapi/SDL_dynapi.c
@@ -19,10 +19,14 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-#include "SDL_config.h"
+#include "build_config/SDL_build_config.h"
 #include "SDL_dynapi.h"
 
 #if SDL_DYNAMIC_API
+
+#ifdef HAVE_STDIO_H
+#include <stdio.h>
+#endif
 
 #include "SDL.h"
 

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -892,3 +892,4 @@
 #define SDL_EGL_SetEGLAttributeCallbacks SDL_EGL_SetEGLAttributeCallbacks_REAL
 #define SDL_GDKSuspendComplete SDL_GDKSuspendComplete_REAL
 #define SDL_GetWindowWMInfo SDL_GetWindowWMInfo_REAL
+#define SDL_memset4 SDL_memset4_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -968,3 +968,4 @@ SDL_DYNAPI_PROC(void,SDL_EGL_SetEGLAttributeCallbacks,(SDL_EGLAttribArrayCallbac
 SDL_DYNAPI_PROC(void,SDL_GDKSuspendComplete,(void),(),return)
 #endif
 SDL_DYNAPI_PROC(int,SDL_GetWindowWMInfo,(SDL_Window *a, SDL_SysWMinfo *b, Uint32 c),(a,b,c),return)
+SDL_DYNAPI_PROC(void*,SDL_memset4,(void *a, Uint32 b, size_t c),(a,b,c),return)

--- a/src/events/SDL_quit.c
+++ b/src/events/SDL_quit.c
@@ -31,7 +31,7 @@
 #include "SDL_events.h"
 #include "SDL_events_c.h"
 
-#if defined(HAVE_SIGNAL_H) || defined(HAVE_SIGACTION)
+#if defined(HAVE_SIGNAL_H) && defined(HAVE_SIGACTION)
 #define HAVE_SIGNAL_SUPPORT 1
 #endif
 

--- a/src/haptic/android/SDL_syshaptic_c.h
+++ b/src/haptic/android/SDL_syshaptic_c.h
@@ -1,11 +1,29 @@
-#include "SDL_config.h"
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2022 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+#include "../../SDL_internal.h"
 
 #ifdef SDL_HAPTIC_ANDROID
 
-
 extern int Android_AddHaptic(int device_id, const char *name);
 extern int Android_RemoveHaptic(int device_id);
-
 
 #endif /* SDL_HAPTIC_ANDROID */
 

--- a/src/locale/SDL_syslocale.h
+++ b/src/locale/SDL_syslocale.h
@@ -18,7 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
+#include "../SDL_internal.h"
 
 /* This is the system specific header for the SDL locale API */
 

--- a/src/main/gdk/SDL_gdk_main.c
+++ b/src/main/gdk/SDL_gdk_main.c
@@ -18,7 +18,6 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
 
 /* Include this so we define UNICODE properly */
 #include "../../core/windows/SDL_windows.h"

--- a/src/main/ps2/SDL_ps2_main.c
+++ b/src/main/ps2/SDL_ps2_main.c
@@ -2,7 +2,7 @@
     SDL_ps2_main.c, fjtrujy@gmail.com 
 */
 
-#include "SDL_config.h"
+#include "SDL_platform.h"
 
 #ifdef __PS2__
 
@@ -12,6 +12,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <stdio.h>
 
 #include <kernel.h>
 #include <sifrpc.h>

--- a/src/main/psp/SDL_psp_main.c
+++ b/src/main/psp/SDL_psp_main.c
@@ -1,7 +1,7 @@
 /*
     SDL_psp_main.c, placed in the public domain by Sam Lantinga  3/13/14
 */
-#include "SDL_config.h"
+#include "SDL_platform.h"
 
 #ifdef __PSP__
 

--- a/src/main/windows/SDL_windows_main.c
+++ b/src/main/windows/SDL_windows_main.c
@@ -3,7 +3,7 @@
 
     The WinMain function -- calls your program's main() function
 */
-#include "SDL_config.h"
+#include "SDL_platform.h"
 
 #ifdef __WIN32__
 

--- a/src/sensor/SDL_sensor_c.h
+++ b/src/sensor/SDL_sensor_c.h
@@ -18,11 +18,10 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
+#include "../SDL_internal.h"
 
 #ifndef SDL_sensor_c_h_
 #define SDL_sensor_c_h_
-
-#include "SDL_config.h"
 
 struct _SDL_SensorDriver;
 

--- a/src/sensor/SDL_syssensor.h
+++ b/src/sensor/SDL_syssensor.h
@@ -18,11 +18,10 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
+#include "../SDL_internal.h"
 
 #ifndef SDL_syssensor_c_h_
 #define SDL_syssensor_c_h_
-
-#include "SDL_config.h"
 
 /* This is the system specific header for the SDL sensor API */
 

--- a/src/sensor/android/SDL_androidsensor.c
+++ b/src/sensor/android/SDL_androidsensor.c
@@ -20,8 +20,6 @@
 */
 #include "../../SDL_internal.h"
 
-#include "SDL_config.h"
-
 #ifdef SDL_SENSOR_ANDROID
 
 /* This is the system specific header for the SDL sensor API */

--- a/src/sensor/android/SDL_androidsensor.h
+++ b/src/sensor/android/SDL_androidsensor.h
@@ -18,7 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
+#include "../../SDL_internal.h"
 
 /* The private structure used to keep track of a sensor */
 struct sensor_hwdata

--- a/src/sensor/coremotion/SDL_coremotionsensor.h
+++ b/src/sensor/coremotion/SDL_coremotionsensor.h
@@ -18,7 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
+#include "../../SDL_internal.h"
 
 /* The private structure used to keep track of a sensor */
 struct sensor_hwdata

--- a/src/sensor/coremotion/SDL_coremotionsensor.m
+++ b/src/sensor/coremotion/SDL_coremotionsensor.m
@@ -18,8 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-
-#include "SDL_config.h"
+#include "../../SDL_internal.h"
 
 #ifdef SDL_SENSOR_COREMOTION
 

--- a/src/sensor/dummy/SDL_dummysensor.c
+++ b/src/sensor/dummy/SDL_dummysensor.c
@@ -20,8 +20,6 @@
 */
 #include "../../SDL_internal.h"
 
-#include "SDL_config.h"
-
 #if defined(SDL_SENSOR_DUMMY) || defined(SDL_SENSOR_DISABLED)
 
 #include "SDL_error.h"

--- a/src/sensor/dummy/SDL_dummysensor.h
+++ b/src/sensor/dummy/SDL_dummysensor.h
@@ -18,6 +18,6 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
+#include "../../SDL_internal.h"
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/sensor/vita/SDL_vitasensor.c
+++ b/src/sensor/vita/SDL_vitasensor.c
@@ -18,8 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-
-#include "SDL_config.h"
+#include "../../SDL_internal.h"
 
 #if defined(SDL_SENSOR_VITA)
 

--- a/src/sensor/vita/SDL_vitasensor.h
+++ b/src/sensor/vita/SDL_vitasensor.h
@@ -18,7 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
+#include "../../SDL_internal.h"
 
 /* The private structure used to keep track of a sensor */
 struct sensor_hwdata

--- a/src/sensor/windows/SDL_windowssensor.c
+++ b/src/sensor/windows/SDL_windowssensor.c
@@ -20,8 +20,6 @@
 */
 #include "../../SDL_internal.h"
 
-#include "SDL_config.h"
-
 #if defined(SDL_SENSOR_WINDOWS)
 
 #include "SDL_error.h"

--- a/src/sensor/windows/SDL_windowssensor.h
+++ b/src/sensor/windows/SDL_windowssensor.h
@@ -18,6 +18,6 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
+#include "../../SDL_internal.h"
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/stdlib/SDL_string.c
+++ b/src/stdlib/SDL_string.c
@@ -26,7 +26,6 @@
 
 /* This file contains portable string manipulation functions for SDL */
 
-#include "SDL_stdinc.h"
 #include "SDL_vacopy.h"
 
 #if defined(__vita__)

--- a/src/test/SDL_test_assert.c
+++ b/src/test/SDL_test_assert.c
@@ -24,9 +24,6 @@
  Used by the test framework and test cases.
 
 */
-
-#include "SDL_config.h"
-
 #include "SDL_test.h"
 
 /* Assert check message format */

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -20,11 +20,7 @@
 */
 
 /* Ported from original test/common.c file. */
-
-#include "SDL_config.h"
 #include "SDL_test.h"
-
-#include <stdio.h>
 
 static const char *video_usage[] = {
     "[--video driver]", "[--renderer driver]", "[--gldebug]",

--- a/src/test/SDL_test_compare.c
+++ b/src/test/SDL_test_compare.c
@@ -26,9 +26,6 @@
  Rewritten for test lib by Andreas Schiffler.
 
 */
-
-#include "SDL_config.h"
-
 #include "SDL_test.h"
 
 

--- a/src/test/SDL_test_crc32.c
+++ b/src/test/SDL_test_crc32.c
@@ -25,9 +25,6 @@
  Original source code contributed by A. Schiffler for GSOC project.
 
 */
-
-#include "SDL_config.h"
-
 #include "SDL_test.h"
 
 

--- a/src/test/SDL_test_font.c
+++ b/src/test/SDL_test_font.c
@@ -18,8 +18,6 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
-
 #include "SDL_test.h"
 
 /* ---- 8x8 font definition ---- */

--- a/src/test/SDL_test_fuzzer.c
+++ b/src/test/SDL_test_fuzzer.c
@@ -24,26 +24,10 @@
   Data generators for fuzzing test data in a reproducible way.
 
 */
-
-#include "SDL_config.h"
-
-#include <limits.h>
-/* Visual Studio 2008 doesn't have stdint.h */
-#if defined(_MSC_VER) && _MSC_VER <= 1500
-#define UINT8_MAX   _UI8_MAX
-#define UINT16_MAX  _UI16_MAX
-#define UINT32_MAX  _UI32_MAX
-#define INT64_MIN    _I64_MIN
-#define INT64_MAX    _I64_MAX
-#define UINT64_MAX  _UI64_MAX
-#else
-#include <stdint.h>
-#endif
-#include <stdio.h>
-#include <stdlib.h>
-#include <float.h>
-
 #include "SDL_test.h"
+
+#include <float.h>      /* Needed for FLT_MAX and DBL_EPSILON */
+#include <limits.h>     /* Needed for UCHAR_MAX, etc. */
 
 /**
  * Counter for fuzzer invocations

--- a/src/test/SDL_test_harness.c
+++ b/src/test/SDL_test_harness.c
@@ -18,15 +18,9 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-
-#include "SDL_config.h"
-
 #include "SDL_test.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
+#include <stdlib.h>     /* Needed for exit() */
 
 /* Invalid test name/description message format */
 #define SDLTEST_INVALID_NAME_FORMAT "(Invalid)"

--- a/src/test/SDL_test_imageBlit.c
+++ b/src/test/SDL_test_imageBlit.c
@@ -18,8 +18,6 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
-
 #include "SDL_test.h"
 
 /* GIMP RGB C-Source image dump (blit.c) */

--- a/src/test/SDL_test_imageBlitBlend.c
+++ b/src/test/SDL_test_imageBlitBlend.c
@@ -18,8 +18,6 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
-
 #include "SDL_test.h"
 
 /* GIMP RGB C-Source image dump (alpha.c) */

--- a/src/test/SDL_test_imageFace.c
+++ b/src/test/SDL_test_imageFace.c
@@ -18,8 +18,6 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
-
 #include "SDL_test.h"
 
 /* GIMP RGBA C-Source image dump (face.c) */

--- a/src/test/SDL_test_imagePrimitives.c
+++ b/src/test/SDL_test_imagePrimitives.c
@@ -18,8 +18,6 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
-
 #include "SDL_test.h"
 
 /* GIMP RGB C-Source image dump (primitives.c) */

--- a/src/test/SDL_test_imagePrimitivesBlend.c
+++ b/src/test/SDL_test_imagePrimitivesBlend.c
@@ -18,8 +18,6 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
-
 #include "SDL_test.h"
 
 /* GIMP RGB C-Source image dump (alpha.c) */

--- a/src/test/SDL_test_log.c
+++ b/src/test/SDL_test_log.c
@@ -29,17 +29,10 @@
 #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
 # define _CRT_SECURE_NO_WARNINGS
 #endif
-
-#include "SDL_config.h"
-
-#include <stdarg.h> /* va_list */
-#include <stdio.h>
-#include <string.h>
-#include <time.h>
-
 #include "SDL.h"
-
 #include "SDL_test.h"
+
+#include <time.h>   /* Needed for localtime() */
 
 /* work around compiler warning on older GCCs. */
 #if (defined(__GNUC__) && (__GNUC__ <= 2))

--- a/src/test/SDL_test_md5.c
+++ b/src/test/SDL_test_md5.c
@@ -50,9 +50,6 @@
  ** documentation and/or software.                                    **
  ***********************************************************************
  */
-
-#include "SDL_config.h"
-
 #include "SDL_test.h"
 
 /* Forward declaration of static helper function */

--- a/src/test/SDL_test_memory.c
+++ b/src/test/SDL_test_memory.c
@@ -18,7 +18,6 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
 #include "SDL_assert.h"
 #include "SDL_stdinc.h"
 #include "SDL_log.h"

--- a/src/test/SDL_test_random.c
+++ b/src/test/SDL_test_random.c
@@ -27,14 +27,10 @@
  Original source code contributed by A. Schiffler for GSOC project.
 
 */
-
-#include "SDL_config.h"
-
-#include <stdlib.h>
-#include <stdio.h>
-#include <time.h>
-
 #include "SDL_test.h"
+
+#include <stdlib.h>     /* Needed for srand() and rand() */
+#include <time.h>       /* Needed for time() */
 
 /* Initialize random number generator with two integer variables */
 

--- a/src/thread/stdcpp/SDL_sysmutex_c.h
+++ b/src/thread/stdcpp/SDL_sysmutex_c.h
@@ -18,7 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
+#include "../../SDL_internal.h"
 
 #include <mutex>
 

--- a/src/thread/stdcpp/SDL_systhread_c.h
+++ b/src/thread/stdcpp/SDL_systhread_c.h
@@ -18,7 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
+#include "../../SDL_internal.h"
 
 /* For a thread handle, use a void pointer to a std::thread */
 typedef void * SYS_ThreadHandle;

--- a/src/video/winrt/SDL_winrtevents_c.h
+++ b/src/video/winrt/SDL_winrtevents_c.h
@@ -18,7 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
+#include "../../SDL_internal.h"
 
 extern "C" {
 #include "../SDL_sysvideo.h"

--- a/src/video/winrt/SDL_winrtgamebar_cpp.h
+++ b/src/video/winrt/SDL_winrtgamebar_cpp.h
@@ -18,7 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
+#include "../../SDL_internal.h"
 
 #ifndef SDL_winrtgamebar_h_
 #define SDL_winrtgamebar_h_

--- a/src/video/winrt/SDL_winrtmouse_c.h
+++ b/src/video/winrt/SDL_winrtmouse_c.h
@@ -18,7 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
+#include "../../SDL_internal.h"
 
 #ifndef SDL_winrtmouse_h_
 #define SDL_winrtmouse_h_

--- a/src/video/winrt/SDL_winrtopengles.h
+++ b/src/video/winrt/SDL_winrtopengles.h
@@ -18,7 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_config.h"
+#include "../../SDL_internal.h"
 
 #ifndef SDL_winrtopengles_h_
 #define SDL_winrtopengles_h_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(SDL3_test)
 
 include(CheckCCompilerFlag)
+include(CheckIncludeFile)
 include(CMakeParseArguments)
 include(CMakePushCheckState)
 
@@ -91,7 +92,17 @@ if(NOT MSVC OR NOT CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64")
 endif()
 
 if (OPENGL_FOUND)
-add_definitions(-DHAVE_OPENGL)
+    add_definitions(-DHAVE_OPENGL)
+endif()
+
+check_include_file(signal.h HAVE_SIGNAL_H)
+if (HAVE_SIGNAL_H)
+    add_definitions(-DHAVE_SIGNAL_H)
+endif()
+
+check_include_file(libudev.h HAVE_LIBUDEV_H)
+if (HAVE_LIBUDEV_H)
+    add_definitions(-DHAVE_LIBUDEV_H)
 endif()
 
 add_sdl_test_executable(checkkeys checkkeys.c)

--- a/test/checkkeys.c
+++ b/test/checkkeys.c
@@ -15,9 +15,7 @@
    pump the event loop and catch keystrokes.
 */
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>

--- a/test/checkkeysthreads.c
+++ b/test/checkkeysthreads.c
@@ -17,7 +17,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>

--- a/test/controllermap.c
+++ b/test/controllermap.c
@@ -15,12 +15,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include "SDL.h"
 #include "testutils.h"
-
-#ifndef SDL_JOYSTICK_DISABLED
 
 /* Define this for verbose output while mapping controllers */
 #define DEBUG_CONTROLLERMAP
@@ -811,16 +808,5 @@ main(int argc, char *argv[])
 
     return 0;
 }
-
-#else
-
-int
-main(int argc, char *argv[])
-{
-    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL compiled without Joystick support.\n");
-    return 1;
-}
-
-#endif
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/test/loopwave.c
+++ b/test/loopwave.c
@@ -15,9 +15,6 @@
 /* loopwaves.c is much more robust in handling WAVE files --
     This is only for simple WAVEs
 */
-#include "SDL_config.h"
-
-#include <stdio.h>
 #include <stdlib.h>
 
 #ifdef __EMSCRIPTEN__

--- a/test/loopwavequeue.c
+++ b/test/loopwavequeue.c
@@ -12,7 +12,6 @@
 
 /* Program to load a wave file and loop playing it using SDL sound queueing */
 
-#include <stdio.h>
 #include <stdlib.h>
 
 #ifdef __EMSCRIPTEN__

--- a/test/testatomic.c
+++ b/test/testatomic.c
@@ -9,8 +9,6 @@
   including commercial applications, and to alter it and redistribute it
   freely.
 */
-#include <stdio.h>
-
 #include "SDL.h"
 
 /*

--- a/test/testaudiocapture.c
+++ b/test/testaudiocapture.c
@@ -9,9 +9,10 @@
   including commercial applications, and to alter it and redistribute it
   freely.
 */
-#include "SDL.h"
 
 #include <stdlib.h>
+
+#include "SDL.h"
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
@@ -163,3 +164,4 @@ main(int argc, char **argv)
     return 0;
 }
 
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testaudiohotplug.c
+++ b/test/testaudiohotplug.c
@@ -12,9 +12,6 @@
 
 /* Program to test hotplugging of audio devices */
 
-#include "SDL_config.h"
-
-#include <stdio.h>
 #include <stdlib.h>
 
 #if HAVE_SIGNAL_H

--- a/test/testaudioinfo.c
+++ b/test/testaudioinfo.c
@@ -9,7 +9,6 @@
   including commercial applications, and to alter it and redistribute it
   freely.
 */
-#include <stdio.h>
 #include "SDL.h"
 
 static void
@@ -102,3 +101,5 @@ main(int argc, char **argv)
     SDL_Quit();
     return 0;
 }
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation.c
+++ b/test/testautomation.c
@@ -11,8 +11,6 @@
 */
 
 #include <stdlib.h>
-#include <stdio.h>
-#include <time.h>
 
 #include "SDL.h"
 #include "SDL_test.h"

--- a/test/testautomation_audio.c
+++ b/test/testautomation_audio.c
@@ -9,7 +9,6 @@
 #endif
 
 #include <stdio.h>
-#include <string.h>
 
 #include "SDL.h"
 #include "SDL_test.h"
@@ -1038,3 +1037,5 @@ SDLTest_TestSuiteReference audioTestSuite = {
     audioTests,
     _audioTearDown
 };
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation_clipboard.c
+++ b/test/testautomation_clipboard.c
@@ -1,10 +1,6 @@
 /**
  * New/updated tests: aschiffler at ferzkopp dot net
  */
-
-#include <stdio.h>
-#include <string.h>
-
 #include "SDL.h"
 #include "SDL_test.h"
 
@@ -334,3 +330,5 @@ SDLTest_TestSuiteReference clipboardTestSuite = {
     clipboardTests,
     NULL
 };
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation_events.c
+++ b/test/testautomation_events.c
@@ -1,9 +1,6 @@
 /**
  * Events test suite
  */
-
-#include <stdio.h>
-
 #include "SDL.h"
 #include "SDL_test.h"
 
@@ -199,3 +196,5 @@ SDLTest_TestSuiteReference eventsTestSuite = {
     eventsTests,
     NULL
 };
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation_guid.c
+++ b/test/testautomation_guid.c
@@ -148,3 +148,5 @@ SDLTest_TestSuiteReference guidTestSuite = {
     guidTests,
     NULL
 };
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation_hints.c
+++ b/test/testautomation_hints.c
@@ -2,8 +2,6 @@
  * Hints test suite
  */
 
-#include <stdio.h>
-
 #include "SDL.h"
 #include "SDL_test.h"
 
@@ -267,3 +265,5 @@ SDLTest_TestSuiteReference hintsTestSuite = {
     hintsTests,
     NULL
 };
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation_joystick.c
+++ b/test/testautomation_joystick.c
@@ -88,3 +88,5 @@ SDLTest_TestSuiteReference joystickTestSuite = {
     joystickTests,
     NULL
 };
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation_keyboard.c
+++ b/test/testautomation_keyboard.c
@@ -2,10 +2,6 @@
  * Keyboard test suite
  */
 
-#include <stdio.h>
-#include <limits.h>
-
-#include "SDL_config.h"
 #include "SDL.h"
 #include "SDL_test.h"
 
@@ -709,3 +705,5 @@ SDLTest_TestSuiteReference keyboardTestSuite = {
     keyboardTests,
     NULL
 };
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation_main.c
+++ b/test/testautomation_main.c
@@ -18,9 +18,6 @@
  */
 static int main_testInitQuitJoystickHaptic (void *arg)
 {
-#if defined SDL_JOYSTICK_DISABLED || defined SDL_HAPTIC_DISABLED
-    return TEST_SKIPPED;
-#else
     int enabled_subsystems;
     int initialized_subsystems = SDL_INIT_JOYSTICK | SDL_INIT_HAPTIC;
 
@@ -35,7 +32,6 @@ static int main_testInitQuitJoystickHaptic (void *arg)
     SDLTest_AssertCheck( enabled_subsystems == 0, "SDL_Quit should shut down everything (%i)", enabled_subsystems );
 
     return TEST_COMPLETED;
-#endif
 }
 
 /* !
@@ -46,9 +42,6 @@ static int main_testInitQuitJoystickHaptic (void *arg)
  */
 static int main_testInitQuitSubSystem (void *arg)
 {
-#if defined SDL_JOYSTICK_DISABLED || defined SDL_HAPTIC_DISABLED || defined SDL_GAMECONTROLLER_DISABLED
-    return TEST_SKIPPED;
-#else
     int i;
     int subsystems[] = { SDL_INIT_JOYSTICK, SDL_INIT_HAPTIC, SDL_INIT_GAMECONTROLLER };
 
@@ -68,15 +61,11 @@ static int main_testInitQuitSubSystem (void *arg)
     }
 
     return TEST_COMPLETED;
-#endif
 }
 
 const int joy_and_controller = SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER;
 static int main_testImpliedJoystickInit (void *arg)
 {
-#if defined SDL_JOYSTICK_DISABLED || defined SDL_GAMECONTROLLER_DISABLED
-    return TEST_SKIPPED;
-#else
     int initialized_system;
 
     /* First initialize the controller */
@@ -94,14 +83,10 @@ static int main_testImpliedJoystickInit (void *arg)
     SDLTest_AssertCheck( (initialized_system & joy_and_controller) == 0, "SDL_WasInit() should be false for joystick & controller (%x)", initialized_system );
 
     return TEST_COMPLETED;
-#endif
 }
 
 static int main_testImpliedJoystickQuit (void *arg)
 {
-#if defined SDL_JOYSTICK_DISABLED || defined SDL_GAMECONTROLLER_DISABLED
-    return TEST_SKIPPED;
-#else
     int initialized_system;
 
     /* First initialize the controller and the joystick (explicitly) */
@@ -122,7 +107,6 @@ static int main_testImpliedJoystickQuit (void *arg)
     SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
 
     return TEST_COMPLETED;
-#endif
 }
 
 #if defined(__GNUC__) || defined(__clang__)

--- a/test/testautomation_math.c
+++ b/test/testautomation_math.c
@@ -3349,4 +3349,11 @@ static const SDLTest_TestCaseReference *mathTests[] = {
     NULL
 };
 
-SDLTest_TestSuiteReference mathTestSuite = { "Math", NULL, mathTests, NULL };
+SDLTest_TestSuiteReference mathTestSuite = {
+    "Math",
+    NULL,
+    mathTests,
+    NULL
+};
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation_mouse.c
+++ b/test/testautomation_mouse.c
@@ -1,8 +1,6 @@
 /**
  * Mouse test suite
  */
-
-#include <stdio.h>
 #include <limits.h>
 
 #include "SDL.h"
@@ -655,3 +653,5 @@ SDLTest_TestSuiteReference mouseTestSuite = {
     mouseTests,
     NULL
 };
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation_pixels.c
+++ b/test/testautomation_pixels.c
@@ -1,9 +1,6 @@
 /**
  * Pixels test suite
  */
-
-#include <stdio.h>
-
 #include "SDL.h"
 #include "SDL_test.h"
 
@@ -424,3 +421,5 @@ SDLTest_TestSuiteReference pixelsTestSuite = {
     pixelsTests,
     NULL
 };
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation_platform.c
+++ b/test/testautomation_platform.c
@@ -2,9 +2,6 @@
  * Original code: automated SDL platform test written by Edgar Simo "bobbens"
  * Extended and updated by aschiffler at ferzkopp dot net
  */
-
-#include <stdio.h>
-
 #include "SDL.h"
 #include "SDL_test.h"
 
@@ -604,3 +601,5 @@ SDLTest_TestSuiteReference platformTestSuite = {
     platformTests,
     NULL
 };
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation_rect.c
+++ b/test/testautomation_rect.c
@@ -2,9 +2,6 @@
  * Original code: automated SDL rect test written by Edgar Simo "bobbens"
  * New/updated tests: aschiffler at ferzkopp dot net
  */
-
-#include <stdio.h>
-
 #include "SDL.h"
 #include "SDL_test.h"
 
@@ -1790,3 +1787,5 @@ SDLTest_TestSuiteReference rectTestSuite = {
     rectTests,
     NULL
 };
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation_render.c
+++ b/test/testautomation_render.c
@@ -2,9 +2,6 @@
  * Original code: automated SDL platform test written by Edgar Simo "bobbens"
  * Extended and extensively updated by aschiffler at ferzkopp dot net
  */
-
-#include <stdio.h>
-
 #include "SDL.h"
 #include "SDL_test.h"
 
@@ -1102,3 +1099,5 @@ SDLTest_TestSuiteReference renderTestSuite = {
     renderTests,
     CleanupDestroyRenderer
 };
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation_rwops.c
+++ b/test/testautomation_rwops.c
@@ -644,3 +644,5 @@ SDLTest_TestSuiteReference rwopsTestSuite = {
     rwopsTests,
     RWopsTearDown
 };
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation_sdltest.c
+++ b/test/testautomation_sdltest.c
@@ -3,21 +3,7 @@
  */
 
 #include <limits.h>
-/* Visual Studio 2008 doesn't have stdint.h */
-#if defined(_MSC_VER) && _MSC_VER <= 1500
-#define UINT8_MAX   _UI8_MAX
-#define UINT16_MAX  _UI16_MAX
-#define UINT32_MAX  _UI32_MAX
-#define INT64_MIN    _I64_MIN
-#define INT64_MAX    _I64_MAX
-#define UINT64_MAX  _UI64_MAX
-#else
-#include <stdint.h>
-#endif
-
-#include <stdio.h>
 #include <float.h>
-#include <ctype.h>
 
 #include "SDL.h"
 #include "SDL_test.h"
@@ -1316,3 +1302,5 @@ SDLTest_TestSuiteReference sdltestTestSuite = {
     sdltestTests,
     NULL
 };
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation_stdlib.c
+++ b/test/testautomation_stdlib.c
@@ -1,9 +1,6 @@
 /**
  * Standard C library routine test suite
  */
-
-#include <stdio.h>
-
 #include "SDL.h"
 #include "SDL_test.h"
 
@@ -599,3 +596,5 @@ SDLTest_TestSuiteReference stdlibTestSuite = {
     stdlibTests,
     NULL
 };
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation_surface.c
+++ b/test/testautomation_surface.c
@@ -824,3 +824,5 @@ SDLTest_TestSuiteReference surfaceTestSuite = {
     _surfaceTearDown
 
 };
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation_syswm.c
+++ b/test/testautomation_syswm.c
@@ -1,9 +1,6 @@
 /**
  * SysWM test suite
  */
-
-#include <stdio.h>
-
 #include "SDL.h"
 #include "SDL_syswm.h"
 #include "SDL_test.h"
@@ -56,3 +53,5 @@ SDLTest_TestSuiteReference syswmTestSuite = {
     syswmTests,
     NULL
 };
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation_timer.c
+++ b/test/testautomation_timer.c
@@ -1,9 +1,6 @@
 /**
  * Timer test suite
  */
-
-#include <stdio.h>
-
 #include "SDL.h"
 #include "SDL_test.h"
 
@@ -199,3 +196,5 @@ SDLTest_TestSuiteReference timerTestSuite = {
     timerTests,
     NULL
 };
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testautomation_video.c
+++ b/test/testautomation_video.c
@@ -1,20 +1,6 @@
 /**
  * Video test suite
  */
-
-#include <stdio.h>
-#include <string.h>
-
-/* Visual Studio 2008 doesn't have stdint.h */
-#if defined(_MSC_VER) && _MSC_VER <= 1500
-#define UINT8_MAX   ~(Uint8)0
-#define UINT16_MAX  ~(Uint16)0
-#define UINT32_MAX  ~(Uint32)0
-#define UINT64_MAX  ~(Uint64)0
-#else
-#include <stdint.h>
-#endif
-
 #include "SDL.h"
 #include "SDL_test.h"
 
@@ -1917,3 +1903,5 @@ SDLTest_TestSuiteReference videoTestSuite = {
     videoTests,
     NULL
 };
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testbounds.c
+++ b/test/testbounds.c
@@ -37,4 +37,3 @@ int main(int argc, char **argv)
 }
 
 /* vi: set ts=4 sw=4 expandtab: */
-

--- a/test/testcustomcursor.c
+++ b/test/testcustomcursor.c
@@ -9,9 +9,7 @@
   including commercial applications, and to alter it and redistribute it
   freely.
 */
-
 #include <stdlib.h>
-#include <stdio.h>
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>

--- a/test/testdisplayinfo.c
+++ b/test/testdisplayinfo.c
@@ -12,10 +12,9 @@
 
 /* Program to test querying of display info */
 
-#include "SDL.h"
-
-#include <stdio.h>
 #include <stdlib.h>
+
+#include "SDL.h"
 
 static void
 print_mode(const char *prefix, const SDL_DisplayMode *mode)
@@ -93,4 +92,3 @@ main(int argc, char *argv[])
 }
 
 /* vi: set ts=4 sw=4 expandtab: */
-

--- a/test/testdraw2.c
+++ b/test/testdraw2.c
@@ -13,7 +13,6 @@
 /* Simple program:  draw as many random objects on the screen as possible */
 
 #include <stdlib.h>
-#include <stdio.h>
 #include <time.h>
 
 #ifdef __EMSCRIPTEN__

--- a/test/testdrawchessboard.c
+++ b/test/testdrawchessboard.c
@@ -14,9 +14,6 @@
 
 /* Sample program:  Draw a Chess Board  by using SDL_CreateSoftwareRenderer API */
 
-#include <stdlib.h>
-#include <stdio.h>
-
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #endif
@@ -145,3 +142,4 @@ main(int argc, char *argv[])
     return 0;
 }
 
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testdropfile.c
+++ b/test/testdropfile.c
@@ -11,7 +11,6 @@
 */
 
 #include <stdlib.h>
-#include <stdio.h>
 
 #include "SDL_test_common.h"
 

--- a/test/testerror.c
+++ b/test/testerror.c
@@ -12,7 +12,6 @@
 
 /* Simple test of the SDL threading code and error handling */
 
-#include <stdio.h>
 #include <stdlib.h>
 
 #include "SDL.h"
@@ -80,3 +79,5 @@ main(int argc, char *argv[])
     SDL_Quit();
     return (0);
 }
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testevdev.c
+++ b/test/testevdev.c
@@ -18,6 +18,7 @@
 
 static int run_test(void);
 
+/* FIXME: Need CMake tests for this */
 #if HAVE_LIBUDEV_H || defined(SDL_JOYSTICK_LINUX)
 
 #include <stdint.h>
@@ -1039,3 +1040,5 @@ main(int argc, char *argv[])
 {
     return run_test() ? 0 : 1;
 }
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testfile.c
+++ b/test/testfile.c
@@ -15,6 +15,7 @@
 /* quiet windows compiler warnings */
 #define _CRT_NONSTDC_NO_WARNINGS
 
+#include <stdio.h>
 #include <stdlib.h>
 
 #ifndef _MSC_VER
@@ -23,8 +24,6 @@
 
 #include "SDL.h"
 
-
-#include <stdio.h>
 
 /* WARNING ! those 2 files will be destroyed by this test program */
 
@@ -281,3 +280,5 @@ main(int argc, char *argv[])
     cleanup();
     return 0;                   /* all ok */
 }
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testfilesystem.c
+++ b/test/testfilesystem.c
@@ -11,7 +11,6 @@
 */
 /* Simple test of filesystem functions. */
 
-#include <stdio.h>
 #include "SDL.h"
 
 int
@@ -58,3 +57,5 @@ main(int argc, char *argv[])
     SDL_Quit();
     return 0;
 }
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testgamecontroller.c
+++ b/test/testgamecontroller.c
@@ -12,18 +12,12 @@
 
 /* Simple program to test the SDL game controller routines */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
 #include "SDL.h"
 #include "testutils.h"
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #endif
-
-#ifndef SDL_JOYSTICK_DISABLED
 
 #define SCREEN_WIDTH    512
 #define SCREEN_HEIGHT   320
@@ -961,16 +955,5 @@ main(int argc, char *argv[])
 
     return 0;
 }
-
-#else
-
-int
-main(int argc, char *argv[])
-{
-    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL compiled without Joystick support.\n");
-    return 1;
-}
-
-#endif
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/test/testgeometry.c
+++ b/test/testgeometry.c
@@ -13,7 +13,6 @@
 /* Simple program:  draw a RGB triangle, with texture  */
 
 #include <stdlib.h>
-#include <stdio.h>
 #include <time.h>
 
 #ifdef __EMSCRIPTEN__

--- a/test/testgesture.c
+++ b/test/testgesture.c
@@ -16,8 +16,9 @@
  *  l to load all touches from "./gestureSave"
  */
 
-#include "SDL.h"
 #include <stdlib.h> /* for exit() */
+
+#include "SDL.h"
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
@@ -298,3 +299,4 @@ int main(int argc, char* argv[])
     return 0;
 }
 
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testgl2.c
+++ b/test/testgl2.c
@@ -9,18 +9,11 @@
   including commercial applications, and to alter it and redistribute it
   freely.
 */
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <math.h>
-
 #include "SDL_test_common.h"
 
-#ifdef __MACOS__
-#define HAVE_OPENGL
-#endif
-
 #ifdef HAVE_OPENGL
+
+#include <stdlib.h>
 
 #include "SDL_opengl.h"
 
@@ -436,3 +429,5 @@ main(int argc, char *argv[])
 }
 
 #endif /* HAVE_OPENGL */
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testgles.c
+++ b/test/testgles.c
@@ -10,9 +10,6 @@
   freely.
 */
 #include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <math.h>
 
 #include "SDL_test_common.h"
 

--- a/test/testgles2.c
+++ b/test/testgles2.c
@@ -10,9 +10,6 @@
   freely.
 */
 #include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <math.h>
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
@@ -21,9 +18,7 @@
 #include "SDL_test_common.h"
 
 #if defined(__IOS__) || defined(__ANDROID__) || defined(__EMSCRIPTEN__) || defined(__WINDOWS__) || defined(__LINUX__)
-#ifndef HAVE_OPENGLES2
 #define HAVE_OPENGLES2
-#endif
 #endif
 
 #ifdef HAVE_OPENGLES2
@@ -240,7 +235,6 @@ process_shader(GLuint *shader, const char * source, GLint shader_type)
         ctx.glGetShaderInfoLog(*shader, sizeof(buffer), &length, &buffer[0]);
         buffer[length] = '\0';
         SDL_Log("Shader compilation failed: %s", buffer);
-        fflush(stderr);
         quit(-1);
     }
 }
@@ -261,7 +255,6 @@ link_program(struct shader_data *data)
          ctx.glGetProgramInfoLog(data->shader_program, sizeof(buffer), &length, &buffer[0]);
          buffer[length] = '\0';
          SDL_Log("Program linking failed: %s", buffer);
-         fflush(stderr);
          quit(-1);
     }
 }

--- a/test/testgles2_sdf.c
+++ b/test/testgles2_sdf.c
@@ -10,9 +10,6 @@
   freely.
 */
 #include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <math.h>
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>

--- a/test/testhaptic.c
+++ b/test/testhaptic.c
@@ -14,9 +14,9 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 /*
  * includes
  */
-#include "SDL.h"
+#include <stdlib.h>
 
-#ifndef SDL_HAPTIC_DISABLED
+#include "SDL.h"
 
 static SDL_Haptic *haptic;
 
@@ -353,13 +353,4 @@ HapticPrintSupported(SDL_Haptic * ptr)
         SDL_Log("      status\n");
 }
 
-#else
-
-int
-main(int argc, char *argv[])
-{
-    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL compiled without Haptic support.\n");
-    return 1;
-}
-
-#endif
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testhittesting.c
+++ b/test/testhittesting.c
@@ -1,4 +1,14 @@
-#include <stdio.h>
+/*
+  Copyright (C) 1997-2022 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely.
+*/
 #include "SDL.h"
 
 /* !!! FIXME: rewrite this to be wired in to test framework. */
@@ -132,3 +142,5 @@ int main(int argc, char **argv)
     SDL_Quit();
     return 0;
 }
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testhotplug.c
+++ b/test/testhotplug.c
@@ -12,13 +12,9 @@
 
 /* Simple program to test the SDL joystick hotplugging */
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include "SDL.h"
-
-#if !defined SDL_JOYSTICK_DISABLED && !defined SDL_HAPTIC_DISABLED
 
 int
 main(int argc, char *argv[])
@@ -150,13 +146,5 @@ main(int argc, char *argv[])
 
     return 0;
 }
-#else
 
-int
-main(int argc, char *argv[])
-{
-    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL compiled without Joystick and haptic support.\n");
-    return 1;
-}
-
-#endif
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testiconv.c
+++ b/test/testiconv.c
@@ -95,3 +95,5 @@ main(int argc, char *argv[])
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Total errors: %d\n", errors);
     return (errors ? errors + 1 : 0);
 }
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testime.c
+++ b/test/testime.c
@@ -13,10 +13,6 @@
    If you build without SDL_ttf, you can use the GNU Unifont hex file instead.
    Download at http://unifoundry.com/unifont.html */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-
 #include "SDL.h"
 #ifdef HAVE_SDL_TTF
 #include "SDL_ttf.h"
@@ -805,6 +801,5 @@ int main(int argc, char *argv[])
     SDLTest_CommonQuit(state);
     return 0;
 }
-
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/test/testintersections.c
+++ b/test/testintersections.c
@@ -13,7 +13,6 @@
 /* Simple program:  draw as many random objects on the screen as possible */
 
 #include <stdlib.h>
-#include <stdio.h>
 #include <time.h>
 
 #ifdef __EMSCRIPTEN__

--- a/test/testjoystick.c
+++ b/test/testjoystick.c
@@ -12,17 +12,13 @@
 
 /* Simple program to test the SDL joystick routines */
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include "SDL.h"
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #endif
-
-#ifndef SDL_JOYSTICK_DISABLED
 
 #ifdef __IOS__
 #define SCREEN_WIDTH    320
@@ -325,16 +321,5 @@ main(int argc, char *argv[])
 
     return 0;
 }
-
-#else
-
-int
-main(int argc, char *argv[])
-{
-    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL compiled without Joystick support.\n");
-    return 1;
-}
-
-#endif
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/test/testkeys.c
+++ b/test/testkeys.c
@@ -12,10 +12,7 @@
 
 /* Print out all the scancodes we have, just to verify them */
 
-#include <stdio.h>
-#include <ctype.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include "SDL.h"
 
@@ -38,3 +35,5 @@ main(int argc, char *argv[])
     SDL_Quit();
     return (0);
 }
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testloadso.c
+++ b/test/testloadso.c
@@ -14,8 +14,6 @@
 */
 
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include "SDL.h"
 
@@ -80,3 +78,5 @@ main(int argc, char *argv[])
     SDL_Quit();
     return retval;
 }
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testlocale.c
+++ b/test/testlocale.c
@@ -9,7 +9,6 @@
   including commercial applications, and to alter it and redistribute it
   freely.
 */
-#include <stdio.h>
 #include "SDL.h"
 
 /* !!! FIXME: move this to the test framework */

--- a/test/testlock.c
+++ b/test/testlock.c
@@ -15,7 +15,6 @@
 */
 
 #include <signal.h>
-#include <stdio.h>
 #include <stdlib.h> /* for atexit() */
 
 #include "SDL.h"
@@ -126,3 +125,5 @@ main(int argc, char *argv[])
 
     return (0);                 /* Never reached */
 }
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testmessage.c
+++ b/test/testmessage.c
@@ -12,7 +12,6 @@
 
 /* Simple test of the SDL MessageBox API */
 
-#include <stdio.h>
 #include <stdlib.h>
 
 #include "SDL.h"
@@ -215,3 +214,5 @@ main(int argc, char *argv[])
     SDL_Quit();
     return (0);
 }
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testmultiaudio.c
+++ b/test/testmultiaudio.c
@@ -199,3 +199,5 @@ main(int argc, char **argv)
     SDL_Quit();
     return 0;
 }
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testnative.c
+++ b/test/testnative.c
@@ -11,7 +11,6 @@
 */
 /* Simple program:  Create a native window and attach an SDL renderer */
 
-#include <stdio.h>
 #include <stdlib.h> /* for srand() */
 #include <time.h> /* for time() */
 

--- a/test/testnativew32.c
+++ b/test/testnativew32.c
@@ -86,3 +86,5 @@ DestroyWindowNative(void *window)
 }
 
 #endif
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testnativex11.c
+++ b/test/testnativex11.c
@@ -53,3 +53,5 @@ DestroyWindowX11(void *window)
 }
 
 #endif
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testoffscreen.c
+++ b/test/testoffscreen.c
@@ -13,7 +13,6 @@
 /* Simple program: picks the offscreen backend and renders each frame to a bmp */
 
 #include <stdlib.h>
-#include <stdio.h>
 #include <time.h>
 
 #ifdef __EMSCRIPTEN__

--- a/test/testplatform.c
+++ b/test/testplatform.c
@@ -9,9 +9,6 @@
   including commercial applications, and to alter it and redistribute it
   freely.
 */
-
-#include <stdio.h>
-
 #include "SDL.h"
 
 /*
@@ -467,3 +464,5 @@ main(int argc, char *argv[])
 
     return status;
 }
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testpower.c
+++ b/test/testpower.c
@@ -11,7 +11,6 @@
 */
 /* Simple test of power subsystem. */
 
-#include <stdio.h>
 #include "SDL.h"
 
 static void
@@ -78,3 +77,5 @@ main(int argc, char *argv[])
 }
 
 /* end of testpower.c ... */
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testqsort.c
+++ b/test/testqsort.c
@@ -103,4 +103,3 @@ main(int argc, char *argv[])
 }
 
 /* vi: set ts=4 sw=4 expandtab: */
-

--- a/test/testrelative.c
+++ b/test/testrelative.c
@@ -13,7 +13,6 @@
 /* Simple program:  Test relative mouse motion */
 
 #include <stdlib.h>
-#include <stdio.h>
 #include <time.h>
 
 #include "SDL_test_common.h"

--- a/test/testrendercopyex.c
+++ b/test/testrendercopyex.c
@@ -12,8 +12,6 @@
 /* Simple program:  Move N sprites around on the screen as fast as possible */
 
 #include <stdlib.h>
-#include <stdio.h>
-#include <time.h>
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>

--- a/test/testrendertarget.c
+++ b/test/testrendertarget.c
@@ -12,8 +12,6 @@
 /* Simple program:  Move N sprites around on the screen as fast as possible */
 
 #include <stdlib.h>
-#include <stdio.h>
-#include <time.h>
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>

--- a/test/testresample.c
+++ b/test/testresample.c
@@ -118,3 +118,5 @@ main(int argc, char **argv)
 }                               /* main */
 
 /* end of testresample.c ... */
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testrumble.c
+++ b/test/testrumble.c
@@ -27,7 +27,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
  */
 #include "SDL.h"
 
-#ifndef SDL_HAPTIC_DISABLED
 
 static SDL_Haptic *haptic;
 
@@ -137,13 +136,4 @@ main(int argc, char **argv)
     return 0;
 }
 
-#else
-
-int
-main(int argc, char *argv[])
-{
-    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL compiled without Haptic support.\n");
-    return 1;
-}
-
-#endif
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testscale.c
+++ b/test/testscale.c
@@ -12,8 +12,6 @@
 /* Simple program:  Move N sprites around on the screen as fast as possible */
 
 #include <stdlib.h>
-#include <stdio.h>
-#include <time.h>
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>

--- a/test/testsem.c
+++ b/test/testsem.c
@@ -12,8 +12,6 @@
 
 /* Simple test of the SDL semaphore code */
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <signal.h>
 
 #include "SDL.h"
@@ -278,3 +276,5 @@ main(int argc, char **argv)
     SDL_Quit();
     return (0);
 }
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testsensor.c
+++ b/test/testsensor.c
@@ -119,3 +119,5 @@ main(int argc, char **argv)
     SDL_Quit();
     return (0);
 }
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testshader.c
+++ b/test/testshader.c
@@ -13,6 +13,8 @@
 
 #include "SDL.h"
 
+#include <stdlib.h>
+
 #ifdef HAVE_OPENGL
 
 #include "SDL_opengl.h"

--- a/test/testshape.c
+++ b/test/testshape.c
@@ -10,8 +10,7 @@
   freely.
 */
 #include <stdlib.h>
-#include <math.h>
-#include <stdio.h>
+
 #include "SDL.h"
 #include "SDL_shape.h"
 

--- a/test/testsprite2.c
+++ b/test/testsprite2.c
@@ -12,7 +12,6 @@
 /* Simple program:  Move N sprites around on the screen as fast as possible */
 
 #include <stdlib.h>
-#include <stdio.h>
 #include <time.h>
 
 #ifdef __EMSCRIPTEN__

--- a/test/testspriteminimal.c
+++ b/test/testspriteminimal.c
@@ -12,7 +12,6 @@
 /* Simple program:  Move N sprites around on the screen as fast as possible */
 
 #include <stdlib.h>
-#include <stdio.h>
 #include <time.h>
 
 #ifdef __EMSCRIPTEN__

--- a/test/teststreaming.c
+++ b/test/teststreaming.c
@@ -16,7 +16,6 @@
  ********************************************************************************/
 
 #include <stdlib.h>
-#include <stdio.h>
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>

--- a/test/testsurround.c
+++ b/test/testsurround.c
@@ -11,8 +11,6 @@
 */
 
 /* Program to test surround sound audio channels */
-#include "SDL_config.h"
-
 #include "SDL.h"
 
 static int total_channels;
@@ -203,3 +201,4 @@ main(int argc, char *argv[])
     return 0;
 }
 
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testthread.c
+++ b/test/testthread.c
@@ -12,7 +12,6 @@
 
 /* Simple test of the SDL threading code */
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <signal.h>
 
@@ -134,3 +133,5 @@ main(int argc, char *argv[])
     SDL_Quit();                 /* Never reached */
     return (0);                 /* Never reached */
 }
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testtimer.c
+++ b/test/testtimer.c
@@ -13,10 +13,6 @@
 /* Test program to check the resolution of the SDL timer on the current
    platform
 */
-
-#include <stdlib.h>
-#include <stdio.h>
-
 #include "SDL.h"
 
 #define DEFAULT_RESOLUTION  1

--- a/test/testutils.c
+++ b/test/testutils.c
@@ -149,3 +149,5 @@ LoadTexture(SDL_Renderer *renderer, const char *file, SDL_bool transparent,
     }
     return texture;
 }
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testver.c
+++ b/test/testver.c
@@ -13,10 +13,6 @@
 /* Test program to compare the compile-time version of SDL with the linked
    version of SDL
 */
-
-#include <stdio.h>
-#include <stdlib.h>
-
 #include "SDL.h"
 #include "SDL_revision.h"
 
@@ -45,3 +41,5 @@ main(int argc, char *argv[])
     SDL_Quit();
     return (0);
 }
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testviewport.c
+++ b/test/testviewport.c
@@ -12,8 +12,6 @@
 /* Simple program:  Check viewports */
 
 #include <stdlib.h>
-#include <stdio.h>
-#include <time.h>
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>

--- a/test/testvulkan.c
+++ b/test/testvulkan.c
@@ -10,9 +10,6 @@
   freely.
 */
 #include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <math.h>
 
 #include "SDL_test_common.h"
 
@@ -1150,3 +1147,5 @@ int main(int argc, char **argv)
 }
 
 #endif
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/test/testwm2.c
+++ b/test/testwm2.c
@@ -11,7 +11,6 @@
 */
 
 #include <stdlib.h>
-#include <stdio.h>
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>

--- a/test/testyuv.c
+++ b/test/testyuv.c
@@ -9,10 +9,6 @@
   including commercial applications, and to alter it and redistribute it
   freely.
 */
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-
 #include "SDL.h"
 #include "SDL_test_font.h"
 #include "testyuv_cvt.h"

--- a/test/torturethread.c
+++ b/test/torturethread.c
@@ -12,10 +12,8 @@
 
 /* Simple test of the SDL threading code */
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <signal.h>
-#include <string.h>
 
 #include "SDL.h"
 
@@ -111,3 +109,5 @@ main(int argc, char *argv[])
     SDL_Quit();
     return (0);
 }
+
+/* vi: set ts=4 sw=4 expandtab: */


### PR DESCRIPTION
The SDL headers are no longer dependent on the build configuration.