### PR TITLE
Solaris getexecname() returns argv[0]; consider using procfs instead.

### DIFF
--- a/src/filesystem/unix/SDL_sysfilesystem.c
+++ b/src/filesystem/unix/SDL_sysfilesystem.c
@@ -199,16 +199,6 @@ SDL_GetBasePath(void)
         SDL_free(cmdline);
     }
 #endif
-#if defined(__SOLARIS__)
-    const char *path = getexecname();
-    if ((path != NULL) && (path[0] == '/')) { /* must be absolute path... */
-        retval = SDL_strdup(path);
-        if (retval == NULL) {
-            SDL_OutOfMemory();
-            return NULL;
-        }
-    }
-#endif
 
     /* is a Linux-style /proc filesystem available? */
     if (retval == NULL && (access("/proc", F_OK) == 0)) {
@@ -219,6 +209,8 @@ SDL_GetBasePath(void)
         retval = readSymLink("/proc/curproc/file");
 #elif defined(__NETBSD__)
         retval = readSymLink("/proc/curproc/exe");
+#elif defined(__SOLARIS__)
+        retval = readSymLink("/proc/self/path/a.out");
 #else
         retval = readSymLink("/proc/self/exe");  /* linux. */
         if (retval == NULL) {
@@ -233,7 +225,18 @@ SDL_GetBasePath(void)
         }
 #endif
     }
-
+#if defined(__SOLARIS__)
+    else {
+        const char *path = getexecname();
+        if ((path != NULL) && (path[0] == '/')) { /* must be absolute path... */
+            retval = SDL_strdup(path);
+            if (retval == NULL) {
+                SDL_OutOfMemory();
+                return NULL;
+            }
+        }
+    }
+#endif
     /* If we had access to argv[0] here, we could check it for a path,
         or troll through $PATH looking for it, too. */
 


### PR DESCRIPTION
`argv[0]`/`getexexname()` are not always absolute paths by default and can be modified to anything the developer wants them to be. Consider using `readSymLink("/proc/self/path/a.out")` instead and `getexecname()` as the fallback, since the symlink will always be the correct absolute path (unless `/proc` is not mounted, but it is by default on Solaris and Illumos platforms).

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
