### PR TITLE
Make Xbox GDK code public (and fix some GDK code rot)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ VisualC/tests/testscale/sample.bmp
 VisualC/tests/testsprite/icon.bmp
 VisualC/tests/testyuv/testyuv.bmp
 VisualC-GDK/**/Layout
+VisualC-GDK/shaders/*.h
 
 # for Android
 android-project/local.properties

--- a/VisualC-GDK/SDL.sln
+++ b/VisualC-GDK/SDL.sln
@@ -11,6 +11,9 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SDL3_test", "SDL_test\SDL_test.vcxproj", "{DA956FD3-E143-46F2-9FE5-C77BEBC56B1A}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "testcontroller", "tests\testcontroller\testcontroller.vcxproj", "{55812185-D13C-4022-9C81-32E0F4A08305}"
+	ProjectSection(ProjectDependencies) = postProject
+		{DA956FD3-E143-46F2-9FE5-C77BEBC56B1A} = {DA956FD3-E143-46F2-9FE5-C77BEBC56B1A}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "testgdk", "tests\testgdk\testgdk.vcxproj", "{1C9A3F71-35A5-4C56-B292-F4375B3C3649}"
 EndProject

--- a/VisualC-GDK/SDL/SDL.vcxproj
+++ b/VisualC-GDK/SDL/SDL.vcxproj
@@ -170,6 +170,12 @@
       <SubSystem>Windows</SubSystem>
       <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
     </Link>
+    <PreBuildEvent>
+      <Command>$(SolutionDir)\shaders\buildshaders.bat $(SolutionDir)</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Building shader blobs (Xbox Scarlett)</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.XboxOne.x64'">
     <Midl>
@@ -198,6 +204,12 @@
       <SubSystem>Windows</SubSystem>
       <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
     </Link>
+    <PreBuildEvent>
+      <Command>$(SolutionDir)\shaders\buildshaders.bat $(SolutionDir)</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Building shader blobs (Xbox One)</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Desktop.x64'">
     <Midl>
@@ -258,6 +270,12 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
     </Link>
+    <PreBuildEvent>
+      <Command>$(SolutionDir)\shaders\buildshaders.bat $(SolutionDir)</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Building shader blobs (Xbox Scarlett)</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.XboxOne.x64'">
     <Midl>
@@ -287,6 +305,12 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
     </Link>
+    <PreBuildEvent>
+      <Command>$(SolutionDir)\shaders\buildshaders.bat $(SolutionDir)</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Building shader blobs (Xbox One)</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\SDL3\SDL_begin_code.h" />

--- a/VisualC-GDK/SDL/SDL.vcxproj
+++ b/VisualC-GDK/SDL/SDL.vcxproj
@@ -130,7 +130,7 @@
       <DebugInformationFormat>OldStyle</DebugInformationFormat>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <OmitDefaultLibName>true</OmitDefaultLibName>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>SDL_internal.h</PrecompiledHeaderFile>
     </ClCompile>
     <ResourceCompile>
@@ -215,7 +215,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <OmitDefaultLibName>true</OmitDefaultLibName>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>SDL_internal.h</PrecompiledHeaderFile>
     </ClCompile>
     <ResourceCompile>
@@ -457,6 +457,12 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Desktop.x64'">Create</PrecompiledHeader>
       <PrecompiledHeaderOutputFile Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Desktop.x64'">$(IntDir)$(TargetName)_cpp.pch</PrecompiledHeaderOutputFile>
     </ClCompile>
+    <ClCompile Include="..\..\src\filesystem\windows\SDL_sysfilesystem.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.Scarlett.x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.Scarlett.x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.XboxOne.x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.XboxOne.x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\render\direct3d12\SDL_render_d3d12_xbox.cpp">
       <PrecompiledHeaderOutputFile Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Desktop.x64'">$(IntDir)$(TargetName)_cpp.pch</PrecompiledHeaderOutputFile>
       <PrecompiledHeaderOutputFile Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Desktop.x64'">$(IntDir)$(TargetName)_cpp.pch</PrecompiledHeaderOutputFile>
@@ -589,7 +595,10 @@
     <ClCompile Include="..\..\src\events\SDL_touch.c" />
     <ClCompile Include="..\..\src\events\SDL_windowevents.c" />
     <ClCompile Include="..\..\src\file\SDL_rwops.c" />
-    <ClCompile Include="..\..\src\filesystem\gdk\SDL_sysfilesystem.c" />
+    <ClCompile Include="..\..\src\filesystem\gdk\SDL_sysfilesystem.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Desktop.x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Desktop.x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\haptic\dummy\SDL_syshaptic.c" />
     <ClCompile Include="..\..\src\haptic\SDL_haptic.c" />
     <ClCompile Include="..\..\src\haptic\windows\SDL_dinputhaptic.c" />
@@ -733,7 +742,7 @@
     <ClCompile Include="..\..\src\stdlib\SDL_iconv.c" />
     <ClCompile Include="..\..\src\stdlib\SDL_malloc.c" />
     <ClCompile Include="..\..\src\stdlib\SDL_mslibc.c" />
-    <MASM Condition="'$(Platform)'=='x64'" Include="..\..\src\stdlib\SDL_mslibc_x64.masm" >
+    <MASM Condition="'$(Platform)'=='x64'" Include="..\..\src\stdlib\SDL_mslibc_x64.masm">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </MASM>
     <ClCompile Include="..\..\src\stdlib\SDL_qsort.c" />
@@ -776,6 +785,7 @@
     <ClCompile Include="..\..\src\video\SDL_stretch.c" />
     <ClCompile Include="..\..\src\video\SDL_surface.c" />
     <ClCompile Include="..\..\src\video\SDL_video.c" />
+    <ClCompile Include="..\..\src\video\SDL_video_capture.c" />
     <ClCompile Include="..\..\src\video\SDL_video_unsupported.c" />
     <ClCompile Include="..\..\src\video\SDL_vulkan_utils.c" />
     <ClCompile Include="..\..\src\video\SDL_yuv.c" />

--- a/VisualC-GDK/SDL/SDL.vcxproj
+++ b/VisualC-GDK/SDL/SDL.vcxproj
@@ -174,7 +174,7 @@
       <Command>$(SolutionDir)\shaders\buildshaders.bat $(SolutionDir)</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>Building shader blobs (Xbox Scarlett)</Message>
+      <Message>Building shader blobs (Xbox Series)</Message>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.XboxOne.x64'">
@@ -205,7 +205,7 @@
       <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
     </Link>
     <PreBuildEvent>
-      <Command>$(SolutionDir)\shaders\buildshaders.bat $(SolutionDir)</Command>
+      <Command>$(SolutionDir)\shaders\buildshaders.bat $(SolutionDir) one</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Building shader blobs (Xbox One)</Message>
@@ -274,7 +274,7 @@
       <Command>$(SolutionDir)\shaders\buildshaders.bat $(SolutionDir)</Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>Building shader blobs (Xbox Scarlett)</Message>
+      <Message>Building shader blobs (Xbox Series)</Message>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.XboxOne.x64'">
@@ -306,7 +306,7 @@
       <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
     </Link>
     <PreBuildEvent>
-      <Command>$(SolutionDir)\shaders\buildshaders.bat $(SolutionDir)</Command>
+      <Command>$(SolutionDir)\shaders\buildshaders.bat $(SolutionDir) one</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Building shader blobs (Xbox One)</Message>

--- a/VisualC-GDK/SDL/SDL.vcxproj.filters
+++ b/VisualC-GDK/SDL/SDL.vcxproj.filters
@@ -1,1432 +1,434 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="API Headers">
-      <UniqueIdentifier>{395b3af0-33d0-411b-b153-de1676bf1ef8}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="audio">
-      <UniqueIdentifier>{5a3e3167-75be-414f-8947-a5306df372b2}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="atomic">
-      <UniqueIdentifier>{546d9ed1-988e-49d3-b1a5-e5b3d19de6c1}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="core">
-      <UniqueIdentifier>{a56247ff-5108-4960-ba6a-6814fd1554ec}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="core\windows">
-      <UniqueIdentifier>{8880dfad-2a06-4e84-ab6e-6583641ad2d1}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="cpuinfo">
-      <UniqueIdentifier>{2b996a7f-f3e9-4300-a97f-2c907bcd89a9}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="dynapi">
-      <UniqueIdentifier>{5713d682-2bc7-4da4-bcf0-262a98f142eb}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="events">
-      <UniqueIdentifier>{5e27e19f-b3f8-4e2d-b323-b00b2040ec86}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="file">
-      <UniqueIdentifier>{a3ab9cff-8495-4a5c-8af6-27e43199a712}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="filesystem">
-      <UniqueIdentifier>{377061e4-3856-4f05-b916-0d3b360df0f6}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="filesystem\gdk">
-      <UniqueIdentifier>{226a6643-1c65-4c7f-92aa-861313d974bb}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="haptic">
-      <UniqueIdentifier>{ef859522-a7fe-4a00-a511-d6a9896adf5b}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="hidapi">
-      <UniqueIdentifier>{01fd2642-4493-4316-b548-fb829f4c9125}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="joystick">
-      <UniqueIdentifier>{cce7558f-590a-4f0a-ac0d-e579f76e588e}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="libm">
-      <UniqueIdentifier>{7a53c9e4-d4bd-40ed-9265-1625df685121}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="hidapi\hidapi">
-      <UniqueIdentifier>{4c7a051c-ce7c-426c-bf8c-9187827f9052}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="loadso">
-      <UniqueIdentifier>{97e2f79f-311b-42ea-81b2-e801649fdd93}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="loadso\windows">
-      <UniqueIdentifier>{baf97c8c-7e90-41e5-bff8-14051b8d3956}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="locale">
-      <UniqueIdentifier>{45e50d3a-56c9-4352-b811-0c60c49a2431}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="misc">
-      <UniqueIdentifier>{9d86e0ef-d6f6-4db2-bfc5-b3529406fa8d}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="misc\windows">
-      <UniqueIdentifier>{b35fa13c-6ed2-4680-8c56-c7d71b76ceab}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="locale\windows">
-      <UniqueIdentifier>{61b61b31-9e26-4171-a3bb-b969f1889726}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="audio\directsound">
-      <UniqueIdentifier>{f63aa216-6ee7-4143-90d3-32be3787f276}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="audio\disk">
-      <UniqueIdentifier>{90bee923-89df-417f-a6c3-3e260a7dd54d}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="audio\dummy">
-      <UniqueIdentifier>{4c8ad943-c2fb-4014-9ca3-041e0ad08426}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="audio\wasapi">
-      <UniqueIdentifier>{3d68ae70-a9ff-46cf-be69-069f0b02aca0}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="haptic\windows">
-      <UniqueIdentifier>{ebc2fca3-3c26-45e3-815e-3e0581d5e226}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="haptic\dummy">
-      <UniqueIdentifier>{47c445a2-7014-4e15-9660-7c89a27dddcf}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="joystick\dummy">
-      <UniqueIdentifier>{d008487d-6ed0-4251-848b-79a68e3c1459}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="joystick\hidapi">
-      <UniqueIdentifier>{c9e8273e-13ae-47dc-bef8-8ad8e64c9a3d}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="joystick\windows">
-      <UniqueIdentifier>{0b8e136d-56ae-47e7-9981-e863a57ac616}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="joystick\virtual">
-      <UniqueIdentifier>{bf3febd3-9328-43e8-b196-0fd3be8177dd}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="video">
-      <UniqueIdentifier>{1a62dc68-52d2-4c07-9d81-d94dfe1d0d12}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="video\dummy">
-      <UniqueIdentifier>{e9f01b22-34b3-4380-ade6-0e96c74e9c90}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="video\yuv2rgb">
-      <UniqueIdentifier>{f674f22f-7841-4f3a-974e-c36b2d4823fc}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="video\windows">
-      <UniqueIdentifier>{d7ad92de-4e55-4202-9b2b-1bd9a35fe4dc}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="timer">
-      <UniqueIdentifier>{8311d79d-9ad5-4369-99fe-b2fb2659d402}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="timer\windows">
-      <UniqueIdentifier>{6c4dfb80-fdf9-497c-a6ff-3cd8f22efde9}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="thread">
-      <UniqueIdentifier>{4810e35c-33cb-4da2-bfaf-452da20d3c9a}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="thread\windows">
-      <UniqueIdentifier>{2cf93f1d-81fd-4bdc-998c-5e2fa43988bc}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="thread\generic">
-      <UniqueIdentifier>{5752b7ab-2344-4f38-95ab-b5d3bc150315}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="stdlib">
-      <UniqueIdentifier>{7a0eae3d-f113-4914-b926-6816d1929250}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="sensor">
-      <UniqueIdentifier>{ee602cbf-96a2-4b0b-92a9-51d38a727411}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="sensor\dummy">
-      <UniqueIdentifier>{a812185b-9060-4a1c-8431-be4f66894626}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="sensor\windows">
-      <UniqueIdentifier>{31c16cdf-adc4-4950-8293-28ba530f3882}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="render">
-      <UniqueIdentifier>{add61b53-8144-47d6-bd67-3420a87c4905}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="render\direct3d">
-      <UniqueIdentifier>{e7cdcf36-b462-49c7-98b7-07ea7b3687f4}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="render\direct3d11">
-      <UniqueIdentifier>{82588eef-dcaa-4f69-b2a9-e675940ce54c}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="render\opengl">
-      <UniqueIdentifier>{560239c3-8fa1-4d23-a81a-b8408b2f7d3f}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="render\opengles2">
-      <UniqueIdentifier>{81711059-7575-4ece-9e68-333b63e992c4}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="render\software">
-      <UniqueIdentifier>{1e44970f-7535-4bfb-b8a5-ea0cea0349e0}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="power">
-      <UniqueIdentifier>{1dd91224-1176-492b-a2cb-e26153394db0}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="power\windows">
-      <UniqueIdentifier>{e3ecfe50-cf22-41d3-8983-2fead5164b47}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="video\khronos">
-      <UniqueIdentifier>{5521d22f-1e52-47a6-8c52-06a3b6bdefd7}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="video\khronos\vulkan">
-      <UniqueIdentifier>{4755f3a6-49ac-46d6-86be-21f5c21f2197}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="render\direct3d12">
-      <UniqueIdentifier>{f48c2b17-1bee-4fec-a7c8-24cf619abe08}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="core\gdk">
-      <UniqueIdentifier>{3ab60a46-e18e-450a-a916-328fb8547e59}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="video\gdk">
-      <UniqueIdentifier>{3ad16a8a-0ed8-439c-a771-383af2e2867f}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="main">
-      <UniqueIdentifier>{00002ddb6c5ea921181bf32d50e40000}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="main\generic">
-      <UniqueIdentifier>{00000a808f8ba6b489985f82a4e80000}</UniqueIdentifier>
-    </Filter>
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="..\..\include\SDL3\SDL_begin_code.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_close_code.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_assert.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_atomic.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_audio.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_bits.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_blendmode.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_clipboard.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_copying.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_cpuinfo.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_egl.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_endian.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_error.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_events.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_filesystem.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_gamepad.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_guid.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_haptic.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_hints.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_hidapi.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_joystick.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_keyboard.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_keycode.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_loadso.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_locale.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_log.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_main.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_messagebox.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_mouse.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_mutex.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_opengl.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_opengl_glext.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_opengles.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_opengles2.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_opengles2_gl2.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_opengles2_gl2ext.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_opengles2_gl2platform.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_opengles2_khrplatform.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_pen.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_pixels.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_platform.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_platform_defines.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_power.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_properties.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_quit.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_rect.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_render.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_revision.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_rwops.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_scancode.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_sensor.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_stdinc.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_surface.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_system.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_test.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_test_assert.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_test_common.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_test_compare.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_test_crc32.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_test_font.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_test_fuzzer.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_test_harness.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_test_log.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_test_md5.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_test_random.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_thread.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_timer.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_touch.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_types.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_version.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_video.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_vulkan.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\main\SDL_main_callbacks.h">
-      <Filter>main</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\SDL_error_c.h" />
-    <ClInclude Include="..\..\src\SDL_hashtable.h" />
-    <ClInclude Include="..\..\src\SDL_list.h" />
-    <ClInclude Include="..\..\include\SDL3\SDL_metal.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_misc.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\SDL3\SDL_test_memory.h">
-      <Filter>API Headers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\audio\SDL_audio_c.h">
-      <Filter>audio</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\audio\SDL_audiodev_c.h">
-      <Filter>audio</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\audio\SDL_wave.h">
-      <Filter>audio</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\audio\SDL_sysaudio.h">
-      <Filter>audio</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\audio\SDL_audioqueue.h">
-      <Filter>audio</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\audio\SDL_audioresample.h">
-      <Filter>audio</Filter>
-    </ClInclude>    
-    <ClInclude Include="..\..\src\core\windows\SDL_hid.h">
-      <Filter>core\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\core\windows\SDL_immdevice.h">
-      <Filter>core\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\core\windows\SDL_windows.h">
-      <Filter>core\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\core\windows\SDL_xinput.h">
-      <Filter>core\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\core\windows\SDL_directx.h">
-      <Filter>core\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\dynapi\SDL_dynapi.h">
-      <Filter>dynapi</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\dynapi\SDL_dynapi_overrides.h">
-      <Filter>dynapi</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\dynapi\SDL_dynapi_procs.h">
-      <Filter>dynapi</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\events\SDL_clipboardevents_c.h">
-      <Filter>events</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\events\SDL_displayevents_c.h">
-      <Filter>events</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\events\SDL_dropevents_c.h">
-      <Filter>events</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\events\SDL_events_c.h">
-      <Filter>events</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\events\SDL_keyboard_c.h">
-      <Filter>events</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\events\SDL_mouse_c.h">
-      <Filter>events</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\events\SDL_touch_c.h">
-      <Filter>events</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\events\SDL_windowevents_c.h">
-      <Filter>events</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\events\blank_cursor.h">
-      <Filter>events</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\events\default_cursor.h">
-      <Filter>events</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\events\scancodes_windows.h">
-      <Filter>events</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\haptic\SDL_syshaptic.h">
-      <Filter>haptic</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\haptic\SDL_haptic_c.h">
-      <Filter>haptic</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\joystick\SDL_gamepad_c.h">
-      <Filter>joystick</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\joystick\SDL_gamepad_db.h">
-      <Filter>joystick</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\joystick\SDL_joystick_c.h">
-      <Filter>joystick</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\joystick\SDL_steam_virtual_gamepad.h">
-      <Filter>joystick</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\joystick\SDL_sysjoystick.h">
-      <Filter>joystick</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\joystick\controller_type.h">
-      <Filter>joystick</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\joystick\usb_ids.h">
-      <Filter>joystick</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\libm\math_libm.h">
-      <Filter>libm</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\libm\math_private.h">
-      <Filter>libm</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\hidapi\hidapi\hidapi.h">
-      <Filter>hidapi\hidapi</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\locale\SDL_syslocale.h">
-      <Filter>locale</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\misc\SDL_sysurl.h">
-      <Filter>misc</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\audio\directsound\SDL_directsound.h">
-      <Filter>audio\directsound</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\audio\disk\SDL_diskaudio.h">
-      <Filter>audio\disk</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\audio\dummy\SDL_dummyaudio.h">
-      <Filter>audio\dummy</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\audio\wasapi\SDL_wasapi.h">
-      <Filter>audio\wasapi</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\haptic\windows\SDL_dinputhaptic_c.h">
-      <Filter>haptic\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\haptic\windows\SDL_windowshaptic_c.h">
-      <Filter>haptic\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\haptic\windows\SDL_xinputhaptic_c.h">
-      <Filter>haptic\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\joystick\hidapi\SDL_hidapijoystick_c.h">
-      <Filter>joystick\hidapi</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\joystick\hidapi\SDL_hidapi_rumble.h">
-      <Filter>joystick\hidapi</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\joystick\windows\SDL_dinputjoystick_c.h">
-      <Filter>joystick\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\joystick\windows\SDL_rawinputjoystick_c.h">
-      <Filter>joystick\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\joystick\windows\SDL_windowsjoystick_c.h">
-      <Filter>joystick\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\joystick\windows\SDL_xinputjoystick_c.h">
-      <Filter>joystick\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\joystick\virtual\SDL_virtualjoystick_c.h">
-      <Filter>joystick\virtual</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\SDL_RLEaccel_c.h">
-      <Filter>video</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\SDL_blit.h">
-      <Filter>video</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\SDL_blit_auto.h">
-      <Filter>video</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\SDL_blit_copy.h">
-      <Filter>video</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\SDL_blit_slow.h">
-      <Filter>video</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\SDL_clipboard_c.h">
-      <Filter>video</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\SDL_pixels_c.h">
-      <Filter>video</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\SDL_rect_c.h">
-      <Filter>video</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\SDL_sysvideo.h">
-      <Filter>video</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\SDL_egl_c.h">
-      <Filter>video</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\SDL_yuv_c.h">
-      <Filter>video</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\SDL_vulkan_internal.h">
-      <Filter>video</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\dummy\SDL_nullevents_c.h">
-      <Filter>video\dummy</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\dummy\SDL_nullframebuffer_c.h">
-      <Filter>video\dummy</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\dummy\SDL_nullvideo.h">
-      <Filter>video\dummy</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\yuv2rgb\yuv_rgb.h">
-      <Filter>video\yuv2rgb</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\yuv2rgb\yuv_rgb_sse_func.h">
-      <Filter>video\yuv2rgb</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\yuv2rgb\yuv_rgb_std_func.h">
-      <Filter>video\yuv2rgb</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\windows\SDL_windowsclipboard.h">
-      <Filter>video\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\windows\SDL_windowsevents.h">
-      <Filter>video\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\windows\SDL_windowsframebuffer.h">
-      <Filter>video\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\windows\SDL_windowskeyboard.h">
-      <Filter>video\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\windows\SDL_windowsmessagebox.h">
-      <Filter>video\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\windows\SDL_windowsmodes.h">
-      <Filter>video\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\windows\SDL_windowsmouse.h">
-      <Filter>video\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\windows\SDL_windowsopengl.h">
-      <Filter>video\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\windows\SDL_windowsvideo.h">
-      <Filter>video\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\windows\SDL_windowsvulkan.h">
-      <Filter>video\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\windows\SDL_windowswindow.h">
-      <Filter>video\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\windows\wmmsg.h">
-      <Filter>video\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\windows\SDL_msctf.h">
-      <Filter>video\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\windows\SDL_windowsopengles.h">
-      <Filter>video\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\timer\SDL_timer_c.h">
-      <Filter>timer</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\thread\SDL_thread_c.h">
-      <Filter>thread</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\thread\SDL_systhread.h">
-      <Filter>thread</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\thread\windows\SDL_sysmutex_c.h">
-      <Filter>thread\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\thread\windows\SDL_systhread_c.h">
-      <Filter>thread\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\thread\generic\SDL_syscond_c.h">
-      <Filter>thread\generic</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\sensor\SDL_sensor_c.h">
-      <Filter>sensor</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\sensor\SDL_syssensor.h">
-      <Filter>sensor</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\sensor\dummy\SDL_dummysensor.h">
-      <Filter>sensor\dummy</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\sensor\windows\SDL_windowssensor.h">
-      <Filter>sensor\windows</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\render\SDL_d3dmath.h">
-      <Filter>render</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\render\SDL_sysrender.h">
-      <Filter>render</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\render\SDL_yuv_sw_c.h">
-      <Filter>render</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\render\direct3d\SDL_shaders_d3d.h">
-      <Filter>render\direct3d</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\render\direct3d11\SDL_shaders_d3d11.h">
-      <Filter>render\direct3d11</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\render\opengl\SDL_glfuncs.h">
-      <Filter>render\opengl</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\render\opengl\SDL_shaders_gl.h">
-      <Filter>render\opengl</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\render\opengles2\SDL_shaders_gles2.h">
-      <Filter>render\opengles2</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\render\opengles2\SDL_gles2funcs.h">
-      <Filter>render\opengles2</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\render\software\SDL_blendfillrect.h">
-      <Filter>render\software</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\render\software\SDL_blendline.h">
-      <Filter>render\software</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\render\software\SDL_blendpoint.h">
-      <Filter>render\software</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\render\software\SDL_draw.h">
-      <Filter>render\software</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\render\software\SDL_drawline.h">
-      <Filter>render\software</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\render\software\SDL_drawpoint.h">
-      <Filter>render\software</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\render\software\SDL_render_sw_c.h">
-      <Filter>render\software</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\render\software\SDL_rotate.h">
-      <Filter>render\software</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\render\software\SDL_triangle.h">
-      <Filter>render\software</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\power\SDL_syspower.h">
-      <Filter>power</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_xlib_xrandr.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vk_icd.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vk_layer.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vk_platform.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vk_sdk_platform.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan.hpp">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_android.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_beta.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_core.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_directfb.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_fuchsia.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_ggp.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_ios.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_macos.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_metal.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_vi.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_wayland.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_win32.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_xcb.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_xlib.h">
-      <Filter>video\khronos\vulkan</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\SDL_assert_c.h" />
-    <ClInclude Include="..\..\src\SDL_hints_c.h" />
-    <ClInclude Include="..\..\src\SDL_internal.h" />
-    <ClInclude Include="..\..\src\SDL_log_c.h" />
-    <ClInclude Include="..\..\src\SDL_properties_c.h" />
-    <ClInclude Include="..\..\src\render\direct3d12\SDL_shaders_d3d12.h">
-      <Filter>render\direct3d12</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\hidapi\SDL_hidapi_c.h" />
-    <ClInclude Include="..\..\src\core\gdk\SDL_gdk.h">
-      <Filter>core\gdk</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\render\direct3d12\SDL_render_d3d12_xbox.h">
-      <Filter>render\direct3d12</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\video\gdk\SDL_gdktextinput.h">
-      <Filter>video\gdk</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\thread\generic\SDL_sysrwlock_c.h">
-      <Filter>thread\generic</Filter>
-    </ClInclude>
-  </ItemGroup>
-  <ItemGroup>
+    <ClCompile Include="..\..\src\core\gdk\SDL_gdk.cpp" />
+    <ClCompile Include="..\..\src\core\windows\pch.c" />
+    <ClCompile Include="..\..\src\core\windows\pch_cpp.cpp" />
+    <ClCompile Include="..\..\src\render\direct3d12\SDL_render_d3d12_xbox.cpp" />
+    <ClCompile Include="..\..\src\render\direct3d12\SDL_shaders_d3d12_xboxone.cpp" />
+    <ClCompile Include="..\..\src\render\direct3d12\SDL_shaders_d3d12_xboxseries.cpp" />
+    <ClCompile Include="..\..\src\main\generic\SDL_sysmain_callbacks.c" />
+    <ClCompile Include="..\..\src\main\SDL_main_callbacks.c" />
+    <ClCompile Include="..\..\src\SDL_guid.c" />
+    <ClCompile Include="..\..\src\atomic\SDL_atomic.c" />
+    <ClCompile Include="..\..\src\atomic\SDL_spinlock.c" />
+    <ClCompile Include="..\..\src\audio\directsound\SDL_directsound.c" />
+    <ClCompile Include="..\..\src\audio\disk\SDL_diskaudio.c" />
+    <ClCompile Include="..\..\src\audio\dummy\SDL_dummyaudio.c" />
+    <ClCompile Include="..\..\src\audio\SDL_audio.c" />
+    <ClCompile Include="..\..\src\audio\SDL_audiocvt.c" />
+    <ClCompile Include="..\..\src\audio\SDL_audiodev.c" />
+    <ClCompile Include="..\..\src\audio\SDL_audiotypecvt.c" />
+    <ClCompile Include="..\..\src\audio\SDL_audioqueue.c" />
+    <ClCompile Include="..\..\src\audio\SDL_audioresample.c" />
+    <ClCompile Include="..\..\src\audio\SDL_mixer.c" />
+    <ClCompile Include="..\..\src\audio\SDL_wave.c" />
     <ClCompile Include="..\..\src\audio\wasapi\SDL_wasapi.c" />
-    <ClCompile Include="..\..\src\main\generic\SDL_sysmain_callbacks.c">
-      <Filter>main\generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\main\SDL_main_callbacks.c">
-      <Filter>main</Filter>
-    </ClCompile>
+    <ClCompile Include="..\..\src\audio\wasapi\SDL_wasapi_win32.c" />
+    <ClCompile Include="..\..\src\core\SDL_core_unsupported.c" />
+    <ClCompile Include="..\..\src\core\SDL_runapp.c" />
+    <ClCompile Include="..\..\src\core\windows\SDL_hid.c" />
+    <ClCompile Include="..\..\src\core\windows\SDL_immdevice.c" />
+    <ClCompile Include="..\..\src\core\windows\SDL_windows.c" />
+    <ClCompile Include="..\..\src\core\windows\SDL_xinput.c" />
+    <ClCompile Include="..\..\src\cpuinfo\SDL_cpuinfo.c" />
+    <ClCompile Include="..\..\src\dynapi\SDL_dynapi.c" />
+    <ClCompile Include="..\..\src\events\SDL_clipboardevents.c" />
+    <ClCompile Include="..\..\src\events\SDL_displayevents.c" />
+    <ClCompile Include="..\..\src\events\SDL_dropevents.c" />
+    <ClCompile Include="..\..\src\events\SDL_events.c" />
+    <ClCompile Include="..\..\src\events\SDL_keyboard.c" />
+    <ClCompile Include="..\..\src\events\SDL_mouse.c" />
+    <ClCompile Include="..\..\src\events\SDL_pen.c" />
+    <ClCompile Include="..\..\src\events\SDL_quit.c" />
+    <ClCompile Include="..\..\src\events\SDL_touch.c" />
+    <ClCompile Include="..\..\src\events\SDL_windowevents.c" />
+    <ClCompile Include="..\..\src\file\SDL_rwops.c" />
+    <ClCompile Include="..\..\src\filesystem\gdk\SDL_sysfilesystem.cpp" />
+    <ClCompile Include="..\..\src\haptic\dummy\SDL_syshaptic.c" />
+    <ClCompile Include="..\..\src\haptic\SDL_haptic.c" />
+    <ClCompile Include="..\..\src\haptic\windows\SDL_dinputhaptic.c" />
+    <ClCompile Include="..\..\src\haptic\windows\SDL_windowshaptic.c" />
+    <ClCompile Include="..\..\src\haptic\windows\SDL_xinputhaptic.c" />
+    <ClCompile Include="..\..\src\hidapi\SDL_hidapi.c" />
+    <ClCompile Include="..\..\src\joystick\controller_type.c" />
+    <ClCompile Include="..\..\src\joystick\dummy\SDL_sysjoystick.c" />
+    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapijoystick.c" />
+    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_combined.c" />
+    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_gamecube.c" />
+    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_luna.c" />
+    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_ps3.c" />
+    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_ps4.c" />
+    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_ps5.c" />
+    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_rumble.c" />
+    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_shield.c" />
+    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_stadia.c" />
+    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_steam.c" />
+    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_steamdeck.c" />
+    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_switch.c" />
+    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_wii.c" />
+    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_xbox360.c" />
+    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_xbox360w.c" />
+    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_xboxone.c" />
+    <ClCompile Include="..\..\src\joystick\SDL_gamepad.c" />
+    <ClCompile Include="..\..\src\joystick\SDL_joystick.c" />
+    <ClCompile Include="..\..\src\joystick\SDL_steam_virtual_gamepad.c" />
+    <ClCompile Include="..\..\src\joystick\virtual\SDL_virtualjoystick.c" />
+    <ClCompile Include="..\..\src\joystick\windows\SDL_dinputjoystick.c" />
+    <ClCompile Include="..\..\src\joystick\windows\SDL_rawinputjoystick.c" />
+    <ClCompile Include="..\..\src\joystick\windows\SDL_windowsjoystick.c" />
+    <ClCompile Include="..\..\src\joystick\windows\SDL_windows_gaming_input.c" />
+    <ClCompile Include="..\..\src\joystick\windows\SDL_xinputjoystick.c" />
+    <ClCompile Include="..\..\src\libm\e_atan2.c" />
+    <ClCompile Include="..\..\src\libm\e_exp.c" />
+    <ClCompile Include="..\..\src\libm\e_fmod.c" />
+    <ClCompile Include="..\..\src\libm\e_log.c" />
+    <ClCompile Include="..\..\src\libm\e_log10.c" />
+    <ClCompile Include="..\..\src\libm\e_pow.c" />
+    <ClCompile Include="..\..\src\libm\e_rem_pio2.c" />
+    <ClCompile Include="..\..\src\libm\e_sqrt.c" />
+    <ClCompile Include="..\..\src\libm\k_cos.c" />
+    <ClCompile Include="..\..\src\libm\k_rem_pio2.c" />
+    <ClCompile Include="..\..\src\libm\k_sin.c" />
+    <ClCompile Include="..\..\src\libm\k_tan.c" />
+    <ClCompile Include="..\..\src\libm\s_atan.c" />
+    <ClCompile Include="..\..\src\libm\s_copysign.c" />
+    <ClCompile Include="..\..\src\libm\s_cos.c" />
+    <ClCompile Include="..\..\src\libm\s_fabs.c" />
+    <ClCompile Include="..\..\src\libm\s_floor.c" />
+    <ClCompile Include="..\..\src\libm\s_modf.c" />
+    <ClCompile Include="..\..\src\libm\s_scalbn.c" />
+    <ClCompile Include="..\..\src\libm\s_sin.c" />
+    <ClCompile Include="..\..\src\libm\s_tan.c" />
+    <ClCompile Include="..\..\src\loadso\windows\SDL_sysloadso.c" />
+    <ClCompile Include="..\..\src\locale\SDL_locale.c" />
+    <ClCompile Include="..\..\src\locale\windows\SDL_syslocale.c" />
+    <ClCompile Include="..\..\src\misc\SDL_url.c" />
+    <ClCompile Include="..\..\src\misc\windows\SDL_sysurl.c" />
+    <ClCompile Include="..\..\src\power\SDL_power.c" />
+    <ClCompile Include="..\..\src\power\windows\SDL_syspower.c" />
+    <ClCompile Include="..\..\src\render\direct3d11\SDL_shaders_d3d11.c" />
+    <ClCompile Include="..\..\src\render\direct3d12\SDL_render_d3d12.c" />
+    <ClCompile Include="..\..\src\render\direct3d12\SDL_shaders_d3d12.c" />
+    <ClCompile Include="..\..\src\render\direct3d\SDL_render_d3d.c" />
+    <ClCompile Include="..\..\src\render\direct3d11\SDL_render_d3d11.c" />
+    <ClCompile Include="..\..\src\render\direct3d\SDL_shaders_d3d.c" />
+    <ClCompile Include="..\..\src\render\opengl\SDL_render_gl.c" />
+    <ClCompile Include="..\..\src\render\opengl\SDL_shaders_gl.c" />
+    <ClCompile Include="..\..\src\render\opengles2\SDL_render_gles2.c" />
+    <ClCompile Include="..\..\src\render\opengles2\SDL_shaders_gles2.c" />
+    <ClCompile Include="..\..\src\render\SDL_d3dmath.c" />
+    <ClCompile Include="..\..\src\render\SDL_render.c" />
+    <ClCompile Include="..\..\src\render\SDL_render_unsupported.c" />
+    <ClCompile Include="..\..\src\render\SDL_yuv_sw.c" />
+    <ClCompile Include="..\..\src\render\software\SDL_blendfillrect.c" />
+    <ClCompile Include="..\..\src\render\software\SDL_blendline.c" />
+    <ClCompile Include="..\..\src\render\software\SDL_blendpoint.c" />
+    <ClCompile Include="..\..\src\render\software\SDL_drawline.c" />
+    <ClCompile Include="..\..\src\render\software\SDL_drawpoint.c" />
+    <ClCompile Include="..\..\src\render\software\SDL_render_sw.c" />
+    <ClCompile Include="..\..\src\render\software\SDL_rotate.c" />
+    <ClCompile Include="..\..\src\render\software\SDL_triangle.c" />
     <ClCompile Include="..\..\src\SDL.c" />
     <ClCompile Include="..\..\src\SDL_assert.c" />
+    <ClCompile Include="..\..\src\SDL_list.c" />
     <ClCompile Include="..\..\src\SDL_error.c" />
-    <ClCompile Include="..\..\src\SDL_guid.c" />
     <ClCompile Include="..\..\src\SDL_hashtable.c" />
     <ClCompile Include="..\..\src\SDL_hints.c" />
-    <ClCompile Include="..\..\src\SDL_list.c" />
+    <ClCompile Include="..\..\src\SDL_log.c" />
     <ClCompile Include="..\..\src\SDL_properties.c" />
     <ClCompile Include="..\..\src\SDL_utils.c" />
-    <ClCompile Include="..\..\src\audio\SDL_audio.c">
-      <Filter>audio</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\audio\SDL_audiocvt.c">
-      <Filter>audio</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\audio\SDL_audiodev.c">
-      <Filter>audio</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\audio\SDL_audiotypecvt.c">
-      <Filter>audio</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\audio\SDL_audioqueue.c">
-      <Filter>audio</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\audio\SDL_audioresample.c">
-      <Filter>audio</Filter>
-    </ClCompile>    
-    <ClCompile Include="..\..\src\audio\SDL_wave.c">
-      <Filter>audio</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\audio\SDL_mixer.c">
-      <Filter>audio</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\atomic\SDL_atomic.c">
-      <Filter>atomic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\atomic\SDL_spinlock.c">
-      <Filter>atomic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\core\SDL_core_unsupported.c">
-      <Filter>core</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\core\SDL_runapp.c">
-      <Filter>core</Filter>
-    </ClCompile>
-    <ClCompile Inclu
-    <ClCompile Include="..\..\src\core\windows\SDL_hid.c">
-      <Filter>core\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\core\windows\SDL_immdevice.c">
-      <Filter>core\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\core\windows\SDL_windows.c">
-      <Filter>core\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\core\windows\SDL_xinput.c">
-      <Filter>core\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\cpuinfo\SDL_cpuinfo.c">
-      <Filter>cpuinfo</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\dynapi\SDL_dynapi.c">
-      <Filter>dynapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\events\SDL_clipboardevents.c">
-      <Filter>events</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\events\SDL_displayevents.c">
-      <Filter>events</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\events\SDL_dropevents.c">
-      <Filter>events</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\events\SDL_events.c">
-      <Filter>events</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\events\SDL_keyboard.c">
-      <Filter>events</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\events\SDL_mouse.c">
-      <Filter>events</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\events\SDL_pen.c">
-      <Filter>events</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\events\SDL_quit.c">
-      <Filter>events</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\events\SDL_touch.c">
-      <Filter>events</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\events\SDL_windowevents.c">
-      <Filter>events</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\file\SDL_rwops.c">
-      <Filter>file</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\filesystem\gdk\SDL_sysfilesystem.c">
-      <Filter>filesystem\gdk</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\haptic\SDL_haptic.c">
-      <Filter>haptic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\hidapi\SDL_hidapi.c">
-      <Filter>hidapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\controller_type.c">
-      <Filter>joystick</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\SDL_gamepad.c">
-      <Filter>joystick</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\SDL_joystick.c">
-      <Filter>joystick</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\SDL_steam_virtual_gamepad.c">
-      <Filter>joystick</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\e_atan2.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\e_exp.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\e_fmod.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\e_log.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\e_log10.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\e_pow.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\e_sqrt.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\e_rem_pio2.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\k_cos.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\k_rem_pio2.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\k_sin.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\k_tan.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\s_atan.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\s_copysign.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\s_cos.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\s_fabs.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\s_floor.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\s_modf.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\s_scalbn.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\s_sin.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\libm\s_tan.c">
-      <Filter>libm</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\loadso\windows\SDL_sysloadso.c">
-      <Filter>loadso\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\misc\SDL_url.c">
-      <Filter>misc</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\misc\windows\SDL_sysurl.c">
-      <Filter>misc\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\locale\windows\SDL_syslocale.c">
-      <Filter>locale\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\locale\SDL_locale.c">
-      <Filter>locale</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\audio\directsound\SDL_directsound.c">
-      <Filter>audio\directsound</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\audio\disk\SDL_diskaudio.c">
-      <Filter>audio\disk</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\audio\dummy\SDL_dummyaudio.c">
-      <Filter>audio\dummy</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\audio\wasapi\SDL_wasapi_win32.c">
-      <Filter>audio\wasapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\audio\wasapi\SDL_wasapi.c">
-      <Filter>audio\wasapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\haptic\windows\SDL_dinputhaptic.c">
-      <Filter>haptic\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\haptic\windows\SDL_windowshaptic.c">
-      <Filter>haptic\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\haptic\windows\SDL_xinputhaptic.c">
-      <Filter>haptic\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\haptic\dummy\SDL_syshaptic.c">
-      <Filter>haptic\dummy</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\dummy\SDL_sysjoystick.c">
-      <Filter>joystick\dummy</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_combined.c">
-      <Filter>joystick\hidapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_gamecube.c">
-      <Filter>joystick\hidapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_luna.c">
-      <Filter>joystick\hidapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_ps3.c">
-      <Filter>joystick\hidapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_ps4.c">
-      <Filter>joystick\hidapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_ps5.c">
-      <Filter>joystick\hidapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_rumble.c">
-      <Filter>joystick\hidapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_shield.c">
-      <Filter>joystick\hidapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_stadia.c">
-      <Filter>joystick\hidapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_steam.c">
-      <Filter>joystick\hidapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_steamdeck.c">
-      <Filter>joystick\hidapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_switch.c">
-      <Filter>joystick\hidapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_wii.c">
-      <Filter>joystick\hidapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_xbox360.c">
-      <Filter>joystick\hidapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_xbox360w.c">
-      <Filter>joystick\hidapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapi_xboxone.c">
-      <Filter>joystick\hidapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\hidapi\SDL_hidapijoystick.c">
-      <Filter>joystick\hidapi</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\windows\SDL_dinputjoystick.c">
-      <Filter>joystick\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\windows\SDL_rawinputjoystick.c">
-      <Filter>joystick\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\windows\SDL_windows_gaming_input.c">
-      <Filter>joystick\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\windows\SDL_windowsjoystick.c">
-      <Filter>joystick\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\windows\SDL_xinputjoystick.c">
-      <Filter>joystick\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\joystick\virtual\SDL_virtualjoystick.c">
-      <Filter>joystick\virtual</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_RLEaccel.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_blit.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_blit_0.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_blit_1.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_blit_A.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_blit_N.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_blit_auto.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_blit_copy.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_blit_slow.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_bmp.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_clipboard.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_egl.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_fillrect.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_pixels.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_rect.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_stretch.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_surface.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_video.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_video_unsupported.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_yuv.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\SDL_vulkan_utils.c">
-      <Filter>video</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\dummy\SDL_nullevents.c">
-      <Filter>video\dummy</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\dummy\SDL_nullframebuffer.c">
-      <Filter>video\dummy</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\dummy\SDL_nullvideo.c">
-      <Filter>video\dummy</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\yuv2rgb\yuv_rgb.c">
-      <Filter>video\yuv2rgb</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\windows\SDL_windowsclipboard.c">
-      <Filter>video\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\windows\SDL_windowsevents.c">
-      <Filter>video\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\windows\SDL_windowsframebuffer.c">
-      <Filter>video\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\windows\SDL_windowskeyboard.c">
-      <Filter>video\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\windows\SDL_windowsmessagebox.c">
-      <Filter>video\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\windows\SDL_windowsmodes.c">
-      <Filter>video\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\windows\SDL_windowsmouse.c">
-      <Filter>video\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\windows\SDL_windowsopengl.c">
-      <Filter>video\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\windows\SDL_windowsopengles.c">
-      <Filter>video\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\windows\SDL_windowsvideo.c">
-      <Filter>video\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\windows\SDL_windowsvulkan.c">
-      <Filter>video\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\windows\SDL_windowswindow.c">
-      <Filter>video\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\timer\SDL_timer.c">
-      <Filter>timer</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\timer\windows\SDL_systimer.c">
-      <Filter>timer\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\thread\SDL_thread.c">
-      <Filter>thread</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\thread\windows\SDL_syscond_cv.c">
-      <Filter>thread\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\thread\windows\SDL_sysmutex.c">
-      <Filter>thread\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\thread\windows\SDL_syssem.c">
-      <Filter>thread\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\thread\windows\SDL_systhread.c">
-      <Filter>thread\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\thread\windows\SDL_systls.c">
-      <Filter>thread\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\thread\generic\SDL_syscond.c">
-      <Filter>thread\generic</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\stdlib\SDL_crc16.c">
-      <Filter>stdlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\stdlib\SDL_crc32.c">
-      <Filter>stdlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\stdlib\SDL_getenv.c">
-      <Filter>stdlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\stdlib\SDL_iconv.c">
-      <Filter>stdlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\stdlib\SDL_malloc.c">
-      <Filter>stdlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\stdlib\SDL_qsort.c">
-      <Filter>stdlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\stdlib\SDL_stdlib.c">
-      <Filter>stdlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\stdlib\SDL_string.c">
-      <Filter>stdlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\stdlib\SDL_strtokr.c">
-      <Filter>stdlib</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\sensor\SDL_sensor.c">
-      <Filter>sensor</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\sensor\dummy\SDL_dummysensor.c">
-      <Filter>sensor\dummy</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\sensor\windows\SDL_windowssensor.c">
-      <Filter>sensor\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\SDL_d3dmath.c">
-      <Filter>render</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\SDL_render.c">
-      <Filter>render</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\SDL_render_unsupported.c">
-      <Filter>render</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\SDL_yuv_sw.c">
-      <Filter>render</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\direct3d\SDL_render_d3d.c">
-      <Filter>render\direct3d</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\direct3d\SDL_shaders_d3d.c">
-      <Filter>render\direct3d</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\direct3d11\SDL_render_d3d11.c">
-      <Filter>render\direct3d11</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\direct3d11\SDL_shaders_d3d11.c">
-      <Filter>render\direct3d11</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\opengl\SDL_render_gl.c">
-      <Filter>render\opengl</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\opengl\SDL_shaders_gl.c">
-      <Filter>render\opengl</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\opengles2\SDL_render_gles2.c">
-      <Filter>render\opengles2</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\opengles2\SDL_shaders_gles2.c">
-      <Filter>render\opengles2</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\software\SDL_blendfillrect.c">
-      <Filter>render\software</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\software\SDL_blendline.c">
-      <Filter>render\software</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\software\SDL_blendpoint.c">
-      <Filter>render\software</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\software\SDL_drawline.c">
-      <Filter>render\software</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\software\SDL_drawpoint.c">
-      <Filter>render\software</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\software\SDL_render_sw.c">
-      <Filter>render\software</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\software\SDL_rotate.c">
-      <Filter>render\software</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\software\SDL_triangle.c">
-      <Filter>render\software</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\power\SDL_power.c">
-      <Filter>power</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\SDL_log.c" />
-    <ClCompile Include="..\..\src\power\windows\SDL_syspower.c">
-      <Filter>power\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\direct3d12\SDL_render_d3d12.c">
-      <Filter>render\direct3d12</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\direct3d12\SDL_shaders_d3d12.c">
-      <Filter>render\direct3d12</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\stdlib\SDL_mslibc.c">
-      <Filter>stdlib</Filter>
-    </ClCompile>
-    <MASM Include="..\..\src\stdlib\SDL_mslibc_x64.masm">
-      <Filter>stdlib</Filter>
-    </MASM>
-    <ClCompile Include="..\..\src\core\gdk\SDL_gdk.cpp">
-      <Filter>core\gdk</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\direct3d12\SDL_render_d3d12_xbox.cpp">
-      <Filter>render\direct3d12</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\direct3d12\SDL_shaders_d3d12_xboxone.cpp">
-      <Filter>render\direct3d12</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render\direct3d12\SDL_shaders_d3d12_xboxseries.cpp">
-      <Filter>render\direct3d12</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\core\windows\pch.c">
-      <Filter>core\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\core\windows\pch_cpp.cpp">
-      <Filter>core\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\video\gdk\SDL_gdktextinput.cpp">
-      <Filter>video\gdk</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\thread\windows\SDL_sysrwlock_srw.c">
-      <Filter>thread\windows</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\thread\generic\SDL_sysrwlock.c">
-      <Filter>thread\generic</Filter>
-    </ClCompile>
+    <ClCompile Include="..\..\src\sensor\dummy\SDL_dummysensor.c" />
+    <ClCompile Include="..\..\src\sensor\SDL_sensor.c" />
+    <ClCompile Include="..\..\src\sensor\windows\SDL_windowssensor.c" />
+    <ClCompile Include="..\..\src\stdlib\SDL_crc16.c" />
+    <ClCompile Include="..\..\src\stdlib\SDL_crc32.c" />
+    <ClCompile Include="..\..\src\stdlib\SDL_getenv.c" />
+    <ClCompile Include="..\..\src\stdlib\SDL_iconv.c" />
+    <ClCompile Include="..\..\src\stdlib\SDL_malloc.c" />
+    <ClCompile Include="..\..\src\stdlib\SDL_mslibc.c" />
+    <ClCompile Include="..\..\src\stdlib\SDL_qsort.c" />
+    <ClCompile Include="..\..\src\stdlib\SDL_stdlib.c" />
+    <ClCompile Include="..\..\src\stdlib\SDL_string.c" />
+    <ClCompile Include="..\..\src\stdlib\SDL_strtokr.c" />
+    <ClCompile Include="..\..\src\thread\generic\SDL_syscond.c" />
+    <ClCompile Include="..\..\src\thread\generic\SDL_sysrwlock.c" />
+    <ClCompile Include="..\..\src\thread\SDL_thread.c" />
+    <ClCompile Include="..\..\src\thread\windows\SDL_syscond_cv.c" />
+    <ClCompile Include="..\..\src\thread\windows\SDL_sysmutex.c" />
+    <ClCompile Include="..\..\src\thread\windows\SDL_sysrwlock_srw.c" />
+    <ClCompile Include="..\..\src\thread\windows\SDL_syssem.c" />
+    <ClCompile Include="..\..\src\thread\windows\SDL_systhread.c" />
+    <ClCompile Include="..\..\src\thread\windows\SDL_systls.c" />
+    <ClCompile Include="..\..\src\timer\SDL_timer.c" />
+    <ClCompile Include="..\..\src\timer\windows\SDL_systimer.c" />
+    <ClCompile Include="..\..\src\video\dummy\SDL_nullevents.c" />
+    <ClCompile Include="..\..\src\video\dummy\SDL_nullframebuffer.c" />
+    <ClCompile Include="..\..\src\video\dummy\SDL_nullvideo.c" />
+    <ClCompile Include="..\..\src\video\gdk\SDL_gdktextinput.cpp" />
+    <ClCompile Include="..\..\src\video\SDL_blit.c" />
+    <ClCompile Include="..\..\src\video\SDL_blit_0.c" />
+    <ClCompile Include="..\..\src\video\SDL_blit_1.c" />
+    <ClCompile Include="..\..\src\video\SDL_blit_A.c" />
+    <ClCompile Include="..\..\src\video\SDL_blit_auto.c" />
+    <ClCompile Include="..\..\src\video\SDL_blit_copy.c" />
+    <ClCompile Include="..\..\src\video\SDL_blit_N.c" />
+    <ClCompile Include="..\..\src\video\SDL_blit_slow.c" />
+    <ClCompile Include="..\..\src\video\SDL_bmp.c" />
+    <ClCompile Include="..\..\src\video\SDL_clipboard.c" />
+    <ClCompile Include="..\..\src\video\SDL_egl.c" />
+    <ClCompile Include="..\..\src\video\SDL_fillrect.c" />
+    <ClCompile Include="..\..\src\video\SDL_pixels.c" />
+    <ClCompile Include="..\..\src\video\SDL_rect.c" />
+    <ClCompile Include="..\..\src\video\SDL_RLEaccel.c" />
+    <ClCompile Include="..\..\src\video\SDL_stretch.c" />
+    <ClCompile Include="..\..\src\video\SDL_surface.c" />
+    <ClCompile Include="..\..\src\video\SDL_video.c" />
+    <ClCompile Include="..\..\src\video\SDL_video_unsupported.c" />
+    <ClCompile Include="..\..\src\video\SDL_vulkan_utils.c" />
+    <ClCompile Include="..\..\src\video\SDL_yuv.c" />
+    <ClCompile Include="..\..\src\video\windows\SDL_windowsclipboard.c" />
+    <ClCompile Include="..\..\src\video\windows\SDL_windowsevents.c" />
+    <ClCompile Include="..\..\src\video\windows\SDL_windowsframebuffer.c" />
+    <ClCompile Include="..\..\src\video\windows\SDL_windowskeyboard.c" />
+    <ClCompile Include="..\..\src\video\windows\SDL_windowsmessagebox.c" />
+    <ClCompile Include="..\..\src\video\windows\SDL_windowsmodes.c" />
+    <ClCompile Include="..\..\src\video\windows\SDL_windowsmouse.c" />
+    <ClCompile Include="..\..\src\video\windows\SDL_windowsopengl.c" />
+    <ClCompile Include="..\..\src\video\windows\SDL_windowsopengles.c" />
+    <ClCompile Include="..\..\src\video\windows\SDL_windowsvideo.c" />
+    <ClCompile Include="..\..\src\video\windows\SDL_windowsvulkan.c" />
+    <ClCompile Include="..\..\src\video\windows\SDL_windowswindow.c" />
+    <ClCompile Include="..\..\src\video\yuv2rgb\yuv_rgb.c" />
+    <ClCompile Include="..\..\src\filesystem\windows\SDL_sysfilesystem.c" />
+    <ClCompile Include="..\..\src\video\SDL_video_capture.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\include\SDL3\SDL_begin_code.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_close_code.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_assert.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_atomic.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_audio.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_bits.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_blendmode.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_clipboard.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_copying.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_cpuinfo.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_egl.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_endian.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_error.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_events.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_filesystem.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_gamepad.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_guid.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_haptic.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_hints.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_hidapi.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_joystick.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_keyboard.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_keycode.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_loadso.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_locale.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_log.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_main.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_messagebox.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_metal.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_misc.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_mouse.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_mutex.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_opengl.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_opengl_glext.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_opengles.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_opengles2.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_opengles2_gl2.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_opengles2_gl2ext.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_opengles2_gl2platform.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_opengles2_khrplatform.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_pen.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_pixels.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_platform.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_platform_defines.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_power.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_quit.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_rect.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_render.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_revision.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_rwops.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_scancode.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_sensor.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_stdinc.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_surface.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_system.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_test.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_test_assert.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_test_common.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_test_compare.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_test_crc32.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_test_font.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_test_fuzzer.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_test_harness.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_test_log.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_test_md5.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_test_memory.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_test_random.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_thread.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_timer.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_touch.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_types.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_version.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_video.h" />
+    <ClInclude Include="..\..\include\SDL3\SDL_vulkan.h" />
+    <ClInclude Include="..\..\src\audio\directsound\SDL_directsound.h" />
+    <ClInclude Include="..\..\src\audio\disk\SDL_diskaudio.h" />
+    <ClInclude Include="..\..\src\audio\dummy\SDL_dummyaudio.h" />
+    <ClInclude Include="..\..\src\audio\SDL_audio_c.h" />
+    <ClInclude Include="..\..\src\audio\SDL_audiodev_c.h" />
+    <ClInclude Include="..\..\src\audio\SDL_sysaudio.h" />
+    <ClInclude Include="..\..\src\audio\SDL_audioqueue.h" />
+    <ClInclude Include="..\..\src\audio\SDL_audioresample.h" />
+    <ClInclude Include="..\..\src\audio\SDL_wave.h" />
+    <ClInclude Include="..\..\src\audio\wasapi\SDL_wasapi.h" />
+    <ClInclude Include="..\..\src\core\gdk\SDL_gdk.h" />
+    <ClInclude Include="..\..\src\core\windows\SDL_directx.h" />
+    <ClInclude Include="..\..\src\core\windows\SDL_hid.h" />
+    <ClInclude Include="..\..\src\core\windows\SDL_immdevice.h" />
+    <ClInclude Include="..\..\src\core\windows\SDL_windows.h" />
+    <ClInclude Include="..\..\src\core\windows\SDL_xinput.h" />
+    <ClInclude Include="..\..\src\dynapi\SDL_dynapi.h" />
+    <ClInclude Include="..\..\src\dynapi\SDL_dynapi_overrides.h" />
+    <ClInclude Include="..\..\src\dynapi\SDL_dynapi_procs.h" />
+    <ClInclude Include="..\..\src\events\blank_cursor.h" />
+    <ClInclude Include="..\..\src\events\default_cursor.h" />
+    <ClInclude Include="..\..\src\events\scancodes_windows.h" />
+    <ClInclude Include="..\..\src\events\SDL_clipboardevents_c.h" />
+    <ClInclude Include="..\..\src\events\SDL_displayevents_c.h" />
+    <ClInclude Include="..\..\src\events\SDL_dropevents_c.h" />
+    <ClInclude Include="..\..\src\events\SDL_events_c.h" />
+    <ClInclude Include="..\..\src\events\SDL_keyboard_c.h" />
+    <ClInclude Include="..\..\src\events\SDL_mouse_c.h" />
+    <ClInclude Include="..\..\src\events\SDL_touch_c.h" />
+    <ClInclude Include="..\..\src\events\SDL_windowevents_c.h" />
+    <ClInclude Include="..\..\src\haptic\SDL_haptic_c.h" />
+    <ClInclude Include="..\..\src\haptic\SDL_syshaptic.h" />
+    <ClInclude Include="..\..\src\haptic\windows\SDL_dinputhaptic_c.h" />
+    <ClInclude Include="..\..\src\haptic\windows\SDL_windowshaptic_c.h" />
+    <ClInclude Include="..\..\src\haptic\windows\SDL_xinputhaptic_c.h" />
+    <ClInclude Include="..\..\src\hidapi\hidapi\hidapi.h" />
+    <ClInclude Include="..\..\src\hidapi\SDL_hidapi_c.h" />
+    <ClInclude Include="..\..\src\joystick\controller_type.h" />
+    <ClInclude Include="..\..\src\joystick\hidapi\SDL_hidapijoystick_c.h" />
+    <ClInclude Include="..\..\src\joystick\hidapi\SDL_hidapi_rumble.h" />
+    <ClInclude Include="..\..\src\joystick\SDL_gamepad_c.h" />
+    <ClInclude Include="..\..\src\joystick\SDL_gamepad_db.h" />
+    <ClInclude Include="..\..\src\joystick\SDL_joystick_c.h" />
+    <ClInclude Include="..\..\src\joystick\SDL_steam_virtual_gamepad.h" />
+    <ClInclude Include="..\..\src\joystick\SDL_sysjoystick.h" />
+    <ClInclude Include="..\..\src\joystick\usb_ids.h" />
+    <ClInclude Include="..\..\src\joystick\virtual\SDL_virtualjoystick_c.h" />
+    <ClInclude Include="..\..\src\joystick\windows\SDL_dinputjoystick_c.h" />
+    <ClInclude Include="..\..\src\joystick\windows\SDL_rawinputjoystick_c.h" />
+    <ClInclude Include="..\..\src\joystick\windows\SDL_windowsjoystick_c.h" />
+    <ClInclude Include="..\..\src\joystick\windows\SDL_xinputjoystick_c.h" />
+    <ClInclude Include="..\..\src\libm\math_libm.h" />
+    <ClInclude Include="..\..\src\libm\math_private.h" />
+    <ClInclude Include="..\..\src\locale\SDL_syslocale.h" />
+    <ClInclude Include="..\..\src\main\SDL_main_callbacks.h" />
+    <ClInclude Include="..\..\src\misc\SDL_sysurl.h" />
+    <ClInclude Include="..\..\src\power\SDL_syspower.h" />
+    <ClInclude Include="..\..\src\render\direct3d11\SDL_shaders_d3d11.h" />
+    <ClInclude Include="..\..\src\render\direct3d12\SDL_render_d3d12_xbox.h" />
+    <ClInclude Include="..\..\src\render\direct3d12\SDL_shaders_d3d12.h" />
+    <ClInclude Include="..\..\src\render\direct3d\SDL_shaders_d3d.h" />
+    <ClInclude Include="..\..\src\render\opengles2\SDL_gles2funcs.h" />
+    <ClInclude Include="..\..\src\render\opengles2\SDL_shaders_gles2.h" />
+    <ClInclude Include="..\..\src\render\opengl\SDL_glfuncs.h" />
+    <ClInclude Include="..\..\src\render\opengl\SDL_shaders_gl.h" />
+    <ClInclude Include="..\..\src\render\SDL_d3dmath.h" />
+    <ClInclude Include="..\..\src\render\SDL_sysrender.h" />
+    <ClInclude Include="..\..\src\render\SDL_yuv_sw_c.h" />
+    <ClInclude Include="..\..\src\render\software\SDL_blendfillrect.h" />
+    <ClInclude Include="..\..\src\render\software\SDL_blendline.h" />
+    <ClInclude Include="..\..\src\render\software\SDL_blendpoint.h" />
+    <ClInclude Include="..\..\src\render\software\SDL_draw.h" />
+    <ClInclude Include="..\..\src\render\software\SDL_drawline.h" />
+    <ClInclude Include="..\..\src\render\software\SDL_drawpoint.h" />
+    <ClInclude Include="..\..\src\render\software\SDL_render_sw_c.h" />
+    <ClInclude Include="..\..\src\render\software\SDL_rotate.h" />
+    <ClInclude Include="..\..\src\render\software\SDL_triangle.h" />
+    <ClInclude Include="..\..\src\SDL_assert_c.h" />
+    <ClInclude Include="..\..\src\SDL_error_c.h" />
+    <ClInclude Include="..\..\src\SDL_hashtable.h" />
+    <ClInclude Include="..\..\src\SDL_hints_c.h" />
+    <ClInclude Include="..\..\src\SDL_internal.h" />
+    <ClInclude Include="..\..\src\SDL_list.h" />
+    <ClInclude Include="..\..\src\SDL_log_c.h" />
+    <ClInclude Include="..\..\src\SDL_properties_c.h" />
+    <ClInclude Include="..\..\src\sensor\dummy\SDL_dummysensor.h" />
+    <ClInclude Include="..\..\src\sensor\SDL_sensor_c.h" />
+    <ClInclude Include="..\..\src\sensor\SDL_syssensor.h" />
+    <ClInclude Include="..\..\src\sensor\windows\SDL_windowssensor.h" />
+    <ClInclude Include="..\..\src\thread\generic\SDL_sysrwlock_c.h" />
+    <ClInclude Include="..\..\src\thread\SDL_systhread.h" />
+    <ClInclude Include="..\..\src\thread\SDL_thread_c.h" />
+    <ClInclude Include="..\..\src\thread\generic\SDL_syscond_c.h" />
+    <ClInclude Include="..\..\src\thread\windows\SDL_sysmutex_c.h" />
+    <ClInclude Include="..\..\src\thread\windows\SDL_systhread_c.h" />
+    <ClInclude Include="..\..\src\timer\SDL_timer_c.h" />
+    <ClInclude Include="..\..\src\video\dummy\SDL_nullevents_c.h" />
+    <ClInclude Include="..\..\src\video\dummy\SDL_nullframebuffer_c.h" />
+    <ClInclude Include="..\..\src\video\dummy\SDL_nullvideo.h" />
+    <ClInclude Include="..\..\src\video\gdk\SDL_gdktextinput.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vk_icd.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vk_layer.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vk_platform.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vk_sdk_platform.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan.hpp" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_android.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_beta.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_core.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_directfb.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_fuchsia.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_ggp.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_ios.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_macos.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_metal.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_vi.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_wayland.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_win32.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_xcb.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_xlib.h" />
+    <ClInclude Include="..\..\src\video\khronos\vulkan\vulkan_xlib_xrandr.h" />
+    <ClInclude Include="..\..\src\video\SDL_blit.h" />
+    <ClInclude Include="..\..\src\video\SDL_blit_auto.h" />
+    <ClInclude Include="..\..\src\video\SDL_blit_copy.h" />
+    <ClInclude Include="..\..\src\video\SDL_blit_slow.h" />
+    <ClInclude Include="..\..\src\video\SDL_clipboard_c.h" />
+    <ClInclude Include="..\..\src\video\SDL_egl_c.h" />
+    <ClInclude Include="..\..\src\video\SDL_pixels_c.h" />
+    <ClInclude Include="..\..\src\video\SDL_rect_c.h" />
+    <ClInclude Include="..\..\src\video\SDL_RLEaccel_c.h" />
+    <ClInclude Include="..\..\src\video\SDL_sysvideo.h" />
+    <ClInclude Include="..\..\src\video\SDL_vulkan_internal.h" />
+    <ClInclude Include="..\..\src\video\SDL_yuv_c.h" />
+    <ClInclude Include="..\..\src\video\windows\SDL_msctf.h" />
+    <ClInclude Include="..\..\src\video\windows\SDL_windowsclipboard.h" />
+    <ClInclude Include="..\..\src\video\windows\SDL_windowsevents.h" />
+    <ClInclude Include="..\..\src\video\windows\SDL_windowsframebuffer.h" />
+    <ClInclude Include="..\..\src\video\windows\SDL_windowskeyboard.h" />
+    <ClInclude Include="..\..\src\video\windows\SDL_windowsmessagebox.h" />
+    <ClInclude Include="..\..\src\video\windows\SDL_windowsmodes.h" />
+    <ClInclude Include="..\..\src\video\windows\SDL_windowsmouse.h" />
+    <ClInclude Include="..\..\src\video\windows\SDL_windowsopengl.h" />
+    <ClInclude Include="..\..\src\video\windows\SDL_windowsopengles.h" />
+    <ClInclude Include="..\..\src\video\windows\SDL_windowsvideo.h" />
+    <ClInclude Include="..\..\src\video\windows\SDL_windowsvulkan.h" />
+    <ClInclude Include="..\..\src\video\windows\SDL_windowswindow.h" />
+    <ClInclude Include="..\..\src\video\windows\wmmsg.h" />
+    <ClInclude Include="..\..\src\video\yuv2rgb\yuv_rgb.h" />
+    <ClInclude Include="..\..\src\video\yuv2rgb\yuv_rgb_sse_func.h" />
+    <ClInclude Include="..\..\src\video\yuv2rgb\yuv_rgb_std_func.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\src\core\windows\version.rc" />

--- a/VisualC-GDK/clean.sh
+++ b/VisualC-GDK/clean.sh
@@ -4,3 +4,4 @@ find . -type f \( -name '*.bmp' -o -name '*.wav' -o -name '*.dat' \) -print -del
 find . -depth -type d \( -name Gaming.Desktop.x64 \) -exec rm -rv {} \;
 find . -depth -type d \( -name Gaming.Xbox.Scarlett.x64 \) -exec rm -rv {} \;
 find . -depth -type d \( -name Gaming.Xbox.XboxOne.x64 \) -exec rm -rv {} \;
+rm shaders/*.h

--- a/VisualC-GDK/shaders/D3D12_PixelShader_Colors.hlsl
+++ b/VisualC-GDK/shaders/D3D12_PixelShader_Colors.hlsl
@@ -1,0 +1,19 @@
+struct PixelShaderInput
+{
+    float4 pos : SV_POSITION;
+    float2 tex : TEXCOORD0;
+    float4 color : COLOR0;
+};
+
+#define ColorRS \
+    "RootFlags ( ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |" \
+    "DENY_DOMAIN_SHADER_ROOT_ACCESS |" \
+    "DENY_GEOMETRY_SHADER_ROOT_ACCESS |" \
+    "DENY_HULL_SHADER_ROOT_ACCESS )," \
+    "RootConstants(num32BitConstants=32, b0)"
+
+[RootSignature(ColorRS)]
+float4 main(PixelShaderInput input) : SV_TARGET0
+{
+    return input.color;
+}

--- a/VisualC-GDK/shaders/D3D12_PixelShader_NV12_BT601.hlsl
+++ b/VisualC-GDK/shaders/D3D12_PixelShader_NV12_BT601.hlsl
@@ -1,0 +1,43 @@
+Texture2D theTextureY : register(t0);
+Texture2D theTextureUV : register(t1);
+SamplerState theSampler : register(s0);
+
+struct PixelShaderInput
+{
+    float4 pos : SV_POSITION;
+    float2 tex : TEXCOORD0;
+    float4 color : COLOR0;
+};
+
+#define NVRS \
+    "RootFlags ( ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |" \
+    "            DENY_DOMAIN_SHADER_ROOT_ACCESS |" \
+    "            DENY_GEOMETRY_SHADER_ROOT_ACCESS |" \
+    "            DENY_HULL_SHADER_ROOT_ACCESS )," \
+    "RootConstants(num32BitConstants=32, b0),"\
+    "DescriptorTable ( SRV(t0), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( SRV(t1), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( Sampler(s0), visibility = SHADER_VISIBILITY_PIXEL )"
+
+[RootSignature(NVRS)]
+float4 main(PixelShaderInput input) : SV_TARGET
+{
+    const float3 offset = {-0.0627451017, -0.501960814, -0.501960814};
+    const float3 Rcoeff = {1.1644,  0.0000,  1.5960};
+    const float3 Gcoeff = {1.1644, -0.3918, -0.8130};
+    const float3 Bcoeff = {1.1644,  2.0172,  0.0000};
+
+    float4 Output;
+
+    float3 yuv;
+    yuv.x = theTextureY.Sample(theSampler, input.tex).r;
+    yuv.yz = theTextureUV.Sample(theSampler, input.tex).rg;
+
+    yuv += offset;
+    Output.r = dot(yuv, Rcoeff);
+    Output.g = dot(yuv, Gcoeff);
+    Output.b = dot(yuv, Bcoeff);
+    Output.a = 1.0f;
+
+    return Output * input.color;
+}

--- a/VisualC-GDK/shaders/D3D12_PixelShader_NV12_BT709.hlsl
+++ b/VisualC-GDK/shaders/D3D12_PixelShader_NV12_BT709.hlsl
@@ -1,0 +1,43 @@
+Texture2D theTextureY : register(t0);
+Texture2D theTextureUV : register(t1);
+SamplerState theSampler : register(s0);
+
+struct PixelShaderInput
+{
+    float4 pos : SV_POSITION;
+    float2 tex : TEXCOORD0;
+    float4 color : COLOR0;
+};
+
+#define NVRS \
+    "RootFlags ( ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |" \
+    "            DENY_DOMAIN_SHADER_ROOT_ACCESS |" \
+    "            DENY_GEOMETRY_SHADER_ROOT_ACCESS |" \
+    "            DENY_HULL_SHADER_ROOT_ACCESS )," \
+    "RootConstants(num32BitConstants=32, b0),"\
+    "DescriptorTable ( SRV(t0), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( SRV(t1), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( Sampler(s0), visibility = SHADER_VISIBILITY_PIXEL )"
+
+[RootSignature(NVRS)]
+float4 main(PixelShaderInput input) : SV_TARGET
+{
+    const float3 offset = {-0.0627451017, -0.501960814, -0.501960814};
+    const float3 Rcoeff = {1.1644,  0.0000,  1.7927};
+    const float3 Gcoeff = {1.1644, -0.2132, -0.5329};
+    const float3 Bcoeff = {1.1644,  2.1124,  0.0000};
+
+    float4 Output;
+
+    float3 yuv;
+    yuv.x = theTextureY.Sample(theSampler, input.tex).r;
+    yuv.yz = theTextureUV.Sample(theSampler, input.tex).rg;
+
+    yuv += offset;
+    Output.r = dot(yuv, Rcoeff);
+    Output.g = dot(yuv, Gcoeff);
+    Output.b = dot(yuv, Bcoeff);
+    Output.a = 1.0f;
+
+    return Output * input.color;
+}

--- a/VisualC-GDK/shaders/D3D12_PixelShader_NV12_JPEG.hlsl
+++ b/VisualC-GDK/shaders/D3D12_PixelShader_NV12_JPEG.hlsl
@@ -1,0 +1,43 @@
+Texture2D theTextureY : register(t0);
+Texture2D theTextureUV : register(t1);
+SamplerState theSampler : register(s0);
+
+struct PixelShaderInput
+{
+    float4 pos : SV_POSITION;
+    float2 tex : TEXCOORD0;
+    float4 color : COLOR0;
+};
+
+#define NVRS \
+    "RootFlags ( ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |" \
+    "            DENY_DOMAIN_SHADER_ROOT_ACCESS |" \
+    "            DENY_GEOMETRY_SHADER_ROOT_ACCESS |" \
+    "            DENY_HULL_SHADER_ROOT_ACCESS )," \
+    "RootConstants(num32BitConstants=32, b0),"\
+    "DescriptorTable ( SRV(t0), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( SRV(t1), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( Sampler(s0), visibility = SHADER_VISIBILITY_PIXEL )"
+
+[RootSignature(NVRS)]
+float4 main(PixelShaderInput input) : SV_TARGET
+{
+    const float3 offset = {0.0, -0.501960814, -0.501960814};
+    const float3 Rcoeff = {1.0000,  0.0000,  1.4020};
+    const float3 Gcoeff = {1.0000, -0.3441, -0.7141};
+    const float3 Bcoeff = {1.0000,  1.7720,  0.0000};
+
+    float4 Output;
+
+    float3 yuv;
+    yuv.x = theTextureY.Sample(theSampler, input.tex).r;
+    yuv.yz = theTextureUV.Sample(theSampler, input.tex).rg;
+
+    yuv += offset;
+    Output.r = dot(yuv, Rcoeff);
+    Output.g = dot(yuv, Gcoeff);
+    Output.b = dot(yuv, Bcoeff);
+    Output.a = 1.0f;
+
+    return Output * input.color;
+}

--- a/VisualC-GDK/shaders/D3D12_PixelShader_NV21_BT601.hlsl
+++ b/VisualC-GDK/shaders/D3D12_PixelShader_NV21_BT601.hlsl
@@ -1,0 +1,43 @@
+Texture2D theTextureY : register(t0);
+Texture2D theTextureUV : register(t1);
+SamplerState theSampler : register(s0);
+
+struct PixelShaderInput
+{
+    float4 pos : SV_POSITION;
+    float2 tex : TEXCOORD0;
+    float4 color : COLOR0;
+};
+
+#define NVRS \
+    "RootFlags ( ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |" \
+    "            DENY_DOMAIN_SHADER_ROOT_ACCESS |" \
+    "            DENY_GEOMETRY_SHADER_ROOT_ACCESS |" \
+    "            DENY_HULL_SHADER_ROOT_ACCESS )," \
+    "RootConstants(num32BitConstants=32, b0),"\
+    "DescriptorTable ( SRV(t0), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( SRV(t1), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( Sampler(s0), visibility = SHADER_VISIBILITY_PIXEL )"
+
+[RootSignature(NVRS)]
+float4 main(PixelShaderInput input) : SV_TARGET
+{
+    const float3 offset = {-0.0627451017, -0.501960814, -0.501960814};
+    const float3 Rcoeff = {1.1644,  0.0000,  1.5960};
+    const float3 Gcoeff = {1.1644, -0.3918, -0.8130};
+    const float3 Bcoeff = {1.1644,  2.0172,  0.0000};
+
+    float4 Output;
+
+    float3 yuv;
+    yuv.x = theTextureY.Sample(theSampler, input.tex).r;
+    yuv.yz = theTextureUV.Sample(theSampler, input.tex).gr;
+
+    yuv += offset;
+    Output.r = dot(yuv, Rcoeff);
+    Output.g = dot(yuv, Gcoeff);
+    Output.b = dot(yuv, Bcoeff);
+    Output.a = 1.0f;
+
+    return Output * input.color;
+}

--- a/VisualC-GDK/shaders/D3D12_PixelShader_NV21_BT709.hlsl
+++ b/VisualC-GDK/shaders/D3D12_PixelShader_NV21_BT709.hlsl
@@ -1,0 +1,43 @@
+Texture2D theTextureY : register(t0);
+Texture2D theTextureUV : register(t1);
+SamplerState theSampler : register(s0);
+
+struct PixelShaderInput
+{
+    float4 pos : SV_POSITION;
+    float2 tex : TEXCOORD0;
+    float4 color : COLOR0;
+};
+
+#define NVRS \
+    "RootFlags ( ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |" \
+    "            DENY_DOMAIN_SHADER_ROOT_ACCESS |" \
+    "            DENY_GEOMETRY_SHADER_ROOT_ACCESS |" \
+    "            DENY_HULL_SHADER_ROOT_ACCESS )," \
+    "RootConstants(num32BitConstants=32, b0),"\
+    "DescriptorTable ( SRV(t0), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( SRV(t1), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( Sampler(s0), visibility = SHADER_VISIBILITY_PIXEL )"
+
+[RootSignature(NVRS)]
+float4 main(PixelShaderInput input) : SV_TARGET
+{
+    const float3 offset = {-0.0627451017, -0.501960814, -0.501960814};
+    const float3 Rcoeff = {1.1644,  0.0000,  1.7927};
+    const float3 Gcoeff = {1.1644, -0.2132, -0.5329};
+    const float3 Bcoeff = {1.1644,  2.1124,  0.0000};
+
+    float4 Output;
+
+    float3 yuv;
+    yuv.x = theTextureY.Sample(theSampler, input.tex).r;
+    yuv.yz = theTextureUV.Sample(theSampler, input.tex).gr;
+
+    yuv += offset;
+    Output.r = dot(yuv, Rcoeff);
+    Output.g = dot(yuv, Gcoeff);
+    Output.b = dot(yuv, Bcoeff);
+    Output.a = 1.0f;
+
+    return Output * input.color;
+}

--- a/VisualC-GDK/shaders/D3D12_PixelShader_NV21_JPEG.hlsl
+++ b/VisualC-GDK/shaders/D3D12_PixelShader_NV21_JPEG.hlsl
@@ -1,0 +1,43 @@
+Texture2D theTextureY : register(t0);
+Texture2D theTextureUV : register(t1);
+SamplerState theSampler : register(s0);
+
+struct PixelShaderInput
+{
+    float4 pos : SV_POSITION;
+    float2 tex : TEXCOORD0;
+    float4 color : COLOR0;
+};
+
+#define NVRS \
+    "RootFlags ( ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |" \
+    "            DENY_DOMAIN_SHADER_ROOT_ACCESS |" \
+    "            DENY_GEOMETRY_SHADER_ROOT_ACCESS |" \
+    "            DENY_HULL_SHADER_ROOT_ACCESS )," \
+    "RootConstants(num32BitConstants=32, b0),"\
+    "DescriptorTable ( SRV(t0), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( SRV(t1), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( Sampler(s0), visibility = SHADER_VISIBILITY_PIXEL )"
+
+[RootSignature(NVRS)]
+float4 main(PixelShaderInput input) : SV_TARGET
+{
+    const float3 offset = {0.0, -0.501960814, -0.501960814};
+    const float3 Rcoeff = {1.0000,  0.0000,  1.4020};
+    const float3 Gcoeff = {1.0000, -0.3441, -0.7141};
+    const float3 Bcoeff = {1.0000,  1.7720,  0.0000};
+
+    float4 Output;
+
+    float3 yuv;
+    yuv.x = theTextureY.Sample(theSampler, input.tex).r;
+    yuv.yz = theTextureUV.Sample(theSampler, input.tex).gr;
+
+    yuv += offset;
+    Output.r = dot(yuv, Rcoeff);
+    Output.g = dot(yuv, Gcoeff);
+    Output.b = dot(yuv, Bcoeff);
+    Output.a = 1.0f;
+
+    return Output * input.color;
+}

--- a/VisualC-GDK/shaders/D3D12_PixelShader_Textures.hlsl
+++ b/VisualC-GDK/shaders/D3D12_PixelShader_Textures.hlsl
@@ -1,0 +1,24 @@
+Texture2D theTexture : register(t0);
+SamplerState theSampler : register(s0);
+
+struct PixelShaderInput
+{
+    float4 pos : SV_POSITION;
+    float2 tex : TEXCOORD0;
+    float4 color : COLOR0;
+};
+
+#define TextureRS \
+    "RootFlags ( ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |" \
+    "            DENY_DOMAIN_SHADER_ROOT_ACCESS |" \
+    "            DENY_GEOMETRY_SHADER_ROOT_ACCESS |" \
+    "            DENY_HULL_SHADER_ROOT_ACCESS )," \
+    "RootConstants(num32BitConstants=32, b0),"\
+    "DescriptorTable ( SRV(t0), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( Sampler(s0), visibility = SHADER_VISIBILITY_PIXEL )"
+
+[RootSignature(TextureRS)]
+float4 main(PixelShaderInput input) : SV_TARGET
+{
+    return theTexture.Sample(theSampler, input.tex) * input.color;
+}

--- a/VisualC-GDK/shaders/D3D12_PixelShader_YUV_BT601.hlsl
+++ b/VisualC-GDK/shaders/D3D12_PixelShader_YUV_BT601.hlsl
@@ -1,0 +1,46 @@
+Texture2D theTextureY : register(t0);
+Texture2D theTextureU : register(t1);
+Texture2D theTextureV : register(t2);
+SamplerState theSampler : register(s0);
+
+struct PixelShaderInput
+{
+    float4 pos : SV_POSITION;
+    float2 tex : TEXCOORD0;
+    float4 color : COLOR0;
+};
+
+#define YUVRS \
+    "RootFlags ( ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |" \
+    "            DENY_DOMAIN_SHADER_ROOT_ACCESS |" \
+    "            DENY_GEOMETRY_SHADER_ROOT_ACCESS |" \
+    "            DENY_HULL_SHADER_ROOT_ACCESS )," \
+    "RootConstants(num32BitConstants=32, b0),"\
+    "DescriptorTable ( SRV(t0), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( SRV(t1), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( SRV(t2), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( Sampler(s0), visibility = SHADER_VISIBILITY_PIXEL )"
+
+[RootSignature(YUVRS)]
+float4 main(PixelShaderInput input) : SV_TARGET
+{
+    const float3 offset = {-0.0627451017, -0.501960814, -0.501960814};
+    const float3 Rcoeff = {1.1644,  0.0000,  1.5960};
+    const float3 Gcoeff = {1.1644, -0.3918, -0.8130};
+    const float3 Bcoeff = {1.1644,  2.0172,  0.0000};
+
+    float4 Output;
+
+    float3 yuv;
+    yuv.x = theTextureY.Sample(theSampler, input.tex).r;
+    yuv.y = theTextureU.Sample(theSampler, input.tex).r;
+    yuv.z = theTextureV.Sample(theSampler, input.tex).r;
+
+    yuv += offset;
+    Output.r = dot(yuv, Rcoeff);
+    Output.g = dot(yuv, Gcoeff);
+    Output.b = dot(yuv, Bcoeff);
+    Output.a = 1.0f;
+
+    return Output * input.color;
+}

--- a/VisualC-GDK/shaders/D3D12_PixelShader_YUV_BT709.hlsl
+++ b/VisualC-GDK/shaders/D3D12_PixelShader_YUV_BT709.hlsl
@@ -1,0 +1,46 @@
+Texture2D theTextureY : register(t0);
+Texture2D theTextureU : register(t1);
+Texture2D theTextureV : register(t2);
+SamplerState theSampler : register(s0);
+
+struct PixelShaderInput
+{
+    float4 pos : SV_POSITION;
+    float2 tex : TEXCOORD0;
+    float4 color : COLOR0;
+};
+
+#define YUVRS \
+    "RootFlags ( ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |" \
+    "            DENY_DOMAIN_SHADER_ROOT_ACCESS |" \
+    "            DENY_GEOMETRY_SHADER_ROOT_ACCESS |" \
+    "            DENY_HULL_SHADER_ROOT_ACCESS )," \
+    "RootConstants(num32BitConstants=32, b0),"\
+    "DescriptorTable ( SRV(t0), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( SRV(t1), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( SRV(t2), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( Sampler(s0), visibility = SHADER_VISIBILITY_PIXEL )"
+
+[RootSignature(YUVRS)]
+float4 main(PixelShaderInput input) : SV_TARGET
+{
+    const float3 offset = {-0.0627451017, -0.501960814, -0.501960814};
+    const float3 Rcoeff = {1.1644,  0.0000,  1.7927};
+    const float3 Gcoeff = {1.1644, -0.2132, -0.5329};
+    const float3 Bcoeff = {1.1644,  2.1124,  0.0000};
+
+    float4 Output;
+
+    float3 yuv;
+    yuv.x = theTextureY.Sample(theSampler, input.tex).r;
+    yuv.y = theTextureU.Sample(theSampler, input.tex).r;
+    yuv.z = theTextureV.Sample(theSampler, input.tex).r;
+
+    yuv += offset;
+    Output.r = dot(yuv, Rcoeff);
+    Output.g = dot(yuv, Gcoeff);
+    Output.b = dot(yuv, Bcoeff);
+    Output.a = 1.0f;
+
+    return Output * input.color;
+}

--- a/VisualC-GDK/shaders/D3D12_PixelShader_YUV_JPEG.hlsl
+++ b/VisualC-GDK/shaders/D3D12_PixelShader_YUV_JPEG.hlsl
@@ -1,0 +1,46 @@
+Texture2D theTextureY : register(t0);
+Texture2D theTextureU : register(t1);
+Texture2D theTextureV : register(t2);
+SamplerState theSampler : register(s0);
+
+struct PixelShaderInput
+{
+    float4 pos : SV_POSITION;
+    float2 tex : TEXCOORD0;
+    float4 color : COLOR0;
+};
+
+#define YUVRS \
+    "RootFlags ( ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |" \
+    "            DENY_DOMAIN_SHADER_ROOT_ACCESS |" \
+    "            DENY_GEOMETRY_SHADER_ROOT_ACCESS |" \
+    "            DENY_HULL_SHADER_ROOT_ACCESS )," \
+    "RootConstants(num32BitConstants=32, b0),"\
+    "DescriptorTable ( SRV(t0), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( SRV(t1), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( SRV(t2), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( Sampler(s0), visibility = SHADER_VISIBILITY_PIXEL )"
+
+[RootSignature(YUVRS)]
+float4 main(PixelShaderInput input) : SV_TARGET
+{
+    const float3 offset = {0.0, -0.501960814, -0.501960814};
+    const float3 Rcoeff = {1.0000,  0.0000,  1.4020};
+    const float3 Gcoeff = {1.0000, -0.3441, -0.7141};
+    const float3 Bcoeff = {1.0000,  1.7720,  0.0000};
+
+    float4 Output;
+
+    float3 yuv;
+    yuv.x = theTextureY.Sample(theSampler, input.tex).r;
+    yuv.y = theTextureU.Sample(theSampler, input.tex).r;
+    yuv.z = theTextureV.Sample(theSampler, input.tex).r;
+
+    yuv += offset;
+    Output.r = dot(yuv, Rcoeff);
+    Output.g = dot(yuv, Gcoeff);
+    Output.b = dot(yuv, Bcoeff);
+    Output.a = 1.0f;
+
+    return Output * input.color;
+}

--- a/VisualC-GDK/shaders/D3D12_VertexShader.hlsl
+++ b/VisualC-GDK/shaders/D3D12_VertexShader.hlsl
@@ -1,0 +1,95 @@
+#pragma pack_matrix( row_major )
+
+struct VertexShaderConstants
+{
+    matrix model;
+    matrix projectionAndView;
+};
+ConstantBuffer<VertexShaderConstants> Constants : register(b0);
+
+struct VertexShaderInput
+{
+    float3 pos : POSITION;
+    float2 tex : TEXCOORD0;
+    float4 color : COLOR0;
+};
+
+struct VertexShaderOutput
+{
+    float4 pos : SV_POSITION;
+    float2 tex : TEXCOORD0;
+    float4 color : COLOR0;
+};
+
+#define ColorRS \
+    "RootFlags ( ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |" \
+    "DENY_DOMAIN_SHADER_ROOT_ACCESS |" \
+    "DENY_GEOMETRY_SHADER_ROOT_ACCESS |" \
+    "DENY_HULL_SHADER_ROOT_ACCESS )," \
+    "RootConstants(num32BitConstants=32, b0)"
+
+#define TextureRS \
+    "RootFlags ( ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |" \
+    "            DENY_DOMAIN_SHADER_ROOT_ACCESS |" \
+    "            DENY_GEOMETRY_SHADER_ROOT_ACCESS |" \
+    "            DENY_HULL_SHADER_ROOT_ACCESS )," \
+    "RootConstants(num32BitConstants=32, b0),"\
+    "DescriptorTable ( SRV(t0), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( Sampler(s0), visibility = SHADER_VISIBILITY_PIXEL )"
+
+#define YUVRS \
+    "RootFlags ( ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |" \
+    "            DENY_DOMAIN_SHADER_ROOT_ACCESS |" \
+    "            DENY_GEOMETRY_SHADER_ROOT_ACCESS |" \
+    "            DENY_HULL_SHADER_ROOT_ACCESS )," \
+    "RootConstants(num32BitConstants=32, b0),"\
+    "DescriptorTable ( SRV(t0), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( SRV(t1), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( SRV(t2), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( Sampler(s0), visibility = SHADER_VISIBILITY_PIXEL )"
+
+#define NVRS \
+    "RootFlags ( ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |" \
+    "            DENY_DOMAIN_SHADER_ROOT_ACCESS |" \
+    "            DENY_GEOMETRY_SHADER_ROOT_ACCESS |" \
+    "            DENY_HULL_SHADER_ROOT_ACCESS )," \
+    "RootConstants(num32BitConstants=32, b0),"\
+    "DescriptorTable ( SRV(t0), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( SRV(t1), visibility = SHADER_VISIBILITY_PIXEL ),"\
+    "DescriptorTable ( Sampler(s0), visibility = SHADER_VISIBILITY_PIXEL )"
+
+[RootSignature(ColorRS)]
+VertexShaderOutput mainColor(VertexShaderInput input)
+{
+    VertexShaderOutput output;
+    float4 pos = float4(input.pos, 1.0f);
+
+    // Transform the vertex position into projected space.
+    pos = mul(pos, Constants.model);
+    pos = mul(pos, Constants.projectionAndView);
+    output.pos = pos;
+
+    // Pass through texture coordinates and color values without transformation
+    output.tex = input.tex;
+    output.color = input.color;
+
+    return output;
+}
+
+[RootSignature(TextureRS)]
+VertexShaderOutput mainTexture(VertexShaderInput input)
+{
+    return mainColor(input);
+}
+
+[RootSignature(YUVRS)]
+VertexShaderOutput mainYUV(VertexShaderInput input)
+{
+    return mainColor(input);
+}
+
+[RootSignature(NVRS)]
+VertexShaderOutput mainNV(VertexShaderInput input)
+{
+    return mainColor(input);
+}

--- a/VisualC-GDK/shaders/buildshaders.bat
+++ b/VisualC-GDK/shaders/buildshaders.bat
@@ -1,0 +1,25 @@
+set XBOXDXC="%GameDKLatest%\GXDK\bin\Scarlett\DXC.exe"
+echo Building with %XBOXDXC%
+cd "%1\shaders"
+rem Root Signatures
+%XBOXDXC% -E ColorRS -T rootsig_1_1 -rootsig-define ColorRS -Fh D3D12_RootSig_Color D3D12_VertexShader.hlsl
+%XBOXDXC% -E TextureRS -T rootsig_1_1 -rootsig-define TextureRS -Fh D3D12_RootSig_Texture D3D12_VertexShader.hlsl
+%XBOXDXC% -E YUVRS -T rootsig_1_1 -rootsig-define YUVRS -Fh D3D12_RootSig_YUV D3D12_VertexShader.hlsl
+%XBOXDXC% -E NVRS -T rootsig_1_1 -rootsig-define NVRS -Fh D3D12_RootSig_NV D3D12_VertexShader.hlsl
+rem Vertex Shaders
+%XBOXDXC% -E mainColor -T vs_6_0 -Fh D3D12_VertexShader_Color D3D12_VertexShader.hlsl
+%XBOXDXC% -E mainTexture -T vs_6_0 -Fh D3D12_VertexShader_Texture D3D12_VertexShader.hlsl
+%XBOXDXC% -E mainNV -T vs_6_0 -Fh D3D12_VertexShader_NV D3D12_VertexShader.hlsl
+%XBOXDXC% -E mainYUV -T vs_6_0 -Fh D3D12_VertexShader_YUV D3D12_VertexShader.hlsl
+rem Pixel Shaders
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_Colors D3D12_PixelShader_Colors.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_NV12_BT601 D3D12_PixelShader_NV12_BT601.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_NV12_BT709 D3D12_PixelShader_NV12_BT709.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_NV12_JPEG D3D12_PixelShader_NV12_JPEG.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_NV21_BT601 D3D12_PixelShader_NV21_BT601.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_NV21_BT709 D3D12_PixelShader_NV21_BT709.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_NV21_JPEG D3D12_PixelShader_NV21_JPEG.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_Textures D3D12_PixelShader_Textures.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_YUV_BT601 D3D12_PixelShader_YUV_BT601.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_YUV_BT709 D3D12_PixelShader_YUV_BT709.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_YUV_JPEG D3D12_PixelShader_YUV_JPEG.hlsl

--- a/VisualC-GDK/shaders/buildshaders.bat
+++ b/VisualC-GDK/shaders/buildshaders.bat
@@ -1,25 +1,35 @@
+if %2.==one. goto setxboxone
+rem Xbox Series compile
 set XBOXDXC="%GameDKLatest%\GXDK\bin\Scarlett\DXC.exe"
+set SUFFIX=_Series.h
+goto startbuild
+
+:setxboxone
+set XBOXDXC="%GameDKLatest%\GXDK\bin\XboxOne\DXC.exe"
+set SUFFIX=_One.h
+
+:startbuild
 echo Building with %XBOXDXC%
 cd "%1\shaders"
 rem Root Signatures
-%XBOXDXC% -E ColorRS -T rootsig_1_1 -rootsig-define ColorRS -Fh D3D12_RootSig_Color D3D12_VertexShader.hlsl
-%XBOXDXC% -E TextureRS -T rootsig_1_1 -rootsig-define TextureRS -Fh D3D12_RootSig_Texture D3D12_VertexShader.hlsl
-%XBOXDXC% -E YUVRS -T rootsig_1_1 -rootsig-define YUVRS -Fh D3D12_RootSig_YUV D3D12_VertexShader.hlsl
-%XBOXDXC% -E NVRS -T rootsig_1_1 -rootsig-define NVRS -Fh D3D12_RootSig_NV D3D12_VertexShader.hlsl
+%XBOXDXC% -E ColorRS -T rootsig_1_1 -rootsig-define ColorRS -Fh D3D12_RootSig_Color%SUFFIX% -Vn D3D12_RootSig_Color D3D12_VertexShader.hlsl
+%XBOXDXC% -E TextureRS -T rootsig_1_1 -rootsig-define TextureRS -Fh D3D12_RootSig_Texture%SUFFIX% -Vn D3D12_RootSig_Texture D3D12_VertexShader.hlsl
+%XBOXDXC% -E YUVRS -T rootsig_1_1 -rootsig-define YUVRS -Fh D3D12_RootSig_YUV%SUFFIX% -Vn D3D12_RootSig_YUV D3D12_VertexShader.hlsl
+%XBOXDXC% -E NVRS -T rootsig_1_1 -rootsig-define NVRS -Fh D3D12_RootSig_NV%SUFFIX% -Vn D3D12_RootSig_NV D3D12_VertexShader.hlsl
 rem Vertex Shaders
-%XBOXDXC% -E mainColor -T vs_6_0 -Fh D3D12_VertexShader_Color D3D12_VertexShader.hlsl
-%XBOXDXC% -E mainTexture -T vs_6_0 -Fh D3D12_VertexShader_Texture D3D12_VertexShader.hlsl
-%XBOXDXC% -E mainNV -T vs_6_0 -Fh D3D12_VertexShader_NV D3D12_VertexShader.hlsl
-%XBOXDXC% -E mainYUV -T vs_6_0 -Fh D3D12_VertexShader_YUV D3D12_VertexShader.hlsl
+%XBOXDXC% -E mainColor -T vs_6_0 -Fh D3D12_VertexShader_Color%SUFFIX% -Vn D3D12_VertexShader_Color D3D12_VertexShader.hlsl
+%XBOXDXC% -E mainTexture -T vs_6_0 -Fh D3D12_VertexShader_Texture%SUFFIX% -Vn D3D12_VertexShader_Texture D3D12_VertexShader.hlsl
+%XBOXDXC% -E mainNV -T vs_6_0 -Fh D3D12_VertexShader_NV%SUFFIX% -Vn D3D12_VertexShader_NV D3D12_VertexShader.hlsl
+%XBOXDXC% -E mainYUV -T vs_6_0 -Fh D3D12_VertexShader_YUV%SUFFIX% -Vn D3D12_VertexShader_YUV D3D12_VertexShader.hlsl
 rem Pixel Shaders
-%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_Colors D3D12_PixelShader_Colors.hlsl
-%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_NV12_BT601 D3D12_PixelShader_NV12_BT601.hlsl
-%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_NV12_BT709 D3D12_PixelShader_NV12_BT709.hlsl
-%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_NV12_JPEG D3D12_PixelShader_NV12_JPEG.hlsl
-%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_NV21_BT601 D3D12_PixelShader_NV21_BT601.hlsl
-%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_NV21_BT709 D3D12_PixelShader_NV21_BT709.hlsl
-%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_NV21_JPEG D3D12_PixelShader_NV21_JPEG.hlsl
-%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_Textures D3D12_PixelShader_Textures.hlsl
-%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_YUV_BT601 D3D12_PixelShader_YUV_BT601.hlsl
-%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_YUV_BT709 D3D12_PixelShader_YUV_BT709.hlsl
-%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_YUV_JPEG D3D12_PixelShader_YUV_JPEG.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_Colors%SUFFIX% -Vn D3D12_PixelShader_Colors D3D12_PixelShader_Colors.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_NV12_BT601%SUFFIX% -Vn D3D12_PixelShader_NV12_BT601 D3D12_PixelShader_NV12_BT601.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_NV12_BT709%SUFFIX% -Vn D3D12_PixelShader_NV12_BT709 D3D12_PixelShader_NV12_BT709.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_NV12_JPEG%SUFFIX% -Vn D3D12_PixelShader_NV12_JPEG D3D12_PixelShader_NV12_JPEG.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_NV21_BT601%SUFFIX% -Vn D3D12_PixelShader_NV21_BT601 D3D12_PixelShader_NV21_BT601.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_NV21_BT709%SUFFIX% -Vn D3D12_PixelShader_NV21_BT709 D3D12_PixelShader_NV21_BT709.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_NV21_JPEG%SUFFIX% -Vn D3D12_PixelShader_NV21_JPEG D3D12_PixelShader_NV21_JPEG.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_Textures%SUFFIX% -Vn D3D12_PixelShader_Textures D3D12_PixelShader_Textures.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_YUV_BT601%SUFFIX% -Vn D3D12_PixelShader_YUV_BT601 D3D12_PixelShader_YUV_BT601.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_YUV_BT709%SUFFIX% -Vn D3D12_PixelShader_YUV_BT709 D3D12_PixelShader_YUV_BT709.hlsl
+%XBOXDXC% -E main -T ps_6_0 -Fh D3D12_PixelShader_YUV_JPEG%SUFFIX% -Vn D3D12_PixelShader_YUV_JPEG D3D12_PixelShader_YUV_JPEG.hlsl

--- a/VisualC-GDK/tests/testcontroller/testcontroller.vcxproj
+++ b/VisualC-GDK/tests/testcontroller/testcontroller.vcxproj
@@ -139,7 +139,7 @@
     </ResourceCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>xgameruntime.lib;../Microsoft.Xbox.Services.141.GDK.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>xgameruntime.lib;../Microsoft.Xbox.Services.GDK.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.Scarlett.x64'">
@@ -211,7 +211,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>xgameruntime.lib;../Microsoft.Xbox.Services.141.GDK.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>xgameruntime.lib;../Microsoft.Xbox.Services.GDK.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.Scarlett.x64'">
@@ -273,6 +273,12 @@
       <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
       <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
     </ProjectReference>
+    <ProjectReference Include="..\..\SDL_test\SDL_test.vcxproj">
+      <Project>{da956fd3-e143-46f2-9fe5-c77bebc56b1a}</Project>
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\test\gamepadutils.c" />
@@ -298,7 +304,7 @@
     <CopyFileToFolders Include="..\..\logos\Logo480x480.png" />
   </ItemGroup>
   <ItemGroup>
-    <CopyFileToFolders Include="$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.141.GDK.C.Thunks.dll">
+    <CopyFileToFolders Include="$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.GDK.C.Thunks.dll">
       <FileType>Document</FileType>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.Scarlett.x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.XboxOne.x64'">true</ExcludedFromBuild>

--- a/VisualC-GDK/tests/testcontroller/testcontroller.vcxproj.filters
+++ b/VisualC-GDK/tests/testcontroller/testcontroller.vcxproj.filters
@@ -18,9 +18,6 @@
     <CopyFileToFolders Include="..\..\logos\Logo480x480.png">
       <Filter>logos</Filter>
     </CopyFileToFolders>
-    <CopyFileToFolders Include="$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.141.GDK.C.Thunks.dll">
-      <Filter>wingdk</Filter>
-    </CopyFileToFolders>
     <CopyFileToFolders Include="wingdk\MicrosoftGame.config">
       <Filter>wingdk</Filter>
     </CopyFileToFolders>
@@ -34,6 +31,9 @@
       <Filter>logos</Filter>
     </CopyFileToFolders>
     <CopyFileToFolders Include="PackageLayout.xml" />
+    <CopyFileToFolders Include="$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.GDK.C.Thunks.dll">
+      <Filter>wingdk</Filter>
+    </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="logos">

--- a/VisualC-GDK/tests/testgdk/testgdk.vcxproj
+++ b/VisualC-GDK/tests/testgdk/testgdk.vcxproj
@@ -139,7 +139,7 @@
     </ResourceCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>xgameruntime.lib;../Microsoft.Xbox.Services.141.GDK.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>xgameruntime.lib;../Microsoft.Xbox.Services.GDK.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>
@@ -223,7 +223,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>xgameruntime.lib;../Microsoft.Xbox.Services.141.GDK.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>xgameruntime.lib;../Microsoft.Xbox.Services.GDK.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>
@@ -346,7 +346,7 @@ copy "%(FullPath)" "$(OutDir)\"</Command>
     </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
-    <CopyFileToFolders Include="$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.141.GDK.C.Thunks.dll">
+    <CopyFileToFolders Include="$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.GDK.C.Thunks.dll">
       <FileType>Document</FileType>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.Scarlett.x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.XboxOne.x64'">true</ExcludedFromBuild>

--- a/VisualC-GDK/tests/testgdk/testgdk.vcxproj.filters
+++ b/VisualC-GDK/tests/testgdk/testgdk.vcxproj.filters
@@ -18,9 +18,6 @@
     <CopyFileToFolders Include="..\..\logos\Logo480x480.png">
       <Filter>logos</Filter>
     </CopyFileToFolders>
-    <CopyFileToFolders Include="$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.141.GDK.C.Thunks.dll">
-      <Filter>wingdk</Filter>
-    </CopyFileToFolders>
     <CopyFileToFolders Include="wingdk\MicrosoftGame.config">
       <Filter>wingdk</Filter>
     </CopyFileToFolders>
@@ -35,6 +32,9 @@
       <Filter>logos</Filter>
     </CopyFileToFolders>
     <CopyFileToFolders Include="PackageLayout.xml" />
+    <CopyFileToFolders Include="$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.GDK.C.Thunks.dll">
+      <Filter>wingdk</Filter>
+    </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="logos">

--- a/VisualC-GDK/tests/testsprite/testsprite.vcxproj
+++ b/VisualC-GDK/tests/testsprite/testsprite.vcxproj
@@ -139,7 +139,7 @@
     </ResourceCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>xgameruntime.lib;../Microsoft.Xbox.Services.141.GDK.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>xgameruntime.lib;../Microsoft.Xbox.Services.GDK.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>
@@ -223,7 +223,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>xgameruntime.lib;../Microsoft.Xbox.Services.141.GDK.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>xgameruntime.lib;../Microsoft.Xbox.Services.GDK.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>
@@ -346,7 +346,7 @@ copy "%(FullPath)" "$(OutDir)\"</Command>
     </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
-    <CopyFileToFolders Include="$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.141.GDK.C.Thunks.dll">
+    <CopyFileToFolders Include="$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.GDK.C.Thunks.dll">
       <FileType>Document</FileType>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.Scarlett.x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.XboxOne.x64'">true</ExcludedFromBuild>

--- a/VisualC-GDK/tests/testsprite/testsprite.vcxproj.filters
+++ b/VisualC-GDK/tests/testsprite/testsprite.vcxproj.filters
@@ -18,9 +18,6 @@
     <CopyFileToFolders Include="..\..\logos\Logo480x480.png">
       <Filter>logos</Filter>
     </CopyFileToFolders>
-    <CopyFileToFolders Include="$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.141.GDK.C.Thunks.dll">
-      <Filter>wingdk</Filter>
-    </CopyFileToFolders>
     <CopyFileToFolders Include="xboxseries\MicrosoftGame.config">
       <Filter>xboxseries</Filter>
     </CopyFileToFolders>
@@ -34,6 +31,9 @@
       <Filter>logos</Filter>
     </CopyFileToFolders>
     <CopyFileToFolders Include="PackageLayout.xml" />
+    <CopyFileToFolders Include="$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.GDK.C.Thunks.dll">
+      <Filter>wingdk</Filter>
+    </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="logos">

--- a/docs/README-gdk.md
+++ b/docs/README-gdk.md
@@ -3,15 +3,16 @@ GDK
 
 This port allows SDL applications to run via Microsoft's Game Development Kit (GDK).
 
-Windows (GDK) and  Xbox One/Xbox Series (GDKX) are supported. Although most of the Xbox code is included in the public SDL source code, NDA access is required for a small number of source files. If you have access to GDKX, these required Xbox files are posted on the GDK forums [here](https://forums.xboxlive.com/questions/130003/).
+Windows (GDK) and  Xbox One/Xbox Series (GDKX) are both supported and all the required code is included in this public SDL release. However, only licensed Xbox developers have access to the GDKX libraries which will allow you to build the Xbox targets.
 
 
 Requirements
 ------------
 
 * Microsoft Visual Studio 2022 (in theory, it should also work in 2017 or 2019, but this has not been tested)
-* Microsoft GDK June 2022 or newer (public release [here](https://github.com/microsoft/GDK/releases/tag/June_2022))
-* To publish a package or successfully authenticate a user, you will need to create an app id/configure services in Partner Center. However, for local testing purposes (without authenticating on Xbox Live), the identifiers used by the GDK test programs in the included solution will work.
+* Microsoft GDK October 2023 Update 1 or newer (public release [here](https://github.com/microsoft/GDK/releases/tag/October_2023_Update_1))
+* For Xbox, you will need the corresponding GDKX version (licensed developers only)
+* To publish a package or successfully authenticate a user, you will need to create an app id/configure services in Partner Center. However, for local testing purposes (without authenticating on Xbox Live), the test identifiers used by the GDK test programs in the included solution work.
 
 
 Windows GDK Status
@@ -32,8 +33,8 @@ The Windows GDK port supports the full set of Win32 APIs, renderers, controllers
 * Single-player games have some additional features available:
   * Call `SDL_GDKGetDefaultUser` to get the default XUserHandle pointer.
   * `SDL_GetPrefPath` still works, but only for single-player titles.
-
-These functions mostly wrap around async APIs, and thus should be treated as synchronous alternatives. Also note that the single-player functions return on any OS errors, so be sure to validate the return values!
+  
+  These functions mostly wrap around async APIs, and thus should be treated as synchronous alternatives. Also note that the single-player functions return on any OS errors, so be sure to validate the return values!
 
 * What doesn't work:
   * Compilation with anything other than through the included Visual C++ solution file
@@ -74,7 +75,7 @@ While the Gaming.Desktop.x64 configuration sets most of the required settings, t
 * Under Linker > Input > Additional Dependencies, you need the following:
   * `SDL3.lib`
   * `xgameruntime.lib`
-  * `../Microsoft.Xbox.Services.141.GDK.C.Thunks.lib`
+  * `../Microsoft.Xbox.Services.GDK.C.Thunks.lib`
 * Note that in general, the GDK libraries depend on the MSVC C/C++ runtime, so there is no way to remove this dependency from a GDK program that links against GDK.
 
 ### 4. Setting up SDL_main ###
@@ -86,7 +87,7 @@ Rather than using your own implementation of `WinMain`, it's recommended that yo
 The game will not launch in the debugger unless required DLLs are included in the directory that contains the game's .exe file. You need to make sure that the following files are copied into the directory:
 
 * Your SDL3.dll
-* "$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.141.GDK.C.Thunks.dll"
+* "$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.GDK.C.Thunks.dll"
 * XCurl.dll
 
 You can either copy these in a post-build step, or you can add the dlls into the project and set its Configuration Properties > General > Item type to "Copy file," which will also copy them into the output directory.
@@ -143,6 +144,20 @@ To create the package:
 6. Once the package is installed, you can run it from the start menu.
 7. As with when running from Visual Studio, if you need to test any Xbox Live functionality you must switch to the correct sandbox.
 
+Xbox GDKX Setup
+---------------------
+In general, the same process in the Windows GDK instructions work. There are just a few additional notes:
+* For Xbox One consoles, use the Gaming.Xbox.XboxOne.x64 target
+* For Xbox Series consoles, use the Gaming.Xbox.Scarlett.x64 target
+* The Xbox One target sets the `__XBOXONE__` define and the Xbox Series target sets the `__XBOXSERIES__` define
+* You don't need to link against the Xbox.Services Thunks lib nor include that dll in your package (it doesn't exist for Xbox)
+* The shader blobs for Xbox are created in a pre-build step for the Xbox targets, rather than included in the source (due to NDA and version compatability reasons)
+* To create a package, use:
+  `makepkg pack /f PackageLayout.xml /lt /d . /pd Package`
+* To install the package, use:
+  `xbapp install [PACKAGE].xvc`
+* For some reason, if you make changes that require SDL3.dll to build, and you are running through the debugger (instead of a package), you have to rebuild your .exe target for the debugger to recognize the dll has changed and needs to be transferred to the console again
+* While there are successful releases of Xbox titles using this port, it is not as extensively tested as other targets
 
 Troubleshooting
 ---------------

--- a/src/core/SDL_core_unsupported.c
+++ b/src/core/SDL_core_unsupported.c
@@ -224,3 +224,12 @@ Sint32 JNI_OnLoad(void *vm, void *reserved)
     return -1; /* JNI_ERR */
 }
 #endif
