### PR TITLE
events: Move the window and display event types to the top level.

### DIFF
--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -86,12 +86,33 @@ typedef enum
 
     SDL_LOCALECHANGED,  /**< The user's locale preferences have changed. */
 
-    /* Display events */
-    SDL_DISPLAYEVENT   = 0x150,  /**< Display state change */
+    /* 0x150 was SDL_DISPLAYEVENT, reserve the number for sdl2-compat */
+    SDL_DISPLAYORIENTATION = 0x151,   /**< Display orientation has changed to data1 */
+    SDL_DISPLAYCONNECTED,             /**< Display has been added to the system */
+    SDL_DISPLAYDISCONNECTED,          /**< Display has been removed from the system */
+    SDL_DISPLAYMOVED,                  /**< Display has changed position */
 
     /* Window events */
-    SDL_WINDOWEVENT    = 0x200, /**< Window state change */
-    SDL_SYSWMEVENT,             /**< System specific event */
+    /* 0x200 was SDL_WINDOWEVENT, reserve the number for sdl2-compat */
+    SDL_SYSWMEVENT     = 0x201, /**< System specific event */
+    SDL_WINSHOWN,               /**< Window has been shown */
+    SDL_WINHIDDEN,              /**< Window has been hidden */
+    SDL_WINEXPOSED,             /**< Window has been exposed and should be redrawn */
+    SDL_WINMOVED,               /**< Window has been moved to data1, data2 */
+    SDL_WINRESIZED,             /**< Window has been resized to data1xdata2 */
+    SDL_WINSIZECHANGED,         /**< The window size has changed, either as a result of an API call or through the system or user changing the window size. */
+    SDL_WINMINIMIZED,           /**< Window has been minimized */
+    SDL_WINMAXIMIZED,           /**< Window has been maximized */
+    SDL_WINRESTORED,            /**< Window has been restored to normal size and position */
+    SDL_WINMOUSEFOCUSGAINED,    /**< Window has gained mouse focus */
+    SDL_WINMOUSEFOCUSLOST,      /**< Window has lost mouse focus */
+    SDL_WINKEYBOARDFOCUSGAINED, /**< Window has gained keyboard focus */
+    SDL_WINKEYBOARDFOCUSLOST,   /**< Window has gained keyboard focus */
+    SDL_WINCLOSE,               /**< The window manager requests that the window be closed */
+    SDL_WINTAKEFOCUS,           /**< Window is being offered a focus (should SetWindowInputFocus() on itself or a subwindow, or ignore) */
+    SDL_WINHITTEST,             /**< Window had a hit test that wasn't SDL_HITTEST_NORMAL. */
+    SDL_WINICCPROFCHANGED,      /**< The ICC profile of the window's display has changed. */
+    SDL_WINDISPLAYCHANGED,      /**< Window has been moved to display data1. */
 
     /* Keyboard events */
     SDL_KEYDOWN        = 0x300, /**< Key pressed */
@@ -185,13 +206,9 @@ typedef struct SDL_CommonEvent
  */
 typedef struct SDL_DisplayEvent
 {
-    Uint32 type;        /**< ::SDL_DISPLAYEVENT */
+    Uint32 type;        /**< ::SDL_DISPLAY* events */
     Uint64 timestamp;   /**< In nanoseconds, populated using SDL_GetTicksNS() */
     Uint32 display;     /**< The associated display index */
-    Uint8 event;        /**< ::SDL_DisplayEventID */
-    Uint8 padding1;
-    Uint8 padding2;
-    Uint8 padding3;
     Sint32 data1;       /**< event dependent data */
 } SDL_DisplayEvent;
 
@@ -200,13 +217,9 @@ typedef struct SDL_DisplayEvent
  */
 typedef struct SDL_WindowEvent
 {
-    Uint32 type;        /**< ::SDL_WINDOWEVENT */
+    Uint32 type;        /**< ::SDL_WIN* events */
     Uint64 timestamp;   /**< In nanoseconds, populated using SDL_GetTicksNS() */
     Uint32 windowID;    /**< The associated window */
-    Uint8 event;        /**< ::SDL_WindowEventID */
-    Uint8 padding1;
-    Uint8 padding2;
-    Uint8 padding3;
     Sint32 data1;       /**< event dependent data */
     Sint32 data2;       /**< event dependent data */
 } SDL_WindowEvent;
@@ -531,7 +544,7 @@ typedef struct SDL_QuitEvent
  */
 typedef struct SDL_OSEvent
 {
-    Uint32 type;        /**< ::SDL_QUIT */
+    Uint32 type;
     Uint64 timestamp;   /**< In nanoseconds, populated using SDL_GetTicksNS() */
 } SDL_OSEvent;
 

--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -149,49 +149,6 @@ typedef enum
             (((X)&0xFFFF0000) == SDL_WINDOWPOS_CENTERED_MASK)
 
 /**
- *  \brief Event subtype for window events
- */
-typedef enum
-{
-    SDL_WINDOWEVENT_NONE,           /**< Never used */
-    SDL_WINDOWEVENT_SHOWN,          /**< Window has been shown */
-    SDL_WINDOWEVENT_HIDDEN,         /**< Window has been hidden */
-    SDL_WINDOWEVENT_EXPOSED,        /**< Window has been exposed and should be
-                                         redrawn */
-    SDL_WINDOWEVENT_MOVED,          /**< Window has been moved to data1, data2
-                                     */
-    SDL_WINDOWEVENT_RESIZED,        /**< Window has been resized to data1xdata2 */
-    SDL_WINDOWEVENT_SIZE_CHANGED,   /**< The window size has changed, either as
-                                         a result of an API call or through the
-                                         system or user changing the window size. */
-    SDL_WINDOWEVENT_MINIMIZED,      /**< Window has been minimized */
-    SDL_WINDOWEVENT_MAXIMIZED,      /**< Window has been maximized */
-    SDL_WINDOWEVENT_RESTORED,       /**< Window has been restored to normal size
-                                         and position */
-    SDL_WINDOWEVENT_ENTER,          /**< Window has gained mouse focus */
-    SDL_WINDOWEVENT_LEAVE,          /**< Window has lost mouse focus */
-    SDL_WINDOWEVENT_FOCUS_GAINED,   /**< Window has gained keyboard focus */
-    SDL_WINDOWEVENT_FOCUS_LOST,     /**< Window has lost keyboard focus */
-    SDL_WINDOWEVENT_CLOSE,          /**< The window manager requests that the window be closed */
-    SDL_WINDOWEVENT_TAKE_FOCUS,     /**< Window is being offered a focus (should SetWindowInputFocus() on itself or a subwindow, or ignore) */
-    SDL_WINDOWEVENT_HIT_TEST,       /**< Window had a hit test that wasn't SDL_HITTEST_NORMAL. */
-    SDL_WINDOWEVENT_ICCPROF_CHANGED,/**< The ICC profile of the window's display has changed. */
-    SDL_WINDOWEVENT_DISPLAY_CHANGED /**< Window has been moved to display data1. */
-} SDL_WindowEventID;
-
-/**
- *  \brief Event subtype for display events
- */
-typedef enum
-{
-    SDL_DISPLAYEVENT_NONE,          /**< Never used */
-    SDL_DISPLAYEVENT_ORIENTATION,   /**< Display orientation has changed to data1 */
-    SDL_DISPLAYEVENT_CONNECTED,     /**< Display has been added to the system */
-    SDL_DISPLAYEVENT_DISCONNECTED,  /**< Display has been removed from the system */
-    SDL_DISPLAYEVENT_MOVED          /**< Display has changed position */
-} SDL_DisplayEventID;
-
-/**
  *  \brief Display orientation
  */
 typedef enum

--- a/src/events/SDL_displayevents.c
+++ b/src/events/SDL_displayevents.c
@@ -24,7 +24,7 @@
 
 #include "SDL_events_c.h"
 
