### PR TITLE
Change `SDL_Keycode` type to an enum

### DIFF
--- a/include/SDL3/SDL_keycode.h
+++ b/include/SDL3/SDL_keycode.h
@@ -31,6 +31,9 @@
 #include <SDL3/SDL_stdinc.h>
 #include <SDL3/SDL_scancode.h>
 
+#define SDLK_SCANCODE_MASK (1<<30)
+#define SDL_SCANCODE_TO_KEYCODE(X)  (X | SDLK_SCANCODE_MASK)
+
 /**
  *  The SDL virtual key representation.
  *
@@ -42,10 +45,6 @@
  *  A special exception is the number keys at the top of the keyboard which
  *  map to SDLK_0...SDLK_9 on AZERTY layouts.
  */
-typedef Sint32 SDL_Keycode;
-
-#define SDLK_SCANCODE_MASK (1<<30)
-#define SDL_SCANCODE_TO_KEYCODE(X)  (X | SDLK_SCANCODE_MASK)
 
 typedef enum
 {
@@ -324,7 +323,7 @@ typedef enum
     SDLK_SOFTRIGHT = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_SOFTRIGHT),
     SDLK_CALL = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_CALL),
     SDLK_ENDCALL = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_ENDCALL)
-} SDL_KeyCode;
+} SDL_Keycode;
 
 /**
  * Enumeration of valid key mods (possibly OR'd together).

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1671,7 +1671,7 @@ static void SDLTest_PrintEvent(const SDL_Event *event)
             SDL_strlcpy(modstr, "NONE", sizeof (modstr));
         }
 
-        SDL_Log("SDL EVENT: Keyboard: key %s in window %" SDL_PRIu32 ": scancode 0x%08X = %s, keycode 0x%08" SDL_PRIX32 " = %s, mods = %s",
+        SDL_Log("SDL EVENT: Keyboard: key %s in window %" SDL_PRIu32 ": scancode 0x%08X = %s, keycode 0x%08X = %s, mods = %s",
                 (event->type == SDL_EVENT_KEY_DOWN) ? "pressed" : "released",
                 event->key.windowID,
                 event->key.keysym.scancode,

--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -516,6 +516,8 @@ static SDL_Keycode Emscripten_MapKeyCode(const EmscriptenKeyboardEvent *keyEvent
                 case SDLK_LGUI:
                     keycode = SDLK_RGUI;
                     break;
+                default:
+                    break;
                 }
             } else if (keyEvent->location == DOM_KEY_LOCATION_NUMPAD) {
                 switch (keycode) {
@@ -563,6 +565,8 @@ static SDL_Keycode Emscripten_MapKeyCode(const EmscriptenKeyboardEvent *keyEvent
                     break;
                 case SDLK_DELETE:
                     keycode = SDLK_KP_PERIOD;
+                    break;
+                default:
                     break;
                 }
             }

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -1381,7 +1381,7 @@ static void Wayland_ReconcileModifiers(struct SDL_WaylandInput *input)
 
 static void Wayland_HandleModifierKeys(struct SDL_WaylandInput *input, SDL_Scancode scancode, SDL_bool pressed)
 {
-    const SDL_KeyCode keycode = SDL_GetKeyFromScancode(scancode);
+    const SDL_Keycode keycode = SDL_GetKeyFromScancode(scancode);
     SDL_Keymod mod;
 
     switch (keycode) {
@@ -1458,7 +1458,7 @@ static void keyboard_handle_enter(void *data, struct wl_keyboard *keyboard,
 
     wl_array_for_each (key, keys) {
         const SDL_Scancode scancode = Wayland_get_scancode_from_key(input, *key + 8);
-        const SDL_KeyCode keycode = SDL_GetKeyFromScancode(scancode);
+        const SDL_Keycode keycode = SDL_GetKeyFromScancode(scancode);
 
         switch (keycode) {
         case SDLK_LSHIFT:

--- a/test/testautomation_keyboard.c
+++ b/test/testautomation_keyboard.c
@@ -61,37 +61,37 @@ static int keyboard_getKeyFromName(void *arg)
     /* Case where Key is known, 1 character input */
     result = SDL_GetKeyFromName("A");
     SDLTest_AssertPass("Call to SDL_GetKeyFromName(known/single)");
