### PR TITLE
main: Added _optional_ callback entry points.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,6 +475,7 @@ sdl_glob_sources(
   "${SDL3_SOURCE_DIR}/src/hidapi/*.c"
   "${SDL3_SOURCE_DIR}/src/libm/*.c"
   "${SDL3_SOURCE_DIR}/src/locale/*.c"
+  "${SDL3_SOURCE_DIR}/src/main/*.c"
   "${SDL3_SOURCE_DIR}/src/misc/*.c"
   "${SDL3_SOURCE_DIR}/src/power/*.c"
   "${SDL3_SOURCE_DIR}/src/render/*.c"
@@ -1383,6 +1384,9 @@ elseif(EMSCRIPTEN)
   # project. Uncomment at will for verbose cross-compiling -I/../ path info.
   sdl_compile_options(PRIVATE "-Wno-warn-absolute-paths")
 
+  sdl_glob_sources("${SDL3_SOURCE_DIR}/src/main/emscripten/*.c")
+  set(HAVE_SDL_MAIN_CALLBACKS TRUE)
+
   if(SDL_MISC)
     sdl_glob_sources("${SDL3_SOURCE_DIR}/src/misc/emscripten/*.c")
     set(HAVE_SDL_MISC TRUE)
@@ -2033,6 +2037,8 @@ elseif(WINDOWS)
 elseif(APPLE)
   # TODO: rework this all for proper macOS, iOS and Darwin support
 
+  # !!! FIXME: all the `if(IOS OR TVOS OR VISIONOS)` checks should get merged into one variable, so we're ready for the next platform (or just WatchOS).
+
   # We always need these libs on macOS at the moment.
   # !!! FIXME: we need Carbon for some very old API calls in
   # !!! FIXME:  src/video/cocoa/SDL_cocoakeyboard.c, but we should figure out
@@ -2043,6 +2049,12 @@ elseif(APPLE)
   endif()
   set(SDL_FRAMEWORK_FOUNDATION 1)
   set(SDL_FRAMEWORK_COREVIDEO 1)
+
+  # iOS can use a CADisplayLink for main callbacks. macOS just uses the generic one atm.
+  if(IOS OR TVOS OR VISIONOS)
+    sdl_glob_sources("${SDL3_SOURCE_DIR}/src/main/ios/*.m")
+    set(HAVE_SDL_MAIN_CALLBACKS TRUE)
+  endif()
 
   # Requires the darwin file implementation
   if(SDL_FILE)
@@ -2801,6 +2813,11 @@ endif()
 if(NOT HAVE_SDL_TIMERS)
   set(SDL_TIMER_DUMMY 1)
   sdl_glob_sources("${SDL3_SOURCE_DIR}/src/timer/dummy/*.c")
+endif()
+
+# Most platforms use this.
+if(NOT HAVE_SDL_MAIN_CALLBACKS)
+  sdl_glob_sources("${SDL3_SOURCE_DIR}/src/main/generic/*.c")
 endif()
 
 # config variables may contain generator expression, so we need to generate SDL_build_config.h in 2 steps:

--- a/VisualC-GDK/SDL/SDL.vcxproj
+++ b/VisualC-GDK/SDL/SDL.vcxproj
@@ -418,6 +418,7 @@
     <ClInclude Include="..\..\src\libm\math_libm.h" />
     <ClInclude Include="..\..\src\libm\math_private.h" />
     <ClInclude Include="..\..\src\locale\SDL_syslocale.h" />
+    <ClInclude Include="..\..\src\main\SDL_main_callbacks.h" />
     <ClInclude Include="..\..\src\misc\SDL_sysurl.h" />
     <ClInclude Include="..\..\src\power\SDL_syspower.h" />
     <ClInclude Include="..\..\src\render\direct3d11\SDL_shaders_d3d11.h" />
@@ -468,6 +469,8 @@
       <PrecompiledHeaderOutputFile Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Desktop.x64'">$(IntDir)$(TargetName)_cpp.pch</PrecompiledHeaderOutputFile>
       <PrecompiledHeaderOutputFile Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Desktop.x64'">$(IntDir)$(TargetName)_cpp.pch</PrecompiledHeaderOutputFile>
     </ClCompile>
+    <ClCompile Include="..\..\src\main\generic\SDL_sysmain_callbacks.c" />
+    <ClCompile Include="..\..\src\main\SDL_main_callbacks.c" />
     <ClCompile Include="..\..\src\SDL_guid.c" />
     <ClInclude Include="..\..\src\SDL_hashtable.h" />
     <ClInclude Include="..\..\src\SDL_hints_c.h" />

--- a/VisualC-GDK/SDL/SDL.vcxproj.filters
+++ b/VisualC-GDK/SDL/SDL.vcxproj.filters
@@ -175,6 +175,12 @@
     <Filter Include="video\gdk">
       <UniqueIdentifier>{3ad16a8a-0ed8-439c-a771-383af2e2867f}</UniqueIdentifier>
     </Filter>
+    <Filter Include="main">
+      <UniqueIdentifier>{00002ddb6c5ea921181bf32d50e40000}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="main\generic">
+      <UniqueIdentifier>{00000a808f8ba6b489985f82a4e80000}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\SDL3\SDL_begin_code.h">
@@ -398,6 +404,9 @@
     </ClInclude>
     <ClInclude Include="..\..\include\SDL3\SDL_vulkan.h">
       <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\SDL_main_callbacks.h">
+      <Filter>main</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\SDL_error_c.h" />
     <ClInclude Include="..\..\src\SDL_hashtable.h" />
@@ -846,6 +855,12 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\audio\wasapi\SDL_wasapi.c" />
+    <ClCompile Include="..\..\src\main\generic\SDL_sysmain_callbacks.c">
+      <Filter>main\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\SDL_main_callbacks.c">
+      <Filter>main</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\SDL.c" />
     <ClCompile Include="..\..\src\SDL_assert.c" />
     <ClCompile Include="..\..\src\SDL_error.c" />

--- a/VisualC-WinRT/SDL-UWP.vcxproj
+++ b/VisualC-WinRT/SDL-UWP.vcxproj
@@ -133,6 +133,7 @@
     <ClInclude Include="..\src\joystick\windows\SDL_windowsjoystick_c.h" />
     <ClInclude Include="..\src\joystick\windows\SDL_xinputjoystick_c.h" />
     <ClInclude Include="..\src\locale\SDL_syslocale.h" />
+    <ClInclude Include="..\src\main\SDL_main_callbacks.h" />
     <ClInclude Include="..\src\render\direct3d11\SDL_render_winrt.h" />
     <ClInclude Include="..\src\render\direct3d11\SDL_shaders_d3d11.h" />
     <ClInclude Include="..\src\render\opengles2\SDL_gles2funcs.h" />
@@ -337,6 +338,8 @@
     <ClCompile Include="..\src\loadso\windows\SDL_sysloadso.c" />
     <ClCompile Include="..\src\locale\SDL_locale.c" />
     <ClCompile Include="..\src\locale\winrt\SDL_syslocale.c" />
+    <ClCompile Include="..\src\main\generic\SDL_sysmain_callbacks.c" />
+    <ClCompile Include="..\src\main\SDL_main_callbacks.c" />
     <ClCompile Include="..\src\misc\SDL_url.c" />
     <ClCompile Include="..\src\misc\winrt\SDL_sysurl.cpp">
       <CompileAsWinRT>true</CompileAsWinRT>

--- a/VisualC-WinRT/SDL-UWP.vcxproj.filters
+++ b/VisualC-WinRT/SDL-UWP.vcxproj.filters
@@ -7,6 +7,12 @@
     <Filter Include="Source Files">
       <UniqueIdentifier>{68e1b30b-19ed-4612-93e4-6260c5a979e5}</UniqueIdentifier>
     </Filter>
+    <Filter Include="main">
+      <UniqueIdentifier>{00004a2523fc69c7128c60648c860000}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="main\generic">
+      <UniqueIdentifier>{0000318d975e0a2867ab1d5727bf0000}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\SDL3\SDL_begin_code.h">
@@ -269,6 +275,9 @@
     </ClInclude>
     <ClInclude Include="..\src\joystick\windows\SDL_xinputjoystick_c.h">
       <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\main\SDL_main_callbacks.h">
+      <Filter>main</Filter>
     </ClInclude>
     <ClInclude Include="..\src\render\direct3d11\SDL_render_winrt.h">
       <Filter>Source Files</Filter>
@@ -587,6 +596,12 @@
     </ClCompile>
     <ClCompile Include="..\src\loadso\windows\SDL_sysloadso.c">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\main\generic\SDL_sysmain_callbacks.c">
+      <Filter>main\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\main\SDL_main_callbacks.c">
+      <Filter>main</Filter>
     </ClCompile>
     <ClCompile Include="..\src\power\SDL_power.c">
       <Filter>Source Files</Filter>

--- a/VisualC/SDL/SDL.vcxproj
+++ b/VisualC/SDL/SDL.vcxproj
@@ -368,6 +368,7 @@
     <ClInclude Include="..\..\src\libm\math_libm.h" />
     <ClInclude Include="..\..\src\libm\math_private.h" />
     <ClInclude Include="..\..\src\locale\SDL_syslocale.h" />
+    <ClInclude Include="..\..\src\main\SDL_main_callbacks.h" />
     <ClInclude Include="..\..\src\misc\SDL_sysurl.h" />
     <ClInclude Include="..\..\src\power\SDL_syspower.h" />
     <ClInclude Include="..\..\src\render\direct3d11\SDL_shaders_d3d11.h" />
@@ -397,6 +398,8 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="..\..\src\main\generic\SDL_sysmain_callbacks.c" />
+    <ClCompile Include="..\..\src\main\SDL_main_callbacks.c" />
     <ClCompile Include="..\..\src\SDL_guid.c" />
     <ClInclude Include="..\..\src\SDL_hashtable.h" />
     <ClInclude Include="..\..\src\SDL_hints_c.h" />

--- a/VisualC/SDL/SDL.vcxproj.filters
+++ b/VisualC/SDL/SDL.vcxproj.filters
@@ -169,6 +169,12 @@
     <Filter Include="render\direct3d12">
       <UniqueIdentifier>{f48c2b17-1bee-4fec-a7c8-24cf619abe08}</UniqueIdentifier>
     </Filter>
+    <Filter Include="main">
+      <UniqueIdentifier>{00001967ea2801028a046a722a070000}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="main\generic">
+      <UniqueIdentifier>{0000ddc7911820dbe64274d3654f0000}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\SDL3\SDL_begin_code.h">
@@ -389,6 +395,9 @@
     </ClInclude>
     <ClInclude Include="..\..\include\SDL3\SDL_vulkan.h">
       <Filter>API Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\SDL_main_callbacks.h">
+      <Filter>main</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\SDL_error_c.h" />
     <ClInclude Include="..\..\src\SDL_hashtable.h" />
@@ -828,6 +837,12 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\audio\wasapi\SDL_wasapi.c" />
+    <ClCompile Include="..\..\src\main\generic\SDL_sysmain_callbacks.c">
+      <Filter>main\generic</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\SDL_main_callbacks.c">
+      <Filter>main</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\SDL.c" />
     <ClCompile Include="..\..\src\SDL_assert.c" />
     <ClCompile Include="..\..\src\SDL_error.c" />

--- a/Xcode/SDL/SDL.xcodeproj/project.pbxproj
+++ b/Xcode/SDL/SDL.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 
 /* Begin PBXBuildFile section */
 		000040E76FDC6AE48CBF0000 /* SDL_hashtable.c in Sources */ = {isa = PBXBuildFile; fileRef = 000078E1881E857EBB6C0000 /* SDL_hashtable.c */; };
+		0000A4DA2F45A31DC4F00000 /* SDL_sysmain_callbacks.m in Sources */ = {isa = PBXBuildFile; fileRef = 0000BB287BA0A0178C1A0000 /* SDL_sysmain_callbacks.m */; platformFilters = (ios, maccatalyst, macos, tvos, watchos, ); };
 		007317A40858DECD00B2BC32 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0073179D0858DECD00B2BC32 /* Cocoa.framework */; platformFilters = (macos, ); };
 		007317A60858DECD00B2BC32 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0073179F0858DECD00B2BC32 /* IOKit.framework */; platformFilters = (ios, maccatalyst, macos, ); };
 		00CFA89D106B4BA100758660 /* ForceFeedback.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00CFA89C106B4BA100758660 /* ForceFeedback.framework */; platformFilters = (macos, ); };
