### PR TITLE
Android AAUDIO: Android audio device selection (see #6824)

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLAudioManager.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLAudioManager.java
@@ -300,6 +300,22 @@ public class SDLAudioManager
     /**
      * This method is called by SDL using JNI.
      */
+    public static int[] getAudioOutputDevices() {
+        AudioManager audioManager = (AudioManager) mContext.getSystemService(Context.AUDIO_SERVICE);
+        return Arrays.stream(audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)).mapToInt(AudioDeviceInfo::getId).toArray();
+    }
+
+    /**
+     * This method is called by SDL using JNI.
+     */
+    public static int[] getAudioInputDevices() {
+        AudioManager audioManager = (AudioManager) mContext.getSystemService(Context.AUDIO_SERVICE);
+        return Arrays.stream(audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS)).mapToInt(AudioDeviceInfo::getId).toArray();
+    }
+
+    /**
+     * This method is called by SDL using JNI.
+     */
     public static void audioWriteByteBuffer(byte[] buffer) {
         if (mAudioTrack == null) {
             Log.e(TAG, "Attempted to make audio call with uninitialized audio!");

--- a/src/audio/aaudio/SDL_aaudio.c
+++ b/src/audio/aaudio/SDL_aaudio.c
@@ -68,6 +68,45 @@ void aaudio_errorCallback(AAudioStream *stream, void *userData, aaudio_result_t 
 
 #define LIB_AAUDIO_SO "libaaudio.so"
 
+static void aaudio_DetectDevices(void)
+{
+    int *inputs;
+    inputs = SDL_malloc(sizeof(int) * 100);
+    SDL_zerop(inputs);
+    int inputs_length = 0;
+
+    Android_JNI_GetAudioInputDevices(inputs, &inputs_length);
+
+    for (int i = 0; i < inputs_length; ++i) {
+        int device_id = inputs[i];
+        int n = (int) (log10(device_id) + 1);
+        char device_name[n];
+        SDL_itoa(device_id, device_name, 10);
+        SDL_Log("Adding input device with name %s", device_name);
+        SDL_AddAudioDevice(SDL_FALSE, SDL_strdup(device_name), NULL, (void *) ((size_t) device_id + 1));
+    }
+
+    SDL_free(inputs);
+
+    int *outputs;
+    outputs = SDL_malloc(sizeof(int) * 100);
+    SDL_zerop(outputs);
+    int outputs_length = 0;
+
+    Android_JNI_GetAudioOutputDevices(outputs, &outputs_length);
+
+    for (int i = 0; i < outputs_length; ++i) {
+        int device_id = outputs[i];
+        int n = (int) (log10(device_id) + 1);
+        char device_name[n];
+        SDL_itoa(device_id, device_name, 10);
+        SDL_Log("Adding output device with name %s", device_name);
+        SDL_AddAudioDevice(SDL_TRUE, SDL_strdup(device_name), NULL, (void *) ((size_t) device_id + 1));
+    }
+
+    SDL_free(outputs);
+}
+
 static int aaudio_OpenDevice(_THIS, const char *devname)
 {
     struct SDL_PrivateAudioData *private;
@@ -99,6 +138,11 @@ static int aaudio_OpenDevice(_THIS, const char *devname)
 
     ctx.AAudioStreamBuilder_setSampleRate(ctx.builder, this->spec.freq);
     ctx.AAudioStreamBuilder_setChannelCount(ctx.builder, this->spec.channels);
+    if(devname != NULL) {
+        int aaudio_device_id = SDL_atoi(devname);
+        LOGI("Opening device id %d", aaudio_device_id);
+        ctx.AAudioStreamBuilder_setDeviceId(ctx.builder, aaudio_device_id);
+    }
     {
         aaudio_direction_t direction = (iscapture ? AAUDIO_DIRECTION_INPUT : AAUDIO_DIRECTION_OUTPUT);
         ctx.AAudioStreamBuilder_setDirection(ctx.builder, direction);
@@ -298,17 +342,19 @@ static SDL_bool aaudio_Init(SDL_AudioDriverImpl *impl)
         goto failure;
     }
 
+    impl->DetectDevices = aaudio_DetectDevices;
     impl->Deinitialize = aaudio_Deinitialize;
     impl->OpenDevice = aaudio_OpenDevice;
     impl->CloseDevice = aaudio_CloseDevice;
     impl->PlayDevice = aaudio_PlayDevice;
     impl->GetDeviceBuf = aaudio_GetDeviceBuf;
     impl->CaptureFromDevice = aaudio_CaptureFromDevice;
+    impl->AllowsArbitraryDeviceNames = SDL_TRUE;
 
     /* and the capabilities */
     impl->HasCaptureSupport = SDL_TRUE;
-    impl->OnlyHasDefaultOutputDevice = SDL_TRUE;
-    impl->OnlyHasDefaultCaptureDevice = SDL_TRUE;
+    impl->OnlyHasDefaultOutputDevice = SDL_FALSE;
+    impl->OnlyHasDefaultCaptureDevice = SDL_FALSE;
 
     /* this audio target is available. */
     LOGI("SDL aaudio_Init OK");

--- a/src/audio/aaudio/SDL_aaudiofuncs.h
+++ b/src/audio/aaudio/SDL_aaudiofuncs.h
@@ -24,7 +24,7 @@
 SDL_PROC(const char *, AAudio_convertResultToText, (aaudio_result_t returnCode))
 SDL_PROC(const char *, AAudio_convertStreamStateToText, (aaudio_stream_state_t state))
 SDL_PROC(aaudio_result_t, AAudio_createStreamBuilder, (AAudioStreamBuilder * *builder))
-SDL_PROC_UNUSED(void, AAudioStreamBuilder_setDeviceId, (AAudioStreamBuilder * builder, int32_t deviceId))
+SDL_PROC(void, AAudioStreamBuilder_setDeviceId, (AAudioStreamBuilder * builder, int32_t deviceId))
 SDL_PROC(void, AAudioStreamBuilder_setSampleRate, (AAudioStreamBuilder * builder, int32_t sampleRate))
 SDL_PROC(void, AAudioStreamBuilder_setChannelCount, (AAudioStreamBuilder * builder, int32_t channelCount))
 SDL_PROC_UNUSED(void, AAudioStreamBuilder_setSamplesPerFrame, (AAudioStreamBuilder * builder, int32_t samplesPerFrame))

--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -322,6 +322,8 @@ static jmethodID midSupportsRelativeMouse;
 static jclass mAudioManagerClass;
 
 /* method signatures */
+static jmethodID midGetAudioOutputDevices;
+static jmethodID midGetAudioInputDevices;
 static jmethodID midAudioOpen;
 static jmethodID midAudioWriteByteBuffer;
 static jmethodID midAudioWriteShortBuffer;
@@ -647,6 +649,12 @@ JNIEXPORT void JNICALL SDL_JAVA_AUDIO_INTERFACE(nativeSetupJNI)(JNIEnv *env, jcl
 
     mAudioManagerClass = (jclass)((*env)->NewGlobalRef(env, cls));
 
+    midGetAudioOutputDevices = (*env)->GetStaticMethodID(env, mAudioManagerClass,
+                                                         "getAudioOutputDevices",
+                                                         "()[I");
+    midGetAudioInputDevices = (*env)->GetStaticMethodID(env, mAudioManagerClass,
+                                                        "getAudioInputDevices",
+                                                        "()[I");
     midAudioOpen = (*env)->GetStaticMethodID(env, mAudioManagerClass,
                                              "audioOpen", "(IIII)[I");
     midAudioWriteByteBuffer = (*env)->GetStaticMethodID(env, mAudioManagerClass,
@@ -670,7 +678,8 @@ JNIEXPORT void JNICALL SDL_JAVA_AUDIO_INTERFACE(nativeSetupJNI)(JNIEnv *env, jcl
     midAudioSetThreadPriority = (*env)->GetStaticMethodID(env, mAudioManagerClass,
                                                           "audioSetThreadPriority", "(ZI)V");
 
-    if (!midAudioOpen || !midAudioWriteByteBuffer || !midAudioWriteShortBuffer || !midAudioWriteFloatBuffer || !midAudioClose ||
+    if (!midGetAudioOutputDevices || !midGetAudioInputDevices ||
+        !midAudioOpen || !midAudioWriteByteBuffer || !midAudioWriteShortBuffer || !midAudioWriteFloatBuffer || !midAudioClose ||
         !midCaptureOpen || !midCaptureReadByteBuffer || !midCaptureReadShortBuffer || !midCaptureReadFloatBuffer || !midCaptureClose || !midAudioSetThreadPriority) {
         __android_log_print(ANDROID_LOG_WARN, "SDL", "Missing some Java callbacks, do you have the latest version of SDLAudioManager.java?");
     }
@@ -1420,6 +1429,28 @@ static jobject audioBuffer = NULL;
 static void *audioBufferPinned = NULL;
 static int captureBufferFormat = 0;
 static jobject captureBuffer = NULL;
+
+void Android_JNI_GetAudioOutputDevices(int *devices, int *length) {
+    JNIEnv *env = Android_JNI_GetEnv();
+    jintArray result;
+
+    result = (*env)->CallStaticObjectMethod(env, mAudioManagerClass, midGetAudioOutputDevices);
+
+    *length = (*env)->GetArrayLength(env, result);
+
+    (*env)->GetIntArrayRegion(env, result, 0, *length, devices);
+}
+
+void Android_JNI_GetAudioInputDevices(int * devices, int *length) {
+    JNIEnv *env = Android_JNI_GetEnv();
+    jintArray result;
+
+    result = (*env)->CallStaticObjectMethod(env, mAudioManagerClass, midGetAudioInputDevices);
+
+    *length = (*env)->GetArrayLength(env, result);
+
+    (*env)->GetIntArrayRegion(env, result, 0, *length, devices);
+}
 
 int Android_JNI_OpenAudioDevice(int iscapture, SDL_AudioSpec *spec)
 {

--- a/src/core/android/SDL_android.h
+++ b/src/core/android/SDL_android.h
@@ -46,6 +46,11 @@ extern ANativeWindow *Android_JNI_GetNativeWindow(void);
 extern SDL_DisplayOrientation Android_JNI_GetDisplayOrientation(void);
 extern int Android_JNI_GetDisplayDPI(float *ddpi, float *xdpi, float *ydpi);
 
+
+/* Driver AAudio support */
+extern void Android_JNI_GetAudioOutputDevices(int* devices, int *length);
+extern void Android_JNI_GetAudioInputDevices(int* devices, int *length);
+
 /* Audio support */
 extern int Android_JNI_OpenAudioDevice(int iscapture, SDL_AudioSpec *spec);
 extern void *Android_JNI_GetAudioBuffer(void);


### PR DESCRIPTION
Make it possible to select a specific audio device for Android

see #6824

= Description =

aaudio  drivers. 

Fixes https://github.com/libsdl-org/SDL/issues/6813