### PR TITLE
opengles2: Call glClearColor() with r,g,b,a, not r,g,g,a

### DIFF
--- a/src/render/opengles2/SDL_render_gles2.c
+++ b/src/render/opengles2/SDL_render_gles2.c
@@ -1279,7 +1279,7 @@ static int GLES2_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd,
                 (g != data->drawstate.clear_color.g) ||
                 (b != data->drawstate.clear_color.b) ||
                 (a != data->drawstate.clear_color.a)) {
-                data->glClearColor(r, g, g, a);
+                data->glClearColor(r, g, b, a);
                 data->drawstate.clear_color.r = r;
                 data->drawstate.clear_color.g = g;
                 data->drawstate.clear_color.b = b;


### PR DESCRIPTION
Commit 554f0625d349c106f2633f6db039e332c4c18cec introduced these changes in `GLES2_RunCommandQueue()`:

https://github.com/libsdl-org/SDL/commit/554f0625d349c106f2633f6db039e332c4c18cec#diff-9275fcae5c62a725a16efd2bd4385f9751628f56bb088846b2db90a7059f37cfL1247-R1247
```diff
@@ -1244,18 +1234,17 @@ static int GLES2_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd,
 
         case SDL_RENDERCMD_CLEAR:
         {
-            const Uint8 r = colorswap ? cmd->data.color.b : cmd->data.color.r;
-            const Uint8 g = cmd->data.color.g;
-            const Uint8 b = colorswap ? cmd->data.color.r : cmd->data.color.b;
-            const Uint8 a = cmd->data.color.a;
-            const Uint32 color = (((Uint32)a << 24) | (r << 16) | (g << 8) | b);
-            if (data->drawstate.clear_color_dirty || (color != data->drawstate.clear_color)) {
-                const GLfloat fr = ((GLfloat)r) * inv255f;
-                const GLfloat fg = ((GLfloat)g) * inv255f;
-                const GLfloat fb = ((GLfloat)b) * inv255f;
-                const GLfloat fa = ((GLfloat)a) * inv255f;
-                data->glClearColor(fr, fg, fb, fa);
-                data->drawstate.clear_color = color;
+            const float r = colorswap ? cmd->data.color.color.b : cmd->data.color.color.r;
+            const float g = cmd->data.color.color.g;
+            const float b = colorswap ? cmd->data.color.color.r : cmd->data.color.color.b;
+            const float a = cmd->data.color.color.a;
+            if (data->drawstate.clear_color_dirty ||
+                (r != data->drawstate.clear_color.r) ||
+                (g != data->drawstate.clear_color.g) ||
+                (b != data->drawstate.clear_color.b) ||
+                (a != data->drawstate.clear_color.a)) {
+                data->glClearColor(r, g, g, a);
+                data->drawstate.clear_color = cmd->data.color.color;
                 data->drawstate.clear_color_dirty = SDL_FALSE;
             }
```

In particular `data->glClearColor(fr, fg, fb, fa);` → `data->glClearColor(r, g, g, a);`. This messes up the colors in the `opengles2` renderer.

Here's a simple test case:

https://gist.github.com/edmonds/99f058753b66fbf533a636c19786da35

It should show a solid magenta window (https://gist.github.com/edmonds/99f058753b66fbf533a636c19786da35#file-sdltest-cpp-L33) but without this commit it shows a solid red window.