### PR TITLE
Update thread naming on Windows

### DIFF
--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -635,6 +635,7 @@ The following hints have been removed:
 * SDL_HINT_VIDEO_FOREIGN_WINDOW_VULKAN - replaced with the "vulkan" property in SDL_CreateWindowWithProperties()
 * SDL_HINT_VIDEO_HIGHDPI_DISABLED - high DPI support is always enabled
 * SDL_HINT_VIDEO_WINDOW_SHARE_PIXEL_FORMAT - replaced with the "win32.pixel_format_hwnd" in SDL_CreateWindowWithProperties()
+* SDL_HINT_WINDOWS_DISABLE_THREAD_NAMING - SDL now properly handles the 0x406D1388 Exception if no debugger intercepts it, preventing its propagation.
 * SDL_HINT_VIDEO_X11_FORCE_EGL - use SDL_HINT_VIDEO_FORCE_EGL instead
 * SDL_HINT_VIDEO_X11_XINERAMA - Xinerama no longer supported by the X11 backend
 * SDL_HINT_VIDEO_X11_XVIDMODE - Xvidmode no longer supported by the X11 backend

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2162,22 +2162,6 @@ extern "C" {
 #define SDL_HINT_WAVE_TRUNCATION   "SDL_WAVE_TRUNCATION"
 
 /**
- * Tell SDL not to name threads on Windows with the 0x406D1388 Exception.
- *        The 0x406D1388 Exception is a trick used to inform Visual Studio of a
- *        thread's name, but it tends to cause problems with other debuggers,
- *        and the .NET runtime. Note that SDL 2.0.6 and later will still use
- *        the (safer) SetThreadDescription API, introduced in the Windows 10
- *        Creators Update, if available.
- *
- * The variable can be set to the following values:
- *   "0"       - SDL will raise the 0x406D1388 Exception to name threads.
- *               This is the default behavior of SDL <= 2.0.4.
- *   "1"       - SDL will not raise this exception, and threads will be unnamed. (default)
- *               This is necessary with .NET languages or debuggers that aren't Visual Studio.
- */
-#define SDL_HINT_WINDOWS_DISABLE_THREAD_NAMING "SDL_WINDOWS_DISABLE_THREAD_NAMING"
-
-/**
  *  Controls whether menus can be opened with their keyboard shortcut (Alt+mnemonic).
  *
  *  If the mnemonics are enabled, then menus can be opened by pressing the Alt

--- a/src/thread/windows/SDL_systhread.c
+++ b/src/thread/windows/SDL_systhread.c
@@ -112,11 +112,18 @@ typedef struct tagTHREADNAME_INFO
 } THREADNAME_INFO;
 #pragma pack(pop)
 
+static LONG NTAPI EmptyVectoredExceptionHandler(EXCEPTION_POINTERS *ExceptionInfo)
+{
+    (void)ExceptionInfo;
+    return EXCEPTION_CONTINUE_EXECUTION;
+}
+
 typedef HRESULT(WINAPI *pfnSetThreadDescription)(HANDLE, PCWSTR);
 
 void SDL_SYS_SetupThread(const char *name)
 {
     if (name) {
+        PVOID exceptionHandlerHandle;
 #ifndef __WINRT__ /* !!! FIXME: There's no LoadLibrary() in WinRT; don't know if SetThreadDescription is available there at all at the moment. */
         static pfnSetThreadDescription pSetThreadDescription = NULL;
         static HMODULE kernel32 = NULL;
@@ -125,6 +132,12 @@ void SDL_SYS_SetupThread(const char *name)
             kernel32 = GetModuleHandle(TEXT("kernel32.dll"));
             if (kernel32) {
                 pSetThreadDescription = (pfnSetThreadDescription)GetProcAddress(kernel32, "SetThreadDescription");
+            }
+            if (!kernel32 || !pSetThreadDescription) {
+                HMODULE kernelBase = GetModuleHandle(TEXT("KernelBase.dll"));
+                if (kernelBase) {
+                    pSetThreadDescription = (pfnSetThreadDescription)GetProcAddress(kernelBase, "SetThreadDescription");
+                }
             }
         }
 
@@ -141,14 +154,9 @@ void SDL_SYS_SetupThread(const char *name)
            but we still need to deal with older OSes and debuggers. Set it with the arcane
            exception magic, too. */
 
-        if (IsDebuggerPresent()) {
+        exceptionHandlerHandle = AddVectoredExceptionHandler(1, EmptyVectoredExceptionHandler);
+        if (exceptionHandlerHandle) {
             THREADNAME_INFO inf;
-
-            /* C# and friends will try to catch this Exception, let's avoid it. */
-            if (SDL_GetHintBoolean(SDL_HINT_WINDOWS_DISABLE_THREAD_NAMING, SDL_TRUE)) {
-                return;
-            }
-
             /* This magic tells the debugger to name a thread if it's listening. */
             SDL_zero(inf);
             inf.dwType = 0x1000;
@@ -158,6 +166,7 @@ void SDL_SYS_SetupThread(const char *name)
 
             /* The debugger catches this, renames the thread, continues on. */
             RaiseException(0x406D1388, 0, sizeof(inf) / sizeof(ULONG), (const ULONG_PTR *)&inf);
+            RemoveVectoredExceptionHandler(exceptionHandlerHandle);
         }
     }
 }


### PR DESCRIPTION
Update the way threads are named in Windows

## Description
 * Regarding the usage of the function `SetThreadDescription`, added a fallback to also look for it in `KernelBase.dll`, as per the docs:
> Windows Server 2016, Windows 10 LTSB 2016 and Windows 10 version 1607: SetThreadDescription is only available by Run Time Dynamic Linking in KrnelBase.dll.

 * For the structured exception approach, use `AddVectoredExceptionHandler` and `RemoveVectoredExceptionHandler` to properly guard the raised exception, so that the extra checks (the debugger being present and the hint added recently) are no longer needed, as the exception will be immediately caught by SDL (the compiler will still be able to react to it and set the name if it supports it).
Those 2 functions are the equivalent of using a ``__try{} __except (EXCEPTION_EXECUTE_HANDLER){}`` block but with the difference of not relying on compiler specific features.
