### PR TITLE
Add 'SDL_NODISCARD' to creation/allocation functions and improve relevant documentation

### DIFF
--- a/include/SDL3/SDL_audio.h
+++ b/include/SDL3/SDL_audio.h
@@ -808,6 +808,8 @@ extern SDL_DECLSPEC SDL_AudioDeviceID SDLCALL SDL_GetAudioStreamDevice(SDL_Audio
 /**
  * Create a new audio stream.
  *
+ * Audio streams created with this function must be freed with SDL_DestroyAudioStream().
+ *
  * \param src_spec The format details of the input audio
  * \param dst_spec The format details of the output audio
  * \returns a new audio stream on success, or NULL on failure.
@@ -824,7 +826,7 @@ extern SDL_DECLSPEC SDL_AudioDeviceID SDLCALL SDL_GetAudioStreamDevice(SDL_Audio
  * \sa SDL_ChangeAudioStreamOutput
  * \sa SDL_DestroyAudioStream
  */
-extern SDL_DECLSPEC SDL_AudioStream *SDLCALL SDL_CreateAudioStream(const SDL_AudioSpec *src_spec, const SDL_AudioSpec *dst_spec);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_AudioStream *SDLCALL SDL_CreateAudioStream(const SDL_AudioSpec *src_spec, const SDL_AudioSpec *dst_spec);
 
 /**
  * Get the properties associated with an audio stream.

--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -1357,7 +1357,7 @@ extern SDL_DECLSPEC Uint32 SDLCALL SDL_RegisterEvents(int numevents);
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern SDL_DECLSPEC void * SDLCALL SDL_AllocateEventMemory(size_t size);
+extern SDL_NODISCARD SDL_DECLSPEC void * SDLCALL SDL_AllocateEventMemory(size_t size);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_filesystem.h
+++ b/include/SDL3/SDL_filesystem.h
@@ -283,7 +283,7 @@ typedef Uint32 SDL_GlobFlags;
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern SDL_DECLSPEC int SDLCALL SDL_CreateDirectory(const char *path);
+extern SDL_NODISCARD SDL_DECLSPEC int SDLCALL SDL_CreateDirectory(const char *path);
 
 /* Callback for directory enumeration. Return 1 to keep enumerating,
    0 to stop enumerating (no error), -1 to stop enumerating and

--- a/include/SDL3/SDL_haptic.h
+++ b/include/SDL3/SDL_haptic.h
@@ -1171,6 +1171,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_HapticEffectSupported(SDL_Haptic *hapti
 /**
  * Create a new haptic effect on a specified device.
  *
+ * Haptic effects created with this function must be freed with SDL_DestroyHapticEffect().
+ *
  * \param haptic an SDL_Haptic device to create the effect on
  * \param effect an SDL_HapticEffect structure containing the properties of
  *               the effect to create
@@ -1183,7 +1185,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_HapticEffectSupported(SDL_Haptic *hapti
  * \sa SDL_RunHapticEffect
  * \sa SDL_UpdateHapticEffect
  */
-extern SDL_DECLSPEC int SDLCALL SDL_CreateHapticEffect(SDL_Haptic *haptic, const SDL_HapticEffect *effect);
+extern SDL_NODISCARD SDL_DECLSPEC int SDLCALL SDL_CreateHapticEffect(SDL_Haptic *haptic, const SDL_HapticEffect *effect);
 
 /**
  * Update the properties of an effect.
@@ -1388,7 +1390,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_HapticRumbleSupported(SDL_Haptic *hapti
  * \sa SDL_StopHapticRumble
  * \sa SDL_HapticRumbleSupported
  */
-extern SDL_DECLSPEC int SDLCALL SDL_InitHapticRumble(SDL_Haptic *haptic);
+extern SDL_NODISCARD SDL_DECLSPEC int SDLCALL SDL_InitHapticRumble(SDL_Haptic *haptic);
 
 /**
  * Run a simple rumble effect on a haptic device.

--- a/include/SDL3/SDL_init.h
+++ b/include/SDL3/SDL_init.h
@@ -116,7 +116,7 @@ typedef Uint32 SDL_InitFlags;
  * \sa SDL_SetMainReady
  * \sa SDL_WasInit
  */
-extern SDL_DECLSPEC int SDLCALL SDL_Init(SDL_InitFlags flags);
+extern SDL_NODISCARD SDL_DECLSPEC int SDLCALL SDL_Init(SDL_InitFlags flags);
 
 /**
  * Compatibility function to initialize the SDL library.
@@ -133,7 +133,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_Init(SDL_InitFlags flags);
  * \sa SDL_Quit
  * \sa SDL_QuitSubSystem
  */
-extern SDL_DECLSPEC int SDLCALL SDL_InitSubSystem(SDL_InitFlags flags);
+extern SDL_NODISCARD SDL_DECLSPEC int SDLCALL SDL_InitSubSystem(SDL_InitFlags flags);
 
 /**
  * Shut down specific SDL subsystems.

--- a/include/SDL3/SDL_mouse.h
+++ b/include/SDL3/SDL_mouse.h
@@ -373,13 +373,15 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GetRelativeMouseMode(void);
  * \sa SDL_DestroyCursor
  * \sa SDL_SetCursor
  */
-extern SDL_DECLSPEC SDL_Cursor *SDLCALL SDL_CreateCursor(const Uint8 * data,
-                                                     const Uint8 * mask,
-                                                     int w, int h, int hot_x,
-                                                     int hot_y);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Cursor *SDLCALL SDL_CreateCursor(const Uint8 * data,
+                                                                       const Uint8 * mask,
+                                                                       int w, int h, int hot_x,
+                                                                       int hot_y);
 
 /**
  * Create a color cursor.
+ *
+ * Cursors created with this function must be freed with SDL_DestroyCursor().
  *
  * \param surface an SDL_Surface structure representing the cursor image
  * \param hot_x the x position of the cursor hot spot
@@ -394,12 +396,14 @@ extern SDL_DECLSPEC SDL_Cursor *SDLCALL SDL_CreateCursor(const Uint8 * data,
  * \sa SDL_DestroyCursor
  * \sa SDL_SetCursor
  */
-extern SDL_DECLSPEC SDL_Cursor *SDLCALL SDL_CreateColorCursor(SDL_Surface *surface,
-                                                          int hot_x,
-                                                          int hot_y);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Cursor *SDLCALL SDL_CreateColorCursor(SDL_Surface *surface,
+                                                                            int hot_x,
+                                                                            int hot_y);
 
 /**
  * Create a system cursor.
+ *
+ * Cursors created with this function must be freed with SDL_DestroyCursor().
  *
  * \param id an SDL_SystemCursor enum value
  * \returns a cursor on success or NULL on failure; call SDL_GetError() for
@@ -409,7 +413,7 @@ extern SDL_DECLSPEC SDL_Cursor *SDLCALL SDL_CreateColorCursor(SDL_Surface *surfa
  *
  * \sa SDL_DestroyCursor
  */
-extern SDL_DECLSPEC SDL_Cursor *SDLCALL SDL_CreateSystemCursor(SDL_SystemCursor id);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Cursor *SDLCALL SDL_CreateSystemCursor(SDL_SystemCursor id);
 
 /**
  * Set the active cursor.

--- a/include/SDL3/SDL_mutex.h
+++ b/include/SDL3/SDL_mutex.h
@@ -154,6 +154,8 @@ typedef struct SDL_Mutex SDL_Mutex;
  *
  * SDL mutexes are reentrant.
  *
+ * Mutexes created with this function must be freed with SDL_DestroyMutex().
+ *
  * \returns the initialized and unlocked mutex or NULL on failure; call
  *          SDL_GetError() for more information.
  *
@@ -164,7 +166,7 @@ typedef struct SDL_Mutex SDL_Mutex;
  * \sa SDL_TryLockMutex
  * \sa SDL_UnlockMutex
  */
-extern SDL_DECLSPEC SDL_Mutex *SDLCALL SDL_CreateMutex(void);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Mutex *SDLCALL SDL_CreateMutex(void);
 
 /**
  * Lock the mutex.
@@ -319,6 +321,8 @@ typedef struct SDL_RWLock SDL_RWLock;
  * and write access at the same time from the same thread (so you can't
  * promote your read-only lock to a write lock without unlocking first).
  *
+ * Locks created with this function must be freed with SDL_DestroyRWLock().
+ *
  * \returns the initialized and unlocked read/write lock or NULL on failure;
  *          call SDL_GetError() for more information.
  *
@@ -331,7 +335,7 @@ typedef struct SDL_RWLock SDL_RWLock;
  * \sa SDL_TryLockRWLockForWriting
  * \sa SDL_UnlockRWLock
  */
-extern SDL_DECLSPEC SDL_RWLock *SDLCALL SDL_CreateRWLock(void);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_RWLock *SDLCALL SDL_CreateRWLock(void);
 
 /**
  * Lock the read/write lock for _read only_ operations.
@@ -537,6 +541,8 @@ typedef struct SDL_Semaphore SDL_Semaphore;
  * is 0. Each post operation will atomically increment the semaphore value and
  * wake waiting threads and allow them to retry the wait operation.
  *
+ * Semaphores created with this function must be freed with SDL_DestroySemaphore().
+ *
  * \param initial_value the starting value of the semaphore
  * \returns a new semaphore or NULL on failure; call SDL_GetError() for more
  *          information.
@@ -550,7 +556,7 @@ typedef struct SDL_Semaphore SDL_Semaphore;
  * \sa SDL_WaitSemaphore
  * \sa SDL_WaitSemaphoreTimeout
  */
-extern SDL_DECLSPEC SDL_Semaphore *SDLCALL SDL_CreateSemaphore(Uint32 initial_value);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Semaphore *SDLCALL SDL_CreateSemaphore(Uint32 initial_value);
 
 /**
  * Destroy a semaphore.
@@ -683,6 +689,8 @@ typedef struct SDL_Condition SDL_Condition;
 /**
  * Create a condition variable.
  *
+ * Condition variables created with this function must be freed with SDL_DestroyCondition().
+ *
  * \returns a new condition variable or NULL on failure; call SDL_GetError()
  *          for more information.
  *
@@ -694,7 +702,7 @@ typedef struct SDL_Condition SDL_Condition;
  * \sa SDL_WaitConditionTimeout
  * \sa SDL_DestroyCondition
  */
-extern SDL_DECLSPEC SDL_Condition *SDLCALL SDL_CreateCondition(void);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Condition *SDLCALL SDL_CreateCondition(void);
 
 /**
  * Destroy a condition variable.

--- a/include/SDL3/SDL_pixels.h
+++ b/include/SDL3/SDL_pixels.h
@@ -824,6 +824,8 @@ extern SDL_DECLSPEC SDL_PixelFormatEnum SDLCALL SDL_GetPixelFormatEnumForMasks(i
  * allocated), and hence should not be modified, especially the palette. Weird
  * errors such as `Blit combination not supported` may occur.
  *
+ * Pixel formats created with this function must be freed with SDL_DestroyPixelFormat().
+ *
  * \param pixel_format one of the SDL_PixelFormatEnum values
  * \returns the new SDL_PixelFormat structure or NULL on failure; call
  *          SDL_GetError() for more information.
@@ -833,7 +835,7 @@ extern SDL_DECLSPEC SDL_PixelFormatEnum SDLCALL SDL_GetPixelFormatEnumForMasks(i
  * \sa SDL_DestroyPixelFormat
  * \sa SDL_SetPixelFormatPalette
  */
-extern SDL_DECLSPEC SDL_PixelFormat * SDLCALL SDL_CreatePixelFormat(SDL_PixelFormatEnum pixel_format);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_PixelFormat * SDLCALL SDL_CreatePixelFormat(SDL_PixelFormatEnum pixel_format);
 
 /**
  * Free an SDL_PixelFormat structure allocated by SDL_CreatePixelFormat().
@@ -851,6 +853,8 @@ extern SDL_DECLSPEC void SDLCALL SDL_DestroyPixelFormat(SDL_PixelFormat *format)
  *
  * The palette entries are initialized to white.
  *
+ * Palettes created with this function must be freed with SDL_DestroyPalette().
+ *
  * \param ncolors represents the number of color entries in the color palette
  * \returns a new SDL_Palette structure on success or NULL on failure (e.g. if
  *          there wasn't enough memory); call SDL_GetError() for more
@@ -862,7 +866,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_DestroyPixelFormat(SDL_PixelFormat *format)
  * \sa SDL_SetPaletteColors
  * \sa SDL_SetPixelFormatPalette
  */
-extern SDL_DECLSPEC SDL_Palette *SDLCALL SDL_CreatePalette(int ncolors);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Palette *SDLCALL SDL_CreatePalette(int ncolors);
 
 /**
  * Set the palette for a pixel format structure.

--- a/include/SDL3/SDL_properties.h
+++ b/include/SDL3/SDL_properties.h
@@ -87,7 +87,7 @@ extern SDL_DECLSPEC SDL_PropertiesID SDLCALL SDL_GetGlobalProperties(void);
  *
  * \sa SDL_DestroyProperties
  */
-extern SDL_DECLSPEC SDL_PropertiesID SDLCALL SDL_CreateProperties(void);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_PropertiesID SDLCALL SDL_CreateProperties(void);
 
 /**
  * Copy a set of properties.

--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -183,6 +183,9 @@ extern SDL_DECLSPEC const char *SDLCALL SDL_GetRenderDriver(int index);
 /**
  * Create a window and default renderer.
  *
+ * Windows created with this function must be freed with SDL_DestroyWindow().
+ * Rendering contexts created with this function must be freed with SDL_DestroyRenderer().
+ *
  * \param title the title of the window, in UTF-8 encoding
  * \param width the width of the window
  * \param height the height of the window
@@ -197,6 +200,8 @@ extern SDL_DECLSPEC const char *SDLCALL SDL_GetRenderDriver(int index);
  *
  * \sa SDL_CreateRenderer
  * \sa SDL_CreateWindow
+ * \sa SDL_DestroyRenderer
+ * \sa SDL_DestroyWindow
  */
 extern SDL_DECLSPEC int SDLCALL SDL_CreateWindowAndRenderer(const char *title, int width, int height, SDL_WindowFlags window_flags, SDL_Window **window, SDL_Renderer **renderer);
 
@@ -213,6 +218,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_CreateWindowAndRenderer(const char *title, i
  * can call SDL_SetRenderLogicalPresentation() to change the content size and
  * scaling options.
  *
+ * Rendering contexts created with this function must be freed with SDL_DestroyRenderer().
+ *
  * \param window the window where rendering is displayed
  * \param name the name of the rendering driver to initialize, or NULL to
  *             initialize the first one supporting the requested flags
@@ -228,7 +235,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_CreateWindowAndRenderer(const char *title, i
  * \sa SDL_GetRenderDriver
  * \sa SDL_GetRendererInfo
  */
-extern SDL_DECLSPEC SDL_Renderer * SDLCALL SDL_CreateRenderer(SDL_Window *window, const char *name);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Renderer * SDLCALL SDL_CreateRenderer(SDL_Window *window, const char *name);
 
 /**
  * Create a 2D rendering context for a window, with the specified properties.
@@ -267,6 +274,8 @@ extern SDL_DECLSPEC SDL_Renderer * SDLCALL SDL_CreateRenderer(SDL_Window *window
  * - `SDL_PROP_RENDERER_CREATE_VULKAN_PRESENT_QUEUE_FAMILY_INDEX_NUMBER`: the
  *   queue family index used for presentation.
  *
+ * Rendering contexts created with this function must be freed with SDL_DestroyRenderer().
+ *
  * \param props the properties to use
  * \returns a valid rendering context or NULL if there was an error; call
  *          SDL_GetError() for more information.
@@ -279,7 +288,7 @@ extern SDL_DECLSPEC SDL_Renderer * SDLCALL SDL_CreateRenderer(SDL_Window *window
  * \sa SDL_DestroyRenderer
  * \sa SDL_GetRendererInfo
  */
-extern SDL_DECLSPEC SDL_Renderer * SDLCALL SDL_CreateRendererWithProperties(SDL_PropertiesID props);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Renderer * SDLCALL SDL_CreateRendererWithProperties(SDL_PropertiesID props);
 
 #define SDL_PROP_RENDERER_CREATE_NAME_STRING                                "name"
 #define SDL_PROP_RENDERER_CREATE_WINDOW_POINTER                             "window"
@@ -301,6 +310,8 @@ extern SDL_DECLSPEC SDL_Renderer * SDLCALL SDL_CreateRendererWithProperties(SDL_
  * create a software renderer, but they are intended to be used with an
  * SDL_Window as the final destination and not an SDL_Surface.
  *
+ * Rendering contexts created with this function must be freed with SDL_DestroyRenderer().
+ *
  * \param surface the SDL_Surface structure representing the surface where
  *                rendering is done
  * \returns a valid rendering context or NULL if there was an error; call
@@ -310,7 +321,7 @@ extern SDL_DECLSPEC SDL_Renderer * SDLCALL SDL_CreateRendererWithProperties(SDL_
  *
  * \sa SDL_DestroyRenderer
  */
-extern SDL_DECLSPEC SDL_Renderer *SDLCALL SDL_CreateSoftwareRenderer(SDL_Surface *surface);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Renderer *SDLCALL SDL_CreateSoftwareRenderer(SDL_Surface *surface);
 
 /**
  * Get the renderer associated with a window.
@@ -493,6 +504,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetCurrentRenderOutputSize(SDL_Renderer *ren
 /**
  * Create a texture for a rendering context.
  *
+ * Textures created with this function must be freed with SDL_DestroyTexture().
+ *
  * \param renderer the rendering context
  * \param format one of the enumerated values in SDL_PixelFormatEnum
  * \param access one of the enumerated values in SDL_TextureAccess
@@ -510,7 +523,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetCurrentRenderOutputSize(SDL_Renderer *ren
  * \sa SDL_QueryTexture
  * \sa SDL_UpdateTexture
  */
-extern SDL_DECLSPEC SDL_Texture *SDLCALL SDL_CreateTexture(SDL_Renderer *renderer, SDL_PixelFormatEnum format, int access, int w, int h);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Texture *SDLCALL SDL_CreateTexture(SDL_Renderer *renderer, SDL_PixelFormatEnum format, int access, int w, int h);
 
 /**
  * Create a texture from an existing surface.
@@ -523,6 +536,8 @@ extern SDL_DECLSPEC SDL_Texture *SDLCALL SDL_CreateTexture(SDL_Renderer *rendere
  * The pixel format of the created texture may be different from the pixel
  * format of the surface. Use SDL_QueryTexture() to query the pixel format of
  * the texture.
+ *
+ * Textures created with this function must be freed with SDL_DestroyTexture().
  *
  * \param renderer the rendering context
  * \param surface the SDL_Surface structure containing pixel data used to fill
@@ -537,7 +552,7 @@ extern SDL_DECLSPEC SDL_Texture *SDLCALL SDL_CreateTexture(SDL_Renderer *rendere
  * \sa SDL_DestroyTexture
  * \sa SDL_QueryTexture
  */
-extern SDL_DECLSPEC SDL_Texture *SDLCALL SDL_CreateTextureFromSurface(SDL_Renderer *renderer, SDL_Surface *surface);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Texture *SDLCALL SDL_CreateTextureFromSurface(SDL_Renderer *renderer, SDL_Surface *surface);
 
 /**
  * Create a texture for a rendering context with the specified properties.
@@ -633,6 +648,8 @@ extern SDL_DECLSPEC SDL_Texture *SDLCALL SDL_CreateTextureFromSurface(SDL_Render
  *   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL associated with the texture, if
  *   you want to wrap an existing texture.
  *
+ * Textures created with this function must be freed with SDL_DestroyTexture().
+ *
  * \param renderer the rendering context
  * \param props the properties to use
  * \returns a pointer to the created texture or NULL if no rendering context
@@ -648,7 +665,7 @@ extern SDL_DECLSPEC SDL_Texture *SDLCALL SDL_CreateTextureFromSurface(SDL_Render
  * \sa SDL_QueryTexture
  * \sa SDL_UpdateTexture
  */
-extern SDL_DECLSPEC SDL_Texture *SDLCALL SDL_CreateTextureWithProperties(SDL_Renderer *renderer, SDL_PropertiesID props);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Texture *SDLCALL SDL_CreateTextureWithProperties(SDL_Renderer *renderer, SDL_PropertiesID props);
 
 #define SDL_PROP_TEXTURE_CREATE_COLORSPACE_NUMBER           "colorspace"
 #define SDL_PROP_TEXTURE_CREATE_FORMAT_NUMBER               "format"

--- a/include/SDL3/SDL_storage.h
+++ b/include/SDL3/SDL_storage.h
@@ -286,7 +286,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_WriteStorageFile(SDL_Storage *storage, const
  *
  * \sa SDL_StorageReady
  */
-extern SDL_DECLSPEC int SDLCALL SDL_CreateStorageDirectory(SDL_Storage *storage, const char *path);
+extern SDL_NODISCARD SDL_DECLSPEC int SDLCALL SDL_CreateStorageDirectory(SDL_Storage *storage, const char *path);
 
 /**
  * Enumerate a directory in a storage container through a callback function.

--- a/include/SDL3/SDL_surface.h
+++ b/include/SDL3/SDL_surface.h
@@ -145,6 +145,8 @@ typedef struct SDL_Surface
 /**
  * Allocate a new RGB surface with a specific pixel format.
  *
+ * Surfaces created with this function must be freed with SDL_DestroySurface().
+ *
  * \param width the width of the surface
  * \param height the height of the surface
  * \param format the SDL_PixelFormatEnum for the new surface's pixel format.
@@ -156,7 +158,7 @@ typedef struct SDL_Surface
  * \sa SDL_CreateSurfaceFrom
  * \sa SDL_DestroySurface
  */
-extern SDL_DECLSPEC SDL_Surface *SDLCALL SDL_CreateSurface(int width, int height, SDL_PixelFormatEnum format);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Surface *SDLCALL SDL_CreateSurface(int width, int height, SDL_PixelFormatEnum format);
 
 /**
  * Allocate a new RGB surface with a specific pixel format and existing pixel
@@ -171,6 +173,8 @@ extern SDL_DECLSPEC SDL_Surface *SDLCALL SDL_CreateSurface(int width, int height
  * You may pass NULL for pixels and 0 for pitch to create a surface that you
  * will fill in with valid values later.
  *
+ * Surfaces created with this function must be freed with SDL_DestroySurface().
+ *
  * \param pixels a pointer to existing pixel data
  * \param width the width of the surface
  * \param height the height of the surface
@@ -184,7 +188,7 @@ extern SDL_DECLSPEC SDL_Surface *SDLCALL SDL_CreateSurface(int width, int height
  * \sa SDL_CreateSurface
  * \sa SDL_DestroySurface
  */
-extern SDL_DECLSPEC SDL_Surface *SDLCALL SDL_CreateSurfaceFrom(void *pixels, int width, int height, int pitch, SDL_PixelFormatEnum format);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Surface *SDLCALL SDL_CreateSurfaceFrom(void *pixels, int width, int height, int pitch, SDL_PixelFormatEnum format);
 
 /**
  * Free an RGB surface.

--- a/include/SDL3/SDL_thread.h
+++ b/include/SDL3/SDL_thread.h
@@ -178,6 +178,8 @@ SDL_CreateThreadWithStackSize(SDL_ThreadFunction fn,
  * SDL_CreateThreadWithStackSize(fn, name, 0, data);
  * ```
  *
+ * Threads created with this function must be cleaned up with SDL_WaitThread() or detached with SDL_DetachThread().
+ *
  * \param fn the SDL_ThreadFunction function to call in the new thread
  * \param name the name of the thread
  * \param data a pointer that is passed to `fn`
@@ -189,8 +191,9 @@ SDL_CreateThreadWithStackSize(SDL_ThreadFunction fn,
  *
  * \sa SDL_CreateThreadWithStackSize
  * \sa SDL_WaitThread
+ * \sa SDL_DetachThread
  */
-extern SDL_DECLSPEC SDL_Thread * SDLCALL SDL_CreateThread(SDL_ThreadFunction fn, const char *name, void *data);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Thread * SDLCALL SDL_CreateThread(SDL_ThreadFunction fn, const char *name, void *data);
 
 /**
  * Create a new thread with a specific stack size.
@@ -219,6 +222,8 @@ extern SDL_DECLSPEC SDL_Thread * SDLCALL SDL_CreateThread(SDL_ThreadFunction fn,
  * multiple of the system's page size (in many cases, this is 4 kilobytes, but
  * check your system documentation).
  *
+ * Threads created with this function must be cleaned up with SDL_WaitThread() or detached with SDL_DetachThread().
+ *
  * \param fn the SDL_ThreadFunction function to call in the new thread
  * \param name the name of the thread
  * \param stacksize the size, in bytes, to allocate for the new thread stack.
@@ -231,8 +236,9 @@ extern SDL_DECLSPEC SDL_Thread * SDLCALL SDL_CreateThread(SDL_ThreadFunction fn,
  *
  * \sa SDL_CreateThread
  * \sa SDL_WaitThread
+ * \sa SDL_DetachThread
  */
-extern SDL_DECLSPEC SDL_Thread * SDLCALL SDL_CreateThreadWithStackSize(SDL_ThreadFunction fn, const char *name, const size_t stacksize, void *data);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Thread * SDLCALL SDL_CreateThreadWithStackSize(SDL_ThreadFunction fn, const char *name, const size_t stacksize, void *data);
 
 #endif
 
@@ -377,14 +383,17 @@ extern SDL_DECLSPEC void SDLCALL SDL_DetachThread(SDL_Thread * thread);
  * This creates an identifier that is globally visible to all threads but
  * refers to data that is thread-specific.
  *
+ * Thread-local storage is automatically cleaned up on SDL_Quit() or via SDL_CleanupTLS().
+ *
  * \returns the newly created thread local storage identifier or 0 on error.
  *
  * \since This function is available since SDL 3.0.0.
  *
  * \sa SDL_GetTLS
  * \sa SDL_SetTLS
+ * \sa SDL_CleanupTLS
  */
-extern SDL_DECLSPEC SDL_TLSID SDLCALL SDL_CreateTLS(void);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_TLSID SDLCALL SDL_CreateTLS(void);
 
 /**
  * Get the current thread's value associated with a thread local storage ID.

--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -823,6 +823,8 @@ extern SDL_DECLSPEC Uint32 SDLCALL SDL_GetWindowPixelFormat(SDL_Window *window);
  * loader or link to a dynamic library version. This limitation may be removed
  * in a future version of SDL.
  *
+ * Windows created with this function must be freed with SDL_DestroyWindow().
+ *
  * \param title the title of the window, in UTF-8 encoding
  * \param w the width of the window
  * \param h the height of the window
@@ -836,7 +838,7 @@ extern SDL_DECLSPEC Uint32 SDLCALL SDL_GetWindowPixelFormat(SDL_Window *window);
  * \sa SDL_CreateWindowWithProperties
  * \sa SDL_DestroyWindow
  */
-extern SDL_DECLSPEC SDL_Window *SDLCALL SDL_CreateWindow(const char *title, int w, int h, SDL_WindowFlags flags);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Window *SDLCALL SDL_CreateWindow(const char *title, int w, int h, SDL_WindowFlags flags);
 
 /**
  * Create a child popup window of the specified parent window.
@@ -891,7 +893,7 @@ extern SDL_DECLSPEC SDL_Window *SDLCALL SDL_CreateWindow(const char *title, int 
  * \sa SDL_DestroyWindow
  * \sa SDL_GetWindowParent
  */
-extern SDL_DECLSPEC SDL_Window *SDLCALL SDL_CreatePopupWindow(SDL_Window *parent, int offset_x, int offset_y, int w, int h, SDL_WindowFlags flags);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Window *SDLCALL SDL_CreatePopupWindow(SDL_Window *parent, int offset_x, int offset_y, int w, int h, SDL_WindowFlags flags);
 
 /**
  * Create a window with the specified properties.
@@ -987,6 +989,8 @@ extern SDL_DECLSPEC SDL_Window *SDLCALL SDL_CreatePopupWindow(SDL_Window *parent
  * Windows with the "tooltip" and "menu" properties are popup windows and have
  * the behaviors and guidelines outlined in SDL_CreatePopupWindow().
  *
+ * Windows created with this function must be freed with SDL_DestroyWindow().
+ *
  * \param props the properties to use
  * \returns the window that was created or NULL on failure; call
  *          SDL_GetError() for more information.
@@ -997,7 +1001,7 @@ extern SDL_DECLSPEC SDL_Window *SDLCALL SDL_CreatePopupWindow(SDL_Window *parent
  * \sa SDL_CreateWindow
  * \sa SDL_DestroyWindow
  */
-extern SDL_DECLSPEC SDL_Window *SDLCALL SDL_CreateWindowWithProperties(SDL_PropertiesID props);
+extern SDL_NODISCARD SDL_DECLSPEC SDL_Window *SDLCALL SDL_CreateWindowWithProperties(SDL_PropertiesID props);
 
 #define SDL_PROP_WINDOW_CREATE_ALWAYS_ON_TOP_BOOLEAN               "always_on_top"
 #define SDL_PROP_WINDOW_CREATE_BORDERLESS_BOOLEAN                  "borderless"

--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -970,14 +970,16 @@ static void AttemptSensorFusion(SDL_Joystick *joystick, SDL_bool invert_sensors)
 
             if (!joystick->accel_sensor && SDL_GetSensorInstanceType(sensor) == SDL_SENSOR_ACCEL) {
                 /* Increment the sensor subsystem reference count */
-                SDL_InitSubSystem(SDL_INIT_SENSOR);
+                const int rc = SDL_InitSubSystem(SDL_INIT_SENSOR);
+                SDL_assert(rc == 0);
 
                 joystick->accel_sensor = sensor;
                 SDL_PrivateJoystickAddSensor(joystick, SDL_SENSOR_ACCEL, 0.0f);
             }
             if (!joystick->gyro_sensor && SDL_GetSensorInstanceType(sensor) == SDL_SENSOR_GYRO) {
                 /* Increment the sensor subsystem reference count */
-                SDL_InitSubSystem(SDL_INIT_SENSOR);
+                const int rc = SDL_InitSubSystem(SDL_INIT_SENSOR);
+                SDL_assert(rc == 0);
 
                 joystick->gyro_sensor = sensor;
                 SDL_PrivateJoystickAddSensor(joystick, SDL_SENSOR_GYRO, 0.0f);

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1437,7 +1437,11 @@ SDL_bool SDLTest_CommonInit(SDLTest_CommonState *state)
     }
 
     if (state->flags & SDL_INIT_CAMERA) {
-        SDL_InitSubSystem(SDL_INIT_CAMERA);
+        if (SDL_InitSubSystem(SDL_INIT_CAMERA) != 0)
+        {
+            SDL_Log("Couldn't init camera subsystem: %s\n", SDL_GetError());
+            return SDL_FALSE;
+        }
     }
 
     return SDL_TRUE;

--- a/test/pretest.c
+++ b/test/pretest.c
@@ -25,7 +25,12 @@ int main(int argc, char *argv[])
     Uint64 prequit;
     (void)argc;
     (void)argv;
-    SDL_Init(0);
+    if (SDL_Init(0) != 0)
+    {
+        SDL_Log("SDL_Init failure");
+        return 1;
+    }
+
     start = SDL_GetTicks();
     SDL_GetPrefPath("libsdl", "test_filesystem");
     prequit = SDL_GetTicks();

--- a/test/testautomation_subsystems.c
+++ b/test/testautomation_subsystems.c
@@ -48,7 +48,7 @@ static int subsystems_referenceCount()
     SDLTest_AssertCheck(SDL_WasInit(system) == 0, "Check result from SDL_WasInit(0x%x)", system);
 
     /* Init subsystem once, and quit once */
-    SDL_InitSubSystem(system);
+    SDLTest_AssertCheck(0 == SDL_InitSubSystem(system), "Non-zero result from SDL_InitSubSystem");
     SDLTest_AssertPass("Call to SDL_InitSubSystem(0x%x)", system);
     result = SDL_WasInit(system);
     SDLTest_AssertCheck(result == system, "Check result from SDL_WasInit(0x%x), expected: 0x%x, got: 0x%x", system, system, result);
@@ -59,9 +59,9 @@ static int subsystems_referenceCount()
     SDLTest_AssertCheck(result == 0, "Check result from SDL_WasInit(0x%x), expected: 0, got: 0x%x", system, result);
 
     /* Init subsystem number of times, then decrement reference count until it's disposed of. */
-    SDL_InitSubSystem(system);
-    SDL_InitSubSystem(system);
-    SDL_InitSubSystem(system);
+    SDLTest_AssertCheck(0 == SDL_InitSubSystem(system), "Non-zero result from SDL_InitSubSystem");
+    SDLTest_AssertCheck(0 == SDL_InitSubSystem(system), "Non-zero result from SDL_InitSubSystem");
+    SDLTest_AssertCheck(0 == SDL_InitSubSystem(system), "Non-zero result from SDL_InitSubSystem");
     SDLTest_AssertPass("Call to SDL_InitSubSystem(0x%x) x3 times", system);
     result = SDL_WasInit(system);
     SDLTest_AssertCheck(result == system, "Check result from SDL_WasInit(0x%x), expected: 0x%x, got: 0x%x", system, system, result);
@@ -84,7 +84,7 @@ static int subsystems_referenceCount()
 
 /**
  * Inits and Quits subsystems that have another as dependency;
- *        check that the dependency is not removed before the last of its dependents.
+ * check that the dependency is not removed before the last of its dependents.
  *
  * \sa SDL_InitSubSystem
  * \sa SDL_QuitSubSystem
@@ -98,7 +98,7 @@ static int subsystems_dependRefCountInitAllQuitByOne()
                         "Check result from SDL_WasInit(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK | SDL_INIT_EVENTS)");
 
     /* Following should init SDL_INIT_EVENTS and give it +3 ref counts. */
-    SDL_InitSubSystem(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK);
+    SDLTest_AssertCheck(0 == SDL_InitSubSystem(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK), "Non-zero result from SDL_InitSubSystem");
     SDLTest_AssertPass("Call to SDL_InitSubSystem(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK)");
     result = SDL_WasInit(SDL_INIT_EVENTS);
     SDLTest_AssertCheck(result == SDL_INIT_EVENTS, "Check result from SDL_WasInit(SDL_INIT_EVENTS), expected: 0x4000, got: 0x%x", result);
@@ -136,13 +136,13 @@ static int subsystems_dependRefCountInitByOneQuitAll()
                         "Check result from SDL_WasInit(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK | SDL_INIT_EVENTS)");
 
     /* Following should init SDL_INIT_EVENTS and give it +3 ref counts. */
-    SDL_InitSubSystem(SDL_INIT_VIDEO);
+    SDLTest_AssertCheck(0 == SDL_InitSubSystem(SDL_INIT_VIDEO), "Non-zero result from SDL_InitSubSystem");
     SDLTest_AssertPass("Call to SDL_InitSubSystem(SDL_INIT_VIDEO)");
     result = SDL_WasInit(SDL_INIT_EVENTS);
     SDLTest_AssertCheck(result == SDL_INIT_EVENTS, "Check result from SDL_WasInit(SDL_INIT_EVENTS), expected: 0x4000, got: 0x%x", result);
-    SDL_InitSubSystem(SDL_INIT_AUDIO);
+    SDLTest_AssertCheck(0 == SDL_InitSubSystem(SDL_INIT_AUDIO), "Non-zero result from SDL_InitSubSystem");
     SDLTest_AssertPass("Call to SDL_InitSubSystem(SDL_INIT_AUDIO)");
-    SDL_InitSubSystem(SDL_INIT_JOYSTICK);
+    SDLTest_AssertCheck(0 == SDL_InitSubSystem(SDL_INIT_JOYSTICK), "Non-zero result from SDL_InitSubSystem");
     SDLTest_AssertPass("Call to SDL_InitSubSystem(SDL_INIT_JOYSTICK)");
 
     /* Quit systems all at once. */
@@ -171,16 +171,16 @@ static int subsystems_dependRefCountWithExtraInit()
                         "Check result from SDL_WasInit(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK | SDL_INIT_EVENTS)");
 
     /* Init EVENTS explicitly, +1 ref count. */
-    SDL_InitSubSystem(SDL_INIT_EVENTS);
+    SDLTest_AssertCheck(0 == SDL_InitSubSystem(SDL_INIT_EVENTS), "Non-zero result from SDL_InitSubSystem");
     SDLTest_AssertPass("Call to SDL_InitSubSystem(SDL_INIT_EVENTS)");
     result = SDL_WasInit(SDL_INIT_EVENTS);
     SDLTest_AssertCheck(result == SDL_INIT_EVENTS, "Check result from SDL_WasInit(SDL_INIT_EVENTS), expected: 0x4000, got: 0x%x", result);
     /* Following should init SDL_INIT_EVENTS and give it +3 ref counts. */
-    SDL_InitSubSystem(SDL_INIT_VIDEO);
+    SDLTest_AssertCheck(0 == SDL_InitSubSystem(SDL_INIT_VIDEO), "Non-zero result from SDL_InitSubSystem");
     SDLTest_AssertPass("Call to SDL_InitSubSystem(SDL_INIT_VIDEO)");
-    SDL_InitSubSystem(SDL_INIT_AUDIO);
+    SDLTest_AssertCheck(0 == SDL_InitSubSystem(SDL_INIT_AUDIO), "Non-zero result from SDL_InitSubSystem");
     SDLTest_AssertPass("Call to SDL_InitSubSystem(SDL_INIT_AUDIO)");
-    SDL_InitSubSystem(SDL_INIT_JOYSTICK);
+    SDLTest_AssertCheck(0 == SDL_InitSubSystem(SDL_INIT_JOYSTICK), "Non-zero result from SDL_InitSubSystem");
     SDLTest_AssertPass("Call to SDL_InitSubSystem(SDL_INIT_JOYSTICK)");
 
     /* Quit EVENTS explicitly, -1 ref count. */

--- a/test/testhaptic.c
+++ b/test/testhaptic.c
@@ -81,8 +81,13 @@ int main(int argc, char **argv)
     }
 
     /* Initialize the force feedbackness */
-    SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_JOYSTICK |
-             SDL_INIT_HAPTIC);
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_JOYSTICK |
+                 SDL_INIT_HAPTIC) != 0)
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_Init failure: %s\n", SDL_GetError());
+        return 1;
+    }
+
     haptics = SDL_GetHaptics(&num_haptics);
     SDL_Log("%d Haptic devices detected.\n", num_haptics);
     for (i = 0; i < num_haptics; ++i) {

--- a/test/testmultiaudio.c
+++ b/test/testmultiaudio.c
@@ -53,7 +53,7 @@ test_multi_audio(SDL_AudioDeviceID *devices, int devcount)
     SDL_Event event;
 
     /* Create a Window to get fully initialized event processing for testing pause on Android. */
-    SDL_CreateWindow("testmultiaudio", 320, 240, 0);
+    SDL_Window* window = SDL_CreateWindow("testmultiaudio", 320, 240, 0);
 #endif
 
     for (i = 0; i < devcount; i++) {
@@ -131,6 +131,10 @@ test_multi_audio(SDL_AudioDeviceID *devices, int devcount)
         SDL_free(streams);
     }
 
+#ifdef SDL_PLATFORM_ANDROID
+    SDL_DestroyWindow(window);
+#endif
+
     SDL_Log("All done!\n");
 }
 
