### PR TITLE
Document that text input is on by default

### DIFF
--- a/include/SDL3/SDL_keyboard.h
+++ b/include/SDL3/SDL_keyboard.h
@@ -251,6 +251,8 @@ extern DECLSPEC SDL_Keycode SDLCALL SDL_GetKeyFromName(const char *name);
  * and SDL_TextEditingEvent (SDL_EVENT_TEXT_EDITING) events. Please use this
  * function in pair with SDL_StopTextInput().
  *
+ * Text input events are received by default.
+ *
  * On some platforms using this function activates the screen keyboard.
  *
  * \since This function is available since SDL 3.0.0.
@@ -273,6 +275,8 @@ extern DECLSPEC SDL_bool SDLCALL SDL_TextInputActive(void);
 
 /**
  * Stop receiving any text input events.
+ *
+ * Text input events are received by default.
  *
  * \since This function is available since SDL 3.0.0.
  *


### PR DESCRIPTION
The tutorial code posted [here](https://wiki.libsdl.org/SDL2/Tutorials-TextInput) implies that `SDL_StartTextInput` must be called before text input events are emitted, but those events are emitted by default. If that default behavior isn't a bug that's being fixed, I think we could save people some time by adding a note to the function headers.