### PR TITLE
wayland: Fix event timestamp wrap detection

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -175,7 +175,7 @@ static struct wl_surface *touch_surface(SDL_TouchID id)
 
 Uint64 Wayland_GetEventTimestamp(Uint32 wayland_timestamp)
 {
-    static Uint32 last;
+    static Uint64 last;
     static Uint64 timestamp_offset;
     Uint64 nsTimestamp = SDL_MS_TO_NS(wayland_timestamp);
     const Uint64 now = SDL_GetTicksNS();


### PR DESCRIPTION
The previous timestamp value needs to be 64-bit since it's stored as nanoseconds instead of milliseconds.
