### PR TITLE
Win32 test fixes

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1090,6 +1090,25 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
         if (data->expected_resize) {
             returnCode = 0;
         }
+
+        if (data->floating_rect_pending &&
+            !IsIconic(hwnd) &&
+            !IsZoomed(hwnd) &&
+            (data->window->flags & (SDL_WINDOW_MAXIMIZED | SDL_WINDOW_MINIMIZED)) &&
+            !(data->window->flags & SDL_WINDOW_FULLSCREEN)) {
+            /* If a new floating size is pending, apply it if moving from a fixed-size to floating state. */
+            WINDOWPOS *windowpos = (WINDOWPOS*)lParam;
+            int fx, fy, fw, fh;
+
+            WIN_AdjustWindowRect(data->window, &fx, &fy, &fw, &fh, SDL_WINDOWRECT_FLOATING);
+            windowpos->x = fx;
+            windowpos->y = fy;
+            windowpos->cx = fw;
+            windowpos->cy = fh;
+            windowpos->flags &= ~(SWP_NOSIZE | SWP_NOMOVE);
+
+            data->floating_rect_pending = SDL_FALSE;
+        }
     } break;
 
     case WM_WINDOWPOSCHANGED:

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -829,6 +829,8 @@ int WIN_SetWindowPosition(SDL_VideoDevice *_this, SDL_Window *window)
             return WIN_SetWindowPositionInternal(window,
                                                  window->driverdata->copybits_flag | SWP_NOZORDER | SWP_NOOWNERZORDER |
                                                  SWP_NOACTIVATE, SDL_WINDOWRECT_FLOATING);
+        } else {
+            window->driverdata->floating_rect_pending = SDL_TRUE;
         }
     } else {
         return SDL_UpdateFullscreenMode(window, SDL_TRUE, SDL_TRUE);
@@ -841,6 +843,8 @@ void WIN_SetWindowSize(SDL_VideoDevice *_this, SDL_Window *window)
 {
     if (!(window->flags & (SDL_WINDOW_FULLSCREEN | SDL_WINDOW_MAXIMIZED))) {
         WIN_SetWindowPositionInternal(window, window->driverdata->copybits_flag | SWP_NOMOVE | SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOACTIVATE, SDL_WINDOWRECT_FLOATING);
+    } else {
+        window->driverdata->floating_rect_pending = SDL_TRUE;
     }
 }
 

--- a/src/video/windows/SDL_windowswindow.h
+++ b/src/video/windows/SDL_windowswindow.h
@@ -59,6 +59,7 @@ struct SDL_WindowData
     SDL_bool expected_resize;
     SDL_bool in_border_change;
     SDL_bool in_title_click;
+    SDL_bool floating_rect_pending;
     Uint8 focus_click_pending;
     SDL_bool skip_update_clipcursor;
     Uint64 last_updated_clipcursor;


### PR DESCRIPTION
Recent changes broke a few of the automated tests on Windows. This fixes the video_getSetWindowSize, video_setWindowCenteredOnDisplay, and video_getSetWindowState tests.

Dealing with windows in a docked/tiled state is annoying, as this state is completely internal to windows with no reliable way to detect it (simply relying on size doesn't always work), and doing things like programmatically changing the size on a window in the docked state will result in the immediate size changing, but Windows considers it to still be docked and will snap it back to the original, pre-docked size as soon as it is moved and leaves the docked state. This is all internal Windows behavior, so there's nothing we can really do to fix this. The best we can do, and what these commits implement, is to just let Windows manage things unless the application explicitly requested a new size/position, in which case it will get what it asked for, but Windows can still revert to the old size later when the window leaves the docked state. This is the case without these commits too, but the tests pass now.