### PR TITLE
wayland: Pass event timestamps to SDL

### DIFF
--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -133,6 +133,9 @@ struct SDL_WaylandInput
 
         enum SDL_WaylandAxisEvent y_axis_type;
         float y;
+
+        /* Event timestamp in milliseconds */
+        Uint32 timestamp;
     } pointer_curr_axis_info;
 
     SDL_WaylandKeyboardRepeat keyboard_repeat;
@@ -145,6 +148,8 @@ struct SDL_WaylandInput
     SDL_bool warp_emulation_prohibited;
     SDL_bool keyboard_is_virtual;
 };
+
+extern Uint64 Wayland_GetEventTimestamp(Uint32 wayland_timestamp);
 
 extern void Wayland_PumpEvents(_THIS);
 extern void Wayland_SendWakeupEvent(_THIS, SDL_Window *window);

--- a/src/video/wayland/SDL_waylandtouch.c
+++ b/src/video/wayland/SDL_waylandtouch.c
@@ -26,6 +26,7 @@
 #ifdef SDL_VIDEO_DRIVER_WAYLAND_QT_TOUCH
 
 #include "SDL_waylandtouch.h"
+#include "SDL_waylandevents_c.h"
 #include "../../events/SDL_touch_c.h"
 
 struct SDL_WaylandTouch
@@ -104,12 +105,13 @@ static void touch_handle_touch(void *data,
     switch (touchState) {
     case QtWaylandTouchPointPressed:
     case QtWaylandTouchPointReleased:
-        SDL_SendTouch(0, deviceId, (SDL_FingerID)id, window,
+        SDL_SendTouch(Wayland_GetEventTimestamp(time), deviceId, (SDL_FingerID)id, window,
                       (touchState == QtWaylandTouchPointPressed) ? SDL_TRUE : SDL_FALSE,
                       xf, yf, pressuref);
         break;
     case QtWaylandTouchPointMoved:
-        SDL_SendTouchMotion(0, deviceId, (SDL_FingerID)id, window, xf, yf, pressuref);
+        SDL_SendTouchMotion(Wayland_GetEventTimestamp(time), deviceId, (SDL_FingerID)id, window,
+                            xf, yf, pressuref);
         break;
     default:
         /* Should not happen */


### PR DESCRIPTION
SDL events support system timestamps now, so pass them through.  This just wires up basic functionality, higher resolution event handling will come later.

Closes #6738 

One issue: On line 483, a pointer movement event is generated when the pointer enters the window, however, there is no system timestamp provided for this event so the default 'now' value is used, which creates an anomaly in the subsequent pointer movement timestamps.   The movement events that follow the enter event have older timestamps even though they are actually newer.

Does this fake movement event still need to be there, or was this to fix a bug in an old version of some compositor and is no longer required?  Any other suggestions for dealing with this issue?
