### PR TITLE
macos: Added a system to make Objective-C class names unique.

### DIFF
--- a/build-scripts/showrevhash.sh
+++ b/build-scripts/showrevhash.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# Print the current source revision hash, if available
+
+SDL_ROOT=$(dirname $0)/..
+cd $SDL_ROOT
+
+if [ -x "$(command -v git)" ]; then
+    rev="$(git rev-parse HEAD 2>/dev/null)"
+    if [ -n "$rev" ]; then
+        echo "$rev"
+        exit 0
+    fi
+fi
+
+if [ -x "$(command -v p4)" ]; then
+    rev="$(p4 changes -m1 ./...\#have 2>/dev/null| awk '{print $2}')"
+    if [ $? = 0 ]; then
+        # e.g. p7511446
+        echo "p${rev}"
+        exit 0
+    fi
+fi
+
+# output nothing if we couldn't figure it out.
+exit 0
+

--- a/build-scripts/updaterev.sh
+++ b/build-scripts/updaterev.sh
@@ -28,6 +28,7 @@ done
 
 rev=`sh showrev.sh 2>/dev/null`
 if [ "$rev" != "" ]; then
+    revhash=`sh showrevhash.sh 2>/dev/null`
     if [ -n "$dist" ]; then
         echo "$rev" > "$outdir/VERSION.txt"
     fi
@@ -41,6 +42,9 @@ if [ "$rev" != "" ]; then
     echo "#define SDL_REVISION \"SDL-$rev\"" >>"$header.new"
     echo "#endif" >>"$header.new"
     echo "#define SDL_REVISION_NUMBER 0" >>"$header.new"
+    echo "/* SDL_REVISION_HASH is not a formal version, but whatever happens to be on this computer." >>"$header.new"
+    echo "   It's used for uniqueness internally and should not be shown to the user. */" >>"$header.new"
+    echo "#define SDL_REVISION_HASH $revhash" >>"$header.new"
     if diff $header $header.new >/dev/null 2>&1; then
         rm "$header.new"
     else

--- a/src/SDL_internal.h
+++ b/src/SDL_internal.h
@@ -26,6 +26,24 @@
 #define _GNU_SOURCE
 #endif
 
+/* if we use the dynamic API on macOS, our internal Objective-C classes will
+   have the same name as the library we are overriding, which confuses things
+   (class names have to be globally unique). Attempt to name these classes
+   with the current git hash appended, if possible, so they won't clash.
+   Just `#define MyObjCClass SDL_UNIQUE_OBJC_CLASS(MyObjCClass)` and then
+   set up `@interface MyObjCClass` etc, as usual. */
+#ifdef __OBJC__
+#   include "SDL_revision.h"
+#   ifdef SDL_REVISION_HASH
+#       define SDL_UNIQUE_OBJC_CLASS3(name, hash) name##_##hash
+#       define SDL_UNIQUE_OBJC_CLASS2(name, hash) SDL_UNIQUE_OBJC_CLASS3(name, hash)
+#       define SDL_UNIQUE_OBJC_CLASS(name) SDL_UNIQUE_OBJC_CLASS2(name, SDL_REVISION_HASH)
+#   else  /* oh well. */
+#       define SDL_UNIQUE_OBJC_CLASS(name) name
+#   endif
+#endif
+
+
 /* This is for a variable-length array at the end of a struct:
     struct x { int y; char z[SDL_VARIABLE_LENGTH_ARRAY]; };
    Use this because GCC 2 needs different magic than other compilers. */

--- a/src/joystick/iphoneos/SDL_mfijoystick.m
+++ b/src/joystick/iphoneos/SDL_mfijoystick.m
@@ -1214,6 +1214,7 @@ static void IOS_MFIJoystickUpdate(SDL_Joystick *joystick)
 
 #ifdef ENABLE_MFI_RUMBLE
 
+#define SDL_RumbleMotor SDL_UNIQUE_OBJC_CLASS(SDL_RumbleMotor)
 @interface SDL_RumbleMotor : NSObject
 @property(nonatomic, strong) CHHapticEngine *engine API_AVAILABLE(macos(10.16), ios(13.0), tvos(14.0));
 @property(nonatomic, strong) id<CHHapticPatternPlayer> player API_AVAILABLE(macos(10.16), ios(13.0), tvos(14.0));
@@ -1335,6 +1336,7 @@ static void IOS_MFIJoystickUpdate(SDL_Joystick *joystick)
 
 @end
 