+
+#if defined(__XBOXONE__) || defined(__XBOXSERIES__)
+char *SDL_GetUserFolder(SDL_Folder folder)
+{
+    (void)folder;
+    SDL_Unsupported();
+    return NULL;
+}
+#endif

--- a/src/filesystem/gdk/SDL_sysfilesystem.cpp
+++ b/src/filesystem/gdk/SDL_sysfilesystem.cpp
@@ -18,7 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "../../SDL_internal.h"
+#include "SDL_internal.h"
 
 #ifdef SDL_FILESYSTEM_XBOX
 
@@ -26,9 +26,9 @@
 /* System dependent filesystem routines                                */
 
 #include "../../core/windows/SDL_windows.h"
-#include "SDL_hints.h"
-#include "SDL_system.h"
-#include "SDL_filesystem.h"
+#include <SDL3/SDL_hints.h>
+#include <SDL3/SDL_system.h>
+#include <SDL3/SDL_filesystem.h>
 #include <XGameSaveFiles.h>
 
 char *

--- a/src/render/direct3d12/SDL_render_d3d12.c
+++ b/src/render/direct3d12/SDL_render_d3d12.c
@@ -1435,7 +1435,7 @@ static void D3D12_FreeSRVIndex(SDL_Renderer *renderer, SIZE_T index)
 
 static int GetTextureProperty(SDL_PropertiesID props, const char *name, ID3D12Resource **texture)
 {
-    IUnknown *unknown = SDL_GetProperty(props, name, NULL);
+    IUnknown *unknown = (IUnknown*)SDL_GetProperty(props, name, NULL);
     if (unknown) {
         HRESULT result = D3D_CALL(unknown, QueryInterface, D3D_GUID(SDL_IID_ID3D12Resource), (void **)texture);
         if (FAILED(result)) {

--- a/src/render/direct3d12/SDL_render_d3d12_xbox.cpp
+++ b/src/render/direct3d12/SDL_render_d3d12_xbox.cpp
@@ -19,9 +19,156 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-#include "SDL_internal.h"
-#if defined(SDL_VIDEO_RENDER_D3D12) && !defined(SDL_RENDER_DISABLED) && (defined(__XBOXONE__) || defined(__XBOXSERIES__))
+#include "../../SDL_internal.h"
+#if SDL_VIDEO_RENDER_D3D12 && !SDL_RENDER_DISABLED && (defined(__XBOXONE__) || defined(__XBOXSERIES__))
 #include "SDL_render_d3d12_xbox.h"
+#include "../../core/windows/SDL_windows.h"
+#include <XGameRuntime.h>
 
-#error "This is a placeholder Xbox file, as the real one is under NDA. See README-gdk.md for more info."
+#if defined(_MSC_VER) && !defined(__clang__)
+#define SDL_COMPOSE_ERROR(str) __FUNCTION__ ", " str
+#else
+#define SDL_COMPOSE_ERROR(str) SDL_STRINGIFY_ARG(__FUNCTION__) ", " str
+#endif
+
+static const GUID SDL_IID_ID3D12Device1 = { 0x77acce80, 0x638e, 0x4e65, { 0x88, 0x95, 0xc1, 0xf2, 0x33, 0x86, 0x86, 0x3e } };
+static const GUID SDL_IID_ID3D12Resource = { 0x696442be, 0xa72e, 0x4059, { 0xbc, 0x79, 0x5b, 0x5c, 0x98, 0x04, 0x0f, 0xad } };
+static const GUID SDL_IID_IDXGIDevice1 = { 0x77db970f, 0x6276, 0x48ba, { 0xba, 0x28, 0x07, 0x01, 0x43, 0xb4, 0x39, 0x2c } };
+
+extern "C" HRESULT
+D3D12_XBOX_CreateDevice(ID3D12Device **device, SDL_bool createDebug)
+{
+    HRESULT result;
+    D3D12XBOX_CREATE_DEVICE_PARAMETERS params;
+    IDXGIDevice1 *dxgiDevice;
+    IDXGIAdapter *dxgiAdapter;
+    IDXGIOutput *dxgiOutput;
+    SDL_zero(params);
+
+    params.Version = D3D12_SDK_VERSION;
+    params.ProcessDebugFlags = createDebug ? D3D12_PROCESS_DEBUG_FLAG_DEBUG_LAYER_ENABLED : D3D12XBOX_PROCESS_DEBUG_FLAG_NONE;
+    params.GraphicsCommandQueueRingSizeBytes = D3D12XBOX_DEFAULT_SIZE_BYTES;
+    params.GraphicsScratchMemorySizeBytes = D3D12XBOX_DEFAULT_SIZE_BYTES;
+    params.ComputeScratchMemorySizeBytes = D3D12XBOX_DEFAULT_SIZE_BYTES;
+
+    result = D3D12XboxCreateDevice(NULL, &params, SDL_IID_ID3D12Device1, (void **) device);
+    if (FAILED(result)) {
+        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("[xbox] D3D12XboxCreateDevice"), result);
+        goto done;
+    }
+
+    result = (*device)->QueryInterface(SDL_IID_IDXGIDevice1, (void **) &dxgiDevice);
+    if (FAILED(result)) {
+        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("[xbox] ID3D12Device to IDXGIDevice1"), result);
+        goto done;
+    }
+
+    result = dxgiDevice->GetAdapter(&dxgiAdapter);
+    if (FAILED(result)) {
+        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("[xbox] dxgiDevice->GetAdapter"), result);
+        goto done;
+    }
+
+    result = dxgiAdapter->EnumOutputs(0, &dxgiOutput);
+    if (FAILED(result)) {
+        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("[xbox] dxgiAdapter->EnumOutputs"), result);
+        goto done;
+    }
+    
+    /* Set frame interval */
+    result = (*device)->SetFrameIntervalX(dxgiOutput, D3D12XBOX_FRAME_INTERVAL_60_HZ, 1, D3D12XBOX_FRAME_INTERVAL_FLAG_NONE);
+    if (FAILED(result)) {
+        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("[xbox] SetFrameIntervalX"), result);
+        goto done;
+    }
+
+    result = (*device)->ScheduleFrameEventX(D3D12XBOX_FRAME_EVENT_ORIGIN, 0, NULL, D3D12XBOX_SCHEDULE_FRAME_EVENT_FLAG_NONE);
+    if (FAILED(result)) {
+        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("[xbox] ScheduleFrameEventX"), result);
+        goto done;
+    }
+
+done:
+    return result;
+}
+
+extern "C" HRESULT
+D3D12_XBOX_CreateBackBufferTarget(ID3D12Device1 *device, int width, int height, void **resource)
+{
+
+    D3D12_HEAP_PROPERTIES heapProps;
+    D3D12_RESOURCE_DESC resourceDesc;
+
+    SDL_zero(heapProps);
+    heapProps.Type = D3D12_HEAP_TYPE_DEFAULT;
+    heapProps.CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN;
+    heapProps.MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN;
+    heapProps.CreationNodeMask = 1;
+    heapProps.VisibleNodeMask = 1;
+
+    SDL_zero(resourceDesc);
+    resourceDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+    resourceDesc.Alignment = 0;
+    resourceDesc.Width = width;
+    resourceDesc.Height = height;
+    resourceDesc.DepthOrArraySize = 1;
+    resourceDesc.MipLevels = 1;
+    resourceDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+    resourceDesc.SampleDesc.Count = 1;
+    resourceDesc.SampleDesc.Quality = 0;
+    resourceDesc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+    resourceDesc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+
+    return device->CreateCommittedResource(&heapProps,
+        D3D12_HEAP_FLAG_ALLOW_DISPLAY,
+        &resourceDesc,
+        D3D12_RESOURCE_STATE_PRESENT,
+        NULL,
+        SDL_IID_ID3D12Resource,
+        resource
+        );
+}
+
+extern "C" HRESULT
+D3D12_XBOX_StartFrame(ID3D12Device1 *device, UINT64 *outToken)
+{
+    *outToken = D3D12XBOX_FRAME_PIPELINE_TOKEN_NULL;
+    return device->WaitFrameEventX(D3D12XBOX_FRAME_EVENT_ORIGIN, INFINITE, NULL, D3D12XBOX_WAIT_FRAME_EVENT_FLAG_NONE, outToken);
+}
+
+extern "C" HRESULT
+D3D12_XBOX_PresentFrame(ID3D12CommandQueue *commandQueue, UINT64 token, ID3D12Resource *renderTarget)
+{
+    D3D12XBOX_PRESENT_PLANE_PARAMETERS planeParameters;
+    SDL_zero(planeParameters);
+    planeParameters.Token = token;
+    planeParameters.ResourceCount = 1;
+    planeParameters.ppResources = &renderTarget;
+    return commandQueue->PresentX(1, &planeParameters, NULL);
+}
+
+extern "C" void
+D3D12_XBOX_GetResolution(Uint32 *width, Uint32 *height)
+{
+    switch (XSystemGetDeviceType()) {
+    case XSystemDeviceType::XboxScarlettLockhart:
+        *width = 2560;
+        *height = 1440;
+        break;
+
+    case XSystemDeviceType::XboxOneX:
+    case XSystemDeviceType::XboxScarlettAnaconda:
+    case XSystemDeviceType::XboxOneXDevkit:
+    case XSystemDeviceType::XboxScarlettDevkit:
+        *width = 3840;
+        *height = 2160;
+        break;
+
+    default:
+        *width = 1920;
+        *height = 1080;
+        break;
+    }
+}
+
 #endif

