### PR TITLE
Fix x11 taskbar icon/title

### DIFF
--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -1934,6 +1934,18 @@ int SDL_X11_SetWindowTitle(Display *display, Window xwindow, char *title)
 
     if (conv == 0) {
         X11_XSetTextProperty(display, xwindow, &titleprop, XA_WM_NAME);
+
+        /* update the x11 class name property for the window */
+        XClassHint *classhints = X11_XAllocClassHint();
+        if (classhints)
+        {
+            classhints->res_class = (char*)titleprop.value;
+            classhints->res_name = (char*)titleprop.value;
+
+            X11_XSetWMProperties(display, xwindow, NULL, NULL, NULL, 0, NULL, NULL, classhints);
+            X11_XFree(classhints);
+        }
+
         X11_XFree(titleprop.value);
         /* we know this can't be a locale error as we checked X locale validity */
     } else if (conv < 0) {
@@ -1947,6 +1959,18 @@ int SDL_X11_SetWindowTitle(Display *display, Window xwindow, char *title)
     status = X11_Xutf8TextListToTextProperty(display, &title, 1, XUTF8StringStyle, &titleprop);
     if (status == Success) {
         X11_XSetTextProperty(display, xwindow, &titleprop, _NET_WM_NAME);
+
+        /* update the x11 class name property for the window */
+        XClassHint *classhints = X11_XAllocClassHint();
+        if (classhints)
+        {
+            classhints->res_class = (char*)titleprop.value;
+            classhints->res_name = (char*)titleprop.value;
+
+            X11_XSetWMProperties(display, xwindow, NULL, NULL, NULL, 0, NULL, NULL, classhints);
+            X11_XFree(classhints);
+        }
+
         X11_XFree(titleprop.value);
     } else {
         return SDL_SetError("Failed to convert title to UTF8! Bad encoding, or bad Xorg encoding? Window title: «%s»", title);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Currently on linux, the "taskbar window title" aka the X11 class property (`WM_CLASS`) is pulled from the executable name - which is reasonable but there is no way for clients to change it.

Moreover, when making SDL calls from another language, for example Python, the python interpreter itself gets detected as the executable. This means that when opening a window in SDL called through Python, the window title will be according to the `SDL_CreateWindow` command, but the taskbar title will just be the Python interpreter. 

This also stops calls to set window icon from propagating correctly to the taskbar. No matter how the window icon changes, the taskbar icon will always be the python logo.

Proposed change is whenever the window title is set, to also change the `WM_CLASS`, updating the taskbar title to the current window title. 

## Description

Whenever the window title is set/changed, the x11 `WM_CLASS` is also changed to match.

## Existing Issue(s)
https://github.com/py-sdl/py-sdl2/issues/268