### PR TITLE
[PSP] [SDL2] Audio Driver - Fix audio for `freq != 4100`

### DIFF
--- a/src/audio/psp/SDL_pspaudio.c
+++ b/src/audio/psp/SDL_pspaudio.c
@@ -41,6 +41,11 @@
 /* The tag name used by PSP audio */
 #define PSPAUDIO_DRIVER_NAME "psp"
 
+static inline SDL_bool isBasicAudioConfig(const SDL_AudioSpec *spec)
+{
+    return spec->freq == 44100;
+}
+
 static int PSPAUDIO_OpenDevice(_THIS, const char *devname)
 {
     int format, mixlen, i;
@@ -55,23 +60,37 @@ static int PSPAUDIO_OpenDevice(_THIS, const char *devname)
     /* device only natively supports S16LSB */
     this->spec.format = AUDIO_S16LSB;
 
-    /* The sample count must be a multiple of 64. */
-    this->spec.samples = PSP_AUDIO_SAMPLE_ALIGN(this->spec.samples);
-
-    /* Setup the hardware channel. */
-    if (this->spec.channels == 1) {
-        format = PSP_AUDIO_FORMAT_MONO;
-    } else {
-        format = PSP_AUDIO_FORMAT_STEREO;
-        this->spec.channels = 2; /* we're forcing the hardware to stereo. */
-    }
-
     /*  PSP has some limitations with the Audio. It fully supports 44.1KHz (Mono & Stereo),
         however with frequencies differents than 44.1KHz, it just supports Stereo,
         so a resampler must be done for these scenarios */
-    if (this->spec.freq == 44100) {
+    if (isBasicAudioConfig(&this->spec)) {
+        /* The sample count must be a multiple of 64. */
+        this->spec.samples = PSP_AUDIO_SAMPLE_ALIGN(this->spec.samples);
+        /* The number of channels (1 or 2). */
+        this->spec.channels = this->spec.channels == 1 ? 1 : 2;
+        format = this->spec.channels == 1 ? PSP_AUDIO_FORMAT_MONO : PSP_AUDIO_FORMAT_STEREO;
         this->hidden->channel = sceAudioChReserve(PSP_AUDIO_NEXT_CHANNEL, this->spec.samples, format);
     } else {
+        /* 48000, 44100, 32000, 24000, 22050, 16000, 12000, 11050, 8000 */
+        switch (this->spec.freq) {
+        case 8000:
+        case 11025:
+        case 12000:
+        case 16000:
+        case 22050:
+        case 24000:
+        case 32000:
+        case 44100:
+        case 48000:
+            this->spec.freq = this->spec.freq;
+            break;
+        default:
+            this->spec.freq = 48000;
+            break;
+        }
+        /* The number of samples to output in one output call (min 17, max 4111). */
+        this->spec.samples = this->spec.samples < 17 ? 17 : (this->spec.samples > 4111 ? 4111 : this->spec.samples);
+        this->spec.channels = 2; /* we're forcing the hardware to stereo. */
         this->hidden->channel = sceAudioSRCChReserve(this->spec.samples, this->spec.freq, 2);
     }
 
@@ -104,12 +123,11 @@ static int PSPAUDIO_OpenDevice(_THIS, const char *devname)
 
 static void PSPAUDIO_PlayDevice(_THIS)
 {
-    if (this->spec.freq != 44100) {
-        Uint8 *mixbuf = this->hidden->mixbufs[this->hidden->next_buffer];
+    Uint8 *mixbuf = this->hidden->mixbufs[this->hidden->next_buffer];
+    if (!isBasicAudioConfig(&this->spec)) {
         SDL_assert(this->spec.channels == 2);
         sceAudioSRCOutputBlocking(PSP_AUDIO_VOLUME_MAX, mixbuf);
     } else {
-        Uint8 *mixbuf = this->hidden->mixbufs[this->hidden->next_buffer];
         sceAudioOutputPannedBlocking(this->hidden->channel, PSP_AUDIO_VOLUME_MAX, PSP_AUDIO_VOLUME_MAX, mixbuf);
     }
 
@@ -130,7 +148,7 @@ static Uint8 *PSPAUDIO_GetDeviceBuf(_THIS)
 static void PSPAUDIO_CloseDevice(_THIS)
 {
     if (this->hidden->channel >= 0) {
-        if (this->spec.freq != 44100) {
+        if (!isBasicAudioConfig(&this->spec)) {
             sceAudioSRCChRelease();
         } else {
             sceAudioChRelease(this->hidden->channel);


### PR DESCRIPTION
## Description
This PR is solving audio issues with frequencies different than 44100 KHz.
There was a [commit](https://github.com/libsdl-org/SDL/commit/5d07c03613cc25ae1564b34408033266c50a0d23) trying to fix an issue in the driver when surround was used, and this one also introduced this issue.

With this PR all the scenarios should be covered properly.
