### PR TITLE
loongarch: Delete the configuration of the compilation option "mlasx"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -927,22 +927,6 @@ if(SDL_ASSEMBLY)
       endif()
     endif()
 
-    if(SDL_LASX)
-      cmake_push_check_state()
-      set(CMAKE_REQUIRED_FLAGS "-mlasx")
-      check_c_source_compiles("
-          #ifndef __loongarch_asx
-          #error Assembler CPP flag not enabled
-          #endif
-          int main(int argc, char **argv) { return 0; }" CPU_SUPPORTS_LASX)
-      check_include_file("lasxintrin.h" HAVE_LASXINTRIN_H)
-      cmake_pop_check_state()
-      if(CPU_SUPPORTS_LASX AND HAVE_LASXINTRIN_H)
-        list(APPEND EXTRA_CFLAGS "-mlasx")
-        set(HAVE_LASX TRUE)
-      endif()
-    endif()
-
     if(SDL_ARMSIMD)
       set(ORIG_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
       set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -x assembler-with-cpp")

--- a/configure
+++ b/configure
@@ -873,7 +873,6 @@ enable_sse2
 enable_sse3
 enable_altivec
 enable_lsx
-enable_lasx
 enable_oss
 enable_alsa
 with_alsa_prefix
@@ -1675,7 +1674,6 @@ Optional Features:
   --enable-sse3           use SSE3 assembly routines [default=maybe]
   --enable-altivec        use Altivec assembly routines [default=yes]
   --enable-lsx            use LSX assembly routines [default=yes]
-  --enable-lasx           use LASX assembly routines [default=yes]
   --enable-oss            support the OSS audio API [default=maybe]
   --enable-alsa           support the ALSA audio API [default=yes]
   --disable-alsatest      Do not try to compile and run a test Alsa program
@@ -21109,80 +21107,6 @@ printf "%s\n" "$have_lsxintrin_h_hdr" >&6; }
     if test x$have_lsxintrin_h_hdr = xyes; then
 
 printf "%s\n" "#define HAVE_LSXINTRIN_H 1" >>confdefs.h
-
-    fi
-
-    # Check whether --enable-lasx was given.
-if test ${enable_lasx+y}
-then :
-  enableval=$enable_lasx;
-else $as_nop
-  enable_LASX=yes
-fi
-
-    if test x$enable_LASX = xyes; then
-        save_CFLAGS="$CFLAGS"
-        have_gcc_lasx=no
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for GCC -mlasx option" >&5
-printf %s "checking for GCC -mlasx option... " >&6; }
-        lasx_CFLAGS="-mlasx"
-        CFLAGS="$save_CFLAGS $lasx_CFLAGS"
-
-        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-        #ifndef __loongarch_asx
-        #error Assembler CPP flag not enabled
-        #endif
-
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  have_gcc_lasx=yes
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $have_gcc_lasx" >&5
-printf "%s\n" "$have_gcc_lasx" >&6; }
-        CFLAGS="$save_CFLAGS"
-
-        if test x$have_gcc_lasx = xyes; then
-            EXTRA_CFLAGS="$EXTRA_CFLAGS $lasx_CFLAGS"
-            SUMMARY_math="${SUMMARY_math} lasx"
-        fi
-    fi
-
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for lasxintrin.h" >&5
-printf %s "checking for lasxintrin.h... " >&6; }
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <lasxintrin.h>
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  have_lasxintrin_h_hdr=yes
-else $as_nop
-  have_lasxintrin_h_hdr=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $have_lasxintrin_h_hdr" >&5
-printf "%s\n" "$have_lasxintrin_h_hdr" >&6; }
-    if test x$have_lasxintrin_h_hdr = xyes; then
-
-printf "%s\n" "#define HAVE_LASXINTRIN_H 1" >>confdefs.h
 
     fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -938,38 +938,6 @@ fi
         AC_DEFINE(HAVE_LSXINTRIN_H, 1, [ ])
     fi
 
-    AC_ARG_ENABLE(lasx,
-[AS_HELP_STRING([--enable-lasx], [use LASX assembly routines [default=yes]])],
-                  , enable_LASX=yes)
-    if test x$enable_LASX = xyes; then
-        save_CFLAGS="$CFLAGS"
-        have_gcc_lasx=no
-        AC_MSG_CHECKING(for GCC -mlasx option)
-        lasx_CFLAGS="-mlasx"
-        CFLAGS="$save_CFLAGS $lasx_CFLAGS"
-
-        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-        #ifndef __loongarch_asx
-        #error Assembler CPP flag not enabled
-        #endif
-        ]], [])], [have_gcc_lasx=yes], [])
-        AC_MSG_RESULT($have_gcc_lasx)
-        CFLAGS="$save_CFLAGS"
-
-        if test x$have_gcc_lasx = xyes; then
-            EXTRA_CFLAGS="$EXTRA_CFLAGS $lasx_CFLAGS"
-            SUMMARY_math="${SUMMARY_math} lasx"
-        fi
-    fi
-
-    AC_MSG_CHECKING(for lasxintrin.h)
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <lasxintrin.h>]])],
-       [have_lasxintrin_h_hdr=yes],[have_lasxintrin_h_hdr=no])
-    AC_MSG_RESULT($have_lasxintrin_h_hdr)
-    if test x$have_lasxintrin_h_hdr = xyes; then
-        AC_DEFINE(HAVE_LASXINTRIN_H, 1, [ ])
-    fi
-
 dnl See if the OSS audio interface is supported
 CheckOSS()
 {


### PR DESCRIPTION
This option causes the compiler to automatically generate 256-bit vector instructions. This can cause errors on some machines(2k2000) that do not support 256-bit vectors. @madebr 