### PR TITLE
RFC: Allow the SDL spin lock to be defined as a pthread mutex

### DIFF
--- a/include/SDL3/SDL_atomic.h
+++ b/include/SDL3/SDL_atomic.h
@@ -64,6 +64,10 @@
 
 #include <SDL3/SDL_begin_code.h>
 
+#if SDL_SPINLOCK_IS_PTHREAD_MUTEX
+#include <pthread.h>
+#endif
+
 /* Set up for C function definitions, even when using C++ */
 #ifdef __cplusplus
 extern "C" {
@@ -86,7 +90,13 @@ extern "C" {
  */
 /* @{ */
 
+#if SDL_SPINLOCK_IS_PTHREAD_MUTEX
+typedef pthread_mutex_t SDL_SpinLock;
+#define SDL_SPINLOCK_INITIALIZER PTHREAD_MUTEX_INITIALIZER
+#else
 typedef int SDL_SpinLock;
+#define SDL_SPINLOCK_INITIALIZER 0
+#endif
 
 /**
  * Try to lock a spin lock by setting it to a non-zero value.

--- a/include/build_config/SDL_build_config.h.cmake
+++ b/include/build_config/SDL_build_config.h.cmake
@@ -518,6 +518,9 @@
 #cmakedefine SDL_VIDEO_VITA_PVR @SDL_VIDEO_VITA_PVR@
 #cmakedefine SDL_VIDEO_VITA_PVR_OGL @SDL_VIDEO_VITA_PVR_OGL@
 
+#cmakedefine SDL_SPINLOCK_IS_PTHREAD_MUTEX @SDL_SPINLOCK_IS_PTHREAD_MUTEX@
+
+
 #if !defined(HAVE_STDINT_H) && !defined(_STDINT_H_)
 /* Most everything except Visual Studio 2008 and earlier has stdint.h now */
 #if defined(_MSC_VER) && (_MSC_VER < 1600)

--- a/src/SDL_assert.c
+++ b/src/SDL_assert.c
@@ -326,7 +326,7 @@ SDL_ReportAssertion(SDL_AssertData *data, const char *func, const char *file,
     static int assertion_running = 0;
 
 #ifndef SDL_THREADS_DISABLED
-    static SDL_SpinLock spinlock = 0;
+    static SDL_SpinLock spinlock = SDL_SPINLOCK_INITIALIZER;
     SDL_AtomicLock(&spinlock);
     if (assertion_mutex == NULL) { /* never called SDL_Init()? */
         assertion_mutex = SDL_CreateMutex();

--- a/src/dynapi/SDL_dynapi.c
+++ b/src/dynapi/SDL_dynapi.c
@@ -472,7 +472,7 @@ static void SDL_InitDynamicAPI(void)
    SDL_ATOMIC_DISABLED, which we can't do here, so in such a
    configuration, you're on your own. */
 #if !SDL_ATOMIC_DISABLED
-    static SDL_SpinLock lock = 0;
+    static SDL_SpinLock lock = SDL_SPINLOCK_INITIALIZER;
     SDL_AtomicLock_REAL(&lock);
 #endif
 

--- a/src/video/SDL_pixels.c
+++ b/src/video/SDL_pixels.c
@@ -509,7 +509,7 @@ SDL_GetPixelFormatEnumForMasks(int bpp, Uint32 Rmask, Uint32 Gmask, Uint32 Bmask
 }
 
 static SDL_PixelFormat *formats;
-static SDL_SpinLock formats_lock = 0;
+static SDL_SpinLock formats_lock = SDL_SPINLOCK_INITIALIZER;
 
 SDL_PixelFormat *
 SDL_CreatePixelFormat(Uint32 pixel_format)


### PR DESCRIPTION
Add a configuration option to use a pthread mutex for the implementation of `SDL_spinlock`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

On systems that use strict priority scheduling a user mode spin lock can cause priority inversion and starvation if held by a low priority thread.
Also, in many case native mutexes are faster than the existing SDL spinlock implementation as they provide fast-path, user-mode only access to the lock if it is not contended.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes issue #7021.