### PR TITLE
ci: update deprecated node.js 16 actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -29,7 +29,7 @@ jobs:
         if: ${{ matrix.platform.name == 'Android.mk' }}
         run: |
           ./build-scripts/androidbuildlibs.sh
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         if: ${{ matrix.platform.name == 'CMake' }}
         with:
           distribution: 'temurin'

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mymindstorm/setup-emsdk@v12
+      - uses: mymindstorm/setup-emsdk@v14
         with:
           version: 3.1.35
       - name: Install ninja

--- a/.github/workflows/loongarch64.yml
+++ b/.github/workflows/loongarch64.yml
@@ -21,7 +21,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends cmake ninja-build pkg-config tar wget
 
-      - uses: actions/cache/restore@v3
+      - uses: actions/cache/restore@v4
         id: restore-cache
         with:
           path: /opt/cross-tools

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -88,7 +88,7 @@ jobs:
 
     - name: Add msbuild to PATH
       if: ${{ matrix.platform.project != '' }}
-      uses: microsoft/setup-msbuild@v1.1.3
+      uses: microsoft/setup-msbuild@v2
     - name: Build msbuild
       if: ${{ matrix.platform.project != '' }}
       run: msbuild ${{ matrix.platform.project }} /m /p:BuildInParallel=true /p:Configuration=Release ${{ matrix.platform.projectflags }}


### PR DESCRIPTION
Fix the following warnings in the related workflows:
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: [...]. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.