### PR TITLE
Fix Caps Lock and Backspace mapping for Colemak

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -137,6 +137,11 @@ static SDL_Scancode VKeytoScancodeFallback(WPARAM vkey)
 static SDL_Scancode VKeytoScancode(WPARAM vkey)
 {
     switch (vkey) {
+    case VK_BACK:
+        return SDL_SCANCODE_BACKSPACE;
+    case VK_CAPITAL:
+        return SDL_SCANCODE_CAPSLOCK;
+
     case VK_MODECHANGE:
         return SDL_SCANCODE_MODE;
     case VK_SELECT:


### PR DESCRIPTION
Fixes issue [Backspace on Colemak keyboard layout doesn't work on Windows #7853](https://github.com/libsdl-org/SDL/issues/7853)