-int SDL_SendDisplayEvent(SDL_VideoDisplay *display, Uint8 displayevent, int data1)
+int SDL_SendDisplayEvent(SDL_VideoDisplay *display, Uint32 displayevent, int data1)
 {
     int posted;
 
@@ -32,7 +32,7 @@ int SDL_SendDisplayEvent(SDL_VideoDisplay *display, Uint8 displayevent, int data
         return 0;
     }
     switch (displayevent) {
-    case SDL_DISPLAYEVENT_ORIENTATION:
+    case SDL_DISPLAYORIENTATION:
         if (data1 == SDL_ORIENTATION_UNKNOWN || data1 == display->orientation) {
             return 0;
         }
@@ -42,11 +42,10 @@ int SDL_SendDisplayEvent(SDL_VideoDisplay *display, Uint8 displayevent, int data
 
     /* Post the event, if desired */
     posted = 0;
-    if (SDL_GetEventState(SDL_DISPLAYEVENT) == SDL_ENABLE) {
+    if (SDL_GetEventState(displayevent) == SDL_ENABLE) {
         SDL_Event event;
-        event.type = SDL_DISPLAYEVENT;
+        event.type = displayevent;
         event.common.timestamp = 0;
-        event.display.event = displayevent;
         event.display.display = SDL_GetIndexOfDisplay(display);
         event.display.data1 = data1;
         posted = (SDL_PushEvent(&event) > 0);

--- a/src/events/SDL_displayevents_c.h
+++ b/src/events/SDL_displayevents_c.h
@@ -23,7 +23,7 @@
 #ifndef SDL_displayevents_c_h_
 #define SDL_displayevents_c_h_
 
-extern int SDL_SendDisplayEvent(SDL_VideoDisplay *display, Uint8 displayevent, int data1);
+extern int SDL_SendDisplayEvent(SDL_VideoDisplay *display, Uint32 displayevent, int data1);
 
 #endif /* SDL_displayevents_c_h_ */
 

--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -197,6 +197,7 @@ static void SDL_LogEvent(const SDL_Event *event)
                            (int)event->user.code, event->user.data1, event->user.data2);
     }
 
+
     switch (event->type) {
 #define SDL_EVENT_CASE(x) \
     case x:               \
@@ -230,69 +231,95 @@ static void SDL_LogEvent(const SDL_Event *event)
         SDL_EVENT_CASE(SDL_RENDER_DEVICE_RESET)
         break;
 
-        SDL_EVENT_CASE(SDL_DISPLAYEVENT)
-        {
-            char name2[64];
-            switch (event->display.event) {
-            case SDL_DISPLAYEVENT_NONE:
-                SDL_strlcpy(name2, "SDL_DISPLAYEVENT_NONE (THIS IS PROBABLY A BUG!)", sizeof(name2));
-                break;
-#define SDL_DISPLAYEVENT_CASE(x)               \
-    case x:                                    \
-        SDL_strlcpy(name2, #x, sizeof(name2)); \
-        break
-                SDL_DISPLAYEVENT_CASE(SDL_DISPLAYEVENT_ORIENTATION);
-                SDL_DISPLAYEVENT_CASE(SDL_DISPLAYEVENT_CONNECTED);
-                SDL_DISPLAYEVENT_CASE(SDL_DISPLAYEVENT_DISCONNECTED);
-                SDL_DISPLAYEVENT_CASE(SDL_DISPLAYEVENT_MOVED);
-#undef SDL_DISPLAYEVENT_CASE
-            default:
-                SDL_strlcpy(name2, "UNKNOWN (bug? fixme?)", sizeof(name2));
-                break;
-            }
-            (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u display=%u event=%s data1=%d)",
-                               (uint)event->display.timestamp, (uint)event->display.display, name2, (int)event->display.data1);
-            break;
-        }
+        SDL_EVENT_CASE(SDL_DISPLAYORIENTATION);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u display=%u data1=%d)",
+                           (uint)event->display.timestamp, (uint)event->display.display, (int)event->display.data1);
+        break;
+        SDL_EVENT_CASE(SDL_DISPLAYCONNECTED);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u display=%u data1=%d)",
+                           (uint)event->display.timestamp, (uint)event->display.display, (int)event->display.data1);
+        break;
+        SDL_EVENT_CASE(SDL_DISPLAYDISCONNECTED);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u display=%u data1=%d)",
+                           (uint)event->display.timestamp, (uint)event->display.display, (int)event->display.data1);
+        break;
+        SDL_EVENT_CASE(SDL_DISPLAYMOVED);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u display=%u data1=%d)",
+                           (uint)event->display.timestamp, (uint)event->display.display, (int)event->display.data1);
+        break;
 
-        SDL_EVENT_CASE(SDL_WINDOWEVENT)
-        {
-            char name2[64];
-            switch (event->window.event) {
-            case SDL_WINDOWEVENT_NONE:
-                SDL_strlcpy(name2, "SDL_WINDOWEVENT_NONE (THIS IS PROBABLY A BUG!)", sizeof(name2));
-                break;
-#define SDL_WINDOWEVENT_CASE(x)                \
-    case x:                                    \
-        SDL_strlcpy(name2, #x, sizeof(name2)); \
-        break
-                SDL_WINDOWEVENT_CASE(SDL_WINDOWEVENT_SHOWN);
-                SDL_WINDOWEVENT_CASE(SDL_WINDOWEVENT_HIDDEN);
-                SDL_WINDOWEVENT_CASE(SDL_WINDOWEVENT_EXPOSED);
-                SDL_WINDOWEVENT_CASE(SDL_WINDOWEVENT_MOVED);
-                SDL_WINDOWEVENT_CASE(SDL_WINDOWEVENT_RESIZED);
-                SDL_WINDOWEVENT_CASE(SDL_WINDOWEVENT_SIZE_CHANGED);
-                SDL_WINDOWEVENT_CASE(SDL_WINDOWEVENT_MINIMIZED);
-                SDL_WINDOWEVENT_CASE(SDL_WINDOWEVENT_MAXIMIZED);
-                SDL_WINDOWEVENT_CASE(SDL_WINDOWEVENT_RESTORED);
-                SDL_WINDOWEVENT_CASE(SDL_WINDOWEVENT_ENTER);
-                SDL_WINDOWEVENT_CASE(SDL_WINDOWEVENT_LEAVE);
-                SDL_WINDOWEVENT_CASE(SDL_WINDOWEVENT_FOCUS_GAINED);
-                SDL_WINDOWEVENT_CASE(SDL_WINDOWEVENT_FOCUS_LOST);
-                SDL_WINDOWEVENT_CASE(SDL_WINDOWEVENT_CLOSE);
-                SDL_WINDOWEVENT_CASE(SDL_WINDOWEVENT_TAKE_FOCUS);
-                SDL_WINDOWEVENT_CASE(SDL_WINDOWEVENT_HIT_TEST);
-                SDL_WINDOWEVENT_CASE(SDL_WINDOWEVENT_ICCPROF_CHANGED);
-                SDL_WINDOWEVENT_CASE(SDL_WINDOWEVENT_DISPLAY_CHANGED);
-#undef SDL_WINDOWEVENT_CASE
-            default:
-                SDL_strlcpy(name2, "UNKNOWN (bug? fixme?)", sizeof(name2));
-                break;
-            }
-            (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u event=%s data1=%d data2=%d)",
-                               (uint)event->window.timestamp, (uint)event->window.windowID, name2, (int)event->window.data1, (int)event->window.data2);
-            break;
-        }
+        SDL_EVENT_CASE(SDL_WINSHOWN);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u data1=%d data2=%d)",
+                          (uint)event->window.timestamp, (uint)event->window.windowID, (int)event->window.data1, (int)event->window.data2);
+        break;
+        SDL_EVENT_CASE(SDL_WINHIDDEN);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u data1=%d data2=%d)",
+                          (uint)event->window.timestamp, (uint)event->window.windowID, (int)event->window.data1, (int)event->window.data2);
+        break;
+        SDL_EVENT_CASE(SDL_WINEXPOSED);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u data1=%d data2=%d)",
+                          (uint)event->window.timestamp, (uint)event->window.windowID, (int)event->window.data1, (int)event->window.data2);
+        break;
+        SDL_EVENT_CASE(SDL_WINMOVED);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u data1=%d data2=%d)",
+                          (uint)event->window.timestamp, (uint)event->window.windowID, (int)event->window.data1, (int)event->window.data2);
+        break;
+        SDL_EVENT_CASE(SDL_WINRESIZED);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u data1=%d data2=%d)",
+                          (uint)event->window.timestamp, (uint)event->window.windowID, (int)event->window.data1, (int)event->window.data2);
+        break;
+        SDL_EVENT_CASE(SDL_WINSIZECHANGED);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u data1=%d data2=%d)",
+                          (uint)event->window.timestamp, (uint)event->window.windowID, (int)event->window.data1, (int)event->window.data2);
+        break;
+        SDL_EVENT_CASE(SDL_WINMINIMIZED);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u data1=%d data2=%d)",
+                          (uint)event->window.timestamp, (uint)event->window.windowID, (int)event->window.data1, (int)event->window.data2);
+        break;
+        SDL_EVENT_CASE(SDL_WINMAXIMIZED);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u data1=%d data2=%d)",
+                          (uint)event->window.timestamp, (uint)event->window.windowID, (int)event->window.data1, (int)event->window.data2);
+        break;
+        SDL_EVENT_CASE(SDL_WINRESTORED);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u data1=%d data2=%d)",
+                          (uint)event->window.timestamp, (uint)event->window.windowID, (int)event->window.data1, (int)event->window.data2);
+        break;
+        SDL_EVENT_CASE(SDL_WINMOUSEFOCUSGAINED);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u data1=%d data2=%d)",
+                          (uint)event->window.timestamp, (uint)event->window.windowID, (int)event->window.data1, (int)event->window.data2);
+        break;
+        SDL_EVENT_CASE(SDL_WINMOUSEFOCUSLOST);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u data1=%d data2=%d)",
+                          (uint)event->window.timestamp, (uint)event->window.windowID, (int)event->window.data1, (int)event->window.data2);
+        break;
+        SDL_EVENT_CASE(SDL_WINKEYBOARDFOCUSGAINED);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u data1=%d data2=%d)",
+                          (uint)event->window.timestamp, (uint)event->window.windowID, (int)event->window.data1, (int)event->window.data2);
+        break;
+        SDL_EVENT_CASE(SDL_WINKEYBOARDFOCUSLOST);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u data1=%d data2=%d)",
+                          (uint)event->window.timestamp, (uint)event->window.windowID, (int)event->window.data1, (int)event->window.data2);
+        break;
+        SDL_EVENT_CASE(SDL_WINCLOSE);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u data1=%d data2=%d)",
+                          (uint)event->window.timestamp, (uint)event->window.windowID, (int)event->window.data1, (int)event->window.data2);
+        break;
+        SDL_EVENT_CASE(SDL_WINTAKEFOCUS);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u data1=%d data2=%d)",
+                          (uint)event->window.timestamp, (uint)event->window.windowID, (int)event->window.data1, (int)event->window.data2);
+        break;
+        SDL_EVENT_CASE(SDL_WINHITTEST);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u data1=%d data2=%d)",
+                          (uint)event->window.timestamp, (uint)event->window.windowID, (int)event->window.data1, (int)event->window.data2);
+        break;
+        SDL_EVENT_CASE(SDL_WINICCPROFCHANGED);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u data1=%d data2=%d)",
+                          (uint)event->window.timestamp, (uint)event->window.windowID, (int)event->window.data1, (int)event->window.data2);
+        break;
+        SDL_EVENT_CASE(SDL_WINDISPLAYCHANGED);
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u data1=%d data2=%d)",
+                          (uint)event->window.timestamp, (uint)event->window.windowID, (int)event->window.data1, (int)event->window.data2);
+        break;
 
         SDL_EVENT_CASE(SDL_SYSWMEVENT)
         /* !!! FIXME: we don't delve further at the moment. */

