### PR TITLE
docs: rename num to size in SDL_iostream

### DIFF
--- a/include/SDL3/SDL_iostream.h
+++ b/include/SDL3/SDL_iostream.h
@@ -483,7 +483,7 @@ extern DECLSPEC size_t SDLCALL SDL_ReadIO(SDL_IOStream *context, void *ptr, size
  *
  * This function writes exactly `size` bytes from the area pointed at by `ptr`
  * to the stream. If this fails for any reason, it'll return less than `size`
- * to demonstrate how far the write progressed. On success, it returns `num`.
+ * to demonstrate how far the write progressed. On success, it returns `size`.
  *
  * On error, this function still attempts to write as much as possible, so it
  * might return a positive value less than the requested write size.
@@ -495,7 +495,7 @@ extern DECLSPEC size_t SDLCALL SDL_ReadIO(SDL_IOStream *context, void *ptr, size
  * \param context a pointer to an SDL_IOStream structure
  * \param ptr a pointer to a buffer containing data to write
  * \param size the number of bytes to write
- * \returns the number of bytes written, which will be less than `num` on
+ * \returns the number of bytes written, which will be less than `size` on
  *          error; call SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.


### PR DESCRIPTION
`num` was used in SDL2's SDL_RWwrite. SDL3's SDL_WriteIO only accepts `size` in bytes, so there's no reason for `num` to be here.