### PR TITLE
Vulkan: Don't invalidate internal state in InvalidateCachedState

### DIFF
--- a/src/render/vulkan/SDL_render_vulkan.c
+++ b/src/render/vulkan/SDL_render_vulkan.c
@@ -3348,11 +3348,7 @@ static void VULKAN_InvalidateCachedState(SDL_Renderer *renderer)
 {
     VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
     rendererData->currentPipelineState = NULL;
-    rendererData->currentVertexBuffer = 0;
-    rendererData->issueBatch = SDL_FALSE;
     rendererData->cliprectDirty = SDL_TRUE;
-    rendererData->currentDescriptorSetIndex = 0;
-    rendererData->currentConstantBufferOffset = 0;
 }
 
 static int VULKAN_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, void *vertices, size_t vertsize)


### PR DESCRIPTION
The ``VULKAN_InvalidateCachedState()`` function seems to be meant to invalidate any _cached_ state, i.e. global state of the API which may have been modified outside the renderer.

However, at the moment, the Vulkan renderer also resets a number of internal variables which track buffers, offsets, etc, in use. As a result, the renderer can get into an inconsistant state and/or lose data.

For example, if ``VULKAN_InvalidateCachedState()`` is called in between two calls to ``VULKAN_UpdateVertexBuffer()``, the data from the first call will be overwritten by that from the second, as the number of the next vertex buffer to use will be reset to 0. This can result in rendering errors, as the same vertex data is used incorrectly for several calls.

I tested this against [Omnispeak](https://davidgow.net/keen/omnispeak.html), built with the ``RENDERER=sdl2`` option, and running under sdl2-compat. Without the fix, part of the screen is cut off (in a way which changes as the window is resized) due to the dest rects from later ``SDL_RenderCopy()``/``SDL_RenderTexture()`` calls overwriting those from earlier ``SDL_RenderCopy()`` calls.

By no longer resetting this 'internal' state here, those glitches disappear. However, I haven't tested this with any applications which mix the Vulkan renderer with their own Vulkan code (do any such applications exist?), so this may be insufficient in case a full flush of the renderer state  — and possibly a wait on the appropriate fence — could be required. So this may not be a complete fix, but it's definitely an improvement.
