### PR TITLE
Use crc16 return value when calculating GUID

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -2615,11 +2615,11 @@ SDL_JoystickGUID SDL_CreateJoystickGUID(Uint16 bus, Uint16 vendor, Uint16 produc
     SDL_zero(guid);
 
     if (vendor_name && *vendor_name && product_name && *product_name) {
-        SDL_crc16(crc, vendor_name, SDL_strlen(vendor_name));
-        SDL_crc16(crc, " ", 1);
-        SDL_crc16(crc, product_name, SDL_strlen(product_name));
+        crc = SDL_crc16(crc, vendor_name, SDL_strlen(vendor_name));
+        crc = SDL_crc16(crc, " ", 1);
+        crc = SDL_crc16(crc, product_name, SDL_strlen(product_name));
     } else if (product_name) {
-        SDL_crc16(crc, product_name, SDL_strlen(product_name));
+        crc = SDL_crc16(crc, product_name, SDL_strlen(product_name));
     }
 
     /* We only need 16 bits for each of these; space them out to fill 128. */


### PR DESCRIPTION
Fixes the regression introduced by 919cd56b20c59249bdde3bb005aeeb8f6550f3e3 (@slouken)

**This also needs to be backmerged to SDL2.**
