### PR TITLE
Improve SDL_GetSystemRAM failure mode

### DIFF
--- a/include/SDL3/SDL_cpuinfo.h
+++ b/include/SDL3/SDL_cpuinfo.h
@@ -345,7 +345,8 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasLASX(void);
 /**
  * Get the amount of RAM configured in the system.
  *
- * \returns the amount of RAM configured in the system in MiB.
+ * \returns the amount of RAM configured in the system in MiB. On error, 0 is returned; call SDL_GetError() for
++ *         more information.
  *
  * \since This function is available since SDL 3.0.0.
  */

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -1071,7 +1071,7 @@ int SDL_GetSystemRAM(void)
         if (SDL_SystemRAM <= 0) {
             /* Vita has 512MiB on SoC, that's split into 256MiB(+109MiB in extended memory mode) for app
                +26MiB of physically continuous memory, +112MiB of CDRAM(VRAM) + system reserved memory. */
-            SDL_SystemRAM = 536870912;
+            SDL_SystemRAM = 512;
         }
 #endif
 #ifdef __PS2__

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -271,7 +271,7 @@ static SDL_bool CPU_OSSavesZMM = SDL_FALSE;
 static void CPU_calcCPUIDFeatures(void)
 {
     static SDL_bool checked = SDL_FALSE;
-    if (!checked) {
+    if (checked == SDL_FALSE) {
         checked = SDL_TRUE;
         if (CPU_haveCPUID()) {
             int a, b, c, d;
@@ -303,7 +303,7 @@ static void CPU_calcCPUIDFeatures(void)
                         }
 #endif
                     CPU_OSSavesYMM = ((a & 6) == 6) ? SDL_TRUE : SDL_FALSE;
-                    CPU_OSSavesZMM = (CPU_OSSavesYMM && ((a & 0xe0) == 0xe0)) ? SDL_TRUE : SDL_FALSE;
+                    CPU_OSSavesZMM = (CPU_OSSavesYMM == SDL_TRUE && ((a & 0xe0) == 0xe0)) ? SDL_TRUE : SDL_FALSE;
                 }
             }
         }
@@ -560,7 +560,7 @@ static int CPU_readCPUCFG(void)
 #define CPU_haveSSE3()  (CPU_CPUIDFeatures[2] & 0x00000001)
 #define CPU_haveSSE41() (CPU_CPUIDFeatures[2] & 0x00080000)
 #define CPU_haveSSE42() (CPU_CPUIDFeatures[2] & 0x00100000)
-#define CPU_haveAVX()   (CPU_OSSavesYMM && (CPU_CPUIDFeatures[2] & 0x10000000))
+#define CPU_haveAVX()   (CPU_OSSavesYMM == SDL_TRUE && (CPU_CPUIDFeatures[2] & 0x10000000))
 #endif
 
 #if defined(__e2k__)
@@ -576,7 +576,7 @@ CPU_haveAVX2(void)
 #else
 static int CPU_haveAVX2(void)
 {
-    if (CPU_OSSavesYMM && (CPU_CPUIDMaxFunction >= 7)) {
+    if (CPU_OSSavesYMM == SDL_TRUE && CPU_CPUIDMaxFunction >= 7) {
         int a, b, c, d;
         (void)a;
         (void)b;
@@ -598,7 +598,7 @@ CPU_haveAVX512F(void)
 #else
 static int CPU_haveAVX512F(void)
 {
-    if (CPU_OSSavesZMM && (CPU_CPUIDMaxFunction >= 7)) {
+    if (CPU_OSSavesZMM == SDL_TRUE && CPU_CPUIDMaxFunction >= 7) {
         int a, b, c, d;
         (void)a;
         (void)b;

--- a/test/testplatform.c
+++ b/test/testplatform.c
@@ -405,7 +405,7 @@ int TestCPUInfo(SDL_bool verbose)
         SDL_Log("NEON %s\n", SDL_HasNEON() ? "detected" : "not detected");
         SDL_Log("LSX %s\n", SDL_HasLSX() ? "detected" : "not detected");
         SDL_Log("LASX %s\n", SDL_HasLASX() ? "detected" : "not detected");
-        SDL_Log("System RAM %d MB\n", SDL_GetSystemRAM());
+        SDL_Log("System RAM %d MiB\n", SDL_GetSystemRAM());
     }
     return 0;
 }


### PR DESCRIPTION
- Document `SDL_GetSystemRAM` returning 0 as its failure mode + get the error through `SDL_GetError`.
- Fix Vita's RAM capacity
- Compare `SDL_bool` types correctly.