### PR TITLE
Update SDL_androidsensor.c

### DIFF
--- a/src/sensor/android/SDL_androidsensor.c
+++ b/src/sensor/android/SDL_androidsensor.c
@@ -53,7 +53,7 @@ static int SDL_ANDROID_SensorInit(void)
     int i, sensors_count;
     ASensorList sensors;
 
-    SDL_sensor_manager = ASensorManager_getInstance();
+    SDL_sensor_manager = ASensorManager_getInstanceForPackage("SDL");
     if (!SDL_sensor_manager) {
         return SDL_SetError("Couldn't create sensor manager");
     }


### PR DESCRIPTION
potential fix for ndk deprecation in v25 -> v26


## Description
uses _getInstanceForPackage("SDL") rather than  _getInstance()

## Existing Issue(s)
_getInstance was deprecated  past Android NDK v25
