### PR TITLE
tests: parse arguments of all tests

### DIFF
--- a/VisualC/tests/gamepadmap/gamepadmap.vcxproj
+++ b/VisualC/tests/gamepadmap/gamepadmap.vcxproj
@@ -188,6 +188,12 @@
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\SDL_test\SDL_test.vcxproj">
+      <Project>{da956fd3-e143-46f2-9fe5-c77bebc56b1a}</Project>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\..\..\test\axis.bmp">

--- a/VisualC/tests/loopwave/loopwave.vcxproj
+++ b/VisualC/tests/loopwave/loopwave.vcxproj
@@ -194,6 +194,12 @@
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\SDL_test\SDL_test.vcxproj">
+      <Project>{da956fd3-e143-46f2-9fe5-c77bebc56b1a}</Project>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Test\loopwave.c" />

--- a/VisualC/tests/testatomic/testatomic.vcxproj
+++ b/VisualC/tests/testatomic/testatomic.vcxproj
@@ -188,6 +188,12 @@
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\SDL_test\SDL_test.vcxproj">
+      <Project>{da956fd3-e143-46f2-9fe5-c77bebc56b1a}</Project>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\test\testatomic.c" />

--- a/VisualC/tests/testfile/testfile.vcxproj
+++ b/VisualC/tests/testfile/testfile.vcxproj
@@ -188,6 +188,12 @@
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\SDL_test\SDL_test.vcxproj">
+      <Project>{da956fd3-e143-46f2-9fe5-c77bebc56b1a}</Project>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Test\testfile.c" />

--- a/VisualC/tests/testgamepad/testgamepad.vcxproj
+++ b/VisualC/tests/testgamepad/testgamepad.vcxproj
@@ -188,6 +188,12 @@
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\SDL_test\SDL_test.vcxproj">
+      <Project>{da956fd3-e143-46f2-9fe5-c77bebc56b1a}</Project>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\..\..\test\axis.bmp">

--- a/VisualC/tests/testjoystick/testjoystick.vcxproj
+++ b/VisualC/tests/testjoystick/testjoystick.vcxproj
@@ -188,6 +188,12 @@
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\SDL_test\SDL_test.vcxproj">
+      <Project>{da956fd3-e143-46f2-9fe5-c77bebc56b1a}</Project>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\test\testjoystick.c" />

--- a/VisualC/tests/testplatform/testplatform.vcxproj
+++ b/VisualC/tests/testplatform/testplatform.vcxproj
@@ -216,6 +216,12 @@
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\SDL_test\SDL_test.vcxproj">
+      <Project>{da956fd3-e143-46f2-9fe5-c77bebc56b1a}</Project>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Test\testplatform.c" />

--- a/VisualC/tests/testpower/testpower.vcxproj
+++ b/VisualC/tests/testpower/testpower.vcxproj
@@ -188,6 +188,12 @@
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\SDL_test\SDL_test.vcxproj">
+      <Project>{da956fd3-e143-46f2-9fe5-c77bebc56b1a}</Project>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\test\testpower.c" />

--- a/VisualC/tests/testrumble/testrumble.vcxproj
+++ b/VisualC/tests/testrumble/testrumble.vcxproj
@@ -188,6 +188,12 @@
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\SDL_test\SDL_test.vcxproj">
+      <Project>{da956fd3-e143-46f2-9fe5-c77bebc56b1a}</Project>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\test\testrumble.c" />

--- a/VisualC/tests/testsensor/testsensor.vcxproj
+++ b/VisualC/tests/testsensor/testsensor.vcxproj
@@ -188,6 +188,12 @@
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\SDL_test\SDL_test.vcxproj">
+      <Project>{da956fd3-e143-46f2-9fe5-c77bebc56b1a}</Project>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\test\testsensor.c" />

--- a/VisualC/tests/testshape/testshape.vcxproj
+++ b/VisualC/tests/testshape/testshape.vcxproj
@@ -188,6 +188,12 @@
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\SDL_test\SDL_test.vcxproj">
+      <Project>{da956fd3-e143-46f2-9fe5-c77bebc56b1a}</Project>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\test\testshape.c" />

--- a/VisualC/tests/testsurround/testsurround.vcxproj
+++ b/VisualC/tests/testsurround/testsurround.vcxproj
@@ -194,6 +194,12 @@
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\SDL_test\SDL_test.vcxproj">
+      <Project>{da956fd3-e143-46f2-9fe5-c77bebc56b1a}</Project>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Test\testsurround.c" />

--- a/VisualC/tests/testyuv/testyuv.vcxproj
+++ b/VisualC/tests/testyuv/testyuv.vcxproj
@@ -218,6 +218,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\..\test\testyuv.c" />
     <ClCompile Include="..\..\..\test\testyuv_cvt.c" />
+    <ClCompile Include="..\..\..\test\testutils.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\test\testyuv_cvt.h" />

--- a/include/SDL3/SDL_test_common.h
+++ b/include/SDL3/SDL_test_common.h
@@ -122,7 +122,7 @@ typedef struct
     int gl_debug;
     int gl_profile_mask;
 
-    /* Additional fields added in 2.0.18 */
+    /* Mouse info */
     SDL_Rect confine;
 
 } SDLTest_CommonState;
@@ -144,6 +144,13 @@ extern "C" {
  * \returns a newly allocated common state object.
  */
 SDLTest_CommonState *SDLTest_CommonCreateState(char **argv, Uint32 flags);
+
+/**
+ * \brief Free the common state object.
+ *
+ * \param state The common state object to destroy
+ */
+void SDLTest_CommonDestroyState(SDLTest_CommonState *state);
 
 /**
  * \brief Process one common argument.

--- a/include/SDL3/SDL_test_common.h
+++ b/include/SDL3/SDL_test_common.h
@@ -171,19 +171,6 @@ int SDLTest_CommonArg(SDLTest_CommonState *state, int index);
 void SDLTest_CommonLogUsage(SDLTest_CommonState *state, const char *argv0, const char **options);
 
 /**
- * \brief Returns common usage information
- *
- * You should (probably) be using SDLTest_CommonLogUsage() instead, but this
- *  function remains for binary compatibility. Strings returned from this
- *  function are valid until SDLTest_CommonQuit() is called, in which case
- *  those strings' memory is freed and can no longer be used.
- *
- * \param state The common state describing the test window to create.
- * \returns a string with usage information
- */
-const char *SDLTest_CommonUsage(SDLTest_CommonState *state);
-
-/**
  * \brief Open test window.
  *
  * \param state The common state describing the test window to create.

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -630,62 +630,9 @@ void SDLTest_CommonLogUsage(SDLTest_CommonState *state, const char *argv0, const
     }
 }
 
-static const char *BuildCommonUsageString(char **pstr, const char **strlist, const int numitems, const char **strlist2, const int numitems2)
-{
-    char *str = *pstr;
-    if (str == NULL) {
-        size_t len = SDL_strlen("[--trackmem]") + 2;
-        int i;
-        for (i = 0; i < numitems; i++) {
-            len += SDL_strlen(strlist[i]) + 1;
-        }
-        if (strlist2) {
-            for (i = 0; i < numitems2; i++) {
-                len += SDL_strlen(strlist2[i]) + 1;
-            }
-        }
-        str = (char *)SDL_calloc(1, len);
-        if (str == NULL) {
-            return ""; /* oh well. */
-        }
-        SDL_strlcat(str, "[--trackmem] ", len);
-        for (i = 0; i < numitems - 1; i++) {
-            SDL_strlcat(str, strlist[i], len);
-            SDL_strlcat(str, " ", len);
-        }
-        SDL_strlcat(str, strlist[i], len);
-        if (strlist2) {
-            SDL_strlcat(str, " ", len);
-            for (i = 0; i < numitems2 - 1; i++) {
-                SDL_strlcat(str, strlist2[i], len);
-                SDL_strlcat(str, " ", len);
-            }
-            SDL_strlcat(str, strlist2[i], len);
-        }
-        *pstr = str;
-    }
-    return str;
-}
-
 static char *common_usage_video = NULL;
 static char *common_usage_audio = NULL;
 static char *common_usage_videoaudio = NULL;
