### PR TITLE
Tests: Use the main callback code macros

### DIFF
--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -22,6 +22,10 @@
 /* Ported from original test/common.c file. */
 #include <SDL3/SDL_test.h>
 
+#define SDL_MAIN_NOIMPL
+#define SDL_MAIN_USE_CALLBACKS
+#include <SDL3/SDL_main.h>
+
 static const char *common_usage[] = {
     "[-h | --help]",
     "[--trackmem]",
@@ -2400,19 +2404,19 @@ int SDLTest_CommonEventMainCallbacks(SDLTest_CommonState *state, const SDL_Event
             }
             break;
         case SDLK_ESCAPE:
-            return 1;
+            return SDL_MAIN_CALLBACK_EXIT_SUCCESS;
         default:
             break;
         }
         break;
     }
     case SDL_EVENT_QUIT:
-        return 1;
+        return SDL_MAIN_CALLBACK_EXIT_SUCCESS;
     default:
         break;
     }
 
-    return 0;  /* keep going */
+    return SDL_MAIN_CALLBACK_CONTINUE;
 }
 
 void SDLTest_CommonEvent(SDLTest_CommonState *state, SDL_Event *event, int *done)

--- a/test/loopwave.c
+++ b/test/loopwave.c
@@ -39,7 +39,7 @@ static int fillerup(void)
     if (SDL_GetAudioStreamQueued(stream) < minimum) {
         SDL_PutAudioStreamData(stream, wave.sound, wave.soundlen);
     }
-    return 0;
+    return SDL_MAIN_CALLBACK_CONTINUE;
 }
 
 int SDL_AppInit(void **appstate, int argc, char *argv[])
@@ -53,7 +53,7 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, 0);
     if (!state) {
-        return 1;
+        return SDL_MAIN_CALLBACK_EXIT_SUCCESS;
     }
 
     /* Enable standard application logging */
@@ -82,21 +82,21 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
     /* Load the SDL library */
     if (SDL_Init(SDL_INIT_AUDIO | SDL_INIT_EVENTS) < 0) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
     filename = GetResourceFilename(filename, "sample.wav");
 
     if (!filename) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s\n", SDL_GetError());
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
     /* Load the wave file into memory */
     if (SDL_LoadWAV(filename, &wave.spec, &wave.sound, &wave.soundlen) == -1) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't load %s: %s\n", filename, SDL_GetError());
         SDL_free(filename);
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
     SDL_free(filename);
@@ -112,16 +112,16 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
     stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_OUTPUT, &wave.spec, NULL, NULL);
     if (!stream) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create audio stream: %s\n", SDL_GetError());
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
     SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(stream));
 
-    return 0;
+    return SDL_MAIN_CALLBACK_CONTINUE;
 }
 
 int SDL_AppEvent(void *appstate, const SDL_Event *event)
 {
-    return (event->type == SDL_EVENT_QUIT) ? 1 : 0;
+    return (event->type == SDL_EVENT_QUIT) ? SDL_MAIN_CALLBACK_EXIT_SUCCESS : SDL_MAIN_CALLBACK_CONTINUE;
 }
 
 int SDL_AppIterate(void *appstate)

--- a/test/testaudio.c
+++ b/test/testaudio.c
@@ -1042,7 +1042,7 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
 
     state = SDLTest_CommonCreateState(argv, SDL_INIT_VIDEO | SDL_INIT_AUDIO);
     if (!state) {
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
     state->window_flags |= SDL_WINDOW_RESIZABLE;
@@ -1060,13 +1060,13 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
                 NULL
             };
             SDLTest_CommonLogUsage(state, argv[0], options);
-            return -1;
+            return SDL_MAIN_CALLBACK_EXIT_FAILURE;
         }
         i += consumed;
     }
 
     if (!SDLTest_CommonInit(state)) {
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
     if (state->audio_id) {
@@ -1088,7 +1088,7 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
     CreateDefaultPhysicalDevice(SDL_FALSE);
     CreateDefaultPhysicalDevice(SDL_TRUE);
 
-    return 0;
+    return SDL_MAIN_CALLBACK_CONTINUE;
 }
 
 
@@ -1229,7 +1229,7 @@ int SDL_AppIterate(void *appstate)
         SDL_Delay(10);
     }
 
-    return 0;  /* keep going. */
+    return SDL_MAIN_CALLBACK_CONTINUE;
 }
 
 void SDL_AppQuit(void *appstate)

