### PR TITLE
include: Fixes the improper fix I made before of documentation, `SDL_SensorType`.

### DIFF
--- a/include/SDL3/SDL_sensor.h
+++ b/include/SDL3/SDL_sensor.h
@@ -62,7 +62,8 @@ typedef struct SDL_Sensor SDL_Sensor;
  */
 typedef Uint32 SDL_SensorID;
 
-/* The different sensors defined by SDL
+/**
+ * The different sensors defined by SDL
  *
  * Additional sensors may be available, using platform dependent semantics.
  *


### PR DESCRIPTION
Fixes #9515 , sorry about that. I have now actually run wikiheaders.pl beforehand and actually confirmed that the Wiki page is generated correctly.