### PR TITLE
[SDL3] render: Enable clipping for zero-sized rectangles

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -2534,7 +2534,7 @@ int SDL_SetRenderClipRect(SDL_Renderer *renderer, const SDL_Rect *rect)
     int retval;
     CHECK_RENDERER_MAGIC(renderer, -1)
 
-    if (rect && rect->w > 0 && rect->h > 0) {
+    if (rect && rect->w >= 0 && rect->h >= 0) {
         renderer->view->clipping_enabled = SDL_TRUE;
         renderer->view->clip_rect.x = rect->x;
         renderer->view->clip_rect.y = rect->y;


### PR DESCRIPTION
Battle for Wesnoth apparently relies on being able to disable rendering of UI elements by setting the clip rectangle to be empty.

Resolves: https://github.com/libsdl-org/SDL/issues/6896
Fixes: 00f05dcf "render: only enable clipping when the rectangle is valid"

---

Untested, but it seems to be what commenters on #6896 are asking for.

@lukegrahamSydney, if your game is using SDL 3, please try this and confirm whether it fixes whatever issue you are seeing? Or if your game is using SDL 2, please test #8229 instead.