### PR TITLE
Rename WindoShapeMode to SDL_WindowShapeType

### DIFF
--- a/WhatsNew.txt
+++ b/WhatsNew.txt
@@ -66,3 +66,8 @@ General:
     * KMOD_RSHIFT => SDL_KMOD_RSHIFT
     * KMOD_SCROLL => SDL_KMOD_SCROLL
     * KMOD_SHIFT => SDL_KMOD_SHIFT
+    * ShapeModeBinarizeAlpha => SDL_SHAPETYPE_BINARIZE_ALPHA
+    * ShapeModeColorKey => SDL_SHAPETYPE_COLORKEY
+    * ShapeModeDefault => SDL_SHAPETYPE_DEFAULT
+    * ShapeModeReverseBinarizeAlpha => SDL_SHAPETYPE_REVERSE_BINARIZE_ALPHA
+    * WindowShapeMode => SDL_WindowShapeType

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -332,6 +332,15 @@ SDL_RWFromFP(void *fp, SDL_bool autoclose)
 Removed SDL_SensorGetDataWithTimestamp(), if you want timestamps for the sensor data, you should use the sensor_timestamp member of SDL_SENSORUPDATE events.
 
 
+## SDL_shape.h
+
+The following enums have been renamed:
+* ShapeModeBinarizeAlpha => SDL_SHAPETYPE_BINARIZE_ALPHA
+* ShapeModeColorKey => SDL_SHAPETYPE_COLORKEY
+* ShapeModeDefault => SDL_SHAPETYPE_DEFAULT
+* ShapeModeReverseBinarizeAlpha => SDL_SHAPETYPE_REVERSE_BINARIZE_ALPHA
+* WindowShapeMode => SDL_WindowShapeType
+
 ## SDL_stdinc.h
 
 The standard C headers like stdio.h and stdlib.h are no longer included, you should include them directly in your project if you use non-SDL C runtime functions.

--- a/include/SDL3/SDL_oldnames.h
+++ b/include/SDL3/SDL_oldnames.h
@@ -72,6 +72,13 @@
 #define RW_SEEK_END SDL_RW_SEEK_END
 #define RW_SEEK_SET SDL_RW_SEEK_SET
 
+/* ##SDL_shape.h */
+#define ShapeModeBinarizeAlpha SDL_SHAPETYPE_BINARIZE_ALPHA
+#define ShapeModeColorKey SDL_SHAPETYPE_COLORKEY
+#define ShapeModeDefault SDL_SHAPETYPE_DEFAULT
+#define ShapeModeReverseBinarizeAlpha SDL_SHAPETYPE_REVERSE_BINARIZE_ALPHA
+#define WindowShapeMode SDL_WindowShapeType
+
 #else /* !SDL_ENABLE_OLD_NAMES */
 
 /* ##SDL_keycode.h */
@@ -106,6 +113,13 @@
 #define RW_SEEK_CUR RW_SEEK_CUR_renamed_SDL_RW_SEEK_CUR
 #define RW_SEEK_END RW_SEEK_END_renamed_SDL_RW_SEEK_END
 #define RW_SEEK_SET RW_SEEK_SET_renamed_SDL_RW_SEEK_SET
+
+/* ##SDL_shape.h */
+#define ShapeModeBinarizeAlpha ShapeModeBinarizeAlpha_renamed_SDL_SHAPETYPE_BINARIZE_ALPHA
+#define ShapeModeColorKey ShapeModeColorKey_renamed_SDL_SHAPETYPE_COLORKEY
+#define ShapeModeDefault ShapeModeDefault_renamed_SDL_SHAPETYPE_DEFAULT
+#define ShapeModeReverseBinarizeAlpha ShapeModeReverseBinarizeAlpha_renamed_SDL_SHAPETYPE_REVERSE_BINARIZE_ALPHA
+#define WindowShapeMode WindowShapeMode_renamed_SDL_WindowShapeType
 
 #endif /* SDL_ENABLE_OLD_NAMES */
 

