### PR TITLE
Update SDL_opengl_glext.h

### DIFF
--- a/include/SDL_opengl_glext.h
+++ b/include/SDL_opengl_glext.h
@@ -1,5 +1,5 @@
-#ifndef __gl_glext_h_
-#define __gl_glext_h_ 1
+#ifndef __glext_h_
+#define __glext_h_ 1
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Fix compile when using MacOS OpenGL Headers

<!--- Provide a general summary of your changes in the Title above -->
Changed the sdl_opengl_glext.h header to correctly check for existing glext header when using MacOS OpenGL framework

## Description
<!--- Describe your changes in detail -->
Changed __gl_glext_h__ to __glext_h__ to reflect MacOS OpenGL Headers

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
