### PR TITLE
Fix out of bound read of 'has_hat' array

### DIFF
--- a/src/joystick/linux/SDL_sysjoystick.c
+++ b/src/joystick/linux/SDL_sysjoystick.c
@@ -1149,7 +1149,7 @@ static void ConfigJoystick(SDL_Joystick *joystick, int fd, int fd_sensor)
         }
         for (i = 0; i < ABS_MAX; ++i) {
             /* Skip digital hats */
-            if (joystick->hwdata->has_hat[(i - ABS_HAT0X) / 2]) {
+            if (i >= ABS_HAT0X && i <= ABS_HAT3Y && joystick->hwdata->has_hat[(i - ABS_HAT0X) / 2]) {
                 continue;
             }
             if (test_bit(i, absbit)) {


### PR DESCRIPTION
## Description
Found with `-fsanitize=undefined`:
SDL3/src/joystick/linux/SDL_sysjoystick.c:1152:42: runtime error: index -8 out of bounds for type 'SDL_bool [4]'

## Existing Issue(s)
Nobody noticed because the `hwdata` structure is memset to 0 so the condition was false as expected.
