### PR TITLE
Try SDL_UDEV_deviceclass to detect joysticks even if in a container

### DIFF
--- a/src/core/linux/SDL_udev.c
+++ b/src/core/linux/SDL_udev.c
@@ -47,6 +47,9 @@ static _THIS = NULL;
 static SDL_bool SDL_UDEV_load_sym(const char *fn, void **addr);
 static int SDL_UDEV_load_syms(void);
 static SDL_bool SDL_UDEV_hotplug_update_available(void);
+static void get_caps(struct udev_device *dev, struct udev_device *pdev, const char *attr, unsigned long *bitmask, size_t bitmask_len);
+static int guess_device_class(struct udev_device *dev);
+static int device_class(struct udev_device *dev);
 static void device_event(SDL_UDEV_deviceevent type, struct udev_device *dev);
 
 static SDL_bool SDL_UDEV_load_sym(const char *fn, void **addr)
@@ -222,7 +225,7 @@ void SDL_UDEV_Scan(void)
     _this->syms.udev_enumerate_unref(enumerate);
 }
 
-SDL_bool SDL_UDEV_GetProductInfo(const char *device_path, Uint16 *vendor, Uint16 *product, Uint16 *version)
+SDL_bool SDL_UDEV_GetProductInfo(const char *device_path, Uint16 *vendor, Uint16 *product, Uint16 *version, int *class)
 {
     struct udev_enumerate *enumerate = NULL;
     struct udev_list_entry *devs = NULL;
@@ -250,6 +253,7 @@ SDL_bool SDL_UDEV_GetProductInfo(const char *device_path, Uint16 *vendor, Uint16
 
             existing_path = _this->syms.udev_device_get_devnode(dev);
             if (existing_path && SDL_strcmp(device_path, existing_path) == 0) {
+                int class_temp;
                 found = SDL_TRUE;
 
                 val = _this->syms.udev_device_get_property_value(dev, "ID_VENDOR_ID");
@@ -265,6 +269,11 @@ SDL_bool SDL_UDEV_GetProductInfo(const char *device_path, Uint16 *vendor, Uint16
                 val = _this->syms.udev_device_get_property_value(dev, "ID_REVISION");
                 if (val) {
                     *version = (Uint16)SDL_strtol(val, NULL, 16);
+                }
+
+                class_temp = device_class(dev);
+                if (class_temp) {
+                    *class = class_temp;
                 }
             }
             _this->syms.udev_device_unref(dev);
@@ -394,20 +403,17 @@ static int guess_device_class(struct udev_device *dev)
                                       &bitmask_rel[0]);
 }
 
-static void device_event(SDL_UDEV_deviceevent type, struct udev_device *dev)
+static int device_class(struct udev_device *dev)
 {
     const char *subsystem;
     const char *val = NULL;
     int devclass = 0;
-    const char *path;
-    SDL_UDEV_CallbackList *item;
-
-    path = _this->syms.udev_device_get_devnode(dev);
-    if (!path) {
-        return;
-    }
 
     subsystem = _this->syms.udev_device_get_subsystem(dev);
+    if (!subsystem) {
+        return 0;
+    }
+
     if (SDL_strcmp(subsystem, "sound") == 0) {
         devclass = SDL_UDEV_DEVICE_SOUND;
     } else if (SDL_strcmp(subsystem, "input") == 0) {
@@ -455,16 +461,31 @@ static void device_event(SDL_UDEV_deviceevent type, struct udev_device *dev)
                     devclass = SDL_UDEV_DEVICE_MOUSE;
                 } else if (SDL_strcmp(val, "kbd") == 0) {
                     devclass = SDL_UDEV_DEVICE_KEYBOARD;
-                } else {
-                    return;
                 }
             } else {
                 /* We could be linked with libudev on a system that doesn't have udev running */
                 devclass = guess_device_class(dev);
             }
         }
