### PR TITLE
[X11, SDL2] Do not raise window on X11 from setting min/max size

### DIFF
--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -865,7 +865,6 @@ void X11_SetWindowMinimumSize(_THIS, SDL_Window *window)
         /* See comment in X11_SetWindowSize. */
         X11_XResizeWindow(display, data->xwindow, window->w, window->h);
         X11_XMoveWindow(display, data->xwindow, window->x - data->border_left, window->y - data->border_top);
-        X11_XRaiseWindow(display, data->xwindow);
     }
 
     X11_XFlush(display);
@@ -893,7 +892,6 @@ void X11_SetWindowMaximumSize(_THIS, SDL_Window *window)
         /* See comment in X11_SetWindowSize. */
         X11_XResizeWindow(display, data->xwindow, window->w, window->h);
         X11_XMoveWindow(display, data->xwindow, window->x - data->border_left, window->y - data->border_top);
-        X11_XRaiseWindow(display, data->xwindow);
     }
 
     X11_XFlush(display);


### PR DESCRIPTION
## Description
I went into a bit more detail on the issue thread I just created #9117

The behavior of raising the window on `X11_SetWindowMinimumSize` and `X11_SetWindowMaximumSize` is unique to SDL2 and X11.  On Mac, Windows, and Wayland this does not happen.  It also appears to have been changed for SDL3.

Can we just not raise the window?  This behavior is undesirable for us in DOSBox Staging and I suspect other people as well.  Plus it would be nice to match behavior of other platforms.

## Existing Issue(s)
#9117