--- a/src/render/direct3d12/SDL_render_d3d12_xbox.h
+++ b/src/render/direct3d12/SDL_render_d3d12_xbox.h
@@ -19,4 +19,31 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-#error "This is a placeholder Xbox file, as the real one is under NDA. See README-gdk.md for more info."
+#ifndef SDL_render_d3d12_xbox_h_
+#define SDL_render_d3d12_xbox_h_
+
+#include "../../SDL_internal.h"
+
+#if defined(__XBOXONE__)
+#include <d3d12_x.h>
+#else /* __XBOXSERIES__ */
+#include <d3d12_xs.h>
+#endif
+
+/* Set up for C function definitions, even when using C++ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern HRESULT D3D12_XBOX_CreateDevice(ID3D12Device **device, SDL_bool createDebug);
+extern HRESULT D3D12_XBOX_CreateBackBufferTarget(ID3D12Device1 *device, int width, int height, void **resource);
+extern HRESULT D3D12_XBOX_StartFrame(ID3D12Device1 *device, UINT64 *outToken);
+extern HRESULT D3D12_XBOX_PresentFrame(ID3D12CommandQueue *commandQueue, UINT64 token, ID3D12Resource *renderTarget);
+extern void D3D12_XBOX_GetResolution(Uint32 *width, Uint32 *height);
+
+/* Ends C function definitions when using C++ */
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/render/direct3d12/SDL_shaders_d3d12_xboxone.cpp
+++ b/src/render/direct3d12/SDL_shaders_d3d12_xboxone.cpp
@@ -18,10 +18,127 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_internal.h"
+#include "../../SDL_internal.h"
 
