### PR TITLE
macOS: include @1x (low-dpi) display modes with the same point-size as @2x (high-dpi) modes

### DIFF
--- a/src/video/cocoa/SDL_cocoamodes.m
+++ b/src/video/cocoa/SDL_cocoamodes.m
@@ -204,14 +204,6 @@ static SDL_bool GetDisplayMode(_THIS, CGDisplayModeRef vidmode, SDL_bool vidmode
             otherformat = GetDisplayModePixelFormat(othermode);
             otherGUI = CGDisplayModeIsUsableForDesktopGUI(othermode);
 
-            /* Ignore this mode if it's low-dpi (@1x) and we have a high-dpi
-             * mode in the list with the same size in points.
-             */
-            if (width == pixelW && height == pixelH && width == otherW && height == otherH && refreshrate == otherrefresh && format == otherformat && (otherpixelW != otherW || otherpixelH != otherH)) {
-                CFRelease(modes);
-                return SDL_FALSE;
-            }
-
             /* Ignore this mode if it's interlaced and there's a non-interlaced
              * mode in the list with the same properties.
              */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Previously they were discarded because SDL didn't expose enough information for apps to differentiate between a low-dpi and high-dpi mode which had the same size in DPI-scaled points (#3025 has some discussion about that). Now the information is available in SDL_DisplayMode.

I'm not to sure how useful this change is in practice, so I wonder if anyone else has opinions about it.

## Existing Issue(s)
Fixes #3025.
