### PR TITLE
Clarify that a window being 'hidden' means that it is unmapped/ordered out

### DIFF
--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -132,7 +132,7 @@ typedef enum
     SDL_WINDOW_FULLSCREEN           = 0x00000001,   /**< window is in fullscreen mode */
     SDL_WINDOW_OPENGL               = 0x00000002,   /**< window usable with OpenGL context */
     SDL_WINDOW_OCCLUDED             = 0x00000004,   /**< window is occluded */
-    SDL_WINDOW_HIDDEN               = 0x00000008,   /**< window is not visible */
+    SDL_WINDOW_HIDDEN               = 0x00000008,   /**< window is neither mapped onto the desktop nor shown in the taskbar/dock/window list; SDL_ShowWindow() is required for it to become visible */
     SDL_WINDOW_BORDERLESS           = 0x00000010,   /**< no window decoration */
     SDL_WINDOW_RESIZABLE            = 0x00000020,   /**< window can be resized */
     SDL_WINDOW_MINIMIZED            = 0x00000040,   /**< window is minimized */

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -643,7 +643,7 @@ static void Cocoa_SendExposedEventIfVisible(SDL_Window *window)
         int newVisibility = [[change objectForKey:@"new"] intValue];
         if (newVisibility) {
             SDL_SendWindowEvent(_data.window, SDL_EVENT_WINDOW_SHOWN, 0, 0);
-        } else {
+        } else if (![_data.nswindow isMiniaturized]) {
             SDL_SendWindowEvent(_data.window, SDL_EVENT_WINDOW_HIDDEN, 0, 0);
         }
     }
