### PR TITLE
testevdev: Verify most Wii devices against real hardware

### DIFF
--- a/test/testevdev.c
+++ b/test/testevdev.c
@@ -979,14 +979,14 @@ static const GuessTest guess_tests[] =
       .bus_type = 0x0005,
       .vendor_id = 0x057e,
       .product_id = 0x0306,
-      .version = 0x8600,
+      .version = 0x0600,
       /* This one is a bit weird because some of the buttons are mapped
        * to the arrow, page up and page down keys, so it's a joystick
        * with a subset of a keyboard attached. */
       /* TODO: Should this be JOYSTICK, or even JOYSTICK|KEYBOARD? */
       .expected = SDL_UDEV_DEVICE_KEYBOARD,
-      /* SYN, KEY */
-      .ev = { 0x03 },
+      /* SYN, KEY, FF */
+      .ev = { 0x03, 0x00, 0x20 },
       .keys = {
           /* 0x00 */ ZEROx8,
           /* left, right, up down */
@@ -1001,15 +1001,21 @@ static const GuessTest guess_tests[] =
       },
     },
     {
+      /* The accelerometer and the Motion Plus gyro report as the same
+       * vendor, product, version and axes, just with different
+       * min/max/fuzz/flat parameters (not shown here). A Wiimote with an
+       * attached Motion Plus reports the accelerometer and gyro as separate
+       * evdev devices. */
       .name = "Wiimote - Motion Plus or accelerometer",
       .bus_type = 0x0005,
       .vendor_id = 0x057e,
       .product_id = 0x0306,
-      .version = 0x8600,
+      .version = 0x0600,
       .expected = SDL_UDEV_DEVICE_ACCELEROMETER,
       /* SYN, ABS */
       .ev = { 0x09 },
-      /* RX, RY, RZ */
+      /* RX, RY, RZ - even for the accelerometer, which would more
+       * conventionally be X, Y, Z */
       .abs = { 0x38 },
     },
     {
@@ -1017,24 +1023,26 @@ static const GuessTest guess_tests[] =
       .bus_type = 0x0005,
       .vendor_id = 0x057e,
       .product_id = 0x0306,
-      .version = 0x8600,
+      .version = 0x0600,
       .expected = SDL_UDEV_DEVICE_UNKNOWN,
       /* SYN, ABS */
       .ev = { 0x09 },
-      /* HAT0 to HAT3 */
-      .abs = { 0x00, 0x1f },
+      /* HAT0X, Y to HAT3X, Y */
+      .abs = { 0x00, 0x00, 0xff },
     },
     {
       .name = "Wiimote - Nunchuck",
       .bus_type = 0x0005,
       .vendor_id = 0x057e,
       .product_id = 0x0306,
-      .version = 0x8600,
+      .version = 0x0600,
       /* TODO: Should this be JOYSTICK? It has one stick and two buttons */
       .expected = SDL_UDEV_DEVICE_UNKNOWN,
       /* SYN, KEY, ABS */
       .ev = { 0x0b },
-      /* RX, RY, RZ, hat 0 */
+      /* RX, RY, RZ, hat 0 - even though this is an accelerometer, which
+       * would more conventionally be X, Y, Z, and a left joystick, which
+       * would more conventionally be X, Y */
       .abs = { 0x38, 0x00, 0x03 },
       .keys = {
           /* 0x00-0xff */ ZEROx8, ZEROx8, ZEROx8, ZEROx8,
@@ -1043,15 +1051,14 @@ static const GuessTest guess_tests[] =
       },
     },
     {
-      /* Flags guessed from kernel source code */
       .name = "Wiimote - Classic Controller",
       /* TODO: Should this be JOYSTICK, or maybe JOYSTICK|KEYBOARD?
        * It's unusual in the same ways as the Wiimote */
       .expected = SDL_UDEV_DEVICE_KEYBOARD,
       /* SYN, KEY, ABS */
       .ev = { 0x0b },
-      /* Hat 1-3 */
-      .abs = { 0x00, 0x1c },
+      /* Hat 1-3 X and Y */
+      .abs = { 0x00, 0x00, 0xfc },
       .keys = {
           /* 0x00 */ ZEROx8,
           /* left, right, up down */
@@ -1059,7 +1066,7 @@ static const GuessTest guess_tests[] =
           /* 0x80 */ ZEROx8,
           /* 0xc0 */ ZEROx8,
           /* A, B, X, Y, MODE, TL, TL2, TR, TR2 */
-          /* 0x100 */ ZEROx4, 0x00, 0x13, 0xdb, 0x10,
+          /* 0x100 */ ZEROx4, 0x00, 0x00, 0xdb, 0x13,
           /* 0x140 */ ZEROx8,
           /* next (keyboard page down), previous (keyboard page up) */
           /* 0x180 */ 0x00, 0x00, 0x80, 0x10, ZEROx4,

--- a/test/testevdev.c
+++ b/test/testevdev.c
@@ -1073,22 +1073,24 @@ static const GuessTest guess_tests[] =
       },
     },
     {
-      /* Flags guessed from kernel source code */
+      /* Flags guessed from kernel source code, not confirmed with real
+       * hardware */
       .name = "Wiimote - Balance Board",
       /* TODO: Should this be JOYSTICK? */
       .expected = SDL_UDEV_DEVICE_UNKNOWN,
       /* SYN, KEY, ABS */
       .ev = { 0x0b },
       /* Hat 0-1 */
-      .abs = { 0x00, 0x0f },
+      .abs = { 0x00, 0x00, 0x0f },
       .keys = {
           /* 0x00-0xff */ ZEROx8, ZEROx8, ZEROx8, ZEROx8,
-          /* A */
+          /* BTN_A */
           /* 0x100 */ ZEROx4, 0x00, 0x00, 0x01, 0x00,
       },
     },
     {
-      /* Flags guessed from kernel source code */
+      /* Flags guessed from kernel source code, not confirmed with real
+       * hardware */
       .name = "Wiimote - Wii U Pro Controller",
       .expected = SDL_UDEV_DEVICE_JOYSTICK,
       /* SYN, KEY, ABS */


### PR DESCRIPTION
* testevdev: Verify most Wii devices against real hardware
    
    Some of the test data previously seen here was guessed from kernel
    source code, and not all of it was correct. The following devices have
    now been verified against `evemu-describe` output with Linux 6.3
    (thanks to Jeremy Whiting for collecting this):
    
    - basic Wiimote

        - buttons

        - 3-axis accelerometer

        - infra-red sensor for Sensor Bar location (precise aim)

    - Motion Plus accessory (3-axis gyroscope)

    - Nunchuck accessory (joystick, 2 buttons, a second 3-axis accelerometer)

    - Classic Controller accessory (a complete traditional gamepad)

* testevdev: Try to correct Wii devices guessed from kernel source
    
    The comments here disagreed with the actual bytes. According to
    https://elixir.bootlin.com/linux/v6.3.7/source/drivers/hid/hid-wiimote-modules.c,
    the Balance Board reports BTN_A and ABS_HAT0X, HAT0Y, HAT1X and HAT1Y.
    This means the comments here were correct, but the .abs bits shown
    were in the wrong byte.
    
    Matching the Wii U Pro Controller against the same kernel source, it
    appears to be correct: it's the same representation as a PS3 gamepad,
    except that it lacks the Z and RZ axes for analogue triggers.