### PR TITLE
filesystem: Rename some internal symbols to remove "FSops" terminology.

### DIFF
--- a/src/filesystem/SDL_filesystem.c
+++ b/src/filesystem/SDL_filesystem.c
@@ -48,7 +48,7 @@ int SDL_RemovePath(const char *path)
     if (!path) {
         return SDL_InvalidParamError("path");
     }
-    return SDL_SYS_FSremove(path);
+    return SDL_SYS_RemovePath(path);
 }
 
 int SDL_RenamePath(const char *oldpath, const char *newpath)
@@ -58,7 +58,7 @@ int SDL_RenamePath(const char *oldpath, const char *newpath)
     } else if (!newpath) {
         return SDL_InvalidParamError("newpath");
     }
-    return SDL_SYS_FSrename(oldpath, newpath);
+    return SDL_SYS_RenamePath(oldpath, newpath);
 }
 
 int SDL_CreateDirectory(const char *path)
@@ -67,7 +67,7 @@ int SDL_CreateDirectory(const char *path)
     if (!path) {
         return SDL_InvalidParamError("path");
     }
-    return SDL_SYS_FSmkdir(path);
+    return SDL_SYS_CreateDirectory(path);
 }
 
 int SDL_EnumerateDirectory(const char *path, SDL_EnumerateDirectoryCallback callback, void *userdata)
@@ -77,15 +77,15 @@ int SDL_EnumerateDirectory(const char *path, SDL_EnumerateDirectoryCallback call
     } else if (!callback) {
         return SDL_InvalidParamError("callback");
     }
-    return SDL_SYS_FSenumerate(path, path, callback, userdata);
+    return SDL_SYS_EnumerateDirectory(path, path, callback, userdata);
 }
 
-int SDL_GetPathInfo(const char *path, SDL_PathInfo *stat)
+int SDL_GetPathInfo(const char *path, SDL_PathInfo *info)
 {
     if (!path) {
         return SDL_InvalidParamError("path");
-    } else if (!stat) {
-        return SDL_InvalidParamError("stat");
+    } else if (!info) {
+        return SDL_InvalidParamError("info");
     }
-    return SDL_SYS_FSstat(path, stat);
+    return SDL_SYS_GetPathInfo(path, info);
 }

--- a/src/filesystem/SDL_sysfilesystem.h
+++ b/src/filesystem/SDL_sysfilesystem.h
@@ -22,11 +22,11 @@
 #ifndef SDL_sysfilesystem_h_
 #define SDL_sysfilesystem_h_
 
-int SDL_SYS_FSenumerate(const char *fullpath, const char *dirname, SDL_EnumerateDirectoryCallback cb, void *userdata);
-int SDL_SYS_FSremove(const char *fullpath);
-int SDL_SYS_FSrename(const char *oldfullpath, const char *newfullpath);
-int SDL_SYS_FSmkdir(const char *fullpath);
-int SDL_SYS_FSstat(const char *fullpath, SDL_PathInfo *info);
+int SDL_SYS_EnumerateDirectory(const char *path, const char *dirname, SDL_EnumerateDirectoryCallback cb, void *userdata);
+int SDL_SYS_RemovePath(const char *path);
+int SDL_SYS_RenamePath(const char *oldpath, const char *newpath);
+int SDL_SYS_CreateDirectory(const char *path);
+int SDL_SYS_GetPathInfo(const char *path, SDL_PathInfo *info);
 
 #endif
 

--- a/src/filesystem/dummy/SDL_sysfsops.c
+++ b/src/filesystem/dummy/SDL_sysfsops.c
@@ -25,27 +25,27 @@
 
 #include "../SDL_sysfilesystem.h"
 
-int SDL_SYS_FSenumerate(const char *fullpath, const char *dirname, SDL_EnumerateDirectoryCallback cb, void *userdata)
+int SDL_SYS_EnumerateDirectory(const char *path, const char *dirname, SDL_EnumerateDirectoryCallback cb, void *userdata)
 {
     return SDL_Unsupported();
 }
 
-int SDL_SYS_FSremove(const char *fullpath)
+int SDL_SYS_RemovePath(const char *path)
 {
     return SDL_Unsupported();
 }
 
-int SDL_SYS_FSrename(const char *oldfullpath, const char *newfullpath)
+int SDL_SYS_RenamePath(const char *oldpath, const char *newpath)
 {
     return SDL_Unsupported();
 }
 
