### PR TITLE
SDL2: android: Fix regressions in android project after controller change backport

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLControllerManager.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLControllerManager.java
@@ -24,7 +24,7 @@ public class SDLControllerManager
     public static native int nativeAddJoystick(int device_id, String name, String desc,
                                                int vendor_id, int product_id,
                                                boolean is_accelerometer, int button_mask,
-                                               int naxes, int axis_mask, int nhats, nballs);
+                                               int naxes, int axis_mask, int nhats, int nballs);
     public static native int nativeRemoveJoystick(int device_id);
     public static native int nativeAddHaptic(int device_id, String name);
     public static native int nativeRemoveHaptic(int device_id);

--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -278,7 +278,7 @@ static JNINativeMethod SDLControllerManager_tab[] = {
     { "onNativePadUp", "(II)I", SDL_JAVA_CONTROLLER_INTERFACE(onNativePadUp) },
     { "onNativeJoy", "(IIF)V", SDL_JAVA_CONTROLLER_INTERFACE(onNativeJoy) },
     { "onNativeHat", "(IIII)V", SDL_JAVA_CONTROLLER_INTERFACE(onNativeHat) },
-    { "nativeAddJoystick", "(ILjava/lang/String;Ljava/lang/String;IIZIIII)I", SDL_JAVA_CONTROLLER_INTERFACE(nativeAddJoystick) },
+    { "nativeAddJoystick", "(ILjava/lang/String;Ljava/lang/String;IIZIIIII)I", SDL_JAVA_CONTROLLER_INTERFACE(nativeAddJoystick) },
     { "nativeRemoveJoystick", "(I)I", SDL_JAVA_CONTROLLER_INTERFACE(nativeRemoveJoystick) },
     { "nativeAddHaptic", "(ILjava/lang/String;)I", SDL_JAVA_CONTROLLER_INTERFACE(nativeAddHaptic) },
     { "nativeRemoveHaptic", "(I)I", SDL_JAVA_CONTROLLER_INTERFACE(nativeRemoveHaptic) }


### PR DESCRIPTION
This PR contains a few fixes for issues I encountered when trying to build and run a test android project off of the `SDL2` branch.

## 3e9b375bf95c206684774e2253583703db4687b0: Fix missing type in SDLControllerManager

The missing type in question is causing compilation failures. The error was introduced in https://github.com/libsdl-org/SDL/commit/dca3fd8307c2c9ebda8d8ea623bbbf19649f5e22, which was a backport of commit https://github.com/libsdl-org/SDL/commit/de3909a190f6e1a3f11776ce42927f99b0381675 from SDL3 to SDL2.

Because `int nballs` was removed as a parameter from the controller API in SDL3 in revision https://github.com/libsdl-org/SDL/commit/fcafe40948fe308cc9552df5a3d625ee2725de5a, this change is only applicable to the SDL2 branch.

## afea1a9b478bc280e71dfa65d2c3e5868c6b0859: Fix mismatching JNI method signature

Another regression from commit https://github.com/libsdl-org/SDL/commit/dca3fd8307c2c9ebda8d8ea623bbbf19649f5e22, which was a backport of commit https://github.com/libsdl-org/SDL/commit/de3909a190f6e1a3f11776ce42927f99b0381675 from SDL3 to SDL2. This time the regression is much less apparent, however, due to two reasons:

- It only appears when the SDL project is ran on an actual device due to magic stringage.
- More importantly, the regression was partially hidden due to the nature of https://github.com/libsdl-org/SDL/commit/de3909a190f6e1a3f11776ce42927f99b0381675.

  The commit which was backported added a single `I` to the JNI method signature in `SDL_android.c`, representing the added `int axis_mask` parameter. The parameter was added to both SDL2 and SDL3.

  However, notably, that `I` was added *after* commit https://github.com/libsdl-org/SDL/commit/fcafe40948fe308cc9552df5a3d625ee2725de5a, which removed the `int nballs` parameter from the joystick API, but only from the SDL3 branch.

  Therefore, in totality, what should really have been a merge conflict, was obscured by the fact that the SDL3 branch ended up having a net-identical JNI signature to the SDL2 branch, due to having one bool param removed and one added - while, in fact, the SDL2 branch needed one bool param added and none removed.

As with the first commit, this is only applicable to the SDL2 branch.