### PR TITLE
Fixed a very small scope issue reported by `cppcheck`

### DIFF
--- a/src/file/SDL_rwops.c
+++ b/src/file/SDL_rwops.c
@@ -553,11 +553,11 @@ SDL_RWFromFile(const char *file, const char *mode)
     } else {
         /* Try opening it from internal storage if it's a relative path */
         char *path;
-        FILE *fp;
 
         /* !!! FIXME: why not just "char path[PATH_MAX];" ? */
         path = SDL_stack_alloc(char, PATH_MAX);
         if (path) {
+            FILE *fp;
             SDL_snprintf(path, PATH_MAX, "%s/%s",
                          SDL_AndroidGetInternalStoragePath(), file);
             fp = fopen(path, mode);


### PR DESCRIPTION
```
$ cppcheck --verbose --quiet --error-exitcode=1 --force --enable=warning,style,performance,portability src/file/
src/file/SDL_rwops.c:556:15: style: The scope of the variable 'fp' can be reduced. Warning: Be careful when fixing this message, especially when there are inner loops. Here is an example where cppcheck will write that the scope for 'i' can be reduced:
void f(int x)
{
    int i = 0;
    if (x) {
        // it's safe to move 'int i = 0;' here
        for (int n = 0; n < 10; ++n) {
            // it is possible but not safe to move 'int i = 0;' here
            do_something(&i);
        }
    }
}
When you see this message it is always safe to reduce the variable scope 1 level. [variableScope]
        FILE *fp;
              ^
```