### PR TITLE
File dialog improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2873,6 +2873,7 @@ elseif(N3DS)
 endif()
 
 if (SDL_DIALOG)
+  sdl_sources(${SDL3_SOURCE_DIR}/src/dialog/SDL_dialog_utils.c)
   if(UNIX AND NOT APPLE AND NOT RISCOS AND NOT HAIKU)
     sdl_sources(${SDL3_SOURCE_DIR}/src/dialog/unix/SDL_unixdialog.c)
     sdl_sources(${SDL3_SOURCE_DIR}/src/dialog/unix/SDL_portaldialog.c)

--- a/VisualC-GDK/SDL/SDL.vcxproj
+++ b/VisualC-GDK/SDL/SDL.vcxproj
@@ -507,6 +507,7 @@
     </ClCompile>
     <ClCompile Include="..\..\src\camera\dummy\SDL_camera_dummy.c" />
     <ClCompile Include="..\..\src\camera\SDL_camera.c" />
+    <ClCompile Include="..\..\src\dialog\SDL_dialog_utils.c" />
     <ClCompile Include="..\..\src\filesystem\SDL_filesystem.c" />
     <ClCompile Include="..\..\src\filesystem\windows\SDL_sysfsops.c" />
     <ClCompile Include="..\..\src\main\generic\SDL_sysmain_callbacks.c" />

--- a/VisualC-GDK/SDL/SDL.vcxproj.filters
+++ b/VisualC-GDK/SDL/SDL.vcxproj.filters
@@ -4,6 +4,9 @@
     <ClCompile Include="..\..\src\core\gdk\SDL_gdk.cpp" />
     <ClCompile Include="..\..\src\core\windows\pch.c" />
     <ClCompile Include="..\..\src\core\windows\pch_cpp.cpp" />
+    <ClCompile Include="..\..\src\dialog\SDL_dialog_utils.c">
+      <Filter>dialog</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\filesystem\SDL_filesystem.c">
       <Filter>filesystem</Filter>
     </ClCompile>

--- a/VisualC-WinRT/SDL-UWP.vcxproj
+++ b/VisualC-WinRT/SDL-UWP.vcxproj
@@ -315,6 +315,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="..\src\dialog\SDL_dialog_utils.c" />
     <ClCompile Include="..\src\events\SDL_clipboardevents.c" />
     <ClCompile Include="..\src\events\SDL_displayevents.c" />
     <ClCompile Include="..\src\events\SDL_dropevents.c" />

--- a/VisualC-WinRT/SDL-UWP.vcxproj.filters
+++ b/VisualC-WinRT/SDL-UWP.vcxproj.filters
@@ -31,6 +31,9 @@
     <Filter Include="time\windows">
       <UniqueIdentifier>{0000012051ca8361c8e1013aee1d0000}</UniqueIdentifier>
     </Filter>
+    <Filter Include="dialog">
+      <UniqueIdentifier>{0000c99bfadbbcb05a474a8472910000}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\SDL3\SDL_begin_code.h">
@@ -566,6 +569,9 @@
     </ClCompile>
     <ClCompile Include="..\src\cpuinfo\SDL_cpuinfo.c">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\dialog\SDL_dialog_utils.c">
+      <Filter>dialog</Filter>
     </ClCompile>
     <ClCompile Include="..\src\dynapi\SDL_dynapi.c">
       <Filter>Source Files</Filter>

--- a/VisualC/SDL/SDL.vcxproj
+++ b/VisualC/SDL/SDL.vcxproj
@@ -404,6 +404,7 @@
     <ClCompile Include="..\..\src\camera\dummy\SDL_camera_dummy.c" />
     <ClCompile Include="..\..\src\camera\mediafoundation\SDL_camera_mediafoundation.c" />
     <ClCompile Include="..\..\src\camera\SDL_camera.c" />
