### PR TITLE
Fix finger double free and general SDL_Finger event nonsense

### DIFF
--- a/src/events/SDL_touch.c
+++ b/src/events/SDL_touch.c
@@ -241,7 +241,12 @@ static int SDL_DelFinger(SDL_Touch *touch, SDL_FingerID fingerid)
     }
 
     if (index < (touch->num_fingers - 1)) {
+        // Move the deleted finger to the end of the active fingers array and shift the active fingers by one.
+        // This ensures that the descriptor for the now-deleted finger is located at `touch->fingers[touch->num_fingers]` (after the decrement below)
+        // and is ready for use in SDL_AddFinger.
+        SDL_Finger *deleted_finger = touch->fingers[index]; 
         SDL_memmove(&touch->fingers[index], &touch->fingers[index + 1], (touch->num_fingers - index - 1) * sizeof(touch->fingers[index]));
+        touch->fingers[touch->num_fingers - 1] = deleted_finger;
     }
     --touch->num_fingers;
     return 0;

--- a/src/events/SDL_touch.c
+++ b/src/events/SDL_touch.c
@@ -240,15 +240,15 @@ static int SDL_DelFinger(SDL_Touch *touch, SDL_FingerID fingerid)
         return -1;
     }
 
-    if (index < (touch->num_fingers - 1)) {
-        // Move the deleted finger to the end of the active fingers array and shift the active fingers by one.
-        // This ensures that the descriptor for the now-deleted finger is located at `touch->fingers[touch->num_fingers]` (after the decrement below)
+    --touch->num_fingers;
+    if (index < (touch->num_fingers)) {
+        // Move the deleted finger to just past the end of the active fingers array and shift the active fingers by one.
+        // This ensures that the descriptor for the now-deleted finger is located at `touch->fingers[touch->num_fingers]`
         // and is ready for use in SDL_AddFinger.
         SDL_Finger *deleted_finger = touch->fingers[index]; 
-        SDL_memmove(&touch->fingers[index], &touch->fingers[index + 1], (touch->num_fingers - index - 1) * sizeof(touch->fingers[index]));
-        touch->fingers[touch->num_fingers - 1] = deleted_finger;
+        SDL_memmove(&touch->fingers[index], &touch->fingers[index + 1], (touch->num_fingers - index) * sizeof(touch->fingers[index]));
+        touch->fingers[touch->num_fingers] = deleted_finger;
     }
-    --touch->num_fingers;
     return 0;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- See https://github.com/libsdl-org/SDL/issues/9810#issuecomment-2120834171 for deep dive into the double-free.
- Regressed with https://github.com/libsdl-org/SDL/commit/1862a62b5d22c90323ddb257d75974348c3c807e.
- Tested on Windows to not cause crashes and the nonsense described in the issues below.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
- Closes https://github.com/libsdl-org/SDL/issues/9591
- Closes https://github.com/libsdl-org/SDL/issues/9810
- Closes https://github.com/libsdl-org/SDL/issues/9833
- Closes downstream issue https://github.com/ppy/osu/issues/28211