### PR TITLE
[SDL3] SDL_SetWindowIcon now reports errors.

### DIFF
--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -245,7 +245,7 @@ struct SDL_VideoDevice
     int (*CreateSDLWindow)(_THIS, SDL_Window *window);
     int (*CreateSDLWindowFrom)(_THIS, SDL_Window *window, const void *data);
     void (*SetWindowTitle)(_THIS, SDL_Window *window);
-    void (*SetWindowIcon)(_THIS, SDL_Window *window, SDL_Surface *icon);
+    int (*SetWindowIcon)(_THIS, SDL_Window *window, SDL_Surface *icon);
     void (*SetWindowPosition)(_THIS, SDL_Window *window);
     void (*SetWindowSize)(_THIS, SDL_Window *window);
     void (*SetWindowMinimumSize)(_THIS, SDL_Window *window);

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2060,7 +2060,7 @@ int SDL_SetWindowIcon(SDL_Window *window, SDL_Surface *icon)
     CHECK_WINDOW_MAGIC(window, -1);
 
     if (icon == NULL) {
-        return 0;
+        return SDL_InvalidParamError("icon");
     }
 
     SDL_DestroySurface(window->icon);
@@ -2071,10 +2071,11 @@ int SDL_SetWindowIcon(SDL_Window *window, SDL_Surface *icon)
         return -1;
     }
 
-    if (_this->SetWindowIcon) {
-        _this->SetWindowIcon(_this, window, window->icon);
+    if (!_this->SetWindowIcon) {
+        return SDL_Unsupported();
     }
-    return 0;
+
+    return _this->SetWindowIcon(_this, window, window->icon);
 }
 
 void *SDL_SetWindowData(SDL_Window *window, const char *name, void *userdata)

--- a/src/video/cocoa/SDL_cocoawindow.h
+++ b/src/video/cocoa/SDL_cocoawindow.h
@@ -142,7 +142,7 @@ extern int Cocoa_CreateWindow(_THIS, SDL_Window *window);
 extern int Cocoa_CreateWindowFrom(_THIS, SDL_Window *window,
                                   const void *data);
 extern void Cocoa_SetWindowTitle(_THIS, SDL_Window *window);
-extern void Cocoa_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon);
+extern int Cocoa_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon);
 extern void Cocoa_SetWindowPosition(_THIS, SDL_Window *window);
 extern void Cocoa_SetWindowSize(_THIS, SDL_Window *window);
 extern void Cocoa_SetWindowMinimumSize(_THIS, SDL_Window *window);

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -1874,14 +1874,18 @@ void Cocoa_SetWindowTitle(_THIS, SDL_Window *window)
     }
 }
 
-void Cocoa_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon)
+int Cocoa_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon)
 {
     @autoreleasepool {
         NSImage *nsimage = Cocoa_CreateImage(icon);
 
         if (nsimage) {
             [NSApp setApplicationIconImage:nsimage];
+
+            return 0;
         }
+
+        return SDL_SetError("Unable to set the window's icon");
     }
 }
 

--- a/src/video/haiku/SDL_bvideo.cc
+++ b/src/video/haiku/SDL_bvideo.cc
@@ -77,7 +77,6 @@ static SDL_VideoDevice * HAIKU_CreateDevice(void)
     device->CreateSDLWindow = HAIKU_CreateWindow;
     device->CreateSDLWindowFrom = HAIKU_CreateWindowFrom;
     device->SetWindowTitle = HAIKU_SetWindowTitle;
-    device->SetWindowIcon = HAIKU_SetWindowIcon;
     device->SetWindowPosition = HAIKU_SetWindowPosition;
     device->SetWindowSize = HAIKU_SetWindowSize;
     device->ShowWindow = HAIKU_ShowWindow;

--- a/src/video/haiku/SDL_bwindow.cc
+++ b/src/video/haiku/SDL_bwindow.cc
@@ -127,10 +127,6 @@ void HAIKU_SetWindowTitle(_THIS, SDL_Window * window) {
     _ToBeWin(window)->PostMessage(&msg);
 }
 
