### PR TITLE
[SDL2] Fix tests for surface sizes that would overflow

### DIFF
--- a/test/testautomation_surface.c
+++ b/test/testautomation_surface.c
@@ -765,6 +765,7 @@ int surface_testOverflow(void *arg)
                         "Expected \"%s\", got \"%s\"", expectedError, SDL_GetError());
 
     if (sizeof(size_t) == 4 && sizeof(int) >= 4) {
+        SDL_ClearError();
         expectedError = "Out of memory";
         /* 0x5555'5555 * 3bpp = 0xffff'ffff which fits in size_t, but adding
          * alignment padding makes it overflow */
@@ -772,15 +773,18 @@ int surface_testOverflow(void *arg)
         SDLTest_AssertCheck(surface == NULL, "Should detect overflow in width + alignment");
         SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), expectedError) == 0,
                             "Expected \"%s\", got \"%s\"", expectedError, SDL_GetError());
+        SDL_ClearError();
         /* 0x4000'0000 * 4bpp = 0x1'0000'0000 which (just) overflows */
         surface = SDL_CreateRGBSurfaceWithFormat(0, 0x40000000, 1, 32, SDL_PIXELFORMAT_ARGB8888);
         SDLTest_AssertCheck(surface == NULL, "Should detect overflow in width * bytes per pixel");
         SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), expectedError) == 0,
                             "Expected \"%s\", got \"%s\"", expectedError, SDL_GetError());
+        SDL_ClearError();
         surface = SDL_CreateRGBSurfaceWithFormat(0, (1 << 29) - 1, (1 << 29) - 1, 8, SDL_PIXELFORMAT_INDEX8);
         SDLTest_AssertCheck(surface == NULL, "Should detect overflow in width * height");
         SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), expectedError) == 0,
                             "Expected \"%s\", got \"%s\"", expectedError, SDL_GetError());
+        SDL_ClearError();
         surface = SDL_CreateRGBSurfaceWithFormat(0, (1 << 15) + 1, (1 << 15) + 1, 32, SDL_PIXELFORMAT_ARGB8888);
         SDLTest_AssertCheck(surface == NULL, "Should detect overflow in width * height * bytes per pixel");
         SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), expectedError) == 0,

--- a/test/testautomation_surface.c
+++ b/test/testautomation_surface.c
@@ -766,7 +766,9 @@ int surface_testOverflow(void *arg)
 
     if (sizeof(size_t) == 4 && sizeof(int) >= 4) {
         expectedError = "Out of memory";
-        surface = SDL_CreateRGBSurfaceWithFormat(0, SDL_MAX_SINT32, 1, 8, SDL_PIXELFORMAT_INDEX8);
+        /* 0x5555'5555 * 3bpp = 0xffff'ffff which fits in size_t, but adding
+         * alignment padding makes it overflow */
+        surface = SDL_CreateRGBSurfaceWithFormat(0, 0x55555555, 1, 24, SDL_PIXELFORMAT_RGB24);
         SDLTest_AssertCheck(surface == NULL, "Should detect overflow in width + alignment");
         SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), expectedError) == 0,
                             "Expected \"%s\", got \"%s\"", expectedError, SDL_GetError());

--- a/test/testautomation_surface.c
+++ b/test/testautomation_surface.c
@@ -772,7 +772,8 @@ int surface_testOverflow(void *arg)
         SDLTest_AssertCheck(surface == NULL, "Should detect overflow in width + alignment");
         SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), expectedError) == 0,
                             "Expected \"%s\", got \"%s\"", expectedError, SDL_GetError());
-        surface = SDL_CreateRGBSurfaceWithFormat(0, SDL_MAX_SINT32 / 2, 1, 32, SDL_PIXELFORMAT_ARGB8888);
+        /* 0x4000'0000 * 4bpp = 0x1'0000'0000 which (just) overflows */
+        surface = SDL_CreateRGBSurfaceWithFormat(0, 0x40000000, 1, 32, SDL_PIXELFORMAT_ARGB8888);
         SDLTest_AssertCheck(surface == NULL, "Should detect overflow in width * bytes per pixel");
         SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), expectedError) == 0,
                             "Expected \"%s\", got \"%s\"", expectedError, SDL_GetError());


### PR DESCRIPTION
Backport of the relevant parts of #8873.

* testautomation_surface: Really make pitch + alignment overflow
    
    Adding 3 bytes of alignment to 0x7fff'ffff is not enough to make it
    overflow a 4-byte unsigned size_t, so this test was not exercising
    the intended failure mode. We cannot actually make this overflow
    with a signed 32-bit width and an 8-bit format: the maximum width is
    not enough to achieve that. However, if we switch to a 24-bit format,
    we can make the calculation overflow.
    
    In SDL 2, this test bug was hidden by the fact that allocating
    0x7fff'ffff bytes on a 32-bit platform will usually fail, and SDL 2
    reported both "malloc() failed" and "this amount of memory is too large
    for a size_t" with the same error code.

* testautomation_surface: Really make width * bpp overflow
    
    A surface of width (0x7fff'ffff) / 2 = 0x3fff'ffff is not quite large
    enough to make the pitch overflow in the way we wanted to test here:
    with a 32-bit format, that makes each row 0xffff'fffc bytes, which
    (just) fits in a 32-bit unsigned size_t. Increasing it to 0x4000'0000
    pixels per row is enough to trigger the overflow we intended to test.
    
    In SDL 2, this test bug was hidden by the fact that allocating
    0xffff'fffc bytes on a 32-bit platform is very likely to fail, and SDL 2
    reported both "malloc() failed" and "this amount of memory is too large
    for a size_t" with the same error code.

* testautomation_surface: Make sure error is set by the function we expect
    
    If the error behaviour in one of these cases was wrong, that could have
    been hidden by the error indicator remaining set from a previous test.

## Existing Issue(s)
Resolves: https://github.com/libsdl-org/SDL/issues/8870