### PR TITLE
Added a DragonRise Inc. Wired Wheel (also known as Superdrive SV-750 …

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -2416,6 +2416,8 @@ static SDL_bool SDL_IsJoystickProductWheel(Uint32 vidpid)
         MAKE_VIDPID(0x044f, 0xb65e),    /* Thrustmaster T500RS */
         MAKE_VIDPID(0x044f, 0xb664),    /* Thrustmaster TX (initial mode) */
         MAKE_VIDPID(0x044f, 0xb669),    /* Thrustmaster TX (active mode) */
+        MAKE_VIDPID(0x11ff, 0x0511),    /* DragonRise Inc. Wired Wheel (non-working mode) */
+        MAKE_VIDPID(0x0079, 0x1864),    /* DragonRise Inc. Wired Wheel (active mode) */
     };
     int i;
 


### PR DESCRIPTION
…or a Genesis Seaborg 400). Non-ForceFeedback budget wheel.

## Description
The wheel was not being detected in Proton, no controller was showing. No vendor or product ID was in SDL.

## Existing Issue(s)

