### PR TITLE
x11: Use double precision to calculate the refresh rate

### DIFF
--- a/src/video/x11/SDL_x11modes.c
+++ b/src/video/x11/SDL_x11modes.c
@@ -195,7 +195,7 @@ static SDL_bool CheckXRandR(Display *display, int *major, int *minor)
 static float CalculateXRandRRefreshRate(const XRRModeInfo *info)
 {
     if (info->hTotal && info->vTotal) {
-        return ((100 * info->dotClock) / (info->hTotal * info->vTotal)) / 100.0f;
+        return ((100 * (Sint64)info->dotClock) / (info->hTotal * info->vTotal)) / 100.0f;
     }
     return 0.0f;
 }


### PR DESCRIPTION
The dot clock value in the Xrandr mode struct can be large enough to overflow a 32-bit integer if multiplied by 100. Perform the calculation using doubles to avoid overflow and precision issues before casting the final value to float.

Should fix #7260 