### PR TITLE
video: Finalize the new video mode before the duplicate check

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -866,13 +866,18 @@ SDL_DisplayOrientation SDL_GetDisplayOrientation(SDL_DisplayID displayID)
 SDL_bool SDL_AddDisplayMode(SDL_VideoDisplay *display, const SDL_DisplayMode *mode)
 {
     SDL_DisplayMode *modes;
+    SDL_DisplayMode new_mode;
     int i, nmodes;
+
+    /* Finalize the parameters of the new mode first so duplicate detection will work */
+    new_mode = *mode;
+    SDL_FinalizeDisplayMode(&new_mode);
 
     /* Make sure we don't already have the mode in the list */
     modes = display->display_modes;
     nmodes = display->num_display_modes;
     for (i = 0; i < nmodes; ++i) {
-        if (cmpmodes(mode, &modes[i]) == 0) {
+        if (cmpmodes(&new_mode, &modes[i]) == 0) {
             return SDL_FALSE;
         }
     }
@@ -886,8 +891,7 @@ SDL_bool SDL_AddDisplayMode(SDL_VideoDisplay *display, const SDL_DisplayMode *mo
         display->display_modes = modes;
         display->max_display_modes += 32;
     }
-    modes[nmodes] = *mode;
-    SDL_FinalizeDisplayMode(&modes[nmodes]);
+    modes[nmodes] = new_mode;
     display->num_display_modes++;
 
     /* Re-sort video modes */


### PR DESCRIPTION
The new mode needs to be finalized before conducting the duplicate check, or it is possible to insert duplicate modes in the list by using different screen and pixel dimensions that ultimately evaluate to the same final values.

For example (added in order):

Mode 1:
- Pixels (10x10)
- Screen (0x0)
- Scale 1.0

Mode 2: 
- Pixels (0x0)
- Screen (10x10)
- Scale 1.0

These are identical once finalized, but will show up twice in the mode list because the duplicate check is run against the finalized version of the first and unfinalized version of the second, and thus the duplicate mode isn't caught.