### PR TITLE
Use `1u <<` when dealing with Uint32 and Uint16

### DIFF
--- a/include/SDL3/SDL_audio.h
+++ b/include/SDL3/SDL_audio.h
@@ -81,9 +81,9 @@ typedef Uint16 SDL_AudioFormat;
 /* @{ */
 
 #define SDL_AUDIO_MASK_BITSIZE       (0xFF)
-#define SDL_AUDIO_MASK_FLOAT         (1<<8)
-#define SDL_AUDIO_MASK_BIG_ENDIAN    (1<<12)
-#define SDL_AUDIO_MASK_SIGNED        (1<<15)
+#define SDL_AUDIO_MASK_FLOAT         (1u<<8)
+#define SDL_AUDIO_MASK_BIG_ENDIAN    (1u<<12)
+#define SDL_AUDIO_MASK_SIGNED        (1u<<15)
 #define SDL_AUDIO_BITSIZE(x)         ((x) & SDL_AUDIO_MASK_BITSIZE)
 #define SDL_AUDIO_BYTESIZE(x)        (SDL_AUDIO_BITSIZE(x) / 8)
 #define SDL_AUDIO_ISFLOAT(x)         ((x) & SDL_AUDIO_MASK_FLOAT)

--- a/include/SDL3/SDL_haptic.h
+++ b/include/SDL3/SDL_haptic.h
@@ -184,7 +184,7 @@ typedef struct SDL_Haptic SDL_Haptic;
  *
  *  \sa SDL_HapticPeriodic
  */
-#define SDL_HAPTIC_SQUARE       (1<<2)
+#define SDL_HAPTIC_SQUARE       (1u<<2)
 
 /**
  *  Triangle wave effect supported.

--- a/include/SDL3/SDL_joystick.h
+++ b/include/SDL3/SDL_joystick.h
@@ -374,9 +374,9 @@ typedef struct SDL_VirtualJoystickDesc
     Uint16 product_id;  /**< the USB product ID of this joystick */
     Uint16 padding;     /**< unused */
     Uint32 button_mask; /**< A mask of which buttons are valid for this controller
-                             e.g. (1 << SDL_GAMEPAD_BUTTON_SOUTH) */
+                             e.g. (1u << SDL_GAMEPAD_BUTTON_SOUTH) */
     Uint32 axis_mask;   /**< A mask of which axes are valid for this controller
-                             e.g. (1 << SDL_GAMEPAD_AXIS_LEFTX) */
+                             e.g. (1u << SDL_GAMEPAD_AXIS_LEFTX) */
     const char *name;   /**< the name of the joystick */
 
     void *userdata;     /**< User data pointer passed to callbacks */

--- a/include/SDL3/SDL_mouse.h
+++ b/include/SDL3/SDL_mouse.h
@@ -513,7 +513,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_CursorVisible(void);
  * - Button 2:  Middle mouse button
  * - Button 3:  Right mouse button
  */
-#define SDL_BUTTON(X)       (1 << ((X)-1))
+#define SDL_BUTTON(X)       (1u << ((X)-1))
 #define SDL_BUTTON_LEFT     1
 #define SDL_BUTTON_MIDDLE   2
 #define SDL_BUTTON_RIGHT    3

--- a/include/SDL3/SDL_pen.h
+++ b/include/SDL3/SDL_pen.h
@@ -95,7 +95,7 @@ typedef enum
 #define SDL_PEN_FLAG_ERASER_BIT_INDEX 15 /* Bit for storing is-eraser or has-eraser-capability property */
 #define SDL_PEN_FLAG_AXIS_BIT_OFFSET  16 /* Bit for storing has-axis-0 property */
 
-#define SDL_PEN_CAPABILITY(capbit)    (1ul << (capbit))
+#define SDL_PEN_CAPABILITY(capbit)    (1u << (capbit))
 #define SDL_PEN_AXIS_CAPABILITY(axis) SDL_PEN_CAPABILITY((axis) + SDL_PEN_FLAG_AXIS_BIT_OFFSET)
 
 /**

--- a/test/testautomation_pen.c
+++ b/test/testautomation_pen.c
@@ -587,14 +587,14 @@ _pen_simulate(simulated_pen_action *steps, int *step_counter, SDL_Pen *simulated
         case SIMPEN_ACTION_DOWN:
             simpen->last.buttons |= SDL_PEN_DOWN_MASK;
             SDLTest_AssertCheck(SDL_SendPenTipEvent(0, simpen->header.id, SDL_PRESSED),
-                                "SIMPEN_ACTION_DOWN [pen %d]: (mask %lx)", step.pen_index, SDL_PEN_DOWN_MASK);
+                                "SIMPEN_ACTION_DOWN [pen %d]: (mask %x)", step.pen_index, SDL_PEN_DOWN_MASK);
             done = SDL_TRUE;
             break;
 
         case SIMPEN_ACTION_UP:
             simpen->last.buttons &= ~SDL_PEN_DOWN_MASK;
             SDLTest_AssertCheck(SDL_SendPenTipEvent(0, simpen->header.id, SDL_RELEASED),
-                                "SIMPEN_ACTION_UP [pen %d]: (mask %lx)", step.pen_index, ~SDL_PEN_DOWN_MASK);
+                                "SIMPEN_ACTION_UP [pen %d]: (mask %x)", step.pen_index, ~SDL_PEN_DOWN_MASK);
             done = SDL_TRUE;
             break;
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Changes `#define`s which define constants commonly used with unsigned integers to use `1u << x` instead of `1 << x` or `1ul << x`.

Helps with generating bindings, as `1u` seems to be platform-agnostic, while `1ul` has platform defined width (at least when using ClangSharp on windows).

Main inspiration is `SDL_haptic.h` definitions (of which `SDL_HAPTIC_SQUARE` was missed!)
