### PR TITLE
Check OpenGL errors before checking `glFramebufferTexture2DEXT()`

### DIFF
--- a/src/render/opengl/SDL_render_gl.c
+++ b/src/render/opengl/SDL_render_gl.c
@@ -910,8 +910,8 @@ static int GL_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
             return SDL_SetError("glFramebufferTexture2DEXT() failed because of GL_FRAMEBUFFER_UNSUPPORTED");
         case GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE:
             return SDL_SetError("glFramebufferTexture2DEXT() failed because of GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE");
-        case GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE:
-            return SDL_SetError("glFramebufferTexture2DEXT() failed because of GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE");
+        case GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS:
+            return SDL_SetError("glFramebufferTexture2DEXT() failed because of GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS");
         default:
             /* check additoinal errors */
             switch (glErr) {

--- a/src/render/opengl/SDL_render_gl.c
+++ b/src/render/opengl/SDL_render_gl.c
@@ -868,6 +868,7 @@ static int GL_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
     GL_RenderData *data = (GL_RenderData *)renderer->driverdata;
     GL_TextureData *texturedata;
     GLenum status;
+    GLenum err;
 
     GL_ActivateRenderer(renderer);
 
@@ -889,7 +890,16 @@ static int GL_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
     /* Check FBO status */
     status = data->glCheckFramebufferStatusEXT(GL_FRAMEBUFFER_EXT);
     if (status != GL_FRAMEBUFFER_COMPLETE_EXT) {
-        return SDL_SetError("glFramebufferTexture2DEXT() failed");
+        if ((err = data->glGetError()) != GL_NO_ERROR) {
+            switch (err) {
+            case GL_INVALID_ENUM:
+                return SDL_SetError("glFramebufferTexture2DEXT() failed because of GL_INVALID_EMUM");
+            case GL_INVALID_OPERATION:
+                return SDL_SetError("glFramebufferTexture2DEXT() failed because of GL_INVALID_OPERATION");
+            }
+
+            return SDL_SetError("glFramebufferTexture2DEXT() failed with (err, status) = (%d, %d)", err, status);
+        }
     }
     return 0;
 }


### PR DESCRIPTION
This PR implements error check codes of `SDL_SetRenderTarget` OpenGL version marked as TODO.

It may be necessary to discuss some error message on some additional errors described below.

## Description

I meets an error caused by this TODO:

https://github.com/libsdl-org/SDL/blob/17e95345e39b2b3ce436ce3029175055c3d48869/src/render/opengl/SDL_render_gl.c#L887-L888

This error caused in a software using SDL2 via FFI (cf. issue is this https://github.com/lem-project/lem/issues/690 but this software is written in Common Lisp and I cannot write reproduce codes in C, sorry :sob:). After debugging this error  including compilation SLD2 on my machine, I found there is no error occur in this case.

Framebuffer-related errors can be checked with `glCheckFramebufferStatus()` function in a OpenGL extension, but framebuffer-related operations may occur some additionally errors not like `GL_FRAMEBUFFER_xxx` things. According to the Khronos group's document ([`glCheckFramebufferStatus()`](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glCheckFramebufferStatus.xhtml)), these errors may occur additionally: `GL_INVALID_ENUM` or `GL_INVALID_OPERATION`. They can be checked via OpenGL's `glGetError()` function and `glCheckFramebufferStatus()` returns zero, **NOT THE `GL_FRAMEBUFFER_COMPLETE`**, in these additionally cases.

So correct error handling on this TODO is:

1. Check the `glCheckFramebufferStatus()` for framebuffer-related errors
2. Check the `glGetError()` for additionally errors, if non-`GL_FRAMEBUFFER_COMPLETE` status in step 1
3. Raise an error if that additionally error occured

This PR implements this correct handling.

## Existing Issue(s)

I cannot find related issues.
