### PR TITLE
Added a single source of SDL object IDs

### DIFF
--- a/src/SDL.c
+++ b/src/SDL.c
@@ -514,6 +514,20 @@ void SDL_Quit(void)
     SDL_bInMainQuit = SDL_FALSE;
 }
 
+/* Assume we can wrap SDL_AtomicInt values and cast to Uint32 */
+SDL_COMPILE_TIME_ASSERT(sizeof_object_id, sizeof(int) == sizeof(Uint32));
+
+Uint32 SDL_GetNextObjectID(void)
+{
+    static SDL_AtomicInt last_id;
+
+    Uint32 id = (Uint32)SDL_AtomicIncRef(&last_id) + 1;
+    if (id == 0) {
+        id = (Uint32)SDL_AtomicIncRef(&last_id) + 1;
+    }
+    return id;
+}
+
 /* Get the library version number */
 int SDL_GetVersion(SDL_version *ver)
 {

--- a/src/SDL_internal.h
+++ b/src/SDL_internal.h
@@ -197,6 +197,7 @@
 extern "C" {
 #endif
 
+extern DECLSPEC Uint32 SDLCALL SDL_GetNextObjectID(void);
 extern DECLSPEC int SDLCALL SDL_WaitSemaphoreTimeoutNS(SDL_Semaphore *sem, Sint64 timeoutNS);
 extern DECLSPEC int SDLCALL SDL_WaitConditionTimeoutNS(SDL_Condition *cond, SDL_Mutex *mutex, Sint64 timeoutNS);
 extern DECLSPEC int SDLCALL SDL_WaitEventTimeoutNS(SDL_Event *event, Sint64 timeoutNS);

--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -116,7 +116,6 @@ static SDL_bool SDL_joysticks_initialized;
 static SDL_bool SDL_joysticks_quitting;
 static SDL_bool SDL_joystick_being_added;
 static SDL_Joystick *SDL_joysticks SDL_GUARDED_BY(SDL_joystick_lock) = NULL;
-static SDL_AtomicInt SDL_last_joystick_instance_id;
 static int SDL_joystick_player_count SDL_GUARDED_BY(SDL_joystick_lock) = 0;
 static SDL_JoystickID *SDL_joystick_players SDL_GUARDED_BY(SDL_joystick_lock) = NULL;
 static SDL_bool SDL_joystick_allows_background_events = SDL_FALSE;
@@ -411,15 +410,6 @@ SDL_JoystickID *SDL_GetJoysticks(int *count)
     SDL_UnlockJoysticks();
 
     return joysticks;
-}
-
-/*
- * Return the next available joystick instance ID
- * This may be called by drivers from multiple threads, unprotected by any locks
- */
-SDL_JoystickID SDL_GetNextJoystickInstanceID(void)
-{
-    return SDL_AtomicIncRef(&SDL_last_joystick_instance_id) + 1;
 }
 
 /*

--- a/src/joystick/SDL_joystick_c.h
+++ b/src/joystick/SDL_joystick_c.h
@@ -53,9 +53,6 @@ extern void SDL_AssertJoysticksLocked(void) SDL_ASSERT_CAPABILITY(SDL_joystick_l
 /* Function to return whether there are any joysticks opened by the application */
 extern SDL_bool SDL_JoysticksOpened(void);
 
-/* Function to get the next available joystick instance ID */
-extern SDL_JoystickID SDL_GetNextJoystickInstanceID(void);
-
 /* Function to standardize the name for a controller
    This should be freed with SDL_free() when no longer needed
  */

--- a/src/joystick/android/SDL_sysjoystick.c
+++ b/src/joystick/android/SDL_sysjoystick.c
@@ -378,7 +378,7 @@ int Android_AddJoystick(int device_id, const char *name, const char *desc, int v
     }
     item->naxes = naxes;
     item->nhats = nhats;
-    item->device_instance = SDL_GetNextJoystickInstanceID();
+    item->device_instance = SDL_GetNextObjectID();
     if (SDL_joylist_tail == NULL) {
         SDL_joylist = SDL_joylist_tail = item;
     } else {

--- a/src/joystick/apple/SDL_mfijoystick.m
+++ b/src/joystick/apple/SDL_mfijoystick.m
@@ -561,7 +561,7 @@ static void IOS_AddJoystickDevice(GCController *controller, SDL_bool acceleromet
     }
 
     device->accelerometer = accelerometer;
-    device->instance_id = SDL_GetNextJoystickInstanceID();
+    device->instance_id = SDL_GetNextObjectID();
 
     if (accelerometer) {
 #ifdef SDL_JOYSTICK_iOS_ACCELEROMETER

--- a/src/joystick/bsd/SDL_bsdjoystick.c
+++ b/src/joystick/bsd/SDL_bsdjoystick.c
@@ -466,7 +466,7 @@ static int MaybeAddDevice(const char *path)
         return -1;
     }
 
-    item->device_instance = SDL_GetNextJoystickInstanceID();
+    item->device_instance = SDL_GetNextObjectID();
     if (SDL_joylist_tail == NULL) {
         SDL_joylist = SDL_joylist_tail = item;
     } else {

--- a/src/joystick/darwin/SDL_iokitjoystick.c
+++ b/src/joystick/darwin/SDL_iokitjoystick.c
@@ -549,7 +549,7 @@ static void JoystickDeviceWasAddedCallback(void *ctx, IOReturn res, void *sender
     device->runLoopAttached = SDL_TRUE;
 
     /* Allocate an instance ID for this device */
-    device->instance_id = SDL_GetNextJoystickInstanceID();
+    device->instance_id = SDL_GetNextObjectID();
 
     /* We have to do some storage of the io_service_t for SDL_HapticOpenFromJoystick */
     ioservice = IOHIDDeviceGetService(ioHIDDeviceObject);

--- a/src/joystick/hidapi/SDL_hidapijoystick.c
+++ b/src/joystick/hidapi/SDL_hidapijoystick.c
@@ -790,7 +790,7 @@ SDL_bool HIDAPI_JoystickConnected(SDL_HIDAPI_Device *device, SDL_JoystickID *pJo
         }
     }
 
-    joystickID = SDL_GetNextJoystickInstanceID();
+    joystickID = SDL_GetNextObjectID();
     HIDAPI_AddJoystickInstanceToDevice(device, joystickID);
 
     for (i = 0; i < device->num_children; ++i) {

--- a/src/joystick/linux/SDL_sysjoystick.c
+++ b/src/joystick/linux/SDL_sysjoystick.c
@@ -443,7 +443,7 @@ static int MaybeAddDevice(const char *path)
             return -1;
         }
 
-        item->device_instance = SDL_GetNextJoystickInstanceID();
+        item->device_instance = SDL_GetNextObjectID();
         if (SDL_joylist_tail == NULL) {
             SDL_joylist = SDL_joylist_tail = item;
         } else {
@@ -615,7 +615,7 @@ static SDL_bool SteamControllerConnectedCallback(const char *name, SDL_JoystickG
         return SDL_FALSE;
     }
 
-    *device_instance = item->device_instance = SDL_GetNextJoystickInstanceID();
+    *device_instance = item->device_instance = SDL_GetNextObjectID();
     if (SDL_joylist_tail == NULL) {
         SDL_joylist = SDL_joylist_tail = item;
     } else {

--- a/src/joystick/virtual/SDL_virtualjoystick.c
+++ b/src/joystick/virtual/SDL_virtualjoystick.c
@@ -237,7 +237,7 @@ SDL_JoystickID SDL_JoystickAttachVirtualInner(const SDL_VirtualJoystickDesc *des
     }
 
     /* Allocate an instance ID for this device */
-    hwdata->instance_id = SDL_GetNextJoystickInstanceID();
+    hwdata->instance_id = SDL_GetNextObjectID();
 
     /* Add virtual joystick to SDL-global lists */
     if (g_VJoys) {

--- a/src/joystick/windows/SDL_rawinputjoystick.c
+++ b/src/joystick/windows/SDL_rawinputjoystick.c
@@ -920,7 +920,7 @@ static void RAWINPUT_AddDevice(HANDLE hDevice)
     CloseHandle(hFile);
     hFile = INVALID_HANDLE_VALUE;
 
-    device->joystick_id = SDL_GetNextJoystickInstanceID();
+    device->joystick_id = SDL_GetNextObjectID();
 
 #ifdef DEBUG_RAWINPUT
     SDL_Log("Adding RAWINPUT device '%s' VID 0x%.4x, PID 0x%.4x, version %d, handle 0x%.8x\n", device->name, device->vendor_id, device->product_id, device->version, device->hDevice);

--- a/src/joystick/windows/SDL_windows_gaming_input.c
+++ b/src/joystick/windows/SDL_windows_gaming_input.c
@@ -489,7 +489,7 @@ static HRESULT STDMETHODCALLTYPE IEventHandler_CRawGameControllerVtbl_InvokeAdde
             WindowsGamingInputControllerState *controllers = SDL_realloc(wgi.controllers, sizeof(wgi.controllers[0]) * (wgi.controller_count + 1));
             if (controllers) {
                 WindowsGamingInputControllerState *state = &controllers[wgi.controller_count];
-                SDL_JoystickID joystickID = SDL_GetNextJoystickInstanceID();
+                SDL_JoystickID joystickID = SDL_GetNextObjectID();
 
                 SDL_zerop(state);
                 state->instance_id = joystickID;

--- a/src/joystick/windows/SDL_windowsjoystick.c
+++ b/src/joystick/windows/SDL_windowsjoystick.c
@@ -453,7 +453,7 @@ static void SDL_StopJoystickThread(void)
 void WINDOWS_AddJoystickDevice(JoyStick_DeviceData *device)
 {
     device->send_add_event = SDL_TRUE;
-    device->nInstanceID = SDL_GetNextJoystickInstanceID();
+    device->nInstanceID = SDL_GetNextObjectID();
     device->pNext = SYS_Joystick;
     SYS_Joystick = device;
 }

--- a/src/sensor/SDL_sensor.c
+++ b/src/sensor/SDL_sensor.c
@@ -58,7 +58,6 @@ static SDL_AtomicInt SDL_sensor_lock_pending;
 static int SDL_sensors_locked;
 static SDL_bool SDL_sensors_initialized;
 static SDL_Sensor *SDL_sensors SDL_GUARDED_BY(SDL_sensor_lock) = NULL;
-static SDL_AtomicInt SDL_last_sensor_instance_id;
 static char SDL_sensor_magic;
 
 #define CHECK_SENSOR_MAGIC(sensor, retval)              \
@@ -216,15 +215,6 @@ SDL_SensorID *SDL_GetSensors(int *count)
     SDL_UnlockSensors();
 
     return sensors;
-}
-
-/*
- * Return the next available sensor instance ID
- * This may be called by drivers from multiple threads, unprotected by any locks
- */
-SDL_SensorID SDL_GetNextSensorInstanceID(void)
-{
-    return SDL_AtomicIncRef(&SDL_last_sensor_instance_id) + 1;
 }
 
 /*

--- a/src/sensor/SDL_sensor_c.h
+++ b/src/sensor/SDL_sensor_c.h
@@ -31,9 +31,6 @@ struct SDL_SensorDriver;
 
 /* Useful functions and variables from SDL_sensor.c */
 
-/* Function to get the next available sensor instance ID */
-extern SDL_SensorID SDL_GetNextSensorInstanceID(void);
-
 /* Initialization and shutdown functions */
 extern int SDL_InitSensors(void);
 extern void SDL_QuitSensors(void);

--- a/src/sensor/android/SDL_androidsensor.c
+++ b/src/sensor/android/SDL_androidsensor.c
@@ -152,7 +152,7 @@ static int SDL_ANDROID_SensorInit(void)
 
         for (i = 0; i < sensors_count; ++i) {
             SDL_sensors[i].asensor = sensors[i];
-            SDL_sensors[i].instance_id = SDL_GetNextSensorInstanceID();
+            SDL_sensors[i].instance_id = SDL_GetNextObjectID();
         }
         SDL_sensors_count = sensors_count;
     }

--- a/src/sensor/coremotion/SDL_coremotionsensor.m
+++ b/src/sensor/coremotion/SDL_coremotionsensor.m
@@ -63,12 +63,12 @@ static int SDL_COREMOTION_SensorInit(void)
         i = 0;
         if (SDL_motion_manager.accelerometerAvailable) {
             SDL_sensors[i].type = SDL_SENSOR_ACCEL;
-            SDL_sensors[i].instance_id = SDL_GetNextSensorInstanceID();
+            SDL_sensors[i].instance_id = SDL_GetNextObjectID();
             ++i;
         }
         if (SDL_motion_manager.gyroAvailable) {
             SDL_sensors[i].type = SDL_SENSOR_GYRO;
-            SDL_sensors[i].instance_id = SDL_GetNextSensorInstanceID();
+            SDL_sensors[i].instance_id = SDL_GetNextObjectID();
             ++i;
         }
         SDL_sensors_count = sensors_count;

--- a/src/sensor/n3ds/SDL_n3dssensor.c
+++ b/src/sensor/n3ds/SDL_n3dssensor.c
@@ -54,9 +54,9 @@ static int N3DS_SensorInit(void)
     }
 
     N3DS_sensors[0].type = SDL_SENSOR_ACCEL;
-    N3DS_sensors[0].instance_id = SDL_GetNextSensorInstanceID();
+    N3DS_sensors[0].instance_id = SDL_GetNextObjectID();
     N3DS_sensors[1].type = SDL_SENSOR_GYRO;
-    N3DS_sensors[1].instance_id = SDL_GetNextSensorInstanceID();
+    N3DS_sensors[1].instance_id = SDL_GetNextObjectID();
     return 0;
 }
 

--- a/src/sensor/vita/SDL_vitasensor.c
+++ b/src/sensor/vita/SDL_vitasensor.c
@@ -56,9 +56,9 @@ static int SDL_VITA_SensorInit(void)
     }
 
     SDL_sensors[0].type = SDL_SENSOR_ACCEL;
-    SDL_sensors[0].instance_id = SDL_GetNextSensorInstanceID();
+    SDL_sensors[0].instance_id = SDL_GetNextObjectID();
     SDL_sensors[1].type = SDL_SENSOR_GYRO;
-    SDL_sensors[1].instance_id = SDL_GetNextSensorInstanceID();
+    SDL_sensors[1].instance_id = SDL_GetNextObjectID();
 
     return 0;
 }

--- a/src/sensor/windows/SDL_windowssensor.c
+++ b/src/sensor/windows/SDL_windowssensor.c
@@ -315,7 +315,7 @@ static int ConnectSensor(ISensor *sensor)
     ++SDL_num_sensors;
 
     SDL_zerop(new_sensor);
-    new_sensor->id = SDL_GetNextSensorInstanceID();
+    new_sensor->id = SDL_GetNextObjectID();
     new_sensor->sensor = sensor;
     new_sensor->type = type;
     new_sensor->name = name;

--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -364,7 +364,6 @@ struct SDL_VideoDevice
     SDL_Window *windows;
     SDL_Window *grabbed_window;
     Uint8 window_magic;
-    SDL_WindowID next_object_id;
     Uint32 clipboard_sequence;
     SDL_ClipboardDataCallback clipboard_callback;
     SDL_ClipboardCleanupCallback clipboard_cleanup;

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -517,7 +517,6 @@ int SDL_VideoInit(const char *driver_name)
     pre_driver_error. */
     _this = video;
     _this->name = bootstrap[i]->name;
-    _this->next_object_id = 1;
     _this->thread = SDL_ThreadID();
 
     /* Set some very sane GL defaults */
@@ -664,7 +663,7 @@ SDL_DisplayID SDL_AddVideoDisplay(const SDL_VideoDisplay *display, SDL_bool send
     _this->displays = displays;
     _this->displays[_this->num_displays++] = new_display;
 
-    id = _this->next_object_id++;
+    id = SDL_GetNextObjectID();
     SDL_memcpy(new_display, display, sizeof(*new_display));
     new_display->id = id;
     new_display->device = _this;
@@ -1950,7 +1949,7 @@ static SDL_Window *SDL_CreateWindowInternal(const char *title, int x, int y, int
         return NULL;
     }
     window->magic = &_this->window_magic;
-    window->id = _this->next_object_id++;
+    window->id = SDL_GetNextObjectID();
     window->windowed.x = window->x = x;
     window->windowed.y = window->y = y;
     window->windowed.w = window->w = w;
@@ -2116,7 +2115,7 @@ SDL_Window *SDL_CreateWindowFrom(const void *data)
         return NULL;
     }
     window->magic = &_this->window_magic;
-    window->id = _this->next_object_id++;
+    window->id = SDL_GetNextObjectID();
     window->flags = flags;
     window->is_destroying = SDL_FALSE;
     window->display_scale = 1.0f;


### PR DESCRIPTION
This ensures that we don't accidentally interpret an ID from one system as an ID in another system. Audio device IDs are not covered here, since they have a unique numbering system.