### PR TITLE
Implement cross-platform tooltips and popup menus

### DIFF
--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -1092,6 +1092,8 @@ SDL_GL_GetSwapInterval() takes the interval as an output parameter and returns 0
 
 SDL_GL_GetDrawableSize() has been removed. SDL_GetWindowSizeInPixels() can be used in its place.
 
+The SDL_WINDOW_TOOLTIP and SDL_WINDOW_POPUP_MENU window flags are now supported on Windows, Mac (Cocoa), X11, and Wayland. Creating windows with these flags must happen via the `SDL_CreatePopupWindow()` function. This function requires passing in the handle to a valid parent window for the popup, and the popup window is positioned relative to the parent.
+
 The following functions have been renamed:
 * SDL_GetClosestDisplayMode() => SDL_GetClosestFullscreenDisplayMode()
 * SDL_GetPointDisplayIndex() => SDL_GetDisplayForPoint()

--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -658,10 +658,57 @@ extern DECLSPEC Uint32 SDLCALL SDL_GetWindowPixelFormat(SDL_Window *window);
  *
  * \since This function is available since SDL 3.0.0.
  *
+ * \sa SDL_CreatePopupWindow
  * \sa SDL_CreateWindowFrom
  * \sa SDL_DestroyWindow
  */
 extern DECLSPEC SDL_Window *SDLCALL SDL_CreateWindow(const char *title, int w, int h, Uint32 flags);
+
+/**
+ * Create a child popup window of the specified parent window.
+ *
+ * 'flags' **must** contain exactly one of the following:
+ * - 'SDL_WINDOW_TOOLTIP': The popup window is a tooltip and will not pass any input events
+ * - 'SDL_WINDOW_POPUP_MENU': The popup window is a popup menu
+ *
+ * The following flags are not valid for popup windows and will be ignored:
+ * - 'SDL_WINDOW_MINIMIZED'
+ * - 'SDL_WINDOW_MAXIMIZED'
+ * - 'SDL_WINDOW_FULLSCREEN'
+ * - `SDL_WINDOW_BORDERLESS`
+ * - `SDL_WINDOW_MOUSE_GRABBED`
+ *
+ * The parent parameter **must** be non-null and a valid window.
+ * The parent of a popup window can be either a regular, toplevel window,
+ * or another popup window.
+ *
+ * Popup windows cannot be minimized, maximized, made fullscreen, or grab
+ * the mouse. Attempts to do so will fail.
+ *
+ * If a parent window is hidden, any child popup windows will be recursively
+ * hidden as well. Child popup windows not explicitly hidden will be restored
+ * when the parent is shown.
+ *
+ * If the parent window is destroyed, any child popup windows will be
+ * recursively destroyed as well.
+ *
+ * \param parent the parent of the window, must not be NULL
+ * \param offset_x the x position of the popup window relative to the origin
+ *                 of the parent, in screen coordinates
+ * \param offset_y the y position of the popup window relative to the origin
+ *                 of the parent window, in screen coordinates
+ * \param w the width of the window, in screen coordinates
+ * \param h the height of the window, in screen coordinates
+ * \param flags 0, or one or more SDL_WindowFlags OR'd together
+ * \returns the window that was created or NULL on failure; call
+ *          SDL_GetError() for more information.
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_CreateWindow
+ * \sa SDL_DestroyWindow
+ */
+extern DECLSPEC SDL_Window *SDLCALL SDL_CreatePopupWindow(SDL_Window *parent, int offset_x, int offset_y, int w, int h, Uint32 flags);
 
 /**
  * Create an SDL window from an existing native window.

--- a/src/dynapi/SDL_dynapi.sym
+++ b/src/dynapi/SDL_dynapi.sym
@@ -839,6 +839,7 @@ SDL3_0.0.0 {
     SDL_GetRenderScale;
     SDL_GetRenderWindowSize;
     SDL_GetSystemTheme;
+    SDL_CreatePopupWindow;
     # extra symbols go here (don't modify this line)
   local: *;
 };

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -866,3 +866,4 @@
 #define SDL_GetRenderScale SDL_GetRenderScale_REAL
 #define SDL_GetRenderWindowSize SDL_GetRenderWindowSize_REAL
 #define SDL_GetSystemTheme SDL_GetSystemTheme_REAL
+#define SDL_CreatePopupWindow SDL_CreatePopupWindow_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -911,3 +911,4 @@ SDL_DYNAPI_PROC(int,SDL_SetRenderScale,(SDL_Renderer *a, float b, float c),(a,b,
 SDL_DYNAPI_PROC(int,SDL_GetRenderScale,(SDL_Renderer *a, float *b, float *c),(a,b,c),return)
 SDL_DYNAPI_PROC(int,SDL_GetRenderWindowSize,(SDL_Renderer *a, int *b, int *c),(a,b,c),return)
 SDL_DYNAPI_PROC(SDL_SystemTheme,SDL_GetSystemTheme,(void),(),return)
+SDL_DYNAPI_PROC(SDL_Window*,SDL_CreatePopupWindow,(SDL_Window *a, int b, int c, int d, int e, Uint32 f),(a,b,c,d,e,f),return)

--- a/src/events/SDL_windowevents.c
+++ b/src/events/SDL_windowevents.c
@@ -212,10 +212,18 @@ int SDL_SendWindowEvent(SDL_Window *window, SDL_EventType windowevent,
         break;
     }
 
-    if (windowevent == SDL_EVENT_WINDOW_CLOSE_REQUESTED) {
-        if (!window->prev && !window->next) {
+    if (windowevent == SDL_EVENT_WINDOW_CLOSE_REQUESTED && window->parent == NULL) {
+        int toplevel_count = 0;
+        SDL_Window *n;
+        for (n = SDL_GetVideoDevice()->windows; n != NULL; n = n->next) {
+            if (n->parent == NULL) {
+                ++toplevel_count;
+            }
+        }
+
+        if (toplevel_count == 1) {
             if (SDL_GetHintBoolean(SDL_HINT_QUIT_ON_LAST_WINDOW_CLOSE, SDL_TRUE)) {
-                SDL_SendQuit(); /* This is the last window in the list so send the SDL_EVENT_QUIT event */
+                SDL_SendQuit(); /* This is the last toplevel window in the list so send the SDL_EVENT_QUIT event */
             }
         }
     }

