### PR TITLE
Unaligned stacks on i686-w64-mingw32, may lead to crashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,11 +620,6 @@ if(USE_GCC OR USE_CLANG OR USE_INTELCC)
     endif()
   endif()
 
-  set(CMAKE_REQUIRED_FLAGS "-mpreferred-stack-boundary=2")
-  check_c_source_compiles("int x = 0; int main(int argc, char **argv) { return 0; }"
-    HAVE_GCC_PREFERRED_STACK_BOUNDARY)
-  set(CMAKE_REQUIRED_FLAGS ${ORIG_CMAKE_REQUIRED_FLAGS})
-
   set(CMAKE_REQUIRED_FLAGS "-fvisibility=hidden -Werror")
   check_c_source_compiles("
       #if !defined(__GNUC__) || __GNUC__ < 4

--- a/configure
+++ b/configure
@@ -23026,41 +23026,6 @@ printf "%s\n" "$have_gcc_no_strict_aliasing" >&6; }
     fi
 }
 
-CheckStackBoundary()
-{
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for GCC -mpreferred-stack-boundary option" >&5
-printf %s "checking for GCC -mpreferred-stack-boundary option... " >&6; }
-    have_gcc_preferred_stack_boundary=no
-
-    save_CFLAGS="$CFLAGS"
-    CFLAGS="$save_CFLAGS -mpreferred-stack-boundary=2"
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-    int x = 0;
-
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  have_gcc_preferred_stack_boundary=yes
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $have_gcc_preferred_stack_boundary" >&5
-printf "%s\n" "$have_gcc_preferred_stack_boundary" >&6; }
-    CFLAGS="$save_CFLAGS"
-
-    if test x$have_gcc_preferred_stack_boundary = xyes; then
-        EXTRA_CFLAGS="$EXTRA_CFLAGS -mpreferred-stack-boundary=2"
-    fi
-}
-
 CheckWerror()
 {
     # Check whether --enable-werror was given.
@@ -27473,9 +27438,6 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $have_wince" >&5
 printf "%s\n" "$have_wince" >&6; }
-
-    # This fixes Windows stack alignment with newer GCC
-    CheckStackBoundary
 
     # headers needed elsewhere
     ac_fn_c_check_header_compile "$LINENO" "tpcshrd.h" "ac_cv_header_tpcshrd_h" "$ac_includes_default"

--- a/configure.ac
+++ b/configure.ac
@@ -1558,26 +1558,6 @@ CheckNoStrictAliasing()
     fi
 }
 
-dnl See if GCC's -mpreferred-stack-boundary is supported.
-dnl  Reference: http://bugzilla.libsdl.org/show_bug.cgi?id=1296
-CheckStackBoundary()
-{
-    AC_MSG_CHECKING(for GCC -mpreferred-stack-boundary option)
-    have_gcc_preferred_stack_boundary=no
-
-    save_CFLAGS="$CFLAGS"
-    CFLAGS="$save_CFLAGS -mpreferred-stack-boundary=2"
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-    int x = 0;
-    ]],[])], [have_gcc_preferred_stack_boundary=yes],[])
-    AC_MSG_RESULT($have_gcc_preferred_stack_boundary)
-    CFLAGS="$save_CFLAGS"
-
-    if test x$have_gcc_preferred_stack_boundary = xyes; then
-        EXTRA_CFLAGS="$EXTRA_CFLAGS -mpreferred-stack-boundary=2"
-    fi
-}
-
 dnl See if GCC's -Werror is supported.
 CheckWerror()
 {
@@ -3305,9 +3285,6 @@ CheckWINDOWS()
        ])
     ],[])
     AC_MSG_RESULT($have_wince)
-
-    # This fixes Windows stack alignment with newer GCC
-    CheckStackBoundary
 
     # headers needed elsewhere
     AC_CHECK_HEADER(tpcshrd.h,have_tpcshrd_h=yes)

--- a/src/SDL.c
+++ b/src/SDL.c
@@ -631,7 +631,7 @@ SDL_bool SDL_IsTablet(void)
 #if defined(__WIN32__)
 
 #if (!defined(HAVE_LIBC) || defined(__WATCOMC__)) && !defined(SDL_STATIC_LIB)
