### PR TITLE
events: Expose a safe method for copying event objects in userspace

### DIFF
--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -910,6 +910,25 @@ extern DECLSPEC SDL_bool SDLCALL SDL_WaitEvent(SDL_Event *event);
 extern DECLSPEC SDL_bool SDLCALL SDL_WaitEventTimeout(SDL_Event *event, Sint32 timeoutMS);
 
 /**
+ * Copy an event
+ *
+ * Some events have internal state and dynamically allocated data that must be
+ * appropriately handled when copying an event object, which won't be accounted for by
+ * a standard memcpy operation. Use this function when making copies of event objects to
+ * ensure that all internal state and reference counting is handled correctly.
+ *
+ * The guidelines for calling SDL_CleanupEvent() apply to copied events as well.
+ *
+ * \param dst a pointer to the destination event
+ * \param src a pointer to the source event
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_CleanupEvent
+ */
+extern DECLSPEC void SDLCALL SDL_CopyEvent(SDL_Event *dst, const SDL_Event *src);
+
+/**
  * Clean up dynamically allocated memory for an event.
  *
  * Some events have dynamically allocated data that must be cleaned up when
@@ -926,6 +945,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_WaitEventTimeout(SDL_Event *event, Sint32 t
  * \sa SDL_PollEvent
  * \sa SDL_WaitEvent
  * \sa SDL_WaitEventTimeout
+ * \sa SDL_CopyEvent
  */
 extern DECLSPEC void SDLCALL SDL_CleanupEvent(SDL_Event *event);
 

--- a/src/dynapi/SDL_dynapi.sym
+++ b/src/dynapi/SDL_dynapi.sym
@@ -924,6 +924,7 @@ SDL3_0.0.0 {
     SDL_CleanupEvent;
     SDL_RWprintf;
     SDL_RWvprintf;
+    SDL_CopyEvent;
     # extra symbols go here (don't modify this line)
   local: *;
 };

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -949,3 +949,4 @@
 #define SDL_CleanupEvent SDL_CleanupEvent_REAL
 #define SDL_RWprintf SDL_RWprintf_REAL
 #define SDL_RWvprintf SDL_RWvprintf_REAL
+#define SDL_CopyEvent SDL_CopyEvent_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -981,3 +981,4 @@ SDL_DYNAPI_PROC(int,SDL_ClearProperty,(SDL_PropertiesID a, const char *b),(a,b),
 SDL_DYNAPI_PROC(int,SDL_EnterAppMainCallbacks,(int a, char *b[], SDL_AppInit_func c, SDL_AppIterate_func d, SDL_AppEvent_func e, SDL_AppQuit_func f),(a,b,c,d,e,f),return)
 SDL_DYNAPI_PROC(void,SDL_CleanupEvent,(SDL_Event *a),(a),)
 SDL_DYNAPI_PROC(size_t,SDL_RWvprintf,(SDL_RWops *a, const char *b, va_list c),(a,b,c),return)
+SDL_DYNAPI_PROC(void,SDL_CopyEvent,(SDL_Event *a, const SDL_Event *b),(a,b),)

--- a/src/events/SDL_dropevents.c
+++ b/src/events/SDL_dropevents.c
@@ -67,7 +67,7 @@ static int SDL_SendDrop(SDL_Window *window, const SDL_EventType evtype, const ch
                 SDL_memcpy(event.drop.short_data, data, len + 1);
                 event.drop.data = event.drop.short_data;
             } else {
-                event.drop.data = SDL_strdup(data);
+                event.drop.data = SDL_StrDupEventStr(data);
             }
         }
         event.drop.windowID = window ? window->id : 0;

--- a/src/events/SDL_events_c.h
+++ b/src/events/SDL_events_c.h
@@ -53,6 +53,8 @@ extern void SDL_QuitEvents(void);
 
 extern void SDL_SendPendingSignalEvents(void);
 
+extern char *SDL_StrDupEventStr(const char *str);
+
 extern int SDL_InitQuit(void);
 extern void SDL_QuitQuit(void);
 

--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -1080,7 +1080,7 @@ int SDL_SendKeyboardText(const char *text)
             SDL_memcpy(event.text.short_text, text, len + 1);
             event.text.text = event.text.short_text;
         } else {
-            event.text.text = SDL_strdup(text);
+            event.text.text = SDL_StrDupEventStr(text);
         }
 
         posted = (SDL_PushEvent(&event) > 0);
@@ -1109,7 +1109,7 @@ int SDL_SendEditingText(const char *text, int start, int length)
             SDL_memcpy(event.edit.short_text, text, len + 1);
             event.edit.text = event.edit.short_text;
         } else {
-            event.edit.text = SDL_strdup(text);
+            event.edit.text = SDL_StrDupEventStr(text);
         }
 
         posted = (SDL_PushEvent(&event) > 0);


### PR DESCRIPTION
Exports SDL_CopyEvents() for userspace use.

Events can contain pointers to dynamically allocated data, and making copies of events will result in two event objects holding pointers to the same memory. If the cleanup function is run on any of the events, the copies will still be holding pointers to freed data, which will cause issues if it is later dereferenced or cleaned up.

Dynamic memory allocations for events are now reference counted to ensure that allocations persist until all instances of their associated event have been cleaned up.