### PR TITLE
Fix clang-tidy error on LLVM 16.

### DIFF
--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -690,6 +690,11 @@ size_t strlcpy(char* dst, const char* src, size_t size);
 size_t strlcat(char* dst, const char* src, size_t size);
 #endif
 
+/* Starting LLVM 16, the analyser errors out if these functions do not have
+   their prototype defined (clang-diagnostic-implicit-function-declaration) */
+#include <stdlib.h>
+#include <string.h>
+
 #define SDL_malloc malloc
 #define SDL_calloc calloc
 #define SDL_realloc realloc


### PR DESCRIPTION
## Description

Starting LLVM 16 (released a few days ago), clang treats implicit function declarations as an error (See [breaking changes](https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html#potentially-breaking-changes)).

This does not change anything for regular builds, but when clang-tidy is enable, this block in SDL_stdinc.h triggers the error:
```c
#if defined(__clang_analyzer__) && !defined(SDL_DISABLE_ANALYZE_MACROS)

#define SDL_malloc malloc
...
```

The errors look like this:
```
SDL/include/SDL3/SDL_stdinc.h:728:12: error: call to undeclared library function 'memcpy' with type 'void *(void *, const void *, unsigned long)'; ISO C99 and later do not support implicit function declarations [clang-diagnostic-implicit-function-declaration]
    return SDL_memcpy(dst, src, dwords * 4);
           ^
SDL/include/SDL3/SDL_stdinc.h:698:20: note: expanded from macro 'SDL_memcpy'
#define SDL_memcpy memcpy
                   ^
SDL/include/SDL3/SDL_stdinc.h:728:12: note: include the header <string.h> or explicitly provide a declaration for 'memcpy'
    return SDL_memcpy(dst, src, dwords * 4);
           ^
SDL/include/SDL3/SDL_stdinc.h:698:20: note: expanded from macro 'SDL_memcpy'
#define SDL_memcpy memcpy
```

Including `stdlib.h` and `string.h` fixes the errors.

## Existing Issue(s)

N/A
