### PR TITLE
ci: Re-enable visionOS ci.

### DIFF
--- a/.github/workflows/visionos.yml
+++ b/.github/workflows/visionos.yml
@@ -1,16 +1,18 @@
 name: Build (visionOS)
 
-# FIXME: Enable this workflow once CMake 3.28 becomes available on GitHub
 on: [push, pull_request]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+env:
+  DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
+
 jobs:
   Build:
     name: visionOS
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The visionOS CI was disabled with a comment saying that it should be enabled once make 3.28 was on GitHub Actions runners. It is now, so trying to re-enable it.