### PR TITLE
libwayland-egl is a hard requirement for wayland backend of SDL

### DIFF
--- a/src/video/wayland/SDL_waylanddyn.c
+++ b/src/video/wayland/SDL_waylanddyn.c
@@ -153,7 +153,7 @@ int SDL_WAYLAND_LoadSymbols(void)
 #define SDL_WAYLAND_INTERFACE(iface)        WAYLAND_##iface = (struct wl_interface *)WAYLAND_GetSym(#iface, thismod, SDL_TRUE);
 #include "SDL_waylandsym.h"
 
-        if (SDL_WAYLAND_HAVE_WAYLAND_CLIENT) {
+        if (SDL_WAYLAND_HAVE_WAYLAND_CLIENT && SDL_WAYLAND_HAVE_WAYLAND_EGL) {
             /* all required symbols loaded. */
             SDL_ClearError();
         } else {


### PR DESCRIPTION
Fixes https://github.com/libsdl-org/SDL/issues/7180

<!--- Provide a general summary of your changes in the Title above -->

## Description

Do not initialize the wayland SDL2 driver when libwayland-egl is not available.

Tested with:
```
$ sudo dnf build-dep SDL2
$ mkdir build && cd build && ../configure --enable-video-wayland -- && make -j32 && cd ..
$ gcc tutorial1.c -o tutorial1 -lGL $(sdl2-config --cflags --libs)
$ sudo dnf remove libwayland-egl
[1]    80941 segmentation fault (core dumped)  ./tutorial1
$ LD_LIBRARY_PATH=./build/build/.libs ./tutorial1
$ SDL_VIDEODRIVER=wayland LD_LIBRARY_PATH=./build/build/.libs  ./tutorial1
Unable to initialize SDL: wayland not available
$ sudo dnf install libwayland-egl
$ SDL_VIDEODRIVER=wayland LD_LIBRARY_PATH=./build/build/.libs ./tutorial1
$
```

It no longer crashes with the patched SDL, and if wayland is explicitly chosen it gives an appropriate error message.
When 'libwayland-egl' is installed the wayland driver is available again.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/7180
