### PR TITLE
windows hidapi: fix header compilation

### DIFF
--- a/src/hidapi/windows/hidapi_descriptor_reconstruct.h
+++ b/src/hidapi/windows/hidapi_descriptor_reconstruct.h
@@ -16,6 +16,8 @@
  code repository located at:
         https://github.com/libusb/hidapi .
 ********************************************************/
+#include "SDL_internal.h"
+
 #ifndef HIDAPI_DESCRIPTOR_RECONSTRUCT_H__
 #define HIDAPI_DESCRIPTOR_RECONSTRUCT_H__
 


### PR DESCRIPTION
## Description
I am compiling SDL using Zig and I hit a compilation error - the `SDL_COMPILE_TIME_ASSERT` macro wasn't available to this header. Following the convention of `SDL_riscosdefs.h`, I think it makes sense to include `SDL_internal.h` at the top of the header. 
