### PR TITLE
Add 8 direction cursors for X11/Wayland hit testing window resizing

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -180,6 +180,14 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     private static final int SDL_SYSTEM_CURSOR_SIZEALL = 9;
     private static final int SDL_SYSTEM_CURSOR_NO = 10;
     private static final int SDL_SYSTEM_CURSOR_HAND = 11;
+    private static final int SDL_SYSTEM_CURSOR_WINDOW_TOPLEFT = 12;
+    private static final int SDL_SYSTEM_CURSOR_WINDOW_TOP = 13;
+    private static final int SDL_SYSTEM_CURSOR_WINDOW_TOPRIGHT = 14;
+    private static final int SDL_SYSTEM_CURSOR_WINDOW_RIGHT = 15;
+    private static final int SDL_SYSTEM_CURSOR_WINDOW_BOTTOMRIGHT = 16;
+    private static final int SDL_SYSTEM_CURSOR_WINDOW_BOTTOM = 17;
+    private static final int SDL_SYSTEM_CURSOR_WINDOW_BOTTOMLEFT = 18;
+    private static final int SDL_SYSTEM_CURSOR_WINDOW_LEFT = 19;
 
     protected static final int SDL_ORIENTATION_UNKNOWN = 0;
     protected static final int SDL_ORIENTATION_LANDSCAPE = 1;
@@ -1830,6 +1838,30 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
             break;
         case SDL_SYSTEM_CURSOR_HAND:
             cursor_type = 1002; //PointerIcon.TYPE_HAND;
+            break;
+        case SDL_SYSTEM_CURSOR_WINDOW_TOPLEFT:
+            cursor_type = 1017; //PointerIcon.TYPE_TOP_LEFT_DIAGONAL_DOUBLE_ARROW;
+            break;
+        case SDL_SYSTEM_CURSOR_WINDOW_TOP:
+            cursor_type = 1015; //PointerIcon.TYPE_VERTICAL_DOUBLE_ARROW;
+            break;
+        case SDL_SYSTEM_CURSOR_WINDOW_TOPRIGHT:
+            cursor_type = 1016; //PointerIcon.TYPE_TOP_RIGHT_DIAGONAL_DOUBLE_ARROW;
+            break;
+        case SDL_SYSTEM_CURSOR_WINDOW_RIGHT:
+            cursor_type = 1014; //PointerIcon.TYPE_HORIZONTAL_DOUBLE_ARROW;
+            break;
+        case SDL_SYSTEM_CURSOR_WINDOW_BOTTOMRIGHT:
+            cursor_type = 1017; //PointerIcon.TYPE_TOP_LEFT_DIAGONAL_DOUBLE_ARROW;
+            break;
+        case SDL_SYSTEM_CURSOR_WINDOW_BOTTOM:
+            cursor_type = 1015; //PointerIcon.TYPE_VERTICAL_DOUBLE_ARROW;
+            break;
+        case SDL_SYSTEM_CURSOR_WINDOW_BOTTOMLEFT:
+            cursor_type = 1016; //PointerIcon.TYPE_TOP_RIGHT_DIAGONAL_DOUBLE_ARROW;
+            break;
+        case SDL_SYSTEM_CURSOR_WINDOW_LEFT:
+            cursor_type = 1014; //PointerIcon.TYPE_HORIZONTAL_DOUBLE_ARROW;
             break;
         }
         if (Build.VERSION.SDK_INT >= 24 /* Android 7.0 (N) */) {

--- a/include/SDL3/SDL_mouse.h
+++ b/include/SDL3/SDL_mouse.h
@@ -59,6 +59,14 @@ typedef enum
     SDL_SYSTEM_CURSOR_SIZEALL,   /**< Four pointed arrow pointing north, south, east, and west */
     SDL_SYSTEM_CURSOR_NO,        /**< Slashed circle or crossbones */
     SDL_SYSTEM_CURSOR_HAND,      /**< Hand */
+    SDL_SYSTEM_CURSOR_WINDOW_TOPLEFT,     /**< Window resize top-left (or SIZENWSE) */
+    SDL_SYSTEM_CURSOR_WINDOW_TOP,         /**< Window resize top (or SIZENS) */
+    SDL_SYSTEM_CURSOR_WINDOW_TOPRIGHT,    /**< Window resize top-right (or SIZENESW) */
+    SDL_SYSTEM_CURSOR_WINDOW_RIGHT,       /**< Window resize right (or SIZEWE) */
+    SDL_SYSTEM_CURSOR_WINDOW_BOTTOMRIGHT, /**< Window resize bottom-right (or SIZENWSE) */
+    SDL_SYSTEM_CURSOR_WINDOW_BOTTOM,      /**< Window resize bottom (or SIZENS) */
+    SDL_SYSTEM_CURSOR_WINDOW_BOTTOMLEFT,  /**< Window resize bottom-left (or SIZENESW) */
+    SDL_SYSTEM_CURSOR_WINDOW_LEFT,        /**< Window resize left (or SIZEWE) */
     SDL_NUM_SYSTEM_CURSORS
 } SDL_SystemCursor;
 

