### PR TITLE
Detect Logitech PRO Racing Wheel as wheel

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -2342,6 +2342,8 @@ static SDL_bool SDL_IsJoystickProductWheel(Uint32 vidpid)
         MAKE_VIDPID(0x046d, 0xc260), /* Logitech G29 (PS4) */
         MAKE_VIDPID(0x046d, 0xc261), /* Logitech G920 (initial mode) */
         MAKE_VIDPID(0x046d, 0xc262), /* Logitech G920 (active mode) */
+        MAKE_VIDPID(0x046d, 0xc268), /* Logitech PRO Racing Wheel (PC mode) */
+        MAKE_VIDPID(0x046d, 0xc269), /* Logitech PRO Racing Wheel (PS4/PS5 mode) */
         MAKE_VIDPID(0x046d, 0xc26d), /* Logitech G923 (Xbox) */
         MAKE_VIDPID(0x046d, 0xc26e), /* Logitech G923 */
         MAKE_VIDPID(0x046d, 0xca03), /* Logitech Momo Racing */


### PR DESCRIPTION
This adds the missing vendor + product id for the Logitech PRO Racing Wheel  in PC and PS4/PS5 mode.
