### PR TITLE
video: Save pending window events when a window is hidden by the wind…

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -3456,6 +3456,12 @@ void SDL_OnWindowShown(SDL_Window *window)
 
 void SDL_OnWindowHidden(SDL_Window *window)
 {
+    /* Store the maximized and fullscreen flags for restoration later, in case
+     * this was initiated by the window manager due to the window being unmapped
+     * when minimized.
+     */
+    window->pending_flags = (window->flags & (SDL_WINDOW_FULLSCREEN | SDL_WINDOW_MAXIMIZED));
+
     /* The window is already hidden at this point, so just change the mode back if necessary. */
     SDL_UpdateFullscreenMode(window, SDL_FALSE, SDL_FALSE);
 }


### PR DESCRIPTION
…ow manager

The window manager might hide/unmap the window when it is minimized, in which case the fullscreen and maximized flags must be preserved as pending flags so the window will be restored to the proper state when shown/mapped on restoration.

Fixes #9003 
