### PR TITLE
Update SDL_pixels.c

### DIFF
--- a/src/video/SDL_pixels.c
+++ b/src/video/SDL_pixels.c
@@ -519,7 +519,7 @@ SDL_CreatePixelFormat(Uint32 pixel_format)
     SDL_AtomicLock(&formats_lock);
 
     /* Look it up in our list of previously allocated formats */
-    for (format = formats; format; format = format->next) {
+    for (format = formats; format && (format != INVALID_HANDLE_VALUE); format = format->next) {
         if (pixel_format == format->format) {
             ++format->refcount;
             SDL_AtomicUnlock(&formats_lock);


### PR DESCRIPTION
Prevent 0xffffffffffffffff pointer dereference

Changed `SDL_AllocFormat` so that is checks `format` for `INVALID_HANDLE_VALUE` as well.
This prevents crash of `https://github.com/enginmanap/LimonEngine` on my machine (MinGW build).

## Details
OS: Windows 8.1 Pro x64
Compiler: MinGW-Clang 15
(`https://github.com/mstorsjo/llvm-mingw/releases/download/20220906/llvm-mingw-20220906-msvcrt-x86_64.zip`)
CMake version: 3.25.1
SDL version: 2.26.2 (built with mentioned compiler)
SDL2_image version: 2.6.2 (prebuilt)

CMake was configured for MinGW makefiles for this build (not Unix ones).

## Application Log (debugger: LLDB 15)
```
$ lldb LimonEngine.exe
(lldb) target create "LimonEngine.exe"
run
Current executable set to 'S:\Projects\LimonEngine\build-win64-mingw_clang15\LimonEngine.exe' (x86_64).
(lldb) run
Process 5868 launched: 'S:\Projects\LimonEngine\build-win64-mingw_clang15\LimonEngine.exe' (x86_64)
No world file specified, world select from release settings
Error loading release settings from ./Data/Release.xml: XML_ERROR_FILE_NOT_FOUND
release settings read failed, defaulting to ./Data/Maps/World001.xml
Loaded  option dataDirectory
Loaded  option screenHeight
Loaded  option screenWidth
Loaded  option SSAOHeight
Loaded  option SSAOWidth
Loaded  option fullScreen
Loaded  option shadowMapDirectionalWidth
Loaded  option shadowMapDirectionalHeight
Loaded  option shadowMapPointWidth
Loaded  option shadowMapPointHeight
Loaded  option debugDrawBufferSize
Loaded  option lightOrthogonalProjectionNearPlane
Loaded  option lightOrthogonalProjectionFarPlane
Loaded  option lightPerspectiveProjectionNearPlane
Loaded  option lightPerspectiveProjectionFarPlane
Loaded  option walkSpeed
Loaded  option walkSpeed
Loaded  option runSpeed
Loaded  option freeMovementSpeed
Loaded  option lightOrthogonalProjectionValues
Loaded  option SSAOEnabled
Loaded  option RenderInformations
Loaded  option SSAOSampleCount
Options loaded successfully
SDL started.
trying to load shared library libGraphicsBackend.dll
Trigger register method found
GLEW Init: Success!
Maximum number of texture image units is 18
Rendererer: AMD Radeon(TM) HD 6480G
GL version: 3.3.13417 Core Profile Forward-Compatible Context 15.301.1901.0
Supported GLSL version is 4.40
found 265 extensions.
Cubemap array support is present.
Uniform alignment size is 256
Uniform maxVertexUniformBlockCount size is 15
trying to load shared library libcustomTriggers.dll
Trigger register method found
registered Trigger: CoinPickUpOnTrigger
registered Trigger: DoorAnimationAction
registered Trigger: KillCowboyPlayer
registered Trigger: MayanCoinPickup
registered Trigger: MayanLever
registered Trigger: WesternStoryAtGrave
registered Trigger: WesternStoryAtSaloon
registered Trigger: WesternStoryAtTrain
registered Trigger: WesternStoryAtUndertaker
registered Trigger: WesternStoryNewGameAction
registered Trigger: WesternStoryStartup
Actor register method found
registered Actor: Cowboy Enemy
registered Actor: ENEMY_AI_SWAT
Player extension register method found
registered Player extension: CowboyShooterExtension
registered Player extension: ShooterPlayerExtension
registered Player extension: WesternMenuExtension
RenderMethod register method found
registered RenderMethod: SSAOKernelRenderMethod
read name as ./Data/Maps/World001.xml
Material not found, create for Gun_Material
simplification1 result:         156     ->      144
simplification2 result:         144     ->      144
simplification3 result:         144     ->      140
after simplification triangle counts:   156, 144, 144, 140
after simplification offsets:   0, 468, 900, 1332
simplification1 result:         3138    ->      2670
simplification2 result:         2670    ->      2003
simplification3 result:         2003    ->      1908
after simplification triangle counts:   3138, 2670, 2003, 1908
after simplification offsets:   0, 9414, 17424, 23433
Process 5868 stopped
* thread #1, stop reason = Exception 0xc0000005 encountered at address 0x7ffae8929ed0: Access violation reading location 0xffffffffffffffff
    frame #0: 0x00007ffae8929ed0 SDL2.dll`SDL_AllocFormat_REAL(pixel_format=376840196) at SDL_pixels.c:514:26
   511
   512      /* Look it up in our list of previously allocated formats */
   513      for (format = formats; format; format = format->next) {
-> 514          if (pixel_format == format->format) {
                                 ^
   515              ++format->refcount;
   516              SDL_AtomicUnlock(&formats_lock);
   517              return format;
(lldb)
```