### PR TITLE
The gamepad event structures caxis, cbutton, cdevice, ctouchpad, and …

### DIFF
--- a/build-scripts/SDL_migration.cocci
+++ b/build-scripts/SDL_migration.cocci
@@ -2467,3 +2467,53 @@ expression e2;
 - SDL_IsScreenSaverEnabled
 + SDL_ScreenSaverEnabled
   (...)
+@@
+SDL_Event e1;
+@@
+- e1.caxis
++ e1.gaxis
+@@
+SDL_Event e1;
+@@
+- e1.cbutton
++ e1.gbutton
+@@
+SDL_Event e1;
+@@
+- e1.cdevice
++ e1.gdevice
+@@
+SDL_Event e1;
+@@
+- e1.ctouchpad
++ e1.gtouchpad
+@@
+SDL_Event e1;
+@@
+- e1.csensor
++ e1.gsensor
+@@
+SDL_Event *e1;
+@@
+- e1->caxis
++ e1->gaxis
+@@
+SDL_Event *e1;
+@@
+- e1->cbutton
++ e1->gbutton
+@@
+SDL_Event *e1;
+@@
+- e1->cdevice
++ e1->gdevice
+@@
+SDL_Event *e1;
+@@
+- e1->ctouchpad
++ e1->gtouchpad
+@@
+SDL_Event *e1;
+@@
+- e1->csensor
++ e1->gsensor

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -148,6 +148,8 @@ The SDL_EVENT_WINDOW_RESIZED event is always sent, even in response to SDL_SetWi
 
 The SDL_EVENT_WINDOW_SIZE_CHANGED event has been removed, and you can use SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED to detect window backbuffer size changes.
 
+The gamepad event structures caxis, cbutton, cdevice, ctouchpad, and csensor have been renamed gaxis, gbutton, gdevice, gtouchpad, and gsensor.
+
 SDL_QUERY, SDL_IGNORE, SDL_ENABLE, and SDL_DISABLE have been removed. You can use the functions SDL_SetEventEnabled() and SDL_EventEnabled() to set and query event processing state.
 
 The following symbols have been renamed:

--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -405,7 +405,7 @@ typedef struct SDL_JoyBatteryEvent
 } SDL_JoyBatteryEvent;
 
 /**
- *  \brief Gamepad axis motion event structure (event.caxis.*)
+ *  \brief Gamepad axis motion event structure (event.gaxis.*)
  */
 typedef struct SDL_GamepadAxisEvent
 {
@@ -422,7 +422,7 @@ typedef struct SDL_GamepadAxisEvent
 
 
 /**
- *  \brief Gamepad button event structure (event.cbutton.*)
+ *  \brief Gamepad button event structure (event.gbutton.*)
  */
 typedef struct SDL_GamepadButtonEvent
 {
@@ -437,7 +437,7 @@ typedef struct SDL_GamepadButtonEvent
 
 
 /**
- *  \brief Gamepad device event structure (event.cdevice.*)
+ *  \brief Gamepad device event structure (event.gdevice.*)
  */
 typedef struct SDL_GamepadDeviceEvent
 {
@@ -447,7 +447,7 @@ typedef struct SDL_GamepadDeviceEvent
 } SDL_GamepadDeviceEvent;
 
 /**
- *  \brief Gamepad touchpad event structure (event.ctouchpad.*)
+ *  \brief Gamepad touchpad event structure (event.gtouchpad.*)
  */
 typedef struct SDL_GamepadTouchpadEvent
 {
@@ -462,7 +462,7 @@ typedef struct SDL_GamepadTouchpadEvent
 } SDL_GamepadTouchpadEvent;
 
 /**
- *  \brief Gamepad sensor event structure (event.csensor.*)
+ *  \brief Gamepad sensor event structure (event.gsensor.*)
  */
 typedef struct SDL_GamepadSensorEvent
 {
@@ -602,11 +602,11 @@ typedef union SDL_Event
     SDL_JoyButtonEvent jbutton;             /**< Joystick button event data */
     SDL_JoyDeviceEvent jdevice;             /**< Joystick device change event data */
     SDL_JoyBatteryEvent jbattery;           /**< Joystick battery event data */
-    SDL_GamepadAxisEvent caxis;             /**< Gamepad axis event data */
-    SDL_GamepadButtonEvent cbutton;         /**< Gamepad button event data */
-    SDL_GamepadDeviceEvent cdevice;         /**< Gamepad device event data */
-    SDL_GamepadTouchpadEvent ctouchpad;     /**< Gamepad touchpad event data */
-    SDL_GamepadSensorEvent csensor;         /**< Gamepad sensor event data */
+    SDL_GamepadAxisEvent gaxis;             /**< Gamepad axis event data */
+    SDL_GamepadButtonEvent gbutton;         /**< Gamepad button event data */
+    SDL_GamepadDeviceEvent gdevice;         /**< Gamepad device event data */
+    SDL_GamepadTouchpadEvent gtouchpad;     /**< Gamepad touchpad event data */
+    SDL_GamepadSensorEvent gsensor;         /**< Gamepad sensor event data */
     SDL_AudioDeviceEvent adevice;           /**< Audio device event data */
     SDL_SensorEvent sensor;                 /**< Sensor event data */
     SDL_QuitEvent quit;                     /**< Quit request event data */

--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -346,14 +346,14 @@ static void SDL_LogEvent(const SDL_Event *event)
 
         SDL_EVENT_CASE(SDL_EVENT_GAMEPAD_AXIS_MOTION)
         (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u which=%d axis=%u value=%d)",
-                           (uint)event->caxis.timestamp, (int)event->caxis.which,
-                           (uint)event->caxis.axis, (int)event->caxis.value);
+                           (uint)event->gaxis.timestamp, (int)event->gaxis.which,
+                           (uint)event->gaxis.axis, (int)event->gaxis.value);
         break;
 
 #define PRINT_CBUTTON_EVENT(event)                                                              \
     (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u which=%d button=%u state=%s)", \
-                       (uint)event->cbutton.timestamp, (int)event->cbutton.which,               \
-                       (uint)event->cbutton.button, event->cbutton.state == SDL_PRESSED ? "pressed" : "released")
+                       (uint)event->gbutton.timestamp, (int)event->gbutton.which,               \
+                       (uint)event->gbutton.button, event->gbutton.state == SDL_PRESSED ? "pressed" : "released")
         SDL_EVENT_CASE(SDL_EVENT_GAMEPAD_BUTTON_DOWN)
         PRINT_CBUTTON_EVENT(event);
         break;
