### PR TITLE
wayland: Add mouse pointer warp support

### DIFF
--- a/docs/README-wayland.md
+++ b/docs/README-wayland.md
@@ -39,9 +39,10 @@ encounter limitations or behavior that is different from other windowing systems
   unknown. In most cases, applications don't actually need the global cursor position and should use the window-relative
   coordinates as provided by the mouse movement event or from ```SDL_GetMouseState()``` instead.
 
-### Warping the global mouse cursor position via ```SDL_WarpMouseGlobal()``` doesn't work
+### Warping the mouse cursor to or from a point outside the window doesn't work
 
-- For security reasons, Wayland does not allow warping the global mouse cursor position.
+- The cursor can be warped only within the window with mouse focus, provided that the `zwp_pointer_confinement_v1`
+  protocol is supported by the compositor.
 
 ### The application icon can't be set via ```SDL_SetWindowIcon()```
 

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2995,19 +2995,21 @@ extern "C" {
 #define SDL_HINT_VIDEO_WAYLAND_ALLOW_LIBDECOR "SDL_VIDEO_WAYLAND_ALLOW_LIBDECOR"
 
 /**
- * Enable or disable mouse pointer warp emulation, needed by some older games.
+ * Enable or disable hidden mouse pointer warp emulation, needed by some older games.
  *
- * Wayland does not directly support warping the mouse. When this hint is set,
- * any SDL will emulate mouse warps using relative mouse mode. This is
- * required for some older games (such as Source engine games), which warp the
- * mouse to the centre of the screen rather than using relative mouse motion.
- * Note that relative mouse mode may have different mouse acceleration
- * behaviour than pointer warps.
+ * Wayland requires the pointer confinement protocol to warp the mouse, but
+ * that is just a hint that the compositor is free to ignore, and warping the
+ * the pointer to or from regions outside of the focused window is prohibited.
+ * When this hint is set and the pointer is hidden, SDL will emulate mouse warps
+ * using relative mouse mode. This is required for some older games (such as Source
+ * engine games), which warp the mouse to the centre of the screen rather than using
+ * relative mouse motion. Note that relative mouse mode may have different mouse
+ * acceleration behaviour than pointer warps.
  *
  * The variable can be set to the following values:
  *
- * - "0": All mouse warps fail, as mouse warping is not available under
- *   wayland.
+ * - "0": Attempts to warp the mouse will be made, if the appropriate protocol
+ *        is available.
  * - "1": Some mouse warps will be emulated by forcing relative mouse mode.
  *
  * If not set, this is automatically enabled unless an application uses

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -3199,32 +3199,47 @@ static const struct zwp_locked_pointer_v1_listener locked_pointer_listener = {
     locked_pointer_unlocked,
 };
 
-static void lock_pointer_to_window(SDL_Window *window,
-                                   struct SDL_WaylandInput *input)
+int Wayland_input_lock_pointer(struct SDL_WaylandInput *input, SDL_Window *window)
 {
     SDL_WindowData *w = window->driverdata;
     SDL_VideoData *d = input->display;
-    struct zwp_locked_pointer_v1 *locked_pointer;
 
     if (!d->pointer_constraints || !input->pointer) {
-        return;
+        return -1;
     }
+
+    if (!w->locked_pointer) {
+        if (w->confined_pointer) {
+            /* If the pointer is already confined to the surface, the lock will fail with a protocol error. */
+            Wayland_input_unconfine_pointer(input, window);
+        }
+
+        w->locked_pointer = zwp_pointer_constraints_v1_lock_pointer(d->pointer_constraints,
+                                                                    w->surface,
+                                                                    input->pointer,
+                                                                    NULL,
+                                                                    ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
+        zwp_locked_pointer_v1_add_listener(w->locked_pointer,
+                                           &locked_pointer_listener,
+                                           window);
+    }
+
+    return 0;
+}
+
+int Wayland_input_unlock_pointer(struct SDL_WaylandInput *input, SDL_Window *window)
+{
+    SDL_WindowData *w = window->driverdata;
 
     if (w->locked_pointer) {
-        return;
+        zwp_locked_pointer_v1_destroy(w->locked_pointer);
+        w->locked_pointer = NULL;
     }
 
-    locked_pointer =
-        zwp_pointer_constraints_v1_lock_pointer(d->pointer_constraints,
-                                                w->surface,
-                                                input->pointer,
-                                                NULL,
-                                                ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT);
-    zwp_locked_pointer_v1_add_listener(locked_pointer,
-                                       &locked_pointer_listener,
-                                       window);
+    /* Restore existing pointer confinement. */
+    Wayland_input_confine_pointer(input, window);
 
-    w->locked_pointer = locked_pointer;
+    return 0;
 }
 
 static void pointer_confine_destroy(SDL_Window *window)
@@ -3236,7 +3251,7 @@ static void pointer_confine_destroy(SDL_Window *window)
     }
 }
 
