### PR TITLE
Add install option for android-project directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,6 +369,7 @@ endforeach()
 set_option(SDL_DISABLE_INSTALL    "Disable installation of SDL3" ${SDL3_SUBPROJECT})
 cmake_dependent_option(SDL_DISABLE_INSTALL_CPACK "Create binary SDL3 archive using CPack" ${SDL3_SUBPROJECT} "NOT SDL_DISABLE_INSTALL" ON)
 cmake_dependent_option(SDL_DISABLE_INSTALL_MAN "Install man pages for SDL3" ${SDL3_SUBPROJECT} "NOT SDL_DISABLE_INSTALL;NOT SDL_FRAMEWORK" ON)
+cmake_dependent_option(SDL_DISABLE_INSTALL_ANDROID_PROJECT "Install Android project for SDL3" ${SDL3_SUBPROJECT} "NOT SDL_DISABLE_INSTALL" ON)
 set_option(SDL_DISABLE_UNINSTALL  "Disable uninstallation of SDL3" OFF)
 
 option_string(SDL_ASSERTIONS "Enable internal sanity checks (auto/disabled/release/enabled/paranoid)" "auto")
@@ -3700,6 +3701,10 @@ if(NOT SDL_DISABLE_INSTALL)
       SYMBOL "SDL_Init"
       WIKIHEADERS_PL_PATH "${CMAKE_CURRENT_SOURCE_DIR}/build-scripts/wikiheaders.pl"
     )
+  endif()
+
+  if(NOT SDL_DISABLE_INSTALL_ANDROID_PROJECT AND ANDROID)
+    install(DIRECTORY android-project DESTINATION "${CMAKE_INSTALL_LIBDIR}")
   endif()
 endif()
 


### PR DESCRIPTION
## Description
This adds a CMake install option for the `android-project` directory so these files are available to be used in an Android app. I think it's particularly valuable to have the contents of `android-project/app/src/main/java/org/libsdl/app` since that code is coupled to a given SDL release.

By delivering these files in the CMake install, they will be available in cases where the developer is not building SDL in their project, such as when they are downloading SDL as a Conan package.

The CMake install only happens for Android builds and has a CMake option to allow it to be shut off completely. I put the files in `lib/android-project`, but let me know if you'd prefer a different location.

## Existing Issue(s)
none known
