### PR TITLE
sdl2.m4: Call $PKG_CONFIG rather than hard-coding pkg-config

### DIFF
--- a/sdl2.m4
+++ b/sdl2.m4
@@ -9,8 +9,9 @@
 # * also look for SDL2.framework under Mac OS X
 # * removed HP/UX 9 support.
 # * updated for newer autoconf.
+# * (v3) use $PKG_CONFIG for pkg-config cross-compiling support
 
-# serial 2
+# serial 3
 
 dnl AM_PATH_SDL2([MINIMUM-VERSION, [ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND]]])
 dnl Test for SDL, and define SDL_CFLAGS and SDL_LIBS
@@ -54,7 +55,7 @@ AC_ARG_VAR(SDL2_FRAMEWORK, [Path to SDL2.framework])
 
   if test "x$sdl_pc" = xyes ; then
     no_sdl=""
-    SDL2_CONFIG="pkg-config sdl2"
+    SDL2_CONFIG="$PKG_CONFIG sdl2"
   else
     as_save_PATH="$PATH"
     if test "x$prefix" != xNONE && test "$cross_compiling" != yes; then


### PR DESCRIPTION
When cross-compiling, pkg.m4 will set the PKG_CONFIG variable to a suitable pkg-config executable, which might be a host-architecture-prefixed name like aarch64-linux-gnu-pkg-config. This ensures that we will use a suitable search path that is suitable for the host architecture (the machine we are compiling for) rather than the build architecture (the machine we are compiling on) to find dependency libraries like SDL. When using pkg-config as a substitute for sdl2-config, we will similarly need to use the host-architecture-prefixed pkg-config.

Setting the PKG_CONFIG environment variable is also the canonical way to request that a different pkg-config implementation be used, if that becomes necessary for some reason.

Bug-Debian: https://bugs.debian.org/1059749

---

Please also apply to 2.28.x if accepted. SDL2 version of https://github.com/libsdl-org/sdl12-compat/pull/326; not needed in SDL 3, which no longer ships custom m4 macros at all, and relies on pkg-config (or CMake) instead.