### PR TITLE
Removing function macro SDL_TABLESIZE()

### DIFF
--- a/build-scripts/SDL_migration.cocci
+++ b/build-scripts/SDL_migration.cocci
@@ -3142,6 +3142,10 @@ typedef SDL_Colour, SDL_Color;
   (...)
 @@
 @@
+- SDL_TABLESIZE
++ SDL_arraysize
+@@
+@@
 - SDL_iPhoneSetEventPump
 + SDL_iOSSetEventPump
   (...)

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -1425,6 +1425,9 @@ SDL3 attempts to apply consistency to case-insensitive string functions. In SDL2
 
 Please note that the case-folding technique used by SDL3 will not produce correct results for the "Turkish 'I'"; this one letter is a surprisingly hard problem in the Unicode world, and since these functions do not specify the human language in use, we have chosen to ignore this problem.
 
+The following macros have been removed:
+* SDL_TABLESIZE() - use SDL_arraysize() instead
+
 The following functions have been renamed:
 * SDL_strtokr() => SDL_strtok_r()
 

--- a/include/SDL3/SDL_oldnames.h
+++ b/include/SDL3/SDL_oldnames.h
@@ -492,6 +492,7 @@
 #define SDL_SensorUpdate SDL_UpdateSensors
 
 /* ##SDL_stdinc.h */
+#define SDL_TABLESIZE SDL_arraysize
 #define SDL_strtokr SDL_strtok_r
 
 /* ##SDL_surface.h */
@@ -999,6 +1000,7 @@
 #define SDL_SensorUpdate SDL_SensorUpdate_renamed_SDL_UpdateSensors
 
 /* ##SDL_stdinc.h */
+#define SDL_TABLESIZE SDL_TABLESIZE_renamed_SDL_arraysize
 #define SDL_strtokr SDL_strtokr_renamed_SDL_strtok_r
 
 /* ##SDL_surface.h */

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -91,10 +91,11 @@ void *alloca(size_t);
 /**
  * The number of elements in an array.
  *
+ * NOTE: This macro double-evaluates the argument, so you should never have side effects in the parameter.
+ * 
  * \since This macro is available since SDL 3.0.0.
  */
