### PR TITLE
x11: Dynamically update the scale factor

### DIFF
--- a/src/core/linux/SDL_dbus.c
+++ b/src/core/linux/SDL_dbus.c
@@ -498,4 +498,16 @@ SDL_DBus_ScreensaverInhibit(SDL_bool inhibit)
 
     return SDL_TRUE;
 }
+
+void SDL_DBus_PumpEvents(void)
+{
+    if (dbus.session_conn) {
+        dbus.connection_read_write(dbus.session_conn, 0);
+
+        while (dbus.connection_dispatch(dbus.session_conn) == DBUS_DISPATCH_DATA_REMAINS) {
+            /* Do nothing, actual work happens in DBus_MessageFilter */
+            SDL_DelayNS(SDL_US_TO_NS(10));
+        }
+    }
+}
 #endif

--- a/src/core/linux/SDL_dbus.h
+++ b/src/core/linux/SDL_dbus.h
@@ -94,6 +94,8 @@ extern SDL_bool SDL_DBus_QueryPropertyOnConnection(DBusConnection *conn, const c
 extern void SDL_DBus_ScreensaverTickle(void);
 extern SDL_bool SDL_DBus_ScreensaverInhibit(SDL_bool inhibit);
 
+extern void SDL_DBus_PumpEvents(void);
+
 #endif /* HAVE_DBUS_DBUS_H */
 
 #endif /* SDL_dbus_h_ */

--- a/src/core/linux/SDL_system_theme.c
+++ b/src/core/linux/SDL_system_theme.c
@@ -158,18 +158,3 @@ SDL_SystemTheme_Get(void)
 {
     return system_theme_data.theme;
 }
-
-void
-SDL_SystemTheme_PumpEvents(void)
-{
-    SDL_DBusContext *dbus = system_theme_data.dbus;
-    DBusConnection *conn;
-    if (dbus == NULL) return;
-    conn = dbus->session_conn;
-    dbus->connection_read_write(conn, 0);
-
-    while (dbus->connection_dispatch(conn) == DBUS_DISPATCH_DATA_REMAINS) {
-        /* Do nothing, actual work happens in DBus_MessageFilter */
-        usleep(10);
-    }
-}

--- a/src/core/linux/SDL_system_theme.h
+++ b/src/core/linux/SDL_system_theme.h
@@ -26,6 +26,5 @@
 
 extern SDL_bool SDL_SystemTheme_Init(void);
 extern SDL_SystemTheme SDL_SystemTheme_Get(void);
-extern void SDL_SystemTheme_PumpEvents(void);
 
 #endif /* SDL_system_theme_h_ */

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -391,7 +391,7 @@ int Wayland_WaitEventTimeout(SDL_VideoDevice *_this, Sint64 timeoutNS)
 #endif
 
 #ifdef SDL_USE_LIBDBUS
-    SDL_SystemTheme_PumpEvents();
+    SDL_DBus_PumpEvents();
 #endif
 
     /* If key repeat is active, we'll need to cap our maximum wait time to handle repeats */
@@ -464,7 +464,7 @@ void Wayland_PumpEvents(SDL_VideoDevice *_this)
 #endif
 
 #ifdef SDL_USE_LIBDBUS
-    SDL_SystemTheme_PumpEvents();
+    SDL_DBus_PumpEvents();
 #endif
 
 #ifdef HAVE_LIBDECOR_H

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -1706,7 +1706,7 @@ int X11_WaitEventTimeout(SDL_VideoDevice *_this, Sint64 timeoutNS)
 #endif
 
 #ifdef SDL_USE_LIBDBUS
-    SDL_SystemTheme_PumpEvents();
+    SDL_DBus_PumpEvents();
 #endif
     return 1;
 }
@@ -1751,7 +1751,7 @@ void X11_PumpEvents(SDL_VideoDevice *_this)
 #endif
 
 #ifdef SDL_USE_LIBDBUS
-    SDL_SystemTheme_PumpEvents();
+    SDL_DBus_PumpEvents();
 #endif
 
     /* FIXME: Only need to do this when there are pending focus changes */


### PR DESCRIPTION
If the `text-scaling-factor` setting is available via D-Bus, add a listener and update the content scale values for the displays if the value is changed during runtime.

Factors out the D-Bus message pump from the system theme detection code to the general D-Bus code, as it's now used for more purposes than just the system theme.

Follow up to #7718