### PR TITLE
Add support for modal windows at creation

### DIFF
--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -144,6 +144,7 @@ typedef Uint32 SDL_WindowFlags;
 #define SDL_WINDOW_INPUT_FOCUS          0x00000200U /**< window has input focus */
 #define SDL_WINDOW_MOUSE_FOCUS          0x00000400U /**< window has mouse focus */
 #define SDL_WINDOW_EXTERNAL             0x00000800U /**< window not created by SDL */
+#define SDL_WINDOW_MODAL                0x00001000U /**< window is modal */
 #define SDL_WINDOW_HIGH_PIXEL_DENSITY   0x00002000U /**< window uses high pixel density back buffer if possible */
 #define SDL_WINDOW_MOUSE_CAPTURE        0x00004000U /**< window has mouse captured (unrelated to MOUSE_GRABBED) */
 #define SDL_WINDOW_ALWAYS_ON_TOP        0x00008000U /**< window should always be above others */
@@ -906,13 +907,15 @@ extern DECLSPEC SDL_Window *SDLCALL SDL_CreatePopupWindow(SDL_Window *parent, in
  *   with Metal rendering
  * - `SDL_PROP_WINDOW_CREATE_MINIMIZED_BOOLEAN`: true if the window should
  *   start minimized
+ * - `SDL_PROP_WINDOW_CREATE_MODAL_BOOLEAN`: true if the window is modal to its
+ *   parent
  * - `SDL_PROP_WINDOW_CREATE_MOUSE_GRABBED_BOOLEAN`: true if the window starts
  *   with grabbed mouse focus
  * - `SDL_PROP_WINDOW_CREATE_OPENGL_BOOLEAN`: true if the window will be used
  *   with OpenGL rendering
  * - `SDL_PROP_WINDOW_CREATE_PARENT_POINTER`: an SDL_Window that will be the
- *   parent of this window, required for windows with the "toolip" and "menu"
- *   properties
+ *   parent of this window, required for windows with the "toolip", "menu" and
+ *   "modal" properties
  * - `SDL_PROP_WINDOW_CREATE_RESIZABLE_BOOLEAN`: true if the window should be
  *   resizable
  * - `SDL_PROP_WINDOW_CREATE_TITLE_STRING`: the title of the window, in UTF-8
@@ -1006,6 +1009,7 @@ extern DECLSPEC SDL_Window *SDLCALL SDL_CreateWindowWithProperties(SDL_Propertie
 #define SDL_PROP_WINDOW_CREATE_MENU_BOOLEAN                        "menu"
 #define SDL_PROP_WINDOW_CREATE_METAL_BOOLEAN                       "metal"
 #define SDL_PROP_WINDOW_CREATE_MINIMIZED_BOOLEAN                   "minimized"
+#define SDL_PROP_WINDOW_CREATE_MODAL_BOOLEAN                       "modal"
 #define SDL_PROP_WINDOW_CREATE_MOUSE_GRABBED_BOOLEAN               "mouse_grabbed"
 #define SDL_PROP_WINDOW_CREATE_OPENGL_BOOLEAN                      "opengl"
 #define SDL_PROP_WINDOW_CREATE_PARENT_POINTER                      "parent"

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1871,7 +1871,7 @@ Uint32 SDL_GetWindowPixelFormat(SDL_Window *window)
 }
 
 #define CREATE_FLAGS \
-    (SDL_WINDOW_OPENGL | SDL_WINDOW_BORDERLESS | SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY | SDL_WINDOW_ALWAYS_ON_TOP | SDL_WINDOW_POPUP_MENU | SDL_WINDOW_UTILITY | SDL_WINDOW_TOOLTIP | SDL_WINDOW_VULKAN | SDL_WINDOW_MINIMIZED | SDL_WINDOW_METAL | SDL_WINDOW_TRANSPARENT | SDL_WINDOW_NOT_FOCUSABLE)
+    (SDL_WINDOW_OPENGL | SDL_WINDOW_BORDERLESS | SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY | SDL_WINDOW_ALWAYS_ON_TOP | SDL_WINDOW_POPUP_MENU | SDL_WINDOW_UTILITY | SDL_WINDOW_TOOLTIP | SDL_WINDOW_VULKAN | SDL_WINDOW_MINIMIZED | SDL_WINDOW_METAL | SDL_WINDOW_TRANSPARENT | SDL_WINDOW_NOT_FOCUSABLE | SDL_WINDOW_MODAL)
 
 static SDL_INLINE SDL_bool IsAcceptingDragAndDrop(void)
 {
@@ -1962,6 +1962,7 @@ static struct {
     { SDL_PROP_WINDOW_CREATE_MENU_BOOLEAN,               SDL_WINDOW_POPUP_MENU,          SDL_FALSE },
     { SDL_PROP_WINDOW_CREATE_METAL_BOOLEAN,              SDL_WINDOW_METAL,               SDL_FALSE },
     { SDL_PROP_WINDOW_CREATE_MINIMIZED_BOOLEAN,          SDL_WINDOW_MINIMIZED,           SDL_FALSE },
+    { SDL_PROP_WINDOW_CREATE_MODAL_BOOLEAN,              SDL_WINDOW_MODAL,               SDL_FALSE },
     { SDL_PROP_WINDOW_CREATE_MOUSE_GRABBED_BOOLEAN,      SDL_WINDOW_MOUSE_GRABBED,       SDL_FALSE },
     { SDL_PROP_WINDOW_CREATE_OPENGL_BOOLEAN,             SDL_WINDOW_OPENGL,              SDL_FALSE },
     { SDL_PROP_WINDOW_CREATE_RESIZABLE_BOOLEAN,          SDL_WINDOW_RESIZABLE,           SDL_FALSE },
@@ -2017,6 +2018,11 @@ SDL_Window *SDL_CreateWindowWithProperties(SDL_PropertiesID props)
         }
     }
 
+    if ((flags & SDL_WINDOW_MODAL) && (!parent || parent->magic != &_this->window_magic)) {
+        SDL_SetError("Modal windows must specify a parent window");
+        return NULL;
+    }
+
     if ((flags & (SDL_WINDOW_TOOLTIP | SDL_WINDOW_POPUP_MENU)) != 0) {
         if (!(_this->device_caps & VIDEO_DEVICE_CAPS_HAS_POPUP_WINDOW_SUPPORT)) {
             SDL_Unsupported();
@@ -2034,7 +2040,7 @@ SDL_Window *SDL_CreateWindowWithProperties(SDL_PropertiesID props)
     }
 
     /* Ensure no more than one of these flags is set */
-    type_flags = flags & (SDL_WINDOW_UTILITY | SDL_WINDOW_TOOLTIP | SDL_WINDOW_POPUP_MENU);
+    type_flags = flags & (SDL_WINDOW_UTILITY | SDL_WINDOW_TOOLTIP | SDL_WINDOW_POPUP_MENU | SDL_WINDOW_MODAL);
     if (type_flags & (type_flags - 1)) {
         SDL_SetError("Conflicting window type flags specified: 0x%.8x", (unsigned int)type_flags);
         return NULL;

--- a/src/video/haiku/SDL_BWin.h
+++ b/src/video/haiku/SDL_BWin.h
@@ -88,8 +88,8 @@ class SDL_BWin : public BWindow
 {
   public:
     /* Constructor/Destructor */
-    SDL_BWin(BRect bounds, window_look look, uint32 flags)
-        : BWindow(bounds, "Untitled", look, B_NORMAL_WINDOW_FEEL, flags)
+    SDL_BWin(BRect bounds, window_look look, window_feel feel, uint32 flags, BWindow *parent)
+        : BWindow(bounds, "Untitled", look, feel, flags)
     {
         _last_buttons = 0;
 
@@ -109,6 +109,10 @@ class SDL_BWin : public BWindow
         /* Handle framebuffer stuff */
         _buffer_locker = new BLocker();
         _bitmap = NULL;
+
+        if (parent) {
+            AddToSubset(parent);
+        }
     }
 
     virtual ~SDL_BWin()

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -1569,6 +1569,15 @@ void Wayland_ShowWindow(SDL_VideoDevice *_this, SDL_Window *window)
                 zxdg_exported_v2_add_listener(data->exported, &exported_v2_listener, data);
             }
 
+            if (window->flags & SDL_WINDOW_MODAL) {
+                if (window->parent->driverdata->shell_surface_type == WAYLAND_SURFACE_LIBDECOR) {
+                    libdecor_frame_set_parent(data->shell_surface.libdecor.frame, window->parent->driverdata->shell_surface.libdecor.frame);
+                } else if (window->parent->driverdata->shell_surface_type == WAYLAND_SURFACE_XDG_TOPLEVEL) {
+                    struct xdg_toplevel *modal_toplevel = libdecor_frame_get_xdg_toplevel(data->shell_surface.libdecor.frame);
+                    xdg_toplevel_set_parent(modal_toplevel, window->parent->driverdata->shell_surface.xdg.roleobj.toplevel);
+                }
+            }
+
             SDL_SetProperty(props, SDL_PROP_WINDOW_WAYLAND_XDG_SURFACE_POINTER, libdecor_frame_get_xdg_surface(data->shell_surface.libdecor.frame));
             SDL_SetProperty(props, SDL_PROP_WINDOW_WAYLAND_XDG_TOPLEVEL_POINTER, libdecor_frame_get_xdg_toplevel(data->shell_surface.libdecor.frame));
         }
@@ -1647,6 +1656,15 @@ void Wayland_ShowWindow(SDL_VideoDevice *_this, SDL_Window *window)
             if (c->zxdg_exporter_v2) {
                 data->exported = zxdg_exporter_v2_export_toplevel(c->zxdg_exporter_v2, data->surface);
                 zxdg_exported_v2_add_listener(data->exported, &exported_v2_listener, data);
+            }
+
+            if (window->flags & SDL_WINDOW_MODAL) {
+                if (window->parent->driverdata->shell_surface_type == WAYLAND_SURFACE_XDG_TOPLEVEL) {
+                    xdg_toplevel_set_parent(data->shell_surface.xdg.roleobj.toplevel, window->parent->driverdata->shell_surface.xdg.roleobj.toplevel);
+                } else if (window->parent->driverdata->shell_surface_type == WAYLAND_SURFACE_LIBDECOR) {
+                    struct xdg_toplevel *parent_toplevel = libdecor_frame_get_xdg_toplevel(window->parent->driverdata->shell_surface.libdecor.frame);
+                    xdg_toplevel_set_parent(data->shell_surface.xdg.roleobj.toplevel, parent_toplevel);
+                }
             }
 
             SDL_SetProperty(props, SDL_PROP_WINDOW_WAYLAND_XDG_TOPLEVEL_POINTER, data->shell_surface.xdg.roleobj.toplevel);

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -202,6 +202,7 @@ static SDL_VideoDevice *WIN_CreateDevice(void)
     device->SetWindowResizable = WIN_SetWindowResizable;
     device->SetWindowAlwaysOnTop = WIN_SetWindowAlwaysOnTop;
     device->SetWindowFullscreen = WIN_SetWindowFullscreen;
+    device->SetWindowModalFor = WIN_SetWindowModalFor;
 #if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
     device->GetWindowICCProfile = WIN_GetWindowICCProfile;
     device->SetWindowMouseRect = WIN_SetWindowMouseRect;

--- a/src/video/windows/SDL_windowswindow.h
+++ b/src/video/windows/SDL_windowswindow.h
@@ -78,6 +78,7 @@ struct SDL_WindowData
 #ifdef SDL_VIDEO_OPENGL_EGL
     EGLSurface egl_surface;
 #endif
+    SDL_Window *modal_parent;
 
     /* Whether we retain the content of the window when changing state */
     UINT copybits_flag;
@@ -118,6 +119,7 @@ extern void WIN_ShowWindowSystemMenu(SDL_Window *window, int x, int y);
 extern int WIN_SetWindowFocusable(SDL_VideoDevice *_this, SDL_Window *window, SDL_bool focusable);
 extern int WIN_AdjustWindowRect(SDL_Window *window, int *x, int *y, int *width, int *height, SDL_WindowRect rect_type);
 extern int WIN_AdjustWindowRectForHWND(HWND hwnd, LPRECT lpRect, UINT frame_dpi);
+extern int WIN_SetWindowModalFor(SDL_VideoDevice *_this, SDL_Window *modal_window, SDL_Window *parent_window);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -791,6 +791,10 @@ int X11_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesI
     }
 #endif
 
+    if (window->flags & SDL_WINDOW_MODAL) {
+        X11_XSetTransientForHint(display, w, window->parent->driverdata->xwindow);
+    }
+
     X11_Xinput2SelectTouch(_this, window);
 
     {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -414,6 +414,7 @@ add_sdl_test_executable(testpopup SOURCES testpopup.c)
 add_sdl_test_executable(testdialog SOURCES testdialog.c)
 add_sdl_test_executable(testtime SOURCES testtime.c)
 add_sdl_test_executable(testmanymouse SOURCES testmanymouse.c)
+add_sdl_test_executable(testmodal SOURCES testmodal.c)
 
 if (HAVE_WAYLAND)
     # Set the GENERATED property on the protocol file, since it is first created at build time

--- a/test/testmodal.c
+++ b/test/testmodal.c
@@ -1,0 +1,196 @@
+/*
+  Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely.
+*/
+/* Sample program:  Create a parent window and a modal child window. */
+
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
+#include <stdlib.h>
+
+static SDL_bool CreateModalWindow(SDL_Window *parent, SDL_Window **w, SDL_Renderer **r)
+{
+    SDL_bool exit_code = SDL_FALSE;
+    SDL_PropertiesID props = SDL_CreateProperties();
+
+    if (!props) {
+        SDL_Log("Failed to create properties: %s\n", SDL_GetError());
+        goto done;
+    }
+
+    if (SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_TITLE_STRING, "Modal Window") < 0) {
+        SDL_Log("Failed to set modal property: %s\n", SDL_GetError());
+        goto done;
+    }
+
+    if (SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_MODAL_BOOLEAN, SDL_TRUE) < 0) {
+        SDL_Log("Failed to set modal property: %s\n", SDL_GetError());
+        goto done;
+    }
+
+    if (SDL_SetProperty(props, SDL_PROP_WINDOW_CREATE_PARENT_POINTER, parent) < 0) {
+        SDL_Log("Failed to set parent property: %s\n", SDL_GetError());
+        goto done;
+    }
+
+    if (SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, 320) < 0) {
+        SDL_Log("Failed to set width property: %s\n", SDL_GetError());
+        goto done;
+    }
+
+    if (SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, 200) < 0) {
+        SDL_Log("Failed to set height property: %s\n", SDL_GetError());
+        goto done;
+    }
+
+    *w = SDL_CreateWindowWithProperties(props);
+
+    if (!*w) {
+        SDL_Log("Failed to create child window: %s\n", SDL_GetError());
+        goto done;
+    }
+
+    *r = SDL_CreateRenderer(*w, NULL, 0);
+
+    if (!*r) {
+        SDL_Log("Failed to create child window: %s\n", SDL_GetError());
+        SDL_DestroyWindow(*w);
+        *w = NULL;
+        goto done;
+    }
+
+    exit_code = SDL_TRUE;
+
+done:
+
+    SDL_DestroyProperties(props);
+
+    return exit_code;
+}
+
+int main(int argc, char *argv[])
+{
+    SDL_Window *w1 = NULL, *w2 = NULL;
+    SDL_Renderer *r1 = NULL, *r2 = NULL;
+    SDLTest_CommonState *state = NULL;
+    Uint64 show_deadline = 0;
+    int i;
+    int exit_code = 0;
+
+    /* Initialize test framework */
+    state = SDLTest_CommonCreateState(argv, 0);
+    if (state == NULL) {
+        return 1;
+    }
+
+    /* Enable standard application logging */
+    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
+
+    /* Parse commandline */
+    for (i = 1; i < argc;) {
+        int consumed;
+
+        consumed = SDLTest_CommonArg(state, i);
+
+        if (consumed <= 0) {
+            static const char *options[] = { NULL };
+            SDLTest_CommonLogUsage(state, argv[0], options);
+            return 1;
+        }
+
+        i += consumed;
+    }
+
+    if (SDL_Init(SDL_INIT_VIDEO) < 0) {
+        SDL_Log("SDL_Init failed (%s)", SDL_GetError());
+        return 1;
+    }
+
+    if (SDL_CreateWindowAndRenderer(640, 480, 0, &w1, &r1) < 0) {
+        SDL_Log("Failed to create parent window and/or renderer: %s\n", SDL_GetError());
+        exit_code = 1;
+        goto sdl_quit;
+    }
+
+    SDL_SetWindowTitle(w1, "Parent Window");
+
+    if (!CreateModalWindow(w1, &w2, &r2)) {
+        exit_code = 1;
+        goto sdl_quit;
+    }
+
+    while (1) {
+        int quit = 0;
+        SDL_Event e;
+        while (SDL_PollEvent(&e)) {
+            if (e.type == SDL_EVENT_QUIT) {
+                quit = 1;
+                break;
+            } else if (e.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED) {
+                if (e.window.windowID == SDL_GetWindowID(w2)) {
+                    SDL_DestroyWindow(w2);
+                    r2 = NULL;
+                    w2 = NULL;
+                } else if (e.window.windowID == SDL_GetWindowID(w1)) {
+                    SDL_DestroyWindow(w1);
+                    r1 = NULL;
+                    w1 = NULL;
+                }
+            } else if (e.type == SDL_EVENT_KEY_DOWN) {
+                if (e.key.keysym.sym == SDLK_m && !w2) {
+                    if (!CreateModalWindow(w1, &w2, &r2)) {
+                        exit_code = 1;
+                        goto sdl_quit;
+                    }
+                } else if (e.key.keysym.sym == SDLK_ESCAPE && w2) {
+                    SDL_DestroyWindow(w2);
+                    r2 = NULL;
+                    w2 = NULL;
+                } else if (e.key.keysym.sym == SDLK_h) {
+                    show_deadline = SDL_GetTicksNS() + SDL_SECONDS_TO_NS(3);
+                    SDL_HideWindow(w1);
+                }
+            }
+        }
+        if (quit) {
+            break;
+        }
+        SDL_Delay(100);
+
+        if (show_deadline && show_deadline <= SDL_GetTicksNS()) {
+            SDL_ShowWindow(w1);
+        }
+
+        /* Parent window is red */
+        if (r1) {
+            SDL_SetRenderDrawColor(r1, 224, 48, 12, SDL_ALPHA_OPAQUE);
+            SDL_RenderClear(r1);
+            SDL_RenderPresent(r1);
+        }
+
+        /* Child window is blue */
+        if (r2) {
+            SDL_SetRenderDrawColor(r2, 6, 76, 255, SDL_ALPHA_OPAQUE);
+            SDL_RenderClear(r2);
+            SDL_RenderPresent(r2);
+        }
+    }
+
+sdl_quit:
+    if (w1) {
+        /* The child window and renderer will be cleaned up automatically. */
+        SDL_DestroyWindow(w1);
+    }
+
+    SDL_Quit();
+    SDLTest_CommonDestroyState(state);
+    return exit_code;
+}


### PR DESCRIPTION
## Description

This adds support for modal windows for more platforms:
- **X11 and Wayland** recycle the `SDL_SetWindowModalFor` function.
- **Windows** implements the `SDL_SetWidnowModalFor` function and uses that.
- **Haiku** uses BeOS' modal window system.
- **Cocoa** is not yet implemented.

It implements the recommended mechanism using properties and a new property, `SDL_PROP_WINDOW_CREATE_MODAL_BOOLEAN`. I've updated the documentation accordingly.

----------

I tested on Linux with both X11 and Wayland, on Haiku and on Wine, and only Wine seemed to work as expected. X11, Wayland and Haiku did not properly disable their parent window. I have no idea why that may be; I'm reusing existing functionality on X11 and Wayland, and I'm not familiar enough with Haiku to debug further.

I added a test program to easily see the modal dialog in action (or their failure, so far). I think I did everything properly, but some review would be welcome.

I had a few uncertainties about the code, but rather than packing this PR with a list of questions, I left `TODO`'s in the code. I would need help to know what to do at those places.

## Existing Issue(s)
Fixes #9427 
