### PR TITLE
testautomation_pixels/audio: use SDL_arraysize and fix warnings

### DIFF
--- a/test/testautomation_audio.c
+++ b/test/testautomation_audio.c
@@ -508,10 +508,10 @@ static const char *g_audioFormatsVerbose[] = { "AUDIO_S8", "AUDIO_U8", "AUDIO_S1
                                        "AUDIO_S32LSB", "AUDIO_S32MSB", "AUDIO_S32SYS", "AUDIO_S32",
                                        "AUDIO_F32LSB", "AUDIO_F32MSB", "AUDIO_F32SYS", "AUDIO_F32" };
 static const int g_numAudioFormats = SDL_arraysize(g_audioFormats);
-static const int g_numAudioChannels = 4;
 static Uint8 g_audioChannels[] = { 1, 2, 4, 6 };
-static const int g_numAudioFrequencies = 4;
+static const int g_numAudioChannels = SDL_arraysize(g_audioChannels);
 static int g_audioFrequencies[] = { 11025, 22050, 44100, 48000 };
+static const int g_numAudioFrequencies = SDL_arraysize(g_audioFrequencies);
 
 /**
  * \brief Builds various audio conversion structures

--- a/test/testautomation_pixels.c
+++ b/test/testautomation_pixels.c
@@ -7,8 +7,7 @@
 /* Test case functions */
 
 /* Definition of all RGB formats used to test pixel conversions */
-const int g_numAllFormats = 38;
-Uint32 g_AllFormats[] = {
+static const Uint32 g_AllFormats[] = {
     SDL_PIXELFORMAT_INDEX1LSB,
     SDL_PIXELFORMAT_INDEX1MSB,
     SDL_PIXELFORMAT_INDEX4LSB,
@@ -48,8 +47,9 @@ Uint32 g_AllFormats[] = {
     SDL_PIXELFORMAT_NV12,
     SDL_PIXELFORMAT_NV21
 };
+static const int g_numAllFormats = SDL_arraysize(g_AllFormats);
 
-const char *g_AllFormatsVerbose[] = {
+static const char *g_AllFormatsVerbose[] = {
     "SDL_PIXELFORMAT_INDEX1LSB",
     "SDL_PIXELFORMAT_INDEX1MSB",
     "SDL_PIXELFORMAT_INDEX4LSB",
@@ -91,12 +91,12 @@ const char *g_AllFormatsVerbose[] = {
 };
 
 /* Definition of some invalid formats for negative tests */
-const int g_numInvalidPixelFormats = 2;
 static Uint32 g_invalidPixelFormats[] = {
     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_ABGR, SDL_PACKEDLAYOUT_1010102 + 1, 32, 4),
     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_ABGR, SDL_PACKEDLAYOUT_1010102 + 2, 32, 4)
 };
-const char *g_invalidPixelFormatsVerbose[] = {
+static const int g_numInvalidPixelFormats = SDL_arraysize(g_invalidPixelFormats);
+static const char *g_invalidPixelFormatsVerbose[] = {
     "SDL_PIXELFORMAT_UNKNOWN",
     "SDL_PIXELFORMAT_UNKNOWN"
 };
@@ -109,7 +109,7 @@ const char *g_invalidPixelFormatsVerbose[] = {
  * \sa SDL_CreatePixelFormat
  * \sa SDL_DestroyPixelFormat
  */
-int pixels_allocFreeFormat(void *arg)
+static int pixels_allocFreeFormat(void *arg)
 {
     const char *unknownFormat = "SDL_PIXELFORMAT_UNKNOWN";
     const char *expectedError = "Parameter 'format' is invalid";
@@ -204,7 +204,7 @@ int pixels_allocFreeFormat(void *arg)
  *
  * \sa SDL_GetPixelFormatName
  */
-int pixels_getPixelFormatName(void *arg)
+static int pixels_getPixelFormatName(void *arg)
 {
     const char *unknownFormat = "SDL_PIXELFORMAT_UNKNOWN";
     const char *error;
@@ -272,7 +272,7 @@ int pixels_getPixelFormatName(void *arg)
  * \sa SDL_CreatePalette
  * \sa SDL_DestroyPalette
  */
-int pixels_allocFreePalette(void *arg)
+static int pixels_allocFreePalette(void *arg)
 {
     const char *expectedError1 = "Parameter 'ncolors' is invalid";
     const char *expectedError2 = "Parameter 'palette' is invalid";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
