### PR TITLE
[SDL2] Fix static build with libdrm 2.4.116

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmsym.h
+++ b/src/video/kmsdrm/SDL_kmsdrmsym.h
@@ -63,7 +63,7 @@ SDL_KMSDRM_SYM(int,drmModeSetCrtc,(int fd, uint32_t crtcId, uint32_t bufferId,
 SDL_KMSDRM_SYM(int,drmModeCrtcGetGamma,(int fd, uint32_t crtc_id, uint32_t size,
                                         uint16_t *red, uint16_t *green, uint16_t *blue))
 SDL_KMSDRM_SYM(int,drmModeCrtcSetGamma,(int fd, uint32_t crtc_id, uint32_t size,
-                                        uint16_t *red, uint16_t *green, uint16_t *blue))
+                                        const uint16_t *red, const uint16_t *green, const uint16_t *blue))
 SDL_KMSDRM_SYM(int,drmModeSetCursor,(int fd, uint32_t crtcId, uint32_t bo_handle,
                                      uint32_t width, uint32_t height))
 SDL_KMSDRM_SYM(int,drmModeSetCursor2,(int fd, uint32_t crtcId, uint32_t bo_handle,


### PR DESCRIPTION
## Description
Fixes the static build with libdrm 2.4.116, which change the signature of this function.
Reference: https://gitlab.freedesktop.org/mesa/drm/-/commit/cc8c223c9e5307387fd5d3c0a77c3a0354610bb3

These symbols have been removed in SDL3, so this is a SDL2-specific fix.