### PR TITLE
wayland: Set the EGL swap timeout to one second from the current time

### DIFF
--- a/src/video/wayland/SDL_waylandopengles.c
+++ b/src/video/wayland/SDL_waylandopengles.c
@@ -125,7 +125,7 @@ int Wayland_GLES_SwapWindow(_THIS, SDL_Window *window)
         SDL_VideoData *videodata = _this->driverdata;
         struct wl_display *display = videodata->display;
         /* 1 sec, so we'll progress even if throttled to zero. */
-        const Uint64 max_wait = SDL_NS_PER_SECOND;
+        const Uint64 max_wait = SDL_GetTicksNS() + SDL_NS_PER_SECOND;
         while (SDL_AtomicGet(&data->swap_interval_ready) == 0) {
             Uint64 now;
 


### PR DESCRIPTION
Set the timeout max to one second from the current time or presentation time will always be greater than the timeout and the application will run unthrottled.

Fixes #7452, which was regressed by #7210 
