### PR TITLE
Always allocate and write zt to output of SDL_iconv_string()

### DIFF
--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -662,7 +662,7 @@ extern DECLSPEC size_t SDLCALL SDL_iconv(SDL_iconv_t cd, const char **inbuf,
                                          size_t * outbytesleft);
 
 /**
- * This function converts a string between encodings in one pass, returning a
+ * This function converts a buffer or string between encodings in one pass, returning a
  * string that must be freed with SDL_free() or NULL on error.
  *
  * \since This function is available since SDL 3.0.0.

--- a/src/stdlib/SDL_iconv.c
+++ b/src/stdlib/SDL_iconv.c
@@ -808,7 +808,7 @@ SDL_iconv_string(const char *tocode, const char *fromcode, const char *inbuf,
     }
 
     stringsize = inbytesleft > 4 ? inbytesleft : 4;
-    string = (char *)SDL_malloc(stringsize);
+    string = (char *)SDL_malloc(stringsize + 1);
     if (string == NULL) {
         SDL_iconv_close(cd);
         return NULL;
@@ -825,7 +825,7 @@ SDL_iconv_string(const char *tocode, const char *fromcode, const char *inbuf,
         {
             char *oldstring = string;
             stringsize *= 2;
-            string = (char *)SDL_realloc(string, stringsize);
+            string = (char *)SDL_realloc(string, stringsize + 1);
             if (string == NULL) {
                 SDL_free(oldstring);
                 SDL_iconv_close(cd);
@@ -851,6 +851,7 @@ SDL_iconv_string(const char *tocode, const char *fromcode, const char *inbuf,
             break;
         }
     }
+    *outbuf = '\0';
     SDL_iconv_close(cd);
 
     return string;


### PR DESCRIPTION
Before this, the function could not be used on buffers, as it would not account for the zero-termination unless it was included in the input. That makes it extremely error-prone to use.

## Description

The output from `SDL_iconv_string()` is prone to generate Valgrind warnings when used on buffers where the input buffer and the provided buffer length does not include a zero-terminator.

This change always accounts for a zt when allocating memory, and unconditionally writes one to the output before returning. 

Since existing SDL code that calls this with `strlen(s)+1` or similar continues to work as before after this change, I did not bother to try and 'adjust' any callsites.

## Test program

```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

#include <SDL3/SDL.h>
#include <SDL3/SDL_main.h>

int main(int argc, char *argv[]) {
	const char buf[] = "test string";
	size_t bs_len = strlen(buf);
	char *res;

	res = SDL_iconv_string("ASCII", "UTF-8", buf, bs_len+1); // OK
	printf("res='%s' (len=%zu)\n", res, strlen(res));
	free(res);

	res = SDL_iconv_string("ASCII", "UTF-8", buf, bs_len);   // Valgrind: "Invalid read of size 1" at strlen() .. reading into adjacent memory
	printf("res='%s' (len=%zu)\n", res, strlen(res));
	free(res);

	return 0;
}
```

## Before

```console
==22051== Memcheck, a memory error detector
==22051== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==22051== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==22051== Command: ./iconv_string_mini
==22051== 
res='test string' (len=11)
==22051== Invalid read of size 1
==22051==    at 0x484E2F3: strlen (vg_replace_strmem.c:494)
==22051==    by 0x40122E: main (iconv_string_mini.c:18)
==22051==  Address 0x4ea4a5b is 0 bytes after a block of size 11 alloc'd
==22051==    at 0x48487B3: malloc (vg_replace_malloc.c:381)
==22051==    by 0x491EAEB: real_malloc (in /home/eddy/local/lib/libSDL3.so.0.0.0)
==22051==    by 0x491ED52: SDL_malloc_REAL (in /home/eddy/local/lib/libSDL3.so.0.0.0)
==22051==    by 0x491E947: SDL_iconv_string_REAL (in /home/eddy/local/lib/libSDL3.so.0.0.0)
==22051==    by 0x48A2652: SDL_iconv_string (in /home/eddy/local/lib/libSDL3.so.0.0.0)
==22051==    by 0x40121C: main (iconv_string_mini.c:17)
==22051== 
==22051== Invalid read of size 1
==22051==    at 0x484E2F3: strlen (vg_replace_strmem.c:494)
==22051==    by 0x4CE0DB0: __vfprintf_internal (vfprintf-internal.c:1517)
==22051==    by 0x4CCA81E: printf (printf.c:33)
==22051==    by 0x401248: main (iconv_string_mini.c:18)
==22051==  Address 0x4ea4a5b is 0 bytes after a block of size 11 alloc'd
==22051==    at 0x48487B3: malloc (vg_replace_malloc.c:381)
==22051==    by 0x491EAEB: real_malloc (in /home/eddy/local/lib/libSDL3.so.0.0.0)
==22051==    by 0x491ED52: SDL_malloc_REAL (in /home/eddy/local/lib/libSDL3.so.0.0.0)
==22051==    by 0x491E947: SDL_iconv_string_REAL (in /home/eddy/local/lib/libSDL3.so.0.0.0)
==22051==    by 0x48A2652: SDL_iconv_string (in /home/eddy/local/lib/libSDL3.so.0.0.0)
==22051==    by 0x40121C: main (iconv_string_mini.c:17)
==22051== 
res='test string' (len=11)
==22051== 
==22051== HEAP SUMMARY:
==22051==     in use at exit: 0 bytes in 0 blocks
==22051==   total heap usage: 17 allocs, 17 frees, 67,023 bytes allocated
==22051== 
==22051== All heap blocks were freed -- no leaks are possible
==22051== 
==22051== For lists of detected and suppressed errors, rerun with: -s
==22051== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```

## After

```console
==23195== Memcheck, a memory error detector
==23195== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==23195== Using Valgrind-3.19.0 and LibVEX; rerun with -h for copyright info
==23195== Command: ./iconv_string_mini
==23195== 
res='test string' (len=11)
res='test string' (len=11)
==23195== 
==23195== HEAP SUMMARY:
==23195==     in use at exit: 0 bytes in 0 blocks
==23195==   total heap usage: 17 allocs, 17 frees, 67,025 bytes allocated
==23195== 
==23195== All heap blocks were freed -- no leaks are possible
==23195== 
==23195== For lists of detected and suppressed errors, rerun with: -s
==23195== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```