### PR TITLE
Fix property cleanup callback not being called on error

### DIFF
--- a/src/SDL_properties.c
+++ b/src/SDL_properties.c
@@ -343,13 +343,17 @@ int SDL_SetPropertyWithCleanup(SDL_PropertiesID props, const char *name, void *v
     SDL_Property *property;
 
     if (!value) {
-        cleanup(userdata, value);
+        if (cleanup) {
+            cleanup(userdata, value);
+        }
         return SDL_ClearProperty(props, name);
     }
 
     property = (SDL_Property *)SDL_calloc(1, sizeof(*property));
     if (!property) {
-        cleanup(userdata, value);
+        if (cleanup) {
+            cleanup(userdata, value);
+        }
         SDL_FreePropertyWithCleanup(NULL, property, NULL, SDL_FALSE);
         return -1;
     }

--- a/src/SDL_properties.c
+++ b/src/SDL_properties.c
@@ -305,11 +305,11 @@ static int SDL_PrivateSetProperty(SDL_PropertiesID props, const char *name, SDL_
     int result = 0;
 
     if (!props) {
-        SDL_FreePropertyWithCleanup(NULL, property, NULL, SDL_FALSE);
+        SDL_FreePropertyWithCleanup(NULL, property, NULL, SDL_TRUE);
         return SDL_InvalidParamError("props");
     }
     if (!name || !*name) {
-        SDL_FreePropertyWithCleanup(NULL, property, NULL, SDL_FALSE);
+        SDL_FreePropertyWithCleanup(NULL, property, NULL, SDL_TRUE);
         return SDL_InvalidParamError("name");
     }
 
@@ -318,7 +318,7 @@ static int SDL_PrivateSetProperty(SDL_PropertiesID props, const char *name, SDL_
     SDL_UnlockMutex(SDL_properties_lock);
 
     if (!properties) {
-        SDL_FreePropertyWithCleanup(NULL, property, NULL, SDL_FALSE);
+        SDL_FreePropertyWithCleanup(NULL, property, NULL, SDL_TRUE);
         return SDL_InvalidParamError("props");
     }
 
@@ -328,7 +328,7 @@ static int SDL_PrivateSetProperty(SDL_PropertiesID props, const char *name, SDL_
         if (property) {
             char *key = SDL_strdup(name);
             if (!SDL_InsertIntoHashTable(properties->props, key, property)) {
-                SDL_FreePropertyWithCleanup(key, property, NULL, SDL_FALSE);
+                SDL_FreePropertyWithCleanup(key, property, NULL, SDL_TRUE);
                 result = -1;
             }
         }
@@ -343,11 +343,13 @@ int SDL_SetPropertyWithCleanup(SDL_PropertiesID props, const char *name, void *v
     SDL_Property *property;
 
     if (!value) {
+        cleanup(userdata, value);
         return SDL_ClearProperty(props, name);
     }
 
     property = (SDL_Property *)SDL_calloc(1, sizeof(*property));
     if (!property) {
+        cleanup(userdata, value);
         SDL_FreePropertyWithCleanup(NULL, property, NULL, SDL_FALSE);
         return -1;
     }

--- a/src/camera/mediafoundation/SDL_camera_mediafoundation.c
+++ b/src/camera/mediafoundation/SDL_camera_mediafoundation.c
@@ -274,7 +274,6 @@ static int MEDIAFOUNDATION_AcquireFrame(SDL_CameraDevice *device, SDL_Surface *f
                 frame->pixels = pixels;
                 frame->pitch = (int) pitch;
                 if (SDL_SetPropertyWithCleanup(surfprops, PROP_SURFACE_IMFOBJS_POINTER, objs, CleanupIMF2DBuffer2, NULL) == -1) {
-                    CleanupIMF2DBuffer2(NULL, objs);
                     retval = -1;
                 }
             }
@@ -287,7 +286,6 @@ static int MEDIAFOUNDATION_AcquireFrame(SDL_CameraDevice *device, SDL_Surface *f
                 frame->pixels = pixels;
                 frame->pitch = (int) pitch;
                 if (SDL_SetPropertyWithCleanup(surfprops, PROP_SURFACE_IMFOBJS_POINTER, objs, CleanupIMF2DBuffer, NULL) == -1) {
-                    CleanupIMF2DBuffer(NULL, objs);
                     retval = -1;
                 }
             }
@@ -305,7 +303,6 @@ static int MEDIAFOUNDATION_AcquireFrame(SDL_CameraDevice *device, SDL_Surface *f
                 frame->pixels = pixels;
                 frame->pitch = (int) pitch;
                 if (SDL_SetPropertyWithCleanup(surfprops, PROP_SURFACE_IMFOBJS_POINTER, objs, CleanupIMFMediaBuffer, NULL) == -1) {
-                    CleanupIMFMediaBuffer(NULL, objs);
                     retval = -1;
                 }
             }

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -321,7 +321,10 @@ static int SDL_CreateWindowTexture(SDL_VideoDevice *_this, SDL_Window *window, S
             SDL_DestroyRenderer(renderer);
             return -1;
         }
-        SDL_SetPropertyWithCleanup(props, SDL_PROP_WINDOW_TEXTUREDATA_POINTER, data, SDL_CleanupWindowTextureData, NULL);
+        if (SDL_SetPropertyWithCleanup(props, SDL_PROP_WINDOW_TEXTUREDATA_POINTER, data, SDL_CleanupWindowTextureData, NULL) < 0) {
+            SDL_DestroyRenderer(renderer);
+            return -1;
+        }
 
         data->renderer = renderer;
     }

--- a/test/testautomation_properties.c
+++ b/test/testautomation_properties.c
@@ -293,7 +293,7 @@ static int properties_testCleanup(void *arg)
     SDLTest_AssertPass("Call to SDL_SetProperty(cleanup)");
     count = 0;
     SDL_SetPropertyWithCleanup(props, "a", "0", cleanup, &count);
-    SDL_SetPropertyWithCleanup(props, "a", NULL, cleanup, &count);
+    SDL_ClearProperty(props, "a");
     SDLTest_AssertCheck(count == 1,
         "Verify cleanup for deleting property, got %d, expected 1", count);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The documentation for `SDL_SetPropertyWithCleanup` mentions that the cleanup function is called upon failure. But this wasn't working in the code.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->

- Closes https://github.com/libsdl-org/SDL/issues/9642