### PR TITLE
Android OpenSLES: use common DetectDevices function

### DIFF
--- a/src/audio/openslES/SDL_openslES.c
+++ b/src/audio/openslES/SDL_openslES.c
@@ -734,8 +734,9 @@ static SDL_bool openslES_Init(SDL_AudioDriverImpl *impl)
 
     /* and the capabilities */
     impl->HasCaptureSupport = SDL_TRUE;
-    impl->OnlyHasDefaultOutputDevice = SDL_TRUE;
-    impl->OnlyHasDefaultCaptureDevice = SDL_TRUE;
+    impl->OnlyHasDefaultOutputDevice = SDL_FALSE;
+    impl->OnlyHasDefaultCaptureDevice = SDL_FALSE;
+    impl->AllowsArbitraryDeviceNames = SDL_TRUE;
 
     LOGI("openslES_Init() - success");
 

--- a/src/audio/openslES/SDL_openslES.c
+++ b/src/audio/openslES/SDL_openslES.c
@@ -723,7 +723,7 @@ static SDL_bool openslES_Init(SDL_AudioDriverImpl *impl)
     LOGI("openslES_Init() - set pointers");
 
     /* Set the function pointers */
-    /* impl->DetectDevices = openslES_DetectDevices; */
+    impl->DetectDevices = Android_DetectDevices;
     impl->OpenDevice = openslES_OpenDevice;
     impl->WaitDevice = openslES_WaitDevice;
     impl->PlayDevice = openslES_PlayDevice;


### PR DESCRIPTION
Android OpenSLES: use common DetectDevices function

and so, this should also immediate for OpenSLES, @v3rm0n  ?