### PR TITLE
Fix missing #include in SDL_blendmode.h

### DIFF
--- a/include/SDL3/SDL_blendmode.h
+++ b/include/SDL3/SDL_blendmode.h
@@ -28,6 +28,8 @@
 #ifndef SDL_blendmode_h_
 #define SDL_blendmode_h_
 
+#include <SDL3/SDL_stdinc.h>
+
 #include <SDL3/SDL_begin_code.h>
 /* Set up for C function definitions, even when using C++ */
 #ifdef __cplusplus


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Regressed when SDL_BlendMode was changed from an enum to a typedef Uint32.

