### PR TITLE
Standardise header includes in public headers

### DIFF
--- a/include/SDL3/SDL_camera.h
+++ b/include/SDL3/SDL_camera.h
@@ -28,7 +28,7 @@
 #ifndef SDL_camera_h_
 #define SDL_camera_h_
 
-#include "SDL3/SDL_video.h"
+#include <SDL3/SDL_video.h>
 
 #include <SDL3/SDL_begin_code.h>
 /* Set up for C function definitions, even when using C++ */

--- a/include/SDL3/SDL_egl.h
+++ b/include/SDL3/SDL_egl.h
@@ -25,7 +25,7 @@
  *  This is a simple file to encapsulate the EGL API headers.
  */
 
-#include "SDL_platform_defines.h"
+#include <SDL3/SDL_platform_defines.h>
 
 #if !defined(_MSC_VER) && !defined(SDL_PLATFORM_ANDROID) && !defined(SDL_USE_BUILTIN_OPENGL_DEFINITIONS)
 

--- a/include/SDL3/SDL_pen.h
+++ b/include/SDL3/SDL_pen.h
@@ -45,9 +45,9 @@
 #ifndef SDL_pen_h_
 #define SDL_pen_h_
 
-#include "SDL_error.h"
-#include "SDL_guid.h"
-#include "SDL_stdinc.h"
+#include <SDL3/SDL_error.h>
+#include <SDL3/SDL_guid.h>
+#include <SDL3/SDL_stdinc.h>
 
 /* Set up for C function definitions, even when using C++ */
 #ifdef __cplusplus


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Changes `"SDL_*.h"` and `"SDL3/SDL_*.h"` to `<SDL3/SDL_*.h>`.

All offending include directives were found by grepping for `#include "`. Grepping after this change yields no matches in the public headers.

Noticed when testing out C# binding generation.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
N/A