### PR TITLE
src/filesystem/unix/SDL_sysfilesystem.c add <stdio.h> inclusion

### DIFF
--- a/src/filesystem/unix/SDL_sysfilesystem.c
+++ b/src/filesystem/unix/SDL_sysfilesystem.c
@@ -25,6 +25,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /* System dependent filesystem routines                                */
 
+#include <stdio.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <dirent.h>


### PR DESCRIPTION
gets rid of following warnings:
```
SDL_repo/src/filesystem/unix/SDL_sysfilesystem.c: In function ‘xdg_user_dir_lookup_with_fallback’:
SDL_repo/src/filesystem/unix/SDL_sysfilesystem.c:393:10: warning: implicit declaration of function ‘fopen’ [-Wimplicit-function-declaration]
  393 |   file = fopen (config_file, "r");
      |          ^~~~~
SDL_repo/src/filesystem/unix/SDL_sysfilesystem.c:37:1: note: ‘fopen’ is defined in header ‘<stdio.h>’; did you forget to ‘#include <stdio.h>’?
   36 | #include <unistd.h>
  +++ |+#include <stdio.h>
   37 | 
SDL_repo/src/filesystem/unix/SDL_sysfilesystem.c:393:8: warning: assignment to ‘FILE *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
  393 |   file = fopen (config_file, "r");
      |        ^
SDL_repo/src/filesystem/unix/SDL_sysfilesystem.c:399:10: warning: implicit declaration of function ‘fgets’; did you mean ‘fgetws’? [-Wimplicit-function-declaration]
  399 |   while (fgets (buffer, sizeof (buffer), file))
      |          ^~~~~
      |          fgetws
[ 97%] Building C object CMakeFiles/SDL3-shared.dir/src/video/offscreen/SDL_offscreenevents.c.o
[ 97%] Building C object CMakeFiles/SDL3-shared.dir/src/dialog/unix/SDL_zenitydialog.c.o
SDL_repo/src/filesystem/unix/SDL_sysfilesystem.c:473:3: warning: implicit declaration of function ‘fclose’; did you mean ‘close’? [-Wimplicit-function-declaration]
  473 |   fclose (file);
      |   ^~~~~~
      |   close
```