### PR TITLE
Fix compilation / same as sdl2-compat

### DIFF
--- a/test/testautomation_platform.c
+++ b/test/testautomation_platform.c
@@ -369,7 +369,7 @@ static int platform_testSetErrorEmptyInput(void *arg)
 static int platform_testSetErrorInvalidInput(void *arg)
 {
     int result;
-    const char *invalidError = NULL;
+    const char *invalidError = "";
     const char *probeError = "Testing";
     const char *lastError;
     size_t len;


### PR DESCRIPTION
```
testautomation_platform.c:351:28: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
  351 |     result = SDL_SetError("%s", testError);
      |                            ^~
/home/slvn/release/Release_SDL/sdl2-compat/test/testautomation_platform.c:364:64: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
  364 |                             "SDL_GetError(): expected message '%s', was message: '%s'",
```

sdl2-compat:
https://github.com/libsdl-org/sdl2-compat/pull/120