### PR TITLE
wayland: Always create the backing input store, even if there is no seat

### DIFF
--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -189,11 +189,11 @@ extern void Wayland_PumpEvents(SDL_VideoDevice *_this);
 extern void Wayland_SendWakeupEvent(SDL_VideoDevice *_this, SDL_Window *window);
 extern int Wayland_WaitEventTimeout(SDL_VideoDevice *_this, Sint64 timeoutNS);
 
-extern void Wayland_add_data_device_manager(SDL_VideoData *d, uint32_t id, uint32_t version);
-extern void Wayland_add_primary_selection_device_manager(SDL_VideoData *d, uint32_t id, uint32_t version);
-extern void Wayland_add_text_input_manager(SDL_VideoData *d, uint32_t id, uint32_t version);
+extern void Wayland_create_data_device(SDL_VideoData *d);
+extern void Wayland_create_primary_selection_device(SDL_VideoData *d);
+extern void Wayland_create_text_input(SDL_VideoData *d);
 
-extern void Wayland_display_add_input(SDL_VideoData *d, uint32_t id, uint32_t version);
+extern void Wayland_input_initialize_seat(SDL_VideoData *d);
 extern void Wayland_display_destroy_input(SDL_VideoData *d);
 
 extern int Wayland_input_lock_pointer(struct SDL_WaylandInput *input);


### PR DESCRIPTION
Fixes a crash if no seat was available at initialization, but still allows for one to still be created later if an input device is added.

Removes some unnecessary abstractions in the process.

This is the SDL3 version, a simplified backport to SDL2 will happen separately.

Fixes #8898