### PR TITLE
cocoa: Set the titled flag on fullscreen space windows

### DIFF
--- a/src/video/cocoa/SDL_cocoawindow.h
+++ b/src/video/cocoa/SDL_cocoawindow.h
@@ -140,6 +140,7 @@ typedef enum
 @property(nonatomic) SDL_CocoaVideoData *videodata;
 @property(nonatomic) SDL_bool send_floating_size;
 @property(nonatomic) SDL_bool send_floating_position;
+@property(nonatomic) SDL_bool border_toggled;
 @property(nonatomic) BOOL checking_zoom;
 #ifdef SDL_VIDEO_OPENGL_EGL
 @property(nonatomic) EGLSurface egl_surface;


### PR DESCRIPTION
For some reason, fullscreen space windows won't receive any mouse button events without the NSWindowStyleMaskTitled flag set, even though they successfully become key and receive key and mouse motion events. Make sure the flag is always set on fullscreen space windows.

Fixes #8778 