### PR TITLE
MMX code removal

### DIFF
--- a/src/video/SDL_blit_copy.c
+++ b/src/video/SDL_blit_copy.c
@@ -50,53 +50,6 @@ static SDL_INLINE void SDL_TARGETING("sse") SDL_memcpySSE(Uint8 *dst, const Uint
 }
 #endif /* SDL_SSE_INTRINSICS */
 
-#ifdef SDL_MMX_INTRINSICS
-#ifdef _MSC_VER
-#pragma warning(disable : 4799)
-#endif
-static SDL_INLINE void SDL_TARGETING("mmx") SDL_memcpyMMX(Uint8 *dst, const Uint8 *src, int len)
-{
-    int remain = len & 63;
-    int i;
-
-    __m64 *d64 = (__m64 *)dst;
-    __m64 *s64 = (__m64 *)src;
-
-    for (i = len / 64; i--;) {
-        d64[0] = s64[0];
-        d64[1] = s64[1];
-        d64[2] = s64[2];
-        d64[3] = s64[3];
-        d64[4] = s64[4];
-        d64[5] = s64[5];
-        d64[6] = s64[6];
-        d64[7] = s64[7];
-
-        d64 += 8;
-        s64 += 8;
-    }
-
-    if (remain) {
-        const int skip = len - remain;
-        dst += skip;
-        src += skip;
-        while (remain--) {
-            *dst++ = *src++;
-        }
-    }
-}
-
-static SDL_INLINE void SDL_TARGETING("mmx") SDL_BlitCopyMMX(Uint8 *dst, const Uint8 *src, const int dstskip, const int srcskip, const int w, int h)
-{
-    while (h--) {
-        SDL_memcpyMMX(dst, src, w);
-        src += srcskip;
-        dst += dstskip;
-    }
-    _mm_empty();
-}
-#endif /* SDL_MMX_INTRINSICS */
-
 void SDL_BlitCopy(SDL_BlitInfo *info)
 {
     SDL_bool overlap;
@@ -145,13 +98,6 @@ void SDL_BlitCopy(SDL_BlitInfo *info)
             src += srcskip;
             dst += dstskip;
         }
-        return;
-    }
-#endif
-
-#ifdef SDL_MMX_INTRINSICS
-    if (SDL_HasMMX() && !(srcskip & 7) && !(dstskip & 7)) {
-        SDL_BlitCopyMMX(dst, src, dstskip, srcskip, w, h);
         return;
     }
 #endif


### PR DESCRIPTION
This is a draft pull request to remove MMX code from SDL3.

There are only three places we use it. One of them is likely superfluous (SDL_BlitCopy), and I have removed it in this first commit. The other two appear like they would be good candidates for replacement with SSE versions, which will let us operate on twice as much data at a time (at least at first glance; I could be wrong).