### PR TITLE
Capture playback devices on wasapi

### DIFF
--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -1220,10 +1220,21 @@ static SDL_AudioDeviceID open_audio_device(const char *devname, int iscapture,
            It might still need to open a device based on the string for,
            say, a network audio server, but this optimizes some cases. */
         SDL_AudioDeviceItem *item;
+
         for (item = iscapture ? current_audio.inputDevices : current_audio.outputDevices; item; item = item->next) {
             if ((item->handle != NULL) && (SDL_strcmp(item->name, devname) == 0)) {
                 handle = item->handle;
                 break;
+            }
+        }
+
+        if (handle == NULL && iscapture && current_audio.impl.SupportsCaptureOnPlaybackDevices)
+        {
+            for (item = ((!iscapture || (iscapture && current_audio.impl.SupportsCaptureOnPlaybackDevices)) ? current_audio.outputDevices : current_audio.inputDevices); item; item = item->next) {
+                if ((item->handle != NULL) && (SDL_strcmp(item->name, devname) == 0)) {
+                    handle = item->handle;
+                    break;
+                }
             }
         }
     }

--- a/src/audio/SDL_sysaudio.h
+++ b/src/audio/SDL_sysaudio.h
@@ -86,6 +86,7 @@ typedef struct SDL_AudioDriverImpl
     SDL_bool OnlyHasDefaultCaptureDevice;
     SDL_bool AllowsArbitraryDeviceNames;
     SDL_bool SupportsNonPow2Samples;
+    SDL_bool SupportsCaptureOnPlaybackDevices;
 } SDL_AudioDriverImpl;
 
 typedef struct SDL_AudioDeviceItem

--- a/src/audio/wasapi/SDL_wasapi.c
+++ b/src/audio/wasapi/SDL_wasapi.c
@@ -457,7 +457,7 @@ int WASAPI_PrepDevice(SDL_AudioDevice *_this, const SDL_bool updatestream)
     }
 #endif
 
-    if (this->iscapture && this->hidden->isplayback)
+    if (_this->iscapture && _this->hidden->isplayback)
     {
         streamflags |= AUDCLNT_STREAMFLAGS_LOOPBACK;
     }

--- a/src/audio/wasapi/SDL_wasapi.c
+++ b/src/audio/wasapi/SDL_wasapi.c
@@ -457,7 +457,13 @@ int WASAPI_PrepDevice(SDL_AudioDevice *_this, const SDL_bool updatestream)
     }
 #endif
 
+    if (this->iscapture && this->hidden->isplayback)
+    {
+        streamflags |= AUDCLNT_STREAMFLAGS_LOOPBACK;
+    }
+    
     streamflags |= AUDCLNT_STREAMFLAGS_EVENTCALLBACK;
+    
     ret = IAudioClient_Initialize(client, sharemode, streamflags, 0, 0, waveformat, NULL);
     if (FAILED(ret)) {
         return WIN_SetErrorFromHRESULT("WASAPI can't initialize audio client", ret);
@@ -599,6 +605,7 @@ static SDL_bool WASAPI_Init(SDL_AudioDriverImpl *impl)
     impl->GetDefaultAudioInfo = WASAPI_GetDefaultAudioInfo;
     impl->HasCaptureSupport = SDL_TRUE;
     impl->SupportsNonPow2Samples = SDL_TRUE;
+    impl->SupportsCaptureOnPlaybackDevices = SDL_TRUE;
 
     return SDL_TRUE; /* this audio target is available. */
 }

--- a/src/audio/wasapi/SDL_wasapi.h
+++ b/src/audio/wasapi/SDL_wasapi.h
@@ -46,6 +46,7 @@ struct SDL_PrivateAudioData
     SDL_bool device_lost;
     void *activation_handler;
     SDL_AtomicInt just_activated;
+    SDL_bool isplayback;
 };
 
 /* win32 and winrt implementations call into these. */

