### PR TITLE
change meaning of SDL_PLATFORM_WINDOWS:

### DIFF
--- a/include/SDL3/SDL_intrin.h
+++ b/include/SDL3/SDL_intrin.h
@@ -64,7 +64,7 @@ _m_prefetch(void *__P)
 #  ifdef __ARM_NEON
 #    define SDL_NEON_INTRINSICS 1
 #    include <arm_neon.h>
-#  elif defined(SDL_PLATFORM_WINDOWS) || defined(SDL_PLATFORM_WINRT) || defined(SDL_PLATFORM_GDK)
+#  elif defined(SDL_PLATFORM_WINDOWS)
 /* Visual Studio doesn't define __ARM_ARCH, but _M_ARM (if set, always 7), and _M_ARM64 (if set, always 1). */
 #    ifdef _M_ARM
 #      define SDL_NEON_INTRINSICS 1

--- a/include/SDL3/SDL_platform_defines.h
+++ b/include/SDL3/SDL_platform_defines.h
@@ -132,7 +132,9 @@
 #define SDL_PLATFORM_CYGWIN 1
 #endif
 
-#if defined(WIN32) || defined(_WIN32) || defined(SDL_PLATFORM_CYGWIN) || defined(__MINGW32__)
+#if defined(_WIN32) || defined(SDL_PLATFORM_CYGWIN)
+#define SDL_PLATFORM_WINDOWS  1    /* Win32 api and Windows-based OSs */
+
 /* Try to find out if we're compiling for WinRT, GDK or non-WinRT/GDK */
 #if defined(_MSC_VER) && defined(__has_include)
 #if __has_include(<winapifamily.h>)
@@ -170,13 +172,10 @@
 #elif defined(_GAMING_XBOX_SCARLETT)
 #define SDL_PLATFORM_XBOXSERIES 1
 #else
-#define SDL_PLATFORM_WINDOWS    1
+#define SDL_PLATFORM_WIN32      1
 #endif
 #endif /* defined(WIN32) || defined(_WIN32) || defined(SDL_PLATFORM_CYGWIN) */
 
-#ifdef SDL_PLATFORM_WINDOWS
-#define SDL_PLATFORM_WIN32  1
-#endif
 /* This is to support generic "any GDK" separate from a platform-specific GDK */
 #if defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_XBOXONE) || defined(SDL_PLATFORM_XBOXSERIES)
 #define SDL_PLATFORM_GDK    1

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -439,7 +439,7 @@ static int CPU_haveNEON(void)
 {
 /* The way you detect NEON is a privileged instruction on ARM, so you have
    query the OS kernel in a platform-specific way. :/ */
-#if (defined(SDL_PLATFORM_WINDOWS) || defined(SDL_PLATFORM_WINRT) || defined(SDL_PLATFORM_GDK)) && (defined(_M_ARM) || defined(_M_ARM64))
+#if defined(SDL_PLATFORM_WINDOWS) && (defined(_M_ARM) || defined(_M_ARM64))
 /* Visual Studio, for ARM, doesn't define __ARM_ARCH. Handle this first. */
 /* Seems to have been removed */
 #ifndef PF_ARM_NEON_INSTRUCTIONS_AVAILABLE

--- a/src/hidapi/SDL_hidapi.c
+++ b/src/hidapi/SDL_hidapi.c
@@ -27,6 +27,7 @@
  * This merges the two, at a small performance cost, until distributions
  * have granted access to /dev/hidraw*
  */
+
 #include "SDL_internal.h"
 
 #include "SDL_hidapi_c.h"
@@ -577,7 +578,7 @@ typedef struct PLATFORM_hid_device_ PLATFORM_hid_device;
 #include "SDL_hidapi_netbsd.h"
 #elif defined(SDL_PLATFORM_MACOS)
 #include "SDL_hidapi_mac.h"
-#elif defined(SDL_PLATFORM_WINDOWS) || defined(SDL_PLATFORM_WINGDK)
+#elif defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
 #include "SDL_hidapi_windows.h"
 #elif defined(SDL_PLATFORM_ANDROID)
 #include "SDL_hidapi_android.h"

--- a/src/joystick/hidapi/SDL_hidapi_ps3.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps3.c
@@ -72,7 +72,7 @@ static SDL_bool HIDAPI_DriverPS3_IsEnabled(void)
 #ifdef SDL_PLATFORM_MACOS
     /* This works well on macOS */
     default_value = SDL_TRUE;
-#elif defined(SDL_PLATFORM_WINDOWS)
+#elif defined(SDL_PLATFORM_WIN32)
     /* You can't initialize the controller with the stock Windows drivers
      * See https://github.com/ViGEm/DsHidMini as an alternative driver
      */

--- a/src/render/opengl/SDL_render_gl.c
+++ b/src/render/opengl/SDL_render_gl.c
@@ -1642,7 +1642,7 @@ static SDL_bool GL_IsProbablyAccelerated(const GL_RenderData *data)
     /*const char *vendor = (const char *) data->glGetString(GL_VENDOR);*/
     const char *renderer = (const char *)data->glGetString(GL_RENDERER);
 
-#if defined(SDL_PLATFORM_WINDOWS) || defined(SDL_PLATFORM_WINGDK)
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
     if (SDL_strcmp(renderer, "GDI Generic") == 0) {
         return SDL_FALSE; /* Microsoft's fallback software renderer. Fix your system! */
     }

--- a/src/test/SDL_test_memory.c
+++ b/src/test/SDL_test_memory.c
@@ -25,7 +25,7 @@
 #include <libunwind.h>
 #endif
 
-#ifdef SDL_PLATFORM_WINDOWS
+#ifdef SDL_PLATFORM_WIN32
 #include <windows.h>
 #include <dbghelp.h>
 
@@ -153,7 +153,7 @@ static void SDL_TrackAllocation(void *mem, size_t size)
             }
         }
     }