-void HAIKU_SetWindowIcon(_THIS, SDL_Window * window, SDL_Surface * icon) {
-    /* FIXME: Icons not supported by Haiku */
-}
-
 void HAIKU_SetWindowPosition(_THIS, SDL_Window * window) {
     BMessage msg(BWIN_MOVE_WINDOW);
     msg.AddInt32("window-x", window->x);

--- a/src/video/haiku/SDL_bwindow.h
+++ b/src/video/haiku/SDL_bwindow.h
@@ -27,7 +27,6 @@
 extern int HAIKU_CreateWindow(_THIS, SDL_Window *window);
 extern int HAIKU_CreateWindowFrom(_THIS, SDL_Window *window, const void *data);
 extern void HAIKU_SetWindowTitle(_THIS, SDL_Window *window);
-extern void HAIKU_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon);
 extern void HAIKU_SetWindowPosition(_THIS, SDL_Window *window);
 extern void HAIKU_SetWindowSize(_THIS, SDL_Window *window);
 extern void HAIKU_SetWindowMinimumSize(_THIS, SDL_Window *window);

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -24,10 +24,10 @@
 #if SDL_VIDEO_DRIVER_KMSDRM
 
 /* SDL internals */
-#include "../SDL_sysvideo.h"
 #include "../../events/SDL_events_c.h"
-#include "../../events/SDL_mouse_c.h"
 #include "../../events/SDL_keyboard_c.h"
+#include "../../events/SDL_mouse_c.h"
+#include "../SDL_sysvideo.h"
 
 #ifdef SDL_INPUT_LINUXEV
 #include "../../core/linux/SDL_evdev.h"
@@ -38,18 +38,18 @@
 #include <SDL3/SDL_syswm.h>
 
 /* KMS/DRM declarations */
-#include "SDL_kmsdrmvideo.h"
-#include "SDL_kmsdrmevents.h"
-#include "SDL_kmsdrmopengles.h"
-#include "SDL_kmsdrmmouse.h"
 #include "SDL_kmsdrmdyn.h"
+#include "SDL_kmsdrmevents.h"
+#include "SDL_kmsdrmmouse.h"
+#include "SDL_kmsdrmopengles.h"
+#include "SDL_kmsdrmvideo.h"
 #include "SDL_kmsdrmvulkan.h"
-#include <sys/stat.h>
-#include <sys/param.h>
-#include <sys/utsname.h>
 #include <dirent.h>
-#include <poll.h>
 #include <errno.h>
+#include <poll.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <sys/utsname.h>
 
 #ifdef __OpenBSD__
 static SDL_bool moderndri = SDL_FALSE;
@@ -285,7 +285,6 @@ static SDL_VideoDevice *KMSDRM_CreateDevice(void)
     device->CreateSDLWindow = KMSDRM_CreateWindow;
     device->CreateSDLWindowFrom = KMSDRM_CreateWindowFrom;
     device->SetWindowTitle = KMSDRM_SetWindowTitle;
-    device->SetWindowIcon = KMSDRM_SetWindowIcon;
     device->SetWindowPosition = KMSDRM_SetWindowPosition;
     device->SetWindowSize = KMSDRM_SetWindowSize;
     device->SetWindowFullscreen = KMSDRM_SetWindowFullscreen;
@@ -323,7 +322,7 @@ static SDL_VideoDevice *KMSDRM_CreateDevice(void)
 
 cleanup:
     if (device) {
-    	SDL_free(device);
+        SDL_free(device);
     }
 
     if (viddata) {
@@ -1558,9 +1557,6 @@ int KMSDRM_CreateWindowFrom(_THIS, SDL_Window *window, const void *data)
 }
 
 void KMSDRM_SetWindowTitle(_THIS, SDL_Window *window)
-{
-}
-void KMSDRM_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon)
 {
 }
 void KMSDRM_SetWindowPosition(_THIS, SDL_Window *window)

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.h
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.h
@@ -124,7 +124,6 @@ int KMSDRM_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mod
 int KMSDRM_CreateWindow(_THIS, SDL_Window *window);
 int KMSDRM_CreateWindowFrom(_THIS, SDL_Window *window, const void *data);
 void KMSDRM_SetWindowTitle(_THIS, SDL_Window *window);