-#if defined(SDL_VIDEO_RENDER_D3D12) && !defined(SDL_RENDER_DISABLED) && defined(__XBOXONE__)
+#if SDL_VIDEO_RENDER_D3D12 && !SDL_RENDER_DISABLED && defined(__XBOXONE__)
 
-#error "This is a placeholder Xbox file, as the real one is under NDA. See README-gdk.md for more info."
+#include <SDL3/SDL_stdinc.h>
+
+#include "../../core/windows/SDL_windows.h"
+#include <d3d12_x.h>
+
+#include "SDL_shaders_d3d12.h"
+
+#define SDL_COMPOSE_ERROR(str) SDL_STRINGIFY_ARG(__FUNCTION__) ", " str
+
+/* Shader blob headers are generated with a pre-build step using buildshaders.bat */
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_Colors_One.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_NV12_BT601_One.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_NV12_BT709_One.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_NV12_JPEG_One.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_NV21_BT601_One.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_NV21_BT709_One.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_NV21_JPEG_One.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_Textures_One.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_YUV_BT601_One.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_YUV_BT709_One.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_YUV_JPEG_One.h"
+
+#include "../VisualC-GDK/shaders/D3D12_VertexShader_Color_One.h"
+#include "../VisualC-GDK/shaders/D3D12_VertexShader_NV_One.h"
+#include "../VisualC-GDK/shaders/D3D12_VertexShader_Texture_One.h"
+#include "../VisualC-GDK/shaders/D3D12_VertexShader_YUV_One.h"
+
+#include "../VisualC-GDK/shaders/D3D12_RootSig_Color_One.h"
+#include "../VisualC-GDK/shaders/D3D12_RootSig_NV_One.h"
+#include "../VisualC-GDK/shaders/D3D12_RootSig_Texture_One.h"
+#include "../VisualC-GDK/shaders/D3D12_RootSig_YUV_One.h"
+
+static struct
+{
+    const void *ps_shader_data;
+    SIZE_T ps_shader_size;
+    const void *vs_shader_data;
+    SIZE_T vs_shader_size;
+    D3D12_RootSignature root_sig;
+} D3D12_shaders[NUM_SHADERS] = {
+    { D3D12_PixelShader_Colors, sizeof(D3D12_PixelShader_Colors),
+      D3D12_VertexShader_Color, sizeof(D3D12_VertexShader_Color),
+      ROOTSIG_COLOR },
+    { D3D12_PixelShader_Textures, sizeof(D3D12_PixelShader_Textures),
+      D3D12_VertexShader_Texture, sizeof(D3D12_VertexShader_Texture),
+      ROOTSIG_TEXTURE },
+#if SDL_HAVE_YUV
+    { D3D12_PixelShader_YUV_JPEG, sizeof(D3D12_PixelShader_YUV_JPEG),
+      D3D12_VertexShader_YUV, sizeof(D3D12_VertexShader_YUV),
+      ROOTSIG_YUV },
+    { D3D12_PixelShader_YUV_BT601, sizeof(D3D12_PixelShader_YUV_BT601),
+      D3D12_VertexShader_YUV, sizeof(D3D12_VertexShader_YUV),
+      ROOTSIG_YUV },
+    { D3D12_PixelShader_YUV_BT709, sizeof(D3D12_PixelShader_YUV_BT709),
+      D3D12_VertexShader_YUV, sizeof(D3D12_VertexShader_YUV),
+      ROOTSIG_YUV },
+    { D3D12_PixelShader_NV12_JPEG, sizeof(D3D12_PixelShader_NV12_JPEG),
+      D3D12_VertexShader_NV, sizeof(D3D12_VertexShader_NV),
+      ROOTSIG_NV },
+    { D3D12_PixelShader_NV12_BT601, sizeof(D3D12_PixelShader_NV12_BT601),
+      D3D12_VertexShader_NV, sizeof(D3D12_VertexShader_NV),
+      ROOTSIG_NV },
+    { D3D12_PixelShader_NV12_BT709, sizeof(D3D12_PixelShader_NV12_BT709),
+      D3D12_VertexShader_NV, sizeof(D3D12_VertexShader_NV),
+      ROOTSIG_NV },
+    { D3D12_PixelShader_NV21_JPEG, sizeof(D3D12_PixelShader_NV21_JPEG),
+      D3D12_VertexShader_NV, sizeof(D3D12_VertexShader_NV),
+      ROOTSIG_NV },
+    { D3D12_PixelShader_NV21_BT601, sizeof(D3D12_PixelShader_NV21_BT601),
+      D3D12_VertexShader_NV, sizeof(D3D12_VertexShader_NV),
+      ROOTSIG_NV },
+    { D3D12_PixelShader_NV21_BT709, sizeof(D3D12_PixelShader_NV21_BT709),
+      D3D12_VertexShader_NV, sizeof(D3D12_VertexShader_NV),
+      ROOTSIG_NV },
+#endif
+};
+
+static struct
+{
+    const void *rs_shader_data;
+    SIZE_T rs_shader_size;
+} D3D12_rootsigs[NUM_ROOTSIGS] = {
+    { D3D12_RootSig_Color, sizeof(D3D12_RootSig_Color) },
+    { D3D12_RootSig_Texture, sizeof(D3D12_RootSig_Texture) },
+#if SDL_HAVE_YUV
+    { D3D12_RootSig_YUV, sizeof(D3D12_RootSig_YUV) },
+    { D3D12_RootSig_NV, sizeof(D3D12_RootSig_NV) },
+#endif
+};
+
+extern "C" void
+D3D12_GetVertexShader(D3D12_Shader shader, D3D12_SHADER_BYTECODE *outBytecode)
+{
+    outBytecode->pShaderBytecode = D3D12_shaders[shader].vs_shader_data;
+    outBytecode->BytecodeLength = D3D12_shaders[shader].vs_shader_size;
+}
+
+extern "C" void
+D3D12_GetPixelShader(D3D12_Shader shader, D3D12_SHADER_BYTECODE *outBytecode)
+{
+    outBytecode->pShaderBytecode = D3D12_shaders[shader].ps_shader_data;
+    outBytecode->BytecodeLength = D3D12_shaders[shader].ps_shader_size;
+}
+
+extern "C" D3D12_RootSignature
+D3D12_GetRootSignatureType(D3D12_Shader shader)
+{
+    return D3D12_shaders[shader].root_sig;
+}
+
+extern "C" void
+D3D12_GetRootSignatureData(D3D12_RootSignature rootSig, D3D12_SHADER_BYTECODE *outBytecode)
+{
+    outBytecode->pShaderBytecode = D3D12_rootsigs[rootSig].rs_shader_data;
+    outBytecode->BytecodeLength = D3D12_rootsigs[rootSig].rs_shader_size;
+}
 
 #endif /* SDL_VIDEO_RENDER_D3D12 && !SDL_RENDER_DISABLED && defined(__XBOXONE__) */
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/src/render/direct3d12/SDL_shaders_d3d12_xboxseries.cpp
+++ b/src/render/direct3d12/SDL_shaders_d3d12_xboxseries.cpp
@@ -18,10 +18,127 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_internal.h"
+#include "../../SDL_internal.h"
 
