### PR TITLE
[SDL2] wayland: Raise the frame throttle limit

### DIFF
--- a/src/video/wayland/SDL_waylandopengles.c
+++ b/src/video/wayland/SDL_waylandopengles.c
@@ -125,8 +125,8 @@ int Wayland_GLES_SwapWindow(_THIS, SDL_Window *window)
         SDL_VideoData *videodata = (SDL_VideoData *)_this->driverdata;
         struct wl_display *display = videodata->display;
         SDL_VideoDisplay *sdldisplay = SDL_GetDisplayForWindow(window);
-        /* ~10 frames (or 1 sec), so we'll progress even if throttled to zero. */
-        const Uint32 max_wait = SDL_GetTicks() + (sdldisplay->current_mode.refresh_rate ? (10000 / sdldisplay->current_mode.refresh_rate) : 1000);
+        /* 1/3 speed (or 20hz), so we'll progress even if throttled to zero. */
+        const Uint32 max_wait = SDL_GetTicks() + (sdldisplay->current_mode.refresh_rate ? (3000 / sdldisplay->current_mode.refresh_rate) : 50);
         while (SDL_AtomicGet(&data->swap_interval_ready) == 0) {
             Uint32 now;
 


### PR DESCRIPTION
Raise the minimum frame throttle limit to 1/3 the refresh rate (or 20hz) to prevent titles from timing out when occluded.

Fixes #8807 