### PR TITLE
SDL_stdinc.h: Android passes sizeof(ENUM) == sizeof(int) assertion

### DIFF
--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -380,8 +380,8 @@ SDL_COMPILE_TIME_ASSERT(sint64, sizeof(Sint64) == 8);
 
 /** \cond */
 #ifndef DOXYGEN_SHOULD_IGNORE_THIS
-#if !defined(SDL_PLATFORM_ANDROID) && !defined(SDL_PLATFORM_VITA) && !defined(SDL_PLATFORM_3DS)
-   /* TODO: include/SDL_stdinc.h:174: error: size of array 'SDL_dummy_enum' is negative */
+#if !defined(SDL_PLATFORM_VITA) && !defined(SDL_PLATFORM_3DS)
+/* TODO: include/SDL_stdinc.h:390: error: size of array 'SDL_dummy_enum' is negative */
 typedef enum
 {
     DUMMY_ENUM_VALUE


### PR DESCRIPTION
Reference issue: https://github.com/libsdl-org/SDL/issues/9392 .

Android builds do survive the assertion, so I guess we can do this?

Maybe even in SDL2 assuming this one goes in SDL3 ??