### PR TITLE
dialog: Allocate space for terminator when building filter string

### DIFF
--- a/src/dialog/SDL_dialog_utils.c
+++ b/src/dialog/SDL_dialog_utils.c
@@ -54,7 +54,7 @@ char *convert_filters(const SDL_DialogFileFilter *filters, NameTransform ntf,
 
         terminator = f[1].name ? separator : suffix;
         new_length = SDL_strlen(combined) + SDL_strlen(converted)
-                   + SDL_strlen(terminator);
+                   + SDL_strlen(terminator) + 1;
 
         new_combined = SDL_realloc(combined, new_length);
 


### PR DESCRIPTION
When building the string in convert_filters, it forgets to allocate an extra space for the terminator character for each iteration. For Windows, this results in the trailing \x01 for each filter not actually being stored, which is undesirable. This fix simply adds 1 to new_length.