### PR TITLE
Use specific types in public headers

### DIFF
--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -574,7 +574,7 @@ typedef struct SDL_PenTipEvent
     Uint32 type;        /**< ::SDL_EVENT_PEN_DOWN or ::SDL_EVENT_PEN_UP */
     Uint32 reserved;
     Uint64 timestamp;   /**< In nanoseconds, populated using SDL_GetTicksNS() */
-    Uint32 windowID;    /**< The window with pen focus, if any */
+    SDL_WindowID windowID;    /**< The window with pen focus, if any */
     SDL_PenID which;    /**< The pen instance id */
     Uint8 tip;          /**< ::SDL_PEN_TIP_INK when using a regular pen tip, or ::SDL_PEN_TIP_ERASER if the pen is being used as an eraser (e.g., flipped to use the eraser tip)  */
     Uint8 state;        /**< ::SDL_PRESSED on ::SDL_EVENT_PEN_DOWN and ::SDL_RELEASED on ::SDL_EVENT_PEN_UP */
@@ -594,7 +594,7 @@ typedef struct SDL_PenMotionEvent
     Uint32 type;        /**< ::SDL_EVENT_PEN_MOTION */
     Uint32 reserved;
     Uint64 timestamp;   /**< In nanoseconds, populated using SDL_GetTicksNS() */
-    Uint32 windowID;    /**< The window with pen focus, if any */
+    SDL_WindowID windowID;    /**< The window with pen focus, if any */
     SDL_PenID which;    /**< The pen instance id */
     Uint8 padding1;
     Uint8 padding2;
@@ -614,7 +614,7 @@ typedef struct SDL_PenButtonEvent
     Uint32 type;        /**< ::SDL_EVENT_PEN_BUTTON_DOWN or ::SDL_EVENT_PEN_BUTTON_UP */
     Uint32 reserved;
     Uint64 timestamp;   /**< In nanoseconds, populated using SDL_GetTicksNS() */
-    Uint32 windowID;    /**< The window with pen focus, if any */
+    SDL_WindowID windowID;    /**< The window with pen focus, if any */
     SDL_PenID which;    /**< The pen instance id */
     Uint8 button;       /**< The pen button index (1 represents the pen tip for compatibility with mouse events) */
     Uint8 state;        /**< ::SDL_PRESSED or ::SDL_RELEASED */

--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -571,18 +571,18 @@ typedef struct SDL_TouchFingerEvent
  */
 typedef struct SDL_PenTipEvent
 {
-    Uint32 type;        /**< ::SDL_EVENT_PEN_DOWN or ::SDL_EVENT_PEN_UP */
+    Uint32 type;            /**< ::SDL_EVENT_PEN_DOWN or ::SDL_EVENT_PEN_UP */
     Uint32 reserved;
-    Uint64 timestamp;   /**< In nanoseconds, populated using SDL_GetTicksNS() */
-    SDL_WindowID windowID;    /**< The window with pen focus, if any */
-    SDL_PenID which;    /**< The pen instance id */
-    Uint8 tip;          /**< ::SDL_PEN_TIP_INK when using a regular pen tip, or ::SDL_PEN_TIP_ERASER if the pen is being used as an eraser (e.g., flipped to use the eraser tip)  */
-    Uint8 state;        /**< ::SDL_PRESSED on ::SDL_EVENT_PEN_DOWN and ::SDL_RELEASED on ::SDL_EVENT_PEN_UP */
-    Uint16 pen_state;   /**< Pen button masks (where SDL_BUTTON(1) is the first button, SDL_BUTTON(2) is the second button etc.),
-			   ::SDL_PEN_DOWN_MASK is set if the pen is touching the surface, and
-			   ::SDL_PEN_ERASER_MASK is set if the pen is (used as) an eraser. */
-    float x;            /**< X coordinate, relative to window */
-    float y;            /**< Y coordinate, relative to window */
+    Uint64 timestamp;       /**< In nanoseconds, populated using SDL_GetTicksNS() */
+    SDL_WindowID windowID;  /**< The window with pen focus, if any */
+    SDL_PenID which;        /**< The pen instance id */
+    Uint8 tip;              /**< ::SDL_PEN_TIP_INK when using a regular pen tip, or ::SDL_PEN_TIP_ERASER if the pen is being used as an eraser (e.g., flipped to use the eraser tip)  */
+    Uint8 state;            /**< ::SDL_PRESSED on ::SDL_EVENT_PEN_DOWN and ::SDL_RELEASED on ::SDL_EVENT_PEN_UP */
+    Uint16 pen_state;       /**< Pen button masks (where SDL_BUTTON(1) is the first button, SDL_BUTTON(2) is the second button etc.),
+			       ::SDL_PEN_DOWN_MASK is set if the pen is touching the surface, and
+			       ::SDL_PEN_ERASER_MASK is set if the pen is (used as) an eraser. */
+    float x;                /**< X coordinate, relative to window */
+    float y;                /**< Y coordinate, relative to window */
     float axes[SDL_PEN_NUM_AXES];   /**< Pen axes such as pressure and tilt (ordered as per ::SDL_PenAxis) */
 } SDL_PenTipEvent;
 