-#if defined(SDL_VIDEO_RENDER_D3D12) && !defined(SDL_RENDER_DISABLED) && defined(__XBOXSERIES__)
+#if SDL_VIDEO_RENDER_D3D12 && !SDL_RENDER_DISABLED && defined(__XBOXSERIES__)
 
-#error "This is a placeholder Xbox file, as the real one is under NDA. See README-gdk.md for more info."
+#include <SDL3/SDL_stdinc.h>
+
+#include "../../core/windows/SDL_windows.h"
+#include <d3d12_xs.h>
+
+#include "SDL_shaders_d3d12.h"
+
+#define SDL_COMPOSE_ERROR(str) SDL_STRINGIFY_ARG(__FUNCTION__) ", " str
+
+/* Shader blob headers are generated with a pre-build step using buildshaders.bat */
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_Colors_Series.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_Textures_Series.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_NV12_BT601_Series.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_NV12_BT709_Series.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_NV12_JPEG_Series.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_NV21_BT601_Series.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_NV21_BT709_Series.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_NV21_JPEG_Series.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_YUV_BT601_Series.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_YUV_BT709_Series.h"
+#include "../VisualC-GDK/shaders/D3D12_PixelShader_YUV_JPEG_Series.h"
+
+#include "../VisualC-GDK/shaders/D3D12_VertexShader_Color_Series.h"
+#include "../VisualC-GDK/shaders/D3D12_VertexShader_Texture_Series.h"
+#include "../VisualC-GDK/shaders/D3D12_VertexShader_NV_Series.h"
+#include "../VisualC-GDK/shaders/D3D12_VertexShader_YUV_Series.h"
+
+#include "../VisualC-GDK/shaders/D3D12_RootSig_Color_Series.h"
+#include "../VisualC-GDK/shaders/D3D12_RootSig_Texture_Series.h"
+#include "../VisualC-GDK/shaders/D3D12_RootSig_YUV_Series.h"
+#include "../VisualC-GDK/shaders/D3D12_RootSig_NV_Series.h"
+
+static struct
+{
+    const void *ps_shader_data;
+    SIZE_T ps_shader_size;
+    const void *vs_shader_data;
+    SIZE_T vs_shader_size;
+    D3D12_RootSignature root_sig;
+} D3D12_shaders[NUM_SHADERS] = {
+    { D3D12_PixelShader_Colors, sizeof(D3D12_PixelShader_Colors),
+      D3D12_VertexShader_Color, sizeof(D3D12_VertexShader_Color),
+      ROOTSIG_COLOR },
+    { D3D12_PixelShader_Textures, sizeof(D3D12_PixelShader_Textures),
+      D3D12_VertexShader_Texture, sizeof(D3D12_VertexShader_Texture),
+      ROOTSIG_TEXTURE },
+#if SDL_HAVE_YUV
+    { D3D12_PixelShader_YUV_JPEG, sizeof(D3D12_PixelShader_YUV_JPEG),
+      D3D12_VertexShader_YUV, sizeof(D3D12_VertexShader_YUV),
+      ROOTSIG_YUV },
+    { D3D12_PixelShader_YUV_BT601, sizeof(D3D12_PixelShader_YUV_BT601),
+      D3D12_VertexShader_YUV, sizeof(D3D12_VertexShader_YUV),
+      ROOTSIG_YUV },
+    { D3D12_PixelShader_YUV_BT709, sizeof(D3D12_PixelShader_YUV_BT709),
+      D3D12_VertexShader_YUV, sizeof(D3D12_VertexShader_YUV),
+      ROOTSIG_YUV },
+    { D3D12_PixelShader_NV12_JPEG, sizeof(D3D12_PixelShader_NV12_JPEG),
+      D3D12_VertexShader_NV, sizeof(D3D12_VertexShader_NV),
+      ROOTSIG_NV },
+    { D3D12_PixelShader_NV12_BT601, sizeof(D3D12_PixelShader_NV12_BT601),
+      D3D12_VertexShader_NV, sizeof(D3D12_VertexShader_NV),
+      ROOTSIG_NV },
+    { D3D12_PixelShader_NV12_BT709, sizeof(D3D12_PixelShader_NV12_BT709),
+      D3D12_VertexShader_NV, sizeof(D3D12_VertexShader_NV),
+      ROOTSIG_NV },
+    { D3D12_PixelShader_NV21_JPEG, sizeof(D3D12_PixelShader_NV21_JPEG),
+      D3D12_VertexShader_NV, sizeof(D3D12_VertexShader_NV),
+      ROOTSIG_NV },
+    { D3D12_PixelShader_NV21_BT601, sizeof(D3D12_PixelShader_NV21_BT601),
+      D3D12_VertexShader_NV, sizeof(D3D12_VertexShader_NV),
+      ROOTSIG_NV },
+    { D3D12_PixelShader_NV21_BT709, sizeof(D3D12_PixelShader_NV21_BT709),
+      D3D12_VertexShader_NV, sizeof(D3D12_VertexShader_NV),
+      ROOTSIG_NV },
+#endif
+};
+
+static struct
+{
+    const void *rs_shader_data;
+    SIZE_T rs_shader_size;
+} D3D12_rootsigs[NUM_ROOTSIGS] = {
+    { D3D12_RootSig_Color, sizeof(D3D12_RootSig_Color) },
+    { D3D12_RootSig_Texture, sizeof(D3D12_RootSig_Texture) },
+#if SDL_HAVE_YUV
+    { D3D12_RootSig_YUV, sizeof(D3D12_RootSig_YUV) },
+    { D3D12_RootSig_NV, sizeof(D3D12_RootSig_NV) },
+#endif
+};
+
+extern "C" void
+D3D12_GetVertexShader(D3D12_Shader shader, D3D12_SHADER_BYTECODE *outBytecode)
+{
+    outBytecode->pShaderBytecode = D3D12_shaders[shader].vs_shader_data;
+    outBytecode->BytecodeLength = D3D12_shaders[shader].vs_shader_size;
+}
+
+extern "C" void
+D3D12_GetPixelShader(D3D12_Shader shader, D3D12_SHADER_BYTECODE *outBytecode)
+{
+    outBytecode->pShaderBytecode = D3D12_shaders[shader].ps_shader_data;
+    outBytecode->BytecodeLength = D3D12_shaders[shader].ps_shader_size;
+}
+
+extern "C" D3D12_RootSignature
+D3D12_GetRootSignatureType(D3D12_Shader shader)
+{
+    return D3D12_shaders[shader].root_sig;
+}
+
+extern "C" void
+D3D12_GetRootSignatureData(D3D12_RootSignature rootSig, D3D12_SHADER_BYTECODE *outBytecode)
+{
+    outBytecode->pShaderBytecode = D3D12_rootsigs[rootSig].rs_shader_data;
+    outBytecode->BytecodeLength = D3D12_rootsigs[rootSig].rs_shader_size;
+}
 
 #endif /* SDL_VIDEO_RENDER_D3D12 && !SDL_RENDER_DISABLED && defined(__XBOXSERIES__) */
