### PR TITLE
SDL_windowsopengl.c: WGL: Fixed null-pointer dereference crash

### DIFF
--- a/src/video/windows/SDL_windowsopengl.c
+++ b/src/video/windows/SDL_windowsopengl.c
@@ -549,11 +549,11 @@ static int WIN_GL_ChoosePixelFormatARB(_THIS, int *iAttribs, float *fAttribs)
             _this->gl_data->wglChoosePixelFormatARB(hdc, iAttribs, fAttribs,
                                                     1, &pixel_format,
                                                     &matching);
-        }
 
-        /* Check whether we actually got an SRGB capable buffer */
-        _this->gl_data->wglGetPixelFormatAttribivARB(hdc, pixel_format, 0, 1, &qAttrib, &srgb);
-        _this->gl_config.framebuffer_srgb_capable = srgb;
+            /* Check whether we actually got an SRGB capable buffer */
+            _this->gl_data->wglGetPixelFormatAttribivARB(hdc, pixel_format, 0, 1, &qAttrib, &srgb);
+            _this->gl_config.framebuffer_srgb_capable = srgb;
+        }
 
         _this->gl_data->wglMakeCurrent(hdc, NULL);
         _this->gl_data->wglDeleteContext(hglrc);


### PR DESCRIPTION
Fixed the crash introduced at https://github.com/libsdl-org/SDL/commit/594a79c2f9db21a11a76c012b2b1655a21fc8982 .

The crash may happen when `wglGetPixelFormatAttribivARB` field gets defined by NULL. To resolve this, I moved two new lines into the condition above that checks, are these fields defined or not.

Fixes #8968