### PR TITLE
Fix size of memcpy in SDL_AudioDeviceFormatChangedAlreadyLocked

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,6 +25,7 @@ Checks: >
   clang-analyzer-core.*,
   clang-analyzer-valist.*,
   clang-analyzer-unix.Malloc,
+  clang-diagnostic-*,
   google-readability-casting,
   misc-misleading-bidirectional,
   misc-misleading-identifier,

--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -1681,7 +1681,7 @@ int SDL_AudioDeviceFormatChangedAlreadyLocked(SDL_AudioDevice *device, const SDL
     const SDL_bool iscapture = device->iscapture;
 
     if ((device->spec.format != newspec->format) || (device->spec.channels != newspec->channels) || (device->spec.freq != newspec->freq)) {
-        SDL_memcpy(&device->spec, newspec, sizeof (newspec));
+        SDL_memcpy(&device->spec, newspec, sizeof (*newspec));
         for (SDL_LogicalAudioDevice *logdev = device->logical_devices; !kill_device && (logdev != NULL); logdev = logdev->next) {
             for (SDL_AudioStream *stream = logdev->bound_streams; !kill_device && (stream != NULL); stream = stream->next_binding) {
                 if (SDL_SetAudioStreamFormat(stream, iscapture ? &device->spec : NULL, iscapture ? NULL : &device->spec) == -1) {


### PR DESCRIPTION
## Description

And add diagnostic that allows to find this kind of issue in clang-tidy.

Clang has a warning for this but it doesn't work on the SDL version of standard functions. It works in clang tidy because SDL function are redifined as standart function (https://github.com/libsdl-org/SDL/blob/main/include/SDL3/SDL_stdinc.h#L719).

## Existing Issue(s)
None
