### PR TITLE
Prevent asan warning on qsort():

### DIFF
--- a/src/stdlib/SDL_qsort.c
+++ b/src/stdlib/SDL_qsort.c
@@ -24,6 +24,9 @@
 #ifdef HAVE_QSORT
 void SDL_qsort(void *base, size_t nmemb, size_t size, int (*compare) (const void *, const void *))
 {
+    if (!base) {
+        return;
+    }
     qsort(base, nmemb, size, compare);
 }
 


### PR DESCRIPTION

Prevent asan warning on qsort():
`'src/stdlib/SDL_qsort.c:27:5: runtime error: null pointer passed as argument 1, which is declared to never be null``
