### PR TITLE
Fix memory barriers on ARMv5

### DIFF
--- a/include/SDL3/SDL_atomic.h
+++ b/include/SDL3/SDL_atomic.h
@@ -213,7 +213,7 @@ typedef void (*SDL_KernelMemoryBarrierFunc)();
 #if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7EM__) || defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7S__) || defined(__ARM_ARCH_8A__)
 #define SDL_MemoryBarrierRelease()   __asm__ __volatile__ ("dmb ish" : : : "memory")
 #define SDL_MemoryBarrierAcquire()   __asm__ __volatile__ ("dmb ish" : : : "memory")
-#elif defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6T2__) || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_5TE__)
+#elif defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6T2__) || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__)
 #ifdef __thumb__
 /* The mcr instruction isn't available in thumb mode, use real functions */
 #define SDL_MEMORY_BARRIER_USES_FUNCTION


### PR DESCRIPTION
## Description

The ARM926EJ-S Technical Reference Manual states:

> You can only access CP15 registers with MRC and MCR instructions in a
> privileged mode. CDP, LDC, STC, MCRR, and MRRC instructions, and unprivileged
> MRC or MCR instructions to CP15 cause the Undefined instruction exception to
> be taken.

Furthermore, `MCR p15, 0, <Rd>, c7, c10, 5` (later called Data Memory Barrier) is not specified for the ARM926. Thus, SDL should not use these cache instructions on ARMv5.

This PR applies to the `main` branch as well as the `SDL2` branch.

## Existing Issue(s)

None.