### PR TITLE
Fixed the hat_map to avoid segmentation fault

### DIFF
--- a/src/joystick/windows/SDL_rawinputjoystick.c
+++ b/src/joystick/windows/SDL_rawinputjoystick.c
@@ -1396,6 +1396,7 @@ static void RAWINPUT_HandleStatePacket(SDL_Joystick *joystick, Uint8 *data, int 
         (1 << SDL_GAMEPAD_BUTTON_DPAD_DOWN) | (1 << SDL_GAMEPAD_BUTTON_DPAD_LEFT),
         (1 << SDL_GAMEPAD_BUTTON_DPAD_LEFT),
         (1 << SDL_GAMEPAD_BUTTON_DPAD_UP) | (1 << SDL_GAMEPAD_BUTTON_DPAD_LEFT),
+        0,
     };
     Uint64 match_state = ctx->match_state;
     /* Update match_state with button bit, then fall through */


### PR DESCRIPTION
## Description
The commit [#e8b1dfe](https://github.com/libsdl-org/SDL/commit/e8b1dfef9b6e581cdf1e219600b106ab9c84db25) fixed the issue #6767, which I have also met when using my FlyDigi Vader 2 Pro Controller in iOS (BlueTooth) mode. I find that there is a risk of segmentation fault related to `hat_map` in the commit: in [this line](https://github.com/libsdl-org/SDL/blob/e8b1dfef9b6e581cdf1e219600b106ab9c84db25/src/joystick/windows/SDL_rawinputjoystick.c#L1471), `hat_map[9]` may be accessed.
```
match_state = (match_state & ~HAT_MASK) | hat_map[state];
```
This PR appends `0` to `hat_map` for avoiding the segmentation fault and other unexpected behaviors.