+#define SDL_RumbleContext SDL_UNIQUE_OBJC_CLASS(SDL_RumbleContext)
 @interface SDL_RumbleContext : NSObject
 @property(nonatomic, strong) SDL_RumbleMotor *lowFrequencyMotor;
 @property(nonatomic, strong) SDL_RumbleMotor *highFrequencyMotor;

--- a/src/render/metal/SDL_render_metal.m
+++ b/src/render/metal/SDL_render_metal.m
@@ -119,6 +119,8 @@ typedef struct METAL_ShaderPipelines
     METAL_PipelineCache caches[SDL_METAL_FRAGMENT_COUNT];
 } METAL_ShaderPipelines;
 
+
+#define METAL_RenderData SDL_UNIQUE_OBJC_CLASS(METAL_RenderData)
 @interface METAL_RenderData : NSObject
     @property (nonatomic, retain) id<MTLDevice> mtldevice;
     @property (nonatomic, retain) id<MTLCommandQueue> mtlcmdqueue;
@@ -141,6 +143,8 @@ typedef struct METAL_ShaderPipelines
 @implementation METAL_RenderData
 @end
 
+
+#define METAL_TextureData SDL_UNIQUE_OBJC_CLASS(METAL_TextureData)
 @interface METAL_TextureData : NSObject
     @property (nonatomic, retain) id<MTLTexture> mtltexture;
     @property (nonatomic, retain) id<MTLTexture> mtltexture_uv;

--- a/src/video/cocoa/SDL_cocoaclipboard.h
+++ b/src/video/cocoa/SDL_cocoaclipboard.h
@@ -23,8 +23,7 @@
 #ifndef SDL_cocoaclipboard_h_
 #define SDL_cocoaclipboard_h_
 
-/* Forward declaration */
-@class SDL_VideoData;
+#include "SDL_cocoavideo.h"
 
 extern int Cocoa_SetClipboardText(_THIS, const char *text);
 extern char *Cocoa_GetClipboardText(_THIS);

--- a/src/video/cocoa/SDL_cocoaevents.m
+++ b/src/video/cocoa/SDL_cocoaevents.m
@@ -55,6 +55,7 @@ static SDL_Window *FindSDLWindowForNSWindow(NSWindow *win)
     return sdlwindow;
 }
 
+#define SDLApplication SDL_UNIQUE_OBJC_CLASS(SDLApplication)
 @interface SDLApplication : NSApplication
 
 - (void)terminate:(id)sender;
@@ -131,6 +132,7 @@ static void Cocoa_DispatchEvent(NSEvent *theEvent)
 - (void)setAppleMenu:(NSMenu *)menu;
 @end
 
