### PR TITLE
Fixed bug #6816 - SDL_RenderSetVSync doesn't disable vsync for software renderer

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -25,6 +25,7 @@
 #include "SDL_sysrender.h"
 #include "software/SDL_render_sw_c.h"
 #include "../video/SDL_pixels_c.h"
+#include "../video/SDL_video_c.h"
 
 #if defined(__ANDROID__)
 #include "../core/android/SDL_android.h"
@@ -4483,6 +4484,14 @@ int SDL_SetRenderVSync(SDL_Renderer *renderer, int vsync)
     }
 
     renderer->wanted_vsync = vsync ? SDL_TRUE : SDL_FALSE;
+
+    /* for the software renderer, forward eventually the call to the WindowTexture renderer */
+    if (renderer->info.flags & SDL_RENDERER_SOFTWARE) {
+        if (SDL_SetWindowTextureVSync(renderer->window, vsync) == 0) {
+            renderer->simulate_vsync = SDL_FALSE;
+            return 0;
+        }
+    }
 
     if (!renderer->SetVSync ||
         renderer->SetVSync(renderer, vsync) < 0) {

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -358,6 +358,20 @@ static void SDL_DestroyWindowTexture(SDL_VideoDevice *unused, SDL_Window *window
     SDL_free(data);
 }
 
+int SDL_SetWindowTextureVSync(SDL_Window *window, int vsync)
+{
+    SDL_WindowTextureData *data;
+
+    data = SDL_GetWindowData(window, SDL_WINDOWTEXTUREDATA);
+    if (data == NULL) {
+        return -1;
+    }
+    if (data->renderer == NULL ) {
+        return -1;
+    }
+    return SDL_SetRenderVSync(data->renderer, vsync);
+}
+
 static int SDLCALL cmpmodes(const void *A, const void *B)
 {
     const SDL_DisplayMode *a = (const SDL_DisplayMode *)A;

--- a/src/video/SDL_video_c.h
+++ b/src/video/SDL_video_c.h
@@ -55,4 +55,6 @@ extern int SDL_VideoInit(const char *driver_name);
  */
 extern void SDL_VideoQuit(void);
 
+extern int SDL_SetWindowTextureVSync(SDL_Window *window, int vsync);
+
 #endif /* SDL_video_c_h_ */


### PR DESCRIPTION
SDL_RenderSetVSync doesn't disable vsync for software renderers created with the SDL_RENDERER_PRESENTVSYNC flag

Attempt to fix: https://github.com/libsdl-org/SDL/issues/6816
not sure if this is the best fixes ..

@hkva please give a try !