### PR TITLE
Fix segmentation fault on Wayland 1.18 + KDE

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -248,7 +248,7 @@ static void Wayland_SortOutputs(SDL_VideoData *vid)
     /* KDE provides the kde-output-order-v1 protocol, which gives us the full preferred display
      * ordering in the form of a list of wl_output.name strings (connector names).
      */
-    if (!WAYLAND_wl_list_empty(&vid->output_order)) {
+    if (!WAYLAND_wl_list_empty(&vid->output_order) && SDL_WL_OUTPUT_VERSION >= WL_OUTPUT_NAME_SINCE_VERSION) {
         struct wl_list sorted_list;
         SDL_WaylandConnectorName *c;
 


### PR DESCRIPTION
## Description

The CI build matrix uses Ubuntu 20.04 as one of its configurations. This platform only comes with Wayland 1.18, but the display output name is only available since Wayland 1.20 (output version 4).

This was considered in other areas, for example the main function that reads this value mentions version 4 specifically:

https://github.com/libsdl-org/SDL/blob/60f26182c3a44544f78c1569906fdf58d1d69374/src/video/wayland/SDL_waylandvideo.c#L915

... and the different versions are selected when adding displays:

https://github.com/libsdl-org/SDL/blob/60f26182c3a44544f78c1569906fdf58d1d69374/src/video/wayland/SDL_waylandvideo.c#L85-L89

We are also providing binaries of our own compiled on Ubuntu 20.04 (still generally supported until 2025-06) specifically to target a lower GLIBC version.