### PR TITLE
wayland: Ensure that the toplevel window is recreated when switching …

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -855,11 +855,10 @@ static void handle_configure_zxdg_decoration(void *data,
         WAYLAND_wl_display_roundtrip(driverdata->waylandData->display);
 
         Wayland_HideWindow(device, window);
+        SDL_zero(driverdata->shell_surface);
         driverdata->shell_surface_type = WAYLAND_SURFACE_LIBDECOR;
 
-        if (!window->is_hiding && !(window->flags & SDL_WINDOW_HIDDEN)) {
-            Wayland_ShowWindow(device, window);
-        }
+        Wayland_ShowWindow(device, window);
     }
 }
 


### PR DESCRIPTION
…decoration modes

If a compositor tries to change the decoration mode when initially creating a window, the hidden flag might not yet be unset if the decoration mode is changed during the initial roundtrip in Wayland_ShowWindow(). As hiding the window destroys the decoration manager object, the hidden flag check is unnecessary, as the decoration configuration listener will never be entered when the window is hidden.

Fixes #8173 