--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -188,6 +188,30 @@ static SDL_Cursor *Cocoa_CreateSystemCursor(SDL_SystemCursor id)
         case SDL_SYSTEM_CURSOR_HAND:
             nscursor = [NSCursor pointingHandCursor];
             break;
+        case SDL_SYSTEM_CURSOR_WINDOW_TOPLEFT:
+            nscursor = LoadHiddenSystemCursor(@"resizenorthwestsoutheast", @selector(closedHandCursor));
+            break;
+        case SDL_SYSTEM_CURSOR_WINDOW_TOP:
+            nscursor = LoadHiddenSystemCursor(@"resizenorthsouth", @selector(resizeUpDownCursor));
+            break;
+        case SDL_SYSTEM_CURSOR_WINDOW_TOPRIGHT:
+            nscursor = LoadHiddenSystemCursor(@"resizenortheastsouthwest", @selector(closedHandCursor));
+            break;
+        case SDL_SYSTEM_CURSOR_WINDOW_RIGHT:
+            nscursor = LoadHiddenSystemCursor(@"resizeeastwest", @selector(resizeLeftRightCursor));
+            break;
+        case SDL_SYSTEM_CURSOR_WINDOW_BOTTOMRIGHT:
+            nscursor = LoadHiddenSystemCursor(@"resizenorthwestsoutheast", @selector(closedHandCursor));
+            break;
+        case SDL_SYSTEM_CURSOR_WINDOW_BOTTOM:
+            nscursor = LoadHiddenSystemCursor(@"resizenorthsouth", @selector(resizeUpDownCursor));
+            break;
+        case SDL_SYSTEM_CURSOR_WINDOW_BOTTOMLEFT:
+            nscursor = LoadHiddenSystemCursor(@"resizenortheastsouthwest", @selector(closedHandCursor));
+            break;
+        case SDL_SYSTEM_CURSOR_WINDOW_LEFT:
+            nscursor = LoadHiddenSystemCursor(@"resizeeastwest", @selector(resizeLeftRightCursor));
+            break;
         default:
             SDL_assert(!"Unknown system cursor");
             return NULL;

--- a/src/video/emscripten/SDL_emscriptenmouse.c
+++ b/src/video/emscripten/SDL_emscriptenmouse.c
@@ -161,6 +161,30 @@ static SDL_Cursor *Emscripten_CreateSystemCursor(SDL_SystemCursor id)
     case SDL_SYSTEM_CURSOR_HAND:
         cursor_name = "pointer";
         break;
+    case SDL_SYSTEM_CURSOR_WINDOW_TOPLEFT:
+        cursor_name = "nwse-resize";
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_TOP:
+        cursor_name = "ns-resize";
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_TOPRIGHT:
+        cursor_name = "nesw-resize";
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_RIGHT:
+        cursor_name = "ew-resize";
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_BOTTOMRIGHT:
+        cursor_name = "nwse-resize";
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_BOTTOM:
+        cursor_name = "ns-resize";
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_BOTTOMLEFT:
+        cursor_name = "nesw-resize";
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_LEFT:
+        cursor_name = "ew-resize";
+        break;
     default:
         SDL_assert(0);
         return NULL;

--- a/src/video/haiku/SDL_bvideo.cc
+++ b/src/video/haiku/SDL_bvideo.cc
@@ -152,6 +152,14 @@ static SDL_Cursor * HAIKU_CreateSystemCursor(SDL_SystemCursor id)
     case SDL_SYSTEM_CURSOR_SIZEALL:   cursorId = B_CURSOR_ID_MOVE; break;
     case SDL_SYSTEM_CURSOR_NO:        cursorId = B_CURSOR_ID_NOT_ALLOWED; break;
     case SDL_SYSTEM_CURSOR_HAND:      cursorId = B_CURSOR_ID_FOLLOW_LINK; break;
