### PR TITLE
[SDL2] [d3d12] Older Windows SDK contain bad function prototypes, so declare our own

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1811,14 +1811,7 @@ elseif(WINDOWS)
 
     check_include_file(d3d9.h HAVE_D3D_H)
     check_include_file(d3d11_1.h HAVE_D3D11_H)
-    check_c_source_compiles("
-      #include <winsdkver.h>
-      #include <sdkddkver.h>
-      #include <d3d12.h>
-      ID3D12Device1 *device;
-      #if WDK_NTDDI_VERSION > 0x0A000008
-      int main(int argc, char **argv) { return 0; }
-      #endif" HAVE_D3D12_H)
+    check_include_file(d3d12.h HAVE_D3D12_H)
     check_include_file(ddraw.h HAVE_DDRAW_H)
     check_include_file(dsound.h HAVE_DSOUND_H)
     check_include_file(dinput.h HAVE_DINPUT_H)

--- a/configure
+++ b/configure
@@ -27513,36 +27513,12 @@ then :
   have_d3d11=yes
 fi
 
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for d3d12 Windows SDK version" >&5
-printf %s "checking for d3d12 Windows SDK version... " >&6; }
-        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-#include <winsdkver.h>
-#include <sdkddkver.h>
-#include <d3d12.h>
-ID3D12Device1 *device;
-#if WDK_NTDDI_VERSION <= 0x0A000008
-asdf
-#endif
-
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
+        ac_fn_c_check_header_compile "$LINENO" "d3d12.h" "ac_cv_header_d3d12_h" "$ac_includes_default"
+if test "x$ac_cv_header_d3d12_h" = xyes
 then :
   have_d3d12=yes
-else $as_nop
-  have_d3d12=no
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $have_d3d12" >&5
-printf "%s\n" "$have_d3d12" >&6; }
+
         ac_fn_c_check_header_compile "$LINENO" "ddraw.h" "ac_cv_header_ddraw_h" "$ac_includes_default"
 if test "x$ac_cv_header_ddraw_h" = xyes
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -3343,17 +3343,7 @@ CheckDIRECTX()
     if test x$enable_directx = xyes; then
         AC_CHECK_HEADER(d3d9.h, have_d3d=yes)
         AC_CHECK_HEADER(d3d11_1.h, have_d3d11=yes)
-        AC_MSG_CHECKING(for d3d12 Windows SDK version)
-        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <winsdkver.h>
-#include <sdkddkver.h>
-#include <d3d12.h>
-ID3D12Device1 *device;
-#if WDK_NTDDI_VERSION <= 0x0A000008
-asdf
-#endif
-            ]])], [have_d3d12=yes],[have_d3d12=no])
-        AC_MSG_RESULT($have_d3d12)
+        AC_CHECK_HEADER(d3d12.h, have_d3d12=yes)
         AC_CHECK_HEADER(ddraw.h, have_ddraw=yes)
         AC_CHECK_HEADER(dsound.h, have_dsound=yes)
         AC_CHECK_HEADER(dinput.h, have_dinput=yes)

--- a/src/render/direct3d12/SDL_render_d3d12.c
+++ b/src/render/direct3d12/SDL_render_d3d12.c
@@ -58,6 +58,11 @@
 #define SDL_COMPOSE_ERROR(str) SDL_STRINGIFY_ARG(__FUNCTION__) ", " str
 #endif
 
+/* DXGI_PRESENT flags are removed on Xbox */
+#if defined(__XBOXONE__) || defined(__XBOXSERIES__)
+#define DXGI_PRESENT_ALLOW_TEARING 0
+#endif
+
 #ifdef __cplusplus
 #define SAFE_RELEASE(X) \
     if (X) {            \


### PR DESCRIPTION
Backport of https://github.com/libsdl-org/SDL/pull/9867, and its successor 89a4d9ae67e82913af71a93611f396530a05f61d

Looks like running `autogen.sh` also fixes support for latest gcc.

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
