### PR TITLE
Named typedef-ed structs

### DIFF
--- a/include/SDL3/SDL_atomic.h
+++ b/include/SDL3/SDL_atomic.h
@@ -267,7 +267,7 @@ typedef void (*SDL_KernelMemoryBarrierFunc)();
  *
  * It is a struct so people don't accidentally use numeric operations on it.
  */
-typedef struct { int value; } SDL_AtomicInt;
+typedef struct SDL_AtomicInt { int value; } SDL_AtomicInt;
 
 /**
  * Set an atomic variable to a new value if it is currently an old value.

--- a/include/SDL3/SDL_guid.h
+++ b/include/SDL3/SDL_guid.h
@@ -52,7 +52,7 @@ extern "C" {
  * GUIDs may be platform-dependent (i.e., the same device may report
  *   different GUIDs on different operating systems).
  */
-typedef struct {
+typedef struct SDL_GUID {
     Uint8 data[16];
 } SDL_GUID;
 

--- a/include/SDL3/SDL_test_crc32.h
+++ b/include/SDL3/SDL_test_crc32.h
@@ -63,7 +63,7 @@ extern "C" {
 /**
  * Data structure for CRC32 (checksum) computation
  */
-  typedef struct {
+  typedef struct SDLTest_Crc32Context {
     CrcUint32    crc32_table[256]; /* CRC table */
   } SDLTest_Crc32Context;
 

--- a/include/SDL3/SDL_test_md5.h
+++ b/include/SDL3/SDL_test_md5.h
@@ -68,7 +68,7 @@ extern "C" {
   typedef Uint32 MD5UINT4;
 
 /* Data structure for MD5 (Message-Digest) computation */
-  typedef struct {
+  typedef struct SDLTest_Md5Context {
     MD5UINT4  i[2];     /* number of _bits_ handled mod 2^64 */
     MD5UINT4  buf[4];       /* scratch buffer */
     unsigned char in[64];   /* input buffer */

--- a/include/SDL3/SDL_test_random.h
+++ b/include/SDL3/SDL_test_random.h
@@ -56,7 +56,7 @@ extern "C" {
 /*
  * Context structure for the random number generator state.
  */
-  typedef struct {
+  typedef struct SDLTest_RandomContext {
     unsigned int a;
     unsigned int x;
     unsigned int c;

--- a/src/hidapi/ios/hid.m
+++ b/src/hidapi/ios/hid.m
@@ -99,7 +99,7 @@ typedef struct
 	};
 } bluetoothSegment;
 
-typedef struct {
+typedef struct hidFeatureReport {
 	uint8_t		id;
 	union {
 		bluetoothSegment segment;
@@ -128,7 +128,7 @@ size_t GetBluetoothSegmentSize(bluetoothSegment *segment)
 #define RingBuffer_cbElem   19
 #define RingBuffer_nElem    4096
 
-typedef struct {
+typedef struct RingBuffer {
 	int _first, _last;
 	uint8_t _data[ ( RingBuffer_nElem * RingBuffer_cbElem ) ];
 	pthread_mutex_t accessLock;

--- a/src/stdlib/SDL_qsort.c
+++ b/src/stdlib/SDL_qsort.c
@@ -180,7 +180,7 @@ static char _ID[]="<qsort.c gjm 1.15 2016-03-10>";
  */
 #define PIVOT_THRESHOLD 40
 
-typedef struct { char * first; char * last; } stack_entry;
+typedef struct stack_entry { char * first; char * last; } stack_entry;
 #define pushLeft {stack[stacktop].first=ffirst;stack[stacktop++].last=last;}
 #define pushRight {stack[stacktop].first=first;stack[stacktop++].last=llast;}
 #define doLeft {first=ffirst;llast=last;continue;}

--- a/src/video/khronos/vulkan/vk_icd.h
+++ b/src/video/khronos/vulkan/vk_icd.h
@@ -88,7 +88,7 @@ extern "C" {
 
 #define ICD_LOADER_MAGIC 0x01CDC0DE
 
-typedef union {
+typedef union VK_LOADER_DATA {
     uintptr_t loaderMagic;
     void *loaderData;
 } VK_LOADER_DATA;
@@ -125,12 +125,12 @@ typedef enum {
     VK_ICD_WSI_PLATFORM_SCREEN,
 } VkIcdWsiPlatform;
 
-typedef struct {
+typedef struct VkIcdSurfaceBase {
     VkIcdWsiPlatform platform;
 } VkIcdSurfaceBase;
 
 #ifdef VK_USE_PLATFORM_MIR_KHR
-typedef struct {
+typedef struct VkIcdSurfaceMir {
     VkIcdSurfaceBase base;
     MirConnection *connection;
     MirSurface *mirSurface;
@@ -138,7 +138,7 @@ typedef struct {
 #endif  // VK_USE_PLATFORM_MIR_KHR
 
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
-typedef struct {
+typedef struct VkIcdSurfaceWayland {
     VkIcdSurfaceBase base;
     struct wl_display *display;
     struct wl_surface *surface;
@@ -146,7 +146,7 @@ typedef struct {
 #endif  // VK_USE_PLATFORM_WAYLAND_KHR
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-typedef struct {
+typedef struct VkIcdSurfaceWin32 {
     VkIcdSurfaceBase base;
     HINSTANCE hinstance;
     HWND hwnd;
@@ -154,7 +154,7 @@ typedef struct {
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
 #ifdef VK_USE_PLATFORM_XCB_KHR
-typedef struct {
+typedef struct VkIcdSurfaceXcb {
     VkIcdSurfaceBase base;
     xcb_connection_t *connection;
     xcb_window_t window;
@@ -162,7 +162,7 @@ typedef struct {
 #endif  // VK_USE_PLATFORM_XCB_KHR
 
 #ifdef VK_USE_PLATFORM_XLIB_KHR
-typedef struct {
+typedef struct VkIcdSurfaceXlib {
     VkIcdSurfaceBase base;
     Display *dpy;
     Window window;
@@ -170,7 +170,7 @@ typedef struct {
 #endif  // VK_USE_PLATFORM_XLIB_KHR
 
 #ifdef VK_USE_PLATFORM_DIRECTFB_EXT
-typedef struct {
+typedef struct VkIcdSurfaceDirectFB {
     VkIcdSurfaceBase base;
     IDirectFB *dfb;
     IDirectFBSurface *surface;
@@ -178,34 +178,34 @@ typedef struct {
 #endif  // VK_USE_PLATFORM_DIRECTFB_EXT
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
-typedef struct {
+typedef struct VkIcdSurfaceAndroid {
     VkIcdSurfaceBase base;
     struct ANativeWindow *window;
 } VkIcdSurfaceAndroid;
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
 
 #ifdef VK_USE_PLATFORM_MACOS_MVK
-typedef struct {
+typedef struct VkIcdSurfaceMacOS {
     VkIcdSurfaceBase base;
     const void *pView;
 } VkIcdSurfaceMacOS;
 #endif  // VK_USE_PLATFORM_MACOS_MVK
 
 #ifdef VK_USE_PLATFORM_IOS_MVK
-typedef struct {
+typedef struct VkIcdSurfaceIOS {
     VkIcdSurfaceBase base;
     const void *pView;
 } VkIcdSurfaceIOS;
 #endif  // VK_USE_PLATFORM_IOS_MVK
 
 #ifdef VK_USE_PLATFORM_GGP
-typedef struct {
+typedef struct VkIcdSurfaceGgp {
     VkIcdSurfaceBase base;
     GgpStreamDescriptor streamDescriptor;
 } VkIcdSurfaceGgp;
 #endif  // VK_USE_PLATFORM_GGP
 
-typedef struct {
+typedef struct VkIcdSurfaceDisplay {
     VkIcdSurfaceBase base;
     VkDisplayModeKHR displayMode;
     uint32_t planeIndex;
@@ -216,26 +216,26 @@ typedef struct {
     VkExtent2D imageExtent;
 } VkIcdSurfaceDisplay;
 
-typedef struct {
+typedef struct VkIcdSurfaceHeadless {
     VkIcdSurfaceBase base;
 } VkIcdSurfaceHeadless;
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
-typedef struct {
+typedef struct VkIcdSurfaceMetal {
     VkIcdSurfaceBase base;
     const CAMetalLayer *pLayer;
 } VkIcdSurfaceMetal;
 #endif // VK_USE_PLATFORM_METAL_EXT
 
 #ifdef VK_USE_PLATFORM_VI_NN
-typedef struct {
+typedef struct VkIcdSurfaceVi {
     VkIcdSurfaceBase base;
     void *window;
 } VkIcdSurfaceVi;
 #endif // VK_USE_PLATFORM_VI_NN
 
 #ifdef VK_USE_PLATFORM_SCREEN_QNX
-typedef struct {
+typedef struct VkIcdSurfaceScreen {
     VkIcdSurfaceBase base;
     struct _screen_context *context;
     struct _screen_window *window;

--- a/src/video/khronos/vulkan/vk_layer.h
+++ b/src/video/khronos/vulkan/vk_layer.h
@@ -118,7 +118,7 @@ typedef enum VkLoaderFeastureFlagBits {
 } VkLoaderFlagBits;
 typedef VkFlags VkLoaderFeatureFlags;
 
-typedef struct {
+typedef struct VkLayerInstanceCreateInfo {
     VkStructureType sType; // VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO
     const void *pNext;
     VkLayerFunction function;
@@ -139,7 +139,7 @@ typedef struct VkLayerDeviceLink_ {
     PFN_vkGetDeviceProcAddr pfnNextGetDeviceProcAddr;
 } VkLayerDeviceLink;
 
-typedef struct {
+typedef struct VkLayerDeviceCreateInfo {
     VkStructureType sType; // VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO
     const void *pNext;
     VkLayerFunction function;

--- a/test/testvideocapture.c
+++ b/test/testvideocapture.c
@@ -36,7 +36,7 @@ Use keyboards:\n\
  \n\
 ";
 
-typedef struct {
+typedef struct measure_fps_t {
     Uint64 next_check;
     int frame_counter;
     int check_delay;


### PR DESCRIPTION
Gave name to structs that were defined like anonymous struct with name given by typedef.
Example 'typedef struct {...} Foo;' -> 'typedef struct Foo {...} Foo;'