@@ -662,7 +662,7 @@ static void Cocoa_SendExposedEventIfVisible(SDL_Window *window)
     if (wasVisible != isVisible) {
         if (isVisible) {
             SDL_SendWindowEvent(_data.window, SDL_EVENT_WINDOW_SHOWN, 0, 0);
-        } else {
+        } else if (![_data.nswindow isMiniaturized]) {
             SDL_SendWindowEvent(_data.window, SDL_EVENT_WINDOW_HIDDEN, 0, 0);
         }
 

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -955,7 +955,12 @@ static void Cocoa_SendExposedEventIfVisible(SDL_Window *window)
 
 - (void)windowDidDeminiaturize:(NSNotification *)aNotification
 {
-    SDL_SendWindowEvent(_data.window, SDL_EVENT_WINDOW_RESTORED, 0, 0);
+    /* isZoomed always returns true if the window is not resizable */
+    if ((_data.window->flags & SDL_WINDOW_RESIZABLE) && [_data.nswindow isZoomed]) {
+        SDL_SendWindowEvent(_data.window, SDL_EVENT_WINDOW_MAXIMIZED, 0, 0);
+    } else {
+        SDL_SendWindowEvent(_data.window, SDL_EVENT_WINDOW_RESTORED, 0, 0);
+    }
 }
 
 - (void)windowDidBecomeKey:(NSNotification *)aNotification

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -1529,12 +1529,6 @@ void Wayland_ShowWindow(SDL_VideoDevice *_this, SDL_Window *window)
 
     /* Restore state that was set prior to this call */
     Wayland_SetWindowTitle(_this, window);
-    if (window->flags & SDL_WINDOW_MAXIMIZED) {
-        Wayland_MaximizeWindow(_this, window);
-    }
-    if (window->flags & SDL_WINDOW_MINIMIZED) {
-        Wayland_MinimizeWindow(_this, window);
-    }
 
     /* We have to wait until the surface gets a "configure" event, or use of
      * this surface will fail. This is a new rule for xdg_shell.
@@ -1940,11 +1934,6 @@ void Wayland_RestoreWindow(SDL_VideoDevice *_this, SDL_Window *window)
         return;
     }
 
-    /* Set this flag now even if we never actually maximized, eventually
-     * ShowWindow will take care of it along with the other window state.
-     */
-    window->flags &= ~SDL_WINDOW_MAXIMIZED;
-
 #ifdef HAVE_LIBDECOR_H
     if (wind->shell_surface_type == WAYLAND_SURFACE_LIBDECOR) {
         if (wind->shell_surface.libdecor.frame == NULL) {
@@ -2025,11 +2014,6 @@ void Wayland_MaximizeWindow(SDL_VideoDevice *_this, SDL_Window *window)
         return;
     }
 
-    /* Set this flag now even if we don't actually maximize yet, eventually
-     * ShowWindow will take care of it along with the other window state.
-     */
-    window->flags |= SDL_WINDOW_MAXIMIZED;
-
 #ifdef HAVE_LIBDECOR_H
     if (wind->shell_surface_type == WAYLAND_SURFACE_LIBDECOR) {
         if (wind->shell_surface.libdecor.frame == NULL) {
@@ -2057,6 +2041,8 @@ void Wayland_MinimizeWindow(SDL_VideoDevice *_this, SDL_Window *window)
     SDL_VideoData *viddata = _this->driverdata;
     SDL_WindowData *wind = window->driverdata;
 
+    /* Maximized and minimized flags are mutually exclusive */
+    window->flags &= ~SDL_WINDOW_MAXIMIZED;
     window->flags |= SDL_WINDOW_MINIMIZED;
 
 #ifdef HAVE_LIBDECOR_H

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -1579,12 +1579,19 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
                 }
             }
 
-            if (changed & SDL_WINDOW_MAXIMIZED) {
-                if (flags & SDL_WINDOW_MAXIMIZED) {
-                    SDL_SendWindowEvent(data->window, SDL_EVENT_WINDOW_MAXIMIZED, 0, 0);
-                } else {
-                    SDL_SendWindowEvent(data->window, SDL_EVENT_WINDOW_RESTORED, 0, 0);
-                }
+            if ((changed & SDL_WINDOW_MAXIMIZED) && ((flags & SDL_WINDOW_MAXIMIZED) && !(flags & SDL_WINDOW_MINIMIZED))) {
+                SDL_SendWindowEvent(data->window, SDL_EVENT_WINDOW_MAXIMIZED, 0, 0);
+            }
+            if ((changed & SDL_WINDOW_MINIMIZED) && (flags & SDL_WINDOW_MINIMIZED)) {
+                SDL_SendWindowEvent(data->window, SDL_EVENT_WINDOW_MINIMIZED, 0, 0);
+            }
+            if (((changed & SDL_WINDOW_MAXIMIZED) || (changed & SDL_WINDOW_MINIMIZED)) &&
+                (!(flags & SDL_WINDOW_MAXIMIZED) && !(flags & SDL_WINDOW_MINIMIZED))) {
+                SDL_SendWindowEvent(data->window, SDL_EVENT_WINDOW_RESTORED, 0, 0);
+            }
+
+            if (changed & SDL_WINDOW_OCCLUDED) {
+                SDL_SendWindowEvent(data->window, (flags & SDL_WINDOW_OCCLUDED) ? SDL_EVENT_WINDOW_OCCLUDED : SDL_EVENT_WINDOW_EXPOSED, 0, 0);
             }
         } else if (xevent->xproperty.atom == videodata->XKLAVIER_STATE) {
             /* Hack for Ubuntu 12.04 (etc) that doesn't send MappingNotify

--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -238,7 +238,7 @@ Uint32 X11_GetNetWMState(SDL_VideoDevice *_this, SDL_Window *window, Window xwin
 
         for (i = 0; i < numItems; ++i) {
             if (atoms[i] == _NET_WM_STATE_HIDDEN) {
-                flags |= SDL_WINDOW_HIDDEN;
+                flags |= SDL_WINDOW_MINIMIZED | SDL_WINDOW_OCCLUDED;
             } else if (atoms[i] == _NET_WM_STATE_FOCUSED) {
                 flags |= SDL_WINDOW_INPUT_FOCUS;
             } else if (atoms[i] == _NET_WM_STATE_MAXIMIZED_VERT) {


### PR DESCRIPTION
SDL considers a hidden window to be unmapped and blocks or defers certain operations until the window is shown again, however, the X11 and Cocoa backends would set the hidden flag when the window was minimized, which blocked the functionality of SDL_RestoreWindow().

This specifies that a window with the hidden flag set is unmapped and not visible on the desktop or in the dock/taskbar/window list without a call to SDL_ShowWindow(), and doesn't set the hidden flag in the X11 and Cocoa backends when the window is in the minimized state, but still mapped to the desktop. The occluded flag is more suitable in these cases (macOS sets it explicitly on miniaturized windows, and we can set it implicitly when X11 windows are 'hidden', but still mapped).

There is some prior art here too, as both GTK and Qt also consider X11 windows to be minimized if the 'hidden' atom is set, vs being closed or unmapped.

Cocoa is also fixed so that minimized windows will be properly hidden, as macOS doesn't remove miniaturized windows via the `orderOut` method, so `close` is now called instead.  This is safe to do since SDL holds a strong reference to the window and was tested to work on both macOS 12 and 13, but it is in a separate commit anyway, so that it can be easily backed-out just in case it has some adverse effects on older versions.