### PR TITLE
video: Return the display ID when the window is fully enclosed

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1215,7 +1215,7 @@ static SDL_DisplayID GetDisplayForRect(int x, int y, int w, int h)
 
             /* Check if the window is fully enclosed */
             if (SDL_GetRectEnclosingPoints(&center, 1, &display_rect, NULL)) {
-                return i;
+                return display->id;
             }
 
             /* Snap window center to the display rect */


### PR DESCRIPTION
If the window was fully enclosed, GetDisplayForRect() would return the index of the display ID in the array instead of the display ID itself. Return the display ID itself.
