### PR TITLE
Fix key code names for ISO keyboard layouts

### DIFF
--- a/src/video/cocoa/SDL_cocoakeyboard.m
+++ b/src/video/cocoa/SDL_cocoakeyboard.m
@@ -279,6 +279,17 @@ static void UpdateKeymap(SDL_CocoaVideoData *data, SDL_bool send_event)
                 continue;
             }
 
+            /* 
+             * Swap the scancode for these two wrongly translated keys
+             * UCKeyTranslate() function does not do its job properly for ISO layout keyboards, where the key '@',
+             * which is located in the top left corner of the keyboard right under the Escape key, and the additional
+             * key '<', which is on the right of the Shift key, are inverted
+            */
+            if ((scancode == SDL_SCANCODE_NONUSBACKSLASH || scancode == SDL_SCANCODE_GRAVE) && KBGetLayoutType(LMGetKbdType()) == kKeyboardISO) {
+                /* see comments in scancodes_darwin.h */
+                scancode = (SDL_Scancode)((SDL_SCANCODE_NONUSBACKSLASH + SDL_SCANCODE_GRAVE) - scancode);
+            }
+
             dead_key_state = 0;
             err = UCKeyTranslate((UCKeyboardLayout *)chr_data,
                                  i, kUCKeyActionDown,
@@ -385,7 +396,7 @@ void Cocoa_HandleKeyEvent(_THIS, NSEvent *event)
 #endif
 
     if ((scancode == 10 || scancode == 50) && KBGetLayoutType(LMGetKbdType()) == kKeyboardISO) {
-        /* see comments in SDL_cocoakeys.h */
+        /* see comments in scancodes_darwin.h */
         scancode = 60 - scancode;
     }
 


### PR DESCRIPTION
This issue has been spotted on Apple MacOS Ventura 13.3, with an Apple Magic Keyboard ISO French layout.

With the tool `checkkeys`:

```
2023-04-04 21:51:37.847 checkkeys[14324:247087] INFO: Initial state: modifiers: (none)
2023-04-04 21:51:40.155 checkkeys[14324:247087] INFO: Key pressed :  scancode 53 = `, keycode 0x0000003C = <  modifiers: (none)
2023-04-04 21:51:40.155 checkkeys[14324:247087] INFO: INPUT Text (\x40): "@"
2023-04-04 21:51:40.358 checkkeys[14324:247087] INFO: Key released:  scancode 53 = `, keycode 0x0000003C = <  modifiers: (none)
2023-04-04 21:51:43.100 checkkeys[14324:247087] INFO: Key pressed :  scancode 100 = , keycode 0x00000040 = @  modifiers: (none)
2023-04-04 21:51:43.101 checkkeys[14324:247087] INFO: INPUT Text (\x3c): "<"
2023-04-04 21:51:43.305 checkkeys[14324:247087] INFO: Key released:  scancode 100 = , keycode 0x00000040 = @  modifiers: (none)
```

As you can see, the key codes of theses two keys seems inverted. The input text below each key press, however, is correct.

Now, with this fix, the key names should eventually match the description written in the file `SDL_scancode.h` about these two keys for ISO layout keyboards.

With the tool `checkkeys` (again):

```
2023-04-05 00:53:52.672 checkkeys[23189:325020] INFO: Initial state: modifiers: (none)
2023-04-05 00:53:58.718 checkkeys[23189:325020] INFO: Key pressed :  scancode 53 = `, keycode 0x00000040 = @  modifiers: (none)
2023-04-05 00:53:58.718 checkkeys[23189:325020] INFO: INPUT Text (\x40): "@"
2023-04-05 00:53:58.819 checkkeys[23189:325020] INFO: Key released:  scancode 53 = `, keycode 0x00000040 = @  modifiers: (none)
2023-04-05 00:53:59.630 checkkeys[23189:325020] INFO: Key pressed :  scancode 100 = , keycode 0x0000003C = <  modifiers: (none)
2023-04-05 00:53:59.630 checkkeys[23189:325020] INFO: INPUT Text (\x3c): "<"
2023-04-05 00:53:59.732 checkkeys[23189:325020] INFO: Key released:  scancode 100 = , keycode 0x0000003C = <  modifiers: (none)
```

Here are additional references I stumbled upon:
- https://github.com/wine-mirror/wine/blob/master/dlls/winemac.drv/keyboard.c#L762
- https://hg.mozilla.org/mozilla-central/file/tip/widget/cocoa/TextInputHandler.mm#l1637

Cheers.
