### PR TITLE
add support for libsamplerate's "linear" resampling mode

### DIFF
--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -160,6 +160,8 @@ static SDL_bool LoadLibSampleRate(void)
         SRC_converter = SRC_SINC_MEDIUM_QUALITY;
     } else if (*hint == '3' || SDL_strcasecmp(hint, "best") == 0) {
         SRC_converter = SRC_SINC_BEST_QUALITY;
+    } else if (*hint == '4' || SDL_strcasecmp(hint, "linear") == 0) {
+        SRC_converter = SRC_LINEAR;
     } else {
         return SDL_FALSE; /* treat it like "default", don't load anything. */
     }


### PR DESCRIPTION
## Description
The libsamplerate library provides 5 different converter types, but only 3 of them (i.e. the SRC_SINC_* converters) can be set through SDL's API. In my projects I need fastest-possible on-the-fly conversion of audio samples and libsamplerate's SRC_LINEAR converter fits this purpose quite well. Please make it possible to select this (and possibly even SRC_ZERO_ORDER_HOLD) through SDL's API.

## Existing Issue(s)
Fixes #6998