### PR TITLE
wayland: Insert new displays at the end of the output list

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -709,7 +709,7 @@ static int Wayland_add_display(SDL_VideoData *d, uint32_t id, uint32_t version)
     SDL_WAYLAND_register_output(output);
 
     /* Keep a list of outputs for deferred xdg-output initialization. */
-    WAYLAND_wl_list_insert(&d->output_list, &data->link);
+    WAYLAND_wl_list_insert(d->output_list.prev, &data->link);
 
     if (data->videodata->xdg_output_manager) {
         data->xdg_output = zxdg_output_manager_v1_get_xdg_output(data->videodata->xdg_output_manager, output);


### PR DESCRIPTION
Insert new displays at the end of the list instead of the front so that the initial ordering, as exposed by the compositor, is preserved. This is particularly important when the compositor exposes the xdg-output instance after the wl_output instance, as xdg-output must be attached to the outputs in the same order that wl_output exposed them, or they can be added to the SDL output list in reverse order.