--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -762,8 +762,7 @@ void SDL_SetKeyboardFocus(SDL_Window *window)
             SDL_assert(!(keyboard->focus->flags & SDL_WINDOW_MOUSE_CAPTURE));
         }
 
-        SDL_SendWindowEvent(keyboard->focus, SDL_WINDOWEVENT_FOCUS_LOST,
-                            0, 0);
+        SDL_SendWindowEvent(keyboard->focus, SDL_WINKEYBOARDFOCUSLOST, 0, 0);
 
         /* Ensures IME compositions are committed */
         if (SDL_EventState(SDL_TEXTINPUT, SDL_QUERY)) {
@@ -777,8 +776,7 @@ void SDL_SetKeyboardFocus(SDL_Window *window)
     keyboard->focus = window;
 
     if (keyboard->focus) {
-        SDL_SendWindowEvent(keyboard->focus, SDL_WINDOWEVENT_FOCUS_GAINED,
-                            0, 0);
+        SDL_SendWindowEvent(keyboard->focus, SDL_WINKEYBOARDFOCUSGAINED, 0, 0);
 
         if (SDL_EventState(SDL_TEXTINPUT, SDL_QUERY)) {
             SDL_VideoDevice *video = SDL_GetVideoDevice();

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -290,14 +290,14 @@ void SDL_SetMouseFocus(SDL_Window *window)
 
     /* See if the current window has lost focus */
     if (mouse->focus) {
-        SDL_SendWindowEvent(mouse->focus, SDL_WINDOWEVENT_LEAVE, 0, 0);
+        SDL_SendWindowEvent(mouse->focus, SDL_WINMOUSEFOCUSLOST, 0, 0);
     }
 
     mouse->focus = window;
     mouse->has_position = SDL_FALSE;
 
     if (mouse->focus) {
-        SDL_SendWindowEvent(mouse->focus, SDL_WINDOWEVENT_ENTER, 0, 0);
+        SDL_SendWindowEvent(mouse->focus, SDL_WINMOUSEFOCUSGAINED, 0, 0);
     }
 
     /* Update cursor visibility */

--- a/src/events/SDL_windowevents_c.h
+++ b/src/events/SDL_windowevents_c.h
@@ -23,7 +23,7 @@
 #ifndef SDL_windowevents_c_h_
 #define SDL_windowevents_c_h_
 
-extern int SDL_SendWindowEvent(SDL_Window *window, Uint8 windowevent,
+extern int SDL_SendWindowEvent(SDL_Window *window, Uint32 windowevent,
                                int data1, int data2);
 
 #endif /* SDL_windowevents_c_h_ */

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -667,11 +667,39 @@ static void GetWindowViewportValues(SDL_Renderer *renderer, int *logical_w, int 
     SDL_UnlockMutex(renderer->target_mutex);
 }
 
+/* !!! FIXME: maybe add categories to events? */
+static SDL_bool IsWindowEvent(Uint32 evtype)
+{
+    switch (evtype) {
+        case SDL_WINSHOWN:
+        case SDL_WINHIDDEN:
+        case SDL_WINEXPOSED:
+        case SDL_WINMOVED:
+        case SDL_WINRESIZED:
+        case SDL_WINSIZECHANGED:
+        case SDL_WINMINIMIZED:
+        case SDL_WINMAXIMIZED:
+        case SDL_WINRESTORED:
+        case SDL_WINMOUSEFOCUSGAINED:
+        case SDL_WINMOUSEFOCUSLOST:
+        case SDL_WINKEYBOARDFOCUSGAINED:
+        case SDL_WINKEYBOARDFOCUSLOST:
+        case SDL_WINCLOSE:
+        case SDL_WINTAKEFOCUS:
+        case SDL_WINHITTEST:
+        case SDL_WINICCPROFCHANGED:
+        case SDL_WINDISPLAYCHANGED:
+            return SDL_TRUE;
+    }
+
+    return SDL_FALSE;
+}
+
 static int SDLCALL SDL_RendererEventWatch(void *userdata, SDL_Event *event)
 {
     SDL_Renderer *renderer = (SDL_Renderer *)userdata;
 
-    if (event->type == SDL_WINDOWEVENT) {
+    if (IsWindowEvent(event->type)) {
         SDL_Window *window = SDL_GetWindowFromID(event->window.windowID);
         if (window == renderer->window) {
             if (renderer->WindowEvent) {
@@ -682,8 +710,8 @@ static int SDLCALL SDL_RendererEventWatch(void *userdata, SDL_Event *event)
              * window display changes as well! If the new display has a new DPI,
              * we need to update the viewport for the new window/drawable ratio.
              */
-            if (event->window.event == SDL_WINDOWEVENT_SIZE_CHANGED ||
-                event->window.event == SDL_WINDOWEVENT_DISPLAY_CHANGED) {
+            if (event->type == SDL_WINSIZECHANGED ||
+                event->type == SDL_WINDISPLAYCHANGED) {
                 /* Make sure we're operating on the default render target */
                 SDL_Texture *saved_target = SDL_GetRenderTarget(renderer);
                 if (saved_target) {
@@ -736,16 +764,16 @@ static int SDLCALL SDL_RendererEventWatch(void *userdata, SDL_Event *event)
                 if (saved_target) {
                     SDL_SetRenderTarget(renderer, saved_target);
                 }
-            } else if (event->window.event == SDL_WINDOWEVENT_HIDDEN) {
+            } else if (event->type == SDL_WINHIDDEN) {
                 renderer->hidden = SDL_TRUE;
-            } else if (event->window.event == SDL_WINDOWEVENT_SHOWN) {
+            } else if (event->type == SDL_WINSHOWN) {
                 if (!(SDL_GetWindowFlags(window) & SDL_WINDOW_MINIMIZED)) {
                     renderer->hidden = SDL_FALSE;
                 }
-            } else if (event->window.event == SDL_WINDOWEVENT_MINIMIZED) {
+            } else if (event->type == SDL_WINMINIMIZED) {
                 renderer->hidden = SDL_TRUE;
-            } else if (event->window.event == SDL_WINDOWEVENT_RESTORED ||
-                       event->window.event == SDL_WINDOWEVENT_MAXIMIZED) {
+            } else if (event->type == SDL_WINRESTORED ||
+                       event->type == SDL_WINMAXIMIZED) {
                 if (!(SDL_GetWindowFlags(window) & SDL_WINDOW_HIDDEN)) {
                     renderer->hidden = SDL_FALSE;
                 }

--- a/src/render/opengl/SDL_render_gl.c
+++ b/src/render/opengl/SDL_render_gl.c
@@ -324,8 +324,7 @@ static void GL_WindowEvent(SDL_Renderer *renderer, const SDL_WindowEvent *event)
      * changed behind our backs. x/y changes might seem weird but viewport
      * resets have been observed on macOS at minimum!
      */
-    if (event->event == SDL_WINDOWEVENT_SIZE_CHANGED ||
-        event->event == SDL_WINDOWEVENT_MOVED) {
+    if (event->type == SDL_WINSIZECHANGED || event->type == SDL_WINMOVED) {
         GL_RenderData *data = (GL_RenderData *)renderer->driverdata;
         data->drawstate.viewport_dirty = SDL_TRUE;
     }

--- a/src/render/opengles2/SDL_render_gles2.c
+++ b/src/render/opengles2/SDL_render_gles2.c
@@ -303,7 +303,7 @@ static void GLES2_WindowEvent(SDL_Renderer *renderer, const SDL_WindowEvent *eve
 {
     GLES2_RenderData *data = (GLES2_RenderData *)renderer->driverdata;
 
-    if (event->event == SDL_WINDOWEVENT_MINIMIZED) {
+    if (event->type == SDL_WINMINIMIZED) {
         /* According to Apple documentation, we need to finish drawing NOW! */
         data->glFinish();
     }

--- a/src/render/software/SDL_render_sw.c
+++ b/src/render/software/SDL_render_sw.c
@@ -69,7 +69,7 @@ static void SW_WindowEvent(SDL_Renderer *renderer, const SDL_WindowEvent *event)
 {
     SW_RenderData *data = (SW_RenderData *)renderer->driverdata;
 
-    if (event->event == SDL_WINDOWEVENT_SIZE_CHANGED) {
+    if (event->type == SDL_WINSIZECHANGED) {
         data->surface = NULL;
         data->window = NULL;
     }

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1432,97 +1432,75 @@ static const char *ControllerButtonName(const SDL_GameControllerButton button)
 static void SDLTest_PrintEvent(SDL_Event *event)
 {
     switch (event->type) {
-    case SDL_DISPLAYEVENT:
-        switch (event->display.event) {
-        case SDL_DISPLAYEVENT_CONNECTED:
-            SDL_Log("SDL EVENT: Display %" SDL_PRIu32 " connected",
-                    event->display.display);
-            break;
-        case SDL_DISPLAYEVENT_MOVED:
-            SDL_Log("SDL EVENT: Display %" SDL_PRIu32 " changed position",
-                    event->display.display);
-            break;
-        case SDL_DISPLAYEVENT_ORIENTATION:
-            SDL_Log("SDL EVENT: Display %" SDL_PRIu32 " changed orientation to %s",
-                    event->display.display, DisplayOrientationName(event->display.data1));
-            break;
-        case SDL_DISPLAYEVENT_DISCONNECTED:
-            SDL_Log("SDL EVENT: Display %" SDL_PRIu32 " disconnected",
-                    event->display.display);
-            break;
-        default:
-            SDL_Log("SDL EVENT: Display %" SDL_PRIu32 " got unknown event 0x%4.4x",
-                    event->display.display, event->display.event);
-            break;
-        }
+    case SDL_DISPLAYCONNECTED:
+        SDL_Log("SDL EVENT: Display %" SDL_PRIu32 " connected", event->display.display);
         break;
-    case SDL_WINDOWEVENT:
-        switch (event->window.event) {
-        case SDL_WINDOWEVENT_SHOWN:
-            SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " shown", event->window.windowID);
-            break;
-        case SDL_WINDOWEVENT_HIDDEN:
-            SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " hidden", event->window.windowID);
-            break;
-        case SDL_WINDOWEVENT_EXPOSED:
-            SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " exposed", event->window.windowID);
-            break;
-        case SDL_WINDOWEVENT_MOVED:
-            SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " moved to %" SDL_PRIs32 ",%" SDL_PRIs32,
-                    event->window.windowID, event->window.data1, event->window.data2);
-            break;
-        case SDL_WINDOWEVENT_RESIZED:
-            SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " resized to %" SDL_PRIs32 "x%" SDL_PRIs32,
-                    event->window.windowID, event->window.data1, event->window.data2);
-            break;
-        case SDL_WINDOWEVENT_SIZE_CHANGED:
-            SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " changed size to %" SDL_PRIs32 "x%" SDL_PRIs32,
-                    event->window.windowID, event->window.data1, event->window.data2);
-            break;
-        case SDL_WINDOWEVENT_MINIMIZED:
-            SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " minimized", event->window.windowID);
-            break;
-        case SDL_WINDOWEVENT_MAXIMIZED:
-            SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " maximized", event->window.windowID);
-            break;
-        case SDL_WINDOWEVENT_RESTORED:
-            SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " restored", event->window.windowID);
-            break;
-        case SDL_WINDOWEVENT_ENTER:
-            SDL_Log("SDL EVENT: Mouse entered window %" SDL_PRIu32 "",
-                    event->window.windowID);
-            break;
-        case SDL_WINDOWEVENT_LEAVE:
-            SDL_Log("SDL EVENT: Mouse left window %" SDL_PRIu32 "", event->window.windowID);
-            break;
-        case SDL_WINDOWEVENT_FOCUS_GAINED:
-            SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " gained keyboard focus",
-                    event->window.windowID);
-            break;
-        case SDL_WINDOWEVENT_FOCUS_LOST:
-            SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " lost keyboard focus",
-                    event->window.windowID);
-            break;
-        case SDL_WINDOWEVENT_CLOSE:
-            SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " closed", event->window.windowID);
-            break;
-        case SDL_WINDOWEVENT_TAKE_FOCUS:
-            SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " take focus", event->window.windowID);
-            break;
-        case SDL_WINDOWEVENT_HIT_TEST:
-            SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " hit test", event->window.windowID);
-            break;
-        case SDL_WINDOWEVENT_ICCPROF_CHANGED:
-            SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " ICC profile changed", event->window.windowID);
-            break;
-        case SDL_WINDOWEVENT_DISPLAY_CHANGED:
-            SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " display changed to %" SDL_PRIs32 "", event->window.windowID, event->window.data1);
-            break;
-        default:
-            SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " got unknown event 0x%4.4x",
-                    event->window.windowID, event->window.event);
-            break;
-        }
+    case SDL_DISPLAYMOVED:
+        SDL_Log("SDL EVENT: Display %" SDL_PRIu32 " changed position", event->display.display);
+        break;
+    case SDL_DISPLAYORIENTATION:
+        SDL_Log("SDL EVENT: Display %" SDL_PRIu32 " changed orientation to %s",
+                event->display.display, DisplayOrientationName(event->display.data1));
+        break;
+    case SDL_DISPLAYDISCONNECTED:
+        SDL_Log("SDL EVENT: Display %" SDL_PRIu32 " disconnected", event->display.display);
+        break;
+    case SDL_WINSHOWN:
+        SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " shown", event->window.windowID);
+        break;
+    case SDL_WINHIDDEN:
+        SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " hidden", event->window.windowID);
+        break;
+    case SDL_WINEXPOSED:
+        SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " exposed", event->window.windowID);
+        break;
+    case SDL_WINMOVED:
+        SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " moved to %" SDL_PRIs32 ",%" SDL_PRIs32,
+                event->window.windowID, event->window.data1, event->window.data2);
+        break;
+    case SDL_WINRESIZED:
+        SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " resized to %" SDL_PRIs32 "x%" SDL_PRIs32,
+                event->window.windowID, event->window.data1, event->window.data2);
+        break;
+    case SDL_WINSIZECHANGED:
+        SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " changed size to %" SDL_PRIs32 "x%" SDL_PRIs32,
+                event->window.windowID, event->window.data1, event->window.data2);
+        break;
+    case SDL_WINMINIMIZED:
+        SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " minimized", event->window.windowID);
+        break;
+    case SDL_WINMAXIMIZED:
+        SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " maximized", event->window.windowID);
+        break;
+    case SDL_WINRESTORED:
+        SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " restored", event->window.windowID);
+        break;
+    case SDL_WINMOUSEFOCUSGAINED:
+        SDL_Log("SDL EVENT: Mouse entered window %" SDL_PRIu32 "", event->window.windowID);
+        break;
+    case SDL_WINMOUSEFOCUSLOST:
+        SDL_Log("SDL EVENT: Mouse left window %" SDL_PRIu32 "", event->window.windowID);
+        break;
+    case SDL_WINKEYBOARDFOCUSGAINED:
+        SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " gained keyboard focus", event->window.windowID);
+        break;
+    case SDL_WINKEYBOARDFOCUSLOST:
+        SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " lost keyboard focus", event->window.windowID);
+        break;
+    case SDL_WINCLOSE:
+        SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " closed", event->window.windowID);
+        break;
+    case SDL_WINTAKEFOCUS:
+        SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " take focus", event->window.windowID);
+        break;
+    case SDL_WINHITTEST:
+        SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " hit test", event->window.windowID);
+        break;
+    case SDL_WINICCPROFCHANGED:
+        SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " ICC profile changed", event->window.windowID);
+        break;
+    case SDL_WINDISPLAYCHANGED:
+        SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " display changed to %" SDL_PRIs32 "", event->window.windowID, event->window.data1);
         break;
     case SDL_KEYDOWN:
         SDL_Log("SDL EVENT: Keyboard: key pressed  in window %" SDL_PRIu32 ": scancode 0x%08X = %s, keycode 0x%08" SDL_PRIX32 " = %s",
@@ -1782,39 +1760,34 @@ void SDLTest_CommonEvent(SDLTest_CommonState *state, SDL_Event *event, int *done
     }
 
     switch (event->type) {
-    case SDL_WINDOWEVENT:
-        switch (event->window.event) {
-        case SDL_WINDOWEVENT_CLOSE:
-        {
+    case SDL_WINCLOSE:
+    {
+        SDL_Window *window = SDL_GetWindowFromID(event->window.windowID);
+        if (window) {
+            for (i = 0; i < state->num_windows; ++i) {
+                if (window == state->windows[i]) {
+                    if (state->targets[i]) {
+                        SDL_DestroyTexture(state->targets[i]);
+                        state->targets[i] = NULL;
+                    }
+                    if (state->renderers[i]) {
+                        SDL_DestroyRenderer(state->renderers[i]);
+                        state->renderers[i] = NULL;
+                    }
+                    SDL_DestroyWindow(state->windows[i]);
+                    state->windows[i] = NULL;
+                    break;
+                }
+            }
+        }
+        break;
+    }
+    case SDL_WINKEYBOARDFOCUSLOST:
+        if (state->flash_on_focus_loss) {
             SDL_Window *window = SDL_GetWindowFromID(event->window.windowID);
             if (window) {
-                for (i = 0; i < state->num_windows; ++i) {
-                    if (window == state->windows[i]) {
-                        if (state->targets[i]) {
-                            SDL_DestroyTexture(state->targets[i]);
-                            state->targets[i] = NULL;
-                        }
-                        if (state->renderers[i]) {
-                            SDL_DestroyRenderer(state->renderers[i]);
-                            state->renderers[i] = NULL;
-                        }
-                        SDL_DestroyWindow(state->windows[i]);
-                        state->windows[i] = NULL;
-                        break;
-                    }
-                }
+                SDL_FlashWindow(window, SDL_FLASH_UNTIL_FOCUSED);
             }
-        } break;
-        case SDL_WINDOWEVENT_FOCUS_LOST:
-            if (state->flash_on_focus_loss) {
-                SDL_Window *window = SDL_GetWindowFromID(event->window.windowID);
-                if (window) {
-                    SDL_FlashWindow(window, SDL_FLASH_UNTIL_FOCUSED);
-                }
-            }
-            break;
-        default:
-            break;
         }
         break;
     case SDL_KEYDOWN:

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -601,7 +601,7 @@ int SDL_AddVideoDisplay(const SDL_VideoDisplay *display, SDL_bool send_event)
         }
 
         if (send_event) {
-            SDL_SendDisplayEvent(&_this->displays[index], SDL_DISPLAYEVENT_CONNECTED, 0);
+            SDL_SendDisplayEvent(&_this->displays[index], SDL_DISPLAYCONNECTED, 0);
         }
     } else {
         SDL_OutOfMemory();
@@ -615,7 +615,7 @@ void SDL_DelVideoDisplay(int index)
         return;
     }
 
-    SDL_SendDisplayEvent(&_this->displays[index], SDL_DISPLAYEVENT_DISCONNECTED, 0);
+    SDL_SendDisplayEvent(&_this->displays[index], SDL_DISPLAYDISCONNECTED, 0);
 
     if (index < (_this->num_displays - 1)) {
         SDL_free(_this->displays[index].driverdata);
@@ -1236,7 +1236,7 @@ int SDL_SetWindowDisplayMode(SDL_Window *window, const SDL_DisplayMode *mode)
                  * use fullscreen_mode.w and fullscreen_mode.h, but rather get our current native size.  As such,
                  * Android's SetWindowFullscreen will generate the window event for us with the proper final size.
                  */
-                SDL_SendWindowEvent(window, SDL_WINDOWEVENT_RESIZED, fullscreen_mode.w, fullscreen_mode.h);
+                SDL_SendWindowEvent(window, SDL_WINRESIZED, fullscreen_mode.w, fullscreen_mode.h);
 #endif
             }
         }