--- a/src/audio/wasapi/SDL_wasapi_win32.c
+++ b/src/audio/wasapi/SDL_wasapi_win32.c
@@ -113,6 +113,8 @@ int WASAPI_ActivateDevice(SDL_AudioDevice *_this, const SDL_bool isrecovery)
         return -1; /* This is already set by SDL_IMMDevice_Get */
     }
 
+    this->hidden->isplayback = !SDL_IMMDevice_GetIsCapture(device);
+
     /* this is not async in standard win32, yay! */
     ret = IMMDevice_Activate(device, &SDL_IID_IAudioClient, CLSCTX_ALL, NULL, (void **)&_this->hidden->client);
     IMMDevice_Release(device);

--- a/src/audio/wasapi/SDL_wasapi_win32.c
+++ b/src/audio/wasapi/SDL_wasapi_win32.c
@@ -113,7 +113,7 @@ int WASAPI_ActivateDevice(SDL_AudioDevice *_this, const SDL_bool isrecovery)
         return -1; /* This is already set by SDL_IMMDevice_Get */
     }
 
-    this->hidden->isplayback = !SDL_IMMDevice_GetIsCapture(device);
+    _this->hidden->isplayback = !SDL_IMMDevice_GetIsCapture(device);
 
     /* this is not async in standard win32, yay! */
     ret = IMMDevice_Activate(device, &SDL_IID_IAudioClient, CLSCTX_ALL, NULL, (void **)&_this->hidden->client);

--- a/src/core/windows/SDL_immdevice.c
+++ b/src/core/windows/SDL_immdevice.c
@@ -355,6 +355,22 @@ void SDL_IMMDevice_Quit(void)
     deviceid_list = NULL;
 }
 
+SDL_bool SDL_IMMDevice_GetIsCapture(IMMDevice *device)
+{
+    SDL_bool iscapture = SDL_FALSE;
+    IMMEndpoint *endpoint = NULL;
+    if (SUCCEEDED(IMMDevice_QueryInterface(device, &SDL_IID_IMMEndpoint, (void **)&endpoint))) {
+        EDataFlow flow;
+        
+        if (SUCCEEDED(IMMEndpoint_GetDataFlow(endpoint, &flow))) {
+            iscapture = (flow == eCapture);
+        }
+    }
+    
+    IMMEndpoint_Release(endpoint);
+    return iscapture;
+}
+
 int SDL_IMMDevice_Get(LPCWSTR devid, IMMDevice **device, SDL_bool iscapture)
 {
     const Uint64 timeout = SDL_GetTicks() + 8000;  /* intel's audio drivers can fail for up to EIGHT SECONDS after a device is connected or we wake from sleep. */

--- a/src/core/windows/SDL_immdevice.h
+++ b/src/core/windows/SDL_immdevice.h
@@ -28,6 +28,7 @@
 
 int SDL_IMMDevice_Init(void);
 void SDL_IMMDevice_Quit(void);
+SDL_bool SDL_IMMDevice_GetIsCapture(IMMDevice* device);
 int SDL_IMMDevice_Get(LPCWSTR devid, IMMDevice **device, SDL_bool iscapture);
 void SDL_IMMDevice_EnumerateEndpoints(SDL_bool useguid);
 int SDL_IMMDevice_GetDefaultAudioInfo(char **name, SDL_AudioSpec *spec, int iscapture);


### PR DESCRIPTION
On the WASAPI backend, you can now call `SDL_OpenAudioDevice` for capture on playback devices.

## Description
- Modified `SDL_AudioDriverImpl` to allow backends to declare the capability to capture playback devices.
- Modified WASAPI backend to declare the above capability.
- Modified SDL_audio to allow users to record Playback devices when the backend declares this capability
- Modified WASAPI backend to pass the LOOPBACK flag when capture is requested on a Playback device.

## Existing Issue(s)
#7691