-void KMSDRM_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon);
 void KMSDRM_SetWindowPosition(_THIS, SDL_Window *window);
 void KMSDRM_SetWindowSize(_THIS, SDL_Window *window);
 void KMSDRM_SetWindowFullscreen(_THIS, SDL_Window *window, SDL_VideoDisplay *_display, SDL_bool fullscreen);

--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -93,7 +93,6 @@ static SDL_VideoDevice *PSP_Create()
     device->CreateSDLWindow = PSP_CreateWindow;
     device->CreateSDLWindowFrom = PSP_CreateWindowFrom;
     device->SetWindowTitle = PSP_SetWindowTitle;
-    device->SetWindowIcon = PSP_SetWindowIcon;
     device->SetWindowPosition = PSP_SetWindowPosition;
     device->SetWindowSize = PSP_SetWindowSize;
     device->ShowWindow = PSP_ShowWindow;
@@ -214,9 +213,6 @@ int PSP_CreateWindowFrom(_THIS, SDL_Window *window, const void *data)
 }
 
 void PSP_SetWindowTitle(_THIS, SDL_Window *window)
-{
-}
-void PSP_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon)
 {
 }
 void PSP_SetWindowPosition(_THIS, SDL_Window *window)

--- a/src/video/psp/SDL_pspvideo.h
+++ b/src/video/psp/SDL_pspvideo.h
@@ -52,7 +52,6 @@ int PSP_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode);
 int PSP_CreateWindow(_THIS, SDL_Window *window);
 int PSP_CreateWindowFrom(_THIS, SDL_Window *window, const void *data);
 void PSP_SetWindowTitle(_THIS, SDL_Window *window);
-void PSP_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon);
 void PSP_SetWindowPosition(_THIS, SDL_Window *window);
 void PSP_SetWindowSize(_THIS, SDL_Window *window);
 void PSP_ShowWindow(_THIS, SDL_Window *window);

--- a/src/video/raspberry/SDL_rpivideo.c
+++ b/src/video/raspberry/SDL_rpivideo.c
@@ -105,7 +105,6 @@ static SDL_VideoDevice *RPI_Create()
     device->CreateSDLWindow = RPI_CreateWindow;
     device->CreateSDLWindowFrom = RPI_CreateWindowFrom;
     device->SetWindowTitle = RPI_SetWindowTitle;
-    device->SetWindowIcon = RPI_SetWindowIcon;
     device->SetWindowPosition = RPI_SetWindowPosition;
     device->SetWindowSize = RPI_SetWindowSize;
     device->ShowWindow = RPI_ShowWindow;
@@ -348,9 +347,6 @@ int RPI_CreateWindowFrom(_THIS, SDL_Window *window, const void *data)
 }
 
 void RPI_SetWindowTitle(_THIS, SDL_Window *window)
-{
-}
-void RPI_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon)
 {
 }
 void RPI_SetWindowPosition(_THIS, SDL_Window *window)

--- a/src/video/raspberry/SDL_rpivideo.h
+++ b/src/video/raspberry/SDL_rpivideo.h
@@ -66,7 +66,6 @@ int RPI_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode);
 int RPI_CreateWindow(_THIS, SDL_Window *window);
 int RPI_CreateWindowFrom(_THIS, SDL_Window *window, const void *data);
 void RPI_SetWindowTitle(_THIS, SDL_Window *window);
-void RPI_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon);
 void RPI_SetWindowPosition(_THIS, SDL_Window *window);
 void RPI_SetWindowSize(_THIS, SDL_Window *window);
 void RPI_ShowWindow(_THIS, SDL_Window *window);

--- a/src/video/vita/SDL_vitavideo.c
+++ b/src/video/vita/SDL_vitavideo.c
@@ -109,7 +109,6 @@ static SDL_VideoDevice *VITA_Create()
     device->CreateSDLWindow = VITA_CreateWindow;
     device->CreateSDLWindowFrom = VITA_CreateWindowFrom;
     device->SetWindowTitle = VITA_SetWindowTitle;
-    device->SetWindowIcon = VITA_SetWindowIcon;
     device->SetWindowPosition = VITA_SetWindowPosition;
     device->SetWindowSize = VITA_SetWindowSize;
     device->ShowWindow = VITA_ShowWindow;