@@ -362,7 +362,7 @@ static void SDL_LogEvent(const SDL_Event *event)
         break;
 #undef PRINT_CBUTTON_EVENT
 
-#define PRINT_GAMEPADDEV_EVENT(event) (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u which=%d)", (uint)event->cdevice.timestamp, (int)event->cdevice.which)
+#define PRINT_GAMEPADDEV_EVENT(event) (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u which=%d)", (uint)event->gdevice.timestamp, (int)event->gdevice.which)
         SDL_EVENT_CASE(SDL_EVENT_GAMEPAD_ADDED)
         PRINT_GAMEPADDEV_EVENT(event);
         break;
@@ -376,9 +376,9 @@ static void SDL_LogEvent(const SDL_Event *event)
 
 #define PRINT_CTOUCHPAD_EVENT(event)                                                                                     \
     (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u which=%d touchpad=%d finger=%d x=%f y=%f pressure=%f)", \
-                       (uint)event->ctouchpad.timestamp, (int)event->ctouchpad.which,                                    \
-                       (int)event->ctouchpad.touchpad, (int)event->ctouchpad.finger,                                     \
-                       event->ctouchpad.x, event->ctouchpad.y, event->ctouchpad.pressure)
+                       (uint)event->gtouchpad.timestamp, (int)event->gtouchpad.which,                                    \
+                       (int)event->gtouchpad.touchpad, (int)event->gtouchpad.finger,                                     \
+                       event->gtouchpad.x, event->gtouchpad.y, event->gtouchpad.pressure)
         SDL_EVENT_CASE(SDL_EVENT_GAMEPAD_TOUCHPAD_DOWN)
         PRINT_CTOUCHPAD_EVENT(event);
         break;
@@ -392,8 +392,8 @@ static void SDL_LogEvent(const SDL_Event *event)
 
         SDL_EVENT_CASE(SDL_EVENT_GAMEPAD_SENSOR_UPDATE)
         (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u which=%d sensor=%d data[0]=%f data[1]=%f data[2]=%f)",
-                           (uint)event->csensor.timestamp, (int)event->csensor.which, (int)event->csensor.sensor,
-                           event->csensor.data[0], event->csensor.data[1], event->csensor.data[2]);
+                           (uint)event->gsensor.timestamp, (int)event->gsensor.which, (int)event->gsensor.sensor,
+                           event->gsensor.data[0], event->gsensor.data[1], event->gsensor.data[2]);
         break;
 
 #define PRINT_FINGER_EVENT(event)                                                                                                                      \

