### PR TITLE
Don't change cwd with file dialogs

### DIFF
--- a/src/dialog/windows/SDL_windowsdialog.c
+++ b/src/dialog/windows/SDL_windowsdialog.c
@@ -189,7 +189,7 @@ void windows_ShowFileDialog(void *ptr)
     dialog.nMaxFileTitle = MAX_PATH;
     dialog.lpstrInitialDir = *initfolder ? initfolder : NULL;
     dialog.lpstrTitle = NULL;
-    dialog.Flags = flags | OFN_EXPLORER | OFN_HIDEREADONLY;
+    dialog.Flags = flags | OFN_EXPLORER | OFN_HIDEREADONLY | OFN_NOCHANGEDIR;
     dialog.nFileOffset = 0;
     dialog.nFileExtension = 0;
     dialog.lpstrDefExt = NULL;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add a flag for file dialogs on Windows to not change the current working directory of the application that invokes it.

## Description
<!--- Describe your changes in detail -->
Windows changes the working directory of the entire application if the file dialog went to a different folder. This does not make sense to me, but I'm open to opinions and willing to take this PR down if this is the intended behavior.

Also, maybe this can use properties, so I don't need to make another parameter alongside `allow_many`?

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
