### PR TITLE
Fixes for Mac/X11/Win32 fullscreen window placement

### DIFF
--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -1348,6 +1348,11 @@ static void X11_SetWindowFullscreenViaWM(_THIS, SDL_Window *window, SDL_VideoDis
         X11_XSendEvent(display, RootWindow(display, displaydata->screen), 0,
                        SubstructureNotifyMask | SubstructureRedirectMask, &e);
 
+        /* Set the position so the window will be on the target display */
+        if (fullscreen) {
+            X11_XMoveWindow(display, data->xwindow, displaydata->x, displaydata->y);
+        }
+
         /* Fullscreen windows sometimes end up being marked maximized by
             window managers. Force it back to how we expect it to be. */
         if (!fullscreen) {


### PR DESCRIPTION
Fixes up the fullscreen placement mechanism so that macOS, Win32 and X11 (real Xorg and XWayland) place exclusive fullscreen window on the proper displays.

This ends up splitting the display retrieval functions into one that returns the explicit display for fullscreen windows over all else and another that works strictly on position for when a window is moved, as Macs and Windows need the former to correctly position exclusive fullscreen windows. A small X11 fix is also needed, as both real Xorg and XWayland need the window to actually be moved to the display where it's being made fullscreen for it to appear on the correct display.