### PR TITLE
wayland: Fix memory leaks

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -672,6 +672,10 @@ static void Wayland_free_display(SDL_VideoDisplay *display)
         SDL_DisplayData *display_data = display->driverdata;
         int i;
 
+        if (display_data->xdg_output) {
+            zxdg_output_v1_destroy(display_data->xdg_output);
+        }
+
         if (wl_output_get_version(display_data->output) >= WL_OUTPUT_RELEASE_SINCE_VERSION) {
             wl_output_release(display_data->output);
         } else {


### PR DESCRIPTION
Fix some memory leaks reported by Valgrind due to not destroying objects. `wl_display_sync()` returns a pointer to a `wl_callback`, which was being ignored and never destroyed, causing a leak. Created xdg_output and primary_selection_device objects were not being destroyed either.

Fixes #8056
