### PR TITLE
[SDL3] .gitignore: Replace all SDL2 with SDL3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,11 @@ config.status
 libtool
 Makefile
 Makefile.rules
-sdl2-config
-sdl2-config.cmake
-sdl2-config-version.cmake
-sdl2.pc
-SDL2.spec
+sdl3-config
+sdl3-config.cmake
+sdl3-config-version.cmake
+sdl3.pc
+SDL3.spec
 build
 gen
 Build
@@ -45,7 +45,7 @@ CMakeFiles/
 CMakeCache.txt
 cmake_install.cmake
 cmake_uninstall.cmake
-SDL2ConfigVersion.cmake
+SDL3ConfigVersion.cmake
 .ninja_*
 *.ninja
 


### PR DESCRIPTION
Some of these are probably unnecessary now that Autotools (with its optional in-tree builds) has been deleted in favour of CMake (with mandatory out-of-tree builds), but let's be consistent.

Spotted while doing a `git grep` for other bugs of the same form as #6801.