### PR TITLE
Fix mouse position, when generated from touch events

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -551,6 +551,8 @@ static int SDL_PrivateSendMouseMotion(Uint64 timestamp, SDL_Window *window, SDL_
     if (mouseID == SDL_TOUCH_MOUSEID && !GetButtonState(mouse, SDL_TRUE)) {
         xrel = 0.0f;
         yrel = 0.0f;
+        mouse->x = x;
+        mouse->y = y;
     }
 
     if (mouse->has_position) {


### PR DESCRIPTION
Not sure the fix is correct.

When using and a touch screen (at least on android, linux/x11), to generate synthetic mouse event,
the synthetic positions doesn't match what I would expect with a real mouse. 