### PR TITLE
udev: Clear intermediate errors when attempting to load libudev.so

### DIFF
--- a/src/core/linux/SDL_udev.c
+++ b/src/core/linux/SDL_udev.c
@@ -299,6 +299,7 @@ int SDL_UDEV_LoadLibrary(void)
     if (_this->udev_handle == NULL) {
         _this->udev_handle = SDL_LoadObject(SDL_UDEV_DYNAMIC);
         if (_this->udev_handle != NULL) {
+            SDL_ClearError();
             retval = SDL_UDEV_load_syms();
             if (retval < 0) {
                 SDL_UDEV_UnloadLibrary();
@@ -311,6 +312,7 @@ int SDL_UDEV_LoadLibrary(void)
         for (i = 0; i < SDL_arraysize(SDL_UDEV_LIBS); i++) {
             _this->udev_handle = SDL_LoadObject(SDL_UDEV_LIBS[i]);
             if (_this->udev_handle != NULL) {
+                SDL_ClearError();
                 retval = SDL_UDEV_load_syms();
                 if (retval < 0) {
                     SDL_UDEV_UnloadLibrary();


### PR DESCRIPTION
## Description
Call `SDL_ClearError()` after a successful `SDL_LoadObject()` call to clear the previous error left over by the previous `SDL_UDEV_load_syms()` procedure (set by `SDL_LoadFunction()`).  This ensures that no error is set when `SDL_UDEV_Init()` returns successfully.

`SDL_UDEV_LoadLibrary()` first attempts to find udev symbols in the libraries that are already loaded, then attempts to find and load `libudev.so*` using a list of names.  Every unsuccessful call to `SDL_UDEV_load_syms()` leaves the error set.  However, if a subsequent call succeeds (i.e. after loading the library), the previous error remains set until `SDL_UDEV_Init()` returns.

This is a serious problem in SDL2 since the (stale) error leaks to the caller after:

    SDL_Init(SDL_INIT_GAMECONTROLLER);

In SDL3, the issue is still present but the error is incidentally cleared by the call to `PLATFORM_hid_init()`.

