### PR TITLE
QtWayland orientation fixes

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -1321,6 +1321,8 @@ extern "C" {
  *
  *  This variable can be one of the following values:
  *    "primary" (default), "portrait", "landscape", "inverted-portrait", "inverted-landscape"
+ *
+ *  Since SDL 2.0.22 this variable accepts a comma-separated list of values above.
  */
 #define SDL_HINT_QTWAYLAND_CONTENT_ORIENTATION "SDL_QTWAYLAND_CONTENT_ORIENTATION"
 

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -1720,6 +1720,8 @@ static void SDLCALL QtExtendedSurface_OnHintChanged(void *userdata, const char *
 
         if (newValue != NULL) {
             const char *value_attempt = newValue;
+
+            orientation = 0;
             while (value_attempt != NULL && *value_attempt != 0) {
                 const char *value_attempt_end = SDL_strchr(value_attempt, ',');
                 size_t value_attempt_len = (value_attempt_end != NULL) ? (value_attempt_end - value_attempt)


### PR DESCRIPTION
## Description
Since 63ae103cd184eb46020eb77f5fd49504183296bd, SDL_HINT_QTWAYLAND_CONTENT_ORIENTATION can accept comma-separated list of used screen orientations. But this change also introduced a bug: primary orientation is always set, no matter the hint value.

Also added a note in SDL_hints.h header about this change.

SDL3 branch has the same bug, probably should be cherry-picked there as well.