### PR TITLE
Wayland popup fixes for UE5

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -317,10 +317,10 @@ static void EnsurePopupPositionIsValid(SDL_Window *window)
         window->y = -window->h;
     }
     if (window->x > window->parent->w) {
-        window->x = window->parent->w;
+        window->x = window->parent->w - 1;
     }
     if (window->y > window->parent->h) {
-        window->y = window->parent->h;
+        window->y = window->parent->h - 1;
     }
 }
 

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -653,7 +653,6 @@ static void handle_configure_xdg_popup(void *data,
                                        int32_t width,
                                        int32_t height)
 {
-    /* Popups can't be resized, so only position data is sent. */
     SDL_WindowData *wind = (SDL_WindowData *)data;
     int offset_x, offset_y;
 
@@ -665,7 +664,6 @@ static void handle_configure_xdg_popup(void *data,
     wind->requested_window_width = width;
     wind->requested_window_height = height;
 
-    ConfigureWindowGeometry(wind->sdlwindow);
     SDL_SendWindowEvent(wind->sdlwindow, SDL_EVENT_WINDOW_MOVED, x, y);
 
     if (wind->surface_status == WAYLAND_SURFACE_STATUS_WAITING_FOR_CONFIGURE) {


### PR DESCRIPTION
Various fixes for bugs that popped up when testing the UE5 editor via sdl2-compat. Wayland has strict rules for popups, so we must ensure, in all cases, that the rules for popup positioning are obeyed.