### PR TITLE
dynapi: SDL_DYNAPI_entry must be in version script

### DIFF
--- a/src/dynapi/SDL_dynapi.sym
+++ b/src/dynapi/SDL_dynapi.sym
@@ -1,6 +1,7 @@
 SDL3_0.0.0 {
   global:
     JNI_OnLoad;
+    SDL_DYNAPI_entry;
     SDL_AddEventWatch;
     SDL_AddGamepadMapping;
     SDL_AddGamepadMappingsFromRW;


### PR DESCRIPTION
For SDL dynapi to work, the `SDL_DYNAPI_entry` symbol must be externally visible.
Adding `__attribute__((visibility(default)))` would not work since version scripts override these.

Before this change, the following always printed `(nil)`.
With this change, it prints an address + seting the `DSL3_DYNAMIC_API` environment variable works without printing a warning about failing dynapi..

```c
#include <dlfcn.h>
#include <stdio.h>

int main(int argc, char *argv[]) {
  void *l = dlopen("./libSDL3.so", RTLD_NOW);
  printf("%p\n", dlsym(l, "SDL_DYNAPI_entry"));
  dlclose(l);
  return 0;
}