### PR TITLE
Making Haptic compact through alignment

### DIFF
--- a/include/SDL3/SDL_haptic.h
+++ b/include/SDL3/SDL_haptic.h
@@ -478,12 +478,13 @@ typedef struct SDL_HapticDirection
 typedef struct SDL_HapticConstant
 {
     /* Header */
-    Uint16 type;            /**< ::SDL_HAPTIC_CONSTANT */
     SDL_HapticDirection direction;  /**< Direction of the effect. */
 
     /* Replay */
     Uint32 length;          /**< Duration of the effect. */
     Uint16 delay;           /**< Delay before starting the effect. */
+
+    Uint16 type;            /**< ::SDL_HAPTIC_CONSTANT */
 
     /* Trigger */
     Uint16 button;          /**< Button that triggers the effect. */
@@ -559,14 +560,15 @@ typedef struct SDL_HapticConstant
 typedef struct SDL_HapticPeriodic
 {
     /* Header */
-    Uint16 type;        /**< ::SDL_HAPTIC_SINE, ::SDL_HAPTIC_LEFTRIGHT,
-                             ::SDL_HAPTIC_TRIANGLE, ::SDL_HAPTIC_SAWTOOTHUP or
-                             ::SDL_HAPTIC_SAWTOOTHDOWN */
     SDL_HapticDirection direction;  /**< Direction of the effect. */
 
     /* Replay */
     Uint32 length;      /**< Duration of the effect. */
     Uint16 delay;       /**< Delay before starting the effect. */
+
+    Uint16 type;        /**< ::SDL_HAPTIC_SINE, ::SDL_HAPTIC_LEFTRIGHT,
+                             ::SDL_HAPTIC_TRIANGLE, ::SDL_HAPTIC_SAWTOOTHUP or
+                             ::SDL_HAPTIC_SAWTOOTHDOWN */
 
     /* Trigger */
     Uint16 button;      /**< Button that triggers the effect. */
@@ -612,13 +614,14 @@ typedef struct SDL_HapticPeriodic
 typedef struct SDL_HapticCondition
 {
     /* Header */
-    Uint16 type;            /**< ::SDL_HAPTIC_SPRING, ::SDL_HAPTIC_DAMPER,
-                                 ::SDL_HAPTIC_INERTIA or ::SDL_HAPTIC_FRICTION */
     SDL_HapticDirection direction;  /**< Direction of the effect - Not used ATM. */
 
     /* Replay */
     Uint32 length;          /**< Duration of the effect. */
     Uint16 delay;           /**< Delay before starting the effect. */
+
+    Uint16 type;            /**< ::SDL_HAPTIC_SPRING, ::SDL_HAPTIC_DAMPER,
+                                 ::SDL_HAPTIC_INERTIA or ::SDL_HAPTIC_FRICTION */
 
     /* Trigger */
     Uint16 button;          /**< Button that triggers the effect. */
@@ -649,12 +652,13 @@ typedef struct SDL_HapticCondition
 typedef struct SDL_HapticRamp
 {
     /* Header */
-    Uint16 type;            /**< ::SDL_HAPTIC_RAMP */
     SDL_HapticDirection direction;  /**< Direction of the effect. */
 
     /* Replay */
     Uint32 length;          /**< Duration of the effect. */
     Uint16 delay;           /**< Delay before starting the effect. */
+
+    Uint16 type;            /**< ::SDL_HAPTIC_RAMP */
 
     /* Trigger */
     Uint16 button;          /**< Button that triggers the effect. */


### PR DESCRIPTION
Compiler insert padding to prevent alignment issue and sometime you end up wasting space.
So here I moved the 16bits type to follow after 32bits and only did it for struct that actually benefited from this.
The most impactful are SDL_HapticCondition which is the largest used in union.
you reduce this it take SDL_HapticEffect from 72 to 64 which fit nicely in cache line.
And SDL_Haptic from 128 to 120.