@@ -476,6 +477,8 @@
 		F3F7D9E12933074E00816151 /* SDL_begin_code.h in Headers */ = {isa = PBXBuildFile; fileRef = F3F7D8E72933074E00816151 /* SDL_begin_code.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F3F7D9E52933074E00816151 /* SDL_system.h in Headers */ = {isa = PBXBuildFile; fileRef = F3F7D8E82933074E00816151 /* SDL_system.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FA73671D19A540EF004122E4 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA73671C19A540EF004122E4 /* CoreVideo.framework */; platformFilters = (ios, maccatalyst, macos, tvos, watchos, ); };
+		000028F8113A53F4333E0000 /* SDL_main_callbacks.c in Sources */ = {isa = PBXBuildFile; fileRef = 00009366FB9FBBD54C390000 /* SDL_main_callbacks.c */; };
+		0000C3B22D46279F99170000 /* SDL_main_callbacks.h in Headers */ = {isa = PBXBuildFile; fileRef = 00003260407E1002EAC10000 /* SDL_main_callbacks.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -504,6 +507,7 @@
 /* Begin PBXFileReference section */
 		000078E1881E857EBB6C0000 /* SDL_hashtable.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = SDL_hashtable.c; sourceTree = "<group>"; };
 		0000B6ADCD88CAD6610F0000 /* SDL_hashtable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDL_hashtable.h; sourceTree = "<group>"; };
+		0000BB287BA0A0178C1A0000 /* SDL_sysmain_callbacks.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDL_sysmain_callbacks.m; sourceTree = "<group>"; };
 		0073179D0858DECD00B2BC32 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		0073179F0858DECD00B2BC32 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		007317C10858E15000B2BC32 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
@@ -977,6 +981,8 @@
 		F59C710600D5CB5801000001 /* SDL.info */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text; path = SDL.info; sourceTree = "<group>"; };
 		F5A2EF3900C6A39A01000001 /* BUGS.txt */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text; name = BUGS.txt; path = ../../BUGS.txt; sourceTree = SOURCE_ROOT; };
 		FA73671C19A540EF004122E4 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