-
-const char *
-SDLTest_CommonUsage(SDLTest_CommonState *state)
-{
-
-    switch (state->flags & (SDL_INIT_VIDEO | SDL_INIT_AUDIO)) {
-    case SDL_INIT_VIDEO:
-        return BuildCommonUsageString(&common_usage_video, video_usage, SDL_arraysize(video_usage), NULL, 0);
-    case SDL_INIT_AUDIO:
-        return BuildCommonUsageString(&common_usage_audio, audio_usage, SDL_arraysize(audio_usage), NULL, 0);
-    case (SDL_INIT_VIDEO | SDL_INIT_AUDIO):
-        return BuildCommonUsageString(&common_usage_videoaudio, video_usage, SDL_arraysize(video_usage), audio_usage, SDL_arraysize(audio_usage));
-    default:
-        return "[--trackmem]";
-    }
-}
 
 SDL_bool
 SDLTest_CommonDefaultArgs(SDLTest_CommonState *state, const int argc, char **argv)

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -659,7 +659,7 @@ SDLTest_CommonDefaultArgs(SDLTest_CommonState *state, const int argc, char **arg
     int i = 1;
     while (i < argc) {
         const int consumed = SDLTest_CommonArg(state, i);
-        if (consumed == 0) {
+        if (consumed <= 0) {
             SDLTest_CommonLogUsage(state, argv[0], NULL);
             return SDL_FALSE;
         }

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -22,10 +22,15 @@
 /* Ported from original test/common.c file. */
 #include <SDL3/SDL_test.h>
 
+static const char *common_usage[] = {
+    "[-h | --help]",
+    "[--trackmem]",
+    "[--log all|error|system|audio|video|render|input]",
+};
+
 static const char *video_usage[] = {
-    "[--video driver]", "[--renderer driver]", "[--gldebug]",
+    "[--video driver]", "[--renderer driver]", "[--gldebug]", "[--display N]",
     "[--info all|video|modes|render|event|event_motion]",
-    "[--log all|error|system|audio|video|render|input]", "[--display N]",
     "[--metal-window | --opengl-window | --vulkan-window]",
     "[--fullscreen | --fullscreen-desktop | --windows N]", "[--title title]",
     "[--icon icon.bmp]", "[--center | --position X,Y]", "[--geometry WxH]",
@@ -615,7 +620,10 @@ void SDLTest_CommonLogUsage(SDLTest_CommonState *state, const char *argv0, const
     int i;
 
     SDL_Log("USAGE: %s", argv0);
-    SDL_Log("    %s", "[--trackmem]");
+
+    for (i = 0; i < SDL_arraysize(common_usage); i++) {
+        SDL_Log("    %s", common_usage[i]);
+    }
 
     if (state->flags & SDL_INIT_VIDEO) {
         for (i = 0; i < SDL_arraysize(video_usage); i++) {

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -142,58 +142,13 @@ int SDLTest_CommonArg(SDLTest_CommonState *state, int index)
 {
     char **argv = state->argv;
 
-    if (SDL_strcasecmp(argv[index], "--video") == 0) {
-        ++index;
-        if (!argv[index]) {
-            return -1;
-        }
-        state->videodriver = argv[index];
-        return 2;
-    }
-    if (SDL_strcasecmp(argv[index], "--renderer") == 0) {
-        ++index;
-        if (!argv[index]) {
-            return -1;
-        }
-        state->renderdriver = argv[index];
-        return 2;
-    }
-    if (SDL_strcasecmp(argv[index], "--gldebug") == 0) {
-        state->gl_debug = 1;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--info") == 0) {
-        ++index;
-        if (!argv[index]) {
-            return -1;
-        }
-        if (SDL_strcasecmp(argv[index], "all") == 0) {
-            state->verbose |=
-                (VERBOSE_VIDEO | VERBOSE_MODES | VERBOSE_RENDER |
-                 VERBOSE_EVENT);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "video") == 0) {
-            state->verbose |= VERBOSE_VIDEO;
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "modes") == 0) {
-            state->verbose |= VERBOSE_MODES;
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "render") == 0) {
-            state->verbose |= VERBOSE_RENDER;
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "event") == 0) {
-            state->verbose |= VERBOSE_EVENT;
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "event_motion") == 0) {
-            state->verbose |= (VERBOSE_EVENT | VERBOSE_MOTION);
-            return 2;
-        }
+    if ((SDL_strcasecmp(argv[index], "-h") == 0) || (SDL_strcasecmp(argv[index], "--help") == 0)) {
+        /* Print the usage message */
         return -1;
+    }
+    if (SDL_strcasecmp(argv[index], "--trackmem") == 0) {
+        /* Already handled in SDLTest_CommonCreateState() */
+        return 1;
     }
     if (SDL_strcasecmp(argv[index], "--log") == 0) {
         ++index;
@@ -230,383 +185,433 @@ int SDLTest_CommonArg(SDLTest_CommonState *state, int index)
         }
         return -1;
     }
-    if (SDL_strcasecmp(argv[index], "--display") == 0) {
-        ++index;
-        if (!argv[index]) {
-            return -1;
-        }
-        state->display_index = SDL_atoi(argv[index]);
-        return 2;
-    }
-    if (SDL_strcasecmp(argv[index], "--metal-window") == 0) {
-        state->window_flags |= SDL_WINDOW_METAL;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--opengl-window") == 0) {
-        state->window_flags |= SDL_WINDOW_OPENGL;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--vulkan-window") == 0) {
-        state->window_flags |= SDL_WINDOW_VULKAN;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--fullscreen") == 0) {
-        state->window_flags |= SDL_WINDOW_FULLSCREEN;
-        state->fullscreen_exclusive = SDL_TRUE;
-        state->num_windows = 1;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--fullscreen-desktop") == 0) {
-        state->window_flags |= SDL_WINDOW_FULLSCREEN;
-        state->fullscreen_exclusive = SDL_FALSE;
-        state->num_windows = 1;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--windows") == 0) {
-        ++index;
-        if (!argv[index] || !SDL_isdigit((unsigned char)*argv[index])) {
-            return -1;
-        }
-        if (!(state->window_flags & SDL_WINDOW_FULLSCREEN)) {
-            state->num_windows = SDL_atoi(argv[index]);
-        }
-        return 2;
-    }
-    if (SDL_strcasecmp(argv[index], "--title") == 0) {
-        ++index;
-        if (!argv[index]) {
-            return -1;
-        }
-        state->window_title = argv[index];
-        return 2;
-    }
-    if (SDL_strcasecmp(argv[index], "--icon") == 0) {
-        ++index;
-        if (!argv[index]) {
-            return -1;
-        }
-        state->window_icon = argv[index];
-        return 2;
-    }
-    if (SDL_strcasecmp(argv[index], "--center") == 0) {
-        state->window_x = SDL_WINDOWPOS_CENTERED;
-        state->window_y = SDL_WINDOWPOS_CENTERED;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--position") == 0) {
-        char *x, *y;
-        ++index;
-        if (!argv[index]) {
-            return -1;
-        }
-        x = argv[index];
-        y = argv[index];
-        while (*y && *y != ',') {
-            ++y;
-        }
-        if (!*y) {
-            return -1;
-        }
-        *y++ = '\0';
-        state->window_x = SDL_atoi(x);
-        state->window_y = SDL_atoi(y);
-        return 2;
-    }
-    if (SDL_strcasecmp(argv[index], "--confine-cursor") == 0) {
-        char *x, *y, *w, *h;
-        ++index;
-        if (!argv[index]) {
-            return -1;
-        }
-        x = argv[index];
-        y = argv[index];
-        SEARCHARG(y)
-        w = y;
-        SEARCHARG(w)
-        h = w;
-        SEARCHARG(h)
-        state->confine.x = SDL_atoi(x);
-        state->confine.y = SDL_atoi(y);
-        state->confine.w = SDL_atoi(w);
-        state->confine.h = SDL_atoi(h);
-        return 2;
-    }
-    if (SDL_strcasecmp(argv[index], "--usable-bounds") == 0) {
-        /* !!! FIXME: this is a bit of a hack, but I don't want to add a
-           !!! FIXME:  flag to the public structure in 2.0.x */
-        state->window_x = -1;
-        state->window_y = -1;
-        state->window_w = -1;
-        state->window_h = -1;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--geometry") == 0) {
-        char *w, *h;
-        ++index;
-        if (!argv[index]) {
-            return -1;
-        }
-        w = argv[index];
-        h = argv[index];
-        while (*h && *h != 'x') {
-            ++h;
-        }
-        if (!*h) {
-            return -1;
-        }
-        *h++ = '\0';
-        state->window_w = SDL_atoi(w);
-        state->window_h = SDL_atoi(h);
-        return 2;
-    }
-    if (SDL_strcasecmp(argv[index], "--min-geometry") == 0) {
-        char *w, *h;
-        ++index;
-        if (!argv[index]) {
-            return -1;
-        }
-        w = argv[index];
-        h = argv[index];
-        while (*h && *h != 'x') {
-            ++h;
-        }
-        if (!*h) {
-            return -1;
-        }
-        *h++ = '\0';
-        state->window_minW = SDL_atoi(w);
-        state->window_minH = SDL_atoi(h);
-        return 2;
-    }
-    if (SDL_strcasecmp(argv[index], "--max-geometry") == 0) {
-        char *w, *h;
-        ++index;
-        if (!argv[index]) {
-            return -1;
-        }
-        w = argv[index];
-        h = argv[index];
-        while (*h && *h != 'x') {
-            ++h;
-        }
-        if (!*h) {
-            return -1;
-        }
-        *h++ = '\0';
-        state->window_maxW = SDL_atoi(w);
-        state->window_maxH = SDL_atoi(h);
-        return 2;
-    }
-    if (SDL_strcasecmp(argv[index], "--logical") == 0) {
-        char *w, *h;
-        ++index;
-        if (!argv[index]) {
-            return -1;
-        }
-        w = argv[index];
-        h = argv[index];
-        while (*h && *h != 'x') {
-            ++h;
-        }
-        if (!*h) {
-            return -1;
-        }
-        *h++ = '\0';
-        state->logical_w = SDL_atoi(w);
-        state->logical_h = SDL_atoi(h);
-        return 2;
-    }
-    if (SDL_strcasecmp(argv[index], "--logical-presentation") == 0) {
-        ++index;
-        if (!argv[index]) {
-            return -1;
-        }
-        if (SDL_strcasecmp(argv[index], "disabled") == 0) {
-            state->logical_presentation = SDL_LOGICAL_PRESENTATION_DISABLED;
+    if (state->flags & SDL_INIT_VIDEO) {
+        if (SDL_strcasecmp(argv[index], "--video") == 0) {
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            state->videodriver = argv[index];
             return 2;
         }
-        if (SDL_strcasecmp(argv[index], "match") == 0) {
-            state->logical_presentation = SDL_LOGICAL_PRESENTATION_MATCH;
+        if (SDL_strcasecmp(argv[index], "--renderer") == 0) {
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            state->renderdriver = argv[index];
             return 2;
         }
-        if (SDL_strcasecmp(argv[index], "stretch") == 0) {
-            state->logical_presentation = SDL_LOGICAL_PRESENTATION_STRETCH;
-            return 2;
+        if (SDL_strcasecmp(argv[index], "--gldebug") == 0) {
+            state->gl_debug = 1;
+            return 1;
         }
-        if (SDL_strcasecmp(argv[index], "letterbox") == 0) {
-            state->logical_presentation = SDL_LOGICAL_PRESENTATION_LETTERBOX;
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "overscan") == 0) {
-            state->logical_presentation = SDL_LOGICAL_PRESENTATION_OVERSCAN;
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "integer_scale") == 0) {
-            state->logical_presentation = SDL_LOGICAL_PRESENTATION_INTEGER_SCALE;
-            return 2;
-        }
-        return -1;
-    }
-    if (SDL_strcasecmp(argv[index], "--logical-scale-quality") == 0) {
-        ++index;
-        if (!argv[index]) {
+        if (SDL_strcasecmp(argv[index], "--info") == 0) {
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            if (SDL_strcasecmp(argv[index], "all") == 0) {
+                state->verbose |=
+                        (VERBOSE_VIDEO | VERBOSE_MODES | VERBOSE_RENDER |
+                         VERBOSE_EVENT);
+                return 2;
+            }
+            if (SDL_strcasecmp(argv[index], "video") == 0) {
+                state->verbose |= VERBOSE_VIDEO;
+                return 2;
+            }
+            if (SDL_strcasecmp(argv[index], "modes") == 0) {
+                state->verbose |= VERBOSE_MODES;
+                return 2;
+            }
+            if (SDL_strcasecmp(argv[index], "render") == 0) {
+                state->verbose |= VERBOSE_RENDER;
+                return 2;
+            }
+            if (SDL_strcasecmp(argv[index], "event") == 0) {
+                state->verbose |= VERBOSE_EVENT;
+                return 2;
+            }
+            if (SDL_strcasecmp(argv[index], "event_motion") == 0) {
+                state->verbose |= (VERBOSE_EVENT | VERBOSE_MOTION);
+                return 2;
+            }
             return -1;
         }
-        if (SDL_strcasecmp(argv[index], "nearest") == 0) {
-            state->logical_scale_mode = SDL_SCALEMODE_NEAREST;
+        if (SDL_strcasecmp(argv[index], "--display") == 0) {
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            state->display_index = SDL_atoi(argv[index]);
             return 2;
         }
-        if (SDL_strcasecmp(argv[index], "linear") == 0) {
-            state->logical_scale_mode = SDL_SCALEMODE_LINEAR;
+        if (SDL_strcasecmp(argv[index], "--metal-window") == 0) {
+            state->window_flags |= SDL_WINDOW_METAL;
+            return 1;
+        }
+        if (SDL_strcasecmp(argv[index], "--opengl-window") == 0) {
+            state->window_flags |= SDL_WINDOW_OPENGL;
+            return 1;
+        }
+        if (SDL_strcasecmp(argv[index], "--vulkan-window") == 0) {
+            state->window_flags |= SDL_WINDOW_VULKAN;
+            return 1;
+        }
+        if (SDL_strcasecmp(argv[index], "--fullscreen") == 0) {
+            state->window_flags |= SDL_WINDOW_FULLSCREEN;
+            state->fullscreen_exclusive = SDL_TRUE;
+            state->num_windows = 1;
+            return 1;
+        }
+        if (SDL_strcasecmp(argv[index], "--fullscreen-desktop") == 0) {
+            state->window_flags |= SDL_WINDOW_FULLSCREEN;
+            state->fullscreen_exclusive = SDL_FALSE;
+            state->num_windows = 1;
+            return 1;
+        }
+        if (SDL_strcasecmp(argv[index], "--windows") == 0) {
+            ++index;
+            if (!argv[index] || !SDL_isdigit((unsigned char) *argv[index])) {
+                return -1;
+            }
+            if (!(state->window_flags & SDL_WINDOW_FULLSCREEN)) {
+                state->num_windows = SDL_atoi(argv[index]);
+            }
             return 2;
         }
-        if (SDL_strcasecmp(argv[index], "best") == 0) {
-            state->logical_scale_mode = SDL_SCALEMODE_BEST;
+        if (SDL_strcasecmp(argv[index], "--title") == 0) {
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            state->window_title = argv[index];
             return 2;
         }
-        return -1;
-    }
-    if (SDL_strcasecmp(argv[index], "--scale") == 0) {
-        ++index;
-        if (!argv[index]) {
+        if (SDL_strcasecmp(argv[index], "--icon") == 0) {
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            state->window_icon = argv[index];
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "--center") == 0) {
+            state->window_x = SDL_WINDOWPOS_CENTERED;
+            state->window_y = SDL_WINDOWPOS_CENTERED;
+            return 1;
+        }
+        if (SDL_strcasecmp(argv[index], "--position") == 0) {
+            char *x, *y;
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            x = argv[index];
+            y = argv[index];
+            while (*y && *y != ',') {
+                ++y;
+            }
+            if (!*y) {
+                return -1;
+            }
+            *y++ = '\0';
+            state->window_x = SDL_atoi(x);
+            state->window_y = SDL_atoi(y);
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "--confine-cursor") == 0) {
+            char *x, *y, *w, *h;
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            x = argv[index];
+            y = argv[index];
+            SEARCHARG(y)
+            w = y;
+            SEARCHARG(w)
+            h = w;
+            SEARCHARG(h)
+            state->confine.x = SDL_atoi(x);
+            state->confine.y = SDL_atoi(y);
+            state->confine.w = SDL_atoi(w);
+            state->confine.h = SDL_atoi(h);
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "--usable-bounds") == 0) {
+            /* !!! FIXME: this is a bit of a hack, but I don't want to add a
+               !!! FIXME:  flag to the public structure in 2.0.x */
+            state->window_x = -1;
+            state->window_y = -1;
+            state->window_w = -1;
+            state->window_h = -1;
+            return 1;
+        }
+        if (SDL_strcasecmp(argv[index], "--geometry") == 0) {
+            char *w, *h;
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            w = argv[index];
+            h = argv[index];
+            while (*h && *h != 'x') {
+                ++h;
+            }
+            if (!*h) {
+                return -1;
+            }
+            *h++ = '\0';
+            state->window_w = SDL_atoi(w);
+            state->window_h = SDL_atoi(h);
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "--min-geometry") == 0) {
+            char *w, *h;
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            w = argv[index];
+            h = argv[index];
+            while (*h && *h != 'x') {
+                ++h;
+            }
+            if (!*h) {
+                return -1;
+            }
+            *h++ = '\0';
+            state->window_minW = SDL_atoi(w);
+            state->window_minH = SDL_atoi(h);
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "--max-geometry") == 0) {
+            char *w, *h;
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            w = argv[index];
+            h = argv[index];
+            while (*h && *h != 'x') {
+                ++h;
+            }
+            if (!*h) {
+                return -1;
+            }
+            *h++ = '\0';
+            state->window_maxW = SDL_atoi(w);
+            state->window_maxH = SDL_atoi(h);
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "--logical") == 0) {
+            char *w, *h;
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            w = argv[index];
+            h = argv[index];
+            while (*h && *h != 'x') {
+                ++h;
+            }
+            if (!*h) {
+                return -1;
+            }
+            *h++ = '\0';
+            state->logical_w = SDL_atoi(w);
+            state->logical_h = SDL_atoi(h);
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "--logical-presentation") == 0) {
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            if (SDL_strcasecmp(argv[index], "disabled") == 0) {
+                state->logical_presentation = SDL_LOGICAL_PRESENTATION_DISABLED;
+                return 2;
+            }
+            if (SDL_strcasecmp(argv[index], "match") == 0) {
+                state->logical_presentation = SDL_LOGICAL_PRESENTATION_MATCH;
+                return 2;
+            }
+            if (SDL_strcasecmp(argv[index], "stretch") == 0) {
+                state->logical_presentation = SDL_LOGICAL_PRESENTATION_STRETCH;
+                return 2;
+            }
+            if (SDL_strcasecmp(argv[index], "letterbox") == 0) {
+                state->logical_presentation = SDL_LOGICAL_PRESENTATION_LETTERBOX;
+                return 2;
+            }
+            if (SDL_strcasecmp(argv[index], "overscan") == 0) {
+                state->logical_presentation = SDL_LOGICAL_PRESENTATION_OVERSCAN;
+                return 2;
+            }
+            if (SDL_strcasecmp(argv[index], "integer_scale") == 0) {
+                state->logical_presentation = SDL_LOGICAL_PRESENTATION_INTEGER_SCALE;
+                return 2;
+            }
             return -1;
         }
-        state->scale = (float)SDL_atof(argv[index]);
-        return 2;
-    }
-    if (SDL_strcasecmp(argv[index], "--depth") == 0) {
-        ++index;
-        if (!argv[index]) {
+        if (SDL_strcasecmp(argv[index], "--logical-scale-quality") == 0) {
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            if (SDL_strcasecmp(argv[index], "nearest") == 0) {
+                state->logical_scale_mode = SDL_SCALEMODE_NEAREST;
+                return 2;
+            }
+            if (SDL_strcasecmp(argv[index], "linear") == 0) {
+                state->logical_scale_mode = SDL_SCALEMODE_LINEAR;
+                return 2;
+            }
+            if (SDL_strcasecmp(argv[index], "best") == 0) {
+                state->logical_scale_mode = SDL_SCALEMODE_BEST;
+                return 2;
+            }
             return -1;
         }
-        state->depth = SDL_atoi(argv[index]);
-        return 2;
-    }
-    if (SDL_strcasecmp(argv[index], "--refresh") == 0) {
-        ++index;
-        if (!argv[index]) {
-            return -1;
-        }
-        state->refresh_rate = (float)SDL_atof(argv[index]);
-        return 2;
-    }
-    if (SDL_strcasecmp(argv[index], "--vsync") == 0) {
-        state->render_flags |= SDL_RENDERER_PRESENTVSYNC;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--noframe") == 0) {
-        state->window_flags |= SDL_WINDOW_BORDERLESS;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--resizable") == 0) {
-        state->window_flags |= SDL_WINDOW_RESIZABLE;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--transparent") == 0) {
-        state->window_flags |= SDL_WINDOW_TRANSPARENT;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--skip-taskbar") == 0) {
-        state->window_flags |= SDL_WINDOW_SKIP_TASKBAR;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--always-on-top") == 0) {
-        state->window_flags |= SDL_WINDOW_ALWAYS_ON_TOP;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--minimize") == 0) {
-        state->window_flags |= SDL_WINDOW_MINIMIZED;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--maximize") == 0) {
-        state->window_flags |= SDL_WINDOW_MAXIMIZED;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--hidden") == 0) {
-        state->window_flags |= SDL_WINDOW_HIDDEN;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--input-focus") == 0) {
-        state->window_flags |= SDL_WINDOW_INPUT_FOCUS;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--mouse-focus") == 0) {
-        state->window_flags |= SDL_WINDOW_MOUSE_FOCUS;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--flash-on-focus-loss") == 0) {
-        state->flash_on_focus_loss = SDL_TRUE;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--grab") == 0) {
-        state->window_flags |= SDL_WINDOW_MOUSE_GRABBED;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--keyboard-grab") == 0) {
-        state->window_flags |= SDL_WINDOW_KEYBOARD_GRABBED;
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--rate") == 0) {
-        ++index;
-        if (!argv[index]) {
-            return -1;
-        }
-        state->audiospec.freq = SDL_atoi(argv[index]);
-        return 2;
-    }
-    if (SDL_strcasecmp(argv[index], "--format") == 0) {
-        ++index;
-        if (!argv[index]) {
-            return -1;
-        }
-        if (SDL_strcasecmp(argv[index], "U8") == 0) {
-            state->audiospec.format = AUDIO_U8;
+        if (SDL_strcasecmp(argv[index], "--scale") == 0) {
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            state->scale = (float) SDL_atof(argv[index]);
             return 2;
         }
-        if (SDL_strcasecmp(argv[index], "S8") == 0) {
-            state->audiospec.format = AUDIO_S8;
+        if (SDL_strcasecmp(argv[index], "--depth") == 0) {
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            state->depth = SDL_atoi(argv[index]);
             return 2;
         }
-        if (SDL_strcasecmp(argv[index], "S16") == 0) {
-            state->audiospec.format = AUDIO_S16;
+        if (SDL_strcasecmp(argv[index], "--refresh") == 0) {
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            state->refresh_rate = (float) SDL_atof(argv[index]);
             return 2;
         }
-        if (SDL_strcasecmp(argv[index], "S16LE") == 0) {
-            state->audiospec.format = AUDIO_S16LSB;
-            return 2;
+        if (SDL_strcasecmp(argv[index], "--vsync") == 0) {
+            state->render_flags |= SDL_RENDERER_PRESENTVSYNC;
+            return 1;
         }
-        if (SDL_strcasecmp(argv[index], "S16BE") == 0) {
-            state->audiospec.format = AUDIO_S16MSB;
-            return 2;
+        if (SDL_strcasecmp(argv[index], "--noframe") == 0) {
+            state->window_flags |= SDL_WINDOW_BORDERLESS;
+            return 1;
         }
+        if (SDL_strcasecmp(argv[index], "--resizable") == 0) {
+            state->window_flags |= SDL_WINDOW_RESIZABLE;
+            return 1;
+        }
+        if (SDL_strcasecmp(argv[index], "--transparent") == 0) {
+            state->window_flags |= SDL_WINDOW_TRANSPARENT;
+            return 1;
+        }
+        if (SDL_strcasecmp(argv[index], "--skip-taskbar") == 0) {
+            state->window_flags |= SDL_WINDOW_SKIP_TASKBAR;
+            return 1;
+        }
+        if (SDL_strcasecmp(argv[index], "--always-on-top") == 0) {
+            state->window_flags |= SDL_WINDOW_ALWAYS_ON_TOP;
+            return 1;
+        }
+        if (SDL_strcasecmp(argv[index], "--minimize") == 0) {
+            state->window_flags |= SDL_WINDOW_MINIMIZED;
+            return 1;
+        }
+        if (SDL_strcasecmp(argv[index], "--maximize") == 0) {
+            state->window_flags |= SDL_WINDOW_MAXIMIZED;
+            return 1;
+        }
+        if (SDL_strcasecmp(argv[index], "--hidden") == 0) {
+            state->window_flags |= SDL_WINDOW_HIDDEN;
+            return 1;
+        }
+        if (SDL_strcasecmp(argv[index], "--input-focus") == 0) {
+            state->window_flags |= SDL_WINDOW_INPUT_FOCUS;
+            return 1;
+        }
+        if (SDL_strcasecmp(argv[index], "--mouse-focus") == 0) {
+            state->window_flags |= SDL_WINDOW_MOUSE_FOCUS;
+            return 1;
+        }
+        if (SDL_strcasecmp(argv[index], "--flash-on-focus-loss") == 0) {
+            state->flash_on_focus_loss = SDL_TRUE;
+            return 1;
+        }
+        if (SDL_strcasecmp(argv[index], "--grab") == 0) {
+            state->window_flags |= SDL_WINDOW_MOUSE_GRABBED;
+            return 1;
+        }
+        if (SDL_strcasecmp(argv[index], "--keyboard-grab") == 0) {
+            state->window_flags |= SDL_WINDOW_KEYBOARD_GRABBED;
+            return 1;
+        }
+    }
 
-        /* !!! FIXME: Float32? Sint32? */
+    if (state->flags & SDL_INIT_AUDIO) {
+        if (SDL_strcasecmp(argv[index], "--rate") == 0) {
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            state->audiospec.freq = SDL_atoi(argv[index]);
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "--format") == 0) {
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            if (SDL_strcasecmp(argv[index], "U8") == 0) {
+                state->audiospec.format = AUDIO_U8;
+                return 2;
+            }
+            if (SDL_strcasecmp(argv[index], "S8") == 0) {
+                state->audiospec.format = AUDIO_S8;
+                return 2;
+            }
+            if (SDL_strcasecmp(argv[index], "S16") == 0) {
+                state->audiospec.format = AUDIO_S16;
+                return 2;
+            }
+            if (SDL_strcasecmp(argv[index], "S16LE") == 0) {
+                state->audiospec.format = AUDIO_S16LSB;
+                return 2;
+            }
+            if (SDL_strcasecmp(argv[index], "S16BE") == 0) {
+                state->audiospec.format = AUDIO_S16MSB;
+                return 2;
+            }
 
-        return -1;
-    }
-    if (SDL_strcasecmp(argv[index], "--channels") == 0) {
-        ++index;
-        if (!argv[index]) {
+            /* !!! FIXME: Float32? Sint32? */
+
             return -1;
         }
-        state->audiospec.channels = (Uint8)SDL_atoi(argv[index]);
-        return 2;
-    }
-    if (SDL_strcasecmp(argv[index], "--samples") == 0) {
-        ++index;
-        if (!argv[index]) {
-            return -1;
+        if (SDL_strcasecmp(argv[index], "--channels") == 0) {
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            state->audiospec.channels = (Uint8) SDL_atoi(argv[index]);
+            return 2;
         }
-        state->audiospec.samples = (Uint16)SDL_atoi(argv[index]);
-        return 2;
-    }
-    if (SDL_strcasecmp(argv[index], "--trackmem") == 0) {
-        /* Already handled in SDLTest_CommonCreateState() */
-        return 1;
-    }
-    if ((SDL_strcasecmp(argv[index], "-h") == 0) || (SDL_strcasecmp(argv[index], "--help") == 0)) {
-        /* Print the usage message */
-        return -1;
+        if (SDL_strcasecmp(argv[index], "--samples") == 0) {
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            state->audiospec.samples = (Uint16) SDL_atoi(argv[index]);
+            return 2;
+        }
     }
     if (SDL_strcmp(argv[index], "-NSDocumentRevisionsDebugMode") == 0) {
         /* Debug flag sent by Xcode */

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -118,6 +118,12 @@ SDLTest_CommonCreateState(char **argv, Uint32 flags)
     return state;
 }
 
+void
+SDLTest_CommonDestroyState(SDLTest_CommonState *state) {
+    SDLTest_LogAllocations();
+    SDL_free(state);
+}
+
 #define SEARCHARG(dim)                  \
     while (*(dim) && *(dim) != ',') {   \
         ++(dim);                        \
@@ -2261,9 +2267,8 @@ void SDLTest_CommonQuit(SDLTest_CommonState *state)
     if (state->flags & SDL_INIT_AUDIO) {
         SDL_QuitSubSystem(SDL_INIT_AUDIO);
     }
-    SDL_free(state);
     SDL_Quit();
-    SDLTest_LogAllocations();
+    SDLTest_CommonDestroyState(state);
 }
 
 void SDLTest_CommonDrawWindowInfo(SDL_Renderer *renderer, SDL_Window *window, float *usedHeight)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -136,9 +136,39 @@ add_sdl_test_executable(testdropfile testdropfile.c)
 add_sdl_test_executable(testerror NONINTERACTIVE testerror.c)
 
 if(LINUX AND TARGET sdl-build-options)
+    set(build_options_dependent_tests )
+
     add_sdl_test_executable(testevdev NONINTERACTIVE testevdev.c)
-    target_include_directories(testevdev BEFORE PRIVATE $<TARGET_PROPERTY:sdl-build-options,INTERFACE_INCLUDE_DIRECTORIES>)
-    target_include_directories(testevdev BEFORE PRIVATE ${SDL3_SOURCE_DIR}/src)
+    list(APPEND build_options_dependent_tests testevdev)
+
+    if(APPLE)
+        add_sdl_test_executable(testnative NEEDS_RESOURCES TESTUTILS
+            testnative.c
+            testnativecocoa.m
+            testnativex11.c
+        )
+        target_compile_definitions(testnative PRIVATE TEST_NATIVE_COCOA)
+
+        cmake_push_check_state()
+        check_c_compiler_flag(-Wno-error=deprecated-declarations HAVE_WNO_ERROR_DEPRECATED_DECLARATIONS)
+        cmake_pop_check_state()
+        if(HAVE_WNO_ERROR_DEPRECATED_DECLARATIONS)
+            set_property(SOURCE "testnativecocoa.m" APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-error=deprecated-declarations")
+        endif()
+        list(APPEND build_options_dependent_tests testnative)
+    elseif(WINDOWS)
+        add_sdl_test_executable(testnative NEEDS_RESOURCES TESTUTILS testnative.c testnativew32.c)
+        list(APPEND build_options_dependent_tests testnative)
+    elseif(HAVE_X11)
+        add_sdl_test_executable(testnative NEEDS_RESOURCES TESTUTILS testnative.c testnativex11.c)
+        target_link_libraries(testnative PRIVATE X11)
+        list(APPEND build_options_dependent_tests testnative)
+    endif()
+
+    foreach(t ${build_options_dependent_tests})
+        target_include_directories(${t} BEFORE PRIVATE $<TARGET_PROPERTY:sdl-build-options,INTERFACE_INCLUDE_DIRECTORIES>)
+        target_include_directories(${t} BEFORE PRIVATE ${SDL3_SOURCE_DIR}/src)
+    endforeach()
 endif()
 
 add_sdl_test_executable(testfile testfile.c)
@@ -161,26 +191,6 @@ add_sdl_test_executable(testlocale NONINTERACTIVE testlocale.c)
 add_sdl_test_executable(testlock testlock.c)
 add_sdl_test_executable(testmouse testmouse.c)
 
-if(APPLE)
-    add_sdl_test_executable(testnative NEEDS_RESOURCES TESTUTILS
-        testnative.c
-        testnativecocoa.m
-        testnativex11.c
-    )
-
-    cmake_push_check_state()
-    check_c_compiler_flag(-Wno-error=deprecated-declarations HAVE_WNO_ERROR_DEPRECATED_DECLARATIONS)
-    cmake_pop_check_state()
-    if(HAVE_WNO_ERROR_DEPRECATED_DECLARATIONS)
-        set_property(SOURCE "testnativecocoa.m" APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-error=deprecated-declarations")
-    endif()
-elseif(WINDOWS)
-    add_sdl_test_executable(testnative NEEDS_RESOURCES TESTUTILS testnative.c testnativew32.c)
-elseif(HAVE_X11)
-    add_sdl_test_executable(testnative NEEDS_RESOURCES TESTUTILS testnative.c testnativex11.c)
-    target_link_libraries(testnative PRIVATE X11)
-endif()
-
 add_sdl_test_executable(testoverlay NEEDS_RESOURCES TESTUTILS testoverlay.c)
 add_sdl_test_executable(testplatform NONINTERACTIVE testplatform.c)
 add_sdl_test_executable(testpower NONINTERACTIVE testpower.c)
@@ -189,7 +199,7 @@ add_sdl_test_executable(testrendertarget NEEDS_RESOURCES TESTUTILS testrendertar
 add_sdl_test_executable(testscale NEEDS_RESOURCES TESTUTILS testscale.c)
 add_sdl_test_executable(testsem testsem.c)
 add_sdl_test_executable(testsensor testsensor.c)
-add_sdl_test_executable(testshader NEEDS_RESOURCES testshader.c)
+add_sdl_test_executable(testshader NEEDS_RESOURCES TESTUTILS testshader.c)
 add_sdl_test_executable(testshape NEEDS_RESOURCES testshape.c)
 add_sdl_test_executable(testsprite NEEDS_RESOURCES TESTUTILS testsprite.c)
 add_sdl_test_executable(testspriteminimal NEEDS_RESOURCES TESTUTILS testspriteminimal.c)
@@ -199,7 +209,7 @@ add_sdl_test_executable(testurl testurl.c)
 add_sdl_test_executable(testver NONINTERACTIVE testver.c)
 add_sdl_test_executable(testviewport NEEDS_RESOURCES TESTUTILS testviewport.c)
 add_sdl_test_executable(testwm testwm.c)
-add_sdl_test_executable(testyuv NEEDS_RESOURCES testyuv.c testyuv_cvt.c)
+add_sdl_test_executable(testyuv NEEDS_RESOURCES TESTUTILS testyuv.c testyuv_cvt.c)
 add_sdl_test_executable(torturethread torturethread.c)
 add_sdl_test_executable(testrendercopyex NEEDS_RESOURCES TESTUTILS testrendercopyex.c)
 add_sdl_test_executable(testmessage testmessage.c)

--- a/test/checkkeys.c
+++ b/test/checkkeys.c
@@ -23,7 +23,7 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
-#include <SDL3/SDL_test_font.h>
+#include <SDL3/SDL_test.h>
 
 static SDL_Window *window;
 static SDL_Renderer *renderer;
@@ -249,8 +249,21 @@ static void loop(void)
 
 int main(int argc, char *argv[])
 {
+    SDLTest_CommonState *state;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
+
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        return 1;
+    }
 
     /* Disable mouse emulation */
     SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
@@ -304,5 +317,6 @@ int main(int argc, char *argv[])
 #endif
 
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
     return 0;
 }

--- a/test/checkkeysthreads.c
+++ b/test/checkkeysthreads.c
@@ -24,6 +24,7 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 static int done;
 
@@ -240,9 +241,21 @@ int main(int argc, char *argv[])
     SDL_Window *window;
     SDL_Renderer *renderer;
     SDL_Thread *thread;
+    SDLTest_CommonState *state;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
 
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        return 1;
+    }
 
     /* Initialize SDL */
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
@@ -290,5 +303,6 @@ int main(int argc, char *argv[])
 
     SDL_WaitThread(thread, NULL);
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
     return 0;
 }

--- a/test/loopwave.c
+++ b/test/loopwave.c
@@ -23,6 +23,7 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 #include "testutils.h"
 
 static struct
@@ -113,9 +114,36 @@ int main(int argc, char *argv[])
 {
     int i;
     char *filename = NULL;
+    SDLTest_CommonState *state;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
 
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    for (i = 1; i < argc;) {
+        int consumed;
+
+        consumed = SDLTest_CommonArg(state, i);
+        if (!consumed) {
+            if (!filename) {
+                filename = argv[i];
+                consumed = 1;
+            }
+        }
+        if (consumed <= 0) {
+            static const char *options[] = { "[sample.wav]", NULL };
+            SDLTest_CommonLogUsage(state, argv[0], options);
+            exit(1);
+        }
+
+        i += consumed;
+    }
 
     /* Load the SDL library */
     if (SDL_Init(SDL_INIT_AUDIO | SDL_INIT_EVENTS) < 0) {
@@ -123,7 +151,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    filename = GetResourceFilename(argc > 1 ? argv[1] : NULL, "sample.wav");
+    filename = GetResourceFilename(filename, "sample.wav");
 
     if (filename == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s\n", SDL_GetError());
@@ -174,5 +202,6 @@ int main(int argc, char *argv[])
     SDL_free(wave.sound);
     SDL_free(filename);
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
     return 0;
 }

--- a/test/testatomic.c
+++ b/test/testatomic.c
@@ -12,6 +12,7 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 /*
   Absolutely basic tests just to see if we get the expected value
@@ -695,8 +696,21 @@ static void RunFIFOTest(SDL_bool lock_free)
 
 int main(int argc, char *argv[])
 {
+    SDLTest_CommonState *state;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
+
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        return 1;
+    }
 
     RunBasicTest();
 
@@ -711,5 +725,6 @@ int main(int argc, char *argv[])
     RunFIFOTest(SDL_FALSE);
 #endif
     RunFIFOTest(SDL_TRUE);
+    SDLTest_CommonDestroyState(state);
     return 0;
 }

--- a/test/testaudiohotplug.c
+++ b/test/testaudiohotplug.c
@@ -24,6 +24,7 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 #include "testutils.h"
 
 static SDL_AudioSpec spec;
@@ -33,11 +34,14 @@ static Uint32 soundlen = 0; /* Length of wave data */
 static int posindex = 0;
 static Uint32 positions[64];
 
+static SDLTest_CommonState *state;
+
 /* Call this instead of exit(), so we can clean up SDL: atexit() is evil. */
 static void
 quit(int rc)
 {
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
     exit(rc);
 }
 
@@ -134,9 +138,36 @@ int main(int argc, char *argv[])
 {
     int i;
     char *filename = NULL;
+    SDL_Window *window;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
 
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    for (i = 1; i < argc;) {
+        int consumed;
+
+        consumed = SDLTest_CommonArg(state, i);
+        if (!consumed) {
+            if (!filename) {
+                filename = argv[i];
+                consumed = 1;
+            }
+        }
+        if (consumed <= 0) {
+            static const char *options[] = { "[sample.wav]", NULL };
+            SDLTest_CommonLogUsage(state, argv[0], options);
+            exit(1);
+        }
+
+        i += consumed;
+    }
 
     /* Load the SDL library */
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO) < 0) {
@@ -145,9 +176,14 @@ int main(int argc, char *argv[])
     }
 
     /* Some targets (Mac CoreAudio) need an event queue for audio hotplug, so make and immediately hide a window. */
-    SDL_MinimizeWindow(SDL_CreateWindow("testaudiohotplug", 640, 480, 0));
+    window = SDL_CreateWindow("testaudiohotplug", 640, 480, 0);
+    if (window == NULL) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_CreateWindow failed: %s\n", SDL_GetError());
+        quit(1);
+    }
+    SDL_MinimizeWindow(window);
 
-    filename = GetResourceFilename(argc > 1 ? argv[1] : NULL, "sample.wav");
+    filename = GetResourceFilename(filename, "sample.wav");
 
     if (filename == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s\n", SDL_GetError());
@@ -195,6 +231,6 @@ int main(int argc, char *argv[])
     SDL_QuitSubSystem(SDL_INIT_AUDIO);
     SDL_free(sound);
     SDL_free(filename);
-    SDL_Quit();
+    quit(0);
     return 0;
 }

--- a/test/testaudioinfo.c
+++ b/test/testaudioinfo.c
@@ -11,6 +11,7 @@
 */
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 static void
 print_devices(int iscapture)
@@ -49,10 +50,23 @@ int main(int argc, char **argv)
 {
     char *deviceName = NULL;
     SDL_AudioSpec spec;
+    int i;
     int n;
+    SDLTest_CommonState *state;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
 
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        return 1;
+    }
 
     /* Load the SDL library */
     if (SDL_Init(SDL_INIT_AUDIO) < 0) {
@@ -65,7 +79,6 @@ int main(int argc, char **argv)
     if (n == 0) {
         SDL_Log("No built-in audio drivers\n\n");
     } else {
-        int i;
         SDL_Log("Built-in audio drivers:\n");
         for (i = 0; i < n; ++i) {
             SDL_Log("  %d: %s\n", i, SDL_GetAudioDriver(i));
@@ -99,5 +112,6 @@ int main(int argc, char **argv)
     }
 
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
     return 0;
 }

--- a/test/testbounds.c
+++ b/test/testbounds.c
@@ -12,11 +12,24 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 int main(int argc, char **argv)
 {
     SDL_DisplayID *displays;
     int i;
+    SDLTest_CommonState *state;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
+
+    /* Parse commandline */
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        return 1;
+    }
 
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
         SDL_Log("SDL_Init(SDL_INIT_VIDEO) failed: %s", SDL_GetError());
@@ -38,5 +51,6 @@ int main(int argc, char **argv)
     }
 
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
     return 0;
 }

--- a/test/testdisplayinfo.c
+++ b/test/testdisplayinfo.c
@@ -16,6 +16,7 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 static void
 print_mode(const char *prefix, const SDL_DisplayMode *mode)
@@ -35,9 +36,21 @@ int main(int argc, char *argv[])
     const SDL_DisplayMode **modes;
     const SDL_DisplayMode *mode;
     int num_displays, i;
+    SDLTest_CommonState *state;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
 
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        return 1;
+    }
 
     /* Load the SDL library */
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
@@ -85,5 +98,6 @@ int main(int argc, char *argv[])
     SDL_free(displays);
 
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
     return 0;
 }

--- a/test/testdrawchessboard.c
+++ b/test/testdrawchessboard.c
@@ -20,6 +20,7 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 static SDL_Window *window;
 static SDL_Renderer *renderer;
@@ -101,8 +102,21 @@ static void loop(void)
 
 int main(int argc, char *argv[])
 {
+    SDLTest_CommonState *state;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
+
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        return 1;
+    }
 
     /* Initialize SDL */
     if (SDL_Init(SDL_INIT_VIDEO) != 0) {
@@ -138,5 +152,6 @@ int main(int argc, char *argv[])
 #endif
 
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
     return 0;
 }

--- a/test/testdropfile.c
+++ b/test/testdropfile.c
@@ -33,14 +33,14 @@ int main(int argc, char *argv[])
     float x = 0.0f, y = 0.0f;
     unsigned int windowID = 0;
 
-    /* Enable standard application logging */
-    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
-
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, SDL_INIT_VIDEO);
     if (state == NULL) {
         return 1;
     }
+
+    /* Enable standard application logging */
+    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
 
     for (i = 1; i < argc;) {
         int consumed;

--- a/test/testerror.c
+++ b/test/testerror.c
@@ -16,6 +16,7 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 static int alive = 0;
 
@@ -44,9 +45,21 @@ ThreadFunc(void *data)
 int main(int argc, char *argv[])
 {
     SDL_Thread *thread;
+    SDLTest_CommonState *state;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
 
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        return 1;
+    }
 
     /* Load the SDL library */
     if (SDL_Init(0) < 0) {
@@ -77,5 +90,6 @@ int main(int argc, char *argv[])
     SDL_Log("Main thread error string: %s\n", SDL_GetError());
 
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
     return 0;
 }

--- a/test/testevdev.c
+++ b/test/testevdev.c
@@ -12,6 +12,7 @@
 */
 
 #include "../src/SDL_internal.h"
+#include <SDL3/SDL_test.h>
 
 #include <stdio.h>
 #include <string.h>
@@ -1038,5 +1039,22 @@ run_test(void)
 
 int main(int argc, char *argv[])
 {
-    return run_test() ? 0 : 1;
+    int result;
+    SDLTest_CommonState *state;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
+
+    /* Parse commandline */
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        return 1;
+    }
+
+    result = run_test() ? 0 : 1;
+
+    SDLTest_CommonDestroyState(state);
+    return result;
 }

--- a/test/testfile.c
+++ b/test/testfile.c
@@ -152,13 +152,13 @@ int main(int argc, char *argv[])
     if (0 != rwops->seek(rwops, 0L, SDL_RW_SEEK_SET)) {
         RWOP_ERR_QUIT(rwops);
     }
-    if (0 != rwops->read(rwops, test_buf, 1)) {
+    if (-1 != rwops->read(rwops, test_buf, 1)) {
         RWOP_ERR_QUIT(rwops); /* we are in write only mode */
     }
 
     rwops->close(rwops);
 
-    rwops = SDL_RWFromFile(FBASENAME1, "rb"); /* read mode, file must exists */
+    rwops = SDL_RWFromFile(FBASENAME1, "rb"); /* read mode, file must exist */
     if (rwops == NULL) {
         RWOP_ERR_QUIT(rwops);
     }
@@ -183,13 +183,13 @@ int main(int argc, char *argv[])
     if (0 != rwops->seek(rwops, -27, SDL_RW_SEEK_CUR)) {
         RWOP_ERR_QUIT(rwops);
     }
-    if (2 != rwops->read(rwops, test_buf, 30)) {
+    if (27 != rwops->read(rwops, test_buf, 30)) {
         RWOP_ERR_QUIT(rwops);
     }
     if (SDL_memcmp(test_buf, "12345678901234567890", 20) != 0) {
         RWOP_ERR_QUIT(rwops);
     }
-    if (0 != rwops->write(rwops, test_buf, 1)) {
+    if (-1 != rwops->write(rwops, test_buf, 1)) {
         RWOP_ERR_QUIT(rwops); /* readonly mode */
     }
 
@@ -237,7 +237,7 @@ int main(int argc, char *argv[])
     if (0 != rwops->seek(rwops, -27, SDL_RW_SEEK_CUR)) {
         RWOP_ERR_QUIT(rwops);
     }
-    if (2 != rwops->read(rwops, test_buf, 30)) {
+    if (27 != rwops->read(rwops, test_buf, 30)) {
         RWOP_ERR_QUIT(rwops);
     }
     if (SDL_memcmp(test_buf, "12345678901234567890", 20) != 0) {
@@ -288,7 +288,7 @@ int main(int argc, char *argv[])
     if (0 != rwops->seek(rwops, -27, SDL_RW_SEEK_CUR)) {
         RWOP_ERR_QUIT(rwops);
     }
-    if (2 != rwops->read(rwops, test_buf, 30)) {
+    if (27 != rwops->read(rwops, test_buf, 30)) {
         RWOP_ERR_QUIT(rwops);
     }
     if (SDL_memcmp(test_buf, "12345678901234567890", 20) != 0) {
@@ -345,7 +345,7 @@ int main(int argc, char *argv[])
     if (0 != rwops->seek(rwops, 0L, SDL_RW_SEEK_SET)) {
         RWOP_ERR_QUIT(rwops);
     }
-    if (3 != rwops->read(rwops, test_buf, 30)) {
+    if (30 != rwops->read(rwops, test_buf, 30)) {
         RWOP_ERR_QUIT(rwops);
     }
     if (SDL_memcmp(test_buf, "123456789012345678901234567123", 30) != 0) {

--- a/test/testfile.c
+++ b/test/testfile.c
@@ -25,6 +25,7 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 /* WARNING ! those 2 files will be destroyed by this test program */
 
@@ -39,6 +40,8 @@
 #ifndef NULL
 #define NULL ((void *)0)
 #endif
+
+static SDLTest_CommonState *state;
 
 static void
 cleanup(void)
@@ -55,6 +58,7 @@ rwops_error_quit(unsigned line, SDL_RWops *rwops)
         rwops->close(rwops); /* This calls SDL_DestroyRW(rwops); */
     }
     cleanup();
+    SDLTest_CommonDestroyState(state);
     exit(1); /* quit with rwops error (test failed) */
 }
 
@@ -65,8 +69,19 @@ int main(int argc, char *argv[])
     SDL_RWops *rwops = NULL;
     char test_buf[30];
 
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
+
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        return 1;
+    }
 
     cleanup();
 
@@ -354,5 +369,6 @@ int main(int argc, char *argv[])
     rwops->close(rwops);
     SDL_Log("test5 OK\n");
     cleanup();
+    SDLTest_CommonDestroyState(state);
     return 0; /* all ok */
 }

--- a/test/testfilesystem.c
+++ b/test/testfilesystem.c
@@ -13,14 +13,27 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 int main(int argc, char *argv[])
 {
+    SDLTest_CommonState *state;
     char *base_path;
     char *pref_path;
 
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
+
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        return 1;
+    }
 
     if (SDL_Init(0) == -1) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_Init() failed: %s\n", SDL_GetError());
@@ -55,5 +68,6 @@ int main(int argc, char *argv[])
     }
 
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
     return 0;
 }

--- a/test/testgeometry.c
+++ b/test/testgeometry.c
@@ -168,14 +168,15 @@ int main(int argc, char *argv[])
     Uint64 then, now;
     Uint32 frames;
 
-    /* Enable standard application logging */
-    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
-
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, SDL_INIT_VIDEO);
     if (state == NULL) {
         return 1;
     }
+
+    /* Enable standard application logging */
+    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
     for (i = 1; i < argc;) {
         int consumed;
 

--- a/test/testgl.c
+++ b/test/testgl.c
@@ -45,7 +45,7 @@ static int LoadContext(GL_Context *data)
 #else
 #define SDL_PROC(ret, func, params)                                                         \
     do {                                                                                    \
-        data->func = (ret (APIENTRY *) params)SDL_GL_GetProcAddress(#func);                                          \
+        data->func = (ret (APIENTRY *) params)SDL_GL_GetProcAddress(#func);                 \
         if (!data->func) {                                                                  \
             return SDL_SetError("Couldn't load GL function %s: %s", #func, SDL_GetError()); \
         }                                                                                   \
@@ -210,9 +210,6 @@ int main(int argc, char *argv[])
     int interval = 0;
     int ret_interval = 0;
 
-    /* Enable standard application logging */
-    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
-
     /* Initialize parameters */
     fsaa = 0;
     accel = -1;
@@ -222,6 +219,10 @@ int main(int argc, char *argv[])
     if (state == NULL) {
         return 1;
     }
+
+    /* Enable standard application logging */
+    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
     for (i = 1; i < argc;) {
         int consumed;
 

--- a/test/testgles.c
+++ b/test/testgles.c
@@ -103,9 +103,6 @@ int main(int argc, char *argv[])
     Uint32 then, now, frames;
     int status;
 
-    /* Enable standard application logging */
-    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
-
     /* Initialize parameters */
     fsaa = 0;
     accel = 0;
@@ -115,6 +112,10 @@ int main(int argc, char *argv[])
     if (state == NULL) {
         return 1;
     }
+
+    /* Enable standard application logging */
+    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
     for (i = 1; i < argc;) {
         int consumed;
 
@@ -131,8 +132,13 @@ int main(int argc, char *argv[])
                 if (!argv[i]) {
                     consumed = -1;
                 } else {
-                    depth = SDL_atoi(argv[i]);
-                    consumed = 1;
+                    char *endptr = NULL;
+                    depth = (int)SDL_strtol(argv[i], &endptr, 0);
+                    if (endptr != argv[i] && *endptr == '\0') {
+                        consumed = 1;
+                    } else {
+                        consumed = -1;
+                    }
                 }
             } else {
                 consumed = -1;

--- a/test/testgles2.c
+++ b/test/testgles2.c
@@ -651,8 +651,13 @@ int main(int argc, char *argv[])
                 if (!argv[i]) {
                     consumed = -1;
                 } else {
-                    depth = SDL_atoi(argv[i]);
-                    consumed = 1;
+                    char *endptr = NULL;
+                    depth = (int)SDL_strtol(argv[i], &endptr, 0);
+                    if (endptr != argv[i] && *endptr == '\0') {
+                        consumed = 1;
+                    } else {
+                        consumed = -1;
+                    }
                 }
             } else {
                 consumed = -1;

--- a/test/testgles2_sdf.c
+++ b/test/testgles2_sdf.c
@@ -465,8 +465,13 @@ int main(int argc, char *argv[])
                 if (!argv[i]) {
                     consumed = -1;
                 } else {
-                    depth = SDL_atoi(argv[i]);
-                    consumed = 1;
+                    char *endptr = NULL;
+                    depth = (int)SDL_strtol(argv[i], &endptr, 0);
+                    if (endptr != argv[i] && *endptr == '\0') {
+                        consumed = 1;
+                    } else {
+                        consumed = -1;
+                    }
                 }
             } else {
                 consumed = -1;

--- a/test/testhotplug.c
+++ b/test/testhotplug.c
@@ -16,6 +16,7 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 int main(int argc, char *argv[])
 {
@@ -27,11 +28,35 @@ int main(int argc, char *argv[])
     int i;
     SDL_bool enable_haptic = SDL_TRUE;
     Uint32 init_subsystems = SDL_INIT_VIDEO | SDL_INIT_JOYSTICK;
+    SDLTest_CommonState *state;
 
-    for (i = 1; i < argc; ++i) {
-        if (SDL_strcasecmp(argv[i], "--nohaptic") == 0) {
-            enable_haptic = SDL_FALSE;
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
+
+    /* Enable standard application logging */
+    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    for (i = 1; i < argc;) {
+        int consumed;
+
+        consumed = SDLTest_CommonArg(state, i);
+        if (!consumed) {
+            if (SDL_strcasecmp(argv[i], "--nohaptic") == 0) {
+                enable_haptic = SDL_FALSE;
+                consumed = 1;
+            }
         }
+        if (consumed <= 0) {
+            static const char *options[] = { "[--nohaptic]", NULL };
+            SDLTest_CommonLogUsage(state, argv[0], options);
+            exit(1);
+        }
+
+        i += consumed;
     }
 
     if (enable_haptic) {
@@ -132,6 +157,7 @@ int main(int argc, char *argv[])
     }
 
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
 
     return 0;
 }

--- a/test/testiconv.c
+++ b/test/testiconv.c
@@ -19,6 +19,7 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 #include "testutils.h"
 
 static size_t
@@ -49,18 +50,45 @@ int main(int argc, char *argv[])
         "UCS-4",
     };
 
-    char *fname;
+    char *fname = NULL;
     char buffer[BUFSIZ];
     char *ucs4;
     char *test[2];
     int i;
     FILE *file;
     int errors = 0;
+    SDLTest_CommonState *state;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
 
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
 
-    fname = GetResourceFilename(argc > 1 ? argv[1] : NULL, "utf8.txt");
+    /* Parse commandline */
+    for (i = 1; i < argc;) {
+        int consumed;
+
+        consumed = SDLTest_CommonArg(state, i);
+        if (!consumed) {
+            if (!fname) {
+                fname = argv[i];
+                consumed = 1;
+            }
+        }
+        if (consumed <= 0) {
+            static const char *options[] = { "[utf8.txt]", NULL };
+            SDLTest_CommonLogUsage(state, argv[0], options);
+            return 1;
+        }
+
+        i += consumed;
+    }
+
+    fname = GetResourceFilename(fname, "utf8.txt");
     file = fopen(fname, "rb");
     if (file == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to open %s\n", fname);
@@ -93,5 +121,6 @@ int main(int argc, char *argv[])
     (void)fclose(file);
 
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Total errors: %d\n", errors);
+    SDLTest_CommonDestroyState(state);
     return errors ? errors + 1 : 0;
 }

--- a/test/testintersections.c
+++ b/test/testintersections.c
@@ -40,7 +40,6 @@ static int current_color = 255;
 static SDL_BlendMode blendMode = SDL_BLENDMODE_NONE;
 
 static float mouse_begin_x = -1.0f, mouse_begin_y = -1.0f;
-static int done;
 
 static void DrawPoints(SDL_Renderer *renderer)
 {
@@ -206,14 +205,15 @@ DrawRectRectIntersections(SDL_Renderer *renderer)
     }
 }
 
-static void loop(void)
+static void loop(void *arg)
 {
     int i;
     SDL_Event event;
+    int *done = (int*)arg;
 
     /* Check for events */
     while (SDL_PollEvent(&event)) {
-        SDLTest_CommonEvent(state, &event, &done);
+        SDLTest_CommonEvent(state, &event, done);
         switch (event.type) {
         case SDL_EVENT_MOUSE_BUTTON_DOWN:
             mouse_begin_x = event.button.x;
@@ -274,7 +274,7 @@ static void loop(void)
         SDL_RenderPresent(renderer);
     }
 #ifdef __EMSCRIPTEN__
-    if (done) {
+    if (*done) {
         emscripten_cancel_main_loop();
     }
 #endif
@@ -285,18 +285,20 @@ int main(int argc, char *argv[])
     int i;
     Uint64 then, now;
     Uint32 frames;
-
-    /* Enable standard application logging */
-    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+    int done;
 
     /* Initialize parameters */
-    num_objects = NUM_OBJECTS;
+    num_objects = -1;  /* -1 means not initialized */
 
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, SDL_INIT_VIDEO);
     if (state == NULL) {
         return 1;
     }
+
+    /* Enable standard application logging */
+    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
     for (i = 1; i < argc;) {
         int consumed;
 
@@ -328,13 +330,16 @@ int main(int argc, char *argv[])
             } else if (SDL_strcasecmp(argv[i], "--cyclealpha") == 0) {
                 cycle_alpha = SDL_TRUE;
                 consumed = 1;
-            } else if (SDL_isdigit(*argv[i])) {
-                num_objects = SDL_atoi(argv[i]);
-                consumed = 1;
+            } else if (num_objects < 0 && SDL_isdigit(*argv[i])) {
+                char *endptr = NULL;
+                num_objects = (int)SDL_strtol(argv[i], &endptr, 0);
+                if (endptr != argv[i] && *endptr == '\0' && num_objects >= 0) {
+                    consumed = 1;
+                }
             }
         }
         if (consumed < 0) {
-            static const char *options[] = { "[--blend none|blend|add|mod|mul]", "[--cyclecolor]", "[--cyclealpha]", NULL };
+            static const char *options[] = { "[--blend none|blend|add|mod|mul]", "[--cyclecolor]", "[--cyclealpha]", "[count]", NULL };
             SDLTest_CommonLogUsage(state, argv[0], options);
             return 1;
         }
@@ -342,6 +347,10 @@ int main(int argc, char *argv[])
     }
     if (!SDLTest_CommonInit(state)) {
         return 2;
+    }
+
+    if (num_objects < 0) {
+        num_objects = NUM_OBJECTS;
     }
 
     /* Create the windows and initialize the renderers */
@@ -360,18 +369,19 @@ int main(int argc, char *argv[])
     done = 0;
 
 #ifdef __EMSCRIPTEN__
-    emscripten_set_main_loop(loop, 0, 1);
+    emscripten_set_main_loop_arg(loop, &done, 0, 1);
 #else
     while (!done) {
         ++frames;
-        loop();
+        loop(&done);
     }
 #endif
 
-    SDLTest_CommonQuit(state);
-
     /* Print out some timing information */
     now = SDL_GetTicks();
+
+    SDLTest_CommonQuit(state);
+
     if (now > then) {
         double fps = ((double)frames * 1000) / (now - then);
         SDL_Log("%2.2f frames per second\n", fps);

--- a/test/testkeys.c
+++ b/test/testkeys.c
@@ -16,13 +16,26 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 int main(int argc, char *argv[])
 {
     SDL_Scancode scancode;
+    SDLTest_CommonState *state;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
 
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        return 1;
+    }
 
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
@@ -33,5 +46,6 @@ int main(int argc, char *argv[])
                 SDL_GetScancodeName(scancode));
     }
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
     return 0;
 }

--- a/test/testloadso.c
+++ b/test/testloadso.c
@@ -17,22 +17,67 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 typedef int (*fntype)(const char *);
 
+static void log_usage(char *progname, SDLTest_CommonState *state) {
+    static const char *options[] = { "library", "functionname|--hello", NULL };
+    SDLTest_CommonLogUsage(state, progname, options);
+    SDL_Log("USAGE: %s <library> <functionname>\n", progname);
+    SDL_Log("       %s <lib with puts()> --hello\n", progname);
+}
+
 int main(int argc, char *argv[])
 {
+    int i;
     int retval = 0;
     int hello = 0;
     const char *libname = NULL;
     const char *symname = NULL;
     void *lib = NULL;
     fntype fn = NULL;
+    SDLTest_CommonState *state;
 
-    if (argc != 3) {
-        const char *app = argv[0];
-        SDL_Log("USAGE: %s <library> <functionname>\n", app);
-        SDL_Log("       %s --hello <lib with puts()>\n", app);
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
+
+    /* Enable standard application logging */
+    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    for (i = 1; i < argc;) {
+        int consumed;
+
+        consumed = SDLTest_CommonArg(state, i);
+        if (!consumed) {
+            if (SDL_strcmp(argv[i], "--hello") == 0) {
+                if (!symname || SDL_strcmp(symname, "puts") == 0) {
+                    symname = "puts";
+                    consumed = 1;
+                    hello = 1;
+                }
+            } else if (!libname) {
+                libname = argv[i];
+                consumed = 1;
+            } else if (!symname) {
+                symname = argv[i];
+                consumed = 1;
+            }
+        }
+        if (consumed <= 0) {
+            log_usage(argv[0], state);
+            return 1;
+        }
+
+        i += consumed;
+    }
+
+    if (!libname || !symname) {
+        log_usage(argv[0], state);
         return 1;
     }
 
@@ -40,15 +85,6 @@ int main(int argc, char *argv[])
     if (SDL_Init(0) < 0) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
         return 2;
-    }
-
-    if (SDL_strcmp(argv[1], "--hello") == 0) {
-        hello = 1;
-        libname = argv[2];
-        symname = "puts";
-    } else {
-        libname = argv[1];
-        symname = argv[2];
     }
 
     lib = SDL_LoadObject(libname);
@@ -74,5 +110,6 @@ int main(int argc, char *argv[])
         SDL_UnloadObject(lib);
     }
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
     return retval;
 }

--- a/test/testlock.c
+++ b/test/testlock.c
@@ -19,11 +19,15 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 static SDL_mutex *mutex = NULL;
 static SDL_threadID mainthread;
-static SDL_Thread *threads[6];
 static SDL_AtomicInt doterminate;
+static int nb_threads = 6;
+static SDL_Thread **threads;
+static int worktime = 1000;
+static SDLTest_CommonState *state;
 
 /**
  * SDL_Quit() shouldn't be used with atexit() directly because
@@ -33,11 +37,12 @@ static void
 SDL_Quit_Wrapper(void)
 {
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
 }
 
 static void printid(void)
 {
-    SDL_Log("Process %lu:  exiting\n", SDL_ThreadID());
+    SDL_Log("Thread %lu:  exiting\n", SDL_ThreadID());
 }
 
 static void terminate(int sig)
@@ -50,30 +55,35 @@ static void closemutex(int sig)
 {
     SDL_threadID id = SDL_ThreadID();
     int i;
-    SDL_Log("Process %lu:  Cleaning up...\n", id == mainthread ? 0 : id);
+    SDL_Log("Thread %lu:  Cleaning up...\n", id == mainthread ? 0 : id);
     SDL_AtomicSet(&doterminate, 1);
-    for (i = 0; i < 6; ++i) {
-        SDL_WaitThread(threads[i], NULL);
+    if (threads) {
+        for (i = 0; i < nb_threads; ++i) {
+            SDL_WaitThread(threads[i], NULL);
+        }
+        SDL_free(threads);
+        threads = NULL;
     }
     SDL_DestroyMutex(mutex);
     exit(sig);
 }
 
 static int SDLCALL
-Run(void *data)
+DoWork(void *data)
 {
     if (SDL_ThreadID() == mainthread) {
         (void)signal(SIGTERM, closemutex);
     }
+    SDL_Log("Thread %lu: starting up", SDL_ThreadID());
     while (!SDL_AtomicGet(&doterminate)) {
-        SDL_Log("Process %lu ready to work\n", SDL_ThreadID());
+        SDL_Log("Thread %lu: ready to work\n", SDL_ThreadID());
         if (SDL_LockMutex(mutex) < 0) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't lock mutex: %s", SDL_GetError());
             exit(1);
         }
-        SDL_Log("Process %lu, working!\n", SDL_ThreadID());
-        SDL_Delay(1 * 1000);
-        SDL_Log("Process %lu, done!\n", SDL_ThreadID());
+        SDL_Log("Thread %lu: start work!\n", SDL_ThreadID());
+        SDL_Delay(1 * worktime);
+        SDL_Log("Thread %lu: work done!\n", SDL_ThreadID());
         if (SDL_UnlockMutex(mutex) < 0) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't unlock mutex: %s", SDL_GetError());
             exit(1);
@@ -82,19 +92,87 @@ Run(void *data)
         SDL_Delay(10);
     }
     if (SDL_ThreadID() == mainthread && SDL_AtomicGet(&doterminate)) {
-        SDL_Log("Process %lu:  raising SIGTERM\n", SDL_ThreadID());
+        SDL_Log("Thread %lu: raising SIGTERM\n", SDL_ThreadID());
         (void)raise(SIGTERM);
     }
+    SDL_Log("Thread %lu: exiting!\n", SDL_ThreadID());
     return 0;
 }
+
+#if !defined(_WIN32)
+Uint32 hit_timeout(Uint32 interval, void *param) {
+    SDL_Log("Hit timeout! Sending SIGINT!");
+    kill(0, SIGINT);
+    return 0;
+}
+#endif
 
 int main(int argc, char *argv[])
 {
     int i;
-    int maxproc = 6;
+#if !defined(_WIN32)
+    int timeout = 0;
+#endif
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
 
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+    /* Parse commandline */
+    for (i = 1; i < argc;) {
+        int consumed;
+
+        consumed = SDLTest_CommonArg(state, i);
+        if (!consumed) {
+            if (SDL_strcmp(argv[i], "--nbthreads") == 0) {
+                if (argv[i + 1]) {
+                    char *endptr;
+                    nb_threads = SDL_strtol(argv[i + 1], &endptr, 0);
+                    if (endptr != argv[i + 1] && *endptr == '\0' && nb_threads > 0) {
+                        consumed = 2;
+                    }
+                }
+            } else if (SDL_strcmp(argv[i], "--worktime") == 0) {
+                if (argv[i + 1]) {
+                    char *endptr;
+                    nb_threads = SDL_strtol(argv[i + 1], &endptr, 0);
+                    if (endptr != argv[i + 1] && *endptr == '\0' && nb_threads > 0) {
+                        consumed = 2;
+                    }
+                }
+#if !defined(_WIN32)
+            } else if (SDL_strcmp(argv[i], "--timeout") == 0) {
+                if (argv[i + 1]) {
+                    char *endptr;
+                    timeout = SDL_strtol(argv[i + 1], &endptr, 0);
+                    if (endptr != argv[i + 1] && *endptr == '\0' && timeout > 0) {
+                        consumed = 2;
+                    }
+                }
+#endif
+            }
+        }
+        if (consumed <= 0) {
+            static const char *options[] = {
+                "[--nbthreads NB]",
+                "[--worktime ms]",
+#if !defined(_WIN32)
+                "[--timeout ms]",
+#endif
+                NULL,
+            };
+            SDLTest_CommonLogUsage(state, argv[0], options);
+            exit(1);
+        }
+
+        i += consumed;
+    }
+
+    threads = SDL_malloc(nb_threads * sizeof(SDL_Thread*));
 
     /* Load the SDL library */
     if (SDL_Init(0) < 0) {
@@ -114,16 +192,23 @@ int main(int argc, char *argv[])
     mainthread = SDL_ThreadID();
     SDL_Log("Main thread: %lu\n", mainthread);
     (void)atexit(printid);
-    for (i = 0; i < maxproc; ++i) {
+    for (i = 0; i < nb_threads; ++i) {
         char name[64];
         (void)SDL_snprintf(name, sizeof(name), "Worker%d", i);
-        threads[i] = SDL_CreateThread(Run, name, NULL);
+        threads[i] = SDL_CreateThread(DoWork, name, &threads[i]);
         if (threads[i] == NULL) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create thread!\n");
         }
     }
+
+#if !defined(_WIN32)
+    if (timeout) {
+        SDL_AddTimer(timeout, hit_timeout, NULL);
+    }
+#endif
+
     (void)signal(SIGINT, terminate);
-    Run(NULL);
+    DoWork(NULL);
 
     return 0; /* Never reached */
 }

--- a/test/testlock.c
+++ b/test/testlock.c
@@ -69,7 +69,7 @@ static void closemutex(int sig)
 }
 
 static int SDLCALL
-DoWork(void *data)
+Run(void *data)
 {
     if (SDL_ThreadID() == mainthread) {
         (void)signal(SIGTERM, closemutex);
@@ -195,7 +195,7 @@ int main(int argc, char *argv[])
     for (i = 0; i < nb_threads; ++i) {
         char name[64];
         (void)SDL_snprintf(name, sizeof(name), "Worker%d", i);
-        threads[i] = SDL_CreateThread(DoWork, name, &threads[i]);
+        threads[i] = SDL_CreateThread(Run, name, NULL);
         if (threads[i] == NULL) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create thread!\n");
         }
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
 #endif
 
     (void)signal(SIGINT, terminate);
-    DoWork(NULL);
+    Run(NULL);
 
     return 0; /* Never reached */
 }

--- a/test/testmessage.c
+++ b/test/testmessage.c
@@ -16,6 +16,7 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 /* Call this instead of exit(), so we can clean up SDL: atexit() is evil. */
 static void
@@ -81,9 +82,21 @@ button_messagebox(void *eventNumber)
 int main(int argc, char *argv[])
 {
     int success;
+    SDLTest_CommonState *state;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
 
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        return 1;
+    }
 
     success = SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR,
                                        "Simple MessageBox",
@@ -208,5 +221,6 @@ int main(int argc, char *argv[])
     }
 
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
     return 0;
 }

--- a/test/testnative.c
+++ b/test/testnative.c
@@ -18,6 +18,7 @@
 #include "testutils.h"
 
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 #define WINDOW_W    640
 #define WINDOW_H    480
@@ -39,6 +40,7 @@ static NativeWindowFactory *factories[] = {
 static NativeWindowFactory *factory = NULL;
 static void *native_window;
 static SDL_FRect *positions, *velocities;
+static SDLTest_CommonState *state;
 
 /* Call this instead of exit(), so we can clean up SDL: atexit() is evil. */
 static void
@@ -48,6 +50,7 @@ quit(int rc)
     if (native_window != NULL && factory != NULL) {
         factory->DestroyNativeWindow(native_window);
     }
+    SDLTest_CommonDestroyState(state);
     exit(rc);
 }
 
@@ -100,8 +103,19 @@ int main(int argc, char *argv[])
     int sprite_w, sprite_h;
     SDL_Event event;
 
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
+
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        return 1;
+    }
 
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL video: %s\n",

--- a/test/testnative.h
+++ b/test/testnative.h
@@ -15,6 +15,14 @@
 */
 #include <SDL3/SDL.h>
 
+/* Hack to avoid dynapi renaming */
+#include "../src/dynapi/SDL_dynapi.h"
+#ifdef SDL_DYNAMIC_API
+#undef SDL_DYNAMIC_API
+#endif
+
+#include "../src/SDL_internal.h"
+
 typedef struct
 {
     const char *tag;

--- a/test/testoffscreen.c
+++ b/test/testoffscreen.c
@@ -21,6 +21,7 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 #include <SDL3/SDL_opengl.h>
 
 static SDL_Renderer *renderer = NULL;
@@ -97,9 +98,21 @@ int main(int argc, char *argv[])
     Uint64 then, now;
     Uint32 frames;
 #endif
+    SDLTest_CommonState *state;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
 
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        return 1;
+    }
 
     /* Force the offscreen renderer, if it cannot be created then fail out */
     SDL_SetHint("SDL_VIDEO_DRIVER", "offscreen");
@@ -159,6 +172,7 @@ int main(int argc, char *argv[])
     SDL_DestroyRenderer(renderer);
     SDL_DestroyWindow(window);
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
 
     return 0;
 }

--- a/test/testpopup.c
+++ b/test/testpopup.c
@@ -241,6 +241,14 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    /* Enable standard application logging */
+    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        return 1;
+    }
+
     if (!SDLTest_CommonInit(state)) {
         SDLTest_CommonQuit(state);
         quit(2);

--- a/test/testpower.c
+++ b/test/testpower.c
@@ -13,6 +13,7 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 static void
 report_power(void)
@@ -60,10 +61,23 @@ report_power(void)
 
 int main(int argc, char *argv[])
 {
+    SDLTest_CommonState *state;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
+
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
 
-    if (SDL_Init(0) == -1) {
+    /* Parse commandline */
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        return 1;
+    }
+
+    if (SDL_Init(0) < 0) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_Init() failed: %s\n", SDL_GetError());
         return 1;
     }
@@ -71,6 +85,8 @@ int main(int argc, char *argv[])
     report_power();
 
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
+
     return 0;
 }
 

--- a/test/testrelative.c
+++ b/test/testrelative.c
@@ -95,9 +95,12 @@ int main(int argc, char *argv[])
     if (state == NULL) {
         return 1;
     }
-    for (i = 1; i < argc; ++i) {
-        SDLTest_CommonArg(state, i);
+
+    /* Parse commandline */
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        return 1;
     }
+
     if (!SDLTest_CommonInit(state)) {
         return 2;
     }

--- a/test/testrendercopyex.c
+++ b/test/testrendercopyex.c
@@ -115,14 +115,14 @@ int main(int argc, char *argv[])
     int frames;
     Uint64 then, now;
 
-    /* Enable standard application logging */
-    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
-
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, SDL_INIT_VIDEO);
     if (state == NULL) {
         return 1;
     }
+
+    /* Enable standard application logging */
+    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
 
     if (!SDLTest_CommonDefaultArgs(state, argc, argv) || !SDLTest_CommonInit(state)) {
         SDLTest_CommonQuit(state);

--- a/test/testscale.c
+++ b/test/testscale.c
@@ -102,18 +102,22 @@ int main(int argc, char *argv[])
     int frames;
     Uint64 then, now;
 
-    /* Enable standard application logging */
-    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
-
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, SDL_INIT_VIDEO);
     if (state == NULL) {
         return 1;
     }
 
-    if (!SDLTest_CommonDefaultArgs(state, argc, argv) || !SDLTest_CommonInit(state)) {
-        SDLTest_CommonQuit(state);
+    /* Enable standard application logging */
+    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
         return 1;
+    }
+
+    if (!SDLTest_CommonInit(state)) {
+        quit(1);
     }
 
     drawstates = SDL_stack_alloc(DrawState, state->num_windows);

--- a/test/testsem.c
+++ b/test/testsem.c
@@ -16,6 +16,7 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 #define NUM_THREADS 10
 /* This value should be smaller than the maximum count of the */
@@ -34,6 +35,11 @@ typedef struct Thread_State
     int loop_count;
     int content_count;
 } Thread_State;
+
+static void log_usage(char *progname, SDLTest_CommonState *state) {
+    static const char *options[] = { "init_value", NULL };
+    SDLTest_CommonLogUsage(state, progname, options);
+}
 
 static void
 killed(int sig)
@@ -248,13 +254,43 @@ TestOverheadContended(SDL_bool try_wait)
 
 int main(int argc, char **argv)
 {
+    int arg_count = 0;
+    int i;
     int init_sem;
+    SDLTest_CommonState *state;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
 
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
 
-    if (argc < 2) {
-        SDL_Log("Usage: %s init_value\n", argv[0]);
+    /* Parse commandline */
+    for (i = 1; i < argc;) {
+        int consumed;
+
+        consumed = SDLTest_CommonArg(state, i);
+        if (arg_count == 0) {
+            char *endptr;
+            init_sem = SDL_strtol(argv[i], &endptr, 0);
+            if (endptr != argv[i] && *endptr == '\0') {
+                arg_count++;
+                consumed = 1;
+            }
+        }
+        if (consumed <= 0) {
+            log_usage(argv[0], state);
+            return 1;
+        }
+
+        i += consumed;
+    }
+
+    if (arg_count != 1) {
+        log_usage(argv[0], state);
         return 1;
     }
 
@@ -280,5 +316,7 @@ int main(int argc, char **argv)
     TestOverheadContended(SDL_TRUE);
 
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
+
     return 0;
 }

--- a/test/testsensor.c
+++ b/test/testsensor.c
@@ -14,6 +14,7 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 static const char *GetSensorTypeString(SDL_SensorType type)
 {
@@ -59,10 +60,26 @@ int main(int argc, char **argv)
 {
     SDL_SensorID *sensors;
     int i, num_sensors, num_opened;
+    SDLTest_CommonState *state;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
+
+    /* Enable standard application logging */
+    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        SDLTest_CommonDestroyState(state);
+        return 1;
+    }
 
     /* Load the SDL library */
     if (SDL_Init(SDL_INIT_SENSOR) < 0) {
         SDL_Log("Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDLTest_CommonDestroyState(state);
         return 1;
     }
 
@@ -119,5 +136,6 @@ int main(int argc, char **argv)
     }
 
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
     return 0;
 }

--- a/test/testspriteminimal.c
+++ b/test/testspriteminimal.c
@@ -103,6 +103,11 @@ int main(int argc, char *argv[])
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
 
+    if (argc > 1) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "USAGE: %s\n", argv[0]);
+        quit(1);
+    }
+
     if (SDL_CreateWindowAndRenderer(WINDOW_WIDTH, WINDOW_HEIGHT, 0, &window, &renderer) < 0) {
         quit(2);
     }

--- a/test/teststreaming.c
+++ b/test/teststreaming.c
@@ -23,6 +23,7 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 #include "testutils.h"
 
 #define MOOSEPIC_W 64
@@ -63,10 +64,12 @@ static SDL_Renderer *renderer;
 static int frame;
 static SDL_Texture *MooseTexture;
 static SDL_bool done = SDL_FALSE;
+SDLTest_CommonState *state;
 
 static void quit(int rc)
 {
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
     exit(rc);
 }
 
@@ -131,8 +134,19 @@ int main(int argc, char **argv)
     SDL_RWops *handle;
     char *filename = NULL;
 
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
+
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        SDLTest_CommonDestroyState(state);
+        return 1;
+    }
 
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());

--- a/test/testsurround.c
+++ b/test/testsurround.c
@@ -13,6 +13,7 @@
 /* Program to test surround sound audio channels */
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 static int total_channels;
 static int active_channel;
@@ -132,9 +133,21 @@ static void SDLCALL fill_buffer(void *unused, Uint8 *stream, int len)
 int main(int argc, char *argv[])
 {
     int i;
+    SDLTest_CommonState *state;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
 
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        SDLTest_CommonQuit(state);
+        return 1;
+    }
 
     if (SDL_Init(SDL_INIT_AUDIO) < 0) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());

--- a/test/testver.c
+++ b/test/testver.c
@@ -25,6 +25,11 @@ int main(int argc, char *argv[])
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
 
+    if (argc > 1) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "USAGE: %s", argv[0]);
+        return 1;
+    }
+
 #if SDL_VERSION_ATLEAST(3, 0, 0)
     SDL_Log("Compiled with SDL 3.0 or newer\n");
 #else

