### PR TITLE
Revert "video: Prefer Wayland over X11 (take 2!)"

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -69,11 +69,17 @@ static VideoBootStrap *bootstrap[] = {
 #ifdef SDL_VIDEO_DRIVER_COCOA
     &COCOA_bootstrap,
 #endif
-#ifdef SDL_VIDEO_DRIVER_WAYLAND
-    &Wayland_bootstrap,
-#endif
+/*
+ * Prefer X11 over Wayland for now until fifo-v1 + commit-timing-v1 are released
+ * and available in compositors otherwise we will suffer large performance/frame pacing
+ * regressions in GPU-bound apps or when the window is obscured when the application is
+ * using FIFO (vsync).
+ */
 #ifdef SDL_VIDEO_DRIVER_X11
     &X11_bootstrap,
+#endif
+#ifdef SDL_VIDEO_DRIVER_WAYLAND
+    &Wayland_bootstrap,
 #endif
 #ifdef SDL_VIDEO_DRIVER_VIVANTE
     &VIVANTE_bootstrap,
@@ -4904,11 +4910,11 @@ int SDL_GetMessageBoxCount(void)
 #ifdef SDL_VIDEO_DRIVER_UIKIT
 #include "uikit/SDL_uikitmessagebox.h"
 #endif
-#ifdef SDL_VIDEO_DRIVER_WAYLAND
-#include "wayland/SDL_waylandmessagebox.h"
-#endif
 #ifdef SDL_VIDEO_DRIVER_X11
 #include "x11/SDL_x11messagebox.h"
+#endif
+#ifdef SDL_VIDEO_DRIVER_WAYLAND
+#include "wayland/SDL_waylandmessagebox.h"
 #endif
 #ifdef SDL_VIDEO_DRIVER_HAIKU
 #include "haiku/SDL_bmessagebox.h"


### PR DESCRIPTION
## Description

This reverts commit f9f7db4e086036bd8ef3bce0f303e9057ee63040

Wayland has a myriad of unresolved problems regarding surface suspension blocking presentation and the FIFO (vsync) implementation being fundamentally broken leading to reduced GPU-bound performance.

That is not to say "we should fix FIFO in Mesa/other drivers," but rather that it is completely unfixable without an additional protocol, in this case fifo-v1[1].

Without this protocol, vkQueuePresent or glSwapBuffers *must* stall for the 'frame' callback after presenting an image. The only reason we can get away with this on SteamOS is because Gamescope implements what is essentially fifo-v1 and we use that there.

The other side is surface suspension -- a very similar issue to the above wrt the frame callback being used in that way and blocking. If the SDL window is obscured, vkQueuePresent *will* block in FIFO, which games typically do NOT like. This is solved by the combination of fifo-v1 and commit-timing-v1.

There is no advantage to games and average applications preferring Wayland over X11 -- only severe performance and unusability regressions right now.
Thus, we must revert this change until fifo-v1 and commit-timing-v1 are released and at least in a stable release for major compositors.

[1]: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/256
