### PR TITLE
Add defined constants for renderer vsync values

### DIFF
--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -2140,8 +2140,8 @@ extern DECLSPEC int SDLCALL SDL_AddVulkanRenderSemaphores(SDL_Renderer *renderer
  * \param renderer The renderer to toggle
  * \param vsync the vertical refresh sync interval, 1 to synchronize present
  *              with every vertical refresh, 2 to synchronize present with
- *              every second vertical refresh, etc., SDL_VSYNC_ADAPTIVE for late swap
- *              tearing (adaptive vsync), or SDL_VSYNC_DISABLED to disable. Not every value is supported by
+ *              every second vertical refresh, etc., SDL_RENDERER_VSYNC_ADAPTIVE for late swap
+ *              tearing (adaptive vsync), or SDL_RENDERER_VSYNC_DISABLED to disable. Not every value is supported by
  *              every renderer, so you should check the return value to see
  *              whether the requested setting is supported.
  * \returns 0 on success or a negative error code on failure; call
@@ -2153,8 +2153,8 @@ extern DECLSPEC int SDLCALL SDL_AddVulkanRenderSemaphores(SDL_Renderer *renderer
  */
 extern DECLSPEC int SDLCALL SDL_SetRenderVSync(SDL_Renderer *renderer, int vsync);
 
-#define SDL_VSYNC_DISABLED 0
-#define SDL_VSYNC_ADAPTIVE (-1)
+#define SDL_RENDERER_VSYNC_DISABLED 0
+#define SDL_RENDERER_VSYNC_ADAPTIVE (-1)
 
 /**
  * Get VSync of the given renderer.

--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -2140,8 +2140,8 @@ extern DECLSPEC int SDLCALL SDL_AddVulkanRenderSemaphores(SDL_Renderer *renderer
  * \param renderer The renderer to toggle
  * \param vsync the vertical refresh sync interval, 1 to synchronize present
  *              with every vertical refresh, 2 to synchronize present with
- *              every second vertical refresh, etc., or -1 for late swap
- *              tearing (adaptive vsync). Not every value is supported by
+ *              every second vertical refresh, etc., SDL_VSYNC_ADAPTIVE for late swap
+ *              tearing (adaptive vsync), or SDL_VSYNC_DISABLED to disable. Not every value is supported by
  *              every renderer, so you should check the return value to see
  *              whether the requested setting is supported.
  * \returns 0 on success or a negative error code on failure; call
@@ -2153,11 +2153,14 @@ extern DECLSPEC int SDLCALL SDL_AddVulkanRenderSemaphores(SDL_Renderer *renderer
  */
 extern DECLSPEC int SDLCALL SDL_SetRenderVSync(SDL_Renderer *renderer, int vsync);
 
+#define SDL_VSYNC_DISABLED 0
+#define SDL_VSYNC_ADAPTIVE (-1)
+
 /**
  * Get VSync of the given renderer.
  *
  * \param renderer The renderer to toggle
- * \param vsync an int filled with the current vertical refresh sync interval
+ * \param vsync an int filled with the current vertical refresh sync interval. See SDL_SetRenderVSync for meaning of the value.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *

--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -2160,7 +2160,7 @@ extern DECLSPEC int SDLCALL SDL_SetRenderVSync(SDL_Renderer *renderer, int vsync
  * Get VSync of the given renderer.
  *
  * \param renderer The renderer to toggle
- * \param vsync an int filled with the current vertical refresh sync interval. See SDL_SetRenderVSync for meaning of the value.
+ * \param vsync an int filled with the current vertical refresh sync interval. See SDL_SetRenderVSync for the meaning of the value.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR expands the documentation of `SDL_SetRenderVSync` to mention how to disable vsync. Also replaces magic integer values used to describe vsync with `SDL_RENDERER_VSYNC_ADAPTIVE` and `SDL_RENDERER_VSYNC_DISABLED` defines.

`SDL_HINT_RENDER_VSYNC` could also be updated to support `-1`, `2`, `3` etc. It says [`0` is the default](https://github.com/libsdl-org/SDL/blob/8b5f0d07e995cf216d2268863e0deb77bb621300/include/SDL3/SDL_hints.h#L2573-L2588), but [`SDL_GetHintBoolean` is called with SDL_TRUE](https://github.com/libsdl-org/SDL/blob/17520c2e6eeac14839ecc510472353bf84a9c985/src/render/SDL_render.c#L972) (after checking that the hint is set).

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
- Closes https://github.com/libsdl-org/sdlwiki/issues/533