### PR TITLE
testlock.c: Replacing function call kill with raise

### DIFF
--- a/test/testlock.c
+++ b/test/testlock.c
@@ -102,7 +102,7 @@ Run(void *data)
 #ifndef _WIN32
 static Uint32 hit_timeout(Uint32 interval, void *param) {
     SDL_Log("Hit timeout! Sending SIGINT!");
-    kill(0, SIGINT);
+    (void)raise(SIGINT);
     return 0;
 }
 #endif


### PR DESCRIPTION
#fixes #9617
Replacing function call `kill(0, SIGINT);` with `(void)raise(SIGINT);` in file test/testlock.c.
The `kill()` function isn't available on Unix systems when compiling with STDC instead of GNUC.