### PR TITLE
Add SDL_migration.cocci for SDL2 to 3 migration

### DIFF
--- a/build-scripts/SDL_migration.cocci
+++ b/build-scripts/SDL_migration.cocci
@@ -1,0 +1,1715 @@
+//
+//
+// This is a coccinelle semantic patch (https://github.com/coccinelle/coccinelle)
+// to ease migration of your project, from SDL2 to SDL3.
+//
+// It generates a 'diff' of your SDL2 project, that you can apply
+// to build for SDL3.
+// 
+//
+// install:
+// $> apt-get install coccinelle
+//
+// apply the semantic patch to generate a diff file:
+// $> spatch --sp-file path/to/SDL_migration.cocci . > your_diff.txt
+//
+// A few options:
+//   --c++=11            to parse cpp file
+//   --max-width 200     to increase line witdth of generated source
+//
+// patch you project (make a copy before..):
+// $> patch -p1 < your_diff.txt
+//
+//
+//
+// #############
+// What it does ? 
+// - all function renaming (without parameter change) as in SDL_oldnames.h
+// - remove SDL_WINDOW_SHOWN
+// - migrate SDL_CreateRGB* and SDL_ConvertSurface* functions
+//
+// #############
+// In very short, a patch is composed of two sub-blocks, like
+//
+// @@
+// declaration
+// @@
+// rule / transformation
+// 
+// So this file, is a set of many patches, mostly independant.
+// it can be incremented by inserting new patches as SDL3 api evolves.
+//
+
+
+// Remove SDL_WINDOW_SHOWN
+@@
+expression e;
+@@
+(
+- SDL_WINDOW_SHOWN | e
++ e
+|
+- SDL_WINDOW_SHOWN 
++ 0
+)
+
+
+@@
+// Remove parameter from SDL_ConvertSurface
+expression e1, e2, e3;
+@@
+SDL_ConvertSurface(e1, e2 
+- ,e3)
++ )
+
+
+@@
+// Remove parameter from SDL_ConvertSurfaceFormat
+expression e1, e2, e3;
+@@
+SDL_ConvertSurfaceFormat(e1, e2
+- ,e3)
++ )
+
+
+@@
+// SDL_CreateRGBSurfaceWithFormat
+// remove 'flags'
+// remove 'depth'
+// rename to SDL_CreateSurface
+expression e1, e2, e3, e4, e5;
+@@
+- SDL_CreateRGBSurfaceWithFormat(e1, e2, e3, e4, e5)
++ SDL_CreateSurface(e2, e3, e5)
+
+
+@@
+// SDL_CreateRGBSurfaceWithFormat:
+// remove 'depth'
+// rename to SDL_CreateSurfaceFrom
+expression e1, e2, e3, e4, e5, e6;
+@@
+- SDL_CreateRGBSurfaceWithFormatFrom(e1, e2, e3, e4, e5, e6)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e5, e6)
+
+
+
+@@
+// SDL_CreateRGBSurface : convert Masks to format
+expression e1, e2, e3, e4, e5, e6, e7, e8, e9;
+
+@@
+
+(
+
+// Generated for all formats:
+
+- SDL_CreateRGBSurface(e1, e2, e3, 1, 0x00000000, 0x00000000, 0x00000000, 0x00000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_INDEX1LSB)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 1, e4, 0x00000000, 0x00000000, 0x00000000, 0x00000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_INDEX1LSB)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 1, 0x00000000, 0x00000000, 0x00000000, 0x00000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_INDEX1MSB)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 1, e4, 0x00000000, 0x00000000, 0x00000000, 0x00000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_INDEX1MSB)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 4, 0x00000000, 0x00000000, 0x00000000, 0x00000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_INDEX4LSB)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 4, e4, 0x00000000, 0x00000000, 0x00000000, 0x00000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_INDEX4LSB)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 4, 0x00000000, 0x00000000, 0x00000000, 0x00000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_INDEX4MSB)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 4, e4, 0x00000000, 0x00000000, 0x00000000, 0x00000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_INDEX4MSB)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 8, 0x00000000, 0x00000000, 0x00000000, 0x00000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_INDEX8)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 8, e4, 0x00000000, 0x00000000, 0x00000000, 0x00000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_INDEX8)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 8, 0x000000E0, 0x0000001C, 0x00000003, 0x00000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_RGB332)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 8, e4, 0x000000E0, 0x0000001C, 0x00000003, 0x00000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_RGB332)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 12, 0x00000F00, 0x000000F0, 0x0000000F, 0x00000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_RGB444)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 12, e4, 0x00000F00, 0x000000F0, 0x0000000F, 0x00000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_RGB444)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 15, 0x00007C00, 0x000003E0, 0x0000001F, 0x00000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_RGB555)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 15, e4, 0x00007C00, 0x000003E0, 0x0000001F, 0x00000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_RGB555)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 15, 0x0000001F, 0x000003E0, 0x00007C00, 0x00000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_BGR555)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 15, e4, 0x0000001F, 0x000003E0, 0x00007C00, 0x00000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_BGR555)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 16, 0x00000F00, 0x000000F0, 0x0000000F, 0x0000F000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_ARGB4444)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 16, e4, 0x00000F00, 0x000000F0, 0x0000000F, 0x0000F000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_ARGB4444)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 16, 0x0000F000, 0x00000F00, 0x000000F0, 0x0000000F)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_RGBA4444)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 16, e4, 0x0000F000, 0x00000F00, 0x000000F0, 0x0000000F)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_RGBA4444)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 16, 0x0000000F, 0x000000F0, 0x00000F00, 0x0000F000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_ABGR4444)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 16, e4, 0x0000000F, 0x000000F0, 0x00000F00, 0x0000F000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_ABGR4444)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 16, 0x000000F0, 0x00000F00, 0x0000F000, 0x0000000F)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_BGRA4444)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 16, e4, 0x000000F0, 0x00000F00, 0x0000F000, 0x0000000F)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_BGRA4444)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 16, 0x00007C00, 0x000003E0, 0x0000001F, 0x00008000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_ARGB1555)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 16, e4, 0x00007C00, 0x000003E0, 0x0000001F, 0x00008000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_ARGB1555)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 16, 0x0000F800, 0x000007C0, 0x0000003E, 0x00000001)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_RGBA5551)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 16, e4, 0x0000F800, 0x000007C0, 0x0000003E, 0x00000001)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_RGBA5551)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 16, 0x0000001F, 0x000003E0, 0x00007C00, 0x00008000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_ABGR1555)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 16, e4, 0x0000001F, 0x000003E0, 0x00007C00, 0x00008000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_ABGR1555)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 16, 0x0000003E, 0x000007C0, 0x0000F800, 0x00000001)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_BGRA5551)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 16, e4, 0x0000003E, 0x000007C0, 0x0000F800, 0x00000001)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_BGRA5551)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 16, 0x0000F800, 0x000007E0, 0x0000001F, 0x00000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_RGB565)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 16, e4, 0x0000F800, 0x000007E0, 0x0000001F, 0x00000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_RGB565)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 16, 0x0000001F, 0x000007E0, 0x0000F800, 0x00000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_BGR565)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 16, e4, 0x0000001F, 0x000007E0, 0x0000F800, 0x00000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_BGR565)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 24, 0x000000FF, 0x0000FF00, 0x00FF0000, 0x00000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_RGB24)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 24, e4, 0x000000FF, 0x0000FF00, 0x00FF0000, 0x00000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_RGB24)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 24, 0x00FF0000, 0x0000FF00, 0x000000FF, 0x00000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_BGR24)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 24, e4, 0x00FF0000, 0x0000FF00, 0x000000FF, 0x00000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_BGR24)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 32, 0x00FF0000, 0x0000FF00, 0x000000FF, 0x00000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_RGB888)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 32, e4, 0x00FF0000, 0x0000FF00, 0x000000FF, 0x00000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_RGB888)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 32, 0xFF000000, 0x00FF0000, 0x0000FF00, 0x00000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_RGBX8888)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 32, e4, 0xFF000000, 0x00FF0000, 0x0000FF00, 0x00000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_RGBX8888)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 32, 0x000000FF, 0x0000FF00, 0x00FF0000, 0x00000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_BGR888)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 32, e4, 0x000000FF, 0x0000FF00, 0x00FF0000, 0x00000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_BGR888)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 32, 0x0000FF00, 0x00FF0000, 0xFF000000, 0x00000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_BGRX8888)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 32, e4, 0x0000FF00, 0x00FF0000, 0xFF000000, 0x00000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_BGRX8888)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 32, 0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_ARGB8888)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 32, e4, 0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_ARGB8888)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 32, 0xFF000000, 0x00FF0000, 0x0000FF00, 0x000000FF)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_RGBA8888)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 32, e4, 0xFF000000, 0x00FF0000, 0x0000FF00, 0x000000FF)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_RGBA8888)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 32, 0x000000FF, 0x0000FF00, 0x00FF0000, 0xFF000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_ABGR8888)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 32, e4, 0x000000FF, 0x0000FF00, 0x00FF0000, 0xFF000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_ABGR8888)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 32, 0x0000FF00, 0x00FF0000, 0xFF000000, 0x000000FF)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_BGRA8888)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 32, e4, 0x0000FF00, 0x00FF0000, 0xFF000000, 0x000000FF)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_BGRA8888)
+
+|
+
+- SDL_CreateRGBSurface(e1, e2, e3, 32, 0x3FF00000, 0x000FFC00, 0x000003FF, 0xC0000000)
++ SDL_CreateSurface(e2, e3, SDL_PIXELFORMAT_ARGB2101010)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, 32, e4, 0x3FF00000, 0x000FFC00, 0x000003FF, 0xC0000000)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e4, SDL_PIXELFORMAT_ARGB2101010)
+
+|
+
+// End Generated
+
+
+- SDL_CreateRGBSurface(e1, e2, e3, e4->BitsPerPixel, e4->Rmask, e4->Gmask, e4->Bmask, e4->Amask)
++ SDL_CreateSurface(e2, e3, e4->format)
+
+|
+
+- SDL_CreateRGBSurfaceFrom(e1, e2, e3, e4->BitsPerPixel, e5, e4->Rmask, e4->Gmask, e4->Bmask, e4->Amask)
++ SDL_CreateSurfaceFrom(e1, e2, e3, e5, e4->format)
+
+|
+
+-SDL_CreateRGBSurface(e1, e2, e3, e4, e5, e6, e7, e8)
++SDL_CreateSurface(e2, e3, SDL_MasksToPixelFormatEnum(e4, e5, e6, e7, e8))
+
+|
+
+-SDL_CreateRGBSurfaceFrom(e1, e2, e3, e4, e5, e6, e7, e8, e9)
++SDL_CreateSurfaceFrom(e1, e2, e3, e5, SDL_MasksToPixelFormatEnum(e4, e6, e7, e8, e9))
+
+)
+
+
+
+// Renaming of SDL_oldnames.h
+
+@@
+@@
+- SDL_AudioStreamAvailable
++ SDL_GetAudioStreamAvailable
+  (...)
+@@
+@@
+- SDL_AudioStreamClear
++ SDL_ClearAudioStream
+  (...)
+@@
+@@
+- SDL_AudioStreamFlush
++ SDL_FlushAudioStream
+  (...)
+@@
+@@
+- SDL_AudioStreamGet
++ SDL_GetAudioStreamData
+  (...)
+@@
+@@
+- SDL_AudioStreamPut
++ SDL_PutAudioStreamData
+  (...)
+@@
+@@
+- SDL_FreeAudioStream
++ SDL_DestroyAudioStream
+  (...)
+@@
+@@
+- SDL_FreeWAV
++ SDL_free
+  (...)
+@@
+@@
+- SDL_NewAudioStream
++ SDL_CreateAudioStream
+  (...)
+@@
+@@
+- SDL_CONTROLLERAXISMOTION
++ SDL_GAMEPADAXISMOTION
+@@
+@@
+- SDL_CONTROLLERBUTTONDOWN
++ SDL_GAMEPADBUTTONDOWN
+@@
+@@
+- SDL_CONTROLLERBUTTONUP
++ SDL_GAMEPADBUTTONUP
+@@
+@@
+- SDL_CONTROLLERDEVICEADDED
++ SDL_GAMEPADADDED
+@@
+@@
+- SDL_CONTROLLERDEVICEREMAPPED
++ SDL_GAMEPADREMAPPED
+@@
+@@
+- SDL_CONTROLLERDEVICEREMOVED
++ SDL_GAMEPADREMOVED
+@@
+@@
+- SDL_CONTROLLERSENSORUPDATE
++ SDL_GAMEPADSENSORUPDATE
+@@
+@@
+- SDL_CONTROLLERTOUCHPADDOWN
++ SDL_GAMEPADTOUCHPADDOWN
+@@
+@@
+- SDL_CONTROLLERTOUCHPADMOTION
++ SDL_GAMEPADTOUCHPADMOTION
+@@
+@@
+- SDL_CONTROLLERTOUCHPADUP
++ SDL_GAMEPADTOUCHPADUP
+@@
+@@
+- SDL_ControllerAxisEvent
++ SDL_GamepadAxisEvent
+  (...)
+@@
+@@
+- SDL_ControllerButtonEvent
++ SDL_GamepadButtonEvent
+  (...)
+@@
+@@
+- SDL_ControllerDeviceEvent
++ SDL_GamepadDeviceEvent
+  (...)
+@@
+@@
+- SDL_ControllerSensorEvent
++ SDL_GamepadSensorEvent
+  (...)
+@@
+@@
+- SDL_ControllerTouchpadEvent
++ SDL_GamepadTouchpadEvent
+  (...)
+@@
+@@
+- SDL_CONTROLLER_AXIS_INVALID
++ SDL_GAMEPAD_AXIS_INVALID
+@@
+@@
+- SDL_CONTROLLER_AXIS_LEFTX
++ SDL_GAMEPAD_AXIS_LEFTX
+@@
+@@
+- SDL_CONTROLLER_AXIS_LEFTY
++ SDL_GAMEPAD_AXIS_LEFTY
+@@
+@@
+- SDL_CONTROLLER_AXIS_MAX
++ SDL_GAMEPAD_AXIS_MAX
+@@
+@@
+- SDL_CONTROLLER_AXIS_RIGHTX
++ SDL_GAMEPAD_AXIS_RIGHTX
+@@
+@@
+- SDL_CONTROLLER_AXIS_RIGHTY
++ SDL_GAMEPAD_AXIS_RIGHTY
+@@
+@@
+- SDL_CONTROLLER_AXIS_TRIGGERLEFT
++ SDL_GAMEPAD_AXIS_LEFT_TRIGGER
+@@
+@@
+- SDL_CONTROLLER_AXIS_TRIGGERRIGHT
++ SDL_GAMEPAD_AXIS_RIGHT_TRIGGER
+@@
+@@
+- SDL_CONTROLLER_BINDTYPE_AXIS
++ SDL_GAMEPAD_BINDTYPE_AXIS
+@@
+@@
+- SDL_CONTROLLER_BINDTYPE_BUTTON
++ SDL_GAMEPAD_BINDTYPE_BUTTON
+@@
+@@
+- SDL_CONTROLLER_BINDTYPE_HAT
++ SDL_GAMEPAD_BINDTYPE_HAT
+@@
+@@
+- SDL_CONTROLLER_BINDTYPE_NONE
++ SDL_GAMEPAD_BINDTYPE_NONE
+@@
+@@
+- SDL_CONTROLLER_BUTTON_A
++ SDL_GAMEPAD_BUTTON_A
+@@
+@@
+- SDL_CONTROLLER_BUTTON_B
++ SDL_GAMEPAD_BUTTON_B
+@@
+@@
+- SDL_CONTROLLER_BUTTON_BACK
++ SDL_GAMEPAD_BUTTON_BACK
+@@
+@@
+- SDL_CONTROLLER_BUTTON_DPAD_DOWN
++ SDL_GAMEPAD_BUTTON_DPAD_DOWN
+@@
+@@
+- SDL_CONTROLLER_BUTTON_DPAD_LEFT
++ SDL_GAMEPAD_BUTTON_DPAD_LEFT
+@@
+@@
+- SDL_CONTROLLER_BUTTON_DPAD_RIGHT
++ SDL_GAMEPAD_BUTTON_DPAD_RIGHT
+@@
+@@
+- SDL_CONTROLLER_BUTTON_DPAD_UP
++ SDL_GAMEPAD_BUTTON_DPAD_UP
+@@
+@@
+- SDL_CONTROLLER_BUTTON_GUIDE
++ SDL_GAMEPAD_BUTTON_GUIDE
+@@
+@@
+- SDL_CONTROLLER_BUTTON_INVALID
++ SDL_GAMEPAD_BUTTON_INVALID
+@@
+@@
+- SDL_CONTROLLER_BUTTON_LEFTSHOULDER
++ SDL_GAMEPAD_BUTTON_LEFT_SHOULDER
+@@
+@@
+- SDL_CONTROLLER_BUTTON_LEFTSTICK
++ SDL_GAMEPAD_BUTTON_LEFT_STICK
+@@
+@@
+- SDL_CONTROLLER_BUTTON_MAX
++ SDL_GAMEPAD_BUTTON_MAX
+@@
+@@
+- SDL_CONTROLLER_BUTTON_MISC1
++ SDL_GAMEPAD_BUTTON_MISC1
+@@
+@@
+- SDL_CONTROLLER_BUTTON_PADDLE1
++ SDL_GAMEPAD_BUTTON_PADDLE1
+@@
+@@
+- SDL_CONTROLLER_BUTTON_PADDLE2
++ SDL_GAMEPAD_BUTTON_PADDLE2
+@@
+@@
+- SDL_CONTROLLER_BUTTON_PADDLE3
++ SDL_GAMEPAD_BUTTON_PADDLE3
+@@
+@@
+- SDL_CONTROLLER_BUTTON_PADDLE4
++ SDL_GAMEPAD_BUTTON_PADDLE4
+@@
+@@
+- SDL_CONTROLLER_BUTTON_RIGHTSHOULDER
++ SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER
+@@
+@@
+- SDL_CONTROLLER_BUTTON_RIGHTSTICK
++ SDL_GAMEPAD_BUTTON_RIGHT_STICK
+@@
+@@
+- SDL_CONTROLLER_BUTTON_START
++ SDL_GAMEPAD_BUTTON_START
+@@
+@@
+- SDL_CONTROLLER_BUTTON_TOUCHPAD
++ SDL_GAMEPAD_BUTTON_TOUCHPAD
+@@
+@@
+- SDL_CONTROLLER_BUTTON_X
++ SDL_GAMEPAD_BUTTON_X
+@@
+@@
+- SDL_CONTROLLER_BUTTON_Y
++ SDL_GAMEPAD_BUTTON_Y
+@@
+@@
+- SDL_CONTROLLER_TYPE_AMAZON_LUNA
++ SDL_GAMEPAD_TYPE_AMAZON_LUNA
+@@
+@@
+- SDL_CONTROLLER_TYPE_GOOGLE_STADIA
++ SDL_GAMEPAD_TYPE_GOOGLE_STADIA
+@@
+@@
+- SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_JOYCON_LEFT
++ SDL_GAMEPAD_TYPE_NINTENDO_SWITCH_JOYCON_LEFT
+@@
+@@
+- SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_JOYCON_PAIR
++ SDL_GAMEPAD_TYPE_NINTENDO_SWITCH_JOYCON_PAIR
+@@
+@@
+- SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_JOYCON_RIGHT
++ SDL_GAMEPAD_TYPE_NINTENDO_SWITCH_JOYCON_RIGHT
+@@
+@@
+- SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_PRO
++ SDL_GAMEPAD_TYPE_NINTENDO_SWITCH_PRO
+@@
+@@
+- SDL_CONTROLLER_TYPE_NVIDIA_SHIELD
++ SDL_GAMEPAD_TYPE_NVIDIA_SHIELD
+@@
+@@
+- SDL_CONTROLLER_TYPE_PS3
++ SDL_GAMEPAD_TYPE_PS3
+@@
+@@
+- SDL_CONTROLLER_TYPE_PS4
++ SDL_GAMEPAD_TYPE_PS4
+@@
+@@
+- SDL_CONTROLLER_TYPE_PS5
++ SDL_GAMEPAD_TYPE_PS5
+@@
+@@
+- SDL_CONTROLLER_TYPE_UNKNOWN
++ SDL_GAMEPAD_TYPE_UNKNOWN
+@@
+@@
+- SDL_CONTROLLER_TYPE_VIRTUAL
++ SDL_GAMEPAD_TYPE_VIRTUAL
+@@
+@@
+- SDL_CONTROLLER_TYPE_XBOX360
++ SDL_GAMEPAD_TYPE_XBOX360
+@@
+@@
+- SDL_CONTROLLER_TYPE_XBOXONE
++ SDL_GAMEPAD_TYPE_XBOXONE
+@@
+@@
+- SDL_GameController
++ SDL_Gamepad
+  (...)
+@@
+@@
+- SDL_GameControllerAddMapping
++ SDL_AddGamepadMapping
+  (...)
+@@
+@@
+- SDL_GameControllerAddMappingsFromFile
++ SDL_AddGamepadMappingsFromFile
+  (...)
+@@
+@@
+- SDL_GameControllerAddMappingsFromRW
++ SDL_AddGamepadMappingsFromRW
+  (...)
+@@
+@@
+- SDL_GameControllerAxis
++ SDL_GamepadAxis
+  (...)
+@@
+@@
+- SDL_GameControllerBindType
++ SDL_GamepadBindingType
+  (...)
+@@
+@@
+- SDL_GameControllerButton
++ SDL_GamepadButton
+  (...)
+@@
+@@
+- SDL_GameControllerButtonBind
++ SDL_GamepadBinding
+  (...)
+@@
+@@
+- SDL_GameControllerClose
++ SDL_CloseGamepad
+  (...)
+@@
+@@
+- SDL_GameControllerFromInstanceID
++ SDL_GetGamepadFromInstanceID
+  (...)
+@@
+@@
+- SDL_GameControllerFromPlayerIndex
++ SDL_GetGamepadFromPlayerIndex
+  (...)
+@@
+@@
+- SDL_GameControllerGetAppleSFSymbolsNameForAxis
++ SDL_GetGamepadAppleSFSymbolsNameForAxis
+  (...)
+@@
+@@
+- SDL_GameControllerGetAppleSFSymbolsNameForButton
++ SDL_GetGamepadAppleSFSymbolsNameForButton
+  (...)
+@@
+@@
+- SDL_GameControllerGetAttached
++ SDL_GamepadConnected
+  (...)
+@@
+@@
+- SDL_GameControllerGetAxis
++ SDL_GetGamepadAxis
+  (...)
+@@
+@@
+- SDL_GameControllerGetAxisFromString
++ SDL_GetGamepadAxisFromString
+  (...)
+@@
+@@
+- SDL_GameControllerGetBindForAxis
++ SDL_GetGamepadBindForAxis
+  (...)
+@@
+@@
+- SDL_GameControllerGetBindForButton
++ SDL_GetGamepadBindForButton
+  (...)
+@@
+@@
+- SDL_GameControllerGetButton
++ SDL_GetGamepadButton
+  (...)
+@@
+@@
+- SDL_GameControllerGetButtonFromString
++ SDL_GetGamepadButtonFromString
+  (...)
+@@
+@@
+- SDL_GameControllerGetFirmwareVersion
++ SDL_GetGamepadFirmwareVersion
+  (...)
+@@
+@@
+- SDL_GameControllerGetJoystick
++ SDL_GetGamepadJoystick
+  (...)
+@@
+@@
+- SDL_GameControllerGetNumTouchpadFingers
++ SDL_GetGamepadNumTouchpadFingers
+  (...)
+@@
+@@
+- SDL_GameControllerGetNumTouchpads
++ SDL_GetGamepadNumTouchpads
+  (...)
+@@
+@@
+- SDL_GameControllerGetPlayerIndex
++ SDL_GetGamepadPlayerIndex
+  (...)
+@@
+@@
+- SDL_GameControllerGetProduct
++ SDL_GetGamepadProduct
+  (...)
+@@
+@@
+- SDL_GameControllerGetProductVersion
++ SDL_GetGamepadProductVersion
+  (...)
+@@
+@@
+- SDL_GameControllerGetSensorData
++ SDL_GetGamepadSensorData
+  (...)
+@@
+@@
+- SDL_GameControllerGetSensorDataRate
++ SDL_GetGamepadSensorDataRate
+  (...)
+@@
+@@
+- SDL_GameControllerGetSerial
++ SDL_GetGamepadSerial
+  (...)
+@@
+@@
+- SDL_GameControllerGetStringForAxis
++ SDL_GetGamepadStringForAxis
+  (...)
+@@
+@@
+- SDL_GameControllerGetStringForButton
++ SDL_GetGamepadStringForButton
+  (...)
+@@
+@@
+- SDL_GameControllerGetTouchpadFinger
++ SDL_GetGamepadTouchpadFinger
+  (...)
+@@
+@@
+- SDL_GameControllerGetType
++ SDL_GetGamepadType
+  (...)
+@@
+@@
+- SDL_GameControllerGetVendor
++ SDL_GetGamepadVendor
+  (...)
+@@
+@@
+- SDL_GameControllerHasAxis
++ SDL_GamepadHasAxis
+  (...)
+@@
+@@
+- SDL_GameControllerHasButton
++ SDL_GamepadHasButton
+  (...)
+@@
+@@
+- SDL_GameControllerHasLED
++ SDL_GamepadHasLED
+  (...)
+@@
+@@
+- SDL_GameControllerHasRumble
++ SDL_GamepadHasRumble
+  (...)
+@@
+@@
+- SDL_GameControllerHasRumbleTriggers
++ SDL_GamepadHasRumbleTriggers
+  (...)
+@@
+@@
+- SDL_GameControllerHasSensor
++ SDL_GamepadHasSensor
+  (...)
+@@
+@@
+- SDL_GameControllerIsSensorEnabled
++ SDL_GamepadSensorEnabled
+  (...)
+@@
+@@
+- SDL_GameControllerMapping
++ SDL_GetGamepadMapping
+  (...)
+@@
+@@
+- SDL_GameControllerMappingForDeviceIndex
++ SDL_GetGamepadMappingForDeviceIndex
+  (...)
+@@
+@@
+- SDL_GameControllerMappingForGUID
++ SDL_GetGamepadMappingForGUID
+  (...)
+@@
+@@
+- SDL_GameControllerMappingForIndex
++ SDL_GetGamepadMappingForIndex
+  (...)
+@@
+@@
+- SDL_GameControllerName
++ SDL_GetGamepadName
+  (...)
+@@
+@@
+- SDL_GameControllerNumMappings
++ SDL_GetNumGamepadMappings
+  (...)
+@@
+@@
+- SDL_GameControllerOpen
++ SDL_OpenGamepad
+  (...)
+@@
+@@
+- SDL_GameControllerPath
++ SDL_GetGamepadPath
+  (...)
+@@
+@@
+- SDL_GameControllerRumble
++ SDL_RumbleGamepad
+  (...)
+@@
+@@
+- SDL_GameControllerRumbleTriggers
++ SDL_RumbleGamepadTriggers
+  (...)
+@@
+@@
+- SDL_GameControllerSendEffect
++ SDL_SendGamepadEffect
+  (...)
+@@
+@@
+- SDL_GameControllerSetLED
++ SDL_SetGamepadLED
+  (...)
+@@
+@@
+- SDL_GameControllerSetPlayerIndex
++ SDL_SetGamepadPlayerIndex
+  (...)
+@@
+@@
+- SDL_GameControllerSetSensorEnabled
++ SDL_SetGamepadSensorEnabled
+  (...)
+@@
+@@
+- SDL_GameControllerType
++ SDL_GamepadType
+  (...)
+@@
+@@
+- SDL_GameControllerUpdate
++ SDL_UpdateGamepads
+  (...)
+@@
+@@
+- SDL_INIT_GAMECONTROLLER
++ SDL_INIT_GAMEPAD
+@@
+@@
+- SDL_IsGameController
++ SDL_IsGamepad
+  (...)
+@@
+@@
+- SDL_JOYSTICK_TYPE_GAMECONTROLLER
++ SDL_JOYSTICK_TYPE_GAMEPAD
+@@
+@@
+- SDL_JoystickAttachVirtual
++ SDL_AttachVirtualJoystick
+  (...)
+@@
+@@
+- SDL_JoystickAttachVirtualEx
++ SDL_AttachVirtualJoystickEx
+  (...)
+@@
+@@
+- SDL_JoystickClose
++ SDL_CloseJoystick
+  (...)
+@@
+@@
+- SDL_JoystickCurrentPowerLevel
++ SDL_GetJoystickPowerLevel
+  (...)
+@@
+@@
+- SDL_JoystickDetachVirtual
++ SDL_DetachVirtualJoystick
+  (...)
+@@
+@@
+- SDL_JoystickFromInstanceID
++ SDL_GetJoystickFromInstanceID
+  (...)
+@@
+@@
+- SDL_JoystickFromPlayerIndex
++ SDL_GetJoystickFromPlayerIndex
+  (...)
+@@
+@@
+- SDL_JoystickGetAttached
++ SDL_JoystickConnected
+  (...)
+@@
+@@
+- SDL_JoystickGetAxis
++ SDL_GetJoystickAxis
+  (...)
+@@
+@@
+- SDL_JoystickGetAxisInitialState
++ SDL_GetJoystickAxisInitialState
+  (...)
+@@
+@@
+- SDL_JoystickGetButton
++ SDL_GetJoystickButton
+  (...)
+@@
+@@
+- SDL_JoystickGetFirmwareVersion
++ SDL_GetJoystickFirmwareVersion
+  (...)
+@@
+@@
+- SDL_JoystickGetGUID
++ SDL_GetJoystickGUID
+  (...)
+@@
+@@
+- SDL_JoystickGetGUIDFromString
++ SDL_GetJoystickGUIDFromString
+  (...)
+@@
+@@
+- SDL_JoystickGetGUIDString
++ SDL_GetJoystickGUIDString
+  (...)
+@@
+@@
+- SDL_JoystickGetHat
++ SDL_GetJoystickHat
+  (...)
+@@
+@@
+- SDL_JoystickGetPlayerIndex
++ SDL_GetJoystickPlayerIndex
+  (...)
+@@
+@@
+- SDL_JoystickGetProduct
++ SDL_GetJoystickProduct
+  (...)
+@@
+@@
+- SDL_JoystickGetProductVersion
++ SDL_GetJoystickProductVersion
+  (...)
+@@
+@@
+- SDL_JoystickGetSerial
++ SDL_GetJoystickSerial
+  (...)
+@@
+@@
+- SDL_JoystickGetType
++ SDL_GetJoystickType
+  (...)
+@@
+@@
+- SDL_JoystickGetVendor
++ SDL_GetJoystickVendor
+  (...)
+@@
+@@
+- SDL_JoystickInstanceID
++ SDL_GetJoystickInstanceID
+  (...)
+@@
+@@
+- SDL_JoystickIsVirtual
++ SDL_IsJoystickVirtual
+  (...)
+@@
+@@
+- SDL_JoystickName
++ SDL_GetJoystickName
+  (...)
+@@
+@@
+- SDL_JoystickNumAxes
++ SDL_GetNumJoystickAxes
+  (...)
+@@
+@@
+- SDL_JoystickNumButtons
++ SDL_GetNumJoystickButtons
+  (...)
+@@
+@@
+- SDL_JoystickNumHats
++ SDL_GetNumJoystickHats
+  (...)
+@@
+@@
+- SDL_JoystickOpen
++ SDL_OpenJoystick
+  (...)
+@@
+@@
+- SDL_JoystickPath
++ SDL_GetJoystickPath
+  (...)
+@@
+@@
+- SDL_JoystickRumble
++ SDL_RumbleJoystick
+  (...)
+@@
+@@
+- SDL_JoystickRumbleTriggers
++ SDL_RumbleJoystickTriggers
+  (...)
+@@
+@@
+- SDL_JoystickSendEffect
++ SDL_SendJoystickEffect
+  (...)
+@@
+@@
+- SDL_JoystickSetLED
++ SDL_SetJoystickLED
+  (...)
+@@
+@@
+- SDL_JoystickSetPlayerIndex
++ SDL_SetJoystickPlayerIndex
+  (...)
+@@
+@@
+- SDL_JoystickSetVirtualAxis
++ SDL_SetJoystickVirtualAxis
+  (...)
+@@
+@@
+- SDL_JoystickSetVirtualButton
++ SDL_SetJoystickVirtualButton
+  (...)
+@@
+@@
+- SDL_JoystickSetVirtualHat
++ SDL_SetJoystickVirtualHat
+  (...)
+@@
+@@
+- SDL_JoystickUpdate
++ SDL_UpdateJoysticks
+  (...)
+@@
+@@
+- SDL_IsScreenKeyboardShown
++ SDL_ScreenKeyboardShown
+  (...)
+@@
+@@
+- SDL_IsTextInputActive
++ SDL_TextInputActive
+  (...)
+@@
+@@
+- SDL_IsTextInputShown
++ SDL_TextInputShown
+  (...)
+@@
+@@
+- KMOD_ALT
++ SDL_KMOD_ALT
+@@
+@@
+- KMOD_CAPS
++ SDL_KMOD_CAPS
+@@
+@@
+- KMOD_CTRL
++ SDL_KMOD_CTRL
+@@
+@@
+- KMOD_GUI
++ SDL_KMOD_GUI
+@@
+@@
+- KMOD_LALT
++ SDL_KMOD_LALT
+@@
+@@
+- KMOD_LCTRL
++ SDL_KMOD_LCTRL
+@@
+@@
+- KMOD_LGUI
++ SDL_KMOD_LGUI
+@@
+@@
+- KMOD_LSHIFT
++ SDL_KMOD_LSHIFT
+@@
+@@
+- KMOD_MODE
++ SDL_KMOD_MODE
+@@
+@@
+- KMOD_NONE
++ SDL_KMOD_NONE
+@@
+@@
+- KMOD_NUM
++ SDL_KMOD_NUM
+@@
+@@
+- KMOD_RALT
++ SDL_KMOD_RALT
+@@
+@@
+- KMOD_RCTRL
++ SDL_KMOD_RCTRL
+@@
+@@
+- KMOD_RESERVED
++ SDL_KMOD_RESERVED
+@@
+@@
+- KMOD_RGUI
++ SDL_KMOD_RGUI
+@@
+@@
+- KMOD_RSHIFT
++ SDL_KMOD_RSHIFT
+@@
+@@
+- KMOD_SCROLL
++ SDL_KMOD_SCROLL
+@@
+@@
+- KMOD_SHIFT
++ SDL_KMOD_SHIFT
+@@
+@@
+- SDL_FreeCursor
++ SDL_DestroyCursor
+  (...)
+@@
+@@
+- SDL_AllocFormat
++ SDL_CreatePixelFormat
+  (...)
+@@
+@@
+- SDL_AllocPalette
++ SDL_CreatePalette
+  (...)
+@@
+@@
+- SDL_FreeFormat
++ SDL_DestroyPixelFormat
+  (...)
+@@
+@@
+- SDL_FreePalette
++ SDL_DestroyPalette
+  (...)
+@@
+@@
+- SDL_MasksToPixelFormatEnum
++ SDL_GetPixelFormatEnumForMasks
+  (...)
+@@
+@@
+- SDL_PixelFormatEnumToMasks
++ SDL_GetMasksForPixelFormatEnum
+  (...)
+@@
+@@
+- SDL_EncloseFPoints
++ SDL_GetRectEnclosingPointsFloat
+  (...)
+@@
+@@
+- SDL_EnclosePoints
++ SDL_GetRectEnclosingPoints
+  (...)
+@@
+@@
+- SDL_FRectEmpty
++ SDL_RectEmptyFloat
+  (...)
+@@
+@@
+- SDL_FRectEquals
++ SDL_RectsEqualFloat
+  (...)
+@@
+@@
+- SDL_FRectEqualsEpsilon
++ SDL_RectsEqualEpsilon
+  (...)
+@@
+@@
+- SDL_HasIntersection
++ SDL_HasRectIntersection
+  (...)
+@@
+@@
+- SDL_HasIntersectionF
++ SDL_HasRectIntersectionFloat
+  (...)
+@@
+@@
+- SDL_IntersectFRect
++ SDL_GetRectIntersectionFloat
+  (...)
+@@
+@@
+- SDL_IntersectFRectAndLine
++ SDL_GetRectAndLineIntersectionFloat
+  (...)
+@@
+@@
+- SDL_IntersectRect
++ SDL_GetRectIntersection
+  (...)
+@@
+@@
+- SDL_IntersectRectAndLine
++ SDL_GetRectAndLineIntersection
+  (...)
+@@
+@@
+- SDL_PointInFRect
++ SDL_PointInRectFloat
+  (...)
+@@
+@@
+- SDL_RectEquals
++ SDL_RectsEqual
+  (...)
+@@
+@@
+- SDL_UnionFRect
++ SDL_GetRectUnionFloat
+  (...)
+@@
+@@
+- SDL_UnionRect
++ SDL_GetRectUnion
+  (...)
+@@
+@@
+- SDL_RenderCopyExF
++ SDL_RenderTextureRotated
+  (...)
+@@
+@@
+- SDL_RenderCopyF
++ SDL_RenderTexture
+  (...)
+@@
+@@
+- SDL_RenderDrawLineF
++ SDL_RenderLine
+  (...)
+@@
+@@
+- SDL_RenderDrawLinesF
++ SDL_RenderLines
+  (...)
+@@
+@@
+- SDL_RenderDrawPointF
++ SDL_RenderPoint
+  (...)
+@@
+@@
+- SDL_RenderDrawPointsF
++ SDL_RenderPoints
+  (...)
+@@
+@@
+- SDL_RenderDrawRectF
++ SDL_RenderRect
+  (...)
+@@
+@@
+- SDL_RenderDrawRectsF
++ SDL_RenderRects
+  (...)
+@@
+@@
+- SDL_RenderFillRectF
++ SDL_RenderFillRect
+  (...)
+@@
+@@
+- SDL_RenderFillRectsF
++ SDL_RenderFillRects
+  (...)
+@@
+@@
+- SDL_RenderGetClipRect
++ SDL_GetRenderClipRect
+  (...)
+@@
+@@
+- SDL_RenderGetIntegerScale
++ SDL_GetRenderIntegerScale
+  (...)
+@@
+@@
+- SDL_RenderGetLogicalSize
++ SDL_GetRenderLogicalSize
+  (...)
+@@
+@@
+- SDL_RenderGetMetalCommandEncoder
++ SDL_GetRenderMetalCommandEncoder
+  (...)
+@@
+@@
+- SDL_RenderGetMetalLayer
++ SDL_GetRenderMetalLayer
+  (...)
+@@
+@@
+- SDL_RenderGetScale
++ SDL_GetRenderScale
+  (...)
+@@
+@@
+- SDL_RenderGetViewport
++ SDL_GetRenderViewport
+  (...)
+@@
+@@
+- SDL_RenderGetWindow
++ SDL_GetRenderWindow
+  (...)
+@@
+@@
+- SDL_RenderIsClipEnabled
++ SDL_RenderClipEnabled
+  (...)
+@@
+@@
+- SDL_RenderSetClipRect
++ SDL_SetRenderClipRect
+  (...)
+@@
+@@
+- SDL_RenderSetIntegerScale
++ SDL_SetRenderIntegerScale
+  (...)
+@@
+@@
+- SDL_RenderSetLogicalSize
++ SDL_SetRenderLogicalSize
+  (...)
+@@
+@@
+- SDL_RenderSetScale
++ SDL_SetRenderScale
+  (...)
+@@
+@@
+- SDL_RenderSetVSync
++ SDL_SetRenderVSync
+  (...)
+@@
+@@
+- SDL_RenderSetViewport
++ SDL_SetRenderViewport
+  (...)
+@@
+@@
+- RW_SEEK_CUR
++ SDL_RW_SEEK_CUR
+@@
+@@
+- RW_SEEK_END
++ SDL_RW_SEEK_END
+@@
+@@
+- RW_SEEK_SET
++ SDL_RW_SEEK_SET
+@@
+@@
+- SDL_AllocRW
++ SDL_CreateRW
+  (...)
+@@
+@@
+- SDL_FreeRW
++ SDL_DestroyRW
+  (...)
+@@
+@@
+- SDL_SensorClose
++ SDL_CloseSensor
+  (...)
+@@
+@@
+- SDL_SensorFromInstanceID
++ SDL_GetSensorFromInstanceID
+  (...)
+@@
+@@
+- SDL_SensorGetData
++ SDL_GetSensorData
+  (...)
+@@
+@@
+- SDL_SensorGetInstanceID
++ SDL_GetSensorInstanceID
+  (...)
+@@
+@@
+- SDL_SensorGetName
++ SDL_GetSensorName
+  (...)
+@@
+@@
+- SDL_SensorGetNonPortableType
++ SDL_GetSensorNonPortableType
+  (...)
+@@
+@@
+- SDL_SensorGetType
++ SDL_GetSensorType
+  (...)
+@@
+@@
+- SDL_SensorOpen
++ SDL_OpenSensor
+  (...)
+@@
+@@
+- SDL_SensorUpdate
++ SDL_UpdateSensors
+  (...)
+@@
+@@
+- SDL_FillRect
++ SDL_FillSurfaceRect
+  (...)
+@@
+@@
+- SDL_FillRects
++ SDL_FillSurfaceRects
+  (...)
+@@
+@@
+- SDL_FreeSurface
++ SDL_DestroySurface
+  (...)
+@@
+@@
+- SDL_GetClipRect
++ SDL_GetSurfaceClipRect
+  (...)
+@@
+@@
+- SDL_GetColorKey
++ SDL_GetSurfaceColorKey
+  (...)
+@@
+@@
+- SDL_HasColorKey
++ SDL_SurfaceHasColorKey
+  (...)
+@@
+@@
+- SDL_HasSurfaceRLE
++ SDL_SurfaceHasRLE
+  (...)
+@@
+@@
+- SDL_LowerBlit
++ SDL_BlitSurfaceUnchecked
+  (...)
+@@
+@@
+- SDL_LowerBlitScaled
++ SDL_BlitSurfaceUncheckedScaled
+  (...)
+@@
+@@
+- SDL_SetClipRect
++ SDL_SetSurfaceClipRect
+  (...)
+@@
+@@
+- SDL_SetColorKey
++ SDL_SetSurfaceColorKey
+  (...)
+@@
+@@
+- SDL_UpperBlit
++ SDL_BlitSurface
+  (...)
+@@
+@@
+- SDL_UpperBlitScaled
++ SDL_BlitSurfaceScaled
+  (...)
+@@
+@@
+- SDL_RenderGetD3D11Device
++ SDL_GetRenderD3D11Device
+  (...)
+@@
+@@
+- SDL_RenderGetD3D9Device
++ SDL_GetRenderD3D9Device
+  (...)
+@@
+@@
+- SDL_GetTicks64
++ SDL_GetTicks
+  (...)
+@@
+@@
+- SDL_GetPointDisplayIndex
++ SDL_GetDisplayIndexForPoint
+  (...)
+@@
+@@
+- SDL_GetRectDisplayIndex
++ SDL_GetDisplayIndexForRect
+  (...)
+
+
+
+

