### PR TITLE
SDL_GetSystemRAM completion for Haiku system.

### DIFF
--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -83,6 +83,10 @@
 #include <kernel.h>
 #endif
 
+#ifdef __HAIKU__
+#include <kernel/OS.h>
+#endif
+
 #define CPU_HAS_RDTSC    (1 << 0)
 #define CPU_HAS_ALTIVEC  (1 << 1)
 #define CPU_HAS_MMX      (1 << 2)
@@ -1079,6 +1083,16 @@ int SDL_GetSystemRAM(void)
             /* PlayStation 2 has 32MiB however there are some special models with 64 and 128 */
             SDL_SystemRAM = GetMemorySize();
         }
+#endif
+#ifdef __HAIKU__
+        if (SDL_SystemRAM <= 0) {
+            system_info info;
+	    if (get_system_info(&info) == B_OK) {
+                /* To have an accurate amount, we also take in account the inaccessible pages (aka ignored)
+                  which is a bit handier compared to the legacy system's api (i.e. used_pages).*/
+                SDL_SystemRAM = (int)round((info.max_pages + info.ignored_pages > 0 ? info.ignored_pages : 0) * B_PAGE_SIZE / 1048576.0);
+	    }
+	}
 #endif
 #endif
     }


### PR DESCRIPTION
using native system_info's api.

