### PR TITLE
Min/Max blending for OpenGL ES 2

### DIFF
--- a/src/render/opengl/SDL_render_gl.c
+++ b/src/render/opengl/SDL_render_gl.c
@@ -375,6 +375,10 @@ static GLenum GetBlendEquation(SDL_BlendOperation operation)
         return GL_FUNC_SUBTRACT;
     case SDL_BLENDOPERATION_REV_SUBTRACT:
         return GL_FUNC_REVERSE_SUBTRACT;
+    case SDL_BLENDOPERATION_MINIMUM:
+        return GL_MIN;
+    case SDL_BLENDOPERATION_MAXIMUM:
+        return GL_MAX;
     default:
         return GL_INVALID_ENUM;
     }

--- a/src/render/opengles/SDL_render_gles.c
+++ b/src/render/opengles/SDL_render_gles.c
@@ -97,6 +97,7 @@ typedef struct
     SDL_bool GL_OES_blend_func_separate_supported;
     SDL_bool GL_OES_blend_equation_separate_supported;
     SDL_bool GL_OES_blend_subtract_supported;
+    SDL_bool GL_EXT_blend_minmax_supported;
 
     GLES_DrawStateCache drawstate;
 } GLES_RenderData;
@@ -263,6 +264,10 @@ static GLenum GetBlendEquation(SDL_BlendOperation operation)
         return GL_FUNC_SUBTRACT_OES;
     case SDL_BLENDOPERATION_REV_SUBTRACT:
         return GL_FUNC_REVERSE_SUBTRACT_OES;
+    case SDL_BLENDOPERATION_MINIMUM:
+        return GL_MIN_EXT;
+    case SDL_BLENDOPERATION_MAXIMUM:
+        return GL_MAX_EXT;
     default:
         return GL_INVALID_ENUM;
     }
@@ -293,6 +298,12 @@ static SDL_bool GLES_SupportsBlendMode(SDL_Renderer *renderer, SDL_BlendMode ble
         return SDL_FALSE;
     }
     if (colorOperation != SDL_BLENDOPERATION_ADD && !data->GL_OES_blend_subtract_supported) {
+        return SDL_FALSE;
+    }
+    if (colorOperation == SDL_BLENDOPERATION_MINIMUM && !data->GL_EXT_blend_minmax_supported) {
+        return SDL_FALSE;
+    }
+    if (colorOperation == SDL_BLENDOPERATION_MAXIMUM && !data->GL_EXT_blend_minmax_supported) {
         return SDL_FALSE;
     }
     return SDL_TRUE;
@@ -1160,6 +1171,9 @@ static SDL_Renderer *GLES_CreateRenderer(SDL_Window *window, Uint32 flags)
     }
     if (SDL_GL_ExtensionSupported("GL_OES_blend_subtract")) {
         data->GL_OES_blend_subtract_supported = SDL_TRUE;
+    }
+    if (SDL_GL_ExtensionSupported("GL_EXT_blend_minmax")) {
+        data->GL_EXT_blend_minmax_supported = SDL_TRUE;
     }
 
     /* Set up parameters for rendering */

--- a/src/render/opengles2/SDL_render_gles2.c
+++ b/src/render/opengles2/SDL_render_gles2.c
@@ -149,6 +149,8 @@ typedef struct GLES2_RenderData
 
     SDL_bool debug_enabled;
 
+    SDL_bool GL_EXT_blend_minmax_supported;
+
 #define SDL_PROC(ret, func, params) ret(APIENTRY *func) params;
 #include "SDL_gles2funcs.h"
 #undef SDL_PROC
@@ -355,6 +357,10 @@ static GLenum GetBlendEquation(SDL_BlendOperation operation)
         return GL_FUNC_SUBTRACT;
     case SDL_BLENDOPERATION_REV_SUBTRACT:
         return GL_FUNC_REVERSE_SUBTRACT;
+    case SDL_BLENDOPERATION_MINIMUM:
+        return GL_MIN_EXT;
+    case SDL_BLENDOPERATION_MAXIMUM:
+        return GL_MAX_EXT;
     default:
         return GL_INVALID_ENUM;
     }
@@ -362,6 +368,8 @@ static GLenum GetBlendEquation(SDL_BlendOperation operation)
 
 static SDL_bool GLES2_SupportsBlendMode(SDL_Renderer *renderer, SDL_BlendMode blendMode)
 {
+    GLES2_RenderData *data = (GLES2_RenderData *)renderer->driverdata;
+
     SDL_BlendFactor srcColorFactor = SDL_GetBlendModeSrcColorFactor(blendMode);
     SDL_BlendFactor srcAlphaFactor = SDL_GetBlendModeSrcAlphaFactor(blendMode);
     SDL_BlendOperation colorOperation = SDL_GetBlendModeColorOperation(blendMode);
@@ -377,6 +385,14 @@ static SDL_bool GLES2_SupportsBlendMode(SDL_Renderer *renderer, SDL_BlendMode bl
         GetBlendEquation(alphaOperation) == GL_INVALID_ENUM) {
         return SDL_FALSE;
     }
+
+    if (colorOperation == SDL_BLENDOPERATION_MINIMUM && !data->GL_EXT_blend_minmax_supported) {
+        return SDL_FALSE;
+    }
+    if (colorOperation == SDL_BLENDOPERATION_MAXIMUM && !data->GL_EXT_blend_minmax_supported) {
+        return SDL_FALSE;
+    }
+
     return SDL_TRUE;
 }
 
@@ -2205,6 +2221,10 @@ static SDL_Renderer *GLES2_CreateRenderer(SDL_Window *window, Uint32 flags)
     renderer->rect_index_order[3] = 1;
     renderer->rect_index_order[4] = 3;
     renderer->rect_index_order[5] = 2;
+
+    if (SDL_GL_ExtensionSupported("GL_EXT_blend_minmax")) {
+        data->GL_EXT_blend_minmax_supported = SDL_TRUE;
+    }
 
     /* Set up parameters for rendering */
     data->glActiveTexture(GL_TEXTURE0);


### PR DESCRIPTION
A small followup to my last PR [edit: linked here #7122 ]. I didn't initially realize that there were separate opengles and opengles2 render drivers. Thanks for letting me know.

## Description
Since min/max blending didn't become core until OpenGL ES 3, the capability checks are still needed. I added a bool to the renderer data struct. I placed it somewhat arbitrarily next to another bool, in a new cluster of declarations.