### PR TITLE
wayland: Don't pass null string pointers to wl_cursor_theme_get_cursor

### DIFF
--- a/src/video/wayland/SDL_waylandmouse.c
+++ b/src/video/wayland/SDL_waylandmouse.c
@@ -259,7 +259,7 @@ static SDL_bool wayland_get_system_cursor(SDL_VideoData *vdata, Wayland_CursorDa
     cssname = SDL_GetCSSCursorName(cdata->system_cursor, &fallback_name);
 
     cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, cssname);
-    if (!cursor) {
+    if (!cursor && fallback_name) {
         cursor = WAYLAND_wl_cursor_theme_get_cursor(theme, fallback_name);
     }
 


### PR DESCRIPTION
The function calls strcmp internally without checking for a null string parameter, and calling strcmp with a null parameter is undefined behavior.

Fixes #9086 