### PR TITLE
testffmpeg_vulkan: fix -Wincompatible-pointer-types warning

### DIFF
--- a/test/testffmpeg_vulkan.c
+++ b/test/testffmpeg_vulkan.c
@@ -16,9 +16,6 @@
 
 #ifdef FFMPEG_VULKAN_SUPPORT
 
-#include <libavutil/hwcontext.h>
-#include <libavutil/hwcontext_vulkan.h>
-
 #define VULKAN_FUNCTIONS()                                             \
     VULKAN_GLOBAL_FUNCTION(vkCreateInstance)                           \
     VULKAN_GLOBAL_FUNCTION(vkEnumerateInstanceExtensionProperties)     \

--- a/test/testffmpeg_vulkan.h
+++ b/test/testffmpeg_vulkan.h
@@ -10,6 +10,7 @@
   freely.
 */
 
+#include <libavutil/hwcontext.h>
 #include <libavutil/hwcontext_vulkan.h>
 
 


### PR DESCRIPTION
Fixes this compile warning:
```
[1/1] Building C object test/CMakeFiles/testffmpeg.dir/testffmpeg_vulkan.c.o
/src/SDL/test/testffmpeg_vulkan.c: In function ‘BeginVulkanFrameRendering’:
/src/SDL/test/testffmpeg_vulkan.c:787:20: warning: passing argument 1 of ‘vk->lock_frame’ from incompatible pointer type [-Wincompatible-pointer-types]
  787 |     vk->lock_frame(frames, pVkFrame);
      |                    ^~~~~~
      |                    |
      |                    AVHWFramesContext *
/src/SDL/test/testffmpeg_vulkan.c:787:20: note: expected ‘struct AVHWFramesContext *’ but argument is of type ‘AVHWFramesContext *’
/src/SDL/test/testffmpeg_vulkan.c: In function ‘FinishVulkanFrameRendering’:
/src/SDL/test/testffmpeg_vulkan.c:885:22: warning: passing argument 1 of ‘vk->unlock_frame’ from incompatible pointer type [-Wincompatible-pointer-types]
  885 |     vk->unlock_frame(frames, pVkFrame);
      |                      ^~~~~~
      |                      |
      |                      AVHWFramesContext *
/src/SDL/test/testffmpeg_vulkan.c:885:22: note: expected ‘struct AVHWFramesContext *’ but argument is of type ‘AVHWFramesContext *’
```

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
