### PR TITLE
wayland: Try to skip the Wayland driver if not connecting to or in a …

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -128,6 +128,14 @@ static SDL_VideoDevice *Wayland_CreateDevice(void)
     SDL_VideoData *data;
     struct wl_display *display;
 
+    /* Are we trying to connect to or are currently in a Wayland session? */
+    if (!getenv("WAYLAND_DISPLAY")) {
+        const char *session = getenv("XDG_SESSION_TYPE");
+        if (session && SDL_strcasecmp(session, "wayland")) {
+            return NULL;
+        }
+    }
+
     if (!SDL_WAYLAND_LoadSymbols()) {
         return NULL;
     }


### PR DESCRIPTION
…Wayland session

When initializing the Wayland driver, check if the application is being started in, or trying to connect to, a Wayland session, and skip to another driver if not. If neither WAYLAND_DISPLAY nor XDG_SESSION_TYPE are set, try to start anyway, and if the Wayland library is missing or no Wayland sessions are started, initialization will fail later in the process as it previously did.

This fixes the case where a Wayland session is running on a different VT, but an application wishes to run via KMSDRM on the current VT.

As it explicitly checks for a combination of envvars specifically telling it that it's _not_ connecting to or in a Wayland session, this won't break toy compositors that don't set anything either (note that nothing specifies that `WAYLAND_DISPLAY` _must_ be set). The only case this breaks is where someone just assumes that an application launched from another VT will always try to connect to a Wayland session on the system via socket 0 by default, but it seems reasonable to require that the intent be specified in this case by setting `WAYLAND_DISPLAY` or `XDG_SESSION_TYPE=wayland` when launching the application.

Closes #8218