### PR TITLE
Fixed stuttering on Android when using the AAudio driver

### DIFF
--- a/src/audio/aaudio/SDL_aaudio.h
+++ b/src/audio/aaudio/SDL_aaudio.h
@@ -27,13 +27,11 @@
 
 void AAUDIO_ResumeDevices(void);
 void AAUDIO_PauseDevices(void);
-SDL_bool AAUDIO_DetectBrokenPlayState(void);
 
 #else
 
 #define AAUDIO_ResumeDevices()
 #define AAUDIO_PauseDevices()
-#define AAUDIO_DetectBrokenPlayState() (SDL_FALSE)
 
 #endif
 

--- a/src/video/android/SDL_androidevents.c
+++ b/src/video/android/SDL_androidevents.c
@@ -159,11 +159,6 @@ void Android_PumpEvents_Blocking(SDL_VideoDevice *_this)
             }
         }
     }
-
-    if (AAUDIO_DetectBrokenPlayState()) {
-        AAUDIO_PauseDevices();
-        AAUDIO_ResumeDevices();
-    }
 }
 
 void Android_PumpEvents_NonBlocking(SDL_VideoDevice *_this)
@@ -244,11 +239,6 @@ void Android_PumpEvents_NonBlocking(SDL_VideoDevice *_this)
                 backup_context = 1;
             }
         }
-    }
-
-    if (AAUDIO_DetectBrokenPlayState()) {
-        AAUDIO_PauseDevices();
-        AAUDIO_ResumeDevices();
     }
 }
 


### PR DESCRIPTION
The audio processing thread isn't scheduled in lock-step with the audio callback so sometimes the callback would consume the same data twice and sometimes the audio processing thread would write to the same buffer twice.

Also handle variable sizes in the audio callback so the Android audio system doesn't have to do additional buffering to match our buffer size requirements.