### PR TITLE
Disable SDL dialogs for tvOS and iOS

### DIFF
--- a/src/dialog/cocoa/SDL_cocoadialog.m
+++ b/src/dialog/cocoa/SDL_cocoadialog.m
@@ -20,8 +20,6 @@
 */
 #include "SDL_internal.h"
 
-/* TODO: Macro? */
-
 #import <Cocoa/Cocoa.h>
 
 typedef enum
@@ -33,6 +31,10 @@ typedef enum
 
 void show_file_dialog(cocoa_FileDialogType type, SDL_DialogFileCallback callback, void* userdata, SDL_Window* window, const SDL_DialogFileFilter *filters, const char* default_location, SDL_bool allow_many)
 {
+#if defined(SDL_PLATFORM_TVOS) || defined(SDL_PLATFORM_IOS)
+    SDL_SetError("tvOS and iOS don't support path-based file dialogs");
+    callback(userdata, NULL, -1);
+#else
     /* NSOpenPanel inherits from NSSavePanel */
     NSSavePanel *dialog;
     NSOpenPanel *dialog_as_open;
@@ -151,6 +153,7 @@ void show_file_dialog(cocoa_FileDialogType type, SDL_DialogFileCallback callback
             callback(userdata, files, -1);
         }
     }
+#endif // defined(SDL_PLATFORM_TVOS) || defined(SDL_PLATFORM_IOS)
 }
 
 void SDL_ShowOpenFileDialog(SDL_DialogFileCallback callback, void* userdata, SDL_Window* window, const SDL_DialogFileFilter *filters, const char* default_location, SDL_bool allow_many)

--- a/src/dialog/dummy/SDL_dummydialog.c
+++ b/src/dialog/dummy/SDL_dummydialog.c
@@ -20,8 +20,6 @@
 */
 #include "SDL_internal.h"
 
-/* TODO: Macro? */
-
 void SDL_ShowOpenFileDialog(SDL_DialogFileCallback callback, void* userdata, SDL_Window* window, const SDL_DialogFileFilter *filters, const char* default_location, SDL_bool allow_many)
 {
   SDL_Unsupported();

--- a/src/dialog/windows/SDL_windowsdialog.c
+++ b/src/dialog/windows/SDL_windowsdialog.c
@@ -20,9 +20,6 @@
 */
 #include "SDL_internal.h"
 
-/* TODO: Macro? */
-
-/* TODO: Better includes? */
 #include <windows.h>
 #include <shlobj.h>
 #include "../../core/windows/SDL_windows.h"


### PR DESCRIPTION
## Description
As stated in #9321, neither tvOS nor iOS support direct file dialogs. This PR disables their use on those platforms.

I also took the opportunity to remove the various `/* TODO: macro? */` that I left in the code, since the build system ended up not needing macros.

## Existing Issue(s)
Fixes #9321
