### PR TITLE
Emscripten_SetWindowFullscreen: Fix crash due to uninitialized EmscriptenFullscreenStrategy member(s)

### DIFF
--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -299,6 +299,7 @@ static int Emscripten_SetWindowFullscreen(SDL_VideoDevice *_this, SDL_Window *wi
             EmscriptenFullscreenStrategy strategy;
             SDL_bool is_fullscreen_desktop = !window->fullscreen_exclusive;
 
+            SDL_zero(strategy);
             strategy.scaleMode = is_fullscreen_desktop ? EMSCRIPTEN_FULLSCREEN_SCALE_STRETCH : EMSCRIPTEN_FULLSCREEN_SCALE_ASPECT;
 
             if (!is_fullscreen_desktop) {


### PR DESCRIPTION
[`EmscriptenFullscreenStrategy`](https://github.com/emscripten-core/emscripten/blob/c47d0601fbf6296ba5f03191c2c9fe99df27d25f/system/include/emscripten/html5.h#L280C16-L287) has a `canvasResizedCallbackTargetThread` member which wasn't being zeroed or initialized by SDL. A garbage `canvasResizedCallbackTargetThread` value can lead to a crash later on inside Emscripten core library code, during the call to `emscripten_request_fullscreen_strategy()`.

## Description

To fix this (and possible future issues), use the same pattern as Emscripten's tests: https://github.com/emscripten-core/emscripten/blob/c47d0601fbf6296ba5f03191c2c9fe99df27d25f/test/test_html5_fullscreen.c#L132

```diff
  EmscriptenFullscreenStrategy strategy;
+ memset(&strategy, 0, sizeof(strategy)); // or, in this case, SDL_zero(strategy);
```

## Notes

This is a good candidate for cherry-picking to SDL2 as well, which is also impacted.