### PR TITLE
[SDL2] Fix automated tests using the dummy video driver

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -171,7 +171,7 @@ static void SDLCALL SDL_MouseRelativeWarpMotionChanged(void *userdata, const cha
 }
 
 /* Public functions */
-int SDL_MouseInit(void)
+int SDL_MousePreInit(void)
 {
     SDL_Mouse *mouse = SDL_GetMouse();
 
@@ -216,11 +216,62 @@ int SDL_MouseInit(void)
     return 0;
 }
 
+void SDL_MousePostInit(void)
+{
+    SDL_Mouse *mouse = SDL_GetMouse();
+
+    /* Create a dummy mouse cursor for video backends that don't support true cursors,
+     * so that mouse grab and focus functionality will work.
+     */
+    if (!mouse->def_cursor) {
+        SDL_Surface *surface = SDL_CreateRGBSurface(0, 1, 1, 32, 0xFF, 0xFF, 0xFF, 0xFF);
+        if (surface) {
+            SDL_memset(surface->pixels, 0, (size_t)surface->h * surface->pitch);
+            SDL_SetDefaultCursor(SDL_CreateColorCursor(surface, 0, 0));
+            SDL_FreeSurface(surface);
+        }
+    }
+}
+
 void SDL_SetDefaultCursor(SDL_Cursor *cursor)
 {
     SDL_Mouse *mouse = SDL_GetMouse();
 
+    if (cursor == mouse->def_cursor) {
+        return;
+    }
+
+    if (mouse->def_cursor) {
+        SDL_Cursor *default_cursor = mouse->def_cursor;
+        SDL_Cursor *prev, *curr;
+
+        if (mouse->cur_cursor == mouse->def_cursor) {
+            mouse->cur_cursor = NULL;
+        }
+        mouse->def_cursor = NULL;
+
+        for (prev = NULL, curr = mouse->cursors; curr;
+             prev = curr, curr = curr->next) {
+            if (curr == default_cursor) {
+                if (prev) {
+                    prev->next = curr->next;
+                } else {
+                    mouse->cursors = curr->next;
+                }
+
+                break;
+            }
+        }
+
+        if (mouse->FreeCursor && default_cursor->driverdata) {
+            mouse->FreeCursor(default_cursor);
+        } else {
+            SDL_free(default_cursor);
+        }
+    }
+
     mouse->def_cursor = cursor;
+
     if (!mouse->cur_cursor) {
         SDL_SetCursor(cursor);
     }
@@ -1271,11 +1322,6 @@ SDL_Cursor *SDL_CreateColorCursor(SDL_Surface *surface, int hot_x, int hot_y)
         return NULL;
     }
 
-    if (!mouse->CreateCursor) {
-        SDL_SetError("Cursors are not currently supported");
-        return NULL;
-    }
-
     /* Sanity check the hot spot */
     if ((hot_x < 0) || (hot_y < 0) ||
         (hot_x >= surface->w) || (hot_y >= surface->h)) {
@@ -1291,7 +1337,15 @@ SDL_Cursor *SDL_CreateColorCursor(SDL_Surface *surface, int hot_x, int hot_y)
         surface = temp;
     }
 
-    cursor = mouse->CreateCursor(surface, hot_x, hot_y);
+    if (mouse->CreateCursor) {
+        cursor = mouse->CreateCursor(surface, hot_x, hot_y);
+    } else {
+        cursor = SDL_calloc(1, sizeof(*cursor));
+        if (!cursor) {
+            SDL_OutOfMemory();
+        }
+    }
+
     if (cursor) {
         cursor->next = mouse->cursors;
         mouse->cursors = cursor;
@@ -1416,6 +1470,8 @@ void SDL_FreeCursor(SDL_Cursor *cursor)
 
             if (mouse->FreeCursor) {
                 mouse->FreeCursor(curr);
+            } else {
+                SDL_free(curr);
             }
             return;
         }

--- a/src/events/SDL_mouse_c.h
+++ b/src/events/SDL_mouse_c.h
@@ -131,7 +131,8 @@ typedef struct
 } SDL_Mouse;
 
 /* Initialize the mouse subsystem */
-extern int SDL_MouseInit(void);
+extern int SDL_MousePreInit(void);
+extern void SDL_MousePostInit(void);
 
 /* Get the mouse state structure */
 SDL_Mouse *SDL_GetMouse(void);

--- a/src/video/dummy/SDL_nullvideo.c
+++ b/src/video/dummy/SDL_nullvideo.c
@@ -53,7 +53,6 @@
 
 /* Initialization/Query functions */
 static int DUMMY_VideoInit(_THIS);
-static int DUMMY_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode);
 static void DUMMY_VideoQuit(_THIS);
 
 #if SDL_INPUT_LINUXEV
@@ -104,7 +103,6 @@ static SDL_VideoDevice *DUMMY_CreateDevice(void)
     /* Set the function pointers */
     device->VideoInit = DUMMY_VideoInit;
     device->VideoQuit = DUMMY_VideoQuit;
-    device->SetDisplayMode = DUMMY_SetDisplayMode;
     device->PumpEvents = DUMMY_PumpEvents;
 #if SDL_INPUT_LINUXEV
     if (evdev) {
@@ -149,7 +147,7 @@ int DUMMY_VideoInit(_THIS)
     mode.format = SDL_PIXELFORMAT_RGB888;
     mode.w = 1024;
     mode.h = 768;
-    mode.refresh_rate = 0;
+    mode.refresh_rate = 60;
     mode.driverdata = NULL;
     if (SDL_AddBasicVideoDisplay(&mode) < 0) {
         return -1;
@@ -162,11 +160,6 @@ int DUMMY_VideoInit(_THIS)
 #endif
 
     /* We're done! */
-    return 0;
-}
-
-static int DUMMY_SetDisplayMode(_THIS, SDL_VideoDisplay *display, SDL_DisplayMode *mode)
-{
     return 0;
 }
 

--- a/test/testautomation_video.c
+++ b/test/testautomation_video.c
@@ -278,6 +278,8 @@ int video_createWindowVariousFlags(void *arg)
             break;
         case 2:
             flags = SDL_WINDOW_OPENGL;
+            /* Skip - not every video driver supports OpenGL; comment out next line to run test */
+            continue;
             break;
         case 3:
             flags = SDL_WINDOW_SHOWN;


### PR DESCRIPTION
Backport of b8d9125 for SDL2 to fix the automated video tests using the dummy video driver.

Fixes #8308
Fixes #8309
