### PR TITLE
testdisplayinfo: use correct index variable

### DIFF
--- a/test/testdisplayinfo.c
+++ b/test/testdisplayinfo.c
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
         for (m = 0; m < num_modes; m++) {
             char prefix[64];
             (void)SDL_snprintf(prefix, sizeof(prefix), "    MODE %d", m);
-            print_mode(prefix, modes[i]);
+            print_mode(prefix, modes[m]);
         }
         SDL_free(modes);
 


### PR DESCRIPTION
All reported modes were identical. Using 'i' variable instead of 'm' seemed wrong.
