### PR TITLE
Fix broken use of MsgWaitForMultipleObjects.

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1687,7 +1687,10 @@ void SDL_SetWindowsMessageHook(SDL_WindowsMessageHook callback, void *userdata)
 int WIN_WaitEventTimeout(SDL_VideoDevice *_this, Sint64 timeoutNS)
 {
     if (g_WindowsEnableMessageLoop) {
-        if (MsgWaitForMultipleObjects(0, NULL, FALSE, (DWORD)SDL_NS_TO_MS(timeoutNS), QS_ALLINPUT)) {
+        DWORD timeout, ret;
+        timeout = timeoutNS < 0 ? INFINITE : (DWORD)SDL_NS_TO_MS(timeoutNS);
+        ret = MsgWaitForMultipleObjects(0, NULL, FALSE, timeout, QS_ALLINPUT);
+        if (ret == WAIT_OBJECT_0) {
             return 1;
         } else {
             return 0;


### PR DESCRIPTION
Fixes regression introduced in

```
commit 2670eb44afec9311ee8fbec447703c427db1e1c8
Author: Sam Lantinga <slouken@libsdl.org>
Date:   Thu Jan 25 06:30:07 2024 -0800

    Improved timing accuracy of SDL_WaitEventTimeout() on Windows

    We don't need to use the hack of setting a timer and waiting for a timer message, MsgWaitForMultipleObjects() will allow us to wait for input directly with a timeout.

    Before this change, sleeping for 20 ms would actually sleep for around 30 ms, with this change the sleep time is pretty accurate at 20-21 ms.
```

Bug manifested where SDL_WaitEvent() would return SDL_FALSE.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Timeout < 0 was not handled properly
- Return value for success is WAIT_OBJECT_0 + nCount, not positive value