--- a/test/testaudiocapture.c
+++ b/test/testaudiocapture.c
@@ -37,7 +37,7 @@ int SDL_AppInit(void **appstate, int argc, char **argv)
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, 0);
     if (!state) {
-        return 1;
+        return SDL_MAIN_CALLBACK_EXIT_SUCCESS;
     }
 
     /* Enable standard application logging */
@@ -57,7 +57,7 @@ int SDL_AppInit(void **appstate, int argc, char **argv)
         if (consumed <= 0) {
             static const char *options[] = { "[device_name]", NULL };
             SDLTest_CommonLogUsage(state, argv[0], options);
-            return -1;
+            return SDL_MAIN_CALLBACK_EXIT_FAILURE;
         }
 
         i += consumed;
@@ -66,12 +66,12 @@ int SDL_AppInit(void **appstate, int argc, char **argv)
     /* Load the SDL library */
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO) < 0) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
-        return 1;
+        return SDL_MAIN_CALLBACK_EXIT_SUCCESS;
     }
 
     if (SDL_CreateWindowAndRenderer("testaudiocapture", 320, 240, 0, &window, &renderer) < 0) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create SDL window and renderer: %s\n", SDL_GetError());
-        return 1;
+        return SDL_MAIN_CALLBACK_EXIT_SUCCESS;
     }
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
     SDL_RenderClear(renderer);
@@ -104,17 +104,17 @@ int SDL_AppInit(void **appstate, int argc, char **argv)
     device = SDL_OpenAudioDevice(SDL_AUDIO_DEVICE_DEFAULT_OUTPUT, NULL);
     if (!device) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't open an audio device for playback: %s!\n", SDL_GetError());
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
     SDL_PauseAudioDevice(device);
     SDL_GetAudioDeviceFormat(device, &outspec, NULL);
     stream_out = SDL_CreateAudioStream(&outspec, &outspec);
     if (!stream_out) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create an audio stream for playback: %s!\n", SDL_GetError());
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     } else if (SDL_BindAudioStream(device, stream_out) == -1) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't bind an audio stream for playback: %s!\n", SDL_GetError());
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
     SDL_Log("Opening capture device %s%s%s...\n",
@@ -125,33 +125,33 @@ int SDL_AppInit(void **appstate, int argc, char **argv)
     device = SDL_OpenAudioDevice(want_device, NULL);
     if (!device) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't open an audio device for capture: %s!\n", SDL_GetError());
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
     SDL_PauseAudioDevice(device);
     SDL_GetAudioDeviceFormat(device, &inspec, NULL);
     stream_in = SDL_CreateAudioStream(&inspec, &inspec);
     if (!stream_in) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create an audio stream for capture: %s!\n", SDL_GetError());
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     } else if (SDL_BindAudioStream(device, stream_in) == -1) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't bind an audio stream for capture: %s!\n", SDL_GetError());
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
     SDL_SetAudioStreamFormat(stream_in, NULL, &outspec);  /* make sure we output at the playback format. */
 
     SDL_Log("Ready! Hold down mouse or finger to record!\n");
 
-    return 0;
+    return SDL_MAIN_CALLBACK_CONTINUE;
 }
 
 int SDL_AppEvent(void *appstate, const SDL_Event *event)
 {
     if (event->type == SDL_EVENT_QUIT) {
-        return 1;  /* terminate as success. */
+        return SDL_MAIN_CALLBACK_EXIT_SUCCESS;
     } else if (event->type == SDL_EVENT_KEY_DOWN) {
         if (event->key.keysym.sym == SDLK_ESCAPE) {
-            return 1;  /* terminate as success. */
+            return SDL_MAIN_CALLBACK_EXIT_SUCCESS;
         }
     } else if (event->type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
         if (event->button.button == 1) {
@@ -166,7 +166,7 @@ int SDL_AppEvent(void *appstate, const SDL_Event *event)
             SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(stream_out));
         }
     }
-    return 0;  /* keep going. */
+    return SDL_MAIN_CALLBACK_CONTINUE;
 }
 
 int SDL_AppIterate(void *appstate)
@@ -185,14 +185,14 @@ int SDL_AppIterate(void *appstate)
         const int br = SDL_GetAudioStreamData(stream_in, buf, sizeof(buf));
         if (br < 0) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to read from input audio stream: %s\n", SDL_GetError());