+		00009366FB9FBBD54C390000 /* SDL_main_callbacks.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = SDL_main_callbacks.c; path = SDL_main_callbacks.c; sourceTree = "<group>"; };
+		00003260407E1002EAC10000 /* SDL_main_callbacks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SDL_main_callbacks.h; path = SDL_main_callbacks.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1002,6 +1008,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		000082EF09C89B62BD840000 /* main */ = {
+			isa = PBXGroup;
+			children = (
+				00008B5A0CB83D2069E80000 /* ios */,
+				00009366FB9FBBD54C390000 /* SDL_main_callbacks.c */,
+				00003260407E1002EAC10000 /* SDL_main_callbacks.h */,
+			);
+			path = main;
+			sourceTree = "<group>";
+		};
+		00008B5A0CB83D2069E80000 /* ios */ = {
+			isa = PBXGroup;
+			children = (
+				0000BB287BA0A0178C1A0000 /* SDL_sysmain_callbacks.m */,
+			);
+			path = ios;
+			sourceTree = "<group>";
+		};
 		0153844A006D81B07F000001 /* Public Headers */ = {
 			isa = PBXGroup;
 			children = (
@@ -1122,6 +1146,7 @@
 				A7D8A91123E2514000DCD162 /* libm */,
 				A7D8A85D23E2513F00DCD162 /* loadso */,
 				566E26CB246274AE00718109 /* locale */,
+				000082EF09C89B62BD840000 /* main */,
 				5616CA47252BB278005D5928 /* misc */,
 				A7D8A7DF23E2513F00DCD162 /* power */,
 				A7D8A8DA23E2514000DCD162 /* render */,
@@ -2614,6 +2639,8 @@
 				A7D8AB6123E2514100DCD162 /* SDL_offscreenwindow.c in Sources */,
 				566E26D8246274CC00718109 /* SDL_locale.c in Sources */,
 				000040E76FDC6AE48CBF0000 /* SDL_hashtable.c in Sources */,
+				0000A4DA2F45A31DC4F00000 /* SDL_sysmain_callbacks.m in Sources */,
+				000028F8113A53F4333E0000 /* SDL_main_callbacks.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2531,6 +2531,22 @@ extern "C" {
  */
 #define SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES "SDL_AUDIO_DEVICE_SAMPLE_FRAMES"
 
+
+/**
+ * Request SDL_AppIterate() be called at a specific rate.
+ *
+ * This number is in Hz, so "60" means try to iterate 60 times per second.
+ *
+ * On some platforms, or if you are using SDL_main instead of SDL_AppIterate,
+ * this hint is ignored. When the hint can be used, it is allowed to be
+ * changed at any time.
+ *
+ * This defaults to 60, and specifying NULL for the hint's value will restore
+ * the default.
+ */
+#define SDL_HINT_MAIN_CALLBACK_RATE "SDL_MAIN_CALLBACK_RATE"
+
+
 /**
  *  \brief  An enumeration of hint priorities
  */

--- a/include/SDL3/SDL_main.h
+++ b/include/SDL3/SDL_main.h
@@ -159,11 +159,8 @@ typedef void (SDLCALL *SDL_AppQuit_func)(void);
 /**
  *  The prototypes for the application's callbacks.
  *  These functions are to be supplied by the app instead of an
- *  SDL_main function if they've defined SDL_MAIN_USE_CALLBACKS
- *  before including SDL_main.h (but the SDL_main magic might
- *  still get used below internally, if we're emulating a callback
- *  mainloop on platforms that don't support it natively, but in that
- *  case we'll provide SDL_main, not the app.
+ *  SDL_main function, if they've defined SDL_MAIN_USE_CALLBACKS
+ *  before including SDL_main.h.
  */
 extern SDLMAIN_DECLSPEC int SDLCALL SDL_AppInit(int argc, char *argv[]);
 extern SDLMAIN_DECLSPEC int SDLCALL SDL_AppIterate(void);

--- a/include/SDL3/SDL_main.h
+++ b/include/SDL3/SDL_main.h
@@ -144,16 +144,15 @@
 #define main    SDL_main
 #endif
 
-#include <SDL3/SDL_events.h>
-
 #include <SDL3/SDL_begin_code.h>
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+union SDL_Event;
 typedef int (SDLCALL *SDL_AppInit_func)(int argc, char *argv[]);
 typedef int (SDLCALL *SDL_AppIterate_func)(void);
-typedef int (SDLCALL *SDL_AppEvent_func)(const SDL_Event *event);
+typedef int (SDLCALL *SDL_AppEvent_func)(const union SDL_Event *event);
 typedef void (SDLCALL *SDL_AppQuit_func)(void);
 
 #ifdef SDL_MAIN_USE_CALLBACKS

--- a/include/SDL3/SDL_main_impl.h
+++ b/include/SDL3/SDL_main_impl.h
@@ -41,6 +41,30 @@
 #  undef main
 #endif /* main */
 
+#ifdef SDL_MAIN_USE_CALLBACKS
+
+#if 0
+    /* currently there are no platforms that _need_ a magic entry point here
+       for callbacks, but if one shows up, implement it here. */
+
+#else /* use a standard SDL_main, which the app SHOULD NOT ALSO SUPPLY. */
+
+/* this define makes the normal SDL_main entry point stuff work...we just provide SDL_main() instead of the app. */
+#define SDL_MAIN_CALLBACK_STANDARD 1
+
+int SDL_main(int argc, char **argv)
+{
+    return SDL_EnterAppMainCallbacks(argc, argv, SDL_AppInit, SDL_AppIterate, SDL_AppEvent, SDL_AppQuit);
+}
+
+#endif  /* platform-specific tests */
+
+#endif  /* SDL_MAIN_USE_CALLBACKS */
+
+
+/* set up the usual SDL_main stuff if we're not using callbacks or if we are but need the normal entry point. */
+#if !defined(SDL_MAIN_USE_CALLBACKS) || defined(SDL_MAIN_CALLBACK_STANDARD)
+
 #if defined(__WIN32__) || defined(__GDK__)
 
 /* these defines/typedefs are needed for the WinMain() definition */
@@ -192,6 +216,8 @@ int main(int argc, char *argv[])
 /* end of impls for standard-conforming platforms */
 
 #endif /* __WIN32__ etc */
+
+#endif /* !defined(SDL_MAIN_USE_CALLBACKS) || defined(SDL_MAIN_CALLBACK_STANDARD) */
 
 /* rename users main() function to SDL_main() so it can be called from the wrappers above */
 #define main    SDL_main

--- a/include/SDL3/SDL_test_common.h
+++ b/include/SDL3/SDL_test_common.h
@@ -201,14 +201,26 @@ SDL_bool SDLTest_CommonInit(SDLTest_CommonState *state);
 SDL_bool SDLTest_CommonDefaultArgs(SDLTest_CommonState *state, const int argc, char **argv);
 
 /**
- * \brief Common event handler for test windows.
+ * Common event handler for test windows if you use a standard SDL_main.
+ *
+ * This will free data from the event, like the string in a drop event!
  *
  * \param state The common state used to create test window.
  * \param event The event to handle.
  * \param done Flag indicating we are done.
- *
  */
 void SDLTest_CommonEvent(SDLTest_CommonState *state, SDL_Event *event, int *done);
+
+/**
+ * Common event handler for test windows if you use SDL_AppEvent.
+ *
+ * This does _not_ free anything in `event`.
+ *
+ * \param state The common state used to create test window.
+ * \param event The event to handle.
+ * \returns Value suitable for returning from SDL_AppEvent().
+ */
+int SDLTest_CommonEventMainCallbacks(SDLTest_CommonState *state, const SDL_Event *event);
 
 /**
  * \brief Close test window.

--- a/src/dynapi/SDL_dynapi.sym
+++ b/src/dynapi/SDL_dynapi.sym
@@ -920,6 +920,7 @@ SDL3_0.0.0 {
     SDL_GetSurfaceProperties;
     SDL_GetWindowProperties;
     SDL_ClearProperty;
+    SDL_EnterAppMainCallbacks;
     # extra symbols go here (don't modify this line)
   local: *;
 };

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -945,3 +945,4 @@
 #define SDL_GetSurfaceProperties SDL_GetSurfaceProperties_REAL
 #define SDL_GetWindowProperties SDL_GetWindowProperties_REAL
 #define SDL_ClearProperty SDL_ClearProperty_REAL
+#define SDL_EnterAppMainCallbacks SDL_EnterAppMainCallbacks_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -977,3 +977,4 @@ SDL_DYNAPI_PROC(SDL_PropertiesID,SDL_GetSensorProperties,(SDL_Sensor *a),(a),ret
 SDL_DYNAPI_PROC(SDL_PropertiesID,SDL_GetSurfaceProperties,(SDL_Surface *a),(a),return)
 SDL_DYNAPI_PROC(SDL_PropertiesID,SDL_GetWindowProperties,(SDL_Window *a),(a),return)
 SDL_DYNAPI_PROC(int,SDL_ClearProperty,(SDL_PropertiesID a, const char *b),(a,b),return)
+SDL_DYNAPI_PROC(int,SDL_EnterAppMainCallbacks,(int a, char *b[], SDL_AppInit_func c, SDL_AppIterate_func d, SDL_AppEvent_func e, SDL_AppQuit_func f),(a,b,c,d,e,f),return)

--- a/src/main/SDL_main_callbacks.c
+++ b/src/main/SDL_main_callbacks.c
@@ -44,6 +44,14 @@ int SDL_InitMainCallbacks(int argc, char* argv[], SDL_AppInit_func appinit, SDL_
 
     const int rc = appinit(argc, argv);
     if (SDL_AtomicCAS(&apprc, 0, rc) && (rc == 0)) {  // bounce if SDL_AppInit already said abort, otherwise...
+        // make sure we definitely have events initialized, even if the app didn't do it.
+        if (!SDL_WasInit(SDL_INIT_EVENTS)) {
+            if (SDL_Init(SDL_INIT_EVENTS) == -1) {
+                SDL_AtomicSet(&apprc, -1);
+                return -1;
+            }
+        }
+
         // drain any initial events that might have arrived before we added a watcher.
         SDL_Event event;
         SDL_Event *pending_events = NULL;

--- a/src/main/SDL_main_callbacks.c
+++ b/src/main/SDL_main_callbacks.c
@@ -35,11 +35,11 @@ static int SDLCALL EventWatcher(void *userdata, SDL_Event *event)
     return 0;
 }
 
-int SDL_InitMainCallbacks(int argc, char* argv[], SDL_AppInit_func appinit, SDL_AppIterate_func _appiter, SDL_AppEvent_func _appevent, SDL_AppQuit_func _appquit)
+int SDL_InitMainCallbacks(int argc, char* argv[], SDL_AppInit_func appinit, SDL_AppIterate_func appiter, SDL_AppEvent_func appevent, SDL_AppQuit_func appquit)
 {
-    SDL_main_iteration_callback = _appiter;
-    SDL_main_event_callback = _appevent;
-    SDL_main_quit_callback = _appquit;
+    SDL_main_iteration_callback = appiter;
+    SDL_main_event_callback = appevent;
+    SDL_main_quit_callback = appquit;
     SDL_AtomicSet(&apprc, 0);
 
     const int rc = appinit(argc, argv);

--- a/src/main/SDL_main_callbacks.c
+++ b/src/main/SDL_main_callbacks.c
@@ -45,11 +45,9 @@ int SDL_InitMainCallbacks(int argc, char* argv[], SDL_AppInit_func appinit, SDL_
     const int rc = appinit(argc, argv);
     if (SDL_AtomicCAS(&apprc, 0, rc) && (rc == 0)) {  // bounce if SDL_AppInit already said abort, otherwise...
         // make sure we definitely have events initialized, even if the app didn't do it.
-        if (!SDL_WasInit(SDL_INIT_EVENTS)) {
-            if (SDL_Init(SDL_INIT_EVENTS) == -1) {
-                SDL_AtomicSet(&apprc, -1);
-                return -1;
-            }
+        if (SDL_Init(SDL_INIT_EVENTS) == -1) {
+            SDL_AtomicSet(&apprc, -1);
+            return -1;
         }
 
         // drain any initial events that might have arrived before we added a watcher.

--- a/src/main/SDL_main_callbacks.c
+++ b/src/main/SDL_main_callbacks.c
@@ -1,0 +1,98 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2023 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include "SDL_internal.h"
+#include "SDL_main_callbacks.h"
+
+static SDL_AppEvent_func appevent;
+static SDL_AppIterate_func appiter;
+static SDL_AppQuit_func appquit;
+static SDL_AtomicInt apprc;  // use an atomic, since events might land from any thread and we don't want to wrap this all in a mutex. A CAS makes sure we only move from zero once.
+
+static int SDLCALL EventWatcher(void *userdata, SDL_Event *event)
+{
+    if (SDL_AtomicGet(&apprc) == 0) {  // if already quitting, don't send the event to the app.
+        SDL_AtomicCAS(&apprc, 0, appevent(event));
+    }
+    return 0;
+}
+
+int SDL_InitMainCallbacks(int argc, char* argv[], SDL_AppInit_func appinit, SDL_AppIterate_func _appiter, SDL_AppEvent_func _appevent, SDL_AppQuit_func _appquit)
+{
+    appiter = _appiter;
+    appevent = _appevent;
+    appquit = _appquit;
+    SDL_AtomicSet(&apprc, 0);
+
+    const int rc = appinit(argc, argv);
+    if (SDL_AtomicCAS(&apprc, 0, rc) && (rc == 0)) {  // bounce if SDL_AppInit already said abort, otherwise...
+        // drain any initial events that might have arrived before we added a watcher.
+        SDL_Event event;
+        SDL_Event *pending_events = NULL;
+        int total_pending_events = 0;
+        while (SDL_PollEvent(&event)) {
+            void *ptr = SDL_realloc(pending_events, sizeof (SDL_Event) * (total_pending_events + 1));
+            if (!ptr) {
+                SDL_OutOfMemory();
+                SDL_free(pending_events);
+                SDL_AtomicSet(&apprc, -1);
+                return -1;
+            }
+            pending_events = (SDL_Event *) ptr;
+            SDL_copyp(&pending_events[total_pending_events], &event);
+            total_pending_events++;
+        }
+
+        SDL_AddEventWatch(EventWatcher, NULL);  // !!! FIXME: this should really return an error.
+
+        for (int i = 0; i < total_pending_events; i++) {
+            SDL_PushEvent(&pending_events[i]);
+        }
+
+        SDL_free(pending_events);
+    }
+
+    return SDL_AtomicGet(&apprc);
+}
+
+int SDL_IterateMainCallbacks(void)
+{
+    SDL_Event event;
+    while (SDL_PollEvent(&event)) {
+        // just empty the queue, EventWatcher sends the events to the app.
+        // !!! FIXME: free dropfile, etc event data.
+    }
+
+    int rc = appiter();
+    if (!SDL_AtomicCAS(&apprc, 0, rc)) {
+        rc = SDL_AtomicGet(&apprc);  // something else already set a quit result, keep that.
+    }
+
+    return rc;
+}
+
+void SDL_QuitMainCallbacks(void)
+{
+    SDL_DelEventWatch(EventWatcher, NULL);
+    appquit();
+    SDL_Quit();
+}
+

--- a/src/main/SDL_main_callbacks.c
+++ b/src/main/SDL_main_callbacks.c
@@ -45,7 +45,7 @@ int SDL_InitMainCallbacks(int argc, char* argv[], SDL_AppInit_func appinit, SDL_
     const int rc = appinit(argc, argv);
     if (SDL_AtomicCAS(&apprc, 0, rc) && (rc == 0)) {  // bounce if SDL_AppInit already said abort, otherwise...
         // make sure we definitely have events initialized, even if the app didn't do it.
-        if (SDL_Init(SDL_INIT_EVENTS) == -1) {
+        if (SDL_InitSubSystem(SDL_INIT_EVENTS) == -1) {
             SDL_AtomicSet(&apprc, -1);
             return -1;
         }
@@ -105,6 +105,10 @@ void SDL_QuitMainCallbacks(void)
 {
     SDL_DelEventWatch(EventWatcher, NULL);
     SDL_main_quit_callback();
+
+    // for symmetry, you should explicitly Quit what you Init, but we might come through here uninitialized and SDL_Quit() will clear everything anyhow.
+    //SDL_QuitSubSystem(SDL_INIT_EVENTS);
+
     SDL_Quit();
 }
 

--- a/src/main/SDL_main_callbacks.c
+++ b/src/main/SDL_main_callbacks.c
@@ -76,7 +76,8 @@ int SDL_InitMainCallbacks(int argc, char* argv[], SDL_AppInit_func appinit, SDL_
 int SDL_IterateMainCallbacks(void)
 {
     SDL_Event event;
-    while (SDL_PollEvent(&event)) {
+    SDL_PumpEvents();
+    while (SDL_PeepEvents(&event, 1, SDL_GETEVENT, SDL_EVENT_FIRST, SDL_EVENT_LAST) == 1) {
         // just empty the queue, EventWatcher sends the events to the app.
         switch (event.type) {
             case SDL_EVENT_DROP_FILE:

--- a/src/main/SDL_main_callbacks.c
+++ b/src/main/SDL_main_callbacks.c
@@ -78,7 +78,12 @@ int SDL_IterateMainCallbacks(void)
     SDL_Event event;
     while (SDL_PollEvent(&event)) {
         // just empty the queue, EventWatcher sends the events to the app.
-        // !!! FIXME: free dropfile, etc event data.
+        switch (event.type) {
+            case SDL_EVENT_DROP_FILE:
+            case SDL_EVENT_DROP_TEXT:
+                SDL_free(event.drop.file);
+                break;
+        }
     }
 
     int rc = appiter();

--- a/src/main/SDL_main_callbacks.h
+++ b/src/main/SDL_main_callbacks.h
@@ -1,0 +1,31 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2023 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDL_main_callbacks_h_
+#define SDL_main_callbacks_h_
+
+int SDL_InitMainCallbacks(int argc, char* argv[], SDL_AppInit_func appinit, SDL_AppIterate_func _appiter, SDL_AppEvent_func _appevent, SDL_AppQuit_func _appquit);
+int SDL_IterateMainCallbacks(void);
+void SDL_QuitMainCallbacks(void);
+
+#endif // SDL_main_callbacks_h_
+
+

--- a/src/main/emscripten/SDL_sysmain_callbacks.c
+++ b/src/main/emscripten/SDL_sysmain_callbacks.c
@@ -1,0 +1,47 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2023 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include "SDL_internal.h"
+#include "../SDL_main_callbacks.h"
+
+#include <emscripten.h>
+
+static void EmscriptenInternalMainloop(void)
+{
+    const int rc = SDL_IterateMainCallbacks();
+    if (rc != 0) {
+        SDL_QuitMainCallbacks();
+        emscripten_cancel_main_loop();  // kill" the mainloop, so it stops calling back into it.
+        exit((rc < 0) ? 1 : 0);  // hopefully this takes down everything else, too.
+    }
+}
+
+int SDL_EnterAppMainCallbacks(int argc, char* argv[], SDL_AppInit_func appinit, SDL_AppIterate_func appiter, SDL_AppEvent_func appevent, SDL_AppQuit_func appquit)
+{
+    const int rc = SDL_InitMainCallbacks(argc, argv, appinit, appiter, appevent, appquit);
+    if (rc == 0) {
+        emscripten_set_main_loop(EmscriptenInternalMainloop, 0, 0);  // run at refresh rate, don't throw an exception since we do an orderly return.
+    } else {
+        SDL_QuitMainCallbacks();
+    }
+    return (rc < 0) ? 1 : 0;
+}
+

--- a/src/main/generic/SDL_sysmain_callbacks.c
+++ b/src/main/generic/SDL_sysmain_callbacks.c
@@ -1,0 +1,80 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2023 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include "SDL_internal.h"
+#include "../SDL_main_callbacks.h"
+#include "../../video/SDL_sysvideo.h"
+
+static int callback_rate_increment = 0;
+
+static void SDLCALL MainCallbackRateHintChanged(void *userdata, const char *name, const char *oldValue, const char *newValue)
+{
+    const int callback_rate = newValue ? SDL_atoi(newValue) : 60;
+    if (callback_rate > 0) {
+        callback_rate_increment = ((Uint64) 1000000000) / ((Uint64) callback_rate);
+    } else {
+        callback_rate_increment = 0;
+    }
+}
+
+int SDL_EnterAppMainCallbacks(int argc, char* argv[], SDL_AppInit_func appinit, SDL_AppIterate_func appiter, SDL_AppEvent_func appevent, SDL_AppQuit_func appquit)
+{
+    int rc = SDL_InitMainCallbacks(argc, argv, appinit, appiter, appevent, appquit);
+
+    SDL_AddHintCallback(SDL_HINT_MAIN_CALLBACK_RATE, MainCallbackRateHintChanged, NULL);
+
+    Uint64 next_iteration = callback_rate_increment ? (SDL_GetTicksNS() + callback_rate_increment) : 0;
+
+    while ((rc = SDL_IterateMainCallbacks()) == 0) {
+        // !!! FIXME: this can be made more complicated if we decide to
+        // !!! FIXME: optionally hand off callback responsibility to the
+        // !!! FIXME: video subsystem (for example, if Wayland has a
+        // !!! FIXME: protocol to drive an animation loop, maybe we hand
+        // !!! FIXME: off to them here if/when the video subsystem becomes
+        // !!! FIXME: initialized).
+
+        // !!! FIXME: maybe respect this hint even if there _is_ a window.
+        // if there's no window, try to run at about 60fps (or whatever rate
+        //  the hint requested). This makes this not eat all the CPU in
+        //  simple things like loopwave. If there's a window, we run as fast
+        //  as possible, which means we'll clamp to vsync in common cases,
+        //  and won't be restrained to vsync if the app is doing a benchmark
+        //  or doesn't want to be, based on how they've set up that window.
+        if ((callback_rate_increment == 0) || SDL_HasWindows()) {
+            next_iteration = 0;  // just clear the timer and run at the pace the video subsystem allows.
+        } else {
+            const Uint64 now = SDL_GetTicksNS();
+            if (next_iteration > now) {  // Running faster than the limit, sleep a little.
+                SDL_DelayNS(next_iteration - now);
+            } else {
+                next_iteration = now;  // running behind (or just lost the window)...reset the timer.
+            }
+            next_iteration += callback_rate_increment;
+        }
+    }
+
+    SDL_DelHintCallback(SDL_HINT_MAIN_CALLBACK_RATE, MainCallbackRateHintChanged, NULL);
+
+    SDL_QuitMainCallbacks();
+
+    return (rc < 0) ? 1 : 0;
+}
+

--- a/src/main/ios/SDL_sysmain_callbacks.m
+++ b/src/main/ios/SDL_sysmain_callbacks.m
@@ -1,0 +1,82 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2023 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include "SDL_internal.h"
+#include "../SDL_main_callbacks.h"
+
+#ifdef __IOS__
+
+#import <UIKit/UIKit.h>
+
+@interface SDLIosMainCallbacksDisplayLink : NSObject
+@property(nonatomic, retain) CADisplayLink *displayLink;
+- (void)appIteration:(CADisplayLink *)sender;
+- (instancetype)init:(SDL_AppIterate_func)_appiter quitfunc:(SDL_AppQuit_func)_appquit;
+@end
+
+static SDLIosMainCallbacksDisplayLink *globalDisplayLink;
+
+@implementation SDLIosMainCallbacksDisplayLink
+
+- (instancetype)init:(SDL_AppIterate_func)_appiter quitfunc:(SDL_AppQuit_func)_appquit;
+{
+    if ((self = [super init])) {
+        self.displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(appIteration:)];
+        [self.displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+    }
+    return self;
+}
+
+- (void)appIteration:(CADisplayLink *)sender
+{
+    const int rc = SDL_IterateMainCallbacks();
+    if (rc != 0) {
+        [self.displayLink invalidate];
+        self.displayLink = nil;
+        globalDisplayLink = nil;
+        SDL_QuitMainCallbacks();
+        exit((rc < 0) ? 1 : 0);
+    }
+}
+@end
+
+// SDL_RunApp will land in UIApplicationMain, which calls SDL_main from postFinishLaunch, which calls this.
+// When we return from here, we're living in the RunLoop, and a CADisplayLink is firing regularly for us.
+int SDL_EnterAppMainCallbacks(int argc, char* argv[], SDL_AppInit_func appinit, SDL_AppIterate_func appiter, SDL_AppEvent_func appevent, SDL_AppQuit_func appquit)
+{
+    const int rc = SDL_InitMainCallbacks(argc, argv, appinit, appiter, appevent, appquit);
+    if (rc == 0) {
+        globalDisplayLink = [[SDLIosMainCallbacksDisplayLink alloc] init:appiter quitfunc:appquit];
+        if (globalDisplayLink != nil) {
+            return 0;  // this will fall all the way out of SDL_main, where UIApplicationMain will keep running the RunLoop.
+        }
+    }
+
+    // appinit requested quit, just bounce out now.
+    SDL_QuitMainCallbacks();
+    exit((rc < 0) ? 1 : 0);
+
+    return 1;  // just in case.
+}
+
+#endif
+
+

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1560,7 +1560,7 @@ static const char *GamepadButtonName(const SDL_GamepadButton button)
     }
 }
 
-static void SDLTest_PrintEvent(SDL_Event *event)
+static void SDLTest_PrintEvent(const SDL_Event *event)
 {
     switch (event->type) {
     case SDL_EVENT_SYSTEM_THEME_CHANGED:
@@ -2029,7 +2029,7 @@ static void FullscreenTo(SDLTest_CommonState *state, int index, int windowId)
     SDL_free(displays);
 }
 
-void SDLTest_CommonEvent(SDLTest_CommonState *state, SDL_Event *event, int *done)
+int SDLTest_CommonEventMainCallbacks(SDLTest_CommonState *state, const SDL_Event *event)
 {
     int i;
 
@@ -2408,20 +2408,27 @@ void SDLTest_CommonEvent(SDLTest_CommonState *state, SDL_Event *event, int *done
             }
             break;
         case SDLK_ESCAPE:
-            *done = 1;
-            break;
+            return 1;
         default:
             break;
         }
         break;
     }
     case SDL_EVENT_QUIT:
-        *done = 1;
-        break;
+        return 1;
+    }
 
+    return 0;  /* keep going */
+}
+
+void SDLTest_CommonEvent(SDLTest_CommonState *state, SDL_Event *event, int *done)
+{
+    *done = SDLTest_CommonEventMainCallbacks(state, event) ? 1 : 0;
+
+    switch (event->type) {
     case SDL_EVENT_DROP_FILE:
     case SDL_EVENT_DROP_TEXT:
-        SDL_free(event->drop.file);
+        SDL_free(event->drop.file);  // SDL frees these if you use SDL_AppEvent, not us, so explicitly handle it here.
         break;
     }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,11 +47,16 @@ if(WINDOWS_STORE)
     target_link_libraries(sdl_test_main_uwp PRIVATE SDL3::Headers)
     target_compile_options(sdl_test_main_uwp PRIVATE "/ZW")
 
+    add_library(sdl_test_main_callbacks_uwp OBJECT main.cpp)
+    target_link_libraries(sdl_test_main_callbacks_uwp PRIVATE SDL3::Headers)
+    target_compile_options(sdl_test_main_callbacks_uwp PRIVATE "/ZW")
+    target_compile_definitions(sdl_test_main_callbacks_uwp PRIVATE "SDL_MAIN_USE_CALLBACKS")
+
     set_source_files_properties(${RESOURCE_FILES} PROPERTIES VS_DEPLOYENT_LOCATION "Assets")
 endif()
 
 macro(add_sdl_test_executable TARGET)
-    cmake_parse_arguments(AST "BUILD_DEPENDENT;NONINTERACTIVE;NEEDS_RESOURCES;TESTUTILS;NO_C90" "" "NONINTERACTIVE_TIMEOUT;NONINTERACTIVE_ARGS;SOURCES" ${ARGN})
+    cmake_parse_arguments(AST "BUILD_DEPENDENT;NONINTERACTIVE;NEEDS_RESOURCES;TESTUTILS;NO_C90;MAIN_CALLBACKS" "" "NONINTERACTIVE_TIMEOUT;NONINTERACTIVE_ARGS;SOURCES" ${ARGN})
     if(AST_UNPARSED_ARGUMENTS)
         message(FATAL_ERROR "Unknown argument(s): ${AST_UNPARSED_ARGUMENTS}")
     endif()
@@ -73,8 +78,14 @@ macro(add_sdl_test_executable TARGET)
             TARGET "${TARGET}"
         )
         set_property(SOURCE "${uwp_bindir}/${TARGET}.appxmanifest" PROPERTY VS_DEPLOYMENT_CONTENT 1)
+
+        if(AST_MAIN_CALLBACKS)
+            list(APPEND EXTRA_SOURCES "$<TARGET_OBJECTS:sdl_test_main_callbacks_uwp>")
+        else()
+            list(APPEND EXTRA_SOURCES "$<TARGET_OBJECTS:sdl_test_main_uwp>")
+        endif()
+
         list(APPEND EXTRA_SOURCES
-            "$<TARGET_OBJECTS:sdl_test_main_uwp>"
             "${uwp_bindir}/${TARGET}.appxmanifest"
             "uwp/logo-50x50.png"
             "uwp/square-44x44.png"
@@ -213,7 +224,7 @@ endif()
 
 add_sdl_test_executable(checkkeys SOURCES checkkeys.c)
 add_sdl_test_executable(checkkeysthreads SOURCES checkkeysthreads.c)
-add_sdl_test_executable(loopwave NEEDS_RESOURCES TESTUTILS SOURCES loopwave.c)
+add_sdl_test_executable(loopwave NEEDS_RESOURCES TESTUTILS MAIN_CALLBACKS SOURCES loopwave.c)
 add_sdl_test_executable(testsurround SOURCES testsurround.c)
 add_sdl_test_executable(testresample NEEDS_RESOURCES SOURCES testresample.c)
 add_sdl_test_executable(testaudioinfo SOURCES testaudioinfo.c)
@@ -223,7 +234,7 @@ file(GLOB TESTAUTOMATION_SOURCE_FILES testautomation*.c)
 add_sdl_test_executable(testautomation NONINTERACTIVE NONINTERACTIVE_TIMEOUT 120 NEEDS_RESOURCES NO_C90 SOURCES ${TESTAUTOMATION_SOURCE_FILES})
 add_sdl_test_executable(testmultiaudio NEEDS_RESOURCES TESTUTILS SOURCES testmultiaudio.c)
 add_sdl_test_executable(testaudiohotplug NEEDS_RESOURCES TESTUTILS SOURCES testaudiohotplug.c)
-add_sdl_test_executable(testaudiocapture SOURCES testaudiocapture.c)
+add_sdl_test_executable(testaudiocapture MAIN_CALLBACKS SOURCES testaudiocapture.c)
 add_sdl_test_executable(testatomic NONINTERACTIVE SOURCES testatomic.c)
 add_sdl_test_executable(testintersections SOURCES testintersections.c)
 add_sdl_test_executable(testrelative SOURCES testrelative.c)
@@ -304,7 +315,7 @@ files2headers(gamepad_image_headers
 )
 files2headers(icon_bmp_header icon.bmp)
 
-add_sdl_test_executable(testaudio NEEDS_RESOURCES TESTUTILS SOURCES testaudio.c)
+add_sdl_test_executable(testaudio MAIN_CALLBACKS NEEDS_RESOURCES TESTUTILS SOURCES testaudio.c)
 add_sdl_test_executable(testfile NONINTERACTIVE SOURCES testfile.c)
 add_sdl_test_executable(testcontroller TESTUTILS SOURCES testcontroller.c gamepadutils.c ${gamepad_image_headers})
 add_sdl_test_executable(testgeometry TESTUTILS SOURCES testgeometry.c)
@@ -341,7 +352,7 @@ add_sdl_test_executable(testsem NONINTERACTIVE NONINTERACTIVE_ARGS 10 NONINTERAC
 add_sdl_test_executable(testsensor SOURCES testsensor.c)
 add_sdl_test_executable(testshader NEEDS_RESOURCES TESTUTILS SOURCES testshader.c)
 add_sdl_test_executable(testshape NEEDS_RESOURCES SOURCES testshape.c)
-add_sdl_test_executable(testsprite NEEDS_RESOURCES TESTUTILS SOURCES testsprite.c)
+add_sdl_test_executable(testsprite MAIN_CALLBACKS NEEDS_RESOURCES TESTUTILS SOURCES testsprite.c)
 add_sdl_test_executable(testspriteminimal SOURCES testspriteminimal.c ${icon_bmp_header})
 add_sdl_test_executable(teststreaming NEEDS_RESOURCES TESTUTILS SOURCES teststreaming.c)
 add_sdl_test_executable(testtimer NONINTERACTIVE NONINTERACTIVE_ARGS --no-interactive NONINTERACTIVE_TIMEOUT 60 SOURCES testtimer.c)

--- a/test/testaudiocapture.c
+++ b/test/testaudiocapture.c
@@ -31,6 +31,9 @@ int SDL_AppInit(int argc, char **argv)
     const char *devname = NULL;
     int i;
 
+    /* this doesn't have to run very much, so give up tons of CPU time between iterations. */
+    SDL_SetHint(SDL_HINT_MAIN_CALLBACK_RATE, "15");
+
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, 0);
     if (state == NULL) {
@@ -188,8 +191,6 @@ int SDL_AppIterate(void)
             return -1;   /* quit the app, report failure. */
         }
     }
-
-    SDL_Delay(10);  /* not a lot going on here, give up CPU time. */
 
     return 0;  /* keep app going. */
 }

