### PR TITLE
Add support for universal links

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -426,6 +426,22 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
                 Log.v(TAG, "Got filename: " + filename);
                 SDLActivity.onNativeDropFile(filename);
             }
+
+            Log.v(TAG, "Got intent link: " + intent.getDataString());
+            SDLActivity.onNativeCreate(intent.getDataString());
+        } else {
+            SDLActivity.onNativeCreate(null);
+        }
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        Intent appIntent = getIntent();
+        if (appIntent != null && appIntent.getDataString() != null) {
+            Log.v(TAG, "Got new intent link: " + appIntent.getDataString());
+            SDLActivity.onNativeIntentLink(appIntent.getDataString());
         }
     }
 
@@ -930,6 +946,8 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     public static native void onNativeOrientationChanged(int orientation);
     public static native void nativeAddTouch(int touchId, String name);
     public static native void nativePermissionResult(int requestCode, boolean result);
+    public static native void onNativeCreate(String intent_data);
+    public static native void onNativeIntentLink(String link);
     public static native void onNativeLocaleChanged();
 
     /**

--- a/include/SDL_events.h
+++ b/include/SDL_events.h
@@ -158,6 +158,9 @@ typedef enum
     /* Sensor events */
     SDL_SENSORUPDATE = 0x1200,     /**< A sensor was updated */
 
+    /* Universal links events */
+    SDL_UNIVERSALLINK = 0x1300,     /**< User clicked on a link associated with application (applies to iOS, MacOS and Android) */
+
     /* Render events */
     SDL_RENDER_TARGETS_RESET = 0x2000, /**< The render targets have been reset and their contents need to be updated */
     SDL_RENDER_DEVICE_RESET, /**< The device has been reset and all textures need to be recreated */
@@ -560,6 +563,20 @@ typedef struct SDL_DropEvent
 
 
 /**
+ *  \brief An event triggered when user clicks on a link associated with the App (applies to MacOS, iOS and Android)
+ *         This is typically used to send users to app instead of website in browser.
+ *         This event is enabled by default, you can disable it with SDL_EventState().
+ *  \note If this event is enabled, you must free the link in the event.
+ */
+typedef struct SDL_UniversalLinkEvent
+{
+    Uint32 type;        /**< ::SDL_UNIVERSALLINK */
+    Uint32 timestamp;   /**< In milliseconds, populated using SDL_GetTicks() */
+    char *link;         /**< The link, which should be freed with SDL_free() */
+} SDL_UniversalLinkEvent;
+
+
+/**
  *  \brief Sensor event structure (event.sensor.*)
  */
 typedef struct SDL_SensorEvent
@@ -655,6 +672,7 @@ typedef union SDL_Event
     SDL_MultiGestureEvent mgesture;         /**< Gesture event data */
     SDL_DollarGestureEvent dgesture;        /**< Gesture event data */
     SDL_DropEvent drop;                     /**< Drag and drop event data */
+    SDL_UniversalLinkEvent unilink;         /**< Universal link event data */
 
     /* This is necessary for ABI compatibility between Visual C++ and GCC.
        Visual C++ will respect the push pack pragma and use 52 bytes (size of

--- a/src/core/android/SDL_android.h
+++ b/src/core/android/SDL_android.h
@@ -146,6 +146,9 @@ void Android_ActivityMutex_Lock(void);
 void Android_ActivityMutex_Unlock(void);
 void Android_ActivityMutex_Lock_Running(void);
 
+/* Posts any unprocessed intent link events to event queue */
+void Android_CheckSendUnilinkEvent(void);
+
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus
 /* *INDENT-OFF* */

--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -515,6 +515,9 @@ static void SDL_LogEvent(const SDL_Event *event)
                            event->sensor.data[0], event->sensor.data[1], event->sensor.data[2],
                            event->sensor.data[3], event->sensor.data[4], event->sensor.data[5]);
         break;
+        SDL_EVENT_CASE(SDL_UNIVERSALLINK)
+        (void)SDL_snprintf(details, sizeof(details), " (link='%s' timestamp=%u)", event->unilink.link, (uint) event->unilink.timestamp);
+        break;
 
 #undef SDL_EVENT_CASE
 

--- a/src/events/SDL_unilinkevents.c
+++ b/src/events/SDL_unilinkevents.c
@@ -18,47 +18,23 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-
-#ifndef SDL_events_c_h_
-#define SDL_events_c_h_
-
 #include "../SDL_internal.h"
 
-/* Useful functions and variables from SDL_events.c */
+/* Universal link event handling code for SDL */
+
 #include "SDL_events.h"