+    <ClCompile Include="..\..\src\dialog\SDL_dialog_utils.c" />
     <ClCompile Include="..\..\src\filesystem\SDL_filesystem.c" />
     <ClCompile Include="..\..\src\filesystem\windows\SDL_sysfsops.c" />
     <ClCompile Include="..\..\src\main\generic\SDL_sysmain_callbacks.c" />

--- a/VisualC/SDL/SDL.vcxproj.filters
+++ b/VisualC/SDL/SDL.vcxproj.filters
@@ -196,6 +196,9 @@
     <Filter Include="time\windows">
       <UniqueIdentifier>{0000d7fda065b13b0ca4ab262c380000}</UniqueIdentifier>
     </Filter>
+    <Filter Include="dialog">
+      <UniqueIdentifier>{00008dfdfa0190856fbf3c7db52d0000}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\SDL3\SDL_begin_code.h">
@@ -882,6 +885,9 @@
     </ClCompile>
     <ClCompile Include="..\..\src\camera\SDL_camera.c">
       <Filter>camera</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\dialog\SDL_dialog_utils.c">
+      <Filter>dialog</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\filesystem\SDL_filesystem.c">
       <Filter>filesystem</Filter>

--- a/Xcode/SDL/SDL.xcodeproj/project.pbxproj
+++ b/Xcode/SDL/SDL.xcodeproj/project.pbxproj
@@ -513,6 +513,7 @@
 		F3FA5A242B59ACE000FEAD97 /* yuv_rgb_lsx.h in Headers */ = {isa = PBXBuildFile; fileRef = F3FA5A1B2B59ACE000FEAD97 /* yuv_rgb_lsx.h */; };
 		F3FA5A252B59ACE000FEAD97 /* yuv_rgb_common.h in Headers */ = {isa = PBXBuildFile; fileRef = F3FA5A1C2B59ACE000FEAD97 /* yuv_rgb_common.h */; };
 		FA73671D19A540EF004122E4 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA73671C19A540EF004122E4 /* CoreVideo.framework */; platformFilters = (ios, maccatalyst, macos, tvos, watchos, ); };
+		0000140640E77F73F1DF0000 /* SDL_dialog_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 0000F6C6A072ED4E3D660000 /* SDL_dialog_utils.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1054,6 +1055,7 @@
 		F59C710600D5CB5801000001 /* SDL.info */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text; path = SDL.info; sourceTree = "<group>"; };
 		F5A2EF3900C6A39A01000001 /* BUGS.txt */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text; name = BUGS.txt; path = ../../BUGS.txt; sourceTree = SOURCE_ROOT; };
 		FA73671C19A540EF004122E4 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
+		0000F6C6A072ED4E3D660000 /* SDL_dialog_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = SDL_dialog_utils.c; path = SDL_dialog_utils.c; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2233,6 +2235,7 @@
 			children = (
 				F37E18552BA50ED50098C111 /* cocoa */,
 				F37E18562BA50F2A0098C111 /* dummy */,
+				0000F6C6A072ED4E3D660000 /* SDL_dialog_utils.c */,
 			);
 			path = dialog;
 			sourceTree = "<group>";
@@ -2872,6 +2875,7 @@
 				0000481D255AF155B42C0000 /* SDL_sysfsops.c in Sources */,
 				0000494CC93F3E624D3C0000 /* SDL_systime.c in Sources */,
 				000095FA1BDE436CF3AF0000 /* SDL_time.c in Sources */,