-    SDLTest_AssertCheck(result == SDLK_a, "Verify result from call, expected: %i, got: %" SDL_PRIs32, SDLK_a, result);
+    SDLTest_AssertCheck(result == SDLK_a, "Verify result from call, expected: %i, got: %i", SDLK_a, result);
 
     /* Case where Key is known, 2 character input */
     result = SDL_GetKeyFromName("F1");
     SDLTest_AssertPass("Call to SDL_GetKeyFromName(known/double)");
-    SDLTest_AssertCheck(result == SDLK_F1, "Verify result from call, expected: %i, got: %" SDL_PRIs32, SDLK_F1, result);
+    SDLTest_AssertCheck(result == SDLK_F1, "Verify result from call, expected: %i, got: %i", SDLK_F1, result);
 
     /* Case where Key is known, 3 character input */
     result = SDL_GetKeyFromName("End");
     SDLTest_AssertPass("Call to SDL_GetKeyFromName(known/triple)");
-    SDLTest_AssertCheck(result == SDLK_END, "Verify result from call, expected: %i, got: %" SDL_PRIs32, SDLK_END, result);
+    SDLTest_AssertCheck(result == SDLK_END, "Verify result from call, expected: %i, got: %i", SDLK_END, result);
 
     /* Case where Key is known, 4 character input */
     result = SDL_GetKeyFromName("Find");
     SDLTest_AssertPass("Call to SDL_GetKeyFromName(known/quad)");
-    SDLTest_AssertCheck(result == SDLK_FIND, "Verify result from call, expected: %i, got: %" SDL_PRIs32, SDLK_FIND, result);
+    SDLTest_AssertCheck(result == SDLK_FIND, "Verify result from call, expected: %i, got: %i", SDLK_FIND, result);
 
     /* Case where Key is known, multiple character input */
     result = SDL_GetKeyFromName("AudioStop");
     SDLTest_AssertPass("Call to SDL_GetKeyFromName(known/multi)");
-    SDLTest_AssertCheck(result == SDLK_AUDIOSTOP, "Verify result from call, expected: %i, got: %" SDL_PRIs32, SDLK_AUDIOSTOP, result);
+    SDLTest_AssertCheck(result == SDLK_AUDIOSTOP, "Verify result from call, expected: %i, got: %i", SDLK_AUDIOSTOP, result);
 
     /* Case where Key is unknown */
     result = SDL_GetKeyFromName("NotThere");
     SDLTest_AssertPass("Call to SDL_GetKeyFromName(unknown)");
-    SDLTest_AssertCheck(result == SDLK_UNKNOWN, "Verify result from call is UNKNOWN, expected: %i, got: %" SDL_PRIs32, SDLK_UNKNOWN, result);
+    SDLTest_AssertCheck(result == SDLK_UNKNOWN, "Verify result from call is UNKNOWN, expected: %i, got: %i", SDLK_UNKNOWN, result);
 
     /* Case where input is NULL/invalid */
     result = SDL_GetKeyFromName(NULL);
     SDLTest_AssertPass("Call to SDL_GetKeyFromName(NULL)");
-    SDLTest_AssertCheck(result == SDLK_UNKNOWN, "Verify result from call is UNKNOWN, expected: %i, got: %" SDL_PRIs32, SDLK_UNKNOWN, result);
+    SDLTest_AssertCheck(result == SDLK_UNKNOWN, "Verify result from call is UNKNOWN, expected: %i, got: %i", SDLK_UNKNOWN, result);
 
     return TEST_COMPLETED;
 }
@@ -126,12 +126,12 @@ static int keyboard_getKeyFromScancode(void *arg)
     /* Case where input is valid */
     result = SDL_GetKeyFromScancode(SDL_SCANCODE_A);
     SDLTest_AssertPass("Call to SDL_GetKeyFromScancode(valid)");
-    SDLTest_AssertCheck(result == SDLK_a, "Verify result from call, expected: %i, got: %" SDL_PRIs32, SDLK_a, result);
+    SDLTest_AssertCheck(result == SDLK_a, "Verify result from call, expected: %i, got: %i", SDLK_a, result);
 
     /* Case where input is zero */
     result = SDL_GetKeyFromScancode(0);
     SDLTest_AssertPass("Call to SDL_GetKeyFromScancode(0)");
-    SDLTest_AssertCheck(result == SDLK_UNKNOWN, "Verify result from call is UNKNOWN, expected: %i, got: %" SDL_PRIs32, SDLK_UNKNOWN, result);
+    SDLTest_AssertCheck(result == SDLK_UNKNOWN, "Verify result from call is UNKNOWN, expected: %i, got: %i", SDLK_UNKNOWN, result);
 
     /* Clear error message */
     SDL_ClearError();
