### PR TITLE
Fixes for Android builds

### DIFF
--- a/include/SDL3/SDL_assert.h
+++ b/include/SDL3/SDL_assert.h
@@ -51,6 +51,9 @@ assert can have unique static variables associated with it.
 /* Don't include intrin.h here because it contains C++ code */
     extern void __cdecl __debugbreak(void);
     #define SDL_TriggerBreakpoint() __debugbreak()
+#elif defined(ANDROID)
+    #include <assert.h>
+    #define SDL_TriggerBreakpoint() assert(0)
 #elif SDL_HAS_BUILTIN(__builtin_debugtrap)
     #define SDL_TriggerBreakpoint() __builtin_debugtrap()
 #elif (defined(__GNUC__) || defined(__clang__)) && (defined(__i386__) || defined(__x86_64__))

--- a/src/video/android/SDL_androidvideo.c
+++ b/src/video/android/SDL_androidvideo.c
@@ -293,6 +293,7 @@ void Android_SendResize(SDL_Window *window)
         int w, h;
         SDL_VideoDisplay *display = SDL_GetVideoDisplayForWindow(window);
         SDL_DisplayMode current_mode;
+        SDL_zero(current_mode);
 
         current_mode.format = Android_ScreenFormat;
         current_mode.pixel_w = Android_DeviceWidth;


### PR DESCRIPTION
With these fixes my sample Android app runs properly:

## Description
- Ensure there is not garbage values in `current_mode`.
- On my device, hitting the `SDL_assert` will terminate the app; unlike with `assert(0)` from `assert.h` Android Studio triggers the breakpoint as expected.

## Existing Issue(s)
- N/A
