### PR TITLE
PSP: implement SDL_GetWindowSurface() API for direct VRAM access

### DIFF
--- a/include/SDL_video.h
+++ b/include/SDL_video.h
@@ -1297,6 +1297,10 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasWindowSurface(SDL_Window *window);
  * This surface will be invalidated if the window is resized. After resizing a
  * window this function must be called again to return a valid surface.
  *
+ * Note that on some platforms the pixels pointer of the surface may be
+ * modified after each call to SDL_UpdateWindowSurface(), so that the platform
+ * code can implement efficient double or triple buffering.
+ *
  * You may not combine this with 3D or the rendering API on this window.
  *
  * This function is affected by `SDL_HINT_FRAMEBUFFER_ACCELERATION`.

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -36,6 +36,7 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <vram.h>
+#include "SDL_render_psp.h"
 
 /* PSP renderer implementation, based on the PGE  */
 
@@ -123,6 +124,24 @@ typedef struct
     SDL_Color col;
     float x, y, z;
 } VertTCV;
+
+int SDL_PSP_RenderGetProp(SDL_Renderer *r, enum SDL_PSP_RenderProps which, void** out)
+{
+    PSP_RenderData *rd;
+    if (r == NULL) {
+        return -1;
+    }
+    rd = r->driverdata;
+    switch (which) {
+        case SDL_PSP_RENDERPROPS_FRONTBUFFER:
+            *out = rd->frontbuffer;
+            return 0;
+        case SDL_PSP_RENDERPROPS_BACKBUFFER:
+            *out = rd->backbuffer;
+            return 0;
+    }
+    return -1;
+}
 
 #define PI 3.14159265358979f
 

--- a/src/render/psp/SDL_render_psp.h
+++ b/src/render/psp/SDL_render_psp.h
@@ -1,0 +1,32 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+/* this header is meant to be included after the other related internal SDL
+   headers. it's the interface between psp renderer and video driver code. */
+
+enum SDL_PSP_RenderProps
+{
+    SDL_PSP_RENDERPROPS_FRONTBUFFER,
+    SDL_PSP_RENDERPROPS_BACKBUFFER,
+};
+
+int SDL_PSP_RenderGetProp(SDL_Renderer *r, enum SDL_PSP_RenderProps which, void** out);
+

--- a/src/video/psp/SDL_pspvideo.h
+++ b/src/video/psp/SDL_pspvideo.h
@@ -68,6 +68,14 @@ void PSP_MinimizeWindow(_THIS, SDL_Window *window);
 void PSP_RestoreWindow(_THIS, SDL_Window *window);
 void PSP_DestroyWindow(_THIS, SDL_Window *window);
 
+/* "methods" aka callbacks for SDL_WindowSurface API */
+int PSP_CreateWindowFramebuffer(_THIS, SDL_Window *window, Uint32 *format,
+ void **pixels, int *pitch);
+int PSP_UpdateWindowFramebuffer(_THIS, SDL_Window *window,
+const SDL_Rect *rects, int numrects);
+void PSP_DestroyWindowFramebuffer(_THIS, SDL_Window *window);
+
+
 /* Window manager function */
 SDL_bool PSP_GetWindowWMInfo(_THIS, SDL_Window * window,
                              struct SDL_SysWMinfo *info);


### PR DESCRIPTION
instead of dealing with renderers and textures, this allows you to create a window, set the pixel format using SDL_SetWindowDisplayMode() - preferably BGR565 for optimal speed - and then request SDL_GetWindowSurface() for each redraw, which provides you a surface with direct framebuffer access - that's why you need to call it on every repaint, rather than storing the surface variable.

note that you need to overwrite all pixels of the PSP visible area (480x272) to not encounter old data.

after you're done writing your pixels, call SDL_UpdateWindowSurface() and your changes will be sent to the graphics chip.

the result is a framerate of 60+ fps with BGR565 mode, unlike the other methods involving renderer and textures and a lot of copying.

# Existing Issue(s)
#9260
