### PR TITLE
video: Don't update the window position if the operation is unsupport…

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2439,14 +2439,24 @@ int SDL_SetWindowPosition(SDL_Window *window, int x, int y)
                 return SDL_UpdateFullscreenMode(window, SDL_TRUE);
             }
         }
-    } else {
+    } else if (_this->SetWindowPosition) {
+        const int original_x = window->x;
+        const int original_y = window->y;
+        int res;
+
         window->x = x;
         window->y = y;
         window->last_displayID = SDL_GetDisplayForWindow(window);
 
-        if (_this->SetWindowPosition) {
-            return _this->SetWindowPosition(_this, window);
+        res = _this->SetWindowPosition(_this, window);
+
+        if (res < 0) {
+            window->x = original_x;
+            window->y = original_y;
+            window->last_displayID = original_displayID;
         }
+
+        return res;
     }
     return SDL_Unsupported();
 }


### PR DESCRIPTION
…ed or fails

If positioning a non-fullscreen window is unsupported by the driver, or the operation fails, the window position is still set to the user requested coordinates, even though the window didn't actually move. Don't change the window position if positioning is unsupported, and restore the old values if the positioning operation failed.

This prevents applications that do things such as get the global cursor coordinates and transform them back to relative via the window position from breaking if the window coordinates as reported by SDL don't match the actual location of the window in desktop space.

The trade-off here is that a pattern such as
```
SDL_SetWindowPosition(win, fake_x, fake_y);
SDL_SetWindowFullscreen(win, SDL_TRUE);
```
for positioning a fullscreen desktop window on a specific display wouldn't work if windowed-mode positioning is unsupported. An application would have to enter fullscreen desktop mode, then move the window to the desired display.