### PR TITLE
iOS: fix the desktop display mode's display scale property.

### DIFF
--- a/src/video/uikit/SDL_uikitmodes.m
+++ b/src/video/uikit/SDL_uikitmodes.m
@@ -339,7 +339,7 @@ int UIKit_AddDisplay(UIScreen *uiscreen, SDL_bool send_event)
     SDL_zero(mode);
     mode.pixel_w = (int)size.width;
     mode.pixel_h = (int)size.height;
-    mode.display_scale = uiscreen.scale;
+    mode.display_scale = uiscreen.nativeScale;
     mode.format = SDL_PIXELFORMAT_ABGR8888;
     mode.refresh_rate = UIKit_GetDisplayModeRefreshRate(uiscreen);
 


### PR DESCRIPTION
## Description
The display scale of other display modes were fixed in my previous PR, but I missed this line in that commit.

## Existing Issue(s)
None.
