### PR TITLE
Fixes a bug that did not allowed to set `ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT` + switches Landscape orientations to reflect docs

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -52,6 +52,9 @@ import android.widget.Toast;
 
 import java.util.Hashtable;
 import java.util.Locale;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Arrays;
 
 
 /**
@@ -968,20 +971,22 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
         int orientation_landscape = -1;
         int orientation_portrait = -1;
 
+        Set<String> hint_parts = new HashSet<String>(Arrays.asList(hint.split(" ")));
+
         /* If set, hint "explicitly controls which UI orientations are allowed". */
-        if (hint.contains("LandscapeRight") && hint.contains("LandscapeLeft")) {
+        if (hint_parts.contains("LandscapeRight") && hint_parts.contains("LandscapeLeft")) {
             orientation_landscape = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE;
-        } else if (hint.contains("LandscapeRight")) {
+        } else if (hint_parts.contains("LandscapeLeft")) {
             orientation_landscape = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE;
-        } else if (hint.contains("LandscapeLeft")) {
+        } else if (hint_parts.contains("LandscapeRight")) {
             orientation_landscape = ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE;
         }
 
-        if (hint.contains("Portrait") && hint.contains("PortraitUpsideDown")) {
+        if (hint_parts.contains("Portrait") && hint_parts.contains("PortraitUpsideDown")) {
             orientation_portrait = ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT;
-        } else if (hint.contains("Portrait")) {
+        } else if (hint_parts.contains("Portrait")) {
             orientation_portrait = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
-        } else if (hint.contains("PortraitUpsideDown")) {
+        } else if (hint_parts.contains("PortraitUpsideDown")) {
             orientation_portrait = ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

1) Prior to these changes, with hint set to `PortraitUpsideDown` orientation, `ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT` has been selected, cause both `Portrait` and `PortraitUpsideDown` were contained into the `PortraitUpsideDown` hint string.

2) Additionally (and thanks @RobertFlatt for pointing out here: https://github.com/kivy/python-for-android/issues/2724#issuecomment-1368142168), `LandscapeLeft` has now been set to `ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE` and `LandscapeRight` to `ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE` in order to reflect the docs: https://wiki.libsdl.org/SDL2/SDL_HINT_ORIENTATIONS


## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
