### PR TITLE
Remove now duplicated section in emscripten docs

### DIFF
--- a/docs/README-emscripten.md
+++ b/docs/README-emscripten.md
@@ -50,11 +50,6 @@ Build:
     $ emmake make
 
 
-To build one of the tests:
-
-    $ cd test/
-    $ emcc -O2 --js-opts 0 -g4 testdraw.c -I../include ../build/.libs/libSDL3.a ../build/libSDL3_test.a -o a.html
-
 Uses GLES2 renderer or software
 
 Some other SDL3 libraries can be easily built (assuming SDL3 is installed somewhere):

--- a/docs/README-emscripten.md
+++ b/docs/README-emscripten.md
@@ -49,12 +49,6 @@ Build:
     $ emcmake cmake ..
     $ emmake make
 
-Or with cmake:
-
-    $ mkdir build
-    $ cd build
-    $ emcmake cmake ..
-    $ emmake make
 
 To build one of the tests:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Since the default is now cmake, we don't need an "or with cmake" section. Might push some more updates while I'm here...

