### PR TITLE
x11: Don't detect mice as pens

### DIFF
--- a/src/video/x11/SDL_x11pen.c
+++ b/src/video/x11/SDL_x11pen.c
@@ -402,7 +402,7 @@ static SDL_bool xinput2_device_is_pen(const XIDeviceInfo *dev)
             XIValuatorClassInfo *val_classinfo = (XIValuatorClassInfo *)classinfo;
             Atom vname = val_classinfo->label;
 
-            if (vname == pen_atoms.abs_pressure) {
+            if (vname != None && vname == pen_atoms.abs_pressure) {
                 return SDL_TRUE;
             }
         }
@@ -482,12 +482,14 @@ void X11_InitPen(SDL_VideoDevice *_this)
                 float min = val_classinfo->min;
                 float max = val_classinfo->max;
 
-                if (vname == pen_atoms.abs_pressure) {
-                    axis = SDL_PEN_AXIS_PRESSURE;
-                } else if (vname == pen_atoms.abs_tilt_x) {
-                    axis = SDL_PEN_AXIS_XTILT;
-                } else if (vname == pen_atoms.abs_tilt_y) {
-                    axis = SDL_PEN_AXIS_YTILT;
+                if (vname != None) {
+                    if (vname == pen_atoms.abs_pressure) {
+                        axis = SDL_PEN_AXIS_PRESSURE;
+                    } else if (vname == pen_atoms.abs_tilt_x) {
+                        axis = SDL_PEN_AXIS_XTILT;
+                    } else if (vname == pen_atoms.abs_tilt_y) {
+                        axis = SDL_PEN_AXIS_YTILT;
+                    }
                 }
 
                 if (axis == -1 && valuator_nr == 5) {


### PR DESCRIPTION
On my system, X11_XInternAtom(disp, "Abs Pressure", True) returns None, presumably because I don't have any pressury devices. Unfortunately, my USB mouse also reports at least one valuator with a None label, which used to be mistaken for a pressure valuator.

This change makes it so my USB mouse is not misdetected as a pen, fixing the generation of mouse events.

Fixes #8611.