+				0000140640E77F73F1DF0000 /* SDL_dialog_utils.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/include/SDL3/SDL_dialog.h
+++ b/include/SDL3/SDL_dialog.h
@@ -36,7 +36,9 @@ extern "C" {
  * `name` is a user-readable label for the filter (for example, "Office document").
  *
  * `pattern` is a semicolon-separated list of file extensions (for example,
- * "doc;docx").
+ * "doc;docx"). File extensions may only contain alphanumeric characters,
+ * hyphens, underscores and periods. Alternatively, the whole string can be a
+ * single asterisk ("*"), which serves as an "All files" filter.
  *
  * \sa SDL_DialogFileCallback
  * \sa SDL_ShowOpenFileDialog

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -414,6 +414,26 @@ extern "C" {
 #define SDL_HINT_JOYSTICK_DIRECTINPUT "SDL_JOYSTICK_DIRECTINPUT"
 
 /**
+ * A variable that specifies a dialog backend to use.
+ *
+ * By default, SDL will try all available dialog backends in a reasonable order until it finds one that can work, but this hint allows the app or user to force a specific target.
+ *
+ * If the specified target does not exist or is not available, the dialog-related function calls will fail.
+ *
+ * This hint currently only applies to platforms using the generic "Unix" dialog implementation, but may be extended to more platforms in the future. Note that some Unix and Unix-like platforms have their own implementation, such as macOS and Haiku.
+ *
+ * The variable can be set to the following values:
+ *   NULL          - Select automatically (default, all platforms)
+ *   "portal"      - Use XDG Portals through DBus (Unix only)
+ *   "zenity"      - Use the Zenity program (Unix only)
+ *
+ * More options may be added in the future.
+ *
+ * This hint can be set anytime.
+ */
+#define SDL_HINT_FILE_DIALOG_DRIVER "SDL_FILE_DIALOG_DRIVER"
+
+/**
  * Override for SDL_GetDisplayUsableBounds()
  *
  * If set, this hint will override the expected results for SDL_GetDisplayUsableBounds() for display index 0. Generally you don't want to do this, but this allows an embedded system to request that some of the screen be reserved for other uses when paired with a well-behaved application.

--- a/src/dialog/SDL_dialog_utils.c
+++ b/src/dialog/SDL_dialog_utils.c
@@ -1,0 +1,237 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+#include "SDL_internal.h"
+
+#include "SDL_dialog_utils.h"
+
+char *convert_filters(const SDL_DialogFileFilter *filters, NameTransform ntf,
+                      const char *prefix, const char *separator,
+                      const char *suffix, const char *filt_prefix,
+                      const char *filt_separator, const char *filt_suffix,
+                      const char *ext_prefix, const char *ext_separator,
+                      const char *ext_suffix)
+{
+    char *combined;
+    char *new_combined;
+    char *converted;
+    const char *terminator;
+    int new_length;
+
+    combined = SDL_strdup(prefix);
+
+    if (!combined) {
+        SDL_OutOfMemory();
+        return NULL;
+    }
+
+    for (const SDL_DialogFileFilter *f = filters; f->name; f++) {
+        converted = convert_filter(*f, ntf, filt_prefix, filt_separator,
+                                   filt_suffix, ext_prefix, ext_separator,
+                                   ext_suffix);
+
+        if (!converted) {
+            return NULL;
+        }
+
+        terminator = f[1].name ? separator : suffix;
+        new_length = SDL_strlen(combined) + SDL_strlen(converted)
+                   + SDL_strlen(terminator);
+
+        new_combined = SDL_realloc(combined, new_length);
+
+        if (!new_combined) {
+            SDL_free(converted);
+            SDL_free(combined);
+            SDL_OutOfMemory();
+            return NULL;
+        }
+
+        combined = new_combined;
+
+        SDL_strlcat(combined, converted, new_length);
+        SDL_strlcat(combined, terminator, new_length);
+    }
+
+    return combined;
+}
+
+char *convert_filter(const SDL_DialogFileFilter filter, NameTransform ntf,
+                      const char *prefix, const char *separator,
+                      const char *suffix, const char *ext_prefix,
+                      const char *ext_separator, const char *ext_suffix)
+{
+    char *converted;
+    char *name_filtered;
+    int total_length;
+    char *list;
+
+    list = convert_ext_list(filter.pattern, ext_prefix, ext_separator,
+                            ext_suffix);
+
+    if (!list) {
+        return NULL;
+    }
+
+    if (ntf) {
+        name_filtered = ntf(filter.name);
+    } else {
+        /* Useless strdup, but easier to read and maintain code this way */
+        name_filtered = SDL_strdup(filter.name);
+    }
+
+    if (!name_filtered) {
+        SDL_free(list);
+        return NULL;
+    }
+
+    total_length = SDL_strlen(prefix) + SDL_strlen(name_filtered)
+                 + SDL_strlen(separator) + SDL_strlen(list)
+                 + SDL_strlen(suffix) + 1;
+
+    converted = (char *) SDL_malloc(total_length);
+
+    if (!converted) {
+        SDL_free(list);
+        SDL_free(name_filtered);
+        SDL_OutOfMemory();
+        return NULL;
+    }
+
+    SDL_snprintf(converted, total_length, "%s%s%s%s%s", prefix, name_filtered,
+                 separator, list, suffix);
+
+    SDL_free(list);
+    SDL_free(name_filtered);
+
+    return converted;
+}
+
+char *convert_ext_list(const char *list, const char *prefix,
+                       const char *separator, const char *suffix)
+{
+    char *converted;
+    int semicolons;
+    int total_length;
+
+    semicolons = 0;
+
+    for (const char *c = list; *c; c++) {
+        semicolons += (*c == ';');
+    }
+
+    total_length =
+        SDL_strlen(list) - semicolons /* length of list contents */
+      + semicolons * SDL_strlen(separator) /* length of separators */
+      + SDL_strlen(prefix) + SDL_strlen(suffix) /* length of prefix/suffix */
+      + 1; /* terminating null byte */
+
+    converted = (char *) SDL_malloc(total_length);
+
+    if (!converted) {
+        SDL_OutOfMemory();
+        return NULL;
+    }
+
+    *converted = '\0';
+
+    SDL_strlcat(converted, prefix, total_length);
+
+    /* Some platforms may prefer to handle the asterisk manually, but this
+       function offers to handle it for ease of use. */
+    if (SDL_strcmp(list, "*") == 0) {
+        SDL_strlcat(converted, "*", total_length);
+    } else {
+        for (const char *c = list; *c; c++) {
+            if ((*c >= 'a' && *c <= 'z') || (*c >= 'A' && *c <= 'Z')
+             || (*c >= '0' && *c <= '9') || *c == '-' || *c == '_'
+             || *c == '.') {
+                char str[2];
+                str[0] = *c;
+                str[1] = '\0';
+                SDL_strlcat(converted, str, total_length);
+            } else if (*c == ';') {
+                if (c == list || c[-1] == ';') {
+                    SDL_SetError("Empty pattern not allowed");
+                    SDL_free(converted);
+                    return NULL;
+                }
+
+                SDL_strlcat(converted, separator, total_length);
+            } else {
+                SDL_SetError("Invalid character '%c' in pattern (Only [a-zA-Z0-9_.-] allowed, or a single *)", *c);
+                SDL_free(converted);
+                return NULL;
+            }
+        }
+    }
+
+    if (list[SDL_strlen(list) - 1] == ';') {
+        SDL_SetError("Empty pattern not allowed");
+        SDL_free(converted);
+        return NULL;
+    }
+
+    SDL_strlcat(converted, suffix, total_length);
+
+    return converted;
+}
+
+const char *validate_filters(const SDL_DialogFileFilter *filters)
+{
+    if (filters) {
+        for (const SDL_DialogFileFilter *f = filters; f->name; f++) {
+             const char *msg = validate_list(f->pattern);
+
+             if (msg) {
+                 return msg;
+             }
+        }
+    }
+
+    return NULL;
+}
+
+const char *validate_list(const char *list)
+{
+    if (SDL_strcmp(list, "*") == 0) {
+        return NULL;
+    } else {
+        for (const char *c = list; *c; c++) {
+            if ((*c >= 'a' && *c <= 'z') || (*c >= 'A' && *c <= 'Z')
+             || (*c >= '0' && *c <= '9') || *c == '-' || *c == '_'
+             || *c == '.') {
+                continue;
+            } else if (*c == ';') {
+                if (c == list || c[-1] == ';') {
+                    return "Empty pattern not allowed";
+                }
+            } else {
+                return "Invalid character in pattern (Only [a-zA-Z0-9_.-] allowed, or a single *)";
+            }
+        }
+    }
+
+    if (list[SDL_strlen(list) - 1] == ';') {
+        return "Empty pattern not allowed";
+    }
+
+    return NULL;
+}

