### PR TITLE
testcamera: fix segfault at exit

### DIFF
--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1567,6 +1567,10 @@ SDL_bool SDLTest_CommonInit(SDLTest_CommonState *state)
         }
     }
 
+    if (state->flags & SDL_INIT_CAMERA) {
+        SDL_InitSubSystem(SDL_INIT_CAMERA);
+    }
+
     return SDL_TRUE;
 }
 
@@ -2561,6 +2565,9 @@ void SDLTest_CommonQuit(SDLTest_CommonState *state)
             SDL_DestroyWindow(state->windows[i]);
         }
         SDL_free(state->windows);
+    }
+    if (state->flags & SDL_INIT_CAMERA) {
+        SDL_QuitSubSystem(SDL_INIT_CAMERA);
     }
     if (state->flags & SDL_INIT_VIDEO) {
         SDL_QuitSubSystem(SDL_INIT_VIDEO);


### PR DESCRIPTION
`SDLTest_CommonEventMainCallbacks` assumes the test framework has created the window(s) and renderer(s), and segfaults because `state->windows` == NULL.
https://github.com/libsdl-org/SDL/blob/26ffbe43c246b71004821d2fcc91d332f2eb2d76/test/testcamera.c#L202
https://github.com/libsdl-org/SDL/blob/26ffbe43c246b71004821d2fcc91d332f2eb2d76/src/test/SDL_test_common.c#L2148-L2155

