### PR TITLE
wayland: Fallback to default cursor if chosen one wasn't found

### DIFF
--- a/src/video/wayland/SDL_waylandmouse.c
+++ b/src/video/wayland/SDL_waylandmouse.c
@@ -271,6 +271,14 @@ static SDL_bool wayland_get_system_cursor(SDL_VideoData *vdata, Wayland_CursorDa
         return SDL_FALSE;
     }
 
+    /* Fallback to the default cursor if the chosen one wasn't found */
+    if (!cursor) {
+        cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "left_ptr");
+        if (!cursor) {
+            return SDL_FALSE;
+        }
+    }
+
     /* ... Set the cursor data, finally. */
     cdata->buffer = WAYLAND_wl_cursor_image_get_buffer(cursor->images[0]);
     cdata->hot_x = cursor->images[0]->hotspot_x;


### PR DESCRIPTION
If a cursor can't be found (for example it's not defined in the user theme) SDL crashes with a segmentation fault.

With this PR, the default cursor is used if the chosen one wasn't found.

This change should be backported to SDL2.