### PR TITLE
For gamepads that don't have their own sensors, try to use the system sensors.

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -617,6 +617,18 @@ extern "C" {
 #define SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS "SDL_GAMECONTROLLER_USE_BUTTON_LABELS"
 
 /**
+ *  \brief  Controls whether the device's built-in accelerometer and gyro should be used as sensors for gamepads.
+ *
+ *  The variable can be set to the following values:
+ *    "auto"    - Sensor fusion is enabled for known wraparound controllers like the Razer Kishi and Backbone One
+ *    "0"       - Sensor fusion is disabled
+ *    "1"       - Sensor fusion is enabled for all controllers that lack sensors
+ *
+ *  The default value is "auto". This hint is checked when a gamepad is opened.
+ */
+#define SDL_HINT_GAMECONTROLLER_SENSOR_FUSION "SDL_GAMECONTROLLER_SENSOR_FUSION"
+
+/**
  *  \brief  A variable controlling whether grabbing input grabs the keyboard
  *
  *  This variable can be set to the following values:

--- a/src/SDL_hints.c
+++ b/src/SDL_hints.c
@@ -171,6 +171,23 @@ const char *SDL_GetHint(const char *name)
     return env;
 }
 
+int SDL_GetStringInteger(const char *value, int default_value)
+{
+    if (value == NULL || !*value) {
+        return default_value;
+    }
+    if (*value == '0' || SDL_strcasecmp(value, "false") == 0) {
+        return 0;
+    }
+    if (*value == '1' || SDL_strcasecmp(value, "true") == 0) {
+        return 1;
+    }
+    if (*value == '-' || SDL_isdigit(*value)) {
+        return SDL_atoi(value);
+    }
+    return default_value;
+}
+
 SDL_bool SDL_GetStringBoolean(const char *value, SDL_bool default_value)
 {
     if (value == NULL || !*value) {

--- a/src/SDL_hints_c.h
+++ b/src/SDL_hints_c.h
@@ -26,5 +26,6 @@
 #define SDL_hints_c_h_
 
 extern SDL_bool SDL_GetStringBoolean(const char *value, SDL_bool default_value);
+extern int SDL_GetStringInteger(const char *value, int default_value);
 
 #endif /* SDL_hints_c_h_ */

--- a/src/joystick/SDL_sysjoystick.h
+++ b/src/joystick/SDL_sysjoystick.h
@@ -113,6 +113,11 @@ struct SDL_Joystick
     SDL_bool delayed_guide_button _guarded;      /* SDL_TRUE if this device has the guide button event delayed */
     SDL_JoystickPowerLevel epowerlevel _guarded; /* power level of this joystick, SDL_JOYSTICK_POWER_UNKNOWN if not supported */
 
+    SDL_SensorID accel_sensor _guarded;
+    SDL_Sensor *accel _guarded;
+    SDL_SensorID gyro_sensor _guarded;
+    SDL_Sensor *gyro _guarded;
+
     struct SDL_JoystickDriver *driver _guarded;
 
     struct joystick_hwdata *hwdata _guarded; /* Driver dependent information */

--- a/src/sensor/SDL_sensor.c
+++ b/src/sensor/SDL_sensor.c
@@ -504,6 +504,11 @@ int SDL_SendSensorUpdate(Uint64 timestamp, SDL_Sensor *sensor, Uint64 sensor_tim
     return posted;
 }
 
+void SDL_UpdateSensor(SDL_Sensor *sensor)
+{
+    sensor->driver->Update(sensor);
+}
+
 void SDL_UpdateSensors(void)
 {
     int i;

--- a/src/sensor/SDL_sensor_c.h
+++ b/src/sensor/SDL_sensor_c.h
@@ -40,6 +40,9 @@ extern void SDL_UnlockSensors(void);
 /* Function to return whether there are any sensors opened by the application */
 extern SDL_bool SDL_SensorsOpened(void);
 
+/* Update an individual sensor, used by gamepad sensor fusion */
+extern void SDL_UpdateSensor(SDL_Sensor *sensor);
+
 /* Internal event queueing functions */
 extern int SDL_SendSensorUpdate(Uint64 timestamp, SDL_Sensor *sensor, Uint64 sensor_timestamp, float *data, int num_values);
 


### PR DESCRIPTION
This allows using the gyro and accelerometer in handheld devices in conjunction with built-in or wraparound controllers.