### PR TITLE
SDL_WindowDestroy: re-check "checked_texture_framebuffer"

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -3433,6 +3433,7 @@ void SDL_DestroyWindow(SDL_Window *window)
         if (_this->DestroyWindowFramebuffer) {
             _this->DestroyWindowFramebuffer(_this, window);
         }
+        _this->checked_texture_framebuffer = SDL_FALSE;
     }
 
     /* make no context current if this is the current context window. */


### PR DESCRIPTION
Not sure if this is the right fix, but : 
- this seems to be done also in SDL_ReCreateWindow() 
 ( https://github.com/libsdl-org/SDL/blob/main/src/video/SDL_video.c#L2077 ) 


it helps to run (and pass):
`./test/testautomation --renderer software  --filter render`