--- a/test/testvulkan.c
+++ b/test/testvulkan.c
@@ -1094,14 +1094,14 @@ int main(int argc, char **argv)
     Uint32 frames;
     int dw, dh;
 
-    /* Enable standard application logging */
-    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
-
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, SDL_INIT_VIDEO);
     if (state == NULL) {
         return 1;
     }
+
+    /* Enable standard application logging */
+    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
 
     /* Set Vulkan parameters */
     state->window_flags |= SDL_WINDOW_VULKAN;

--- a/test/testwm.c
+++ b/test/testwm.c
@@ -259,16 +259,16 @@ int main(int argc, char *argv[])
 {
     int i;
 
-    /* Enable standard application logging */
-    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
-
-    SDL_assert(SDL_arraysize(cursorNames) == SDL_NUM_SYSTEM_CURSORS);
-
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, SDL_INIT_VIDEO);
     if (state == NULL) {
         return 1;
     }
+
+    /* Enable standard application logging */
+    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    SDL_assert(SDL_arraysize(cursorNames) == SDL_NUM_SYSTEM_CURSORS);
 
     if (!SDLTest_CommonDefaultArgs(state, argc, argv) || !SDLTest_CommonInit(state)) {
         SDLTest_CommonQuit(state);

--- a/test/testyuv.c
+++ b/test/testyuv.c
@@ -11,8 +11,9 @@
 */
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
-#include <SDL3/SDL_test_font.h>
+#include <SDL3/SDL_test.h>
 #include "testyuv_cvt.h"
+#include "testutils.h"
 
 /* 422 (YUY2, etc) formats are the largest */
 #define MAX_YUV_SURFACE_SIZE(W, H, P) (H * 4 * (W + P + 1) / 2)
@@ -239,8 +240,7 @@ int main(int argc, char **argv)
         { SDL_TRUE, 33, 3 },
         { SDL_TRUE, 37, 3 },
     };
