### PR TITLE
thread: fix inconsistent return values

### DIFF
--- a/src/thread/n3ds/SDL_syssem.c
+++ b/src/thread/n3ds/SDL_syssem.c
@@ -113,7 +113,8 @@ Uint32
 SDL_SemValue(SDL_sem *sem)
 {
     if (sem == NULL) {
-        return SDL_InvalidParamError("sem");
+        SDL_InvalidParamError("sem");
+        return 0;
     }
     return sem->semaphore.current_count;
 }

--- a/src/thread/ngage/SDL_sysmutex.cpp
+++ b/src/thread/ngage/SDL_sysmutex.cpp
@@ -47,6 +47,7 @@ SDL_CreateMutex(void)
     TInt status = CreateUnique(NewMutex, &rmutex, NULL);
     if (status != KErrNone) {
         SDL_SetError("Couldn't create mutex.");
+        return NULL;
     }
     SDL_mutex* mutex = new /*(ELeave)*/ SDL_mutex;
     mutex->handle = rmutex.Handle();


### PR DESCRIPTION
- SDL_CreateMutex returns NULL when the creation fails (ngage)
- SDL_SemValue returns 0 when the semaphore is NULL (n3ds)