### PR TITLE
x11: Fix text input not being null-terminated

### DIFF
--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -839,6 +839,7 @@ void X11_HandleKeyEvent(SDL_VideoDevice *_this, SDL_WindowData *windowdata, SDL_
     Display *display = videodata->display;
     KeyCode keycode = xevent->xkey.keycode;
     KeySym keysym = NoSymbol;
+    int text_length = 0;
     char text[64];
     Status status = 0;
     SDL_bool handled_by_ime = SDL_FALSE;
@@ -891,13 +892,13 @@ void X11_HandleKeyEvent(SDL_VideoDevice *_this, SDL_WindowData *windowdata, SDL_
 
 #ifdef X_HAVE_UTF8_STRING
         if (windowdata->ic && xevent->type == KeyPress) {
-            X11_Xutf8LookupString(windowdata->ic, &xevent->xkey, text, sizeof(text),
+            text_length = X11_Xutf8LookupString(windowdata->ic, &xevent->xkey, text, sizeof(text) - 1,
                                   &keysym, &status);
         } else {
-            XLookupStringAsUTF8(&xevent->xkey, text, sizeof(text), &keysym, NULL);
+            text_length = XLookupStringAsUTF8(&xevent->xkey, text, sizeof(text) - 1, &keysym, NULL);
         }
 #else
-        XLookupStringAsUTF8(&xevent->xkey, text, sizeof(text), &keysym, NULL);
+        text_length = XLookupStringAsUTF8(&xevent->xkey, text, sizeof(text) - 1, &keysym, NULL);
 #endif
 
 #ifdef SDL_USE_IME
@@ -912,6 +913,7 @@ void X11_HandleKeyEvent(SDL_VideoDevice *_this, SDL_WindowData *windowdata, SDL_
                 SDL_SendKeyboardKey(0, keyboardID, SDL_PRESSED, videodata->key_layout[keycode]);
             }
             if (*text) {
+                text[text_length] = '\0';
                 SDL_SendKeyboardText(text);
             }
         } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This patch fixes text input not being null-terminated on X11.

I noticed that garbage characters are coming up through `SDL_EVENT_TEXT_INPUT` when I am using X11 session, especially while using numpad:
```
SDL EVENT: SDL_EVENT_KEY_DOWN (timestamp=2027784466 windowid=2 which=0 state=pressed repeat=false scancode=95 keycode=1073741919 mod=4096)
SDL EVENT: SDL_EVENT_TEXT_INPUT (timestamp=2027852784 windowid=2 text='7�|��]')
SDL EVENT: SDL_EVENT_KEY_UP (timestamp=2112871448 windowid=2 which=0 state=released repeat=false scancode=95 keycode=1073741919 mod=4096)
SDL EVENT: SDL_EVENT_KEY_DOWN (timestamp=2989397106 windowid=2 which=0 state=pressed repeat=false scancode=92 keycode=1073741916 mod=4096)
SDL EVENT: SDL_EVENT_TEXT_INPUT (timestamp=2989506902 windowid=2 text='4')
SDL EVENT: SDL_EVENT_KEY_UP (timestamp=3078089026 windowid=2 which=0 state=released repeat=false scancode=92 keycode=1073741916 mod=4096)
SDL EVENT: SDL_EVENT_KEY_DOWN (timestamp=3308976279 windowid=2 which=0 state=pressed repeat=false scancode=93 keycode=1073741917 mod=4096)
SDL EVENT: SDL_EVENT_TEXT_INPUT (timestamp=3309009681 windowid=2 text='5')
SDL EVENT: SDL_EVENT_KEY_UP (timestamp=3386919154 windowid=2 which=0 state=released repeat=false scancode=93 keycode=1073741917 mod=4096)
SDL EVENT: SDL_EVENT_KEY_DOWN (timestamp=3573564511 windowid=2 which=0 state=pressed repeat=false scancode=94 keycode=1073741918 mod=4096)
SDL EVENT: SDL_EVENT_TEXT_INPUT (timestamp=3573594498 windowid=2 text='6')
SDL EVENT: SDL_EVENT_KEY_UP (timestamp=3673791741 windowid=2 which=0 state=released repeat=false scancode=94 keycode=1073741918 mod=4096)
SDL EVENT: SDL_EVENT_KEY_DOWN (timestamp=3892989124 windowid=2 which=0 state=pressed repeat=false scancode=89 keycode=1073741913 mod=4096)
SDL EVENT: SDL_EVENT_TEXT_INPUT (timestamp=3893043206 windowid=2 text='1')
SDL EVENT: SDL_EVENT_KEY_UP (timestamp=3982566826 windowid=2 which=0 state=released repeat=false scancode=89 keycode=1073741913 mod=4096)
SDL EVENT: SDL_EVENT_KEY_DOWN (timestamp=4162447699 windowid=2 which=0 state=pressed repeat=false scancode=90 keycode=1073741914 mod=4096)
SDL EVENT: SDL_EVENT_TEXT_INPUT (timestamp=4162485140 windowid=2 text='2�������')
SDL EVENT: SDL_EVENT_KEY_UP (timestamp=4252118936 windowid=2 which=0 state=released repeat=false scancode=90 keycode=1073741914 mod=4096)
SDL EVENT: SDL_EVENT_KEY_DOWN (timestamp=592450730 windowid=2 which=0 state=pressed repeat=false scancode=91 keycode=1073741915 mod=4096)
SDL EVENT: SDL_EVENT_TEXT_INPUT (timestamp=592480405 windowid=2 text='3�������')
SDL EVENT: SDL_EVENT_KEY_UP (timestamp=676513951 windowid=2 which=0 state=released repeat=false scancode=91 keycode=1073741915 mod=4096)
SDL EVENT: SDL_EVENT_KEY_DOWN (timestamp=1232889015 windowid=2 which=0 state=pressed repeat=false scancode=90 keycode=1073741914 mod=4096)
SDL EVENT: SDL_EVENT_TEXT_INPUT (timestamp=1232920995 windowid=2 text='2�������')
SDL EVENT: SDL_EVENT_KEY_UP (timestamp=1334063702 windowid=2 which=0 state=released repeat=false scancode=90 keycode=1073741914 mod=4096)
```

A weird thing with this bug is that I could only notice this while using a package from my distro PPA (openSUSE Open Build Service), but not while using [the binary provided by the game](https://github.com/ppy/SDL3-CS/). Both of them use no patches on top of upstream tree as far as I know.

[Xutf8LookupString](https://www.x.org/releases/X11R7.5/doc/man/man3/Xutf8LookupString.3.html) returns the length of the string in bytes.

## Existing Issue(s)
Probably none?
