### PR TITLE
SDLTest_CommonEvent: only set done when it is finished

### DIFF
--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -2429,7 +2429,9 @@ int SDLTest_CommonEventMainCallbacks(SDLTest_CommonState *state, const SDL_Event
 
 void SDLTest_CommonEvent(SDLTest_CommonState *state, SDL_Event *event, int *done)
 {
-    *done = SDLTest_CommonEventMainCallbacks(state, event) ? 1 : 0;
+    if (SDLTest_CommonEventMainCallbacks(state, event)) {
+        *done = 1;
+    }
 }
 
 void SDLTest_CommonQuit(SDLTest_CommonState *state)


### PR DESCRIPTION
A few tests (e.g. testwm) were not exiting when pressing the close window because the event loop keeps processing events. Those later events cause the `done` variable to reset to false.