### PR TITLE
X11: Fix refresh rate calculation

### DIFF
--- a/src/video/x11/SDL_x11modes.c
+++ b/src/video/x11/SDL_x11modes.c
@@ -402,8 +402,21 @@ static SDL_bool CheckXRandR(Display *display, int *major, int *minor)
 
 static float CalculateXRandRRefreshRate(const XRRModeInfo *info)
 {
-    if (info->hTotal && info->vTotal) {
-        return ((100 * (Sint64)info->dotClock) / (info->hTotal * info->vTotal)) / 100.0f;
+    double vTotal = info->vTotal;
+
+    if (info->modeFlags & RR_DoubleScan) {
+        /* doublescan doubles the number of lines */
+        vTotal *= 2;
+    }
+
+    if (info->modeFlags & RR_Interlace) {
+        /* interlace splits the frame into two fields */
+        /* the field rate is what is typically reported by monitors */
+        vTotal /= 2;
+    }
+
+    if (info->hTotal && vTotal) {
+        return ((100 * (Sint64)info->dotClock) / (info->hTotal * vTotal)) / 100.0f;
     }
     return 0.0f;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes outdated refresh rate calculations from XRandR's output.

## Description
<!--- Describe your changes in detail -->
The original `CalculateXRandRRefreshRate` function didn't consider double scan and interlace and thus led to incorrect display mode. see #8918 for more info.

## Existing Issue(s)
should be able to close #8918 