### PR TITLE
SDL_audiotypecvt.c: Fixed memory corruption when resampling S16 to F32

### DIFF
--- a/src/audio/SDL_audiotypecvt.c
+++ b/src/audio/SDL_audiotypecvt.c
@@ -125,7 +125,7 @@ static void SDLCALL SDL_Convert_U8_to_F32_Scalar(SDL_AudioCVT *cvt, SDL_AudioFor
 
 static void SDLCALL SDL_Convert_S16_to_F32_Scalar(SDL_AudioCVT *cvt, SDL_AudioFormat format)
 {
-    const int num_samples = cvt->len_cvt;
+    const int num_samples = cvt->len_cvt / sizeof(Sint16);
     const Sint16 *src = (const Sint16 *)cvt->buf;
     float *dst = (float *)cvt->buf;
     int i;


### PR DESCRIPTION
I accidentally found that my pre-Pentium III 32-bit builds (most of SSE2+ extensions got been disabled) do crash for unknown and weird reason, and I found accidentally, that it was at the `SDL_Convert_S16_to_F32_Scalar()` function: the num_samples was being assigned without being divided by the size of the Sint16.