### PR TITLE
wasapi: Force WIN_CoInitialize duing device open.

### DIFF
--- a/src/audio/wasapi/SDL_wasapi.h
+++ b/src/audio/wasapi/SDL_wasapi.h
@@ -47,6 +47,7 @@ struct SDL_PrivateAudioData
     SDL_AudioStream *capturestream;
     HANDLE event;
     HANDLE task;
+    SDL_threadID open_threadid;
     SDL_bool coinitialized;
     int framesize;
     int default_device_generation;


### PR DESCRIPTION
(Putting this in a pull request so I can make sure it compiles on Windows.)

This lets background threads open a WASAPI audio device.

Note that this PR is for SDL2; for SDL3, we'll avoid the chance of a leak by managing this ourselves, since we're (hopefully) changing how device opens happen.

Fixes #7478.
