### PR TITLE
Updated README-cmake.md to include --prefix=`pwd` (i.e build .)

### DIFF
--- a/docs/README-cmake.md
+++ b/docs/README-cmake.md
@@ -36,7 +36,7 @@ This will build the static and dynamic versions of SDL in the `~/build` director
 Installation can be done using:
 
 ```sh
-cmake --install .        # '--install' requires CMake 3.15, or newer
+cmake --install . --prefix=`pwd`        # '--install' requires CMake 3.15, or newer
 ```
 
 ## Including SDL in your project


### PR DESCRIPTION
This fix corrects the author's intentions.

## Description
Changes cmake to build into working directory

## Existing Issue(s)
Otherwise command requires sudo and is likely to fail.
