### PR TITLE
Fix TOCTOU race condition

### DIFF
--- a/src/audio/SDL_audiodev.c
+++ b/src/audio/SDL_audiodev.c
@@ -48,9 +48,9 @@
 static void test_device(const SDL_bool iscapture, const char *fname, int flags, SDL_bool (*test)(int fd))
 {
     struct stat sb;
-    if ((stat(fname, &sb) == 0) && (S_ISCHR(sb.st_mode))) {
-        const int audio_fd = open(fname, flags | O_CLOEXEC, 0);
-        if (audio_fd >= 0) {
+    const int audio_fd = open(fname, flags | O_CLOEXEC, 0);
+    if (audio_fd >= 0) {
+        if ((fstat(audio_fd, &sb) == 0) && (S_ISCHR(sb.st_mode))) {
             const SDL_bool okay = test(audio_fd);
             close(audio_fd);
             if (okay) {
@@ -65,6 +65,8 @@ static void test_device(const SDL_bool iscapture, const char *fname, int flags, 
                  */
                 SDL_AddAudioDevice(iscapture, fname, NULL, (void *)(uintptr_t)dummyhandle);
             }
+        } else {
+            close(audio_fd);
         }
     }
 }

--- a/src/haptic/linux/SDL_syshaptic.c
+++ b/src/haptic/linux/SDL_syshaptic.c
@@ -240,22 +240,24 @@ static int MaybeAddDevice(const char *path)
         return -1;
     }
 
-    /* check to see if file exists */
-    if (stat(path, &sb) != 0) {
+    /* try to open */
+    fd = open(path, O_RDWR | O_CLOEXEC, 0);
+    if (fd < 0) {
+        return -1;
+    }
+
+    /* get file status */
+    if (fstat(fd, &sb) != 0) {
+        close(fd);
         return -1;
     }
 
     /* check for duplicates */
     for (item = SDL_hapticlist; item; item = item->next) {
         if (item->dev_num == sb.st_rdev) {
+            close(fd);
             return -1; /* duplicate. */
         }
-    }
-
-    /* try to open */
-    fd = open(path, O_RDWR | O_CLOEXEC, 0);
-    if (fd < 0) {
-        return -1;
     }
 
 #ifdef DEBUG_INPUT_EVENTS

--- a/src/joystick/linux/SDL_sysjoystick.c
+++ b/src/joystick/linux/SDL_sysjoystick.c
@@ -417,7 +417,13 @@ static void MaybeAddDevice(const char *path)
         return;
     }
 
-    if (stat(path, &sb) == -1) {
+    fd = open(path, O_RDONLY | O_CLOEXEC, 0);
+    if (fd < 0) {
+        return;
+    }
+
+    if (fstat(fd, &sb) == -1) {
+        close(fd);
         return;
     }
 
@@ -433,11 +439,6 @@ static void MaybeAddDevice(const char *path)
         if (sb.st_rdev == item_sensor->devnum) {
             goto done; /* already have this one */
         }
-    }
-
-    fd = open(path, O_RDONLY | O_CLOEXEC, 0);
-    if (fd < 0) {
-        goto done;
     }
 
 #ifdef DEBUG_INPUT_EVENTS
@@ -507,9 +508,7 @@ static void MaybeAddDevice(const char *path)
     }
 
 done:
-    if (fd >= 0) {
-        close(fd);
-    }
+    close(fd);
     SDL_UnlockJoysticks();
 }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
Separately checking the state of a file before operating on it may allow an attacker to modify the file between the two operations. (CWE-367) Fix by using fstat() instead of stat().

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