--- a/src/joystick/SDL_gamepad.c
+++ b/src/joystick/SDL_gamepad.c
@@ -419,7 +419,7 @@ static int SDLCALL SDL_GamepadEventWatcher(void *userdata, SDL_Event *event)
 
             deviceevent.type = SDL_EVENT_GAMEPAD_ADDED;
             deviceevent.common.timestamp = 0;
-            deviceevent.cdevice.which = event->jdevice.which;
+            deviceevent.gdevice.which = event->jdevice.which;
             SDL_PushEvent(&deviceevent);
         }
     } break;
@@ -440,7 +440,7 @@ static int SDLCALL SDL_GamepadEventWatcher(void *userdata, SDL_Event *event)
 
             deviceevent.type = SDL_EVENT_GAMEPAD_REMOVED;
             deviceevent.common.timestamp = 0;
-            deviceevent.cdevice.which = event->jdevice.which;
+            deviceevent.gdevice.which = event->jdevice.which;
             SDL_PushEvent(&deviceevent);
         }
     } break;
@@ -1214,7 +1214,7 @@ static void SDL_PrivateRefreshGamepadMapping(GamepadMapping_t *pGamepadMapping)
 
                 event.type = SDL_EVENT_GAMEPAD_REMAPPED;
                 event.common.timestamp = 0;
-                event.cdevice.which = gamepad->joystick->instance_id;
+                event.gdevice.which = gamepad->joystick->instance_id;
                 SDL_PushEvent(&event);
             }
         }
@@ -1901,7 +1901,7 @@ int SDL_InitGamepads(void)
                 SDL_Event deviceevent;
                 deviceevent.type = SDL_EVENT_GAMEPAD_ADDED;
                 deviceevent.common.timestamp = 0;
-                deviceevent.cdevice.which = joysticks[i];
+                deviceevent.gdevice.which = joysticks[i];
                 SDL_PushEvent(&deviceevent);
             }
         }
@@ -3060,9 +3060,9 @@ static int SDL_SendGamepadAxis(Uint64 timestamp, SDL_Gamepad *gamepad, SDL_Gamep
         SDL_Event event;
         event.type = SDL_EVENT_GAMEPAD_AXIS_MOTION;
         event.common.timestamp = timestamp;
-        event.caxis.which = gamepad->joystick->instance_id;
-        event.caxis.axis = axis;
-        event.caxis.value = value;
+        event.gaxis.which = gamepad->joystick->instance_id;
+        event.gaxis.axis = axis;
+        event.gaxis.value = value;
         posted = SDL_PushEvent(&event) == 1;
     }
 #endif /* !SDL_EVENTS_DISABLED */
