### PR TITLE
pipewire: Raise minimum build version to 0.3.44

### DIFF
--- a/cmake/sdlchecks.cmake
+++ b/cmake/sdlchecks.cmake
@@ -134,7 +134,7 @@ endmacro()
 # - HAVE_SDL_LOADSO opt
 macro(CheckPipewire)
   if(SDL_PIPEWIRE)
-    set(PipeWire_PKG_CONFIG_SPEC libpipewire-0.3>=0.3.20)
+    set(PipeWire_PKG_CONFIG_SPEC libpipewire-0.3>=0.3.44)
     pkg_check_modules(PC_PIPEWIRE IMPORTED_TARGET ${PipeWire_PKG_CONFIG_SPEC})
     if(PC_PIPEWIRE_FOUND)
       set(HAVE_PIPEWIRE TRUE)


### PR DESCRIPTION
Currently, the minimum version of the Pipewire library required to build the SDL backend is 0.3.20, with 0.3.24 required for basic operation. Several config keys have been backported from newer versions, and version checks are required to account for behavior changes. There seems to be little point in keeping the base build version so low for SDL 3, as every distro that isn't currently EOL-ed either [ships a much newer version than is required](https://repology.org/project/pipewire/versions), or, in the cases of Debian 11 and Ubuntu 20.02, ships a version below the base version of 0.3.20 that is currently required (0.3.19 and 0.2.7 respectfully, although Debian 11 backports offers 0.3.65).

This bumps the minimum version to 0.3.44 (released in Jan 2022), which allows for the removal of the extra version checks and backported config keys. It's still low enough that no currently supported distro support is lost, but allows for some cleanup in the code.