-#include "SDL_thread.h"
-#include "../video/SDL_sysvideo.h"
-
-#include "SDL_clipboardevents_c.h"
-#include "SDL_displayevents_c.h"
-#include "SDL_dropevents_c.h"
-#include "SDL_gesture_c.h"
-#include "SDL_keyboard_c.h"
-#include "SDL_mouse_c.h"
-#include "SDL_touch_c.h"
 #include "SDL_unilinkevents_c.h"
-#include "SDL_windowevents_c.h"
 
-/* Start and stop the event processing loop */
-extern int SDL_StartEventLoop(void);
-extern void SDL_StopEventLoop(void);
-extern void SDL_QuitInterrupt(void);
-
-extern int SDL_SendAppEvent(SDL_EventType eventType);
-extern int SDL_SendSysWMEvent(SDL_SysWMmsg *message);
-extern int SDL_SendKeymapChangedEvent(void);
-extern int SDL_SendLocaleChangedEvent(void);
-
-extern int SDL_SendQuit(void);
-
-extern int SDL_EventsInit(void);
-extern void SDL_EventsQuit(void);
-
-extern void SDL_SendPendingSignalEvents(void);
-
-extern int SDL_QuitInit(void);
-extern void SDL_QuitQuit(void);
-
-#endif /* SDL_events_c_h_ */
+int SDL_SendUnilink(const char *link)
+{
+    if (SDL_GetEventState(SDL_UNIVERSALLINK) == SDL_ENABLE) {
+        SDL_Event event;
+        SDL_zero(event);
+        event.type = SDL_UNIVERSALLINK;
+        event.unilink.link = SDL_strdup(link);
+        return (SDL_PushEvent(&event) > 0);
+    }
+    return 0;
+}
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/events/SDL_unilinkevents_c.h
+++ b/src/events/SDL_unilinkevents_c.h
@@ -1,0 +1,30 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2023 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+#include "../SDL_internal.h"
+
+#ifndef SDL_unilinkevents_c_h_
+#define SDL_unilinkevents_c_h_
+
+extern int SDL_SendUnilink(const char *link);
+
+#endif /* SDL_unilinkevents_c_h_ */
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/android/SDL_androidevents.c
+++ b/src/video/android/SDL_androidevents.c
@@ -107,6 +107,8 @@ static void android_egl_context_backup(SDL_Window *window)
 
 void Android_PumpEvents_Blocking(_THIS)
 {
+    Android_CheckSendUnilinkEvent();
+
     SDL_VideoData *videodata = (SDL_VideoData *)_this->driverdata;
 
     if (videodata->isPaused) {
@@ -182,6 +184,8 @@ void Android_PumpEvents_Blocking(_THIS)
 
 void Android_PumpEvents_NonBlocking(_THIS)
 {
+    Android_CheckSendUnilinkEvent();
+
     SDL_VideoData *videodata = (SDL_VideoData *)_this->driverdata;
     static int backup_context = 0;
 

--- a/src/video/cocoa/SDL_cocoaevents.m
+++ b/src/video/cocoa/SDL_cocoaevents.m
@@ -310,6 +310,14 @@ static void Cocoa_DispatchEvent(NSEvent *theEvent)
     SDL_SendDropComplete(NULL);
 }
 
+- (BOOL)application:(NSApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray<id<NSUserActivityRestoring>> *restorableObjects))restorationHandler
+{
+    if ([userActivity.activityType isEqualToString: NSUserActivityTypeBrowsingWeb]) {
+        return SDL_SendUnilink([[userActivity.webpageURL absoluteString] UTF8String]) ? YES : NO;
+    }
+    return NO;
+}
+
 @end
 
 static SDLAppDelegate *appDelegate = nil;

--- a/src/video/uikit/SDL_uikitappdelegate.m
+++ b/src/video/uikit/SDL_uikitappdelegate.m
@@ -519,6 +519,13 @@ static UIImage *SDL_LoadLaunchImageNamed(NSString *name, int screenh)
 
 #endif
 
+-(BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler
+{
+    if ([userActivity.activityType isEqualToString: NSUserActivityTypeBrowsingWeb]) {
+        return SDL_SendUnilink([[userActivity.webpageURL absoluteString] UTF8String]) ? YES : NO;
+    }
+    return NO;
+}
 @end
 
 #endif /* SDL_VIDEO_DRIVER_UIKIT */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

These changes provide support for universal links on MacOS, iOS and Android. Universal links are a feature where clicking on a link in browser or chat opens app instead of website.

## Description
<!--- Describe your changes in detail -->

At present SDL users have to modify the library in order to enable this feature on Apple platforms (MacOS/iOS), because all access to Objective C code is hidden behind SDL api. After this change SDL will provide `SDL_UNIVERSALLINK` event that its users can listen to instead of having to modify its code. Apart from `SDL_UNIVERSALLINK` users just have to properly configure corresponding entitlements and their website, SDL will take care of all the rest.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
