### PR TITLE
Add documentation about dialogs and events

### DIFF
--- a/include/SDL3/SDL_dialog.h
+++ b/include/SDL3/SDL_dialog.h
@@ -101,6 +101,10 @@ typedef void(SDLCALL *SDL_DialogFileCallback)(void *userdata, const char * const
  * Depending on the platform, the user may be allowed to input paths that
  * don't yet exist.
  *
+ * On Linux, dialogs may require XDG Portals, which requires DBus, which
+ * requires and event-handling loop. Apps that do not use SDL to handle events
+ * should add a call to SDL_PumpEvents in their main loop.
+ *
  * \param callback An SDL_DialogFileCallback to be invoked when the user
  *                 selects a file and accepts, or cancels the dialog, or an
  *                 error occurs. The first argument is a null-terminated list
@@ -153,6 +157,10 @@ extern DECLSPEC void SDLCALL SDL_ShowOpenFileDialog(SDL_DialogFileCallback callb
  *
  * The chosen file may or may not already exist.
  *
+ * On Linux, dialogs may require XDG Portals, which requires DBus, which
+ * requires and event-handling loop. Apps that do not use SDL to handle events
+ * should add a call to SDL_PumpEvents in their main loop.
+ *
  * \param callback An SDL_DialogFileCallback to be invoked when the user
  *                 selects a file and accepts, or cancels the dialog, or an
  *                 error occurs. The first argument is a null-terminated list
@@ -202,6 +210,10 @@ extern DECLSPEC void SDLCALL SDL_ShowSaveFileDialog(SDL_DialogFileCallback callb
  *
  * Depending on the platform, the user may be allowed to input paths that
  * don't yet exist.
+ *
+ * On Linux, dialogs may require XDG Portals, which requires DBus, which
+ * requires and event-handling loop. Apps that do not use SDL to handle events
+ * should add a call to SDL_PumpEvents in their main loop.
  *
  * \param callback An SDL_DialogFileCallback to be invoked when the user
  *                 selects a file and accepts, or cancels the dialog, or an


### PR DESCRIPTION
## Description

I added documentation for dialogs about the case on Linux where handling events is required.

I did not mention the workaround with `SDL_SetHint(SDL_HINT_FILE_DIALOG_DRIVER, "zenity")` because I'm not sure how reliable that is (not all systems ship zenity, some features like modality don't work with zenity, some behavior may change in the future, new options can pop, etc).

## Existing Issue(s)

Fixes #9703 somewhat, I'm not sure there can be any better fix than that.