--- a/build-scripts/SDL_migration.cocci
+++ b/build-scripts/SDL_migration.cocci
@@ -41,6 +41,20 @@
 //
 
 
+// SDL_PauseAudioDevice / SDL_PlayAudioDevice
+@@
+expression e;
+@@
+(
+- SDL_PauseAudioDevice(1, e)
++ SDL_PauseAudioDevice(e)
+|
+- SDL_PauseAudioDevice(0, e)
++ SDL_PlayAudioDevice(e)
+)
+
+
+
 // Remove SDL_WINDOW_SHOWN
 @@
 expression e;

--- a/build-scripts/SDL_migration.cocci
+++ b/build-scripts/SDL_migration.cocci
@@ -46,13 +46,29 @@
 expression e;
 @@
 (
-- SDL_PauseAudioDevice(1, e)
+- SDL_PauseAudioDevice(e, 1)
 + SDL_PauseAudioDevice(e)
 |
-- SDL_PauseAudioDevice(0, e)
+- SDL_PauseAudioDevice(e, SDL_TRUE)
++ SDL_PauseAudioDevice(e)
+|
+- SDL_PauseAudioDevice(e, 0)
++ SDL_PlayAudioDevice(e)
+|
+- SDL_PauseAudioDevice(e, SDL_FALSE)
 + SDL_PlayAudioDevice(e)
 )
 
