### PR TITLE
test of removing audio callback api

### DIFF
--- a/include/SDL3/SDL_audio.h
+++ b/include/SDL3/SDL_audio.h
@@ -144,23 +144,6 @@ typedef Uint16 SDL_AudioFormat;
 /* @} *//* Audio flags */
 
 /**
- *  This function is called when the audio device needs more data.
- *
- *  \param userdata An application-specific parameter saved in
- *                  the SDL_AudioSpec structure
- *  \param stream A pointer to the audio data buffer.
- *  \param len    The length of that buffer in bytes.
- *
- *  Once the callback returns, the buffer will no longer be valid.
- *  Stereo samples are stored in a LRLRLR ordering.
- *
- *  You can choose to avoid callbacks and use SDL_QueueAudio() instead, if
- *  you like. Just open your audio device with a NULL callback.
- */
-typedef void (SDLCALL * SDL_AudioCallback) (void *userdata, Uint8 * stream,
-                                            int len);
-
-/**
  *  The calculated values in this structure are calculated by SDL_OpenAudioDevice().
  *
  *  For multi-channel audio, the default SDL channel mapping is:
@@ -181,8 +164,6 @@ typedef struct SDL_AudioSpec
     Uint16 samples;             /**< Audio buffer size in sample FRAMES (total samples divided by channel count) */
     Uint16 padding;             /**< Necessary for some compile environments */
     Uint32 size;                /**< Audio buffer size in bytes (calculated) */
-    SDL_AudioCallback callback; /**< Callback that feeds the audio device (NULL to use SDL_QueueAudio()). */
-    void *userdata;             /**< Userdata passed to callback (ignored for NULL callbacks). */
 } SDL_AudioSpec;
 
 

--- a/src/audio/SDL_sysaudio.h
+++ b/src/audio/SDL_sysaudio.h
@@ -60,6 +60,11 @@ extern void SDL_OpenedAudioDeviceDisconnected(SDL_AudioDevice *device);
    The system preallocates enough packets for 2 callbacks' worth of data. */
 #define SDL_AUDIOBUFFERQUEUE_PACKETLEN (8 * 1024)
 
