### PR TITLE
3DS: Improve framebuffer support

### DIFF
--- a/src/video/n3ds/SDL_n3dsvideo.h
+++ b/src/video/n3ds/SDL_n3dsvideo.h
@@ -38,8 +38,6 @@ typedef struct SDL_WindowData
     gfxScreen_t screen; /**< Keeps track of which N3DS screen is targetted */
 } SDL_WindowData;
 
-#define FRAMEBUFFER_FORMAT SDL_PIXELFORMAT_RGBA8888
-
 #endif /* SDL_n3dsvideo_h_ */
 
 /* vi: set sts=4 ts=4 sw=4 expandtab: */


### PR DESCRIPTION
I'm not sure the implementation of `SetDisplayMode` is correct since I can't figure out how to select modes that use `GSP_RGB565_OES` or `GSP_RGB5_A1_OES` with it, but these changes help make things faster compared to before.

Requires the changes from PRs #9519 and #9525.