### PR TITLE
Remove reserved underscore SDL_AudioStream in public API

### DIFF
--- a/WhatsNew.txt
+++ b/WhatsNew.txt
@@ -195,3 +195,5 @@ General:
     * KMOD_RSHIFT => SDL_KMOD_RSHIFT
     * KMOD_SCROLL => SDL_KMOD_SCROLL
     * KMOD_SHIFT => SDL_KMOD_SHIFT
+* The following structures have been renamed:
+    * _SDL_AudioStream => SDL_AudioStream

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -55,6 +55,9 @@ The following functions have been renamed:
 * SDL_FreeAudioStream => SDL_DestroyAudioStream
 * SDL_NewAudioStream => SDL_CreateAudioStream
 
+The following structures have been renamed:
+* _SDL_AudioStream => SDL_AudioStream
+
 ## SDL_cpuinfo.h
 
 SDL_Has3DNow() has been removed; there is no replacement.

--- a/include/SDL3/SDL_audio.h
+++ b/include/SDL3/SDL_audio.h
@@ -925,8 +925,7 @@ extern DECLSPEC int SDLCALL SDL_ConvertAudio(SDL_AudioCVT * cvt);
     - You push data as you have it, and pull it when you need it
  */
 /* this is opaque to the outside world. */
-struct _SDL_AudioStream;
-typedef struct _SDL_AudioStream SDL_AudioStream;
+typedef struct SDL_AudioStream SDL_AudioStream;
 
 /**
  * Create a new audio stream.

--- a/include/SDL3/SDL_oldnames.h
+++ b/include/SDL3/SDL_oldnames.h
@@ -48,6 +48,7 @@
 #define SDL_FreeAudioStream SDL_DestroyAudioStream
 #define SDL_FreeWAV SDL_free
 #define SDL_NewAudioStream SDL_CreateAudioStream
+#define _SDL_AudioStream SDL_AudioStream
 
 /* ##SDL_joystick.h */
 #define SDL_JoystickAttachVirtual SDL_AttachVirtualJoystick
@@ -222,6 +223,7 @@
 #define SDL_FreeAudioStream SDL_FreeAudioStream_renamed_SDL_DestroyAudioStream
 #define SDL_FreeWAV SDL_FreeWAV_renamed_SDL_free
 #define SDL_NewAudioStream SDL_NewAudioStream_renamed_SDL_CreateAudioStream
+#define _SDL_AudioStream _SDL_AudioStream_renamed_SDL_AudioStream
 
 /* ##SDL_joystick.h */
 #define SDL_JoystickAttachVirtual SDL_JoystickAttachVirtual_renamed_SDL_AttachVirtualJoystick

--- a/src/audio/SDL_audiocvt.c
+++ b/src/audio/SDL_audiocvt.c
@@ -830,7 +830,7 @@ typedef int (*SDL_ResampleAudioStreamFunc)(SDL_AudioStream *stream, const void *
 typedef void (*SDL_ResetAudioStreamResamplerFunc)(SDL_AudioStream *stream);
 typedef void (*SDL_CleanupAudioStreamResamplerFunc)(SDL_AudioStream *stream);
 
-struct _SDL_AudioStream
+struct SDL_AudioStream
 {
     SDL_AudioCVT cvt_before_resampling;
     SDL_AudioCVT cvt_after_resampling;


### PR DESCRIPTION
remove reserved prefix underscrore

_SDL_AudioStream

https://github.com/libsdl-org/SDL/issues/6856
