### PR TITLE
Add SDLTest_CompareMemory function to compare memory ranges

### DIFF
--- a/include/SDL3/SDL_test_compare.h
+++ b/include/SDL3/SDL_test_compare.h
@@ -55,6 +55,19 @@ extern "C" {
  */
 int SDLTest_CompareSurfaces(SDL_Surface *surface, SDL_Surface *referenceSurface, int allowable_error);
 
+/**
+ * Compares 2 memory blocks for equality
+ *
+ * \param actual Memory used in comparison, displayed on the left
+ * \param size_actual Size of actual in bytes
+ * \param reference Reference memory, displayed on the right
+ * \param size_reference Size of reference in bytes
+ *
+ * \returns 0 if the left and right memory block are equal, non-zero if they are non-equal.
+ *
+ * \since This function is available since SDL 3.0.0.
+ */
+extern int SDLTest_CompareMemory(const void *actual, size_t size_actual, const void *reference, size_t size_reference);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus


### PR DESCRIPTION
When 2 memory blocks are not equal, this prints a xxd-style hexdump.
The hexdumps don't contain color codes because these show up in the raw github logs.

For example:
```
INFO:  04/03/24 02:36:57: Assert 'Sizes of memory blocks must be equal (256 == 256)': Passed
ERROR: 04/03/24 02:22:53: Assert 'Memory blocks contains the same data': Failed
ERROR: 04/03/24 02:22:53: 0000000000000000 42 4d 52 0e 01 00 00 00 00 00 2a 04 00 00 28 00 BMR.......*...(. | 2e 00 16 54 08 00 38 22 48 00 08 0a 14 00 62 42 ...T..8"H.....bB
ERROR: 04/03/24 02:22:53: 0000000000000010 00 00 98 01 00 00 a7 00 00 00 01 00 08 00 00 00 ................ | 4c 00 3a 34 32 00 6a 52 4e 00 62 34 30 00 06 20 L.:42.jRN.b40.. 
ERROR: 04/03/24 02:22:53: 0000000000000020 00 00 28 0a 01 00 6d 0b 00 00 6d 0b 00 00 fd 00 ..(...m...m..... | 2e 00 22 3e 3e 00 06 14 14 00 14 0a 18 00 04 06 ..">>...........
ERROR: 04/03/24 02:22:53: 0000000000000030 00 00 fd 00 00 00 00 00 00 00 02 00 00 00 00 00 ................ | 20 00 6a 56 62 00 00 00 20 00 00 00 26 00 00 00  .jVb... ...&...
ERROR: 04/03/24 02:22:53: 0000000000000040 02 00 3c 22 00 00 a2 50 14 00 18 32 46 00 22 1a ..<"...P...2F.". | 18 00 00 00 14 00 00 00 1a 00 00 00 0c 00 00 02 ................
ERROR: 04/03/24 02:22:53: 0000000000000050 3c 00 00 84 3a 00 78 6a 62 00 22 16 16 00 60 44 <...:.xjb."...`D | 00 00 00 00 2c 00 62 00 6a 00 78 00 40 00 00 00 ....,.b.j.x.@...
ERROR: 04/03/24 02:22:53: 0000000000000060 40 00 30 9c 86 00 08 06 0a 00 70 a2 16 00 84 6a @.0.......p....j | 1c 00 10 00 24 00 82 00 28 00 5e 00 5e 00 60 00 ....$...(.^.^.`.
ERROR: 04/03/24 02:22:53: 0000000000000070 40 00 56 48 56 00 0e 60 12 00 46 32 48 00 02 04 @.VHV..`..F2H... | 34 00 04 00 06 00 14 00 00 00 2e 00 30 00 14 00 4...........0...
ERROR: 04/03/24 02:22:53: 0000000000000080 00 00 42 30 00 00 38 60 6e 00 16 14 1c 00 98 68 ..B0..8`n......h | 14 00 58 00 26 00 78 00 4e 00 04 00 12 00 16 00 ..X.&.x.N.......
ERROR: 04/03/24 02:22:53: 0000000000000090 0a 00 3c 20 18 00 72 30 0c 00 12 0c 2e 00 82 84 ..< ..r0........ | 32 00 84 00 34 00 7a 00 5c 00 36 00 14 00 20 00 2...4.z.\.6... .
ERROR: 04/03/24 02:22:53: 00000000000000a0 02 00 50 20 10 00 94 84 80 00 2c 82 80 00 12 26 ..P ......,....& | 3e 00 2c 00 24 00 42 00 44 00 04 00 16 00 6a 00 >.,.$.B.D.....j.
ERROR: 04/03/24 02:22:53: 00000000000000b0 3c 00 10 2a 06 00 36 6a 5c 00 74 16 6c 00 4c 40 <..*..6j\.t.l.L@ | 40 00 6a 00 4e 00 6c 00 18 00 8e 00 5c 00 58 00 @.j.N.l.....\.X.
ERROR: 04/03/24 02:22:53: 00000000000000c0 12 00 78 66 70 00 2a a0 18 00 40 34 3c 00 5c ba ..xfp.*...@4<.\. | 08 00 86 00 90 00 72 00 5c 00 36 00 02 00 14 00 ......r.\.6.....
ERROR: 04/03/24 02:22:53: 00000000000000d0 18 00 26 1c 2c 00 4e 52 10 00 a0 40 16 00 1a 34 ..&.,.NR...@...4 | 0c 00 76 00 74 00 12 00 1c 00 88 00 3e 00 8c 00 ..v.t.......>...
ERROR: 04/03/24 02:22:53: 00000000000000e0 2e 00 00 10 30 00 12 40 10 00 0c 22 08 00 28 2c ....0..@..."..(, | 4c 00 7c 00 6a 00 04 00 1c 00 00 00 32 00 06 04 L.|.j.......2...
ERROR: 04/03/24 02:22:53: 00000000000000f0 2e 00 24 36 3c 00 04 ba 9c 00 0a 72 42 00 58 2a ..$6<......rB.X* | 16 00 0a 18 28 00 58 ae 5a 00 38 28 30 00 04 0e ....(.X.Z.8(0...
```

This should be useful for comparing (compressed) files in the satellite libraries.
Right now [they print a byte per line](https://github.com/libsdl-org/SDL_image/actions/runs/8529489274/job/23365367054#step:18:400)

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
