### PR TITLE
wayland: Set the display scale for video modes

### DIFF
--- a/src/video/wayland/SDL_waylandmouse.c
+++ b/src/video/wayland/SDL_waylandmouse.c
@@ -194,7 +194,7 @@ static SDL_bool wayland_get_system_cursor(SDL_VideoData *vdata, Wayland_CursorDa
     focusdata = focus->driverdata;
 
     /* Cursors use integer scaling. */
-    *scale = SDL_ceilf(focusdata->scale_factor);
+    *scale = SDL_ceilf(focusdata->windowed_scale_factor);
     size *= *scale;
     for (i = 0; i < vdata->num_cursor_themes; i += 1) {
         if (vdata->cursor_themes[i].size == size) {

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -103,7 +103,7 @@ typedef struct
     SDL_WaylandOutputData **outputs;
     int num_outputs;
 
-    float scale_factor;
+    float windowed_scale_factor;
     float pointer_scale_x;
     float pointer_scale_y;
     int drawable_width, drawable_height;


### PR DESCRIPTION
- Set the desktop display scale
- Exclusive fullscreen modes all have a scale of 1.0, so don't add the scaled desktop mode to the list.
