### PR TITLE
cpuinfo: Fix detection of physical memory above 2GB on NetBSD

### DIFF
--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -1011,16 +1011,19 @@ int SDL_GetSystemRAM(void)
 #endif
 #ifdef HAVE_SYSCTLBYNAME
         if (SDL_SystemRAM <= 0) {
-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__DragonFly__)
-#ifdef HW_REALMEM
+#ifdef HW_PHYSMEM64
+            /* (64-bit): NetBSD since 2003, OpenBSD */
+            int mib[2] = { CTL_HW, HW_PHYSMEM64 };
+#elif defined(HW_REALMEM)
+            /* (64-bit): FreeBSD since 2005, DragonFly */
             int mib[2] = { CTL_HW, HW_REALMEM };
-#else
-            /* might only report up to 2 GiB */
-            int mib[2] = { CTL_HW, HW_PHYSMEM };
-#endif /* HW_REALMEM */
-#else
+#elif defined(HW_MEMSIZE)
+            /* (64-bit): Darwin */
             int mib[2] = { CTL_HW, HW_MEMSIZE };
-#endif /* __FreeBSD__ || __FreeBSD_kernel__ */
+#else
+            /* (32-bit): very old BSD, might only report up to 2 GiB */
+            int mib[2] = { CTL_HW, HW_PHYSMEM };
+#endif /* HW_PHYSMEM64 */
             Uint64 memsize = 0;
             size_t len = sizeof(memsize);
 


### PR DESCRIPTION
Rework the code to clearly prefer 64-bit sysctls first, then legacy sysctls, and eliminate a second ifdef.

HW_PHYSMEM64: https://github.com/NetBSD/src/commit/9e7bb2595ef5b2d59e74dc036b67e6b0efe842c8

HW_REALMEM: https://github.com/freebsd/freebsd-src/commit/a09150446db803d356fd7058462a595bdb114f0e

HW_MEMSIZE: https://opensource.apple.com/source/xnu/xnu-1456.1.26/bsd/sys/sysctl.h.auto.html