@@ -1452,8 +1452,7 @@ static int SDL_UpdateFullscreenMode(SDL_Window *window, SDL_bool fullscreen)
                      * WM_WINDOWPOSCHANGED will send SDL_WINDOWEVENT_RESIZED). Also, on Windows with DPI scaling enabled,
                      * we're keeping modes in pixels, but window sizes in dpi-scaled points, so this would be a unit mismatch.
                      */
-                    SDL_SendWindowEvent(other, SDL_WINDOWEVENT_RESIZED,
-                                        fullscreen_mode.w, fullscreen_mode.h);
+                    SDL_SendWindowEvent(other, SDL_WINRESIZED, fullscreen_mode.w, fullscreen_mode.h);
 #endif
                 } else {
                     SDL_OnWindowResized(other);
@@ -2459,7 +2458,7 @@ void SDL_ShowWindow(SDL_Window *window)
     if (_this->ShowWindow) {
         _this->ShowWindow(_this, window);
     }
-    SDL_SendWindowEvent(window, SDL_WINDOWEVENT_SHOWN, 0, 0);
+    SDL_SendWindowEvent(window, SDL_WINSHOWN, 0, 0);
 }
 
 void SDL_HideWindow(SDL_Window *window)
@@ -2477,7 +2476,7 @@ void SDL_HideWindow(SDL_Window *window)
         _this->HideWindow(_this, window);
     }
     window->is_hiding = SDL_FALSE;
