### PR TITLE
ci: add NetBSD to test matrix

### DIFF
--- a/.github/workflows/cpactions.yml
+++ b/.github/workflows/cpactions.yml
@@ -9,53 +9,41 @@ concurrency:
 jobs:
   freebsd:
     runs-on: ubuntu-latest
-    name: FreeBSD
+    name: '${{ matrix.platform.name }} ${{ matrix.platform.os-version }}'
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { name: FreeBSD,  os: freebsd,  os-version: 13.2, os-arch: x86-64,  artifact: SDL-freebsd-x64,
+              sdl-cmake-configure-arguments: '-DSDL_CHECK_REQUIRED_INCLUDES="/usr/local/include" -DSDL_CHECK_REQUIRED_LINK_OPTIONS="-L/usr/local/lib"',
+              setup-cmd: 'sudo pkg update',
+              install-cmd: 'sudo pkg install -y cmake ninja pkgconf libXcursor libXext libXinerama libXi libXfixes libXrandr libXScrnSaver libXxf86vm wayland wayland-protocols libxkbcommon mesa-libs libglvnd evdev-proto libinotify alsa-lib jackit pipewire pulseaudio sndio dbus zh-fcitx ibus libudev-devd',
+            }
+          - { name: NetBSD,   os: netbsd,   os-version: 9.3,  os-arch: x86-64,  artifact: SDL-netbsd-x64,
+              sdl-cmake-configure-arguments: '',
+              setup-cmd: 'export PATH="/usr/pkg/sbin:/usr/pkg/bin:/sbin:$PATH";export PKG_CONFIG_PATH="/usr/pkg/lib/pkgconfig";export PKG_PATH="https://cdn.netBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r|cut -f "1 2" -d.)/All/";echo "PKG_PATH=$PKG_PATH";echo "uname -a -> \"$(uname -a)\"";sudo -E sysctl -w security.pax.aslr.enabled=0;sudo -E sysctl -w security.pax.aslr.global=0;sudo -E pkgin clean;sudo -E pkgin update',
+              install-cmd: 'sudo -E pkgin -y install cmake dbus pkgconf ninja-build pulseaudio libxkbcommon wayland wayland-protocols libinotify libusb1',
+            }
     steps:
     - uses: actions/checkout@v3
     - name: Build
-      uses: cross-platform-actions/action@v0.19.1
+      uses: cross-platform-actions/action@v0.21.1
       with:
-        operating_system: freebsd
-        version: '13.2'
+        operating_system: ${{ matrix.platform.os }}
+        architecture: ${{ matrix.platform.os-arch }}
+        version: ${{ matrix.platform.os-version }}
         run: |
-          sudo pkg update
-          sudo pkg install -y \
-              cmake \
-              ninja \
-              pkgconf \
-              libXcursor \
-              libXext \
-              libXinerama \
-              libXi \
-              libXfixes \
-              libXrandr \
-              libXScrnSaver \
-              libXxf86vm \
-              wayland \
-              wayland-protocols \
-              libxkbcommon \
-              mesa-libs \
-              libglvnd \
-              evdev-proto \
-              libinotify \
-              alsa-lib \
-              jackit \
-              pipewire \
-              pulseaudio \
-              sndio \
-              dbus \
-              zh-fcitx \
-              ibus \
-              libudev-devd
+          ${{ matrix.platform.setup-cmd }}
+          ${{ matrix.platform.install-cmd }}
           cmake -S . -B build -GNinja  \
             -Wdeprecated -Wdev -Werror \
             -DCMAKE_BUILD_TYPE=Release \
-            -DSDL_CHECK_REQUIRED_INCLUDES="/usr/local/include" \
-            -DSDL_CHECK_REQUIRED_LINK_OPTIONS="-L/usr/local/lib"
-          cmake --build build/ --config Release --verbose -- -j`sysctl -n hw.ncpu`
+            -DSDL_WERROR=ON \
+            ${{ matrix.platform.sdl-cmake-configure-arguments }}
+          cmake --build build/ --config Release --verbose
           cmake --build build/ --config Release --target package
-          
+
           cmake --build build/ --config Release --target clean
           rm -rf build/dist/_CPack_Packages
           rm -rf build/CMakeFiles
@@ -64,5 +52,5 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         if-no-files-found: error
-        name: SDL-freebsd
+        name: ${{ matrix.platform.artifact }}
         path: build/dist/SDL3*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1590,7 +1590,7 @@ elseif(UNIX AND NOT APPLE AND NOT RISCOS AND NOT HAIKU)
         set(SDL_USE_IME 1)
       endif()
 
