### PR TITLE
[SDL2]wayland: Always use the entire buffer for the viewport source

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -202,7 +202,7 @@ static void SetDrawSurfaceViewport(SDL_Window *window, int src_width, int src_he
             wind->draw_viewport = wp_viewporter_get_viewport(video->viewporter, wind->surface);
         }
 
-        wp_viewport_set_source(wind->draw_viewport, wl_fixed_from_int(0), wl_fixed_from_int(0), wl_fixed_from_int(src_width), wl_fixed_from_int(src_height));
+        wp_viewport_set_source(wind->draw_viewport, wl_fixed_from_int(-1), wl_fixed_from_int(-1), wl_fixed_from_int(-1), wl_fixed_from_int(-1));
         wp_viewport_set_destination(wind->draw_viewport, dst_width, dst_height);
     }
 }


### PR DESCRIPTION
Not doing so can result in protocol errors if the viewport source region is updated and a buffer with the old, smaller dimensions is committed.

SDL2 version of the fix. Will be cherry-picked to 2.30.x (maybe further back?)

Fixes #9283