### PR TITLE
test: When listing test-cases, say which ones are disabled

### DIFF
--- a/src/test/SDL_test_harness.c
+++ b/src/test/SDL_test_harness.c
@@ -504,7 +504,7 @@ int SDLTest_RunSuites(SDLTest_TestSuiteReference *testSuites[], const char *user
                 /* Within each suite, loop over all test cases to check if we have a filter match */
                 for (testCounter = 0; testSuite->testCases[testCounter]; ++testCounter) {
                     testCase = testSuite->testCases[testCounter];
-                    SDLTest_Log("      test: %s", testCase->name);
+                    SDLTest_Log("      test: %s%s", testCase->name, testCase->enabled ? "" : " (disabled)");
                 }
             }
             SDLTest_Log("Exit code: 2");

--- a/test/testautomation.c
+++ b/test/testautomation.c
@@ -133,7 +133,7 @@ int main(int argc, char *argv[])
             SDL_Log("Test suite: %s", testSuite->name);
             for (testCounter = 0; testSuite->testCases[testCounter]; ++testCounter) {
                 const SDLTest_TestCaseReference *testCase = testSuite->testCases[testCounter];
-                SDL_Log("      test: %s", testCase->name);
+                SDL_Log("      test: %s%s", testCase->name, testCase->enabled ? "" : " (disabled)");
             }
         }
         return 0;


### PR DESCRIPTION
When a test has been disabled because it's known not to work reliably or it's a test for unimplemented functionality, we probably don't want to encourage developers and testers to run it and report its failures as a bug.

Helps: #8798, #8800