### PR TITLE
Set udev class for accelerometer

### DIFF
--- a/src/core/linux/SDL_udev.c
+++ b/src/core/linux/SDL_udev.c
@@ -428,6 +428,11 @@ static int device_class(struct udev_device *dev)
             devclass |= SDL_UDEV_DEVICE_JOYSTICK;
         }
 
+        val = _this->syms.udev_device_get_property_value(dev, "ID_INPUT_ACCELEROMETER");
+        if (val && SDL_strcmp(val, "1") == 0) {
+            devclass |= SDL_UDEV_DEVICE_ACCELEROMETER;
+        }
+
         val = _this->syms.udev_device_get_property_value(dev, "ID_INPUT_MOUSE");
         if (val && SDL_strcmp(val, "1") == 0) {
             devclass |= SDL_UDEV_DEVICE_MOUSE;

--- a/src/joystick/linux/SDL_sysjoystick.c
+++ b/src/joystick/linux/SDL_sysjoystick.c
@@ -360,7 +360,7 @@ static void joystick_udev_callback(SDL_UDEV_deviceevent udev_type, int udev_clas
 
     switch (udev_type) {
     case SDL_UDEV_DEVICEADDED:
-        if (!(udev_class & SDL_UDEV_DEVICE_JOYSTICK)) {
+        if (!(udev_class & (SDL_UDEV_DEVICE_JOYSTICK | SDL_UDEV_DEVICE_ACCELEROMETER))) {
             return;
         }
         if (SDL_classic_joysticks) {


### PR DESCRIPTION
## Description

Set the correct class for accelerometer and do not filter them out in hotplug callback.

## Existing Issue(s)
Since "Removed SDL_HINT_ACCELEROMETER_AS_JOYSTICK" (9ce7fe2), sensors do not show up when hot plugging a gamepad. The hint was setting joystick class to accelerometer by default.
