### PR TITLE
SDL_scancode.h: Updating HID usage tables link

### DIFF
--- a/include/SDL3/SDL_scancode.h
+++ b/include/SDL3/SDL_scancode.h
@@ -40,7 +40,7 @@
  * in the `keysym.scancode` field of the SDL_KeyboardEvent structure.
  *
  * The values in this enumeration are based on the USB usage page standard:
- * https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf
+ * https://usb.org/sites/default/files/hut1_5.pdf
  *
  * \since This enum is available since SDL 3.0.0.
  */
@@ -349,7 +349,6 @@ typedef enum SDL_Scancode
      *  \name Usage page 0x0C
      *
      *  These values are mapped from usage page 0x0C (USB consumer page).
-     *  See https://usb.org/sites/default/files/hut1_2.pdf
      *
      *  There are way more keys in the spec than we can represent in the
      *  current scancode range, so pick the ones that commonly come up in


### PR DESCRIPTION
usb.org updated the HID specification this year to version 1.5.

This commit updates the link in `SDL_scancode.h` to point to the new pdf version.
It also removes the second link near the bottom of the file.