### PR TITLE
Fixed Doxygen comments

### DIFF
--- a/include/SDL3/SDL_surface.h
+++ b/include/SDL3/SDL_surface.h
@@ -641,7 +641,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_SetSurfaceClipRect(SDL_Surface *surface, co
  */
 extern DECLSPEC int SDLCALL SDL_GetSurfaceClipRect(SDL_Surface *surface, SDL_Rect *rect);
 
-/*
+/**
  * Flip a surface vertically or horizontally.
  *
  * \param surface the surface to flip
@@ -653,7 +653,7 @@ extern DECLSPEC int SDLCALL SDL_GetSurfaceClipRect(SDL_Surface *surface, SDL_Rec
  */
 extern DECLSPEC int SDLCALL SDL_FlipSurface(SDL_Surface *surface, SDL_FlipMode flip);
 
-/*
+/**
  * Creates a new surface identical to the existing surface.
  *
  * The returned surface should be freed with SDL_DestroySurface().


### PR DESCRIPTION
## Description
I noticed the Doxygen comments for SDL_FlipSurface and SDL_DuplicateSurface were not highlighting properly in my IDE (CLion).  I changed the start of both Doxygen comments from '/*' to '/**' to fix this.