### PR TITLE
N3DS: Semaphore fixes.

### DIFF
--- a/docs/README-n3ds.md
+++ b/docs/README-n3ds.md
@@ -25,3 +25,4 @@ cmake --install build
 -   SDL3_main should be used to ensure ROMFS is enabled.
 -   By default, the extra L2 cache and higher clock speeds of the New 2/3DS lineup are enabled. If you wish to turn it off, use `osSetSpeedupEnable(false)` in your main function.
 -   `SDL_GetBasePath` returns the romfs root instead of the executable's directory.
+-   The Nintendo 3DS uses a cooperative threading model on a single core, meaning a thread will never yield unless done manually through the `SDL_Delay` functions, or blocking waits (`SDL_LockMutex`, `SDL_SemWait`, `SDL_CondWait`, `SDL_WaitThread`). To avoid starving other threads, `SDL_SemTryWait` and `SDL_SemWaitTimeout` will yield if they fail to acquire the semaphore, see https://github.com/libsdl-org/SDL/pull/6776 for more information.

--- a/src/thread/n3ds/SDL_syssem.c
+++ b/src/thread/n3ds/SDL_syssem.c
@@ -73,7 +73,7 @@ int SDL_SemWaitTimeoutNS(SDL_sem *sem, Sint64 timeoutNS)
     }
 
     if (LightSemaphore_TryAcquire(&sem->semaphore, 1) != 0) {
-        return WaitOnSemaphore(sem, timeoutNS);
+        return WaitOnSemaphoreFor(sem, timeoutNS);
     }
 
     return 0;

--- a/src/thread/n3ds/SDL_systhread.c
+++ b/src/thread/n3ds/SDL_systhread.c
@@ -49,8 +49,9 @@ static void ThreadEntry(void *arg)
 
 int SDL_SYS_CreateThread(SDL_Thread *thread)
 {
-    s32 priority = N3DS_THREAD_PRIORITY_MEDIUM;
+    s32 priority;
     size_t stack_size = GetStackSize(thread->stacksize);
+    svcGetThreadPriority(&priority, CUR_THREAD_HANDLE);
 
     thread->handle = threadCreate(ThreadEntry,
                                   thread,

--- a/test/testsem.c
+++ b/test/testsem.c
@@ -208,6 +208,8 @@ TestOverheadContended(SDL_bool try_wait)
         }
         /* Make sure threads consumed everything */
         while (SDL_SemValue(sem)) {
+            /* Friendlier with cooperative threading models */
+            SDL_DelayNS(1);
         }
     }
     end_ticks = SDL_GetTicks();


### PR DESCRIPTION
## Description

There were a handful of issues with Nintendo 3DS' semaphore implementation. Namely:
- lacking a function to wait with a timeout, it had a naive implementation that tried once every millisecond.
- contended Post/TryWait operations would hang the OS.

This PR addresses both issues:
- the best delay between acquire attempts seems to be around 10-100µs, which gave about 10 timeouts each for 10000 iterations
- for TryWait, a delay of at least 50µs after the call is needed to avoid the OS hang.

Testing was done using `test/testsem.c`.

I'll make a similar patch for the SDL2 branch since it is also applicable there.

## Existing Issue(s)
N/A
