### PR TITLE
Implicitly destroy renderers when the associated window is destroyed

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -3635,6 +3635,11 @@ void SDL_DestroyWindow(SDL_Window *window)
 
     SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_DESTROYED, 0, 0);
 
+    SDL_Renderer *renderer = SDL_GetRenderer(window);
+    if (renderer) {
+        SDL_DestroyRenderer(renderer);
+    }
+
     SDL_DestroyProperties(window->props);
 
     /* If this is a child window, unlink it from its siblings */

--- a/test/testautomation_video.c
+++ b/test/testautomation_video.c
@@ -55,7 +55,6 @@ static SDL_Window *createVideoSuiteTestWindow(const char *title)
              * so delay to give the window time to actually appear on the desktop.
              */
             SDL_Delay(100);
-            SDL_DestroyRenderer(renderer);
         } else {
             SDLTest_Log("Unable to create a renderer, some tests may fail on Wayland/XWayland");
         }
@@ -1736,7 +1735,6 @@ static int video_setWindowCenteredOnDisplay(void *arg)
                          * so delay to give the window time to actually appear on the desktop.
                          */
                         SDL_Delay(100);
-                        SDL_DestroyRenderer(renderer);
                     } else {
                         SDLTest_Log("Unable to create a renderer, tests may fail under Wayland");
                     }


### PR DESCRIPTION
Previously, renderers would be implicitly destroyed when their associated window was destroyed, a behavior that was lost when the old window userdata system was removed in favor of the property system. This behavior change isn't noted in any commits, so I'm guessing it was an oversight. This checks for and destroys an associated renderer when a window is destroyed, restoring the previous behavior.

This is the root cause of #9278 and otherwise caused renderer objects to be leaked when SDL_Quit() was called without them being explicitly cleaned up first.