### PR TITLE
Limit CPU features through a hint

### DIFF
--- a/VisualC-GDK/SDL/SDL.vcxproj
+++ b/VisualC-GDK/SDL/SDL.vcxproj
@@ -407,6 +407,7 @@
     <ClInclude Include="..\..\src\core\windows\SDL_immdevice.h" />
     <ClInclude Include="..\..\src\core\windows\SDL_windows.h" />
     <ClInclude Include="..\..\src\core\windows\SDL_xinput.h" />
+    <ClInclude Include="..\..\src\cpuinfo\SDL_cpuinfo_c.h" />
     <ClInclude Include="..\..\src\dynapi\SDL_dynapi.h" />
     <ClInclude Include="..\..\src\dynapi\SDL_dynapi_overrides.h" />
     <ClInclude Include="..\..\src\dynapi\SDL_dynapi_procs.h" />

--- a/VisualC-GDK/SDL/SDL.vcxproj.filters
+++ b/VisualC-GDK/SDL/SDL.vcxproj.filters
@@ -299,6 +299,7 @@
     <ClInclude Include="..\..\src\core\windows\SDL_immdevice.h" />
     <ClInclude Include="..\..\src\core\windows\SDL_windows.h" />
     <ClInclude Include="..\..\src\core\windows\SDL_xinput.h" />
+    <ClInclude Include="..\..\src\cpuinfo\SDL_cpuinfo_c.h" />
     <ClInclude Include="..\..\src\dynapi\SDL_dynapi.h" />
     <ClInclude Include="..\..\src\dynapi\SDL_dynapi_overrides.h" />
     <ClInclude Include="..\..\src\dynapi\SDL_dynapi_procs.h" />

--- a/VisualC-WinRT/SDL-UWP.vcxproj
+++ b/VisualC-WinRT/SDL-UWP.vcxproj
@@ -107,6 +107,7 @@
     <ClInclude Include="..\src\core\winrt\SDL_winrtapp_common.h" />
     <ClInclude Include="..\src\core\winrt\SDL_winrtapp_direct3d.h" />
     <ClInclude Include="..\src\core\winrt\SDL_winrtapp_xaml.h" />
+    <ClInclude Include="..\src\cpuinfo\SDL_cpuinfo_c.h" />
     <ClInclude Include="..\src\dynapi\SDL_dynapi.h" />
     <ClInclude Include="..\src\dynapi\SDL_dynapi_overrides.h" />
     <ClInclude Include="..\src\dynapi\SDL_dynapi_procs.h" />

--- a/VisualC-WinRT/SDL-UWP.vcxproj.filters
+++ b/VisualC-WinRT/SDL-UWP.vcxproj.filters
@@ -228,6 +228,9 @@
     <ClInclude Include="..\src\core\winrt\SDL_winrtapp_xaml.h">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\cpuinfo\SDL_cpuinfo_c.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\dynapi\SDL_dynapi.h">
       <Filter>Source Files</Filter>
     </ClInclude>

--- a/VisualC/SDL/SDL.vcxproj
+++ b/VisualC/SDL/SDL.vcxproj
@@ -328,6 +328,7 @@
     <ClInclude Include="..\..\src\core\windows\SDL_immdevice.h" />
     <ClInclude Include="..\..\src\core\windows\SDL_windows.h" />
     <ClInclude Include="..\..\src\core\windows\SDL_xinput.h" />
+    <ClInclude Include="..\..\src\cpuinfo\SDL_cpuinfo_c.h" />
     <ClInclude Include="..\..\src\dynapi\SDL_dynapi.h" />
     <ClInclude Include="..\..\src\dynapi\SDL_dynapi_overrides.h" />
     <ClInclude Include="..\..\src\dynapi\SDL_dynapi_procs.h" />

--- a/VisualC/SDL/SDL.vcxproj.filters
+++ b/VisualC/SDL/SDL.vcxproj.filters
@@ -465,6 +465,9 @@
     <ClInclude Include="..\..\src\core\windows\SDL_directx.h">
       <Filter>core\windows</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\cpuinfo\SDL_cpuinfo_c.h">
