### PR TITLE
Fix joysticks returning invalid device IDs

### DIFF
--- a/src/joystick/haiku/SDL_haikujoystick.cc
+++ b/src/joystick/haiku/SDL_haikujoystick.cc
@@ -113,7 +113,7 @@ extern "C"
 /* Function to perform the mapping from device index to the instance id for this index */
     static SDL_JoystickID HAIKU_JoystickGetDeviceInstanceID(int device_index)
     {
-        return device_index;
+        return device_index + 1;
     }
 
     static void HAIKU_JoystickClose(SDL_Joystick *joystick);

--- a/src/joystick/n3ds/SDL_sysjoystick.c
+++ b/src/joystick/n3ds/SDL_sysjoystick.c
@@ -73,7 +73,7 @@ static SDL_JoystickGUID N3DS_JoystickGetDeviceGUID(int device_index)
 
 static SDL_JoystickID N3DS_JoystickGetDeviceInstanceID(int device_index)
 {
-    return device_index;
+    return device_index + 1;
 }
 
 static int N3DS_JoystickOpen(SDL_Joystick *joystick, int device_index)

--- a/src/joystick/ps2/SDL_sysjoystick.c
+++ b/src/joystick/ps2/SDL_sysjoystick.c
@@ -179,7 +179,7 @@ static SDL_JoystickGUID PS2_JoystickGetDeviceGUID(int device_index)
 /* Function to get the current instance id of the joystick located at device_index */
 static SDL_JoystickID PS2_JoystickGetDeviceInstanceID(int device_index)
 {
-    return device_index;
+    return device_index + 1;
 }
 
 /*  Function to open a joystick for use.

--- a/src/joystick/psp/SDL_sysjoystick.c
+++ b/src/joystick/psp/SDL_sysjoystick.c
@@ -140,7 +140,7 @@ static SDL_JoystickGUID PSP_JoystickGetDeviceGUID(int device_index)
 /* Function to perform the mapping from device index to the instance id for this index */
 static SDL_JoystickID PSP_JoystickGetDeviceInstanceID(int device_index)
 {
-    return device_index;
+    return device_index + 1;
 }
 
 /* Function to open a joystick for use.

--- a/src/joystick/vita/SDL_sysjoystick.c
+++ b/src/joystick/vita/SDL_sysjoystick.c
@@ -151,7 +151,7 @@ void VITA_JoystickDetect()
 /* Function to perform the mapping from device index to the instance id for this index */
 SDL_JoystickID VITA_JoystickGetDeviceInstanceID(int device_index)
 {
-    return device_index;
+    return device_index + 1;
 }
 
 const char *VITA_JoystickGetDeviceName(int index)


### PR DESCRIPTION
## Description
Fix joystick implementations returning invalid (0) device IDs

