### PR TITLE
DBus: add a reference to the connection (Fixed bug #6712)

### DIFF
--- a/src/core/linux/SDL_dbus.c
+++ b/src/core/linux/SDL_dbus.c
@@ -51,6 +51,7 @@ static int LoadDBUSSyms(void)
     SDL_DBUS_SYM(connection_send);
     SDL_DBUS_SYM(connection_send_with_reply_and_block);
     SDL_DBUS_SYM(connection_close);
+    SDL_DBUS_SYM(connection_ref);
     SDL_DBUS_SYM(connection_unref);
     SDL_DBUS_SYM(connection_flush);
     SDL_DBUS_SYM(connection_read_write);

--- a/src/core/linux/SDL_dbus.h
+++ b/src/core/linux/SDL_dbus.h
@@ -45,6 +45,7 @@ typedef struct SDL_DBusContext
     dbus_bool_t (*connection_send)(DBusConnection *, DBusMessage *, dbus_uint32_t *);
     DBusMessage *(*connection_send_with_reply_and_block)(DBusConnection *, DBusMessage *, int, DBusError *);
     void (*connection_close)(DBusConnection *);
+    void (*connection_ref)(DBusConnection *);
     void (*connection_unref)(DBusConnection *);
     void (*connection_flush)(DBusConnection *);
     dbus_bool_t (*connection_read_write)(DBusConnection *, int);

--- a/src/core/linux/SDL_ibus.c
+++ b/src/core/linux/SDL_ibus.c
@@ -483,9 +483,10 @@ static SDL_bool IBus_SetupConnection(SDL_DBusContext *dbus, const char *addr)
         result = SDL_DBus_CallMethodOnConnection(ibus_conn, ibus_service, IBUS_PATH, ibus_interface, "CreateInputContext",
                                                  DBUS_TYPE_STRING, &client_name, DBUS_TYPE_INVALID,
                                                  DBUS_TYPE_OBJECT_PATH, &path, DBUS_TYPE_INVALID);
+    } else {
+        /* re-using dbus->session_conn */
+        dbus->connection_ref(ibus_conn);
     }
-
-    dbus->connection_ref(ibus_conn);
 
     if (result) {
         char matchstr[128];

--- a/src/core/linux/SDL_ibus.c
+++ b/src/core/linux/SDL_ibus.c
@@ -485,6 +485,8 @@ static SDL_bool IBus_SetupConnection(SDL_DBusContext *dbus, const char *addr)
                                                  DBUS_TYPE_OBJECT_PATH, &path, DBUS_TYPE_INVALID);
     }
 
+    dbus->connection_ref(ibus_conn);
+
     if (result) {
         char matchstr[128];
         (void)SDL_snprintf(matchstr, sizeof matchstr, "type='signal',interface='%s'", ibus_input_interface);


### PR DESCRIPTION
This fixes the crash seen https://github.com/libsdl-org/SDL/issues/6712
not sure if this is the right thing to do.
but there were already a "connection_unref", make sense to have a "connection_ref"