@@ -3120,9 +3120,9 @@ static int SDL_SendGamepadButton(Uint64 timestamp, SDL_Gamepad *gamepad, SDL_Gam
 #if !SDL_EVENTS_DISABLED
     if (SDL_EventEnabled(event.type)) {
         event.common.timestamp = timestamp;
-        event.cbutton.which = gamepad->joystick->instance_id;
-        event.cbutton.button = button;
-        event.cbutton.state = state;
+        event.gbutton.which = gamepad->joystick->instance_id;
+        event.gbutton.button = button;
+        event.gbutton.state = state;
         posted = SDL_PushEvent(&event) == 1;
     }
 #endif /* !SDL_EVENTS_DISABLED */

--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -2959,12 +2959,12 @@ int SDL_SendJoystickTouchpad(Uint64 timestamp, SDL_Joystick *joystick, int touch
         SDL_Event event;
         event.type = event_type;
         event.common.timestamp = timestamp;
-        event.ctouchpad.which = joystick->instance_id;
-        event.ctouchpad.touchpad = touchpad;
-        event.ctouchpad.finger = finger;
-        event.ctouchpad.x = x;
-        event.ctouchpad.y = y;
-        event.ctouchpad.pressure = pressure;
+        event.gtouchpad.which = joystick->instance_id;
+        event.gtouchpad.touchpad = touchpad;
+        event.gtouchpad.finger = finger;
+        event.gtouchpad.x = x;
+        event.gtouchpad.y = y;
+        event.gtouchpad.pressure = pressure;
         posted = SDL_PushEvent(&event) == 1;
     }
 #endif /* !SDL_EVENTS_DISABLED */
@@ -2999,12 +2999,15 @@ int SDL_SendJoystickSensor(Uint64 timestamp, SDL_Joystick *joystick, SDL_SensorT
                     SDL_Event event;
                     event.type = SDL_EVENT_GAMEPAD_SENSOR_UPDATE;
                     event.common.timestamp = timestamp;
-                    event.csensor.which = joystick->instance_id;
-                    event.csensor.sensor = type;
-                    num_values = SDL_min(num_values, SDL_arraysize(event.csensor.data));
-                    SDL_memset(event.csensor.data, 0, sizeof(event.csensor.data));
-                    SDL_memcpy(event.csensor.data, data, num_values * sizeof(*data));
-                    event.csensor.sensor_timestamp = sensor_timestamp;
+                    event.gsensor.which = joystick->instance_id;
+                    event.gsensor.sensor = type;
+                    num_values = SDL_min(num_values,
+                                         SDL_arraysize(event.gsensor.data));
+                    SDL_memset(event.gsensor.data, 0,
+                               sizeof(event.gsensor.data));
+                    SDL_memcpy(event.gsensor.data, data,
+                               num_values * sizeof(*data));
+                    event.gsensor.sensor_timestamp = sensor_timestamp;
                     posted = SDL_PushEvent(&event) == 1;
                 }
 #endif /* !SDL_EVENTS_DISABLED */

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1681,28 +1681,28 @@ static void SDLTest_PrintEvent(SDL_Event *event)
         break;
     case SDL_EVENT_GAMEPAD_ADDED:
         SDL_Log("SDL EVENT: Gamepad index %" SDL_PRIu32 " attached",
-                event->cdevice.which);
+                event->gdevice.which);
         break;
     case SDL_EVENT_GAMEPAD_REMOVED:
         SDL_Log("SDL EVENT: Gamepad %" SDL_PRIu32 " removed",
-                event->cdevice.which);
+                event->gdevice.which);
         break;
     case SDL_EVENT_GAMEPAD_AXIS_MOTION:
         SDL_Log("SDL EVENT: Gamepad %" SDL_PRIu32 " axis %d ('%s') value: %d",
-                event->caxis.which,
-                event->caxis.axis,
-                GamepadAxisName((SDL_GamepadAxis)event->caxis.axis),
-                event->caxis.value);
+                event->gaxis.which,
+                event->gaxis.axis,
+                GamepadAxisName((SDL_GamepadAxis)event->gaxis.axis),
+                event->gaxis.value);
         break;
     case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
         SDL_Log("SDL EVENT: Gamepad %" SDL_PRIu32 "button %d ('%s') down",
-                event->cbutton.which, event->cbutton.button,
-                GamepadButtonName((SDL_GamepadButton)event->cbutton.button));
+                event->gbutton.which, event->gbutton.button,
+                GamepadButtonName((SDL_GamepadButton)event->gbutton.button));
         break;
     case SDL_EVENT_GAMEPAD_BUTTON_UP:
         SDL_Log("SDL EVENT: Gamepad %" SDL_PRIu32 " button %d ('%s') up",
-                event->cbutton.which, event->cbutton.button,
-                GamepadButtonName((SDL_GamepadButton)event->cbutton.button));
+                event->gbutton.which, event->gbutton.button,
+                GamepadButtonName((SDL_GamepadButton)event->gbutton.button));
         break;
     case SDL_EVENT_CLIPBOARD_UPDATE:
         SDL_Log("SDL EVENT: Clipboard updated");

--- a/test/testgamepad.c
+++ b/test/testgamepad.c
@@ -629,61 +629,69 @@ void loop(void *arg)
             break;
 
         case SDL_EVENT_GAMEPAD_ADDED:
-            SDL_Log("Gamepad device %" SDL_PRIu32 " added.\n", event.cdevice.which);
-            AddGamepad(event.cdevice.which, SDL_TRUE);
+            SDL_Log("Gamepad device %" SDL_PRIu32 " added.\n",
+                    event.gdevice.which);
+            AddGamepad(event.gdevice.which, SDL_TRUE);
             break;
 
         case SDL_EVENT_GAMEPAD_REMOVED:
