### PR TITLE
Fix last warning when building SDL with -DSDL_LIBC=OFF

### DIFF
--- a/src/SDL_log.c
+++ b/src/SDL_log.c
@@ -65,6 +65,11 @@ static SDL_LogOutputFunction SDL_log_function = SDL_LogOutput;
 static void *SDL_log_userdata = NULL;
 static SDL_mutex *log_function_mutex = NULL;
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
+
 static const char *SDL_priority_prefixes[SDL_NUM_LOG_PRIORITIES] = {
     NULL,
     "VERBOSE",
@@ -74,6 +79,10 @@ static const char *SDL_priority_prefixes[SDL_NUM_LOG_PRIORITIES] = {
     "ERROR",
     "CRITICAL"
 };
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 #ifdef __ANDROID__
 static const char *SDL_category_prefixes[] = {


### PR DESCRIPTION
There was only 1 warning left when building SDL3, configured with `-DSDL_LIBC=OFF`:
```
/home/maarten/programming/SDL/src/SDL_log.c:73:20: warning: ‘SDL_priority_prefixes’ defined but not used [-Wunused-variable]
   73 | static const char *SDL_priority_prefixes[SDL_NUM_LOG_PRIORITIES] = {
      |                    ^~~~~~~~~~~~~~~~~~~~~
```
This pr fixes this by surrounding the variable with `#pragma GCC diagnostic ignored "-Wunused-variable"`

## Existing Issue(s)
Fixes #6622