### PR TITLE
Handle moving exclusive fullscreen windows between displays

### DIFF
--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -107,13 +107,14 @@ struct SDL_Window
     int last_pixel_w, last_pixel_h;
     Uint32 flags;
     SDL_bool fullscreen_exclusive;  /* The window is currently fullscreen exclusive */
-    SDL_bool last_fullscreen_exclusive;  /* The last fullscreen_exclusive setting */
+    SDL_DisplayID last_fullscreen_exclusive_display;  /* The last fullscreen_exclusive display */
     SDL_DisplayID last_displayID;
 
     /* Stored position and size for windowed mode */
     SDL_Rect windowed;
 
-    SDL_DisplayMode fullscreen_mode;
+    SDL_DisplayMode requested_fullscreen_mode;
+    SDL_DisplayMode current_fullscreen_mode;
 
     float opacity;
 

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1055,8 +1055,8 @@ const SDL_DisplayMode *SDL_GetClosestFullscreenDisplayMode(SDL_DisplayID display
                     continue;
                 }
 
-                if (mode->refresh_rate < refresh_rate) {
-                    /* We already found a mode and the new mode doesn't meet our
+                if (SDL_fabsf(closest->refresh_rate - refresh_rate) < SDL_fabsf(mode->refresh_rate - refresh_rate)) {
+                    /* We already found a mode and the new mode is further from our
                      * refresh rate target */
                     continue;
                 }

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -570,7 +570,7 @@ static void Cocoa_UpdateClipCursor(SDL_Window *window)
         return NO; /* Spaces are forcibly disabled. */
     } else if (state && window->fullscreen_exclusive) {
         return NO; /* we only allow you to make a Space on fullscreen desktop windows. */
-    } else if (!state && window->last_fullscreen_exclusive) {
+    } else if (!state && window->last_fullscreen_exclusive_display) {
         return NO; /* we only handle leaving the Space on windows that were previously fullscreen desktop. */
     } else if (state == isFullscreenSpace) {
         return YES; /* already there. */

--- a/src/video/kmsdrm/SDL_kmsdrmvulkan.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvulkan.c
@@ -371,7 +371,7 @@ SDL_bool KMSDRM_Vulkan_CreateSurface(_THIS,
         new_mode_parameters.visibleRegion.height = window->h;
         /* SDL (and DRM, if we look at drmModeModeInfo vrefresh) uses plain integer Hz for
            display mode refresh rate, but Vulkan expects higher precision. */
-        new_mode_parameters.refreshRate = window->fullscreen_mode.refresh_rate * 1000;
+        new_mode_parameters.refreshRate = window->current_fullscreen_mode.refresh_rate * 1000;
 
         SDL_zero(display_mode_create_info);
         display_mode_create_info.sType = VK_STRUCTURE_TYPE_DISPLAY_MODE_CREATE_INFO_KHR;

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -957,10 +957,10 @@ static int Wayland_GetDisplayBounds(_THIS, SDL_VideoDisplay *display, SDL_Rect *
     if (display->fullscreen_window &&
         display->fullscreen_window->fullscreen_exclusive &&
         display->fullscreen_window == SDL_GetFocusWindow() &&
-        display->fullscreen_window->fullscreen_mode.screen_w != 0 &&
-        display->fullscreen_window->fullscreen_mode.screen_h != 0) {
-        rect->w = display->fullscreen_window->fullscreen_mode.screen_w;
-        rect->h = display->fullscreen_window->fullscreen_mode.screen_h;
+        display->fullscreen_window->current_fullscreen_mode.screen_w != 0 &&
+        display->fullscreen_window->current_fullscreen_mode.screen_h != 0) {
+        rect->w = display->fullscreen_window->current_fullscreen_mode.screen_w;
+        rect->h = display->fullscreen_window->current_fullscreen_mode.screen_h;
     } else {
         rect->w = display->current_mode->screen_w;
         rect->h = display->current_mode->screen_h;

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -56,7 +56,7 @@ SDL_FORCE_INLINE SDL_bool FloatEqual(float a, float b)
 static SDL_bool SurfaceScaleIsFractional(SDL_Window *window)
 {
     SDL_WindowData *data = window->driverdata;
-    const float scale_value = !(window->fullscreen_exclusive) ? data->windowed_scale_factor : window->fullscreen_mode.display_scale;
+    const float scale_value = !(window->fullscreen_exclusive) ? data->windowed_scale_factor : window->current_fullscreen_mode.display_scale;
     return !FloatEqual(SDL_roundf(scale_value), scale_value);
 }
 
@@ -77,7 +77,7 @@ static SDL_bool WindowNeedsViewport(SDL_Window *window)
         if (SurfaceScaleIsFractional(window)) {
             return SDL_TRUE;
         } else if (window->fullscreen_exclusive) {
-            if (window->fullscreen_mode.screen_w != output_width || window->fullscreen_mode.screen_h != output_height) {
+            if (window->current_fullscreen_mode.screen_w != output_width || window->current_fullscreen_mode.screen_h != output_height) {
                 return SDL_TRUE;
             }
         }
@@ -93,8 +93,8 @@ static void GetBufferSize(SDL_Window *window, int *width, int *height)
     int buf_height;
 
     if (window->fullscreen_exclusive) {
-        buf_width = window->fullscreen_mode.pixel_w;
-        buf_height = window->fullscreen_mode.pixel_h;
+        buf_width = window->current_fullscreen_mode.pixel_w;
+        buf_height = window->current_fullscreen_mode.pixel_h;
     } else {
         /* Round fractional backbuffer sizes halfway away from zero. */
         buf_width = (int)SDL_lroundf((float)data->requested_window_width * data->windowed_scale_factor);
@@ -160,8 +160,8 @@ static void ConfigureWindowGeometry(SDL_Window *window)
         /* If the compositor supplied fullscreen dimensions, use them, otherwise fall back to the display dimensions. */
         const int output_width = data->requested_window_width ? data->requested_window_width : output->screen_width;
         const int output_height = data->requested_window_height ? data->requested_window_height : output->screen_height;
-        window_width = window->fullscreen_mode.screen_w;
-        window_height = window->fullscreen_mode.screen_h;
+        window_width = window->current_fullscreen_mode.screen_w;
+        window_height = window->current_fullscreen_mode.screen_h;
 
         window_size_changed = window_width != window->w || window_height != window->h ||
             data->wl_window_width != output_width || data->wl_window_height != output_height;
@@ -178,10 +178,10 @@ static void ConfigureWindowGeometry(SDL_Window *window)
             } else {
                 /* Always use the mode dimensions for integer scaling. */
                 UnsetDrawSurfaceViewport(window);
-                wl_surface_set_buffer_scale(data->surface, (int32_t)window->fullscreen_mode.display_scale);
+                wl_surface_set_buffer_scale(data->surface, (int32_t)window->current_fullscreen_mode.display_scale);
 
-                data->wl_window_width = window->fullscreen_mode.screen_w;
-                data->wl_window_height = window->fullscreen_mode.screen_h;
+                data->wl_window_width = window->current_fullscreen_mode.screen_w;
+                data->wl_window_height = window->current_fullscreen_mode.screen_h;
             }
 
             data->pointer_scale_x = (float)window_width / (float)data->wl_window_width;
@@ -554,7 +554,7 @@ static void handle_configure_xdg_toplevel(void *data,
          * place the fullscreen window is unknown.
          */
         if (window->fullscreen_exclusive && !wind->fullscreen_was_positioned) {
-            SDL_VideoDisplay *disp = SDL_GetVideoDisplay(window->fullscreen_mode.displayID);
+            SDL_VideoDisplay *disp = SDL_GetVideoDisplay(window->current_fullscreen_mode.displayID);
             if (disp) {
                 wind->fullscreen_was_positioned = SDL_TRUE;
                 xdg_toplevel_set_fullscreen(xdg_toplevel, disp->driverdata->output);
@@ -768,7 +768,7 @@ static void decoration_frame_configure(struct libdecor_frame *frame,
          * place the fullscreen window is unknown.
          */
         if (window->fullscreen_exclusive && !wind->fullscreen_was_positioned) {
-            SDL_VideoDisplay *disp = SDL_GetVideoDisplay(window->fullscreen_mode.displayID);
+            SDL_VideoDisplay *disp = SDL_GetVideoDisplay(window->current_fullscreen_mode.displayID);
             if (disp) {
                 wind->fullscreen_was_positioned = SDL_TRUE;
                 libdecor_frame_set_fullscreen(frame, disp->driverdata->output);


### PR DESCRIPTION
This set of patches, along with some previous work, allows for moving exclusive fullscreen windows between displays with proper sizing and mode selection. When an exclusive fullscreen mode is chosen for the window, it is stored in the window properties as the 'desired mode', and when an application requests to enter fullscreen, it is initially set as the window's fullscreen mode and the window will be placed on the display specified by it. If an exclusive fullscreen window is then moved, an attempt to find a matching mode on the new display will be made and, if one is found, the window on the new display will use the closest match mode. If none exists, it will become desktop fullscreen. If the window is again moved, the process will repeat and attempt to find a mode that matches the application's requested exclusive fullscreen mode and fall back to fullscreen desktop if one is not found. If an application leaves and re-enters fullscreen, the window is placed back on the display originally specified in the desired mode.

This has been tested to work on Windows, macOS, X11 (real and XWayland), and Wayland.

Additional changes:

- A change to the closest mode matching code is needed to allow for matching refresh rates that are similar, but not exact, as with floating point refresh rate values, there can be subtle differences in refresh rate values that shouldn't prevent suitable modes from being rejected (e.g. the target is 60hz, but the display is running at 59.98).

- A fix for the Windows backend is also needed as desktop fullscreen windows can be set to the wrong size when moving between displays with different scale values, as Windows may suggest a window size that doesn't cover the entire display in the WM_DPICHANGED event. To fix this, fullscreen window sizes are intercepted in the WM_WINDOWPOSCHANGING event and modified to ensure that they always cover the entire display, although I'm not sure if this is the best way to handle this (pinging @ericwa).