### PR TITLE
improve DUFFS_LOOP_124

### DIFF
--- a/src/video/SDL_blit.h
+++ b/src/video/SDL_blit.h
@@ -535,22 +535,15 @@ extern SDL_BlitFunc SDL_CalculateBlitA(SDL_Surface *surface);
         int n = width;                               \
         if (n & 1) {                                 \
             pixel_copy_increment1;                   \
-            n -= 1;                                  \
         }                                            \
-        if (n & 2) {                                 \
+        n >>= 1;                                     \
+        if (n & 1) {                                 \
             pixel_copy_increment2;                   \
-            n -= 2;                                  \
         }                                            \
-        if (n & 4) {                                 \
+        n >>= 1;                                     \
+        while (n > 0) {                              \
             pixel_copy_increment4;                   \
-            n -= 4;                                  \
-        }                                            \
-        if (n) {                                     \
-            n /= 8;                                  \
-            do {                                     \
-                pixel_copy_increment4;               \
-                pixel_copy_increment4;               \
-            } while (--n > 0);                       \
+            n--;                                     \
         }                                            \
     }
 


### PR DESCRIPTION
- use sar (shr?) instead of dec/sub
- use sar (shr?) instead of (optimized) idiv
- check against zero only at one place
- use pixel_copy_increment4 only once