### PR TITLE
Fix testfile

### DIFF
--- a/include/SDL3/SDL_rwops.h
+++ b/include/SDL3/SDL_rwops.h
@@ -73,7 +73,8 @@ typedef struct SDL_RWops
      *  signed so you definitely cannot overflow the return value on a
      *  successful run with enormous amounts of data.
      *
-     *  \return the number of objects read, or 0 on end of file, or -1 on error.
+     *  \return the number of objects read, or 0 on end of file, -1 on error,
+     *          and -2 for data not ready with a non-blocking context.
      */
     Sint64 (SDLCALL * read) (struct SDL_RWops * context, void *ptr,
                              Sint64 size);
@@ -88,7 +89,8 @@ typedef struct SDL_RWops
      *  successful run with enormous amounts of data.
      *
      *  \return the number of bytes written, which might be less than \c size,
-     *          and -1 on error.
+     *          -1 on error and -2 for a non-blocking contexts signifying
+     *          try again later.
      */
     Sint64 (SDLCALL * write) (struct SDL_RWops * context, const void *ptr,
                               Sint64 size);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -139,7 +139,7 @@ if(LINUX AND TARGET sdl-build-options)
     target_include_directories(testevdev BEFORE PRIVATE ${SDL3_SOURCE_DIR}/src)
 endif()
 
-add_sdl_test_executable(testfile testfile.c)
+add_sdl_test_executable(testfile NONINTERACTIVE testfile.c)
 add_sdl_test_executable(testgamepad NEEDS_RESOURCES TESTUTILS testgamepad.c)
 add_sdl_test_executable(testgeometry TESTUTILS testgeometry.c)
 add_sdl_test_executable(testgl testgl.c)

--- a/test/testfile.c
+++ b/test/testfile.c
@@ -10,7 +10,7 @@
   freely.
 */
 
-/* sanity tests on SDL_rwops.c (usefull for alternative implementations of stdio rwops) */
+/* sanity tests on SDL_rwops.c (useful for alternative implementations of stdio rwops) */
 
 /* quiet windows compiler warnings */
 #if defined(_MSC_VER) && !defined(_CRT_NONSTDC_NO_WARNINGS)
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
     if (0 != rwops->seek(rwops, 0L, SDL_RW_SEEK_SET)) {
         RWOP_ERR_QUIT(rwops);
     }
-    if (0 != rwops->read(rwops, test_buf, 1)) {
+    if (-1 != rwops->read(rwops, test_buf, 1)) {
         RWOP_ERR_QUIT(rwops); /* we are in write only mode */
     }
 
@@ -183,13 +183,13 @@ int main(int argc, char *argv[])
     if (0 != rwops->seek(rwops, -27, SDL_RW_SEEK_CUR)) {
         RWOP_ERR_QUIT(rwops);
     }
-    if (2 != rwops->read(rwops, test_buf, 30)) {
+    if (27 != rwops->read(rwops, test_buf, 30)) {
         RWOP_ERR_QUIT(rwops);
     }
     if (SDL_memcmp(test_buf, "12345678901234567890", 20) != 0) {
         RWOP_ERR_QUIT(rwops);
     }
-    if (0 != rwops->write(rwops, test_buf, 1)) {
+    if (-1 != rwops->write(rwops, test_buf, 1)) {
         RWOP_ERR_QUIT(rwops); /* readonly mode */
     }
 
@@ -237,7 +237,7 @@ int main(int argc, char *argv[])
     if (0 != rwops->seek(rwops, -27, SDL_RW_SEEK_CUR)) {
         RWOP_ERR_QUIT(rwops);
     }
-    if (2 != rwops->read(rwops, test_buf, 30)) {
+    if (27 != rwops->read(rwops, test_buf, 30)) {
         RWOP_ERR_QUIT(rwops);
     }
     if (SDL_memcmp(test_buf, "12345678901234567890", 20) != 0) {
@@ -288,7 +288,7 @@ int main(int argc, char *argv[])
     if (0 != rwops->seek(rwops, -27, SDL_RW_SEEK_CUR)) {
         RWOP_ERR_QUIT(rwops);
     }
-    if (2 != rwops->read(rwops, test_buf, 30)) {
+    if (27 != rwops->read(rwops, test_buf, 30)) {
         RWOP_ERR_QUIT(rwops);
     }
     if (SDL_memcmp(test_buf, "12345678901234567890", 20) != 0) {
@@ -345,7 +345,7 @@ int main(int argc, char *argv[])
     if (0 != rwops->seek(rwops, 0L, SDL_RW_SEEK_SET)) {
         RWOP_ERR_QUIT(rwops);
     }
-    if (3 != rwops->read(rwops, test_buf, 30)) {
+    if (30 != rwops->read(rwops, test_buf, 30)) {
         RWOP_ERR_QUIT(rwops);
     }
     if (SDL_memcmp(test_buf, "123456789012345678901234567123", 30) != 0) {


### PR DESCRIPTION
Fixes rwops and testfile

## Description

Fix testfile for new rwops behavior: rwops->read and rwops->write return -1 on error.
Also fix some values that are used to compare against..

Also add testfile to the test matrix such that it is run on ci.

Please verify before merging.


## Existing Issue(s)
Fixes #7048

