### PR TITLE
SDL_hidapi_steam.c: Fix compilation under c2x.

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -31,11 +31,9 @@
 
 #include <stdint.h>
 
-typedef enum
-{
-    false,
-    true
-} bool;
+#define bool SDL_bool
+#define true SDL_TRUE
+#define false SDL_FALSE
 
 typedef uint32_t uint32;
 typedef uint64_t uint64;


### PR DESCRIPTION

## Description

When N2935 is implemented, the enum breaks compilation in c2x mode. This PR replaces the enum with a `#define` to the `SDL_bool` type.

## Existing Issue(s)

Fixes #7522 
