### PR TITLE
video: fix error messages

### DIFF
--- a/src/video/SDL_pixels.c
+++ b/src/video/SDL_pixels.c
@@ -528,7 +528,6 @@ SDL_AllocFormat(Uint32 pixel_format)
     if (SDL_InitFormat(format, pixel_format) < 0) {
         SDL_AtomicUnlock(&formats_lock);
         SDL_free(format);
-        SDL_InvalidParamError("format");
         return NULL;
     }
 
@@ -669,6 +668,7 @@ SDL_AllocPalette(int ncolors)
         (SDL_Color *) SDL_malloc(ncolors * sizeof(*palette->colors));
     if (!palette->colors) {
         SDL_free(palette);
+        SDL_OutOfMemory();
         return NULL;
     }
     palette->ncolors = ncolors;

--- a/src/video/cocoa/SDL_cocoametalview.m
+++ b/src/video/cocoa/SDL_cocoametalview.m
@@ -145,6 +145,7 @@ Cocoa_Metal_CreateView(_THIS, SDL_Window * window)
                                                 highDPI:highDPI
                                                 windowID:windowID];
     if (newview == nil) {
+        SDL_OutOfMemory();
         return NULL;
     }
 

--- a/src/video/uikit/SDL_uikitmetalview.m
+++ b/src/video/uikit/SDL_uikitmetalview.m
@@ -94,6 +94,11 @@ UIKit_Metal_CreateView(_THIS, SDL_Window * window)
 
     metalview = [[SDL_uikitmetalview alloc] initWithFrame:data.uiwindow.bounds
                                                     scale:scale];
+    if (metalview == nil) {
+        SDL_OutOfMemory();
+        return NULL;
+    }
+
     [metalview setSDLWindow:window];
 
     return (void*)CFBridgingRetain(metalview);


### PR DESCRIPTION
- do not overwrite error message set by SDL_InitFormat (SDL_AllocFormat)
- set proper error message (SDL_AllocPalette + Cocoa_Metal_CreateView)
- protect against allocation failure (UIKit_Metal_CreateView)