### PR TITLE
Fix compilation problems about yuv_rgb_lsx.c

### DIFF
--- a/src/video/yuv2rgb/yuv_rgb_lsx.c
+++ b/src/video/yuv2rgb/yuv_rgb_lsx.c
@@ -4,6 +4,7 @@
 
 #if SDL_HAVE_YUV
 #include "yuv_rgb_lsx.h"
+#include "yuv_rgb_internal.h"
 
 #ifdef SDL_LSX_INTRINSICS
 


### PR DESCRIPTION
After testing #8864  , it was found thatit did not compile on the loongson platform. The reason is that ’yuv_rgb_lsx.c‘ is missing ’yuv_rgb_internal.h‘. @madebr 