### PR TITLE
Add missing break

### DIFF
--- a/src/render/SDL_yuv_sw.c
+++ b/src/render/SDL_yuv_sw.c
@@ -211,7 +211,7 @@ int SDL_SW_UpdateYUVTexture(SDL_SW_YUVTexture *swdata, const SDL_Rect *rect,
                 dst += 2 * ((swdata->w + 1) / 2);
             }
         }
-    }
+    } break;
     default:
         return SDL_SetError("Unsupported YUV format");
     }


### PR DESCRIPTION
## Description
`break` is missing for `case SDL_PIXELFORMAT_NV12` and `SDL_PIXELFORMAT_NV21`.
You may want to enable `-Wimplicit-fallthrough` and annotate remaining actual fall through with `SDL_FALLTHROUGH`.

## Existing Issue(s)
None 