-    int arg = 1;
-    const char *filename;
+    char *filename = NULL;
     SDL_Surface *original;
     SDL_Surface *converted;
     SDL_Window *window;
@@ -256,58 +256,106 @@ int main(int argc, char **argv)
     int pitch;
     Uint8 *raw_yuv;
     Uint64 then, now;
-    Uint32 i, iterations = 100;
+    int i, iterations = 100;
     SDL_bool should_run_automated_tests = SDL_FALSE;
+    SDLTest_CommonState *state;
 
-    while (argv[arg] && *argv[arg] == '-') {
-        if (SDL_strcmp(argv[arg], "--jpeg") == 0) {
-            SDL_SetYUVConversionMode(SDL_YUV_CONVERSION_JPEG);
-        } else if (SDL_strcmp(argv[arg], "--bt601") == 0) {
-            SDL_SetYUVConversionMode(SDL_YUV_CONVERSION_BT601);
-        } else if (SDL_strcmp(argv[arg], "--bt709") == 0) {
-            SDL_SetYUVConversionMode(SDL_YUV_CONVERSION_BT709);
-        } else if (SDL_strcmp(argv[arg], "--auto") == 0) {
-            SDL_SetYUVConversionMode(SDL_YUV_CONVERSION_AUTOMATIC);
-        } else if (SDL_strcmp(argv[arg], "--yv12") == 0) {
-            yuv_format = SDL_PIXELFORMAT_YV12;
-        } else if (SDL_strcmp(argv[arg], "--iyuv") == 0) {
-            yuv_format = SDL_PIXELFORMAT_IYUV;
-        } else if (SDL_strcmp(argv[arg], "--yuy2") == 0) {
-            yuv_format = SDL_PIXELFORMAT_YUY2;
-        } else if (SDL_strcmp(argv[arg], "--uyvy") == 0) {
-            yuv_format = SDL_PIXELFORMAT_UYVY;
-        } else if (SDL_strcmp(argv[arg], "--yvyu") == 0) {
-            yuv_format = SDL_PIXELFORMAT_YVYU;
-        } else if (SDL_strcmp(argv[arg], "--nv12") == 0) {
-            yuv_format = SDL_PIXELFORMAT_NV12;
-        } else if (SDL_strcmp(argv[arg], "--nv21") == 0) {
-            yuv_format = SDL_PIXELFORMAT_NV21;
-        } else if (SDL_strcmp(argv[arg], "--rgb555") == 0) {
-            rgb_format = SDL_PIXELFORMAT_RGB555;
-        } else if (SDL_strcmp(argv[arg], "--rgb565") == 0) {
-            rgb_format = SDL_PIXELFORMAT_RGB565;
-        } else if (SDL_strcmp(argv[arg], "--rgb24") == 0) {
-            rgb_format = SDL_PIXELFORMAT_RGB24;
-        } else if (SDL_strcmp(argv[arg], "--argb") == 0) {
-            rgb_format = SDL_PIXELFORMAT_ARGB8888;
-        } else if (SDL_strcmp(argv[arg], "--abgr") == 0) {
-            rgb_format = SDL_PIXELFORMAT_ABGR8888;
-        } else if (SDL_strcmp(argv[arg], "--rgba") == 0) {
-            rgb_format = SDL_PIXELFORMAT_RGBA8888;
-        } else if (SDL_strcmp(argv[arg], "--bgra") == 0) {
-            rgb_format = SDL_PIXELFORMAT_BGRA8888;
-        } else if (SDL_strcmp(argv[arg], "--automated") == 0) {
-            should_run_automated_tests = SDL_TRUE;
-        } else {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Usage: %s [--jpeg|--bt601|-bt709|--auto] [--yv12|--iyuv|--yuy2|--uyvy|--yvyu|--nv12|--nv21] [--rgb555|--rgb565|--rgb24|--argb|--abgr|--rgba|--bgra] [image_filename]\n", argv[0]);
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
+
+    /* Enable standard application logging */
+    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    for (i = 1; i < argc;) {
+        int consumed;
+
+        consumed = SDLTest_CommonArg(state, i);
+        if (!consumed) {
+            if (SDL_strcmp(argv[i], "--jpeg") == 0) {
+                SDL_SetYUVConversionMode(SDL_YUV_CONVERSION_JPEG);
+                consumed = 1;
+            } else if (SDL_strcmp(argv[i], "--bt601") == 0) {
+                SDL_SetYUVConversionMode(SDL_YUV_CONVERSION_BT601);
+                consumed = 1;
+            } else if (SDL_strcmp(argv[i], "--bt709") == 0) {
+                SDL_SetYUVConversionMode(SDL_YUV_CONVERSION_BT709);
+                consumed = 1;
+            } else if (SDL_strcmp(argv[i], "--auto") == 0) {
+                SDL_SetYUVConversionMode(SDL_YUV_CONVERSION_AUTOMATIC);
+                consumed = 1;
+            } else if (SDL_strcmp(argv[i], "--yv12") == 0) {
+                yuv_format = SDL_PIXELFORMAT_YV12;
+                consumed = 1;
+            } else if (SDL_strcmp(argv[i], "--iyuv") == 0) {
+                yuv_format = SDL_PIXELFORMAT_IYUV;
+                consumed = 1;
+            } else if (SDL_strcmp(argv[i], "--yuy2") == 0) {
+                yuv_format = SDL_PIXELFORMAT_YUY2;
+                consumed = 1;
+            } else if (SDL_strcmp(argv[i], "--uyvy") == 0) {
+                yuv_format = SDL_PIXELFORMAT_UYVY;
+                consumed = 1;
+            } else if (SDL_strcmp(argv[i], "--yvyu") == 0) {
+                yuv_format = SDL_PIXELFORMAT_YVYU;
+                consumed = 1;
+            } else if (SDL_strcmp(argv[i], "--nv12") == 0) {
+                yuv_format = SDL_PIXELFORMAT_NV12;
+                consumed = 1;
+            } else if (SDL_strcmp(argv[i], "--nv21") == 0) {
+                yuv_format = SDL_PIXELFORMAT_NV21;
+                consumed = 1;
+            } else if (SDL_strcmp(argv[i], "--rgb555") == 0) {
+                rgb_format = SDL_PIXELFORMAT_RGB555;
+                consumed = 1;
+            } else if (SDL_strcmp(argv[i], "--rgb565") == 0) {
+                rgb_format = SDL_PIXELFORMAT_RGB565;
+                consumed = 1;
+            } else if (SDL_strcmp(argv[i], "--rgb24") == 0) {
+                rgb_format = SDL_PIXELFORMAT_RGB24;
+                consumed = 1;
+            } else if (SDL_strcmp(argv[i], "--argb") == 0) {
+                rgb_format = SDL_PIXELFORMAT_ARGB8888;
+                consumed = 1;
+            } else if (SDL_strcmp(argv[i], "--abgr") == 0) {
+                rgb_format = SDL_PIXELFORMAT_ABGR8888;
+                consumed = 1;
+            } else if (SDL_strcmp(argv[i], "--rgba") == 0) {
+                rgb_format = SDL_PIXELFORMAT_RGBA8888;
+                consumed = 1;
+            } else if (SDL_strcmp(argv[i], "--bgra") == 0) {
+                rgb_format = SDL_PIXELFORMAT_BGRA8888;
+                consumed = 1;
+            } else if (SDL_strcmp(argv[i], "--automated") == 0) {
+                should_run_automated_tests = SDL_TRUE;
+                consumed = 1;
+            } else if (!filename) {
+                filename = argv[i];
+                consumed = 1;
+            }
+        }
+        if (consumed <= 0) {
+            static const char *options[] = {
+                "[--jpeg|--bt601|-bt709|--auto]",
+                "[--yv12|--iyuv|--yuy2|--uyvy|--yvyu|--nv12|--nv21]",
+                "[--rgb555|--rgb565|--rgb24|--argb|--abgr|--rgba|--bgra]",
+                "[--automated]",
+                "[sample.bmp]",
+                NULL,
+            };
+            SDLTest_CommonLogUsage(state, argv[0], options);
+            SDLTest_CommonDestroyState(state);
             return 1;
         }
-        ++arg;
+        i += consumed;
     }
 
     /* Run automated tests */
     if (should_run_automated_tests) {
-        for (i = 0; i < SDL_arraysize(automated_test_params); ++i) {
+        for (i = 0; i < (int)SDL_arraysize(automated_test_params); ++i) {
             SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Running automated test, pattern size %d, extra pitch %d, intrinsics %s\n",
                         automated_test_params[i].pattern_size,
                         automated_test_params[i].extra_pitch,
@@ -319,11 +367,7 @@ int main(int argc, char **argv)
         return 0;
     }
 
-    if (argv[arg]) {
-        filename = argv[arg];
-    } else {
-        filename = "testyuv.bmp";
-    }
+    filename = GetResourceFilename(filename, "testyuv.bmp");
     original = SDL_ConvertSurfaceFormat(SDL_LoadBMP(filename), SDL_PIXELFORMAT_RGB24);
     if (original == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't load %s: %s\n", filename, SDL_GetError());
@@ -347,7 +391,7 @@ int main(int argc, char **argv)
         SDL_ConvertPixels(original->w, original->h, yuv_format, raw_yuv, pitch, rgb_format, converted->pixels, converted->pitch);
     }
     now = SDL_GetTicks();
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "%" SDL_PRIu32 " iterations in %" SDL_PRIu64 " ms, %.2fms each\n", iterations, (now - then), (float)(now - then) / iterations);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "%d iterations in %" SDL_PRIu64 " ms, %.2fms each\n", iterations, (now - then), (float)(now - then) / iterations);
 
     window = SDL_CreateWindow("YUV test", original->w, original->h, 0);
     if (window == NULL) {
@@ -437,6 +481,8 @@ int main(int argc, char **argv)
             SDL_Delay(10);
         }
     }
+    SDL_free(filename);
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
     return 0;
 }

