### PR TITLE
simplify OpenBSD D-pad calculation with bitwise operation

### DIFF
--- a/src/joystick/bsd/SDL_bsdjoystick.c
+++ b/src/joystick/bsd/SDL_bsdjoystick.c
@@ -709,6 +709,10 @@ static void BSD_JoystickUpdate(SDL_Joystick *joy)
                     //default:
 	                // no-op
                     }
+                    SDL_PrivateJoystickHat(joy, 0, (dpad[0] * HAT_UP) |
+                                                   (dpad[1] * HAT_DOWN) |
+                                                   (dpad[2] * HAT_RIGHT) |
+                                                   (dpad[3] * HAT_LEFT) );
 #endif
                     break;
                 }
@@ -724,12 +728,6 @@ static void BSD_JoystickUpdate(SDL_Joystick *joy)
             default:
                 break;
             }
-#ifdef __OpenBSD__
-            SDL_PrivateJoystickHat(joy, 0, (dpad[0] * HAT_UP) |
-                                           (dpad[1] * HAT_DOWN) |
-                                           (dpad[2] * HAT_RIGHT) |
-                                           (dpad[3] * HAT_LEFT) );
-#endif
         }
         hid_end_parse(hdata);
     }

--- a/src/joystick/bsd/SDL_bsdjoystick.c
+++ b/src/joystick/bsd/SDL_bsdjoystick.c
@@ -92,40 +92,11 @@
 #define HUG_DPAD_RIGHT 0x92
 #define HUG_DPAD_LEFT  0x93
 
-#define HAT_CENTERED  0x00
 #define HAT_UP        0x01
 #define HAT_RIGHT     0x02
 #define HAT_DOWN      0x04
 #define HAT_LEFT      0x08
-#define HAT_RIGHTUP   (HAT_RIGHT | HAT_UP)
-#define HAT_RIGHTDOWN (HAT_RIGHT | HAT_DOWN)
-#define HAT_LEFTUP    (HAT_LEFT | HAT_UP)
-#define HAT_LEFTDOWN  (HAT_LEFT | HAT_DOWN)
 
-/* calculate the value from the state of the dpad */
-int dpad_to_sdl(Sint32 *dpad)
-{
-    if (dpad[2]) {
-        if (dpad[0])
-            return HAT_RIGHTUP;
-        else if (dpad[1])
-            return HAT_RIGHTDOWN;
-        else
-            return HAT_RIGHT;
-    } else if (dpad[3]) {
-        if (dpad[0])
-            return HAT_LEFTUP;
-        else if (dpad[1])
-            return HAT_LEFTDOWN;
-        else
-            return HAT_LEFT;
-    } else if (dpad[0]) {
-        return HAT_UP;
-    } else if (dpad[1]) {
-        return HAT_DOWN;
-    }
-    return HAT_CENTERED;
-}
 #endif
 
 struct report
@@ -719,18 +690,24 @@ static void BSD_JoystickUpdate(SDL_Joystick *joy)
                                                    hitem.logical_minimum);
                     }
 #ifdef __OpenBSD__
-                    else if (usage == HUG_DPAD_UP) {
+                    /* here D-pad directions are reported like separate buttons.
+                     * calculate the SDL hat value from the 4 separate values.
+                     */
+                    switch (usage) {
+	            case HUG_DPAD_UP:
                         dpad[0] = (Sint32)hid_get_data(REP_BUF_DATA(rep), &hitem);
-                        SDL_SendJoystickHat(timestamp, joy, 0, dpad_to_sdl(dpad));
-                    } else if (usage == HUG_DPAD_DOWN) {
+                        break;
+                    case HUG_DPAD_DOWN:
                         dpad[1] = (Sint32)hid_get_data(REP_BUF_DATA(rep), &hitem);
-                        SDL_SendJoystickHat(timestamp, joy, 0, dpad_to_sdl(dpad));
-                    } else if (usage == HUG_DPAD_RIGHT) {
+                        break;
+                    case HUG_DPAD_RIGHT:
                         dpad[2] = (Sint32)hid_get_data(REP_BUF_DATA(rep), &hitem);
-                        SDL_SendJoystickHat(timestamp, joy, 0, dpad_to_sdl(dpad));
-                    } else if (usage == HUG_DPAD_LEFT) {
+                        break;
+                    case HUG_DPAD_LEFT:
                         dpad[3] = (Sint32)hid_get_data(REP_BUF_DATA(rep), &hitem);
-                        SDL_SendJoystickHat(timestamp, joy, 0, dpad_to_sdl(dpad));
+                        break;
+                    //default:
+	                // no-op
                     }
 #endif
                     break;
@@ -747,6 +724,12 @@ static void BSD_JoystickUpdate(SDL_Joystick *joy)
             default:
                 break;
             }
+#ifdef __OpenBSD__
+            SDL_PrivateJoystickHat(joy, 0, (dpad[0] * HAT_UP) |
+                                           (dpad[1] * HAT_DOWN) |
+                                           (dpad[2] * HAT_RIGHT) |
+                                           (dpad[3] * HAT_LEFT) );
+#endif
         }
         hid_end_parse(hdata);
     }


### PR DESCRIPTION
## Description
The OpenBSD D-pad code converts a series of button-like inputs (`HUG_DPAD_UP` etc.) into an integer to pass to `SDL_PrivateJoystickHat()`. The existing solution in SDL_bsdjoystick.c is overly complicated for the task by using branching if-logic.

This PR changes this into a bitwise operation which is shorter and should also be more performant. I have tested this on OpenBSD 7.3 -current with sdl2-jstest and other applications that use SDL2's gamecontroller code without issues.

## Existing Issue(s)
None known.
