### PR TITLE
Support application/vnd.portal.filetransfer mime type for drag n drop

### DIFF
--- a/src/core/linux/SDL_dbus.h
+++ b/src/core/linux/SDL_dbus.h
@@ -101,6 +101,7 @@ extern SDL_bool SDL_DBus_ScreensaverInhibit(SDL_bool inhibit);
 
 extern void SDL_DBus_PumpEvents(void);
 extern char *SDL_DBus_GetLocalMachineId(void);
+extern char **SDL_DBus_GetPortalFilePaths(char *token, int *file_path_count);
 
 #endif /* HAVE_DBUS_DBUS_H */
 

--- a/src/video/wayland/SDL_waylanddatamanager.h
+++ b/src/video/wayland/SDL_waylanddatamanager.h
@@ -29,6 +29,7 @@
 
 #define TEXT_MIME "text/plain;charset=utf-8"
 #define FILE_MIME "text/uri-list"
+#define FILE_PORTAL_MIME "application/vnd.portal.filetransfer"
 
 typedef struct
 {


### PR DESCRIPTION
## Description
Allows a sandboxed SDL3 app to receive files from a drag and drop operation. Only works with files (which are not symlinked)

I don't know if this is the proper style of if I could those SDL_DBus functions, but this current implementation is working quite well.

#6368 