### PR TITLE
SDL_video.c: move os2 video before offscreen.

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -127,15 +127,15 @@ static VideoBootStrap *bootstrap[] = {
 #if SDL_VIDEO_DRIVER_QNX
     &QNX_bootstrap,
 #endif
+#if SDL_VIDEO_DRIVER_OS2
+    &OS2DIVE_bootstrap,
+    &OS2VMAN_bootstrap,
+#endif
 #if SDL_VIDEO_DRIVER_OFFSCREEN
     &OFFSCREEN_bootstrap,
 #endif
 #if SDL_VIDEO_DRIVER_NGAGE
     &NGAGE_bootstrap,
-#endif
-#if SDL_VIDEO_DRIVER_OS2
-    &OS2DIVE_bootstrap,
-    &OS2VMAN_bootstrap,
 #endif
 #if SDL_VIDEO_DRIVER_DUMMY
     &DUMMY_bootstrap,


### PR DESCRIPTION
As offscreen is enabled in CMakeLists.txt, we get a blanks window
otherwise.

From a patch by Silvan Scherrer, at Bitwiseworks' fork.

NOTE: One might think of the same as NGAGE driver: Should I move it
before offscreen too?