### PR TITLE
Add full high DPI information to SDL_DisplayMode

### DIFF
--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -954,6 +954,8 @@ The SDL_WINDOW_SHOWN flag has been removed. Windows are shown by default and can
 
 The SDL_WINDOW_ALLOW_HIGHDPI flag has been removed. Windows are automatically high DPI aware and their coordinates are in screen space, which may differ from physical pixels on displays using display scaling.
 
+SDL_DisplayMode now includes the pixel size, the screen size and the relationship between the two. For example, a 4K display at 200% scale could have a pixel size of 3840x2160, a screen size of 1920x1080, and a display scale of 2.0.
+
 The refresh rate in SDL_DisplayMode is now a float.
 
 SDL_SetWindowBrightness and SDL_SetWindowGammaRamp have been removed from the API, because they interact poorly with modern operating systems and aren't able to limit their effects to the SDL window.

--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -56,9 +56,11 @@ typedef Uint32 SDL_WindowID;
 typedef struct
 {
     Uint32 format;              /**< pixel format */
-    int w;                      /**< width in pixels */
-    int h;                      /**< height in pixels */
-    float display_scale;        /**< scale converting screen coordinates to pixels (e.g. a 3840x2160 mode with 1.5 scale would have a screen size of 2560x1440) */
+    int pixel_w;                /**< width in pixels (used for creating back buffers) */
+    int pixel_h;                /**< height in pixels (used for creating back buffers) */
+    int screen_w;               /**< width in screen coordinates (used for creating windows) */
+    int screen_h;               /**< height in screen coordinates (used for creating windows) */
+    float display_scale;        /**< scale converting screen coordinates to pixels (e.g. a 2560x1440 screen size mode with 1.5 scale would have 3840x2160 pixels) */
     float refresh_rate;         /**< refresh rate (or zero for unspecified) */
     void *driverdata;           /**< driver-specific data, initialize to 0 */
 } SDL_DisplayMode;

--- a/src/core/winrt/SDL_winrtapp_direct3d.cpp
+++ b/src/core/winrt/SDL_winrtapp_direct3d.cpp
@@ -116,10 +116,10 @@ static void WINRT_ProcessWindowSizeChange() // TODO: Pass an SDL_Window-identify
             SDL_Window *window = WINRT_GlobalSDLWindow;
             SDL_WindowData *data = (SDL_WindowData *)window->driverdata;
 
-            int x = WINRT_DIPS_TO_PHYSICAL_PIXELS(data->coreWindow->Bounds.Left);
-            int y = WINRT_DIPS_TO_PHYSICAL_PIXELS(data->coreWindow->Bounds.Top);
-            int w = WINRT_DIPS_TO_PHYSICAL_PIXELS(data->coreWindow->Bounds.Width);
-            int h = WINRT_DIPS_TO_PHYSICAL_PIXELS(data->coreWindow->Bounds.Height);
+            int x = (int)SDL_lroundf(data->coreWindow->Bounds.Left);
+            int y = (int)SDL_lroundf(data->coreWindow->Bounds.Top);
+            int w = (int)SDL_floorf(data->coreWindow->Bounds.Width);
+            int h = (int)SDL_floorf(data->coreWindow->Bounds.Height);
 
 #if (WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP) && (NTDDI_VERSION == NTDDI_WIN8)
             /* WinPhone 8.0 always keeps its native window size in portrait,
@@ -235,8 +235,8 @@ void SDL_WinRTApp::OnOrientationChanged(Object ^ sender)
     SDL_Window *window = WINRT_GlobalSDLWindow;
     if (window) {
         SDL_WindowData *data = (SDL_WindowData *)window->driverdata;
-        int w = WINRT_DIPS_TO_PHYSICAL_PIXELS(data->coreWindow->Bounds.Width);
-        int h = WINRT_DIPS_TO_PHYSICAL_PIXELS(data->coreWindow->Bounds.Height);
+        int w = (int)SDL_floorf(data->coreWindow->Bounds.Width);
+        int h = (int)SDL_floorf(data->coreWindow->Bounds.Height);
         SDL_SendWindowEvent(WINRT_GlobalSDLWindow, SDL_EVENT_WINDOW_SIZE_CHANGED, w, h);
     }
 #endif

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1130,7 +1130,7 @@ SDLTest_CommonInit(SDLTest_CommonState *state)
                 SDL_GetMasksForPixelFormatEnum(mode.format, &bpp, &Rmask, &Gmask,
                                            &Bmask, &Amask);
                 SDL_Log("  Current mode: %dx%d@%gHz, %d%% scale, %d bits-per-pixel (%s)\n",
-                        mode.w, mode.h, mode.refresh_rate, (int)(mode.display_scale * 100.0f), bpp,
+                        mode.pixel_w, mode.pixel_h, mode.refresh_rate, (int)(mode.display_scale * 100.0f), bpp,
                         SDL_GetPixelFormatName(mode.format));
                 if (Rmask || Gmask || Bmask) {
                     SDL_Log("      Red Mask   = 0x%.8" SDL_PRIx32 "\n", Rmask);
@@ -1152,7 +1152,7 @@ SDLTest_CommonInit(SDLTest_CommonState *state)
                         SDL_GetMasksForPixelFormatEnum(mode.format, &bpp, &Rmask,
                                                    &Gmask, &Bmask, &Amask);
                         SDL_Log("    Mode %d: %dx%d@%gHz, %d%% scale, %d bits-per-pixel (%s)\n",
-                                j, mode.w, mode.h, mode.refresh_rate, (int)(mode.display_scale * 100.0f), bpp,
+                                j, mode.pixel_w, mode.pixel_h, mode.refresh_rate, (int)(mode.display_scale * 100.0f), bpp,
                                 SDL_GetPixelFormatName(mode.format));
                         if (Rmask || Gmask || Bmask) {
                             SDL_Log("        Red Mask   = 0x%.8" SDL_PRIx32 "\n",
@@ -2246,7 +2246,7 @@ void SDLTest_CommonDrawWindowInfo(SDL_Renderer *renderer, SDL_Window *window, fl
 
     if (0 == SDL_GetWindowDisplayMode(window, &mode)) {
         (void)SDL_snprintf(text, sizeof text, "SDL_GetWindowDisplayMode: %dx%d@%gHz %d%% scale, (%s)",
-                           mode.w, mode.h, mode.refresh_rate, (int)(mode.display_scale * 100.0f), SDL_GetPixelFormatName(mode.format));
+                           mode.pixel_w, mode.pixel_h, mode.refresh_rate, (int)(mode.display_scale * 100.0f), SDL_GetPixelFormatName(mode.format));
         SDLTest_DrawString(renderer, 0.0f, textY, text);
         textY += lineHeight;
     }
@@ -2276,14 +2276,14 @@ void SDLTest_CommonDrawWindowInfo(SDL_Renderer *renderer, SDL_Window *window, fl
 
     if (0 == SDL_GetCurrentDisplayMode(windowDisplayIndex, &mode)) {
         (void)SDL_snprintf(text, sizeof text, "SDL_GetCurrentDisplayMode: %dx%d@%gHz %d%% scale, (%s)",
-                           mode.w, mode.h, mode.refresh_rate, (int)(mode.display_scale * 100.0f), SDL_GetPixelFormatName(mode.format));
+                           mode.pixel_w, mode.pixel_h, mode.refresh_rate, (int)(mode.display_scale * 100.0f), SDL_GetPixelFormatName(mode.format));
         SDLTest_DrawString(renderer, 0.0f, textY, text);
         textY += lineHeight;
     }
 
     if (0 == SDL_GetDesktopDisplayMode(windowDisplayIndex, &mode)) {
         (void)SDL_snprintf(text, sizeof text, "SDL_GetDesktopDisplayMode: %dx%d@%gHz %d%% scale, (%s)",
-                           mode.w, mode.h, mode.refresh_rate, (int)(mode.display_scale * 100.0f), SDL_GetPixelFormatName(mode.format));
+                           mode.pixel_w, mode.pixel_h, mode.refresh_rate, (int)(mode.display_scale * 100.0f), SDL_GetPixelFormatName(mode.format));
         SDLTest_DrawString(renderer, 0.0f, textY, text);
         textY += lineHeight;
     }

--- a/src/video/android/SDL_androidvideo.c
+++ b/src/video/android/SDL_androidvideo.c
@@ -180,8 +180,8 @@ int Android_VideoInit(_THIS)
 
     SDL_zero(mode);
     mode.format = Android_ScreenFormat;
-    mode.w = Android_DeviceWidth;
-    mode.h = Android_DeviceHeight;
+    mode.pixel_w = Android_DeviceWidth;
+    mode.pixel_h = Android_DeviceHeight;
     mode.display_scale = Android_ScreenDensity;
     mode.refresh_rate = Android_ScreenRate;
     mode.driverdata = NULL;
@@ -276,11 +276,15 @@ void Android_SendResize(SDL_Window *window)
     SDL_VideoDevice *device = SDL_GetVideoDevice();
     if (device && device->num_displays > 0) {
         SDL_VideoDisplay *display = &device->displays[0];
-        display->desktop_mode.format = Android_ScreenFormat;
-        display->desktop_mode.w = Android_DeviceWidth;
-        display->desktop_mode.h = Android_DeviceHeight;
-        display->desktop_mode.display_scale = Android_ScreenDensity;
-        display->desktop_mode.refresh_rate = Android_ScreenRate;
+        SDL_DisplayMode desktop_mode;
+
+        SDL_zero(desktop_mode);
+        desktop_mode.format = Android_ScreenFormat;
+        desktop_mode.pixel_w = Android_DeviceWidth;
+        desktop_mode.pixel_h = Android_DeviceHeight;
+        desktop_mode.display_scale = Android_ScreenDensity;
+        desktop_mode.refresh_rate = Android_ScreenRate;
+        SDL_SetDesktopDisplayMode(display, &desktop_mode);
     }
 
     if (window) {
@@ -288,15 +292,17 @@ void Android_SendResize(SDL_Window *window)
          * will fall back to the old mode */
         int w, h;
         SDL_VideoDisplay *display = SDL_GetDisplayForWindow(window);
