### PR TITLE
Wayland / Drag and Drop: find the current window

### DIFF
--- a/src/video/wayland/SDL_waylanddatamanager.h
+++ b/src/video/wayland/SDL_waylanddatamanager.h
@@ -75,6 +75,7 @@ typedef struct
     uint32_t drag_serial;
     SDL_WaylandDataOffer *drag_offer;
     SDL_WaylandDataOffer *selection_offer;
+    SDL_Window *dnd_window;
 
     /* Clipboard and Primary Selection */
     uint32_t selection_serial;

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -1654,6 +1654,14 @@ static void data_device_handle_enter(void *data, struct wl_data_device *wl_data_
             wl_data_offer_set_actions(data_device->drag_offer->offer,
                                       dnd_action, dnd_action);
         }
+
+        /* find the current window */
+        if (surface && SDL_WAYLAND_own_surface(surface)) {
+           SDL_WindowData *window = (SDL_WindowData *)wl_surface_get_user_data(surface);
+           if (window) {
+              data_device->dnd_window = window->sdlwindow;
+           }
+        }
     }
 }
 
@@ -1809,11 +1817,11 @@ static void data_device_handle_drop(void *data, struct wl_data_device *wl_data_d
             while (token != NULL) {
                 char *fn = Wayland_URIToLocal(token);
                 if (fn) {
-                    SDL_SendDropFile(NULL, fn); /* FIXME: Window? */
+                    SDL_SendDropFile(data_device->dnd_window, fn);
                 }
                 token = SDL_strtokr(NULL, "\r\n", &saveptr);
             }
-            SDL_SendDropComplete(NULL); /* FIXME: Window? */
+            SDL_SendDropComplete(data_device->dnd_window);
             SDL_free(buffer);
         }
     }


### PR DESCRIPTION
this resolves fixme's in wayland code. to give the correct SDL_Window to the Drag and drop API.
probably need also to apply to SDL2