@@ -591,18 +591,18 @@ typedef struct SDL_PenTipEvent
  */
 typedef struct SDL_PenMotionEvent
 {
-    Uint32 type;        /**< ::SDL_EVENT_PEN_MOTION */
+    Uint32 type;            /**< ::SDL_EVENT_PEN_MOTION */
     Uint32 reserved;
-    Uint64 timestamp;   /**< In nanoseconds, populated using SDL_GetTicksNS() */
-    SDL_WindowID windowID;    /**< The window with pen focus, if any */
-    SDL_PenID which;    /**< The pen instance id */
+    Uint64 timestamp;       /**< In nanoseconds, populated using SDL_GetTicksNS() */
+    SDL_WindowID windowID;  /**< The window with pen focus, if any */
+    SDL_PenID which;        /**< The pen instance id */
     Uint8 padding1;
     Uint8 padding2;
-    Uint16 pen_state;   /**< Pen button masks (where SDL_BUTTON(1) is the first button, SDL_BUTTON(2) is the second button etc.),
-			   ::SDL_PEN_DOWN_MASK is set if the pen is touching the surface, and
-			   ::SDL_PEN_ERASER_MASK is set if the pen is (used as) an eraser. */
-    float x;            /**< X coordinate, relative to window */
-    float y;            /**< Y coordinate, relative to window */
+    Uint16 pen_state;       /**< Pen button masks (where SDL_BUTTON(1) is the first button, SDL_BUTTON(2) is the second button etc.),
+			       ::SDL_PEN_DOWN_MASK is set if the pen is touching the surface, and
+			       ::SDL_PEN_ERASER_MASK is set if the pen is (used as) an eraser. */
+    float x;                /**< X coordinate, relative to window */
+    float y;                /**< Y coordinate, relative to window */
     float axes[SDL_PEN_NUM_AXES];   /**< Pen axes such as pressure and tilt (ordered as per ::SDL_PenAxis) */
 } SDL_PenMotionEvent;
 
@@ -611,18 +611,18 @@ typedef struct SDL_PenMotionEvent
  */
 typedef struct SDL_PenButtonEvent
 {
-    Uint32 type;        /**< ::SDL_EVENT_PEN_BUTTON_DOWN or ::SDL_EVENT_PEN_BUTTON_UP */
+    Uint32 type;            /**< ::SDL_EVENT_PEN_BUTTON_DOWN or ::SDL_EVENT_PEN_BUTTON_UP */
     Uint32 reserved;
-    Uint64 timestamp;   /**< In nanoseconds, populated using SDL_GetTicksNS() */
-    SDL_WindowID windowID;    /**< The window with pen focus, if any */
-    SDL_PenID which;    /**< The pen instance id */
-    Uint8 button;       /**< The pen button index (1 represents the pen tip for compatibility with mouse events) */
-    Uint8 state;        /**< ::SDL_PRESSED or ::SDL_RELEASED */
-    Uint16 pen_state;   /**< Pen button masks (where SDL_BUTTON(1) is the first button, SDL_BUTTON(2) is the second button etc.),
-			   ::SDL_PEN_DOWN_MASK is set if the pen is touching the surface, and
-			   ::SDL_PEN_ERASER_MASK is set if the pen is (used as) an eraser. */
-    float x;            /**< X coordinate, relative to window */
-    float y;            /**< Y coordinate, relative to window */
+    Uint64 timestamp;       /**< In nanoseconds, populated using SDL_GetTicksNS() */
+    SDL_WindowID windowID;  /**< The window with pen focus, if any */
+    SDL_PenID which;        /**< The pen instance id */
+    Uint8 button;           /**< The pen button index (1 represents the pen tip for compatibility with mouse events) */
+    Uint8 state;            /**< ::SDL_PRESSED or ::SDL_RELEASED */
+    Uint16 pen_state;       /**< Pen button masks (where SDL_BUTTON(1) is the first button, SDL_BUTTON(2) is the second button etc.),
+			       ::SDL_PEN_DOWN_MASK is set if the pen is touching the surface, and
+			       ::SDL_PEN_ERASER_MASK is set if the pen is (used as) an eraser. */
+    float x;                /**< X coordinate, relative to window */
+    float y;                /**< Y coordinate, relative to window */
     float axes[SDL_PEN_NUM_AXES]; /**< Pen axes such as pressure and tilt (ordered as per ::SDL_PenAxis) */
 } SDL_PenButtonEvent;
 

--- a/include/SDL3/SDL_pen.h
+++ b/include/SDL3/SDL_pen.h
@@ -56,9 +56,9 @@ extern "C" {
 
 typedef Uint32 SDL_PenID; /**< SDL_PenIDs identify pens uniquely within a session */
 
-#define SDL_PEN_INVALID ((Uint32)0) /**< Reserved invalid ::SDL_PenID is valid */
+#define SDL_PEN_INVALID ((SDL_PenID)0) /**< Reserved invalid ::SDL_PenID is valid */
 
-#define SDL_PEN_MOUSEID ((Uint32)-2) /**< Device ID for mouse events triggered by pen events */
+#define SDL_PEN_MOUSEID ((SDL_PenID)-2) /**< Device ID for mouse events triggered by pen events */
 
 #define SDL_PEN_INFO_UNKNOWN (-1) /**< Marks unknown information when querying the pen */
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Uses specific typedef'd types instead of generic integral types where applicable.

PR of salvageable parts of https://github.com/libsdl-org/SDL/pull/9191. As enums don't seem to be adequate for strong typing in C.