-    SDL_SendWindowEvent(window, SDL_WINDOWEVENT_HIDDEN, 0, 0);
+    SDL_SendWindowEvent(window, SDL_WINHIDDEN, 0, 0);
 }
 
 void SDL_RaiseWindow(SDL_Window *window)
@@ -2933,11 +2932,11 @@ void SDL_OnWindowResized(SDL_Window *window)
     window->surface_valid = SDL_FALSE;
 
     if (!window->is_destroying) {
-        SDL_SendWindowEvent(window, SDL_WINDOWEVENT_SIZE_CHANGED, window->w, window->h);
+        SDL_SendWindowEvent(window, SDL_WINSIZECHANGED, window->w, window->h);
 
         if (display_index != window->display_index && display_index != -1) {
             window->display_index = display_index;
-            SDL_SendWindowEvent(window, SDL_WINDOWEVENT_DISPLAY_CHANGED, window->display_index, 0);
+            SDL_SendWindowEvent(window, SDL_WINDISPLAYCHANGED, window->display_index, 0);
         }
     }
 }
@@ -2948,7 +2947,7 @@ void SDL_OnWindowMoved(SDL_Window *window)
 
     if (!window->is_destroying && display_index != window->display_index && display_index != -1) {
         window->display_index = display_index;
-        SDL_SendWindowEvent(window, SDL_WINDOWEVENT_DISPLAY_CHANGED, window->display_index, 0);
+        SDL_SendWindowEvent(window, SDL_WINDISPLAYCHANGED, window->display_index, 0);
     }
 }
 
