### PR TITLE
[SDL2] Make testautomation --filter Surface pass on big-endian

### DIFF
--- a/src/test/SDL_test_imageBlit.c
+++ b/src/test/SDL_test_imageBlit.c
@@ -542,24 +542,13 @@ static const SDLTest_SurfaceImage_t SDLTest_imageBlit = {
  */
 SDL_Surface *SDLTest_ImageBlit()
 {
-    SDL_Surface *surface = SDL_CreateRGBSurfaceFrom(
+    SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imageBlit.pixel_data,
         SDLTest_imageBlit.width,
         SDLTest_imageBlit.height,
         SDLTest_imageBlit.bytes_per_pixel * 8,
         SDLTest_imageBlit.width * SDLTest_imageBlit.bytes_per_pixel,
-#if (SDL_BYTEORDER == SDL_BIG_ENDIAN)
-        0xff000000, /* Red bit mask. */
-        0x00ff0000, /* Green bit mask. */
-        0x0000ff00, /* Blue bit mask. */
-        0x000000ff  /* Alpha bit mask. */
-#else
-        0x000000ff, /* Red bit mask. */
-        0x0000ff00, /* Green bit mask. */
-        0x00ff0000, /* Blue bit mask. */
-        0xff000000  /* Alpha bit mask. */
-#endif
-    );
+        SDL_PIXELFORMAT_RGB24);
     return surface;
 }
 
@@ -1027,24 +1016,13 @@ static const SDLTest_SurfaceImage_t SDLTest_imageBlitColor = {
  */
 SDL_Surface *SDLTest_ImageBlitColor()
 {
-    SDL_Surface *surface = SDL_CreateRGBSurfaceFrom(
+    SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imageBlitColor.pixel_data,
         SDLTest_imageBlitColor.width,
         SDLTest_imageBlitColor.height,
         SDLTest_imageBlitColor.bytes_per_pixel * 8,
         SDLTest_imageBlitColor.width * SDLTest_imageBlitColor.bytes_per_pixel,
-#if (SDL_BYTEORDER == SDL_BIG_ENDIAN)
-        0xff000000, /* Red bit mask. */
-        0x00ff0000, /* Green bit mask. */
-        0x0000ff00, /* Blue bit mask. */
-        0x000000ff  /* Alpha bit mask. */
-#else
-        0x000000ff, /* Red bit mask. */
-        0x0000ff00, /* Green bit mask. */
-        0x00ff0000, /* Blue bit mask. */
-        0xff000000  /* Alpha bit mask. */
-#endif
-    );
+        SDL_PIXELFORMAT_RGB24);
     return surface;
 }
 
@@ -1675,24 +1653,13 @@ static const SDLTest_SurfaceImage_t SDLTest_imageBlitAlpha = {
  */
 SDL_Surface *SDLTest_ImageBlitAlpha()
 {
-    SDL_Surface *surface = SDL_CreateRGBSurfaceFrom(
+    SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imageBlitAlpha.pixel_data,
         SDLTest_imageBlitAlpha.width,
         SDLTest_imageBlitAlpha.height,
         SDLTest_imageBlitAlpha.bytes_per_pixel * 8,
         SDLTest_imageBlitAlpha.width * SDLTest_imageBlitAlpha.bytes_per_pixel,
-#if (SDL_BYTEORDER == SDL_BIG_ENDIAN)
-        0xff000000, /* Red bit mask. */
-        0x00ff0000, /* Green bit mask. */
-        0x0000ff00, /* Blue bit mask. */
-        0x000000ff  /* Alpha bit mask. */
-#else
-        0x000000ff, /* Red bit mask. */
-        0x0000ff00, /* Green bit mask. */
-        0x00ff0000, /* Blue bit mask. */
-        0xff000000  /* Alpha bit mask. */
-#endif
-    );
+        SDL_PIXELFORMAT_RGB24);
     return surface;
 }
 