+      <Filter>cpuinfo</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\dynapi\SDL_dynapi.h">
       <Filter>dynapi</Filter>
     </ClInclude>

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -372,6 +372,37 @@ extern "C" {
 #define SDL_HINT_CAMERA_DRIVER "SDL_CAMERA_DRIVER"
 
 /**
+ *  A variable that limits what CPU features are available.
+ *
+ *  By default, SDL marks all features the current CPU supports as available.
+ *  This hint allows to limit these to a subset.
+ *
+ *  When the hint is unset, or empty, SDL will enable all detected CPU
+ *  features.
+ *
+ * The variable can be set to a comma separated list containing the following items:
+ *   "all"
+ *   "altivec"
+ *   "sse"
+ *   "sse2"
+ *   "sse3"
+ *   "sse41"
+ *   "sse42"
+ *   "avx"
+ *   "avx2"
+ *   "avx512f"
+ *   "arm-simd"
+ *   "neon"
+ *   "lsx"
+ *   "lasx"
+ *
+ *  The items can be prefixed by '+'/'-' to add/remove features.
+ *
+ *  This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_CPU_FEATURE_MASK "SDL_CPU_FEATURE_MASK"
+
+/**
  * A variable controlling whether DirectInput should be used for controllers
  *
  * The variable can be set to the following values:

--- a/src/SDL.c
+++ b/src/SDL.c
@@ -41,6 +41,7 @@
 #include "SDL_log_c.h"
 #include "SDL_properties_c.h"
 #include "audio/SDL_sysaudio.h"
+#include "cpuinfo/SDL_cpuinfo_c.h"
 #include "video/SDL_video_c.h"
 #include "events/SDL_events_c.h"
 #include "haptic/SDL_haptic_c.h"
@@ -543,6 +544,8 @@ void SDL_Quit(void)
 
     SDL_ClearHints();
     SDL_AssertionsQuit();
+
+    SDL_QuitCPUInfo();
 
     SDL_QuitProperties();
     SDL_QuitLog();

--- a/src/audio/SDL_audiotypecvt.c
+++ b/src/audio/SDL_audiotypecvt.c
@@ -25,26 +25,9 @@
 // TODO: NEON is disabled until https://github.com/libsdl-org/SDL/issues/8352 can be fixed
 #undef SDL_NEON_INTRINSICS
 
-#ifndef SDL_PLATFORM_EMSCRIPTEN
-#if defined(__x86_64__) && defined(SDL_SSE2_INTRINSICS)
-#define NEED_SCALAR_CONVERTER_FALLBACKS 0 // x86_64 guarantees SSE2.
-#elif defined(SDL_PLATFORM_MACOS) && defined(SDL_SSE2_INTRINSICS)
-#define NEED_SCALAR_CONVERTER_FALLBACKS 0 // macOS/Intel guarantees SSE2.
-#elif defined(__ARM_ARCH) && (__ARM_ARCH >= 8) && defined(SDL_NEON_INTRINSICS)
-#define NEED_SCALAR_CONVERTER_FALLBACKS 0 // ARMv8+ promise NEON.
-#elif defined(SDL_PLATFORM_APPLE) && defined(__ARM_ARCH) && (__ARM_ARCH >= 7) && defined(SDL_NEON_INTRINSICS)
-#define NEED_SCALAR_CONVERTER_FALLBACKS 0 // All Apple ARMv7 chips promise NEON support.
-#endif
-#endif /* SDL_PLATFORM_EMSCRIPTEN */
-
-// Set to zero if platform is guaranteed to use a SIMD codepath here.
-#if !defined(NEED_SCALAR_CONVERTER_FALLBACKS)
-#define NEED_SCALAR_CONVERTER_FALLBACKS 1
-#endif
-
 #define DIVBY2147483648 0.0000000004656612873077392578125f // 0x1p-31f
 
-#if NEED_SCALAR_CONVERTER_FALLBACKS
+// start fallback scalar converters
 
 // This code requires that floats are in the IEEE-754 binary32 format
 SDL_COMPILE_TIME_ASSERT(float_bits, sizeof(float) == sizeof(Uint32));
@@ -201,7 +184,7 @@ static void SDL_Convert_F32_to_S32_Scalar(Sint32 *dst, const float *src, int num
 
 #undef SIGNMASK
 
-#endif // NEED_SCALAR_CONVERTER_FALLBACKS
+// end fallback scalar converters
 
 #ifdef SDL_SSE2_INTRINSICS
 static void SDL_TARGETING("sse2") SDL_Convert_S8_to_F32_SSE2(float *dst, const Sint8 *src, int num_samples)
@@ -999,9 +982,7 @@ void SDL_ChooseAudioConverters(void)
     }
 #endif
 
-#if NEED_SCALAR_CONVERTER_FALLBACKS
     SET_CONVERTER_FUNCS(Scalar);
-#endif
 
 #undef SET_CONVERTER_FUNCS
 

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -18,6 +18,7 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
+
 #include "SDL_internal.h"
 
 #if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINRT) || defined(SDL_PLATFORM_GDK)
@@ -855,7 +856,9 @@ int SDL_GetCPUCacheLineSize(void)
     }
 }
 
