### PR TITLE
[SDL2] Fix dynapi signature for SDL_GDKSuspendComplete

### DIFF
--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -977,5 +977,5 @@ SDL_DYNAPI_PROC(int,SDL_SensorGetDataWithTimestamp,(SDL_Sensor *a, Uint64 *b, fl
 SDL_DYNAPI_PROC(void,SDL_ResetHints,(void),(),)
 SDL_DYNAPI_PROC(char*,SDL_strcasestr,(const char *a, const char *b),(a,b),return)
 #if defined(__GDK__)
-SDL_DYNAPI_PROC(void,SDL_GDKSuspendComplete,(void),(),return)
+SDL_DYNAPI_PROC(void,SDL_GDKSuspendComplete,(void),(),)
 #endif


### PR DESCRIPTION
## Description
Fixes the dynapi signature of `SDL_GDKSuspendComplete` to remove a stray `return` that was resulting in build warnings for GDK. This was already fixed on main, but it wasn't backported to SDL2. 