### PR TITLE
wikiheaders.pl: create Unsupported.md file with list of functions undocumented in either the headers or the wiki

### DIFF
--- a/build-scripts/wikiheaders.pl
+++ b/build-scripts/wikiheaders.pl
@@ -792,6 +792,45 @@ while (my $d = readdir(DH)) {
 }
 closedir(DH);
 
+delete $wikifuncs{"Undocumented"};
+
+{
+    my $path = "$wikipath/Undocumented.md";
+    open(FH, '>', $path) or die("Can't open '$path': $!\n");
+
+    print FH "# Undocumented\n\n";
+
+    print FH "## Functions defined in the headers, but not in the wiki\n\n";
+    my $header_only_func = 0;
+    foreach (keys %headerfuncs) {
+        my $fn = $_;
+        if (not defined $wikifuncs{$fn}) {
+            print FH "- [$fn]($fn)\n";
+            $header_only_func = 1;
+        }
+    }
+    if (!$header_only_func) {
+        print FH "(none)\n";
+    }
+    print FH "\n";
+
+    print FH "## Functions defined in the wiki, but not in the headers\n\n";
+
+    my $wiki_only_func = 0;
+    foreach (keys %wikifuncs) {
+        my $fn = $_;
+        if (not defined $headerfuncs{$fn}) {
+            print FH "- [$fn]($fn)\n";
+            $wiki_only_func = 1;
+        }
+    }
+    if (!$wiki_only_func) {
+        print FH "(none)\n";
+    }
+    print FH "\n";
+
+    close(FH);
+}
 
 if ($warn_about_missing) {
     foreach (keys %wikifuncs) {


### PR DESCRIPTION
Implements [this suggestion](https://github.com/libsdl-org/SDL_mixer/pull/552#issuecomment-1708302299) by @icculus 

> What if, instead of printing warnings, it generates a wiki page called "Undocumented.md" that updates on each run? That way we would have a public list of things that lack documentation.

I've kept the `warn_about_missing` option alone, so you can still run the perl script with `--warn-about-missing`.

## Description

For SDL3, this will generate `Undocumented.md` with the following contents:

<details>

<summary>Undocumented.md</summary>

```
# Undocumented

## Functions defined in the headers, but not in the wiki

- [SDL_calloc](SDL_calloc)
- [SDL_ulltoa](SDL_ulltoa)
- [SDL_wcslen](SDL_wcslen)
- [SDL_strtoul](SDL_strtoul)
- [SDL_atoi](SDL_atoi)
- [SDL_strtoull](SDL_strtoull)
- [SDL_wcsnlen](SDL_wcsnlen)
- [SDL_asinf](SDL_asinf)
- [SDL_fabsf](SDL_fabsf)
- [SDL_expf](SDL_expf)
- [SDL_strncasecmp](SDL_strncasecmp)
- [SDL_truncf](SDL_truncf)
- [SDL_strcasecmp](SDL_strcasecmp)
- [SDL_acosf](SDL_acosf)
- [SDL_OnApplicationWillResignActive](SDL_OnApplicationWillResignActive)
- [SDL_exp](SDL_exp)
- [SDL_strlcpy](SDL_strlcpy)
- [SDL_sin](SDL_sin)
- [SDL_isdigit](SDL_isdigit)
- [SDL_memset4](SDL_memset4)
- [SDL_round](SDL_round)
- [SDL_vsscanf](SDL_vsscanf)
- [SDL_copysignf](SDL_copysignf)
- [SDL_strrchr](SDL_strrchr)
- [SDL_strdup](SDL_strdup)
- [SDL_sinf](SDL_sinf)
- [SDL_isupper](SDL_isupper)
- [SDL_ispunct](SDL_ispunct)
- [SDL_wcsstr](SDL_wcsstr)
- [SDL_free](SDL_free)
- [SDL_atan2](SDL_atan2)
- [SDL_logf](SDL_logf)
- [SDL_memcpy](SDL_memcpy)
- [SDL_islower](SDL_islower)
- [SDL_snprintf](SDL_snprintf)
- [SDL_fmod](SDL_fmod)
- [SDL_log](SDL_log)
- [SDL_sqrtf](SDL_sqrtf)
- [SDL_strlcat](SDL_strlcat)
- [SDL_atan](SDL_atan)
- [SDL_realloc](SDL_realloc)
- [SDL_bsearch](SDL_bsearch)
- [SDL_vswprintf](SDL_vswprintf)
- [SDL_wcstol](SDL_wcstol)
- [SDL_qsort](SDL_qsort)
- [SDL_ultoa](SDL_ultoa)
- [SDL_ltoa](SDL_ltoa)
- [SDL_copysign](SDL_copysign)
- [SDL_strupr](SDL_strupr)
- [SDL_strncmp](SDL_strncmp)
- [SDL_OnApplicationDidEnterBackground](SDL_OnApplicationDidEnterBackground)
- [SDL_isprint](SDL_isprint)
- [SDL_sscanf](SDL_sscanf)
- [SDL_memmove](SDL_memmove)
- [SDL_log10f](SDL_log10f)
- [SDL_asprintf](SDL_asprintf)
- [SDL_lroundf](SDL_lroundf)
- [SDL_strcasestr](SDL_strcasestr)
- [SDL_isalpha](SDL_isalpha)
- [SDL_scalbn](SDL_scalbn)
- [SDL_iconv](SDL_iconv)
- [SDL_floorf](SDL_floorf)
- [SDL_strcmp](SDL_strcmp)
- [SDL_DuplicateSurface](SDL_DuplicateSurface)
- [SDL_memset](SDL_memset)
- [SDL_modff](SDL_modff)
- [SDL_ceil](SDL_ceil)
- [SDL_strtok_r](SDL_strtok_r)
- [SDL_utf8strlen](SDL_utf8strlen)
- [SDL_memcmp](SDL_memcmp)
- [SDL_uitoa](SDL_uitoa)
- [SDL_log10](SDL_log10)
- [SDL_strrev](SDL_strrev)
- [SDL_toupper](SDL_toupper)
- [SDL_wcsncmp](SDL_wcsncmp)
- [SDL_OnApplicationDidReceiveMemoryWarning](SDL_OnApplicationDidReceiveMemoryWarning)
- [SDL_sqrt](SDL_sqrt)
- [SDL_isalnum](SDL_isalnum)
- [SDL_strtol](SDL_strtol)
- [SDL_strchr](SDL_strchr)
- [SDL_fmodf](SDL_fmodf)
- [SDL_crc16](SDL_crc16)
- [SDL_tolower](SDL_tolower)
- [SDL_floor](SDL_floor)
- [SDL_asin](SDL_asin)
- [SDL_isblank](SDL_isblank)
- [SDL_atof](SDL_atof)
- [SDL_itoa](SDL_itoa)
- [SDL_swprintf](SDL_swprintf)
- [SDL_iscntrl](SDL_iscntrl)
- [SDL_utf8strlcpy](SDL_utf8strlcpy)
- [SDL_isgraph](SDL_isgraph)
- [SDL_vsnprintf](SDL_vsnprintf)
- [SDL_crc32](SDL_crc32)
- [SDL_wcscmp](SDL_wcscmp)
- [SDL_OnApplicationDidChangeStatusBarOrientation](SDL_OnApplicationDidChangeStatusBarOrientation)
- [SDL_cosf](SDL_cosf)
- [SDL_tan](SDL_tan)
- [SDL_fabs](SDL_fabs)
- [SDL_tanf](SDL_tanf)
- [SDL_cos](SDL_cos)
- [SDL_strndup](SDL_strndup)
- [SDL_roundf](SDL_roundf)
- [SDL_wcsncasecmp](SDL_wcsncasecmp)
- [SDL_isxdigit](SDL_isxdigit)
- [SDL_wcscasecmp](SDL_wcscasecmp)
- [SDL_wcslcpy](SDL_wcslcpy)
- [SDL_powf](SDL_powf)
- [SDL_utf8strnlen](SDL_utf8strnlen)
- [SDL_setenv](SDL_setenv)
- [SDL_lltoa](SDL_lltoa)
- [SDL_pow](SDL_pow)
- [SDL_getenv](SDL_getenv)
- [SDL_strtoll](SDL_strtoll)
- [SDL_OnApplicationWillEnterForeground](SDL_OnApplicationWillEnterForeground)
- [SDL_OnApplicationDidBecomeActive](SDL_OnApplicationDidBecomeActive)
- [SDL_strnlen](SDL_strnlen)
- [SDL_ceilf](SDL_ceilf)
- [SDL_MemoryBarrierAcquireFunction](SDL_MemoryBarrierAcquireFunction)
- [SDL_modf](SDL_modf)
- [SDL_atan2f](SDL_atan2f)
- [SDL_strlen](SDL_strlen)
- [SDL_abs](SDL_abs)
- [SDL_lround](SDL_lround)
- [SDL_malloc](SDL_malloc)
- [SDL_wcslcat](SDL_wcslcat)
- [SDL_scalbnf](SDL_scalbnf)
- [SDL_OnApplicationWillTerminate](SDL_OnApplicationWillTerminate)
- [SDL_strstr](SDL_strstr)
- [SDL_atanf](SDL_atanf)
- [SDL_strlwr](SDL_strlwr)
- [SDL_trunc](SDL_trunc)
- [SDL_strtod](SDL_strtod)
- [SDL_isspace](SDL_isspace)
- [SDL_wcsdup](SDL_wcsdup)
- [SDL_vasprintf](SDL_vasprintf)
- [SDL_iconv_close](SDL_iconv_close)
- [SDL_iconv_open](SDL_iconv_open)

## Functions defined in the wiki, but not in the headers

(none)
```

</details>

## Existing Issue(s)