--- a/src/test/SDL_test_imageBlitBlend.c
+++ b/src/test/SDL_test_imageBlitBlend.c
@@ -582,24 +582,13 @@ static const SDLTest_SurfaceImage_t SDLTest_imageBlitBlendAdd = {
  */
 SDL_Surface *SDLTest_ImageBlitBlendAdd()
 {
-    SDL_Surface *surface = SDL_CreateRGBSurfaceFrom(
+    SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imageBlitBlendAdd.pixel_data,
         SDLTest_imageBlitBlendAdd.width,
         SDLTest_imageBlitBlendAdd.height,
         SDLTest_imageBlitBlendAdd.bytes_per_pixel * 8,
         SDLTest_imageBlitBlendAdd.width * SDLTest_imageBlitBlendAdd.bytes_per_pixel,
-#if (SDL_BYTEORDER == SDL_BIG_ENDIAN)
-        0xff000000, /* Red bit mask. */
-        0x00ff0000, /* Green bit mask. */
-        0x0000ff00, /* Blue bit mask. */
-        0x000000ff  /* Alpha bit mask. */
-#else
-        0x000000ff, /* Red bit mask. */
-        0x0000ff00, /* Green bit mask. */
-        0x00ff0000, /* Blue bit mask. */
-        0xff000000  /* Alpha bit mask. */
-#endif
-    );
+        SDL_PIXELFORMAT_RGB24);
     return surface;
 }
 
@@ -1184,24 +1173,13 @@ static const SDLTest_SurfaceImage_t SDLTest_imageBlitBlend = {
  */
 SDL_Surface *SDLTest_ImageBlitBlend()
 {
-    SDL_Surface *surface = SDL_CreateRGBSurfaceFrom(
+    SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imageBlitBlend.pixel_data,
         SDLTest_imageBlitBlend.width,
         SDLTest_imageBlitBlend.height,
         SDLTest_imageBlitBlend.bytes_per_pixel * 8,
         SDLTest_imageBlitBlend.width * SDLTest_imageBlitBlend.bytes_per_pixel,
-#if (SDL_BYTEORDER == SDL_BIG_ENDIAN)
-        0xff000000, /* Red bit mask. */
-        0x00ff0000, /* Green bit mask. */
-        0x0000ff00, /* Blue bit mask. */
-        0x000000ff  /* Alpha bit mask. */
-#else
-        0x000000ff, /* Red bit mask. */
-        0x0000ff00, /* Green bit mask. */
-        0x00ff0000, /* Blue bit mask. */
-        0xff000000  /* Alpha bit mask. */
-#endif
-    );
+        SDL_PIXELFORMAT_RGB24);
     return surface;
 }
 
@@ -1616,24 +1594,13 @@ static const SDLTest_SurfaceImage_t SDLTest_imageBlitBlendMod = {
  */
 SDL_Surface *SDLTest_ImageBlitBlendMod()
 {
-    SDL_Surface *surface = SDL_CreateRGBSurfaceFrom(
+    SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imageBlitBlendMod.pixel_data,
         SDLTest_imageBlitBlendMod.width,
         SDLTest_imageBlitBlendMod.height,
         SDLTest_imageBlitBlendMod.bytes_per_pixel * 8,
         SDLTest_imageBlitBlendMod.width * SDLTest_imageBlitBlendMod.bytes_per_pixel,
-#if (SDL_BYTEORDER == SDL_BIG_ENDIAN)
-        0xff000000, /* Red bit mask. */
-        0x00ff0000, /* Green bit mask. */
-        0x0000ff00, /* Blue bit mask. */
-        0x000000ff  /* Alpha bit mask. */
-#else
-        0x000000ff, /* Red bit mask. */
-        0x0000ff00, /* Green bit mask. */
-        0x00ff0000, /* Blue bit mask. */
-        0xff000000  /* Alpha bit mask. */
-#endif
-    );
+        SDL_PIXELFORMAT_RGB24);
     return surface;
 }
 
