### PR TITLE
Fixed STYLE_BORDERLESS_WINDOWED not allowing resizing through SDL_HITTEST_RESIZE_*

### DIFF
--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -81,17 +81,18 @@ static const TCHAR *SDL_HelperWindowName = TEXT("SDLHelperWindowInputMsgWindow")
 static ATOM SDL_HelperWindowClass = 0;
 
 /* For borderless Windows, still want the following flag:
+   - WS_THICKFRAME: without this the window cannot be resized and so aero snap, de-maximizing and minimizing won't work
    - WS_MINIMIZEBOX: window will respond to Windows minimize commands sent to all windows, such as windows key + m, shaking title bar, etc.
    Additionally, non-fullscreen windows can add:
-   - WS_CAPTION: this seems to enable the Windows minimize animation
-   - WS_SYSMENU: enables system context menu on task bar
+   - WS_CAPTION: enables aero minimize animation/transition
+   - WS_SYSMENU: enables the context menu with the move, close, maximize, minize... commands (shift + right-click on the task bar item)
    This will also cause the task bar to overlap the window and other windowed behaviors, so only use this for windows that shouldn't appear to be fullscreen
  */
 
 #define STYLE_BASIC               (WS_CLIPSIBLINGS | WS_CLIPCHILDREN)
 #define STYLE_FULLSCREEN          (WS_POPUP | WS_MINIMIZEBOX)
 #define STYLE_BORDERLESS          (WS_POPUP | WS_MINIMIZEBOX)
-#define STYLE_BORDERLESS_WINDOWED (WS_POPUP | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX)
+#define STYLE_BORDERLESS_WINDOWED (WS_POPUP | WS_THICKFRAME | WS_CAPTION | WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX)
 #define STYLE_NORMAL              (WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX)
 #define STYLE_RESIZABLE           (WS_THICKFRAME | WS_MAXIMIZEBOX)
 #define STYLE_MASK                (STYLE_FULLSCREEN | STYLE_BORDERLESS | STYLE_NORMAL | STYLE_RESIZABLE)


### PR DESCRIPTION
When the window uses the STYLE_BORDERLESS_WINDOWED style, Windows does not respond to SDL_HITTEST_RESIZE_* leading me to use STYLE_BORDERLESS that doesn't enable aero features such as snapping.

## Description
I found [this](https://github.com/melak47/BorderlessWindow) repository that implements aero, resizable borderless windows and from [this](https://github.com/melak47/BorderlessWindow/blob/3b6978d88c0eef47f79c0ac125ec154bf701375c/BorderlessWindow/src/BorderlessWindow.cpp#L20) code snippet concluded that i had to add the WS_THICKFRAME flag to enable resizing.
Since i copied the snippet from the repository, i also added the WS_MAXIMIZEBOX flag, that should enable maximizing if that wasn't a thing already.

## Existing Issue(s)
Might be a fix to #8586 if the issue is talking about borderless windows
