### PR TITLE
testautomation_math.c: use isinf(V) instead of fpclassify(V) == FP_INFINITE

### DIFF
--- a/test/testautomation_math.c
+++ b/test/testautomation_math.c
@@ -25,7 +25,7 @@
 #define EULER M_E
 #endif
 
-#define IS_INFINITY(V) fpclassify(V) == FP_INFINITE
+#define IS_INFINITY(V) isinf(V)
 
 /* Square root of 3 (used in atan2) */
 #define SQRT3 1.7320508075688771931766041234368458390235900878906250


### PR DESCRIPTION
Fixes #9284

Using `fpclassify` can cause a linker error.
Using `isinf` instead fixes this.