### PR TITLE
Fixed GetResamplerAvailableOutputFrames

### DIFF
--- a/src/audio/SDL_audiocvt.c
+++ b/src/audio/SDL_audiocvt.c
@@ -54,7 +54,7 @@ static Sint64 GetResampleRate(const int src_rate, const int dst_rate)
 
 static size_t GetResamplerAvailableOutputFrames(const size_t input_frames, const Sint64 resample_rate, const Sint64 resample_offset)
 {
-    const Sint64 output_frames = ((((Sint64)input_frames << 32) - resample_offset - 1) / resample_rate) + 1;
+    const Sint64 output_frames = (((Sint64)input_frames << 32) - resample_offset + resample_rate - 1) / resample_rate;
 
     return (size_t) SDL_max(output_frames, 0);
 }


### PR DESCRIPTION
Non-euclidean division is a pain.

## Existing Issue(s)
#8155
