### PR TITLE
video: Window placement fixes

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1323,6 +1323,9 @@ static int SDL_UpdateFullscreenMode(SDL_Window *window, SDL_bool fullscreen)
         mode = (SDL_DisplayMode *)SDL_GetWindowFullscreenMode(window);
         if (mode != NULL) {
             window->fullscreen_exclusive = SDL_TRUE;
+        } else {
+            /* Make sure the current mode is zeroed for fullscreen desktop. */
+            SDL_zero(window->current_fullscreen_mode);
         }
     }
 
@@ -2190,21 +2193,9 @@ int SDL_SetWindowPosition(SDL_Window *window, int x, int y)
             SDL_DisplayID displayID = GetDisplayForRect(x, y, 1, 1);
 
             if (displayID != original_displayID) {
-                SDL_Rect bounds;
-                SDL_zero(bounds);
-                SDL_GetDisplayBounds(displayID, &bounds);
-
-                window->x = bounds.x;
-                window->y = bounds.y;
-                window->w = bounds.w;
-                window->h = bounds.h;
-
-                if (_this->SetWindowPosition) {
-                    _this->SetWindowPosition(_this, window);
-                }
-                if (_this->SetWindowSize) {
-                    _this->SetWindowSize(_this, window);
-                }
+                /* Set the new target display and update the fullscreen mode */
+                window->current_fullscreen_mode.displayID = displayID;
+                SDL_UpdateFullscreenMode(window, SDL_TRUE);
             }
         }
     } else {

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2201,6 +2201,7 @@ int SDL_SetWindowPosition(SDL_Window *window, int x, int y)
     } else {
         window->x = x;
         window->y = y;
+        window->last_displayID = SDL_GetDisplayForWindow(window);
 
         if (_this->SetWindowPosition) {
             _this->SetWindowPosition(_this, window);

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -958,6 +958,8 @@ static void Wayland_move_window(SDL_Window *window, SDL_DisplayData *driverdata)
                  */
                 SDL_Rect bounds;
                 SDL_GetDisplayBounds(displays[i], &bounds);
+
+                window->driverdata->last_displayID = displays[i];
                 SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_MOVED, bounds.x, bounds.y);
                 break;
             }
@@ -1611,7 +1613,7 @@ void Wayland_SetWindowFullscreen(_THIS, SDL_Window *window,
          * If the window is already positioned on the target output, just update the
          * window geometry.
          */
-        if (window->last_displayID != display->id) {
+        if (wind->last_displayID != display->id) {
             wind->fullscreen_was_positioned = SDL_TRUE;
             SetFullscreen(window, output);
         } else {

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -111,6 +111,7 @@ struct SDL_WindowData
     int wl_window_width, wl_window_height;
     int system_min_required_width;
     int system_min_required_height;
+    SDL_DisplayID last_displayID;
     SDL_bool floating;
     SDL_bool is_fullscreen;
     SDL_bool in_fullscreen_transition;

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1241,7 +1241,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
         RECT rect;
         int x, y;
         int w, h;
-        SDL_DisplayID displayID = SDL_GetDisplayForWindow(data->window);
+        const SDL_DisplayID original_displayID = data->last_displayID;
 
         if (data->initializing || data->in_border_change) {
             break;
@@ -1294,7 +1294,10 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
         /* Forces a WM_PAINT event */
         InvalidateRect(hwnd, NULL, FALSE);
 
-        if (data->window->last_displayID != displayID) {
+        /* Update the window display position */
+        data->last_displayID = SDL_GetDisplayForWindow(data->window);
+
+        if (data->last_displayID != original_displayID) {
             /* Display changed, check ICC profile */
             WIN_UpdateWindowICCProfile(data->window, SDL_TRUE);
         }

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -309,6 +309,7 @@ static int SetupWindowData(_THIS, SDL_Window *window, HWND hwnd, HWND parent, SD
     data->last_pointer_update = (LPARAM)-1;
     data->videodata = videodata;
     data->initializing = SDL_TRUE;
+    data->last_displayID = window->last_displayID;
     data->scaling_dpi = WIN_GetScalingDPIForHWND(videodata, hwnd);
 
 #ifdef HIGHDPI_DEBUG

--- a/src/video/windows/SDL_windowswindow.h
+++ b/src/video/windows/SDL_windowswindow.h
@@ -62,6 +62,7 @@ struct SDL_WindowData
     RECT cursor_clipped_rect;
     SDL_Point last_raw_mouse_position;
     SDL_bool mouse_tracked;
+    SDL_DisplayID last_displayID;
     WCHAR *ICMFileName;
     struct SDL_VideoData *videodata;
 #if SDL_VIDEO_OPENGL_EGL


### PR DESCRIPTION
Use `SDL_UpdateFullscreenMode()` for repositioning desktop fullscreen windows to handle cases where the target display changed the video mode and/or already has a fullscreen window on it.

Additionally, update the window's display ID when setting the position programmatically so it remains in sync with the current window position, even if the move event is deduplicated.