### PR TITLE
wayland: Add high-resolution event timestamp support

### DIFF
--- a/src/video/wayland/SDL_waylandtouch.c
+++ b/src/video/wayland/SDL_waylandtouch.c
@@ -71,6 +71,8 @@ static void touch_handle_touch(void *data,
      * (src/compositor/wayland_wrapper/qwltouch.cpp)
      **/
 
+    SDL_VideoData *viddata = (SDL_VideoData *)data;
+
     float FIXED_TO_FLOAT = 1. / 10000.;
     float xf = FIXED_TO_FLOAT * normalized_x;
     float yf = FIXED_TO_FLOAT * normalized_y;
@@ -105,13 +107,12 @@ static void touch_handle_touch(void *data,
     switch (touchState) {
     case QtWaylandTouchPointPressed:
     case QtWaylandTouchPointReleased:
-        SDL_SendTouch(Wayland_GetEventTimestamp(time), deviceId, (SDL_FingerID)id, window,
-                      (touchState == QtWaylandTouchPointPressed) ? SDL_TRUE : SDL_FALSE,
-                      xf, yf, pressuref);
+        SDL_SendTouch(Wayland_GetTouchTimestamp(viddata->input, time), deviceId, (SDL_FingerID)id,
+                      window, (touchState == QtWaylandTouchPointPressed) ? SDL_TRUE : SDL_FALSE, xf, yf, pressuref);
         break;
     case QtWaylandTouchPointMoved:
-        SDL_SendTouchMotion(Wayland_GetEventTimestamp(time), deviceId, (SDL_FingerID)id, window,
-                            xf, yf, pressuref);
+        SDL_SendTouchMotion(Wayland_GetTouchTimestamp(viddata->input, time), deviceId, (SDL_FingerID)id,
+                            window, xf, yf, pressuref);
         break;
     default:
         /* Should not happen */

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -53,6 +53,7 @@
 #include "viewporter-client-protocol.h"
 #include "primary-selection-unstable-v1-client-protocol.h"
 #include "fractional-scale-v1-client-protocol.h"
+#include "input-timestamps-unstable-v1-client-protocol.h"
 
 #ifdef HAVE_LIBDECOR_H
 #include <libdecor.h>
@@ -849,6 +850,11 @@ static void display_handle_global(void *data, struct wl_registry *registry, uint
         d->viewporter = wl_registry_bind(d->registry, id, &wp_viewporter_interface, 1);
     } else if (SDL_strcmp(interface, "wp_fractional_scale_manager_v1") == 0) {
         d->fractional_scale_manager = wl_registry_bind(d->registry, id, &wp_fractional_scale_manager_v1_interface, 1);
+    } else if (SDL_strcmp(interface, "zwp_input_timestamps_manager_v1") == 0) {
+        d->input_timestamps_manager = wl_registry_bind(d->registry, id, &zwp_input_timestamps_manager_v1_interface, 1);
+        if (d->input) {
+            Wayland_RegisterTimestampListeners(d->input);
+        }
 #ifdef SDL_VIDEO_DRIVER_WAYLAND_QT_TOUCH
     } else if (SDL_strcmp(interface, "qt_touch_extension") == 0) {
         Wayland_touch_create(d, id);
@@ -1097,6 +1103,11 @@ static void Wayland_VideoCleanup(_THIS)
     if (data->fractional_scale_manager) {
         wp_fractional_scale_manager_v1_destroy(data->fractional_scale_manager);
         data->fractional_scale_manager = NULL;
+    }
+
+    if (data->input_timestamps_manager) {
+        zwp_input_timestamps_manager_v1_destroy(data->input_timestamps_manager);
+        data->input_timestamps_manager = NULL;
     }
 
     if (data->compositor) {

--- a/src/video/wayland/SDL_waylandvideo.h
+++ b/src/video/wayland/SDL_waylandvideo.h
@@ -79,6 +79,7 @@ typedef struct
     struct zxdg_output_manager_v1 *xdg_output_manager;
     struct wp_viewporter *viewporter;
     struct wp_fractional_scale_manager_v1 *fractional_scale_manager;
+    struct zwp_input_timestamps_manager_v1 *input_timestamps_manager;
 
     EGLDisplay edpy;
     EGLContext context;

--- a/wayland-protocols/input-timestamps-unstable-v1.xml
+++ b/wayland-protocols/input-timestamps-unstable-v1.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="input_timestamps_unstable_v1">
+
+  <copyright>
+    Copyright © 2017 Collabora, Ltd.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="High-resolution timestamps for input events">
+    This protocol specifies a way for a client to request and receive
+    high-resolution timestamps for input events.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible changes
+    may be added together with the corresponding interface version bump.
+    Backward incompatible changes are done by bumping the version number in
+    the protocol and interface names and resetting the interface version.
+    Once the protocol is to be declared stable, the 'z' prefix and the
+    version number in the protocol and interface names are removed and the
+    interface version number is reset.
+  </description>
+
+  <interface name="zwp_input_timestamps_manager_v1" version="1">
+    <description summary="context object for high-resolution input timestamps">
+      A global interface used for requesting high-resolution timestamps
+      for input events.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the input timestamps manager object">
+        Informs the server that the client will no longer be using this
+        protocol object. Existing objects created by this object are not
+        affected.
+      </description>
+    </request>
+
+    <request name="get_keyboard_timestamps">
+      <description summary="subscribe to high-resolution keyboard timestamp events">
+        Creates a new input timestamps object that represents a subscription
+        to high-resolution timestamp events for all wl_keyboard events that
+        carry a timestamp.
+
+        If the associated wl_keyboard object is invalidated, either through
+        client action (e.g. release) or server-side changes, the input
+        timestamps object becomes inert and the client should destroy it
+        by calling zwp_input_timestamps_v1.destroy.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_input_timestamps_v1"/>
+      <arg name="keyboard" type="object" interface="wl_keyboard"
+           summary="the wl_keyboard object for which to get timestamp events"/>
+    </request>
+
+    <request name="get_pointer_timestamps">
+      <description summary="subscribe to high-resolution pointer timestamp events">
+        Creates a new input timestamps object that represents a subscription
+        to high-resolution timestamp events for all wl_pointer events that
+        carry a timestamp.
+
+        If the associated wl_pointer object is invalidated, either through
+        client action (e.g. release) or server-side changes, the input
+        timestamps object becomes inert and the client should destroy it
+        by calling zwp_input_timestamps_v1.destroy.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_input_timestamps_v1"/>
+      <arg name="pointer" type="object" interface="wl_pointer"
+           summary="the wl_pointer object for which to get timestamp events"/>
+    </request>
+
+    <request name="get_touch_timestamps">
+      <description summary="subscribe to high-resolution touch timestamp events">
+        Creates a new input timestamps object that represents a subscription
+        to high-resolution timestamp events for all wl_touch events that
+        carry a timestamp.
+
+        If the associated wl_touch object becomes invalid, either through
+        client action (e.g. release) or server-side changes, the input
+        timestamps object becomes inert and the client should destroy it
+        by calling zwp_input_timestamps_v1.destroy.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_input_timestamps_v1"/>
+      <arg name="touch" type="object" interface="wl_touch"
+           summary="the wl_touch object for which to get timestamp events"/>
+    </request>
+  </interface>
+
+  <interface name="zwp_input_timestamps_v1" version="1">
+    <description summary="context object for input timestamps">
+      Provides high-resolution timestamp events for a set of subscribed input
+      events. The set of subscribed input events is determined by the
+      zwp_input_timestamps_manager_v1 request used to create this object.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the input timestamps object">
+        Informs the server that the client will no longer be using this
+        protocol object. After the server processes the request, no more
+        timestamp events will be emitted.
+      </description>
+    </request>
+
+    <event name="timestamp">
+      <description summary="high-resolution timestamp event">
+        The timestamp event is associated with the first subsequent input event
+        carrying a timestamp which belongs to the set of input events this
+        object is subscribed to.
+
+        The timestamp provided by this event is a high-resolution version of
+        the timestamp argument of the associated input event. The provided
+        timestamp is in the same clock domain and is at least as accurate as
+        the associated input event timestamp.
+
+        The timestamp is expressed as tv_sec_hi, tv_sec_lo, tv_nsec triples,
+        each component being an unsigned 32-bit value. Whole seconds are in
+        tv_sec which is a 64-bit value combined from tv_sec_hi and tv_sec_lo,
+        and the additional fractional part in tv_nsec as nanoseconds. Hence,
+        for valid timestamps tv_nsec must be in [0, 999999999].
+      </description>
+      <arg name="tv_sec_hi" type="uint"
+           summary="high 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_sec_lo" type="uint"
+           summary="low 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_nsec" type="uint"
+           summary="nanoseconds part of the timestamp"/>
+    </event>
+  </interface>
+
+</protocol>


### PR DESCRIPTION
Add the protocol for high-resolution timestamp events and subscribe to them if available.

Event timestamps are now handled natively in nanoseconds as much as possible to avoid error-prone conversions.

Variables have been appended with _ms or _ns where appropriate, to avoid ambiguity.
