### PR TITLE
Use specific types in SDL_touch.h

### DIFF
--- a/include/SDL3/SDL_touch.h
+++ b/include/SDL3/SDL_touch.h
@@ -58,10 +58,10 @@ typedef struct SDL_Finger
 } SDL_Finger;
 
 /* Used as the device ID for mouse events simulated with touch input */
-#define SDL_TOUCH_MOUSEID ((Uint32)-1)
+#define SDL_TOUCH_MOUSEID ((SDL_MouseID)-1)
 
 /* Used as the SDL_TouchID for touch events simulated with mouse input */
-#define SDL_MOUSE_TOUCHID ((Uint64)-1)
+#define SDL_MOUSE_TOUCHID ((SDL_TouchID)-1)
 
 
 /**


### PR DESCRIPTION
## Description
Missed when picking 7ff34249c753122a2ba67e78aa6e9f9b56aa4a65 from https://github.com/libsdl-org/SDL/pull/9191.
