### PR TITLE
Fixes for the 3DS Audio

### DIFF
--- a/src/audio/n3ds/SDL_n3dsaudio.c
+++ b/src/audio/n3ds/SDL_n3dsaudio.c
@@ -246,7 +246,7 @@ static void N3DSAUDIO_CloseDevice(_THIS)
 
 static void N3DSAUDIO_ThreadInit(_THIS)
 {
-    s32 current_priority;
+    s32 current_priority = 0x30;
     svcGetThreadPriority(&current_priority, CUR_THREAD_HANDLE);
     current_priority--;
     /* 0x18 is reserved for video, 0x30 is the default for main thread */

--- a/src/audio/n3ds/SDL_n3dsaudio.c
+++ b/src/audio/n3ds/SDL_n3dsaudio.c
@@ -38,6 +38,7 @@ static SDL_AudioDevice *audio_device;
 static void FreePrivateData(_THIS);
 static int FindAudioFormat(_THIS);
 
+/* fully local functions related to the wavebufs / DSP, not the same as the SDL-wide mixer lock */
 static SDL_INLINE void contextLock(_THIS)
 {
     LightLock_Lock(&this->hidden->lock);
@@ -46,16 +47,6 @@ static SDL_INLINE void contextLock(_THIS)
 static SDL_INLINE void contextUnlock(_THIS)
 {
     LightLock_Unlock(&this->hidden->lock);
-}
-
-static void N3DSAUD_LockAudio(_THIS)
-{
-    contextLock(this);
-}
-
-static void N3DSAUD_UnlockAudio(_THIS)
-{
-    contextUnlock(this);
 }
 
 static void N3DSAUD_DspHook(DSP_HookType hook)
@@ -195,6 +186,7 @@ static void N3DSAUDIO_PlayDevice(_THIS)
 {
     size_t nextbuf;
     size_t sampleLen;
+
     contextLock(this);
 
     nextbuf = this->hidden->nextbuf;
@@ -271,8 +263,6 @@ static SDL_bool N3DSAUDIO_Init(SDL_AudioDriverImpl *impl)
     impl->GetDeviceBuf = N3DSAUDIO_GetDeviceBuf;
     impl->CloseDevice = N3DSAUDIO_CloseDevice;
     impl->ThreadInit = N3DSAUDIO_ThreadInit;
-    impl->LockDevice = N3DSAUD_LockAudio;
-    impl->UnlockDevice = N3DSAUD_UnlockAudio;
     impl->OnlyHasDefaultOutputDevice = SDL_TRUE;
 
     /* Should be possible, but micInit would fail */

--- a/src/audio/n3ds/SDL_n3dsaudio.h
+++ b/src/audio/n3ds/SDL_n3dsaudio.h
@@ -27,7 +27,7 @@
 /* Hidden "this" pointer for the audio functions */
 #define _THIS SDL_AudioDevice *this
 
-#define NUM_BUFFERS 2 /* -- Don't lower this! */
+#define NUM_BUFFERS 3 /* -- Minimum 2! */
 
 struct SDL_PrivateAudioData
 {

--- a/src/thread/n3ds/SDL_systhread.c
+++ b/src/thread/n3ds/SDL_systhread.c
@@ -26,9 +26,8 @@
 
 #include "../SDL_systhread.h"
 
-/* N3DS has very limited RAM (128MB), so we put a limit on thread stack size. */
-#define N3DS_THREAD_STACK_SIZE_MAX     (16 * 1024)
-#define N3DS_THREAD_STACK_SIZE_DEFAULT (4 * 1024)
+/* N3DS has very limited RAM (128MB), so we set a low default thread stack size. */
+#define N3DS_THREAD_STACK_SIZE_DEFAULT (80 * 1024)
 
 #define N3DS_THREAD_PRIORITY_LOW           0x3F /**< Minimum priority */
 #define N3DS_THREAD_PRIORITY_MEDIUM        0x2F /**< Slightly higher than main thread (0x30) */
@@ -80,14 +79,6 @@ static size_t GetStackSize(size_t requested_size)
         return N3DS_THREAD_STACK_SIZE_DEFAULT;
     }
 
-    if (requested_size > N3DS_THREAD_STACK_SIZE_MAX) {
-        SDL_LogWarn(SDL_LOG_CATEGORY_SYSTEM,
-                    "Requested a thread size of %zu,"
-                    " falling back to the maximum supported of %zu\n",
-                    requested_size,
-                    N3DS_THREAD_STACK_SIZE_MAX);
-        requested_size = N3DS_THREAD_STACK_SIZE_MAX;
-    }
     return requested_size;
 }
 


### PR DESCRIPTION
* SDL_n3dsaudio.c: separate mixer locks from audio device locks
* SDL_n3dsaudio.h: use triple buffer by default
* SDL2: fix 3DS mixer thread stack overflows
* SDL_n3dsaudio.c: don't leave priority uninitialized
* SDL_systhread.c: attempt to put audio thread on system core
* Comment and style fixes

## Description
This is a set of fixes to improve the stability of audio processing on 3DS made by me and @ds-sloth.
- Audio needs a different priority setup in order to don't slow-down the main thread and don't lead the choppy playback on using some heavier codec libraries.
- Audio needs a bigger stack size, otherwise it leads a memory data damage because of some custom codec libraries that allocate more memory size than stack allows.
- The own audio lock is redundant as SDL does it already, and this may lead a deadlock in some cases.

