### PR TITLE
 Run tests in non-linear order (see #9303)

### DIFF
--- a/include/SDL3/SDL_test_harness.h
+++ b/include/SDL3/SDL_test_harness.h
@@ -117,10 +117,11 @@ char *SDLTest_GenerateRunSeed(const int length);
  * \param userExecKey Custom execution key provided by user, or 0 to autogenerate one.
  * \param filter Filter specification. NULL disables. Case sensitive.
  * \param testIterations Number of iterations to run each test case.
+ * \param randomOrder allow to run suites and tests in random order when there is no filter
  *
  * \returns the test run result: 0 when all tests passed, 1 if any tests failed.
  */
-int SDLTest_RunSuites(SDLTest_TestSuiteReference *testSuites[], const char *userRunSeed, Uint64 userExecKey, const char *filter, int testIterations);
+int SDLTest_RunSuites(SDLTest_TestSuiteReference *testSuites[], const char *userRunSeed, Uint64 userExecKey, const char *filter, int testIterations, SDL_bool randomOrder);
 
 
 /* Ends C function definitions when using C++ */

--- a/test/testautomation.c
+++ b/test/testautomation.c
@@ -75,6 +75,7 @@ int main(int argc, char *argv[])
     int i, done;
     SDL_Event event;
     int list = 0;
+    SDL_bool randomOrder = SDL_FALSE;
 
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, SDL_INIT_VIDEO | SDL_INIT_AUDIO);
@@ -118,10 +119,21 @@ int main(int argc, char *argv[])
             } else if (SDL_strcasecmp(argv[i], "--list") == 0) {
                 consumed = 1;
                 list = 1;
+            } else if (SDL_strcasecmp(argv[i], "--random-order") == 0) {
+                consumed = 1;
+                randomOrder = SDL_TRUE;
             }
+
         }
         if (consumed < 0) {
-            static const char *options[] = { "[--iterations #]", "[--execKey #]", "[--seed string]", "[--filter suite_name|test_name]", "[--list]", NULL };
+            static const char *options[] = {
+                "[--iterations #]",
+                "[--execKey #]",
+                "[--seed string]",
+                "[--filter suite_name|test_name]",
+                "[--list]",
+                "[--random-order]",
+                NULL };
             SDLTest_CommonLogUsage(state, argv[0], options);
             quit(1);
         }
@@ -157,7 +169,7 @@ int main(int argc, char *argv[])
     }
 
     /* Call Harness */
-    result = SDLTest_RunSuites(testSuites, userRunSeed, userExecKey, filter, testIterations);
+    result = SDLTest_RunSuites(testSuites, userRunSeed, userExecKey, filter, testIterations, randomOrder);
 
     /* Empty event queue */
     done = 0;


### PR DESCRIPTION
Run tests in non-linear order (see #9303)

It mixes the testSuites array, and for each suite, it mixes the sub-tests.

Hence, it changes the public API behavior of SDLTest_RunSuites(). not sure if this is acceptable ? 
