### PR TITLE
windows/gles: do not unload EGL when context is destroyed

### DIFF
--- a/src/video/windows/SDL_windowsopengles.c
+++ b/src/video/windows/SDL_windowsopengles.c
@@ -97,7 +97,6 @@ WIN_GLES_CreateContext(_THIS, SDL_Window *window)
 int WIN_GLES_DeleteContext(_THIS, SDL_GLContext context)
 {
     SDL_EGL_DeleteContext(_this, context);
-    WIN_GLES_UnloadLibrary(_this);
     return 0;
 }
 

--- a/src/video/windows/SDL_windowsopengles.c
+++ b/src/video/windows/SDL_windowsopengles.c
@@ -101,10 +101,12 @@ int WIN_GLES_DeleteContext(_THIS, SDL_GLContext context)
     return 0;
 }
 
+/* *INDENT-OFF* */ /* clang-format off */
 SDL_EGL_SwapWindow_impl(WIN)
-    SDL_EGL_MakeCurrent_impl(WIN)
+SDL_EGL_MakeCurrent_impl(WIN)
+/* *INDENT-ON* */ /* clang-format on */
 
-        int WIN_GLES_SetupWindow(_THIS, SDL_Window *window)
+int WIN_GLES_SetupWindow(_THIS, SDL_Window *window)
 {
     /* The current context is lost in here; save it and reset it. */
     SDL_WindowData *windowdata = window->driverdata;


### PR DESCRIPTION
It's legitimate to have other contexts and keep using EGL.