### PR TITLE
[SDL3] macOS SetCursor performance fix (fixes #7151)

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -1260,6 +1260,11 @@ void SDL_SetCursor(SDL_Cursor *cursor)
 {
     SDL_Mouse *mouse = SDL_GetMouse();
 
+    /* Return immediately if setting the cursor to the currently set one (fixes #7151) */
+    if (cursor == mouse->cur_cursor) {
+        return;
+    }
+
     /* Set the new cursor */
     if (cursor) {
         /* Make sure the cursor is still valid for this mouse */

--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -219,11 +219,15 @@ static int Cocoa_ShowCursor(SDL_Cursor *cursor)
         SDL_VideoDevice *device = SDL_GetVideoDevice();
         SDL_Window *window = (device ? device->windows : NULL);
         for (; window != NULL; window = window->next) {
-            SDL_WindowData *driverdata = window->driverdata;
-            if (driverdata) {
-                [driverdata.nswindow performSelectorOnMainThread:@selector(invalidateCursorRectsForView:)
-                                                      withObject:[driverdata.nswindow contentView]
-                                                   waitUntilDone:NO];
+            SDL_Mouse *mouse = SDL_GetMouse();
+            if(mouse->focus) {
+                if (mouse->cursor_shown && mouse->cur_cursor && !mouse->relative_mode) {
+                    [(__bridge NSCursor*)mouse->cur_cursor->driverdata set];
+                } else {
+                    [[NSCursor invisibleCursor] set];
+                }
+            } else {
+                [[NSCursor arrowCursor] set];
             }
         }
         return 0;

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -1590,29 +1590,6 @@ static int Cocoa_SendMouseButtonClicks(SDL_Mouse *mouse, NSEvent *theEvent, SDL_
     return YES;
 }
 
-- (void)resetCursorRects
-{
-    SDL_Mouse *mouse;
-    [super resetCursorRects];
-    mouse = SDL_GetMouse();
-
-    if (mouse->cursor_shown && mouse->cur_cursor && !mouse->relative_mode) {
-        [self addCursorRect:[self bounds]
-                     cursor:(__bridge NSCursor *)mouse->cur_cursor->driverdata];
-    } else {
-        [self addCursorRect:[self bounds]
-                     cursor:[NSCursor invisibleCursor]];
-    }
-}
-
-- (BOOL)acceptsFirstMouse:(NSEvent *)theEvent
-{
-    if (SDL_GetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH)) {
-        return SDL_GetHintBoolean(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, SDL_FALSE);
-    } else {
-        return SDL_GetHintBoolean("SDL_MAC_MOUSE_FOCUS_CLICKTHROUGH", SDL_FALSE);
-    }
-}
 @end
 
 static int SetupWindowData(_THIS, SDL_Window *window, NSWindow *nswindow, NSView *nsview, SDL_bool created)

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -1590,6 +1590,15 @@ static int Cocoa_SendMouseButtonClicks(SDL_Mouse *mouse, NSEvent *theEvent, SDL_
     return YES;
 }
 
+- (BOOL)acceptsFirstMouse:(NSEvent *)theEvent
+{
+    if (SDL_GetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH)) {
+        return SDL_GetHintBoolean(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, SDL_FALSE);
+    } else {
+        return SDL_GetHintBoolean("SDL_MAC_MOUSE_FOCUS_CLICKTHROUGH", SDL_FALSE);
+    }
+}
+
 @end
 
 static int SetupWindowData(_THIS, SDL_Window *window, NSWindow *nswindow, NSView *nsview, SDL_bool created)


### PR DESCRIPTION
Currently, changing the mouse cursor on macOS is very slow. It can cause the next `SDL_PollEvent()` loop to take over a millisecond! Unfortunately, some libraries (like Dear ImGui) call `SDL_SetCursor()` every single frame, which can cause stuttering if the long event polling loop causes a vsync miss.

This PR will give SDL3 applications that use Dear ImGui (whenever it gets an SDL3 backend) a decent performance boost.

## Description

This PR does 2 things:
1) Multiple calls to `SDL_SetCursor()` with the same cursor is a no-op
2) When the cursor really does change, increase performance by calling `[NSCursor set]` instead of invalidating the Cocoa cursor rects.

Since `[NSCursor set]` changes the cursor for the entire screen, this PR checks to see if the mouse has gone outside the window or if the window has lost focus. If so, it instead changes to the default system arrow cursor.

The net effect preserves the current behavior while increasing performance.

## Existing Issue(s)
#7151 
