### PR TITLE
PSP: don't block on joystick event query

### DIFF
--- a/src/joystick/psp/SDL_sysjoystick.c
+++ b/src/joystick/psp/SDL_sysjoystick.c
@@ -210,7 +210,7 @@ static void PSP_JoystickUpdate(SDL_Joystick *joystick)
     static enum PspCtrlButtons old_buttons = 0;
     static unsigned char old_x = 0, old_y = 0;
 
-    sceCtrlReadBufferPositive(&pad, 1);
+    if(sceCtrlPeekBufferPositive(&pad, 1) <= 0) return;
     buttons = pad.Buttons;
     x = pad.Lx;
     y = pad.Ly;

--- a/src/joystick/psp/SDL_sysjoystick.c
+++ b/src/joystick/psp/SDL_sysjoystick.c
@@ -210,7 +210,9 @@ static void PSP_JoystickUpdate(SDL_Joystick *joystick)
     static enum PspCtrlButtons old_buttons = 0;
     static unsigned char old_x = 0, old_y = 0;
 
-    if(sceCtrlPeekBufferPositive(&pad, 1) <= 0) return;
+    if (sceCtrlPeekBufferPositive(&pad, 1) <= 0) {
+        return;
+    }
     buttons = pad.Buttons;
     x = pad.Lx;
     y = pad.Ly;


### PR DESCRIPTION
using the blocking sceCtrlReadBufferPositive() effectively turns SDL_PollEvent() into WaitForVblank(), because the functions does exactly that if no input is buffered. due to this, calling SDL_PollEvent() once per frame averaged in 7 ms delay, wasting nearly half of the available 16ms budget to get a frame calculated and drawn to achieve 60 fps.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
