### PR TITLE
SDL2 backport of macOS messagebox fix (#6991)

### DIFF
--- a/src/video/cocoa/SDL_cocoamessagebox.m
+++ b/src/video/cocoa/SDL_cocoamessagebox.m
@@ -32,8 +32,7 @@
     NSInteger clicked;
     NSWindow *nswindow;
 }
-- (id) initWithParentWindow:(SDL_Window *)window;
-- (void) alertDidEnd:(NSAlert *)alert returnCode:(NSInteger)returnCode contextInfo:(void *)contextInfo;
+- (id)initWithParentWindow:(SDL_Window *)window;
 @end
 
 @implementation SDLMessageBoxPresenter
@@ -57,35 +56,16 @@
 - (void)showAlert:(NSAlert*)alert
 {
     if (nswindow) {
-#ifdef MAC_OS_X_VERSION_10_9
-        if ([alert respondsToSelector:@selector(beginSheetModalForWindow:completionHandler:)]) {
-            [alert beginSheetModalForWindow:nswindow completionHandler:^(NSModalResponse returnCode) {
-                self->clicked = returnCode;
-            }];
-        } else
-#endif
-        {
-#if MAC_OS_X_VERSION_MIN_REQUIRED < 1090
-            [alert beginSheetModalForWindow:nswindow modalDelegate:self didEndSelector:@selector(alertDidEnd:returnCode:contextInfo:) contextInfo:nil];
-#endif
-        }
-
-        while (clicked < 0) {
-            SDL_PumpEvents();
-            SDL_Delay(100);
-        }
-
+        [alert beginSheetModalForWindow:nswindow
+                      completionHandler:^(NSModalResponse returnCode) {
+                        [NSApp stopModalWithCode:returnCode];
+                      }];
+        clicked = [NSApp runModalForWindow:nswindow];
         nswindow = nil;
     } else {
         clicked = [alert runModal];
     }
 }
-
-- (void) alertDidEnd:(NSAlert *)alert returnCode:(NSInteger)returnCode contextInfo:(void *)contextInfo
-{
-    clicked = returnCode;
-}
-
 @end
 
 


### PR DESCRIPTION
## Description

SDL2 MessageBoxes on macOS have broken VoiceOver support (#6948), this change fixes it. It was already merged into the main branch via #6991.

SDL2 officially dropped support for pre-10.9 macOS systems last year, but this might be the first change to SDL2 which removes runtime code support for that. If it's at all important to keep we can change this commit a bit to do so.

## Existing Issue(s)
#6948
