### PR TITLE
evdev: Use time64-friendly accessors for struct input_event

### DIFF
--- a/src/core/linux/SDL_evdev.c
+++ b/src/core/linux/SDL_evdev.c
@@ -59,6 +59,16 @@
 #define REL_HWHEEL_HI_RES 0x0c
 #endif
 
+/* The field to look up in struct input_event for integer seconds */
+#ifndef input_event_sec
+#define input_event_sec time.tv_sec
+#endif
+
+/* The field to look up in struct input_event for fractional seconds */
+#ifndef input_event_usec
+#define input_event_usec time.tv_usec
+#endif
+
 typedef struct SDL_evdevlist_item
 {
     char *path;
@@ -879,9 +889,9 @@ Uint64 SDL_EVDEV_GetEventTimestamp(struct input_event *event)
 
     /* The kernel internally has nanosecond timestamps, but converts it
        to microseconds when delivering the events */
-    timestamp = event->time.tv_sec;
+    timestamp = event->input_event_sec;
     timestamp *= SDL_NS_PER_SECOND;
-    timestamp += SDL_US_TO_NS(event->time.tv_usec);
+    timestamp += SDL_US_TO_NS(event->input_event_usec);
 
     if (!timestamp_offset) {
         timestamp_offset = (now - timestamp);


### PR DESCRIPTION
## Description

On 32-bit platforms such as i386, if SDL is compiled with -D_TIME_BITS=64 to opt-in to ABIs that will not stop working in 2038, the fields in this struct change their naming and interpretation.

The Linux header <linux/input.h> defines macros input_event_sec and input_event_usec which resolve to the right struct field to look at. The actual field names and types are an implementation detail, historically signed 32-bit time.tv_sec and time.tv_usec on 32-bit platforms, but becoming unsigned __sec and __usec when using 64-bit time (which makes them able to represent times up to 2106).

## Existing Issue(s)

None

---

Without this, when forcing `_TIME_BITS=64` and `_FILE_OFFSET_BITS=64`, I get:

```
/home/smcv/src/SDL/src/core/linux/SDL_evdev.c: In function ‘SDL_EVDEV_GetEventTimestamp’:
/home/smcv/src/SDL/src/core/linux/SDL_evdev.c:882:22: error: ‘struct input_event’ has no member named ‘time’
  882 |     timestamp = event->time.tv_sec;
      |                      ^~
In file included from /home/smcv/src/SDL/include/SDL3/SDL.h:74,
                 from /home/smcv/src/SDL/src/SDL_internal.h:186,
                 from /home/smcv/src/SDL/_build-i386-time64/CMakeFiles/SDL3-shared.dir/cmake_pch.h:4,
                 from <command-line>:
/home/smcv/src/SDL/src/core/linux/SDL_evdev.c:884:36: error: ‘struct input_event’ has no member named ‘time’
  884 |     timestamp += SDL_US_TO_NS(event->time.tv_usec);
```

This is a small step towards trying to actually compile SDL with `-D_TIME_BITS=64` by default (like dbus in https://gitlab.freedesktop.org/dbus/dbus/-/merge_requests/416), which would help with issues related to the one worked around in #7850 - but I'm having trouble getting abi-compliance-checker to show me whether there's a problem or not, so no tested merge request for that yet, sorry.