### PR TITLE
Add back in the square haptic effect (fixes #8753)

### DIFF
--- a/include/SDL_haptic.h
+++ b/include/SDL_haptic.h
@@ -70,14 +70,14 @@
  *    if (haptic == NULL) return -1; // Most likely joystick isn't haptic
  *
  *    // See if it can do sine waves
- *    if ((SDL_HapticQuery(haptic) & SDL_HAPTIC_SINE)==0) {
+ *    if ((SDL_HapticQuery(haptic) & SDL_HAPTIC_FEATURE_SINE)==0) {
  *       SDL_HapticClose(haptic); // No sine effect
  *       return -1;
  *    }
  *
  *    // Create the effect
  *    SDL_memset( &effect, 0, sizeof(SDL_HapticEffect) ); // 0 is safe default
- *    effect.type = SDL_HAPTIC_SINE;
+ *    effect.type = SDL_HAPTIC_EFFECT_SINE;
  *    effect.periodic.direction.type = SDL_HAPTIC_POLAR; // Polar coordinates
  *    effect.periodic.direction.dir[0] = 18000; // Force comes from south
  *    effect.periodic.period = 1000; // 1000 ms
@@ -140,16 +140,35 @@ extern "C" {
 struct _SDL_Haptic;
 typedef struct _SDL_Haptic SDL_Haptic;
 
+/* Legacy combined feature and effect defines (depricated due to lack of bits) */
+#define SDL_HAPTIC_CONSTANT     (1u<<0)
+#define SDL_HAPTIC_SINE         (1u<<1)
+#define SDL_HAPTIC_LEFTRIGHT    (1u<<2)
+#define SDL_HAPTIC_TRIANGLE     (1u<<3)
+#define SDL_HAPTIC_SAWTOOTHUP   (1u<<4)
+#define SDL_HAPTIC_SAWTOOTHDOWN (1u<<5)
+#define SDL_HAPTIC_RAMP         (1u<<6)
+#define SDL_HAPTIC_SPRING       (1u<<7)
+#define SDL_HAPTIC_DAMPER       (1u<<8)
+#define SDL_HAPTIC_INERTIA      (1u<<9)
+#define SDL_HAPTIC_FRICTION     (1u<<10)
+#define SDL_HAPTIC_CUSTOM       (1u<<11)
+#define SDL_HAPTIC_GAIN         (1u<<12)
+#define SDL_HAPTIC_AUTOCENTER   (1u<<13)
+#define SDL_HAPTIC_STATUS       (1u<<14)
+#define SDL_HAPTIC_PAUSE        (1u<<15)
 
 /**
  *  \name Haptic features
  *
  *  Different haptic features a device can have.
- */
-/* @{ */
-
-/**
- *  \name Haptic effects
+ *
+ *  \warning Feature and effect used to share the same defines (i.e.,
+ *           SDL_HAPTIC_CONSTANT, etc.). They have now been split (i.e.,
+ *           SDL_HAPTIC_FETAURE_CONSTANT, SD_HAPTIC_EFFECT_CONSTANT, etc.) due to
+ *           running out bits for effects. The shared defines are now deprecated.
+ *
+ *  \sa Haptic effects
  */
 /* @{ */
 
@@ -160,7 +179,7 @@ typedef struct _SDL_Haptic SDL_Haptic;
  *
  *  \sa SDL_HapticCondition
  */
-#define SDL_HAPTIC_CONSTANT   (1u<<0)
+#define SDL_HAPTIC_FEATURE_CONSTANT     SDL_HAPTIC_CONSTANT
 
 /**
  *  \brief Sine wave effect supported.
@@ -169,7 +188,7 @@ typedef struct _SDL_Haptic SDL_Haptic;
  *
  *  \sa SDL_HapticPeriodic
  */
-#define SDL_HAPTIC_SINE       (1u<<1)
+#define SDL_HAPTIC_FEATURE_SINE         SDL_HAPTIC_SINE
 
 /**
  *  \brief Left/Right effect supported.
@@ -177,13 +196,8 @@ typedef struct _SDL_Haptic SDL_Haptic;
  *  Haptic effect for direct control over high/low frequency motors.
  *
  *  \sa SDL_HapticLeftRight
- * \warning this value was SDL_HAPTIC_SQUARE right before 2.0.0 shipped. Sorry,
- *          we ran out of bits, and this is important for XInput devices.
  */
-#define SDL_HAPTIC_LEFTRIGHT     (1u<<2)
-
-/* !!! FIXME: put this back when we have more bits in 2.1 */
-/* #define SDL_HAPTIC_SQUARE     (1<<2) */
+#define SDL_HAPTIC_FEATURE_LEFTRIGHT    SDL_HAPTIC_LEFTRIGHT
 
 /**
  *  \brief Triangle wave effect supported.
@@ -192,7 +206,7 @@ typedef struct _SDL_Haptic SDL_Haptic;
  *
  *  \sa SDL_HapticPeriodic
  */
-#define SDL_HAPTIC_TRIANGLE   (1u<<3)
+#define SDL_HAPTIC_FEATURE_TRIANGLE     SDL_HAPTIC_TRIANGLE
 
 /**
  *  \brief Sawtoothup wave effect supported.
@@ -201,7 +215,7 @@ typedef struct _SDL_Haptic SDL_Haptic;
  *
  *  \sa SDL_HapticPeriodic
  */
-#define SDL_HAPTIC_SAWTOOTHUP (1u<<4)
+#define SDL_HAPTIC_FEATURE_SAWTOOTHUP   SDL_HAPTIC_SAWTOOTHUP
 
 /**
  *  \brief Sawtoothdown wave effect supported.
@@ -210,7 +224,7 @@ typedef struct _SDL_Haptic SDL_Haptic;
  *
  *  \sa SDL_HapticPeriodic
  */
-#define SDL_HAPTIC_SAWTOOTHDOWN (1u<<5)
+#define SDL_HAPTIC_FEATURE_SAWTOOTHDOWN SDL_HAPTIC_SAWTOOTHDOWN
 
 /**
  *  \brief Ramp effect supported.
@@ -219,7 +233,7 @@ typedef struct _SDL_Haptic SDL_Haptic;
  *
  *  \sa SDL_HapticRamp
  */
-#define SDL_HAPTIC_RAMP       (1u<<6)
+#define SDL_HAPTIC_FEATURE_RAMP         SDL_HAPTIC_RAMP
 
 /**
  *  \brief Spring effect supported - uses axes position.
@@ -229,7 +243,7 @@ typedef struct _SDL_Haptic SDL_Haptic;
  *
  *  \sa SDL_HapticCondition
  */
-#define SDL_HAPTIC_SPRING     (1u<<7)
+#define SDL_HAPTIC_FEATURE_SPRING       SDL_HAPTIC_SPRING
 
 /**
  *  \brief Damper effect supported - uses axes velocity.
@@ -239,7 +253,7 @@ typedef struct _SDL_Haptic SDL_Haptic;
  *
  *  \sa SDL_HapticCondition
  */
-#define SDL_HAPTIC_DAMPER     (1u<<8)
+#define SDL_HAPTIC_FEATURE_DAMPER       SDL_HAPTIC_DAMPER
 
 /**
  *  \brief Inertia effect supported - uses axes acceleration.
@@ -249,7 +263,7 @@ typedef struct _SDL_Haptic SDL_Haptic;
  *
  *  \sa SDL_HapticCondition
  */
-#define SDL_HAPTIC_INERTIA    (1u<<9)
+#define SDL_HAPTIC_FEATURE_INERTIA      SDL_HAPTIC_INERTIA
 
 /**
  *  \brief Friction effect supported - uses axes movement.
@@ -259,18 +273,14 @@ typedef struct _SDL_Haptic SDL_Haptic;
  *
  *  \sa SDL_HapticCondition
  */
-#define SDL_HAPTIC_FRICTION   (1u<<10)
+#define SDL_HAPTIC_FEATURE_FRICTION     SDL_HAPTIC_FRICTION
 
 /**
  *  \brief Custom effect is supported.
  *
  *  User defined custom haptic effect.
  */
-#define SDL_HAPTIC_CUSTOM     (1u<<11)
-
-/* @} *//* Haptic effects */
-
-/* These last few are features the device has, not effects */
+#define SDL_HAPTIC_FEATURE_CUSTOM       SDL_HAPTIC_CUSTOM
 
 /**
  *  \brief Device can set global gain.
@@ -279,7 +289,7 @@ typedef struct _SDL_Haptic SDL_Haptic;
  *
  *  \sa SDL_HapticSetGain
  */
-#define SDL_HAPTIC_GAIN       (1u<<12)
+#define SDL_HAPTIC_FEATURE_GAIN         SDL_HAPTIC_GAIN
 
 /**
  *  \brief Device can set autocenter.
@@ -288,7 +298,7 @@ typedef struct _SDL_Haptic SDL_Haptic;
  *
  *  \sa SDL_HapticSetAutocenter
  */
-#define SDL_HAPTIC_AUTOCENTER (1u<<13)
+#define SDL_HAPTIC_FEATURE_AUTOCENTER   SDL_HAPTIC_AUTOCENTER
 
 /**
  *  \brief Device can be queried for effect status.
@@ -297,7 +307,7 @@ typedef struct _SDL_Haptic SDL_Haptic;
  *
  *  \sa SDL_HapticGetEffectStatus
  */
-#define SDL_HAPTIC_STATUS     (1u<<14)
+#define SDL_HAPTIC_FEATURE_STATUS       SDL_HAPTIC_STATUS
 
 /**
  *  \brief Device can be paused.
@@ -307,11 +317,171 @@ typedef struct _SDL_Haptic SDL_Haptic;
  *  \sa SDL_HapticPause
  *  \sa SDL_HapticUnpause
  */
-#define SDL_HAPTIC_PAUSE      (1u<<15)
+#define SDL_HAPTIC_FEATURE_PAUSE        SDL_HAPTIC_PAUSE
+
+/**
+ *  \brief Square wave effect supported.
+ *
+ *  Periodic haptic effect that simulates square waves.
+ *
+ *  \sa SDL_HapticPeriodic
+ */
+#define SDL_HAPTIC_FEATURE_SQUARE       (1u<<16)
+
+/* @} *//* Haptic features */
+
+
+/**
+ *  \name Haptic effects
+ *
+ *  Effect type for SDL_HapticEffect, SDL_HapticConstant, etc.
+ *
+ *  \warning Feature and effect used to share the same defines (i.e.,
+ *           SDL_HAPTIC_CONSTANT, etc.). They have now been split (i.e.,
+ *           SDL_HAPTIC_FETAURE_CONSTANT, SD_HAPTIC_EFFECT_CONSTANT, etc.) due to
+ *           running out bits for effects. The shared defines are now deprecated.
+ *
+ *  \sa Haptic features
+ *  \sa SDL_HapticEffect
+ *  \sa SDL_HapticConstant
+ *  \sa SDL_HapticPeriodic
+ *  \sa SDL_HapticCondition
+ *  \sa SDL_HapticRamp
+ *  \sa SDL_HapticLeftRight
+ *  \sa SDL_HapticCustom
+ */
+/* @{ */
+
+/**
+ *  \brief Constant effect.
+ *
+ *  Constant haptic effect.
+ *
+ *  \sa SDL_HapticCondition
+ */
+#define SDL_HAPTIC_EFFECT_CONSTANT     SDL_HAPTIC_CONSTANT
+
+/**
+ *  \brief Sine wave effect.
+ *
+ *  Periodic haptic effect that simulates sine waves.
+ *
+ *  \sa SDL_HapticPeriodic
+ */
+#define SDL_HAPTIC_EFFECT_SINE         SDL_HAPTIC_SINE
+
+/**
+ *  \brief Left/Right effect.
+ *
+ *  Haptic effect for direct control over high/low frequency motors.
+ *
+ *  \sa SDL_HapticLeftRight
+ */
+#define SDL_HAPTIC_EFFECT_LEFTRIGHT    SDL_HAPTIC_LEFTRIGHT
+
+/**
+ *  \brief Triangle wave effect.
+ *
+ *  Periodic haptic effect that simulates triangular waves.
+ *
+ *  \sa SDL_HapticPeriodic
+ */
+#define SDL_HAPTIC_EFFECT_TRIANGLE     SDL_HAPTIC_TRIANGLE
+
+/**
+ *  \brief Sawtoothup wave effect.
+ *
+ *  Periodic haptic effect that simulates saw tooth up waves.
+ *
+ *  \sa SDL_HapticPeriodic
+ */
+#define SDL_HAPTIC_EFFECT_SAWTOOTHUP   SDL_HAPTIC_SAWTOOTHUP
+
+/**
+ *  \brief Sawtoothdown wave effect.
+ *
+ *  Periodic haptic effect that simulates saw tooth down waves.
+ *
+ *  \sa SDL_HapticPeriodic
+ */
+#define SDL_HAPTIC_EFFECT_SAWTOOTHDOWN SDL_HAPTIC_SAWTOOTHDOWN
+
+/**
+ *  \brief Ramp effect.
+ *
+ *  Ramp haptic effect.
+ *
+ *  \sa SDL_HapticRamp
+ */
+#define SDL_HAPTIC_EFFECT_RAMP         SDL_HAPTIC_RAMP
+
+/**
+ *  \brief Spring effect - uses axes position.
+ *
+ *  Condition haptic effect that simulates a spring.  Effect is based on the
+ *  axes position.
+ *
+ *  \sa SDL_HapticCondition
+ */
+#define SDL_HAPTIC_EFFECT_SPRING       SDL_HAPTIC_SPRING
+
+/**
+ *  \brief Damper effect - uses axes velocity.
+ *
+ *  Condition haptic effect that simulates dampening.  Effect is based on the
+ *  axes velocity.
+ *
+ *  \sa SDL_HapticCondition
+ */
+#define SDL_HAPTIC_EFFECT_DAMPER       SDL_HAPTIC_DAMPER
+
+/**
+ *  \brief Inertia effect - uses axes acceleration.
+ *
+ *  Condition haptic effect that simulates inertia.  Effect is based on the axes
+ *  acceleration.
+ *
+ *  \sa SDL_HapticCondition
+ */
+#define SDL_HAPTIC_EFFECT_INERTIA      SDL_HAPTIC_INERTIA
+
+/**
+ *  \brief Friction effect - uses axes movement.
+ *
+ *  Condition haptic effect that simulates friction.  Effect is based on the
+ *  axes movement.
+ *
+ *  \sa SDL_HapticCondition
+ */
+#define SDL_HAPTIC_EFFECT_FRICTION     SDL_HAPTIC_FRICTION
+
+/**
+ *  \brief Custom effect.
+ *
+ *  User defined custom haptic effect.
+ */
+#define SDL_HAPTIC_EFFECT_CUSTOM       SDL_HAPTIC_CUSTOM
+
+/**
+ *  \brief Square wave effect supported.
+ *
+ *  Periodic haptic effect that simulates square waves.
+ *
+ *  \sa SDL_HapticPeriodic
+ */
+/* Re-use the non-effects features with their single bit encodings (i.e.,
+ * SDL_HAPTIC_GAIN through SDL_HAPTIC_PAUSE) and then switch to multi-bit
+ * encodings (i.e., 3u, 5u, 6u, 7u, 9u, etc.). */
+#define SDL_HAPTIC_EFFECT_SQUARE       SDL_HAPTIC_GAIN
+
+
+/* @} *//* Haptic effects */
 
 
 /**
  * \name Direction encodings
+ *
+ * Effect type for SDL_HapticEffect, SDL_HapticConstant, etc.
  */
 /* @{ */
 
@@ -345,8 +515,6 @@ typedef struct _SDL_Haptic SDL_Haptic;
 #define SDL_HAPTIC_STEERING_AXIS 3
 
 /* @} *//* Direction encodings */
-
-/* @} *//* Haptic features */
 
 /*
  * Misc defines.
@@ -466,18 +634,19 @@ typedef struct SDL_HapticDirection
 /**
  *  \brief A structure containing a template for a Constant effect.
  *
- *  This struct is exclusively for the ::SDL_HAPTIC_CONSTANT effect.
+ *  This struct is exclusively for the ::SDL_HAPTIC_EFFECT_CONSTANT effect.
  *
  *  A constant effect applies a constant force in the specified direction
  *  to the joystick.
  *
- *  \sa SDL_HAPTIC_CONSTANT
+ *  \sa SDL_HAPTIC_FEATURE_CONSTANT
+ *  \sa SDL_HAPTIC_EFFECT_CONSTANT
  *  \sa SDL_HapticEffect
  */
 typedef struct SDL_HapticConstant
 {
     /* Header */
-    Uint16 type;            /**< ::SDL_HAPTIC_CONSTANT */
+    Uint16 type;            /**< ::SDL_HAPTIC_EFFECT_CONSTANT */
     SDL_HapticDirection direction;  /**< Direction of the effect. */
 
     /* Replay */
@@ -502,11 +671,12 @@ typedef struct SDL_HapticConstant
  *  \brief A structure containing a template for a Periodic effect.
  *
  *  The struct handles the following effects:
- *   - ::SDL_HAPTIC_SINE
- *   - ::SDL_HAPTIC_LEFTRIGHT
- *   - ::SDL_HAPTIC_TRIANGLE
- *   - ::SDL_HAPTIC_SAWTOOTHUP
- *   - ::SDL_HAPTIC_SAWTOOTHDOWN
+ *   - ::SDL_HAPTIC_EFFECT_SINE
+ *   - ::SDL_HAPTIC_EFFECT_LEFTRIGHT
+ *   - ::SDL_HAPTIC_EFFECT_TRIANGLE
+ *   - ::SDL_HAPTIC_EFFECT_SAWTOOTHUP
+ *   - ::SDL_HAPTIC_EFFECT_SAWTOOTHDOWN
+ *   - ::SDL_HAPTIC_EFFECT_SQUARE
  *
  *  A periodic effect consists in a wave-shaped effect that repeats itself
  *  over time.  The type determines the shape of the wave and the parameters
@@ -522,45 +692,53 @@ typedef struct SDL_HapticConstant
  *
  *  Examples:
  *  \verbatim
-    SDL_HAPTIC_SINE
+    SDL_HAPTIC_EFFECT_SINE
       __      __      __      __
      /  \    /  \    /  \    /
     /    \__/    \__/    \__/
 
-    SDL_HAPTIC_SQUARE
-     __    __    __    __    __
-    |  |  |  |  |  |  |  |  |  |
-    |  |__|  |__|  |__|  |__|  |
-
-    SDL_HAPTIC_TRIANGLE
+    SDL_HAPTIC_EFFECT_TRIANGLE
       /\    /\    /\    /\    /\
      /  \  /  \  /  \  /  \  /
     /    \/    \/    \/    \/
 
-    SDL_HAPTIC_SAWTOOTHUP
+    SDL_HAPTIC_EFFECT_SAWTOOTHUP
       /|  /|  /|  /|  /|  /|  /|
      / | / | / | / | / | / | / |
     /  |/  |/  |/  |/  |/  |/  |
 
-    SDL_HAPTIC_SAWTOOTHDOWN
+    SDL_HAPTIC_EFFECT_SAWTOOTHDOWN
     \  |\  |\  |\  |\  |\  |\  |
      \ | \ | \ | \ | \ | \ | \ |
       \|  \|  \|  \|  \|  \|  \|
+
+    SDL_HAPTIC_EFFECT_SQUARE
+     __    __    __    __    __
+    |  |  |  |  |  |  |  |  |  |
+    |  |__|  |__|  |__|  |__|  |
+
     \endverbatim
  *
- *  \sa SDL_HAPTIC_SINE
- *  \sa SDL_HAPTIC_LEFTRIGHT
- *  \sa SDL_HAPTIC_TRIANGLE
- *  \sa SDL_HAPTIC_SAWTOOTHUP
- *  \sa SDL_HAPTIC_SAWTOOTHDOWN
+ *  \sa SDL_HAPTIC_FEATURE_SINE
+ *  \sa SDL_HAPTIC_FEATURE_LEFTRIGHT
+ *  \sa SDL_HAPTIC_FEATURE_TRIANGLE
+ *  \sa SDL_HAPTIC_FEATURE_SAWTOOTHUP
+ *  \sa SDL_HAPTIC_FEATURE_SAWTOOTHDOWN
+ *  \sa SDL_HAPTIC_FEATURE_SQUARE
+ *  \sa SDL_HAPTIC_EFFECT_SINE
+ *  \sa SDL_HAPTIC_EFFECT_LEFTRIGHT
+ *  \sa SDL_HAPTIC_EFFECT_TRIANGLE
+ *  \sa SDL_HAPTIC_EFFECT_SAWTOOTHUP
+ *  \sa SDL_HAPTIC_EFFECT_SAWTOOTHDOWN
+ *  \sa SDL_HAPTIC_EFFECT_SQUARE
  *  \sa SDL_HapticEffect
  */
 typedef struct SDL_HapticPeriodic
 {
     /* Header */
-    Uint16 type;        /**< ::SDL_HAPTIC_SINE, ::SDL_HAPTIC_LEFTRIGHT,
-                             ::SDL_HAPTIC_TRIANGLE, ::SDL_HAPTIC_SAWTOOTHUP or
-                             ::SDL_HAPTIC_SAWTOOTHDOWN */
+    Uint16 type;        /**< ::SDL_HAPTIC_EFFECT_SINE, ::SDL_HAPTIC_EFFECT_LEFTRIGHT,
+                             ::SDL_HAPTIC_EFFECT_TRIANGLE, ::SDL_HAPTIC_EFFECT_SAWTOOTHUP,
+                             ::SDL_HAPTIC_EFFECT_SAWTOOTHDOWN, or ::SDL_HAPTIC_EFFECT_SQUARE */
     SDL_HapticDirection direction;  /**< Direction of the effect. */
 
     /* Replay */
@@ -588,10 +766,10 @@ typedef struct SDL_HapticPeriodic
  *  \brief A structure containing a template for a Condition effect.
  *
  *  The struct handles the following effects:
- *   - ::SDL_HAPTIC_SPRING: Effect based on axes position.
- *   - ::SDL_HAPTIC_DAMPER: Effect based on axes velocity.
- *   - ::SDL_HAPTIC_INERTIA: Effect based on axes acceleration.
- *   - ::SDL_HAPTIC_FRICTION: Effect based on axes movement.
+ *   - ::SDL_HAPTIC_EFFECT_SPRING: Effect based on axes position.
+ *   - ::SDL_HAPTIC_EFFECT_DAMPER: Effect based on axes velocity.
+ *   - ::SDL_HAPTIC_EFFECT_INERTIA: Effect based on axes acceleration.
+ *   - ::SDL_HAPTIC_EFFECT_FRICTION: Effect based on axes movement.
  *
  *  Direction is handled by condition internals instead of a direction member.
  *  The condition effect specific members have three parameters.  The first
@@ -602,17 +780,21 @@ typedef struct SDL_HapticPeriodic
  *  which is negative.
  *
  *  \sa SDL_HapticDirection
- *  \sa SDL_HAPTIC_SPRING
- *  \sa SDL_HAPTIC_DAMPER
- *  \sa SDL_HAPTIC_INERTIA
- *  \sa SDL_HAPTIC_FRICTION
+ *  \sa SDL_HAPTIC_FEATURE_SPRING
+ *  \sa SDL_HAPTIC_FEATURE_DAMPER
+ *  \sa SDL_HAPTIC_FEATURE_INERTIA
+ *  \sa SDL_HAPTIC_FEATURE_FRICTION
+ *  \sa SDL_HAPTIC_EFFECT_SPRING
+ *  \sa SDL_HAPTIC_EFFECT_DAMPER
+ *  \sa SDL_HAPTIC_EFFECT_INERTIA
+ *  \sa SDL_HAPTIC_EFFECT_FRICTION
  *  \sa SDL_HapticEffect
  */
 typedef struct SDL_HapticCondition
 {
     /* Header */
-    Uint16 type;            /**< ::SDL_HAPTIC_SPRING, ::SDL_HAPTIC_DAMPER,
-                                 ::SDL_HAPTIC_INERTIA or ::SDL_HAPTIC_FRICTION */
+    Uint16 type;            /**< ::SDL_HAPTIC_EFFECT_SPRING, ::SDL_HAPTIC_EFFECT_DAMPER,
+                                 ::SDL_HAPTIC_EFFECT_INERTIA or ::SDL_HAPTIC_EFFECT_FRICTION */
     SDL_HapticDirection direction;  /**< Direction of the effect - Not used ATM. */
 
     /* Replay */
@@ -635,20 +817,21 @@ typedef struct SDL_HapticCondition
 /**
  *  \brief A structure containing a template for a Ramp effect.
  *
- *  This struct is exclusively for the ::SDL_HAPTIC_RAMP effect.
+ *  This struct is exclusively for the ::SDL_HAPTIC_EFFECT_RAMP effect.
  *
  *  The ramp effect starts at start strength and ends at end strength.
  *  It augments in linear fashion.  If you use attack and fade with a ramp
  *  the effects get added to the ramp effect making the effect become
  *  quadratic instead of linear.
  *
- *  \sa SDL_HAPTIC_RAMP
+ *  \sa SDL_HAPTIC_FEATURE_RAMP
+ *  \sa SDL_HAPTIC_EFFECT_RAMP
  *  \sa SDL_HapticEffect
  */
 typedef struct SDL_HapticRamp
 {
     /* Header */
-    Uint16 type;            /**< ::SDL_HAPTIC_RAMP */
+    Uint16 type;            /**< ::SDL_HAPTIC_EFFECT_RAMP */
     SDL_HapticDirection direction;  /**< Direction of the effect. */
 
     /* Replay */
@@ -673,19 +856,20 @@ typedef struct SDL_HapticRamp
 /**
  * \brief A structure containing a template for a Left/Right effect.
  *
- * This struct is exclusively for the ::SDL_HAPTIC_LEFTRIGHT effect.
+ * This struct is exclusively for the ::SDL_HAPTIC_EFFECT_LEFTRIGHT effect.
  *
  * The Left/Right effect is used to explicitly control the large and small
  * motors, commonly found in modern game controllers. The small (right) motor
  * is high frequency, and the large (left) motor is low frequency.
  *
- * \sa SDL_HAPTIC_LEFTRIGHT
+ * \sa SDL_HAPTIC_FEATURE_LEFTRIGHT
+ * \sa SDL_HAPTIC_EFFECT_LEFTRIGHT
  * \sa SDL_HapticEffect
  */
 typedef struct SDL_HapticLeftRight
 {
     /* Header */
-    Uint16 type;            /**< ::SDL_HAPTIC_LEFTRIGHT */
+    Uint16 type;            /**< ::SDL_HAPTIC_EFFECT_LEFTRIGHT */
 
     /* Replay */
     Uint32 length;          /**< Duration of the effect in milliseconds. */
@@ -696,9 +880,9 @@ typedef struct SDL_HapticLeftRight
 } SDL_HapticLeftRight;
 
 /**
- *  \brief A structure containing a template for the ::SDL_HAPTIC_CUSTOM effect.
+ *  \brief A structure containing a template for the ::SDL_HAPTIC_EFFECT_CUSTOM effect.
  *
- *  This struct is exclusively for the ::SDL_HAPTIC_CUSTOM effect.
+ *  This struct is exclusively for the ::SDL_HAPTIC_EFFECT_CUSTOM effect.
  *
  *  A custom force feedback effect is much like a periodic effect, where the
  *  application can define its exact shape.  You will have to allocate the
@@ -707,13 +891,14 @@ typedef struct SDL_HapticLeftRight
  *  If channels is one, the effect is rotated using the defined direction.
  *  Otherwise it uses the samples in data for the different axes.
  *
- *  \sa SDL_HAPTIC_CUSTOM
+ *  \sa SDL_HAPTIC_FEATURE_CUSTOM
+ *  \sa SDL_HAPTIC_EFFECT_CUSTOM
  *  \sa SDL_HapticEffect
  */
 typedef struct SDL_HapticCustom
 {
     /* Header */
-    Uint16 type;            /**< ::SDL_HAPTIC_CUSTOM */
+    Uint16 type;            /**< ::SDL_HAPTIC_EFFECT_CUSTOM */
     SDL_HapticDirection direction;  /**< Direction of the effect. */
 
     /* Replay */
@@ -747,8 +932,8 @@ typedef struct SDL_HapticCustom
  *  value.  Neither delay, interval, attack_length nor fade_length support
  *  ::SDL_HAPTIC_INFINITY.  Fade will also not be used since effect never ends.
  *
- *  Additionally, the ::SDL_HAPTIC_RAMP effect does not support a duration of
- *  ::SDL_HAPTIC_INFINITY.
+ *  Additionally, the ::SDL_HAPTIC_EFFECT_RAMP effect does not support a
+ *  duration of ::SDL_HAPTIC_INFINITY.
  *
  *  Button triggers may not be supported on all devices, it is advised to not
  *  use them if possible.  Buttons start at index 1 instead of index 0 like
@@ -1165,7 +1350,7 @@ extern DECLSPEC void SDLCALL SDL_HapticDestroyEffect(SDL_Haptic * haptic,
 /**
  * Get the status of the current effect on the specified haptic device.
  *
- * Device must support the SDL_HAPTIC_STATUS feature.
+ * Device must support the SDL_HAPTIC_FEATURE_STATUS feature.
  *
  * \param haptic the SDL_Haptic device to query for the effect status on
  * \param effect the ID of the haptic effect to query its status
@@ -1183,7 +1368,7 @@ extern DECLSPEC int SDLCALL SDL_HapticGetEffectStatus(SDL_Haptic * haptic,
 /**
  * Set the global gain of the specified haptic device.
  *
- * Device must support the SDL_HAPTIC_GAIN feature.
+ * Device must support the SDL_HAPTIC_FEATURE_GAIN feature.
  *
  * The user may specify the maximum gain by setting the environment variable
  * `SDL_HAPTIC_GAIN_MAX` which should be between 0 and 100. All calls to
@@ -1207,7 +1392,7 @@ extern DECLSPEC int SDLCALL SDL_HapticSetGain(SDL_Haptic * haptic, int gain);
  * Autocenter should be between 0 and 100. Setting it to 0 will disable
  * autocentering.
  *
- * Device must support the SDL_HAPTIC_AUTOCENTER feature.
+ * Device must support the SDL_HAPTIC_FEATURE_AUTOCENTER feature.
  *
  * \param haptic the SDL_Haptic device to set autocentering on
  * \param autocenter value to set autocenter to (0-100)
@@ -1224,7 +1409,7 @@ extern DECLSPEC int SDLCALL SDL_HapticSetAutocenter(SDL_Haptic * haptic,
 /**
  * Pause a haptic device.
  *
- * Device must support the `SDL_HAPTIC_PAUSE` feature. Call
+ * Device must support the `SDL_HAPTIC_FEATURE_PAUSE` feature. Call
  * SDL_HapticUnpause() to resume playback.
  *
  * Do not modify the effects nor add new ones while the device is paused. That

--- a/src/haptic/SDL_haptic.c
+++ b/src/haptic/SDL_haptic.c
@@ -145,10 +145,10 @@ SDL_Haptic *SDL_HapticOpen(int device_index)
     SDL_haptics = haptic;
 
     /* Disable autocenter and set gain to max. */
-    if (haptic->supported & SDL_HAPTIC_GAIN) {
+    if (haptic->supported & SDL_HAPTIC_FEATURE_GAIN) {
         SDL_HapticSetGain(haptic, 100);
     }
-    if (haptic->supported & SDL_HAPTIC_AUTOCENTER) {
+    if (haptic->supported & SDL_HAPTIC_FEATURE_AUTOCENTER) {
         SDL_HapticSetAutocenter(haptic, 0);
     }
 
@@ -580,7 +580,7 @@ int SDL_HapticGetEffectStatus(SDL_Haptic *haptic, int effect)
         return -1;
     }
 
-    if (!(haptic->supported & SDL_HAPTIC_STATUS)) {
+    if (!(haptic->supported & SDL_HAPTIC_FEATURE_STATUS)) {
         return SDL_SetError("Haptic: Device does not support status queries.");
     }
 
@@ -599,7 +599,7 @@ int SDL_HapticSetGain(SDL_Haptic *haptic, int gain)
         return -1;
     }
 
-    if (!(haptic->supported & SDL_HAPTIC_GAIN)) {
+    if (!(haptic->supported & SDL_HAPTIC_FEATURE_GAIN)) {
         return SDL_SetError("Haptic: Device does not support setting gain.");
     }
 
@@ -641,7 +641,7 @@ int SDL_HapticSetAutocenter(SDL_Haptic *haptic, int autocenter)
         return -1;
     }
 
-    if (!(haptic->supported & SDL_HAPTIC_AUTOCENTER)) {
+    if (!(haptic->supported & SDL_HAPTIC_FEATURE_AUTOCENTER)) {
         return SDL_SetError("Haptic: Device does not support setting autocenter.");
     }
 
@@ -665,7 +665,7 @@ int SDL_HapticPause(SDL_Haptic *haptic)
         return -1;
     }
 
-    if (!(haptic->supported & SDL_HAPTIC_PAUSE)) {
+    if (!(haptic->supported & SDL_HAPTIC_FEATURE_PAUSE)) {
         return SDL_SetError("Haptic: Device does not support setting pausing.");
     }
 
@@ -681,7 +681,7 @@ int SDL_HapticUnpause(SDL_Haptic *haptic)
         return -1;
     }
 
-    if (!(haptic->supported & SDL_HAPTIC_PAUSE)) {
+    if (!(haptic->supported & SDL_HAPTIC_FEATURE_PAUSE)) {
         return 0; /* Not going to be paused, so we pretend it's unpaused. */
     }
 
@@ -710,7 +710,7 @@ int SDL_HapticRumbleSupported(SDL_Haptic *haptic)
     }
 
     /* Most things can use SINE, but XInput only has LEFTRIGHT. */
-    return (haptic->supported & (SDL_HAPTIC_SINE | SDL_HAPTIC_LEFTRIGHT)) != 0;
+    return (haptic->supported & (SDL_HAPTIC_FEATURE_SINE | SDL_HAPTIC_FEATURE_LEFTRIGHT)) != 0;
 }
 
 /*
@@ -730,16 +730,16 @@ int SDL_HapticRumbleInit(SDL_Haptic *haptic)
     }
 
     SDL_zerop(efx);
-    if (haptic->supported & SDL_HAPTIC_SINE) {
-        efx->type = SDL_HAPTIC_SINE;
+    if (haptic->supported & SDL_HAPTIC_FEATURE_SINE) {
+        efx->type = SDL_HAPTIC_EFFECT_SINE;
         efx->periodic.direction.type = SDL_HAPTIC_CARTESIAN;
         efx->periodic.period = 1000;
         efx->periodic.magnitude = 0x4000;
         efx->periodic.length = 5000;
         efx->periodic.attack_length = 0;
         efx->periodic.fade_length = 0;
-    } else if (haptic->supported & SDL_HAPTIC_LEFTRIGHT) { /* XInput? */
-        efx->type = SDL_HAPTIC_LEFTRIGHT;
+    } else if (haptic->supported & SDL_HAPTIC_FEATURE_LEFTRIGHT) { /* XInput? */
+        efx->type = SDL_HAPTIC_EFFECT_LEFTRIGHT;
         efx->leftright.length = 5000;
         efx->leftright.large_magnitude = 0x4000;
         efx->leftright.small_magnitude = 0x4000;
@@ -779,10 +779,10 @@ int SDL_HapticRumblePlay(SDL_Haptic *haptic, float strength, Uint32 length)
     magnitude = (Sint16)(32767.0f * strength);
 
     efx = &haptic->rumble_effect;
-    if (efx->type == SDL_HAPTIC_SINE) {
+    if (efx->type == SDL_HAPTIC_EFFECT_SINE) {
         efx->periodic.magnitude = magnitude;
         efx->periodic.length = length;
-    } else if (efx->type == SDL_HAPTIC_LEFTRIGHT) {
+    } else if (efx->type == SDL_HAPTIC_EFFECT_LEFTRIGHT) {
         efx->leftright.small_magnitude = efx->leftright.large_magnitude = magnitude;
         efx->leftright.length = length;
     } else {

--- a/src/haptic/android/SDL_syshaptic.c
+++ b/src/haptic/android/SDL_syshaptic.c
@@ -113,7 +113,7 @@ static SDL_hapticlist_item *OpenHaptic(SDL_Haptic *haptic, SDL_hapticlist_item *
     haptic->hwdata = (struct haptic_hwdata *)item;
     item->haptic = haptic;
 
-    haptic->supported = SDL_HAPTIC_LEFTRIGHT;
+    haptic->supported = SDL_HAPTIC_FEATURE_LEFTRIGHT;
     haptic->neffects = 1;
     haptic->nplaying = haptic->neffects;
     haptic->effects = (struct haptic_effect *)SDL_malloc(sizeof(struct haptic_effect) * haptic->neffects);

--- a/src/haptic/darwin/SDL_syshaptic.c
+++ b/src/haptic/darwin/SDL_syshaptic.c
@@ -420,25 +420,24 @@ static unsigned int GetSupportedFeatures(SDL_Haptic *haptic)
     haptic->nplaying = features.playbackCapacity;
 
     /* Test for effects. */
-    FF_TEST(FFCAP_ET_CONSTANTFORCE, SDL_HAPTIC_CONSTANT);
-    FF_TEST(FFCAP_ET_RAMPFORCE, SDL_HAPTIC_RAMP);
-    /* !!! FIXME: put this back when we have more bits in 2.1 */
-    /* FF_TEST(FFCAP_ET_SQUARE, SDL_HAPTIC_SQUARE); */
-    FF_TEST(FFCAP_ET_SINE, SDL_HAPTIC_SINE);
-    FF_TEST(FFCAP_ET_TRIANGLE, SDL_HAPTIC_TRIANGLE);
-    FF_TEST(FFCAP_ET_SAWTOOTHUP, SDL_HAPTIC_SAWTOOTHUP);
-    FF_TEST(FFCAP_ET_SAWTOOTHDOWN, SDL_HAPTIC_SAWTOOTHDOWN);
-    FF_TEST(FFCAP_ET_SPRING, SDL_HAPTIC_SPRING);
-    FF_TEST(FFCAP_ET_DAMPER, SDL_HAPTIC_DAMPER);
-    FF_TEST(FFCAP_ET_INERTIA, SDL_HAPTIC_INERTIA);
-    FF_TEST(FFCAP_ET_FRICTION, SDL_HAPTIC_FRICTION);
-    FF_TEST(FFCAP_ET_CUSTOMFORCE, SDL_HAPTIC_CUSTOM);
+    FF_TEST(FFCAP_ET_CONSTANTFORCE, SDL_HAPTIC_FEATURE_CONSTANT);
+    FF_TEST(FFCAP_ET_RAMPFORCE, SDL_HAPTIC_FEATURE_RAMP);
+    FF_TEST(FFCAP_ET_SQUARE, SDL_HAPTIC_FEATURE_SQUARE);
+    FF_TEST(FFCAP_ET_SINE, SDL_HAPTIC_FEATURE_SINE);
+    FF_TEST(FFCAP_ET_TRIANGLE, SDL_HAPTIC_FEATURE_TRIANGLE);
+    FF_TEST(FFCAP_ET_SAWTOOTHUP, SDL_HAPTIC_FEATURE_SAWTOOTHUP);
+    FF_TEST(FFCAP_ET_SAWTOOTHDOWN, SDL_HAPTIC_FEATURE_SAWTOOTHDOWN);
+    FF_TEST(FFCAP_ET_SPRING, SDL_HAPTIC_FEATURE_SPRING);
+    FF_TEST(FFCAP_ET_DAMPER, SDL_HAPTIC_FEATURE_DAMPER);
+    FF_TEST(FFCAP_ET_INERTIA, SDL_HAPTIC_FEATURE_INERTIA);
+    FF_TEST(FFCAP_ET_FRICTION, SDL_HAPTIC_FEATURE_FRICTION);
+    FF_TEST(FFCAP_ET_CUSTOMFORCE, SDL_HAPTIC_FEATURE_CUSTOM);
 
     /* Check if supports gain. */
     ret = FFDeviceGetForceFeedbackProperty(device, FFPROP_FFGAIN,
                                            &val, sizeof(val));
     if (ret == FF_OK) {
-        supported |= SDL_HAPTIC_GAIN;
+        supported |= SDL_HAPTIC_FEATURE_GAIN;
     } else if (ret != FFERR_UNSUPPORTED) {
         return SDL_SetError("Haptic: Unable to get if device supports gain: %s.",
                             FFStrError(ret));
@@ -448,7 +447,7 @@ static unsigned int GetSupportedFeatures(SDL_Haptic *haptic)
     ret = FFDeviceGetForceFeedbackProperty(device, FFPROP_AUTOCENTER,
                                            &val, sizeof(val));
     if (ret == FF_OK) {
-        supported |= SDL_HAPTIC_AUTOCENTER;
+        supported |= SDL_HAPTIC_FEATURE_AUTOCENTER;
     } else if (ret != FFERR_UNSUPPORTED) {
         return SDL_SetError("Haptic: Unable to get if device supports autocenter: %s.",
                             FFStrError(ret));
@@ -461,7 +460,7 @@ static unsigned int GetSupportedFeatures(SDL_Haptic *haptic)
                haptic->naxes * sizeof(Uint8));
 
     /* Always supported features. */
-    supported |= SDL_HAPTIC_STATUS | SDL_HAPTIC_PAUSE;
+    supported |= SDL_HAPTIC_FEATURE_STATUS | SDL_HAPTIC_FEATURE_PAUSE;
 
     haptic->supported = supported;
     return 0;
@@ -806,7 +805,7 @@ static int SDL_SYS_ToFFEFFECT(SDL_Haptic *haptic, FFEFFECT *dest, SDL_HapticEffe
 
     /* The big type handling switch, even bigger then Linux's version. */
     switch (src->type) {
-    case SDL_HAPTIC_CONSTANT:
+    case SDL_HAPTIC_EFFECT_CONSTANT:
         hap_constant = &src->constant;
         constant = SDL_malloc(sizeof(FFCONSTANTFORCE));
         if (!constant) {
@@ -843,12 +842,11 @@ static int SDL_SYS_ToFFEFFECT(SDL_Haptic *haptic, FFEFFECT *dest, SDL_HapticEffe
 
         break;
 
-    case SDL_HAPTIC_SINE:
-    /* !!! FIXME: put this back when we have more bits in 2.1 */
-    /* case SDL_HAPTIC_SQUARE: */
-    case SDL_HAPTIC_TRIANGLE:
-    case SDL_HAPTIC_SAWTOOTHUP:
-    case SDL_HAPTIC_SAWTOOTHDOWN:
+    case SDL_HAPTIC_EFFECT_SINE:
+    case SDL_HAPTIC_EFFECT_SQUARE:
+    case SDL_HAPTIC_EFFECT_TRIANGLE:
+    case SDL_HAPTIC_EFFECT_SAWTOOTHUP:
+    case SDL_HAPTIC_EFFECT_SAWTOOTHDOWN:
         hap_periodic = &src->periodic;
         periodic = SDL_malloc(sizeof(FFPERIODIC));
         if (!periodic) {
@@ -889,10 +887,10 @@ static int SDL_SYS_ToFFEFFECT(SDL_Haptic *haptic, FFEFFECT *dest, SDL_HapticEffe
 
         break;
 
-    case SDL_HAPTIC_SPRING:
-    case SDL_HAPTIC_DAMPER:
-    case SDL_HAPTIC_INERTIA:
-    case SDL_HAPTIC_FRICTION:
+    case SDL_HAPTIC_EFFECT_SPRING:
+    case SDL_HAPTIC_EFFECT_DAMPER:
+    case SDL_HAPTIC_EFFECT_INERTIA:
+    case SDL_HAPTIC_EFFECT_FRICTION:
         hap_condition = &src->condition;
         if (dest->cAxes > 0) {
             condition = SDL_malloc(sizeof(FFCONDITION) * dest->cAxes);
@@ -936,7 +934,7 @@ static int SDL_SYS_ToFFEFFECT(SDL_Haptic *haptic, FFEFFECT *dest, SDL_HapticEffe
 
         break;
 
-    case SDL_HAPTIC_RAMP:
+    case SDL_HAPTIC_EFFECT_RAMP:
         hap_ramp = &src->ramp;
         ramp = SDL_malloc(sizeof(FFRAMPFORCE));
         if (!ramp) {
@@ -974,7 +972,7 @@ static int SDL_SYS_ToFFEFFECT(SDL_Haptic *haptic, FFEFFECT *dest, SDL_HapticEffe
 
         break;
 
-    case SDL_HAPTIC_CUSTOM:
+    case SDL_HAPTIC_EFFECT_CUSTOM:
         hap_custom = &src->custom;
         custom = SDL_malloc(sizeof(FFCUSTOMFORCE));
         if (!custom) {
@@ -1038,7 +1036,7 @@ static void SDL_SYS_HapticFreeFFEFFECT(FFEFFECT *effect, int type)
     SDL_free(effect->rgdwAxes);
     effect->rgdwAxes = NULL;
     if (effect->lpvTypeSpecificParams) {
-        if (type == SDL_HAPTIC_CUSTOM) { /* Must free the custom data. */
+        if (type == SDL_HAPTIC_EFFECT_CUSTOM) { /* Must free the custom data. */
             custom = (FFCUSTOMFORCE *)effect->lpvTypeSpecificParams;
             SDL_free(custom->rglForceData);
             custom->rglForceData = NULL;
@@ -1057,41 +1055,40 @@ CFUUIDRef
 SDL_SYS_HapticEffectType(Uint16 type)
 {
     switch (type) {
-    case SDL_HAPTIC_CONSTANT:
+    case SDL_HAPTIC_EFFECT_CONSTANT:
         return kFFEffectType_ConstantForce_ID;
 
-    case SDL_HAPTIC_RAMP:
+    case SDL_HAPTIC_EFFECT_RAMP:
         return kFFEffectType_RampForce_ID;
 
-        /* !!! FIXME: put this back when we have more bits in 2.1 */
-        /* case SDL_HAPTIC_SQUARE:
-            return kFFEffectType_Square_ID; */
+    case SDL_HAPTIC_EFFECT_SQUARE:
+        return kFFEffectType_Square_ID;
 
-    case SDL_HAPTIC_SINE:
+    case SDL_HAPTIC_EFFECT_SINE:
         return kFFEffectType_Sine_ID;
 
-    case SDL_HAPTIC_TRIANGLE:
+    case SDL_HAPTIC_EFFECT_TRIANGLE:
         return kFFEffectType_Triangle_ID;
 
-    case SDL_HAPTIC_SAWTOOTHUP:
+    case SDL_HAPTIC_EFFECT_SAWTOOTHUP:
         return kFFEffectType_SawtoothUp_ID;
 
-    case SDL_HAPTIC_SAWTOOTHDOWN:
+    case SDL_HAPTIC_EFFECT_SAWTOOTHDOWN:
         return kFFEffectType_SawtoothDown_ID;
 
-    case SDL_HAPTIC_SPRING:
+    case SDL_HAPTIC_EFFECT_SPRING:
         return kFFEffectType_Spring_ID;
 
-    case SDL_HAPTIC_DAMPER:
+    case SDL_HAPTIC_EFFECT_DAMPER:
         return kFFEffectType_Damper_ID;
 
-    case SDL_HAPTIC_INERTIA:
+    case SDL_HAPTIC_EFFECT_INERTIA:
         return kFFEffectType_Inertia_ID;
 
-    case SDL_HAPTIC_FRICTION:
+    case SDL_HAPTIC_EFFECT_FRICTION:
         return kFFEffectType_Friction_ID;
 
-    case SDL_HAPTIC_CUSTOM:
+    case SDL_HAPTIC_EFFECT_CUSTOM:
         return kFFEffectType_CustomForce_ID;
 
     default:

--- a/src/haptic/linux/SDL_syshaptic.c
+++ b/src/haptic/linux/SDL_syshaptic.c
@@ -104,22 +104,21 @@ static int EV_IsHaptic(int fd)
     }
 
     /* Convert supported features to SDL_HAPTIC platform-neutral features. */
-    EV_TEST(FF_CONSTANT, SDL_HAPTIC_CONSTANT);
-    EV_TEST(FF_SINE, SDL_HAPTIC_SINE);
-    /* !!! FIXME: put this back when we have more bits in 2.1 */
-    /* EV_TEST(FF_SQUARE, SDL_HAPTIC_SQUARE); */
-    EV_TEST(FF_TRIANGLE, SDL_HAPTIC_TRIANGLE);
-    EV_TEST(FF_SAW_UP, SDL_HAPTIC_SAWTOOTHUP);
-    EV_TEST(FF_SAW_DOWN, SDL_HAPTIC_SAWTOOTHDOWN);
-    EV_TEST(FF_RAMP, SDL_HAPTIC_RAMP);
-    EV_TEST(FF_SPRING, SDL_HAPTIC_SPRING);
-    EV_TEST(FF_FRICTION, SDL_HAPTIC_FRICTION);
-    EV_TEST(FF_DAMPER, SDL_HAPTIC_DAMPER);
-    EV_TEST(FF_INERTIA, SDL_HAPTIC_INERTIA);
-    EV_TEST(FF_CUSTOM, SDL_HAPTIC_CUSTOM);
-    EV_TEST(FF_GAIN, SDL_HAPTIC_GAIN);
-    EV_TEST(FF_AUTOCENTER, SDL_HAPTIC_AUTOCENTER);
-    EV_TEST(FF_RUMBLE, SDL_HAPTIC_LEFTRIGHT);
+    EV_TEST(FF_CONSTANT, SDL_HAPTIC_FEATURE_CONSTANT);
+    EV_TEST(FF_SINE, SDL_HAPTIC_FEATURE_SINE);
+    EV_TEST(FF_SQUARE, SDL_HAPTIC_FEATURE_SQUARE);
+    EV_TEST(FF_TRIANGLE, SDL_HAPTIC_FEATURE_TRIANGLE);
+    EV_TEST(FF_SAW_UP, SDL_HAPTIC_FEATURE_SAWTOOTHUP);
+    EV_TEST(FF_SAW_DOWN, SDL_HAPTIC_FEATURE_SAWTOOTHDOWN);
+    EV_TEST(FF_RAMP, SDL_HAPTIC_FEATURE_RAMP);
+    EV_TEST(FF_SPRING, SDL_HAPTIC_FEATURE_SPRING);
+    EV_TEST(FF_FRICTION, SDL_HAPTIC_FEATURE_FRICTION);
+    EV_TEST(FF_DAMPER, SDL_HAPTIC_FEATURE_DAMPER);
+    EV_TEST(FF_INERTIA, SDL_HAPTIC_FEATURE_INERTIA);
+    EV_TEST(FF_CUSTOM, SDL_HAPTIC_FEATURE_CUSTOM);
+    EV_TEST(FF_GAIN, SDL_HAPTIC_FEATURE_GAIN);
+    EV_TEST(FF_AUTOCENTER, SDL_HAPTIC_FEATURE_AUTOCENTER);
+    EV_TEST(FF_RUMBLE, SDL_HAPTIC_FEATURE_LEFTRIGHT);
 
     /* Return what it supports. */
     return ret;
@@ -714,7 +713,7 @@ static int SDL_SYS_ToFFEffect(struct ff_effect *dest, SDL_HapticEffect *src)
     SDL_memset(dest, 0, sizeof(struct ff_effect));
 
     switch (src->type) {
-    case SDL_HAPTIC_CONSTANT:
+    case SDL_HAPTIC_EFFECT_CONSTANT:
         constant = &src->constant;
 
         /* Header */
@@ -744,12 +743,11 @@ static int SDL_SYS_ToFFEffect(struct ff_effect *dest, SDL_HapticEffect *src)
 
         break;
 
-    case SDL_HAPTIC_SINE:
-    /* !!! FIXME: put this back when we have more bits in 2.1 */
-    /* case SDL_HAPTIC_SQUARE: */
-    case SDL_HAPTIC_TRIANGLE:
-    case SDL_HAPTIC_SAWTOOTHUP:
-    case SDL_HAPTIC_SAWTOOTHDOWN:
+    case SDL_HAPTIC_EFFECT_SINE:
+    case SDL_HAPTIC_EFFECT_SQUARE:
+    case SDL_HAPTIC_EFFECT_TRIANGLE:
+    case SDL_HAPTIC_EFFECT_SAWTOOTHUP:
+    case SDL_HAPTIC_EFFECT_SAWTOOTHDOWN:
         periodic = &src->periodic;
 
         /* Header */
@@ -767,16 +765,15 @@ static int SDL_SYS_ToFFEffect(struct ff_effect *dest, SDL_HapticEffect *src)
         dest->trigger.interval = CLAMP(periodic->interval);
 
         /* Periodic */
-        if (periodic->type == SDL_HAPTIC_SINE) {
+        if (periodic->type == SDL_HAPTIC_EFFECT_SINE) {
             dest->u.periodic.waveform = FF_SINE;
-            /* !!! FIXME: put this back when we have more bits in 2.1 */
-            /* else if (periodic->type == SDL_HAPTIC_SQUARE)
-                dest->u.periodic.waveform = FF_SQUARE; */
-        } else if (periodic->type == SDL_HAPTIC_TRIANGLE) {
+        } else if (periodic->type == SDL_HAPTIC_EFFECT_SQUARE) {
+            dest->u.periodic.waveform = FF_SQUARE;
+        } else if (periodic->type == SDL_HAPTIC_EFFECT_TRIANGLE) {
             dest->u.periodic.waveform = FF_TRIANGLE;
-        } else if (periodic->type == SDL_HAPTIC_SAWTOOTHUP) {
+        } else if (periodic->type == SDL_HAPTIC_EFFECT_SAWTOOTHUP) {
             dest->u.periodic.waveform = FF_SAW_UP;
-        } else if (periodic->type == SDL_HAPTIC_SAWTOOTHDOWN) {
+        } else if (periodic->type == SDL_HAPTIC_EFFECT_SAWTOOTHDOWN) {
             dest->u.periodic.waveform = FF_SAW_DOWN;
         }
         dest->u.periodic.period = CLAMP(periodic->period);
@@ -795,20 +792,20 @@ static int SDL_SYS_ToFFEffect(struct ff_effect *dest, SDL_HapticEffect *src)
 
         break;
 
-    case SDL_HAPTIC_SPRING:
-    case SDL_HAPTIC_DAMPER:
-    case SDL_HAPTIC_INERTIA:
-    case SDL_HAPTIC_FRICTION:
+    case SDL_HAPTIC_EFFECT_SPRING:
+    case SDL_HAPTIC_EFFECT_DAMPER:
+    case SDL_HAPTIC_EFFECT_INERTIA:
+    case SDL_HAPTIC_EFFECT_FRICTION:
         condition = &src->condition;
 
         /* Header */
-        if (condition->type == SDL_HAPTIC_SPRING) {
+        if (condition->type == SDL_HAPTIC_EFFECT_SPRING) {
             dest->type = FF_SPRING;
-        } else if (condition->type == SDL_HAPTIC_DAMPER) {
+        } else if (condition->type == SDL_HAPTIC_EFFECT_DAMPER) {
             dest->type = FF_DAMPER;
-        } else if (condition->type == SDL_HAPTIC_INERTIA) {
+        } else if (condition->type == SDL_HAPTIC_EFFECT_INERTIA) {
             dest->type = FF_INERTIA;
-        } else if (condition->type == SDL_HAPTIC_FRICTION) {
+        } else if (condition->type == SDL_HAPTIC_EFFECT_FRICTION) {
             dest->type = FF_FRICTION;
         }
 
@@ -844,7 +841,7 @@ static int SDL_SYS_ToFFEffect(struct ff_effect *dest, SDL_HapticEffect *src)
 
         break;
 
-    case SDL_HAPTIC_RAMP:
+    case SDL_HAPTIC_EFFECT_RAMP:
         ramp = &src->ramp;
 
         /* Header */
@@ -873,7 +870,7 @@ static int SDL_SYS_ToFFEffect(struct ff_effect *dest, SDL_HapticEffect *src)
 
         break;
 
-    case SDL_HAPTIC_LEFTRIGHT:
+    case SDL_HAPTIC_EFFECT_LEFTRIGHT:
         leftright = &src->leftright;
 
         /* Header */

--- a/src/haptic/windows/SDL_dinputhaptic.c
+++ b/src/haptic/windows/SDL_dinputhaptic.c
@@ -258,19 +258,18 @@ static BOOL CALLBACK DI_EffectCallback(LPCDIEFFECTINFO pei, LPVOID pv)
     SDL_Haptic *haptic = (SDL_Haptic *)pv;
 
     /* Get supported. */
-    EFFECT_TEST(GUID_Spring, SDL_HAPTIC_SPRING);
-    EFFECT_TEST(GUID_Damper, SDL_HAPTIC_DAMPER);
-    EFFECT_TEST(GUID_Inertia, SDL_HAPTIC_INERTIA);
-    EFFECT_TEST(GUID_Friction, SDL_HAPTIC_FRICTION);
-    EFFECT_TEST(GUID_ConstantForce, SDL_HAPTIC_CONSTANT);
-    EFFECT_TEST(GUID_CustomForce, SDL_HAPTIC_CUSTOM);
-    EFFECT_TEST(GUID_Sine, SDL_HAPTIC_SINE);
-    /* !!! FIXME: put this back when we have more bits in 2.1 */
-    /* EFFECT_TEST(GUID_Square, SDL_HAPTIC_SQUARE); */
-    EFFECT_TEST(GUID_Triangle, SDL_HAPTIC_TRIANGLE);
-    EFFECT_TEST(GUID_SawtoothUp, SDL_HAPTIC_SAWTOOTHUP);
-    EFFECT_TEST(GUID_SawtoothDown, SDL_HAPTIC_SAWTOOTHDOWN);
-    EFFECT_TEST(GUID_RampForce, SDL_HAPTIC_RAMP);
+    EFFECT_TEST(GUID_Spring, SDL_HAPTIC_FEATURE_SPRING);
+    EFFECT_TEST(GUID_Damper, SDL_HAPTIC_FEATURE_DAMPER);
+    EFFECT_TEST(GUID_Inertia, SDL_HAPTIC_FEATURE_INERTIA);
+    EFFECT_TEST(GUID_Friction, SDL_HAPTIC_FEATURE_FRICTION);
+    EFFECT_TEST(GUID_ConstantForce, SDL_HAPTIC_FEATURE_CONSTANT);
+    EFFECT_TEST(GUID_CustomForce, SDL_HAPTIC_FEATURE_CUSTOM);
+    EFFECT_TEST(GUID_Sine, SDL_HAPTIC_FEATURE_SINE);
+    EFFECT_TEST(GUID_Square, SDL_HAPTIC_FEATURE_SQUARE);
+    EFFECT_TEST(GUID_Triangle, SDL_HAPTIC_FEATURE_TRIANGLE);
+    EFFECT_TEST(GUID_SawtoothUp, SDL_HAPTIC_FEATURE_SAWTOOTHUP);
+    EFFECT_TEST(GUID_SawtoothDown, SDL_HAPTIC_FEATURE_SAWTOOTHDOWN);
+    EFFECT_TEST(GUID_RampForce, SDL_HAPTIC_FEATURE_RAMP);
 
     /* Check for more. */
     return DIENUM_CONTINUE;
@@ -383,7 +382,7 @@ static int SDL_DINPUT_HapticOpenFromDevice(SDL_Haptic *haptic, LPDIRECTINPUTDEVI
     ret = IDirectInputDevice8_SetProperty(haptic->hwdata->device,
                                           DIPROP_FFGAIN, &dipdw.diph);
     if (!FAILED(ret)) { /* Gain is supported. */
-        haptic->supported |= SDL_HAPTIC_GAIN;
+        haptic->supported |= SDL_HAPTIC_FEATURE_GAIN;
     }
     dipdw.diph.dwObj = 0;
     dipdw.diph.dwHow = DIPH_DEVICE;
@@ -391,11 +390,11 @@ static int SDL_DINPUT_HapticOpenFromDevice(SDL_Haptic *haptic, LPDIRECTINPUTDEVI
     ret = IDirectInputDevice8_SetProperty(haptic->hwdata->device,
                                           DIPROP_AUTOCENTER, &dipdw.diph);
     if (!FAILED(ret)) { /* Autocenter is supported. */
-        haptic->supported |= SDL_HAPTIC_AUTOCENTER;
+        haptic->supported |= SDL_HAPTIC_FEATURE_AUTOCENTER;
     }
 
     /* Status is always supported. */
-    haptic->supported |= SDL_HAPTIC_STATUS | SDL_HAPTIC_PAUSE;
+    haptic->supported |= SDL_HAPTIC_FEATURE_STATUS | SDL_HAPTIC_FEATURE_PAUSE;
 
     /* Check maximum effects. */
     haptic->neffects = 128; /* This is not actually supported as thus under windows,
@@ -650,7 +649,7 @@ static int SDL_SYS_ToDIEFFECT(SDL_Haptic *haptic, DIEFFECT *dest,
 
     /* The big type handling switch, even bigger than Linux's version. */
     switch (src->type) {
-    case SDL_HAPTIC_CONSTANT:
+    case SDL_HAPTIC_EFFECT_CONSTANT:
         hap_constant = &src->constant;
         constant = SDL_malloc(sizeof(DICONSTANTFORCE));
         if (!constant) {
@@ -687,12 +686,11 @@ static int SDL_SYS_ToDIEFFECT(SDL_Haptic *haptic, DIEFFECT *dest,
 
         break;
 
-    case SDL_HAPTIC_SINE:
-    /* !!! FIXME: put this back when we have more bits in 2.1 */
-    /* case SDL_HAPTIC_SQUARE: */
-    case SDL_HAPTIC_TRIANGLE:
-    case SDL_HAPTIC_SAWTOOTHUP:
-    case SDL_HAPTIC_SAWTOOTHDOWN:
+    case SDL_HAPTIC_EFFECT_SINE:
+    case SDL_HAPTIC_EFFECT_SQUARE:
+    case SDL_HAPTIC_EFFECT_TRIANGLE:
+    case SDL_HAPTIC_EFFECT_SAWTOOTHUP:
+    case SDL_HAPTIC_EFFECT_SAWTOOTHDOWN:
         hap_periodic = &src->periodic;
         periodic = SDL_malloc(sizeof(DIPERIODIC));
         if (!periodic) {
@@ -733,10 +731,10 @@ static int SDL_SYS_ToDIEFFECT(SDL_Haptic *haptic, DIEFFECT *dest,
 
         break;
 
-    case SDL_HAPTIC_SPRING:
-    case SDL_HAPTIC_DAMPER:
-    case SDL_HAPTIC_INERTIA:
-    case SDL_HAPTIC_FRICTION:
+    case SDL_HAPTIC_EFFECT_SPRING:
+    case SDL_HAPTIC_EFFECT_DAMPER:
+    case SDL_HAPTIC_EFFECT_INERTIA:
+    case SDL_HAPTIC_EFFECT_FRICTION:
         hap_condition = &src->condition;
         condition = SDL_malloc(sizeof(DICONDITION) * dest->cAxes);
         if (!condition) {
@@ -777,7 +775,7 @@ static int SDL_SYS_ToDIEFFECT(SDL_Haptic *haptic, DIEFFECT *dest,
 
         break;
 
-    case SDL_HAPTIC_RAMP:
+    case SDL_HAPTIC_EFFECT_RAMP:
         hap_ramp = &src->ramp;
         ramp = SDL_malloc(sizeof(DIRAMPFORCE));
         if (!ramp) {
@@ -815,7 +813,7 @@ static int SDL_SYS_ToDIEFFECT(SDL_Haptic *haptic, DIEFFECT *dest,
 
         break;
 
-    case SDL_HAPTIC_CUSTOM:
+    case SDL_HAPTIC_EFFECT_CUSTOM:
         hap_custom = &src->custom;
         custom = SDL_malloc(sizeof(DICUSTOMFORCE));
         if (!custom) {
@@ -878,7 +876,7 @@ static void SDL_SYS_HapticFreeDIEFFECT(DIEFFECT *effect, int type)
     SDL_free(effect->rgdwAxes);
     effect->rgdwAxes = NULL;
     if (effect->lpvTypeSpecificParams) {
-        if (type == SDL_HAPTIC_CUSTOM) { /* Must free the custom data. */
+        if (type == SDL_HAPTIC_EFFECT_CUSTOM) { /* Must free the custom data. */
             custom = (DICUSTOMFORCE *)effect->lpvTypeSpecificParams;
             SDL_free(custom->rglForceData);
             custom->rglForceData = NULL;
@@ -897,41 +895,40 @@ static void SDL_SYS_HapticFreeDIEFFECT(DIEFFECT *effect, int type)
 static REFGUID SDL_SYS_HapticEffectType(SDL_HapticEffect *effect)
 {
     switch (effect->type) {
-    case SDL_HAPTIC_CONSTANT:
+    case SDL_HAPTIC_EFFECT_CONSTANT:
         return &GUID_ConstantForce;
 
-    case SDL_HAPTIC_RAMP:
+    case SDL_HAPTIC_EFFECT_RAMP:
         return &GUID_RampForce;
 
-        /* !!! FIXME: put this back when we have more bits in 2.1 */
-        /* case SDL_HAPTIC_SQUARE:
-            return &GUID_Square; */
+    case SDL_HAPTIC_EFFECT_SQUARE:
+        return &GUID_Square;
 
-    case SDL_HAPTIC_SINE:
+    case SDL_HAPTIC_EFFECT_SINE:
         return &GUID_Sine;
 
-    case SDL_HAPTIC_TRIANGLE:
+    case SDL_HAPTIC_EFFECT_TRIANGLE:
         return &GUID_Triangle;
 
-    case SDL_HAPTIC_SAWTOOTHUP:
+    case SDL_HAPTIC_EFFECT_SAWTOOTHUP:
         return &GUID_SawtoothUp;
 
-    case SDL_HAPTIC_SAWTOOTHDOWN:
+    case SDL_HAPTIC_EFFECT_SAWTOOTHDOWN:
         return &GUID_SawtoothDown;
 
-    case SDL_HAPTIC_SPRING:
+    case SDL_HAPTIC_EFFECT_SPRING:
         return &GUID_Spring;
 
-    case SDL_HAPTIC_DAMPER:
+    case SDL_HAPTIC_EFFECT_DAMPER:
         return &GUID_Damper;
 
-    case SDL_HAPTIC_INERTIA:
+    case SDL_HAPTIC_EFFECT_INERTIA:
         return &GUID_Inertia;
 
-    case SDL_HAPTIC_FRICTION:
+    case SDL_HAPTIC_EFFECT_FRICTION:
         return &GUID_Friction;
 
-    case SDL_HAPTIC_CUSTOM:
+    case SDL_HAPTIC_EFFECT_CUSTOM:
         return &GUID_CustomForce;
 
     default:

--- a/src/haptic/windows/SDL_xinputhaptic.c
+++ b/src/haptic/windows/SDL_xinputhaptic.c
@@ -170,7 +170,7 @@ static int SDL_XINPUT_HapticOpenFromUserIndex(SDL_Haptic *haptic, const Uint8 us
     XINPUT_VIBRATION vibration = { 0, 0 }; /* stop any current vibration */
     XINPUTSETSTATE(userid, &vibration);
 
-    haptic->supported = SDL_HAPTIC_LEFTRIGHT;
+    haptic->supported = SDL_HAPTIC_FEATURE_LEFTRIGHT;
 
     haptic->neffects = 1;
     haptic->nplaying = 1;
@@ -262,14 +262,14 @@ void SDL_XINPUT_HapticQuit(void)
 
 int SDL_XINPUT_HapticNewEffect(SDL_Haptic *haptic, struct haptic_effect *effect, SDL_HapticEffect *base)
 {
-    SDL_assert(base->type == SDL_HAPTIC_LEFTRIGHT); /* should catch this at higher level */
+    SDL_assert(base->type == SDL_HAPTIC_EFFECT_LEFTRIGHT); /* should catch this at higher level */
     return SDL_XINPUT_HapticUpdateEffect(haptic, effect, base);
 }
 
 int SDL_XINPUT_HapticUpdateEffect(SDL_Haptic *haptic, struct haptic_effect *effect, SDL_HapticEffect *data)
 {
     XINPUT_VIBRATION *vib = &effect->hweffect->vibration;
-    SDL_assert(data->type == SDL_HAPTIC_LEFTRIGHT);
+    SDL_assert(data->type == SDL_HAPTIC_EFFECT_LEFTRIGHT);
     /* SDL_HapticEffect has max magnitude of 32767, XInput expects 65535 max, so multiply */
     vib->wLeftMotorSpeed = data->leftright.large_magnitude * 2;
     vib->wRightMotorSpeed = data->leftright.small_magnitude * 2;
@@ -284,7 +284,7 @@ int SDL_XINPUT_HapticUpdateEffect(SDL_Haptic *haptic, struct haptic_effect *effe
 int SDL_XINPUT_HapticRunEffect(SDL_Haptic *haptic, struct haptic_effect *effect, Uint32 iterations)
 {
     XINPUT_VIBRATION *vib = &effect->hweffect->vibration;
-    SDL_assert(effect->effect.type == SDL_HAPTIC_LEFTRIGHT); /* should catch this at higher level */
+    SDL_assert(effect->effect.type == SDL_HAPTIC_EFFECT_LEFTRIGHT); /* should catch this at higher level */
     SDL_LockMutex(haptic->hwdata->mutex);
     if (effect->effect.leftright.length == SDL_HAPTIC_INFINITY || iterations == SDL_HAPTIC_INFINITY) {
         haptic->hwdata->stopTicks = SDL_HAPTIC_INFINITY;

--- a/test/testhaptic.c
+++ b/test/testhaptic.c
@@ -36,8 +36,8 @@ int main(int argc, char **argv)
     int i;
     char *name;
     int index;
-    SDL_HapticEffect efx[9];
-    int id[9];
+    SDL_HapticEffect efx[12];
+    int id[12];
     int nefx;
     unsigned int supported;
 
@@ -126,12 +126,62 @@ int main(int argc, char **argv)
         }
         nefx++;
     }
+    /* First we'll try a TRIANGLE effect. */
+    if (supported & SDL_HAPTIC_FEATURE_TRIANGLE) {
+        SDL_Log("   effect %d: Triangle\n", nefx);
+        efx[nefx].type = SDL_HAPTIC_EFFECT_TRIANGLE;
+        efx[nefx].periodic.period = 1000;
+        efx[nefx].periodic.magnitude = -0x5000; /* Negative magnitude and ...                      */
+        efx[nefx].periodic.phase = 18000;       /* ... 180 degrees phase shift => cancel eachother */
+        efx[nefx].periodic.length = 5000;
+        efx[nefx].periodic.attack_length = 1000;
+        efx[nefx].periodic.fade_length = 1000;
+        id[nefx] = SDL_HapticNewEffect(haptic, &efx[nefx]);
+        if (id[nefx] < 0) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s\n", SDL_GetError());
+            abort_execution();
+        }
+        nefx++;
+    }
     /* Now we'll try a SAWTOOTHUP */
     if (supported & SDL_HAPTIC_FEATURE_SAWTOOTHUP) {
         SDL_Log("   effect %d: Sawtooth Up\n", nefx);
         efx[nefx].type = SDL_HAPTIC_EFFECT_SAWTOOTHUP;
         efx[nefx].periodic.period = 500;
         efx[nefx].periodic.magnitude = 0x5000;
+        efx[nefx].periodic.length = 5000;
+        efx[nefx].periodic.attack_length = 1000;
+        efx[nefx].periodic.fade_length = 1000;
+        id[nefx] = SDL_HapticNewEffect(haptic, &efx[nefx]);
+        if (id[nefx] < 0) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s\n", SDL_GetError());
+            abort_execution();
+        }
+        nefx++;
+    }
+    /* Now we'll try a SAWTOOTHDOWN */
+    if (supported & SDL_HAPTIC_FEATURE_SAWTOOTHDOWN) {
+        SDL_Log("   effect %d: Sawtooth Down\n", nefx);
+        efx[nefx].type = SDL_HAPTIC_EFFECT_SAWTOOTHDOWN;
+        efx[nefx].periodic.period = 500;
+        efx[nefx].periodic.magnitude = 0x5000;
+        efx[nefx].periodic.length = 5000;
+        efx[nefx].periodic.attack_length = 1000;
+        efx[nefx].periodic.fade_length = 1000;
+        id[nefx] = SDL_HapticNewEffect(haptic, &efx[nefx]);
+        if (id[nefx] < 0) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s\n", SDL_GetError());
+            abort_execution();
+        }
+        nefx++;
+    }
+    /* Now we'll try a SQUARE effect. */
+    if (supported & SDL_HAPTIC_FEATURE_SQUARE) {
+        SDL_Log("   effect %d: Square\n", nefx);
+        efx[nefx].type = SDL_HAPTIC_EFFECT_SQUARE;
+        efx[nefx].periodic.period = 1000;
+        efx[nefx].periodic.magnitude = -0x5000; /* Negative magnitude and ...                      */
+        efx[nefx].periodic.phase = 18000;       /* ... 180 degrees phase shift => cancel eachother */
         efx[nefx].periodic.length = 5000;
         efx[nefx].periodic.attack_length = 1000;
         efx[nefx].periodic.fade_length = 1000;

--- a/test/testhaptic.c
+++ b/test/testhaptic.c
@@ -110,9 +110,9 @@ int main(int argc, char **argv)
 
     SDL_Log("\nUploading effects\n");
     /* First we'll try a SINE effect. */
-    if (supported & SDL_HAPTIC_SINE) {
+    if (supported & SDL_HAPTIC_FEATURE_SINE) {
         SDL_Log("   effect %d: Sine Wave\n", nefx);
-        efx[nefx].type = SDL_HAPTIC_SINE;
+        efx[nefx].type = SDL_HAPTIC_EFFECT_SINE;
         efx[nefx].periodic.period = 1000;
         efx[nefx].periodic.magnitude = -0x2000; /* Negative magnitude and ...                      */
         efx[nefx].periodic.phase = 18000;       /* ... 180 degrees phase shift => cancel eachother */
@@ -127,9 +127,9 @@ int main(int argc, char **argv)
         nefx++;
     }
     /* Now we'll try a SAWTOOTHUP */
-    if (supported & SDL_HAPTIC_SAWTOOTHUP) {
+    if (supported & SDL_HAPTIC_FEATURE_SAWTOOTHUP) {
         SDL_Log("   effect %d: Sawtooth Up\n", nefx);
-        efx[nefx].type = SDL_HAPTIC_SAWTOOTHUP;
+        efx[nefx].type = SDL_HAPTIC_EFFECT_SAWTOOTHUP;
         efx[nefx].periodic.period = 500;
         efx[nefx].periodic.magnitude = 0x5000;
         efx[nefx].periodic.length = 5000;
@@ -144,9 +144,9 @@ int main(int argc, char **argv)
     }
 
     /* Now the classical constant effect. */
-    if (supported & SDL_HAPTIC_CONSTANT) {
+    if (supported & SDL_HAPTIC_FEATURE_CONSTANT) {
         SDL_Log("   effect %d: Constant Force\n", nefx);
-        efx[nefx].type = SDL_HAPTIC_CONSTANT;
+        efx[nefx].type = SDL_HAPTIC_EFFECT_CONSTANT;
         efx[nefx].constant.direction.type = SDL_HAPTIC_POLAR;
         efx[nefx].constant.direction.dir[0] = 20000; /* Force comes from the south-west. */
         efx[nefx].constant.length = 5000;
@@ -162,9 +162,9 @@ int main(int argc, char **argv)
     }
 
     /* The cute spring effect. */
-    if (supported & SDL_HAPTIC_SPRING) {
+    if (supported & SDL_HAPTIC_FEATURE_SPRING) {
         SDL_Log("   effect %d: Condition Spring\n", nefx);
-        efx[nefx].type = SDL_HAPTIC_SPRING;
+        efx[nefx].type = SDL_HAPTIC_EFFECT_SPRING;
         efx[nefx].condition.length = 5000;
         for (i = 0; i < SDL_HapticNumAxes(haptic); i++) {
             efx[nefx].condition.right_sat[i] = 0xFFFF;
@@ -181,9 +181,9 @@ int main(int argc, char **argv)
         nefx++;
     }
     /* The interesting damper effect. */
-    if (supported & SDL_HAPTIC_DAMPER) {
+    if (supported & SDL_HAPTIC_FEATURE_DAMPER) {
         SDL_Log("   effect %d: Condition Damper\n", nefx);
-        efx[nefx].type = SDL_HAPTIC_DAMPER;
+        efx[nefx].type = SDL_HAPTIC_EFFECT_DAMPER;
         efx[nefx].condition.length = 5000;
         for (i = 0; i < SDL_HapticNumAxes(haptic); i++) {
             efx[nefx].condition.right_sat[i] = 0xFFFF;
@@ -199,9 +199,9 @@ int main(int argc, char **argv)
         nefx++;
     }
     /* The pretty awesome inertia effect. */
-    if (supported & SDL_HAPTIC_INERTIA) {
+    if (supported & SDL_HAPTIC_FEATURE_INERTIA) {
         SDL_Log("   effect %d: Condition Inertia\n", nefx);
-        efx[nefx].type = SDL_HAPTIC_INERTIA;
+        efx[nefx].type = SDL_HAPTIC_EFFECT_INERTIA;
         efx[nefx].condition.length = 5000;
         for (i = 0; i < SDL_HapticNumAxes(haptic); i++) {
             efx[nefx].condition.right_sat[i] = 0xFFFF;
@@ -218,9 +218,9 @@ int main(int argc, char **argv)
         nefx++;
     }
     /* The hot friction effect. */
-    if (supported & SDL_HAPTIC_FRICTION) {
+    if (supported & SDL_HAPTIC_FEATURE_FRICTION) {
         SDL_Log("   effect %d: Condition Friction\n", nefx);
-        efx[nefx].type = SDL_HAPTIC_FRICTION;
+        efx[nefx].type = SDL_HAPTIC_EFFECT_FRICTION;
         efx[nefx].condition.length = 5000;
         for (i = 0; i < SDL_HapticNumAxes(haptic); i++) {
             efx[nefx].condition.right_sat[i] = 0xFFFF;
@@ -237,9 +237,9 @@ int main(int argc, char **argv)
     }
 
     /* Now we'll try a ramp effect */
-    if (supported & SDL_HAPTIC_RAMP) {
+    if (supported & SDL_HAPTIC_FEATURE_RAMP) {
         SDL_Log("   effect %d: Ramp\n", nefx);
-        efx[nefx].type = SDL_HAPTIC_RAMP;
+        efx[nefx].type = SDL_HAPTIC_EFFECT_RAMP;
         efx[nefx].ramp.direction.type = SDL_HAPTIC_CARTESIAN;
         efx[nefx].ramp.direction.dir[0] = 1;  /* Force comes from                 */
         efx[nefx].ramp.direction.dir[1] = -1; /*                  the north-east. */
@@ -257,9 +257,9 @@ int main(int argc, char **argv)
     }
 
     /* Finally we'll try a left/right effect. */
-    if (supported & SDL_HAPTIC_LEFTRIGHT) {
+    if (supported & SDL_HAPTIC_FEATURE_LEFTRIGHT) {
         SDL_Log("   effect %d: Left/Right\n", nefx);
-        efx[nefx].type = SDL_HAPTIC_LEFTRIGHT;
+        efx[nefx].type = SDL_HAPTIC_EFFECT_LEFTRIGHT;
         efx[nefx].leftright.length = 5000;
         efx[nefx].leftright.large_magnitude = 0x3000;
         efx[nefx].leftright.small_magnitude = 0xFFFF;
@@ -312,53 +312,56 @@ HapticPrintSupported(SDL_Haptic *ptr)
     supported = SDL_HapticQuery(ptr);
     SDL_Log("   Supported effects [%d effects, %d playing]:\n",
             SDL_HapticNumEffects(ptr), SDL_HapticNumEffectsPlaying(ptr));
-    if (supported & SDL_HAPTIC_CONSTANT) {
+    if (supported & SDL_HAPTIC_FEATURE_CONSTANT) {
         SDL_Log("      constant\n");
     }
-    if (supported & SDL_HAPTIC_SINE) {
+    if (supported & SDL_HAPTIC_FEATURE_SINE) {
         SDL_Log("      sine\n");
     }
-    /* !!! FIXME: put this back when we have more bits in 2.1 */
-    /* if (supported & SDL_HAPTIC_SQUARE)
-        SDL_Log("      square\n"); */
-    if (supported & SDL_HAPTIC_TRIANGLE) {
+    if (supported & SDL_HAPTIC_FEATURE_SQUARE) {
+        SDL_Log("      square\n");
+    }
+    if (supported & SDL_HAPTIC_FEATURE_TRIANGLE) {
         SDL_Log("      triangle\n");
     }
-    if (supported & SDL_HAPTIC_SAWTOOTHUP) {
+    if (supported & SDL_HAPTIC_FEATURE_SAWTOOTHUP) {
         SDL_Log("      sawtoothup\n");
     }
-    if (supported & SDL_HAPTIC_SAWTOOTHDOWN) {
+    if (supported & SDL_HAPTIC_FEATURE_SAWTOOTHDOWN) {
         SDL_Log("      sawtoothdown\n");
     }
-    if (supported & SDL_HAPTIC_RAMP) {
+    if (supported & SDL_HAPTIC_FEATURE_SQUARE) {
+        SDL_Log("      square\n");
+    }
+    if (supported & SDL_HAPTIC_FEATURE_RAMP) {
         SDL_Log("      ramp\n");
     }
-    if (supported & SDL_HAPTIC_FRICTION) {
+    if (supported & SDL_HAPTIC_FEATURE_FRICTION) {
         SDL_Log("      friction\n");
     }
-    if (supported & SDL_HAPTIC_SPRING) {
+    if (supported & SDL_HAPTIC_FEATURE_SPRING) {
         SDL_Log("      spring\n");
     }
-    if (supported & SDL_HAPTIC_DAMPER) {
+    if (supported & SDL_HAPTIC_FEATURE_DAMPER) {
         SDL_Log("      damper\n");
     }
-    if (supported & SDL_HAPTIC_INERTIA) {
+    if (supported & SDL_HAPTIC_FEATURE_INERTIA) {
         SDL_Log("      inertia\n");
     }
-    if (supported & SDL_HAPTIC_CUSTOM) {
+    if (supported & SDL_HAPTIC_FEATURE_CUSTOM) {
         SDL_Log("      custom\n");
     }
-    if (supported & SDL_HAPTIC_LEFTRIGHT) {
+    if (supported & SDL_HAPTIC_FEATURE_LEFTRIGHT) {
         SDL_Log("      left/right\n");
     }
     SDL_Log("   Supported capabilities:\n");
-    if (supported & SDL_HAPTIC_GAIN) {
+    if (supported & SDL_HAPTIC_FEATURE_GAIN) {
         SDL_Log("      gain\n");
     }
-    if (supported & SDL_HAPTIC_AUTOCENTER) {
+    if (supported & SDL_HAPTIC_FEATURE_AUTOCENTER) {
         SDL_Log("      autocenter\n");
     }
-    if (supported & SDL_HAPTIC_STATUS) {
+    if (supported & SDL_HAPTIC_FEATURE_STATUS) {
         SDL_Log("      status\n");
     }
 }


### PR DESCRIPTION
This adds back in the SQUARE haptic effect in a binary compatible way by splitting the supported feature bitmap defines for the effect type defines. If accepted, I will port if forward to SDL3 too.

## Description

In the [SDL_haptic.h header file](https://github.com/libsdl-org/SDL/blob/6620913/include/SDL_haptic.h#L174C1-L187C1) it says
```
/**
 *  Left/Right effect supported.
 *
 *  Haptic effect for direct control over high/low frequency motors.
 *
 *  \sa SDL_HapticLeftRight
 * \warning this value was SDL_HAPTIC_SQUARE right before 2.0.0 shipped. Sorry,
 *          we ran out of bits, and this is important for XInput devices.
 */
#define SDL_HAPTIC_LEFTRIGHT     (1u<<2)

/* !!! FIXME: put this back when we have more bits in 2.1 */
/* #define SDL_HAPTIC_SQUARE     (1<<2) */
```

Extending the [effect `type`](https://github.com/libsdl-org/SDL/blob/6620913/include/SDL_haptic.h#L809C1-L820C1) from `Uint16` to `Uint32`
```
typedef union SDL_HapticEffect
{
    /* Common for all force feedback effects */
    Uint16 type;                    /**< Effect type. */
    SDL_HapticConstant constant;    /**< Constant effect. */
    SDL_HapticPeriodic periodic;    /**< Periodic effect. */
    SDL_HapticCondition condition;  /**< Condition effect. */
    SDL_HapticRamp ramp;            /**< Ramp effect. */
    SDL_HapticLeftRight leftright;  /**< Left/Right effect. */
    SDL_HapticCustom custom;        /**< Custom effect. */
} SDL_HapticEffect;
```
will introduce binary breakage though as these structures are exposed to and initialized by user code.

A `Uint16`  is plenty sufficient to encode many types though as it can on 65536 unique values. The only reason it looks like we are currently out of space is we are restricting each type to be identified by a different bit so we can use the same set of defines for the features bitmap. Splitting these two uses into separate defines entirely solves the issue.

## Existing Issue(s)

This fixes #8753 is a way that works for both SDL2 and SDL3. I will cherry pick it forward and do another pull for SDL3 if it is accepted.