### PR TITLE
wayland: Handle latched/locked and remapped modifiers

### DIFF
--- a/src/events/SDL_keyboard_c.h
+++ b/src/events/SDL_keyboard_c.h
@@ -52,6 +52,7 @@ extern int SDL_SendKeyboardUnicodeKey(Uint64 timestamp, Uint32 ch);
 /* Send a keyboard key event */
 extern int SDL_SendKeyboardKey(Uint64 timestamp, Uint8 state, SDL_Scancode scancode);
 extern int SDL_SendKeyboardKeyAutoRelease(Uint64 timestamp, SDL_Scancode scancode);
+extern int SDL_SendKeyboardKeyIgnoreModifiers(Uint64 timestamp, Uint8 state, SDL_Scancode scancode);
 
 /* This is for platforms that don't know the keymap but can report scancode and keycode directly.
    Most platforms should prefer to optionally call SDL_SetKeymap and then use SDL_SendKeyboardKey. */

--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -125,8 +125,13 @@ struct SDL_WaylandInput
         uint32_t idx_ctrl;
         uint32_t idx_alt;
         uint32_t idx_gui;
+        uint32_t idx_mode;
         uint32_t idx_num;
         uint32_t idx_caps;
+
+        /* Current system modifier flags */
+        uint32_t wl_pressed_modifiers;
+        uint32_t wl_locked_modifiers;
     } xkb;
 
     /* information about axis events on current frame */
@@ -151,6 +156,10 @@ struct SDL_WaylandInput
     SDL_bool relative_mode_override;
     SDL_bool warp_emulation_prohibited;
     SDL_bool keyboard_is_virtual;
+
+    /* Current SDL modifier flags */
+    SDL_Keymod pressed_modifiers;
+    SDL_Keymod locked_modifiers;
 };
 
 extern Uint64 Wayland_GetTouchTimestamp(struct SDL_WaylandInput *input, Uint32 wl_timestamp_ms);


### PR DESCRIPTION
Modifier keys on Wayland can be remapped, latched/locked, and change the system modifier state on key release events instead of key down events, which the default SDL modifier handling code doesn't deal with correctly. This tracks and sets the modifier keys internally to deal with the plethora of various combinations that the system modifier state can be in and correctly reflects the actual system modifier state to SDL applications.

This fixes such cases as:
- Latching or locking modifiers (e.g. sticky keys).
- Handling the level 3 shift/AltGr/Mode modifier correctly, including remapping.
- Remapping capslock to shiftlock (caps:shiftlock), where it still sends the capslock scancode and keycode, but activates the shift modifier.
- Remapping numlock to capslock (caps:numlock), where capslock sends the numlock key and toggles the numlock modifier, and the numlock key still sends the numlock scancode and keycode, but doesn't toggle the numlock modifier.
- Handling cases where the system doesn't unlock modifiers until the associated key is pressed and released.  For instance, on GNOME with capslock enabled, the modifier isn't cancelled when the capslock key is subsequently pressed, but rather when it is released.

To achieve this, as new internal `SDL_SendKeyboardKeyIgnoreModifiers()` function was added to send keystrokes while not updating the internal SDL modifier state to avoid conflicts between the Wayland and SDL modifier logic.