### PR TITLE
Fix memory leak in SDL_UpdateSteamVirtualGamepadInfo()

### DIFF
--- a/src/joystick/SDL_steam_virtual_gamepad.c
+++ b/src/joystick/SDL_steam_virtual_gamepad.c
@@ -219,6 +219,7 @@ SDL_bool SDL_UpdateSteamVirtualGamepadInfo(void)
     if (slot >= 0) {
         AddVirtualGamepadInfo(slot, &info);
     }
+    SDL_free(info.name);
     SDL_free(data);
 
     SDL_steam_virtual_gamepad_info_file_mtime = mtime;


### PR DESCRIPTION
## Description
Allocation of `info.name` in the last iteration of the loop is never freed.

## Existing Issue(s)
None
