### PR TITLE
emscripten: Replace a stray reference to SDL2 with SDL3

### DIFF
--- a/src/video/emscripten/SDL_emscriptenframebuffer.c
+++ b/src/video/emscripten/SDL_emscriptenframebuffer.c
@@ -97,7 +97,7 @@ int Emscripten_UpdateWindowFramebuffer(_THIS, SDL_Window *window, const SDL_Rect
             SDL3.data8 = new Uint8Array(data.buffer);
             SDL3.data32Data = data;
         }
-        var data32 = SDL2.data32;
+        var data32 = SDL3.data32;
         num = data32.length;
         // logically we need to do
         //      while (dst < num) {


### PR DESCRIPTION
Entirely untested, but I'm fairly sure this is what was intended.

---

Same class of bug as #6801. I noticed this when I did a `git grep` to see whether there were more.