### PR TITLE
wayland: Don't initialize OpenGL when the window flags didn't specify it

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -2089,13 +2089,6 @@ int Wayland_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window)
     c = _this->driverdata;
     window->driverdata = data;
 
-    if (!(window->flags & SDL_WINDOW_VULKAN)) {
-        if (!(window->flags & SDL_WINDOW_OPENGL)) {
-            SDL_GL_LoadLibrary(NULL);
-            window->flags |= SDL_WINDOW_OPENGL;
-        }
-    }
-
     if (window->x == SDL_WINDOWPOS_UNDEFINED) {
         window->x = 0;
     }


### PR DESCRIPTION
Applications that don't specify a rendering flag are likely handling Vulkan/GL themselves, so SDL loading OpenGL by default in this case is unnecessary overhead, and if a render backend requires it, the window will be recreated with the appropriate flags when the renderer is initialized.

This was there from the very first commit of the skeleton Wayland code in 2013. Maybe it made sense then, but now there seems to be little point in it, as it just adds overhead for applications that want a bare surface.  BGFX, for example, creates it's own EGL window and handles OpenGL itself, so SDL is just creating additional overhead by loading OpenGL internally.  Similarly, if an application wants a bare window to pass to its own Vulkan loader instance, initializing OpenGL has no point.

X11 doesn't default to loading OpenGL either.

I'll leave this open for a bit just in case there is some edge case I'm missing, but otherwise, we shouldn't be forcing OpenGL to be loaded if it wasn't asked for.