### PR TITLE
Update #pragma aux for Open Watcom

### DIFF
--- a/include/SDL_atomic.h
+++ b/include/SDL_atomic.h
@@ -249,9 +249,8 @@ typedef void (*SDL_KernelMemoryBarrierFunc)();
 #elif defined(_MSC_VER) && (defined(_M_ARM) || defined(_M_ARM64))
     #define SDL_CPUPauseInstruction() __yield()
 #elif defined(__WATCOMC__) && defined(__386__)
-    /* watcom assembler rejects PAUSE if CPU < i686, and it refuses REP NOP as an invalid combination. Hardcode the bytes.  */
     extern __inline void SDL_CPUPauseInstruction(void);
-    #pragma aux SDL_CPUPauseInstruction = "db 0f3h,90h"
+    #pragma aux SDL_CPUPauseInstruction = ".686" "pause"
 #else
     #define SDL_CPUPauseInstruction()
 #endif

--- a/include/SDL_atomic.h
+++ b/include/SDL_atomic.h
@@ -250,7 +250,7 @@ typedef void (*SDL_KernelMemoryBarrierFunc)();
     #define SDL_CPUPauseInstruction() __yield()
 #elif defined(__WATCOMC__) && defined(__386__)
     extern __inline void SDL_CPUPauseInstruction(void);
-    #pragma aux SDL_CPUPauseInstruction = ".686" "pause"
+    #pragma aux SDL_CPUPauseInstruction = ".686p" ".xmm2" "pause"
 #else
     #define SDL_CPUPauseInstruction()
 #endif


### PR DESCRIPTION
Update #pragma aux to not use hardcoded instruction bytes

## Description
Appropriate CPU directive can be used in #pragma aux that not necessary to hardcode instruction bytes

## Existing Issue(s)
