### PR TITLE
wayland: Implement animated system cursors when not using the cursor …

### DIFF
--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -110,6 +110,7 @@ struct SDL_WaylandInput
     struct zwp_input_timestamps_v1 *touch_timestamps;
     SDL_WindowData *pointer_focus;
     SDL_WindowData *keyboard_focus;
+    struct Wayland_CursorData *current_cursor;
     Uint32 keyboard_id;
     Uint32 pointer_id;
     uint32_t pointer_enter_serial;


### PR DESCRIPTION
…shape protocol

If a system cursor has more than one frame, create a frame callback to run the animation and attach new buffers as necessary to animate the cursor.

Fixes #9897