### PR TITLE
Use #ifdef/#ifndef instead of #if defined/#if !defined

### DIFF
--- a/cmake/test/main_lib.c
+++ b/cmake/test/main_lib.c
@@ -4,7 +4,7 @@
 
 #include EXPORT_HEADER
 
-#if defined(_WIN32)
+#ifdef _WIN32
 #include <windows.h>
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved) {
     return TRUE;

--- a/include/SDL3/SDL_assert.h
+++ b/include/SDL3/SDL_assert.h
@@ -53,7 +53,7 @@ on the assertion line and not in some random guts of SDL, and so each
 assert can have unique static variables associated with it.
 */
 
-#if defined(_MSC_VER)
+#ifdef _MSC_VER
 /* Don't include intrin.h here because it contains C++ code */
     extern void __cdecl __debugbreak(void);
     #define SDL_TriggerBreakpoint() __debugbreak()
@@ -150,7 +150,7 @@ typedef struct SDL_AssertData
 extern DECLSPEC SDL_AssertState SDLCALL SDL_ReportAssertion(SDL_AssertData *data,
                                                             const char *func,
                                                             const char *file, int line)
-#if defined(__clang__)
+#ifdef __clang__
 #if __has_feature(attribute_analyzer_noreturn)
    __attribute__((analyzer_noreturn))
 #endif

--- a/include/SDL3/SDL_begin_code.h
+++ b/include/SDL3/SDL_begin_code.h
@@ -99,7 +99,7 @@
 #endif /* Compiler needs structure packing set */
 
 #ifndef SDL_INLINE
-#if defined(__GNUC__)
+#ifdef __GNUC__
 #define SDL_INLINE __inline__
 #elif defined(_MSC_VER) || defined(__BORLANDC__) || \
       defined(__DMC__) || defined(__SC__) || \
@@ -118,7 +118,7 @@
 #endif /* SDL_INLINE not defined */
 
 #ifndef SDL_FORCE_INLINE
-#if defined(_MSC_VER)
+#ifdef _MSC_VER
 #define SDL_FORCE_INLINE __forceinline
 #elif ( (defined(__GNUC__) && (__GNUC__ >= 4)) || defined(__clang__) )
 #define SDL_FORCE_INLINE __attribute__((always_inline)) static __inline__
@@ -128,7 +128,7 @@
 #endif /* SDL_FORCE_INLINE not defined */
 
 #ifndef SDL_NORETURN
-#if defined(__GNUC__)
+#ifdef __GNUC__
 #define SDL_NORETURN __attribute__((noreturn))
 #elif defined(_MSC_VER)
 #define SDL_NORETURN __declspec(noreturn)
@@ -138,7 +138,7 @@
 #endif /* SDL_NORETURN not defined */
 
 /* Apparently this is needed by several Windows compilers */
-#if !defined(__MACH__)
+#ifndef __MACH__
 #ifndef NULL
 #ifdef __cplusplus
 #define NULL 0
@@ -153,7 +153,7 @@
     (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202000L)
 #define SDL_FALLTHROUGH [[fallthrough]]
 #else
-#if defined(__has_attribute)
+#ifdef __has_attribute
 #define SDL_HAS_FALLTHROUGH __has_attribute(__fallthrough__)
 #else
 #define SDL_HAS_FALLTHROUGH 0

--- a/include/SDL3/SDL_intrin.h
+++ b/include/SDL3/SDL_intrin.h
@@ -60,13 +60,13 @@ _m_prefetch(void *__P)
 #define SDL_ALTIVEC_INTRINSICS 1
 #include <altivec.h>
 #endif
-#if !defined(SDL_DISABLE_NEON)
-#  if defined(__ARM_NEON)
+#ifndef SDL_DISABLE_NEON
+#  ifdef __ARM_NEON
 #    define SDL_NEON_INTRINSICS 1
 #    include <arm_neon.h>
 #  elif defined(__WINDOWS__) || defined(__WINRT__) || defined(__GDK__)
 /* Visual Studio doesn't define __ARM_ARCH, but _M_ARM (if set, always 7), and _M_ARM64 (if set, always 1). */
-#    if defined(_M_ARM)
+#    ifdef _M_ARM
 #      define SDL_NEON_INTRINSICS 1
 #      include <armintr.h>
 #      include <arm_neon.h>
@@ -99,7 +99,7 @@ _m_prefetch(void *__P)
 # define SDL_TARGETING(x)
 #endif
 
-#if defined(__loongarch64)
+#ifdef __loongarch64
 # ifndef SDL_DISABLE_LSX
 #  define SDL_LSX_INTRINSICS 1
 #  include <lsxintrin.h>

--- a/include/SDL3/SDL_main.h
+++ b/include/SDL3/SDL_main.h
@@ -31,7 +31,7 @@
  */
 
 #ifndef SDL_MAIN_HANDLED
-#if defined(__WIN32__)
+#ifdef __WIN32__
 /* On Windows SDL provides WinMain(), which parses the command line and passes
    the arguments to your main function.
 
@@ -253,7 +253,7 @@ extern DECLSPEC void SDLCALL SDL_UnregisterApp(void);
 
 #endif /* __WINRT__ */
 
-#if defined(__IOS__)
+#ifdef __IOS__
 
 /* for compatibility with SDL2's function of this name */
 #define SDL_UIKitRunApp(ARGC, ARGV, MAIN_FUNC)  SDL_RunApp(ARGC, ARGV, MAIN_FUNC, NULL)

--- a/include/SDL3/SDL_main_impl.h
+++ b/include/SDL3/SDL_main_impl.h
@@ -22,7 +22,7 @@
 #ifndef SDL_main_impl_h_
 #define SDL_main_impl_h_
 
-#if !defined(SDL_main_h_)
+#ifndef SDL_main_h_
 #error "This header should not be included directly, but only via SDL_main.h!"
 #endif
 

--- a/include/SDL3/SDL_opengl.h
+++ b/include/SDL3/SDL_opengl.h
@@ -68,7 +68,7 @@
 #ifndef __gl_h_
 #define __gl_h_
 
-#if defined(USE_MGL_NAMESPACE)
+#ifdef USE_MGL_NAMESPACE
 #include <SDL3/gl_mangle.h>
 #endif
 

--- a/include/SDL3/SDL_platform_defines.h
+++ b/include/SDL3/SDL_platform_defines.h
@@ -28,11 +28,11 @@
 #ifndef SDL_platform_defines_h_
 #define SDL_platform_defines_h_
 
-#if defined(_AIX)
+#ifdef _AIX
 #undef __AIX__
 #define __AIX__     1
 #endif
-#if defined(__HAIKU__)
+#ifdef __HAIKU__
 #undef __HAIKU__
 #define __HAIKU__   1
 #endif
@@ -40,7 +40,7 @@
 #undef __BSDI__
 #define __BSDI__    1
 #endif
-#if defined(_arch_dreamcast)
+#ifdef _arch_dreamcast
 #undef __DREAMCAST__
 #define __DREAMCAST__   1
 #endif
@@ -65,12 +65,12 @@
 #undef __LINUX__ /* do we need to do this? */
 #define __ANDROID__ 1
 #endif
-#if defined(__NGAGE__)
+#ifdef __NGAGE__
 #undef __NGAGE__
 #define __NGAGE__ 1
 #endif
 
-#if defined(__APPLE__)
+#ifdef __APPLE__
 /* lets us know what version of macOS we're compiling on */
 #include <AvailabilityMacros.h>
 #include <TargetConditionals.h>
@@ -111,11 +111,11 @@
 #endif /* TARGET_OS_IPHONE */
 #endif /* defined(__APPLE__) */
 
-#if defined(__NetBSD__)
+#ifdef __NetBSD__
 #undef __NETBSD__
 #define __NETBSD__  1
 #endif
-#if defined(__OpenBSD__)
+#ifdef __OpenBSD__
 #undef __OPENBSD__
 #define __OPENBSD__ 1
 #endif
@@ -127,7 +127,7 @@
 #undef __OSF__
 #define __OSF__     1
 #endif
-#if defined(__QNXNTO__)
+#ifdef __QNXNTO__
 #undef __QNXNTO__
 #define __QNXNTO__  1
 #endif
@@ -187,7 +187,7 @@
 #endif
 #endif /* defined(WIN32) || defined(_WIN32) || defined(__CYGWIN__) */
 
-#if defined(__WINDOWS__)
+#ifdef __WINDOWS__
 #undef __WIN32__
 #define __WIN32__ 1
 #endif
@@ -196,19 +196,19 @@
 #undef __GDK__
 #define __GDK__ 1
 #endif
-#if defined(__PSP__)
+#ifdef __PSP__
 #undef __PSP__
 #define __PSP__ 1
 #endif
-#if defined(PS2)
+#ifdef PS2
 #define __PS2__ 1
 #endif
 
-#if defined(__vita__)
+#ifdef __vita__
 #define __VITA__ 1
 #endif
 
-#if defined(__3DS__)
+#ifdef __3DS__
 #undef __3DS__
 #define __3DS__ 1
 #endif

--- a/include/SDL3/SDL_rwops.h
+++ b/include/SDL3/SDL_rwops.h
@@ -103,7 +103,7 @@ typedef struct SDL_RWops
     Uint32 type;
     union
     {
-#if defined(__ANDROID__)
+#ifdef __ANDROID__
         struct
         {
             void *asset;

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -37,8 +37,8 @@
 #include <stdint.h>
 #include <wchar.h>
 
-#if !defined(alloca)
-# if defined(HAVE_ALLOCA_H)
+#ifndef alloca
+# ifdef HAVE_ALLOCA_H
 #  include <alloca.h>
 # elif defined(__GNUC__)
 #  define alloca __builtin_alloca
@@ -309,7 +309,7 @@ typedef uint64_t Uint64;
 #define SDL_PRINTF_FORMAT_STRING
 #define SDL_SCANF_FORMAT_STRING
 #endif
-#if defined(__GNUC__)
+#ifdef __GNUC__
 #define SDL_PRINTF_VARARG_FUNC( fmtargnumber ) __attribute__ (( format( __printf__, fmtargnumber, fmtargnumber+1 )))
 #define SDL_SCANF_VARARG_FUNC( fmtargnumber ) __attribute__ (( format( __scanf__, fmtargnumber, fmtargnumber+1 )))
 #else
@@ -319,7 +319,7 @@ typedef uint64_t Uint64;
 #endif /* SDL_DISABLE_ANALYZE_MACROS */
 
 #ifndef SDL_COMPILE_TIME_ASSERT
-#if defined(__cplusplus)
+#ifdef __cplusplus
 #if (__cplusplus >= 201103L)
 #define SDL_COMPILE_TIME_ASSERT(name, x)  static_assert(x, #x)
 #endif

--- a/include/SDL3/SDL_system.h
+++ b/include/SDL3/SDL_system.h
@@ -622,7 +622,7 @@ extern DECLSPEC void SDLCALL SDL_OnApplicationDidChangeStatusBarOrientation(void
 #endif
 
 /* Functions used only by GDK */
-#if defined(__GDK__)
+#ifdef __GDK__
 typedef struct XTaskQueueObject * XTaskQueueHandle;
 
 /**

--- a/include/SDL3/SDL_syswm.h
+++ b/include/SDL3/SDL_syswm.h
@@ -45,7 +45,7 @@
 /**
  *  The available subsystems based on platform
  */
-#if !defined(SDL_DISABLE_SYSWM_PLATFORMS)
+#ifndef SDL_DISABLE_SYSWM_PLATFORMS
 
 #ifndef SDL_DISABLE_SYSWM_ANDROID
 #ifdef __ANDROID__
@@ -227,7 +227,7 @@ struct SDL_SysWMmsg
 
     union
     {
-#if defined(SDL_ENABLE_SYSWM_WINDOWS)
+#ifdef SDL_ENABLE_SYSWM_WINDOWS
         struct {
             HWND hwnd;                  /**< The window for the message */
             UINT msg;                   /**< The type of message */
@@ -235,7 +235,7 @@ struct SDL_SysWMmsg
             LPARAM lParam;              /**< LONG message parameter */
         } win;
 #endif
-#if defined(SDL_ENABLE_SYSWM_X11)
+#ifdef SDL_ENABLE_SYSWM_X11
         struct {
             XEvent event;
         } x11;
@@ -260,7 +260,7 @@ struct SDL_SysWMinfo
 
     union
     {
-#if defined(SDL_ENABLE_SYSWM_WINDOWS)
+#ifdef SDL_ENABLE_SYSWM_WINDOWS
         struct
         {
             HWND window;                /**< The window handle */
@@ -268,13 +268,13 @@ struct SDL_SysWMinfo
             HINSTANCE hinstance;        /**< The instance handle */
         } win;
 #endif
-#if defined(SDL_ENABLE_SYSWM_WINRT)
+#ifdef SDL_ENABLE_SYSWM_WINRT
         struct
         {
             IInspectable * window;      /**< The WinRT CoreWindow */
         } winrt;
 #endif
-#if defined(SDL_ENABLE_SYSWM_X11)
+#ifdef SDL_ENABLE_SYSWM_X11
         struct
         {
             Display *display;           /**< The X11 display */
@@ -282,7 +282,7 @@ struct SDL_SysWMinfo
             Window window;              /**< The X11 window */
         } x11;
 #endif
-#if defined(SDL_ENABLE_SYSWM_COCOA)
+#ifdef SDL_ENABLE_SYSWM_COCOA
         struct
         {
 #if defined(__OBJC__) && defined(__has_feature)
@@ -296,7 +296,7 @@ struct SDL_SysWMinfo
 #endif
         } cocoa;
 #endif
-#if defined(SDL_ENABLE_SYSWM_UIKIT)
+#ifdef SDL_ENABLE_SYSWM_UIKIT
         struct
         {
 #if defined(__OBJC__) && defined(__has_feature)
@@ -313,7 +313,7 @@ struct SDL_SysWMinfo
             GLuint resolveFramebuffer; /**< The Framebuffer Object which holds the resolve color Renderbuffer, when MSAA is used. */
         } uikit;
 #endif
-#if defined(SDL_ENABLE_SYSWM_WAYLAND)
+#ifdef SDL_ENABLE_SYSWM_WAYLAND
         struct
         {
             struct wl_display *display;             /**< Wayland display */
@@ -326,7 +326,7 @@ struct SDL_SysWMinfo
         } wl;
 #endif
 
-#if defined(SDL_ENABLE_SYSWM_ANDROID)
+#ifdef SDL_ENABLE_SYSWM_ANDROID
         struct
         {
             ANativeWindow *window;
@@ -334,7 +334,7 @@ struct SDL_SysWMinfo
         } android;
 #endif
 
-#if defined(SDL_ENABLE_SYSWM_VIVANTE)
+#ifdef SDL_ENABLE_SYSWM_VIVANTE
         struct
         {
             EGLNativeDisplayType display;
@@ -342,7 +342,7 @@ struct SDL_SysWMinfo
         } vivante;
 #endif
 
-#if defined(SDL_ENABLE_SYSWM_KMSDRM)
+#ifdef SDL_ENABLE_SYSWM_KMSDRM
         struct
         {
             int dev_index;               /**< Device index (ex: the X in /dev/dri/cardX) */

--- a/include/SDL3/SDL_test_common.h
+++ b/include/SDL3/SDL_test_common.h
@@ -34,7 +34,7 @@
 
 #include <SDL3/SDL.h>
 
-#if defined(__PSP__)
+#ifdef __PSP__
 #define DEFAULT_WINDOW_WIDTH  480
 #define DEFAULT_WINDOW_HEIGHT 272
 #elif defined(__VITA__)

--- a/src/SDL.c
+++ b/src/SDL.c
@@ -30,7 +30,7 @@
 /* this checks for HAVE_DBUS_DBUS_H internally. */
 #include "core/linux/SDL_dbus.h"
 
-#if defined(__EMSCRIPTEN__)
+#ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #endif
 
@@ -548,7 +548,7 @@ SDL_GetRevision(void)
 const char *
 SDL_GetPlatform(void)
 {
-#if defined(__AIX__)
+#ifdef __AIX__
     return "AIX";
 #elif defined(__ANDROID__)
     return "Android";
@@ -620,7 +620,7 @@ SDL_GetPlatform(void)
 SDL_bool
 SDL_IsTablet(void)
 {
-#if defined(__ANDROID__)
+#ifdef __ANDROID__
     extern SDL_bool SDL_IsAndroidTablet(void);
     return SDL_IsAndroidTablet();
 #elif defined(__IOS__)
@@ -631,7 +631,7 @@ SDL_IsTablet(void)
 #endif
 }
 
-#if defined(__WIN32__)
+#ifdef __WIN32__
 
 #if (!defined(HAVE_LIBC) || defined(__WATCOMC__)) && !defined(SDL_STATIC_LIB)
 /* Need to include DllMain() on Watcom C for some reason.. */

--- a/src/SDL_assert.c
+++ b/src/SDL_assert.c
@@ -33,7 +33,7 @@
 #endif
 #endif
 
-#if defined(__EMSCRIPTEN__)
+#ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #endif
 
@@ -123,13 +123,13 @@ static void SDL_GenerateAssertionReport(void)
 /* This is not declared in any header, although it is shared between some
     parts of SDL, because we don't want anything calling it without an
     extremely good reason. */
-#if defined(__WATCOMC__)
+#ifdef __WATCOMC__
 extern void SDL_ExitProcess(int exitcode);
 #pragma aux SDL_ExitProcess aborts;
 #endif
 extern SDL_NORETURN void SDL_ExitProcess(int exitcode);
 
-#if defined(__WATCOMC__)
+#ifdef __WATCOMC__
 static void SDL_AbortAssertion(void);
 #pragma aux SDL_AbortAssertion aborts;
 #endif
@@ -238,7 +238,7 @@ static SDL_AssertState SDLCALL SDL_PromptAssertion(const SDL_AssertData *data, v
             state = (SDL_AssertState)selected;
         }
     } else {
-#if defined(__EMSCRIPTEN__)
+#ifdef __EMSCRIPTEN__
         /* This is nasty, but we can't block on a custom UI. */
         for (;;) {
             SDL_bool okay = SDL_TRUE;

--- a/src/SDL_internal.h
+++ b/src/SDL_internal.h
@@ -75,15 +75,15 @@
 #ifdef HAVE_STDIO_H
 #include <stdio.h>
 #endif
-#if defined(HAVE_STDLIB_H)
+#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
 #elif defined(HAVE_MALLOC_H)
 #include <malloc.h>
 #endif
-#if defined(HAVE_STDDEF_H)
+#ifdef HAVE_STDDEF_H
 #include <stddef.h>
 #endif
-#if defined(HAVE_STDARG_H)
+#ifdef HAVE_STDARG_H
 #include <stdarg.h>
 #endif
 #ifdef HAVE_STRING_H
@@ -98,7 +98,7 @@
 #ifdef HAVE_WCHAR_H
 #include <wchar.h>
 #endif
-#if defined(HAVE_INTTYPES_H)
+#ifdef HAVE_INTTYPES_H
 #include <inttypes.h>
 #elif defined(HAVE_STDINT_H)
 #include <stdint.h>

--- a/src/SDL_log.c
+++ b/src/SDL_log.c
@@ -32,7 +32,7 @@
 #include <stdio.h>
 #endif
 
-#if defined(__ANDROID__)
+#ifdef __ANDROID__
 #include <android/log.h>
 #endif
 

--- a/src/atomic/SDL_atomic.c
+++ b/src/atomic/SDL_atomic.c
@@ -25,7 +25,7 @@
 #define HAVE_MSC_ATOMICS 1
 #endif
 
-#if defined(__MACOS__) /* !!! FIXME: should we favor gcc atomics? */
+#ifdef __MACOS__ /* !!! FIXME: should we favor gcc atomics? */
 #include <libkern/OSAtomic.h>
 #endif
 
@@ -34,11 +34,11 @@
 #endif
 
 /* The __atomic_load_n() intrinsic showed up in different times for different compilers. */
-#if defined(__clang__)
+#ifdef __clang__
 #if __has_builtin(__atomic_load_n) || defined(HAVE_GCC_ATOMICS)
 /* !!! FIXME: this advertises as available in the NDK but uses an external symbol we don't have.
    It might be in a later NDK or we might need an extra library? --ryan. */
-#if !defined(__ANDROID__)
+#ifndef __ANDROID__
 #define HAVE_ATOMIC_LOAD_N 1
 #endif
 #endif
@@ -155,7 +155,7 @@ SDL_AtomicCAS(SDL_AtomicInt *a, int oldval, int newval)
 SDL_bool
 SDL_AtomicCASPtr(void **a, void *oldval, void *newval)
 {
-#if defined(HAVE_MSC_ATOMICS)
+#ifdef HAVE_MSC_ATOMICS
     return _InterlockedCompareExchangePointer(a, newval, oldval) == oldval;
 #elif defined(HAVE_WATCOM_ATOMICS)
     return (SDL_bool)_SDL_cmpxchg_watcom((int *)a, (long)newval, (long)oldval);
@@ -206,7 +206,7 @@ int SDL_AtomicSet(SDL_AtomicInt *a, int v)
 void *
 SDL_AtomicSetPtr(void **a, void *v)
 {
-#if defined(HAVE_MSC_ATOMICS)
+#ifdef HAVE_MSC_ATOMICS
     return _InterlockedExchangePointer(a, v);
 #elif defined(HAVE_WATCOM_ATOMICS)
     return (void *)_SDL_xchg_watcom((int *)a, (long)v);

--- a/src/atomic/SDL_spinlock.c
+++ b/src/atomic/SDL_spinlock.c
@@ -36,7 +36,7 @@
 #include <xmmintrin.h>
 #endif
 
-#if defined(PS2)
+#ifdef PS2
 #include <kernel.h>
 #endif
 
@@ -60,7 +60,7 @@ extern __inline int _SDL_xchg_watcom(volatile int *a, int v);
 SDL_bool
 SDL_AtomicTryLock(SDL_SpinLock *lock)
 {
-#if defined(SDL_ATOMIC_DISABLED)
+#ifdef SDL_ATOMIC_DISABLED
     /* Terrible terrible damage */
     static SDL_mutex *_spinlock_mutex;
 
@@ -98,7 +98,7 @@ SDL_AtomicTryLock(SDL_SpinLock *lock)
      defined(__ARM_ARCH_5TEJ__))
     int result;
 
-#if defined(__RISCOS__)
+#ifdef __RISCOS__
     if (__cpucap_have_rex()) {
         __asm__ __volatile__(
             "ldrex %0, [%2]\nteq   %0, #0\nstrexeq %0, %1, [%2]"

--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -646,7 +646,7 @@ static int SDLCALL SDL_RunAudio(void *devicep)
 
     SDL_assert(!device->iscapture);
 
-#if defined(SDL_AUDIO_DRIVER_ANDROID)
+#ifdef SDL_AUDIO_DRIVER_ANDROID
     {
         /* Set thread priority to THREAD_PRIORITY_AUDIO */
         Android_JNI_AudioSetThreadPriority(device->iscapture, device->id);
@@ -746,7 +746,7 @@ static int SDLCALL SDL_CaptureAudio(void *devicep)
 
     SDL_assert(device->iscapture);
 
-#if defined(SDL_AUDIO_DRIVER_ANDROID)
+#ifdef SDL_AUDIO_DRIVER_ANDROID
     {
         /* Set thread priority to THREAD_PRIORITY_AUDIO */
         Android_JNI_AudioSetThreadPriority(device->iscapture, device->id);

--- a/src/audio/SDL_audiocvt.c
+++ b/src/audio/SDL_audiocvt.c
@@ -144,7 +144,7 @@ static int SDL_ConvertAudio(SDL_AudioCVT * cvt);
  * 8 channels (7.1) layout: FL+FR+FC+LFE+BL+BR+SL+SR
  */
 
-#if defined(SDL_SSE3_INTRINSICS)
+#ifdef SDL_SSE3_INTRINSICS
 /* Convert from stereo to mono. Average left and right. */
 static void SDLCALL SDL_TARGETING("sse3") SDL_ConvertStereoToMono_SSE3(SDL_AudioCVT *cvt, SDL_AudioFormat format)
 {
@@ -181,7 +181,7 @@ static void SDLCALL SDL_TARGETING("sse3") SDL_ConvertStereoToMono_SSE3(SDL_Audio
 }
 #endif
 
-#if defined(SDL_SSE_INTRINSICS)
+#ifdef SDL_SSE_INTRINSICS
 /* Convert from mono to stereo. Duplicate to stereo left and right. */
 static void SDLCALL SDL_TARGETING("sse") SDL_ConvertMonoToStereo_SSE(SDL_AudioCVT *cvt, SDL_AudioFormat format)
 {
@@ -834,7 +834,7 @@ static int SDL_BuildAudioCVT(SDL_AudioCVT *cvt,
         /* swap in some SIMD versions for a few of these. */
         if (channel_converter == SDL_ConvertStereoToMono) {
             SDL_AudioFilter filter = NULL;
-#if defined(SDL_SSE3_INTRINSICS)
+#ifdef SDL_SSE3_INTRINSICS
             if (!filter && SDL_HasSSE3()) {
                 filter = SDL_ConvertStereoToMono_SSE3;
             }
@@ -844,7 +844,7 @@ static int SDL_BuildAudioCVT(SDL_AudioCVT *cvt,
             }
         } else if (channel_converter == SDL_ConvertMonoToStereo) {
             SDL_AudioFilter filter = NULL;
-#if defined(SDL_SSE_INTRINSICS)
+#ifdef SDL_SSE_INTRINSICS
             if (!filter && SDL_HasSSE()) {
                 filter = SDL_ConvertMonoToStereo_SSE;
             }

--- a/src/audio/SDL_audiotypecvt.c
+++ b/src/audio/SDL_audiotypecvt.c
@@ -226,7 +226,7 @@ static void SDLCALL SDL_Convert_F32_to_S32_Scalar(SDL_AudioCVT *cvt, SDL_AudioFo
 }
 #endif
 
-#if defined(SDL_SSE2_INTRINSICS)
+#ifdef SDL_SSE2_INTRINSICS
 static void SDLCALL SDL_TARGETING("sse2") SDL_Convert_S8_to_F32_SSE2(SDL_AudioCVT *cvt, SDL_AudioFormat format)
 {
     const Sint8 *src = ((const Sint8 *)(cvt->buf + cvt->len_cvt)) - 1;
@@ -1175,7 +1175,7 @@ void SDL_ChooseAudioConverters(void)
     SDL_Convert_F32_to_S32 = SDL_Convert_F32_to_S32_##fntype; \
     converters_chosen = SDL_TRUE
 
-#if defined(SDL_SSE2_INTRINSICS)
+#ifdef SDL_SSE2_INTRINSICS
     if (SDL_HasSSE2()) {
         SET_CONVERTER_FUNCS(SSE2);
         return;

--- a/src/audio/coreaudio/SDL_coreaudio.h
+++ b/src/audio/coreaudio/SDL_coreaudio.h
@@ -25,7 +25,7 @@
 
 #include "../SDL_sysaudio.h"
 
-#if !defined(__IOS__)
+#ifndef __IOS__
 #define MACOSX_COREAUDIO
 #endif
 

--- a/src/audio/coreaudio/SDL_coreaudio.m
+++ b/src/audio/coreaudio/SDL_coreaudio.m
@@ -891,7 +891,7 @@ static int prepare_audioqueue(_THIS)
 
     /* Make sure we can feed the device a minimum amount of time */
     MINIMUM_AUDIO_BUFFER_TIME_MS = 15.0;
-#if defined(__IOS__)
+#ifdef __IOS__
     if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_7_1) {
         /* Older iOS hardware, use 40 ms as a minimum time */
         MINIMUM_AUDIO_BUFFER_TIME_MS = 40.0;

--- a/src/audio/directsound/SDL_directsound.c
+++ b/src/audio/directsound/SDL_directsound.c
@@ -186,14 +186,14 @@ static BOOL CALLBACK FindAllDevs(LPGUID guid, LPCWSTR desc, LPCWSTR module, LPVO
 
 static void DSOUND_DetectDevices(void)
 {
-#if defined(HAVE_MMDEVICEAPI_H)
+#ifdef HAVE_MMDEVICEAPI_H
     if (SupportsIMMDevice) {
         SDL_IMMDevice_EnumerateEndpoints(SDL_TRUE);
     } else {
 #endif /* HAVE_MMDEVICEAPI_H */
         pDirectSoundCaptureEnumerateW(FindAllDevs, (void *)((size_t)1));
         pDirectSoundEnumerateW(FindAllDevs, (void *)((size_t)0));
-#if defined(HAVE_MMDEVICEAPI_H)
+#ifdef HAVE_MMDEVICEAPI_H
     }
 #endif /* HAVE_MMDEVICEAPI_H*/
 }
@@ -609,7 +609,7 @@ static int DSOUND_OpenDevice(_THIS, const char *devname)
 
 static void DSOUND_Deinitialize(void)
 {
-#if defined(HAVE_MMDEVICEAPI_H)
+#ifdef HAVE_MMDEVICEAPI_H
     if (SupportsIMMDevice) {
         SDL_IMMDevice_Quit();
         SupportsIMMDevice = SDL_FALSE;
@@ -624,7 +624,7 @@ static SDL_bool DSOUND_Init(SDL_AudioDriverImpl *impl)
         return SDL_FALSE;
     }
 
-#if defined(HAVE_MMDEVICEAPI_H)
+#ifdef HAVE_MMDEVICEAPI_H
     SupportsIMMDevice = !(SDL_IMMDevice_Init() < 0);
 #endif /* HAVE_MMDEVICEAPI_H */
 

--- a/src/audio/netbsd/SDL_netbsdaudio.c
+++ b/src/audio/netbsd/SDL_netbsdaudio.c
@@ -20,7 +20,7 @@
 */
 #include "SDL_internal.h"
 
-#if defined(SDL_AUDIO_DRIVER_NETBSD)
+#ifdef SDL_AUDIO_DRIVER_NETBSD
 
 /*
  * Driver for native NetBSD audio(4).

--- a/src/core/haiku/SDL_BeApp.cc
+++ b/src/core/haiku/SDL_BeApp.cc
@@ -20,7 +20,7 @@
 */
 #include "SDL_internal.h"
 
-#if defined(__HAIKU__)
+#ifdef __HAIKU__
 
 /* Handle the BeApp specific portions of the application */
 

--- a/src/core/linux/SDL_fcitx.c
+++ b/src/core/linux/SDL_fcitx.c
@@ -61,7 +61,7 @@ static char *GetAppName(void)
     char linkfile[1024];
     int linksize;
 
-#if defined(__LINUX__)
+#ifdef __LINUX__
     (void)SDL_snprintf(procfile, sizeof(procfile), "/proc/%d/exe", getpid());
 #elif defined(__FREEBSD__)
     (void)SDL_snprintf(procfile, sizeof(procfile), "/proc/%d/file", getpid());

--- a/src/core/openbsd/SDL_wscons_kbd.c
+++ b/src/core/openbsd/SDL_wscons_kbd.c
@@ -319,7 +319,7 @@ static struct wscons_keycode_to_SDL
     { KS_f18, SDL_SCANCODE_F18 },
     { KS_f19, SDL_SCANCODE_F19 },
     { KS_f20, SDL_SCANCODE_F20 },
-#if !defined(__NetBSD__)
+#ifndef __NetBSD__
     { KS_f21, SDL_SCANCODE_F21 },
     { KS_f22, SDL_SCANCODE_F22 },
     { KS_f23, SDL_SCANCODE_F23 },

--- a/src/core/windows/SDL_windows.c
+++ b/src/core/windows/SDL_windows.c
@@ -25,7 +25,7 @@
 #include "SDL_windows.h"
 
 #include <objbase.h> /* for CoInitialize/CoUninitialize (Win32 only) */
-#if defined(HAVE_ROAPI_H)
+#ifdef HAVE_ROAPI_H
 #include <roapi.h> /* For RoInitialize/RoUninitialize (Win32 only) */
 #else
 typedef enum RO_INIT_TYPE
@@ -411,7 +411,7 @@ SDL_RunApp(int _argc, char* _argv[], SDL_main_func mainFunction, void * reserved
 /*
  * Public APIs
  */
-#if !defined(SDL_VIDEO_DRIVER_WINDOWS)
+#ifndef SDL_VIDEO_DRIVER_WINDOWS
 
 #if defined(__WIN32__) || defined(__GDK__)
 int SDL_RegisterApp(const char *name, Uint32 style, void *hInst)

--- a/src/core/windows/SDL_windows.h
+++ b/src/core/windows/SDL_windows.h
@@ -24,7 +24,7 @@
 #ifndef _INCLUDED_WINDOWS_H
 #define _INCLUDED_WINDOWS_H
 
-#if defined(__WIN32__)
+#ifdef __WIN32__
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN 1
 #endif
@@ -36,7 +36,7 @@
 #endif
 #undef WINVER
 #undef _WIN32_WINNT
-#if defined(SDL_VIDEO_RENDER_D3D12)
+#ifdef SDL_VIDEO_RENDER_D3D12
 #define _WIN32_WINNT 0xA00 /* For D3D12, 0xA00 is required */
 #elif defined(HAVE_SHELLSCALINGAPI_H)
 #define _WIN32_WINNT 0x603 /* For DPI support */
@@ -118,7 +118,7 @@ extern int WIN_SetErrorFromHRESULT(const char *prefix, HRESULT hr);
 /* Sets an error message based on GetLastError(). Always return -1. */
 extern int WIN_SetError(const char *prefix);
 
-#if !defined(__WINRT__)
+#ifndef __WINRT__
 /* Load a function from combase.dll */
 void *WIN_LoadComBaseFunction(const char *name);
 #endif

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -439,12 +439,12 @@ static int CPU_haveNEON(void)
 {
 /* The way you detect NEON is a privileged instruction on ARM, so you have
    query the OS kernel in a platform-specific way. :/ */
-#if defined(SDL_CPUINFO_DISABLED)
+#ifdef SDL_CPUINFO_DISABLED
     return 0; /* disabled */
 #elif (defined(__WINDOWS__) || defined(__WINRT__) || defined(__GDK__)) && (defined(_M_ARM) || defined(_M_ARM64))
 /* Visual Studio, for ARM, doesn't define __ARM_ARCH. Handle this first. */
 /* Seems to have been removed */
-#if !defined(PF_ARM_NEON_INSTRUCTIONS_AVAILABLE)
+#ifndef PF_ARM_NEON_INSTRUCTIONS_AVAILABLE
 #define PF_ARM_NEON_INSTRUCTIONS_AVAILABLE 19
 #endif
     /* All WinRT ARM devices are required to support NEON, but just in case. */
@@ -519,38 +519,38 @@ static int CPU_readCPUCFG(void)
 #define CPU_haveLSX()  (CPU_readCPUCFG() & CPU_CFG2_LSX)
 #define CPU_haveLASX() (CPU_readCPUCFG() & CPU_CFG2_LASX)
 
-#if defined(__e2k__)
-#if defined(__MMX__)
+#ifdef __e2k__
+#ifdef __MMX__
 #define CPU_haveMMX() (1)
 #else
 #define CPU_haveMMX() (0)
 #endif
-#if defined(__SSE__)
+#ifdef __SSE__
 #define CPU_haveSSE() (1)
 #else
 #define CPU_haveSSE() (0)
 #endif
-#if defined(__SSE2__)
+#ifdef __SSE2__
 #define CPU_haveSSE2() (1)
 #else
 #define CPU_haveSSE2() (0)
 #endif
-#if defined(__SSE3__)
+#ifdef __SSE3__
 #define CPU_haveSSE3() (1)
 #else
 #define CPU_haveSSE3() (0)
 #endif
-#if defined(__SSE4_1__)
+#ifdef __SSE4_1__
 #define CPU_haveSSE41() (1)
 #else
 #define CPU_haveSSE41() (0)
 #endif
-#if defined(__SSE4_2__)
+#ifdef __SSE4_2__
 #define CPU_haveSSE42() (1)
 #else
 #define CPU_haveSSE42() (0)
 #endif
-#if defined(__AVX__)
+#ifdef __AVX__
 #define CPU_haveAVX() (1)
 #else
 #define CPU_haveAVX() (0)
@@ -565,11 +565,11 @@ static int CPU_readCPUCFG(void)
 #define CPU_haveAVX()   (CPU_OSSavesYMM && (CPU_CPUIDFeatures[2] & 0x10000000))
 #endif
 
-#if defined(__e2k__)
+#ifdef __e2k__
 inline int
 CPU_haveAVX2(void)
 {
-#if defined(__AVX2__)
+#ifdef __AVX2__
     return 1;
 #else
     return 0;
@@ -591,7 +591,7 @@ static int CPU_haveAVX2(void)
 }
 #endif
 
-#if defined(__e2k__)
+#ifdef __e2k__
 inline int
 CPU_haveAVX512F(void)
 {
@@ -646,7 +646,7 @@ int SDL_GetCPUCount(void)
     return SDL_CPUCount;
 }
 
-#if defined(__e2k__)
+#ifdef __e2k__
 inline const char *
 SDL_GetCPUType(void)
 {
@@ -704,7 +704,7 @@ static const char *SDL_GetCPUType(void)
 
 #if 0
 !!! FIXME: Not used at the moment. */
-#if defined(__e2k__)
+#ifdef __e2k__
 inline const char *
 SDL_GetCPUName(void)
 {

--- a/src/dynapi/SDL_dynapi.c
+++ b/src/dynapi/SDL_dynapi.c
@@ -425,7 +425,7 @@ static void dynapi_warn(const char *msg)
 extern "C" {
 #endif
 extern SDL_NORETURN void SDL_ExitProcess(int exitcode);
-#if defined(__WATCOMC__)
+#ifdef __WATCOMC__
 #pragma aux SDL_ExitProcess aborts;
 #endif
 #ifdef __cplusplus

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -78,7 +78,7 @@ SDL_DYNAPI_PROC(ID3D11Device*,SDL_GetRenderD3D11Device,(SDL_Renderer *a),(a),ret
 SDL_DYNAPI_PROC(IDirect3DDevice9*,SDL_GetRenderD3D9Device,(SDL_Renderer *a),(a),return)
 #endif
 
-#if defined(__GDK__)
+#ifdef __GDK__
 SDL_DYNAPI_PROC(int,SDL_GDKGetTaskQueue,(XTaskQueueHandle *a),(a),return)
 SDL_DYNAPI_PROC(void,SDL_GDKSuspendComplete,(void),(),)
 #endif

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -105,7 +105,7 @@ static void SDLCALL SDL_TouchMouseEventsChanged(void *userdata, const char *name
     mouse->touch_mouse_events = SDL_GetStringBoolean(hint, SDL_TRUE);
 }
 
-#if defined(__vita__)
+#ifdef __vita__
 static void SDLCALL SDL_VitaTouchMouseDeviceChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
 {
     SDL_Mouse *mouse = (SDL_Mouse *)userdata;
@@ -186,7 +186,7 @@ int SDL_InitMouse(void)
     SDL_AddHintCallback(SDL_HINT_TOUCH_MOUSE_EVENTS,
                         SDL_TouchMouseEventsChanged, mouse);
 
-#if defined(__vita__)
+#ifdef __vita__
     SDL_AddHintCallback(SDL_HINT_VITA_TOUCH_MOUSE_DEVICE,
                         SDL_VitaTouchMouseDeviceChanged, mouse);
 #endif

--- a/src/events/SDL_mouse_c.h
+++ b/src/events/SDL_mouse_c.h
@@ -98,7 +98,7 @@ typedef struct
     SDL_bool touch_mouse_events;
     SDL_bool mouse_touch_events;
     SDL_bool was_touch_mouse_events; /* Was a touch-mouse event pending? */
-#if defined(__vita__)
+#ifdef __vita__
     Uint8 vita_touch_mouse_device;
 #endif
     SDL_bool auto_capture;

--- a/src/events/SDL_touch.c
+++ b/src/events/SDL_touch.c
@@ -250,7 +250,7 @@ int SDL_SendTouch(Uint64 timestamp, SDL_TouchID id, SDL_FingerID fingerid, SDL_W
     /* SDL_HINT_TOUCH_MOUSE_EVENTS: controlling whether touch events should generate synthetic mouse events */
     /* SDL_HINT_VITA_TOUCH_MOUSE_DEVICE: controlling which touchpad should generate synthetic mouse events, PSVita-only */
     {
-#if defined(__vita__)
+#ifdef __vita__
         if (mouse->touch_mouse_events && ((mouse->vita_touch_mouse_device == id) || (mouse->vita_touch_mouse_device == 2))) {
 #else
         if (mouse->touch_mouse_events) {

--- a/src/file/SDL_rwops.c
+++ b/src/file/SDL_rwops.c
@@ -508,7 +508,7 @@ SDL_RWFromFile(const char *file, const char *mode)
         SDL_SetError("SDL_RWFromFile(): No file or no mode specified");
         return NULL;
     }
-#if defined(__ANDROID__)
+#ifdef __ANDROID__
 #ifdef HAVE_STDIO_H
     /* Try to open the file on the filesystem first */
     if (*file == '/') {

--- a/src/filesystem/ps2/SDL_sysfilesystem.c
+++ b/src/filesystem/ps2/SDL_sysfilesystem.c
@@ -23,7 +23,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#if defined(SDL_FILESYSTEM_PS2)
+#ifdef SDL_FILESYSTEM_PS2
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /* System dependent filesystem routines                                */

--- a/src/filesystem/psp/SDL_sysfilesystem.c
+++ b/src/filesystem/psp/SDL_sysfilesystem.c
@@ -23,7 +23,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#if defined(SDL_FILESYSTEM_PSP)
+#ifdef SDL_FILESYSTEM_PSP
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /* System dependent filesystem routines                                */

--- a/src/filesystem/unix/SDL_sysfilesystem.c
+++ b/src/filesystem/unix/SDL_sysfilesystem.c
@@ -68,7 +68,7 @@ static char *readSymLink(const char *path)
     return NULL;
 }
 
-#if defined(__OPENBSD__)
+#ifdef __OPENBSD__
 static char *search_path_for_binary(const char *bin)
 {
     char *envr = SDL_getenv("PATH");
@@ -124,7 +124,7 @@ SDL_GetBasePath(void)
 {
     char *retval = NULL;
 
-#if defined(__FREEBSD__)
+#ifdef __FREEBSD__
     char fullpath[PATH_MAX];
     size_t buflen = sizeof(fullpath);
     const int mib[] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
@@ -136,7 +136,7 @@ SDL_GetBasePath(void)
         }
     }
 #endif
-#if defined(__OPENBSD__)
+#ifdef __OPENBSD__
     /* Please note that this will fail if the process was launched with a relative path and $PWD + the cwd have changed, or argv is altered. So don't do that. Or add a new sysctl to OpenBSD. */
     char **cmdline;
     size_t len;
@@ -201,7 +201,7 @@ SDL_GetBasePath(void)
         /* !!! FIXME: after 2.0.6 ships, let's delete this code and just
                       use the /proc/%llu version. There's no reason to have
                       two copies of this plus all the #ifdefs. --ryan. */
-#if defined(__FREEBSD__)
+#ifdef __FREEBSD__
         retval = readSymLink("/proc/curproc/file");
 #elif defined(__NETBSD__)
         retval = readSymLink("/proc/curproc/exe");
@@ -222,7 +222,7 @@ SDL_GetBasePath(void)
 #endif
     }
 
-#if defined(__SOLARIS__)  /* try this as a fallback if /proc didn't pan out */
+#ifdef __SOLARIS__  /* try this as a fallback if /proc didn't pan out */
     if (!retval) {
         const char *path = getexecname();
         if ((path != NULL) && (path[0] == '/')) { /* must be absolute path... */

--- a/src/hidapi/SDL_hidapi.c
+++ b/src/hidapi/SDL_hidapi.c
@@ -37,7 +37,7 @@
 #include "../core/windows/SDL_windows.h"
 #endif
 
-#if defined(__MACOS__)
+#ifdef __MACOS__
 #include <CoreFoundation/CoreFoundation.h>
 #include <mach/mach.h>
 #include <IOKit/IOKitLib.h>
@@ -68,7 +68,7 @@
 #include <unistd.h>
 #endif
 
-#if defined(SDL_USE_LIBUDEV)
+#ifdef SDL_USE_LIBUDEV
 typedef enum
 {
     ENUMERATION_UNSET,
@@ -79,11 +79,11 @@ typedef enum
 static LinuxEnumerationMethod linux_enumeration_method = ENUMERATION_UNSET;
 #endif
 
-#if defined(HAVE_INOTIFY)
+#ifdef HAVE_INOTIFY
 static int inotify_fd = -1;
 #endif
 
-#if defined(SDL_USE_LIBUDEV)
+#ifdef SDL_USE_LIBUDEV
 static const SDL_UDEV_Symbols *usyms = NULL;
 #endif
 
@@ -102,12 +102,12 @@ static struct
     double m_flLastWin32MessageCheck;
 #endif
 
-#if defined(__MACOS__)
+#ifdef __MACOS__
     IONotificationPortRef m_notificationPort;
     mach_port_t m_notificationMach;
 #endif
 
-#if defined(SDL_USE_LIBUDEV)
+#ifdef SDL_USE_LIBUDEV
     struct udev *m_pUdev;
     struct udev_monitor *m_pUdevMonitor;
     int m_nUdevFd;
@@ -162,7 +162,7 @@ static LRESULT CALLBACK ControllerWndProc(HWND hwnd, UINT message, WPARAM wParam
 }
 #endif /* defined(__WIN32__) || defined(__WINGDK__) */
 
-#if defined(__MACOS__)
+#ifdef __MACOS__
 static void CallbackIOServiceFunc(void *context, io_iterator_t portIterator)
 {
     /* Must drain the iterator, or we won't receive new notifications */
@@ -255,7 +255,7 @@ HIDAPI_InitializeDiscovery()
     }
 #endif /* defined(__WIN32__) || defined(__WINGDK__) */
 
-#if defined(__MACOS__)
+#ifdef __MACOS__
     SDL_HIDAPI_discovery.m_notificationPort = IONotificationPortCreate(kIOMainPortDefault);
     if (SDL_HIDAPI_discovery.m_notificationPort) {
         {
@@ -307,7 +307,7 @@ HIDAPI_InitializeDiscovery()
 
 #endif /* __MACOS__ */
 
-#if defined(SDL_USE_LIBUDEV)
+#ifdef SDL_USE_LIBUDEV
     if (linux_enumeration_method == ENUMERATION_LIBUDEV) {
         SDL_HIDAPI_discovery.m_pUdev = NULL;
         SDL_HIDAPI_discovery.m_pUdevMonitor = NULL;
@@ -328,7 +328,7 @@ HIDAPI_InitializeDiscovery()
     } else
 #endif /* SDL_USE_LIBUDEV */
     {
-#if defined(HAVE_INOTIFY)
+#ifdef HAVE_INOTIFY
         inotify_fd = SDL_inotify_init1();
 
         if (inotify_fd < 0) {
@@ -390,7 +390,7 @@ HIDAPI_UpdateDiscovery()
 #endif
 #endif /* defined(__WIN32__) || defined(__WINGDK__) */
 
-#if defined(__MACOS__)
+#ifdef __MACOS__
     if (SDL_HIDAPI_discovery.m_notificationPort) {
         struct
         {
@@ -403,7 +403,7 @@ HIDAPI_UpdateDiscovery()
     }
 #endif
 
-#if defined(SDL_USE_LIBUDEV)
+#ifdef SDL_USE_LIBUDEV
     if (linux_enumeration_method == ENUMERATION_LIBUDEV) {
         if (SDL_HIDAPI_discovery.m_nUdevFd >= 0) {
             /* Drain all notification events.
@@ -435,7 +435,7 @@ HIDAPI_UpdateDiscovery()
     } else
 #endif /* SDL_USE_LIBUDEV */
     {
-#if defined(HAVE_INOTIFY)
+#ifdef HAVE_INOTIFY
         if (inotify_fd >= 0) {
             union
             {
@@ -495,13 +495,13 @@ HIDAPI_ShutdownDiscovery()
     UnregisterClassA(SDL_HIDAPI_discovery.m_wndClass.lpszClassName, SDL_HIDAPI_discovery.m_wndClass.hInstance);
 #endif
 
-#if defined(__MACOS__)
+#ifdef __MACOS__
     if (SDL_HIDAPI_discovery.m_notificationPort) {
         IONotificationPortDestroy(SDL_HIDAPI_discovery.m_notificationPort);
     }
 #endif
 
-#if defined(SDL_USE_LIBUDEV)
+#ifdef SDL_USE_LIBUDEV
     if (linux_enumeration_method == ENUMERATION_LIBUDEV) {
         if (usyms) {
             if (SDL_HIDAPI_discovery.m_pUdevMonitor) {
@@ -516,7 +516,7 @@ HIDAPI_ShutdownDiscovery()
     } else
 #endif /* SDL_USE_LIBUDEV */
     {
-#if defined(HAVE_INOTIFY)
+#ifdef HAVE_INOTIFY
         if (inotify_fd >= 0) {
             close(inotify_fd);
             inotify_fd = -1;
@@ -1048,7 +1048,7 @@ int SDL_hid_init(void)
         return 0;
     }
 
-#if defined(SDL_USE_LIBUDEV)
+#ifdef SDL_USE_LIBUDEV
     if (SDL_getenv("SDL_HIDAPI_JOYSTICK_DISABLE_UDEV") != NULL) {
         SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
                      "udev disabled by SDL_HIDAPI_JOYSTICK_DISABLE_UDEV");
@@ -1375,7 +1375,7 @@ SDL_hid_device *SDL_hid_open(unsigned short vendor_id, unsigned short product_id
         return NULL;
     }
 
-#if defined(HAVE_PLATFORM_BACKEND)
+#ifdef HAVE_PLATFORM_BACKEND
     if (udev_ctx) {
         pDevice = PLATFORM_hid_open(vendor_id, product_id, serial_number);
         if (pDevice != NULL) {
@@ -1414,7 +1414,7 @@ SDL_hid_device *SDL_hid_open_path(const char *path, int bExclusive /* = false */
         return NULL;
     }
 
-#if defined(HAVE_PLATFORM_BACKEND)
+#ifdef HAVE_PLATFORM_BACKEND
     if (udev_ctx) {
         pDevice = PLATFORM_hid_open_path(path, bExclusive);
         if (pDevice != NULL) {

--- a/src/hidapi/android/hid.h
+++ b/src/hidapi/android/hid.h
@@ -26,13 +26,13 @@
 
 #include <jni.h>
 
-#if defined(__cplusplus)
+#ifdef __cplusplus
 extern "C" {
 #endif
 
 extern JNINativeMethod HIDDeviceManager_tab[8];
 
-#if defined(__cplusplus)
+#ifdef __cplusplus
 }
 #endif
 

--- a/src/hidapi/libusb/hid.c
+++ b/src/hidapi/libusb/hid.c
@@ -421,7 +421,7 @@ static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
 	int len;
 	wchar_t *str = NULL;
 
-#if !defined(NO_ICONV)
+#ifndef NO_ICONV
 	wchar_t wbuf[256];
 	SDL_iconv_t ic;
 	size_t inbytes;
@@ -448,7 +448,7 @@ static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
 	if (len < 0)
 		return NULL;
 
-#if defined(NO_ICONV) /* original hidapi code for NO_ICONV : */
+#ifdef NO_ICONV /* original hidapi code for NO_ICONV : */
 
 	/* Bionic does not have wchar_t iconv support, so it
 	   has to be done manually.  The following code will only work for

--- a/src/hidapi/mac/hid.c
+++ b/src/hidapi/mac/hid.c
@@ -556,7 +556,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 		}
 
 #if 0 // Prefer direct HID support as that has extended functionality
-#if defined(SDL_JOYSTICK_MFI)
+#ifdef SDL_JOYSTICK_MFI
 		// We want to prefer Game Controller support where available,
 		// as Apple will likely be requiring that for supported devices.
 		extern SDL_bool IOS_SupportedHIDDevice(IOHIDDeviceRef device);

--- a/src/hidapi/windows/hid.c
+++ b/src/hidapi/windows/hid.c
@@ -154,7 +154,7 @@ static void free_library_handles(void)
 	cfgmgr32_lib_handle = NULL;
 }
 
-#if defined(__GNUC__)
+#ifdef __GNUC__
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wcast-function-type"
 #endif
@@ -202,7 +202,7 @@ err:
 	free_library_handles();
 	return -1;
 }
-#if defined(__GNUC__)
+#ifdef __GNUC__
 # pragma GCC diagnostic pop
 #endif
 

--- a/src/joystick/SDL_gamepad.c
+++ b/src/joystick/SDL_gamepad.c
@@ -34,7 +34,7 @@
 #include "../events/SDL_events_c.h"
 #endif
 
-#if defined(__ANDROID__)
+#ifdef __ANDROID__
 #endif
 
 /* Many gamepads turn the center button into an instantaneous button press */
@@ -1845,7 +1845,7 @@ static SDL_bool SDL_GetGamepadMappingFilePath(char *path, size_t size)
         return SDL_strlcpy(path, hint, size) < size;
     }
 
-#if defined(__ANDROID__)
+#ifdef __ANDROID__
     return SDL_snprintf(path, size, "%s/gamepad_map.txt", SDL_AndroidGetInternalStoragePath()) < size;
 #else
     return SDL_FALSE;
@@ -2055,7 +2055,7 @@ SDL_bool SDL_IsGamepad(SDL_JoystickID instance_id)
     return retval;
 }
 
-#if defined(__LINUX__)
+#ifdef __LINUX__
 static SDL_bool SDL_endswith(const char *string, const char *suffix)
 {
     size_t string_length = string ? SDL_strlen(string) : 0;
@@ -2081,7 +2081,7 @@ SDL_bool SDL_ShouldIgnoreGamepad(const char *name, SDL_JoystickGUID guid)
     Uint16 version;
     Uint32 vidpid;
 
-#if defined(__LINUX__)
+#ifdef __LINUX__
     if (SDL_endswith(name, " Motion Sensors")) {
         /* Don't treat the PS3 and PS4 motion controls as a separate gamepad */
         return SDL_TRUE;
@@ -2115,7 +2115,7 @@ SDL_bool SDL_ShouldIgnoreGamepad(const char *name, SDL_JoystickGUID guid)
         /* We shouldn't ignore Steam's virtual gamepad since it's using the hints to filter out the real gamepads so it can remap input for the virtual gamepad */
         /* https://partner.steamgames.com/doc/features/steam_gamepad/steam_input_gamepad_emulation_bestpractices */
         SDL_bool bSteamVirtualGamepad = SDL_FALSE;
-#if defined(__LINUX__)
+#ifdef __LINUX__
         bSteamVirtualGamepad = (vendor == USB_VENDOR_VALVE && product == USB_PRODUCT_STEAM_VIRTUAL_GAMEPAD);
 #elif defined(__MACOS__)
         bSteamVirtualGamepad = (vendor == USB_VENDOR_MICROSOFT && product == USB_PRODUCT_XBOX360_WIRED_CONTROLLER && version == 1);
@@ -3190,7 +3190,7 @@ void SDL_GamepadHandleDelayedGuideButton(SDL_Joystick *joystick)
 
 const char *SDL_GetGamepadAppleSFSymbolsNameForButton(SDL_Gamepad *gamepad, SDL_GamepadButton button)
 {
-#if defined(SDL_JOYSTICK_MFI)
+#ifdef SDL_JOYSTICK_MFI
     const char *IOS_GetAppleSFSymbolsNameForButton(SDL_Gamepad *gamepad, SDL_GamepadButton button);
     const char *retval;
 
@@ -3210,7 +3210,7 @@ const char *SDL_GetGamepadAppleSFSymbolsNameForButton(SDL_Gamepad *gamepad, SDL_
 
 const char *SDL_GetGamepadAppleSFSymbolsNameForAxis(SDL_Gamepad *gamepad, SDL_GamepadAxis axis)
 {
-#if defined(SDL_JOYSTICK_MFI)
+#ifdef SDL_JOYSTICK_MFI
     const char *IOS_GetAppleSFSymbolsNameForAxis(SDL_Gamepad *gamepad, SDL_GamepadAxis axis);
     const char *retval;
 

--- a/src/joystick/SDL_gamepad_db.h
+++ b/src/joystick/SDL_gamepad_db.h
@@ -363,7 +363,7 @@ static const char *s_GamepadMappings[] = {
     "030000004f04000003d0000000000000,run'n'drive,a:b1,b:b2,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b7,leftshoulder:a3,leftstick:b10,lefttrigger:b4,leftx:a0,lefty:a1,rightshoulder:a4,rightstick:b11,righttrigger:b5,rightx:a2,righty:a5,start:b9,x:b0,y:b3,",
     "03000000101c0000171c000000000000,uRage Gamepad,a:b2,b:b1,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b4,leftstick:b10,lefttrigger:b6,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:b7,rightx:a2,righty:a3,start:b9,x:b3,y:b0,",
 #endif
-#if defined(__MACOS__)
+#ifdef __MACOS__
     "03000000c82d00000090000001000000,8BitDo FC30 Pro,a:b0,b:b1,back:b10,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b6,leftstick:b13,lefttrigger:a4,leftx:a0,lefty:a1,rightshoulder:b7,rightstick:b14,righttrigger:a5,rightx:a2,righty:a3,start:b11,x:b3,y:b4,hint:SDL_GAMECONTROLLER_USE_BUTTON_LABELS:=1,",
     "03000000c82d00000090000001000000,8BitDo FC30 Pro,a:b1,b:b0,back:b10,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b6,leftstick:b13,lefttrigger:a4,leftx:a0,lefty:a1,rightshoulder:b7,rightstick:b14,righttrigger:a5,rightx:a2,righty:a3,start:b11,x:b4,y:b3,hint:!SDL_GAMECONTROLLER_USE_BUTTON_LABELS:=1,",
     "03000000c82d00001038000000010000,8BitDo FC30 Pro,a:b0,b:b1,back:b10,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftshoulder:b6,leftstick:b13,lefttrigger:a5,leftx:a0,lefty:a1,rightshoulder:b7,rightstick:b14,righttrigger:a4,rightx:a2,righty:a3,start:b11,x:b3,y:b4,hint:SDL_GAMECONTROLLER_USE_BUTTON_LABELS:=1,",
@@ -878,12 +878,12 @@ static const char *s_GamepadMappings[] = {
     "030000009b2800008000000020020000,raphnet technologies 1-player WUSBMote v2.2,a:b1,b:b4,back:b2,dpdown:b13,dpleft:b14,dpright:b15,dpup:b12,leftshoulder:b6,rightshoulder:b7,start:b3,x:b0,y:b5,",
     "030000009b2800000300000001010000,raphnet.net 4nes4snes v1.5,a:b0,b:b4,back:b2,leftshoulder:b6,leftx:a0,lefty:a1,rightshoulder:b7,start:b3,x:b1,y:b5,",
 #endif
-#if defined(__OpenBSD__)
+#ifdef __OpenBSD__
     "030000004c050000c405000000010000,PS4 Controller,a:b1,b:b2,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b12,leftshoulder:b4,leftstick:b10,lefttrigger:a3,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:a4,rightx:a2,righty:a5,start:b9,x:b0,y:b3,",
     "030000004c050000e60c000000010000,PS5 Controller,a:b1,b:b2,back:b8,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b12,leftshoulder:b4,leftstick:b10,lefttrigger:a3,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b11,righttrigger:a4,rightx:a2,righty:a5,start:b9,x:b0,y:b3,",
     "030000005e0400008e02000010010000,Xbox 360 Controller,a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b10,leftshoulder:b4,leftstick:b8,lefttrigger:a2,leftx:a0,lefty:a1~,rightshoulder:b5,rightstick:b9,righttrigger:a5,rightx:a3,righty:a4~,start:b7,x:b2,y:b3,",
 #endif
-#if defined(__ANDROID__)
+#ifdef __ANDROID__
     "05000000c82d000006500000ffff3f00,8BitDo M30 Gamepad,a:b0,b:b1,back:b4,guide:b17,leftshoulder:b9,lefttrigger:a5,leftx:a0,lefty:a1,rightshoulder:b10,righttrigger:a4,start:b6,x:b2,y:b3,hint:SDL_GAMECONTROLLER_USE_BUTTON_LABELS:=1,",
     "05000000c82d000006500000ffff3f00,8BitDo M30 Gamepad,a:b1,b:b0,back:b4,guide:b17,leftshoulder:b9,lefttrigger:a5,leftx:a0,lefty:a1,rightshoulder:b10,righttrigger:a4,start:b6,x:b3,y:b2,hint:!SDL_GAMECONTROLLER_USE_BUTTON_LABELS:=1,",
     "05000000c82d000051060000ffff3f00,8BitDo M30 Gamepad,a:b0,b:b1,back:b4,guide:b17,leftshoulder:b9,lefttrigger:a4,leftx:a0,lefty:a1,rightshoulder:b10,righttrigger:a5,start:b6,x:b2,y:b3,hint:SDL_GAMECONTROLLER_USE_BUTTON_LABELS:=1,",

--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -58,10 +58,10 @@ static SDL_JoystickDriver *SDL_joystick_drivers[] = {
 #if defined(SDL_JOYSTICK_DINPUT) || defined(SDL_JOYSTICK_XINPUT) /* Before WGI driver, as WGI wants to check if this driver is handling things */
     &SDL_WINDOWS_JoystickDriver,
 #endif
-#if defined(SDL_JOYSTICK_WGI)
+#ifdef SDL_JOYSTICK_WGI
     &SDL_WGI_JoystickDriver,
 #endif
-#if defined(SDL_JOYSTICK_WINMM)
+#ifdef SDL_JOYSTICK_WINMM
     &SDL_WINMM_JoystickDriver,
 #endif
 #ifdef SDL_JOYSTICK_LINUX
@@ -631,7 +631,7 @@ SDL_JoystickID SDL_AttachVirtualJoystick(SDL_JoystickType type, int naxes, int n
 
 SDL_JoystickID SDL_AttachVirtualJoystickEx(const SDL_VirtualJoystickDesc *desc)
 {
-#if defined(SDL_JOYSTICK_VIRTUAL)
+#ifdef SDL_JOYSTICK_VIRTUAL
     SDL_JoystickID retval;
 
     SDL_LockJoysticks();
@@ -645,7 +645,7 @@ SDL_JoystickID SDL_AttachVirtualJoystickEx(const SDL_VirtualJoystickDesc *desc)
 
 int SDL_DetachVirtualJoystick(SDL_JoystickID instance_id)
 {
-#if defined(SDL_JOYSTICK_VIRTUAL)
+#ifdef SDL_JOYSTICK_VIRTUAL
     int retval;
 
     SDL_LockJoysticks();
@@ -659,7 +659,7 @@ int SDL_DetachVirtualJoystick(SDL_JoystickID instance_id)
 
 SDL_bool SDL_IsJoystickVirtual(SDL_JoystickID instance_id)
 {
-#if defined(SDL_JOYSTICK_VIRTUAL)
+#ifdef SDL_JOYSTICK_VIRTUAL
     SDL_JoystickDriver *driver;
     int device_index;
     SDL_bool is_virtual = SDL_FALSE;
@@ -686,7 +686,7 @@ int SDL_SetJoystickVirtualAxis(SDL_Joystick *joystick, int axis, Sint16 value)
     {
         CHECK_JOYSTICK_MAGIC(joystick, -1);
 
-#if defined(SDL_JOYSTICK_VIRTUAL)
+#ifdef SDL_JOYSTICK_VIRTUAL
         retval = SDL_SetJoystickVirtualAxisInner(joystick, axis, value);
 #else
         retval = SDL_SetError("SDL not built with virtual-joystick support");
@@ -705,7 +705,7 @@ int SDL_SetJoystickVirtualButton(SDL_Joystick *joystick, int button, Uint8 value
     {
         CHECK_JOYSTICK_MAGIC(joystick, -1);
 
-#if defined(SDL_JOYSTICK_VIRTUAL)
+#ifdef SDL_JOYSTICK_VIRTUAL
         retval = SDL_SetJoystickVirtualButtonInner(joystick, button, value);
 #else
         retval = SDL_SetError("SDL not built with virtual-joystick support");
@@ -724,7 +724,7 @@ int SDL_SetJoystickVirtualHat(SDL_Joystick *joystick, int hat, Uint8 value)
     {
         CHECK_JOYSTICK_MAGIC(joystick, -1);
 
-#if defined(SDL_JOYSTICK_VIRTUAL)
+#ifdef SDL_JOYSTICK_VIRTUAL
         retval = SDL_SetJoystickVirtualHatInner(joystick, hat, value);
 #else
         retval = SDL_SetError("SDL not built with virtual-joystick support");

--- a/src/joystick/apple/SDL_mfijoystick.m
+++ b/src/joystick/apple/SDL_mfijoystick.m
@@ -37,7 +37,7 @@
 #import <CoreMotion/CoreMotion.h>
 #endif
 
-#if defined(__MACOS__)
+#ifdef __MACOS__
 #include <IOKit/hid/IOHIDManager.h>
 #include <AppKit/NSApplication.h>
 #ifndef NSAppKitVersionNumber10_15
@@ -660,7 +660,7 @@ static void SDLCALL SDL_AppleTVRemoteRotationHintChanged(void *udata, const char
 
 static int IOS_JoystickInit(void)
 {
-#if defined(__MACOS__)
+#ifdef __MACOS__
 #if SDL_HAS_BUILTIN(__builtin_available)
     if (@available(macOS 10.16, *)) {
         /* Continue with initialization on macOS 11+ */

--- a/src/joystick/bsd/SDL_bsdjoystick.c
+++ b/src/joystick/bsd/SDL_bsdjoystick.c
@@ -40,7 +40,7 @@
 #define __FreeBSD_kernel_version __FreeBSD_version
 #endif
 
-#if defined(HAVE_USB_H)
+#ifdef HAVE_USB_H
 #include <usb.h>
 #endif
 #ifdef __DragonFly__
@@ -51,7 +51,7 @@
 #include <dev/usb/usbhid.h>
 #endif
 
-#if defined(HAVE_USBHID_H)
+#ifdef HAVE_USBHID_H
 #include <usbhid.h>
 #elif defined(HAVE_LIBUSB_H)
 #include <libusb.h>

--- a/src/joystick/darwin/SDL_iokitjoystick.c
+++ b/src/joystick/darwin/SDL_iokitjoystick.c
@@ -499,7 +499,7 @@ static SDL_bool JoystickAlreadyKnown(IOHIDDeviceRef ioHIDDeviceObject)
 {
     recDevice *i;
 
-#if defined(SDL_JOYSTICK_MFI)
+#ifdef SDL_JOYSTICK_MFI
     extern SDL_bool IOS_SupportedHIDDevice(IOHIDDeviceRef device);
     if (IOS_SupportedHIDDevice(ioHIDDeviceObject)) {
         return SDL_TRUE;

--- a/src/joystick/hidapi/SDL_hidapi_luna.c
+++ b/src/joystick/hidapi/SDL_hidapi_luna.c
@@ -32,7 +32,7 @@
 /*#define DEBUG_LUNA_PROTOCOL*/
 
 /* Sending rumble on macOS blocks for a long time and eventually fails */
-#if !defined(__MACOS__)
+#ifndef __MACOS__
 #define ENABLE_LUNA_BLUETOOTH_RUMBLE
 #endif
 

--- a/src/joystick/hidapi/SDL_hidapi_ps3.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps3.c
@@ -69,7 +69,7 @@ static SDL_bool HIDAPI_DriverPS3_IsEnabled(void)
 {
     SDL_bool default_value;
 
-#if defined(__MACOS__)
+#ifdef __MACOS__
     /* This works well on macOS */
     default_value = SDL_TRUE;
 #elif defined(__WINDOWS__)

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -979,7 +979,7 @@ static SDL_bool HIDAPI_DriverSteam_InitDevice(SDL_HIDAPI_Device *device)
     }
     device->context = ctx;
 
-#if defined(__WIN32__)
+#ifdef __WIN32__
     if (device->serial) {
         /* We get a garbage serial number on Windows */
         SDL_free(device->serial);

--- a/src/joystick/hidapi/SDL_hidapi_wii.c
+++ b/src/joystick/hidapi/SDL_hidapi_wii.c
@@ -455,7 +455,7 @@ static void CheckMotionPlusConnection(SDL_DriverWii_Context *ctx)
 
 static void ActivateMotionPlusWithMode(SDL_DriverWii_Context *ctx, Uint8 mode)
 {
-#if defined(__LINUX__)
+#ifdef __LINUX__
     /* Linux drivers maintain a lot of state around the Motion Plus
      * extension, so don't mess with it here.
      */

--- a/src/joystick/hidapi/SDL_hidapi_xbox360.c
+++ b/src/joystick/hidapi/SDL_hidapi_xbox360.c
@@ -82,7 +82,7 @@ static SDL_bool HIDAPI_DriverXbox360_IsSupportedDevice(SDL_HIDAPI_Device *device
         return SDL_FALSE;
     }
 #endif
-#if defined(__MACOS__)
+#ifdef __MACOS__
     /* Wired Xbox One controllers are handled by this driver, interfacing with
        the 360Controller driver available from:
        https://github.com/360Controller/360Controller/releases

--- a/src/joystick/hidapi/SDL_hidapijoystick.c
+++ b/src/joystick/hidapi/SDL_hidapijoystick.c
@@ -561,7 +561,7 @@ static int HIDAPI_JoystickInit(void)
         return 0;
     }
 
-#if defined(SDL_USE_LIBUDEV)
+#ifdef SDL_USE_LIBUDEV
     if (linux_enumeration_method == ENUMERATION_UNSET) {
         if (SDL_getenv("SDL_HIDAPI_JOYSTICK_DISABLE_UDEV") != NULL) {
             SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,

--- a/src/joystick/linux/SDL_sysjoystick.c
+++ b/src/joystick/linux/SDL_sysjoystick.c
@@ -765,7 +765,7 @@ static int LINUX_JoystickInit(void)
     } else
 #endif
     {
-#if defined(HAVE_INOTIFY)
+#ifdef HAVE_INOTIFY
         inotify_fd = SDL_inotify_init1();
 
         if (inotify_fd < 0) {

--- a/src/joystick/virtual/SDL_virtualjoystick.c
+++ b/src/joystick/virtual/SDL_virtualjoystick.c
@@ -20,7 +20,7 @@
 */
 #include "SDL_internal.h"
 
-#if defined(SDL_JOYSTICK_VIRTUAL)
+#ifdef SDL_JOYSTICK_VIRTUAL
 
 /* This is the virtual implementation of the SDL joystick API */
 

--- a/src/joystick/windows/SDL_rawinputjoystick.c
+++ b/src/joystick/windows/SDL_rawinputjoystick.c
@@ -1282,7 +1282,7 @@ static int RAWINPUT_JoystickRumble(SDL_Joystick *joystick, Uint16 low_frequency_
 
 static int RAWINPUT_JoystickRumbleTriggers(SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble)
 {
-#if defined(SDL_JOYSTICK_RAWINPUT_WGI)
+#ifdef SDL_JOYSTICK_RAWINPUT_WGI
     RAWINPUT_DeviceContext *ctx = joystick->hwdata;
 
     if (ctx->wgi_correlated) {

--- a/src/joystick/windows/SDL_windowsjoystick.c
+++ b/src/joystick/windows/SDL_windowsjoystick.c
@@ -336,7 +336,7 @@ static SDL_bool SDL_WaitForDeviceNotification(SDL_DeviceNotificationData *data, 
 
 #endif /* !defined(__WINRT__) && !defined(__XBOXONE__) && !defined(__XBOXSERIES__) */
 
-#if !defined(__WINRT__)
+#ifndef __WINRT__
 
 #if !defined(__XBOXONE__) && !defined(__XBOXSERIES__)
 static SDL_DeviceNotificationData s_notification_data;

--- a/src/misc/unix/SDL_sysurl.c
+++ b/src/misc/unix/SDL_sysurl.c
@@ -37,7 +37,7 @@ int SDL_SYS_OpenURL(const char *url)
 {
     const pid_t pid1 = fork();
     if (pid1 == 0) { /* child process */
-#if defined(USE_POSIX_SPAWN)
+#ifdef USE_POSIX_SPAWN
         pid_t pid2;
         const char *args[] = { "xdg-open", url, NULL };
         /* Clear LD_PRELOAD so Chrome opens correctly when this application is launched by Steam */

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -27,7 +27,7 @@
 #include "../video/SDL_pixels_c.h"
 #include "../video/SDL_video_c.h"
 
-#if defined(__ANDROID__)
+#ifdef __ANDROID__
 #include "../core/android/SDL_android.h"
 #endif
 
@@ -668,7 +668,7 @@ static int UpdateLogicalPresentation(SDL_Renderer *renderer);
 
 int SDL_GetNumRenderDrivers(void)
 {
-#if !defined(SDL_RENDER_DISABLED)
+#ifndef SDL_RENDER_DISABLED
     return SDL_arraysize(render_drivers);
 #else
     return 0;
@@ -677,7 +677,7 @@ int SDL_GetNumRenderDrivers(void)
 
 const char *SDL_GetRenderDriver(int index)
 {
-#if !defined(SDL_RENDER_DISABLED)
+#ifndef SDL_RENDER_DISABLED
     if (index < 0 || index >= SDL_GetNumRenderDrivers()) {
         SDL_SetError("index must be in the range of 0 - %d",
                             SDL_GetNumRenderDrivers() - 1);
@@ -741,7 +741,7 @@ int SDL_CreateWindowAndRenderer(int width, int height, Uint32 window_flags, SDL_
     return 0;
 }
 
-#if !defined(SDL_RENDER_DISABLED)
+#ifndef SDL_RENDER_DISABLED
 static SDL_INLINE void VerifyDrawQueueFunctions(const SDL_Renderer *renderer)
 {
     /* all of these functions are required to be implemented, even as no-ops, so we don't
@@ -801,14 +801,14 @@ static void SDL_CalculateSimulatedVSyncInterval(SDL_Renderer *renderer, SDL_Wind
 
 SDL_Renderer *SDL_CreateRenderer(SDL_Window *window, const char *name, Uint32 flags)
 {
-#if !defined(SDL_RENDER_DISABLED)
+#ifndef SDL_RENDER_DISABLED
     SDL_Renderer *renderer = NULL;
     const int n = SDL_GetNumRenderDrivers();
     SDL_bool batching = SDL_TRUE;
     const char *hint;
     int i;
 
-#if defined(__ANDROID__)
+#ifdef __ANDROID__
     Android_ActivityMutex_Lock_Running();
 #endif
 
@@ -928,14 +928,14 @@ SDL_Renderer *SDL_CreateRenderer(SDL_Window *window, const char *name, Uint32 fl
     SDL_LogInfo(SDL_LOG_CATEGORY_RENDER,
                 "Created renderer: %s", renderer->info.name);
 
-#if defined(__ANDROID__)
+#ifdef __ANDROID__
     Android_ActivityMutex_Unlock();
 #endif
     return renderer;
 
 error:
 
-#if defined(__ANDROID__)
+#ifdef __ANDROID__
     Android_ActivityMutex_Unlock();
 #endif
     return NULL;

--- a/src/render/direct3d11/SDL_render_d3d11.c
+++ b/src/render/direct3d11/SDL_render_d3d11.c
@@ -24,7 +24,7 @@
 
 #define COBJMACROS
 #include "../../core/windows/SDL_windows.h"
-#if !defined(__WINRT__)
+#ifndef __WINRT__
 #include "../../video/windows/SDL_windowswindow.h"
 #endif
 #include "../SDL_sysrender.h"
@@ -895,7 +895,7 @@ static HRESULT D3D11_CreateWindowSizeDependentResources(SDL_Renderer *renderer)
     /* The width and height of the swap chain must be based on the display's
      * non-rotated size.
      */
-#if defined(__WINRT__)
+#ifdef __WINRT__
     SDL_GetWindowSize(renderer->window, &w, &h);
 #else
     SDL_GetWindowSizeInPixels(renderer->window, &w, &h);

--- a/src/render/direct3d11/SDL_shaders_d3d11.c
+++ b/src/render/direct3d11/SDL_shaders_d3d11.c
@@ -77,7 +77,7 @@
        return input.color;
    }
 */
-#if defined(D3D11_USE_SHADER_MODEL_4_0_level_9_1)
+#ifdef D3D11_USE_SHADER_MODEL_4_0_level_9_1
 static const DWORD D3D11_PixelShader_Colors[] = {
     0x43425844, 0xd74c28fe, 0xa1eb8804, 0x269d512a, 0x7699723d, 0x00000001,
     0x00000240, 0x00000006, 0x00000038, 0x00000084, 0x000000c4, 0x00000140,
@@ -153,7 +153,7 @@ static const DWORD D3D11_PixelShader_Colors[] = {
         return theTexture.Sample(theSampler, input.tex) * input.color;
     }
 */
-#if defined(D3D11_USE_SHADER_MODEL_4_0_level_9_1)
+#ifdef D3D11_USE_SHADER_MODEL_4_0_level_9_1
 static const DWORD D3D11_PixelShader_Textures[] = {
     0x43425844, 0x6299b59f, 0x155258f2, 0x873ab86a, 0xfcbb6dcd, 0x00000001,
     0x00000330, 0x00000006, 0x00000038, 0x000000c0, 0x0000015c, 0x000001d8,
@@ -270,7 +270,7 @@ static const DWORD D3D11_PixelShader_Textures[] = {
     }
 
 */
-#if defined(D3D11_USE_SHADER_MODEL_4_0_level_9_1)
+#ifdef D3D11_USE_SHADER_MODEL_4_0_level_9_1
 static const DWORD D3D11_PixelShader_YUV_JPEG[] = {
     0x43425844, 0x10359e9c, 0x92c3d2c4, 0x00bf0cd5, 0x5ce8c499, 0x00000001,
     0x000005e8, 0x00000006, 0x00000038, 0x000001dc, 0x000003bc, 0x00000438,
@@ -444,7 +444,7 @@ static const DWORD D3D11_PixelShader_YUV_JPEG[] = {
     }
 
 */
-#if defined(D3D11_USE_SHADER_MODEL_4_0_level_9_1)
+#ifdef D3D11_USE_SHADER_MODEL_4_0_level_9_1
 static const DWORD D3D11_PixelShader_YUV_BT601[] = {
     0x43425844, 0x628ec838, 0xbe9cec6a, 0xc9ee10bb, 0x63283218, 0x00000001,
     0x000005e8, 0x00000006, 0x00000038, 0x000001dc, 0x000003bc, 0x00000438,
@@ -618,7 +618,7 @@ static const DWORD D3D11_PixelShader_YUV_BT601[] = {
     }
 
 */
-#if defined(D3D11_USE_SHADER_MODEL_4_0_level_9_1)
+#ifdef D3D11_USE_SHADER_MODEL_4_0_level_9_1
 static const DWORD D3D11_PixelShader_YUV_BT709[] = {
     0x43425844, 0x5045fa84, 0xc2908cce, 0x278dacc3, 0xd4276f8f, 0x00000001,
     0x000005e8, 0x00000006, 0x00000038, 0x000001dc, 0x000003bc, 0x00000438,
@@ -790,7 +790,7 @@ static const DWORD D3D11_PixelShader_YUV_BT709[] = {
     }
 
 */
-#if defined(D3D11_USE_SHADER_MODEL_4_0_level_9_1)
+#ifdef D3D11_USE_SHADER_MODEL_4_0_level_9_1
 static const DWORD D3D11_PixelShader_NV12_JPEG[] = {
     0x43425844, 0x8fb9c77a, 0xe9e39686, 0x62b0e0e9, 0xd2bf8183, 0x00000001,
     0x00000548, 0x00000006, 0x00000038, 0x000001b0, 0x00000348, 0x000003c4,
@@ -949,7 +949,7 @@ static const DWORD D3D11_PixelShader_NV12_JPEG[] = {
     }
 
 */
-#if defined(D3D11_USE_SHADER_MODEL_4_0_level_9_1)
+#ifdef D3D11_USE_SHADER_MODEL_4_0_level_9_1
 static const DWORD D3D11_PixelShader_NV12_BT601[] = {
     0x43425844, 0xd1d24a0c, 0x337c447a, 0x22b55cff, 0xb5c9c74b, 0x00000001,
     0x00000548, 0x00000006, 0x00000038, 0x000001b0, 0x00000348, 0x000003c4,
@@ -1108,7 +1108,7 @@ static const DWORD D3D11_PixelShader_NV12_BT601[] = {
     }
 
 */
-#if defined(D3D11_USE_SHADER_MODEL_4_0_level_9_1)
+#ifdef D3D11_USE_SHADER_MODEL_4_0_level_9_1
 static const DWORD D3D11_PixelShader_NV12_BT709[] = {
     0x43425844, 0x40d1b8d5, 0xaf4b78b5, 0x907fd0b5, 0xa2d23686, 0x00000001,
     0x00000548, 0x00000006, 0x00000038, 0x000001b0, 0x00000348, 0x000003c4,
@@ -1267,7 +1267,7 @@ static const DWORD D3D11_PixelShader_NV12_BT709[] = {
     }
 
 */
-#if defined(D3D11_USE_SHADER_MODEL_4_0_level_9_1)
+#ifdef D3D11_USE_SHADER_MODEL_4_0_level_9_1
 static const DWORD D3D11_PixelShader_NV21_JPEG[] = {
     0x43425844, 0x9c41f579, 0xfd1019d8, 0x7c27e3ae, 0x52e3a5ff, 0x00000001,
     0x00000554, 0x00000006, 0x00000038, 0x000001bc, 0x00000354, 0x000003d0,
@@ -1426,7 +1426,7 @@ static const DWORD D3D11_PixelShader_NV21_JPEG[] = {
     }
 
 */
-#if defined(D3D11_USE_SHADER_MODEL_4_0_level_9_1)
+#ifdef D3D11_USE_SHADER_MODEL_4_0_level_9_1
 static const DWORD D3D11_PixelShader_NV21_BT601[] = {
     0x43425844, 0x7fc6cfdc, 0xba87a4ff, 0xa72685a6, 0xa051b38c, 0x00000001,
     0x00000554, 0x00000006, 0x00000038, 0x000001bc, 0x00000354, 0x000003d0,
@@ -1585,7 +1585,7 @@ static const DWORD D3D11_PixelShader_NV21_BT601[] = {
     }
 
 */
-#if defined(D3D11_USE_SHADER_MODEL_4_0_level_9_1)
+#ifdef D3D11_USE_SHADER_MODEL_4_0_level_9_1
 static const DWORD D3D11_PixelShader_NV21_BT709[] = {
     0x43425844, 0x754ba6c4, 0xe321a747, 0x23680787, 0x6bb1bdcc, 0x00000001,
     0x00000554, 0x00000006, 0x00000038, 0x000001bc, 0x00000354, 0x000003d0,
@@ -1749,7 +1749,7 @@ static const DWORD D3D11_PixelShader_NV21_BT709[] = {
        return output;
    }
 */
-#if defined(D3D11_USE_SHADER_MODEL_4_0_level_9_1)
+#ifdef D3D11_USE_SHADER_MODEL_4_0_level_9_1
 static const DWORD D3D11_VertexShader[] = {
     0x43425844, 0x62dfae5f, 0x3e8bd8df, 0x9ec97127, 0x5044eefb, 0x00000001,
     0x00000598, 0x00000006, 0x00000038, 0x0000016c, 0x00000334, 0x000003b0,

--- a/src/render/opengles2/SDL_render_gles2.c
+++ b/src/render/opengles2/SDL_render_gles2.c
@@ -33,7 +33,7 @@
    In all other cases, attempt to use client-side arrays, as they tend to
    be dramatically faster when not batching, and about the same when
    we are. */
-#if defined(__EMSCRIPTEN__)
+#ifdef __EMSCRIPTEN__
 #define USE_VERTEX_BUFFER_OBJECTS 1
 #else
 #define USE_VERTEX_BUFFER_OBJECTS 0

--- a/src/sensor/vita/SDL_vitasensor.c
+++ b/src/sensor/vita/SDL_vitasensor.c
@@ -20,13 +20,13 @@
 */
 #include "SDL_internal.h"
 
-#if defined(SDL_SENSOR_VITA)
+#ifdef SDL_SENSOR_VITA
 
 #include "SDL_vitasensor.h"
 #include "../SDL_syssensor.h"
 #include <psp2/motion.h>
 
-#if !defined(SCE_MOTION_MAX_NUM_STATES)
+#ifndef SCE_MOTION_MAX_NUM_STATES
 #define SCE_MOTION_MAX_NUM_STATES 64
 #endif
 

--- a/src/sensor/windows/SDL_windowssensor.c
+++ b/src/sensor/windows/SDL_windowssensor.c
@@ -20,7 +20,7 @@
 */
 #include "SDL_internal.h"
 
-#if defined(SDL_SENSOR_WINDOWS)
+#ifdef SDL_SENSOR_WINDOWS
 
 #include "SDL_windowssensor.h"
 #include "../SDL_syssensor.h"

--- a/src/stdlib/SDL_getenv.c
+++ b/src/stdlib/SDL_getenv.c
@@ -24,7 +24,7 @@
 #include "../core/windows/SDL_windows.h"
 #endif
 
-#if defined(__ANDROID__)
+#ifdef __ANDROID__
 #include "../core/android/SDL_android.h"
 #endif
 
@@ -36,7 +36,7 @@ static size_t SDL_envmemlen = 0;
 
 /* Put a variable into the environment */
 /* Note: Name may not contain a '=' character. (Reference: http://www.unix.com/man-page/Linux/3/setenv/) */
-#if defined(HAVE_SETENV)
+#ifdef HAVE_SETENV
 int SDL_setenv(const char *name, const char *value, int overwrite)
 {
     /* Input validation */
@@ -160,11 +160,11 @@ int SDL_setenv(const char *name, const char *value, int overwrite)
 #endif
 
 /* Retrieve a variable named "name" from the environment */
-#if defined(HAVE_GETENV)
+#ifdef HAVE_GETENV
 char *
 SDL_getenv(const char *name)
 {
-#if defined(__ANDROID__)
+#ifdef __ANDROID__
     /* Make sure variables from the application manifest are available */
     Android_JNI_GetManifestEnvironmentVariables();
 #endif

--- a/src/stdlib/SDL_mslibc.c
+++ b/src/stdlib/SDL_mslibc.c
@@ -26,7 +26,7 @@
 
 /* These are some C runtime intrinsics that need to be defined */
 
-#if defined(_MSC_VER)
+#ifdef _MSC_VER
 
 #ifndef __FLTUSED__
 #define __FLTUSED__
@@ -42,7 +42,7 @@ extern void *memcpy(void *dst, const void *src, size_t len);
 #pragma intrinsic(memcpy)
 #endif
 
-#if !defined(__clang__)
+#ifndef __clang__
 #pragma function(memcpy)
 #endif
 /* NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) */
@@ -57,7 +57,7 @@ extern void *memset(void *dst, int c, size_t len);
 #pragma intrinsic(memset)
 #endif
 
-#if !defined(__clang__)
+#ifndef __clang__
 #pragma function(memset)
 #endif
 /* NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) */
@@ -700,7 +700,7 @@ RETZERO:
 
 #endif /* MSC_VER */
 
-#if defined(__ICL)
+#ifdef __ICL
 /* The classic Intel compiler generates calls to _intel_fast_memcpy
  * and _intel_fast_memset when building an optimized SDL library */
 void *_intel_fast_memcpy(void *dst, const void *src, size_t len)

--- a/src/stdlib/SDL_qsort.c
+++ b/src/stdlib/SDL_qsort.c
@@ -21,7 +21,7 @@
 #include "SDL_internal.h"
 
 
-#if defined(HAVE_QSORT)
+#ifdef HAVE_QSORT
 void
 SDL_qsort(void *base, size_t nmemb, size_t size, int (*compare) (const void *, const void *))
 {
@@ -531,7 +531,7 @@ extern void qsortG(void *base, size_t nmemb, size_t size,
 void *
 SDL_bsearch(const void *key, const void *base, size_t nmemb, size_t size, int (*compare)(const void *, const void *))
 {
-#if defined(HAVE_BSEARCH)
+#ifdef HAVE_BSEARCH
     return bsearch(key, base, nmemb, size, compare);
 #else
 /* SDL's replacement:  Taken from the Public Domain C Library (PDCLib):

--- a/src/stdlib/SDL_stdlib.c
+++ b/src/stdlib/SDL_stdlib.c
@@ -27,7 +27,7 @@
 double
 SDL_atan(double x)
 {
-#if defined(HAVE_ATAN)
+#ifdef HAVE_ATAN
     return atan(x);
 #else
     return SDL_uclibc_atan(x);
@@ -36,7 +36,7 @@ SDL_atan(double x)
 
 float SDL_atanf(float x)
 {
-#if defined(HAVE_ATANF)
+#ifdef HAVE_ATANF
     return atanf(x);
 #else
     return (float)SDL_atan((double)x);
@@ -46,7 +46,7 @@ float SDL_atanf(float x)
 double
 SDL_atan2(double y, double x)
 {
-#if defined(HAVE_ATAN2)
+#ifdef HAVE_ATAN2
     return atan2(y, x);
 #else
     return SDL_uclibc_atan2(y, x);
@@ -55,7 +55,7 @@ SDL_atan2(double y, double x)
 
 float SDL_atan2f(float y, float x)
 {
-#if defined(HAVE_ATAN2F)
+#ifdef HAVE_ATAN2F
     return atan2f(y, x);
 #else
     return (float)SDL_atan2((double)y, (double)x);
@@ -65,7 +65,7 @@ float SDL_atan2f(float y, float x)
 double
 SDL_acos(double val)
 {
-#if defined(HAVE_ACOS)
+#ifdef HAVE_ACOS
     return acos(val);
 #else
     double result;
@@ -83,7 +83,7 @@ SDL_acos(double val)
 
 float SDL_acosf(float val)
 {
-#if defined(HAVE_ACOSF)
+#ifdef HAVE_ACOSF
     return acosf(val);
 #else
     return (float)SDL_acos((double)val);
@@ -93,7 +93,7 @@ float SDL_acosf(float val)
 double
 SDL_asin(double val)
 {
-#if defined(HAVE_ASIN)
+#ifdef HAVE_ASIN
     return asin(val);
 #else
     double result;
@@ -108,7 +108,7 @@ SDL_asin(double val)
 
 float SDL_asinf(float val)
 {
-#if defined(HAVE_ASINF)
+#ifdef HAVE_ASINF
     return asinf(val);
 #else
     return (float)SDL_asin((double)val);
@@ -118,7 +118,7 @@ float SDL_asinf(float val)
 double
 SDL_ceil(double x)
 {
-#if defined(HAVE_CEIL)
+#ifdef HAVE_CEIL
     return ceil(x);
 #else
     double integer = SDL_floor(x);
@@ -132,7 +132,7 @@ SDL_ceil(double x)
 
 float SDL_ceilf(float x)
 {
-#if defined(HAVE_CEILF)
+#ifdef HAVE_CEILF
     return ceilf(x);
 #else
     return (float)SDL_ceil((double)x);
@@ -142,7 +142,7 @@ float SDL_ceilf(float x)
 double
 SDL_copysign(double x, double y)
 {
-#if defined(HAVE_COPYSIGN)
+#ifdef HAVE_COPYSIGN
     return copysign(x, y);
 #elif defined(HAVE__COPYSIGN)
     return _copysign(x, y);
@@ -159,7 +159,7 @@ SDL_copysign(double x, double y)
 
 float SDL_copysignf(float x, float y)
 {
-#if defined(HAVE_COPYSIGNF)
+#ifdef HAVE_COPYSIGNF
     return copysignf(x, y);
 #else
     return (float)SDL_copysign((double)x, (double)y);
@@ -169,7 +169,7 @@ float SDL_copysignf(float x, float y)
 double
 SDL_cos(double x)
 {
-#if defined(HAVE_COS)
+#ifdef HAVE_COS
     return cos(x);
 #else
     return SDL_uclibc_cos(x);
@@ -178,7 +178,7 @@ SDL_cos(double x)
 
 float SDL_cosf(float x)
 {
-#if defined(HAVE_COSF)
+#ifdef HAVE_COSF
     return cosf(x);
 #else
     return (float)SDL_cos((double)x);
@@ -188,7 +188,7 @@ float SDL_cosf(float x)
 double
 SDL_exp(double x)
 {
-#if defined(HAVE_EXP)
+#ifdef HAVE_EXP
     return exp(x);
 #else
     return SDL_uclibc_exp(x);
@@ -197,7 +197,7 @@ SDL_exp(double x)
 
 float SDL_expf(float x)
 {
-#if defined(HAVE_EXPF)
+#ifdef HAVE_EXPF
     return expf(x);
 #else
     return (float)SDL_exp((double)x);
@@ -207,7 +207,7 @@ float SDL_expf(float x)
 double
 SDL_fabs(double x)
 {
-#if defined(HAVE_FABS)
+#ifdef HAVE_FABS
     return fabs(x);
 #else
     return SDL_uclibc_fabs(x);
@@ -216,7 +216,7 @@ SDL_fabs(double x)
 
 float SDL_fabsf(float x)
 {
-#if defined(HAVE_FABSF)
+#ifdef HAVE_FABSF
     return fabsf(x);
 #else
     return (float)SDL_fabs((double)x);
@@ -226,7 +226,7 @@ float SDL_fabsf(float x)
 double
 SDL_floor(double x)
 {
-#if defined(HAVE_FLOOR)
+#ifdef HAVE_FLOOR
     return floor(x);
 #else
     return SDL_uclibc_floor(x);
@@ -235,7 +235,7 @@ SDL_floor(double x)
 
 float SDL_floorf(float x)
 {
-#if defined(HAVE_FLOORF)
+#ifdef HAVE_FLOORF
     return floorf(x);
 #else
     return (float)SDL_floor((double)x);
@@ -245,7 +245,7 @@ float SDL_floorf(float x)
 double
 SDL_trunc(double x)
 {
-#if defined(HAVE_TRUNC)
+#ifdef HAVE_TRUNC
     return trunc(x);
 #else
     if (x >= 0.0f) {
@@ -258,7 +258,7 @@ SDL_trunc(double x)
 
 float SDL_truncf(float x)
 {
-#if defined(HAVE_TRUNCF)
+#ifdef HAVE_TRUNCF
     return truncf(x);
 #else
     return (float)SDL_trunc((double)x);
@@ -268,7 +268,7 @@ float SDL_truncf(float x)
 double
 SDL_fmod(double x, double y)
 {
-#if defined(HAVE_FMOD)
+#ifdef HAVE_FMOD
     return fmod(x, y);
 #else
     return SDL_uclibc_fmod(x, y);
@@ -277,7 +277,7 @@ SDL_fmod(double x, double y)
 
 float SDL_fmodf(float x, float y)
 {
-#if defined(HAVE_FMODF)
+#ifdef HAVE_FMODF
     return fmodf(x, y);
 #else
     return (float)SDL_fmod((double)x, (double)y);
@@ -287,7 +287,7 @@ float SDL_fmodf(float x, float y)
 double
 SDL_log(double x)
 {
-#if defined(HAVE_LOG)
+#ifdef HAVE_LOG
     return log(x);
 #else
     return SDL_uclibc_log(x);
@@ -296,7 +296,7 @@ SDL_log(double x)
 
 float SDL_logf(float x)
 {
-#if defined(HAVE_LOGF)
+#ifdef HAVE_LOGF
     return logf(x);
 #else
     return (float)SDL_log((double)x);
@@ -306,7 +306,7 @@ float SDL_logf(float x)
 double
 SDL_log10(double x)
 {
-#if defined(HAVE_LOG10)
+#ifdef HAVE_LOG10
     return log10(x);
 #else
     return SDL_uclibc_log10(x);
@@ -315,7 +315,7 @@ SDL_log10(double x)
 
 float SDL_log10f(float x)
 {
-#if defined(HAVE_LOG10F)
+#ifdef HAVE_LOG10F
     return log10f(x);
 #else
     return (float)SDL_log10((double)x);
@@ -325,7 +325,7 @@ float SDL_log10f(float x)
 double
 SDL_modf(double x, double *y)
 {
-#if defined(HAVE_MODF)
+#ifdef HAVE_MODF
     return modf(x, y);
 #else
     return SDL_uclibc_modf(x, y);
@@ -334,7 +334,7 @@ SDL_modf(double x, double *y)
 
 float SDL_modff(float x, float *y)
 {
-#if defined(HAVE_MODFF)
+#ifdef HAVE_MODFF
     return modff(x, y);
 #else
     double double_result, double_y;
@@ -347,7 +347,7 @@ float SDL_modff(float x, float *y)
 double
 SDL_pow(double x, double y)
 {
-#if defined(HAVE_POW)
+#ifdef HAVE_POW
     return pow(x, y);
 #else
     return SDL_uclibc_pow(x, y);
@@ -356,7 +356,7 @@ SDL_pow(double x, double y)
 
 float SDL_powf(float x, float y)
 {
-#if defined(HAVE_POWF)
+#ifdef HAVE_POWF
     return powf(x, y);
 #else
     return (float)SDL_pow((double)x, (double)y);
@@ -407,7 +407,7 @@ long SDL_lroundf(float arg)
 double
 SDL_scalbn(double x, int n)
 {
-#if defined(HAVE_SCALBN)
+#ifdef HAVE_SCALBN
     return scalbn(x, n);
 #elif defined(HAVE__SCALB)
     return _scalb(x, n);
@@ -422,7 +422,7 @@ SDL_scalbn(double x, int n)
 
 float SDL_scalbnf(float x, int n)
 {
-#if defined(HAVE_SCALBNF)
+#ifdef HAVE_SCALBNF
     return scalbnf(x, n);
 #else
     return (float)SDL_scalbn((double)x, n);
@@ -432,7 +432,7 @@ float SDL_scalbnf(float x, int n)
 double
 SDL_sin(double x)
 {
-#if defined(HAVE_SIN)
+#ifdef HAVE_SIN
     return sin(x);
 #else
     return SDL_uclibc_sin(x);
@@ -441,7 +441,7 @@ SDL_sin(double x)
 
 float SDL_sinf(float x)
 {
-#if defined(HAVE_SINF)
+#ifdef HAVE_SINF
     return sinf(x);
 #else
     return (float)SDL_sin((double)x);
@@ -451,7 +451,7 @@ float SDL_sinf(float x)
 double
 SDL_sqrt(double x)
 {
-#if defined(HAVE_SQRT)
+#ifdef HAVE_SQRT
     return sqrt(x);
 #else
     return SDL_uclibc_sqrt(x);
@@ -460,7 +460,7 @@ SDL_sqrt(double x)
 
 float SDL_sqrtf(float x)
 {
-#if defined(HAVE_SQRTF)
+#ifdef HAVE_SQRTF
     return sqrtf(x);
 #else
     return (float)SDL_sqrt((double)x);
@@ -470,7 +470,7 @@ float SDL_sqrtf(float x)
 double
 SDL_tan(double x)
 {
-#if defined(HAVE_TAN)
+#ifdef HAVE_TAN
     return tan(x);
 #else
     return SDL_uclibc_tan(x);
@@ -479,7 +479,7 @@ SDL_tan(double x)
 
 float SDL_tanf(float x)
 {
-#if defined(HAVE_TANF)
+#ifdef HAVE_TANF
     return tanf(x);
 #else
     return (float)SDL_tan((double)x);
@@ -488,14 +488,14 @@ float SDL_tanf(float x)
 
 int SDL_abs(int x)
 {
-#if defined(HAVE_ABS)
+#ifdef HAVE_ABS
     return abs(x);
 #else
     return (x < 0) ? -x : x;
 #endif
 }
 
-#if defined(HAVE_CTYPE_H)
+#ifdef HAVE_CTYPE_H
 int SDL_isalpha(int x)
 {
     return isalpha(x);
@@ -589,7 +589,7 @@ SDL_memcpy(SDL_OUT_BYTECAP(len) void *dst, SDL_IN_BYTECAP(len) const void *src, 
 void *
 SDL_memset(SDL_OUT_BYTECAP(len) void *dst, int c, size_t len)
 {
-#if defined(HAVE_MEMSET)
+#ifdef HAVE_MEMSET
     return memset(dst, c, len);
 #else
     size_t left;

--- a/src/stdlib/SDL_string.c
+++ b/src/stdlib/SDL_string.c
@@ -24,7 +24,7 @@
 
 #include "SDL_vacopy.h"
 
-#if defined(__vita__)
+#ifdef __vita__
 #include <psp2/kernel/clib.h>
 #endif
 
@@ -290,7 +290,7 @@ SDL_ScanFloat(const char *text, double *valuep)
 void *
 SDL_memmove(SDL_OUT_BYTECAP(len) void *dst, SDL_IN_BYTECAP(len) const void *src, size_t len)
 {
-#if defined(HAVE_MEMMOVE)
+#ifdef HAVE_MEMMOVE
     return memmove(dst, src, len);
 #else
     char *srcp = (char *)src;
@@ -313,7 +313,7 @@ SDL_memmove(SDL_OUT_BYTECAP(len) void *dst, SDL_IN_BYTECAP(len) const void *src,
 
 int SDL_memcmp(const void *s1, const void *s2, size_t len)
 {
-#if defined(__vita__)
+#ifdef __vita__
     /*
       Using memcmp on NULL is UB per POSIX / C99 7.21.1/2.
       But, both linux and bsd allow that, with an exception:
@@ -343,7 +343,7 @@ int SDL_memcmp(const void *s1, const void *s2, size_t len)
 size_t
 SDL_strlen(const char *string)
 {
-#if defined(HAVE_STRLEN)
+#ifdef HAVE_STRLEN
     return strlen(string);
 #else
     size_t len = 0;
@@ -357,7 +357,7 @@ SDL_strlen(const char *string)
 size_t
 SDL_wcslen(const wchar_t *string)
 {
-#if defined(HAVE_WCSLEN)
+#ifdef HAVE_WCSLEN
     return wcslen(string);
 #else
     size_t len = 0;
@@ -371,7 +371,7 @@ SDL_wcslen(const wchar_t *string)
 size_t
 SDL_wcslcpy(SDL_OUT_Z_CAP(maxlen) wchar_t *dst, const wchar_t *src, size_t maxlen)
 {
-#if defined(HAVE_WCSLCPY)
+#ifdef HAVE_WCSLCPY
     return wcslcpy(dst, src, maxlen);
 #else
     size_t srclen = SDL_wcslen(src);
@@ -387,7 +387,7 @@ SDL_wcslcpy(SDL_OUT_Z_CAP(maxlen) wchar_t *dst, const wchar_t *src, size_t maxle
 size_t
 SDL_wcslcat(SDL_INOUT_Z_CAP(maxlen) wchar_t *dst, const wchar_t *src, size_t maxlen)
 {
-#if defined(HAVE_WCSLCAT)
+#ifdef HAVE_WCSLCAT
     return wcslcat(dst, src, maxlen);
 #else
     size_t dstlen = SDL_wcslen(dst);
@@ -413,7 +413,7 @@ SDL_wcsdup(const wchar_t *string)
 wchar_t *
 SDL_wcsstr(const wchar_t *haystack, const wchar_t *needle)
 {
-#if defined(HAVE_WCSSTR)
+#ifdef HAVE_WCSSTR
     return SDL_const_cast(wchar_t *, wcsstr(haystack, needle));
 #else
     size_t length = SDL_wcslen(needle);
@@ -429,7 +429,7 @@ SDL_wcsstr(const wchar_t *haystack, const wchar_t *needle)
 
 int SDL_wcscmp(const wchar_t *str1, const wchar_t *str2)
 {
-#if defined(HAVE_WCSCMP)
+#ifdef HAVE_WCSCMP
     return wcscmp(str1, str2);
 #else
     while (*str1 && *str2) {
@@ -445,7 +445,7 @@ int SDL_wcscmp(const wchar_t *str1, const wchar_t *str2)
 
 int SDL_wcsncmp(const wchar_t *str1, const wchar_t *str2, size_t maxlen)
 {
-#if defined(HAVE_WCSNCMP)
+#ifdef HAVE_WCSNCMP
     return wcsncmp(str1, str2, maxlen);
 #else
     while (*str1 && *str2 && maxlen) {
@@ -466,7 +466,7 @@ int SDL_wcsncmp(const wchar_t *str1, const wchar_t *str2, size_t maxlen)
 
 int SDL_wcscasecmp(const wchar_t *str1, const wchar_t *str2)
 {
-#if defined(HAVE_WCSCASECMP)
+#ifdef HAVE_WCSCASECMP
     return wcscasecmp(str1, str2);
 #elif defined(HAVE__WCSICMP)
     return _wcsicmp(str1, str2);
@@ -503,7 +503,7 @@ int SDL_wcscasecmp(const wchar_t *str1, const wchar_t *str2)
 
 int SDL_wcsncasecmp(const wchar_t *str1, const wchar_t *str2, size_t maxlen)
 {
-#if defined(HAVE_WCSNCASECMP)
+#ifdef HAVE_WCSNCASECMP
     return wcsncasecmp(str1, str2, maxlen);
 #elif defined(HAVE__WCSNICMP)
     return _wcsnicmp(str1, str2, maxlen);
@@ -546,7 +546,7 @@ int SDL_wcsncasecmp(const wchar_t *str1, const wchar_t *str2, size_t maxlen)
 size_t
 SDL_strlcpy(SDL_OUT_Z_CAP(maxlen) char *dst, const char *src, size_t maxlen)
 {
-#if defined(HAVE_STRLCPY)
+#ifdef HAVE_STRLCPY
     return strlcpy(dst, src, maxlen);
 #else
     size_t srclen = SDL_strlen(src);
@@ -628,7 +628,7 @@ SDL_utf8strnlen(const char *str, size_t bytes)
 size_t
 SDL_strlcat(SDL_INOUT_Z_CAP(maxlen) char *dst, const char *src, size_t maxlen)
 {
-#if defined(HAVE_STRLCAT)
+#ifdef HAVE_STRLCAT
     return strlcat(dst, src, maxlen);
 #else
     size_t dstlen = SDL_strlen(dst);
@@ -654,7 +654,7 @@ SDL_strdup(const char *string)
 char *
 SDL_strrev(char *string)
 {
-#if defined(HAVE__STRREV)
+#ifdef HAVE__STRREV
     return _strrev(string);
 #else
     size_t len = SDL_strlen(string);
@@ -673,7 +673,7 @@ SDL_strrev(char *string)
 char *
 SDL_strupr(char *string)
 {
-#if defined(HAVE__STRUPR)
+#ifdef HAVE__STRUPR
     return _strupr(string);
 #else
     char *bufp = string;
@@ -688,7 +688,7 @@ SDL_strupr(char *string)
 char *
 SDL_strlwr(char *string)
 {
-#if defined(HAVE__STRLWR)
+#ifdef HAVE__STRLWR
     return _strlwr(string);
 #else
     char *bufp = string;
@@ -743,7 +743,7 @@ SDL_strrchr(const char *string, int c)
 char *
 SDL_strstr(const char *haystack, const char *needle)
 {
-#if defined(HAVE_STRSTR)
+#ifdef HAVE_STRSTR
     return SDL_const_cast(char *, strstr(haystack, needle));
 #else
     size_t length = SDL_strlen(needle);
@@ -760,7 +760,7 @@ SDL_strstr(const char *haystack, const char *needle)
 char *
 SDL_strcasestr(const char *haystack, const char *needle)
 {
-#if defined(HAVE_STRCASESTR)
+#ifdef HAVE_STRCASESTR
     return SDL_const_cast(char *, strcasestr(haystack, needle));
 #else
     size_t length = SDL_strlen(needle);
@@ -807,7 +807,7 @@ SDL_uitoa(unsigned int value, char *string, int radix)
 char *
 SDL_ltoa(long value, char *string, int radix)
 {
-#if defined(HAVE__LTOA)
+#ifdef HAVE__LTOA
     return _ltoa(value, string, radix);
 #else
     char *bufp = string;
@@ -826,7 +826,7 @@ SDL_ltoa(long value, char *string, int radix)
 char *
 SDL_ultoa(unsigned long value, char *string, int radix)
 {
-#if defined(HAVE__ULTOA)
+#ifdef HAVE__ULTOA
     return _ultoa(value, string, radix);
 #else
     char *bufp = string;
@@ -851,7 +851,7 @@ SDL_ultoa(unsigned long value, char *string, int radix)
 char *
 SDL_lltoa(Sint64 value, char *string, int radix)
 {
-#if defined(HAVE__I64TOA)
+#ifdef HAVE__I64TOA
     return _i64toa(value, string, radix);
 #else
     char *bufp = string;
@@ -870,7 +870,7 @@ SDL_lltoa(Sint64 value, char *string, int radix)
 char *
 SDL_ulltoa(Uint64 value, char *string, int radix)
 {
-#if defined(HAVE__UI64TOA)
+#ifdef HAVE__UI64TOA
     return _ui64toa(value, string, radix);
 #else
     char *bufp = string;
@@ -912,7 +912,7 @@ double SDL_atof(const char *string)
 
 long SDL_strtol(const char *string, char **endp, int base)
 {
-#if defined(HAVE_STRTOL)
+#ifdef HAVE_STRTOL
     return strtol(string, endp, base);
 #else
     size_t len;
@@ -937,7 +937,7 @@ long SDL_strtol(const char *string, char **endp, int base)
 unsigned long
 SDL_strtoul(const char *string, char **endp, int base)
 {
-#if defined(HAVE_STRTOUL)
+#ifdef HAVE_STRTOUL
     return strtoul(string, endp, base);
 #else
     size_t len;
@@ -962,7 +962,7 @@ SDL_strtoul(const char *string, char **endp, int base)
 Sint64
 SDL_strtoll(const char *string, char **endp, int base)
 {
-#if defined(HAVE_STRTOLL)
+#ifdef HAVE_STRTOLL
     return strtoll(string, endp, base);
 #else
     size_t len;
@@ -987,7 +987,7 @@ SDL_strtoll(const char *string, char **endp, int base)
 Uint64
 SDL_strtoull(const char *string, char **endp, int base)
 {
-#if defined(HAVE_STRTOULL)
+#ifdef HAVE_STRTOULL
     return strtoull(string, endp, base);
 #else
     size_t len;
@@ -1012,7 +1012,7 @@ SDL_strtoull(const char *string, char **endp, int base)
 double
 SDL_strtod(const char *string, char **endp)
 {
-#if defined(HAVE_STRTOD)
+#ifdef HAVE_STRTOD
     return strtod(string, endp);
 #else
     size_t len;
@@ -1028,7 +1028,7 @@ SDL_strtod(const char *string, char **endp)
 
 int SDL_strcmp(const char *str1, const char *str2)
 {
-#if defined(HAVE_STRCMP)
+#ifdef HAVE_STRCMP
     return strcmp(str1, str2);
 #else
     int result;
@@ -1047,7 +1047,7 @@ int SDL_strcmp(const char *str1, const char *str2)
 
 int SDL_strncmp(const char *str1, const char *str2, size_t maxlen)
 {
-#if defined(HAVE_STRNCMP)
+#ifdef HAVE_STRNCMP
     return strncmp(str1, str2, maxlen);
 #else
     int result;

--- a/src/stdlib/SDL_vacopy.h
+++ b/src/stdlib/SDL_vacopy.h
@@ -20,7 +20,7 @@
 */
 
 /* Do our best to make sure va_copy is working */
-#if defined(__NGAGE__)
+#ifdef __NGAGE__
 #undef va_copy
 #define va_copy(dst, src) dst = src
 

--- a/src/test/SDL_test_harness.c
+++ b/src/test/SDL_test_harness.c
@@ -213,7 +213,7 @@ static SDL_TimerID SDLTest_SetTestTimeout(int timeout, void(SDLCALL *callback)(v
 /**
  * \brief Timeout handler. Aborts test run and exits harness process.
  */
-#if defined(__WATCOMC__)
+#ifdef __WATCOMC__
 #pragma aux SDLTest_BailOut aborts;
 #endif
 static SDL_NORETURN void SDLCALL SDLTest_BailOut(void)

--- a/src/thread/SDL_thread.c
+++ b/src/thread/SDL_thread.c
@@ -219,7 +219,7 @@ static void SDLCALL SDL_FreeErrBuf(void *data)
 SDL_error *
 SDL_GetErrBuf(void)
 {
-#if defined(SDL_THREADS_DISABLED)
+#ifdef SDL_THREADS_DISABLED
     return SDL_GetStaticErrBuf();
 #else
     static SDL_SpinLock tls_lock;

--- a/src/thread/SDL_thread_c.h
+++ b/src/thread/SDL_thread_c.h
@@ -24,7 +24,7 @@
 #define SDL_thread_c_h_
 
 /* Need the definitions of SYS_ThreadHandle */
-#if defined(SDL_THREADS_DISABLED)
+#ifdef SDL_THREADS_DISABLED
 #include "generic/SDL_systhread_c.h"
 #elif defined(SDL_THREAD_PTHREAD)
 #include "pthread/SDL_systhread_c.h"

--- a/src/thread/generic/SDL_syscond.c
+++ b/src/thread/generic/SDL_syscond.c
@@ -32,7 +32,7 @@
  * will be chosen at runtime), the function names need to be
  * suffixed
  */
-#if !defined(SDL_THREAD_GENERIC_COND_SUFFIX)
+#ifndef SDL_THREAD_GENERIC_COND_SUFFIX
 #define SDL_CreateCond_generic      SDL_CreateCond
 #define SDL_DestroyCond_generic     SDL_DestroyCond
 #define SDL_CondSignal_generic      SDL_CondSignal

--- a/src/thread/generic/SDL_sysmutex.c
+++ b/src/thread/generic/SDL_sysmutex.c
@@ -72,7 +72,7 @@ void SDL_DestroyMutex(SDL_mutex *mutex)
 /* Lock the mutex */
 int SDL_LockMutex(SDL_mutex *mutex) SDL_NO_THREAD_SAFETY_ANALYSIS /* clang doesn't know about NULL mutexes */
 {
-#if defined(SDL_THREADS_DISABLED)
+#ifdef SDL_THREADS_DISABLED
     return 0;
 #else
     SDL_threadID this_thread;
@@ -101,7 +101,7 @@ int SDL_LockMutex(SDL_mutex *mutex) SDL_NO_THREAD_SAFETY_ANALYSIS /* clang doesn
 /* try Lock the mutex */
 int SDL_TryLockMutex(SDL_mutex *mutex)
 {
-#if defined(SDL_THREADS_DISABLED)
+#ifdef SDL_THREADS_DISABLED
     return 0;
 #else
     int retval = 0;
@@ -133,7 +133,7 @@ int SDL_TryLockMutex(SDL_mutex *mutex)
 /* Unlock the mutex */
 int SDL_UnlockMutex(SDL_mutex *mutex) SDL_NO_THREAD_SAFETY_ANALYSIS /* clang doesn't know about NULL mutexes */
 {
-#if defined(SDL_THREADS_DISABLED)
+#ifdef SDL_THREADS_DISABLED
     return 0;
 #else
     if (mutex == NULL) {

--- a/src/thread/generic/SDL_syssem.c
+++ b/src/thread/generic/SDL_syssem.c
@@ -24,7 +24,7 @@
 
 #include "SDL_systhread_c.h"
 
-#if defined(SDL_THREADS_DISABLED)
+#ifdef SDL_THREADS_DISABLED
 
 SDL_sem *
 SDL_CreateSemaphore(Uint32 initial_value)

--- a/src/thread/psp/SDL_sysmutex.c
+++ b/src/thread/psp/SDL_sysmutex.c
@@ -75,7 +75,7 @@ void SDL_DestroyMutex(SDL_mutex *mutex)
 /* Lock the mutex */
 int SDL_LockMutex(SDL_mutex *mutex) SDL_NO_THREAD_SAFETY_ANALYSIS /* clang doesn't know about NULL mutexes */
 {
-#if defined(SDL_THREADS_DISABLED)
+#ifdef SDL_THREADS_DISABLED
     return 0;
 #else
     SceInt32 res = 0;
@@ -96,7 +96,7 @@ int SDL_LockMutex(SDL_mutex *mutex) SDL_NO_THREAD_SAFETY_ANALYSIS /* clang doesn
 /* Try to lock the mutex */
 int SDL_TryLockMutex(SDL_mutex *mutex)
 {
-#if defined(SDL_THREADS_DISABLED)
+#ifdef SDL_THREADS_DISABLED
     return 0;
 #else
     SceInt32 res = 0;
@@ -125,7 +125,7 @@ int SDL_TryLockMutex(SDL_mutex *mutex)
 /* Unlock the mutex */
 int SDL_UnlockMutex(SDL_mutex *mutex) SDL_NO_THREAD_SAFETY_ANALYSIS /* clang doesn't know about NULL mutexes */
 {
-#if defined(SDL_THREADS_DISABLED)
+#ifdef SDL_THREADS_DISABLED
     return 0;
 #else
     SceInt32 res = 0;

--- a/src/thread/pthread/SDL_sysmutex.c
+++ b/src/thread/pthread/SDL_sysmutex.c
@@ -48,7 +48,7 @@ SDL_CreateMutex(void)
     mutex = (SDL_mutex *)SDL_calloc(1, sizeof(*mutex));
     if (mutex) {
         pthread_mutexattr_init(&attr);
-#if defined(SDL_THREAD_PTHREAD_RECURSIVE_MUTEX)
+#ifdef SDL_THREAD_PTHREAD_RECURSIVE_MUTEX
         pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
 #elif defined(SDL_THREAD_PTHREAD_RECURSIVE_MUTEX_NP)
         pthread_mutexattr_setkind_np(&attr, PTHREAD_MUTEX_RECURSIVE_NP);

--- a/src/thread/pthread/SDL_systhread.c
+++ b/src/thread/pthread/SDL_systhread.c
@@ -133,7 +133,7 @@ void SDL_SYS_SetupThread(const char *name)
 #endif
         }
 #elif defined(HAVE_PTHREAD_SETNAME_NP)
-#if defined(__NETBSD__)
+#ifdef __NETBSD__
         pthread_setname_np(pthread_self(), "%s", name);
 #else
         if (pthread_setname_np(pthread_self(), name) == ERANGE) {
@@ -176,7 +176,7 @@ SDL_ThreadID(void)
 
 int SDL_SYS_SetThreadPriority(SDL_ThreadPriority priority)
 {
-#if defined(__RISCOS__)
+#ifdef __RISCOS__
     /* FIXME: Setting thread priority does not seem to be supported */
     return 0;
 #else

--- a/src/thread/vita/SDL_sysmutex.c
+++ b/src/thread/vita/SDL_sysmutex.c
@@ -71,7 +71,7 @@ void SDL_DestroyMutex(SDL_mutex *mutex)
 /* Lock the mutex */
 int SDL_LockMutex(SDL_mutex *mutex) SDL_NO_THREAD_SAFETY_ANALYSIS /* clang doesn't know about NULL mutexes */
 {
-#if defined(SDL_THREADS_DISABLED)
+#ifdef SDL_THREADS_DISABLED
     return 0;
 #else
     SceInt32 res = 0;
@@ -92,7 +92,7 @@ int SDL_LockMutex(SDL_mutex *mutex) SDL_NO_THREAD_SAFETY_ANALYSIS /* clang doesn
 /* Try to lock the mutex */
 int SDL_TryLockMutex(SDL_mutex *mutex)
 {
-#if defined(SDL_THREADS_DISABLED)
+#ifdef SDL_THREADS_DISABLED
     return 0;
 #else
     SceInt32 res = 0;
@@ -121,7 +121,7 @@ int SDL_TryLockMutex(SDL_mutex *mutex)
 /* Unlock the mutex */
 int SDL_UnlockMutex(SDL_mutex *mutex) SDL_NO_THREAD_SAFETY_ANALYSIS /* clang doesn't know about NULL mutexes */
 {
-#if defined(SDL_THREADS_DISABLED)
+#ifdef SDL_THREADS_DISABLED
     return 0;
 #else
     SceInt32 res = 0;

--- a/src/timer/ngage/SDL_systimer.cpp
+++ b/src/timer/ngage/SDL_systimer.cpp
@@ -20,7 +20,7 @@
 */
 #include "SDL_internal.h"
 
-#if defined(SDL_TIMER_NGAGE)
+#ifdef SDL_TIMER_NGAGE
 
 #include <e32std.h>
 #include <e32hal.h>

--- a/src/timer/unix/SDL_systimer.c
+++ b/src/timer/unix/SDL_systimer.c
@@ -69,7 +69,7 @@ static SDL_bool has_monotonic_time = SDL_FALSE;
 
 static void CheckMonotonicTime(void)
 {
-#if defined(HAVE_CLOCK_GETTIME)
+#ifdef HAVE_CLOCK_GETTIME
     struct timespec value;
     if (clock_gettime(SDL_MONOTONIC_CLOCK, &value) == 0) {
         has_monotonic_time = SDL_TRUE;
@@ -92,7 +92,7 @@ SDL_GetPerformanceCounter(void)
     }
 
     if (has_monotonic_time) {
-#if defined(HAVE_CLOCK_GETTIME)
+#ifdef HAVE_CLOCK_GETTIME
         struct timespec now;
 
         clock_gettime(SDL_MONOTONIC_CLOCK, &now);
@@ -124,7 +124,7 @@ SDL_GetPerformanceFrequency(void)
     }
 
     if (has_monotonic_time) {
-#if defined(HAVE_CLOCK_GETTIME)
+#ifdef HAVE_CLOCK_GETTIME
         return SDL_NS_PER_SECOND;
 #elif defined(__APPLE__)
         Uint64 freq = mach_base_info.denom;
@@ -141,7 +141,7 @@ void SDL_DelayNS(Uint64 ns)
 {
     int was_error;
 
-#if defined(HAVE_NANOSLEEP)
+#ifdef HAVE_NANOSLEEP
     struct timespec tv, remaining;
 #else
     struct timeval tv;
@@ -157,7 +157,7 @@ void SDL_DelayNS(Uint64 ns)
 #endif
 
     /* Set the timeout interval */
-#if defined(HAVE_NANOSLEEP)
+#ifdef HAVE_NANOSLEEP
     remaining.tv_sec = (time_t)(ns / SDL_NS_PER_SECOND);
     remaining.tv_nsec = (long)(ns % SDL_NS_PER_SECOND);
 #else
@@ -166,7 +166,7 @@ void SDL_DelayNS(Uint64 ns)
     do {
         errno = 0;
 
-#if defined(HAVE_NANOSLEEP)
+#ifdef HAVE_NANOSLEEP
         tv.tv_sec = remaining.tv_sec;
         tv.tv_nsec = remaining.tv_nsec;
         was_error = nanosleep(&tv, &remaining);

--- a/src/video/SDL_blit.h
+++ b/src/video/SDL_blit.h
@@ -112,7 +112,7 @@ extern SDL_BlitFunc SDL_CalculateBlitA(SDL_Surface *surface);
  * Useful macros for blitting routines
  */
 
-#if defined(__GNUC__)
+#ifdef __GNUC__
 #define DECLARE_ALIGNED(t, v, a) t __attribute__((aligned(a))) v
 #elif defined(_MSC_VER)
 #define DECLARE_ALIGNED(t, v, a) __declspec(align(a)) t v

--- a/src/video/SDL_blit_A.c
+++ b/src/video/SDL_blit_A.c
@@ -166,7 +166,7 @@ static void BlitNto1SurfaceAlphaKey(SDL_BlitInfo *info)
     }
 }
 
-#if defined(SDL_MMX_INTRINSICS)
+#ifdef SDL_MMX_INTRINSICS
 
 /* fast RGB888->(A)RGB888 blending with surface alpha=128 special case */
 static void SDL_TARGETING("mmx") BlitRGBtoRGBSurfaceAlpha128MMX(SDL_BlitInfo *info)
@@ -441,7 +441,7 @@ static void BlitRGBtoRGBPixelAlphaARMSIMD(SDL_BlitInfo *info)
 }
 #endif
 
-#if defined(SDL_ARM_NEON_BLITTERS)
+#ifdef SDL_ARM_NEON_BLITTERS
 void BlitARGBto565PixelAlphaARMNEONAsm(int32_t w, int32_t h, uint16_t *dst, int32_t dst_stride, uint32_t *src, int32_t src_stride);
 
 static void BlitARGBto565PixelAlphaARMNEON(SDL_BlitInfo *info)
@@ -750,7 +750,7 @@ static void Blit16to16SurfaceAlpha128(SDL_BlitInfo *info, Uint16 mask)
     }
 }
 
-#if defined(SDL_MMX_INTRINSICS)
+#ifdef SDL_MMX_INTRINSICS
 
 /* fast RGB565->RGB565 blending with surface alpha */
 static void SDL_TARGETING("mmx") Blit565to565SurfaceAlphaMMX(SDL_BlitInfo *info)
@@ -1337,12 +1337,12 @@ SDL_CalculateBlitA(SDL_Surface *surface)
         case 2:
 #if defined(SDL_ARM_NEON_BLITTERS) || defined(SDL_ARM_SIMD_BLITTERS)
             if (sf->BytesPerPixel == 4 && sf->Amask == 0xff000000 && sf->Gmask == 0xff00 && df->Gmask == 0x7e0 && ((sf->Rmask == 0xff && df->Rmask == 0x1f) || (sf->Bmask == 0xff && df->Bmask == 0x1f))) {
-#if defined(SDL_ARM_NEON_BLITTERS)
+#ifdef SDL_ARM_NEON_BLITTERS
                 if (SDL_HasNEON()) {
                     return BlitARGBto565PixelAlphaARMNEON;
                 }
 #endif
-#if defined(SDL_ARM_SIMD_BLITTERS)
+#ifdef SDL_ARM_SIMD_BLITTERS
                 if (SDL_HasARMSIMD()) {
                     return BlitARGBto565PixelAlphaARMSIMD;
                 }
@@ -1360,7 +1360,7 @@ SDL_CalculateBlitA(SDL_Surface *surface)
 
         case 4:
             if (sf->Rmask == df->Rmask && sf->Gmask == df->Gmask && sf->Bmask == df->Bmask && sf->BytesPerPixel == 4) {
-#if defined(SDL_MMX_INTRINSICS)
+#ifdef SDL_MMX_INTRINSICS
                 if (sf->Rshift % 8 == 0 && sf->Gshift % 8 == 0 && sf->Bshift % 8 == 0 && sf->Ashift % 8 == 0 && sf->Aloss == 0) {
                     if (SDL_HasMMX()) {
                         return BlitRGBtoRGBPixelAlphaMMX;
@@ -1368,12 +1368,12 @@ SDL_CalculateBlitA(SDL_Surface *surface)
                 }
 #endif /* SDL_MMX_INTRINSICS */
                 if (sf->Amask == 0xff000000) {
-#if defined(SDL_ARM_NEON_BLITTERS)
+#ifdef SDL_ARM_NEON_BLITTERS
                     if (SDL_HasNEON()) {
                         return BlitRGBtoRGBPixelAlphaARMNEON;
                     }
 #endif
-#if defined(SDL_ARM_SIMD_BLITTERS)
+#ifdef SDL_ARM_SIMD_BLITTERS
                     if (SDL_HasARMSIMD()) {
                         return BlitRGBtoRGBPixelAlphaARMSIMD;
                     }
@@ -1408,7 +1408,7 @@ SDL_CalculateBlitA(SDL_Surface *surface)
             case 2:
                 if (surface->map->identity) {
                     if (df->Gmask == 0x7e0) {
-#if defined(SDL_MMX_INTRINSICS)
+#ifdef SDL_MMX_INTRINSICS
                         if (SDL_HasMMX()) {
                             return Blit565to565SurfaceAlphaMMX;
                         } else
@@ -1417,7 +1417,7 @@ SDL_CalculateBlitA(SDL_Surface *surface)
                             return Blit565to565SurfaceAlpha;
                         }
                     } else if (df->Gmask == 0x3e0) {
-#if defined(SDL_MMX_INTRINSICS)
+#ifdef SDL_MMX_INTRINSICS
                         if (SDL_HasMMX()) {
                             return Blit555to555SurfaceAlphaMMX;
                         } else
@@ -1431,7 +1431,7 @@ SDL_CalculateBlitA(SDL_Surface *surface)
 
             case 4:
                 if (sf->Rmask == df->Rmask && sf->Gmask == df->Gmask && sf->Bmask == df->Bmask && sf->BytesPerPixel == 4) {
-#if defined(SDL_MMX_INTRINSICS)
+#ifdef SDL_MMX_INTRINSICS
                     if (sf->Rshift % 8 == 0 && sf->Gshift % 8 == 0 && sf->Bshift % 8 == 0 && SDL_HasMMX()) {
                         return BlitRGBtoRGBSurfaceAlphaMMX;
                     }

--- a/src/video/SDL_blit_N.c
+++ b/src/video/SDL_blit_N.c
@@ -29,7 +29,7 @@
 #define HAVE_FAST_WRITE_INT8 1
 
 /* On some CPU, it's slower than combining and write a word */
-#if defined(__MIPS__)
+#ifdef __MIPS__
 #undef HAVE_FAST_WRITE_INT8
 #define HAVE_FAST_WRITE_INT8 0
 #endif
@@ -904,7 +904,7 @@ static enum blit_features GetBlitFeatures(void)
 #define GetBlitFeatures() ((SDL_HasMMX() ? BLIT_FEATURE_HAS_MMX : 0) | (SDL_HasARMSIMD() ? BLIT_FEATURE_HAS_ARM_SIMD : 0))
 #endif
 
-#if defined(SDL_ARM_SIMD_BLITTERS)
+#ifdef SDL_ARM_SIMD_BLITTERS
 void Blit_BGR888_RGB888ARMSIMDAsm(int32_t w, int32_t h, uint32_t *dst, int32_t dst_stride, uint32_t *src, int32_t src_stride);
 
 static void Blit_BGR888_RGB888ARMSIMD(SDL_BlitInfo *info)

--- a/src/video/SDL_blit_copy.c
+++ b/src/video/SDL_blit_copy.c
@@ -23,7 +23,7 @@
 #include "SDL_blit.h"
 #include "SDL_blit_copy.h"
 
-#if defined(SDL_SSE_INTRINSICS)
+#ifdef SDL_SSE_INTRINSICS
 /* This assumes 16-byte aligned src and dst */
 static SDL_INLINE void SDL_TARGETING("sse") SDL_memcpySSE(Uint8 *dst, const Uint8 *src, int len)
 {
@@ -50,7 +50,7 @@ static SDL_INLINE void SDL_TARGETING("sse") SDL_memcpySSE(Uint8 *dst, const Uint
 }
 #endif /* SDL_SSE_INTRINSICS */
 
-#if defined(SDL_MMX_INTRINSICS)
+#ifdef SDL_MMX_INTRINSICS
 #ifdef _MSC_VER
 #pragma warning(disable : 4799)
 #endif
@@ -136,7 +136,7 @@ void SDL_BlitCopy(SDL_BlitInfo *info)
         return;
     }
 
-#if defined(SDL_SSE_INTRINSICS)
+#ifdef SDL_SSE_INTRINSICS
     if (SDL_HasSSE() &&
         !((uintptr_t)src & 15) && !(srcskip & 15) &&
         !((uintptr_t)dst & 15) && !(dstskip & 15)) {
@@ -149,7 +149,7 @@ void SDL_BlitCopy(SDL_BlitInfo *info)
     }
 #endif
 
-#if defined(SDL_MMX_INTRINSICS)
+#ifdef SDL_MMX_INTRINSICS
     if (SDL_HasMMX() && !(srcskip & 7) && !(dstskip & 7)) {
         SDL_BlitCopyMMX(dst, src, dstskip, srcskip, w, h);
         return;

--- a/src/video/SDL_egl.c
+++ b/src/video/SDL_egl.c
@@ -58,7 +58,7 @@
 #define EGL_PRESENT_OPAQUE_EXT 0x31DF
 #endif /* EGL_EXT_present_opaque */
 
-#if defined(SDL_VIDEO_DRIVER_RPI)
+#ifdef SDL_VIDEO_DRIVER_RPI
 /* Raspbian places the OpenGL ES/EGL binaries in a non standard path */
 #define DEFAULT_EGL        (vc4 ? "libEGL.so.1" : "libbrcmEGL.so")
 #define DEFAULT_OGL_ES2    (vc4 ? "libGLESv2.so.2" : "libbrcmGLESv2.so")
@@ -304,7 +304,7 @@ static int SDL_EGL_LoadLibraryInternal(_THIS, const char *egl_path)
 #if defined(SDL_VIDEO_DRIVER_WINDOWS) || defined(SDL_VIDEO_DRIVER_WINRT)
     const char *d3dcompiler;
 #endif
-#if defined(SDL_VIDEO_DRIVER_RPI)
+#ifdef SDL_VIDEO_DRIVER_RPI
     SDL_bool vc4 = (0 == access("/sys/module/vc4/", F_OK));
 #endif
 
@@ -425,7 +425,7 @@ static int SDL_EGL_LoadLibraryInternal(_THIS, const char *egl_path)
 #endif
 
     _this->egl_data->egl_dll_handle = egl_dll_handle;
-#if defined(SDL_VIDEO_DRIVER_VITA)
+#ifdef SDL_VIDEO_DRIVER_VITA
     _this->egl_data->opengl_dll_handle = opengl_dll_handle;
 #endif
 
@@ -512,8 +512,8 @@ int SDL_EGL_LoadLibrary(_THIS, const char *egl_path, NativeDisplayType native_di
 
     _this->egl_data->egl_display = EGL_NO_DISPLAY;
 
-#if !defined(__WINRT__)
-#if !defined(SDL_VIDEO_DRIVER_VITA)
+#ifndef __WINRT__
+#ifndef SDL_VIDEO_DRIVER_VITA
     if (platform) {
         /* EGL 1.5 allows querying for client version with EGL_NO_DISPLAY
          * --

--- a/src/video/SDL_fillrect.c
+++ b/src/video/SDL_fillrect.c
@@ -22,7 +22,7 @@
 
 #include "SDL_blit.h"
 
-#if defined(SDL_SSE_INTRINSICS)
+#ifdef SDL_SSE_INTRINSICS
 /* *INDENT-OFF* */ /* clang-format off */
 
 #if defined(_MSC_VER) && !defined(__clang__)
@@ -247,7 +247,7 @@ int SDL_FillSurfaceRect(SDL_Surface *dst, const SDL_Rect *rect, Uint32 color)
     return SDL_FillSurfaceRects(dst, rect, 1, color);
 }
 
-#if defined(SDL_ARM_NEON_BLITTERS)
+#ifdef SDL_ARM_NEON_BLITTERS
 void FillSurfaceRect8ARMNEONAsm(int32_t w, int32_t h, uint8_t *dst, int32_t dst_stride, uint8_t src);
 void FillSurfaceRect16ARMNEONAsm(int32_t w, int32_t h, uint16_t *dst, int32_t dst_stride, uint16_t src);
 void FillSurfaceRect32ARMNEONAsm(int32_t w, int32_t h, uint32_t *dst, int32_t dst_stride, uint32_t src);
@@ -339,7 +339,7 @@ int SDL_FillSurfaceRects(SDL_Surface *dst, const SDL_Rect *rects, int count,
         return SDL_SetError("SDL_FillSurfaceRects(): Unsupported surface format");
     }
 
-#if defined(SDL_ARM_NEON_BLITTERS)
+#ifdef SDL_ARM_NEON_BLITTERS
     if (SDL_HasNEON() && dst->format->BytesPerPixel != 3 && fill_function == NULL) {
         switch (dst->format->BytesPerPixel) {
         case 1:
@@ -376,7 +376,7 @@ int SDL_FillSurfaceRects(SDL_Surface *dst, const SDL_Rect *rects, int count,
         {
             color |= (color << 8);
             color |= (color << 16);
-#if defined(SDL_SSE_INTRINSICS)
+#ifdef SDL_SSE_INTRINSICS
             if (SDL_HasSSE()) {
                 fill_function = SDL_FillSurfaceRect1SSE;
                 break;
@@ -389,7 +389,7 @@ int SDL_FillSurfaceRects(SDL_Surface *dst, const SDL_Rect *rects, int count,
         case 2:
         {
             color |= (color << 16);
-#if defined(SDL_SSE_INTRINSICS)
+#ifdef SDL_SSE_INTRINSICS
             if (SDL_HasSSE()) {
                 fill_function = SDL_FillSurfaceRect2SSE;
                 break;
@@ -408,7 +408,7 @@ int SDL_FillSurfaceRects(SDL_Surface *dst, const SDL_Rect *rects, int count,
 
         case 4:
         {
-#if defined(SDL_SSE_INTRINSICS)
+#ifdef SDL_SSE_INTRINSICS
             if (SDL_HasSSE()) {
                 fill_function = SDL_FillSurfaceRect4SSE;
                 break;

--- a/src/video/SDL_stretch.c
+++ b/src/video/SDL_stretch.c
@@ -183,7 +183,7 @@ static int SDL_UpperSoftStretch(SDL_Surface *src, const SDL_Rect *srcrect,
     left_pad_w = left_pad_w_init;                                      \
     middle = middle_init;
 
-#if defined(__clang__)
+#ifdef __clang__
 // Remove inlining of this function
 // Compiler crash with clang 9.0.8 / android-ndk-r21d
 // Compiler crash with clang 11.0.3 / Xcode
@@ -346,7 +346,7 @@ static int scale_mat(const Uint32 *src, int src_w, int src_h, int src_pitch,
 #endif
 #endif
 
-#if defined(SDL_SSE2_INTRINSICS)
+#ifdef SDL_SSE2_INTRINSICS
 
 #if 0
 static void SDL_TARGETING("sse2") printf_128(const char *str, __m128i var)
@@ -524,7 +524,7 @@ static int SDL_TARGETING("sse2") scale_mat_SSE(const Uint32 *src, int src_w, int
 }
 #endif
 
-#if defined(SDL_NEON_INTRINSICS)
+#ifdef SDL_NEON_INTRINSICS
 
 static SDL_INLINE int hasNEON(void)
 {
@@ -800,13 +800,13 @@ int SDL_LowerSoftStretchLinear(SDL_Surface *s, const SDL_Rect *srcrect,
     Uint32 *src = (Uint32 *)((Uint8 *)s->pixels + srcrect->x * 4 + srcrect->y * src_pitch);
     Uint32 *dst = (Uint32 *)((Uint8 *)d->pixels + dstrect->x * 4 + dstrect->y * dst_pitch);
 
-#if defined(SDL_NEON_INTRINSICS)
+#ifdef SDL_NEON_INTRINSICS
     if (ret == -1 && hasNEON()) {
         ret = scale_mat_NEON(src, src_w, src_h, src_pitch, dst, dst_w, dst_h, dst_pitch);
     }
 #endif
 
-#if defined(SDL_SSE2_INTRINSICS)
+#ifdef SDL_SSE2_INTRINSICS
     if (ret == -1 && hasSSE2()) {
         ret = scale_mat_SSE(src, src_w, src_h, src_pitch, dst, dst_w, dst_h, dst_pitch);
     }

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -46,7 +46,7 @@
 #include <SDL3/SDL_opengles2.h>
 #endif /* SDL_VIDEO_OPENGL_ES2 && !SDL_VIDEO_OPENGL */
 
-#if !defined(SDL_VIDEO_OPENGL)
+#ifndef SDL_VIDEO_OPENGL
 #ifndef GL_CONTEXT_RELEASE_BEHAVIOR_KHR
 #define GL_CONTEXT_RELEASE_BEHAVIOR_KHR 0x82FB
 #endif
@@ -1536,7 +1536,7 @@ static int SDL_UpdateFullscreenMode(SDL_Window *window, SDL_bool fullscreen)
         }
         display->fullscreen_window = window;
 
-#if defined(__ANDROID__)
+#ifdef __ANDROID__
         /* Android may not resize the window to exactly what our fullscreen mode is,
          * especially on windowed Android environments like the Chromebook or Samsung DeX.
          * Given this, we shouldn't use the mode size. Android's SetWindowFullscreen
@@ -2901,7 +2901,7 @@ static SDL_Surface *SDL_CreateWindowFramebuffer(SDL_Window *window)
             attempt_texture_framebuffer = SDL_FALSE;
         }
 
-#if defined(__LINUX__)
+#ifdef __LINUX__
         /* On WSL, direct X11 is faster than using OpenGL for window framebuffers, so try to detect WSL and avoid texture framebuffer. */
         else if ((_this->CreateWindowFramebuffer != NULL) && (SDL_strcmp(_this->name, "x11") == 0)) {
             struct stat sb;
@@ -2915,7 +2915,7 @@ static SDL_Surface *SDL_CreateWindowFramebuffer(SDL_Window *window)
             attempt_texture_framebuffer = SDL_FALSE;
         }
 #endif
-#if defined(__EMSCRIPTEN__)
+#ifdef __EMSCRIPTEN__
         else {
             attempt_texture_framebuffer = SDL_FALSE;
         }
@@ -3672,7 +3672,7 @@ void SDL_GL_UnloadLibrary(void)
 typedef GLenum (APIENTRY* PFNGLGETERRORPROC) (void);
 typedef void (APIENTRY* PFNGLGETINTEGERVPROC) (GLenum pname, GLint *params);
 typedef const GLubyte *(APIENTRY* PFNGLGETSTRINGPROC) (GLenum name);
-#if !defined(SDL_VIDEO_OPENGL)
+#ifndef SDL_VIDEO_OPENGL
 typedef const GLubyte *(APIENTRY* PFNGLGETSTRINGIPROC) (GLenum name, GLuint index);
 #endif
 
@@ -3839,7 +3839,7 @@ void SDL_GL_ResetAttributes(void)
     _this->gl_config.retained_backing = 1;
     _this->gl_config.accelerated = -1; /* accelerated or not, both are fine */
 
-#if defined(SDL_VIDEO_OPENGL)
+#ifdef SDL_VIDEO_OPENGL
     _this->gl_config.major_version = 2;
     _this->gl_config.minor_version = 1;
     _this->gl_config.profile_mask = 0;
@@ -4102,7 +4102,7 @@ int SDL_GL_GetAttribute(SDL_GLattr attr, int *value)
         attrib = GL_SAMPLES;
         break;
     case SDL_GL_CONTEXT_RELEASE_BEHAVIOR:
-#if defined(SDL_VIDEO_OPENGL)
+#ifdef SDL_VIDEO_OPENGL
         attrib = GL_CONTEXT_RELEASE_BEHAVIOR;
 #else
         attrib = GL_CONTEXT_RELEASE_BEHAVIOR_KHR;

--- a/src/video/SDL_yuv.c
+++ b/src/video/SDL_yuv.c
@@ -303,7 +303,7 @@ static int GetYUVPlanes(int width, int height, Uint32 format, const void *yuv, i
     return 0;
 }
 
-#if defined(SDL_SSE2_INTRINSICS)
+#ifdef SDL_SSE2_INTRINSICS
 static SDL_bool SDL_TARGETING("sse2") yuv_rgb_sse(
     Uint32 src_format, Uint32 dst_format,
     Uint32 width, Uint32 height,
@@ -1122,7 +1122,7 @@ static int SDL_ConvertPixels_SwapUVPlanes(int width, int height, const void *src
     return 0;
 }
 
-#if defined(SDL_SSE2_INTRINSICS)
+#ifdef SDL_SSE2_INTRINSICS
 static int SDL_TARGETING("sse2") SDL_ConvertPixels_PackUVPlanes_to_NV_SSE2(int width, int height, const void *src, int src_pitch, void *dst, int dst_pitch, SDL_bool reverseUV)
 {
     int x, y;
@@ -1441,7 +1441,7 @@ static int SDL_ConvertPixels_SwapNV_std(int width, int height, const void *src, 
 
 static int SDL_ConvertPixels_PackUVPlanes_to_NV(int width, int height, const void *src, int src_pitch, void *dst, int dst_pitch, SDL_bool reverseUV)
 {
-#if defined(SDL_SSE2_INTRINSICS)
+#ifdef SDL_SSE2_INTRINSICS
     if (SDL_HasSSE2()) {
       return SDL_ConvertPixels_PackUVPlanes_to_NV_SSE2(width, height, src, src_pitch, dst, dst_pitch, reverseUV);
     }
@@ -1451,7 +1451,7 @@ static int SDL_ConvertPixels_PackUVPlanes_to_NV(int width, int height, const voi
 
 static int SDL_ConvertPixels_SplitNV_to_UVPlanes(int width, int height, const void *src, int src_pitch, void *dst, int dst_pitch, SDL_bool reverseUV)
 {
-#if defined(SDL_SSE2_INTRINSICS)
+#ifdef SDL_SSE2_INTRINSICS
     if (SDL_HasSSE2()) {
       return SDL_ConvertPixels_SplitNV_to_UVPlanes_SSE2(width, height, src, src_pitch, dst, dst_pitch, reverseUV);
     }
@@ -1461,7 +1461,7 @@ static int SDL_ConvertPixels_SplitNV_to_UVPlanes(int width, int height, const vo
 
 static int SDL_ConvertPixels_SwapNV(int width, int height, const void *src, int src_pitch, void *dst, int dst_pitch)
 {
-#if defined(SDL_SSE2_INTRINSICS)
+#ifdef SDL_SSE2_INTRINSICS
     if (SDL_HasSSE2()) {
       return SDL_ConvertPixels_SwapNV_SSE2(width, height, src, src_pitch, dst, dst_pitch);
     }
@@ -1541,7 +1541,7 @@ static int SDL_ConvertPixels_Planar2x2_to_Planar2x2(int width, int height,
                         SDL_GetPixelFormatName(dst_format));
 }
 
-#if defined(SDL_SSE2_INTRINSICS)
+#ifdef SDL_SSE2_INTRINSICS
 #define PACKED4_TO_PACKED4_ROW_SSE2(shuffle)                      \
     while (x >= 4) {                                              \
         __m128i yuv = _mm_loadu_si128((__m128i *)srcYUV);         \
@@ -1969,7 +1969,7 @@ static int SDL_ConvertPixels_YVYU_to_UYVY_std(int width, int height, const void 
 
 static int SDL_ConvertPixels_YUY2_to_UYVY(int width, int height, const void *src, int src_pitch, void *dst, int dst_pitch)
 {
-#if defined(SDL_SSE2_INTRINSICS)
+#ifdef SDL_SSE2_INTRINSICS
     if (SDL_HasSSE2()) {
       return SDL_ConvertPixels_YUY2_to_UYVY_SSE2(width, height, src, src_pitch, dst, dst_pitch);
     }
@@ -1979,7 +1979,7 @@ static int SDL_ConvertPixels_YUY2_to_UYVY(int width, int height, const void *src
 
 static int SDL_ConvertPixels_YUY2_to_YVYU(int width, int height, const void *src, int src_pitch, void *dst, int dst_pitch)
 {
-#if defined(SDL_SSE2_INTRINSICS)
+#ifdef SDL_SSE2_INTRINSICS
     if (SDL_HasSSE2()) {
       return SDL_ConvertPixels_YUY2_to_YVYU_SSE2(width, height, src, src_pitch, dst, dst_pitch);
     }
@@ -1989,7 +1989,7 @@ static int SDL_ConvertPixels_YUY2_to_YVYU(int width, int height, const void *src
 
 static int SDL_ConvertPixels_UYVY_to_YUY2(int width, int height, const void *src, int src_pitch, void *dst, int dst_pitch)
 {
-#if defined(SDL_SSE2_INTRINSICS)
+#ifdef SDL_SSE2_INTRINSICS
     if (SDL_HasSSE2()) {
       return SDL_ConvertPixels_UYVY_to_YUY2_SSE2(width, height, src, src_pitch, dst, dst_pitch);
     }
@@ -1999,7 +1999,7 @@ static int SDL_ConvertPixels_UYVY_to_YUY2(int width, int height, const void *src
 
 static int SDL_ConvertPixels_UYVY_to_YVYU(int width, int height, const void *src, int src_pitch, void *dst, int dst_pitch)
 {
-#if defined(SDL_SSE2_INTRINSICS)
+#ifdef SDL_SSE2_INTRINSICS
     if (SDL_HasSSE2()) {
       return SDL_ConvertPixels_UYVY_to_YVYU_SSE2(width, height, src, src_pitch, dst, dst_pitch);
     }
@@ -2009,7 +2009,7 @@ static int SDL_ConvertPixels_UYVY_to_YVYU(int width, int height, const void *src
 
 static int SDL_ConvertPixels_YVYU_to_YUY2(int width, int height, const void *src, int src_pitch, void *dst, int dst_pitch)
 {
-#if defined(SDL_SSE2_INTRINSICS)
+#ifdef SDL_SSE2_INTRINSICS
     if (SDL_HasSSE2()) {
       return SDL_ConvertPixels_YVYU_to_YUY2_SSE2(width, height, src, src_pitch, dst, dst_pitch);
     }
@@ -2019,7 +2019,7 @@ static int SDL_ConvertPixels_YVYU_to_YUY2(int width, int height, const void *src
 
 static int SDL_ConvertPixels_YVYU_to_UYVY(int width, int height, const void *src, int src_pitch, void *dst, int dst_pitch)
 {
-#if defined(SDL_SSE2_INTRINSICS)
+#ifdef SDL_SSE2_INTRINSICS
     if (SDL_HasSSE2()) {
       return SDL_ConvertPixels_YVYU_to_UYVY_SSE2(width, height, src, src_pitch, dst, dst_pitch);
     }

--- a/src/video/cocoa/SDL_cocoakeyboard.m
+++ b/src/video/cocoa/SDL_cocoakeyboard.m
@@ -448,7 +448,7 @@ extern CGError CGSSetGlobalHotKeyOperatingMode(CGSConnection connection, CGSGlob
 
 void Cocoa_SetWindowKeyboardGrab(_THIS, SDL_Window *window, SDL_bool grabbed)
 {
-#if defined(SDL_MAC_NO_SANDBOX)
+#ifdef SDL_MAC_NO_SANDBOX
     CGSSetGlobalHotKeyOperatingMode(_CGSDefaultConnection(), grabbed ? CGSGlobalHotKeyDisable : CGSGlobalHotKeyEnable);
 #endif
 }

--- a/src/video/cocoa/SDL_cocoamodes.m
+++ b/src/video/cocoa/SDL_cocoamodes.m
@@ -20,7 +20,7 @@
 */
 #include "SDL_internal.h"
 
-#if defined(SDL_VIDEO_DRIVER_COCOA)
+#ifdef SDL_VIDEO_DRIVER_COCOA
 
 #include "SDL_cocoavideo.h"
 

--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -20,7 +20,7 @@
 */
 #include "SDL_internal.h"
 
-#if defined(SDL_VIDEO_DRIVER_COCOA)
+#ifdef SDL_VIDEO_DRIVER_COCOA
 
 #include "SDL_cocoamouse.h"
 #include "SDL_cocoavideo.h"

--- a/src/video/cocoa/SDL_cocoashape.m
+++ b/src/video/cocoa/SDL_cocoashape.m
@@ -20,7 +20,7 @@
 */
 #include "SDL_internal.h"
 
-#if defined(SDL_VIDEO_DRIVER_COCOA)
+#ifdef SDL_VIDEO_DRIVER_COCOA
 
 #include "SDL_cocoavideo.h"
 #include "SDL_cocoashape.h"

--- a/src/video/cocoa/SDL_cocoavideo.m
+++ b/src/video/cocoa/SDL_cocoavideo.m
@@ -20,7 +20,7 @@
 */
 #include "SDL_internal.h"
 
-#if defined(SDL_VIDEO_DRIVER_COCOA)
+#ifdef SDL_VIDEO_DRIVER_COCOA
 
 #if !__has_feature(objc_arc)
 #error SDL must be built with Objective-C ARC (automatic reference counting) enabled

--- a/src/video/khronos/EGL/eglplatform.h
+++ b/src/video/khronos/EGL/eglplatform.h
@@ -48,7 +48,7 @@
  * implementations.
  */
 
-#if defined(EGL_NO_PLATFORM_SPECIFIC_TYPES)
+#ifdef EGL_NO_PLATFORM_SPECIFIC_TYPES
 
 typedef void *EGLNativeDisplayType;
 typedef void *EGLNativePixmapType;
@@ -160,7 +160,7 @@ typedef khronos_int32_t EGLint;
 
 
 /* C++ / C typecast macros for special EGL handle values */
-#if defined(__cplusplus)
+#ifdef __cplusplus
 #define EGL_CAST(type, value) (static_cast<type>(value))
 #else
 #define EGL_CAST(type, value) ((type) (value))

--- a/src/video/khronos/KHR/khrplatform.h
+++ b/src/video/khronos/KHR/khrplatform.h
@@ -99,7 +99,7 @@
  *-------------------------------------------------------------------------
  * This precedes the return type of the function in the function prototype.
  */
-#if defined(KHRONOS_STATIC)
+#ifdef KHRONOS_STATIC
     /* If the preprocessor constant KHRONOS_STATIC is defined, make the
      * header compatible with static linking. */
 #   define KHRONOS_APICALL
@@ -260,7 +260,7 @@ typedef signed   long  int     khronos_intptr_t;
 typedef unsigned long  int     khronos_uintptr_t;
 #endif
 
-#if defined(_WIN64)
+#ifdef _WIN64
 typedef signed   long long int khronos_ssize_t;
 typedef unsigned long long int khronos_usize_t;
 #else

--- a/src/video/kmsdrm/SDL_kmsdrmvulkan.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvulkan.c
@@ -36,7 +36,7 @@
 
 #include <sys/ioctl.h>
 
-#if defined(__OpenBSD__)
+#ifdef __OpenBSD__
 #define DEFAULT_VULKAN "libvulkan.so"
 #else
 #define DEFAULT_VULKAN "libvulkan.so.1"

--- a/src/video/uikit/SDL_uikitvideo.m
+++ b/src/video/uikit/SDL_uikitvideo.m
@@ -265,7 +265,7 @@ void UIKit_ForceUpdateHomeIndicator()
  *  identical!
  */
 
-#if !defined(SDL_VIDEO_DRIVER_COCOA)
+#ifndef SDL_VIDEO_DRIVER_COCOA
 void SDL_NSLog(const char *prefix, const char *text)
 {
     @autoreleasepool {

--- a/src/video/vita/SDL_vitakeyboard.c
+++ b/src/video/vita/SDL_vitakeyboard.c
@@ -39,7 +39,7 @@ Uint8 lock_key_down = 0;
 
 void VITA_InitKeyboard(void)
 {
-#if defined(SDL_VIDEO_VITA_PVR)
+#ifdef SDL_VIDEO_VITA_PVR
     sceSysmoduleLoadModule(SCE_SYSMODULE_IME); /** For PVR OSK Support **/
 #endif
     sceHidKeyboardEnumerate(&keyboard_hid_handle, 1);

--- a/src/video/vita/SDL_vitavideo.c
+++ b/src/video/vita/SDL_vitavideo.c
@@ -38,11 +38,11 @@
 #include "SDL_vitamouse_c.h"
 #include "SDL_vitaframebuffer.h"
 
-#if defined(SDL_VIDEO_VITA_PIB)
+#ifdef SDL_VIDEO_VITA_PIB
 #include "SDL_vitagles_c.h"
 #elif defined(SDL_VIDEO_VITA_PVR)
 #include "SDL_vitagles_pvr_c.h"
-#if defined(SDL_VIDEO_VITA_PVR_OGL)
+#ifdef SDL_VIDEO_VITA_PVR_OGL
 #include "SDL_vitagl_pvr_c.h"
 #endif
 #define VITA_GLES_GetProcAddress  SDL_EGL_GetProcAddressInternal
@@ -64,7 +64,7 @@ static SDL_VideoDevice *VITA_Create()
 {
     SDL_VideoDevice *device;
     SDL_VideoData *phdata;
-#if defined(SDL_VIDEO_VITA_PIB)
+#ifdef SDL_VIDEO_VITA_PIB
     SDL_GLDriverData *gldata;
 #endif
     /* Initialize SDL_VideoDevice structure */
@@ -81,7 +81,7 @@ static SDL_VideoDevice *VITA_Create()
         SDL_free(device);
         return NULL;
     }
-#if defined(SDL_VIDEO_VITA_PIB)
+#ifdef SDL_VIDEO_VITA_PIB
 
     gldata = (SDL_GLDriverData *)SDL_calloc(1, sizeof(SDL_GLDriverData));
     if (gldata == NULL) {
@@ -129,7 +129,7 @@ static SDL_VideoDevice *VITA_Create()
     */
 
 #if defined(SDL_VIDEO_VITA_PIB) || defined(SDL_VIDEO_VITA_PVR)
-#if defined(SDL_VIDEO_VITA_PVR_OGL)
+#ifdef SDL_VIDEO_VITA_PVR_OGL
     if (SDL_getenv("VITA_PVR_OGL") != NULL) {
         device->GL_LoadLibrary = VITA_GL_LoadLibrary;
         device->GL_CreateContext = VITA_GL_CreateContext;
@@ -139,7 +139,7 @@ static SDL_VideoDevice *VITA_Create()
         device->GL_LoadLibrary = VITA_GLES_LoadLibrary;
         device->GL_CreateContext = VITA_GLES_CreateContext;
         device->GL_GetProcAddress = VITA_GLES_GetProcAddress;
-#if defined(SDL_VIDEO_VITA_PVR_OGL)
+#ifdef SDL_VIDEO_VITA_PVR_OGL
     }
 #endif
 
@@ -173,12 +173,12 @@ VideoBootStrap VITA_bootstrap = {
 int VITA_VideoInit(_THIS)
 {
     SDL_DisplayMode mode;
-#if defined(SDL_VIDEO_VITA_PVR)
+#ifdef SDL_VIDEO_VITA_PVR
     char *res = SDL_getenv("VITA_RESOLUTION");
 #endif
     SDL_zero(mode);
 
-#if defined(SDL_VIDEO_VITA_PVR)
+#ifdef SDL_VIDEO_VITA_PVR
     if (res) {
         /* 1088i for PSTV (Or Sharpscale) */
         if (!SDL_strncmp(res, "1080", 4)) {
@@ -196,7 +196,7 @@ int VITA_VideoInit(_THIS)
 #endif
         mode.pixel_w = 960;
         mode.pixel_h = 544;
-#if defined(SDL_VIDEO_VITA_PVR)
+#ifdef SDL_VIDEO_VITA_PVR
     }
 #endif
 
@@ -224,7 +224,7 @@ void VITA_VideoQuit(_THIS)
 int VITA_CreateWindow(_THIS, SDL_Window *window)
 {
     SDL_WindowData *wdata;
-#if defined(SDL_VIDEO_VITA_PVR)
+#ifdef SDL_VIDEO_VITA_PVR
     Psp2NativeWindow win;
     int temp_major = 2;
     int temp_minor = 1;
@@ -247,7 +247,7 @@ int VITA_CreateWindow(_THIS, SDL_Window *window)
 
     Vita_Window = window;
 
-#if defined(SDL_VIDEO_VITA_PVR)
+#ifdef SDL_VIDEO_VITA_PVR
     win.type = PSP2_DRAWABLE_TYPE_WINDOW;
     win.numFlipBuffers = 2;
     win.flipChainThrdAffinity = 0x20000;
@@ -350,7 +350,7 @@ SDL_bool VITA_HasScreenKeyboardSupport(_THIS)
     return SDL_TRUE;
 }
 
-#if !defined(SCE_IME_LANGUAGE_ENGLISH_US)
+#ifndef SCE_IME_LANGUAGE_ENGLISH_US
 #define SCE_IME_LANGUAGE_ENGLISH_US SCE_IME_LANGUAGE_ENGLISH
 #endif
 
@@ -379,7 +379,7 @@ static void utf16_to_utf8(const uint16_t *src, uint8_t *dst)
     *dst = '\0';
 }
 
-#if defined(SDL_VIDEO_VITA_PVR)
+#ifdef SDL_VIDEO_VITA_PVR
 SceWChar16 libime_out[SCE_IME_MAX_PREEDIT_LENGTH + SCE_IME_MAX_TEXT_LENGTH + 1];
 char libime_initval[8] = { 1 };
 SceImeCaret caret_rev;
@@ -424,7 +424,7 @@ void VITA_ShowScreenKeyboard(_THIS, SDL_Window *window)
     SDL_VideoData *videodata = _this->driverdata;
     SceInt32 res;
 
-#if defined(SDL_VIDEO_VITA_PVR)
+#ifdef SDL_VIDEO_VITA_PVR
 
     SceUInt32 libime_work[SCE_IME_WORK_BUFFER_SIZE / sizeof(SceInt32)];
     SceImeParam param;
@@ -482,7 +482,7 @@ void VITA_ShowScreenKeyboard(_THIS, SDL_Window *window)
 
 void VITA_HideScreenKeyboard(_THIS, SDL_Window *window)
 {
-#if !defined(SDL_VIDEO_VITA_PVR)
+#ifndef SDL_VIDEO_VITA_PVR
     SDL_VideoData *videodata = _this->driverdata;
 
     SceCommonDialogStatus dialogStatus = sceImeDialogGetStatus();
@@ -503,7 +503,7 @@ void VITA_HideScreenKeyboard(_THIS, SDL_Window *window)
 
 SDL_bool VITA_IsScreenKeyboardShown(_THIS, SDL_Window *window)
 {
-#if defined(SDL_VIDEO_VITA_PVR)
+#ifdef SDL_VIDEO_VITA_PVR
     SDL_VideoData *videodata = _this->driverdata;
     return videodata->ime_active;
 #else
@@ -514,7 +514,7 @@ SDL_bool VITA_IsScreenKeyboardShown(_THIS, SDL_Window *window)
 
 void VITA_PumpEvents(_THIS)
 {
-#if !defined(SDL_VIDEO_VITA_PVR)
+#ifndef SDL_VIDEO_VITA_PVR
     SDL_VideoData *videodata = _this->driverdata;
 #endif
 
@@ -527,7 +527,7 @@ void VITA_PumpEvents(_THIS)
     VITA_PollKeyboard();
     VITA_PollMouse();
 
-#if !defined(SDL_VIDEO_VITA_PVR)
+#ifndef SDL_VIDEO_VITA_PVR
     if (videodata->ime_active == SDL_TRUE) {
         // update IME status. Terminate, if finished
         SceCommonDialogStatus dialogStatus = sceImeDialogGetStatus();

--- a/src/video/vita/SDL_vitavideo.h
+++ b/src/video/vita/SDL_vitavideo.h
@@ -45,7 +45,7 @@ struct SDL_WindowData
     SDL_bool uses_gles;
     SceUID buffer_uid;
     void *buffer;
-#if defined(SDL_VIDEO_VITA_PVR)
+#ifdef SDL_VIDEO_VITA_PVR
     EGLSurface egl_surface;
     EGLContext egl_context;
 #endif
@@ -77,7 +77,7 @@ void VITA_SetWindowGrab(_THIS, SDL_Window *window, SDL_bool grabbed);
 void VITA_DestroyWindow(_THIS, SDL_Window *window);
 
 #ifdef SDL_VIDEO_DRIVER_VITA
-#if defined(SDL_VIDEO_VITA_PVR_OGL)
+#ifdef SDL_VIDEO_VITA_PVR_OGL
 /* OpenGL functions */
 int VITA_GL_LoadLibrary(_THIS, const char *path);
 SDL_GLContext VITA_GL_CreateContext(_THIS, SDL_Window *window);

--- a/src/video/vivante/SDL_vivanteplatform.h
+++ b/src/video/vivante/SDL_vivanteplatform.h
@@ -27,7 +27,7 @@
 
 #include "SDL_vivantevideo.h"
 
-#if defined(CAVIUM)
+#ifdef CAVIUM
 #define VIVANTE_PLATFORM_CAVIUM
 #elif defined(MARVELL)
 #define VIVANTE_PLATFORM_MARVELL

--- a/src/video/wayland/SDL_waylanddatamanager.c
+++ b/src/video/wayland/SDL_waylanddatamanager.c
@@ -54,7 +54,7 @@ static ssize_t write_pipe(int fd, const void *buffer, size_t total_length, size_
     sigemptyset(&sig_set);
     sigaddset(&sig_set, SIGPIPE);
 
-#if defined(SDL_THREADS_DISABLED)
+#ifdef SDL_THREADS_DISABLED
     sigprocmask(SIG_BLOCK, &sig_set, &old_sig_set);
 #else
     pthread_sigmask(SIG_BLOCK, &sig_set, &old_sig_set);
@@ -76,7 +76,7 @@ static ssize_t write_pipe(int fd, const void *buffer, size_t total_length, size_
 
     sigtimedwait(&sig_set, 0, &zerotime);
 
-#if defined(SDL_THREADS_DISABLED)
+#ifdef SDL_THREADS_DISABLED
     sigprocmask(SIG_SETMASK, &old_sig_set, NULL);
 #else
     pthread_sigmask(SIG_SETMASK, &old_sig_set, NULL);

--- a/src/video/wayland/SDL_waylandmouse.h
+++ b/src/video/wayland/SDL_waylandmouse.h
@@ -22,7 +22,7 @@
 #include "SDL_internal.h"
 #include "SDL_waylandvideo.h"
 
-#if defined(SDL_VIDEO_DRIVER_WAYLAND)
+#ifdef SDL_VIDEO_DRIVER_WAYLAND
 
 extern void Wayland_InitMouse(void);
 extern void Wayland_FiniMouse(SDL_VideoData *data);

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -101,7 +101,7 @@ static char *get_classname(void)
 
     /* Next look at the application's executable name */
 #if defined(__LINUX__) || defined(__FREEBSD__)
-#if defined(__LINUX__)
+#ifdef __LINUX__
     (void)SDL_snprintf(procfile, SDL_arraysize(procfile), "/proc/%d/exe", getpid());
 #elif defined(__FREEBSD__)
     (void)SDL_snprintf(procfile, SDL_arraysize(procfile), "/proc/%d/file", getpid());

--- a/src/video/wayland/SDL_waylandvulkan.c
+++ b/src/video/wayland/SDL_waylandvulkan.c
@@ -35,7 +35,7 @@
 
 #include <SDL3/SDL_syswm.h>
 
-#if defined(__OpenBSD__)
+#ifdef __OpenBSD__
 #define DEFAULT_VULKAN "libvulkan.so"
 #else
 #define DEFAULT_VULKAN "libvulkan.so.1"

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -737,7 +737,7 @@ static const struct zxdg_toplevel_decoration_v1_listener decoration_listener = {
  */
 static void OverrideLibdecorLimits(SDL_Window *window)
 {
-#if defined(SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_LIBDECOR)
+#ifdef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_LIBDECOR
     if (libdecor_frame_get_min_content_size == NULL) {
         SetMinMaxDimensions(window, SDL_FALSE);
     }
@@ -756,7 +756,7 @@ static void OverrideLibdecorLimits(SDL_Window *window)
  */
 static void LibdecorGetMinContentSize(struct libdecor_frame *frame, int *min_w, int *min_h)
 {
-#if defined(SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_LIBDECOR)
+#ifdef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_LIBDECOR
     if (libdecor_frame_get_min_content_size != NULL) {
         libdecor_frame_get_min_content_size(frame, min_w, min_h);
     }

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -604,7 +604,7 @@ static SDL_bool DXGI_LoadDLL(void **pDXGIDLL, IDXGIFactory **pDXGIFactory)
 
 SDL_bool SDL_DXGIGetOutputInfo(SDL_DisplayID displayID, int *adapterIndex, int *outputIndex)
 {
-#if !defined(HAVE_DXGI_H)
+#ifndef HAVE_DXGI_H
     if (adapterIndex) {
         *adapterIndex = -1;
     }

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -20,7 +20,7 @@
 */
 #include "SDL_internal.h"
 
-#if defined(SDL_VIDEO_DRIVER_WINDOWS)
+#ifdef SDL_VIDEO_DRIVER_WINDOWS
 
 #include "../../core/windows/SDL_windows.h"
 

--- a/src/video/x11/SDL_x11mouse.c
+++ b/src/video/x11/SDL_x11mouse.c
@@ -413,7 +413,7 @@ static Uint32 X11_GetGlobalMouseState(float *x, float *y)
 
     /* !!! FIXME: should we XSync() here first? */
 
-#if !defined(SDL_VIDEO_DRIVER_X11_XINPUT2)
+#ifndef SDL_VIDEO_DRIVER_X11_XINPUT2
     videodata->global_mouse_changed = SDL_TRUE;
 #else
     if (!SDL_X11_HAVE_XINPUT2)

--- a/src/video/x11/SDL_x11sym.h
+++ b/src/video/x11/SDL_x11sym.h
@@ -232,7 +232,7 @@ SDL_X11_SYM(void,_XRead32,(Display *dpy,register long *data,long len),(dpy,data,
 /*
  * These only show up on some variants of Unix.
  */
-#if defined(__osf__)
+#ifdef __osf__
 SDL_X11_MODULE(OSF_ENTRY_POINTS)
 SDL_X11_SYM(void,_SmtBufferOverflow,(Display *dpy,register smtDisplayPtr p),(dpy,p),)
 SDL_X11_SYM(void,_SmtIpError,(Display *dpy,register smtDisplayPtr p,int i),(dpy,p,i),)

--- a/src/video/x11/SDL_x11video.c
+++ b/src/video/x11/SDL_x11video.c
@@ -63,7 +63,7 @@ static char *get_classname(void)
 
     /* Next look at the application's executable name */
 #if defined(__LINUX__) || defined(__FREEBSD__)
-#if defined(__LINUX__)
+#ifdef __LINUX__
     (void)SDL_snprintf(procfile, SDL_arraysize(procfile), "/proc/%d/exe", getpid());
 #elif defined(__FREEBSD__)
     (void)SDL_snprintf(procfile, SDL_arraysize(procfile), "/proc/%d/file", getpid());

--- a/src/video/x11/SDL_x11vulkan.c
+++ b/src/video/x11/SDL_x11vulkan.c
@@ -29,7 +29,7 @@
 #include <X11/Xlib.h>
 /*#include <xcb/xcb.h>*/
 
-#if defined(__OpenBSD__)
+#ifdef __OpenBSD__
 #define DEFAULT_VULKAN "libvulkan.so"
 #else
 #define DEFAULT_VULKAN "libvulkan.so.1"

--- a/src/video/yuv2rgb/yuv_rgb.c
+++ b/src/video/yuv2rgb/yuv_rgb.c
@@ -239,7 +239,7 @@ void rgb24_yuv420_std(
 	}
 }
 
-#if defined(SDL_SSE2_INTRINSICS)
+#ifdef SDL_SSE2_INTRINSICS
 
 #define SSE_FUNCTION_NAME	yuv420_rgb565_sse
 #define STD_FUNCTION_NAME	yuv420_rgb565_std

--- a/test/testautomation_intrinsics.c
+++ b/test/testautomation_intrinsics.c
@@ -193,7 +193,7 @@ static void kernel_doubles_add_cpu(double *dest, const double *a, const double *
     }
 }
 
-#if defined(SDL_MMX_INTRINSICS)
+#ifdef SDL_MMX_INTRINSICS
 SDL_TARGETING("mmx") static void kernel_ints_add_mmx(Sint32 *dest, const Sint32 *a, const Sint32 *b, size_t size) {
     for (; size >= 2; size -= 2, dest += 2, a += 2, b += 2) {
         *(__m64*)dest = _mm_add_pi32(*(__m64*)a, *(__m64*)b);
@@ -205,7 +205,7 @@ SDL_TARGETING("mmx") static void kernel_ints_add_mmx(Sint32 *dest, const Sint32 
 }
 #endif
 
-#if defined(SDL_SSE_INTRINSICS)
+#ifdef SDL_SSE_INTRINSICS
 SDL_TARGETING("sse") static void kernel_floats_add_sse(float *dest, const float *a, const float *b, size_t size) {
     for (; size >= 4; size -= 4, dest += 4, a += 4, b += 4) {
         _mm_storeu_ps(dest, _mm_add_ps(_mm_loadu_ps(a), _mm_loadu_ps (b)));
@@ -216,7 +216,7 @@ SDL_TARGETING("sse") static void kernel_floats_add_sse(float *dest, const float 
 }
 #endif
 
-#if defined(SDL_SSE2_INTRINSICS)
+#ifdef SDL_SSE2_INTRINSICS
 SDL_TARGETING("sse2") static void kernel_doubles_add_sse2(double *dest, const double *a, const double *b, size_t size) {
     for (; size >= 2; size -= 2, dest += 2, a += 2, b += 2) {
         _mm_storeu_pd(dest, _mm_add_pd(_mm_loadu_pd(a), _mm_loadu_pd(b)));
@@ -227,7 +227,7 @@ SDL_TARGETING("sse2") static void kernel_doubles_add_sse2(double *dest, const do
 }
 #endif
 
-#if defined(SDL_SSE3_INTRINSICS)
+#ifdef SDL_SSE3_INTRINSICS
 SDL_TARGETING("sse3") static void kernel_ints_add_sse3(Sint32 *dest, const Sint32 *a, const Sint32 *b, size_t size) {
     for (; size >= 4; size -= 4, dest += 4, a += 4, b += 4) {
         _mm_storeu_si128((__m128i*)dest, _mm_add_epi32(_mm_lddqu_si128((__m128i*)a), _mm_lddqu_si128((__m128i*)b)));
@@ -238,7 +238,7 @@ SDL_TARGETING("sse3") static void kernel_ints_add_sse3(Sint32 *dest, const Sint3
 }
 #endif
 
-#if defined(SDL_SSE4_1_INTRINSICS)
+#ifdef SDL_SSE4_1_INTRINSICS
 SDL_TARGETING("sse4.1") static void kernel_ints_mul_sse4_1(Sint32 *dest, const Sint32 *a, const Sint32 *b, size_t size) {
     for (; size >= 4; size -= 4, dest += 4, a += 4, b += 4) {
         _mm_storeu_si128((__m128i*)dest, _mm_mullo_epi32(_mm_lddqu_si128((__m128i*)a), _mm_lddqu_si128((__m128i*)b)));
@@ -249,7 +249,7 @@ SDL_TARGETING("sse4.1") static void kernel_ints_mul_sse4_1(Sint32 *dest, const S
 }
 #endif
 
-#if defined(SDL_SSE4_2_INTRINSICS)
+#ifdef SDL_SSE4_2_INTRINSICS
 SDL_TARGETING("sse4.2") static Uint32 calculate_crc32c_sse4_2(const char *text) {
     Uint32 crc32c = ~0;
     size_t len = SDL_strlen(text);
@@ -280,7 +280,7 @@ SDL_TARGETING("sse4.2") static Uint32 calculate_crc32c_sse4_2(const char *text) 
 }
 #endif
 
-#if defined(SDL_AVX_INTRINSICS)
+#ifdef SDL_AVX_INTRINSICS
 SDL_TARGETING("avx") static void kernel_floats_add_avx(float *dest, const float *a, const float *b, size_t size) {
     for (; size >= 8; size -= 8, dest += 8, a += 8, b += 8) {
         _mm256_storeu_ps(dest, _mm256_add_ps(_mm256_loadu_ps(a), _mm256_loadu_ps(b)));
@@ -291,7 +291,7 @@ SDL_TARGETING("avx") static void kernel_floats_add_avx(float *dest, const float 
 }
 #endif
 
-#if defined(SDL_AVX2_INTRINSICS)
+#ifdef SDL_AVX2_INTRINSICS
 SDL_TARGETING("avx2") static void kernel_ints_add_avx2(Sint32 *dest, const Sint32 *a, const Sint32 *b, size_t size) {
     for (; size >= 8; size -= 8, dest += 8, a += 8, b += 8) {
         _mm256_storeu_si256((__m256i*)dest, _mm256_add_epi32(_mm256_loadu_si256((__m256i*)a), _mm256_loadu_si256((__m256i*)b)));
@@ -302,7 +302,7 @@ SDL_TARGETING("avx2") static void kernel_ints_add_avx2(Sint32 *dest, const Sint3
 }
 #endif
 
-#if defined(SDL_AVX512F_INTRINSICS)
+#ifdef SDL_AVX512F_INTRINSICS
 SDL_TARGETING("avx512f") static void kernel_floats_add_avx512f(float *dest, const float *a, const float *b, size_t size) {
     for (; size >= 16; size -= 16, dest += 16, a += 16, b += 16) {
         _mm512_storeu_ps(dest, _mm512_add_ps(_mm512_loadu_ps(a), _mm512_loadu_ps(b)));
@@ -364,7 +364,7 @@ static int intrinsics_testMMX(void *arg)
 {
     if (SDL_HasMMX()) {
         SDLTest_AssertCheck(SDL_TRUE, "CPU of test machine has MMX support.");
-#if defined(SDL_MMX_INTRINSICS)
+#ifdef SDL_MMX_INTRINSICS
         {
             size_t size;
             Sint32 *dest, *a, *b;
@@ -392,7 +392,7 @@ static int intrinsics_testSSE(void *arg)
 {
     if (SDL_HasSSE()) {
         SDLTest_AssertCheck(SDL_TRUE, "CPU of test machine has SSE support.");
-#if defined(SDL_SSE_INTRINSICS)
+#ifdef SDL_SSE_INTRINSICS
         {
             size_t size;
             float *dest, *a, *b;
@@ -420,7 +420,7 @@ static int intrinsics_testSSE2(void *arg)
 {
     if (SDL_HasSSE2()) {
         SDLTest_AssertCheck(SDL_TRUE, "CPU of test machine has SSE2 support.");
-#if defined(SDL_SSE2_INTRINSICS)
+#ifdef SDL_SSE2_INTRINSICS
         {
             size_t size;
             double *dest, *a, *b;
@@ -448,7 +448,7 @@ static int intrinsics_testSSE3(void *arg)
 {
     if (SDL_HasSSE3()) {
         SDLTest_AssertCheck(SDL_TRUE, "CPU of test machine has SSE3 support.");
-#if defined(SDL_SSE3_INTRINSICS)
+#ifdef SDL_SSE3_INTRINSICS
         {
             size_t size;
             Sint32 *dest, *a, *b;
@@ -476,7 +476,7 @@ static int intrinsics_testSSE4_1(void *arg)
 {
     if (SDL_HasSSE41()) {
         SDLTest_AssertCheck(SDL_TRUE, "CPU of test machine has SSE4.1 support.");
-#if defined(SDL_SSE4_1_INTRINSICS)
+#ifdef SDL_SSE4_1_INTRINSICS
         {
             size_t size;
             Sint32 *dest, *a, *b;
@@ -504,7 +504,7 @@ static int intrinsics_testSSE4_2(void *arg)
 {
     if (SDL_HasSSE42()) {
         SDLTest_AssertCheck(SDL_TRUE, "CPU of test machine has SSE4.2 support.");
-#if defined(SDL_SSE4_2_INTRINSICS)
+#ifdef SDL_SSE4_2_INTRINSICS
         {
             struct {
                 const char *input;
@@ -539,7 +539,7 @@ static int intrinsics_testAVX(void *arg)
 {
     if (SDL_HasAVX()) {
         SDLTest_AssertCheck(SDL_TRUE, "CPU of test machine has AVX support.");
-#if defined(SDL_AVX_INTRINSICS)
+#ifdef SDL_AVX_INTRINSICS
         {
             size_t size;
             float *dest, *a, *b;
@@ -567,7 +567,7 @@ static int intrinsics_testAVX2(void *arg)
 {
     if (SDL_HasAVX2()) {
         SDLTest_AssertCheck(SDL_TRUE, "CPU of test machine has AVX2 support.");
-#if defined(SDL_AVX2_INTRINSICS)
+#ifdef SDL_AVX2_INTRINSICS
         {
             size_t size;
             Sint32 *dest, *a, *b;
@@ -595,7 +595,7 @@ static int intrinsics_testAVX512F(void *arg)
 {
     if (SDL_HasAVX512F()) {
         SDLTest_AssertCheck(SDL_TRUE, "CPU of test machine has AVX512F support.");
-#if defined(SDL_AVX512F_INTRINSICS)
+#ifdef SDL_AVX512F_INTRINSICS
         {
             size_t size;
             float *dest, *a, *b;

--- a/test/testautomation_platform.c
+++ b/test/testautomation_platform.c
@@ -357,7 +357,7 @@ static int platform_testSetErrorEmptyInput(void *arg)
     return TEST_COMPLETED;
 }
 
-#if defined(HAVE_WFORMAT_OVERFLOW)
+#ifdef HAVE_WFORMAT_OVERFLOW
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-overflow"
 #endif
@@ -441,7 +441,7 @@ static int platform_testSetErrorInvalidInput(void *arg)
     return TEST_COMPLETED;
 }
 
-#if defined(HAVE_WFORMAT_OVERFLOW)
+#ifdef HAVE_WFORMAT_OVERFLOW
 #pragma GCC diagnostic pop
 #endif
 

--- a/test/testautomation_rwops.c
+++ b/test/testautomation_rwops.c
@@ -309,7 +309,7 @@ static int rwops_testFileRead(void *arg)
     }
 
     /* Check type */
-#if defined(__ANDROID__)
+#ifdef __ANDROID__
     SDLTest_AssertCheck(
         rw->type == SDL_RWOPS_STDFILE || rw->type == SDL_RWOPS_JNIFILE,
         "Verify RWops type is SDL_RWOPS_STDFILE or SDL_RWOPS_JNIFILE; expected: %d|%d, got: %d", SDL_RWOPS_STDFILE, SDL_RWOPS_JNIFILE, rw->type);
@@ -356,7 +356,7 @@ static int rwops_testFileWrite(void *arg)
     }
 
     /* Check type */
-#if defined(__ANDROID__)
+#ifdef __ANDROID__
     SDLTest_AssertCheck(
         rw->type == SDL_RWOPS_STDFILE || rw->type == SDL_RWOPS_JNIFILE,
         "Verify RWops type is SDL_RWOPS_STDFILE or SDL_RWOPS_JNIFILE; expected: %d|%d, got: %d", SDL_RWOPS_STDFILE, SDL_RWOPS_JNIFILE, rw->type);

--- a/test/testautomation_stdlib.c
+++ b/test/testautomation_stdlib.c
@@ -34,10 +34,10 @@ static int stdlib_strlcpy(void *arg)
 
 #if defined(HAVE_WFORMAT) || defined(HAVE_WFORMAT_EXTRA_ARGS)
 #pragma GCC diagnostic push
-#if defined(HAVE_WFORMAT)
+#ifdef HAVE_WFORMAT
 #pragma GCC diagnostic ignored "-Wformat"
 #endif
-#if defined(HAVE_WFORMAT_EXTRA_ARGS)
+#ifdef HAVE_WFORMAT_EXTRA_ARGS
 #pragma GCC diagnostic ignored "-Wformat-extra-args"
 #endif
 #endif
@@ -344,10 +344,10 @@ static int stdlib_getsetenv(void *arg)
 
 #if defined(HAVE_WFORMAT) || defined(HAVE_WFORMAT_EXTRA_ARGS)
 #pragma GCC diagnostic push
-#if defined(HAVE_WFORMAT)
+#ifdef HAVE_WFORMAT
 #pragma GCC diagnostic ignored "-Wformat"
 #endif
-#if defined(HAVE_WFORMAT_EXTRA_ARGS)
+#ifdef HAVE_WFORMAT_EXTRA_ARGS
 #pragma GCC diagnostic ignored "-Wformat-extra-args"
 #endif
 #endif
@@ -437,7 +437,7 @@ static int stdlib_sscanf(void *arg)
 #pragma GCC diagnostic pop
 #endif
 
-#if defined(_WIN64)
+#ifdef _WIN64
 #define SIZE_FORMAT "I64u"
 #elif defined(__WIN32__)
 #define SIZE_FORMAT "I32u"

--- a/test/testgles.c
+++ b/test/testgles.c
@@ -332,7 +332,7 @@ int main(int argc, char *argv[])
         SDL_Log("%2.2f frames per second\n",
                 ((double)frames * 1000) / (now - then));
     }
-#if !defined(__ANDROID__)
+#ifndef __ANDROID__
     quit(0);
 #endif
     return 0;

--- a/test/testgles2.c
+++ b/test/testgles2.c
@@ -893,7 +893,7 @@ int main(int argc, char *argv[])
         SDL_Log("%2.2f frames per second\n",
                 ((double)frames * 1000) / (now - then));
     }
-#if !defined(__ANDROID__)
+#ifndef __ANDROID__
     quit(0);
 #endif
     return 0;

--- a/test/testgles2_sdf.c
+++ b/test/testgles2_sdf.c
@@ -780,7 +780,7 @@ int main(int argc, char *argv[])
         SDL_Log("%2.2f frames per second\n",
                 ((double)frames * 1000) / (now - then));
     }
-#if !defined(__ANDROID__)
+#ifndef __ANDROID__
     quit(0);
 #endif
     return 0;

--- a/test/testlock.c
+++ b/test/testlock.c
@@ -99,7 +99,7 @@ Run(void *data)
     return 0;
 }
 
-#if !defined(_WIN32)
+#ifndef _WIN32
 Uint32 hit_timeout(Uint32 interval, void *param) {
     SDL_Log("Hit timeout! Sending SIGINT!");
     kill(0, SIGINT);
@@ -110,7 +110,7 @@ Uint32 hit_timeout(Uint32 interval, void *param) {
 int main(int argc, char *argv[])
 {
     int i;
-#if !defined(_WIN32)
+#ifndef _WIN32
     int timeout = 0;
 #endif
 
@@ -144,7 +144,7 @@ int main(int argc, char *argv[])
                         consumed = 2;
                     }
                 }
-#if !defined(_WIN32)
+#ifndef _WIN32
             } else if (SDL_strcmp(argv[i], "--timeout") == 0) {
                 if (argv[i + 1]) {
                     char *endptr;
@@ -160,7 +160,7 @@ int main(int argc, char *argv[])
             static const char *options[] = {
                 "[--nbthreads NB]",
                 "[--worktime ms]",
-#if !defined(_WIN32)
+#ifndef _WIN32
                 "[--timeout ms]",
 #endif
                 NULL,
@@ -201,7 +201,7 @@ int main(int argc, char *argv[])
         }
     }
 
-#if !defined(_WIN32)
+#ifndef _WIN32
     if (timeout) {
         SDL_AddTimer(timeout, hit_timeout, NULL);
     }


### PR DESCRIPTION
This pr replaces occurrences of `#if defined(xxx)` with `#ifdef xxx` and `#if !defined(xxx)` with `#ifndef xxx`.

This pr is the result of running the script below on the SDL source tree.
I then removed the changes to khronos opengl and vulkan headers.

<details>

<summary>Script to replace #if defined(xxx) with #ifdef xxx</summary>

```python
#!/usr/bin/env python

import argparse
import os
import pathlib
import re


def main():
    parser = argparse.ArgumentParser(allow_abbrev=False)
    parser.add_argument("folder", type=pathlib.Path)
    args = parser.parse_args()

    folder: pathlib.Path = args.folder
    folder = folder.expanduser()
    assert folder.exists() and folder.is_dir()

    for root, dirs, files in os.walk(folder):
        if "build" in root:
            continue
        for file in files:
            if any(file.endswith(ext) for ext in (".m", ".c", ".h", ".cc", ".cpp")):
                path = pathlib.Path(root) / file
                try:
                    txt = path.open().read()
                except UnicodeDecodeError:
                    print(f"Failed to read {path}")
                    continue

                def repl_func(m: re.Match) -> str:
                    macro_func = "ifndef" if m.group("inverse") else "ifdef"
                    return f"{m.group('start')}{macro_func} {m.group('name')}{m.group('comments') or ''}{m.group('end')}"

                new_string, _ = re.subn("(?P<start>(?:\n|^)[ \t]*#[ \t]*)if[ \t]*(?P<inverse>![ \t]*)?defined\\([ \t]*(?P<name>[A-Za-z0-9_]+)[ \t]*\\)(?P<comments>[ \t]*/[*]+[^*]+(?:[*]+/)?)?(?P<end>\n|$)", repl_func, txt, flags=re.M)
                path.open(mode="w").write(new_string)


if __name__ == "__main__":
    raise SystemExit(main())
```
</details>


## Existing Issue(s)
https://github.com/libsdl-org/SDL/pull/7551#issuecomment-1488933426
