### PR TITLE
fix pipewire camera interval fraction inversion

### DIFF
--- a/src/camera/pipewire/SDL_camera_pipewire.c
+++ b/src/camera/pipewire/SDL_camera_pipewire.c
@@ -621,8 +621,9 @@ static void collect_rates(CameraFormatAddData *data, struct param *p, const Uint
 	SPA_FALLTHROUGH;
     case SPA_CHOICE_Enum:
 	for (i = 0; i < n_vals; i++) {
+            // denom and num are switched, because sdl expects an interval, while pw provides a rate
             if (SDL_AddCameraFormat(data, sdlfmt, size->width, size->height,
-				    rates[i].num, rates[i].denom) == -1) {
+				    rates[i].denom, rates[i].num) == -1) {
                 return;  // Probably out of memory; we'll go with what we have, if anything.
             }
 	}


### PR DESCRIPTION
SDL expects an interval fraction to be provided by the backend, but pipewire provides a framerate fraction, so we we just switch them.

<!--- Provide a general summary of your changes in the Title above -->

## Example
```
SDL Camera Driver: v4l2
### found cameras:
  - Camera #0: Chicony USB2.0 Camera: Chicony
    - 1280x720@10 SDL_PIXELFORMAT_YUY2
    /- d10 n1
    - 640x480@30 SDL_PIXELFORMAT_YUY2
    /- d30 n1
```

pw (wrong)
```
SDL Camera Driver: pipewire
### found cameras:
  - Camera #0: Chicony USB2.0 Camera (V4L2)
    - 1280x720@0.1 SDL_PIXELFORMAT_YUY2
    /- d1 n10
    - 640x480@0.0333333 SDL_PIXELFORMAT_YUY2
    /- d1 n30
```

CC @wtay 