### PR TITLE
bug fix add sync geometry to xdg_surface

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -528,6 +528,7 @@ static void handle_configure_xdg_shell_surface(void *data, struct xdg_surface *x
     SDL_WindowData *wind = (SDL_WindowData *)data;
     SDL_Window *window = wind->sdlwindow;
 
+    xdg_surface_set_window_geometry(xdg, 0, 0, window->w, window->h);
     Wayland_HandleResize(window, window->w, window->h, wind->scale_factor);
     xdg_surface_ack_configure(xdg, serial);
 


### PR DESCRIPTION
When connecting multiple screens with different

resolutions,create windows on each screen, and

we need synchronize the current window size to

xdg_surface geometry,otherwise xdg_surface geometry

will use the default。

Signed-off-by: Lei.Huang <leihuang@amd.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
[why]
When connecting multiple screens with different resolutions, create windows on each screen, and we need synchronize the current window size to xdg_surface geometry。
otherwise xdg_surface geometry  will use the default。
As a result, three screens are connected, one with 4k resolution, two with 1080p resolution, and two with 1080p resolution are distributed to the androd vm. The following errors will occur when xen starts.
xdg_wm_base@19: error 4: xdg_surface geometry (3840 x 2160) is larger than the configured fullscreen state (1920 x 1080)。
[how]
Add synchronize the current window size to xdg_surface geometry.
## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
