### PR TITLE
Fix SDL_GetDaysInMonth() num days in january

### DIFF
--- a/src/time/SDL_time.c
+++ b/src/time/SDL_time.c
@@ -90,7 +90,7 @@ void SDL_QuitTime()
 int SDL_GetDaysInMonth(int year, int month)
 {
     static const int DAYS_IN_MONTH[] = {
-        30, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+        31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
     };
 
     if (month < 1 || month > 12) {


### PR DESCRIPTION
In SDL_time.c SDL_GetDaysInMonth()
Setting the number of days in january to 31.