### PR TITLE
Add Wayland screen space scaling

### DIFF
--- a/docs/README-wayland.md
+++ b/docs/README-wayland.md
@@ -6,6 +6,14 @@ encounter limitations or behavior that is different from other windowing systems
 
 ## Common issues:
 
+### Legacy, DPI-unaware applications are blurry
+
+- Wayland handles high-DPI displays by scaling the desktop, which causes applications that are not designed to be 
+  DPI-aware to be automatically scaled by the window manager, which results in them being blurry. SDL can _attempt_ to
+  scale these applications such that they will be output with a 1:1 pixel aspect, however this may be buggy, especially
+  with odd-sized windows and/or scale factors that aren't quarter-increments (125%, 150%, etc...). To enable this, set
+  the environment variable `SDL_HINT_VIDEO_WAYLAND_SCALE_TO_DISPLAY=1`
+
 ### Window decorations are missing, or the decorations look strange
 
 - On some desktops (i.e. GNOME), Wayland applications use a library

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -1985,6 +1985,32 @@ extern "C" {
 #define SDL_HINT_VIDEO_WAYLAND_MODE_SCALING "SDL_VIDEO_WAYLAND_MODE_SCALING"
 
 /**
+ *  A variable forcing non-DPI-aware Wayland windows to output at 1:1 scaling.
+ *
+ *  When this hint is set, Wayland windows that are not flagged as being DPI-aware will be
+ *  output with scaling designed to force 1:1 pixel mapping.
+ *
+ *  This is intended to allow legacy applications to be displayed without desktop scaling
+ *  being applied, and has issues with certain display configurations, as this forces the
+ *  window to behave in a way that Wayland desktops were not designed to accommodate:
+ *
+ *   - Rounding errors can result with odd window sizes and/or desktop scales.
+ *   - The window may be unusably small.
+ *   - The window may jump in size at times.
+ *   - The window may appear to be larger than the desktop size to the application.
+ *   - Possible loss of cursor precision.
+ *
+ *  New applications should be designed with proper DPI awareness handling instead of enabling this.
+ *
+ *  This variable can be set to the following values:
+ *    "0"       - Windows will be scaled normally.
+ *    "1"       - Windows will be forced to scale to achieve 1:1 output.
+ *
+ *  By default, scaling to the display is disabled.
+ */
+#define SDL_HINT_VIDEO_WAYLAND_SCALE_TO_DISPLAY "SDL_VIDEO_WAYLAND_SCALE_TO_DISPLAY"
+
+/**
  *  Enable or disable mouse pointer warp emulation, needed by some older games.
  *
  *  When this hint is set, any SDL will emulate mouse warps using relative mouse mode.

--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -883,6 +883,18 @@ extern DECLSPEC SDL_Window *SDLCALL SDL_CreatePopupWindow(SDL_Window *parent, in
  *
  * These are additional supported properties on Wayland:
  *
+ * - `SDL_PROP_WINDOW_CREATE_WAYLAND_SCALE_TO_DISPLAY` - true if the window
+ *   should use forced scaling designed to produce 1:1 pixel mapping if not
+ *   flagged as being DPI-aware. This is intended to allow legacy applications
+ *   to be displayed without desktop scaling being applied, and has issues with
+ *   certain display configurations, as this forces the window to behave in a
+ *   way that Wayland desktops were not designed to accommodate. Potential
+ *   issues include, but are not limited to: rounding errors can result when
+ *   odd window sizes/scales are used, the window may be unusably small, the
+ *   window may jump in visible size at times, the window may appear to be
+ *   larger than the desktop space, and possible loss of cursor precision can
+ *   occur. New applications should be designed with proper DPI awareness and
+ *   handling instead of enabling this.
  * - `SDL_PROP_WINDOW_CREATE_WAYLAND_SURFACE_ROLE_CUSTOM_BOOLEAN` - true if
  *   the application wants to use the Wayland surface for a custom role and
  *   does not want it attached to an XDG toplevel window. See
@@ -947,6 +959,7 @@ extern DECLSPEC SDL_Window *SDLCALL SDL_CreateWindowWithProperties(SDL_Propertie
 #define SDL_PROP_WINDOW_CREATE_Y_NUMBER                            "y"
 #define SDL_PROP_WINDOW_CREATE_COCOA_WINDOW_POINTER                "cocoa.window"
 #define SDL_PROP_WINDOW_CREATE_COCOA_VIEW_POINTER                  "cocoa.view"
+#define SDL_PROP_WINDOW_CREATE_WAYLAND_SCALE_TO_DISPLAY            "wayland.scale_to_display"
 #define SDL_PROP_WINDOW_CREATE_WAYLAND_SURFACE_ROLE_CUSTOM_BOOLEAN "wayland.surface_role_custom"
 #define SDL_PROP_WINDOW_CREATE_WAYLAND_CREATE_EGL_WINDOW_BOOLEAN   "wayland.create_egl_window"
 #define SDL_PROP_WINDOW_CREATE_WAYLAND_WL_SURFACE_POINTER          "wayland.wl_surface"

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -507,7 +507,8 @@ static void pointer_handle_motion(void *data, struct wl_pointer *pointer,
     }
 
     if (window && window->hit_test) {
-        const SDL_Point point = { wl_fixed_to_int(sx_w), wl_fixed_to_int(sy_w) };
+        const SDL_Point point = { (int)SDL_floor(wl_fixed_to_double(sx_w) * window_data->pointer_scale_x),
+                                  (int)SDL_floor(wl_fixed_to_double(sy_w) * window_data->pointer_scale_y) };
         SDL_HitTestResult rc = window->hit_test(window, &point, window->hit_test_data);
         if (rc == window_data->hit_test_result) {
             return;

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -1204,8 +1204,24 @@ static int Wayland_GetDisplayBounds(SDL_VideoDevice *_this, SDL_VideoDisplay *di
         rect->w = display->fullscreen_window->current_fullscreen_mode.w;
         rect->h = display->fullscreen_window->current_fullscreen_mode.h;
     } else {
-        rect->w = display->current_mode->w;
-        rect->h = display->current_mode->h;
+        /* If the focused window is on the requested display and requires display scaling,
+         * return the physical dimensions in pixels.
+         */
+        SDL_Window *kb = SDL_GetKeyboardFocus();
+        SDL_Window *m = SDL_GetMouseFocus();
+        SDL_bool scale_output = (kb && kb->driverdata->scale_to_display && (kb->last_displayID == display->id)) ||
+                                (m && m->driverdata->scale_to_display && (m->last_displayID == display->id));
+
+        if (!scale_output) {
+            rect->w = display->current_mode->w;
+            rect->h = display->current_mode->h;
+        } else if (driverdata->transform & WL_OUTPUT_TRANSFORM_90) {
+            rect->w = driverdata->pixel_height;
+            rect->h = driverdata->pixel_width;
+        } else {
+            rect->w = driverdata->pixel_width;
+            rect->h = driverdata->pixel_height;
+        }
     }
     return 0;
 }

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -787,8 +787,10 @@ static void handle_configure_xdg_toplevel(void *data,
                  */
                 width = window->floating.w;
                 height = window->floating.h;
-                wind->requested.logical_width = PixelToPoint(window, width);
-                wind->requested.logical_height = PixelToPoint(window, height);
+                if (wind->scale_to_display) {
+                    wind->requested.logical_width = PixelToPoint(window, width);
+                    wind->requested.logical_height = PixelToPoint(window, height);
+                }
             } else if (wind->scale_to_display) {
                 /* Don't convert if the size hasn't changed to avoid rounding errors. */
                 if (width != wind->current.logical_width || height != wind->current.logical_height) {
@@ -808,8 +810,10 @@ static void handle_configure_xdg_toplevel(void *data,
              */
             width = window->floating.w;
             height = window->floating.h;
-            wind->requested.logical_width = PixelToPoint(window, width);
-            wind->requested.logical_height = PixelToPoint(window, height);
+            if (wind->scale_to_display) {
+                wind->requested.logical_width = PixelToPoint(window, width);
+                wind->requested.logical_height = PixelToPoint(window, height);
+            }
         }
 
         /* The content limits are only a hint, which the compositor is free to ignore,
@@ -829,8 +833,10 @@ static void handle_configure_xdg_toplevel(void *data,
             }
             height = SDL_max(height, window->min_h);
 
-            wind->requested.logical_width = PixelToPoint(window, width);
-            wind->requested.logical_height = PixelToPoint(window, height);
+            if (wind->scale_to_display) {
+                wind->requested.logical_width = PixelToPoint(window, width);
+                wind->requested.logical_height = PixelToPoint(window, height);
+            }
         }
     } else {
         /* Fullscreen windows know their exact size. */
@@ -1100,8 +1106,10 @@ static void decoration_frame_configure(struct libdecor_frame *frame,
             width = window->floating.w;
             height = window->floating.h;
 
-            wind->requested.logical_width = PixelToPoint(window, width);
-            wind->requested.logical_height = PixelToPoint(window, height);
+            if (wind->scale_to_display) {
+                wind->requested.logical_width = PixelToPoint(window, width);
+                wind->requested.logical_height = PixelToPoint(window, height);
+            }
 
             OverrideLibdecorLimits(window);
         } else {
@@ -1132,8 +1140,10 @@ static void decoration_frame_configure(struct libdecor_frame *frame,
                     height = window->windowed.h;
                 }
 
-                wind->requested.logical_width = PixelToPoint(window, width);
-                wind->requested.logical_height = PixelToPoint(window, height);
+                if (wind->scale_to_display) {
+                    wind->requested.logical_width = PixelToPoint(window, width);
+                    wind->requested.logical_height = PixelToPoint(window, height);
+                }
             } else if (wind->scale_to_display) {
                 /* Don't convert if the size hasn't changed to avoid rounding errors. */
                 if (width != wind->current.logical_width || height != wind->current.logical_height) {
@@ -1165,8 +1175,10 @@ static void decoration_frame_configure(struct libdecor_frame *frame,
             }
             height = SDL_max(height, window->min_h);
 
-            wind->requested.logical_width = PixelToPoint(window, width);
-            wind->requested.logical_height = PixelToPoint(window, height);
+            if (wind->scale_to_display) {
+                wind->requested.logical_width = PixelToPoint(window, width);
+                wind->requested.logical_height = PixelToPoint(window, height);
+            }
         }
     }
 
@@ -2242,8 +2254,10 @@ int Wayland_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Propert
 
     data->requested.width = window->w;
     data->requested.height = window->h;
-    data->requested.logical_width = PixelToPoint(window, window->w);
-    data->requested.logical_height = PixelToPoint(window, window->h);
+    if (data->scale_to_display) {
+        data->requested.logical_width = PixelToPoint(window, window->w);
+        data->requested.logical_height = PixelToPoint(window, window->h);
+    }
 
     if (!external_surface) {
         data->surface = wl_compositor_create_surface(c->compositor);

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -1714,6 +1714,10 @@ void Wayland_ShowWindow(SDL_VideoDevice *_this, SDL_Window *window)
         wl_surface_commit(data->surface);
     }
 
+    /* Make sure the window can't be resized to 0 or it can be spuriously closed by the window manager. */
+    data->system_limits.min_width = SDL_max(data->system_limits.min_width, 1);
+    data->system_limits.min_height = SDL_max(data->system_limits.min_height, 1);
+
     /* Unlike the rest of window state we have to set this _after_ flushing the
      * display, because we need to create the decorations before possibly hiding
      * them immediately afterward.

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -115,6 +115,7 @@ struct SDL_WindowData
 
     int last_configure_width, last_configure_height;
     int requested_window_width, requested_window_height;
+    int requested_logical_width, requested_logical_height; /* Only used for screen space scaling. */
     int drawable_width, drawable_height;
     int wl_window_width, wl_window_height;
     int system_min_required_width;
@@ -128,6 +129,7 @@ struct SDL_WindowData
     SDL_bool drop_fullscreen_requests;
     SDL_bool fullscreen_was_positioned;
     SDL_bool show_hide_sync_required;
+    SDL_bool scale_to_display;
 
     SDL_HitTestResult hit_test_result;
 

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -105,21 +105,61 @@ struct SDL_WindowData
 
     char *app_id;
     float windowed_scale_factor;
-    float pointer_scale_x;
-    float pointer_scale_y;
 
     struct
     {
-        int width, height;
+        float x;
+        float y;
+    } pointer_scale;
+
+    /* The current pending user requested resize event. */
+    struct
+    {
+        /* These units can represent points or pixels, depending on the scaling mode. */
+        int width;
+        int height;
     } pending_size_event;
 
-    int last_configure_width, last_configure_height;
-    int requested_window_width, requested_window_height;
-    int requested_logical_width, requested_logical_height; /* Only used for screen space scaling. */
-    int drawable_width, drawable_height;
-    int wl_window_width, wl_window_height;
-    int system_min_required_width;
-    int system_min_required_height;
+    /* The in-flight window size request. */
+    struct
+    {
+        /* These units can represent points or pixels, depending on the scaling mode. */
+        int width;
+        int height;
+
+        /* The requested logical window size when using screen space scaling. */
+        int logical_width;
+        int logical_height;
+    } requested;
+
+    /* The current size of the window and drawable backing store. */
+    struct
+    {
+        /* The size of the window backbuffer in pixels. */
+        int drawable_width;
+        int drawable_height;
+
+        /* The size of the underlying window. */
+        int logical_width;
+        int logical_height;
+    } current;
+
+    /* The last compositor requested parameters; used for deduplication of window geometry configuration. */
+    struct
+    {
+        /* These units can be points or pixels, depending on the scaling mode. */
+        int width;
+        int height;
+    } last_configure;
+
+    /* System enforced window size limits. */
+    struct
+    {
+        /* Minimum allowed logical window size. */
+        int min_width;
+        int min_height;
+    } system_limits;
+
     SDL_DisplayID last_displayID;
     int fullscreen_deadline_count;
     SDL_bool floating;

--- a/test/testautomation_video.c
+++ b/test/testautomation_video.c
@@ -1750,7 +1750,7 @@ static int video_setWindowCenteredOnDisplay(void *arg)
                 int expectedX = 0, expectedY = 0;
                 int currentDisplay;
                 int expectedDisplay;
-                SDL_Rect expectedDisplayRect;
+                SDL_Rect expectedDisplayRect, expectedFullscreenRect;
                 SDL_PropertiesID props;
 
                 /* xVariation is the display we start on */
@@ -1826,16 +1826,24 @@ static int video_setWindowCenteredOnDisplay(void *arg)
                 SDL_GetWindowSize(window, &currentW, &currentH);
                 SDL_GetWindowPosition(window, &currentX, &currentY);
 
+                /* Get the expected fullscreen rect.
+                 * This needs to be queried after window creation and positioning as some drivers can alter the
+                 * usable bounds based on the window scaling mode.
+                 */
+                result = SDL_GetDisplayBounds(expectedDisplay, &expectedFullscreenRect);
+                SDLTest_AssertPass("SDL_GetDisplayBounds()");
+                SDLTest_AssertCheck(result == 0, "Verify return value; expected: 0, got: %d", result);
+
                 if (!video_driver_is_wayland) {
                     SDLTest_AssertCheck(currentDisplay == expectedDisplay, "Validate display ID (current: %d, expected: %d)", currentDisplay, expectedDisplay);
                 } else {
                     SDLTest_Log("Skipping display ID validation: Wayland driver does not support window positioning");
                 }
-                SDLTest_AssertCheck(currentW == expectedDisplayRect.w, "Validate width (current: %d, expected: %d)", currentW, expectedDisplayRect.w);
-                SDLTest_AssertCheck(currentH == expectedDisplayRect.h, "Validate height (current: %d, expected: %d)", currentH, expectedDisplayRect.h);
+                SDLTest_AssertCheck(currentW == expectedFullscreenRect.w, "Validate width (current: %d, expected: %d)", currentW, expectedFullscreenRect.w);
+                SDLTest_AssertCheck(currentH == expectedFullscreenRect.h, "Validate height (current: %d, expected: %d)", currentH, expectedFullscreenRect.h);
                 if (!video_driver_is_wayland) {
-                    SDLTest_AssertCheck(currentX == expectedDisplayRect.x, "Validate x (current: %d, expected: %d)", currentX, expectedDisplayRect.x);
-                    SDLTest_AssertCheck(currentY == expectedDisplayRect.y, "Validate y (current: %d, expected: %d)", currentY, expectedDisplayRect.y);
+                    SDLTest_AssertCheck(currentX == expectedFullscreenRect.x, "Validate x (current: %d, expected: %d)", currentX, expectedFullscreenRect.x);
+                    SDLTest_AssertCheck(currentY == expectedFullscreenRect.y, "Validate y (current: %d, expected: %d)", currentY, expectedFullscreenRect.y);
                 } else {
                     SDLTest_Log("Skipping window position validation: Wayland driver does not support window positioning");
                 }


### PR DESCRIPTION
Adds a hint and property to force non-DPI-aware Wayland windows to output at 1:1.
 
When this hint is set, Wayland windows that are not flagged as being DPI-aware will have their logical size altered to force 1:1 output when on a scaled desktop. In essence, it uses more scaling to try and make it look like the window _isn't_ scaled.

This is intended for legacy games/applications that will never be updated to be DPI-aware, and has various issues with certain display configurations, as this forces the window to behave in a way that Wayland desktops were not designed to accommodate:
- Rounding errors can result with odd window sizes and/or desktop scales.
- The window may be unusably small.
- The window may jump in size at times.
- The window may appear to be larger than the desktop size to the application.
- Possible loss of cursor precision due to the logical window size being reduced.

New applications should be designed with proper DPI awareness handling instead of enabling this, and are duly warned.

DPI-aware windows are not affected by this setting, so naively setting this as a global envvar won't break DPI-aware games/applications.

Closes #8768