### PR TITLE
Fix SDL_LEAN_AND_MEAN build + add to Android ci

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,8 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { name: Android.mk  }
-          - { name: CMake, cmake: 1, android_abi: "arm64-v8a", android_platform: 23, arch: "aarch64", artifact: "SDL-android-arm64", apk-artifact: "SDL-android-apks-arm64" }
+          - { name: "Android.mk"  }
+          - { name: "CMake", cmake: 1, android_abi: "arm64-v8a", android_platform: 23, arch: "aarch64", artifact: "SDL-android-arm64", apk-artifact: "SDL-android-apks-arm64" }
+          - { name: "CMake (lean and mean)", cmake: 1, cppflags: "-DSDL_LEAN_AND_MEAN=1", android_abi: "arm64-v8a", android_platform: 23, arch: "aarch64", artifact: "SDL-lean-android-arm64", apk-artifact: "SDL-lean-android-apks-arm64" }
 
     steps:
       - uses: actions/checkout@v4
@@ -26,23 +27,25 @@ jobs:
           local-cache: true
           ndk-version: r21e
       - name: Build (Android.mk)
-        if: ${{ matrix.platform.name == 'Android.mk' }}
+        if: ${{ contains(matrix.platform.name, 'Android.mk') }}
         run: |
           ./build-scripts/androidbuildlibs.sh
       - uses: actions/setup-java@v4
-        if: ${{ matrix.platform.name == 'CMake' }}
+        if: ${{ contains(matrix.platform.name, 'CMake') }}
         with:
           distribution: 'temurin'
           java-version: '11'
       - name: Setup (CMake)
-        if: ${{ matrix.platform.name == 'CMake' }}
+        if: ${{ contains(matrix.platform.name, 'CMake') }}
         run: |
           sudo apt-get update
           sudo apt-get install ninja-build pkg-config
       - name: Configure (CMake)
-        if: ${{ matrix.platform.name == 'CMake' }}
+        if: ${{ contains(matrix.platform.name, 'CMake') }}
         run: |
           cmake -S . -B build \
+            -DCMAKE_C_FLAGS="${{ matrix.platform.cppflags }}" \
+            -DCMAKE_CXX_FLAGS="${{ matrix.platform.cppflags }}" \
             -Wdeprecated -Wdev -Werror \
             -DCMAKE_TOOLCHAIN_FILE=${{ steps.setup_ndk.outputs.ndk-path }}/build/cmake/android.toolchain.cmake \
             -DSDL_WERROR=ON \
@@ -59,25 +62,25 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -GNinja
       - name: Build (CMake)
-        if: ${{ matrix.platform.name == 'CMake' }}
+        if: ${{ contains(matrix.platform.name, 'CMake') }}
         run: |
           cmake --build build --config Release --parallel --verbose
       - name: Build test apk's (CMake)
-        if: ${{ matrix.platform.name == 'CMake' }}
+        if: ${{ contains(matrix.platform.name, 'CMake') }}
         run: |
           cmake --build build --config Release --parallel --verbose --target testaudiocapture-apk testcontroller-apk testmultiaudio-apk testsprite-apk
       - name: Install (CMake)
-        if: ${{ matrix.platform.name == 'CMake' }}
+        if: ${{ contains(matrix.platform.name, 'CMake') }}
         run: |
           cmake --install build --config Release
           echo "SDL3_DIR=$(pwd)/prefix" >> $GITHUB_ENV
           ( cd prefix; find ) | LC_ALL=C sort -u
       - name: Package (CPack)
-        if: ${{ matrix.platform.name == 'CMake' }}
+        if: ${{ contains(matrix.platform.name, 'CMake') }}
         run: |
           cmake --build build/ --config Release --target package
       - name: Verify CMake configuration files
-        if: ${{ matrix.platform.name == 'CMake' }}
+        if: ${{ contains(matrix.platform.name, 'CMake') }}
         run: |
           cmake -S cmake/test -B cmake_config_build -G Ninja \
             -DCMAKE_TOOLCHAIN_FILE=${{ steps.setup_ndk.outputs.ndk-path }}/build/cmake/android.toolchain.cmake \
@@ -87,19 +90,19 @@ jobs:
             -DCMAKE_PREFIX_PATH=${{ env.SDL3_DIR }}
           cmake --build cmake_config_build --verbose
       - name: Verify sdl3.pc
