### PR TITLE
Always set menubar visibiliy when going fullscreen on macOS

### DIFF
--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -1018,10 +1018,6 @@ static void Cocoa_SendExposedEventIfVisible(SDL_Window *window)
     if (SDL_GetKeyboardFocus() == _data.window) {
         SDL_SetKeyboardFocus(NULL);
     }
-
-    if (isFullscreenSpace) {
-        [NSMenu setMenuBarVisible:YES];
-    }
 }
 
 - (void)windowDidChangeBackingProperties:(NSNotification *)aNotification
@@ -1181,7 +1177,6 @@ static void Cocoa_SendExposedEventIfVisible(SDL_Window *window)
         } else {
             [nswindow setCollectionBehavior:NSWindowCollectionBehaviorManaged];
         }
-        [NSMenu setMenuBarVisible:YES];
 
         pendingWindowOperation = PENDING_OPERATION_NONE;
 
@@ -2552,9 +2547,6 @@ void Cocoa_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
 
 #endif /* SDL_VIDEO_OPENGL */
 
-            if ([data.listener isInFullscreenSpace]) {
-                [NSMenu setMenuBarVisible:YES];
-            }
             [data.listener close];
             data.listener = nil;
             if (data.created) {
@@ -2634,6 +2626,8 @@ SDL_bool Cocoa_SetWindowFullscreenSpace(SDL_Window *window, SDL_bool state)
             }
             /* Return TRUE to prevent non-space fullscreen logic from running */
             succeeded = SDL_TRUE;
+
+            [NSMenu setMenuBarVisible:YES];
         }
         data.inWindowFullscreenTransition = SDL_FALSE;
 


### PR DESCRIPTION
## Description
This will always make sure that the menu bar is visible when window goes to fullscreen space on macOS

## Existing Issue(s)
I noticed that when a window is created with a fullscreen window flag on macos the menubar won't be available

```c++
SDL_CreateWindow(nullptr, default_window_width, default_window_height, SDL_WINDOW_FULLSCREEN)
```

But when a window is manually set to fullscreen then menubar visibility will be true
```c++
SDL_SetWindowFullscreen(window, SDL_TRUE);
```

# Question
Is it right to asume that the menubar should be always shown with `[NSMenu setMenuBarVisible:YES];` when calling `Cocoa_SetWindowFullscreenSpace` ?
