### PR TITLE
Fix a few -Wunused-function/-Wunused-variable warnings

### DIFF
--- a/src/video/x11/SDL_x11modes.c
+++ b/src/video/x11/SDL_x11modes.c
@@ -620,6 +620,7 @@ int X11_InitModes(_THIS)
 
 int X11_GetDisplayModes(_THIS, SDL_VideoDisplay *sdl_display)
 {
+#if SDL_VIDEO_DRIVER_X11_XRANDR
     SDL_DisplayData *data = sdl_display->driverdata;
     SDL_DisplayMode mode;
 
@@ -632,7 +633,6 @@ int X11_GetDisplayModes(_THIS, SDL_VideoDisplay *sdl_display)
     SDL_zero(mode);
     mode.format = sdl_display->desktop_mode.format;
 
-#if SDL_VIDEO_DRIVER_X11_XRANDR
     if (data->use_xrandr) {
         Display *display = _this->driverdata->display;
         XRRScreenResources *res;

--- a/src/video/x11/SDL_x11shape.c
+++ b/src/video/x11/SDL_x11shape.c
@@ -31,9 +31,10 @@ SDL_WindowShaper *
 X11_CreateShaper(SDL_Window *window)
 {
     SDL_WindowShaper *result = NULL;
-    SDL_ShapeData *data = NULL;
 
 #if SDL_VIDEO_DRIVER_X11_XSHAPE
+    SDL_ShapeData *data = NULL;
+
     if (SDL_X11_HAVE_XSHAPE) { /* Make sure X server supports it. */
         result = SDL_malloc(sizeof(SDL_WindowShaper));
         if (result == NULL) {
@@ -95,9 +96,11 @@ int X11_ResizeWindowShape(SDL_Window *window)
 
 int X11_SetWindowShape(SDL_WindowShaper *shaper, SDL_Surface *shape, SDL_WindowShapeMode *shape_mode)
 {
+#if SDL_VIDEO_DRIVER_X11_XSHAPE
     SDL_ShapeData *data = NULL;
     SDL_WindowData *windowdata = NULL;
     Pixmap shapemask;
+#endif
 
     if (shaper == NULL || shape == NULL || shaper->driverdata == NULL) {
         return -1;

--- a/src/video/x11/SDL_x11xinput2.c
+++ b/src/video/x11/SDL_x11xinput2.c
@@ -181,6 +181,7 @@ void X11_InitXinput2(_THIS)
 #endif
 }
 
+#if SDL_VIDEO_DRIVER_X11_XINPUT2
 /* xi2 device went away? take it out of the list. */
 static void xinput2_remove_device_info(SDL_VideoData *videodata, const int device_id)
 {
@@ -202,7 +203,6 @@ static void xinput2_remove_device_info(SDL_VideoData *videodata, const int devic
     }
 }
 
-#if SDL_VIDEO_DRIVER_X11_XINPUT2
 static SDL_XInput2DeviceInfo *xinput2_get_device_info(SDL_VideoData *videodata, const int device_id)
 {
     /* cache device info as we see new devices. */


### PR DESCRIPTION
These warnings showed up when building with:
- `-DSDL_X11_XSHAPE=OFF`
- `-DSDL_X11_XRANDR=OFF`
- `-DSDL_X11_XINPUT2=OFF`