### PR TITLE
Remove the leftover CloseIC dbus call in fcitx module

### DIFF
--- a/src/core/linux/SDL_fcitx.c
+++ b/src/core/linux/SDL_fcitx.c
@@ -399,7 +399,6 @@ void SDL_Fcitx_SetFocus(SDL_bool focused)
 void SDL_Fcitx_Reset(void)
 {
     FcitxClientICCallMethod(&fcitx_client, "Reset");
-    FcitxClientICCallMethod(&fcitx_client, "CloseIC");
 }
 
 SDL_bool SDL_Fcitx_ProcessKeyEvent(Uint32 keysym, Uint32 keycode, Uint8 state)


### PR DESCRIPTION
This call is actually a left-over when porting from fcitx4 service to the new org.freedesktop.portal.Fcitx supported by both fcitx4/fcitx5. CloseIC is actually never a part of the new interface on org.freedesktop.portal.Fcitx. It cause any issue user visible effect.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Reference to the interface in fcitx 4 and fcitx5
https://github.com/fcitx/fcitx/blob/master/src/frontend/ipcportal/ipcportal.c#L120
https://github.com/fcitx/fcitx5/blob/master/src/frontend/dbusfrontend/dbusfrontend.cpp#L375

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
