### PR TITLE
Fix empty prefix in Xcode sdl3-config.cmake when SDL3.framework is found with find_package

### DIFF
--- a/Xcode/SDL/pkg-support/resources/CMake/sdl3-config.cmake
+++ b/Xcode/SDL/pkg-support/resources/CMake/sdl3-config.cmake
@@ -33,8 +33,8 @@ set(SDL3_FOUND TRUE)
 
 # Compute the installation prefix relative to this file.
 get_filename_component(_sdl3_framework_path "${CMAKE_CURRENT_LIST_FILE}" PATH)      # /SDL3.framework/Resources/CMake/
-get_filename_component(_sdl3_framework_path "${_IMPORT_PREFIX}" PATH)               # /SDL3.framework/Resources/
-get_filename_component(_sdl3_framework_path "${_IMPORT_PREFIX}" PATH)               # /SDL3.framework/
+get_filename_component(_sdl3_framework_path "${_sdl3_framework_path}" PATH)         # /SDL3.framework/Resources/
+get_filename_component(_sdl3_framework_path "${_sdl3_framework_path}" PATH)         # /SDL3.framework/
 get_filename_component(_sdl3_framework_parent_path "${_sdl3_framework_path}" PATH)  # /
 
 set_and_check(_sdl3_include_dirs "${_sdl3_framework_path}/Headers")


### PR DESCRIPTION
## Description
The Xcode framework CMake config file uses `get_filename_component` in PATH mode three times in a row to get the parent framework path, however the last two invocations use `_IMPORT_PREFIX` as the filename which on my system is empty, causing the `set_and_check` macro to immediately error with: 
```
CMake Error at /Library/Frameworks/SDL3.framework/Resources/CMake/sdl3-config.cmake:17 (message):
  File or directory /Headers referenced by variable _sdl3_include_dirs does
  not exist !
Call Stack (most recent call first):
  /Library/Frameworks/SDL3.framework/Resources/CMake/sdl3-config.cmake:40 (set_and_check)
  CMakeLists.txt:4 (find_package)
```

Even if `_IMPORT_PREFIX` held the correct value I'm not sure how this script would've worked properly and this seems like a typo, this PR replaces it with `_sdl3_framework_path` which seems more correct & successfully allows me to find and link the framework properly.