### PR TITLE
SDL3: Add SDL_SetClipboardTextBuffer()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -973,7 +973,7 @@ if(SDL_LIBC)
     foreach(_FN
             malloc calloc realloc free bsearch qsort abs memset memcpy memmove memcmp
             wcslen _wcsdup wcsdup wcsstr wcscmp wcsncmp _wcsicmp _wcsnicmp
-            strlen strnlen strdup strndup _strrev _strupr _strlwr strchr strrchr strstr itoa _ltoa
+            strlen _strrev _strupr _strlwr strchr strrchr strstr itoa _ltoa
             _ultoa strtol strtoul strtoll strtod atoi atof strcmp strncmp
             _stricmp _strnicmp sscanf
             acos acosf asin asinf atan atanf atan2 atan2f ceil ceilf
@@ -1025,7 +1025,7 @@ if(SDL_LIBC)
                              int main(void) { return 0; }" HAVE_MPROTECT)
     foreach(_FN
             strtod malloc calloc realloc free getenv setenv putenv unsetenv
-            bsearch qsort abs bcopy memset memcpy memmove memcmp strlen strnlen strdup strndup strlcpy strlcat
+            bsearch qsort abs bcopy memset memcpy memmove memcmp strlen strnlen strlcpy strlcat
             _strrev _strupr _strlwr index rindex strchr strrchr strstr strtok_r
             itoa _ltoa _uitoa _ultoa strtol strtoul _i64toa _ui64toa strtoll strtoull
             atoi atof strcmp strncmp _stricmp strcasecmp _strnicmp strncasecmp strcasestr

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -973,7 +973,7 @@ if(SDL_LIBC)
     foreach(_FN
             malloc calloc realloc free bsearch qsort abs memset memcpy memmove memcmp
             wcslen _wcsdup wcsdup wcsstr wcscmp wcsncmp _wcsicmp _wcsnicmp
-            strlen _strrev _strupr _strlwr strchr strrchr strstr itoa _ltoa
+            strlen strnlen strdup strndup _strrev _strupr _strlwr strchr strrchr strstr itoa _ltoa
             _ultoa strtol strtoul strtoll strtod atoi atof strcmp strncmp
             _stricmp _strnicmp sscanf
             acos acosf asin asinf atan atanf atan2 atan2f ceil ceilf
@@ -1025,7 +1025,7 @@ if(SDL_LIBC)
                              int main(void) { return 0; }" HAVE_MPROTECT)
     foreach(_FN
             strtod malloc calloc realloc free getenv setenv putenv unsetenv
-            bsearch qsort abs bcopy memset memcpy memmove memcmp strlen strlcpy strlcat
+            bsearch qsort abs bcopy memset memcpy memmove memcmp strlen strnlen strdup strndup strlcpy strlcat
             _strrev _strupr _strlwr index rindex strchr strrchr strstr strtok_r
             itoa _ltoa _uitoa _ultoa strtol strtoul _i64toa _ui64toa strtoll strtoull
             atoi atof strcmp strncmp _stricmp strcasecmp _strnicmp strncasecmp strcasestr

--- a/include/SDL3/SDL_clipboard.h
+++ b/include/SDL3/SDL_clipboard.h
@@ -47,10 +47,27 @@ extern "C" {
  *
  * \since This function is available since SDL 3.0.0.
  *
+ * \sa SDL_SetClipboardTextBuffer
  * \sa SDL_GetClipboardText
  * \sa SDL_HasClipboardText
  */
 extern DECLSPEC int SDLCALL SDL_SetClipboardText(const char *text);
+
+/**
+ * Put UTF-8 text from a buffer into the clipboard.
+ *
+ * \param text the text to store in the clipboard
+ * \param len the number of octets in the buffer
+ * \returns 0 on success or a negative error code on failure; call
+ *          SDL_GetError() for more information.
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_SetClipboardText
+ * \sa SDL_GetClipboardText
+ * \sa SDL_HasClipboardText
+ */
+extern DECLSPEC int SDLCALL SDL_SetClipboardTextBuffer(const char *text, size_t len);
 
 /**
  * Get UTF-8 text from the clipboard, which must be freed with SDL_free().

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -538,10 +538,12 @@ extern DECLSPEC int SDLCALL SDL_wcscasecmp(const wchar_t *str1, const wchar_t *s
 extern DECLSPEC int SDLCALL SDL_wcsncasecmp(const wchar_t *str1, const wchar_t *str2, size_t len);
 
 extern DECLSPEC size_t SDLCALL SDL_strlen(const char *str);
+extern DECLSPEC size_t SDLCALL SDL_strnlen(const char *str, size_t maxlen);
 extern DECLSPEC size_t SDLCALL SDL_strlcpy(SDL_OUT_Z_CAP(maxlen) char *dst, const char *src, size_t maxlen);
 extern DECLSPEC size_t SDLCALL SDL_utf8strlcpy(SDL_OUT_Z_CAP(dst_bytes) char *dst, const char *src, size_t dst_bytes);
 extern DECLSPEC size_t SDLCALL SDL_strlcat(SDL_INOUT_Z_CAP(maxlen) char *dst, const char *src, size_t maxlen);
 extern DECLSPEC SDL_MALLOC char *SDLCALL SDL_strdup(const char *str);
+extern DECLSPEC SDL_MALLOC char *SDLCALL SDL_strndup(const char *str, size_t n);
 extern DECLSPEC char *SDLCALL SDL_strrev(char *str);
 extern DECLSPEC char *SDLCALL SDL_strupr(char *str);
 extern DECLSPEC char *SDLCALL SDL_strlwr(char *str);

--- a/src/core/android/SDL_android.h
+++ b/src/core/android/SDL_android.h
@@ -70,7 +70,7 @@ int Android_JNI_FileClose(SDL_RWops *ctx);
 void Android_JNI_GetManifestEnvironmentVariables(void);
 
 /* Clipboard support */
-int Android_JNI_SetClipboardText(const char *text);
+int Android_JNI_SetClipboardText(const char *text, size_t len, SDL_bool is_string);
 char *Android_JNI_GetClipboardText(void);
 SDL_bool Android_JNI_HasClipboardText(void);
 

--- a/src/dynapi/SDL_dynapi.sym
+++ b/src/dynapi/SDL_dynapi.sym
@@ -838,6 +838,8 @@ SDL3_0.0.0 {
     SDL_SetRenderScale;
     SDL_GetRenderScale;
     SDL_GetRenderWindowSize;
+    SDL_strnlen;
+    SDL_strndup;
     # extra symbols go here (don't modify this line)
   local: *;
 };

--- a/src/dynapi/SDL_dynapi.sym
+++ b/src/dynapi/SDL_dynapi.sym
@@ -840,6 +840,7 @@ SDL3_0.0.0 {
     SDL_GetRenderWindowSize;
     SDL_strnlen;
     SDL_strndup;
+    SDL_SetClipboardTextBuffer;
     # extra symbols go here (don't modify this line)
   local: *;
 };

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -865,3 +865,5 @@
 #define SDL_SetRenderScale SDL_SetRenderScale_REAL
 #define SDL_GetRenderScale SDL_GetRenderScale_REAL
 #define SDL_GetRenderWindowSize SDL_GetRenderWindowSize_REAL
+#define SDL_strnlen SDL_strnlen_REAL
+#define SDL_strndup SDL_strndup_REAL

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -867,3 +867,4 @@
 #define SDL_GetRenderWindowSize SDL_GetRenderWindowSize_REAL
 #define SDL_strnlen SDL_strnlen_REAL
 #define SDL_strndup SDL_strndup_REAL
+#define SDL_SetClipboardTextBuffer SDL_SetClipboardTextBuffer_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -912,3 +912,4 @@ SDL_DYNAPI_PROC(int,SDL_GetRenderScale,(SDL_Renderer *a, float *b, float *c),(a,
 SDL_DYNAPI_PROC(int,SDL_GetRenderWindowSize,(SDL_Renderer *a, int *b, int *c),(a,b,c),return)
 SDL_DYNAPI_PROC(size_t,SDL_strnlen,(const char *a, size_t b),(a,b),return)
 SDL_DYNAPI_PROC(char*,SDL_strndup,(const char *a, size_t b),(a,b),return)
+SDL_DYNAPI_PROC(int,SDL_SetClipboardTextBuffer,(const char *a, size_t b),(a,b),return)

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -910,3 +910,5 @@ SDL_DYNAPI_PROC(int,SDL_ConvertEventToRenderCoordinates,(SDL_Renderer *a, SDL_Ev
 SDL_DYNAPI_PROC(int,SDL_SetRenderScale,(SDL_Renderer *a, float b, float c),(a,b,c),return)
 SDL_DYNAPI_PROC(int,SDL_GetRenderScale,(SDL_Renderer *a, float *b, float *c),(a,b,c),return)
 SDL_DYNAPI_PROC(int,SDL_GetRenderWindowSize,(SDL_Renderer *a, int *b, int *c),(a,b,c),return)
+SDL_DYNAPI_PROC(size_t,SDL_strnlen,(const char *a, size_t b),(a,b),return)
+SDL_DYNAPI_PROC(char*,SDL_strndup,(const char *a, size_t b),(a,b),return)

--- a/src/stdlib/SDL_string.c
+++ b/src/stdlib/SDL_string.c
@@ -658,24 +658,17 @@ SDL_strlcat(SDL_INOUT_Z_CAP(maxlen) char *dst, const char *src, size_t maxlen)
 char *
 SDL_strdup(const char *string)
 {
-#if defined(HAVE_STRDUP)
-    return strdup(string);
-#else
     size_t len = SDL_strlen(string) + 1;
     char *newstr = (char *)SDL_malloc(len);
     if (newstr) {
         SDL_memcpy(newstr, string, len);
     }
     return newstr;
-#endif /* HAVE_STRDUP */
 }
 
 char *
 SDL_strndup(const char *string, size_t n)
 {
-#if defined(HAVE_STRNDUP)
-    return strndup(string);
-#else
     size_t len = SDL_strnlen(string, n);
     char *newstr = (char *)SDL_malloc(len + 1);
     if (newstr) {
@@ -683,7 +676,6 @@ SDL_strndup(const char *string, size_t n)
         newstr[len] = 0;
     }
     return newstr;
-#endif /* HAVE_STRNDUP */
 }
 
 char *

--- a/src/stdlib/SDL_string.c
+++ b/src/stdlib/SDL_string.c
@@ -355,6 +355,21 @@ SDL_strlen(const char *string)
 }
 
 size_t
+SDL_strnlen(const char *string, size_t maxlen)
+{
+#if defined(HAVE_STRNLEN)
+    return strnlen(string, maxlen);
+#else
+    /* PERF: memchr would probably be faster */
+    size_t len = 0;
+    while (len < maxlen && *string++) {
+        ++len;
+    }
+    return len;
+#endif /* HAVE_STRNLEN */
+}
+
+size_t
 SDL_wcslen(const wchar_t *string)
 {
 #if defined(HAVE_WCSLEN)
@@ -643,12 +658,32 @@ SDL_strlcat(SDL_INOUT_Z_CAP(maxlen) char *dst, const char *src, size_t maxlen)
 char *
 SDL_strdup(const char *string)
 {
+#if defined(HAVE_STRDUP)
+    return strdup(string);
+#else
     size_t len = SDL_strlen(string) + 1;
     char *newstr = (char *)SDL_malloc(len);
     if (newstr) {
         SDL_memcpy(newstr, string, len);
     }
     return newstr;
+#endif /* HAVE_STRDUP */
+}
+
+char *
+SDL_strndup(const char *string, size_t n)
+{
+#if defined(HAVE_STRNDUP)
+    return strndup(string);
+#else
+    size_t len = SDL_strnlen(string, n);
+    char *newstr = (char *)SDL_malloc(len + 1);
+    if (newstr) {
+        SDL_memcpy(newstr, string, len);
+        newstr[len] = 0;
+    }
+    return newstr;
+#endif /* HAVE_STRNDUP */
 }
 
 char *

--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -324,7 +324,7 @@ struct SDL_VideoDevice
     SDL_bool (*IsScreenKeyboardShown)(_THIS, SDL_Window *window);
 
     /* Clipboard */
-    int (*SetClipboardText)(_THIS, const char *text);
+    int (*SetClipboardText)(_THIS, const char *text, size_t len, SDL_bool is_string);
     char *(*GetClipboardText)(_THIS);
     SDL_bool (*HasClipboardText)(_THIS);
     int (*SetPrimarySelectionText)(_THIS, const char *text);
@@ -356,6 +356,7 @@ struct SDL_VideoDevice
     SDL_WindowID next_object_id;
     char *clipboard_text;
     char *primary_selection_text;
+    SDL_bool clipboard_accepts_buffer;
     SDL_bool setting_display_mode;
     Uint32 quirk_flags;
 

--- a/src/video/android/SDL_androidclipboard.c
+++ b/src/video/android/SDL_androidclipboard.c
@@ -26,9 +26,9 @@
 #include "SDL_androidclipboard.h"
 #include "../../core/android/SDL_android.h"
 
-int Android_SetClipboardText(_THIS, const char *text)
+int Android_SetClipboardText(_THIS, const char *text, size_t len, SDL_bool is_string)
 {
-    return Android_JNI_SetClipboardText(text);
+    return Android_JNI_SetClipboardText(text, len, is_string);
 }
 
 char *

--- a/src/video/android/SDL_androidclipboard.h
+++ b/src/video/android/SDL_androidclipboard.h
@@ -23,7 +23,7 @@
 #ifndef SDL_androidclipboard_h_
 #define SDL_androidclipboard_h_
 
-extern int Android_SetClipboardText(_THIS, const char *text);
+extern int Android_SetClipboardText(_THIS, const char *text, size_t len, SDL_bool is_string);
 extern char *Android_GetClipboardText(_THIS);
 extern SDL_bool Android_HasClipboardText(_THIS);
 

--- a/src/video/android/SDL_androidvideo.c
+++ b/src/video/android/SDL_androidvideo.c
@@ -152,6 +152,7 @@ static SDL_VideoDevice *Android_CreateDevice(void)
     device->IsScreenKeyboardShown = Android_IsScreenKeyboardShown;
 
     /* Clipboard */
+    device->clipboard_accepts_buffer = SDL_TRUE;
     device->SetClipboardText = Android_SetClipboardText;
     device->GetClipboardText = Android_GetClipboardText;
     device->HasClipboardText = Android_HasClipboardText;

--- a/src/video/cocoa/SDL_cocoaclipboard.h
+++ b/src/video/cocoa/SDL_cocoaclipboard.h
@@ -26,7 +26,7 @@
 /* Forward declaration */
 @class SDL_CocoaVideoData;
 
-extern int Cocoa_SetClipboardText(_THIS, const char *text);
+extern int Cocoa_SetClipboardText(_THIS, const char *text, size_t len, SDL_bool is_string);
 extern char *Cocoa_GetClipboardText(_THIS);
 extern SDL_bool Cocoa_HasClipboardText(_THIS);
 extern void Cocoa_CheckClipboardUpdate(SDL_CocoaVideoData *data);

--- a/src/video/cocoa/SDL_cocoaclipboard.m
+++ b/src/video/cocoa/SDL_cocoaclipboard.m
@@ -25,7 +25,7 @@
 #include "SDL_cocoavideo.h"
 #include "../../events/SDL_clipboardevents_c.h"
 
-int Cocoa_SetClipboardText(_THIS, const char *text)
+int Cocoa_SetClipboardText(_THIS, const char *text, size_t len, SDL_bool is_string)
 {
     @autoreleasepool {
         SDL_CocoaVideoData *data = (__bridge SDL_CocoaVideoData *)_this->driverdata;

--- a/src/video/cocoa/SDL_cocoavideo.m
+++ b/src/video/cocoa/SDL_cocoavideo.m
@@ -171,6 +171,7 @@ static SDL_VideoDevice *Cocoa_CreateDevice(void)
         device->StopTextInput = Cocoa_StopTextInput;
         device->SetTextInputRect = Cocoa_SetTextInputRect;
 
+        device->clipboard_accepts_buffer = SDL_FALSE;
         device->SetClipboardText = Cocoa_SetClipboardText;
         device->GetClipboardText = Cocoa_GetClipboardText;
         device->HasClipboardText = Cocoa_HasClipboardText;

--- a/src/video/haiku/SDL_bclipboard.cc
+++ b/src/video/haiku/SDL_bclipboard.cc
@@ -34,15 +34,12 @@
 extern "C" {
 #endif
 
-int HAIKU_SetClipboardText(_THIS, const char *text) {
+int HAIKU_SetClipboardText(_THIS, const char *text, size_t len, SDL_bool is_string SDL_UNUSED) {
     BMessage *clip = NULL;
     if (be_clipboard->Lock()) {
         be_clipboard->Clear();
         if ((clip = be_clipboard->Data())) {
-            /* Presumably the string of characters is ascii-format */
-            ssize_t asciiLength = 0;
-            for (; text[asciiLength] != 0; ++asciiLength) {}
-            clip->AddData("text/plain", B_MIME_TYPE, text, asciiLength);
+            clip->AddData("text/plain", B_MIME_TYPE, text, len);
             be_clipboard->Commit();
         }
         be_clipboard->Unlock();
@@ -52,7 +49,7 @@ int HAIKU_SetClipboardText(_THIS, const char *text) {
 
 char *HAIKU_GetClipboardText(_THIS) {
     BMessage *clip = NULL;
-    const char *text = NULL;    
+    const char *text = NULL;
     ssize_t length;
     char *result;
     if (be_clipboard->Lock()) {

--- a/src/video/haiku/SDL_bclipboard.h
+++ b/src/video/haiku/SDL_bclipboard.h
@@ -24,7 +24,7 @@
 #ifndef SDL_BCLIPBOARD_H
 #define SDL_BCLIPBOARD_H
 
-extern int HAIKU_SetClipboardText(_THIS, const char *text);
+extern int HAIKU_SetClipboardText(_THIS, const char *text, size_t len, SDL_bool is_string);
 extern char *HAIKU_GetClipboardText(_THIS);
 extern SDL_bool HAIKU_HasClipboardText(_THIS);
 

--- a/src/video/haiku/SDL_bvideo.cc
+++ b/src/video/haiku/SDL_bvideo.cc
@@ -116,6 +116,7 @@ static SDL_VideoDevice * HAIKU_CreateDevice(void)
     device->StopTextInput = HAIKU_StopTextInput;
     device->SetTextInputRect = HAIKU_SetTextInputRect;
 
+    device->clipboard_accepts_buffer = SDL_TRUE;
     device->SetClipboardText = HAIKU_SetClipboardText;
     device->GetClipboardText = HAIKU_GetClipboardText;
     device->HasClipboardText = HAIKU_HasClipboardText;

--- a/src/video/uikit/SDL_uikitclipboard.h
+++ b/src/video/uikit/SDL_uikitclipboard.h
@@ -23,7 +23,7 @@
 
 #include "../SDL_sysvideo.h"
 
-extern int UIKit_SetClipboardText(_THIS, const char *text);
+extern int UIKit_SetClipboardText(_THIS, const char *text, size_t len, SDL_bool is_string);
 extern char *UIKit_GetClipboardText(_THIS);
 extern SDL_bool UIKit_HasClipboardText(_THIS);
 

--- a/src/video/uikit/SDL_uikitclipboard.m
+++ b/src/video/uikit/SDL_uikitclipboard.m
@@ -27,7 +27,7 @@
 
 #import <UIKit/UIPasteboard.h>
 
-int UIKit_SetClipboardText(_THIS, const char *text)
+int UIKit_SetClipboardText(_THIS, const char *text, size_t len, SDL_bool is_string)
 {
 #if TARGET_OS_TV
     return SDL_SetError("The clipboard is not available on tvOS");

--- a/src/video/uikit/SDL_uikitvideo.m
+++ b/src/video/uikit/SDL_uikitvideo.m
@@ -103,6 +103,7 @@ static SDL_VideoDevice *UIKit_CreateDevice(void)
         device->SetTextInputRect = UIKit_SetTextInputRect;
 #endif
 
+        device->clipboard_accepts_buffer = SDL_FALSE;
         device->SetClipboardText = UIKit_SetClipboardText;
         device->GetClipboardText = UIKit_GetClipboardText;
         device->HasClipboardText = UIKit_HasClipboardText;

--- a/src/video/wayland/SDL_waylandclipboard.c
+++ b/src/video/wayland/SDL_waylandclipboard.c
@@ -26,7 +26,7 @@
 #include "SDL_waylandevents_c.h"
 #include "SDL_waylandclipboard.h"
 
-int Wayland_SetClipboardText(_THIS, const char *text)
+int Wayland_SetClipboardText(_THIS, const char *text, size_t len, SDL_bool is_string SDL_UNUSED)
 {
     SDL_VideoData *video_data = NULL;
     SDL_WaylandDataDevice *data_device = NULL;
@@ -39,10 +39,9 @@ int Wayland_SetClipboardText(_THIS, const char *text)
         video_data = _this->driverdata;
         if (video_data->input != NULL && video_data->input->data_device != NULL) {
             data_device = video_data->input->data_device;
-            if (text[0] != '\0') {
+            if (len) {
                 SDL_WaylandDataSource *source = Wayland_data_source_create(_this);
-                Wayland_data_source_add_data(source, TEXT_MIME, text,
-                                             SDL_strlen(text));
+                Wayland_data_source_add_data(source, TEXT_MIME, text, len);
 
                 status = Wayland_data_device_set_selection(data_device, source);
                 if (status != 0) {

--- a/src/video/wayland/SDL_waylandclipboard.h
+++ b/src/video/wayland/SDL_waylandclipboard.h
@@ -23,7 +23,7 @@
 #ifndef SDL_waylandclipboard_h_
 #define SDL_waylandclipboard_h_
 
-extern int Wayland_SetClipboardText(_THIS, const char *text);
+extern int Wayland_SetClipboardText(_THIS, const char *text, size_t len, SDL_bool is_string);
 extern char *Wayland_GetClipboardText(_THIS);
 extern SDL_bool Wayland_HasClipboardText(_THIS);
 extern int Wayland_SetPrimarySelectionText(_THIS, const char *text);

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -249,6 +249,7 @@ static SDL_VideoDevice *Wayland_CreateDevice(void)
     device->FlashWindow = Wayland_FlashWindow;
     device->HasScreenKeyboardSupport = Wayland_HasScreenKeyboardSupport;
 
+    device->clipboard_accepts_buffer = SDL_TRUE;
     device->SetClipboardText = Wayland_SetClipboardText;
     device->GetClipboardText = Wayland_GetClipboardText;
     device->HasClipboardText = Wayland_HasClipboardText;

--- a/src/video/windows/SDL_windowsclipboard.c
+++ b/src/video/windows/SDL_windowsclipboard.c
@@ -44,7 +44,7 @@ static HWND GetWindowHandle(_THIS)
     return NULL;
 }
 
-int WIN_SetClipboardText(_THIS, const char *text)
+int WIN_SetClipboardText(_THIS, const char *text, size_t len, SDL_bool is_string SDL_UNUSED)
 {
     SDL_VideoData *data = _this->driverdata;
     int result = 0;

--- a/src/video/windows/SDL_windowsclipboard.h
+++ b/src/video/windows/SDL_windowsclipboard.h
@@ -26,7 +26,7 @@
 /* Forward declaration */
 struct SDL_VideoData;
 
-extern int WIN_SetClipboardText(_THIS, const char *text);
+extern int WIN_SetClipboardText(_THIS, const char *text, size_t len, SDL_bool is_string);
 extern char *WIN_GetClipboardText(_THIS);
 extern SDL_bool WIN_HasClipboardText(_THIS);
 extern void WIN_CheckClipboardUpdate(struct SDL_VideoData *data);

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -253,6 +253,7 @@ static SDL_VideoDevice *WIN_CreateDevice(void)
     device->ClearComposition = WIN_ClearComposition;
     device->IsTextInputShown = WIN_IsTextInputShown;
 
+    device->clipboard_accepts_buffer = SDL_FALSE;
     device->SetClipboardText = WIN_SetClipboardText;
     device->GetClipboardText = WIN_GetClipboardText;
     device->HasClipboardText = WIN_HasClipboardText;

--- a/src/video/x11/SDL_x11clipboard.h
+++ b/src/video/x11/SDL_x11clipboard.h
@@ -34,7 +34,7 @@ enum ESDLX11ClipboardMimeType
     SDL_X11_CLIPBOARD_MIME_TYPE_MAX
 };
 
-extern int X11_SetClipboardText(_THIS, const char *text);
+extern int X11_SetClipboardText(_THIS, const char *text, size_t len, SDL_bool is_string);
 extern char *X11_GetClipboardText(_THIS);
 extern SDL_bool X11_HasClipboardText(_THIS);
 extern int X11_SetPrimarySelectionText(_THIS, const char *text);

--- a/src/video/x11/SDL_x11video.c
+++ b/src/video/x11/SDL_x11video.c
@@ -293,6 +293,7 @@ static SDL_VideoDevice *X11_CreateDevice(void)
 #endif
 #endif
 
+    device->clipboard_accepts_buffer = SDL_TRUE;
     device->SetClipboardText = X11_SetClipboardText;
     device->GetClipboardText = X11_GetClipboardText;
     device->HasClipboardText = X11_HasClipboardText;

--- a/test/testautomation_clipboard.c
+++ b/test/testautomation_clipboard.c
@@ -118,7 +118,6 @@ int clipboard_testSetClipboardTextBuffer(void *arg)
     SDL_free(textRef);
     SDL_free(text);
 
-
     return TEST_COMPLETED;
 }
 
@@ -255,7 +254,6 @@ int clipboard_testPrimarySelectionTextFunctions(void *arg)
     char *text = SDL_strdup(textRef);
     SDL_bool boolResult;
     int intResult;
-    int lenLimit;
     char *charResult;
 
     /* Clear primary selection text state */

--- a/test/testautomation_clipboard.c
+++ b/test/testautomation_clipboard.c
@@ -94,6 +94,35 @@ int clipboard_testSetClipboardText(void *arg)
 }
 
 /**
+ * \brief Check call to SDL_SetClipboardTextBuffer
+ * \sa SDL_SetClipboardTextBuffer
+ */
+int clipboard_testSetClipboardTextBuffer(void *arg)
+{
+    char *textRef = SDLTest_RandomAsciiString();
+    char *text = SDL_strdup(textRef);
+    int lenLimit = 8;
+    int result;
+    result = SDL_SetClipboardTextBuffer((const char *)text, lenLimit);
+    SDLTest_AssertPass("Call to SDL_SetClipboardTextBuffer succeeded");
+    SDLTest_AssertCheck(
+        result == 0,
+        "Validate SDL_SetClipboardTextBuffer result, expected 0, got %i",
+        result);
+    SDLTest_AssertCheck(
+        SDL_strcmp(textRef, text) == 0,
+        "Verify SDL_SetClipboardTextBuffer did not modify input string, expected '%s', got '%s'",
+        textRef, text);
+
+    /* Cleanup */
+    SDL_free(textRef);
+    SDL_free(text);
+
+
+    return TEST_COMPLETED;
+}
+
+/**
  * \brief Check call to SDL_SetPrimarySelectionText
  * \sa SDL_SetPrimarySelectionText
  */
@@ -125,6 +154,7 @@ int clipboard_testSetPrimarySelectionText(void *arg)
  * \sa SDL_HasClipboardText
  * \sa SDL_GetClipboardText
  * \sa SDL_SetClipboardText
+ * \sa SDL_SetClipboardTextBuffer
  */
 int clipboard_testClipboardTextFunctions(void *arg)
 {
@@ -132,6 +162,7 @@ int clipboard_testClipboardTextFunctions(void *arg)
     char *text = SDL_strdup(textRef);
     SDL_bool boolResult;
     int intResult;
+    int lenLimit;
     char *charResult;
 
     /* Clear clipboard text state */
@@ -189,6 +220,21 @@ int clipboard_testClipboardTextFunctions(void *arg)
         "Verify SDL_GetClipboardText returned correct string, expected '%s', got '%s'",
         textRef, charResult);
 
+    /* Verify adding part of buffer to clipboard */
+    lenLimit = 8;
+    intResult = SDL_SetClipboardTextBuffer((const char *)text, lenLimit);
+    SDLTest_AssertPass("Call to SDL_SetClipboardTextBuffer with length succeeded");
+    charResult = SDL_GetClipboardText();
+    SDLTest_AssertPass("Call to SDL_GetClipboardText succeeded");
+    SDLTest_AssertCheck(
+        SDL_strlen(charResult) == lenLimit,
+        "Verify clipboard string length, expected '%i', got '%i'",
+        lenLimit, (int)SDL_strlen(charResult));
+    SDLTest_AssertCheck(
+        SDL_strncmp(textRef, charResult, lenLimit) == 0,
+        "Verify SDL_GetClipboardText returned correct string, expected '%.*s', got '%s'",
+        lenLimit, textRef, charResult);
+
     /* Cleanup */
     SDL_free(textRef);
     SDL_free(text);
@@ -209,6 +255,7 @@ int clipboard_testPrimarySelectionTextFunctions(void *arg)
     char *text = SDL_strdup(textRef);
     SDL_bool boolResult;
     int intResult;
+    int lenLimit;
     char *charResult;
 
     /* Clear primary selection text state */
@@ -298,20 +345,24 @@ static const SDLTest_TestCaseReference clipboardTest5 = {
 };
 
 static const SDLTest_TestCaseReference clipboardTest6 = {
-    (SDLTest_TestCaseFp)clipboard_testSetPrimarySelectionText, "clipboard_testSetPrimarySelectionText", "Check call to SDL_SetPrimarySelectionText", TEST_ENABLED
+    (SDLTest_TestCaseFp)clipboard_testSetClipboardTextBuffer, "clipboard_testSetClipboardTextBuffer", "Check call to SDL_SetClipboardTextBuffer", TEST_ENABLED
 };
 
 static const SDLTest_TestCaseReference clipboardTest7 = {
-    (SDLTest_TestCaseFp)clipboard_testClipboardTextFunctions, "clipboard_testClipboardTextFunctions", "End-to-end test of SDL_xyzClipboardText functions", TEST_ENABLED
+    (SDLTest_TestCaseFp)clipboard_testSetPrimarySelectionText, "clipboard_testSetPrimarySelectionText", "Check call to SDL_SetPrimarySelectionText", TEST_ENABLED
 };
 
 static const SDLTest_TestCaseReference clipboardTest8 = {
+    (SDLTest_TestCaseFp)clipboard_testClipboardTextFunctions, "clipboard_testClipboardTextFunctions", "End-to-end test of SDL_xyzClipboardText functions", TEST_ENABLED
+};
+
+static const SDLTest_TestCaseReference clipboardTest9 = {
     (SDLTest_TestCaseFp)clipboard_testPrimarySelectionTextFunctions, "clipboard_testPrimarySelectionTextFunctions", "End-to-end test of SDL_xyzPrimarySelectionText functions", TEST_ENABLED
 };
 
 /* Sequence of Clipboard test cases */
 static const SDLTest_TestCaseReference *clipboardTests[] = {
-    &clipboardTest1, &clipboardTest2, &clipboardTest3, &clipboardTest4, &clipboardTest5, &clipboardTest6, &clipboardTest7, &clipboardTest8, NULL
+    &clipboardTest1, &clipboardTest2, &clipboardTest3, &clipboardTest4, &clipboardTest5, &clipboardTest6, &clipboardTest7, &clipboardTest8, &clipboardTest9, NULL
 };
 
 /* Clipboard test suite (global) */


### PR DESCRIPTION
_WARNING: All code except X11 is untested. CI failures and lots of rebasing is inevitable._

The purpose of which is to allow clients to pass in data from buffers that are not zero-terminated, with minimal copying.
    
Implements non-pessimized paths to the clipboard on a few select platforms as a starting point.

## Description

A flag `clipboard_accepts_buffer` was added to VideoDevice, and the prototype for
`device->SetClipboardText` extended to allow the backends to make better decisions.

For X11, Wayland and Haiku this is set to true, and `SDL_SetClipboardTextBuffer`
can pass the input straight through. Nice.

For Android it is also set to true, but here the backend use new device->SetClipboardText
arguments to convert the incoming buffer to a jstring if it is required.

For Windows, Cocoa and uikit `clipboard_accepts_buffer` is set to false, and
in this case `SDL_SetClipboardTextBuffer` will strndup the incoming data and provide
the backends with a string like it's always worked.

Adds `SDL_strnlen()` and `SDL_strndup()` to stdlib.

## Q & A

Q: Why not `SDL_SetPrimarySelectionText`?
A: Keeping it simple. The main clipboard is more widely supported, and more important.

Q: What about Windows though, surely..?
A: Yes. I believe we could just change `tstr = WIN_UTF8ToString(text);` to pass through `len` to `SDL_iconv_string` and it should work. It's still doing copying, but we wouldn't add to the pile.

Q: Apple platforms?
A: I tried, but I don't speak ObjectiveC so I left it out for expedience. I can post my attempt as a comment, for humor.

## Existing Issue(s)

Fixes #7371
