### PR TITLE
SDL_x11sym.h: corrected XQueryKeymap() proto.

### DIFF
--- a/src/video/x11/SDL_x11sym.h
+++ b/src/video/x11/SDL_x11sym.h
@@ -99,7 +99,7 @@ SDL_X11_SYM(Status,XInitThreads,(void),(),return)
 SDL_X11_SYM(int,XPeekEvent,(Display* a,XEvent* b),(a,b),return)
 SDL_X11_SYM(int,XPending,(Display* a),(a),return)
 SDL_X11_SYM(int,XPutImage,(Display* a,Drawable b,GC c,XImage* d,int e,int f,int g,int h,unsigned int i,unsigned int j),(a,b,c,d,e,f,g,h,i,j),return)
-SDL_X11_SYM(int,XQueryKeymap,(Display* a,char *b),(a,b),return)
+SDL_X11_SYM(int,XQueryKeymap,(Display* a,char b[32]),(a,b),return)
 SDL_X11_SYM(Bool,XQueryPointer,(Display* a,Window b,Window* c,Window* d,int* e,int* f,int* g,int* h,unsigned int* i),(a,b,c,d,e,f,g,h,i),return)
 SDL_X11_SYM(int,XRaiseWindow,(Display* a,Window b),(a,b),return)
 SDL_X11_SYM(int,XReparentWindow,(Display* a,Window b,Window c,int d,int e),(a,b,c,d,e),return)
@@ -163,7 +163,6 @@ SDL_X11_SYM(char*,XResourceManagerString,(Display *display),(display),)
 SDL_X11_SYM(XrmDatabase,XrmGetStringDatabase,(char *data),(data),)
 SDL_X11_SYM(void,XrmDestroyDatabase,(XrmDatabase db),(db),)
 SDL_X11_SYM(Bool,XrmGetResource,(XrmDatabase db, char* str_name, char* str_class, char **str_type_return, XrmValue *),(db, str_name, str_class,str_type_return,value_return),)
-
 
 #ifdef SDL_VIDEO_DRIVER_X11_XFIXES
 SDL_X11_MODULE(XFIXES)


### PR DESCRIPTION
Noticed this in SDL-1.2 in a gcc-13 build, which emitted the following
warning:  (No such warnings in SDL2 and SDL3, due to macro differences)

```
./src/video/x11/SDL_x11sym.h:84:48: warning: argument 2 of type 'char *' declared as a pointer [-Warray-parameter=]
   84 | SDL_X11_SYM(int,XQueryKeymap,(Display* a,char *b),(a,b),return)
      |                                          ~~~~~~^
./src/video/x11/SDL_x11dyn.c:95:15: note: in definition of macro 'SDL_X11_SYM'
   95 |         rc fn params { ret p##fn args ; }
      |               ^~~~~~
In file included from ./src/video/x11/SDL_x11dyn.h:27,
                 from ./src/video/x11/SDL_x11dyn.c:26:
/usr/include/X11/Xlib.h:2980:5: note: previously declared as an array 'char[32]'
 2980 |     char [32]           /* keys_return */
      |     ^~~~~~~~~
```

The original actually was char[32] but was changed with
https://github.com/libsdl-org/SDL-1.2/commit/8ada1e8a6eb2b3e7da1503345ebc4d785aa96302
(https://bugzilla.libsdl.org/show_bug.cgi?id=170
https://github.com/libsdl-org/SDL-1.2/issues/101)
@icculus: Do you remember why that was?
