### PR TITLE
Add missing `windres` RC compiler to cmake mingw64 buildscripts

### DIFF
--- a/build-scripts/cmake-toolchain-mingw64-i686.cmake
+++ b/build-scripts/cmake-toolchain-mingw64-i686.cmake
@@ -3,6 +3,7 @@ set(CMAKE_SYSTEM_PROCESSOR x86)
 
 find_program(CMAKE_C_COMPILER NAMES i686-w64-mingw32-gcc)
 find_program(CMAKE_CXX_COMPILER NAMES i686-w64-mingw32-g++)
+find_program(CMAKE_RC_COMPILER NAMES i686-w64-mingw32-windres)
 
 if(NOT CMAKE_C_COMPILER)
 	message(FATAL_ERROR "Failed to find CMAKE_C_COMPILER.")
@@ -10,4 +11,8 @@ endif()
 
 if(NOT CMAKE_CXX_COMPILER)
 	message(FATAL_ERROR "Failed to find CMAKE_CXX_COMPILER.")
+endif()
+
+if(NOT CMAKE_RC_COMPILER)
+        message(FATAL_ERROR "Failed to find CMAKE_RC_COMPILER.")
 endif()

--- a/build-scripts/cmake-toolchain-mingw64-x86_64.cmake
+++ b/build-scripts/cmake-toolchain-mingw64-x86_64.cmake
@@ -3,6 +3,7 @@ set(CMAKE_SYSTEM_PROCESSOR x86_64)
 
 find_program(CMAKE_C_COMPILER NAMES x86_64-w64-mingw32-gcc)
 find_program(CMAKE_CXX_COMPILER NAMES x86_64-w64-mingw32-g++)
+find_program(CMAKE_RC_COMPILER NAMES x86_64-w64-mingw32-windres)
 
 if(NOT CMAKE_C_COMPILER)
 	message(FATAL_ERROR "Failed to find CMAKE_C_COMPILER.")
@@ -10,4 +11,8 @@ endif()
 
 if(NOT CMAKE_CXX_COMPILER)
 	message(FATAL_ERROR "Failed to find CMAKE_CXX_COMPILER.")
+endif()
+
+if(NOT CMAKE_RC_COMPILER)
+        message(FATAL_ERROR "Failed to find CMAKE_RC_COMPILER.")
 endif()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add missing `windres` RC compiler to cmake mingw64 buildscripts.

Was causing fatal error during build process as seen in #8942

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
#8942