-static Uint32 SDL_CPUFeatures = 0xFFFFFFFF;
+#define SDL_CPUFEATURES_RESET_VALUE 0xFFFFFFFF
+
+static Uint32 SDL_CPUFeatures = SDL_CPUFEATURES_RESET_VALUE;
 static Uint32 SDL_SIMDAlignment = 0xFFFFFFFF;
 
 static SDL_bool ref_string_equals(const char *ref, const char *test, const char *end_test) {
@@ -865,10 +868,10 @@ static SDL_bool ref_string_equals(const char *ref, const char *test, const char 
 
 static Uint32 SDLCALL SDL_CPUFeatureMaskFromHint(void)
 {
-    Uint32 result_mask = 0xFFFFFFFF;
+    Uint32 result_mask = SDL_CPUFEATURES_RESET_VALUE;
 
     const char *hint = SDL_GetHint(SDL_HINT_CPU_FEATURE_MASK);
-    
+
     if (hint) {
         for (const char *spot = hint, *next; *spot; spot = next) {
             const char *end = SDL_strchr(spot, ',');
@@ -889,7 +892,7 @@ static Uint32 SDLCALL SDL_CPUFeatureMaskFromHint(void)
                 spot += 1;
             }
             if (ref_string_equals("all", spot, end)) {
-                spot_mask = 0xFFFFFFFF;
+                spot_mask = SDL_CPUFEATURES_RESET_VALUE;
             } else if (ref_string_equals("altivec", spot, end)) {
                 spot_mask= CPU_HAS_ALTIVEC;
             } else if (ref_string_equals("mmx", spot, end)) {
@@ -934,7 +937,7 @@ static Uint32 SDLCALL SDL_CPUFeatureMaskFromHint(void)
 
 static Uint32 SDL_GetCPUFeatures(void)
 {
-    if (SDL_CPUFeatures == 0xFFFFFFFF) {
+    if (SDL_CPUFeatures == SDL_CPUFEATURES_RESET_VALUE) {
         CPU_calcCPUIDFeatures();
         SDL_CPUFeatures = 0;
         SDL_SIMDAlignment = sizeof(void *); /* a good safe base value */
@@ -997,6 +1000,10 @@ static Uint32 SDL_GetCPUFeatures(void)
         SDL_CPUFeatures &= SDL_CPUFeatureMaskFromHint();
     }
     return SDL_CPUFeatures;
+}
+
+void SDL_QuitCPUInfo(void) {
+    SDL_CPUFeatures = SDL_CPUFEATURES_RESET_VALUE;
 }
 
 #define CPU_FEATURE_AVAILABLE(f) ((SDL_GetCPUFeatures() & (f)) ? SDL_TRUE : SDL_FALSE)

--- a/src/cpuinfo/SDL_cpuinfo_c.h
+++ b/src/cpuinfo/SDL_cpuinfo_c.h
@@ -1,0 +1,27 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDL_cpuinfo_c_h_
+#define SDL_cpuinfo_c_h_
+
+extern void SDL_QuitCPUInfo(void);
+
+#endif /* SDL_cpuinfo_c_h_ */

--- a/src/video/SDL_blit.c
+++ b/src/video/SDL_blit.c
@@ -130,29 +130,21 @@ static SDL_BlitFunc SDL_ChooseBlitFunc(Uint32 src_format, Uint32 dst_format, int
 
     /* Get the available CPU features */
     if (features == 0x7fffffff) {
-        const char *override = SDL_getenv("SDL_BLIT_CPU_FEATURES");
-
         features = SDL_CPU_ANY;
-
-        /* Allow an override for testing .. */
-        if (override) {
-            (void)SDL_sscanf(override, "%u", &features);
-        } else {
-            if (SDL_HasMMX()) {
-                features |= SDL_CPU_MMX;
-            }
-            if (SDL_HasSSE()) {
-                features |= SDL_CPU_SSE;
-            }
-            if (SDL_HasSSE2()) {
-                features |= SDL_CPU_SSE2;
-            }
-            if (SDL_HasAltiVec()) {
-                if (SDL_UseAltivecPrefetch()) {
-                    features |= SDL_CPU_ALTIVEC_PREFETCH;
-                } else {
-                    features |= SDL_CPU_ALTIVEC_NOPREFETCH;
-                }
+        if (SDL_HasMMX()) {
+            features |= SDL_CPU_MMX;
+        }
+        if (SDL_HasSSE()) {
+            features |= SDL_CPU_SSE;
+        }
+        if (SDL_HasSSE2()) {
+            features |= SDL_CPU_SSE2;
+        }
+        if (SDL_HasAltiVec()) {
+            if (SDL_UseAltivecPrefetch()) {
+                features |= SDL_CPU_ALTIVEC_PREFETCH;
+            } else {
+                features |= SDL_CPU_ALTIVEC_NOPREFETCH;
             }
         }
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -569,40 +569,51 @@ set(TESTS_ENVIRONMENT
     PATH=$<TARGET_FILE_DIR:SDL3::${sdl_name_component}>
 )
 
-foreach(TEST ${SDL_TEST_EXECUTABLES})
-    get_property(noninteractive TARGET ${TEST} PROPERTY SDL_NONINTERACTIVE)
+function(add_sdl_test TEST TARGET)
+    cmake_parse_arguments(ast "INSTALL" "" "" ${ARGN})
+    get_property(noninteractive TARGET ${TARGET} PROPERTY SDL_NONINTERACTIVE)
     if(noninteractive)
-        set(command ${TEST})
-        get_property(noninteractive_arguments TARGET ${TEST} PROPERTY SDL_NONINTERACTIVE_ARGUMENTS)
+        set(command ${TARGET})
+        get_property(noninteractive_arguments TARGET ${TARGET} PROPERTY SDL_NONINTERACTIVE_ARGUMENTS)
         if(noninteractive_arguments)
             list(APPEND command ${noninteractive_arguments})
         endif()
         add_test(
-            NAME ${TEST}
-            COMMAND ${command}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                NAME ${TEST}
+                COMMAND ${command}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         )
         set_tests_properties(${TEST} PROPERTIES ENVIRONMENT "${TESTS_ENVIRONMENT}")
-        get_property(noninteractive_timeout TARGET ${TEST} PROPERTY SDL_NONINTERACTIVE_TIMEOUT)
+        get_property(noninteractive_timeout TARGET ${TARGET} PROPERTY SDL_NONINTERACTIVE_TIMEOUT)
         if(NOT noninteractive_timeout)
             set(noninteractive_timeout 10)
         endif()
         math(EXPR noninteractive_timeout "${noninteractive_timeout}*${SDL_TESTS_TIMEOUT_MULTIPLIER}")
         set_tests_properties(${TEST} PROPERTIES TIMEOUT "${noninteractive_timeout}")
-        if(SDL_INSTALL_TESTS)
-            set(exe ${TEST})
+        if(ast_INSTALL AND SDL_INSTALL_TESTS)
+            set(exe ${TARGET})
             set(installedtestsdir "${CMAKE_INSTALL_FULL_LIBEXECDIR}/installed-tests/SDL3")
             configure_file(template.test.in "${exe}.test" @ONLY)
             install(
-                FILES "${CMAKE_CURRENT_BINARY_DIR}/${exe}.test"
-                DESTINATION ${CMAKE_INSTALL_DATADIR}/installed-tests/SDL3
+                    FILES "${CMAKE_CURRENT_BINARY_DIR}/${exe}.test"
+                    DESTINATION ${CMAKE_INSTALL_DATADIR}/installed-tests/SDL3
             )
         endif()
-        if(TARGET pretest AND NOT "${TEST}" MATCHES "pretest")
+        if(TARGET pretest AND NOT "${TARGET}" MATCHES "pretest")
             set_property(TEST ${TEST} APPEND PROPERTY DEPENDS pretest)
         endif()
     endif()
+endfunction()
+
+foreach(TARGET ${SDL_TEST_EXECUTABLES})
+    add_sdl_test(${TARGET} ${TARGET} INSTALL)
 endforeach()
+
+add_sdl_test(testautomation-no-simd testautomation)
+set_property(TEST testautomation-no-simd APPEND PROPERTY ENVIRONMENT "SDL_CPU_FEATURE_MASK=-all")
+
+add_sdl_test(testplatform-no-simd testplatform)
+set_property(TEST testplatform-no-simd APPEND PROPERTY ENVIRONMENT "SDL_CPU_FEATURE_MASK=-all")
 
 if(SDL_INSTALL_TESTS)
     if(RISCOS)


### PR DESCRIPTION
- Introduces a `SDL_HINT_CPU_FEATURE_MASK` hint with which you can limit supported cpu features.
- Add another run of testautomation and testplatform to the test matrix, but without simd support.
- Always build scalar audio converters, since it is now possible to e.g. not have sse2 on x86_64.
- Reset cpuinfo flags on `SDL_Quit`

Things to consider when reviewing:
- is the hint correctly named?
- for all CPU features, you currently need to run with `SDL_CPU_FEATURES=sse,sse2,sse3,sse41,sse42`. Should we assume when you pass `sse42`, you also want sse1 to sse4.1?
- please review the hint documentation
- ~The hint is only parsed once. Should it be used through `SDL_AddHintCallback` instead? This would be useful for GUI options, or for doing performance testing with one non-forking executable.~ Not needed anymore by resetting cpuinfo in `SDL_Quit`.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/8994

