### PR TITLE
cmake: disable SYSTEM property on exported SDL targets

### DIFF
--- a/.github/workflows/psp.yml
+++ b/.github/workflows/psp.yml
@@ -16,10 +16,6 @@ jobs:
       run: |
         apk update
         apk add cmake gmp mpc1 mpfr4 make pkgconf
-    - name: Patch the pspdev toolchain to use -isystem instead of -I
-      run: |
-        # https://github.com/pspdev/pspsdk/issues/123
-        sed -E s/-I/-isystem/g -i $PSPDEV/psp/share/pspdev.cmake
     - name: Configure (CMake)
       run: |
         cmake -S . -B build \

--- a/.github/workflows/psp.yml
+++ b/.github/workflows/psp.yml
@@ -16,6 +16,21 @@ jobs:
       run: |
         apk update
         apk add cmake gmp mpc1 mpfr4 make pkgconf
+    - name: Pollute PSP SDK with "bad" SDL headers
+      run: |
+        # Create "bad" SDL headers in the PSP SDK.
+        # SDL sources should not use these. 
+        infixes=". psp psp/sdk"
+        for infix in $infixes; do
+          directory="$PSPDEV/$infix/include/SDL3"
+          echo "Creating directory $directory"
+          mkdir -p "$directory"
+          for include in include/SDL3/*.h; do
+            dest="$PSPDEV/$infix/include/SDL3/$(basename "$include")"
+            echo "Creating $dest"
+            echo '#error "System SDL headers must not be used by build system"' >"$dest"
+          done
+        done
     - name: Configure (CMake)
       run: |
         cmake -S . -B build \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3208,9 +3208,10 @@ endif()
 
 add_library(SDL3_Headers INTERFACE)
 add_library(SDL3::Headers ALIAS SDL3_Headers)
-set_target_properties(SDL3_Headers PROPERTIES
-  EXPORT_NAME "Headers"
-)
+set_property(TARGET SDL3_Headers PROPERTY EXPORT_NAME "Headers")
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.25")
+  set_property(TARGET SDL3_Headers PROPERTY EXPORT_NO_SYSTEM "TRUE")
+endif()
 target_include_directories(SDL3_Headers
   INTERFACE
     "$<BUILD_INTERFACE:${SDL3_BINARY_DIR}/include>"


### PR DESCRIPTION
CMake automatically sets the `SYSTEM` property on imported targets.
This pr disables that such that a project using SDL from a non-system SDL prefix will not accidentally use headers from a system SDL prefix.
This might be an issue for projects doing `#include "SDL.h"` instead of `#include <SDL.h>`.

This pr also tests this by "polluting" the psp prefix with bad SDL headers that should not be used in any situation.

Finally, this pr also removes a psp fix that has been fixed upstream.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
