### PR TITLE
Annotate SDL function definitions making it easy to enable checking for return value handling.

### DIFF
--- a/build-scripts/check_stdlib_usage.py
+++ b/build-scripts/check_stdlib_usage.py
@@ -208,7 +208,7 @@ def find_symbols_in_file(file, regex):
 
                     # double check
                     # Remove one line comment /* ... */
-                    # eg: extern DECLSPEC SDL_hid_device * SDLCALL SDL_hid_open_path(const char *path, int bExclusive /* = false */);
+                    # eg: extern SDL_DECLSPEC_RETURN SDL_hid_device * SDLCALL SDL_hid_open_path(const char *path, int bExclusive /* = false */);
                     l = reg_comment_remove_content.sub('', l)
 
                     # Remove strings " ... "

--- a/build-scripts/wikiheaders.pl
+++ b/build-scripts/wikiheaders.pl
@@ -746,7 +746,7 @@ while (my $d = readdir(DH)) {
             #print("CATEGORY FOR '$dent' CHANGED TO " . (defined($current_wiki_category) ? "'$current_wiki_category'" : '(undef)') . "\n");
             push @contents, $_;
             next;
-        } elsif (/\A\s*extern\s+(SDL_DEPRECATED\s+|)(SDLMAIN_)?DECLSPEC/) {  # a function declaration without a doxygen comment?
+        } elsif (/\A\s*extern\s+(SDL_DEPRECATED\s+|)(SDLMAIN_|SDL_)?DECLSPEC_[A-Z]*/) {  # a function declaration without a doxygen comment?
             $symtype = 1;   # function declaration
             @templines = ();
             $decl = $_;
@@ -819,7 +819,7 @@ while (my $d = readdir(DH)) {
                 $lineno++ if defined $decl;
                 $decl = '' if not defined $decl;
                 chomp($decl);
-                if ($decl =~ /\A\s*extern\s+(SDL_DEPRECATED\s+|)(SDLMAIN_)?DECLSPEC/) {
+                if ($decl =~ /\A\s*extern\s+(SDL_DEPRECATED\s+|)(SDLMAIN_|SDL_)?DECLSPEC_[A-Z]*/) {
                     $symtype = 1;   # function declaration
                 } elsif ($decl =~ /\A\s*SDL_FORCE_INLINE/) {
                     $symtype = 1;   # (forced-inline) function declaration
@@ -974,7 +974,7 @@ while (my $d = readdir(DH)) {
         } elsif ($symtype == 2) {  # a macro
             if ($decl =~ /\A\s*\#\s*define\s+(.*?)(\(.*?\)|)\s+/) {
                 $sym = $1;
-                #$decl =~ s/\A\s*extern\s+DECLSPEC\s+(.*?)\s+SDLCALL/$1/;
+                #$decl =~ s/\A\s*extern\s+(SDLMAIN_|SDL_)?DECLSPEC_[A-Z]*\s+(.*?)\s+SDLCALL/$1/;
             } else {
                 #print "Found doxygen but no macro:\n$str\n\n";
                 foreach (@templines) {
@@ -1698,7 +1698,7 @@ if ($copy_direction == 1) {  # --copy-to-headers
 
         my $decl = $headerdecls{$sym};
         #$decl =~ s/\*\s+SDLCALL/ *SDLCALL/;  # Try to make "void * Function" become "void *Function"
-        #$decl =~ s/\A\s*extern\s+(SDL_DEPRECATED\s+|)DECLSPEC\s+(.*?)\s+(\*?)SDLCALL/$2$3/;
+        #$decl =~ s/\A\s*extern\s+(SDL_DEPRECATED\s+|)(SDLMAIN_|SDL_)?DECLSPEC_[A-Z]*\s+(.*?)\s+(\*?)SDLCALL/$2$3/;
 
         my $syntax = '';
         if ($wikitype eq 'mediawiki') {

--- a/include/SDL3/SDL_assert.h
+++ b/include/SDL3/SDL_assert.h
@@ -240,7 +240,7 @@ typedef struct SDL_AssertData
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_AssertState SDLCALL SDL_ReportAssertion(SDL_AssertData *data,
+extern SDL_DECLSPEC_RETURN SDL_AssertState SDLCALL SDL_ReportAssertion(SDL_AssertData *data,
                                                             const char *func,
                                                             const char *file, int line)
 #ifdef __clang__
@@ -464,7 +464,7 @@ typedef SDL_AssertState (SDLCALL *SDL_AssertionHandler)(
  *
  * \sa SDL_GetAssertionHandler
  */
-extern DECLSPEC void SDLCALL SDL_SetAssertionHandler(
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_SetAssertionHandler(
                                             SDL_AssertionHandler handler,
                                             void *userdata);
 
@@ -483,7 +483,7 @@ extern DECLSPEC void SDLCALL SDL_SetAssertionHandler(
  *
  * \sa SDL_GetAssertionHandler
  */
-extern DECLSPEC SDL_AssertionHandler SDLCALL SDL_GetDefaultAssertionHandler(void);
+extern SDL_DECLSPEC_RETURN SDL_AssertionHandler SDLCALL SDL_GetDefaultAssertionHandler(void);
 
 /**
  * Get the current assertion handler.
@@ -506,7 +506,7 @@ extern DECLSPEC SDL_AssertionHandler SDLCALL SDL_GetDefaultAssertionHandler(void
  *
  * \sa SDL_SetAssertionHandler
  */
-extern DECLSPEC SDL_AssertionHandler SDLCALL SDL_GetAssertionHandler(void **puserdata);
+extern SDL_DECLSPEC_RETURN SDL_AssertionHandler SDLCALL SDL_GetAssertionHandler(void **puserdata);
 
 /**
  * Get a list of all assertion failures.
@@ -534,7 +534,7 @@ extern DECLSPEC SDL_AssertionHandler SDLCALL SDL_GetAssertionHandler(void **puse
  *
  * \sa SDL_ResetAssertionReport
  */
-extern DECLSPEC const SDL_AssertData * SDLCALL SDL_GetAssertionReport(void);
+extern SDL_DECLSPEC_RETURN const SDL_AssertData * SDLCALL SDL_GetAssertionReport(void);
 
 /**
  * Clear the list of all assertion failures.
@@ -548,7 +548,7 @@ extern DECLSPEC const SDL_AssertData * SDLCALL SDL_GetAssertionReport(void);
  *
  * \sa SDL_GetAssertionReport
  */
-extern DECLSPEC void SDLCALL SDL_ResetAssertionReport(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_ResetAssertionReport(void);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_atomic.h
+++ b/include/SDL3/SDL_atomic.h
@@ -96,7 +96,7 @@ typedef int SDL_SpinLock;
  * \sa SDL_LockSpinlock
  * \sa SDL_UnlockSpinlock
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_TryLockSpinlock(SDL_SpinLock *lock);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_TryLockSpinlock(SDL_SpinLock *lock);
 
 /**
  * Lock a spin lock by setting it to a non-zero value.
@@ -111,7 +111,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_TryLockSpinlock(SDL_SpinLock *lock);
  * \sa SDL_TryLockSpinlock
  * \sa SDL_UnlockSpinlock
  */
-extern DECLSPEC void SDLCALL SDL_LockSpinlock(SDL_SpinLock *lock);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_LockSpinlock(SDL_SpinLock *lock);
 
 /**
  * Unlock a spin lock by setting it to 0.
@@ -128,7 +128,7 @@ extern DECLSPEC void SDLCALL SDL_LockSpinlock(SDL_SpinLock *lock);
  * \sa SDL_LockSpinlock
  * \sa SDL_TryLockSpinlock
  */
-extern DECLSPEC void SDLCALL SDL_UnlockSpinlock(SDL_SpinLock *lock);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_UnlockSpinlock(SDL_SpinLock *lock);
 
 
 #ifdef SDL_WIKI_DOCUMENTATION_SECTION
@@ -192,7 +192,7 @@ extern __inline void SDL_CompilerBarrier(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_MemoryBarrierReleaseFunction(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_MemoryBarrierReleaseFunction(void);
 
 /**
  * Insert a memory acquire barrier.
@@ -207,7 +207,7 @@ extern DECLSPEC void SDLCALL SDL_MemoryBarrierReleaseFunction(void);
  *
  * \sa SDL_MemoryBarrierReleaseFunction
  */
-extern DECLSPEC void SDLCALL SDL_MemoryBarrierAcquireFunction(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_MemoryBarrierAcquireFunction(void);
 
 /* !!! FIXME: this should have documentation! */
 #if defined(__GNUC__) && (defined(__powerpc__) || defined(__ppc__))
@@ -342,7 +342,7 @@ typedef struct SDL_AtomicInt { int value; } SDL_AtomicInt;
  *
  * \sa SDL_AtomicCompareAndSwapPointer
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_AtomicCompareAndSwap(SDL_AtomicInt *a, int oldval, int newval);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_AtomicCompareAndSwap(SDL_AtomicInt *a, int oldval, int newval);
 
 /**
  * Set an atomic variable to a value.
@@ -360,7 +360,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_AtomicCompareAndSwap(SDL_AtomicInt *a, int 
  *
  * \sa SDL_AtomicGet
  */
-extern DECLSPEC int SDLCALL SDL_AtomicSet(SDL_AtomicInt *a, int v);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_AtomicSet(SDL_AtomicInt *a, int v);
 
 /**
  * Get the value of an atomic variable.
@@ -375,7 +375,7 @@ extern DECLSPEC int SDLCALL SDL_AtomicSet(SDL_AtomicInt *a, int v);
  *
  * \sa SDL_AtomicSet
  */
-extern DECLSPEC int SDLCALL SDL_AtomicGet(SDL_AtomicInt *a);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_AtomicGet(SDL_AtomicInt *a);
 
 /**
  * Add to an atomic variable.
@@ -394,7 +394,7 @@ extern DECLSPEC int SDLCALL SDL_AtomicGet(SDL_AtomicInt *a);
  * \sa SDL_AtomicDecRef
  * \sa SDL_AtomicIncRef
  */
-extern DECLSPEC int SDLCALL SDL_AtomicAdd(SDL_AtomicInt *a, int v);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_AtomicAdd(SDL_AtomicInt *a, int v);
 
 #ifndef SDL_AtomicIncRef
 
@@ -448,7 +448,7 @@ extern DECLSPEC int SDLCALL SDL_AtomicAdd(SDL_AtomicInt *a, int v);
  * \sa SDL_AtomicGetPtr
  * \sa SDL_AtomicSetPtr
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_AtomicCompareAndSwapPointer(void **a, void *oldval, void *newval);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_AtomicCompareAndSwapPointer(void **a, void *oldval, void *newval);
 
 /**
  * Set a pointer to a value atomically.
@@ -465,7 +465,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_AtomicCompareAndSwapPointer(void **a, void 
  * \sa SDL_AtomicCompareAndSwapPointer
  * \sa SDL_AtomicGetPtr
  */
-extern DECLSPEC void* SDLCALL SDL_AtomicSetPtr(void **a, void* v);
+extern SDL_DECLSPEC_RETURN void* SDLCALL SDL_AtomicSetPtr(void **a, void* v);
 
 /**
  * Get the value of a pointer atomically.
@@ -481,7 +481,7 @@ extern DECLSPEC void* SDLCALL SDL_AtomicSetPtr(void **a, void* v);
  * \sa SDL_AtomicCompareAndSwapPointer
  * \sa SDL_AtomicSetPtr
  */
-extern DECLSPEC void* SDLCALL SDL_AtomicGetPtr(void **a);
+extern SDL_DECLSPEC_RETURN void* SDLCALL SDL_AtomicGetPtr(void **a);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_audio.h
+++ b/include/SDL3/SDL_audio.h
@@ -364,7 +364,7 @@ typedef struct SDL_AudioStream SDL_AudioStream;
  *
  * \sa SDL_GetAudioDriver
  */
-extern DECLSPEC int SDLCALL SDL_GetNumAudioDrivers(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetNumAudioDrivers(void);
 
 /**
  * Use this function to get the name of a built in audio driver.
@@ -388,7 +388,7 @@ extern DECLSPEC int SDLCALL SDL_GetNumAudioDrivers(void);
  *
  * \sa SDL_GetNumAudioDrivers
  */
-extern DECLSPEC const char *SDLCALL SDL_GetAudioDriver(int index);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetAudioDriver(int index);
 /* @} */
 
 /**
@@ -407,7 +407,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetAudioDriver(int index);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC const char *SDLCALL SDL_GetCurrentAudioDriver(void);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetCurrentAudioDriver(void);
 
 /**
  * Get a list of currently-connected audio output devices.
@@ -432,7 +432,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetCurrentAudioDriver(void);
  * \sa SDL_OpenAudioDevice
  * \sa SDL_GetAudioCaptureDevices
  */
-extern DECLSPEC SDL_AudioDeviceID *SDLCALL SDL_GetAudioOutputDevices(int *count);
+extern SDL_DECLSPEC_RETURN SDL_AudioDeviceID *SDLCALL SDL_GetAudioOutputDevices(int *count);
 
 /**
  * Get a list of currently-connected audio capture devices.
@@ -457,7 +457,7 @@ extern DECLSPEC SDL_AudioDeviceID *SDLCALL SDL_GetAudioOutputDevices(int *count)
  * \sa SDL_OpenAudioDevice
  * \sa SDL_GetAudioOutputDevices
  */
-extern DECLSPEC SDL_AudioDeviceID *SDLCALL SDL_GetAudioCaptureDevices(int *count);
+extern SDL_DECLSPEC_RETURN SDL_AudioDeviceID *SDLCALL SDL_GetAudioCaptureDevices(int *count);
 
 /**
  * Get the human-readable name of a specific audio device.
@@ -476,7 +476,7 @@ extern DECLSPEC SDL_AudioDeviceID *SDLCALL SDL_GetAudioCaptureDevices(int *count
  * \sa SDL_GetAudioCaptureDevices
  * \sa SDL_GetDefaultAudioInfo
  */
-extern DECLSPEC char *SDLCALL SDL_GetAudioDeviceName(SDL_AudioDeviceID devid);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_GetAudioDeviceName(SDL_AudioDeviceID devid);
 
 /**
  * Get the current audio format of a specific audio device.
@@ -511,7 +511,7 @@ extern DECLSPEC char *SDLCALL SDL_GetAudioDeviceName(SDL_AudioDeviceID devid);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetAudioDeviceFormat(SDL_AudioDeviceID devid, SDL_AudioSpec *spec, int *sample_frames);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetAudioDeviceFormat(SDL_AudioDeviceID devid, SDL_AudioSpec *spec, int *sample_frames);
 
 
 /**
@@ -587,7 +587,7 @@ extern DECLSPEC int SDLCALL SDL_GetAudioDeviceFormat(SDL_AudioDeviceID devid, SD
  * \sa SDL_CloseAudioDevice
  * \sa SDL_GetAudioDeviceFormat
  */
-extern DECLSPEC SDL_AudioDeviceID SDLCALL SDL_OpenAudioDevice(SDL_AudioDeviceID devid, const SDL_AudioSpec *spec);
+extern SDL_DECLSPEC_RETURN SDL_AudioDeviceID SDLCALL SDL_OpenAudioDevice(SDL_AudioDeviceID devid, const SDL_AudioSpec *spec);
 
 /**
  * Use this function to pause audio playback on a specified device.
@@ -618,7 +618,7 @@ extern DECLSPEC SDL_AudioDeviceID SDLCALL SDL_OpenAudioDevice(SDL_AudioDeviceID 
  * \sa SDL_ResumeAudioDevice
  * \sa SDL_AudioDevicePaused
  */
-extern DECLSPEC int SDLCALL SDL_PauseAudioDevice(SDL_AudioDeviceID dev);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_PauseAudioDevice(SDL_AudioDeviceID dev);
 
 /**
  * Use this function to unpause audio playback on a specified device.
@@ -646,7 +646,7 @@ extern DECLSPEC int SDLCALL SDL_PauseAudioDevice(SDL_AudioDeviceID dev);
  * \sa SDL_AudioDevicePaused
  * \sa SDL_PauseAudioDevice
  */
-extern DECLSPEC int SDLCALL SDL_ResumeAudioDevice(SDL_AudioDeviceID dev);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ResumeAudioDevice(SDL_AudioDeviceID dev);
 
 /**
  * Use this function to query if an audio device is paused.
@@ -668,7 +668,7 @@ extern DECLSPEC int SDLCALL SDL_ResumeAudioDevice(SDL_AudioDeviceID dev);
  * \sa SDL_PauseAudioDevice
  * \sa SDL_ResumeAudioDevice
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_AudioDevicePaused(SDL_AudioDeviceID dev);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_AudioDevicePaused(SDL_AudioDeviceID dev);
 
 /**
  * Close a previously-opened audio device.
@@ -689,7 +689,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_AudioDevicePaused(SDL_AudioDeviceID dev);
  *
  * \sa SDL_OpenAudioDevice
  */
-extern DECLSPEC void SDLCALL SDL_CloseAudioDevice(SDL_AudioDeviceID devid);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_CloseAudioDevice(SDL_AudioDeviceID devid);
 
 /**
  * Bind a list of audio streams to an audio device.
@@ -726,7 +726,7 @@ extern DECLSPEC void SDLCALL SDL_CloseAudioDevice(SDL_AudioDeviceID devid);
  * \sa SDL_UnbindAudioStream
  * \sa SDL_GetAudioStreamDevice
  */
-extern DECLSPEC int SDLCALL SDL_BindAudioStreams(SDL_AudioDeviceID devid, SDL_AudioStream **streams, int num_streams);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_BindAudioStreams(SDL_AudioDeviceID devid, SDL_AudioStream **streams, int num_streams);
 
 /**
  * Bind a single audio stream to an audio device.
@@ -747,7 +747,7 @@ extern DECLSPEC int SDLCALL SDL_BindAudioStreams(SDL_AudioDeviceID devid, SDL_Au
  * \sa SDL_UnbindAudioStream
  * \sa SDL_GetAudioStreamDevice
  */
-extern DECLSPEC int SDLCALL SDL_BindAudioStream(SDL_AudioDeviceID devid, SDL_AudioStream *stream);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_BindAudioStream(SDL_AudioDeviceID devid, SDL_AudioStream *stream);
 
 /**
  * Unbind a list of audio streams from their audio devices.
@@ -767,7 +767,7 @@ extern DECLSPEC int SDLCALL SDL_BindAudioStream(SDL_AudioDeviceID devid, SDL_Aud
  *
  * \sa SDL_BindAudioStreams
  */
-extern DECLSPEC void SDLCALL SDL_UnbindAudioStreams(SDL_AudioStream **streams, int num_streams);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_UnbindAudioStreams(SDL_AudioStream **streams, int num_streams);
 
 /**
  * Unbind a single audio stream from its audio device.
@@ -783,7 +783,7 @@ extern DECLSPEC void SDLCALL SDL_UnbindAudioStreams(SDL_AudioStream **streams, i
  *
  * \sa SDL_BindAudioStream
  */
-extern DECLSPEC void SDLCALL SDL_UnbindAudioStream(SDL_AudioStream *stream);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_UnbindAudioStream(SDL_AudioStream *stream);
 
 /**
  * Query an audio stream for its currently-bound device.
@@ -803,7 +803,7 @@ extern DECLSPEC void SDLCALL SDL_UnbindAudioStream(SDL_AudioStream *stream);
  * \sa SDL_BindAudioStream
  * \sa SDL_BindAudioStreams
  */
-extern DECLSPEC SDL_AudioDeviceID SDLCALL SDL_GetAudioStreamDevice(SDL_AudioStream *stream);
+extern SDL_DECLSPEC_RETURN SDL_AudioDeviceID SDLCALL SDL_GetAudioStreamDevice(SDL_AudioStream *stream);
 
 /**
  * Create a new audio stream.
@@ -824,7 +824,7 @@ extern DECLSPEC SDL_AudioDeviceID SDLCALL SDL_GetAudioStreamDevice(SDL_AudioStre
  * \sa SDL_ChangeAudioStreamOutput
  * \sa SDL_DestroyAudioStream
  */
-extern DECLSPEC SDL_AudioStream *SDLCALL SDL_CreateAudioStream(const SDL_AudioSpec *src_spec, const SDL_AudioSpec *dst_spec);
+extern SDL_DECLSPEC_RETURN SDL_AudioStream *SDLCALL SDL_CreateAudioStream(const SDL_AudioSpec *src_spec, const SDL_AudioSpec *dst_spec);
 
 /**
  * Get the properties associated with an audio stream.
@@ -838,7 +838,7 @@ extern DECLSPEC SDL_AudioStream *SDLCALL SDL_CreateAudioStream(const SDL_AudioSp
  * \sa SDL_GetProperty
  * \sa SDL_SetProperty
  */
-extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetAudioStreamProperties(SDL_AudioStream *stream);
+extern SDL_DECLSPEC_RETURN SDL_PropertiesID SDLCALL SDL_GetAudioStreamProperties(SDL_AudioStream *stream);
 
 /**
  * Query the current format of an audio stream.
@@ -853,7 +853,7 @@ extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetAudioStreamProperties(SDL_AudioS
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetAudioStreamFormat(SDL_AudioStream *stream,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetAudioStreamFormat(SDL_AudioStream *stream,
                                                      SDL_AudioSpec *src_spec,
                                                      SDL_AudioSpec *dst_spec);
 
@@ -885,7 +885,7 @@ extern DECLSPEC int SDLCALL SDL_GetAudioStreamFormat(SDL_AudioStream *stream,
  * \sa SDL_GetAudioStreamFormat
  * \sa SDL_SetAudioStreamFrequencyRatio
  */
-extern DECLSPEC int SDLCALL SDL_SetAudioStreamFormat(SDL_AudioStream *stream,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetAudioStreamFormat(SDL_AudioStream *stream,
                                                      const SDL_AudioSpec *src_spec,
                                                      const SDL_AudioSpec *dst_spec);
 
@@ -902,7 +902,7 @@ extern DECLSPEC int SDLCALL SDL_SetAudioStreamFormat(SDL_AudioStream *stream,
  *
  * \sa SDL_SetAudioStreamFrequencyRatio
  */
-extern DECLSPEC float SDLCALL SDL_GetAudioStreamFrequencyRatio(SDL_AudioStream *stream);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_GetAudioStreamFrequencyRatio(SDL_AudioStream *stream);
 
 /**
  * Change the frequency ratio of an audio stream.
@@ -929,7 +929,7 @@ extern DECLSPEC float SDLCALL SDL_GetAudioStreamFrequencyRatio(SDL_AudioStream *
  * \sa SDL_GetAudioStreamFrequencyRatio
  * \sa SDL_SetAudioStreamFormat
  */
-extern DECLSPEC int SDLCALL SDL_SetAudioStreamFrequencyRatio(SDL_AudioStream *stream, float ratio);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetAudioStreamFrequencyRatio(SDL_AudioStream *stream, float ratio);
 
 /**
  * Add data to the stream.
@@ -959,7 +959,7 @@ extern DECLSPEC int SDLCALL SDL_SetAudioStreamFrequencyRatio(SDL_AudioStream *st
  * \sa SDL_GetAudioStreamData
  * \sa SDL_GetAudioStreamQueued
  */
-extern DECLSPEC int SDLCALL SDL_PutAudioStreamData(SDL_AudioStream *stream, const void *buf, int len);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_PutAudioStreamData(SDL_AudioStream *stream, const void *buf, int len);
 
 /**
  * Get converted/resampled data from the stream.
@@ -988,7 +988,7 @@ extern DECLSPEC int SDLCALL SDL_PutAudioStreamData(SDL_AudioStream *stream, cons
  * \sa SDL_GetAudioStreamAvailable
  * \sa SDL_PutAudioStreamData
  */
-extern DECLSPEC int SDLCALL SDL_GetAudioStreamData(SDL_AudioStream *stream, void *buf, int len);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetAudioStreamData(SDL_AudioStream *stream, void *buf, int len);
 
 /**
  * Get the number of converted/resampled bytes available.
@@ -1013,7 +1013,7 @@ extern DECLSPEC int SDLCALL SDL_GetAudioStreamData(SDL_AudioStream *stream, void
  * \sa SDL_GetAudioStreamData
  * \sa SDL_PutAudioStreamData
  */
-extern DECLSPEC int SDLCALL SDL_GetAudioStreamAvailable(SDL_AudioStream *stream);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetAudioStreamAvailable(SDL_AudioStream *stream);
 
 
 /**
@@ -1045,7 +1045,7 @@ extern DECLSPEC int SDLCALL SDL_GetAudioStreamAvailable(SDL_AudioStream *stream)
  * \sa SDL_PutAudioStreamData
  * \sa SDL_ClearAudioStream
  */
-extern DECLSPEC int SDLCALL SDL_GetAudioStreamQueued(SDL_AudioStream *stream);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetAudioStreamQueued(SDL_AudioStream *stream);
 
 
 /**
@@ -1066,7 +1066,7 @@ extern DECLSPEC int SDLCALL SDL_GetAudioStreamQueued(SDL_AudioStream *stream);
  *
  * \sa SDL_PutAudioStreamData
  */
-extern DECLSPEC int SDLCALL SDL_FlushAudioStream(SDL_AudioStream *stream);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_FlushAudioStream(SDL_AudioStream *stream);
 
 /**
  * Clear any pending data in the stream.
@@ -1087,7 +1087,7 @@ extern DECLSPEC int SDLCALL SDL_FlushAudioStream(SDL_AudioStream *stream);
  * \sa SDL_GetAudioStreamQueued
  * \sa SDL_PutAudioStreamData
  */
-extern DECLSPEC int SDLCALL SDL_ClearAudioStream(SDL_AudioStream *stream);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ClearAudioStream(SDL_AudioStream *stream);
 
 /**
  * Lock an audio stream for serialized access.
@@ -1115,7 +1115,7 @@ extern DECLSPEC int SDLCALL SDL_ClearAudioStream(SDL_AudioStream *stream);
  *
  * \sa SDL_UnlockAudioStream
  */
-extern DECLSPEC int SDLCALL SDL_LockAudioStream(SDL_AudioStream *stream);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_LockAudioStream(SDL_AudioStream *stream);
 
 
 /**
@@ -1134,7 +1134,7 @@ extern DECLSPEC int SDLCALL SDL_LockAudioStream(SDL_AudioStream *stream);
  *
  * \sa SDL_LockAudioStream
  */
-extern DECLSPEC int SDLCALL SDL_UnlockAudioStream(SDL_AudioStream *stream);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_UnlockAudioStream(SDL_AudioStream *stream);
 
 /**
  * A callback that fires when data passes through an SDL_AudioStream.
@@ -1221,7 +1221,7 @@ typedef void (SDLCALL *SDL_AudioStreamCallback)(void *userdata, SDL_AudioStream 
  *
  * \sa SDL_SetAudioStreamPutCallback
  */
-extern DECLSPEC int SDLCALL SDL_SetAudioStreamGetCallback(SDL_AudioStream *stream, SDL_AudioStreamCallback callback, void *userdata);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetAudioStreamGetCallback(SDL_AudioStream *stream, SDL_AudioStreamCallback callback, void *userdata);
 
 /**
  * Set a callback that runs when data is added to an audio stream.
@@ -1269,7 +1269,7 @@ extern DECLSPEC int SDLCALL SDL_SetAudioStreamGetCallback(SDL_AudioStream *strea
  *
  * \sa SDL_SetAudioStreamGetCallback
  */
-extern DECLSPEC int SDLCALL SDL_SetAudioStreamPutCallback(SDL_AudioStream *stream, SDL_AudioStreamCallback callback, void *userdata);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetAudioStreamPutCallback(SDL_AudioStream *stream, SDL_AudioStreamCallback callback, void *userdata);
 
 
 /**
@@ -1291,7 +1291,7 @@ extern DECLSPEC int SDLCALL SDL_SetAudioStreamPutCallback(SDL_AudioStream *strea
  *
  * \sa SDL_CreateAudioStream
  */
-extern DECLSPEC void SDLCALL SDL_DestroyAudioStream(SDL_AudioStream *stream);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_DestroyAudioStream(SDL_AudioStream *stream);
 
 
 /**
@@ -1348,7 +1348,7 @@ extern DECLSPEC void SDLCALL SDL_DestroyAudioStream(SDL_AudioStream *stream);
  * \sa SDL_GetAudioStreamDevice
  * \sa SDL_ResumeAudioDevice
  */
-extern DECLSPEC SDL_AudioStream *SDLCALL SDL_OpenAudioDeviceStream(SDL_AudioDeviceID devid, const SDL_AudioSpec *spec, SDL_AudioStreamCallback callback, void *userdata);
+extern SDL_DECLSPEC_RETURN SDL_AudioStream *SDLCALL SDL_OpenAudioDeviceStream(SDL_AudioDeviceID devid, const SDL_AudioSpec *spec, SDL_AudioStreamCallback callback, void *userdata);
 
 /**
  * A callback that fires when data is about to be fed to an audio device.
@@ -1435,7 +1435,7 @@ typedef void (SDLCALL *SDL_AudioPostmixCallback)(void *userdata, const SDL_Audio
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SetAudioPostmixCallback(SDL_AudioDeviceID devid, SDL_AudioPostmixCallback callback, void *userdata);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetAudioPostmixCallback(SDL_AudioDeviceID devid, SDL_AudioPostmixCallback callback, void *userdata);
 
 
 /**
@@ -1516,7 +1516,7 @@ extern DECLSPEC int SDLCALL SDL_SetAudioPostmixCallback(SDL_AudioDeviceID devid,
  * \sa SDL_free
  * \sa SDL_LoadWAV
  */
-extern DECLSPEC int SDLCALL SDL_LoadWAV_IO(SDL_IOStream * src, SDL_bool closeio,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_LoadWAV_IO(SDL_IOStream * src, SDL_bool closeio,
                                            SDL_AudioSpec * spec, Uint8 ** audio_buf,
                                            Uint32 * audio_len);
 
@@ -1554,7 +1554,7 @@ extern DECLSPEC int SDLCALL SDL_LoadWAV_IO(SDL_IOStream * src, SDL_bool closeio,
  * \sa SDL_free
  * \sa SDL_LoadWAV_IO
  */
-extern DECLSPEC int SDLCALL SDL_LoadWAV(const char *path, SDL_AudioSpec * spec,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_LoadWAV(const char *path, SDL_AudioSpec * spec,
                                         Uint8 ** audio_buf, Uint32 * audio_len);
 
 /**
@@ -1598,7 +1598,7 @@ extern DECLSPEC int SDLCALL SDL_LoadWAV(const char *path, SDL_AudioSpec * spec,
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_MixAudioFormat(Uint8 * dst,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_MixAudioFormat(Uint8 * dst,
                                                const Uint8 * src,
                                                SDL_AudioFormat format,
                                                Uint32 len, int volume);
@@ -1631,7 +1631,7 @@ extern DECLSPEC int SDLCALL SDL_MixAudioFormat(Uint8 * dst,
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_ConvertAudioSamples(const SDL_AudioSpec *src_spec,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ConvertAudioSamples(const SDL_AudioSpec *src_spec,
                                                     const Uint8 *src_data,
                                                     int src_len,
                                                     const SDL_AudioSpec *dst_spec,
@@ -1653,7 +1653,7 @@ extern DECLSPEC int SDLCALL SDL_ConvertAudioSamples(const SDL_AudioSpec *src_spe
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetSilenceValueForFormat(SDL_AudioFormat format);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetSilenceValueForFormat(SDL_AudioFormat format);
 
 
 /* Ends C function definitions when using C++ */

--- a/include/SDL3/SDL_audio.h
+++ b/include/SDL3/SDL_audio.h
@@ -432,7 +432,7 @@ extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetCurrentAudioDriver(void);
  * \sa SDL_OpenAudioDevice
  * \sa SDL_GetAudioCaptureDevices
  */
-extern SDL_DECLSPEC_RETURN SDL_AudioDeviceID *SDLCALL SDL_GetAudioOutputDevices(int *count);
+extern SDL_DECLSPEC_NODISCARD SDL_AudioDeviceID *SDLCALL SDL_GetAudioOutputDevices(int *count);
 
 /**
  * Get a list of currently-connected audio capture devices.
@@ -457,7 +457,7 @@ extern SDL_DECLSPEC_RETURN SDL_AudioDeviceID *SDLCALL SDL_GetAudioOutputDevices(
  * \sa SDL_OpenAudioDevice
  * \sa SDL_GetAudioOutputDevices
  */
-extern SDL_DECLSPEC_RETURN SDL_AudioDeviceID *SDLCALL SDL_GetAudioCaptureDevices(int *count);
+extern SDL_DECLSPEC_NODISCARD SDL_AudioDeviceID *SDLCALL SDL_GetAudioCaptureDevices(int *count);
 
 /**
  * Get the human-readable name of a specific audio device.
@@ -476,7 +476,7 @@ extern SDL_DECLSPEC_RETURN SDL_AudioDeviceID *SDLCALL SDL_GetAudioCaptureDevices
  * \sa SDL_GetAudioCaptureDevices
  * \sa SDL_GetDefaultAudioInfo
  */
-extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_GetAudioDeviceName(SDL_AudioDeviceID devid);
+extern SDL_DECLSPEC_NODISCARD char *SDLCALL SDL_GetAudioDeviceName(SDL_AudioDeviceID devid);
 
 /**
  * Get the current audio format of a specific audio device.
@@ -587,7 +587,7 @@ extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetAudioDeviceFormat(SDL_AudioDeviceI
  * \sa SDL_CloseAudioDevice
  * \sa SDL_GetAudioDeviceFormat
  */
-extern SDL_DECLSPEC_RETURN SDL_AudioDeviceID SDLCALL SDL_OpenAudioDevice(SDL_AudioDeviceID devid, const SDL_AudioSpec *spec);
+extern SDL_DECLSPEC_NODISCARD SDL_AudioDeviceID SDLCALL SDL_OpenAudioDevice(SDL_AudioDeviceID devid, const SDL_AudioSpec *spec);
 
 /**
  * Use this function to pause audio playback on a specified device.
@@ -824,7 +824,7 @@ extern SDL_DECLSPEC_RETURN SDL_AudioDeviceID SDLCALL SDL_GetAudioStreamDevice(SD
  * \sa SDL_ChangeAudioStreamOutput
  * \sa SDL_DestroyAudioStream
  */
-extern SDL_DECLSPEC_RETURN SDL_AudioStream *SDLCALL SDL_CreateAudioStream(const SDL_AudioSpec *src_spec, const SDL_AudioSpec *dst_spec);
+extern SDL_DECLSPEC_NODISCARD SDL_AudioStream *SDLCALL SDL_CreateAudioStream(const SDL_AudioSpec *src_spec, const SDL_AudioSpec *dst_spec);
 
 /**
  * Get the properties associated with an audio stream.
@@ -1348,7 +1348,7 @@ extern SDL_DECLSPEC_VOID void SDLCALL SDL_DestroyAudioStream(SDL_AudioStream *st
  * \sa SDL_GetAudioStreamDevice
  * \sa SDL_ResumeAudioDevice
  */
-extern SDL_DECLSPEC_RETURN SDL_AudioStream *SDLCALL SDL_OpenAudioDeviceStream(SDL_AudioDeviceID devid, const SDL_AudioSpec *spec, SDL_AudioStreamCallback callback, void *userdata);
+extern SDL_DECLSPEC_NODISCARD SDL_AudioStream *SDLCALL SDL_OpenAudioDeviceStream(SDL_AudioDeviceID devid, const SDL_AudioSpec *spec, SDL_AudioStreamCallback callback, void *userdata);
 
 /**
  * A callback that fires when data is about to be fed to an audio device.

--- a/include/SDL3/SDL_begin_code.h
+++ b/include/SDL3/SDL_begin_code.h
@@ -51,21 +51,41 @@
 #  endif
 #endif
 
+#ifndef SDL_NODISCARD
+#if (defined(__cplusplus) && __cplusplus >= 201703L) || \
+    (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L)
+#define SDL_NODISCARD [[nodiscard]]
+#elif ( (defined(__GNUC__) && (__GNUC__ >= 4)) || defined(__clang__) )
+#define SDL_NODISCARD __attribute__((warn_unused_result))
+#elif defined(_MSC_VER) && (_MSC_VER >= 1700)
+#define SDL_NODISCARD _Check_return_
+#else
+#define SDL_NODISCARD
+#endif /* C++17 or C23 */
+#endif /* SDL_NODISCARD not defined */
+
 /* Some compilers use a special export keyword */
-#ifndef DECLSPEC
+#ifndef SDL_DECLSPEC
 # if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINRT) || defined(SDL_PLATFORM_CYGWIN) || defined(SDL_PLATFORM_GDK)
 #  ifdef DLL_EXPORT
-#   define DECLSPEC __declspec(dllexport)
+#   define SDL_DECLSPEC __declspec(dllexport)
 #  else
-#   define DECLSPEC
+#   define SDL_DECLSPEC
 #  endif
 # else
 #  if defined(__GNUC__) && __GNUC__ >= 4
-#   define DECLSPEC __attribute__ ((visibility("default")))
+#   define SDL_DECLSPEC __attribute__ ((visibility("default")))
 #  else
-#   define DECLSPEC
+#   define SDL_DECLSPEC
 #  endif
 # endif
+#endif
+#define SDL_DECLSPEC_VOID       SDL_DECLSPEC
+#define SDL_DECLSPEC_NODISCARD  SDL_NODISCARD SDL_DECLSPEC
+#ifdef SDL_NODISCARD_PEDANTIC
+#define SDL_DECLSPEC_RETURN     SDL_DECLSPEC_NODISCARD
+#else
+#define SDL_DECLSPEC_RETURN     SDL_DECLSPEC
 #endif
 
 /* By default SDL uses the C calling convention */
@@ -170,19 +190,6 @@
 #undef SDL_HAS_FALLTHROUGH
 #endif /* C++17 or C2x */
 #endif /* SDL_FALLTHROUGH not defined */
-
-#ifndef SDL_NODISCARD
-#if (defined(__cplusplus) && __cplusplus >= 201703L) || \
-    (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L)
-#define SDL_NODISCARD [[nodiscard]]
-#elif ( (defined(__GNUC__) && (__GNUC__ >= 4)) || defined(__clang__) )
-#define SDL_NODISCARD __attribute__((warn_unused_result))
-#elif defined(_MSC_VER) && (_MSC_VER >= 1700)
-#define SDL_NODISCARD _Check_return_
-#else
-#define SDL_NODISCARD
-#endif /* C++17 or C23 */
-#endif /* SDL_NODISCARD not defined */
 
 #ifndef SDL_MALLOC
 #if defined(__GNUC__) && (__GNUC__ >= 3)

--- a/include/SDL3/SDL_blendmode.h
+++ b/include/SDL3/SDL_blendmode.h
@@ -190,7 +190,7 @@ typedef enum SDL_BlendFactor
  * \sa SDL_SetTextureBlendMode
  * \sa SDL_GetTextureBlendMode
  */
-extern DECLSPEC SDL_BlendMode SDLCALL SDL_ComposeCustomBlendMode(SDL_BlendFactor srcColorFactor,
+extern SDL_DECLSPEC_RETURN SDL_BlendMode SDLCALL SDL_ComposeCustomBlendMode(SDL_BlendFactor srcColorFactor,
                                                                  SDL_BlendFactor dstColorFactor,
                                                                  SDL_BlendOperation colorOperation,
                                                                  SDL_BlendFactor srcAlphaFactor,

--- a/include/SDL3/SDL_camera.h
+++ b/include/SDL3/SDL_camera.h
@@ -121,7 +121,7 @@ typedef enum SDL_CameraPosition
  *
  * \sa SDL_GetCameraDriver
  */
-extern DECLSPEC int SDLCALL SDL_GetNumCameraDrivers(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetNumCameraDrivers(void);
 
 /**
  * Use this function to get the name of a built in camera driver.
@@ -145,7 +145,7 @@ extern DECLSPEC int SDLCALL SDL_GetNumCameraDrivers(void);
  *
  * \sa SDL_GetNumCameraDrivers
  */
-extern DECLSPEC const char *SDLCALL SDL_GetCameraDriver(int index);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetCameraDriver(int index);
 
 /**
  * Get the name of the current camera driver.
@@ -163,7 +163,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetCameraDriver(int index);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC const char *SDLCALL SDL_GetCurrentCameraDriver(void);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetCurrentCameraDriver(void);
 
 /**
  * Get a list of currently connected camera devices.
@@ -180,7 +180,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetCurrentCameraDriver(void);
  *
  * \sa SDL_OpenCamera
  */
-extern DECLSPEC SDL_CameraDeviceID *SDLCALL SDL_GetCameraDevices(int *count);
+extern SDL_DECLSPEC_RETURN SDL_CameraDeviceID *SDLCALL SDL_GetCameraDevices(int *count);
 
 /**
  * Get the list of native formats/sizes a camera supports.
@@ -223,7 +223,7 @@ extern DECLSPEC SDL_CameraDeviceID *SDLCALL SDL_GetCameraDevices(int *count);
  * \sa SDL_GetCameraDevices
  * \sa SDL_OpenCameraDevice
  */
-extern DECLSPEC SDL_CameraSpec *SDLCALL SDL_GetCameraDeviceSupportedFormats(SDL_CameraDeviceID devid, int *count);
+extern SDL_DECLSPEC_RETURN SDL_CameraSpec *SDLCALL SDL_GetCameraDeviceSupportedFormats(SDL_CameraDeviceID devid, int *count);
 
 /**
  * Get human-readable device name for a camera.
@@ -241,7 +241,7 @@ extern DECLSPEC SDL_CameraSpec *SDLCALL SDL_GetCameraDeviceSupportedFormats(SDL_
  *
  * \sa SDL_GetCameraDevices
  */
-extern DECLSPEC char * SDLCALL SDL_GetCameraDeviceName(SDL_CameraDeviceID instance_id);
+extern SDL_DECLSPEC_RETURN char * SDLCALL SDL_GetCameraDeviceName(SDL_CameraDeviceID instance_id);
 
 /**
  * Get the position of the camera in relation to the system.
@@ -260,7 +260,7 @@ extern DECLSPEC char * SDLCALL SDL_GetCameraDeviceName(SDL_CameraDeviceID instan
  *
  * \sa SDL_GetCameraDevices
  */
-extern DECLSPEC SDL_CameraPosition SDLCALL SDL_GetCameraDevicePosition(SDL_CameraDeviceID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_CameraPosition SDLCALL SDL_GetCameraDevicePosition(SDL_CameraDeviceID instance_id);
 
 /**
  * Open a video capture device (a "camera").
@@ -306,7 +306,7 @@ extern DECLSPEC SDL_CameraPosition SDLCALL SDL_GetCameraDevicePosition(SDL_Camer
  * \sa SDL_GetCameraDevices
  * \sa SDL_GetCameraFormat
  */
-extern DECLSPEC SDL_Camera *SDLCALL SDL_OpenCameraDevice(SDL_CameraDeviceID instance_id, const SDL_CameraSpec *spec);
+extern SDL_DECLSPEC_RETURN SDL_Camera *SDLCALL SDL_OpenCameraDevice(SDL_CameraDeviceID instance_id, const SDL_CameraSpec *spec);
 
 /**
  * Query if camera access has been approved by the user.
@@ -339,7 +339,7 @@ extern DECLSPEC SDL_Camera *SDLCALL SDL_OpenCameraDevice(SDL_CameraDeviceID inst
  * \sa SDL_OpenCameraDevice
  * \sa SDL_CloseCamera
  */
-extern DECLSPEC int SDLCALL SDL_GetCameraPermissionState(SDL_Camera *camera);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetCameraPermissionState(SDL_Camera *camera);
 
 /**
  * Get the instance ID of an opened camera.
@@ -354,7 +354,7 @@ extern DECLSPEC int SDLCALL SDL_GetCameraPermissionState(SDL_Camera *camera);
  *
  * \sa SDL_OpenCameraDevice
  */
-extern DECLSPEC SDL_CameraDeviceID SDLCALL SDL_GetCameraInstanceID(SDL_Camera *camera);
+extern SDL_DECLSPEC_RETURN SDL_CameraDeviceID SDLCALL SDL_GetCameraInstanceID(SDL_Camera *camera);
 
 /**
  * Get the properties associated with an opened camera.
@@ -370,7 +370,7 @@ extern DECLSPEC SDL_CameraDeviceID SDLCALL SDL_GetCameraInstanceID(SDL_Camera *c
  * \sa SDL_GetProperty
  * \sa SDL_SetProperty
  */
-extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetCameraProperties(SDL_Camera *camera);
+extern SDL_DECLSPEC_RETURN SDL_PropertiesID SDLCALL SDL_GetCameraProperties(SDL_Camera *camera);
 
 /**
  * Get the spec that a camera is using when generating images.
@@ -395,7 +395,7 @@ extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetCameraProperties(SDL_Camera *cam
  *
  * \sa SDL_OpenCameraDevice
  */
-extern DECLSPEC int SDLCALL SDL_GetCameraFormat(SDL_Camera *camera, SDL_CameraSpec *spec);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetCameraFormat(SDL_Camera *camera, SDL_CameraSpec *spec);
 
 /**
  * Acquire a frame.
@@ -438,7 +438,7 @@ extern DECLSPEC int SDLCALL SDL_GetCameraFormat(SDL_Camera *camera, SDL_CameraSp
  *
  * \sa SDL_ReleaseCameraFrame
  */
-extern DECLSPEC SDL_Surface * SDLCALL SDL_AcquireCameraFrame(SDL_Camera *camera, Uint64 *timestampNS);
+extern SDL_DECLSPEC_RETURN SDL_Surface * SDLCALL SDL_AcquireCameraFrame(SDL_Camera *camera, Uint64 *timestampNS);
 
 /**
  * Release a frame of video acquired from a camera.
@@ -468,7 +468,7 @@ extern DECLSPEC SDL_Surface * SDLCALL SDL_AcquireCameraFrame(SDL_Camera *camera,
  *
  * \sa SDL_AcquireCameraFrame
  */
-extern DECLSPEC int SDLCALL SDL_ReleaseCameraFrame(SDL_Camera *camera, SDL_Surface *frame);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ReleaseCameraFrame(SDL_Camera *camera, SDL_Surface *frame);
 
 /**
  * Use this function to shut down camera processing and close the camera
@@ -484,7 +484,7 @@ extern DECLSPEC int SDLCALL SDL_ReleaseCameraFrame(SDL_Camera *camera, SDL_Surfa
  * \sa SDL_OpenCameraWithSpec
  * \sa SDL_OpenCamera
  */
-extern DECLSPEC void SDLCALL SDL_CloseCamera(SDL_Camera *camera);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_CloseCamera(SDL_Camera *camera);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_camera.h
+++ b/include/SDL3/SDL_camera.h
@@ -180,7 +180,7 @@ extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetCurrentCameraDriver(void);
  *
  * \sa SDL_OpenCamera
  */
-extern SDL_DECLSPEC_RETURN SDL_CameraDeviceID *SDLCALL SDL_GetCameraDevices(int *count);
+extern SDL_DECLSPEC_NODISCARD SDL_CameraDeviceID *SDLCALL SDL_GetCameraDevices(int *count);
 
 /**
  * Get the list of native formats/sizes a camera supports.
@@ -223,7 +223,7 @@ extern SDL_DECLSPEC_RETURN SDL_CameraDeviceID *SDLCALL SDL_GetCameraDevices(int 
  * \sa SDL_GetCameraDevices
  * \sa SDL_OpenCameraDevice
  */
-extern SDL_DECLSPEC_RETURN SDL_CameraSpec *SDLCALL SDL_GetCameraDeviceSupportedFormats(SDL_CameraDeviceID devid, int *count);
+extern SDL_DECLSPEC_NODISCARD SDL_CameraSpec *SDLCALL SDL_GetCameraDeviceSupportedFormats(SDL_CameraDeviceID devid, int *count);
 
 /**
  * Get human-readable device name for a camera.
@@ -241,7 +241,7 @@ extern SDL_DECLSPEC_RETURN SDL_CameraSpec *SDLCALL SDL_GetCameraDeviceSupportedF
  *
  * \sa SDL_GetCameraDevices
  */
-extern SDL_DECLSPEC_RETURN char * SDLCALL SDL_GetCameraDeviceName(SDL_CameraDeviceID instance_id);
+extern SDL_DECLSPEC_NODISCARD char * SDLCALL SDL_GetCameraDeviceName(SDL_CameraDeviceID instance_id);
 
 /**
  * Get the position of the camera in relation to the system.
@@ -306,7 +306,7 @@ extern SDL_DECLSPEC_RETURN SDL_CameraPosition SDLCALL SDL_GetCameraDevicePositio
  * \sa SDL_GetCameraDevices
  * \sa SDL_GetCameraFormat
  */
-extern SDL_DECLSPEC_RETURN SDL_Camera *SDLCALL SDL_OpenCameraDevice(SDL_CameraDeviceID instance_id, const SDL_CameraSpec *spec);
+extern SDL_DECLSPEC_NODISCARD SDL_Camera *SDLCALL SDL_OpenCameraDevice(SDL_CameraDeviceID instance_id, const SDL_CameraSpec *spec);
 
 /**
  * Query if camera access has been approved by the user.

--- a/include/SDL3/SDL_clipboard.h
+++ b/include/SDL3/SDL_clipboard.h
@@ -72,7 +72,7 @@ extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetClipboardText(const char *text);
  * \sa SDL_HasClipboardText
  * \sa SDL_SetClipboardText
  */
-extern SDL_DECLSPEC_RETURN char * SDLCALL SDL_GetClipboardText(void);
+extern SDL_DECLSPEC_NODISCARD char * SDLCALL SDL_GetClipboardText(void);
 
 /**
  * Query whether the clipboard exists and contains a non-empty text string.
@@ -117,7 +117,7 @@ extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetPrimarySelectionText(const char *t
  * \sa SDL_HasPrimarySelectionText
  * \sa SDL_SetPrimarySelectionText
  */
-extern SDL_DECLSPEC_RETURN char * SDLCALL SDL_GetPrimarySelectionText(void);
+extern SDL_DECLSPEC_NODISCARD char * SDLCALL SDL_GetPrimarySelectionText(void);
 
 /**
  * Query whether the primary selection exists and contains a non-empty text
@@ -228,7 +228,7 @@ extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ClearClipboardData(void);
  * \sa SDL_HasClipboardData
  * \sa SDL_SetClipboardData
  */
-extern SDL_DECLSPEC_RETURN void *SDLCALL SDL_GetClipboardData(const char *mime_type, size_t *size);
+extern SDL_DECLSPEC_NODISCARD void *SDLCALL SDL_GetClipboardData(const char *mime_type, size_t *size);
 
 /**
  * Query whether there is data in the clipboard for the provided mime type.

--- a/include/SDL3/SDL_clipboard.h
+++ b/include/SDL3/SDL_clipboard.h
@@ -54,7 +54,7 @@ extern "C" {
  * \sa SDL_GetClipboardText
  * \sa SDL_HasClipboardText
  */
-extern DECLSPEC int SDLCALL SDL_SetClipboardText(const char *text);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetClipboardText(const char *text);
 
 /**
  * Get UTF-8 text from the clipboard, which must be freed with SDL_free().
@@ -72,7 +72,7 @@ extern DECLSPEC int SDLCALL SDL_SetClipboardText(const char *text);
  * \sa SDL_HasClipboardText
  * \sa SDL_SetClipboardText
  */
-extern DECLSPEC char * SDLCALL SDL_GetClipboardText(void);
+extern SDL_DECLSPEC_RETURN char * SDLCALL SDL_GetClipboardText(void);
 
 /**
  * Query whether the clipboard exists and contains a non-empty text string.
@@ -84,7 +84,7 @@ extern DECLSPEC char * SDLCALL SDL_GetClipboardText(void);
  * \sa SDL_GetClipboardText
  * \sa SDL_SetClipboardText
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasClipboardText(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasClipboardText(void);
 
 /**
  * Put UTF-8 text into the primary selection.
@@ -98,7 +98,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasClipboardText(void);
  * \sa SDL_GetPrimarySelectionText
  * \sa SDL_HasPrimarySelectionText
  */
-extern DECLSPEC int SDLCALL SDL_SetPrimarySelectionText(const char *text);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetPrimarySelectionText(const char *text);
 
 /**
  * Get UTF-8 text from the primary selection, which must be freed with
@@ -117,7 +117,7 @@ extern DECLSPEC int SDLCALL SDL_SetPrimarySelectionText(const char *text);
  * \sa SDL_HasPrimarySelectionText
  * \sa SDL_SetPrimarySelectionText
  */
-extern DECLSPEC char * SDLCALL SDL_GetPrimarySelectionText(void);
+extern SDL_DECLSPEC_RETURN char * SDLCALL SDL_GetPrimarySelectionText(void);
 
 /**
  * Query whether the primary selection exists and contains a non-empty text
@@ -131,7 +131,7 @@ extern DECLSPEC char * SDLCALL SDL_GetPrimarySelectionText(void);
  * \sa SDL_GetPrimarySelectionText
  * \sa SDL_SetPrimarySelectionText
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasPrimarySelectionText(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasPrimarySelectionText(void);
 
 /**
  * Callback function that will be called when data for the specified mime-type
@@ -197,7 +197,7 @@ typedef void (SDLCALL *SDL_ClipboardCleanupCallback)(void *userdata);
  * \sa SDL_GetClipboardData
  * \sa SDL_HasClipboardData
  */
-extern DECLSPEC int SDLCALL SDL_SetClipboardData(SDL_ClipboardDataCallback callback, SDL_ClipboardCleanupCallback cleanup, void *userdata, const char **mime_types, size_t num_mime_types);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetClipboardData(SDL_ClipboardDataCallback callback, SDL_ClipboardCleanupCallback cleanup, void *userdata, const char **mime_types, size_t num_mime_types);
 
 /**
  * Clear the clipboard data.
@@ -209,7 +209,7 @@ extern DECLSPEC int SDLCALL SDL_SetClipboardData(SDL_ClipboardDataCallback callb
  *
  * \sa SDL_SetClipboardData
  */
-extern DECLSPEC int SDLCALL SDL_ClearClipboardData(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ClearClipboardData(void);
 
 /**
  * Get the data from clipboard for a given mime type.
@@ -228,7 +228,7 @@ extern DECLSPEC int SDLCALL SDL_ClearClipboardData(void);
  * \sa SDL_HasClipboardData
  * \sa SDL_SetClipboardData
  */
-extern DECLSPEC void *SDLCALL SDL_GetClipboardData(const char *mime_type, size_t *size);
+extern SDL_DECLSPEC_RETURN void *SDLCALL SDL_GetClipboardData(const char *mime_type, size_t *size);
 
 /**
  * Query whether there is data in the clipboard for the provided mime type.
@@ -242,7 +242,7 @@ extern DECLSPEC void *SDLCALL SDL_GetClipboardData(const char *mime_type, size_t
  * \sa SDL_SetClipboardData
  * \sa SDL_GetClipboardData
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasClipboardData(const char *mime_type);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasClipboardData(const char *mime_type);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_cpuinfo.h
+++ b/include/SDL3/SDL_cpuinfo.h
@@ -62,7 +62,7 @@ extern "C" {
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetCPUCount(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetCPUCount(void);
 
 /**
  * Determine the L1 cache line size of the CPU.
@@ -74,7 +74,7 @@ extern DECLSPEC int SDLCALL SDL_GetCPUCount(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetCPUCacheLineSize(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetCPUCacheLineSize(void);
 
 /**
  * Determine whether the CPU has AltiVec features.
@@ -86,7 +86,7 @@ extern DECLSPEC int SDLCALL SDL_GetCPUCacheLineSize(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasAltiVec(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasAltiVec(void);
 
 /**
  * Determine whether the CPU has MMX features.
@@ -97,7 +97,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasAltiVec(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasMMX(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasMMX(void);
 
 /**
  * Determine whether the CPU has SSE features.
@@ -113,7 +113,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasMMX(void);
  * \sa SDL_HasSSE41
  * \sa SDL_HasSSE42
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasSSE(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasSSE(void);
 
 /**
  * Determine whether the CPU has SSE2 features.
@@ -129,7 +129,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasSSE(void);
  * \sa SDL_HasSSE41
  * \sa SDL_HasSSE42
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasSSE2(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasSSE2(void);
 
 /**
  * Determine whether the CPU has SSE3 features.
@@ -145,7 +145,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasSSE2(void);
  * \sa SDL_HasSSE41
  * \sa SDL_HasSSE42
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasSSE3(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasSSE3(void);
 
 /**
  * Determine whether the CPU has SSE4.1 features.
@@ -161,7 +161,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasSSE3(void);
  * \sa SDL_HasSSE3
  * \sa SDL_HasSSE42
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasSSE41(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasSSE41(void);
 
 /**
  * Determine whether the CPU has SSE4.2 features.
@@ -177,7 +177,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasSSE41(void);
  * \sa SDL_HasSSE3
  * \sa SDL_HasSSE41
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasSSE42(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasSSE42(void);
 
 /**
  * Determine whether the CPU has AVX features.
@@ -191,7 +191,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasSSE42(void);
  * \sa SDL_HasAVX2
  * \sa SDL_HasAVX512F
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasAVX(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasAVX(void);
 
 /**
  * Determine whether the CPU has AVX2 features.
@@ -205,7 +205,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasAVX(void);
  * \sa SDL_HasAVX
  * \sa SDL_HasAVX512F
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasAVX2(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasAVX2(void);
 
 /**
  * Determine whether the CPU has AVX-512F (foundation) features.
@@ -219,7 +219,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasAVX2(void);
  * \sa SDL_HasAVX
  * \sa SDL_HasAVX2
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasAVX512F(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasAVX512F(void);
 
 /**
  * Determine whether the CPU has ARM SIMD (ARMv6) features.
@@ -234,7 +234,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasAVX512F(void);
  *
  * \sa SDL_HasNEON
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasARMSIMD(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasARMSIMD(void);
 
 /**
  * Determine whether the CPU has NEON (ARM SIMD) features.
@@ -245,7 +245,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasARMSIMD(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasNEON(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasNEON(void);
 
 /**
  * Determine whether the CPU has LSX (LOONGARCH SIMD) features.
@@ -258,7 +258,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasNEON(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasLSX(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasLSX(void);
 
 /**
  * Determine whether the CPU has LASX (LOONGARCH SIMD) features.
@@ -271,7 +271,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasLSX(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasLASX(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasLASX(void);
 
 /**
  * Get the amount of RAM configured in the system.
@@ -280,7 +280,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasLASX(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetSystemRAM(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetSystemRAM(void);
 
 /**
  * Report the alignment this system needs for SIMD allocations.
@@ -302,7 +302,7 @@ extern DECLSPEC int SDLCALL SDL_GetSystemRAM(void);
  * \sa SDL_aligned_alloc
  * \sa SDL_aligned_free
  */
-extern DECLSPEC size_t SDLCALL SDL_GetSIMDAlignment(void);
+extern SDL_DECLSPEC_RETURN size_t SDLCALL SDL_GetSIMDAlignment(void);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_dialog.h
+++ b/include/SDL3/SDL_dialog.h
@@ -146,7 +146,7 @@ typedef void(SDLCALL *SDL_DialogFileCallback)(void *userdata, const char * const
  * \sa SDL_ShowSaveFileDialog
  * \sa SDL_ShowOpenFolderDialog
  */
-extern DECLSPEC void SDLCALL SDL_ShowOpenFileDialog(SDL_DialogFileCallback callback, void *userdata, SDL_Window *window, const SDL_DialogFileFilter *filters, const char *default_location, SDL_bool allow_many);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_ShowOpenFileDialog(SDL_DialogFileCallback callback, void *userdata, SDL_Window *window, const SDL_DialogFileFilter *filters, const char *default_location, SDL_bool allow_many);
 
 /**
  * Displays a dialog that lets the user choose a new or existing file on their
@@ -196,7 +196,7 @@ extern DECLSPEC void SDLCALL SDL_ShowOpenFileDialog(SDL_DialogFileCallback callb
  * \sa SDL_ShowOpenFileDialog
  * \sa SDL_ShowOpenFolderDialog
  */
-extern DECLSPEC void SDLCALL SDL_ShowSaveFileDialog(SDL_DialogFileCallback callback, void *userdata, SDL_Window *window, const SDL_DialogFileFilter *filters, const char *default_location);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_ShowSaveFileDialog(SDL_DialogFileCallback callback, void *userdata, SDL_Window *window, const SDL_DialogFileFilter *filters, const char *default_location);
 
 /**
  * Displays a dialog that lets the user select a folder on their filesystem.
@@ -240,7 +240,7 @@ extern DECLSPEC void SDLCALL SDL_ShowSaveFileDialog(SDL_DialogFileCallback callb
  * \sa SDL_ShowOpenFileDialog
  * \sa SDL_ShowSaveFileDialog
  */
-extern DECLSPEC void SDLCALL SDL_ShowOpenFolderDialog(SDL_DialogFileCallback callback, void *userdata, SDL_Window *window, const char *default_location, SDL_bool allow_many);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_ShowOpenFolderDialog(SDL_DialogFileCallback callback, void *userdata, SDL_Window *window, const char *default_location, SDL_bool allow_many);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_error.h
+++ b/include/SDL3/SDL_error.h
@@ -63,7 +63,7 @@ extern "C" {
  * \sa SDL_ClearError
  * \sa SDL_GetError
  */
-extern DECLSPEC int SDLCALL SDL_SetError(SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(1);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetError(SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(1);
 
 /**
  * Set an error indicating that memory allocation failed.
@@ -74,7 +74,7 @@ extern DECLSPEC int SDLCALL SDL_SetError(SDL_PRINTF_FORMAT_STRING const char *fm
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_OutOfMemory(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_OutOfMemory(void);
 
 /**
  * Retrieve a message about the last error that occurred on the current
@@ -111,7 +111,7 @@ extern DECLSPEC int SDLCALL SDL_OutOfMemory(void);
  * \sa SDL_ClearError
  * \sa SDL_SetError
  */
-extern DECLSPEC const char *SDLCALL SDL_GetError(void);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetError(void);
 
 /**
  * Clear any previous error message for this thread.
@@ -123,7 +123,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetError(void);
  * \sa SDL_GetError
  * \sa SDL_SetError
  */
-extern DECLSPEC int SDLCALL SDL_ClearError(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ClearError(void);
 
 /**
  *  \name Internal error functions

--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -893,7 +893,7 @@ SDL_COMPILE_TIME_ASSERT(SDL_Event, sizeof(SDL_Event) == sizeof(((SDL_Event *)NUL
  * \sa SDL_PollEvent
  * \sa SDL_WaitEvent
  */
-extern DECLSPEC void SDLCALL SDL_PumpEvents(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_PumpEvents(void);
 
 /* @{ */
 typedef enum SDL_EventAction
@@ -941,7 +941,7 @@ typedef enum SDL_EventAction
  * \sa SDL_PumpEvents
  * \sa SDL_PushEvent
  */
-extern DECLSPEC int SDLCALL SDL_PeepEvents(SDL_Event *events, int numevents, SDL_EventAction action, Uint32 minType, Uint32 maxType);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_PeepEvents(SDL_Event *events, int numevents, SDL_EventAction action, Uint32 minType, Uint32 maxType);
 /* @} */
 
 /**
@@ -958,7 +958,7 @@ extern DECLSPEC int SDLCALL SDL_PeepEvents(SDL_Event *events, int numevents, SDL
  *
  * \sa SDL_HasEvents
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasEvent(Uint32 type);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasEvent(Uint32 type);
 
 
 /**
@@ -977,7 +977,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasEvent(Uint32 type);
  *
  * \sa SDL_HasEvents
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasEvents(Uint32 minType, Uint32 maxType);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasEvents(Uint32 minType, Uint32 maxType);
 
 /**
  * Clear events of a specific type from the event queue.
@@ -1003,7 +1003,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasEvents(Uint32 minType, Uint32 maxType);
  *
  * \sa SDL_FlushEvents
  */
-extern DECLSPEC void SDLCALL SDL_FlushEvent(Uint32 type);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_FlushEvent(Uint32 type);
 
 /**
  * Clear events of a range of types from the event queue.
@@ -1028,7 +1028,7 @@ extern DECLSPEC void SDLCALL SDL_FlushEvent(Uint32 type);
  *
  * \sa SDL_FlushEvent
  */
-extern DECLSPEC void SDLCALL SDL_FlushEvents(Uint32 minType, Uint32 maxType);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_FlushEvents(Uint32 minType, Uint32 maxType);
 
 /**
  * Poll for currently pending events.
@@ -1073,7 +1073,7 @@ extern DECLSPEC void SDLCALL SDL_FlushEvents(Uint32 minType, Uint32 maxType);
  * \sa SDL_WaitEvent
  * \sa SDL_WaitEventTimeout
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_PollEvent(SDL_Event *event);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_PollEvent(SDL_Event *event);
 
 /**
  * Wait indefinitely for the next available event.
@@ -1095,7 +1095,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_PollEvent(SDL_Event *event);
  * \sa SDL_PushEvent
  * \sa SDL_WaitEventTimeout
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_WaitEvent(SDL_Event *event);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_WaitEvent(SDL_Event *event);
 
 /**
  * Wait until the specified timeout (in milliseconds) for the next available
@@ -1123,7 +1123,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_WaitEvent(SDL_Event *event);
  * \sa SDL_PushEvent
  * \sa SDL_WaitEvent
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_WaitEventTimeout(SDL_Event *event, Sint32 timeoutMS);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_WaitEventTimeout(SDL_Event *event, Sint32 timeoutMS);
 
 /**
  * Add an event to the event queue.
@@ -1157,7 +1157,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_WaitEventTimeout(SDL_Event *event, Sint32 t
  * \sa SDL_PollEvent
  * \sa SDL_RegisterEvents
  */
-extern DECLSPEC int SDLCALL SDL_PushEvent(SDL_Event *event);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_PushEvent(SDL_Event *event);
 
 /**
  * A function pointer used for callbacks that watch the event queue.
@@ -1225,7 +1225,7 @@ typedef int (SDLCALL *SDL_EventFilter)(void *userdata, SDL_Event *event);
  * \sa SDL_PeepEvents
  * \sa SDL_PushEvent
  */
-extern DECLSPEC void SDLCALL SDL_SetEventFilter(SDL_EventFilter filter, void *userdata);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_SetEventFilter(SDL_EventFilter filter, void *userdata);
 
 /**
  * Query the current event filter.
@@ -1242,7 +1242,7 @@ extern DECLSPEC void SDLCALL SDL_SetEventFilter(SDL_EventFilter filter, void *us
  *
  * \sa SDL_SetEventFilter
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GetEventFilter(SDL_EventFilter *filter, void **userdata);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GetEventFilter(SDL_EventFilter *filter, void **userdata);
 
 /**
  * Add a callback to be triggered when an event is added to the event queue.
@@ -1272,7 +1272,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_GetEventFilter(SDL_EventFilter *filter, voi
  * \sa SDL_DelEventWatch
  * \sa SDL_SetEventFilter
  */
-extern DECLSPEC int SDLCALL SDL_AddEventWatch(SDL_EventFilter filter, void *userdata);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_AddEventWatch(SDL_EventFilter filter, void *userdata);
 
 /**
  * Remove an event watch callback added with SDL_AddEventWatch().
@@ -1287,7 +1287,7 @@ extern DECLSPEC int SDLCALL SDL_AddEventWatch(SDL_EventFilter filter, void *user
  *
  * \sa SDL_AddEventWatch
  */
-extern DECLSPEC void SDLCALL SDL_DelEventWatch(SDL_EventFilter filter, void *userdata);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_DelEventWatch(SDL_EventFilter filter, void *userdata);
 
 /**
  * Run a specific filter function on the current event queue, removing any
@@ -1305,7 +1305,7 @@ extern DECLSPEC void SDLCALL SDL_DelEventWatch(SDL_EventFilter filter, void *use
  * \sa SDL_GetEventFilter
  * \sa SDL_SetEventFilter
  */
-extern DECLSPEC void SDLCALL SDL_FilterEvents(SDL_EventFilter filter, void *userdata);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_FilterEvents(SDL_EventFilter filter, void *userdata);
 
 /**
  * Set the state of processing events by type.
@@ -1317,7 +1317,7 @@ extern DECLSPEC void SDLCALL SDL_FilterEvents(SDL_EventFilter filter, void *user
  *
  * \sa SDL_EventEnabled
  */
-extern DECLSPEC void SDLCALL SDL_SetEventEnabled(Uint32 type, SDL_bool enabled);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_SetEventEnabled(Uint32 type, SDL_bool enabled);
 
 /**
  * Query the state of processing events by type.
@@ -1329,7 +1329,7 @@ extern DECLSPEC void SDLCALL SDL_SetEventEnabled(Uint32 type, SDL_bool enabled);
  *
  * \sa SDL_SetEventEnabled
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_EventEnabled(Uint32 type);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_EventEnabled(Uint32 type);
 
 /**
  * Allocate a set of user-defined events, and return the beginning event
@@ -1343,7 +1343,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_EventEnabled(Uint32 type);
  *
  * \sa SDL_PushEvent
  */
-extern DECLSPEC Uint32 SDLCALL SDL_RegisterEvents(int numevents);
+extern SDL_DECLSPEC_RETURN Uint32 SDLCALL SDL_RegisterEvents(int numevents);
 
 /**
  * Allocate dynamic memory for an SDL event.
@@ -1357,7 +1357,7 @@ extern DECLSPEC Uint32 SDLCALL SDL_RegisterEvents(int numevents);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void * SDLCALL SDL_AllocateEventMemory(size_t size);
+extern SDL_DECLSPEC_RETURN void * SDLCALL SDL_AllocateEventMemory(size_t size);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_filesystem.h
+++ b/include/SDL3/SDL_filesystem.h
@@ -240,7 +240,7 @@ typedef enum SDL_Folder
  *
  * \sa SDL_Folder
  */
-extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_GetUserFolder(SDL_Folder folder);
+extern SDL_DECLSPEC_NODISCARD char *SDLCALL SDL_GetUserFolder(SDL_Folder folder);
 
 
 /* Abstract filesystem interface */
@@ -371,13 +371,13 @@ extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetPathInfo(const char *path, SDL_Pat
  *              array. Can be NULL.
  * \returns an array of strings on success or NULL on failure; call
  *          SDL_GetError() for more information. The caller should pass the
- *          returned pointer to SDL_free when done with it.
+ *          returned pointer to SDL_free() when done with it.
  *
  * \threadsafety It is safe to call this function from any thread.
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern SDL_DECLSPEC_RETURN char **SDLCALL SDL_GlobDirectory(const char *path, const char *pattern, SDL_GlobFlags flags, int *count);
+extern SDL_DECLSPEC_NODISCARD char **SDLCALL SDL_GlobDirectory(const char *path, const char *pattern, SDL_GlobFlags flags, int *count);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_filesystem.h
+++ b/include/SDL3/SDL_filesystem.h
@@ -80,7 +80,7 @@ extern "C" {
  *
  * \sa SDL_GetPrefPath
  */
-extern DECLSPEC char *SDLCALL SDL_GetBasePath(void);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_GetBasePath(void);
 
 /**
  * Get the user-and-app-specific path where files can be written.
@@ -137,7 +137,7 @@ extern DECLSPEC char *SDLCALL SDL_GetBasePath(void);
  *
  * \sa SDL_GetBasePath
  */
-extern DECLSPEC char *SDLCALL SDL_GetPrefPath(const char *org, const char *app);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_GetPrefPath(const char *org, const char *app);
 
 /**
  * The type of the OS-provided default folder for a specific purpose.
@@ -240,7 +240,7 @@ typedef enum SDL_Folder
  *
  * \sa SDL_Folder
  */
-extern DECLSPEC char *SDLCALL SDL_GetUserFolder(SDL_Folder folder);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_GetUserFolder(SDL_Folder folder);
 
 
 /* Abstract filesystem interface */
@@ -283,7 +283,7 @@ typedef Uint32 SDL_GlobFlags;
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_CreateDirectory(const char *path);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_CreateDirectory(const char *path);
 
 /* Callback for directory enumeration. Return 1 to keep enumerating,
    0 to stop enumerating (no error), -1 to stop enumerating and
@@ -306,7 +306,7 @@ typedef int (SDLCALL *SDL_EnumerateDirectoryCallback)(void *userdata, const char
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_EnumerateDirectory(const char *path, SDL_EnumerateDirectoryCallback callback, void *userdata);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_EnumerateDirectory(const char *path, SDL_EnumerateDirectoryCallback callback, void *userdata);
 
 /**
  * Remove a file or an empty directory.
@@ -317,7 +317,7 @@ extern DECLSPEC int SDLCALL SDL_EnumerateDirectory(const char *path, SDL_Enumera
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_RemovePath(const char *path);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RemovePath(const char *path);
 
 /**
  * Rename a file or directory.
@@ -329,7 +329,7 @@ extern DECLSPEC int SDLCALL SDL_RemovePath(const char *path);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_RenamePath(const char *oldpath, const char *newpath);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenamePath(const char *oldpath, const char *newpath);
 
 /**
  * Get information about a filesystem path.
@@ -342,7 +342,7 @@ extern DECLSPEC int SDLCALL SDL_RenamePath(const char *oldpath, const char *newp
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetPathInfo(const char *path, SDL_PathInfo *info);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetPathInfo(const char *path, SDL_PathInfo *info);
 
 /**
  * Enumerate a directory tree, filtered by pattern, and return a list.
@@ -377,7 +377,7 @@ extern DECLSPEC int SDLCALL SDL_GetPathInfo(const char *path, SDL_PathInfo *info
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC char **SDLCALL SDL_GlobDirectory(const char *path, const char *pattern, SDL_GlobFlags flags, int *count);
+extern SDL_DECLSPEC_RETURN char **SDLCALL SDL_GlobDirectory(const char *path, const char *pattern, SDL_GlobFlags flags, int *count);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_gamepad.h
+++ b/include/SDL3/SDL_gamepad.h
@@ -308,7 +308,7 @@ typedef struct SDL_GamepadBinding
  * \sa SDL_GetGamepadMapping
  * \sa SDL_GetGamepadMappingForGUID
  */
-extern DECLSPEC int SDLCALL SDL_AddGamepadMapping(const char *mapping);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_AddGamepadMapping(const char *mapping);
 
 /**
  * Load a set of gamepad mappings from an SDL_IOStream.
@@ -340,7 +340,7 @@ extern DECLSPEC int SDLCALL SDL_AddGamepadMapping(const char *mapping);
  * \sa SDL_GetGamepadMapping
  * \sa SDL_GetGamepadMappingForGUID
  */
-extern DECLSPEC int SDLCALL SDL_AddGamepadMappingsFromIO(SDL_IOStream *src, SDL_bool closeio);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_AddGamepadMappingsFromIO(SDL_IOStream *src, SDL_bool closeio);
 
 /**
  * Load a set of gamepad mappings from a file.
@@ -366,7 +366,7 @@ extern DECLSPEC int SDLCALL SDL_AddGamepadMappingsFromIO(SDL_IOStream *src, SDL_
  * \sa SDL_GetGamepadMapping
  * \sa SDL_GetGamepadMappingForGUID
  */
-extern DECLSPEC int SDLCALL SDL_AddGamepadMappingsFromFile(const char *file);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_AddGamepadMappingsFromFile(const char *file);
 
 /**
  * Reinitialize the SDL mapping database to its initial state.
@@ -378,7 +378,7 @@ extern DECLSPEC int SDLCALL SDL_AddGamepadMappingsFromFile(const char *file);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_ReloadGamepadMappings(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ReloadGamepadMappings(void);
 
 /**
  * Get the current gamepad mappings.
@@ -393,7 +393,7 @@ extern DECLSPEC int SDLCALL SDL_ReloadGamepadMappings(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC char ** SDLCALL SDL_GetGamepadMappings(int *count);
+extern SDL_DECLSPEC_RETURN char ** SDLCALL SDL_GetGamepadMappings(int *count);
 
 /**
  * Get the gamepad mapping string for a given GUID.
@@ -409,7 +409,7 @@ extern DECLSPEC char ** SDLCALL SDL_GetGamepadMappings(int *count);
  * \sa SDL_GetJoystickInstanceGUID
  * \sa SDL_GetJoystickGUID
  */
-extern DECLSPEC char * SDLCALL SDL_GetGamepadMappingForGUID(SDL_JoystickGUID guid);
+extern SDL_DECLSPEC_RETURN char * SDLCALL SDL_GetGamepadMappingForGUID(SDL_JoystickGUID guid);
 
 /**
  * Get the current mapping of a gamepad.
@@ -429,7 +429,7 @@ extern DECLSPEC char * SDLCALL SDL_GetGamepadMappingForGUID(SDL_JoystickGUID gui
  * \sa SDL_GetGamepadMappingForGUID
  * \sa SDL_SetGamepadMapping
  */
-extern DECLSPEC char * SDLCALL SDL_GetGamepadMapping(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_RETURN char * SDLCALL SDL_GetGamepadMapping(SDL_Gamepad *gamepad);
 
 /**
  * Set the current mapping of a joystick or gamepad.
@@ -447,7 +447,7 @@ extern DECLSPEC char * SDLCALL SDL_GetGamepadMapping(SDL_Gamepad *gamepad);
  * \sa SDL_AddGamepadMapping
  * \sa SDL_GetGamepadMapping
  */
-extern DECLSPEC int SDLCALL SDL_SetGamepadMapping(SDL_JoystickID instance_id, const char *mapping);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetGamepadMapping(SDL_JoystickID instance_id, const char *mapping);
 
 /**
  * Return whether a gamepad is currently connected.
@@ -458,7 +458,7 @@ extern DECLSPEC int SDLCALL SDL_SetGamepadMapping(SDL_JoystickID instance_id, co
  *
  * \sa SDL_GetGamepads
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasGamepad(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasGamepad(void);
 
 /**
  * Get a list of currently connected gamepads.
@@ -473,7 +473,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasGamepad(void);
  * \sa SDL_HasGamepad
  * \sa SDL_OpenGamepad
  */
-extern DECLSPEC SDL_JoystickID *SDLCALL SDL_GetGamepads(int *count);
+extern SDL_DECLSPEC_RETURN SDL_JoystickID *SDLCALL SDL_GetGamepads(int *count);
 
 /**
  * Check if the given joystick is supported by the gamepad interface.
@@ -487,7 +487,7 @@ extern DECLSPEC SDL_JoystickID *SDLCALL SDL_GetGamepads(int *count);
  * \sa SDL_GetJoysticks
  * \sa SDL_OpenGamepad
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_IsGamepad(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_IsGamepad(SDL_JoystickID instance_id);
 
 /**
  * Get the implementation dependent name of a gamepad.
@@ -503,7 +503,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_IsGamepad(SDL_JoystickID instance_id);
  * \sa SDL_GetGamepadName
  * \sa SDL_GetGamepads
  */
-extern DECLSPEC const char *SDLCALL SDL_GetGamepadInstanceName(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetGamepadInstanceName(SDL_JoystickID instance_id);
 
 /**
  * Get the implementation dependent path of a gamepad.
@@ -519,7 +519,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetGamepadInstanceName(SDL_JoystickID in
  * \sa SDL_GetGamepadPath
  * \sa SDL_GetGamepads
  */
-extern DECLSPEC const char *SDLCALL SDL_GetGamepadInstancePath(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetGamepadInstancePath(SDL_JoystickID instance_id);
 
 /**
  * Get the player index of a gamepad.
@@ -534,7 +534,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetGamepadInstancePath(SDL_JoystickID in
  * \sa SDL_GetGamepadPlayerIndex
  * \sa SDL_GetGamepads
  */
-extern DECLSPEC int SDLCALL SDL_GetGamepadInstancePlayerIndex(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetGamepadInstancePlayerIndex(SDL_JoystickID instance_id);
 
 /**
  * Get the implementation-dependent GUID of a gamepad.
@@ -551,7 +551,7 @@ extern DECLSPEC int SDLCALL SDL_GetGamepadInstancePlayerIndex(SDL_JoystickID ins
  * \sa SDL_GetGamepadGUIDString
  * \sa SDL_GetGamepads
  */
-extern DECLSPEC SDL_JoystickGUID SDLCALL SDL_GetGamepadInstanceGUID(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_JoystickGUID SDLCALL SDL_GetGamepadInstanceGUID(SDL_JoystickID instance_id);
 
 /**
  * Get the USB vendor ID of a gamepad, if available.
@@ -568,7 +568,7 @@ extern DECLSPEC SDL_JoystickGUID SDLCALL SDL_GetGamepadInstanceGUID(SDL_Joystick
  * \sa SDL_GetGamepadVendor
  * \sa SDL_GetGamepads
  */
-extern DECLSPEC Uint16 SDLCALL SDL_GetGamepadInstanceVendor(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN Uint16 SDLCALL SDL_GetGamepadInstanceVendor(SDL_JoystickID instance_id);
 
 /**
  * Get the USB product ID of a gamepad, if available.
@@ -585,7 +585,7 @@ extern DECLSPEC Uint16 SDLCALL SDL_GetGamepadInstanceVendor(SDL_JoystickID insta
  * \sa SDL_GetGamepadProduct
  * \sa SDL_GetGamepads
  */
-extern DECLSPEC Uint16 SDLCALL SDL_GetGamepadInstanceProduct(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN Uint16 SDLCALL SDL_GetGamepadInstanceProduct(SDL_JoystickID instance_id);
 
 /**
  * Get the product version of a gamepad, if available.
@@ -602,7 +602,7 @@ extern DECLSPEC Uint16 SDLCALL SDL_GetGamepadInstanceProduct(SDL_JoystickID inst
  * \sa SDL_GetGamepadProductVersion
  * \sa SDL_GetGamepads
  */
-extern DECLSPEC Uint16 SDLCALL SDL_GetGamepadInstanceProductVersion(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN Uint16 SDLCALL SDL_GetGamepadInstanceProductVersion(SDL_JoystickID instance_id);
 
 /**
  * Get the type of a gamepad.
@@ -618,7 +618,7 @@ extern DECLSPEC Uint16 SDLCALL SDL_GetGamepadInstanceProductVersion(SDL_Joystick
  * \sa SDL_GetGamepads
  * \sa SDL_GetRealGamepadInstanceType
  */
-extern DECLSPEC SDL_GamepadType SDLCALL SDL_GetGamepadInstanceType(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_GamepadType SDLCALL SDL_GetGamepadInstanceType(SDL_JoystickID instance_id);
 
 /**
  * Get the type of a gamepad, ignoring any mapping override.
@@ -634,7 +634,7 @@ extern DECLSPEC SDL_GamepadType SDLCALL SDL_GetGamepadInstanceType(SDL_JoystickI
  * \sa SDL_GetGamepads
  * \sa SDL_GetRealGamepadType
  */
-extern DECLSPEC SDL_GamepadType SDLCALL SDL_GetRealGamepadInstanceType(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_GamepadType SDLCALL SDL_GetRealGamepadInstanceType(SDL_JoystickID instance_id);
 
 /**
  * Get the mapping of a gamepad.
@@ -650,7 +650,7 @@ extern DECLSPEC SDL_GamepadType SDLCALL SDL_GetRealGamepadInstanceType(SDL_Joyst
  * \sa SDL_GetGamepads
  * \sa SDL_GetGamepadMapping
  */
-extern DECLSPEC char *SDLCALL SDL_GetGamepadInstanceMapping(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_GetGamepadInstanceMapping(SDL_JoystickID instance_id);
 
 /**
  * Open a gamepad for use.
@@ -664,7 +664,7 @@ extern DECLSPEC char *SDLCALL SDL_GetGamepadInstanceMapping(SDL_JoystickID insta
  * \sa SDL_CloseGamepad
  * \sa SDL_IsGamepad
  */
-extern DECLSPEC SDL_Gamepad *SDLCALL SDL_OpenGamepad(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_Gamepad *SDLCALL SDL_OpenGamepad(SDL_JoystickID instance_id);
 
 /**
  * Get the SDL_Gamepad associated with a joystick instance ID, if it has been
@@ -676,7 +676,7 @@ extern DECLSPEC SDL_Gamepad *SDLCALL SDL_OpenGamepad(SDL_JoystickID instance_id)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_Gamepad *SDLCALL SDL_GetGamepadFromInstanceID(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_Gamepad *SDLCALL SDL_GetGamepadFromInstanceID(SDL_JoystickID instance_id);
 
 /**
  * Get the SDL_Gamepad associated with a player index.
@@ -689,7 +689,7 @@ extern DECLSPEC SDL_Gamepad *SDLCALL SDL_GetGamepadFromInstanceID(SDL_JoystickID
  * \sa SDL_GetGamepadPlayerIndex
  * \sa SDL_SetGamepadPlayerIndex
  */
-extern DECLSPEC SDL_Gamepad *SDLCALL SDL_GetGamepadFromPlayerIndex(int player_index);
+extern SDL_DECLSPEC_RETURN SDL_Gamepad *SDLCALL SDL_GetGamepadFromPlayerIndex(int player_index);
 
 /**
  * Get the properties associated with an opened gamepad.
@@ -719,7 +719,7 @@ extern DECLSPEC SDL_Gamepad *SDLCALL SDL_GetGamepadFromPlayerIndex(int player_in
  * \sa SDL_GetProperty
  * \sa SDL_SetProperty
  */
-extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetGamepadProperties(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_RETURN SDL_PropertiesID SDLCALL SDL_GetGamepadProperties(SDL_Gamepad *gamepad);
 
 #define SDL_PROP_GAMEPAD_CAP_MONO_LED_BOOLEAN       SDL_PROP_JOYSTICK_CAP_MONO_LED_BOOLEAN
 #define SDL_PROP_GAMEPAD_CAP_RGB_LED_BOOLEAN        SDL_PROP_JOYSTICK_CAP_RGB_LED_BOOLEAN
@@ -737,7 +737,7 @@ extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetGamepadProperties(SDL_Gamepad *g
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_JoystickID SDLCALL SDL_GetGamepadInstanceID(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_RETURN SDL_JoystickID SDLCALL SDL_GetGamepadInstanceID(SDL_Gamepad *gamepad);
 
 /**
  * Get the implementation-dependent name for an opened gamepad.
@@ -751,7 +751,7 @@ extern DECLSPEC SDL_JoystickID SDLCALL SDL_GetGamepadInstanceID(SDL_Gamepad *gam
  *
  * \sa SDL_GetGamepadInstanceName
  */
-extern DECLSPEC const char *SDLCALL SDL_GetGamepadName(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetGamepadName(SDL_Gamepad *gamepad);
 
 /**
  * Get the implementation-dependent path for an opened gamepad.
@@ -765,7 +765,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetGamepadName(SDL_Gamepad *gamepad);
  *
  * \sa SDL_GetGamepadInstancePath
  */
-extern DECLSPEC const char *SDLCALL SDL_GetGamepadPath(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetGamepadPath(SDL_Gamepad *gamepad);
 
 /**
  * Get the type of an opened gamepad.
@@ -778,7 +778,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetGamepadPath(SDL_Gamepad *gamepad);
  *
  * \sa SDL_GetGamepadInstanceType
  */
-extern DECLSPEC SDL_GamepadType SDLCALL SDL_GetGamepadType(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_RETURN SDL_GamepadType SDLCALL SDL_GetGamepadType(SDL_Gamepad *gamepad);
 
 /**
  * Get the type of an opened gamepad, ignoring any mapping override.
@@ -791,7 +791,7 @@ extern DECLSPEC SDL_GamepadType SDLCALL SDL_GetGamepadType(SDL_Gamepad *gamepad)
  *
  * \sa SDL_GetRealGamepadInstanceType
  */
-extern DECLSPEC SDL_GamepadType SDLCALL SDL_GetRealGamepadType(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_RETURN SDL_GamepadType SDLCALL SDL_GetRealGamepadType(SDL_Gamepad *gamepad);
 
 /**
  * Get the player index of an opened gamepad.
@@ -805,7 +805,7 @@ extern DECLSPEC SDL_GamepadType SDLCALL SDL_GetRealGamepadType(SDL_Gamepad *game
  *
  * \sa SDL_SetGamepadPlayerIndex
  */
-extern DECLSPEC int SDLCALL SDL_GetGamepadPlayerIndex(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetGamepadPlayerIndex(SDL_Gamepad *gamepad);
 
 /**
  * Set the player index of an opened gamepad.
@@ -820,7 +820,7 @@ extern DECLSPEC int SDLCALL SDL_GetGamepadPlayerIndex(SDL_Gamepad *gamepad);
  *
  * \sa SDL_GetGamepadPlayerIndex
  */
-extern DECLSPEC int SDLCALL SDL_SetGamepadPlayerIndex(SDL_Gamepad *gamepad, int player_index);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetGamepadPlayerIndex(SDL_Gamepad *gamepad, int player_index);
 
 /**
  * Get the USB vendor ID of an opened gamepad, if available.
@@ -834,7 +834,7 @@ extern DECLSPEC int SDLCALL SDL_SetGamepadPlayerIndex(SDL_Gamepad *gamepad, int 
  *
  * \sa SDL_GetGamepadInstanceVendor
  */
-extern DECLSPEC Uint16 SDLCALL SDL_GetGamepadVendor(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_RETURN Uint16 SDLCALL SDL_GetGamepadVendor(SDL_Gamepad *gamepad);
 
 /**
  * Get the USB product ID of an opened gamepad, if available.
@@ -848,7 +848,7 @@ extern DECLSPEC Uint16 SDLCALL SDL_GetGamepadVendor(SDL_Gamepad *gamepad);
  *
  * \sa SDL_GetGamepadInstanceProduct
  */
-extern DECLSPEC Uint16 SDLCALL SDL_GetGamepadProduct(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_RETURN Uint16 SDLCALL SDL_GetGamepadProduct(SDL_Gamepad *gamepad);
 
 /**
  * Get the product version of an opened gamepad, if available.
@@ -862,7 +862,7 @@ extern DECLSPEC Uint16 SDLCALL SDL_GetGamepadProduct(SDL_Gamepad *gamepad);
  *
  * \sa SDL_GetGamepadInstanceProductVersion
  */
-extern DECLSPEC Uint16 SDLCALL SDL_GetGamepadProductVersion(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_RETURN Uint16 SDLCALL SDL_GetGamepadProductVersion(SDL_Gamepad *gamepad);
 
 /**
  * Get the firmware version of an opened gamepad, if available.
@@ -874,7 +874,7 @@ extern DECLSPEC Uint16 SDLCALL SDL_GetGamepadProductVersion(SDL_Gamepad *gamepad
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC Uint16 SDLCALL SDL_GetGamepadFirmwareVersion(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_RETURN Uint16 SDLCALL SDL_GetGamepadFirmwareVersion(SDL_Gamepad *gamepad);
 
 /**
  * Get the serial number of an opened gamepad, if available.
@@ -886,7 +886,7 @@ extern DECLSPEC Uint16 SDLCALL SDL_GetGamepadFirmwareVersion(SDL_Gamepad *gamepa
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC const char * SDLCALL SDL_GetGamepadSerial(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_RETURN const char * SDLCALL SDL_GetGamepadSerial(SDL_Gamepad *gamepad);
 
 /**
  * Get the Steam Input handle of an opened gamepad, if available.
@@ -899,7 +899,7 @@ extern DECLSPEC const char * SDLCALL SDL_GetGamepadSerial(SDL_Gamepad *gamepad);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC Uint64 SDLCALL SDL_GetGamepadSteamHandle(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_RETURN Uint64 SDLCALL SDL_GetGamepadSteamHandle(SDL_Gamepad *gamepad);
 
 /**
  * Get the connection state of a gamepad.
@@ -911,7 +911,7 @@ extern DECLSPEC Uint64 SDLCALL SDL_GetGamepadSteamHandle(SDL_Gamepad *gamepad);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_JoystickConnectionState SDLCALL SDL_GetGamepadConnectionState(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_RETURN SDL_JoystickConnectionState SDLCALL SDL_GetGamepadConnectionState(SDL_Gamepad *gamepad);
 
 /**
  * Get the battery state of a gamepad.
@@ -931,7 +931,7 @@ extern DECLSPEC SDL_JoystickConnectionState SDLCALL SDL_GetGamepadConnectionStat
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_PowerState SDLCALL SDL_GetGamepadPowerInfo(SDL_Gamepad *gamepad, int *percent);
+extern SDL_DECLSPEC_RETURN SDL_PowerState SDLCALL SDL_GetGamepadPowerInfo(SDL_Gamepad *gamepad, int *percent);
 
 /**
  * Check if a gamepad has been opened and is currently connected.
@@ -943,7 +943,7 @@ extern DECLSPEC SDL_PowerState SDLCALL SDL_GetGamepadPowerInfo(SDL_Gamepad *game
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GamepadConnected(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GamepadConnected(SDL_Gamepad *gamepad);
 
 /**
  * Get the underlying joystick from a gamepad.
@@ -962,7 +962,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_GamepadConnected(SDL_Gamepad *gamepad);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_Joystick *SDLCALL SDL_GetGamepadJoystick(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_RETURN SDL_Joystick *SDLCALL SDL_GetGamepadJoystick(SDL_Gamepad *gamepad);
 
 /**
  * Set the state of gamepad event processing.
@@ -977,7 +977,7 @@ extern DECLSPEC SDL_Joystick *SDLCALL SDL_GetGamepadJoystick(SDL_Gamepad *gamepa
  * \sa SDL_GamepadEventsEnabled
  * \sa SDL_UpdateGamepads
  */
-extern DECLSPEC void SDLCALL SDL_SetGamepadEventsEnabled(SDL_bool enabled);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_SetGamepadEventsEnabled(SDL_bool enabled);
 
 /**
  * Query the state of gamepad event processing.
@@ -992,7 +992,7 @@ extern DECLSPEC void SDLCALL SDL_SetGamepadEventsEnabled(SDL_bool enabled);
  *
  * \sa SDL_SetGamepadEventsEnabled
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GamepadEventsEnabled(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GamepadEventsEnabled(void);
 
 /**
  * Get the SDL joystick layer bindings for a gamepad.
@@ -1005,7 +1005,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_GamepadEventsEnabled(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_GamepadBinding **SDLCALL SDL_GetGamepadBindings(SDL_Gamepad *gamepad, int *count);
+extern SDL_DECLSPEC_RETURN SDL_GamepadBinding **SDLCALL SDL_GetGamepadBindings(SDL_Gamepad *gamepad, int *count);
 
 /**
  * Manually pump gamepad updates if not using the loop.
@@ -1016,7 +1016,7 @@ extern DECLSPEC SDL_GamepadBinding **SDLCALL SDL_GetGamepadBindings(SDL_Gamepad 
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_UpdateGamepads(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_UpdateGamepads(void);
 
 /**
  * Convert a string into SDL_GamepadType enum.
@@ -1034,7 +1034,7 @@ extern DECLSPEC void SDLCALL SDL_UpdateGamepads(void);
  *
  * \sa SDL_GetGamepadStringForType
  */
-extern DECLSPEC SDL_GamepadType SDLCALL SDL_GetGamepadTypeFromString(const char *str);
+extern SDL_DECLSPEC_RETURN SDL_GamepadType SDLCALL SDL_GetGamepadTypeFromString(const char *str);
 
 /**
  * Convert from an SDL_GamepadType enum to a string.
@@ -1050,7 +1050,7 @@ extern DECLSPEC SDL_GamepadType SDLCALL SDL_GetGamepadTypeFromString(const char 
  *
  * \sa SDL_GetGamepadTypeFromString
  */
-extern DECLSPEC const char *SDLCALL SDL_GetGamepadStringForType(SDL_GamepadType type);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetGamepadStringForType(SDL_GamepadType type);
 
 /**
  * Convert a string into SDL_GamepadAxis enum.
@@ -1072,7 +1072,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetGamepadStringForType(SDL_GamepadType 
  *
  * \sa SDL_GetGamepadStringForAxis
  */
-extern DECLSPEC SDL_GamepadAxis SDLCALL SDL_GetGamepadAxisFromString(const char *str);
+extern SDL_DECLSPEC_RETURN SDL_GamepadAxis SDLCALL SDL_GetGamepadAxisFromString(const char *str);
 
 /**
  * Convert from an SDL_GamepadAxis enum to a string.
@@ -1088,7 +1088,7 @@ extern DECLSPEC SDL_GamepadAxis SDLCALL SDL_GetGamepadAxisFromString(const char 
  *
  * \sa SDL_GetGamepadAxisFromString
  */
-extern DECLSPEC const char * SDLCALL SDL_GetGamepadStringForAxis(SDL_GamepadAxis axis);
+extern SDL_DECLSPEC_RETURN const char * SDLCALL SDL_GetGamepadStringForAxis(SDL_GamepadAxis axis);
 
 /**
  * Query whether a gamepad has a given axis.
@@ -1105,7 +1105,7 @@ extern DECLSPEC const char * SDLCALL SDL_GetGamepadStringForAxis(SDL_GamepadAxis
  * \sa SDL_GamepadHasButton
  * \sa SDL_GetGamepadAxis
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GamepadHasAxis(SDL_Gamepad *gamepad, SDL_GamepadAxis axis);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GamepadHasAxis(SDL_Gamepad *gamepad, SDL_GamepadAxis axis);
 
 /**
  * Get the current state of an axis control on a gamepad.
@@ -1129,7 +1129,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_GamepadHasAxis(SDL_Gamepad *gamepad, SDL_Ga
  * \sa SDL_GamepadHasAxis
  * \sa SDL_GetGamepadButton
  */
-extern DECLSPEC Sint16 SDLCALL SDL_GetGamepadAxis(SDL_Gamepad *gamepad, SDL_GamepadAxis axis);
+extern SDL_DECLSPEC_RETURN Sint16 SDLCALL SDL_GetGamepadAxis(SDL_Gamepad *gamepad, SDL_GamepadAxis axis);
 
 /**
  * Convert a string into an SDL_GamepadButton enum.
@@ -1147,7 +1147,7 @@ extern DECLSPEC Sint16 SDLCALL SDL_GetGamepadAxis(SDL_Gamepad *gamepad, SDL_Game
  *
  * \sa SDL_GetGamepadStringForButton
  */
-extern DECLSPEC SDL_GamepadButton SDLCALL SDL_GetGamepadButtonFromString(const char *str);
+extern SDL_DECLSPEC_RETURN SDL_GamepadButton SDLCALL SDL_GetGamepadButtonFromString(const char *str);
 
 /**
  * Convert from an SDL_GamepadButton enum to a string.
@@ -1163,7 +1163,7 @@ extern DECLSPEC SDL_GamepadButton SDLCALL SDL_GetGamepadButtonFromString(const c
  *
  * \sa SDL_GetGamepadButtonFromString
  */
-extern DECLSPEC const char* SDLCALL SDL_GetGamepadStringForButton(SDL_GamepadButton button);
+extern SDL_DECLSPEC_RETURN const char* SDLCALL SDL_GetGamepadStringForButton(SDL_GamepadButton button);
 
 /**
  * Query whether a gamepad has a given button.
@@ -1179,7 +1179,7 @@ extern DECLSPEC const char* SDLCALL SDL_GetGamepadStringForButton(SDL_GamepadBut
  *
  * \sa SDL_GamepadHasAxis
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GamepadHasButton(SDL_Gamepad *gamepad, SDL_GamepadButton button);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GamepadHasButton(SDL_Gamepad *gamepad, SDL_GamepadButton button);
 
 /**
  * Get the current state of a button on a gamepad.
@@ -1194,7 +1194,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_GamepadHasButton(SDL_Gamepad *gamepad, SDL_
  * \sa SDL_GamepadHasButton
  * \sa SDL_GetGamepadAxis
  */
-extern DECLSPEC Uint8 SDLCALL SDL_GetGamepadButton(SDL_Gamepad *gamepad, SDL_GamepadButton button);
+extern SDL_DECLSPEC_RETURN Uint8 SDLCALL SDL_GetGamepadButton(SDL_Gamepad *gamepad, SDL_GamepadButton button);
 
 /**
  * Get the label of a button on a gamepad.
@@ -1207,7 +1207,7 @@ extern DECLSPEC Uint8 SDLCALL SDL_GetGamepadButton(SDL_Gamepad *gamepad, SDL_Gam
  *
  * \sa SDL_GetGamepadButtonLabel
  */
-extern DECLSPEC SDL_GamepadButtonLabel SDLCALL SDL_GetGamepadButtonLabelForType(SDL_GamepadType type, SDL_GamepadButton button);
+extern SDL_DECLSPEC_RETURN SDL_GamepadButtonLabel SDLCALL SDL_GetGamepadButtonLabelForType(SDL_GamepadType type, SDL_GamepadButton button);
 
 /**
  * Get the label of a button on a gamepad.
@@ -1220,7 +1220,7 @@ extern DECLSPEC SDL_GamepadButtonLabel SDLCALL SDL_GetGamepadButtonLabelForType(
  *
  * \sa SDL_GetGamepadButtonLabelForType
  */
-extern DECLSPEC SDL_GamepadButtonLabel SDLCALL SDL_GetGamepadButtonLabel(SDL_Gamepad *gamepad, SDL_GamepadButton button);
+extern SDL_DECLSPEC_RETURN SDL_GamepadButtonLabel SDLCALL SDL_GetGamepadButtonLabel(SDL_Gamepad *gamepad, SDL_GamepadButton button);
 
 /**
  * Get the number of touchpads on a gamepad.
@@ -1232,7 +1232,7 @@ extern DECLSPEC SDL_GamepadButtonLabel SDLCALL SDL_GetGamepadButtonLabel(SDL_Gam
  *
  * \sa SDL_GetNumGamepadTouchpadFingers
  */
-extern DECLSPEC int SDLCALL SDL_GetNumGamepadTouchpads(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetNumGamepadTouchpads(SDL_Gamepad *gamepad);
 
 /**
  * Get the number of supported simultaneous fingers on a touchpad on a game
@@ -1247,7 +1247,7 @@ extern DECLSPEC int SDLCALL SDL_GetNumGamepadTouchpads(SDL_Gamepad *gamepad);
  * \sa SDL_GetGamepadTouchpadFinger
  * \sa SDL_GetNumGamepadTouchpads
  */
-extern DECLSPEC int SDLCALL SDL_GetNumGamepadTouchpadFingers(SDL_Gamepad *gamepad, int touchpad);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetNumGamepadTouchpadFingers(SDL_Gamepad *gamepad, int touchpad);
 
 /**
  * Get the current state of a finger on a touchpad on a gamepad.
@@ -1268,7 +1268,7 @@ extern DECLSPEC int SDLCALL SDL_GetNumGamepadTouchpadFingers(SDL_Gamepad *gamepa
  *
  * \sa SDL_GetNumGamepadTouchpadFingers
  */
-extern DECLSPEC int SDLCALL SDL_GetGamepadTouchpadFinger(SDL_Gamepad *gamepad, int touchpad, int finger, Uint8 *state, float *x, float *y, float *pressure);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetGamepadTouchpadFinger(SDL_Gamepad *gamepad, int touchpad, int finger, Uint8 *state, float *x, float *y, float *pressure);
 
 /**
  * Return whether a gamepad has a particular sensor.
@@ -1283,7 +1283,7 @@ extern DECLSPEC int SDLCALL SDL_GetGamepadTouchpadFinger(SDL_Gamepad *gamepad, i
  * \sa SDL_GetGamepadSensorDataRate
  * \sa SDL_SetGamepadSensorEnabled
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GamepadHasSensor(SDL_Gamepad *gamepad, SDL_SensorType type);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GamepadHasSensor(SDL_Gamepad *gamepad, SDL_SensorType type);
 
 /**
  * Set whether data reporting for a gamepad sensor is enabled.
@@ -1299,7 +1299,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_GamepadHasSensor(SDL_Gamepad *gamepad, SDL_
  * \sa SDL_GamepadHasSensor
  * \sa SDL_GamepadSensorEnabled
  */
-extern DECLSPEC int SDLCALL SDL_SetGamepadSensorEnabled(SDL_Gamepad *gamepad, SDL_SensorType type, SDL_bool enabled);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetGamepadSensorEnabled(SDL_Gamepad *gamepad, SDL_SensorType type, SDL_bool enabled);
 
 /**
  * Query whether sensor data reporting is enabled for a gamepad.
@@ -1312,7 +1312,7 @@ extern DECLSPEC int SDLCALL SDL_SetGamepadSensorEnabled(SDL_Gamepad *gamepad, SD
  *
  * \sa SDL_SetGamepadSensorEnabled
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GamepadSensorEnabled(SDL_Gamepad *gamepad, SDL_SensorType type);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GamepadSensorEnabled(SDL_Gamepad *gamepad, SDL_SensorType type);
 
 /**
  * Get the data rate (number of events per second) of a gamepad sensor.
@@ -1323,7 +1323,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_GamepadSensorEnabled(SDL_Gamepad *gamepad, 
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC float SDLCALL SDL_GetGamepadSensorDataRate(SDL_Gamepad *gamepad, SDL_SensorType type);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_GetGamepadSensorDataRate(SDL_Gamepad *gamepad, SDL_SensorType type);
 
 /**
  * Get the current state of a gamepad sensor.
@@ -1340,7 +1340,7 @@ extern DECLSPEC float SDLCALL SDL_GetGamepadSensorDataRate(SDL_Gamepad *gamepad,
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetGamepadSensorData(SDL_Gamepad *gamepad, SDL_SensorType type, float *data, int num_values);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetGamepadSensorData(SDL_Gamepad *gamepad, SDL_SensorType type, float *data, int num_values);
 
 /**
  * Start a rumble effect on a gamepad.
@@ -1361,7 +1361,7 @@ extern DECLSPEC int SDLCALL SDL_GetGamepadSensorData(SDL_Gamepad *gamepad, SDL_S
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_RumbleGamepad(SDL_Gamepad *gamepad, Uint16 low_frequency_rumble, Uint16 high_frequency_rumble, Uint32 duration_ms);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RumbleGamepad(SDL_Gamepad *gamepad, Uint16 low_frequency_rumble, Uint16 high_frequency_rumble, Uint32 duration_ms);
 
 /**
  * Start a rumble effect in the gamepad's triggers.
@@ -1389,7 +1389,7 @@ extern DECLSPEC int SDLCALL SDL_RumbleGamepad(SDL_Gamepad *gamepad, Uint16 low_f
  *
  * \sa SDL_RumbleGamepad
  */
-extern DECLSPEC int SDLCALL SDL_RumbleGamepadTriggers(SDL_Gamepad *gamepad, Uint16 left_rumble, Uint16 right_rumble, Uint32 duration_ms);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RumbleGamepadTriggers(SDL_Gamepad *gamepad, Uint16 left_rumble, Uint16 right_rumble, Uint32 duration_ms);
 
 /**
  * Update a gamepad's LED color.
@@ -1409,7 +1409,7 @@ extern DECLSPEC int SDLCALL SDL_RumbleGamepadTriggers(SDL_Gamepad *gamepad, Uint
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SetGamepadLED(SDL_Gamepad *gamepad, Uint8 red, Uint8 green, Uint8 blue);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetGamepadLED(SDL_Gamepad *gamepad, Uint8 red, Uint8 green, Uint8 blue);
 
 /**
  * Send a gamepad specific effect packet.
@@ -1422,7 +1422,7 @@ extern DECLSPEC int SDLCALL SDL_SetGamepadLED(SDL_Gamepad *gamepad, Uint8 red, U
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SendGamepadEffect(SDL_Gamepad *gamepad, const void *data, int size);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SendGamepadEffect(SDL_Gamepad *gamepad, const void *data, int size);
 
 /**
  * Close a gamepad previously opened with SDL_OpenGamepad().
@@ -1434,7 +1434,7 @@ extern DECLSPEC int SDLCALL SDL_SendGamepadEffect(SDL_Gamepad *gamepad, const vo
  *
  * \sa SDL_OpenGamepad
  */
-extern DECLSPEC void SDLCALL SDL_CloseGamepad(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_CloseGamepad(SDL_Gamepad *gamepad);
 
 /**
  * Return the sfSymbolsName for a given button on a gamepad on Apple
@@ -1448,7 +1448,7 @@ extern DECLSPEC void SDLCALL SDL_CloseGamepad(SDL_Gamepad *gamepad);
  *
  * \sa SDL_GetGamepadAppleSFSymbolsNameForAxis
  */
-extern DECLSPEC const char* SDLCALL SDL_GetGamepadAppleSFSymbolsNameForButton(SDL_Gamepad *gamepad, SDL_GamepadButton button);
+extern SDL_DECLSPEC_RETURN const char* SDLCALL SDL_GetGamepadAppleSFSymbolsNameForButton(SDL_Gamepad *gamepad, SDL_GamepadButton button);
 
 /**
  * Return the sfSymbolsName for a given axis on a gamepad on Apple platforms.
@@ -1461,7 +1461,7 @@ extern DECLSPEC const char* SDLCALL SDL_GetGamepadAppleSFSymbolsNameForButton(SD
  *
  * \sa SDL_GetGamepadAppleSFSymbolsNameForButton
  */
-extern DECLSPEC const char* SDLCALL SDL_GetGamepadAppleSFSymbolsNameForAxis(SDL_Gamepad *gamepad, SDL_GamepadAxis axis);
+extern SDL_DECLSPEC_RETURN const char* SDLCALL SDL_GetGamepadAppleSFSymbolsNameForAxis(SDL_Gamepad *gamepad, SDL_GamepadAxis axis);
 
 
 /* Ends C function definitions when using C++ */

--- a/include/SDL3/SDL_gamepad.h
+++ b/include/SDL3/SDL_gamepad.h
@@ -393,7 +393,7 @@ extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ReloadGamepadMappings(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern SDL_DECLSPEC_RETURN char ** SDLCALL SDL_GetGamepadMappings(int *count);
+extern SDL_DECLSPEC_NODISCARD char ** SDLCALL SDL_GetGamepadMappings(int *count);
 
 /**
  * Get the gamepad mapping string for a given GUID.
@@ -409,7 +409,7 @@ extern SDL_DECLSPEC_RETURN char ** SDLCALL SDL_GetGamepadMappings(int *count);
  * \sa SDL_GetJoystickInstanceGUID
  * \sa SDL_GetJoystickGUID
  */
-extern SDL_DECLSPEC_RETURN char * SDLCALL SDL_GetGamepadMappingForGUID(SDL_JoystickGUID guid);
+extern SDL_DECLSPEC_NODISCARD char * SDLCALL SDL_GetGamepadMappingForGUID(SDL_JoystickGUID guid);
 
 /**
  * Get the current mapping of a gamepad.
@@ -429,7 +429,7 @@ extern SDL_DECLSPEC_RETURN char * SDLCALL SDL_GetGamepadMappingForGUID(SDL_Joyst
  * \sa SDL_GetGamepadMappingForGUID
  * \sa SDL_SetGamepadMapping
  */
-extern SDL_DECLSPEC_RETURN char * SDLCALL SDL_GetGamepadMapping(SDL_Gamepad *gamepad);
+extern SDL_DECLSPEC_NODISCARD char * SDLCALL SDL_GetGamepadMapping(SDL_Gamepad *gamepad);
 
 /**
  * Set the current mapping of a joystick or gamepad.
@@ -473,7 +473,7 @@ extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasGamepad(void);
  * \sa SDL_HasGamepad
  * \sa SDL_OpenGamepad
  */
-extern SDL_DECLSPEC_RETURN SDL_JoystickID *SDLCALL SDL_GetGamepads(int *count);
+extern SDL_DECLSPEC_NODISCARD SDL_JoystickID *SDLCALL SDL_GetGamepads(int *count);
 
 /**
  * Check if the given joystick is supported by the gamepad interface.
@@ -650,7 +650,7 @@ extern SDL_DECLSPEC_RETURN SDL_GamepadType SDLCALL SDL_GetRealGamepadInstanceTyp
  * \sa SDL_GetGamepads
  * \sa SDL_GetGamepadMapping
  */
-extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_GetGamepadInstanceMapping(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_NODISCARD char *SDLCALL SDL_GetGamepadInstanceMapping(SDL_JoystickID instance_id);
 
 /**
  * Open a gamepad for use.
@@ -664,7 +664,7 @@ extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_GetGamepadInstanceMapping(SDL_Joyst
  * \sa SDL_CloseGamepad
  * \sa SDL_IsGamepad
  */
-extern SDL_DECLSPEC_RETURN SDL_Gamepad *SDLCALL SDL_OpenGamepad(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_NODISCARD SDL_Gamepad *SDLCALL SDL_OpenGamepad(SDL_JoystickID instance_id);
 
 /**
  * Get the SDL_Gamepad associated with a joystick instance ID, if it has been
@@ -1005,7 +1005,7 @@ extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GamepadEventsEnabled(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern SDL_DECLSPEC_RETURN SDL_GamepadBinding **SDLCALL SDL_GetGamepadBindings(SDL_Gamepad *gamepad, int *count);
+extern SDL_DECLSPEC_NODISCARD SDL_GamepadBinding **SDLCALL SDL_GetGamepadBindings(SDL_Gamepad *gamepad, int *count);
 
 /**
  * Manually pump gamepad updates if not using the loop.

--- a/include/SDL3/SDL_guid.h
+++ b/include/SDL3/SDL_guid.h
@@ -78,7 +78,7 @@ typedef struct SDL_GUID {
  *
  * \sa SDL_GUIDFromString
  */
-extern DECLSPEC int SDLCALL SDL_GUIDToString(SDL_GUID guid, char *pszGUID, int cbGUID);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GUIDToString(SDL_GUID guid, char *pszGUID, int cbGUID);
 
 /**
  * Convert a GUID string into a SDL_GUID structure.
@@ -94,7 +94,7 @@ extern DECLSPEC int SDLCALL SDL_GUIDToString(SDL_GUID guid, char *pszGUID, int c
  *
  * \sa SDL_GUIDToString
  */
-extern DECLSPEC SDL_GUID SDLCALL SDL_GUIDFromString(const char *pchGUID);
+extern SDL_DECLSPEC_RETURN SDL_GUID SDLCALL SDL_GUIDFromString(const char *pchGUID);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_haptic.h
+++ b/include/SDL3/SDL_haptic.h
@@ -941,7 +941,7 @@ typedef Uint32 SDL_HapticID;
  *
  * \sa SDL_OpenHaptic
  */
-extern SDL_DECLSPEC_RETURN SDL_HapticID *SDLCALL SDL_GetHaptics(int *count);
+extern SDL_DECLSPEC_NODISCARD SDL_HapticID *SDLCALL SDL_GetHaptics(int *count);
 
 /**
  * Get the implementation dependent name of a haptic device.
@@ -983,7 +983,7 @@ extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetHapticInstanceName(SDL_Hap
  * \sa SDL_SetHapticAutocenter
  * \sa SDL_SetHapticGain
  */
-extern SDL_DECLSPEC_RETURN SDL_Haptic *SDLCALL SDL_OpenHaptic(SDL_HapticID instance_id);
+extern SDL_DECLSPEC_NODISCARD SDL_Haptic *SDLCALL SDL_OpenHaptic(SDL_HapticID instance_id);
 
 
 /**
@@ -1044,7 +1044,7 @@ extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_IsMouseHaptic(void);
  * \sa SDL_CloseHaptic
  * \sa SDL_IsMouseHaptic
  */
-extern SDL_DECLSPEC_RETURN SDL_Haptic *SDLCALL SDL_OpenHapticFromMouse(void);
+extern SDL_DECLSPEC_NODISCARD SDL_Haptic *SDLCALL SDL_OpenHapticFromMouse(void);
 
 /**
  * Query if a joystick has haptic features.
@@ -1078,7 +1078,7 @@ extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_IsJoystickHaptic(SDL_Joystick *j
  * \sa SDL_CloseHaptic
  * \sa SDL_IsJoystickHaptic
  */
-extern SDL_DECLSPEC_RETURN SDL_Haptic *SDLCALL SDL_OpenHapticFromJoystick(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_NODISCARD SDL_Haptic *SDLCALL SDL_OpenHapticFromJoystick(SDL_Joystick *joystick);
 
 /**
  * Close a haptic device previously opened with SDL_OpenHaptic().
@@ -1183,7 +1183,7 @@ extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HapticEffectSupported(SDL_Haptic
  * \sa SDL_RunHapticEffect
  * \sa SDL_UpdateHapticEffect
  */
-extern SDL_DECLSPEC_RETURN int SDLCALL SDL_CreateHapticEffect(SDL_Haptic *haptic, const SDL_HapticEffect *effect);
+extern SDL_DECLSPEC_NODISCARD int SDLCALL SDL_CreateHapticEffect(SDL_Haptic *haptic, const SDL_HapticEffect *effect);
 
 /**
  * Update the properties of an effect.

--- a/include/SDL3/SDL_haptic.h
+++ b/include/SDL3/SDL_haptic.h
@@ -941,7 +941,7 @@ typedef Uint32 SDL_HapticID;
  *
  * \sa SDL_OpenHaptic
  */
-extern DECLSPEC SDL_HapticID *SDLCALL SDL_GetHaptics(int *count);
+extern SDL_DECLSPEC_RETURN SDL_HapticID *SDLCALL SDL_GetHaptics(int *count);
 
 /**
  * Get the implementation dependent name of a haptic device.
@@ -958,7 +958,7 @@ extern DECLSPEC SDL_HapticID *SDLCALL SDL_GetHaptics(int *count);
  * \sa SDL_GetHapticName
  * \sa SDL_OpenHaptic
  */
-extern DECLSPEC const char *SDLCALL SDL_GetHapticInstanceName(SDL_HapticID instance_id);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetHapticInstanceName(SDL_HapticID instance_id);
 
 /**
  * Open a haptic device for use.
@@ -983,7 +983,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetHapticInstanceName(SDL_HapticID insta
  * \sa SDL_SetHapticAutocenter
  * \sa SDL_SetHapticGain
  */
-extern DECLSPEC SDL_Haptic *SDLCALL SDL_OpenHaptic(SDL_HapticID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_Haptic *SDLCALL SDL_OpenHaptic(SDL_HapticID instance_id);
 
 
 /**
@@ -995,7 +995,7 @@ extern DECLSPEC SDL_Haptic *SDLCALL SDL_OpenHaptic(SDL_HapticID instance_id);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_Haptic *SDLCALL SDL_GetHapticFromInstanceID(SDL_HapticID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_Haptic *SDLCALL SDL_GetHapticFromInstanceID(SDL_HapticID instance_id);
 
 /**
  * Get the instance ID of an opened haptic device.
@@ -1006,7 +1006,7 @@ extern DECLSPEC SDL_Haptic *SDLCALL SDL_GetHapticFromInstanceID(SDL_HapticID ins
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_HapticID SDLCALL SDL_GetHapticInstanceID(SDL_Haptic *haptic);
+extern SDL_DECLSPEC_RETURN SDL_HapticID SDLCALL SDL_GetHapticInstanceID(SDL_Haptic *haptic);
 
 /**
  * Get the implementation dependent name of a haptic device.
@@ -1020,7 +1020,7 @@ extern DECLSPEC SDL_HapticID SDLCALL SDL_GetHapticInstanceID(SDL_Haptic *haptic)
  *
  * \sa SDL_GetHapticInstanceName
  */
-extern DECLSPEC const char *SDLCALL SDL_GetHapticName(SDL_Haptic *haptic);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetHapticName(SDL_Haptic *haptic);
 
 /**
  * Query whether or not the current mouse has haptic capabilities.
@@ -1031,7 +1031,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetHapticName(SDL_Haptic *haptic);
  *
  * \sa SDL_OpenHapticFromMouse
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_IsMouseHaptic(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_IsMouseHaptic(void);
 
 /**
  * Try to open a haptic device from the current mouse.
@@ -1044,7 +1044,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_IsMouseHaptic(void);
  * \sa SDL_CloseHaptic
  * \sa SDL_IsMouseHaptic
  */
-extern DECLSPEC SDL_Haptic *SDLCALL SDL_OpenHapticFromMouse(void);
+extern SDL_DECLSPEC_RETURN SDL_Haptic *SDLCALL SDL_OpenHapticFromMouse(void);
 
 /**
  * Query if a joystick has haptic features.
@@ -1056,7 +1056,7 @@ extern DECLSPEC SDL_Haptic *SDLCALL SDL_OpenHapticFromMouse(void);
  *
  * \sa SDL_OpenHapticFromJoystick
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_IsJoystickHaptic(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_IsJoystickHaptic(SDL_Joystick *joystick);
 
 /**
  * Open a haptic device for use from a joystick device.
@@ -1078,7 +1078,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_IsJoystickHaptic(SDL_Joystick *joystick);
  * \sa SDL_CloseHaptic
  * \sa SDL_IsJoystickHaptic
  */
-extern DECLSPEC SDL_Haptic *SDLCALL SDL_OpenHapticFromJoystick(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN SDL_Haptic *SDLCALL SDL_OpenHapticFromJoystick(SDL_Joystick *joystick);
 
 /**
  * Close a haptic device previously opened with SDL_OpenHaptic().
@@ -1089,7 +1089,7 @@ extern DECLSPEC SDL_Haptic *SDLCALL SDL_OpenHapticFromJoystick(SDL_Joystick *joy
  *
  * \sa SDL_OpenHaptic
  */
-extern DECLSPEC void SDLCALL SDL_CloseHaptic(SDL_Haptic *haptic);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_CloseHaptic(SDL_Haptic *haptic);
 
 /**
  * Get the number of effects a haptic device can store.
@@ -1107,7 +1107,7 @@ extern DECLSPEC void SDLCALL SDL_CloseHaptic(SDL_Haptic *haptic);
  * \sa SDL_GetMaxHapticEffectsPlaying
  * \sa SDL_GetHapticFeatures
  */
-extern DECLSPEC int SDLCALL SDL_GetMaxHapticEffects(SDL_Haptic *haptic);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetMaxHapticEffects(SDL_Haptic *haptic);
 
 /**
  * Get the number of effects a haptic device can play at the same time.
@@ -1124,7 +1124,7 @@ extern DECLSPEC int SDLCALL SDL_GetMaxHapticEffects(SDL_Haptic *haptic);
  * \sa SDL_GetMaxHapticEffects
  * \sa SDL_GetHapticFeatures
  */
-extern DECLSPEC int SDLCALL SDL_GetMaxHapticEffectsPlaying(SDL_Haptic *haptic);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetMaxHapticEffectsPlaying(SDL_Haptic *haptic);
 
 /**
  * Get the haptic device's supported features in bitwise manner.
@@ -1138,7 +1138,7 @@ extern DECLSPEC int SDLCALL SDL_GetMaxHapticEffectsPlaying(SDL_Haptic *haptic);
  * \sa SDL_HapticEffectSupported
  * \sa SDL_GetMaxHapticEffects
  */
-extern DECLSPEC Uint32 SDLCALL SDL_GetHapticFeatures(SDL_Haptic *haptic);
+extern SDL_DECLSPEC_RETURN Uint32 SDLCALL SDL_GetHapticFeatures(SDL_Haptic *haptic);
 
 /**
  * Get the number of haptic axes the device has.
@@ -1152,7 +1152,7 @@ extern DECLSPEC Uint32 SDLCALL SDL_GetHapticFeatures(SDL_Haptic *haptic);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetNumHapticAxes(SDL_Haptic *haptic);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetNumHapticAxes(SDL_Haptic *haptic);
 
 /**
  * Check to see if an effect is supported by a haptic device.
@@ -1166,7 +1166,7 @@ extern DECLSPEC int SDLCALL SDL_GetNumHapticAxes(SDL_Haptic *haptic);
  * \sa SDL_CreateHapticEffect
  * \sa SDL_GetHapticFeatures
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HapticEffectSupported(SDL_Haptic *haptic, const SDL_HapticEffect *effect);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HapticEffectSupported(SDL_Haptic *haptic, const SDL_HapticEffect *effect);
 
 /**
  * Create a new haptic effect on a specified device.
@@ -1183,7 +1183,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HapticEffectSupported(SDL_Haptic *haptic, c
  * \sa SDL_RunHapticEffect
  * \sa SDL_UpdateHapticEffect
  */
-extern DECLSPEC int SDLCALL SDL_CreateHapticEffect(SDL_Haptic *haptic, const SDL_HapticEffect *effect);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_CreateHapticEffect(SDL_Haptic *haptic, const SDL_HapticEffect *effect);
 
 /**
  * Update the properties of an effect.
@@ -1205,7 +1205,7 @@ extern DECLSPEC int SDLCALL SDL_CreateHapticEffect(SDL_Haptic *haptic, const SDL
  * \sa SDL_CreateHapticEffect
  * \sa SDL_RunHapticEffect
  */
-extern DECLSPEC int SDLCALL SDL_UpdateHapticEffect(SDL_Haptic *haptic, int effect, const SDL_HapticEffect *data);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_UpdateHapticEffect(SDL_Haptic *haptic, int effect, const SDL_HapticEffect *data);
 
 /**
  * Run the haptic effect on its associated haptic device.
@@ -1229,7 +1229,7 @@ extern DECLSPEC int SDLCALL SDL_UpdateHapticEffect(SDL_Haptic *haptic, int effec
  * \sa SDL_StopHapticEffect
  * \sa SDL_StopHapticEffects
  */
-extern DECLSPEC int SDLCALL SDL_RunHapticEffect(SDL_Haptic *haptic, int effect, Uint32 iterations);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RunHapticEffect(SDL_Haptic *haptic, int effect, Uint32 iterations);
 
 /**
  * Stop the haptic effect on its associated haptic device.
@@ -1244,7 +1244,7 @@ extern DECLSPEC int SDLCALL SDL_RunHapticEffect(SDL_Haptic *haptic, int effect, 
  * \sa SDL_RunHapticEffect
  * \sa SDL_StopHapticEffects
  */
-extern DECLSPEC int SDLCALL SDL_StopHapticEffect(SDL_Haptic *haptic, int effect);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_StopHapticEffect(SDL_Haptic *haptic, int effect);
 
 /**
  * Destroy a haptic effect on the device.
@@ -1259,7 +1259,7 @@ extern DECLSPEC int SDLCALL SDL_StopHapticEffect(SDL_Haptic *haptic, int effect)
  *
  * \sa SDL_CreateHapticEffect
  */
-extern DECLSPEC void SDLCALL SDL_DestroyHapticEffect(SDL_Haptic *haptic, int effect);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_DestroyHapticEffect(SDL_Haptic *haptic, int effect);
 
 /**
  * Get the status of the current effect on the specified haptic device.
@@ -1273,7 +1273,7 @@ extern DECLSPEC void SDLCALL SDL_DestroyHapticEffect(SDL_Haptic *haptic, int eff
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetHapticEffectStatus(SDL_Haptic *haptic, int effect);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetHapticEffectStatus(SDL_Haptic *haptic, int effect);
 
 /**
  * Set the global gain of the specified haptic device.
@@ -1294,7 +1294,7 @@ extern DECLSPEC int SDLCALL SDL_GetHapticEffectStatus(SDL_Haptic *haptic, int ef
  *
  * \sa SDL_GetHapticFeatures
  */
-extern DECLSPEC int SDLCALL SDL_SetHapticGain(SDL_Haptic *haptic, int gain);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetHapticGain(SDL_Haptic *haptic, int gain);
 
 /**
  * Set the global autocenter of the device.
@@ -1313,7 +1313,7 @@ extern DECLSPEC int SDLCALL SDL_SetHapticGain(SDL_Haptic *haptic, int gain);
  *
  * \sa SDL_GetHapticFeatures
  */
-extern DECLSPEC int SDLCALL SDL_SetHapticAutocenter(SDL_Haptic *haptic, int autocenter);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetHapticAutocenter(SDL_Haptic *haptic, int autocenter);
 
 /**
  * Pause a haptic device.
@@ -1332,7 +1332,7 @@ extern DECLSPEC int SDLCALL SDL_SetHapticAutocenter(SDL_Haptic *haptic, int auto
  *
  * \sa SDL_ResumeHaptic
  */
-extern DECLSPEC int SDLCALL SDL_PauseHaptic(SDL_Haptic *haptic);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_PauseHaptic(SDL_Haptic *haptic);
 
 /**
  * Resume a haptic device.
@@ -1347,7 +1347,7 @@ extern DECLSPEC int SDLCALL SDL_PauseHaptic(SDL_Haptic *haptic);
  *
  * \sa SDL_PauseHaptic
  */
-extern DECLSPEC int SDLCALL SDL_ResumeHaptic(SDL_Haptic *haptic);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ResumeHaptic(SDL_Haptic *haptic);
 
 /**
  * Stop all the currently playing effects on a haptic device.
@@ -1361,7 +1361,7 @@ extern DECLSPEC int SDLCALL SDL_ResumeHaptic(SDL_Haptic *haptic);
  * \sa SDL_RunHapticEffect
  * \sa SDL_StopHapticEffects
  */
-extern DECLSPEC int SDLCALL SDL_StopHapticEffects(SDL_Haptic *haptic);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_StopHapticEffects(SDL_Haptic *haptic);
 
 /**
  * Check whether rumble is supported on a haptic device.
@@ -1373,7 +1373,7 @@ extern DECLSPEC int SDLCALL SDL_StopHapticEffects(SDL_Haptic *haptic);
  *
  * \sa SDL_InitHapticRumble
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HapticRumbleSupported(SDL_Haptic *haptic);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HapticRumbleSupported(SDL_Haptic *haptic);
 
 /**
  * Initialize a haptic device for simple rumble playback.
@@ -1388,7 +1388,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HapticRumbleSupported(SDL_Haptic *haptic);
  * \sa SDL_StopHapticRumble
  * \sa SDL_HapticRumbleSupported
  */
-extern DECLSPEC int SDLCALL SDL_InitHapticRumble(SDL_Haptic *haptic);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_InitHapticRumble(SDL_Haptic *haptic);
 
 /**
  * Run a simple rumble effect on a haptic device.
@@ -1404,7 +1404,7 @@ extern DECLSPEC int SDLCALL SDL_InitHapticRumble(SDL_Haptic *haptic);
  * \sa SDL_InitHapticRumble
  * \sa SDL_StopHapticRumble
  */
-extern DECLSPEC int SDLCALL SDL_PlayHapticRumble(SDL_Haptic *haptic, float strength, Uint32 length);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_PlayHapticRumble(SDL_Haptic *haptic, float strength, Uint32 length);
 
 /**
  * Stop the simple rumble on a haptic device.
@@ -1417,7 +1417,7 @@ extern DECLSPEC int SDLCALL SDL_PlayHapticRumble(SDL_Haptic *haptic, float stren
  *
  * \sa SDL_PlayHapticRumble
  */
-extern DECLSPEC int SDLCALL SDL_StopHapticRumble(SDL_Haptic *haptic);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_StopHapticRumble(SDL_Haptic *haptic);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_hidapi.h
+++ b/include/SDL3/SDL_hidapi.h
@@ -188,7 +188,7 @@ typedef struct SDL_hid_device_info
  *
  * \sa SDL_hid_exit
  */
-extern DECLSPEC int SDLCALL SDL_hid_init(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_hid_init(void);
 
 /**
  * Finalize the HIDAPI library.
@@ -203,7 +203,7 @@ extern DECLSPEC int SDLCALL SDL_hid_init(void);
  *
  * \sa SDL_hid_init
  */
-extern DECLSPEC int SDLCALL SDL_hid_exit(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_hid_exit(void);
 
 /**
  * Check to see if devices may have been added or removed.
@@ -224,7 +224,7 @@ extern DECLSPEC int SDLCALL SDL_hid_exit(void);
  *
  * \sa SDL_hid_enumerate
  */
-extern DECLSPEC Uint32 SDLCALL SDL_hid_device_change_count(void);
+extern SDL_DECLSPEC_RETURN Uint32 SDLCALL SDL_hid_device_change_count(void);
 
 /**
  * Enumerate the HID Devices.
@@ -252,7 +252,7 @@ extern DECLSPEC Uint32 SDLCALL SDL_hid_device_change_count(void);
  *
  * \sa SDL_hid_device_change_count
  */
-extern DECLSPEC SDL_hid_device_info * SDLCALL SDL_hid_enumerate(unsigned short vendor_id, unsigned short product_id);
+extern SDL_DECLSPEC_RETURN SDL_hid_device_info * SDLCALL SDL_hid_enumerate(unsigned short vendor_id, unsigned short product_id);
 
 /**
  * Free an enumeration linked list.
@@ -264,7 +264,7 @@ extern DECLSPEC SDL_hid_device_info * SDLCALL SDL_hid_enumerate(unsigned short v
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_hid_free_enumeration(SDL_hid_device_info *devs);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_hid_free_enumeration(SDL_hid_device_info *devs);
 
 /**
  * Open a HID device using a Vendor ID (VID), Product ID (PID) and optionally
@@ -282,7 +282,7 @@ extern DECLSPEC void SDLCALL SDL_hid_free_enumeration(SDL_hid_device_info *devs)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_hid_device * SDLCALL SDL_hid_open(unsigned short vendor_id, unsigned short product_id, const wchar_t *serial_number);
+extern SDL_DECLSPEC_RETURN SDL_hid_device * SDLCALL SDL_hid_open(unsigned short vendor_id, unsigned short product_id, const wchar_t *serial_number);
 
 /**
  * Open a HID device by its path name.
@@ -296,7 +296,7 @@ extern DECLSPEC SDL_hid_device * SDLCALL SDL_hid_open(unsigned short vendor_id, 
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_hid_device * SDLCALL SDL_hid_open_path(const char *path);
+extern SDL_DECLSPEC_RETURN SDL_hid_device * SDLCALL SDL_hid_open_path(const char *path);
 
 /**
  * Write an Output report to a HID device.
@@ -322,7 +322,7 @@ extern DECLSPEC SDL_hid_device * SDLCALL SDL_hid_open_path(const char *path);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_hid_write(SDL_hid_device *dev, const unsigned char *data, size_t length);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_hid_write(SDL_hid_device *dev, const unsigned char *data, size_t length);
 
 /**
  * Read an Input report from a HID device with timeout.
@@ -343,7 +343,7 @@ extern DECLSPEC int SDLCALL SDL_hid_write(SDL_hid_device *dev, const unsigned ch
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_hid_read_timeout(SDL_hid_device *dev, unsigned char *data, size_t length, int milliseconds);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_hid_read_timeout(SDL_hid_device *dev, unsigned char *data, size_t length, int milliseconds);
 
 /**
  * Read an Input report from a HID device.
@@ -363,7 +363,7 @@ extern DECLSPEC int SDLCALL SDL_hid_read_timeout(SDL_hid_device *dev, unsigned c
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_hid_read(SDL_hid_device *dev, unsigned char *data, size_t length);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_hid_read(SDL_hid_device *dev, unsigned char *data, size_t length);
 
 /**
  * Set the device handle to be non-blocking.
@@ -382,7 +382,7 @@ extern DECLSPEC int SDLCALL SDL_hid_read(SDL_hid_device *dev, unsigned char *dat
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_hid_set_nonblocking(SDL_hid_device *dev, int nonblock);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_hid_set_nonblocking(SDL_hid_device *dev, int nonblock);
 
 /**
  * Send a Feature report to the device.
@@ -406,7 +406,7 @@ extern DECLSPEC int SDLCALL SDL_hid_set_nonblocking(SDL_hid_device *dev, int non
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_hid_send_feature_report(SDL_hid_device *dev, const unsigned char *data, size_t length);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_hid_send_feature_report(SDL_hid_device *dev, const unsigned char *data, size_t length);
 
 /**
  * Get a feature report from a HID device.
@@ -428,7 +428,7 @@ extern DECLSPEC int SDLCALL SDL_hid_send_feature_report(SDL_hid_device *dev, con
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_hid_get_feature_report(SDL_hid_device *dev, unsigned char *data, size_t length);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_hid_get_feature_report(SDL_hid_device *dev, unsigned char *data, size_t length);
 
 /**
  * Get an input report from a HID device.
@@ -450,7 +450,7 @@ extern DECLSPEC int SDLCALL SDL_hid_get_feature_report(SDL_hid_device *dev, unsi
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_hid_get_input_report(SDL_hid_device *dev, unsigned char *data, size_t length);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_hid_get_input_report(SDL_hid_device *dev, unsigned char *data, size_t length);
 
 /**
  * Close a HID device.
@@ -461,7 +461,7 @@ extern DECLSPEC int SDLCALL SDL_hid_get_input_report(SDL_hid_device *dev, unsign
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_hid_close(SDL_hid_device *dev);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_hid_close(SDL_hid_device *dev);
 
 /**
  * Get The Manufacturer String from a HID device.
@@ -474,7 +474,7 @@ extern DECLSPEC int SDLCALL SDL_hid_close(SDL_hid_device *dev);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_hid_get_manufacturer_string(SDL_hid_device *dev, wchar_t *string, size_t maxlen);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_hid_get_manufacturer_string(SDL_hid_device *dev, wchar_t *string, size_t maxlen);
 
 /**
  * Get The Product String from a HID device.
@@ -487,7 +487,7 @@ extern DECLSPEC int SDLCALL SDL_hid_get_manufacturer_string(SDL_hid_device *dev,
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_hid_get_product_string(SDL_hid_device *dev, wchar_t *string, size_t maxlen);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_hid_get_product_string(SDL_hid_device *dev, wchar_t *string, size_t maxlen);
 
 /**
  * Get The Serial Number String from a HID device.
@@ -500,7 +500,7 @@ extern DECLSPEC int SDLCALL SDL_hid_get_product_string(SDL_hid_device *dev, wcha
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_hid_get_serial_number_string(SDL_hid_device *dev, wchar_t *string, size_t maxlen);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_hid_get_serial_number_string(SDL_hid_device *dev, wchar_t *string, size_t maxlen);
 
 /**
  * Get a string from a HID device, based on its string index.
@@ -514,7 +514,7 @@ extern DECLSPEC int SDLCALL SDL_hid_get_serial_number_string(SDL_hid_device *dev
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_hid_get_indexed_string(SDL_hid_device *dev, int string_index, wchar_t *string, size_t maxlen);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_hid_get_indexed_string(SDL_hid_device *dev, int string_index, wchar_t *string, size_t maxlen);
 
 /**
  * Get the device info from a HID device.
@@ -527,7 +527,7 @@ extern DECLSPEC int SDLCALL SDL_hid_get_indexed_string(SDL_hid_device *dev, int 
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_hid_device_info * SDLCALL SDL_hid_get_device_info(SDL_hid_device *dev);
+extern SDL_DECLSPEC_RETURN SDL_hid_device_info * SDLCALL SDL_hid_get_device_info(SDL_hid_device *dev);
 
 /**
  * Get a report descriptor from a HID device.
@@ -543,7 +543,7 @@ extern DECLSPEC SDL_hid_device_info * SDLCALL SDL_hid_get_device_info(SDL_hid_de
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_hid_get_report_descriptor(SDL_hid_device *dev, unsigned char *buf, size_t buf_size);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_hid_get_report_descriptor(SDL_hid_device *dev, unsigned char *buf, size_t buf_size);
 
 /**
  * Start or stop a BLE scan on iOS and tvOS to pair Steam Controllers.
@@ -552,7 +552,7 @@ extern DECLSPEC int SDLCALL SDL_hid_get_report_descriptor(SDL_hid_device *dev, u
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_hid_ble_scan(SDL_bool active);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_hid_ble_scan(SDL_bool active);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -3749,7 +3749,7 @@ typedef enum SDL_HintPriority
  * \sa SDL_ResetHint
  * \sa SDL_SetHint
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_SetHintWithPriority(const char *name,
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_SetHintWithPriority(const char *name,
                                                          const char *value,
                                                          SDL_HintPriority priority);
 
@@ -3770,7 +3770,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_SetHintWithPriority(const char *name,
  * \sa SDL_ResetHint
  * \sa SDL_SetHintWithPriority
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_SetHint(const char *name,
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_SetHint(const char *name,
                                              const char *value);
 
 /**
@@ -3788,7 +3788,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_SetHint(const char *name,
  * \sa SDL_SetHint
  * \sa SDL_ResetHints
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_ResetHint(const char *name);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_ResetHint(const char *name);
 
 /**
  * Reset all hints to the default values.
@@ -3801,7 +3801,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_ResetHint(const char *name);
  *
  * \sa SDL_ResetHint
  */
-extern DECLSPEC void SDLCALL SDL_ResetHints(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_ResetHints(void);
 
 /**
  * Get the value of a hint.
@@ -3814,7 +3814,7 @@ extern DECLSPEC void SDLCALL SDL_ResetHints(void);
  * \sa SDL_SetHint
  * \sa SDL_SetHintWithPriority
  */
-extern DECLSPEC const char * SDLCALL SDL_GetHint(const char *name);
+extern SDL_DECLSPEC_RETURN const char * SDLCALL SDL_GetHint(const char *name);
 
 /**
  * Get the boolean value of a hint variable.
@@ -3829,7 +3829,7 @@ extern DECLSPEC const char * SDLCALL SDL_GetHint(const char *name);
  * \sa SDL_GetHint
  * \sa SDL_SetHint
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GetHintBoolean(const char *name, SDL_bool default_value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GetHintBoolean(const char *name, SDL_bool default_value);
 
 /**
  * Type definition of the hint callback function.
@@ -3857,7 +3857,7 @@ typedef void (SDLCALL *SDL_HintCallback)(void *userdata, const char *name, const
  *
  * \sa SDL_DelHintCallback
  */
-extern DECLSPEC int SDLCALL SDL_AddHintCallback(const char *name,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_AddHintCallback(const char *name,
                                                 SDL_HintCallback callback,
                                                 void *userdata);
 
@@ -3873,7 +3873,7 @@ extern DECLSPEC int SDLCALL SDL_AddHintCallback(const char *name,
  *
  * \sa SDL_AddHintCallback
  */
-extern DECLSPEC void SDLCALL SDL_DelHintCallback(const char *name,
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_DelHintCallback(const char *name,
                                                  SDL_HintCallback callback,
                                                  void *userdata);
 

--- a/include/SDL3/SDL_init.h
+++ b/include/SDL3/SDL_init.h
@@ -116,7 +116,7 @@ typedef Uint32 SDL_InitFlags;
  * \sa SDL_SetMainReady
  * \sa SDL_WasInit
  */
-extern DECLSPEC int SDLCALL SDL_Init(SDL_InitFlags flags);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_Init(SDL_InitFlags flags);
 
 /**
  * Compatibility function to initialize the SDL library.
@@ -133,7 +133,7 @@ extern DECLSPEC int SDLCALL SDL_Init(SDL_InitFlags flags);
  * \sa SDL_Quit
  * \sa SDL_QuitSubSystem
  */
-extern DECLSPEC int SDLCALL SDL_InitSubSystem(SDL_InitFlags flags);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_InitSubSystem(SDL_InitFlags flags);
 
 /**
  * Shut down specific SDL subsystems.
@@ -148,7 +148,7 @@ extern DECLSPEC int SDLCALL SDL_InitSubSystem(SDL_InitFlags flags);
  * \sa SDL_InitSubSystem
  * \sa SDL_Quit
  */
-extern DECLSPEC void SDLCALL SDL_QuitSubSystem(SDL_InitFlags flags);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_QuitSubSystem(SDL_InitFlags flags);
 
 /**
  * Get a mask of the specified subsystems which are currently initialized.
@@ -162,7 +162,7 @@ extern DECLSPEC void SDLCALL SDL_QuitSubSystem(SDL_InitFlags flags);
  * \sa SDL_Init
  * \sa SDL_InitSubSystem
  */
-extern DECLSPEC SDL_InitFlags SDLCALL SDL_WasInit(SDL_InitFlags flags);
+extern SDL_DECLSPEC_RETURN SDL_InitFlags SDLCALL SDL_WasInit(SDL_InitFlags flags);
 
 /**
  * Clean up all initialized subsystems.
@@ -180,7 +180,7 @@ extern DECLSPEC SDL_InitFlags SDLCALL SDL_WasInit(SDL_InitFlags flags);
  * \sa SDL_Init
  * \sa SDL_QuitSubSystem
  */
-extern DECLSPEC void SDLCALL SDL_Quit(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_Quit(void);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_iostream.h
+++ b/include/SDL3/SDL_iostream.h
@@ -216,7 +216,7 @@ typedef struct SDL_IOStream SDL_IOStream;
  * \sa SDL_TellIO
  * \sa SDL_WriteIO
  */
-extern DECLSPEC SDL_IOStream *SDLCALL SDL_IOFromFile(const char *file, const char *mode);
+extern SDL_DECLSPEC_RETURN SDL_IOStream *SDLCALL SDL_IOFromFile(const char *file, const char *mode);
 
 #define SDL_PROP_IOSTREAM_WINDOWS_HANDLE_POINTER    "SDL.iostream.windows.handle"
 #define SDL_PROP_IOSTREAM_STDIO_FILE_POINTER        "SDL.iostream.stdio.file"
@@ -251,7 +251,7 @@ extern DECLSPEC SDL_IOStream *SDLCALL SDL_IOFromFile(const char *file, const cha
  * \sa SDL_TellIO
  * \sa SDL_WriteIO
  */
-extern DECLSPEC SDL_IOStream *SDLCALL SDL_IOFromMem(void *mem, size_t size);
+extern SDL_DECLSPEC_RETURN SDL_IOStream *SDLCALL SDL_IOFromMem(void *mem, size_t size);
 
 /**
  * Use this function to prepare a read-only memory buffer for use with
@@ -283,7 +283,7 @@ extern DECLSPEC SDL_IOStream *SDLCALL SDL_IOFromMem(void *mem, size_t size);
  * \sa SDL_SeekIO
  * \sa SDL_TellIO
  */
-extern DECLSPEC SDL_IOStream *SDLCALL SDL_IOFromConstMem(const void *mem, size_t size);
+extern SDL_DECLSPEC_RETURN SDL_IOStream *SDLCALL SDL_IOFromConstMem(const void *mem, size_t size);
 
 /**
  * Use this function to create an SDL_IOStream that is backed by dynamically
@@ -308,7 +308,7 @@ extern DECLSPEC SDL_IOStream *SDLCALL SDL_IOFromConstMem(const void *mem, size_t
  * \sa SDL_TellIO
  * \sa SDL_WriteIO
  */
-extern DECLSPEC SDL_IOStream *SDLCALL SDL_IOFromDynamicMem(void);
+extern SDL_DECLSPEC_RETURN SDL_IOStream *SDLCALL SDL_IOFromDynamicMem(void);
 
 #define SDL_PROP_IOSTREAM_DYNAMIC_MEMORY_POINTER    "SDL.iostream.dynamic.memory"
 #define SDL_PROP_IOSTREAM_DYNAMIC_CHUNKSIZE_NUMBER  "SDL.iostream.dynamic.chunksize"
@@ -342,7 +342,7 @@ extern DECLSPEC SDL_IOStream *SDLCALL SDL_IOFromDynamicMem(void);
  * \sa SDL_IOFromFile
  * \sa SDL_IOFromMem
  */
-extern DECLSPEC SDL_IOStream *SDLCALL SDL_OpenIO(const SDL_IOStreamInterface *iface, void *userdata);
+extern SDL_DECLSPEC_RETURN SDL_IOStream *SDLCALL SDL_OpenIO(const SDL_IOStreamInterface *iface, void *userdata);
 
 /**
  * Close and free an allocated SDL_IOStream structure.
@@ -363,7 +363,7 @@ extern DECLSPEC SDL_IOStream *SDLCALL SDL_OpenIO(const SDL_IOStreamInterface *if
  *
  * \sa SDL_OpenIO
  */
-extern DECLSPEC int SDLCALL SDL_CloseIO(SDL_IOStream *context);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_CloseIO(SDL_IOStream *context);
 
 /**
  * Get the properties associated with an SDL_IOStream.
@@ -377,7 +377,7 @@ extern DECLSPEC int SDLCALL SDL_CloseIO(SDL_IOStream *context);
  * \sa SDL_GetProperty
  * \sa SDL_SetProperty
  */
-extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetIOProperties(SDL_IOStream *context);
+extern SDL_DECLSPEC_RETURN SDL_PropertiesID SDLCALL SDL_GetIOProperties(SDL_IOStream *context);
 
 /* Possible `whence` values for SDL_IOStream seeking... */
 #define SDL_IO_SEEK_SET 0       /**< Seek from the beginning of data */
@@ -403,7 +403,7 @@ extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetIOProperties(SDL_IOStream *conte
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_IOStatus SDLCALL SDL_GetIOStatus(SDL_IOStream *context);
+extern SDL_DECLSPEC_RETURN SDL_IOStatus SDLCALL SDL_GetIOStatus(SDL_IOStream *context);
 
 /**
  * Use this function to get the size of the data stream in an SDL_IOStream.
@@ -415,7 +415,7 @@ extern DECLSPEC SDL_IOStatus SDLCALL SDL_GetIOStatus(SDL_IOStream *context);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC Sint64 SDLCALL SDL_GetIOSize(SDL_IOStream *context);
+extern SDL_DECLSPEC_RETURN Sint64 SDLCALL SDL_GetIOSize(SDL_IOStream *context);
 
 /**
  * Seek within an SDL_IOStream data stream.
@@ -442,7 +442,7 @@ extern DECLSPEC Sint64 SDLCALL SDL_GetIOSize(SDL_IOStream *context);
  *
  * \sa SDL_TellIO
  */
-extern DECLSPEC Sint64 SDLCALL SDL_SeekIO(SDL_IOStream *context, Sint64 offset, int whence);
+extern SDL_DECLSPEC_RETURN Sint64 SDLCALL SDL_SeekIO(SDL_IOStream *context, Sint64 offset, int whence);
 
 /**
  * Determine the current read/write offset in an SDL_IOStream data stream.
@@ -460,7 +460,7 @@ extern DECLSPEC Sint64 SDLCALL SDL_SeekIO(SDL_IOStream *context, Sint64 offset, 
  *
  * \sa SDL_SeekIO
  */
-extern DECLSPEC Sint64 SDLCALL SDL_TellIO(SDL_IOStream *context);
+extern SDL_DECLSPEC_RETURN Sint64 SDLCALL SDL_TellIO(SDL_IOStream *context);
 
 /**
  * Read from a data source.
@@ -481,7 +481,7 @@ extern DECLSPEC Sint64 SDLCALL SDL_TellIO(SDL_IOStream *context);
  * \sa SDL_WriteIO
  * \sa SDL_GetIOStatus
  */
-extern DECLSPEC size_t SDLCALL SDL_ReadIO(SDL_IOStream *context, void *ptr, size_t size);
+extern SDL_DECLSPEC_RETURN size_t SDLCALL SDL_ReadIO(SDL_IOStream *context, void *ptr, size_t size);
 
 /**
  * Write to an SDL_IOStream data stream.
@@ -510,7 +510,7 @@ extern DECLSPEC size_t SDLCALL SDL_ReadIO(SDL_IOStream *context, void *ptr, size
  * \sa SDL_SeekIO
  * \sa SDL_GetIOStatus
  */
-extern DECLSPEC size_t SDLCALL SDL_WriteIO(SDL_IOStream *context, const void *ptr, size_t size);
+extern SDL_DECLSPEC_RETURN size_t SDLCALL SDL_WriteIO(SDL_IOStream *context, const void *ptr, size_t size);
 
 /**
  * Print to an SDL_IOStream data stream.
@@ -529,7 +529,7 @@ extern DECLSPEC size_t SDLCALL SDL_WriteIO(SDL_IOStream *context, const void *pt
  * \sa SDL_IOvprintf
  * \sa SDL_WriteIO
  */
-extern DECLSPEC size_t SDLCALL SDL_IOprintf(SDL_IOStream *context, SDL_PRINTF_FORMAT_STRING const char *fmt, ...)  SDL_PRINTF_VARARG_FUNC(2);
+extern SDL_DECLSPEC_RETURN size_t SDLCALL SDL_IOprintf(SDL_IOStream *context, SDL_PRINTF_FORMAT_STRING const char *fmt, ...)  SDL_PRINTF_VARARG_FUNC(2);
 
 /**
  * Print to an SDL_IOStream data stream.
@@ -547,7 +547,7 @@ extern DECLSPEC size_t SDLCALL SDL_IOprintf(SDL_IOStream *context, SDL_PRINTF_FO
  * \sa SDL_IOprintf
  * \sa SDL_WriteIO
  */
-extern DECLSPEC size_t SDLCALL SDL_IOvprintf(SDL_IOStream *context, SDL_PRINTF_FORMAT_STRING const char *fmt, va_list ap) SDL_PRINTF_VARARG_FUNCV(2);
+extern SDL_DECLSPEC_RETURN size_t SDLCALL SDL_IOvprintf(SDL_IOStream *context, SDL_PRINTF_FORMAT_STRING const char *fmt, va_list ap) SDL_PRINTF_VARARG_FUNCV(2);
 
 /**
  * Load all the data from an SDL data stream.
@@ -568,7 +568,7 @@ extern DECLSPEC size_t SDLCALL SDL_IOvprintf(SDL_IOStream *context, SDL_PRINTF_F
  *
  * \sa SDL_LoadFile
  */
-extern DECLSPEC void *SDLCALL SDL_LoadFile_IO(SDL_IOStream *src, size_t *datasize, SDL_bool closeio);
+extern SDL_DECLSPEC_RETURN void *SDLCALL SDL_LoadFile_IO(SDL_IOStream *src, size_t *datasize, SDL_bool closeio);
 
 /**
  * Load all the data from a file path.
@@ -587,7 +587,7 @@ extern DECLSPEC void *SDLCALL SDL_LoadFile_IO(SDL_IOStream *src, size_t *datasiz
  *
  * \sa SDL_LoadFile_IO
  */
-extern DECLSPEC void *SDLCALL SDL_LoadFile(const char *file, size_t *datasize);
+extern SDL_DECLSPEC_RETURN void *SDLCALL SDL_LoadFile(const char *file, size_t *datasize);
 
 /**
  *  \name Read endian functions
@@ -606,7 +606,7 @@ extern DECLSPEC void *SDLCALL SDL_LoadFile(const char *file, size_t *datasize);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_ReadU8(SDL_IOStream *src, Uint8 *value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_ReadU8(SDL_IOStream *src, Uint8 *value);
 
 /**
  * Use this function to read 16 bits of little-endian data from an
@@ -622,7 +622,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_ReadU8(SDL_IOStream *src, Uint8 *value);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_ReadU16LE(SDL_IOStream *src, Uint16 *value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_ReadU16LE(SDL_IOStream *src, Uint16 *value);
 
 /**
  * Use this function to read 16 bits of little-endian data from an
@@ -638,7 +638,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_ReadU16LE(SDL_IOStream *src, Uint16 *value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_ReadS16LE(SDL_IOStream *src, Sint16 *value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_ReadS16LE(SDL_IOStream *src, Sint16 *value);
 
 /**
  * Use this function to read 16 bits of big-endian data from an SDL_IOStream
@@ -654,7 +654,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_ReadS16LE(SDL_IOStream *src, Sint16 *value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_ReadU16BE(SDL_IOStream *src, Uint16 *value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_ReadU16BE(SDL_IOStream *src, Uint16 *value);
 
 /**
  * Use this function to read 16 bits of big-endian data from an SDL_IOStream
@@ -670,7 +670,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_ReadU16BE(SDL_IOStream *src, Uint16 *value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_ReadS16BE(SDL_IOStream *src, Sint16 *value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_ReadS16BE(SDL_IOStream *src, Sint16 *value);
 
 /**
  * Use this function to read 32 bits of little-endian data from an
@@ -686,7 +686,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_ReadS16BE(SDL_IOStream *src, Sint16 *value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_ReadU32LE(SDL_IOStream *src, Uint32 *value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_ReadU32LE(SDL_IOStream *src, Uint32 *value);
 
 /**
  * Use this function to read 32 bits of little-endian data from an
@@ -702,7 +702,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_ReadU32LE(SDL_IOStream *src, Uint32 *value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_ReadS32LE(SDL_IOStream *src, Sint32 *value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_ReadS32LE(SDL_IOStream *src, Sint32 *value);
 
 /**
  * Use this function to read 32 bits of big-endian data from an SDL_IOStream
@@ -718,7 +718,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_ReadS32LE(SDL_IOStream *src, Sint32 *value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_ReadU32BE(SDL_IOStream *src, Uint32 *value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_ReadU32BE(SDL_IOStream *src, Uint32 *value);
 
 /**
  * Use this function to read 32 bits of big-endian data from an SDL_IOStream
@@ -734,7 +734,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_ReadU32BE(SDL_IOStream *src, Uint32 *value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_ReadS32BE(SDL_IOStream *src, Sint32 *value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_ReadS32BE(SDL_IOStream *src, Sint32 *value);
 
 /**
  * Use this function to read 64 bits of little-endian data from an
@@ -750,7 +750,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_ReadS32BE(SDL_IOStream *src, Sint32 *value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_ReadU64LE(SDL_IOStream *src, Uint64 *value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_ReadU64LE(SDL_IOStream *src, Uint64 *value);
 
 /**
  * Use this function to read 64 bits of little-endian data from an
@@ -766,7 +766,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_ReadU64LE(SDL_IOStream *src, Uint64 *value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_ReadS64LE(SDL_IOStream *src, Sint64 *value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_ReadS64LE(SDL_IOStream *src, Sint64 *value);
 
 /**
  * Use this function to read 64 bits of big-endian data from an SDL_IOStream
@@ -782,7 +782,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_ReadS64LE(SDL_IOStream *src, Sint64 *value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_ReadU64BE(SDL_IOStream *src, Uint64 *value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_ReadU64BE(SDL_IOStream *src, Uint64 *value);
 
 /**
  * Use this function to read 64 bits of big-endian data from an SDL_IOStream
@@ -798,7 +798,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_ReadU64BE(SDL_IOStream *src, Uint64 *value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_ReadS64BE(SDL_IOStream *src, Sint64 *value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_ReadS64BE(SDL_IOStream *src, Sint64 *value);
 /* @} *//* Read endian functions */
 
 /**
@@ -818,7 +818,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_ReadS64BE(SDL_IOStream *src, Sint64 *value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_WriteU8(SDL_IOStream *dst, Uint8 value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_WriteU8(SDL_IOStream *dst, Uint8 value);
 
 /**
  * Use this function to write 16 bits in native format to an SDL_IOStream as
@@ -835,7 +835,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_WriteU8(SDL_IOStream *dst, Uint8 value);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_WriteU16LE(SDL_IOStream *dst, Uint16 value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_WriteU16LE(SDL_IOStream *dst, Uint16 value);
 
 /**
  * Use this function to write 16 bits in native format to an SDL_IOStream as
@@ -852,7 +852,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_WriteU16LE(SDL_IOStream *dst, Uint16 value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_WriteS16LE(SDL_IOStream *dst, Sint16 value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_WriteS16LE(SDL_IOStream *dst, Sint16 value);
 
 /**
  * Use this function to write 16 bits in native format to an SDL_IOStream as
@@ -868,7 +868,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_WriteS16LE(SDL_IOStream *dst, Sint16 value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_WriteU16BE(SDL_IOStream *dst, Uint16 value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_WriteU16BE(SDL_IOStream *dst, Uint16 value);
 
 /**
  * Use this function to write 16 bits in native format to an SDL_IOStream as
@@ -884,7 +884,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_WriteU16BE(SDL_IOStream *dst, Uint16 value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_WriteS16BE(SDL_IOStream *dst, Sint16 value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_WriteS16BE(SDL_IOStream *dst, Sint16 value);
 
 /**
  * Use this function to write 32 bits in native format to an SDL_IOStream as
@@ -901,7 +901,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_WriteS16BE(SDL_IOStream *dst, Sint16 value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_WriteU32LE(SDL_IOStream *dst, Uint32 value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_WriteU32LE(SDL_IOStream *dst, Uint32 value);
 
 /**
  * Use this function to write 32 bits in native format to an SDL_IOStream as
@@ -918,7 +918,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_WriteU32LE(SDL_IOStream *dst, Uint32 value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_WriteS32LE(SDL_IOStream *dst, Sint32 value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_WriteS32LE(SDL_IOStream *dst, Sint32 value);
 
 /**
  * Use this function to write 32 bits in native format to an SDL_IOStream as
@@ -934,7 +934,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_WriteS32LE(SDL_IOStream *dst, Sint32 value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_WriteU32BE(SDL_IOStream *dst, Uint32 value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_WriteU32BE(SDL_IOStream *dst, Uint32 value);
 
 /**
  * Use this function to write 32 bits in native format to an SDL_IOStream as
@@ -950,7 +950,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_WriteU32BE(SDL_IOStream *dst, Uint32 value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_WriteS32BE(SDL_IOStream *dst, Sint32 value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_WriteS32BE(SDL_IOStream *dst, Sint32 value);
 
 /**
  * Use this function to write 64 bits in native format to an SDL_IOStream as
@@ -967,7 +967,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_WriteS32BE(SDL_IOStream *dst, Sint32 value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_WriteU64LE(SDL_IOStream *dst, Uint64 value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_WriteU64LE(SDL_IOStream *dst, Uint64 value);
 
 /**
  * Use this function to write 64 bits in native format to an SDL_IOStream as
@@ -984,7 +984,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_WriteU64LE(SDL_IOStream *dst, Uint64 value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_WriteS64LE(SDL_IOStream *dst, Sint64 value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_WriteS64LE(SDL_IOStream *dst, Sint64 value);
 
 /**
  * Use this function to write 64 bits in native format to an SDL_IOStream as
@@ -1000,7 +1000,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_WriteS64LE(SDL_IOStream *dst, Sint64 value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_WriteU64BE(SDL_IOStream *dst, Uint64 value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_WriteU64BE(SDL_IOStream *dst, Uint64 value);
 
 /**
  * Use this function to write 64 bits in native format to an SDL_IOStream as
@@ -1016,7 +1016,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_WriteU64BE(SDL_IOStream *dst, Uint64 value)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_WriteS64BE(SDL_IOStream *dst, Sint64 value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_WriteS64BE(SDL_IOStream *dst, Sint64 value);
 
 /* @} *//* Write endian functions */
 

--- a/include/SDL3/SDL_iostream.h
+++ b/include/SDL3/SDL_iostream.h
@@ -216,7 +216,7 @@ typedef struct SDL_IOStream SDL_IOStream;
  * \sa SDL_TellIO
  * \sa SDL_WriteIO
  */
-extern SDL_DECLSPEC_RETURN SDL_IOStream *SDLCALL SDL_IOFromFile(const char *file, const char *mode);
+extern SDL_DECLSPEC_NODISCARD SDL_IOStream *SDLCALL SDL_IOFromFile(const char *file, const char *mode);
 
 #define SDL_PROP_IOSTREAM_WINDOWS_HANDLE_POINTER    "SDL.iostream.windows.handle"
 #define SDL_PROP_IOSTREAM_STDIO_FILE_POINTER        "SDL.iostream.stdio.file"
@@ -251,7 +251,7 @@ extern SDL_DECLSPEC_RETURN SDL_IOStream *SDLCALL SDL_IOFromFile(const char *file
  * \sa SDL_TellIO
  * \sa SDL_WriteIO
  */
-extern SDL_DECLSPEC_RETURN SDL_IOStream *SDLCALL SDL_IOFromMem(void *mem, size_t size);
+extern SDL_DECLSPEC_NODISCARD SDL_IOStream *SDLCALL SDL_IOFromMem(void *mem, size_t size);
 
 /**
  * Use this function to prepare a read-only memory buffer for use with
@@ -283,7 +283,7 @@ extern SDL_DECLSPEC_RETURN SDL_IOStream *SDLCALL SDL_IOFromMem(void *mem, size_t
  * \sa SDL_SeekIO
  * \sa SDL_TellIO
  */
-extern SDL_DECLSPEC_RETURN SDL_IOStream *SDLCALL SDL_IOFromConstMem(const void *mem, size_t size);
+extern SDL_DECLSPEC_NODISCARD SDL_IOStream *SDLCALL SDL_IOFromConstMem(const void *mem, size_t size);
 
 /**
  * Use this function to create an SDL_IOStream that is backed by dynamically
@@ -308,7 +308,7 @@ extern SDL_DECLSPEC_RETURN SDL_IOStream *SDLCALL SDL_IOFromConstMem(const void *
  * \sa SDL_TellIO
  * \sa SDL_WriteIO
  */
-extern SDL_DECLSPEC_RETURN SDL_IOStream *SDLCALL SDL_IOFromDynamicMem(void);
+extern SDL_DECLSPEC_NODISCARD SDL_IOStream *SDLCALL SDL_IOFromDynamicMem(void);
 
 #define SDL_PROP_IOSTREAM_DYNAMIC_MEMORY_POINTER    "SDL.iostream.dynamic.memory"
 #define SDL_PROP_IOSTREAM_DYNAMIC_CHUNKSIZE_NUMBER  "SDL.iostream.dynamic.chunksize"
@@ -342,7 +342,7 @@ extern SDL_DECLSPEC_RETURN SDL_IOStream *SDLCALL SDL_IOFromDynamicMem(void);
  * \sa SDL_IOFromFile
  * \sa SDL_IOFromMem
  */
-extern SDL_DECLSPEC_RETURN SDL_IOStream *SDLCALL SDL_OpenIO(const SDL_IOStreamInterface *iface, void *userdata);
+extern SDL_DECLSPEC_NODISCARD SDL_IOStream *SDLCALL SDL_OpenIO(const SDL_IOStreamInterface *iface, void *userdata);
 
 /**
  * Close and free an allocated SDL_IOStream structure.
@@ -568,7 +568,7 @@ extern SDL_DECLSPEC_RETURN size_t SDLCALL SDL_IOvprintf(SDL_IOStream *context, S
  *
  * \sa SDL_LoadFile
  */
-extern SDL_DECLSPEC_RETURN void *SDLCALL SDL_LoadFile_IO(SDL_IOStream *src, size_t *datasize, SDL_bool closeio);
+extern SDL_DECLSPEC_NODISCARD void *SDLCALL SDL_LoadFile_IO(SDL_IOStream *src, size_t *datasize, SDL_bool closeio);
 
 /**
  * Load all the data from a file path.
@@ -587,7 +587,7 @@ extern SDL_DECLSPEC_RETURN void *SDLCALL SDL_LoadFile_IO(SDL_IOStream *src, size
  *
  * \sa SDL_LoadFile_IO
  */
-extern SDL_DECLSPEC_RETURN void *SDLCALL SDL_LoadFile(const char *file, size_t *datasize);
+extern SDL_DECLSPEC_NODISCARD void *SDLCALL SDL_LoadFile(const char *file, size_t *datasize);
 
 /**
  *  \name Read endian functions

--- a/include/SDL3/SDL_joystick.h
+++ b/include/SDL3/SDL_joystick.h
@@ -224,7 +224,7 @@ extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasJoystick(void);
  * \sa SDL_HasJoystick
  * \sa SDL_OpenJoystick
  */
-extern SDL_DECLSPEC_RETURN SDL_JoystickID *SDLCALL SDL_GetJoysticks(int *count);
+extern SDL_DECLSPEC_NODISCARD SDL_JoystickID *SDLCALL SDL_GetJoysticks(int *count);
 
 /**
  * Get the implementation dependent name of a joystick.
@@ -371,7 +371,7 @@ extern SDL_DECLSPEC_RETURN SDL_JoystickType SDLCALL SDL_GetJoystickInstanceType(
  *
  * \sa SDL_CloseJoystick
  */
-extern SDL_DECLSPEC_RETURN SDL_Joystick *SDLCALL SDL_OpenJoystick(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_NODISCARD SDL_Joystick *SDLCALL SDL_OpenJoystick(SDL_JoystickID instance_id);
 
 /**
  * Get the SDL_Joystick associated with an instance ID, if it has been opened.

--- a/include/SDL3/SDL_joystick.h
+++ b/include/SDL3/SDL_joystick.h
@@ -191,14 +191,14 @@ typedef enum SDL_JoystickConnectionState
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_LockJoysticks(void) SDL_ACQUIRE(SDL_joystick_lock);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_LockJoysticks(void) SDL_ACQUIRE(SDL_joystick_lock);
 
 /**
  * Unlocking for atomic access to the joystick API.
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_UnlockJoysticks(void) SDL_RELEASE(SDL_joystick_lock);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_UnlockJoysticks(void) SDL_RELEASE(SDL_joystick_lock);
 
 /**
  * Return whether a joystick is currently connected.
@@ -209,7 +209,7 @@ extern DECLSPEC void SDLCALL SDL_UnlockJoysticks(void) SDL_RELEASE(SDL_joystick_
  *
  * \sa SDL_GetJoysticks
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasJoystick(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasJoystick(void);
 
 /**
  * Get a list of currently connected joysticks.
@@ -224,7 +224,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasJoystick(void);
  * \sa SDL_HasJoystick
  * \sa SDL_OpenJoystick
  */
-extern DECLSPEC SDL_JoystickID *SDLCALL SDL_GetJoysticks(int *count);
+extern SDL_DECLSPEC_RETURN SDL_JoystickID *SDLCALL SDL_GetJoysticks(int *count);
 
 /**
  * Get the implementation dependent name of a joystick.
@@ -240,7 +240,7 @@ extern DECLSPEC SDL_JoystickID *SDLCALL SDL_GetJoysticks(int *count);
  * \sa SDL_GetJoystickName
  * \sa SDL_GetJoysticks
  */
-extern DECLSPEC const char *SDLCALL SDL_GetJoystickInstanceName(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetJoystickInstanceName(SDL_JoystickID instance_id);
 
 /**
  * Get the implementation dependent path of a joystick.
@@ -256,7 +256,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetJoystickInstanceName(SDL_JoystickID i
  * \sa SDL_GetJoystickPath
  * \sa SDL_GetJoysticks
  */
-extern DECLSPEC const char *SDLCALL SDL_GetJoystickInstancePath(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetJoystickInstancePath(SDL_JoystickID instance_id);
 
 /**
  * Get the player index of a joystick.
@@ -271,7 +271,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetJoystickInstancePath(SDL_JoystickID i
  * \sa SDL_GetJoystickPlayerIndex
  * \sa SDL_GetJoysticks
  */
-extern DECLSPEC int SDLCALL SDL_GetJoystickInstancePlayerIndex(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetJoystickInstancePlayerIndex(SDL_JoystickID instance_id);
 
 /**
  * Get the implementation-dependent GUID of a joystick.
@@ -287,7 +287,7 @@ extern DECLSPEC int SDLCALL SDL_GetJoystickInstancePlayerIndex(SDL_JoystickID in
  * \sa SDL_GetJoystickGUID
  * \sa SDL_GetJoystickGUIDString
  */
-extern DECLSPEC SDL_JoystickGUID SDLCALL SDL_GetJoystickInstanceGUID(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_JoystickGUID SDLCALL SDL_GetJoystickInstanceGUID(SDL_JoystickID instance_id);
 
 /**
  * Get the USB vendor ID of a joystick, if available.
@@ -304,7 +304,7 @@ extern DECLSPEC SDL_JoystickGUID SDLCALL SDL_GetJoystickInstanceGUID(SDL_Joystic
  * \sa SDL_GetJoystickVendor
  * \sa SDL_GetJoysticks
  */
-extern DECLSPEC Uint16 SDLCALL SDL_GetJoystickInstanceVendor(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN Uint16 SDLCALL SDL_GetJoystickInstanceVendor(SDL_JoystickID instance_id);
 
 /**
  * Get the USB product ID of a joystick, if available.
@@ -321,7 +321,7 @@ extern DECLSPEC Uint16 SDLCALL SDL_GetJoystickInstanceVendor(SDL_JoystickID inst
  * \sa SDL_GetJoystickProduct
  * \sa SDL_GetJoysticks
  */
-extern DECLSPEC Uint16 SDLCALL SDL_GetJoystickInstanceProduct(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN Uint16 SDLCALL SDL_GetJoystickInstanceProduct(SDL_JoystickID instance_id);
 
 /**
  * Get the product version of a joystick, if available.
@@ -338,7 +338,7 @@ extern DECLSPEC Uint16 SDLCALL SDL_GetJoystickInstanceProduct(SDL_JoystickID ins
  * \sa SDL_GetJoystickProductVersion
  * \sa SDL_GetJoysticks
  */
-extern DECLSPEC Uint16 SDLCALL SDL_GetJoystickInstanceProductVersion(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN Uint16 SDLCALL SDL_GetJoystickInstanceProductVersion(SDL_JoystickID instance_id);
 
 /**
  * Get the type of a joystick, if available.
@@ -355,7 +355,7 @@ extern DECLSPEC Uint16 SDLCALL SDL_GetJoystickInstanceProductVersion(SDL_Joystic
  * \sa SDL_GetJoystickType
  * \sa SDL_GetJoysticks
  */
-extern DECLSPEC SDL_JoystickType SDLCALL SDL_GetJoystickInstanceType(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_JoystickType SDLCALL SDL_GetJoystickInstanceType(SDL_JoystickID instance_id);
 
 /**
  * Open a joystick for use.
@@ -371,7 +371,7 @@ extern DECLSPEC SDL_JoystickType SDLCALL SDL_GetJoystickInstanceType(SDL_Joystic
  *
  * \sa SDL_CloseJoystick
  */
-extern DECLSPEC SDL_Joystick *SDLCALL SDL_OpenJoystick(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_Joystick *SDLCALL SDL_OpenJoystick(SDL_JoystickID instance_id);
 
 /**
  * Get the SDL_Joystick associated with an instance ID, if it has been opened.
@@ -382,7 +382,7 @@ extern DECLSPEC SDL_Joystick *SDLCALL SDL_OpenJoystick(SDL_JoystickID instance_i
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_Joystick *SDLCALL SDL_GetJoystickFromInstanceID(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_Joystick *SDLCALL SDL_GetJoystickFromInstanceID(SDL_JoystickID instance_id);
 
 /**
  * Get the SDL_Joystick associated with a player index.
@@ -396,7 +396,7 @@ extern DECLSPEC SDL_Joystick *SDLCALL SDL_GetJoystickFromInstanceID(SDL_Joystick
  * \sa SDL_GetJoystickPlayerIndex
  * \sa SDL_SetJoystickPlayerIndex
  */
-extern DECLSPEC SDL_Joystick *SDLCALL SDL_GetJoystickFromPlayerIndex(int player_index);
+extern SDL_DECLSPEC_RETURN SDL_Joystick *SDLCALL SDL_GetJoystickFromPlayerIndex(int player_index);
 
 /**
  * The structure that describes a virtual joystick touchpad.
@@ -477,7 +477,7 @@ typedef struct SDL_VirtualJoystickDesc
  *
  * \sa SDL_DetachVirtualJoystick
  */
-extern DECLSPEC SDL_JoystickID SDLCALL SDL_AttachVirtualJoystick(const SDL_VirtualJoystickDesc *desc);
+extern SDL_DECLSPEC_RETURN SDL_JoystickID SDLCALL SDL_AttachVirtualJoystick(const SDL_VirtualJoystickDesc *desc);
 
 /**
  * Detach a virtual joystick.
@@ -491,7 +491,7 @@ extern DECLSPEC SDL_JoystickID SDLCALL SDL_AttachVirtualJoystick(const SDL_Virtu
  *
  * \sa SDL_AttachVirtualJoystick
  */
-extern DECLSPEC int SDLCALL SDL_DetachVirtualJoystick(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_DetachVirtualJoystick(SDL_JoystickID instance_id);
 
 /**
  * Query whether or not a joystick is virtual.
@@ -501,7 +501,7 @@ extern DECLSPEC int SDLCALL SDL_DetachVirtualJoystick(SDL_JoystickID instance_id
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_IsJoystickVirtual(SDL_JoystickID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_IsJoystickVirtual(SDL_JoystickID instance_id);
 
 /**
  * Set the state of an axis on an opened virtual joystick.
@@ -524,7 +524,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_IsJoystickVirtual(SDL_JoystickID instance_i
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SetJoystickVirtualAxis(SDL_Joystick *joystick, int axis, Sint16 value);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetJoystickVirtualAxis(SDL_Joystick *joystick, int axis, Sint16 value);
 
 /**
  * Generate ball motion on an opened virtual joystick.
@@ -544,7 +544,7 @@ extern DECLSPEC int SDLCALL SDL_SetJoystickVirtualAxis(SDL_Joystick *joystick, i
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SetJoystickVirtualBall(SDL_Joystick *joystick, int ball, Sint16 xrel, Sint16 yrel);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetJoystickVirtualBall(SDL_Joystick *joystick, int ball, Sint16 xrel, Sint16 yrel);
 
 /**
  * Set the state of a button on an opened virtual joystick.
@@ -563,7 +563,7 @@ extern DECLSPEC int SDLCALL SDL_SetJoystickVirtualBall(SDL_Joystick *joystick, i
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SetJoystickVirtualButton(SDL_Joystick *joystick, int button, Uint8 value);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetJoystickVirtualButton(SDL_Joystick *joystick, int button, Uint8 value);
 
 /**
  * Set the state of a hat on an opened virtual joystick.
@@ -582,7 +582,7 @@ extern DECLSPEC int SDLCALL SDL_SetJoystickVirtualButton(SDL_Joystick *joystick,
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SetJoystickVirtualHat(SDL_Joystick *joystick, int hat, Uint8 value);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetJoystickVirtualHat(SDL_Joystick *joystick, int hat, Uint8 value);
 
 /**
  * Set touchpad finger state on an opened virtual joystick.
@@ -609,7 +609,7 @@ extern DECLSPEC int SDLCALL SDL_SetJoystickVirtualHat(SDL_Joystick *joystick, in
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SetJoystickVirtualTouchpad(SDL_Joystick *joystick, int touchpad, int finger, Uint8 state, float x, float y, float pressure);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetJoystickVirtualTouchpad(SDL_Joystick *joystick, int touchpad, int finger, Uint8 state, float x, float y, float pressure);
 
 /**
  * Send a sensor update for an opened virtual joystick.
@@ -631,7 +631,7 @@ extern DECLSPEC int SDLCALL SDL_SetJoystickVirtualTouchpad(SDL_Joystick *joystic
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SendJoystickVirtualSensorData(SDL_Joystick *joystick, SDL_SensorType type, Uint64 sensor_timestamp, const float *data, int num_values);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SendJoystickVirtualSensorData(SDL_Joystick *joystick, SDL_SensorType type, Uint64 sensor_timestamp, const float *data, int num_values);
 
 /**
  * Get the properties associated with a joystick.
@@ -658,7 +658,7 @@ extern DECLSPEC int SDLCALL SDL_SendJoystickVirtualSensorData(SDL_Joystick *joys
  * \sa SDL_GetProperty
  * \sa SDL_SetProperty
  */
-extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetJoystickProperties(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN SDL_PropertiesID SDLCALL SDL_GetJoystickProperties(SDL_Joystick *joystick);
 
 #define SDL_PROP_JOYSTICK_CAP_MONO_LED_BOOLEAN          "SDL.joystick.cap.mono_led"
 #define SDL_PROP_JOYSTICK_CAP_RGB_LED_BOOLEAN           "SDL.joystick.cap.rgb_led"
@@ -677,7 +677,7 @@ extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetJoystickProperties(SDL_Joystick 
  *
  * \sa SDL_GetJoystickInstanceName
  */
-extern DECLSPEC const char *SDLCALL SDL_GetJoystickName(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetJoystickName(SDL_Joystick *joystick);
 
 /**
  * Get the implementation dependent path of a joystick.
@@ -690,7 +690,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetJoystickName(SDL_Joystick *joystick);
  *
  * \sa SDL_GetJoystickInstancePath
  */
-extern DECLSPEC const char *SDLCALL SDL_GetJoystickPath(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetJoystickPath(SDL_Joystick *joystick);
 
 /**
  * Get the player index of an opened joystick.
@@ -705,7 +705,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetJoystickPath(SDL_Joystick *joystick);
  *
  * \sa SDL_SetJoystickPlayerIndex
  */
-extern DECLSPEC int SDLCALL SDL_GetJoystickPlayerIndex(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetJoystickPlayerIndex(SDL_Joystick *joystick);
 
 /**
  * Set the player index of an opened joystick.
@@ -720,7 +720,7 @@ extern DECLSPEC int SDLCALL SDL_GetJoystickPlayerIndex(SDL_Joystick *joystick);
  *
  * \sa SDL_GetJoystickPlayerIndex
  */
-extern DECLSPEC int SDLCALL SDL_SetJoystickPlayerIndex(SDL_Joystick *joystick, int player_index);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetJoystickPlayerIndex(SDL_Joystick *joystick, int player_index);
 
 /**
  * Get the implementation-dependent GUID for the joystick.
@@ -737,7 +737,7 @@ extern DECLSPEC int SDLCALL SDL_SetJoystickPlayerIndex(SDL_Joystick *joystick, i
  * \sa SDL_GetJoystickInstanceGUID
  * \sa SDL_GetJoystickGUIDString
  */
-extern DECLSPEC SDL_JoystickGUID SDLCALL SDL_GetJoystickGUID(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN SDL_JoystickGUID SDLCALL SDL_GetJoystickGUID(SDL_Joystick *joystick);
 
 /**
  * Get the USB vendor ID of an opened joystick, if available.
@@ -751,7 +751,7 @@ extern DECLSPEC SDL_JoystickGUID SDLCALL SDL_GetJoystickGUID(SDL_Joystick *joyst
  *
  * \sa SDL_GetJoystickInstanceVendor
  */
-extern DECLSPEC Uint16 SDLCALL SDL_GetJoystickVendor(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN Uint16 SDLCALL SDL_GetJoystickVendor(SDL_Joystick *joystick);
 
 /**
  * Get the USB product ID of an opened joystick, if available.
@@ -765,7 +765,7 @@ extern DECLSPEC Uint16 SDLCALL SDL_GetJoystickVendor(SDL_Joystick *joystick);
  *
  * \sa SDL_GetJoystickInstanceProduct
  */
-extern DECLSPEC Uint16 SDLCALL SDL_GetJoystickProduct(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN Uint16 SDLCALL SDL_GetJoystickProduct(SDL_Joystick *joystick);
 
 /**
  * Get the product version of an opened joystick, if available.
@@ -779,7 +779,7 @@ extern DECLSPEC Uint16 SDLCALL SDL_GetJoystickProduct(SDL_Joystick *joystick);
  *
  * \sa SDL_GetJoystickInstanceProductVersion
  */
-extern DECLSPEC Uint16 SDLCALL SDL_GetJoystickProductVersion(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN Uint16 SDLCALL SDL_GetJoystickProductVersion(SDL_Joystick *joystick);
 
 /**
  * Get the firmware version of an opened joystick, if available.
@@ -792,7 +792,7 @@ extern DECLSPEC Uint16 SDLCALL SDL_GetJoystickProductVersion(SDL_Joystick *joyst
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC Uint16 SDLCALL SDL_GetJoystickFirmwareVersion(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN Uint16 SDLCALL SDL_GetJoystickFirmwareVersion(SDL_Joystick *joystick);
 
 /**
  * Get the serial number of an opened joystick, if available.
@@ -805,7 +805,7 @@ extern DECLSPEC Uint16 SDLCALL SDL_GetJoystickFirmwareVersion(SDL_Joystick *joys
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC const char * SDLCALL SDL_GetJoystickSerial(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN const char * SDLCALL SDL_GetJoystickSerial(SDL_Joystick *joystick);
 
 /**
  * Get the type of an opened joystick.
@@ -817,7 +817,7 @@ extern DECLSPEC const char * SDLCALL SDL_GetJoystickSerial(SDL_Joystick *joystic
  *
  * \sa SDL_GetJoystickInstanceType
  */
-extern DECLSPEC SDL_JoystickType SDLCALL SDL_GetJoystickType(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN SDL_JoystickType SDLCALL SDL_GetJoystickType(SDL_Joystick *joystick);
 
 /**
  * Get an ASCII string representation for a given SDL_JoystickGUID.
@@ -836,7 +836,7 @@ extern DECLSPEC SDL_JoystickType SDLCALL SDL_GetJoystickType(SDL_Joystick *joyst
  * \sa SDL_GetJoystickGUID
  * \sa SDL_GetJoystickGUIDFromString
  */
-extern DECLSPEC int SDLCALL SDL_GetJoystickGUIDString(SDL_JoystickGUID guid, char *pszGUID, int cbGUID);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetJoystickGUIDString(SDL_JoystickGUID guid, char *pszGUID, int cbGUID);
 
 /**
  * Convert a GUID string into a SDL_JoystickGUID structure.
@@ -852,7 +852,7 @@ extern DECLSPEC int SDLCALL SDL_GetJoystickGUIDString(SDL_JoystickGUID guid, cha
  *
  * \sa SDL_GetJoystickGUIDString
  */
-extern DECLSPEC SDL_JoystickGUID SDLCALL SDL_GetJoystickGUIDFromString(const char *pchGUID);
+extern SDL_DECLSPEC_RETURN SDL_JoystickGUID SDLCALL SDL_GetJoystickGUIDFromString(const char *pchGUID);
 
 /**
  * Get the device information encoded in a SDL_JoystickGUID structure.
@@ -871,7 +871,7 @@ extern DECLSPEC SDL_JoystickGUID SDLCALL SDL_GetJoystickGUIDFromString(const cha
  *
  * \sa SDL_GetJoystickInstanceGUID
  */
-extern DECLSPEC void SDLCALL SDL_GetJoystickGUIDInfo(SDL_JoystickGUID guid, Uint16 *vendor, Uint16 *product, Uint16 *version, Uint16 *crc16);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_GetJoystickGUIDInfo(SDL_JoystickGUID guid, Uint16 *vendor, Uint16 *product, Uint16 *version, Uint16 *crc16);
 
 /**
  * Get the status of a specified joystick.
@@ -882,7 +882,7 @@ extern DECLSPEC void SDLCALL SDL_GetJoystickGUIDInfo(SDL_JoystickGUID guid, Uint
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_JoystickConnected(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_JoystickConnected(SDL_Joystick *joystick);
 
 /**
  * Get the instance ID of an opened joystick.
@@ -893,7 +893,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_JoystickConnected(SDL_Joystick *joystick);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_JoystickID SDLCALL SDL_GetJoystickInstanceID(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN SDL_JoystickID SDLCALL SDL_GetJoystickInstanceID(SDL_Joystick *joystick);
 
 /**
  * Get the number of general axis controls on a joystick.
@@ -914,7 +914,7 @@ extern DECLSPEC SDL_JoystickID SDLCALL SDL_GetJoystickInstanceID(SDL_Joystick *j
  * \sa SDL_GetNumJoystickButtons
  * \sa SDL_GetNumJoystickHats
  */
-extern DECLSPEC int SDLCALL SDL_GetNumJoystickAxes(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetNumJoystickAxes(SDL_Joystick *joystick);
 
 /**
  * Get the number of trackballs on a joystick.
@@ -935,7 +935,7 @@ extern DECLSPEC int SDLCALL SDL_GetNumJoystickAxes(SDL_Joystick *joystick);
  * \sa SDL_GetNumJoystickButtons
  * \sa SDL_GetNumJoystickHats
  */
-extern DECLSPEC int SDLCALL SDL_GetNumJoystickBalls(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetNumJoystickBalls(SDL_Joystick *joystick);
 
 /**
  * Get the number of POV hats on a joystick.
@@ -951,7 +951,7 @@ extern DECLSPEC int SDLCALL SDL_GetNumJoystickBalls(SDL_Joystick *joystick);
  * \sa SDL_GetNumJoystickBalls
  * \sa SDL_GetNumJoystickButtons
  */
-extern DECLSPEC int SDLCALL SDL_GetNumJoystickHats(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetNumJoystickHats(SDL_Joystick *joystick);
 
 /**
  * Get the number of buttons on a joystick.
@@ -967,7 +967,7 @@ extern DECLSPEC int SDLCALL SDL_GetNumJoystickHats(SDL_Joystick *joystick);
  * \sa SDL_GetNumJoystickBalls
  * \sa SDL_GetNumJoystickHats
  */
-extern DECLSPEC int SDLCALL SDL_GetNumJoystickButtons(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetNumJoystickButtons(SDL_Joystick *joystick);
 
 /**
  * Set the state of joystick event processing.
@@ -983,7 +983,7 @@ extern DECLSPEC int SDLCALL SDL_GetNumJoystickButtons(SDL_Joystick *joystick);
  * \sa SDL_JoystickEventsEnabled
  * \sa SDL_UpdateJoysticks
  */
-extern DECLSPEC void SDLCALL SDL_SetJoystickEventsEnabled(SDL_bool enabled);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_SetJoystickEventsEnabled(SDL_bool enabled);
 
 /**
  * Query the state of joystick event processing.
@@ -999,7 +999,7 @@ extern DECLSPEC void SDLCALL SDL_SetJoystickEventsEnabled(SDL_bool enabled);
  *
  * \sa SDL_SetJoystickEventsEnabled
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_JoystickEventsEnabled(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_JoystickEventsEnabled(void);
 
 /**
  * Update the current state of the open joysticks.
@@ -1009,7 +1009,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_JoystickEventsEnabled(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_UpdateJoysticks(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_UpdateJoysticks(void);
 
 /**
  * Get the current state of an axis control on a joystick.
@@ -1033,7 +1033,7 @@ extern DECLSPEC void SDLCALL SDL_UpdateJoysticks(void);
  *
  * \sa SDL_GetNumJoystickAxes
  */
-extern DECLSPEC Sint16 SDLCALL SDL_GetJoystickAxis(SDL_Joystick *joystick, int axis);
+extern SDL_DECLSPEC_RETURN Sint16 SDLCALL SDL_GetJoystickAxis(SDL_Joystick *joystick, int axis);
 
 /**
  * Get the initial state of an axis control on a joystick.
@@ -1049,7 +1049,7 @@ extern DECLSPEC Sint16 SDLCALL SDL_GetJoystickAxis(SDL_Joystick *joystick, int a
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GetJoystickAxisInitialState(SDL_Joystick *joystick, int axis, Sint16 *state);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GetJoystickAxisInitialState(SDL_Joystick *joystick, int axis, Sint16 *state);
 
 /**
  * Get the ball axis change since the last poll.
@@ -1070,7 +1070,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_GetJoystickAxisInitialState(SDL_Joystick *j
  *
  * \sa SDL_GetNumJoystickBalls
  */
-extern DECLSPEC int SDLCALL SDL_GetJoystickBall(SDL_Joystick *joystick, int ball, int *dx, int *dy);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetJoystickBall(SDL_Joystick *joystick, int ball, int *dx, int *dy);
 
 /**
  * Get the current state of a POV hat on a joystick.
@@ -1085,7 +1085,7 @@ extern DECLSPEC int SDLCALL SDL_GetJoystickBall(SDL_Joystick *joystick, int ball
  *
  * \sa SDL_GetNumJoystickHats
  */
-extern DECLSPEC Uint8 SDLCALL SDL_GetJoystickHat(SDL_Joystick *joystick, int hat);
+extern SDL_DECLSPEC_RETURN Uint8 SDLCALL SDL_GetJoystickHat(SDL_Joystick *joystick, int hat);
 
 #define SDL_HAT_CENTERED    0x00u
 #define SDL_HAT_UP          0x01u
@@ -1109,7 +1109,7 @@ extern DECLSPEC Uint8 SDLCALL SDL_GetJoystickHat(SDL_Joystick *joystick, int hat
  *
  * \sa SDL_GetNumJoystickButtons
  */
-extern DECLSPEC Uint8 SDLCALL SDL_GetJoystickButton(SDL_Joystick *joystick, int button);
+extern SDL_DECLSPEC_RETURN Uint8 SDLCALL SDL_GetJoystickButton(SDL_Joystick *joystick, int button);
 
 /**
  * Start a rumble effect.
@@ -1130,7 +1130,7 @@ extern DECLSPEC Uint8 SDLCALL SDL_GetJoystickButton(SDL_Joystick *joystick, int 
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_RumbleJoystick(SDL_Joystick *joystick, Uint16 low_frequency_rumble, Uint16 high_frequency_rumble, Uint32 duration_ms);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RumbleJoystick(SDL_Joystick *joystick, Uint16 low_frequency_rumble, Uint16 high_frequency_rumble, Uint32 duration_ms);
 
 /**
  * Start a rumble effect in the joystick's triggers.
@@ -1159,7 +1159,7 @@ extern DECLSPEC int SDLCALL SDL_RumbleJoystick(SDL_Joystick *joystick, Uint16 lo
  *
  * \sa SDL_RumbleJoystick
  */
-extern DECLSPEC int SDLCALL SDL_RumbleJoystickTriggers(SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble, Uint32 duration_ms);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RumbleJoystickTriggers(SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble, Uint32 duration_ms);
 
 /**
  * Update a joystick's LED color.
@@ -1179,7 +1179,7 @@ extern DECLSPEC int SDLCALL SDL_RumbleJoystickTriggers(SDL_Joystick *joystick, U
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SetJoystickLED(SDL_Joystick *joystick, Uint8 red, Uint8 green, Uint8 blue);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetJoystickLED(SDL_Joystick *joystick, Uint8 red, Uint8 green, Uint8 blue);
 
 /**
  * Send a joystick specific effect packet.
@@ -1192,7 +1192,7 @@ extern DECLSPEC int SDLCALL SDL_SetJoystickLED(SDL_Joystick *joystick, Uint8 red
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SendJoystickEffect(SDL_Joystick *joystick, const void *data, int size);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SendJoystickEffect(SDL_Joystick *joystick, const void *data, int size);
 
 /**
  * Close a joystick previously opened with SDL_OpenJoystick().
@@ -1203,7 +1203,7 @@ extern DECLSPEC int SDLCALL SDL_SendJoystickEffect(SDL_Joystick *joystick, const
  *
  * \sa SDL_OpenJoystick
  */
-extern DECLSPEC void SDLCALL SDL_CloseJoystick(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_CloseJoystick(SDL_Joystick *joystick);
 
 /**
  * Get the connection state of a joystick.
@@ -1215,7 +1215,7 @@ extern DECLSPEC void SDLCALL SDL_CloseJoystick(SDL_Joystick *joystick);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_JoystickConnectionState SDLCALL SDL_GetJoystickConnectionState(SDL_Joystick *joystick);
+extern SDL_DECLSPEC_RETURN SDL_JoystickConnectionState SDLCALL SDL_GetJoystickConnectionState(SDL_Joystick *joystick);
 
 /**
  * Get the battery state of a joystick.
@@ -1236,7 +1236,7 @@ extern DECLSPEC SDL_JoystickConnectionState SDLCALL SDL_GetJoystickConnectionSta
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_PowerState SDLCALL SDL_GetJoystickPowerInfo(SDL_Joystick *joystick, int *percent);
+extern SDL_DECLSPEC_RETURN SDL_PowerState SDLCALL SDL_GetJoystickPowerInfo(SDL_Joystick *joystick, int *percent);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_keyboard.h
+++ b/include/SDL3/SDL_keyboard.h
@@ -102,7 +102,7 @@ extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasKeyboard(void);
  * \sa SDL_GetKeyboardInstanceName
  * \sa SDL_HasKeyboard
  */
-extern SDL_DECLSPEC_RETURN SDL_KeyboardID *SDLCALL SDL_GetKeyboards(int *count);
+extern SDL_DECLSPEC_NODISCARD SDL_KeyboardID *SDLCALL SDL_GetKeyboards(int *count);
 
 /**
  * Get the name of a keyboard.

--- a/include/SDL3/SDL_keyboard.h
+++ b/include/SDL3/SDL_keyboard.h
@@ -82,7 +82,7 @@ typedef struct SDL_Keysym
  *
  * \sa SDL_GetKeyboards
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasKeyboard(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasKeyboard(void);
 
 /**
  * Get a list of currently connected keyboards.
@@ -102,7 +102,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasKeyboard(void);
  * \sa SDL_GetKeyboardInstanceName
  * \sa SDL_HasKeyboard
  */
-extern DECLSPEC SDL_KeyboardID *SDLCALL SDL_GetKeyboards(int *count);
+extern SDL_DECLSPEC_RETURN SDL_KeyboardID *SDLCALL SDL_GetKeyboards(int *count);
 
 /**
  * Get the name of a keyboard.
@@ -117,7 +117,7 @@ extern DECLSPEC SDL_KeyboardID *SDLCALL SDL_GetKeyboards(int *count);
  *
  * \sa SDL_GetKeyboards
  */
-extern DECLSPEC const char *SDLCALL SDL_GetKeyboardInstanceName(SDL_KeyboardID instance_id);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetKeyboardInstanceName(SDL_KeyboardID instance_id);
 
 /**
  * Query the window which currently has keyboard focus.
@@ -126,7 +126,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetKeyboardInstanceName(SDL_KeyboardID i
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_Window * SDLCALL SDL_GetKeyboardFocus(void);
+extern SDL_DECLSPEC_RETURN SDL_Window * SDLCALL SDL_GetKeyboardFocus(void);
 
 /**
  * Get a snapshot of the current state of the keyboard.
@@ -157,7 +157,7 @@ extern DECLSPEC SDL_Window * SDLCALL SDL_GetKeyboardFocus(void);
  * \sa SDL_PumpEvents
  * \sa SDL_ResetKeyboard
  */
-extern DECLSPEC const Uint8 *SDLCALL SDL_GetKeyboardState(int *numkeys);
+extern SDL_DECLSPEC_RETURN const Uint8 *SDLCALL SDL_GetKeyboardState(int *numkeys);
 
 /**
  * Clear the state of the keyboard.
@@ -168,7 +168,7 @@ extern DECLSPEC const Uint8 *SDLCALL SDL_GetKeyboardState(int *numkeys);
  *
  * \sa SDL_GetKeyboardState
  */
-extern DECLSPEC void SDLCALL SDL_ResetKeyboard(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_ResetKeyboard(void);
 
 /**
  * Get the current key modifier state for the keyboard.
@@ -181,7 +181,7 @@ extern DECLSPEC void SDLCALL SDL_ResetKeyboard(void);
  * \sa SDL_GetKeyboardState
  * \sa SDL_SetModState
  */
-extern DECLSPEC SDL_Keymod SDLCALL SDL_GetModState(void);
+extern SDL_DECLSPEC_RETURN SDL_Keymod SDLCALL SDL_GetModState(void);
 
 /**
  * Set the current key modifier state for the keyboard.
@@ -200,7 +200,7 @@ extern DECLSPEC SDL_Keymod SDLCALL SDL_GetModState(void);
  *
  * \sa SDL_GetModState
  */
-extern DECLSPEC void SDLCALL SDL_SetModState(SDL_Keymod modstate);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_SetModState(SDL_Keymod modstate);
 
 /**
  * Get the key code corresponding to the given scancode according to the
@@ -216,7 +216,7 @@ extern DECLSPEC void SDLCALL SDL_SetModState(SDL_Keymod modstate);
  * \sa SDL_GetKeyName
  * \sa SDL_GetScancodeFromKey
  */
-extern DECLSPEC SDL_Keycode SDLCALL SDL_GetKeyFromScancode(SDL_Scancode scancode);
+extern SDL_DECLSPEC_RETURN SDL_Keycode SDLCALL SDL_GetKeyFromScancode(SDL_Scancode scancode);
 
 /**
  * Get the scancode corresponding to the given key code according to the
@@ -232,7 +232,7 @@ extern DECLSPEC SDL_Keycode SDLCALL SDL_GetKeyFromScancode(SDL_Scancode scancode
  * \sa SDL_GetKeyFromScancode
  * \sa SDL_GetScancodeName
  */
-extern DECLSPEC SDL_Scancode SDLCALL SDL_GetScancodeFromKey(SDL_Keycode key);
+extern SDL_DECLSPEC_RETURN SDL_Scancode SDLCALL SDL_GetScancodeFromKey(SDL_Keycode key);
 
 /**
  * Get a human-readable name for a scancode.
@@ -257,7 +257,7 @@ extern DECLSPEC SDL_Scancode SDLCALL SDL_GetScancodeFromKey(SDL_Keycode key);
  * \sa SDL_GetScancodeFromKey
  * \sa SDL_GetScancodeFromName
  */
-extern DECLSPEC const char *SDLCALL SDL_GetScancodeName(SDL_Scancode scancode);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetScancodeName(SDL_Scancode scancode);
 
 /**
  * Get a scancode from a human-readable name.
@@ -272,7 +272,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetScancodeName(SDL_Scancode scancode);
  * \sa SDL_GetScancodeFromKey
  * \sa SDL_GetScancodeName
  */
-extern DECLSPEC SDL_Scancode SDLCALL SDL_GetScancodeFromName(const char *name);
+extern SDL_DECLSPEC_RETURN SDL_Scancode SDLCALL SDL_GetScancodeFromName(const char *name);
 
 /**
  * Get a human-readable name for a key.
@@ -291,7 +291,7 @@ extern DECLSPEC SDL_Scancode SDLCALL SDL_GetScancodeFromName(const char *name);
  * \sa SDL_GetKeyFromScancode
  * \sa SDL_GetScancodeFromKey
  */
-extern DECLSPEC const char *SDLCALL SDL_GetKeyName(SDL_Keycode key);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetKeyName(SDL_Keycode key);
 
 /**
  * Get a key code from a human-readable name.
@@ -306,7 +306,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetKeyName(SDL_Keycode key);
  * \sa SDL_GetKeyName
  * \sa SDL_GetScancodeFromName
  */
-extern DECLSPEC SDL_Keycode SDLCALL SDL_GetKeyFromName(const char *name);
+extern SDL_DECLSPEC_RETURN SDL_Keycode SDLCALL SDL_GetKeyFromName(const char *name);
 
 /**
  * Start accepting Unicode text input events.
@@ -325,7 +325,7 @@ extern DECLSPEC SDL_Keycode SDLCALL SDL_GetKeyFromName(const char *name);
  * \sa SDL_SetTextInputRect
  * \sa SDL_StopTextInput
  */
-extern DECLSPEC void SDLCALL SDL_StartTextInput(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_StartTextInput(void);
 
 /**
  * Check whether or not Unicode text input events are enabled.
@@ -336,7 +336,7 @@ extern DECLSPEC void SDLCALL SDL_StartTextInput(void);
  *
  * \sa SDL_StartTextInput
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_TextInputActive(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_TextInputActive(void);
 
 /**
  * Stop receiving any text input events.
@@ -347,7 +347,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_TextInputActive(void);
  *
  * \sa SDL_StartTextInput
  */
-extern DECLSPEC void SDLCALL SDL_StopTextInput(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_StopTextInput(void);
 
 /**
  * Dismiss the composition window/IME without disabling the subsystem.
@@ -357,7 +357,7 @@ extern DECLSPEC void SDLCALL SDL_StopTextInput(void);
  * \sa SDL_StartTextInput
  * \sa SDL_StopTextInput
  */
-extern DECLSPEC void SDLCALL SDL_ClearComposition(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_ClearComposition(void);
 
 /**
  * Set the rectangle used to type Unicode text inputs.
@@ -382,7 +382,7 @@ extern DECLSPEC void SDLCALL SDL_ClearComposition(void);
  *
  * \sa SDL_StartTextInput
  */
-extern DECLSPEC int SDLCALL SDL_SetTextInputRect(const SDL_Rect *rect);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetTextInputRect(const SDL_Rect *rect);
 
 /**
  * Check whether the platform has screen keyboard support.
@@ -395,7 +395,7 @@ extern DECLSPEC int SDLCALL SDL_SetTextInputRect(const SDL_Rect *rect);
  * \sa SDL_StartTextInput
  * \sa SDL_ScreenKeyboardShown
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasScreenKeyboardSupport(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasScreenKeyboardSupport(void);
 
 /**
  * Check whether the screen keyboard is shown for given window.
@@ -407,7 +407,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasScreenKeyboardSupport(void);
  *
  * \sa SDL_HasScreenKeyboardSupport
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_ScreenKeyboardShown(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_ScreenKeyboardShown(SDL_Window *window);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_loadso.h
+++ b/include/SDL3/SDL_loadso.h
@@ -64,7 +64,7 @@ extern "C" {
  * \sa SDL_LoadFunction
  * \sa SDL_UnloadObject
  */
-extern DECLSPEC void *SDLCALL SDL_LoadObject(const char *sofile);
+extern SDL_DECLSPEC_RETURN void *SDLCALL SDL_LoadObject(const char *sofile);
 
 /**
  * Look up the address of the named function in a shared object.
@@ -90,7 +90,7 @@ extern DECLSPEC void *SDLCALL SDL_LoadObject(const char *sofile);
  *
  * \sa SDL_LoadObject
  */
-extern DECLSPEC SDL_FunctionPointer SDLCALL SDL_LoadFunction(void *handle, const char *name);
+extern SDL_DECLSPEC_RETURN SDL_FunctionPointer SDLCALL SDL_LoadFunction(void *handle, const char *name);
 
 /**
  * Unload a shared object from memory.
@@ -101,7 +101,7 @@ extern DECLSPEC SDL_FunctionPointer SDLCALL SDL_LoadFunction(void *handle, const
  *
  * \sa SDL_LoadObject
  */
-extern DECLSPEC void SDLCALL SDL_UnloadObject(void *handle);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_UnloadObject(void *handle);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_locale.h
+++ b/include/SDL3/SDL_locale.h
@@ -100,7 +100,7 @@ typedef struct SDL_Locale
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern SDL_DECLSPEC_RETURN SDL_Locale * SDLCALL SDL_GetPreferredLocales(void);
+extern SDL_DECLSPEC_NODISCARD SDL_Locale * SDLCALL SDL_GetPreferredLocales(void);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_locale.h
+++ b/include/SDL3/SDL_locale.h
@@ -100,7 +100,7 @@ typedef struct SDL_Locale
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_Locale * SDLCALL SDL_GetPreferredLocales(void);
+extern SDL_DECLSPEC_RETURN SDL_Locale * SDLCALL SDL_GetPreferredLocales(void);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_log.h
+++ b/include/SDL3/SDL_log.h
@@ -117,7 +117,7 @@ typedef enum SDL_LogPriority
  * \sa SDL_ResetLogPriorities
  * \sa SDL_SetLogPriority
  */
-extern DECLSPEC void SDLCALL SDL_SetLogPriorities(SDL_LogPriority priority);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_SetLogPriorities(SDL_LogPriority priority);
 
 /**
  * Set the priority of a particular log category.
@@ -131,7 +131,7 @@ extern DECLSPEC void SDLCALL SDL_SetLogPriorities(SDL_LogPriority priority);
  * \sa SDL_ResetLogPriorities
  * \sa SDL_SetLogPriorities
  */
-extern DECLSPEC void SDLCALL SDL_SetLogPriority(int category,
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_SetLogPriority(int category,
                                                 SDL_LogPriority priority);
 
 /**
@@ -144,7 +144,7 @@ extern DECLSPEC void SDLCALL SDL_SetLogPriority(int category,
  *
  * \sa SDL_SetLogPriority
  */
-extern DECLSPEC SDL_LogPriority SDLCALL SDL_GetLogPriority(int category);
+extern SDL_DECLSPEC_RETURN SDL_LogPriority SDLCALL SDL_GetLogPriority(int category);
 
 /**
  * Reset all priorities to default.
@@ -156,7 +156,7 @@ extern DECLSPEC SDL_LogPriority SDLCALL SDL_GetLogPriority(int category);
  * \sa SDL_SetLogPriorities
  * \sa SDL_SetLogPriority
  */
-extern DECLSPEC void SDLCALL SDL_ResetLogPriorities(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_ResetLogPriorities(void);
 
 /**
  * Log a message with SDL_LOG_CATEGORY_APPLICATION and SDL_LOG_PRIORITY_INFO.
@@ -176,7 +176,7 @@ extern DECLSPEC void SDLCALL SDL_ResetLogPriorities(void);
  * \sa SDL_LogVerbose
  * \sa SDL_LogWarn
  */
-extern DECLSPEC void SDLCALL SDL_Log(SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(1);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_Log(SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(1);
 
 /**
  * Log a message with SDL_LOG_PRIORITY_VERBOSE.
@@ -197,7 +197,7 @@ extern DECLSPEC void SDLCALL SDL_Log(SDL_PRINTF_FORMAT_STRING const char *fmt, .
  * \sa SDL_LogMessageV
  * \sa SDL_LogWarn
  */
-extern DECLSPEC void SDLCALL SDL_LogVerbose(int category, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(2);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_LogVerbose(int category, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(2);
 
 /**
  * Log a message with SDL_LOG_PRIORITY_DEBUG.
@@ -218,7 +218,7 @@ extern DECLSPEC void SDLCALL SDL_LogVerbose(int category, SDL_PRINTF_FORMAT_STRI
  * \sa SDL_LogVerbose
  * \sa SDL_LogWarn
  */
-extern DECLSPEC void SDLCALL SDL_LogDebug(int category, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(2);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_LogDebug(int category, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(2);
 
 /**
  * Log a message with SDL_LOG_PRIORITY_INFO.
@@ -239,7 +239,7 @@ extern DECLSPEC void SDLCALL SDL_LogDebug(int category, SDL_PRINTF_FORMAT_STRING
  * \sa SDL_LogVerbose
  * \sa SDL_LogWarn
  */
-extern DECLSPEC void SDLCALL SDL_LogInfo(int category, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(2);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_LogInfo(int category, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(2);
 
 /**
  * Log a message with SDL_LOG_PRIORITY_WARN.
@@ -260,7 +260,7 @@ extern DECLSPEC void SDLCALL SDL_LogInfo(int category, SDL_PRINTF_FORMAT_STRING 
  * \sa SDL_LogMessageV
  * \sa SDL_LogVerbose
  */
-extern DECLSPEC void SDLCALL SDL_LogWarn(int category, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(2);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_LogWarn(int category, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(2);
 
 /**
  * Log a message with SDL_LOG_PRIORITY_ERROR.
@@ -281,7 +281,7 @@ extern DECLSPEC void SDLCALL SDL_LogWarn(int category, SDL_PRINTF_FORMAT_STRING 
  * \sa SDL_LogVerbose
  * \sa SDL_LogWarn
  */
-extern DECLSPEC void SDLCALL SDL_LogError(int category, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(2);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_LogError(int category, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(2);
 
 /**
  * Log a message with SDL_LOG_PRIORITY_CRITICAL.
@@ -302,7 +302,7 @@ extern DECLSPEC void SDLCALL SDL_LogError(int category, SDL_PRINTF_FORMAT_STRING
  * \sa SDL_LogVerbose
  * \sa SDL_LogWarn
  */
-extern DECLSPEC void SDLCALL SDL_LogCritical(int category, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(2);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_LogCritical(int category, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(2);
 
 /**
  * Log a message with the specified category and priority.
@@ -324,7 +324,7 @@ extern DECLSPEC void SDLCALL SDL_LogCritical(int category, SDL_PRINTF_FORMAT_STR
  * \sa SDL_LogVerbose
  * \sa SDL_LogWarn
  */
-extern DECLSPEC void SDLCALL SDL_LogMessage(int category,
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_LogMessage(int category,
                                             SDL_LogPriority priority,
                                             SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(3);
 
@@ -347,7 +347,7 @@ extern DECLSPEC void SDLCALL SDL_LogMessage(int category,
  * \sa SDL_LogVerbose
  * \sa SDL_LogWarn
  */
-extern DECLSPEC void SDLCALL SDL_LogMessageV(int category,
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_LogMessageV(int category,
                                              SDL_LogPriority priority,
                                              SDL_PRINTF_FORMAT_STRING const char *fmt, va_list ap) SDL_PRINTF_VARARG_FUNCV(3);
 
@@ -377,7 +377,7 @@ typedef void (SDLCALL *SDL_LogOutputFunction)(void *userdata, int category, SDL_
  *
  * \sa SDL_SetLogOutputFunction
  */
-extern DECLSPEC void SDLCALL SDL_GetLogOutputFunction(SDL_LogOutputFunction *callback, void **userdata);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_GetLogOutputFunction(SDL_LogOutputFunction *callback, void **userdata);
 
 /**
  * Replace the default log output function with one of your own.
@@ -389,7 +389,7 @@ extern DECLSPEC void SDLCALL SDL_GetLogOutputFunction(SDL_LogOutputFunction *cal
  *
  * \sa SDL_GetLogOutputFunction
  */
-extern DECLSPEC void SDLCALL SDL_SetLogOutputFunction(SDL_LogOutputFunction callback, void *userdata);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_SetLogOutputFunction(SDL_LogOutputFunction callback, void *userdata);
 
 
 /* Ends C function definitions when using C++ */

--- a/include/SDL3/SDL_main.h
+++ b/include/SDL3/SDL_main.h
@@ -92,7 +92,7 @@
         #define SDL_MAIN_NEEDED
 
         /* We need to export SDL_main so it can be launched from Java */
-        #define SDLMAIN_DECLSPEC    DECLSPEC
+        #define SDLMAIN_DECLSPEC_RETURN    SDL_DECLSPEC_RETURN
 
     #elif defined(SDL_PLATFORM_PSP)
         /* On PSP SDL provides a main function that sets the module info,
@@ -129,8 +129,8 @@
     #endif
 #endif /* SDL_MAIN_HANDLED */
 
-#ifndef SDLMAIN_DECLSPEC
-#define SDLMAIN_DECLSPEC
+#ifndef SDLMAIN_DECLSPEC_RETURN
+#define SDLMAIN_DECLSPEC_RETURN
 #endif
 
 /**
@@ -257,7 +257,7 @@ typedef void (SDLCALL *SDL_AppQuit_func)(void *appstate);
  * \sa SDL_AppEvent
  * \sa SDL_AppQuit
  */
-extern SDLMAIN_DECLSPEC int SDLCALL SDL_AppInit(void **appstate, int argc, char *argv[]);
+extern SDLMAIN_DECLSPEC_RETURN int SDLCALL SDL_AppInit(void **appstate, int argc, char *argv[]);
 
 /**
  * App-implemented iteration entry point for SDL_MAIN_USE_CALLBACKS apps.
@@ -304,7 +304,7 @@ extern SDLMAIN_DECLSPEC int SDLCALL SDL_AppInit(void **appstate, int argc, char 
  * \sa SDL_AppInit
  * \sa SDL_AppEvent
  */
-extern SDLMAIN_DECLSPEC int SDLCALL SDL_AppIterate(void *appstate);
+extern SDLMAIN_DECLSPEC_RETURN int SDLCALL SDL_AppIterate(void *appstate);
 
 /**
  * App-implemented event entry point for SDL_MAIN_USE_CALLBACKS apps.
@@ -350,7 +350,7 @@ extern SDLMAIN_DECLSPEC int SDLCALL SDL_AppIterate(void *appstate);
  * \sa SDL_AppInit
  * \sa SDL_AppIterate
  */
-extern SDLMAIN_DECLSPEC int SDLCALL SDL_AppEvent(void *appstate, const SDL_Event *event);
+extern SDLMAIN_DECLSPEC_RETURN int SDLCALL SDL_AppEvent(void *appstate, const SDL_Event *event);
 
 /**
  * App-implemented deinit entry point for SDL_MAIN_USE_CALLBACKS apps.
@@ -384,7 +384,7 @@ extern SDLMAIN_DECLSPEC int SDLCALL SDL_AppEvent(void *appstate, const SDL_Event
  *
  * \sa SDL_AppInit
  */
-extern SDLMAIN_DECLSPEC void SDLCALL SDL_AppQuit(void *appstate);
+extern SDLMAIN_DECLSPEC_RETURN void SDLCALL SDL_AppQuit(void *appstate);
 
 #endif  /* SDL_MAIN_USE_CALLBACKS */
 
@@ -421,7 +421,7 @@ typedef int (SDLCALL *SDL_main_func)(int argc, char *argv[]);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern SDLMAIN_DECLSPEC int SDLCALL SDL_main(int argc, char *argv[]);
+extern SDLMAIN_DECLSPEC_RETURN int SDLCALL SDL_main(int argc, char *argv[]);
 
 /**
  * Circumvent failure of SDL_Init() when not using SDL_main() as an entry
@@ -436,7 +436,7 @@ extern SDLMAIN_DECLSPEC int SDLCALL SDL_main(int argc, char *argv[]);
  *
  * \sa SDL_Init
  */
-extern DECLSPEC void SDLCALL SDL_SetMainReady(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_SetMainReady(void);
 
 /**
  * Initializes and launches an SDL application, by doing platform-specific
@@ -463,7 +463,7 @@ extern DECLSPEC void SDLCALL SDL_SetMainReady(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_RunApp(int argc, char* argv[], SDL_main_func mainFunction, void * reserved);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RunApp(int argc, char* argv[], SDL_main_func mainFunction, void * reserved);
 
 /**
  * An entry point for SDL's use in SDL_MAIN_USE_CALLBACKS.
@@ -490,7 +490,7 @@ extern DECLSPEC int SDLCALL SDL_RunApp(int argc, char* argv[], SDL_main_func mai
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_EnterAppMainCallbacks(int argc, char* argv[], SDL_AppInit_func appinit, SDL_AppIterate_func appiter, SDL_AppEvent_func appevent, SDL_AppQuit_func appquit);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_EnterAppMainCallbacks(int argc, char* argv[], SDL_AppInit_func appinit, SDL_AppIterate_func appiter, SDL_AppEvent_func appevent, SDL_AppQuit_func appquit);
 
 
 #if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_GDK)
@@ -519,7 +519,7 @@ extern DECLSPEC int SDLCALL SDL_EnterAppMainCallbacks(int argc, char* argv[], SD
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_RegisterApp(const char *name, Uint32 style, void *hInst);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RegisterApp(const char *name, Uint32 style, void *hInst);
 
 /**
  * Deregister the win32 window class from an SDL_RegisterApp call.
@@ -536,7 +536,7 @@ extern DECLSPEC int SDLCALL SDL_RegisterApp(const char *name, Uint32 style, void
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_UnregisterApp(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_UnregisterApp(void);
 
 #endif /* defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_GDK) */
 
@@ -547,7 +547,7 @@ extern DECLSPEC void SDLCALL SDL_UnregisterApp(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_GDKSuspendComplete(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_GDKSuspendComplete(void);
 
 #endif /* SDL_PLATFORM_GDK */
 

--- a/include/SDL3/SDL_messagebox.h
+++ b/include/SDL3/SDL_messagebox.h
@@ -160,7 +160,7 @@ typedef struct SDL_MessageBoxData
  *
  * \sa SDL_ShowSimpleMessageBox
  */
-extern DECLSPEC int SDLCALL SDL_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonid);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonid);
 
 /**
  * Display a simple modal message box.
@@ -202,7 +202,7 @@ extern DECLSPEC int SDLCALL SDL_ShowMessageBox(const SDL_MessageBoxData *message
  *
  * \sa SDL_ShowMessageBox
  */
-extern DECLSPEC int SDLCALL SDL_ShowSimpleMessageBox(SDL_MessageBoxFlags flags, const char *title, const char *message, SDL_Window *window);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ShowSimpleMessageBox(SDL_MessageBoxFlags flags, const char *title, const char *message, SDL_Window *window);
 
 
 /* Ends C function definitions when using C++ */

--- a/include/SDL3/SDL_metal.h
+++ b/include/SDL3/SDL_metal.h
@@ -66,7 +66,7 @@ typedef void *SDL_MetalView;
  * \sa SDL_Metal_DestroyView
  * \sa SDL_Metal_GetLayer
  */
-extern DECLSPEC SDL_MetalView SDLCALL SDL_Metal_CreateView(SDL_Window * window);
+extern SDL_DECLSPEC_RETURN SDL_MetalView SDLCALL SDL_Metal_CreateView(SDL_Window * window);
 
 /**
  * Destroy an existing SDL_MetalView object.
@@ -80,7 +80,7 @@ extern DECLSPEC SDL_MetalView SDLCALL SDL_Metal_CreateView(SDL_Window * window);
  *
  * \sa SDL_Metal_CreateView
  */
-extern DECLSPEC void SDLCALL SDL_Metal_DestroyView(SDL_MetalView view);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_Metal_DestroyView(SDL_MetalView view);
 
 /**
  * Get a pointer to the backing CAMetalLayer for the given view.
@@ -90,7 +90,7 @@ extern DECLSPEC void SDLCALL SDL_Metal_DestroyView(SDL_MetalView view);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void *SDLCALL SDL_Metal_GetLayer(SDL_MetalView view);
+extern SDL_DECLSPEC_RETURN void *SDLCALL SDL_Metal_GetLayer(SDL_MetalView view);
 
 /* @} *//* Metal support functions */
 

--- a/include/SDL3/SDL_metal.h
+++ b/include/SDL3/SDL_metal.h
@@ -66,7 +66,7 @@ typedef void *SDL_MetalView;
  * \sa SDL_Metal_DestroyView
  * \sa SDL_Metal_GetLayer
  */
-extern SDL_DECLSPEC_RETURN SDL_MetalView SDLCALL SDL_Metal_CreateView(SDL_Window * window);
+extern SDL_DECLSPEC_NODISCARD SDL_MetalView SDLCALL SDL_Metal_CreateView(SDL_Window * window);
 
 /**
  * Destroy an existing SDL_MetalView object.

--- a/include/SDL3/SDL_misc.h
+++ b/include/SDL3/SDL_misc.h
@@ -67,7 +67,7 @@ extern "C" {
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_OpenURL(const char *url);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_OpenURL(const char *url);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_mouse.h
+++ b/include/SDL3/SDL_mouse.h
@@ -94,7 +94,7 @@ typedef enum SDL_MouseWheelDirection
  *
  * \sa SDL_GetMice
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasMouse(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasMouse(void);
 
 /**
  * Get a list of currently connected mice.
@@ -114,7 +114,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasMouse(void);
  * \sa SDL_GetMouseInstanceName
  * \sa SDL_HasMouse
  */
-extern DECLSPEC SDL_MouseID *SDLCALL SDL_GetMice(int *count);
+extern SDL_DECLSPEC_RETURN SDL_MouseID *SDLCALL SDL_GetMice(int *count);
 
 /**
  * Get the name of a mouse.
@@ -129,7 +129,7 @@ extern DECLSPEC SDL_MouseID *SDLCALL SDL_GetMice(int *count);
  *
  * \sa SDL_GetMice
  */
-extern DECLSPEC const char *SDLCALL SDL_GetMouseInstanceName(SDL_MouseID instance_id);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetMouseInstanceName(SDL_MouseID instance_id);
 
 /**
  * Get the window which currently has mouse focus.
@@ -138,7 +138,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetMouseInstanceName(SDL_MouseID instanc
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_Window * SDLCALL SDL_GetMouseFocus(void);
+extern SDL_DECLSPEC_RETURN SDL_Window * SDLCALL SDL_GetMouseFocus(void);
 
 /**
  * Retrieve the current state of the mouse.
@@ -160,7 +160,7 @@ extern DECLSPEC SDL_Window * SDLCALL SDL_GetMouseFocus(void);
  * \sa SDL_GetGlobalMouseState
  * \sa SDL_GetRelativeMouseState
  */
-extern DECLSPEC Uint32 SDLCALL SDL_GetMouseState(float *x, float *y);
+extern SDL_DECLSPEC_RETURN Uint32 SDLCALL SDL_GetMouseState(float *x, float *y);
 
 /**
  * Get the current state of the mouse in relation to the desktop.
@@ -190,7 +190,7 @@ extern DECLSPEC Uint32 SDLCALL SDL_GetMouseState(float *x, float *y);
  * \sa SDL_CaptureMouse
  * \sa SDL_GetMouseState
  */
-extern DECLSPEC Uint32 SDLCALL SDL_GetGlobalMouseState(float *x, float *y);
+extern SDL_DECLSPEC_RETURN Uint32 SDLCALL SDL_GetGlobalMouseState(float *x, float *y);
 
 /**
  * Retrieve the relative state of the mouse.
@@ -209,7 +209,7 @@ extern DECLSPEC Uint32 SDLCALL SDL_GetGlobalMouseState(float *x, float *y);
  *
  * \sa SDL_GetMouseState
  */
-extern DECLSPEC Uint32 SDLCALL SDL_GetRelativeMouseState(float *x, float *y);
+extern SDL_DECLSPEC_RETURN Uint32 SDLCALL SDL_GetRelativeMouseState(float *x, float *y);
 
 /**
  * Move the mouse cursor to the given position within the window.
@@ -230,7 +230,7 @@ extern DECLSPEC Uint32 SDLCALL SDL_GetRelativeMouseState(float *x, float *y);
  *
  * \sa SDL_WarpMouseGlobal
  */
-extern DECLSPEC void SDLCALL SDL_WarpMouseInWindow(SDL_Window * window,
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_WarpMouseInWindow(SDL_Window * window,
                                                    float x, float y);
 
 /**
@@ -253,7 +253,7 @@ extern DECLSPEC void SDLCALL SDL_WarpMouseInWindow(SDL_Window * window,
  *
  * \sa SDL_WarpMouseInWindow
  */
-extern DECLSPEC int SDLCALL SDL_WarpMouseGlobal(float x, float y);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_WarpMouseGlobal(float x, float y);
 
 /**
  * Set relative mouse mode.
@@ -272,7 +272,7 @@ extern DECLSPEC int SDLCALL SDL_WarpMouseGlobal(float x, float y);
  *
  * \sa SDL_GetRelativeMouseMode
  */
-extern DECLSPEC int SDLCALL SDL_SetRelativeMouseMode(SDL_bool enabled);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetRelativeMouseMode(SDL_bool enabled);
 
 /**
  * Capture the mouse and to track input outside an SDL window.
@@ -318,7 +318,7 @@ extern DECLSPEC int SDLCALL SDL_SetRelativeMouseMode(SDL_bool enabled);
  *
  * \sa SDL_GetGlobalMouseState
  */
-extern DECLSPEC int SDLCALL SDL_CaptureMouse(SDL_bool enabled);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_CaptureMouse(SDL_bool enabled);
 
 /**
  * Query whether relative mouse mode is enabled.
@@ -329,7 +329,7 @@ extern DECLSPEC int SDLCALL SDL_CaptureMouse(SDL_bool enabled);
  *
  * \sa SDL_SetRelativeMouseMode
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GetRelativeMouseMode(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GetRelativeMouseMode(void);
 
 /**
  * Create a cursor using the specified bitmap data and mask (in MSB format).
@@ -373,7 +373,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_GetRelativeMouseMode(void);
  * \sa SDL_DestroyCursor
  * \sa SDL_SetCursor
  */
-extern DECLSPEC SDL_Cursor *SDLCALL SDL_CreateCursor(const Uint8 * data,
+extern SDL_DECLSPEC_RETURN SDL_Cursor *SDLCALL SDL_CreateCursor(const Uint8 * data,
                                                      const Uint8 * mask,
                                                      int w, int h, int hot_x,
                                                      int hot_y);
@@ -394,7 +394,7 @@ extern DECLSPEC SDL_Cursor *SDLCALL SDL_CreateCursor(const Uint8 * data,
  * \sa SDL_DestroyCursor
  * \sa SDL_SetCursor
  */
-extern DECLSPEC SDL_Cursor *SDLCALL SDL_CreateColorCursor(SDL_Surface *surface,
+extern SDL_DECLSPEC_RETURN SDL_Cursor *SDLCALL SDL_CreateColorCursor(SDL_Surface *surface,
                                                           int hot_x,
                                                           int hot_y);
 
@@ -409,7 +409,7 @@ extern DECLSPEC SDL_Cursor *SDLCALL SDL_CreateColorCursor(SDL_Surface *surface,
  *
  * \sa SDL_DestroyCursor
  */
-extern DECLSPEC SDL_Cursor *SDLCALL SDL_CreateSystemCursor(SDL_SystemCursor id);
+extern SDL_DECLSPEC_RETURN SDL_Cursor *SDLCALL SDL_CreateSystemCursor(SDL_SystemCursor id);
 
 /**
  * Set the active cursor.
@@ -427,7 +427,7 @@ extern DECLSPEC SDL_Cursor *SDLCALL SDL_CreateSystemCursor(SDL_SystemCursor id);
  *
  * \sa SDL_GetCursor
  */
-extern DECLSPEC int SDLCALL SDL_SetCursor(SDL_Cursor * cursor);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetCursor(SDL_Cursor * cursor);
 
 /**
  * Get the active cursor.
@@ -441,7 +441,7 @@ extern DECLSPEC int SDLCALL SDL_SetCursor(SDL_Cursor * cursor);
  *
  * \sa SDL_SetCursor
  */
-extern DECLSPEC SDL_Cursor *SDLCALL SDL_GetCursor(void);
+extern SDL_DECLSPEC_RETURN SDL_Cursor *SDLCALL SDL_GetCursor(void);
 
 /**
  * Get the default cursor.
@@ -453,7 +453,7 @@ extern DECLSPEC SDL_Cursor *SDLCALL SDL_GetCursor(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_Cursor *SDLCALL SDL_GetDefaultCursor(void);
+extern SDL_DECLSPEC_RETURN SDL_Cursor *SDLCALL SDL_GetDefaultCursor(void);
 
 /**
  * Free a previously-created cursor.
@@ -469,7 +469,7 @@ extern DECLSPEC SDL_Cursor *SDLCALL SDL_GetDefaultCursor(void);
  * \sa SDL_CreateCursor
  * \sa SDL_CreateSystemCursor
  */
-extern DECLSPEC void SDLCALL SDL_DestroyCursor(SDL_Cursor * cursor);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_DestroyCursor(SDL_Cursor * cursor);
 
 /**
  * Show the cursor.
@@ -482,7 +482,7 @@ extern DECLSPEC void SDLCALL SDL_DestroyCursor(SDL_Cursor * cursor);
  * \sa SDL_CursorVisible
  * \sa SDL_HideCursor
  */
-extern DECLSPEC int SDLCALL SDL_ShowCursor(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ShowCursor(void);
 
 /**
  * Hide the cursor.
@@ -495,7 +495,7 @@ extern DECLSPEC int SDLCALL SDL_ShowCursor(void);
  * \sa SDL_CursorVisible
  * \sa SDL_ShowCursor
  */
-extern DECLSPEC int SDLCALL SDL_HideCursor(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_HideCursor(void);
 
 /**
  * Return whether the cursor is currently being shown.
@@ -508,7 +508,7 @@ extern DECLSPEC int SDLCALL SDL_HideCursor(void);
  * \sa SDL_HideCursor
  * \sa SDL_ShowCursor
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_CursorVisible(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_CursorVisible(void);
 
 /**
  * Used as a mask when testing buttons in buttonstate.

--- a/include/SDL3/SDL_mouse.h
+++ b/include/SDL3/SDL_mouse.h
@@ -114,7 +114,7 @@ extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasMouse(void);
  * \sa SDL_GetMouseInstanceName
  * \sa SDL_HasMouse
  */
-extern SDL_DECLSPEC_RETURN SDL_MouseID *SDLCALL SDL_GetMice(int *count);
+extern SDL_DECLSPEC_NODISCARD SDL_MouseID *SDLCALL SDL_GetMice(int *count);
 
 /**
  * Get the name of a mouse.
@@ -373,7 +373,7 @@ extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GetRelativeMouseMode(void);
  * \sa SDL_DestroyCursor
  * \sa SDL_SetCursor
  */
-extern SDL_DECLSPEC_RETURN SDL_Cursor *SDLCALL SDL_CreateCursor(const Uint8 * data,
+extern SDL_DECLSPEC_NODISCARD SDL_Cursor *SDLCALL SDL_CreateCursor(const Uint8 * data,
                                                      const Uint8 * mask,
                                                      int w, int h, int hot_x,
                                                      int hot_y);
@@ -394,7 +394,7 @@ extern SDL_DECLSPEC_RETURN SDL_Cursor *SDLCALL SDL_CreateCursor(const Uint8 * da
  * \sa SDL_DestroyCursor
  * \sa SDL_SetCursor
  */
-extern SDL_DECLSPEC_RETURN SDL_Cursor *SDLCALL SDL_CreateColorCursor(SDL_Surface *surface,
+extern SDL_DECLSPEC_NODISCARD SDL_Cursor *SDLCALL SDL_CreateColorCursor(SDL_Surface *surface,
                                                           int hot_x,
                                                           int hot_y);
 
@@ -409,7 +409,7 @@ extern SDL_DECLSPEC_RETURN SDL_Cursor *SDLCALL SDL_CreateColorCursor(SDL_Surface
  *
  * \sa SDL_DestroyCursor
  */
-extern SDL_DECLSPEC_RETURN SDL_Cursor *SDLCALL SDL_CreateSystemCursor(SDL_SystemCursor id);
+extern SDL_DECLSPEC_NODISCARD SDL_Cursor *SDLCALL SDL_CreateSystemCursor(SDL_SystemCursor id);
 
 /**
  * Set the active cursor.

--- a/include/SDL3/SDL_mutex.h
+++ b/include/SDL3/SDL_mutex.h
@@ -164,7 +164,7 @@ typedef struct SDL_Mutex SDL_Mutex;
  * \sa SDL_TryLockMutex
  * \sa SDL_UnlockMutex
  */
-extern SDL_DECLSPEC_RETURN SDL_Mutex *SDLCALL SDL_CreateMutex(void);
+extern SDL_DECLSPEC_NODISCARD SDL_Mutex *SDLCALL SDL_CreateMutex(void);
 
 /**
  * Lock the mutex.
@@ -331,7 +331,7 @@ typedef struct SDL_RWLock SDL_RWLock;
  * \sa SDL_TryLockRWLockForWriting
  * \sa SDL_UnlockRWLock
  */
-extern SDL_DECLSPEC_RETURN SDL_RWLock *SDLCALL SDL_CreateRWLock(void);
+extern SDL_DECLSPEC_NODISCARD SDL_RWLock *SDLCALL SDL_CreateRWLock(void);
 
 /**
  * Lock the read/write lock for _read only_ operations.
@@ -550,7 +550,7 @@ typedef struct SDL_Semaphore SDL_Semaphore;
  * \sa SDL_WaitSemaphore
  * \sa SDL_WaitSemaphoreTimeout
  */
-extern SDL_DECLSPEC_RETURN SDL_Semaphore *SDLCALL SDL_CreateSemaphore(Uint32 initial_value);
+extern SDL_DECLSPEC_NODISCARD SDL_Semaphore *SDLCALL SDL_CreateSemaphore(Uint32 initial_value);
 
 /**
  * Destroy a semaphore.
@@ -694,7 +694,7 @@ typedef struct SDL_Condition SDL_Condition;
  * \sa SDL_WaitConditionTimeout
  * \sa SDL_DestroyCondition
  */
-extern SDL_DECLSPEC_RETURN SDL_Condition *SDLCALL SDL_CreateCondition(void);
+extern SDL_DECLSPEC_NODISCARD SDL_Condition *SDLCALL SDL_CreateCondition(void);
 
 /**
  * Destroy a condition variable.

--- a/include/SDL3/SDL_mutex.h
+++ b/include/SDL3/SDL_mutex.h
@@ -164,7 +164,7 @@ typedef struct SDL_Mutex SDL_Mutex;
  * \sa SDL_TryLockMutex
  * \sa SDL_UnlockMutex
  */
-extern DECLSPEC SDL_Mutex *SDLCALL SDL_CreateMutex(void);
+extern SDL_DECLSPEC_RETURN SDL_Mutex *SDLCALL SDL_CreateMutex(void);
 
 /**
  * Lock the mutex.
@@ -188,7 +188,7 @@ extern DECLSPEC SDL_Mutex *SDLCALL SDL_CreateMutex(void);
  * \sa SDL_TryLockMutex
  * \sa SDL_UnlockMutex
  */
-extern DECLSPEC void SDLCALL SDL_LockMutex(SDL_Mutex *mutex) SDL_ACQUIRE(mutex);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_LockMutex(SDL_Mutex *mutex) SDL_ACQUIRE(mutex);
 
 /**
  * Try to lock a mutex without blocking.
@@ -212,7 +212,7 @@ extern DECLSPEC void SDLCALL SDL_LockMutex(SDL_Mutex *mutex) SDL_ACQUIRE(mutex);
  * \sa SDL_LockMutex
  * \sa SDL_UnlockMutex
  */
-extern DECLSPEC int SDLCALL SDL_TryLockMutex(SDL_Mutex *mutex) SDL_TRY_ACQUIRE(0, mutex);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_TryLockMutex(SDL_Mutex *mutex) SDL_TRY_ACQUIRE(0, mutex);
 
 /**
  * Unlock the mutex.
@@ -231,7 +231,7 @@ extern DECLSPEC int SDLCALL SDL_TryLockMutex(SDL_Mutex *mutex) SDL_TRY_ACQUIRE(0
  * \sa SDL_LockMutex
  * \sa SDL_TryLockMutex
  */
-extern DECLSPEC void SDLCALL SDL_UnlockMutex(SDL_Mutex *mutex) SDL_RELEASE(mutex);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_UnlockMutex(SDL_Mutex *mutex) SDL_RELEASE(mutex);
 
 /**
  * Destroy a mutex created with SDL_CreateMutex().
@@ -248,7 +248,7 @@ extern DECLSPEC void SDLCALL SDL_UnlockMutex(SDL_Mutex *mutex) SDL_RELEASE(mutex
  *
  * \sa SDL_CreateMutex
  */
-extern DECLSPEC void SDLCALL SDL_DestroyMutex(SDL_Mutex *mutex);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_DestroyMutex(SDL_Mutex *mutex);
 
 /* @} *//* Mutex functions */
 
@@ -331,7 +331,7 @@ typedef struct SDL_RWLock SDL_RWLock;
  * \sa SDL_TryLockRWLockForWriting
  * \sa SDL_UnlockRWLock
  */
-extern DECLSPEC SDL_RWLock *SDLCALL SDL_CreateRWLock(void);
+extern SDL_DECLSPEC_RETURN SDL_RWLock *SDLCALL SDL_CreateRWLock(void);
 
 /**
  * Lock the read/write lock for _read only_ operations.
@@ -368,7 +368,7 @@ extern DECLSPEC SDL_RWLock *SDLCALL SDL_CreateRWLock(void);
  * \sa SDL_TryLockRWLockForReading
  * \sa SDL_UnlockRWLock
  */
-extern DECLSPEC void SDLCALL SDL_LockRWLockForReading(SDL_RWLock *rwlock) SDL_ACQUIRE_SHARED(rwlock);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_LockRWLockForReading(SDL_RWLock *rwlock) SDL_ACQUIRE_SHARED(rwlock);
 
 /**
  * Lock the read/write lock for _write_ operations.
@@ -399,7 +399,7 @@ extern DECLSPEC void SDLCALL SDL_LockRWLockForReading(SDL_RWLock *rwlock) SDL_AC
  * \sa SDL_TryLockRWLockForWriting
  * \sa SDL_UnlockRWLock
  */
-extern DECLSPEC void SDLCALL SDL_LockRWLockForWriting(SDL_RWLock *rwlock) SDL_ACQUIRE(rwlock);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_LockRWLockForWriting(SDL_RWLock *rwlock) SDL_ACQUIRE(rwlock);
 
 /**
  * Try to lock a read/write lock _for reading_ without blocking.
@@ -427,7 +427,7 @@ extern DECLSPEC void SDLCALL SDL_LockRWLockForWriting(SDL_RWLock *rwlock) SDL_AC
  * \sa SDL_TryLockRWLockForWriting
  * \sa SDL_UnlockRWLock
  */
-extern DECLSPEC int SDLCALL SDL_TryLockRWLockForReading(SDL_RWLock *rwlock) SDL_TRY_ACQUIRE_SHARED(0, rwlock);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_TryLockRWLockForReading(SDL_RWLock *rwlock) SDL_TRY_ACQUIRE_SHARED(0, rwlock);
 
 /**
  * Try to lock a read/write lock _for writing_ without blocking.
@@ -460,7 +460,7 @@ extern DECLSPEC int SDLCALL SDL_TryLockRWLockForReading(SDL_RWLock *rwlock) SDL_
  * \sa SDL_TryLockRWLockForReading
  * \sa SDL_UnlockRWLock
  */
-extern DECLSPEC int SDLCALL SDL_TryLockRWLockForWriting(SDL_RWLock *rwlock) SDL_TRY_ACQUIRE(0, rwlock);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_TryLockRWLockForWriting(SDL_RWLock *rwlock) SDL_TRY_ACQUIRE(0, rwlock);
 
 /**
  * Unlock the read/write lock.
@@ -485,7 +485,7 @@ extern DECLSPEC int SDLCALL SDL_TryLockRWLockForWriting(SDL_RWLock *rwlock) SDL_
  * \sa SDL_TryLockRWLockForReading
  * \sa SDL_TryLockRWLockForWriting
  */
-extern DECLSPEC void SDLCALL SDL_UnlockRWLock(SDL_RWLock *rwlock) SDL_RELEASE_GENERIC(rwlock);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_UnlockRWLock(SDL_RWLock *rwlock) SDL_RELEASE_GENERIC(rwlock);
 
 /**
  * Destroy a read/write lock created with SDL_CreateRWLock().
@@ -502,7 +502,7 @@ extern DECLSPEC void SDLCALL SDL_UnlockRWLock(SDL_RWLock *rwlock) SDL_RELEASE_GE
  *
  * \sa SDL_CreateRWLock
  */
-extern DECLSPEC void SDLCALL SDL_DestroyRWLock(SDL_RWLock *rwlock);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_DestroyRWLock(SDL_RWLock *rwlock);
 
 /* @} *//* Read/write lock functions */
 
@@ -550,7 +550,7 @@ typedef struct SDL_Semaphore SDL_Semaphore;
  * \sa SDL_WaitSemaphore
  * \sa SDL_WaitSemaphoreTimeout
  */
-extern DECLSPEC SDL_Semaphore *SDLCALL SDL_CreateSemaphore(Uint32 initial_value);
+extern SDL_DECLSPEC_RETURN SDL_Semaphore *SDLCALL SDL_CreateSemaphore(Uint32 initial_value);
 
 /**
  * Destroy a semaphore.
@@ -564,7 +564,7 @@ extern DECLSPEC SDL_Semaphore *SDLCALL SDL_CreateSemaphore(Uint32 initial_value)
  *
  * \sa SDL_CreateSemaphore
  */
-extern DECLSPEC void SDLCALL SDL_DestroySemaphore(SDL_Semaphore *sem);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_DestroySemaphore(SDL_Semaphore *sem);
 
 /**
  * Wait until a semaphore has a positive value and then decrements it.
@@ -587,7 +587,7 @@ extern DECLSPEC void SDLCALL SDL_DestroySemaphore(SDL_Semaphore *sem);
  * \sa SDL_TryWaitSemaphore
  * \sa SDL_WaitSemaphoreTimeout
  */
-extern DECLSPEC int SDLCALL SDL_WaitSemaphore(SDL_Semaphore *sem);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_WaitSemaphore(SDL_Semaphore *sem);
 
 /**
  * See if a semaphore has a positive value and decrement it if it does.
@@ -608,7 +608,7 @@ extern DECLSPEC int SDLCALL SDL_WaitSemaphore(SDL_Semaphore *sem);
  * \sa SDL_WaitSemaphore
  * \sa SDL_WaitSemaphoreTimeout
  */
-extern DECLSPEC int SDLCALL SDL_TryWaitSemaphore(SDL_Semaphore *sem);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_TryWaitSemaphore(SDL_Semaphore *sem);
 
 /**
  * Wait until a semaphore has a positive value and then decrements it.
@@ -630,7 +630,7 @@ extern DECLSPEC int SDLCALL SDL_TryWaitSemaphore(SDL_Semaphore *sem);
  * \sa SDL_TryWaitSemaphore
  * \sa SDL_WaitSemaphore
  */
-extern DECLSPEC int SDLCALL SDL_WaitSemaphoreTimeout(SDL_Semaphore *sem, Sint32 timeoutMS);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_WaitSemaphoreTimeout(SDL_Semaphore *sem, Sint32 timeoutMS);
 
 /**
  * Atomically increment a semaphore's value and wake waiting threads.
@@ -645,7 +645,7 @@ extern DECLSPEC int SDLCALL SDL_WaitSemaphoreTimeout(SDL_Semaphore *sem, Sint32 
  * \sa SDL_WaitSemaphore
  * \sa SDL_WaitSemaphoreTimeout
  */
-extern DECLSPEC int SDLCALL SDL_PostSemaphore(SDL_Semaphore *sem);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_PostSemaphore(SDL_Semaphore *sem);
 
 /**
  * Get the current value of a semaphore.
@@ -655,7 +655,7 @@ extern DECLSPEC int SDLCALL SDL_PostSemaphore(SDL_Semaphore *sem);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC Uint32 SDLCALL SDL_GetSemaphoreValue(SDL_Semaphore *sem);
+extern SDL_DECLSPEC_RETURN Uint32 SDLCALL SDL_GetSemaphoreValue(SDL_Semaphore *sem);
 
 /* @} *//* Semaphore functions */
 
@@ -694,7 +694,7 @@ typedef struct SDL_Condition SDL_Condition;
  * \sa SDL_WaitConditionTimeout
  * \sa SDL_DestroyCondition
  */
-extern DECLSPEC SDL_Condition *SDLCALL SDL_CreateCondition(void);
+extern SDL_DECLSPEC_RETURN SDL_Condition *SDLCALL SDL_CreateCondition(void);
 
 /**
  * Destroy a condition variable.
@@ -705,7 +705,7 @@ extern DECLSPEC SDL_Condition *SDLCALL SDL_CreateCondition(void);
  *
  * \sa SDL_CreateCondition
  */
-extern DECLSPEC void SDLCALL SDL_DestroyCondition(SDL_Condition *cond);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_DestroyCondition(SDL_Condition *cond);
 
 /**
  * Restart one of the threads that are waiting on the condition variable.
@@ -720,7 +720,7 @@ extern DECLSPEC void SDLCALL SDL_DestroyCondition(SDL_Condition *cond);
  * \sa SDL_WaitCondition
  * \sa SDL_WaitConditionTimeout
  */
-extern DECLSPEC int SDLCALL SDL_SignalCondition(SDL_Condition *cond);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SignalCondition(SDL_Condition *cond);
 
 /**
  * Restart all threads that are waiting on the condition variable.
@@ -735,7 +735,7 @@ extern DECLSPEC int SDLCALL SDL_SignalCondition(SDL_Condition *cond);
  * \sa SDL_WaitCondition
  * \sa SDL_WaitConditionTimeout
  */
-extern DECLSPEC int SDLCALL SDL_BroadcastCondition(SDL_Condition *cond);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_BroadcastCondition(SDL_Condition *cond);
 
 /**
  * Wait until a condition variable is signaled.
@@ -763,7 +763,7 @@ extern DECLSPEC int SDLCALL SDL_BroadcastCondition(SDL_Condition *cond);
  * \sa SDL_SignalCondition
  * \sa SDL_WaitConditionTimeout
  */
-extern DECLSPEC int SDLCALL SDL_WaitCondition(SDL_Condition *cond, SDL_Mutex *mutex);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_WaitCondition(SDL_Condition *cond, SDL_Mutex *mutex);
 
 /**
  * Wait until a condition variable is signaled or a certain time has passed.
@@ -792,7 +792,7 @@ extern DECLSPEC int SDLCALL SDL_WaitCondition(SDL_Condition *cond, SDL_Mutex *mu
  * \sa SDL_SignalCondition
  * \sa SDL_WaitCondition
  */
-extern DECLSPEC int SDLCALL SDL_WaitConditionTimeout(SDL_Condition *cond,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_WaitConditionTimeout(SDL_Condition *cond,
                                                 SDL_Mutex *mutex, Sint32 timeoutMS);
 
 /* @} *//* Condition variable functions */

--- a/include/SDL3/SDL_pen.h
+++ b/include/SDL3/SDL_pen.h
@@ -157,7 +157,7 @@ typedef enum SDL_PenSubtype
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_PenID *SDLCALL SDL_GetPens(int *count);
+extern SDL_DECLSPEC_RETURN SDL_PenID *SDLCALL SDL_GetPens(int *count);
 
 /**
  * Retrieves the pen's current status.
@@ -178,7 +178,7 @@ extern DECLSPEC SDL_PenID *SDLCALL SDL_GetPens(int *count);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC Uint32 SDLCALL SDL_GetPenStatus(SDL_PenID instance_id, float *x, float *y, float *axes, size_t num_axes);
+extern SDL_DECLSPEC_RETURN Uint32 SDLCALL SDL_GetPenStatus(SDL_PenID instance_id, float *x, float *y, float *axes, size_t num_axes);
 
 /**
  * Retrieves an SDL_PenID for the given SDL_GUID.
@@ -189,7 +189,7 @@ extern DECLSPEC Uint32 SDLCALL SDL_GetPenStatus(SDL_PenID instance_id, float *x,
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_PenID SDLCALL SDL_GetPenFromGUID(SDL_GUID guid);
+extern SDL_DECLSPEC_RETURN SDL_PenID SDLCALL SDL_GetPenFromGUID(SDL_GUID guid);
 
 /**
  * Retrieves the SDL_GUID for a given SDL_PenID.
@@ -200,7 +200,7 @@ extern DECLSPEC SDL_PenID SDLCALL SDL_GetPenFromGUID(SDL_GUID guid);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_GUID SDLCALL SDL_GetPenGUID(SDL_PenID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_GUID SDLCALL SDL_GetPenGUID(SDL_PenID instance_id);
 
 /**
  * Checks whether a pen is still attached.
@@ -214,7 +214,7 @@ extern DECLSPEC SDL_GUID SDLCALL SDL_GetPenGUID(SDL_PenID instance_id);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_PenConnected(SDL_PenID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_PenConnected(SDL_PenID instance_id);
 
 /**
  * Retrieves a human-readable description for a SDL_PenID.
@@ -230,7 +230,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_PenConnected(SDL_PenID instance_id);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC const char *SDLCALL SDL_GetPenName(SDL_PenID instance_id);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetPenName(SDL_PenID instance_id);
 
 /**
  * Pen capabilities, as reported by SDL_GetPenCapabilities()
@@ -254,7 +254,7 @@ typedef struct SDL_PenCapabilityInfo
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC Uint32 SDLCALL SDL_GetPenCapabilities(SDL_PenID instance_id, SDL_PenCapabilityInfo *capabilities);
+extern SDL_DECLSPEC_RETURN Uint32 SDLCALL SDL_GetPenCapabilities(SDL_PenID instance_id, SDL_PenCapabilityInfo *capabilities);
 
 /**
  * Retrieves the pen type for a given SDL_PenID.
@@ -269,7 +269,7 @@ extern DECLSPEC Uint32 SDLCALL SDL_GetPenCapabilities(SDL_PenID instance_id, SDL
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_PenSubtype SDLCALL SDL_GetPenType(SDL_PenID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_PenSubtype SDLCALL SDL_GetPenType(SDL_PenID instance_id);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_pen.h
+++ b/include/SDL3/SDL_pen.h
@@ -157,7 +157,7 @@ typedef enum SDL_PenSubtype
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern SDL_DECLSPEC_RETURN SDL_PenID *SDLCALL SDL_GetPens(int *count);
+extern SDL_DECLSPEC_NODISCARD SDL_PenID *SDLCALL SDL_GetPens(int *count);
 
 /**
  * Retrieves the pen's current status.

--- a/include/SDL3/SDL_pixels.h
+++ b/include/SDL3/SDL_pixels.h
@@ -768,7 +768,7 @@ typedef struct SDL_PixelFormat
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC const char* SDLCALL SDL_GetPixelFormatName(SDL_PixelFormatEnum format);
+extern SDL_DECLSPEC_RETURN const char* SDLCALL SDL_GetPixelFormatName(SDL_PixelFormatEnum format);
 
 /**
  * Convert one of the enumerated pixel formats to a bpp value and RGBA masks.
@@ -786,7 +786,7 @@ extern DECLSPEC const char* SDLCALL SDL_GetPixelFormatName(SDL_PixelFormatEnum f
  *
  * \sa SDL_GetPixelFormatEnumForMasks
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GetMasksForPixelFormatEnum(SDL_PixelFormatEnum format,
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GetMasksForPixelFormatEnum(SDL_PixelFormatEnum format,
                                                             int *bpp,
                                                             Uint32 * Rmask,
                                                             Uint32 * Gmask,
@@ -811,7 +811,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_GetMasksForPixelFormatEnum(SDL_PixelFormatE
  *
  * \sa SDL_GetMasksForPixelFormatEnum
  */
-extern DECLSPEC SDL_PixelFormatEnum SDLCALL SDL_GetPixelFormatEnumForMasks(int bpp,
+extern SDL_DECLSPEC_RETURN SDL_PixelFormatEnum SDLCALL SDL_GetPixelFormatEnumForMasks(int bpp,
                                                           Uint32 Rmask,
                                                           Uint32 Gmask,
                                                           Uint32 Bmask,
@@ -833,7 +833,7 @@ extern DECLSPEC SDL_PixelFormatEnum SDLCALL SDL_GetPixelFormatEnumForMasks(int b
  * \sa SDL_DestroyPixelFormat
  * \sa SDL_SetPixelFormatPalette
  */
-extern DECLSPEC SDL_PixelFormat * SDLCALL SDL_CreatePixelFormat(SDL_PixelFormatEnum pixel_format);
+extern SDL_DECLSPEC_RETURN SDL_PixelFormat * SDLCALL SDL_CreatePixelFormat(SDL_PixelFormatEnum pixel_format);
 
 /**
  * Free an SDL_PixelFormat structure allocated by SDL_CreatePixelFormat().
@@ -844,7 +844,7 @@ extern DECLSPEC SDL_PixelFormat * SDLCALL SDL_CreatePixelFormat(SDL_PixelFormatE
  *
  * \sa SDL_CreatePixelFormat
  */
-extern DECLSPEC void SDLCALL SDL_DestroyPixelFormat(SDL_PixelFormat *format);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_DestroyPixelFormat(SDL_PixelFormat *format);
 
 /**
  * Create a palette structure with the specified number of color entries.
@@ -862,7 +862,7 @@ extern DECLSPEC void SDLCALL SDL_DestroyPixelFormat(SDL_PixelFormat *format);
  * \sa SDL_SetPaletteColors
  * \sa SDL_SetPixelFormatPalette
  */
-extern DECLSPEC SDL_Palette *SDLCALL SDL_CreatePalette(int ncolors);
+extern SDL_DECLSPEC_RETURN SDL_Palette *SDLCALL SDL_CreatePalette(int ncolors);
 
 /**
  * Set the palette for a pixel format structure.
@@ -874,7 +874,7 @@ extern DECLSPEC SDL_Palette *SDLCALL SDL_CreatePalette(int ncolors);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SetPixelFormatPalette(SDL_PixelFormat * format,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetPixelFormatPalette(SDL_PixelFormat * format,
                                                       SDL_Palette *palette);
 
 /**
@@ -889,7 +889,7 @@ extern DECLSPEC int SDLCALL SDL_SetPixelFormatPalette(SDL_PixelFormat * format,
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SetPaletteColors(SDL_Palette * palette,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetPaletteColors(SDL_Palette * palette,
                                                  const SDL_Color * colors,
                                                  int firstcolor, int ncolors);
 
@@ -902,7 +902,7 @@ extern DECLSPEC int SDLCALL SDL_SetPaletteColors(SDL_Palette * palette,
  *
  * \sa SDL_CreatePalette
  */
-extern DECLSPEC void SDLCALL SDL_DestroyPalette(SDL_Palette * palette);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_DestroyPalette(SDL_Palette * palette);
 
 /**
  * Map an RGB triple to an opaque pixel value for a given pixel format.
@@ -934,7 +934,7 @@ extern DECLSPEC void SDLCALL SDL_DestroyPalette(SDL_Palette * palette);
  * \sa SDL_GetRGBA
  * \sa SDL_MapRGBA
  */
-extern DECLSPEC Uint32 SDLCALL SDL_MapRGB(const SDL_PixelFormat * format,
+extern SDL_DECLSPEC_RETURN Uint32 SDLCALL SDL_MapRGB(const SDL_PixelFormat * format,
                                           Uint8 r, Uint8 g, Uint8 b);
 
 /**
@@ -969,7 +969,7 @@ extern DECLSPEC Uint32 SDLCALL SDL_MapRGB(const SDL_PixelFormat * format,
  * \sa SDL_GetRGBA
  * \sa SDL_MapRGB
  */
-extern DECLSPEC Uint32 SDLCALL SDL_MapRGBA(const SDL_PixelFormat * format,
+extern SDL_DECLSPEC_RETURN Uint32 SDLCALL SDL_MapRGBA(const SDL_PixelFormat * format,
                                            Uint8 r, Uint8 g, Uint8 b,
                                            Uint8 a);
 
@@ -994,7 +994,7 @@ extern DECLSPEC Uint32 SDLCALL SDL_MapRGBA(const SDL_PixelFormat * format,
  * \sa SDL_MapRGB
  * \sa SDL_MapRGBA
  */
-extern DECLSPEC void SDLCALL SDL_GetRGB(Uint32 pixel,
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_GetRGB(Uint32 pixel,
                                         const SDL_PixelFormat * format,
                                         Uint8 * r, Uint8 * g, Uint8 * b);
 
@@ -1023,7 +1023,7 @@ extern DECLSPEC void SDLCALL SDL_GetRGB(Uint32 pixel,
  * \sa SDL_MapRGB
  * \sa SDL_MapRGBA
  */
-extern DECLSPEC void SDLCALL SDL_GetRGBA(Uint32 pixel,
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_GetRGBA(Uint32 pixel,
                                          const SDL_PixelFormat * format,
                                          Uint8 * r, Uint8 * g, Uint8 * b,
                                          Uint8 * a);

--- a/include/SDL3/SDL_pixels.h
+++ b/include/SDL3/SDL_pixels.h
@@ -833,7 +833,7 @@ extern SDL_DECLSPEC_RETURN SDL_PixelFormatEnum SDLCALL SDL_GetPixelFormatEnumFor
  * \sa SDL_DestroyPixelFormat
  * \sa SDL_SetPixelFormatPalette
  */
-extern SDL_DECLSPEC_RETURN SDL_PixelFormat * SDLCALL SDL_CreatePixelFormat(SDL_PixelFormatEnum pixel_format);
+extern SDL_DECLSPEC_NODISCARD SDL_PixelFormat * SDLCALL SDL_CreatePixelFormat(SDL_PixelFormatEnum pixel_format);
 
 /**
  * Free an SDL_PixelFormat structure allocated by SDL_CreatePixelFormat().
@@ -862,7 +862,7 @@ extern SDL_DECLSPEC_VOID void SDLCALL SDL_DestroyPixelFormat(SDL_PixelFormat *fo
  * \sa SDL_SetPaletteColors
  * \sa SDL_SetPixelFormatPalette
  */
-extern SDL_DECLSPEC_RETURN SDL_Palette *SDLCALL SDL_CreatePalette(int ncolors);
+extern SDL_DECLSPEC_NODISCARD SDL_Palette *SDLCALL SDL_CreatePalette(int ncolors);
 
 /**
  * Set the palette for a pixel format structure.

--- a/include/SDL3/SDL_platform.h
+++ b/include/SDL3/SDL_platform.h
@@ -53,7 +53,7 @@ extern "C" {
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC const char * SDLCALL SDL_GetPlatform (void);
+extern SDL_DECLSPEC_RETURN const char * SDLCALL SDL_GetPlatform (void);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_power.h
+++ b/include/SDL3/SDL_power.h
@@ -82,7 +82,7 @@ typedef enum SDL_PowerState
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_PowerState SDLCALL SDL_GetPowerInfo(int *seconds, int *percent);
+extern SDL_DECLSPEC_RETURN SDL_PowerState SDLCALL SDL_GetPowerInfo(int *seconds, int *percent);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_properties.h
+++ b/include/SDL3/SDL_properties.h
@@ -87,7 +87,7 @@ extern SDL_DECLSPEC_RETURN SDL_PropertiesID SDLCALL SDL_GetGlobalProperties(void
  *
  * \sa SDL_DestroyProperties
  */
-extern SDL_DECLSPEC_RETURN SDL_PropertiesID SDLCALL SDL_CreateProperties(void);
+extern SDL_DECLSPEC_NODISCARD SDL_PropertiesID SDLCALL SDL_CreateProperties(void);
 
 /**
  * Copy a set of properties.

--- a/include/SDL3/SDL_properties.h
+++ b/include/SDL3/SDL_properties.h
@@ -71,7 +71,7 @@ typedef enum SDL_PropertyType
  * \sa SDL_GetProperty
  * \sa SDL_SetProperty
  */
-extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetGlobalProperties(void);
+extern SDL_DECLSPEC_RETURN SDL_PropertiesID SDLCALL SDL_GetGlobalProperties(void);
 
 /**
  * Create a set of properties.
@@ -87,7 +87,7 @@ extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetGlobalProperties(void);
  *
  * \sa SDL_DestroyProperties
  */
-extern DECLSPEC SDL_PropertiesID SDLCALL SDL_CreateProperties(void);
+extern SDL_DECLSPEC_RETURN SDL_PropertiesID SDLCALL SDL_CreateProperties(void);
 
 /**
  * Copy a set of properties.
@@ -106,7 +106,7 @@ extern DECLSPEC SDL_PropertiesID SDLCALL SDL_CreateProperties(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_CopyProperties(SDL_PropertiesID src, SDL_PropertiesID dst);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_CopyProperties(SDL_PropertiesID src, SDL_PropertiesID dst);
 
 /**
  * Lock a set of properties.
@@ -130,7 +130,7 @@ extern DECLSPEC int SDLCALL SDL_CopyProperties(SDL_PropertiesID src, SDL_Propert
  *
  * \sa SDL_UnlockProperties
  */
-extern DECLSPEC int SDLCALL SDL_LockProperties(SDL_PropertiesID props);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_LockProperties(SDL_PropertiesID props);
 
 /**
  * Unlock a set of properties.
@@ -143,7 +143,7 @@ extern DECLSPEC int SDLCALL SDL_LockProperties(SDL_PropertiesID props);
  *
  * \sa SDL_LockProperties
  */
-extern DECLSPEC void SDLCALL SDL_UnlockProperties(SDL_PropertiesID props);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_UnlockProperties(SDL_PropertiesID props);
 
 /**
  * Set a property on a set of properties with a cleanup function that is
@@ -168,7 +168,7 @@ extern DECLSPEC void SDLCALL SDL_UnlockProperties(SDL_PropertiesID props);
  * \sa SDL_GetProperty
  * \sa SDL_SetProperty
  */
-extern DECLSPEC int SDLCALL SDL_SetPropertyWithCleanup(SDL_PropertiesID props, const char *name, void *value, void (SDLCALL *cleanup)(void *userdata, void *value), void *userdata);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetPropertyWithCleanup(SDL_PropertiesID props, const char *name, void *value, void (SDLCALL *cleanup)(void *userdata, void *value), void *userdata);
 
 /**
  * Set a property on a set of properties.
@@ -191,7 +191,7 @@ extern DECLSPEC int SDLCALL SDL_SetPropertyWithCleanup(SDL_PropertiesID props, c
  * \sa SDL_SetPropertyWithCleanup
  * \sa SDL_SetStringProperty
  */
-extern DECLSPEC int SDLCALL SDL_SetProperty(SDL_PropertiesID props, const char *name, void *value);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetProperty(SDL_PropertiesID props, const char *name, void *value);
 
 /**
  * Set a string property on a set of properties.
@@ -211,7 +211,7 @@ extern DECLSPEC int SDLCALL SDL_SetProperty(SDL_PropertiesID props, const char *
  *
  * \sa SDL_GetStringProperty
  */
-extern DECLSPEC int SDLCALL SDL_SetStringProperty(SDL_PropertiesID props, const char *name, const char *value);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetStringProperty(SDL_PropertiesID props, const char *name, const char *value);
 
 /**
  * Set an integer property on a set of properties.
@@ -228,7 +228,7 @@ extern DECLSPEC int SDLCALL SDL_SetStringProperty(SDL_PropertiesID props, const 
  *
  * \sa SDL_GetNumberProperty
  */
-extern DECLSPEC int SDLCALL SDL_SetNumberProperty(SDL_PropertiesID props, const char *name, Sint64 value);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetNumberProperty(SDL_PropertiesID props, const char *name, Sint64 value);
 
 /**
  * Set a floating point property on a set of properties.
@@ -245,7 +245,7 @@ extern DECLSPEC int SDLCALL SDL_SetNumberProperty(SDL_PropertiesID props, const 
  *
  * \sa SDL_GetFloatProperty
  */
-extern DECLSPEC int SDLCALL SDL_SetFloatProperty(SDL_PropertiesID props, const char *name, float value);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetFloatProperty(SDL_PropertiesID props, const char *name, float value);
 
 /**
  * Set a boolean property on a set of properties.
@@ -262,7 +262,7 @@ extern DECLSPEC int SDLCALL SDL_SetFloatProperty(SDL_PropertiesID props, const c
  *
  * \sa SDL_GetBooleanProperty
  */
-extern DECLSPEC int SDLCALL SDL_SetBooleanProperty(SDL_PropertiesID props, const char *name, SDL_bool value);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetBooleanProperty(SDL_PropertiesID props, const char *name, SDL_bool value);
 
 /**
  * Return whether a property exists in a set of properties.
@@ -277,7 +277,7 @@ extern DECLSPEC int SDLCALL SDL_SetBooleanProperty(SDL_PropertiesID props, const
  *
  * \sa SDL_GetPropertyType
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasProperty(SDL_PropertiesID props, const char *name);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasProperty(SDL_PropertiesID props, const char *name);
 
 /**
  * Get the type of a property on a set of properties.
@@ -293,7 +293,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasProperty(SDL_PropertiesID props, const c
  *
  * \sa SDL_HasProperty
  */
-extern DECLSPEC SDL_PropertyType SDLCALL SDL_GetPropertyType(SDL_PropertiesID props, const char *name);
+extern SDL_DECLSPEC_RETURN SDL_PropertyType SDLCALL SDL_GetPropertyType(SDL_PropertiesID props, const char *name);
 
 /**
  * Get a property on a set of properties.
@@ -325,7 +325,7 @@ extern DECLSPEC SDL_PropertyType SDLCALL SDL_GetPropertyType(SDL_PropertiesID pr
  * \sa SDL_HasProperty
  * \sa SDL_SetProperty
  */
-extern DECLSPEC void *SDLCALL SDL_GetProperty(SDL_PropertiesID props, const char *name, void *default_value);
+extern SDL_DECLSPEC_RETURN void *SDLCALL SDL_GetProperty(SDL_PropertiesID props, const char *name, void *default_value);
 
 /**
  * Get a string property on a set of properties.
@@ -344,7 +344,7 @@ extern DECLSPEC void *SDLCALL SDL_GetProperty(SDL_PropertiesID props, const char
  * \sa SDL_HasProperty
  * \sa SDL_SetStringProperty
  */
-extern DECLSPEC const char *SDLCALL SDL_GetStringProperty(SDL_PropertiesID props, const char *name, const char *default_value);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetStringProperty(SDL_PropertiesID props, const char *name, const char *default_value);
 
 /**
  * Get a number property on a set of properties.
@@ -366,7 +366,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetStringProperty(SDL_PropertiesID props
  * \sa SDL_HasProperty
  * \sa SDL_SetNumberProperty
  */
-extern DECLSPEC Sint64 SDLCALL SDL_GetNumberProperty(SDL_PropertiesID props, const char *name, Sint64 default_value);
+extern SDL_DECLSPEC_RETURN Sint64 SDLCALL SDL_GetNumberProperty(SDL_PropertiesID props, const char *name, Sint64 default_value);
 
 /**
  * Get a floating point property on a set of properties.
@@ -388,7 +388,7 @@ extern DECLSPEC Sint64 SDLCALL SDL_GetNumberProperty(SDL_PropertiesID props, con
  * \sa SDL_HasProperty
  * \sa SDL_SetFloatProperty
  */
-extern DECLSPEC float SDLCALL SDL_GetFloatProperty(SDL_PropertiesID props, const char *name, float default_value);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_GetFloatProperty(SDL_PropertiesID props, const char *name, float default_value);
 
 /**
  * Get a boolean property on a set of properties.
@@ -410,7 +410,7 @@ extern DECLSPEC float SDLCALL SDL_GetFloatProperty(SDL_PropertiesID props, const
  * \sa SDL_HasProperty
  * \sa SDL_SetBooleanProperty
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GetBooleanProperty(SDL_PropertiesID props, const char *name, SDL_bool default_value);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GetBooleanProperty(SDL_PropertiesID props, const char *name, SDL_bool default_value);
 
 /**
  * Clear a property on a set of properties.
@@ -424,7 +424,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_GetBooleanProperty(SDL_PropertiesID props, 
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_ClearProperty(SDL_PropertiesID props, const char *name);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ClearProperty(SDL_PropertiesID props, const char *name);
 
 typedef void (SDLCALL *SDL_EnumeratePropertiesCallback)(void *userdata, SDL_PropertiesID props, const char *name);
 
@@ -444,7 +444,7 @@ typedef void (SDLCALL *SDL_EnumeratePropertiesCallback)(void *userdata, SDL_Prop
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_EnumerateProperties(SDL_PropertiesID props, SDL_EnumeratePropertiesCallback callback, void *userdata);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_EnumerateProperties(SDL_PropertiesID props, SDL_EnumeratePropertiesCallback callback, void *userdata);
 
 /**
  * Destroy a set of properties.
@@ -462,7 +462,7 @@ extern DECLSPEC int SDLCALL SDL_EnumerateProperties(SDL_PropertiesID props, SDL_
  *
  * \sa SDL_CreateProperties
  */
-extern DECLSPEC void SDLCALL SDL_DestroyProperties(SDL_PropertiesID props);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_DestroyProperties(SDL_PropertiesID props);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_rect.h
+++ b/include/SDL3/SDL_rect.h
@@ -202,7 +202,7 @@ SDL_FORCE_INLINE SDL_bool SDL_RectsEqual(const SDL_Rect *a, const SDL_Rect *b)
  *
  * \sa SDL_GetRectIntersection
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasRectIntersection(const SDL_Rect * A,
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasRectIntersection(const SDL_Rect * A,
                                                          const SDL_Rect * B);
 
 /**
@@ -220,7 +220,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasRectIntersection(const SDL_Rect * A,
  *
  * \sa SDL_HasRectIntersection
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GetRectIntersection(const SDL_Rect * A,
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GetRectIntersection(const SDL_Rect * A,
                                                    const SDL_Rect * B,
                                                    SDL_Rect * result);
 
@@ -236,7 +236,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_GetRectIntersection(const SDL_Rect * A,
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetRectUnion(const SDL_Rect * A,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetRectUnion(const SDL_Rect * A,
                                            const SDL_Rect * B,
                                            SDL_Rect * result);
 
@@ -257,7 +257,7 @@ extern DECLSPEC int SDLCALL SDL_GetRectUnion(const SDL_Rect * A,
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GetRectEnclosingPoints(const SDL_Point * points,
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GetRectEnclosingPoints(const SDL_Point * points,
                                                    int count,
                                                    const SDL_Rect * clip,
                                                    SDL_Rect * result);
@@ -280,7 +280,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_GetRectEnclosingPoints(const SDL_Point * po
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GetRectAndLineIntersection(const SDL_Rect *
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GetRectAndLineIntersection(const SDL_Rect *
                                                           rect, int *X1,
                                                           int *Y1, int *X2,
                                                           int *Y2);
@@ -415,7 +415,7 @@ SDL_FORCE_INLINE SDL_bool SDL_RectsEqualFloat(const SDL_FRect *a, const SDL_FRec
  *
  * \sa SDL_GetRectIntersection
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_HasRectIntersectionFloat(const SDL_FRect * A,
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_HasRectIntersectionFloat(const SDL_FRect * A,
                                                       const SDL_FRect * B);
 
 /**
@@ -433,7 +433,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_HasRectIntersectionFloat(const SDL_FRect * 
  *
  * \sa SDL_HasRectIntersectionFloat
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GetRectIntersectionFloat(const SDL_FRect * A,
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GetRectIntersectionFloat(const SDL_FRect * A,
                                                     const SDL_FRect * B,
                                                     SDL_FRect * result);
 
@@ -449,7 +449,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_GetRectIntersectionFloat(const SDL_FRect * 
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetRectUnionFloat(const SDL_FRect * A,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetRectUnionFloat(const SDL_FRect * A,
                                             const SDL_FRect * B,
                                             SDL_FRect * result);
 
@@ -471,7 +471,7 @@ extern DECLSPEC int SDLCALL SDL_GetRectUnionFloat(const SDL_FRect * A,
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GetRectEnclosingPointsFloat(const SDL_FPoint * points,
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GetRectEnclosingPointsFloat(const SDL_FPoint * points,
                                                     int count,
                                                     const SDL_FRect * clip,
                                                     SDL_FRect * result);
@@ -495,7 +495,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_GetRectEnclosingPointsFloat(const SDL_FPoin
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GetRectAndLineIntersectionFloat(const SDL_FRect *
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GetRectAndLineIntersectionFloat(const SDL_FRect *
                                                            rect, float *X1,
                                                            float *Y1, float *X2,
                                                            float *Y2);

--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -153,7 +153,7 @@ typedef struct SDL_Texture SDL_Texture;
  * \sa SDL_CreateRenderer
  * \sa SDL_GetRenderDriver
  */
-extern DECLSPEC int SDLCALL SDL_GetNumRenderDrivers(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetNumRenderDrivers(void);
 
 /**
  * Use this function to get the name of a built in 2D rendering driver.
@@ -178,7 +178,7 @@ extern DECLSPEC int SDLCALL SDL_GetNumRenderDrivers(void);
  *
  * \sa SDL_GetNumRenderDrivers
  */
-extern DECLSPEC const char *SDLCALL SDL_GetRenderDriver(int index);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetRenderDriver(int index);
 
 /**
  * Create a window and default renderer.
@@ -198,7 +198,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetRenderDriver(int index);
  * \sa SDL_CreateRenderer
  * \sa SDL_CreateWindow
  */
-extern DECLSPEC int SDLCALL SDL_CreateWindowAndRenderer(const char *title, int width, int height, SDL_WindowFlags window_flags, SDL_Window **window, SDL_Renderer **renderer);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_CreateWindowAndRenderer(const char *title, int width, int height, SDL_WindowFlags window_flags, SDL_Window **window, SDL_Renderer **renderer);
 
 /**
  * Create a 2D rendering context for a window.
@@ -228,7 +228,7 @@ extern DECLSPEC int SDLCALL SDL_CreateWindowAndRenderer(const char *title, int w
  * \sa SDL_GetRenderDriver
  * \sa SDL_GetRendererInfo
  */
-extern DECLSPEC SDL_Renderer * SDLCALL SDL_CreateRenderer(SDL_Window *window, const char *name);
+extern SDL_DECLSPEC_RETURN SDL_Renderer * SDLCALL SDL_CreateRenderer(SDL_Window *window, const char *name);
 
 /**
  * Create a 2D rendering context for a window, with the specified properties.
@@ -279,7 +279,7 @@ extern DECLSPEC SDL_Renderer * SDLCALL SDL_CreateRenderer(SDL_Window *window, co
  * \sa SDL_DestroyRenderer
  * \sa SDL_GetRendererInfo
  */
-extern DECLSPEC SDL_Renderer * SDLCALL SDL_CreateRendererWithProperties(SDL_PropertiesID props);
+extern SDL_DECLSPEC_RETURN SDL_Renderer * SDLCALL SDL_CreateRendererWithProperties(SDL_PropertiesID props);
 
 #define SDL_PROP_RENDERER_CREATE_NAME_STRING                                "name"
 #define SDL_PROP_RENDERER_CREATE_WINDOW_POINTER                             "window"
@@ -310,7 +310,7 @@ extern DECLSPEC SDL_Renderer * SDLCALL SDL_CreateRendererWithProperties(SDL_Prop
  *
  * \sa SDL_DestroyRenderer
  */
-extern DECLSPEC SDL_Renderer *SDLCALL SDL_CreateSoftwareRenderer(SDL_Surface *surface);
+extern SDL_DECLSPEC_RETURN SDL_Renderer *SDLCALL SDL_CreateSoftwareRenderer(SDL_Surface *surface);
 
 /**
  * Get the renderer associated with a window.
@@ -321,7 +321,7 @@ extern DECLSPEC SDL_Renderer *SDLCALL SDL_CreateSoftwareRenderer(SDL_Surface *su
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_Renderer *SDLCALL SDL_GetRenderer(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN SDL_Renderer *SDLCALL SDL_GetRenderer(SDL_Window *window);
 
 /**
  * Get the window associated with a renderer.
@@ -332,7 +332,7 @@ extern DECLSPEC SDL_Renderer *SDLCALL SDL_GetRenderer(SDL_Window *window);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_Window *SDLCALL SDL_GetRenderWindow(SDL_Renderer *renderer);
+extern SDL_DECLSPEC_RETURN SDL_Window *SDLCALL SDL_GetRenderWindow(SDL_Renderer *renderer);
 
 /**
  * Get information about a rendering context.
@@ -348,7 +348,7 @@ extern DECLSPEC SDL_Window *SDLCALL SDL_GetRenderWindow(SDL_Renderer *renderer);
  * \sa SDL_CreateRenderer
  * \sa SDL_CreateRendererWithProperties
  */
-extern DECLSPEC int SDLCALL SDL_GetRendererInfo(SDL_Renderer *renderer, SDL_RendererInfo *info);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetRendererInfo(SDL_Renderer *renderer, SDL_RendererInfo *info);
 
 /**
  * Get the properties associated with a renderer.
@@ -427,7 +427,7 @@ extern DECLSPEC int SDLCALL SDL_GetRendererInfo(SDL_Renderer *renderer, SDL_Rend
  * \sa SDL_GetProperty
  * \sa SDL_SetProperty
  */
-extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetRendererProperties(SDL_Renderer *renderer);
+extern SDL_DECLSPEC_RETURN SDL_PropertiesID SDLCALL SDL_GetRendererProperties(SDL_Renderer *renderer);
 
 #define SDL_PROP_RENDERER_NAME_STRING                               "SDL.renderer.name"
 #define SDL_PROP_RENDERER_WINDOW_POINTER                            "SDL.renderer.window"
@@ -468,7 +468,7 @@ extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetRendererProperties(SDL_Renderer 
  *
  * \sa SDL_GetCurrentRenderOutputSize
  */
-extern DECLSPEC int SDLCALL SDL_GetRenderOutputSize(SDL_Renderer *renderer, int *w, int *h);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetRenderOutputSize(SDL_Renderer *renderer, int *w, int *h);
 
 /**
  * Get the current output size in pixels of a rendering context.
@@ -488,7 +488,7 @@ extern DECLSPEC int SDLCALL SDL_GetRenderOutputSize(SDL_Renderer *renderer, int 
  *
  * \sa SDL_GetRenderOutputSize
  */
-extern DECLSPEC int SDLCALL SDL_GetCurrentRenderOutputSize(SDL_Renderer *renderer, int *w, int *h);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetCurrentRenderOutputSize(SDL_Renderer *renderer, int *w, int *h);
 
 /**
  * Create a texture for a rendering context.
@@ -510,7 +510,7 @@ extern DECLSPEC int SDLCALL SDL_GetCurrentRenderOutputSize(SDL_Renderer *rendere
  * \sa SDL_QueryTexture
  * \sa SDL_UpdateTexture
  */
-extern DECLSPEC SDL_Texture *SDLCALL SDL_CreateTexture(SDL_Renderer *renderer, SDL_PixelFormatEnum format, int access, int w, int h);
+extern SDL_DECLSPEC_RETURN SDL_Texture *SDLCALL SDL_CreateTexture(SDL_Renderer *renderer, SDL_PixelFormatEnum format, int access, int w, int h);
 
 /**
  * Create a texture from an existing surface.
@@ -537,7 +537,7 @@ extern DECLSPEC SDL_Texture *SDLCALL SDL_CreateTexture(SDL_Renderer *renderer, S
  * \sa SDL_DestroyTexture
  * \sa SDL_QueryTexture
  */
-extern DECLSPEC SDL_Texture *SDLCALL SDL_CreateTextureFromSurface(SDL_Renderer *renderer, SDL_Surface *surface);
+extern SDL_DECLSPEC_RETURN SDL_Texture *SDLCALL SDL_CreateTextureFromSurface(SDL_Renderer *renderer, SDL_Surface *surface);
 
 /**
  * Create a texture for a rendering context with the specified properties.
@@ -648,7 +648,7 @@ extern DECLSPEC SDL_Texture *SDLCALL SDL_CreateTextureFromSurface(SDL_Renderer *
  * \sa SDL_QueryTexture
  * \sa SDL_UpdateTexture
  */
-extern DECLSPEC SDL_Texture *SDLCALL SDL_CreateTextureWithProperties(SDL_Renderer *renderer, SDL_PropertiesID props);
+extern SDL_DECLSPEC_RETURN SDL_Texture *SDLCALL SDL_CreateTextureWithProperties(SDL_Renderer *renderer, SDL_PropertiesID props);
 
 #define SDL_PROP_TEXTURE_CREATE_COLORSPACE_NUMBER           "colorspace"
 #define SDL_PROP_TEXTURE_CREATE_FORMAT_NUMBER               "format"
@@ -766,7 +766,7 @@ extern DECLSPEC SDL_Texture *SDLCALL SDL_CreateTextureWithProperties(SDL_Rendere
  * \sa SDL_GetProperty
  * \sa SDL_SetProperty
  */
-extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetTextureProperties(SDL_Texture *texture);
+extern SDL_DECLSPEC_RETURN SDL_PropertiesID SDLCALL SDL_GetTextureProperties(SDL_Texture *texture);
 
 #define SDL_PROP_TEXTURE_COLORSPACE_NUMBER                  "SDL.texture.colorspace"
 #define SDL_PROP_TEXTURE_SDR_WHITE_POINT_FLOAT              "SDL.texture.SDR_white_point"
@@ -802,7 +802,7 @@ extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetTextureProperties(SDL_Texture *t
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_Renderer *SDLCALL SDL_GetRendererFromTexture(SDL_Texture *texture);
+extern SDL_DECLSPEC_RETURN SDL_Renderer *SDLCALL SDL_GetRendererFromTexture(SDL_Texture *texture);
 
 /**
  * Query the attributes of a texture.
@@ -824,7 +824,7 @@ extern DECLSPEC SDL_Renderer *SDLCALL SDL_GetRendererFromTexture(SDL_Texture *te
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_QueryTexture(SDL_Texture *texture, SDL_PixelFormatEnum *format, int *access, int *w, int *h);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_QueryTexture(SDL_Texture *texture, SDL_PixelFormatEnum *format, int *access, int *w, int *h);
 
 /**
  * Set an additional color value multiplied into render copy operations.
@@ -851,7 +851,7 @@ extern DECLSPEC int SDLCALL SDL_QueryTexture(SDL_Texture *texture, SDL_PixelForm
  * \sa SDL_SetTextureAlphaMod
  * \sa SDL_SetTextureColorModFloat
  */
-extern DECLSPEC int SDLCALL SDL_SetTextureColorMod(SDL_Texture *texture, Uint8 r, Uint8 g, Uint8 b);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetTextureColorMod(SDL_Texture *texture, Uint8 r, Uint8 g, Uint8 b);
 
 
 /**
@@ -879,7 +879,7 @@ extern DECLSPEC int SDLCALL SDL_SetTextureColorMod(SDL_Texture *texture, Uint8 r
  * \sa SDL_SetTextureAlphaModFloat
  * \sa SDL_SetTextureColorMod
  */
-extern DECLSPEC int SDLCALL SDL_SetTextureColorModFloat(SDL_Texture *texture, float r, float g, float b);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetTextureColorModFloat(SDL_Texture *texture, float r, float g, float b);
 
 
 /**
@@ -898,7 +898,7 @@ extern DECLSPEC int SDLCALL SDL_SetTextureColorModFloat(SDL_Texture *texture, fl
  * \sa SDL_GetTextureColorModFloat
  * \sa SDL_SetTextureColorMod
  */
-extern DECLSPEC int SDLCALL SDL_GetTextureColorMod(SDL_Texture *texture, Uint8 *r, Uint8 *g, Uint8 *b);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetTextureColorMod(SDL_Texture *texture, Uint8 *r, Uint8 *g, Uint8 *b);
 
 /**
  * Get the additional color value multiplied into render copy operations.
@@ -916,7 +916,7 @@ extern DECLSPEC int SDLCALL SDL_GetTextureColorMod(SDL_Texture *texture, Uint8 *
  * \sa SDL_GetTextureColorMod
  * \sa SDL_SetTextureColorModFloat
  */
-extern DECLSPEC int SDLCALL SDL_GetTextureColorModFloat(SDL_Texture *texture, float *r, float *g, float *b);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetTextureColorModFloat(SDL_Texture *texture, float *r, float *g, float *b);
 
 /**
  * Set an additional alpha value multiplied into render copy operations.
@@ -940,7 +940,7 @@ extern DECLSPEC int SDLCALL SDL_GetTextureColorModFloat(SDL_Texture *texture, fl
  * \sa SDL_SetTextureAlphaModFloat
  * \sa SDL_SetTextureColorMod
  */
-extern DECLSPEC int SDLCALL SDL_SetTextureAlphaMod(SDL_Texture *texture, Uint8 alpha);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetTextureAlphaMod(SDL_Texture *texture, Uint8 alpha);
 
 /**
  * Set an additional alpha value multiplied into render copy operations.
@@ -964,7 +964,7 @@ extern DECLSPEC int SDLCALL SDL_SetTextureAlphaMod(SDL_Texture *texture, Uint8 a
  * \sa SDL_SetTextureAlphaMod
  * \sa SDL_SetTextureColorModFloat
  */
-extern DECLSPEC int SDLCALL SDL_SetTextureAlphaModFloat(SDL_Texture *texture, float alpha);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetTextureAlphaModFloat(SDL_Texture *texture, float alpha);
 
 /**
  * Get the additional alpha value multiplied into render copy operations.
@@ -980,7 +980,7 @@ extern DECLSPEC int SDLCALL SDL_SetTextureAlphaModFloat(SDL_Texture *texture, fl
  * \sa SDL_GetTextureColorMod
  * \sa SDL_SetTextureAlphaMod
  */
-extern DECLSPEC int SDLCALL SDL_GetTextureAlphaMod(SDL_Texture *texture, Uint8 *alpha);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetTextureAlphaMod(SDL_Texture *texture, Uint8 *alpha);
 
 /**
  * Get the additional alpha value multiplied into render copy operations.
@@ -996,7 +996,7 @@ extern DECLSPEC int SDLCALL SDL_GetTextureAlphaMod(SDL_Texture *texture, Uint8 *
  * \sa SDL_GetTextureColorModFloat
  * \sa SDL_SetTextureAlphaModFloat
  */
-extern DECLSPEC int SDLCALL SDL_GetTextureAlphaModFloat(SDL_Texture *texture, float *alpha);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetTextureAlphaModFloat(SDL_Texture *texture, float *alpha);
 
 /**
  * Set the blend mode for a texture, used by SDL_RenderTexture().
@@ -1013,7 +1013,7 @@ extern DECLSPEC int SDLCALL SDL_GetTextureAlphaModFloat(SDL_Texture *texture, fl
  *
  * \sa SDL_GetTextureBlendMode
  */
-extern DECLSPEC int SDLCALL SDL_SetTextureBlendMode(SDL_Texture *texture, SDL_BlendMode blendMode);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetTextureBlendMode(SDL_Texture *texture, SDL_BlendMode blendMode);
 
 /**
  * Get the blend mode used for texture copy operations.
@@ -1027,7 +1027,7 @@ extern DECLSPEC int SDLCALL SDL_SetTextureBlendMode(SDL_Texture *texture, SDL_Bl
  *
  * \sa SDL_SetTextureBlendMode
  */
-extern DECLSPEC int SDLCALL SDL_GetTextureBlendMode(SDL_Texture *texture, SDL_BlendMode *blendMode);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetTextureBlendMode(SDL_Texture *texture, SDL_BlendMode *blendMode);
 
 /**
  * Set the scale mode used for texture scale operations.
@@ -1045,7 +1045,7 @@ extern DECLSPEC int SDLCALL SDL_GetTextureBlendMode(SDL_Texture *texture, SDL_Bl
  *
  * \sa SDL_GetTextureScaleMode
  */
-extern DECLSPEC int SDLCALL SDL_SetTextureScaleMode(SDL_Texture *texture, SDL_ScaleMode scaleMode);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetTextureScaleMode(SDL_Texture *texture, SDL_ScaleMode scaleMode);
 
 /**
  * Get the scale mode used for texture scale operations.
@@ -1059,7 +1059,7 @@ extern DECLSPEC int SDLCALL SDL_SetTextureScaleMode(SDL_Texture *texture, SDL_Sc
  *
  * \sa SDL_SetTextureScaleMode
  */
-extern DECLSPEC int SDLCALL SDL_GetTextureScaleMode(SDL_Texture *texture, SDL_ScaleMode *scaleMode);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetTextureScaleMode(SDL_Texture *texture, SDL_ScaleMode *scaleMode);
 
 /**
  * Update the given texture rectangle with new pixel data.
@@ -1091,7 +1091,7 @@ extern DECLSPEC int SDLCALL SDL_GetTextureScaleMode(SDL_Texture *texture, SDL_Sc
  * \sa SDL_UpdateNVTexture
  * \sa SDL_UpdateYUVTexture
  */
-extern DECLSPEC int SDLCALL SDL_UpdateTexture(SDL_Texture *texture, const SDL_Rect *rect, const void *pixels, int pitch);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_UpdateTexture(SDL_Texture *texture, const SDL_Rect *rect, const void *pixels, int pitch);
 
 /**
  * Update a rectangle within a planar YV12 or IYUV texture with new pixel
@@ -1121,7 +1121,7 @@ extern DECLSPEC int SDLCALL SDL_UpdateTexture(SDL_Texture *texture, const SDL_Re
  * \sa SDL_UpdateNVTexture
  * \sa SDL_UpdateTexture
  */
-extern DECLSPEC int SDLCALL SDL_UpdateYUVTexture(SDL_Texture *texture,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_UpdateYUVTexture(SDL_Texture *texture,
                                                  const SDL_Rect *rect,
                                                  const Uint8 *Yplane, int Ypitch,
                                                  const Uint8 *Uplane, int Upitch,
@@ -1151,7 +1151,7 @@ extern DECLSPEC int SDLCALL SDL_UpdateYUVTexture(SDL_Texture *texture,
  * \sa SDL_UpdateTexture
  * \sa SDL_UpdateYUVTexture
  */
-extern DECLSPEC int SDLCALL SDL_UpdateNVTexture(SDL_Texture *texture,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_UpdateNVTexture(SDL_Texture *texture,
                                                  const SDL_Rect *rect,
                                                  const Uint8 *Yplane, int Ypitch,
                                                  const Uint8 *UVplane, int UVpitch);
@@ -1184,7 +1184,7 @@ extern DECLSPEC int SDLCALL SDL_UpdateNVTexture(SDL_Texture *texture,
  * \sa SDL_LockTextureToSurface
  * \sa SDL_UnlockTexture
  */
-extern DECLSPEC int SDLCALL SDL_LockTexture(SDL_Texture *texture,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_LockTexture(SDL_Texture *texture,
                                             const SDL_Rect *rect,
                                             void **pixels, int *pitch);
 
@@ -1220,7 +1220,7 @@ extern DECLSPEC int SDLCALL SDL_LockTexture(SDL_Texture *texture,
  * \sa SDL_LockTexture
  * \sa SDL_UnlockTexture
  */
-extern DECLSPEC int SDLCALL SDL_LockTextureToSurface(SDL_Texture *texture,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_LockTextureToSurface(SDL_Texture *texture,
                                             const SDL_Rect *rect,
                                             SDL_Surface **surface);
 
@@ -1241,7 +1241,7 @@ extern DECLSPEC int SDLCALL SDL_LockTextureToSurface(SDL_Texture *texture,
  *
  * \sa SDL_LockTexture
  */
-extern DECLSPEC void SDLCALL SDL_UnlockTexture(SDL_Texture *texture);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_UnlockTexture(SDL_Texture *texture);
 
 /**
  * Set a texture as the current rendering target.
@@ -1261,7 +1261,7 @@ extern DECLSPEC void SDLCALL SDL_UnlockTexture(SDL_Texture *texture);
  *
  * \sa SDL_GetRenderTarget
  */
-extern DECLSPEC int SDLCALL SDL_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture);
 
 /**
  * Get the current render target.
@@ -1276,7 +1276,7 @@ extern DECLSPEC int SDLCALL SDL_SetRenderTarget(SDL_Renderer *renderer, SDL_Text
  *
  * \sa SDL_SetRenderTarget
  */
-extern DECLSPEC SDL_Texture *SDLCALL SDL_GetRenderTarget(SDL_Renderer *renderer);
+extern SDL_DECLSPEC_RETURN SDL_Texture *SDLCALL SDL_GetRenderTarget(SDL_Renderer *renderer);
 
 /**
  * Set a device independent resolution and presentation mode for rendering.
@@ -1305,7 +1305,7 @@ extern DECLSPEC SDL_Texture *SDLCALL SDL_GetRenderTarget(SDL_Renderer *renderer)
  * \sa SDL_ConvertEventToRenderCoordinates
  * \sa SDL_GetRenderLogicalPresentation
  */
-extern DECLSPEC int SDLCALL SDL_SetRenderLogicalPresentation(SDL_Renderer *renderer, int w, int h, SDL_RendererLogicalPresentation mode, SDL_ScaleMode scale_mode);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetRenderLogicalPresentation(SDL_Renderer *renderer, int w, int h, SDL_RendererLogicalPresentation mode, SDL_ScaleMode scale_mode);
 
 /**
  * Get device independent resolution and presentation mode for rendering.
@@ -1325,7 +1325,7 @@ extern DECLSPEC int SDLCALL SDL_SetRenderLogicalPresentation(SDL_Renderer *rende
  *
  * \sa SDL_SetRenderLogicalPresentation
  */
-extern DECLSPEC int SDLCALL SDL_GetRenderLogicalPresentation(SDL_Renderer *renderer, int *w, int *h, SDL_RendererLogicalPresentation *mode, SDL_ScaleMode *scale_mode);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetRenderLogicalPresentation(SDL_Renderer *renderer, int *w, int *h, SDL_RendererLogicalPresentation *mode, SDL_ScaleMode *scale_mode);
 
 /**
  * Get a point in render coordinates when given a point in window coordinates.
@@ -1343,7 +1343,7 @@ extern DECLSPEC int SDLCALL SDL_GetRenderLogicalPresentation(SDL_Renderer *rende
  * \sa SDL_SetRenderLogicalPresentation
  * \sa SDL_SetRenderScale
  */
-extern DECLSPEC int SDLCALL SDL_RenderCoordinatesFromWindow(SDL_Renderer *renderer, float window_x, float window_y, float *x, float *y);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenderCoordinatesFromWindow(SDL_Renderer *renderer, float window_x, float window_y, float *x, float *y);
 
 /**
  * Get a point in window coordinates when given a point in render coordinates.
@@ -1363,7 +1363,7 @@ extern DECLSPEC int SDLCALL SDL_RenderCoordinatesFromWindow(SDL_Renderer *render
  * \sa SDL_SetRenderLogicalPresentation
  * \sa SDL_SetRenderScale
  */
-extern DECLSPEC int SDLCALL SDL_RenderCoordinatesToWindow(SDL_Renderer *renderer, float x, float y, float *window_x, float *window_y);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenderCoordinatesToWindow(SDL_Renderer *renderer, float x, float y, float *window_x, float *window_y);
 
 /**
  * Convert the coordinates in an event to render coordinates.
@@ -1382,7 +1382,7 @@ extern DECLSPEC int SDLCALL SDL_RenderCoordinatesToWindow(SDL_Renderer *renderer
  *
  * \sa SDL_GetRenderCoordinatesFromWindowCoordinates
  */
-extern DECLSPEC int SDLCALL SDL_ConvertEventToRenderCoordinates(SDL_Renderer *renderer, SDL_Event *event);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ConvertEventToRenderCoordinates(SDL_Renderer *renderer, SDL_Event *event);
 
 /**
  * Set the drawing area for rendering on the current target.
@@ -1398,7 +1398,7 @@ extern DECLSPEC int SDLCALL SDL_ConvertEventToRenderCoordinates(SDL_Renderer *re
  * \sa SDL_GetRenderViewport
  * \sa SDL_RenderViewportSet
  */
-extern DECLSPEC int SDLCALL SDL_SetRenderViewport(SDL_Renderer *renderer, const SDL_Rect *rect);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetRenderViewport(SDL_Renderer *renderer, const SDL_Rect *rect);
 
 /**
  * Get the drawing area for the current target.
@@ -1413,7 +1413,7 @@ extern DECLSPEC int SDLCALL SDL_SetRenderViewport(SDL_Renderer *renderer, const 
  * \sa SDL_RenderViewportSet
  * \sa SDL_SetRenderViewport
  */
-extern DECLSPEC int SDLCALL SDL_GetRenderViewport(SDL_Renderer *renderer, SDL_Rect *rect);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetRenderViewport(SDL_Renderer *renderer, SDL_Rect *rect);
 
 /**
  * Return whether an explicit rectangle was set as the viewport.
@@ -1431,7 +1431,7 @@ extern DECLSPEC int SDLCALL SDL_GetRenderViewport(SDL_Renderer *renderer, SDL_Re
  * \sa SDL_GetRenderViewport
  * \sa SDL_SetRenderViewport
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_RenderViewportSet(SDL_Renderer *renderer);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_RenderViewportSet(SDL_Renderer *renderer);
 
 /**
  * Set the clip rectangle for rendering on the specified target.
@@ -1447,7 +1447,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_RenderViewportSet(SDL_Renderer *renderer);
  * \sa SDL_GetRenderClipRect
  * \sa SDL_RenderClipEnabled
  */
-extern DECLSPEC int SDLCALL SDL_SetRenderClipRect(SDL_Renderer *renderer, const SDL_Rect *rect);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetRenderClipRect(SDL_Renderer *renderer, const SDL_Rect *rect);
 
 /**
  * Get the clip rectangle for the current target.
@@ -1463,7 +1463,7 @@ extern DECLSPEC int SDLCALL SDL_SetRenderClipRect(SDL_Renderer *renderer, const 
  * \sa SDL_RenderClipEnabled
  * \sa SDL_SetRenderClipRect
  */
-extern DECLSPEC int SDLCALL SDL_GetRenderClipRect(SDL_Renderer *renderer, SDL_Rect *rect);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetRenderClipRect(SDL_Renderer *renderer, SDL_Rect *rect);
 
 /**
  * Get whether clipping is enabled on the given renderer.
@@ -1477,7 +1477,7 @@ extern DECLSPEC int SDLCALL SDL_GetRenderClipRect(SDL_Renderer *renderer, SDL_Re
  * \sa SDL_GetRenderClipRect
  * \sa SDL_SetRenderClipRect
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_RenderClipEnabled(SDL_Renderer *renderer);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_RenderClipEnabled(SDL_Renderer *renderer);
 
 /**
  * Set the drawing scale for rendering on the current target.
@@ -1500,7 +1500,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_RenderClipEnabled(SDL_Renderer *renderer);
  *
  * \sa SDL_GetRenderScale
  */
-extern DECLSPEC int SDLCALL SDL_SetRenderScale(SDL_Renderer *renderer, float scaleX, float scaleY);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetRenderScale(SDL_Renderer *renderer, float scaleX, float scaleY);
 
 /**
  * Get the drawing scale for the current target.
@@ -1515,7 +1515,7 @@ extern DECLSPEC int SDLCALL SDL_SetRenderScale(SDL_Renderer *renderer, float sca
  *
  * \sa SDL_SetRenderScale
  */
-extern DECLSPEC int SDLCALL SDL_GetRenderScale(SDL_Renderer *renderer, float *scaleX, float *scaleY);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetRenderScale(SDL_Renderer *renderer, float *scaleX, float *scaleY);
 
 /**
  * Set the color used for drawing operations.
@@ -1538,7 +1538,7 @@ extern DECLSPEC int SDLCALL SDL_GetRenderScale(SDL_Renderer *renderer, float *sc
  * \sa SDL_GetRenderDrawColor
  * \sa SDL_SetRenderDrawColorFloat
  */
-extern DECLSPEC int SDLCALL SDL_SetRenderDrawColor(SDL_Renderer *renderer, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetRenderDrawColor(SDL_Renderer *renderer, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 /**
  * Set the color used for drawing operations (Rect, Line and Clear).
@@ -1561,7 +1561,7 @@ extern DECLSPEC int SDLCALL SDL_SetRenderDrawColor(SDL_Renderer *renderer, Uint8
  * \sa SDL_GetRenderDrawColorFloat
  * \sa SDL_SetRenderDrawColor
  */
-extern DECLSPEC int SDLCALL SDL_SetRenderDrawColorFloat(SDL_Renderer *renderer, float r, float g, float b, float a);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetRenderDrawColorFloat(SDL_Renderer *renderer, float r, float g, float b, float a);
 
 /**
  * Get the color used for drawing operations (Rect, Line and Clear).
@@ -1583,7 +1583,7 @@ extern DECLSPEC int SDLCALL SDL_SetRenderDrawColorFloat(SDL_Renderer *renderer, 
  * \sa SDL_GetRenderDrawColorFloat
  * \sa SDL_SetRenderDrawColor
  */
-extern DECLSPEC int SDLCALL SDL_GetRenderDrawColor(SDL_Renderer *renderer, Uint8 *r, Uint8 *g, Uint8 *b, Uint8 *a);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetRenderDrawColor(SDL_Renderer *renderer, Uint8 *r, Uint8 *g, Uint8 *b, Uint8 *a);
 
 /**
  * Get the color used for drawing operations (Rect, Line and Clear).
@@ -1605,7 +1605,7 @@ extern DECLSPEC int SDLCALL SDL_GetRenderDrawColor(SDL_Renderer *renderer, Uint8
  * \sa SDL_SetRenderDrawColorFloat
  * \sa SDL_GetRenderDrawColor
  */
-extern DECLSPEC int SDLCALL SDL_GetRenderDrawColorFloat(SDL_Renderer *renderer, float *r, float *g, float *b, float *a);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetRenderDrawColorFloat(SDL_Renderer *renderer, float *r, float *g, float *b, float *a);
 
 /**
  * Set the color scale used for render operations.
@@ -1627,7 +1627,7 @@ extern DECLSPEC int SDLCALL SDL_GetRenderDrawColorFloat(SDL_Renderer *renderer, 
  *
  * \sa SDL_GetRenderColorScale
  */
-extern DECLSPEC int SDLCALL SDL_SetRenderColorScale(SDL_Renderer *renderer, float scale);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetRenderColorScale(SDL_Renderer *renderer, float scale);
 
 /**
  * Get the color scale used for render operations.
@@ -1641,7 +1641,7 @@ extern DECLSPEC int SDLCALL SDL_SetRenderColorScale(SDL_Renderer *renderer, floa
  *
  * \sa SDL_SetRenderColorScale
  */
-extern DECLSPEC int SDLCALL SDL_GetRenderColorScale(SDL_Renderer *renderer, float *scale);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetRenderColorScale(SDL_Renderer *renderer, float *scale);
 
 /**
  * Set the blend mode used for drawing operations (Fill and Line).
@@ -1657,7 +1657,7 @@ extern DECLSPEC int SDLCALL SDL_GetRenderColorScale(SDL_Renderer *renderer, floa
  *
  * \sa SDL_GetRenderDrawBlendMode
  */
-extern DECLSPEC int SDLCALL SDL_SetRenderDrawBlendMode(SDL_Renderer *renderer, SDL_BlendMode blendMode);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetRenderDrawBlendMode(SDL_Renderer *renderer, SDL_BlendMode blendMode);
 
 /**
  * Get the blend mode used for drawing operations.
@@ -1671,7 +1671,7 @@ extern DECLSPEC int SDLCALL SDL_SetRenderDrawBlendMode(SDL_Renderer *renderer, S
  *
  * \sa SDL_SetRenderDrawBlendMode
  */
-extern DECLSPEC int SDLCALL SDL_GetRenderDrawBlendMode(SDL_Renderer *renderer, SDL_BlendMode *blendMode);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetRenderDrawBlendMode(SDL_Renderer *renderer, SDL_BlendMode *blendMode);
 
 /**
  * Clear the current rendering target with the drawing color.
@@ -1687,7 +1687,7 @@ extern DECLSPEC int SDLCALL SDL_GetRenderDrawBlendMode(SDL_Renderer *renderer, S
  *
  * \sa SDL_SetRenderDrawColor
  */
-extern DECLSPEC int SDLCALL SDL_RenderClear(SDL_Renderer *renderer);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenderClear(SDL_Renderer *renderer);
 
 /**
  * Draw a point on the current rendering target at subpixel precision.
@@ -1701,7 +1701,7 @@ extern DECLSPEC int SDLCALL SDL_RenderClear(SDL_Renderer *renderer);
  *
  * \sa SDL_RenderPoints
  */
-extern DECLSPEC int SDLCALL SDL_RenderPoint(SDL_Renderer *renderer, float x, float y);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenderPoint(SDL_Renderer *renderer, float x, float y);
 
 /**
  * Draw multiple points on the current rendering target at subpixel precision.
@@ -1716,7 +1716,7 @@ extern DECLSPEC int SDLCALL SDL_RenderPoint(SDL_Renderer *renderer, float x, flo
  *
  * \sa SDL_RenderPoint
  */
-extern DECLSPEC int SDLCALL SDL_RenderPoints(SDL_Renderer *renderer, const SDL_FPoint *points, int count);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenderPoints(SDL_Renderer *renderer, const SDL_FPoint *points, int count);
 
 /**
  * Draw a line on the current rendering target at subpixel precision.
@@ -1732,7 +1732,7 @@ extern DECLSPEC int SDLCALL SDL_RenderPoints(SDL_Renderer *renderer, const SDL_F
  *
  * \sa SDL_RenderLines
  */
-extern DECLSPEC int SDLCALL SDL_RenderLine(SDL_Renderer *renderer, float x1, float y1, float x2, float y2);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenderLine(SDL_Renderer *renderer, float x1, float y1, float x2, float y2);
 
 /**
  * Draw a series of connected lines on the current rendering target at
@@ -1748,7 +1748,7 @@ extern DECLSPEC int SDLCALL SDL_RenderLine(SDL_Renderer *renderer, float x1, flo
  *
  * \sa SDL_RenderLine
  */
-extern DECLSPEC int SDLCALL SDL_RenderLines(SDL_Renderer *renderer, const SDL_FPoint *points, int count);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenderLines(SDL_Renderer *renderer, const SDL_FPoint *points, int count);
 
 /**
  * Draw a rectangle on the current rendering target at subpixel precision.
@@ -1762,7 +1762,7 @@ extern DECLSPEC int SDLCALL SDL_RenderLines(SDL_Renderer *renderer, const SDL_FP
  *
  * \sa SDL_RenderRects
  */
-extern DECLSPEC int SDLCALL SDL_RenderRect(SDL_Renderer *renderer, const SDL_FRect *rect);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenderRect(SDL_Renderer *renderer, const SDL_FRect *rect);
 
 /**
  * Draw some number of rectangles on the current rendering target at subpixel
@@ -1778,7 +1778,7 @@ extern DECLSPEC int SDLCALL SDL_RenderRect(SDL_Renderer *renderer, const SDL_FRe
  *
  * \sa SDL_RenderRect
  */
-extern DECLSPEC int SDLCALL SDL_RenderRects(SDL_Renderer *renderer, const SDL_FRect *rects, int count);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenderRects(SDL_Renderer *renderer, const SDL_FRect *rects, int count);
 
 /**
  * Fill a rectangle on the current rendering target with the drawing color at
@@ -1793,7 +1793,7 @@ extern DECLSPEC int SDLCALL SDL_RenderRects(SDL_Renderer *renderer, const SDL_FR
  *
  * \sa SDL_RenderFillRects
  */
-extern DECLSPEC int SDLCALL SDL_RenderFillRect(SDL_Renderer *renderer, const SDL_FRect *rect);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenderFillRect(SDL_Renderer *renderer, const SDL_FRect *rect);
 
 /**
  * Fill some number of rectangles on the current rendering target with the
@@ -1809,7 +1809,7 @@ extern DECLSPEC int SDLCALL SDL_RenderFillRect(SDL_Renderer *renderer, const SDL
  *
  * \sa SDL_RenderFillRect
  */
-extern DECLSPEC int SDLCALL SDL_RenderFillRects(SDL_Renderer *renderer, const SDL_FRect *rects, int count);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenderFillRects(SDL_Renderer *renderer, const SDL_FRect *rects, int count);
 
 /**
  * Copy a portion of the texture to the current rendering target at subpixel
@@ -1827,7 +1827,7 @@ extern DECLSPEC int SDLCALL SDL_RenderFillRects(SDL_Renderer *renderer, const SD
  *
  * \sa SDL_RenderTextureRotated
  */
-extern DECLSPEC int SDLCALL SDL_RenderTexture(SDL_Renderer *renderer, SDL_Texture *texture, const SDL_FRect *srcrect, const SDL_FRect *dstrect);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenderTexture(SDL_Renderer *renderer, SDL_Texture *texture, const SDL_FRect *srcrect, const SDL_FRect *dstrect);
 
 /**
  * Copy a portion of the source texture to the current rendering target, with
@@ -1853,7 +1853,7 @@ extern DECLSPEC int SDLCALL SDL_RenderTexture(SDL_Renderer *renderer, SDL_Textur
  *
  * \sa SDL_RenderTexture
  */
-extern DECLSPEC int SDLCALL SDL_RenderTextureRotated(SDL_Renderer *renderer, SDL_Texture *texture,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenderTextureRotated(SDL_Renderer *renderer, SDL_Texture *texture,
                                                      const SDL_FRect *srcrect, const SDL_FRect *dstrect,
                                                      const double angle, const SDL_FPoint *center,
                                                      const SDL_FlipMode flip);
@@ -1877,7 +1877,7 @@ extern DECLSPEC int SDLCALL SDL_RenderTextureRotated(SDL_Renderer *renderer, SDL
  *
  * \sa SDL_RenderGeometryRaw
  */
-extern DECLSPEC int SDLCALL SDL_RenderGeometry(SDL_Renderer *renderer,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenderGeometry(SDL_Renderer *renderer,
                                                SDL_Texture *texture,
                                                const SDL_Vertex *vertices, int num_vertices,
                                                const int *indices, int num_indices);
@@ -1907,7 +1907,7 @@ extern DECLSPEC int SDLCALL SDL_RenderGeometry(SDL_Renderer *renderer,
  *
  * \sa SDL_RenderGeometry
  */
-extern DECLSPEC int SDLCALL SDL_RenderGeometryRaw(SDL_Renderer *renderer,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenderGeometryRaw(SDL_Renderer *renderer,
                                                SDL_Texture *texture,
                                                const float *xy, int xy_stride,
                                                const SDL_Color *color, int color_stride,
@@ -1941,7 +1941,7 @@ extern DECLSPEC int SDLCALL SDL_RenderGeometryRaw(SDL_Renderer *renderer,
  * \sa SDL_RenderGeometry
  * \sa SDL_RenderGeometryRaw
  */
-extern DECLSPEC int SDLCALL SDL_RenderGeometryRawFloat(SDL_Renderer *renderer,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenderGeometryRawFloat(SDL_Renderer *renderer,
                                                SDL_Texture *texture,
                                                const float *xy, int xy_stride,
                                                const SDL_FColor *color, int color_stride,
@@ -1966,7 +1966,7 @@ extern DECLSPEC int SDLCALL SDL_RenderGeometryRawFloat(SDL_Renderer *renderer,
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_Surface * SDLCALL SDL_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rect *rect);
+extern SDL_DECLSPEC_RETURN SDL_Surface * SDLCALL SDL_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rect *rect);
 
 /**
  * Update the screen with any rendering performed since the previous call.
@@ -2007,7 +2007,7 @@ extern DECLSPEC SDL_Surface * SDLCALL SDL_RenderReadPixels(SDL_Renderer *rendere
  * \sa SDL_SetRenderDrawBlendMode
  * \sa SDL_SetRenderDrawColor
  */
-extern DECLSPEC int SDLCALL SDL_RenderPresent(SDL_Renderer *renderer);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenderPresent(SDL_Renderer *renderer);
 
 /**
  * Destroy the specified texture.
@@ -2022,7 +2022,7 @@ extern DECLSPEC int SDLCALL SDL_RenderPresent(SDL_Renderer *renderer);
  * \sa SDL_CreateTexture
  * \sa SDL_CreateTextureFromSurface
  */
-extern DECLSPEC void SDLCALL SDL_DestroyTexture(SDL_Texture *texture);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_DestroyTexture(SDL_Texture *texture);
 
 /**
  * Destroy the rendering context for a window and free associated textures.
@@ -2036,7 +2036,7 @@ extern DECLSPEC void SDLCALL SDL_DestroyTexture(SDL_Texture *texture);
  *
  * \sa SDL_CreateRenderer
  */
-extern DECLSPEC void SDLCALL SDL_DestroyRenderer(SDL_Renderer *renderer);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_DestroyRenderer(SDL_Renderer *renderer);
 
 /**
  * Force the rendering context to flush any pending commands and state.
@@ -2067,7 +2067,7 @@ extern DECLSPEC void SDLCALL SDL_DestroyRenderer(SDL_Renderer *renderer);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_FlushRenderer(SDL_Renderer *renderer);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_FlushRenderer(SDL_Renderer *renderer);
 
 /**
  * Get the CAMetalLayer associated with the given Metal renderer.
@@ -2083,7 +2083,7 @@ extern DECLSPEC int SDLCALL SDL_FlushRenderer(SDL_Renderer *renderer);
  *
  * \sa SDL_GetRenderMetalCommandEncoder
  */
-extern DECLSPEC void *SDLCALL SDL_GetRenderMetalLayer(SDL_Renderer *renderer);
+extern SDL_DECLSPEC_RETURN void *SDLCALL SDL_GetRenderMetalLayer(SDL_Renderer *renderer);
 
 /**
  * Get the Metal command encoder for the current frame.
@@ -2104,7 +2104,7 @@ extern DECLSPEC void *SDLCALL SDL_GetRenderMetalLayer(SDL_Renderer *renderer);
  *
  * \sa SDL_GetRenderMetalLayer
  */
-extern DECLSPEC void *SDLCALL SDL_GetRenderMetalCommandEncoder(SDL_Renderer *renderer);
+extern SDL_DECLSPEC_RETURN void *SDLCALL SDL_GetRenderMetalCommandEncoder(SDL_Renderer *renderer);
 
 
 /**
@@ -2132,7 +2132,7 @@ extern DECLSPEC void *SDLCALL SDL_GetRenderMetalCommandEncoder(SDL_Renderer *ren
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_AddVulkanRenderSemaphores(SDL_Renderer *renderer, Uint32 wait_stage_mask, Sint64 wait_semaphore, Sint64 signal_semaphore);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_AddVulkanRenderSemaphores(SDL_Renderer *renderer, Uint32 wait_stage_mask, Sint64 wait_semaphore, Sint64 signal_semaphore);
 
 /**
  * Toggle VSync of the given renderer.
@@ -2153,7 +2153,7 @@ extern DECLSPEC int SDLCALL SDL_AddVulkanRenderSemaphores(SDL_Renderer *renderer
  *
  * \sa SDL_GetRenderVSync
  */
-extern DECLSPEC int SDLCALL SDL_SetRenderVSync(SDL_Renderer *renderer, int vsync);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetRenderVSync(SDL_Renderer *renderer, int vsync);
 
 #define SDL_RENDERER_VSYNC_DISABLED 0
 #define SDL_RENDERER_VSYNC_ADAPTIVE (-1)
@@ -2171,7 +2171,7 @@ extern DECLSPEC int SDLCALL SDL_SetRenderVSync(SDL_Renderer *renderer, int vsync
  *
  * \sa SDL_SetRenderVSync
  */
-extern DECLSPEC int SDLCALL SDL_GetRenderVSync(SDL_Renderer *renderer, int *vsync);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetRenderVSync(SDL_Renderer *renderer, int *vsync);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -228,7 +228,7 @@ extern SDL_DECLSPEC_RETURN int SDLCALL SDL_CreateWindowAndRenderer(const char *t
  * \sa SDL_GetRenderDriver
  * \sa SDL_GetRendererInfo
  */
-extern SDL_DECLSPEC_RETURN SDL_Renderer * SDLCALL SDL_CreateRenderer(SDL_Window *window, const char *name);
+extern SDL_DECLSPEC_NODISCARD SDL_Renderer * SDLCALL SDL_CreateRenderer(SDL_Window *window, const char *name);
 
 /**
  * Create a 2D rendering context for a window, with the specified properties.
@@ -279,7 +279,7 @@ extern SDL_DECLSPEC_RETURN SDL_Renderer * SDLCALL SDL_CreateRenderer(SDL_Window 
  * \sa SDL_DestroyRenderer
  * \sa SDL_GetRendererInfo
  */
-extern SDL_DECLSPEC_RETURN SDL_Renderer * SDLCALL SDL_CreateRendererWithProperties(SDL_PropertiesID props);
+extern SDL_DECLSPEC_NODISCARD SDL_Renderer * SDLCALL SDL_CreateRendererWithProperties(SDL_PropertiesID props);
 
 #define SDL_PROP_RENDERER_CREATE_NAME_STRING                                "name"
 #define SDL_PROP_RENDERER_CREATE_WINDOW_POINTER                             "window"
@@ -310,7 +310,7 @@ extern SDL_DECLSPEC_RETURN SDL_Renderer * SDLCALL SDL_CreateRendererWithProperti
  *
  * \sa SDL_DestroyRenderer
  */
-extern SDL_DECLSPEC_RETURN SDL_Renderer *SDLCALL SDL_CreateSoftwareRenderer(SDL_Surface *surface);
+extern SDL_DECLSPEC_NODISCARD SDL_Renderer *SDLCALL SDL_CreateSoftwareRenderer(SDL_Surface *surface);
 
 /**
  * Get the renderer associated with a window.
@@ -510,7 +510,7 @@ extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetCurrentRenderOutputSize(SDL_Render
  * \sa SDL_QueryTexture
  * \sa SDL_UpdateTexture
  */
-extern SDL_DECLSPEC_RETURN SDL_Texture *SDLCALL SDL_CreateTexture(SDL_Renderer *renderer, SDL_PixelFormatEnum format, int access, int w, int h);
+extern SDL_DECLSPEC_NODISCARD SDL_Texture *SDLCALL SDL_CreateTexture(SDL_Renderer *renderer, SDL_PixelFormatEnum format, int access, int w, int h);
 
 /**
  * Create a texture from an existing surface.
@@ -537,7 +537,7 @@ extern SDL_DECLSPEC_RETURN SDL_Texture *SDLCALL SDL_CreateTexture(SDL_Renderer *
  * \sa SDL_DestroyTexture
  * \sa SDL_QueryTexture
  */
-extern SDL_DECLSPEC_RETURN SDL_Texture *SDLCALL SDL_CreateTextureFromSurface(SDL_Renderer *renderer, SDL_Surface *surface);
+extern SDL_DECLSPEC_NODISCARD SDL_Texture *SDLCALL SDL_CreateTextureFromSurface(SDL_Renderer *renderer, SDL_Surface *surface);
 
 /**
  * Create a texture for a rendering context with the specified properties.
@@ -648,7 +648,7 @@ extern SDL_DECLSPEC_RETURN SDL_Texture *SDLCALL SDL_CreateTextureFromSurface(SDL
  * \sa SDL_QueryTexture
  * \sa SDL_UpdateTexture
  */
-extern SDL_DECLSPEC_RETURN SDL_Texture *SDLCALL SDL_CreateTextureWithProperties(SDL_Renderer *renderer, SDL_PropertiesID props);
+extern SDL_DECLSPEC_NODISCARD SDL_Texture *SDLCALL SDL_CreateTextureWithProperties(SDL_Renderer *renderer, SDL_PropertiesID props);
 
 #define SDL_PROP_TEXTURE_CREATE_COLORSPACE_NUMBER           "colorspace"
 #define SDL_PROP_TEXTURE_CREATE_FORMAT_NUMBER               "format"
@@ -1966,7 +1966,7 @@ extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenderGeometryRawFloat(SDL_Renderer *
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern SDL_DECLSPEC_RETURN SDL_Surface * SDLCALL SDL_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rect *rect);
+extern SDL_DECLSPEC_NODISCARD SDL_Surface * SDLCALL SDL_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rect *rect);
 
 /**
  * Update the screen with any rendering performed since the previous call.

--- a/include/SDL3/SDL_sensor.h
+++ b/include/SDL3/SDL_sensor.h
@@ -153,7 +153,7 @@ typedef enum SDL_SensorType
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern SDL_DECLSPEC_RETURN SDL_SensorID *SDLCALL SDL_GetSensors(int *count);
+extern SDL_DECLSPEC_NODISCARD SDL_SensorID *SDLCALL SDL_GetSensors(int *count);
 
 /**
  * Get the implementation dependent name of a sensor.
@@ -195,7 +195,7 @@ extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetSensorInstanceNonPortableType(SDL_
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern SDL_DECLSPEC_RETURN SDL_Sensor *SDLCALL SDL_OpenSensor(SDL_SensorID instance_id);
+extern SDL_DECLSPEC_NODISCARD SDL_Sensor *SDLCALL SDL_OpenSensor(SDL_SensorID instance_id);
 
 /**
  * Return the SDL_Sensor associated with an instance ID.

--- a/include/SDL3/SDL_sensor.h
+++ b/include/SDL3/SDL_sensor.h
@@ -153,7 +153,7 @@ typedef enum SDL_SensorType
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_SensorID *SDLCALL SDL_GetSensors(int *count);
+extern SDL_DECLSPEC_RETURN SDL_SensorID *SDLCALL SDL_GetSensors(int *count);
 
 /**
  * Get the implementation dependent name of a sensor.
@@ -163,7 +163,7 @@ extern DECLSPEC SDL_SensorID *SDLCALL SDL_GetSensors(int *count);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC const char *SDLCALL SDL_GetSensorInstanceName(SDL_SensorID instance_id);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetSensorInstanceName(SDL_SensorID instance_id);
 
 /**
  * Get the type of a sensor.
@@ -174,7 +174,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetSensorInstanceName(SDL_SensorID insta
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_SensorType SDLCALL SDL_GetSensorInstanceType(SDL_SensorID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_SensorType SDLCALL SDL_GetSensorInstanceType(SDL_SensorID instance_id);
 
 /**
  * Get the platform dependent type of a sensor.
@@ -185,7 +185,7 @@ extern DECLSPEC SDL_SensorType SDLCALL SDL_GetSensorInstanceType(SDL_SensorID in
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetSensorInstanceNonPortableType(SDL_SensorID instance_id);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetSensorInstanceNonPortableType(SDL_SensorID instance_id);
 
 /**
  * Open a sensor for use.
@@ -195,7 +195,7 @@ extern DECLSPEC int SDLCALL SDL_GetSensorInstanceNonPortableType(SDL_SensorID in
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_Sensor *SDLCALL SDL_OpenSensor(SDL_SensorID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_Sensor *SDLCALL SDL_OpenSensor(SDL_SensorID instance_id);
 
 /**
  * Return the SDL_Sensor associated with an instance ID.
@@ -205,7 +205,7 @@ extern DECLSPEC SDL_Sensor *SDLCALL SDL_OpenSensor(SDL_SensorID instance_id);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_Sensor *SDLCALL SDL_GetSensorFromInstanceID(SDL_SensorID instance_id);
+extern SDL_DECLSPEC_RETURN SDL_Sensor *SDLCALL SDL_GetSensorFromInstanceID(SDL_SensorID instance_id);
 
 /**
  * Get the properties associated with a sensor.
@@ -219,7 +219,7 @@ extern DECLSPEC SDL_Sensor *SDLCALL SDL_GetSensorFromInstanceID(SDL_SensorID ins
  * \sa SDL_GetProperty
  * \sa SDL_SetProperty
  */
-extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetSensorProperties(SDL_Sensor *sensor);
+extern SDL_DECLSPEC_RETURN SDL_PropertiesID SDLCALL SDL_GetSensorProperties(SDL_Sensor *sensor);
 
 /**
  * Get the implementation dependent name of a sensor.
@@ -229,7 +229,7 @@ extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetSensorProperties(SDL_Sensor *sen
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC const char *SDLCALL SDL_GetSensorName(SDL_Sensor *sensor);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetSensorName(SDL_Sensor *sensor);
 
 /**
  * Get the type of a sensor.
@@ -240,7 +240,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetSensorName(SDL_Sensor *sensor);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_SensorType SDLCALL SDL_GetSensorType(SDL_Sensor *sensor);
+extern SDL_DECLSPEC_RETURN SDL_SensorType SDLCALL SDL_GetSensorType(SDL_Sensor *sensor);
 
 /**
  * Get the platform dependent type of a sensor.
@@ -250,7 +250,7 @@ extern DECLSPEC SDL_SensorType SDLCALL SDL_GetSensorType(SDL_Sensor *sensor);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetSensorNonPortableType(SDL_Sensor *sensor);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetSensorNonPortableType(SDL_Sensor *sensor);
 
 /**
  * Get the instance ID of a sensor.
@@ -260,7 +260,7 @@ extern DECLSPEC int SDLCALL SDL_GetSensorNonPortableType(SDL_Sensor *sensor);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_SensorID SDLCALL SDL_GetSensorInstanceID(SDL_Sensor *sensor);
+extern SDL_DECLSPEC_RETURN SDL_SensorID SDLCALL SDL_GetSensorInstanceID(SDL_Sensor *sensor);
 
 /**
  * Get the current state of an opened sensor.
@@ -275,7 +275,7 @@ extern DECLSPEC SDL_SensorID SDLCALL SDL_GetSensorInstanceID(SDL_Sensor *sensor)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetSensorData(SDL_Sensor *sensor, float *data, int num_values);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetSensorData(SDL_Sensor *sensor, float *data, int num_values);
 
 /**
  * Close a sensor previously opened with SDL_OpenSensor().
@@ -284,7 +284,7 @@ extern DECLSPEC int SDLCALL SDL_GetSensorData(SDL_Sensor *sensor, float *data, i
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_CloseSensor(SDL_Sensor *sensor);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_CloseSensor(SDL_Sensor *sensor);
 
 /**
  * Update the current state of the open sensors.
@@ -297,7 +297,7 @@ extern DECLSPEC void SDLCALL SDL_CloseSensor(SDL_Sensor *sensor);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_UpdateSensors(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_UpdateSensors(void);
 
 
 /* Ends C function definitions when using C++ */

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -482,9 +482,9 @@ extern "C" {
 #define SDL_stack_free(data)            SDL_free(data)
 #endif
 
-extern SDL_DECLSPEC_RETURN SDL_MALLOC void *SDLCALL SDL_malloc(size_t size);
-extern SDL_DECLSPEC_RETURN SDL_MALLOC SDL_ALLOC_SIZE2(1, 2) void *SDLCALL SDL_calloc(size_t nmemb, size_t size);
-extern SDL_DECLSPEC_RETURN SDL_ALLOC_SIZE(2) void *SDLCALL SDL_realloc(void *mem, size_t size);
+extern SDL_DECLSPEC_NODISCARD SDL_MALLOC void *SDLCALL SDL_malloc(size_t size);
+extern SDL_DECLSPEC_NODISCARD SDL_MALLOC SDL_ALLOC_SIZE2(1, 2) void *SDLCALL SDL_calloc(size_t nmemb, size_t size);
+extern SDL_DECLSPEC_NODISCARD SDL_ALLOC_SIZE(2) void *SDLCALL SDL_realloc(void *mem, size_t size);
 extern SDL_DECLSPEC_VOID void SDLCALL SDL_free(void *mem);
 
 typedef void *(SDLCALL *SDL_malloc_func)(size_t size);
@@ -558,7 +558,7 @@ extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetMemoryFunctions(SDL_malloc_func ma
  *
  * \sa SDL_aligned_free
  */
-extern SDL_DECLSPEC_RETURN SDL_MALLOC void *SDLCALL SDL_aligned_alloc(size_t alignment, size_t size);
+extern SDL_DECLSPEC_NODISCARD SDL_MALLOC void *SDLCALL SDL_aligned_alloc(size_t alignment, size_t size);
 
 /**
  * Free memory allocated by SDL_aligned_alloc().
@@ -2402,7 +2402,7 @@ extern SDL_DECLSPEC_RETURN size_t SDLCALL SDL_iconv(SDL_iconv_t cd, const char *
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_iconv_string(const char *tocode,
+extern SDL_DECLSPEC_NODISCARD char *SDLCALL SDL_iconv_string(const char *tocode,
                                                const char *fromcode,
                                                const char *inbuf,
                                                size_t inbytesleft);

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -482,10 +482,10 @@ extern "C" {
 #define SDL_stack_free(data)            SDL_free(data)
 #endif
 
-extern DECLSPEC SDL_MALLOC void *SDLCALL SDL_malloc(size_t size);
-extern DECLSPEC SDL_MALLOC SDL_ALLOC_SIZE2(1, 2) void *SDLCALL SDL_calloc(size_t nmemb, size_t size);
-extern DECLSPEC SDL_ALLOC_SIZE(2) void *SDLCALL SDL_realloc(void *mem, size_t size);
-extern DECLSPEC void SDLCALL SDL_free(void *mem);
+extern SDL_DECLSPEC_RETURN SDL_MALLOC void *SDLCALL SDL_malloc(size_t size);
+extern SDL_DECLSPEC_RETURN SDL_MALLOC SDL_ALLOC_SIZE2(1, 2) void *SDLCALL SDL_calloc(size_t nmemb, size_t size);
+extern SDL_DECLSPEC_RETURN SDL_ALLOC_SIZE(2) void *SDLCALL SDL_realloc(void *mem, size_t size);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_free(void *mem);
 
 typedef void *(SDLCALL *SDL_malloc_func)(size_t size);
 typedef void *(SDLCALL *SDL_calloc_func)(size_t nmemb, size_t size);
@@ -502,7 +502,7 @@ typedef void (SDLCALL *SDL_free_func)(void *mem);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_GetOriginalMemoryFunctions(SDL_malloc_func *malloc_func,
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_GetOriginalMemoryFunctions(SDL_malloc_func *malloc_func,
                                                             SDL_calloc_func *calloc_func,
                                                             SDL_realloc_func *realloc_func,
                                                             SDL_free_func *free_func);
@@ -517,7 +517,7 @@ extern DECLSPEC void SDLCALL SDL_GetOriginalMemoryFunctions(SDL_malloc_func *mal
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_GetMemoryFunctions(SDL_malloc_func *malloc_func,
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_GetMemoryFunctions(SDL_malloc_func *malloc_func,
                                                     SDL_calloc_func *calloc_func,
                                                     SDL_realloc_func *realloc_func,
                                                     SDL_free_func *free_func);
@@ -534,7 +534,7 @@ extern DECLSPEC void SDLCALL SDL_GetMemoryFunctions(SDL_malloc_func *malloc_func
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SetMemoryFunctions(SDL_malloc_func malloc_func,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetMemoryFunctions(SDL_malloc_func malloc_func,
                                                    SDL_calloc_func calloc_func,
                                                    SDL_realloc_func realloc_func,
                                                    SDL_free_func free_func);
@@ -558,7 +558,7 @@ extern DECLSPEC int SDLCALL SDL_SetMemoryFunctions(SDL_malloc_func malloc_func,
  *
  * \sa SDL_aligned_free
  */
-extern DECLSPEC SDL_MALLOC void *SDLCALL SDL_aligned_alloc(size_t alignment, size_t size);
+extern SDL_DECLSPEC_RETURN SDL_MALLOC void *SDLCALL SDL_aligned_alloc(size_t alignment, size_t size);
 
 /**
  * Free memory allocated by SDL_aligned_alloc().
@@ -567,7 +567,7 @@ extern DECLSPEC SDL_MALLOC void *SDLCALL SDL_aligned_alloc(size_t alignment, siz
  *
  * \sa SDL_aligned_alloc
  */
-extern DECLSPEC void SDLCALL SDL_aligned_free(void *mem);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_aligned_free(void *mem);
 
 /**
  * Get the number of outstanding (unfreed) allocations.
@@ -576,18 +576,18 @@ extern DECLSPEC void SDLCALL SDL_aligned_free(void *mem);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetNumAllocations(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetNumAllocations(void);
 
-extern DECLSPEC char *SDLCALL SDL_getenv(const char *name);
-extern DECLSPEC int SDLCALL SDL_setenv(const char *name, const char *value, int overwrite);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_getenv(const char *name);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_setenv(const char *name, const char *value, int overwrite);
 
-extern DECLSPEC void SDLCALL SDL_qsort(void *base, size_t nmemb, size_t size, int (SDLCALL *compare) (const void *, const void *));
-extern DECLSPEC void * SDLCALL SDL_bsearch(const void *key, const void *base, size_t nmemb, size_t size, int (SDLCALL *compare) (const void *, const void *));
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_qsort(void *base, size_t nmemb, size_t size, int (SDLCALL *compare) (const void *, const void *));
+extern SDL_DECLSPEC_RETURN void * SDLCALL SDL_bsearch(const void *key, const void *base, size_t nmemb, size_t size, int (SDLCALL *compare) (const void *, const void *));
 
-extern DECLSPEC void SDLCALL SDL_qsort_r(void *base, size_t nmemb, size_t size, int (SDLCALL *compare) (void *, const void *, const void *), void *userdata);
-extern DECLSPEC void * SDLCALL SDL_bsearch_r(const void *key, const void *base, size_t nmemb, size_t size, int (SDLCALL *compare) (void *, const void *, const void *), void *userdata);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_qsort_r(void *base, size_t nmemb, size_t size, int (SDLCALL *compare) (void *, const void *, const void *), void *userdata);
+extern SDL_DECLSPEC_RETURN void * SDLCALL SDL_bsearch_r(const void *key, const void *base, size_t nmemb, size_t size, int (SDLCALL *compare) (void *, const void *, const void *), void *userdata);
 
-extern DECLSPEC int SDLCALL SDL_abs(int x);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_abs(int x);
 
 /* NOTE: these double-evaluate their arguments, so you should never have side effects in the parameters */
 #define SDL_min(x, y) (((x) < (y)) ? (x) : (y))
@@ -607,7 +607,7 @@ extern DECLSPEC int SDLCALL SDL_abs(int x);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_isalpha(int x);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_isalpha(int x);
 
 /**
  * Query if a character is alphabetic (a letter) or a number.
@@ -622,7 +622,7 @@ extern DECLSPEC int SDLCALL SDL_isalpha(int x);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_isalnum(int x);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_isalnum(int x);
 
 /**
  * Report if a character is blank (a space or tab).
@@ -637,7 +637,7 @@ extern DECLSPEC int SDLCALL SDL_isalnum(int x);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_isblank(int x);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_isblank(int x);
 
 /**
  * Report if a character is a control character.
@@ -652,7 +652,7 @@ extern DECLSPEC int SDLCALL SDL_isblank(int x);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_iscntrl(int x);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_iscntrl(int x);
 
 /**
  * Report if a character is a numeric digit.
@@ -667,7 +667,7 @@ extern DECLSPEC int SDLCALL SDL_iscntrl(int x);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_isdigit(int x);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_isdigit(int x);
 
 /**
  * Report if a character is a hexadecimal digit.
@@ -682,7 +682,7 @@ extern DECLSPEC int SDLCALL SDL_isdigit(int x);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_isxdigit(int x);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_isxdigit(int x);
 
 /**
  * Report if a character is a punctuation mark.
@@ -700,7 +700,7 @@ extern DECLSPEC int SDLCALL SDL_isxdigit(int x);
  * \sa SDL_isgraph
  * \sa SDL_isalnum
  */
-extern DECLSPEC int SDLCALL SDL_ispunct(int x);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ispunct(int x);
 
 /**
  * Report if a character is whitespace.
@@ -722,7 +722,7 @@ extern DECLSPEC int SDLCALL SDL_ispunct(int x);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_isspace(int x);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_isspace(int x);
 
 /**
  * Report if a character is upper case.
@@ -737,7 +737,7 @@ extern DECLSPEC int SDLCALL SDL_isspace(int x);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_isupper(int x);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_isupper(int x);
 
 /**
  * Report if a character is lower case.
@@ -752,7 +752,7 @@ extern DECLSPEC int SDLCALL SDL_isupper(int x);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_islower(int x);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_islower(int x);
 
 /**
  * Report if a character is "printable".
@@ -771,7 +771,7 @@ extern DECLSPEC int SDLCALL SDL_islower(int x);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_isprint(int x);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_isprint(int x);
 
 /**
  * Report if a character is any "printable" except space.
@@ -792,7 +792,7 @@ extern DECLSPEC int SDLCALL SDL_isprint(int x);
  *
  * \sa SDL_isprint
  */
-extern DECLSPEC int SDLCALL SDL_isgraph(int x);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_isgraph(int x);
 
 /**
  * Convert low-ASCII English letters to uppercase.
@@ -810,7 +810,7 @@ extern DECLSPEC int SDLCALL SDL_isgraph(int x);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_toupper(int x);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_toupper(int x);
 
 /**
  * Convert low-ASCII English letters to lowercase.
@@ -828,12 +828,12 @@ extern DECLSPEC int SDLCALL SDL_toupper(int x);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_tolower(int x);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_tolower(int x);
 
-extern DECLSPEC Uint16 SDLCALL SDL_crc16(Uint16 crc, const void *data, size_t len);
-extern DECLSPEC Uint32 SDLCALL SDL_crc32(Uint32 crc, const void *data, size_t len);
+extern SDL_DECLSPEC_RETURN Uint16 SDLCALL SDL_crc16(Uint16 crc, const void *data, size_t len);
+extern SDL_DECLSPEC_RETURN Uint32 SDLCALL SDL_crc32(Uint32 crc, const void *data, size_t len);
 
-extern DECLSPEC void *SDLCALL SDL_memcpy(SDL_OUT_BYTECAP(len) void *dst, SDL_IN_BYTECAP(len) const void *src, size_t len);
+extern SDL_DECLSPEC_RETURN void *SDLCALL SDL_memcpy(SDL_OUT_BYTECAP(len) void *dst, SDL_IN_BYTECAP(len) const void *src, size_t len);
 
 /* Take advantage of compiler optimizations for memcpy */
 #ifndef SDL_SLOW_MEMCPY
@@ -847,7 +847,7 @@ extern DECLSPEC void *SDLCALL SDL_memcpy(SDL_OUT_BYTECAP(len) void *dst, SDL_IN_
     { SDL_COMPILE_TIME_ASSERT(SDL_copyp, sizeof (*(dst)) == sizeof (*(src))); }             \
     SDL_memcpy((dst), (src), sizeof(*(src)))
 
-extern DECLSPEC void *SDLCALL SDL_memmove(SDL_OUT_BYTECAP(len) void *dst, SDL_IN_BYTECAP(len) const void *src, size_t len);
+extern SDL_DECLSPEC_RETURN void *SDLCALL SDL_memmove(SDL_OUT_BYTECAP(len) void *dst, SDL_IN_BYTECAP(len) const void *src, size_t len);
 
 /* Take advantage of compiler optimizations for memmove */
 #ifndef SDL_SLOW_MEMMOVE
@@ -857,8 +857,8 @@ extern DECLSPEC void *SDLCALL SDL_memmove(SDL_OUT_BYTECAP(len) void *dst, SDL_IN
 #define SDL_memmove memmove
 #endif
 
-extern DECLSPEC void *SDLCALL SDL_memset(SDL_OUT_BYTECAP(len) void *dst, int c, size_t len);
-extern DECLSPEC void *SDLCALL SDL_memset4(void *dst, Uint32 val, size_t dwords);
+extern SDL_DECLSPEC_RETURN void *SDLCALL SDL_memset(SDL_OUT_BYTECAP(len) void *dst, int c, size_t len);
+extern SDL_DECLSPEC_RETURN void *SDLCALL SDL_memset4(void *dst, Uint32 val, size_t dwords);
 
 /* Take advantage of compiler optimizations for memset */
 #ifndef SDL_SLOW_MEMSET
@@ -872,15 +872,15 @@ extern DECLSPEC void *SDLCALL SDL_memset4(void *dst, Uint32 val, size_t dwords);
 #define SDL_zerop(x) SDL_memset((x), 0, sizeof(*(x)))
 #define SDL_zeroa(x) SDL_memset((x), 0, sizeof((x)))
 
-extern DECLSPEC int SDLCALL SDL_memcmp(const void *s1, const void *s2, size_t len);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_memcmp(const void *s1, const void *s2, size_t len);
 
-extern DECLSPEC size_t SDLCALL SDL_wcslen(const wchar_t *wstr);
-extern DECLSPEC size_t SDLCALL SDL_wcsnlen(const wchar_t *wstr, size_t maxlen);
-extern DECLSPEC size_t SDLCALL SDL_wcslcpy(SDL_OUT_Z_CAP(maxlen) wchar_t *dst, const wchar_t *src, size_t maxlen);
-extern DECLSPEC size_t SDLCALL SDL_wcslcat(SDL_INOUT_Z_CAP(maxlen) wchar_t *dst, const wchar_t *src, size_t maxlen);
-extern DECLSPEC wchar_t *SDLCALL SDL_wcsdup(const wchar_t *wstr);
-extern DECLSPEC wchar_t *SDLCALL SDL_wcsstr(const wchar_t *haystack, const wchar_t *needle);
-extern DECLSPEC wchar_t *SDLCALL SDL_wcsnstr(const wchar_t *haystack, const wchar_t *needle, size_t maxlen);
+extern SDL_DECLSPEC_RETURN size_t SDLCALL SDL_wcslen(const wchar_t *wstr);
+extern SDL_DECLSPEC_RETURN size_t SDLCALL SDL_wcsnlen(const wchar_t *wstr, size_t maxlen);
+extern SDL_DECLSPEC_RETURN size_t SDLCALL SDL_wcslcpy(SDL_OUT_Z_CAP(maxlen) wchar_t *dst, const wchar_t *src, size_t maxlen);
+extern SDL_DECLSPEC_RETURN size_t SDLCALL SDL_wcslcat(SDL_INOUT_Z_CAP(maxlen) wchar_t *dst, const wchar_t *src, size_t maxlen);
+extern SDL_DECLSPEC_RETURN wchar_t *SDLCALL SDL_wcsdup(const wchar_t *wstr);
+extern SDL_DECLSPEC_RETURN wchar_t *SDLCALL SDL_wcsstr(const wchar_t *haystack, const wchar_t *needle);
+extern SDL_DECLSPEC_RETURN wchar_t *SDLCALL SDL_wcsnstr(const wchar_t *haystack, const wchar_t *needle, size_t maxlen);
 
 /**
  * Compare two null-terminated wide strings.
@@ -899,7 +899,7 @@ extern DECLSPEC wchar_t *SDLCALL SDL_wcsnstr(const wchar_t *haystack, const wcha
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_wcscmp(const wchar_t *str1, const wchar_t *str2);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_wcscmp(const wchar_t *str1, const wchar_t *str2);
 
 /**
  * Compare two wide strings up to a number of wchar_t values.
@@ -930,7 +930,7 @@ extern DECLSPEC int SDLCALL SDL_wcscmp(const wchar_t *str1, const wchar_t *str2)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_wcsncmp(const wchar_t *str1, const wchar_t *str2, size_t maxlen);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_wcsncmp(const wchar_t *str1, const wchar_t *str2, size_t maxlen);
 
 /**
  * Compare two null-terminated wide strings, case-insensitively.
@@ -960,7 +960,7 @@ extern DECLSPEC int SDLCALL SDL_wcsncmp(const wchar_t *str1, const wchar_t *str2
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_wcscasecmp(const wchar_t *str1, const wchar_t *str2);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_wcscasecmp(const wchar_t *str1, const wchar_t *str2);
 
 /**
  * Compare two wide strings, case-insensitively, up to a number of wchar_t.
@@ -1002,18 +1002,18 @@ extern DECLSPEC int SDLCALL SDL_wcscasecmp(const wchar_t *str1, const wchar_t *s
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_wcsncasecmp(const wchar_t *str1, const wchar_t *str2, size_t maxlen);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_wcsncasecmp(const wchar_t *str1, const wchar_t *str2, size_t maxlen);
 
-extern DECLSPEC long SDLCALL SDL_wcstol(const wchar_t *str, wchar_t **endp, int base);
+extern SDL_DECLSPEC_RETURN long SDLCALL SDL_wcstol(const wchar_t *str, wchar_t **endp, int base);
 
-extern DECLSPEC size_t SDLCALL SDL_strlen(const char *str);
-extern DECLSPEC size_t SDLCALL SDL_strnlen(const char *str, size_t maxlen);
-extern DECLSPEC size_t SDLCALL SDL_strlcpy(SDL_OUT_Z_CAP(maxlen) char *dst, const char *src, size_t maxlen);
-extern DECLSPEC size_t SDLCALL SDL_utf8strlcpy(SDL_OUT_Z_CAP(dst_bytes) char *dst, const char *src, size_t dst_bytes);
-extern DECLSPEC size_t SDLCALL SDL_strlcat(SDL_INOUT_Z_CAP(maxlen) char *dst, const char *src, size_t maxlen);
-extern DECLSPEC SDL_MALLOC char *SDLCALL SDL_strdup(const char *str);
-extern DECLSPEC SDL_MALLOC char *SDLCALL SDL_strndup(const char *str, size_t maxlen);
-extern DECLSPEC char *SDLCALL SDL_strrev(char *str);
+extern SDL_DECLSPEC_RETURN size_t SDLCALL SDL_strlen(const char *str);
+extern SDL_DECLSPEC_RETURN size_t SDLCALL SDL_strnlen(const char *str, size_t maxlen);
+extern SDL_DECLSPEC_RETURN size_t SDLCALL SDL_strlcpy(SDL_OUT_Z_CAP(maxlen) char *dst, const char *src, size_t maxlen);
+extern SDL_DECLSPEC_RETURN size_t SDLCALL SDL_utf8strlcpy(SDL_OUT_Z_CAP(dst_bytes) char *dst, const char *src, size_t dst_bytes);
+extern SDL_DECLSPEC_RETURN size_t SDLCALL SDL_strlcat(SDL_INOUT_Z_CAP(maxlen) char *dst, const char *src, size_t maxlen);
+extern SDL_DECLSPEC_RETURN SDL_MALLOC char *SDLCALL SDL_strdup(const char *str);
+extern SDL_DECLSPEC_RETURN SDL_MALLOC char *SDLCALL SDL_strndup(const char *str, size_t maxlen);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_strrev(char *str);
 
 /**
  * Convert a string to uppercase.
@@ -1031,7 +1031,7 @@ extern DECLSPEC char *SDLCALL SDL_strrev(char *str);
  *
  * \sa SDL_strlwr
  */
-extern DECLSPEC char *SDLCALL SDL_strupr(char *str);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_strupr(char *str);
 
 /**
  * Convert a string to lowercase.
@@ -1052,31 +1052,31 @@ extern DECLSPEC char *SDLCALL SDL_strupr(char *str);
  *
  * \sa SDL_strupr
  */
-extern DECLSPEC char *SDLCALL SDL_strlwr(char *str);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_strlwr(char *str);
 
-extern DECLSPEC char *SDLCALL SDL_strchr(const char *str, int c);
-extern DECLSPEC char *SDLCALL SDL_strrchr(const char *str, int c);
-extern DECLSPEC char *SDLCALL SDL_strstr(const char *haystack, const char *needle);
-extern DECLSPEC char *SDLCALL SDL_strnstr(const char *haystack, const char *needle, size_t maxlen);
-extern DECLSPEC char *SDLCALL SDL_strcasestr(const char *haystack, const char *needle);
-extern DECLSPEC char *SDLCALL SDL_strtok_r(char *s1, const char *s2, char **saveptr);
-extern DECLSPEC size_t SDLCALL SDL_utf8strlen(const char *str);
-extern DECLSPEC size_t SDLCALL SDL_utf8strnlen(const char *str, size_t bytes);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_strchr(const char *str, int c);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_strrchr(const char *str, int c);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_strstr(const char *haystack, const char *needle);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_strnstr(const char *haystack, const char *needle, size_t maxlen);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_strcasestr(const char *haystack, const char *needle);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_strtok_r(char *s1, const char *s2, char **saveptr);
+extern SDL_DECLSPEC_RETURN size_t SDLCALL SDL_utf8strlen(const char *str);
+extern SDL_DECLSPEC_RETURN size_t SDLCALL SDL_utf8strnlen(const char *str, size_t bytes);
 
-extern DECLSPEC char *SDLCALL SDL_itoa(int value, char *str, int radix);
-extern DECLSPEC char *SDLCALL SDL_uitoa(unsigned int value, char *str, int radix);
-extern DECLSPEC char *SDLCALL SDL_ltoa(long value, char *str, int radix);
-extern DECLSPEC char *SDLCALL SDL_ultoa(unsigned long value, char *str, int radix);
-extern DECLSPEC char *SDLCALL SDL_lltoa(Sint64 value, char *str, int radix);
-extern DECLSPEC char *SDLCALL SDL_ulltoa(Uint64 value, char *str, int radix);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_itoa(int value, char *str, int radix);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_uitoa(unsigned int value, char *str, int radix);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_ltoa(long value, char *str, int radix);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_ultoa(unsigned long value, char *str, int radix);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_lltoa(Sint64 value, char *str, int radix);
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_ulltoa(Uint64 value, char *str, int radix);
 
-extern DECLSPEC int SDLCALL SDL_atoi(const char *str);
-extern DECLSPEC double SDLCALL SDL_atof(const char *str);
-extern DECLSPEC long SDLCALL SDL_strtol(const char *str, char **endp, int base);
-extern DECLSPEC unsigned long SDLCALL SDL_strtoul(const char *str, char **endp, int base);
-extern DECLSPEC Sint64 SDLCALL SDL_strtoll(const char *str, char **endp, int base);
-extern DECLSPEC Uint64 SDLCALL SDL_strtoull(const char *str, char **endp, int base);
-extern DECLSPEC double SDLCALL SDL_strtod(const char *str, char **endp);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_atoi(const char *str);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_atof(const char *str);
+extern SDL_DECLSPEC_RETURN long SDLCALL SDL_strtol(const char *str, char **endp, int base);
+extern SDL_DECLSPEC_RETURN unsigned long SDLCALL SDL_strtoul(const char *str, char **endp, int base);
+extern SDL_DECLSPEC_RETURN Sint64 SDLCALL SDL_strtoll(const char *str, char **endp, int base);
+extern SDL_DECLSPEC_RETURN Uint64 SDLCALL SDL_strtoull(const char *str, char **endp, int base);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_strtod(const char *str, char **endp);
 
 /**
  * Compare two null-terminated UTF-8 strings.
@@ -1096,7 +1096,7 @@ extern DECLSPEC double SDLCALL SDL_strtod(const char *str, char **endp);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_strcmp(const char *str1, const char *str2);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_strcmp(const char *str1, const char *str2);
 
 /**
  * Compare two UTF-8 strings up to a number of bytes.
@@ -1126,7 +1126,7 @@ extern DECLSPEC int SDLCALL SDL_strcmp(const char *str1, const char *str2);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_strncmp(const char *str1, const char *str2, size_t maxlen);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_strncmp(const char *str1, const char *str2, size_t maxlen);
 
 /**
  * Compare two null-terminated UTF-8 strings, case-insensitively.
@@ -1154,7 +1154,7 @@ extern DECLSPEC int SDLCALL SDL_strncmp(const char *str1, const char *str2, size
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_strcasecmp(const char *str1, const char *str2);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_strcasecmp(const char *str1, const char *str2);
 
 
 /**
@@ -1194,16 +1194,16 @@ extern DECLSPEC int SDLCALL SDL_strcasecmp(const char *str1, const char *str2);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_strncasecmp(const char *str1, const char *str2, size_t maxlen);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_strncasecmp(const char *str1, const char *str2, size_t maxlen);
 
-extern DECLSPEC int SDLCALL SDL_sscanf(const char *text, SDL_SCANF_FORMAT_STRING const char *fmt, ...) SDL_SCANF_VARARG_FUNC(2);
-extern DECLSPEC int SDLCALL SDL_vsscanf(const char *text, SDL_SCANF_FORMAT_STRING const char *fmt, va_list ap) SDL_SCANF_VARARG_FUNCV(2);
-extern DECLSPEC int SDLCALL SDL_snprintf(SDL_OUT_Z_CAP(maxlen) char *text, size_t maxlen, SDL_PRINTF_FORMAT_STRING const char *fmt, ... ) SDL_PRINTF_VARARG_FUNC(3);
-extern DECLSPEC int SDLCALL SDL_swprintf(SDL_OUT_Z_CAP(maxlen) wchar_t *text, size_t maxlen, SDL_PRINTF_FORMAT_STRING const wchar_t *fmt, ... ) SDL_WPRINTF_VARARG_FUNC(3);
-extern DECLSPEC int SDLCALL SDL_vsnprintf(SDL_OUT_Z_CAP(maxlen) char *text, size_t maxlen, SDL_PRINTF_FORMAT_STRING const char *fmt, va_list ap) SDL_PRINTF_VARARG_FUNCV(3);
-extern DECLSPEC int SDLCALL SDL_vswprintf(SDL_OUT_Z_CAP(maxlen) wchar_t *text, size_t maxlen, const wchar_t *fmt, va_list ap);
-extern DECLSPEC int SDLCALL SDL_asprintf(char **strp, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(2);
-extern DECLSPEC int SDLCALL SDL_vasprintf(char **strp, SDL_PRINTF_FORMAT_STRING const char *fmt, va_list ap) SDL_PRINTF_VARARG_FUNCV(2);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_sscanf(const char *text, SDL_SCANF_FORMAT_STRING const char *fmt, ...) SDL_SCANF_VARARG_FUNC(2);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_vsscanf(const char *text, SDL_SCANF_FORMAT_STRING const char *fmt, va_list ap) SDL_SCANF_VARARG_FUNCV(2);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_snprintf(SDL_OUT_Z_CAP(maxlen) char *text, size_t maxlen, SDL_PRINTF_FORMAT_STRING const char *fmt, ... ) SDL_PRINTF_VARARG_FUNC(3);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_swprintf(SDL_OUT_Z_CAP(maxlen) wchar_t *text, size_t maxlen, SDL_PRINTF_FORMAT_STRING const wchar_t *fmt, ... ) SDL_WPRINTF_VARARG_FUNC(3);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_vsnprintf(SDL_OUT_Z_CAP(maxlen) char *text, size_t maxlen, SDL_PRINTF_FORMAT_STRING const char *fmt, va_list ap) SDL_PRINTF_VARARG_FUNCV(3);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_vswprintf(SDL_OUT_Z_CAP(maxlen) wchar_t *text, size_t maxlen, const wchar_t *fmt, va_list ap);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_asprintf(char **strp, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(2);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_vasprintf(char **strp, SDL_PRINTF_FORMAT_STRING const char *fmt, va_list ap) SDL_PRINTF_VARARG_FUNCV(2);
 
 #ifndef SDL_PI_D
 #define SDL_PI_D   3.141592653589793238462643383279502884       /**< pi (double) */
@@ -1240,7 +1240,7 @@ extern DECLSPEC int SDLCALL SDL_vasprintf(char **strp, SDL_PRINTF_FORMAT_STRING 
  * \sa SDL_asin
  * \sa SDL_cos
  */
-extern DECLSPEC double SDLCALL SDL_acos(double x);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_acos(double x);
 
 /**
  * Compute the arc cosine of `x`.
@@ -1268,7 +1268,7 @@ extern DECLSPEC double SDLCALL SDL_acos(double x);
  * \sa SDL_asinf
  * \sa SDL_cosf
  */
-extern DECLSPEC float SDLCALL SDL_acosf(float x);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_acosf(float x);
 
 /**
  * Compute the arc sine of `x`.
@@ -1296,7 +1296,7 @@ extern DECLSPEC float SDLCALL SDL_acosf(float x);
  * \sa SDL_acos
  * \sa SDL_sin
  */
-extern DECLSPEC double SDLCALL SDL_asin(double x);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_asin(double x);
 
 /**
  * Compute the arc sine of `x`.
@@ -1324,7 +1324,7 @@ extern DECLSPEC double SDLCALL SDL_asin(double x);
  * \sa SDL_acosf
  * \sa SDL_sinf
  */
-extern DECLSPEC float SDLCALL SDL_asinf(float x);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_asinf(float x);
 
 /**
  * Compute the arc tangent of `x`.
@@ -1354,7 +1354,7 @@ extern DECLSPEC float SDLCALL SDL_asinf(float x);
  * \sa SDL_atan2
  * \sa SDL_tan
  */
-extern DECLSPEC double SDLCALL SDL_atan(double x);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_atan(double x);
 
 /**
  * Compute the arc tangent of `x`.
@@ -1384,7 +1384,7 @@ extern DECLSPEC double SDLCALL SDL_atan(double x);
  * \sa SDL_atan2f
  * \sa SDL_tanf
  */
-extern DECLSPEC float SDLCALL SDL_atanf(float x);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_atanf(float x);
 
 /**
  * Compute the arc tangent of `y / x`, using the signs of x and y to adjust
@@ -1418,7 +1418,7 @@ extern DECLSPEC float SDLCALL SDL_atanf(float x);
  * \sa SDL_atan
  * \sa SDL_tan
  */
-extern DECLSPEC double SDLCALL SDL_atan2(double y, double x);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_atan2(double y, double x);
 
 /**
  * Compute the arc tangent of `y / x`, using the signs of x and y to adjust
@@ -1452,7 +1452,7 @@ extern DECLSPEC double SDLCALL SDL_atan2(double y, double x);
  * \sa SDL_atan
  * \sa SDL_tan
  */
-extern DECLSPEC float SDLCALL SDL_atan2f(float y, float x);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_atan2f(float y, float x);
 
 /**
  * Compute the ceiling of `x`.
@@ -1478,7 +1478,7 @@ extern DECLSPEC float SDLCALL SDL_atan2f(float y, float x);
  * \sa SDL_round
  * \sa SDL_lround
  */
-extern DECLSPEC double SDLCALL SDL_ceil(double x);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_ceil(double x);
 
 /**
  * Compute the ceiling of `x`.
@@ -1504,7 +1504,7 @@ extern DECLSPEC double SDLCALL SDL_ceil(double x);
  * \sa SDL_roundf
  * \sa SDL_lroundf
  */
-extern DECLSPEC float SDLCALL SDL_ceilf(float x);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_ceilf(float x);
 
 /**
  * Copy the sign of one floating-point value to another.
@@ -1527,7 +1527,7 @@ extern DECLSPEC float SDLCALL SDL_ceilf(float x);
  * \sa SDL_copysignf
  * \sa SDL_fabs
  */
-extern DECLSPEC double SDLCALL SDL_copysign(double x, double y);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_copysign(double x, double y);
 
 /**
  * Copy the sign of one floating-point value to another.
@@ -1550,7 +1550,7 @@ extern DECLSPEC double SDLCALL SDL_copysign(double x, double y);
  * \sa SDL_copysignf
  * \sa SDL_fabsf
  */
-extern DECLSPEC float SDLCALL SDL_copysignf(float x, float y);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_copysignf(float x, float y);
 
 /**
  * Compute the cosine of `x`.
@@ -1576,7 +1576,7 @@ extern DECLSPEC float SDLCALL SDL_copysignf(float x, float y);
  * \sa SDL_acos
  * \sa SDL_sin
  */
-extern DECLSPEC double SDLCALL SDL_cos(double x);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_cos(double x);
 
 /**
  * Compute the cosine of `x`.
@@ -1602,7 +1602,7 @@ extern DECLSPEC double SDLCALL SDL_cos(double x);
  * \sa SDL_acosf
  * \sa SDL_sinf
  */
-extern DECLSPEC float SDLCALL SDL_cosf(float x);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_cosf(float x);
 
 /**
  * Compute the exponential of `x`.
@@ -1632,7 +1632,7 @@ extern DECLSPEC float SDLCALL SDL_cosf(float x);
  * \sa SDL_expf
  * \sa SDL_log
  */
-extern DECLSPEC double SDLCALL SDL_exp(double x);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_exp(double x);
 
 /**
  * Compute the exponential of `x`.
@@ -1662,7 +1662,7 @@ extern DECLSPEC double SDLCALL SDL_exp(double x);
  * \sa SDL_exp
  * \sa SDL_logf
  */
-extern DECLSPEC float SDLCALL SDL_expf(float x);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_expf(float x);
 
 /**
  * Compute the absolute value of `x`
@@ -1681,7 +1681,7 @@ extern DECLSPEC float SDLCALL SDL_expf(float x);
  *
  * \sa SDL_fabsf
  */
-extern DECLSPEC double SDLCALL SDL_fabs(double x);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_fabs(double x);
 
 /**
  * Compute the absolute value of `x`
@@ -1700,7 +1700,7 @@ extern DECLSPEC double SDLCALL SDL_fabs(double x);
  *
  * \sa SDL_fabs
  */
-extern DECLSPEC float SDLCALL SDL_fabsf(float x);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_fabsf(float x);
 
 /**
  * Compute the floor of `x`.
@@ -1726,7 +1726,7 @@ extern DECLSPEC float SDLCALL SDL_fabsf(float x);
  * \sa SDL_round
  * \sa SDL_lround
  */
-extern DECLSPEC double SDLCALL SDL_floor(double x);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_floor(double x);
 
 /**
  * Compute the floor of `x`.
@@ -1752,7 +1752,7 @@ extern DECLSPEC double SDLCALL SDL_floor(double x);
  * \sa SDL_roundf
  * \sa SDL_lroundf
  */
-extern DECLSPEC float SDLCALL SDL_floorf(float x);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_floorf(float x);
 
 /**
  * Truncate `x` to an integer.
@@ -1779,7 +1779,7 @@ extern DECLSPEC float SDLCALL SDL_floorf(float x);
  * \sa SDL_round
  * \sa SDL_lround
  */
-extern DECLSPEC double SDLCALL SDL_trunc(double x);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_trunc(double x);
 
 /**
  * Truncate `x` to an integer.
@@ -1806,7 +1806,7 @@ extern DECLSPEC double SDLCALL SDL_trunc(double x);
  * \sa SDL_roundf
  * \sa SDL_lroundf
  */
-extern DECLSPEC float SDLCALL SDL_truncf(float x);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_truncf(float x);
 
 /**
  * Return the floating-point remainder of `x / y`
@@ -1834,7 +1834,7 @@ extern DECLSPEC float SDLCALL SDL_truncf(float x);
  * \sa SDL_round
  * \sa SDL_lround
  */
-extern DECLSPEC double SDLCALL SDL_fmod(double x, double y);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_fmod(double x, double y);
 
 /**
  * Return the floating-point remainder of `x / y`
@@ -1862,7 +1862,7 @@ extern DECLSPEC double SDLCALL SDL_fmod(double x, double y);
  * \sa SDL_roundf
  * \sa SDL_lroundf
  */
-extern DECLSPEC float SDLCALL SDL_fmodf(float x, float y);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_fmodf(float x, float y);
 
 /**
  * Compute the natural logarithm of `x`.
@@ -1890,7 +1890,7 @@ extern DECLSPEC float SDLCALL SDL_fmodf(float x, float y);
  * \sa SDL_log10
  * \sa SDL_exp
  */
-extern DECLSPEC double SDLCALL SDL_log(double x);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_log(double x);
 
 /**
  * Compute the natural logarithm of `x`.
@@ -1917,7 +1917,7 @@ extern DECLSPEC double SDLCALL SDL_log(double x);
  * \sa SDL_log
  * \sa SDL_expf
  */
-extern DECLSPEC float SDLCALL SDL_logf(float x);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_logf(float x);
 
 /**
  * Compute the base-10 logarithm of `x`.
@@ -1945,7 +1945,7 @@ extern DECLSPEC float SDLCALL SDL_logf(float x);
  * \sa SDL_log
  * \sa SDL_pow
  */
-extern DECLSPEC double SDLCALL SDL_log10(double x);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_log10(double x);
 
 /**
  * Compute the base-10 logarithm of `x`.
@@ -1973,7 +1973,7 @@ extern DECLSPEC double SDLCALL SDL_log10(double x);
  * \sa SDL_logf
  * \sa SDL_powf
  */
-extern DECLSPEC float SDLCALL SDL_log10f(float x);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_log10f(float x);
 
 /**
  * Split `x` into integer and fractional parts
@@ -1991,7 +1991,7 @@ extern DECLSPEC float SDLCALL SDL_log10f(float x);
  * \sa SDL_trunc
  * \sa SDL_fmod
  */
-extern DECLSPEC double SDLCALL SDL_modf(double x, double *y);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_modf(double x, double *y);
 
 /**
  * Split `x` into integer and fractional parts
@@ -2009,7 +2009,7 @@ extern DECLSPEC double SDLCALL SDL_modf(double x, double *y);
  * \sa SDL_truncf
  * \sa SDL_fmodf
  */
-extern DECLSPEC float SDLCALL SDL_modff(float x, float *y);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_modff(float x, float *y);
 
 /**
  * Raise `x` to the power `y`
@@ -2039,7 +2039,7 @@ extern DECLSPEC float SDLCALL SDL_modff(float x, float *y);
  * \sa SDL_exp
  * \sa SDL_log
  */
-extern DECLSPEC double SDLCALL SDL_pow(double x, double y);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_pow(double x, double y);
 
 /**
  * Raise `x` to the power `y`
@@ -2069,7 +2069,7 @@ extern DECLSPEC double SDLCALL SDL_pow(double x, double y);
  * \sa SDL_expf
  * \sa SDL_logf
  */
-extern DECLSPEC float SDLCALL SDL_powf(float x, float y);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_powf(float x, float y);
 
 /**
  * Round `x` to the nearest integer.
@@ -2096,7 +2096,7 @@ extern DECLSPEC float SDLCALL SDL_powf(float x, float y);
  * \sa SDL_ceil
  * \sa SDL_trunc
  */
-extern DECLSPEC double SDLCALL SDL_round(double x);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_round(double x);
 
 /**
  * Round `x` to the nearest integer.
@@ -2123,7 +2123,7 @@ extern DECLSPEC double SDLCALL SDL_round(double x);
  * \sa SDL_ceilf
  * \sa SDL_truncf
  */
-extern DECLSPEC float SDLCALL SDL_roundf(float x);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_roundf(float x);
 
 /**
  * Round `x` to the nearest integer representable as a long
@@ -2150,7 +2150,7 @@ extern DECLSPEC float SDLCALL SDL_roundf(float x);
  * \sa SDL_ceil
  * \sa SDL_trunc
  */
-extern DECLSPEC long SDLCALL SDL_lround(double x);
+extern SDL_DECLSPEC_RETURN long SDLCALL SDL_lround(double x);
 
 /**
  * Round `x` to the nearest integer representable as a long
@@ -2177,7 +2177,7 @@ extern DECLSPEC long SDLCALL SDL_lround(double x);
  * \sa SDL_ceilf
  * \sa SDL_truncf
  */
-extern DECLSPEC long SDLCALL SDL_lroundf(float x);
+extern SDL_DECLSPEC_RETURN long SDLCALL SDL_lroundf(float x);
 
 /**
  * Scale `x` by an integer power of two.
@@ -2200,7 +2200,7 @@ extern DECLSPEC long SDLCALL SDL_lroundf(float x);
  * \sa SDL_scalbnf
  * \sa SDL_pow
  */
-extern DECLSPEC double SDLCALL SDL_scalbn(double x, int n);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_scalbn(double x, int n);
 
 /**
  * Scale `x` by an integer power of two.
@@ -2223,7 +2223,7 @@ extern DECLSPEC double SDLCALL SDL_scalbn(double x, int n);
  * \sa SDL_scalbn
  * \sa SDL_powf
  */
-extern DECLSPEC float SDLCALL SDL_scalbnf(float x, int n);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_scalbnf(float x, int n);
 
 /**
  * Compute the sine of `x`.
@@ -2249,7 +2249,7 @@ extern DECLSPEC float SDLCALL SDL_scalbnf(float x, int n);
  * \sa SDL_asin
  * \sa SDL_cos
  */
-extern DECLSPEC double SDLCALL SDL_sin(double x);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_sin(double x);
 
 /**
  * Compute the sine of `x`.
@@ -2275,7 +2275,7 @@ extern DECLSPEC double SDLCALL SDL_sin(double x);
  * \sa SDL_asinf
  * \sa SDL_cosf
  */
-extern DECLSPEC float SDLCALL SDL_sinf(float x);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_sinf(float x);
 
 /**
  * Compute the square root of `x`.
@@ -2299,7 +2299,7 @@ extern DECLSPEC float SDLCALL SDL_sinf(float x);
  *
  * \sa SDL_sqrtf
  */
-extern DECLSPEC double SDLCALL SDL_sqrt(double x);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_sqrt(double x);
 
 /**
  * Compute the square root of `x`.
@@ -2323,7 +2323,7 @@ extern DECLSPEC double SDLCALL SDL_sqrt(double x);
  *
  * \sa SDL_sqrt
  */
-extern DECLSPEC float SDLCALL SDL_sqrtf(float x);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_sqrtf(float x);
 
 /**
  * Compute the tangent of `x`.
@@ -2351,7 +2351,7 @@ extern DECLSPEC float SDLCALL SDL_sqrtf(float x);
  * \sa SDL_atan
  * \sa SDL_atan2
  */
-extern DECLSPEC double SDLCALL SDL_tan(double x);
+extern SDL_DECLSPEC_RETURN double SDLCALL SDL_tan(double x);
 
 /**
  * Compute the tangent of `x`.
@@ -2379,7 +2379,7 @@ extern DECLSPEC double SDLCALL SDL_tan(double x);
  * \sa SDL_atanf
  * \sa SDL_atan2f
  */
-extern DECLSPEC float SDLCALL SDL_tanf(float x);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_tanf(float x);
 
 /* The SDL implementation of iconv() returns these error codes */
 #define SDL_ICONV_ERROR     (size_t)-1
@@ -2389,10 +2389,10 @@ extern DECLSPEC float SDLCALL SDL_tanf(float x);
 
 /* SDL_iconv_* are now always real symbols/types, not macros or inlined. */
 typedef struct SDL_iconv_data_t *SDL_iconv_t;
-extern DECLSPEC SDL_iconv_t SDLCALL SDL_iconv_open(const char *tocode,
+extern SDL_DECLSPEC_RETURN SDL_iconv_t SDLCALL SDL_iconv_open(const char *tocode,
                                                    const char *fromcode);
-extern DECLSPEC int SDLCALL SDL_iconv_close(SDL_iconv_t cd);
-extern DECLSPEC size_t SDLCALL SDL_iconv(SDL_iconv_t cd, const char **inbuf,
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_iconv_close(SDL_iconv_t cd);
+extern SDL_DECLSPEC_RETURN size_t SDLCALL SDL_iconv(SDL_iconv_t cd, const char **inbuf,
                                          size_t * inbytesleft, char **outbuf,
                                          size_t * outbytesleft);
 
@@ -2402,7 +2402,7 @@ extern DECLSPEC size_t SDLCALL SDL_iconv(SDL_iconv_t cd, const char **inbuf,
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC char *SDLCALL SDL_iconv_string(const char *tocode,
+extern SDL_DECLSPEC_RETURN char *SDLCALL SDL_iconv_string(const char *tocode,
                                                const char *fromcode,
                                                const char *inbuf,
                                                size_t inbytesleft);

--- a/include/SDL3/SDL_storage.h
+++ b/include/SDL3/SDL_storage.h
@@ -113,7 +113,7 @@ typedef struct SDL_Storage SDL_Storage;
  * \sa SDL_OpenUserStorage
  * \sa SDL_ReadStorageFile
  */
-extern SDL_DECLSPEC_RETURN SDL_Storage *SDLCALL SDL_OpenTitleStorage(const char *override, SDL_PropertiesID props);
+extern SDL_DECLSPEC_NODISCARD SDL_Storage *SDLCALL SDL_OpenTitleStorage(const char *override, SDL_PropertiesID props);
 
 /**
  * Opens up a container for a user's unique read/write filesystem.
@@ -139,7 +139,7 @@ extern SDL_DECLSPEC_RETURN SDL_Storage *SDLCALL SDL_OpenTitleStorage(const char 
  * \sa SDL_StorageReady
  * \sa SDL_WriteStorageFile
  */
-extern SDL_DECLSPEC_RETURN SDL_Storage *SDLCALL SDL_OpenUserStorage(const char *org, const char *app, SDL_PropertiesID props);
+extern SDL_DECLSPEC_NODISCARD SDL_Storage *SDLCALL SDL_OpenUserStorage(const char *org, const char *app, SDL_PropertiesID props);
 
 /**
  * Opens up a container for local filesystem storage.
@@ -163,7 +163,7 @@ extern SDL_DECLSPEC_RETURN SDL_Storage *SDLCALL SDL_OpenUserStorage(const char *
  * \sa SDL_ReadStorageFile
  * \sa SDL_WriteStorageFile
  */
-extern SDL_DECLSPEC_RETURN SDL_Storage *SDLCALL SDL_OpenFileStorage(const char *path);
+extern SDL_DECLSPEC_NODISCARD SDL_Storage *SDLCALL SDL_OpenFileStorage(const char *path);
 
 /**
  * Opens up a container using a client-provided storage interface.
@@ -187,7 +187,7 @@ extern SDL_DECLSPEC_RETURN SDL_Storage *SDLCALL SDL_OpenFileStorage(const char *
  * \sa SDL_StorageReady
  * \sa SDL_WriteStorageFile
  */
-extern SDL_DECLSPEC_RETURN SDL_Storage *SDLCALL SDL_OpenStorage(const SDL_StorageInterface *iface, void *userdata);
+extern SDL_DECLSPEC_NODISCARD SDL_Storage *SDLCALL SDL_OpenStorage(const SDL_StorageInterface *iface, void *userdata);
 
 /**
  * Closes and frees a storage container.
@@ -401,7 +401,7 @@ extern SDL_DECLSPEC_RETURN Uint64 SDLCALL SDL_GetStorageSpaceRemaining(SDL_Stora
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern SDL_DECLSPEC_RETURN char **SDLCALL SDL_GlobStorageDirectory(SDL_Storage *storage, const char *path, const char *pattern, SDL_GlobFlags flags, int *count);
+extern SDL_DECLSPEC_NODISCARD char **SDLCALL SDL_GlobStorageDirectory(SDL_Storage *storage, const char *path, const char *pattern, SDL_GlobFlags flags, int *count);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_storage.h
+++ b/include/SDL3/SDL_storage.h
@@ -113,7 +113,7 @@ typedef struct SDL_Storage SDL_Storage;
  * \sa SDL_OpenUserStorage
  * \sa SDL_ReadStorageFile
  */
-extern DECLSPEC SDL_Storage *SDLCALL SDL_OpenTitleStorage(const char *override, SDL_PropertiesID props);
+extern SDL_DECLSPEC_RETURN SDL_Storage *SDLCALL SDL_OpenTitleStorage(const char *override, SDL_PropertiesID props);
 
 /**
  * Opens up a container for a user's unique read/write filesystem.
@@ -139,7 +139,7 @@ extern DECLSPEC SDL_Storage *SDLCALL SDL_OpenTitleStorage(const char *override, 
  * \sa SDL_StorageReady
  * \sa SDL_WriteStorageFile
  */
-extern DECLSPEC SDL_Storage *SDLCALL SDL_OpenUserStorage(const char *org, const char *app, SDL_PropertiesID props);
+extern SDL_DECLSPEC_RETURN SDL_Storage *SDLCALL SDL_OpenUserStorage(const char *org, const char *app, SDL_PropertiesID props);
 
 /**
  * Opens up a container for local filesystem storage.
@@ -163,7 +163,7 @@ extern DECLSPEC SDL_Storage *SDLCALL SDL_OpenUserStorage(const char *org, const 
  * \sa SDL_ReadStorageFile
  * \sa SDL_WriteStorageFile
  */
-extern DECLSPEC SDL_Storage *SDLCALL SDL_OpenFileStorage(const char *path);
+extern SDL_DECLSPEC_RETURN SDL_Storage *SDLCALL SDL_OpenFileStorage(const char *path);
 
 /**
  * Opens up a container using a client-provided storage interface.
@@ -187,7 +187,7 @@ extern DECLSPEC SDL_Storage *SDLCALL SDL_OpenFileStorage(const char *path);
  * \sa SDL_StorageReady
  * \sa SDL_WriteStorageFile
  */
-extern DECLSPEC SDL_Storage *SDLCALL SDL_OpenStorage(const SDL_StorageInterface *iface, void *userdata);
+extern SDL_DECLSPEC_RETURN SDL_Storage *SDLCALL SDL_OpenStorage(const SDL_StorageInterface *iface, void *userdata);
 
 /**
  * Closes and frees a storage container.
@@ -205,7 +205,7 @@ extern DECLSPEC SDL_Storage *SDLCALL SDL_OpenStorage(const SDL_StorageInterface 
  * \sa SDL_OpenTitleStorage
  * \sa SDL_OpenUserStorage
  */
-extern DECLSPEC int SDLCALL SDL_CloseStorage(SDL_Storage *storage);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_CloseStorage(SDL_Storage *storage);
 
 /**
  * Checks if the storage container is ready to use.
@@ -219,7 +219,7 @@ extern DECLSPEC int SDLCALL SDL_CloseStorage(SDL_Storage *storage);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_StorageReady(SDL_Storage *storage);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_StorageReady(SDL_Storage *storage);
 
 /**
  * Query the size of a file within a storage container.
@@ -235,7 +235,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_StorageReady(SDL_Storage *storage);
  * \sa SDL_ReadStorageFile
  * \sa SDL_StorageReady
  */
-extern DECLSPEC int SDLCALL SDL_GetStorageFileSize(SDL_Storage *storage, const char *path, Uint64 *length);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetStorageFileSize(SDL_Storage *storage, const char *path, Uint64 *length);
 
 /**
  * Synchronously read a file from a storage container into a client-provided
@@ -254,7 +254,7 @@ extern DECLSPEC int SDLCALL SDL_GetStorageFileSize(SDL_Storage *storage, const c
  * \sa SDL_StorageReady
  * \sa SDL_WriteStorageFile
  */
-extern DECLSPEC int SDLCALL SDL_ReadStorageFile(SDL_Storage *storage, const char *path, void *destination, Uint64 length);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ReadStorageFile(SDL_Storage *storage, const char *path, void *destination, Uint64 length);
 
 /**
  * Synchronously write a file from client memory into a storage container.
@@ -272,7 +272,7 @@ extern DECLSPEC int SDLCALL SDL_ReadStorageFile(SDL_Storage *storage, const char
  * \sa SDL_ReadStorageFile
  * \sa SDL_StorageReady
  */
-extern DECLSPEC int SDLCALL SDL_WriteStorageFile(SDL_Storage *storage, const char *path, const void *source, Uint64 length);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_WriteStorageFile(SDL_Storage *storage, const char *path, const void *source, Uint64 length);
 
 /**
  * Create a directory in a writable storage container.
@@ -286,7 +286,7 @@ extern DECLSPEC int SDLCALL SDL_WriteStorageFile(SDL_Storage *storage, const cha
  *
  * \sa SDL_StorageReady
  */
-extern DECLSPEC int SDLCALL SDL_CreateStorageDirectory(SDL_Storage *storage, const char *path);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_CreateStorageDirectory(SDL_Storage *storage, const char *path);
 
 /**
  * Enumerate a directory in a storage container through a callback function.
@@ -306,7 +306,7 @@ extern DECLSPEC int SDLCALL SDL_CreateStorageDirectory(SDL_Storage *storage, con
  *
  * \sa SDL_StorageReady
  */
-extern DECLSPEC int SDLCALL SDL_EnumerateStorageDirectory(SDL_Storage *storage, const char *path, SDL_EnumerateDirectoryCallback callback, void *userdata);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_EnumerateStorageDirectory(SDL_Storage *storage, const char *path, SDL_EnumerateDirectoryCallback callback, void *userdata);
 
 /**
  * Remove a file or an empty directory in a writable storage container.
@@ -320,7 +320,7 @@ extern DECLSPEC int SDLCALL SDL_EnumerateStorageDirectory(SDL_Storage *storage, 
  *
  * \sa SDL_StorageReady
  */
-extern DECLSPEC int SDLCALL SDL_RemoveStoragePath(SDL_Storage *storage, const char *path);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RemoveStoragePath(SDL_Storage *storage, const char *path);
 
 /**
  * Rename a file or directory in a writable storage container.
@@ -335,7 +335,7 @@ extern DECLSPEC int SDLCALL SDL_RemoveStoragePath(SDL_Storage *storage, const ch
  *
  * \sa SDL_StorageReady
  */
-extern DECLSPEC int SDLCALL SDL_RenameStoragePath(SDL_Storage *storage, const char *oldpath, const char *newpath);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RenameStoragePath(SDL_Storage *storage, const char *oldpath, const char *newpath);
 
 /**
  * Get information about a filesystem path in a storage container.
@@ -351,7 +351,7 @@ extern DECLSPEC int SDLCALL SDL_RenameStoragePath(SDL_Storage *storage, const ch
  *
  * \sa SDL_StorageReady
  */
-extern DECLSPEC int SDLCALL SDL_GetStoragePathInfo(SDL_Storage *storage, const char *path, SDL_PathInfo *info);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetStoragePathInfo(SDL_Storage *storage, const char *path, SDL_PathInfo *info);
 
 /**
  * Queries the remaining space in a storage container.
@@ -364,7 +364,7 @@ extern DECLSPEC int SDLCALL SDL_GetStoragePathInfo(SDL_Storage *storage, const c
  * \sa SDL_StorageReady
  * \sa SDL_WriteStorageFile
  */
-extern DECLSPEC Uint64 SDLCALL SDL_GetStorageSpaceRemaining(SDL_Storage *storage);
+extern SDL_DECLSPEC_RETURN Uint64 SDLCALL SDL_GetStorageSpaceRemaining(SDL_Storage *storage);
 
 /**
  * Enumerate a directory tree, filtered by pattern, and return a list.
@@ -401,7 +401,7 @@ extern DECLSPEC Uint64 SDLCALL SDL_GetStorageSpaceRemaining(SDL_Storage *storage
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC char **SDLCALL SDL_GlobStorageDirectory(SDL_Storage *storage, const char *path, const char *pattern, SDL_GlobFlags flags, int *count);
+extern SDL_DECLSPEC_RETURN char **SDLCALL SDL_GlobStorageDirectory(SDL_Storage *storage, const char *path, const char *pattern, SDL_GlobFlags flags, int *count);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_surface.h
+++ b/include/SDL3/SDL_surface.h
@@ -156,7 +156,7 @@ typedef struct SDL_Surface
  * \sa SDL_CreateSurfaceFrom
  * \sa SDL_DestroySurface
  */
-extern SDL_DECLSPEC_RETURN SDL_Surface *SDLCALL SDL_CreateSurface(int width, int height, SDL_PixelFormatEnum format);
+extern SDL_DECLSPEC_NODISCARD SDL_Surface *SDLCALL SDL_CreateSurface(int width, int height, SDL_PixelFormatEnum format);
 
 /**
  * Allocate a new RGB surface with a specific pixel format and existing pixel
@@ -184,7 +184,7 @@ extern SDL_DECLSPEC_RETURN SDL_Surface *SDLCALL SDL_CreateSurface(int width, int
  * \sa SDL_CreateSurface
  * \sa SDL_DestroySurface
  */
-extern SDL_DECLSPEC_RETURN SDL_Surface *SDLCALL SDL_CreateSurfaceFrom(void *pixels, int width, int height, int pitch, SDL_PixelFormatEnum format);
+extern SDL_DECLSPEC_NODISCARD SDL_Surface *SDLCALL SDL_CreateSurfaceFrom(void *pixels, int width, int height, int pitch, SDL_PixelFormatEnum format);
 
 /**
  * Free an RGB surface.
@@ -339,7 +339,7 @@ extern SDL_DECLSPEC_VOID void SDLCALL SDL_UnlockSurface(SDL_Surface *surface);
  * \sa SDL_LoadBMP
  * \sa SDL_SaveBMP_IO
  */
-extern SDL_DECLSPEC_RETURN SDL_Surface *SDLCALL SDL_LoadBMP_IO(SDL_IOStream *src, SDL_bool closeio);
+extern SDL_DECLSPEC_NODISCARD SDL_Surface *SDLCALL SDL_LoadBMP_IO(SDL_IOStream *src, SDL_bool closeio);
 
 /**
  * Load a BMP image from a file.
@@ -357,7 +357,7 @@ extern SDL_DECLSPEC_RETURN SDL_Surface *SDLCALL SDL_LoadBMP_IO(SDL_IOStream *src
  * \sa SDL_LoadBMP_IO
  * \sa SDL_SaveBMP
  */
-extern SDL_DECLSPEC_RETURN SDL_Surface *SDLCALL SDL_LoadBMP(const char *file);
+extern SDL_DECLSPEC_NODISCARD SDL_Surface *SDLCALL SDL_LoadBMP(const char *file);
 
 /**
  * Save a surface to a seekable SDL data stream in BMP format.
@@ -670,7 +670,7 @@ extern SDL_DECLSPEC_RETURN int SDLCALL SDL_FlipSurface(SDL_Surface *surface, SDL
  *
  * \sa SDL_DestroySurface
  */
-extern SDL_DECLSPEC_RETURN SDL_Surface *SDLCALL SDL_DuplicateSurface(SDL_Surface *surface);
+extern SDL_DECLSPEC_NODISCARD SDL_Surface *SDLCALL SDL_DuplicateSurface(SDL_Surface *surface);
 
 /**
  * Copy an existing surface to a new surface of the specified format.
@@ -693,7 +693,7 @@ extern SDL_DECLSPEC_RETURN SDL_Surface *SDLCALL SDL_DuplicateSurface(SDL_Surface
  * \sa SDL_CreatePixelFormat
  * \sa SDL_DestroySurface
  */
-extern SDL_DECLSPEC_RETURN SDL_Surface *SDLCALL SDL_ConvertSurface(SDL_Surface *surface, const SDL_PixelFormat *format);
+extern SDL_DECLSPEC_NODISCARD SDL_Surface *SDLCALL SDL_ConvertSurface(SDL_Surface *surface, const SDL_PixelFormat *format);
 
 /**
  * Copy an existing surface to a new surface of the specified format.

--- a/include/SDL3/SDL_surface.h
+++ b/include/SDL3/SDL_surface.h
@@ -156,7 +156,7 @@ typedef struct SDL_Surface
  * \sa SDL_CreateSurfaceFrom
  * \sa SDL_DestroySurface
  */
-extern DECLSPEC SDL_Surface *SDLCALL SDL_CreateSurface(int width, int height, SDL_PixelFormatEnum format);
+extern SDL_DECLSPEC_RETURN SDL_Surface *SDLCALL SDL_CreateSurface(int width, int height, SDL_PixelFormatEnum format);
 
 /**
  * Allocate a new RGB surface with a specific pixel format and existing pixel
@@ -184,7 +184,7 @@ extern DECLSPEC SDL_Surface *SDLCALL SDL_CreateSurface(int width, int height, SD
  * \sa SDL_CreateSurface
  * \sa SDL_DestroySurface
  */
-extern DECLSPEC SDL_Surface *SDLCALL SDL_CreateSurfaceFrom(void *pixels, int width, int height, int pitch, SDL_PixelFormatEnum format);
+extern SDL_DECLSPEC_RETURN SDL_Surface *SDLCALL SDL_CreateSurfaceFrom(void *pixels, int width, int height, int pitch, SDL_PixelFormatEnum format);
 
 /**
  * Free an RGB surface.
@@ -198,7 +198,7 @@ extern DECLSPEC SDL_Surface *SDLCALL SDL_CreateSurfaceFrom(void *pixels, int wid
  * \sa SDL_CreateSurface
  * \sa SDL_CreateSurfaceFrom
  */
-extern DECLSPEC void SDLCALL SDL_DestroySurface(SDL_Surface *surface);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_DestroySurface(SDL_Surface *surface);
 
 /**
  * Get the properties associated with a surface.
@@ -234,7 +234,7 @@ extern DECLSPEC void SDLCALL SDL_DestroySurface(SDL_Surface *surface);
  * \sa SDL_GetProperty
  * \sa SDL_SetProperty
  */
-extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetSurfaceProperties(SDL_Surface *surface);
+extern SDL_DECLSPEC_RETURN SDL_PropertiesID SDLCALL SDL_GetSurfaceProperties(SDL_Surface *surface);
 
 #define SDL_PROP_SURFACE_COLORSPACE_NUMBER                  "SDL.surface.colorspace"
 #define SDL_PROP_SURFACE_SDR_WHITE_POINT_FLOAT              "SDL.surface.SDR_white_point"
@@ -254,7 +254,7 @@ extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetSurfaceProperties(SDL_Surface *s
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SetSurfaceColorspace(SDL_Surface *surface, SDL_Colorspace colorspace);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetSurfaceColorspace(SDL_Surface *surface, SDL_Colorspace colorspace);
 
 /**
  * Get the colorspace used by a surface.
@@ -271,7 +271,7 @@ extern DECLSPEC int SDLCALL SDL_SetSurfaceColorspace(SDL_Surface *surface, SDL_C
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetSurfaceColorspace(SDL_Surface *surface, SDL_Colorspace *colorspace);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetSurfaceColorspace(SDL_Surface *surface, SDL_Colorspace *colorspace);
 
 /**
  * Set the palette used by a surface.
@@ -285,7 +285,7 @@ extern DECLSPEC int SDLCALL SDL_GetSurfaceColorspace(SDL_Surface *surface, SDL_C
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SetSurfacePalette(SDL_Surface *surface, SDL_Palette *palette);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetSurfacePalette(SDL_Surface *surface, SDL_Palette *palette);
 
 /**
  * Set up a surface for directly accessing the pixels.
@@ -308,7 +308,7 @@ extern DECLSPEC int SDLCALL SDL_SetSurfacePalette(SDL_Surface *surface, SDL_Pale
  * \sa SDL_MUSTLOCK
  * \sa SDL_UnlockSurface
  */
-extern DECLSPEC int SDLCALL SDL_LockSurface(SDL_Surface *surface);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_LockSurface(SDL_Surface *surface);
 
 /**
  * Release a surface after directly accessing the pixels.
@@ -319,7 +319,7 @@ extern DECLSPEC int SDLCALL SDL_LockSurface(SDL_Surface *surface);
  *
  * \sa SDL_LockSurface
  */
-extern DECLSPEC void SDLCALL SDL_UnlockSurface(SDL_Surface *surface);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_UnlockSurface(SDL_Surface *surface);
 
 /**
  * Load a BMP image from a seekable SDL data stream.
@@ -339,7 +339,7 @@ extern DECLSPEC void SDLCALL SDL_UnlockSurface(SDL_Surface *surface);
  * \sa SDL_LoadBMP
  * \sa SDL_SaveBMP_IO
  */
-extern DECLSPEC SDL_Surface *SDLCALL SDL_LoadBMP_IO(SDL_IOStream *src, SDL_bool closeio);
+extern SDL_DECLSPEC_RETURN SDL_Surface *SDLCALL SDL_LoadBMP_IO(SDL_IOStream *src, SDL_bool closeio);
 
 /**
  * Load a BMP image from a file.
@@ -357,7 +357,7 @@ extern DECLSPEC SDL_Surface *SDLCALL SDL_LoadBMP_IO(SDL_IOStream *src, SDL_bool 
  * \sa SDL_LoadBMP_IO
  * \sa SDL_SaveBMP
  */
-extern DECLSPEC SDL_Surface *SDLCALL SDL_LoadBMP(const char *file);
+extern SDL_DECLSPEC_RETURN SDL_Surface *SDLCALL SDL_LoadBMP(const char *file);
 
 /**
  * Save a surface to a seekable SDL data stream in BMP format.
@@ -380,7 +380,7 @@ extern DECLSPEC SDL_Surface *SDLCALL SDL_LoadBMP(const char *file);
  * \sa SDL_LoadBMP_IO
  * \sa SDL_SaveBMP
  */
-extern DECLSPEC int SDLCALL SDL_SaveBMP_IO(SDL_Surface *surface, SDL_IOStream *dst, SDL_bool closeio);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SaveBMP_IO(SDL_Surface *surface, SDL_IOStream *dst, SDL_bool closeio);
 
 /**
  * Save a surface to a file.
@@ -401,7 +401,7 @@ extern DECLSPEC int SDLCALL SDL_SaveBMP_IO(SDL_Surface *surface, SDL_IOStream *d
  * \sa SDL_LoadBMP
  * \sa SDL_SaveBMP_IO
  */
-extern DECLSPEC int SDLCALL SDL_SaveBMP(SDL_Surface *surface, const char *file);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SaveBMP(SDL_Surface *surface, const char *file);
 
 /**
  * Set the RLE acceleration hint for a surface.
@@ -420,7 +420,7 @@ extern DECLSPEC int SDLCALL SDL_SaveBMP(SDL_Surface *surface, const char *file);
  * \sa SDL_LockSurface
  * \sa SDL_UnlockSurface
  */
-extern DECLSPEC int SDLCALL SDL_SetSurfaceRLE(SDL_Surface *surface, int flag);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetSurfaceRLE(SDL_Surface *surface, int flag);
 
 /**
  * Returns whether the surface is RLE enabled.
@@ -434,7 +434,7 @@ extern DECLSPEC int SDLCALL SDL_SetSurfaceRLE(SDL_Surface *surface, int flag);
  *
  * \sa SDL_SetSurfaceRLE
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_SurfaceHasRLE(SDL_Surface *surface);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_SurfaceHasRLE(SDL_Surface *surface);
 
 /**
  * Set the color key (transparent pixel) in a surface.
@@ -460,7 +460,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_SurfaceHasRLE(SDL_Surface *surface);
  * \sa SDL_GetSurfaceColorKey
  * \sa SDL_SurfaceHasColorKey
  */
-extern DECLSPEC int SDLCALL SDL_SetSurfaceColorKey(SDL_Surface *surface, int flag, Uint32 key);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetSurfaceColorKey(SDL_Surface *surface, int flag, Uint32 key);
 
 /**
  * Returns whether the surface has a color key.
@@ -475,7 +475,7 @@ extern DECLSPEC int SDLCALL SDL_SetSurfaceColorKey(SDL_Surface *surface, int fla
  * \sa SDL_SetSurfaceColorKey
  * \sa SDL_GetSurfaceColorKey
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_SurfaceHasColorKey(SDL_Surface *surface);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_SurfaceHasColorKey(SDL_Surface *surface);
 
 /**
  * Get the color key (transparent pixel) for a surface.
@@ -495,7 +495,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_SurfaceHasColorKey(SDL_Surface *surface);
  * \sa SDL_SetSurfaceColorKey
  * \sa SDL_SurfaceHasColorKey
  */
-extern DECLSPEC int SDLCALL SDL_GetSurfaceColorKey(SDL_Surface *surface, Uint32 *key);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetSurfaceColorKey(SDL_Surface *surface, Uint32 *key);
 
 /**
  * Set an additional color value multiplied into blit operations.
@@ -518,7 +518,7 @@ extern DECLSPEC int SDLCALL SDL_GetSurfaceColorKey(SDL_Surface *surface, Uint32 
  * \sa SDL_GetSurfaceColorMod
  * \sa SDL_SetSurfaceAlphaMod
  */
-extern DECLSPEC int SDLCALL SDL_SetSurfaceColorMod(SDL_Surface *surface, Uint8 r, Uint8 g, Uint8 b);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetSurfaceColorMod(SDL_Surface *surface, Uint8 r, Uint8 g, Uint8 b);
 
 
 /**
@@ -536,7 +536,7 @@ extern DECLSPEC int SDLCALL SDL_SetSurfaceColorMod(SDL_Surface *surface, Uint8 r
  * \sa SDL_GetSurfaceAlphaMod
  * \sa SDL_SetSurfaceColorMod
  */
-extern DECLSPEC int SDLCALL SDL_GetSurfaceColorMod(SDL_Surface *surface, Uint8 *r, Uint8 *g, Uint8 *b);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetSurfaceColorMod(SDL_Surface *surface, Uint8 *r, Uint8 *g, Uint8 *b);
 
 /**
  * Set an additional alpha value used in blit operations.
@@ -556,7 +556,7 @@ extern DECLSPEC int SDLCALL SDL_GetSurfaceColorMod(SDL_Surface *surface, Uint8 *
  * \sa SDL_GetSurfaceAlphaMod
  * \sa SDL_SetSurfaceColorMod
  */
-extern DECLSPEC int SDLCALL SDL_SetSurfaceAlphaMod(SDL_Surface *surface, Uint8 alpha);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetSurfaceAlphaMod(SDL_Surface *surface, Uint8 alpha);
 
 /**
  * Get the additional alpha value used in blit operations.
@@ -571,7 +571,7 @@ extern DECLSPEC int SDLCALL SDL_SetSurfaceAlphaMod(SDL_Surface *surface, Uint8 a
  * \sa SDL_GetSurfaceColorMod
  * \sa SDL_SetSurfaceAlphaMod
  */
-extern DECLSPEC int SDLCALL SDL_GetSurfaceAlphaMod(SDL_Surface *surface, Uint8 *alpha);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetSurfaceAlphaMod(SDL_Surface *surface, Uint8 *alpha);
 
 /**
  * Set the blend mode used for blit operations.
@@ -589,7 +589,7 @@ extern DECLSPEC int SDLCALL SDL_GetSurfaceAlphaMod(SDL_Surface *surface, Uint8 *
  *
  * \sa SDL_GetSurfaceBlendMode
  */
-extern DECLSPEC int SDLCALL SDL_SetSurfaceBlendMode(SDL_Surface *surface, SDL_BlendMode blendMode);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetSurfaceBlendMode(SDL_Surface *surface, SDL_BlendMode blendMode);
 
 /**
  * Get the blend mode used for blit operations.
@@ -603,7 +603,7 @@ extern DECLSPEC int SDLCALL SDL_SetSurfaceBlendMode(SDL_Surface *surface, SDL_Bl
  *
  * \sa SDL_SetSurfaceBlendMode
  */
-extern DECLSPEC int SDLCALL SDL_GetSurfaceBlendMode(SDL_Surface *surface, SDL_BlendMode *blendMode);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetSurfaceBlendMode(SDL_Surface *surface, SDL_BlendMode *blendMode);
 
 /**
  * Set the clipping rectangle for a surface.
@@ -624,7 +624,7 @@ extern DECLSPEC int SDLCALL SDL_GetSurfaceBlendMode(SDL_Surface *surface, SDL_Bl
  *
  * \sa SDL_GetSurfaceClipRect
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_SetSurfaceClipRect(SDL_Surface *surface, const SDL_Rect *rect);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_SetSurfaceClipRect(SDL_Surface *surface, const SDL_Rect *rect);
 
 /**
  * Get the clipping rectangle for a surface.
@@ -643,7 +643,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_SetSurfaceClipRect(SDL_Surface *surface, co
  *
  * \sa SDL_SetSurfaceClipRect
  */
-extern DECLSPEC int SDLCALL SDL_GetSurfaceClipRect(SDL_Surface *surface, SDL_Rect *rect);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetSurfaceClipRect(SDL_Surface *surface, SDL_Rect *rect);
 
 /**
  * Flip a surface vertically or horizontally.
@@ -655,7 +655,7 @@ extern DECLSPEC int SDLCALL SDL_GetSurfaceClipRect(SDL_Surface *surface, SDL_Rec
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_FlipSurface(SDL_Surface *surface, SDL_FlipMode flip);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_FlipSurface(SDL_Surface *surface, SDL_FlipMode flip);
 
 /**
  * Creates a new surface identical to the existing surface.
@@ -670,7 +670,7 @@ extern DECLSPEC int SDLCALL SDL_FlipSurface(SDL_Surface *surface, SDL_FlipMode f
  *
  * \sa SDL_DestroySurface
  */
-extern DECLSPEC SDL_Surface *SDLCALL SDL_DuplicateSurface(SDL_Surface *surface);
+extern SDL_DECLSPEC_RETURN SDL_Surface *SDLCALL SDL_DuplicateSurface(SDL_Surface *surface);
 
 /**
  * Copy an existing surface to a new surface of the specified format.
@@ -693,7 +693,7 @@ extern DECLSPEC SDL_Surface *SDLCALL SDL_DuplicateSurface(SDL_Surface *surface);
  * \sa SDL_CreatePixelFormat
  * \sa SDL_DestroySurface
  */
-extern DECLSPEC SDL_Surface *SDLCALL SDL_ConvertSurface(SDL_Surface *surface, const SDL_PixelFormat *format);
+extern SDL_DECLSPEC_RETURN SDL_Surface *SDLCALL SDL_ConvertSurface(SDL_Surface *surface, const SDL_PixelFormat *format);
 
 /**
  * Copy an existing surface to a new surface of the specified format.
@@ -714,7 +714,7 @@ extern DECLSPEC SDL_Surface *SDLCALL SDL_ConvertSurface(SDL_Surface *surface, co
  * \sa SDL_ConvertSurfaceFormatAndColorspace
  * \sa SDL_DestroySurface
  */
-extern DECLSPEC SDL_Surface *SDLCALL SDL_ConvertSurfaceFormat(SDL_Surface *surface, SDL_PixelFormatEnum pixel_format);
+extern SDL_DECLSPEC_RETURN SDL_Surface *SDLCALL SDL_ConvertSurfaceFormat(SDL_Surface *surface, SDL_PixelFormatEnum pixel_format);
 
 /**
  * Copy an existing surface to a new surface of the specified format and
@@ -737,7 +737,7 @@ extern DECLSPEC SDL_Surface *SDLCALL SDL_ConvertSurfaceFormat(SDL_Surface *surfa
  * \sa SDL_ConvertSurfaceFormat
  * \sa SDL_DestroySurface
  */
-extern DECLSPEC SDL_Surface *SDLCALL SDL_ConvertSurfaceFormatAndColorspace(SDL_Surface *surface, SDL_PixelFormatEnum pixel_format, SDL_Colorspace colorspace, SDL_PropertiesID props);
+extern SDL_DECLSPEC_RETURN SDL_Surface *SDLCALL SDL_ConvertSurfaceFormatAndColorspace(SDL_Surface *surface, SDL_PixelFormatEnum pixel_format, SDL_Colorspace colorspace, SDL_PropertiesID props);
 
 /**
  * Copy a block of pixels of one format to another format.
@@ -757,7 +757,7 @@ extern DECLSPEC SDL_Surface *SDLCALL SDL_ConvertSurfaceFormatAndColorspace(SDL_S
  *
  * \sa SDL_ConvertPixelsAndColorspace
  */
-extern DECLSPEC int SDLCALL SDL_ConvertPixels(int width, int height, SDL_PixelFormatEnum src_format, const void *src, int src_pitch, SDL_PixelFormatEnum dst_format, void *dst, int dst_pitch);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ConvertPixels(int width, int height, SDL_PixelFormatEnum src_format, const void *src, int src_pitch, SDL_PixelFormatEnum dst_format, void *dst, int dst_pitch);
 
 /**
  * Copy a block of pixels of one format and colorspace to another format and
@@ -786,7 +786,7 @@ extern DECLSPEC int SDLCALL SDL_ConvertPixels(int width, int height, SDL_PixelFo
  *
  * \sa SDL_ConvertPixels
  */
-extern DECLSPEC int SDLCALL SDL_ConvertPixelsAndColorspace(int width, int height, SDL_PixelFormatEnum src_format, SDL_Colorspace src_colorspace, SDL_PropertiesID src_properties, const void *src, int src_pitch, SDL_PixelFormatEnum dst_format, SDL_Colorspace dst_colorspace, SDL_PropertiesID dst_properties, void *dst, int dst_pitch);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ConvertPixelsAndColorspace(int width, int height, SDL_PixelFormatEnum src_format, SDL_Colorspace src_colorspace, SDL_PropertiesID src_properties, const void *src, int src_pitch, SDL_PixelFormatEnum dst_format, SDL_Colorspace dst_colorspace, SDL_PropertiesID dst_properties, void *dst, int dst_pitch);
 
 /**
  * Premultiply the alpha on a block of pixels.
@@ -808,7 +808,7 @@ extern DECLSPEC int SDLCALL SDL_ConvertPixelsAndColorspace(int width, int height
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_PremultiplyAlpha(int width, int height, SDL_PixelFormatEnum src_format, const void *src, int src_pitch, SDL_PixelFormatEnum dst_format, void *dst, int dst_pitch);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_PremultiplyAlpha(int width, int height, SDL_PixelFormatEnum src_format, const void *src, int src_pitch, SDL_PixelFormatEnum dst_format, void *dst, int dst_pitch);
 
 /**
  * Perform a fast fill of a rectangle with a specific color.
@@ -833,7 +833,7 @@ extern DECLSPEC int SDLCALL SDL_PremultiplyAlpha(int width, int height, SDL_Pixe
  *
  * \sa SDL_FillSurfaceRects
  */
-extern DECLSPEC int SDLCALL SDL_FillSurfaceRect(SDL_Surface *dst, const SDL_Rect *rect, Uint32 color);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_FillSurfaceRect(SDL_Surface *dst, const SDL_Rect *rect, Uint32 color);
 
 /**
  * Perform a fast fill of a set of rectangles with a specific color.
@@ -858,7 +858,7 @@ extern DECLSPEC int SDLCALL SDL_FillSurfaceRect(SDL_Surface *dst, const SDL_Rect
  *
  * \sa SDL_FillSurfaceRect
  */
-extern DECLSPEC int SDLCALL SDL_FillSurfaceRects(SDL_Surface *dst, const SDL_Rect *rects, int count, Uint32 color);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_FillSurfaceRects(SDL_Surface *dst, const SDL_Rect *rects, int count, Uint32 color);
 
 /**
  * Performs a fast blit from the source surface to the destination surface.
@@ -928,7 +928,7 @@ extern DECLSPEC int SDLCALL SDL_FillSurfaceRects(SDL_Surface *dst, const SDL_Rec
  *
  * \sa SDL_BlitSurfaceScaled
  */
-extern DECLSPEC int SDLCALL SDL_BlitSurface(SDL_Surface *src, const SDL_Rect *srcrect, SDL_Surface *dst, SDL_Rect *dstrect);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_BlitSurface(SDL_Surface *src, const SDL_Rect *srcrect, SDL_Surface *dst, SDL_Rect *dstrect);
 
 /**
  * Perform low-level surface blitting only.
@@ -949,7 +949,7 @@ extern DECLSPEC int SDLCALL SDL_BlitSurface(SDL_Surface *src, const SDL_Rect *sr
  *
  * \sa SDL_BlitSurface
  */
-extern DECLSPEC int SDLCALL SDL_BlitSurfaceUnchecked(SDL_Surface *src, const SDL_Rect *srcrect, SDL_Surface *dst, const SDL_Rect *dstrect);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_BlitSurfaceUnchecked(SDL_Surface *src, const SDL_Rect *srcrect, SDL_Surface *dst, const SDL_Rect *dstrect);
 
 /**
  * Perform stretch blit between two surfaces of the same format.
@@ -971,7 +971,7 @@ extern DECLSPEC int SDLCALL SDL_BlitSurfaceUnchecked(SDL_Surface *src, const SDL
  *
  * \sa SDL_BlitSurfaceScaled
  */
-extern DECLSPEC int SDLCALL SDL_SoftStretch(SDL_Surface *src, const SDL_Rect *srcrect, SDL_Surface *dst, const SDL_Rect *dstrect, SDL_ScaleMode scaleMode);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SoftStretch(SDL_Surface *src, const SDL_Rect *srcrect, SDL_Surface *dst, const SDL_Rect *dstrect, SDL_ScaleMode scaleMode);
 
 /**
  * Perform a scaled blit to a destination surface, which may be of a different
@@ -992,7 +992,7 @@ extern DECLSPEC int SDLCALL SDL_SoftStretch(SDL_Surface *src, const SDL_Rect *sr
  *
  * \sa SDL_BlitSurface
  */
-extern DECLSPEC int SDLCALL SDL_BlitSurfaceScaled(SDL_Surface *src, const SDL_Rect *srcrect, SDL_Surface *dst, SDL_Rect *dstrect, SDL_ScaleMode scaleMode);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_BlitSurfaceScaled(SDL_Surface *src, const SDL_Rect *srcrect, SDL_Surface *dst, SDL_Rect *dstrect, SDL_ScaleMode scaleMode);
 
 /**
  * Perform low-level surface scaled blitting only.
@@ -1014,7 +1014,7 @@ extern DECLSPEC int SDLCALL SDL_BlitSurfaceScaled(SDL_Surface *src, const SDL_Re
  *
  * \sa SDL_BlitSurfaceScaled
  */
-extern DECLSPEC int SDLCALL SDL_BlitSurfaceUncheckedScaled(SDL_Surface *src, const SDL_Rect *srcrect, SDL_Surface *dst, const SDL_Rect *dstrect, SDL_ScaleMode scaleMode);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_BlitSurfaceUncheckedScaled(SDL_Surface *src, const SDL_Rect *srcrect, SDL_Surface *dst, const SDL_Rect *dstrect, SDL_ScaleMode scaleMode);
 
 /**
  * Retrieves a single pixel from a surface.
@@ -1041,7 +1041,7 @@ extern DECLSPEC int SDLCALL SDL_BlitSurfaceUncheckedScaled(SDL_Surface *src, con
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_ReadSurfacePixel(SDL_Surface *surface, int x, int y, Uint8 *r, Uint8 *g, Uint8 *b, Uint8 *a);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ReadSurfacePixel(SDL_Surface *surface, int x, int y, Uint8 *r, Uint8 *g, Uint8 *b, Uint8 *a);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_system.h
+++ b/include/SDL3/SDL_system.h
@@ -88,7 +88,7 @@ typedef SDL_bool (SDLCALL *SDL_WindowsMessageHook)(void *userdata, MSG *msg);
  * \sa SDL_WindowsMessageHook
  * \sa SDL_HINT_WINDOWS_ENABLE_MESSAGELOOP
  */
-extern DECLSPEC void SDLCALL SDL_SetWindowsMessageHook(SDL_WindowsMessageHook callback, void *userdata);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_SetWindowsMessageHook(SDL_WindowsMessageHook callback, void *userdata);
 
 #endif /* defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_GDK) */
 
@@ -106,7 +106,7 @@ extern DECLSPEC void SDLCALL SDL_SetWindowsMessageHook(SDL_WindowsMessageHook ca
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_Direct3D9GetAdapterIndex(SDL_DisplayID displayID);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_Direct3D9GetAdapterIndex(SDL_DisplayID displayID);
 
 #endif /* defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) */
 
@@ -127,7 +127,7 @@ extern DECLSPEC int SDLCALL SDL_Direct3D9GetAdapterIndex(SDL_DisplayID displayID
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_DXGIGetOutputInfo(SDL_DisplayID displayID, int *adapterIndex, int *outputIndex);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_DXGIGetOutputInfo(SDL_DisplayID displayID, int *adapterIndex, int *outputIndex);
 
 #endif /* defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) */
 
@@ -150,7 +150,7 @@ typedef SDL_bool (SDLCALL *SDL_X11EventHook)(void *userdata, XEvent *xevent);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_SetX11EventHook(SDL_X11EventHook callback, void *userdata);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_SetX11EventHook(SDL_X11EventHook callback, void *userdata);
 
 /* Platform specific functions for Linux*/
 #ifdef SDL_PLATFORM_LINUX
@@ -166,7 +166,7 @@ extern DECLSPEC void SDLCALL SDL_SetX11EventHook(SDL_X11EventHook callback, void
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_LinuxSetThreadPriority(Sint64 threadID, int priority);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_LinuxSetThreadPriority(Sint64 threadID, int priority);
 
 /**
  * Sets the priority (not nice level) and scheduling policy for a thread.
@@ -182,7 +182,7 @@ extern DECLSPEC int SDLCALL SDL_LinuxSetThreadPriority(Sint64 threadID, int prio
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_LinuxSetThreadPriorityAndPolicy(Sint64 threadID, int sdlPriority, int schedPolicy);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_LinuxSetThreadPriorityAndPolicy(Sint64 threadID, int sdlPriority, int schedPolicy);
 
 #endif /* SDL_PLATFORM_LINUX */
 
@@ -228,7 +228,7 @@ extern DECLSPEC int SDLCALL SDL_LinuxSetThreadPriorityAndPolicy(Sint64 threadID,
  *
  * \sa SDL_iOSSetEventPump
  */
-extern DECLSPEC int SDLCALL SDL_iOSSetAnimationCallback(SDL_Window * window, int interval, void (SDLCALL *callback)(void*), void *callbackParam);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_iOSSetAnimationCallback(SDL_Window * window, int interval, void (SDLCALL *callback)(void*), void *callbackParam);
 
 /**
  * Use this function to enable or disable the SDL event pump on Apple iOS.
@@ -241,7 +241,7 @@ extern DECLSPEC int SDLCALL SDL_iOSSetAnimationCallback(SDL_Window * window, int
  *
  * \sa SDL_iOSSetAnimationCallback
  */
-extern DECLSPEC void SDLCALL SDL_iOSSetEventPump(SDL_bool enabled);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_iOSSetEventPump(SDL_bool enabled);
 
 #endif /* SDL_PLATFORM_IOS */
 
@@ -268,7 +268,7 @@ extern DECLSPEC void SDLCALL SDL_iOSSetEventPump(SDL_bool enabled);
  *
  * \sa SDL_AndroidGetActivity
  */
-extern DECLSPEC void * SDLCALL SDL_AndroidGetJNIEnv(void);
+extern SDL_DECLSPEC_RETURN void * SDLCALL SDL_AndroidGetJNIEnv(void);
 
 /**
  * Retrieve the Java instance of the Android activity class.
@@ -290,7 +290,7 @@ extern DECLSPEC void * SDLCALL SDL_AndroidGetJNIEnv(void);
  *
  * \sa SDL_AndroidGetJNIEnv
  */
-extern DECLSPEC void * SDLCALL SDL_AndroidGetActivity(void);
+extern SDL_DECLSPEC_RETURN void * SDLCALL SDL_AndroidGetActivity(void);
 
 /**
  * Query Android API level of the current device.
@@ -325,7 +325,7 @@ extern DECLSPEC void * SDLCALL SDL_AndroidGetActivity(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetAndroidSDKVersion(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetAndroidSDKVersion(void);
 
 /**
  * Query if the application is running on Android TV.
@@ -334,7 +334,7 @@ extern DECLSPEC int SDLCALL SDL_GetAndroidSDKVersion(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_IsAndroidTV(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_IsAndroidTV(void);
 
 /**
  * Query if the application is running on a Chromebook.
@@ -343,7 +343,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_IsAndroidTV(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_IsChromebook(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_IsChromebook(void);
 
 /**
  * Query if the application is running on a Samsung DeX docking station.
@@ -352,14 +352,14 @@ extern DECLSPEC SDL_bool SDLCALL SDL_IsChromebook(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_IsDeXMode(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_IsDeXMode(void);
 
 /**
  * Trigger the Android system back button behavior.
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_AndroidBackButton(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_AndroidBackButton(void);
 
 /**
  * See the official Android developer guide for more information:
@@ -386,7 +386,7 @@ extern DECLSPEC void SDLCALL SDL_AndroidBackButton(void);
  *
  * \sa SDL_AndroidGetExternalStorageState
  */
-extern DECLSPEC const char * SDLCALL SDL_AndroidGetInternalStoragePath(void);
+extern SDL_DECLSPEC_RETURN const char * SDLCALL SDL_AndroidGetInternalStoragePath(void);
 
 /**
  * Get the current state of external storage.
@@ -405,7 +405,7 @@ extern DECLSPEC const char * SDLCALL SDL_AndroidGetInternalStoragePath(void);
  *
  * \sa SDL_AndroidGetExternalStoragePath
  */
-extern DECLSPEC int SDLCALL SDL_AndroidGetExternalStorageState(Uint32 *state);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_AndroidGetExternalStorageState(Uint32 *state);
 
 /**
  * Get the path used for external storage for this application.
@@ -423,7 +423,7 @@ extern DECLSPEC int SDLCALL SDL_AndroidGetExternalStorageState(Uint32 *state);
  *
  * \sa SDL_AndroidGetExternalStorageState
  */
-extern DECLSPEC const char * SDLCALL SDL_AndroidGetExternalStoragePath(void);
+extern SDL_DECLSPEC_RETURN const char * SDLCALL SDL_AndroidGetExternalStoragePath(void);
 
 
 typedef void (SDLCALL *SDL_AndroidRequestPermissionCallback)(void *userdata, const char *permission, SDL_bool granted);
@@ -456,7 +456,7 @@ typedef void (SDLCALL *SDL_AndroidRequestPermissionCallback)(void *userdata, con
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_AndroidRequestPermission(const char *permission, SDL_AndroidRequestPermissionCallback cb, void *userdata);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_AndroidRequestPermission(const char *permission, SDL_AndroidRequestPermissionCallback cb, void *userdata);
 
 /**
  * Shows an Android toast notification.
@@ -482,7 +482,7 @@ extern DECLSPEC int SDLCALL SDL_AndroidRequestPermission(const char *permission,
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_AndroidShowToast(const char* message, int duration, int gravity, int xoffset, int yoffset);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_AndroidShowToast(const char* message, int duration, int gravity, int xoffset, int yoffset);
 
 /**
  * Send a user command to SDLActivity.
@@ -496,7 +496,7 @@ extern DECLSPEC int SDLCALL SDL_AndroidShowToast(const char* message, int durati
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_AndroidSendMessage(Uint32 command, int param);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_AndroidSendMessage(Uint32 command, int param);
 
 #endif /* SDL_PLATFORM_ANDROID */
 
@@ -571,7 +571,7 @@ typedef enum SDL_WinRT_DeviceFamily
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC const char * SDLCALL SDL_WinRTGetFSPath(SDL_WinRT_Path pathType);
+extern SDL_DECLSPEC_RETURN const char * SDLCALL SDL_WinRTGetFSPath(SDL_WinRT_Path pathType);
 
 /**
  * Detects the device family of WinRT platform at runtime.
@@ -580,7 +580,7 @@ extern DECLSPEC const char * SDLCALL SDL_WinRTGetFSPath(SDL_WinRT_Path pathType)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_WinRT_DeviceFamily SDLCALL SDL_WinRTGetDeviceFamily();
+extern SDL_DECLSPEC_RETURN SDL_WinRT_DeviceFamily SDLCALL SDL_WinRTGetDeviceFamily();
 
 #endif /* SDL_PLATFORM_WINRT */
 
@@ -593,7 +593,7 @@ extern DECLSPEC SDL_WinRT_DeviceFamily SDLCALL SDL_WinRTGetDeviceFamily();
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_IsTablet(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_IsTablet(void);
 
 /* Functions used by iOS app delegates to notify SDL about state changes. */
 
@@ -612,7 +612,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_IsTablet(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_OnApplicationWillTerminate(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_OnApplicationWillTerminate(void);
 
 /**
  * Let iOS apps with external event handling report
@@ -629,7 +629,7 @@ extern DECLSPEC void SDLCALL SDL_OnApplicationWillTerminate(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_OnApplicationDidReceiveMemoryWarning(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_OnApplicationDidReceiveMemoryWarning(void);
 
 /**
  * Let iOS apps with external event handling report
@@ -646,7 +646,7 @@ extern DECLSPEC void SDLCALL SDL_OnApplicationDidReceiveMemoryWarning(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_OnApplicationWillResignActive(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_OnApplicationWillResignActive(void);
 
 /**
  * Let iOS apps with external event handling report
@@ -663,7 +663,7 @@ extern DECLSPEC void SDLCALL SDL_OnApplicationWillResignActive(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_OnApplicationDidEnterBackground(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_OnApplicationDidEnterBackground(void);
 
 /**
  * Let iOS apps with external event handling report
@@ -680,7 +680,7 @@ extern DECLSPEC void SDLCALL SDL_OnApplicationDidEnterBackground(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_OnApplicationWillEnterForeground(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_OnApplicationWillEnterForeground(void);
 
 /**
  * Let iOS apps with external event handling report
@@ -697,7 +697,7 @@ extern DECLSPEC void SDLCALL SDL_OnApplicationWillEnterForeground(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_OnApplicationDidBecomeActive(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_OnApplicationDidBecomeActive(void);
 
 #ifdef SDL_PLATFORM_IOS
 
@@ -716,7 +716,7 @@ extern DECLSPEC void SDLCALL SDL_OnApplicationDidBecomeActive(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_OnApplicationDidChangeStatusBarOrientation(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_OnApplicationDidChangeStatusBarOrientation(void);
 #endif
 
 /*
@@ -740,7 +740,7 @@ typedef struct XUser *XUserHandle;
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GDKGetTaskQueue(XTaskQueueHandle * outTaskQueue);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GDKGetTaskQueue(XTaskQueueHandle * outTaskQueue);
 
 /**
  * Gets a reference to the default user handle for GDK.
@@ -754,7 +754,7 @@ extern DECLSPEC int SDLCALL SDL_GDKGetTaskQueue(XTaskQueueHandle * outTaskQueue)
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GDKGetDefaultUser(XUserHandle * outUserHandle);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GDKGetDefaultUser(XUserHandle * outUserHandle);
 
 #endif
 

--- a/include/SDL3/SDL_thread.h
+++ b/include/SDL3/SDL_thread.h
@@ -130,7 +130,7 @@ typedef void (__cdecl * pfnSDL_CurrentEndThread) (unsigned code);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_Thread *SDLCALL
+extern SDL_DECLSPEC_RETURN SDL_Thread *SDLCALL
 SDL_CreateThread(SDL_ThreadFunction fn, const char *name, void *data,
                  pfnSDL_CurrentBeginThread pfnBeginThread,
                  pfnSDL_CurrentEndThread pfnEndThread);
@@ -149,7 +149,7 @@ SDL_CreateThread(SDL_ThreadFunction fn, const char *name, void *data,
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_Thread *SDLCALL
+extern SDL_DECLSPEC_RETURN SDL_Thread *SDLCALL
 SDL_CreateThreadWithStackSize(SDL_ThreadFunction fn,
                  const char *name, const size_t stacksize, void *data,
                  pfnSDL_CurrentBeginThread pfnBeginThread,
@@ -190,7 +190,7 @@ SDL_CreateThreadWithStackSize(SDL_ThreadFunction fn,
  * \sa SDL_CreateThreadWithStackSize
  * \sa SDL_WaitThread
  */
-extern DECLSPEC SDL_Thread * SDLCALL SDL_CreateThread(SDL_ThreadFunction fn, const char *name, void *data);
+extern SDL_DECLSPEC_RETURN SDL_Thread * SDLCALL SDL_CreateThread(SDL_ThreadFunction fn, const char *name, void *data);
 
 /**
  * Create a new thread with a specific stack size.
@@ -232,7 +232,7 @@ extern DECLSPEC SDL_Thread * SDLCALL SDL_CreateThread(SDL_ThreadFunction fn, con
  * \sa SDL_CreateThread
  * \sa SDL_WaitThread
  */
-extern DECLSPEC SDL_Thread * SDLCALL SDL_CreateThreadWithStackSize(SDL_ThreadFunction fn, const char *name, const size_t stacksize, void *data);
+extern SDL_DECLSPEC_RETURN SDL_Thread * SDLCALL SDL_CreateThreadWithStackSize(SDL_ThreadFunction fn, const char *name, const size_t stacksize, void *data);
 
 #endif
 
@@ -248,7 +248,7 @@ extern DECLSPEC SDL_Thread * SDLCALL SDL_CreateThreadWithStackSize(SDL_ThreadFun
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC const char *SDLCALL SDL_GetThreadName(SDL_Thread *thread);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetThreadName(SDL_Thread *thread);
 
 /**
  * Get the thread identifier for the current thread.
@@ -266,7 +266,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetThreadName(SDL_Thread *thread);
  *
  * \sa SDL_GetThreadID
  */
-extern DECLSPEC SDL_ThreadID SDLCALL SDL_GetCurrentThreadID(void);
+extern SDL_DECLSPEC_RETURN SDL_ThreadID SDLCALL SDL_GetCurrentThreadID(void);
 
 /**
  * Get the thread identifier for the specified thread.
@@ -283,7 +283,7 @@ extern DECLSPEC SDL_ThreadID SDLCALL SDL_GetCurrentThreadID(void);
  *
  * \sa SDL_GetCurrentThreadID
  */
-extern DECLSPEC SDL_ThreadID SDLCALL SDL_GetThreadID(SDL_Thread * thread);
+extern SDL_DECLSPEC_RETURN SDL_ThreadID SDLCALL SDL_GetThreadID(SDL_Thread * thread);
 
 /**
  * Set the priority for the current thread.
@@ -298,7 +298,7 @@ extern DECLSPEC SDL_ThreadID SDLCALL SDL_GetThreadID(SDL_Thread * thread);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SetThreadPriority(SDL_ThreadPriority priority);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetThreadPriority(SDL_ThreadPriority priority);
 
 /**
  * Wait for a thread to finish.
@@ -333,7 +333,7 @@ extern DECLSPEC int SDLCALL SDL_SetThreadPriority(SDL_ThreadPriority priority);
  * \sa SDL_CreateThread
  * \sa SDL_DetachThread
  */
-extern DECLSPEC void SDLCALL SDL_WaitThread(SDL_Thread * thread, int *status);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_WaitThread(SDL_Thread * thread, int *status);
 
 /**
  * Let a thread clean up on exit without intervention.
@@ -369,7 +369,7 @@ extern DECLSPEC void SDLCALL SDL_WaitThread(SDL_Thread * thread, int *status);
  * \sa SDL_CreateThread
  * \sa SDL_WaitThread
  */
-extern DECLSPEC void SDLCALL SDL_DetachThread(SDL_Thread * thread);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_DetachThread(SDL_Thread * thread);
 
 /**
  * Create a piece of thread-local storage.
@@ -384,7 +384,7 @@ extern DECLSPEC void SDLCALL SDL_DetachThread(SDL_Thread * thread);
  * \sa SDL_GetTLS
  * \sa SDL_SetTLS
  */
-extern DECLSPEC SDL_TLSID SDLCALL SDL_CreateTLS(void);
+extern SDL_DECLSPEC_RETURN SDL_TLSID SDLCALL SDL_CreateTLS(void);
 
 /**
  * Get the current thread's value associated with a thread local storage ID.
@@ -397,7 +397,7 @@ extern DECLSPEC SDL_TLSID SDLCALL SDL_CreateTLS(void);
  *
  * \sa SDL_SetTLS
  */
-extern DECLSPEC void * SDLCALL SDL_GetTLS(SDL_TLSID id);
+extern SDL_DECLSPEC_RETURN void * SDLCALL SDL_GetTLS(SDL_TLSID id);
 
 /**
  * Set the current thread's value associated with a thread local storage ID.
@@ -421,14 +421,14 @@ extern DECLSPEC void * SDLCALL SDL_GetTLS(SDL_TLSID id);
  *
  * \sa SDL_GetTLS
  */
-extern DECLSPEC int SDLCALL SDL_SetTLS(SDL_TLSID id, const void *value, void (SDLCALL *destructor)(void*));
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetTLS(SDL_TLSID id, const void *value, void (SDLCALL *destructor)(void*));
 
 /**
  * Cleanup all TLS data for this thread.
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_CleanupTLS(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_CleanupTLS(void);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_time.h
+++ b/include/SDL3/SDL_time.h
@@ -100,7 +100,7 @@ typedef enum SDL_TimeFormat
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetDateTimeLocalePreferences(SDL_DateFormat *dateFormat, SDL_TimeFormat *timeFormat);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetDateTimeLocalePreferences(SDL_DateFormat *dateFormat, SDL_TimeFormat *timeFormat);
 
 /**
  * Gets the current value of the system realtime clock in nanoseconds since
@@ -112,7 +112,7 @@ extern DECLSPEC int SDLCALL SDL_GetDateTimeLocalePreferences(SDL_DateFormat *dat
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetCurrentTime(SDL_Time *ticks);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetCurrentTime(SDL_Time *ticks);
 
 /**
  * Converts an SDL_Time in nanoseconds since the epoch to a calendar time in
@@ -128,7 +128,7 @@ extern DECLSPEC int SDLCALL SDL_GetCurrentTime(SDL_Time *ticks);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_TimeToDateTime(SDL_Time ticks, SDL_DateTime *dt, SDL_bool localTime);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_TimeToDateTime(SDL_Time ticks, SDL_DateTime *dt, SDL_bool localTime);
 
 /**
  * Converts a calendar time to an SDL_Time in nanoseconds since the epoch.
@@ -143,7 +143,7 @@ extern DECLSPEC int SDLCALL SDL_TimeToDateTime(SDL_Time ticks, SDL_DateTime *dt,
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_DateTimeToTime(const SDL_DateTime *dt, SDL_Time *ticks);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_DateTimeToTime(const SDL_DateTime *dt, SDL_Time *ticks);
 
 /**
  * Converts an SDL time into a Windows FILETIME (100-nanosecond intervals
@@ -159,7 +159,7 @@ extern DECLSPEC int SDLCALL SDL_DateTimeToTime(const SDL_DateTime *dt, SDL_Time 
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_TimeToWindows(SDL_Time ticks, Uint32 *dwLowDateTime, Uint32 *dwHighDateTime);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_TimeToWindows(SDL_Time ticks, Uint32 *dwLowDateTime, Uint32 *dwHighDateTime);
 
 /**
  * Converts a Windows FILETIME (100-nanosecond intervals since January 1,
@@ -174,7 +174,7 @@ extern DECLSPEC void SDLCALL SDL_TimeToWindows(SDL_Time ticks, Uint32 *dwLowDate
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_Time SDLCALL SDL_TimeFromWindows(Uint32 dwLowDateTime, Uint32 dwHighDateTime);
+extern SDL_DECLSPEC_RETURN SDL_Time SDLCALL SDL_TimeFromWindows(Uint32 dwLowDateTime, Uint32 dwHighDateTime);
 
 /**
  * Get the number of days in a month for a given year.
@@ -186,7 +186,7 @@ extern DECLSPEC SDL_Time SDLCALL SDL_TimeFromWindows(Uint32 dwLowDateTime, Uint3
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetDaysInMonth(int year, int month);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetDaysInMonth(int year, int month);
 
 /**
  * Get the day of year for a calendar date.
@@ -199,7 +199,7 @@ extern DECLSPEC int SDLCALL SDL_GetDaysInMonth(int year, int month);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetDayOfYear(int year, int month, int day);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetDayOfYear(int year, int month, int day);
 
 /**
  * Get the day of week for a calendar date.
@@ -212,7 +212,7 @@ extern DECLSPEC int SDLCALL SDL_GetDayOfYear(int year, int month, int day);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GetDayOfWeek(int year, int month, int day);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetDayOfWeek(int year, int month, int day);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_timer.h
+++ b/include/SDL3/SDL_timer.h
@@ -58,7 +58,7 @@ extern "C" {
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC Uint64 SDLCALL SDL_GetTicks(void);
+extern SDL_DECLSPEC_RETURN Uint64 SDLCALL SDL_GetTicks(void);
 
 /**
  * Get the number of nanoseconds since SDL library initialization.
@@ -68,7 +68,7 @@ extern DECLSPEC Uint64 SDLCALL SDL_GetTicks(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC Uint64 SDLCALL SDL_GetTicksNS(void);
+extern SDL_DECLSPEC_RETURN Uint64 SDLCALL SDL_GetTicksNS(void);
 
 /**
  * Get the current value of the high resolution counter.
@@ -85,7 +85,7 @@ extern DECLSPEC Uint64 SDLCALL SDL_GetTicksNS(void);
  *
  * \sa SDL_GetPerformanceFrequency
  */
-extern DECLSPEC Uint64 SDLCALL SDL_GetPerformanceCounter(void);
+extern SDL_DECLSPEC_RETURN Uint64 SDLCALL SDL_GetPerformanceCounter(void);
 
 /**
  * Get the count per second of the high resolution counter.
@@ -96,7 +96,7 @@ extern DECLSPEC Uint64 SDLCALL SDL_GetPerformanceCounter(void);
  *
  * \sa SDL_GetPerformanceCounter
  */
-extern DECLSPEC Uint64 SDLCALL SDL_GetPerformanceFrequency(void);
+extern SDL_DECLSPEC_RETURN Uint64 SDLCALL SDL_GetPerformanceFrequency(void);
 
 /**
  * Wait a specified number of milliseconds before returning.
@@ -109,7 +109,7 @@ extern DECLSPEC Uint64 SDLCALL SDL_GetPerformanceFrequency(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_Delay(Uint32 ms);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_Delay(Uint32 ms);
 
 /**
  * Wait a specified number of nanoseconds before returning.
@@ -122,7 +122,7 @@ extern DECLSPEC void SDLCALL SDL_Delay(Uint32 ms);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_DelayNS(Uint64 ns);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_DelayNS(Uint64 ns);
 
 /**
  * Function prototype for the timer callback function.
@@ -187,7 +187,7 @@ typedef Uint32 SDL_TimerID;
  *
  * \sa SDL_RemoveTimer
  */
-extern DECLSPEC SDL_TimerID SDLCALL SDL_AddTimer(Uint32 interval,
+extern SDL_DECLSPEC_RETURN SDL_TimerID SDLCALL SDL_AddTimer(Uint32 interval,
                                                  SDL_TimerCallback callback,
                                                  void *param);
 
@@ -202,7 +202,7 @@ extern DECLSPEC SDL_TimerID SDLCALL SDL_AddTimer(Uint32 interval,
  *
  * \sa SDL_AddTimer
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_RemoveTimer(SDL_TimerID id);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_RemoveTimer(SDL_TimerID id);
 
 
 /* Ends C function definitions when using C++ */

--- a/include/SDL3/SDL_touch.h
+++ b/include/SDL3/SDL_touch.h
@@ -91,7 +91,7 @@ typedef struct SDL_Finger
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_TouchID *SDLCALL SDL_GetTouchDevices(int *count);
+extern SDL_DECLSPEC_RETURN SDL_TouchID *SDLCALL SDL_GetTouchDevices(int *count);
 
 /**
  * Get the touch device name as reported from the driver.
@@ -104,7 +104,7 @@ extern DECLSPEC SDL_TouchID *SDLCALL SDL_GetTouchDevices(int *count);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC const char* SDLCALL SDL_GetTouchDeviceName(SDL_TouchID touchID);
+extern SDL_DECLSPEC_RETURN const char* SDLCALL SDL_GetTouchDeviceName(SDL_TouchID touchID);
 
 /**
  * Get the type of the given touch device.
@@ -114,7 +114,7 @@ extern DECLSPEC const char* SDLCALL SDL_GetTouchDeviceName(SDL_TouchID touchID);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_TouchDeviceType SDLCALL SDL_GetTouchDeviceType(SDL_TouchID touchID);
+extern SDL_DECLSPEC_RETURN SDL_TouchDeviceType SDLCALL SDL_GetTouchDeviceType(SDL_TouchID touchID);
 
 /**
  * Get a list of active fingers for a given touch device.
@@ -128,7 +128,7 @@ extern DECLSPEC SDL_TouchDeviceType SDLCALL SDL_GetTouchDeviceType(SDL_TouchID t
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_Finger **SDLCALL SDL_GetTouchFingers(SDL_TouchID touchID, int *count);
+extern SDL_DECLSPEC_RETURN SDL_Finger **SDLCALL SDL_GetTouchFingers(SDL_TouchID touchID, int *count);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_touch.h
+++ b/include/SDL3/SDL_touch.h
@@ -91,7 +91,7 @@ typedef struct SDL_Finger
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern SDL_DECLSPEC_RETURN SDL_TouchID *SDLCALL SDL_GetTouchDevices(int *count);
+extern SDL_DECLSPEC_NODISCARD SDL_TouchID *SDLCALL SDL_GetTouchDevices(int *count);
 
 /**
  * Get the touch device name as reported from the driver.
@@ -128,7 +128,7 @@ extern SDL_DECLSPEC_RETURN SDL_TouchDeviceType SDLCALL SDL_GetTouchDeviceType(SD
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern SDL_DECLSPEC_RETURN SDL_Finger **SDLCALL SDL_GetTouchFingers(SDL_TouchID touchID, int *count);
+extern SDL_DECLSPEC_NODISCARD SDL_Finger **SDLCALL SDL_GetTouchFingers(SDL_TouchID touchID, int *count);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_version.h
+++ b/include/SDL3/SDL_version.h
@@ -124,7 +124,7 @@ extern "C" {
  *
  * \sa SDL_GetRevision
  */
-extern DECLSPEC int SDLCALL SDL_GetVersion(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetVersion(void);
 
 /**
  * Get the code revision of SDL that is linked against your program.
@@ -150,7 +150,7 @@ extern DECLSPEC int SDLCALL SDL_GetVersion(void);
  *
  * \sa SDL_GetVersion
  */
-extern DECLSPEC const char *SDLCALL SDL_GetRevision(void);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetRevision(void);
 
 
 /* Ends C function definitions when using C++ */

--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -330,7 +330,7 @@ typedef enum SDL_GLContextResetNotification
  *
  * \sa SDL_GetVideoDriver
  */
-extern DECLSPEC int SDLCALL SDL_GetNumVideoDrivers(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetNumVideoDrivers(void);
 
 /**
  * Get the name of a built in video driver.
@@ -345,7 +345,7 @@ extern DECLSPEC int SDLCALL SDL_GetNumVideoDrivers(void);
  *
  * \sa SDL_GetNumVideoDrivers
  */
-extern DECLSPEC const char *SDLCALL SDL_GetVideoDriver(int index);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetVideoDriver(int index);
 
 /**
  * Get the name of the currently initialized video driver.
@@ -358,7 +358,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetVideoDriver(int index);
  * \sa SDL_GetNumVideoDrivers
  * \sa SDL_GetVideoDriver
  */
-extern DECLSPEC const char *SDLCALL SDL_GetCurrentVideoDriver(void);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetCurrentVideoDriver(void);
 
 /**
  * Get the current system theme.
@@ -367,7 +367,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetCurrentVideoDriver(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_SystemTheme SDLCALL SDL_GetSystemTheme(void);
+extern SDL_DECLSPEC_RETURN SDL_SystemTheme SDLCALL SDL_GetSystemTheme(void);
 
 /**
  * Get a list of currently connected displays.
@@ -379,7 +379,7 @@ extern DECLSPEC SDL_SystemTheme SDLCALL SDL_GetSystemTheme(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_DisplayID *SDLCALL SDL_GetDisplays(int *count);
+extern SDL_DECLSPEC_RETURN SDL_DisplayID *SDLCALL SDL_GetDisplays(int *count);
 
 /**
  * Return the primary display.
@@ -391,7 +391,7 @@ extern DECLSPEC SDL_DisplayID *SDLCALL SDL_GetDisplays(int *count);
  *
  * \sa SDL_GetDisplays
  */
-extern DECLSPEC SDL_DisplayID SDLCALL SDL_GetPrimaryDisplay(void);
+extern SDL_DECLSPEC_RETURN SDL_DisplayID SDLCALL SDL_GetPrimaryDisplay(void);
 
 /**
  * Get the properties associated with a display.
@@ -428,7 +428,7 @@ extern DECLSPEC SDL_DisplayID SDLCALL SDL_GetPrimaryDisplay(void);
  * \sa SDL_GetProperty
  * \sa SDL_SetProperty
  */
-extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetDisplayProperties(SDL_DisplayID displayID);
+extern SDL_DECLSPEC_RETURN SDL_PropertiesID SDLCALL SDL_GetDisplayProperties(SDL_DisplayID displayID);
 
 #define SDL_PROP_DISPLAY_HDR_ENABLED_BOOLEAN             "SDL.display.HDR_enabled"
 #define SDL_PROP_DISPLAY_SDR_WHITE_POINT_FLOAT           "SDL.display.SDR_white_point"
@@ -446,7 +446,7 @@ extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetDisplayProperties(SDL_DisplayID 
  *
  * \sa SDL_GetDisplays
  */
-extern DECLSPEC const char *SDLCALL SDL_GetDisplayName(SDL_DisplayID displayID);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetDisplayName(SDL_DisplayID displayID);
 
 /**
  * Get the desktop area represented by a display.
@@ -463,7 +463,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetDisplayName(SDL_DisplayID displayID);
  * \sa SDL_GetDisplayUsableBounds
  * \sa SDL_GetDisplays
  */
-extern DECLSPEC int SDLCALL SDL_GetDisplayBounds(SDL_DisplayID displayID, SDL_Rect *rect);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetDisplayBounds(SDL_DisplayID displayID, SDL_Rect *rect);
 
 /**
  * Get the usable desktop area represented by a display, in screen
@@ -487,7 +487,7 @@ extern DECLSPEC int SDLCALL SDL_GetDisplayBounds(SDL_DisplayID displayID, SDL_Re
  * \sa SDL_GetDisplayBounds
  * \sa SDL_GetDisplays
  */
-extern DECLSPEC int SDLCALL SDL_GetDisplayUsableBounds(SDL_DisplayID displayID, SDL_Rect *rect);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetDisplayUsableBounds(SDL_DisplayID displayID, SDL_Rect *rect);
 
 /**
  * Get the orientation of a display when it is unrotated.
@@ -500,7 +500,7 @@ extern DECLSPEC int SDLCALL SDL_GetDisplayUsableBounds(SDL_DisplayID displayID, 
  *
  * \sa SDL_GetDisplays
  */
-extern DECLSPEC SDL_DisplayOrientation SDLCALL SDL_GetNaturalDisplayOrientation(SDL_DisplayID displayID);
+extern SDL_DECLSPEC_RETURN SDL_DisplayOrientation SDLCALL SDL_GetNaturalDisplayOrientation(SDL_DisplayID displayID);
 
 /**
  * Get the orientation of a display.
@@ -513,7 +513,7 @@ extern DECLSPEC SDL_DisplayOrientation SDLCALL SDL_GetNaturalDisplayOrientation(
  *
  * \sa SDL_GetDisplays
  */
-extern DECLSPEC SDL_DisplayOrientation SDLCALL SDL_GetCurrentDisplayOrientation(SDL_DisplayID displayID);
+extern SDL_DECLSPEC_RETURN SDL_DisplayOrientation SDLCALL SDL_GetCurrentDisplayOrientation(SDL_DisplayID displayID);
 
 /**
  * Get the content scale of a display.
@@ -531,7 +531,7 @@ extern DECLSPEC SDL_DisplayOrientation SDLCALL SDL_GetCurrentDisplayOrientation(
  *
  * \sa SDL_GetDisplays
  */
-extern DECLSPEC float SDLCALL SDL_GetDisplayContentScale(SDL_DisplayID displayID);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_GetDisplayContentScale(SDL_DisplayID displayID);
 
 /**
  * Get a list of fullscreen display modes available on a display.
@@ -555,7 +555,7 @@ extern DECLSPEC float SDLCALL SDL_GetDisplayContentScale(SDL_DisplayID displayID
  *
  * \sa SDL_GetDisplays
  */
-extern DECLSPEC const SDL_DisplayMode **SDLCALL SDL_GetFullscreenDisplayModes(SDL_DisplayID displayID, int *count);
+extern SDL_DECLSPEC_RETURN const SDL_DisplayMode **SDLCALL SDL_GetFullscreenDisplayModes(SDL_DisplayID displayID, int *count);
 
 /**
  * Get the closest match to the requested display mode.
@@ -583,7 +583,7 @@ extern DECLSPEC const SDL_DisplayMode **SDLCALL SDL_GetFullscreenDisplayModes(SD
  * \sa SDL_GetDisplays
  * \sa SDL_GetFullscreenDisplayModes
  */
-extern DECLSPEC const SDL_DisplayMode *SDLCALL SDL_GetClosestFullscreenDisplayMode(SDL_DisplayID displayID, int w, int h, float refresh_rate, SDL_bool include_high_density_modes);
+extern SDL_DECLSPEC_RETURN const SDL_DisplayMode *SDLCALL SDL_GetClosestFullscreenDisplayMode(SDL_DisplayID displayID, int w, int h, float refresh_rate, SDL_bool include_high_density_modes);
 
 /**
  * Get information about the desktop's display mode.
@@ -602,7 +602,7 @@ extern DECLSPEC const SDL_DisplayMode *SDLCALL SDL_GetClosestFullscreenDisplayMo
  * \sa SDL_GetCurrentDisplayMode
  * \sa SDL_GetDisplays
  */
-extern DECLSPEC const SDL_DisplayMode *SDLCALL SDL_GetDesktopDisplayMode(SDL_DisplayID displayID);
+extern SDL_DECLSPEC_RETURN const SDL_DisplayMode *SDLCALL SDL_GetDesktopDisplayMode(SDL_DisplayID displayID);
 
 /**
  * Get information about the current display mode.
@@ -621,7 +621,7 @@ extern DECLSPEC const SDL_DisplayMode *SDLCALL SDL_GetDesktopDisplayMode(SDL_Dis
  * \sa SDL_GetDesktopDisplayMode
  * \sa SDL_GetDisplays
  */
-extern DECLSPEC const SDL_DisplayMode *SDLCALL SDL_GetCurrentDisplayMode(SDL_DisplayID displayID);
+extern SDL_DECLSPEC_RETURN const SDL_DisplayMode *SDLCALL SDL_GetCurrentDisplayMode(SDL_DisplayID displayID);
 
 /**
  * Get the display containing a point.
@@ -635,7 +635,7 @@ extern DECLSPEC const SDL_DisplayMode *SDLCALL SDL_GetCurrentDisplayMode(SDL_Dis
  * \sa SDL_GetDisplayBounds
  * \sa SDL_GetDisplays
  */
-extern DECLSPEC SDL_DisplayID SDLCALL SDL_GetDisplayForPoint(const SDL_Point *point);
+extern SDL_DECLSPEC_RETURN SDL_DisplayID SDLCALL SDL_GetDisplayForPoint(const SDL_Point *point);
 
 /**
  * Get the display primarily containing a rect.
@@ -650,7 +650,7 @@ extern DECLSPEC SDL_DisplayID SDLCALL SDL_GetDisplayForPoint(const SDL_Point *po
  * \sa SDL_GetDisplayBounds
  * \sa SDL_GetDisplays
  */
-extern DECLSPEC SDL_DisplayID SDLCALL SDL_GetDisplayForRect(const SDL_Rect *rect);
+extern SDL_DECLSPEC_RETURN SDL_DisplayID SDLCALL SDL_GetDisplayForRect(const SDL_Rect *rect);
 
 /**
  * Get the display associated with a window.
@@ -665,7 +665,7 @@ extern DECLSPEC SDL_DisplayID SDLCALL SDL_GetDisplayForRect(const SDL_Rect *rect
  * \sa SDL_GetDisplayBounds
  * \sa SDL_GetDisplays
  */
-extern DECLSPEC SDL_DisplayID SDLCALL SDL_GetDisplayForWindow(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN SDL_DisplayID SDLCALL SDL_GetDisplayForWindow(SDL_Window *window);
 
 /**
  * Get the pixel density of a window.
@@ -682,7 +682,7 @@ extern DECLSPEC SDL_DisplayID SDLCALL SDL_GetDisplayForWindow(SDL_Window *window
  *
  * \sa SDL_GetWindowDisplayScale
  */
-extern DECLSPEC float SDLCALL SDL_GetWindowPixelDensity(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_GetWindowPixelDensity(SDL_Window *window);
 
 /**
  * Get the content display scale relative to a window's pixel size.
@@ -704,7 +704,7 @@ extern DECLSPEC float SDLCALL SDL_GetWindowPixelDensity(SDL_Window *window);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC float SDLCALL SDL_GetWindowDisplayScale(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN float SDLCALL SDL_GetWindowDisplayScale(SDL_Window *window);
 
 /**
  * Set the display mode to use when a window is visible and fullscreen.
@@ -737,7 +737,7 @@ extern DECLSPEC float SDLCALL SDL_GetWindowDisplayScale(SDL_Window *window);
  * \sa SDL_SetWindowFullscreen
  * \sa SDL_SyncWindow
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowFullscreenMode(SDL_Window *window, const SDL_DisplayMode *mode);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowFullscreenMode(SDL_Window *window, const SDL_DisplayMode *mode);
 
 /**
  * Query the display mode to use when a window is visible at fullscreen.
@@ -751,7 +751,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowFullscreenMode(SDL_Window *window, cons
  * \sa SDL_SetWindowFullscreenMode
  * \sa SDL_SetWindowFullscreen
  */
-extern DECLSPEC const SDL_DisplayMode *SDLCALL SDL_GetWindowFullscreenMode(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN const SDL_DisplayMode *SDLCALL SDL_GetWindowFullscreenMode(SDL_Window *window);
 
 /**
  * Get the raw ICC profile data for the screen the window is currently on.
@@ -765,7 +765,7 @@ extern DECLSPEC const SDL_DisplayMode *SDLCALL SDL_GetWindowFullscreenMode(SDL_W
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void *SDLCALL SDL_GetWindowICCProfile(SDL_Window *window, size_t *size);
+extern SDL_DECLSPEC_RETURN void *SDLCALL SDL_GetWindowICCProfile(SDL_Window *window, size_t *size);
 
 /**
  * Get the pixel format associated with the window.
@@ -777,7 +777,7 @@ extern DECLSPEC void *SDLCALL SDL_GetWindowICCProfile(SDL_Window *window, size_t
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC Uint32 SDLCALL SDL_GetWindowPixelFormat(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN Uint32 SDLCALL SDL_GetWindowPixelFormat(SDL_Window *window);
 
 /**
  * Create a window with the specified dimensions and flags.
@@ -836,7 +836,7 @@ extern DECLSPEC Uint32 SDLCALL SDL_GetWindowPixelFormat(SDL_Window *window);
  * \sa SDL_CreateWindowWithProperties
  * \sa SDL_DestroyWindow
  */
-extern DECLSPEC SDL_Window *SDLCALL SDL_CreateWindow(const char *title, int w, int h, SDL_WindowFlags flags);
+extern SDL_DECLSPEC_RETURN SDL_Window *SDLCALL SDL_CreateWindow(const char *title, int w, int h, SDL_WindowFlags flags);
 
 /**
  * Create a child popup window of the specified parent window.
@@ -891,7 +891,7 @@ extern DECLSPEC SDL_Window *SDLCALL SDL_CreateWindow(const char *title, int w, i
  * \sa SDL_DestroyWindow
  * \sa SDL_GetWindowParent
  */
-extern DECLSPEC SDL_Window *SDLCALL SDL_CreatePopupWindow(SDL_Window *parent, int offset_x, int offset_y, int w, int h, SDL_WindowFlags flags);
+extern SDL_DECLSPEC_RETURN SDL_Window *SDLCALL SDL_CreatePopupWindow(SDL_Window *parent, int offset_x, int offset_y, int w, int h, SDL_WindowFlags flags);
 
 /**
  * Create a window with the specified properties.
@@ -997,7 +997,7 @@ extern DECLSPEC SDL_Window *SDLCALL SDL_CreatePopupWindow(SDL_Window *parent, in
  * \sa SDL_CreateWindow
  * \sa SDL_DestroyWindow
  */
-extern DECLSPEC SDL_Window *SDLCALL SDL_CreateWindowWithProperties(SDL_PropertiesID props);
+extern SDL_DECLSPEC_RETURN SDL_Window *SDLCALL SDL_CreateWindowWithProperties(SDL_PropertiesID props);
 
 #define SDL_PROP_WINDOW_CREATE_ALWAYS_ON_TOP_BOOLEAN               "always_on_top"
 #define SDL_PROP_WINDOW_CREATE_BORDERLESS_BOOLEAN                  "borderless"
@@ -1047,7 +1047,7 @@ extern DECLSPEC SDL_Window *SDLCALL SDL_CreateWindowWithProperties(SDL_Propertie
  *
  * \sa SDL_GetWindowFromID
  */
-extern DECLSPEC SDL_WindowID SDLCALL SDL_GetWindowID(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN SDL_WindowID SDLCALL SDL_GetWindowID(SDL_Window *window);
 
 /**
  * Get a window from a stored ID.
@@ -1063,7 +1063,7 @@ extern DECLSPEC SDL_WindowID SDLCALL SDL_GetWindowID(SDL_Window *window);
  *
  * \sa SDL_GetWindowID
  */
-extern DECLSPEC SDL_Window *SDLCALL SDL_GetWindowFromID(SDL_WindowID id);
+extern SDL_DECLSPEC_RETURN SDL_Window *SDLCALL SDL_GetWindowFromID(SDL_WindowID id);
 
 /**
  * Get parent of a window.
@@ -1076,7 +1076,7 @@ extern DECLSPEC SDL_Window *SDLCALL SDL_GetWindowFromID(SDL_WindowID id);
  *
  * \sa SDL_CreatePopupWindow
  */
-extern DECLSPEC SDL_Window *SDLCALL SDL_GetWindowParent(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN SDL_Window *SDLCALL SDL_GetWindowParent(SDL_Window *window);
 
 /**
  * Get the properties associated with a window.
@@ -1178,7 +1178,7 @@ extern DECLSPEC SDL_Window *SDLCALL SDL_GetWindowParent(SDL_Window *window);
  * \sa SDL_GetProperty
  * \sa SDL_GetNumberProperty
  */
-extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetWindowProperties(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN SDL_PropertiesID SDLCALL SDL_GetWindowProperties(SDL_Window *window);
 
 #define SDL_PROP_WINDOW_SHAPE_POINTER                             "SDL.window.shape"
 #define SDL_PROP_WINDOW_ANDROID_WINDOW_POINTER                    "SDL.window.android.window"
@@ -1225,7 +1225,7 @@ extern DECLSPEC SDL_PropertiesID SDLCALL SDL_GetWindowProperties(SDL_Window *win
  * \sa SDL_SetWindowMouseGrab
  * \sa SDL_ShowWindow
  */
-extern DECLSPEC SDL_WindowFlags SDLCALL SDL_GetWindowFlags(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN SDL_WindowFlags SDLCALL SDL_GetWindowFlags(SDL_Window *window);
 
 /**
  * Set the title of a window.
@@ -1241,7 +1241,7 @@ extern DECLSPEC SDL_WindowFlags SDLCALL SDL_GetWindowFlags(SDL_Window *window);
  *
  * \sa SDL_GetWindowTitle
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowTitle(SDL_Window *window, const char *title);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowTitle(SDL_Window *window, const char *title);
 
 /**
  * Get the title of a window.
@@ -1254,7 +1254,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowTitle(SDL_Window *window, const char *t
  *
  * \sa SDL_SetWindowTitle
  */
-extern DECLSPEC const char *SDLCALL SDL_GetWindowTitle(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN const char *SDLCALL SDL_GetWindowTitle(SDL_Window *window);
 
 /**
  * Set the icon for a window.
@@ -1266,7 +1266,7 @@ extern DECLSPEC const char *SDLCALL SDL_GetWindowTitle(SDL_Window *window);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowIcon(SDL_Window *window, SDL_Surface *icon);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowIcon(SDL_Window *window, SDL_Surface *icon);
 
 /**
  * Request that the window's position be set.
@@ -1306,7 +1306,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowIcon(SDL_Window *window, SDL_Surface *i
  * \sa SDL_GetWindowPosition
  * \sa SDL_SyncWindow
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowPosition(SDL_Window *window, int x, int y);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowPosition(SDL_Window *window, int x, int y);
 
 /**
  * Get the position of a window.
@@ -1327,7 +1327,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowPosition(SDL_Window *window, int x, int
  *
  * \sa SDL_SetWindowPosition
  */
-extern DECLSPEC int SDLCALL SDL_GetWindowPosition(SDL_Window *window, int *x, int *y);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetWindowPosition(SDL_Window *window, int *x, int *y);
 
 /**
  * Request that the size of a window's client area be set.
@@ -1366,7 +1366,7 @@ extern DECLSPEC int SDLCALL SDL_GetWindowPosition(SDL_Window *window, int *x, in
  * \sa SDL_SetWindowFullscreenMode
  * \sa SDL_SyncWindow
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowSize(SDL_Window *window, int w, int h);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowSize(SDL_Window *window, int w, int h);
 
 /**
  * Get the size of a window's client area.
@@ -1390,7 +1390,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowSize(SDL_Window *window, int w, int h);
  * \sa SDL_GetWindowSizeInPixels
  * \sa SDL_SetWindowSize
  */
-extern DECLSPEC int SDLCALL SDL_GetWindowSize(SDL_Window *window, int *w, int *h);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetWindowSize(SDL_Window *window, int *w, int *h);
 
 /**
  * Get the size of a window's borders (decorations) around the client area.
@@ -1424,7 +1424,7 @@ extern DECLSPEC int SDLCALL SDL_GetWindowSize(SDL_Window *window, int *w, int *h
  *
  * \sa SDL_GetWindowSize
  */
-extern DECLSPEC int SDLCALL SDL_GetWindowBordersSize(SDL_Window *window, int *top, int *left, int *bottom, int *right);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetWindowBordersSize(SDL_Window *window, int *top, int *left, int *bottom, int *right);
 
 /**
  * Get the size of a window's client area, in pixels.
@@ -1441,7 +1441,7 @@ extern DECLSPEC int SDLCALL SDL_GetWindowBordersSize(SDL_Window *window, int *to
  * \sa SDL_CreateWindow
  * \sa SDL_GetWindowSize
  */
-extern DECLSPEC int SDLCALL SDL_GetWindowSizeInPixels(SDL_Window *window, int *w, int *h);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetWindowSizeInPixels(SDL_Window *window, int *w, int *h);
 
 /**
  * Set the minimum size of a window's client area.
@@ -1457,7 +1457,7 @@ extern DECLSPEC int SDLCALL SDL_GetWindowSizeInPixels(SDL_Window *window, int *w
  * \sa SDL_GetWindowMinimumSize
  * \sa SDL_SetWindowMaximumSize
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowMinimumSize(SDL_Window *window, int min_w, int min_h);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowMinimumSize(SDL_Window *window, int min_w, int min_h);
 
 /**
  * Get the minimum size of a window's client area.
@@ -1475,7 +1475,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowMinimumSize(SDL_Window *window, int min
  * \sa SDL_GetWindowMaximumSize
  * \sa SDL_SetWindowMinimumSize
  */
-extern DECLSPEC int SDLCALL SDL_GetWindowMinimumSize(SDL_Window *window, int *w, int *h);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetWindowMinimumSize(SDL_Window *window, int *w, int *h);
 
 /**
  * Set the maximum size of a window's client area.
@@ -1491,7 +1491,7 @@ extern DECLSPEC int SDLCALL SDL_GetWindowMinimumSize(SDL_Window *window, int *w,
  * \sa SDL_GetWindowMaximumSize
  * \sa SDL_SetWindowMinimumSize
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowMaximumSize(SDL_Window *window, int max_w, int max_h);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowMaximumSize(SDL_Window *window, int max_w, int max_h);
 
 /**
  * Get the maximum size of a window's client area.
@@ -1509,7 +1509,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowMaximumSize(SDL_Window *window, int max
  * \sa SDL_GetWindowMinimumSize
  * \sa SDL_SetWindowMaximumSize
  */
-extern DECLSPEC int SDLCALL SDL_GetWindowMaximumSize(SDL_Window *window, int *w, int *h);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetWindowMaximumSize(SDL_Window *window, int *w, int *h);
 
 /**
  * Set the border state of a window.
@@ -1529,7 +1529,7 @@ extern DECLSPEC int SDLCALL SDL_GetWindowMaximumSize(SDL_Window *window, int *w,
  *
  * \sa SDL_GetWindowFlags
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowBordered(SDL_Window *window, SDL_bool bordered);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowBordered(SDL_Window *window, SDL_bool bordered);
 
 /**
  * Set the user-resizable state of a window.
@@ -1549,7 +1549,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowBordered(SDL_Window *window, SDL_bool b
  *
  * \sa SDL_GetWindowFlags
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowResizable(SDL_Window *window, SDL_bool resizable);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowResizable(SDL_Window *window, SDL_bool resizable);
 
 /**
  * Set the window to always be above the others.
@@ -1567,7 +1567,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowResizable(SDL_Window *window, SDL_bool 
  *
  * \sa SDL_GetWindowFlags
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowAlwaysOnTop(SDL_Window *window, SDL_bool on_top);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowAlwaysOnTop(SDL_Window *window, SDL_bool on_top);
 
 /**
  * Show a window.
@@ -1581,7 +1581,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowAlwaysOnTop(SDL_Window *window, SDL_boo
  * \sa SDL_HideWindow
  * \sa SDL_RaiseWindow
  */
-extern DECLSPEC int SDLCALL SDL_ShowWindow(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ShowWindow(SDL_Window *window);
 
 /**
  * Hide a window.
@@ -1594,7 +1594,7 @@ extern DECLSPEC int SDLCALL SDL_ShowWindow(SDL_Window *window);
  *
  * \sa SDL_ShowWindow
  */
-extern DECLSPEC int SDLCALL SDL_HideWindow(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_HideWindow(SDL_Window *window);
 
 /**
  * Raise a window above other windows and set the input focus.
@@ -1605,7 +1605,7 @@ extern DECLSPEC int SDLCALL SDL_HideWindow(SDL_Window *window);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_RaiseWindow(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RaiseWindow(SDL_Window *window);
 
 /**
  * Request that the window be made as large as possible.
@@ -1637,7 +1637,7 @@ extern DECLSPEC int SDLCALL SDL_RaiseWindow(SDL_Window *window);
  * \sa SDL_RestoreWindow
  * \sa SDL_SyncWindow
  */
-extern DECLSPEC int SDLCALL SDL_MaximizeWindow(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_MaximizeWindow(SDL_Window *window);
 
 /**
  * Request that the window be minimized to an iconic representation.
@@ -1661,7 +1661,7 @@ extern DECLSPEC int SDLCALL SDL_MaximizeWindow(SDL_Window *window);
  * \sa SDL_RestoreWindow
  * \sa SDL_SyncWindow
  */
-extern DECLSPEC int SDLCALL SDL_MinimizeWindow(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_MinimizeWindow(SDL_Window *window);
 
 /**
  * Request that the size and position of a minimized or maximized window be
@@ -1686,7 +1686,7 @@ extern DECLSPEC int SDLCALL SDL_MinimizeWindow(SDL_Window *window);
  * \sa SDL_MinimizeWindow
  * \sa SDL_SyncWindow
  */
-extern DECLSPEC int SDLCALL SDL_RestoreWindow(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_RestoreWindow(SDL_Window *window);
 
 /**
  * Request that the window's fullscreen state be changed.
@@ -1715,7 +1715,7 @@ extern DECLSPEC int SDLCALL SDL_RestoreWindow(SDL_Window *window);
  * \sa SDL_SetWindowFullscreenMode
  * \sa SDL_SyncWindow
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowFullscreen(SDL_Window *window, SDL_bool fullscreen);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowFullscreen(SDL_Window *window, SDL_bool fullscreen);
 
 /**
  * Block until any pending window state is finalized.
@@ -1745,7 +1745,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowFullscreen(SDL_Window *window, SDL_bool
  * \sa SDL_RestoreWindow
  * \sa SDL_HINT_VIDEO_SYNC_WINDOW_OPERATIONS
  */
-extern DECLSPEC int SDLCALL SDL_SyncWindow(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SyncWindow(SDL_Window *window);
 
 /**
  * Return whether the window has a surface associated with it.
@@ -1758,7 +1758,7 @@ extern DECLSPEC int SDLCALL SDL_SyncWindow(SDL_Window *window);
  *
  * \sa SDL_GetWindowSurface
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_WindowHasSurface(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_WindowHasSurface(SDL_Window *window);
 
 /**
  * Get the SDL surface associated with the window.
@@ -1785,7 +1785,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_WindowHasSurface(SDL_Window *window);
  * \sa SDL_UpdateWindowSurface
  * \sa SDL_UpdateWindowSurfaceRects
  */
-extern DECLSPEC SDL_Surface *SDLCALL SDL_GetWindowSurface(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN SDL_Surface *SDLCALL SDL_GetWindowSurface(SDL_Window *window);
 
 /**
  * Copy the window surface to the screen.
@@ -1804,7 +1804,7 @@ extern DECLSPEC SDL_Surface *SDLCALL SDL_GetWindowSurface(SDL_Window *window);
  * \sa SDL_GetWindowSurface
  * \sa SDL_UpdateWindowSurfaceRects
  */
-extern DECLSPEC int SDLCALL SDL_UpdateWindowSurface(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_UpdateWindowSurface(SDL_Window *window);
 
 /**
  * Copy areas of the window surface to the screen.
@@ -1831,7 +1831,7 @@ extern DECLSPEC int SDLCALL SDL_UpdateWindowSurface(SDL_Window *window);
  * \sa SDL_GetWindowSurface
  * \sa SDL_UpdateWindowSurface
  */
-extern DECLSPEC int SDLCALL SDL_UpdateWindowSurfaceRects(SDL_Window *window, const SDL_Rect *rects, int numrects);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_UpdateWindowSurfaceRects(SDL_Window *window, const SDL_Rect *rects, int numrects);
 
 /**
  * Destroy the surface associated with the window.
@@ -1845,7 +1845,7 @@ extern DECLSPEC int SDLCALL SDL_UpdateWindowSurfaceRects(SDL_Window *window, con
  * \sa SDL_GetWindowSurface
  * \sa SDL_WindowHasSurface
  */
-extern DECLSPEC int SDLCALL SDL_DestroyWindowSurface(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_DestroyWindowSurface(SDL_Window *window);
 
 /**
  * Set a window's keyboard grab mode.
@@ -1876,7 +1876,7 @@ extern DECLSPEC int SDLCALL SDL_DestroyWindowSurface(SDL_Window *window);
  * \sa SDL_GetWindowKeyboardGrab
  * \sa SDL_SetWindowMouseGrab
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowKeyboardGrab(SDL_Window *window, SDL_bool grabbed);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowKeyboardGrab(SDL_Window *window, SDL_bool grabbed);
 
 /**
  * Set a window's mouse grab mode.
@@ -1893,7 +1893,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowKeyboardGrab(SDL_Window *window, SDL_bo
  * \sa SDL_GetWindowMouseGrab
  * \sa SDL_SetWindowKeyboardGrab
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowMouseGrab(SDL_Window *window, SDL_bool grabbed);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowMouseGrab(SDL_Window *window, SDL_bool grabbed);
 
 /**
  * Get a window's keyboard grab mode.
@@ -1905,7 +1905,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowMouseGrab(SDL_Window *window, SDL_bool 
  *
  * \sa SDL_SetWindowKeyboardGrab
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GetWindowKeyboardGrab(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GetWindowKeyboardGrab(SDL_Window *window);
 
 /**
  * Get a window's mouse grab mode.
@@ -1917,7 +1917,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_GetWindowKeyboardGrab(SDL_Window *window);
  *
  * \sa SDL_SetWindowKeyboardGrab
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GetWindowMouseGrab(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GetWindowMouseGrab(SDL_Window *window);
 
 /**
  * Get the window that currently has an input grab enabled.
@@ -1929,7 +1929,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_GetWindowMouseGrab(SDL_Window *window);
  * \sa SDL_SetWindowMouseGrab
  * \sa SDL_SetWindowKeyboardGrab
  */
-extern DECLSPEC SDL_Window *SDLCALL SDL_GetGrabbedWindow(void);
+extern SDL_DECLSPEC_RETURN SDL_Window *SDLCALL SDL_GetGrabbedWindow(void);
 
 /**
  * Confines the cursor to the specified area of a window.
@@ -1948,7 +1948,7 @@ extern DECLSPEC SDL_Window *SDLCALL SDL_GetGrabbedWindow(void);
  * \sa SDL_GetWindowMouseRect
  * \sa SDL_SetWindowMouseGrab
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowMouseRect(SDL_Window *window, const SDL_Rect *rect);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowMouseRect(SDL_Window *window, const SDL_Rect *rect);
 
 /**
  * Get the mouse confinement rectangle of a window.
@@ -1961,7 +1961,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowMouseRect(SDL_Window *window, const SDL
  *
  * \sa SDL_SetWindowMouseRect
  */
-extern DECLSPEC const SDL_Rect *SDLCALL SDL_GetWindowMouseRect(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN const SDL_Rect *SDLCALL SDL_GetWindowMouseRect(SDL_Window *window);
 
 /**
  * Set the opacity for a window.
@@ -1980,7 +1980,7 @@ extern DECLSPEC const SDL_Rect *SDLCALL SDL_GetWindowMouseRect(SDL_Window *windo
  *
  * \sa SDL_GetWindowOpacity
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowOpacity(SDL_Window *window, float opacity);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowOpacity(SDL_Window *window, float opacity);
 
 /**
  * Get the opacity of a window.
@@ -2001,7 +2001,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowOpacity(SDL_Window *window, float opaci
  *
  * \sa SDL_SetWindowOpacity
  */
-extern DECLSPEC int SDLCALL SDL_GetWindowOpacity(SDL_Window *window, float *out_opacity);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GetWindowOpacity(SDL_Window *window, float *out_opacity);
 
 /**
  * Set the window as a modal to a parent window.
@@ -2020,7 +2020,7 @@ extern DECLSPEC int SDLCALL SDL_GetWindowOpacity(SDL_Window *window, float *out_
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowModalFor(SDL_Window *modal_window, SDL_Window *parent_window);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowModalFor(SDL_Window *modal_window, SDL_Window *parent_window);
 
 /**
  * Explicitly set input focus to the window.
@@ -2037,7 +2037,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowModalFor(SDL_Window *modal_window, SDL_
  *
  * \sa SDL_RaiseWindow
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowInputFocus(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowInputFocus(SDL_Window *window);
 
 /**
  * Set whether the window may have input focus.
@@ -2050,7 +2050,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowInputFocus(SDL_Window *window);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowFocusable(SDL_Window *window, SDL_bool focusable);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowFocusable(SDL_Window *window, SDL_bool focusable);
 
 
 /**
@@ -2074,7 +2074,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowFocusable(SDL_Window *window, SDL_bool 
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_ShowWindowSystemMenu(SDL_Window *window, int x, int y);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_ShowWindowSystemMenu(SDL_Window *window, int x, int y);
 
 /**
  * Possible return values from the SDL_HitTest callback.
@@ -2151,7 +2151,7 @@ typedef SDL_HitTestResult (SDLCALL *SDL_HitTest)(SDL_Window *win,
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowHitTest(SDL_Window *window, SDL_HitTest callback, void *callback_data);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowHitTest(SDL_Window *window, SDL_HitTest callback, void *callback_data);
 
 /**
  * Set the shape of a transparent window.
@@ -2175,7 +2175,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowHitTest(SDL_Window *window, SDL_HitTest
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_SetWindowShape(SDL_Window *window, SDL_Surface *shape);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_SetWindowShape(SDL_Window *window, SDL_Surface *shape);
 
 /**
  * Request a window to demand attention from the user.
@@ -2187,7 +2187,7 @@ extern DECLSPEC int SDLCALL SDL_SetWindowShape(SDL_Window *window, SDL_Surface *
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_FlashWindow(SDL_Window *window, SDL_FlashOperation operation);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_FlashWindow(SDL_Window *window, SDL_FlashOperation operation);
 
 /**
  * Destroy a window.
@@ -2206,7 +2206,7 @@ extern DECLSPEC int SDLCALL SDL_FlashWindow(SDL_Window *window, SDL_FlashOperati
  * \sa SDL_CreateWindow
  * \sa SDL_CreateWindowWithProperties
  */
-extern DECLSPEC void SDLCALL SDL_DestroyWindow(SDL_Window *window);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_DestroyWindow(SDL_Window *window);
 
 
 /**
@@ -2224,7 +2224,7 @@ extern DECLSPEC void SDLCALL SDL_DestroyWindow(SDL_Window *window);
  * \sa SDL_DisableScreenSaver
  * \sa SDL_EnableScreenSaver
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_ScreenSaverEnabled(void);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_ScreenSaverEnabled(void);
 
 /**
  * Allow the screen to be blanked by a screen saver.
@@ -2237,7 +2237,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_ScreenSaverEnabled(void);
  * \sa SDL_DisableScreenSaver
  * \sa SDL_ScreenSaverEnabled
  */
-extern DECLSPEC int SDLCALL SDL_EnableScreenSaver(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_EnableScreenSaver(void);
 
 /**
  * Prevent the screen from being blanked by a screen saver.
@@ -2256,7 +2256,7 @@ extern DECLSPEC int SDLCALL SDL_EnableScreenSaver(void);
  * \sa SDL_EnableScreenSaver
  * \sa SDL_ScreenSaverEnabled
  */
-extern DECLSPEC int SDLCALL SDL_DisableScreenSaver(void);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_DisableScreenSaver(void);
 
 
 /**
@@ -2284,7 +2284,7 @@ extern DECLSPEC int SDLCALL SDL_DisableScreenSaver(void);
  * \sa SDL_GL_GetProcAddress
  * \sa SDL_GL_UnloadLibrary
  */
-extern DECLSPEC int SDLCALL SDL_GL_LoadLibrary(const char *path);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GL_LoadLibrary(const char *path);
 
 /**
  * Get an OpenGL function by name.
@@ -2337,7 +2337,7 @@ extern DECLSPEC int SDLCALL SDL_GL_LoadLibrary(const char *path);
  * \sa SDL_GL_LoadLibrary
  * \sa SDL_GL_UnloadLibrary
  */
-extern DECLSPEC SDL_FunctionPointer SDLCALL SDL_GL_GetProcAddress(const char *proc);
+extern SDL_DECLSPEC_RETURN SDL_FunctionPointer SDLCALL SDL_GL_GetProcAddress(const char *proc);
 
 /**
  * Get an EGL library function by name.
@@ -2354,7 +2354,7 @@ extern DECLSPEC SDL_FunctionPointer SDLCALL SDL_GL_GetProcAddress(const char *pr
  *
  * \sa SDL_GL_GetCurrentEGLDisplay
  */
-extern DECLSPEC SDL_FunctionPointer SDLCALL SDL_EGL_GetProcAddress(const char *proc);
+extern SDL_DECLSPEC_RETURN SDL_FunctionPointer SDLCALL SDL_EGL_GetProcAddress(const char *proc);
 
 /**
  * Unload the OpenGL library previously loaded by SDL_GL_LoadLibrary().
@@ -2363,7 +2363,7 @@ extern DECLSPEC SDL_FunctionPointer SDLCALL SDL_EGL_GetProcAddress(const char *p
  *
  * \sa SDL_GL_LoadLibrary
  */
-extern DECLSPEC void SDLCALL SDL_GL_UnloadLibrary(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_GL_UnloadLibrary(void);
 
 /**
  * Check if an OpenGL extension is supported for the current context.
@@ -2384,7 +2384,7 @@ extern DECLSPEC void SDLCALL SDL_GL_UnloadLibrary(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_GL_ExtensionSupported(const char *extension);
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_GL_ExtensionSupported(const char *extension);
 
 /**
  * Reset all previously set OpenGL context attributes to their default values.
@@ -2394,7 +2394,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_GL_ExtensionSupported(const char *extension
  * \sa SDL_GL_GetAttribute
  * \sa SDL_GL_SetAttribute
  */
-extern DECLSPEC void SDLCALL SDL_GL_ResetAttributes(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_GL_ResetAttributes(void);
 
 /**
  * Set an OpenGL window attribute before window creation.
@@ -2414,7 +2414,7 @@ extern DECLSPEC void SDLCALL SDL_GL_ResetAttributes(void);
  * \sa SDL_GL_GetAttribute
  * \sa SDL_GL_ResetAttributes
  */
-extern DECLSPEC int SDLCALL SDL_GL_SetAttribute(SDL_GLattr attr, int value);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GL_SetAttribute(SDL_GLattr attr, int value);
 
 /**
  * Get the actual value for an attribute from the current context.
@@ -2429,7 +2429,7 @@ extern DECLSPEC int SDLCALL SDL_GL_SetAttribute(SDL_GLattr attr, int value);
  * \sa SDL_GL_ResetAttributes
  * \sa SDL_GL_SetAttribute
  */
-extern DECLSPEC int SDLCALL SDL_GL_GetAttribute(SDL_GLattr attr, int *value);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GL_GetAttribute(SDL_GLattr attr, int *value);
 
 /**
  * Create an OpenGL context for an OpenGL window, and make it current.
@@ -2451,7 +2451,7 @@ extern DECLSPEC int SDLCALL SDL_GL_GetAttribute(SDL_GLattr attr, int *value);
  * \sa SDL_GL_DeleteContext
  * \sa SDL_GL_MakeCurrent
  */
-extern DECLSPEC SDL_GLContext SDLCALL SDL_GL_CreateContext(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN SDL_GLContext SDLCALL SDL_GL_CreateContext(SDL_Window *window);
 
 /**
  * Set up an OpenGL context for rendering into an OpenGL window.
@@ -2467,7 +2467,7 @@ extern DECLSPEC SDL_GLContext SDLCALL SDL_GL_CreateContext(SDL_Window *window);
  *
  * \sa SDL_GL_CreateContext
  */
-extern DECLSPEC int SDLCALL SDL_GL_MakeCurrent(SDL_Window *window, SDL_GLContext context);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GL_MakeCurrent(SDL_Window *window, SDL_GLContext context);
 
 /**
  * Get the currently active OpenGL window.
@@ -2477,7 +2477,7 @@ extern DECLSPEC int SDLCALL SDL_GL_MakeCurrent(SDL_Window *window, SDL_GLContext
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_Window *SDLCALL SDL_GL_GetCurrentWindow(void);
+extern SDL_DECLSPEC_RETURN SDL_Window *SDLCALL SDL_GL_GetCurrentWindow(void);
 
 /**
  * Get the currently active OpenGL context.
@@ -2489,7 +2489,7 @@ extern DECLSPEC SDL_Window *SDLCALL SDL_GL_GetCurrentWindow(void);
  *
  * \sa SDL_GL_MakeCurrent
  */
-extern DECLSPEC SDL_GLContext SDLCALL SDL_GL_GetCurrentContext(void);
+extern SDL_DECLSPEC_RETURN SDL_GLContext SDLCALL SDL_GL_GetCurrentContext(void);
 
 /**
  * Get the currently active EGL display.
@@ -2499,7 +2499,7 @@ extern DECLSPEC SDL_GLContext SDLCALL SDL_GL_GetCurrentContext(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_EGLDisplay SDLCALL SDL_EGL_GetCurrentEGLDisplay(void);
+extern SDL_DECLSPEC_RETURN SDL_EGLDisplay SDLCALL SDL_EGL_GetCurrentEGLDisplay(void);
 
 /**
  * Get the currently active EGL config.
@@ -2509,7 +2509,7 @@ extern DECLSPEC SDL_EGLDisplay SDLCALL SDL_EGL_GetCurrentEGLDisplay(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_EGLConfig SDLCALL SDL_EGL_GetCurrentEGLConfig(void);
+extern SDL_DECLSPEC_RETURN SDL_EGLConfig SDLCALL SDL_EGL_GetCurrentEGLConfig(void);
 
 /**
  * Get the EGL surface associated with the window.
@@ -2520,7 +2520,7 @@ extern DECLSPEC SDL_EGLConfig SDLCALL SDL_EGL_GetCurrentEGLConfig(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_EGLSurface SDLCALL SDL_EGL_GetWindowEGLSurface(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN SDL_EGLSurface SDLCALL SDL_EGL_GetWindowEGLSurface(SDL_Window *window);
 
 /**
  * Sets the callbacks for defining custom EGLAttrib arrays for EGL
@@ -2544,7 +2544,7 @@ extern DECLSPEC SDL_EGLSurface SDLCALL SDL_EGL_GetWindowEGLSurface(SDL_Window *w
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC void SDLCALL SDL_EGL_SetEGLAttributeCallbacks(SDL_EGLAttribArrayCallback platformAttribCallback,
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_EGL_SetEGLAttributeCallbacks(SDL_EGLAttribArrayCallback platformAttribCallback,
                                                               SDL_EGLIntArrayCallback surfaceAttribCallback,
                                                               SDL_EGLIntArrayCallback contextAttribCallback);
 
@@ -2575,7 +2575,7 @@ extern DECLSPEC void SDLCALL SDL_EGL_SetEGLAttributeCallbacks(SDL_EGLAttribArray
  *
  * \sa SDL_GL_GetSwapInterval
  */
-extern DECLSPEC int SDLCALL SDL_GL_SetSwapInterval(int interval);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GL_SetSwapInterval(int interval);
 
 /**
  * Get the swap interval for the current OpenGL context.
@@ -2594,7 +2594,7 @@ extern DECLSPEC int SDLCALL SDL_GL_SetSwapInterval(int interval);
  *
  * \sa SDL_GL_SetSwapInterval
  */
-extern DECLSPEC int SDLCALL SDL_GL_GetSwapInterval(int *interval);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GL_GetSwapInterval(int *interval);
 
 /**
  * Update a window with OpenGL rendering.
@@ -2612,7 +2612,7 @@ extern DECLSPEC int SDLCALL SDL_GL_GetSwapInterval(int *interval);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC int SDLCALL SDL_GL_SwapWindow(SDL_Window *window);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GL_SwapWindow(SDL_Window *window);
 
 /**
  * Delete an OpenGL context.
@@ -2625,7 +2625,7 @@ extern DECLSPEC int SDLCALL SDL_GL_SwapWindow(SDL_Window *window);
  *
  * \sa SDL_GL_CreateContext
  */
-extern DECLSPEC int SDLCALL SDL_GL_DeleteContext(SDL_GLContext context);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GL_DeleteContext(SDL_GLContext context);
 
 /* @} *//* OpenGL support functions */
 

--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -379,7 +379,7 @@ extern SDL_DECLSPEC_RETURN SDL_SystemTheme SDLCALL SDL_GetSystemTheme(void);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern SDL_DECLSPEC_RETURN SDL_DisplayID *SDLCALL SDL_GetDisplays(int *count);
+extern SDL_DECLSPEC_NODISCARD SDL_DisplayID *SDLCALL SDL_GetDisplays(int *count);
 
 /**
  * Return the primary display.
@@ -555,7 +555,7 @@ extern SDL_DECLSPEC_RETURN float SDLCALL SDL_GetDisplayContentScale(SDL_DisplayI
  *
  * \sa SDL_GetDisplays
  */
-extern SDL_DECLSPEC_RETURN const SDL_DisplayMode **SDLCALL SDL_GetFullscreenDisplayModes(SDL_DisplayID displayID, int *count);
+extern SDL_DECLSPEC_NODISCARD const SDL_DisplayMode **SDLCALL SDL_GetFullscreenDisplayModes(SDL_DisplayID displayID, int *count);
 
 /**
  * Get the closest match to the requested display mode.
@@ -765,7 +765,7 @@ extern SDL_DECLSPEC_RETURN const SDL_DisplayMode *SDLCALL SDL_GetWindowFullscree
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern SDL_DECLSPEC_RETURN void *SDLCALL SDL_GetWindowICCProfile(SDL_Window *window, size_t *size);
+extern SDL_DECLSPEC_NODISCARD void *SDLCALL SDL_GetWindowICCProfile(SDL_Window *window, size_t *size);
 
 /**
  * Get the pixel format associated with the window.
@@ -836,7 +836,7 @@ extern SDL_DECLSPEC_RETURN Uint32 SDLCALL SDL_GetWindowPixelFormat(SDL_Window *w
  * \sa SDL_CreateWindowWithProperties
  * \sa SDL_DestroyWindow
  */
-extern SDL_DECLSPEC_RETURN SDL_Window *SDLCALL SDL_CreateWindow(const char *title, int w, int h, SDL_WindowFlags flags);
+extern SDL_DECLSPEC_NODISCARD SDL_Window *SDLCALL SDL_CreateWindow(const char *title, int w, int h, SDL_WindowFlags flags);
 
 /**
  * Create a child popup window of the specified parent window.
@@ -891,7 +891,7 @@ extern SDL_DECLSPEC_RETURN SDL_Window *SDLCALL SDL_CreateWindow(const char *titl
  * \sa SDL_DestroyWindow
  * \sa SDL_GetWindowParent
  */
-extern SDL_DECLSPEC_RETURN SDL_Window *SDLCALL SDL_CreatePopupWindow(SDL_Window *parent, int offset_x, int offset_y, int w, int h, SDL_WindowFlags flags);
+extern SDL_DECLSPEC_NODISCARD SDL_Window *SDLCALL SDL_CreatePopupWindow(SDL_Window *parent, int offset_x, int offset_y, int w, int h, SDL_WindowFlags flags);
 
 /**
  * Create a window with the specified properties.
@@ -997,7 +997,7 @@ extern SDL_DECLSPEC_RETURN SDL_Window *SDLCALL SDL_CreatePopupWindow(SDL_Window 
  * \sa SDL_CreateWindow
  * \sa SDL_DestroyWindow
  */
-extern SDL_DECLSPEC_RETURN SDL_Window *SDLCALL SDL_CreateWindowWithProperties(SDL_PropertiesID props);
+extern SDL_DECLSPEC_NODISCARD SDL_Window *SDLCALL SDL_CreateWindowWithProperties(SDL_PropertiesID props);
 
 #define SDL_PROP_WINDOW_CREATE_ALWAYS_ON_TOP_BOOLEAN               "always_on_top"
 #define SDL_PROP_WINDOW_CREATE_BORDERLESS_BOOLEAN                  "borderless"
@@ -2451,7 +2451,7 @@ extern SDL_DECLSPEC_RETURN int SDLCALL SDL_GL_GetAttribute(SDL_GLattr attr, int 
  * \sa SDL_GL_DeleteContext
  * \sa SDL_GL_MakeCurrent
  */
-extern SDL_DECLSPEC_RETURN SDL_GLContext SDLCALL SDL_GL_CreateContext(SDL_Window *window);
+extern SDL_DECLSPEC_NODISCARD SDL_GLContext SDLCALL SDL_GL_CreateContext(SDL_Window *window);
 
 /**
  * Set up an OpenGL context for rendering into an OpenGL window.

--- a/include/SDL3/SDL_vulkan.h
+++ b/include/SDL3/SDL_vulkan.h
@@ -102,7 +102,7 @@ struct VkAllocationCallbacks;
  * \sa SDL_Vulkan_GetVkGetInstanceProcAddr
  * \sa SDL_Vulkan_UnloadLibrary
  */
-extern DECLSPEC int SDLCALL SDL_Vulkan_LoadLibrary(const char *path);
+extern SDL_DECLSPEC_RETURN int SDLCALL SDL_Vulkan_LoadLibrary(const char *path);
 
 /**
  * Get the address of the `vkGetInstanceProcAddr` function.
@@ -122,7 +122,7 @@ extern DECLSPEC int SDLCALL SDL_Vulkan_LoadLibrary(const char *path);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern DECLSPEC SDL_FunctionPointer SDLCALL SDL_Vulkan_GetVkGetInstanceProcAddr(void);
+extern SDL_DECLSPEC_RETURN SDL_FunctionPointer SDLCALL SDL_Vulkan_GetVkGetInstanceProcAddr(void);
 
 /**
  * Unload the Vulkan library previously loaded by SDL_Vulkan_LoadLibrary().
@@ -131,7 +131,7 @@ extern DECLSPEC SDL_FunctionPointer SDLCALL SDL_Vulkan_GetVkGetInstanceProcAddr(
  *
  * \sa SDL_Vulkan_LoadLibrary
  */
-extern DECLSPEC void SDLCALL SDL_Vulkan_UnloadLibrary(void);
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_Vulkan_UnloadLibrary(void);
 
 /**
  * Get the Vulkan instance extensions needed for vkCreateInstance.
@@ -154,7 +154,7 @@ extern DECLSPEC void SDLCALL SDL_Vulkan_UnloadLibrary(void);
  *
  * \sa SDL_Vulkan_CreateSurface
  */
-extern DECLSPEC char const* const* SDLCALL SDL_Vulkan_GetInstanceExtensions(Uint32 *count);
+extern SDL_DECLSPEC_RETURN char const* const* SDLCALL SDL_Vulkan_GetInstanceExtensions(Uint32 *count);
 
 /**
  * Create a Vulkan rendering surface for a window.
@@ -179,7 +179,7 @@ extern DECLSPEC char const* const* SDLCALL SDL_Vulkan_GetInstanceExtensions(Uint
  * \sa SDL_Vulkan_GetInstanceExtensions
  * \sa SDL_Vulkan_DestroySurface
  */
-extern DECLSPEC SDL_bool SDLCALL SDL_Vulkan_CreateSurface(SDL_Window *window,
+extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_Vulkan_CreateSurface(SDL_Window *window,
                                                           VkInstance instance,
                                                           const struct VkAllocationCallbacks *allocator,
                                                           VkSurfaceKHR* surface);
@@ -207,7 +207,7 @@ extern DECLSPEC SDL_bool SDLCALL SDL_Vulkan_CreateSurface(SDL_Window *window,
  * \sa SDL_Vulkan_GetInstanceExtensions
  * \sa SDL_Vulkan_CreateSurface
  */
-extern DECLSPEC void SDLCALL SDL_Vulkan_DestroySurface(VkInstance instance,
+extern SDL_DECLSPEC_VOID void SDLCALL SDL_Vulkan_DestroySurface(VkInstance instance,
                                                        VkSurfaceKHR surface,
                                                        const struct VkAllocationCallbacks *allocator);
 

--- a/include/SDL3/SDL_vulkan.h
+++ b/include/SDL3/SDL_vulkan.h
@@ -179,7 +179,7 @@ extern SDL_DECLSPEC_RETURN char const* const* SDLCALL SDL_Vulkan_GetInstanceExte
  * \sa SDL_Vulkan_GetInstanceExtensions
  * \sa SDL_Vulkan_DestroySurface
  */
-extern SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_Vulkan_CreateSurface(SDL_Window *window,
+extern SDL_DECLSPEC_NODISCARD SDL_bool SDLCALL SDL_Vulkan_CreateSurface(SDL_Window *window,
                                                           VkInstance instance,
                                                           const struct VkAllocationCallbacks *allocator,
                                                           VkSurfaceKHR* surface);

--- a/src/SDL_internal.h
+++ b/src/SDL_internal.h
@@ -66,12 +66,12 @@
 
 #if SDL_DYNAMIC_API
 #include "dynapi/SDL_dynapi_overrides.h"
-/* force DECLSPEC off...it's all internal symbols now.
+/* force SDL_DECLSPEC off...it's all internal symbols now.
    These will have actual #defines during SDL_dynapi.c only */
-#ifdef DECLSPEC
-#undef DECLSPEC
+#ifdef SDL_DECLSPEC
+#undef SDL_DECLSPEC
 #endif
-#define DECLSPEC
+#define SDL_DECLSPEC
 #endif
 
 #ifdef SDL_PLATFORM_APPLE
@@ -279,10 +279,10 @@
 extern "C" {
 #endif
 
-extern DECLSPEC Uint32 SDLCALL SDL_GetNextObjectID(void);
-extern DECLSPEC int SDLCALL SDL_WaitSemaphoreTimeoutNS(SDL_Semaphore *sem, Sint64 timeoutNS);
-extern DECLSPEC int SDLCALL SDL_WaitConditionTimeoutNS(SDL_Condition *cond, SDL_Mutex *mutex, Sint64 timeoutNS);
-extern DECLSPEC SDL_bool SDLCALL SDL_WaitEventTimeoutNS(SDL_Event *event, Sint64 timeoutNS);
+extern Uint32 SDLCALL SDL_GetNextObjectID(void);
+extern int SDLCALL SDL_WaitSemaphoreTimeoutNS(SDL_Semaphore *sem, Sint64 timeoutNS);
+extern int SDLCALL SDL_WaitConditionTimeoutNS(SDL_Condition *cond, SDL_Mutex *mutex, Sint64 timeoutNS);
+extern SDL_bool SDLCALL SDL_WaitEventTimeoutNS(SDL_Event *event, Sint64 timeoutNS);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/src/core/SDL_core_unsupported.c
+++ b/src/core/SDL_core_unsupported.c
@@ -22,7 +22,7 @@
 
 #ifndef SDL_VIDEO_DRIVER_X11
 
-DECLSPEC void SDLCALL SDL_SetX11EventHook(SDL_X11EventHook callback, void *userdata)
+SDL_DECLSPEC_VOID void SDLCALL SDL_SetX11EventHook(SDL_X11EventHook callback, void *userdata)
 {
 }
 
@@ -30,7 +30,7 @@ DECLSPEC void SDLCALL SDL_SetX11EventHook(SDL_X11EventHook callback, void *userd
 
 #ifndef SDL_PLATFORM_LINUX
 
-DECLSPEC int SDLCALL SDL_LinuxSetThreadPriority(Sint64 threadID, int priority);
+SDL_DECLSPEC_RETURN int SDLCALL SDL_LinuxSetThreadPriority(Sint64 threadID, int priority);
 int SDL_LinuxSetThreadPriority(Sint64 threadID, int priority)
 {
     (void)threadID;
@@ -38,7 +38,7 @@ int SDL_LinuxSetThreadPriority(Sint64 threadID, int priority)
     return SDL_Unsupported();
 }
 
-DECLSPEC int SDLCALL SDL_LinuxSetThreadPriorityAndPolicy(Sint64 threadID, int sdlPriority, int schedPolicy);
+SDL_DECLSPEC_RETURN int SDLCALL SDL_LinuxSetThreadPriorityAndPolicy(Sint64 threadID, int sdlPriority, int schedPolicy);
 int SDL_LinuxSetThreadPriorityAndPolicy(Sint64 threadID, int sdlPriority, int schedPolicy)
 {
     (void)threadID;
@@ -51,13 +51,13 @@ int SDL_LinuxSetThreadPriorityAndPolicy(Sint64 threadID, int sdlPriority, int sc
 
 #ifndef SDL_PLATFORM_GDK
 
-DECLSPEC void SDLCALL SDL_GDKSuspendComplete(void);
+SDL_DECLSPEC_VOID void SDLCALL SDL_GDKSuspendComplete(void);
 void SDL_GDKSuspendComplete(void)
 {
     SDL_Unsupported();
 }
 
-DECLSPEC int SDLCALL SDL_GDKGetDefaultUser(void *outUserHandle); /* XUserHandle *outUserHandle */
+SDL_DECLSPEC_RETURN int SDLCALL SDL_GDKGetDefaultUser(void *outUserHandle); /* XUserHandle *outUserHandle */
 int SDL_GDKGetDefaultUser(void *outUserHandle)
 {
     return SDL_Unsupported();
@@ -67,7 +67,7 @@ int SDL_GDKGetDefaultUser(void *outUserHandle)
 
 #if !(defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINRT) || defined(SDL_PLATFORM_GDK))
 
-DECLSPEC int SDLCALL SDL_RegisterApp(const char *name, Uint32 style, void *hInst);
+SDL_DECLSPEC_RETURN int SDLCALL SDL_RegisterApp(const char *name, Uint32 style, void *hInst);
 int SDL_RegisterApp(const char *name, Uint32 style, void *hInst)
 {
     (void)name;
@@ -76,7 +76,7 @@ int SDL_RegisterApp(const char *name, Uint32 style, void *hInst)
     return SDL_Unsupported();
 }
 
-DECLSPEC void SDLCALL SDL_SetWindowsMessageHook(void *callback, void *userdata); /* SDL_WindowsMessageHook callback */
+SDL_DECLSPEC_VOID void SDLCALL SDL_SetWindowsMessageHook(void *callback, void *userdata); /* SDL_WindowsMessageHook callback */
 void SDL_SetWindowsMessageHook(void *callback, void *userdata)
 {
     (void)callback;
@@ -84,7 +84,7 @@ void SDL_SetWindowsMessageHook(void *callback, void *userdata)
     SDL_Unsupported();
 }
 
-DECLSPEC void SDLCALL SDL_UnregisterApp(void);
+SDL_DECLSPEC_VOID void SDLCALL SDL_UnregisterApp(void);
 void SDL_UnregisterApp(void)
 {
     SDL_Unsupported();
@@ -95,14 +95,14 @@ void SDL_UnregisterApp(void)
 #ifndef SDL_PLATFORM_WINRT
 
 /* Returns SDL_WinRT_DeviceFamily enum */
-DECLSPEC int SDLCALL SDL_WinRTGetDeviceFamily(void);
+SDL_DECLSPEC_RETURN int SDLCALL SDL_WinRTGetDeviceFamily(void);
 int SDL_WinRTGetDeviceFamily()
 {
     SDL_Unsupported();
     return 0; /* SDL_WINRT_DEVICEFAMILY_UNKNOWN */
 }
 
-DECLSPEC const char *SDLCALL SDL_WinRTGetFSPath(int pathType); /* SDL_WinRT_Path pathType */
+SDL_DECLSPEC_RETURN const char *SDLCALL SDL_WinRTGetFSPath(int pathType); /* SDL_WinRT_Path pathType */
 const char *SDL_WinRTGetFSPath(int pathType)
 {
     (void)pathType;
@@ -113,40 +113,40 @@ const char *SDL_WinRTGetFSPath(int pathType)
 
 #ifndef SDL_PLATFORM_ANDROID
 
-DECLSPEC void SDLCALL SDL_AndroidBackButton(void);
+SDL_DECLSPEC_VOID void SDLCALL SDL_AndroidBackButton(void);
 void SDL_AndroidBackButton()
 {
     SDL_Unsupported();
 }
 
-DECLSPEC void *SDLCALL SDL_AndroidGetActivity(void);
+SDL_DECLSPEC_RETURN void *SDLCALL SDL_AndroidGetActivity(void);
 void *SDL_AndroidGetActivity()
 {
     SDL_Unsupported();
     return NULL;
 }
 
-DECLSPEC const char *SDLCALL SDL_AndroidGetExternalStoragePath(void);
+SDL_DECLSPEC_RETURN const char *SDLCALL SDL_AndroidGetExternalStoragePath(void);
 const char* SDL_AndroidGetExternalStoragePath()
 {
     SDL_Unsupported();
     return NULL;
 }
 
-DECLSPEC int SDLCALL SDL_AndroidGetExternalStorageState(Uint32 *state);
+SDL_DECLSPEC_RETURN int SDLCALL SDL_AndroidGetExternalStorageState(Uint32 *state);
 int SDL_AndroidGetExternalStorageState(Uint32 *state)
 {
     (void)state;
     return SDL_Unsupported();
 }
-DECLSPEC const char *SDLCALL SDL_AndroidGetInternalStoragePath(void);
+SDL_DECLSPEC_RETURN const char *SDLCALL SDL_AndroidGetInternalStoragePath(void);
 const char *SDL_AndroidGetInternalStoragePath()
 {
     SDL_Unsupported();
     return NULL;
 }
 
-DECLSPEC void *SDLCALL SDL_AndroidGetJNIEnv(void);
+SDL_DECLSPEC_RETURN void *SDLCALL SDL_AndroidGetJNIEnv(void);
 void *SDL_AndroidGetJNIEnv()
 {
     SDL_Unsupported();
@@ -154,7 +154,7 @@ void *SDL_AndroidGetJNIEnv()
 }
 
 typedef void (SDLCALL *SDL_AndroidRequestPermissionCallback)(void *userdata, const char *permission, SDL_bool granted);
-DECLSPEC int SDLCALL SDL_AndroidRequestPermission(const char *permission, SDL_AndroidRequestPermissionCallback cb, void *userdata);
+SDL_DECLSPEC_RETURN int SDLCALL SDL_AndroidRequestPermission(const char *permission, SDL_AndroidRequestPermissionCallback cb, void *userdata);
 int SDL_AndroidRequestPermission(const char *permission, SDL_AndroidRequestPermissionCallback cb, void *userdata)
 {
     (void)permission;
@@ -163,7 +163,7 @@ int SDL_AndroidRequestPermission(const char *permission, SDL_AndroidRequestPermi
     return SDL_Unsupported();
 }
 
-DECLSPEC int SDLCALL SDL_AndroidSendMessage(Uint32 command, int param);
+SDL_DECLSPEC_RETURN int SDLCALL SDL_AndroidSendMessage(Uint32 command, int param);
 int SDL_AndroidSendMessage(Uint32 command, int param)
 {
     (void)command;
@@ -171,7 +171,7 @@ int SDL_AndroidSendMessage(Uint32 command, int param)
     return SDL_Unsupported();
 }
 
-DECLSPEC int SDLCALL SDL_AndroidShowToast(const char* message, int duration, int gravity, int xoffset, int yoffset);
+SDL_DECLSPEC_RETURN int SDLCALL SDL_AndroidShowToast(const char* message, int duration, int gravity, int xoffset, int yoffset);
 int SDL_AndroidShowToast(const char* message, int duration, int gravity, int xoffset, int yoffset)
 {
     (void)message;
@@ -182,34 +182,34 @@ int SDL_AndroidShowToast(const char* message, int duration, int gravity, int xof
     return SDL_Unsupported();
 }
 
-DECLSPEC int SDLCALL SDL_GetAndroidSDKVersion(void);
+SDL_DECLSPEC_RETURN int SDLCALL SDL_GetAndroidSDKVersion(void);
 int SDL_GetAndroidSDKVersion()
 {
     return SDL_Unsupported();
 }
 
-DECLSPEC SDL_bool SDLCALL SDL_IsAndroidTV(void);
+SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_IsAndroidTV(void);
 SDL_bool SDL_IsAndroidTV()
 {
     SDL_Unsupported();
     return SDL_FALSE;
 }
 
-DECLSPEC SDL_bool SDLCALL SDL_IsChromebook(void);
+SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_IsChromebook(void);
 SDL_bool SDL_IsChromebook()
 {
     SDL_Unsupported();
     return SDL_FALSE;
 }
 
-DECLSPEC SDL_bool SDLCALL SDL_IsDeXMode(void);
+SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_IsDeXMode(void);
 SDL_bool SDL_IsDeXMode(void)
 {
     SDL_Unsupported();
     return SDL_FALSE;
 }
 
-DECLSPEC Sint32 SDLCALL JNI_OnLoad(void *vm, void *reserved);
+SDL_DECLSPEC_RETURN Sint32 SDLCALL JNI_OnLoad(void *vm, void *reserved);
 Sint32 JNI_OnLoad(void *vm, void *reserved)
 {
     (void)vm;

--- a/src/core/SDL_runapp.c
+++ b/src/core/SDL_runapp.c
@@ -24,8 +24,7 @@
  * If not, you can special case it here by appending || defined(__YOUR_PLATFORM__) */
 #if ( !defined(SDL_MAIN_NEEDED) && !defined(SDL_MAIN_AVAILABLE) ) || defined(SDL_PLATFORM_ANDROID)
 
-DECLSPEC int
-SDL_RunApp(int argc, char* argv[], SDL_main_func mainFunction, void * reserved)
+int SDL_RunApp(int argc, char* argv[], SDL_main_func mainFunction, void * reserved)
 {
     (void)reserved;
 

--- a/src/core/gdk/SDL_gdk.cpp
+++ b/src/core/gdk/SDL_gdk.cpp
@@ -35,8 +35,8 @@ PAPPSTATE_REGISTRATION hPLM = {};
 PAPPCONSTRAIN_REGISTRATION hCPLM = {};
 HANDLE plmSuspendComplete = nullptr;
 
-extern "C" DECLSPEC int
-SDL_GDKGetTaskQueue(XTaskQueueHandle *outTaskQueue)
+extern "C"
+int SDL_GDKGetTaskQueue(XTaskQueueHandle *outTaskQueue)
 {
     /* If this is the first call, first create the global task queue. */
     if (!GDK_GlobalTaskQueue) {
@@ -61,8 +61,8 @@ SDL_GDKGetTaskQueue(XTaskQueueHandle *outTaskQueue)
     return 0;
 }
 
-extern "C" void
-GDK_DispatchTaskQueue(void)
+extern "C"
+void GDK_DispatchTaskQueue(void)
 {
     /* If there is no global task queue, don't do anything.
      * This gives the option to opt-out for those who want to handle everything themselves.
@@ -75,8 +75,7 @@ GDK_DispatchTaskQueue(void)
 }
 
 /* Pop up an out of memory message, returns to Windows */
-extern "C" static BOOL
-OutOfMemory(void)
+static BOOL OutOfMemory(void)
 {
     SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Fatal Error", "Out of memory - aborting", NULL);
     return FALSE;
@@ -84,8 +83,8 @@ OutOfMemory(void)
 
 /* Gets the arguments with GetCommandLine, converts them to argc and argv
    and calls SDL_main */
-extern "C" DECLSPEC int
-SDL_RunApp(int, char**, SDL_main_func mainFunction, void *reserved)
+extern "C"
+int SDL_RunApp(int, char**, SDL_main_func mainFunction, void *reserved)
 {
     LPWSTR *argvw;
     char **argv;
@@ -228,16 +227,16 @@ SDL_RunApp(int, char**, SDL_main_func mainFunction, void *reserved)
     return result;
 }
 
-extern "C" DECLSPEC void
-SDL_GDKSuspendComplete()
+extern "C"
+void SDL_GDKSuspendComplete()
 {
     if (plmSuspendComplete) {
         SetEvent(plmSuspendComplete);
     }
 }
 
-extern "C" DECLSPEC int
-SDL_GDKGetDefaultUser(XUserHandle *outUserHandle)
+extern "C"
+int SDL_GDKGetDefaultUser(XUserHandle *outUserHandle)
 {
     XAsyncBlock block = { 0 };
     HRESULT result;

--- a/src/core/n3ds/SDL_n3ds.c
+++ b/src/core/n3ds/SDL_n3ds.c
@@ -25,8 +25,7 @@
 
 #include <3ds.h>
 
-DECLSPEC int
-SDL_RunApp(int argc, char* argv[], SDL_main_func mainFunction, void * reserved)
+int SDL_RunApp(int argc, char* argv[], SDL_main_func mainFunction, void * reserved)
 {
     int result;
     /* init */

--- a/src/core/ngage/SDL_ngage_runapp.cpp
+++ b/src/core/ngage/SDL_ngage_runapp.cpp
@@ -17,8 +17,7 @@
 #include <apgtask.h>
 
 
-DECLSPEC int
-SDL_RunApp(int argc_, char* argv_[], SDL_main_func mainFunction, void * reserved)
+int SDL_RunApp(int argc_, char* argv_[], SDL_main_func mainFunction, void * reserved)
 {
     (void)argc_; (void)argv_; (void)reserved;
     /*  Get the clean-up stack */

--- a/src/core/ps2/SDL_ps2.c
+++ b/src/core/ps2/SDL_ps2.c
@@ -64,8 +64,7 @@ static void deinit_drivers()
 	deinit_ps2_filesystem_driver();
 }
 
-DECLSPEC int
-SDL_RunApp(int argc, char* argv[], SDL_main_func mainFunction, void * reserved)
+int SDL_RunApp(int argc, char* argv[], SDL_main_func mainFunction, void * reserved)
 {
     int res;
     (void)reserved;

--- a/src/core/psp/SDL_psp.c
+++ b/src/core/psp/SDL_psp.c
@@ -68,8 +68,7 @@ int sdl_psp_setup_callbacks(void)
     return thid;
 }
 
-DECLSPEC int
-SDL_RunApp(int argc, char* argv[], SDL_main_func mainFunction, void * reserved)
+int SDL_RunApp(int argc, char* argv[], SDL_main_func mainFunction, void * reserved)
 {
     (void)reserved;
     sdl_psp_setup_callbacks();

--- a/src/core/windows/SDL_windows.c
+++ b/src/core/windows/SDL_windows.c
@@ -403,7 +403,7 @@ static int OutOfMemory(void)
     return -1;
 }
 
-DECLSPEC int MINGW32_FORCEALIGN SDL_RunApp(int _argc, char* _argv[], SDL_main_func mainFunction, void * reserved)
+int MINGW32_FORCEALIGN SDL_RunApp(int _argc, char* _argv[], SDL_main_func mainFunction, void * reserved)
 {
 
     /* Gets the arguments with GetCommandLine, converts them to argc and argv

--- a/src/core/winrt/SDL_winrtapp_common.cpp
+++ b/src/core/winrt/SDL_winrtapp_common.cpp
@@ -27,8 +27,8 @@
 
 int (*WINRT_SDLAppEntryPoint)(int, char **) = NULL;
 
-extern "C" DECLSPEC int
-SDL_RunApp(int, char**, SDL_main_func mainFunction, void * xamlBackgroundPanel)
+extern "C"
+int SDL_RunApp(int, char**, SDL_main_func mainFunction, void * xamlBackgroundPanel)
 {
     if (xamlBackgroundPanel) {
         return SDL_WinRTInitXAMLApp(mainFunction, xamlBackgroundPanel);
@@ -40,8 +40,8 @@ SDL_RunApp(int, char**, SDL_main_func mainFunction, void * xamlBackgroundPanel)
     }
 }
 
-extern "C" DECLSPEC SDL_WinRT_DeviceFamily
-SDL_WinRTGetDeviceFamily()
+extern "C"
+SDL_WinRT_DeviceFamily SDL_WinRTGetDeviceFamily()
 {
 #if NTDDI_VERSION >= NTDDI_WIN10 /* !!! FIXME: I have no idea if this is the right test. This is a UWP API, I think. Older windows should...just return "mobile"? I don't know. --ryan. */
     Platform::String ^ deviceFamily = Windows::System::Profile::AnalyticsInfo::VersionInfo->DeviceFamily;

--- a/src/dynapi/SDL_dynapi.c
+++ b/src/dynapi/SDL_dynapi.c
@@ -382,7 +382,7 @@ static Sint32 initialize_jumptable(Uint32 apiver, void *table, Uint32 tablesize)
 /* Here's the exported entry point that fills in the jump table. */
 /*  Use specific types when an "int" might suffice to keep this sane. */
 typedef Sint32 (SDLCALL *SDL_DYNAPI_ENTRYFN)(Uint32 apiver, void *table, Uint32 tablesize);
-extern DECLSPEC Sint32 SDLCALL SDL_DYNAPI_entry(Uint32, void *, Uint32);
+extern SDL_DECLSPEC_RETURN Sint32 SDLCALL SDL_DYNAPI_entry(Uint32, void *, Uint32);
 
 Sint32 SDL_DYNAPI_entry(Uint32 apiver, void *table, Uint32 tablesize)
 {

--- a/src/dynapi/gendynapi.py
+++ b/src/dynapi/gendynapi.py
@@ -87,7 +87,7 @@ def main():
                 continue
 
             # Remove one line comment /* ... */
-            # eg: extern DECLSPEC SDL_hid_device * SDLCALL SDL_hid_open_path(const char *path, int bExclusive /* = false */);
+            # eg: extern SDL_DECLSPEC_RETURN SDL_hid_device * SDLCALL SDL_hid_open_path(const char *path, int bExclusive /* = false */);
             line = reg_comment_remove_content.sub('', line)
 
             # Get the comment block /* ... */ across several lines
@@ -137,10 +137,10 @@ def main():
                     print("  Discard, doesn't have SDLCALL: " + func)
                 continue
 
-            # Discard if it contains 'SDLMAIN_DECLSPEC' (these are not SDL symbols).
-            if "SDLMAIN_DECLSPEC" in func:
+            # Discard if it contains 'SDLMAIN_DECLSPEC_RETURN' (these are not SDL symbols).
+            if "SDLMAIN_DECLSPEC_RETURN" in func:
                 if args.debug:
-                    print("  Discard, has SDLMAIN_DECLSPEC: " + func)
+                    print("  Discard, has SDLMAIN_DECLSPEC_RETURN: " + func)
                 continue
 
             if args.debug:
@@ -183,7 +183,7 @@ def main():
             #
             func_ret = func_ret.replace('extern', ' ')
             func_ret = func_ret.replace('SDLCALL', ' ')
-            func_ret = func_ret.replace('DECLSPEC', ' ')
+            func_ret = re.sub(r"SDL_DECLSPEC_[A-Z]*", " ", func_ret)
             # Remove trailing spaces in front of '*'
             tmp = ""
             while func_ret != tmp:

--- a/src/thread/SDL_thread.c
+++ b/src/thread/SDL_thread.c
@@ -368,12 +368,12 @@ SDL_Thread *SDL_CreateThreadWithStackSize(int(SDLCALL *fn)(void *),
 }
 
 #ifdef SDL_PASSED_BEGINTHREAD_ENDTHREAD
-DECLSPEC SDL_Thread *SDLCALL SDL_CreateThread(int(SDLCALL *fn)(void *),
+SDL_Thread *SDLCALL SDL_CreateThread(int(SDLCALL *fn)(void *),
                  const char *name, void *data,
                  pfnSDL_CurrentBeginThread pfnBeginThread,
                  pfnSDL_CurrentEndThread pfnEndThread)
 #else
-DECLSPEC SDL_Thread *SDLCALL SDL_CreateThread(int(SDLCALL *fn)(void *),
+SDL_Thread *SDLCALL SDL_CreateThread(int(SDLCALL *fn)(void *),
                  const char *name, void *data)
 #endif
 {

--- a/src/video/SDL_video_unsupported.c
+++ b/src/video/SDL_video_unsupported.c
@@ -42,7 +42,7 @@ void SDL_SetWindowsMessageHook(SDL_WindowsMessageHook callback, void *userdata)
 
 #endif /* SDL_PLATFORM_WIN32 || SDL_PLATFORM_GDK */
 
-DECLSPEC SDL_bool SDLCALL SDL_DXGIGetOutputInfo(SDL_DisplayID displayID, int *adapterIndex, int *outputIndex);
+SDL_DECLSPEC_RETURN SDL_bool SDLCALL SDL_DXGIGetOutputInfo(SDL_DisplayID displayID, int *adapterIndex, int *outputIndex);
 SDL_bool SDL_DXGIGetOutputInfo(SDL_DisplayID displayID, int *adapterIndex, int *outputIndex)
 {
     (void)displayID;
@@ -52,7 +52,7 @@ SDL_bool SDL_DXGIGetOutputInfo(SDL_DisplayID displayID, int *adapterIndex, int *
     return SDL_FALSE;
 }
 
-DECLSPEC int SDLCALL SDL_Direct3D9GetAdapterIndex(SDL_DisplayID displayID);
+SDL_DECLSPEC_RETURN int SDLCALL SDL_Direct3D9GetAdapterIndex(SDL_DisplayID displayID);
 int SDL_Direct3D9GetAdapterIndex(SDL_DisplayID displayID)
 {
     (void)displayID;
@@ -61,7 +61,7 @@ int SDL_Direct3D9GetAdapterIndex(SDL_DisplayID displayID)
 
 #elif defined(SDL_PLATFORM_XBOXONE) || defined(SDL_PLATFORM_XBOXSERIES)
 
-DECLSPEC int SDLCALL SDL_Direct3D9GetAdapterIndex(SDL_DisplayID displayID);
+SDL_DECLSPEC_RETURN int SDLCALL SDL_Direct3D9GetAdapterIndex(SDL_DisplayID displayID);
 int SDL_Direct3D9GetAdapterIndex(SDL_DisplayID displayID)
 {
     (void)displayID;
@@ -72,7 +72,7 @@ int SDL_Direct3D9GetAdapterIndex(SDL_DisplayID displayID)
 
 #ifndef SDL_PLATFORM_GDK
 
-DECLSPEC int SDLCALL SDL_GDKGetTaskQueue(void *outTaskQueue);
+SDL_DECLSPEC_RETURN int SDLCALL SDL_GDKGetTaskQueue(void *outTaskQueue);
 int SDL_GDKGetTaskQueue(void *outTaskQueue)
 {
     (void)outTaskQueue;
@@ -83,7 +83,7 @@ int SDL_GDKGetTaskQueue(void *outTaskQueue)
 
 #ifndef SDL_VIDEO_DRIVER_UIKIT
 
-DECLSPEC void SDLCALL SDL_OnApplicationDidChangeStatusBarOrientation(void);
+SDL_DECLSPEC_VOID void SDLCALL SDL_OnApplicationDidChangeStatusBarOrientation(void);
 void SDL_OnApplicationDidChangeStatusBarOrientation(void)
 {
     SDL_Unsupported();
@@ -93,7 +93,7 @@ void SDL_OnApplicationDidChangeStatusBarOrientation(void)
 
 #ifndef SDL_VIDEO_DRIVER_UIKIT
 
-DECLSPEC int SDLCALL SDL_iOSSetAnimationCallback(SDL_Window *window, int interval, void (*callback)(void *), void *callbackParam);
+SDL_DECLSPEC_RETURN int SDLCALL SDL_iOSSetAnimationCallback(SDL_Window *window, int interval, void (*callback)(void *), void *callbackParam);
 int SDL_iOSSetAnimationCallback(SDL_Window *window, int interval, void (*callback)(void *), void *callbackParam)
 {
     (void)window;
@@ -103,7 +103,7 @@ int SDL_iOSSetAnimationCallback(SDL_Window *window, int interval, void (*callbac
     return SDL_Unsupported();
 }
 
-DECLSPEC void SDLCALL SDL_iOSSetEventPump(SDL_bool enabled);
+SDL_DECLSPEC_VOID void SDLCALL SDL_iOSSetEventPump(SDL_bool enabled);
 void SDL_iOSSetEventPump(SDL_bool enabled)
 {
     (void)enabled;

--- a/test/checkkeys.c
+++ b/test/checkkeys.c
@@ -271,7 +271,7 @@ int main(int argc, char *argv[])
         int i;
         /* Creating the context creates the view, which we need to show keyboard */
         for (i = 0; i < state->num_windows; i++) {
-            SDL_GL_CreateContext(state->windows[i]);
+            (void)SDL_GL_CreateContext(state->windows[i]);
         }
     }
 #endif

--- a/test/checkkeysthreads.c
+++ b/test/checkkeysthreads.c
@@ -281,7 +281,7 @@ int main(int argc, char *argv[])
 
 #ifdef SDL_PLATFORM_IOS
     /* Creating the context creates the view, which we need to show keyboard */
-    SDL_GL_CreateContext(window);
+    (void)SDL_GL_CreateContext(window);
 #endif
 
     SDL_StartTextInput();

--- a/test/testmultiaudio.c
+++ b/test/testmultiaudio.c
@@ -53,7 +53,7 @@ test_multi_audio(SDL_AudioDeviceID *devices, int devcount)
     SDL_Event event;
 
     /* Create a Window to get fully initialized event processing for testing pause on Android. */
-    SDL_CreateWindow("testmultiaudio", 320, 240, 0);
+    SDL_Window *window = SDL_CreateWindow("testmultiaudio", 320, 240, 0);
 #endif
 
     for (i = 0; i < devcount; i++) {
@@ -130,6 +130,10 @@ test_multi_audio(SDL_AudioDeviceID *devices, int devcount)
 
         SDL_free(streams);
     }
+
+#ifdef SDL_PLATFORM_ANDROID  /* !!! FIXME: maybe always create a window, in the SDLTest layer, so these #ifdefs don't have to be here? */
+    SDL_DestroyWindow(window);
+#endif
 
     SDL_Log("All done!\n");
 }

--- a/test/testsensor.c
+++ b/test/testsensor.c
@@ -112,7 +112,7 @@ int main(int argc, char **argv)
         SDL_bool done = SDL_FALSE;
         SDL_Event event;
 
-        SDL_CreateWindow("Sensor Test", 0, 0, SDL_WINDOW_FULLSCREEN);
+        SDL_Window *window = SDL_CreateWindow("Sensor Test", 0, 0, SDL_WINDOW_FULLSCREEN);
         while (!done) {
             /* Update to get the current event state */
             SDL_PumpEvents();
@@ -133,6 +133,7 @@ int main(int argc, char **argv)
                 }
             }
         }
+        SDL_DestroyWindow(window);
     }
 
     SDL_Quit();


### PR DESCRIPTION
@icculus, I tried to make this read naturally, and make it possible for people to turn on pedantic checking for return value handling. What do you think?