### PR TITLE
hidapi: silence redefinition warnings

### DIFF
--- a/src/hidapi/SDL_hidapi_libusb.h
+++ b/src/hidapi/SDL_hidapi_libusb.h
@@ -20,22 +20,52 @@
 */
 
 /* Define standard library functions in terms of SDL */
-#define free    SDL_free
+#pragma push_macro("malloc")
+#pragma push_macro("realloc")
+#pragma push_macro("free")
+#pragma push_macro("iconv_t")
+#pragma push_macro("iconv")
+#pragma push_macro("iconv_open")
+#pragma push_macro("iconv_close")
+#pragma push_macro("setlocale")
+#pragma push_macro("snprintf")
+#pragma push_macro("strcmp")
+#pragma push_macro("strdup")
+#pragma push_macro("strncpy")
+#pragma push_macro("tolower")
+#pragma push_macro("wcsdup")
+
+#undef malloc
+#undef realloc
+#undef free
+#undef iconv_t
+#undef iconv
+#undef iconv_open
+#undef iconv_close
+#undef setlocale
+#undef snprintf
+#undef strcmp
+#undef strdup
+#undef strncpy
+#undef tolower
+#undef wcsdup
+
+#define malloc          SDL_malloc
+#define realloc         SDL_realloc
+#define free            SDL_free
 #define iconv_t         SDL_iconv_t
+#ifndef ICONV_CONST
 #define ICONV_CONST
+#define UNDEF_ICONV_CONST
+#endif
 #define iconv(a,b,c,d,e) SDL_iconv(a, (const char **)b, c, d, e)
 #define iconv_open      SDL_iconv_open
 #define iconv_close     SDL_iconv_close
-#define malloc          SDL_malloc
-#define realloc         SDL_realloc
 #define setlocale(X, Y) NULL
 #define snprintf        SDL_snprintf
 #define strcmp          SDL_strcmp
 #define strdup          SDL_strdup
 #define strncpy         SDL_strlcpy
-#ifdef tolower
-#undef tolower
-#endif
 #define tolower         SDL_tolower
 #define wcsdup          SDL_wcsdup
 
@@ -57,3 +87,23 @@ static int SDL_libusb_get_string_descriptor(libusb_device_handle *dev,
 
 #undef HIDAPI_H__
 #include "libusb/hid.c"
+
+/* restore libc function macros */
+#ifdef UNDEF_ICONV_CONST
+#undef ICONV_CONST
+#undef UNDEF_ICONV_CONST
+#endif
+#pragma pop_macro("malloc")
+#pragma pop_macro("realloc")
+#pragma pop_macro("free")
+#pragma pop_macro("iconv_t")
+#pragma pop_macro("iconv")
+#pragma pop_macro("iconv_open")
+#pragma pop_macro("iconv_close")
+#pragma pop_macro("setlocale")
+#pragma pop_macro("snprintf")
+#pragma pop_macro("strcmp")
+#pragma pop_macro("strdup")
+#pragma pop_macro("strncpy")
+#pragma pop_macro("tolower")
+#pragma pop_macro("wcsdup")

--- a/src/hidapi/SDL_hidapi_windows.h
+++ b/src/hidapi/SDL_hidapi_windows.h
@@ -20,6 +20,32 @@
 */
 
 /* Define standard library functions in terms of SDL */
+#pragma push_macro("calloc")
+#pragma push_macro("free")
+#pragma push_macro("malloc")
+#pragma push_macro("memcmp")
+#pragma push_macro("swprintf")
+#pragma push_macro("towupper")
+#pragma push_macro("wcscmp")
+#pragma push_macro("_wcsdup")
+#pragma push_macro("wcslen")
+#pragma push_macro("wcsncpy")
+#pragma push_macro("wcsstr")
+#pragma push_macro("wcstol")
+
+#undef calloc
+#undef free
+#undef malloc
+#undef memcmp
+#undef swprintf
+#undef towupper
+#undef wcscmp
+#undef _wcsdup
+#undef wcslen
+#undef wcsncpy
+#undef wcsstr
+#undef wcstol
+
 #define calloc      SDL_calloc
 #define free        SDL_free
 #define malloc      SDL_malloc
@@ -37,3 +63,17 @@
 #include "windows/hid.c"
 #define HAVE_PLATFORM_BACKEND 1
 #define udev_ctx              1
+
+/* restore libc function macros */
+#pragma pop_macro("calloc")
+#pragma pop_macro("free")
+#pragma pop_macro("malloc")
+#pragma pop_macro("memcmp")
+#pragma pop_macro("swprintf")
+#pragma pop_macro("towupper")
+#pragma pop_macro("wcscmp")
+#pragma pop_macro("_wcsdup")
+#pragma pop_macro("wcslen")
+#pragma pop_macro("wcsncpy")
+#pragma pop_macro("wcsstr")
+#pragma pop_macro("wcstol")

--- a/src/hidapi/libusb/hid.c
+++ b/src/hidapi/libusb/hid.c
@@ -598,7 +598,7 @@ int HID_API_EXPORT hid_init(void)
 		/* Set the locale if it's not set. */
 		locale = setlocale(LC_CTYPE, NULL);
 		if (!locale)
-			setlocale(LC_CTYPE, "");
+			(void) setlocale(LC_CTYPE, "");
 	}
 
 	return 0;


### PR DESCRIPTION
Fixes https://github.com/libsdl-org/SDL/issues/7771

I preferred using push_macro/pop_macro pragmas because, if I am not
mistaken, SDL_hidapi.c can include multiple backends.

There is one warning remaining:
```
In file included from /home/sezero/SDL/src/hidapi/SDL_hidapi_libusb.h:89,
                 from /home/sezero/SDL/src/hidapi/SDL_hidapi.c:816:
/home/sezero/SDL/src/hidapi/libusb/hid.c:1482:104: warning: "LIBUSB_API_VERSION" is not defined
```

That `-Wundef` warning is because my installed libusb version is too old.
HOWEVER: We are dlopen()ing libusb _and_ `libusb_wrap_sys_device` dlsym()
failure is considered a failure: we should not. That should be a subject
of another issue and a patch, so I did not silence that warning.
