### PR TITLE
[SDL2] test: Backport SDL3 commits to accept small numerical differences

### DIFF
--- a/test/testautomation_math.c
+++ b/test/testautomation_math.c
@@ -2256,7 +2256,7 @@ acos_limitCases(void *args)
                         1.0, 0.0, result);
 
     result = SDL_acos(-1.0);
-    SDLTest_AssertCheck(M_PI == result,
+    SDLTest_AssertCheck(SDL_fabs(M_PI - result) <= EPSILON,
                         "Acos(%f), expected %f, got %f",
                         -1.0, M_PI, result);
 
@@ -2343,12 +2343,12 @@ asin_limitCases(void *args)
     double result;
 
     result = SDL_asin(1.0);
-    SDLTest_AssertCheck(M_PI / 2.0 == result,
+    SDLTest_AssertCheck(SDL_fabs(M_PI / 2.0 - result) <= EPSILON,
                         "Asin(%f), expected %f, got %f",
                         1.0, M_PI / 2.0, result);
 
     result = SDL_asin(-1.0);
-    SDLTest_AssertCheck(-M_PI / 2.0 == result,
+    SDLTest_AssertCheck(SDL_fabs(-M_PI / 2.0 - result) <= EPSILON,
                         "Asin(%f), expected %f, got %f",
                         -1.0, -M_PI / 2.0, result);
 
@@ -2535,7 +2535,7 @@ atan2_bothZeroCases(void *args)
         { 0.0, -0.0, M_PI },
         { -0.0, -0.0, -M_PI },
     };
-    return helper_ddtod("SDL_atan2", SDL_atan2, cases, SDL_arraysize(cases));
+    return helper_ddtod_inexact("SDL_atan2", SDL_atan2, cases, SDL_arraysize(cases));
 }
 
 /**
@@ -2554,7 +2554,7 @@ atan2_yZeroCases(void *args)
         { -0.0, 1.0, -0.0 },
         { -0.0, -1.0, -M_PI }
     };
-    return helper_ddtod("SDL_atan2", SDL_atan2, cases, SDL_arraysize(cases));
+    return helper_ddtod_inexact("SDL_atan2", SDL_atan2, cases, SDL_arraysize(cases));
 }
 
 /**
@@ -2570,7 +2570,7 @@ atan2_xZeroCases(void *args)
         { 1.0, -0.0, M_PI / 2.0 },
         { -1.0, -0.0, -M_PI / 2.0 }
     };
-    return helper_ddtod("SDL_atan2", SDL_atan2, cases, SDL_arraysize(cases));
+    return helper_ddtod_inexact("SDL_atan2", SDL_atan2, cases, SDL_arraysize(cases));
 }
 
 /* Infinity cases */
@@ -2589,22 +2589,22 @@ atan2_bothInfCases(void *args)
     double result;
 
     result = SDL_atan2(INFINITY, INFINITY);
-    SDLTest_AssertCheck(M_PI / 4.0 == result,
+    SDLTest_AssertCheck(SDL_fabs(M_PI / 4.0 - result) <= EPSILON,
                         "Atan2(%f,%f), expected %f, got %f",
                         INFINITY, INFINITY, M_PI / 4.0, result);
 
     result = SDL_atan2(INFINITY, -INFINITY);
-    SDLTest_AssertCheck(3.0 * M_PI / 4.0 == result,
+    SDLTest_AssertCheck(SDL_fabs(3.0 * M_PI / 4.0 - result) <= EPSILON,
                         "Atan2(%f,%f), expected %f, got %f",
                         INFINITY, -INFINITY, 3.0 * M_PI / 4.0, result);
 
     result = SDL_atan2(-INFINITY, INFINITY);
-    SDLTest_AssertCheck(-M_PI / 4.0 == result,
+    SDLTest_AssertCheck(SDL_fabs(-M_PI / 4.0 - result) <= EPSILON,
                         "Atan2(%f,%f), expected %f, got %f",
                         -INFINITY, INFINITY, -M_PI / 4.0, result);
 
     result = SDL_atan2(-INFINITY, -INFINITY);
-    SDLTest_AssertCheck(-3.0 * M_PI / 4.0 == result,
+    SDLTest_AssertCheck(SDL_fabs(-3.0 * M_PI / 4.0 - result) <= EPSILON,
                         "Atan2(%f,%f), expected %f, got %f",
                         -INFINITY, -INFINITY, -3.0 * M_PI / 4.0, result);
 
@@ -2621,22 +2621,22 @@ atan2_yInfCases(void *args)
     double result;
 
     result = SDL_atan2(INFINITY, 1.0);
-    SDLTest_AssertCheck(M_PI / 2.0 == result,
+    SDLTest_AssertCheck(SDL_fabs(M_PI / 2.0 - result) <= EPSILON,
                         "Atan2(%f,%f), expected %f, got %f",
                         INFINITY, 1.0, M_PI / 2.0, result);
 
     result = SDL_atan2(INFINITY, -1.0);
-    SDLTest_AssertCheck(M_PI / 2.0 == result,
+    SDLTest_AssertCheck(SDL_fabs(M_PI / 2.0 - result) <= EPSILON,
                         "Atan2(%f,%f), expected %f, got %f",
                         INFINITY, -1.0, M_PI / 2.0, result);
 
     result = SDL_atan2(-INFINITY, 1.0);
-    SDLTest_AssertCheck(-M_PI / 2.0 == result,
+    SDLTest_AssertCheck(SDL_fabs(-M_PI / 2.0 - result) <= EPSILON,
                         "Atan2(%f,%f), expected %f, got %f",
                         -INFINITY, 1.0, -M_PI / 2.0, result);
 
     result = SDL_atan2(-INFINITY, -1.0);
-    SDLTest_AssertCheck(-M_PI / 2.0 == result,
+    SDLTest_AssertCheck(SDL_fabs(-M_PI / 2.0 - result) <= EPSILON,
                         "Atan2(%f,%f), expected %f, got %f",
                         -INFINITY, -1.0, -M_PI / 2.0, result);
 
@@ -2665,12 +2665,12 @@ atan2_xInfCases(void *args)
                         -1.0, INFINITY, -0.0, result);
 
     result = SDL_atan2(1.0, -INFINITY);
-    SDLTest_AssertCheck(M_PI == result,
+    SDLTest_AssertCheck(SDL_fabs(M_PI - result) <= EPSILON,
                         "Atan2(%f,%f), expected %f, got %f",
                         1.0, -INFINITY, M_PI, result);
 
     result = SDL_atan2(-1.0, -INFINITY);
-    SDLTest_AssertCheck(-M_PI == result,
+    SDLTest_AssertCheck(SDL_fabs(-M_PI - result) <= EPSILON,
                         "Atan2(%f,%f), expected %f, got %f",
                         -1.0, -INFINITY, -M_PI, result);
 

--- a/test/testautomation_math.c
+++ b/test/testautomation_math.c
@@ -76,7 +76,7 @@ helper_dtod(const char *func_name, d_to_d_func func,
     Uint32 i;
     for (i = 0; i < cases_size; i++) {
         const double result = func(cases[i].input);
-        SDLTest_AssertCheck(result == cases[i].expected,
+        SDLTest_AssertCheck((result - cases[i].expected) < FLT_EPSILON,
                             "%s(%f), expected %f, got %f",
                             func_name,
                             cases[i].input,
@@ -1138,7 +1138,7 @@ log_baseCases(void *args)
                         1.0, 0.0, result);
 
     result = SDL_log(EULER);
-    SDLTest_AssertCheck(1.0 == result,
+    SDLTest_AssertCheck((result - 1.) < FLT_EPSILON,
                         "Log(%f), expected %f, got %f",
                         EULER, 1.0, result);
 


### PR DESCRIPTION
* testautomation: don't do float equality tests

    From: Anonymous Maarten
    (cherry picked from commit 474c8d0073b0fb4b14b65b79c7e620db1332e4f3)

* test: Accept small numerical differences in more mathematical tests
    
    We can't rely on irrational numbers like pi being represented exactly,
    particularly when compiling for i386, where the i387 floating-point
    interface carries out calculations in registers that have higher
    precision than the actual double-precision variable. The 1980s were a
    strange time.
    
    Resolves: https://github.com/libsdl-org/SDL/issues/8311
    (cherry picked from commit 6248472c0c738496a6f246aafa07a0e30afa6a01)

---

Changes vs. SDL3: replace `SDL_PI_D` with `M_PI` since that's what SDL2 uses.

I hope we now have SDL2 testautomation working on x86_64, but when I tried x86_64 + i386 builds, the i387 FPU continues to hate me. I think we'll need these changes, backported from SDL3, to make it work reliably on i386.