### PR TITLE
'SDL_AudioCallback' callback type uses a 'void *' stream parameter

### DIFF
--- a/VisualC-GDK/tests/testgdk/src/testgdk.cpp
+++ b/VisualC-GDK/tests/testgdk/src/testgdk.cpp
@@ -103,9 +103,10 @@ reopen_audio()
 }
 
 void SDLCALL
-fillerup(void *unused, Uint8 *stream, int len)
+fillerup(void *unused, void *stream_param, int len)
 {
     Uint8 *waveptr;
+    Uint8 *stream = stream_param;
     int waveleft;
 
     /* Set up the pointers */

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -46,6 +46,9 @@ SDL_AudioInit() and SDL_AudioQuit() have been removed. Instead you can call SDL_
 
 SDL_FreeWAV has been removed and calls can be replaced with SDL_free.
 
+'SDL_AudioCallback' callback type uses a 'void *' stream parameter
+
+
 The following functions have been renamed:
 * SDL_AudioStreamAvailable => SDL_GetAudioStreamAvailable
 * SDL_AudioStreamClear => SDL_ClearAudioStream

--- a/include/SDL3/SDL_audio.h
+++ b/include/SDL3/SDL_audio.h
@@ -153,7 +153,7 @@ typedef Uint16 SDL_AudioFormat;
  *
  *  \param userdata An application-specific parameter saved in
  *                  the SDL_AudioSpec structure
- *  \param stream A pointer to the audio data buffer.
+ *  \param stream A pointer to the audio data buffer (variable type).
  *  \param len    The length of that buffer in bytes.
  *
  *  Once the callback returns, the buffer will no longer be valid.
@@ -162,8 +162,7 @@ typedef Uint16 SDL_AudioFormat;
  *  You can choose to avoid callbacks and use SDL_QueueAudio() instead, if
  *  you like. Just open your audio device with a NULL callback.
  */
-typedef void (SDLCALL * SDL_AudioCallback) (void *userdata, Uint8 * stream,
-                                            int len);
+typedef void (SDLCALL * SDL_AudioCallback) (void *userdata, void *stream, int len);
 
 /**
  *  The calculated values in this structure are calculated by SDL_OpenAudio().

--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -512,11 +512,12 @@ void SDL_RemoveAudioDevice(const SDL_bool iscapture, void *handle)
 
 /* buffer queueing support... */
 
-static void SDLCALL SDL_BufferQueueDrainCallback(void *userdata, Uint8 *stream, int len)
+static void SDLCALL SDL_BufferQueueDrainCallback(void *userdata, void *stream_param, int len)
 {
     /* this function always holds the mixer lock before being called. */
     SDL_AudioDevice *device = (SDL_AudioDevice *)userdata;
     size_t dequeued;
+    Uint8 *stream = stream_param;
 
     SDL_assert(device != NULL);     /* this shouldn't ever happen, right?! */
     SDL_assert(!device->iscapture); /* this shouldn't ever happen, right?! */
@@ -532,10 +533,11 @@ static void SDLCALL SDL_BufferQueueDrainCallback(void *userdata, Uint8 *stream, 
     }
 }
 
-static void SDLCALL SDL_BufferQueueFillCallback(void *userdata, Uint8 *stream, int len)
+static void SDLCALL SDL_BufferQueueFillCallback(void *userdata, void *stream_param, int len)
 {
     /* this function always holds the mixer lock before being called. */
     SDL_AudioDevice *device = (SDL_AudioDevice *)userdata;
+    Uint8 *stream = stream_param;
 
     SDL_assert(device != NULL);    /* this shouldn't ever happen, right?! */
     SDL_assert(device->iscapture); /* this shouldn't ever happen, right?! */

--- a/test/loopwave.c
+++ b/test/loopwave.c
@@ -76,9 +76,10 @@ static void reopen_audio()
 #endif
 
 void SDLCALL
-fillerup(void *unused, Uint8 *stream, int len)
+fillerup(void *unused, void *stream_param, int len)
 {
     Uint8 *waveptr;
+    Uint8 *stream = stream_param;
     int waveleft;
 
     /* Set up the pointers */

--- a/test/testaudiohotplug.c
+++ b/test/testaudiohotplug.c
@@ -42,10 +42,11 @@ quit(int rc)
 }
 
 void SDLCALL
-fillerup(void *_pos, Uint8 *stream, int len)
+fillerup(void *_pos, void *stream_param, int len)
 {
     Uint32 pos = *((Uint32 *)_pos);
     Uint8 *waveptr;
+    Uint8 *stream = stream_param;
     int waveleft;
 
     /* Set up the pointers */

--- a/test/testautomation_audio.c
+++ b/test/testautomation_audio.c
@@ -43,7 +43,7 @@ int _audio_testCallbackCounter;
 int _audio_testCallbackLength;
 
 /* Test callback function */
-void SDLCALL _audio_testCallback(void *userdata, Uint8 *stream, int len)
+void SDLCALL _audio_testCallback(void *userdata, void *stream, int len)
 {
     /* track that callback was called */
     _audio_testCallbackCounter++;

--- a/test/testmultiaudio.c
+++ b/test/testmultiaudio.c
@@ -34,8 +34,9 @@ typedef struct
 callback_data cbd[64];
 
 void SDLCALL
-play_through_once(void *arg, Uint8 *stream, int len)
+play_through_once(void *arg, void *stream_param, int len)
 {
+    Uint8 *stream = stream_param;
     callback_data *cbdata = (callback_data *)arg;
     Uint8 *waveptr = sound + cbdata->soundpos;
     int waveleft = soundlen - cbdata->soundpos;

--- a/test/testsurround.c
+++ b/test/testsurround.c
@@ -91,7 +91,7 @@ is_lfe_channel(int channel_index, int channel_count)
 }
 
 void SDLCALL
-fill_buffer(void *unused, Uint8 *stream, int len)
+fill_buffer(void *unused, void *stream, int len)
 {
     Sint16 *buffer = (Sint16 *)stream;
     int samples = len / sizeof(Sint16);


### PR DESCRIPTION
'SDL_AudioCallback' callback type uses a 'void *' stream parameter

https://github.com/libsdl-org/SDL/issues/2625
