### PR TITLE
Fix C89 declaration for iOS/tvOS modules.

### DIFF
--- a/src/audio/coreaudio/SDL_coreaudio.m
+++ b/src/audio/coreaudio/SDL_coreaudio.m
@@ -461,12 +461,13 @@ static BOOL update_audio_session(_THIS, SDL_bool open, SDL_bool allow_playandrec
 
         if ((open_playback_devices || open_capture_devices) && !session_active) {
             if (![session setActive:YES error:&err]) {
+                NSString *desc;
                 if ([err code] == AVAudioSessionErrorCodeResourceNotAvailable &&
                     category == AVAudioSessionCategoryPlayAndRecord) {
                     return update_audio_session(this, open, SDL_FALSE);
                 }
 
-                NSString *desc = err.description;
+                desc = err.description;
                 SDL_SetError("Could not activate Audio Session: %s", desc.UTF8String);
                 return NO;
             }

--- a/src/hidapi/ios/hid.m
+++ b/src/hidapi/ios/hid.m
@@ -290,6 +290,8 @@ typedef enum
 {
 	static uint64_t s_unLastUpdateTick = 0;
 	static mach_timebase_info_data_t s_timebase_info;
+    uint64_t ticksNow;
+    NSArray<CBPeripheral *> *peripherals;
 	
 	if ( self.centralManager == nil )
     {
@@ -301,7 +303,7 @@ typedef enum
 		mach_timebase_info( &s_timebase_info );
 	}
 	
-	uint64_t ticksNow = mach_approximate_time();
+	ticksNow = mach_approximate_time();
 	if ( !bForce && ( ( (ticksNow - s_unLastUpdateTick) * s_timebase_info.numer ) / s_timebase_info.denom ) < (5ull * NSEC_PER_SEC) )
 		return (int)self.deviceMap.count;
 	
@@ -318,7 +320,7 @@ typedef enum
 	if ( self.nPendingPairs > 0 )
 		return (int)self.deviceMap.count;
 
-	NSArray<CBPeripheral *> *peripherals = [self.centralManager retrieveConnectedPeripheralsWithServices: @[ [CBUUID UUIDWithString:@"180A"]]];
+	peripherals = [self.centralManager retrieveConnectedPeripheralsWithServices: @[ [CBUUID UUIDWithString:@"180A"]]];
 	for ( CBPeripheral *peripheral in peripherals )
 	{
 		// we already know this peripheral
@@ -328,8 +330,9 @@ typedef enum
 		NSLog( @"connected peripheral: %@", peripheral );
 		if ( [peripheral.name isEqualToString:@"SteamController"] )
 		{
+            HIDBLEDevice *steamController;
 			self.nPendingPairs += 1;
-			HIDBLEDevice *steamController = [[HIDBLEDevice alloc] initWithPeripheral:peripheral];
+			steamController = [[HIDBLEDevice alloc] initWithPeripheral:peripheral];
 			[self.deviceMap setObject:steamController forKey:peripheral];
 			[self.centralManager connectPeripheral:peripheral options:nil];
 		}
@@ -452,9 +455,10 @@ typedef enum
 	
 	if ( [localName isEqualToString:@"SteamController"] )
 	{
+        HIDBLEDevice *steamController;
 		NSLog( @"%@ : %@ - %@", log, peripheral, advertisementData );
 		self.nPendingPairs += 1;
-		HIDBLEDevice *steamController = [[HIDBLEDevice alloc] initWithPeripheral:peripheral];
+		steamController = [[HIDBLEDevice alloc] initWithPeripheral:peripheral];
 		[self.deviceMap setObject:steamController forKey:peripheral];
 		[self.centralManager connectPeripheral:peripheral options:nil];
 	}
@@ -841,10 +845,12 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 		 ( vendor_id == VALVE_USB_VID && product_id == D0G_BLE2_PID ) )
 	{
 		HIDBLEManager *bleManager = HIDBLEManager.sharedInstance;
+        NSEnumerator<HIDBLEDevice *> *devices;
 		[bleManager updateConnectedSteamControllers:false];
-		NSEnumerator<HIDBLEDevice *> *devices = [bleManager.deviceMap objectEnumerator];
+		devices = [bleManager.deviceMap objectEnumerator];
 		for ( HIDBLEDevice *device in devices )
 		{
+            struct hid_device_info *device_info;
 			// there are several brief windows in connecting to an already paired device and
 			// one long window waiting for users to confirm pairing where we don't want
 			// to consider a device ready - if we hand it back to SDL or another
@@ -862,7 +868,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 				}
 				continue;
 			}
-			struct hid_device_info *device_info = (struct hid_device_info *)malloc( sizeof(struct hid_device_info) );
+			device_info = (struct hid_device_info *)malloc( sizeof(struct hid_device_info) );
 			memset( device_info, 0, sizeof(struct hid_device_info) );
 			device_info->next = root;
 			root = device_info;
@@ -937,11 +943,12 @@ int HID_API_EXPORT hid_send_feature_report(hid_device *dev, const unsigned char 
 int HID_API_EXPORT hid_get_feature_report(hid_device *dev, unsigned char *data, size_t length)
 {
     HIDBLEDevice *device_handle = (__bridge HIDBLEDevice *)dev->device_handle;
+    size_t written;
 
 	if ( !device_handle.connected )
 		return -1;
 
-	size_t written = [device_handle get_feature_report:data[0] into:data];
+	written = [device_handle get_feature_report:data[0] into:data];
 	
 	return written == length-1 ? (int)length : (int)written;
 }
@@ -959,7 +966,8 @@ int HID_API_EXPORT hid_read(hid_device *dev, unsigned char *data, size_t length)
 int HID_API_EXPORT hid_read_timeout(hid_device *dev, unsigned char *data, size_t length, int milliseconds)
 {
     HIDBLEDevice *device_handle = (__bridge HIDBLEDevice *)dev->device_handle;
-
+    int result;
+    
 	if ( !device_handle.connected )
 		return -1;
 	
@@ -967,7 +975,7 @@ int HID_API_EXPORT hid_read_timeout(hid_device *dev, unsigned char *data, size_t
 	{
 		NSLog( @"hid_read_timeout with non-zero wait" );
 	}
-	int result = (int)[device_handle read_input_report:data];
+	result = (int)[device_handle read_input_report:data];
 #if FEATURE_REPORT_LOGGING
 	NSLog( @"HIDBLE:hid_read_timeout (%d) [%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x]", result,
 		  data[1], data[2], data[3], data[4], data[5], data[6],

--- a/src/power/uikit/SDL_syspower.m
+++ b/src/power/uikit/SDL_syspower.m
@@ -64,6 +64,7 @@ SDL_GetPowerInfo_UIKit(SDL_PowerState * state, int *seconds, int *percent)
 #else /* TARGET_OS_TV */
     @autoreleasepool {
         UIDevice *uidev = [UIDevice currentDevice];
+        const float level = uidev.batteryLevel;
 
         if (!SDL_UIKitLastPowerInfoQuery) {
             SDL_assert(uidev.isBatteryMonitoringEnabled == NO);
@@ -98,7 +99,6 @@ SDL_GetPowerInfo_UIKit(SDL_PowerState * state, int *seconds, int *percent)
             break;
         }
 
-        const float level = uidev.batteryLevel;
         *percent = ( (level < 0.0f) ? -1 : ((int) ((level * 100) + 0.5f)) );
     }
 #endif /* TARGET_OS_TV */

--- a/src/video/uikit/SDL_uikitappdelegate.m
+++ b/src/video/uikit/SDL_uikitappdelegate.m
@@ -135,13 +135,16 @@ SDL_LoadLaunchImageNamed(NSString *name, int screenh)
 
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
+    NSString *screenname;
+    NSBundle *bundle;
+    BOOL atleastiOS8;
     if (!(self = [super initWithNibName:nil bundle:nil])) {
         return nil;
     }
 
-    NSString *screenname = nibNameOrNil;
-    NSBundle *bundle = nibBundleOrNil;
-    BOOL atleastiOS8 = UIKit_IsSystemVersionAtLeast(8.0);
+    screenname = nibNameOrNil;
+    bundle = nibBundleOrNil;
+    atleastiOS8 = UIKit_IsSystemVersionAtLeast(8.0);
 
     /* Launch screens were added in iOS 8. Otherwise we use launch images. */
     if (screenname && atleastiOS8) {
@@ -179,7 +182,10 @@ SDL_LoadLaunchImageNamed(NSString *name, int screenh)
             for (NSDictionary *dict in launchimages) {
                 NSString *minversion = dict[@"UILaunchImageMinimumOSVersion"];
                 NSString *sizestring = dict[@"UILaunchImageSize"];
-
+#if !TARGET_OS_TV
+                UIInterfaceOrientationMask orientmask;
+                NSString *orientstring;
+#endif
                 /* Ignore this image if the current version is too low. */
                 if (minversion && !UIKit_IsSystemVersionAtLeast(minversion.doubleValue)) {
                     continue;
@@ -194,8 +200,8 @@ SDL_LoadLaunchImageNamed(NSString *name, int screenh)
                 }
 
 #if !TARGET_OS_TV
-                UIInterfaceOrientationMask orientmask = UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
-                NSString *orientstring = dict[@"UILaunchImageOrientation"];
+                orientmask = UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskPortraitUpsideDown;
+                orientstring = dict[@"UILaunchImageOrientation"];
 
                 if (orientstring) {
                     if ([orientstring isEqualToString:@"PortraitUpsideDown"]) {

--- a/src/video/uikit/SDL_uikitevents.m
+++ b/src/video/uikit/SDL_uikitevents.m
@@ -50,6 +50,8 @@ SDL_iPhoneSetEventPump(SDL_bool enabled)
 void
 UIKit_PumpEvents(_THIS)
 {
+    const CFTimeInterval seconds = 0.000002;
+    SInt32 result;
     if (!UIKit_EventPumpEnabled) {
         return;
     }
@@ -60,10 +62,8 @@ UIKit_PumpEvents(_THIS)
        to touch input), but not long enough to introduce a significant
        delay in the rest of the app.
     */
-    const CFTimeInterval seconds = 0.000002;
 
     /* Pump most event types. */
-    SInt32 result;
     do {
         result = CFRunLoopRunInMode(kCFRunLoopDefaultMode, seconds, TRUE);
     } while (result == kCFRunLoopRunHandledSource);
@@ -87,13 +87,14 @@ static id keyboard_disconnect_observer = nil;
 
 static void OnGCKeyboardConnected(GCKeyboard *keyboard) API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0))
 {
+    dispatch_queue_t queue;
     keyboard_connected = SDL_TRUE;
     keyboard.keyboardInput.keyChangedHandler = ^(GCKeyboardInput *kbrd, GCControllerButtonInput *key, GCKeyCode keyCode, BOOL pressed)
     {
         SDL_SendKeyboardKey(pressed ? SDL_PRESSED : SDL_RELEASED, (SDL_Scancode)keyCode);
     };
 
-    dispatch_queue_t queue = dispatch_queue_create( "org.libsdl.input.keyboard", DISPATCH_QUEUE_SERIAL );
+    queue = dispatch_queue_create( "org.libsdl.input.keyboard", DISPATCH_QUEUE_SERIAL );
     dispatch_set_target_queue( queue, dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_HIGH, 0 ) );
     keyboard.handlerQueue = queue;
 }
@@ -211,6 +212,8 @@ static void OnGCMouseButtonChanged(SDL_MouseID mouseID, Uint8 button, BOOL press
 static void OnGCMouseConnected(GCMouse *mouse) API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0))
 {
     SDL_MouseID mouseID = mice_connected;
+    int auxiliary_button;
+    dispatch_queue_t queue;
 
     mouse.mouseInput.leftButton.pressedChangedHandler = ^(GCControllerButtonInput *button, float value, BOOL pressed)
     {
@@ -225,7 +228,7 @@ static void OnGCMouseConnected(GCMouse *mouse) API_AVAILABLE(macos(11.0), ios(14
         OnGCMouseButtonChanged(mouseID, SDL_BUTTON_RIGHT, pressed);
     };
 
-    int auxiliary_button = SDL_BUTTON_X1;
+    auxiliary_button = SDL_BUTTON_X1;
     for (GCControllerButtonInput *btn in mouse.mouseInput.auxiliaryButtons) {
         btn.pressedChangedHandler = ^(GCControllerButtonInput *button, float value, BOOL pressed)
         {
@@ -241,7 +244,7 @@ static void OnGCMouseConnected(GCMouse *mouse) API_AVAILABLE(macos(11.0), ios(14
         }
     };
 
-    dispatch_queue_t queue = dispatch_queue_create( "org.libsdl.input.mouse", DISPATCH_QUEUE_SERIAL );
+    queue = dispatch_queue_create( "org.libsdl.input.mouse", DISPATCH_QUEUE_SERIAL );
     dispatch_set_target_queue( queue, dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_HIGH, 0 ) );
     mouse.handlerQueue = queue;
 

--- a/src/video/uikit/SDL_uikitmessagebox.m
+++ b/src/video/uikit/SDL_uikitmessagebox.m
@@ -59,12 +59,12 @@ UIKit_ShowMessageBoxAlertController(const SDL_MessageBoxData *messageboxdata, in
     int __block clickedindex = messageboxdata->numbuttons;
     UIWindow *window = nil;
     UIWindow *alertwindow = nil;
+    UIAlertController *alert;
 
     if (![UIAlertController class]) {
         return NO;
     }
 
-    UIAlertController *alert;
     alert = [UIAlertController alertControllerWithTitle:@(messageboxdata->title)
                                                 message:@(messageboxdata->message)
                                          preferredStyle:UIAlertControllerStyleAlert];

--- a/src/video/uikit/SDL_uikitmodes.m
+++ b/src/video/uikit/SDL_uikitmodes.m
@@ -34,13 +34,18 @@
 - (instancetype)initWithScreen:(UIScreen*)screen
 {
     if (self = [super init]) {
+        NSDictionary* devices;
+        struct utsname systemInfo;
+        NSString* deviceName;
+        id foundDPI;
+
         self.uiscreen = screen;
 
         /*
          * A well up to date list of device info can be found here:
          * https://github.com/lmirosevic/GBDeviceInfo/blob/master/GBDeviceInfo/GBDeviceInfo_iOS.m
          */
-        NSDictionary* devices = @{
+        devices = @{
             @"iPhone1,1": @163,
             @"iPhone1,2": @163,
             @"iPhone2,1": @163,
@@ -138,11 +143,10 @@
             @"iPod9,1": @326,
         };
 
-        struct utsname systemInfo;
         uname(&systemInfo);
-        NSString* deviceName =
+        deviceName =
             [NSString stringWithCString:systemInfo.machine encoding:NSUTF8StringEncoding];
-        id foundDPI = devices[deviceName];
+        foundDPI = devices[deviceName];
         if (foundDPI) {
             self.screenDPI = (float)[foundDPI integerValue];
         } else {
@@ -309,6 +313,7 @@ UIKit_AddDisplay(UIScreen *uiscreen, SDL_bool send_event)
     CGSize size = uiscreen.bounds.size;
     SDL_VideoDisplay display;
     SDL_DisplayMode mode;
+    SDL_DisplayData *data;
     SDL_zero(mode);
 
     /* Make sure the width/height are oriented correctly */
@@ -332,7 +337,7 @@ UIKit_AddDisplay(UIScreen *uiscreen, SDL_bool send_event)
     display.current_mode = mode;
 
     /* Allocate the display data */
-    SDL_DisplayData *data = [[SDL_DisplayData alloc] initWithScreen:uiscreen];
+    data = [[SDL_DisplayData alloc] initWithScreen:uiscreen];
     if (!data) {
         UIKit_FreeDisplayModeData(&display.desktop_mode);
         return SDL_OutOfMemory();
@@ -521,10 +526,10 @@ UIKit_GetDisplayUsableBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * rect)
 void
 UIKit_QuitModes(_THIS)
 {
+    int i, j;
     [SDL_DisplayWatch stop];
 
     /* Release Objective-C objects, so higher level doesn't free() them. */
-    int i, j;
     @autoreleasepool {
         for (i = 0; i < _this->num_displays; i++) {
             SDL_VideoDisplay *display = &_this->displays[i];

--- a/src/video/uikit/SDL_uikitopenglview.m
+++ b/src/video/uikit/SDL_uikitopenglview.m
@@ -74,6 +74,7 @@
         const BOOL useStencilBuffer = (stencilBits != 0);
         const BOOL useDepthBuffer = (depthBits != 0);
         NSString *colorFormat = nil;
+        CAEAGLLayer *eaglLayer;
 
         context = glcontext;
         samples = multisamples;
@@ -111,7 +112,7 @@
             colorBufferFormat = GL_RGB565;
         }
 
-        CAEAGLLayer *eaglLayer = (CAEAGLLayer *)self.layer;
+        eaglLayer = (CAEAGLLayer *)self.layer;
 
         eaglLayer.opaque = YES;
         eaglLayer.drawableProperties = @{
@@ -321,10 +322,11 @@
 
 - (void)layoutSubviews
 {
+    int width, height;
     [super layoutSubviews];
 
-    int width  = (int) (self.bounds.size.width * self.contentScaleFactor);
-    int height = (int) (self.bounds.size.height * self.contentScaleFactor);
+    width  = (int) (self.bounds.size.width * self.contentScaleFactor);
+    height = (int) (self.bounds.size.height * self.contentScaleFactor);
 
     /* Update the color and depth buffer storage if the layer size has changed. */
     if (width != backingWidth || height != backingHeight) {

--- a/src/video/uikit/SDL_uikitview.m
+++ b/src/video/uikit/SDL_uikitview.m
@@ -270,6 +270,7 @@ extern int SDL_AppleTVRemoteOpenedAsJoystick;
             SDL_TouchDeviceType touchType = [self touchTypeForTouch:touch];
             SDL_TouchID touchId = [self touchIdForType:touchType];
             float pressure = [self pressureForTouch:touch];
+            CGPoint locationInView;
 
             if (SDL_AddTouch(touchId, touchType, "") < 0) {
                 continue;
@@ -277,7 +278,7 @@ extern int SDL_AppleTVRemoteOpenedAsJoystick;
 
             /* FIXME, need to send: int clicks = (int) touch.tapCount; ? */
 
-            CGPoint locationInView = [self touchLocation:touch shouldNormalize:YES];
+            locationInView = [self touchLocation:touch shouldNormalize:YES];
             SDL_SendTouch(touchId, (SDL_FingerID)((size_t)touch), sdlwindow,
                           SDL_TRUE, locationInView.x, locationInView.y, pressure);
         }
@@ -325,6 +326,7 @@ extern int SDL_AppleTVRemoteOpenedAsJoystick;
             SDL_TouchDeviceType touchType = [self touchTypeForTouch:touch];
             SDL_TouchID touchId = [self touchIdForType:touchType];
             float pressure = [self pressureForTouch:touch];
+            CGPoint locationInView;
 
             if (SDL_AddTouch(touchId, touchType, "") < 0) {
                 continue;
@@ -332,7 +334,7 @@ extern int SDL_AppleTVRemoteOpenedAsJoystick;
 
             /* FIXME, need to send: int clicks = (int) touch.tapCount; ? */
 
-            CGPoint locationInView = [self touchLocation:touch shouldNormalize:YES];
+            locationInView = [self touchLocation:touch shouldNormalize:YES];
             SDL_SendTouch(touchId, (SDL_FingerID)((size_t)touch), sdlwindow,
                           SDL_FALSE, locationInView.x, locationInView.y, pressure);
         }
@@ -361,12 +363,13 @@ extern int SDL_AppleTVRemoteOpenedAsJoystick;
             SDL_TouchDeviceType touchType = [self touchTypeForTouch:touch];
             SDL_TouchID touchId = [self touchIdForType:touchType];
             float pressure = [self pressureForTouch:touch];
+            CGPoint locationInView;
 
             if (SDL_AddTouch(touchId, touchType, "") < 0) {
                 continue;
             }
 
-            CGPoint locationInView = [self touchLocation:touch shouldNormalize:YES];
+            locationInView = [self touchLocation:touch shouldNormalize:YES];
             SDL_SendTouchMotion(touchId, (SDL_FingerID)((size_t)touch), sdlwindow,
                                 locationInView.x, locationInView.y, pressure);
         }

--- a/src/video/uikit/SDL_uikitviewcontroller.m
+++ b/src/video/uikit/SDL_uikitviewcontroller.m
@@ -145,10 +145,13 @@ SDL_HideHomeIndicatorHintChanged(void *userdata, const char *name, const char *o
 
 - (void)startAnimation
 {
+#ifdef __IPHONE_10_3
+    SDL_WindowData *data;
+#endif
     displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(doLoop:)];
 
 #ifdef __IPHONE_10_3
-    SDL_WindowData *data = (__bridge SDL_WindowData *) window->driverdata;
+    data = (__bridge SDL_WindowData *) window->driverdata;
 
     if ([displayLink respondsToSelector:@selector(preferredFramesPerSecond)]
         && data != nil && data.uiwindow != nil
@@ -263,6 +266,7 @@ SDL_HideHomeIndicatorHintChanged(void *userdata, const char *name, const char *o
 /* Set ourselves up as a UITextFieldDelegate */
 - (void)initKeyboard
 {
+    NSNotificationCenter *center;
     changeText = nil;
     obligateForBackspace = @"                                                                "; /* 64 space */
     textField = [[UITextField alloc] initWithFrame:CGRectZero];
@@ -282,7 +286,7 @@ SDL_HideHomeIndicatorHintChanged(void *userdata, const char *name, const char *o
     textField.hidden = YES;
     keyboardVisible = NO;
 
-    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+    center = [NSNotificationCenter defaultCenter];
 #if !TARGET_OS_TV
     [center addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
     [center addObserver:self selector:@selector(keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
@@ -500,12 +504,13 @@ SDL_HideHomeIndicatorHintChanged(void *userdata, const char *name, const char *o
 static SDL_uikitviewcontroller *
 GetWindowViewController(SDL_Window * window)
 {
+    SDL_WindowData *data;
     if (!window || !window->driverdata) {
         SDL_SetError("Invalid window");
         return nil;
     }
 
-    SDL_WindowData *data = (__bridge SDL_WindowData *)window->driverdata;
+    data = (__bridge SDL_WindowData *)window->driverdata;
 
     return data.viewcontroller;
 }

--- a/src/video/uikit/SDL_uikitwindow.m
+++ b/src/video/uikit/SDL_uikitwindow.m
@@ -115,6 +115,9 @@ SetupWindowData(_THIS, SDL_Window *window, UIWindow *uiwindow, SDL_bool created)
 
 #if !TARGET_OS_TV
     if (displaydata.uiscreen == [UIScreen mainScreen]) {
+        NSUInteger orients;
+        BOOL supportsLandscape;
+        BOOL supportsPortrait;
         /* SDL_CreateWindow sets the window w&h to the display's bounds if the
          * fullscreen flag is set. But the display bounds orientation might not
          * match what we want, and GetSupportedOrientations call below uses the
@@ -123,9 +126,9 @@ SetupWindowData(_THIS, SDL_Window *window, UIWindow *uiwindow, SDL_bool created)
         window->w = window->windowed.w;
         window->h = window->windowed.h;
 
-        NSUInteger orients = UIKit_GetSupportedOrientations(window);
-        BOOL supportsLandscape = (orients & UIInterfaceOrientationMaskLandscape) != 0;
-        BOOL supportsPortrait = (orients & (UIInterfaceOrientationMaskPortrait|UIInterfaceOrientationMaskPortraitUpsideDown)) != 0;
+        orients = UIKit_GetSupportedOrientations(window);
+        supportsLandscape = (orients & UIInterfaceOrientationMaskLandscape) != 0;
+        supportsPortrait = (orients & (UIInterfaceOrientationMaskPortrait|UIInterfaceOrientationMaskPortraitUpsideDown)) != 0;
 
         /* Make sure the width/height are oriented correctly */
         if ((width > height && !supportsLandscape) || (height > width && !supportsPortrait)) {
@@ -163,6 +166,11 @@ UIKit_CreateWindow(_THIS, SDL_Window *window)
         SDL_VideoDisplay *display = SDL_GetDisplayForWindow(window);
         SDL_DisplayData *data = (__bridge SDL_DisplayData *) display->driverdata;
         SDL_Window *other;
+#if !TARGET_OS_TV
+        CGSize origsize;
+        const SDL_DisplayMode *bestmode = NULL;
+#endif
+        UIWindow *uiwindow;
 
         /* We currently only handle a single window per display on iOS */
         for (other = _this->windows; other; other = other->next) {
@@ -175,14 +183,13 @@ UIKit_CreateWindow(_THIS, SDL_Window *window)
          * user, so it's in standby), try to force the display to a resolution
          * that most closely matches the desired window size. */
 #if !TARGET_OS_TV
-        const CGSize origsize = data.uiscreen.currentMode.size;
+        origsize = data.uiscreen.currentMode.size;
         if ((origsize.width == 0.0f) && (origsize.height == 0.0f)) {
+            int i;
             if (display->num_display_modes == 0) {
                 _this->GetDisplayModes(_this, display);
             }
 
-            int i;
-            const SDL_DisplayMode *bestmode = NULL;
             for (i = display->num_display_modes; i >= 0; i--) {
                 const SDL_DisplayMode *mode = &display->display_modes[i];
                 if ((mode->w >= window->w) && (mode->h >= window->h)) {
@@ -212,7 +219,7 @@ UIKit_CreateWindow(_THIS, SDL_Window *window)
 
         /* ignore the size user requested, and make a fullscreen window */
         /* !!! FIXME: can we have a smaller view? */
-        UIWindow *uiwindow = [[SDL_uikitwindow alloc] initWithFrame:data.uiscreen.bounds];
+        uiwindow = [[SDL_uikitwindow alloc] initWithFrame:data.uiscreen.bounds];
 
         /* put the window on an external display if appropriate. */
         if (data.uiscreen != [UIScreen mainScreen]) {
@@ -241,11 +248,13 @@ UIKit_ShowWindow(_THIS, SDL_Window * window)
 {
     @autoreleasepool {
         SDL_WindowData *data = (__bridge SDL_WindowData *) window->driverdata;
+        SDL_VideoDisplay *display;
+        SDL_DisplayData *displaydata;
         [data.uiwindow makeKeyAndVisible];
 
         /* Make this window the current mouse focus for touch input */
-        SDL_VideoDisplay *display = SDL_GetDisplayForWindow(window);
-        SDL_DisplayData *displaydata = (__bridge SDL_DisplayData *) display->driverdata;
+        display = SDL_GetDisplayForWindow(window);
+        displaydata = (__bridge SDL_DisplayData *) display->driverdata;
         if (displaydata.uiscreen == [UIScreen mainScreen]) {
             SDL_SetMouseFocus(window);
             SDL_SetKeyboardFocus(window);


### PR DESCRIPTION
Since Clang 14, `-Wdeclaration-after-statement` is enforced on every standard.