### PR TITLE
Gesture: use eventwatch, allow testgesture.c without touch

### DIFF
--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -1235,8 +1235,6 @@ int SDL_PushEvent(SDL_Event *event)
         return -1;
     }
 
-    SDL_GestureProcessEvent(event);
-
     return 1;
 }
 

--- a/src/events/SDL_gesture.c
+++ b/src/events/SDL_gesture.c
@@ -79,6 +79,8 @@ static SDL_GestureTouch *SDL_gestureTouch;
 static int SDL_numGestureTouches = 0;
 static SDL_bool recordAll;
 
+static int SDL_GestureProcessEvent(void *userdata, SDL_Event *event);
+
 #if 0
 static void PrintPath(SDL_FloatPoint *path)
 {
@@ -108,8 +110,15 @@ int SDL_RecordGesture(SDL_TouchID touchId)
     return touchId < 0;
 }
 
-void SDL_GestureQuit()
+
+void SDL_GestureInit(void)
 {
+    SDL_AddEventWatch(SDL_GestureProcessEvent, NULL);
+}
+
+void SDL_GestureQuit(void)
+{
+    SDL_DelEventWatch(SDL_GestureProcessEvent, NULL);
     SDL_free(SDL_gestureTouch);
     SDL_gestureTouch = NULL;
 }
@@ -569,7 +578,8 @@ static void SDL_SendDollarRecord(SDL_GestureTouch *touch, SDL_GestureID gestureI
 }
 #endif
 
-void SDL_GestureProcessEvent(SDL_Event *event)
+/* Returned value is ignored because this is a callback for event watching */
+static int SDL_GestureProcessEvent(void *userdata, SDL_Event *event)
 {
     float x, y;
 #if defined(ENABLE_DOLLAR)
@@ -591,7 +601,7 @@ void SDL_GestureProcessEvent(SDL_Event *event)
 
         /* Shouldn't be possible */
         if (inTouch == NULL) {
-            return;
+            return 0;
         }
 
         x = event->tfinger.x;
@@ -738,6 +748,8 @@ void SDL_GestureProcessEvent(SDL_Event *event)
 #endif
         }
     }
+
+    return 0;
 }
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/events/SDL_gesture_c.h
+++ b/src/events/SDL_gesture_c.h
@@ -26,8 +26,7 @@
 extern int SDL_GestureAddTouch(SDL_TouchID touchId);
 extern int SDL_GestureDelTouch(SDL_TouchID touchId);
 
-extern void SDL_GestureProcessEvent(SDL_Event *event);
-
+extern void SDL_GestureInit(void);
 extern void SDL_GestureQuit(void);
 
 #endif /* SDL_gesture_c_h_ */

--- a/src/events/SDL_touch.c
+++ b/src/events/SDL_touch.c
@@ -41,6 +41,7 @@ static SDL_TouchID track_touchid;
 /* Public functions */
 int SDL_TouchInit(void)
 {
+    SDL_GestureInit();
     return 0;
 }
 

--- a/test/testgesture.c
+++ b/test/testgesture.c
@@ -284,7 +284,7 @@ loop(void)
 #endif
 }
 
-const char *usage = "\n\
+static const char *usage = "\n\
     i: info about devices \n\
     r: record a Gesture.(press 'r' before each new record)\n\
     s: save gestures into 'gestureSave'file\n\
@@ -309,7 +309,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    SDL_Log(usage);
+    SDL_Log("%s", usage);
 
 
 #ifdef __EMSCRIPTEN__

--- a/test/testgesture.c
+++ b/test/testgesture.c
@@ -197,7 +197,7 @@ loop(void)
                 break;
             }
 
-            case SDLK_SPACE:
+            case SDLK_r:
                 SDL_RecordGesture(-1);
                 break;
 
@@ -209,9 +209,23 @@ loop(void)
 
             case SDLK_l:
                 stream = SDL_RWFromFile("gestureSave", "r");
-                SDL_Log("Loaded: %i", SDL_LoadDollarTemplates(-1, stream));
-                SDL_RWclose(stream);
+                if (stream) {
+                    SDL_Log("Loaded: %i", SDL_LoadDollarTemplates(-1, stream));
+                    SDL_RWclose(stream);
+                } else {
+                    SDL_Log("Cannot load 'gestureSave' file");
+                }
                 break;
+
+            case SDLK_v:
+                /* Transform mouse event to touch events for testing without a touch screen */
+                SDL_SetHint(SDL_HINT_MOUSE_TOUCH_EVENTS, "1");
+                SDL_Log("SDL_HINT_MOUSE_TOUCH_EVENTS enabled");
+                break;
+
+
+
+
             }
             break;
 
@@ -270,6 +284,14 @@ loop(void)
 #endif
 }
 
+const char *usage = "\n\
+    i: info about devices \n\
+    r: record a Gesture.(press 'r' before each new record)\n\
+    s: save gestures into 'gestureSave'file\n\
+    l: load 'gestureSave' file\n\
+    v: enable virtual touch. Touch events are synthetized when Mouse events occur\n\
+";
+
 int main(int argc, char *argv[])
 {
     state = SDLTest_CommonCreateState(argv, SDL_INIT_VIDEO);
@@ -287,11 +309,15 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    SDL_Log(usage);
+
+
 #ifdef __EMSCRIPTEN__
     emscripten_set_main_loop(loop, 0, 1);
 #else
     while (!quitting) {
         loop();
+        SDL_Delay(10);
     }
 #endif
 


### PR DESCRIPTION
Before Gesture gets removed ..
this allows: 
- use SDL_AddEventWatch() instead of calling SDL_GestureProcessEvent() (so it should be easier to remove/add gesture from SDL)

- change test/testgesture so that it can work on desktop.  + add some help/usage.
 ```
    i: info about devices 
    r: record a Gesture.(press 'r' before each new record)
    s: save gestures into 'gestureSave'file
    l: load 'gestureSave' file
    v: enable virtual touch. Touch events are synthetized when Mouse events occur
```

to be fully removed and re-add able.
- probable we would need events to know when touch device are added / removed.
- maybe also an event when touch subsystem is initialized/terminated



