### PR TITLE
Fix static build with libdecor 0.2.0

### DIFF
--- a/src/video/wayland/SDL_waylandsym.h
+++ b/src/video/wayland/SDL_waylandsym.h
@@ -221,10 +221,10 @@ SDL_WAYLAND_SYM(int, libdecor_dispatch, (struct libdecor *, int))
 
 #if defined(SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC_LIBDECOR) || defined(SDL_HAVE_LIBDECOR_VER_0_2_0)
 /* Only found in libdecor 0.1.1 or higher, so failure to load them is not fatal. */
-SDL_WAYLAND_SYM_OPT(void, libdecor_frame_get_min_content_size, (struct libdecor_frame *,\
+SDL_WAYLAND_SYM_OPT(void, libdecor_frame_get_min_content_size, (const struct libdecor_frame *,\
                                                             int *,\
                                                             int *))
-SDL_WAYLAND_SYM_OPT(void, libdecor_frame_get_max_content_size, (struct libdecor_frame *,\
+SDL_WAYLAND_SYM_OPT(void, libdecor_frame_get_max_content_size, (const struct libdecor_frame *,\
                                                             int *,\
                                                             int *))
 #endif


### PR DESCRIPTION
## Description
Fixes the static build with libdecor v0.2.0 which changed the signature of these functions. Please cherry-pick to SDL2.
Reference: https://gitlab.freedesktop.org/libdecor/libdecor/-/commit/c3b3965dcf0fe07e95b8a36bf17d65ebb965852b