### PR TITLE
fix string literal constness warnings

### DIFF
--- a/src/video/winrt/SDL_winrtgamebar.cpp
+++ b/src/video/winrt/SDL_winrtgamebar.cpp
@@ -78,7 +78,7 @@ static GUID IID_IGameBarStatics_ = { MAKELONG(0xA292, 0x1DB9), 0xCC78, 0x4173, {
 */
 static IGameBarStatics_ *WINRT_GetGameBar()
 {
-    wchar_t *wClassName = L"Windows.Gaming.UI.GameBar";
+    const wchar_t *wClassName = L"Windows.Gaming.UI.GameBar";
     HSTRING hClassName;
     IActivationFactory *pActivationFactory = NULL;
     IGameBarStatics_ *pGameBar = NULL;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add `const` on some strings, use `SDL_strdup` on others.

## Existing Issue(s)
I recently compiled the WinRT code of SDL and ran into these warnings (as errors from `/Zc:strictStrings`, in my project).
