### PR TITLE
testevdev: cannot test evdev capabilities without linux input

### DIFF
--- a/test/testevdev.c
+++ b/test/testevdev.c
@@ -19,7 +19,7 @@
 static int run_test(void);
 
 /* FIXME: Need CMake tests for this */
-#if HAVE_LIBUDEV_H || defined(SDL_JOYSTICK_LINUX)
+#if (HAVE_LIBUDEV_H || defined(SDL_JOYSTICK_LINUX)) && HAVE_LINUX_INPUT_H
 
 #include <stdint.h>
 


### PR DESCRIPTION
Configure with "-DSDL_LIBC=OFF" to get this configuration.