### PR TITLE
Add window title to app_ids for different

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -1270,7 +1270,11 @@ void Wayland_ShowWindow(_THIS, SDL_Window *window)
             }
         } else {
             data->shell_surface.xdg.roleobj.toplevel = xdg_surface_get_toplevel(data->shell_surface.xdg.surface);
-            xdg_toplevel_set_app_id(data->shell_surface.xdg.roleobj.toplevel, c->classname);
+            if (c->classname != NULL) {
+                xdg_toplevel_set_app_id(data->shell_surface.xdg.roleobj.toplevel, c->classname);
+            } else {
+                xdg_toplevel_set_app_id(data->shell_surface.xdg.roleobj.toplevel, window->title);
+            }
             xdg_toplevel_add_listener(data->shell_surface.xdg.roleobj.toplevel, &toplevel_listener_xdg, data);
         }
     }


### PR DESCRIPTION
"app_ids" can be used for multiple windows

Signed-off-by: Lei.Huang <leihuang@amd.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
 Currently, classname is used. Only one name can be set for a process, which cannot support multiple windows。
 Added a method to set the appid, which is set through the sdl window title 

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
