### PR TITLE
emscripten: Update deprecated calls to EM_ASM*.

### DIFF
--- a/src/audio/emscripten/SDL_emscriptenaudio.c
+++ b/src/audio/emscripten/SDL_emscriptenaudio.c
@@ -263,7 +263,7 @@ static int EMSCRIPTENAUDIO_OpenDevice(_THIS, const char *devname)
     this->hidden = (struct SDL_PrivateAudioData *)0x1;
 
     /* limit to native freq */
-    this->spec.freq = EM_ASM_INT_V({
+    this->spec.freq = EM_ASM_INT({
         var SDL3 = Module['SDL3'];
         return SDL3.audioContext.sampleRate;
     });

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -4562,7 +4562,7 @@ int SDL_ShowSimpleMessageBox(Uint32 flags, const char *title, const char *messag
     if (message == NULL) {
         message = "";
     }
-    EM_ASM_({
+    EM_ASM({
         alert(UTF8ToString($0) + "\n\n" + UTF8ToString($1));
     },
             title, message);


### PR DESCRIPTION
`EM_ASM_` and `EM_ASM_INT_V` are calls that have been deprecated for a long time.

Since the return value isn't used for the call to `EM_ASM_`, it can be replaced with `EM_ASM`.

`EM_ASM_INT_V` is now (for the last few years) `EM_ASM_INT`.

cc: @sbc100 @kripken 

This is related to taking another run at fixing https://github.com/emscripten-core/emscripten/pull/9874
