### PR TITLE
Fixed bug #7462 - 8888 as default GL backbuffer red/green/blue/alpha bit sizes

### DIFF
--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -96,10 +96,10 @@ SDLTest_CommonCreateState(char **argv, Uint32 flags)
     state->audiospec.samples = 2048;
 
     /* Set some very sane GL defaults */
-    state->gl_red_size = 3;
-    state->gl_green_size = 3;
-    state->gl_blue_size = 2;
-    state->gl_alpha_size = 0;
+    state->gl_red_size = 8;
+    state->gl_green_size = 8;
+    state->gl_blue_size = 8;
+    state->gl_alpha_size = 8;
     state->gl_buffer_size = 0;
     state->gl_depth_size = 16;
     state->gl_stencil_size = 0;

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -3798,10 +3798,10 @@ void SDL_GL_ResetAttributes(void)
     _this->egl_surfaceattrib_callback = NULL;
     _this->egl_contextattrib_callback = NULL;
 
-    _this->gl_config.red_size = 3;
-    _this->gl_config.green_size = 3;
-    _this->gl_config.blue_size = 2;
-    _this->gl_config.alpha_size = 0;
+    _this->gl_config.red_size = 8;
+    _this->gl_config.green_size = 8;
+    _this->gl_config.blue_size = 8;
+    _this->gl_config.alpha_size = 8;
     _this->gl_config.buffer_size = 0;
     _this->gl_config.depth_size = 16;
     _this->gl_config.stencil_size = 0;


### PR DESCRIPTION
#7462