### PR TITLE
Fix SDL_mfijoystick build issues

### DIFF
--- a/src/joystick/apple/SDL_mfijoystick.m
+++ b/src/joystick/apple/SDL_mfijoystick.m
@@ -370,6 +370,7 @@ static BOOL IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
     NSLog(@"Product name: %@\n", controller.vendorName);
     NSLog(@"Product category: %@\n", controller.productCategory);
     NSLog(@"Elements available:\n");
+#ifdef ENABLE_PHYSICAL_INPUT_PROFILE
     if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
         NSDictionary<NSString *, GCControllerElement *> *elements = controller.physicalInputProfile.elements;
         for (id key in controller.physicalInputProfile.buttons) {
@@ -382,6 +383,7 @@ static BOOL IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
             NSLog(@"\tHat: %@\n", key);
         }
     }
+#endif
 #endif
 
     device->is_xbox = IsControllerXbox(controller);
@@ -1121,7 +1123,7 @@ static void IOS_MFIJoystickUpdate(SDL_Joystick *joystick)
         int i;
         Uint64 timestamp = SDL_GetTicksNS();
 
-#ifdef DEBUG_CONTROLLER_STATE
+#if defined(DEBUG_CONTROLLER_STATE) && defined(ENABLE_PHYSICAL_INPUT_PROFILE)
         if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
             if (controller.physicalInputProfile) {
                 for (id key in controller.physicalInputProfile.buttons) {
@@ -1148,6 +1150,7 @@ static void IOS_MFIJoystickUpdate(SDL_Joystick *joystick)
         }
 #endif /* DEBUG_CONTROLLER_STATE */
 
+#ifdef ENABLE_PHYSICAL_INPUT_PROFILE
         if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
             NSDictionary<NSString *, GCControllerElement *> *elements = controller.physicalInputProfile.elements;
             NSDictionary<NSString *, GCControllerButtonInput *> *buttons = controller.physicalInputProfile.buttons;
@@ -1174,7 +1177,9 @@ static void IOS_MFIJoystickUpdate(SDL_Joystick *joystick)
                 }
                 SDL_SendJoystickButton(timestamp, joystick, button++, value);
             }
-        } else if (controller.extendedGamepad) {
+        } else
+#endif
+        if (controller.extendedGamepad) {
             SDL_bool isstack;
             GCExtendedGamepad *gamepad = controller.extendedGamepad;
 

--- a/src/joystick/apple/SDL_mfijoystick_c.h
+++ b/src/joystick/apple/SDL_mfijoystick_c.h
@@ -25,7 +25,8 @@
 
 #include "../SDL_sysjoystick.h"
 
-#include <CoreFoundation/CoreFoundation.h>
+#import <CoreFoundation/CoreFoundation.h>
+#import <Foundation/Foundation.h>
 
 @class GCController;
 
@@ -58,8 +59,8 @@ typedef struct joystick_hwdata
     SDL_bool is_backbone_one;
     int is_siri_remote;
 
-    NSArray *axes;
-    NSArray *buttons;
+    NSArray __unsafe_unretained *axes;
+    NSArray __unsafe_unretained *buttons;
 
     SDL_bool has_dualshock_touchpad;
     SDL_bool has_xbox_paddles;


### PR DESCRIPTION
## Description
Add missing guards around use of physicalInputProfile.

Add explicit import of Foundation which seems to be needed on some systems to get the NSArray definition.

Add `__unsafe_unretained` to ObjC types in struct so the compiler doesn't complain about that not being allowed with ARC.

## Existing Issue(s)
#8979
