### PR TITLE
Add SDL_HINT_AUDIO_DEVICE_APP_ICON_NAME

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -293,6 +293,28 @@ extern "C" {
 #define SDL_HINT_AUDIO_DEVICE_APP_NAME "SDL_AUDIO_DEVICE_APP_NAME"
 
 /**
+ * Specify an application icon name for an audio device.
+ *
+ * Some audio backends (such as Pulseaudio and Pipewire) allow you to set an
+ * XDG icon name for your application. Among other things, this icon might show
+ * up in a system control panel that lets the user adjust the volume on specific
+ * audio streams instead of using one giant master volume slider. Note that this
+ * is unrelated to the icon used by the windowing system, which may be set with
+ * SDL_SetWindowIcon (or via desktop file on Wayland).
+ *
+ * Setting this to "" or leaving it unset will have SDL use a reasonable
+ * default, "applications-games", which is likely to be installed.
+ * See https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html
+ * and https://specifications.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html
+ * for the relevant XDG icon specs.
+ *
+ * This hint should be set before an audio device is opened.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_AUDIO_DEVICE_APP_ICON_NAME "SDL_AUDIO_DEVICE_APP_ICON_NAME"
+
+/**
  * A variable controlling device buffer size.
  *
  * This hint is an integer > 0, that represents the size of the device's

--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -1108,7 +1108,7 @@ static int PIPEWIRE_OpenDevice(SDL_AudioDevice *device)
     const struct spa_pod *params = NULL;
     struct SDL_PrivateAudioData *priv;
     struct pw_properties *props;
-    const char *app_name, *app_id, *stream_name, *stream_role, *error;
+    const char *app_name, *icon_name, *app_id, *stream_name, *stream_role, *error;
     Uint32 node_id = !device->handle ? PW_ID_ANY : PW_HANDLE_TO_ID(device->handle);
     const SDL_bool iscapture = device->iscapture;
     int res;
@@ -1116,13 +1116,18 @@ static int PIPEWIRE_OpenDevice(SDL_AudioDevice *device)
     // Clamp the period size to sane values
     const int min_period = PW_MIN_SAMPLES * SPA_MAX(device->spec.freq / PW_BASE_CLOCK_RATE, 1);
 
-    // Get the hints for the application name, stream name and role
+    // Get the hints for the application name, icon name, stream name and role
     app_name = SDL_GetHint(SDL_HINT_AUDIO_DEVICE_APP_NAME);
     if (!app_name || *app_name == '\0') {
         app_name = SDL_GetHint(SDL_HINT_APP_NAME);
         if (!app_name || *app_name == '\0') {
             app_name = "SDL Application";
         }
+    }
+
+    icon_name = SDL_GetHint(SDL_HINT_AUDIO_DEVICE_APP_ICON_NAME);
+    if (!icon_name || *icon_name == '\0') {
+        icon_name = "applications-games";
     }
 
     // App ID. Default to NULL if not available.
@@ -1190,6 +1195,7 @@ static int PIPEWIRE_OpenDevice(SDL_AudioDevice *device)
     PIPEWIRE_pw_properties_set(props, PW_KEY_MEDIA_CATEGORY, iscapture ? "Capture" : "Playback");
     PIPEWIRE_pw_properties_set(props, PW_KEY_MEDIA_ROLE, stream_role);
     PIPEWIRE_pw_properties_set(props, PW_KEY_APP_NAME, app_name);
+    PIPEWIRE_pw_properties_set(props, PW_KEY_APP_ICON_NAME, icon_name);
     if (app_id) {
         PIPEWIRE_pw_properties_set(props, PW_KEY_APP_ID, app_id);
     }


### PR DESCRIPTION
Add a new hint, `SDL_HINT_AUDIO_DEVICE_APP_ICON_NAME`, to request an XDG icon name which may be displayed in audio mixers, such as pavucontrol and the KDE Plasma sound settings.

## Description

Here is the description I've added to the hints header file:

```
/**
 * Specify an application icon name for an audio device.
 *
 * Some audio backends (such as Pulseaudio and Pipewire) allow you to set an
 * XDG icon name for your application. Among other things, this icon might show
 * up in a system control panel that lets the user adjust the volume on specific
 * audio streams instead of using one giant master volume slider. Note that this
 * is unrelated to the icon used by the windowing system, which may be set with
 * SDL_SetWindowIcon (or via desktop file on Wayland).
 *
 * Setting this to "" or leaving it unset will have SDL use a reasonable
 * default, "applications-games", which is likely to be installed.
 * See https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html
 * and https://specifications.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html
 * for the relevant XDG icon specs.
 *
 * This hint should be set before an audio device is opened.
 *
 * \since This hint is available since SDL 3.0.0.
 */
```


Here is an example of using the new hint to request a "camera-video" audio icon:

```c
#include "SDL3/SDL.h"

int main(int argc, char *argv[]) {
	SDL_Version ver;
	SDL_GetVersion(&ver);
	SDL_Log("SDL version: %u.%u.%u", ver.major, ver.minor, ver.patch);
	SDL_SetHint(SDL_HINT_AUDIO_DEVICE_APP_NAME, "sdl-example");
	SDL_SetHint(SDL_HINT_AUDIO_DEVICE_STREAM_NAME, "total silence");
	SDL_SetHint(SDL_HINT_AUDIO_DEVICE_STREAM_ROLE, "Game");
	char *audio_icon = (argc > 1) ? argv[1] : "camera-video";
	SDL_SetHint(SDL_HINT_AUDIO_DEVICE_APP_ICON_NAME, audio_icon);
	SDL_Log("Set hint for audio icon: %s", audio_icon);
	SDL_Init(SDL_INIT_AUDIO);
	SDL_Log("Audio driver: %s", SDL_GetCurrentAudioDriver());
	SDL_AudioSpec spec = {SDL_AUDIO_U8, 1, 4000}; // minimally acceptable dummy values
	SDL_AudioStream *stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_OUTPUT, &spec, NULL, NULL);
	SDL_Event e;
	_Bool quit = 0;
	while (!quit) {
		while (SDL_PollEvent(&e)) if (e.type == SDL_EVENT_QUIT) quit = 1;
		SDL_Delay(100);
	}
	SDL_DestroyAudioStream(stream);
	SDL_Quit();
	return 0;
}
```
This example application just plays silence, but it appears in audio mixers as a playback stream. Here are screenshots of how the application appears in KDE Plasma sound settings under three conditions:
1. Audio icon hint line is commented out, and app is linked to SDL *without* patch. We get a generic audio icon: ![1](https://github.com/libsdl-org/SDL/assets/47096018/acff046a-902d-420c-aef1-d30fe62ab493)
2. Audio icon hint line is commented out, and app is linked to SDL with patch. We get a better default, "applications-games": ![2](https://github.com/libsdl-org/SDL/assets/47096018/a139e18d-d7a0-4f5d-aa0c-c888fcfd5bcb)
3. Audio icon hint line is left intact, and app is linked to SDL with patch. We are able to choose the icon ourselves: ![3](https://github.com/libsdl-org/SDL/assets/47096018/fb3c88f2-4e15-421e-aae4-ebe8dc4c5b72)

I've tested this on Arch Linux running KDE Plasma, and I used the `SDL_AUDIO_DRIVER` environment variable to explicitly test with both Pulseaudio and Pipewire backends.