### PR TITLE
Reapply "Changed 'freesrc' parameter from int to SDL_bool" to SDL_wave.c

### DIFF
--- a/include/SDL3/SDL_audio.h
+++ b/include/SDL3/SDL_audio.h
@@ -1066,9 +1066,6 @@ extern DECLSPEC SDL_AudioStream *SDLCALL SDL_CreateAndBindAudioStream(SDL_AudioD
  * be valid pointers. The entire data portion of the file is then loaded into
  * memory and decoded if necessary.
  *
- * If `freesrc` is non-zero, the data source gets automatically closed and
- * freed before the function returns.
- *
  * Supported formats are RIFF WAVE files with the formats PCM (8, 16, 24, and
  * 32 bits), IEEE Float (32 bits), Microsoft ADPCM and IMA ADPCM (4 bits), and
  * A-law and mu-law (8 bits). Other formats are currently unsupported and
@@ -1115,11 +1112,11 @@ extern DECLSPEC SDL_AudioStream *SDLCALL SDL_CreateAndBindAudioStream(SDL_AudioD
  * ```
  *
  * \param src The data source for the WAVE data
- * \param freesrc If non-zero, SDL will _always_ free the data source
+ * \param freesrc If SDL_TRUE, calls SDL_RWclose() on `src` before returning, even in the case of an error
  * \param spec A pointer to an SDL_AudioSpec that will be set to the WAVE
- *             data's format details on successful return.
+ *             data's format details on successful return
  * \param audio_buf A pointer filled with the audio data, allocated by the
- *                  function.
+ *                  function
  * \param audio_len A pointer filled with the length of the audio data buffer
  *                  in bytes
  * \returns This function, if successfully called, returns 0. `audio_buf` will
@@ -1141,7 +1138,7 @@ extern DECLSPEC SDL_AudioStream *SDLCALL SDL_CreateAndBindAudioStream(SDL_AudioD
  * \sa SDL_free
  * \sa SDL_LoadWAV
  */
-extern DECLSPEC int SDLCALL SDL_LoadWAV_RW(SDL_RWops * src, int freesrc,
+extern DECLSPEC int SDLCALL SDL_LoadWAV_RW(SDL_RWops * src, SDL_bool freesrc,
                                            SDL_AudioSpec * spec, Uint8 ** audio_buf,
                                            Uint32 * audio_len);
 

--- a/src/audio/SDL_wave.c
+++ b/src/audio/SDL_wave.c
@@ -2070,20 +2070,23 @@ static int WaveLoad(SDL_RWops *src, WaveFile *file, SDL_AudioSpec *spec, Uint8 *
     return 0;
 }
 
-int SDL_LoadWAV_RW(SDL_RWops *src, int freesrc, SDL_AudioSpec *spec, Uint8 **audio_buf, Uint32 *audio_len)
+int SDL_LoadWAV_RW(SDL_RWops *src, SDL_bool freesrc, SDL_AudioSpec *spec, Uint8 **audio_buf, Uint32 *audio_len)
 {
     int result = -1;
     WaveFile file;
 
     /* Make sure we are passed a valid data source */
     if (src == NULL) {
-        return -1;  /* Error may come from RWops. */
+        goto done;  /* Error may come from RWops. */
     } else if (spec == NULL) {
-        return SDL_InvalidParamError("spec");
+        SDL_InvalidParamError("spec");
+        goto done;
     } else if (audio_buf == NULL) {
-        return SDL_InvalidParamError("audio_buf");
+        SDL_InvalidParamError("audio_buf");
+        goto done;
     } else if (audio_len == NULL) {
-        return SDL_InvalidParamError("audio_len");
+        SDL_InvalidParamError("audio_len");
+        goto done;
     }
 
     *audio_buf = NULL;
@@ -2107,7 +2110,10 @@ int SDL_LoadWAV_RW(SDL_RWops *src, int freesrc, SDL_AudioSpec *spec, Uint8 **aud
     }
     WaveFreeChunkData(&file.chunk);
     SDL_free(file.decoderdata);
-
+done:
+    if (freesrc && src) {
+        SDL_RWclose(src);
+    }
     return result;
 }
 

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -947,7 +947,7 @@ SDL_DYNAPI_PROC(int,SDL_SetAudioStreamGetCallback,(SDL_AudioStream *a, SDL_Audio
 SDL_DYNAPI_PROC(int,SDL_SetAudioStreamPutCallback,(SDL_AudioStream *a, SDL_AudioStreamRequestCallback b, void *c),(a,b,c),return)
 SDL_DYNAPI_PROC(void,SDL_DestroyAudioStream,(SDL_AudioStream *a),(a),)
 SDL_DYNAPI_PROC(SDL_AudioStream*,SDL_CreateAndBindAudioStream,(SDL_AudioDeviceID a, const SDL_AudioSpec *b),(a,b),return)
-SDL_DYNAPI_PROC(int,SDL_LoadWAV_RW,(SDL_RWops *a, int b, SDL_AudioSpec *c, Uint8 **d, Uint32 *e),(a,b,c,d,e),return)
+SDL_DYNAPI_PROC(int,SDL_LoadWAV_RW,(SDL_RWops *a, SDL_bool b, SDL_AudioSpec *c, Uint8 **d, Uint32 *e),(a,b,c,d,e),return)
 SDL_DYNAPI_PROC(int,SDL_MixAudioFormat,(Uint8 *a, const Uint8 *b, SDL_AudioFormat c, Uint32 d, int e),(a,b,c,d,e),return)
 SDL_DYNAPI_PROC(int,SDL_ConvertAudioSamples,(const SDL_AudioSpec *a, const Uint8 *b, int c, const SDL_AudioSpec *d, Uint8 **e, int *f),(a,b,c,d,e,f),return)
 SDL_DYNAPI_PROC(int,SDL_GetSilenceValueForFormat,(SDL_AudioFormat a),(a),return)


### PR DESCRIPTION
## Description
Commit bea99d4 was partially reverted by 905c4ff "audio: First shot at the SDL3 audio subsystem redesign!"

This commit also modified error management of `SDL_LoadWAV_RW()`, so reapplying it is needed to respect the `freesrc` parameter.

## Existing Issue(s)
None