-#define SDL_arraysize(array)    (sizeof(array)/sizeof(array[0]))
-#define SDL_TABLESIZE(table)    SDL_arraysize(table)
+#define SDL_arraysize(array) (sizeof(array)/sizeof(array[0]))
 
 /**
  * Macro useful for building other macros with strings in them.

--- a/src/video/haiku/SDL_bkeyboard.cc
+++ b/src/video/haiku/SDL_bkeyboard.cc
@@ -40,7 +40,7 @@ static SDL_Scancode keymap[KEYMAP_SIZE];
 static int8 keystate[KEYMAP_SIZE];
 
 void HAIKU_InitOSKeymap(void) {
-        for ( uint i = 0; i < SDL_TABLESIZE(keymap); ++i ) {
+        for ( uint i = 0; i < SDL_arraysize(keymap); ++i ) {
             keymap[i] = SDL_SCANCODE_UNKNOWN;
         }
 
@@ -158,7 +158,7 @@ void HAIKU_InitOSKeymap(void) {
 }
 
 SDL_Scancode HAIKU_GetScancodeFromBeKey(int32 bkey) {
-    if (bkey > 0 && bkey < (int32)SDL_TABLESIZE(keymap)) {
+    if (bkey > 0 && bkey < (int32)SDL_arraysize(keymap)) {
         return keymap[bkey];
     } else {
         return SDL_SCANCODE_UNKNOWN;

--- a/src/video/kmsdrm/SDL_kmsdrmdyn.c
+++ b/src/video/kmsdrm/SDL_kmsdrmdyn.c
@@ -48,7 +48,7 @@ static void *KMSDRM_GetSym(const char *fnname, int *pHasModule)
 {
     int i;
     void *fn = NULL;
-    for (i = 0; i < SDL_TABLESIZE(kmsdrmlibs); i++) {
+    for (i = 0; i < SDL_arraysize(kmsdrmlibs); i++) {
         if (kmsdrmlibs[i].lib) {
             fn = SDL_LoadFunction(kmsdrmlibs[i].lib, fnname);
             if (fn) {
@@ -97,7 +97,7 @@ void SDL_KMSDRM_UnloadSymbols(void)
 #include "SDL_kmsdrmsym.h"
 
 #ifdef SDL_VIDEO_DRIVER_KMSDRM_DYNAMIC
-            for (i = 0; i < SDL_TABLESIZE(kmsdrmlibs); i++) {
+            for (i = 0; i < SDL_arraysize(kmsdrmlibs); i++) {
                 if (kmsdrmlibs[i].lib) {
                     SDL_UnloadObject(kmsdrmlibs[i].lib);
                     kmsdrmlibs[i].lib = NULL;
@@ -118,7 +118,7 @@ int SDL_KMSDRM_LoadSymbols(void)
 #ifdef SDL_VIDEO_DRIVER_KMSDRM_DYNAMIC
         int i;
         int *thismod = NULL;
-        for (i = 0; i < SDL_TABLESIZE(kmsdrmlibs); i++) {
+        for (i = 0; i < SDL_arraysize(kmsdrmlibs); i++) {
             if (kmsdrmlibs[i].libname) {
                 kmsdrmlibs[i].lib = SDL_LoadObject(kmsdrmlibs[i].libname);
             }

--- a/src/video/psp/SDL_pspevents.c
+++ b/src/video/psp/SDL_pspevents.c
@@ -128,7 +128,7 @@ void PSP_InitOSKeymap(SDL_VideoDevice *_this)
 {
 #ifdef PSPIRKEYB
     int i;
-    for (i = 0; i < SDL_TABLESIZE(keymap); ++i) {
+    for (i = 0; i < SDL_arraysize(keymap); ++i) {
         keymap[i] = SDLK_UNKNOWN;
     }
 

--- a/src/video/qnx/SDL_qnxkeyboard.c
+++ b/src/video/qnx/SDL_qnxkeyboard.c
@@ -106,7 +106,7 @@ void handleKeyboardEvent(screen_event_t event)
     }
 
     // Skip unrecognized keys.
-    if ((val < 0) || (val >= SDL_TABLESIZE(key_to_sdl))) {
+    if ((val < 0) || (val >= SDL_arraysize(key_to_sdl))) {
         return;
     }
 

--- a/src/video/wayland/SDL_waylanddyn.c
+++ b/src/video/wayland/SDL_waylanddyn.c
@@ -111,7 +111,7 @@ void SDL_WAYLAND_UnloadSymbols(void)
 #include "SDL_waylandsym.h"
 
 #ifdef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC
-            for (i = 0; i < SDL_TABLESIZE(waylandlibs); i++) {
+            for (i = 0; i < SDL_arraysize(waylandlibs); i++) {
                 if (waylandlibs[i].lib) {
                     SDL_UnloadObject(waylandlibs[i].lib);
                     waylandlibs[i].lib = NULL;
@@ -132,7 +132,7 @@ int SDL_WAYLAND_LoadSymbols(void)
 #ifdef SDL_VIDEO_DRIVER_WAYLAND_DYNAMIC
         int i;
         int *thismod = NULL;
-        for (i = 0; i < SDL_TABLESIZE(waylandlibs); i++) {
+        for (i = 0; i < SDL_arraysize(waylandlibs); i++) {
             if (waylandlibs[i].libname) {
                 waylandlibs[i].lib = SDL_LoadObject(waylandlibs[i].libname);
             }

--- a/src/video/x11/SDL_x11dyn.c
+++ b/src/video/x11/SDL_x11dyn.c
@@ -71,7 +71,7 @@ static void *X11_GetSym(const char *fnname, int *pHasModule)
 {
     int i;
     void *fn = NULL;
-    for (i = 0; i < SDL_TABLESIZE(x11libs); i++) {
+    for (i = 0; i < SDL_arraysize(x11libs); i++) {
         if (x11libs[i].lib) {
             fn = SDL_LoadFunction(x11libs[i].lib, fnname);
             if (fn) {
@@ -132,7 +132,7 @@ void SDL_X11_UnloadSymbols(void)
 #endif
 
 #ifdef SDL_VIDEO_DRIVER_X11_DYNAMIC
-            for (i = 0; i < SDL_TABLESIZE(x11libs); i++) {
+            for (i = 0; i < SDL_arraysize(x11libs); i++) {
                 if (x11libs[i].lib) {
                     SDL_UnloadObject(x11libs[i].lib);
                     x11libs[i].lib = NULL;
@@ -153,7 +153,7 @@ int SDL_X11_LoadSymbols(void)
 #ifdef SDL_VIDEO_DRIVER_X11_DYNAMIC
         int i;
         int *thismod = NULL;
-        for (i = 0; i < SDL_TABLESIZE(x11libs); i++) {
+        for (i = 0; i < SDL_arraysize(x11libs); i++) {
             if (x11libs[i].libname) {
                 x11libs[i].lib = SDL_LoadObject(x11libs[i].libname);
             }


### PR DESCRIPTION
For some structures, like a keymap, getting the "table-size" sounds more explicit than an "array-size", but having two names for exactly the same expression can also be confusing.