+
+
+extern void SDL_BufferQueueDrainCallback(SDL_AudioDevice *device, Uint8 *stream, int len);
+extern void SDL_BufferQueueFillCallback(SDL_AudioDevice *device, Uint8 *stream, int len);
+
 typedef struct SDL_AudioDriverImpl
 {
     void (*DetectDevices)(void);

--- a/src/audio/coreaudio/SDL_coreaudio.m
+++ b/src/audio/coreaudio/SDL_coreaudio.m
@@ -537,8 +537,7 @@ static void outputCallback(void *inUserData, AudioQueueRef inAQ, AudioQueueBuffe
         while (remaining > 0) {
             if (SDL_GetAudioStreamAvailable(this->stream) == 0) {
                 /* Generate the data */
-                (*this->callbackspec.callback)(this->callbackspec.userdata,
-                                               this->hidden->buffer, this->hidden->bufferSize);
+                SDL_BufferQueueDrainCallback(this, this->hidden->buffer, this->hidden->bufferSize);
                 this->hidden->bufferOffset = 0;
                 SDL_PutAudioStreamData(this->stream, this->hidden->buffer, this->hidden->bufferSize);
             }
@@ -565,8 +564,7 @@ static void outputCallback(void *inUserData, AudioQueueRef inAQ, AudioQueueBuffe
             UInt32 len;
             if (this->hidden->bufferOffset >= this->hidden->bufferSize) {
                 /* Generate the data */
-                (*this->callbackspec.callback)(this->callbackspec.userdata,
-                                               this->hidden->buffer, this->hidden->bufferSize);
+                SDL_BufferQueueDrainCallback(this, this->hidden->buffer, this->hidden->bufferSize);
                 this->hidden->bufferOffset = 0;
             }
 
@@ -615,7 +613,7 @@ static void inputCallback(void *inUserData, AudioQueueRef inAQ, AudioQueueBuffer
 
             if (this->hidden->bufferOffset >= this->hidden->bufferSize) {
                 SDL_LockMutex(this->mixer_lock);
-                (*this->callbackspec.callback)(this->callbackspec.userdata, this->hidden->buffer, this->hidden->bufferSize);
+                SDL_BufferQueueFillCallback(this, this->hidden->buffer, this->hidden->bufferSize);
                 SDL_UnlockMutex(this->mixer_lock);
                 this->hidden->bufferOffset = 0;
             }

--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -977,13 +977,13 @@ static void output_callback(void *data)
         }
 
         if (!this->stream) {
-            this->callbackspec.callback(this->callbackspec.userdata, dst, this->callbackspec.size);
+            SDL_BufferQueueDrainCallback(this, dst, this->callbackspec.size);
         } else {
             int got;
 
             /* Fire the callback until we have enough to fill a buffer */
             while (SDL_GetAudioStreamAvailable(this->stream) < this->spec.size) {
-                this->callbackspec.callback(this->callbackspec.userdata, this->work_buffer, this->callbackspec.size);
+                SDL_BufferQueueDrainCallback(this, this->work_buffer, this->callbackspec.size);
                 SDL_PutAudioStreamData(this->stream, this->work_buffer, this->callbackspec.size);
             }
 
@@ -1045,7 +1045,7 @@ static void input_callback(void *data)
             SDL_ReadFromDataQueue(this->hidden->buffer, this->work_buffer, this->callbackspec.size);
 
             SDL_LockMutex(this->mixer_lock);
-            this->callbackspec.callback(this->callbackspec.userdata, this->work_buffer, this->callbackspec.size);
+            SDL_BufferQueueFillCallback(this, this->work_buffer, this->callbackspec.size);
             SDL_UnlockMutex(this->mixer_lock);
         }
     } else if (this->hidden->buffer) { /* Flush the buffer when paused */

--- a/src/audio/pulseaudio/SDL_pulseaudio.c
+++ b/src/audio/pulseaudio/SDL_pulseaudio.c
@@ -701,8 +701,6 @@ static void SinkInfoCallback(pa_context *c, const pa_sink_info *i, int is_last, 
         spec.silence = 0;
         spec.samples = 0;
         spec.size = 0;
-        spec.callback = NULL;
-        spec.userdata = NULL;
 
         if (add) {
             SDL_AddAudioDevice(SDL_FALSE, i->description, &spec, (void *)((intptr_t)i->index + 1));
@@ -731,8 +729,6 @@ static void SourceInfoCallback(pa_context *c, const pa_source_info *i, int is_la
             spec.silence = 0;
             spec.samples = 0;
             spec.size = 0;
-            spec.callback = NULL;
-            spec.userdata = NULL;
 
             if (add) {
                 SDL_AddAudioDevice(SDL_TRUE, i->description, &spec, (void *)((intptr_t)i->index + 1));

--- a/test/loopwavequeue.c
+++ b/test/loopwavequeue.c
@@ -97,8 +97,6 @@ int main(int argc, char *argv[])
         quit(1);
     }
 
-    wave.spec.callback = NULL; /* we'll push audio. */
-
 #if HAVE_SIGNAL_H
     /* Set the signals */
 #ifdef SIGHUP

--- a/test/testaudiocapture.c
+++ b/test/testaudiocapture.c
@@ -122,7 +122,6 @@ int main(int argc, char **argv)
     wanted.format = AUDIO_F32SYS;
     wanted.channels = 1;
     wanted.samples = 4096;
-    wanted.callback = NULL;
 
     SDL_zero(spec);
 


### PR DESCRIPTION
just a test to remove audio callback api.
it assumes, it gets set to NULL, and uses SDL_BufferQueueFillCallback / SDL_BufferQueueDrainCallback internally

not even sure if this is correct....

I see that:
- lot of test programs uses it
- SDL_mixer uses it also
- ( backends pipewire, pulse audio, coreaudio, haiku directly calls the callback ? )
