### PR TITLE
audio: Disable NEON sample conversion until test failures are fixed

### DIFF
--- a/src/audio/SDL_audiotypecvt.c
+++ b/src/audio/SDL_audiotypecvt.c
@@ -22,6 +22,10 @@
 
 #include "SDL_audio_c.h"
 
+/* TODO: NEON is disabled until https://github.com/libsdl-org/SDL/issues/8352
+ * can be fixed */
+#undef SDL_NEON_INTRINSICS
+
 #ifndef SDL_CPUINFO_DISABLED
 #if defined(__x86_64__) && defined(SDL_SSE2_INTRINSICS)
 #define NEED_SCALAR_CONVERTER_FALLBACKS 0 /* x86_64 guarantees SSE2. */


### PR DESCRIPTION
We need to do this early in the file, so that it will be taken into account when deciding whether to define NEED_SCALAR_CONVERTER_FALLBACKS and therefore provide a non-SIMD fallback.

Mitigates: https://github.com/libsdl-org/SDL/issues/8352