### PR TITLE
SDL_stdinc.h: Removed "ll" suffix from integer literals

### DIFF
--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -228,8 +228,8 @@ typedef uint32_t Uint32;
  *
  * \since This macro is available since SDL 3.0.0.
  */
-#define SDL_MAX_SINT64  ((Sint64)0x7FFFFFFFFFFFFFFFll)      /* 9223372036854775807 */
-#define SDL_MIN_SINT64  ((Sint64)(~0x7FFFFFFFFFFFFFFFll))   /* -9223372036854775808 */
+#define SDL_MAX_SINT64  ((Sint64)0x7FFFFFFFFFFFFFFF)      /* 9223372036854775807 */
+#define SDL_MIN_SINT64  ((Sint64)(~0x7FFFFFFFFFFFFFFF))   /* -9223372036854775808 */
 typedef int64_t Sint64;
 
 /**
@@ -237,8 +237,8 @@ typedef int64_t Sint64;
  *
  * \since This macro is available since SDL 3.0.0.
  */
-#define SDL_MAX_UINT64  ((Uint64)0xFFFFFFFFFFFFFFFFull)     /* 18446744073709551615 */
-#define SDL_MIN_UINT64  ((Uint64)(0x0000000000000000ull))   /* 0 */
+#define SDL_MAX_UINT64  ((Uint64)0xFFFFFFFFFFFFFFFFu)     /* 18446744073709551615 */
+#define SDL_MIN_UINT64  ((Uint64)(0x0000000000000000u))   /* 0 */
 typedef uint64_t Uint64;
 
 /**


### PR DESCRIPTION
For C89 compatibility in SDL headers.
The "ll" suffix hid behind macros.