### PR TITLE
Android: use the headers to have the audio pause/resume definitions

### DIFF
--- a/src/audio/aaudio/SDL_aaudio.c
+++ b/src/audio/aaudio/SDL_aaudio.c
@@ -22,9 +22,26 @@
 
 #ifdef SDL_AUDIO_DRIVER_AAUDIO
 
+#include "../SDL_sysaudio.h"
 #include "../SDL_audio_c.h"
-#include "../../core/android/SDL_android.h"
 #include "SDL_aaudio.h"
+
+#include "../../core/android/SDL_android.h"
+#include <stdbool.h>
+#include <aaudio/AAudio.h>
+
+struct SDL_PrivateAudioData
+{
+    AAudioStream *stream;
+
+    /* Raw mixing buffer */
+    Uint8 *mixbuf;
+    int mixlen;
+    int frame_size;
+
+    /* Resume device if it was paused automatically */
+    int resume;
+};
 
 /* Debug */
 #if 0

--- a/src/audio/aaudio/SDL_aaudio.h
+++ b/src/audio/aaudio/SDL_aaudio.h
@@ -20,28 +20,21 @@
 */
 #include "SDL_internal.h"
 
-#ifndef SDL_aaudio_h
-#define SDL_aaudio_h
+#ifndef SDL_aaudio_h_
+#define SDL_aaudio_h_
 
-#include "../SDL_sysaudio.h"
-#include <stdbool.h>
-#include <aaudio/AAudio.h>
-
-struct SDL_PrivateAudioData
-{
-    AAudioStream *stream;
-
-    /* Raw mixing buffer */
-    Uint8 *mixbuf;
-    int mixlen;
-    int frame_size;
-
-    /* Resume device if it was paused automatically */
-    int resume;
-};
+#ifdef SDL_AUDIO_DRIVER_AAUDIO
 
 void aaudio_ResumeDevices(void);
 void aaudio_PauseDevices(void);
 SDL_bool aaudio_DetectBrokenPlayState(void);
 
-#endif /* SDL_aaudio_h */
+#else
+
+static void aaudio_ResumeDevices(void) {}
+static void aaudio_PauseDevices(void) {}
+static SDL_bool aaudio_DetectBrokenPlayState(void) { return SDL_FALSE; }
+
+#endif
+
+#endif /* SDL_aaudio_h_ */

--- a/src/audio/android/SDL_androidaudio.c
+++ b/src/audio/android/SDL_androidaudio.c
@@ -24,12 +24,19 @@
 
 /* Output audio to Android */
 
+#include "../SDL_sysaudio.h"
 #include "../SDL_audio_c.h"
 #include "SDL_androidaudio.h"
 
 #include "../../core/android/SDL_android.h"
-
 #include <android/log.h>
+
+
+struct SDL_PrivateAudioData
+{
+    /* Resume device if it was paused automatically */
+    int resume;
+};
 
 static SDL_AudioDevice *audioDevice = NULL;
 static SDL_AudioDevice *captureDevice = NULL;
@@ -207,10 +214,5 @@ void ANDROIDAUDIO_ResumeDevices(void)
         }
     }
 }
-
-#else
-
-void ANDROIDAUDIO_ResumeDevices(void) {}
-void ANDROIDAUDIO_PauseDevices(void) {}
 
 #endif /* SDL_AUDIO_DRIVER_ANDROID */

--- a/src/audio/android/SDL_androidaudio.h
+++ b/src/audio/android/SDL_androidaudio.h
@@ -23,15 +23,16 @@
 #ifndef SDL_androidaudio_h_
 #define SDL_androidaudio_h_
 
-#include "../SDL_sysaudio.h"
-
-struct SDL_PrivateAudioData
-{
-    /* Resume device if it was paused automatically */
-    int resume;
-};
+#ifdef SDL_AUDIO_DRIVER_ANDROID
 
 void ANDROIDAUDIO_ResumeDevices(void);
 void ANDROIDAUDIO_PauseDevices(void);
+
+#else
+
+static void ANDROIDAUDIO_ResumeDevices(void) {}
+static void ANDROIDAUDIO_PauseDevices(void) {}
+
+#endif
 
 #endif /* SDL_androidaudio_h_ */

