### PR TITLE
Fix window size in X11 when window manager refuses to resize

### DIFF
--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -997,6 +997,10 @@ void X11_SetWindowSize(_THIS, SDL_Window *window)
         }
 
         if (SDL_GetTicks() >= timeout) {
+            /* Timeout occurred and window size didn't change
+             * wwindow manager likely denied the resize. */
+            window->w = orig_w;
+            window->h = orig_h;
             break;
         }
 


### PR DESCRIPTION
## Description
When a window is maximized, a call to `SDL_SetWindowSize` will fail to resize the window with X11 (and KDE at least).
Thep orblem is that `window->w` and `window->h` are modified to take the requested size into account and GL renderer uses this new size to draw resulting in image being located in lower left corner.

This bug exists in SDL2 and SDL3 (SDL1.2 not tested).
A backport would be great.

## Existing Issue(s)
A test case can be found here: https://gist.github.com/lephilousophe/33936ede1631e1d237927f1233365b42
It compiles with SDL2 and 3.