### PR TITLE
Disable SDL_DYNAMIC_API during IntelliSense

### DIFF
--- a/src/dynapi/SDL_dynapi.h
+++ b/src/dynapi/SDL_dynapi.h
@@ -57,7 +57,7 @@
 #define SDL_DYNAMIC_API 0
 #elif defined(SDL_PLATFORM_RISCOS) /* probably not useful on RISC OS, since dlopen() can't be used when using static linking. */
 #define SDL_DYNAMIC_API 0
-#elif defined(__clang_analyzer__) || defined(SDL_THREAD_SAFETY_ANALYSIS)
+#elif defined(__clang_analyzer__) || defined(__INTELLISENSE__) || defined(SDL_THREAD_SAFETY_ANALYSIS)
 #define SDL_DYNAMIC_API 0 /* Turn off for static analysis, so reports are more clear. */
 #elif defined(SDL_PLATFORM_VITA)
 #define SDL_DYNAMIC_API 0 /* vitasdk doesn't support dynamic linking */


### PR DESCRIPTION
Same issue as other static analyzers, stops visual studio showing multiple definitions when trying to navigate to a function.