@@ -4584,8 +4583,8 @@ void SDL_OnApplicationWillResignActive(void)
     if (_this) {
         SDL_Window *window;
         for (window = _this->windows; window != NULL; window = window->next) {
-            SDL_SendWindowEvent(window, SDL_WINDOWEVENT_FOCUS_LOST, 0, 0);
-            SDL_SendWindowEvent(window, SDL_WINDOWEVENT_MINIMIZED, 0, 0);
+            SDL_SendWindowEvent(window, SDL_WINKEYBOARDFOCUSLOST, 0, 0);
+            SDL_SendWindowEvent(window, SDL_WINMINIMIZED, 0, 0);
         }
     }
     SDL_SendAppEvent(SDL_APP_WILLENTERBACKGROUND);
@@ -4608,8 +4607,8 @@ void SDL_OnApplicationDidBecomeActive(void)
     if (_this) {
         SDL_Window *window;
         for (window = _this->windows; window != NULL; window = window->next) {
-            SDL_SendWindowEvent(window, SDL_WINDOWEVENT_FOCUS_GAINED, 0, 0);
-            SDL_SendWindowEvent(window, SDL_WINDOWEVENT_RESTORED, 0, 0);
+            SDL_SendWindowEvent(window, SDL_WINKEYBOARDFOCUSGAINED, 0, 0);
+            SDL_SendWindowEvent(window, SDL_WINRESTORED, 0, 0);
         }
     }
 }

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -1124,7 +1124,7 @@ static void KMSDRM_DirtySurfaces(SDL_Window *window)
        or SetWindowFullscreen, send a fake event for now since the actual
        recreation is deferred */
     KMSDRM_GetModeToSet(window, &mode);
-    SDL_SendWindowEvent(window, SDL_WINDOWEVENT_RESIZED, mode.hdisplay, mode.vdisplay);
+    SDL_SendWindowEvent(window, SDL_WINRESIZED, mode.hdisplay, mode.vdisplay);
 }
 
 /* This determines the size of the fb, which comes from the GBM surface
@@ -1188,8 +1188,7 @@ int KMSDRM_CreateSurfaces(_THIS, SDL_Window *window)
     egl_context = (EGLContext)SDL_GL_GetCurrentContext();
     ret = SDL_EGL_MakeCurrent(_this, windata->egl_surface, egl_context);
 
-    SDL_SendWindowEvent(window, SDL_WINDOWEVENT_RESIZED,
-                        dispdata->mode.hdisplay, dispdata->mode.vdisplay);
+    SDL_SendWindowEvent(window, SDL_WINRESIZED, dispdata->mode.hdisplay, dispdata->mode.vdisplay);
 
     windata->egl_surface_dirty = SDL_FALSE;
 
@@ -1520,7 +1519,7 @@ int KMSDRM_CreateWindow(_THIS, SDL_Window *window)
     SDL_SetKeyboardFocus(window);
 
     /* Tell the app that the window has moved to top-left. */
-    SDL_SendWindowEvent(window, SDL_WINDOWEVENT_MOVED, 0, 0);
+    SDL_SendWindowEvent(window, SDL_WINMOVED, 0, 0);
 
     /* Allocated windata will be freed in KMSDRM_DestroyWindow,
        and KMSDRM_DestroyWindow() will be called by SDL_CreateWindow()

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -650,7 +650,7 @@ static void display_handle_done(void *data,
         SDL_free(driverdata->placeholder.name);
         SDL_zero(driverdata->placeholder);
     } else {
-        SDL_SendDisplayEvent(dpy, SDL_DISPLAYEVENT_ORIENTATION, driverdata->orientation);
+        SDL_SendDisplayEvent(dpy, SDL_DISPLAYORIENTATION, driverdata->orientation);
     }
 }
 

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -618,9 +618,7 @@ static void handle_configure_xdg_toplevel(void *data,
          *
          * No, we do not get minimize events from xdg-shell.
          */
