### PR TITLE
fix type redefinition errors after #9817

### DIFF
--- a/src/video/wayland/SDL_waylandvulkan.h
+++ b/src/video/wayland/SDL_waylandvulkan.h
@@ -29,8 +29,7 @@
 #ifndef SDL_waylandvulkan_h_
 #define SDL_waylandvulkan_h_
 
-#include "../SDL_vulkan_internal.h"
-#include "../SDL_sysvideo.h"
+#include <SDL3/SDL_vulkan.h>
 
 #if defined(SDL_VIDEO_VULKAN) && defined(SDL_VIDEO_DRIVER_WAYLAND)
 

--- a/src/video/windows/SDL_windowsvulkan.h
+++ b/src/video/windows/SDL_windowsvulkan.h
@@ -29,8 +29,7 @@
 #ifndef SDL_windowsvulkan_h_
 #define SDL_windowsvulkan_h_
 
-#include "../SDL_vulkan_internal.h"
-#include "../SDL_sysvideo.h"
+#include <SDL3/SDL_vulkan.h>
 
 #if defined(SDL_VIDEO_VULKAN) && defined(SDL_VIDEO_DRIVER_WINDOWS)
 

--- a/src/video/x11/SDL_x11vulkan.h
+++ b/src/video/x11/SDL_x11vulkan.h
@@ -23,8 +23,7 @@
 #ifndef SDL_x11vulkan_h_
 #define SDL_x11vulkan_h_
 
-#include "../SDL_vulkan_internal.h"
-#include "../SDL_sysvideo.h"
+#include <SDL3/SDL_vulkan.h>
 
 #if defined(SDL_VIDEO_VULKAN) && defined(SDL_VIDEO_DRIVER_X11)
 


### PR DESCRIPTION
Fixes the following errors in x11. (The wayland and windows code touched w/o build-testing but passes the CI runs.)

CC: @Lephar (also CC: @Sackzement )

<details>

