### PR TITLE
Added a way to access logical_dst_rect

### DIFF
--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -1072,6 +1072,11 @@ extern DECLSPEC int SDLCALL SDL_SetRenderLogicalPresentation(SDL_Renderer *rende
 extern DECLSPEC int SDLCALL SDL_GetRenderLogicalPresentation(SDL_Renderer *renderer, int *w, int *h, SDL_RendererLogicalPresentation *mode, SDL_ScaleMode *scale_mode);
 
 /**
+ * Get the logical destination rect
+ */
+extern DECLSPEC int SDL_GetLogicalRect(SDL_Renderer *renderer, SDL_Rect* rect);
+
+/**
  * Get a point in render coordinates when given a point in window coordinates.
  *
  * \param renderer the rendering context

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -2285,6 +2285,11 @@ int SDL_GetRenderLogicalPresentation(SDL_Renderer *renderer, int *w, int *h, SDL
     return 0;
 }
 
+int SDL_GetLogicalRect(SDL_Renderer *renderer, SDL_Rect* rect) {
+    *rect = renderer->logical_dst_rect;
+    return 0;
+}
+
 static void SDL_RenderLogicalBorders(SDL_Renderer *renderer)
 {
     const SDL_FRect *dst = &renderer->logical_dst_rect;


### PR DESCRIPTION
SDL_GetLogicalRect function to get the logical destination rect 

** This was my origin issue ** 
I need to know where it is to correctly draw an imgui panel, for logical rendering I have to turn it off before I render the imgui frame, because of that I need to know where to put the frame, and that involves the offset that the logical rect is from 0, 0 because of how it is pushed to the middle with letterboxing, currently I am using a modified version of the UpdateLogicalPresentation method to get the rect, but this should just be a sdl feature
