### PR TITLE
Fix GetGlobalMouseState when xi2 is not available at runtime

### DIFF
--- a/src/video/x11/SDL_x11mouse.c
+++ b/src/video/x11/SDL_x11mouse.c
@@ -415,6 +415,9 @@ static Uint32 X11_GetGlobalMouseState(float *x, float *y)
 
 #if !SDL_VIDEO_DRIVER_X11_XINPUT2
     videodata->global_mouse_changed = SDL_TRUE;
+#else
+    if (!SDL_X11_HAVE_XINPUT2)
+        videodata->global_mouse_changed = SDL_TRUE;
 #endif
 
     /* check if we have this cached since XInput last saw the mouse move. */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When XI2 was available at build time but is not available at runtime, GetGlobalMouseState will return a static mouse position. This patch fixes this.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
