### PR TITLE
Fix memory leak in dialog

### DIFF
--- a/src/dialog/SDL_dialog_utils.c
+++ b/src/dialog/SDL_dialog_utils.c
@@ -48,6 +48,7 @@ char *convert_filters(const SDL_DialogFileFilter *filters, NameTransform ntf,
                                    ext_suffix);
 
         if (!converted) {
+            SDL_free(combined);
             return NULL;
         }
 
@@ -68,6 +69,7 @@ char *convert_filters(const SDL_DialogFileFilter *filters, NameTransform ntf,
 
         SDL_strlcat(combined, converted, new_length);
         SDL_strlcat(combined, terminator, new_length);
+        SDL_free(converted);
     }
 
     return combined;


### PR DESCRIPTION
## Description
`converted` is never freed on success, `combined` need to be freed on error.

## Existing Issue(s)
None
