### PR TITLE
wasapi: Deal with device failures when we aren't holding the device lock

### DIFF
--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -818,7 +818,9 @@ SDL_bool SDL_OutputAudioThreadIterate(SDL_AudioDevice *device)
     SDL_bool retval = SDL_TRUE;
     int buffer_size = device->buffer_size;
     Uint8 *device_buffer = current_audio.impl.GetDeviceBuf(device, &buffer_size);
-    if (!device_buffer) {
+    if (buffer_size == 0) {
+        // WASAPI (maybe others, later) does this to say "just abandon this iteration and try again next time."
+    } else if (!device_buffer) {
         retval = SDL_FALSE;
     } else {
         SDL_assert(buffer_size <= device->buffer_size);  // you can ask for less, but not more.

--- a/src/audio/wasapi/SDL_wasapi.h
+++ b/src/audio/wasapi/SDL_wasapi.h
@@ -41,12 +41,13 @@ struct SDL_PrivateAudioData
     SDL_bool coinitialized;
     int framesize;
     SDL_bool device_lost;
+    SDL_bool device_dead;
     void *activation_handler;
 };
 
 /* win32 and winrt implementations call into these. */
 int WASAPI_PrepDevice(SDL_AudioDevice *device);
-void WASAPI_DisconnectDevice(SDL_AudioDevice *device);
+void WASAPI_DisconnectDevice(SDL_AudioDevice *device);  // don't hold the device lock when calling this!
 
 
 // BE CAREFUL: if you are holding the device lock and proxy to the management thread with wait_until_complete, and grab the lock again, you will deadlock.


### PR DESCRIPTION
Since these get proxied to a different thread, if we wait for that thread to finish while holding the lock, and the management thread _also_ requests the lock, we're screwed.

WaitDevice never holds the lock by design, so just mark devices as failed and clean up or recover them in there.

In the WASAPI backend, both playback and capture devices use the same WaitDevice implementation.

Putting this in a PR because I'm not near a Windows machine right now to test this until later today.