### PR TITLE
SDL_iconv_string: simplify recomputation of outbuf and outbytesleft

### DIFF
--- a/src/stdlib/SDL_iconv.c
+++ b/src/stdlib/SDL_iconv.c
@@ -813,6 +813,7 @@ char *SDL_iconv_string(const char *tocode, const char *fromcode, const char *inb
         switch (retCode) {
         case SDL_ICONV_E2BIG:
         {
+            const ptrdiff_t diff = (ptrdiff_t) (outbuf - string);
             char *oldstring = string;
             stringsize *= 2;
             string = (char *)SDL_realloc(string, stringsize + sizeof(Uint32));
@@ -821,8 +822,8 @@ char *SDL_iconv_string(const char *tocode, const char *fromcode, const char *inb
                 SDL_iconv_close(cd);
                 return NULL;
             }
-            outbuf = string + (outbuf - oldstring);
-            outbytesleft = stringsize - (outbuf - string);
+            outbuf = string + diff;
+            outbytesleft = stringsize - diff;
             SDL_memset(outbuf, 0, sizeof(Uint32));
             continue;
         }


### PR DESCRIPTION
The change matches the intention, yes?

Noticed this in SDL-1.2 where gcc-13 emits a -Wuse-after-free warning.
No such warning in SDL2 and SDL3, because unlike SDL1.2, SDL_realloc()
is not a macro expanding to libc realloc(). It warns, of course, if
SDL_realloc() is replaced with plain realloc():

```
src/stdlib/SDL_iconv.c: In function 'SDL_iconv_string_REAL':
src/stdlib/SDL_iconv.c:824:39: warning: pointer 'oldstring' may be used after 'realloc' [-Wuse-after-free]
  824 |             outbuf = string + (outbuf - oldstring);
      |                               ~~~~~~~~^~~~~~~~~~~~
src/stdlib/SDL_iconv.c:818:30: note: call to 'realloc' here
  818 |             string = (char *)realloc(string, stringsize + sizeof(Uint32));
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I don't know of a gcc attribute to trigger such warnings with SDL_
allocators.
