### PR TITLE
Hint registration

### DIFF
--- a/src/SDL_hints.c
+++ b/src/SDL_hints.c
@@ -324,7 +324,7 @@ void SDL_UnregisterIntHint(const char *name, int *addr)
 
 static void SDLCALL UpdateRegisteredFloatHintCallback(void *userdata, const char *name, const char *oldValue, const char *newValue)
 {
-    *((float *) userdata) = newValue ? SDL_atof(newValue) : 0.0f;
+    *((float *) userdata) = newValue ? ((float) SDL_atof(newValue)) : 0.0f;
 }
 
 SDL_bool SDL_RegisterFloatHint(const char *name, float *addr, float default_value)

--- a/src/SDL_hints_c.h
+++ b/src/SDL_hints_c.h
@@ -27,4 +27,27 @@
 
 extern SDL_bool SDL_GetStringBoolean(const char *value, SDL_bool default_value);
 
+/* You can "register" a hint, which will set its default value to `default_value` and
+   then whenever the hint changes, `*addr` will update, so you can check a static variable
+   instead of searching a linked list with SDL_GetHint every time, or deciding how to parse
+   a string for ints, floats, or bools, or having to manage your own callback just to get
+   fast lookups. String hints store a pointer to the hint's internal string; it is not to
+   be modified or freed through this interface, and may change at any time. Plan accordingly.
+   `*addr` is set by this call, to either the default or an overridden hint value from the
+   app or user. You can register the same hint to multiple variables, and registering
+   the same hint to the same address multiple times is safe to do, it will only leave
+   a single registration. */
+extern SDL_bool SDL_RegisterIntHint(const char *name, int *addr, int default_value);
+extern SDL_bool SDL_RegisterFloatHint(const char *name, float *addr, float default_value);
+extern SDL_bool SDL_RegisterBoolHint(const char *name, SDL_bool *addr, SDL_bool default_value);
+extern SDL_bool SDL_RegisterStringHint(const char *name, const char **addr, const char *default_value);
+
+/* It's not strictly necessary to unregister hints, as long as they are registered to
+   static memory, since SDL_ClearHint will clear it at shutdown.
+   But in case you want or need to, you can. */
+extern void SDL_UnregisterIntHint(const char *name, int *addr);
+extern void SDL_UnregisterFloatHint(const char *name, float *addr);
+extern void SDL_UnregisterBoolHint(const char *name, SDL_bool *addr);
+extern void SDL_UnregisterStringHint(const char *name, const char **addr);
+
 #endif /* SDL_hints_c_h_ */

--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -99,25 +99,11 @@ static struct
 } SDL_EventQ = { NULL, SDL_FALSE, { 0 }, 0, NULL, NULL, NULL, NULL, NULL };
 
 #if !SDL_JOYSTICK_DISABLED
-
 static SDL_bool SDL_update_joysticks = SDL_TRUE;
-
-static void SDLCALL SDL_AutoUpdateJoysticksChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
-{
-    SDL_update_joysticks = SDL_GetStringBoolean(hint, SDL_TRUE);
-}
-
 #endif /* !SDL_JOYSTICK_DISABLED */
 
 #if !SDL_SENSOR_DISABLED
-
 static SDL_bool SDL_update_sensors = SDL_TRUE;
-
-static void SDLCALL SDL_AutoUpdateSensorsChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
-{
-    SDL_update_sensors = SDL_GetStringBoolean(hint, SDL_TRUE);
-}
-
 #endif /* !SDL_SENSOR_DISABLED */
 
 static void SDLCALL SDL_PollSentinelChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
