### PR TITLE
Popup checks

### DIFF
--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -667,20 +667,29 @@ extern DECLSPEC SDL_Window *SDLCALL SDL_CreateWindow(const char *title, int w, i
 /**
  * Create a child popup window of the specified parent window.
  *
- * 'flags' **must** contain exactly one of the following: -
- * 'SDL_WINDOW_TOOLTIP': The popup window is a tooltip and will not pass any
- * input events - 'SDL_WINDOW_POPUP_MENU': The popup window is a popup menu
+ * 'flags' **must** contain exactly one of the following:
+ * - 'SDL_WINDOW_TOOLTIP': The popup window is a tooltip and will not pass any
+ *                         input events.
+ * - 'SDL_WINDOW_POPUP_MENU': The popup window is a popup menu. The topmost
+ *                            popup menu will implicitly gain the keyboard focus.
  *
- * The following flags are not valid for popup windows and will be ignored: -
- * 'SDL_WINDOW_MINIMIZED' - 'SDL_WINDOW_MAXIMIZED' - 'SDL_WINDOW_FULLSCREEN' -
- * `SDL_WINDOW_BORDERLESS` - `SDL_WINDOW_MOUSE_GRABBED`
+ * The following flags are not relevant to popup window creation and will be ignored:
+ * - 'SDL_WINDOW_MINIMIZED'
+ * - 'SDL_WINDOW_MAXIMIZED'
+ * - 'SDL_WINDOW_FULLSCREEN'
+ * - 'SDL_WINDOW_BORDERLESS'
+ * - 'SDL_WINDOW_SKIP_TASKBAR'
  *
  * The parent parameter **must** be non-null and a valid window. The parent of
  * a popup window can be either a regular, toplevel window, or another popup
  * window.
  *
- * Popup windows cannot be minimized, maximized, made fullscreen, or grab the
- * mouse. Attempts to do so will fail.
+ * Popup windows cannot be minimized, maximized, made fullscreen, raised, flash,
+ * be made a modal window, be the parent of a modal window, or grab the mouse
+ * and/or keyboard. Attempts to do so will fail.
+ *
+ * Popup windows implicitly do not have a border/decorations and do not appear
+ * on the taskbar/dock or in lists of windows such as alt-tab menus.
  *
  * If a parent window is hidden, any child popup windows will be recursively
  * hidden as well. Child popup windows not explicitly hidden will be restored
@@ -696,7 +705,8 @@ extern DECLSPEC SDL_Window *SDLCALL SDL_CreateWindow(const char *title, int w, i
  *                 of the parent window, in screen coordinates
  * \param w the width of the window, in screen coordinates
  * \param h the height of the window, in screen coordinates
- * \param flags 0, or one or more SDL_WindowFlags OR'd together
+ * \param flags SDL_WINDOW_TOOLTIP or SDL_WINDOW_POPUP MENU, and zero or more
+ *              additional SDL_WindowFlags OR'd together.
  * \returns the window that was created or NULL on failure; call
  *          SDL_GetError() for more information.
  *

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1953,7 +1953,7 @@ SDL_Window *SDL_CreatePopupWindow(SDL_Window *parent, int offset_x, int offset_y
     }
 
     /* Remove invalid flags */
-    flags &= ~(SDL_WINDOW_MINIMIZED | SDL_WINDOW_MAXIMIZED | SDL_WINDOW_FULLSCREEN | SDL_WINDOW_MOUSE_GRABBED);
+    flags &= ~(SDL_WINDOW_MINIMIZED | SDL_WINDOW_MAXIMIZED | SDL_WINDOW_FULLSCREEN | SDL_WINDOW_BORDERLESS | SDL_WINDOW_SKIP_TASKBAR);
 
     return SDL_CreateWindowInternal(NULL, offset_x, offset_y, w, h, parent, flags);
 }

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2739,6 +2739,7 @@ int SDL_HideWindow(SDL_Window *window)
 int SDL_RaiseWindow(SDL_Window *window)
 {
     CHECK_WINDOW_MAGIC(window, -1);
+    CHECK_WINDOW_NOT_POPUP(window, -1);
 
     if (window->flags & SDL_WINDOW_HIDDEN) {
         return 0;
@@ -3012,6 +3013,8 @@ int SDL_SetWindowModalFor(SDL_Window *modal_window, SDL_Window *parent_window)
 {
     CHECK_WINDOW_MAGIC(modal_window, -1);
     CHECK_WINDOW_MAGIC(parent_window, -1);
+    CHECK_WINDOW_NOT_POPUP(modal_window, -1);
+    CHECK_WINDOW_NOT_POPUP(parent_window, -1);
 
     if (!_this->SetWindowModalFor) {
         return SDL_Unsupported();
@@ -3023,6 +3026,7 @@ int SDL_SetWindowModalFor(SDL_Window *modal_window, SDL_Window *parent_window)
 int SDL_SetWindowInputFocus(SDL_Window *window)
 {
     CHECK_WINDOW_MAGIC(window, -1);
+    CHECK_WINDOW_NOT_POPUP(window, -1);
 
     if (!_this->SetWindowInputFocus) {
         return SDL_Unsupported();
@@ -3092,6 +3096,7 @@ int SDL_SetWindowGrab(SDL_Window *window, SDL_bool grabbed)
 int SDL_SetWindowKeyboardGrab(SDL_Window *window, SDL_bool grabbed)
 {
     CHECK_WINDOW_MAGIC(window, -1);
+    CHECK_WINDOW_NOT_POPUP(window, -1);
 
     if (!!grabbed == !!(window->flags & SDL_WINDOW_KEYBOARD_GRABBED)) {
         return 0;
@@ -3108,6 +3113,7 @@ int SDL_SetWindowKeyboardGrab(SDL_Window *window, SDL_bool grabbed)
 int SDL_SetWindowMouseGrab(SDL_Window *window, SDL_bool grabbed)
 {
     CHECK_WINDOW_MAGIC(window, -1);
+    CHECK_WINDOW_NOT_POPUP(window, -1);
 
     if (!!grabbed == !!(window->flags & SDL_WINDOW_MOUSE_GRABBED)) {
         return 0;
@@ -3178,6 +3184,7 @@ const SDL_Rect *SDL_GetWindowMouseRect(SDL_Window *window)
 int SDL_FlashWindow(SDL_Window *window, SDL_FlashOperation operation)
 {
     CHECK_WINDOW_MAGIC(window, -1);
+    CHECK_WINDOW_NOT_POPUP(window, -1);
 
     if (_this->FlashWindow) {
         return _this->FlashWindow(_this, window, operation);


### PR DESCRIPTION
- Disallow additional operations on popups where they have no effect or don't make sense.
- Update the popup window creation documentation with information about popup menu input focus, additional ignored flags, and note additional invalid popup window operations.
