### PR TITLE
Fixed bug #7302 - Memory 'leak' in SDL_SetMouseSystemScale()

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -851,6 +851,12 @@ void SDL_QuitMouse(void)
     }
     mouse->num_clickstates = 0;
 
+    if (mouse->system_scale_values) {
+        SDL_free(mouse->system_scale_values);
+        mouse->system_scale_values = NULL;
+    }
+    mouse->num_system_scale_values = 0;
+
     SDL_DelHintCallback(SDL_HINT_MOUSE_DOUBLE_CLICK_TIME,
                         SDL_MouseDoubleClickTimeChanged, mouse);
 


### PR DESCRIPTION
Fixed bug #7302 - Memory 'leak' in SDL_SetMouseSystemScale()