@@ -2431,24 +2398,13 @@ static const SDLTest_SurfaceImage_t SDLTest_imageBlitBlendNone = {
  */
 SDL_Surface *SDLTest_ImageBlitBlendNone()
 {
-    SDL_Surface *surface = SDL_CreateRGBSurfaceFrom(
+    SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imageBlitBlendNone.pixel_data,
         SDLTest_imageBlitBlendNone.width,
         SDLTest_imageBlitBlendNone.height,
         SDLTest_imageBlitBlendNone.bytes_per_pixel * 8,
         SDLTest_imageBlitBlendNone.width * SDLTest_imageBlitBlendNone.bytes_per_pixel,
-#if (SDL_BYTEORDER == SDL_BIG_ENDIAN)
-        0xff000000, /* Red bit mask. */
-        0x00ff0000, /* Green bit mask. */
-        0x0000ff00, /* Blue bit mask. */
-        0x000000ff  /* Alpha bit mask. */
-#else
-        0x000000ff, /* Red bit mask. */
-        0x0000ff00, /* Green bit mask. */
-        0x00ff0000, /* Blue bit mask. */
-        0xff000000  /* Alpha bit mask. */
-#endif
-    );
+        SDL_PIXELFORMAT_RGB24);
     return surface;
 }
 
@@ -2978,24 +2934,13 @@ static const SDLTest_SurfaceImage_t SDLTest_imageBlitBlendAll = {
  */
 SDL_Surface *SDLTest_ImageBlitBlendAll()
 {
-    SDL_Surface *surface = SDL_CreateRGBSurfaceFrom(
+    SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imageBlitBlendAll.pixel_data,
         SDLTest_imageBlitBlendAll.width,
         SDLTest_imageBlitBlendAll.height,
         SDLTest_imageBlitBlendAll.bytes_per_pixel * 8,
         SDLTest_imageBlitBlendAll.width * SDLTest_imageBlitBlendAll.bytes_per_pixel,
-#if (SDL_BYTEORDER == SDL_BIG_ENDIAN)
-        0xff000000, /* Red bit mask. */
-        0x00ff0000, /* Green bit mask. */
-        0x0000ff00, /* Blue bit mask. */
-        0x000000ff  /* Alpha bit mask. */
-#else
-        0x000000ff, /* Red bit mask. */
-        0x0000ff00, /* Green bit mask. */
-        0x00ff0000, /* Blue bit mask. */
-        0xff000000  /* Alpha bit mask. */
-#endif
-    );
+        SDL_PIXELFORMAT_RGB24);
     return surface;
 }
 

--- a/src/test/SDL_test_imageFace.c
+++ b/src/test/SDL_test_imageFace.c
@@ -225,24 +225,13 @@ static const SDLTest_SurfaceImage_t SDLTest_imageFace = {
  */
 SDL_Surface *SDLTest_ImageFace()
 {
-    SDL_Surface *surface = SDL_CreateRGBSurfaceFrom(
+    SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imageFace.pixel_data,
         SDLTest_imageFace.width,
         SDLTest_imageFace.height,
         SDLTest_imageFace.bytes_per_pixel * 8,
         SDLTest_imageFace.width * SDLTest_imageFace.bytes_per_pixel,
-#if (SDL_BYTEORDER == SDL_BIG_ENDIAN)
-        0xff000000, /* Red bit mask. */
-        0x00ff0000, /* Green bit mask. */
-        0x0000ff00, /* Blue bit mask. */
-        0x000000ff  /* Alpha bit mask. */
-#else
-        0x000000ff, /* Red bit mask. */
-        0x0000ff00, /* Green bit mask. */
-        0x00ff0000, /* Blue bit mask. */
-        0xff000000  /* Alpha bit mask. */
-#endif
-    );
+        SDL_PIXELFORMAT_RGBA32);
     return surface;
 }
 

