### PR TITLE
[SDL2] Autotools changes for libdecor min/max detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1787,6 +1787,14 @@ dnl See if libdecor is available
                     else
                         EXTRA_LDFLAGS="$EXTRA_LDFLAGS $DECOR_LIBS"
                     fi
+
+                    saved_cflags=$CFLAGS
+                    CFLAGS="$CFLAGS $DECOR_CFLAGS"
+                    AC_CHECK_DECLS([libdecor_frame_get_min_content_size, libdecor_frame_get_max_content_size], [libdecor_get_min_max=yes], [ ], [[#include <libdecor.h>]])
+                    if test x$libdecor_get_min_max = xyes; then
+                        AC_DEFINE(SDL_HAVE_LIBDECOR_GET_MIN_MAX, 1, [ ])
+                    fi
+                    CFLAGS="$saved_cflags"
                 fi
             fi
         fi

--- a/include/SDL_config.h.in
+++ b/include/SDL_config.h.in
@@ -491,4 +491,7 @@
 /* Enable dynamic libsamplerate support */
 #undef SDL_LIBSAMPLERATE_DYNAMIC
 
+/* Libdecor get min/max content size functions */
+#undef SDL_HAVE_LIBDECOR_GET_MIN_MAX
+
 #endif /* SDL_config_h_ */


### PR DESCRIPTION
SDL2 specific autotools changes for #7085 

I did not regenerate the configure script as there seems to be an error when I do:
```
./configure: line 29778: syntax error near unexpected token `pkg_cmakedir:prefix:cmake_prefix_relpath'
./configure: line 29778: `AX_COMPUTE_RELATIVE_PATHS(pkg_cmakedir:prefix:cmake_prefix_relpath bindir:prefix:bin_prefix_relpath)'
```
This happens on a fresh pull without my changes, so there's either a preexisting mistake in it, or the version of autotools shipped with Fedora 37 has a problem with it. My changes do work if I manually edit out the offending line from the configure script, though.