### PR TITLE
Android: add timeout when waiting the SDL thread to finish

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -658,7 +658,11 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
 
             // Wait for "SDLThread" thread to end
             try {
-                SDLActivity.mSDLThread.join();
+                // 500ms timeout, because:
+                // C SDLmain() thread might have started (mSDLThread.start() called)
+                // while the SDL_Init() might not have been called yet,
+                // and so the previous QUIT event will be discarded by SDL_Init() and app is running, not exiting.
+                SDLActivity.mSDLThread.join(500);
             } catch(Exception e) {
                 Log.v(TAG, "Problem stopping SDLThread: " + e);
             }


### PR DESCRIPTION
Android: add timeout when waiting the SDL thread to finish
C SDLmain() thread might have started (mSDLThread.start() called) while the SDL_Init() might not have been called yet, and so the previous QUIT event will be discarded by SDL_Init() and app is running, not exiting.

This is reprocible by adding instrumentation code in the SDLActivity.

And hopefully, this could fix an ANR, where SDLActivity is in WAITING state (in thread.join()):
  at java.lang.Thread.join (Thread.java:1519)
  at org.libsdl.app.SDLActivity.onDestroy (SDLActivity.java)

while SDLThread seems to be running