--- a/test/testaudiocapture.c
+++ b/test/testaudiocapture.c
@@ -10,94 +10,20 @@
   freely.
 */
 
-#include <stdlib.h>
-
+#define SDL_MAIN_USE_CALLBACKS 1
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
 #include <SDL3/SDL_test.h>
-
-#ifdef __EMSCRIPTEN__
-#include <emscripten/emscripten.h>
-#endif
 
 static SDL_Window *window = NULL;
 static SDL_Renderer *renderer = NULL;
 static SDL_AudioStream *stream_in = NULL;
 static SDL_AudioStream *stream_out = NULL;
-static int done = 0;
+static SDLTest_CommonState *state = NULL;
 
-static void loop(void)
-{
-    const SDL_AudioDeviceID devid_in = SDL_GetAudioStreamDevice(stream_in);
-    const SDL_AudioDeviceID devid_out = SDL_GetAudioStreamDevice(stream_out);
-    SDL_bool please_quit = SDL_FALSE;
-    SDL_Event e;
-
-    while (SDL_PollEvent(&e)) {
-        if (e.type == SDL_EVENT_QUIT) {
-            please_quit = SDL_TRUE;
-        } else if (e.type == SDL_EVENT_KEY_DOWN) {
-            if (e.key.keysym.sym == SDLK_ESCAPE) {
-                please_quit = SDL_TRUE;
-            }
-        } else if (e.type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
-            if (e.button.button == 1) {
-                SDL_PauseAudioDevice(devid_out);
-                SDL_ResumeAudioDevice(devid_in);
-            }
-        } else if (e.type == SDL_EVENT_MOUSE_BUTTON_UP) {
-            if (e.button.button == 1) {
-                SDL_PauseAudioDevice(devid_in);
-                SDL_FlushAudioStream(stream_in);  /* so no samples are held back for resampling purposes. */
-                SDL_ResumeAudioDevice(devid_out);
-            }
-        }
-    }
-
-    if (!SDL_AudioDevicePaused(devid_in)) {
-        SDL_SetRenderDrawColor(renderer, 0, 255, 0, 255);
-    } else {
-        SDL_SetRenderDrawColor(renderer, 255, 0, 0, 255);
-    }
-    SDL_RenderClear(renderer);
-    SDL_RenderPresent(renderer);
-
-    /* Feed any new data we captured to the output stream. It'll play when we unpause the device. */
-    while (!please_quit && (SDL_GetAudioStreamAvailable(stream_in) > 0)) {
-        Uint8 buf[1024];
-        const int br = SDL_GetAudioStreamData(stream_in, buf, sizeof(buf));
-        if (br < 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to read from input audio stream: %s\n", SDL_GetError());
-            please_quit = 1;
-        } else if (SDL_PutAudioStreamData(stream_out, buf, br) < 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to write to output audio stream: %s\n", SDL_GetError());
-            please_quit = 1;
-        }
-    }
-
-    if (please_quit) {
-        /* stop playing back, quit. */
-        SDL_Log("Shutting down.\n");
-        SDL_CloseAudioDevice(devid_in);
-        SDL_CloseAudioDevice(devid_out);
-        SDL_DestroyAudioStream(stream_in);
-        SDL_DestroyAudioStream(stream_out);
-        SDL_DestroyRenderer(renderer);
-        SDL_DestroyWindow(window);
-        SDL_Quit();
-#ifdef __EMSCRIPTEN__
-        emscripten_cancel_main_loop();
-#endif
-        /* Let 'main()' return normally */
-        done = 1;
-        return;
-    }
-}
-
-int main(int argc, char **argv)
+int SDL_AppInit(int argc, char **argv)
 {
     SDL_AudioDeviceID *devices;
-    SDLTest_CommonState *state;
     SDL_AudioSpec outspec;
     SDL_AudioSpec inspec;
     SDL_AudioDeviceID device;
@@ -128,7 +54,7 @@ int main(int argc, char **argv)
         if (consumed <= 0) {
             static const char *options[] = { "[device_name]", NULL };
             SDLTest_CommonLogUsage(state, argv[0], options);
-            exit(1);
+            return -1;
         }
 
         i += consumed;
@@ -175,20 +101,17 @@ int main(int argc, char **argv)
     device = SDL_OpenAudioDevice(SDL_AUDIO_DEVICE_DEFAULT_OUTPUT, NULL);
     if (!device) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't open an audio device for playback: %s!\n", SDL_GetError());
-        SDL_Quit();
-        exit(1);
+        return -1;
     }
     SDL_PauseAudioDevice(device);
     SDL_GetAudioDeviceFormat(device, &outspec, NULL);
     stream_out = SDL_CreateAudioStream(&outspec, &outspec);
     if (!stream_out) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create an audio stream for playback: %s!\n", SDL_GetError());
