### PR TITLE
Fix 'SyntaxWarning: invalid escape sequence' when running `gendynapi.py`

### DIFF
--- a/src/dynapi/gendynapi.py
+++ b/src/dynapi/gendynapi.py
@@ -55,14 +55,14 @@ def main():
     # Get list of SDL headers
     sdl_list_includes = get_header_list()
 
-    reg_externC = re.compile('.*extern[ "]*C[ "].*')
-    reg_comment_remove_content = re.compile('\/\*.*\*/')
-    reg_parsing_function = re.compile('(.*SDLCALL[^\(\)]*) ([a-zA-Z0-9_]+) *\((.*)\) *;.*')
+    reg_externC = re.compile(r'.*extern[ "]*C[ "].*')
+    reg_comment_remove_content = re.compile(r'\/\*.*\*/')
+    reg_parsing_function = re.compile(r'(.*SDLCALL[^\(\)]*) ([a-zA-Z0-9_]+) *\((.*)\) *;.*')
 
     #eg:
     # void (SDLCALL *callback)(void*, int)
     # \1(\2)\3
-    reg_parsing_callback = re.compile('([^\(\)]*)\(([^\(\)]+)\)(.*)')
+    reg_parsing_callback = re.compile(r'([^\(\)]*)\(([^\(\)]+)\)(.*)')
 
     for filename in sdl_list_includes:
         if args.debug:
@@ -160,13 +160,13 @@ def main():
             func = func.replace(" SDL_MALLOC", "");
             func = func.replace(" SDL_ALLOC_SIZE2(1, 2)", "");
             func = func.replace(" SDL_ALLOC_SIZE(2)", "");
-            func = re.sub(" SDL_ACQUIRE\(.*\)", "", func);
-            func = re.sub(" SDL_ACQUIRE_SHARED\(.*\)", "", func);
-            func = re.sub(" SDL_TRY_ACQUIRE\(.*\)", "", func);
-            func = re.sub(" SDL_TRY_ACQUIRE_SHARED\(.*\)", "", func);
-            func = re.sub(" SDL_RELEASE\(.*\)", "", func);
-            func = re.sub(" SDL_RELEASE_SHARED\(.*\)", "", func);
-            func = re.sub(" SDL_RELEASE_GENERIC\(.*\)", "", func);
+            func = re.sub(r" SDL_ACQUIRE\(.*\)", "", func);
+            func = re.sub(r" SDL_ACQUIRE_SHARED\(.*\)", "", func);
+            func = re.sub(r" SDL_TRY_ACQUIRE\(.*\)", "", func);
+            func = re.sub(r" SDL_TRY_ACQUIRE_SHARED\(.*\)", "", func);
+            func = re.sub(r" SDL_RELEASE\(.*\)", "", func);
+            func = re.sub(r" SDL_RELEASE_SHARED\(.*\)", "", func);
+            func = re.sub(r" SDL_RELEASE_GENERIC\(.*\)", "", func);
 
             # Should be a valid function here
             match = reg_parsing_function.match(func)
@@ -427,7 +427,7 @@ def check_comment():
 
 # Parse 'sdl_dynapi_procs_h' file to find existing functions
 def find_existing_procs():
-    reg = re.compile('SDL_DYNAPI_PROC\([^,]*,([^,]*),.*\)')
+    reg = re.compile(r'SDL_DYNAPI_PROC\([^,]*,([^,]*),.*\)')
     ret = []
     input = open(SDL_DYNAPI_PROCS_H)
 
@@ -444,7 +444,7 @@ def find_existing_procs():
 
 # Get list of SDL headers
 def get_header_list():
-    reg = re.compile('^.*\.h$')
+    reg = re.compile(r'^.*\.h$')
     ret = []
     tmp = os.listdir(SDL_INCLUDE_DIR)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Currently, running `gendynapi.py` with a recent python version produces multiple warnings about using invalid escape sequences in some regular expressions.

The solution to this problem is outlined in https://docs.python.org/3/library/re.html and is applied as such in this PR. I've checked that all escape sequences are invalid, and therefore won't be affected by using raw strings.

> The solution is to use Python’s raw string notation for regular expression patterns; backslashes are not handled in any special way in a string literal prefixed with `'r'`. So `r"\n"` is a two-character string containing `'\'` and `'n'`, while `"\n"` is a one-character string containing a newline. Usually patterns will be expressed in Python code using this raw string notation.

The warnings in question:

```py
❯ py -3.12 src\dynapi\gendynapi.py --dump
S:\code\SDL\src\dynapi\gendynapi.py:59: SyntaxWarning: invalid escape sequence '\/'
  reg_comment_remove_content = re.compile('\/\*.*\*/')
S:\code\SDL\src\dynapi\gendynapi.py:60: SyntaxWarning: invalid escape sequence '\('
  reg_parsing_function = re.compile('(.*SDLCALL[^\(\)]*) ([a-zA-Z0-9_]+) *\((.*)\) *;.*')
S:\code\SDL\src\dynapi\gendynapi.py:65: SyntaxWarning: invalid escape sequence '\('
  reg_parsing_callback = re.compile('([^\(\)]*)\(([^\(\)]+)\)(.*)')
S:\code\SDL\src\dynapi\gendynapi.py:163: SyntaxWarning: invalid escape sequence '\('
  func = re.sub(" SDL_ACQUIRE\(.*\)", "", func);
S:\code\SDL\src\dynapi\gendynapi.py:164: SyntaxWarning: invalid escape sequence '\('
  func = re.sub(" SDL_ACQUIRE_SHARED\(.*\)", "", func);
S:\code\SDL\src\dynapi\gendynapi.py:165: SyntaxWarning: invalid escape sequence '\('
  func = re.sub(" SDL_TRY_ACQUIRE\(.*\)", "", func);
S:\code\SDL\src\dynapi\gendynapi.py:166: SyntaxWarning: invalid escape sequence '\('
  func = re.sub(" SDL_TRY_ACQUIRE_SHARED\(.*\)", "", func);
S:\code\SDL\src\dynapi\gendynapi.py:167: SyntaxWarning: invalid escape sequence '\('
  func = re.sub(" SDL_RELEASE\(.*\)", "", func);
S:\code\SDL\src\dynapi\gendynapi.py:168: SyntaxWarning: invalid escape sequence '\('
  func = re.sub(" SDL_RELEASE_SHARED\(.*\)", "", func);
S:\code\SDL\src\dynapi\gendynapi.py:169: SyntaxWarning: invalid escape sequence '\('
  func = re.sub(" SDL_RELEASE_GENERIC\(.*\)", "", func);
S:\code\SDL\src\dynapi\gendynapi.py:430: SyntaxWarning: invalid escape sequence '\('
  reg = re.compile('SDL_DYNAPI_PROC\([^,]*,([^,]*),.*\)')
S:\code\SDL\src\dynapi\gendynapi.py:447: SyntaxWarning: invalid escape sequence '\.'
  reg = re.compile('^.*\.h$')
dump API to 'sdl.json'
done!
```
