### PR TITLE
cmake: allow users of sdl2-config.cmake to not add -mwindows to the link options

### DIFF
--- a/sdl2-config.cmake.in
+++ b/sdl2-config.cmake.in
@@ -60,6 +60,11 @@ string(REGEX MATCHALL "-L([-a-zA-Z0-9._/]+)" _sdl2_static_private_libdirs "${_sd
 string(REGEX REPLACE "^-L" "" _sdl2_static_private_libdirs "${_sdl2_static_private_libdirs}")
 string(REGEX REPLACE ";-L" ";" _sdl2_static_private_libdirs "${_sdl2_static_private_libdirs}")
 
+# Set SDL2_NO_MWINDOWS to a true-ish value to not add the -mwindows link option
+if(SDL2_NO_MWINDOWS)
+  list(REMOVE_ITEM _sdl2_libraries "-mwindows")
+endif()
+
 if(_sdl2_libraries MATCHES ".*SDL2main.*")
   list(INSERT SDL2_LIBRARIES 0 SDL2::SDL2main)
   list(INSERT SDL2_STATIC_LIBRARIES 0 SDL2::SDL2main)


### PR DESCRIPTION
Add option to `sdl2-config.cmake` to remove `-mwindows` of the link options.


## Description

It's to be used as:
```
add_executable(my_game my_game.c)
set(SDL2_NO_WINDOWS TRUE)
find_package(SDL2 REQUIRED)
target_link_libraries(my_game PRIVATE SDL2::SDL2)
# my_game now displays a console
```
The option is added for keeping the current behavior.
`SDL2Config.cmake`, and `SDL3Config.cmake` never add `-mwindows`.
These expect users to set the [`WIN32_EXECUTABLE` property](https://cmake.org/cmake/help/latest/prop_tgt/WIN32_EXECUTABLE.html).

TODO:
- add item to sdlwiki SDL2 cmake page

## Existing Issue(s)
Fixes https://github.com/libsdl-org/sdlwiki/issues/368