### PR TITLE
[SDL2] Run testautomation under Autotools

### DIFF
--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -95,7 +95,7 @@ installedtestsmetadir = $(datadir)/installed-tests/SDL2
 
 generatetestmeta:
 	rm -f *.test
-	set -e; for exe in $(noninteractive) $(needs_audio) $(needs_display); do \
+	set -e; for exe in $(TESTS); do \
 		sed \
 			-e 's#@installedtestsdir@#$(installedtestsdir)#g' \
 			-e "s#@exe@#$$exe#g" \
@@ -386,8 +386,11 @@ distclean: clean
 	rm -f config.status config.cache config.log
 	rm -rf $(srcdir)/autom4te*
 
-noninteractive = \
+TESTS = \
 	testatomic$(EXE) \
+	testaudioinfo$(EXE) \
+	testbounds$(EXE) \
+	testdisplayinfo$(EXE) \
 	testerror$(EXE) \
 	testevdev$(EXE) \
 	testfilesystem$(EXE) \
@@ -396,22 +399,11 @@ noninteractive = \
 	testplatform$(EXE) \
 	testpower$(EXE) \
 	testqsort$(EXE) \
+	testsurround$(EXE) \
 	testthread$(EXE) \
 	testtimer$(EXE) \
 	testver$(EXE) \
 	$(NULL)
-
-needs_audio = \
-	testaudioinfo$(EXE) \
-	testsurround$(EXE) \
-	$(NULL)
-
-needs_display = \
-	testbounds$(EXE) \
-	testdisplayinfo$(EXE) \
-	$(NULL)
-
-TESTS = $(noninteractive) $(needs_audio) $(needs_display)
 
 check:
 	@set -e; \

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -389,6 +389,7 @@ distclean: clean
 TESTS = \
 	testatomic$(EXE) \
 	testaudioinfo$(EXE) \
+	testautomation$(EXE) \
 	testbounds$(EXE) \
 	testdisplayinfo$(EXE) \
 	testerror$(EXE) \


### PR DESCRIPTION
* test: Don't distinguish between different categories of tests
    
    It's reasonable to assume that any of them might need a display and an
    audio backend. We run them with SDL_VIDEODRIVER and SDL_AUDIODRIVER
    set to dummy anyway.

* test: Run testautomation under Autotools too, not just CMake
    
    The CMake build system runs this since #8313, so we already have to make
    sure it doesn't regress.

---

Autotools equivalent of #8313.

In at least Debian/Ubuntu and the Steam Runtime, we're still using Autotools to build and test SDL2. If the SDL team would recommend switching to CMake (like Fedora and Arch did) then we can do that, but I was under the impression that Autotools is still the recommendation for 2.x, until it gets fully superseded by SDL3 + sdl2-compat.