### PR TITLE
Fix use after free in SDL_GetGamepads

### DIFF
--- a/src/joystick/SDL_gamepad.c
+++ b/src/joystick/SDL_gamepad.c
@@ -1928,7 +1928,6 @@ SDL_JoystickID *SDL_GetGamepads(int *count)
                 SDL_memmove(&joysticks[i], &joysticks[i+1], (num_gamepads + 1) * sizeof(joysticks[i]));
             }
         }
-        SDL_free(joysticks);
     }
     if (count) {
         *count = num_gamepads;


### PR DESCRIPTION
## Description
`joysticks` is returned by SDL_GetGamepads , it shoud not be freed.

## Existing Issue(s)
None
