### PR TITLE
testwm.c: show all modes of all displays in the on-screen list

### DIFF
--- a/test/testwm.c
+++ b/test/testwm.c
@@ -216,6 +216,7 @@ void loop()
         if (event.type == SDL_EVENT_MOUSE_BUTTON_UP) {
             SDL_Window *window = SDL_GetMouseFocus();
             if (highlighted_mode != NULL && window != NULL) {
+                SDL_memcpy(&state->fullscreen_mode, highlighted_mode, sizeof(state->fullscreen_mode));
                 SDL_SetWindowFullscreenMode(window, highlighted_mode);
             }
         }


### PR DESCRIPTION
Previously, only the modes for the window's current display were listed.

To be able to test https://github.com/libsdl-org/SDL/pull/7317 , it sounds like we want to list all modes of all displays.

![image](https://user-images.githubusercontent.com/239161/218924882-6e3d56f6-fc35-4788-8c9c-233377b3ce1f.png)