+
+/* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/SDL_video_unsupported.c
+++ b/src/video/SDL_video_unsupported.c
@@ -81,3 +81,11 @@ void SDL_iPhoneSetEventPump(SDL_bool enabled)
     SDL_Unsupported();
 }
 #endif
+
+#if defined(__XBOXONE__) || defined(__XBOXSERIES__)
+int SDL_Direct3D9GetAdapterIndex(SDL_DisplayID displayID)
+{
+    (void)displayID;
+    return SDL_Unsupported();
+}
+#endif

--- a/src/video/SDL_video_unsupported.c
+++ b/src/video/SDL_video_unsupported.c
@@ -41,7 +41,7 @@ int SDL_Direct3D9GetAdapterIndex(SDL_DisplayID displayID)
 
 #endif
 
-#ifndef SDL_GDK_TEXTINPUT
+#ifndef __GDK__
 
 DECLSPEC int SDLCALL SDL_GDKGetTaskQueue(void *outTaskQueue);
 int SDL_GDKGetTaskQueue(void *outTaskQueue)

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -169,9 +169,11 @@ static SDL_Scancode WindowsScanCodeToSDLScanCode(LPARAM lParam, WPARAM wParam)
     } else {
         Uint16 vkCode = LOWORD(wParam);
 
+#if !defined(__XBOXONE__) && !defined(__XBOXSERIES__)
         /* Windows may not report scan codes for some buttons (multimedia buttons etc).
          * Get scan code from the VK code.*/
         scanCode = LOWORD(MapVirtualKey(vkCode, MAPVK_VK_TO_VSC_EX));
