### PR TITLE
call GLES2_ActivateRenderer before SDL_GL_SwapWindow in GLES2_RenderPresent

### DIFF
--- a/src/render/opengles2/SDL_render_gles2.c
+++ b/src/render/opengles2/SDL_render_gles2.c
@@ -1999,6 +1999,7 @@ static SDL_Surface *GLES2_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rec
 
 static int GLES2_RenderPresent(SDL_Renderer *renderer)
 {
+    GLES2_ActivateRenderer(renderer);
     /* Tell the video driver to swap buffers */
     return SDL_GL_SwapWindow(renderer->window);
 }


### PR DESCRIPTION
Is this not necessary? It seems reasonable based on the other implementations.
It was there originally, but replaced with `GLES2_FlushCommands(renderer);` in 0d3275297d468a563c7b46ef649c1b2d067270ef, which still did this and more.
However in c20a858da53f39307176e61463d96e14e40ce5ff the `GLES2_FlushCommands(renderer);` was removed for unknown reason...