### PR TITLE
Close pipe in Wayland_ShowMessageBox

### DIFF
--- a/src/video/wayland/SDL_waylandmessagebox.c
+++ b/src/video/wayland/SDL_waylandmessagebox.c
@@ -212,6 +212,7 @@ int Wayland_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *button
         FILE *outputfp = NULL;
         char *output = NULL;
         char *tmp = NULL;
+        close(fd_pipe[1]);
 
         if (!buttonID) {
             /* if we don't need buttonID, we can return immediately */


### PR DESCRIPTION
## Description

When closing message box by pressing escape, Zenity does not write to the pipe and fgets() get stuck waiting for EOF.

## Existing Issue(s)

Fix #9565