+#endif /*!defined(__XBOXONE__) && !defined(__XBOXSERIES__)*/
 
         /* Pause/Break key have a special scan code with 0xe1 prefix.
          * Use Pause scan code that is used in Win32. */
@@ -515,8 +517,6 @@ WIN_KeyboardHookProc(int nCode, WPARAM wParam, LPARAM lParam)
     return 1;
 }
 
-#endif /*!defined(__XBOXONE__) && !defined(__XBOXSERIES__)*/
-
 static void WIN_HandleRawMouseInput(Uint64 timestamp, SDL_WindowData *data, RAWMOUSE *rawmouse)
 {
     SDL_MouseID mouseID;
@@ -692,6 +692,7 @@ void WIN_PollRawMouseInput(void)
     data->last_rawinput_poll = now;
 }
 
+#endif /*!defined(__XBOXONE__) && !defined(__XBOXSERIES__)*/
 
 LRESULT CALLBACK
 WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -264,7 +264,7 @@ int WIN_AdjustWindowRectForHWND(HWND hwnd, LPRECT lpRect, UINT frame_dpi)
 #endif
 
 #if defined(__XBOXONE__) || defined(__XBOXSERIES__)
-    AdjustWindowRectEx(&rect, style, menu, styleEx);
+    AdjustWindowRectEx(lpRect, style, menu, styleEx);
 #else
     if (WIN_IsPerMonitorV2DPIAware(videodevice)) {
         /* With per-monitor v2, the window border/titlebar size depend on the DPI, so we need to call AdjustWindowRectExForDpi instead of AdjustWindowRectEx. */
@@ -490,6 +490,7 @@ static int SetupWindowData(SDL_VideoDevice *_this, SDL_Window *window, HWND hwnd
 
     data->initializing = SDL_FALSE;
 
+#if !defined(__XBOXONE__) && !defined(__XBOXSERIES__)
     if (window->flags & SDL_WINDOW_EXTERNAL) {
         /* Query the title from the existing window */
         LPTSTR title;
@@ -510,6 +511,7 @@ static int SetupWindowData(SDL_VideoDevice *_this, SDL_Window *window, HWND hwnd
             SDL_small_free(title, isstack);
         }
     }
+#endif /*!defined(__XBOXONE__) && !defined(__XBOXSERIES__)*/
 
     SDL_PropertiesID props = SDL_GetWindowProperties(window);
     SDL_SetProperty(props, SDL_PROPERTY_WINDOW_WIN32_HWND_POINTER, data->hwnd);
@@ -554,7 +556,9 @@ static void CleanupWindowData(SDL_VideoDevice *_this, SDL_Window *window)
 #endif
             }
         }
