### PR TITLE
wayland: Don't throttle presentation until the first swap has occurred

### DIFF
--- a/src/video/wayland/SDL_waylandopengles.c
+++ b/src/video/wayland/SDL_waylandopengles.c
@@ -121,7 +121,7 @@ int Wayland_GLES_SwapWindow(_THIS, SDL_Window *window)
     }
 
     /* Control swap interval ourselves. See comments on Wayland_GLES_SetSwapInterval */
-    if (swap_interval != 0) {
+    if (swap_interval != 0 && data->surface_status == WAYLAND_SURFACE_STATUS_SHOWN) {
         SDL_VideoData *videodata = _this->driverdata;
         struct wl_display *display = videodata->display;
         /* 1 sec, so we'll progress even if throttled to zero. */


### PR DESCRIPTION
Don't throttle window updates until the first swap has occurred, as the window won't actually be shown or receive the frame callback until that point and this causes new window creation to have a full 1 second delay.
