### PR TITLE
Don't pass NULL to strncmp

### DIFF
--- a/src/audio/alsa/SDL_alsa_audio.c
+++ b/src/audio/alsa/SDL_alsa_audio.c
@@ -812,7 +812,7 @@ static void ALSA_HotplugIteration(SDL_bool *has_default_output, SDL_bool *has_de
 
                 // only want physical hardware interfaces
                 const SDL_bool is_default = (has_default == i) ? SDL_TRUE : SDL_FALSE;
-                if (is_default || SDL_strncmp(name, match, match_len) == 0) {
+                if (is_default || (match != NULL && SDL_strncmp(name, match, match_len) == 0)) {
                     char *ioid = ALSA_snd_device_name_get_hint(hints[i], "IOID");
                     const SDL_bool isoutput = (ioid == NULL) || (SDL_strcmp(ioid, "Output") == 0);
                     const SDL_bool isinput = (ioid == NULL) || (SDL_strcmp(ioid, "Input") == 0);


### PR DESCRIPTION
## Description
if there are 2 devices and `match` is NULL, then one of the device is not the default and NULL is passed to `SDL_strncmp()`.

## Existing Issue(s)
None
