### PR TITLE
Update SDL_joystick.c

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -2356,7 +2356,6 @@ static SDL_bool SDL_IsJoystickProductWheel(Uint32 vidpid)
         MAKE_VIDPID(0x044f, 0xb66e), /* Thrustmaster T300RS (normal mode) */
         MAKE_VIDPID(0x044f, 0xb66f), /* Thrustmaster T300RS (advanced mode) */
         MAKE_VIDPID(0x044f, 0xb66d), /* Thrustmaster T300RS (PS4 mode) */
-        MAKE_VIDPID(0x044f, 0xb65e), /* Thrustmaster T500RS */
         MAKE_VIDPID(0x044f, 0xb664), /* Thrustmaster TX (initial mode) */
         MAKE_VIDPID(0x044f, 0xb669), /* Thrustmaster TX (active mode) */
         MAKE_VIDPID(0x11ff, 0x0511), /* DragonRise Inc. Wired Wheel (initial mode) (also known as PXN V900 (PS3), Superdrive SV-750, or a Genesis Seaborg 400) */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removed T500 RS in an effort to make device detectable by Steam Input by showing it as detected device.  It seems to get hidden from Steam Input because of the device is joystickwheel being set.  imo this option should be exposed through steam ui so end users can choose how they want steam input to handle their hardware
## Description
<!--- Describe your changes in detail -->
For testing just deleted the T500 RS line
## Existing Issue(s)
Have asked for info on explaining what setting joystickiswheel does and for help in better understanding why Steam Input no longer detects T500 RS as generic device like how it used to (2016-202*) so i can map a simple gamepad config for steam ui configs to use.
A bug report is made at  https://steamcommunity.com/groups/SteamClientBeta/discussions/0/3763356923841756034/