-        if: ${{ matrix.platform.name == 'CMake' }}
+        if: ${{ contains(matrix.platform.name, 'CMake') }}
         run: |
           export CC="${{ steps.setup_ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang --target=${{ matrix.platform.arch }}-none-linux-androideabi${{ matrix.platform.android_platform }}"
           export PKG_CONFIG_PATH=${{ env.SDL3_DIR }}/lib/pkgconfig
           cmake/test/test_pkgconfig.sh
       - uses: actions/upload-artifact@v4
-        if: ${{ matrix.platform.name == 'CMake' }}
+        if: ${{ contains(matrix.platform.name, 'CMake') }}
         with:
           if-no-files-found: error
           name: ${{ matrix.platform.artifact }}
           path: build/dist/SDL3*
       - uses: actions/upload-artifact@v4
-        if: ${{ matrix.platform.name == 'CMake' }}
+        if: ${{ contains(matrix.platform.name, 'CMake') }}
         with:
           if-no-files-found: error
           name: ${{ matrix.platform.apk-artifact }}

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -931,7 +931,12 @@ SDL_Renderer *SDL_CreateRendererWithProperties(SDL_PropertiesID props)
     }
 
     if (surface) {
+#if SDL_VIDEO_RENDER_SW
         renderer = SW_CreateRendererForSurface(surface, props);
+#else
+        renderer = NULL;
+        SDL_SetError("SDL not built with software renderer");
+#endif
         if (!renderer) {
             goto error;
         }

--- a/test/testautomation_surface.c
+++ b/test/testautomation_surface.c
@@ -364,16 +364,21 @@ static int surface_testCompleteSurfaceConversion(void *arg)
     for (i = 0; i < SDL_arraysize(pixel_formats); ++i) {
         for (j = 0; j < SDL_arraysize(pixel_formats); ++j) {
             fmt1 = SDL_CreatePixelFormat(pixel_formats[i]);
-            SDL_assert(fmt1 != NULL);
+            SDLTest_AssertCheck(fmt1 != NULL, "SDL_CreatePixelFormat(%s[0x%08" SDL_PRIx32 "]) should return a non-null pixel format",
+                                SDL_GetPixelFormatName(pixel_formats[i]), pixel_formats[i]);
             cvt1 = SDL_ConvertSurface(face, fmt1);
-            SDL_assert(cvt1 != NULL);
+            SDLTest_AssertCheck(cvt1 != NULL, "SDL_ConvertSurface(..., %s[0x%08" SDL_PRIx32 "]) should return a non-null surface",
+                                SDL_GetPixelFormatName(pixel_formats[i]), pixel_formats[i]);
 
             fmt2 = SDL_CreatePixelFormat(pixel_formats[j]);
-            SDL_assert(fmt1 != NULL);
+            SDLTest_AssertCheck(fmt2 != NULL, "SDL_CreatePixelFormat(%s[0x%08" SDL_PRIx32 "]) should return a non-null pixel format",
+                                SDL_GetPixelFormatName(pixel_formats[i]), pixel_formats[i]);
             cvt2 = SDL_ConvertSurface(cvt1, fmt2);
-            SDL_assert(cvt2 != NULL);
+            SDLTest_AssertCheck(cvt2 != NULL, "SDL_ConvertSurface(..., %s[0x%08" SDL_PRIx32 "]) should return a non-null surface",
+                                SDL_GetPixelFormatName(pixel_formats[i]), pixel_formats[i]);
 
-            if (fmt1->bytes_per_pixel == face->format->bytes_per_pixel &&
+            if (fmt1 && fmt2 &&
+                fmt1->bytes_per_pixel == face->format->bytes_per_pixel &&
                 fmt2->bytes_per_pixel == face->format->bytes_per_pixel &&
                 (fmt1->Amask != 0) == (face->format->Amask != 0) &&
                 (fmt2->Amask != 0) == (face->format->Amask != 0)) {


### PR DESCRIPTION
This builds a lean SDL by building with `-DCMAKE_C_FLAGS="-DSDL_LEAN_AND_MEAN=1"`.

Do we want a `SDL_LEAN_AND_MEAN` CMake option that does this instead?

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
Fixes #9248
Fixes #9249