-        SDL_Quit();
-        exit(1);
+        return -1;
     } else if (SDL_BindAudioStream(device, stream_out) == -1) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't bind an audio stream for playback: %s!\n", SDL_GetError());
-        SDL_Quit();
-        exit(1);
+        return -1;
     }
 
     SDL_Log("Opening capture device %s%s%s...\n",
@@ -199,38 +122,91 @@ int main(int argc, char **argv)
     device = SDL_OpenAudioDevice(want_device, NULL);
     if (!device) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't open an audio device for capture: %s!\n", SDL_GetError());
-        SDL_Quit();
-        exit(1);
+        return -1;
     }
     SDL_PauseAudioDevice(device);
     SDL_GetAudioDeviceFormat(device, &inspec, NULL);
     stream_in = SDL_CreateAudioStream(&inspec, &inspec);
     if (!stream_in) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create an audio stream for capture: %s!\n", SDL_GetError());
-        SDL_Quit();
-        exit(1);
+        return -1;
     } else if (SDL_BindAudioStream(device, stream_in) == -1) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't bind an audio stream for capture: %s!\n", SDL_GetError());
-        SDL_Quit();
-        exit(1);
+        return -1;
     }
 
     SDL_SetAudioStreamFormat(stream_in, NULL, &outspec);  /* make sure we output at the playback format. */
 
     SDL_Log("Ready! Hold down mouse or finger to record!\n");
 
