### PR TITLE
Add missing include

### DIFF
--- a/include/SDL3/SDL_properties.h
+++ b/include/SDL3/SDL_properties.h
@@ -28,6 +28,8 @@
 #ifndef SDL_properties_h_
 #define SDL_properties_h_
 
+#include <SDL3/SDL_stdinc.h>
+
 #include <SDL3/SDL_begin_code.h>
 /* Set up for C function definitions, even when using C++ */
 #ifdef __cplusplus


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adds an include that was missing in `SDL_properties.h`. `SDL_stdinc.h` was included by other headers, so this isn't easily noticeable when building the project.

Noticed this when [ClangSharpPInvokeGenerator](https://github.com/dotnet/ClangSharp) gave me a bunch of errors:

```
Diagnostics for 'S:\code\SDL\include\SDL3/SDL_properties.h':
    S:\code\SDL\include\SDL3/SDL_properties.h:42:9: error: unknown type name 'Uint32'
    S:\code\SDL\include\SDL3/SDL_properties.h:220:93: error: unknown type name 'Sint64'
    S:\code\SDL\include\SDL3/SDL_properties.h:254:94: error: unknown type name 'SDL_bool'
    S:\code\SDL\include\SDL3/SDL_properties.h:269:17: error: unknown type name 'SDL_bool'
    S:\code\SDL\include\SDL3/SDL_properties.h:354:17: error: unknown type name 'Sint64'
    S:\code\SDL\include\SDL3/SDL_properties.h:354:96: error: unknown type name 'Sint64'
    S:\code\SDL\include\SDL3/SDL_properties.h:398:17: error: unknown type name 'SDL_bool'
    S:\code\SDL\include\SDL3/SDL_properties.h:398:99: error: unknown type name 'SDL_bool'
Skipping 'S:\code\SDL\include\SDL3/SDL_properties.h' due to one or more errors listed above.
```