### PR TITLE
SDL_audio.c: Fix buffer overflow in SDL_RunAudio

### DIFF
--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -677,6 +677,7 @@ static int SDLCALL SDL_RunAudio(void *userdata)
     SDL_AudioCallback callback = device->callbackspec.callback;
     int data_len = 0;
     Uint8 *data;
+    Uint8 *device_buf_keepsafe = NULL;
 
     SDL_assert(!device->iscapture);
 
@@ -703,8 +704,16 @@ static int SDLCALL SDL_RunAudio(void *userdata)
 
         /* Fill the current buffer with sound */
         if (!device->stream && SDL_AtomicGet(&device->enabled)) {
-            SDL_assert(data_len == device->spec.size);
             data = current_audio.impl.GetDeviceBuf(device);
+
+            if (device->stream && SDL_AtomicGet(&device->enabled)) {
+                /* Oops. Audio device reset and now we suddenly use a stream, */
+                /* so save this devicebuf for later, to prevent de-sync */
+                if (data != NULL) {
+                    device_buf_keepsafe = data;
+                }
+                data = NULL;
+            }
         } else {
             /* if the device isn't enabled, we still write to the
                work_buffer, so the app's callback will fire with
@@ -735,7 +744,19 @@ static int SDLCALL SDL_RunAudio(void *userdata)
 
             while (SDL_AudioStreamAvailable(device->stream) >= ((int)device->spec.size)) {
                 int got;
-                data = SDL_AtomicGet(&device->enabled) ? current_audio.impl.GetDeviceBuf(device) : NULL;
+                if (SDL_AtomicGet(&device->enabled)) {
+                    /* if device reset occured - a switch from direct output to streaming */
+                    /* use the already aquired device buffer */
+                    if (device_buf_keepsafe) {
+                        data = device_buf_keepsafe;
+                        device_buf_keepsafe = NULL;
+                    } else {
+                        /* else - normal flow, just acquire the device buffer here */
+                        data = current_audio.impl.GetDeviceBuf(device);
+                    }
+                } else {
+                    data = NULL;
+                }
                 got = SDL_AudioStreamGet(device->stream, data ? data : device->work_buffer, device->spec.size);
                 SDL_assert((got <= 0) || (got == device->spec.size));
 
@@ -749,6 +770,14 @@ static int SDLCALL SDL_RunAudio(void *userdata)
                     current_audio.impl.PlayDevice(device);
                     current_audio.impl.WaitDevice(device);
                 }
+            }
+
+            /* it seems resampling was not fast enough, device_buf_keepsafe was not released yet, so play silence here */
+            if (device_buf_keepsafe) {
+                SDL_memset(device_buf_keepsafe, device->spec.silence, device->spec.size);
+                current_audio.impl.PlayDevice(device);
+                current_audio.impl.WaitDevice(device);
+                device_buf_keepsafe = NULL;
             }
         } else if (data == device->work_buffer) {
             /* nothing to do; pause like we queued a buffer to play. */


### PR DESCRIPTION
I'll quickly describe the scenario we had. It may happen under totally different circumstances too.
I compiled SDL2 with AddressSanitizer to see where it happens.

Windows
SDL2
FNA/FNAAudio (https://github.com/FNA-XNA/FNA)
ClassicUO (https://github.com/ClassicUO/ClassicUO/)

If you do this while in-game:
![image](https://github.com/libsdl-org/SDL/assets/8710555/0ca1e537-991c-4f57-924c-3a9b52d0a155)

this happens:
![image](https://github.com/libsdl-org/SDL/assets/8710555/34ff0ed1-2e82-42ae-8d3b-e494879a7503)

This is because SDL uses the WASAPI backend implementation on modern Windows. 
If the default audio device changes or gets reset, the WASAPI will try to recover, which is fine. 
But some things may change: device buffer size, work buffer size, and device->stream will hop from 0 to 1, or from 1 to 0

When SDL_OpenAudioDevice is called, the function reports a certain WaveFormat to the application, and the application will keep streaming in that format, so if the underlying device changes its waveformat, SDL2 will use resampling. BUT: on the first call to GetDeviceBuf() (there is where the device reset can happen), device->stream may be set to 1 and the device buffer may be smaller than the callbackspec.size, and then the wrong data_len is reported to the callbackspec.callback, leading to this buffer overrun.

There is another case in which the buffer overrun will not occur if you e.g. switch from a device with almost same wave format but less channels, to a device with more channels (just because the size is lower then as the size of the working buffer), but then you will run into the scenario where you call GetDeviceBuf() twice. Because streaming will be enabled after GetDeviceBuf(), and the second call without Device Buffer release is in the streaming code a little below. Wasapi will then be stuck in an endless loop because it fails with AUDCLNT_E_OUT_OF_ORDER.

The commit fixes the buffer overruns and prevent double call of GetDeviceBuf and de-sync.