--- a/src/test/SDL_test_imagePrimitives.c
+++ b/src/test/SDL_test_imagePrimitives.c
@@ -506,24 +506,13 @@ static const SDLTest_SurfaceImage_t SDLTest_imagePrimitives = {
  */
 SDL_Surface *SDLTest_ImagePrimitives()
 {
-    SDL_Surface *surface = SDL_CreateRGBSurfaceFrom(
+    SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imagePrimitives.pixel_data,
         SDLTest_imagePrimitives.width,
         SDLTest_imagePrimitives.height,
         SDLTest_imagePrimitives.bytes_per_pixel * 8,
         SDLTest_imagePrimitives.width * SDLTest_imagePrimitives.bytes_per_pixel,
-#if (SDL_BYTEORDER == SDL_BIG_ENDIAN)
-        0xff000000, /* Red bit mask. */
-        0x00ff0000, /* Green bit mask. */
-        0x0000ff00, /* Blue bit mask. */
-        0x000000ff  /* Alpha bit mask. */
-#else
-        0x000000ff, /* Red bit mask. */
-        0x0000ff00, /* Green bit mask. */
-        0x00ff0000, /* Blue bit mask. */
-        0xff000000  /* Alpha bit mask. */
-#endif
-    );
+        SDL_PIXELFORMAT_RGB24);
     return surface;
 }
 

--- a/src/test/SDL_test_imagePrimitivesBlend.c
+++ b/src/test/SDL_test_imagePrimitivesBlend.c
@@ -679,24 +679,13 @@ static const SDLTest_SurfaceImage_t SDLTest_imagePrimitivesBlend = {
  */
 SDL_Surface *SDLTest_ImagePrimitivesBlend()
 {
-    SDL_Surface *surface = SDL_CreateRGBSurfaceFrom(
+    SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imagePrimitivesBlend.pixel_data,
         SDLTest_imagePrimitivesBlend.width,
         SDLTest_imagePrimitivesBlend.height,
         SDLTest_imagePrimitivesBlend.bytes_per_pixel * 8,
         SDLTest_imagePrimitivesBlend.width * SDLTest_imagePrimitivesBlend.bytes_per_pixel,
-#if (SDL_BYTEORDER == SDL_BIG_ENDIAN)
-        0xff000000, /* Red bit mask. */
-        0x00ff0000, /* Green bit mask. */
-        0x0000ff00, /* Blue bit mask. */
-        0x000000ff  /* Alpha bit mask. */
-#else
-        0x000000ff, /* Red bit mask. */
-        0x0000ff00, /* Green bit mask. */
-        0x00ff0000, /* Blue bit mask. */
-        0xff000000  /* Alpha bit mask. */
-#endif
-    );
+        SDL_PIXELFORMAT_RGB24);
     return surface;
 }
 


### PR DESCRIPTION
* test: Fix encoding declaration for RGB24 test images
    
    All of these test images are provided as an octal dump of
    3-bytes-per-pixel data with red, green and blue bytes in that order,
    referred to as RGB24 in SDL's taxonomy. However, the call to
    SDL_CreateRGBSurfaceFrom() used masks that would have been appropriate
    for RGBA32 data.
    
    On little-endian platforms, the test images loaded as intended anyway,
    because SDL does not actually check all four masks before deciding to
    use RGB24 (it only looks at the red mask), and the red channel happens to
    be in the 0x000000FF position for both RGB24 and RGBA32 on little-endian.
    
    Unfortunately, on big-endian platforms, the required masks are not the
    same and the call failed with "Unknown pixel format". As far as I can
    tell, this means testautomation_surface has never succeeded on big-endian
    platforms, but presumably nobody has tried to run it on such platforms
    until now.
    
    In the SDL 3 branch, this was fixed as a side-effect of commit
    932f6134 `"Remove mask versions of SDL_CreateRGBSurface* #6701  (#6711)"`,
    which I have used as a reference to confirm that RGB24 is correct.
    
    Resolves: https://github.com/libsdl-org/SDL/issues/8817

* test: Use SDL_CreateRGBSurfaceWithFormatFrom for SDLTest_ImageFace
    
    Unlike the test images in the previous commit, this one is
    4-bytes-per-pixel RGBA32, so the masks used here appear to be correct
    for both endiannesses. Converting it to SDL_PIXELFORMAT_RGBA32 just
    makes it more concise.