### PR TITLE
Rect huge parameters

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -2766,11 +2766,17 @@ static int RenderLinesWithRectsF(SDL_Renderer *renderer,
     const float scale_y = renderer->scale.y;
     SDL_FRect *frect;
     SDL_FRect *frects;
+    SDL_FRect frenderer_viewport;
     int i, nrects = 0;
     int retval = 0;
     SDL_bool isstack;
     SDL_bool drew_line = SDL_FALSE;
     SDL_bool draw_last = SDL_FALSE;
+
+    frenderer_viewport.x = (float)renderer->viewport.x;
+    frenderer_viewport.y = (float)renderer->viewport.y;
+    frenderer_viewport.w = (float)renderer->viewport.w;
+    frenderer_viewport.h = (float)renderer->viewport.h;
 
     frects = SDL_small_alloc(SDL_FRect, count - 1, &isstack);
     if (frects == NULL) {
@@ -2815,8 +2821,11 @@ static int RenderLinesWithRectsF(SDL_Renderer *renderer,
                 frect->x += scale_x;
             }
         } else {
-            retval += RenderLineBresenham(renderer, (int)SDL_roundf(points[i].x), (int)SDL_roundf(points[i].y),
-                                              (int)SDL_roundf(points[i + 1].x), (int)SDL_roundf(points[i + 1].y), draw_last);
+            float fx1 = points[i].x, fy1 = points[i].y;
+            float fx2 = points[i + 1].x, fy2 = points[i + 1].y;
+            SDL_GetRectAndLineIntersectionFloat(&frenderer_viewport, &fx1, &fy1, &fx2, &fy2);
+
+            retval += RenderLineBresenham(renderer, (int)fx1, (int)fy1, (int)fx2, (int)fy2, draw_last);
         }
         drew_line = SDL_TRUE;
     }

--- a/src/video/SDL_rect.c
+++ b/src/video/SDL_rect.c
@@ -86,26 +86,30 @@ SDL_GetSpanEnclosingRect(int width, int height,
 #define CODE_RIGHT  8
 
 /* Same code twice, for float and int versions... */
-#define RECTTYPE                 SDL_Rect
-#define POINTTYPE                SDL_Point
-#define SCALARTYPE               int
-#define COMPUTEOUTCODE           ComputeOutCode
-#define SDL_HASINTERSECTION      SDL_HasRectIntersection
-#define SDL_INTERSECTRECT        SDL_GetRectIntersection
-#define SDL_RECTEMPTY            SDL_RectEmpty
-#define SDL_UNIONRECT            SDL_GetRectUnion
-#define SDL_ENCLOSEPOINTS        SDL_GetRectEnclosingPoints
-#define SDL_INTERSECTRECTANDLINE SDL_GetRectAndLineIntersection
+#define RECTTYPE                    SDL_Rect
+#define POINTTYPE                   SDL_Point
+#define SCALARTYPE                  int
+#define SCALAR_EP_TYPE              Sint64
+#define COMPUTEOUTCODE              ComputeOutCode
+#define SUBSTRACT_MULTIPLY_DIVIDE   SubstractMultiplyDivide
+#define SDL_HASINTERSECTION         SDL_HasRectIntersection
+#define SDL_INTERSECTRECT           SDL_GetRectIntersection
+#define SDL_RECTEMPTY               SDL_RectEmpty
+#define SDL_UNIONRECT               SDL_GetRectUnion
+#define SDL_ENCLOSEPOINTS           SDL_GetRectEnclosingPoints
+#define SDL_INTERSECTRECTANDLINE    SDL_GetRectAndLineIntersection
 #include "SDL_rect_impl.h"
 
-#define RECTTYPE                 SDL_FRect
-#define POINTTYPE                SDL_FPoint
-#define SCALARTYPE               float
-#define COMPUTEOUTCODE           ComputeOutCodeFloat
-#define SDL_HASINTERSECTION      SDL_HasRectIntersectionFloat
-#define SDL_INTERSECTRECT        SDL_GetRectIntersectionFloat
-#define SDL_RECTEMPTY            SDL_RectEmptyFloat
-#define SDL_UNIONRECT            SDL_GetRectUnionFloat
-#define SDL_ENCLOSEPOINTS        SDL_GetRectEnclosingPointsFloat
-#define SDL_INTERSECTRECTANDLINE SDL_GetRectAndLineIntersectionFloat
+#define RECTTYPE                    SDL_FRect
+#define POINTTYPE                   SDL_FPoint
+#define SCALARTYPE                  float
+#define SCALAR_EP_TYPE              double
+#define COMPUTEOUTCODE              ComputeOutCodeFloat
+#define SUBSTRACT_MULTIPLY_DIVIDE   SubstractMultiplyDivideFloat
+#define SDL_HASINTERSECTION         SDL_HasRectIntersectionFloat
+#define SDL_INTERSECTRECT           SDL_GetRectIntersectionFloat
+#define SDL_RECTEMPTY               SDL_RectEmptyFloat
+#define SDL_UNIONRECT               SDL_GetRectUnionFloat
+#define SDL_ENCLOSEPOINTS           SDL_GetRectEnclosingPointsFloat
+#define SDL_INTERSECTRECTANDLINE    SDL_GetRectAndLineIntersectionFloat
 #include "SDL_rect_impl.h"

--- a/src/video/SDL_rect_impl.h
+++ b/src/video/SDL_rect_impl.h
@@ -289,6 +289,15 @@ static int COMPUTEOUTCODE(const RECTTYPE *rect, SCALARTYPE x, SCALARTYPE y)
     return code;
 }
 
