### PR TITLE
ci: build simple Android SDL app using gradle

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,33 +15,46 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { name: "Android.mk"  }
+          - { name: "Android.mk", ndk-build: 1 }
+          - { name: "Gradle", gradle: 1 }
           - { name: "CMake", cmake: 1, android_abi: "arm64-v8a", android_platform: 23, arch: "aarch64", artifact: "SDL-android-arm64", apk-artifact: "SDL-android-apks-arm64" }
           - { name: "CMake (lean and mean)", cmake: 1, cppflags: "-DSDL_LEAN_AND_MEAN=1", android_abi: "arm64-v8a", android_platform: 23, arch: "aarch64", artifact: "SDL-lean-android-arm64", apk-artifact: "SDL-lean-android-apks-arm64" }
 
     steps:
       - uses: actions/checkout@v4
       - uses: nttld/setup-ndk@v1
+        if: ${{ matrix.platform.cmake || matrix.platform.ndk-build }}
         id: setup_ndk
         with:
           local-cache: true
           ndk-version: r21e
       - name: Build (Android.mk)
-        if: ${{ contains(matrix.platform.name, 'Android.mk') }}
+        if: ${{ matrix.platform.ndk-build }}
         run: |
           ./build-scripts/androidbuildlibs.sh
       - uses: actions/setup-java@v4
-        if: ${{ contains(matrix.platform.name, 'CMake') }}
+        if: ${{ matrix.platform.cmake || matrix.platform.gradle }}
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
+      - name: Build app (Gradle)
+        if: ${{ matrix.platform.gradle }}
+        run: |
+          ln -s ${{ github.workspace }} ${{ github.workspace }}/android-project/app/jni/SDL
+          cd android-project
+          ./gradlew -i assembleRelease
+#      - name: Build library (Gradle)
+#        if: ${{ matrix.platform.gradle }}
+#        run: |
+#          cd android-project
+#          ./gradlew -i assembleRelease -PBUILD_AS_LIBRARY=1
       - name: Setup (CMake)
-        if: ${{ contains(matrix.platform.name, 'CMake') }}
+        if: ${{ matrix.platform.cmake }}
         run: |
           sudo apt-get update
           sudo apt-get install ninja-build pkg-config
       - name: Configure (CMake)
-        if: ${{ contains(matrix.platform.name, 'CMake') }}
+        if: ${{ matrix.platform.cmake }}
         run: |
           cmake -S . -B build \
             -DCMAKE_C_FLAGS="${{ matrix.platform.cppflags }}" \
@@ -63,25 +76,25 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -GNinja
       - name: Build (CMake)
-        if: ${{ contains(matrix.platform.name, 'CMake') }}
+        if: ${{ matrix.platform.cmake }}
         run: |
           cmake --build build --config Release --parallel --verbose
       - name: Build test apk's (CMake)
-        if: ${{ contains(matrix.platform.name, 'CMake') }}
+        if: ${{ matrix.platform.cmake }}
         run: |
           cmake --build build --config Release --parallel --verbose --target testautomation-apk testaudiocapture-apk testcontroller-apk testmultiaudio-apk testsprite-apk
       - name: Install (CMake)
-        if: ${{ contains(matrix.platform.name, 'CMake') }}
+        if: ${{ matrix.platform.cmake }}
         run: |
           cmake --install build --config Release
           echo "SDL3_DIR=$(pwd)/prefix" >> $GITHUB_ENV
           ( cd prefix; find ) | LC_ALL=C sort -u
       - name: Package (CPack)
-        if: ${{ contains(matrix.platform.name, 'CMake') }}
+        if: ${{ matrix.platform.cmake }}
         run: |
           cmake --build build/ --config Release --target package
       - name: Verify CMake configuration files
-        if: ${{ contains(matrix.platform.name, 'CMake') }}
+        if: ${{ matrix.platform.cmake }}
         run: |
           cmake -S cmake/test -B cmake_config_build -G Ninja \
             -DCMAKE_TOOLCHAIN_FILE=${{ steps.setup_ndk.outputs.ndk-path }}/build/cmake/android.toolchain.cmake \
@@ -91,19 +104,19 @@ jobs:
             -DCMAKE_PREFIX_PATH=${{ env.SDL3_DIR }}
           cmake --build cmake_config_build --verbose
       - name: Verify sdl3.pc
