### PR TITLE
Fix bug memory access

### DIFF
--- a/src/video/directfb/SDL_DirectFB_shape.c
+++ b/src/video/directfb/SDL_DirectFB_shape.c
@@ -103,7 +103,7 @@ DirectFB_SetWindowShape(SDL_WindowShaper *shaper,SDL_Surface *shape,SDL_WindowSh
         dsc.pixelformat = DSPF_ARGB;
 
         SDL_DFB_CHECKERR(devdata->dfb->CreateSurface(devdata->dfb, &dsc, &data->surface));
-
+        SDL_DFB_CALLOC(bitmap, shape->w * shape->h, 1);
         /* Assume that shaper->alphacutoff already has a value, because SDL_SetWindowShape() should have given it one. */
         SDL_CalculateShapeBitmap(shaper->mode, shape, bitmap, 1);
 


### PR DESCRIPTION
Bitmap is not initialized before use, that cause segmentation fault on function use it. Fix by allocate memory before use.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allocate memory for bitmap with the require size for the function before pass to the function. The current will meet the segmentation fault because function use bitmap will memset the bitmap with the size of the shape. 
## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/libsdl-org/SDL/issues/7676