### PR TITLE
Add `SDL_NODISCARD` macro to `SDL_begin_code.h`

### DIFF
--- a/include/SDL3/SDL_begin_code.h
+++ b/include/SDL3/SDL_begin_code.h
@@ -171,6 +171,19 @@
 #endif /* C++17 or C2x */
 #endif /* SDL_FALLTHROUGH not defined */
 
+#ifndef SDL_NODISCARD
+#if (defined(__cplusplus) && __cplusplus >= 201703L) || \
+    (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L)
+#define SDL_NODISCARD [[nodiscard]]
+#elif ( (defined(__GNUC__) && (__GNUC__ >= 4)) || defined(__clang__) )
+#define SDL_NODISCARD __attribute__((warn_unused_result))
+#elif defined(_MSC_VER) && (_MSC_VER >= 1700)
+#define SDL_NODISCARD _Check_return_
+#else
+#define SDL_NODISCARD
+#endif /* C++17 or C23 */
+#endif /* SDL_NODISCARD not defined */
+
 #ifndef SDL_MALLOC
 #if defined(__GNUC__) && (__GNUC__ >= 3)
 #define SDL_MALLOC __attribute__((malloc))


### PR DESCRIPTION
Add a `SDL_NODISCARD` macro that, when applied to a function, warns the user of that function if the return value is ignored. The presence of this macro prevents defects in programs caused by forgetting to check a function's error code return value, either by absentmindedness or because the function's name did not suggest that an error code would be returned.

~~As a proof of concept, the `SDL_NODISCARD` macro has been selectively applied to some functions in `SDL_audio`.~~

## Description

The `SDL_NODISCARD` macro expands to, in order:
- `[[nodiscard]]` in C++17 and C23;
- otherwise, `__attribute__((warn_unused_result))` for GCC and Clang;
- otherwise, `_Check_return_` in MSVC;
- otherwise, expands to nothing.

The `SDL_NODISCARD` macro could theoretically be applied on any function that returns a value that the user *must* use or read. This would produce a warning any time the user clearly misuses a function, which massively decreases the likelihood of defects making it into actual shipped software.

The drawback is that pretty much every function in SDL would be decorated with `SDL_NODISCARD`, adding a bit of noise to SDL's headers.

As a starting point, I've decided to conservatively apply the `SDL_NODISCARD` macro using the same principles that I describe in my ["Pragmatic Simplicity" CppCon 2022 talk](https://www.youtube.com/watch?v=3eH7JRgLnG8):

- Functions that are named `GetXXX` something and clearly return a value are unlikely to be misused, therefore the `SDL_NODISCARD` macro was not applied there;

- Functions that return an error code and whose name does not suggest that a value is returned are prime candidates for a bug and maximize the noise-to-value ratio of `SDL_NODISCARD`, therfore the macro was applied there.

I am not against the idea of applying `SDL_NODISCARD` more liberally to ensure that even the most unlikely function misuses are caught at compile-time, but there is definitely a small readability impact on the codebase, and -- as explained in the talk -- if everything is marked `SDL_NODISCARD`, then the value and attention that the users give to such a macro is diluted.

If this PR is well-received, `SDL_NODISCARD` can be applied to other SDL modules in future PRs.

## Existing Issue(s)

N/A