--- a/src/dialog/SDL_dialog_utils.h
+++ b/src/dialog/SDL_dialog_utils.h
@@ -1,0 +1,57 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+#include "SDL_internal.h"
+
+/* The following are utility functions to help implementations.
+   They are ordered by scope largeness, decreasing. All implementations
+   should use them, as they check for invalid filters. Where they are unused,
+   the validate_* function further down below should be used. */
+
+/* Transform the name given in argument into something viable for the engine.
+   Useful if there are special characters to avoid on certain platforms (such
+   as "|" with Zenity). */
+typedef char *(NameTransform)(const char * name);
+
+/* Converts all the filters into a single string. */
+/* <prefix>[filter]{<separator>[filter]...}<suffix> */
+char *convert_filters(const SDL_DialogFileFilter *filters, NameTransform ntf,
+                      const char *prefix, const char *separator,
+                      const char *suffix, const char *filt_prefix,
+                      const char *filt_separator, const char *filt_suffix,
+                      const char *ext_prefix, const char *ext_separator,
+                      const char *ext_suffix);
+
+/* Converts one filter into a single string. */
+/* <prefix>[filter name]<separator>[filter extension list]<suffix> */
+char *convert_filter(const SDL_DialogFileFilter filter, NameTransform ntf,
+                      const char *prefix, const char *separator,
+                      const char *suffix, const char *ext_prefix,
+                      const char *ext_separator, const char *ext_suffix);
+
+/* Converts the extenstion list of a filter into a single string. */
+/* <prefix>[extension]{<separator>[extension]...}<suffix> */
+char *convert_ext_list(const char *list, const char *prefix,
+                       const char *suffix, const char *separator);
+
+/* Must be used if convert_* functions aren't used */
+/* Returns an error message if there's a problem, NULL otherwise */
+const char *validate_filters(const SDL_DialogFileFilter *filters);
+const char *validate_list(const char *list);

