### PR TITLE
Fix uninitialised variable 'properties'

### DIFF
--- a/src/SDL_properties.c
+++ b/src/SDL_properties.c
@@ -119,7 +119,7 @@ SDL_PropertiesID SDL_CreateProperties(void)
         return 0;
     }
 
-    properties = SDL_malloc(sizeof(*properties));
+    properties = SDL_calloc(1, sizeof(*properties));
     if (!properties) {
         goto error;
     }


### PR DESCRIPTION

## Description
If SDL_CreateHashTable() fails, properties->lock is not initialised, SDL_FreeProperties() is called and destroys the uninitialised lock.

## Existing Issue(s)
None

