### PR TITLE
ibus: Handle error when getting the D-Bus machine ID

### DIFF
--- a/src/core/linux/SDL_dbus.h
+++ b/src/core/linux/SDL_dbus.h
@@ -72,6 +72,7 @@ typedef struct SDL_DBusContext
     dbus_bool_t (*error_is_set)(const DBusError *);
     void (*error_free)(DBusError *);
     char *(*get_local_machine_id)(void);
+    char *(*try_get_local_machine_id)(DBusError *);
     void (*free)(void *);
     void (*free_string_array)(char **);
     void (*shutdown)(void);
@@ -94,6 +95,8 @@ extern SDL_bool SDL_DBus_QueryPropertyOnConnection(DBusConnection *conn, const c
 
 extern void SDL_DBus_ScreensaverTickle(void);
 extern SDL_bool SDL_DBus_ScreensaverInhibit(SDL_bool inhibit);
+
+extern char *SDL_DBus_GetLocalMachineId(void);
 
 #endif /* HAVE_DBUS_DBUS_H */
 

--- a/src/core/linux/SDL_ibus.c
+++ b/src/core/linux/SDL_ibus.c
@@ -410,7 +410,12 @@ static char *IBus_GetDBusAddressFilename(void)
         (void)SDL_snprintf(config_dir, sizeof(config_dir), "%s/.config", home_env);
     }
 
-    key = dbus->get_local_machine_id();
+    key = SDL_DBus_GetLocalMachineId();
+
+    if (key == NULL) {
+        SDL_free(display);
+        return NULL;
+    }
 
     SDL_memset(file_path, 0, sizeof(file_path));
     (void)SDL_snprintf(file_path, sizeof(file_path), "%s/ibus/bus/%s-%s-%s",


### PR DESCRIPTION
It is possible for retrieving the machine ID to fail, either because dbus was installed incorrectly (machine ID absent or corrupt), or in 32-bit builds, because stat() on the machine ID fails with EOVERFLOW if it has an out-of-range timestamp or inode number.

dbus has historically treated this as a faulty installation, raising a warning which by default causes the process to crash. Unfortunately, dbus_get_local_machine_id() never had a way to report errors, so it has no alternative for that (bad) error handling.

In dbus >= 1.12.0, we can use dbus_try_get_local_machine_id() to get the same information, but with the ability to cope gracefully with errors. ibus won't work in this situation, but that's better than crashing.

(cherry picked from commit 91198baed40d5709020c3001e9234f4580df696a)

Mitigates: https://github.com/ValveSoftware/steam-for-linux/issues/9605