### PR TITLE
video: Sort scaled modes largest to smallest

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -391,7 +391,7 @@ static int SDLCALL cmpmodes(const void *A, const void *B)
     } else if (a->h != b->h) {
         return b->h - a->h;
     } else if (a_display_scale != b_display_scale) {
-        return (int)(a_display_scale * 100) - (int)(b_display_scale * 100);
+        return (int)(b_display_scale * 100) - (int)(a_display_scale * 100);
     } else if (SDL_BITSPERPIXEL(a->format) != SDL_BITSPERPIXEL(b->format)) {
         return SDL_BITSPERPIXEL(b->format) - SDL_BITSPERPIXEL(a->format);
     } else if (SDL_PIXELLAYOUT(a->format) != SDL_PIXELLAYOUT(b->format)) {


### PR DESCRIPTION
Modes in the list are sorted from largest to smallest, so when modes with identical dimensions, but different scale values, are present, they should be sorted from the largest to the smallest scale values to maintain consistency, as the modes with higher scale values will have larger physical pixel counts.

Currently if you have two 1920x1080 modes in the list at 1x and 2x scale factors, they would be sorted as:
1. 1920x1080 x1
2. 1920x1080 x2

which isn't consistent with how the list is otherwise sorted as the second value is actually the larger of the two. Reversing the comparison arithmetic fixes this.