### PR TITLE
Prevent ASAN warning in SDL_triangle.c

### DIFF
--- a/src/render/software/SDL_triangle.c
+++ b/src/render/software/SDL_triangle.c
@@ -112,10 +112,23 @@ static int is_top_left(const SDL_Point *a, const SDL_Point *b, int is_clockwise)
     return 0;
 }
 
+/* x = (y << FP_BITS) */
+/* prevent runtime error: left shift of negative value */
+#define PRECOMP(x, y)               \
+        val = y;                    \
+        if (val >= 0) {             \
+            x = val << FP_BITS;     \
+        } else {                    \
+            val *= -1;              \
+            x = val << FP_BITS;     \
+            x *= -1;                \
+        }
+
 void trianglepoint_2_fixedpoint(SDL_Point *a)
 {
-    a->x <<= FP_BITS;
-    a->y <<= FP_BITS;
+    int val;
+    PRECOMP(a->x, a->x);
+    PRECOMP(a->y, a->y);
 }
 
 /* bounding rect of three points (in fixed point) */
@@ -297,12 +310,15 @@ int SDL_SW_FillTriangle(SDL_Surface *dst, SDL_Point *d0, SDL_Point *d1, SDL_Poin
     is_clockwise = area > 0;
     area = SDL_abs(area);
 
-    d2d1_y = (d1->y - d2->y) << FP_BITS;
-    d0d2_y = (d2->y - d0->y) << FP_BITS;
-    d1d0_y = (d0->y - d1->y) << FP_BITS;
-    d1d2_x = (d2->x - d1->x) << FP_BITS;
-    d2d0_x = (d0->x - d2->x) << FP_BITS;
-    d0d1_x = (d1->x - d0->x) << FP_BITS;
+    {
+        int val;
+        PRECOMP(d2d1_y, d1->y - d2->y)
+        PRECOMP(d0d2_y, d2->y - d0->y)
+        PRECOMP(d1d0_y, d0->y - d1->y)
+        PRECOMP(d1d2_x, d2->x - d1->x)
+        PRECOMP(d2d0_x, d0->x - d2->x)
+        PRECOMP(d0d1_x, d1->x - d0->x)
+    }
 
     /* Starting point for rendering, at the middle of a pixel */
     {
@@ -564,13 +580,15 @@ int SDL_SW_BlitTriangle(
     is_clockwise = area > 0;
     area = SDL_abs(area);
 
-    d2d1_y = (d1->y - d2->y) << FP_BITS;
-    d0d2_y = (d2->y - d0->y) << FP_BITS;
-    d1d0_y = (d0->y - d1->y) << FP_BITS;
-
-    d1d2_x = (d2->x - d1->x) << FP_BITS;
-    d2d0_x = (d0->x - d2->x) << FP_BITS;
-    d0d1_x = (d1->x - d0->x) << FP_BITS;
+    {
+        int val;
+        PRECOMP(d2d1_y, d1->y - d2->y)
+        PRECOMP(d0d2_y, d2->y - d0->y)
+        PRECOMP(d1d0_y, d0->y - d1->y)
+        PRECOMP(d1d2_x, d2->x - d1->x)
+        PRECOMP(d2d0_x, d0->x - d2->x)
+        PRECOMP(d0d1_x, d1->x - d0->x)
+    }
 
     s2s0_x = s0->x - s2->x;
     s2s1_x = s1->x - s2->x;

--- a/test/testgeometry.c
+++ b/test/testgeometry.c
@@ -29,6 +29,8 @@ static SDL_Texture **sprites;
 static SDL_BlendMode blendMode = SDL_BLENDMODE_NONE;
 static float angle = 0.0f;
 static int sprite_w, sprite_h;
+static int translate_cx = 0;
+static int translate_cy = 0;
 
 static int done;
 
@@ -92,6 +94,18 @@ static void loop(void)
                     angle += yrel;
                 }
             }
+        } else if (event.type == SDL_EVENT_KEY_DOWN) {
+            if (event.key.keysym.sym == SDLK_LEFT) {
+                translate_cx -= 1;
+            } else if (event.key.keysym.sym == SDLK_RIGHT) {
+                translate_cx += 1;
+            } else if (event.key.keysym.sym == SDLK_UP) {
+                translate_cy -= 1;
+            } else if (event.key.keysym.sym == SDLK_DOWN) {
+                translate_cy += 1;
+            } else {
+                SDLTest_CommonEvent(state, &event, &done);
+            }
         } else {
             SDLTest_CommonEvent(state, &event, &done);
         }
@@ -118,6 +132,9 @@ static void loop(void)
             cx = viewport.x + viewport.w / 2;
             cy = viewport.y + viewport.h / 2;
             d = (viewport.w + viewport.h) / 5.f;
+
+            cx += translate_cx;
+            cy += translate_cy;
 
             a = (angle * 3.1415f) / 180.0f;
             verts[0].position.x = cx + d * SDL_cosf(a);


### PR DESCRIPTION
like SDL_triangle.c:305:30: runtime error: left shift of negative value -672 (even if the value was correctly computed)


