### PR TITLE
Add kernel32 to SDL_EXTRA_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2018,7 +2018,7 @@ elseif(WINDOWS)
 
   # Libraries for Win32 native and MinGW
   if(NOT WINDOWS_STORE)
-    list(APPEND SDL_EXTRA_LIBS user32 gdi32 winmm imm32 ole32 oleaut32 version uuid advapi32 setupapi shell32)
+    list(APPEND SDL_EXTRA_LIBS kernel32 user32 gdi32 winmm imm32 ole32 oleaut32 version uuid advapi32 setupapi shell32)
   endif()
 
   if(WINDOWS_STORE)


### PR DESCRIPTION
## Description

When cross-compiling with [`clang-cl`](https://clang.llvm.org/docs/MSVCCompatibility.html) targeting Win32 native using this [CMake toolchain file provided by LLVM](https://github.com/llvm-mirror/llvm/blob/d35e5f8dded4c884ca25ca88f184e1505cad106c/cmake/platforms/WinMsvc.cmake).

I get the following linking errors.

```
[ 62%] Linking C shared library SDL2d.dll
cd /home/jshbrntt/snake/build/win32/_deps/sdl2-build && /usr/bin/cmake -E cmake_link_script CMakeFiles/SDL2.dir/link.txt --verbose=1
/usr/bin/cmake -E vs_link_dll --intdir=CMakeFiles/SDL2.dir --rc=llvm-windres-16 --mt=CMAKE_MT-NOTFOUND --manifests -- /usr/bin/lld-link  @CMakeFiles/SDL2.dir/objects1.rsp  /out:SDL2d.dll /implib:SDL2d.lib /pdb:/home/jshbrntt/snake/win32/_deps/sdl2-build/SDL2d.pdb /dll /version:2.26  /manifest:no -libpath:"/xwin/crt/lib/x86_64" -libpath:"/xwin/sdk/lib/10.0.22000/ucrt/x86_64" -libpath:"/xwin/sdk/lib/10.0.22000/um/x86_64" /debug /INCREMENTAL  user32.lib gdi32.lib winmm.lib imm32.lib ole32.lib oleaut32.lib version.lib uuid.lib advapi32.lib setupapi.lib shell32.lib  
LINK: command "/usr/bin/lld-link @CMakeFiles/SDL2.dir/objects1.rsp /out:SDL2d.dll /implib:SDL2d.lib /pdb:/home/jshbrntt/snake/win32/_deps/sdl2-build/SDL2d.pdb /dll /version:2.26 /manifest:no -libpath:/xwin/crt/lib/x86_64 -libpath:/xwin/sdk/lib/10.0.22000/ucrt/x86_64 -libpath:/xwin/sdk/lib/10.0.22000/um/x86_64 /debug /INCREMENTAL user32.lib gdi32.lib winmm.lib imm32.lib ole32.lib oleaut32.lib version.lib uuid.lib advapi32.lib setupapi.lib shell32.lib" failed (exit code 1) with the following output:
lld-link: error: undefined symbol: __declspec(dllimport) GetCurrentProcess
>>> referenced by /home/jshbrntt/snake/build/win32/_deps/sdl2-src/src/SDL.c:96
>>>               CMakeFiles/SDL2.dir/src/SDL.c.obj:(SDL_ExitProcess)
```

This is due to SDL not explicitly including `kernel32` in the libraries required.

The toolchain sets `CMAKE_C_STANDARD_LIBRARIES` and `CMAKE_CXX_STANDARD_LIBRARIES` to empty and expects project to explicitly include the libraries they require, see this [comment](https://github.com/llvm-mirror/llvm/blob/d35e5f8dded4c884ca25ca88f184e1505cad106c/cmake/platforms/WinMsvc.cmake#L317-L321).
