### PR TITLE
Fix windows touch normalisation on the Y axis

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1230,7 +1230,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
                 for (i = 0; i < num_inputs; ++i) {
                     PTOUCHINPUT input = &inputs[i];
                     const int w = (rect.right - rect.left);
-                    const int h = (rect.right - rect.left);
+                    const int h = (rect.bottom - rect.top);
 
                     const SDL_TouchID touchId = (SDL_TouchID)((size_t)input->hSource);
 

--- a/test/testwm.c
+++ b/test/testwm.c
@@ -34,6 +34,14 @@ static const char *cursorNames[] = {
     "sizeALL",
     "NO",
     "hand",
+    "window top left",
+    "window top",
+    "window top right",
+    "window right",
+    "window bottom right",
+    "window bottom",
+    "window bottom left",
+    "window left"
 };
 static int system_cursor = -1;
 static SDL_Cursor *cursor = NULL;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes a copy-paste typo from https://github.com/libsdl-org/SDL/commit/9302d7732dfbb3c6364da142efd06ea9846206c1.

Also includes a bonus fix for `testwm` that would trigger an assert on startup, and an array out-of-bounds access if the relevant code paths were reached.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->

Notices when looking into https://github.com/libsdl-org/SDL/issues/8725.

SDL really needs a mouse+finger+pen test. I'm currently modifying `testwm.c` to test this. I don't really feel comfortable adding a new test, as lots of project files for lots of different platforms need to be updated.