+#if !defined(__XBOXONE__) && !defined(__XBOXSERIES__)
         SDL_free(data->rawinput);
+#endif /*!defined(__XBOXONE__) && !defined(__XBOXSERIES__)*/
         SDL_free(data);
     }
     window->driverdata = NULL;
@@ -672,6 +676,7 @@ int WIN_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesI
         }
     }
 
+#if !defined(__XBOXONE__) && !defined(__XBOXSERIES__)
     /* FIXME: does not work on all hardware configurations with different renders (i.e. hybrid GPUs) */
     if (window->flags & SDL_WINDOW_TRANSPARENT) {
         void *handle = SDL_LoadObject("dwmapi.dll");
@@ -739,6 +744,7 @@ int WIN_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesI
         return SDL_SetError("Could not create GL window (WGL support not configured)");
 #endif
     }
+#endif /*!defined(__XBOXONE__) && !defined(__XBOXSERIES__)*/
 
     return 0;
 }

--- a/src/video/windows/SDL_windowswindow.h
+++ b/src/video/windows/SDL_windowswindow.h
@@ -66,11 +66,13 @@ struct SDL_WindowData
     SDL_bool windowed_mode_was_maximized;
     SDL_bool in_window_deactivation;
     RECT cursor_clipped_rect;
+#if !defined(__XBOXONE__) && !defined(__XBOXSERIES__)
     RAWINPUT *rawinput;
     UINT rawinput_offset;
     UINT rawinput_size;
     UINT rawinput_count;
     Uint64 last_rawinput_poll;
+#endif /*!defined(__XBOXONE__) && !defined(__XBOXSERIES__)*/
     SDL_Point last_raw_mouse_position;
     SDL_bool mouse_tracked;
     SDL_bool destroy_parent_with_window;


### PR DESCRIPTION
This adds the Xbox GDK code that previously was hidden on an NDA forum, resolving the issue with shader blobs that Microsoft requested I change before making it public.

## Description
* Updated to October 2023 Update 1 version of GDK
* Fixed some compile errors on both WinGDK and XboxGDK which had been introduced with SDL3 changes (both in SDL3 and in the GDK tests)
* The Xbox rendering code is now fully included in the public repo. For the Xbox shader file blobs, the headers are generated by a batch file that is a pre-build step. This means Xbox no longer requires you to chase down files on the NDA forums to get it to work (though of course, you can still only install GDKX and build the project for Xbox if you have NDA access)
* Updated README-gdk.md to include information about Xbox

## Existing Issue(s)
Resolves #8681 

@TheSpydog @flibitijibibo Are you able to test this PR and make sure that you are able to run the VisualC-GDK tests on your Xbox kits? I actually had to give my Xbox kit to another developer, so while I know everything builds with GDKX, I'm currently not able to test on an Xbox. (I did confirm all the WinGDK stuff still works with the changes, though).