### PR TITLE
Check return value of SDL_malloc()

### DIFF
--- a/src/video/SDL_shape.c
+++ b/src/video/SDL_shape.c
@@ -131,6 +131,11 @@ static SDL_ShapeTree *RecursivelyCalculateShapeTree(SDL_WindowShapeMode mode, SD
     SDL_ShapeTree *result = (SDL_ShapeTree *)SDL_malloc(sizeof(SDL_ShapeTree));
     SDL_Rect next = { 0, 0, 0, 0 };
 
+    if (result == NULL) {
+        SDL_OutOfMemory();
+        return NULL;
+    }
+
     for (y = dimensions.y; y < dimensions.y + dimensions.h; y++) {
         for (x = dimensions.x; x < dimensions.x + dimensions.w; x++) {
             pixel_value = 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In function `RecursivelyCalculateShapeTree()`, check the return value of `SDL_malloc()` to prevent null pointer dereference.

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