-int Wayland_input_lock_pointer(struct SDL_WaylandInput *input)
+int Wayland_input_enable_relative_pointer(struct SDL_WaylandInput *input)
 {
     SDL_VideoDevice *vd = SDL_GetVideoDevice();
     SDL_VideoData *d = input->display;
@@ -3263,10 +3278,7 @@ int Wayland_input_lock_pointer(struct SDL_WaylandInput *input)
     }
 
     if (!input->relative_pointer) {
-        relative_pointer =
-            zwp_relative_pointer_manager_v1_get_relative_pointer(
-                d->relative_pointer_manager,
-                input->pointer);
+        relative_pointer = zwp_relative_pointer_manager_v1_get_relative_pointer(d->relative_pointer_manager, input->pointer);
         zwp_relative_pointer_v1_add_listener(relative_pointer,
                                              &relative_pointer_listener,
                                              input);
@@ -3274,7 +3286,7 @@ int Wayland_input_lock_pointer(struct SDL_WaylandInput *input)
     }
 
     for (window = vd->windows; window; window = window->next) {
-        lock_pointer_to_window(window, input);
+        Wayland_input_lock_pointer(input, window);
     }
 
     d->relative_mouse_mode = 1;
@@ -3282,19 +3294,14 @@ int Wayland_input_lock_pointer(struct SDL_WaylandInput *input)
     return 0;
 }
 
-int Wayland_input_unlock_pointer(struct SDL_WaylandInput *input)
+int Wayland_input_disable_relative_pointer(struct SDL_WaylandInput *input)
 {
     SDL_VideoDevice *vd = SDL_GetVideoDevice();
     SDL_VideoData *d = input->display;
     SDL_Window *window;
-    SDL_WindowData *w;
 
     for (window = vd->windows; window; window = window->next) {
-        w = window->driverdata;
-        if (w->locked_pointer) {
-            zwp_locked_pointer_v1_destroy(w->locked_pointer);
-        }
-        w->locked_pointer = NULL;
+        Wayland_input_unlock_pointer(input, window);
     }
 
     if (input->relative_pointer) {

--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -200,8 +200,11 @@ extern void Wayland_create_text_input(SDL_VideoData *d);
 extern void Wayland_input_initialize_seat(SDL_VideoData *d);
 extern void Wayland_display_destroy_input(SDL_VideoData *d);
 
-extern int Wayland_input_lock_pointer(struct SDL_WaylandInput *input);
-extern int Wayland_input_unlock_pointer(struct SDL_WaylandInput *input);
+extern int Wayland_input_enable_relative_pointer(struct SDL_WaylandInput *input);
+extern int Wayland_input_disable_relative_pointer(struct SDL_WaylandInput *input);
+
+extern int Wayland_input_lock_pointer(struct SDL_WaylandInput *input, SDL_Window *window);
+extern int Wayland_input_unlock_pointer(struct SDL_WaylandInput *input, SDL_Window *window);
 
 extern int Wayland_input_confine_pointer(struct SDL_WaylandInput *input, SDL_Window *window);
 extern int Wayland_input_unconfine_pointer(struct SDL_WaylandInput *input, SDL_Window *window);

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -2350,7 +2350,7 @@ int Wayland_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Propert
 #endif
 
     if (c->relative_mouse_mode) {
-        Wayland_input_lock_pointer(c->input);
+        Wayland_input_enable_relative_pointer(c->input);
     }
 
     /* We may need to create an idle inhibitor for this new window */

--- a/test/testmouse.c
+++ b/test/testmouse.c
@@ -211,6 +211,20 @@ static void loop(void *arg)
             break;
 
         case SDL_EVENT_KEY_DOWN:
+            if (event.key.keysym.sym == SDLK_c) {
+                int x, y, w, h;
+                SDL_GetWindowPosition(window, &x, &y);
+                SDL_GetWindowSize(window, &w, &h);
+                w /= 2;
+                h /= 2;
+
+                if (event.key.keysym.mod & SDL_KMOD_ALT) {
+                    SDL_WarpMouseGlobal((float)(x + w), (float)(y + h));
+                } else {
+                    SDL_WarpMouseInWindow(window, (float)w, (float)h);
+                }
+            }
+            SDL_FALLTHROUGH;
         case SDL_EVENT_KEY_UP:
             switch (event.key.keysym.sym) {
             case SDLK_LSHIFT:


### PR DESCRIPTION
The pointer confinement protocol does allow warping the pointer via a hint, provided that the window has focus, the pointer is locked at the time of the request, and the requested coordinates fall within the bounds of the window.

Toggle the pointer locked state and request the pointer warp when the required protocol is available. This is similar to what XWayland does internally, and what commit [a845c70](https://github.com/libsdl-org/SDL/commit/a845c7027e68ff1c75bf814819d8e6b22499d899) causes to happen behind the scenes.

The warp emulation using relative mode that is triggered when warping a hidden cursor remains enabled by default for now, as otherwise, the cursor could potentially leave the window if it is moved fast enough, and once out, it can't be warped back in.