-#ifdef __EMSCRIPTEN__
-    emscripten_set_main_loop(loop, 0, 1);
-#else
-    while (!done) {
-        loop();
-        if (!done) {
-            SDL_Delay(16);
-        }
-    }
-#endif
-
-    SDLTest_CommonDestroyState(state);
-
     return 0;
 }
+
+int SDL_AppEvent(const SDL_Event *event)
+{
+    if (event->type == SDL_EVENT_QUIT) {
+        return 1;  /* terminate as success. */
+    } else if (event->type == SDL_EVENT_KEY_DOWN) {
+        if (event->key.keysym.sym == SDLK_ESCAPE) {
+            return 1;  /* terminate as success. */
+        }
+    } else if (event->type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
+        if (event->button.button == 1) {
+            SDL_PauseAudioDevice(SDL_GetAudioStreamDevice(stream_out));
+            SDL_FlushAudioStream(stream_out);  /* so no samples are held back for resampling purposes. */
+            SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(stream_in));
+        }
+    } else if (event->type == SDL_EVENT_MOUSE_BUTTON_UP) {
+        if (event->button.button == 1) {
+            SDL_PauseAudioDevice(SDL_GetAudioStreamDevice(stream_in));
+            SDL_FlushAudioStream(stream_in);  /* so no samples are held back for resampling purposes. */
+            SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(stream_out));
+        }
+    }
+    return 0;  /* keep going. */
+}
+
+int SDL_AppIterate(void)
+{
+    if (!SDL_AudioDevicePaused(SDL_GetAudioStreamDevice(stream_in))) {
+        SDL_SetRenderDrawColor(renderer, 0, 255, 0, 255);
+    } else {
+        SDL_SetRenderDrawColor(renderer, 255, 0, 0, 255);
+    }
+    SDL_RenderClear(renderer);
+    SDL_RenderPresent(renderer);
+
+    /* Feed any new data we captured to the output stream. It'll play when we unpause the device. */
+    while (SDL_GetAudioStreamAvailable(stream_in) > 0) {
+        Uint8 buf[1024];
+        const int br = SDL_GetAudioStreamData(stream_in, buf, sizeof(buf));
+        if (br < 0) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to read from input audio stream: %s\n", SDL_GetError());
+            return -1;   /* quit the app, report failure. */
+        } else if (SDL_PutAudioStreamData(stream_out, buf, br) < 0) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to write to output audio stream: %s\n", SDL_GetError());
+            return -1;   /* quit the app, report failure. */
+        }
+    }
+
+    SDL_Delay(10);  /* not a lot going on here, give up CPU time. */
+
+    return 0;  /* keep app going. */
+}
+
+void SDL_AppQuit(void)
+{
+    SDL_Log("Shutting down.\n");
+    const SDL_AudioDeviceID devid_in = SDL_GetAudioStreamDevice(stream_in);
+    const SDL_AudioDeviceID devid_out = SDL_GetAudioStreamDevice(stream_out);
+    SDL_CloseAudioDevice(devid_in);  /* !!! FIXME: use SDL_OpenAudioDeviceStream instead so we can dump this. */
+    SDL_CloseAudioDevice(devid_out);
+    SDL_DestroyAudioStream(stream_in);
+    SDL_DestroyAudioStream(stream_out);
+    SDL_DestroyRenderer(renderer);
+    SDL_DestroyWindow(window);
+    SDLTest_CommonDestroyState(state);
+    SDL_Quit();
+}
+
+


