### PR TITLE
Fix X11 scancode remaping

### DIFF
--- a/src/video/x11/SDL_x11keyboard.c
+++ b/src/video/x11/SDL_x11keyboard.c
@@ -264,7 +264,7 @@ int X11_InitKeyboard(_THIS)
             if (scancode == data->key_layout[i]) {
                 continue;
             }
-            if (default_keymap[scancode] >= SDLK_SCANCODE_MASK) {
+            if (default_keymap[data->key_layout[i]] >= SDLK_SCANCODE_MASK) {
                 /* Not a character key, safe to remap */
 #ifdef DEBUG_KEYBOARD
                 SDL_Log("Changing scancode, was %d (%s), now %d (%s)\n", data->key_layout[i], SDL_GetScancodeName(data->key_layout[i]), scancode, SDL_GetScancodeName(scancode));


### PR DESCRIPTION
## Description
This is my attempt at fixing incorrect scancode when pressing `5` on azerty keyboard (see #6787).

This patches fixes this by checking that the scancode is a character key based on the default qwerty layout rather than actual layout.

Keyboard initialisation is complex so I am not sure this is a correct fix. I do not understand why `LinuxKeycodeKeysyms` includes keycode for `'` `(` `-` but not for `"` or `_`, maybe `LinuxKeycodeKeysyms` table should be updated. I also do not understand why keycode for`(` is higher than `SDLK_SCANCODE_MASK` and not considered a "character key".

Here what's going on in `X11_InitKeyboard()`:

 - For key `1`, `2`, `3`, `7`, `8`, `9` and `0` (`&`, `é`, `"`, `è`, `_`, `ç`, `à`):
`X11_KeyCodeToSDLScancode()` returns 0 so  scancode is not remapped.

 - For key `4` and `6` (`'`, `-`):
`X11_KeyCodeToSDLScancode()` returns 52 and 45 because `SDL_GetScancodeFromKeySym()` found the keycode in `LinuxKeycodeKeysyms`.  Keycodes for these scancodes are less than `SDLK_SCANCODE_MASK` so it is not remapped.

 - For key `5` (`(`):
`X11_KeyCodeToSDLScancode()` return 182 because `SDL_GetScancodeFromKeySym()` found the keycode in `LinuxKeycodeKeysyms`.  Keycode is 1073742006 which is more than `SDLK_SCANCODE_MASK` so it is remapped: 34 (5) to 182 (Keypad ))

This is also needed for SDL2.

## Existing Issue(s)
Fix #6787
