### PR TITLE
wayland: Check that all required dynamic symbols have been successful…

### DIFF
--- a/src/video/wayland/SDL_waylanddyn.c
+++ b/src/video/wayland/SDL_waylanddyn.c
@@ -152,8 +152,11 @@ int SDL_WAYLAND_LoadSymbols(void)
 #define SDL_WAYLAND_INTERFACE(iface)        WAYLAND_##iface = (struct wl_interface *)WAYLAND_GetSym(#iface, thismod, SDL_TRUE);
 #include "SDL_waylandsym.h"
 
-        if (SDL_WAYLAND_HAVE_WAYLAND_CLIENT) {
-            /* all required symbols loaded. */
+        if (SDL_WAYLAND_HAVE_WAYLAND_CLIENT &&
+            SDL_WAYLAND_HAVE_WAYLAND_CURSOR &&
+            SDL_WAYLAND_HAVE_WAYLAND_EGL &&
+            SDL_WAYLAND_HAVE_WAYLAND_XKB) {
+            /* All required symbols loaded, only libdecor is optional. */
             SDL_ClearError();
         } else {
             /* in case something got loaded... */


### PR DESCRIPTION
…ly resolved at init time

Ensure that all hard dependencies are resolved when dynamically loading the libraries required for the Wayland backend and fail gracefully if a required module was not initialized successfully.

These are hard dependencies for building the Wayland backend and should be a package dependency of whatever installed SDL to begin with, so there's nothing to be done but fail gracefully if something is missing, probably because a dependency was set incorrectly or someone is managing things manually.

Fixes #7180