### PR TITLE
wayland: Handle the Num Lock and Caps Lock modifiers via modifier events

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -1340,14 +1340,15 @@ static void keyboard_handle_modifiers(void *data, struct wl_keyboard *keyboard,
     WAYLAND_xkb_state_update_mask(input->xkb.state, mods_depressed, mods_latched,
                                   mods_locked, 0, 0, group);
 
+    SDL_ToggleModState(KMOD_NUM, modstate & input->xkb.idx_num);
+    SDL_ToggleModState(KMOD_CAPS, modstate & input->xkb.idx_caps);
+
     /* Toggle the modifier states for virtual keyboards, as they may not send key presses. */
     if (input->keyboard_is_virtual) {
         SDL_ToggleModState(KMOD_SHIFT, modstate & input->xkb.idx_shift);
         SDL_ToggleModState(KMOD_CTRL, modstate & input->xkb.idx_ctrl);
         SDL_ToggleModState(KMOD_ALT, modstate & input->xkb.idx_alt);
         SDL_ToggleModState(KMOD_GUI, modstate & input->xkb.idx_gui);
-        SDL_ToggleModState(KMOD_NUM, modstate & input->xkb.idx_num);
-        SDL_ToggleModState(KMOD_CAPS, modstate & input->xkb.idx_caps);
     }
 
     /* If a key is repeating, update the text to apply the modifier. */


### PR DESCRIPTION
Num Lock and Caps Lock always need to be explicitly handled by the modifier handler function, or they won't be correctly set if active at application startup, or if the lock state is changed while the application lacks focus since a key press for these keys will never be received.  In these cases, the internal SDL modifier state can end up the inverse of the actual modifier state.
