### PR TITLE
ci: retry package creation multiple times

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,7 +139,22 @@ jobs:
     - name: Package (CPack)
       if: ${{ always() && steps.build.outcome == 'success' }}
       run: |
-        cmake --build build/ --config Release --target package
+        # DMG creation on macOS occasionally fails, so try multiple times
+        # https://gitlab.kitware.com/cmake/cmake/-/issues/25671
+        success=0
+        max_tries=10
+        for i in $(seq $max_tries); do
+         cmake --build build/ --config Release --target package && success=1
+         if test $success = 1; then
+          break
+         fi
+         echo "Package creation failed. Sleep 1 second and try again."
+         sleep 1
+        done
+        if test $success = 0; then
+         echo "Package creation failed after $max_tries attempts."
+         exit 1
+        fi
     - name: Verify CMake configuration files
       run: |
         ${{ matrix.platform.source_cmd }}


### PR DESCRIPTION
DMG creation on macOS occasionally fails, so try multiple times https://gitlab.kitware.com/cmake/cmake/-/issues/25671

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
Fixes #9815
