### PR TITLE
Set framebuffer_srgb_capable to the actual value obtained

### DIFF
--- a/src/video/windows/SDL_windowsopengl.c
+++ b/src/video/windows/SDL_windowsopengl.c
@@ -551,7 +551,7 @@ static int WIN_GL_ChoosePixelFormatARB(_THIS, int *iAttribs, float *fAttribs)
                                                     &matching);
         }
 
-        //Check whether we actually got an SRGB capable buffer
+        /* Check whether we actually got an SRGB capable buffer */
         _this->gl_data->wglGetPixelFormatAttribivARB(hdc, pixel_format, 0, 1, &qAttrib, &srgb);
         _this->gl_config.framebuffer_srgb_capable = srgb;
 

--- a/src/video/windows/SDL_windowsopengl.c
+++ b/src/video/windows/SDL_windowsopengl.c
@@ -548,6 +548,13 @@ static int WIN_GL_ChoosePixelFormatARB(_THIS, int *iAttribs, float *fAttribs)
                                                     &matching);
         }
 
+        //Check whether we actually got an SRGB capable buffer
+        int qAttrib = WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB;
+        int srgb = 0;
+
+        _this->gl_data->wglGetPixelFormatAttribivARB(hdc, pixel_format, 0, 1, &qAttrib, &srgb);
+        _this->gl_config.framebuffer_srgb_capable = srgb;
+
         _this->gl_data->wglMakeCurrent(hdc, NULL);
         _this->gl_data->wglDeleteContext(hglrc);
     }

--- a/src/video/windows/SDL_windowsopengl.c
+++ b/src/video/windows/SDL_windowsopengl.c
@@ -527,6 +527,9 @@ static int WIN_GL_ChoosePixelFormatARB(_THIS, int *iAttribs, float *fAttribs)
     int pixel_format = 0;
     unsigned int matching;
 
+    int qAttrib = WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB;
+    int srgb = 0;
+
     hwnd =
         CreateWindow(SDL_Appname, SDL_Appname, (WS_POPUP | WS_DISABLED), 0, 0,
                      10, 10, NULL, NULL, SDL_Instance, NULL);
@@ -549,9 +552,6 @@ static int WIN_GL_ChoosePixelFormatARB(_THIS, int *iAttribs, float *fAttribs)
         }
 
         //Check whether we actually got an SRGB capable buffer
-        int qAttrib = WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB;
-        int srgb = 0;
-
         _this->gl_data->wglGetPixelFormatAttribivARB(hdc, pixel_format, 0, 1, &qAttrib, &srgb);
         _this->gl_config.framebuffer_srgb_capable = srgb;
 


### PR DESCRIPTION
Allow checking to see if we actually got an sRGB framebuffer on windows opengl

## Description
Update the value of framebuffer_srgb_capable based on the value of WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB obtained from the driver

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/8632
