### PR TITLE
Documentation and test updates for renderer destruction changes

### DIFF
--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -2031,10 +2031,6 @@ extern DECLSPEC void SDLCALL SDL_DestroyTexture(SDL_Texture *texture);
  * If `renderer` is NULL, this function will return immediately after setting
  * the SDL error message to "Invalid renderer". See SDL_GetError().
  *
- * Note that destroying a window implicitly destroys the associated renderer,
- * so this should not be called if the window associated with the renderer has
- * already been destroyed.
- *
  * \param renderer the rendering context
  *
  * \since This function is available since SDL 3.0.0.

--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -2179,9 +2179,6 @@ extern DECLSPEC int SDLCALL SDL_FlashWindow(SDL_Window *window, SDL_FlashOperati
 /**
  * Destroy a window.
  *
- * If the window has an associated SDL_Renderer, it will be implicitly
- * destroyed as well.
- *
  * If `window` is NULL, this function will return immediately after setting
  * the SDL error message to "Invalid window". See SDL_GetError().
  *

--- a/test/testautomation_video.c
+++ b/test/testautomation_video.c
@@ -75,6 +75,10 @@ static SDL_Window *createVideoSuiteTestWindow(const char *title)
 static void destroyVideoSuiteTestWindow(SDL_Window *window)
 {
     if (window != NULL) {
+        SDL_Renderer *renderer = SDL_GetRenderer(window);
+        if (renderer) {
+            SDL_DestroyRenderer(renderer);
+        }
         SDL_DestroyWindow(window);
         window = NULL;
         SDLTest_AssertPass("Call to SDL_DestroyWindow()");


### PR DESCRIPTION
-Removes the documentation about renderers being implicitly destroyed with windows.
-Cleans up renderers associated with windows in the automated video test suite.

Cleanups for #9540