-        SDL_SendWindowEvent(window,
-                            maximized ? SDL_WINDOWEVENT_MAXIMIZED : SDL_WINDOWEVENT_RESTORED,
-                            0, 0);
+        SDL_SendWindowEvent(window, maximized ? SDL_WINMAXIMIZED : SDL_WINRESTORED, 0, 0);
 
         /* Store current floating dimensions for restoring */
         if (floating) {
@@ -669,7 +667,7 @@ static void handle_configure_xdg_toplevel(void *data,
 static void handle_close_xdg_toplevel(void *data, struct xdg_toplevel *xdg_toplevel)
 {
     SDL_WindowData *window = (SDL_WindowData *)data;
-    SDL_SendWindowEvent(window->sdlwindow, SDL_WINDOWEVENT_CLOSE, 0, 0);
+    SDL_SendWindowEvent(window->sdlwindow, SDL_WINCLOSE, 0, 0);
 }
 
 static const struct xdg_toplevel_listener toplevel_listener_xdg = {
@@ -690,7 +688,7 @@ static void handle_configure_xdg_popup(void *data,
 static void handle_done_xdg_popup(void *data, struct xdg_popup *xdg_popup)
 {
     SDL_WindowData *window = (SDL_WindowData *)data;
-    SDL_SendWindowEvent(window->sdlwindow, SDL_WINDOWEVENT_CLOSE, 0, 0);
+    SDL_SendWindowEvent(window->sdlwindow, SDL_WINCLOSE, 0, 0);
 }
 
 static void handle_repositioned_xdg_popup(void *data,
@@ -806,15 +804,11 @@ static void decoration_frame_configure(struct libdecor_frame *frame,
          *
          * No, we do not get minimize events from libdecor.
          */
-        SDL_SendWindowEvent(window,
-                            maximized ? SDL_WINDOWEVENT_MAXIMIZED : SDL_WINDOWEVENT_RESTORED,
-                            0, 0);
+        SDL_SendWindowEvent(window, maximized ? SDL_WINMAXIMIZED : SDL_WINRESTORED, 0, 0);
     }
 
     /* Similar to maximized/restore events above, send focus events too! */
-    SDL_SendWindowEvent(window,
-                        focused ? SDL_WINDOWEVENT_FOCUS_GAINED : SDL_WINDOWEVENT_FOCUS_LOST,
-                        0, 0);
+    SDL_SendWindowEvent(window, focused ? SDL_WINKEYBOARDFOCUSGAINED : SDL_WINKEYBOARDFOCUSLOST, 0, 0);
 
     /* For fullscreen or fixed-size windows we know our size.
      * Always assume the configure is wrong.
@@ -905,14 +899,14 @@ static void decoration_frame_configure(struct libdecor_frame *frame,
 
 static void decoration_frame_close(struct libdecor_frame *frame, void *user_data)
 {
-    SDL_SendWindowEvent(((SDL_WindowData *)user_data)->sdlwindow, SDL_WINDOWEVENT_CLOSE, 0, 0);
+    SDL_SendWindowEvent(((SDL_WindowData *)user_data)->sdlwindow, SDL_WINCLOSE, 0, 0);
 }
 
 static void decoration_frame_commit(struct libdecor_frame *frame, void *user_data)
 {
     SDL_WindowData *wind = user_data;
 
-    SDL_SendWindowEvent(wind->sdlwindow, SDL_WINDOWEVENT_EXPOSED, 0, 0);
+    SDL_SendWindowEvent(wind->sdlwindow, SDL_WINEXPOSED, 0, 0);
 }
 
 static struct libdecor_frame_interface libdecor_frame_interface = {
@@ -937,7 +931,7 @@ static void handle_set_generic_property(void *data,
 static void handle_close(void *data, struct qt_extended_surface *qt_extended_surface)
 {
     SDL_WindowData *window = (SDL_WindowData *)data;
-    SDL_SendWindowEvent(window->sdlwindow, SDL_WINDOWEVENT_CLOSE, 0, 0);
+    SDL_SendWindowEvent(window->sdlwindow, SDL_WINCLOSE, 0, 0);
 }
 
 static const struct qt_extended_surface_listener extended_surface_listener = {
@@ -1037,7 +1031,7 @@ static void Wayland_move_window(SDL_Window *window,
              * -flibit
              */
             SDL_GetDisplayBounds(i, &bounds);
-            SDL_SendWindowEvent(window, SDL_WINDOWEVENT_MOVED, bounds.x, bounds.y);
+            SDL_SendWindowEvent(window, SDL_WINMOVED, bounds.x, bounds.y);
 
             /*
              * If the fullscreen output was changed, and we have bad dimensions from
@@ -2028,7 +2022,7 @@ static void Wayland_HandleResize(SDL_Window *window, int width, int height, floa
          * so we must override the deduplication logic in the video core */
         window->w = 0;
         window->h = 0;
-        SDL_SendWindowEvent(window, SDL_WINDOWEVENT_RESIZED, width, height);
+        SDL_SendWindowEvent(window, SDL_WINRESIZED, width, height);
         window->w = width;
         window->h = height;
         data->needs_resize_event = SDL_FALSE;

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -492,8 +492,8 @@ static void X11_DispatchFocusOut(_THIS, SDL_WindowData *data)
 static void X11_DispatchMapNotify(SDL_WindowData *data)
 {
     SDL_Window *window = data->window;
-    SDL_SendWindowEvent(window, SDL_WINDOWEVENT_RESTORED, 0, 0);
-    SDL_SendWindowEvent(window, SDL_WINDOWEVENT_SHOWN, 0, 0);
+    SDL_SendWindowEvent(window, SDL_WINRESTORED, 0, 0);
+    SDL_SendWindowEvent(window, SDL_WINSHOWN, 0, 0);
     if (!(window->flags & SDL_WINDOW_HIDDEN) && (window->flags & SDL_WINDOW_INPUT_FOCUS)) {
         SDL_UpdateWindowGrab(window);
     }
@@ -501,8 +501,8 @@ static void X11_DispatchMapNotify(SDL_WindowData *data)
 
 static void X11_DispatchUnmapNotify(SDL_WindowData *data)
 {
-    SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_HIDDEN, 0, 0);
-    SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_MINIMIZED, 0, 0);
+    SDL_SendWindowEvent(data->window, SDL_WINHIDDEN, 0, 0);
+    SDL_SendWindowEvent(data->window, SDL_WINMINIMIZED, 0, 0);
 }
 
 static void InitiateWindowMove(_THIS, const SDL_WindowData *data, const SDL_Point *point)
@@ -879,12 +879,12 @@ static void X11_DispatchEvent(_THIS, XEvent *xevent)
                         X11_XGetWindowAttributes(display, data->xwindow, &attrib);
                         screennum = X11_XScreenNumberOfScreen(attrib.screen);
                         if (screennum == 0 && SDL_strcmp(name_of_atom, "_ICC_PROFILE") == 0) {
-                            SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_ICCPROF_CHANGED, 0, 0);
+                            SDL_SendWindowEvent(data->window, SDL_WINICCPROFCHANGED, 0, 0);
                         } else if (SDL_strncmp(name_of_atom, "_ICC_PROFILE_", sizeof("_ICC_PROFILE_") - 1) == 0 && SDL_strlen(name_of_atom) > sizeof("_ICC_PROFILE_") - 1) {
                             int iccscreennum = SDL_atoi(&name_of_atom[sizeof("_ICC_PROFILE_") - 1]);
 
                             if (screennum == iccscreennum) {
-                                SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_ICCPROF_CHANGED, 0, 0);
+                                SDL_SendWindowEvent(data->window, SDL_WINICCPROFCHANGED, 0, 0);
                             }
                         }
                     }
@@ -1168,7 +1168,7 @@ static void X11_DispatchEvent(_THIS, XEvent *xevent)
 
         if (xevent->xconfigure.x != data->last_xconfigure.x ||
             xevent->xconfigure.y != data->last_xconfigure.y) {
-            SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_MOVED,
+            SDL_SendWindowEvent(data->window, SDL_WINMOVED,
                                 xevent->xconfigure.x, xevent->xconfigure.y);
 #ifdef SDL_USE_IME
             if (SDL_GetEventState(SDL_TEXTINPUT) == SDL_ENABLE) {
@@ -1179,7 +1179,7 @@ static void X11_DispatchEvent(_THIS, XEvent *xevent)
         }
         if (xevent->xconfigure.width != data->last_xconfigure.width ||
             xevent->xconfigure.height != data->last_xconfigure.height) {
-            SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_RESIZED,
+            SDL_SendWindowEvent(data->window, SDL_WINRESIZED,
                                 xevent->xconfigure.width,
                                 xevent->xconfigure.height);
         }
@@ -1280,7 +1280,7 @@ static void X11_DispatchEvent(_THIS, XEvent *xevent)
 #ifdef DEBUG_XEVENTS
             printf("window %p: WM_DELETE_WINDOW\n", data);
 #endif
-            SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_CLOSE, 0, 0);
+            SDL_SendWindowEvent(data->window, SDL_WINCLOSE, 0, 0);
             break;
         } else if ((xevent->xclient.message_type == videodata->WM_PROTOCOLS) &&
                    (xevent->xclient.format == 32) &&
@@ -1289,7 +1289,7 @@ static void X11_DispatchEvent(_THIS, XEvent *xevent)
 #ifdef DEBUG_XEVENTS
             printf("window %p: WM_TAKE_FOCUS\n", data);
 #endif
-            SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_TAKE_FOCUS, 0, 0);
+            SDL_SendWindowEvent(data->window, SDL_WINTAKEFOCUS, 0, 0);
             break;
         }
     } break;
@@ -1300,7 +1300,7 @@ static void X11_DispatchEvent(_THIS, XEvent *xevent)
 #ifdef DEBUG_XEVENTS
         printf("window %p: Expose (count = %d)\n", data, xevent->xexpose.count);
 #endif
-        SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_EXPOSED, 0, 0);
+        SDL_SendWindowEvent(data->window, SDL_WINEXPOSED, 0, 0);
     } break;
 
     case MotionNotify:
