### PR TITLE
Improve ability to debug failed surface comparisons

### DIFF
--- a/src/test/SDL_test_compare.c
+++ b/src/test/SDL_test_compare.c
@@ -67,12 +67,19 @@ int SDLTest_CompareSurfaces(SDL_Surface *surface, SDL_Surface *referenceSurface,
     char referenceFilename[FILENAME_SIZE];
 
     /* Validate input surfaces */
-    if (surface == NULL || referenceSurface == NULL) {
+    if (surface == NULL) {
+        SDLTest_LogError("Cannot compare NULL surface");
+        return -1;
+    }
+
+    if (referenceSurface == NULL) {
+        SDLTest_LogError("Cannot compare NULL reference surface");
         return -1;
     }
 
     /* Make sure surface size is the same. */
     if ((surface->w != referenceSurface->w) || (surface->h != referenceSurface->h)) {
+        SDLTest_LogError("Expected %dx%d surface, got %dx%d", referenceSurface->w, referenceSurface->h, surface->w, surface->h);
         return -2;
     }
 

--- a/src/test/SDL_test_compare.c
+++ b/src/test/SDL_test_compare.c
@@ -52,6 +52,16 @@ GetPixel(Uint8 *p, size_t bytes_per_pixel)
     return ret;
 }
 
+static void
+LogErrorFormat(const char *name, const SDL_PixelFormat *format)
+{
+  SDLTest_LogError("%s: %08" SDL_PRIx32 " %s, %u bits/%u bytes per pixel", name, format->format, SDL_GetPixelFormatName(format->format), format->BitsPerPixel, format->BytesPerPixel);
+  SDLTest_LogError("%s: R mask %08" SDL_PRIx32 ", loss %u, shift %u", name, format->Rmask, format->Rloss, format->Rshift);
+  SDLTest_LogError("%s: G mask %08" SDL_PRIx32 ", loss %u, shift %u", name, format->Gmask, format->Gloss, format->Gshift);
+  SDLTest_LogError("%s: B mask %08" SDL_PRIx32 ", loss %u, shift %u", name, format->Bmask, format->Bloss, format->Bshift);
+  SDLTest_LogError("%s: A mask %08" SDL_PRIx32 ", loss %u, shift %u", name, format->Amask, format->Aloss, format->Ashift);
+}
+
 /* Compare surfaces */
 int SDLTest_CompareSurfaces(SDL_Surface *surface, SDL_Surface *referenceSurface, int allowable_error)
 {
@@ -130,6 +140,8 @@ int SDLTest_CompareSurfaces(SDL_Surface *surface, SDL_Surface *referenceSurface,
     _CompareSurfaceCount++;
     if (ret != 0) {
         SDLTest_LogError("Comparison of pixels with allowable error of %i failed %i times.", allowable_error, ret);
+        LogErrorFormat("Reference surface format", referenceSurface->format);
+        LogErrorFormat("Actual surface format   ", surface->format);
         SDLTest_LogError("First detected occurrence at position %i,%i with a squared RGB-difference of %i.", sampleErrorX, sampleErrorY, sampleDist);
         (void)SDL_snprintf(imageFilename, FILENAME_SIZE - 1, "CompareSurfaces%04d_TestOutput.bmp", _CompareSurfaceCount);
         SDL_SaveBMP(surface, imageFilename);

--- a/src/test/SDL_test_compare.c
+++ b/src/test/SDL_test_compare.c
@@ -71,6 +71,8 @@ int SDLTest_CompareSurfaces(SDL_Surface *surface, SDL_Surface *referenceSurface,
     Uint8 *p, *p_reference;
     int dist;
     int sampleErrorX = 0, sampleErrorY = 0, sampleDist = 0;
+    SDL_Color sampleReference = { 0, 0, 0, 0 };
+    SDL_Color sampleActual = { 0, 0, 0, 0 };
     Uint8 R, G, B, A;
     Uint8 Rd, Gd, Bd, Ad;
     char imageFilename[FILENAME_SIZE];
@@ -128,6 +130,14 @@ int SDLTest_CompareSurfaces(SDL_Surface *surface, SDL_Surface *referenceSurface,
                     sampleErrorX = i;
                     sampleErrorY = j;
                     sampleDist = dist;
+                    sampleReference.r = Rd;
+                    sampleReference.g = Gd;
+                    sampleReference.b = Bd;
+                    sampleReference.a = Ad;
+                    sampleActual.r = R;
+                    sampleActual.g = G;
+                    sampleActual.b = B;
+                    sampleActual.a = A;
                 }
             }
         }
@@ -143,6 +153,8 @@ int SDLTest_CompareSurfaces(SDL_Surface *surface, SDL_Surface *referenceSurface,
         LogErrorFormat("Reference surface format", referenceSurface->format);
         LogErrorFormat("Actual surface format   ", surface->format);
         SDLTest_LogError("First detected occurrence at position %i,%i with a squared RGB-difference of %i.", sampleErrorX, sampleErrorY, sampleDist);
+        SDLTest_LogError("Reference pixel: R=%u G=%u B=%u A=%u", sampleReference.r, sampleReference.g, sampleReference.b, sampleReference.a);
+        SDLTest_LogError("Actual pixel   : R=%u G=%u B=%u A=%u", sampleActual.r, sampleActual.g, sampleActual.b, sampleActual.a);
         (void)SDL_snprintf(imageFilename, FILENAME_SIZE - 1, "CompareSurfaces%04d_TestOutput.bmp", _CompareSurfaceCount);
         SDL_SaveBMP(surface, imageFilename);
         (void)SDL_snprintf(referenceFilename, FILENAME_SIZE - 1, "CompareSurfaces%04d_Reference.bmp", _CompareSurfaceCount);


### PR DESCRIPTION
* SDLTest_CompareSurfaces: Log better messages if NULL or different sizes
* SDLTest_CompareSurfaces: If surfaces differ, log their formats
* SDLTest_CompareSurfaces: Output RGBA values of first differing pixel

---

I used this to get better information out of #8315.
