### PR TITLE
Vulkan: Improve memory type selection (Fix #9130)

### DIFF
--- a/src/render/vulkan/SDL_render_vulkan.c
+++ b/src/render/vulkan/SDL_render_vulkan.c
@@ -1171,7 +1171,7 @@ static SDL_bool VULKAN_FindMemoryTypeIndex(VULKAN_RenderData *rendererData, uint
     if (!foundExactMatch) {
         for (memoryTypeIndex = 0; memoryTypeIndex < rendererData->physicalDeviceMemoryProperties.memoryTypeCount; memoryTypeIndex++) {
             if (typeBits & (1 << memoryTypeIndex)) {
-                if (rendererData->physicalDeviceMemoryProperties.memoryTypes[memoryTypeIndex].propertyFlags & flags) {
+                if ((rendererData->physicalDeviceMemoryProperties.memoryTypes[memoryTypeIndex].propertyFlags & flags) == flags) {
                     break;
                 }
             }


### PR DESCRIPTION
There are a couple of problems with the way we select a memory type in ``VULKAN_FindMemoryTypeIndex()``:
- We can return a memory type which doesn't have some properties we need (leading, e.g., to ``vkMapMemory()`` failing because a memory type without ``VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT`` was selected).
- We can fail to find any suitable memory types, because we are overzealous in throwing out types without ``VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT`` (bug #9130).

This PR addresses both of these issues (in separate commits, for clarity), by only returning memory types which are a superset of the required flags (patch 1), and by splitting the flags up into separate "required" and "desired" flags (patch 2).

There's still more we could do to improve this (by more explicitly ranking memory types), but this should be enough to at least get everything working.

CC: @danginsburg 