### PR TITLE
Fix warnings 'macro argument should be enclosed in parentheses'

### DIFF
--- a/src/audio/SDL_mixer.c
+++ b/src/audio/SDL_mixer.c
@@ -78,9 +78,9 @@ static const Uint8 mix8[] = {
 };
 
 /* The volume ranges from 0 - 128 */
-#define ADJUST_VOLUME(s, v)     (s = (s * v) / SDL_MIX_MAXVOLUME)
-#define ADJUST_VOLUME_U8(s, v)  (s = (((s - 128) * v) / SDL_MIX_MAXVOLUME) + 128)
-#define ADJUST_VOLUME_U16(s, v) (s = (((s - 32768) * v) / SDL_MIX_MAXVOLUME) + 32768)
+#define ADJUST_VOLUME(s, v)     ((s) = ((s) * (v)) / SDL_MIX_MAXVOLUME)
+#define ADJUST_VOLUME_U8(s, v)  ((s) = ((((s) - 128) * (v)) / SDL_MIX_MAXVOLUME) + 128)
+#define ADJUST_VOLUME_U16(s, v) ((s) = ((((s) - 32768) * (v)) / SDL_MIX_MAXVOLUME) + 32768)
 
 void SDL_MixAudioFormat(Uint8 *dst, const Uint8 *src, SDL_AudioFormat format,
                         Uint32 len, int volume)

--- a/src/core/openbsd/SDL_wscons_kbd.c
+++ b/src/core/openbsd/SDL_wscons_kbd.c
@@ -41,7 +41,7 @@
 #endif
 
 #define RETIFIOCTLERR(x) \
