### PR TITLE
Add SDL_TriggerBreakpointFunction for platforms that use raise()

### DIFF
--- a/include/SDL_assert.h
+++ b/include/SDL_assert.h
@@ -47,6 +47,8 @@ on the assertion line and not in some random guts of SDL, and so each
 assert can have unique static variables associated with it.
 */
 
+extern DECLSPEC void SDLCALL SDL_TriggerBreakpointFunction(void);
+
 #if defined(_MSC_VER)
 /* Don't include intrin.h here because it contains C++ code */
     extern void __cdecl __debugbreak(void);
@@ -61,12 +63,9 @@ assert can have unique static variables associated with it.
     #define SDL_TriggerBreakpoint() __asm__ __volatile__ ( "bkpt #22\n\t" )
 #elif defined(__386__) && defined(__WATCOMC__)
     #define SDL_TriggerBreakpoint() { _asm { int 0x03 } }
-#elif defined(HAVE_SIGNAL_H) && !defined(__WATCOMC__)
-    #include <signal.h>
-    #define SDL_TriggerBreakpoint() raise(SIGTRAP)
 #else
-    /* How do we trigger breakpoints on this platform? */
-    #define SDL_TriggerBreakpoint()
+#define SDL_TRIGGER_BREAKPOINT_USES_FUNCTION
+    #define SDL_TriggerBreakpoint() SDL_TriggerBreakpointFunction()
 #endif
 
 #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 supports __func__ as a standard. */

--- a/src/SDL_assert.c
+++ b/src/SDL_assert.c
@@ -42,6 +42,10 @@
 #include <emscripten.h>
 #endif
 
+#if defined(HAVE_SIGNAL_H)
+#include <signal.h>
+#endif
+
 /* The size of the stack buffer to use for rendering assert messages. */
 #define SDL_MAX_ASSERT_MESSAGE_STACK 256
 
@@ -460,6 +464,17 @@ SDL_AssertionHandler SDL_GetAssertionHandler(void **userdata)
         *userdata = assertion_userdata;
     }
     return assertion_handler;
+}
+
+void SDL_TriggerBreakpointFunction()
+{
+#ifndef SDL_TRIGGER_BREAKPOINT_USES_FUNCTION
+    SDL_TriggerBreakpoint();
+#elif defined(HAVE_SIGNAL_H) && !defined(__WATCOMC__)
+    raise(SIGTRAP);
+#else
+#warning How do we trigger breakpoints on this platform?
+#endif
 }
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -893,3 +893,4 @@
 #define SDL_GDKSuspendComplete SDL_GDKSuspendComplete_REAL
 #define SDL_GetWindowWMInfo SDL_GetWindowWMInfo_REAL
 #define SDL_memset4 SDL_memset4_REAL
+#define SDL_TriggerBreakpointFunction SDL_TriggerBreakpointFunction_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -969,3 +969,4 @@ SDL_DYNAPI_PROC(void,SDL_GDKSuspendComplete,(void),(),return)
 #endif
 SDL_DYNAPI_PROC(int,SDL_GetWindowWMInfo,(SDL_Window *a, SDL_SysWMinfo *b, Uint32 c),(a,b,c),return)
 SDL_DYNAPI_PROC(void*,SDL_memset4,(void *a, Uint32 b, size_t c),(a,b,c),return)
+SDL_DYNAPI_PROC(void,SDL_TriggerBreakpointFunction,(void),(),)


### PR DESCRIPTION
`HAVE_SIGNAL_H` is no longer defined in the public headers.