### PR TITLE
Android: Allow SDL_IOFromFile to open content:// URI.

### DIFF
--- a/android-project/app/proguard-rules.pro
+++ b/android-project/app/proguard-rules.pro
@@ -48,6 +48,7 @@
     int openURL(java.lang.String);
     int showToast(java.lang.String, int, int, int, int);
     native java.lang.String nativeGetHint(java.lang.String);
+    int openFileDescriptor(java.lang.String, java.lang.String);
 }
 
 -keep,includedescriptorclasses,allowoptimization class org.libsdl.app.HIDDeviceManager {

--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -45,6 +45,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import java.io.FileNotFoundException;
 import java.util.Hashtable;
 import java.util.Locale;
 
@@ -1948,8 +1949,13 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
             return -1;
         }
 
-        ParcelFileDescriptor pfd = mSingleton.getContentResolver().openFileDescriptor(Uri.parse(uri), mode);
-        return pfd.detachFd();
+        try {
+            ParcelFileDescriptor pfd = mSingleton.getContentResolver().openFileDescriptor(Uri.parse(uri), mode);
+            return pfd != null ? pfd.detachFd() : -1;
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+            return -1;
+        }
     }
 }
 

--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -23,6 +23,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
+import android.os.ParcelFileDescriptor;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.SparseArray;
@@ -1937,6 +1938,18 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
             return -1;
         }
         return 0;
+    }
+
+    /**
+     * This method is called by SDL using JNI.
+     */
+    public static int openFileDescriptor(String uri, String mode) throws Exception {
+        if (mSingleton == null) {
+            return -1;
+        }
+
+        ParcelFileDescriptor pfd = mSingleton.getContentResolver().openFileDescriptor(Uri.parse(uri), mode);
+        return pfd.detachFd();
     }
 }
 

--- a/include/SDL3/SDL_iostream.h
+++ b/include/SDL3/SDL_iostream.h
@@ -175,8 +175,9 @@ typedef struct SDL_IOStream SDL_IOStream;
  * This function supports Unicode filenames, but they must be encoded in UTF-8
  * format, regardless of the underlying operating system.
  *
- * As a fallback, SDL_IOFromFile() will transparently open a matching filename
- * in an Android app's `assets`.
+ * In Android, SDL_IOFromFile() can be used to open content:// URIs. As a
+ * fallback, SDL_IOFromFile() will transparently open a matching filename
+ * in the app's `assets`.
  *
  * Closing the SDL_IOStream will close SDL's internal file handle.
  *

--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -345,6 +345,7 @@ static jmethodID midSetWindowStyle;
 static jmethodID midShouldMinimizeOnFocusLoss;
 static jmethodID midShowTextInput;
 static jmethodID midSupportsRelativeMouse;
+static jmethodID midOpenFileDescriptor;
 
 /* audio manager */
 static jclass mAudioManagerClass;
