### PR TITLE
Fix For issue #6948

### DIFF
--- a/src/video/cocoa/SDL_cocoamessagebox.m
+++ b/src/video/cocoa/SDL_cocoamessagebox.m
@@ -31,7 +31,6 @@
     NSWindow *nswindow;
 }
 - (id)initWithParentWindow:(SDL_Window *)window;
-- (void)alertDidEnd:(NSAlert *)alert returnCode:(NSInteger)returnCode contextInfo:(void *)contextInfo;
 @end
 
 @implementation SDLMessageBoxPresenter
@@ -55,30 +54,16 @@
 - (void)showAlert:(NSAlert *)alert
 {
     if (nswindow) {
-        if ([alert respondsToSelector:@selector(beginSheetModalForWindow:completionHandler:)]) {
-            [alert beginSheetModalForWindow:nswindow
-                          completionHandler:^(NSModalResponse returnCode) {
-                            [NSApp stopModalWithCode:returnCode];
-                          }];
-        } else {
-            [alert beginSheetModalForWindow:nswindow
-                              modalDelegate:self
-                             didEndSelector:@selector(alertDidEnd:returnCode:contextInfo:)
-                                contextInfo:nil];
-        }
+        [alert beginSheetModalForWindow:nswindow
+                      completionHandler:^(NSModalResponse returnCode) {
+                        [NSApp stopModalWithCode:returnCode];
+                      }];
         clicked = [NSApp runModalForWindow:nswindow];
         nswindow = nil;
     } else {
         clicked = [alert runModal];
     }
 }
-
-- (void)alertDidEnd:(NSAlert *)alert returnCode:(NSInteger)returnCode contextInfo:(void *)contextInfo
-{
-    clicked = returnCode;
-    [NSApp stopModalWithCode:returnCode];
-}
-
 @end
 
 static void Cocoa_ShowMessageBoxImpl(const SDL_MessageBoxData *messageboxdata, int *buttonid, int *returnValue)

--- a/src/video/cocoa/SDL_cocoamessagebox.m
+++ b/src/video/cocoa/SDL_cocoamessagebox.m
@@ -55,28 +55,18 @@
 - (void)showAlert:(NSAlert *)alert
 {
     if (nswindow) {
-#ifdef MAC_OS_X_VERSION_10_9
         if ([alert respondsToSelector:@selector(beginSheetModalForWindow:completionHandler:)]) {
             [alert beginSheetModalForWindow:nswindow
                           completionHandler:^(NSModalResponse returnCode) {
-                            self->clicked = returnCode;
+                            [NSApp stopModalWithCode:returnCode];
                           }];
-        } else
-#endif
-        {
-#if MAC_OS_X_VERSION_MIN_REQUIRED < 1090
+        } else {
             [alert beginSheetModalForWindow:nswindow
                               modalDelegate:self
                              didEndSelector:@selector(alertDidEnd:returnCode:contextInfo:)
                                 contextInfo:nil];
-#endif
         }
-
-        while (clicked < 0) {
-            SDL_PumpEvents();
-            SDL_Delay(100);
-        }
-
+        clicked = [NSApp runModalForWindow:nswindow];
         nswindow = nil;
     } else {
         clicked = [alert runModal];
@@ -86,6 +76,7 @@
 - (void)alertDidEnd:(NSAlert *)alert returnCode:(NSInteger)returnCode contextInfo:(void *)contextInfo
 {
     clicked = returnCode;
+    [NSApp stopModalWithCode:returnCode];
 }
 
 @end


### PR DESCRIPTION
MessageBoxes attached to a window in macOS should use modal APIs and not use a poll/sleep pattern on the main thread. Sleeping the main thread makes the NSWindow message loop sluggish and interferes with external applications that need to send messages to that window, such as VoiceOver.

<!--- Provide a general summary of your changes in the Title above -->

## Description
- use [NSApplication runModalForWindow] / [NSApplication stopModalWithCode] APIs for the showAlert: implementation in SDL_cocoamessagebox.m
- unify the runtime paths around window-attached and application modal as much as possible
- Clean up #ifdef code in showAlert. It was subtly buggy, and the runtime detection of which beginSheetModalForWindow... selector to use should be sufficient.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/6948
