### PR TITLE
Drop stray trailing whitespace for android-project

### DIFF
--- a/android-project/app/build.gradle
+++ b/android-project/app/build.gradle
@@ -52,7 +52,7 @@ android {
             //     path 'jni/CMakeLists.txt'
             // }
         }
-       
+
     }
     lint {
         abortOnError false

--- a/android-project/app/src/main/AndroidManifest.xml
+++ b/android-project/app/src/main/AndroidManifest.xml
@@ -53,7 +53,7 @@
 
     <!-- Create a Java class extending SDLActivity and place it in a
          directory under app/src/main/java matching the package, e.g. app/src/main/java/com/gamemaker/game/MyGame.java
- 
+
          then replace "SDLActivity" with the name of your class (e.g. "MyGame")
          in the XML below.
 
@@ -68,7 +68,7 @@
         <!-- Example of setting SDL hints from AndroidManifest.xml:
         <meta-data android:name="SDL_ENV.SDL_ANDROID_TRAP_BACK_BUTTON" android:value="0"/>
          -->
-     
+
         <activity android:name="SDLActivity"
             android:label="@string/app_name"
             android:alwaysRetainTaskState="true"

--- a/android-project/app/src/main/java/org/libsdl/app/SDL.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDL.java
@@ -44,13 +44,13 @@ public class SDL {
         }
 
         try {
-            // Let's see if we have ReLinker available in the project.  This is necessary for 
-            // some projects that have huge numbers of local libraries bundled, and thus may 
+            // Let's see if we have ReLinker available in the project.  This is necessary for
+            // some projects that have huge numbers of local libraries bundled, and thus may
             // trip a bug in Android's native library loader which ReLinker works around.  (If
             // loadLibrary works properly, ReLinker will simply use the normal Android method
             // internally.)
             //
-            // To use ReLinker, just add it as a dependency.  For more information, see 
+            // To use ReLinker, just add it as a dependency.  For more information, see
             // https://github.com/KeepSafe/ReLinker for ReLinker's repository.
             //
             Class<?> relinkClass = mContext.getClassLoader().loadClass("com.getkeepsafe.relinker.ReLinker");
@@ -58,7 +58,7 @@ public class SDL {
             Class<?> contextClass = mContext.getClassLoader().loadClass("android.content.Context");
             Class<?> stringClass = mContext.getClassLoader().loadClass("java.lang.String");
 
-            // Get a 'force' instance of the ReLinker, so we can ensure libraries are reinstalled if 
+            // Get a 'force' instance of the ReLinker, so we can ensure libraries are reinstalled if
             // they've changed during updates.
             Method forceMethod = relinkClass.getDeclaredMethod("force");
             Object relinkInstance = forceMethod.invoke(null);


### PR DESCRIPTION
A simple change to drop stray trailing whitespace.

There is some leftover in src/hidapi/windows/test/data, but it looked fragile and I was afraid to touch it.