### PR TITLE
wayland: fix arguments for zenity messagebox

### DIFF
--- a/src/video/wayland/SDL_waylandmessagebox.c
+++ b/src/video/wayland/SDL_waylandmessagebox.c
@@ -60,7 +60,7 @@ int Wayland_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *button
             _exit(128);
         }
 
-        argv[argc++] = "--icon-name";
+        argv[argc++] = "--icon";
         switch (messageboxdata->flags) {
         case SDL_MESSAGEBOX_ERROR:
             argv[argc++] = "dialog-error";


### PR DESCRIPTION
Zenity message boxes failed on wayland, it printed the following error message instead:
```
This option is not available. Please see --help for all possible usages.
```
The issue is that `--icon-name` is unknown.
```
$ zenity --help-question
Usage:
  zenity [OPTION…]

Question options
  --question                                        Display question dialog
  --text=TEXT                                       Set the dialog text
  --icon=ICON-NAME                                  Set the icon name
  --no-wrap                                         Do not enable text wrapping
  --no-markup                                       Do not enable Pango markup
  --default-cancel                                  Give Cancel button focus by default
  --ellipsize                                       Enable ellipsizing in the dialog text. This fixes the high window size with long texts
  --switch                                          Suppress OK and Cancel buttons
$ zenity --version
3.92.0
```

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->