-    if (x == -1) {       \
+    if ((x) == -1) {     \
         free(input);     \
         input = NULL;    \
         return NULL;     \

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -956,7 +956,7 @@ static Uint32 SDL_GetCPUFeatures(void)
     return SDL_CPUFeatures;
 }
 
-#define CPU_FEATURE_AVAILABLE(f) ((SDL_GetCPUFeatures() & f) ? SDL_TRUE : SDL_FALSE)
+#define CPU_FEATURE_AVAILABLE(f) ((SDL_GetCPUFeatures() & (f)) ? SDL_TRUE : SDL_FALSE)
 
 SDL_bool SDL_HasRDTSC(void)
 {

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -44,27 +44,27 @@ this should probably be removed at some point in the future.  --ryan. */
 
 #define SDL_WINDOWRENDERDATA "_SDL_WindowRenderData"
 
-#define CHECK_RENDERER_MAGIC(renderer, retval)             \
-    if (!renderer || renderer->magic != &renderer_magic) { \
-        SDL_InvalidParamError("renderer");                 \
-        return retval;                                     \
+#define CHECK_RENDERER_MAGIC(renderer, retval)                  \
+    if (!(renderer) || (renderer)->magic != &renderer_magic) {  \
+        SDL_InvalidParamError("renderer");                      \
+        return retval;                                          \
     }
 
-#define CHECK_TEXTURE_MAGIC(texture, retval)            \
-    if (!texture || texture->magic != &texture_magic) { \
-        SDL_InvalidParamError("texture");               \
-        return retval;                                  \
+#define CHECK_TEXTURE_MAGIC(texture, retval)                    \
+    if (!(texture) || (texture)->magic != &texture_magic) {     \
+        SDL_InvalidParamError("texture");                       \
+        return retval;                                          \
     }
 
 /* Predefined blend modes */
 #define SDL_COMPOSE_BLENDMODE(srcColorFactor, dstColorFactor, colorOperation, \
                               srcAlphaFactor, dstAlphaFactor, alphaOperation) \
-    (SDL_BlendMode)(((Uint32)colorOperation << 0) |                           \
-                    ((Uint32)srcColorFactor << 4) |                           \
-                    ((Uint32)dstColorFactor << 8) |                           \
-                    ((Uint32)alphaOperation << 16) |                          \
-                    ((Uint32)srcAlphaFactor << 20) |                          \
-                    ((Uint32)dstAlphaFactor << 24))
+    (SDL_BlendMode)(((Uint32)(colorOperation) << 0) |                         \
+                    ((Uint32)(srcColorFactor) << 4) |                         \
+                    ((Uint32)(dstColorFactor) << 8) |                         \
+                    ((Uint32)(alphaOperation) << 16) |                        \
+                    ((Uint32)(srcAlphaFactor) << 20) |                        \
+                    ((Uint32)(dstAlphaFactor) << 24))
 
 #define SDL_BLENDMODE_NONE_FULL                                                              \
     SDL_COMPOSE_BLENDMODE(SDL_BLENDFACTOR_ONE, SDL_BLENDFACTOR_ZERO, SDL_BLENDOPERATION_ADD, \
@@ -3048,10 +3048,10 @@ int SDL_RenderDrawLinesF(SDL_Renderer *renderer,
                 *ptr_xy++ = q.x;
                 *ptr_xy++ = q.y + scale_y;
 
-#define ADD_TRIANGLE(i1, i2, i3)     \
-    *ptr_indices++ = cur_index + i1; \
-    *ptr_indices++ = cur_index + i2; \
-    *ptr_indices++ = cur_index + i3; \
+#define ADD_TRIANGLE(i1, i2, i3)        \
+    *ptr_indices++ = cur_index + (i1);  \
+    *ptr_indices++ = cur_index + (i2);  \
+    *ptr_indices++ = cur_index + (i3);  \
     num_indices += 3;
 
                 /* closed polyline, don´t draw twice the point */

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -112,14 +112,14 @@ SDLTest_CommonCreateState(char **argv, Uint32 flags)
     return state;
 }
 
-#define SEARCHARG(dim)            \
-    while (*dim && *dim != ',') { \
-        ++dim;                    \
-    }                             \
-    if (!*dim) {                  \
-        return -1;                \
-    }                             \
-    *dim++ = '\0';
+#define SEARCHARG(dim)                  \
+    while (*(dim) && *(dim) != ',') {   \
+        ++(dim);                        \
+    }                                   \
+    if (!*(dim)) {                      \
+        return -1;                      \
+    }                                   \
+    *(dim)++ = '\0';
 
 int SDLTest_CommonArg(SDLTest_CommonState *state, int index)
 {

--- a/src/test/SDL_test_md5.c
+++ b/src/test/SDL_test_md5.c
@@ -67,10 +67,10 @@ static unsigned char MD5PADDING[64] = {
 };
 
 /* F, G, H and I are basic MD5 functions */
-#define F(x, y, z) (((x) & (y)) | ((~x) & (z)))
-#define G(x, y, z) (((x) & (z)) | ((y) & (~z)))
+#define F(x, y, z) (((x) & (y)) | ((~(x)) & (z)))
+#define G(x, y, z) (((x) & (z)) | ((y) & (~(z))))
 #define H(x, y, z) ((x) ^ (y) ^ (z))
-#define I(x, y, z) ((y) ^ ((x) | (~z)))
+#define I(x, y, z) ((y) ^ ((x) | (~(z))))
 
 /* ROTATE_LEFT rotates x left n bits */
 #define ROTATE_LEFT(x, n) (((x) << (n)) | ((x) >> (32 - (n))))

--- a/src/video/SDL_blit_slow.c
+++ b/src/video/SDL_blit_slow.c
@@ -24,7 +24,7 @@
 #include "SDL_blit_slow.h"
 
 #define FORMAT_ALPHA                0
-#define FORMAT_NO_ALPHA             -1
+#define FORMAT_NO_ALPHA             (-1)
 #define FORMAT_2101010              1
 #define FORMAT_HAS_ALPHA(format)    format == 0
 #define FORMAT_HAS_NO_ALPHA(format) format < 0

--- a/src/video/SDL_fillrect.c
+++ b/src/video/SDL_fillrect.c
@@ -63,27 +63,27 @@ static void SDL_FillRect##bpp##SSE(Uint8 *pixels, int pitch, Uint32 color, int w
     SSE_BEGIN; \
  \
     while (h--) { \
-        n = w * bpp; \
+        n = (w) * (bpp); \
         p = pixels; \
  \
         if (n > 63) { \
             int adjust = 16 - ((uintptr_t)p & 15); \
             if (adjust < 16) { \
                 n -= adjust; \
-                adjust /= bpp; \
+                adjust /= (bpp); \
                 while (adjust--) { \
                     *((type *)p) = (type)color; \
-                    p += bpp; \
+                    p += (bpp); \
                 } \
             } \
             SSE_WORK; \
         } \
         if (n & 63) { \
             int remainder = (n & 63); \
-            remainder /= bpp; \
+            remainder /= (bpp); \
             while (remainder--) { \
                 *((type *)p) = (type)color; \
-                p += bpp; \
+                p += (bpp); \
             } \
         } \
         pixels += pitch; \

--- a/src/video/SDL_stretch.c
+++ b/src/video/SDL_stretch.c
@@ -140,7 +140,7 @@ static int SDL_UpperSoftStretch(SDL_Surface *src, const SDL_Rect *srcrect,
 #define FIXED_POINT(i) ((Uint32)(i) << 16)
 #define SRC_INDEX(fp)  ((Uint32)(fp) >> 16)
 #define INTEGER(fp)    ((Uint32)(fp) >> PRECISION)
-#define FRAC(fp)       ((Uint32)(fp >> (16 - PRECISION)) & ((1 << PRECISION) - 1))
+#define FRAC(fp)       ((Uint32)((fp) >> (16 - PRECISION)) & ((1 << PRECISION) - 1))
 #define FRAC_ZERO      0
 #define FRAC_ONE       (1 << PRECISION)
 #define FP_ONE         FIXED_POINT(1)

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -129,25 +129,25 @@ static VideoBootStrap *bootstrap[] = {
     NULL
 };
 
-#define CHECK_WINDOW_MAGIC(window, retval)                  \
-    if (!_this) {                                           \
-        SDL_UninitializedVideo();                           \
-        return retval;                                      \
-    }                                                       \
-    if (!window || window->magic != &_this->window_magic) { \
-        SDL_SetError("Invalid window");                     \
-        return retval;                                      \
+#define CHECK_WINDOW_MAGIC(window, retval)                              \
+    if (!_this) {                                                       \
+        SDL_UninitializedVideo();                                       \
+        return retval;                                                  \
+    }                                                                   \
+    if (!(window) || (window)->magic != &_this->window_magic) {         \
+        SDL_SetError("Invalid window");                                 \
+        return retval;                                                  \
     }
 
-#define CHECK_DISPLAY_INDEX(displayIndex, retval)                  \
-    if (!_this) {                                                  \
-        SDL_UninitializedVideo();                                  \
-        return retval;                                             \
-    }                                                              \
-    if (displayIndex < 0 || displayIndex >= _this->num_displays) { \
-        SDL_SetError("displayIndex must be in the range 0 - %d",   \
-                     _this->num_displays - 1);                     \
-        return retval;                                             \
+#define CHECK_DISPLAY_INDEX(displayIndex, retval)                       \
+    if (!_this) {                                                       \
+        SDL_UninitializedVideo();                                       \
+        return retval;                                                  \
+    }                                                                   \
+    if ((displayIndex) < 0 || (displayIndex) >= _this->num_displays) {  \
+        SDL_SetError("displayIndex must be in the range 0 - %d",        \
+                     _this->num_displays - 1);                          \
+        return retval;                                                  \
     }
 
 #define FULLSCREEN_MASK (SDL_WINDOW_FULLSCREEN_DESKTOP | SDL_WINDOW_FULLSCREEN)


### PR DESCRIPTION
Fix warnings 'macro argument should be enclosed in parentheses'

