### PR TITLE
Stop beep when running iOS apps on ARM-based Macs

### DIFF
--- a/src/video/uikit/SDL_uikitview.m
+++ b/src/video/uikit/SDL_uikitview.m
@@ -417,7 +417,6 @@ extern int SDL_AppleTVRemoteOpenedAsJoystick;
             SDL_SendKeyboardKey(UIKit_GetEventTimestamp([event timestamp]), SDL_PRESSED, scancode);
         }
     }
-    [super pressesBegan:presses withEvent:event];
 }
 
 - (void)pressesEnded:(NSSet<UIPress *> *)presses withEvent:(UIPressesEvent *)event
@@ -428,7 +427,6 @@ extern int SDL_AppleTVRemoteOpenedAsJoystick;
             SDL_SendKeyboardKey(UIKit_GetEventTimestamp([event timestamp]), SDL_RELEASED, scancode);
         }
     }
-    [super pressesEnded:presses withEvent:event];
 }
 
 - (void)pressesCancelled:(NSSet<UIPress *> *)presses withEvent:(UIPressesEvent *)event
@@ -439,13 +437,11 @@ extern int SDL_AppleTVRemoteOpenedAsJoystick;
             SDL_SendKeyboardKey(UIKit_GetEventTimestamp([event timestamp]), SDL_RELEASED, scancode);
         }
     }
-    [super pressesCancelled:presses withEvent:event];
 }
 
 - (void)pressesChanged:(NSSet<UIPress *> *)presses withEvent:(UIPressesEvent *)event
 {
     /* This is only called when the force of a press changes. */
-    [super pressesChanged:presses withEvent:event];
 }
 
 #endif /* TARGET_OS_TV || defined(__IPHONE_9_1) */


### PR DESCRIPTION
If an SDL-based iOS app is running on an ARM-based Mac, certain keypresses may result in a system beep.

## Description
We built a project in C# using FNA which uses SDL with a target of iOS 11.  It runs fine on ARM-based Macs, however, some keypresses (for example, enter but not an array key) result in the system beep sound, even though the application can process the keypress correctly.

Some searching brought us to this:
https://developer.apple.com/forums/thread/651252

Removing the super calls in our own build removed the beeping sound.

## Existing Issue(s)
N/A