### PR TITLE
document the purpose of SDL_SetTextInputRect

### DIFF
--- a/include/SDL3/SDL_keyboard.h
+++ b/include/SDL3/SDL_keyboard.h
@@ -300,8 +300,10 @@ extern DECLSPEC void SDLCALL SDL_ClearComposition(void);
 extern DECLSPEC SDL_bool SDLCALL SDL_TextInputShown(void);
 
 /**
- * Set the rectangle used to type Unicode text inputs.
- *
+ * Set the rectangle used to type Unicode text inputs. Native input methods
+ * will place a window with word suggestions near it, without covering the
+ * text being inputted.
+ * 
  * To start text input in a given location, this function is intended to be
  * called before SDL_StartTextInput, although some platforms support moving
  * the rectangle even while text input (and a composition) is active.


### PR DESCRIPTION
The original doc is hopelessly useless. Rect for what and why?

Based on what I read from X11/Wayland implementation. This is the same as 

* Qt's QInputMethod::setInputItemRectangle https://doc.qt.io/qt-6/qinputmethod.html#setInputItemRectangle
* GTK's gtk_im_context_set_cursor_location https://docs.gtk.org/gtk4/method.IMContext.set_cursor_location.html

It will set a cursor position so that native input methods will smartly avoid covering text being inputted.

## Description
Better doc.

## Existing Issue(s)
None.
