### PR TITLE
test: Don't flag testsurround as suitable for non-interactive use

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -279,7 +279,6 @@ endif()
 
 if(SDL_DUMMYAUDIO)
     set_property(TARGET testaudioinfo PROPERTY SDL_NONINTERACTIVE 1)
-    set_property(TARGET testsurround PROPERTY SDL_NONINTERACTIVE 1)
 endif()
 
 if(SDL_DUMMYVIDEO)


### PR DESCRIPTION
According to #8088 it has no value as an automated test, and by default it takes long enough to hit the default test timeout.

Resolves: #8088