### PR TITLE
macOS: fix initial Metal drawable size in certain multi-display setups

### DIFF
--- a/src/video/cocoa/SDL_cocoametalview.m
+++ b/src/video/cocoa/SDL_cocoametalview.m
@@ -150,6 +150,9 @@ Cocoa_Metal_CreateView(_THIS, SDL_Window *window)
 
         [view addSubview:newview];
 
+        /* Make sure the drawable size is up to date after attaching the view. */
+        [newview updateDrawableSize];
+
         metalview = (SDL_MetalView)CFBridgingRetain(newview);
 
         return metalview;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
On macOS, the internal drawable size of a Metal layer was being computed before the layer's view was attached to the window's content view, and wasn't being recomputed after attaching until another resize event in SDL.

In practice this meant that the pixel size of the layer wasn't always right in mixed-density multi display setups depending on which display the window was created in.

In SDL2 this also affected `SDL_Metal_GetDrawableSize`. This should be backported to SDL2 after merging.

## Existing Issue(s)
Fixes #7215
