### PR TITLE
cmake: add SDL3 to include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3147,7 +3147,9 @@ if(SDL_SHARED)
     PUBLIC
       "$<BUILD_INTERFACE:${SDL3_BINARY_DIR}/include>"
       "$<BUILD_INTERFACE:${SDL3_SOURCE_DIR}/include>"
+      "$<BUILD_INTERFACE:${SDL3_SOURCE_DIR}/include/SDL3>"
       "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+      "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/SDL3>"
   )
   # This picks up all the compiler options and such we've accumulated up to here.
   target_link_libraries(SDL3 PRIVATE $<BUILD_INTERFACE:sdl-build-options>)
@@ -3180,7 +3182,9 @@ if(SDL_STATIC)
     PUBLIC
       "$<BUILD_INTERFACE:${SDL3_BINARY_DIR}/include>"
       "$<BUILD_INTERFACE:${SDL3_SOURCE_DIR}/include>"
+      "$<BUILD_INTERFACE:${SDL3_SOURCE_DIR}/include/SDL3>"
       "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+      "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/SDL3>"
   )
   # This picks up all the compiler options and such we've accumulated up to here.
   target_link_libraries(SDL3-static PRIVATE $<BUILD_INTERFACE:sdl-build-options>)
@@ -3210,7 +3214,9 @@ if(SDL_TEST)
     PUBLIC
       "$<BUILD_INTERFACE:${SDL3_BINARY_DIR}/include>"
       "$<BUILD_INTERFACE:${SDL3_SOURCE_DIR}/include>"
+      "$<BUILD_INTERFACE:${SDL3_SOURCE_DIR}/include/SDL3>"
       "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+      "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/SDL3>"
   )
   target_link_libraries(SDL3_test PRIVATE ${EXTRA_TEST_LIBS})
 endif()

--- a/VisualC/pkg-support/cmake/sdl3-config.cmake
+++ b/VisualC/pkg-support/cmake/sdl3-config.cmake
@@ -44,7 +44,7 @@ endif()
 set_and_check(SDL3_PREFIX       "${CMAKE_CURRENT_LIST_DIR}/..")
 set_and_check(SDL3_EXEC_PREFIX  "${CMAKE_CURRENT_LIST_DIR}/..")
 set_and_check(SDL3_INCLUDE_DIR  "${SDL3_PREFIX}/include")
-set(SDL3_INCLUDE_DIRS           "${SDL3_INCLUDE_DIR}")
+set(SDL3_INCLUDE_DIRS           "${SDL3_INCLUDE_DIR};${SDL3_INCLUDE_DIR}/SDL3")
 set_and_check(SDL3_BINDIR       "${SDL3_PREFIX}/lib/${_sdl_arch_subdir}")
 set_and_check(SDL3_LIBDIR       "${SDL3_PREFIX}/lib/${_sdl_arch_subdir}")
 

--- a/Xcode/SDL/pkg-support/resources/CMake/sdl3-config.cmake
+++ b/Xcode/SDL/pkg-support/resources/CMake/sdl3-config.cmake
@@ -39,7 +39,7 @@ string(REGEX REPLACE "SDL3\\.framework.*" "" SDL3_FRAMEWORK_PARENT_PATH "${CMAKE
 set_and_check(SDL3_PREFIX       "${SDL3_FRAMEWORK_PATH}")
 set_and_check(SDL3_EXEC_PREFIX  "${SDL3_FRAMEWORK_PATH}")
 set_and_check(SDL3_INCLUDE_DIR  "${SDL3_FRAMEWORK_PATH}/Headers")
-set(SDL3_INCLUDE_DIRS           "${SDL3_INCLUDE_DIR};${SDL3_FRAMEWORK_PATH}")
+set(SDL3_INCLUDE_DIRS           "${SDL3_INCLUDE_DIR}")
 set_and_check(SDL3_BINDIR       "${SDL3_FRAMEWORK_PATH}")
 set_and_check(SDL3_LIBDIR       "${SDL3_FRAMEWORK_PATH}")
 

--- a/cmake/sdl3.pc.in
+++ b/cmake/sdl3.pc.in
@@ -2,8 +2,8 @@
 
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=@CMAKE_INSTALL_FULL_LIBDIR@
-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: sdl3
 Description: Simple DirectMedia Layer is a cross-platform multimedia library designed to provide low level access to audio, keyboard, mouse, joystick, 3D hardware via OpenGL, and 2D video framebuffer.
@@ -11,4 +11,4 @@ Version: @SDL_VERSION@
 Requires.private: @PKGCONFIG_DEPENDS@
 Conflicts:
 Libs: -L${libdir} @SDL_RLD_FLAGS@ @SDL_LIBS@ @PKGCONFIG_LIBS_PRIV@ @SDL_STATIC_LIBS@
-Cflags: -I${includedir} @SDL_CFLAGS@
+Cflags: -I${includedir} -I${includedir}/SDL3 @SDL_CFLAGS@


### PR DESCRIPTION
This reverts parts of 9f2ca87

I *think* the SDL3 framework also supports both include styles: `#include "SDL.h"` and `#include <SDL3/SDL.h>`:
- The `-F SDL3.framework` will make sure `#include <SDL3/SDL.h>` works.
- The `INTERFACE_INCLUDE_DIRECTORIES` will make sure `#include "SDL.h"` works.

But once again: somebody with a mac, please verify.