### PR TITLE
Fix Xbox link error from IsRectEmpty

### DIFF
--- a/src/core/windows/SDL_windows.c
+++ b/src/core/windows/SDL_windows.c
@@ -331,6 +331,12 @@ void WIN_RectToRECT(const SDL_Rect *sdlrect, RECT *winrect)
     winrect->bottom = sdlrect->y + sdlrect->h - 1;
 }
 
+BOOL WIN_IsRectEmpty(const RECT *rect)
+{
+    /* Calculating this manually because UWP and Xbox do not support Win32 IsRectEmpty. */
+    return (rect->right <= rect->left) || (rect->bottom <= rect->top);
+}
+
 /* Win32-specific SDL_RunApp(), which does most of the SDL_main work,
   based on SDL_windows_main.c, placed in the public domain by Sam Lantinga  4/13/98 */
 #ifdef __WIN32__

--- a/src/core/windows/SDL_windows.h
+++ b/src/core/windows/SDL_windows.h
@@ -151,6 +151,9 @@ extern BOOL WIN_IsEqualIID(REFIID a, REFIID b);
 extern void WIN_RECTToRect(const RECT *winrect, SDL_Rect *sdlrect);
 extern void WIN_RectToRECT(const SDL_Rect *sdlrect, RECT *winrect);
 
+/* Returns SDL_TRUE if the rect is empty */
+extern BOOL WIN_IsRectEmpty(const RECT *rect);
+
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus
 }

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1243,7 +1243,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
             break;
         }
 
-        if (!GetClientRect(hwnd, &rect) || IsRectEmpty(&rect)) {
+        if (!GetClientRect(hwnd, &rect) || WIN_IsRectEmpty(&rect)) {
             break;
         }
         ClientToScreen(hwnd, (LPPOINT)&rect);
@@ -1404,7 +1404,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
                 RECT rect;
                 float x, y;
 
-                if (!GetClientRect(hwnd, &rect) || IsRectEmpty(&rect)) {
+                if (!GetClientRect(hwnd, &rect) || WIN_IsRectEmpty(&rect)) {
                     if (inputs) {
                         SDL_small_free(inputs, isstack);
                     }

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -825,7 +825,7 @@ void WIN_GetWindowSizeInPixels(SDL_VideoDevice *_this, SDL_Window *window, int *
     HWND hwnd = data->hwnd;
     RECT rect;
 
-    if (GetClientRect(hwnd, &rect) && !IsRectEmpty(&rect)) {
+    if (GetClientRect(hwnd, &rect) && !WIN_IsRectEmpty(&rect)) {
         *w = rect.right;
         *h = rect.bottom;
     } else {
@@ -1358,7 +1358,7 @@ void WIN_UpdateClipCursor(SDL_Window *window)
                     }
                 }
                 if (SDL_memcmp(&rect, &clipped_rect, sizeof(rect)) != 0) {
-                    if (!IsRectEmpty(&rect)) {
+                    if (!WIN_IsRectEmpty(&rect)) {
                         if (ClipCursor(&rect)) {
                             data->cursor_clipped_rect = rect;
                         }


### PR DESCRIPTION
`IsRectEmpty` is not defined for Xbox GDK, resulting in a link error in `WIN_GetWindowSizeInPixels`. Note that `IsRectEmpty` is called elsewhere in the codebase too, but this is the only place it's not #ifdef'd out for Xbox.

I wasn't sure how to style this, since it's a bit of a weird case where the #ifdef goes in the middle of an `if` statement. I'm happy to reformat this if needed.

Note that this affects SDL2 too, since the commit introducing this line was cherrypicked for the SDL2 branch.