### PR TITLE
fixed const error when compiling for mutated total_need value in SDL_…

### DIFF
--- a/src/file/SDL_rwops.c
+++ b/src/file/SDL_rwops.c
@@ -185,7 +185,7 @@ static Sint64 SDLCALL windows_file_seek(SDL_RWops *context, Sint64 offset, int w
 static Sint64 SDLCALL
 windows_file_read(SDL_RWops *context, void *ptr, Sint64 size)
 {
-    const size_t total_need = (size_t) size;
+    size_t total_need = (size_t) size;
     size_t total_read = 0;
     size_t read_ahead;
     DWORD byte_read;


### PR DESCRIPTION
…rwops.c

## Summary

72c1f73bc5227bf9e9c213dc1f1a4f6f826d0107 appears to break build on MSVC in SDL_rwops.c :

```
> msbuild VisualC/SDL.sln
...
.\src\file\SDL_rwops.c(213,9): error C2166: l-value specifies const object [.\
VisualC\SDL\SDL.vcxproj]
```

## Description

Variable "total_need" is declared as constant (L188) but conditionally mutated within same scope (L213). Fixed with this MR.

## Existing Issue(s)

[n/a]
