### PR TITLE
linux/SDL_system_theme.c: fix an include path

### DIFF
--- a/src/core/linux/SDL_system_theme.c
+++ b/src/core/linux/SDL_system_theme.c
@@ -22,7 +22,7 @@
 
 #include "SDL_dbus.h"
 #include "SDL_system_theme.h"
-#include "../SDL_sysvideo.h"
+#include "../../video/SDL_sysvideo.h"
 
 #include <unistd.h>
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Fix an include path.

```
src/core/linux/SDL_system_theme.c:25:10: error: '../SDL_sysvideo.h' file not found             
#include "../SDL_sysvideo.h" 
```

Fwiw, I only noticed this when compiling with a non-cmake build system.

Files, for context:
```sh
$ fd SDL_sysvideo ; fd SDL_system_theme
src/video/SDL_sysvideo.h
src/core/linux/SDL_system_theme.c
src/core/linux/SDL_system_theme.h
```