### PR TITLE
Fixed bug #7614: Segmentation Fault in SDL_BlitSurface

### DIFF
--- a/src/video/SDL_surface.c
+++ b/src/video/SDL_surface.c
@@ -675,7 +675,8 @@ int SDL_BlitSurface(SDL_Surface *src, const SDL_Rect *srcrect,
                   SDL_Surface *dst, SDL_Rect *dstrect)
 {
     SDL_Rect fulldst;
-    int srcx, srcy, w, h;
+    int srcx, srcy;
+    Sint64 w, h;
 
     /* Make sure the surfaces aren't locked */
     if (!src || !dst) {


### PR DESCRIPTION
Fix overflow  of issue https://github.com/libsdl-org/SDL/issues/7614
(simplier fix, compared to #7808)

SDL3 and SDL2 are affected
but I think, the code should be re-written using SDL_GetRectIntersection() like it was done in #7808
