### PR TITLE
GitIgnore: Also ignore "build-*/" sub-directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 build-*/
+!build-scripts/
 buildbot/
 /VERSION.txt
 __pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+build-*/
 buildbot/
 /VERSION.txt
 __pycache__


### PR DESCRIPTION
Locally, I do make multiple build directories for various purposes, like "build-debug", "build-release", "build-novideo", etc. Also, Qt Creator (if configure it) may automatically create build directories that always starts with a "build-*" prefix.
