### PR TITLE
Fix running testautomation with high iteration count + events + audio

### DIFF
--- a/test/testautomation_audio.c
+++ b/test/testautomation_audio.c
@@ -32,6 +32,9 @@ static void SDLCALL audioSetUp(void **arg)
 
 static void SDLCALL audioTearDown(void *arg)
 {
+    SDL_QuitSubSystem(SDL_INIT_AUDIO);
+    SDLTest_AssertPass("Call to SDL_QuitSubSystem(SDL_INIT_AUDIO)");
+
     /* Remove a possibly created file from SDL disk writer audio driver; ignore errors */
     (void)remove("sdlaudio.raw");
 

--- a/test/testautomation_events.c
+++ b/test/testautomation_events.c
@@ -7,6 +7,25 @@
 
 /* ================= Test Case Implementation ================== */
 
+/* Fixture */
+
+static void SDLCALL eventsSetUp(void **arg)
+{
+    /* Start SDL events subsystem */
+    int ret = SDL_InitSubSystem(SDL_INIT_EVENTS);
+    SDLTest_AssertPass("Call to SDL_InitSubSystem(SDL_INIT_EVENTS)");
+    SDLTest_AssertCheck(ret == true, "Check result from SDL_InitSubSystem(SDL_INIT_EVENTS) (%s)", ret ? "" : SDL_GetError());
+    if (ret != 0) {
+        SDLTest_LogError("%s", SDL_GetError());
+    }
+}
+
+static void SDLCALL eventsTearDown(void *arg)
+{
+    SDL_QuitSubSystem(SDL_INIT_EVENTS);
+    SDLTest_AssertPass("Call to SDL_QuitSubSystem(SDL_INIT_EVENTS)");
+}
+
 /* Test case functions */
 
 /* Flag indicating if the userdata should be checked */
@@ -229,7 +248,7 @@ static const SDLTest_TestCaseReference *eventsTests[] = {
 /* Events test suite (global) */
 SDLTest_TestSuiteReference eventsTestSuite = {
     "Events",
-    NULL,
+    eventsSetUp,
     eventsTests,
-    NULL
+    eventsTearDown
 };

--- a/test/testautomation_timer.c
+++ b/test/testautomation_timer.c
@@ -24,6 +24,10 @@ static void SDLCALL timerSetUp(void **arg)
 {
 }
 
+static void SDLCALL timerTearDown(void *arg)
+{
+}
+
 /* Test case functions */
 
 /**
@@ -203,5 +207,5 @@ SDLTest_TestSuiteReference timerTestSuite = {
     "Timer",
     timerSetUp,
     timerTests,
-    NULL
+    timerTearDown
 };


### PR DESCRIPTION
- Fix running `testautomation` with `--iterations` >= 256
- Make sure events subsystem is initialized for events tests (there was a bug in `testautomation_audio.c` that closed the audio subsystem too often)
- Running `testautomation` without any `SDL_AUDIO_DRIVER` environment variable, will not actually test all audio drivers that are built-in.

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
