### PR TITLE
event: Always clear the mouse capture flag, even if the backend captu…

### DIFF
--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -907,9 +907,15 @@ int SDL_SetKeyboardFocus(SDL_Window *window)
 
         /* old window must lose an existing mouse capture. */
         if (keyboard->focus->flags & SDL_WINDOW_MOUSE_CAPTURE) {
-            SDL_CaptureMouse(SDL_FALSE); /* drop the capture. */
-            SDL_UpdateMouseCapture(SDL_TRUE);
-            SDL_assert(!(keyboard->focus->flags & SDL_WINDOW_MOUSE_CAPTURE));
+            SDL_Mouse *mouse = SDL_GetMouse();
+
+            if (mouse->CaptureMouse) {
+                SDL_CaptureMouse(SDL_FALSE); /* drop the capture. */
+                SDL_UpdateMouseCapture(SDL_TRUE);
+                SDL_assert(!(keyboard->focus->flags & SDL_WINDOW_MOUSE_CAPTURE));
+            } else {
+                keyboard->focus->flags &= ~SDL_WINDOW_MOUSE_CAPTURE;
+            }
         }
 
         SDL_SendWindowEvent(keyboard->focus, SDL_EVENT_WINDOW_FOCUS_LOST, 0, 0);


### PR DESCRIPTION
…re function isn't implemented.

Some backends, such as Wayland, don't support explicit mouse capture, and thus don't implement the backend function to do so, but do set/unset the capture flag on button events to handle cases where a button is pressed and the pointer is dragged outside the window.

If the backend doesn't support explicitly setting the mouse capture mode, manually clear the capture flag when the window has had the focus forcibly removed, to avoid sending bogus motion events as well as an assert condition.

Fixes #9612