### PR TITLE
PSP: send initial SDL_JOYDEVICEADDED event

### DIFF
--- a/src/joystick/psp/SDL_sysjoystick.c
+++ b/src/joystick/psp/SDL_sysjoystick.c
@@ -96,6 +96,9 @@ static int PSP_JoystickInit(void)
         analog_map[127 - i] = -1 * analog_map[i + 128];
     }
 
+    /* Fire off a joystick add event */
+    SDL_PrivateJoystickAdded(0);
+
     return 1;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
At the moment no joystick add event is created on the PSP when the controls are initialized. This can cause issues in some games.

## Description
<!--- Describe your changes in detail -->
This change makes sure the event is created when controls are initialized. The controls on the PSP are not hotpluggable at all, so this solution should be good enough. I've done some testing with it and it solves the problem.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
