### PR TITLE
Fix touchid assertion faliure on emscripten

### DIFF
--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -762,7 +762,7 @@ static EM_BOOL Emscripten_HandleTouch(int eventType, const EmscriptenTouchEvent 
             continue;
         }
 
-        id = touchEvent->touches[i].identifier;
+        id = touchEvent->touches[i].identifier + 1;
         if (client_w <= 1) {
             x = 0.5f;
         } else {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added 1 to touchid received from emscriptien. 

## Original bug
When browsing a emscripten project on android, if I click the window, the assertion at line 212 in `src/events/SDL_touch.c` triggers. Which leads to crash.
```
WARN: [TileMap.js:1628:16](http://mysite:8000/TileMap.js)
<empty string> [TileMap.js:1628:16](http://mysite:8000/TileMap.js)
Assertion failure at SDL_AddFinger (/home/user/Developer/web/SDL/src/events/SDL_touch.c:212), triggered 1 time: [TileMap.js:1628:16](http://mysite:8000/TileMap.js)
  'fingerid != 0' [TileMap.js:1628:16](http://mysite:8000/TileMap.js)
<empty string> [TileMap.js:1628:16](http://mysite:8000/TileMap.js)
`allocate` is a library symbol and not included by default; add it to your library.js __deps or to DEFAULT_LIBRARY_FUNCS_TO_INCLUDE on the command line (e.g. -sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE='$allocate') [TileMap.js:1032:12](http://mysite:8000/TileMap.js)
`ALLOC_NORMAL` is a library symbol and not included by default; add it to your library.js __deps or to DEFAULT_LIBRARY_FUNCS_TO_INCLUDE on the command line (e.g. -sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE='$ALLOC_NORMAL') [TileMap.js:1032:12](http://mysite:8000/TileMap.js)
Uncaught TypeError: allocate is not a function
    218944 http://mysite:8000/TileMap.js:932
    runMainThreadEmAsm http://mysite:8000/TileMap.js:4259
    _emscripten_asm_const_ptr_sync_on_main_thread http://mysite:8000/TileMap.js:4263
    touchEventHandlerFunc http://mysite:8000/TileMap.js:8347
    eventListenerFunc http://mysite:8000/TileMap.js:5214
    registerOrRemoveHandler http://mysite:8000/TileMap.js:5221
    registerTouchEventCallback http://mysite:8000/TileMap.js:8358
    _emscripten_set_touchstart_callback_on_thread http://mysite:8000/TileMap.js:8370
    createExportWrapper http://mysite:8000/TileMap.js:646
    callMain http://mysite:8000/TileMap.js:9875
    doRun http://mysite:8000/TileMap.js:9925
    run http://mysite:8000/TileMap.js:9936
    setTimeout handler*run http://mysite:8000/TileMap.js:9932
    runCaller http://mysite:8000/TileMap.js:9852
    removeRunDependency http://mysite:8000/TileMap.js:582
    receiveInstance http://mysite:8000/TileMap.js:784
    receiveInstantiationResult http://mysite:8000/TileMap.js:802
    promise callback*instantiateAsync/< http://mysite:8000/TileMap.js:738
    promise callback*instantiateAsync http://mysite:8000/TileMap.js:730
    createWasm http://mysite:8000/TileMap.js:822
    <anonymous> http://mysite:8000/TileMap.js:9537
[TileMap.js:932:185](http://mysite:8000/TileMap.js)
emscripten_force_exit cannot actually shut down the runtime, as the build does not have EXIT_RUNTIME set [TileMap.js:1032:12](http://mysite:8000/TileMap.js)
[post-exception status] Exception thrown, see JavaScript console [mysite:8000:164:29](http://mysite:8000/)
Uncaught 
Object { name: "ExitStatus", message: "Program terminated with exit(42)", status: 42 }
```
PS. 