### PR TITLE
[SDL2] test: Use AUDIO_F32SYS for native-endianness

### DIFF
--- a/test/testautomation_audio.c
+++ b/test/testautomation_audio.c
@@ -1040,8 +1040,8 @@ int audio_resampleLoss()
     SDLTest_AssertPass("Test resampling of %i s %i Hz %f phase sine wave from sampling rate of %i Hz to %i Hz",
                        spec->time, spec->freq, spec->phase, spec->rate_in, spec->rate_out);
 
-    ret = SDL_BuildAudioCVT(&cvt, AUDIO_F32, 1, spec->rate_in, AUDIO_F32, 1, spec->rate_out);
-    SDLTest_AssertPass("Call to SDL_BuildAudioCVT(&cvt, AUDIO_F32, 1, %i, AUDIO_F32, 1, %i)", spec->rate_in, spec->rate_out);
+    ret = SDL_BuildAudioCVT(&cvt, AUDIO_F32SYS, 1, spec->rate_in, AUDIO_F32SYS, 1, spec->rate_out);
+    SDLTest_AssertPass("Call to SDL_BuildAudioCVT(&cvt, AUDIO_F32SYS, 1, %i, AUDIO_F32SYS, 1, %i)", spec->rate_in, spec->rate_out);
     SDLTest_AssertCheck(ret == 1, "Expected SDL_BuildAudioCVT to succeed and conversion to be needed.");
     if (ret != 1) {
       return TEST_ABORTED;


### PR DESCRIPTION
AUDIO_F32 is an alias for AUDIO_F32LSB, 32-bit floating point with least significant byte first, resulting in audio_resampleLoss() failing on big-endian machines. This particular test generates a buffer with native-endianness float values, so it ought to be using AUDIO_F32SYS, which is 32-bit floating point in the native endianness.

Already fixed by commit 47bcb078 "Fixed some incorrect SDL_AUDIO_F32 uses" on the SDL 3 branch.

Resolves: https://github.com/libsdl-org/SDL/issues/8818

---

With this + #8819, a SDL2 git snapshot can pass `./testautomation` on Debian s390x.