### PR TITLE
Fix SDL_RenderSetVSync does not update flags if simulated vsync is on

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -4510,8 +4510,13 @@ int SDL_RenderSetVSync(SDL_Renderer *renderer, int vsync)
     renderer->wanted_vsync = vsync ? SDL_TRUE : SDL_FALSE;
 
     if (!renderer->SetVSync ||
-        renderer->SetVSync(renderer, vsync) < 0) {
+        renderer->SetVSync(renderer, vsync) != 0) {
         renderer->simulate_vsync = vsync ? SDL_TRUE : SDL_FALSE;
+        if (renderer->simulate_vsync) {
+            renderer->info.flags |= SDL_RENDERER_PRESENTVSYNC;
+        } else {
+            renderer->info.flags &= ~SDL_RENDERER_PRESENTVSYNC;
+        }
     } else {
         renderer->simulate_vsync = SDL_FALSE;
     }


### PR DESCRIPTION
## Description

The RendererInfo's flags are supposed to contain SDL_RENDERER_PRESENTVSYNC in case vsync is on, and not have it set if it's off.
Usually this is done inside SetVSync implementations for each separate "driver". But this flag is not updated within SDL_RenderSetVSync() in case the driver fails and the simulated vsync is enabled instead. This change lets the user to correctly detect current vsync state by reading SDL_RendererInfo in case the simulated vsync was activated.

Also fixes SetVSync's return value check: it may be positive for error too, but existing condition only tests for `< 0` values.
TBH I don't know how this is seen from design pov; if it's not correct, and simulated vsync must not be active in this case, then the flag should be updated under a separate condition perhaps?

## Existing Issue(s)

Fixes #7491.
