### PR TITLE
Added SDL_strnstr.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1065,7 +1065,7 @@ if(SDL_LIBC)
     realloc rindex round roundf
     scalbn scalbnf setenv sin sinf sqr sqrt sqrtf sscanf strchr
     strcmp strlcat strlcpy strlen strncmp strnlen
-    strrchr strstr strtod strtok_r strtol strtoll strtoul strtoull
+    strrchr strstr strnstr strtod strtok_r strtol strtoll strtoul strtoull
     tan tanf trunc truncf
     unsetenv
     vsnprintf vsscanf

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -566,6 +566,7 @@ extern DECLSPEC char *SDLCALL SDL_strlwr(char *str);
 extern DECLSPEC char *SDLCALL SDL_strchr(const char *str, int c);
 extern DECLSPEC char *SDLCALL SDL_strrchr(const char *str, int c);
 extern DECLSPEC char *SDLCALL SDL_strstr(const char *haystack, const char *needle);
+extern DECLSPEC char *SDLCALL SDL_strnstr(const char *big, const char *little, size_t len);
 extern DECLSPEC char *SDLCALL SDL_strcasestr(const char *haystack, const char *needle);
 extern DECLSPEC char *SDLCALL SDL_strtok_r(char *s1, const char *s2, char **saveptr);
 extern DECLSPEC size_t SDLCALL SDL_utf8strlen(const char *str);

--- a/src/dynapi/SDL_dynapi.sym
+++ b/src/dynapi/SDL_dynapi.sym
@@ -960,6 +960,7 @@ SDL3_0.0.0 {
     SDL_GetGamepadMappings;
     SDL_GetTouchDevices;
     SDL_GetTouchDeviceName;
+    SDL_strnstr;
     # extra symbols go here (don't modify this line)
   local: *;
 };

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -985,3 +985,4 @@
 #define SDL_GetGamepadMappings SDL_GetGamepadMappings_REAL
 #define SDL_GetTouchDevices SDL_GetTouchDevices_REAL
 #define SDL_GetTouchDeviceName SDL_GetTouchDeviceName_REAL
+#define SDL_strnstr SDL_strnstr_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -1010,3 +1010,4 @@ SDL_DYNAPI_PROC(SDL_Renderer*,SDL_CreateRendererWithProperties,(SDL_PropertiesID
 SDL_DYNAPI_PROC(char**,SDL_GetGamepadMappings,(int *a),(a),return)
 SDL_DYNAPI_PROC(SDL_TouchID*,SDL_GetTouchDevices,(int *a),(a),return)
 SDL_DYNAPI_PROC(const char*,SDL_GetTouchDeviceName,(SDL_TouchID a),(a),return)
+SDL_DYNAPI_PROC(char*,SDL_strnstr,(const char *a, const char *b, size_t c),(a,b,c),return)

--- a/src/stdlib/SDL_string.c
+++ b/src/stdlib/SDL_string.c
@@ -837,6 +837,46 @@ char *SDL_strstr(const char *haystack, const char *needle)
 #endif /* HAVE_STRSTR */
 }
 
+char *SDL_strnstr(const char *haystack, const char *needle, size_t size)
+{
+#ifdef HAVE_STRNSTR
+    return SDL_const_cast(char *, strnstr(haystack, needle, size));
+#else
+    size_t needlesize;
+    const char *end, *giveup;
+
+    needlesize = SDL_strlen(needle);
+    /* We can give up if needle is empty, or haystack can never contain it */
+    if ((needlesize == 0) || (needlesize > size)) {
+        return NULL;
+    }
+    /* The pointer value that marks the end of haystack */
+    end = haystack + size;
+    /* The maximum value of i, because beyond this haystack cannot contain needle */
+    giveup = end - needlesize + 1;
+
+    /* i is used to iterate over haystack */
+    for (const char *i = haystack; i != giveup; i++) {
+        const char *j, *k;
+        /* j is used to iterate over part of haystack during comparison */
+        /* k is used to iterate over needle during comparison */
+        for (j = i, k = needle; j != end && *k != '\0'; j++, k++) {
+            /* Bail on the first character that doesn't match */
+            if (*j != *k) {
+                break;
+            }
+        }
+        /* If we've reached the end of needle, we've found a match */
+        /* i contains the start of our match */
+        if (*k == '\0') {
+            return (char*) i;
+        }
+    }
+    /* Fell through the loops, nothing found */
+    return NULL;
+#endif /* HAVE_STRNSTR */
+}
+
 char *SDL_strcasestr(const char *haystack, const char *needle)
 {
 #ifdef HAVE_STRCASESTR


### PR DESCRIPTION
Added support for SDL_strnstr which is equivalent to the BSD function strnstr.

## Description
Basically the same as SDL_strstr, but for strnstr.

The implementation is taken from the one used in the game Naev as a fallback when the OS does not support it. It should be well tested.

I'm not too familiar with the SDL build system, so I may have overlooked something, but it compiles and works fine here (linux).

## Existing Issue(s)
None that I know of.