--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -98,6 +98,7 @@ struct SDL_Window
     SDL_bool surface_valid;
 
     SDL_bool is_hiding;
+    SDL_bool restore_on_show; /* Child was hidden recursively by the parent, restore when shown. */
     SDL_bool is_destroying;
     SDL_bool is_dropping; /* drag/drop in progress, expecting SDL_SendDropComplete(). */
 
@@ -114,12 +115,21 @@ struct SDL_Window
 
     SDL_Window *prev;
     SDL_Window *next;
+
+    SDL_Window *parent;
+    SDL_Window *first_child;
+    SDL_Window *prev_sibling;
+    SDL_Window *next_sibling;
 };
 #define SDL_WINDOW_FULLSCREEN_VISIBLE(W)        \
     ((((W)->flags & SDL_WINDOW_FULLSCREEN) != 0) &&   \
      (((W)->flags & SDL_WINDOW_HIDDEN) == 0) && \
      (((W)->flags & SDL_WINDOW_MINIMIZED) == 0))
 
+#define SDL_WINDOW_IS_POPUP(W)                   \
+    ((((W)->flags & SDL_WINDOW_TOOLTIP) != 0) || \
+    (((W)->flags & SDL_WINDOW_POPUP_MENU) != 0)) \
+                                                 \
 /*
  * Define the SDL display structure.
  * This corresponds to physical monitors attached to the system.
@@ -153,6 +163,7 @@ typedef enum
 {
     VIDEO_DEVICE_QUIRK_MODE_SWITCHING_EMULATED = 0x01,
     VIDEO_DEVICE_QUIRK_DISABLE_UNSET_FULLSCREEN_ON_MINIMIZE = 0x02,
+    VIDEO_DEVICE_QUIRK_HAS_POPUP_WINDOW_SUPPORT = 0x04,
 } DeviceQuirkFlags;
 
 struct SDL_VideoDevice
@@ -496,6 +507,8 @@ extern void SDL_GL_DeduceMaxSupportedESProfile(int *major, int *minor);
 
 extern int SDL_RecreateWindow(SDL_Window *window, Uint32 flags);
 extern SDL_bool SDL_HasWindows(void);
+extern void SDL_RelativeToGlobalForWindow(SDL_Window *window, int rel_x, int rel_y, int *abs_x, int *abs_y);
+extern void SDL_GlobalToRelativeForWindow(SDL_Window *window, int abs_x, int abs_y, int *rel_x, int *rel_y);
 
 extern void SDL_OnWindowShown(SDL_Window *window);
 extern void SDL_OnWindowHidden(SDL_Window *window);

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -145,6 +145,12 @@ static VideoBootStrap *bootstrap[] = {
         return retval;                                                  \
     }                                                                   \
 
+#define CHECK_WINDOW_NOT_POPUP(window, retval)                          \
+    if (SDL_WINDOW_IS_POPUP(window)) {                                  \
+        SDL_SetError("Operation invalid on popup windows");             \
+        return retval;                                                  \
+    }
+
 #if defined(__MACOS__) && defined(SDL_VIDEO_DRIVER_COCOA)
 /* Support for macOS fullscreen spaces */
 extern SDL_bool Cocoa_IsWindowInFullscreenSpace(SDL_Window *window);
@@ -1230,6 +1236,46 @@ static SDL_DisplayID GetDisplayForRect(int x, int y, int w, int h)
     return closest;
 }
 
