### PR TITLE
SDL3 removed SDL_HINT_RENDER_SCALE_QUALITY hint

### DIFF
--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -494,9 +494,6 @@ extern DECLSPEC int SDLCALL SDL_GetCurrentRenderOutputSize(SDL_Renderer *rendere
 /**
  * Create a texture for a rendering context.
  *
- * You can set the texture scaling method by setting
- * `SDL_HINT_RENDER_SCALE_QUALITY` before creating the texture.
- *
  * \param renderer the rendering context
  * \param format one of the enumerated values in SDL_PixelFormatEnum
  * \param access one of the enumerated values in SDL_TextureAccess


### PR DESCRIPTION
textures now default to linear filtering, use SDL_SetTextureScaleMode(texture, SDL_SCALEMODE_NEAREST) if you want nearest pixel mode instead

https://github.com/libsdl-org/SDL/blob/093160904d49d99c9e50467a3dd04c0f98f292d2/docs/README-migration.md?plain=1#L724

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
