### PR TITLE
Fix undefined behaviour in memcpy when destination ptr is null

### DIFF
--- a/src/hidapi/mac/hid.c
+++ b/src/hidapi/mac/hid.c
@@ -957,7 +957,10 @@ static int return_data(hid_device *dev, unsigned char *data, size_t length)
 	size_t len = 0;
 	if (rpt != NULL) {
 		len = (length < rpt->len)? length: rpt->len;
-		memcpy(data, rpt->data, len);
+		if (data != NULL)
+		{
+			memcpy(data, rpt->data, len);
+		}
 		dev->input_reports = rpt->next;
 		free(rpt->data);
 		free(rpt);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

addresses https://github.com/libsdl-org/SDL/issues/8428

## Description

`memcpy()` with null destination pointer is undefined behaviour.

## Existing Issue(s)

https://github.com/libsdl-org/SDL/issues/8428