+void SDL_RelativeToGlobalForWindow(SDL_Window *window, int rel_x, int rel_y, int *abs_x, int *abs_y)
+{
+    SDL_Window *w;
+
+    if (SDL_WINDOW_IS_POPUP(window)) {
+        /* Calculate the total offset of the popup from the parents */
+        for (w = window->parent; w != NULL; w = w->parent) {
+            rel_x += w->x;
+            rel_y += w->y;
+        }
+    }
+
+    if (abs_x) {
+        *abs_x = rel_x;
+    }
+    if (abs_y) {
+        *abs_y = rel_y;
+    }
+}
+
+void SDL_GlobalToRelativeForWindow(SDL_Window *window, int abs_x, int abs_y, int *rel_x, int *rel_y)
+{
+    SDL_Window *w;
+
+    if (SDL_WINDOW_IS_POPUP(window)) {
+        /* Convert absolute window coordinates to relative for a popup */
+        for (w = window->parent; w != NULL; w = w->parent) {
+            abs_x -= w->x;
+            abs_y -= w->y;
+        }
+    }
+
+    if (rel_x) {
+        *rel_x = abs_x;
+    }
+    if (rel_y) {
+        *rel_y = abs_y;
+    }
+}
+
 SDL_DisplayID SDL_GetDisplayForPoint(const SDL_Point *point)
 {
     return GetDisplayForRect(point->x, point->y, 1, 1);
@@ -1242,6 +1288,7 @@ SDL_DisplayID SDL_GetDisplayForRect(const SDL_Rect *rect)
 
 static SDL_DisplayID SDL_GetDisplayForWindowPosition(SDL_Window *window)
 {
+    int x, y;
     SDL_DisplayID displayID = 0;
 
     CHECK_WINDOW_MAGIC(window, 0);
@@ -1254,8 +1301,10 @@ static SDL_DisplayID SDL_GetDisplayForWindowPosition(SDL_Window *window)
      * (for example if the window is off-screen), but other code may expect it
      * to succeed in that situation, so we fall back to a generic position-
      * based implementation in that case. */
+    SDL_RelativeToGlobalForWindow(window, window->x, window->y, &x, &y);
+
     if (!displayID) {
-        displayID = GetDisplayForRect(window->x, window->y, window->w, window->h);
+        displayID = GetDisplayForRect(x, y, window->w, window->h);
     }
     if (!displayID) {
         /* Use the primary display for a window if we can't find it anywhere else */
@@ -1536,6 +1585,7 @@ error:
 int SDL_SetWindowFullscreenMode(SDL_Window *window, const SDL_DisplayMode *mode)
 {
     CHECK_WINDOW_MAGIC(window, -1);
+    CHECK_WINDOW_NOT_POPUP(window, -1);
 
     if (mode) {
         if (!SDL_GetFullscreenModeMatch(mode)) {
@@ -1561,6 +1611,7 @@ int SDL_SetWindowFullscreenMode(SDL_Window *window, const SDL_DisplayMode *mode)
 const SDL_DisplayMode *SDL_GetWindowFullscreenMode(SDL_Window *window)
 {
     CHECK_WINDOW_MAGIC(window, NULL);
+    CHECK_WINDOW_NOT_POPUP(window, NULL);
 
     if (window->flags & SDL_WINDOW_FULLSCREEN) {
         return SDL_GetFullscreenModeMatch(&window->current_fullscreen_mode);
@@ -1668,12 +1719,10 @@ static int SDL_DllNotSupported(const char *name)
     return SDL_SetError("No dynamic %s support in current SDL video driver (%s)", name, _this->name);
 }
 
-SDL_Window *SDL_CreateWindow(const char *title, int w, int h, Uint32 flags)
+SDL_Window *SDL_CreateWindowInternal(const char *title, int x, int y, int w, int h, SDL_Window *parent, Uint32 flags)
 {
     SDL_Window *window;
     Uint32 type_flags, graphics_flags;
-    int x = SDL_WINDOWPOS_UNDEFINED;
-    int y = SDL_WINDOWPOS_UNDEFINED;
     SDL_bool undefined_x = SDL_FALSE;
     SDL_bool undefined_y = SDL_FALSE;
 
@@ -1698,6 +1747,12 @@ SDL_Window *SDL_CreateWindow(const char *title, int w, int h, Uint32 flags)
     type_flags = flags & (SDL_WINDOW_UTILITY | SDL_WINDOW_TOOLTIP | SDL_WINDOW_POPUP_MENU);
     if (type_flags & (type_flags - 1)) {
         SDL_SetError("Conflicting window type flags specified: 0x%.8x", (unsigned int)type_flags);
+        return NULL;
+    }
+
+    /* Tooltip and popup menu window must specify a parent window */
+    if (!parent && ((type_flags & SDL_WINDOW_TOOLTIP) || (type_flags & SDL_WINDOW_POPUP_MENU))) {
+        SDL_SetError("Tooltip and popup menu windows must specify a parent window");
         return NULL;
     }
 
@@ -1824,6 +1879,16 @@ SDL_Window *SDL_CreateWindow(const char *title, int w, int h, Uint32 flags)
     }
     _this->windows = window;
 
+    if (parent) {
+        window->parent = parent;
+
+        window->next_sibling = parent->first_child;
+        if (parent->first_child) {
+            parent->first_child->prev_sibling = window;
+        }
+        parent->first_child = window;
+    }
+
     if (_this->CreateSDLWindow && _this->CreateSDLWindow(_this, window) < 0) {
         SDL_DestroyWindow(window);
         return NULL;
@@ -1861,6 +1926,33 @@ SDL_Window *SDL_CreateWindow(const char *title, int w, int h, Uint32 flags)
     }
 
     return window;
+}
+
+SDL_Window *SDL_CreateWindow(const char *title, int w, int h, Uint32 flags)
+{
+    return SDL_CreateWindowInternal(title, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, w , h, NULL, flags);
+}
+
+SDL_Window *SDL_CreatePopupWindow(SDL_Window *parent, int offset_x, int offset_y, int w, int h, Uint32 flags)
+{
+    if (!(_this->quirk_flags & VIDEO_DEVICE_QUIRK_HAS_POPUP_WINDOW_SUPPORT)) {
+        SDL_Unsupported();
+        return NULL;
+    }
+
+    /* Parent must be a valid window */
+    CHECK_WINDOW_MAGIC(parent, NULL);
+
+    /* Remove invalid flags */
+    flags &= ~(SDL_WINDOW_MINIMIZED | SDL_WINDOW_MAXIMIZED | SDL_WINDOW_FULLSCREEN | SDL_WINDOW_MOUSE_GRABBED);
+
+    /* Popups must specify either the tooltip or popup menu window flags */
+    if ((flags & SDL_WINDOW_TOOLTIP) || (flags & SDL_WINDOW_POPUP_MENU)) {
+        return SDL_CreateWindowInternal(NULL, offset_x, offset_y, w, h, parent, flags);
+    }
+
+    SDL_SetError("Popup windows must specify either the 'SDL_WINDOW_TOOLTIP' or the 'SDL_WINDOW_POPUP_MENU' flag");
+    return NULL;
 }
 
 SDL_Window *SDL_CreateWindowFrom(const void *data)
@@ -2106,6 +2198,7 @@ Uint32 SDL_GetWindowFlags(SDL_Window *window)
 int SDL_SetWindowTitle(SDL_Window *window, const char *title)
 {
     CHECK_WINDOW_MAGIC(window, -1);
+    CHECK_WINDOW_NOT_POPUP(window, -1);
 
     if (title == window->title) {
         return 0;
@@ -2326,6 +2419,7 @@ int SDL_GetWindowPosition(SDL_Window *window, int *x, int *y)
 int SDL_SetWindowBordered(SDL_Window *window, SDL_bool bordered)
 {
     CHECK_WINDOW_MAGIC(window, -1);
+    CHECK_WINDOW_NOT_POPUP(window, -1);
     if (!(window->flags & SDL_WINDOW_FULLSCREEN)) {
         const int want = (bordered != SDL_FALSE); /* normalize the flag. */
         const int have = !(window->flags & SDL_WINDOW_BORDERLESS);
@@ -2344,6 +2438,7 @@ int SDL_SetWindowBordered(SDL_Window *window, SDL_bool bordered)
 int SDL_SetWindowResizable(SDL_Window *window, SDL_bool resizable)
 {
     CHECK_WINDOW_MAGIC(window, -1);
+    CHECK_WINDOW_NOT_POPUP(window, -1);
     if (!(window->flags & SDL_WINDOW_FULLSCREEN)) {
         const int want = (resizable != SDL_FALSE); /* normalize the flag. */
         const int have = ((window->flags & SDL_WINDOW_RESIZABLE) != 0);
@@ -2362,6 +2457,7 @@ int SDL_SetWindowResizable(SDL_Window *window, SDL_bool resizable)
 int SDL_SetWindowAlwaysOnTop(SDL_Window *window, SDL_bool on_top)
 {
     CHECK_WINDOW_MAGIC(window, -1);
+    CHECK_WINDOW_NOT_POPUP(window, -1);
     if (!(window->flags & SDL_WINDOW_FULLSCREEN)) {
         const int want = (on_top != SDL_FALSE); /* normalize the flag. */
         const int have = ((window->flags & SDL_WINDOW_ALWAYS_ON_TOP) != 0);
@@ -2580,9 +2676,16 @@ int SDL_GetWindowMaximumSize(SDL_Window *window, int *max_w, int *max_h)
 
 int SDL_ShowWindow(SDL_Window *window)
 {
+    SDL_Window *child;
     CHECK_WINDOW_MAGIC(window, -1);
 
     if (!(window->flags & SDL_WINDOW_HIDDEN)) {
+        return 0;
+    }
+
+    /* If the parent is hidden, set the flag to restore this when the parent is shown */
+    if (window->parent && (window->parent->flags & SDL_WINDOW_HIDDEN)) {
+        window->restore_on_show = SDL_TRUE;
         return 0;
     }
 
@@ -2590,15 +2693,35 @@ int SDL_ShowWindow(SDL_Window *window)
         _this->ShowWindow(_this, window);
     }
     SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_SHOWN, 0, 0);
+
+    /* Restore child windows */
+    for (child = window->first_child; child != NULL; child = child->next_sibling) {
+        if (!child->restore_on_show && (child->flags & SDL_WINDOW_HIDDEN)) {
+            break;
+        }
+        SDL_ShowWindow(child);
+        child->restore_on_show = SDL_FALSE;
+    }
     return 0;
 }
 
 int SDL_HideWindow(SDL_Window *window)
 {
+    SDL_Window *child;
     CHECK_WINDOW_MAGIC(window, -1);
 
     if (window->flags & SDL_WINDOW_HIDDEN) {
+        window->restore_on_show = SDL_FALSE;
         return 0;
+    }
+
+    /* Hide all child windows */
+    for (child = window->first_child; child != NULL; child = child->next_sibling) {
+        if (child->flags & SDL_WINDOW_HIDDEN) {
+            break;
+        }
+        SDL_HideWindow(child);
+        child->restore_on_show = SDL_TRUE;
     }
 
     window->is_hiding = SDL_TRUE;
@@ -2626,6 +2749,7 @@ int SDL_RaiseWindow(SDL_Window *window)
 int SDL_MaximizeWindow(SDL_Window *window)
 {
     CHECK_WINDOW_MAGIC(window, -1);
+    CHECK_WINDOW_NOT_POPUP(window, -1);
 
     if (window->flags & SDL_WINDOW_MAXIMIZED) {
         return 0;
@@ -2641,7 +2765,7 @@ int SDL_MaximizeWindow(SDL_Window *window)
 
 static SDL_bool SDL_CanMinimizeWindow(SDL_Window *window)
 {
-    if (!_this->MinimizeWindow) {
+    if (!_this->MinimizeWindow || SDL_WINDOW_IS_POPUP(window)) {
         return SDL_FALSE;
     }
     return SDL_TRUE;
@@ -2650,6 +2774,7 @@ static SDL_bool SDL_CanMinimizeWindow(SDL_Window *window)
 int SDL_MinimizeWindow(SDL_Window *window)
 {
     CHECK_WINDOW_MAGIC(window, -1);
+    CHECK_WINDOW_NOT_POPUP(window, -1);
 
     if (window->flags & SDL_WINDOW_MINIMIZED) {
         return 0;
@@ -2672,6 +2797,7 @@ int SDL_MinimizeWindow(SDL_Window *window)
 int SDL_RestoreWindow(SDL_Window *window)
 {
     CHECK_WINDOW_MAGIC(window, -1);
+    CHECK_WINDOW_NOT_POPUP(window, -1);
 
     if (!(window->flags & (SDL_WINDOW_MAXIMIZED | SDL_WINDOW_MINIMIZED))) {
         return 0;
@@ -2689,6 +2815,7 @@ int SDL_SetWindowFullscreen(SDL_Window *window, SDL_bool fullscreen)
     Uint32 flags = fullscreen ? SDL_WINDOW_FULLSCREEN : 0;
 
     CHECK_WINDOW_MAGIC(window, -1);
+    CHECK_WINDOW_NOT_POPUP(window, -1);
 
     if (flags == (window->flags & SDL_WINDOW_FULLSCREEN)) {
         return 0;
@@ -2949,6 +3076,7 @@ void SDL_UpdateWindowGrab(SDL_Window *window)
 int SDL_SetWindowGrab(SDL_Window *window, SDL_bool grabbed)
 {
     CHECK_WINDOW_MAGIC(window, -1);
+    CHECK_WINDOW_NOT_POPUP(window, -1);
 
     SDL_SetWindowMouseGrab(window, grabbed);
 
@@ -3232,6 +3360,23 @@ void SDL_DestroyWindow(SDL_Window *window)
     CHECK_WINDOW_MAGIC(window,);
 
     window->is_destroying = SDL_TRUE;
+
+    /* Destroy any child windows of this window */
+    while (window->first_child) {
+        SDL_DestroyWindow(window->first_child);
+    }
+
+    /* If this is a child window, unlink it from its siblings */
+    if (window->parent) {
+        if (window->next_sibling) {
+            window->next_sibling->prev_sibling = window->prev_sibling;
+        }
+        if (window->prev_sibling) {
+            window->prev_sibling->next_sibling = window->next_sibling;
+        } else {
+            window->parent->first_child = window->next_sibling;
+        }
+    }
 
     /* Restore video mode, etc. */
     SDL_UpdateFullscreenMode(window, SDL_FALSE);

--- a/src/video/cocoa/SDL_cocoavideo.m
+++ b/src/video/cocoa/SDL_cocoavideo.m
@@ -177,6 +177,8 @@ static SDL_VideoDevice *Cocoa_CreateDevice(void)
 
         device->free = Cocoa_DeleteDevice;
 
+        device->quirk_flags = VIDEO_DEVICE_QUIRK_HAS_POPUP_WINDOW_SUPPORT;
+
         return device;
     }
 }

--- a/src/video/cocoa/SDL_cocoawindow.h
+++ b/src/video/cocoa/SDL_cocoawindow.h
@@ -131,6 +131,7 @@ typedef enum
 @property(nonatomic) SDL_bool inWindowFullscreenTransition;
 @property(nonatomic) NSInteger window_number;
 @property(nonatomic) NSInteger flash_request;
+@property(nonatomic) SDL_Window *keyboard_focus;
 @property(nonatomic) Cocoa_WindowListener *listener;
 @property(nonatomic) SDL_CocoaVideoData *videodata;
 #if SDL_VIDEO_OPENGL_EGL

--- a/src/video/wayland/SDL_waylanddyn.h
+++ b/src/video/wayland/SDL_waylanddyn.h
@@ -160,6 +160,7 @@ void SDL_WAYLAND_UnloadSymbols(void);
 #define libdecor_frame_set_parent               (*WAYLAND_libdecor_frame_set_parent)
 #define libdecor_frame_get_xdg_surface          (*WAYLAND_libdecor_frame_get_xdg_surface)
 #define libdecor_frame_get_xdg_toplevel         (*WAYLAND_libdecor_frame_get_xdg_toplevel)
+#define libdecor_frame_translate_coordinate     (*WAYLAND_libdecor_frame_translate_coordinate)
 #define libdecor_frame_map                      (*WAYLAND_libdecor_frame_map)
 #define libdecor_state_new                      (*WAYLAND_libdecor_state_new)
 #define libdecor_state_free                     (*WAYLAND_libdecor_state_free)

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -1355,7 +1355,9 @@ static void keyboard_handle_enter(void *data, struct wl_keyboard *keyboard,
     if (window) {
         input->keyboard_focus = window;
         window->keyboard_device = input;
-        SDL_SetKeyboardFocus(window->sdlwindow);
+
+        /* Restore the keyboard focus to the child popup that was holding it */
+        SDL_SetKeyboardFocus(window->keyboard_focus ? window->keyboard_focus : window->sdlwindow);
     }
 #ifdef SDL_USE_IME
     if (!input->text_input) {

--- a/src/video/wayland/SDL_waylandopengles.c
+++ b/src/video/wayland/SDL_waylandopengles.c
@@ -115,7 +115,8 @@ int Wayland_GLES_SwapWindow(_THIS, SDL_Window *window)
      * FIXME: Request EGL_WAYLAND_swap_buffers_with_timeout.
      * -flibit
      */
-    if (window->flags & SDL_WINDOW_HIDDEN) {
+    if (data->surface_status != WAYLAND_SURFACE_STATUS_SHOWN &&
+        data->surface_status != WAYLAND_SURFACE_STATUS_WAITING_FOR_FRAME) {
         return 0;
     }
 

--- a/src/video/wayland/SDL_waylandsym.h
+++ b/src/video/wayland/SDL_waylandsym.h
@@ -206,6 +206,7 @@ SDL_WAYLAND_SYM(void, libdecor_frame_set_parent, (struct libdecor_frame *,\
                                                   struct libdecor_frame *))
 SDL_WAYLAND_SYM(struct xdg_surface *, libdecor_frame_get_xdg_surface, (struct libdecor_frame *))
 SDL_WAYLAND_SYM(struct xdg_toplevel *, libdecor_frame_get_xdg_toplevel, (struct libdecor_frame *))
+SDL_WAYLAND_SYM(void, libdecor_frame_translate_coordinate, (struct libdecor_frame *, int, int, int *, int *))
 SDL_WAYLAND_SYM(void, libdecor_frame_map, (struct libdecor_frame *))
 SDL_WAYLAND_SYM(struct libdecor_state *, libdecor_state_new, (int, int))
 SDL_WAYLAND_SYM(void, libdecor_state_free, (struct libdecor_state *))

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -239,6 +239,7 @@ static SDL_VideoDevice *Wayland_CreateDevice(void)
     device->RestoreWindow = Wayland_RestoreWindow;
     device->SetWindowBordered = Wayland_SetWindowBordered;
     device->SetWindowResizable = Wayland_SetWindowResizable;
+    device->SetWindowPosition = Wayland_SetWindowPosition;
     device->SetWindowSize = Wayland_SetWindowSize;
     device->SetWindowMinimumSize = Wayland_SetWindowMinimumSize;
     device->SetWindowMaximumSize = Wayland_SetWindowMaximumSize;
@@ -275,7 +276,8 @@ static SDL_VideoDevice *Wayland_CreateDevice(void)
     device->free = Wayland_DeleteDevice;
 
     device->quirk_flags = VIDEO_DEVICE_QUIRK_MODE_SWITCHING_EMULATED |
-                          VIDEO_DEVICE_QUIRK_DISABLE_UNSET_FULLSCREEN_ON_MINIMIZE;
+                          VIDEO_DEVICE_QUIRK_DISABLE_UNSET_FULLSCREEN_ON_MINIMIZE |
+                          VIDEO_DEVICE_QUIRK_HAS_POPUP_WINDOW_SUPPORT;
 
     return device;
 }

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -41,7 +41,7 @@ struct SDL_WindowData
     struct wl_callback *gles_swap_frame_callback;
     struct wl_event_queue *gles_swap_frame_event_queue;
     struct wl_surface *gles_swap_frame_surface_wrapper;
-    struct wl_callback *surface_damage_frame_callback;
+    struct wl_callback *surface_frame_callback;
 
     union
     {
@@ -62,8 +62,6 @@ struct SDL_WindowData
                 {
                     struct xdg_popup *popup;
                     struct xdg_positioner *positioner;
-                    Uint32 parentID;
-                    SDL_Window *child;
                 } popup;
             } roleobj;
             SDL_bool initial_configure_seen;
@@ -76,6 +74,14 @@ struct SDL_WindowData
         WAYLAND_SURFACE_XDG_POPUP,
         WAYLAND_SURFACE_LIBDECOR
     } shell_surface_type;
+    enum
+    {
+        WAYLAND_SURFACE_STATUS_HIDDEN = 0,
+        WAYLAND_SURFACE_STATUS_WAITING_FOR_CONFIGURE,
+        WAYLAND_SURFACE_STATUS_WAITING_FOR_FRAME,
+        WAYLAND_SURFACE_STATUS_SHOW_PENDING,
+        WAYLAND_SURFACE_STATUS_SHOWN
+    } surface_status;
 
     struct wl_egl_window *egl_window;
     struct SDL_WaylandInput *keyboard_device;
@@ -102,6 +108,8 @@ struct SDL_WindowData
 
     SDL_DisplayData **outputs;
     int num_outputs;
+
+    SDL_Window *keyboard_focus;
 
     float windowed_scale_factor;
     float pointer_scale_x;
@@ -133,6 +141,7 @@ extern void Wayland_RestoreWindow(_THIS, SDL_Window *window);
 extern void Wayland_SetWindowBordered(_THIS, SDL_Window *window, SDL_bool bordered);
 extern void Wayland_SetWindowResizable(_THIS, SDL_Window *window, SDL_bool resizable);
 extern int Wayland_CreateWindow(_THIS, SDL_Window *window);
+extern void Wayland_SetWindowPosition(_THIS, SDL_Window *window);
 extern void Wayland_SetWindowSize(_THIS, SDL_Window *window);
 extern void Wayland_SetWindowMinimumSize(_THIS, SDL_Window *window);
 extern void Wayland_SetWindowMaximumSize(_THIS, SDL_Window *window);

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -260,6 +260,8 @@ static SDL_VideoDevice *WIN_CreateDevice(void)
 
     device->free = WIN_DeleteDevice;
 
+    device->quirk_flags = VIDEO_DEVICE_QUIRK_HAS_POPUP_WINDOW_SUPPORT;
+
     return device;
 }
 

--- a/src/video/windows/SDL_windowswindow.h
+++ b/src/video/windows/SDL_windowswindow.h
@@ -62,8 +62,10 @@ struct SDL_WindowData
     RECT cursor_clipped_rect;
     SDL_Point last_raw_mouse_position;
     SDL_bool mouse_tracked;
+    SDL_bool destroy_parent_with_window;
     SDL_DisplayID last_displayID;
     WCHAR *ICMFileName;
+    SDL_Window *keyboard_focus;
     struct SDL_VideoData *videodata;
 #if SDL_VIDEO_OPENGL_EGL
     EGLSurface egl_surface;
@@ -111,6 +113,7 @@ extern void WIN_ClientPointFromSDLFloat(const SDL_Window *window, float x, float
 extern void WIN_AcceptDragAndDrop(SDL_Window *window, SDL_bool accept);
 extern int WIN_FlashWindow(_THIS, SDL_Window *window, SDL_FlashOperation operation);
 extern void WIN_UpdateDarkModeForHWND(HWND hwnd);
+extern void WIN_SetWindowPositionInternal(SDL_Window *window, UINT flags);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/src/video/x11/SDL_x11sym.h
+++ b/src/video/x11/SDL_x11sym.h
@@ -155,6 +155,8 @@ SDL_X11_SYM(void,XRefreshKeyboardMapping,(XMappingEvent *a),(a),)
 SDL_X11_SYM(int,XQueryTree,(Display* a,Window b,Window* c,Window* d,Window** e,unsigned int* f),(a,b,c,d,e,f),return)
 SDL_X11_SYM(Bool,XSupportsLocale,(void),(),return)
 SDL_X11_SYM(Status,XmbTextListToTextProperty,(Display* a,char** b,int c,XICCEncodingStyle d,XTextProperty* e),(a,b,c,d,e),return)
+SDL_X11_SYM(Region,XCreateRegion,(void),(),return)
+SDL_X11_SYM(void,XDestroyRegion,(Region),(a),)
 
 #if SDL_VIDEO_DRIVER_X11_XFIXES
 SDL_X11_MODULE(XFIXES)
@@ -314,6 +316,7 @@ SDL_X11_SYM(void,XScreenSaverSuspend,(Display *dpy,Bool suspend),(dpy,suspend),r
 #if SDL_VIDEO_DRIVER_X11_XSHAPE
 SDL_X11_MODULE(XSHAPE)
 SDL_X11_SYM(void,XShapeCombineMask,(Display *dpy,Window dest,int dest_kind,int x_off,int y_off,Pixmap src,int op),(dpy,dest,dest_kind,x_off,y_off,src,op),)
+SDL_X11_SYM(void,XShapeCombineRegion,(Display *a,Window b,int c,int d,int e,Region f,int g),(a,b,c,d,e,f,g),)
 #endif
 
 #undef SDL_X11_MODULE

--- a/src/video/x11/SDL_x11video.c
+++ b/src/video/x11/SDL_x11video.c
@@ -321,6 +321,8 @@ static SDL_VideoDevice *X11_CreateDevice(void)
         device->system_theme = SDL_SystemTheme_Get();
 #endif
 
+    device->quirk_flags = VIDEO_DEVICE_QUIRK_HAS_POPUP_WINDOW_SUPPORT;
+
     return device;
 }
 

--- a/src/video/x11/SDL_x11window.h
+++ b/src/video/x11/SDL_x11window.h
@@ -60,6 +60,7 @@ struct SDL_WindowData
     int border_top;
     int border_bottom;
     SDL_bool mouse_grabbed;
+    SDL_bool hidden_by_parent_focus;
     Uint64 last_focus_event_time;
     PendingFocusEnum pending_focus;
     Uint64 pending_focus_time;
@@ -70,6 +71,7 @@ struct SDL_WindowData
     Window xdnd_source;
     SDL_bool flashing_window;
     Uint64 flash_cancel_time;
+    SDL_Window *keyboard_focus;
 #if SDL_VIDEO_OPENGL_EGL
     EGLSurface egl_surface;
 #endif
@@ -116,5 +118,6 @@ extern void X11_AcceptDragAndDrop(SDL_Window *window, SDL_bool accept);
 extern int X11_FlashWindow(_THIS, SDL_Window *window, SDL_FlashOperation operation);
 
 int SDL_X11_SetWindowTitle(Display *display, Window xwindow, char *title);
+void X11_UpdateWindowPosition(SDL_Window *window);
 
 #endif /* SDL_x11window_h_ */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -204,6 +204,7 @@ add_sdl_test_executable(testcustomcursor testcustomcursor.c)
 add_sdl_test_executable(gamepadmap NEEDS_RESOURCES TESTUTILS gamepadmap.c)
 add_sdl_test_executable(testvulkan testvulkan.c)
 add_sdl_test_executable(testoffscreen testoffscreen.c)
+add_sdl_test_executable(testpopup testpopup.c)
 
 check_c_compiler_flag(-Wformat-overflow HAVE_WFORMAT_OVERFLOW)
 if(HAVE_WFORMAT_OVERFLOW)

--- a/test/testpopup.c
+++ b/test/testpopup.c
@@ -1,0 +1,248 @@
+/*
+Copyright (C) 1997-2023 Sam Lantinga <slouken@libsdl.org>
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely.
+*/
+/* Simple program:  Move N sprites around on the screen as fast as possible */
+
+#include <stdlib.h>
+#include <time.h>
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten/emscripten.h>
+#endif
+
+#include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test_common.h>
+#include <SDL3/SDL_test_font.h>
+
+#define MENU_WIDTH  120
+#define MENU_HEIGHT 300
+
+#define TOOLTIP_DELAY  500
+#define TOOLTIP_WIDTH  175
+#define TOOLTIP_HEIGHT 32
+
+static SDLTest_CommonState *state;
+static int num_menus;
+static Uint64 tooltip_timer;
+static int done;
+static const SDL_Color colors[] = {
+    { 0x7F, 0x00, 0x00, 0xFF },
+    { 0x00, 0x7F, 0x00, 0xFF },
+    { 0x00, 0x00, 0x7F, 0xFF }
+};
+
+struct PopupWindow
+{
+    SDL_Window *win;
+    SDL_Window *parent;
+    SDL_Renderer *renderer;
+    int idx;
+};
+
+struct PopupWindow *menus;
+struct PopupWindow tooltip;
+
+/* Call this instead of exit(), so we can clean up SDL: atexit() is evil. */
+static void quit(int rc)
+{
+    SDL_free(menus);
+    menus = NULL;
+
+    SDLTest_CommonQuit(state);
+    exit(rc);
+}
+
+static int get_menu_index_by_window(SDL_Window *window)
+{
+    int i;
+    for (i = 0; i < num_menus; ++i) {
+        if (menus[i].win == window) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+static SDL_bool window_is_root(SDL_Window *window)
+{
+    int i;
+    for (i = 0; i < state->num_windows; ++i) {
+        if (window == state->windows[i]) {
+            return SDL_TRUE;
+        }
+    }
+
+    return SDL_FALSE;
+}
+
+static SDL_bool create_popup(struct PopupWindow *new_popup, SDL_bool is_menu)
+{
+    SDL_Window *focus;
+    SDL_Window *new_win;
+    SDL_Renderer *new_renderer;
+    const int w = is_menu ? MENU_WIDTH : TOOLTIP_WIDTH;
+    const int h = is_menu ? MENU_HEIGHT : TOOLTIP_HEIGHT;
+    const int v_off = is_menu ? 0 : 32;
+    const Uint32 flags = is_menu ? SDL_WINDOW_POPUP_MENU : SDL_WINDOW_TOOLTIP;
+    float x, y;
+
+    focus = SDL_GetMouseFocus();
+
+    SDL_GetMouseState(&x, &y);
+    new_win = SDL_CreatePopupWindow(focus,
+                                    (int)x, (int)y + v_off, w, h, flags);
+
+    if (new_win) {
+        new_renderer = SDL_CreateRenderer(new_win, state->renderdriver, state->render_flags);
+
+        new_popup->win = new_win;
+        new_popup->renderer = new_renderer;
+        new_popup->parent = focus;
+
+        return SDL_TRUE;
+    }
+
+    SDL_zerop(new_popup);
+    return SDL_FALSE;
+}
+
+static void close_popups()
+{
+    int i;
+
+    for (i = 0; i < num_menus; ++i) {
+        /* Destroying the lowest level window recursively destroys the child windows */
+        if (window_is_root(menus[i].parent)) {
+            SDL_DestroyWindow(menus[i].win);
+        }
+    }
+    SDL_free(menus);
+    menus = NULL;
+    num_menus = 0;
+
+    /* If the tooltip was a child of a popup, it was recursively destroyed with the popup */
+    if (!window_is_root(tooltip.parent)) {
+        SDL_zero(tooltip);
+    }
+}
+
+static void loop()
+{
+    int i;
+    char fmt_str[128];
+    SDL_Event event;
+
+    /* Check for events */
+    while (SDL_PollEvent(&event)) {
+        SDLTest_CommonEvent(state, &event, &done);
+
+        if (event.type == SDL_EVENT_MOUSE_MOTION) {
+            /* Hide the tooltip and restart the timer if the mouse is moved */
+            if (tooltip.win) {
+                SDL_DestroyWindow(tooltip.win);
+                SDL_zero(tooltip);
+            }
+            tooltip_timer = SDL_GetTicks() + TOOLTIP_DELAY;
+        } else if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
+            /* Left click closes the popup menus */
+            if (event.button.button == SDL_BUTTON_LEFT) {
+                close_popups();
+            } else if (event.button.button == SDL_BUTTON_RIGHT) {
+                /* Create a new popup menu */
+                menus = SDL_realloc(menus, sizeof(struct PopupWindow) * (num_menus + 1));
+                if (create_popup(&menus[num_menus], SDL_TRUE)) {
+                    ++num_menus;
+                }
+            }
+        }
+    }
+
+    /* Show the tooltip if the delay period has elapsed */
+    if (SDL_GetTicks() > tooltip_timer) {
+        if (tooltip.win == NULL) {
+            create_popup(&tooltip, SDL_FALSE);
+        }
+    }
+
+    /* Draw the window */
+    for (i = 0; i < state->num_windows; ++i) {
+        SDL_Renderer *renderer = state->renderers[i];
+        SDL_RenderClear(renderer);
+        SDL_RenderPresent(renderer);
+    }
+
+    /* Draw the menus in alternating colors */
+    for (i = 0; i < num_menus; ++i) {
+        const SDL_Color *c = &colors[i % SDL_arraysize(colors)];
+        SDL_Renderer *renderer = menus[i].renderer;
+
+        SDL_SetRenderDrawColor(renderer, c->r, c->g, c->b, c->a);
+        SDL_RenderClear(renderer);
+        SDL_SetRenderDrawColor(renderer, 0xFF, 0xFF, 0xFF, 0xFF);
+        SDL_snprintf(fmt_str, sizeof(fmt_str), "Popup Menu %i", i);
+        SDLTest_DrawString(renderer, 10.0f, 10.0f, fmt_str);
+        SDL_RenderPresent(renderer);
+    }
+
+    /* Draw the tooltip */
+    if (tooltip.win) {
+        int menu_idx;
+
+        SDL_SetRenderDrawColor(tooltip.renderer, 0x00, 0x00, 0x00, 0xFF);
+        SDL_RenderClear(tooltip.renderer);
+        SDL_SetRenderDrawColor(tooltip.renderer, 0xFF, 0xFF, 0xFF, 0xFF);
+
+        menu_idx = get_menu_index_by_window(tooltip.parent);
+        if (menu_idx >= 0) {
+            SDL_snprintf(fmt_str, sizeof(fmt_str), "Tooltip for popup %i", menu_idx);
+        } else {
+            SDL_snprintf(fmt_str, sizeof(fmt_str), "Toplevel tooltip");
+        }
+        SDLTest_DrawString(tooltip.renderer, 10.0f, TOOLTIP_HEIGHT / 2, fmt_str);
+        SDL_RenderPresent(tooltip.renderer);
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    int i;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, SDL_INIT_VIDEO);
+    if (state == NULL) {
+        return 1;
+    }
+
+    if (!SDLTest_CommonInit(state)) {
+        SDLTest_CommonQuit(state);
+        quit(2);
+    }
+
+    for (i = 0; i < state->num_windows; ++i) {
+        SDL_Renderer *renderer = state->renderers[i];
+        SDL_SetRenderDrawColor(renderer, 0xA0, 0xA0, 0xA0, 0xFF);
+        SDL_RenderClear(renderer);
+    }
+
+    /* Main render loop */
+    done = 0;
+#ifdef __EMSCRIPTEN__
+    emscripten_set_main_loop(loop, 0, 1);
+#else
+    while (!done) {
+        loop();
+    }
+#endif
+    quit(0);
+    /* keep the compiler happy ... */
+    return 0;
+}


### PR DESCRIPTION
Implements cross-platform tooltips and popup menus.

Previously, popup menus and tooltips were only implemented on Wayland and X11, and there was no standardized behavior for these window types. This implements popup windows on Win, Mac, X11 and Wayland, with consistent behavior across all platforms.

The video layer gains the concept of parent/child windows to handle this, as popups must have an associated parent. Closing, hiding, or showing a parent will also perform the action recursively on it's child windows. Popups are positioned relative to their parent windows, move with them, and are confined to the display boundaries of the parent window, so as not to position them off screen or between displays.

To applications, tooltip and popup menu windows are mostly identical in behavior, except that tooltips are transparent to input so as not to obstruct whatever is underneath, while menus are not. Internally though, there are some differences in how focus for the two window types is handled in the backends.

Still need to update the documentation and take another pass over everything for cleanup work, but it's good  enough for general feedback at this point.

Closes #7364