### PR TITLE
Fix unused function warning in SDL_x11xinput2.c

### DIFF
--- a/src/video/x11/SDL_x11xinput2.c
+++ b/src/video/x11/SDL_x11xinput2.c
@@ -182,7 +182,7 @@ void X11_InitXinput2(_THIS)
 }
 
 /* xi2 device went away? take it out of the list. */
-static void xinput2_remove_device_info(SDL_VideoData *videodata, const int device_id)
+__attribute__((unused)) static void xinput2_remove_device_info(SDL_VideoData *videodata, const int device_id)
 {
     SDL_XInput2DeviceInfo *prev = NULL;
     SDL_XInput2DeviceInfo *devinfo;


### PR DESCRIPTION
The function xinput2_remove_device_info in SDL_x11xinput2.c was defined but not used, resulting in a warning during compilation. To address this, the function definition has been marked with the __attribute__((unused)) attribute, indicating to the compiler that it may remain unused. This prevents the warning from being issued.