### PR DESCRIPTION
**EDIT: updated this on 10/29/2023 with SDL_AppEvent details, etc.**

This lets apps optionally have a handful of callbacks for their entry points instead of a single `main` function. If used, the actual main/SDL_main/whatever entry point will be implemented in the single-header library SDL_main.h and the app will implement four separate functions:

First:

```c
int SDL_AppInit(int argc, char **argv);
```

This will be called _once_ before anything else. argc/argv work like they always do. If this returns 0, the app runs. If it returns < 0, the app calls SDL_AppQuit and terminates with an exit code that reports an error to the platform. If it returns > 0, the app calls SDL_AppQuit and terminates with an exit code that reports success to the platform. This function should not go into an infinite mainloop; it should do any one-time startup it requires and then return.

Then:

```c
int SDL_AppIterate(void);
```

This is called over and over, possibly at the refresh rate of the display or some other metric that the platform dictates. This is where the heart of your app runs. It should return as quickly as reasonably possible, but it's not a "run one memcpy and that's all the time you have" sort of thing. The app should do any game updates, and render a frame of video. If it returns < 0, SDL will call SDL_AppQuit and terminate the process with an exit code that reports an error to the platform. If it returns > 0, the app calls SDL_AppQuit and terminates with an exit code that reports success to the platform. If it returns 0, then SDL_AppIterate will be called again at some regular frequency. The platform may choose to run this more or less (perhaps less in the background, etc), or it might just call this function in a loop as fast as possible. You do not check the event queue in this function (SDL_AppEvent exists for that).

