### PR TITLE
joystick: Remove redundant CHECK_JOYSTICK_MAGIC in SDL_GetJoystickName

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -1547,8 +1547,6 @@ const char *SDL_GetJoystickName(SDL_Joystick *joystick)
         if (info) {
             retval = info->name;
         } else {
-            CHECK_JOYSTICK_MAGIC(joystick, NULL);
-
             retval = joystick->name;
         }
     }


### PR DESCRIPTION
Since commit 0dfdf1f3 "Fixed crash if joystick functions are passed a NULL joystick", we've already done this check by the time we get to this point.