### PR TITLE
Improve ps2 workflow

### DIFF
--- a/.github/workflows/ps2.yml
+++ b/.github/workflows/ps2.yml
@@ -17,15 +17,6 @@ jobs:
         apk update
         apk add cmake gmp mpc1 mpfr4 ninja pkgconf make git
 
-    # To be removed once ps2_drivers is part of PS2DEV
-    - name: Install ps2_drivers lib
-      run: |
-        git clone https://github.com/fjtrujy/ps2_drivers.git
-        cd ps2_drivers
-        make -j $(getconf _NPROCESSORS_ONLN) clean
-        make -j $(getconf _NPROCESSORS_ONLN)
-        make -j $(getconf _NPROCESSORS_ONLN) install
-
     - name: Configure (CMake)
       run: |
         cmake -S . -B build -G Ninja \

--- a/.github/workflows/ps2.yml
+++ b/.github/workflows/ps2.yml
@@ -27,7 +27,7 @@ jobs:
           -DCMAKE_INSTALL_PREFIX=cmake_prefix \
           -DCMAKE_BUILD_TYPE=Release
     - name: Build (CMake)
-      run: cmake --build build --config Release --verbose -- -j 1
+      run: cmake --build build --config Release --verbose
     - name: Install (CMake)
       run: |
         set -eu
@@ -36,7 +36,7 @@ jobs:
         ( cd cmake_prefix; find ) | LC_ALL=C sort -u
     - name: Package (CPack)
       run: |
-        cmake --build build/ --config Release --target package -- -j 1
+        cmake --build build/ --config Release --target package
 
     - name: Verify CMake configuration files
       run: |
@@ -46,7 +46,7 @@ jobs:
           -DTEST_SHARED=FALSE \
           -DCMAKE_PREFIX_PATH=${{ env.SDL3_DIR }} \
           -DCMAKE_BUILD_TYPE=Release
-        cmake --build cmake_config_build --verbose -- -j 1
+        cmake --build cmake_config_build --verbose
     - name: Verify sdl3.pc
       run: |
         export CC=mips64r5900el-ps2-elf-gcc


### PR DESCRIPTION
## Description
This PR basically do 2 things:
- Remove from workflow the previous `ps2_drivers` installation because it is already included in the docker
- Put back the usage of all the threads (@madebr let's check now if the issue you raised https://github.com/ps2dev/ps2dev/issues/67 is still happening. Could you also add here more information about how to reproduce it? I just see this [PR](https://github.com/libsdl-org/SDL/pull/7505) making reference)

Cheers.