### PR TITLE
Add VS code directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ cmake-build-*
 xcuserdata
 *.xcworkspace
 
+# for Visual Studio Code
+.vscode/
+
 # for Visual C++
 .vs
 Debug


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I made a minor PR about pixelformats today, and I noticed this VS code folder popped into the diff. I figure it should just be gitignored. Other IDEs have specific gitignore entries already. Maybe this will save someone a second in the future if they accidentally commit things from the `.vscode` folder.


## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
None