### PR TITLE
Update WhatsNew.txt with removed hints.

### DIFF
--- a/WhatsNew.txt
+++ b/WhatsNew.txt
@@ -19,4 +19,9 @@ General:
 	* SDL_RWFromFP()
 	* SDL_SetWindowBrightness()
 	* SDL_SetWindowGammaRamp()
+* Removed the following hints from the API:
+	* SDL_HINT_IDLE_TIMER_DISABLED
+	* SDL_HINT_VIDEO_X11_FORCE_EGL
+	* SDL_HINT_VIDEO_X11_XINERAMA
+	* SDL_HINT_VIDEO_X11_XVIDMODE
 * SDL_stdinc.h no longer includes stdio.h, stdlib.h, etc., it only provides the SDL C runtime functionality


### PR DESCRIPTION
## Description
SDL2 hints that are removed in SDL3 weren't listed in WhatsNew.txt before this change.

## Existing Issue(s)
Followup of https://github.com/libsdl-org/SDL/pull/6671#issuecomment-1328283945
