### PR TITLE
wayland: Never use the cached size for maximized or tiled windows

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -843,8 +843,9 @@ static void decoration_frame_configure(struct libdecor_frame *frame,
          *
          *      https://gitlab.gnome.org/jadahl/libdecor/-/issues/40
          */
-        const SDL_bool use_cached_size = (floating && !wind->floating) ||
-                                         (window->is_hiding || !!(window->flags & SDL_WINDOW_HIDDEN));
+        const SDL_bool use_cached_size = !maximized && !tiled &&
+                                         ((floating && !wind->floating) ||
+                                          (window->is_hiding || (window->flags & SDL_WINDOW_HIDDEN)));
 
         /* This will never set 0 for width/height unless the function returns false */
         if (use_cached_size || !libdecor_configuration_get_content_size(configuration, frame, &width, &height)) {


### PR DESCRIPTION
Don't use the cached floating window size for maximized or tiled windows. Fixes the initial window size when creating a window with the maximized flag set.
