### PR TITLE
Significant device enumeration speedup by using udev info instead of opening device files

### DIFF
--- a/src/joystick/linux/SDL_sysjoystick.c
+++ b/src/joystick/linux/SDL_sysjoystick.c
@@ -986,6 +986,9 @@ static void LINUX_JoystickDetect(void)
 static int LINUX_JoystickInit(void)
 {
     const char *devices = SDL_GetHint(SDL_HINT_JOYSTICK_DEVICE);
+#ifdef SDL_USE_LIBUDEV
+    int udev_status = SDL_UDEV_Init();
+#endif
 
     SDL_classic_joysticks = SDL_GetHintBoolean(SDL_HINT_LINUX_JOYSTICK_CLASSIC, SDL_FALSE);
 
@@ -1036,7 +1039,7 @@ static int LINUX_JoystickInit(void)
     }
 
     if (enumeration_method == ENUMERATION_LIBUDEV) {
-        if (SDL_UDEV_Init() == 0) {
+        if (udev_status == 0) {
             /* Set up the udev callback */
             if (SDL_UDEV_AddCallback(joystick_udev_callback) < 0) {
                 SDL_UDEV_Quit();

--- a/src/joystick/linux/SDL_sysjoystick.c
+++ b/src/joystick/linux/SDL_sysjoystick.c
@@ -273,7 +273,7 @@ static int GuessIsSensor(int fd)
     return 0;
 }
 
-static int IsJoystick(const char *path, int fd, char **name_return, Uint16 *vendor_return, Uint16 *product_return, SDL_JoystickGUID *guid)
+static int IsJoystick(const char *path, int *fd, char **name_return, Uint16 *vendor_return, Uint16 *product_return, SDL_JoystickGUID *guid)
 {
     struct input_id inpid;
     char *name;
@@ -282,21 +282,32 @@ static int IsJoystick(const char *path, int fd, char **name_return, Uint16 *vend
 
     SDL_zero(inpid);
 #ifdef SDL_USE_LIBUDEV
-    SDL_UDEV_GetProductInfo(path, &inpid.vendor, &inpid.product, &inpid.version, &class);
+    /* Opening input devices can generate synchronous device I/O, so avoid it if we can */
+    if (SDL_UDEV_GetProductInfo(path, &inpid.vendor, &inpid.product, &inpid.version, &class) &&
+        !(class & SDL_UDEV_DEVICE_JOYSTICK)) {
+        return 0;
+    }
 #endif
-    if (ioctl(fd, JSIOCGNAME(sizeof(product_string)), product_string) <= 0) {
-        /* When udev is enabled we only get joystick devices here, so there's no need to test them */
-        if (enumeration_method != ENUMERATION_LIBUDEV &&
-            !(class & SDL_UDEV_DEVICE_JOYSTICK) && ( class || !GuessIsJoystick(fd))) {
+
+    if (fd && *fd < 0) {
+        *fd = open(path, O_RDONLY | O_CLOEXEC, 0);
+    }
+    if (!fd || *fd < 0) {
+        return 0;
+    }
+
+    if (ioctl(*fd, JSIOCGNAME(sizeof(product_string)), product_string) <= 0) {
+        /* When udev enumeration or classification, we only got joysticks here, so no need to test */
+        if (enumeration_method != ENUMERATION_LIBUDEV && !class && !GuessIsJoystick(*fd)) {
             return 0;
         }
 
         /* Could have vendor and product already from udev, but should agree with evdev */
-        if (ioctl(fd, EVIOCGID, &inpid) < 0) {
+        if (ioctl(*fd, EVIOCGID, &inpid) < 0) {
             return 0;
         }
 
-        if (ioctl(fd, EVIOCGNAME(sizeof(product_string)), product_string) < 0) {
+        if (ioctl(*fd, EVIOCGNAME(sizeof(product_string)), product_string) < 0) {
             return 0;
         }
     }
@@ -315,7 +326,7 @@ static int IsJoystick(const char *path, int fd, char **name_return, Uint16 *vend
     }
 #endif
 
-    FixupDeviceInfoForMapping(fd, &inpid);
+    FixupDeviceInfoForMapping(*fd, &inpid);
 
 #ifdef DEBUG_JOYSTICK
     SDL_Log("Joystick: %s, bustype = %d, vendor = 0x%.4x, product = 0x%.4x, version = %d\n", name, inpid.bustype, inpid.vendor, inpid.product, inpid.version);
@@ -333,11 +344,32 @@ static int IsJoystick(const char *path, int fd, char **name_return, Uint16 *vend
     return 1;
 }
 
-static int IsSensor(const char *path, int fd)
+static int IsSensor(const char *path, int *fd)
 {
     struct input_id inpid;
+    int class = 0;
 
-    if (ioctl(fd, EVIOCGID, &inpid) < 0) {
+    SDL_zero(inpid);
+#ifdef SDL_USE_LIBUDEV
+    /* Opening input devices can generate synchronous device I/O, so avoid it if we can */
+    if (SDL_UDEV_GetProductInfo(path, &inpid.vendor, &inpid.product, &inpid.version, &class) &&
+        !(class & SDL_UDEV_DEVICE_ACCELEROMETER)) {
+        return 0;
+    }
+#endif
+
+    if (fd && *fd < 0) {
+        *fd = open(path, O_RDONLY | O_CLOEXEC, 0);
+    }
+    if (!fd || *fd < 0) {
+        return 0;
+    }
+
+    if (!class && !GuessIsSensor(*fd)) {
+        return 0;
+    }
+
+    if (ioctl(*fd, EVIOCGID, &inpid) < 0) {
         return 0;
     }
 
@@ -347,7 +379,7 @@ static int IsSensor(const char *path, int fd)
         return 0;
     }
 
-    return GuessIsSensor(fd);
+    return 1;
 }
 
 #ifdef SDL_USE_LIBUDEV
@@ -434,16 +466,11 @@ static void MaybeAddDevice(const char *path)
         }
     }
 
-    fd = open(path, O_RDONLY | O_CLOEXEC, 0);
-    if (fd < 0) {
-        goto done;
-    }
-
 #ifdef DEBUG_INPUT_EVENTS
     SDL_Log("Checking %s\n", path);
 #endif
 
-    if (IsJoystick(path, fd, &name, &vendor, &product, &guid)) {
+    if (IsJoystick(path, &fd, &name, &vendor, &product, &guid)) {
 #ifdef DEBUG_INPUT_EVENTS
         SDL_Log("found joystick: %s\n", path);
 #endif
@@ -484,7 +511,7 @@ static void MaybeAddDevice(const char *path)
         goto done;
     }
 
-    if (IsSensor(path, fd)) {
+    if (IsSensor(path, &fd)) {
 #ifdef DEBUG_INPUT_EVENTS
         SDL_Log("found sensor: %s\n", path);
 #endif
@@ -880,11 +907,22 @@ static void LINUX_ScanSteamVirtualGamepads(void)
     int num_virtual_gamepads = 0;
     int virtual_gamepad_slot;
     VirtualGamepadEntry *virtual_gamepads = NULL;
+    int class;
 
     count = scandir("/dev/input", &entries, filter_entries, NULL);
     for (i = 0; i < count; ++i) {
         (void)SDL_snprintf(path, SDL_arraysize(path), "/dev/input/%s", entries[i]->d_name);
 
+#ifdef SDL_USE_LIBUDEV
+        /* Opening input devices can generate synchronous device I/O, so avoid it if we can */
+        class = 0;
+        SDL_zero(inpid);
+        if (SDL_UDEV_GetProductInfo(path, &inpid.vendor, &inpid.product, &inpid.version, &class) &&
+            (inpid.vendor != USB_VENDOR_VALVE || inpid.product != USB_PRODUCT_STEAM_VIRTUAL_GAMEPAD)) {
+            free(entries[i]); /* This should NOT be SDL_free() */
+            continue;
+        }
+#endif
         fd = open(path, O_RDONLY | O_CLOEXEC, 0);
         if (fd >= 0) {
             if (ioctl(fd, EVIOCGID, &inpid) == 0 &&


### PR DESCRIPTION
This adds several early outs to the scanning before opening device files, if udev can returns information about devices, to avoid long synchronous device closes
* in `IsJoystick` if `SDL_UDEV_GetProductInfo` says device file is not joystick class
* in `IsSensor` if  `SDL_UDEV_GetProductInfo` says device file is not accelerometer class
* in `LINUX_ScanSteamVirtualGamepads` if `SDL_UDEV_GetProductInfo` says vendor and product isn't a Steam virtual gamepad

## Description

In #9092 it was revealed that closing device files can take anywhere from 0.5-0.01s. If the user has permissions to open a large number of device files, this can accumulate to significant startup time.

This resolves this in the case that the udev device data is available by using the udev devices data, which comes from _/run/udev_ or _/sys_ files with close times of 0.00002s (500-2,5000x faster), instead of opening devices when possible.

Here are profile and offcputime flamegraphs provided by @parkerlreed showing behaviour before this patch
* [offcputime](https://github.com/libsdl-org/SDL/assets/841440/32d544f0-02d7-4f1d-a14f-c20b81305e07)
* [profile](https://github.com/libsdl-org/SDL/assets/841440/18505936-1b43-43f1-b72b-bc4886477816)

and after it
* [offcputime](https://github.com/libsdl-org/SDL/assets/841440/72b138f9-62d8-4165-9881-aac8d34da41b)
* [profile](https://github.com/libsdl-org/SDL/assets/841440/c9f2f80c-816e-40c4-be84-b73980f9ba9b)

Note how total offcputime (time the program is blocked) went for over 2s to under 14ms (this varied a bit in subsequent test, but report are consistently under 300ms). Also note how the prior offcputime was dominated by `close` calls under `SDL_JoystickInit`, while the new one is now dominated by display related calls.

## Existing Issue(s)

See discussion at bottom of #9092. Note that 9092 was a combination of this slow device behaviour and commit 3b1e0e163ba3933daa9aa19f06a7bb3909e05c8a introducing O(n²) device walking for the full class of devices. The O(n²) device walking was resolved in that issue, but the general slowness was not.