@@ -638,6 +639,7 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(nativeSetupJNI)(JNIEnv *env, jclass cl
     midShouldMinimizeOnFocusLoss = (*env)->GetStaticMethodID(env, mActivityClass, "shouldMinimizeOnFocusLoss", "()Z");
     midShowTextInput = (*env)->GetStaticMethodID(env, mActivityClass, "showTextInput", "(IIII)Z");
     midSupportsRelativeMouse = (*env)->GetStaticMethodID(env, mActivityClass, "supportsRelativeMouse", "()Z");
+    midOpenFileDescriptor = (*env)->GetStaticMethodID(env, mActivityClass, "openFileDescriptor", "(Ljava/lang/String;Ljava/lang/String;)I");
 
     if (!midClipboardGetText ||
         !midClipboardHasText ||
@@ -667,7 +669,8 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(nativeSetupJNI)(JNIEnv *env, jclass cl
         !midSetWindowStyle ||
         !midShouldMinimizeOnFocusLoss ||
         !midShowTextInput ||
-        !midSupportsRelativeMouse) {
+        !midSupportsRelativeMouse ||
+        !midOpenFileDescriptor) {
         __android_log_print(ANDROID_LOG_WARN, "SDL", "Missing some Java callbacks, do you have the latest version of SDLActivity.java?");
     }
 
@@ -2764,6 +2767,87 @@ int Android_JNI_OpenURL(const char *url)
     const int ret = (*env)->CallStaticIntMethod(env, mActivityClass, midOpenURL, jurl);
     (*env)->DeleteLocalRef(env, jurl);
     return ret;
+}
+
+static jstring Android_GetExceptionString(JNIEnv *env)
+{
+    jthrowable throwable = (*env)->ExceptionOccurred(env);
+
+    if (throwable)
+    {
+        (*env)->ExceptionClear(env);
+
+        jclass javaObject = (*env)->FindClass(env, "java/lang/Object");
+        jmethodID toString = (*env)->GetMethodID(env, javaObject, "toString", "()Ljava/lang/String;");
+        jstring message = (*env)->CallObjectMethod(env, throwable, toString);
+
+        (*env)->DeleteLocalRef(env, javaObject);
+        (*env)->DeleteLocalRef(env, throwable);
+        return message;
+    }
+
+    return NULL;
+}
+
+int Android_JNI_OpenFileDescriptor(const char *uri, const char *mode)
+{
+    /* Get fopen-style modes */
+    int moderead = 0, modewrite = 0, modeappend = 0, modeupdate = 0;
+
+    for (const char *cmode = mode; *cmode; cmode++) {
+        switch (*cmode) {
+            case 'a':
+                modeappend = 1;
+                break;
+            case 'r':
+                moderead = 1;
+                break;
+            case 'w':
+                modewrite = 1;
+                break;
+            case '+':
+                modeupdate = 1;
+                break;
+            default:
+                break;
+        }
+    }
+
+    /* Translate fopen-style modes to ContentResolver modes. */
+    /* Android only allows "r", "w", "wt", "wa", "rw" or "rwt". */
+    const char *contentResolverMode = "r";
+
+    if (moderead) {
+        if (modewrite) {
+            contentResolverMode = modeupdate ? "rw" : "rwt";
+        } else {
+            contentResolverMode = modeupdate ? "rw" : "r";
+        }
+    } else if (modewrite) {
+        contentResolverMode = modeupdate ? "rw" : "wt";
+    } else if (modeappend) {
+        contentResolverMode = modeupdate ? "rw" : "wa";
+    }
+
+    JNIEnv *env = Android_JNI_GetEnv();
+    jstring jstringUri = (*env)->NewStringUTF(env, uri);
+    jstring jstringMode = (*env)->NewStringUTF(env, contentResolverMode);
+    jint fd = (*env)->CallStaticIntMethod(env, mActivityClass, midOpenFileDescriptor, jstringUri, jstringMode);
+    (*env)->DeleteLocalRef(env, jstringUri);
+    (*env)->DeleteLocalRef(env, jstringMode);
+
+    jstring exceptionMessage = Android_GetExceptionString(env);
+    if (exceptionMessage) {
+        const char *msg = (*env)->GetStringUTFChars(env, exceptionMessage, NULL);
+        SDL_SetError("JNI Exception: %s", msg);
+        (*env)->ReleaseStringUTFChars(env, exceptionMessage, msg);
+        (*env)->DeleteLocalRef(env, exceptionMessage);
+        fd = -1;
+    } else if (fd == -1) {
+        SDL_SetError("Unknown error");
+    }
+
+    return fd;
 }
 
 #endif /* SDL_PLATFORM_ANDROID */

--- a/src/core/android/SDL_android.h
+++ b/src/core/android/SDL_android.h
@@ -75,6 +75,7 @@ int Android_JNI_FileClose(void *userdata);
 
 /* Environment support */
 void Android_JNI_GetManifestEnvironmentVariables(void);
+int Android_JNI_OpenFileDescriptor(const char *uri, const char *mode);
 
 /* Clipboard support */
 int Android_JNI_SetClipboardText(const char *text);

--- a/src/file/SDL_iostream.c
+++ b/src/file/SDL_iostream.c
@@ -559,7 +559,7 @@ SDL_IOStream *SDL_IOFromFile(const char *file, const char *mode)
             }
             return SDL_IOFromFP(fp, 1);
         }
-    } else if (SDL_strstr(file, "content://") == file) {
+    } else if (SDL_strncmp(file, "content://", 10) == 0) {
         /* Try opening content:// URI */
         int fd = Android_JNI_OpenFileDescriptor(file, mode);
         if (fd == -1) {


### PR DESCRIPTION
Allow opening `content://` URIs using `SDL_IOFromFile` in Android.

## Description
This change allows `SDL_IOFromFile` to open Android's `content://` URI retrieved either through file dialogs (#9687) or by other means. The motivation of this change is mainly to support former usecase as Android doesn't return ordinary file paths rather than `content://` URIs.

This change used to be in the Android file dialog pull request but I've been asked to separate the `SDL_IOFromFile` changes and remove the `SDL_AndroidOpenFileDescriptor` API.

## Existing Issue(s)
