### PR TITLE
raspberry: SDL_DisplayMode's w/h members have been renamed to screen_w/screen_h

### DIFF
--- a/src/video/raspberry/SDL_rpivideo.c
+++ b/src/video/raspberry/SDL_rpivideo.c
@@ -245,8 +245,8 @@ int RPI_CreateWindow(_THIS, SDL_Window *window)
     displaydata = display->driverdata;
 
     /* Windows have one size for now */
-    window->w = display->desktop_mode.w;
-    window->h = display->desktop_mode.h;
+    window->w = display->desktop_mode.screen_w;
+    window->h = display->desktop_mode.screen_h;
 
     /* OpenGL ES is the law here, buddy */
     window->flags |= SDL_WINDOW_OPENGL;


### PR DESCRIPTION
Found by running build-scripts/SDL_migration.cocci on SDL's source tree.


