### PR TITLE
Make sure the string is terminated, fixed invalid read in SDL_PrivateParseGamepadConfigString()

### DIFF
--- a/src/joystick/SDL_gamepad.c
+++ b/src/joystick/SDL_gamepad.c
@@ -1282,12 +1282,14 @@ static int SDL_PrivateParseGamepadConfigString(SDL_Gamepad *gamepad, const char 
 
         } else if (bGameButton) {
             if (i >= sizeof(szGameButton)) {
+                szGameButton[sizeof(szGameButton) - 1] = '\0';
                 return SDL_SetError("Button name too large: %s", szGameButton);
             }
             szGameButton[i] = *pchPos;
             i++;
         } else {
             if (i >= sizeof(szJoystickButton)) {
+                szJoystickButton[sizeof(szJoystickButton) - 1] = '\0';
                 return SDL_SetError("Joystick button name too large: %s", szJoystickButton);
             }
             szJoystickButton[i] = *pchPos;


### PR DESCRIPTION
Make sure the string is terminated, fixed invalid read in SDL_PrivateParseGamepadConfigString()
```

 ----- Test Case 7.1: 'TestVirtualJoystick' started
==51751== Conditional jump or move depends on uninitialised value(s)
==51751==    at 0x484BC38: strlen (vg_replace_strmem.c:501)
==51751==    by 0x4BD5D57: __printf_buffer (vfprintf-process-arg.c:435)
==51751==    by 0x4BFA443: __vsnprintf_internal (vsnprintf.c:96)
==51751==    by 0x4BFA443: vsnprintf (vsnprintf.c:103)
==51751==    by 0x493DD92: SDL_vsnprintf_REAL (SDL_git/src/stdlib/SDL_string.c:1636)
==51751==    by 0x4882839: SDL_SetError_REAL (SDL_git/src/SDL_error.c:38)
==51751==    by 0x48D58DF: SDL_PrivateParseGamepadConfigString (SDL_git/src/joystick/SDL_gamepad.c:1291)
==51751==    by 0x48D15FE: SDL_PrivateLoadButtonMapping (SDL_git/src/joystick/SDL_gamepad.c:1412)
==51751==    by 0x48CF198: PopMappingChangeTracking (SDL_git/src/joystick/SDL_gamepad.c:574)
==51751==    by 0x48D0633: SDL_PrivateAddMappingForGUID (SDL_git/src/joystick/SDL_gamepad.c:1652)
==51751==    by 0x48D0206: SDL_SetGamepadMapping_REAL (SDL_git/src/joystick/SDL_gamepad.c:2192)
==51751==    by 0x48A6C5E: SDL_SetGamepadMapping (SDL_git/src/dynapi/SDL_dynapi_procs.h:881)
==51751==    by 0x122AE5: TestVirtualJoystick (SDL_git/test/testautomation_joystick.c:86)


```