### PR TITLE
os2 audio refactoring and capture support

### DIFF
--- a/src/audio/os2/SDL_os2audio.h
+++ b/src/audio/os2/SDL_os2audio.h
@@ -43,10 +43,11 @@ typedef struct SDL_PrivateAudioData
     BYTE                _pad[2];
     MCI_MIXSETUP_PARMS  stMCIMixSetup;
     HEV                 hevBuf;
-    ULONG               ulNextBuf;
+    PMCI_MIX_BUFFER     pFillBuffer;
+    PMCI_MIX_BUFFER     pDrainBuffer;
+    ULONG               ulState;
     ULONG               cMixBuffers;
     MCI_MIX_BUFFER      aMixBuffers[NUM_BUFFERS];
-/*  ULONG               ulQueuedBuf;*/
 } SDL_PrivateAudioData;
 
 #endif /* SDL_os2mm_h_ */


### PR DESCRIPTION
- Fixes audio device detection and usage,
- Implements audio capture support,
- Refactors buffer handling to separate pointers to fill and drain buffers.

Based on patches by josch1710 and Lars Erdmann:
https://github.com/bitwiseworks/SDL2-os2/pull/7

P.S.: If this is accepted, consider for release-2.28.x or not?