### PR TITLE
Correct name for SDL_CreateThreadWithStackSize()

### DIFF
--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -1631,7 +1631,7 @@ becomes:
 
 ## SDL_thread.h
 
-SDL_CreateThreadWithStackSpace has been replaced with SDL_CreateThreadWithProperties.
+SDL_CreateThreadWithStackSize has been replaced with SDL_CreateThreadWithProperties.
 
 SDL_CreateThread and SDL_CreateThreadWithProperties now take beginthread/endthread function pointers on all platforms (ignoring them on most), and have been replaced with macros that hide this detail on all platforms. This works the same as before at the source code level, but the actual function signature that is called in SDL has changed. The library's exported symbol is SDL_CreateThreadRuntime, and looking for "SDL_CreateThread" in the DLL/Shared Library/Dylib will fail. You should not call this directly, but instead always use the macro!
 


### PR DESCRIPTION
Fixes an incorrect name in the migration guide.