### PR TITLE
Fix typo in SDL_filesystem.h

### DIFF
--- a/include/SDL3/SDL_filesystem.h
+++ b/include/SDL3/SDL_filesystem.h
@@ -206,8 +206,8 @@ typedef enum
 } SDL_Folder;
 
 /**
- * Finds the most suitable user folder for @p purpose, and returns its path in
- * OS-specific notation.
+ * Finds the most suitable user folder for the specified purpose, and returns
+ * its path in OS-specific notation.
  *
  * Many OSes provide certain standard folders for certain purposes, such as
  * storing pictures, music or videos for a certain user. This function gives


### PR DESCRIPTION
## Description
Changes the description of SDL_GetUserFolder() in SDL_filesystem.h to account for a renamed parameter. I removed the reference to the parameter entirely.

## Existing Issue(s)
Fixes #9115
