### PR TITLE
video: set error code when SetWindowPosition fails

### DIFF
--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -233,7 +233,7 @@ struct SDL_VideoDevice
     int (*CreateSDLWindowFrom)(_THIS, SDL_Window *window, const void *data);
     void (*SetWindowTitle)(_THIS, SDL_Window *window);
     int (*SetWindowIcon)(_THIS, SDL_Window *window, SDL_Surface *icon);
-    void (*SetWindowPosition)(_THIS, SDL_Window *window);
+    int (*SetWindowPosition)(_THIS, SDL_Window *window);
     void (*SetWindowSize)(_THIS, SDL_Window *window);
     void (*SetWindowMinimumSize)(_THIS, SDL_Window *window);
     void (*SetWindowMaximumSize)(_THIS, SDL_Window *window);

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2365,7 +2365,9 @@ int SDL_SetWindowPosition(SDL_Window *window, int x, int y)
         }
 
         SDL_zero(bounds);
-        SDL_GetDisplayBounds(displayID, &bounds);
+        if (SDL_GetDisplayBounds(displayID, &bounds) < 0) {
+            return -1;
+        }
         if (SDL_WINDOWPOS_ISCENTERED(x)) {
             x = bounds.x + (bounds.w - window->windowed.w) / 2;
         }
@@ -2387,7 +2389,7 @@ int SDL_SetWindowPosition(SDL_Window *window, int x, int y)
             if (displayID != original_displayID) {
                 /* Set the new target display and update the fullscreen mode */
                 window->current_fullscreen_mode.displayID = displayID;
-                SDL_UpdateFullscreenMode(window, SDL_TRUE);
+                return SDL_UpdateFullscreenMode(window, SDL_TRUE);
             }
         }
     } else {
@@ -2396,10 +2398,10 @@ int SDL_SetWindowPosition(SDL_Window *window, int x, int y)
         window->last_displayID = SDL_GetDisplayForWindow(window);
 
         if (_this->SetWindowPosition) {
-            _this->SetWindowPosition(_this, window);
+            return _this->SetWindowPosition(_this, window);
         }
     }
-    return 0;
+    return SDL_Unsupported();
 }
 
 int SDL_GetWindowPosition(SDL_Window *window, int *x, int *y)

--- a/src/video/cocoa/SDL_cocoawindow.h
+++ b/src/video/cocoa/SDL_cocoawindow.h
@@ -144,7 +144,7 @@ extern int Cocoa_CreateWindowFrom(_THIS, SDL_Window *window,
                                   const void *data);
 extern void Cocoa_SetWindowTitle(_THIS, SDL_Window *window);
 extern int Cocoa_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon);
-extern void Cocoa_SetWindowPosition(_THIS, SDL_Window *window);
+extern int Cocoa_SetWindowPosition(_THIS, SDL_Window *window);
 extern void Cocoa_SetWindowSize(_THIS, SDL_Window *window);
 extern void Cocoa_SetWindowMinimumSize(_THIS, SDL_Window *window);
 extern void Cocoa_SetWindowMaximumSize(_THIS, SDL_Window *window);

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -1985,7 +1985,7 @@ int Cocoa_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon)
     }
 }
 
-void Cocoa_SetWindowPosition(_THIS, SDL_Window *window)
+int Cocoa_SetWindowPosition(_THIS, SDL_Window *window)
 {
     @autoreleasepool {
         SDL_CocoaWindowData *windata = (__bridge SDL_CocoaWindowData *)window->driverdata;
@@ -2026,6 +2026,7 @@ void Cocoa_SetWindowPosition(_THIS, SDL_Window *window)
 
         ScheduleContextUpdates(windata);
     }
+    return 0;
 }
 
 void Cocoa_SetWindowSize(_THIS, SDL_Window *window)