-#elif defined(SDL_PLATFORM_WINDOWS)
+#elif defined(SDL_PLATFORM_WIN32)
     {
         Uint32 count;
         PVOID frames[63];
@@ -295,7 +295,7 @@ void SDLTest_TrackAllocations(void)
     if (s_previous_allocations != 0) {
         SDL_Log("SDLTest_TrackAllocations(): There are %d previous allocations, disabling free() validation", s_previous_allocations);
     }
-#ifdef SDL_PLATFORM_WINDOWS
+#ifdef SDL_PLATFORM_WIN32
     {
         s_dbghelp = SDL_LoadObject("dbghelp.dll");
         if (s_dbghelp) {

--- a/test/testgles2.c
+++ b/test/testgles2.c
@@ -19,7 +19,7 @@
 
 #include <stdlib.h>
 
-#if defined(SDL_PLATFORM_IOS) || defined(SDL_PLATFORM_ANDROID) || defined(SDL_PLATFORM_EMSCRIPTEN) || defined(SDL_PLATFORM_WINDOWS) || defined(SDL_PLATFORM_LINUX)
+#if defined(SDL_PLATFORM_IOS) || defined(SDL_PLATFORM_ANDROID) || defined(SDL_PLATFORM_EMSCRIPTEN) || defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_LINUX)
 #define HAVE_OPENGLES2
 #endif
 

--- a/test/testgles2_sdf.c
+++ b/test/testgles2_sdf.c
@@ -20,7 +20,7 @@
 
 #include <stdlib.h>
 
-#if defined(SDL_PLATFORM_IOS) || defined(SDL_PLATFORM_ANDROID) || defined(SDL_PLATFORM_EMSCRIPTEN) || defined(SDL_PLATFORM_WINDOWS) || defined(SDL_PLATFORM_LINUX)
+#if defined(SDL_PLATFORM_IOS) || defined(SDL_PLATFORM_ANDROID) || defined(SDL_PLATFORM_EMSCRIPTEN) || defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_LINUX)
 #define HAVE_OPENGLES2
 #endif
 


### PR DESCRIPTION
As discussed originally at https://github.com/libsdl-org/SDL_mixer/commit/0238375811c54f4ccebc6212bab66d89fa45f4d3#r137721878:

Macro `SDL_PLATFORM_WINDOWS` now means Win32 api and Windows-based OS's.
Macro `SDL_PLATFORM_WIN32` means desktop windows, i.e. anything other than
WinRT or GDK, etc.

Please carefully review the `SDL_PLATFORM_WINDOWS` usage changes.

P.S.: I did not review or made any changes to `SDL_PLATFORM_WIN32`
usages.
