### PR TITLE
Fix potential access violation in testautomation_clipboard.c

### DIFF
--- a/test/testautomation_clipboard.c
+++ b/test/testautomation_clipboard.c
@@ -175,13 +175,18 @@ static int clipboard_testClipboardDataFunctions(void *arg)
         "Verify has test text data, expected SDL_TRUE, got SDL_FALSE");
     text = SDL_GetClipboardData(test_mime_types[TEST_MIME_TYPE_TEXT], &size);
     SDLTest_AssertCheck(
-        text && text[size] == '\0',
-        "Verify test text data, expected null termination, got %c",
-        text[size]);
-    SDLTest_AssertCheck(
-        text && SDL_strcmp(text, expected_text) == 0,
-        "Verify test text data, expected \"%s\", got \"%s\"",
-        expected_text, text);
+        text != NULL,
+        "Verify has test text data, expected valid result, got NULL");
+    if (text) {
+        SDLTest_AssertCheck(
+            text[size] == '\0',
+            "Verify test text data, expected null termination, got %c",
+            text[size]);
+        SDLTest_AssertCheck(
+            SDL_strcmp(text, expected_text) == 0,
+            "Verify test text data, expected \"%s\", got \"%s\"",
+            expected_text, text);
+    }
     SDLTest_AssertCheck(
         size == SDL_strlen(expected_text),
         "Verify test text size, expected %d, got %d",
@@ -195,13 +200,18 @@ static int clipboard_testClipboardDataFunctions(void *arg)
         "Verify has test text data, expected SDL_TRUE, got SDL_FALSE");
     text = SDL_GetClipboardData(test_mime_types[TEST_MIME_TYPE_CUSTOM_TEXT], &size);
     SDLTest_AssertCheck(
-        text && text[size] == '\0',
-        "Verify test text data, expected null termination, got %c",
-        text[size]);
-    SDLTest_AssertCheck(
-        text && SDL_strcmp(text, expected_text) == 0,
-        "Verify test text data, expected \"%s\", got \"%s\"",
-        expected_text, text);
+        text != NULL,
+        "Verify has test text data, expected valid result, got NULL");
+    if (text) {
+        SDLTest_AssertCheck(
+            text[size] == '\0',
+            "Verify test text data, expected null termination, got %c",
+            text[size]);
+        SDLTest_AssertCheck(
+            SDL_strcmp(text, expected_text) == 0,
+            "Verify test text data, expected \"%s\", got \"%s\"",
+            expected_text, text);
+    }
     SDLTest_AssertCheck(
         size == SDL_strlen(expected_text),
         "Verify test text size, expected %d, got %d",
@@ -214,7 +224,7 @@ static int clipboard_testClipboardDataFunctions(void *arg)
         "Verify has test text data, expected SDL_TRUE, got SDL_FALSE");
     data = SDL_GetClipboardData(test_mime_types[TEST_MIME_TYPE_DATA], &size);
     SDLTest_AssertCheck(
-        SDL_memcmp(data, test_data1.data, test_data1.data_size) == 0,
+        data && SDL_memcmp(data, test_data1.data, test_data1.data_size) == 0,
         "Verify test data");
     SDLTest_AssertCheck(
         size == test_data1.data_size,
@@ -276,13 +286,18 @@ static int clipboard_testClipboardDataFunctions(void *arg)
         "Verify has test text data, expected SDL_TRUE, got SDL_FALSE");
     text = SDL_GetClipboardData(test_mime_types[TEST_MIME_TYPE_TEXT], &size);
     SDLTest_AssertCheck(
-        text && text[size] == '\0',
-        "Verify test text data, expected null termination, got %c",
-        text[size]);
-    SDLTest_AssertCheck(
-        text && SDL_strcmp(text, expected_text) == 0,
-        "Verify test text data, expected \"%s\", got \"%s\"",
-        expected_text, text);
+        text != NULL,
+        "Verify has test text data, expected valid result, got NULL");
+    if (text) {
+        SDLTest_AssertCheck(
+            text[size] == '\0',
+            "Verify test text data, expected null termination, got %c",
+            text[size]);
+        SDLTest_AssertCheck(
+            SDL_strcmp(text, expected_text) == 0,
+            "Verify test text data, expected \"%s\", got \"%s\"",
+            expected_text, text);
+    }
     SDLTest_AssertCheck(
         size == SDL_strlen(expected_text),
         "Verify test text size, expected %d, got %d",
@@ -296,13 +311,18 @@ static int clipboard_testClipboardDataFunctions(void *arg)
         "Verify has test text data, expected SDL_TRUE, got SDL_FALSE");
     text = SDL_GetClipboardData(test_mime_types[TEST_MIME_TYPE_CUSTOM_TEXT], &size);
     SDLTest_AssertCheck(
-        text && text[size] == '\0',
-        "Verify test text data, expected null termination, got %c",
-        text[size]);
-    SDLTest_AssertCheck(
-        text && SDL_strcmp(text, expected_text) == 0,
-        "Verify test text data, expected \"%s\", got \"%s\"",
-        expected_text, text);
+        text != NULL,
+        "Verify has test text data, expected valid result, got NULL");
+    if (text) {
+        SDLTest_AssertCheck(
+            text[size] == '\0',
+            "Verify test text data, expected null termination, got %c",
+            text[size]);
+        SDLTest_AssertCheck(
+            SDL_strcmp(text, expected_text) == 0,
+            "Verify test text data, expected \"%s\", got \"%s\"",
+            expected_text, text);
+    }
     SDLTest_AssertCheck(
         size == SDL_strlen(expected_text),
         "Verify test text size, expected %d, got %d",
@@ -311,7 +331,7 @@ static int clipboard_testClipboardDataFunctions(void *arg)
 
     data = SDL_GetClipboardData(test_mime_types[TEST_MIME_TYPE_DATA], &size);
     SDLTest_AssertCheck(
-        SDL_memcmp(data, test_data2.data, test_data2.data_size) == 0,
+        data && SDL_memcmp(data, test_data2.data, test_data2.data_size) == 0,
         "Verify test data");
     SDLTest_AssertCheck(
         size == test_data2.data_size,


### PR DESCRIPTION
## Description
Fixes several cases of potentially accessing null pointer in testautomation_clipboard.c. The NULL result may be returned by `SDL_GetClipboardData`.

Found this is possible while experimenting with #8385, apparently clipboard requires certain subsystems to be present, so if prerequisites are not initialized then `SDL_GetClipboardData` fails.