-            return -1;   /* quit the app, report failure. */
+            return SDL_MAIN_CALLBACK_EXIT_FAILURE;
         } else if (SDL_PutAudioStreamData(stream_out, buf, br) < 0) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to write to output audio stream: %s\n", SDL_GetError());
-            return -1;   /* quit the app, report failure. */
+            return SDL_MAIN_CALLBACK_EXIT_FAILURE;
         }
     }
 
-    return 0;  /* keep app going. */
+    return SDL_MAIN_CALLBACK_CONTINUE;
 }
 
 void SDL_AppQuit(void *appstate)

--- a/test/testcamera.c
+++ b/test/testcamera.c
@@ -34,14 +34,14 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, SDL_INIT_VIDEO | SDL_INIT_CAMERA);
     if (!state) {
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
     /* Enable standard application logging */
     SDL_SetLogPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
 
     if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
     state->num_windows = 1;
@@ -49,13 +49,13 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
     /* Load the SDL library */
     if (!SDLTest_CommonInit(state)) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
     window = state->windows[0];
     if (!window) {
         SDL_Log("Couldn't create window: %s", SDL_GetError());
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
     SDL_SetLogPriorities(SDL_LOG_PRIORITY_VERBOSE);
@@ -63,13 +63,13 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
     renderer = state->renderers[0];
     if (!renderer) {
         /* SDL_Log("Couldn't create renderer: %s", SDL_GetError()); */
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
     SDL_CameraDeviceID *devices = SDL_GetCameraDevices(&devcount);
     if (!devices) {
         SDL_Log("SDL_GetCameraDevices failed: %s", SDL_GetError());
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
     SDL_Log("Saw %d camera devices.", devcount);
@@ -94,7 +94,7 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
 
     if (!devid) {
         SDL_Log("No cameras available?");
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
     SDL_CameraSpec *pspec = &spec;
@@ -104,10 +104,10 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
     camera = SDL_OpenCameraDevice(devid, pspec);
     if (!camera) {
         SDL_Log("Failed to open camera device: %s", SDL_GetError());
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
-    return 0;  /* start the main app loop. */
+    return SDL_MAIN_CALLBACK_CONTINUE;
 }
 
 
@@ -115,7 +115,7 @@ static int FlipCamera(void)
 {
     static Uint64 last_flip = 0;
     if ((SDL_GetTicks() - last_flip) < 3000) {  /* must wait at least 3 seconds between flips. */
-        return 0;
+        return SDL_MAIN_CALLBACK_CONTINUE;
     }
 
     if (camera) {
@@ -145,14 +145,14 @@ static int FlipCamera(void)
             camera = SDL_OpenCameraDevice(nextcam, NULL);
             if (!camera) {
                 SDL_Log("Failed to open camera device: %s", SDL_GetError());
-                return -1;
+                return SDL_MAIN_CALLBACK_EXIT_FAILURE;
             }
 
             last_flip = SDL_GetTicks();
         }
     }
 
-    return 0;
+    return SDL_MAIN_CALLBACK_CONTINUE;
 }
 
 int SDL_AppEvent(void *appstate, const SDL_Event *event)
@@ -162,10 +162,10 @@ int SDL_AppEvent(void *appstate, const SDL_Event *event)
             const SDL_Keycode sym = event->key.keysym.sym;
             if (sym == SDLK_ESCAPE || sym == SDLK_AC_BACK) {
                 SDL_Log("Key : Escape!");
-                return 1;
+                return SDL_MAIN_CALLBACK_EXIT_SUCCESS;
             } else if (sym == SDLK_SPACE) {
                 FlipCamera();
-                return 0;
+                return SDL_MAIN_CALLBACK_CONTINUE;
             }
             break;
         }
@@ -182,7 +182,7 @@ int SDL_AppEvent(void *appstate, const SDL_Event *event)
             SDL_Log("Camera approved!");
             if (SDL_GetCameraFormat(camera, &spec) < 0) {
                 SDL_Log("Couldn't get camera spec: %s", SDL_GetError());
-                return -1;
+                return SDL_MAIN_CALLBACK_EXIT_FAILURE;
             }
 
             /* Resize the window to match */
@@ -193,14 +193,14 @@ int SDL_AppEvent(void *appstate, const SDL_Event *event)
             texture = SDL_CreateTexture(renderer, spec.format, SDL_TEXTUREACCESS_STREAMING, spec.width, spec.height);
             if (!texture) {
                 SDL_Log("Couldn't create texture: %s", SDL_GetError());
-                return -1;
+                return SDL_MAIN_CALLBACK_EXIT_FAILURE;
             }
             break;
 
         case SDL_EVENT_CAMERA_DEVICE_DENIED:
             SDL_Log("Camera denied!");
             SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Camera permission denied!", "User denied access to the camera!", window);
-            return -1;
+            return SDL_MAIN_CALLBACK_EXIT_FAILURE;
         default:
             break;
     }
@@ -258,7 +258,7 @@ int SDL_AppIterate(void *appstate)
 
     SDL_RenderPresent(renderer);
 
-    return 0;  /* keep iterating. */
+    return SDL_MAIN_CALLBACK_CONTINUE;
 }
 
 void SDL_AppQuit(void *appstate)

--- a/test/testdropfile.c
+++ b/test/testdropfile.c
@@ -63,7 +63,7 @@ int SDL_AppIterate(void *appstate)
         }
         SDL_RenderPresent(renderer);
     }
