### PR TITLE
Add macOSSetAnimationCallback for SDL_Window's

### DIFF
--- a/include/SDL3/SDL_system.h
+++ b/include/SDL3/SDL_system.h
@@ -187,6 +187,13 @@ extern DECLSPEC int SDLCALL SDL_LinuxSetThreadPriorityAndPolicy(Sint64 threadID,
 #endif /* SDL_PLATFORM_LINUX */
 
 /*
+ * Platform specific functions for macOS
+ */
+#ifdef SDL_PLATFORM_MACOS
+extern DECLSPEC int SDLCALL SDL_macOSSetAnimationCallback(SDL_Window * window, int interval, void (SDLCALL *callback)(void*), void *callbackParam);
+#endif /* __MACOS__ */
+
+/*
  * Platform specific functions for iOS
  */
 #ifdef SDL_PLATFORM_IOS

--- a/src/dynapi/SDL_dynapi.sym
+++ b/src/dynapi/SDL_dynapi.sym
@@ -910,6 +910,7 @@ SDL3_0.0.0 {
     SDL_hid_send_feature_report;
     SDL_hid_set_nonblocking;
     SDL_hid_write;
+    SDL_macOSSetAnimationCallback;
     SDL_iOSSetAnimationCallback;
     SDL_iOSSetEventPump;
     SDL_iconv;

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -934,6 +934,7 @@
 #define SDL_hid_send_feature_report SDL_hid_send_feature_report_REAL
 #define SDL_hid_set_nonblocking SDL_hid_set_nonblocking_REAL
 #define SDL_hid_write SDL_hid_write_REAL
+#define SDL_macOSSetAnimationCallback  SDL_macOSSetAnimationCallback_REAL
 #define SDL_iOSSetAnimationCallback  SDL_iOSSetAnimationCallback_REAL
 #define SDL_iOSSetEventPump  SDL_iOSSetEventPump_REAL
 #define SDL_iconv SDL_iconv_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -953,6 +953,7 @@ SDL_DYNAPI_PROC(int,SDL_hid_read_timeout,(SDL_hid_device *a, unsigned char *b, s
 SDL_DYNAPI_PROC(int,SDL_hid_send_feature_report,(SDL_hid_device *a, const unsigned char *b, size_t c),(a,b,c),return)
 SDL_DYNAPI_PROC(int,SDL_hid_set_nonblocking,(SDL_hid_device *a, int b),(a,b),return)
 SDL_DYNAPI_PROC(int,SDL_hid_write,(SDL_hid_device *a, const unsigned char *b, size_t c),(a,b,c),return)
+SDL_DYNAPI_PROC(int,SDL_macOSSetAnimationCallback,(SDL_Window *a, int b, void (SDLCALL *c)(void *), void *d),(a,b,c,d),return)
 SDL_DYNAPI_PROC(int,SDL_iOSSetAnimationCallback,(SDL_Window *a, int b, void (SDLCALL *c)(void *), void *d),(a,b,c,d),return)
 SDL_DYNAPI_PROC(void,SDL_iOSSetEventPump,(SDL_bool a),(a),)
 SDL_DYNAPI_PROC(size_t,SDL_iconv,(SDL_iconv_t a, const char **b, size_t *c, char **d, size_t *e),(a,b,c,d,e),return)

--- a/src/video/SDL_video_unsupported.c
+++ b/src/video/SDL_video_unsupported.c
@@ -93,16 +93,6 @@ void SDL_OnApplicationDidChangeStatusBarOrientation(void)
 
 #ifndef SDL_VIDEO_DRIVER_UIKIT
 
-DECLSPEC int SDLCALL SDL_macOSSetAnimationCallback(SDL_Window *window, int interval, void (*callback)(void *), void *callbackParam);
-int SDL_macOSSetAnimationCallback(SDL_Window *window, int interval, void (*callback)(void *), void *callbackParam)
-{
-    (void)window;
-    (void)interval;
-    (void)callback;
-    (void)callbackParam;
-    return SDL_Unsupported();
-}
-
 DECLSPEC int SDLCALL SDL_iOSSetAnimationCallback(SDL_Window *window, int interval, void (*callback)(void *), void *callbackParam);
 int SDL_iOSSetAnimationCallback(SDL_Window *window, int interval, void (*callback)(void *), void *callbackParam)
 {

--- a/src/video/SDL_video_unsupported.c
+++ b/src/video/SDL_video_unsupported.c
@@ -93,6 +93,16 @@ void SDL_OnApplicationDidChangeStatusBarOrientation(void)
 
 #ifndef SDL_VIDEO_DRIVER_UIKIT
 
+DECLSPEC int SDLCALL SDL_macOSSetAnimationCallback(SDL_Window *window, int interval, void (*callback)(void *), void *callbackParam);
+int SDL_macOSSetAnimationCallback(SDL_Window *window, int interval, void (*callback)(void *), void *callbackParam)
+{
+    (void)window;
+    (void)interval;
+    (void)callback;
+    (void)callbackParam;
+    return SDL_Unsupported();
+}
+
 DECLSPEC int SDLCALL SDL_iOSSetAnimationCallback(SDL_Window *window, int interval, void (*callback)(void *), void *callbackParam);
 int SDL_iOSSetAnimationCallback(SDL_Window *window, int interval, void (*callback)(void *), void *callbackParam)
 {


### PR DESCRIPTION
Adds an animation callback to macOS windows. Just like we do for iOS.

## Description
In macOS each window has their own run loop, therefore, we run have an animation callback for each window. This allows you to handle this callback as needed.