-      if(FREEBSD AND NOT HAVE_INOTIFY)
+      if((FREEBSD OR NETBSD) AND NOT HAVE_INOTIFY)
         set(LibInotify_PKG_CONFIG_SPEC libinotify)
         pkg_check_modules(PC_LIBINOTIFY IMPORTED_TARGET ${LibInotify_PKG_CONFIG_SPEC})
         if(PC_LIBINOTIFY_FOUND)


### PR DESCRIPTION
Add NetBSD to test matrix

Building currently fails because of the following errors:
- ci installs libiconv. It cannot find the `iconv_open` symbol in the `iconv` library, but can find `iconv_open` in the C library.
  Looking at [libiconv.h from netbsd](https://cdn.netbsd.org/pub/pkgsrc/packages/NetBSD/x86_64/9.3/All/), its header does `#define iconv_open libiconv_open` for all iconv symbols.
    ```
    ld: CMakeFiles/SDL3-shared.dir/src/stdlib/SDL_iconv.c.o: in function `SDL_iconv_REAL':
    SDL_iconv.c:(.text+0xc): undefined reference to `libiconv'
    ld: CMakeFiles/SDL3-shared.dir/src/stdlib/SDL_iconv.c.o: in function `SDL_iconv_string_REAL':
    SDL_iconv.c:(.text+0x91): undefined reference to `libiconv_open'
    ld: SDL_iconv.c:(.text+0x140): undefined reference to `libiconv'
    ld: SDL_iconv.c:(.text+0x1f3): undefined reference to `libiconv_close'
    ld: SDL_iconv.c:(.text+0x215): undefined reference to `libiconv_close'
    ld: CMakeFiles/SDL3-shared.dir/src/stdlib/SDL_iconv.c.o: in function `SDL_iconv_open_REAL':
    SDL_iconv.c:(.text+0x1): undefined reference to `libiconv_open'
    ld: CMakeFiles/SDL3-shared.dir/src/stdlib/SDL_iconv.c.o: in function `SDL_iconv_close_REAL':
    SDL_iconv.c:(.text+0x6): undefined reference to `libiconv_close'
    ```
- Something kmsdrm related:
    ```
    ld: CMakeFiles/SDL3-shared.dir/src/video/kmsdrm/SDL_kmsdrmevents.c.o: in function `KMSDRM_PumpEvents':
    SDL_kmsdrmevents.c:(.text+0x3): undefined reference to `SDL_WSCONS_PumpEvents'
    ld: CMakeFiles/SDL3-shared.dir/src/video/kmsdrm/SDL_kmsdrmvideo.c.o: in function `KMSDRM_VideoQuit':
    SDL_kmsdrmvideo.c:(.text+0x8a1): undefined reference to `SDL_WSCONS_Quit'
    ld: CMakeFiles/SDL3-shared.dir/src/video/kmsdrm/SDL_kmsdrmvideo.c.o: in function `KMSDRM_VideoInit':
    SDL_kmsdrmvideo.c:(.text+0xb81): undefined reference to `SDL_WSCONS_Init'
    ```
- Looks like `__builtin_alloca` does not work for NetBSD's gcc 7.5:
    ```
    [224/229] /usr/bin/cc  -I/home/runner/work/SDL/SDL/build/include -I/home/runner/work/SDL/SDL/include -I/home/runner/work/SDL/SDL/include/SDL3 -O3 -DNDEBUG -Wall -Wundef -fno-strict-aliasing -Wshadow -Wno-unused-local-typedefs -fdiagnostics-color=always -MD -MT CMakeFiles/SDL3_test.dir/src/test/SDL_test_harness.c.o -MF CMakeFiles/SDL3_test.dir/src/test/SDL_test_harness.c.o.d -o CMakeFiles/SDL3_test.dir/src/test/SDL_test_harness.c.o -c /home/runner/work/SDL/SDL/src/test/SDL_test_harness.c
    In file included from /home/runner/work/SDL/SDL/include/SDL3/SDL.h:32:0,
                     from /home/runner/work/SDL/SDL/include/SDL3/SDL_test.h:33,
                     from /home/runner/work/SDL/SDL/src/test/SDL_test_harness.c:21:
    /home/runner/work/SDL/SDL/include/SDL3/SDL_stdinc.h:45:19: warning: "__builtin_alloca" is not defined, evaluates to 0 [-Wundef]
     #   define alloca __builtin_alloca
                       ^
    ```

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
Fixes #8537