### PR TITLE
Android: potential ANR during onKeyDown/Up

### DIFF
--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -1157,7 +1157,13 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeKeyDown)(
     JNIEnv *env, jclass jcls,
     jint keycode)
 {
-    Android_OnKeyDown(keycode);
+    SDL_LockMutex(Android_ActivityMutex);
+
+    if (Android_Window) {
+        Android_OnKeyDown(keycode);
+    }
+
+    SDL_UnlockMutex(Android_ActivityMutex);
 }
 
 /* Keyup */
@@ -1165,7 +1171,13 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeKeyUp)(
     JNIEnv *env, jclass jcls,
     jint keycode)
 {
-    Android_OnKeyUp(keycode);
+    SDL_LockMutex(Android_ActivityMutex);
+
+    if (Android_Window) {
+        Android_OnKeyUp(keycode);
+    }
+
+    SDL_UnlockMutex(Android_ActivityMutex);
 }
 
 /* Virtual keyboard return key might stop text input */


### PR DESCRIPTION
Android: potential ANR during onKeyDown/Up
SDLActivity may call onNativeKeyDown, while application is quitting


cannot reproduce, but the stack-trace:

```
SDLActivity: 
#00  pc 0x0000000000089630  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+32)
#01  pc 0x000000000008e0f8  /apex/com.android.runtime/lib64/bionic/libc.so (__futex_wait_ex(void volatile*, bool, int, bool, timespec const*)+148)
#02  pc 0x00000000000f6790  /apex/com.android.runtime/lib64/bionic/libc.so (NonPI::MutexLockWithTimeout(pthread_mutex_internal_t*, bool, timespec const*)+660)
#03  pc 0x00000000000f6360  /apex/com.android.runtime/lib64/bionic/libc.so (pthread_mutex_lock+264)
#04  pc 0x000000000028fd18  split_config.arm64_v8a.apk (SDL_LockMutex+4096)
#05  pc 0x0000000000279de0  split_config.arm64_v8a.apk (SDL_PeepEventsInternal+4096)
#06  pc 0x000000000027b56c  split_config.arm64_v8a.apk (SDL_PushEvent+4096)
#07  pc 0x000000000027c354  split_config.arm64_v8a.apk (SDL_SendKeyboardKeyInternal+4096)
 at org.libsdl.app.SDLActivity.onNativeKeyDown (SDLActivity.java)
 at org.libsdl.app.SDLActivity.handleKeyEvent (SDLActivity.java:89)
```

there are no SDLThread in the list. but threads goes up to Thread 19  "RenderThread" in my last ANR.
Though, on others same ANR, there're more threads.


