### PR TITLE
kmsdrm: Fix wrong check on KMSDRM_CreateWindow.

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -1490,7 +1490,7 @@ int KMSDRM_CreateWindow(_THIS, SDL_Window *window)
         /* Create the window surfaces with the size we have just chosen.
            Needs the window diverdata in place. */
         ret = KMSDRM_CreateSurfaces(_this, window);
-        if (ret == 0) {
+        if (ret != 0) {
             return SDL_SetError("Can't window GBM/EGL surfaces on window creation.");
         }
     } /* NON-Vulkan block ends. */


### PR DESCRIPTION
A previous cleanup commit inverted a statement that checked the return value of a KMSDRM_CreateSurfaces call during KMSDRM_CreateWindow, which causes the video backend to always fail despite success.

This commit restores the intended behavior. It probably needs to also be cherry-picked for the SDL2 branch.

Fixes: 3c501b963dd8 ("Clang-Tidy fixes (#6725)").