### PR TITLE
wayland: don't define SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_* macro's

### DIFF
--- a/src/video/wayland/SDL_waylanddyn.c
+++ b/src/video/wayland/SDL_waylanddyn.c
@@ -34,34 +34,29 @@ typedef struct
     const char *libname;
 } waylanddynlib;
 
-#ifndef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_EGL
-#define SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_EGL NULL
-#endif
-#ifndef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_CURSOR
-#define SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_CURSOR NULL
-#endif
-#ifndef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_XKBCOMMON
-#define SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_XKBCOMMON NULL
-#endif
-#ifndef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_LIBDECOR
-#define SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_LIBDECOR NULL
-#endif
-
 static waylanddynlib waylandlibs[] = {
+#ifdef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_EGL
     { NULL, SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC },
-    { NULL, SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_EGL },
+#endif
+#ifdef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_CURSOR
     { NULL, SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_CURSOR },
+#endif
+#ifdef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_XKBCOMMON
     { NULL, SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_XKBCOMMON },
-    { NULL, SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_LIBDECOR }
+#endif
+#ifdef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_LIBDECOR
+    { NULL, SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_LIBDECOR },
+#endif
+    { NULL, NULL }
 };
 
 static void *WAYLAND_GetSym(const char *fnname, int *pHasModule, SDL_bool required)
 {
-    int i;
     void *fn = NULL;
-    for (i = 0; i < SDL_TABLESIZE(waylandlibs); i++) {
-        if (waylandlibs[i].lib != NULL) {
-            fn = SDL_LoadFunction(waylandlibs[i].lib, fnname);
+    waylanddynlib *dynlib;
+    for (dynlib = waylandlibs; dynlib->libname; dynlib++) {
+        if (dynlib->lib != NULL) {
+            fn = SDL_LoadFunction(dynlib->lib, fnname);
             if (fn != NULL) {
                 break;
             }
@@ -69,10 +64,11 @@ static void *WAYLAND_GetSym(const char *fnname, int *pHasModule, SDL_bool requir
     }
 
 #if DEBUG_DYNAMIC_WAYLAND
-    if (fn != NULL)
-        SDL_Log("WAYLAND: Found '%s' in %s (%p)\n", fnname, waylandlibs[i].libname, fn);
-    else
+    if (fn != NULL) {
+        SDL_Log("WAYLAND: Found '%s' in %s (%p)\n", fnname, dynlib->libname, fn);
+    } else {
         SDL_Log("WAYLAND: Symbol '%s' NOT FOUND!\n", fnname);
+    }
 #endif
 
     if (fn == NULL && required) {


### PR DESCRIPTION
These defines mess with `#ifdef` conditionals in headers

Fixes #8183