### PR TITLE
x11: workaround issues with primary selection and clipboard temporal ignorance

### DIFF
--- a/src/video/x11/SDL_x11clipboard.c
+++ b/src/video/x11/SDL_x11clipboard.c
@@ -30,10 +30,10 @@
 #include "../../events/SDL_events_c.h"
 
 static const char *text_mime_types[] = {
+    "UTF8_STRING",
     "text/plain;charset=utf-8",
     "text/plain",
     "TEXT",
-    "UTF8_STRING",
     "STRING"
 };
 


### PR DESCRIPTION
## Description
Make it check for the most commonly used text type first.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/8338 talks more about the issue. This pr does not fix it, but it makes the bug occur less often and differently.