### PR TITLE
Fix minor inconsistencies in event types

### DIFF
--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -239,7 +239,7 @@ typedef enum
  */
 typedef struct SDL_CommonEvent
 {
-    Uint32 type;
+    SDL_EventType type;
     Uint32 reserved;
     Uint64 timestamp;   /**< In nanoseconds, populated using SDL_GetTicksNS() */
 } SDL_CommonEvent;
@@ -543,6 +543,7 @@ typedef struct SDL_AudioDeviceEvent
 typedef struct SDL_CameraDeviceEvent
 {
     SDL_EventType type; /**< ::SDL_EVENT_CAMERA_DEVICE_ADDED, ::SDL_EVENT_CAMERA_DEVICE_REMOVED, ::SDL_EVENT_CAMERA_DEVICE_APPROVED, ::SDL_EVENT_CAMERA_DEVICE_DENIED */
+    Uint32 reserved;
     Uint64 timestamp;   /**< In nanoseconds, populated using SDL_GetTicksNS() */
     SDL_CameraDeviceID which;       /**< SDL_CameraDeviceID for the device being added or removed or changing */
     Uint8 padding1;
@@ -680,7 +681,7 @@ typedef struct SDL_QuitEvent
  */
 typedef struct SDL_UserEvent
 {
-    Uint32 type;        /**< ::SDL_EVENT_USER through ::SDL_EVENT_LAST-1 */
+    SDL_EventType type; /**< ::SDL_EVENT_USER through ::SDL_EVENT_LAST-1 */
     Uint32 reserved;
     Uint64 timestamp;   /**< In nanoseconds, populated using SDL_GetTicksNS() */
     SDL_WindowID windowID; /**< The associated window if any */
@@ -695,7 +696,7 @@ typedef struct SDL_UserEvent
  */
 typedef union SDL_Event
 {
-    Uint32 type;                            /**< Event type, shared with all events */
+    SDL_EventType type;                     /**< Event type, shared with all events */
     SDL_CommonEvent common;                 /**< Common event data */
     SDL_DisplayEvent display;               /**< Display event data */
     SDL_WindowEvent window;                 /**< Window event data */

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1855,7 +1855,7 @@ static void SDLTest_PrintEvent(const SDL_Event *event)
         SDL_Log("SDL EVENT: User event %" SDL_PRIs32, event->user.code);
         break;
     default:
-        SDL_Log("Unknown event 0x%4.4" SDL_PRIu32, event->type);
+        SDL_Log("Unknown event 0x%4.4" SDL_PRIu32, (Uint32) event->type);
         break;
     }
 }

--- a/test/testime.c
+++ b/test/testime.c
@@ -784,6 +784,9 @@ int main(int argc, char *argv[])
                 cursor = event.edit.start;
                 Redraw();
                 break;
+
+            default:
+                break;
             }
         }
     }


### PR DESCRIPTION
## Description
`SDL_CameraDeviceEvent` was missing a reserved field and 2 specific events as well as the event union itself were using `Uint32` instead of `SDL_EventType`.