### PR TITLE
Add properties to enable/enhance the use of SDL Wayland windows outside of SDL

### DIFF
--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -1033,8 +1033,6 @@ extern DECLSPEC SDL_Window *SDLCALL SDL_GetWindowParent(SDL_Window *window);
  * show/hide calls. They will be null if the window is hidden and must be
  * queried each time it is shown.
  *
- * - `SDL_PROPERTY_WINDOW_WAYLAND_REGISTRY_POINTER`: the wl_registry
- *   associated with the window
  * - `SDL_PROPERTY_WINDOW_WAYLAND_DISPLAY_POINTER`: the wl_display associated
  *   with the window
  * - `SDL_PROPERTY_WINDOW_WAYLAND_SURFACE_POINTER`: the wl_surface associated
@@ -1086,7 +1084,6 @@ extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetWindowProperties(SDL_Window *win
 #define SDL_PROPERTY_WINDOW_WIN32_HWND_POINTER              "SDL.window.win32.hwnd"
 #define SDL_PROPERTY_WINDOW_WIN32_HDC_POINTER               "SDL.window.win32.hdc"
 #define SDL_PROPERTY_WINDOW_WIN32_INSTANCE_POINTER          "SDL.window.win32.instance"
-#define SDL_PROPERTY_WINDOW_WAYLAND_REGISTRY_POINTER        "SDL.window.wayland.registry"
 #define SDL_PROPERTY_WINDOW_WAYLAND_DISPLAY_POINTER         "SDL.window.wayland.display"
 #define SDL_PROPERTY_WINDOW_WAYLAND_SURFACE_POINTER         "SDL.window.wayland.surface"
 #define SDL_PROPERTY_WINDOW_WAYLAND_EGL_WINDOW_POINTER      "SDL.window.wayland.egl_window"

--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -872,6 +872,9 @@ extern DECLSPEC SDL_Window *SDLCALL SDL_CreatePopupWindow(SDL_Window *parent, in
  *   if the application wants to use the Wayland surface for a custom role and
  *   does not want it attached to an XDG toplevel window. See
  *   docs/README-wayland.md for more information on using custom surfaces.
+ * - `SDL_PROPERTY_WINDOW_CREATE_WAYLAND_CREATE_EGL_WINDOW_BOOLEAN - true if
+ *   the application wants an associated `wl_egl_window` object to be created,
+ *   even if the window does not have the OpenGL property or flag set.
  *
  * These are additional supported properties on Windows:
  *
@@ -927,6 +930,7 @@ extern DECLSPEC SDL_Window *SDLCALL SDL_CreateWindowWithProperties(SDL_Propertie
 #define SDL_PROPERTY_WINDOW_CREATE_COCOA_WINDOW_POINTER                "cocoa.window"
 #define SDL_PROPERTY_WINDOW_CREATE_COCOA_VIEW_POINTER                  "cocoa.view"
 #define SDL_PROPERTY_WINDOW_CREATE_WAYLAND_SURFACE_ROLE_CUSTOM_BOOLEAN "wayland.surface_role_custom"
+#define SDL_PROPERTY_WINDOW_CREATE_WAYLAND_CREATE_EGL_WINDOW_BOOLEAN   "wayland.create_egl_window"
 #define SDL_PROPERTY_WINDOW_CREATE_WIN32_HWND_POINTER                  "win32.hwnd"
 #define SDL_PROPERTY_WINDOW_CREATE_WIN32_PIXEL_FORMAT_HWND_POINTER     "win32.pixel_format_hwnd"
 #define SDL_PROPERTY_WINDOW_CREATE_X11_WINDOW_NUMBER                   "x11.window"

--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -866,6 +866,13 @@ extern DECLSPEC SDL_Window *SDLCALL SDL_CreatePopupWindow(SDL_Window *parent, in
  *   `(__unsafe_unretained)` NSView associated with the window, defaults to
  *   `[window contentView]`
  *
+ * These are additional supported properties on Wayland:
+ *
+ * - `SDL_PROPERTY_WINDOW_CREATE_WAYLAND_SURFACE_ROLE_CUSTOM_BOOLEAN` - true
+ *   if the application wants to use the Wayland surface for a custom role and
+ *   does not want it attached to an XDG toplevel window. See
+ *   docs/README-wayland.md for more information on using custom surfaces.
+ *
  * These are additional supported properties on Windows:
  *
  * - `SDL_PROPERTY_WINDOW_CREATE_WIN32_HWND_POINTER`: the HWND associated with
@@ -894,35 +901,35 @@ extern DECLSPEC SDL_Window *SDLCALL SDL_CreatePopupWindow(SDL_Window *parent, in
  */
 extern DECLSPEC SDL_Window *SDLCALL SDL_CreateWindowWithProperties(SDL_PropertiesID props);
 
-#define SDL_PROPERTY_WINDOW_CREATE_ALWAYS_ON_TOP_BOOLEAN            "always-on-top"
-#define SDL_PROPERTY_WINDOW_CREATE_BORDERLESS_BOOLEAN               "borderless"
-#define SDL_PROPERTY_WINDOW_CREATE_FOCUSABLE_BOOLEAN                "focusable"
-#define SDL_PROPERTY_WINDOW_CREATE_FULLSCREEN_BOOLEAN               "fullscreen"
-#define SDL_PROPERTY_WINDOW_CREATE_HEIGHT_NUMBER                    "height"
-#define SDL_PROPERTY_WINDOW_CREATE_HIDDEN_BOOLEAN                   "hidden"
-#define SDL_PROPERTY_WINDOW_CREATE_HIGH_PIXEL_DENSITY_BOOLEAN       "high-pixel-density"
-#define SDL_PROPERTY_WINDOW_CREATE_MAXIMIZED_BOOLEAN                "maximized"
-#define SDL_PROPERTY_WINDOW_CREATE_MENU_BOOLEAN                     "menu"
-#define SDL_PROPERTY_WINDOW_CREATE_METAL_BOOLEAN                    "metal"
-#define SDL_PROPERTY_WINDOW_CREATE_MINIMIZED_BOOLEAN                "minimized"
-#define SDL_PROPERTY_WINDOW_CREATE_MOUSE_GRABBED_BOOLEAN            "mouse-grabbed"
-#define SDL_PROPERTY_WINDOW_CREATE_OPENGL_BOOLEAN                   "opengl"
-#define SDL_PROPERTY_WINDOW_CREATE_PARENT_POINTER                   "parent"
-#define SDL_PROPERTY_WINDOW_CREATE_RESIZABLE_BOOLEAN                "resizable"
-#define SDL_PROPERTY_WINDOW_CREATE_TITLE_STRING                     "title"
-#define SDL_PROPERTY_WINDOW_CREATE_TRANSPARENT_BOOLEAN              "transparent"
-#define SDL_PROPERTY_WINDOW_CREATE_TOOLTIP_BOOLEAN                  "tooltip"
-#define SDL_PROPERTY_WINDOW_CREATE_UTILITY_BOOLEAN                  "utility"
-#define SDL_PROPERTY_WINDOW_CREATE_VULKAN_BOOLEAN                   "vulkan"
-#define SDL_PROPERTY_WINDOW_CREATE_WIDTH_NUMBER                     "width"
-#define SDL_PROPERTY_WINDOW_CREATE_X_NUMBER                         "x"
-#define SDL_PROPERTY_WINDOW_CREATE_Y_NUMBER                         "y"
-#define SDL_PROPERTY_WINDOW_CREATE_COCOA_WINDOW_POINTER             "cocoa.window"
-#define SDL_PROPERTY_WINDOW_CREATE_COCOA_VIEW_POINTER               "cocoa.view"
-#define SDL_PROPERTY_WINDOW_CREATE_WIN32_HWND_POINTER               "win32.hwnd"
-#define SDL_PROPERTY_WINDOW_CREATE_WIN32_PIXEL_FORMAT_HWND_POINTER  "win32.pixel_format_hwnd"
-#define SDL_PROPERTY_WINDOW_CREATE_X11_WINDOW_NUMBER                "x11.window"
-
+#define SDL_PROPERTY_WINDOW_CREATE_ALWAYS_ON_TOP_BOOLEAN               "always-on-top"
+#define SDL_PROPERTY_WINDOW_CREATE_BORDERLESS_BOOLEAN                  "borderless"
+#define SDL_PROPERTY_WINDOW_CREATE_FOCUSABLE_BOOLEAN                   "focusable"
+#define SDL_PROPERTY_WINDOW_CREATE_FULLSCREEN_BOOLEAN                  "fullscreen"
+#define SDL_PROPERTY_WINDOW_CREATE_HEIGHT_NUMBER                       "height"
+#define SDL_PROPERTY_WINDOW_CREATE_HIDDEN_BOOLEAN                      "hidden"
+#define SDL_PROPERTY_WINDOW_CREATE_HIGH_PIXEL_DENSITY_BOOLEAN          "high-pixel-density"
+#define SDL_PROPERTY_WINDOW_CREATE_MAXIMIZED_BOOLEAN                   "maximized"
+#define SDL_PROPERTY_WINDOW_CREATE_MENU_BOOLEAN                        "menu"
+#define SDL_PROPERTY_WINDOW_CREATE_METAL_BOOLEAN                       "metal"
+#define SDL_PROPERTY_WINDOW_CREATE_MINIMIZED_BOOLEAN                   "minimized"
+#define SDL_PROPERTY_WINDOW_CREATE_MOUSE_GRABBED_BOOLEAN               "mouse-grabbed"
+#define SDL_PROPERTY_WINDOW_CREATE_OPENGL_BOOLEAN                      "opengl"
+#define SDL_PROPERTY_WINDOW_CREATE_PARENT_POINTER                      "parent"
+#define SDL_PROPERTY_WINDOW_CREATE_RESIZABLE_BOOLEAN                   "resizable"
+#define SDL_PROPERTY_WINDOW_CREATE_TITLE_STRING                        "title"
+#define SDL_PROPERTY_WINDOW_CREATE_TRANSPARENT_BOOLEAN                 "transparent"
+#define SDL_PROPERTY_WINDOW_CREATE_TOOLTIP_BOOLEAN                     "tooltip"
+#define SDL_PROPERTY_WINDOW_CREATE_UTILITY_BOOLEAN                     "utility"
+#define SDL_PROPERTY_WINDOW_CREATE_VULKAN_BOOLEAN                      "vulkan"
+#define SDL_PROPERTY_WINDOW_CREATE_WIDTH_NUMBER                        "width"
+#define SDL_PROPERTY_WINDOW_CREATE_X_NUMBER                            "x"
+#define SDL_PROPERTY_WINDOW_CREATE_Y_NUMBER                            "y"
+#define SDL_PROPERTY_WINDOW_CREATE_COCOA_WINDOW_POINTER                "cocoa.window"
+#define SDL_PROPERTY_WINDOW_CREATE_COCOA_VIEW_POINTER                  "cocoa.view"
+#define SDL_PROPERTY_WINDOW_CREATE_WAYLAND_SURFACE_ROLE_CUSTOM_BOOLEAN "wayland.surface_role_custom"
+#define SDL_PROPERTY_WINDOW_CREATE_WIN32_HWND_POINTER                  "win32.hwnd"
+#define SDL_PROPERTY_WINDOW_CREATE_WIN32_PIXEL_FORMAT_HWND_POINTER     "win32.pixel_format_hwnd"
+#define SDL_PROPERTY_WINDOW_CREATE_X11_WINDOW_NUMBER                   "x11.window"
 
 /**
  * Get the numeric ID of a window.

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -2154,7 +2154,6 @@ int Wayland_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Propert
     } /* All other cases will be WAYLAND_SURFACE_UNKNOWN */
 
     SDL_PropertiesID props = SDL_GetWindowProperties(window);
-    SDL_SetProperty(props, SDL_PROPERTY_WINDOW_WAYLAND_REGISTRY_POINTER, c->registry);
     SDL_SetProperty(props, SDL_PROPERTY_WINDOW_WAYLAND_DISPLAY_POINTER, data->waylandData->display);
     SDL_SetProperty(props, SDL_PROPERTY_WINDOW_WAYLAND_SURFACE_POINTER, data->surface);
     SDL_SetProperty(props, SDL_PROPERTY_WINDOW_WAYLAND_EGL_WINDOW_POINTER, data->egl_window);

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -2056,6 +2056,8 @@ int Wayland_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Propert
     SDL_WindowData *data;
     SDL_VideoData *c;
     const SDL_bool custom_surface_role = SDL_GetBooleanProperty(create_props, SDL_PROPERTY_WINDOW_CREATE_WAYLAND_SURFACE_ROLE_CUSTOM_BOOLEAN, SDL_FALSE);
+    const SDL_bool create_egl_window = !!(window->flags & SDL_WINDOW_OPENGL) ||
+                                       SDL_GetBooleanProperty(create_props, SDL_PROPERTY_WINDOW_CREATE_WAYLAND_CREATE_EGL_WINDOW_BOOLEAN, SDL_FALSE);
 
     data = SDL_calloc(1, sizeof(*data));
     if (!data) {
@@ -2129,18 +2131,20 @@ int Wayland_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Propert
         }
     }
 
-    if (window->flags & SDL_WINDOW_OPENGL) {
+    if (create_egl_window) {
         data->egl_window = WAYLAND_wl_egl_window_create(data->surface, data->drawable_width, data->drawable_height);
+    }
 
 #ifdef SDL_VIDEO_OPENGL_EGL
+    if (window->flags & SDL_WINDOW_OPENGL) {
         /* Create the GLES window surface */
         data->egl_surface = SDL_EGL_CreateSurface(_this, window, (NativeWindowType)data->egl_window);
 
         if (data->egl_surface == EGL_NO_SURFACE) {
             return -1; /* SDL_EGL_CreateSurface should have set error */
         }
-#endif
     }
+#endif
 
     if (c->relative_mouse_mode) {
         Wayland_input_lock_pointer(c->input);

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -70,7 +70,8 @@ struct SDL_WindowData
         WAYLAND_SURFACE_UNKNOWN = 0,
         WAYLAND_SURFACE_XDG_TOPLEVEL,
         WAYLAND_SURFACE_XDG_POPUP,
-        WAYLAND_SURFACE_LIBDECOR
+        WAYLAND_SURFACE_LIBDECOR,
+        WAYLAND_SURFACE_CUSTOM
     } shell_surface_type;
     enum
     {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -398,6 +398,15 @@ add_sdl_test_executable(testvulkan NO_C90 SOURCES testvulkan.c)
 add_sdl_test_executable(testoffscreen SOURCES testoffscreen.c)
 add_sdl_test_executable(testpopup SOURCES testpopup.c)
 
+if (HAVE_WAYLAND)
+    # Set the GENERATED property on the protocol file, since it is first created at build time
+    set_property(SOURCE ${SDL3_BINARY_DIR}/wayland-generated-protocols/xdg-shell-protocol.c PROPERTY GENERATED 1)
+    add_sdl_test_executable(testwaylandcustom NO_C90 NEEDS_RESOURCES SOURCES testwaylandcustom.c ${SDL3_BINARY_DIR}/wayland-generated-protocols/xdg-shell-protocol.c)
+    # Needed to silence the documentation warning in the generated header file
+    target_compile_options(testwaylandcustom PRIVATE -Wno-documentation-unknown-command)
+    target_link_libraries(testwaylandcustom PRIVATE wayland-client)
+endif()
+
 check_c_compiler_flag(-Wformat-overflow HAVE_WFORMAT_OVERFLOW)
 if(HAVE_WFORMAT_OVERFLOW)
     target_compile_definitions(testautomation PRIVATE HAVE_WFORMAT_OVERFLOW)

--- a/test/testwaylandcustom.c
+++ b/test/testwaylandcustom.c
@@ -1,0 +1,333 @@
+/*
+  Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely.
+*/
+
+#include <stdlib.h>
+#include <time.h>
+
+#include <SDL3/SDL.h>
+#include <wayland-client.h>
+#include <xdg-shell-client-protocol.h>
+
+#include "icon.h"
+
+#define WINDOW_WIDTH  640
+#define WINDOW_HEIGHT 480
+#define NUM_SPRITES   100
+#define MAX_SPEED     1
+
+static SDL_Window *window;
+static SDL_Renderer *renderer;
+static SDL_Texture *sprite;
+static SDL_FRect positions[NUM_SPRITES];
+static SDL_FRect velocities[NUM_SPRITES];
+static int sprite_w, sprite_h;
+static int done;
+
+static SDL_Texture *CreateTexture(SDL_Renderer *r, unsigned char *data, unsigned int len, int *w, int *h)
+{
+    SDL_Texture *texture = NULL;
+    SDL_Surface *surface;
+    SDL_RWops *src = SDL_RWFromConstMem(data, len);
+    if (src) {
+        surface = SDL_LoadBMP_RW(src, SDL_TRUE);
+        if (surface) {
+            /* Treat white as transparent */
+            SDL_SetSurfaceColorKey(surface, SDL_TRUE, SDL_MapRGB(surface->format, 255, 255, 255));
+
+            texture = SDL_CreateTextureFromSurface(r, surface);
+            *w = surface->w;
+            *h = surface->h;
+            SDL_DestroySurface(surface);
+        }
+    }
+    return texture;
+}
+
+static void MoveSprites(void)
+{
+    int i;
+    int window_w;
+    int window_h;
+    SDL_FRect *position, *velocity;
+
+    /* Get the window size */
+    SDL_GetWindowSizeInPixels(window, &window_w, &window_h);
+
+    /* Draw a gray background */
+    SDL_SetRenderDrawColor(renderer, 0xA0, 0xA0, 0xA0, 0xFF);
+    SDL_RenderClear(renderer);
+
+    /* Move the sprite, bounce at the wall, and draw */
+    for (i = 0; i < NUM_SPRITES; ++i) {
+        position = &positions[i];
+        velocity = &velocities[i];
+        position->x += velocity->x;
+        if ((position->x < 0) || (position->x >= (window_w - sprite_w))) {
+            velocity->x = -velocity->x;
+            position->x += velocity->x;
+        }
+        position->y += velocity->y;
+        if ((position->y < 0) || (position->y >= (window_h - sprite_h))) {
+            velocity->y = -velocity->y;
+            position->y += velocity->y;
+        }
+
+        /* Blit the sprite onto the screen */
+        SDL_RenderTexture(renderer, sprite, NULL, position);
+    }
+
+    /* Update the screen! */
+    SDL_RenderPresent(renderer);
+}
+
+static int InitSprites(void)
+{
+    /* Create the sprite texture and initialize the sprite positions */
+    sprite = CreateTexture(renderer, icon_bmp, icon_bmp_len, &sprite_w, &sprite_h);
+
+    if (!sprite) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create sprite texture");
+        return -1;
+    }
+
+    srand((unsigned int)time(NULL));
+    for (int i = 0; i < NUM_SPRITES; ++i) {
+        positions[i].x = (float)(rand() % (WINDOW_WIDTH - sprite_w));
+        positions[i].y = (float)(rand() % (WINDOW_HEIGHT - sprite_h));
+        positions[i].w = (float)sprite_w;
+        positions[i].h = (float)sprite_h;
+        velocities[i].x = 0.0f;
+        velocities[i].y = 0.0f;
+        while (!velocities[i].x && !velocities[i].y) {
+            velocities[i].x = (float)((rand() % (MAX_SPEED * 2 + 1)) - MAX_SPEED);
+            velocities[i].y = (float)((rand() % (MAX_SPEED * 2 + 1)) - MAX_SPEED);
+        }
+    }
+
+    return 0;
+}
+
+/* Encapsulated in a struct to silence shadow variable warnings */
+static struct _state
+{
+    /* These are owned by SDL and must not be destroyed! */
+    struct wl_display *wl_display;
+    struct wl_surface *wl_surface;
+
+    /* These are owned by the application and need to be cleaned up on exit. */
+    struct wl_registry *wl_registry;
+    struct xdg_wm_base *xdg_wm_base;
+    struct xdg_surface *xdg_surface;
+    struct xdg_toplevel *xdg_toplevel;
+} state;
+
+static void xdg_surface_configure(void *data, struct xdg_surface *xdg_surface, uint32_t serial)
+{
+    xdg_surface_ack_configure(state.xdg_surface, serial);
+}
+
+static const struct xdg_surface_listener xdg_surface_listener = {
+    .configure = xdg_surface_configure,
+};
+
+static void xdg_toplevel_configure(void *data, struct xdg_toplevel *xdg_toplevel, int32_t width, int32_t height, struct wl_array *states)
+{
+    /* NOP */
+}
+
+static void xdg_toplevel_close(void *data, struct xdg_toplevel *xdg_toplevel)
+{
+    done = 1;
+}
+
+static void xdg_toplevel_configure_bounds(void *data, struct xdg_toplevel *xdg_toplevel, int32_t width, int32_t height)
+{
+    /* NOP */
+}
+
+static void xdg_toplevel_wm_capabilities(void *data, struct xdg_toplevel *xdg_toplevel, struct wl_array *capabilities)
+{
+    /* NOP */
+}
+
+static const struct xdg_toplevel_listener xdg_toplevel_listener = {
+    .configure = xdg_toplevel_configure,
+    .close = xdg_toplevel_close,
+    .configure_bounds = xdg_toplevel_configure_bounds,
+    .wm_capabilities = xdg_toplevel_wm_capabilities
+};
+
+static void xdg_wm_base_ping(void *data, struct xdg_wm_base *xdg_wm_base, uint32_t serial)
+{
+    xdg_wm_base_pong(state.xdg_wm_base, serial);
+}
+
+static const struct xdg_wm_base_listener xdg_wm_base_listener = {
+    .ping = xdg_wm_base_ping,
+};
+
+static void registry_global(void *data, struct wl_registry *wl_registry, uint32_t name, const char *interface, uint32_t version)
+{
+    if (SDL_strcmp(interface, xdg_wm_base_interface.name) == 0) {
+        state.xdg_wm_base = wl_registry_bind(state.wl_registry, name, &xdg_wm_base_interface, 1);
+        xdg_wm_base_add_listener(state.xdg_wm_base, &xdg_wm_base_listener, NULL);
+    }
+}
+
+static void registry_global_remove(void *data, struct wl_registry *wl_registry, uint32_t name)
+{
+    /* NOP */
+}
+
+static const struct wl_registry_listener wl_registry_listener = {
+    .global = registry_global,
+    .global_remove = registry_global_remove,
+};
+
+int main(int argc, char **argv)
+{
+    int ret = -1;
+    SDL_PropertiesID props;
+
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS) != 0) {
+        return -1;
+    }
+
+    if (SDL_strcmp(SDL_GetCurrentVideoDriver(), "wayland") != 0) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Video driver must be 'wayland', not '%s'", SDL_GetCurrentVideoDriver());
+        goto exit;
+    }
+
+    /* Create a window with the custom surface role property set. */
+    props = SDL_CreateProperties();
+    SDL_SetBooleanProperty(props, SDL_PROPERTY_WINDOW_CREATE_WAYLAND_SURFACE_ROLE_CUSTOM_BOOLEAN, SDL_TRUE);   /* Roleless surface */
+    SDL_SetBooleanProperty(props, SDL_PROPERTY_WINDOW_CREATE_OPENGL_BOOLEAN, SDL_TRUE);                        /* OpenGL enabled */
+    SDL_SetNumberProperty(props, SDL_PROPERTY_WINDOW_CREATE_WIDTH_NUMBER, WINDOW_WIDTH);                       /* Default width */
+    SDL_SetNumberProperty(props, SDL_PROPERTY_WINDOW_CREATE_HEIGHT_NUMBER, WINDOW_HEIGHT);                     /* Default height */
+    SDL_SetBooleanProperty(props, SDL_PROPERTY_WINDOW_CREATE_HIGH_PIXEL_DENSITY_BOOLEAN, SDL_TRUE);            /* Handle DPI scaling internally */
+    SDL_SetStringProperty(props, SDL_PROPERTY_WINDOW_CREATE_TITLE_STRING, "Wayland custom surface role test"); /* Default title */
+
+    window = SDL_CreateWindowWithProperties(props);
+    if (!window) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Window creation failed");
+        goto exit;
+    }
+
+    /* Create the renderer */
+    renderer = SDL_CreateRenderer(window, NULL, 0);
+    if (!renderer) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Renderer creation failed");
+        goto exit;
+    }
+
+    /* Get the display object and use it to create a registry object, which will enumerate the xdg_wm_base protocol. */
+    state.wl_display = SDL_GetProperty(SDL_GetWindowProperties(window), SDL_PROPERTY_WINDOW_WAYLAND_DISPLAY_POINTER, NULL);
+    state.wl_registry = wl_display_get_registry(state.wl_display);
+    wl_registry_add_listener(state.wl_registry, &wl_registry_listener, NULL);
+
+    /* Roundtrip to enumerate registry objects. */
+    wl_display_roundtrip(state.wl_display);
+
+    if (!state.xdg_wm_base) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "'xdg_wm_base' protocol not found!");
+        goto exit;
+    }
+
+    /* Get the wl_surface object from the SDL_Window, and create a toplevel window with it. */
+    state.wl_surface = SDL_GetProperty(SDL_GetWindowProperties(window), SDL_PROPERTY_WINDOW_WAYLAND_SURFACE_POINTER, NULL);
+
+    /* Create the xdg_surface from the wl_surface. */
+    state.xdg_surface = xdg_wm_base_get_xdg_surface(state.xdg_wm_base, state.wl_surface);
+    xdg_surface_add_listener(state.xdg_surface, &xdg_surface_listener, NULL);
+
+    /* Create the xdg_toplevel from the xdg_surface. */
+    state.xdg_toplevel = xdg_surface_get_toplevel(state.xdg_surface);
+    xdg_toplevel_add_listener(state.xdg_toplevel, &xdg_toplevel_listener, NULL);
+    xdg_toplevel_set_title(state.xdg_toplevel, SDL_GetWindowTitle(window));
+
+    /* Initialize the sprites. */
+    if (InitSprites() < 0) {
+        goto exit;
+    }
+
+    while (!done) {
+        SDL_Event event;
+        while (SDL_PollEvent(&event)) {
+            if (event.type == SDL_EVENT_KEY_DOWN) {
+                switch (event.key.keysym.sym) {
+                case SDLK_ESCAPE:
+                    done = 1;
+                    break;
+                case SDLK_EQUALS:
+                    /* Ctrl+ enlarges the window */
+                    if (event.key.keysym.mod & SDL_KMOD_CTRL) {
+                        int w, h;
+                        SDL_GetWindowSize(window, &w, &h);
+                        SDL_SetWindowSize(window, w * 2, h * 2);
+                    }
+                    break;
+                case SDLK_MINUS:
+                    /* Ctrl- shrinks the window */
+                    if (event.key.keysym.mod & SDL_KMOD_CTRL) {
+                        int w, h;
+                        SDL_GetWindowSize(window, &w, &h);
+                        SDL_SetWindowSize(window, w / 2, h / 2);
+                    }
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+
+        /* Draw the sprites */
+        MoveSprites();
+    }
+
+    ret = 0;
+
+exit:
+    /* The display and surface handles obtained from SDL are owned by SDL and must *NOT* be destroyed here! */
+    if (state.xdg_toplevel) {
+        xdg_toplevel_destroy(state.xdg_toplevel);
+        state.xdg_toplevel = NULL;
+    }
+    if (state.xdg_surface) {
+        xdg_surface_destroy(state.xdg_surface);
+        state.xdg_surface = NULL;
+    }
+    if (state.xdg_wm_base) {
+        xdg_wm_base_destroy(state.xdg_wm_base);
+        state.xdg_wm_base = NULL;
+    }
+    if (state.wl_registry) {
+        wl_registry_destroy(state.wl_registry);
+        state.wl_registry = NULL;
+    }
+
+    /* Destroy the SDL resources */
+    if (sprite) {
+        SDL_DestroyTexture(sprite);
+        sprite = NULL;
+    }
+    if (renderer) {
+        SDL_DestroyRenderer(renderer);
+        renderer = NULL;
+    }
+    if (window) {
+        SDL_DestroyWindow(window);
+        window = NULL;
+    }
+
+    SDL_Quit();
+    return ret;
+}


### PR DESCRIPTION
This adds the ability to create and SDL_Window with a 'roleless' Wayland surface not attached to a toplevel window, so it can be used by the application for its own purposes, such with the wlr_layer_shell protocol, which has been requested before (#5779 #7262), or whatever custom purpose the application may have. A simple test/example is included, which demonstrates how to create an SDL_Window with a custom surface role, attach it to an XDG toplevel window managed by the application, and signal size changes back to SDL.

The internal changes were fairly simple, and generally cleaned up the logic while removing redundant checks in the process.

The final commit adds a property to force the creation of a `wl_egl_window`, even if the window is not flagged as OpenGL-enabled, to make it easier to use SDL windows with applications/frameworks that handle OpenGL themselves, such as with BGFX (#5386).

@madebr Can you check the CMake changes? The bit where I had to add the protocol source file to the example and manually flag it as `GENERATED` feels a bit hacky, but it was necessary to make things work, since that file isn't created until the first time the project is actually built.