### PR TITLE
Guard against _USE_MATH_DEFINES redefinition

### DIFF
--- a/include/SDL_stdinc.h
+++ b/include/SDL_stdinc.h
@@ -85,7 +85,9 @@
    Visual Studio.  See http://msdn.microsoft.com/en-us/library/4hwaceh6.aspx
    for more information.
 */
-#  define _USE_MATH_DEFINES
+#  ifndef _USE_MATH_DEFINES
+#    define _USE_MATH_DEFINES
+#  endif
 # endif
 # include <math.h>
 #endif


### PR DESCRIPTION
## Description
Currently if a project has already defined _USE_MATH_DEFINES for other purposes, inclusion of SDL_stdinc.h will error with a macro redefinition error.  This guards against that error while still retaining the functionality.

## Existing Issue(s)
No existing issue