--- a/src/dialog/unix/SDL_portaldialog.c
+++ b/src/dialog/unix/SDL_portaldialog.c
@@ -19,7 +19,7 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 #include "SDL_internal.h"
-#include "./SDL_dialog.h"
+#include "../SDL_dialog_utils.h"
 
 #include "../../core/linux/SDL_dbus.h"
 
@@ -269,6 +269,14 @@ static void DBus_OpenDialog(const char *method, const char *method_title, SDL_Di
     static uint32_t handle_id = 0;
     static char *default_parent_window = "";
     SDL_PropertiesID props = SDL_GetWindowProperties(window);
+
+    const char *err_msg = validate_filters(filters);
+
+    if (err_msg) {
+        SDL_SetError("%s", err_msg);
+        callback(userdata, NULL, -1);
+        return;
+    }
 
     if (dbus == NULL) {
         SDL_SetError("Failed to connect to DBus");

--- a/src/dialog/unix/SDL_zenitydialog.c
+++ b/src/dialog/unix/SDL_zenitydialog.c
@@ -19,7 +19,7 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 #include "SDL_internal.h"
-#include "./SDL_dialog.h"
+#include "../SDL_dialog_utils.h"
 
 #include <errno.h>
 #include <sys/types.h>
@@ -64,6 +64,22 @@ typedef struct
             CLEAR_AND_RETURN()                                                \
         }                                                                     \
     }
