### PR TITLE
render: Fix line clipping with translated viewports

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -2815,8 +2815,8 @@ static int RenderDrawLineBresenham(SDL_Renderer *renderer, int x1, int y1, int x
     /* the backend might clip this further to the clipping rect, but we
        just want a basic safety against generating millions of points for
        massive lines. */
-    clip_rect.x = (int) renderer->viewport.x;
-    clip_rect.y = (int) renderer->viewport.y;
+    clip_rect.x = 0;
+    clip_rect.y = 0;
     clip_rect.w = (int) renderer->viewport.w;
     clip_rect.h = (int) renderer->viewport.h;
     if (!SDL_IntersectRectAndLine(&clip_rect, &x1, &y1, &x2, &y2)) {


### PR DESCRIPTION
The previous code was working incorrectly on viewports not having the top left corner on the origin: even in those cases we only need to look at the width and height of the viewport, because the drawing coordinates are translated.

Fixes #8828
