### PR TITLE
x11: Mark XWayland as MODE_SWITCHING_EMULATED

### DIFF
--- a/src/video/x11/SDL_x11video.c
+++ b/src/video/x11/SDL_x11video.c
@@ -101,6 +101,12 @@ static int X11_SafetyNetErrHandler(Display *d, XErrorEvent *e)
     return 0;
 }
 
+static SDL_bool X11_IsXWayland(Display *d)
+{
+    int opcode, event, error;
+    return X11_XQueryExtension(d, "XWAYLAND", &opcode, &event, &error) == True;
+}
+
 static SDL_VideoDevice *X11_CreateDevice(void)
 {
     SDL_VideoDevice *device;
@@ -282,6 +288,9 @@ static SDL_VideoDevice *X11_CreateDevice(void)
 
     device->device_caps = VIDEO_DEVICE_CAPS_HAS_POPUP_WINDOW_SUPPORT |
                           VIDEO_DEVICE_CAPS_SENDS_FULLSCREEN_DIMENSIONS;
+
+    if (X11_IsXWayland(x11_display))
+        device->device_caps |= VIDEO_DEVICE_CAPS_MODE_SWITCHING_EMULATED;
 
     return device;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

That way we don't do the awful minimise on focus loss logic by default on XWayland where mode switching is emulated (like on the Wayland backend).

This fixes CS2, Dota 2 minimising on alt-tab when playing in fullscreen (which is really annoying when managing eg. Discord on another screen)

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