-    return 0;  /* keep going */
+    return SDL_MAIN_CALLBACK_CONTINUE;
 }
 
 int SDL_AppInit(void **appstate, int argc, char *argv[]) {
@@ -74,7 +74,7 @@ int SDL_AppInit(void **appstate, int argc, char *argv[]) {
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, SDL_INIT_VIDEO);
     if (!state) {
-        return -1;  /* terminate with an error */
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
     /* Enable standard application logging */
@@ -107,10 +107,10 @@ int SDL_AppInit(void **appstate, int argc, char *argv[]) {
     *appstate = dialog;
 
     dialog->state = state;
-    return 0; /* continue */
+    return SDL_MAIN_CALLBACK_CONTINUE;
 onerror:
     SDLTest_CommonQuit(state);
-    return -1;  /* terminate with an error */
+    return SDL_MAIN_CALLBACK_EXIT_FAILURE;
 }
 
 void SDL_AppQuit(void *appstate)

--- a/test/testsprite.c
+++ b/test/testsprite.c
@@ -422,7 +422,7 @@ int SDL_AppIterate(void *appstate)
         frames = 0;
     }
 
-    return 0;  /* keep going */
+    return SDL_MAIN_CALLBACK_CONTINUE;
 }
 
 int SDL_AppInit(void **appstate, int argc, char *argv[])
@@ -437,7 +437,7 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, SDL_INIT_VIDEO);
     if (!state) {
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
     for (i = 1; i < argc;) {
@@ -495,7 +495,7 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
                          * Use an 'indices' array */
                         use_rendergeometry = 2;
                     } else {
-                        return -1;
+                        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
                     }
                 }
                 consumed = 2;
@@ -520,12 +520,12 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
                 NULL
             };
             SDLTest_CommonLogUsage(state, argv[0], options);
-            return -1;
+            return SDL_MAIN_CALLBACK_EXIT_FAILURE;
         }
         i += consumed;
     }
     if (!SDLTest_CommonInit(state)) {
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
     /* Create the windows, initialize the renderers, and load the textures */
@@ -533,7 +533,7 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
         (SDL_Texture **)SDL_malloc(state->num_windows * sizeof(*sprites));
     if (!sprites) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!\n");
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
     for (i = 0; i < state->num_windows; ++i) {
         SDL_Renderer *renderer = state->renderers[i];
@@ -541,7 +541,7 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
         SDL_RenderClear(renderer);
     }
     if (LoadSprite(icon) < 0) {
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
     /* Allocate memory for the sprite info */
@@ -549,7 +549,7 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
     velocities = (SDL_FRect *)SDL_malloc(num_sprites * sizeof(*velocities));
     if (!positions || !velocities) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!\n");
-        return -1;
+        return SDL_MAIN_CALLBACK_EXIT_FAILURE;
     }
 
     /* Position sprites and set their velocities using the fuzzer */
@@ -578,6 +578,6 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
     frames = 0;
     next_fps_check = SDL_GetTicks() + fps_check_delay;
 
-    return 0;
+    return SDL_MAIN_CALLBACK_CONTINUE;
 }
 


### PR DESCRIPTION
Use the new main callback code macros in the tests that use those callbacks, as discussed in #9883.