### PR TITLE
SDL2: Fixed a C++-style single line comment at SDL_mute.h

### DIFF
--- a/include/SDL_mutex.h
+++ b/include/SDL_mutex.h
@@ -39,7 +39,7 @@
     defined(__clang__) && (!defined(SWIG))
 #define SDL_THREAD_ANNOTATION_ATTRIBUTE__(x)   __attribute__((x))
 #else
-#define SDL_THREAD_ANNOTATION_ATTRIBUTE__(x)   // no-op
+#define SDL_THREAD_ANNOTATION_ATTRIBUTE__(x)   /* no-op */
 #endif
 
 #define SDL_CAPABILITY(x) \


### PR DESCRIPTION
Apply the same fix as was been applied to main brainch: https://github.com/libsdl-org/SDL/commit/78725dc0cd8502a91d2565af44ff9e6e65f0f30d

## Description
Fixes C90 compatibility in the public header

## Existing Issue(s)
C90-enforcing projects fails to build because of C++ comment in the public header.
