### PR TITLE
clipboard: Fixes additional x11 clipboard bugs found in tests

### DIFF
--- a/test/testautomation_clipboard.c
+++ b/test/testautomation_clipboard.c
@@ -30,7 +30,7 @@ static int clipboard_testHasClipboardText(void *arg)
 static int clipboard_testHasClipboardData(void *arg)
 {
     SDL_HasClipboardData("image/png");
-    SDLTest_AssertPass("Call to SDL_HasClipboardText succeeded");
+    SDLTest_AssertPass("Call to SDL_HasClipboardData succeeded");
 
     return TEST_COMPLETED;
 }


### PR DESCRIPTION
Fixes one more x11 clipboard bug uncovered by automated tests. If a user doesn't supply a callback method when setting clipboard data and instead supplies NULL this wasn't handled gracefully in all places.

## Description

Introduces additional NULL checks before using the user supplied clipboard data callback function.

## Existing Issue(s)

#7800 