### PR TITLE
ci: bump cross-platform-actions/action version to v0.23.0

### DIFF
--- a/.github/workflows/cpactions.yml
+++ b/.github/workflows/cpactions.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build
-      uses: cross-platform-actions/action@v0.21.1
+      uses: cross-platform-actions/action@v0.23.0
       with:
         operating_system: ${{ matrix.platform.os }}
         architecture: ${{ matrix.platform.os-arch }}


### PR DESCRIPTION
Improve performance by using the latest version

[main](https://github.com/libsdl-org/SDL/actions/runs/8022297829)
- FreeBSD 13.2: 11m7s
- NetBSD 9.3: 10m9s

[PR](https://github.com/libsdl-org/SDL/actions/runs/8024470767)
- FreeBSD 13.2: 2m13s
- NetBSD 9.3: 2m2s