+@@
+expression e, pause_on;
+statement S;
+@@
+- SDL_PauseAudioDevice(e, pause_on);
++ if (pause_on) {
++    SDL_PauseAudioDevice(e);
++ } else {
++    SDL_PlayAudioDevice(e);
++ }
 
 
 // Remove SDL_WINDOW_SHOWN

--- a/build-scripts/SDL_migration.cocci
+++ b/build-scripts/SDL_migration.cocci
@@ -61,7 +61,6 @@ expression e;
 
 @@
 expression e, pause_on;
-statement S;
 @@
 - SDL_PauseAudioDevice(e, pause_on);
 + if (pause_on) {

--- a/build-scripts/rename_api.py
+++ b/build-scripts/rename_api.py
@@ -14,6 +14,7 @@ from rename_symbols import create_regex_from_replacements, replace_symbols_in_pa
 SDL_ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 SDL_INCLUDE_DIR = SDL_ROOT / "include/SDL3"
+SDL_BUILD_SCRIPTS = SDL_ROOT / "build-scripts"
 
 
 def main():
@@ -63,6 +64,7 @@ def main():
 
         add_symbol_to_oldnames(header.name, oldname, newname)
         add_symbol_to_migration(header.name, args.type, oldname, newname)
+        add_symbol_to_coccinelle(args.type, oldname, newname)
         i += 2
 
 
@@ -81,6 +83,18 @@ def add_content(lines, i, content, add_trailing_line):
     if add_trailing_line:
         i = add_line(lines, i, "")
     return i
+
+
+def add_symbol_to_coccinelle(symbol_type, oldname, newname):
+    file = open(SDL_BUILD_SCRIPTS / "SDL_migration.cocci", "a")
+    # Append-adds at last
+    file.write("@@\n")
+    file.write("@@\n")
+    file.write("- %s\n" % oldname)
+    file.write("+ %s\n" % newname)
+    if symbol_type == "function":
+        file.write("  (...)\n")
+    file.close()
 
 
 def add_symbol_to_oldnames(header, oldname, newname):

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -9,6 +9,9 @@ Many functions and symbols have been renamed. We have provided a handy Python sc
 rename_symbols.py --all-symbols source_code_path
 ```
 
+It's also possible to apply a semantic patch to migrate more easily to SDL3: [SDL_migration.cocci](https://github.com/libsdl-org/SDL/blob/main/build-scripts/SDL_migration.cocci)
+
+
 SDL headers should now be included as `#include <SDL3/SDL.h>`. Typically that's the only header you'll need in your application unless you are using OpenGL or Vulkan functionality. We have provided a handy Python script [rename_headers.py](https://github.com/libsdl-org/SDL/blob/main/build-scripts/rename_headers.py) to rename SDL2 headers to their SDL3 counterparts:
 ```sh
 rename_headers.py source_code_path


### PR DESCRIPTION
semantic patch for project migration

// - all function renaming (without parameter change) as in SDL_oldnames.h
// - remove SDL_WINDOW_SHOWN
// - migrate SDL_CreateRGB* and SDL_ConvertSurface* functions