--- a/test/testyuv.c
+++ b/test/testyuv.c
@@ -34,7 +34,7 @@ static SDL_Surface *generate_test_pattern(int pattern_size)
         const int thickness = 2; /* Important so 2x2 blocks of color are the same, to avoid Cr/Cb interpolation over pixels */
 
         /* R, G, B in alternating horizontal bands */
-        for (y = 0; y < pattern->h; y += thickness) {
+        for (y = 0; y < pattern->h - (thickness - 1); y += thickness) {
             for (i = 0; i < thickness; ++i) {
                 p = (Uint8 *)pattern->pixels + (y + i) * pattern->pitch + ((y / thickness) % 3);
                 for (x = 0; x < pattern->w; ++x) {

--- a/test/torturethread.c
+++ b/test/torturethread.c
@@ -17,6 +17,7 @@
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
 
 #define NUMTHREADS 10
 
@@ -76,6 +77,13 @@ int main(int argc, char *argv[])
 {
     SDL_Thread *threads[NUMTHREADS];
     int i;
+    SDLTest_CommonState *state;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
 
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
@@ -83,6 +91,11 @@ int main(int argc, char *argv[])
     /* Load the SDL library */
     if (SDL_Init(0) < 0) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
+        return 1;
+    }
+
+    if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        SDLTest_CommonDestroyState(state);
         return 1;
     }
 
@@ -107,5 +120,6 @@ int main(int argc, char *argv[])
         SDL_WaitThread(threads[i], NULL);
     }
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
     return 0;
 }


### PR DESCRIPTION
Currently, it is possible to pass nonsense options to (some) tests, without failure.
These changes adds parsing to all tests using the already existing `SDLText_CommonState` related functions.

- `SDLTest_CommonDestroyState` is extracted from `SDLTest_CommonQuit` to free a `SDLTest_CommonState` state.
  So now there is `SDLTest_CommonCreateState` to allocate and initialize a state and `SDLTest_ComonDestroyState` to free it.
  `SDLTest_CommonInit` and `SDLTest_CommonQuit` remain to initialize and quit SDL.
  The new function is useful to make use of the argument parsing logic, without letting `SDLTest` handle SDL initialization.
- Only parse/print video/audio related argument options if the SDL subsystem is initialized by SDLTest.
- remove unused `SDLTest_CommonUsage`
- fix infinite loop when passing 2 sequential optional arguments taking no arguments.
  e.g. `test/testvulkan  --grab -h` loops forever.
- Fix buffer overflow write in testyuv
- Fix testfile reference values
- Add argument parsing to (all) tests

I have created separate commits for each test to keep my work manageable.
Quite a few commits can be squashed when merging.