### PR TITLE
Support MIN/MAX blend on OpenGL + ES

### DIFF
--- a/src/render/opengl/SDL_render_gl.c
+++ b/src/render/opengl/SDL_render_gl.c
@@ -375,6 +375,10 @@ static GLenum GetBlendEquation(SDL_BlendOperation operation)
         return GL_FUNC_SUBTRACT;
     case SDL_BLENDOPERATION_REV_SUBTRACT:
         return GL_FUNC_REVERSE_SUBTRACT;
+    case SDL_BLENDOPERATION_MINIMUM:
+        return GL_MIN;
+    case SDL_BLENDOPERATION_MAXIMUM:
+        return GL_MAX;
     default:
         return GL_INVALID_ENUM;
     }

--- a/src/render/opengles/SDL_render_gles.c
+++ b/src/render/opengles/SDL_render_gles.c
@@ -97,6 +97,7 @@ typedef struct
     SDL_bool GL_OES_blend_func_separate_supported;
     SDL_bool GL_OES_blend_equation_separate_supported;
     SDL_bool GL_OES_blend_subtract_supported;
+    SDL_bool GL_EXT_blend_minmax_supported;
 
     GLES_DrawStateCache drawstate;
 } GLES_RenderData;
@@ -263,6 +264,10 @@ static GLenum GetBlendEquation(SDL_BlendOperation operation)
         return GL_FUNC_SUBTRACT_OES;
     case SDL_BLENDOPERATION_REV_SUBTRACT:
         return GL_FUNC_REVERSE_SUBTRACT_OES;
+    case SDL_BLENDOPERATION_MINIMUM:
+        return GL_MIN_EXT;
+    case SDL_BLENDOPERATION_MAXIMUM:
+        return GL_MAX_EXT;
     default:
         return GL_INVALID_ENUM;
     }
@@ -293,6 +298,12 @@ static SDL_bool GLES_SupportsBlendMode(SDL_Renderer *renderer, SDL_BlendMode ble
         return SDL_FALSE;
     }
     if (colorOperation != SDL_BLENDOPERATION_ADD && !data->GL_OES_blend_subtract_supported) {
+        return SDL_FALSE;
+    }
+    if (colorOperation == SDL_BLENDOPERATION_MINIMUM && !data->GL_EXT_blend_minmax_supported) {
+        return SDL_FALSE;
+    }
+    if (colorOperation == SDL_BLENDOPERATION_MAXIMUM && !data->GL_EXT_blend_minmax_supported) {
         return SDL_FALSE;
     }
     return SDL_TRUE;
@@ -1160,6 +1171,9 @@ static SDL_Renderer *GLES_CreateRenderer(SDL_Window *window, Uint32 flags)
     }
     if (SDL_GL_ExtensionSupported("GL_OES_blend_subtract")) {
         data->GL_OES_blend_subtract_supported = SDL_TRUE;
+    }
+    if (SDL_GL_ExtensionSupported("GL_EXT_blend_minmax")) {
+        data->GL_EXT_blend_minmax_supported = SDL_TRUE;
     }
 
     /* Set up parameters for rendering */


### PR DESCRIPTION
Hello! I noticed that OpenGL has always supported the Min/Max blend operations and OpenGL ES supports them through an extension (https://registry.khronos.org/OpenGL/extensions/EXT/EXT_blend_minmax.txt; GL ES 3.0 makes this support core). I'd like to add this support to SDL2.

I think this is a reasonable addition because it doesn't extend the render API, but rather makes its support more complete.

Thank you for your time and work on the project!

## Functionality considerations

> The GL_MIN, and GL_MAX equations do not use the source or destination factors, only the source and destination colors. (https://registry.khronos.org/OpenGL-Refpages/gl4/html/glBlendEquation.xhtml)

In OpenGL, these operations effectively use blend factors of ONE, but I think that returning that the blend mode is unsupported when non-ONE blend factors are used would be unexpected to the user in many cases, and would keep the functionality from working on some applications that currently work with Direct3D.

I also wonder whether Direct3D has the same behavior and this is the cause of the remark on the SDL wiki:

> However, some factors produce unexpected results with `SDL_BLENDOPERATION_MINIMUM` and `SDL_BLENDOPERATION_MAXIMUM`. (https://wiki.libsdl.org/SDL2/SDL_ComposeCustomBlendMode)

## Implementation

* In the OpenGL renderer I simply add the blend operations to the lookup function.

* In the OpenGL ES renderer, which I believe targets OpenGL ES 1.1, I check for support for EXT_blend_minmax, store the result in the renderer's data (increasing the renderer data's size by one SDL_bool), and use it to report whether the blend operations are supported. This is the part of the PR I am the least confident about and would appreciate review from one of the maintainers of the OpenGL ES renderer.

* I also add the blend operations to the lookup function of OpenGL ES.

## Existing Issue(s)

I don't see any open issues, but min/max blend operations can in some cases substitute for bitwise blending operations, which were requested by my collaborator in #5455