+/* Calculate ((a - b) * (c - d)) / (e - f) */
+static SCALARTYPE SUBSTRACT_MULTIPLY_DIVIDE(SCALARTYPE a, SCALARTYPE b, SCALARTYPE c, SCALARTYPE d, SCALARTYPE e, SCALARTYPE f)
+{
+    SCALAR_EP_TYPE ab = (SCALAR_EP_TYPE)a - (SCALAR_EP_TYPE)b;
+    SCALAR_EP_TYPE cd = (SCALAR_EP_TYPE)c - (SCALAR_EP_TYPE)d;
+    SCALAR_EP_TYPE ef = (SCALAR_EP_TYPE)e - (SCALAR_EP_TYPE)f;
+    return (SCALARTYPE)((ab * cd) / ef);
+}
+
 SDL_bool
 SDL_INTERSECTRECTANDLINE(const RECTTYPE *rect, SCALARTYPE *X1, SCALARTYPE *Y1, SCALARTYPE *X2,
                          SCALARTYPE *Y2)
@@ -382,16 +391,16 @@ SDL_INTERSECTRECTANDLINE(const RECTTYPE *rect, SCALARTYPE *X1, SCALARTYPE *Y1, S
         if (outcode1) {
             if (outcode1 & CODE_TOP) {
                 y = recty1;
-                x = x1 + ((x2 - x1) * (y - y1)) / (y2 - y1);
+                x = x1 + SUBSTRACT_MULTIPLY_DIVIDE(x2, x1, y, y1, y2, y1);
             } else if (outcode1 & CODE_BOTTOM) {
                 y = recty2;
-                x = x1 + ((x2 - x1) * (y - y1)) / (y2 - y1);
+                x = x1 + SUBSTRACT_MULTIPLY_DIVIDE(x2, x1, y, y1, y2, y1);
             } else if (outcode1 & CODE_LEFT) {
                 x = rectx1;
-                y = y1 + ((y2 - y1) * (x - x1)) / (x2 - x1);
+                y = y1 + SUBSTRACT_MULTIPLY_DIVIDE(y2, y1, x, x1, x2, x1);
             } else if (outcode1 & CODE_RIGHT) {
                 x = rectx2;
-                y = y1 + ((y2 - y1) * (x - x1)) / (x2 - x1);
+                y = y1 + SUBSTRACT_MULTIPLY_DIVIDE(y2, y1, x, x1, x2, x1);
             }
             x1 = x;
             y1 = y;
@@ -400,23 +409,23 @@ SDL_INTERSECTRECTANDLINE(const RECTTYPE *rect, SCALARTYPE *X1, SCALARTYPE *Y1, S
             if (outcode2 & CODE_TOP) {
                 SDL_assert(y2 != y1); /* if equal: division by zero. */
                 y = recty1;
-                x = x1 + ((x2 - x1) * (y - y1)) / (y2 - y1);
+                x = x1 + SUBSTRACT_MULTIPLY_DIVIDE(x2, x1, y, y1, y2, y1);
             } else if (outcode2 & CODE_BOTTOM) {
                 SDL_assert(y2 != y1); /* if equal: division by zero. */
                 y = recty2;
-                x = x1 + ((x2 - x1) * (y - y1)) / (y2 - y1);
+                x = x1 + SUBSTRACT_MULTIPLY_DIVIDE(x2, x1, y, y1, y2, y1);
             } else if (outcode2 & CODE_LEFT) {
                 /* If this assertion ever fires, here's the static analysis that warned about it:
                    http://buildbot.libsdl.org/sdl-static-analysis/sdl-macosx-static-analysis/sdl-macosx-static-analysis-1101/report-b0d01a.html#EndPath */
                 SDL_assert(x2 != x1); /* if equal: division by zero. */
                 x = rectx1;
-                y = y1 + ((y2 - y1) * (x - x1)) / (x2 - x1);
+                y = y1 + SUBSTRACT_MULTIPLY_DIVIDE(y2, y1, x, x1, x2, x1);
             } else if (outcode2 & CODE_RIGHT) {
                 /* If this assertion ever fires, here's the static analysis that warned about it:
                    http://buildbot.libsdl.org/sdl-static-analysis/sdl-macosx-static-analysis/sdl-macosx-static-analysis-1101/report-39b114.html#EndPath */
                 SDL_assert(x2 != x1); /* if equal: division by zero. */
                 x = rectx2;
-                y = y1 + ((y2 - y1) * (x - x1)) / (x2 - x1);
+                y = y1 + SUBSTRACT_MULTIPLY_DIVIDE(y2, y1, x, x1, x2, x1);
             }
             x2 = x;
             y2 = y;
@@ -433,7 +442,9 @@ SDL_INTERSECTRECTANDLINE(const RECTTYPE *rect, SCALARTYPE *X1, SCALARTYPE *Y1, S
 #undef RECTTYPE
 #undef POINTTYPE
 #undef SCALARTYPE
+#undef SCALAR_EP_TYPE
 #undef COMPUTEOUTCODE
+#undef SUBSTRACT_MULTIPLY_DIVIDE
 #undef SDL_HASINTERSECTION
 #undef SDL_INTERSECTRECT
 #undef SDL_RECTEMPTY


### PR DESCRIPTION
Avoid overflow of multiplication of huge numbers by using intermediate types with extra precision.

## Description

The following source would block and hog a lot of memory:
```c
#include <SDL3/SDL.h>
#include <stdlib.h>

int main()
{
    int rc;
    SDL_Window *win;
    SDL_Renderer* renderer;
    SDL_Event event;

    rc = SDL_Init(SDL_INIT_EVERYTHING);
    if (rc) {
        exit(1);
    }

    win = SDL_CreateWindow("test", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 400, 400, 0);
    if (!win) {
        exit(1);
    }

    renderer = SDL_CreateRenderer(win, NULL, SDL_RENDERER_SOFTWARE);

    // accelerated renderer has the same issue
    // renderer = SDL_CreateRenderer(win, NULL, SDL_RENDERER_ACCELERATED);
    if (!renderer) {
        exit(1);
    }
    while (1) {
        while (SDL_PollEvent(&event)) {
            if (event.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED) {
                return 0;
            }
        }
        SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
        SDL_RenderClear(renderer);
        SDL_SetRenderDrawColor(renderer, 255, 0, 0, 255);
        SDL_RenderLine(renderer, -1e20f, -1e20f, 10.f, 10.f);
        SDL_RenderPresent(renderer);
    }
}
```

## Existing Issue(s)
Fixes #6116
