### PR TITLE
build: Generate Vulkan headers automatically as part of the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2762,6 +2762,61 @@ if(SDL_VIDEO)
   endif()
 endif()
 
+find_program(GLSLANG NAMES glslang glslangValidator)
+
+if(SDL_VULKAN AND GLSLANG)
+  set(SDL3_Vulkan_headers)
+
+  function(glslang2vkpixelheader dir name)
+    set(input "${CMAKE_CURRENT_SOURCE_DIR}/${dir}/VULKAN_PixelShader_${name}.hlsl")
+    set(intermediate "${CMAKE_CURRENT_BINARY_DIR}/${dir}/VULKAN_PixelShader_${name}.h")
+    set(output "${CMAKE_CURRENT_SOURCE_DIR}/${dir}/VULKAN_PixelShader_${name}.h")
+    add_custom_command(OUTPUT "${intermediate}"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${dir}"
+      COMMAND "${GLSLANG}"
+        -D --sep main -e main -S frag --target-env vulkan1.0
+        --auto-sampled-textures --vn "VULKAN_PixelShader_${name}"
+        -o "${intermediate}"
+        "VULKAN_PixelShader_${name}.hlsl"
+      COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${intermediate}" "${output}"
+      DEPENDS "${input}" "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt"
+    )
+    set(SDL3_Vulkan_headers "${SDL3_Vulkan_headers};${intermediate}" PARENT_SCOPE)
+  endfunction()
+
+  function(glslang2vkvertexheader dir)
+    set(input "${CMAKE_CURRENT_SOURCE_DIR}/${dir}/VULKAN_VertexShader.hlsl")
+    set(intermediate "${CMAKE_CURRENT_BINARY_DIR}/${dir}/VULKAN_VertexShader.h")
+    set(output "${CMAKE_CURRENT_SOURCE_DIR}/${dir}/VULKAN_VertexShader.h")
+    add_custom_command(OUTPUT "${intermediate}"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${dir}"
+      COMMAND "${GLSLANG}"
+        -D --sep mainColor -e main -S frag --iy --target-env vulkan1.0
+        --vn VULKAN_VertexShader
+        -o "${intermediate}"
+        "VULKAN_VertexShader.hlsl"
+      COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${intermediate}" "${output}"
+      DEPENDS "${input}" "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt"
+    )
+    set(SDL3_Vulkan_headers "${SDL3_Vulkan_headers};${intermediate}" PARENT_SCOPE)
+  endfunction()
+
+  glslang2vkpixelheader(src/render/vulkan Colors)
+  glslang2vkpixelheader(src/render/vulkan Textures)
+  glslang2vkpixelheader(src/render/vulkan Advanced)
+  glslang2vkvertexheader(src/render/vulkan)
+
+  add_custom_target(SDL3-Vulkan-headers DEPENDS ${SDL3_Vulkan_headers})
+
+  if(TARGET SDL3-shared)
+    add_dependencies(SDL3-shared SDL3-Vulkan-headers)
+  endif()
+
+  if(TARGET SDL3-static)
+    add_dependencies(SDL3-static SDL3-Vulkan-headers)
+  endif()
+endif()
+
 # Dummies
 # configure.ac does it differently:
 # if not have X

--- a/src/render/vulkan/compile_shaders.bat
+++ b/src/render/vulkan/compile_shaders.bat
@@ -1,5 +1,0 @@
-glslangValidator -D --sep main -e main -S frag --target-env vulkan1.0 --auto-sampled-textures --vn VULKAN_PixelShader_Colors -o VULKAN_PixelShader_Colors.h VULKAN_PixelShader_Colors.hlsl 
-glslangValidator -D --sep main -e main -S frag --target-env vulkan1.0 --auto-sampled-textures --vn VULKAN_PixelShader_Textures -o VULKAN_PixelShader_Textures.h VULKAN_PixelShader_Textures.hlsl 
-glslangValidator -D --sep main -e main -S frag --target-env vulkan1.0 --auto-sampled-textures --vn VULKAN_PixelShader_Advanced -o VULKAN_PixelShader_Advanced.h VULKAN_PixelShader_Advanced.hlsl 
-
-glslangValidator -D --sep mainColor -e main -S vert --iy --target-env vulkan1.0 --vn VULKAN_VertexShader -o VULKAN_VertexShader.h VULKAN_VertexShader.hlsl 


### PR DESCRIPTION
If the glslang tool is available, we can regenerate the Vulkan headers with it during the build, rather than having an out-of-band step to produce Vulkan headers on a maintainer's Windows machine and having everyone else rely on the derived files having been committed to git.

On platforms where compiling everything from its preferred from for modification is desired, such as many Linux distributions, the generated headers can be deleted from the source directory to force them to be regenerated.

The derived files are still copied into the source directory to be committed, in case there are platforms where the Vulkan driver is desirable but CMake is not used. This could be removed if no such platform exists.

glslangValidator(1) is an older name for glslang(1), so look for both names.

---

glslang-tools version 14.0.0 on Debian produces a slightly different `VULKAN_VertexShader.h`. Is this expected? The current headers seem to have been generated with 13.1.1, and the pixel shaders come out identical except for the comment that indicates the version of glslang that was used to generate them.