### PR TITLE
Fix flickering of window when using desktop-fullscreen and borderless…

### DIFF
--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -604,8 +604,14 @@ int X11_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window)
         return SDL_SetError("Couldn't create window");
     }
 
-    SetWindowBordered(display, screen, w,
-                      !(window->flags & SDL_WINDOW_BORDERLESS));
+    /* Do not set borderless window if in desktop fullscreen, this causes
+       flickering in multi-monitor setups */
+    if (!((window->pending_flags & SDL_WINDOW_FULLSCREEN) &&
+          (window->flags & SDL_WINDOW_BORDERLESS) &&
+          !window->fullscreen_exclusive)) {
+        SetWindowBordered(display, screen, w,
+                          !(window->flags & SDL_WINDOW_BORDERLESS));
+    }
 
     sizehints = X11_XAllocSizeHints();
     /* Setup the normal size hints */


### PR DESCRIPTION
… window on multiple monitors on Linux.  Closes #8186.

## Description
On X11, do not set borderless window state when in desktop friendly fullscreen and borderless window is set as this causes constant flickering on multi-monitor setups.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/8186
