### PR TITLE
PSP: improve performance counter res to us granularity

### DIFF
--- a/src/timer/psp/SDL_systimer.c
+++ b/src/timer/psp/SDL_systimer.c
@@ -30,35 +30,21 @@
 #include <time.h>
 #include <sys/time.h>
 #include <pspthreadman.h>
-
-static struct timeval start;
-static SDL_bool ticks_started = SDL_FALSE;
+#include <psprtc.h>
 
 void SDL_TicksInit(void)
 {
-    if (ticks_started) {
-        return;
-    }
-    ticks_started = SDL_TRUE;
-
-    gettimeofday(&start, NULL);
 }
 
 void SDL_TicksQuit(void)
 {
-    ticks_started = SDL_FALSE;
 }
 
 Uint64 SDL_GetTicks64(void)
 {
-    struct timeval now;
-
-    if (!ticks_started) {
-        SDL_TicksInit();
-    }
-
-    gettimeofday(&now, NULL);
-    return (Uint64)(((Sint64)(now.tv_sec - start.tv_sec) * 1000) + ((now.tv_usec - start.tv_usec) / 1000));
+    Uint64 ticks;
+    sceRtcGetCurrentTick(&ticks);
+    return ticks;
 }
 
 Uint64 SDL_GetPerformanceCounter(void)
@@ -68,7 +54,7 @@ Uint64 SDL_GetPerformanceCounter(void)
 
 Uint64 SDL_GetPerformanceFrequency(void)
 {
-    return 1000;
+    return sceRtcGetTickResolution();
 }
 
 void SDL_Delay(Uint32 ms)


### PR DESCRIPTION
currently the granularity of the PSP tickcounter is only millisecond based,
however almost all of te PSP APIs work on microsecond granularity.
this change allows more precise timing measurements.
