### PR TITLE
Android active driver check

### DIFF
--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -214,12 +214,12 @@ JNIEXPORT void JNICALL SDL_JAVA_AUDIO_INTERFACE(nativeSetupJNI)(
     JNIEnv *env, jclass jcls);
 
 JNIEXPORT void JNICALL
-SDL_JAVA_AUDIO_INTERFACE(addAudioDevice)(JNIEnv *env, jclass jcls, jboolean is_capture,
-                                         jint device_id);
+    SDL_JAVA_AUDIO_INTERFACE(addAudioDevice)(JNIEnv *env, jclass jcls, jboolean is_capture,
+                                             jint device_id);
 
 JNIEXPORT void JNICALL
-SDL_JAVA_AUDIO_INTERFACE(removeAudioDevice)(JNIEnv *env, jclass jcls, jboolean is_capture,
-                                            jint device_id);
+    SDL_JAVA_AUDIO_INTERFACE(removeAudioDevice)(JNIEnv *env, jclass jcls, jboolean is_capture,
+                                                jint device_id);
 
 static JNINativeMethod SDLAudioManager_tab[] = {
     { "nativeSetupJNI", "()I", SDL_JAVA_AUDIO_INTERFACE(nativeSetupJNI) },
@@ -932,18 +932,22 @@ JNIEXPORT void JNICALL
 SDL_JAVA_AUDIO_INTERFACE(addAudioDevice)(JNIEnv *env, jclass jcls, jboolean is_capture,
                                          jint device_id)
 {
-    char device_name[64];
-    SDL_snprintf(device_name, sizeof (device_name), "%d", device_id);
-    SDL_Log("Adding device with name %s, capture %d", device_name, is_capture);
-    SDL_AddAudioDevice(is_capture, SDL_strdup(device_name), NULL, (void *) ((size_t) device_id + 1));
+    if (SDL_GetCurrentAudioDriver() != NULL) {
+        char device_name[64];
+        SDL_snprintf(device_name, sizeof(device_name), "%d", device_id);
+        SDL_Log("Adding device with name %s, capture %d", device_name, is_capture);
+        SDL_AddAudioDevice(is_capture, SDL_strdup(device_name), NULL, (void *)((size_t)device_id + 1));
+    }
 }
 
 JNIEXPORT void JNICALL
 SDL_JAVA_AUDIO_INTERFACE(removeAudioDevice)(JNIEnv *env, jclass jcls, jboolean is_capture,
                                             jint device_id)
 {
-    SDL_Log("Removing device with handle %d, capture %d", device_id + 1, is_capture);
-    SDL_RemoveAudioDevice(is_capture, (void *) ((size_t) device_id + 1));
+    if (SDL_GetCurrentAudioDriver() != NULL) {
+        SDL_Log("Removing device with handle %d, capture %d", device_id + 1, is_capture);
+        SDL_RemoveAudioDevice(is_capture, (void *)((size_t)device_id + 1));
+    }
 }
 
 /* Paddown */
@@ -1496,9 +1500,9 @@ void Android_DetectDevices(void)
     for (int i = 0; i < inputs_length; ++i) {
         int device_id = inputs[i];
         char device_name[64];
-        SDL_snprintf(device_name, sizeof (device_name), "%d", device_id);
+        SDL_snprintf(device_name, sizeof(device_name), "%d", device_id);
         SDL_Log("Adding input device with name %s", device_name);
-        SDL_AddAudioDevice(SDL_TRUE, SDL_strdup(device_name), NULL, (void *) ((size_t) device_id + 1));
+        SDL_AddAudioDevice(SDL_TRUE, SDL_strdup(device_name), NULL, (void *)((size_t)device_id + 1));
     }
 
     SDL_zeroa(outputs);
@@ -1508,9 +1512,9 @@ void Android_DetectDevices(void)
     for (int i = 0; i < outputs_length; ++i) {
         int device_id = outputs[i];
         char device_name[64];
-        SDL_snprintf(device_name, sizeof (device_name), "%d", device_id);
+        SDL_snprintf(device_name, sizeof(device_name), "%d", device_id);
         SDL_Log("Adding output device with name %s", device_name);
-        SDL_AddAudioDevice(SDL_FALSE, SDL_strdup(device_name), NULL, (void *) ((size_t) device_id + 1));
+        SDL_AddAudioDevice(SDL_FALSE, SDL_strdup(device_name), NULL, (void *)((size_t)device_id + 1));
     }
 }
 


### PR DESCRIPTION
Check if a driver is active before attempting to handle the devices. Otherwise an assertion will fail.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Android event handlers get registered before audio system is initialised and event handling will fail when there is no driver.

Fixed a couple of formatting errors from my previous PR's.
## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
