### PR TITLE
Fix possible assert crash inside `iscntrl` after 0413f6f.

### DIFF
--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -1063,7 +1063,7 @@ int SDL_SendKeyboardText(const char *text)
     int posted;
 
     /* Don't post text events for unprintable characters */
-    if (SDL_iscntrl((int)*text)) {
+    if (text[0] < '\x80' && SDL_iscntrl((int)*text)) {
         return 0;
     }
 


### PR DESCRIPTION
Can occur on non-ASCII input in UWP after 0413f6f due to assert inside `iscntrl`.

