### PR TITLE
wayland: Destroy proxy wrappers before and callbacks before event queues

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -2278,9 +2278,9 @@ void Wayland_DestroyWindow(_THIS, SDL_Window *window)
         SDL_free(wind->outputs);
 
         if (wind->gles_swap_frame_callback) {
-            WAYLAND_wl_event_queue_destroy(wind->gles_swap_frame_event_queue);
-            WAYLAND_wl_proxy_wrapper_destroy(wind->gles_swap_frame_surface_wrapper);
             wl_callback_destroy(wind->gles_swap_frame_callback);
+            WAYLAND_wl_proxy_wrapper_destroy(wind->gles_swap_frame_surface_wrapper);
+            WAYLAND_wl_event_queue_destroy(wind->gles_swap_frame_event_queue);
         }
 
         if (wind->surface_frame_callback) {


### PR DESCRIPTION
Destroy any proxy wrappers and callbacks before the associated event queues to silence libwayland warnings about destroying the queues while proxies are still attached.

Fixes #7397