### PR TITLE
testautomation_pixels: calling SDL_DestroyPixelFormat or SDL_DestroyP…

### DIFF
--- a/test/testautomation_pixels.c
+++ b/test/testautomation_pixels.c
@@ -113,8 +113,7 @@ static const char *g_invalidPixelFormatsVerbose[] = {
 static int pixels_allocFreeFormat(void *arg)
 {
     const char *unknownFormat = "SDL_PIXELFORMAT_UNKNOWN";
-    const char *expectedError = "Parameter 'format' is invalid";
-    const char *expectedError2 = "Unknown pixel format";
+    const char *expectedError = "Unknown pixel format";
     const char *error;
     int i;
     Uint32 format;
@@ -179,8 +178,8 @@ static int pixels_allocFreeFormat(void *arg)
         SDLTest_AssertPass("Call to SDL_GetError()");
         SDLTest_AssertCheck(error != NULL, "Validate that error message was not NULL");
         if (error != NULL) {
-            SDLTest_AssertCheck(SDL_strcmp(error, expectedError2) == 0,
-                                "Validate error message, expected: '%s', got: '%s'", expectedError2, error);
+            SDLTest_AssertCheck(SDL_strcmp(error, expectedError) == 0,
+                                "Validate error message, expected: '%s', got: '%s'", expectedError, error);
         }
     }
 
@@ -191,11 +190,7 @@ static int pixels_allocFreeFormat(void *arg)
     SDLTest_AssertPass("Call to SDL_DestroyPixelFormat(NULL)");
     error = SDL_GetError();
     SDLTest_AssertPass("Call to SDL_GetError()");
-    SDLTest_AssertCheck(error != NULL, "Validate that error message was not NULL");
-    if (error != NULL) {
-        SDLTest_AssertCheck(SDL_strcmp(error, expectedError) == 0,
-                            "Validate error message, expected: '%s', got: '%s'", expectedError, error);
-    }
+    SDLTest_AssertCheck(error == NULL || error[0] == '\0', "Validate that error message is empty");
 
     return TEST_COMPLETED;
 }
@@ -275,8 +270,7 @@ static int pixels_getPixelFormatName(void *arg)
  */
 static int pixels_allocFreePalette(void *arg)
 {
-    const char *expectedError1 = "Parameter 'ncolors' is invalid";
-    const char *expectedError2 = "Parameter 'palette' is invalid";
+    const char *expectedError = "Parameter 'ncolors' is invalid";
     const char *error;
     int variation;
     int i;
@@ -336,8 +330,8 @@ static int pixels_allocFreePalette(void *arg)
         SDLTest_AssertPass("Call to SDL_GetError()");
         SDLTest_AssertCheck(error != NULL, "Validate that error message was not NULL");
         if (error != NULL) {
-            SDLTest_AssertCheck(SDL_strcmp(error, expectedError1) == 0,
-                                "Validate error message, expected: '%s', got: '%s'", expectedError1, error);
+            SDLTest_AssertCheck(SDL_strcmp(error, expectedError) == 0,
+                                "Validate error message, expected: '%s', got: '%s'", expectedError, error);
         }
     }
 
@@ -348,11 +342,7 @@ static int pixels_allocFreePalette(void *arg)
     SDLTest_AssertPass("Call to SDL_DestroyPalette(NULL)");
     error = SDL_GetError();
     SDLTest_AssertPass("Call to SDL_GetError()");
-    SDLTest_AssertCheck(error != NULL, "Validate that error message was not NULL");
-    if (error != NULL) {
-        SDLTest_AssertCheck(SDL_strcmp(error, expectedError2) == 0,
-                            "Validate error message, expected: '%s', got: '%s'", expectedError2, error);
-    }
+    SDLTest_AssertCheck(error == NULL || error[0] == '\0', "Validate that error message is empty");
 
     return TEST_COMPLETED;
 }


### PR DESCRIPTION
…alette with NULL parameter doesn't generate an error

https://github.com/libsdl-org/SDL/issues/7467