### PR TITLE
Issues with SDL_platform.h

### DIFF
--- a/include/SDL_platform.h
+++ b/include/SDL_platform.h
@@ -234,7 +234,7 @@
 #define __3DS__ 1
 #endif
 
-#include "begin_code.h"
+#include "SDL2/begin_code.h"
 /* Set up for C function definitions, even when using C++ */
 #ifdef __cplusplus
 extern "C" {
@@ -262,7 +262,7 @@ extern DECLSPEC const char * SDLCALL SDL_GetPlatform (void);
 #ifdef __cplusplus
 }
 #endif
-#include "close_code.h"
+#include "SDL2/close_code.h"
 
 #endif /* SDL_platform_h_ */
 


### PR DESCRIPTION
# Changed the paths in SDL_platform.h
(Similar to #6669)

## Description
I was having trouble with SDL installed with Ubuntu (`sudo apt-get install libsdl2-dev`) with CMake and Clang++. I ended up having to go and edit SDL_platform.h with the method specified in #6669.

## Additional Details
This was fixed in SDL3, but I feel as if this should be contributed to the SDL2 branch of the project.
