### PR TITLE
SDL_stdinc.h: add fallback cases for SDL_SINT64_C and SDL_UINT64_C

### DIFF
--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -139,8 +139,19 @@ void *alloca(size_t);
 /**
  * Append the 64 bit integer suffix to an integer literal.
  */
+#if defined(INT64_C)
 #define SDL_SINT64_C(c)  INT64_C(c)
 #define SDL_UINT64_C(c)  UINT64_C(c)
+#elif defined(_MSC_VER)
+#define SDL_INT64_C(c)   c ## i64
+#define SDL_UINT64_C(c)  c ## ui64
+#elif defined(__LP64__) || defined(_LP64)
+#define SDL_INT64_C(c)   c ## L
+#define SDL_UINT64_C(c)  c ## UL
+#else
+#define SDL_INT64_C(c)   c ## LL
+#define SDL_UINT64_C(c)  c ## ULL
+#endif
 
 /**
  *  \name Basic data types


### PR DESCRIPTION
These are needed when `INT64_C` and `UINT64_C` macros are either not
available (not likely), or guarded by `__STDC_LIMIT_MACROS` in C++
compilations (which is the case in many old SDKs.)

@icculus: Don't know if this is good wrt documentation (i.e. wikiheaders, etc)

CC: @Sackzement 
