### PR TITLE
clipboard: Fixes testautomation fails introduced by clipboard changes

### DIFF
--- a/src/video/x11/SDL_x11clipboard.c
+++ b/src/video/x11/SDL_x11clipboard.c
@@ -181,7 +181,7 @@ static void *GetSelectionData(SDL_VideoDevice *_this, Atom selection_type, size_
     owner = X11_XGetSelectionOwner(display, selection_type);
     if (owner == None) {
         /* This requires a fallback to ancient X10 cut-buffers. We will just skip those for now */
-        return NULL;
+        data = NULL;
     } else if (owner == window) {
         owner = DefaultRootWindow(display);
         if (selection_type == XA_PRIMARY) {
@@ -227,6 +227,10 @@ static void *GetSelectionData(SDL_VideoDevice *_this, Atom selection_type, size_
             }
             X11_XFree(src);
         }
+    }
+
+    if (nullterminate && data == NULL) {
+        data = strdup("");
     }
 
     return data;


### PR DESCRIPTION
The X11 driver was failing to adhere to the test 'Verify SDL_GetClipboardText did not return NULL' which has been fixed.

The wayland driver was failing to check if clipboard content is available when the program itself is the current clipboard content holder. This happened for both clipboard and primary selection. It has also been fixed.

## Description
Fixed problems in the two drivers.

## Existing Issue(s)
#7800 