### PR TITLE
Remove underscore for some SDL_ builtin function/macros

### DIFF
--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -698,13 +698,13 @@ SDL_FORCE_INLINE int SDL_size_mul_overflow (size_t a,
 /* This needs to be wrapped in an inline rather than being a direct #define,
  * because __builtin_mul_overflow() is type-generic, but we want to be
  * consistent about interpreting a and b as size_t. */
-SDL_FORCE_INLINE int _SDL_size_mul_overflow_builtin (size_t a,
+SDL_FORCE_INLINE int SDL_size_mul_overflow_builtin (size_t a,
                                                      size_t b,
                                                      size_t *ret)
 {
     return __builtin_mul_overflow(a, b, ret) == 0 ? 0 : -1;
 }
-#define SDL_size_mul_overflow(a, b, ret) (_SDL_size_mul_overflow_builtin(a, b, ret))
+#define SDL_size_mul_overflow(a, b, ret) (SDL_size_mul_overflow_builtin(a, b, ret))
 #endif
 
 /**
@@ -727,13 +727,13 @@ SDL_FORCE_INLINE int SDL_size_add_overflow (size_t a,
 #if _SDL_HAS_BUILTIN(__builtin_add_overflow)
 /* This needs to be wrapped in an inline rather than being a direct #define,
  * the same as the call to __builtin_mul_overflow() above. */
-SDL_FORCE_INLINE int _SDL_size_add_overflow_builtin (size_t a,
+SDL_FORCE_INLINE int SDL_size_add_overflow_builtin (size_t a,
                                                      size_t b,
                                                      size_t *ret)
 {
     return __builtin_add_overflow(a, b, ret) == 0 ? 0 : -1;
 }
-#define SDL_size_add_overflow(a, b, ret) (_SDL_size_add_overflow_builtin(a, b, ret))
+#define SDL_size_add_overflow(a, b, ret) (SDL_size_add_overflow_builtin(a, b, ret))
 #endif
 
 /* Ends C function definitions when using C++ */


### PR DESCRIPTION
more `warning: identifier '_SDL_size_mul_overflow_builtin' is reserved because it starts with '_' followed by a capital letter`
