### PR TITLE
x11: Don't move the window when restoring and ensure that resize and …

### DIFF
--- a/src/video/x11/SDL_x11window.h
+++ b/src/video/x11/SDL_x11window.h
@@ -93,9 +93,9 @@ struct SDL_WindowData
         X11_PENDING_OP_RESIZE = 0x20
     } pending_operation;
 
-    SDL_bool initial_border_adjustment;
     SDL_bool window_was_maximized;
-    int skip_size_count;
+    SDL_bool disable_size_position_events;
+    SDL_bool previous_borders_nonzero;
     SDL_HitTestResult hit_test_result;
 };
 


### PR DESCRIPTION
…position events are sent when entering or leaving fullscreen

Account for the border sizes when restoring the window and only turn off resize events when entering or leaving fullscreen until the frame extents are changed, and only if they are, or previously were, non-zero. This fixes the window 'walking' when changing focus or leaving fullscreen.

This necessitated further refinement to the sync algorithm as well, but as a result, the sync function no longer occasionally times out if creating a window and immediately recreating it when initializing a renderer, and some rare, spurious size and position failures in the centered window and state automated tests seem to be fixed.

Fixes #8689 