### PR TITLE
Add hint to make SDL handle dbus_shutdown()

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2706,7 +2706,6 @@ extern "C" {
  */
 #define SDL_HINT_AUDIO_DEVICE_SAMPLE_FRAMES "SDL_AUDIO_DEVICE_SAMPLE_FRAMES"
 
-
 /**
  * Request SDL_AppIterate() be called at a specific rate.
  *
@@ -2720,6 +2719,22 @@ extern "C" {
  * the default.
  */
 #define SDL_HINT_MAIN_CALLBACK_RATE "SDL_MAIN_CALLBACK_RATE"
+
+/**
+ * Let SDL handle dbus_shutdown().
+ *
+ * Only enable this option if no other dependency uses D-Bus.
+ *
+ * This option tells SDL that it can safely call dbus_shutdown() when
+ * SDL_Quit() is called. You must ensure that no other library still uses
+ * D-Bus when SDL_Quit() is called, otherwise resources will be freed while
+ * they are still in use, which results in undefined behavior and likely a
+ * crash.
+ *
+ * Use this option to prevent memory leaks if your application doesn't use
+ * D-Bus other than through SDL.
+ */
+#define SDL_HINT_SHUTDOWN_DBUS_ON_QUIT "SDL_SHUTDOWN_DBUS_ON_QUIT"
 
 
 /**

--- a/src/SDL.c
+++ b/src/SDL.c
@@ -517,12 +517,12 @@ void SDL_Quit(void)
     SDL_QuitTicks();
 #endif
 
-    SDL_ClearHints();
-    SDL_AssertionsQuit();
-
 #ifdef SDL_USE_LIBDBUS
     SDL_DBus_Quit();
 #endif
+
+    SDL_ClearHints();
+    SDL_AssertionsQuit();
 
     SDL_QuitProperties();
     SDL_QuitLog();

--- a/src/core/linux/SDL_dbus.c
+++ b/src/core/linux/SDL_dbus.c
@@ -183,14 +183,12 @@ void SDL_DBus_Quit(void)
         dbus.connection_close(dbus.session_conn);
         dbus.connection_unref(dbus.session_conn);
     }
-/* Don't do this - bug 3950
-   dbus_shutdown() is a debug feature which closes all global resources in the dbus library. Calling this should be done by the app, not a library, because if there are multiple users of dbus in the process then SDL could shut it down even though another part is using it.
-*/
-#if 0
-    if (dbus.shutdown) {
+
+    SDL_bool q = SDL_GetHintBoolean(SDL_HINT_SHUTDOWN_DBUS_ON_QUIT, SDL_FALSE);
+    if (q == SDL_TRUE && dbus.shutdown) {
         dbus.shutdown();
     }
-#endif
+
     SDL_zero(dbus);
     UnloadDBUSLibrary();
     SDL_free(inhibit_handle);


### PR DESCRIPTION
## Description
Adds a new hint, `SDL_HINT_SHUTDOWN_DBUS_ON_QUIT`, to allow app developers to let SDL know they won't use D-Bus directly, and that it can safely call dbus_shutdown() within SDL_Quit().

As requested, the default behavior is to keep D-Bus open on quit.

I added a description that clearly explains why SDL doesn't close D-Bus by default, and what to think about before enabling the option (such as making sure no other dependency uses D-Bus). I'm open to adapt the description, if necessary.

### Example of use

```c
#include "SDL3/SDL.h"

int main()
{
  SDL_SetHint(SDL_HINT_SHUTDOWN_DBUS_ON_QUIT, "1");

  SDL_Init(0);

  // ...

  SDL_Quit();

  return 0;
}
```

I had to change the shutdown order in SDL.c, because hints were cleared before SDL_DBus_Quit() was called. I wanted to specify this because I'm not sure if it could have other unforeseen side effects.

## Existing Issue(s)
Resolves #8764
