### PR TITLE
x11: Always update clipboard owner

### DIFF
--- a/src/video/x11/SDL_x11clipboard.c
+++ b/src/video/x11/SDL_x11clipboard.c
@@ -92,9 +92,7 @@ static int SetSelectionData(SDL_VideoDevice *_this, Atom selection, SDL_Clipboar
     clipboard->mime_count = mime_count;
     clipboard->sequence = sequence;
 
-    if (!clipboard_owner) {
-        X11_XSetSelectionOwner(display, selection, window, CurrentTime);
-    }
+    X11_XSetSelectionOwner(display, selection, window, CurrentTime);
     return 0;
 }
 


### PR DESCRIPTION
Without this PR, if the clipboard is set multiple times from the same SDL application, clipboard managers fail to pick up the changes.

This should be cherry-picked for SDL2.

## Existing Issue(s)
lite-xl/lite-xl#1610