### PR TITLE
render: Fix SDL_RenderSetVSync w/ software backend

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -994,16 +994,6 @@ SDL_CreateRenderer(SDL_Window *window, const char *name, Uint32 flags)
         goto error;
     }
 
-    if ((flags & SDL_RENDERER_PRESENTVSYNC) != 0) {
-        renderer->wanted_vsync = SDL_TRUE;
-
-        if ((renderer->info.flags & SDL_RENDERER_PRESENTVSYNC) == 0) {
-            renderer->simulate_vsync = SDL_TRUE;
-            renderer->info.flags |= SDL_RENDERER_PRESENTVSYNC;
-        }
-    }
-    SDL_CalculateSimulatedVSyncInterval(renderer, window);
-
     VerifyDrawQueueFunctions(renderer);
 
     /* let app/user override batching decisions. */
@@ -1054,6 +1044,11 @@ SDL_CreateRenderer(SDL_Window *window, const char *name, Uint32 flags)
     } else {
         renderer->hidden = SDL_FALSE;
     }
+
+    if ((flags & SDL_RENDERER_PRESENTVSYNC) != 0) {
+        SDL_RenderSetVSync(renderer, SDL_TRUE);
+    }
+    SDL_CalculateSimulatedVSyncInterval(renderer, window);
 
     SDL_SetWindowData(window, SDL_WINDOWRENDERDATA, renderer);
 

--- a/src/render/software/SDL_render_sw.c
+++ b/src/render/software/SDL_render_sw.c
@@ -1132,6 +1132,7 @@ SW_CreateRendererForSurface(SDL_Surface *surface)
     renderer->DestroyTexture = SW_DestroyTexture;
     renderer->DestroyRenderer = SW_DestroyRenderer;
     renderer->info = SW_RenderDriver.info;
+    renderer->info.flags = (SDL_RENDERER_SOFTWARE | SDL_RENDERER_TARGETTEXTURE);
     renderer->driverdata = data;
 
     SW_SelectBestFormats(renderer, surface->format->format);
@@ -1143,28 +1144,7 @@ SW_CreateRendererForSurface(SDL_Surface *surface)
 
 static SDL_Renderer *SW_CreateRenderer(SDL_Window *window, Uint32 flags)
 {
-    const char *hint;
-    SDL_Surface *surface;
-    SDL_bool no_hint_set;
-
-    /* Set the vsync hint based on our flags, if it's not already set */
-    hint = SDL_GetHint(SDL_HINT_RENDER_VSYNC);
-    if (hint == NULL || !*hint) {
-        no_hint_set = SDL_TRUE;
-    } else {
-        no_hint_set = SDL_FALSE;
-    }
-
-    if (no_hint_set) {
-        SDL_SetHint(SDL_HINT_RENDER_VSYNC, (flags & SDL_RENDERER_PRESENTVSYNC) ? "1" : "0");
-    }
-
-    surface = SDL_GetWindowSurface(window);
-
-    /* Reset the vsync hint if we set it above */
-    if (no_hint_set) {
-        SDL_SetHint(SDL_HINT_RENDER_VSYNC, "");
-    }
+    SDL_Surface *surface = SDL_GetWindowSurface(window);
 
     if (surface == NULL) {
         return NULL;


### PR DESCRIPTION
This is my newbie attempt at fixing #6816 

## Description

This prevents the software renderer from creating a VSync-enabled framebuffer (unless SDL_HINT_RENDER_VSYNC is set), so VSync is determined by the actual software renderer rather than whichever renderer is used to display the framebuffer.

## Existing Issue(s)

#6816
