### PR TITLE
wayland: Correct mode values to use pixels instead of screen units

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -298,7 +298,7 @@ static void xdg_output_handle_logical_size(void *data, struct zxdg_output_v1 *xd
 {
     SDL_WaylandOutputData *driverdata = data;
 
-    if (driverdata->width != 0 && driverdata->height != 0) {
+    if (driverdata->screen_width != 0 && driverdata->screen_height != 0) {
         /* FIXME: GNOME has a bug where the logical size does not account for
          * scale, resulting in bogus viewport sizes.
          *
@@ -307,7 +307,7 @@ static void xdg_output_handle_logical_size(void *data, struct zxdg_output_v1 *xd
          * detected otherwise), then override if necessary.
          * -flibit
          */
-        const float scale = (float)driverdata->width / (float)width;
+        const float scale = (float)driverdata->screen_width / (float)width;
         if ((scale == 1.0f) && (driverdata->scale_factor != 1.0f)) {
             SDL_LogWarn(
                 SDL_LOG_CATEGORY_VIDEO,
@@ -316,8 +316,8 @@ static void xdg_output_handle_logical_size(void *data, struct zxdg_output_v1 *xd
         }
     }
 
-    driverdata->width = width;
-    driverdata->height = height;
+    driverdata->screen_width = width;
+    driverdata->screen_height = height;
     driverdata->has_logical_size = SDL_TRUE;
 }
 
@@ -414,12 +414,15 @@ static void AddEmulatedModes(SDL_VideoDisplay *dpy, SDL_bool rot_90)
 
     int i;
     SDL_DisplayMode mode;
-    const int native_width = dpy->display_modes->w;
-    const int native_height = dpy->display_modes->h;
+    const int native_width = dpy->display_modes->pixel_w;
+    const int native_height = dpy->display_modes->pixel_h;
 
     for (i = 0; i < SDL_arraysize(mode_list); ++i) {
-        mode = *dpy->display_modes;
+        SDL_zero(mode);
+        mode.format = dpy->display_modes->format;
         mode.display_scale = 1.0f;
+        mode.refresh_rate = dpy->display_modes->refresh_rate;
+        mode.driverdata = dpy->display_modes->driverdata;
 
         if (rot_90) {
             mode.pixel_w = mode_list[i].h;
@@ -521,16 +524,16 @@ static void display_handle_mode(void *data,
     SDL_WaylandOutputData *driverdata = data;
 
     if (flags & WL_OUTPUT_MODE_CURRENT) {
-        driverdata->native_width = width;
-        driverdata->native_height = height;
+        driverdata->pixel_width = width;
+        driverdata->pixel_height = height;
 
         /*
          * Don't rotate this yet, wl-output coordinates are transformed in
          * handle_done and xdg-output coordinates are pre-transformed.
          */
         if (!driverdata->has_logical_size) {
-            driverdata->width = width;
-            driverdata->height = height;
+            driverdata->screen_width = width;
+            driverdata->screen_height = height;
         }
 
         driverdata->refresh = refresh;
@@ -565,11 +568,11 @@ static void display_handle_done(void *data,
     native_mode.format = SDL_PIXELFORMAT_RGB888;
 
     if (driverdata->transform & WL_OUTPUT_TRANSFORM_90) {
-        native_mode.pixel_w = driverdata->native_height;
-        native_mode.pixel_h = driverdata->native_width;
+        native_mode.pixel_w = driverdata->pixel_height;
+        native_mode.pixel_h = driverdata->pixel_width;
     } else {
-        native_mode.pixel_w = driverdata->native_width;
-        native_mode.pixel_h = driverdata->native_height;
+        native_mode.pixel_w = driverdata->pixel_width;
+        native_mode.pixel_h = driverdata->pixel_height;
     }
     native_mode.display_scale = 1.0f;
     native_mode.refresh_rate = ((100 * driverdata->refresh) / 1000) / 100.0f; /* mHz to Hz */
@@ -581,20 +584,20 @@ static void display_handle_done(void *data,
 
     if (driverdata->has_logical_size) { /* If xdg-output is present, calculate the true scale of the desktop */
         if (video->viewporter) {
-            driverdata->scale_factor = (float)native_mode.w / (float)driverdata->width;
+            driverdata->scale_factor = (float)native_mode.pixel_w / (float)driverdata->screen_width;
         }
     } else { /* Scale the desktop coordinates, if xdg-output isn't present */
-        driverdata->width /= driverdata->scale_factor;
-        driverdata->height /= driverdata->scale_factor;
+        driverdata->screen_width /= driverdata->scale_factor;
+        driverdata->screen_height /= driverdata->scale_factor;
     }
 
     /* xdg-output dimensions are already transformed, so no need to rotate. */
     if (driverdata->has_logical_size || !(driverdata->transform & WL_OUTPUT_TRANSFORM_90)) {
-        desktop_mode.pixel_w = driverdata->width;
-        desktop_mode.pixel_h = driverdata->height;
+        desktop_mode.pixel_w = driverdata->pixel_width;
+        desktop_mode.pixel_h = driverdata->pixel_height;
     } else {
-        desktop_mode.pixel_w = driverdata->height;
-        desktop_mode.pixel_h = driverdata->width;
+        desktop_mode.pixel_w = driverdata->pixel_height;
+        desktop_mode.pixel_h = driverdata->pixel_width;
     }
     desktop_mode.display_scale = driverdata->scale_factor;
     desktop_mode.refresh_rate = ((100 * driverdata->refresh) / 1000) / 100.0f; /* mHz to Hz */
@@ -617,10 +620,15 @@ static void display_handle_done(void *data,
         if (video->viewporter != NULL) {
             SDL_AddDisplayMode(dpy, &native_mode);
         } else {
-            /* ...if not, expose the integer scale desktop modes down to 1.0. */
+            /* ...if not, expose some smaller, integer scaled resolutions. */
             int i;
-            for (i = (int)driverdata->scale_factor - 1; i > 0; --i) {
+            const int base_pixel_w = desktop_mode.pixel_w / (int)desktop_mode.display_scale;
+            const int base_pixel_h = desktop_mode.pixel_h / (int)desktop_mode.display_scale;
+            for (i = 1; i < (int)desktop_mode.display_scale; ++i) {
+                desktop_mode.pixel_w = base_pixel_w * i;
+                desktop_mode.pixel_h = base_pixel_h * i;
                 desktop_mode.display_scale = (float)i;
+
                 SDL_AddDisplayMode(dpy, &desktop_mode);
             }
         }
@@ -629,23 +637,23 @@ static void display_handle_done(void *data,
     /* Add emulated modes if wp_viewporter is supported and mode emulation is enabled. */
     if (video->viewporter && mode_emulation_enabled) {
         const SDL_bool rot_90 = ((driverdata->transform & WL_OUTPUT_TRANSFORM_90) != 0) ||
-                                (driverdata->width < driverdata->height);
+                                (driverdata->screen_width < driverdata->screen_height);
         AddEmulatedModes(dpy, rot_90);
     }
 
     /* Calculate the display DPI */
     if (driverdata->transform & WL_OUTPUT_TRANSFORM_90) {
-        driverdata->hdpi = driverdata->physical_height ? (((float)driverdata->height) * 25.4f / driverdata->physical_height) : 0.0f;
-        driverdata->vdpi = driverdata->physical_width ? (((float)driverdata->width) * 25.4f / driverdata->physical_width) : 0.0f;
-        driverdata->ddpi = SDL_ComputeDiagonalDPI(driverdata->height,
-                                                  driverdata->width,
+        driverdata->hdpi = driverdata->physical_height ? (((float)driverdata->pixel_height) * 25.4f / driverdata->physical_height) : 0.0f;
+        driverdata->vdpi = driverdata->physical_width ? (((float)driverdata->pixel_width) * 25.4f / driverdata->physical_width) : 0.0f;
+        driverdata->ddpi = SDL_ComputeDiagonalDPI(driverdata->pixel_height,
+                                                  driverdata->pixel_width,
                                                   ((float)driverdata->physical_height) / 25.4f,
                                                   ((float)driverdata->physical_width) / 25.4f);
     } else {
-        driverdata->hdpi = driverdata->physical_width ? (((float)driverdata->width) * 25.4f / driverdata->physical_width) : 0.0f;
-        driverdata->vdpi = driverdata->physical_height ? (((float)driverdata->height) * 25.4f / driverdata->physical_height) : 0.0f;
-        driverdata->ddpi = SDL_ComputeDiagonalDPI(driverdata->width,
-                                                  driverdata->height,
+        driverdata->hdpi = driverdata->physical_width ? (((float)driverdata->pixel_width) * 25.4f / driverdata->physical_width) : 0.0f;
+        driverdata->vdpi = driverdata->physical_height ? (((float)driverdata->pixel_height) * 25.4f / driverdata->physical_height) : 0.0f;
+        driverdata->ddpi = SDL_ComputeDiagonalDPI(driverdata->pixel_width,
+                                                  driverdata->pixel_height,
                                                   ((float)driverdata->physical_width) / 25.4f,
                                                   ((float)driverdata->physical_height) / 25.4f);
     }

--- a/src/video/wayland/SDL_waylandvideo.h
+++ b/src/video/wayland/SDL_waylandvideo.h
@@ -109,8 +109,8 @@ struct SDL_WaylandOutputData
     struct zxdg_output_v1 *xdg_output;
     uint32_t registry_id;
     float scale_factor;
-    int native_width, native_height;
-    int x, y, width, height, refresh, transform;
+    int pixel_width, pixel_height;
+    int x, y, screen_width, screen_height, refresh, transform;
     SDL_DisplayOrientation orientation;
     int physical_width, physical_height;
     float ddpi, hdpi, vdpi;


### PR DESCRIPTION
Fixes the Wayland backend to report the desktop mode dimensions in pixels instead of screen units, adjusts enumerated fullscreen resolutions to use the correct pixel values and scaling, and changes the Wayland backend `SDL_GetDisplayBounds()` function to return screen coordinates instead of the desktop mode in pixels.
