### PR TITLE
Revert "wayland: Don't try to restore non-resizable windows"

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -1699,10 +1699,6 @@ void Wayland_RestoreWindow(_THIS, SDL_Window *window)
         return;
     }
 
-    if (!(window->flags & SDL_WINDOW_RESIZABLE)) {
-            return;
-    }
-
     /* Set this flag now even if we never actually maximized, eventually
      * ShowWindow will take care of it along with the other window state.
      */


### PR DESCRIPTION
This reverts commit e35c3872dc6a8f7741baba8b786b202cef7503ac.

The bug turned out to be unrelated, so this should be reverted to restore behavior that matches other platforms.