### PR TITLE
Vulkan Renderer - fix crash with imgui SDL3 renderer

### DIFF
--- a/src/render/vulkan/SDL_render_vulkan.c
+++ b/src/render/vulkan/SDL_render_vulkan.c
@@ -3146,6 +3146,8 @@ static SDL_bool VULKAN_UpdateVertexBuffer(SDL_Renderer *renderer,
     }
     /* If the existing vertex buffer isn't big enough, we need to recreate a big enough one */
     if (dataSizeInBytes > rendererData->vertexBuffers[vbidx].size) {
+        VULKAN_IssueBatch(rendererData);
+        VULKAN_WaitForGPU(rendererData);
         VULKAN_CreateVertexBuffer(rendererData, vbidx, dataSizeInBytes);
     }
 


### PR DESCRIPTION
When the vertex buffer size is exceeed, make sure to wait for outstanding work before resizing it.  This fixes validation errors/crash found with using Imgui SDL3 renderer on Vulkan.  Closes #9385. 

