### PR TITLE
[SDL2]: Fix #7151: Setting the same mouse cursor twice is a no-op

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -1333,6 +1333,11 @@ void SDL_SetCursor(SDL_Cursor *cursor)
 {
     SDL_Mouse *mouse = SDL_GetMouse();
 
+    /* Return immediately if setting the cursor to the currently set one (fixes #7151) */
+    if (cursor == mouse->cur_cursor) {
+        return;
+    }
+
     /* Set the new cursor */
     if (cursor) {
         /* Make sure the cursor is still valid for this mouse */


### PR DESCRIPTION
Changing the mouse cursor isn't cheap on some platforms, so this turns multiple calls to `SDL_SetCursor()` with the same cursor into a no-op.

## Description

Dear ImGui sets the mouse cursor every frame (downside of being an immediate mode GUI), and due to the specifics of how SDL2 handles mouse cursor changes on macOS, this has a large impact on event polling performance. Sometimes it makes the event polling loop take over a millisecond!

This mostly fixes the issue. Calling `SDL_SetCursor()` with a different cursor will still be expensive, but calling it again (next frame or whenever) with the same cursor returns immediately.

## Existing Issue(s)

Fixes issue #7151 for SDL 2
https://github.com/libsdl-org/SDL/issues/7151
