### PR TITLE
Fixed bug #9672 - v4l2/camera prevent deadlock when there is a delay …

### DIFF
--- a/src/camera/v4l2/SDL_camera_v4l2.c
+++ b/src/camera/v4l2/SDL_camera_v4l2.c
@@ -107,6 +107,12 @@ static int V4L2_WaitDevice(SDL_CameraDevice *device)
         if ((retval == -1) && (errno == EINTR)) {
             retval = 0;  // pretend it was a timeout, keep looping.
         }
+
+        // Thread is requested to shut down
+        if (SDL_AtomicGet(&device->shutdown)) {
+            return 0;
+        }
+
     } while (retval == 0);
 
     return retval;


### PR DESCRIPTION
Fixed bug #9672 - v4l2/camera prevent deadlock when there is a delay between SDL_ReleaseCameraFrame and SDL_CloseCamera

