### PR TITLE
render: SDL_DestroyWindow hollows out its renderer but doesn't free it. 

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -900,11 +900,17 @@ SDL_Renderer *SDL_CreateRendererWithProperties(SDL_PropertiesID props)
     SDL_Window *window = (SDL_Window *)SDL_GetProperty(props, SDL_PROP_RENDERER_CREATE_WINDOW_POINTER, NULL);
     SDL_Surface *surface = (SDL_Surface *)SDL_GetProperty(props, SDL_PROP_RENDERER_CREATE_SURFACE_POINTER, NULL);
     const char *name = SDL_GetStringProperty(props, SDL_PROP_RENDERER_CREATE_NAME_STRING, NULL);
-    SDL_Renderer *renderer = NULL;
     const int n = SDL_GetNumRenderDrivers();
     const char *hint;
     int i, attempted = 0;
     SDL_PropertiesID new_props;
+
+    SDL_Renderer *renderer = (SDL_Renderer *)SDL_calloc(1, sizeof(*renderer));
+    if (!renderer) {
+        return NULL;
+    }
+
+    renderer->magic = &SDL_renderer_magic;
 
 #ifdef SDL_PLATFORM_ANDROID
     Android_ActivityMutex_Lock_Running();
@@ -932,15 +938,15 @@ SDL_Renderer *SDL_CreateRendererWithProperties(SDL_PropertiesID props)
 
     if (surface) {
 #if SDL_VIDEO_RENDER_SW
-        renderer = SW_CreateRendererForSurface(surface, props);
+        const int rc = SW_CreateRendererForSurface(renderer, surface, props);
 #else
-        renderer = NULL;
-        SDL_SetError("SDL not built with software renderer");
+        const int rc = SDL_SetError("SDL not built with software renderer");
 #endif
-        if (!renderer) {
+        if (rc == -1) {
             goto error;
         }
     } else {
+        int rc = -1;
         if (!name) {
             name = SDL_GetHint(SDL_HINT_RENDER_DRIVER);
         }
@@ -949,26 +955,27 @@ SDL_Renderer *SDL_CreateRendererWithProperties(SDL_PropertiesID props)
             for (i = 0; i < n; i++) {
                 const SDL_RenderDriver *driver = render_drivers[i];
                 if (SDL_strcasecmp(name, driver->info.name) == 0) {
-                    /* Create a new renderer instance */
+                    // Create a new renderer instance
                     ++attempted;
-                    renderer = driver->CreateRenderer(window, props);
+                    rc = driver->CreateRenderer(renderer, window, props);
                     break;
                 }
             }
         } else {
             for (i = 0; i < n; i++) {
                 const SDL_RenderDriver *driver = render_drivers[i];
-                /* Create a new renderer instance */
+                // Create a new renderer instance
                 ++attempted;
-                renderer = driver->CreateRenderer(window, props);
-                if (renderer) {
-                    /* Yay, we got one! */
-                    break;
+                rc = driver->CreateRenderer(renderer, window, props);
+                if (rc == 0) {
+                    break;  // Yay, we got one!
                 }
+                SDL_zerop(renderer);  // make sure we don't leave function pointers from a previous CreateRenderer() in this struct.
+                renderer->magic = &SDL_renderer_magic;
             }
         }
 
-        if (!renderer) {
+        if (rc == -1) {
             if (!name || !attempted) {
                 SDL_SetError("Couldn't find matching render driver");
             }
@@ -1072,6 +1079,7 @@ error:
 #ifdef SDL_PLATFORM_ANDROID
     Android_ActivityMutex_Unlock();
 #endif
+    SDL_free(renderer);
     return NULL;
 
 #else
@@ -4522,7 +4530,6 @@ void SDL_DestroyRenderer(SDL_Renderer *renderer)
     /* Free existing textures for this renderer */
     while (renderer->textures) {
         SDL_Texture *tex = renderer->textures;
-        (void)tex;
         SDL_DestroyTextureInternal(renderer->textures, SDL_TRUE /* is_destroying */);
         SDL_assert(tex != renderer->textures); /* satisfy static analysis. */
     }
@@ -4540,8 +4547,10 @@ void SDL_DestroyRenderer(SDL_Renderer *renderer)
     SDL_DestroyMutex(renderer->target_mutex);
     renderer->target_mutex = NULL;
 
-    /* Free the renderer instance */
+    /* Clean up renderer-specific resources */
     renderer->DestroyRenderer(renderer);
+
+    SDL_free(renderer);
 }
 
 void *SDL_GetRenderMetalLayer(SDL_Renderer *renderer)

--- a/src/render/SDL_sysrender.h
+++ b/src/render/SDL_sysrender.h
@@ -289,6 +289,8 @@ struct SDL_Renderer
 
     SDL_PropertiesID props;
 
+    SDL_bool destroyed;   // already destroyed by SDL_DestroyWindow; just free this struct in SDL_DestroyRenderer.
+
     void *driverdata;
 };
 
@@ -334,6 +336,9 @@ extern SDL_BlendOperation SDL_GetBlendModeAlphaOperation(SDL_BlendMode blendMode
    for a vertex buffer during RunCommandQueue(). Pointers returned here are only valid until
    the next call, because it might be in an array that gets realloc()'d. */
 extern void *SDL_AllocateRenderVertices(SDL_Renderer *renderer, const size_t numbytes, const size_t alignment, size_t *offset);
+
+// Let the video subsystem destroy a renderer without making its pointer invalid.
+extern void SDL_DestroyRendererWithoutFreeing(SDL_Renderer *renderer);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/src/render/SDL_sysrender.h
+++ b/src/render/SDL_sysrender.h
@@ -295,7 +295,7 @@ struct SDL_Renderer
 /* Define the SDL render driver structure */
 struct SDL_RenderDriver
 {
-    SDL_Renderer *(*CreateRenderer)(SDL_Window *window, SDL_PropertiesID props);
+    int (*CreateRenderer)(SDL_Renderer *renderer, SDL_Window *window, SDL_PropertiesID props);
 
     /* Info about the renderer capabilities */
     SDL_RendererInfo info;

--- a/src/render/direct3d12/SDL_render_d3d12.c
+++ b/src/render/direct3d12/SDL_render_d3d12.c
@@ -587,7 +587,6 @@ static void D3D12_DestroyRenderer(SDL_Renderer *renderer)
     if (data) {
         SDL_free(data);
     }
-    SDL_free(renderer);
 }
 
 static D3D12_BLEND GetBlendFunc(SDL_BlendFactor factor)
@@ -3173,37 +3172,26 @@ static int D3D12_SetVSync(SDL_Renderer *renderer, const int vsync)
     return 0;
 }
 
-SDL_Renderer *D3D12_CreateRenderer(SDL_Window *window, SDL_PropertiesID create_props)
+int D3D12_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_PropertiesID create_props)
 {
-    SDL_Renderer *renderer;
     D3D12_RenderData *data;
 
     if (SDL_GetWindowFlags(window) & SDL_WINDOW_TRANSPARENT) {
 		/* D3D12 removed the swap effect needed to support transparent windows, use D3D11 instead */
-		SDL_SetError("The direct3d12 renderer doesn't work with transparent windows");
-		return NULL;
+		return SDL_SetError("The direct3d12 renderer doesn't work with transparent windows");
 	}
-
-    renderer = (SDL_Renderer *)SDL_calloc(1, sizeof(*renderer));
-    if (!renderer) {
-        return NULL;
-    }
-    renderer->magic = &SDL_renderer_magic;
 
     SDL_SetupRendererColorspace(renderer, create_props);
 
     if (renderer->output_colorspace != SDL_COLORSPACE_SRGB &&
         renderer->output_colorspace != SDL_COLORSPACE_SRGB_LINEAR
         /*&& renderer->output_colorspace != SDL_COLORSPACE_HDR10*/) {
-        SDL_SetError("Unsupported output colorspace");
-        SDL_free(renderer);
-        return NULL;
+        return SDL_SetError("Unsupported output colorspace");
     }
 
     data = (D3D12_RenderData *)SDL_calloc(1, sizeof(*data));
     if (!data) {
-        SDL_free(renderer);
-        return NULL;
+        return -1;
     }
 
     data->identity = MatrixIdentity();
@@ -3248,14 +3236,14 @@ SDL_Renderer *D3D12_CreateRenderer(SDL_Window *window, SDL_PropertiesID create_p
     /* Initialize Direct3D resources */
     if (FAILED(D3D12_CreateDeviceResources(renderer))) {
         D3D12_DestroyRenderer(renderer);
-        return NULL;
+        return -1;
     }
     if (FAILED(D3D12_CreateWindowSizeDependentResources(renderer))) {
         D3D12_DestroyRenderer(renderer);
-        return NULL;
+        return -1;
     }
 
-    return renderer;
+    return 0;
 }
 
 SDL_RenderDriver D3D12_RenderDriver = {

--- a/src/render/ps2/SDL_render_ps2.c
+++ b/src/render/ps2/SDL_render_ps2.c
@@ -602,8 +602,6 @@ static void PS2_DestroyRenderer(SDL_Renderer *renderer)
     if (vsync_sema_id >= 0) {
         DeleteSema(vsync_sema_id);
     }
-
-    SDL_free(renderer);
 }
 
 static int PS2_SetVSync(SDL_Renderer *renderer, const int vsync)
@@ -614,32 +612,23 @@ static int PS2_SetVSync(SDL_Renderer *renderer, const int vsync)
     return 0;
 }
 
-static SDL_Renderer *PS2_CreateRenderer(SDL_Window *window, SDL_PropertiesID create_props)
+static int PS2_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_PropertiesID create_props)
 {
-    SDL_Renderer *renderer;
     PS2_RenderData *data;
     GSGLOBAL *gsGlobal;
     ee_sema_t sema;
     SDL_bool dynamicVsync;
 
-    renderer = (SDL_Renderer *)SDL_calloc(1, sizeof(*renderer));
-    if (!renderer) {
-        return NULL;
-    }
-    renderer->magic = &SDL_renderer_magic;
-
     SDL_SetupRendererColorspace(renderer, create_props);
 
     if (renderer->output_colorspace != SDL_COLORSPACE_SRGB) {
-        SDL_SetError("Unsupported output colorspace");
         SDL_free(renderer);
-        return NULL;
+        return SDL_SetError("Unsupported output colorspace");
     }
 
     data = (PS2_RenderData *)SDL_calloc(1, sizeof(*data));
     if (!data) {
-        PS2_DestroyRenderer(renderer);
-        return NULL;
+        return -1;
     }
 
     /* Specific gsKit init */
@@ -711,7 +700,7 @@ static SDL_Renderer *PS2_CreateRenderer(SDL_Window *window, SDL_PropertiesID cre
     if (data->vsync) {
         renderer->info.flags |= SDL_RENDERER_PRESENTVSYNC;
     }
-    return renderer;
+    return 0;
 }
 
 SDL_RenderDriver PS2_RenderDriver = {

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -1277,7 +1277,6 @@ static void PSP_DestroyRenderer(SDL_Renderer *renderer)
         data->displayListAvail = SDL_FALSE;
         SDL_free(data);
     }
-    SDL_free(renderer);
 }
 
 static int PSP_SetVSync(SDL_Renderer *renderer, const int vsync)
