### PR TITLE
src/SDL.c: add managarm support

### DIFF
--- a/src/SDL.c
+++ b/src/SDL.c
@@ -609,6 +609,8 @@ const char *SDL_GetPlatform(void)
     return "Nokia N-Gage";
 #elif defined(__3DS__)
     return "Nintendo 3DS";
+#elif defined(__managarm__)
+    return "Managarm";
 #else
     return "Unknown (see SDL_platform.h)";
 #endif


### PR DESCRIPTION
## Description
This returns the correct platform name when running on Managarm.
