### PR TITLE
Add trailing '/' to `SDL_GetUserFolder(SDL_FOLDER_HOME)` on Cocoa and Unix

### DIFF
--- a/src/filesystem/cocoa/SDL_sysfilesystem.m
+++ b/src/filesystem/cocoa/SDL_sysfilesystem.m
@@ -146,9 +146,10 @@ char *SDL_GetUserFolder(SDL_Folder folder)
 
             if (!base) {
                 SDL_SetError("No $HOME environment variable available");
+                return NULL;
             }
 
-            return SDL_strdup(base);
+            goto append_slash;
 
         case SDL_FOLDER_DESKTOP:
             dir = NSDesktopDirectory;
@@ -209,6 +210,7 @@ char *SDL_GetUserFolder(SDL_Folder folder)
             return NULL;
         }
 
+append_slash:
         retval = SDL_malloc(SDL_strlen(base) + 2);
         if (retval == NULL) {
             return NULL;

--- a/src/filesystem/unix/SDL_sysfilesystem.c
+++ b/src/filesystem/unix/SDL_sysfilesystem.c
@@ -535,7 +535,8 @@ char *SDL_GetUserFolder(SDL_Folder folder)
             return NULL;
         }
 
-        return SDL_strdup(param);
+        retval = SDL_strdup(param);
+        goto append_slash;
 
     case SDL_FOLDER_DESKTOP:
         param = "DESKTOP";
@@ -595,6 +596,7 @@ char *SDL_GetUserFolder(SDL_Folder folder)
         return NULL;
     }
 
+append_slash:
     newretval = (char *) SDL_realloc(retval, SDL_strlen(retval) + 2);
 
     if (!newretval) {


### PR DESCRIPTION
## Description

@Sackzement noticed [here](https://github.com/libsdl-org/SDL/pull/9658#issuecomment-2089933247) that the specific case of `SDL_FOLDER_HOME` did not have a trailing slash on Unix and/or Cocoa. This PR fixes both cases :)
