### PR TITLE
Fix mutex warning // can be "static"

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -102,7 +102,7 @@ static SDL_JoystickDriver *SDL_joystick_drivers[] = {
         &SDL_DUMMY_JoystickDriver
 #endif
 };
-SDL_mutex *SDL_joystick_lock = NULL; /* This needs to support recursive locks */
+static SDL_mutex *SDL_joystick_lock = NULL; /* This needs to support recursive locks */
 static int SDL_joysticks_locked;
 static SDL_bool SDL_joysticks_initialized;
 static SDL_bool SDL_joysticks_quitting = SDL_FALSE;

--- a/src/joystick/hidapi/SDL_hidapi_rumble.c
+++ b/src/joystick/hidapi/SDL_hidapi_rumble.c
@@ -49,7 +49,7 @@ typedef struct SDL_HIDAPI_RumbleContext
     SDL_HIDAPI_RumbleRequest *requests_tail;
 } SDL_HIDAPI_RumbleContext;
 
-SDL_mutex *SDL_HIDAPI_rumble_lock;
+static SDL_mutex *SDL_HIDAPI_rumble_lock;
 static SDL_HIDAPI_RumbleContext rumble_context SDL_GUARDED_BY(SDL_HIDAPI_rumble_lock);
 
 static int SDLCALL SDL_HIDAPI_RumbleThread(void *data)


### PR DESCRIPTION
Not sure if this is correct because of clang changes needed to check for thread safety

```
 ./src/joystick/SDL_joystick.c:105:12: warning: no previous extern declaration for non-static variable 'SDL_joystick_lock' [-Wmissing-variable-declarations]
SDL_mutex *SDL_joystick_lock = NULL; /* This needs to support recursive locks */
           ^
./src/joystick/SDL_joystick.c:105:1: note: declare 'static' if the variable is not intended to be used outside of this translation unit
SDL_mutex *SDL_joystick_lock = NULL; /* This needs to support recursive locks */
^
1 warning generated.
```
```

./src/joystick/hidapi/SDL_hidapi_rumble.c:52:12: warning: no previous extern declaration for non-static variable 'SDL_HIDAPI_rumble_lock' [-Wmissing-variable-declarations]
SDL_mutex *SDL_HIDAPI_rumble_lock;
           ^
./src/joystick/hidapi/SDL_hidapi_rumble.c:52:1: note: declare 'static' if the variable is not intended to be used outside of this translation unit
SDL_mutex *SDL_HIDAPI_rumble_lock;
^
```