### PR TITLE
Update SDL_render.h for supporting SDL_FLIP_DIAGONAL

### DIFF
--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -131,7 +131,8 @@ typedef enum
 {
     SDL_FLIP_NONE = 0x00000000,     /**< Do not flip */
     SDL_FLIP_HORIZONTAL = 0x00000001,    /**< flip horizontally */
-    SDL_FLIP_VERTICAL = 0x00000002     /**< flip vertically */
+    SDL_FLIP_VERTICAL = 0x00000002,     /**< flip vertically */
+    SDL_FLIP_DIAGONAL = 0x00000003     /**< flip diagonally */
 } SDL_RendererFlip;
 
 /**


### PR DESCRIPTION
Since SDL_RenderFlip is an enum, SDL_FLIP_HORIZONTAL and SDL_FLIP_VERTICAL can not be OR'ed to get the "SDL_FLIP_DIAGONAL". 
Render code is actually able to perform these 3 kind of "flipping" so I just added a new enum called SDL_FLIP_DIAGONAL with the OR'ed value (3) so it can be used.

