### PR TITLE
[SDL2] render: Enable clipping for zero-sized rectangles

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -2481,7 +2481,7 @@ int SDL_RenderSetClipRect(SDL_Renderer *renderer, const SDL_Rect *rect)
     int retval;
     CHECK_RENDERER_MAGIC(renderer, -1)
 
-    if (rect && rect->w > 0 && rect->h > 0) {
+    if (rect && rect->w >= 0 && rect->h >= 0) {
         renderer->clipping_enabled = SDL_TRUE;
         renderer->clip_rect.x = (double)rect->x * renderer->scale.x;
         renderer->clip_rect.y = (double)rect->y * renderer->scale.y;


### PR DESCRIPTION
Battle for Wesnoth apparently relies on being able to disable rendering of UI elements by setting the clip rectangle to be empty.

Resolves: https://github.com/libsdl-org/SDL/issues/6896
Fixes: 00f05dcf "render: only enable clipping when the rectangle is valid"

---

SDL 2 version of #8228, which doesn't cherry-pick trivially to SDL 2 since adjacent code has changed. Untested, but it seems to be what commenters on https://github.com/libsdl-org/SDL/issues/6896 are asking for.

@Pentarctagon, please could you confirm whether a SDL 2 with this change fixes the GUI issues you see in Wesnoth?

@lukegrahamSydney, if your game is using SDL 2, same question for your game? Or if your game is using SDL 3, please test #8228 instead.