+    case SDL_SYSTEM_CURSOR_WINDOW_TOPLEFT:     cursorId = B_CURSOR_ID_RESIZE_NORTH_WEST_SOUTH_EAST; break;
+    case SDL_SYSTEM_CURSOR_WINDOW_TOP:         cursorId = B_CURSOR_ID_RESIZE_NORTH_SOUTH; break;
+    case SDL_SYSTEM_CURSOR_WINDOW_TOPRIGHT:    cursorId = B_CURSOR_ID_RESIZE_NORTH_EAST_SOUTH_WEST; break;
+    case SDL_SYSTEM_CURSOR_WINDOW_RIGHT:       cursorId = B_CURSOR_ID_RESIZE_EAST_WEST; break;
+    case SDL_SYSTEM_CURSOR_WINDOW_BOTTOMRIGHT: cursorId = B_CURSOR_ID_RESIZE_NORTH_WEST_SOUTH_EAST; break;
+    case SDL_SYSTEM_CURSOR_WINDOW_BOTTOM:      cursorId = B_CURSOR_ID_RESIZE_NORTH_SOUTH; break;
+    case SDL_SYSTEM_CURSOR_WINDOW_BOTTOMLEFT:  cursorId = B_CURSOR_ID_RESIZE_NORTH_EAST_SOUTH_WEST; break;
+    case SDL_SYSTEM_CURSOR_WINDOW_LEFT:        cursorId = B_CURSOR_ID_RESIZE_EAST_WEST; break;
     }
 
     cursor = (SDL_Cursor *) SDL_calloc(1, sizeof(*cursor));

--- a/src/video/wayland/SDL_waylandmouse.c
+++ b/src/video/wayland/SDL_waylandmouse.c
@@ -356,6 +356,30 @@ static SDL_bool wayland_get_system_cursor(SDL_VideoData *vdata, Wayland_CursorDa
     case SDL_SYSTEM_CURSOR_HAND:
         cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "pointer");
         break;
+    case SDL_SYSTEM_CURSOR_WINDOW_TOPLEFT:
+        cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "nw-resize");
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_TOP:
+        cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "n-resize");
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_TOPRIGHT:
+        cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "ne-resize");
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_RIGHT:
+        cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "e-resize");
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_BOTTOMRIGHT:
+        cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "se-resize");
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_BOTTOM:
+        cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "s-resize");
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_BOTTOMLEFT:
+        cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "sw-resize");
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_LEFT:
+        cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, "w-resize");
+        break;
     default:
         SDL_assert(0);
         return SDL_FALSE;
@@ -779,14 +803,14 @@ void Wayland_InitMouse(void)
         switch (r) {
         case SDL_HITTEST_NORMAL: sys_cursors[r] = Wayland_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW); break;
         case SDL_HITTEST_DRAGGABLE: sys_cursors[r] = Wayland_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW); break;
-        case SDL_HITTEST_RESIZE_TOPLEFT: sys_cursors[r] = Wayland_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZENWSE); break;
-        case SDL_HITTEST_RESIZE_TOP: sys_cursors[r] = Wayland_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZENS); break;
-        case SDL_HITTEST_RESIZE_TOPRIGHT: sys_cursors[r] = Wayland_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZENESW); break;
-        case SDL_HITTEST_RESIZE_RIGHT: sys_cursors[r] = Wayland_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZEWE); break;
-        case SDL_HITTEST_RESIZE_BOTTOMRIGHT: sys_cursors[r] = Wayland_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZENWSE); break;
-        case SDL_HITTEST_RESIZE_BOTTOM: sys_cursors[r] = Wayland_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZENS); break;
-        case SDL_HITTEST_RESIZE_BOTTOMLEFT: sys_cursors[r] = Wayland_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZENESW); break;
-        case SDL_HITTEST_RESIZE_LEFT: sys_cursors[r] = Wayland_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZEWE); break;
+        case SDL_HITTEST_RESIZE_TOPLEFT: sys_cursors[r] = Wayland_CreateSystemCursor(SDL_SYSTEM_CURSOR_WINDOW_TOPLEFT); break;
+        case SDL_HITTEST_RESIZE_TOP: sys_cursors[r] = Wayland_CreateSystemCursor(SDL_SYSTEM_CURSOR_WINDOW_TOP); break;
+        case SDL_HITTEST_RESIZE_TOPRIGHT: sys_cursors[r] = Wayland_CreateSystemCursor(SDL_SYSTEM_CURSOR_WINDOW_TOPRIGHT); break;
+        case SDL_HITTEST_RESIZE_RIGHT: sys_cursors[r] = Wayland_CreateSystemCursor(SDL_SYSTEM_CURSOR_WINDOW_RIGHT); break;
+        case SDL_HITTEST_RESIZE_BOTTOMRIGHT: sys_cursors[r] = Wayland_CreateSystemCursor(SDL_SYSTEM_CURSOR_WINDOW_BOTTOMRIGHT); break;
+        case SDL_HITTEST_RESIZE_BOTTOM: sys_cursors[r] = Wayland_CreateSystemCursor(SDL_SYSTEM_CURSOR_WINDOW_BOTTOM); break;
+        case SDL_HITTEST_RESIZE_BOTTOMLEFT: sys_cursors[r] = Wayland_CreateSystemCursor(SDL_SYSTEM_CURSOR_WINDOW_BOTTOMLEFT); break;
+        case SDL_HITTEST_RESIZE_LEFT: sys_cursors[r] = Wayland_CreateSystemCursor(SDL_SYSTEM_CURSOR_WINDOW_LEFT); break;
         }
         r++;
     }

