### PR TITLE
SDL_ShowMessageBox: Remove `#ifdef`s and respect SDL_VIDEO_DRIVER hint.

### DIFF
--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -447,6 +447,7 @@ typedef struct VideoBootStrap
     const char *name;
     const char *desc;
     SDL_VideoDevice *(*create)(void);
+    int (*ShowMessageBox)(const SDL_MessageBoxData *messageboxdata, int *buttonid);  /* can be done without initializing backend! */
 } VideoBootStrap;
 
 /* Not all of these are available in a given build. Use #ifdefs, etc. */

--- a/src/video/android/SDL_androidvideo.c
+++ b/src/video/android/SDL_androidvideo.c
@@ -38,6 +38,7 @@
 #include "SDL_androidtouch.h"
 #include "SDL_androidwindow.h"
 #include "SDL_androidvulkan.h"
+#include "SDL_androidmessagebox.h"
 
 #define ANDROID_VID_DRIVER_NAME "Android"
 
@@ -162,7 +163,8 @@ static SDL_VideoDevice *Android_CreateDevice(void)
 
 VideoBootStrap Android_bootstrap = {
     ANDROID_VID_DRIVER_NAME, "SDL Android video driver",
-    Android_CreateDevice
+    Android_CreateDevice,
+    Android_ShowMessageBox
 };
 
 int Android_VideoInit(SDL_VideoDevice *_this)

--- a/src/video/cocoa/SDL_cocoavideo.m
+++ b/src/video/cocoa/SDL_cocoavideo.m
@@ -30,6 +30,7 @@
 #include "SDL_cocoavulkan.h"
 #include "SDL_cocoametalview.h"
 #include "SDL_cocoaopengles.h"
+#include "SDL_cocoamessagebox.h"
 
 @implementation SDL_CocoaVideoData
 
@@ -180,7 +181,8 @@ static SDL_VideoDevice *Cocoa_CreateDevice(void)
 
 VideoBootStrap COCOA_bootstrap = {
     "cocoa", "SDL Cocoa video driver",
-    Cocoa_CreateDevice
+    Cocoa_CreateDevice,
+    Cocoa_ShowMessageBox
 };
 
 int Cocoa_VideoInit(SDL_VideoDevice *_this)

--- a/src/video/dummy/SDL_nullvideo.c
+++ b/src/video/dummy/SDL_nullvideo.c
@@ -120,7 +120,8 @@ static SDL_VideoDevice *DUMMY_CreateDevice(void)
 
 VideoBootStrap DUMMY_bootstrap = {
     DUMMYVID_DRIVER_NAME, "SDL dummy video driver",
-    DUMMY_CreateDevice
+    DUMMY_CreateDevice,
+    NULL /* no ShowMessageBox implementation */
 };
 
 #ifdef SDL_INPUT_LINUXEV
@@ -142,7 +143,8 @@ static SDL_VideoDevice *DUMMY_EVDEV_CreateDevice(void)
 
 VideoBootStrap DUMMY_evdev_bootstrap = {
     DUMMYVID_DRIVER_EVDEV_NAME, "SDL dummy video driver with evdev",
-    DUMMY_EVDEV_CreateDevice
+    DUMMY_EVDEV_CreateDevice,
+    NULL /* no ShowMessageBox implementation */
 };
 
 #endif /* SDL_INPUT_LINUXEV */

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -116,7 +116,8 @@ static SDL_VideoDevice *Emscripten_CreateDevice(void)
 
 VideoBootStrap Emscripten_bootstrap = {
     EMSCRIPTENVID_DRIVER_NAME, "SDL emscripten video driver",
-    Emscripten_CreateDevice
+    Emscripten_CreateDevice,
+    NULL /* no ShowMessageBox implementation */
 };
 
 int Emscripten_VideoInit(SDL_VideoDevice *_this)

