### PR TITLE
cmake: Compile with 64-bit time stamps where possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,11 +67,12 @@ include(${SDL3_SOURCE_DIR}/cmake/CheckCPUArchitecture.cmake)
 include(${SDL3_SOURCE_DIR}/cmake/GetGitRevisionDescription.cmake)
 include(${SDL3_SOURCE_DIR}/cmake/3rdparty.cmake)
 
-# Enable large file support on 32-bit glibc, so that we can access files
-# with large inode numbers
 check_symbol_exists("__GLIBC__" "stdlib.h" LIBC_IS_GLIBC)
-if (LIBC_IS_GLIBC AND CMAKE_SIZEOF_VOID_P EQUAL 4)
-    target_compile_definitions(sdl-build-options INTERFACE "_FILE_OFFSET_BITS=64")
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+  # Enable large file support on 32-bit glibc, so that we can access files with large inode numbers
+  target_compile_definitions(sdl-build-options INTERFACE "_FILE_OFFSET_BITS=64")
+  # Enable 64-bit time_t on 32-bit glibc, so that time stamps remain correct beyond January 2038
+  target_compile_definitions(sdl-build-options INTERFACE "_TIME_BITS=64")
 endif()
 
 if(CMAKE_VERSION VERSION_LESS "3.26")


### PR DESCRIPTION
Define `_TIME_BITS=64` on 32-bit glibc, such that`time_t` becomes a 64-bit timestamp.

I got `abi-compliance-checker` working with the following script:
```sh
#!bin/sh

set -ex

git checkout origin/main
cmake -S . -B /tmp/SDL3-before -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Og -gdwarf-4 -m32" -DCMAKE_CXX_FLAGS="-Og -gdwarf-4 -m32"
cmake --build /tmp/SDL3-before --target SDL3-shared

git checkout 64-bit-timestamps
cmake -S . -B /tmp/SDL3-after -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-Og -gdwarf-4 -m32" -DCMAKE_CXX_FLAGS="-Og -gdwarf-4 -m32"
cmake --build /tmp/SDL3-after --target SDL3-shared

rm -rf workdir
mkdir workdir
pushd workdir

abi-dumper /tmp/SDL3-before/libSDL3.so.0.0.0 -o ABI-0.dump -lver 0
abi-dumper /tmp/SDL3-after/libSDL3.so.0.0.0 -o ABI-1.dump -lver 1

abi-compliance-checker -l SDL3 -old ABI-0.dump -new ABI-1.dump

popd
```
It produces the following report: [report.zip](https://github.com/libsdl-org/SDL/files/11901161/report.zip)


Fixes #7886 

/cc @smcv as he practically wrote the whole thing