+
+char *zenity_clean_name(const char *name)
+{
+    char *newname = SDL_strdup(name);
+
+    /* Filter out "|", which Zenity considers a special character. Let's hope
+       there aren't others. TODO: find something better. */
+    for (char *c = newname; *c; c++) {
+        if (*c == '|') {
+            /* Zenity doesn't support escaping with \ */
+            *c = '/';
+        }
+    }
+
+    return newname;
+}
 
 /* Exec call format:
  *
@@ -147,68 +163,15 @@ static char** generate_args(const zenityArgs* info)
         const SDL_DialogFileFilter *filter_ptr = info->filters;
 
         while (filter_ptr->name && filter_ptr->pattern) {
-            /* *Normally*, no filter arg should exceed 4096 bytes. */
-            char buffer[4096];
+            char *filter_str = convert_filter(*filter_ptr, zenity_clean_name,
+                                              "--file-filter=", " | ", "",
+                                              "*.", " *.", "");
 
-            SDL_snprintf(buffer, 4096, "--file-filter=%s | *.", filter_ptr->name);
-            size_t i_buf = SDL_strlen(buffer);
-
-            /* "|" is a special character for Zenity */
-            for (char *c = buffer; *c; c++) {
-                if (*c == '|') {
-                    *c = ' ';
-                }
-            }
-
-            for (size_t i_pat = 0; i_buf < 4095 && filter_ptr->pattern[i_pat]; i_pat++) {
-                const char *c = filter_ptr->pattern + i_pat;
-
-                if (*c == ';') {
-                    /* Disallow empty patterns (might bug Zenity) */
-                    int at_end = (c[1] == '\0');
-                    int at_mid = (c[1] == ';');
-                    int at_beg = (i_pat == 0);
-                    if (at_end || at_mid || at_beg) {
-                        const char *pos_str = "";
-
-                        if (at_end) {
-                            pos_str = "end";
-                        } else if (at_mid) {
-                            pos_str = "middle";
-                        } else if (at_beg) {
-                            pos_str = "beginning";
-                        }
-
-                        SDL_SetError("Empty pattern file extension (at %s of list)", pos_str);
-                        CLEAR_AND_RETURN()
-                    }
-
-                    if (i_buf + 3 >= 4095) {
-                        i_buf += 3;
-                        break;
-                    }
-
-                    buffer[i_buf++] = ' ';
-                    buffer[i_buf++] = '*';
-                    buffer[i_buf++] = '.';
-                } else if (*c == '*' && (c[1] == '\0' || c[1] == ';') && (i_pat == 0 || *(c - 1) == ';')) {
-                    buffer[i_buf++] = '*';
-                } else if (!((*c >= 'a' && *c <= 'z') || (*c >= 'A' && *c <= 'Z') || (*c >= '0' && *c <= '9') || *c == '.' || *c == '_' || *c == '-')) {
-                    SDL_SetError("Illegal character in pattern name: %c (Only alphanumeric characters, periods, underscores and hyphens allowed)", *c);
-                    CLEAR_AND_RETURN()
-                } else {
-                    buffer[i_buf++] = *c;
-                }
-            }
-
-            if (i_buf >= 4095) {
-                SDL_SetError("Filter '%s' wouldn't fit in a 4096 byte buffer; please report your use case if you need filters that long", filter_ptr->name);
+            if (!filter_str) {
                 CLEAR_AND_RETURN()
             }
 
-            buffer[i_buf] = '\0';
-
-            argv[nextarg++] = SDL_strdup(buffer);
+            argv[nextarg++] = filter_str;
             CHECK_OOM()
 
             filter_ptr++;


### PR DESCRIPTION
## Description
- Add a globally-accessible function to handle the parsing of filter extensions (reduces difficulty of porting, and risks of adding memory issues)
- Remove the ability of putting the wildcard `*` among other patterns; it's either a list of patterns or a single `*` now
- Add a hint to select between portals and Zenity on Unix

I've also added some documentation for the callback.

The documentation for the hint would need review. I wrote what I think makes sense (I mostly copied the description of the similar video driver hint), but the writing style may need to be adjusted.

## Existing Issue(s)
Closes #9432 
