### PR TITLE
SDL_camera_v4l2: allow building against older kernel headers

### DIFF
--- a/src/camera/v4l2/SDL_camera_v4l2.c
+++ b/src/camera/v4l2/SDL_camera_v4l2.c
@@ -22,6 +22,7 @@
 
 #ifdef SDL_CAMERA_DRIVER_V4L2
 
+#include <stddef.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
 #include <fcntl.h>              // low-level i/o
@@ -29,6 +30,12 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <linux/videodev2.h>
+
+#ifndef V4L2_CAP_DEVICE_CAPS
+// device_caps was added to struct v4l2_capability as of kernel 3.4.
+#define device_caps reserved[0]
+SDL_COMPILE_TIME_ASSERT(v4l2devicecaps, offsetof(struct v4l2_capability,device_caps) == offsetof(struct v4l2_capability,capabilities) + 4);
+#endif
 
 #include "../SDL_syscamera.h"
 #include "../SDL_camera_c.h"


### PR DESCRIPTION
Build of SDL_camera_v4l2.c fails against old kernel headers:

```
/tmp/SDL3/src/camera/v4l2/SDL_camera_v4l2.c: In function ‘V4L2_OpenDevice’:
/tmp/SDL3/src/camera/v4l2/SDL_camera_v4l2.c:482: error: ‘struct v4l2_capability’ has no member named ‘device_caps’
/tmp/SDL3/src/camera/v4l2/SDL_camera_v4l2.c:552: error: ‘struct v4l2_capability’ has no member named ‘device_caps’
/tmp/SDL3/src/camera/v4l2/SDL_camera_v4l2.c:573: error: ‘struct v4l2_capability’ has no member named ‘device_caps’
/tmp/SDL3/src/camera/v4l2/SDL_camera_v4l2.c: In function ‘MaybeAddDevice’:
/tmp/SDL3/src/camera/v4l2/SDL_camera_v4l2.c:698: error: ‘struct v4l2_capability’ has no member named ‘device_caps’
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/camera/v4l2/SDL_camera_v4l2.c.o] Error 1
```

`device_caps` member in `struct v4l2_capability` seems to be a thing of kernel >= 3.4.
