### PR TITLE
Fix memory leak in SDL_SW_CreateYUVTexture

### DIFF
--- a/src/render/SDL_yuv_sw.c
+++ b/src/render/SDL_yuv_sw.c
@@ -59,6 +59,7 @@ SDL_SW_CreateYUVTexture(Uint32 format, int w, int h)
     {
         size_t dst_size;
         if (SDL_CalculateYUVSize(format, w, h, &dst_size, NULL) < 0) {
+            SDL_SW_DestroyYUVTexture(swdata);
             SDL_OutOfMemory();
             return NULL;
         }


### PR DESCRIPTION
## Description
`swdata` is leaked in case of error.

## Existing Issue(s)
None