-        if: ${{ contains(matrix.platform.name, 'CMake') }}
+        if: ${{ matrix.platform.cmake }}
         run: |
           export CC="${{ steps.setup_ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang --target=${{ matrix.platform.arch }}-none-linux-androideabi${{ matrix.platform.android_platform }}"
           export PKG_CONFIG_PATH=${{ env.SDL3_DIR }}/lib/pkgconfig
           cmake/test/test_pkgconfig.sh
       - uses: actions/upload-artifact@v4
-        if: ${{ contains(matrix.platform.name, 'CMake') }}
+        if: ${{ matrix.platform.cmake }}
         with:
           if-no-files-found: error
           name: ${{ matrix.platform.artifact }}
           path: build/dist/SDL3*
       - uses: actions/upload-artifact@v4
-        if: ${{ contains(matrix.platform.name, 'CMake') }}
+        if: ${{ matrix.platform.cmake }}
         with:
           if-no-files-found: error
           name: ${{ matrix.platform.apk-artifact }}

--- a/android-project/app/build.gradle
+++ b/android-project/app/build.gradle
@@ -24,7 +24,7 @@ android {
                 abiFilters 'arm64-v8a'
             }
             cmake {
-                arguments "-DANDROID_APP_PLATFORM=android-19", "-DANDROID_STL=c++_static"
+                arguments "-DANDROID_PLATFORM=android-19", "-DANDROID_STL=c++_static"
                 // abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
                 abiFilters 'arm64-v8a'
             }
@@ -45,12 +45,12 @@ android {
             jniLibs.srcDir 'libs'
         }
         externalNativeBuild {
-            ndkBuild {
-                path 'jni/Android.mk'
-            }
-            // cmake {
-            //     path 'jni/CMakeLists.txt'
+            // ndkBuild {
+            //     path 'jni/Android.mk'
             // }
+            cmake {
+                path 'jni/CMakeLists.txt'
+            }
         }
 
     }

--- a/android-project/app/jni/src/CMakeLists.txt
+++ b/android-project/app/jni/src/CMakeLists.txt
@@ -1,13 +1,29 @@
 cmake_minimum_required(VERSION 3.6)
 
-project(MY_APP)
+project(my_app)
 
-find_library(SDL3 SDL3)
+if(NOT TARGET SDL3::SDL3)
+    find_package(SDL3 CONFIG)
+endif()
 
-add_library(main SHARED)
+if(NOT TARGET SDL3::SDL3)
+    find_library(SDL3_LIBRARY NAMES "SDL3")
+    find_path(SDL3_INCLUDE_DIR NAMES "SDL3/SDL.h")
+    add_library(SDL3::SDL3 UNKNOWN IMPORTED)
+    set_property(TARGET SDL3::SDL3 PROPERTY IMPORTED_LOCATION "${SDL3_LIBRARY}")
+    set_property(TARGET SDL3::SDL3 PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${SDL3_INCLUDE_DIR}")
+endif()
 
-target_sources(main PRIVATE YourSourceHere.c)
+if(NOT TARGET SDL3::SDL3)
+    message(FATAL_ERROR "Cannot find SDL3.
 
-target_link_libraries(main SDL3)
+Possible ways to fix this:
+- Use a SDL3 Android aar archive, and configure gradle to use it: prefab is required.
+- Add add_subdirectory(path/to/SDL) to your CMake script, and make sure a vendored SDL is present there.
+")
+endif()
 
-
+add_library(main SHARED
+    YourSourceHere.c
+)
+target_link_libraries(main PRIVATE SDL3::SDL3)

--- a/android-project/app/jni/src/YourSourceHere.c
+++ b/android-project/app/jni/src/YourSourceHere.c
@@ -1,0 +1,26 @@
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
+
+/* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
+/*                                                       */
+/* Remove this source, and replace with your SDL sources */
+/*                                                       */
+/* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
+
+int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
+    if (SDL_Init(SDL_INIT_EVENTS | SDL_INIT_VIDEO) < 0) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_Init failed (%s)", SDL_GetError());
+        return 1;
+    }
+
+    if (SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION, "Hello World",
+                                 "!! Your SDL project successfully runs on Android !!", NULL) < 0) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_ShowSimpleMessageBox failed (%s)", SDL_GetError());
+        return 1;
+    }
+
+    SDL_Quit();
+    return 0;
+}


### PR DESCRIPTION
This also:
- Modifies the gradle project file to use the CMake script by default instead of the `Android.mk` makefile
- Adds a minimum, barely functioning, SDL app

## Description

ci job output:
https://github.com/libsdl-org/SDL/actions/runs/9181472626/job/25248284307?pr=9849


## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
