### PR TITLE
cocoa: Remove resize hack when changing the window backing scale

### DIFF
--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -1139,9 +1139,7 @@ static SDL_bool Cocoa_IsZoomed(SDL_Window *window)
     }
 
     if ([oldscale doubleValue] != [_data.nswindow backingScaleFactor]) {
-        /* Force a resize event when the backing scale factor changes. */
-        _data.window->w = 0;
-        _data.window->h = 0;
+        /* Send a resize event when the backing scale factor changes. */
         [self windowDidResize:aNotification];
     }
 }


### PR DESCRIPTION
Zeroing the window width and height was necessary in SDL2 to short-circuit the resize event deduplication code when the window backing scale changed, but not the logical size. This is no longer necessary in SDL3, as it will explicitly check for scale changes on resize events and dispatch pixel size/scale changed events as appropriate, even if the window's logical size hasn't changed.

Fixes #9061 
