### PR TITLE
migration: replace SDL_DisplayMode w and h

### DIFF
--- a/build-scripts/SDL_migration.cocci
+++ b/build-scripts/SDL_migration.cocci
@@ -2334,3 +2334,23 @@ expression e;
 @@
 - SDL_WINDOW_INPUT_GRABBED
 + SDL_WINDOW_MOUSE_GRABBED
+@@
+SDL_DisplayMode *e;
+@@
+(
+- e->w
++ e->screen_w
+|
+- e->h
++ e->screen_h
+)
+@@
+SDL_DisplayMode e;
+@@
+(
+- e.w
++ e.screen_w
+|
+- e.h
++ e.screen_h
+)


### PR DESCRIPTION
Update the migration script, so that:

`SDL_DisplayMode.w` or `h` gets replaced by `screen_w / display_scale` or `screen_h / display_scale`