### PR TITLE
SDL_DestroyWindow: some safety fix

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -3458,6 +3458,10 @@ void SDL_DestroyWindow(SDL_Window *window)
         _this->grabbed_window = NULL; /* ungrabbing input. */
     }
 
+    if (_this->current_glwin == window) {
+        _this->current_glwin = NULL;
+    }
+
     /* Now invalidate magic */
     window->magic = NULL;
 

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -3462,6 +3462,10 @@ void SDL_DestroyWindow(SDL_Window *window)
         _this->current_glwin = NULL;
     }
 
+    if (_this->wakeup_window == window) {
+        _this->wakeup_window = NULL;
+    }
+
     /* Now invalidate magic */
     window->magic = NULL;
 


### PR DESCRIPTION
I haven't been able to reproduce them with current test (eg testautomation), 
but ot sounds, like there could be issues after Destroying a window, if:

- a wakeup event for the window is pending 
- _this->current_glwin is accessed

so let's clear those variables if needed