### PR TITLE
Add support for monochrome cursors with inverted pixels under Windows

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -1238,6 +1238,12 @@ SDL_Cursor *SDL_CreateCursor(const Uint8 *data, const Uint8 *mask, int w, int h,
     const Uint32 black = 0xFF000000;
     const Uint32 white = 0xFFFFFFFF;
     const Uint32 transparent = 0x00000000;
+#if defined(__WIN32__)
+    /* Only Windows backend supports inverted pixels in mono cursors. */
+    const Uint32 inverted = 0x00FFFFFF;
+#else
+    const Uint32 inverted = 0xFF000000;
+#endif /* defined(__WIN32__) */
 
     /* Make sure the width is a multiple of 8 */
     w = ((w + 7) & ~7);
@@ -1257,7 +1263,7 @@ SDL_Cursor *SDL_CreateCursor(const Uint8 *data, const Uint8 *mask, int w, int h,
             if (maskb & 0x80) {
                 *pixel++ = (datab & 0x80) ? black : white;
             } else {
-                *pixel++ = (datab & 0x80) ? black : transparent;
+                *pixel++ = (datab & 0x80) ? inverted : transparent;
             }
             datab <<= 1;
             maskb <<= 1;


### PR DESCRIPTION
## Description
Used this code to test `SDL_CreateCursor`:

```cpp
static const char *g_mouseArrowData[] = {
    /* pixels */
    "X                               ",
    "XX                              ",
    "X.X                             ",
    "X..X                            ",
    "X...X                           ",
    "X....X                          ",
    "X.....X                         ",
    "X......X                        ",
    "X.......X                       ",
    "X........X                      ",
    "X.....XXXXX                     ",
    "X..X..X                         ",
    "X.X X..X                        ",
    "XX  X..X                        ",
    "X    X..X                       ",
    "     X..X                       ",
    "      X..X                      ",
    "      X..X                      ",
    "       XX                       ",
    "                                ",
    "                                ",
    "                                ",
    "                                ",
    "                                ",
    "                                ",
    "                                ",
    "                                ",
    "                                ",
    "                                ",
    "                                ",
    "                                ",
    "                                "
};

static const char *g_mouseCrossData[] = {
    /* pixels */
    "                                ",
    "                                ",
    "                                ",
    "                                ",
    "               oo               ",
    "               oo               ",
    "               oo               ",
    "               oo               ",
    "               oo               ",
    "               oo               ",
    "               oo               ",
    "               oo               ",
    "               oo               ",
    "               oo               ",
    "               oo               ",
    "    oooooooooooooooooooooooo    ",
    "    oooooooooooooooooooooooo    ",
    "               oo               ",
    "               oo               ",
    "               oo               ",
    "               oo               ",
    "               oo               ",
    "               oo               ",
    "               oo               ",
    "               oo               ",
    "               oo               ",
    "               oo               ",
    "               oo               ",
    "                                ",
    "                                ",
    "                                ",
    "                                "
};

/* Helper that creates a new mouse cursor from an XPM */
static SDL_Cursor *initCursor(const char *image[])
{
    SDL_Cursor *cursor;
    int i, row, col;
    Uint8 data[4 * 32];
    Uint8 mask[4 * 32];

    i = -1;
    for (row = 0; row < 32; ++row) {
        for (col = 0; col < 32; ++col) {
            if (col % 8) {
                data[i] <<= 1;
                mask[i] <<= 1;
            } else {
                ++i;
                data[i] = mask[i] = 0;
            }
            switch (image[row][col]) {
            case 'X':
                data[i] |= 0x01;
                mask[i] |= 0x01;
                break;
            case '.':
                mask[i] |= 0x01;
                break;
            case 'o':
                data[i] |= 0x01;
                break;
            case ' ':
                break;
            }
        }
    }

    cursor = SDL_CreateCursor(data, mask, 32, 32, 0, 0);
    return cursor;
}

...

//SDL_Cursor *cursor = initCursor(g_mouseArrowData);
SDL_Cursor *cursor = initCursor(g_mouseCrossData);
//SDL_Cursor *cursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_CROSSHAIR);
SDL_SetCursor(cursor);
```

PS: Seems XORed cursors are only supported in Windows due to already expired [US4197590A](https://patents.google.com/patent/US4197590A) patent.

## Existing Issue(s)
Fixes #8157
