### PR TITLE
cmake: use compatible interface properties to disallow linking to a different version of SDL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3245,9 +3245,13 @@ if(SDL_SHARED)
       target_link_options(SDL3-shared PRIVATE -static-libgcc)
     endif()
   endif()
-  # Use `Compatible Interface Properties` to allow consumers to enforce a shared/static library
-  set_property(TARGET SDL3-shared PROPERTY INTERFACE_SDL3_SHARED TRUE)
+  # Use `Compatible Interface Properties` to:
+  # - allow consumers to enforce a shared/static library
+  # - block linking to SDL libraries of different major version
   set_property(TARGET SDL3-shared APPEND PROPERTY COMPATIBLE_INTERFACE_BOOL SDL3_SHARED)
+  set_property(TARGET SDL3-shared PROPERTY INTERFACE_SDL3_SHARED TRUE)
+  set_property(TARGET SDL3-shared APPEND PROPERTY COMPATIBLE_INTERFACE_STRING "SDL_VERSION")
+  set_property(TARGET SDL3-shared PROPERTY INTERFACE_SDL_VERSION "SDL${SDL3_VERSION_MAJOR}")
   if(NOT CMAKE_VERSION VERSION_LESS "3.16")
     target_precompile_headers(SDL3-shared PRIVATE "${PROJECT_SOURCE_DIR}/src/SDL_internal.h")
   endif()
@@ -3283,9 +3287,13 @@ if(SDL_STATIC)
   # This picks up all the compiler options and such we've accumulated up to here.
   target_link_libraries(SDL3-static PRIVATE $<${build_local_interface}:sdl-build-options>)
   target_link_libraries(SDL3-static PRIVATE $<${build_local_interface}:sdl-global-options>)
-  # Use `Compatible Interface Properties` to allow consumers to enforce a shared/static library
-  set_property(TARGET SDL3-static PROPERTY INTERFACE_SDL3_SHARED FALSE)
+  # Use `Compatible Interface Properties` to:
+  # - allow consumers to enforce a shared/static library
+  # - block linking to SDL libraries of different major version
   set_property(TARGET SDL3-static APPEND PROPERTY COMPATIBLE_INTERFACE_BOOL SDL3_SHARED)
+  set_property(TARGET SDL3-static PROPERTY INTERFACE_SDL3_SHARED FALSE)
+  set_property(TARGET SDL3-static APPEND PROPERTY COMPATIBLE_INTERFACE_STRING "SDL_VERSION")
+  set_property(TARGET SDL3-static PROPERTY INTERFACE_SDL_VERSION "SDL${SDL3_VERSION_MAJOR}")
   if(NOT CMAKE_VERSION VERSION_LESS "3.16")
     target_precompile_headers(SDL3-static PRIVATE "${PROJECT_SOURCE_DIR}/src/SDL_internal.h")
   endif()
@@ -3322,6 +3330,8 @@ if(SDL_TEST)
   )
   target_link_libraries(SDL3_test PUBLIC $<TARGET_NAME:SDL3::Headers>)
   target_link_libraries(SDL3_test PRIVATE ${EXTRA_TEST_LIBS})
+  set_property(TARGET SDL3_test APPEND PROPERTY COMPATIBLE_INTERFACE_STRING "SDL_VERSION")
+  set_property(TARGET SDL3_test PROPERTY INTERFACE_SDL_VERSION "SDL${SDL3_VERSION_MAJOR}")
 endif()
 
 ##### Configure installation folders #####

--- a/VisualC/pkg-support/cmake/sdl3-config.cmake
+++ b/VisualC/pkg-support/cmake/sdl3-config.cmake
@@ -72,6 +72,8 @@ if(EXISTS "${_sdl3_library}" AND EXISTS "${_sdl3_dll_library}")
                 IMPORTED_LOCATION "${_sdl3_dll_library}"
                 COMPATIBLE_INTERFACE_BOOL "SDL3_SHARED"
                 INTERFACE_SDL3_SHARED "ON"
+                COMPATIBLE_INTERFACE_STRING "SDL_VERSION"
+                INTERFACE_SDL_VERSION "SDL3"
         )
     endif()
     set(SDL3_SDL3-shared_FOUND TRUE)
@@ -91,6 +93,8 @@ if(EXISTS "${_sdl3test_library}")
             PROPERTIES
                 INTERFACE_LINK_LIBRARIES "SDL3::Headers"
                 IMPORTED_LOCATION "${_sdl3test_library}"
+                COMPATIBLE_INTERFACE_STRING "SDL_VERSION"
+                INTERFACE_SDL_VERSION "SDL3"
         )
     endif()
     set(SDL3_SDL3_test_FOUND TRUE)

--- a/Xcode/SDL/pkg-support/resources/CMake/sdl3-config.cmake
+++ b/Xcode/SDL/pkg-support/resources/CMake/sdl3-config.cmake
@@ -65,6 +65,8 @@ if(NOT TARGET SDL3::SDL3-shared)
             IMPORTED_SONAME "${_sdl3_framework_path}/SDL3"
             COMPATIBLE_INTERFACE_BOOL "SDL3_SHARED"
             INTERFACE_SDL3_SHARED "ON"
+            COMPATIBLE_INTERFACE_STRING "SDL_VERSION"
+            INTERFACE_SDL_VERSION "SDL3"
     )
 endif()
 set(SDL3_SDL3-shared_FOUND TRUE)


### PR DESCRIPTION
With this change, CMake will detect and block linking to SDL2 and SDL3 simultaneously.
(SDL2 will need a similar change)

The following trivial CMake script will fail to configure:
```cmake
cmake_minimum_required(VERSION 3.25)
project(test_compatible_interface_properties C)

find_package(SDL2 REQUIRED CONFIG)
find_package(SDL3 REQUIRED CONFIG)

file(WRITE main.c [[
#include "SDL.h"

int main(int argc, char *argv[]) {
 SDL_Init(SDL_INIT_EVERYTHING);
 SDL_Quit();
 return 0;
}
]])

add_executable(main main.c)
target_link_libraries(main PRIVATE SDL2::SDL2 SDL3::SDL3)
```

The error is:
```
-- Configuring done
CMake Error: The INTERFACE_SDL_VERSION property of "SDL3::SDL3-shared" does
not agree with the value of SDL_VERSION already determined
for "main".

-- Generating done
CMake Generate step failed.  Build files cannot be regenerated correctly.
```