### PR TITLE
Fix overflow with SDL_sscanf(..., "%hd", ...)

### DIFF
--- a/src/stdlib/SDL_string.c
+++ b/src/stdlib/SDL_string.c
@@ -1275,7 +1275,9 @@ int SDL_vsscanf(const char *text, const char *fmt, va_list ap)
                     suppress = SDL_TRUE;
                     break;
                 case 'h':
-                    if (inttype > DO_SHORT) {
+                    if (inttype == DO_INT) {
+                        inttype = DO_SHORT;
+                    } else if (inttype > DO_SHORT) {
                         ++inttype;
                     }
                     break;


### PR DESCRIPTION
Fix an overflow when using `%hd` in `SDL_sscanf`.
This happened with the clang toolchains of msys2.
For example, see [this ci output](https://github.com/libsdl-org/sdl2-compat/actions/runs/5803154544/job/15730733338?pr=97#step:10:7114).

Because `SDL_sscanf` always wrote the parsed integer as a 32-bit integer, it overflowed into other data on the stack.
The automation test catched this issue because `expected_result` got corrupted (=zeroed).

https://github.com/libsdl-org/SDL/blob/9129e1d5577ef2eeaa7008eee14473dcf27d92c3/test/testautomation_stdlib.c#L620-L639

## Description

## Existing Issue(s)
