### PR TITLE
tests: fix some leaks + fix debug messages when exiting testcamera

### DIFF
--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -2063,29 +2063,6 @@ int SDLTest_CommonEventMainCallbacks(SDLTest_CommonState *state, const SDL_Event
     }
 
     switch (event->type) {
-    case SDL_EVENT_WINDOW_CLOSE_REQUESTED:
-    {
-        SDL_Window *window = SDL_GetWindowFromID(event->window.windowID);
-        if (window) {
-            /* Clear cache to avoid stale textures */
-            SDLTest_CleanupTextDrawing();
-            for (i = 0; i < state->num_windows; ++i) {
-                if (window == state->windows[i]) {
-                    if (state->targets[i]) {
-                        SDL_DestroyTexture(state->targets[i]);
-                        state->targets[i] = NULL;
-                    }
-                    if (state->renderers[i]) {
-                        SDL_DestroyRenderer(state->renderers[i]);
-                        state->renderers[i] = NULL;
-                    }
-                    SDL_DestroyWindow(state->windows[i]);
-                    state->windows[i] = NULL;
-                    break;
-                }
-            }
-        }
-    } break;
     case SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED:
         if (state->auto_scale_content) {
             SDL_Window *window = SDL_GetWindowFromID(event->window.windowID);

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -3748,6 +3748,12 @@ void SDL_DestroyWindow(SDL_Window *window)
         SDL_DestroyRendererWithoutFreeing(renderer);
     }
 
+    /* Restore video mode, etc. */
+    SDL_UpdateFullscreenMode(window, SDL_FALSE, SDL_TRUE);
+    if (!(window->flags & SDL_WINDOW_EXTERNAL)) {
+        SDL_HideWindow(window);
+    }
+
     SDL_DestroyProperties(window->props);
 
     /* Clear the modal status, but don't unset the parent, as it may be
@@ -3756,12 +3762,6 @@ void SDL_DestroyWindow(SDL_Window *window)
      */
     if (_this->SetWindowModalFor && (window->flags & SDL_WINDOW_MODAL)) {
         _this->SetWindowModalFor(_this, window, NULL);
-    }
-
-    /* Restore video mode, etc. */
-    SDL_UpdateFullscreenMode(window, SDL_FALSE, SDL_TRUE);
-    if (!(window->flags & SDL_WINDOW_EXTERNAL)) {
-        SDL_HideWindow(window);
     }
 
     /* Make sure the destroyed window isn't referenced by any display as a fullscreen window. */

--- a/test/testatomic.c
+++ b/test/testatomic.c
@@ -128,7 +128,8 @@ static int SDLCALL adder(void *junk)
 static void runAdder(void)
 {
     Uint64 start, end;
-    int T = NThreads;
+    int i;
+    SDL_Thread *threads[NThreads];
 
     start = SDL_GetTicksNS();
 
@@ -136,12 +137,16 @@ static void runAdder(void)
 
     SDL_AtomicSet(&threadsRunning, NThreads);
 
-    while (T--) {
-        SDL_CreateThread(adder, "Adder", NULL);
+    for (i = 0; i < NThreads; i++) {
+        threads[i] = SDL_CreateThread(adder, "Adder", NULL);
     }
 
     while (SDL_AtomicGet(&threadsRunning) > 0) {
         SDL_WaitSemaphore(threadDone);
+    }
+
+    for (i = 0; i < NThreads; i++) {
+        SDL_WaitThread(threads[i], NULL);
     }
 
     SDL_DestroySemaphore(threadDone);
@@ -726,6 +731,7 @@ int main(int argc, char *argv[])
     RunFIFOTest(SDL_FALSE);
 #endif
     RunFIFOTest(SDL_TRUE);
+    SDL_Quit();
     SDLTest_CommonDestroyState(state);
     return 0;
 }

--- a/test/testcamera.c
+++ b/test/testcamera.c
@@ -175,7 +175,7 @@ int SDL_AppEvent(void *appstate, const SDL_Event *event)
             return FlipCamera();
 
         case SDL_EVENT_QUIT:
-            SDL_Log("Ctlr+C : Quit!");
+            SDL_Log("Quit!");
             return 1;
 
         case SDL_EVENT_CAMERA_DEVICE_APPROVED:
@@ -266,8 +266,5 @@ void SDL_AppQuit(void *appstate)
     SDL_ReleaseCameraFrame(camera, frame_current);
     SDL_CloseCamera(camera);
     SDL_DestroyTexture(texture);
-    SDL_DestroyRenderer(renderer);
-    SDL_DestroyWindow(window);
     SDLTest_CommonQuit(state);
 }
-

--- a/test/testiconv.c
+++ b/test/testiconv.c
@@ -121,6 +121,7 @@ int main(int argc, char *argv[])
     (void)fclose(file);
 
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Total errors: %d\n", errors);
+    SDL_Quit();
     SDLTest_CommonDestroyState(state);
     return errors ? errors + 1 : 0;
 }


### PR DESCRIPTION
This pr fixes leaks in `testatomic` and `testiconv`  when running with `--trackmem`.
It also fixes printing of the following debug messages when exiting `testcamera`:
```
DEBUG: Parameter 'texture' is invalid
DEBUG: Parameter 'renderer' is invalid
DEBUG: Invalid window
DEBUG: Invalid window
```


This pr does *not* address the leak in testautomation. See issue 9778.