@@ -1287,31 +1286,21 @@ static int PSP_SetVSync(SDL_Renderer *renderer, const int vsync)
     return 0;
 }
 
-SDL_Renderer *PSP_CreateRenderer(SDL_Window *window, SDL_PropertiesID create_props)
+static int PSP_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_PropertiesID create_props)
 {
-    SDL_Renderer *renderer;
     PSP_RenderData *data;
     int pixelformat;
     void *doublebuffer = NULL;
 
-    renderer = (SDL_Renderer *)SDL_calloc(1, sizeof(*renderer));
-    if (!renderer) {
-        return NULL;
-    }
-    renderer->magic = &SDL_renderer_magic;
-
     SDL_SetupRendererColorspace(renderer, create_props);
 
     if (renderer->output_colorspace != SDL_COLORSPACE_SRGB) {
-        SDL_SetError("Unsupported output colorspace");
-        SDL_free(renderer);
-        return NULL;
+        return SDL_SetError("Unsupported output colorspace");
     }
 
     data = (PSP_RenderData *)SDL_calloc(1, sizeof(*data));
     if (!data) {
-        PSP_DestroyRenderer(renderer);
-        return NULL;
+        return -1;
     }
 
     renderer->WindowEvent = PSP_WindowEvent;
@@ -1406,7 +1395,7 @@ SDL_Renderer *PSP_CreateRenderer(SDL_Window *window, SDL_PropertiesID create_pro
     if (data->vsync) {
         renderer->info.flags |= SDL_RENDERER_PRESENTVSYNC;
     }
-    return renderer;
+    return 0;
 }
 
 SDL_RenderDriver PSP_RenderDriver = {

--- a/src/render/software/SDL_render_sw_c.h
+++ b/src/render/software/SDL_render_sw_c.h
@@ -22,6 +22,6 @@
 #ifndef SDL_render_sw_c_h_
 #define SDL_render_sw_c_h_
 
-extern SDL_Renderer *SW_CreateRendererForSurface(SDL_Surface *surface, SDL_PropertiesID create_props);
+extern int SW_CreateRendererForSurface(SDL_Renderer *renderer, SDL_Surface *surface, SDL_PropertiesID create_props);
 
 #endif /* SDL_render_sw_c_h_ */

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -34,6 +34,7 @@
 #include "../SDL_properties_c.h"
 #include "../timer/SDL_timer_c.h"
 #include "../camera/SDL_camera_c.h"
+#include "../render/SDL_sysrender.h"
 
 #ifdef SDL_VIDEO_OPENGL
 #include <SDL3/SDL_opengl.h>
@@ -3649,7 +3650,7 @@ void SDL_DestroyWindow(SDL_Window *window)
 
     SDL_Renderer *renderer = SDL_GetRenderer(window);
     if (renderer) {
-        SDL_DestroyRenderer(renderer);
+        SDL_DestroyRendererWithoutFreeing(renderer);
     }
 
     SDL_DestroyProperties(window->props);


### PR DESCRIPTION
This allows apps to destroy the window and renderer in either order, but makes sure that the renderer can properly clean up its resources while OpenGL contexts and libraries are still loaded, etc.
    
If the window is destroyed first, the renderer is (mostly) destroyed but its pointer remains valid. Attempts to use the renderer will return an error, but it can still be explicitly destroyed, at which time the struct is free'd.
    
If the renderer is destroyed first, everything works as before, and a new renderer can still be created on the existing window.

This also moves memory management of the SDL_Renderer struct itself out of the backends and to the higher level, which was necessary for this, but also turned out to be a nice code cleanup.

Fixes #9540.
