### PR TITLE
.gitignore: Adding compile_commands.json and .cache/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ cmake_uninstall.cmake
 SDL3ConfigVersion.cmake
 .ninja_*
 *.ninja
+compile_commands.json
+.cache/
 
 # for CLion
 .idea


### PR DESCRIPTION
Useful when compiling with `CMake` and the `-D CMAKE_EXPORT_COMPILE_COMMANDS=YES` flag and then placing the `compile_commands.json` file (or a symlink) into the SDL directory for linting.