### PR TITLE
test: Free clipboard data after calling SDL_GetClipboardText()

### DIFF
--- a/test/testautomation_clipboard.c
+++ b/test/testautomation_clipboard.c
@@ -168,6 +168,7 @@ static int clipboard_testClipboardDataFunctions(void *arg)
         text && SDL_strcmp(text, expected_text) == 0,
         "Verify clipboard text, expected \"%s\", got \"%s\"",
         expected_text, text);
+    SDL_free(text);
 
     boolResult = SDL_HasClipboardData(test_mime_types[TEST_MIME_TYPE_TEXT]);
     SDLTest_AssertCheck(
@@ -269,6 +270,7 @@ static int clipboard_testClipboardDataFunctions(void *arg)
         text && SDL_strcmp(text, expected_text) == 0,
         "Verify clipboard text, expected \"%s\", got \"%s\"",
         expected_text, text);
+    SDL_free(text);
 
     boolResult = SDL_HasClipboardData(test_mime_types[TEST_MIME_TYPE_TEXT]);
     SDLTest_AssertCheck(


### PR DESCRIPTION
Clipboard allocations were being leaked in two instances.

Fixes #9778