### PR TITLE
Replace if() with SDL_assert() in `Wayland_GetWindowSizeInPixels`

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -2471,11 +2471,12 @@ void Wayland_SetWindowSize(SDL_VideoDevice *_this, SDL_Window *window)
 void Wayland_GetWindowSizeInPixels(SDL_VideoDevice *_this, SDL_Window *window, int *w, int *h)
 {
     SDL_WindowData *data;
-    if (window->driverdata) {
-        data = window->driverdata;
-        *w = data->current.drawable_width;
-        *h = data->current.drawable_height;
-    }
+
+    SDL_assert(window->driverdata)
+
+    data = window->driverdata;
+    *w = data->current.drawable_width;
+    *h = data->current.drawable_height;
 }
 
 void Wayland_SetWindowTitle(SDL_VideoDevice *_this, SDL_Window *window)


### PR DESCRIPTION
## Description
If the if statement was not fulfilled, the pointers passed would be silently left unfilled.

I kept the `SDL_WindowData *data;` variable, although I'm not sure why it would need to be stored in a variable.

## Existing Issue(s)
Fixes #9530 