-int SDL_SYS_FSmkdir(const char *fullpath)
+int SDL_SYS_CreateDirectory(const char *path)
 {
     return SDL_Unsupported();
 }
 
-int SDL_SYS_FSstat(const char *fullpath, SDL_PathInfo *st)
+int SDL_SYS_GetPathInfo(const char *path, SDL_PathInfo *info)
 {
     return SDL_Unsupported();
 }

--- a/src/filesystem/posix/SDL_sysfsops.c
+++ b/src/filesystem/posix/SDL_sysfsops.c
@@ -31,11 +31,11 @@
 
 #include "../SDL_sysfilesystem.h"
 
-int SDL_SYS_FSenumerate(const char *fullpath, const char *dirname, SDL_EnumerateDirectoryCallback cb, void *userdata)
+int SDL_SYS_EnumerateDirectory(const char *path, const char *dirname, SDL_EnumerateDirectoryCallback cb, void *userdata)
 {
     int retval = 1;
 
-    DIR *dir = opendir(fullpath);
+    DIR *dir = opendir(path);
     if (!dir) {
         return SDL_SetError("Can't open directory: %s", strerror(errno));
     }
@@ -55,13 +55,13 @@ int SDL_SYS_FSenumerate(const char *fullpath, const char *dirname, SDL_Enumerate
     return retval;
 }
 
-int SDL_SYS_FSremove(const char *fullpath)
+int SDL_SYS_RemovePath(const char *path)
 {
-    int rc = remove(fullpath);
+    int rc = remove(path);
     if (rc < 0) {
         const int origerrno = errno;
         if (origerrno == ENOENT) {
-            char *parent = SDL_strdup(fullpath);
+            char *parent = SDL_strdup(path);
             if (!parent) {
                 return -1;
             }
@@ -83,22 +83,22 @@ int SDL_SYS_FSremove(const char *fullpath)
     return 0;
 }
 
-int SDL_SYS_FSrename(const char *oldfullpath, const char *newfullpath)
+int SDL_SYS_RenamePath(const char *oldpath, const char *newpath)
 {
-    if (rename(oldfullpath, newfullpath) < 0) {
+    if (rename(oldpath, newpath) < 0) {
         return SDL_SetError("Can't remove path: %s", strerror(errno));
     }
     return 0;
 }
 
-int SDL_SYS_FSmkdir(const char *fullpath)
+int SDL_SYS_CreateDirectory(const char *path)
 {
-    const int rc = mkdir(fullpath, 0770);
+    const int rc = mkdir(path, 0770);
     if (rc < 0) {
         const int origerrno = errno;
         if (origerrno == EEXIST) {
             struct stat statbuf;
-            if ((stat(fullpath, &statbuf) == 0) && (S_ISDIR(statbuf.st_mode))) {
+            if ((stat(path, &statbuf) == 0) && (S_ISDIR(statbuf.st_mode))) {
                 return 0;  // it already exists and it's a directory, consider it success.
             }
         }
@@ -107,10 +107,10 @@ int SDL_SYS_FSmkdir(const char *fullpath)
     return 0;
 }
 
-int SDL_SYS_FSstat(const char *fullpath, SDL_PathInfo *info)
+int SDL_SYS_GetPathInfo(const char *path, SDL_PathInfo *info)
 {
     struct stat statbuf;
-    const int rc = stat(fullpath, &statbuf);
+    const int rc = stat(path, &statbuf);
     if (rc < 0) {
         return SDL_SetError("Can't stat: %s", strerror(errno));
     } else if (S_ISREG(statbuf.st_mode)) {

--- a/src/filesystem/windows/SDL_sysfsops.c
+++ b/src/filesystem/windows/SDL_sysfsops.c
@@ -26,10 +26,10 @@
 #include "../../core/windows/SDL_windows.h"
 #include "../SDL_sysfilesystem.h"
 
-int SDL_SYS_FSenumerate(const char *fullpath, const char *dirname, SDL_EnumerateDirectoryCallback cb, void *userdata)
+int SDL_SYS_EnumerateDirectory(const char *path, const char *dirname, SDL_EnumerateDirectoryCallback cb, void *userdata)
 {
     int retval = 1;
-    if (*fullpath == '\0') {  // if empty (completely at the root), we need to enumerate drive letters.
+    if (*path == '\0') {  // if empty (completely at the root), we need to enumerate drive letters.
         const DWORD drives = GetLogicalDrives();
         char name[3] = { 0, ':', '\0' };
         for (int i = 'A'; (retval == 1) && (i <= 'Z'); i++) {
@@ -39,7 +39,7 @@ int SDL_SYS_FSenumerate(const char *fullpath, const char *dirname, SDL_Enumerate
             }
         }
     } else {
-        const size_t patternlen = SDL_strlen(fullpath) + 3;
+        const size_t patternlen = SDL_strlen(path) + 3;
         char *pattern = (char *) SDL_malloc(patternlen);
         if (!pattern) {
             return -1;
@@ -48,7 +48,7 @@ int SDL_SYS_FSenumerate(const char *fullpath, const char *dirname, SDL_Enumerate
         // you need a wildcard to enumerate through FindFirstFileEx(), but the wildcard is only checked in the
         // filename element at the end of the path string, so always tack on a "\\*" to get everything, and
         // also prevent any wildcards inserted by the app from being respected.
-        SDL_snprintf(pattern, patternlen, "%s\\*", fullpath);
+        SDL_snprintf(pattern, patternlen, "%s\\*", path);
 
         WCHAR *wpattern = WIN_UTF8ToString(pattern);
         SDL_free(pattern);
@@ -87,9 +87,9 @@ int SDL_SYS_FSenumerate(const char *fullpath, const char *dirname, SDL_Enumerate
     return retval;
 }
 
-int SDL_SYS_FSremove(const char *fullpath)
+int SDL_SYS_RemovePath(const char *path)
 {
-    WCHAR *wpath = WIN_UTF8ToString(fullpath);
+    WCHAR *wpath = WIN_UTF8ToString(path);
     if (!wpath) {
         return -1;
     }
@@ -109,14 +109,14 @@ int SDL_SYS_FSremove(const char *fullpath)
     return !rc ? WIN_SetError("Couldn't remove path") : 0;
 }
 
-int SDL_SYS_FSrename(const char *oldfullpath, const char *newfullpath)
+int SDL_SYS_RenamePath(const char *oldpath, const char *newpath)
 {
-    WCHAR *woldpath = WIN_UTF8ToString(oldfullpath);
+    WCHAR *woldpath = WIN_UTF8ToString(oldpath);
     if (!woldpath) {
         return -1;
     }
 
-    WCHAR *wnewpath = WIN_UTF8ToString(newfullpath);
+    WCHAR *wnewpath = WIN_UTF8ToString(newpath);
     if (!wnewpath) {
         SDL_free(woldpath);
         return -1;
@@ -128,9 +128,9 @@ int SDL_SYS_FSrename(const char *oldfullpath, const char *newfullpath)
     return !rc ? WIN_SetError("Couldn't rename path") : 0;
 }
 
-int SDL_SYS_FSmkdir(const char *fullpath)
+int SDL_SYS_CreateDirectory(const char *path)
 {
-    WCHAR *wpath = WIN_UTF8ToString(fullpath);
+    WCHAR *wpath = WIN_UTF8ToString(path);
     if (!wpath) {
         return -1;
     }
@@ -152,9 +152,9 @@ static Sint64 FileTimeToSDLTime(const FILETIME *ft)
     return (Sint64) ((((Uint64)large.QuadPart) - delta_1601_epoch_100ns) / (SDL_NS_PER_SECOND / 100ull));  // [secs] (adjust to epoch and convert 1/100th nanosecond units to seconds).
 }
 
-int SDL_SYS_FSstat(const char *fullpath, SDL_PathInfo *info)
+int SDL_SYS_GetPathInfo(const char *path, SDL_PathInfo *info)
 {
-    WCHAR *wpath = WIN_UTF8ToString(fullpath);
+    WCHAR *wpath = WIN_UTF8ToString(path);
     if (!wpath) {
         return -1;
     }


### PR DESCRIPTION
This removes the "FSops" naming scheme, which was meant to mirror the "RWops" naming scheme, which was also recently removed from SDL3.

The build system defines (`SDL_FSOPS_POSIX`, etc) and the source code filenames retain this, because there's already things using the word "filesystem" that might overlap (for example, lots of things have a unique "SDL_sysfilesystem.c", to query base dirs, etc, but almost everything uses the POSIX "SDL_sysfsops.c" source code.

Fixes #9288.
