### PR TITLE
SDL_Vulkan_GetInstanceExtensions: Remove unused window parameter

### DIFF
--- a/include/SDL3/SDL_vulkan.h
+++ b/include/SDL3/SDL_vulkan.h
@@ -59,9 +59,6 @@ typedef VkSurfaceKHR SDL_vulkanSurface; /* for compatibility with Tizen */
 
 /**
  *  \name Vulkan support functions
- *
- *  \note SDL_Vulkan_GetInstanceExtensions & SDL_Vulkan_CreateSurface API
- *        is compatable with Tizen's implementation of Vulkan in SDL.
  */
 /* @{ */
 
@@ -142,11 +139,6 @@ extern DECLSPEC void SDLCALL SDL_Vulkan_UnloadLibrary(void);
  * required extensions, SDL_FALSE will be returned instead of SDL_TRUE, to
  * indicate that not all the required extensions were returned.
  *
- * The `window` parameter is currently needed to be valid as of SDL 2.0.8,
- * however, this parameter will likely be removed in future releases
- *
- * \param window A window for which the required Vulkan instance extensions
- *               should be retrieved (will be deprecated in a future release)
  * \param pCount A pointer to an unsigned int corresponding to the number of
  *               extensions to be returned
  * \param pNames NULL or a pointer to an array to be filled with required
@@ -157,8 +149,7 @@ extern DECLSPEC void SDLCALL SDL_Vulkan_UnloadLibrary(void);
  *
  * \sa SDL_Vulkan_CreateSurface
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_Vulkan_GetInstanceExtensions(SDL_Window *window,
-                                                                  unsigned int *pCount,
+extern DECLSPEC SDL_bool SDLCALL SDL_Vulkan_GetInstanceExtensions(unsigned int *pCount,
                                                                   const char **pNames);
 
 /**

--- a/include/SDL3/SDL_vulkan.h
+++ b/include/SDL3/SDL_vulkan.h
@@ -130,6 +130,9 @@ extern DECLSPEC void SDLCALL SDL_Vulkan_UnloadLibrary(void);
  * Get the names of the Vulkan instance extensions needed to create a surface
  * with SDL_Vulkan_CreateSurface.
  *
+ * This should be called after either calling SDL_Vulkan_LoadLibrary() or
+ * creating an SDL_Window with the `SDL_WINDOW_VULKAN` flag.
+ *
  * If `pNames` is NULL, then the number of required Vulkan instance extensions
  * is returned in `pCount`. Otherwise, `pCount` must point to a variable set
  * to the number of elements in the `pNames` array, and on return the variable

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -754,7 +754,7 @@ SDL_DYNAPI_PROC(int,SDL_UpdateWindowSurfaceRects,(SDL_Window *a, const SDL_Rect 
 SDL_DYNAPI_PROC(int,SDL_UpdateYUVTexture,(SDL_Texture *a, const SDL_Rect *b, const Uint8 *c, int d, const Uint8 *e, int f, const Uint8 *g, int h),(a,b,c,d,e,f,g,h),return)
 SDL_DYNAPI_PROC(SDL_bool,SDL_Vulkan_CreateSurface,(SDL_Window *a, VkInstance b, VkSurfaceKHR *c),(a,b,c),return)
 SDL_DYNAPI_PROC(void,SDL_Vulkan_GetDrawableSize,(SDL_Window *a, int *b, int *c),(a,b,c),)
-SDL_DYNAPI_PROC(SDL_bool,SDL_Vulkan_GetInstanceExtensions,(SDL_Window *a, unsigned int *b, const char **c),(a,b,c),return)
+SDL_DYNAPI_PROC(SDL_bool,SDL_Vulkan_GetInstanceExtensions,(unsigned int *a, const char **b),(a,b),return)
 SDL_DYNAPI_PROC(void*,SDL_Vulkan_GetVkGetInstanceProcAddr,(void),(),return)
 SDL_DYNAPI_PROC(int,SDL_Vulkan_LoadLibrary,(const char *a),(a),return)
 SDL_DYNAPI_PROC(void,SDL_Vulkan_UnloadLibrary,(void),(),)

--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -282,7 +282,7 @@ struct SDL_VideoDevice
      */
     int (*Vulkan_LoadLibrary)(_THIS, const char *path);
     void (*Vulkan_UnloadLibrary)(_THIS);
-    SDL_bool (*Vulkan_GetInstanceExtensions)(_THIS, SDL_Window *window, unsigned *count, const char **names);
+    SDL_bool (*Vulkan_GetInstanceExtensions)(_THIS, unsigned *count, const char **names);
     SDL_bool (*Vulkan_CreateSurface)(_THIS, SDL_Window *window, VkInstance instance, VkSurfaceKHR *surface);
     void (*Vulkan_GetDrawableSize)(_THIS, SDL_Window *window, int *w, int *h);
 

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -4687,23 +4687,14 @@ void SDL_Vulkan_UnloadLibrary(void)
     }
 }
 
