### PR TITLE
Use `onTrimMemory()` instead of `onLowMemory()` on Android

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -625,9 +625,9 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     }
 
     @Override
-    public void onLowMemory() {
-        Log.v(TAG, "onLowMemory()");
-        super.onLowMemory();
+    public void onTrimMemory(int level) {
+        Log.v(TAG, "onTrimMemory()");
+        super.onTrimMemory(level);
 
         if (SDLActivity.mBrokenLibraries) {
            return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR uses the new [`onTrimMemory()`](https://developer.android.com/reference/android/content/ComponentCallbacks2#onTrimMemory(int)) function instead of the old `onLowMemory()` to provide `SDL_EVENT_LOW_MEMORY` events to applications. `onTrimMemory()` provides different levels of memory to trim, but I've opted to always send the event.

From the docs: https://developer.android.com/reference/android/content/ComponentCallbacks#onLowMemory()

> Preferably, you should implement ComponentCallbacks2#onTrimMemory from ComponentCallbacks2 [...].
> That API is available for API level 14 and higher, so you should only use this onLowMemory() method as a fallback for older versions.

Since the SDL3 min API level is 19, there's no need for `onLowMemory()` compat.
