### PR TITLE
Move some code blocks inside `SDL_VIDEO_RENDER_SW`, where it belongs

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -3820,6 +3820,7 @@ static int remap_one_indice(
     return prev;
 }
 
+#if SDL_VIDEO_RENDER_SW
 static int remap_indices(
     int prev[3],
     int k,
@@ -3844,7 +3845,6 @@ static int remap_indices(
 
 #define DEBUG_SW_RENDER_GEOMETRY 0
 /* For the software renderer, try to reinterpret triangles as SDL_Rect */
-#if SDL_VIDEO_RENDER_SW
 static int SDLCALL SDL_SW_RenderGeometryRaw(SDL_Renderer *renderer,
                                             SDL_Texture *texture,
                                             const float *xy, int xy_stride,

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -3782,6 +3782,7 @@ int SDL_RenderGeometry(SDL_Renderer *renderer,
     }
 }
 
+#if SDL_VIDEO_RENDER_SW
 static int remap_one_indice(
     int prev,
     int k,
@@ -3820,7 +3821,6 @@ static int remap_one_indice(
     return prev;
 }
 
-#if SDL_VIDEO_RENDER_SW
 static int remap_indices(
     int prev[3],
     int k,
@@ -4151,7 +4151,7 @@ end:
 
     return retval;
 }
-#endif
+#endif /* SDL_VIDEO_RENDER_SW */
 
 int SDL_RenderGeometryRawFloat(SDL_Renderer *renderer,
                           SDL_Texture *texture,

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -3844,6 +3844,7 @@ static int remap_indices(
 
 #define DEBUG_SW_RENDER_GEOMETRY 0
 /* For the software renderer, try to reinterpret triangles as SDL_Rect */
+#if SDL_VIDEO_RENDER_SW
 static int SDLCALL SDL_SW_RenderGeometryRaw(SDL_Renderer *renderer,
                                             SDL_Texture *texture,
                                             const float *xy, int xy_stride,
@@ -4150,6 +4151,7 @@ end:
 
     return retval;
 }
+#endif
 
 int SDL_RenderGeometryRawFloat(SDL_Renderer *renderer,
                           SDL_Texture *texture,
@@ -4247,11 +4249,13 @@ int SDL_RenderGeometryRawFloat(SDL_Renderer *renderer,
     }
 
     /* For the software renderer, try to reinterpret triangles as SDL_Rect */
+#if SDL_VIDEO_RENDER_SW
     if (renderer->info.flags & SDL_RENDERER_SOFTWARE) {
         return SDL_SW_RenderGeometryRaw(renderer, texture,
                                         xy, xy_stride, color, color_stride, uv, uv_stride, num_vertices,
                                         indices, num_indices, size_indices);
     }
+#endif
 
     return QueueCmdGeometry(renderer, texture,
                               xy, xy_stride, color, color_stride, uv, uv_stride,
@@ -4673,12 +4677,14 @@ int SDL_SetRenderVSync(SDL_Renderer *renderer, int vsync)
     renderer->wanted_vsync = vsync ? SDL_TRUE : SDL_FALSE;
 
     /* for the software renderer, forward eventually the call to the WindowTexture renderer */
+#if SDL_VIDEO_RENDER_SW
     if (renderer->info.flags & SDL_RENDERER_SOFTWARE) {
         if (SDL_SetWindowTextureVSync(renderer->window, vsync) == 0) {
             renderer->simulate_vsync = SDL_FALSE;
             return 0;
         }
     }
+#endif
 
     if (!renderer->SetVSync ||
         renderer->SetVSync(renderer, vsync) != 0) {


### PR DESCRIPTION
There was some software renderer specific code that can be excluded with `SDL_LEAN_AND_MEAN`. This contributes towards #9206

Visual Studio DLL sizes before this change:

Win32 1,167,872 bytes
x64 1,415,680 bytes

After:

Win32 1,165,824 bytes (saving 2,048 bytes) 
x64 1,413,120 bytes (saving 2,560 bytes)

