### PR TITLE
Fixed bug #9672 - add a Camera / StopDevice() for v4l2 back-end metho…

### DIFF
--- a/src/camera/SDL_camera.c
+++ b/src/camera/SDL_camera.c
@@ -231,7 +231,10 @@ static void ClosePhysicalCameraDevice(SDL_CameraDevice *device)
 
     SDL_AtomicSet(&device->shutdown, 1);
 
-// !!! FIXME: the close_cond stuff from audio might help the race condition here.
+    // stop the device, so that the thread can end
+    if (camera_driver.impl.StopDevice) { // FIXME: this probably should be implemented for all backends
+        camera_driver.impl.StopDevice(device);
+    }
 
     if (device->thread != NULL) {
         SDL_WaitThread(device->thread, NULL);

--- a/src/camera/SDL_syscamera.h
+++ b/src/camera/SDL_syscamera.h
@@ -163,6 +163,7 @@ typedef struct SDL_CameraDriverImpl
     void (*DetectDevices)(void);
     int (*OpenDevice)(SDL_CameraDevice *device, const SDL_CameraSpec *spec);
     void (*CloseDevice)(SDL_CameraDevice *device);
+    void (*StopDevice)(SDL_CameraDevice *device);
     int (*WaitDevice)(SDL_CameraDevice *device);
     int (*AcquireFrame)(SDL_CameraDevice *device, SDL_Surface *frame, Uint64 *timestampNS); // set frame->pixels, frame->pitch, and *timestampNS!
     void (*ReleaseFrame)(SDL_CameraDevice *device, SDL_Surface *frame); // Reclaim frame->pixels and frame->pitch!


### PR DESCRIPTION
Fixed bug #9672 - add a Camera / StopDevice() for v4l2 back-end method so that the internal thread can end.
prevent deadlock when there is a delay between SDL_ReleaseCameraFrame and SDL_CloseCamera


It currently only fix the v4l2 backend. other backend needs the same thing I guess ...
