### PR TITLE
add failsafe for querying cache line size on linux

### DIFF
--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -859,12 +859,12 @@ int SDL_GetCPUCacheLineSize(void)
 	cacheline_size = c & 0xff;
         return cacheline_size;
     } else {
+#if defined(HAVE_SYSCONF) && defined(_SC_LEVEL1_DCACHE_LINESIZE)
+        if ((cacheline_size = sysconf(_SC_LEVEL1_DCACHE_LINESIZE)) > 0)
+		return cacheline_size;
+#endif
 #if defined(__LINUX__)
         FILE *f = NULL;
-#if defined(__GLIBC__)
-        if ((cacheline_size = sysconf(_SC_LEVEL1_DCACHE_LINESIZE)) != -1)
-            return cacheline_size;
-#endif
         f = fopen("/sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size", "r");
         if (f) {
             int r = fscanf(f, "%d", &cacheline_size);
@@ -872,13 +872,13 @@ int SDL_GetCPUCacheLineSize(void)
 
             return (r == 1) ? cacheline_size : SDL_CACHELINE_SIZE;
         }
-#elif defined __FreeBSD__
-#ifdef CACHE_LINE_SIZE
+#endif
+#if defined(__FreeBSD__) && defined(CACHE_LINE_SIZE)
         cacheline_size = CACHE_LINE_SIZE;
         return cacheline_size;
 #endif
-#endif
         /* Just make a guess here... */
+	(void) cacheline_size;
         return SDL_CACHELINE_SIZE;
     }
 }

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -859,18 +859,19 @@ int SDL_GetCPUCacheLineSize(void)
 	cacheline_size = c & 0xff;
         return cacheline_size;
     } else {
-#if defined(__LINUX__) && defined (__GLIBC__)
+#if defined(__LINUX__)
+        FILE *f = NULL;
+#if defined(__GLIBC__)
         if ((cacheline_size = sysconf(_SC_LEVEL1_DCACHE_LINESIZE)) != -1)
             return cacheline_size;
 #endif
-#if defined(__LINUX__) /* non glibc linux systems */
-        FILE *f = NULL;
-
         f = fopen("/sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size", "r");
         if (f) {
-            fscanf(f, "%d", &cacheline_size);
+            if ((fscanf(f, "%d", &cacheline_size)) > 0) {
+                fclose(f);
+                return cacheline_size;
+            }
             fclose(f);
-            return cacheline_size;
 	}
 #elif defined __FreeBSD__
 #ifdef CACHE_LINE_SIZE

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -840,7 +840,6 @@ static const char *SDL_GetCPUName(void)
 int SDL_GetCPUCacheLineSize(void)
 {
     const char *cpuType = SDL_GetCPUType();
-    int failsafe_cacheline_size;
     int a, b, c, d;
     (void)a;
     (void)b;
@@ -854,6 +853,7 @@ int SDL_GetCPUCacheLineSize(void)
         return c & 0xff;
     } else {
 #ifdef __LINUX__
+        int failsafe_cacheline_size;
         if ((failsafe_cacheline_size = sysconf(_SC_LEVEL1_DCACHE_LINESIZE)) != -1)
             return failsafe_cacheline_size;
 #endif

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -840,6 +840,7 @@ static const char *SDL_GetCPUName(void)
 int SDL_GetCPUCacheLineSize(void)
 {
     const char *cpuType = SDL_GetCPUType();
+    int failsafe_cacheline_size;
     int a, b, c, d;
     (void)a;
     (void)b;
@@ -852,6 +853,10 @@ int SDL_GetCPUCacheLineSize(void)
         cpuid(0x80000005, a, b, c, d);
         return c & 0xff;
     } else {
+#ifdef __LINUX__
+        if ((failsafe_cacheline_size = sysconf(_SC_LEVEL1_DCACHE_LINESIZE)) != -1)
+            return failsafe_cacheline_size;
+#endif
         /* Just make a guess here... */
         return SDL_CACHELINE_SIZE;
     }

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -859,7 +859,7 @@ int SDL_GetCPUCacheLineSize(void)
 	cacheline_size = c & 0xff;
         return cacheline_size;
     } else {
-#if defined(__LINUX__) && defined (__GNUC__)
+#if defined(__LINUX__) && defined (__GLIBC__)
         if ((cacheline_size = sysconf(_SC_LEVEL1_DCACHE_LINESIZE)) != -1)
             return cacheline_size;
 #endif

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -867,12 +867,11 @@ int SDL_GetCPUCacheLineSize(void)
 #endif
         f = fopen("/sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size", "r");
         if (f) {
-            if ((fscanf(f, "%d", &cacheline_size)) > 0) {
-                fclose(f);
-                return cacheline_size;
-            }
+            int r = fscanf(f, "%d", &cacheline_size);
             fclose(f);
-	}
+
+            return (r == 1) ? cacheline_size : SDL_CACHELINE_SIZE;
+        }
 #elif defined __FreeBSD__
 #ifdef CACHE_LINE_SIZE
         cacheline_size = CACHE_LINE_SIZE;


### PR DESCRIPTION
Handle fail case when querying cpu cache line size

## Description
A small patch just to add fail safe mechanism to see if sysconfig can determine the correct value, if that fails it returns ```SDL_CACHELINE_SIZE``` like before. I implemented the same thing on Windows with ```GetLogicalProcessorInformationEx```, it returns the correct cache line size (on my machine) but returns an error code. I don't know if that's a bug or what is going on behind that function so I didn't add it. There is also a FreeBSD Cache line constant which I will test if approved.

I actually suggest going with sysconfig by default, instead of using it as a fail-safe mechanism and using [CACHE_LINE_SIZE](https://lists.freebsd.org/pipermail/freebsd-arch/2009-April/009190.html) on FreeBSD, with that we would not have to do a bunch of string comparisons and can get the value from the platform layer itself.