### PR TITLE
x11: Don't resize, move, or raise windows when changing the min/max size

### DIFF
--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -861,11 +861,6 @@ void X11_SetWindowMinimumSize(_THIS, SDL_Window *window)
         X11_XSetWMNormalHints(display, data->xwindow, sizehints);
 
         X11_XFree(sizehints);
-
-        /* See comment in X11_SetWindowSize. */
-        X11_XResizeWindow(display, data->xwindow, window->w, window->h);
-        X11_XMoveWindow(display, data->xwindow, window->x - data->border_left, window->y - data->border_top);
-        X11_XRaiseWindow(display, data->xwindow);
     }
 
     X11_XFlush(display);
@@ -889,11 +884,6 @@ void X11_SetWindowMaximumSize(_THIS, SDL_Window *window)
         X11_XSetWMNormalHints(display, data->xwindow, sizehints);
 
         X11_XFree(sizehints);
-
-        /* See comment in X11_SetWindowSize. */
-        X11_XResizeWindow(display, data->xwindow, window->w, window->h);
-        X11_XMoveWindow(display, data->xwindow, window->x - data->border_left, window->y - data->border_top);
-        X11_XRaiseWindow(display, data->xwindow);
     }
 
     X11_XFlush(display);


### PR DESCRIPTION
The resize/move/raise calls when changing a window's min/max size are redundant, as the video core will call the X11_SetWindowSize() function after the change, and the resize function will perform whatever actions are necessary.

SDL3 was changed to have similar behavior some time ago.

Fixes #9117 