### PR TITLE
Replacing SDL_SCANCODE_AUDIOMUTE by SDL_SCANCODE_MUTE on Windows

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -189,7 +189,7 @@ static SDL_Scancode VKeytoScancode(WPARAM vkey)
     case VK_BROWSER_HOME:
         return SDL_SCANCODE_AC_HOME;
     case VK_VOLUME_MUTE:
-        return SDL_SCANCODE_AUDIOMUTE;
+        return SDL_SCANCODE_MUTE;
     case VK_VOLUME_DOWN:
         return SDL_SCANCODE_VOLUMEDOWN;
     case VK_VOLUME_UP:
@@ -500,7 +500,7 @@ static void WIN_UpdateFocus(SDL_Window *window, SDL_bool expect_focus)
         SDL_ToggleModState(KMOD_CAPS, (GetKeyState(VK_CAPITAL) & 0x0001) ? SDL_TRUE : SDL_FALSE);
         SDL_ToggleModState(KMOD_NUM, (GetKeyState(VK_NUMLOCK) & 0x0001) ? SDL_TRUE : SDL_FALSE);
         SDL_ToggleModState(KMOD_SCROLL, (GetKeyState(VK_SCROLL) & 0x0001) ? SDL_TRUE : SDL_FALSE);
- 
+
         WIN_UpdateWindowICCProfile(data->window, SDL_TRUE);
     } else {
         RECT rect;


### PR DESCRIPTION
## Description
When using the MUTE button on the keyboard, there was an inconsistency between my Linux installation and my Windows installation. With SDL on Linux, the MUTE button triggers a SDL_SCANCODE_MUTE constant and on windows, it triggers a SDL_SCANCODE_AUDIOMUTE constant. Base on the context of the Windows code, I think that the SDL_SCANCODE_MUTE should be the good one to use.

