### PR TITLE
Don't clear checked_texture_framebuffer

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2078,7 +2078,6 @@ int SDL_RecreateWindow(SDL_Window *window, Uint32 flags)
         if (_this->DestroyWindowFramebuffer) {
             _this->DestroyWindowFramebuffer(_this, window);
         }
-        _this->checked_texture_framebuffer = SDL_FALSE;
     }
 
     if ((window->flags & SDL_WINDOW_OPENGL) != (flags & SDL_WINDOW_OPENGL)) {


### PR DESCRIPTION

other way to fix https://github.com/libsdl-org/SDL/pull/7543  is not to clear the flags

(was added here :  https://github.com/libsdl-org/SDL/commit/d305bc6d5565a675ccdc58ac432bd6978ccc3030 )