### PR TITLE
Specify bash for androidbuildlibs.sh

### DIFF
--- a/build-scripts/androidbuildlibs.sh
+++ b/build-scripts/androidbuildlibs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Build the Android libraries without needing a project
 # (AndroidManifest.xml, jni/{Application,Android}.mk, etc.)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This script relies on string indexes in parameter expansions, which aren't suppored by /bin/sh (e.g. dash).

Based on a patch by Roflcopter4:
https://github.com/joncampbell123/dosbox-x/pull/3850

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
