### PR TITLE
SDL_VideoCapture: use 0-copy for backend android and linux/v4l2

### DIFF
--- a/include/SDL3/SDL_video_capture.h
+++ b/include/SDL3/SDL_video_capture.h
@@ -104,6 +104,8 @@ typedef struct SDL_VideoCaptureFrame
     int num_planes;             /**< Number of planes */
     Uint8 *data[3];             /**< Pointer to data of i-th plane */
     int pitch[3];               /**< Pitch of i-th plane */
+    int fd;                     /**< DMABUF file descriptor if available (-1 if not) */
+    void *clientbuffer;         /**< Android clientbuffer if available (NULL if not) */
     void *internal;             /**< Private field */
 } SDL_VideoCaptureFrame;
 

--- a/src/video/SDL_video_capture.c
+++ b/src/video/SDL_video_capture.c
@@ -408,6 +408,8 @@ SDL_CaptureVideoThread(void *devicep)
         entry_t *entry;
 
         SDL_zero(f);
+        f.fd = -1;
+        f.clientbuffer = NULL;
 
         SDL_LockMutex(device->acquiring_lock);
         ret = AcquireFrame(device, &f);
@@ -640,6 +642,8 @@ SDL_AcquireVideoCaptureFrame(SDL_VideoCaptureDevice *device, SDL_VideoCaptureFra
     }
 
     SDL_zerop(frame);
+    frame->fd = -1;
+    frame->clientbuffer = NULL;
 
     if (device->thread == NULL) {
         int ret;

--- a/src/video/SDL_video_capture_v4l2.c
+++ b/src/video/SDL_video_capture_v4l2.c
@@ -42,6 +42,7 @@ enum io_method {
 struct buffer {
     void   *start;
     size_t  length;
+    int dmabuf_fd;
     int available; /* Is available in userspace */
 };
 
@@ -136,6 +137,7 @@ acquire_frame(SDL_VideoCaptureDevice *_this, SDL_VideoCaptureFrame *frame)
             frame->num_planes = 1;
             frame->data[0] = _this->hidden->buffers[buf.index].start;
             frame->pitch[0] = _this->hidden->driver_pitch;
+            frame->fd = _this->hidden->buffers[buf.index].dmabuf_fd;
             _this->hidden->buffers[buf.index].available = 1;
 
 #if DEBUG_VIDEO_CAPTURE_CAPTURE
@@ -527,6 +529,26 @@ alloc_buffer_userp(SDL_VideoCaptureDevice *_this, size_t buffer_size)
     return 0;
 }
 
+static int
+export_dmabuf(SDL_VideoCaptureDevice *_this)
+{
+    int fd = _this->hidden->fd;
+    Uint32 i;
+    for (i = 0; i < _this->hidden->nb_buffers; ++i) {
+        struct v4l2_exportbuffer expbuf;
+        SDL_zero(expbuf);
+        expbuf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+        expbuf.index = i;
+        expbuf.flags = O_RDWR;
+        if (ioctl(fd, VIDIOC_EXPBUF, &expbuf) == -1) {
+            SDL_SetError("VIDIOC_EXPBUF");
+            return -1;
+        }
+        _this->hidden->buffers[i].dmabuf_fd = expbuf.fd;
+    }
+    return 0;
+}
+
 static Uint32
 format_v4l2_2_sdl(Uint32 fmt)
 {
@@ -768,9 +790,14 @@ InitDevice(SDL_VideoCaptureDevice *_this)
     }
 
     {
+        Uint32 i;
         _this->hidden->buffers = SDL_calloc(_this->hidden->nb_buffers, sizeof(*_this->hidden->buffers));
         if (!_this->hidden->buffers) {
             return SDL_OutOfMemory();
+        }
+
+        for (i = 0; i < _this->hidden->nb_buffers; ++i) {
+            _this->hidden->buffers[i].dmabuf_fd = -1;
         }
     }
 
@@ -785,6 +812,8 @@ InitDevice(SDL_VideoCaptureDevice *_this)
 
             case IO_METHOD_MMAP:
                 ret = alloc_buffer_mmap(_this);
+
+                export_dmabuf(_this);
                 break;
 
             case IO_METHOD_USERPTR:
@@ -819,6 +848,9 @@ CloseDevice(SDL_VideoCaptureDevice *_this)
 
                 case IO_METHOD_MMAP:
                     for (i = 0; i < _this->hidden->nb_buffers; ++i) {
+                        if (_this->hidden->buffers[i].dmabuf_fd != -1) {
+                            close(_this->hidden->buffers[i].dmabuf_fd);
+                        }
                         if (munmap(_this->hidden->buffers[i].start, _this->hidden->buffers[i].length) == -1) {
                             SDL_SetError("munmap");
                         }

--- a/src/video/android/SDL_android_video_capture.c
+++ b/src/video/android/SDL_android_video_capture.c
@@ -443,6 +443,15 @@ AcquireFrame(SDL_VideoCaptureDevice *_this, SDL_VideoCaptureFrame *frame)
             }
         }
 
+#if __ANDROID_API__ >= 26
+        {
+            AHardwareBuffer *buffer = NULL;
+            AImage_getHardwareBuffer(image, &buffer);
+            if (buffer && eglGetNativeClientBufferANDROID) {
+                frame->clientbuffer = eglGetNativeClientBufferANDROID(buffer);
+            }
+        }
+#endif
         frame->internal = (void*)image;
         return 0;
     } else if (res == AMEDIA_IMGREADER_MAX_IMAGES_ACQUIRED) {


### PR DESCRIPTION
this allows to do 0-copy when doing video capture.

linux / android back-end.


I re-applied the patch I wrote before. This used to work with android and linux.
currently:
- not tested on Android.
- on linux: this now crashes in "glEGLImageTargetTexture2DOES()"
  not sure why ...
  (If you comment this function, buffers seem to iterates correctly but nothing is display ofcourse...)

