### PR TITLE
build: Consistently use pathlib APIs in cmake/xxd.py

### DIFF
--- a/cmake/xxd.py
+++ b/cmake/xxd.py
@@ -17,7 +17,7 @@ def main():
 
     binary_data = args.input.open("rb").read()
 
-    with open(args.output, "w") as fout:
+    with args.output.open("w") as fout:
         fout.write("unsigned char {}[] = {{\n".format(varname))
         bytes_written = 0
         while bytes_written < len(binary_data):


### PR DESCRIPTION
The ability to pass a pathlib.Path to open() was new in Python 3.6, and the oldest branch of the Steam Runtime only has Python 3.5 available. Even without considering retrocomputing, using the Path.open method is more consistent with how we read the input 2 lines earlier.