### PR TITLE
Remove reserved underscore SDL_joystick

### DIFF
--- a/include/SDL3/SDL_joystick.h
+++ b/include/SDL3/SDL_joystick.h
@@ -70,8 +70,8 @@ extern "C" {
 #ifdef SDL_THREAD_SAFETY_ANALYSIS
 extern SDL_mutex *SDL_joystick_lock;
 #endif
-struct _SDL_Joystick;
-typedef struct _SDL_Joystick SDL_Joystick;
+struct SDL_Joystick;
+typedef struct SDL_Joystick SDL_Joystick;
 
 /* A structure that encodes the stable unique id for a joystick device */
 typedef SDL_GUID SDL_JoystickGUID;

--- a/src/joystick/SDL_sysjoystick.h
+++ b/src/joystick/SDL_sysjoystick.h
@@ -67,7 +67,7 @@ typedef struct SDL_JoystickSensorInfo
 
 #define _guarded SDL_GUARDED_BY(SDL_joystick_lock)
 
-struct _SDL_Joystick
+struct SDL_Joystick
 {
     const void *magic _guarded;
 
@@ -119,7 +119,7 @@ struct _SDL_Joystick
 
     int ref_count _guarded; /* Reference count for multiple opens */
 
-    struct _SDL_Joystick *next _guarded; /* pointer to next joystick we have allocated */
+    struct SDL_Joystick *next _guarded; /* pointer to next joystick we have allocated */
 };
 
 #undef _guarded


### PR DESCRIPTION
remove underscore in _SDL_Joystick 
@slouken it seems you missed this one ? 
