### PR TITLE
Use the correct type for the modifier in SDL_Keysym

### DIFF
--- a/include/SDL3/SDL_keyboard.h
+++ b/include/SDL3/SDL_keyboard.h
@@ -64,8 +64,8 @@ typedef struct SDL_Keysym
 {
     SDL_Scancode scancode;      /**< SDL physical key code - see ::SDL_Scancode for details */
     SDL_Keycode sym;            /**< SDL virtual key code - see ::SDL_Keycode for details */
-    Uint16 mod;                 /**< current key modifiers */
-    Uint32 unused;
+    SDL_Keymod mod;             /**< current key modifiers */
+    Uint16 unused;
 } SDL_Keysym;
 
 /* Function prototypes */


### PR DESCRIPTION
This shrinks the structure by 32-bits because we've removed implicit padding between the fields.

This doesn't affect sdl2-compat because the keysym is the last field in the structure and sizeof(keysym.mod) is the same.