### PR TITLE
Destroy properties after using them to avoid memory leakage

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -1539,6 +1539,7 @@ SDL_Texture *SDL_CreateTextureFromSurface(SDL_Renderer *renderer, SDL_Surface *s
     SDL_SetNumberProperty(props, SDL_PROP_TEXTURE_CREATE_WIDTH_NUMBER, surface->w);
     SDL_SetNumberProperty(props, SDL_PROP_TEXTURE_CREATE_HEIGHT_NUMBER, surface->h);
     texture = SDL_CreateTextureWithProperties(renderer, props);
+    SDL_DestroyProperties(props);
     if (!texture) {
         return NULL;
     }


### PR DESCRIPTION
Properties created in `SDL_CreateTextureFromSurface` should be destroyed after using them in `SDL_CreateTextureWithProperties` call.

## Description

## Existing Issue(s)
#9051
