### PR TITLE
SDL_sysmutex.c: fix void return compile error

### DIFF
--- a/src/thread/pthread/SDL_sysmutex.c
+++ b/src/thread/pthread/SDL_sysmutex.c
@@ -141,7 +141,8 @@ void SDL_UnlockMutex(SDL_Mutex *mutex) SDL_NO_THREAD_SAFETY_ANALYSIS // clang do
                 pthread_mutex_unlock(&mutex->id);
             }
         } else {
-            return SDL_SetError("mutex not owned by this thread");
+            SDL_SetError("mutex not owned by this thread");
+            return;
         }
 
 #else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix a tiny compile error:

```
src/thread/pthread/SDL_sysmutex.c:144:13: error: void function 'SDL_UnlockMutex' should not return a value                     
            return SDL_SetError("mutex not owned by this thread");
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```