### PR TITLE
Fixes for testdialog.c

### DIFF
--- a/test/testdialog.c
+++ b/test/testdialog.c
@@ -70,8 +70,7 @@ int main(int argc, char *argv[]) {
         int consumed;
 
         consumed = SDLTest_CommonArg(state, i);
-        if (!consumed) {
-        }
+
         if (consumed <= 0) {
             static const char *options[] = { NULL };
             SDLTest_CommonLogUsage(state, argv[0], options);
@@ -87,6 +86,7 @@ int main(int argc, char *argv[]) {
     }
     if (SDL_CreateWindowAndRenderer(640, 480, 0, &w, &r) < 0) {
         SDL_Log("Failed to create window and/or renderer: %s\n", SDL_GetError());
+        SDL_Quit();
         return 1;
     }
 


### PR DESCRIPTION
## Description
This fixes a few apparent problems in `test/testdialog.c`:
- Removes one empty `if` block that doesn't execute anything, neither in its body nor its condition.
- Adds a missing `SDL_Quit()` in an error branch that occurs after `SDL_Init()` was called.