-/* Need to include DllMain() on Watcom C for some reason.. */
+/* FIXME: Still need to include DllMain() on Watcom C ? */
 
 BOOL APIENTRY MINGW32_FORCEALIGN _DllMainCRTStartup(HANDLE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {

--- a/src/SDL.c
+++ b/src/SDL.c
@@ -633,6 +633,9 @@ SDL_bool SDL_IsTablet(void)
 #if (!defined(HAVE_LIBC) || defined(__WATCOMC__)) && !defined(SDL_STATIC_LIB)
 /* Need to include DllMain() on Watcom C for some reason.. */
 
+#if defined(__GNUC__) && defined(__i686__)
+__attribute__((force_align_arg_pointer))
+#endif
 BOOL APIENTRY _DllMainCRTStartup(HANDLE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
     switch (ul_reason_for_call) {

--- a/src/SDL.c
+++ b/src/SDL.c
@@ -633,10 +633,7 @@ SDL_bool SDL_IsTablet(void)
 #if (!defined(HAVE_LIBC) || defined(__WATCOMC__)) && !defined(SDL_STATIC_LIB)
 /* Need to include DllMain() on Watcom C for some reason.. */
 
-#if defined(__GNUC__) && defined(__i686__)
-__attribute__((force_align_arg_pointer))
-#endif
-BOOL APIENTRY _DllMainCRTStartup(HANDLE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+BOOL APIENTRY MINGW32_FORCEALIGN _DllMainCRTStartup(HANDLE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
     switch (ul_reason_for_call) {
     case DLL_PROCESS_ATTACH:

--- a/src/core/windows/SDL_windows.h
+++ b/src/core/windows/SDL_windows.h
@@ -76,6 +76,19 @@
 #define WINVER       _WIN32_WINNT
 #endif
 
+/* See https://github.com/libsdl-org/SDL/pull/7607  */
+/* force_align_arg_pointer attribute requires gcc >= 4.2.x.  */
+#if defined(__clang__)
+#define HAVE_FORCE_ALIGN_ARG_POINTER
+#elif defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2))
+#define HAVE_FORCE_ALIGN_ARG_POINTER
+#endif
+#if defined(__GNUC__) && defined(__i386__) && defined(HAVE_FORCE_ALIGN_ARG_POINTER)
+#define MINGW32_FORCEALIGN __attribute__((force_align_arg_pointer))
+#else
+#define MINGW32_FORCEALIGN
+#endif
+
 #include <windows.h>
 #include <basetyps.h> /* for REFIID with broken mingw.org headers */
 

--- a/src/main/windows/SDL_windows_main.c
+++ b/src/main/windows/SDL_windows_main.c
@@ -103,6 +103,9 @@ int console_wmain(int argc, wchar_t *wargv[], wchar_t *wenvp)
 #endif
 
 /* This is where execution begins [windowed apps] */
+#if defined(__GNUC__) && defined(__i686__)
+__attribute__((force_align_arg_pointer))
+#endif
 int WINAPI
 WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR szCmdLine, int sw) /* NOLINT(readability-inconsistent-declaration-parameter-name) */
 {

--- a/src/main/windows/SDL_windows_main.c
+++ b/src/main/windows/SDL_windows_main.c
@@ -103,10 +103,7 @@ int console_wmain(int argc, wchar_t *wargv[], wchar_t *wenvp)
 #endif
 
 /* This is where execution begins [windowed apps] */
-#if defined(__GNUC__) && defined(__i686__)
-__attribute__((force_align_arg_pointer))
-#endif
-int WINAPI
+int WINAPI MINGW32_FORCEALIGN
 WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR szCmdLine, int sw) /* NOLINT(readability-inconsistent-declaration-parameter-name) */
 {
     return main_getcmdline();

--- a/src/thread/windows/SDL_systhread.c
+++ b/src/thread/windows/SDL_systhread.c
@@ -55,18 +55,12 @@ static DWORD RunThread(void *data)
     return 0;
 }
 
-#if defined(__GNUC__) && defined(__i686__)
-__attribute__((force_align_arg_pointer))
-#endif
-static DWORD WINAPI RunThreadViaCreateThread(LPVOID data)
+static DWORD WINAPI MINGW32_FORCEALIGN RunThreadViaCreateThread(LPVOID data)
 {
     return RunThread(data);
 }
 
-#if defined(__GNUC__) && defined(__i686__)
-__attribute__((force_align_arg_pointer))
-#endif
-static unsigned __stdcall RunThreadViaBeginThreadEx(void *data)
+static unsigned __stdcall MINGW32_FORCEALIGN RunThreadViaBeginThreadEx(void *data)
 {
     return (unsigned)RunThread(data);
 }

--- a/src/thread/windows/SDL_systhread.c
+++ b/src/thread/windows/SDL_systhread.c
@@ -55,11 +55,17 @@ static DWORD RunThread(void *data)
     return 0;
 }
 
+#if defined(__GNUC__) && defined(__i686__)
+__attribute__((force_align_arg_pointer))
+#endif
 static DWORD WINAPI RunThreadViaCreateThread(LPVOID data)
 {
     return RunThread(data);
 }
 
+#if defined(__GNUC__) && defined(__i686__)
+__attribute__((force_align_arg_pointer))
+#endif
 static unsigned __stdcall RunThreadViaBeginThreadEx(void *data)
 {
     return (unsigned)RunThread(data);


### PR DESCRIPTION
Affects both SDL2 and SDL3. GCC 4.5.2 and later assume a 16-byte aligned stack, but the x86 Windows stack is not necessarily so aligned. This problem was observed in #477 (2011), and the workaround was to use `-mpreferred-stack-boundary` to, in essence, disable this assumption when building SDL itself — at some small performance and size cost.

However, that disabled assumption does not carry into applications running on top of SDL, particularly `SDL_main` and thread entry points. The use of `-mpreferred-stack-boundary` prevents most such crashes on the main thread *purely by accident*, which, in addition to the x64 ABI being unaffected, is probably why it's gone mostly unnoticed for the past 12 years. That is, SDL 16-byte aligns the main thread stack for applications by chance — a result of the particular choice of compiler options, GCC code generation, and that Windows enters SDL with a consistently-congruent stack pointer on the main thread.

Here's a simple SDL program that may observe unaligned locals, and does so consistently for me using the official SDL2 build:

```c
#include "SDL.h"

void set64(volatile Uint64 *x)
{
    *x = 1;
}

int threadfunc(void *arg)
{
    Uint64 x;
    set64(&x);
    return 0;
}

int main(int argc, char **argv)
{
    SDL_Thread *thr = SDL_CreateThread(threadfunc, 0, 0);
    SDL_WaitThread(thr, 0);
    return 0;
}
```

For simplicity, compile with UBSan to add an alignment check (otherwise set a breakpoint and inspect it yourself):

    $ i686-w64-mingw32-gcc -g3 -fsanitize=undefined -fsanitize-undefined-trap-on-error example.c $(sdl2-config --cflags --libs)

The indirection through `set64` is because UBSan assumes locals are aligned and so doesn't instrument them. When I run this under GDB, it traps on the `*x = 1` because the `Uint64` is unaligned. Since `threadfunc` was entered unaligned, its `x` is unaligned. While 64-bit integer alignment doesn't matter much here for x86, it does [if SIMD is involved](https://www.peterstock.co.uk/games/mingw_sse/), including auto-vectorization, per the 12-year-old bug report.

The proper solution is to align the stack on all x86 entry points using the `force_align_arg_pointer` attribute. In other words, every SDL function marked `__stdcall`, `WINAPI`, or `APIENTRY` should have this attribute on i686-w64-mingw32. That is, put this (or an equivalent macro) in front of each definition:

```c
#if defined(__GNUC__) && defined(__i686__)
__attribute__((force_align_arg_pointer))
#endif
```

Particularly:

* ~~`src/main/windows/SDL_windows_main.c` on `WinMain`~~ (edit: `msvcrt.dll` currently aligns the stack)
* `src/thread/windows/SDL_systhread.c` on `RunThreadViaBeginThreadEx` and `RunThreadViaCreateThread`
* `src/SDL.c` on `_DllMainCRTStartup` (being a no-op, not actually important)

This is basically working around a very old compiler bug: GCC ought to already assume `__stdcall` functions won't be called with a 16-byte aligned stack on i686, because, unlike `__cdecl`, *they rarely are*.

However, this must also coincide with removing `-mpreferred-stack-boundary`, which effectively disables `force_align_arg_pointer`. Fortunately with this new fix the stack alignment override is unnecessary anyway.

This merge request is a preliminary version of the changes for SDL2. The SDL3 branch would need similar treatment.