--- a/src/video/haiku/SDL_bwindow.h
+++ b/src/video/haiku/SDL_bwindow.h
@@ -27,7 +27,7 @@
 extern int HAIKU_CreateWindow(_THIS, SDL_Window *window);
 extern int HAIKU_CreateWindowFrom(_THIS, SDL_Window *window, const void *data);
 extern void HAIKU_SetWindowTitle(_THIS, SDL_Window *window);
-extern void HAIKU_SetWindowPosition(_THIS, SDL_Window *window);
+extern int HAIKU_SetWindowPosition(_THIS, SDL_Window *window);
 extern void HAIKU_SetWindowSize(_THIS, SDL_Window *window);
 extern void HAIKU_SetWindowMinimumSize(_THIS, SDL_Window *window);
 extern void HAIKU_ShowWindow(_THIS, SDL_Window *window);

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -1559,8 +1559,9 @@ int KMSDRM_CreateWindowFrom(_THIS, SDL_Window *window, const void *data)
 void KMSDRM_SetWindowTitle(_THIS, SDL_Window *window)
 {
 }
-void KMSDRM_SetWindowPosition(_THIS, SDL_Window *window)
+int KMSDRM_SetWindowPosition(_THIS, SDL_Window *window)
 {
+    return SDL_Unsupported();
 }
 void KMSDRM_SetWindowSize(_THIS, SDL_Window *window)
 {

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.h
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.h
@@ -124,7 +124,7 @@ int KMSDRM_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mod
 int KMSDRM_CreateWindow(_THIS, SDL_Window *window);
 int KMSDRM_CreateWindowFrom(_THIS, SDL_Window *window, const void *data);
 void KMSDRM_SetWindowTitle(_THIS, SDL_Window *window);
-void KMSDRM_SetWindowPosition(_THIS, SDL_Window *window);
+int KMSDRM_SetWindowPosition(_THIS, SDL_Window *window);
 void KMSDRM_SetWindowSize(_THIS, SDL_Window *window);
 void KMSDRM_SetWindowFullscreen(_THIS, SDL_Window *window, SDL_VideoDisplay *_display, SDL_bool fullscreen);
 void KMSDRM_ShowWindow(_THIS, SDL_Window *window);

--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -215,8 +215,9 @@ int PSP_CreateWindowFrom(_THIS, SDL_Window *window, const void *data)
 void PSP_SetWindowTitle(_THIS, SDL_Window *window)
 {
 }
-void PSP_SetWindowPosition(_THIS, SDL_Window *window)
+int PSP_SetWindowPosition(_THIS, SDL_Window *window)
 {
+    return SDL_Unsupported();
 }
 void PSP_SetWindowSize(_THIS, SDL_Window *window)
 {

--- a/src/video/psp/SDL_pspvideo.h
+++ b/src/video/psp/SDL_pspvideo.h
@@ -52,7 +52,7 @@ int PSP_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode);
 int PSP_CreateWindow(_THIS, SDL_Window *window);
 int PSP_CreateWindowFrom(_THIS, SDL_Window *window, const void *data);
 void PSP_SetWindowTitle(_THIS, SDL_Window *window);
-void PSP_SetWindowPosition(_THIS, SDL_Window *window);
+int PSP_SetWindowPosition(_THIS, SDL_Window *window);
 void PSP_SetWindowSize(_THIS, SDL_Window *window);
 void PSP_ShowWindow(_THIS, SDL_Window *window);
 void PSP_HideWindow(_THIS, SDL_Window *window);

--- a/src/video/raspberry/SDL_rpivideo.c
+++ b/src/video/raspberry/SDL_rpivideo.c
@@ -349,8 +349,9 @@ int RPI_CreateWindowFrom(_THIS, SDL_Window *window, const void *data)
 void RPI_SetWindowTitle(_THIS, SDL_Window *window)
 {
 }
-void RPI_SetWindowPosition(_THIS, SDL_Window *window)
+int RPI_SetWindowPosition(_THIS, SDL_Window *window)
 {
+    return SDL_Unsupported();
 }
 void RPI_SetWindowSize(_THIS, SDL_Window *window)
 {

--- a/src/video/raspberry/SDL_rpivideo.h
+++ b/src/video/raspberry/SDL_rpivideo.h
@@ -66,7 +66,7 @@ int RPI_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode);
 int RPI_CreateWindow(_THIS, SDL_Window *window);
 int RPI_CreateWindowFrom(_THIS, SDL_Window *window, const void *data);
 void RPI_SetWindowTitle(_THIS, SDL_Window *window);
-void RPI_SetWindowPosition(_THIS, SDL_Window *window);
+int RPI_SetWindowPosition(_THIS, SDL_Window *window);
 void RPI_SetWindowSize(_THIS, SDL_Window *window);
 void RPI_ShowWindow(_THIS, SDL_Window *window);
 void RPI_HideWindow(_THIS, SDL_Window *window);

--- a/src/video/vita/SDL_vitavideo.c
+++ b/src/video/vita/SDL_vitavideo.c
@@ -303,8 +303,9 @@ int VITA_CreateWindowFrom(_THIS, SDL_Window *window, const void *data)
 void VITA_SetWindowTitle(_THIS, SDL_Window *window)
 {
 }
-void VITA_SetWindowPosition(_THIS, SDL_Window *window)
+int VITA_SetWindowPosition(_THIS, SDL_Window *window)
 {
+    return SDL_Unsupported();
 }
 void VITA_SetWindowSize(_THIS, SDL_Window *window)
 {

--- a/src/video/vita/SDL_vitavideo.h
+++ b/src/video/vita/SDL_vitavideo.h
@@ -65,7 +65,7 @@ int VITA_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode)
 int VITA_CreateWindow(_THIS, SDL_Window *window);
 int VITA_CreateWindowFrom(_THIS, SDL_Window *window, const void *data);
 void VITA_SetWindowTitle(_THIS, SDL_Window *window);
-void VITA_SetWindowPosition(_THIS, SDL_Window *window);
+int VITA_SetWindowPosition(_THIS, SDL_Window *window);
 void VITA_SetWindowSize(_THIS, SDL_Window *window);
 void VITA_ShowWindow(_THIS, SDL_Window *window);
 void VITA_HideWindow(_THIS, SDL_Window *window);

--- a/src/video/vivante/SDL_vivantevideo.c
+++ b/src/video/vivante/SDL_vivantevideo.c
@@ -314,9 +314,10 @@ void VIVANTE_SetWindowTitle(_THIS, SDL_Window *window)
 #endif
 }
 
