### PR TITLE
Make size cursors be double arrows on Wayland

### DIFF
--- a/src/video/wayland/SDL_waylandmouse.c
+++ b/src/video/wayland/SDL_waylandmouse.c
@@ -336,19 +336,33 @@ static SDL_bool wayland_get_system_cursor(SDL_VideoData *vdata, Wayland_CursorDa
         cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "progress");
         break;
     case SDL_SYSTEM_CURSOR_SIZENWSE:
-        cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "nw-resize");
+        cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "nwse-resize");
+        if (!cursor) {
+            /* only a single arrow */
+            cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "nw-resize");
+        }
         break;
     case SDL_SYSTEM_CURSOR_SIZENESW:
-        cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "ne-resize");
+        cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "nesw-resize");
+        if (!cursor) {
+            /* only a single arrow */
+            cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "ne-resize");
+        }
         break;
     case SDL_SYSTEM_CURSOR_SIZEWE:
-        cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "e-resize");
+        cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "ew-resize");
+        if (!cursor) {
+            cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "col-resize");
+        }
         break;
     case SDL_SYSTEM_CURSOR_SIZENS:
-        cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "n-resize");
+        cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "ns-resize");
+        if (!cursor) {
+            cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "row-resize");
+        }
         break;
     case SDL_SYSTEM_CURSOR_SIZEALL:
-        cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "fleur");  // ?
+        cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "all-scroll");
         break;
     case SDL_SYSTEM_CURSOR_NO:
         cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "not-allowed");


### PR DESCRIPTION
On Wayland, use double arrow cursors for SIZE cursors and change SIZEALL "fleur" (not in spec list) to "all-scroll". Related to changes in https://github.com/libsdl-org/SDL/pull/8582 which changed SIZENS and SIZEWE from double arrows to a single arrow.

I added fallbacks as these cursors are listed under "to be discussed" in the [spec](https://www.freedesktop.org/wiki/Specifications/cursor-spec/) but I don't know if fallback is necessary.

Only tested on GNOME (which has all the cursors).