--- a/src/video/haiku/SDL_bvideo.cc
+++ b/src/video/haiku/SDL_bvideo.cc
@@ -39,6 +39,7 @@ extern "C" {
 #include "SDL_bmodes.h"
 #include "SDL_bframebuffer.h"
 #include "SDL_bevents.h"
+#include "SDL_bmessagebox.h"
 
 static SDL_INLINE SDL_BWin *_ToBeWin(SDL_Window *window) {
     return (SDL_BWin *)(window->driverdata);
@@ -121,7 +122,8 @@ static SDL_VideoDevice * HAIKU_CreateDevice(void)
 
 VideoBootStrap HAIKU_bootstrap = {
     "haiku", "Haiku graphics",
-    HAIKU_CreateDevice
+    HAIKU_CreateDevice,
+    HAIKU_ShowMessageBox
 };
 
 void HAIKU_DeleteDevice(SDL_VideoDevice * device)

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -328,7 +328,8 @@ cleanup:
 VideoBootStrap KMSDRM_bootstrap = {
     "KMSDRM",
     "KMS/DRM Video Driver",
-    KMSDRM_CreateDevice
+    KMSDRM_CreateDevice,
+    NULL /* no ShowMessageBox implementation */
 };
 
 static void KMSDRM_FBDestroyCallback(struct gbm_bo *bo, void *data)

--- a/src/video/n3ds/SDL_n3dsvideo.c
+++ b/src/video/n3ds/SDL_n3dsvideo.c
@@ -82,7 +82,7 @@ static SDL_VideoDevice *N3DS_CreateDevice(void)
     return device;
 }
 
-VideoBootStrap N3DS_bootstrap = { N3DSVID_DRIVER_NAME, "N3DS Video Driver", N3DS_CreateDevice };
+VideoBootStrap N3DS_bootstrap = { N3DSVID_DRIVER_NAME, "N3DS Video Driver", N3DS_CreateDevice, NULL /* no ShowMessageBox implementation */ };
 
 static int N3DS_VideoInit(SDL_VideoDevice *_this)
 {

--- a/src/video/ngage/SDL_ngagevideo.cpp
+++ b/src/video/ngage/SDL_ngagevideo.cpp
@@ -136,7 +136,8 @@ static SDL_VideoDevice *NGAGE_CreateDevice(void)
 
 VideoBootStrap NGAGE_bootstrap = {
     NGAGEVID_DRIVER_NAME, "SDL ngage video driver",
-    NGAGE_CreateDevice
+    NGAGE_CreateDevice,
+    NULL /* no ShowMessageBox implementation */
 };
 
 int NGAGE_VideoInit(SDL_VideoDevice *_this)

--- a/src/video/offscreen/SDL_offscreenvideo.c
+++ b/src/video/offscreen/SDL_offscreenvideo.c
@@ -93,7 +93,8 @@ static SDL_VideoDevice *OFFSCREEN_CreateDevice(void)
 
 VideoBootStrap OFFSCREEN_bootstrap = {
     OFFSCREENVID_DRIVER_NAME, "SDL offscreen video driver",
-    OFFSCREEN_CreateDevice
+    OFFSCREEN_CreateDevice,
+    NULL /* no ShowMessageBox implementation */
 };
 
 int OFFSCREEN_VideoInit(SDL_VideoDevice *_this)

--- a/src/video/ps2/SDL_ps2video.c
+++ b/src/video/ps2/SDL_ps2video.c
@@ -113,7 +113,8 @@ static SDL_VideoDevice *PS2_CreateDevice(void)
 VideoBootStrap PS2_bootstrap = {
     "PS2",
     "PS2 Video Driver",
-    PS2_CreateDevice
+    PS2_CreateDevice,
+    NULL /* no ShowMessageBox implementation */
 };
 
 #endif /* SDL_VIDEO_DRIVER_PS2 */

--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -118,7 +118,8 @@ static SDL_VideoDevice *PSP_Create()
 VideoBootStrap PSP_bootstrap = {
     "PSP",
     "PSP Video Driver",
-    PSP_Create
+    PSP_Create,
+    NULL /* no ShowMessageBox implementation */
 };
 
 /*****************************************************************************/

--- a/src/video/qnx/SDL_qnxvideo.c
+++ b/src/video/qnx/SDL_qnxvideo.c
@@ -340,5 +340,6 @@ static SDL_VideoDevice *createDevice()
 
 VideoBootStrap QNX_bootstrap = {
     "qnx", "QNX Screen",
-    createDevice
+    createDevice,
+    NULL /* no ShowMessageBox implementation */
 };

--- a/src/video/raspberry/SDL_rpivideo.c
+++ b/src/video/raspberry/SDL_rpivideo.c
@@ -128,7 +128,8 @@ static SDL_VideoDevice *RPI_Create()
 VideoBootStrap RPI_bootstrap = {
     "RPI",
     "RPI Video Driver",
-    RPI_Create
+    RPI_Create,
+    NULL /* no ShowMessageBox implementation */
 };
 
 /*****************************************************************************/

--- a/src/video/riscos/SDL_riscosvideo.c
+++ b/src/video/riscos/SDL_riscosvideo.c
@@ -32,6 +32,7 @@
 #include "SDL_riscosmouse.h"
 #include "SDL_riscosmodes.h"
 #include "SDL_riscoswindow.h"
+#include "SDL_riscosmessagebox.h"
 
 #define RISCOSVID_DRIVER_NAME "riscos"
 
@@ -89,7 +90,8 @@ static SDL_VideoDevice *RISCOS_CreateDevice(void)
 
 VideoBootStrap RISCOS_bootstrap = {
     RISCOSVID_DRIVER_NAME, "SDL RISC OS video driver",
-    RISCOS_CreateDevice
+    RISCOS_CreateDevice,
+    RISCOS_ShowMessageBox
 };
 
 static int RISCOS_VideoInit(SDL_VideoDevice *_this)

--- a/src/video/uikit/SDL_uikitvideo.m
+++ b/src/video/uikit/SDL_uikitvideo.m
@@ -36,6 +36,7 @@
 #include "SDL_uikitclipboard.h"
 #include "SDL_uikitvulkan.h"
 #include "SDL_uikitmetalview.h"
+#include "SDL_uikitmessagebox.h"
 
 #define UIKITVID_DRIVER_NAME "uikit"
 
@@ -141,7 +142,8 @@ static SDL_VideoDevice *UIKit_CreateDevice(void)
 
 VideoBootStrap UIKIT_bootstrap = {
     UIKITVID_DRIVER_NAME, "SDL UIKit video driver",
-    UIKit_CreateDevice
+    UIKit_CreateDevice,
+    UIKit_ShowMessageBox
 };
 
 int UIKit_VideoInit(SDL_VideoDevice *_this)

--- a/src/video/vita/SDL_vitavideo.c
+++ b/src/video/vita/SDL_vitavideo.c
@@ -35,6 +35,7 @@
 #include "SDL_vitakeyboard.h"
 #include "SDL_vitamouse_c.h"
 #include "SDL_vitaframebuffer.h"
+#include "SDL_vitamessagebox.h"
 
 #ifdef SDL_VIDEO_VITA_PIB
 #include "SDL_vitagles_c.h"
@@ -158,7 +159,8 @@ static SDL_VideoDevice *VITA_Create()
 VideoBootStrap VITA_bootstrap = {
     "VITA",
     "VITA Video Driver",
-    VITA_Create
+    VITA_Create,
+    VITA_ShowMessageBox
 };
 
 /*****************************************************************************/

--- a/src/video/vivante/SDL_vivantevideo.c
+++ b/src/video/vivante/SDL_vivantevideo.c
@@ -105,7 +105,8 @@ static SDL_VideoDevice *VIVANTE_Create()
 VideoBootStrap VIVANTE_bootstrap = {
     "vivante",
     "Vivante EGL Video Driver",
-    VIVANTE_Create
+    VIVANTE_Create,
+    NULL /* no ShowMessageBox implementation */
 };
 
 /*****************************************************************************/

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -34,6 +34,7 @@
 #include "SDL_waylandkeyboard.h"
 #include "SDL_waylandclipboard.h"
 #include "SDL_waylandvulkan.h"
+#include "SDL_waylandmessagebox.h"
 
 #include <sys/types.h>
 #include <unistd.h>
@@ -318,7 +319,8 @@ static SDL_VideoDevice *Wayland_CreateDevice(void)
 
 VideoBootStrap Wayland_bootstrap = {
     WAYLANDVID_DRIVER_NAME, "SDL Wayland video driver",
-    Wayland_CreateDevice
+    Wayland_CreateDevice,
+    Wayland_ShowMessageBox
 };
 
 static void xdg_output_handle_logical_position(void *data, struct zxdg_output_v1 *xdg_output,

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -32,6 +32,7 @@
 #include "SDL_windowsvideo.h"
 #include "SDL_windowsframebuffer.h"
 #include "SDL_windowsvulkan.h"
+#include "SDL_windowsmessagebox.h"
 
 #ifdef SDL_GDK_TEXTINPUT
 #include "../gdk/SDL_gdktextinput.h"
@@ -284,7 +285,12 @@ static SDL_VideoDevice *WIN_CreateDevice(void)
 }
 
 VideoBootStrap WINDOWS_bootstrap = {
-    "windows", "SDL Windows video driver", WIN_CreateDevice
+    "windows", "SDL Windows video driver", WIN_CreateDevice,
+    #if !defined(__XBOXONE__) && !defined(__XBOXSERIES__)
+    WIN_ShowMessageBox
+    #else
+    NULL
+    #endif
 };
 
 static BOOL WIN_DeclareDPIAwareUnaware(SDL_VideoDevice *_this)

--- a/src/video/winrt/SDL_winrtmessagebox.cpp
+++ b/src/video/winrt/SDL_winrtmessagebox.cpp
@@ -40,7 +40,7 @@ static String ^ WINRT_UTF8ToPlatformString(const char *str) {
     return rtstr;
 }
 
-    extern "C" int WINRT_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonid)
+extern "C" int WINRT_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonid)
 {
 #if SDL_WINAPI_FAMILY_PHONE && NTDDI_VERSION == NTDDI_WIN8
     /* Sadly, Windows Phone 8 doesn't include the MessageDialog class that

--- a/src/video/winrt/SDL_winrtvideo.cpp
+++ b/src/video/winrt/SDL_winrtvideo.cpp
@@ -58,6 +58,7 @@ extern "C" {
 #include "../SDL_pixels_c.h"
 #include "../SDL_sysvideo.h"
 #include "SDL_winrtopengles.h"
+#include "SDL_winrtmessagebox.h"
 }
 
 #include "../../core/winrt/SDL_winrtapp_direct3d.h"
@@ -155,10 +156,10 @@ static SDL_VideoDevice *WINRT_CreateDevice(void)
     return device;
 }
 
-#define WINRTVID_DRIVER_NAME "winrt"
 VideoBootStrap WINRT_bootstrap = {
-    WINRTVID_DRIVER_NAME, "SDL WinRT video driver",
-    WINRT_CreateDevice
+    "winrt", "SDL WinRT video driver",
+    WINRT_CreateDevice,
+    WINRT_ShowMessageBox
 };
 
 static void SDLCALL WINRT_SetDisplayOrientationsPreference(void *userdata, const char *name, const char *oldValue, const char *newValue)

--- a/src/video/x11/SDL_x11video.c
+++ b/src/video/x11/SDL_x11video.c
@@ -34,6 +34,7 @@
 #include "SDL_x11video.h"
 #include "SDL_x11xfixes.h"
 #include "SDL_x11xinput2.h"
+#include "SDL_x11messagebox.h"
 
 #ifdef SDL_VIDEO_OPENGL_EGL
 #include "SDL_x11opengles.h"
@@ -283,7 +284,8 @@ static SDL_VideoDevice *X11_CreateDevice(void)
 
 VideoBootStrap X11_bootstrap = {
     "x11", "SDL X11 video driver",
-    X11_CreateDevice
+    X11_CreateDevice,
+    X11_ShowMessageBox
 };
 
 static int (*handler)(Display *, XErrorEvent *) = NULL;


### PR DESCRIPTION
This a larger change than was discussed, so I'm putting it in a Pull Request for GitHub Actions to test, and humans to scrutinize.

But this cleans out a bunch of platform-specific `#ifdef` blocks from SDL_video.c that no longer need to be updated as supported platforms change, and also makes it so the extended `SDL_VIDEO_DRIVER=target1,target2,etc` format is respected.

We'll cherry-pick this back to SDL2 if it makes sense, or do something less invasive if not.

Fixes #8892.
