### PR TITLE
Fix -Wimplicit-fallthrough warnings

### DIFF
--- a/include/SDL3/SDL_audio.h
+++ b/include/SDL3/SDL_audio.h
@@ -164,13 +164,13 @@ typedef void (SDLCALL * SDL_AudioCallback) (void *userdata, Uint8 * stream,
  *  The calculated values in this structure are calculated by SDL_OpenAudioDevice().
  *
  *  For multi-channel audio, the default SDL channel mapping is:
- *  2:  FL FR                       (stereo)
- *  3:  FL FR LFE                   (2.1 surround)
- *  4:  FL FR BL BR                 (quad)
- *  5:  FL FR LFE BL BR             (4.1 surround)
- *  6:  FL FR FC LFE SL SR          (5.1 surround - last two can also be BL BR)
- *  7:  FL FR FC LFE BC SL SR       (6.1 surround)
- *  8:  FL FR FC LFE BL BR SL SR    (7.1 surround)
+ *  2:  FL  FR                          (stereo)
+ *  3:  FL  FR LFE                      (2.1 surround)
+ *  4:  FL  FR  BL  BR                  (quad)
+ *  5:  FL  FR LFE  BL  BR              (4.1 surround)
+ *  6:  FL  FR  FC LFE  SL  SR          (5.1 surround - last two can also be BL BR)
+ *  7:  FL  FR  FC LFE  BC  SL  SR      (6.1 surround)
+ *  8:  FL  FR  FC LFE  BL  BR  SL  SR  (7.1 surround)
  */
 typedef struct SDL_AudioSpec
 {

--- a/src/joystick/linux/SDL_sysjoystick.c
+++ b/src/joystick/linux/SDL_sysjoystick.c
@@ -1449,6 +1449,7 @@ static void HandleInputEvents(SDL_Joystick *joystick)
                         HandleHat(SDL_EVDEV_GetEventTimestamp(event), joystick, hat_index, code % 2, event->value);
                         break;
                     }
+                    SDL_FALLTHROUGH;
                 default:
                     event->value = AxisCorrect(joystick, code, event->value);
                     SDL_SendJoystickAxis(SDL_EVDEV_GetEventTimestamp(event), joystick,
@@ -1521,6 +1522,7 @@ static void HandleClassicEvents(SDL_Joystick *joystick)
                         HandleHat(timestamp, joystick, hat_index, code % 2, events[i].value);
                         break;
                     }
+                    SDL_FALLTHROUGH;
                 default:
                     SDL_SendJoystickAxis(timestamp, joystick,
                                             joystick->hwdata->abs_map[code],

--- a/src/video/SDL_blit_1.c
+++ b/src/video/SDL_blit_1.c
@@ -138,6 +138,7 @@ static void Blit1to2(SDL_BlitInfo *info)
             case 3:
                 *(Uint16 *)dst = map[*src++];
                 dst += 2;
+                SDL_FALLTHROUGH;
             case 2:
                 *(Uint32 *)dst = (map[src[HI]] << 16) | (map[src[LO]]);
                 src += 2;
@@ -167,6 +168,7 @@ static void Blit1to2(SDL_BlitInfo *info)
             case 3:
                 *(Uint16 *)dst = map[*src++];
                 dst += 2;
+                SDL_FALLTHROUGH;
             case 2:
                 *(Uint32 *)dst = (map[src[HI]] << 16) | (map[src[LO]]);
                 src += 2;
@@ -268,8 +270,10 @@ static void Blit1to4(SDL_BlitInfo *info)
         switch (width & 3) {
         case 3:
             *dst++ = map[*src++];
+            SDL_FALLTHROUGH;
         case 2:
             *dst++ = map[*src++];
+            SDL_FALLTHROUGH;
         case 1:
             *dst++ = map[*src++];
         }

--- a/src/video/SDL_blit_A.c
+++ b/src/video/SDL_blit_A.c
@@ -767,6 +767,7 @@ static void Blit565to565SurfaceAlphaMMX(SDL_BlitInfo *info)
         int dstskip = info->dst_skip >> 1;
         Uint32 s, d;
 
+#ifdef USE_DUFFS_LOOP
         __m64 src1, dst1, src2, dst2, gmask, bmask, mm_res, mm_alpha;
 
         alpha &= ~(1 + 2 + 4);             /* cut alpha to get the exact same behaviour */
@@ -782,6 +783,7 @@ static void Blit565to565SurfaceAlphaMMX(SDL_BlitInfo *info)
         /* Setup the 565 color channel masks */
         gmask = _mm_set_pi32(0x07E007E0, 0x07E007E0); /* MASKGREEN -> gmask */
         bmask = _mm_set_pi32(0x001F001F, 0x001F001F); /* MASKBLUE -> bmask */
+#endif
 
         while (height--) {
             /* *INDENT-OFF* */ /* clang-format off */
@@ -903,6 +905,7 @@ static void Blit555to555SurfaceAlphaMMX(SDL_BlitInfo *info)
         int dstskip = info->dst_skip >> 1;
         Uint32 s, d;
 
+#ifdef USE_DUFFS_LOOP
         __m64 src1, dst1, src2, dst2, rmask, gmask, bmask, mm_res, mm_alpha;
 
         alpha &= ~(1 + 2 + 4);             /* cut alpha to get the exact same behaviour */
@@ -919,7 +922,7 @@ static void Blit555to555SurfaceAlphaMMX(SDL_BlitInfo *info)
         rmask = _mm_set_pi32(0x7C007C00, 0x7C007C00); /* MASKRED -> rmask */
         gmask = _mm_set_pi32(0x03E003E0, 0x03E003E0); /* MASKGREEN -> gmask */
         bmask = _mm_set_pi32(0x001F001F, 0x001F001F); /* MASKBLUE -> bmask */
-
+#endif
         while (height--) {
             /* *INDENT-OFF* */ /* clang-format off */
             DUFFS_LOOP_124(

--- a/src/video/SDL_blit_N.c
+++ b/src/video/SDL_blit_N.c
@@ -993,9 +993,11 @@ static void Blit_RGB888_index8(SDL_BlitInfo *info)
             case 3:
                 RGB888_RGB332(*dst++, *src);
                 ++src;
+                SDL_FALLTHROUGH;
             case 2:
                 RGB888_RGB332(*dst++, *src);
                 ++src;
+                SDL_FALLTHROUGH;
             case 1:
                 RGB888_RGB332(*dst++, *src);
                 ++src;
@@ -1037,10 +1039,12 @@ static void Blit_RGB888_index8(SDL_BlitInfo *info)
                 RGB888_RGB332(Pixel, *src);
                 *dst++ = map[Pixel];
                 ++src;
+                SDL_FALLTHROUGH;
             case 2:
                 RGB888_RGB332(Pixel, *src);
                 *dst++ = map[Pixel];
                 ++src;
+                SDL_FALLTHROUGH;
             case 1:
                 RGB888_RGB332(Pixel, *src);
                 *dst++ = map[Pixel];
@@ -1103,9 +1107,11 @@ static void Blit_RGB101010_index8(SDL_BlitInfo *info)
             case 3:
                 RGB101010_RGB332(*dst++, *src);
                 ++src;
+                SDL_FALLTHROUGH;
             case 2:
                 RGB101010_RGB332(*dst++, *src);
                 ++src;
+                SDL_FALLTHROUGH;
             case 1:
                 RGB101010_RGB332(*dst++, *src);
                 ++src;
@@ -1147,10 +1153,12 @@ static void Blit_RGB101010_index8(SDL_BlitInfo *info)
                 RGB101010_RGB332(Pixel, *src);
                 *dst++ = map[Pixel];
                 ++src;
+                SDL_FALLTHROUGH;
             case 2:
                 RGB101010_RGB332(Pixel, *src);
                 *dst++ = map[Pixel];
                 ++src;
+                SDL_FALLTHROUGH;
             case 1:
                 RGB101010_RGB332(Pixel, *src);
                 *dst++ = map[Pixel];
@@ -1242,6 +1250,7 @@ static void Blit_RGB888_RGB555(SDL_BlitInfo *info)
                 RGB888_RGB555(dst, src);
                 ++src;
                 ++dst;
+                SDL_FALLTHROUGH;
             case 2:
                 RGB888_RGB555_TWO(dst, src);
                 src += 2;
@@ -1273,6 +1282,7 @@ static void Blit_RGB888_RGB555(SDL_BlitInfo *info)
                 RGB888_RGB555(dst, src);
                 ++src;
                 ++dst;
+                SDL_FALLTHROUGH;
             case 2:
                 RGB888_RGB555_TWO(dst, src);
                 src += 2;
@@ -1370,6 +1380,7 @@ static void Blit_RGB888_RGB565(SDL_BlitInfo *info)
                 RGB888_RGB565(dst, src);
                 ++src;
                 ++dst;
+                SDL_FALLTHROUGH;
             case 2:
                 RGB888_RGB565_TWO(dst, src);
                 src += 2;
@@ -1401,6 +1412,7 @@ static void Blit_RGB888_RGB565(SDL_BlitInfo *info)
                 RGB888_RGB565(dst, src);
                 ++src;
                 ++dst;
+                SDL_FALLTHROUGH;
             case 2:
                 RGB888_RGB565_TWO(dst, src);
                 src += 2;
@@ -1472,9 +1484,11 @@ static void Blit_RGB565_32(SDL_BlitInfo *info, const Uint32 *map)
         case 3:
             *dst++ = RGB565_32(dst, src, map);
             src += 2;
+            SDL_FALLTHROUGH;
         case 2:
             *dst++ = RGB565_32(dst, src, map);
             src += 2;
+            SDL_FALLTHROUGH;
         case 1:
             *dst++ = RGB565_32(dst, src, map);
             src += 2;

--- a/test/testautomation_audio.c
+++ b/test/testautomation_audio.c
@@ -272,6 +272,7 @@ static int audio_pauseUnpauseAudio(void *arg)
                 desired.samples = 4096;
                 desired.callback = audio_testCallback;
                 desired.userdata = NULL;
+                break;
 
             case 1:
                 /* Set custom desired spec */

--- a/test/testsurround.c
+++ b/test/testsurround.c
@@ -38,6 +38,7 @@ get_channel_name(int channel_index, int channel_count)
     case 2:
         switch (channel_count) {
         case 3:
+        case 5:
             return "Low Frequency Effects";
         case 4:
             return "Back Left";
@@ -57,27 +58,32 @@ get_channel_name(int channel_index, int channel_count)
         switch (channel_count) {
         case 5:
             return "Back Right";
+        case 6:
+            return "Side Left";
         case 7:
             return "Back Center";
-        case 6:
         case 8:
             return "Back Left";
         }
+        SDL_assert(0);
     case 5:
         switch (channel_count) {
-        case 7:
-            return "Back Left";
         case 6:
+            return "Side Right";
+        case 7:
+            return "Side Left";
         case 8:
             return "Back Right";
         }
+        SDL_assert(0);
     case 6:
         switch (channel_count) {
         case 7:
-            return "Back Right";
+            return "Side Right";
         case 8:
             return "Side Left";
         }
+        SDL_assert(0);
     case 7:
         return "Side Right";
     }


### PR DESCRIPTION
For some warnings to reproduce, I locally disabled duff's loop in `include/video/SDL_blit.h`.

- For testsurround, I used this table as reference:
    https://github.com/libsdl-org/SDL/blob/f360965db64e1f90b578c9e9d28f73d0266fd4aa/include/SDL3/SDL_audio.h#L164-L173
- Fix missing fallthroughs in video blitting code
- Fix missing break in testautomation_audio.c (this bug caused less test coverage)
- Fix warnings about unused variables when disabling duff's device in the blitting code

Since SDL3 is VS2010+, the ability to disable the duff's device might be reconsidered.