### PR TITLE
SDL_error.h inclusion and comment fixes

### DIFF
--- a/include/SDL3/SDL_locale.h
+++ b/include/SDL3/SDL_locale.h
@@ -84,7 +84,8 @@ typedef struct SDL_Locale
  * preferred locales.
  *
  * \returns array of locales, terminated with a locale with a NULL language
- *          field. Will return NULL on error.
+ *          field. Will return NULL on error; call SDL_GetError() for more
+ *          information.
  *
  * \since This function is available since SDL 3.0.0.
  */

--- a/include/SDL3/SDL_quit.h
+++ b/include/SDL3/SDL_quit.h
@@ -29,7 +29,6 @@
 #define SDL_quit_h_
 
 #include <SDL3/SDL_stdinc.h>
-#include <SDL3/SDL_error.h>
 
 /**
  *  \file SDL_quit.h


### PR DESCRIPTION
In `SDL_quit.h`: removing `SDL_error.h` inclusion
In `SDL_locale.h` -> `SDL_GetPreferredLocales()`: adding `SDL_GetError()` comment

From #9444, fixes these:
SDL headers, which include `SDL_error.h` but don't have a comment about calling `SDL_GetError()`:
```
SDL_locale.h
SDL_quit.h
```