### PR TITLE
Capture debug macros off by default

### DIFF
--- a/src/video/SDL_video_capture.c
+++ b/src/video/SDL_video_capture.c
@@ -27,7 +27,7 @@
 #include "SDL_pixels_c.h"
 #include "../thread/SDL_systhread.h"
 
-#define DEBUG_VIDEO_CAPTURE_CAPTURE 1
+#define DEBUG_VIDEO_CAPTURE_CAPTURE 0
 
 
 #ifdef SDL_VIDEO_CAPTURE

--- a/src/video/SDL_video_capture_v4l2.c
+++ b/src/video/SDL_video_capture_v4l2.c
@@ -32,7 +32,7 @@
 #include "../../core/linux/SDL_udev.h"
 #include <limits.h>      /* INT_MAX */
 
-#define DEBUG_VIDEO_CAPTURE_CAPTURE 1
+#define DEBUG_VIDEO_CAPTURE_CAPTURE 0
 
 #if defined(__linux__) && !defined(__ANDROID__)
 
@@ -692,6 +692,7 @@ GetFrameSize(SDL_VideoCaptureDevice *_this, Uint32 format, int index, int *width
 
 
 
+#if DEBUG_VIDEO_CAPTURE_CAPTURE
 static void
 dbg_v4l2_pixelformat(const char *str, int f) {
     SDL_Log("%s  V4L2_format=%d  %c%c%c%c", str, f,
@@ -700,6 +701,7 @@ dbg_v4l2_pixelformat(const char *str, int f) {
                 (f >> 16) & 0xff,
                 (f >> 24) & 0xff);
 }
+#endif
 
 int
 GetDeviceSpec(SDL_VideoCaptureDevice *_this, SDL_VideoCaptureSpec *spec)

--- a/src/video/android/SDL_android_video_capture.c
+++ b/src/video/android/SDL_android_video_capture.c
@@ -27,7 +27,7 @@
 #include "../SDL_pixels_c.h"
 #include "../../thread/SDL_systhread.h"
 
-#define DEBUG_VIDEO_CAPTURE_CAPTURE 1
+#define DEBUG_VIDEO_CAPTURE_CAPTURE 0
 
 #if defined(__ANDROID__) && __ANDROID_API__ >= 24
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Disables the debug macros for video capture by default.

## Description
<!--- Describe your changes in detail -->
Currently the debug macros are enabled by default, unlike all other debug macros.
Effect is writing debug info to command line about video capture devices even when build is release. (src/video/SDL_video_capture_v4l2.c line 1167 in this commit)

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
