### PR TITLE
SDL_PenModifyForWacomID: return zero as axis_flags upon failure.

### DIFF
--- a/src/events/SDL_pen.c
+++ b/src/events/SDL_pen.c
@@ -1058,6 +1058,7 @@ int SDL_PenModifyForWacomID(SDL_Pen *pen, Uint32 wacom_devicetype_id, Uint32 *ax
     }
 
     if (!name) {
+        *axis_flags = 0;
         return SDL_FALSE;
     }
 


### PR DESCRIPTION
Fixes uninitialized warning in testautomation_pen.c:
`testautomation_pen.c:1512: warning: 'mask' may be used uninitialized in this function`

CC: @creichen
