### PR TITLE
video: Cleanup renderers when shutting down the video system (take 2)

### DIFF
--- a/src/render/SDL_sysrender.h
+++ b/src/render/SDL_sysrender.h
@@ -289,6 +289,8 @@ struct SDL_Renderer
     SDL_PropertiesID props;
 
     void *driverdata;
+
+    SDL_Renderer *prev, *next;
 };
 
 /* Define the SDL render driver structure */
@@ -333,6 +335,9 @@ extern SDL_BlendOperation SDL_GetBlendModeAlphaOperation(SDL_BlendMode blendMode
    for a vertex buffer during RunCommandQueue(). Pointers returned here are only valid until
    the next call, because it might be in an array that gets realloc()'d. */
 extern void *SDL_AllocateRenderVertices(SDL_Renderer *renderer, const size_t numbytes, const size_t alignment, size_t *offset);
+
+/* Clean up any remaining renderers on quit. */
+extern void SDL_QuitRenderer();
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -34,6 +34,7 @@
 #include "../SDL_properties_c.h"
 #include "../timer/SDL_timer_c.h"
 #include "../camera/SDL_camera_c.h"
+#include "../render/SDL_sysrender.h"
 
 #ifdef SDL_VIDEO_OPENGL
 #include <SDL3/SDL_opengl.h>
@@ -3635,11 +3636,6 @@ void SDL_DestroyWindow(SDL_Window *window)
 
     SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_DESTROYED, 0, 0);
 
-    SDL_Renderer *renderer = SDL_GetRenderer(window);
-    if (renderer) {
-        SDL_DestroyRenderer(renderer);
-    }
-
     SDL_DestroyProperties(window->props);
 
     /* If this is a child window, unlink it from its siblings */
@@ -3789,6 +3785,9 @@ void SDL_VideoQuit(void)
     SDL_QuitSubSystem(SDL_INIT_EVENTS);
 
     SDL_EnableScreenSaver();
+
+    /* Clean up any renderers */
+    SDL_QuitRenderer();
 
     /* Clean up the system video */
     while (_this->windows) {

--- a/test/testautomation_video.c
+++ b/test/testautomation_video.c
@@ -55,6 +55,7 @@ static SDL_Window *createVideoSuiteTestWindow(const char *title)
              * so delay to give the window time to actually appear on the desktop.
              */
             SDL_Delay(100);
+            SDL_DestroyRenderer(renderer);
         } else {
             SDLTest_Log("Unable to create a renderer, some tests may fail on Wayland/XWayland");
         }
@@ -1735,6 +1736,7 @@ static int video_setWindowCenteredOnDisplay(void *arg)
                          * so delay to give the window time to actually appear on the desktop.
                          */
                         SDL_Delay(100);
+                        SDL_DestroyRenderer(renderer);
                     } else {
                         SDLTest_Log("Unable to create a renderer, tests may fail under Wayland");
                     }


### PR DESCRIPTION
Track and remove any remaining renderers when shutting down the video system, or they will be leaked and prevent the renderer backends from properly shutting down.

Rework of 8f14fa11

The implicit renderer destruction that I was previously seeing was happening because the software renderer was creating a secondary renderer for presentation purposes, and the secondary presentation renderer was being destroyed with the window. This achieves the same end result of cleaning up any existing renderers when the video system is being shut down, such as from a sudden SDL_Quit() call, but otherwise leaves renderer object lifetime up to the application, which is the previously existing behavior, as there is technically nothing wrong with an application destroying a window before its associated renderer.