@@ -133,11 +119,6 @@ static void SDLCALL SDL_PollSentinelChanged(void *userdata, const char *name, co
  *  - 3: as above, plus SDL_SysWMEvents
  */
 static int SDL_EventLoggingVerbosity = 0;
-
-static void SDLCALL SDL_EventLoggingChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
-{
-    SDL_EventLoggingVerbosity = (hint && *hint) ? SDL_clamp(SDL_atoi(hint), 0, 3) : 0;
-}
 
 static void SDL_LogEvent(const SDL_Event *event)
 {
@@ -1348,15 +1329,14 @@ int SDL_SendLocaleChangedEvent(void)
 int SDL_InitEvents(void)
 {
 #if !SDL_JOYSTICK_DISABLED
-    SDL_AddHintCallback(SDL_HINT_AUTO_UPDATE_JOYSTICKS, SDL_AutoUpdateJoysticksChanged, NULL);
+    SDL_RegisterBoolHint(SDL_HINT_AUTO_UPDATE_JOYSTICKS, &SDL_update_joysticks, SDL_TRUE);
 #endif
 #if !SDL_SENSOR_DISABLED
-    SDL_AddHintCallback(SDL_HINT_AUTO_UPDATE_SENSORS, SDL_AutoUpdateSensorsChanged, NULL);
+    SDL_RegisterBoolHint(SDL_HINT_AUTO_UPDATE_SENSORS, &SDL_update_sensors, SDL_TRUE);
 #endif
-    SDL_AddHintCallback(SDL_HINT_EVENT_LOGGING, SDL_EventLoggingChanged, NULL);
+    SDL_RegisterIntHint(SDL_HINT_EVENT_LOGGING, &SDL_EventLoggingVerbosity, 0);
     SDL_AddHintCallback(SDL_HINT_POLL_SENTINEL, SDL_PollSentinelChanged, NULL);
     if (SDL_StartEventLoop() < 0) {
-        SDL_DelHintCallback(SDL_HINT_EVENT_LOGGING, SDL_EventLoggingChanged, NULL);
         return -1;
     }
 
@@ -1370,11 +1350,4 @@ void SDL_QuitEvents(void)
     SDL_QuitQuit();
     SDL_StopEventLoop();
     SDL_DelHintCallback(SDL_HINT_POLL_SENTINEL, SDL_PollSentinelChanged, NULL);
-    SDL_DelHintCallback(SDL_HINT_EVENT_LOGGING, SDL_EventLoggingChanged, NULL);
-#if !SDL_JOYSTICK_DISABLED
-    SDL_DelHintCallback(SDL_HINT_AUTO_UPDATE_JOYSTICKS, SDL_AutoUpdateJoysticksChanged, NULL);
-#endif
-#if !SDL_SENSOR_DISABLED
-    SDL_DelHintCallback(SDL_HINT_AUTO_UPDATE_SENSORS, SDL_AutoUpdateSensorsChanged, NULL);
-#endif
 }

--- a/src/events/SDL_mouse_c.h
+++ b/src/events/SDL_mouse_c.h
@@ -86,20 +86,18 @@ typedef struct
     SDL_bool relative_mode;
     SDL_bool relative_mode_warp;
     SDL_bool relative_mode_warp_motion;
-    SDL_bool enable_normal_speed_scale;
     float normal_speed_scale;
-    SDL_bool enable_relative_speed_scale;
     float relative_speed_scale;
     SDL_bool enable_relative_system_scale;
     int num_system_scale_values;
     float *system_scale_values;
-    Uint32 double_click_time;
+    int double_click_time;
     int double_click_radius;
     SDL_bool touch_mouse_events;
     SDL_bool mouse_touch_events;
     SDL_bool was_touch_mouse_events; /* Was a touch-mouse event pending? */
 #if defined(__vita__)
-    Uint8 vita_touch_mouse_device;
+    int vita_touch_mouse_device;
 #endif
     SDL_bool auto_capture;
     SDL_bool capture_desired;

--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -283,15 +283,6 @@ static SDL_bool SDL_SetJoystickIDForPlayerIndex(int player_index, SDL_JoystickID
     return SDL_TRUE;
 }
 
-static void SDLCALL SDL_JoystickAllowBackgroundEventsChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
-{
-    if (SDL_GetStringBoolean(hint, SDL_FALSE)) {
-        SDL_joystick_allows_background_events = SDL_TRUE;
-    } else {
-        SDL_joystick_allows_background_events = SDL_FALSE;
-    }
-}
-
 int SDL_InitJoysticks(void)
 {
     int i, status;
@@ -314,8 +305,7 @@ int SDL_InitJoysticks(void)
     SDL_InitGamepadMappings();
 
     /* See if we should allow joystick events while in the background */
-    SDL_AddHintCallback(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS,
-                        SDL_JoystickAllowBackgroundEventsChanged, NULL);
+    SDL_RegisterBoolHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, &SDL_joystick_allows_background_events, SDL_FALSE);
 
     status = -1;
     for (i = 0; i < SDL_arraysize(SDL_joystick_drivers); ++i) {
@@ -1302,9 +1292,6 @@ void SDL_QuitJoysticks(void)
 #if !SDL_EVENTS_DISABLED
     SDL_QuitSubSystem(SDL_INIT_EVENTS);
 #endif
-
-    SDL_DelHintCallback(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS,
-                        SDL_JoystickAllowBackgroundEventsChanged, NULL);
 
     SDL_QuitGamepadMappings();
 

--- a/src/video/cocoa/SDL_cocoaopengl.m
+++ b/src/video/cocoa/SDL_cocoaopengl.m
@@ -202,7 +202,6 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
 
 - (void)dealloc
 {
-    SDL_DelHintCallback(SDL_HINT_MAC_OPENGL_ASYNC_DISPATCH, SDL_OpenGLAsyncDispatchChanged, NULL);
     if (self->displayLink) {
         CVDisplayLinkRelease(self->displayLink);
     }

--- a/src/video/cocoa/SDL_cocoaopengl.m
+++ b/src/video/cocoa/SDL_cocoaopengl.m
@@ -54,11 +54,6 @@
 
 static SDL_bool SDL_opengl_async_dispatch = SDL_FALSE;
 
-static void SDLCALL SDL_OpenGLAsyncDispatchChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
-{
-    SDL_opengl_async_dispatch = SDL_GetStringBoolean(hint, SDL_FALSE);
-}
-
 static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeStamp *now, const CVTimeStamp *outputTime, CVOptionFlags flagsIn, CVOptionFlags *flagsOut, void *displayLinkContext)
 {
     SDLOpenGLContext *nscontext = (__bridge SDLOpenGLContext *)displayLinkContext;
@@ -100,7 +95,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
         CVDisplayLinkStart(displayLink);
     }
 
-    SDL_AddHintCallback(SDL_HINT_MAC_OPENGL_ASYNC_DISPATCH, SDL_OpenGLAsyncDispatchChanged, NULL);
+    SDL_RegisterBoolHint(SDL_HINT_MAC_OPENGL_ASYNC_DISPATCH, &SDL_opengl_async_dispatch, SDL_FALSE);
     return self;
 }
 

--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -154,7 +154,7 @@ struct SDL_WaylandInput
     /* are we forcing relative mouse mode? */
     SDL_bool cursor_visible;
     SDL_bool relative_mode_override;
-    SDL_bool warp_emulation_prohibited;
+    SDL_bool warp_emulation_allowed;
     SDL_bool keyboard_is_virtual;
 
     /* Current SDL modifier flags */

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -42,21 +42,6 @@ SDL_bool g_WindowsEnableMessageLoop = SDL_TRUE;
 SDL_bool g_WindowsEnableMenuMnemonics = SDL_FALSE;
 SDL_bool g_WindowFrameUsableWhileCursorHidden = SDL_TRUE;
 
-static void SDLCALL UpdateWindowsEnableMessageLoop(void *userdata, const char *name, const char *oldValue, const char *newValue)
-{
-    g_WindowsEnableMessageLoop = SDL_GetStringBoolean(newValue, SDL_TRUE);
-}
-
-static void SDLCALL UpdateWindowsEnableMenuMnemonics(void *userdata, const char *name, const char *oldValue, const char *newValue)
-{
-    g_WindowsEnableMenuMnemonics = SDL_GetStringBoolean(newValue, SDL_FALSE);
-}
-
-static void SDLCALL UpdateWindowFrameUsableWhileCursorHidden(void *userdata, const char *name, const char *oldValue, const char *newValue)
-{
-    g_WindowFrameUsableWhileCursorHidden = SDL_GetStringBoolean(newValue, SDL_TRUE);
-}
-
 #if !defined(__XBOXONE__) && !defined(__XBOXSERIES__)
 static void WIN_SuspendScreenSaver(_THIS)
 {
@@ -448,9 +433,9 @@ int WIN_VideoInit(_THIS)
     WIN_InitMouse(_this);
 #endif
 
-    SDL_AddHintCallback(SDL_HINT_WINDOWS_ENABLE_MESSAGELOOP, UpdateWindowsEnableMessageLoop, NULL);
-    SDL_AddHintCallback(SDL_HINT_WINDOWS_ENABLE_MENU_MNEMONICS, UpdateWindowsEnableMenuMnemonics, NULL);
-    SDL_AddHintCallback(SDL_HINT_WINDOW_FRAME_USABLE_WHILE_CURSOR_HIDDEN, UpdateWindowFrameUsableWhileCursorHidden, NULL);
+    SDL_RegisterBoolHint(SDL_HINT_WINDOWS_ENABLE_MESSAGELOOP, &g_WindowsEnableMessageLoop, SDL_TRUE);
+    SDL_RegisterBoolHint(SDL_HINT_WINDOWS_ENABLE_MENU_MNEMONICS, &g_WindowsEnableMenuMnemonics, SDL_FALSE);
+    SDL_RegisterBoolHint(SDL_HINT_WINDOW_FRAME_USABLE_WHILE_CURSOR_HIDDEN, &g_WindowFrameUsableWhileCursorHidden, SDL_TRUE);
 
 #if !defined(__XBOXONE__) && !defined(__XBOXSERIES__)
     data->_SDL_WAKEUP = RegisterWindowMessageA("_SDL_WAKEUP");

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -231,12 +231,6 @@ static void WIN_SetWindowPositionInternal(_THIS, SDL_Window *window, UINT flags)
     data->expected_resize = SDL_FALSE;
 }
 
-static void SDLCALL WIN_MouseRelativeModeCenterChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
-{
-    SDL_WindowData *data = (SDL_WindowData *)userdata;
-    data->mouse_relative_mode_center = SDL_GetStringBoolean(hint, SDL_TRUE);
-}
-
 static int WIN_GetScalingDPIForHWND(const SDL_VideoData *videodata, HWND hwnd)
 {
 #if defined(__XBOXONE__) || defined(__XBOXSERIES__)
@@ -308,7 +302,7 @@ static int SetupWindowData(_THIS, SDL_Window *window, HWND hwnd, HWND parent, SD
     SDL_Log("SetupWindowData: initialized data->scaling_dpi to %d", data->scaling_dpi);
 #endif
 
-    SDL_AddHintCallback(SDL_HINT_MOUSE_RELATIVE_MODE_CENTER, WIN_MouseRelativeModeCenterChanged, data);
+    SDL_RegisterBoolHint(SDL_HINT_MOUSE_RELATIVE_MODE_CENTER, &data->mouse_relative_mode_center, SDL_TRUE);
 
     window->driverdata = data;
 
@@ -442,7 +436,7 @@ static void CleanupWindowData(_THIS, SDL_Window *window)
     SDL_WindowData *data = (SDL_WindowData *)window->driverdata;
 
     if (data) {
-        SDL_DelHintCallback(SDL_HINT_MOUSE_RELATIVE_MODE_CENTER, WIN_MouseRelativeModeCenterChanged, data);
+        SDL_UnregisterBoolHint(SDL_HINT_MOUSE_RELATIVE_MODE_CENTER, &data->mouse_relative_mode_center);
 
 #if !defined(__XBOXONE__) && !defined(__XBOXSERIES__)
         if (data->ICMFileName) {


### PR DESCRIPTION
This PR adds hint "registration," which basically makes hints that have simple requirements easier to manage.

Basically you register a hint to an address, and it'll update that address whenever the hint was set. This piggybacks off the existing hint callback mechanism, so largely this cleans up existing code.

I originally intended to rip out the existing hint subsystem and turn it into something more like how Quake handles its "cvars," but it turns out the existing code is pretty powerful, and the specific feature I desired is easy to layer onto the existing callbacks with very little new code and without adding any new allocations...and we can pick and choose what makes sense--between SDL_GetHint, callbacks, and the new registration interface--on a per-hint basis.

Note that this is (currently) an internal-only interface.

I've cleaned out all the callbacks that are just doing simple variable upkeep, but I haven't started evaluating any of the internal calls to SDL_GetHint. Most of those should be cleaned out, too, as it will turn a pile of string comparisons while traversing a linked list, plus a getenv() call, plus parsing a string, into a simple static variable access.

This is still a draft PR until I do that.

Note that this could probably be applied to SDL 2.28.0 as well, assuming other factors haven't made this difficult to merge.

Fixes #6627.