@@ -1328,7 +1328,7 @@ static void X11_DispatchEvent(_THIS, XEvent *xevent)
             int button = xevent->xbutton.button;
             if (button == Button1) {
                 if (ProcessHitTest(_this, data, xevent)) {
-                    SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_HIT_TEST, 0, 0);
+                    SDL_SendWindowEvent(data->window, SDL_WINHITTEST, 0, 0);
                     break; /* don't pass this event on to app. */
                 }
             } else if (button > 7) {
@@ -1475,9 +1475,9 @@ static void X11_DispatchEvent(_THIS, XEvent *xevent)
 
             if (changed & SDL_WINDOW_MAXIMIZED) {
                 if (flags & SDL_WINDOW_MAXIMIZED) {
-                    SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_MAXIMIZED, 0, 0);
+                    SDL_SendWindowEvent(data->window, SDL_WINMAXIMIZED, 0, 0);
                 } else {
-                    SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_RESTORED, 0, 0);
+                    SDL_SendWindowEvent(data->window, SDL_WINRESTORED, 0, 0);
                 }
             }
         } else if (xevent->xproperty.atom == videodata->XKLAVIER_STATE) {

--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -1390,12 +1390,12 @@ static void X11_SetWindowFullscreenViaWM(_THIS, SDL_Window *window, SDL_VideoDis
             if (!caught_x11_error) {
                 SDL_bool window_changed = SDL_FALSE;
                 if ((x != orig_x) || (y != orig_y)) {
-                    SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_MOVED, x, y);
+                    SDL_SendWindowEvent(data->window, SDL_WINMOVED, x, y);
                     window_changed = SDL_TRUE;
                 }
 
                 if ((attrs.width != orig_w) || (attrs.height != orig_h)) {
-                    SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_RESIZED, attrs.width, attrs.height);
+                    SDL_SendWindowEvent(data->window, SDL_WINRESIZED, attrs.width, attrs.height);
                     window_changed = SDL_TRUE;
                 }
 

--- a/test/testdrawchessboard.c
+++ b/test/testdrawchessboard.c
@@ -56,8 +56,7 @@ void loop()
     while (SDL_PollEvent(&e)) {
 
         /* Re-create when window has been resized */
-        if ((e.type == SDL_WINDOWEVENT) && (e.window.event == SDL_WINDOWEVENT_SIZE_CHANGED)) {
-
+        if (e.type == SDL_WINSIZECHANGED) {
             SDL_DestroyRenderer(renderer);
 
             surface = SDL_GetWindowSurface(window);

--- a/test/testgles2.c
+++ b/test/testgles2.c
@@ -567,7 +567,7 @@ loop_threaded()
 
     /* Wait for events */
     while (SDL_WaitEvent(&event) && !done) {
-        if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_CLOSE) {
+        if (event.type == SDL_WINCLOSE) {
             SDL_Window *window = SDL_GetWindowFromID(event.window.windowID);
             if (window) {
                 for (i = 0; i < state->num_windows; ++i) {

--- a/test/testgles2_sdf.c
+++ b/test/testgles2_sdf.c
@@ -355,30 +355,27 @@ void loop()
             break;
         }
 
-        case SDL_WINDOWEVENT:
-            switch (event.window.event) {
-            case SDL_WINDOWEVENT_RESIZED:
-                for (i = 0; i < state->num_windows; ++i) {
-                    if (event.window.windowID == SDL_GetWindowID(state->windows[i])) {
-                        int w, h;
-                        status = SDL_GL_MakeCurrent(state->windows[i], context[i]);
-                        if (status) {
-                            SDL_Log("SDL_GL_MakeCurrent(): %s\n", SDL_GetError());
-                            break;
-                        }
-                        /* Change view port to the new window dimensions */
-                        SDL_GL_GetDrawableSize(state->windows[i], &w, &h);
-                        ctx.glViewport(0, 0, w, h);
-                        state->window_w = event.window.data1;
-                        state->window_h = event.window.data2;
-                        /* Update window content */
-                        Render(event.window.data1, event.window.data2, &datas[i]);
-                        SDL_GL_SwapWindow(state->windows[i]);
+        case SDL_WINRESIZED:
+            for (i = 0; i < state->num_windows; ++i) {
+                if (event.window.windowID == SDL_GetWindowID(state->windows[i])) {
+                    int w, h;
+                    status = SDL_GL_MakeCurrent(state->windows[i], context[i]);
+                    if (status) {
+                        SDL_Log("SDL_GL_MakeCurrent(): %s\n", SDL_GetError());
                         break;
                     }
+                    /* Change view port to the new window dimensions */
+                    SDL_GL_GetDrawableSize(state->windows[i], &w, &h);
+                    ctx.glViewport(0, 0, w, h);
+                    state->window_w = event.window.data1;
+                    state->window_h = event.window.data2;
+                    /* Update window content */
+                    Render(event.window.data1, event.window.data2, &datas[i]);
+                    SDL_GL_SwapWindow(state->windows[i]);
+                    break;
                 }
-                break;
             }
+            break;
         }
         SDLTest_CommonEvent(state, &event, &done);
     }

--- a/test/testhittesting.c
+++ b/test/testhittesting.c
@@ -107,10 +107,8 @@ int main(int argc, char **argv)
                 SDL_Log("button up!\n");
                 break;
 
-            case SDL_WINDOWEVENT:
-                if (e.window.event == SDL_WINDOWEVENT_MOVED) {
-                    SDL_Log("Window event moved to (%d, %d)!\n", (int)e.window.data1, (int)e.window.data2);
-                }
+            case SDL_WINMOVED:
+                SDL_Log("Window event moved to (%d, %d)!\n", (int)e.window.data1, (int)e.window.data2);
                 break;
 
             case SDL_KEYDOWN:

--- a/test/testoverlay2.c
+++ b/test/testoverlay2.c
@@ -229,12 +229,10 @@ void loop()
         SDLTest_CommonEvent(state, &event, &done);
 
         switch (event.type) {
-        case SDL_WINDOWEVENT:
-            if (event.window.event == SDL_WINDOWEVENT_RESIZED) {
-                SDL_RenderSetViewport(renderer, NULL);
-                displayrect.w = window_w = event.window.data1;
-                displayrect.h = window_h = event.window.data2;
-            }
+        case SDL_WINRESIZED:
+            SDL_RenderSetViewport(renderer, NULL);
+            displayrect.w = window_w = event.window.data1;
+            displayrect.h = window_h = event.window.data2;
             break;
         case SDL_MOUSEBUTTONDOWN:
             displayrect.x = event.button.x - window_w / 2;

--- a/test/testvulkan.c
+++ b/test/testvulkan.c
@@ -1125,7 +1125,7 @@ int main(int argc, char **argv)
             /* Need to destroy the swapchain before the window created
              * by SDL.
              */
-            if (event.type == SDL_WINDOWEVENT_CLOSE) {
+            if (event.type == SDL_WINCLOSE) {
                 destroySwapchainAndSwapchainSpecificStuff(SDL_TRUE);
             }
             SDLTest_CommonEvent(state, &event, &done);

--- a/test/testwm2.c
+++ b/test/testwm2.c
@@ -151,39 +151,33 @@ void loop()
     while (SDL_PollEvent(&event)) {
         SDLTest_CommonEvent(state, &event, &done);
 
-        if (event.type == SDL_WINDOWEVENT) {
-            if (event.window.event == SDL_WINDOWEVENT_RESIZED) {
-                SDL_Window *window = SDL_GetWindowFromID(event.window.windowID);
-                if (window) {
-                    SDL_Log("Window %" SDL_PRIu32 " resized to %" SDL_PRIs32 "x%" SDL_PRIs32 "\n",
-                            event.window.windowID,
-                            event.window.data1,
-                            event.window.data2);
-                }
+        if (event.type == SDL_WINRESIZED) {
+            SDL_Window *window = SDL_GetWindowFromID(event.window.windowID);
+            if (window) {
+                SDL_Log("Window %" SDL_PRIu32 " resized to %" SDL_PRIs32 "x%" SDL_PRIs32 "\n",
+                        event.window.windowID,
+                        event.window.data1,
+                        event.window.data2);
             }
-            if (event.window.event == SDL_WINDOWEVENT_MOVED) {
-                SDL_Window *window = SDL_GetWindowFromID(event.window.windowID);
-                if (window) {
-                    SDL_Log("Window %" SDL_PRIu32 " moved to %" SDL_PRIs32 ",%" SDL_PRIs32 " (display %s)\n",
-                            event.window.windowID,
-                            event.window.data1,
-                            event.window.data2,
-                            SDL_GetDisplayName(SDL_GetWindowDisplayIndex(window)));
-                }
+        } else if (event.type == SDL_WINMOVED) {
+            SDL_Window *window = SDL_GetWindowFromID(event.window.windowID);
+            if (window) {
+                SDL_Log("Window %" SDL_PRIu32 " moved to %" SDL_PRIs32 ",%" SDL_PRIs32 " (display %s)\n",
+                        event.window.windowID,
+                        event.window.data1,
+                        event.window.data2,
+                        SDL_GetDisplayName(SDL_GetWindowDisplayIndex(window)));
             }
-            if (event.window.event == SDL_WINDOWEVENT_FOCUS_LOST) {
-                relative_mode = SDL_GetRelativeMouseMode();
-                if (relative_mode) {
-                    SDL_SetRelativeMouseMode(SDL_FALSE);
-                }
+        } else if (event.type == SDL_WINKEYBOARDFOCUSLOST) {
+            relative_mode = SDL_GetRelativeMouseMode();
+            if (relative_mode) {
+                SDL_SetRelativeMouseMode(SDL_FALSE);
             }
-            if (event.window.event == SDL_WINDOWEVENT_FOCUS_GAINED) {
-                if (relative_mode) {
-                    SDL_SetRelativeMouseMode(SDL_TRUE);
-                }
+        } else if (event.type == SDL_WINKEYBOARDFOCUSGAINED) {
+            if (relative_mode) {
+                SDL_SetRelativeMouseMode(SDL_TRUE);
             }
-        }
-        if (event.type == SDL_KEYUP) {
+        } else if (event.type == SDL_KEYUP) {
             SDL_bool updateCursor = SDL_FALSE;
 
             if (event.key.keysym.sym == SDLK_LEFT) {
@@ -205,8 +199,7 @@ void loop()
                 cursor = SDL_CreateSystemCursor((SDL_SystemCursor)system_cursor);
                 SDL_SetCursor(cursor);
             }
-        }
-        if (event.type == SDL_MOUSEBUTTONUP) {
+        } else if (event.type == SDL_MOUSEBUTTONUP) {
             SDL_Window *window = SDL_GetMouseFocus();
             if (highlighted_mode != -1 && window != NULL) {
                 const int display_index = SDL_GetWindowDisplayIndex(window);


### PR DESCRIPTION

This is a first shot at what we're talking about in #6772. I'm not super thrilled with the new names, but they _do_ "feel" like SDL event type names: SDL_WINCLOSE, SDL_DISPLAYCHANGED, etc.

This did clean up a few things in satisfying ways...code that did...

```c
if (event->type == SDL_WINDOWEVENT && event->window.event == SDL_WINDOWEVENT_CLOSE)
```

...condensed to...

```c
if (event->type == SDL_WINCLOSE)
```

...and that's kinda satisfying. Removing switch statements inside switch statements, doubly so.

I _was_ surprised how little we referenced these types...obviously our event subsystem did a lot, but the test apps? Very little, and that makes me confident this isn't going to be a giant migration pain...most apps handle events in one place, so they'll just have to make small edits and move on.