### PR TITLE
Xbox: Fix compile error with XInputOnGameInput.h

### DIFF
--- a/src/core/windows/SDL_xinput.h
+++ b/src/core/windows/SDL_xinput.h
@@ -28,6 +28,7 @@
 #ifdef HAVE_XINPUT_H
 #if defined(__XBOXONE__) || defined(__XBOXSERIES__)
 /* Xbox supports an XInput wrapper which is a C++-only header... */
+#include <math.h> /* Required to compile with recent MSVC... */
 #include <XInputOnGameInput.h>
 using namespace XInputOnGameInput;
 #else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A recent version of the MSVC v143 toolset broke compilation for the XInputOnGameInput.h header we use on Xbox platforms. Specifically, the header uses some math functions but does not explicitly `#include <math.h>` -- instead, it has historically pulled them in indirectly from another standard library header (`<atomic>`). However, due to recent changes in the toolset header files, `<atomic>` no longer implicitly pulls in those math function declarations. This results in a bunch of "missing identifier" errors and a build failure.

Since this is an official GDK header, I have reported this to Microsoft on the private Xbox forum for a proper fix, but this PR addresses the issue on our end by simply including math.h before we include the header.

This will also need to be backported to SDL2.

cc @chalonverse 