### PR TITLE
linux: Guess device type from input properties

### DIFF
--- a/src/core/linux/SDL_evdev_capabilities.c
+++ b/src/core/linux/SDL_evdev_capabilities.c
@@ -37,7 +37,8 @@
 #endif
 
 extern int
-SDL_EVDEV_GuessDeviceClass(const unsigned long bitmask_ev[NBITS(EV_MAX)],
+SDL_EVDEV_GuessDeviceClass(const unsigned long bitmask_props[NBITS(INPUT_PROP_MAX)],
+                           const unsigned long bitmask_ev[NBITS(EV_MAX)],
                            const unsigned long bitmask_abs[NBITS(ABS_MAX)],
                            const unsigned long bitmask_key[NBITS(KEY_MAX)],
                            const unsigned long bitmask_rel[NBITS(REL_MAX)])

--- a/src/core/linux/SDL_evdev_capabilities.c
+++ b/src/core/linux/SDL_evdev_capabilities.c
@@ -58,6 +58,22 @@ SDL_EVDEV_GuessDeviceClass(const unsigned long bitmask_props[NBITS(INPUT_PROP_MA
     int devclass = 0;
     unsigned long keyboard_mask;
 
+    /* If the kernel specifically says it's an accelerometer, believe it */
+    if (test_bit(INPUT_PROP_ACCELEROMETER, bitmask_props)) {
+        return SDL_UDEV_DEVICE_ACCELEROMETER;
+    }
+
+    /* We treat pointing sticks as indistinguishable from mice */
+    if (test_bit(INPUT_PROP_POINTING_STICK, bitmask_props)) {
+        return SDL_UDEV_DEVICE_MOUSE;
+    }
+
+    /* We treat buttonpads as equivalent to touchpads */
+    if (test_bit(INPUT_PROP_TOPBUTTONPAD, bitmask_props) ||
+        test_bit(INPUT_PROP_BUTTONPAD, bitmask_props)) {
+        return SDL_UDEV_DEVICE_TOUCHPAD;
+    }
+
     /* X, Y, Z axes but no buttons probably means an accelerometer */
     if (test_bit(EV_ABS, bitmask_ev) &&
         test_bit(ABS_X, bitmask_abs) &&
@@ -67,7 +83,8 @@ SDL_EVDEV_GuessDeviceClass(const unsigned long bitmask_props[NBITS(INPUT_PROP_MA
         return SDL_UDEV_DEVICE_ACCELEROMETER;
     }
 
-    /* RX, RY, RZ axes but no buttons also probably means an accelerometer */
+    /* RX, RY, RZ axes but no buttons probably means a gyro or
+     * accelerometer (we don't distinguish) */
     if (test_bit(EV_ABS, bitmask_ev) &&
         test_bit(ABS_RX, bitmask_abs) &&
         test_bit(ABS_RY, bitmask_abs) &&

--- a/src/core/linux/SDL_evdev_capabilities.h
+++ b/src/core/linux/SDL_evdev_capabilities.h
@@ -28,6 +28,10 @@
 
 #include <linux/input.h>
 
+#ifndef INPUT_PROP_MAX
+#define INPUT_PROP_MAX 0x1f
+#endif
+
 /* A device can be any combination of these classes */
 typedef enum
 {
@@ -47,7 +51,8 @@ typedef enum
 #define EVDEV_LONG(x)        ((x) / BITS_PER_LONG)
 #define test_bit(bit, array) ((array[EVDEV_LONG(bit)] >> EVDEV_OFF(bit)) & 1)
 
-extern int SDL_EVDEV_GuessDeviceClass(const unsigned long bitmask_ev[NBITS(EV_MAX)],
+extern int SDL_EVDEV_GuessDeviceClass(const unsigned long bitmask_props[NBITS(INPUT_PROP_MAX)],
+                                      const unsigned long bitmask_ev[NBITS(EV_MAX)],
                                       const unsigned long bitmask_abs[NBITS(ABS_MAX)],
                                       const unsigned long bitmask_key[NBITS(KEY_MAX)],
                                       const unsigned long bitmask_rel[NBITS(REL_MAX)]);

--- a/src/core/linux/SDL_udev.c
+++ b/src/core/linux/SDL_udev.c
@@ -362,6 +362,7 @@ static void get_caps(struct udev_device *dev, struct udev_device *pdev, const ch
 static int guess_device_class(struct udev_device *dev)
 {
     struct udev_device *pdev;
+    unsigned long bitmask_props[NBITS(INPUT_PROP_MAX)];
     unsigned long bitmask_ev[NBITS(EV_MAX)];
     unsigned long bitmask_abs[NBITS(ABS_MAX)];
     unsigned long bitmask_key[NBITS(KEY_MAX)];
@@ -377,12 +378,14 @@ static int guess_device_class(struct udev_device *dev)
         return 0;
     }
 
+    get_caps(dev, pdev, "properties", bitmask_props, SDL_arraysize(bitmask_props));
     get_caps(dev, pdev, "capabilities/ev", bitmask_ev, SDL_arraysize(bitmask_ev));
     get_caps(dev, pdev, "capabilities/abs", bitmask_abs, SDL_arraysize(bitmask_abs));
     get_caps(dev, pdev, "capabilities/rel", bitmask_rel, SDL_arraysize(bitmask_rel));
     get_caps(dev, pdev, "capabilities/key", bitmask_key, SDL_arraysize(bitmask_key));
 
-    return SDL_EVDEV_GuessDeviceClass(&bitmask_ev[0],
+    return SDL_EVDEV_GuessDeviceClass(&bitmask_props[0],
+                                      &bitmask_ev[0],
                                       &bitmask_abs[0],
                                       &bitmask_key[0],
                                       &bitmask_rel[0]);

--- a/src/joystick/linux/SDL_sysjoystick.c
+++ b/src/joystick/linux/SDL_sysjoystick.c
@@ -204,6 +204,7 @@ static SDL_bool IsVirtualJoystick(Uint16 vendor, Uint16 product, Uint16 version,
 
 static int GuessIsJoystick(int fd)
 {
+    unsigned long propbit[NBITS(INPUT_PROP_MAX)] = { 0 };
     unsigned long evbit[NBITS(EV_MAX)] = { 0 };
     unsigned long keybit[NBITS(KEY_MAX)] = { 0 };
     unsigned long absbit[NBITS(ABS_MAX)] = { 0 };
@@ -217,7 +218,11 @@ static int GuessIsJoystick(int fd)
         return 0;
     }
 
-    devclass = SDL_EVDEV_GuessDeviceClass(evbit, absbit, keybit, relbit);
+    /* This is a newer feature, so it's allowed to fail - if so, then the
+     * device just doesn't have any properties. */
+    (void) ioctl(fd, EVIOCGPROP(sizeof(propbit)), propbit);
+
+    devclass = SDL_EVDEV_GuessDeviceClass(propbit, evbit, absbit, keybit, relbit);
 
     if (devclass & SDL_UDEV_DEVICE_JOYSTICK) {
         return 1;

--- a/test/testevdev.c
+++ b/test/testevdev.c
@@ -1760,6 +1760,36 @@ static const GuessTest guess_tests[] =
       .hid_report_descriptor_length = sizeof (fanatec_handbrake_hid_report_descriptor),
       .hid_report_descriptor = &fanatec_handbrake_hid_report_descriptor[0],
     },
+    { /* Artificial test data, not a real device */
+      .name = "Fake accelerometer with fewer than usual axes reported",
+      .expected = SDL_UDEV_DEVICE_ACCELEROMETER,
+      /* SYN, ABS */
+      .ev = { 0x09 },
+      /* X only */
+      .abs = { 0x01 },
+      /* ACCELEROMETER */
+      .props = { 0x40 },
+    },
+    { /* Artificial test data, not a real device */
+      .name = "Fake pointing stick with no buttons",
+      .expected = SDL_UDEV_DEVICE_MOUSE,
+      /* SYN, REL */
+      .ev = { 0x05 },
+      /* X,Y */
+      .rel = { 0x03 },
+      /* POINTER, POINTING_STICK */
+      .props = { 0x21 },
+    },
+    { /* Artificial test data, not a real device */
+      .name = "Fake buttonpad",
+      .expected = SDL_UDEV_DEVICE_TOUCHPAD,
+      /* SYN, ABS */
+      .ev = { 0x09 },
+      /* X,Y */
+      .abs = { 0x03 },
+      /* POINTER, BUTTONPAD */
+      .props = { 0x05 },
+    },
     {
       .name = "No information",
       .expected = SDL_UDEV_DEVICE_UNKNOWN,

--- a/test/testevdev.c
+++ b/test/testevdev.c
@@ -1796,6 +1796,7 @@ run_test(void)
         int actual;
         struct
         {
+            unsigned long props[NBITS(INPUT_PROP_MAX)];
             unsigned long ev[NBITS(EV_MAX)];
             unsigned long abs[NBITS(ABS_MAX)];
             unsigned long keys[NBITS(KEY_MAX)];
@@ -1805,10 +1806,15 @@ run_test(void)
         printf("%s...\n", t->name);
 
         memset(&caps, '\0', sizeof(caps));
+        memcpy(caps.props, t->props, sizeof(t->props));
         memcpy(caps.ev, t->ev, sizeof(t->ev));
         memcpy(caps.keys, t->keys, sizeof(t->keys));
         memcpy(caps.abs, t->abs, sizeof(t->abs));
         memcpy(caps.rel, t->rel, sizeof(t->rel));
+
+        for (j = 0; j < SDL_arraysize(caps.props); j++) {
+            caps.props[j] = SwapLongLE(caps.props[j]);
+        }
 
         for (j = 0; j < SDL_arraysize(caps.ev); j++) {
             caps.ev[j] = SwapLongLE(caps.ev[j]);
@@ -1826,8 +1832,8 @@ run_test(void)
             caps.rel[j] = SwapLongLE(caps.rel[j]);
         }
 
-        actual = SDL_EVDEV_GuessDeviceClass(caps.ev, caps.abs, caps.keys,
-                                            caps.rel);
+        actual = SDL_EVDEV_GuessDeviceClass(caps.props, caps.ev, caps.abs,
+                                            caps.keys, caps.rel);
 
         if (actual == t->expected) {
             printf("\tOK\n");

--- a/test/testevdev.c
+++ b/test/testevdev.c
@@ -72,7 +72,7 @@ typedef struct
     uint8_t abs[(ABS_MAX + 1) / 8];
     uint8_t rel[(REL_MAX + 1) / 8];
     uint8_t ff[(FF_MAX + 1) / 8];
-    uint8_t props[INPUT_PROP_MAX / 8];
+    uint8_t props[(INPUT_PROP_MAX + 1) / 8];
     int expected;
     const char *todo;
     size_t hid_report_descriptor_length;


### PR DESCRIPTION
## Description
* testevdev: Allow device properties to be fully populated
    
    The props array was too small for the highest property bits to be set,
    although in practice this didn't matter since only the lower-order bits
    have a meaning. Make it consistent with all the others.

* linux: Pass evdev properties when guessing device type
    
    In newer kernels, devices that can be positively identified as a
    particular device type (for example accelerometers) get a property
    bit set. Plumb this information through into the function, but don't
    use it for anything just yet.

* linux: If the kernel specifically tells us the device type, trust it
    
    If a device is positively identified as an accelerometer, pointing stick
    or clickpad, then we don't need to second-guess it.
    
    In practice this does not change the result for any device in our
    test data, so add some artificial records that exercise this.

## Existing Issue(s)
None