### PR TITLE
Fix return value of WIN_GetMonitorPathInfo

### DIFF
--- a/src/video/windows/SDL_windowsmodes.c
+++ b/src/video/windows/SDL_windowsmodes.c
@@ -407,7 +407,7 @@ static SDL_bool WIN_GetMonitorPathInfo(HMONITOR hMonitor, DISPLAYCONFIG_PATH_INF
 
     do {
         if (GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &num_path_array_elements, &num_mode_info_array_elements) != ERROR_SUCCESS) {
-            return -1;
+            return SDL_FALSE;
         }
 
         new_path_infos = (DISPLAYCONFIG_PATH_INFO *)SDL_realloc(path_infos, num_path_array_elements * sizeof(*path_infos));


### PR DESCRIPTION
## Description
WIN_GetMonitorPathInfo() returns a bool, not an int.

## Existing Issue(s)
None
