### PR TITLE
Do not store pointer before potentialy freeing it

### DIFF
--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -388,8 +388,6 @@ static int SetupWindowData(SDL_VideoDevice *_this, SDL_Window *window, HWND hwnd
 
     SDL_AddHintCallback(SDL_HINT_MOUSE_RELATIVE_MODE_CENTER, WIN_MouseRelativeModeCenterChanged, data);
 
-    window->driverdata = data;
-
 #if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
     /* Associate the data with the window */
     if (!SetProp(hwnd, TEXT("SDL_WindowData"), data)) {
@@ -398,6 +396,8 @@ static int SetupWindowData(SDL_VideoDevice *_this, SDL_Window *window, HWND hwnd
         return WIN_SetError("SetProp() failed");
     }
 #endif
+    
+    window->driverdata = data;
 
     /* Set up the window proc function */
 #ifdef GWLP_WNDPROC


### PR DESCRIPTION
## Description
Store `data` to `windows->driverdata` after call to `SetProp()` in case it fails.

## Existing Issue(s)
None
