### PR TITLE
wayland: Add aspect-correct output for scaled modes

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -1785,6 +1785,21 @@ extern "C" {
 #define SDL_HINT_VIDEO_WAYLAND_MODE_EMULATION "SDL_VIDEO_WAYLAND_MODE_EMULATION"
 
 /**
+ *  \brief  A variable controlling how modes with a non-native aspect ratio are displayed under Wayland.
+ *
+ *  When this hint is set, the requested scaling will be used when displaying fullscreen video modes
+ *  that don't match the display's native aspect ratio. This is contingent on compositor viewport support.
+ *
+ *  This variable can be set to the following values:
+ *    "aspect"       - Video modes will be displayed scaled, in their proper aspect ratio, with black bars.
+ *    "stretch"      - Video modes will be scaled to fill the entire display.
+ *    "none"         - Video modes will be displayed as 1:1 with no scaling.
+ *
+ *  By default 'stretch' is used.
+ */
+#define SDL_HINT_VIDEO_WAYLAND_MODE_SCALING "SDL_VIDEO_WAYLAND_MODE_SCALING"
+
+/**
  *  \brief  Enable or disable mouse pointer warp emulation, needed by some older games.
  *
  *  When this hint is set, any SDL will emulate mouse warps using relative mouse mode.


### PR DESCRIPTION
Add aspect-correct output of scaled video modes and a hint to control this behavior (aspect, stretch, or none).

The Wayland spec states that fullscreen surfaces that do not cover the entire output shall be centered with the borders masked by the compositor, so no additional work is required aside from calculating the proper window dimensions, which is fairly simple (unlike the previous attempt that used subsurfaces, and became quite ugly trying to work around compositor bugs).

The default is still 'stretch' mode (same as the existing behavior), as some window managers as of right now (KDE and older versions of GNOME still found in LTS distros) don't behave according to the spec and present an unmasked window that is not centered, so it's not yet safe to change the default.

KDE will likely have to implement correct behavior relatively soon, as the forthcoming Wine Wayland driver is said to need this too (https://bugs.kde.org/show_bug.cgi?id=461063).