### PR TITLE
remove most of SDL_OutOfMemory() calls where SDL is the allocator.

### DIFF
--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -1335,8 +1335,6 @@ static SDL_AudioDeviceID *GetAudioDevices(int *count, SDL_bool iscapture)
 
                 SDL_assert(devs_seen == num_devices);
                 retval[devs_seen] = 0;  // null-terminated.
-            } else {
-                SDL_OutOfMemory();
             }
         }
         SDL_UnlockRWLock(current_audio.device_hash_lock);

--- a/src/audio/SDL_audioqueue.c
+++ b/src/audio/SDL_audioqueue.c
@@ -126,7 +126,7 @@ static int ReserveMemoryPoolBlocks(SDL_MemoryPool *pool, size_t num_blocks)
         void *block = AllocNewMemoryPoolBlock(pool);
 
         if (block == NULL) {
-            return SDL_OutOfMemory();
+            return -1;
         }
 
         *(void **)block = pool->free_blocks;

--- a/src/camera/emscripten/SDL_camera_emscripten.c
+++ b/src/camera/emscripten/SDL_camera_emscripten.c
@@ -44,7 +44,7 @@ static int EMSCRIPTENCAMERA_AcquireFrame(SDL_CameraDevice *device, SDL_Surface *
 {
     void *rgba = SDL_malloc(device->actual_spec.width * device->actual_spec.height * 4);
     if (!rgba) {
-        return SDL_OutOfMemory();
+        return -1;
     }
 
     *timestampNS = SDL_GetTicksNS();  // best we can do here.

--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -2855,7 +2855,6 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeFileDialog)(
         char **charFileList = SDL_calloc(sizeof(char*), count + 1);
 
         if (charFileList == NULL) {
-            SDL_OutOfMemory();
             mAndroidFileDialogData.callback(mAndroidFileDialogData.userdata, NULL, -1);
             mAndroidFileDialogData.callback = NULL;
             return;
@@ -2879,7 +2878,6 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeFileDialog)(
             if (!newFile) {
                 (*env)->ReleaseStringUTFChars(env, string, utf8string);
                 (*env)->DeleteLocalRef(env, string);
-                SDL_OutOfMemory();
                 mAndroidFileDialogData.callback(mAndroidFileDialogData.userdata, NULL, -1);
                 mAndroidFileDialogData.callback = NULL;
 

--- a/src/dialog/cocoa/SDL_cocoadialog.m
+++ b/src/dialog/cocoa/SDL_cocoadialog.m
@@ -87,7 +87,6 @@ void show_file_dialog(cocoa_FileDialogType type, SDL_DialogFileCallback callback
             char *pattern_ptr = pattern;
 
             if (!pattern_ptr) {
-                SDL_OutOfMemory();
                 callback(userdata, NULL, -1);
                 return;
             }

--- a/src/dialog/unix/SDL_portaldialog.c
+++ b/src/dialog/unix/SDL_portaldialog.c
@@ -86,7 +86,6 @@ static void DBus_AppendFilter(SDL_DBusContext *dbus, DBusMessageIter *parent, co
 
     patterns = SDL_strdup(filter->pattern);
     if (!patterns) {
-        SDL_OutOfMemory();
         goto cleanup;
     }
 
@@ -99,7 +98,6 @@ static void DBus_AppendFilter(SDL_DBusContext *dbus, DBusMessageIter *parent, co
 
         glob_pattern = SDL_calloc(sizeof(char), max_len);
         if (!glob_pattern) {
-            SDL_OutOfMemory();
             goto cleanup;
         }
         glob_pattern[0] = '*';
@@ -222,7 +220,6 @@ static DBusHandlerResult DBus_MessageFilter(DBusConnection *conn, DBusMessage *m
 
         path = SDL_malloc(sizeof(const char *) * length);
         if (!path) {
-            SDL_OutOfMemory();
             signal_data->callback(signal_data->userdata, NULL, -1);
             goto cleanup;
         }
@@ -233,7 +230,6 @@ static DBusHandlerResult DBus_MessageFilter(DBusConnection *conn, DBusMessage *m
                 ++length;
                 path = SDL_realloc(path, sizeof(const char *) * length);
                 if (!path) {
-                    SDL_OutOfMemory();
                     signal_data->callback(signal_data->userdata, NULL, -1);
                     goto cleanup;
                 }

--- a/src/dialog/unix/SDL_zenitydialog.c
+++ b/src/dialog/unix/SDL_zenitydialog.c
@@ -54,7 +54,6 @@ typedef struct
 #define CHECK_OOM()                                                           \
     {                                                                         \
         if (!argv[nextarg - 1]) {                                             \
-            SDL_OutOfMemory();                                                \
             CLEAR_AND_RETURN()                                                \
         }                                                                     \
                                                                               \
@@ -120,9 +119,7 @@ static char** generate_args(const zenityArgs* info)
     }
 
     argv = SDL_malloc(sizeof(char *) * argc + 1);
-
     if (!argv) {
-        SDL_OutOfMemory();
         return NULL;
     }
 
@@ -259,7 +256,6 @@ static void run_zenity(zenityArgs* arg_struct)
         while ((bytes_last_read = read(out[0], readbuffer, sizeof(readbuffer)))) {
             char *new_container = SDL_realloc(container, bytes_read + bytes_last_read);
             if (!new_container) {
-                SDL_OutOfMemory();
                 SDL_free(container);
                 close(out[0]);
                 callback(userdata, NULL, -1);
@@ -286,7 +282,6 @@ static void run_zenity(zenityArgs* arg_struct)
         char **array = (char **) SDL_malloc((narray + 1) * sizeof(char *));
 
         if (!array) {
-            SDL_OutOfMemory();
             SDL_free(container);
             callback(userdata, NULL, -1);
             return;
@@ -304,7 +299,6 @@ static void run_zenity(zenityArgs* arg_struct)
                     narray++;
                     char **new_array = (char **) SDL_realloc(array, (narray + 1) * sizeof(char *));
                     if (!new_array) {
-                        SDL_OutOfMemory();
                         SDL_free(container);
                         SDL_free(array);
                         callback(userdata, NULL, -1);
@@ -343,7 +337,6 @@ void SDL_Zenity_ShowOpenFileDialog(SDL_DialogFileCallback callback, void* userda
 
     args = SDL_malloc(sizeof(*args));
     if (!args) {
-        SDL_OutOfMemory();
         callback(userdata, NULL, -1);
         return;
     }
@@ -371,7 +364,6 @@ void SDL_Zenity_ShowSaveFileDialog(SDL_DialogFileCallback callback, void* userda
 
     args = SDL_malloc(sizeof(zenityArgs));
     if (args == NULL) {
-        SDL_OutOfMemory();
         callback(userdata, NULL, -1);
         return;
     }
@@ -399,7 +391,6 @@ void SDL_Zenity_ShowOpenFolderDialog(SDL_DialogFileCallback callback, void* user
 
     args = SDL_malloc(sizeof(zenityArgs));
     if (args == NULL) {
-        SDL_OutOfMemory();
         callback(userdata, NULL, -1);
         return;
     }

--- a/src/dialog/windows/SDL_windowsdialog.c
+++ b/src/dialog/windows/SDL_windowsdialog.c
@@ -369,29 +369,22 @@ int windows_file_dialog_thread(void* ptr)
     return 0;
 }
 
-int CALLBACK browse_callback_proc(
-				HWND hwnd, 
-				UINT uMsg, 
-				LPARAM lParam, 
-				LPARAM lpData)
+int CALLBACK browse_callback_proc(HWND hwnd, UINT uMsg, LPARAM lParam, LPARAM lpData)
 {
-  
-	switch (uMsg)
-	{
-	case BFFM_INITIALIZED :
-		if(lpData)
-        {
-		  SendMessage(hwnd, BFFM_SETSELECTION, TRUE, lpData);
+    switch (uMsg) {
+    case BFFM_INITIALIZED:
+        if (lpData) {
+            SendMessage(hwnd, BFFM_SETSELECTION, TRUE, lpData);
         }
-		break;
-	case BFFM_SELCHANGED :
-		break;
-	case BFFM_VALIDATEFAILED :
-		break;
-	default:
-		break;
-	}
-	return 0; 
+        break;
+    case BFFM_SELCHANGED:
+        break;
+    case BFFM_VALIDATEFAILED:
+        break;
+    default:
+        break;
+    }
+    return 0;
 }
 
 void windows_ShowFolderDialog(void* ptr)
@@ -400,7 +393,6 @@ void windows_ShowFolderDialog(void* ptr)
     SDL_Window *window = args->parent;
     SDL_DialogFileCallback callback = args->callback;
     void *userdata = args->userdata;
-
     HWND parent = NULL;
 
     if (window) {

--- a/src/joystick/gdk/SDL_gameinputjoystick.c
+++ b/src/joystick/gdk/SDL_gameinputjoystick.c
@@ -109,13 +109,13 @@ static int GAMEINPUT_InternalAddOrFind(IGameInputDevice *pDevice)
 
     elem = (GAMEINPUT_InternalDevice *)SDL_calloc(1, sizeof(*elem));
     if (!elem) {
-        return SDL_OutOfMemory();
+        return -1;
     }
 
     devicelist = (GAMEINPUT_InternalDevice **)SDL_realloc(g_GameInputList.devices, sizeof(elem) * (g_GameInputList.count + 1LL));
     if (!devicelist) {
         SDL_free(elem);
-        return SDL_OutOfMemory();
+        return -1;
     }
 
     /* Generate a device path */
@@ -264,7 +264,7 @@ static int GAMEINPUT_JoystickGetCount(void)
 
 static void GAMEINPUT_JoystickDetect(void)
 {
-    int idx = 0;
+    int idx;
     GAMEINPUT_InternalDevice *elem = NULL;
 
     for (idx = 0; idx < g_GameInputList.count; ++idx) {
@@ -396,7 +396,7 @@ static int GAMEINPUT_JoystickOpen(SDL_Joystick *joystick, int device_index)
 
     hwdata = (GAMEINPUT_InternalJoystickHwdata *)SDL_calloc(1, sizeof(*hwdata));
     if (!hwdata) {
-        return SDL_OutOfMemory();
+        return -1;
     }
 
     hwdata->devref = elem;

--- a/src/joystick/hidapi/SDL_hidapi_steamdeck.c
+++ b/src/joystick/hidapi/SDL_hidapi_steamdeck.c
@@ -184,7 +184,6 @@ static SDL_bool HIDAPI_DriverSteamDeck_InitDevice(SDL_HIDAPI_Device *device)
 
     ctx = (SDL_DriverSteamDeck_Context *)SDL_calloc(1, sizeof(*ctx));
     if (ctx == NULL) {
-        SDL_OutOfMemory();
         return SDL_FALSE;
     }
 

--- a/src/storage/steam/SDL_steamstorage.c
+++ b/src/storage/steam/SDL_steamstorage.c
@@ -151,7 +151,6 @@ static SDL_Storage *STEAM_User_Create(const char *org, const char *app, SDL_Prop
 
     steam = (STEAM_RemoteStorage*) SDL_malloc(sizeof(STEAM_RemoteStorage));
     if (steam == NULL) {
-        SDL_OutOfMemory();
         return NULL;
     }
 

--- a/src/test/SDL_test_harness.c
+++ b/src/test/SDL_test_harness.c
@@ -76,7 +76,6 @@ char *SDLTest_GenerateRunSeed(const int length)
     seed = (char *)SDL_malloc((length + 1) * sizeof(char));
     if (!seed) {
         SDLTest_LogError("SDL_malloc for run seed output buffer failed.");
-        SDL_OutOfMemory();
         return NULL;
     }
 
@@ -151,7 +150,6 @@ static Uint64 SDLTest_GenerateExecKey(const char *runSeed, const char *suiteName
     buffer = (char *)SDL_malloc(entireStringLength);
     if (!buffer) {
         SDLTest_LogError("Failed to allocate buffer for execKey generation.");
-        SDL_OutOfMemory();
         return 0;
     }
     (void)SDL_snprintf(buffer, entireStringLength, "%s%s%s%d", runSeed, suiteName, testName, iteration);
@@ -457,7 +455,6 @@ int SDLTest_RunSuites(SDLTest_TestSuiteReference *testSuites[], const char *user
     failedTests = (const SDLTest_TestCaseReference **)SDL_malloc(totalNumberOfTests * sizeof(SDLTest_TestCaseReference *));
     if (!failedTests) {
         SDLTest_LogError("Unable to allocate cache for failed tests");
-        SDL_OutOfMemory();
         return -1;
     }
 

--- a/src/thread/SDL_thread.c
+++ b/src/thread/SDL_thread.c
@@ -60,7 +60,6 @@ int SDL_SetTLS(SDL_TLSID id, const void *value, void(SDLCALL *destructor)(void *
         newlimit = (id + TLS_ALLOC_CHUNKSIZE);
         new_storage = (SDL_TLSData *)SDL_realloc(storage, sizeof(*storage) + (newlimit - 1) * sizeof(storage->array[0]));
         if (!new_storage) {
-            SDL_OutOfMemory();
             return -1;
         }
         storage = new_storage;

--- a/src/video/n3ds/SDL_n3dsvideo.c
+++ b/src/video/n3ds/SDL_n3dsvideo.c
@@ -85,7 +85,6 @@ static SDL_VideoDevice *N3DS_CreateDevice(void)
     /* Initialize internal data */
     phdata = (SDL_VideoData *)SDL_calloc(1, sizeof(SDL_VideoData));
     if (!phdata) {
-        SDL_OutOfMemory();
         SDL_free(device);
         return NULL;
     }

--- a/src/video/x11/SDL_x11mouse.c
+++ b/src/video/x11/SDL_x11mouse.c
@@ -75,7 +75,6 @@ static SDL_Cursor *X11_CreateDefaultCursor(void)
         /* None is used to indicate the default cursor */
         cursor->driverdata = (void *)(uintptr_t)None;
     }
-
     return cursor;
 }
 
@@ -263,9 +262,7 @@ static SDL_Cursor *X11_CreateSystemCursor(SDL_SystemCursor id)
 
     if (x11_cursor != None) {
         cursor = SDL_calloc(1, sizeof(*cursor));
-        if (!cursor) {
-            SDL_OutOfMemory();
-        } else {
+        if (cursor) {
             cursor->driverdata = (void *)(uintptr_t)x11_cursor;
         }
     }


### PR DESCRIPTION
Since commit 447b508a77b8601d23ca48cf189fe4436ab33572, SDL_malloc, SDL_calloc, and SDL_realloc already calls SDL_OutOfMemory().

If this is good, I can do the same for SDL3 satellite libraries.
