### PR TITLE
Check return value of VIRTUAL_HWDataForIndex()

### DIFF
--- a/src/joystick/virtual/SDL_virtualjoystick.c
+++ b/src/joystick/virtual/SDL_virtualjoystick.c
@@ -585,7 +585,7 @@ static SDL_bool VIRTUAL_JoystickGetGamepadMapping(int device_index, SDL_GamepadM
     Uint8 current_button = 0;
     Uint8 current_axis = 0;
 
-    if (hwdata->desc.type != SDL_JOYSTICK_TYPE_GAMEPAD) {
+    if (!hwdata || hwdata->desc.type != SDL_JOYSTICK_TYPE_GAMEPAD) {
         return SDL_FALSE;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In function `VIRTUAL_JoystickGetGamepadMapping()`, check return value of `VIRTUAL_HWDataForIndex()` for null.


## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