--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -251,6 +251,30 @@ static SDL_Cursor *WIN_CreateSystemCursor(SDL_SystemCursor id)
     case SDL_SYSTEM_CURSOR_HAND:
         name = IDC_HAND;
         break;
+    case SDL_SYSTEM_CURSOR_WINDOW_TOPLEFT:
+        name = IDC_SIZENWSE;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_TOP:
+        name = IDC_SIZENS;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_TOPRIGHT:
+        name = IDC_SIZENESW;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_RIGHT:
+        name = IDC_SIZEWE;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_BOTTOMRIGHT:
+        name = IDC_SIZENWSE;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_BOTTOM:
+        name = IDC_SIZENS;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_BOTTOMLEFT:
+        name = IDC_SIZENESW;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_LEFT:
+        name = IDC_SIZEWE;
+        break;
     }
 
     cursor = SDL_calloc(1, sizeof(*cursor));

--- a/src/video/winrt/SDL_winrtmouse.cpp
+++ b/src/video/winrt/SDL_winrtmouse.cpp
@@ -90,6 +90,30 @@ static SDL_Cursor *WINRT_CreateSystemCursor(SDL_SystemCursor id)
     case SDL_SYSTEM_CURSOR_HAND:
         cursorType = CoreCursorType::Hand;
         break;
+    case SDL_SYSTEM_CURSOR_WINDOW_TOPLEFT:
+        cursorType = CoreCursorType::SizeNorthwestSoutheast;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_TOP:
+        cursorType = CoreCursorType::SizeNorthSouth;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_TOPRIGHT:
+        cursorType = CoreCursorType::SizeNortheastSouthwest;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_RIGHT:
+        cursorType = CoreCursorType::SizeWestEast;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_BOTTOMRIGHT:
+        cursorType = CoreCursorType::SizeNorthwestSoutheast;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_BOTTOM:
+        cursorType = CoreCursorType::SizeNorthSouth;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_BOTTOMLEFT:
+        cursorType = CoreCursorType::SizeNortheastSouthwest;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_LEFT:
+        cursorType = CoreCursorType::SizeWestEast;
+        break;
     }
 
     cursor = (SDL_Cursor *)SDL_calloc(1, sizeof(*cursor));

--- a/src/video/x11/SDL_x11mouse.c
+++ b/src/video/x11/SDL_x11mouse.c
@@ -269,6 +269,30 @@ static SDL_Cursor *X11_CreateSystemCursor(SDL_SystemCursor id)
     case SDL_SYSTEM_CURSOR_HAND:
         shape = XC_hand2;
         break;
+    case SDL_SYSTEM_CURSOR_WINDOW_TOPLEFT:
+        shape = XC_top_left_corner;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_TOP:
+        shape = XC_top_side;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_TOPRIGHT:
+        shape = XC_top_right_corner;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_RIGHT:
+        shape = XC_right_side;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_BOTTOMRIGHT:
+        shape = XC_bottom_right_corner;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_BOTTOM:
+        shape = XC_bottom_side;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_BOTTOMLEFT:
+        shape = XC_bottom_left_corner;
+        break;
+    case SDL_SYSTEM_CURSOR_WINDOW_LEFT:
+        shape = XC_left_side;
+        break;
     }
 
     cursor = SDL_calloc(1, sizeof(*cursor));
@@ -479,14 +503,14 @@ void X11_InitMouse(SDL_VideoDevice *_this)
         switch (r) {
         case SDL_HITTEST_NORMAL: sys_cursors[r] = X11_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW); break;
         case SDL_HITTEST_DRAGGABLE: sys_cursors[r] = X11_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW); break;