--- a/src/audio/openslES/SDL_openslES.c
+++ b/src/audio/openslES/SDL_openslES.c
@@ -26,15 +26,25 @@
    https://googlesamples.github.io/android-audio-high-performance/guides/opensl_es.html
 */
 
+#include "../SDL_sysaudio.h"
 #include "../SDL_audio_c.h"
-#include "../../core/android/SDL_android.h"
 #include "SDL_openslES.h"
 
-/* for native audio */
+#include "../../core/android/SDL_android.h"
 #include <SLES/OpenSLES.h>
 #include <SLES/OpenSLES_Android.h>
-
 #include <android/log.h>
+
+
+#define NUM_BUFFERS 2 /* -- Don't lower this! */
+
+struct SDL_PrivateAudioData
+{
+    Uint8 *mixbuff;
+    int next_buffer;
+    Uint8 *pmixbuff[NUM_BUFFERS];
+    SDL_Semaphore *playsem;
+};
 
 #if 0
 #define LOG_TAG   "SDL_openslES"

--- a/src/audio/openslES/SDL_openslES.h
+++ b/src/audio/openslES/SDL_openslES.h
@@ -20,22 +20,19 @@
 */
 #include "SDL_internal.h"
 
-#ifndef SDL_openslesaudio_h
-#define SDL_openslesaudio_h
+#ifndef SDL_openslesaudio_h_
+#define SDL_openslesaudio_h_
 
-#include "../SDL_sysaudio.h"
-
-#define NUM_BUFFERS 2 /* -- Don't lower this! */
-
-struct SDL_PrivateAudioData
-{
-    Uint8 *mixbuff;
-    int next_buffer;
-    Uint8 *pmixbuff[NUM_BUFFERS];
-    SDL_Semaphore *playsem;
-};
+#ifdef SDL_AUDIO_DRIVER_OPENSLES
 
 void openslES_ResumeDevices(void);
 void openslES_PauseDevices(void);
 
-#endif /* SDL_openslesaudio_h */
+#else
+
+static void openslES_ResumeDevices(void) {}
+static void openslES_PauseDevices(void) {}
+
+#endif
+
+#endif /* SDL_openslesaudio_h_ */

--- a/src/video/android/SDL_androidevents.c
+++ b/src/video/android/SDL_androidevents.c
@@ -28,38 +28,10 @@
 #include "../SDL_sysvideo.h"
 #include "../../events/SDL_events_c.h"
 
-/* Can't include sysaudio "../../audio/android/SDL_androidaudio.h"
- * because of THIS redefinition */
 
-#if !defined(SDL_AUDIO_DISABLED) && defined(SDL_AUDIO_DRIVER_ANDROID)
-extern void ANDROIDAUDIO_ResumeDevices(void);
-extern void ANDROIDAUDIO_PauseDevices(void);
-#else
-static void ANDROIDAUDIO_ResumeDevices(void) {}
-static void ANDROIDAUDIO_PauseDevices(void) {}
-#endif
-
-#if !defined(SDL_AUDIO_DISABLED) && defined(SDL_AUDIO_DRIVER_OPENSLES)
-extern void openslES_ResumeDevices(void);
-extern void openslES_PauseDevices(void);
-#else
-static void openslES_ResumeDevices(void)
-{
-}
-static void openslES_PauseDevices(void) {}
-#endif
-
-#if !defined(SDL_AUDIO_DISABLED) && defined(SDL_AUDIO_DRIVER_AAUDIO)
-extern void aaudio_ResumeDevices(void);
-extern void aaudio_PauseDevices(void);
-SDL_bool aaudio_DetectBrokenPlayState(void);
-#else
-static void aaudio_ResumeDevices(void)
-{
-}
-static void aaudio_PauseDevices(void) {}
-static SDL_bool aaudio_DetectBrokenPlayState(void) { return SDL_FALSE; }
-#endif
+#include "../../audio/android/SDL_androidaudio.h"
+#include "../../audio/aaudio/SDL_aaudio.h"
+#include "../../audio/openslES/SDL_openslES.h"
 
 /* Number of 'type' events in the event queue */
 static int SDL_NumberOfEvents(Uint32 type)


### PR DESCRIPTION
Android: use the headers to have the audio pause/resume definitions
and make SDL_PriveAudioData more private

(after  https://github.com/libsdl-org/SDL/pull/7692 and https://github.com/libsdl-org/SDL/issues/7688 )
