### PR TITLE
linux: Handle upower's UP_DEVICE_STATE_PENDING_CHARGE, PENDING_DISCHARGE

### DIFF
--- a/src/power/linux/SDL_syspower.c
+++ b/src/power/linux/SDL_syspower.c
@@ -561,9 +561,17 @@ static void check_upower_device(DBusConnection *conn, const char *path, SDL_Powe
             st = SDL_POWERSTATE_UNKNOWN; /* uh oh */
         } else if (ui32 == 1) {          /* 1 == charging */
             st = SDL_POWERSTATE_CHARGING;
-        } else if ((ui32 == 2) || (ui32 == 3)) { /* 2 == discharging, 3 == empty. */
+        } else if ((ui32 == 2) || (ui32 == 3) || (ui32 == 6)) {
+            /* 2 == discharging;
+             * 3 == empty;
+             * 6 == "pending discharge" which GNOME interprets as equivalent
+             * to discharging */
             st = SDL_POWERSTATE_ON_BATTERY;
-        } else if (ui32 == 4) { /* 4 == full */
+        } else if ((ui32 == 4) || (ui32 == 5)) {
+            /* 4 == full;
+             * 5 == "pending charge" which GNOME shows as "Not charging",
+             * used when a battery is configured to stop charging at a
+             * lower than 100% threshold */
             st = SDL_POWERSTATE_CHARGED;
         } else {
             st = SDL_POWERSTATE_UNKNOWN; /* uh oh */


### PR DESCRIPTION
On my laptop, the battery is configured to stop charging at around 80% most of the time, to increase the overall useful lifetime of the battery. When in that state, upower reports UP_DEVICE_STATE_PENDING_CHARGE (numeric value 5), which SDL previously mapped to SDL_POWERSTATE_UNKNOWN. This made the platform_testGetPowerInfo automated test fail, because it assumes that SDL_POWERSTATE_UNKNOWN means no battery is connected, and does not expect to see a percentage.

Map UP_DEVICE_STATE_PENDING_CHARGE (5) to SDL_POWERSTATE_CHARGED, which seems close enough.

Also map UP_DEVICE_STATE_PENDING_DISCHARGE (6) to
SDL_POWERSTATE_ON_BATTERY, which matches how at least GNOME presents it.