@@ -140,13 +140,13 @@ static int keyboard_getKeyFromScancode(void *arg)
     /* Case where input is invalid (too small) */
     result = SDL_GetKeyFromScancode(-999);
     SDLTest_AssertPass("Call to SDL_GetKeyFromScancode(-999)");
-    SDLTest_AssertCheck(result == SDLK_UNKNOWN, "Verify result from call is UNKNOWN, expected: %i, got: %" SDL_PRIs32, SDLK_UNKNOWN, result);
+    SDLTest_AssertCheck(result == SDLK_UNKNOWN, "Verify result from call is UNKNOWN, expected: %i, got: %i", SDLK_UNKNOWN, result);
     checkInvalidScancodeError();
 
     /* Case where input is invalid (too big) */
     result = SDL_GetKeyFromScancode(999);
     SDLTest_AssertPass("Call to SDL_GetKeyFromScancode(999)");
-    SDLTest_AssertCheck(result == SDLK_UNKNOWN, "Verify result from call is UNKNOWN, expected: %i, got: %" SDL_PRIs32, SDLK_UNKNOWN, result);
+    SDLTest_AssertCheck(result == SDLK_UNKNOWN, "Verify result from call is UNKNOWN, expected: %i, got: %i", SDLK_UNKNOWN, result);
     checkInvalidScancodeError();
 
     return TEST_COMPLETED;
@@ -247,7 +247,7 @@ static int keyboard_getKeyNameNegative(void *arg)
     /* Unknown keycode */
     keycode = SDLK_UNKNOWN;
     result = SDL_GetKeyName(keycode);
-    SDLTest_AssertPass("Call to SDL_GetKeyName(%" SDL_PRIs32 "/unknown)", keycode);
+    SDLTest_AssertPass("Call to SDL_GetKeyName(%i/unknown)", keycode);
     SDLTest_AssertCheck(result != NULL, "Verify result from call is not NULL");
     SDLTest_AssertCheck(SDL_strcmp(result, expected) == 0, "Verify result from call is valid, expected: '%s', got: '%s'", expected, result);
 
@@ -258,7 +258,7 @@ static int keyboard_getKeyNameNegative(void *arg)
     /* Negative keycode */
     keycode = (SDL_Keycode)SDLTest_RandomIntegerInRange(-255, -1);
     result = SDL_GetKeyName(keycode);
-    SDLTest_AssertPass("Call to SDL_GetKeyName(%" SDL_PRIs32 "/negative)", keycode);
+    SDLTest_AssertPass("Call to SDL_GetKeyName(%i/negative)", keycode);
     SDLTest_AssertCheck(result != NULL, "Verify result from call is not NULL");
     SDLTest_AssertCheck(SDL_strcmp(result, expected) == 0, "Verify result from call is valid, expected: '%s', got: '%s'", expected, result);
     checkInvalidScancodeError();

--- a/test/testime.c
+++ b/test/testime.c
@@ -742,6 +742,8 @@ int main(int argc, char *argv[])
                         Redraw();
                     }
                     break;
+                default:
+                    break;
                 }
 
                 if (done) {

--- a/test/testintersections.c
+++ b/test/testintersections.c
@@ -251,6 +251,8 @@ static void loop(void *arg)
                         (float)(rand() % 480));
                 }
                 break;
+            default:
+                break;
             }
             break;
         default:

--- a/test/testmouse.c
+++ b/test/testmouse.c
@@ -213,6 +213,8 @@ static void loop(void *arg)
                     active->isRect = isRect;
                 }
                 break;
+            default:
+                break;
             }
             break;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Previously, the `SDL_Keycode` was a `Sint32` typedef, while the actual enum was named `SDL_KeyCode` (notice the capital C).

This PR:
- removes the typedef and changes the enum name
- adds `default` branches to switch statements involving `SDL_Keycode`s to silence compiler errors about not handling all enum values
- changes format specifiers involving `SDL_Keycode`s to `%i` (to match surrounding code style and prevent errors)
   - I recommend to use `%d` in new code, as that is a more known specifier, and [there are no differences](https://en.cppreference.com/w/c/io/fprintf)

Changes in this PR have been picked from https://github.com/libsdl-org/SDL/pull/9191.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
- https://github.com/libsdl-org/SDL/issues/9186