### PR TITLE
Audio fixes and randmem test argument

### DIFF
--- a/include/SDL3/SDL_test_memory.h
+++ b/include/SDL3/SDL_test_memory.h
@@ -42,7 +42,14 @@ extern "C" {
  *
  * \note This should be called before any other SDL functions for complete tracking coverage
  */
-int SDLTest_TrackAllocations(void);
+void SDLTest_TrackAllocations(void);
+
+/**
+ * \brief Fill allocations with random data
+ *
+ * \note This implicitly calls SDLTest_TrackAllocations()
+ */
+void SDLTest_RandFillAllocations();
 
 /**
  * \brief Print a log of any outstanding allocations

--- a/src/audio/SDL_audiocvt.c
+++ b/src/audio/SDL_audiocvt.c
@@ -205,7 +205,7 @@ static void SDL_TARGETING("sse") ResampleFrame_SSE(const float* src, float* dst,
 
     int i, chan = 0;
 
-    for (; chan + 4 <= chans; chan++) {
+    for (; chan + 4 <= chans; chan += 4) {
         f0 = _mm_setzero_ps();
 
         for (i = 0; i < RESAMPLER_SAMPLES_PER_FRAME; i++) {

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -25,6 +25,7 @@
 static const char *common_usage[] = {
     "[-h | --help]",
     "[--trackmem]",
+    "[--randmem]",
     "[--log all|error|system|audio|video|render|input]",
 };
 
@@ -95,7 +96,8 @@ SDLTest_CommonState *SDLTest_CommonCreateState(char **argv, Uint32 flags)
     for (i = 1; argv[i]; ++i) {
         if (SDL_strcasecmp(argv[i], "--trackmem") == 0) {
             SDLTest_TrackAllocations();
-            break;
+        } else if (SDL_strcasecmp(argv[i], "--randmem") == 0) {
+            SDLTest_RandFillAllocations();
         }
     }
 
@@ -167,6 +169,10 @@ int SDLTest_CommonArg(SDLTest_CommonState *state, int index)
         return -1;
     }
     if (SDL_strcasecmp(argv[index], "--trackmem") == 0) {
+        /* Already handled in SDLTest_CommonCreateState() */
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--randmem") == 0) {
         /* Already handled in SDLTest_CommonCreateState() */
         return 1;
     }

--- a/test/testautomation_audio.c
+++ b/test/testautomation_audio.c
@@ -811,7 +811,7 @@ static int audio_resampleLoss(void *arg)
   int max_channels = 1 /*8*/;
   int num_channels = min_channels;
 
-  for (spec_idx = 0; test_specs[spec_idx].time > 0; ++num_channels) {
+  for (spec_idx = 0; test_specs[spec_idx].time > 0;) {
     const struct test_spec_t *spec = &test_specs[spec_idx];
     const int frames_in = spec->time * spec->rate_in;
     const int frames_target = spec->time * spec->rate_out;
@@ -832,11 +832,6 @@ static int audio_resampleLoss(void *arg)
     double sum_squared_error = 0;
     double sum_squared_value = 0;
     double signal_to_noise = 0;
-   
-    if (num_channels > max_channels) {
-        num_channels = 1;
-        ++spec_idx;
-    }
 
     SDLTest_AssertPass("Test resampling of %i s %i Hz %f phase sine wave from sampling rate of %i Hz to %i Hz",
                        spec->time, spec->freq, spec->phase, spec->rate_in, spec->rate_out);
@@ -928,6 +923,11 @@ static int audio_resampleLoss(void *arg)
                         signal_to_noise, spec->signal_to_noise);
     SDLTest_AssertCheck(max_error <= spec->max_error, "Maximum conversion error %f should be no more than %f.",
                         max_error, spec->max_error);
+       
+    if (++num_channels > max_channels) {
+        num_channels = min_channels;
+        ++spec_idx;
+    }
   }
 
   return TEST_COMPLETED;

--- a/test/testautomation_audio.c
+++ b/test/testautomation_audio.c
@@ -717,6 +717,9 @@ static int audio_convertAudio(void *arg)
                             return TEST_ABORTED;
                         }
 
+                        real_dst_len = SDL_GetAudioStreamAvailable(stream);
+                        SDLTest_AssertCheck(0 == real_dst_len, "Verify available (pre-put); expected: %i; got: %i", 0, real_dst_len);
+
                         /* Run the audio converter */
                         if (SDL_PutAudioStreamData(stream, src_buf, src_len) < 0 ||
                                 SDL_FlushAudioStream(stream) < 0) {
@@ -724,7 +727,7 @@ static int audio_convertAudio(void *arg)
                         }
 
                         real_dst_len = SDL_GetAudioStreamAvailable(stream);
-                        SDLTest_AssertCheck(dst_len == real_dst_len, "Verify available; expected: %i; got: %i", dst_len, real_dst_len);
+                        SDLTest_AssertCheck(dst_len == real_dst_len, "Verify available (post-put); expected: %i; got: %i", dst_len, real_dst_len);
 
                         real_dst_len = SDL_GetAudioStreamData(stream, dst_buf, dst_len);
                         SDLTest_AssertCheck(dst_len == real_dst_len, "Verify result value; expected: %i; got: %i", dst_len, real_dst_len);
@@ -732,9 +735,12 @@ static int audio_convertAudio(void *arg)
                             return TEST_ABORTED;
                         }
 
+                        real_dst_len = SDL_GetAudioStreamAvailable(stream);
+                        SDLTest_AssertCheck(0 == real_dst_len, "Verify available (post-get); expected: %i; got: %i", 0, real_dst_len);
+
                         dst_silence = SDL_GetSilenceValueForFormat(spec2.format);
 
-                        for (m = 0; m < real_dst_len; ++m) {
+                        for (m = 0; m < dst_len; ++m) {
                             if (dst_buf[m] != dst_silence) {
                                 SDLTest_LogError("Output buffer is not silent");
                                 return TEST_ABORTED;


### PR DESCRIPTION
A small collection of audio-related fixes, plus added the `--randmem` argument to hopefully make finding uninitialized data issues easier.

## Existing Issue(s)
#8164