### PR TITLE
Fixes for building on Mac with OpenGL disabled.

### DIFF
--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -919,11 +919,16 @@ static void Cocoa_UpdateClipCursor(SDL_Window *window)
 - (void)windowDidChangeScreen:(NSNotification *)aNotification
 {
     /*printf("WINDOWDIDCHANGESCREEN\n");*/
+
+#if SDL_VIDEO_OPENGL
+
     if (_data && _data.nscontexts) {
         for (SDLOpenGLContext *context in _data.nscontexts) {
             [context movedToNewScreen];
         }
     }
+
+#endif /* SDL_VIDEO_OPENGL */
 }
 
 - (void)windowWillEnterFullScreen:(NSNotification *)aNotification
@@ -2316,7 +2321,12 @@ void Cocoa_DestroyWindow(_THIS, SDL_Window *window)
         SDL_WindowData *data = (SDL_WindowData *)CFBridgingRelease(window->driverdata);
 
         if (data) {
+#if SDL_VIDEO_OPENGL
+
             NSArray *contexts;
+
+#endif /* SDL_VIDEO_OPENGL */
+
             if ([data.listener isInFullscreenSpace]) {
                 [NSMenu setMenuBarVisible:YES];
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Code that referenced OpenGL access was unprotected with defines to determine whether OpenGL is enabled.

## Description
<!--- Describe your changes in detail -->
Added #if checks for SDL_VIDEO_OPENGL around code that triggered compiler errors or warnings.
