### PR TITLE
video: Document that renderer lifetimes are tied to their associated …

### DIFF
--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -2020,6 +2020,10 @@ extern DECLSPEC void SDLCALL SDL_DestroyTexture(SDL_Texture *texture);
  * If `renderer` is NULL, this function will return immediately after setting
  * the SDL error message to "Invalid renderer". See SDL_GetError().
  *
+ * Note that destroying a window implicitly destroys the associated renderer,
+ * so this should not be called if the window associated with the renderer has
+ * already been destroyed.
+ *
  * \param renderer the rendering context
  *
  * \since This function is available since SDL 3.0.0.

--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -2110,7 +2110,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowShape(SDL_Window *window, SDL_Surface *
 extern DECLSPEC int SDLCALL SDL_FlashWindow(SDL_Window *window, SDL_FlashOperation operation);
 
 /**
- * Destroy a window.
+ * Destroy a window. If the window has an associated SDL_Renderer, it will be implicitly destroyed as well.
  *
  * If `window` is NULL, this function will return immediately after setting
  * the SDL error message to "Invalid window". See SDL_GetError().


### PR DESCRIPTION
…windows

Destroying a renderer after the window it is associated with has always had problems (e.g. destroying a window decrements the GL refcount->GL is unloaded->destroying a GL renderer crashes because it tried to call unloaded GL functions), this just makes it official that renderers shouldn't be manually destroyed if the window they are associated with has already been destroyed.