### PR TITLE
hidapi: switch: Handle MCU input reports

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_switch.c
+++ b/src/joystick/hidapi/SDL_hidapi_switch.c
@@ -67,6 +67,7 @@ typedef enum
 {
     k_eSwitchInputReportIDs_SubcommandReply = 0x21,
     k_eSwitchInputReportIDs_FullControllerState = 0x30,
+    k_eSwitchInputReportIDs_FullControllerAndMcuState = 0x31,
     k_eSwitchInputReportIDs_SimpleControllerState = 0x3F,
     k_eSwitchInputReportIDs_CommandAck = 0x81,
 } ESwitchInputReportIDs;
@@ -2201,6 +2202,7 @@ static SDL_bool HIDAPI_DriverSwitch_UpdateDevice(SDL_HIDAPI_Device *device)
                 HandleSimpleControllerState(joystick, ctx, (SwitchSimpleStatePacket_t *)&ctx->m_rgucReadBuffer[1]);
                 break;
             case k_eSwitchInputReportIDs_FullControllerState:
+            case k_eSwitchInputReportIDs_FullControllerAndMcuState:
                 HandleFullControllerState(joystick, ctx, (SwitchStatePacket_t *)&ctx->m_rgucReadBuffer[1]);
                 break;
             default:


### PR DESCRIPTION
MCU input reports are practically identical to normal reports with the only difference of having extra data at the end of the package. Yuzu configures the controller in this state to access advanced features like IR, NFC or RingCon. SDL stops responding in this mode.

This is solved by simply not ignoring the report.