### PR TITLE
Allow building the Raspberry Pi video driver with standard EGL headers (SDL2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,7 +467,7 @@ dep_option(SDL_WAYLAND_SHARED      "Dynamically load Wayland support" ON "SDL_WA
 dep_option(SDL_WAYLAND_LIBDECOR    "Use client-side window decorations on Wayland" ON "SDL_WAYLAND" OFF)
 dep_option(SDL_WAYLAND_LIBDECOR_SHARED     "Dynamically load libdecor support" ON "SDL_WAYLAND_LIBDECOR;SDL_WAYLAND_SHARED" OFF)
 dep_option(SDL_WAYLAND_QT_TOUCH    "QtWayland server support for Wayland video driver" ON "SDL_WAYLAND" OFF)
-set_option(SDL_RPI                 "Use Raspberry Pi video driver" ${UNIX_SYS})
+set_option(SDL_RPI                 "Use Raspberry Pi 0-3 video driver" ${UNIX_SYS})
 set_option(SDL_COCOA               "Use Cocoa video driver" ${APPLE})
 set_option(SDL_DIRECTX             "Use DirectX for Windows audio/video" ${WINDOWS})
 set_option(SDL_XINPUT              "Use Xinput for Windows" ${WINDOWS})

--- a/cmake/sdlchecks.cmake
+++ b/cmake/sdlchecks.cmake
@@ -1277,13 +1277,18 @@ endmacro()
 # - n/a
 macro(CheckRPI)
   if(SDL_RPI)
-    pkg_check_modules(VIDEO_RPI bcm_host brcmegl)
+    pkg_check_modules(VIDEO_RPI bcm_host)
     if (NOT VIDEO_RPI_FOUND)
       set(VIDEO_RPI_INCLUDE_DIRS "/opt/vc/include" "/opt/vc/include/interface/vcos/pthreads" "/opt/vc/include/interface/vmcs_host/linux/" )
       set(VIDEO_RPI_LIBRARY_DIRS "/opt/vc/lib" )
       set(VIDEO_RPI_LIBRARIES bcm_host )
-      set(VIDEO_RPI_LDFLAGS "-Wl,-rpath,/opt/vc/lib")
     endif()
+
+    pkg_check_modules(VIDEO_RPI_EGL brcmegl)
+    if (NOT VIDEO_RPI_EGL_FOUND)
+      set(VIDEO_RPI_EGL_LDFLAGS "-Wl,-rpath,/opt/vc/lib")
+    endif()
+
     listtostr(VIDEO_RPI_INCLUDE_DIRS VIDEO_RPI_INCLUDE_FLAGS "-I")
     listtostr(VIDEO_RPI_LIBRARY_DIRS VIDEO_RPI_LIBRARY_FLAGS "-L")
 
@@ -1292,9 +1297,7 @@ macro(CheckRPI)
     set(CMAKE_REQUIRED_LIBRARIES "${VIDEO_RPI_LIBRARIES}")
     check_c_source_compiles("
         #include <bcm_host.h>
-        #include <EGL/eglplatform.h>
         int main(int argc, char **argv) {
-          EGL_DISPMANX_WINDOW_T window;
           bcm_host_init();
         }" HAVE_RPI)
     set(CMAKE_REQUIRED_FLAGS "${ORIG_CMAKE_REQUIRED_FLAGS}")
@@ -1308,7 +1311,7 @@ macro(CheckRPI)
       list(APPEND EXTRA_LIBS ${VIDEO_RPI_LIBRARIES})
       # !!! FIXME: shouldn't be using CMAKE_C_FLAGS, right?
       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${VIDEO_RPI_INCLUDE_FLAGS} ${VIDEO_RPI_LIBRARY_FLAGS}")
-      list(APPEND EXTRA_LDFLAGS ${VIDEO_RPI_LDFLAGS})
+      list(APPEND EXTRA_LDFLAGS ${VIDEO_RPI_LDFLAGS} ${VIDEO_RPI_EGL_LDFLAGS})
     endif()
   endif()
 endmacro()

--- a/configure.ac
+++ b/configure.ac
@@ -1848,18 +1848,27 @@ CheckNativeClient()
 CheckRPI()
 {
     AC_ARG_ENABLE(video-rpi,
-[AS_HELP_STRING([--enable-video-rpi], [use Raspberry Pi 2/3 video driver [default=yes]])],
+[AS_HELP_STRING([--enable-video-rpi], [use Raspberry Pi 0-3 video driver [default=yes]])],
                   , enable_video_rpi=yes)
     if test x$enable_video = xyes -a x$enable_video_rpi = xyes; then
-        PKG_CHECK_MODULES([RPI], [bcm_host brcmegl], video_rpi=yes, video_rpi=no)
+        PKG_CHECK_MODULES([RPI], [bcm_host], video_rpi=yes, video_rpi=no)
+        PKG_CHECK_MODULES([RPI_EGL], [brcmegl], video_rpi_egl=yes, video_rpi_egl=no)
 
         if test x$video_rpi = xno; then
             if test x$ARCH = xnetbsd; then
                 RPI_CFLAGS="-I/usr/pkg/include -I/usr/pkg/include/interface/vcos/pthreads -I/usr/pkg/include/interface/vmcs_host/linux"
-                RPI_LIBS="-Wl,-R/usr/pkg/lib -L/usr/pkg/lib -lbcm_host"
+                RPI_LIBS="-L/usr/pkg/lib -lbcm_host"
             else
                 RPI_CFLAGS="-I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux"
-                RPI_LIBS="-Wl,-rpath,/opt/vc/lib -L/opt/vc/lib -lbcm_host"
+                RPI_LIBS="-L/opt/vc/lib -lbcm_host"
+            fi
+        fi
+
+        if test x$video_rpi_egl = xno; then
+            if test x$ARCH = xnetbsd; then
+                RPI_EGL_LIBS="-Wl,-R/usr/pkg/lib"
+            else
+                RPI_EGL_LIBS="-Wl,-rpath,/opt/vc/lib"
             fi
         fi
 
@@ -1867,15 +1876,13 @@ CheckRPI()
         ac_save_cflags="$CFLAGS"; ac_save_libs="$LIBS"
 
         # Add the Raspberry Pi compiler flags and libraries
-        CFLAGS="$CFLAGS $RPI_CFLAGS"; LIBS="$LIBS $RPI_LIBS"
+        CFLAGS="$CFLAGS $RPI_CFLAGS"; LIBS="$LIBS $RPI_EGL_LIBS $RPI_LIBS"
 
-        AC_MSG_CHECKING(for Raspberry Pi 2/3)
+        AC_MSG_CHECKING(for Raspberry Pi 0-3)
         have_video_rpi=no
         AC_LINK_IFELSE([AC_LANG_PROGRAM([[
           #include <bcm_host.h>
-          #include <EGL/eglplatform.h>
         ]], [[
-          EGL_DISPMANX_WINDOW_T window;
           bcm_host_init();
         ]])], [have_video_rpi=yes],[])
         AC_MSG_RESULT($have_video_rpi)
@@ -1887,7 +1894,7 @@ CheckRPI()
             CFLAGS="$CFLAGS $RPI_CFLAGS"
             SDL_CFLAGS="$SDL_CFLAGS $RPI_CFLAGS"
             EXTRA_CFLAGS="$EXTRA_CFLAGS $RPI_CFLAGS"
-            EXTRA_LDFLAGS="$EXTRA_LDFLAGS $RPI_LIBS"
+            EXTRA_LDFLAGS="$EXTRA_LDFLAGS $RPI_EGL_LIBS $RPI_LIBS"
             SOURCES="$SOURCES $srcdir/src/video/raspberry/*.c"
             AC_DEFINE(SDL_VIDEO_DRIVER_RPI, 1, [ ])
             SUMMARY_video="${SUMMARY_video} rpi"

--- a/src/video/raspberry/SDL_rpivideo.h
+++ b/src/video/raspberry/SDL_rpivideo.h
@@ -30,6 +30,14 @@
 #include "EGL/egl.h"
 #include "EGL/eglext.h"
 
+/* This must match the definition of EGL_DISPMANX_WINDOW_T in EGL/eglplatform.h,
+   and is defined here to allow compiling with standard headers. */
+typedef struct {
+    DISPMANX_ELEMENT_HANDLE_T element;
+    int width;
+    int height;
+} SDL_EGL_DISPMANX_WINDOW_T;
+
 typedef struct SDL_VideoData
 {
     uint32_t egl_refcount; /* OpenGL ES reference count              */
@@ -42,7 +50,7 @@ typedef struct SDL_DisplayData
 
 typedef struct SDL_WindowData
 {
-    EGL_DISPMANX_WINDOW_T dispman_window;
+    SDL_EGL_DISPMANX_WINDOW_T dispman_window;
 #ifdef SDL_VIDEO_OPENGL_EGL
     EGLSurface egl_surface;
 #endif


### PR DESCRIPTION
This is required with newer versions of Raspberry Pi OS that don't supply the custom EGL headers with the rest of the dispmanx headers.