@@ -203,4 +207,3 @@ int main(int argc, char **argv)
 
     return 0;
 }
-

--- a/test/testrumble.c
+++ b/test/testrumble.c
@@ -85,8 +85,13 @@ int main(int argc, char **argv)
     }
 
     /* Initialize the force feedbackness */
-    SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_JOYSTICK |
-             SDL_INIT_HAPTIC);
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER | SDL_INIT_JOYSTICK |
+                 SDL_INIT_HAPTIC) != 0)
+    {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_Init failure: %s\n", SDL_GetError());
+        return 1;
+    }
+
     haptics = SDL_GetHaptics(&num_haptics);
     SDL_Log("%d Haptic devices detected.\n", num_haptics);
     if (haptics) {

--- a/test/testsensor.c
+++ b/test/testsensor.c
@@ -112,7 +112,7 @@ int main(int argc, char **argv)
         SDL_bool done = SDL_FALSE;
         SDL_Event event;
 
-        SDL_CreateWindow("Sensor Test", 0, 0, SDL_WINDOW_FULLSCREEN);
+        SDL_Window* window = SDL_CreateWindow("Sensor Test", 0, 0, SDL_WINDOW_FULLSCREEN);
         while (!done) {
             /* Update to get the current event state */
             SDL_PumpEvents();
@@ -133,6 +133,8 @@ int main(int argc, char **argv)
                 }
             }
         }
+
+        SDL_DestroyWindow(window);
     }
 
     SDL_Quit();


### PR DESCRIPTION
Builds upon #9809, hopefully a less controversial changeset compared to the previously proposed one. Adds `SDL_NODISCARD` to functions that create or allocate resources, and clarifies documentation regarding the intended cleanup.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds `SDL_NODISCARD` to all `SDL_CreateXXX` functions, and explicitly specifies what clean-up function should be invoked in the documentation of the affected functions. Occurrences in test code where the result values were discarded were fixed.

Adds `SDL_NODISCARD` to `SDL_Init` and `SDL_InitSubSystem`, and fixed occurrences in library and test code where the result values were discarded were fixed.


## Existing Issue(s)

N/A.
