### PR TITLE
Only check for linux/input.h on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1555,14 +1555,13 @@ elseif(UNIX AND NOT APPLE AND NOT RISCOS AND NOT HAIKU)
   if(UNIX)
     sdl_glob_sources("${SDL3_SOURCE_DIR}/src/core/unix/*.c")
 
-    check_c_source_compiles("
-        #include <linux/input.h>
-        #ifndef EVIOCGNAME
-        #error EVIOCGNAME() ioctl not available
-        #endif
-        int main(int argc, char** argv) { return 0; }" HAVE_LINUX_INPUT_H)
-
     if(LINUX)
+      check_c_source_compiles("
+          #include <linux/input.h>
+          #ifndef EVIOCGNAME
+          #error EVIOCGNAME() ioctl not available
+          #endif
+          int main(int argc, char** argv) { return 0; }" HAVE_LINUX_INPUT_H)
       check_c_source_compiles("
           #include <linux/kd.h>
           #include <linux/keyboard.h>


### PR DESCRIPTION
Only try to detect the linux/input.h header under Linux. Under some conditions the
header might exist under OpenBSD but we do not want it to be detected.