-void VIVANTE_SetWindowPosition(_THIS, SDL_Window *window)
+int VIVANTE_SetWindowPosition(_THIS, SDL_Window *window)
 {
     /* FIXME */
+    return SDL_Unsupported();
 }
 
 void VIVANTE_SetWindowSize(_THIS, SDL_Window *window)

--- a/src/video/vivante/SDL_vivantevideo.h
+++ b/src/video/vivante/SDL_vivantevideo.h
@@ -74,7 +74,7 @@ int VIVANTE_GetDisplayModes(_THIS, SDL_VideoDisplay *display);
 int VIVANTE_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode);
 int VIVANTE_CreateWindow(_THIS, SDL_Window *window);
 void VIVANTE_SetWindowTitle(_THIS, SDL_Window *window);
-void VIVANTE_SetWindowPosition(_THIS, SDL_Window *window);
+int VIVANTE_SetWindowPosition(_THIS, SDL_Window *window);
 void VIVANTE_SetWindowSize(_THIS, SDL_Window *window);
 void VIVANTE_ShowWindow(_THIS, SDL_Window *window);
 void VIVANTE_HideWindow(_THIS, SDL_Window *window);

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -141,7 +141,7 @@ extern void Wayland_RestoreWindow(_THIS, SDL_Window *window);
 extern void Wayland_SetWindowBordered(_THIS, SDL_Window *window, SDL_bool bordered);
 extern void Wayland_SetWindowResizable(_THIS, SDL_Window *window, SDL_bool resizable);
 extern int Wayland_CreateWindow(_THIS, SDL_Window *window);
