### PR TITLE
X11 mode switch sync fix

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1248,8 +1248,11 @@ const SDL_DisplayMode *SDL_GetCurrentDisplayMode(SDL_DisplayID displayID)
 
 int SDL_SetDisplayModeForDisplay(SDL_VideoDisplay *display, SDL_DisplayMode *mode)
 {
-    /* Mode switching is being emulated per-window; nothing to do and cannot fail. */
-    if (SDL_ModeSwitchingEmulated(_this)) {
+    /* Mode switching is being emulated per-window; nothing to do and cannot fail,
+     * except for XWayland, which still needs the actual mode setting call since
+     * it's emulated via the XRandR interface.
+     */
+    if (SDL_ModeSwitchingEmulated(_this) && SDL_strcmp(_this->name, "x11") != 0) {
         return 0;
     }
 

--- a/src/video/x11/SDL_x11modes.c
+++ b/src/video/x11/SDL_x11modes.c
@@ -921,7 +921,7 @@ int X11_SetDisplayMode(SDL_VideoDevice *_this, SDL_VideoDisplay *sdl_display, SD
 
     viddata->last_mode_change_deadline = SDL_GetTicks() + (PENDING_FOCUS_TIME * 2);
 
-    if (mode != &sdl_display->desktop_mode) {
+    if (sdl_display->current_mode != mode) {
         data->mode_switch_deadline_ns = SDL_GetTicksNS() + MODE_SWITCH_TIMEOUT_NS;
     } else {
         data->mode_switch_deadline_ns = 0;

--- a/src/video/x11/SDL_x11modes.c
+++ b/src/video/x11/SDL_x11modes.c
@@ -921,10 +921,13 @@ int X11_SetDisplayMode(SDL_VideoDevice *_this, SDL_VideoDisplay *sdl_display, SD
 
     viddata->last_mode_change_deadline = SDL_GetTicks() + (PENDING_FOCUS_TIME * 2);
 
-    if (sdl_display->current_mode != mode) {
-        data->mode_switch_deadline_ns = SDL_GetTicksNS() + MODE_SWITCH_TIMEOUT_NS;
-    } else {
-        data->mode_switch_deadline_ns = 0;
+    /* XWayland mode switches are emulated with viewports and thus instantaneous. */
+    if (!viddata->is_xwayland) {
+        if (sdl_display->current_mode != mode) {
+            data->mode_switch_deadline_ns = SDL_GetTicksNS() + MODE_SWITCH_TIMEOUT_NS;
+        } else {
+            data->mode_switch_deadline_ns = 0;
+        }
     }
 
 #ifdef SDL_VIDEO_DRIVER_X11_XRANDR


### PR DESCRIPTION
Allows additional sync time if a mode switch is in progress.

Fixes the incorrect fullscreen flag issue in #9560 