@@ -302,9 +301,6 @@ int VITA_CreateWindowFrom(_THIS, SDL_Window *window, const void *data)
 }
 
 void VITA_SetWindowTitle(_THIS, SDL_Window *window)
-{
-}
-void VITA_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon)
 {
 }
 void VITA_SetWindowPosition(_THIS, SDL_Window *window)

--- a/src/video/vita/SDL_vitavideo.h
+++ b/src/video/vita/SDL_vitavideo.h
@@ -65,7 +65,6 @@ int VITA_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode)
 int VITA_CreateWindow(_THIS, SDL_Window *window);
 int VITA_CreateWindowFrom(_THIS, SDL_Window *window, const void *data);
 void VITA_SetWindowTitle(_THIS, SDL_Window *window);
-void VITA_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon);
 void VITA_SetWindowPosition(_THIS, SDL_Window *window);
 void VITA_SetWindowSize(_THIS, SDL_Window *window);
 void VITA_ShowWindow(_THIS, SDL_Window *window);

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -628,8 +628,9 @@ void WIN_SetWindowTitle(_THIS, SDL_Window *window)
 #endif
 }
 
-void WIN_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon)
+int WIN_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon)
 {
+    int retVal = 0;
 #if !defined(__XBOXONE__) && !defined(__XBOXSERIES__)
     HWND hwnd = window->driverdata->hwnd;
     HICON hicon = NULL;
@@ -677,12 +678,20 @@ void WIN_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon)
 
     SDL_small_free(icon_bmp, isstack);
 
+    if (hicon == NULL) {
+        SDL_SetError("SetWindowIcon() failed, error %08X", (unsigned int)GetLastError());
+        retVal = -1;
+    }
+
     /* Set the icon for the window */
     SendMessage(hwnd, WM_SETICON, ICON_SMALL, (LPARAM)hicon);
 
     /* Set the icon in the task manager (should we do this?) */
     SendMessage(hwnd, WM_SETICON, ICON_BIG, (LPARAM)hicon);
+#else
+    retVal = SDL_Unsupported();
 #endif
+    return retVal;
 }
 
 void WIN_SetWindowPosition(_THIS, SDL_Window *window)

--- a/src/video/windows/SDL_windowswindow.h
+++ b/src/video/windows/SDL_windowswindow.h
@@ -77,7 +77,7 @@ struct SDL_WindowData
 extern int WIN_CreateWindow(_THIS, SDL_Window *window);
 extern int WIN_CreateWindowFrom(_THIS, SDL_Window *window, const void *data);
 extern void WIN_SetWindowTitle(_THIS, SDL_Window *window);
-extern void WIN_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon);
+extern int WIN_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon);
 extern void WIN_SetWindowPosition(_THIS, SDL_Window *window);
 extern void WIN_SetWindowSize(_THIS, SDL_Window *window);
 extern int WIN_GetWindowBordersSize(_THIS, SDL_Window *window, int *top, int *left, int *bottom, int *right);

--- a/src/video/x11/SDL_x11window.h
+++ b/src/video/x11/SDL_x11window.h
@@ -87,7 +87,7 @@ extern int X11_CreateWindow(_THIS, SDL_Window *window);
 extern int X11_CreateWindowFrom(_THIS, SDL_Window *window, const void *data);
 extern char *X11_GetWindowTitle(_THIS, Window xwindow);
 extern void X11_SetWindowTitle(_THIS, SDL_Window *window);
-extern void X11_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon);
+extern int X11_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon);
 extern void X11_SetWindowPosition(_THIS, SDL_Window *window);
 extern void X11_SetWindowMinimumSize(_THIS, SDL_Window *window);
 extern void X11_SetWindowMaximumSize(_THIS, SDL_Window *window);


### PR DESCRIPTION
## Description
As described in the issue, when `SDL_SetWindowIcon` fails, it does so silently. This PR changes:
1. The signature of the function so that it return `0` on success or an integer on error
2. Calls `SDL_GetError` in order to report what when wrong while trying to set the Window's Icon.

Calling this function on a system which does not support setting a window's icon (or it is meaningless to do so), will always return `SDL_UNSUPPORTED`.

## Existing Issue(s)
Closes #1473