-        case SDL_HITTEST_RESIZE_TOPLEFT: sys_cursors[r] = X11_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZENWSE); break;
-        case SDL_HITTEST_RESIZE_TOP: sys_cursors[r] = X11_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZENS); break;
-        case SDL_HITTEST_RESIZE_TOPRIGHT: sys_cursors[r] = X11_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZENESW); break;
-        case SDL_HITTEST_RESIZE_RIGHT: sys_cursors[r] = X11_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZEWE); break;
-        case SDL_HITTEST_RESIZE_BOTTOMRIGHT: sys_cursors[r] = X11_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZENWSE); break;
-        case SDL_HITTEST_RESIZE_BOTTOM: sys_cursors[r] = X11_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZENS); break;
-        case SDL_HITTEST_RESIZE_BOTTOMLEFT: sys_cursors[r] = X11_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZENESW); break;
-        case SDL_HITTEST_RESIZE_LEFT: sys_cursors[r] = X11_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZEWE); break;
+        case SDL_HITTEST_RESIZE_TOPLEFT: sys_cursors[r] = X11_CreateSystemCursor(SDL_SYSTEM_CURSOR_WINDOW_TOPLEFT); break;
+        case SDL_HITTEST_RESIZE_TOP: sys_cursors[r] = X11_CreateSystemCursor(SDL_SYSTEM_CURSOR_WINDOW_TOP); break;
+        case SDL_HITTEST_RESIZE_TOPRIGHT: sys_cursors[r] = X11_CreateSystemCursor(SDL_SYSTEM_CURSOR_WINDOW_TOPRIGHT); break;
+        case SDL_HITTEST_RESIZE_RIGHT: sys_cursors[r] = X11_CreateSystemCursor(SDL_SYSTEM_CURSOR_WINDOW_RIGHT); break;
+        case SDL_HITTEST_RESIZE_BOTTOMRIGHT: sys_cursors[r] = X11_CreateSystemCursor(SDL_SYSTEM_CURSOR_WINDOW_BOTTOMRIGHT); break;
+        case SDL_HITTEST_RESIZE_BOTTOM: sys_cursors[r] = X11_CreateSystemCursor(SDL_SYSTEM_CURSOR_WINDOW_BOTTOM); break;
+        case SDL_HITTEST_RESIZE_BOTTOMLEFT: sys_cursors[r] = X11_CreateSystemCursor(SDL_SYSTEM_CURSOR_WINDOW_BOTTOMLEFT); break;
+        case SDL_HITTEST_RESIZE_LEFT: sys_cursors[r] = X11_CreateSystemCursor(SDL_SYSTEM_CURSOR_WINDOW_LEFT); break;
         }
         r++;
     }

--- a/test/testcustomcursor.c
+++ b/test/testcustomcursor.c
@@ -215,6 +215,30 @@ static void loop(void)
                 case SDL_SYSTEM_CURSOR_HAND:
                     SDL_Log("Hand");
                     break;
+                case SDL_SYSTEM_CURSOR_WINDOW_TOPLEFT:
+                    SDL_Log("Window resize top-left");
+                    break;
+                case SDL_SYSTEM_CURSOR_WINDOW_TOP:
+                    SDL_Log("Window resize top");
+                    break;
+                case SDL_SYSTEM_CURSOR_WINDOW_TOPRIGHT:
+                    SDL_Log("Window resize top-right");
+                    break;
+                case SDL_SYSTEM_CURSOR_WINDOW_RIGHT:
+                    SDL_Log("Window resize right");
+                    break;
+                case SDL_SYSTEM_CURSOR_WINDOW_BOTTOMRIGHT:
+                    SDL_Log("Window resize bottom-right");
+                    break;
+                case SDL_SYSTEM_CURSOR_WINDOW_BOTTOM:
+                    SDL_Log("Window resize bottom");
+                    break;
+                case SDL_SYSTEM_CURSOR_WINDOW_BOTTOMLEFT:
+                    SDL_Log("Window resize bottom-left");
+                    break;
+                case SDL_SYSTEM_CURSOR_WINDOW_LEFT:
+                    SDL_Log("Window resize left");
+                    break;
                 default:
                     SDL_Log("UNKNOWN CURSOR TYPE, FIX THIS PROGRAM.");
                     break;


### PR DESCRIPTION
This PR makes X11/Wayland hit testing resize hover cursors match Linux usage of 8 unique (single arrow with edge/corner) cursors for each side/corner.

## Description
Currently SDL tries to mimic Windows double arrows when hovering and then the compositor switches to 8 direction cursors when the mouse is clicked.

The cursors are added as SDL_SYSTEM_CURSOR_WINDOW_TOPLEFT, etc matching the SDL_HITTEST_RESIZE_TOPLEFT names and order. X11/Wayland have new cursors. Other platforms use the existing SIZE cursors.

These should not replace SDL_SYSTEM_CURSOR_SIZENS, SIZEWE, etc as resizing a column/row in a window uses double arrows on Linux.