### PR TITLE
SDL_GetRenderer: don't report a renderer when it's for internal use

### DIFF
--- a/src/core/winrt/SDL_winrtapp_direct3d.cpp
+++ b/src/core/winrt/SDL_winrtapp_direct3d.cpp
@@ -620,7 +620,7 @@ void SDL_WinRTApp::OnSuspending(Platform::Object ^ sender, SuspendingEventArgs ^
         // More details at: http://msdn.microsoft.com/en-us/library/windows/apps/Hh994929.aspx
 #if defined(SDL_VIDEO_RENDER_D3D11) && !defined(SDL_RENDER_DISABLED)
         if (WINRT_GlobalSDLWindow) {
-            SDL_Renderer *renderer = SDL_GetRenderer(WINRT_GlobalSDLWindow);
+            SDL_Renderer *renderer = SDL_GetRendererInternal(WINRT_GlobalSDLWindow);
             if (renderer && (SDL_strcmp(renderer->info.name, "direct3d11") == 0)) {
                 D3D11_Trim(renderer);
             }

--- a/src/render/SDL_sysrender.h
+++ b/src/render/SDL_sysrender.h
@@ -310,6 +310,9 @@ extern void *SDL_AllocateRenderVertices(SDL_Renderer *renderer, const size_t num
 extern int SDL_PrivateBlitSurfaceUncheckedScaled(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *dst, SDL_Rect *dstrect, SDL_ScaleMode scaleMode);
 extern int SDL_PrivateBlitSurfaceScaled(SDL_Surface *src, const SDL_Rect *srcrect, SDL_Surface *dst, SDL_Rect *dstrect, SDL_ScaleMode scaleMode);
 
+
+extern SDL_Renderer *SDL_GetRendererInternal(SDL_Window *window);
+
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus
 }

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -235,6 +235,7 @@ static int SDL_CreateWindowTexture(SDL_VideoDevice *_this, SDL_Window *window, U
                 }
                 return SDL_SetError("Requested renderer for " SDL_HINT_FRAMEBUFFER_ACCELERATION " is not available");
             }
+            SDL_MarkRendererInternal(window);
             /* if it was specifically requested, even if SDL_RENDERER_ACCELERATED isn't set, we'll accept this renderer. */
         } else {
             const int total = SDL_GetNumRenderDrivers();
@@ -243,6 +244,7 @@ static int SDL_CreateWindowTexture(SDL_VideoDevice *_this, SDL_Window *window, U
                 if (name && (SDL_strcmp(name, "software") != 0)) {
                     renderer = SDL_CreateRenderer(window, name, 0);
                     if (renderer && (SDL_GetRendererInfo(renderer, &info) == 0) && (info.flags & SDL_RENDERER_ACCELERATED)) {
+                        SDL_MarkRendererInternal(window);
                         break; /* this will work. */
                     }
                     if (renderer) { /* wasn't accelerated, etc, skip it. */

--- a/src/video/SDL_video_c.h
+++ b/src/video/SDL_video_c.h
@@ -57,4 +57,6 @@ extern void SDL_VideoQuit(void);
 
 extern int SDL_SetWindowTextureVSync(SDL_Window *window, int vsync);
 
+extern void SDL_MarkRendererInternal(SDL_Window *window);
+
 #endif /* SDL_video_c_h_ */


### PR DESCRIPTION
SDL_GetRenderer: don't report a renderer when it's for internal use 

see #7793


