### PR TITLE
[SDL2] Fixed crash if joystick functions are passed a NULL joystick

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -1313,13 +1313,15 @@ const char *SDL_JoystickName(SDL_Joystick *joystick)
     const SDL_SteamVirtualGamepadInfo *info;
 
     SDL_LockJoysticks();
-    info = SDL_GetJoystickInstanceVirtualGamepadInfo(joystick->instance_id);
-    if (info) {
-        retval = info->name;
-    } else {
+    {
         CHECK_JOYSTICK_MAGIC(joystick, NULL);
 
-        retval = joystick->name;
+        info = SDL_GetJoystickInstanceVirtualGamepadInfo(joystick->instance_id);
+        if (info) {
+            retval = info->name;
+        } else {
+            retval = joystick->name;
+        }
     }
     SDL_UnlockJoysticks();
 
@@ -3102,13 +3104,17 @@ Uint16 SDL_JoystickGetVendor(SDL_Joystick *joystick)
     const SDL_SteamVirtualGamepadInfo *info;
 
     SDL_LockJoysticks();
-    info = SDL_GetJoystickInstanceVirtualGamepadInfo(joystick->instance_id);
-    if (info) {
-        vendor = info->vendor_id;
-    } else {
-        SDL_JoystickGUID guid = SDL_JoystickGetGUID(joystick);
+    {
+        CHECK_JOYSTICK_MAGIC(joystick, 0);
 
-        SDL_GetJoystickGUIDInfo(guid, &vendor, NULL, NULL, NULL);
+        info = SDL_GetJoystickInstanceVirtualGamepadInfo(joystick->instance_id);
+        if (info) {
+            vendor = info->vendor_id;
+        } else {
+            SDL_JoystickGUID guid = SDL_JoystickGetGUID(joystick);
+
+            SDL_GetJoystickGUIDInfo(guid, &vendor, NULL, NULL, NULL);
+        }
     }
     SDL_UnlockJoysticks();
 
@@ -3121,13 +3127,17 @@ Uint16 SDL_JoystickGetProduct(SDL_Joystick *joystick)
     const SDL_SteamVirtualGamepadInfo *info;
 
     SDL_LockJoysticks();
-    info = SDL_GetJoystickInstanceVirtualGamepadInfo(joystick->instance_id);
-    if (info) {
-        product = info->product_id;
-    } else {
-        SDL_JoystickGUID guid = SDL_JoystickGetGUID(joystick);
+    {
+        CHECK_JOYSTICK_MAGIC(joystick, 0);
 
-        SDL_GetJoystickGUIDInfo(guid, NULL, &product, NULL, NULL);
+        info = SDL_GetJoystickInstanceVirtualGamepadInfo(joystick->instance_id);
+        if (info) {
+            product = info->product_id;
+        } else {
+            SDL_JoystickGUID guid = SDL_JoystickGetGUID(joystick);
+
+            SDL_GetJoystickGUIDInfo(guid, NULL, &product, NULL, NULL);
+        }
     }
     SDL_UnlockJoysticks();
 


### PR DESCRIPTION
In particular this affects the doomsday game engine if no joystick or gamepad is attached.

(cherry picked from commit 0dfdf1f3f2a1f62e579527ef3abe63543af7e6da)  
[smcv: Also included minor adjustment from #9233]

---

Backport from SDL3, with #9233 also included. This fixes a crash in the doomsday game engine: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1062969