### PR TITLE
Create `arm-linux-gnueabihf` cmake toolchain

### DIFF
--- a/build-scripts/cmake-toolchain-arm-linux-gnueabihf.cmake
+++ b/build-scripts/cmake-toolchain-arm-linux-gnueabihf.cmake
@@ -1,0 +1,18 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+find_program(CMAKE_C_COMPILER NAMES arm-linux-gnueabihf-gcc)
+find_program(CMAKE_CXX_COMPILER NAMES arm-linux-gnueabihf-g++)
+find_program(CMAKE_RC_COMPILER NAMES arm-linux-gnueabihf-windres)
+
+if(NOT CMAKE_C_COMPILER)
+	message(FATAL_ERROR "Failed to find CMAKE_C_COMPILER.")
+endif()
+
+if(NOT CMAKE_CXX_COMPILER)
+	message(FATAL_ERROR "Failed to find CMAKE_CXX_COMPILER.")
+endif()
+
+if(NOT CMAKE_RC_COMPILER)
+        message(FATAL_ERROR "Failed to find CMAKE_RC_COMPILER.")
+endif()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the ability to cross-compile x86 -> aarch64

This code is untested as I currently am unable to access a host linux x86 machine.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/9142