### PR TITLE
Renaming SDL_eventaction tag to SDL_EventAction

### DIFF
--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -900,7 +900,7 @@ SDL_COMPILE_TIME_ASSERT(SDL_Event, sizeof(SDL_Event) == sizeof(((SDL_Event *)NUL
 extern DECLSPEC void SDLCALL SDL_PumpEvents(void);
 
 /* @{ */
-typedef enum SDL_eventaction
+typedef enum SDL_EventAction
 {
     SDL_ADDEVENT,
     SDL_PEEKEVENT,


### PR DESCRIPTION
In c8a0660 `SDL_eventaction` was renamed to `SDL_EventAction`.
At that time it only had an identifier in the ordinary name space.

Shortly after, ad090d2 added a tag name but it was the old name `SDL_eventaction`.

This commit here also changes the tag name to `SDL_EventAction`.