-extern void Wayland_SetWindowPosition(_THIS, SDL_Window *window);
+extern int Wayland_SetWindowPosition(_THIS, SDL_Window *window);
 extern void Wayland_SetWindowSize(_THIS, SDL_Window *window);
 extern void Wayland_SetWindowMinimumSize(_THIS, SDL_Window *window);
 extern void Wayland_SetWindowMaximumSize(_THIS, SDL_Window *window);

--- a/src/video/windows/SDL_windowswindow.h
+++ b/src/video/windows/SDL_windowswindow.h
@@ -84,7 +84,7 @@ extern int WIN_CreateWindow(_THIS, SDL_Window *window);
 extern int WIN_CreateWindowFrom(_THIS, SDL_Window *window, const void *data);
 extern void WIN_SetWindowTitle(_THIS, SDL_Window *window);
 extern int WIN_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon);
-extern void WIN_SetWindowPosition(_THIS, SDL_Window *window);
+extern int WIN_SetWindowPosition(_THIS, SDL_Window *window);
 extern void WIN_SetWindowSize(_THIS, SDL_Window *window);
 extern int WIN_GetWindowBordersSize(_THIS, SDL_Window *window, int *top, int *left, int *bottom, int *right);
 extern void WIN_GetWindowSizeInPixels(_THIS, SDL_Window *window, int *width, int *height);
@@ -116,7 +116,7 @@ extern void WIN_ClientPointFromSDLFloat(const SDL_Window *window, float x, float
 extern void WIN_AcceptDragAndDrop(SDL_Window *window, SDL_bool accept);
 extern int WIN_FlashWindow(_THIS, SDL_Window *window, SDL_FlashOperation operation);
 extern void WIN_UpdateDarkModeForHWND(HWND hwnd);
-extern void WIN_SetWindowPositionInternal(SDL_Window *window, UINT flags);
+extern int WIN_SetWindowPositionInternal(SDL_Window *window, UINT flags);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -959,12 +959,13 @@ void X11_UpdateWindowPosition(SDL_Window *window)
     }
 }
 
-void X11_SetWindowPosition(_THIS, SDL_Window *window)
+int X11_SetWindowPosition(_THIS, SDL_Window *window)
 {
     if (SDL_WINDOW_IS_POPUP(window)) {
         X11_ConstrainPopup(window);
     }
     X11_UpdateWindowPosition(window);
+    return 0;
 }
 
 static void X11_SetWMNormalHints(_THIS, SDL_Window *window, XSizeHints *sizehints)

--- a/src/video/x11/SDL_x11window.h
+++ b/src/video/x11/SDL_x11window.h
@@ -89,7 +89,7 @@ extern int X11_CreateWindowFrom(_THIS, SDL_Window *window, const void *data);
 extern char *X11_GetWindowTitle(_THIS, Window xwindow);
 extern void X11_SetWindowTitle(_THIS, SDL_Window *window);
 extern int X11_SetWindowIcon(_THIS, SDL_Window *window, SDL_Surface *icon);
-extern void X11_SetWindowPosition(_THIS, SDL_Window *window);
+extern int X11_SetWindowPosition(_THIS, SDL_Window *window);
 extern void X11_SetWindowMinimumSize(_THIS, SDL_Window *window);
 extern void X11_SetWindowMaximumSize(_THIS, SDL_Window *window);
 extern int X11_GetWindowBordersSize(_THIS, SDL_Window *window, int *top, int *left, int *bottom, int *right);


### PR DESCRIPTION
This pr is created as a result of this comment:
https://github.com/libsdl-org/SDL/issues/7197#issuecomment-1524160409

## Description
Return a negative error variable when `SDL_SetWindowPosition` fails.

## Existing Issue(s)
#7197
