### PR TITLE
Removing SDL_Colour macro

### DIFF
--- a/build-scripts/SDL_migration.cocci
+++ b/build-scripts/SDL_migration.cocci
@@ -3124,3 +3124,8 @@ typedef SDL_eventaction, SDL_EventAction;
 @@
 - SDL_eventaction
 + SDL_EventAction
+@@
+typedef SDL_Colour, SDL_Color;
+@@
+- SDL_Colour
++ SDL_Color

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -977,6 +977,9 @@ The following functions have been renamed:
 * SDL_MasksToPixelFormatEnum() => SDL_GetPixelFormatEnumForMasks()
 * SDL_PixelFormatEnumToMasks() => SDL_GetMasksForPixelFormatEnum()
 
+The following macros have been removed:
+* SDL_Colour - use SDL_Color instead
+
 ## SDL_platform.h
 
 The following platform preprocessor macros have been renamed:

--- a/include/SDL3/SDL_oldnames.h
+++ b/include/SDL3/SDL_oldnames.h
@@ -388,6 +388,7 @@
 /* ##SDL_pixels.h */
 #define SDL_AllocFormat SDL_CreatePixelFormat
 #define SDL_AllocPalette SDL_CreatePalette
+#define SDL_Colour SDL_Color
 #define SDL_FreeFormat SDL_DestroyPixelFormat
 #define SDL_FreePalette SDL_DestroyPalette
 #define SDL_MasksToPixelFormatEnum SDL_GetPixelFormatEnumForMasks
@@ -888,6 +889,7 @@
 /* ##SDL_pixels.h */
 #define SDL_AllocFormat SDL_AllocFormat_renamed_SDL_CreatePixelFormat
 #define SDL_AllocPalette SDL_AllocPalette_renamed_SDL_CreatePalette
+#define SDL_Colour SDL_Colour_renamed_SDL_Color
 #define SDL_FreeFormat SDL_FreeFormat_renamed_SDL_DestroyPixelFormat
 #define SDL_FreePalette SDL_FreePalette_renamed_SDL_DestroyPalette
 #define SDL_MasksToPixelFormatEnum SDL_MasksToPixelFormatEnum_renamed_SDL_GetPixelFormatEnumForMasks

--- a/include/SDL3/SDL_pixels.h
+++ b/include/SDL3/SDL_pixels.h
@@ -672,7 +672,6 @@ typedef struct SDL_Color
     Uint8 b;
     Uint8 a;
 } SDL_Color;
-#define SDL_Colour SDL_Color
 
 /**
  * The bits of this structure can be directly reinterpreted as a float-packed


### PR DESCRIPTION
fixes #9469

-------------------------------------------------------------------------

Steps to reproduce

Execute script:
```
./build-scripts/rename_api.py ./include/SDL3/SDL_pixels.h structure SDL_Colour SDL_Color
```
In `SDL_pixels.h` remove line:
```
#define SDL_Color SDL_Color
```
In `README-migration.md` replace this:
```
The following structures have been renamed:
* SDL_Colour => SDL_Color
```
with this:
```
The following macros have been removed:
* SDL_Colour - use SDL_Color instead
```

--------------------------------------------------------
I'm not sure about this line in `SDL_oldnames.h`:
```
#define SDL_Colour SDL_Colour_renamed_SDL_Color
```
because technically it wasn't renamed, but removed.

ps: I tried renaming `SDL_Colour` with the script as a symbol first, but when testing, it did't work and showed a warning: `warning: line 3129: should SDL_Colour be a metavariable?`