### PR TITLE
Avoid textinput events when pasting from clipboard on iOS.

### DIFF
--- a/src/video/uikit/SDL_uikitviewcontroller.h
+++ b/src/video/uikit/SDL_uikitviewcontroller.h
@@ -31,6 +31,10 @@
 #define SDLRootViewController UIViewController
 #endif
 
+@interface SDLUITextField : UITextField
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender;
+@end
+
 #if SDL_IPHONE_KEYBOARD
 @interface SDL_uikitviewcontroller : SDLRootViewController <UITextFieldDelegate>
 #else

--- a/src/video/uikit/SDL_uikitviewcontroller.m
+++ b/src/video/uikit/SDL_uikitviewcontroller.m
@@ -60,6 +60,17 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 }
 #endif
 
+@implementation SDLUITextField : UITextField
+- (BOOL)canPerformAction:(SEL)action withSender:(id)sender
+{
+	if (action == @selector(paste:)) {
+		return NO;
+	}
+
+	return [super canPerformAction:action withSender:sender];
+}
+@end
+
 @implementation SDL_uikitviewcontroller
 {
     CADisplayLink *displayLink;
@@ -68,7 +79,7 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
     void *animationCallbackParam;
 
 #if SDL_IPHONE_KEYBOARD
-    UITextField *textField;
+    SDLUITextField *textField;
     BOOL hardwareKeyboard;
     BOOL showingKeyboard;
     BOOL rotatingOrientation;
@@ -252,7 +263,7 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 - (void)initKeyboard
 {
     obligateForBackspace = @"                                                                "; /* 64 space */
-    textField = [[UITextField alloc] initWithFrame:CGRectZero];
+    textField = [[SDLUITextField alloc] initWithFrame:CGRectZero];
     textField.delegate = self;
     /* placeholder so there is something to delete! */
     textField.text = obligateForBackspace;


### PR DESCRIPTION
I handle command+C and command+V shortcuts for copy/paste from clipboard using SDL_GetClipboardText/SDL_SetClipboardText. But on iOS command+V shortcut is also handled by system, so that I also get textinput event with that clipboard text. And thus the application gets this clipboard text twice (from SDL_GetClipboardText and from textinput event).

I assume that intended behavior is that command+V shouldn't generate textinput events. At least as far as I know ctrl+V on other platforms does nothing. This commit disables paste action for UITextField, so that textinput event isn't generated anymore.
