### PR TITLE
Change the Visual Studio project search paths to look relative to the project, not the solution.

### DIFF
--- a/VisualC/SDL/SDL.vcxproj
+++ b/VisualC/SDL/SDL.vcxproj
@@ -86,16 +86,16 @@
     <LibraryPath Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">C:\Program Files %28x86%29\Microsoft DirectX SDK %28June 2010%29\Lib\x86;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>$(SolutionDir)/../src;$(IncludePath)</IncludePath>
+    <IncludePath>$(ProjectDir)/../../src;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <IncludePath>$(SolutionDir)/../src;$(IncludePath)</IncludePath>
+    <IncludePath>$(ProjectDir)/../../src;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>$(SolutionDir)/../src;$(IncludePath)</IncludePath>
+    <IncludePath>$(ProjectDir)/../../src;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>$(SolutionDir)/../src;$(IncludePath)</IncludePath>
+    <IncludePath>$(ProjectDir)/../../src;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <PreBuildEvent>


### PR DESCRIPTION
## Description
The Visual Studio project for SDL3 uses search paths relative to the solution file, meaning that they are incorrect if you try to build the project from inside a different solution. The solution is to change the paths to be relative to the project file instead.

## Existing Issue(s)
Fixes #7139 