### PR TITLE
Android: need to save/restore the swap interval / vsync

### DIFF
--- a/src/video/android/SDL_androidevents.c
+++ b/src/video/android/SDL_androidevents.c
@@ -82,15 +82,28 @@ static void android_egl_context_restore(SDL_Window *window)
             SDL_PushEvent(&event);
         }
         data->backup_done = 0;
+
+        if (data->has_swap_interval) {
+            SDL_GL_SetSwapInterval(data->swap_interval);
+        }
+
     }
 }
 
 static void android_egl_context_backup(SDL_Window *window)
 {
     if (window) {
+        int interval = 0;
         /* Keep a copy of the EGL Context so we can try to restore it when we resume */
         SDL_WindowData *data = window->driverdata;
         data->egl_context = SDL_GL_GetCurrentContext();
+
+        /* Save/Restore the swap interval / vsync */
+        if (SDL_GL_GetSwapInterval(&interval) == 0) {
+            data->has_swap_interval = 1;
+            data->swap_interval = interval;
+        }
+
         /* We need to do this so the EGLSurface can be freed */
         SDL_GL_MakeCurrent(window, NULL);
         data->backup_done = 1;

--- a/src/video/android/SDL_androidwindow.h
+++ b/src/video/android/SDL_androidwindow.h
@@ -41,6 +41,8 @@ struct SDL_WindowData
 #ifdef SDL_VIDEO_OPENGL_EGL
     EGLSurface egl_surface;
     EGLContext egl_context; /* We use this to preserve the context when losing focus */
+    int has_swap_interval;  /* Save/Restore the swap interval / vsync */
+    int swap_interval;
 #endif
     SDL_bool backup_done;
     ANativeWindow *native_window;


### PR DESCRIPTION
 Android: need to save/restore the swap interval / vsync
otherwise, there is a difference of framerate, either with gles2 or SDL_renderer (testspriteminimal, testgles2).

