### PR TITLE
metal: Add hint to select low power device instead of the default one

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -1489,6 +1489,17 @@ extern "C" {
 #define SDL_HINT_RENDER_VSYNC               "SDL_RENDER_VSYNC"
 
 /**
+ *  \brief  A variable controlling whether the Metal render driver select low power device over default one
+ *
+ *  This variable can be set to the following values:
+ *    "0"       - Use the prefered OS device
+ *    "1"       - Select a low power one
+ *
+ *  By default the prefered OS device is used.
+ */
+#define SDL_HINT_RENDER_METAL_PREFER_LOW_POWER_DEVICE "SDL_RENDER_METAL_PREFER_LOW_POWER_DEVICE"
+
+/**
  *  \brief  A variable controlling if VSYNC is automatically disable if doesn't reach the enough FPS
  *
  *  This variable can be set to the following values:
@@ -2499,16 +2510,6 @@ extern "C" {
  */
 #define SDL_HINT_GDK_TEXTINPUT_MAX_LENGTH "SDL_GDK_TEXTINPUT_MAX_LENGTH"
 
-/**
- *  \brief  A variable controlling whether the Metal render driver select low power device over default one
- *
- *  This variable can be set to the following values:
- *    "0"       - Use the prefered OS device
- *    "1"       - Select a low power one
- *
- *  By default the prefered OS device is used.
- */
-#define SDL_HINT_METAL_PREFER_LOW_POWER_DEVICE "SDL_METAL_PREFER_LOW_POWER_DEVICE"
 
 /**
  *  \brief  An enumeration of hint priorities

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2499,6 +2499,16 @@ extern "C" {
  */
 #define SDL_HINT_GDK_TEXTINPUT_MAX_LENGTH "SDL_GDK_TEXTINPUT_MAX_LENGTH"
 
+/**
+ *  \brief  A variable controlling whether the Metal render driver select low power device over default one
+ *
+ *  This variable can be set to the following values:
+ *    "0"       - Use the prefered OS device
+ *    "1"       - Select a low power one
+ *
+ *  By default the prefered OS device is used.
+ */
+#define SDL_HINT_METAL_PREFER_LOW_POWER_DEVICE "SDL_METAL_PREFER_LOW_POWER_DEVICE"
 
 /**
  *  \brief  An enumeration of hint priorities

--- a/src/render/metal/SDL_render_metal.m
+++ b/src/render/metal/SDL_render_metal.m
@@ -1755,7 +1755,7 @@ static SDL_Renderer *METAL_CreateRenderer(SDL_Window *window, Uint32 flags)
         }
 
 #ifdef __MACOS__
-        if (SDL_GetHintBoolean(SDL_HINT_METAL_PREFER_LOW_POWER_DEVICE, SDL_TRUE)) {
+        if (SDL_GetHintBoolean(SDL_HINT_RENDER_METAL_PREFER_LOW_POWER_DEVICE, SDL_TRUE)) {
             NSArray<id<MTLDevice>> *devices = MTLCopyAllDevices();
 
             for (id<MTLDevice> device in devices) {

--- a/src/render/metal/SDL_render_metal.m
+++ b/src/render/metal/SDL_render_metal.m
@@ -1754,8 +1754,20 @@ static SDL_Renderer *METAL_CreateRenderer(SDL_Window *window, Uint32 flags)
             return NULL;
         }
 
-        // !!! FIXME: MTLCopyAllDevices() can find other GPUs on macOS...
-        mtldevice = MTLCreateSystemDefaultDevice();
+        if (SDL_GetHintBoolean(SDL_HINT_METAL_PREFER_LOW_POWER_DEVICE, SDL_TRUE)) {
+            NSArray<id<MTLDevice>> *devices = MTLCopyAllDevices();
+
+            for (id<MTLDevice> device in devices) {
+                if (device.isLowPower) {
+                    mtldevice = device;
+                    break;
+                }
+            }
+        }
+
+        if (mtldevice == nil) {
+            mtldevice = MTLCreateSystemDefaultDevice();
+        }
 
         if (mtldevice == nil) {
             SDL_free(renderer);

--- a/src/render/metal/SDL_render_metal.m
+++ b/src/render/metal/SDL_render_metal.m
@@ -1754,6 +1754,7 @@ static SDL_Renderer *METAL_CreateRenderer(SDL_Window *window, Uint32 flags)
             return NULL;
         }
 
+#ifdef __MACOS__
         if (SDL_GetHintBoolean(SDL_HINT_METAL_PREFER_LOW_POWER_DEVICE, SDL_TRUE)) {
             NSArray<id<MTLDevice>> *devices = MTLCopyAllDevices();
 
@@ -1764,6 +1765,7 @@ static SDL_Renderer *METAL_CreateRenderer(SDL_Window *window, Uint32 flags)
                 }
             }
         }
+#endif
 
         if (mtldevice == nil) {
             mtldevice = MTLCreateSystemDefaultDevice();


### PR DESCRIPTION
Metal API allow device selection based on capabilities.
Low power consumption is one of them and in some case like video rendering (e.g. ffplay) a low power device is enough for display.
This PR add a hint to ask for a low power device.
If no such device respect the hint, the default device is selected as before.

## Description
On some system like MacBook Pro Intel with AMD card, asking for the default device will always return the AMD GPU.
This is not an issue for 99% of the case when the renderer context is here to provide the maximum performance level like for game.
However, for video application using GPU for 1 quad and 1 texture, using the discrete GPU for that lead to an important power consumption (4 to 8W), heat increase, and fan noise.
With this patch, I successfully amend ffplay to only use the integrated GPU (i.e. the Intel one), instead of the discrete GPU (i.e. the AMD one).