```
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11clipboard.c:27:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:101: error: redefinition of typedef ‘VkInstance’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:53: note: previous declaration of ‘VkInstance’ was here
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11clipboard.c:27:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:7549: error: redefinition of typedef ‘VkSurfaceKHR’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:54: note: previous declaration of ‘VkSurfaceKHR’ was here
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11clipboard.c.o] Error 1
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11events.c:31:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:101: error: redefinition of typedef ‘VkInstance’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:53: note: previous declaration of ‘VkInstance’ was here
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11events.c:31:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:7549: error: redefinition of typedef ‘VkSurfaceKHR’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:54: note: previous declaration of ‘VkSurfaceKHR’ was here
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11events.c.o] Error 1
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11framebuffer.c:25:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:101: error: redefinition of typedef ‘VkInstance’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:53: note: previous declaration of ‘VkInstance’ was here
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11framebuffer.c:25:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:7549: error: redefinition of typedef ‘VkSurfaceKHR’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:54: note: previous declaration of ‘VkSurfaceKHR’ was here
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11framebuffer.c.o] Error 1
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11keyboard.c:25:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:101: error: redefinition of typedef ‘VkInstance’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:53: note: previous declaration of ‘VkInstance’ was here
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11keyboard.c:25:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:7549: error: redefinition of typedef ‘VkSurfaceKHR’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:54: note: previous declaration of ‘VkSurfaceKHR’ was here
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11keyboard.c.o] Error 1
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11messagebox.c:26:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:101: error: redefinition of typedef ‘VkInstance’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:53: note: previous declaration of ‘VkInstance’ was here
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11messagebox.c:26:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:7549: error: redefinition of typedef ‘VkSurfaceKHR’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:54: note: previous declaration of ‘VkSurfaceKHR’ was here
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11messagebox.c.o] Error 1
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11modes.c:25:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:101: error: redefinition of typedef ‘VkInstance’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:53: note: previous declaration of ‘VkInstance’ was here
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11modes.c:25:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:7549: error: redefinition of typedef ‘VkSurfaceKHR’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:54: note: previous declaration of ‘VkSurfaceKHR’ was here
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11modes.c.o] Error 1
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11mouse.c:26:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:101: error: redefinition of typedef ‘VkInstance’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:53: note: previous declaration of ‘VkInstance’ was here
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11mouse.c:26:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:7549: error: redefinition of typedef ‘VkSurfaceKHR’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:54: note: previous declaration of ‘VkSurfaceKHR’ was here
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11mouse.c.o] Error 1
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11opengl.c:26:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:101: error: redefinition of typedef ‘VkInstance’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:53: note: previous declaration of ‘VkInstance’ was here
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11opengl.c:26:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:7549: error: redefinition of typedef ‘VkSurfaceKHR’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:54: note: previous declaration of ‘VkSurfaceKHR’ was here
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11opengl.c.o] Error 1
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11opengles.c:25:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:101: error: redefinition of typedef ‘VkInstance’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:53: note: previous declaration of ‘VkInstance’ was here
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11opengles.c:25:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:7549: error: redefinition of typedef ‘VkSurfaceKHR’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:54: note: previous declaration of ‘VkSurfaceKHR’ was here
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11opengles.c.o] Error 1
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11pen.h:28,
                 from /tmp/SDL3/src/video/x11/SDL_x11pen.c:27:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:101: error: redefinition of typedef ‘VkInstance’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:53: note: previous declaration of ‘VkInstance’ was here
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11pen.h:28,
                 from /tmp/SDL3/src/video/x11/SDL_x11pen.c:27:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:7549: error: redefinition of typedef ‘VkSurfaceKHR’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:54: note: previous declaration of ‘VkSurfaceKHR’ was here
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11pen.c.o] Error 1
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11shape.c:25:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:101: error: redefinition of typedef ‘VkInstance’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:53: note: previous declaration of ‘VkInstance’ was here
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11shape.c:25:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:7549: error: redefinition of typedef ‘VkSurfaceKHR’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:54: note: previous declaration of ‘VkSurfaceKHR’ was here
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11shape.c.o] Error 1
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11touch.c:25:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:101: error: redefinition of typedef ‘VkInstance’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:53: note: previous declaration of ‘VkInstance’ was here
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11touch.c:25:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:7549: error: redefinition of typedef ‘VkSurfaceKHR’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:54: note: previous declaration of ‘VkSurfaceKHR’ was here
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11touch.c.o] Error 1
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11pen.h:28,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.c:34:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:101: error: redefinition of typedef ‘VkInstance’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:53: note: previous declaration of ‘VkInstance’ was here
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11pen.h:28,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.c:34:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:7549: error: redefinition of typedef ‘VkSurfaceKHR’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:54: note: previous declaration of ‘VkSurfaceKHR’ was here
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11video.c.o] Error 1
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11window.c:32:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:101: error: redefinition of typedef ‘VkInstance’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:53: note: previous declaration of ‘VkInstance’ was here
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11window.c:32:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:7549: error: redefinition of typedef ‘VkSurfaceKHR’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:54: note: previous declaration of ‘VkSurfaceKHR’ was here
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11window.c.o] Error 1
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11xfixes.c:26:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:101: error: redefinition of typedef ‘VkInstance’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:53: note: previous declaration of ‘VkInstance’ was here
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11xfixes.c:26:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:7549: error: redefinition of typedef ‘VkSurfaceKHR’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:54: note: previous declaration of ‘VkSurfaceKHR’ was here
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11xfixes.c.o] Error 1
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11pen.h:28,
                 from /tmp/SDL3/src/video/x11/SDL_x11xinput2.c:25:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:101: error: redefinition of typedef ‘VkInstance’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:53: note: previous declaration of ‘VkInstance’ was here
In file included from /tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/video/x11/SDL_x11pen.h:28,
                 from /tmp/SDL3/src/video/x11/SDL_x11xinput2.c:25:
/tmp/SDL3/src/video/x11/.././khronos/vulkan/vulkan_core.h:7549: error: redefinition of typedef ‘VkSurfaceKHR’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:54: note: previous declaration of ‘VkSurfaceKHR’ was here
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11xinput2.c.o] Error 1
In file included from /tmp/SDL3/src/core/linux/../../video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/core/linux/../../video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/core/linux/../../video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/core/linux/../../video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/core/linux/SDL_ibus.c:33:
/tmp/SDL3/src/core/linux/../../video/x11/.././khronos/vulkan/vulkan_core.h:101: error: redefinition of typedef ‘VkInstance’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:53: note: previous declaration of ‘VkInstance’ was here
In file included from /tmp/SDL3/src/core/linux/../../video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/core/linux/../../video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/core/linux/../../video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/core/linux/../../video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/core/linux/SDL_ibus.c:33:
/tmp/SDL3/src/core/linux/../../video/x11/.././khronos/vulkan/vulkan_core.h:7549: error: redefinition of typedef ‘VkSurfaceKHR’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:54: note: previous declaration of ‘VkSurfaceKHR’ was here
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/core/linux/SDL_ibus.c.o] Error 1
In file included from /tmp/SDL3/src/core/linux/../../video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/core/linux/../../video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/core/linux/../../video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/core/linux/../../video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/core/linux/SDL_fcitx.c:30:
/tmp/SDL3/src/core/linux/../../video/x11/.././khronos/vulkan/vulkan_core.h:101: error: redefinition of typedef ‘VkInstance’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:53: note: previous declaration of ‘VkInstance’ was here
In file included from /tmp/SDL3/src/core/linux/../../video/x11/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/core/linux/../../video/x11/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/core/linux/../../video/x11/SDL_x11vulkan.h:26,
                 from /tmp/SDL3/src/core/linux/../../video/x11/SDL_x11video.h:40,
                 from /tmp/SDL3/src/core/linux/SDL_fcitx.c:30:
/tmp/SDL3/src/core/linux/../../video/x11/.././khronos/vulkan/vulkan_core.h:7549: error: redefinition of typedef ‘VkSurfaceKHR’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:54: note: previous declaration of ‘VkSurfaceKHR’ was here
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/core/linux/SDL_fcitx.c.o] Error 1
make[2]: Target `CMakeFiles/SDL3-shared.dir/build' not remade because of errors.
make[1]: *** [CMakeFiles/SDL3-shared.dir/all] Error 2
make[1]: Target `all' not remade because of errors.
make: *** [all] Error 2
```

</details>
