### PR TITLE
Use libsndfile for audio import

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,6 +399,8 @@ set_option(SDL_SNDIO               "Support the sndio audio API" ${UNIX_SYS})
 dep_option(SDL_SNDIO_SHARED        "Dynamically load the sndio audio API" ON "SDL_SNDIO" OFF)
 set_option(SDL_LIBSAMPLERATE       "Use libsamplerate for audio rate conversion" ${UNIX_SYS})
 dep_option(SDL_LIBSAMPLERATE_SHARED "Dynamically load libsamplerate" ON "SDL_LIBSAMPLERATE" OFF)
+set_option(SDL_LIBSNDFILE          "Use libsndfile for audio import" ${UNIX_SYS})
+dep_option(SDL_LIBSNDFILE_SHARED   "Dynamically load libsndfile" ON "SDL_LIBSNDFILE" OFF)
 set_option(SDL_RPATH               "Use an rpath when linking SDL" ${UNIX_SYS})
 set_option(SDL_CLOCK_GETTIME       "Use clock_gettime() instead of gettimeofday()" ${SDL_CLOCK_GETTIME_ENABLED_BY_DEFAULT})
 set_option(SDL_X11                 "Use X11 video driver" ${UNIX_SYS})
@@ -2743,6 +2745,7 @@ endif()
 
 # Platform-independent options
 CheckLibSampleRate()
+CheckLibSndFile()
 
 if(SDL_VIDEO)
   if(SDL_OFFSCREEN AND SDL_VIDEO_OPENGL_EGL)

--- a/include/build_config/SDL_build_config.h.cmake
+++ b/include/build_config/SDL_build_config.h.cmake
@@ -240,6 +240,7 @@
 
 #cmakedefine HAVE_LIBUDEV_H 1
 #cmakedefine HAVE_LIBSAMPLERATE_H 1
+#cmakedefine HAVE_LIBSNDFILE_H 1
 #cmakedefine HAVE_LIBDECOR_H  1
 
 #cmakedefine HAVE_D3D_H @HAVE_D3D_H@
@@ -561,6 +562,9 @@
 
 /* Enable dynamic libsamplerate support */
 #cmakedefine SDL_LIBSAMPLERATE_DYNAMIC @SDL_LIBSAMPLERATE_DYNAMIC@
+
+/* Enable dynamic libsndfile support */
+#cmakedefine SDL_LIBSNDFILE_DYNAMIC @SDL_LIBSNDFILE_DYNAMIC@
 
 /* Enable ime support */
 #cmakedefine SDL_USE_IME @SDL_USE_IME@


### PR DESCRIPTION
This PR adds some initial support for using libsndfile API in SDL_LoadWAV_RW() to make use of its extended format support, which by far exceeds the ability to load merely WAV/RIFF format files.

## Description
This PR replaces `WaveLoad()` with a function that calls into the sndfile API and lets it do all the grunt work of format guessing, loading and converting. It is currently rather limited, e.g. it converts all audio data into S16 format, regardless of the source format. Also, there is no error reporting, currently. Well, it's a start.

## Existing Issue(s)
Does there need to be an issue? :wink: 
No, seriously, with this PR you can use `SDL_LoadWAV_RW()` to load sound file in about any possible format and you are not restricted to one of the uncompressed WAV formats anymore.