### PR TITLE
[SDL2] PS2 Main - Use filesystem drivers

### DIFF
--- a/src/main/ps2/SDL_ps2_main.c
+++ b/src/main/ps2/SDL_ps2_main.c
@@ -17,9 +17,7 @@
 #include <sifrpc.h>
 #include <iopcontrol.h>
 #include <sbv_patches.h>
-#include <ps2_fileXio_driver.h>
-#include <ps2_memcard_driver.h>
-#include <ps2_usb_driver.h>
+#include <ps2_filesystem_driver.h>
 
 #ifdef main
 #undef main
@@ -45,29 +43,12 @@ static void prepare_IOP()
 
 static void init_drivers()
 {
-    init_memcard_driver(true);
-    init_usb_driver(true);
+	init_ps2_filesystem_driver();
 }
 
 static void deinit_drivers()
 {
-    deinit_usb_driver(true);
-    deinit_memcard_driver(true);
-}
-
-static void waitUntilDeviceIsReady(char *path)
-{
-    struct stat buffer;
-    int ret = -1;
-    int retries = 50;
-
-    while (ret != 0 && retries > 0) {
-        ret = stat(path, &buffer);
-        /* Wait until the device is ready */
-        nopdelay();
-
-        retries--;
-    }
+	deinit_ps2_filesystem_driver();
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
## Description

This PR improves the `PS2 main` driver, it now supports:

- `exFat` format devices
- `HDD` devices
- `CDFS` devices

Everything now is done, in the `ps2_driver` library instead to be here in the SDL

Cheers