### PR TITLE
TESTWM : Option --hide-cursor and Keyboard toggle Ctrl-h to ShowCursor and HideCursor

### DIFF
--- a/include/SDL3/SDL_test_common.h
+++ b/include/SDL3/SDL_test_common.h
@@ -127,6 +127,7 @@ typedef struct
 
     /* Mouse info */
     SDL_Rect confine;
+    SDL_bool hide_cursor;
 
 } SDLTest_CommonState;
 

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -590,6 +590,10 @@ int SDLTest_CommonArg(SDLTest_CommonState *state, int index)
             state->window_flags |= SDL_WINDOW_UTILITY;
             return 1;
         }
+        if (SDL_strcasecmp(argv[index], "--hide-cursor") == 0) {
+            state->hide_cursor = SDL_TRUE;
+            return 1;
+        }
     }
 
     if (state->flags & SDL_INIT_AUDIO) {
@@ -1400,6 +1404,9 @@ SDL_bool SDLTest_CommonInit(SDLTest_CommonState *state)
 
             SDL_ShowWindow(state->windows[i]);
         }
+        if (state->hide_cursor) {
+            SDL_HideCursor();
+        }
     }
 
     if (state->flags & SDL_INIT_AUDIO) {
@@ -2181,6 +2188,16 @@ int SDLTest_CommonEventMainCallbacks(SDLTest_CommonState *state, const SDL_Event
                 }
             }
             break;
+        case SDLK_h:
+            if (withControl) {
+                /* Ctrl-H changes cursor visibility. */
+                if (SDL_CursorVisible()) {
+                    SDL_HideCursor();
+                } else {
+                    SDL_ShowCursor();
+                }
+            }
+            break;
         case SDLK_c:
             if (withAlt) {
                 /* Alt-C copy awesome text to the primary selection! */
@@ -2318,7 +2335,7 @@ int SDLTest_CommonEventMainCallbacks(SDLTest_CommonState *state, const SDL_Event
                 if (window) {
                     SDL_WindowFlags flags = SDL_GetWindowFlags(window);
                     if (!(flags & SDL_WINDOW_FULLSCREEN) ||
-						!SDL_GetWindowFullscreenMode(window)) {
+                        !SDL_GetWindowFullscreenMode(window)) {
                         SDL_SetWindowFullscreenMode(window, &state->fullscreen_mode);
                         SDL_SetWindowFullscreen(window, SDL_TRUE);
                     } else {
@@ -2331,7 +2348,7 @@ int SDLTest_CommonEventMainCallbacks(SDLTest_CommonState *state, const SDL_Event
                 if (window) {
                     SDL_WindowFlags flags = SDL_GetWindowFlags(window);
                     if (!(flags & SDL_WINDOW_FULLSCREEN) ||
-						SDL_GetWindowFullscreenMode(window)) {
+                        SDL_GetWindowFullscreenMode(window)) {
                         SDL_SetWindowFullscreenMode(window, NULL);
                         SDL_SetWindowFullscreen(window, SDL_TRUE);
                     } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
To help debugging SDL applications that are running with the cursor hidden, provide an option to hide the cursor in SDL tests at startup, and a key toggle to show / hide the cursor while the test is running.
The prime target is `testwm`, but as the option  and the key are handled by `SDL_test_common.c`, this in fact applies to any SDL test that uses `SDLTest_CommonInit`.

**Changes:**
- In `include/SDL3/SDL_test_common.h` : Add flag `state->hide_cursor`,
- In `src/test/SDL_test_common.c` : Handle option `--hide-cursor` setting `state->hide_cursor` to apply `SDL_HideCursor` downstream, Handle `Ctrl-h` toggle to `SDL_HideCursor` and `SDL_ShowCursor`. Also two replacements of tabs to spaces.

**NB** There are no SDL test that use `Ctrl-h` except `testmodal`, and `testmodal` does not use `SDLTest_CommonInit`. 
<!--- Describe your changes in detail -->

## Existing Issue(s)
This change would have helped in issue #9827.
<!--- If it fixes an open issue, please link to the issue here. -->
