### PR TITLE
hidapi/libusb: don't try to dlsym libusb_wrap_sys_device

### DIFF
--- a/src/hidapi/SDL_hidapi.c
+++ b/src/hidapi/SDL_hidapi.c
@@ -710,7 +710,6 @@ static struct
     uint8_t (LIBUSB_CALL *get_bus_number)(libusb_device *dev);
     int (LIBUSB_CALL *get_port_numbers)(libusb_device *dev, uint8_t *port_numbers, int port_numbers_len);
     uint8_t (LIBUSB_CALL *get_device_address)(libusb_device *dev);
-    int (LIBUSB_CALL *wrap_sys_device)(libusb_context *ctx, intptr_t sys_dev, libusb_device_handle **dev_handle);
     int (LIBUSB_CALL *open)(libusb_device *dev, libusb_device_handle **dev_handle);
     void (LIBUSB_CALL *close)(libusb_device_handle *dev_handle);
     libusb_device *(LIBUSB_CALL *get_device)(libusb_device_handle *dev_handle);
@@ -760,7 +759,6 @@ static struct
 #define libusb_get_bus_number               libusb_ctx.get_bus_number
 #define libusb_get_port_numbers             libusb_ctx.get_port_numbers
 #define libusb_get_device_address           libusb_ctx.get_device_address
-#define libusb_wrap_sys_device              libusb_ctx.wrap_sys_device
 #define libusb_open                         libusb_ctx.open
 #define libusb_close                        libusb_ctx.close
 #define libusb_get_device                   libusb_ctx.get_device
@@ -826,7 +824,6 @@ typedef struct LIBUSB_hid_device_ LIBUSB_hid_device;
 #undef libusb_get_bus_number
 #undef libusb_get_port_numbers
 #undef libusb_get_device_address
-#undef libusb_wrap_sys_device
 #undef libusb_open
 #undef libusb_close
 #undef libusb_get_device
@@ -1146,7 +1143,6 @@ int SDL_hid_init(void)
             LOAD_LIBUSB_SYMBOL(uint8_t (LIBUSB_CALL *)(libusb_device *), get_bus_number)
             LOAD_LIBUSB_SYMBOL(int (LIBUSB_CALL *)(libusb_device *dev, uint8_t *port_numbers, int port_numbers_len), get_port_numbers)
             LOAD_LIBUSB_SYMBOL(uint8_t (LIBUSB_CALL *)(libusb_device *), get_device_address)
-            LOAD_LIBUSB_SYMBOL(int (LIBUSB_CALL *)(libusb_context *ctx, intptr_t sys_dev, libusb_device_handle **dev_handle), wrap_sys_device)
             LOAD_LIBUSB_SYMBOL(int (LIBUSB_CALL *)(libusb_device *, libusb_device_handle **), open)
             LOAD_LIBUSB_SYMBOL(void (LIBUSB_CALL *)(libusb_device_handle *), close)
             LOAD_LIBUSB_SYMBOL(libusb_device * (LIBUSB_CALL *)(libusb_device_handle *dev_handle), get_device)

--- a/src/hidapi/SDL_hidapi_libusb.h
+++ b/src/hidapi/SDL_hidapi_libusb.h
@@ -54,6 +54,8 @@ static int SDL_libusb_get_string_descriptor(libusb_device_handle *dev,
 #endif /* __FreeBSD__ */
 
 #define HIDAPI_THREAD_MODEL_INCLUDE "hidapi_thread_sdl.h"
+/* we don't need libusb_wrap_sys_device: */
+#define HIDAPI_TARGET_LIBUSB_API_VERSION 0x01000100
 
 #undef HIDAPI_H__
 #include "libusb/hid.c"


### PR DESCRIPTION
not used in SDL.
