### PR TITLE
Removed SDL_ATOMIC_DISABLED

### DIFF
--- a/include/build_config/SDL_build_config.h.cmake
+++ b/include/build_config/SDL_build_config.h.cmake
@@ -256,7 +256,6 @@
 #cmakedefine SDL_VIDEO_CAPTURE
 
 /* Allow disabling of core subsystems */
-#cmakedefine SDL_ATOMIC_DISABLED @SDL_ATOMIC_DISABLED@
 #cmakedefine SDL_AUDIO_DISABLED @SDL_AUDIO_DISABLED@
 #cmakedefine SDL_CPUINFO_DISABLED @SDL_CPUINFO_DISABLED@
 #cmakedefine SDL_EVENTS_DISABLED @SDL_EVENTS_DISABLED@

--- a/src/dynapi/SDL_dynapi.c
+++ b/src/dynapi/SDL_dynapi.c
@@ -535,22 +535,15 @@ static void SDL_InitDynamicAPI(void)
      */
     static SDL_bool already_initialized = SDL_FALSE;
 
-    /* SDL_AtomicLock calls SDL mutex functions to emulate if
-       SDL_ATOMIC_DISABLED, which we can't do here, so in such a
-       configuration, you're on your own. */
-    #ifndef SDL_ATOMIC_DISABLED
     static SDL_SpinLock lock = 0;
     SDL_AtomicLock_REAL(&lock);
-    #endif
 
     if (!already_initialized) {
         SDL_InitDynamicAPILocked();
         already_initialized = SDL_TRUE;
     }
 
-    #ifndef SDL_ATOMIC_DISABLED
     SDL_AtomicUnlock_REAL(&lock);
-    #endif
 }
 
 #else /* SDL_DYNAMIC_API */


### PR DESCRIPTION
It turns out that because we redefine SDL functions internally, it is safe to call SDL mutex functions while initializing the jump table