-        display->display_modes[0].format = Android_ScreenFormat;
-        display->display_modes[0].w = Android_DeviceWidth;
-        display->display_modes[0].h = Android_DeviceHeight;
-        display->display_modes[0].display_scale = Android_ScreenDensity;
-        display->display_modes[0].refresh_rate = Android_ScreenRate;
-        display->current_mode = display->display_modes[0];
+        SDL_DisplayMode current_mode;
 
-        w = (int)SDL_ceilf(Android_SurfaceWidth / Android_ScreenDensity);
-        h = (int)SDL_ceilf(Android_SurfaceHeight / Android_ScreenDensity);
+        current_mode.format = Android_ScreenFormat;
+        current_mode.pixel_w = Android_DeviceWidth;
+        current_mode.pixel_h = Android_DeviceHeight;
+        current_mode.display_scale = Android_ScreenDensity;
+        current_mode.refresh_rate = Android_ScreenRate;
+        SDL_SetCurrentDisplayMode(display, &current_mode);
+
+        w = (int)SDL_floorf(Android_SurfaceWidth / Android_ScreenDensity);
+        h = (int)SDL_floorf(Android_SurfaceHeight / Android_ScreenDensity);
         SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_RESIZED, w, h);
     }
 }

--- a/src/video/cocoa/SDL_cocoamodes.m
+++ b/src/video/cocoa/SDL_cocoamodes.m
@@ -143,10 +143,10 @@ static SDL_bool GetDisplayMode(_THIS, CGDisplayModeRef vidmode, SDL_bool vidmode
 {
     SDL_DisplayModeData *data;
     bool usableForGUI = CGDisplayModeIsUsableForDesktopGUI(vidmode);
-    int width = (int)CGDisplayModeGetWidth(vidmode);
-    int height = (int)CGDisplayModeGetHeight(vidmode);
-    int pixelW = width;
-    int pixelH = height;
+    size_t width = CGDisplayModeGetWidth(vidmode);
+    size_t height = CGDisplayModeGetHeight(vidmode);
+    size_t pixelW = width;
+    size_t pixelH = height;
     uint32_t ioflags = CGDisplayModeGetIOFlags(vidmode);
     float refreshrate = GetDisplayModeRefreshRate(vidmode, link);
     Uint32 format = GetDisplayModePixelFormat(vidmode);
@@ -173,15 +173,15 @@ static SDL_bool GetDisplayMode(_THIS, CGDisplayModeRef vidmode, SDL_bool vidmode
      * modes to try (see comment below for why that's necessary).
      * CGDisplayModeGetPixelWidth and friends are only available in 10.8+. */
 #ifdef MAC_OS_X_VERSION_10_8
-    pixelW = (int)CGDisplayModeGetPixelWidth(vidmode);
-    pixelH = (int)CGDisplayModeGetPixelHeight(vidmode);
+    pixelW = CGDisplayModeGetPixelWidth(vidmode);
+    pixelH = CGDisplayModeGetPixelHeight(vidmode);
 
     if (modelist != NULL && floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_7) {
         CFIndex modescount = CFArrayGetCount(modelist);
         int i;
 
         for (i = 0; i < modescount; i++) {
-            int otherW, otherH, otherpixelW, otherpixelH;
+            size_t otherW, otherH, otherpixelW, otherpixelH;
             float otherrefresh;
             Uint32 otherformat;
             bool otherGUI;
@@ -196,10 +196,10 @@ static SDL_bool GetDisplayMode(_THIS, CGDisplayModeRef vidmode, SDL_bool vidmode
                 continue;
             }
 
-            otherW = (int)CGDisplayModeGetWidth(othermode);
-            otherH = (int)CGDisplayModeGetHeight(othermode);
-            otherpixelW = (int)CGDisplayModeGetPixelWidth(othermode);
-            otherpixelH = (int)CGDisplayModeGetPixelHeight(othermode);
+            otherW = CGDisplayModeGetWidth(othermode);
+            otherH = CGDisplayModeGetHeight(othermode);
+            otherpixelW = CGDisplayModeGetPixelWidth(othermode);
+            otherpixelH = CGDisplayModeGetPixelHeight(othermode);
             otherrefresh = GetDisplayModeRefreshRate(othermode, link);
             otherformat = GetDisplayModePixelFormat(othermode);
             otherGUI = CGDisplayModeIsUsableForDesktopGUI(othermode);
@@ -264,9 +264,10 @@ static SDL_bool GetDisplayMode(_THIS, CGDisplayModeRef vidmode, SDL_bool vidmode
     }
     data->modes = modes;
     mode->format = format;
-    mode->w = pixelW;
-    mode->h = pixelH;
-    mode->display_scale = (float)pixelW / width;
+    mode->pixel_w = (int)pixelW;
+    mode->pixel_h = (int)pixelH;
+    mode->screen_w = (int)width;
+    mode->screen_h = (int)height;
     mode->refresh_rate = refreshrate;
     mode->driverdata = data;
     return SDL_TRUE;

--- a/src/video/dummy/SDL_nullvideo.c
+++ b/src/video/dummy/SDL_nullvideo.c
@@ -144,8 +144,8 @@ int DUMMY_VideoInit(_THIS)
     /* Use a fake 32-bpp desktop mode */
     SDL_zero(mode);
     mode.format = SDL_PIXELFORMAT_RGB888;
-    mode.w = 1024;
-    mode.h = 768;
+    mode.pixel_w = 1024;
+    mode.pixel_h = 768;
     if (SDL_AddBasicVideoDisplay(&mode) < 0) {
         return -1;
     }

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -129,7 +129,8 @@ int Emscripten_VideoInit(_THIS)
     /* Use a fake 32-bpp desktop mode */
     SDL_zero(mode);
     mode.format = SDL_PIXELFORMAT_RGB888;
-    emscripten_get_screen_size(&mode.w, &mode.h);
+    emscripten_get_screen_size(&mode.screen_w, &mode.screen_h);
+    mode.display_scale = emscripten_get_device_pixel_ratio();
 
     if (SDL_AddBasicVideoDisplay(&mode) < 0) {
         return -1;

--- a/src/video/n3ds/SDL_n3dsvideo.c
+++ b/src/video/n3ds/SDL_n3dsvideo.c
@@ -118,8 +118,8 @@ AddN3DSDisplay(gfxScreen_t screen)
 
     display_driver_data->screen = screen;
 
-    mode.w = (screen == GFX_TOP) ? GSP_SCREEN_HEIGHT_TOP : GSP_SCREEN_HEIGHT_BOTTOM;
-    mode.h = GSP_SCREEN_WIDTH;
+    mode.pixel_w = (screen == GFX_TOP) ? GSP_SCREEN_HEIGHT_TOP : GSP_SCREEN_HEIGHT_BOTTOM;
+    mode.pixel_h = GSP_SCREEN_WIDTH;
     mode.refresh_rate = 60.0f;
     mode.format = FRAMEBUFFER_FORMAT;
 
@@ -154,8 +154,8 @@ static int N3DS_GetDisplayBounds(_THIS, SDL_VideoDisplay *display, SDL_Rect *rec
     }
     rect->x = 0;
     rect->y = (driver_data->screen == GFX_TOP) ? 0 : GSP_SCREEN_WIDTH;
-    rect->w = display->current_mode.w;
-    rect->h = display->current_mode.h;
+    rect->w = display->current_mode.screen_w;
+    rect->h = display->current_mode.screen_h;
 
     return 0;
 }

--- a/src/video/ngage/SDL_ngagevideo.cpp
+++ b/src/video/ngage/SDL_ngagevideo.cpp
@@ -150,8 +150,8 @@ int NGAGE_VideoInit(_THIS)
     /* Use 12-bpp desktop mode */
     SDL_zero(mode);
     mode.format = SDL_PIXELFORMAT_RGB444;
-    mode.w = 176;
-    mode.h = 208;
+    mode.pixel_w = 176;
+    mode.pixel_h = 208;
     if (SDL_AddBasicVideoDisplay(&mode) < 0) {
         return -1;
     }

--- a/src/video/offscreen/SDL_offscreenvideo.c
+++ b/src/video/offscreen/SDL_offscreenvideo.c
@@ -103,8 +103,8 @@ int OFFSCREEN_VideoInit(_THIS)
     /* Use a fake 32-bpp desktop mode */
     SDL_zero(mode);
     mode.format = SDL_PIXELFORMAT_RGB888;
-    mode.w = 1024;
-    mode.h = 768;
+    mode.pixel_w = 1024;
+    mode.pixel_h = 768;
     if (SDL_AddBasicVideoDisplay(&mode) < 0) {
         return -1;
     }

--- a/src/video/ps2/SDL_ps2video.c
+++ b/src/video/ps2/SDL_ps2video.c
@@ -65,23 +65,17 @@ static int PS2_CreateWindow(_THIS, SDL_Window *window)
 
 static int PS2_VideoInit(_THIS)
 {
-    SDL_VideoDisplay display;
-    SDL_DisplayMode current_mode;
+    SDL_DisplayMode mode;
 
-    SDL_zero(current_mode);
-    current_mode.w = 640;
-    current_mode.h = 480;
-    current_mode.refresh_rate = 60.0f;
+    SDL_zero(mode);
+    mode.pixel_w = 640;
+    mode.pixel_h = 480;
+    mode.refresh_rate = 60.0f;
 
     /* 32 bpp for default */
-    current_mode.format = SDL_PIXELFORMAT_ABGR8888;
+    mode.format = SDL_PIXELFORMAT_ABGR8888;
 
-    SDL_zero(display);
-    display.desktop_mode = current_mode;
-    display.current_mode = current_mode;
-    SDL_AddDisplayMode(&display, &current_mode);
-
-    SDL_AddVideoDisplay(&display, SDL_FALSE);
+    SDL_AddBasicVideoDisplay(&mode);
 
     return 1;
 }

--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -137,29 +137,28 @@ VideoBootStrap PSP_bootstrap = {
 int PSP_VideoInit(_THIS)
 {
     SDL_VideoDisplay display;
-    SDL_DisplayMode current_mode;
+    SDL_DisplayMode mode;
 
-    SDL_zero(current_mode);
-    current_mode.w = 480;
-    current_mode.h = 272;
-    current_mode.refresh_rate = 60.0f;
+    SDL_zero(mode);
+    mode.pixel_w = 480;
+    mode.pixel_h = 272;
+    mode.refresh_rate = 60.0f;
 
     /* 32 bpp for default */
-    current_mode.format = SDL_PIXELFORMAT_ABGR8888;
+    mode.format = SDL_PIXELFORMAT_ABGR8888;
 
     SDL_zero(display);
-    display.desktop_mode = current_mode;
-    display.current_mode = current_mode;
+    display.desktop_mode = mode;
+    display.current_mode = mode;
 
-    SDL_AddDisplayMode(&display, &current_mode);
+    SDL_AddDisplayMode(&display, &mode);
 
     /* 16 bpp secondary mode */
-    current_mode.format = SDL_PIXELFORMAT_BGR565;
-    display.desktop_mode = current_mode;
-    display.current_mode = current_mode;
-    SDL_AddDisplayMode(&display, &current_mode);
+    mode.format = SDL_PIXELFORMAT_BGR565;
+    SDL_AddDisplayMode(&display, &mode);
 
     SDL_AddVideoDisplay(&display, SDL_FALSE);
+
     return 1;
 }
 

--- a/src/video/raspberry/SDL_rpivideo.c
+++ b/src/video/raspberry/SDL_rpivideo.c
@@ -148,7 +148,7 @@ static void AddDispManXDisplay(const int display_id)
     DISPMANX_MODEINFO_T modeinfo;
     DISPMANX_DISPLAY_HANDLE_T handle;
     SDL_VideoDisplay display;
-    SDL_DisplayMode current_mode;
+    SDL_DisplayMode mode;
     SDL_DisplayData *data;
 
     handle = vc_dispmanx_display_open(display_id);
@@ -162,17 +162,17 @@ static void AddDispManXDisplay(const int display_id)
     }
 
     /* RPI_GetRefreshRate() doesn't distinguish between displays. I'm not sure the hardware distinguishes either */
-    SDL_zero(current_mode);
-    current_mode.w = modeinfo.width;
-    current_mode.h = modeinfo.height;
-    current_mode.refresh_rate = RPI_GetRefreshRate();
+    SDL_zero(mode);
+    mode.pixel_w = modeinfo.width;
+    mode.pixel_h = modeinfo.height;
+    mode.refresh_rate = RPI_GetRefreshRate();
 
     /* 32 bpp for default */
-    current_mode.format = SDL_PIXELFORMAT_ABGR8888;
+    mode.format = SDL_PIXELFORMAT_ABGR8888;
 
     SDL_zero(display);
-    display.desktop_mode = current_mode;
-    display.current_mode = current_mode;
+    display.desktop_mode = mode;
+    display.current_mode = mode;
 
     /* Allocate display internal data */
     data = (SDL_DisplayData *)SDL_calloc(1, sizeof(SDL_DisplayData));

--- a/src/video/riscos/SDL_riscosmodes.c
+++ b/src/video/riscos/SDL_riscosmodes.c
@@ -137,8 +137,8 @@ static SDL_bool read_mode_block(int *block, SDL_DisplayMode *mode, SDL_bool exte
     }
 
     SDL_zerop(mode);
-    mode->w = xres;
-    mode->h = yres;
+    mode->pixel_w = xres;
+    mode->pixel_h = yres;
     mode->format = RISCOS_ModeToPixelFormat(ncolour, modeflags, log2bpp);
     mode->refresh_rate = (float)rate;
 

--- a/src/video/uikit/SDL_uikitmodes.m
+++ b/src/video/uikit/SDL_uikitmodes.m
@@ -269,8 +269,8 @@ static int UIKit_AddSingleDisplayMode(SDL_VideoDisplay *display, int w, int h,
         return -1;
     }
 
-    mode.w = w;
-    mode.h = h;
+    mode.pixel_w = w;
+    mode.pixel_h = h;
     mode.display_scale = uiscreen.scale;
     mode.refresh_rate = UIKit_GetDisplayModeRefreshRate(uiscreen);
     mode.format = SDL_PIXELFORMAT_ABGR8888;
@@ -315,8 +315,8 @@ int UIKit_AddDisplay(UIScreen *uiscreen, SDL_bool send_event)
     }
 
     SDL_zero(mode);
-    mode.w = (int)size.width;
-    mode.h = (int)size.height;
+    mode.pixel_w = (int)size.width;
+    mode.pixel_h = (int)size.height;
     mode.display_scale = uiscreen.scale;
     mode.format = SDL_PIXELFORMAT_ABGR8888;
     mode.refresh_rate = UIKit_GetDisplayModeRefreshRate(uiscreen);
@@ -455,11 +455,11 @@ int UIKit_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode
             /* [UIApplication setStatusBarOrientation:] no longer works reliably
              * in recent iOS versions, so we can't rotate the screen when setting
              * the display mode. */
-            if (mode->w > mode->h) {
+            if (mode->pixel_w > mode->pixel_h) {
                 if (!UIKit_IsDisplayLandscape(data.uiscreen)) {
                     return SDL_SetError("Screen orientation does not match display mode size");
                 }
-            } else if (mode->w < mode->h) {
+            } else if (mode->pixel_w < mode->pixel_h) {
                 if (UIKit_IsDisplayLandscape(data.uiscreen)) {
                     return SDL_SetError("Screen orientation does not match display mode size");
                 }
@@ -531,17 +531,23 @@ void SDL_OnApplicationDidChangeStatusBarOrientation()
          * orientation so that updating a window's fullscreen state to
          * SDL_WINDOW_FULLSCREEN_DESKTOP keeps the window dimensions in the
          * correct orientation. */
-        if (isLandscape != (desktopmode->w > desktopmode->h)) {
-            int height = desktopmode->w;
-            desktopmode->w = desktopmode->h;
-            desktopmode->h = height;
+        if (isLandscape != (desktopmode->pixel_w > desktopmode->pixel_h)) {
+            int height = desktopmode->pixel_w;
+            desktopmode->pixel_w = desktopmode->pixel_h;
+            desktopmode->pixel_h = height;
+            height = desktopmode->screen_w;
+            desktopmode->screen_w = desktopmode->screen_h;
+            desktopmode->screen_h = height;
         }
 
         /* Same deal with the current mode + SDL_GetCurrentDisplayMode. */
-        if (isLandscape != (currentmode->w > currentmode->h)) {
-            int height = currentmode->w;
-            currentmode->w = currentmode->h;
-            currentmode->h = height;
+        if (isLandscape != (currentmode->pixel_w > currentmode->pixel_h)) {
+            int height = currentmode->pixel_w;
+            currentmode->pixel_w = currentmode->pixel_h;
+            currentmode->pixel_h = height;
+            height = currentmode->screen_w;
+            currentmode->screen_w = currentmode->screen_h;
+            currentmode->screen_h = height;
         }
 
         switch ([UIApplication sharedApplication].statusBarOrientation) {

--- a/src/video/uikit/SDL_uikitwindow.m
+++ b/src/video/uikit/SDL_uikitwindow.m
@@ -177,7 +177,7 @@ int UIKit_CreateWindow(_THIS, SDL_Window *window)
             const SDL_DisplayMode *bestmode = NULL;
             for (i = display->num_display_modes; i >= 0; i--) {
                 const SDL_DisplayMode *mode = &display->display_modes[i];
-                if ((mode->w >= window->w) && (mode->h >= window->h)) {
+                if ((mode->screen_w >= window->w) && (mode->screen_h >= window->h)) {
                     bestmode = mode;
                 }
             }

--- a/src/video/vita/SDL_vitavideo.c
+++ b/src/video/vita/SDL_vitavideo.c
@@ -180,45 +180,41 @@ VideoBootStrap VITA_bootstrap = {
 /*****************************************************************************/
 int VITA_VideoInit(_THIS)
 {
-    SDL_VideoDisplay display;
-    SDL_DisplayMode current_mode;
+    SDL_DisplayMode mode;
 #if defined(SDL_VIDEO_VITA_PVR)
     char *res = SDL_getenv("VITA_RESOLUTION");
 #endif
-    SDL_zero(current_mode);
+    SDL_zero(mode);
 
 #if defined(SDL_VIDEO_VITA_PVR)
     if (res) {
         /* 1088i for PSTV (Or Sharpscale) */
         if (!SDL_strncmp(res, "1080", 4)) {
-            current_mode.w = 1920;
-            current_mode.h = 1088;
+            mode.pixel_w = 1920;
+            mode.pixel_h = 1088;
         }
         /* 725p for PSTV (Or Sharpscale) */
         else if (!SDL_strncmp(res, "720", 3)) {
-            current_mode.w = 1280;
-            current_mode.h = 725;
+            mode.pixel_w = 1280;
+            mode.pixel_h = 725;
         }
     }
     /* 544p */
     else {
 #endif
-        current_mode.w = 960;
-        current_mode.h = 544;
+        mode.pixel_w = 960;
+        mode.pixel_h = 544;
 #if defined(SDL_VIDEO_VITA_PVR)
     }
 #endif
 
-    current_mode.refresh_rate = 60.0f;
+    mode.refresh_rate = 60.0f;
 
     /* 32 bpp for default */
-    current_mode.format = SDL_PIXELFORMAT_ABGR8888;
+    mode.format = SDL_PIXELFORMAT_ABGR8888;
 
-    SDL_zero(display);
-    display.desktop_mode = current_mode;
-    display.current_mode = current_mode;
+    SDL_AddBasicVideoDisplay(&mode);
 
-    SDL_AddVideoDisplay(&display, SDL_FALSE);
     VITA_InitTouch();
     VITA_InitKeyboard();
     VITA_InitMouse();

--- a/src/video/vivante/SDL_vivantevideo.c
+++ b/src/video/vivante/SDL_vivantevideo.c
@@ -125,7 +125,7 @@ static int VIVANTE_AddVideoDisplays(_THIS)
 {
     SDL_VideoData *videodata = _this->driverdata;
     SDL_VideoDisplay display;
-    SDL_DisplayMode current_mode;
+    SDL_DisplayMode mode;
     SDL_DisplayData *data;
     int pitch = 0, bpp = 0;
     unsigned long pixels = 0;
@@ -135,33 +135,33 @@ static int VIVANTE_AddVideoDisplays(_THIS)
         return SDL_OutOfMemory();
     }
 
-    SDL_zero(current_mode);
+    SDL_zero(mode);
 #if SDL_VIDEO_DRIVER_VIVANTE_VDK
     data->native_display = vdkGetDisplay(videodata->vdk_private);
 
-    vdkGetDisplayInfo(data->native_display, &current_mode.w, &current_mode.h, &pixels, &pitch, &bpp);
+    vdkGetDisplayInfo(data->native_display, &mode.pixel_w, &mode.pixel_h, &pixels, &pitch, &bpp);
 #else
     data->native_display = videodata->fbGetDisplayByIndex(0);
 
-    videodata->fbGetDisplayInfo(data->native_display, &current_mode.w, &current_mode.h, &pixels, &pitch, &bpp);
+    videodata->fbGetDisplayInfo(data->native_display, &mode.pixel_w, &mode.pixel_h, &pixels, &pitch, &bpp);
 #endif /* SDL_VIDEO_DRIVER_VIVANTE_VDK */
 
     switch (bpp) {
     default: /* Is another format used? */
     case 32:
-        current_mode.format = SDL_PIXELFORMAT_ARGB8888;
+        mode.format = SDL_PIXELFORMAT_ARGB8888;
         break;
     case 16:
-        current_mode.format = SDL_PIXELFORMAT_RGB565;
+        mode.format = SDL_PIXELFORMAT_RGB565;
         break;
     }
     /* FIXME: How do we query refresh rate? */
-    current_mode.refresh_rate = 60.0f;
+    mode.refresh_rate = 60.0f;
 
     SDL_zero(display);
     display.name = VIVANTE_GetDisplayName(_this);
-    display.desktop_mode = current_mode;
-    display.current_mode = current_mode;
+    display.desktop_mode = mode;
+    display.current_mode = mode;
     display.driverdata = data;
     SDL_AddVideoDisplay(&display, SDL_FALSE);
     return 0;

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -422,17 +422,17 @@ static void AddEmulatedModes(SDL_VideoDisplay *dpy, SDL_bool rot_90)
         mode.display_scale = 1.0f;
 
         if (rot_90) {
-            mode.w = mode_list[i].h;
-            mode.h = mode_list[i].w;
+            mode.pixel_w = mode_list[i].h;
+            mode.pixel_h = mode_list[i].w;
         } else {
-            mode.w = mode_list[i].w;
-            mode.h = mode_list[i].h;
+            mode.pixel_w = mode_list[i].w;
+            mode.pixel_h = mode_list[i].h;
         }
 
         /* Only add modes that are smaller than the native mode. */
-        if ((mode.w < native_width && mode.h < native_height) ||
-            (mode.w < native_width && mode.h == native_height) ||
-            (mode.w == native_width && mode.h < native_height)) {
+        if ((mode.pixel_w < native_width && mode.pixel_h < native_height) ||
+            (mode.pixel_w < native_width && mode.pixel_h == native_height) ||
+            (mode.pixel_w == native_width && mode.pixel_h < native_height)) {
             SDL_AddDisplayMode(dpy, &mode);
         }
     }
@@ -565,11 +565,11 @@ static void display_handle_done(void *data,
     native_mode.format = SDL_PIXELFORMAT_RGB888;
 
     if (driverdata->transform & WL_OUTPUT_TRANSFORM_90) {
-        native_mode.w = driverdata->native_height;
-        native_mode.h = driverdata->native_width;
+        native_mode.pixel_w = driverdata->native_height;
+        native_mode.pixel_h = driverdata->native_width;
     } else {
-        native_mode.w = driverdata->native_width;
-        native_mode.h = driverdata->native_height;
+        native_mode.pixel_w = driverdata->native_width;
+        native_mode.pixel_h = driverdata->native_height;
     }
     native_mode.display_scale = 1.0f;
     native_mode.refresh_rate = ((100 * driverdata->refresh) / 1000) / 100.0f; /* mHz to Hz */
@@ -590,11 +590,11 @@ static void display_handle_done(void *data,
 
     /* xdg-output dimensions are already transformed, so no need to rotate. */
     if (driverdata->has_logical_size || !(driverdata->transform & WL_OUTPUT_TRANSFORM_90)) {
-        desktop_mode.w = driverdata->width;
-        desktop_mode.h = driverdata->height;
+        desktop_mode.pixel_w = driverdata->width;
+        desktop_mode.pixel_h = driverdata->height;
     } else {
-        desktop_mode.w = driverdata->height;
-        desktop_mode.h = driverdata->width;
+        desktop_mode.pixel_w = driverdata->height;
+        desktop_mode.pixel_h = driverdata->width;
     }
     desktop_mode.display_scale = driverdata->scale_factor;
     desktop_mode.refresh_rate = ((100 * driverdata->refresh) / 1000) / 100.0f; /* mHz to Hz */
@@ -976,8 +976,8 @@ static int Wayland_GetDisplayBounds(_THIS, SDL_VideoDisplay *display, SDL_Rect *
     SDL_WaylandOutputData *driverdata = (SDL_WaylandOutputData *)display->driverdata;
     rect->x = driverdata->x;
     rect->y = driverdata->y;
-    rect->w = display->current_mode.w;
-    rect->h = display->current_mode.h;
+    rect->w = display->current_mode.screen_w;
+    rect->h = display->current_mode.screen_h;
     return 0;
 }
 

--- a/src/video/windows/SDL_windowsmodes.c
+++ b/src/video/windows/SDL_windowsmodes.c
@@ -38,9 +38,7 @@ static void WIN_UpdateDisplayMode(_THIS, LPCWSTR deviceName, DWORD index, SDL_Di
     SDL_DisplayModeData *data = (SDL_DisplayModeData *)mode->driverdata;
     HDC hdc;
 
-    data->DeviceMode.dmFields =
-        (DM_BITSPERPEL | DM_PELSWIDTH | DM_PELSHEIGHT | DM_DISPLAYFREQUENCY |
-         DM_DISPLAYFLAGS);
+    data->DeviceMode.dmFields = (DM_BITSPERPEL | DM_PELSWIDTH | DM_PELSHEIGHT | DM_DISPLAYFREQUENCY | DM_DISPLAYFLAGS);
 
     /* NOLINTNEXTLINE(bugprone-assignment-in-if-condition): No simple way to extract the assignment */
     if (index == ENUM_CURRENT_SETTINGS && (hdc = CreateDC(deviceName, NULL, NULL, NULL)) != NULL) {
@@ -180,14 +178,14 @@ static SDL_bool WIN_GetDisplayMode(_THIS, HMONITOR hMonitor, LPCWSTR deviceName,
     data->DeviceMode = devmode;
 
     mode->format = SDL_PIXELFORMAT_UNKNOWN;
-    mode->w = data->DeviceMode.dmPelsWidth;
-    mode->h = data->DeviceMode.dmPelsHeight;
+    mode->pixel_w = data->DeviceMode.dmPelsWidth;
+    mode->pixel_h = data->DeviceMode.dmPelsHeight;
     mode->refresh_rate = WIN_GetRefreshRate(&data->DeviceMode);
 
     if (index == ENUM_CURRENT_SETTINGS && videodata->GetDpiForMonitor) {
         UINT hdpi_uint, vdpi_uint;
         if (videodata->GetDpiForMonitor(hMonitor, MDT_EFFECTIVE_DPI, &hdpi_uint, &vdpi_uint) == S_OK) {
-            mode->display_scale = (float)hdpi_uint / 96;
+            mode->display_scale = hdpi_uint / 96.0f;
         }
     }
 

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -423,19 +423,14 @@ int WIN_VideoInit(_THIS)
 #if defined(__XBOXONE__) || defined(__XBOXSERIES__)
     /* For Xbox, we just need to create the single display */
     {
-        SDL_VideoDisplay display;
-        SDL_DisplayMode current_mode;
+        SDL_DisplayMode mode;
 
-        SDL_zero(current_mode);
-        D3D12_XBOX_GetResolution(&current_mode.w, &current_mode.h);
-        current_mode.refresh_rate = 60.0f;
-        current_mode.format = SDL_PIXELFORMAT_ARGB8888;
+        SDL_zero(mode);
+        D3D12_XBOX_GetResolution(&mode.pixel_w, &mode.pixel_h);
+        mode.refresh_rate = 60.0f;
+        mode.format = SDL_PIXELFORMAT_ARGB8888;
 
-        SDL_zero(display);
-        display.desktop_mode = current_mode;
-        display.current_mode = current_mode;
-
-        SDL_AddVideoDisplay(&display, SDL_FALSE);
+        SDL_AddBasicVideoDisplay(&mode);
     }
 #else /*!defined(__XBOXONE__) && !defined(__XBOXSERIES__)*/
     if (WIN_InitModes(_this) < 0) {

--- a/src/video/winrt/SDL_winrtvideo.cpp
+++ b/src/video/winrt/SDL_winrtvideo.cpp
@@ -253,8 +253,8 @@ extern "C" Uint32 D3D11_DXGIFormatToSDLPixelFormat(DXGI_FORMAT dxgiFormat);
 static void WINRT_DXGIModeToSDLDisplayMode(const DXGI_MODE_DESC *dxgiMode, SDL_DisplayMode *sdlMode)
 {
     SDL_zerop(sdlMode);
-    sdlMode->w = dxgiMode->Width;
-    sdlMode->h = dxgiMode->Height;
+    sdlMode->pixel_w = dxgiMode->Width;
+    sdlMode->pixel_h = dxgiMode->Height;
     sdlMode->refresh_rate = (((100 * dxgiMode->RefreshRate.Numerator) / dxgiMode->RefreshRate.Denominator) / 100.0f);
     sdlMode->format = D3D11_DXGIFormatToSDLPixelFormat(dxgiMode->Format);
 }
@@ -303,10 +303,9 @@ static int WINRT_AddDisplaysForOutput(_THIS, IDXGIAdapter1 *dxgiAdapter1, int ou
         SDL_DisplayMode mode;
         SDL_zero(mode);
         display.name = SDL_strdup("Windows Simulator / Terminal Services Display");
-        mode.w = (dxgiOutputDesc.DesktopCoordinates.right - dxgiOutputDesc.DesktopCoordinates.left);
-        mode.h = (dxgiOutputDesc.DesktopCoordinates.bottom - dxgiOutputDesc.DesktopCoordinates.top);
+        mode.pixel_w = (dxgiOutputDesc.DesktopCoordinates.right - dxgiOutputDesc.DesktopCoordinates.left);
+        mode.pixel_h = (dxgiOutputDesc.DesktopCoordinates.bottom - dxgiOutputDesc.DesktopCoordinates.top);
         mode.format = DXGI_FORMAT_B8G8R8A8_UNORM;
-        mode.refresh_rate = 0.0f; /* Display mode is unknown, so just fill in zero, as specified by SDL's header files */
         display.desktop_mode = mode;
         display.current_mode = mode;
         if (!SDL_AddDisplayMode(&display, &mode)) {
@@ -415,18 +414,23 @@ static int WINRT_AddDisplaysForAdapter(_THIS, IDXGIFactory2 *dxgiFactory2, int a
                 */
 
 #if (NTDDI_VERSION >= NTDDI_WIN10) || (SDL_WINRT_USE_APPLICATIONVIEW && WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP)
-                mode.w = WINRT_DIPS_TO_PHYSICAL_PIXELS(appView->VisibleBounds.Width);
-                mode.h = WINRT_DIPS_TO_PHYSICAL_PIXELS(appView->VisibleBounds.Height);
+                mode.pixel_w = WINRT_DIPS_TO_PHYSICAL_PIXELS(appView->VisibleBounds.Width);
+                mode.pixel_h = WINRT_DIPS_TO_PHYSICAL_PIXELS(appView->VisibleBounds.Height);
+                mode.screen_w = appView->VisibleBounds.Width;
+                mode.screen_h = appView->VisibleBounds.Height;
+                mode.display_scale = WINRT_DISPLAY_PROPERTY(LogicalDpi) / 96.0f;
 #else
                 /* On platform(s) that do not support VisibleBounds, such as Windows 8.1,
                    fall back to CoreWindow's Bounds property.
                 */
-                mode.w = WINRT_DIPS_TO_PHYSICAL_PIXELS(coreWin->Bounds.Width);
-                mode.h = WINRT_DIPS_TO_PHYSICAL_PIXELS(coreWin->Bounds.Height);
+                mode.pixel_w = WINRT_DIPS_TO_PHYSICAL_PIXELS(coreWin->Bounds.Width);
+                mode.pixel_h = WINRT_DIPS_TO_PHYSICAL_PIXELS(coreWin->Bounds.Height);
+                mode.screen_w = coreWin->Bounds.Width;
+                mode.screen_h = coreWin->Bounds.Height;
+                mode.display_scale = WINRT_DISPLAY_PROPERTY(LogicalDpi) / 96.0f;
 #endif
 
                 mode.format = DXGI_FORMAT_B8G8R8A8_UNORM;
-                mode.refresh_rate = 0.0f; /* Display mode is unknown, so just fill in zero, as specified by SDL's header files */
                 display.desktop_mode = mode;
                 display.current_mode = mode;
                 bool error = SDL_AddDisplayMode(&display, &mode) < 0 ||
@@ -532,7 +536,7 @@ WINRT_DetectWindowFlags(SDL_Window *window)
             }
 #endif
 
-            if (display->desktop_mode.w != w || display->desktop_mode.h != h) {
+            if (display->desktop_mode.pixel_w != w || display->desktop_mode.pixel_h != h) {
                 latestFlags |= SDL_WINDOW_MAXIMIZED;
             } else {
                 latestFlags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
@@ -701,12 +705,12 @@ int WINRT_CreateWindow(_THIS, SDL_Window *window)
            user choice of various things.  For now, just adapt the SDL_Window to
            whatever Windows set-up as the native-window's geometry.
         */
-        window->x = WINRT_DIPS_TO_PHYSICAL_PIXELS(data->coreWindow->Bounds.Left);
-        window->y = WINRT_DIPS_TO_PHYSICAL_PIXELS(data->coreWindow->Bounds.Top);
+        window->x = (int)SDL_lroundf(data->coreWindow->Bounds.Left);
+        window->y = (int)SDL_lroundf(data->coreWindow->Bounds.Top);
 #if NTDDI_VERSION < NTDDI_WIN10
         /* On WinRT 8.x / pre-Win10, just use the size we were given. */
-        window->w = WINRT_DIPS_TO_PHYSICAL_PIXELS(data->coreWindow->Bounds.Width);
-        window->h = WINRT_DIPS_TO_PHYSICAL_PIXELS(data->coreWindow->Bounds.Height);
+        window->w = (int)SDL_floorf(data->coreWindow->Bounds.Width);
+        window->h = (int)SDL_floorf(data->coreWindow->Bounds.Height);
 #else
         /* On Windows 10, we occasionally get control over window size.  For windowed
            mode apps, try this.
@@ -721,8 +725,8 @@ int WINRT_CreateWindow(_THIS, SDL_Window *window)
             /* We either weren't able to set the window size, or a request for
                fullscreen was made.  Get window-size info from the OS.
             */
-            window->w = WINRT_DIPS_TO_PHYSICAL_PIXELS(data->coreWindow->Bounds.Width);
-            window->h = WINRT_DIPS_TO_PHYSICAL_PIXELS(data->coreWindow->Bounds.Height);
+            window->w = (int)SDL_floorf(data->coreWindow->Bounds.Width);
+            window->h = (int)SDL_floorf(data->coreWindow->Bounds.Height);
         }
 #endif
 

--- a/src/video/x11/SDL_x11messagebox.c
+++ b/src/video/x11/SDL_x11messagebox.c
@@ -471,8 +471,8 @@ static int X11_MessageBoxCreateWindow(SDL_MessageBoxDataX11 *data)
         if ((dev) && (dev->displays) && (dev->num_displays > 0)) {
             const SDL_VideoDisplay *dpy = &dev->displays[0];
             const SDL_DisplayData *dpydata = (SDL_DisplayData *)dpy->driverdata;
-            x = dpydata->x + ((dpy->current_mode.w - data->dialog_width) / 2);
-            y = dpydata->y + ((dpy->current_mode.h - data->dialog_height) / 3);
+            x = dpydata->x + ((dpy->current_mode.pixel_w - data->dialog_width) / 2);
+            y = dpydata->y + ((dpy->current_mode.pixel_h - data->dialog_height) / 3);
         } else { /* oh well. This will misposition on a multi-head setup. Init first next time. */
             x = (DisplayWidth(display, data->screen) - data->dialog_width) / 2;
             y = (DisplayHeight(display, data->screen) - data->dialog_height) / 3;

--- a/src/video/x11/SDL_x11modes.c
+++ b/src/video/x11/SDL_x11modes.c
@@ -217,11 +217,11 @@ static SDL_bool SetXRandRModeInfo(Display *display, XRRScreenResources *res, RRC
             }
 
             if (rotation & (XRANDR_ROTATION_LEFT | XRANDR_ROTATION_RIGHT)) {
-                mode->w = info->height;
-                mode->h = info->width;
+                mode->pixel_w = info->height;
+                mode->pixel_h = info->width;
             } else {
-                mode->w = info->width;
-                mode->h = info->height;
+                mode->pixel_w = info->width;
+                mode->pixel_h = info->height;
             }
             mode->refresh_rate = CalculateXRandRRefreshRate(info);
             ((SDL_DisplayModeData *)mode->driverdata)->xrandr_mode = modeID;
@@ -343,8 +343,8 @@ static int X11_AddXRandRDisplay(_THIS, Display *dpy, int screen, RROutput output
 
     SDL_zero(mode);
     modeID = crtc->mode;
-    mode.w = crtc->width;
-    mode.h = crtc->height;
+    mode.pixel_w = crtc->width;
+    mode.pixel_h = crtc->height;
     mode.format = pixelformat;
 
     display_x = crtc->x;
@@ -369,9 +369,9 @@ static int X11_AddXRandRDisplay(_THIS, Display *dpy, int screen, RROutput output
     displaydata->screen = screen;
     displaydata->visual = vinfo.visual;
     displaydata->depth = vinfo.depth;
-    displaydata->hdpi = display_mm_width ? (((float)mode.w) * 25.4f / display_mm_width) : 0.0f;
-    displaydata->vdpi = display_mm_height ? (((float)mode.h) * 25.4f / display_mm_height) : 0.0f;
-    displaydata->ddpi = SDL_ComputeDiagonalDPI(mode.w, mode.h, ((float)display_mm_width) / 25.4f, ((float)display_mm_height) / 25.4f);
+    displaydata->hdpi = display_mm_width ? (((float)mode.pixel_w) * 25.4f / display_mm_width) : 0.0f;
+    displaydata->vdpi = display_mm_height ? (((float)mode.pixel_h) * 25.4f / display_mm_height) : 0.0f;
+    displaydata->ddpi = SDL_ComputeDiagonalDPI(mode.pixel_w, mode.pixel_h, ((float)display_mm_width) / 25.4f, ((float)display_mm_height) / 25.4f);
     displaydata->scanline_pad = scanline_pad;
     displaydata->x = display_x;
     displaydata->y = display_y;
@@ -574,8 +574,8 @@ static int X11_InitModes_StdXlib(_THIS)
     }
 
     SDL_zero(mode);
-    mode.w = WidthOfScreen(screen);
-    mode.h = HeightOfScreen(screen);
+    mode.pixel_w = WidthOfScreen(screen);
+    mode.pixel_h = HeightOfScreen(screen);
     mode.format = pixelformat;
 
     displaydata = (SDL_DisplayData *)SDL_calloc(1, sizeof(*displaydata));
@@ -596,9 +596,9 @@ static int X11_InitModes_StdXlib(_THIS)
     displaydata->screen = default_screen;
     displaydata->visual = vinfo.visual;
     displaydata->depth = vinfo.depth;
-    displaydata->hdpi = display_mm_width ? (((float)mode.w) * 25.4f / display_mm_width) : 0.0f;
-    displaydata->vdpi = display_mm_height ? (((float)mode.h) * 25.4f / display_mm_height) : 0.0f;
-    displaydata->ddpi = SDL_ComputeDiagonalDPI(mode.w, mode.h, ((float)display_mm_width) / 25.4f, ((float)display_mm_height) / 25.4f);
+    displaydata->hdpi = display_mm_width ? (((float)mode.pixel_w) * 25.4f / display_mm_width) : 0.0f;
+    displaydata->vdpi = display_mm_height ? (((float)mode.pixel_h) * 25.4f / display_mm_height) : 0.0f;
+    displaydata->ddpi = SDL_ComputeDiagonalDPI(mode.pixel_w, mode.pixel_h, ((float)display_mm_width) / 25.4f, ((float)display_mm_height) / 25.4f);
 
     xft_dpi = GetXftDPI(dpy);
     if (xft_dpi > 0) {
@@ -783,8 +783,8 @@ int X11_SetDisplayMode(_THIS, SDL_VideoDisplay *sdl_display, SDL_DisplayMode *mo
             goto ungrabServer;
         }
 
-        mm_width = mode->w * DisplayWidthMM(display, data->screen) / DisplayWidth(display, data->screen);
-        mm_height = mode->h * DisplayHeightMM(display, data->screen) / DisplayHeight(display, data->screen);
+        mm_width = mode->pixel_w * DisplayWidthMM(display, data->screen) / DisplayWidth(display, data->screen);
+        mm_height = mode->pixel_h * DisplayHeightMM(display, data->screen) / DisplayHeight(display, data->screen);
 
         /* !!! FIXME: this can get into a problem scenario when a window is
            bigger than a physical monitor in a configuration where one screen
@@ -795,7 +795,7 @@ int X11_SetDisplayMode(_THIS, SDL_VideoDisplay *sdl_display, SDL_DisplayMode *mo
            crashing */
         X11_XSync(display, False);
         PreXRRSetScreenSizeErrorHandler = X11_XSetErrorHandler(SDL_XRRSetScreenSizeErrHandler);
-        X11_XRRSetScreenSize(display, RootWindow(display, data->screen), mode->w, mode->h, mm_width, mm_height);
+        X11_XRRSetScreenSize(display, RootWindow(display, data->screen), mode->pixel_w, mode->pixel_h, mm_width, mm_height);
         X11_XSync(display, False);
         X11_XSetErrorHandler(PreXRRSetScreenSizeErrorHandler);
 
@@ -831,8 +831,8 @@ int X11_GetDisplayBounds(_THIS, SDL_VideoDisplay *sdl_display, SDL_Rect *rect)
 
     rect->x = data->x;
     rect->y = data->y;
-    rect->w = sdl_display->current_mode.w;
-    rect->h = sdl_display->current_mode.h;
+    rect->w = sdl_display->current_mode.screen_w;
+    rect->h = sdl_display->current_mode.screen_h;
 
     return 0;
 }

--- a/test/testautomation_video.c
+++ b/test/testautomation_video.c
@@ -425,8 +425,9 @@ int video_getClosestDisplayModeCurrentResolution(void *arg)
         }
 
         /* Set the desired resolution equals to current resolution */
-        target.w = current.w;
-        target.h = current.h;
+        SDL_zero(target);
+        target.pixel_w = current.pixel_w;
+        target.pixel_h = current.pixel_h;
         for (variation = 0; variation < 8; variation++) {
             /* Vary constraints on other query parameters */
             target.format = (variation & 1) ? current.format : 0;
@@ -439,11 +440,11 @@ int video_getClosestDisplayModeCurrentResolution(void *arg)
             SDLTest_Assert(dResult != NULL, "Verify returned value is not NULL");
 
             /* Check that one gets the current resolution back again */
-            SDLTest_AssertCheck(closest.w == current.w, "Verify returned width matches current width; expected: %d, got: %d", current.w, closest.w);
-            SDLTest_AssertCheck(closest.h == current.h, "Verify returned height matches current height; expected: %d, got: %d", current.h, closest.h);
+            SDLTest_AssertCheck(closest.pixel_w == current.pixel_w, "Verify returned width matches current width; expected: %d, got: %d", current.pixel_w, closest.pixel_w);
+            SDLTest_AssertCheck(closest.pixel_h == current.pixel_h, "Verify returned height matches current height; expected: %d, got: %d", current.pixel_h, closest.pixel_h);
             /* NOLINTBEGIN(clang-analyzer-core.NullDereference): Checked earlier for NULL */
-            SDLTest_AssertCheck(closest.w == dResult->w, "Verify return value matches assigned value; expected: %d, got: %d", closest.w, dResult->w);
-            SDLTest_AssertCheck(closest.h == dResult->h, "Verify return value matches assigned value; expected: %d, got: %d", closest.h, dResult->h);
+            SDLTest_AssertCheck(closest.pixel_w == dResult->pixel_w, "Verify return value matches assigned value; expected: %d, got: %d", closest.pixel_w, dResult->pixel_w);
+            SDLTest_AssertCheck(closest.pixel_h == dResult->pixel_h, "Verify return value matches assigned value; expected: %d, got: %d", closest.pixel_h, dResult->pixel_h);
             /* NOLINTEND(clang-analyzer-core.NullDereference) */
         }
     }
@@ -473,11 +474,11 @@ int video_getClosestDisplayModeRandomResolution(void *arg)
         for (variation = 0; variation < 16; variation++) {
 
             /* Set random constraints */
-            target.w = (variation & 1) ? SDLTest_RandomIntegerInRange(1, 4096) : 0;
-            target.h = (variation & 2) ? SDLTest_RandomIntegerInRange(1, 4096) : 0;
+            SDL_zero(target);
+            target.pixel_w = (variation & 1) ? SDLTest_RandomIntegerInRange(1, 4096) : 0;
+            target.pixel_h = (variation & 2) ? SDLTest_RandomIntegerInRange(1, 4096) : 0;
             target.format = (variation & 4) ? SDLTest_RandomIntegerInRange(1, 10) : 0;
             target.refresh_rate = (variation & 8) ? (float)SDLTest_RandomIntegerInRange(25, 120) : 0.0f;
-            target.driverdata = 0;
 
             /* Make call; may or may not find anything, so don't validate any further */
             SDL_GetClosestDisplayMode(i, &target, &closest);
@@ -501,8 +502,8 @@ int video_getWindowDisplayMode(void *arg)
     int result;
 
     /* Invalidate part of the mode content so we can check values later */
-    mode.w = -1;
-    mode.h = -1;
+    mode.pixel_w = -1;
+    mode.pixel_h = -1;
     mode.refresh_rate = -1.0f;
 
     /* Call against new test window */
@@ -511,8 +512,8 @@ int video_getWindowDisplayMode(void *arg)
         result = SDL_GetWindowDisplayMode(window, &mode);
         SDLTest_AssertPass("Call to SDL_GetWindowDisplayMode()");
         SDLTest_AssertCheck(result == 0, "Validate result value; expected: 0, got: %d", result);
-        SDLTest_AssertCheck(mode.w > 0, "Validate mode.w content; expected: >0, got: %d", mode.w);
-        SDLTest_AssertCheck(mode.h > 0, "Validate mode.h content; expected: >0, got: %d", mode.h);
+        SDLTest_AssertCheck(mode.pixel_w > 0, "Validate mode.w content; expected: >0, got: %d", mode.pixel_w);
+        SDLTest_AssertCheck(mode.pixel_h > 0, "Validate mode.h content; expected: >0, got: %d", mode.pixel_h);
         SDLTest_AssertCheck(mode.refresh_rate > 0.0f, "Validate mode.refresh_rate content; expected: >0, got: %g", mode.refresh_rate);
     }
 

--- a/test/testdisplayinfo.c
+++ b/test/testdisplayinfo.c
@@ -24,9 +24,9 @@ print_mode(const char *prefix, const SDL_DisplayMode *mode)
         return;
     }
 
-    SDL_Log("%s: fmt=%s w=%d h=%d refresh=%gHz\n",
+    SDL_Log("%s: fmt=%s w=%d h=%d scale=%d%% refresh=%gHz\n",
             prefix, SDL_GetPixelFormatName(mode->format),
-            mode->w, mode->h, mode->refresh_rate);
+            mode->pixel_w, mode->pixel_h, (int)(mode->display_scale * 100.0f), mode->refresh_rate);
 }
 
 int main(int argc, char *argv[])

--- a/test/testwm.c
+++ b/test/testwm.c
@@ -108,7 +108,7 @@ draw_modes_menu(SDL_Window *window, SDL_Renderer *renderer, SDL_FRect viewport)
         }
 
         (void)SDL_snprintf(text, sizeof text, "%d: %dx%d@%gHz",
-                           i, mode.w, mode.h, mode.refresh_rate);
+                           i, mode.pixel_w, mode.pixel_h, mode.refresh_rate);
 
         /* Update column width */
         text_length = (int)SDL_strlen(text);


### PR DESCRIPTION
SDL_DisplayMode now includes the pixel size, the screen size and the relationship between the two. For example, a 4K display at 200% scale could have a pixel size of 3840x2160, a screen size of 1920x1080, and a display scale of 2.0.