### PR TITLE
use RAWMOUSE.ulExtraInformation for discerning touch events.

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -609,9 +609,8 @@ typedef enum
     SDL_MOUSE_EVENT_SOURCE_PEN,
 } SDL_MOUSE_EVENT_SOURCE;
 
-static SDL_MOUSE_EVENT_SOURCE GetMouseMessageSource()
+static SDL_MOUSE_EVENT_SOURCE GetMouseMessageSource(ULONG extrainfo)
 {
-    LPARAM extrainfo = GetMessageExtraInfo();
     /* Mouse data (ignoring synthetic mouse events generated for touchscreens) */
     /* Versions below Vista will set the low 7 bits to the Mouse ID and don't use bit 7:
        Check bits 8-32 for the signature (which will indicate a Tablet PC Pen or Touch Device).
@@ -831,7 +830,8 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
         if (!mouse->relative_mode || mouse->relative_mode_warp) {
             /* Only generate mouse events for real mouse */
-            if (GetMouseMessageSource() != SDL_MOUSE_EVENT_SOURCE_TOUCH &&
+            LPARAM extrainfo = GetMessageExtraInfo();
+            if (GetMouseMessageSource((ULONG)extrainfo) != SDL_MOUSE_EVENT_SOURCE_TOUCH &&
                 lParam != data->last_pointer_update) {
                 SDL_SendMouseMotion(WIN_GetEventTimestamp(), data->window, 0, 0, (float)GET_X_LPARAM(lParam), (float)GET_Y_LPARAM(lParam));
             }
@@ -853,7 +853,8 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
     {
         SDL_Mouse *mouse = SDL_GetMouse();
         if (!mouse->relative_mode || mouse->relative_mode_warp) {
-            if (GetMouseMessageSource() != SDL_MOUSE_EVENT_SOURCE_TOUCH &&
+            LPARAM extrainfo = GetMessageExtraInfo();
+            if (GetMouseMessageSource((ULONG)extrainfo) != SDL_MOUSE_EVENT_SOURCE_TOUCH &&
                 lParam != data->last_pointer_update) {
                 WIN_CheckWParamMouseButtons(wParam, data, 0);
             }
@@ -884,7 +885,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
             SDL_MouseID mouseID;
             RAWMOUSE *rawmouse;
             if (SDL_GetNumTouchDevices() > 0 &&
-                (GetMouseMessageSource() == SDL_MOUSE_EVENT_SOURCE_TOUCH || (GetMessageExtraInfo() & 0x82) == 0x82)) {
+                (GetMouseMessageSource(inp.data.mouse.ulExtraInformation) == SDL_MOUSE_EVENT_SOURCE_TOUCH || (inp.data.mouse.ulExtraInformation & 0x82) == 0x82)) {
                 break;
             }
             /* We do all of our mouse state checking against mouse ID 0


### PR DESCRIPTION
The `GetMessageExtraInfo()` result is not authoritative of what the message's original extrainfo was, because the program can always call `SetMessageExtraInfo` to mutate the global state until the next message is fetched from the queue in the messageloop.

On the other hand, RAWMOUSE's ulExtraInfo field is always associated with the individual ExtraInfo that the OS originally supplied it with, meaning that 1) it is not subject to mutation and 2) it can be retrieved asynchronously without worrying about the extrainfo field being overwritten by the next message fetch.

Notes that this is a "rough sketch" PR as I'm not familiar with the codebase or C programming in general, it's mainly to convey the general idea and will need your guidance on how to fix it correctly.

I've left in place some of the `GetMessageExtraInfo` calls for non-`WM_INPUT` messages, not quite sure what to do with those yet

Closes https://github.com/libsdl-org/SDL/issues/8298