### PR TITLE
Update migration guide with info on trackballs

### DIFF
--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -476,6 +476,7 @@ The following functions have been removed:
 * SDL_JoystickGetDeviceType() - replaced with SDL_GetJoystickInstanceType()
 * SDL_JoystickGetDeviceVendor() - replaced with SDL_GetJoystickInstanceVendor()
 * SDL_JoystickNameForIndex() - replaced with SDL_GetJoystickInstanceName()
+* SDL_JoystickNumBalls() - API has been removed, see https://github.com/libsdl-org/SDL/issues/6766
 * SDL_JoystickPathForIndex() - replaced with SDL_GetJoystickInstancePath()
 * SDL_NumJoysticks() - replaced with SDL_GetJoysticks()
 

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -480,6 +480,9 @@ The following functions have been removed:
 * SDL_JoystickPathForIndex() - replaced with SDL_GetJoystickInstancePath()
 * SDL_NumJoysticks() - replaced with SDL_GetJoysticks()
 
+The following symbols have been removed:
+* SDL_JOYBALLMOTION
+
 ## SDL_keyboard.h
 
 The following functions have been renamed:


### PR DESCRIPTION
Add info pointing users to #6766 when they look for SDL_JoystickNumBalls
