### PR TITLE
Fix crash in AudioConvertByteswap

### DIFF
--- a/src/audio/SDL_audiocvt.c
+++ b/src/audio/SDL_audiocvt.c
@@ -238,7 +238,7 @@ static void AudioConvertByteswap(void *dst, const void *src, int num_samples, in
     case b: { \
         const Uint##b *tsrc = (const Uint##b *)src; \
         Uint##b *tdst = (Uint##b *)dst; \
-        for (i = num_samples; i; i++) { \
+        for (i = 0; i < num_samples; i++) { \
             tdst[i] = SDL_Swap##b(tsrc[i]); \
         } \
         break; \


### PR DESCRIPTION
For-loop in this function crashed. For example, on a little-endian system one might change testautomation audio_resampleLoss case to use F32MSB type to trigger a segmentation fault on Linux.