+#define SDLAppDelegate SDL_UNIQUE_OBJC_CLASS(SDLAppDelegate)
 @interface SDLAppDelegate : NSObject <NSApplicationDelegate> {
 @public
     BOOL seenFirstActivate;

--- a/src/video/cocoa/SDL_cocoamessagebox.m
+++ b/src/video/cocoa/SDL_cocoamessagebox.m
@@ -27,6 +27,7 @@
 #include "SDL_messagebox.h"
 #include "SDL_cocoavideo.h"
 
+#define SDLMessageBoxPresenter SDL_UNIQUE_OBJC_CLASS(SDLMessageBoxPresenter)
 @interface SDLMessageBoxPresenter : NSObject {
 @public
     NSInteger clicked;

--- a/src/video/cocoa/SDL_cocoametalview.h
+++ b/src/video/cocoa/SDL_cocoametalview.h
@@ -40,6 +40,7 @@
 #import <QuartzCore/CAMetalLayer.h>
 
 
+#define SDL_cocoametalview SDL_UNIQUE_OBJC_CLASS(SDL_cocoametalview)
 @interface SDL_cocoametalview : NSView
 
 - (instancetype)initWithFrame:(NSRect)frame

--- a/src/video/cocoa/SDL_cocoaopengl.h
+++ b/src/video/cocoa/SDL_cocoaopengl.h
@@ -40,6 +40,7 @@ struct SDL_GLDriverData
     int initialized;
 };
 
+#define SDLOpenGLContext SDL_UNIQUE_OBJC_CLASS(SDLOpenGLContext)
 @interface SDLOpenGLContext : NSOpenGLContext {
     SDL_atomic_t dirty;
     SDL_Window *window;

--- a/src/video/cocoa/SDL_cocoashape.h
+++ b/src/video/cocoa/SDL_cocoashape.h
@@ -29,6 +29,7 @@
 #include "SDL_shape.h"
 #include "../SDL_shape_internals.h"
 
+#define SDL_ShapeData SDL_UNIQUE_OBJC_CLASS(SDL_ShapeData)
 @interface SDL_ShapeData : NSObject
     @property (nonatomic) NSGraphicsContext* context;
     @property (nonatomic) SDL_bool saved;

--- a/src/video/cocoa/SDL_cocoashape.m
+++ b/src/video/cocoa/SDL_cocoashape.m
@@ -30,6 +30,7 @@
 @implementation SDL_ShapeData
 @end
 
+#define SDL_CocoaClosure SDL_UNIQUE_OBJC_CLASS(SDL_CocoaClosure)
 @interface SDL_CocoaClosure : NSObject
     @property (nonatomic) NSView* view;
     @property (nonatomic) NSBezierPath* path;

--- a/src/video/cocoa/SDL_cocoavideo.h
+++ b/src/video/cocoa/SDL_cocoavideo.h
@@ -32,6 +32,9 @@
 #include "SDL_keycode.h"
 #include "../SDL_sysvideo.h"
 
+#define SDL_VideoData SDL_UNIQUE_OBJC_CLASS(SDL_VideoData)
+@class SDL_VideoData;
+
 #include "SDL_cocoaclipboard.h"
 #include "SDL_cocoaevents.h"
 #include "SDL_cocoakeyboard.h"
@@ -95,6 +98,7 @@ DECLARE_ALERT_STYLE(Critical);
 
 /* Private display data */
 
+#define SDLTranslatorResponder SDL_UNIQUE_OBJC_CLASS(SDLTranslatorResponder)
 @class SDLTranslatorResponder;
 
 @interface SDL_VideoData : NSObject

--- a/src/video/cocoa/SDL_cocoawindow.h
+++ b/src/video/cocoa/SDL_cocoawindow.h
@@ -29,6 +29,9 @@
 #include "../SDL_egl_c.h"
 #endif
 
+#include "SDL_cocoavideo.h"
+
+#define SDL_WindowData SDL_UNIQUE_OBJC_CLASS(SDL_WindowData)
 @class SDL_WindowData;
 
 typedef enum
@@ -39,6 +42,7 @@ typedef enum
     PENDING_OPERATION_MINIMIZE
 } PendingWindowOperation;
 
+#define Cocoa_WindowListener SDL_UNIQUE_OBJC_CLASS(Cocoa_WindowListener)
 @interface Cocoa_WindowListener : NSResponder <NSWindowDelegate> {
     /* SDL_WindowData owns this Listener and has a strong reference to it.
      * To avoid reference cycles, we could have either a weak or an
@@ -117,9 +121,6 @@ typedef enum
 
 @end
 /* *INDENT-ON* */
-
-@class SDLOpenGLContext;
-@class SDL_VideoData;
 
 @interface SDL_WindowData : NSObject
     @property (nonatomic) SDL_Window *window;

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -75,6 +75,8 @@
 @property (nonatomic) NSRect mouseConfinementRect;
 @end
 
+
+#define SDLWindow SDL_UNIQUE_OBJC_CLASS(SDLWindow)
 @interface SDLWindow : NSWindow <NSDraggingDestination>
 /* These are needed for borderless/fullscreen windows */
 - (BOOL)canBecomeKeyWindow;
@@ -1527,6 +1529,7 @@ Cocoa_SendMouseButtonClicks(SDL_Mouse * mouse, NSEvent *theEvent, SDL_Window * w
 
 @end
 
+#define SDLView SDL_UNIQUE_OBJC_CLASS(SDLView)
 @interface SDLView : NSView {
     SDL_Window *_sdlWindow;
 }


### PR DESCRIPTION
(Please note that this is for SDL2, and we might want to explore the alternative solution for SDL3.)

This is to workaround issues with the Dynamic API where you have two copies of SDL loaded, and even though you only use one of them, Objective-C might choose the wrong version of a class, since the names must be globally unique.

This works by appending the git hash (or p4 changeset) for the current working copy to the class names with a little preprocessor magic.

This isn't _perfect_ in that if you try to override an SDL with one built from the same git revision plus a temporary patch, it'll still conflict, or if a hash isn't available for whatever reason, the usual names are used.

Another suggestion was to build up these classes at runtime with the Objective-C's runtime's dynamic features, which could avoid these edge cases, but might involve other inconveniences, so this patch seems like a good first step.

Fixes #7484.
