### PR TITLE
Fix caps/num/scroll lock keys getting out of sync with keyboard

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1147,7 +1147,13 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
             }
         }
 
-        if (!data->videodata->raw_keyboard_enabled && code != SDL_SCANCODE_UNKNOWN) {
+        /* Ignore auto-repeat keys from the Caps Lock, Num Lock and Scroll Lock keys,
+         * otherwise the toggle states will get out of sync with physical keyboard state.
+         */
+        SDL_bool isToggleKey = wParam == VK_CAPITAL || wParam == VK_NUMLOCK || wParam == VK_SCROLL;
+        SDL_bool isRepeat = (lParam & (1 << 30)) != 0;
+
+        if (!data->videodata->raw_keyboard_enabled && code != SDL_SCANCODE_UNKNOWN && !(isToggleKey && isRepeat)) {
             SDL_SendKeyboardKey(WIN_GetEventTimestamp(), SDL_GLOBAL_KEYBOARD_ID, SDL_PRESSED, code);
         }
     }


### PR DESCRIPTION
## Description
If you hold down one of these toggle keys on Windows, the auto-repeat WM_KEYDOWN messages send extra SDL events, which toggle SDL's internal toggle state for these keys and cause the SDL toggle state to get out of sync with the physical keyboard state 50% of the time.

The fix is to ignore the repeat WM_KEYDOWN messages for these toggle keys.

I didn't check whether the same change is needed in the WIN_KeyboardHookProc case, or if other platforms might have the same problem