Next:

```c
int SDL_AppEvent(const SDL_Event *event);
```

This will be called once for each event pushed into the SDL queue. This may be called from any thread, and possibly in parallel to SDL_AppIterate. The fields in `event` do not need to be free'd (as you would normally need to do for SDL_EVENT_DROP_FILE, etc), and your app should not call SDL_PollEvent, SDL_PumpEvent, etc, as SDL will manage this for you. Return values are the same as from SDL_AppIterate(), so you can terminate in response to SDL_EVENT_QUIT, etc.


Finally:

```c
void SDL_AppQuit(void);
```

This is called once before terminating the app--assuming the app isn't being forcibly killed or crashed--as a last chance to clean up. After this returns, SDL will call SDL_Quit so the app doesn't have to (but it's safe for the app to call it, too). Process termination proceeds as if the app returned normally from main(), so atexit handles will run, if your platform supports that.

The app does _not_ implement SDL_main if using this. To turn this on, define `SDL_MAIN_USE_CALLBACKS` before including SDL_main.h. Defines like SDL_MAIN_HANDLED and SDL_MAIN_NOIMPL are also respected for callbacks, if the app wants to do some sort of magic main implementation thing.

In theory, on most platforms these can be implemented in the app itself, but this saves some `#ifdef`s in the app and lets everyone struggle less against some platforms, and might be more efficient in the long run, too.

On some platforms, it's possible this is the only reasonable way to go, but we haven't actually hit one that 100% requires it yet (but we will, if we want to write a RetroArch backend, for example).

Using the callback entry points works on every platform, because on platforms that don't require them, we can fake them with a simple loop in an internal implementation of the usual SDL_main.

The primary way we expect people to write SDL apps is with SDL_main, and this is not intended to replace it. If the app chooses to use this, it just removes some platform-specific details they might have to otherwise manage, and maybe removes a barrier to entry on some future platform.

This PR updates a few SDL test apps (loopwave, testaudio,  testsprite, and testaudiocapture) to use this; it nicely cleans up some ugliness! This doesn't change _all_ of the test apps, because we'd like to exercise both SDL_main approaches, and also, we don't want to give the idea that this is the _only_ way to write an SDL app.

Fixes #6785.
