### PR TITLE
SDL2 Wayland Fullscreen Fixes

### DIFF
--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1287,6 +1287,8 @@ SDLTest_CommonInit(SDLTest_CommonState *state)
                 state->window_w = w;
                 state->window_h = h;
             }
+            fullscreen_mode.w = state->window_w;
+            fullscreen_mode.h = state->window_h;
             if (SDL_SetWindowDisplayMode(state->windows[i], &fullscreen_mode) < 0) {
                 SDL_Log("Can't set up fullscreen display mode: %s\n",
                         SDL_GetError());

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -266,8 +266,12 @@ static void ConfigureWindowGeometry(SDL_Window *window)
             } else {
                 UnsetDrawSurfaceViewport(window);
 
-                /* Round to the next integer in case of a fractional value. */
-                wl_surface_set_buffer_scale(data->surface, (int32_t)SDL_ceilf(data->scale_factor));
+                if (!FullscreenModeEmulation(window)) {
+                    /* Round to the next integer in case of a fractional value. */
+                    wl_surface_set_buffer_scale(data->surface, (int32_t)SDL_ceilf(data->scale_factor));
+                } else {
+                    wl_surface_set_buffer_scale(data->surface, 1);
+                }
             }
 
             data->window_width = window->w;


### PR DESCRIPTION
Sets the scale factor correctly for fullscreen windows when the dimensions match the desktop size and integer scaling is used, and fixes the test framework so it sets valid fullscreen width/height values.

Fixes #7418 
