### PR TITLE
windows: fixed rawinput crash

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -674,6 +674,8 @@ void WIN_PollRawInput(SDL_VideoDevice *_this)
     /* Relative mouse motion is delivered to the window with keyboard focus */
     window = SDL_GetKeyboardFocus();
     if (!window) {
+        // Clear the queue status so MsgWaitForMultipleObjects() will wait again
+        (void)GetQueueStatus(QS_RAWINPUT);
         return;
     }
     data = window->driverdata;

--- a/src/video/windows/SDL_windowsrawinput.c
+++ b/src/video/windows/SDL_windowsrawinput.c
@@ -81,9 +81,6 @@ static DWORD WINAPI WIN_RawInputThread(LPVOID param)
             break;
         }
 
-        /* Clear the queue status so MsgWaitForMultipleObjects() will wait again */
-        (void)GetQueueStatus(QS_RAWINPUT);
-
         WIN_PollRawInput(_this);
     }
 

--- a/src/video/windows/SDL_windowswindow.h
+++ b/src/video/windows/SDL_windowswindow.h
@@ -70,7 +70,7 @@ struct SDL_WindowData
     UINT windowed_mode_corner_rounding;
     COLORREF dwma_border_color;
 #if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
-    RAWINPUT *rawinput;
+    BYTE *rawinput;
     UINT rawinput_offset;
     UINT rawinput_size;
     UINT rawinput_count;


### PR DESCRIPTION
RAWINPUT structures are variable size

Multiplying size by 8 is important when reallocating the rawinput buffer