-    } else {
+    }
+
+    return devclass;
+}
+
+static void device_event(SDL_UDEV_deviceevent type, struct udev_device *dev)
+{
+    int devclass = 0;
+    const char *path;
+    SDL_UDEV_CallbackList *item;
+
+    path = _this->syms.udev_device_get_devnode(dev);
+    if (!path) {
         return;
+    }
+
+    devclass = device_class(dev);
+    if (!devclass) {
+         return;
     }
 
     /* Process callbacks */

--- a/src/core/linux/SDL_udev.h
+++ b/src/core/linux/SDL_udev.h
@@ -103,7 +103,7 @@ extern void SDL_UDEV_UnloadLibrary(void);
 extern int SDL_UDEV_LoadLibrary(void);
 extern void SDL_UDEV_Poll(void);
 extern void SDL_UDEV_Scan(void);
-extern SDL_bool SDL_UDEV_GetProductInfo(const char *device_path, Uint16 *vendor, Uint16 *product, Uint16 *version);
+extern SDL_bool SDL_UDEV_GetProductInfo(const char *device_path, Uint16 *vendor, Uint16 *product, Uint16 *version, int *class);
 extern int SDL_UDEV_AddCallback(SDL_UDEV_Callback cb);
 extern void SDL_UDEV_DelCallback(SDL_UDEV_Callback cb);
 extern const SDL_UDEV_Symbols *SDL_UDEV_GetUdevSyms(void);

--- a/src/joystick/linux/SDL_sysjoystick.c
+++ b/src/joystick/linux/SDL_sysjoystick.c
@@ -260,18 +260,20 @@ static int IsJoystick(const char *path, int fd, char **name_return, SDL_Joystick
     struct input_id inpid;
     char *name;
     char product_string[128];
+    int class = 0;
 
-    if (ioctl(fd, JSIOCGNAME(sizeof(product_string)), product_string) >= 0) {
-        SDL_zero(inpid);
+    SDL_zero(inpid);
 #ifdef SDL_USE_LIBUDEV
-        SDL_UDEV_GetProductInfo(path, &inpid.vendor, &inpid.product, &inpid.version);
+    SDL_UDEV_GetProductInfo(path, &inpid.vendor, &inpid.product, &inpid.version, &class);
 #endif
-    } else {
+    if (ioctl(fd, JSIOCGNAME(sizeof(product_string)), product_string) <= 0) {
         /* When udev is enabled we only get joystick devices here, so there's no need to test them */
-        if (enumeration_method != ENUMERATION_LIBUDEV && !GuessIsJoystick(fd)) {
+        if (enumeration_method != ENUMERATION_LIBUDEV &&
+            !(class & SDL_UDEV_DEVICE_JOYSTICK) && ( class || !GuessIsJoystick(fd))) {
             return 0;
         }
 
+        /* Could have vendor and product already from udev, but should agree with evdev */
         if (ioctl(fd, EVIOCGID, &inpid) < 0) {
             return 0;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The udev container issue is mostly to do with device notifications and netlink. The device classification stuff just pokes file in /sys and /run/udev. Doesn't hurt to try it first for classifying joysticks and then fall to the guess heuristics if it fails.                                                                     

Here is an example of the the [sdl-jtest](https://github.com/Grumbel/sdl-jstest) program compiled against the current SDL2 HEAD
```
tyson@tux ~> ./sdl2-orig/bin/sdl2-jstest -l
Found 1 joystick(s)

Joystick Name:     'PRODUCTS CH PRO PEDALS USB'
Joystick GUID:     0300b9e88e060000f200000000010000
Joystick Number:    0
Number of Axes:     3
Number of Buttons:  0
Number of Hats:     0
Number of Balls:    0
GameControllerConfig:
  missing (see 'gamecontrollerdb.txt' or SDL_GAMECONTROLLERCONFIG)
```
and here it is inside the steam pressure vessel container
```
tyson@tux ~> steam-run /home/tyson/.local/share/Steam/steamapps/common/SteamLinuxRuntime_sniper/_v2-entry-point -- ./sdl2-orig/bin/sdl2-jstest -l
...
No joysticks were found
```
The issue being the the heuristics fail because the CH PRO PEDALS are three axis with no buttons, which is the same as an accelerometer. It works outside the container because the udev hwdb has an entry for this device.

Now with it build against SDL with these changes (and the `-DDEBUG_INPUT_EVENTS` and `DDEBUG_JOYSTICK` turned on for some more clarity)
```
tyson@tux ~> ./sdl2-patch/bin/sdl2-jstest -l
INFO: Checking /dev/input/event6
INFO: Joystick: PRODUCTS CH PRO PEDALS USB, bustype = 3, vendor = 0x068e, product = 0x00f2, version = 256
INFO: found joystick: /dev/input/event6
INFO: Joystick has absolute axis: 0x00
INFO: Values = { val:0, min:0, max:255, fuzz:0, flat:15, res:0 }
INFO: Joystick has absolute axis: 0x01
INFO: Values = { val:0, min:0, max:255, fuzz:0, flat:15, res:0 }
INFO: Joystick has absolute axis: 0x02
INFO: Values = { val:124, min:0, max:255, fuzz:0, flat:15, res:0 }
Checking /dev/input/event6
Checking /dev/input/event6
Checking /dev/input/js0
Found 1 joystick(s)

INFO: Joystick has absolute axis: 0x00
INFO: Values = { val:0, min:0, max:255, fuzz:0, flat:15, res:0 }
INFO: Joystick has absolute axis: 0x01
INFO: Values = { val:0, min:0, max:255, fuzz:0, flat:15, res:0 }
INFO: Joystick has absolute axis: 0x02
INFO: Values = { val:125, min:0, max:255, fuzz:0, flat:15, res:0 }
INFO: Joystick : Re-read Axis 0 (0) val= -32768
INFO: Joystick : Re-read Axis 1 (1) val= -32768
INFO: Joystick : Re-read Axis 2 (2) val= -643
Joystick Name:     'PRODUCTS CH PRO PEDALS USB'
Joystick GUID:     0300b9e88e060000f200000000010000
Joystick Number:    0
Number of Axes:     3
Number of Buttons:  0
Number of Hats:     0
Number of Balls:    0
GameControllerConfig:
  missing (see 'gamecontrollerdb.txt' or SDL_GAMECONTROLLERCONFIG)
```
and inside the container
```
tyson@tux ~> steam-run /home/tyson/.local/share/Steam/steamapps/common/SteamLinuxRuntime_sniper/_v2-entry-point -- ./sdl2-patch/bin/sdl2-jstest -l
...
INFO: Checking /dev/input/event6
INFO: Joystick: PRODUCTS CH PRO PEDALS USB, bustype = 3, vendor = 0x068e, product = 0x00f2, version = 256
INFO: found joystick: /dev/input/event6
INFO: Joystick has absolute axis: 0x00
INFO: Values = { val:0, min:0, max:255, fuzz:0, flat:15, res:0 }
INFO: Joystick has absolute axis: 0x01
INFO: Values = { val:0, min:0, max:255, fuzz:0, flat:15, res:0 }
INFO: Joystick has absolute axis: 0x02
INFO: Values = { val:124, min:0, max:255, fuzz:0, flat:15, res:0 }
Checking /dev/input/event6
Checking /dev/input/event6
Checking /dev/input/js0
Found 1 joystick(s)

INFO: Joystick has absolute axis: 0x00
INFO: Values = { val:0, min:0, max:255, fuzz:0, flat:15, res:0 }
INFO: Joystick has absolute axis: 0x01
INFO: Values = { val:0, min:0, max:255, fuzz:0, flat:15, res:0 }
INFO: Joystick has absolute axis: 0x02
INFO: Values = { val:125, min:0, max:255, fuzz:0, flat:15, res:0 }
INFO: Joystick : Re-read Axis 0 (0) val= -32768
INFO: Joystick : Re-read Axis 1 (1) val= -32768
INFO: Joystick : Re-read Axis 2 (2) val= -643
Joystick Name:     'PRODUCTS CH PRO PEDALS USB'
Joystick GUID:     0300b9e88e060000f200000000010000
Joystick Number:    0
Number of Axes:     3
Number of Buttons:  0
Number of Hats:     0
Number of Balls:    0
GameControllerConfig:
  missing (see 'gamecontrollerdb.txt' or SDL_GAMECONTROLLERCONFIG)
```

## Existing Issue(s)

This should close #7500.

## Other

This cherry picks reasonably well onto the master SDL3 branch as well. If you find it acceptable, I will do another pull request for SDL3 too.