### PR TITLE
test/template.test.in: Pass SDL_NONINTERACTIVE_ARGUMENTS to installed-tests

### DIFF
--- a/test/template.test.in
+++ b/test/template.test.in
@@ -1,3 +1,3 @@
 [Test]
 Type=session
-Exec=@installedtestsdir@/@exe@
+Exec=@installedtestsdir@/@exe@ @noninteractive_arguments@


### PR DESCRIPTION
Otherwise they'll try to run with no arguments, and fail, when run by ginsttest-runner.

Fixes: 81ca9d61 "cmake+test: add more automated tests + use properties"

---

We use the installed-tests (and run them via GNOME's ginsttest-runner) as a smoke-test in the Debian packaging, to make sure that changes in SDL's dependencies don't make it regress: for example see <https://ci.debian.net/packages/libs/libsdl3/unstable/amd64/>. (We'll make more active use of this when SDL3 reaches a point where its API/ABI are stable and it's suitable to be shipped to users, but at the moment its packaging in Debian experimental is more like a proof-of-concept so that we can catch any showstopper issues early.)