-SDL_bool SDL_Vulkan_GetInstanceExtensions(SDL_Window *window, unsigned *count, const char **names)
+SDL_bool SDL_Vulkan_GetInstanceExtensions(unsigned *count, const char **names)
 {
-    if (window) {
-        CHECK_WINDOW_MAGIC(window, SDL_FALSE);
-
-        if (!(window->flags & SDL_WINDOW_VULKAN)) {
-            SDL_SetError(NOT_A_VULKAN_WINDOW);
-            return SDL_FALSE;
-        }
-    }
-
     if (count == NULL) {
         SDL_InvalidParamError("count");
         return SDL_FALSE;
     }
 
-    return _this->Vulkan_GetInstanceExtensions(_this, window, count, names);
+    return _this->Vulkan_GetInstanceExtensions(_this, count, names);
 }
 
 SDL_bool SDL_Vulkan_CreateSurface(SDL_Window *window,

--- a/src/video/android/SDL_androidvulkan.c
+++ b/src/video/android/SDL_androidvulkan.c
@@ -111,7 +111,6 @@ void Android_Vulkan_UnloadLibrary(_THIS)
 }
 
 SDL_bool Android_Vulkan_GetInstanceExtensions(_THIS,
-                                              SDL_Window *window,
                                               unsigned *count,
                                               const char **names)
 {

--- a/src/video/android/SDL_androidvulkan.h
+++ b/src/video/android/SDL_androidvulkan.h
@@ -37,7 +37,6 @@
 int Android_Vulkan_LoadLibrary(_THIS, const char *path);
 void Android_Vulkan_UnloadLibrary(_THIS);
 SDL_bool Android_Vulkan_GetInstanceExtensions(_THIS,
-                                              SDL_Window *window,
                                               unsigned *count,
                                               const char **names);
 SDL_bool Android_Vulkan_CreateSurface(_THIS,

--- a/src/video/cocoa/SDL_cocoavulkan.h
+++ b/src/video/cocoa/SDL_cocoavulkan.h
@@ -37,7 +37,6 @@
 int Cocoa_Vulkan_LoadLibrary(_THIS, const char *path);
 void Cocoa_Vulkan_UnloadLibrary(_THIS);
 SDL_bool Cocoa_Vulkan_GetInstanceExtensions(_THIS,
-                                            SDL_Window *window,
                                             unsigned *count,
                                             const char **names);
 SDL_bool Cocoa_Vulkan_CreateSurface(_THIS,

--- a/src/video/cocoa/SDL_cocoavulkan.m
+++ b/src/video/cocoa/SDL_cocoavulkan.m
@@ -165,7 +165,6 @@ void Cocoa_Vulkan_UnloadLibrary(_THIS)
 }
 
 SDL_bool Cocoa_Vulkan_GetInstanceExtensions(_THIS,
-                                            SDL_Window *window,
                                             unsigned *count,
                                             const char **names)
 {

--- a/src/video/kmsdrm/SDL_kmsdrmvulkan.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvulkan.c
@@ -142,7 +142,6 @@ void KMSDRM_Vulkan_UnloadLibrary(_THIS)
 /* vkCreateInstance().                                               */
 /*********************************************************************/
 SDL_bool KMSDRM_Vulkan_GetInstanceExtensions(_THIS,
-                                             SDL_Window *window,
                                              unsigned *count,
                                              const char **names)
 {

--- a/src/video/kmsdrm/SDL_kmsdrmvulkan.h
+++ b/src/video/kmsdrm/SDL_kmsdrmvulkan.h
@@ -37,7 +37,6 @@
 int KMSDRM_Vulkan_LoadLibrary(_THIS, const char *path);
 void KMSDRM_Vulkan_UnloadLibrary(_THIS);
 SDL_bool KMSDRM_Vulkan_GetInstanceExtensions(_THIS,
-                                             SDL_Window *window,
                                              unsigned *count,
                                              const char **names);
 void KMSDRM_Vulkan_GetDrawableSize(_THIS, SDL_Window *window, int *w, int *h);

--- a/src/video/uikit/SDL_uikitvulkan.h
+++ b/src/video/uikit/SDL_uikitvulkan.h
@@ -37,7 +37,6 @@
 int UIKit_Vulkan_LoadLibrary(_THIS, const char *path);
 void UIKit_Vulkan_UnloadLibrary(_THIS);
 SDL_bool UIKit_Vulkan_GetInstanceExtensions(_THIS,
-                                            SDL_Window *window,
                                             unsigned *count,
                                             const char **names);
 SDL_bool UIKit_Vulkan_CreateSurface(_THIS,

--- a/src/video/uikit/SDL_uikitvulkan.m
+++ b/src/video/uikit/SDL_uikitvulkan.m
@@ -171,7 +171,6 @@ void UIKit_Vulkan_UnloadLibrary(_THIS)
 }
 
 SDL_bool UIKit_Vulkan_GetInstanceExtensions(_THIS,
-                                            SDL_Window *window,
                                             unsigned *count,
                                             const char **names)
 {

--- a/src/video/vivante/SDL_vivantevulkan.c
+++ b/src/video/vivante/SDL_vivantevulkan.c
@@ -118,7 +118,6 @@ void VIVANTE_Vulkan_UnloadLibrary(_THIS)
 }
 
 SDL_bool VIVANTE_Vulkan_GetInstanceExtensions(_THIS,
-                                              SDL_Window *window,
                                               unsigned *count,
                                               const char **names)
 {

--- a/src/video/vivante/SDL_vivantevulkan.h
+++ b/src/video/vivante/SDL_vivantevulkan.h
@@ -37,7 +37,6 @@
 int VIVANTE_Vulkan_LoadLibrary(_THIS, const char *path);
 void VIVANTE_Vulkan_UnloadLibrary(_THIS);
 SDL_bool VIVANTE_Vulkan_GetInstanceExtensions(_THIS,
-                                              SDL_Window *window,
                                               unsigned *count,
                                               const char **names);
 SDL_bool VIVANTE_Vulkan_CreateSurface(_THIS,

--- a/src/video/wayland/SDL_waylandvulkan.c
+++ b/src/video/wayland/SDL_waylandvulkan.c
@@ -117,7 +117,6 @@ void Wayland_Vulkan_UnloadLibrary(_THIS)
 }
 
 SDL_bool Wayland_Vulkan_GetInstanceExtensions(_THIS,
-                                              SDL_Window *window,
                                               unsigned *count,
                                               const char **names)
 {

--- a/src/video/wayland/SDL_waylandvulkan.h
+++ b/src/video/wayland/SDL_waylandvulkan.h
@@ -37,7 +37,6 @@
 int Wayland_Vulkan_LoadLibrary(_THIS, const char *path);
 void Wayland_Vulkan_UnloadLibrary(_THIS);
 SDL_bool Wayland_Vulkan_GetInstanceExtensions(_THIS,
-                                              SDL_Window *window,
                                               unsigned *count,
                                               const char **names);
 SDL_bool Wayland_Vulkan_CreateSurface(_THIS,

--- a/src/video/windows/SDL_windowsvulkan.c
+++ b/src/video/windows/SDL_windowsvulkan.c
@@ -112,7 +112,6 @@ void WIN_Vulkan_UnloadLibrary(_THIS)
 }
 
 SDL_bool WIN_Vulkan_GetInstanceExtensions(_THIS,
-                                          SDL_Window *window,
                                           unsigned *count,
                                           const char **names)
 {

--- a/src/video/windows/SDL_windowsvulkan.h
+++ b/src/video/windows/SDL_windowsvulkan.h
@@ -37,7 +37,6 @@
 int WIN_Vulkan_LoadLibrary(_THIS, const char *path);
 void WIN_Vulkan_UnloadLibrary(_THIS);
 SDL_bool WIN_Vulkan_GetInstanceExtensions(_THIS,
-                                          SDL_Window *window,
                                           unsigned *count,
                                           const char **names);
 SDL_bool WIN_Vulkan_CreateSurface(_THIS,

--- a/src/video/x11/SDL_x11vulkan.c
+++ b/src/video/x11/SDL_x11vulkan.c
@@ -141,7 +141,6 @@ void X11_Vulkan_UnloadLibrary(_THIS)
 }
 
 SDL_bool X11_Vulkan_GetInstanceExtensions(_THIS,
-                                          SDL_Window *window,
                                           unsigned *count,
                                           const char **names)
 {

--- a/src/video/x11/SDL_x11vulkan.h
+++ b/src/video/x11/SDL_x11vulkan.h
@@ -33,7 +33,6 @@ typedef xcb_connection_t *(*PFN_XGetXCBConnection)(Display *dpy);
 int X11_Vulkan_LoadLibrary(_THIS, const char *path);
 void X11_Vulkan_UnloadLibrary(_THIS);
 SDL_bool X11_Vulkan_GetInstanceExtensions(_THIS,
-                                          SDL_Window *window,
                                           unsigned *count,
                                           const char **names);
 SDL_bool X11_Vulkan_CreateSurface(_THIS,

--- a/test/testvulkan.c
+++ b/test/testvulkan.c
@@ -227,7 +227,7 @@ static void createInstance(void)
     appInfo.apiVersion = VK_API_VERSION_1_0;
     instanceCreateInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
     instanceCreateInfo.pApplicationInfo = &appInfo;
-    if (!SDL_Vulkan_GetInstanceExtensions(NULL, &extensionCount, NULL)) {
+    if (!SDL_Vulkan_GetInstanceExtensions(&extensionCount, NULL)) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                      "SDL_Vulkan_GetInstanceExtensions(): %s\n",
                      SDL_GetError());
@@ -238,7 +238,7 @@ static void createInstance(void)
         SDL_OutOfMemory();
         quit(2);
     }
-    if (!SDL_Vulkan_GetInstanceExtensions(NULL, &extensionCount, extensions)) {
+    if (!SDL_Vulkan_GetInstanceExtensions(&extensionCount, extensions)) {
         SDL_free((void *)extensions);
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                      "SDL_Vulkan_GetInstanceExtensions(): %s\n",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This patch removes the unused `window` parameter from SDL_Vulkan_GetInstanceExtensions and adds a call to SDL_Vulkan_LoadLibrary.

## Description
Before calling SDL_Vulkan_GetInstanceExtensions an app has to either:

1. Create a Vulkan-capable window **or**
2. Pass a NULL window but manually call SDL_Vulkan_LoadLibrary beforehand

None of the video backends actually use the supplied window, so I (and the other users in #6895) suggest it should go. With the window parameter gone, SDL_Vulkan_GetInstanceExtensions should call SDL_Vulkan_LoadLibrary since it's the first SDL_Vulkan-related function called in a typical SDL+Vulkan application.

**Edit**: I force-pushed and removed the call to SDL_Vulkan_LoadLibrary and replaced it with a documentation update.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/6895