### PR TITLE
Fix testautomation failures (including clip rect) - closes #9145.  Du…

### DIFF
--- a/src/render/vulkan/SDL_render_vulkan.c
+++ b/src/render/vulkan/SDL_render_vulkan.c
@@ -3363,12 +3363,12 @@ static SDL_bool VULKAN_SetDrawState(SDL_Renderer *renderer, const SDL_RenderComm
             constantBuffer = rendererData->constantBuffers[rendererData->currentCommandBufferIndex][rendererData->currentConstantBufferIndex].buffer;
         }
 
+        SDL_memcpy(&rendererData->currentPipelineState->shader_constants, shader_constants, sizeof(*shader_constants));
+
         /* Upload constants to persistently mapped buffer */
         uint8_t *dst = rendererData->constantBuffers[rendererData->currentCommandBufferIndex][rendererData->currentConstantBufferIndex].mappedBufferPtr;
         dst += constantBufferOffset;
         SDL_memcpy(dst, &rendererData->currentPipelineState->shader_constants, sizeof(PixelShaderConstants));
-
-        SDL_memcpy(&rendererData->currentPipelineState->shader_constants, shader_constants, sizeof(*shader_constants));
     }
 
     /* Allocate/update descriptor set with the bindings */


### PR DESCRIPTION
…ring merging for prep'ing the final PR for the Vulkan Renderer, I misordered a memcpy that regressed several of the testautomation tests.  From now on, I will make sure to run testautomation on any future PRs before submitting.

