### PR TITLE
feature: user defined GetMessage on Windows

### DIFF
--- a/include/SDL_system.h
+++ b/include/SDL_system.h
@@ -55,6 +55,14 @@ typedef void (SDLCALL * SDL_WindowsMessageHook)(void *userdata, void *hWnd, unsi
  */
 extern DECLSPEC void SDLCALL SDL_SetWindowsMessageHook(SDL_WindowsMessageHook callback, void *userdata);
 
+// the return value is BOOL
+typedef int(SDLCALL *SDL_WindowsGetMessageImpl)(void *userdata, void *lpMsg, void *hWnd, unsigned int wMsgFilterMin, unsigned int wMsgFilterMax);
+
+/**
+ * Set a GetMessage implement, for blocking etc.
+ */
+extern DECLSPEC void SDLCALL SDL_SetWindowsGetMessageImpl(SDL_WindowsGetMessageImpl callback, void *userdata);
+
 #endif /* defined(__WIN32__) || defined(__GDK__) */
 
 #if defined(__WIN32__) || defined(__WINGDK__)

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1767,6 +1767,25 @@ void SDL_SetWindowsMessageHook(SDL_WindowsMessageHook callback, void *userdata)
     g_WindowsMessageHookData = userdata;
 }
 
+// A user implement API: GetMessage
+static SDL_WindowsGetMessageImpl g_WindowsGetMessageImpl = NULL;
+static void *g_WindowsGetMessageImplData = NULL;
+
+void SDLCALL SDL_SetWindowsGetMessageImpl(SDL_WindowsGetMessageImpl callback, void* userdata)
+{
+    g_WindowsGetMessageImpl = callback;
+    g_WindowsGetMessageImplData = userdata;
+}
+
+static BOOL GetMessageImpl(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, UINT wMsgFilterMax)
+{
+    if (g_WindowsGetMessageImpl)
+    {
+        return g_WindowsGetMessageImpl(g_WindowsGetMessageImplData, lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax);
+    }
+    return GetMessage(lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax);
+}
+
 int WIN_WaitEventTimeout(_THIS, int timeout)
 {
     MSG msg;
@@ -1775,12 +1794,12 @@ int WIN_WaitEventTimeout(_THIS, int timeout)
         UINT_PTR timer_id = 0;
         if (timeout > 0) {
             timer_id = SetTimer(NULL, 0, timeout, NULL);
-            message_result = GetMessage(&msg, 0, 0, 0);
+            message_result = GetMessageImpl(&msg, 0, 0, 0);
             KillTimer(NULL, timer_id);
         } else if (timeout == 0) {
             message_result = PeekMessage(&msg, NULL, 0, 0, PM_REMOVE);
         } else {
-            message_result = GetMessage(&msg, 0, 0, 0);
+            message_result = GetMessageImpl(&msg, 0, 0, 0);
         }
         if (message_result) {
             if (msg.message == WM_TIMER && msg.hwnd == NULL && msg.wParam == timer_id) {


### PR DESCRIPTION
it is make that user can intergate other loop to sdl

## Description
add a user implement GetMessage to do other things, because the API is blocking!
in my case:
i will call ``MsgWaitForMultipleObjects`` instead of ``GetMessage`` to wait a IOCP handle and win32-message together
if wait a message, call ``PeekMessage`` and return, if wait a IOCP event, do my logic and wait MSG again

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
