### PR TITLE
include: Fix documentation generation for SDL_SensorType.

### DIFF
--- a/include/SDL3/SDL_sensor.h
+++ b/include/SDL3/SDL_sensor.h
@@ -69,7 +69,7 @@ typedef Uint32 SDL_SensorID;
  * Hare are the additional Android sensors:
  * https://developer.android.com/reference/android/hardware/SensorEvent.html#values
  */
-typedef enum
+typedef enum SDL_SensorType
 {
     SDL_SENSOR_INVALID = -1,    /**< Returned for an invalid sensor */
     SDL_SENSOR_UNKNOWN,         /**< Unknown sensor type */


### PR DESCRIPTION
There is an existing SDL3 Wiki page at https://wiki.libsdl.org/SDL3/SDL_SensorType , the documentation in the header includes all the information in that Wiki page.