### PR TITLE
Don't use SDL platform macros in contexts where they seem inappropriate

### DIFF
--- a/cmake/sdlchecks.cmake
+++ b/cmake/sdlchecks.cmake
@@ -849,7 +849,7 @@ macro(CheckPTHREAD)
         check_c_source_compiles("
             #include <pthread.h>
             int main(int argc, char **argv) {
-              #ifdef SDL_PLATFORM_APPLE
+              #ifdef __APPLE__
               pthread_setname_np(\"\");
               #else
               pthread_setname_np(pthread_self(),\"\");

--- a/src/video/arm/pixman-arm-neon-asm.S
+++ b/src/video/arm/pixman-arm-neon-asm.S
@@ -44,7 +44,7 @@
  */
 
 /* Prevent the stack from becoming executable for no reason... */
-#if defined(SDL_PLATFORM_LINUX) && defined(__ELF__)
+#if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif
 

--- a/src/video/arm/pixman-arm-simd-asm.S
+++ b/src/video/arm/pixman-arm-simd-asm.S
@@ -19,7 +19,7 @@
  */
 
 /* Prevent the stack from becoming executable */
-#if defined(SDL_PLATFORM_LINUX) && defined(__ELF__)
+#if defined(__linux__) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif
 

--- a/src/video/khronos/EGL/eglplatform.h
+++ b/src/video/khronos/EGL/eglplatform.h
@@ -48,13 +48,13 @@
  * implementations.
  */
 
-#ifdef EGL_NO_PLATFORM_SPECIFIC_TYPES
+#if defined(EGL_NO_PLATFORM_SPECIFIC_TYPES)
 
 typedef void *EGLNativeDisplayType;
 typedef void *EGLNativePixmapType;
 typedef void *EGLNativeWindowType;
 
-#elif defined(_WIN32) || defined(__VC32__) && !defined(SDL_PLATFORM_CYGWIN) && !defined(__SCITECH_SNAP__) /* Win32 and WinCE */
+#elif defined(_WIN32) || defined(__VC32__) && !defined(__CYGWIN__) && !defined(__SCITECH_SNAP__) /* Win32 and WinCE */
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN 1
 #endif
@@ -88,7 +88,7 @@ typedef struct gbm_device  *EGLNativeDisplayType;
 typedef struct gbm_bo      *EGLNativePixmapType;
 typedef void               *EGLNativeWindowType;
 
-#elif defined(SDL_PLATFORM_ANDROID) || defined(ANDROID)
+#elif defined(__ANDROID__) || defined(ANDROID)
 
 struct ANativeWindow;
 struct egl_native_pixmap_t;
@@ -125,7 +125,7 @@ typedef int   EGLNativeDisplayType;
 typedef void *EGLNativePixmapType;
 typedef void *EGLNativeWindowType;
 
-#elif defined(SDL_PLATFORM_HAIKU)
+#elif defined(__HAIKU__)
 
 #include <kernel/image.h>
 
@@ -160,7 +160,7 @@ typedef khronos_int32_t EGLint;
 
 
 /* C++ / C typecast macros for special EGL handle values */
-#ifdef __cplusplus
+#if defined(__cplusplus)
 #define EGL_CAST(type, value) (static_cast<type>(value))
 #else
 #define EGL_CAST(type, value) ((type) (value))

--- a/src/video/khronos/KHR/khrplatform.h
+++ b/src/video/khronos/KHR/khrplatform.h
@@ -99,7 +99,7 @@
  *-------------------------------------------------------------------------
  * This precedes the return type of the function in the function prototype.
  */
-#ifdef KHRONOS_STATIC
+#if defined(KHRONOS_STATIC)
     /* If the preprocessor constant KHRONOS_STATIC is defined, make the
      * header compatible with static linking. */
 #   define KHRONOS_APICALL
@@ -107,7 +107,7 @@
 #   define KHRONOS_APICALL __declspec(dllimport)
 #elif defined (__SYMBIAN32__)
 #   define KHRONOS_APICALL IMPORT_C
-#elif defined(SDL_PLATFORM_ANDROID)
+#elif defined(__ANDROID__)
 #   define KHRONOS_APICALL __attribute__((visibility("default")))
 #else
 #   define KHRONOS_APICALL
@@ -260,7 +260,7 @@ typedef signed   long  int     khronos_intptr_t;
 typedef unsigned long  int     khronos_uintptr_t;
 #endif
 
-#ifdef _WIN64
+#if defined(_WIN64)
 typedef signed   long long int khronos_ssize_t;
 typedef unsigned long long int khronos_usize_t;
 #else

--- a/src/video/khronos/vulkan/vk_platform.h
+++ b/src/video/khronos/vulkan/vk_platform.h
@@ -41,9 +41,9 @@ extern "C"
     #define VKAPI_ATTR
     #define VKAPI_CALL __stdcall
     #define VKAPI_PTR  VKAPI_CALL
-#elif defined(SDL_PLATFORM_ANDROID) && defined(__ARM_ARCH) && __ARM_ARCH < 7
+#elif defined(__ANDROID__) && defined(__ARM_ARCH) && __ARM_ARCH < 7
     #error "Vulkan is not supported for the 'armeabi' NDK ABI"
-#elif defined(SDL_PLATFORM_ANDROID) && defined(__ARM_ARCH) && __ARM_ARCH >= 7 && defined(__ARM_32BIT_STATE)
+#elif defined(__ANDROID__) && defined(__ARM_ARCH) && __ARM_ARCH >= 7 && defined(__ARM_32BIT_STATE)
     // On Android 32-bit ARM targets, Vulkan functions use the "hardfloat"
     // calling convention, i.e. float parameters are passed in registers. This
     // is true even if the rest of the application passes floats on the stack,


### PR DESCRIPTION
* Revert Khronos headers to upstream version
    
    These are third-party headers, so it's best if they're identical to the
    upstream version rather than using SDL-specific macros or coding style.

    This partially reverts commits b6ae281e and 31d133db.
    
    Fixes: 31d133db "Define SDL_PLATFORM_* macros instead of underscored ones (#8875)"

* Go back to using compiler built-in macros in ARM assembly code
    
    These files don't #include SDL headers, so SDL-specific macros will
    never be defined here.
    
    This partially reverts commit 31d133db.
    
    Fixes: 31d133db "Define SDL_PLATFORM_* macros instead of underscored ones (#8875)"

* Don't try to use SDL platform macros in configure-time checks
    
    At the point that we run this, nothing SDL-specific is set up yet.
    `__APPLE__` is a compiler predefined macro that forms part of the API on
    Apple platforms, so it's fine to rely on it.
    
    This partially reverts commit 31d133db.
    
    Fixes: 31d133db "Define SDL_PLATFORM_* macros instead of underscored ones (#8875)"

cc @slouken @madebr