### PR TITLE
Add gradle-wrapper-validation job for android-project

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,14 @@
+name: "Validate Gradle Wrapper"
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  validation:
+    name: "Validation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
## Description
Add the official gradle-wrapper-validation job based on GitHub Actions to validate gradle wrapper files for every PR to avoid gradle wrapper files' attack.

See https://github.com/gradle/wrapper-validation-action.

## Existing Issue(s)

None.