-            SDL_Log("Gamepad device %" SDL_PRIu32 " removed.\n", event.cdevice.which);
-            DelGamepad(event.cdevice.which);
+            SDL_Log("Gamepad device %" SDL_PRIu32 " removed.\n",
+                    event.gdevice.which);
+            DelGamepad(event.gdevice.which);
             break;
 
         case SDL_EVENT_GAMEPAD_TOUCHPAD_DOWN:
         case SDL_EVENT_GAMEPAD_TOUCHPAD_MOTION:
         case SDL_EVENT_GAMEPAD_TOUCHPAD_UP:
             SDL_Log("Gamepad %" SDL_PRIu32 " touchpad %" SDL_PRIs32 " finger %" SDL_PRIs32 " %s %.2f, %.2f, %.2f\n",
-                    event.ctouchpad.which,
-                    event.ctouchpad.touchpad,
-                    event.ctouchpad.finger,
+                    event.gtouchpad.which,
+                    event.gtouchpad.touchpad,
+                    event.gtouchpad.finger,
                     (event.type == SDL_EVENT_GAMEPAD_TOUCHPAD_DOWN ? "pressed at" : (event.type == SDL_EVENT_GAMEPAD_TOUCHPAD_UP ? "released at" : "moved to")),
-                    event.ctouchpad.x,
-                    event.ctouchpad.y,
-                    event.ctouchpad.pressure);
+                    event.gtouchpad.x,
+                    event.gtouchpad.y,
+                    event.gtouchpad.pressure);
             break;
 
 #define VERBOSE_SENSORS
 #ifdef VERBOSE_SENSORS
         case SDL_EVENT_GAMEPAD_SENSOR_UPDATE:
             SDL_Log("Gamepad %" SDL_PRIu32 " sensor %s: %.2f, %.2f, %.2f (%" SDL_PRIu64 ")\n",
-                    event.csensor.which,
-                    GetSensorName((SDL_SensorType)event.csensor.sensor),
-                    event.csensor.data[0],
-                    event.csensor.data[1],
-                    event.csensor.data[2],
-                    event.csensor.sensor_timestamp);
+                    event.gsensor.which,
+                    GetSensorName((SDL_SensorType) event.gsensor.sensor),
+                    event.gsensor.data[0],
+                    event.gsensor.data[1],
+                    event.gsensor.data[2],
+                    event.gsensor.sensor_timestamp);
             break;
 #endif /* VERBOSE_SENSORS */
 
 #define VERBOSE_AXES
 #ifdef VERBOSE_AXES
         case SDL_EVENT_GAMEPAD_AXIS_MOTION:
-            if (event.caxis.value <= (-SDL_JOYSTICK_AXIS_MAX / 2) || event.caxis.value >= (SDL_JOYSTICK_AXIS_MAX / 2)) {
-                SetGamepad(event.caxis.which);
+            if (event.gaxis.value <= (-SDL_JOYSTICK_AXIS_MAX / 2) || event.gaxis.value >= (SDL_JOYSTICK_AXIS_MAX / 2)) {
+                SetGamepad(event.gaxis.which);
             }
-            SDL_Log("Gamepad %" SDL_PRIu32 " axis %s changed to %d\n", event.caxis.which, SDL_GetGamepadStringForAxis((SDL_GamepadAxis)event.caxis.axis), event.caxis.value);
+            SDL_Log("Gamepad %" SDL_PRIu32 " axis %s changed to %d\n",
+                    event.gaxis.which,
+                    SDL_GetGamepadStringForAxis((SDL_GamepadAxis) event.gaxis.axis),
+                    event.gaxis.value);
             break;
 #endif /* VERBOSE_AXES */
 
         case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
         case SDL_EVENT_GAMEPAD_BUTTON_UP:
             if (event.type == SDL_EVENT_GAMEPAD_BUTTON_DOWN) {
-                SetGamepad(event.cbutton.which);
+                SetGamepad(event.gbutton.which);
             }
-            SDL_Log("Gamepad %" SDL_PRIu32 " button %s %s\n", event.cbutton.which, SDL_GetGamepadStringForButton((SDL_GamepadButton)event.cbutton.button), event.cbutton.state ? "pressed" : "released");
+            SDL_Log("Gamepad %" SDL_PRIu32 " button %s %s\n",
+                    event.gbutton.which,
+                    SDL_GetGamepadStringForButton((SDL_GamepadButton) event.gbutton.button),
+                    event.gbutton.state ? "pressed" : "released");
 
             /* Cycle PS5 trigger effects when the microphone button is pressed */
             if (event.type == SDL_EVENT_GAMEPAD_BUTTON_DOWN &&
-                event.cbutton.button == SDL_GAMEPAD_BUTTON_MISC1 &&
+                event.gbutton.button == SDL_GAMEPAD_BUTTON_MISC1 &&
                 SDL_GetGamepadType(gamepad) == SDL_GAMEPAD_TYPE_PS5) {
                 CyclePS5TriggerEffect();
             }


### PR DESCRIPTION
…csensor have been renamed gaxis, gbutton, gdevice, gtouchpad, and gsensor.

Fixes https://github.com/libsdl-org/SDL/issues/7375