### PR TITLE
video: Don't resize fullscreen windows when moved to a display that doesn't support the requested video mode

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2930,7 +2930,12 @@ void SDL_OnWindowDisplayChanged(SDL_Window *window)
 
         if (FULLSCREEN_VISIBLE(window) && (window->flags & SDL_WINDOW_FULLSCREEN_DESKTOP) != SDL_WINDOW_FULLSCREEN_DESKTOP) {
             window->last_fullscreen_flags = 0;
-            SDL_UpdateFullscreenMode(window, SDL_TRUE);
+
+            if (SDL_UpdateFullscreenMode(window, SDL_TRUE) != 0) {
+                /* Something went wrong and the window is no longer fullscreen. */
+                window->flags &= ~FULLSCREEN_MASK;
+                return;
+            }
         }
 
         /*

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1324,6 +1324,7 @@ static int SDL_UpdateFullscreenMode(SDL_Window *window, SDL_bool fullscreen)
 {
     SDL_VideoDisplay *display;
     SDL_Window *other;
+    int retval = 0;
 
     CHECK_WINDOW_MAGIC(window, -1);
 
@@ -1468,6 +1469,9 @@ static int SDL_UpdateFullscreenMode(SDL_Window *window, SDL_bool fullscreen)
 
                 window->last_fullscreen_flags = window->flags;
                 return 0;
+            } else {
+                /* Failed to find a matching mode, return an error after restoring windowed mode. */
+                retval = -1;
             }
         }
     }
@@ -1487,7 +1491,7 @@ static int SDL_UpdateFullscreenMode(SDL_Window *window, SDL_bool fullscreen)
     SDL_RestoreMousePosition(window);
 
     window->last_fullscreen_flags = window->flags;
-    return 0;
+    return retval;
 }
 
 #define CREATE_FLAGS \


### PR DESCRIPTION
When moving exclusive fullscreen windows to another display, `SDL_UpdateFullscreenMode()` may kick the window out of fullscreen if the display to which it was moved doesn't support the window's requested video mode. This can happen when, for example, moving a native resolution, exclusive fullscreen window from a 4k display to a 1080p display. Additionally, the resulting window will be resized as though it were still fullscreen, which can result in a window larger than the usable desktop bounds.

Two parts to the fix:
- `SDL_UpdateFullscreenMode()` returns a success code even when it can't find a matching video mode and the fullscreen request fails; modify it to return an error on failure to find a compatible display mode.
- Clear the fullscreen flag and skip the resize of the moved window if the operation fails and the window is no longer fullscreen.
