### PR TITLE
Adding comments to init-flags SDL_INIT_AUDIO and SDL_INIT_SENSOR that they imply SDL_INIT_EVENTS

### DIFF
--- a/include/SDL3/SDL_init.h
+++ b/include/SDL3/SDL_init.h
@@ -53,13 +53,13 @@ extern "C" {
 typedef enum
 {
     SDL_INIT_TIMER        = 0x00000001,
-    SDL_INIT_AUDIO        = 0x00000010,
+    SDL_INIT_AUDIO        = 0x00000010,  /**< `SDL_INIT_AUDIO` implies `SDL_INIT_EVENTS` */
     SDL_INIT_VIDEO        = 0x00000020,  /**< `SDL_INIT_VIDEO` implies `SDL_INIT_EVENTS` */
     SDL_INIT_JOYSTICK     = 0x00000200,  /**< `SDL_INIT_JOYSTICK` implies `SDL_INIT_EVENTS` */
     SDL_INIT_HAPTIC       = 0x00001000,
     SDL_INIT_GAMEPAD      = 0x00002000,  /**< `SDL_INIT_GAMEPAD` implies `SDL_INIT_JOYSTICK` */
     SDL_INIT_EVENTS       = 0x00004000,
-    SDL_INIT_SENSOR       = 0x00008000,
+    SDL_INIT_SENSOR       = 0x00008000,  /**< `SDL_INIT_SENSOR` implies `SDL_INIT_EVENTS` */
     SDL_INIT_CAMERA       = 0x00010000   /**< `SDL_INIT_CAMERA` implies `SDL_INIT_EVENTS` */
 } SDL_InitFlags;
 


### PR DESCRIPTION
When initializing SDL with the flag SDL_INIT_AUDIO or SDL_INIT_SENSOR, the event subsystem also gets initialized(SDL_INIT_EVENTS). This isn't mentioned in the comments.

This commit adds the two comments.


Here SDL_INIT_AUDIO initializes SDL_INIT_EVENTS:
https://github.com/libsdl-org/SDL/blob/495e432fb9776fdc13a8d96179136064ccddf6e5/src/SDL.c#L261-L268

Here SDL_INIT_SENSOR initializes SDL_INIT_EVENTS:
https://github.com/libsdl-org/SDL/blob/495e432fb9776fdc13a8d96179136064ccddf6e5/src/sensor/SDL_sensor.c#L124-L135