--- a/include/SDL3/SDL_shape.h
+++ b/include/SDL3/SDL_shape.h
@@ -84,16 +84,16 @@ extern DECLSPEC SDL_bool SDLCALL SDL_IsShapedWindow(const SDL_Window *window);
 /** \brief An enum denoting the specific type of contents present in an SDL_WindowShapeParams union. */
 typedef enum {
     /** \brief The default mode, a binarized alpha cutoff of 1. */
-    ShapeModeDefault,
+    SDL_SHAPETYPE_DEFAULT,
     /** \brief A binarized alpha cutoff with a given integer value. */
-    ShapeModeBinarizeAlpha,
+    SDL_SHAPETYPE_BINARIZE_ALPHA,
     /** \brief A binarized alpha cutoff with a given integer value, but with the opposite comparison. */
-    ShapeModeReverseBinarizeAlpha,
+    SDL_SHAPETYPE_REVERSE_BINARIZE_ALPHA,
     /** \brief A color key is applied. */
-    ShapeModeColorKey
-} WindowShapeMode;
+    SDL_SHAPETYPE_COLORKEY
+} SDL_WindowShapeType;
 
-#define SDL_SHAPEMODEALPHA(mode) (mode == ShapeModeDefault || mode == ShapeModeBinarizeAlpha || mode == ShapeModeReverseBinarizeAlpha)
+#define SDL_SHAPEMODEALPHA(mode) (mode == SDL_SHAPETYPE_DEFAULT || mode == SDL_SHAPETYPE_BINARIZE_ALPHA || mode == SDL_SHAPETYPE_REVERSE_BINARIZE_ALPHA)
 
 /** \brief A union containing parameters for shaped windows. */
 typedef union {
@@ -105,7 +105,7 @@ typedef union {
 /** \brief A struct that tags the SDL_WindowShapeParams union with an enum describing the type of its contents. */
 typedef struct SDL_WindowShapeMode {
     /** \brief The mode of these window-shape parameters. */
-    WindowShapeMode mode;
+    SDL_WindowShapeType mode;
     /** \brief Window-shape parameters. */
     SDL_WindowShapeParams parameters;
 } SDL_WindowShapeMode;

--- a/src/video/SDL_shape.c
+++ b/src/video/SDL_shape.c
@@ -37,7 +37,7 @@ SDL_CreateShapedWindow(const char *title, unsigned int x, unsigned int y, unsign
         if (result->shaper != NULL) {
             result->shaper->userx = x;
             result->shaper->usery = y;
-            result->shaper->mode.mode = ShapeModeDefault;
+            result->shaper->mode.mode = SDL_SHAPETYPE_DEFAULT;
             result->shaper->mode.parameters.binarizationCutoff = 1;
             result->shaper->hasshape = SDL_FALSE;
             return result;
@@ -98,16 +98,16 @@ void SDL_CalculateShapeBitmap(SDL_WindowShapeMode mode, SDL_Surface *shape, Uint
             }
             SDL_GetRGBA(pixel_value, shape->format, &r, &g, &b, &alpha);
             switch (mode.mode) {
-            case (ShapeModeDefault):
+            case (SDL_SHAPETYPE_DEFAULT):
                 mask_value = (alpha >= 1 ? 1 : 0);
                 break;
-            case (ShapeModeBinarizeAlpha):
+            case (SDL_SHAPETYPE_BINARIZE_ALPHA):
                 mask_value = (alpha >= mode.parameters.binarizationCutoff ? 1 : 0);
                 break;
-            case (ShapeModeReverseBinarizeAlpha):
+            case (SDL_SHAPETYPE_REVERSE_BINARIZE_ALPHA):
                 mask_value = (alpha <= mode.parameters.binarizationCutoff ? 1 : 0);
                 break;
-            case (ShapeModeColorKey):
+            case (SDL_SHAPETYPE_COLORKEY):
                 key = mode.parameters.colorKey;
                 mask_value = ((key.r != r || key.g != g || key.b != b) ? 1 : 0);
                 break;
@@ -153,16 +153,16 @@ static SDL_ShapeTree *RecursivelyCalculateShapeTree(SDL_WindowShapeMode mode, SD
             }
             SDL_GetRGBA(pixel_value, mask->format, &r, &g, &b, &a);
             switch (mode.mode) {
-            case (ShapeModeDefault):
+            case (SDL_SHAPETYPE_DEFAULT):
                 pixel_opaque = (a >= 1 ? SDL_TRUE : SDL_FALSE);
                 break;
-            case (ShapeModeBinarizeAlpha):
+            case (SDL_SHAPETYPE_BINARIZE_ALPHA):
                 pixel_opaque = (a >= mode.parameters.binarizationCutoff ? SDL_TRUE : SDL_FALSE);
                 break;
-            case (ShapeModeReverseBinarizeAlpha):
+            case (SDL_SHAPETYPE_REVERSE_BINARIZE_ALPHA):
                 pixel_opaque = (a <= mode.parameters.binarizationCutoff ? SDL_TRUE : SDL_FALSE);
                 break;
-            case (ShapeModeColorKey):
+            case (SDL_SHAPETYPE_COLORKEY):
                 key = mode.parameters.colorKey;
                 pixel_opaque = ((key.r != r || key.g != g || key.b != b) ? SDL_TRUE : SDL_FALSE);
                 break;

--- a/src/video/cocoa/SDL_cocoashape.m
+++ b/src/video/cocoa/SDL_cocoashape.m
@@ -58,7 +58,7 @@ Cocoa_CreateShaper(SDL_Window *window)
         [windata.nswindow setStyleMask:NSWindowStyleMaskBorderless];
 
         result->window = window;
-        result->mode.mode = ShapeModeDefault;
+        result->mode.mode = SDL_SHAPETYPE_DEFAULT;
         result->mode.parameters.binarizationCutoff = 1;
         result->userx = result->usery = 0;
         window->shaper = result;

--- a/src/video/windows/SDL_windowsshape.c
+++ b/src/video/windows/SDL_windowsshape.c
@@ -35,7 +35,7 @@ Win32_CreateShaper(SDL_Window *window)
         return NULL;
     }
     result->window = window;
-    result->mode.mode = ShapeModeDefault;
+    result->mode.mode = SDL_SHAPETYPE_DEFAULT;
     result->mode.parameters.binarizationCutoff = 1;
     result->userx = result->usery = 0;
     result->hasshape = SDL_FALSE;
@@ -80,7 +80,7 @@ int Win32_SetWindowShape(SDL_WindowShaper *shaper, SDL_Surface *shape, SDL_Windo
 
     if ((shaper == NULL) ||
         (shape == NULL) ||
-        ((shape->format->Amask == 0) && (shape_mode->mode != ShapeModeColorKey)) ||
+        ((shape->format->Amask == 0) && (shape_mode->mode != SDL_SHAPETYPE_COLORKEY)) ||
         (shape->w != shaper->window->w) ||
         (shape->h != shaper->window->h)) {
         return SDL_INVALID_SHAPE_ARGUMENT;

--- a/src/video/x11/SDL_x11shape.c
+++ b/src/video/x11/SDL_x11shape.c
@@ -41,7 +41,7 @@ X11_CreateShaper(SDL_Window *window)
             return NULL;
         }
         result->window = window;
-        result->mode.mode = ShapeModeDefault;
+        result->mode.mode = SDL_SHAPETYPE_DEFAULT;
         result->mode.parameters.binarizationCutoff = 1;
         result->userx = result->usery = 0;
         data = SDL_malloc(sizeof(SDL_ShapeData));

--- a/test/testshape.c
+++ b/test/testshape.c
@@ -92,10 +92,10 @@ int main(int argc, char **argv)
 
         format = pictures[i].surface->format;
         if (SDL_ISPIXELFORMAT_ALPHA(format->format)) {
-            pictures[i].mode.mode = ShapeModeBinarizeAlpha;
+            pictures[i].mode.mode = SDL_SHAPETYPE_BINARIZE_ALPHA;
             pictures[i].mode.parameters.binarizationCutoff = 255;
         } else {
-            pictures[i].mode.mode = ShapeModeColorKey;
+            pictures[i].mode.mode = SDL_SHAPETYPE_COLORKEY;
             pictures[i].mode.parameters.colorKey = black;
         }
     }


### PR DESCRIPTION
renaming WindowShapeMode to SDL_WindowShapeType  
because SDL_WindowShapeMode is already taken.

See #6897

