### PR TITLE
Remove accelerometer-as-joystick (see #3012)

### DIFF
--- a/android-project/app/src/main/AndroidManifest.xml
+++ b/android-project/app/src/main/AndroidManifest.xml
@@ -67,7 +67,7 @@
         android:hardwareAccelerated="true" >
 
         <!-- Example of setting SDL hints from AndroidManifest.xml:
-        <meta-data android:name="SDL_ENV.SDL_ACCELEROMETER_AS_JOYSTICK" android:value="0"/>
+        <meta-data android:name="SDL_ENV.SDL_ANDROID_TRAP_BACK_BUTTON" android:value="0"/>
          -->
      
         <activity android:name="SDLActivity"

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -48,16 +48,6 @@ extern "C" {
 #endif
 
 /**
- *  \brief  A variable controlling whether the Android / iOS built-in
- *  accelerometer should be listed as a joystick device.
- *
- *  This variable can be set to the following values:
- *    "0"       - The accelerometer is not listed as a joystick
- *    "1"       - The accelerometer is available as a 3 axis joystick (the default).
- */
-#define SDL_HINT_ACCELEROMETER_AS_JOYSTICK "SDL_ACCELEROMETER_AS_JOYSTICK"
-
-/**
  *  \brief Specify the behavior of Alt+Tab while the keyboard is grabbed.
  *
  * By default, SDL emulates Alt+Tab functionality while the keyboard is grabbed

--- a/src/core/linux/SDL_udev.c
+++ b/src/core/linux/SDL_udev.c
@@ -415,12 +415,6 @@ static void device_event(SDL_UDEV_deviceevent type, struct udev_device *dev)
             devclass |= SDL_UDEV_DEVICE_JOYSTICK;
         }
 
-        val = _this->syms.udev_device_get_property_value(dev, "ID_INPUT_ACCELEROMETER");
-        if (SDL_GetHintBoolean(SDL_HINT_ACCELEROMETER_AS_JOYSTICK, SDL_TRUE) &&
-            val != NULL && SDL_strcmp(val, "1") == 0) {
-            devclass |= SDL_UDEV_DEVICE_JOYSTICK;
-        }
-
         val = _this->syms.udev_device_get_property_value(dev, "ID_INPUT_MOUSE");
         if (val != NULL && SDL_strcmp(val, "1") == 0) {
             devclass |= SDL_UDEV_DEVICE_MOUSE;

--- a/src/joystick/android/SDL_sysjoystick.c
+++ b/src/joystick/android/SDL_sysjoystick.c
@@ -52,8 +52,6 @@
 #define AKEYCODE_BUTTON_16 203
 #endif
 
-#define ANDROID_ACCELEROMETER_NAME      "Android Accelerometer"
-#define ANDROID_ACCELEROMETER_DEVICE_ID INT_MIN
 #define ANDROID_MAX_NBUTTONS            36
 
 static SDL_joylist_item *JoystickByDeviceId(int device_id);
@@ -459,11 +457,6 @@ static void ANDROID_JoystickDetect(void);
 static int ANDROID_JoystickInit(void)
 {
     ANDROID_JoystickDetect();
-
-    if (SDL_GetHintBoolean(SDL_HINT_ACCELEROMETER_AS_JOYSTICK, SDL_TRUE)) {
-        /* Default behavior, accelerometer as joystick */
-        Android_AddJoystick(ANDROID_ACCELEROMETER_DEVICE_ID, ANDROID_ACCELEROMETER_NAME, ANDROID_ACCELEROMETER_NAME, 0, 0, SDL_TRUE, 0, 3, 0x0003, 0);
-    }
     return 0;
 }
 

--- a/src/joystick/apple/SDL_mfijoystick.m
+++ b/src/joystick/apple/SDL_mfijoystick.m
@@ -689,12 +689,6 @@ static int IOS_JoystickInit(void)
 #ifdef SDL_JOYSTICK_MFI
         NSNotificationCenter *center;
 #endif
-#ifdef SDL_JOYSTICK_iOS_ACCELEROMETER
-        if (SDL_GetHintBoolean(SDL_HINT_ACCELEROMETER_AS_JOYSTICK, SDL_TRUE)) {
-            /* Default behavior, accelerometer as joystick */
-            IOS_AddJoystickDevice(nil, SDL_TRUE);
-        }
-#endif
 
 #ifdef SDL_JOYSTICK_MFI
         /* GameController.framework was added in iOS 7. */

--- a/test/gamepadmap.c
+++ b/test/gamepadmap.c
@@ -732,8 +732,6 @@ int main(int argc, char *argv[])
     SDL_Joystick *joystick = NULL;
     SDLTest_CommonState *state;
 
-    SDL_SetHint(SDL_HINT_ACCELEROMETER_AS_JOYSTICK, "0");
-
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, 0);
     if (state == NULL) {

--- a/test/testautomation_hints.c
+++ b/test/testautomation_hints.c
@@ -7,7 +7,6 @@
 #include "testautomation_suites.h"
 
 static const char *HintsEnum[] = {
-    SDL_HINT_ACCELEROMETER_AS_JOYSTICK,
     SDL_HINT_FRAMEBUFFER_ACCELERATION,
     SDL_HINT_GAMECONTROLLERCONFIG,
     SDL_HINT_GRAB_KEYBOARD,
@@ -30,7 +29,6 @@ static const char *HintsEnum[] = {
     SDL_HINT_XINPUT_ENABLED,
 };
 static const char *HintsVerbose[] = {
-    "SDL_ACCELEROMETER_AS_JOYSTICK",
     "SDL_FRAMEBUFFER_ACCELERATION",
     "SDL_GAMECONTROLLERCONFIG",
     "SDL_GRAB_KEYBOARD",

--- a/test/testgamepad.c
+++ b/test/testgamepad.c
@@ -872,7 +872,6 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    SDL_SetHint(SDL_HINT_ACCELEROMETER_AS_JOYSTICK, "0");
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, "1");
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, "1");
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_STEAM, "1");

--- a/test/testjoystick.c
+++ b/test/testjoystick.c
@@ -297,8 +297,6 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    SDL_SetHint(SDL_HINT_ACCELEROMETER_AS_JOYSTICK, "0");
-
     /* Enable standard application logging */
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
 


### PR DESCRIPTION
Remove accelerometer-as-joystick (see #3012)
not really tested.

Also I wonder, if we should remove the:
init sensor here ? 
https://github.com/libsdl-org/SDL/blob/main/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java#L787