### PR TITLE
Split up CFLAGS construction so it can be overridden

### DIFF
--- a/Makefile.minimal
+++ b/Makefile.minimal
@@ -1,7 +1,7 @@
 # Makefile to build the SDL library
 
-INCLUDE = -I./include
-CFLAGS  = -g -O2 $(INCLUDE)
+CPPFLAGS = -I./include
+CFLAGS  = -g -O2
 AR	= ar
 RANLIB	= ranlib
 


### PR DESCRIPTION
CFLAGS currently takes care of two aspects of the build: optimisation and debug symbols on one hand, the include path on the other. The former should be overridable by users, the latter shouldn't. This patch allows CFLAGS to be overridden either from the environment or from the command line, and adds the required include setting unconditionnally.

Based on a patch by Roflcopter4:
https://github.com/joncampbell123/dosbox-x/pull/3850