### PR TITLE
Annotate pointer parameters and returned pointers to help with language bindings

### DIFF
--- a/include/SDL3/SDL_assert.h
+++ b/include/SDL3/SDL_assert.h
@@ -232,9 +232,9 @@ typedef struct SDL_AssertData
  *
  * Use the SDL_assert* macros instead.
  *
- * \param data assert data structure
- * \param func function name
- * \param file file name
+ * \param[inout] data assert data structure
+ * \param[in] func function name
+ * \param[in] file file name
  * \param line line number
  * \returns assert state
  *
@@ -456,9 +456,9 @@ typedef SDL_AssertState (SDLCALL *SDL_AssertionHandler)(
  *
  * This callback is NOT reset to SDL's internal handler upon SDL_Quit()!
  *
- * \param handler the SDL_AssertionHandler function to call when an assertion
+ * \param[in,opt] handler the SDL_AssertionHandler function to call when an assertion
  *                fails or NULL for the default handler
- * \param userdata a pointer that is passed to `handler`
+ * \param[inout,opt] userdata a pointer that is passed to `handler`
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -498,7 +498,7 @@ extern SDL_DECLSPEC SDL_AssertionHandler SDLCALL SDL_GetDefaultAssertionHandler(
  * will always be NULL for the default handler. If you don't care about this
  * data, it is safe to pass a NULL pointer to this function to ignore it.
  *
- * \param puserdata pointer which is filled with the "userdata" pointer that
+ * \param[out,opt] puserdata pointer which is filled with the "userdata" pointer that
  *                  was passed to SDL_SetAssertionHandler()
  * \returns the SDL_AssertionHandler that is called when an assert triggers.
  *

--- a/include/SDL3/SDL_atomic.h
+++ b/include/SDL3/SDL_atomic.h
@@ -87,7 +87,7 @@ typedef int SDL_SpinLock;
  * ***Please note that spinlocks are dangerous if you don't know what you're
  * doing. Please be careful using any sort of spinlock!***
  *
- * \param lock a pointer to a lock variable
+ * \param[inout] lock a pointer to a lock variable
  * \returns SDL_TRUE if the lock succeeded, SDL_FALSE if the lock is already
  *          held.
  *
@@ -104,7 +104,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_TryLockSpinlock(SDL_SpinLock *lock);
  * ***Please note that spinlocks are dangerous if you don't know what you're
  * doing. Please be careful using any sort of spinlock!***
  *
- * \param lock a pointer to a lock variable
+ * \param[inout] lock a pointer to a lock variable
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -121,7 +121,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_LockSpinlock(SDL_SpinLock *lock);
  * ***Please note that spinlocks are dangerous if you don't know what you're
  * doing. Please be careful using any sort of spinlock!***
  *
- * \param lock a pointer to a lock variable
+ * \param[inout] lock a pointer to a lock variable
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -333,7 +333,7 @@ typedef struct SDL_AtomicInt { int value; } SDL_AtomicInt;
  * ***Note: If you don't know what this function is for, you shouldn't use
  * it!***
  *
- * \param a a pointer to an SDL_AtomicInt variable to be modified
+ * \param[inout] a a pointer to an SDL_AtomicInt variable to be modified
  * \param oldval the old value
  * \param newval the new value
  * \returns SDL_TRUE if the atomic variable was set, SDL_FALSE otherwise.
@@ -354,7 +354,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_AtomicCompareAndSwap(SDL_AtomicInt *a, 
  * ***Note: If you don't know what this function is for, you shouldn't use
  * it!***
  *
- * \param a a pointer to an SDL_AtomicInt variable to be modified
+ * \param[inout] a a pointer to an SDL_AtomicInt variable to be modified
  * \param v the desired value
  * \returns the previous value of the atomic variable.
  *
@@ -372,7 +372,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_AtomicSet(SDL_AtomicInt *a, int v);
  * ***Note: If you don't know what this function is for, you shouldn't use
  * it!***
  *
- * \param a a pointer to an SDL_AtomicInt variable
+ * \param[in] a a pointer to an SDL_AtomicInt variable
  * \returns the current value of an atomic variable.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -391,7 +391,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_AtomicGet(SDL_AtomicInt *a);
  * ***Note: If you don't know what this function is for, you shouldn't use
  * it!***
  *
- * \param a a pointer to an SDL_AtomicInt variable to be modified
+ * \param[inout] a a pointer to an SDL_AtomicInt variable to be modified
  * \param v the desired value to add
  * \returns the previous value of the atomic variable.
  *
@@ -411,7 +411,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_AtomicAdd(SDL_AtomicInt *a, int v);
  *
  * ***Note: If you don't know what this macro is for, you shouldn't use it!***
  *
- * \param a a pointer to an SDL_AtomicInt to increment.
+ * \param[inout] a a pointer to an SDL_AtomicInt to increment.
  * \returns the previous value of the atomic variable.
  *
  * \since This macro is available since SDL 3.0.0.
@@ -428,7 +428,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_AtomicAdd(SDL_AtomicInt *a, int v);
  *
  * ***Note: If you don't know what this macro is for, you shouldn't use it!***
  *
- * \param a a pointer to an SDL_AtomicInt to increment.
+ * \param[inout] a a pointer to an SDL_AtomicInt to increment.
  * \returns SDL_TRUE if the variable reached zero after decrementing,
  *          SDL_FALSE otherwise
  *
@@ -445,9 +445,9 @@ extern SDL_DECLSPEC int SDLCALL SDL_AtomicAdd(SDL_AtomicInt *a, int v);
  * ***Note: If you don't know what this function is for, you shouldn't use
  * it!***
  *
- * \param a a pointer to a pointer
- * \param oldval the old pointer value
- * \param newval the new pointer value
+ * \param[inout] a a pointer to a pointer
+ * \param[in] oldval the old pointer value
+ * \param[in] newval the new pointer value
  * \returns SDL_TRUE if the pointer was set, SDL_FALSE otherwise.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -466,8 +466,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_AtomicCompareAndSwapPointer(void **a, v
  * ***Note: If you don't know what this function is for, you shouldn't use
  * it!***
  *
- * \param a a pointer to a pointer
- * \param v the desired pointer value
+ * \param[inout] a a pointer to a pointer
+ * \param[in] v the desired pointer value
  * \returns the previous value of the pointer.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -485,7 +485,7 @@ extern SDL_DECLSPEC void* SDLCALL SDL_AtomicSetPtr(void **a, void* v);
  * ***Note: If you don't know what this function is for, you shouldn't use
  * it!***
  *
- * \param a a pointer to a pointer
+ * \param[in] a a pointer to a pointer
  * \returns the current value of a pointer.
  *
  * \threadsafety It is safe to call this function from any thread.

--- a/include/SDL3/SDL_audio.h
+++ b/include/SDL3/SDL_audio.h
@@ -423,9 +423,9 @@ extern SDL_DECLSPEC const char *SDLCALL SDL_GetCurrentAudioDriver(void);
  * If this function returns NULL, to signify an error, `*count` will be set to
  * zero.
  *
- * \param count a pointer filled in with the number of devices returned. NULL
+ * \param[out,opt] count a pointer filled in with the number of devices returned. NULL
  *              is allowed.
- * \returns a 0 terminated array of device instance IDs which should be freed
+ * \returns[own] a 0 terminated array of device instance IDs which should be freed
  *          with SDL_free(), or NULL on error; call SDL_GetError() for more
  *          details.
  *
@@ -452,9 +452,9 @@ extern SDL_DECLSPEC SDL_AudioDeviceID *SDLCALL SDL_GetAudioOutputDevices(int *co
  * If this function returns NULL, to signify an error, `*count` will be set to
  * zero.
  *
- * \param count a pointer filled in with the number of devices returned. NULL
+ * \param[out,opt] count a pointer filled in with the number of devices returned. NULL
  *              is allowed.
- * \returns a 0 terminated array of device instance IDs which should be freed
+ * \returns[own] a 0 terminated array of device instance IDs which should be freed
  *          with SDL_free(), or NULL on error; call SDL_GetError() for more
  *          details.
  *
@@ -509,8 +509,8 @@ extern SDL_DECLSPEC char *SDLCALL SDL_GetAudioDeviceName(SDL_AudioDeviceID devid
  * playback timing. Most apps do not need this.
  *
  * \param devid the instance ID of the device to query.
- * \param spec On return, will be filled with device details.
- * \param sample_frames Pointer to store device buffer size, in sample frames.
+ * \param[out] spec On return, will be filled with device details.
+ * \param[out,opt] sample_frames Pointer to store device buffer size, in sample frames.
  *                      Can be NULL.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -583,7 +583,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetAudioDeviceFormat(SDL_AudioDeviceID devid
  *              SDL_AUDIO_DEVICE_DEFAULT_OUTPUT or
  *              SDL_AUDIO_DEVICE_DEFAULT_CAPTURE for the most reasonable
  *              default device.
- * \param spec the requested device configuration. Can be NULL to use
+ * \param[in,opt] spec the requested device configuration. Can be NULL to use
  *             reasonable defaults.
  * \returns The device ID on success, 0 on error; call SDL_GetError() for more
  *          information.
@@ -721,7 +721,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_CloseAudioDevice(SDL_AudioDeviceID devid);
  * format at any time.
  *
  * \param devid an audio device to bind a stream to.
- * \param streams an array of audio streams to unbind.
+ * \param[inout] streams an array of audio streams to unbind.
  * \param num_streams Number streams listed in the `streams` array.
  * \returns 0 on success, -1 on error; call SDL_GetError() for more
  *          information.
@@ -743,7 +743,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_BindAudioStreams(SDL_AudioDeviceID devid, SD
  * `SDL_BindAudioStreams(devid, &stream, 1)`.
  *
  * \param devid an audio device to bind a stream to.
- * \param stream an audio stream to bind to a device.
+ * \param[inout] stream an audio stream to bind to a device.
  * \returns 0 on success, -1 on error; call SDL_GetError() for more
  *          information.
  *
@@ -766,7 +766,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_BindAudioStream(SDL_AudioDeviceID devid, SDL
  *
  * Unbinding a stream that isn't bound to a device is a legal no-op.
  *
- * \param streams an array of audio streams to unbind.
+ * \param[inout] streams an array of audio streams to unbind.
  * \param num_streams Number streams listed in the `streams` array.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -783,7 +783,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_UnbindAudioStreams(SDL_AudioStream **stream
  * This is a convenience function, equivalent to calling
  * `SDL_UnbindAudioStreams(&stream, 1)`.
  *
- * \param stream an audio stream to unbind from a device.
+ * \param[inout] stream an audio stream to unbind from a device.
  *
  * \threadsafety It is safe to call this function from any thread.
  *
@@ -801,7 +801,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_UnbindAudioStream(SDL_AudioStream *stream);
  * If not bound, or invalid, this returns zero, which is not a valid device
  * ID.
  *
- * \param stream the audio stream to query.
+ * \param[inout] stream the audio stream to query.
  * \returns The bound audio device, or 0 if not bound or invalid.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -816,9 +816,9 @@ extern SDL_DECLSPEC SDL_AudioDeviceID SDLCALL SDL_GetAudioStreamDevice(SDL_Audio
 /**
  * Create a new audio stream.
  *
- * \param src_spec The format details of the input audio
- * \param dst_spec The format details of the output audio
- * \returns a new audio stream on success, or NULL on failure.
+ * \param[in,opt] src_spec The format details of the input audio
+ * \param[in,opt] dst_spec The format details of the output audio
+ * \returns[own] a new audio stream on success, or NULL on failure.
  *
  * \threadsafety It is safe to call this function from any thread.
  *
@@ -837,7 +837,7 @@ extern SDL_DECLSPEC SDL_AudioStream *SDLCALL SDL_CreateAudioStream(const SDL_Aud
 /**
  * Get the properties associated with an audio stream.
  *
- * \param stream the SDL_AudioStream to query
+ * \param[inout] stream the SDL_AudioStream to query
  * \returns a valid property ID on success or 0 on failure; call
  *          SDL_GetError() for more information.
  *
@@ -851,9 +851,9 @@ extern SDL_DECLSPEC SDL_PropertiesID SDLCALL SDL_GetAudioStreamProperties(SDL_Au
 /**
  * Query the current format of an audio stream.
  *
- * \param stream the SDL_AudioStream to query.
- * \param src_spec Where to store the input audio format; ignored if NULL.
- * \param dst_spec Where to store the output audio format; ignored if NULL.
+ * \param[inout] stream the SDL_AudioStream to query.
+ * \param[out,opt] src_spec Where to store the input audio format; ignored if NULL.
+ * \param[out,opt] dst_spec Where to store the output audio format; ignored if NULL.
  * \returns 0 on success, or -1 on error.
  *
  * \threadsafety It is safe to call this function from any thread, as it holds
@@ -878,10 +878,10 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetAudioStreamFormat(SDL_AudioStream *stream
  * next sound file, and start putting that new data while the previous sound
  * file is still queued, and everything will still play back correctly.
  *
- * \param stream The stream the format is being changed
- * \param src_spec The new format of the audio input; if NULL, it is not
+ * \param[inout] stream The stream the format is being changed
+ * \param[in,opt] src_spec The new format of the audio input; if NULL, it is not
  *                 changed.
- * \param dst_spec The new format of the audio output; if NULL, it is not
+ * \param[in,opt] dst_spec The new format of the audio output; if NULL, it is not
  *                 changed.
  * \returns 0 on success, or -1 on error.
  *
@@ -900,7 +900,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetAudioStreamFormat(SDL_AudioStream *stream
 /**
  * Get the frequency ratio of an audio stream.
  *
- * \param stream the SDL_AudioStream to query.
+ * \param[inout] stream the SDL_AudioStream to query.
  * \returns the frequency ratio of the stream, or 0.0 on error
  *
  * \threadsafety It is safe to call this function from any thread, as it holds
@@ -924,7 +924,7 @@ extern SDL_DECLSPEC float SDLCALL SDL_GetAudioStreamFrequencyRatio(SDL_AudioStre
  * This is applied during SDL_GetAudioStreamData, and can be continuously
  * changed to create various effects.
  *
- * \param stream The stream the frequency ratio is being changed
+ * \param[inout] stream The stream the frequency ratio is being changed
  * \param ratio The frequency ratio. 1.0 is normal speed. Must be between 0.01
  *              and 100.
  * \returns 0 on success, or -1 on error.
@@ -950,8 +950,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetAudioStreamFrequencyRatio(SDL_AudioStream
  * different than SDL2, where data was converted during the Put call and the
  * Get call would just dequeue the previously-converted data.
  *
- * \param stream The stream the audio data is being added to
- * \param buf A pointer to the audio data to add
+ * \param[inout] stream The stream the audio data is being added to
+ * \param[in] buf A pointer to the audio data to add
  * \param len The number of bytes to write to the stream
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -981,8 +981,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_PutAudioStreamData(SDL_AudioStream *stream, 
  * is different than SDL2, where that work was done while inputting new data
  * to the stream and requesting the output just copied the converted data.
  *
- * \param stream The stream the audio is being requested from
- * \param buf A buffer to fill with audio data
+ * \param[inout] stream The stream the audio is being requested from
+ * \param[out] buf A buffer to fill with audio data
  * \param len The maximum number of bytes to fill
  * \returns the number of bytes read from the stream, or -1 on error
  *
@@ -1011,7 +1011,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetAudioStreamData(SDL_AudioStream *stream, 
  * SDL_GetAudioStreamData before this function's return value is no longer
  * clamped.
  *
- * \param stream The audio stream to query
+ * \param[inout] stream The audio stream to query
  * \returns the number of converted/resampled bytes available.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -1043,7 +1043,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetAudioStreamAvailable(SDL_AudioStream *str
  * SDL_GetAudioStreamData before this function's return value is no longer
  * clamped.
  *
- * \param stream The audio stream to query
+ * \param[inout] stream The audio stream to query
  * \returns the number of bytes queued.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -1064,7 +1064,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetAudioStreamQueued(SDL_AudioStream *stream
  * audio gaps in the output. Generally this is intended to signal the end of
  * input, so the complete output becomes available.
  *
- * \param stream The audio stream to flush
+ * \param[inout] stream The audio stream to flush
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1082,7 +1082,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_FlushAudioStream(SDL_AudioStream *stream);
  * This drops any queued data, so there will be nothing to read from the
  * stream until more is added.
  *
- * \param stream The audio stream to clear
+ * \param[inout] stream The audio stream to clear
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1109,7 +1109,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_ClearAudioStream(SDL_AudioStream *stream);
  * audio streams. This might be useful while a game is paused, or a level is
  * loading, etc.
  *
- * \param stream The audio stream associated with the audio device to pause
+ * \param[inout] stream The audio stream associated with the audio device to pause
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1129,7 +1129,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_PauseAudioStreamDevice(SDL_AudioStream *stre
  * previously been paused. Once unpaused, any bound audio streams will begin
  * to progress again, and audio can be generated.
  *
- * \param stream The audio stream associated with the audio device to resume
+ * \param[inout] stream The audio stream associated with the audio device to resume
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1157,7 +1157,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_ResumeAudioStreamDevice(SDL_AudioStream *str
  * As this is just a wrapper over SDL_LockMutex for an internal lock; it has
  * all the same attributes (recursive locks are allowed, etc).
  *
- * \param stream The audio stream to lock.
+ * \param[inout] stream The audio stream to lock.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1175,7 +1175,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_LockAudioStream(SDL_AudioStream *stream);
  *
  * This unlocks an audio stream after a call to SDL_LockAudioStream.
  *
- * \param stream The audio stream to unlock.
+ * \param[inout] stream The audio stream to unlock.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1260,10 +1260,10 @@ typedef void (SDLCALL *SDL_AudioStreamCallback)(void *userdata, SDL_AudioStream 
  *
  * Setting a NULL function turns off the callback.
  *
- * \param stream the audio stream to set the new callback on.
- * \param callback the new callback function to call when data is added to the
+ * \param[inout] stream the audio stream to set the new callback on.
+ * \param[in,opt] callback the new callback function to call when data is added to the
  *                 stream.
- * \param userdata an opaque pointer provided to the callback for its own
+ * \param[inout,opt] userdata an opaque pointer provided to the callback for its own
  *                 personal use.
  * \returns 0 on success, -1 on error. This only fails if `stream` is NULL.
  *
@@ -1308,10 +1308,10 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetAudioStreamGetCallback(SDL_AudioStream *s
  *
  * Setting a NULL function turns off the callback.
  *
- * \param stream the audio stream to set the new callback on.
- * \param callback the new callback function to call when data is added to the
+ * \param[inout] stream the audio stream to set the new callback on.
+ * \param[in,opt] callback the new callback function to call when data is added to the
  *                 stream.
- * \param userdata an opaque pointer provided to the callback for its own
+ * \param[inout,opt] userdata an opaque pointer provided to the callback for its own
  *                 personal use.
  * \returns 0 on success, -1 on error. This only fails if `stream` is NULL.
  *
@@ -1335,7 +1335,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetAudioStreamPutCallback(SDL_AudioStream *s
  * device that was opened alongside this stream's creation will be closed,
  * too.
  *
- * \param stream The audio stream to destroy.
+ * \param[inout] stream The audio stream to destroy.
  *
  * \threadsafety It is safe to call this function from any thread.
  *
@@ -1386,14 +1386,14 @@ extern SDL_DECLSPEC void SDLCALL SDL_DestroyAudioStream(SDL_AudioStream *stream)
  *
  * \param devid an audio device to open, or SDL_AUDIO_DEVICE_DEFAULT_OUTPUT or
  *              SDL_AUDIO_DEVICE_DEFAULT_CAPTURE.
- * \param spec the audio stream's data format. Can be NULL.
- * \param callback A callback where the app will provide new data for
+ * \param[in,opt] spec the audio stream's data format. Can be NULL.
+ * \param[in,opt] callback A callback where the app will provide new data for
  *                 playback, or receive new data for capture. Can be NULL, in
  *                 which case the app will need to call SDL_PutAudioStreamData
  *                 or SDL_GetAudioStreamData as necessary.
- * \param userdata App-controlled pointer passed to callback. Can be NULL.
+ * \param[inout,opt] userdata App-controlled pointer passed to callback. Can be NULL.
  *                 Ignored if callback is NULL.
- * \returns an audio stream on success, ready to use. NULL on error; call
+ * \returns[own] an audio stream on success, ready to use. NULL on error; call
  *          SDL_GetError() for more information. When done with this stream,
  *          call SDL_DestroyAudioStream to free resources and close the
  *          device.
@@ -1483,8 +1483,8 @@ typedef void (SDLCALL *SDL_AudioPostmixCallback)(void *userdata, const SDL_Audio
  * Setting a NULL callback function disables any previously-set callback.
  *
  * \param devid The ID of an opened audio device.
- * \param callback A callback function to be called. Can be NULL.
- * \param userdata App-controlled pointer passed to callback. Can be NULL.
+ * \param[in,opt] callback A callback function to be called. Can be NULL.
+ * \param[inout,opt] userdata App-controlled pointer passed to callback. Can be NULL.
  * \returns zero on success, -1 on error; call SDL_GetError() for more
  *          information.
  *
@@ -1546,14 +1546,14 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetAudioPostmixCallback(SDL_AudioDeviceID de
  * SDL_LoadWAV("sample.wav", &spec, &buf, &len);
  * ```
  *
- * \param src The data source for the WAVE data
+ * \param[inout] src The data source for the WAVE data
  * \param closeio If SDL_TRUE, calls SDL_CloseIO() on `src` before returning,
  *                even in the case of an error
- * \param spec A pointer to an SDL_AudioSpec that will be set to the WAVE
+ * \param[out] spec A pointer to an SDL_AudioSpec that will be set to the WAVE
  *             data's format details on successful return
- * \param audio_buf A pointer filled with the audio data, allocated by the
+ * \param[out,own] audio_buf A pointer filled with the audio data, allocated by the
  *                  function
- * \param audio_len A pointer filled with the length of the audio data buffer
+ * \param[out] audio_len A pointer filled with the length of the audio data buffer
  *                  in bytes
  * \returns 0 on success. `audio_buf` will be filled with a pointer to an
  *          allocated buffer containing the audio data, and `audio_len` is
@@ -1586,12 +1586,12 @@ extern SDL_DECLSPEC int SDLCALL SDL_LoadWAV_IO(SDL_IOStream * src, SDL_bool clos
  * SDL_LoadWAV_IO(SDL_IOFromFile(path, "rb"), 1, spec, audio_buf, audio_len);
  * ```
  *
- * \param path The file path of the WAV file to open.
- * \param spec A pointer to an SDL_AudioSpec that will be set to the WAVE
+ * \param[in] path The file path of the WAV file to open.
+ * \param[out] spec A pointer to an SDL_AudioSpec that will be set to the WAVE
  *             data's format details on successful return.
- * \param audio_buf A pointer filled with the audio data, allocated by the
+ * \param[out,own] audio_buf A pointer filled with the audio data, allocated by the
  *                  function.
- * \param audio_len A pointer filled with the length of the audio data buffer
+ * \param[out] audio_len A pointer filled with the length of the audio data buffer
  *                  in bytes
  * \returns 0 on success. `audio_buf` will be filled with a pointer to an
  *          allocated buffer containing the audio data, and `audio_len` is
@@ -1634,8 +1634,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_LoadWAV(const char *path, SDL_AudioSpec * sp
  * SDL_MixAudio() is really only needed when you're mixing a single audio
  * stream with a volume adjustment.
  *
- * \param dst the destination for the mixed audio
- * \param src the source audio buffer to be mixed
+ * \param[inout] dst the destination for the mixed audio
+ * \param[in] src the source audio buffer to be mixed
  * \param format the SDL_AudioFormat structure representing the desired audio
  *               format
  * \param len the length of the audio buffer in bytes
@@ -1666,14 +1666,14 @@ extern SDL_DECLSPEC int SDLCALL SDL_MixAudio(Uint8 * dst,
  * use, so it's also less efficient than using one directly, if you need to
  * convert multiple times.
  *
- * \param src_spec The format details of the input audio
- * \param src_data The audio data to be converted
+ * \param[in] src_spec The format details of the input audio
+ * \param[in] src_data The audio data to be converted
  * \param src_len The len of src_data
- * \param dst_spec The format details of the output audio
- * \param dst_data Will be filled with a pointer to converted audio data,
+ * \param[in] dst_spec The format details of the output audio
+ * \param[out,own] dst_data Will be filled with a pointer to converted audio data,
  *                 which should be freed with SDL_free(). On error, it will be
  *                 NULL.
- * \param dst_len Will be filled with the len of dst_data
+ * \param[out] dst_len Will be filled with the len of dst_data
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *

--- a/include/SDL3/SDL_camera.h
+++ b/include/SDL3/SDL_camera.h
@@ -168,9 +168,9 @@ extern SDL_DECLSPEC const char *SDLCALL SDL_GetCurrentCameraDriver(void);
 /**
  * Get a list of currently connected camera devices.
  *
- * \param count a pointer filled in with the number of camera devices. Can be
+ * \param[out,opt] count a pointer filled in with the number of camera devices. Can be
  *              NULL.
- * \returns a 0 terminated array of camera instance IDs which should be freed
+ * \returns[own] a 0 terminated array of camera instance IDs which should be freed
  *          with SDL_free(), or NULL on error; call SDL_GetError() for more
  *          details.
  *
@@ -210,9 +210,9 @@ extern SDL_DECLSPEC SDL_CameraDeviceID *SDLCALL SDL_GetCameraDevices(int *count)
  * scary warning popup.
  *
  * \param devid the camera device instance ID to query.
- * \param count a pointer filled in with the number of elements in the list.
+ * \param[out,opt] count a pointer filled in with the number of elements in the list.
  *              Can be NULL.
- * \returns a 0 terminated array of SDL_CameraSpecs, which should be freed
+ * \returns[own] a 0 terminated array of SDL_CameraSpecs, which should be freed
  *          with SDL_free(), or NULL on error; call SDL_GetError() for more
  *          details.
  *
@@ -232,7 +232,7 @@ extern SDL_DECLSPEC SDL_CameraSpec *SDLCALL SDL_GetCameraDeviceSupportedFormats(
  * SDL_free() when done with it.
  *
  * \param instance_id the camera device instance ID
- * \returns Human-readable device name, or NULL on error; call SDL_GetError()
+ * \returns[own] Human-readable device name, or NULL on error; call SDL_GetError()
  *          for more information.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -294,9 +294,9 @@ extern SDL_DECLSPEC SDL_CameraPosition SDLCALL SDL_GetCameraDevicePosition(SDL_C
  * immediately, but it might come seconds, minutes, or hours later!
  *
  * \param instance_id the camera device instance ID
- * \param spec The desired format for data the device will provide. Can be
+ * \param[in,opt] spec The desired format for data the device will provide. Can be
  *             NULL.
- * \returns device, or NULL on failure; call SDL_GetError() for more
+ * \returns[own] device, or NULL on failure; call SDL_GetError() for more
  *          information.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -328,7 +328,7 @@ extern SDL_DECLSPEC SDL_Camera *SDLCALL SDL_OpenCameraDevice(SDL_CameraDeviceID 
  * If a camera is declined, there's nothing to be done but call
  * SDL_CloseCamera() to dispose of it.
  *
- * \param camera the opened camera device to query
+ * \param[inout] camera the opened camera device to query
  * \returns -1 if user denied access to the camera, 1 if user approved access,
  *          0 if no decision has been made yet.
  *
@@ -344,7 +344,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetCameraPermissionState(SDL_Camera *camera)
 /**
  * Get the instance ID of an opened camera.
  *
- * \param camera an SDL_Camera to query
+ * \param[inout] camera an SDL_Camera to query
  * \returns the instance ID of the specified camera on success or 0 on
  *          failure; call SDL_GetError() for more information.
  *
@@ -359,7 +359,7 @@ extern SDL_DECLSPEC SDL_CameraDeviceID SDLCALL SDL_GetCameraInstanceID(SDL_Camer
 /**
  * Get the properties associated with an opened camera.
  *
- * \param camera the SDL_Camera obtained from SDL_OpenCameraDevice()
+ * \param[inout] camera the SDL_Camera obtained from SDL_OpenCameraDevice()
  * \returns a valid property ID on success or 0 on failure; call
  *          SDL_GetError() for more information.
  *
@@ -384,8 +384,8 @@ extern SDL_DECLSPEC SDL_PropertiesID SDLCALL SDL_GetCameraProperties(SDL_Camera 
  * (or SDL_EVENT_CAMERA_DEVICE_DENIED) event, or poll SDL_IsCameraApproved()
  * occasionally until it returns non-zero.
  *
- * \param camera opened camera device
- * \param spec The SDL_CameraSpec to be initialized by this function.
+ * \param[inout] camera opened camera device
+ * \param[out] spec The SDL_CameraSpec to be initialized by this function.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -426,10 +426,10 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetCameraFormat(SDL_Camera *camera, SDL_Came
  * SDL_EVENT_CAMERA_DEVICE_DENIED) event, or poll SDL_IsCameraApproved()
  * occasionally until it returns non-zero.
  *
- * \param camera opened camera device
- * \param timestampNS a pointer filled in with the frame's timestamp, or 0 on
+ * \param[inout] camera opened camera device
+ * \param[out,opt] timestampNS a pointer filled in with the frame's timestamp, or 0 on
  *                    error. Can be NULL.
- * \returns A new frame of video on success, NULL if none is currently
+ * \returns[own] A new frame of video on success, NULL if none is currently
  *          available.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -457,8 +457,8 @@ extern SDL_DECLSPEC SDL_Surface * SDLCALL SDL_AcquireCameraFrame(SDL_Camera *cam
  * The app should not use the surface again after calling this function;
  * assume the surface is freed and the pointer is invalid.
  *
- * \param camera opened camera device
- * \param frame The video frame surface to release.
+ * \param[inout] camera opened camera device
+ * \param[inout] frame The video frame surface to release.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -474,7 +474,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_ReleaseCameraFrame(SDL_Camera *camera, SDL_S
  * Use this function to shut down camera processing and close the camera
  * device.
  *
- * \param camera opened camera device
+ * \param[inout] camera opened camera device
  *
  * \threadsafety It is safe to call this function from any thread, but no
  *               thread may reference `device` once this function is called.

--- a/include/SDL3/SDL_clipboard.h
+++ b/include/SDL3/SDL_clipboard.h
@@ -45,7 +45,7 @@ extern "C" {
 /**
  * Put UTF-8 text into the clipboard.
  *
- * \param text the text to store in the clipboard
+ * \param[in] text the text to store in the clipboard
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -62,7 +62,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetClipboardText(const char *text);
  * This functions returns empty string if there was not enough memory left for
  * a copy of the clipboard's content.
  *
- * \returns the clipboard text on success or an empty string on failure; call
+ * \returns[own] the clipboard text on success or an empty string on failure; call
  *          SDL_GetError() for more information. Caller must call SDL_free()
  *          on the returned pointer when done with it (even if there was an
  *          error).
@@ -89,7 +89,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_HasClipboardText(void);
 /**
  * Put UTF-8 text into the primary selection.
  *
- * \param text the text to store in the primary selection
+ * \param[in] text the text to store in the primary selection
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -107,7 +107,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetPrimarySelectionText(const char *text);
  * This functions returns empty string if there was not enough memory left for
  * a copy of the primary selection's content.
  *
- * \returns the primary selection text on success or an empty string on
+ * \returns[own] the primary selection text on success or an empty string on
  *          failure; call SDL_GetError() for more information. Caller must
  *          call SDL_free() on the returned pointer when done with it (even if
  *          there was an error).
@@ -181,13 +181,13 @@ typedef void (SDLCALL *SDL_ClipboardCleanupCallback)(void *userdata);
  * not need to be null terminated (e.g. you can directly copy a portion of a
  * document)
  *
- * \param callback A function pointer to the function that provides the
+ * \param[in] callback A function pointer to the function that provides the
  *                 clipboard data
- * \param cleanup A function pointer to the function that cleans up the
+ * \param[in] cleanup A function pointer to the function that cleans up the
  *                clipboard data
- * \param userdata An opaque pointer that will be forwarded to the callbacks
- * \param mime_types A list of mime-types that are being offered
- * \param num_mime_types The number of mime-types in the mime_types list
+ * \param[inout,opt] userdata An opaque pointer that will be forwarded to the callbacks
+ * \param[in] mime_types A list of mime-types that are being offered
+ * \param[in] num_mime_types The number of mime-types in the mime_types list
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -217,9 +217,9 @@ extern SDL_DECLSPEC int SDLCALL SDL_ClearClipboardData(void);
  * The size of text data does not include the terminator, but the text is
  * guaranteed to be null terminated.
  *
- * \param mime_type The mime type to read from the clipboard
+ * \param[in] mime_type The mime type to read from the clipboard
  * \param size A pointer filled in with the length of the returned data
- * \returns the retrieved data buffer or NULL on failure; call SDL_GetError()
+ * \returns[own] the retrieved data buffer or NULL on failure; call SDL_GetError()
  *          for more information. Caller must call SDL_free() on the returned
  *          pointer when done with it.
  *
@@ -233,7 +233,7 @@ extern SDL_DECLSPEC void *SDLCALL SDL_GetClipboardData(const char *mime_type, si
 /**
  * Query whether there is data in the clipboard for the provided mime type.
  *
- * \param mime_type The mime type to check for data for
+ * \param[in] mime_type The mime type to check for data for
  * \returns SDL_TRUE if there exists data in clipboard for the provided mime
  *          type, SDL_FALSE if it does not.
  *

--- a/include/SDL3/SDL_dialog.h
+++ b/include/SDL3/SDL_dialog.h
@@ -118,7 +118,7 @@ typedef void(SDLCALL *SDL_DialogFileCallback)(void *userdata, const char * const
  * requires an event-handling loop. Apps that do not use SDL to handle events
  * should add a call to SDL_PumpEvents in their main loop.
  *
- * \param callback An SDL_DialogFileCallback to be invoked when the user
+ * \param[in] callback An SDL_DialogFileCallback to be invoked when the user
  *                 selects a file and accepts, or cancels the dialog, or an
  *                 error occurs. The first argument is a null-terminated list
  *                 of C strings, representing the paths chosen by the user.
@@ -131,14 +131,14 @@ typedef void(SDLCALL *SDL_DialogFileCallback)(void *userdata, const char * const
  *                 index of the terminating NULL filter) if no filter was
  *                 chosen, or -1 if the platform does not support detecting
  *                 the selected filter.
- * \param userdata An optional pointer to pass extra data to the callback when
+ * \param[inout,opt] userdata An optional pointer to pass extra data to the callback when
  *                 it will be invoked.
- * \param window The window that the dialog should be modal for. May be NULL.
+ * \param[inout,opt] window The window that the dialog should be modal for. May be NULL.
  *               Not all platforms support this option.
- * \param filters A null-terminated list of SDL_DialogFileFilter's. May be
+ * \param[in,opt] filters A null-terminated list of SDL_DialogFileFilter's. May be
  *                NULL. Not all platforms support this option, and platforms
  *                that do support it may allow the user to ignore the filters.
- * \param default_location The default folder or file to start the dialog at.
+ * \param[in,opt] default_location The default folder or file to start the dialog at.
  *                         May be NULL. Not all platforms support this option.
  * \param allow_many If non-zero, the user will be allowed to select multiple
  *                   entries. Not all platforms support this option.
@@ -174,7 +174,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_ShowOpenFileDialog(SDL_DialogFileCallback c
  * requires an event-handling loop. Apps that do not use SDL to handle events
  * should add a call to SDL_PumpEvents in their main loop.
  *
- * \param callback An SDL_DialogFileCallback to be invoked when the user
+ * \param[in] callback An SDL_DialogFileCallback to be invoked when the user
  *                 selects a file and accepts, or cancels the dialog, or an
  *                 error occurs. The first argument is a null-terminated list
  *                 of C strings, representing the paths chosen by the user.
@@ -187,14 +187,14 @@ extern SDL_DECLSPEC void SDLCALL SDL_ShowOpenFileDialog(SDL_DialogFileCallback c
  *                 index of the terminating NULL filter) if no filter was
  *                 chosen, or -1 if the platform does not support detecting
  *                 the selected filter.
- * \param userdata An optional pointer to pass extra data to the callback when
+ * \param[inout,opt] userdata An optional pointer to pass extra data to the callback when
  *                 it will be invoked.
- * \param window The window that the dialog should be modal for. May be NULL.
+ * \param[inout,opt] window The window that the dialog should be modal for. May be NULL.
  *               Not all platforms support this option.
- * \param filters A null-terminated list of SDL_DialogFileFilter's. May be
+ * \param[in,opt] filters A null-terminated list of SDL_DialogFileFilter's. May be
  *                NULL. Not all platforms support this option, and platforms
  *                that do support it may allow the user to ignore the filters.
- * \param default_location The default folder or file to start the dialog at.
+ * \param[in,opt] default_location The default folder or file to start the dialog at.
  *                         May be NULL. Not all platforms support this option.
  *
  * \since This function is available since SDL 3.0.0.
@@ -228,7 +228,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_ShowSaveFileDialog(SDL_DialogFileCallback c
  * requires an event-handling loop. Apps that do not use SDL to handle events
  * should add a call to SDL_PumpEvents in their main loop.
  *
- * \param callback An SDL_DialogFileCallback to be invoked when the user
+ * \param[in] callback An SDL_DialogFileCallback to be invoked when the user
  *                 selects a file and accepts, or cancels the dialog, or an
  *                 error occurs. The first argument is a null-terminated list
  *                 of C strings, representing the paths chosen by the user.
@@ -237,11 +237,11 @@ extern SDL_DECLSPEC void SDLCALL SDL_ShowSaveFileDialog(SDL_DialogFileCallback c
  *                 it can be fetched with SDL_GetError(). The second argument
  *                 is the userdata pointer passed to the function. The third
  *                 argument is always -1 for SDL_ShowOpenFolderDialog.
- * \param userdata An optional pointer to pass extra data to the callback when
+ * \param[inout,opt] userdata An optional pointer to pass extra data to the callback when
  *                 it will be invoked.
- * \param window The window that the dialog should be modal for. May be NULL.
+ * \param[inout,opt] window The window that the dialog should be modal for. May be NULL.
  *               Not all platforms support this option.
- * \param default_location The default folder or file to start the dialog at.
+ * \param[in,opt] default_location The default folder or file to start the dialog at.
  *                         May be NULL. Not all platforms support this option.
  * \param allow_many If non-zero, the user will be allowed to select multiple
  *                   entries. Not all platforms support this option.

--- a/include/SDL3/SDL_error.h
+++ b/include/SDL3/SDL_error.h
@@ -53,7 +53,7 @@ extern "C" {
  * }
  * ```
  *
- * \param fmt a printf()-style message format string
+ * \param[in] fmt a printf()-style message format string
  * \param ... additional parameters matching % tokens in the `fmt` string, if
  *            any
  * \returns always -1.

--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -929,7 +929,7 @@ typedef enum SDL_EventAction
  *
  * This function is thread-safe.
  *
- * \param events destination buffer for the retrieved events
+ * \param[out] events destination buffer for the retrieved events
  * \param numevents if action is SDL_ADDEVENT, the number of events to add
  *                  back to the event queue; if action is SDL_PEEKEVENT or
  *                  SDL_GETEVENT, the maximum number of events to retrieve
@@ -1068,7 +1068,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_FlushEvents(Uint32 minType, Uint32 maxType)
  * }
  * ```
  *
- * \param event the SDL_Event structure to be filled with the next event from
+ * \param[out,opt] event the SDL_Event structure to be filled with the next event from
  *              the queue, or NULL
  * \returns SDL_TRUE if this got an event or SDL_FALSE if there are none
  *          available.
@@ -1090,7 +1090,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_PollEvent(SDL_Event *event);
  * As this function may implicitly call SDL_PumpEvents(), you can only call
  * this function in the thread that initialized the video subsystem.
  *
- * \param event the SDL_Event structure to be filled in with the next event
+ * \param[out,opt] event the SDL_Event structure to be filled in with the next event
  *              from the queue, or NULL
  * \returns SDL_TRUE on success or SDL_FALSE if there was an error while
  *          waiting for events; call SDL_GetError() for more information.
@@ -1116,7 +1116,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_WaitEvent(SDL_Event *event);
  * The timeout is not guaranteed, the actual wait time could be longer due to
  * system scheduling.
  *
- * \param event the SDL_Event structure to be filled in with the next event
+ * \param[out,opt] event the SDL_Event structure to be filled in with the next event
  *              from the queue, or NULL
  * \param timeoutMS the maximum number of milliseconds to wait for the next
  *                  available event
@@ -1152,7 +1152,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_WaitEventTimeout(SDL_Event *event, Sint
  * get an event type that does not conflict with other code that also wants
  * its own custom event types.
  *
- * \param event the SDL_Event to be added to the queue
+ * \param[inout] event the SDL_Event to be added to the queue
  * \returns 1 on success, 0 if the event was filtered, or a negative error
  *          code on failure; call SDL_GetError() for more information. A
  *          common reason for error is the event queue being full.
@@ -1216,8 +1216,8 @@ typedef int (SDLCALL *SDL_EventFilter)(void *userdata, SDL_Event *event);
  * the event filter, but events pushed onto the queue with SDL_PeepEvents() do
  * not.
  *
- * \param filter An SDL_EventFilter function to call when an event happens
- * \param userdata a pointer that is passed to `filter`
+ * \param[in] filter An SDL_EventFilter function to call when an event happens
+ * \param[inout,opt] userdata a pointer that is passed to `filter`
  *
  * \threadsafety SDL may call the filter callback at any time from any thread;
  *               the application is responsible for locking resources the
@@ -1239,8 +1239,8 @@ extern SDL_DECLSPEC void SDLCALL SDL_SetEventFilter(SDL_EventFilter filter, void
  * This function can be used to "chain" filters, by saving the existing filter
  * before replacing it with a function that will call that saved filter.
  *
- * \param filter the current callback function will be stored here
- * \param userdata the pointer that is passed to the current event filter will
+ * \param[out] filter the current callback function will be stored here
+ * \param[out] userdata the pointer that is passed to the current event filter will
  *                 be stored here
  * \returns SDL_TRUE on success or SDL_FALSE if there is no event filter set.
  *
@@ -1268,8 +1268,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GetEventFilter(SDL_EventFilter *filter,
  * callback set with SDL_SetEventFilter(), nor for events posted by the user
  * through SDL_PeepEvents().
  *
- * \param filter an SDL_EventFilter function to call when an event happens.
- * \param userdata a pointer that is passed to `filter`
+ * \param[in] filter an SDL_EventFilter function to call when an event happens.
+ * \param[inout,opt] userdata a pointer that is passed to `filter`
  * \returns 0 on success, or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1288,8 +1288,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_AddEventWatch(SDL_EventFilter filter, void *
  * This function takes the same input as SDL_AddEventWatch() to identify and
  * delete the corresponding callback.
  *
- * \param filter the function originally passed to SDL_AddEventWatch()
- * \param userdata the pointer originally passed to SDL_AddEventWatch()
+ * \param[in] filter the function originally passed to SDL_AddEventWatch()
+ * \param[inout,opt] userdata the pointer originally passed to SDL_AddEventWatch()
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -1305,8 +1305,8 @@ extern SDL_DECLSPEC void SDLCALL SDL_DelEventWatch(SDL_EventFilter filter, void 
  * this function does not change the filter permanently, it only uses the
  * supplied filter until this function returns.
  *
- * \param filter the SDL_EventFilter function to call when an event happens
- * \param userdata a pointer that is passed to `filter`
+ * \param[in] filter the SDL_EventFilter function to call when an event happens
+ * \param[inout,opt] userdata a pointer that is passed to `filter`
  *
  * \since This function is available since SDL 3.0.0.
  *

--- a/include/SDL3/SDL_filesystem.h
+++ b/include/SDL3/SDL_filesystem.h
@@ -71,7 +71,7 @@ extern "C" {
  * The pointer returned is owned by the caller. Please call SDL_free() on the
  * pointer when done with it.
  *
- * \returns an absolute path in UTF-8 encoding to the application data
+ * \returns[own] an absolute path in UTF-8 encoding to the application data
  *          directory. NULL will be returned on error or when the platform
  *          doesn't implement this functionality, call SDL_GetError() for more
  *          information.
@@ -127,9 +127,9 @@ extern SDL_DECLSPEC char *SDLCALL SDL_GetBasePath(void);
  * The pointer returned is owned by the caller. Please call SDL_free() on the
  * pointer when done with it.
  *
- * \param org the name of your organization
- * \param app the name of your application
- * \returns a UTF-8 string of the user directory in platform-dependent
+ * \param[in] org the name of your organization
+ * \param[in] app the name of your application
+ * \returns[own] a UTF-8 string of the user directory in platform-dependent
  *          notation. NULL if there's a problem (creating directory failed,
  *          etc.).
  *
@@ -233,7 +233,7 @@ typedef enum SDL_Folder
  * If NULL is returned, the error may be obtained with SDL_GetError().
  *
  * \param folder The type of folder to find
- * \returns Either a null-terminated C string containing the full path to the
+ * \returns[own] Either a null-terminated C string containing the full path to the
  *          folder, or NULL if an error happened.
  *
  * \since This function is available since SDL 3.0.0.
@@ -277,7 +277,7 @@ typedef Uint32 SDL_GlobFlags;
 /**
  * Create a directory.
  *
- * \param path the path of the directory to create
+ * \param[in] path the path of the directory to create
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -298,9 +298,9 @@ typedef int (SDLCALL *SDL_EnumerateDirectoryCallback)(void *userdata, const char
  * callback, called once for each directory entry, until all results have been
  * provided or the callback returns <= 0.
  *
- * \param path the path of the directory to enumerate
- * \param callback a function that is called for each entry in the directory
- * \param userdata a pointer that is passed to `callback`
+ * \param[in] path the path of the directory to enumerate
+ * \param[in] callback a function that is called for each entry in the directory
+ * \param[inout,opt] userdata a pointer that is passed to `callback`
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -311,7 +311,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_EnumerateDirectory(const char *path, SDL_Enu
 /**
  * Remove a file or an empty directory.
  *
- * \param path the path of the directory to enumerate
+ * \param[in] path the path of the directory to enumerate
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -322,8 +322,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_RemovePath(const char *path);
 /**
  * Rename a file or directory.
  *
- * \param oldpath the old path
- * \param newpath the new path
+ * \param[in] oldpath the old path
+ * \param[in] newpath the new path
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -334,8 +334,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_RenamePath(const char *oldpath, const char *
 /**
  * Get information about a filesystem path.
  *
- * \param path the path to query
- * \param info a pointer filled in with information about the path, or NULL to
+ * \param[in] path the path to query
+ * \param[out] info a pointer filled in with information about the path, or NULL to
  *             check for the existence of a file
  * \returns 0 on success or a negative error code if the file doesn't exist,
  *          or another failure; call SDL_GetError() for more information.
@@ -363,13 +363,13 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetPathInfo(const char *path, SDL_PathInfo *
  *
  * You must free the returned pointer with SDL_free() when done with it.
  *
- * \param path the path of the directory to enumerate
- * \param pattern the pattern that files in the directory must match. Can be
+ * \param[in] path the path of the directory to enumerate
+ * \param[in,opt] pattern the pattern that files in the directory must match. Can be
  *                NULL.
  * \param flags `SDL_GLOB_*` bitflags that affect this search.
- * \param count on return, will be set to the number of items in the returned
+ * \param[out,opt] count on return, will be set to the number of items in the returned
  *              array. Can be NULL.
- * \returns an array of strings on success or NULL on failure; call
+ * \returns[own] an array of strings on success or NULL on failure; call
  *          SDL_GetError() for more information. The caller should pass the
  *          returned pointer to SDL_free when done with it.
  *

--- a/include/SDL3/SDL_gamepad.h
+++ b/include/SDL3/SDL_gamepad.h
@@ -299,7 +299,7 @@ typedef struct SDL_GamepadBinding
  * "341a3608000000000000504944564944,Afterglow PS3 Controller,a:b1,b:b2,y:b3,x:b0,start:b9,guide:b12,back:b8,dpup:h0.1,dpleft:h0.8,dpdown:h0.4,dpright:h0.2,leftshoulder:b4,rightshoulder:b5,leftstick:b10,rightstick:b11,leftx:a0,lefty:a1,rightx:a2,righty:a3,lefttrigger:b6,righttrigger:b7"
  * ```
  *
- * \param mapping the mapping string
+ * \param[in] mapping the mapping string
  * \returns 1 if a new mapping is added, 0 if an existing mapping is updated,
  *          -1 on error; call SDL_GetError() for more information.
  *
@@ -329,7 +329,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_AddGamepadMapping(const char *mapping);
  * processing it, so take this into consideration if you are in a memory
  * constrained environment.
  *
- * \param src the data stream for the mappings to be added
+ * \param[inout] src the data stream for the mappings to be added
  * \param closeio if SDL_TRUE, calls SDL_CloseIO() on `src` before returning,
  *                even in the case of an error
  * \returns the number of mappings added or -1 on error; call SDL_GetError()
@@ -359,7 +359,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_AddGamepadMappingsFromIO(SDL_IOStream *src, 
  * specified will be ignored (i.e. mappings for Linux will be ignored in
  * Windows, etc).
  *
- * \param file the mappings file to load
+ * \param[in] file the mappings file to load
  * \returns the number of mappings added or -1 on error; call SDL_GetError()
  *          for more information.
  *
@@ -392,9 +392,9 @@ extern SDL_DECLSPEC int SDLCALL SDL_ReloadGamepadMappings(void);
  * You must free the returned pointer with SDL_free() when you are done with
  * it, but you do _not_ free each string in the array.
  *
- * \param count a pointer filled in with the number of mappings returned, can
+ * \param[out,opt] count a pointer filled in with the number of mappings returned, can
  *              be NULL.
- * \returns an array of the mapping strings, NULL-terminated. Must be freed
+ * \returns[own] an array of the mapping strings, NULL-terminated. Must be freed
  *          with SDL_free(). Returns NULL on error.
  *
  * \since This function is available since SDL 3.0.0.
@@ -407,7 +407,7 @@ extern SDL_DECLSPEC char ** SDLCALL SDL_GetGamepadMappings(int *count);
  * The returned string must be freed with SDL_free().
  *
  * \param guid a structure containing the GUID for which a mapping is desired
- * \returns a mapping string or NULL on error; call SDL_GetError() for more
+ * \returns[own] a mapping string or NULL on error; call SDL_GetError() for more
  *          information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -424,8 +424,8 @@ extern SDL_DECLSPEC char * SDLCALL SDL_GetGamepadMappingForGUID(SDL_JoystickGUID
  *
  * Details about mappings are discussed with SDL_AddGamepadMapping().
  *
- * \param gamepad the gamepad you want to get the current mapping for
- * \returns a string that has the gamepad's mapping or NULL if no mapping is
+ * \param[inout] gamepad the gamepad you want to get the current mapping for
+ * \returns[own] a string that has the gamepad's mapping or NULL if no mapping is
  *          available; call SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -443,7 +443,7 @@ extern SDL_DECLSPEC char * SDLCALL SDL_GetGamepadMapping(SDL_Gamepad *gamepad);
  * Details about mappings are discussed with SDL_AddGamepadMapping().
  *
  * \param instance_id the joystick instance ID
- * \param mapping the mapping to use for this device, or NULL to clear the
+ * \param[in,opt] mapping the mapping to use for this device, or NULL to clear the
  *                mapping
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -469,8 +469,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_HasGamepad(void);
 /**
  * Get a list of currently connected gamepads.
  *
- * \param count a pointer filled in with the number of gamepads returned
- * \returns a 0 terminated array of joystick instance IDs which should be
+ * \param[out] count a pointer filled in with the number of gamepads returned
+ * \returns[own] a 0 terminated array of joystick instance IDs which should be
  *          freed with SDL_free(), or NULL on error; call SDL_GetError() for
  *          more details.
  *
@@ -648,7 +648,7 @@ extern SDL_DECLSPEC SDL_GamepadType SDLCALL SDL_GetRealGamepadInstanceType(SDL_J
  * This can be called before any gamepads are opened.
  *
  * \param instance_id the joystick instance ID
- * \returns the mapping string. Must be freed with SDL_free(). Returns NULL if
+ * \returns[own] the mapping string. Must be freed with SDL_free(). Returns NULL if
  *          no mapping is available.
  *
  * \since This function is available since SDL 3.0.0.
@@ -662,7 +662,7 @@ extern SDL_DECLSPEC char *SDLCALL SDL_GetGamepadInstanceMapping(SDL_JoystickID i
  * Open a gamepad for use.
  *
  * \param instance_id the joystick instance ID
- * \returns a gamepad identifier or NULL if an error occurred; call
+ * \returns[own] a gamepad identifier or NULL if an error occurred; call
  *          SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -715,7 +715,7 @@ extern SDL_DECLSPEC SDL_Gamepad *SDLCALL SDL_GetGamepadFromPlayerIndex(int playe
  * - `SDL_PROP_GAMEPAD_CAP_TRIGGER_RUMBLE_BOOLEAN`: true if this gamepad has
  *   simple trigger rumble
  *
- * \param gamepad a gamepad identifier previously returned by
+ * \param[inout] gamepad a gamepad identifier previously returned by
  *                SDL_OpenGamepad()
  * \returns a valid property ID on success or 0 on failure; call
  *          SDL_GetError() for more information.
@@ -736,7 +736,7 @@ extern SDL_DECLSPEC SDL_PropertiesID SDLCALL SDL_GetGamepadProperties(SDL_Gamepa
 /**
  * Get the instance ID of an opened gamepad.
  *
- * \param gamepad a gamepad identifier previously returned by
+ * \param[inout] gamepad a gamepad identifier previously returned by
  *                SDL_OpenGamepad()
  * \returns the instance ID of the specified gamepad on success or 0 on
  *          failure; call SDL_GetError() for more information.
@@ -748,7 +748,7 @@ extern SDL_DECLSPEC SDL_JoystickID SDLCALL SDL_GetGamepadInstanceID(SDL_Gamepad 
 /**
  * Get the implementation-dependent name for an opened gamepad.
  *
- * \param gamepad a gamepad identifier previously returned by
+ * \param[inout] gamepad a gamepad identifier previously returned by
  *                SDL_OpenGamepad()
  * \returns the implementation dependent name for the gamepad, or NULL if
  *          there is no name or the identifier passed is invalid.
@@ -762,7 +762,7 @@ extern SDL_DECLSPEC const char *SDLCALL SDL_GetGamepadName(SDL_Gamepad *gamepad)
 /**
  * Get the implementation-dependent path for an opened gamepad.
  *
- * \param gamepad a gamepad identifier previously returned by
+ * \param[inout] gamepad a gamepad identifier previously returned by
  *                SDL_OpenGamepad()
  * \returns the implementation dependent path for the gamepad, or NULL if
  *          there is no path or the identifier passed is invalid.
@@ -776,7 +776,7 @@ extern SDL_DECLSPEC const char *SDLCALL SDL_GetGamepadPath(SDL_Gamepad *gamepad)
 /**
  * Get the type of an opened gamepad.
  *
- * \param gamepad the gamepad object to query.
+ * \param[inout] gamepad the gamepad object to query.
  * \returns the gamepad type, or SDL_GAMEPAD_TYPE_UNKNOWN if it's not
  *          available.
  *
@@ -789,7 +789,7 @@ extern SDL_DECLSPEC SDL_GamepadType SDLCALL SDL_GetGamepadType(SDL_Gamepad *game
 /**
  * Get the type of an opened gamepad, ignoring any mapping override.
  *
- * \param gamepad the gamepad object to query.
+ * \param[inout] gamepad the gamepad object to query.
  * \returns the gamepad type, or SDL_GAMEPAD_TYPE_UNKNOWN if it's not
  *          available.
  *
@@ -804,7 +804,7 @@ extern SDL_DECLSPEC SDL_GamepadType SDLCALL SDL_GetRealGamepadType(SDL_Gamepad *
  *
  * For XInput gamepads this returns the XInput user index.
  *
- * \param gamepad the gamepad object to query.
+ * \param[inout] gamepad the gamepad object to query.
  * \returns the player index for gamepad, or -1 if it's not available.
  *
  * \since This function is available since SDL 3.0.0.
@@ -816,7 +816,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetGamepadPlayerIndex(SDL_Gamepad *gamepad);
 /**
  * Set the player index of an opened gamepad.
  *
- * \param gamepad the gamepad object to adjust.
+ * \param[inout] gamepad the gamepad object to adjust.
  * \param player_index Player index to assign to this gamepad, or -1 to clear
  *                     the player index and turn off player LEDs.
  * \returns 0 on success or a negative error code on failure; call
@@ -833,7 +833,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetGamepadPlayerIndex(SDL_Gamepad *gamepad, 
  *
  * If the vendor ID isn't available this function returns 0.
  *
- * \param gamepad the gamepad object to query.
+ * \param[inout] gamepad the gamepad object to query.
  * \returns the USB vendor ID, or zero if unavailable.
  *
  * \since This function is available since SDL 3.0.0.
@@ -847,7 +847,7 @@ extern SDL_DECLSPEC Uint16 SDLCALL SDL_GetGamepadVendor(SDL_Gamepad *gamepad);
  *
  * If the product ID isn't available this function returns 0.
  *
- * \param gamepad the gamepad object to query.
+ * \param[inout] gamepad the gamepad object to query.
  * \returns the USB product ID, or zero if unavailable.
  *
  * \since This function is available since SDL 3.0.0.
@@ -861,7 +861,7 @@ extern SDL_DECLSPEC Uint16 SDLCALL SDL_GetGamepadProduct(SDL_Gamepad *gamepad);
  *
  * If the product version isn't available this function returns 0.
  *
- * \param gamepad the gamepad object to query.
+ * \param[inout] gamepad the gamepad object to query.
  * \returns the USB product version, or zero if unavailable.
  *
  * \since This function is available since SDL 3.0.0.
@@ -875,7 +875,7 @@ extern SDL_DECLSPEC Uint16 SDLCALL SDL_GetGamepadProductVersion(SDL_Gamepad *gam
  *
  * If the firmware version isn't available this function returns 0.
  *
- * \param gamepad the gamepad object to query.
+ * \param[inout] gamepad the gamepad object to query.
  * \returns the gamepad firmware version, or zero if unavailable.
  *
  * \since This function is available since SDL 3.0.0.
@@ -887,7 +887,7 @@ extern SDL_DECLSPEC Uint16 SDLCALL SDL_GetGamepadFirmwareVersion(SDL_Gamepad *ga
  *
  * Returns the serial number of the gamepad, or NULL if it is not available.
  *
- * \param gamepad the gamepad object to query.
+ * \param[inout] gamepad the gamepad object to query.
  * \returns the serial number, or NULL if unavailable.
  *
  * \since This function is available since SDL 3.0.0.
@@ -900,7 +900,7 @@ extern SDL_DECLSPEC const char * SDLCALL SDL_GetGamepadSerial(SDL_Gamepad *gamep
  * Returns an InputHandle_t for the gamepad that can be used with Steam Input
  * API: https://partner.steamgames.com/doc/api/ISteamInput
  *
- * \param gamepad the gamepad object to query.
+ * \param[inout] gamepad the gamepad object to query.
  * \returns the gamepad handle, or 0 if unavailable.
  *
  * \since This function is available since SDL 3.0.0.
@@ -910,7 +910,7 @@ extern SDL_DECLSPEC Uint64 SDLCALL SDL_GetGamepadSteamHandle(SDL_Gamepad *gamepa
 /**
  * Get the connection state of a gamepad.
  *
- * \param gamepad the gamepad object to query.
+ * \param[inout] gamepad the gamepad object to query.
  * \returns the connection state on success or
  *          `SDL_JOYSTICK_CONNECTION_INVALID` on failure; call SDL_GetError()
  *          for more information.
@@ -928,8 +928,8 @@ extern SDL_DECLSPEC SDL_JoystickConnectionState SDLCALL SDL_GetGamepadConnection
  * not uncommon for older batteries to lose stored power much faster than it
  * reports, or completely drain when reporting it has 20 percent left, etc.
  *
- * \param gamepad the gamepad object to query.
- * \param percent a pointer filled in with the percentage of battery life
+ * \param[inout] gamepad the gamepad object to query.
+ * \param[out,opt] percent a pointer filled in with the percentage of battery life
  *                left, between 0 and 100, or NULL to ignore. This will be
  *                filled in with -1 we can't determine a value or there is no
  *                battery.
@@ -942,7 +942,7 @@ extern SDL_DECLSPEC SDL_PowerState SDLCALL SDL_GetGamepadPowerInfo(SDL_Gamepad *
 /**
  * Check if a gamepad has been opened and is currently connected.
  *
- * \param gamepad a gamepad identifier previously returned by
+ * \param[inout] gamepad a gamepad identifier previously returned by
  *                SDL_OpenGamepad()
  * \returns SDL_TRUE if the gamepad has been opened and is currently
  *          connected, or SDL_FALSE if not.
@@ -963,7 +963,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GamepadConnected(SDL_Gamepad *gamepad);
  * SDL_CloseJoystick() on it, for example, since doing so will likely cause
  * SDL to crash.
  *
- * \param gamepad the gamepad object that you want to get a joystick from
+ * \param[inout] gamepad the gamepad object that you want to get a joystick from
  * \returns an SDL_Joystick object; call SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1003,9 +1003,9 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GamepadEventsEnabled(void);
 /**
  * Get the SDL joystick layer bindings for a gamepad.
  *
- * \param gamepad a gamepad
- * \param count a pointer filled in with the number of bindings returned
- * \returns a NULL terminated array of pointers to bindings which should be
+ * \param[inout] gamepad a gamepad
+ * \param[out,opt] count a pointer filled in with the number of bindings returned
+ * \returns[own] a NULL terminated array of pointers to bindings which should be
  *          freed with SDL_free(), or NULL on error; call SDL_GetError() for
  *          more details.
  *
@@ -1032,7 +1032,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_UpdateGamepads(void);
  * You do not normally need to call this function unless you are parsing
  * SDL_Gamepad mappings in your own code.
  *
- * \param str string representing a SDL_GamepadType type
+ * \param[in] str string representing a SDL_GamepadType type
  * \returns the SDL_GamepadType enum corresponding to the input string, or
  *          `SDL_GAMEPAD_TYPE_UNKNOWN` if no match was found.
  *
@@ -1070,7 +1070,7 @@ extern SDL_DECLSPEC const char *SDLCALL SDL_GetGamepadStringForType(SDL_GamepadT
  * `SDL_GAMEPAD_AXIS_RIGHT_TRIGGER` and `SDL_GAMEPAD_AXIS_LEFT_TRIGGER`,
  * respectively.
  *
- * \param str string representing a SDL_Gamepad axis
+ * \param[in] str string representing a SDL_Gamepad axis
  * \returns the SDL_GamepadAxis enum corresponding to the input string, or
  *          `SDL_GAMEPAD_AXIS_INVALID` if no match was found.
  *
@@ -1102,7 +1102,7 @@ extern SDL_DECLSPEC const char * SDLCALL SDL_GetGamepadStringForAxis(SDL_Gamepad
  * This merely reports whether the gamepad's mapping defined this axis, as
  * that is all the information SDL has about the physical device.
  *
- * \param gamepad a gamepad
+ * \param[inout] gamepad a gamepad
  * \param axis an axis enum value (an SDL_GamepadAxis value)
  * \returns SDL_TRUE if the gamepad has this axis, SDL_FALSE otherwise.
  *
@@ -1125,7 +1125,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GamepadHasAxis(SDL_Gamepad *gamepad, SD
  * return a negative value. Note that this differs from the value reported by
  * the lower-level SDL_GetJoystickAxis(), which normally uses the full range.
  *
- * \param gamepad a gamepad
+ * \param[inout] gamepad a gamepad
  * \param axis an axis index (one of the SDL_GamepadAxis values)
  * \returns axis state (including 0) on success or 0 (also) on failure; call
  *          SDL_GetError() for more information.
@@ -1145,7 +1145,7 @@ extern SDL_DECLSPEC Sint16 SDLCALL SDL_GetGamepadAxis(SDL_Gamepad *gamepad, SDL_
  * You do not normally need to call this function unless you are parsing
  * SDL_Gamepad mappings in your own code.
  *
- * \param str string representing a SDL_Gamepad axis
+ * \param[in] str string representing a SDL_Gamepad axis
  * \returns the SDL_GamepadButton enum corresponding to the input string, or
  *          `SDL_GAMEPAD_BUTTON_INVALID` if no match was found.
  *
@@ -1177,7 +1177,7 @@ extern SDL_DECLSPEC const char* SDLCALL SDL_GetGamepadStringForButton(SDL_Gamepa
  * This merely reports whether the gamepad's mapping defined this button, as
  * that is all the information SDL has about the physical device.
  *
- * \param gamepad a gamepad
+ * \param[inout] gamepad a gamepad
  * \param button a button enum value (an SDL_GamepadButton value)
  * \returns SDL_TRUE if the gamepad has this button, SDL_FALSE otherwise.
  *
@@ -1190,7 +1190,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GamepadHasButton(SDL_Gamepad *gamepad, 
 /**
  * Get the current state of a button on a gamepad.
  *
- * \param gamepad a gamepad
+ * \param[inout] gamepad a gamepad
  * \param button a button index (one of the SDL_GamepadButton values)
  * \returns 1 for pressed state or 0 for not pressed state or error; call
  *          SDL_GetError() for more information.
@@ -1218,7 +1218,7 @@ extern SDL_DECLSPEC SDL_GamepadButtonLabel SDLCALL SDL_GetGamepadButtonLabelForT
 /**
  * Get the label of a button on a gamepad.
  *
- * \param gamepad a gamepad
+ * \param[inout] gamepad a gamepad
  * \param button a button index (one of the SDL_GamepadButton values)
  * \returns the SDL_GamepadButtonLabel enum corresponding to the button label
  *
@@ -1231,7 +1231,7 @@ extern SDL_DECLSPEC SDL_GamepadButtonLabel SDLCALL SDL_GetGamepadButtonLabel(SDL
 /**
  * Get the number of touchpads on a gamepad.
  *
- * \param gamepad a gamepad
+ * \param[inout] gamepad a gamepad
  * \returns number of touchpads
  *
  * \since This function is available since SDL 3.0.0.
@@ -1244,7 +1244,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetNumGamepadTouchpads(SDL_Gamepad *gamepad)
  * Get the number of supported simultaneous fingers on a touchpad on a game
  * gamepad.
  *
- * \param gamepad a gamepad
+ * \param[inout] gamepad a gamepad
  * \param touchpad a touchpad
  * \returns number of supported simultaneous fingers
  *
@@ -1258,15 +1258,15 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetNumGamepadTouchpadFingers(SDL_Gamepad *ga
 /**
  * Get the current state of a finger on a touchpad on a gamepad.
  *
- * \param gamepad a gamepad
+ * \param[inout] gamepad a gamepad
  * \param touchpad a touchpad
  * \param finger a finger
  * \param state filled with state
- * \param x filled with x position, normalized 0 to 1, with the origin in the
+ * \param[out] x filled with x position, normalized 0 to 1, with the origin in the
  *          upper left
- * \param y filled with y position, normalized 0 to 1, with the origin in the
+ * \param[out] y filled with y position, normalized 0 to 1, with the origin in the
  *          upper left
- * \param pressure filled with pressure value
+ * \param[out] pressure filled with pressure value
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1279,7 +1279,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetGamepadTouchpadFinger(SDL_Gamepad *gamepa
 /**
  * Return whether a gamepad has a particular sensor.
  *
- * \param gamepad The gamepad to query
+ * \param[inout] gamepad The gamepad to query
  * \param type The type of sensor to query
  * \returns SDL_TRUE if the sensor exists, SDL_FALSE otherwise.
  *
@@ -1294,7 +1294,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GamepadHasSensor(SDL_Gamepad *gamepad, 
 /**
  * Set whether data reporting for a gamepad sensor is enabled.
  *
- * \param gamepad The gamepad to update
+ * \param[inout] gamepad The gamepad to update
  * \param type The type of sensor to enable/disable
  * \param enabled Whether data reporting should be enabled
  * \returns 0 on success or a negative error code on failure; call
@@ -1310,7 +1310,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetGamepadSensorEnabled(SDL_Gamepad *gamepad
 /**
  * Query whether sensor data reporting is enabled for a gamepad.
  *
- * \param gamepad The gamepad to query
+ * \param[inout] gamepad The gamepad to query
  * \param type The type of sensor to query
  * \returns SDL_TRUE if the sensor is enabled, SDL_FALSE otherwise.
  *
@@ -1323,7 +1323,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GamepadSensorEnabled(SDL_Gamepad *gamep
 /**
  * Get the data rate (number of events per second) of a gamepad sensor.
  *
- * \param gamepad The gamepad to query
+ * \param[inout] gamepad The gamepad to query
  * \param type The type of sensor to query
  * \returns the data rate, or 0.0f if the data rate is not available.
  *
@@ -1337,9 +1337,9 @@ extern SDL_DECLSPEC float SDLCALL SDL_GetGamepadSensorDataRate(SDL_Gamepad *game
  * The number of values and interpretation of the data is sensor dependent.
  * See SDL_sensor.h for the details for each type of sensor.
  *
- * \param gamepad The gamepad to query
+ * \param[inout] gamepad The gamepad to query
  * \param type The type of sensor to query
- * \param data A pointer filled with the current sensor state
+ * \param[out] data A pointer filled with the current sensor state
  * \param num_values The number of values to write to data
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1357,7 +1357,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetGamepadSensorData(SDL_Gamepad *gamepad, S
  * This function requires you to process SDL events or call
  * SDL_UpdateJoysticks() to update rumble state.
  *
- * \param gamepad The gamepad to vibrate
+ * \param[inout] gamepad The gamepad to vibrate
  * \param low_frequency_rumble The intensity of the low frequency (left)
  *                             rumble motor, from 0 to 0xFFFF
  * \param high_frequency_rumble The intensity of the high frequency (right)
@@ -1382,7 +1382,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_RumbleGamepad(SDL_Gamepad *gamepad, Uint16 l
  * This function requires you to process SDL events or call
  * SDL_UpdateJoysticks() to update rumble state.
  *
- * \param gamepad The gamepad to vibrate
+ * \param[inout] gamepad The gamepad to vibrate
  * \param left_rumble The intensity of the left trigger rumble motor, from 0
  *                    to 0xFFFF
  * \param right_rumble The intensity of the right trigger rumble motor, from 0
@@ -1406,7 +1406,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_RumbleGamepadTriggers(SDL_Gamepad *gamepad, 
  * For gamepads with a single color LED, the maximum of the RGB values will be
  * used as the LED brightness.
  *
- * \param gamepad The gamepad to update
+ * \param[inout] gamepad The gamepad to update
  * \param red The intensity of the red LED
  * \param green The intensity of the green LED
  * \param blue The intensity of the blue LED
@@ -1420,8 +1420,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetGamepadLED(SDL_Gamepad *gamepad, Uint8 re
 /**
  * Send a gamepad specific effect packet.
  *
- * \param gamepad The gamepad to affect
- * \param data The data to send to the gamepad
+ * \param[inout] gamepad The gamepad to affect
+ * \param[in] data The data to send to the gamepad
  * \param size The size of the data to send to the gamepad
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1433,7 +1433,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SendGamepadEffect(SDL_Gamepad *gamepad, cons
 /**
  * Close a gamepad previously opened with SDL_OpenGamepad().
  *
- * \param gamepad a gamepad identifier previously returned by
+ * \param[inout] gamepad a gamepad identifier previously returned by
  *                SDL_OpenGamepad()
  *
  * \since This function is available since SDL 3.0.0.
@@ -1446,7 +1446,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_CloseGamepad(SDL_Gamepad *gamepad);
  * Return the sfSymbolsName for a given button on a gamepad on Apple
  * platforms.
  *
- * \param gamepad the gamepad to query
+ * \param[inout] gamepad the gamepad to query
  * \param button a button on the gamepad
  * \returns the sfSymbolsName or NULL if the name can't be found
  *
@@ -1459,7 +1459,7 @@ extern SDL_DECLSPEC const char* SDLCALL SDL_GetGamepadAppleSFSymbolsNameForButto
 /**
  * Return the sfSymbolsName for a given axis on a gamepad on Apple platforms.
  *
- * \param gamepad the gamepad to query
+ * \param[inout] gamepad the gamepad to query
  * \param axis an axis on the gamepad
  * \returns the sfSymbolsName or NULL if the name can't be found
  *

--- a/include/SDL3/SDL_guid.h
+++ b/include/SDL3/SDL_guid.h
@@ -69,7 +69,7 @@ typedef struct SDL_GUID {
  * You should supply at least 33 bytes for pszGUID.
  *
  * \param guid the SDL_GUID you wish to convert to string
- * \param pszGUID buffer in which to write the ASCII string
+ * \param[out] pszGUID buffer in which to write the ASCII string
  * \param cbGUID the size of pszGUID
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -87,7 +87,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GUIDToString(SDL_GUID guid, char *pszGUID, i
  * an invalid GUID, the function will silently succeed, but the GUID generated
  * will not be useful.
  *
- * \param pchGUID string containing an ASCII representation of a GUID
+ * \param[in] pchGUID string containing an ASCII representation of a GUID
  * \returns a SDL_GUID structure.
  *
  * \since This function is available since SDL 3.0.0.

--- a/include/SDL3/SDL_haptic.h
+++ b/include/SDL3/SDL_haptic.h
@@ -932,8 +932,8 @@ typedef Uint32 SDL_HapticID;
 /**
  * Get a list of currently connected haptic devices.
  *
- * \param count a pointer filled in with the number of haptic devices returned
- * \returns a 0 terminated array of haptic device instance IDs which should be
+ * \param[out] count a pointer filled in with the number of haptic devices returned
+ * \returns[own] a 0 terminated array of haptic device instance IDs which should be
  *          freed with SDL_free(), or NULL on error; call SDL_GetError() for
  *          more details.
  *
@@ -971,7 +971,7 @@ extern SDL_DECLSPEC const char *SDLCALL SDL_GetHapticInstanceName(SDL_HapticID i
  * and SDL_SetHapticAutocenter().
  *
  * \param instance_id the haptic device instance ID
- * \returns the device identifier or NULL on failure; call SDL_GetError() for
+ * \returns[own] the device identifier or NULL on failure; call SDL_GetError() for
  *          more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1000,7 +1000,7 @@ extern SDL_DECLSPEC SDL_Haptic *SDLCALL SDL_GetHapticFromInstanceID(SDL_HapticID
 /**
  * Get the instance ID of an opened haptic device.
  *
- * \param haptic the SDL_Haptic device to query
+ * \param[inout] haptic the SDL_Haptic device to query
  * \returns the instance ID of the specified haptic device on success or 0 on
  *          failure; call SDL_GetError() for more information.
  *
@@ -1011,7 +1011,7 @@ extern SDL_DECLSPEC SDL_HapticID SDLCALL SDL_GetHapticInstanceID(SDL_Haptic *hap
 /**
  * Get the implementation dependent name of a haptic device.
  *
- * \param haptic the SDL_Haptic obtained from SDL_OpenJoystick()
+ * \param[inout] haptic the SDL_Haptic obtained from SDL_OpenJoystick()
  * \returns the name of the selected haptic device. If no name can be found,
  *          this function returns NULL; call SDL_GetError() for more
  *          information.
@@ -1049,7 +1049,7 @@ extern SDL_DECLSPEC SDL_Haptic *SDLCALL SDL_OpenHapticFromMouse(void);
 /**
  * Query if a joystick has haptic features.
  *
- * \param joystick the SDL_Joystick to test for haptic capabilities
+ * \param[inout] joystick the SDL_Joystick to test for haptic capabilities
  * \returns SDL_TRUE if the joystick is haptic or SDL_FALSE if it isn't.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1069,8 +1069,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_IsJoystickHaptic(SDL_Joystick *joystick
  * device will also get unallocated and you'll be unable to use force feedback
  * on that device.
  *
- * \param joystick the SDL_Joystick to create a haptic device from
- * \returns a valid haptic device identifier on success or NULL on failure;
+ * \param[inout] joystick the SDL_Joystick to create a haptic device from
+ * \returns[own] a valid haptic device identifier on success or NULL on failure;
  *          call SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1083,7 +1083,7 @@ extern SDL_DECLSPEC SDL_Haptic *SDLCALL SDL_OpenHapticFromJoystick(SDL_Joystick 
 /**
  * Close a haptic device previously opened with SDL_OpenHaptic().
  *
- * \param haptic the SDL_Haptic device to close
+ * \param[inout] haptic the SDL_Haptic device to close
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -1098,7 +1098,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_CloseHaptic(SDL_Haptic *haptic);
  * approximation. Always check to see if your created effect was actually
  * created and do not rely solely on SDL_GetMaxHapticEffects().
  *
- * \param haptic the SDL_Haptic device to query
+ * \param[inout] haptic the SDL_Haptic device to query
  * \returns the number of effects the haptic device can store or a negative
  *          error code on failure; call SDL_GetError() for more information.
  *
@@ -1114,7 +1114,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetMaxHapticEffects(SDL_Haptic *haptic);
  *
  * This is not supported on all platforms, but will always return a value.
  *
- * \param haptic the SDL_Haptic device to query maximum playing effects
+ * \param[inout] haptic the SDL_Haptic device to query maximum playing effects
  * \returns the number of effects the haptic device can play at the same time
  *          or a negative error code on failure; call SDL_GetError() for more
  *          information.
@@ -1129,7 +1129,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetMaxHapticEffectsPlaying(SDL_Haptic *hapti
 /**
  * Get the haptic device's supported features in bitwise manner.
  *
- * \param haptic the SDL_Haptic device to query
+ * \param[inout] haptic the SDL_Haptic device to query
  * \returns a list of supported haptic features in bitwise manner (OR'd), or 0
  *          on failure; call SDL_GetError() for more information.
  *
@@ -1146,7 +1146,7 @@ extern SDL_DECLSPEC Uint32 SDLCALL SDL_GetHapticFeatures(SDL_Haptic *haptic);
  * The number of haptic axes might be useful if working with the
  * SDL_HapticDirection effect.
  *
- * \param haptic the SDL_Haptic device to query
+ * \param[inout] haptic the SDL_Haptic device to query
  * \returns the number of axes on success or a negative error code on failure;
  *          call SDL_GetError() for more information.
  *
@@ -1157,8 +1157,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetNumHapticAxes(SDL_Haptic *haptic);
 /**
  * Check to see if an effect is supported by a haptic device.
  *
- * \param haptic the SDL_Haptic device to query
- * \param effect the desired effect to query
+ * \param[inout] haptic the SDL_Haptic device to query
+ * \param[in] effect the desired effect to query
  * \returns SDL_TRUE if the effect is supported or SDL_FALSE if it isn't.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1171,8 +1171,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_HapticEffectSupported(SDL_Haptic *hapti
 /**
  * Create a new haptic effect on a specified device.
  *
- * \param haptic an SDL_Haptic device to create the effect on
- * \param effect an SDL_HapticEffect structure containing the properties of
+ * \param[inout] haptic an SDL_Haptic device to create the effect on
+ * \param[in] effect an SDL_HapticEffect structure containing the properties of
  *               the effect to create
  * \returns the ID of the effect on success or a negative error code on
  *          failure; call SDL_GetError() for more information.
@@ -1193,9 +1193,9 @@ extern SDL_DECLSPEC int SDLCALL SDL_CreateHapticEffect(SDL_Haptic *haptic, const
  * start playing from the start. You also cannot change the type either when
  * running SDL_UpdateHapticEffect().
  *
- * \param haptic the SDL_Haptic device that has the effect
+ * \param[inout] haptic the SDL_Haptic device that has the effect
  * \param effect the identifier of the effect to update
- * \param data an SDL_HapticEffect structure containing the new effect
+ * \param[in] data an SDL_HapticEffect structure containing the new effect
  *             properties to use
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1216,7 +1216,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_UpdateHapticEffect(SDL_Haptic *haptic, int e
  * set the effect's `length` in its structure/union to `SDL_HAPTIC_INFINITY`
  * instead.
  *
- * \param haptic the SDL_Haptic device to run the effect on
+ * \param[inout] haptic the SDL_Haptic device to run the effect on
  * \param effect the ID of the haptic effect to run
  * \param iterations the number of iterations to run the effect; use
  *                   `SDL_HAPTIC_INFINITY` to repeat forever
@@ -1234,7 +1234,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_RunHapticEffect(SDL_Haptic *haptic, int effe
 /**
  * Stop the haptic effect on its associated haptic device.
  *
- * \param haptic the SDL_Haptic device to stop the effect on
+ * \param[inout] haptic the SDL_Haptic device to stop the effect on
  * \param effect the ID of the haptic effect to stop
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1252,7 +1252,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_StopHapticEffect(SDL_Haptic *haptic, int eff
  * This will stop the effect if it's running. Effects are automatically
  * destroyed when the device is closed.
  *
- * \param haptic the SDL_Haptic device to destroy the effect on
+ * \param[inout] haptic the SDL_Haptic device to destroy the effect on
  * \param effect the ID of the haptic effect to destroy
  *
  * \since This function is available since SDL 3.0.0.
@@ -1266,7 +1266,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_DestroyHapticEffect(SDL_Haptic *haptic, int
  *
  * Device must support the SDL_HAPTIC_STATUS feature.
  *
- * \param haptic the SDL_Haptic device to query for the effect status on
+ * \param[inout] haptic the SDL_Haptic device to query for the effect status on
  * \param effect the ID of the haptic effect to query its status
  * \returns 0 if it isn't playing, 1 if it is playing, or a negative error
  *          code on failure; call SDL_GetError() for more information.
@@ -1285,7 +1285,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetHapticEffectStatus(SDL_Haptic *haptic, in
  * SDL_SetHapticGain() will scale linearly using `SDL_HAPTIC_GAIN_MAX` as the
  * maximum.
  *
- * \param haptic the SDL_Haptic device to set the gain on
+ * \param[inout] haptic the SDL_Haptic device to set the gain on
  * \param gain value to set the gain to, should be between 0 and 100 (0 - 100)
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1304,7 +1304,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetHapticGain(SDL_Haptic *haptic, int gain);
  *
  * Device must support the SDL_HAPTIC_AUTOCENTER feature.
  *
- * \param haptic the SDL_Haptic device to set autocentering on
+ * \param[inout] haptic the SDL_Haptic device to set autocentering on
  * \param autocenter value to set autocenter to (0-100)
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1324,7 +1324,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetHapticAutocenter(SDL_Haptic *haptic, int 
  * Do not modify the effects nor add new ones while the device is paused. That
  * can cause all sorts of weird errors.
  *
- * \param haptic the SDL_Haptic device to pause
+ * \param[inout] haptic the SDL_Haptic device to pause
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1339,7 +1339,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_PauseHaptic(SDL_Haptic *haptic);
  *
  * Call to unpause after SDL_PauseHaptic().
  *
- * \param haptic the SDL_Haptic device to unpause
+ * \param[inout] haptic the SDL_Haptic device to unpause
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1352,7 +1352,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_ResumeHaptic(SDL_Haptic *haptic);
 /**
  * Stop all the currently playing effects on a haptic device.
  *
- * \param haptic the SDL_Haptic device to stop
+ * \param[inout] haptic the SDL_Haptic device to stop
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1366,7 +1366,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_StopHapticEffects(SDL_Haptic *haptic);
 /**
  * Check whether rumble is supported on a haptic device.
  *
- * \param haptic haptic device to check for rumble support
+ * \param[inout] haptic haptic device to check for rumble support
  * \returns SDL_TRUE if the effect is supported or SDL_FALSE if it isn't.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1378,7 +1378,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_HapticRumbleSupported(SDL_Haptic *hapti
 /**
  * Initialize a haptic device for simple rumble playback.
  *
- * \param haptic the haptic device to initialize for simple rumble playback
+ * \param[inout] haptic the haptic device to initialize for simple rumble playback
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1393,7 +1393,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_InitHapticRumble(SDL_Haptic *haptic);
 /**
  * Run a simple rumble effect on a haptic device.
  *
- * \param haptic the haptic device to play the rumble effect on
+ * \param[inout] haptic the haptic device to play the rumble effect on
  * \param strength strength of the rumble to play as a 0-1 float value
  * \param length length of the rumble to play in milliseconds
  * \returns 0 on success or a negative error code on failure; call
@@ -1409,7 +1409,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_PlayHapticRumble(SDL_Haptic *haptic, float s
 /**
  * Stop the simple rumble on a haptic device.
  *
- * \param haptic the haptic device to stop the rumble effect on
+ * \param[inout] haptic the haptic device to stop the rumble effect on
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *

--- a/include/SDL3/SDL_hidapi.h
+++ b/include/SDL3/SDL_hidapi.h
@@ -229,7 +229,7 @@ extern SDL_DECLSPEC Uint32 SDLCALL SDL_hid_device_change_count(void);
  *                  to match any vendor.
  * \param product_id The Product ID (PID) of the types of device to open, or 0
  *                   to match any product.
- * \returns a pointer to a linked list of type SDL_hid_device_info, containing
+ * \returns[own] a pointer to a linked list of type SDL_hid_device_info, containing
  *          information about the HID devices attached to the system, or NULL
  *          in the case of failure. Free this linked list by calling
  *          SDL_hid_free_enumeration().
@@ -245,7 +245,7 @@ extern SDL_DECLSPEC SDL_hid_device_info * SDLCALL SDL_hid_enumerate(unsigned sho
  *
  * This function frees a linked list created by SDL_hid_enumerate().
  *
- * \param devs Pointer to a list of struct_device returned from
+ * \param[inout] devs Pointer to a list of struct_device returned from
  *             SDL_hid_enumerate().
  *
  * \since This function is available since SDL 3.0.0.
@@ -261,9 +261,9 @@ extern SDL_DECLSPEC void SDLCALL SDL_hid_free_enumeration(SDL_hid_device_info *d
  *
  * \param vendor_id The Vendor ID (VID) of the device to open.
  * \param product_id The Product ID (PID) of the device to open.
- * \param serial_number The Serial Number of the device to open (Optionally
+ * \param[in,opt] serial_number The Serial Number of the device to open (Optionally
  *                      NULL).
- * \returns a pointer to a SDL_hid_device object on success or NULL on
+ * \returns[own] a pointer to a SDL_hid_device object on success or NULL on
  *          failure.
  *
  * \since This function is available since SDL 3.0.0.
@@ -276,8 +276,8 @@ extern SDL_DECLSPEC SDL_hid_device * SDLCALL SDL_hid_open(unsigned short vendor_
  * The path name be determined by calling SDL_hid_enumerate(), or a
  * platform-specific path name can be used (eg: /dev/hidraw0 on Linux).
  *
- * \param path The path name of the device to open
- * \returns a pointer to a SDL_hid_device object on success or NULL on
+ * \param[in] path The path name of the device to open
+ * \returns[own] a pointer to a SDL_hid_device object on success or NULL on
  *          failure.
  *
  * \since This function is available since SDL 3.0.0.
@@ -300,8 +300,8 @@ extern SDL_DECLSPEC SDL_hid_device * SDLCALL SDL_hid_open_path(const char *path)
  * exists. If it does not, it will send the data through the Control Endpoint
  * (Endpoint 0).
  *
- * \param dev A device handle returned from SDL_hid_open().
- * \param data The data to send, including the report number as the first
+ * \param[inout] dev A device handle returned from SDL_hid_open().
+ * \param[in] data The data to send, including the report number as the first
  *             byte.
  * \param length The length in bytes of the data to send.
  * \returns the actual number of bytes written and -1 on error.
@@ -317,8 +317,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_hid_write(SDL_hid_device *dev, const unsigne
  * The first byte will contain the Report number if the device uses numbered
  * reports.
  *
- * \param dev A device handle returned from SDL_hid_open().
- * \param data A buffer to put the read data into.
+ * \param[inout] dev A device handle returned from SDL_hid_open().
+ * \param[out] data A buffer to put the read data into.
  * \param length The number of bytes to read. For devices with multiple
  *               reports, make sure to read an extra byte for the report
  *               number.
@@ -338,8 +338,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_hid_read_timeout(SDL_hid_device *dev, unsign
  * The first byte will contain the Report number if the device uses numbered
  * reports.
  *
- * \param dev A device handle returned from SDL_hid_open().
- * \param data A buffer to put the read data into.
+ * \param[inout] dev A device handle returned from SDL_hid_open().
+ * \param[out] data A buffer to put the read data into.
  * \param length The number of bytes to read. For devices with multiple
  *               reports, make sure to read an extra byte for the report
  *               number.
@@ -360,7 +360,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_hid_read(SDL_hid_device *dev, unsigned char 
  *
  * Nonblocking can be turned on and off at any time.
  *
- * \param dev A device handle returned from SDL_hid_open().
+ * \param[inout] dev A device handle returned from SDL_hid_open().
  * \param nonblock enable or not the nonblocking reads - 1 to enable
  *                 nonblocking - 0 to disable nonblocking.
  * \returns 0 on success or a negative error code on failure; call
@@ -383,8 +383,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_hid_set_nonblocking(SDL_hid_device *dev, int
  * devices which do not use numbered reports), followed by the report data (16
  * bytes). In this example, the length passed in would be 17.
  *
- * \param dev A device handle returned from SDL_hid_open().
- * \param data The data to send, including the report number as the first
+ * \param[inout] dev A device handle returned from SDL_hid_open().
+ * \param[in] data The data to send, including the report number as the first
  *             byte.
  * \param length The length in bytes of the data to send, including the report
  *               number.
@@ -402,8 +402,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_hid_send_feature_report(SDL_hid_device *dev,
  * first byte will still contain the Report ID, and the report data will start
  * in data[1].
  *
- * \param dev A device handle returned from SDL_hid_open().
- * \param data A buffer to put the read data into, including the Report ID.
+ * \param[inout] dev A device handle returned from SDL_hid_open().
+ * \param[out] data A buffer to put the read data into, including the Report ID.
  *             Set the first byte of `data` to the Report ID of the report to
  *             be read, or set it to zero if your device does not use numbered
  *             reports.
@@ -424,8 +424,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_hid_get_feature_report(SDL_hid_device *dev, 
  * first byte will still contain the Report ID, and the report data will start
  * in data[1].
  *
- * \param dev A device handle returned from SDL_hid_open().
- * \param data A buffer to put the read data into, including the Report ID.
+ * \param[inout] dev A device handle returned from SDL_hid_open().
+ * \param[out] data A buffer to put the read data into, including the Report ID.
  *             Set the first byte of `data` to the Report ID of the report to
  *             be read, or set it to zero if your device does not use numbered
  *             reports.
@@ -441,7 +441,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_hid_get_input_report(SDL_hid_device *dev, un
 /**
  * Close a HID device.
  *
- * \param dev A device handle returned from SDL_hid_open().
+ * \param[inout] dev A device handle returned from SDL_hid_open().
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -452,8 +452,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_hid_close(SDL_hid_device *dev);
 /**
  * Get The Manufacturer String from a HID device.
  *
- * \param dev A device handle returned from SDL_hid_open().
- * \param string A wide string buffer to put the data into.
+ * \param[inout] dev A device handle returned from SDL_hid_open().
+ * \param[out] string A wide string buffer to put the data into.
  * \param maxlen The length of the buffer in multiples of wchar_t.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -465,8 +465,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_hid_get_manufacturer_string(SDL_hid_device *
 /**
  * Get The Product String from a HID device.
  *
- * \param dev A device handle returned from SDL_hid_open().
- * \param string A wide string buffer to put the data into.
+ * \param[inout] dev A device handle returned from SDL_hid_open().
+ * \param[out] string A wide string buffer to put the data into.
  * \param maxlen The length of the buffer in multiples of wchar_t.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -478,8 +478,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_hid_get_product_string(SDL_hid_device *dev, 
 /**
  * Get The Serial Number String from a HID device.
  *
- * \param dev A device handle returned from SDL_hid_open().
- * \param string A wide string buffer to put the data into.
+ * \param[inout] dev A device handle returned from SDL_hid_open().
+ * \param[out] string A wide string buffer to put the data into.
  * \param maxlen The length of the buffer in multiples of wchar_t.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -491,9 +491,9 @@ extern SDL_DECLSPEC int SDLCALL SDL_hid_get_serial_number_string(SDL_hid_device 
 /**
  * Get a string from a HID device, based on its string index.
  *
- * \param dev A device handle returned from SDL_hid_open().
+ * \param[inout] dev A device handle returned from SDL_hid_open().
  * \param string_index The index of the string to get.
- * \param string A wide string buffer to put the data into.
+ * \param[out] string A wide string buffer to put the data into.
  * \param maxlen The length of the buffer in multiples of wchar_t.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -505,7 +505,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_hid_get_indexed_string(SDL_hid_device *dev, 
 /**
  * Get the device info from a HID device.
  *
- * \param dev A device handle returned from SDL_hid_open().
+ * \param[inout] dev A device handle returned from SDL_hid_open().
  * \returns a pointer to the SDL_hid_device_info for this hid_device, or NULL
  *          in the case of failure; call SDL_GetError() for more information.
  *          This struct is valid until the device is closed with
@@ -521,8 +521,8 @@ extern SDL_DECLSPEC SDL_hid_device_info * SDLCALL SDL_hid_get_device_info(SDL_hi
  * User has to provide a preallocated buffer where descriptor will be copied
  * to. The recommended size for a preallocated buffer is 4096 bytes.
  *
- * \param dev A device handle returned from SDL_hid_open().
- * \param buf The buffer to copy descriptor into.
+ * \param[inout] dev A device handle returned from SDL_hid_open().
+ * \param[out] buf The buffer to copy descriptor into.
  * \param buf_size The size of the buffer in bytes.
  * \returns the number of bytes actually copied, or -1 on error; call
  *          SDL_GetError() for more information.

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -3738,8 +3738,8 @@ typedef enum SDL_HintPriority
  * value. Hints will replace existing hints of their priority and lower.
  * Environment variables are considered to have override priority.
  *
- * \param name the hint to set
- * \param value the value of the hint variable
+ * \param[in] name the hint to set
+ * \param[in] value the value of the hint variable
  * \param priority the SDL_HintPriority level for the hint
  * \returns SDL_TRUE if the hint was set, SDL_FALSE otherwise.
  *
@@ -3760,8 +3760,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_SetHintWithPriority(const char *name,
  * variable that takes precedence. You can use SDL_SetHintWithPriority() to
  * set the hint with override priority instead.
  *
- * \param name the hint to set
- * \param value the value of the hint variable
+ * \param[in] name the hint to set
+ * \param[in] value the value of the hint variable
  * \returns SDL_TRUE if the hint was set, SDL_FALSE otherwise.
  *
  * \since This function is available since SDL 3.0.0.
@@ -3780,7 +3780,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_SetHint(const char *name,
  * the environment isn't set. Callbacks will be called normally with this
  * change.
  *
- * \param name the hint to set
+ * \param[in] name the hint to set
  * \returns SDL_TRUE if the hint was set, SDL_FALSE otherwise.
  *
  * \since This function is available since SDL 3.0.0.
@@ -3806,7 +3806,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_ResetHints(void);
 /**
  * Get the value of a hint.
  *
- * \param name the hint to query
+ * \param[in] name the hint to query
  * \returns the string value of a hint or NULL if the hint isn't set.
  *
  * \since This function is available since SDL 3.0.0.
@@ -3819,7 +3819,7 @@ extern SDL_DECLSPEC const char * SDLCALL SDL_GetHint(const char *name);
 /**
  * Get the boolean value of a hint variable.
  *
- * \param name the name of the hint to get the boolean value from
+ * \param[in] name the name of the hint to get the boolean value from
  * \param default_value the value to return if the hint does not exist
  * \returns the boolean value of a hint or the provided default value if the
  *          hint does not exist.
@@ -3846,10 +3846,10 @@ typedef void (SDLCALL *SDL_HintCallback)(void *userdata, const char *name, const
 /**
  * Add a function to watch a particular hint.
  *
- * \param name the hint to watch
- * \param callback An SDL_HintCallback function that will be called when the
+ * \param[in] name the hint to watch
+ * \param[in] callback An SDL_HintCallback function that will be called when the
  *                 hint value changes
- * \param userdata a pointer to pass to the callback function
+ * \param[inout,opt] userdata a pointer to pass to the callback function
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -3867,10 +3867,10 @@ extern SDL_DECLSPEC int SDLCALL SDL_AddHintCallback(const char *name,
 /**
  * Remove a function watching a particular hint.
  *
- * \param name the hint being watched
- * \param callback An SDL_HintCallback function that will be called when the
+ * \param[in] name the hint being watched
+ * \param[in] callback An SDL_HintCallback function that will be called when the
  *                 hint value changes
- * \param userdata a pointer being passed to the callback function
+ * \param[inout,opt] userdata a pointer being passed to the callback function
  *
  * \since This function is available since SDL 3.0.0.
  *

--- a/include/SDL3/SDL_iostream.h
+++ b/include/SDL3/SDL_iostream.h
@@ -202,10 +202,10 @@ typedef struct SDL_IOStream SDL_IOStream;
  *   the filesystem. If SDL used some other method to access the filesystem,
  *   this property will not be set.
  *
- * \param file a UTF-8 string representing the filename to open
- * \param mode an ASCII string representing the mode to be used for opening
+ * \param[in] file a UTF-8 string representing the filename to open
+ * \param[in] mode an ASCII string representing the mode to be used for opening
  *             the file.
- * \returns a pointer to the SDL_IOStream structure that is created, or NULL
+ * \returns[own] a pointer to the SDL_IOStream structure that is created, or NULL
  *          on failure; call SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -237,9 +237,9 @@ extern SDL_DECLSPEC SDL_IOStream *SDLCALL SDL_IOFromFile(const char *file, const
  * buffer, you should use SDL_IOFromConstMem() with a read-only buffer of
  * memory instead.
  *
- * \param mem a pointer to a buffer to feed an SDL_IOStream stream
+ * \param[inout] mem a pointer to a buffer to feed an SDL_IOStream stream
  * \param size the buffer size, in bytes
- * \returns a pointer to a new SDL_IOStream structure, or NULL if it fails;
+ * \returns[own] a pointer to a new SDL_IOStream structure, or NULL if it fails;
  *          call SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -270,9 +270,9 @@ extern SDL_DECLSPEC SDL_IOStream *SDLCALL SDL_IOFromMem(void *mem, size_t size);
  * If you need to write to a memory buffer, you should use SDL_IOFromMem()
  * with a writable buffer of memory instead.
  *
- * \param mem a pointer to a read-only buffer to feed an SDL_IOStream stream
+ * \param[in] mem a pointer to a read-only buffer to feed an SDL_IOStream stream
  * \param size the buffer size, in bytes
- * \returns a pointer to a new SDL_IOStream structure, or NULL if it fails;
+ * \returns[own] a pointer to a new SDL_IOStream structure, or NULL if it fails;
  *          call SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -297,7 +297,7 @@ extern SDL_DECLSPEC SDL_IOStream *SDLCALL SDL_IOFromConstMem(const void *mem, si
  * must be SDL_CloseIO(). - `SDL_PROP_IOSTREAM_DYNAMIC_CHUNKSIZE_NUMBER`:
  * memory will be allocated in multiples of this size, defaulting to 1024.
  *
- * \returns a pointer to a new SDL_IOStream structure, or NULL if it fails;
+ * \returns[own] a pointer to a new SDL_IOStream structure, or NULL if it fails;
  *          call SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -329,10 +329,10 @@ extern SDL_DECLSPEC SDL_IOStream *SDLCALL SDL_IOFromDynamicMem(void);
  * This function makes a copy of `iface` and the caller does not need to keep
  * this data around after this call.
  *
- * \param iface The function pointers that implement this SDL_IOStream.
- * \param userdata The app-controlled pointer that is passed to iface's
+ * \param[in] iface The function pointers that implement this SDL_IOStream.
+ * \param[inout] userdata The app-controlled pointer that is passed to iface's
  *                 functions when called.
- * \returns a pointer to the allocated memory on success, or NULL on failure;
+ * \returns[own] a pointer to the allocated memory on success, or NULL on failure;
  *          call SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -355,7 +355,7 @@ extern SDL_DECLSPEC SDL_IOStream *SDLCALL SDL_OpenIO(const SDL_IOStreamInterface
  * Note that if this fails to flush the stream to disk, this function reports
  * an error, but the SDL_IOStream is still invalid once this function returns.
  *
- * \param context SDL_IOStream structure to close
+ * \param[inout] context SDL_IOStream structure to close
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -368,7 +368,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_CloseIO(SDL_IOStream *context);
 /**
  * Get the properties associated with an SDL_IOStream.
  *
- * \param context a pointer to an SDL_IOStream structure
+ * \param[inout] context a pointer to an SDL_IOStream structure
  * \returns a valid property ID on success or 0 on failure; call
  *          SDL_GetError() for more information.
  *
@@ -395,7 +395,7 @@ extern SDL_DECLSPEC SDL_PropertiesID SDLCALL SDL_GetIOProperties(SDL_IOStream *c
  * SDL_WriteIO call; don't expect it to change if you just call this query
  * function in a tight loop.
  *
- * \param context the SDL_IOStream to query.
+ * \param[inout] context the SDL_IOStream to query.
  * \returns an SDL_IOStatus enum with the current state.
  *
  * \threadsafety This function should not be called at the same time that
@@ -408,7 +408,7 @@ extern SDL_DECLSPEC SDL_IOStatus SDLCALL SDL_GetIOStatus(SDL_IOStream *context);
 /**
  * Use this function to get the size of the data stream in an SDL_IOStream.
  *
- * \param context the SDL_IOStream to get the size of the data stream from
+ * \param[inout] context the SDL_IOStream to get the size of the data stream from
  * \returns the size of the data stream in the SDL_IOStream on success or a
  *          negative error code on failure; call SDL_GetError() for more
  *          information.
@@ -430,7 +430,7 @@ extern SDL_DECLSPEC Sint64 SDLCALL SDL_GetIOSize(SDL_IOStream *context);
  *
  * If this stream can not seek, it will return -1.
  *
- * \param context a pointer to an SDL_IOStream structure
+ * \param[inout] context a pointer to an SDL_IOStream structure
  * \param offset an offset in bytes, relative to **whence** location; can be
  *               negative
  * \param whence any of `SDL_IO_SEEK_SET`, `SDL_IO_SEEK_CUR`,
@@ -451,7 +451,7 @@ extern SDL_DECLSPEC Sint64 SDLCALL SDL_SeekIO(SDL_IOStream *context, Sint64 offs
  * `seek` method, with an offset of 0 bytes from `SDL_IO_SEEK_CUR`, to
  * simplify application development.
  *
- * \param context an SDL_IOStream data stream object from which to get the
+ * \param[inout] context an SDL_IOStream data stream object from which to get the
  *                current offset
  * \returns the current offset in the stream, or -1 if the information can not
  *          be determined.
@@ -471,8 +471,8 @@ extern SDL_DECLSPEC Sint64 SDLCALL SDL_TellIO(SDL_IOStream *context);
  * determine if there was an error or all data was read, call
  * SDL_GetIOStatus().
  *
- * \param context a pointer to an SDL_IOStream structure
- * \param ptr a pointer to a buffer to read data into
+ * \param[inout] context a pointer to an SDL_IOStream structure
+ * \param[out] ptr a pointer to a buffer to read data into
  * \param size the number of bytes to read from the data source.
  * \returns the number of bytes read, or 0 on end of file or other error.
  *
@@ -497,8 +497,8 @@ extern SDL_DECLSPEC size_t SDLCALL SDL_ReadIO(SDL_IOStream *context, void *ptr, 
  * recoverable, such as a non-blocking write that can simply be retried later,
  * or a fatal error.
  *
- * \param context a pointer to an SDL_IOStream structure
- * \param ptr a pointer to a buffer containing data to write
+ * \param[inout] context a pointer to an SDL_IOStream structure
+ * \param[in] ptr a pointer to a buffer containing data to write
  * \param size the number of bytes to write
  * \returns the number of bytes written, which will be less than `size` on
  *          error; call SDL_GetError() for more information.
@@ -517,8 +517,8 @@ extern SDL_DECLSPEC size_t SDLCALL SDL_WriteIO(SDL_IOStream *context, const void
  *
  * This function does formatted printing to the stream.
  *
- * \param context a pointer to an SDL_IOStream structure
- * \param fmt a printf() style format string
+ * \param[inout] context a pointer to an SDL_IOStream structure
+ * \param[in] fmt a printf() style format string
  * \param ... additional parameters matching % tokens in the `fmt` string, if
  *            any
  * \returns the number of bytes written, or 0 on error; call SDL_GetError()
@@ -536,8 +536,8 @@ extern SDL_DECLSPEC size_t SDLCALL SDL_IOprintf(SDL_IOStream *context, SDL_PRINT
  *
  * This function does formatted printing to the stream.
  *
- * \param context a pointer to an SDL_IOStream structure
- * \param fmt a printf() style format string
+ * \param[inout] context a pointer to an SDL_IOStream structure
+ * \param[in] fmt a printf() style format string
  * \param ap a variable argument list
  * \returns the number of bytes written, or 0 on error; call SDL_GetError()
  *          for more information.
@@ -558,11 +558,11 @@ extern SDL_DECLSPEC size_t SDLCALL SDL_IOvprintf(SDL_IOStream *context, SDL_PRIN
  *
  * The data should be freed with SDL_free().
  *
- * \param src the SDL_IOStream to read all available data from
- * \param datasize if not NULL, will store the number of bytes read
+ * \param[inout] src the SDL_IOStream to read all available data from
+ * \param[out,opt] datasize if not NULL, will store the number of bytes read
  * \param closeio if SDL_TRUE, calls SDL_CloseIO() on `src` before returning,
  *                even in the case of an error
- * \returns the data, or NULL if there was an error.
+ * \returns[own] the data, or NULL if there was an error.
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -579,9 +579,9 @@ extern SDL_DECLSPEC void *SDLCALL SDL_LoadFile_IO(SDL_IOStream *src, size_t *dat
  *
  * The data should be freed with SDL_free().
  *
- * \param file the path to read all available data from
- * \param datasize if not NULL, will store the number of bytes read
- * \returns the data, or NULL if there was an error.
+ * \param[inout] file the path to read all available data from
+ * \param[out,opt] datasize if not NULL, will store the number of bytes read
+ * \returns[own] the data, or NULL if there was an error.
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -599,8 +599,8 @@ extern SDL_DECLSPEC void *SDLCALL SDL_LoadFile(const char *file, size_t *datasiz
 /**
  * Use this function to read a byte from an SDL_IOStream.
  *
- * \param src the SDL_IOStream to read from
- * \param value a pointer filled in with the data read
+ * \param[inout] src the SDL_IOStream to read from
+ * \param[out] value a pointer filled in with the data read
  * \returns SDL_TRUE on success or SDL_FALSE on failure; call SDL_GetError()
  *          for more information.
  *
@@ -615,8 +615,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_ReadU8(SDL_IOStream *src, Uint8 *value)
  * SDL byteswaps the data only if necessary, so the data returned will be in
  * the native byte order.
  *
- * \param src the stream from which to read data
- * \param value a pointer filled in with the data read
+ * \param[inout] src the stream from which to read data
+ * \param[out] value a pointer filled in with the data read
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
  *
@@ -631,8 +631,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_ReadU16LE(SDL_IOStream *src, Uint16 *va
  * SDL byteswaps the data only if necessary, so the data returned will be in
  * the native byte order.
  *
- * \param src the stream from which to read data
- * \param value a pointer filled in with the data read
+ * \param[inout] src the stream from which to read data
+ * \param[out] value a pointer filled in with the data read
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
  *
@@ -647,8 +647,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_ReadS16LE(SDL_IOStream *src, Sint16 *va
  * SDL byteswaps the data only if necessary, so the data returned will be in
  * the native byte order.
  *
- * \param src the stream from which to read data
- * \param value a pointer filled in with the data read
+ * \param[inout] src the stream from which to read data
+ * \param[out] value a pointer filled in with the data read
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
  *
@@ -663,8 +663,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_ReadU16BE(SDL_IOStream *src, Uint16 *va
  * SDL byteswaps the data only if necessary, so the data returned will be in
  * the native byte order.
  *
- * \param src the stream from which to read data
- * \param value a pointer filled in with the data read
+ * \param[inout] src the stream from which to read data
+ * \param[out] value a pointer filled in with the data read
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
  *
@@ -679,8 +679,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_ReadS16BE(SDL_IOStream *src, Sint16 *va
  * SDL byteswaps the data only if necessary, so the data returned will be in
  * the native byte order.
  *
- * \param src the stream from which to read data
- * \param value a pointer filled in with the data read
+ * \param[inout] src the stream from which to read data
+ * \param[out] value a pointer filled in with the data read
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
  *
@@ -695,8 +695,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_ReadU32LE(SDL_IOStream *src, Uint32 *va
  * SDL byteswaps the data only if necessary, so the data returned will be in
  * the native byte order.
  *
- * \param src the stream from which to read data
- * \param value a pointer filled in with the data read
+ * \param[inout] src the stream from which to read data
+ * \param[out] value a pointer filled in with the data read
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
  *
@@ -711,8 +711,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_ReadS32LE(SDL_IOStream *src, Sint32 *va
  * SDL byteswaps the data only if necessary, so the data returned will be in
  * the native byte order.
  *
- * \param src the stream from which to read data
- * \param value a pointer filled in with the data read
+ * \param[inout] src the stream from which to read data
+ * \param[out] value a pointer filled in with the data read
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
  *
@@ -727,8 +727,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_ReadU32BE(SDL_IOStream *src, Uint32 *va
  * SDL byteswaps the data only if necessary, so the data returned will be in
  * the native byte order.
  *
- * \param src the stream from which to read data
- * \param value a pointer filled in with the data read
+ * \param[inout] src the stream from which to read data
+ * \param[out] value a pointer filled in with the data read
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
  *
@@ -743,8 +743,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_ReadS32BE(SDL_IOStream *src, Sint32 *va
  * SDL byteswaps the data only if necessary, so the data returned will be in
  * the native byte order.
  *
- * \param src the stream from which to read data
- * \param value a pointer filled in with the data read
+ * \param[inout] src the stream from which to read data
+ * \param[out] value a pointer filled in with the data read
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
  *
@@ -759,8 +759,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_ReadU64LE(SDL_IOStream *src, Uint64 *va
  * SDL byteswaps the data only if necessary, so the data returned will be in
  * the native byte order.
  *
- * \param src the stream from which to read data
- * \param value a pointer filled in with the data read
+ * \param[inout] src the stream from which to read data
+ * \param[out] value a pointer filled in with the data read
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
  *
@@ -775,8 +775,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_ReadS64LE(SDL_IOStream *src, Sint64 *va
  * SDL byteswaps the data only if necessary, so the data returned will be in
  * the native byte order.
  *
- * \param src the stream from which to read data
- * \param value a pointer filled in with the data read
+ * \param[inout] src the stream from which to read data
+ * \param[out] value a pointer filled in with the data read
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
  *
@@ -791,8 +791,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_ReadU64BE(SDL_IOStream *src, Uint64 *va
  * SDL byteswaps the data only if necessary, so the data returned will be in
  * the native byte order.
  *
- * \param src the stream from which to read data
- * \param value a pointer filled in with the data read
+ * \param[inout] src the stream from which to read data
+ * \param[out] value a pointer filled in with the data read
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
  *
@@ -811,7 +811,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_ReadS64BE(SDL_IOStream *src, Sint64 *va
 /**
  * Use this function to write a byte to an SDL_IOStream.
  *
- * \param dst the SDL_IOStream to write to
+ * \param[inout] dst the SDL_IOStream to write to
  * \param value the byte value to write
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
@@ -828,7 +828,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_WriteU8(SDL_IOStream *dst, Uint8 value)
  * specifies native format, and the data written will be in little-endian
  * format.
  *
- * \param dst the stream to which data will be written
+ * \param[inout] dst the stream to which data will be written
  * \param value the data to be written, in native format
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
@@ -845,7 +845,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_WriteU16LE(SDL_IOStream *dst, Uint16 va
  * specifies native format, and the data written will be in little-endian
  * format.
  *
- * \param dst the stream to which data will be written
+ * \param[inout] dst the stream to which data will be written
  * \param value the data to be written, in native format
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
@@ -861,7 +861,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_WriteS16LE(SDL_IOStream *dst, Sint16 va
  * SDL byteswaps the data only if necessary, so the application always
  * specifies native format, and the data written will be in big-endian format.
  *
- * \param dst the stream to which data will be written
+ * \param[inout] dst the stream to which data will be written
  * \param value the data to be written, in native format
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
@@ -877,7 +877,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_WriteU16BE(SDL_IOStream *dst, Uint16 va
  * SDL byteswaps the data only if necessary, so the application always
  * specifies native format, and the data written will be in big-endian format.
  *
- * \param dst the stream to which data will be written
+ * \param[inout] dst the stream to which data will be written
  * \param value the data to be written, in native format
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
@@ -894,7 +894,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_WriteS16BE(SDL_IOStream *dst, Sint16 va
  * specifies native format, and the data written will be in little-endian
  * format.
  *
- * \param dst the stream to which data will be written
+ * \param[inout] dst the stream to which data will be written
  * \param value the data to be written, in native format
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
@@ -911,7 +911,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_WriteU32LE(SDL_IOStream *dst, Uint32 va
  * specifies native format, and the data written will be in little-endian
  * format.
  *
- * \param dst the stream to which data will be written
+ * \param[inout] dst the stream to which data will be written
  * \param value the data to be written, in native format
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
@@ -927,7 +927,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_WriteS32LE(SDL_IOStream *dst, Sint32 va
  * SDL byteswaps the data only if necessary, so the application always
  * specifies native format, and the data written will be in big-endian format.
  *
- * \param dst the stream to which data will be written
+ * \param[inout] dst the stream to which data will be written
  * \param value the data to be written, in native format
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
@@ -943,7 +943,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_WriteU32BE(SDL_IOStream *dst, Uint32 va
  * SDL byteswaps the data only if necessary, so the application always
  * specifies native format, and the data written will be in big-endian format.
  *
- * \param dst the stream to which data will be written
+ * \param[inout] dst the stream to which data will be written
  * \param value the data to be written, in native format
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
@@ -960,7 +960,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_WriteS32BE(SDL_IOStream *dst, Sint32 va
  * specifies native format, and the data written will be in little-endian
  * format.
  *
- * \param dst the stream to which data will be written
+ * \param[inout] dst the stream to which data will be written
  * \param value the data to be written, in native format
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
@@ -977,7 +977,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_WriteU64LE(SDL_IOStream *dst, Uint64 va
  * specifies native format, and the data written will be in little-endian
  * format.
  *
- * \param dst the stream to which data will be written
+ * \param[inout] dst the stream to which data will be written
  * \param value the data to be written, in native format
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
@@ -993,7 +993,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_WriteS64LE(SDL_IOStream *dst, Sint64 va
  * SDL byteswaps the data only if necessary, so the application always
  * specifies native format, and the data written will be in big-endian format.
  *
- * \param dst the stream to which data will be written
+ * \param[inout] dst the stream to which data will be written
  * \param value the data to be written, in native format
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.
@@ -1009,7 +1009,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_WriteU64BE(SDL_IOStream *dst, Uint64 va
  * SDL byteswaps the data only if necessary, so the application always
  * specifies native format, and the data written will be in big-endian format.
  *
- * \param dst the stream to which data will be written
+ * \param[inout] dst the stream to which data will be written
  * \param value the data to be written, in native format
  * \returns SDL_TRUE on successful write, SDL_FALSE on failure; call
  *          SDL_GetError() for more information.

--- a/include/SDL3/SDL_joystick.h
+++ b/include/SDL3/SDL_joystick.h
@@ -214,8 +214,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_HasJoystick(void);
 /**
  * Get a list of currently connected joysticks.
  *
- * \param count a pointer filled in with the number of joysticks returned
- * \returns a 0 terminated array of joystick instance IDs which should be
+ * \param[out] count a pointer filled in with the number of joysticks returned
+ * \returns[own] a 0 terminated array of joystick instance IDs which should be
  *          freed with SDL_free(), or NULL on error; call SDL_GetError() for
  *          more details.
  *
@@ -364,7 +364,7 @@ extern SDL_DECLSPEC SDL_JoystickType SDLCALL SDL_GetJoystickInstanceType(SDL_Joy
  * for use.
  *
  * \param instance_id the joystick instance ID
- * \returns a joystick identifier or NULL if an error occurred; call
+ * \returns[own] a joystick identifier or NULL if an error occurred; call
  *          SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -469,7 +469,7 @@ typedef struct SDL_VirtualJoystickDesc
 /**
  * Attach a new virtual joystick.
  *
- * \param desc Joystick description
+ * \param[in] desc Joystick description
  * \returns the joystick instance ID, or 0 if an error occurred; call
  *          SDL_GetError() for more information.
  *
@@ -516,7 +516,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_IsJoystickVirtual(SDL_JoystickID instan
  * range of Sint16. For example, a trigger at rest would have the value of
  * `SDL_JOYSTICK_AXIS_MIN`.
  *
- * \param joystick the virtual joystick on which to set state.
+ * \param[inout] joystick the virtual joystick on which to set state.
  * \param axis the index of the axis on the virtual joystick to update.
  * \param value the new value for the specified axis.
  * \returns 0 on success or a negative error code on failure; call
@@ -535,7 +535,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetJoystickVirtualAxis(SDL_Joystick *joystic
  * the following: SDL_PollEvent, SDL_PumpEvents, SDL_WaitEventTimeout,
  * SDL_WaitEvent.
  *
- * \param joystick the virtual joystick on which to set state.
+ * \param[inout] joystick the virtual joystick on which to set state.
  * \param ball the index of the ball on the virtual joystick to update.
  * \param xrel the relative motion on the X axis.
  * \param yrel the relative motion on the Y axis.
@@ -555,7 +555,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetJoystickVirtualBall(SDL_Joystick *joystic
  * the following: SDL_PollEvent, SDL_PumpEvents, SDL_WaitEventTimeout,
  * SDL_WaitEvent.
  *
- * \param joystick the virtual joystick on which to set state.
+ * \param[inout] joystick the virtual joystick on which to set state.
  * \param button the index of the button on the virtual joystick to update.
  * \param value the new value for the specified button.
  * \returns 0 on success or a negative error code on failure; call
@@ -574,7 +574,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetJoystickVirtualButton(SDL_Joystick *joyst
  * the following: SDL_PollEvent, SDL_PumpEvents, SDL_WaitEventTimeout,
  * SDL_WaitEvent.
  *
- * \param joystick the virtual joystick on which to set state.
+ * \param[inout] joystick the virtual joystick on which to set state.
  * \param hat the index of the hat on the virtual joystick to update.
  * \param value the new value for the specified hat.
  * \returns 0 on success or a negative error code on failure; call
@@ -593,7 +593,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetJoystickVirtualHat(SDL_Joystick *joystick
  * the following: SDL_PollEvent, SDL_PumpEvents, SDL_WaitEventTimeout,
  * SDL_WaitEvent.
  *
- * \param joystick the virtual joystick on which to set state.
+ * \param[inout] joystick the virtual joystick on which to set state.
  * \param touchpad the index of the touchpad on the virtual joystick to
  *                 update.
  * \param finger the index of the finger on the touchpad to set.
@@ -620,11 +620,11 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetJoystickVirtualTouchpad(SDL_Joystick *joy
  * the following: SDL_PollEvent, SDL_PumpEvents, SDL_WaitEventTimeout,
  * SDL_WaitEvent.
  *
- * \param joystick the virtual joystick on which to set state.
+ * \param[inout] joystick the virtual joystick on which to set state.
  * \param type the type of the sensor on the virtual joystick to update.
  * \param sensor_timestamp a 64-bit timestamp in nanoseconds associated with
  *                         the sensor reading
- * \param data the data associated with the sensor reading
+ * \param[in] data the data associated with the sensor reading
  * \param num_values the number of values pointed to by `data`
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -649,7 +649,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SendJoystickVirtualSensorData(SDL_Joystick *
  * - `SDL_PROP_JOYSTICK_CAP_TRIGGER_RUMBLE_BOOLEAN`: true if this joystick has
  *   simple trigger rumble
  *
- * \param joystick the SDL_Joystick obtained from SDL_OpenJoystick()
+ * \param[inout] joystick the SDL_Joystick obtained from SDL_OpenJoystick()
  * \returns a valid property ID on success or 0 on failure; call
  *          SDL_GetError() for more information.
  *
@@ -669,7 +669,7 @@ extern SDL_DECLSPEC SDL_PropertiesID SDLCALL SDL_GetJoystickProperties(SDL_Joyst
 /**
  * Get the implementation dependent name of a joystick.
  *
- * \param joystick the SDL_Joystick obtained from SDL_OpenJoystick()
+ * \param[inout] joystick the SDL_Joystick obtained from SDL_OpenJoystick()
  * \returns the name of the selected joystick. If no name can be found, this
  *          function returns NULL; call SDL_GetError() for more information.
  *
@@ -682,7 +682,7 @@ extern SDL_DECLSPEC const char *SDLCALL SDL_GetJoystickName(SDL_Joystick *joysti
 /**
  * Get the implementation dependent path of a joystick.
  *
- * \param joystick the SDL_Joystick obtained from SDL_OpenJoystick()
+ * \param[inout] joystick the SDL_Joystick obtained from SDL_OpenJoystick()
  * \returns the path of the selected joystick. If no path can be found, this
  *          function returns NULL; call SDL_GetError() for more information.
  *
@@ -698,7 +698,7 @@ extern SDL_DECLSPEC const char *SDLCALL SDL_GetJoystickPath(SDL_Joystick *joysti
  * For XInput controllers this returns the XInput user index. Many joysticks
  * will not be able to supply this information.
  *
- * \param joystick the SDL_Joystick obtained from SDL_OpenJoystick()
+ * \param[inout] joystick the SDL_Joystick obtained from SDL_OpenJoystick()
  * \returns the player index, or -1 if it's not available.
  *
  * \since This function is available since SDL 3.0.0.
@@ -710,7 +710,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetJoystickPlayerIndex(SDL_Joystick *joystic
 /**
  * Set the player index of an opened joystick.
  *
- * \param joystick the SDL_Joystick obtained from SDL_OpenJoystick()
+ * \param[inout] joystick the SDL_Joystick obtained from SDL_OpenJoystick()
  * \param player_index Player index to assign to this joystick, or -1 to clear
  *                     the player index and turn off player LEDs.
  * \returns 0 on success or a negative error code on failure; call
@@ -727,7 +727,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetJoystickPlayerIndex(SDL_Joystick *joystic
  *
  * This function requires an open joystick.
  *
- * \param joystick the SDL_Joystick obtained from SDL_OpenJoystick()
+ * \param[inout] joystick the SDL_Joystick obtained from SDL_OpenJoystick()
  * \returns the GUID of the given joystick. If called on an invalid index,
  *          this function returns a zero GUID; call SDL_GetError() for more
  *          information.
@@ -744,7 +744,7 @@ extern SDL_DECLSPEC SDL_JoystickGUID SDLCALL SDL_GetJoystickGUID(SDL_Joystick *j
  *
  * If the vendor ID isn't available this function returns 0.
  *
- * \param joystick the SDL_Joystick obtained from SDL_OpenJoystick()
+ * \param[inout] joystick the SDL_Joystick obtained from SDL_OpenJoystick()
  * \returns the USB vendor ID of the selected joystick, or 0 if unavailable.
  *
  * \since This function is available since SDL 3.0.0.
@@ -758,7 +758,7 @@ extern SDL_DECLSPEC Uint16 SDLCALL SDL_GetJoystickVendor(SDL_Joystick *joystick)
  *
  * If the product ID isn't available this function returns 0.
  *
- * \param joystick the SDL_Joystick obtained from SDL_OpenJoystick()
+ * \param[inout] joystick the SDL_Joystick obtained from SDL_OpenJoystick()
  * \returns the USB product ID of the selected joystick, or 0 if unavailable.
  *
  * \since This function is available since SDL 3.0.0.
@@ -772,7 +772,7 @@ extern SDL_DECLSPEC Uint16 SDLCALL SDL_GetJoystickProduct(SDL_Joystick *joystick
  *
  * If the product version isn't available this function returns 0.
  *
- * \param joystick the SDL_Joystick obtained from SDL_OpenJoystick()
+ * \param[inout] joystick the SDL_Joystick obtained from SDL_OpenJoystick()
  * \returns the product version of the selected joystick, or 0 if unavailable.
  *
  * \since This function is available since SDL 3.0.0.
@@ -786,7 +786,7 @@ extern SDL_DECLSPEC Uint16 SDLCALL SDL_GetJoystickProductVersion(SDL_Joystick *j
  *
  * If the firmware version isn't available this function returns 0.
  *
- * \param joystick the SDL_Joystick obtained from SDL_OpenJoystick()
+ * \param[inout] joystick the SDL_Joystick obtained from SDL_OpenJoystick()
  * \returns the firmware version of the selected joystick, or 0 if
  *          unavailable.
  *
@@ -799,7 +799,7 @@ extern SDL_DECLSPEC Uint16 SDLCALL SDL_GetJoystickFirmwareVersion(SDL_Joystick *
  *
  * Returns the serial number of the joystick, or NULL if it is not available.
  *
- * \param joystick the SDL_Joystick obtained from SDL_OpenJoystick()
+ * \param[inout] joystick the SDL_Joystick obtained from SDL_OpenJoystick()
  * \returns the serial number of the selected joystick, or NULL if
  *          unavailable.
  *
@@ -810,7 +810,7 @@ extern SDL_DECLSPEC const char * SDLCALL SDL_GetJoystickSerial(SDL_Joystick *joy
 /**
  * Get the type of an opened joystick.
  *
- * \param joystick the SDL_Joystick obtained from SDL_OpenJoystick()
+ * \param[inout] joystick the SDL_Joystick obtained from SDL_OpenJoystick()
  * \returns the SDL_JoystickType of the selected joystick.
  *
  * \since This function is available since SDL 3.0.0.
@@ -858,13 +858,13 @@ extern SDL_DECLSPEC SDL_JoystickGUID SDLCALL SDL_GetJoystickGUIDFromString(const
  * Get the device information encoded in a SDL_JoystickGUID structure.
  *
  * \param guid the SDL_JoystickGUID you wish to get info about
- * \param vendor A pointer filled in with the device VID, or 0 if not
+ * \param[out,opt] vendor A pointer filled in with the device VID, or 0 if not
  *               available
- * \param product A pointer filled in with the device PID, or 0 if not
+ * \param[out,opt] product A pointer filled in with the device PID, or 0 if not
  *                available
- * \param version A pointer filled in with the device version, or 0 if not
+ * \param[out,opt] version A pointer filled in with the device version, or 0 if not
  *                available
- * \param crc16 A pointer filled in with a CRC used to distinguish different
+ * \param[out,opt] crc16 A pointer filled in with a CRC used to distinguish different
  *              products with the same VID/PID, or 0 if not available
  *
  * \since This function is available since SDL 3.0.0.
@@ -876,7 +876,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_GetJoystickGUIDInfo(SDL_JoystickGUID guid, 
 /**
  * Get the status of a specified joystick.
  *
- * \param joystick the joystick to query
+ * \param[inout] joystick the joystick to query
  * \returns SDL_TRUE if the joystick has been opened, SDL_FALSE if it has not;
  *          call SDL_GetError() for more information.
  *
@@ -887,7 +887,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_JoystickConnected(SDL_Joystick *joystic
 /**
  * Get the instance ID of an opened joystick.
  *
- * \param joystick an SDL_Joystick structure containing joystick information
+ * \param[inout] joystick an SDL_Joystick structure containing joystick information
  * \returns the instance ID of the specified joystick on success or 0 on
  *          failure; call SDL_GetError() for more information.
  *
@@ -902,7 +902,7 @@ extern SDL_DECLSPEC SDL_JoystickID SDLCALL SDL_GetJoystickInstanceID(SDL_Joystic
  * separate buttons or a POV hat, and not axes, but all of this is up to the
  * device and platform.
  *
- * \param joystick an SDL_Joystick structure containing joystick information
+ * \param[inout] joystick an SDL_Joystick structure containing joystick information
  * \returns the number of axis controls/number of axes on success or a
  *          negative error code on failure; call SDL_GetError() for more
  *          information.
@@ -924,7 +924,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetNumJoystickAxes(SDL_Joystick *joystick);
  *
  * Most joysticks do not have trackballs.
  *
- * \param joystick an SDL_Joystick structure containing joystick information
+ * \param[inout] joystick an SDL_Joystick structure containing joystick information
  * \returns the number of trackballs on success or a negative error code on
  *          failure; call SDL_GetError() for more information.
  *
@@ -940,7 +940,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetNumJoystickBalls(SDL_Joystick *joystick);
 /**
  * Get the number of POV hats on a joystick.
  *
- * \param joystick an SDL_Joystick structure containing joystick information
+ * \param[inout] joystick an SDL_Joystick structure containing joystick information
  * \returns the number of POV hats on success or a negative error code on
  *          failure; call SDL_GetError() for more information.
  *
@@ -956,7 +956,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetNumJoystickHats(SDL_Joystick *joystick);
 /**
  * Get the number of buttons on a joystick.
  *
- * \param joystick an SDL_Joystick structure containing joystick information
+ * \param[inout] joystick an SDL_Joystick structure containing joystick information
  * \returns the number of buttons on success or a negative error code on
  *          failure; call SDL_GetError() for more information.
  *
@@ -1024,7 +1024,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_UpdateJoysticks(void);
  * 32767) representing the current position of the axis. It may be necessary
  * to impose certain tolerances on these values to account for jitter.
  *
- * \param joystick an SDL_Joystick structure containing joystick information
+ * \param[inout] joystick an SDL_Joystick structure containing joystick information
  * \param axis the axis to query; the axis indices start at index 0
  * \returns a 16-bit signed integer representing the current position of the
  *          axis or 0 on failure; call SDL_GetError() for more information.
@@ -1042,9 +1042,9 @@ extern SDL_DECLSPEC Sint16 SDLCALL SDL_GetJoystickAxis(SDL_Joystick *joystick, i
  *
  * The axis indices start at index 0.
  *
- * \param joystick an SDL_Joystick structure containing joystick information
+ * \param[inout] joystick an SDL_Joystick structure containing joystick information
  * \param axis the axis to query; the axis indices start at index 0
- * \param state Upon return, the initial value is supplied here.
+ * \param[out,opt] state Upon return, the initial value is supplied here.
  * \returns SDL_TRUE if this axis has any initial value, or SDL_FALSE if not.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1059,10 +1059,10 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GetJoystickAxisInitialState(SDL_Joystic
  *
  * Most joysticks do not have trackballs.
  *
- * \param joystick the SDL_Joystick to query
+ * \param[inout] joystick the SDL_Joystick to query
  * \param ball the ball index to query; ball indices start at index 0
- * \param dx stores the difference in the x axis position since the last poll
- * \param dy stores the difference in the y axis position since the last poll
+ * \param[out,opt] dx stores the difference in the x axis position since the last poll
+ * \param[out,opt] dy stores the difference in the y axis position since the last poll
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1077,7 +1077,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetJoystickBall(SDL_Joystick *joystick, int 
  *
  * The returned value will be one of the `SDL_HAT_*` values.
  *
- * \param joystick an SDL_Joystick structure containing joystick information
+ * \param[inout] joystick an SDL_Joystick structure containing joystick information
  * \param hat the hat index to get the state from; indices start at index 0
  * \returns the current hat position.
  *
@@ -1100,7 +1100,7 @@ extern SDL_DECLSPEC Uint8 SDLCALL SDL_GetJoystickHat(SDL_Joystick *joystick, int
 /**
  * Get the current state of a button on a joystick.
  *
- * \param joystick an SDL_Joystick structure containing joystick information
+ * \param[inout] joystick an SDL_Joystick structure containing joystick information
  * \param button the button index to get the state from; indices start at
  *               index 0
  * \returns 1 if the specified button is pressed, 0 otherwise.
@@ -1120,7 +1120,7 @@ extern SDL_DECLSPEC Uint8 SDLCALL SDL_GetJoystickButton(SDL_Joystick *joystick, 
  * This function requires you to process SDL events or call
  * SDL_UpdateJoysticks() to update rumble state.
  *
- * \param joystick The joystick to vibrate
+ * \param[inout] joystick The joystick to vibrate
  * \param low_frequency_rumble The intensity of the low frequency (left)
  *                             rumble motor, from 0 to 0xFFFF
  * \param high_frequency_rumble The intensity of the high frequency (right)
@@ -1146,7 +1146,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_RumbleJoystick(SDL_Joystick *joystick, Uint1
  * This function requires you to process SDL events or call
  * SDL_UpdateJoysticks() to update rumble state.
  *
- * \param joystick The joystick to vibrate
+ * \param[inout] joystick The joystick to vibrate
  * \param left_rumble The intensity of the left trigger rumble motor, from 0
  *                    to 0xFFFF
  * \param right_rumble The intensity of the right trigger rumble motor, from 0
@@ -1170,7 +1170,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_RumbleJoystickTriggers(SDL_Joystick *joystic
  * For joysticks with a single color LED, the maximum of the RGB values will
  * be used as the LED brightness.
  *
- * \param joystick The joystick to update
+ * \param[inout] joystick The joystick to update
  * \param red The intensity of the red LED
  * \param green The intensity of the green LED
  * \param blue The intensity of the blue LED
@@ -1184,8 +1184,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetJoystickLED(SDL_Joystick *joystick, Uint8
 /**
  * Send a joystick specific effect packet.
  *
- * \param joystick The joystick to affect
- * \param data The data to send to the joystick
+ * \param[inout] joystick The joystick to affect
+ * \param[in] data The data to send to the joystick
  * \param size The size of the data to send to the joystick
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1197,7 +1197,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SendJoystickEffect(SDL_Joystick *joystick, c
 /**
  * Close a joystick previously opened with SDL_OpenJoystick().
  *
- * \param joystick The joystick device to close
+ * \param[inout] joystick The joystick device to close
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -1208,7 +1208,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_CloseJoystick(SDL_Joystick *joystick);
 /**
  * Get the connection state of a joystick.
  *
- * \param joystick The joystick to query
+ * \param[inout] joystick The joystick to query
  * \returns the connection state on success or
  *          `SDL_JOYSTICK_CONNECTION_INVALID` on failure; call SDL_GetError()
  *          for more information.
@@ -1226,8 +1226,8 @@ extern SDL_DECLSPEC SDL_JoystickConnectionState SDLCALL SDL_GetJoystickConnectio
  * not uncommon for older batteries to lose stored power much faster than it
  * reports, or completely drain when reporting it has 20 percent left, etc.
  *
- * \param joystick The joystick to query
- * \param percent a pointer filled in with the percentage of battery life
+ * \param[inout] joystick The joystick to query
+ * \param[out,opt] percent a pointer filled in with the percentage of battery life
  *                left, between 0 and 100, or NULL to ignore. This will be
  *                filled in with -1 we can't determine a value or there is no
  *                battery.

--- a/include/SDL3/SDL_keyboard.h
+++ b/include/SDL3/SDL_keyboard.h
@@ -92,8 +92,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_HasKeyboard(void);
  * power buttons, etc. You should wait for input from a device before you
  * consider it actively in use.
  *
- * \param count a pointer filled in with the number of keyboards returned
- * \returns a 0 terminated array of keyboards instance IDs which should be
+ * \param[out,opt] count a pointer filled in with the number of keyboards returned
+ * \returns[own] a 0 terminated array of keyboards instance IDs which should be
  *          freed with SDL_free(), or NULL on error; call SDL_GetError() for
  *          more details.
  *
@@ -149,7 +149,7 @@ extern SDL_DECLSPEC SDL_Window * SDLCALL SDL_GetKeyboardFocus(void);
  * Note: This function doesn't take into account whether shift has been
  * pressed or not.
  *
- * \param numkeys if non-NULL, receives the length of the returned array
+ * \param[out] numkeys if non-NULL, receives the length of the returned array
  * \returns a pointer to an array of key states.
  *
  * \since This function is available since SDL 3.0.0.
@@ -262,7 +262,7 @@ extern SDL_DECLSPEC const char *SDLCALL SDL_GetScancodeName(SDL_Scancode scancod
 /**
  * Get a scancode from a human-readable name.
  *
- * \param name the human-readable scancode name
+ * \param[in] name the human-readable scancode name
  * \returns the SDL_Scancode, or `SDL_SCANCODE_UNKNOWN` if the name wasn't
  *          recognized; call SDL_GetError() for more information.
  *
@@ -296,7 +296,7 @@ extern SDL_DECLSPEC const char *SDLCALL SDL_GetKeyName(SDL_Keycode key);
 /**
  * Get a key code from a human-readable name.
  *
- * \param name the human-readable key name
+ * \param[in] name the human-readable key name
  * \returns key code, or `SDLK_UNKNOWN` if the name wasn't recognized; call
  *          SDL_GetError() for more information.
  *
@@ -373,7 +373,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_ClearComposition(void);
  * **SDL_HINT_IME_SHOW_UI** to **1**, otherwise this function won't give you
  * any feedback.
  *
- * \param rect the SDL_Rect structure representing the rectangle to receive
+ * \param[in,opt] rect the SDL_Rect structure representing the rectangle to receive
  *             text (ignored if NULL)
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -400,7 +400,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_HasScreenKeyboardSupport(void);
 /**
  * Check whether the screen keyboard is shown for given window.
  *
- * \param window the window for which screen keyboard should be queried
+ * \param[inout] window the window for which screen keyboard should be queried
  * \returns SDL_TRUE if screen keyboard is shown or SDL_FALSE if not.
  *
  * \since This function is available since SDL 3.0.0.

--- a/include/SDL3/SDL_loadso.h
+++ b/include/SDL3/SDL_loadso.h
@@ -55,8 +55,8 @@ extern "C" {
 /**
  * Dynamically load a shared object.
  *
- * \param sofile a system-dependent name of the object file
- * \returns an opaque pointer to the object handle or NULL if there was an
+ * \param[in] sofile a system-dependent name of the object file
+ * \returns[own] an opaque pointer to the object handle or NULL if there was an
  *          error; call SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -81,8 +81,8 @@ extern SDL_DECLSPEC void *SDLCALL SDL_LoadObject(const char *sofile);
  *
  * If the requested function doesn't exist, NULL is returned.
  *
- * \param handle a valid shared object handle returned by SDL_LoadObject()
- * \param name the name of the function to look up
+ * \param[inout] handle a valid shared object handle returned by SDL_LoadObject()
+ * \param[in] name the name of the function to look up
  * \returns a pointer to the function or NULL if there was an error; call
  *          SDL_GetError() for more information.
  *
@@ -95,7 +95,7 @@ extern SDL_DECLSPEC SDL_FunctionPointer SDLCALL SDL_LoadFunction(void *handle, c
 /**
  * Unload a shared object from memory.
  *
- * \param handle a valid shared object handle returned by SDL_LoadObject()
+ * \param[inout] handle a valid shared object handle returned by SDL_LoadObject()
  *
  * \since This function is available since SDL 3.0.0.
  *

--- a/include/SDL3/SDL_log.h
+++ b/include/SDL3/SDL_log.h
@@ -161,7 +161,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_ResetLogPriorities(void);
 /**
  * Log a message with SDL_LOG_CATEGORY_APPLICATION and SDL_LOG_PRIORITY_INFO.
  *
- * \param fmt a printf() style message format string
+ * \param[in] fmt a printf() style message format string
  * \param ... additional parameters matching % tokens in the `fmt` string, if
  *            any
  *
@@ -182,7 +182,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_Log(SDL_PRINTF_FORMAT_STRING const char *fm
  * Log a message with SDL_LOG_PRIORITY_VERBOSE.
  *
  * \param category the category of the message
- * \param fmt a printf() style message format string
+ * \param[in] fmt a printf() style message format string
  * \param ... additional parameters matching % tokens in the **fmt** string,
  *            if any
  *
@@ -203,7 +203,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_LogVerbose(int category, SDL_PRINTF_FORMAT_
  * Log a message with SDL_LOG_PRIORITY_DEBUG.
  *
  * \param category the category of the message
- * \param fmt a printf() style message format string
+ * \param[in] fmt a printf() style message format string
  * \param ... additional parameters matching % tokens in the **fmt** string,
  *            if any
  *
@@ -224,7 +224,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_LogDebug(int category, SDL_PRINTF_FORMAT_ST
  * Log a message with SDL_LOG_PRIORITY_INFO.
  *
  * \param category the category of the message
- * \param fmt a printf() style message format string
+ * \param[in] fmt a printf() style message format string
  * \param ... additional parameters matching % tokens in the **fmt** string,
  *            if any
  *
@@ -245,7 +245,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_LogInfo(int category, SDL_PRINTF_FORMAT_STR
  * Log a message with SDL_LOG_PRIORITY_WARN.
  *
  * \param category the category of the message
- * \param fmt a printf() style message format string
+ * \param[in] fmt a printf() style message format string
  * \param ... additional parameters matching % tokens in the **fmt** string,
  *            if any
  *
@@ -266,7 +266,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_LogWarn(int category, SDL_PRINTF_FORMAT_STR
  * Log a message with SDL_LOG_PRIORITY_ERROR.
  *
  * \param category the category of the message
- * \param fmt a printf() style message format string
+ * \param[in] fmt a printf() style message format string
  * \param ... additional parameters matching % tokens in the **fmt** string,
  *            if any
  *
@@ -287,7 +287,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_LogError(int category, SDL_PRINTF_FORMAT_ST
  * Log a message with SDL_LOG_PRIORITY_CRITICAL.
  *
  * \param category the category of the message
- * \param fmt a printf() style message format string
+ * \param[in] fmt a printf() style message format string
  * \param ... additional parameters matching % tokens in the **fmt** string,
  *            if any
  *
@@ -309,7 +309,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_LogCritical(int category, SDL_PRINTF_FORMAT
  *
  * \param category the category of the message
  * \param priority the priority of the message
- * \param fmt a printf() style message format string
+ * \param[in] fmt a printf() style message format string
  * \param ... additional parameters matching % tokens in the **fmt** string,
  *            if any
  *
@@ -333,7 +333,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_LogMessage(int category,
  *
  * \param category the category of the message
  * \param priority the priority of the message
- * \param fmt a printf() style message format string
+ * \param[in] fmt a printf() style message format string
  * \param ap a variable argument list
  *
  * \since This function is available since SDL 3.0.0.
@@ -368,9 +368,9 @@ typedef void (SDLCALL *SDL_LogOutputFunction)(void *userdata, int category, SDL_
 /**
  * Get the current log output function.
  *
- * \param callback an SDL_LogOutputFunction filled in with the current log
+ * \param[out] callback an SDL_LogOutputFunction filled in with the current log
  *                 callback
- * \param userdata a pointer filled in with the pointer that is passed to
+ * \param[out] userdata a pointer filled in with the pointer that is passed to
  *                 `callback`
  *
  * \since This function is available since SDL 3.0.0.
@@ -382,8 +382,8 @@ extern SDL_DECLSPEC void SDLCALL SDL_GetLogOutputFunction(SDL_LogOutputFunction 
 /**
  * Replace the default log output function with one of your own.
  *
- * \param callback an SDL_LogOutputFunction to call instead of the default
- * \param userdata a pointer that is passed to `callback`
+ * \param[in] callback an SDL_LogOutputFunction to call instead of the default
+ * \param[inout] userdata a pointer that is passed to `callback`
  *
  * \since This function is available since SDL 3.0.0.
  *

--- a/include/SDL3/SDL_main.h
+++ b/include/SDL3/SDL_main.h
@@ -493,9 +493,9 @@ extern SDL_DECLSPEC void SDLCALL SDL_SetMainReady(void);
  *
  * \param argc The argc parameter from the application's main() function, or 0
  *             if the platform's main-equivalent has no argc
- * \param argv The argv parameter from the application's main() function, or
+ * \param[in] argv The argv parameter from the application's main() function, or
  *             NULL if the platform's main-equivalent has no argv
- * \param mainFunction Your SDL app's C-style main(), an SDL_main_func. NOT
+ * \param[in] mainFunction Your SDL app's C-style main(), an SDL_main_func. NOT
  *                     the function you're calling this from! Its name doesn't
  *                     matter, but its signature must be like int my_main(int
  *                     argc, char* argv[])
@@ -521,11 +521,11 @@ extern SDL_DECLSPEC int SDLCALL SDL_RunApp(int argc, char* argv[], SDL_main_func
  * _really_ know what you're doing.
  *
  * \param argc standard Unix main argc
- * \param argv standard Unix main argv
- * \param appinit The application's SDL_AppInit function
- * \param appiter The application's SDL_AppIterate function
- * \param appevent The application's SDL_AppEvent function
- * \param appquit The application's SDL_AppQuit function
+ * \param[in] argv standard Unix main argv
+ * \param[in] appinit The application's SDL_AppInit function
+ * \param[in] appiter The application's SDL_AppIterate function
+ * \param[in] appevent The application's SDL_AppEvent function
+ * \param[in] appquit The application's SDL_AppQuit function
  * \returns standard Unix main return value
  *
  * \threadsafety It is not safe to call this anywhere except as the only

--- a/include/SDL3/SDL_messagebox.h
+++ b/include/SDL3/SDL_messagebox.h
@@ -150,9 +150,9 @@ typedef struct SDL_MessageBoxData
  * concern, check the return value from this function and fall back to writing
  * to stderr if you can.
  *
- * \param messageboxdata the SDL_MessageBoxData structure with title, text and
+ * \param[in] messageboxdata the SDL_MessageBoxData structure with title, text and
  *                       other options
- * \param buttonid the pointer to which user id of hit button should be copied
+ * \param[out,opt] buttonid the pointer to which user id of hit button should be copied
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -192,9 +192,9 @@ extern SDL_DECLSPEC int SDLCALL SDL_ShowMessageBox(const SDL_MessageBoxData *mes
  * to stderr if you can.
  *
  * \param flags an SDL_MessageBoxFlags value
- * \param title UTF-8 title text
- * \param message UTF-8 message text
- * \param window the parent window, or NULL for no parent
+ * \param[in] title UTF-8 title text
+ * \param[in] message UTF-8 message text
+ * \param[inout,opt] window the parent window, or NULL for no parent
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *

--- a/include/SDL3/SDL_metal.h
+++ b/include/SDL3/SDL_metal.h
@@ -58,7 +58,7 @@ typedef void *SDL_MetalView;
  * The returned handle can be casted directly to a NSView or UIView. To access
  * the backing CAMetalLayer, call SDL_Metal_GetLayer().
  *
- * \param window the window
+ * \param[inout] window the window
  * \returns handle NSView or UIView
  *
  * \since This function is available since SDL 3.0.0.
@@ -74,7 +74,7 @@ extern SDL_DECLSPEC SDL_MetalView SDLCALL SDL_Metal_CreateView(SDL_Window * wind
  * This should be called before SDL_DestroyWindow, if SDL_Metal_CreateView was
  * called after SDL_CreateWindow.
  *
- * \param view the SDL_MetalView object
+ * \param[inout] view the SDL_MetalView object
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -85,7 +85,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_Metal_DestroyView(SDL_MetalView view);
 /**
  * Get a pointer to the backing CAMetalLayer for the given view.
  *
- * \param view the SDL_MetalView object
+ * \param[inout] view the SDL_MetalView object
  * \returns a pointer
  *
  * \since This function is available since SDL 3.0.0.

--- a/include/SDL3/SDL_misc.h
+++ b/include/SDL3/SDL_misc.h
@@ -60,7 +60,7 @@ extern "C" {
  * All this to say: this function can be useful, but you should definitely
  * test it on every platform you target.
  *
- * \param url A valid URL/URI to open. Use `file:///full/path/to/file` for
+ * \param[in] url A valid URL/URI to open. Use `file:///full/path/to/file` for
  *            local files, if supported.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.

--- a/include/SDL3/SDL_mouse.h
+++ b/include/SDL3/SDL_mouse.h
@@ -135,8 +135,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_HasMouse(void);
  * You should wait for input from a device before you consider it actively in
  * use.
  *
- * \param count a pointer filled in with the number of mice returned
- * \returns a 0 terminated array of mouse instance IDs which should be freed
+ * \param[out,opt] count a pointer filled in with the number of mice returned
+ * \returns[own] a 0 terminated array of mouse instance IDs which should be freed
  *          with SDL_free(), or NULL on error; call SDL_GetError() for more
  *          details.
  *
@@ -180,9 +180,9 @@ extern SDL_DECLSPEC SDL_Window * SDLCALL SDL_GetMouseFocus(void);
  * mouse cursor position relative to the focus window. You can pass NULL for
  * either `x` or `y`.
  *
- * \param x the x coordinate of the mouse cursor position relative to the
+ * \param[out,opt] x the x coordinate of the mouse cursor position relative to the
  *          focus window
- * \param y the y coordinate of the mouse cursor position relative to the
+ * \param[out,opt] y the y coordinate of the mouse cursor position relative to the
  *          focus window
  * \returns a 32-bit button bitmask of the current button state.
  *
@@ -209,9 +209,9 @@ extern SDL_DECLSPEC SDL_MouseButtonFlags SDLCALL SDL_GetMouseState(float *x, flo
  * efficient function. Unless you know what you're doing and have a good
  * reason to use this function, you probably want SDL_GetMouseState() instead.
  *
- * \param x filled in with the current X coord relative to the desktop; can be
+ * \param[out,opt] x filled in with the current X coord relative to the desktop; can be
  *          NULL
- * \param y filled in with the current Y coord relative to the desktop; can be
+ * \param[out,opt] y filled in with the current Y coord relative to the desktop; can be
  *          NULL
  * \returns the current button state as a bitmask which can be tested using
  *          the SDL_BUTTON(X) macros.
@@ -232,8 +232,8 @@ extern SDL_DECLSPEC SDL_MouseButtonFlags SDLCALL SDL_GetGlobalMouseState(float *
  * mouse deltas since the last call to SDL_GetRelativeMouseState() or since
  * event initialization. You can pass NULL for either `x` or `y`.
  *
- * \param x a pointer filled with the last recorded x coordinate of the mouse
- * \param y a pointer filled with the last recorded y coordinate of the mouse
+ * \param[out,opt] x a pointer filled with the last recorded x coordinate of the mouse
+ * \param[out,opt] y a pointer filled with the last recorded y coordinate of the mouse
  * \returns a 32-bit button bitmask of the relative button state.
  *
  * \since This function is available since SDL 3.0.0.
@@ -252,7 +252,7 @@ extern SDL_DECLSPEC SDL_MouseButtonFlags SDLCALL SDL_GetRelativeMouseState(float
  * Note that this function will appear to succeed, but not actually move the
  * mouse when used over Microsoft Remote Desktop.
  *
- * \param window the window to move the mouse into, or NULL for the current
+ * \param[inout] window the window to move the mouse into, or NULL for the current
  *               mouse focus
  * \param x the x coordinate within the window
  * \param y the y coordinate within the window
@@ -386,15 +386,15 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GetRelativeMouseMode(void);
  * Also, SDL_CreateSystemCursor() is available, which provides several
  * readily-available system cursors to pick from.
  *
- * \param data the color value for each pixel of the cursor
- * \param mask the mask value for each pixel of the cursor
+ * \param[in] data the color value for each pixel of the cursor
+ * \param[in] mask the mask value for each pixel of the cursor
  * \param w the width of the cursor
  * \param h the height of the cursor
  * \param hot_x the x-axis offset from the left of the cursor image to the
  *              mouse x position, in the range of 0 to `w` - 1
  * \param hot_y the y-axis offset from the top of the cursor image to the
  *              mouse y position, in the range of 0 to `h` - 1
- * \returns a new cursor with the specified parameters on success or NULL on
+ * \returns[own] a new cursor with the specified parameters on success or NULL on
  *          failure; call SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -412,10 +412,10 @@ extern SDL_DECLSPEC SDL_Cursor *SDLCALL SDL_CreateCursor(const Uint8 * data,
 /**
  * Create a color cursor.
  *
- * \param surface an SDL_Surface structure representing the cursor image
+ * \param[inout] surface an SDL_Surface structure representing the cursor image
  * \param hot_x the x position of the cursor hot spot
  * \param hot_y the y position of the cursor hot spot
- * \returns the new cursor on success or NULL on failure; call SDL_GetError()
+ * \returns[own] the new cursor on success or NULL on failure; call SDL_GetError()
  *          for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -433,7 +433,7 @@ extern SDL_DECLSPEC SDL_Cursor *SDLCALL SDL_CreateColorCursor(SDL_Surface *surfa
  * Create a system cursor.
  *
  * \param id an SDL_SystemCursor enum value
- * \returns a cursor on success or NULL on failure; call SDL_GetError() for
+ * \returns[own] a cursor on success or NULL on failure; call SDL_GetError() for
  *          more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -450,7 +450,7 @@ extern SDL_DECLSPEC SDL_Cursor *SDLCALL SDL_CreateSystemCursor(SDL_SystemCursor 
  * the display. SDL_SetCursor(NULL) can be used to force cursor redraw, if
  * this is desired for any reason.
  *
- * \param cursor a cursor to make active
+ * \param[inout] cursor a cursor to make active
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -492,7 +492,7 @@ extern SDL_DECLSPEC SDL_Cursor *SDLCALL SDL_GetDefaultCursor(void);
  * Use this function to free cursor resources created with SDL_CreateCursor(),
  * SDL_CreateColorCursor() or SDL_CreateSystemCursor().
  *
- * \param cursor the cursor to free
+ * \param[inout] cursor the cursor to free
  *
  * \since This function is available since SDL 3.0.0.
  *

--- a/include/SDL3/SDL_mutex.h
+++ b/include/SDL3/SDL_mutex.h
@@ -154,7 +154,7 @@ typedef struct SDL_Mutex SDL_Mutex;
  *
  * SDL mutexes are reentrant.
  *
- * \returns the initialized and unlocked mutex or NULL on failure; call
+ * \returns[own] the initialized and unlocked mutex or NULL on failure; call
  *          SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -181,7 +181,7 @@ extern SDL_DECLSPEC SDL_Mutex *SDLCALL SDL_CreateMutex(void);
  * having locked nothing. If the mutex is valid, this function will always
  * block until it can lock the mutex, and return with it locked.
  *
- * \param mutex the mutex to lock
+ * \param[inout] mutex the mutex to lock
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -204,7 +204,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_LockMutex(SDL_Mutex *mutex) SDL_ACQUIRE(mut
  * either lock the mutex and return 0, or return SDL_MUTEX_TIMEOUT and lock
  * nothing.
  *
- * \param mutex the mutex to try to lock
+ * \param[inout] mutex the mutex to try to lock
  * \returns 0 or `SDL_MUTEX_TIMEDOUT`
  *
  * \since This function is available since SDL 3.0.0.
@@ -224,7 +224,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_TryLockMutex(SDL_Mutex *mutex) SDL_TRY_ACQUI
  * It is illegal to unlock a mutex that has not been locked by the current
  * thread, and doing so results in undefined behavior.
  *
- * \param mutex the mutex to unlock.
+ * \param[inout] mutex the mutex to unlock.
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -242,7 +242,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_UnlockMutex(SDL_Mutex *mutex) SDL_RELEASE(m
  * to destroy a locked mutex, and may result in undefined behavior depending
  * on the platform.
  *
- * \param mutex the mutex to destroy
+ * \param[inout] mutex the mutex to destroy
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -756,8 +756,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_BroadcastCondition(SDL_Condition *cond);
  * This function is the equivalent of calling SDL_WaitConditionTimeout() with
  * a time length of -1.
  *
- * \param cond the condition variable to wait on
- * \param mutex the mutex used to coordinate thread access
+ * \param[inout] cond the condition variable to wait on
+ * \param[inout] mutex the mutex used to coordinate thread access
  * \returns 0 when it is signaled or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -784,8 +784,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_WaitCondition(SDL_Condition *cond, SDL_Mutex
  * recursively (more than once) is not supported and leads to undefined
  * behavior.
  *
- * \param cond the condition variable to wait on
- * \param mutex the mutex used to coordinate thread access
+ * \param[inout] cond the condition variable to wait on
+ * \param[inout] mutex the mutex used to coordinate thread access
  * \param timeoutMS the maximum time to wait, in milliseconds, or -1 to wait
  *                  indefinitely
  * \returns 0 if the condition variable is signaled, `SDL_MUTEX_TIMEDOUT` if

--- a/include/SDL3/SDL_pen.h
+++ b/include/SDL3/SDL_pen.h
@@ -154,9 +154,9 @@ typedef enum SDL_PenSubtype
  * throughout a session. To track pens across sessions (program restart), use
  * SDL_GUID .
  *
- * \param count The number of pens in the array (number of array elements
+ * \param[out,opt] count The number of pens in the array (number of array elements
  *              minus 1, i.e., not counting the terminator 0).
- * \returns A 0 terminated array of SDL_PenID values, or NULL on error. The
+ * \returns[own] A 0 terminated array of SDL_PenID values, or NULL on error. The
  *          array must be freed with SDL_free(). On a NULL return,
  *          SDL_GetError() is set.
  *
@@ -171,9 +171,9 @@ extern SDL_DECLSPEC SDL_PenID *SDLCALL SDL_GetPens(int *count);
  * default values.
  *
  * \param instance_id The pen to query.
- * \param x Out-mode parameter for pen x coordinate. May be NULL.
- * \param y Out-mode parameter for pen y coordinate. May be NULL.
- * \param axes Out-mode parameter for axis information. May be null. The axes
+ * \param[out,opt] x Out-mode parameter for pen x coordinate. May be NULL.
+ * \param[out,opt] y Out-mode parameter for pen y coordinate. May be NULL.
+ * \param[out,opt] axes Out-mode parameter for axis information. May be null. The axes
  *             are in the same order as SDL_PenAxis.
  * \param num_axes Maximum number of axes to write to "axes".
  * \returns a bit mask with the current pen button states (SDL_BUTTON_LMASK
@@ -253,7 +253,7 @@ typedef struct SDL_PenCapabilityInfo
  * Retrieves capability flags for a given SDL_PenID.
  *
  * \param instance_id The pen to query.
- * \param capabilities Detail information about pen capabilities, such as the
+ * \param[out,opt] capabilities Detail information about pen capabilities, such as the
  *                     number of buttons
  * \returns a set of capability flags, cf. SDL_PEN_CAPABILITIES
  *

--- a/include/SDL3/SDL_pixels.h
+++ b/include/SDL3/SDL_pixels.h
@@ -774,11 +774,11 @@ extern SDL_DECLSPEC const char* SDLCALL SDL_GetPixelFormatName(SDL_PixelFormatEn
  * Convert one of the enumerated pixel formats to a bpp value and RGBA masks.
  *
  * \param format one of the SDL_PixelFormatEnum values
- * \param bpp a bits per pixel value; usually 15, 16, or 32
- * \param Rmask a pointer filled in with the red mask for the format
- * \param Gmask a pointer filled in with the green mask for the format
- * \param Bmask a pointer filled in with the blue mask for the format
- * \param Amask a pointer filled in with the alpha mask for the format
+ * \param[out] bpp a bits per pixel value; usually 15, 16, or 32
+ * \param[out] Rmask a pointer filled in with the red mask for the format
+ * \param[out] Gmask a pointer filled in with the green mask for the format
+ * \param[out] Bmask a pointer filled in with the blue mask for the format
+ * \param[out] Amask a pointer filled in with the alpha mask for the format
  * \returns SDL_TRUE on success or SDL_FALSE if the conversion wasn't
  *          possible; call SDL_GetError() for more information.
  *
@@ -825,7 +825,7 @@ extern SDL_DECLSPEC SDL_PixelFormatEnum SDLCALL SDL_GetPixelFormatEnumForMasks(i
  * errors such as `Blit combination not supported` may occur.
  *
  * \param pixel_format one of the SDL_PixelFormatEnum values
- * \returns the new SDL_PixelFormat structure or NULL on failure; call
+ * \returns[own] the new SDL_PixelFormat structure or NULL on failure; call
  *          SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -838,7 +838,7 @@ extern SDL_DECLSPEC SDL_PixelFormat * SDLCALL SDL_CreatePixelFormat(SDL_PixelFor
 /**
  * Free an SDL_PixelFormat structure allocated by SDL_CreatePixelFormat().
  *
- * \param format the SDL_PixelFormat structure to free
+ * \param[inout] format the SDL_PixelFormat structure to free
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -852,7 +852,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_DestroyPixelFormat(SDL_PixelFormat *format)
  * The palette entries are initialized to white.
  *
  * \param ncolors represents the number of color entries in the color palette
- * \returns a new SDL_Palette structure on success or NULL on failure (e.g. if
+ * \returns[own] a new SDL_Palette structure on success or NULL on failure (e.g. if
  *          there wasn't enough memory); call SDL_GetError() for more
  *          information.
  *
@@ -867,8 +867,8 @@ extern SDL_DECLSPEC SDL_Palette *SDLCALL SDL_CreatePalette(int ncolors);
 /**
  * Set the palette for a pixel format structure.
  *
- * \param format the SDL_PixelFormat structure that will use the palette
- * \param palette the SDL_Palette structure that will be used
+ * \param[inout] format the SDL_PixelFormat structure that will use the palette
+ * \param[inout] palette the SDL_Palette structure that will be used
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -880,8 +880,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetPixelFormatPalette(SDL_PixelFormat * form
 /**
  * Set a range of colors in a palette.
  *
- * \param palette the SDL_Palette structure to modify
- * \param colors an array of SDL_Color structures to copy into the palette
+ * \param[inout] palette the SDL_Palette structure to modify
+ * \param[in] colors an array of SDL_Color structures to copy into the palette
  * \param firstcolor the index of the first palette entry to modify
  * \param ncolors the number of entries to modify
  * \returns 0 on success or a negative error code on failure; call
@@ -896,7 +896,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetPaletteColors(SDL_Palette * palette,
 /**
  * Free a palette created with SDL_CreatePalette().
  *
- * \param palette the SDL_Palette structure to be freed
+ * \param[inout] palette the SDL_Palette structure to be freed
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -922,7 +922,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_DestroyPalette(SDL_Palette * palette);
  * format the return value can be assigned to a Uint16, and similarly a Uint8
  * for an 8-bpp format).
  *
- * \param format an SDL_PixelFormat structure describing the pixel format
+ * \param[in] format an SDL_PixelFormat structure describing the pixel format
  * \param r the red component of the pixel in the range 0-255
  * \param g the green component of the pixel in the range 0-255
  * \param b the blue component of the pixel in the range 0-255
@@ -955,7 +955,7 @@ extern SDL_DECLSPEC Uint32 SDLCALL SDL_MapRGB(const SDL_PixelFormat * format,
  * format the return value can be assigned to a Uint16, and similarly a Uint8
  * for an 8-bpp format).
  *
- * \param format an SDL_PixelFormat structure describing the format of the
+ * \param[in] format an SDL_PixelFormat structure describing the format of the
  *               pixel
  * \param r the red component of the pixel in the range 0-255
  * \param g the green component of the pixel in the range 0-255
@@ -982,11 +982,11 @@ extern SDL_DECLSPEC Uint32 SDLCALL SDL_MapRGBA(const SDL_PixelFormat * format,
  * 0xff, 0xff] not [0xf8, 0xfc, 0xf8]).
  *
  * \param pixel a pixel value
- * \param format an SDL_PixelFormat structure describing the format of the
+ * \param[in] format an SDL_PixelFormat structure describing the format of the
  *               pixel
- * \param r a pointer filled in with the red component
- * \param g a pointer filled in with the green component
- * \param b a pointer filled in with the blue component
+ * \param[out] r a pointer filled in with the red component
+ * \param[out] g a pointer filled in with the green component
+ * \param[out] b a pointer filled in with the blue component
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -1010,12 +1010,12 @@ extern SDL_DECLSPEC void SDLCALL SDL_GetRGB(Uint32 pixel,
  * (100% opaque).
  *
  * \param pixel a pixel value
- * \param format an SDL_PixelFormat structure describing the format of the
+ * \param[in] format an SDL_PixelFormat structure describing the format of the
  *               pixel
- * \param r a pointer filled in with the red component
- * \param g a pointer filled in with the green component
- * \param b a pointer filled in with the blue component
- * \param a a pointer filled in with the alpha component
+ * \param[out] r a pointer filled in with the red component
+ * \param[out] g a pointer filled in with the green component
+ * \param[out] b a pointer filled in with the blue component
+ * \param[out] a a pointer filled in with the alpha component
  *
  * \since This function is available since SDL 3.0.0.
  *

--- a/include/SDL3/SDL_power.h
+++ b/include/SDL3/SDL_power.h
@@ -70,10 +70,10 @@ typedef enum SDL_PowerState
  * It's possible a platform can only report battery percentage or time left
  * but not both.
  *
- * \param seconds a pointer filled in with the seconds of battery life left,
+ * \param[out,opt] seconds a pointer filled in with the seconds of battery life left,
  *                or NULL to ignore. This will be filled in with -1 if we
  *                can't determine a value or there is no battery.
- * \param percent a pointer filled in with the percentage of battery life
+ * \param[out,opt] percent a pointer filled in with the percentage of battery life
  *                left, between 0 and 100, or NULL to ignore. This will be
  *                filled in with -1 we can't determine a value or there is no
  *                battery.

--- a/include/SDL3/SDL_properties.h
+++ b/include/SDL3/SDL_properties.h
@@ -182,11 +182,11 @@ typedef void (SDLCALL *SDL_CleanupPropertyCallback)(void *userdata, void *value)
  * function is only for more complex, custom data.
  *
  * \param props the properties to modify
- * \param name the name of the property to modify
- * \param value the new value of the property, or NULL to delete the property
- * \param cleanup the function to call when this property is deleted, or NULL
+ * \param[in] name the name of the property to modify
+ * \param[inout,opt] value the new value of the property, or NULL to delete the property
+ * \param[in] cleanup the function to call when this property is deleted, or NULL
  *                if no cleanup is necessary
- * \param userdata a pointer that is passed to the cleanup function
+ * \param[inout,opt] userdata a pointer that is passed to the cleanup function
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -204,8 +204,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetPropertyWithCleanup(SDL_PropertiesID prop
  * Set a property on a set of properties.
  *
  * \param props the properties to modify
- * \param name the name of the property to modify
- * \param value the new value of the property, or NULL to delete the property
+ * \param[in] name the name of the property to modify
+ * \param[inout,opt] value the new value of the property, or NULL to delete the property
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -230,8 +230,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetProperty(SDL_PropertiesID props, const ch
  * preserve the data after this call completes.
  *
  * \param props the properties to modify
- * \param name the name of the property to modify
- * \param value the new value of the property, or NULL to delete the property
+ * \param[in] name the name of the property to modify
+ * \param[inout,opt] value the new value of the property, or NULL to delete the property
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -247,7 +247,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetStringProperty(SDL_PropertiesID props, co
  * Set an integer property on a set of properties.
  *
  * \param props the properties to modify
- * \param name the name of the property to modify
+ * \param[in] name the name of the property to modify
  * \param value the new value of the property
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -264,7 +264,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetNumberProperty(SDL_PropertiesID props, co
  * Set a floating point property on a set of properties.
  *
  * \param props the properties to modify
- * \param name the name of the property to modify
+ * \param[in] name the name of the property to modify
  * \param value the new value of the property
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -281,7 +281,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetFloatProperty(SDL_PropertiesID props, con
  * Set a boolean property on a set of properties.
  *
  * \param props the properties to modify
- * \param name the name of the property to modify
+ * \param[in] name the name of the property to modify
  * \param value the new value of the property
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -298,7 +298,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetBooleanProperty(SDL_PropertiesID props, c
  * Return whether a property exists in a set of properties.
  *
  * \param props the properties to query
- * \param name the name of the property to query
+ * \param[in] name the name of the property to query
  * \returns SDL_TRUE if the property exists, or SDL_FALSE if it doesn't.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -313,7 +313,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_HasProperty(SDL_PropertiesID props, con
  * Get the type of a property on a set of properties.
  *
  * \param props the properties to query
- * \param name the name of the property to query
+ * \param[in] name the name of the property to query
  * \returns the type of the property, or SDL_PROPERTY_TYPE_INVALID if it is
  *          not set.
  *
@@ -334,8 +334,8 @@ extern SDL_DECLSPEC SDL_PropertyType SDLCALL SDL_GetPropertyType(SDL_PropertiesI
  * modified by applications.
  *
  * \param props the properties to query
- * \param name the name of the property to query
- * \param default_value the default value of the property
+ * \param[in] name the name of the property to query
+ * \param[inout] default_value the default value of the property
  * \returns the value of the property, or `default_value` if it is not set or
  *          not a pointer property.
  *
@@ -361,8 +361,8 @@ extern SDL_DECLSPEC void *SDLCALL SDL_GetProperty(SDL_PropertiesID props, const 
  * Get a string property on a set of properties.
  *
  * \param props the properties to query
- * \param name the name of the property to query
- * \param default_value the default value of the property
+ * \param[in] name the name of the property to query
+ * \param[in] default_value the default value of the property
  * \returns the value of the property, or `default_value` if it is not set or
  *          not a string property.
  *
@@ -383,7 +383,7 @@ extern SDL_DECLSPEC const char *SDLCALL SDL_GetStringProperty(SDL_PropertiesID p
  * is a number property.
  *
  * \param props the properties to query
- * \param name the name of the property to query
+ * \param[in] name the name of the property to query
  * \param default_value the default value of the property
  * \returns the value of the property, or `default_value` if it is not set or
  *          not a number property.
@@ -405,7 +405,7 @@ extern SDL_DECLSPEC Sint64 SDLCALL SDL_GetNumberProperty(SDL_PropertiesID props,
  * is a floating point property.
  *
  * \param props the properties to query
- * \param name the name of the property to query
+ * \param[in] name the name of the property to query
  * \param default_value the default value of the property
  * \returns the value of the property, or `default_value` if it is not set or
  *          not a float property.
@@ -427,7 +427,7 @@ extern SDL_DECLSPEC float SDLCALL SDL_GetFloatProperty(SDL_PropertiesID props, c
  * is a boolean property.
  *
  * \param props the properties to query
- * \param name the name of the property to query
+ * \param[in] name the name of the property to query
  * \param default_value the default value of the property
  * \returns the value of the property, or `default_value` if it is not set or
  *          not a float property.
@@ -446,7 +446,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GetBooleanProperty(SDL_PropertiesID pro
  * Clear a property on a set of properties.
  *
  * \param props the properties to modify
- * \param name the name of the property to clear
+ * \param[in] name the name of the property to clear
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -483,7 +483,7 @@ typedef void (SDLCALL *SDL_EnumeratePropertiesCallback)(void *userdata, SDL_Prop
  *
  * \param props the properties to query
  * \param callback the function to call for each property
- * \param userdata a pointer that is passed to `callback`
+ * \param[inout,opt] userdata a pointer that is passed to `callback`
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *

--- a/include/SDL3/SDL_rect.h
+++ b/include/SDL3/SDL_rect.h
@@ -125,8 +125,8 @@ typedef struct SDL_FRect
  * embedded in the calling program and the linker and dynamic loader will not
  * be able to find this function inside SDL itself).
  *
- * \param p the point to test.
- * \param r the rectangle to test.
+ * \param[in,opt] p the point to test.
+ * \param[in,opt] r the rectangle to test.
  * \returns SDL_TRUE if `p` is contained by `r`, SDL_FALSE otherwise.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -150,7 +150,7 @@ SDL_FORCE_INLINE SDL_bool SDL_PointInRect(const SDL_Point *p, const SDL_Rect *r)
  * embedded in the calling program and the linker and dynamic loader will not
  * be able to find this function inside SDL itself).
  *
- * \param r the rectangle to test.
+ * \param[in,opt] r the rectangle to test.
  * \returns SDL_TRUE if the rectangle is "empty", SDL_FALSE otherwise.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -173,8 +173,8 @@ SDL_FORCE_INLINE SDL_bool SDL_RectEmpty(const SDL_Rect *r)
  * embedded in the calling program and the linker and dynamic loader will not
  * be able to find this function inside SDL itself).
  *
- * \param a the first rectangle to test.
- * \param b the second rectangle to test.
+ * \param[in,opt] a the first rectangle to test.
+ * \param[in,opt] b the second rectangle to test.
  * \returns SDL_TRUE if the rectangles are equal, SDL_FALSE otherwise.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -192,8 +192,8 @@ SDL_FORCE_INLINE SDL_bool SDL_RectsEqual(const SDL_Rect *a, const SDL_Rect *b)
  *
  * If either pointer is NULL the function will return SDL_FALSE.
  *
- * \param A an SDL_Rect structure representing the first rectangle
- * \param B an SDL_Rect structure representing the second rectangle
+ * \param[in,opt] A an SDL_Rect structure representing the first rectangle
+ * \param[in,opt] B an SDL_Rect structure representing the second rectangle
  * \returns SDL_TRUE if there is an intersection, SDL_FALSE otherwise.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -210,9 +210,9 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_HasRectIntersection(const SDL_Rect * A,
  *
  * If `result` is NULL then this function will return SDL_FALSE.
  *
- * \param A an SDL_Rect structure representing the first rectangle
- * \param B an SDL_Rect structure representing the second rectangle
- * \param result an SDL_Rect structure filled in with the intersection of
+ * \param[in,opt] A an SDL_Rect structure representing the first rectangle
+ * \param[in,opt] B an SDL_Rect structure representing the second rectangle
+ * \param[out,opt] result an SDL_Rect structure filled in with the intersection of
  *               rectangles `A` and `B`
  * \returns SDL_TRUE if there is an intersection, SDL_FALSE otherwise.
  *
@@ -227,9 +227,9 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GetRectIntersection(const SDL_Rect * A,
 /**
  * Calculate the union of two rectangles.
  *
- * \param A an SDL_Rect structure representing the first rectangle
- * \param B an SDL_Rect structure representing the second rectangle
- * \param result an SDL_Rect structure filled in with the union of rectangles
+ * \param[in,opt] A an SDL_Rect structure representing the first rectangle
+ * \param[in,opt] B an SDL_Rect structure representing the second rectangle
+ * \param[out,opt] result an SDL_Rect structure filled in with the union of rectangles
  *               `A` and `B`
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -246,11 +246,11 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetRectUnion(const SDL_Rect * A,
  * If `clip` is not NULL then only points inside of the clipping rectangle are
  * considered.
  *
- * \param points an array of SDL_Point structures representing points to be
+ * \param[in] points an array of SDL_Point structures representing points to be
  *               enclosed
  * \param count the number of structures in the `points` array
- * \param clip an SDL_Rect used for clipping or NULL to enclose all points
- * \param result an SDL_Rect structure filled in with the minimal enclosing
+ * \param[in,opt] clip an SDL_Rect used for clipping or NULL to enclose all points
+ * \param[out,opt] result an SDL_Rect structure filled in with the minimal enclosing
  *               rectangle
  * \returns SDL_TRUE if any points were enclosed or SDL_FALSE if all the
  *          points were outside of the clipping rectangle.
@@ -271,11 +271,11 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GetRectEnclosingPoints(const SDL_Point 
  * both ends will be clipped to the boundary of the rectangle and the new
  * coordinates saved in `X1`, `Y1`, `X2`, and/or `Y2` as necessary.
  *
- * \param rect an SDL_Rect structure representing the rectangle to intersect
- * \param X1 a pointer to the starting X-coordinate of the line
- * \param Y1 a pointer to the starting Y-coordinate of the line
- * \param X2 a pointer to the ending X-coordinate of the line
- * \param Y2 a pointer to the ending Y-coordinate of the line
+ * \param[in] rect an SDL_Rect structure representing the rectangle to intersect
+ * \param[out,opt] X1 a pointer to the starting X-coordinate of the line
+ * \param[out,opt] Y1 a pointer to the starting Y-coordinate of the line
+ * \param[out,opt] X2 a pointer to the ending X-coordinate of the line
+ * \param[out,opt] Y2 a pointer to the ending Y-coordinate of the line
  * \returns SDL_TRUE if there is an intersection, SDL_FALSE otherwise.
  *
  * \since This function is available since SDL 3.0.0.
@@ -301,8 +301,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GetRectAndLineIntersection(const SDL_Re
  * embedded in the calling program and the linker and dynamic loader will not
  * be able to find this function inside SDL itself).
  *
- * \param p the point to test.
- * \param r the rectangle to test.
+ * \param[in,opt] p the point to test.
+ * \param[in,opt] r the rectangle to test.
  * \returns SDL_TRUE if `p` is contained by `r`, SDL_FALSE otherwise.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -326,7 +326,7 @@ SDL_FORCE_INLINE SDL_bool SDL_PointInRectFloat(const SDL_FPoint *p, const SDL_FR
  * embedded in the calling program and the linker and dynamic loader will not
  * be able to find this function inside SDL itself).
  *
- * \param r the rectangle to test.
+ * \param[in,opt] r the rectangle to test.
  * \returns SDL_TRUE if the rectangle is "empty", SDL_FALSE otherwise.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -352,8 +352,8 @@ SDL_FORCE_INLINE SDL_bool SDL_RectEmptyFloat(const SDL_FRect *r)
  * embedded in the calling program and the linker and dynamic loader will not
  * be able to find this function inside SDL itself).
  *
- * \param a the first rectangle to test.
- * \param b the second rectangle to test.
+ * \param[in,opt] a the first rectangle to test.
+ * \param[in,opt] b the second rectangle to test.
  * \returns SDL_TRUE if the rectangles are equal, SDL_FALSE otherwise.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -387,8 +387,8 @@ SDL_FORCE_INLINE SDL_bool SDL_RectsEqualEpsilon(const SDL_FRect *a, const SDL_FR
  * embedded in the calling program and the linker and dynamic loader will not
  * be able to find this function inside SDL itself).
  *
- * \param a the first rectangle to test.
- * \param b the second rectangle to test.
+ * \param[in,opt] a the first rectangle to test.
+ * \param[in,opt] b the second rectangle to test.
  * \returns SDL_TRUE if the rectangles are equal, SDL_FALSE otherwise.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -407,8 +407,8 @@ SDL_FORCE_INLINE SDL_bool SDL_RectsEqualFloat(const SDL_FRect *a, const SDL_FRec
  *
  * If either pointer is NULL the function will return SDL_FALSE.
  *
- * \param A an SDL_FRect structure representing the first rectangle
- * \param B an SDL_FRect structure representing the second rectangle
+ * \param[in,opt] A an SDL_FRect structure representing the first rectangle
+ * \param[in,opt] B an SDL_FRect structure representing the second rectangle
  * \returns SDL_TRUE if there is an intersection, SDL_FALSE otherwise.
  *
  * \since This function is available since SDL 3.0.0.
@@ -423,9 +423,9 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_HasRectIntersectionFloat(const SDL_FRec
  *
  * If `result` is NULL then this function will return SDL_FALSE.
  *
- * \param A an SDL_FRect structure representing the first rectangle
- * \param B an SDL_FRect structure representing the second rectangle
- * \param result an SDL_FRect structure filled in with the intersection of
+ * \param[in,opt] A an SDL_FRect structure representing the first rectangle
+ * \param[in,opt] B an SDL_FRect structure representing the second rectangle
+ * \param[out,opt] result an SDL_FRect structure filled in with the intersection of
  *               rectangles `A` and `B`
  * \returns SDL_TRUE if there is an intersection, SDL_FALSE otherwise.
  *
@@ -440,9 +440,9 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GetRectIntersectionFloat(const SDL_FRec
 /**
  * Calculate the union of two rectangles with float precision.
  *
- * \param A an SDL_FRect structure representing the first rectangle
- * \param B an SDL_FRect structure representing the second rectangle
- * \param result an SDL_FRect structure filled in with the union of rectangles
+ * \param[in,opt] A an SDL_FRect structure representing the first rectangle
+ * \param[in,opt] B an SDL_FRect structure representing the second rectangle
+ * \param[out,opt] result an SDL_FRect structure filled in with the union of rectangles
  *               `A` and `B`
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -460,11 +460,11 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetRectUnionFloat(const SDL_FRect * A,
  * If `clip` is not NULL then only points inside of the clipping rectangle are
  * considered.
  *
- * \param points an array of SDL_FPoint structures representing points to be
+ * \param[in] points an array of SDL_FPoint structures representing points to be
  *               enclosed
  * \param count the number of structures in the `points` array
- * \param clip an SDL_FRect used for clipping or NULL to enclose all points
- * \param result an SDL_FRect structure filled in with the minimal enclosing
+ * \param[in,opt] clip an SDL_FRect used for clipping or NULL to enclose all points
+ * \param[out,opt] result an SDL_FRect structure filled in with the minimal enclosing
  *               rectangle
  * \returns SDL_TRUE if any points were enclosed or SDL_FALSE if all the
  *          points were outside of the clipping rectangle.
@@ -486,11 +486,11 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GetRectEnclosingPointsFloat(const SDL_F
  * both ends will be clipped to the boundary of the rectangle and the new
  * coordinates saved in `X1`, `Y1`, `X2`, and/or `Y2` as necessary.
  *
- * \param rect an SDL_FRect structure representing the rectangle to intersect
- * \param X1 a pointer to the starting X-coordinate of the line
- * \param Y1 a pointer to the starting Y-coordinate of the line
- * \param X2 a pointer to the ending X-coordinate of the line
- * \param Y2 a pointer to the ending Y-coordinate of the line
+ * \param[in,opt] rect an SDL_FRect structure representing the rectangle to intersect
+ * \param[out,opt] X1 a pointer to the starting X-coordinate of the line
+ * \param[out,opt] Y1 a pointer to the starting Y-coordinate of the line
+ * \param[out,opt] X2 a pointer to the ending X-coordinate of the line
+ * \param[out,opt] Y2 a pointer to the ending Y-coordinate of the line
  * \returns SDL_TRUE if there is an intersection, SDL_FALSE otherwise.
  *
  * \since This function is available since SDL 3.0.0.

--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -183,13 +183,13 @@ extern SDL_DECLSPEC const char *SDLCALL SDL_GetRenderDriver(int index);
 /**
  * Create a window and default renderer.
  *
- * \param title the title of the window, in UTF-8 encoding
+ * \param[in] title the title of the window, in UTF-8 encoding
  * \param width the width of the window
  * \param height the height of the window
  * \param window_flags the flags used to create the window (see
  *                     SDL_CreateWindow())
- * \param window a pointer filled with the window, or NULL on error
- * \param renderer a pointer filled with the renderer, or NULL on error
+ * \param[out,own] window a pointer filled with the window, or NULL on error
+ * \param[out,own] renderer a pointer filled with the renderer, or NULL on error
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -213,10 +213,10 @@ extern SDL_DECLSPEC int SDLCALL SDL_CreateWindowAndRenderer(const char *title, i
  * can call SDL_SetRenderLogicalPresentation() to change the content size and
  * scaling options.
  *
- * \param window the window where rendering is displayed
- * \param name the name of the rendering driver to initialize, or NULL to
+ * \param[inout] window the window where rendering is displayed
+ * \param[in] name the name of the rendering driver to initialize, or NULL to
  *             initialize the first one supporting the requested flags
- * \returns a valid rendering context or NULL if there was an error; call
+ * \returns[own] a valid rendering context or NULL if there was an error; call
  *          SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -268,7 +268,7 @@ extern SDL_DECLSPEC SDL_Renderer * SDLCALL SDL_CreateRenderer(SDL_Window *window
  *   queue family index used for presentation.
  *
  * \param props the properties to use
- * \returns a valid rendering context or NULL if there was an error; call
+ * \returns[own] a valid rendering context or NULL if there was an error; call
  *          SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -301,9 +301,9 @@ extern SDL_DECLSPEC SDL_Renderer * SDLCALL SDL_CreateRendererWithProperties(SDL_
  * create a software renderer, but they are intended to be used with an
  * SDL_Window as the final destination and not an SDL_Surface.
  *
- * \param surface the SDL_Surface structure representing the surface where
+ * \param[inout] surface the SDL_Surface structure representing the surface where
  *                rendering is done
- * \returns a valid rendering context or NULL if there was an error; call
+ * \returns[own] a valid rendering context or NULL if there was an error; call
  *          SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -315,7 +315,7 @@ extern SDL_DECLSPEC SDL_Renderer *SDLCALL SDL_CreateSoftwareRenderer(SDL_Surface
 /**
  * Get the renderer associated with a window.
  *
- * \param window the window to query
+ * \param[inout] window the window to query
  * \returns the rendering context on success or NULL on failure; call
  *          SDL_GetError() for more information.
  *
@@ -326,7 +326,7 @@ extern SDL_DECLSPEC SDL_Renderer *SDLCALL SDL_GetRenderer(SDL_Window *window);
 /**
  * Get the window associated with a renderer.
  *
- * \param renderer the renderer to query
+ * \param[inout] renderer the renderer to query
  * \returns the window on success or NULL on failure; call SDL_GetError() for
  *          more information.
  *
@@ -337,8 +337,8 @@ extern SDL_DECLSPEC SDL_Window *SDLCALL SDL_GetRenderWindow(SDL_Renderer *render
 /**
  * Get information about a rendering context.
  *
- * \param renderer the rendering context
- * \param info an SDL_RendererInfo structure filled with information about the
+ * \param[inout] renderer the rendering context
+ * \param[out] info an SDL_RendererInfo structure filled with information about the
  *             current renderer
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -418,7 +418,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetRendererInfo(SDL_Renderer *renderer, SDL_
  *   swapchain images, or potential frames in flight, used by the Vulkan
  *   renderer
  *
- * \param renderer the rendering context
+ * \param[inout] renderer the rendering context
  * \returns a valid property ID on success or 0 on failure; call
  *          SDL_GetError() for more information.
  *
@@ -458,9 +458,9 @@ extern SDL_DECLSPEC SDL_PropertiesID SDLCALL SDL_GetRendererProperties(SDL_Rende
  * This returns the true output size in pixels, ignoring any render targets or
  * logical size and presentation.
  *
- * \param renderer the rendering context
- * \param w a pointer filled in with the width in pixels
- * \param h a pointer filled in with the height in pixels
+ * \param[inout] renderer the rendering context
+ * \param[out,opt] w a pointer filled in with the width in pixels
+ * \param[out,opt] h a pointer filled in with the height in pixels
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -478,9 +478,9 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetRenderOutputSize(SDL_Renderer *renderer, 
  * logical size, otherwise it will return the value of
  * SDL_GetRenderOutputSize().
  *
- * \param renderer the rendering context
- * \param w a pointer filled in with the current width
- * \param h a pointer filled in with the current height
+ * \param[inout] renderer the rendering context
+ * \param[out,opt] w a pointer filled in with the current width
+ * \param[out,opt] h a pointer filled in with the current height
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -493,7 +493,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetCurrentRenderOutputSize(SDL_Renderer *ren
 /**
  * Create a texture for a rendering context.
  *
- * \param renderer the rendering context
+ * \param[inout] renderer the rendering context
  * \param format one of the enumerated values in SDL_PixelFormatEnum
  * \param access one of the enumerated values in SDL_TextureAccess
  * \param w the width of the texture in pixels
@@ -524,10 +524,10 @@ extern SDL_DECLSPEC SDL_Texture *SDLCALL SDL_CreateTexture(SDL_Renderer *rendere
  * format of the surface. Use SDL_QueryTexture() to query the pixel format of
  * the texture.
  *
- * \param renderer the rendering context
- * \param surface the SDL_Surface structure containing pixel data used to fill
+ * \param[inout] renderer the rendering context
+ * \param[inout] surface the SDL_Surface structure containing pixel data used to fill
  *                the texture
- * \returns the created texture or NULL on failure; call SDL_GetError() for
+ * \returns[own] the created texture or NULL on failure; call SDL_GetError() for
  *          more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -633,9 +633,9 @@ extern SDL_DECLSPEC SDL_Texture *SDLCALL SDL_CreateTextureFromSurface(SDL_Render
  *   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL associated with the texture, if
  *   you want to wrap an existing texture.
  *
- * \param renderer the rendering context
+ * \param[inout] renderer the rendering context
  * \param props the properties to use
- * \returns a pointer to the created texture or NULL if no rendering context
+ * \returns[own] a pointer to the created texture or NULL if no rendering context
  *          was active, the format was unsupported, or the width or height
  *          were out of range; call SDL_GetError() for more information.
  *
@@ -1250,8 +1250,8 @@ extern SDL_DECLSPEC void SDLCALL SDL_UnlockTexture(SDL_Texture *texture);
  * To stop rendering to a texture and render to the window again, call this
  * function with a NULL `texture`.
  *
- * \param renderer the rendering context
- * \param texture the targeted texture, which must be created with the
+ * \param[inout] renderer the rendering context
+ * \param[inout] texture the targeted texture, which must be created with the
  *                `SDL_TEXTUREACCESS_TARGET` flag, or NULL to render to the
  *                window instead of a texture.
  * \returns 0 on success or a negative error code on failure; call
@@ -1269,7 +1269,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetRenderTarget(SDL_Renderer *renderer, SDL_
  * The default render target is the window for which the renderer was created,
  * and is reported a NULL here.
  *
- * \param renderer the rendering context
+ * \param[inout] renderer the rendering context
  * \returns the current render target or NULL for the default render target.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1292,7 +1292,7 @@ extern SDL_DECLSPEC SDL_Texture *SDLCALL SDL_GetRenderTarget(SDL_Renderer *rende
  * You can convert coordinates in an event into rendering coordinates using
  * SDL_ConvertEventToRenderCoordinates().
  *
- * \param renderer the rendering context
+ * \param[inout] renderer the rendering context
  * \param w the width of the logical resolution
  * \param h the height of the logical resolution
  * \param mode the presentation mode used
@@ -1313,11 +1313,11 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetRenderLogicalPresentation(SDL_Renderer *r
  * This function gets the width and height of the logical rendering output, or
  * the output size in pixels if a logical resolution is not enabled.
  *
- * \param renderer the rendering context
- * \param w an int to be filled with the width
- * \param h an int to be filled with the height
- * \param mode a pointer filled in with the presentation mode
- * \param scale_mode a pointer filled in with the scale mode
+ * \param[inout] renderer the rendering context
+ * \param[out,opt] w an int to be filled with the width
+ * \param[out,opt] h an int to be filled with the height
+ * \param[out,opt] mode a pointer filled in with the presentation mode
+ * \param[out,opt] scale_mode a pointer filled in with the scale mode
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1330,11 +1330,11 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetRenderLogicalPresentation(SDL_Renderer *r
 /**
  * Get a point in render coordinates when given a point in window coordinates.
  *
- * \param renderer the rendering context
+ * \param[inout] renderer the rendering context
  * \param window_x the x coordinate in window coordinates
  * \param window_y the y coordinate in window coordinates
- * \param x a pointer filled with the x coordinate in render coordinates
- * \param y a pointer filled with the y coordinate in render coordinates
+ * \param[out,opt] x a pointer filled with the x coordinate in render coordinates
+ * \param[out,opt] y a pointer filled with the y coordinate in render coordinates
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1348,12 +1348,12 @@ extern SDL_DECLSPEC int SDLCALL SDL_RenderCoordinatesFromWindow(SDL_Renderer *re
 /**
  * Get a point in window coordinates when given a point in render coordinates.
  *
- * \param renderer the rendering context
+ * \param[inout] renderer the rendering context
  * \param x the x coordinate in render coordinates
  * \param y the y coordinate in render coordinates
- * \param window_x a pointer filled with the x coordinate in window
+ * \param[out,opt] window_x a pointer filled with the x coordinate in window
  *                 coordinates
- * \param window_y a pointer filled with the y coordinate in window
+ * \param[out,opt] window_y a pointer filled with the y coordinate in window
  *                 coordinates
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1373,8 +1373,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_RenderCoordinatesToWindow(SDL_Renderer *rend
  *
  * Once converted, the coordinates may be outside the rendering area.
  *
- * \param renderer the rendering context
- * \param event the event to modify
+ * \param[inout] renderer the rendering context
+ * \param[out] event the event to modify
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1387,8 +1387,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_ConvertEventToRenderCoordinates(SDL_Renderer
 /**
  * Set the drawing area for rendering on the current target.
  *
- * \param renderer the rendering context
- * \param rect the SDL_Rect structure representing the drawing area, or NULL
+ * \param[inout] renderer the rendering context
+ * \param[in,opt] rect the SDL_Rect structure representing the drawing area, or NULL
  *             to set the viewport to the entire target
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1403,8 +1403,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetRenderViewport(SDL_Renderer *renderer, co
 /**
  * Get the drawing area for the current target.
  *
- * \param renderer the rendering context
- * \param rect an SDL_Rect structure filled in with the current drawing area
+ * \param[inout] renderer the rendering context
+ * \param[out] rect an SDL_Rect structure filled in with the current drawing area
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1422,7 +1422,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetRenderViewport(SDL_Renderer *renderer, SD
  * whether you should restore a specific rectangle or NULL. Note that the
  * viewport is always reset when changing rendering targets.
  *
- * \param renderer the rendering context
+ * \param[inout] renderer the rendering context
  * \returns SDL_TRUE if the viewport was set to a specific rectangle, or
  *          SDL_FALSE if it was set to NULL (the entire target)
  *
@@ -1436,8 +1436,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_RenderViewportSet(SDL_Renderer *rendere
 /**
  * Set the clip rectangle for rendering on the specified target.
  *
- * \param renderer the rendering context
- * \param rect an SDL_Rect structure representing the clip area, relative to
+ * \param[inout] renderer the rendering context
+ * \param[in,opt] rect an SDL_Rect structure representing the clip area, relative to
  *             the viewport, or NULL to disable clipping
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1452,8 +1452,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetRenderClipRect(SDL_Renderer *renderer, co
 /**
  * Get the clip rectangle for the current target.
  *
- * \param renderer the rendering context
- * \param rect an SDL_Rect structure filled in with the current clipping area
+ * \param[inout] renderer the rendering context
+ * \param[out,opt] rect an SDL_Rect structure filled in with the current clipping area
  *             or an empty rectangle if clipping is disabled
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1468,7 +1468,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetRenderClipRect(SDL_Renderer *renderer, SD
 /**
  * Get whether clipping is enabled on the given renderer.
  *
- * \param renderer the rendering context
+ * \param[inout] renderer the rendering context
  * \returns SDL_TRUE if clipping is enabled or SDL_FALSE if not; call
  *          SDL_GetError() for more information.
  *
@@ -1490,7 +1490,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_RenderClipEnabled(SDL_Renderer *rendere
  * will be handled using the appropriate quality hints. For best results use
  * integer scaling factors.
  *
- * \param renderer the rendering context
+ * \param[inout] renderer the rendering context
  * \param scaleX the horizontal scaling factor
  * \param scaleY the vertical scaling factor
  * \returns 0 on success or a negative error code on failure; call
@@ -1505,9 +1505,9 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetRenderScale(SDL_Renderer *renderer, float
 /**
  * Get the drawing scale for the current target.
  *
- * \param renderer the rendering context
- * \param scaleX a pointer filled in with the horizontal scaling factor
- * \param scaleY a pointer filled in with the vertical scaling factor
+ * \param[inout] renderer the rendering context
+ * \param[out,opt] scaleX a pointer filled in with the horizontal scaling factor
+ * \param[out,opt] scaleY a pointer filled in with the vertical scaling factor
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1523,7 +1523,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetRenderScale(SDL_Renderer *renderer, float
  * Set the color for drawing or filling rectangles, lines, and points, and for
  * SDL_RenderClear().
  *
- * \param renderer the rendering context
+ * \param[inout] renderer the rendering context
  * \param r the red value used to draw on the rendering target
  * \param g the green value used to draw on the rendering target
  * \param b the blue value used to draw on the rendering target
@@ -1546,7 +1546,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetRenderDrawColor(SDL_Renderer *renderer, U
  * Set the color for drawing or filling rectangles, lines, and points, and for
  * SDL_RenderClear().
  *
- * \param renderer the rendering context
+ * \param[inout] renderer the rendering context
  * \param r the red value used to draw on the rendering target
  * \param g the green value used to draw on the rendering target
  * \param b the blue value used to draw on the rendering target
@@ -1566,14 +1566,14 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetRenderDrawColorFloat(SDL_Renderer *render
 /**
  * Get the color used for drawing operations (Rect, Line and Clear).
  *
- * \param renderer the rendering context
- * \param r a pointer filled in with the red value used to draw on the
+ * \param[inout] renderer the rendering context
+ * \param[out,opt] r a pointer filled in with the red value used to draw on the
  *          rendering target
- * \param g a pointer filled in with the green value used to draw on the
+ * \param[out,opt] g a pointer filled in with the green value used to draw on the
  *          rendering target
- * \param b a pointer filled in with the blue value used to draw on the
+ * \param[out,opt] b a pointer filled in with the blue value used to draw on the
  *          rendering target
- * \param a a pointer filled in with the alpha value used to draw on the
+ * \param[out,opt] a a pointer filled in with the alpha value used to draw on the
  *          rendering target; usually `SDL_ALPHA_OPAQUE` (255)
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1588,14 +1588,14 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetRenderDrawColor(SDL_Renderer *renderer, U
 /**
  * Get the color used for drawing operations (Rect, Line and Clear).
  *
- * \param renderer the rendering context
- * \param r a pointer filled in with the red value used to draw on the
+ * \param[inout] renderer the rendering context
+ * \param[out,opt] r a pointer filled in with the red value used to draw on the
  *          rendering target
- * \param g a pointer filled in with the green value used to draw on the
+ * \param[out,opt] g a pointer filled in with the green value used to draw on the
  *          rendering target
- * \param b a pointer filled in with the blue value used to draw on the
+ * \param[out,opt] b a pointer filled in with the blue value used to draw on the
  *          rendering target
- * \param a a pointer filled in with the alpha value used to draw on the
+ * \param[out,opt] a a pointer filled in with the alpha value used to draw on the
  *          rendering target
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1618,7 +1618,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetRenderDrawColorFloat(SDL_Renderer *render
  * The color scale does not affect the alpha channel, only the color
  * brightness.
  *
- * \param renderer the rendering context
+ * \param[inout] renderer the rendering context
  * \param scale the color scale value
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1632,8 +1632,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetRenderColorScale(SDL_Renderer *renderer, 
 /**
  * Get the color scale used for render operations.
  *
- * \param renderer the rendering context
- * \param scale a pointer filled in with the current color scale value
+ * \param[inout] renderer the rendering context
+ * \param[out,opt] scale a pointer filled in with the current color scale value
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1648,7 +1648,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetRenderColorScale(SDL_Renderer *renderer, 
  *
  * If the blend mode is not supported, the closest supported mode is chosen.
  *
- * \param renderer the rendering context
+ * \param[inout] renderer the rendering context
  * \param blendMode the SDL_BlendMode to use for blending
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1662,8 +1662,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetRenderDrawBlendMode(SDL_Renderer *rendere
 /**
  * Get the blend mode used for drawing operations.
  *
- * \param renderer the rendering context
- * \param blendMode a pointer filled in with the current SDL_BlendMode
+ * \param[inout] renderer the rendering context
+ * \param[out,opt] blendMode a pointer filled in with the current SDL_BlendMode
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1681,7 +1681,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetRenderDrawBlendMode(SDL_Renderer *rendere
  * the rendering target to current renderer draw color, so make sure to invoke
  * SDL_SetRenderDrawColor() when needed.
  *
- * \param renderer the rendering context
+ * \param[inout] renderer the rendering context
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1694,7 +1694,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_RenderClear(SDL_Renderer *renderer);
 /**
  * Draw a point on the current rendering target at subpixel precision.
  *
- * \param renderer The renderer which should draw a point.
+ * \param[inout] renderer The renderer which should draw a point.
  * \param x The x coordinate of the point.
  * \param y The y coordinate of the point.
  * \returns 0 on success, or -1 on error
@@ -1708,8 +1708,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_RenderPoint(SDL_Renderer *renderer, float x,
 /**
  * Draw multiple points on the current rendering target at subpixel precision.
  *
- * \param renderer The renderer which should draw multiple points.
- * \param points The points to draw
+ * \param[inout] renderer The renderer which should draw multiple points.
+ * \param[in,opt] points The points to draw
  * \param count The number of points to draw
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1723,7 +1723,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_RenderPoints(SDL_Renderer *renderer, const S
 /**
  * Draw a line on the current rendering target at subpixel precision.
  *
- * \param renderer The renderer which should draw a line.
+ * \param[inout] renderer The renderer which should draw a line.
  * \param x1 The x coordinate of the start point.
  * \param y1 The y coordinate of the start point.
  * \param x2 The x coordinate of the end point.
@@ -1740,8 +1740,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_RenderLine(SDL_Renderer *renderer, float x1,
  * Draw a series of connected lines on the current rendering target at
  * subpixel precision.
  *
- * \param renderer The renderer which should draw multiple lines.
- * \param points The points along the lines
+ * \param[inout] renderer The renderer which should draw multiple lines.
+ * \param[in,opt] points The points along the lines
  * \param count The number of points, drawing count-1 lines
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1755,8 +1755,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_RenderLines(SDL_Renderer *renderer, const SD
 /**
  * Draw a rectangle on the current rendering target at subpixel precision.
  *
- * \param renderer The renderer which should draw a rectangle.
- * \param rect A pointer to the destination rectangle, or NULL to outline the
+ * \param[inout] renderer The renderer which should draw a rectangle.
+ * \param[in,opt] rect A pointer to the destination rectangle, or NULL to outline the
  *             entire rendering target.
  * \returns 0 on success, or -1 on error
  *
@@ -1770,8 +1770,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_RenderRect(SDL_Renderer *renderer, const SDL
  * Draw some number of rectangles on the current rendering target at subpixel
  * precision.
  *
- * \param renderer The renderer which should draw multiple rectangles.
- * \param rects A pointer to an array of destination rectangles.
+ * \param[inout] renderer The renderer which should draw multiple rectangles.
+ * \param[in,opt] rects A pointer to an array of destination rectangles.
  * \param count The number of rectangles.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1786,8 +1786,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_RenderRects(SDL_Renderer *renderer, const SD
  * Fill a rectangle on the current rendering target with the drawing color at
  * subpixel precision.
  *
- * \param renderer The renderer which should fill a rectangle.
- * \param rect A pointer to the destination rectangle, or NULL for the entire
+ * \param[inout] renderer The renderer which should fill a rectangle.
+ * \param[in,opt] rect A pointer to the destination rectangle, or NULL for the entire
  *             rendering target.
  * \returns 0 on success, or -1 on error
  *
@@ -1801,8 +1801,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_RenderFillRect(SDL_Renderer *renderer, const
  * Fill some number of rectangles on the current rendering target with the
  * drawing color at subpixel precision.
  *
- * \param renderer The renderer which should fill multiple rectangles.
- * \param rects A pointer to an array of destination rectangles.
+ * \param[inout] renderer The renderer which should fill multiple rectangles.
+ * \param[in,opt] rects A pointer to an array of destination rectangles.
  * \param count The number of rectangles.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1817,11 +1817,11 @@ extern SDL_DECLSPEC int SDLCALL SDL_RenderFillRects(SDL_Renderer *renderer, cons
  * Copy a portion of the texture to the current rendering target at subpixel
  * precision.
  *
- * \param renderer The renderer which should copy parts of a texture.
- * \param texture The source texture.
- * \param srcrect A pointer to the source rectangle, or NULL for the entire
+ * \param[inout] renderer The renderer which should copy parts of a texture.
+ * \param[inout] texture The source texture.
+ * \param[in,opt] srcrect A pointer to the source rectangle, or NULL for the entire
  *                texture.
- * \param dstrect A pointer to the destination rectangle, or NULL for the
+ * \param[in,opt] dstrect A pointer to the destination rectangle, or NULL for the
  *                entire rendering target.
  * \returns 0 on success, or -1 on error
  *
@@ -1835,15 +1835,15 @@ extern SDL_DECLSPEC int SDLCALL SDL_RenderTexture(SDL_Renderer *renderer, SDL_Te
  * Copy a portion of the source texture to the current rendering target, with
  * rotation and flipping, at subpixel precision.
  *
- * \param renderer The renderer which should copy parts of a texture.
- * \param texture The source texture.
- * \param srcrect A pointer to the source rectangle, or NULL for the entire
+ * \param[inout] renderer The renderer which should copy parts of a texture.
+ * \param[inout] texture The source texture.
+ * \param[in,opt] srcrect A pointer to the source rectangle, or NULL for the entire
  *                texture.
- * \param dstrect A pointer to the destination rectangle, or NULL for the
+ * \param[in,opt] dstrect A pointer to the destination rectangle, or NULL for the
  *                entire rendering target.
  * \param angle An angle in degrees that indicates the rotation that will be
  *              applied to dstrect, rotating it in a clockwise direction
- * \param center A pointer to a point indicating the point around which
+ * \param[in,opt] center A pointer to a point indicating the point around which
  *               dstrect will be rotated (if NULL, rotation will be done
  *               around dstrect.w/2, dstrect.h/2).
  * \param flip An SDL_FlipMode value stating which flipping actions should be
@@ -1865,11 +1865,11 @@ extern SDL_DECLSPEC int SDLCALL SDL_RenderTextureRotated(SDL_Renderer *renderer,
  * vertex array Color and alpha modulation is done per vertex
  * (SDL_SetTextureColorMod and SDL_SetTextureAlphaMod are ignored).
  *
- * \param renderer The rendering context.
- * \param texture (optional) The SDL texture to use.
- * \param vertices Vertices.
+ * \param[inout] renderer The rendering context.
+ * \param[inout,opt] texture (optional) The SDL texture to use.
+ * \param[in] vertices Vertices.
  * \param num_vertices Number of vertices.
- * \param indices (optional) An array of integer indices into the 'vertices'
+ * \param[in,opt] indices (optional) An array of integer indices into the 'vertices'
  *                array, if NULL all vertices will be rendered in sequential
  *                order.
  * \param num_indices Number of indices.
@@ -1889,16 +1889,16 @@ extern SDL_DECLSPEC int SDLCALL SDL_RenderGeometry(SDL_Renderer *renderer,
  * vertex arrays Color and alpha modulation is done per vertex
  * (SDL_SetTextureColorMod and SDL_SetTextureAlphaMod are ignored).
  *
- * \param renderer The rendering context.
- * \param texture (optional) The SDL texture to use.
- * \param xy Vertex positions
+ * \param[inout] renderer The rendering context.
+ * \param[inout,opt] texture (optional) The SDL texture to use.
+ * \param[in] xy Vertex positions
  * \param xy_stride Byte size to move from one element to the next element
- * \param color Vertex colors (as SDL_Color)
+ * \param[in] color Vertex colors (as SDL_Color)
  * \param color_stride Byte size to move from one element to the next element
- * \param uv Vertex normalized texture coordinates
+ * \param[in] uv Vertex normalized texture coordinates
  * \param uv_stride Byte size to move from one element to the next element
  * \param num_vertices Number of vertices.
- * \param indices (optional) An array of indices into the 'vertices' arrays,
+ * \param[in,opt] indices (optional) An array of indices into the 'vertices' arrays,
  *                if NULL all vertices will be rendered in sequential order.
  * \param num_indices Number of indices.
  * \param size_indices Index size: 1 (byte), 2 (short), 4 (int)
@@ -1922,16 +1922,16 @@ extern SDL_DECLSPEC int SDLCALL SDL_RenderGeometryRaw(SDL_Renderer *renderer,
  * vertex arrays Color and alpha modulation is done per vertex
  * (SDL_SetTextureColorMod and SDL_SetTextureAlphaMod are ignored).
  *
- * \param renderer The rendering context.
- * \param texture (optional) The SDL texture to use.
- * \param xy Vertex positions
+ * \param[inout] renderer The rendering context.
+ * \param[inout,opt] texture (optional) The SDL texture to use.
+ * \param[in] xy Vertex positions
  * \param xy_stride Byte size to move from one element to the next element
- * \param color Vertex colors (as SDL_FColor)
+ * \param[in] color Vertex colors (as SDL_FColor)
  * \param color_stride Byte size to move from one element to the next element
- * \param uv Vertex normalized texture coordinates
+ * \param[in] uv Vertex normalized texture coordinates
  * \param uv_stride Byte size to move from one element to the next element
  * \param num_vertices Number of vertices.
- * \param indices (optional) An array of indices into the 'vertices' arrays,
+ * \param[in,opt] indices (optional) An array of indices into the 'vertices' arrays,
  *                if NULL all vertices will be rendered in sequential order.
  * \param num_indices Number of indices.
  * \param size_indices Index size: 1 (byte), 2 (short), 4 (int)
@@ -1960,10 +1960,10 @@ extern SDL_DECLSPEC int SDLCALL SDL_RenderGeometryRawFloat(SDL_Renderer *rendere
  * frequently. If you're using this on the main rendering target, it should be
  * called after rendering and before SDL_RenderPresent().
  *
- * \param renderer the rendering context
- * \param rect an SDL_Rect structure representing the area in pixels relative
+ * \param[inout] renderer the rendering context
+ * \param[in,opt] rect an SDL_Rect structure representing the area in pixels relative
  *             to the to current viewport, or NULL for the entire viewport
- * \returns a new SDL_Surface on success or NULL on failure; call
+ * \returns[own] a new SDL_Surface on success or NULL on failure; call
  *          SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1989,7 +1989,7 @@ extern SDL_DECLSPEC SDL_Surface * SDLCALL SDL_RenderReadPixels(SDL_Renderer *ren
  * starting each new frame's drawing, even if you plan to overwrite every
  * pixel.
  *
- * \param renderer the rendering context
+ * \param[inout] renderer the rendering context
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -2017,7 +2017,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_RenderPresent(SDL_Renderer *renderer);
  * Passing NULL or an otherwise invalid texture will set the SDL error message
  * to "Invalid texture".
  *
- * \param texture the texture to destroy
+ * \param[inout] texture the texture to destroy
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -2032,7 +2032,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_DestroyTexture(SDL_Texture *texture);
  * If `renderer` is NULL, this function will return immediately after setting
  * the SDL error message to "Invalid renderer". See SDL_GetError().
  *
- * \param renderer the rendering context
+ * \param[inout] renderer the rendering context
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -2063,7 +2063,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_DestroyRenderer(SDL_Renderer *renderer);
  * OpenGL state that can confuse things; you should use your best judgement
  * and be prepared to make changes if specific state needs to be protected.
  *
- * \param renderer the rendering context
+ * \param[inout] renderer the rendering context
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -2077,7 +2077,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_FlushRenderer(SDL_Renderer *renderer);
  * This function returns `void *`, so SDL doesn't have to include Metal's
  * headers, but it can be safely cast to a `CAMetalLayer *`.
  *
- * \param renderer The renderer to query
+ * \param[inout] renderer The renderer to query
  * \returns a `CAMetalLayer *` on success, or NULL if the renderer isn't a
  *          Metal renderer
  *
@@ -2098,7 +2098,7 @@ extern SDL_DECLSPEC void *SDLCALL SDL_GetRenderMetalLayer(SDL_Renderer *renderer
  * doesn't apply to command encoders for render targets, just the window's
  * backbuffer. Check your return values!
  *
- * \param renderer The renderer to query
+ * \param[inout] renderer The renderer to query
  * \returns an `id<MTLRenderCommandEncoder>` on success, or NULL if the
  *          renderer isn't a Metal renderer or there was an error.
  *
@@ -2122,7 +2122,7 @@ extern SDL_DECLSPEC void *SDLCALL SDL_GetRenderMetalCommandEncoder(SDL_Renderer 
  * SDL_PROP_RENDERER_VULKAN_SWAPCHAIN_IMAGE_COUNT_NUMBER will give you the
  * maximum number of semaphores you'll need.
  *
- * \param renderer the rendering context
+ * \param[inout] renderer the rendering context
  * \param wait_stage_mask the VkPipelineStageFlags for the wait
  * \param wait_semaphore a VkSempahore to wait on before rendering the current
  *                       frame, or 0 if not needed
@@ -2142,7 +2142,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_AddVulkanRenderSemaphores(SDL_Renderer *rend
 /**
  * Toggle VSync of the given renderer.
  *
- * \param renderer The renderer to toggle
+ * \param[inout] renderer The renderer to toggle
  * \param vsync the vertical refresh sync interval, 1 to synchronize present
  *              with every vertical refresh, 2 to synchronize present with
  *              every second vertical refresh, etc.,
@@ -2166,7 +2166,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetRenderVSync(SDL_Renderer *renderer, int v
 /**
  * Get VSync of the given renderer.
  *
- * \param renderer The renderer to toggle
+ * \param[inout] renderer The renderer to toggle
  * \param vsync an int filled with the current vertical refresh sync interval.
  *              See SDL_SetRenderVSync for the meaning of the value.
  * \returns 0 on success or a negative error code on failure; call

--- a/include/SDL3/SDL_sensor.h
+++ b/include/SDL3/SDL_sensor.h
@@ -146,8 +146,8 @@ typedef enum SDL_SensorType
 /**
  * Get a list of currently connected sensors.
  *
- * \param count a pointer filled in with the number of sensors returned
- * \returns a 0 terminated array of sensor instance IDs which should be freed
+ * \param[out,opt] count a pointer filled in with the number of sensors returned
+ * \returns[own] a 0 terminated array of sensor instance IDs which should be freed
  *          with SDL_free(), or NULL on error; call SDL_GetError() for more
  *          details.
  *
@@ -191,7 +191,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetSensorInstanceNonPortableType(SDL_SensorI
  * Open a sensor for use.
  *
  * \param instance_id the sensor instance ID
- * \returns an SDL_Sensor sensor object, or NULL if an error occurred.
+ * \returns[own] an SDL_Sensor sensor object, or NULL if an error occurred.
  *
  * \since This function is available since SDL 3.0.0.
  */
@@ -210,7 +210,7 @@ extern SDL_DECLSPEC SDL_Sensor *SDLCALL SDL_GetSensorFromInstanceID(SDL_SensorID
 /**
  * Get the properties associated with a sensor.
  *
- * \param sensor The SDL_Sensor object
+ * \param[inout] sensor The SDL_Sensor object
  * \returns a valid property ID on success or 0 on failure; call
  *          SDL_GetError() for more information.
  *
@@ -224,7 +224,7 @@ extern SDL_DECLSPEC SDL_PropertiesID SDLCALL SDL_GetSensorProperties(SDL_Sensor 
 /**
  * Get the implementation dependent name of a sensor.
  *
- * \param sensor The SDL_Sensor object
+ * \param[inout] sensor The SDL_Sensor object
  * \returns the sensor name, or NULL if `sensor` is NULL.
  *
  * \since This function is available since SDL 3.0.0.
@@ -234,7 +234,7 @@ extern SDL_DECLSPEC const char *SDLCALL SDL_GetSensorName(SDL_Sensor *sensor);
 /**
  * Get the type of a sensor.
  *
- * \param sensor The SDL_Sensor object to inspect
+ * \param[inout] sensor The SDL_Sensor object to inspect
  * \returns the SDL_SensorType type, or `SDL_SENSOR_INVALID` if `sensor` is
  *          NULL.
  *
@@ -245,7 +245,7 @@ extern SDL_DECLSPEC SDL_SensorType SDLCALL SDL_GetSensorType(SDL_Sensor *sensor)
 /**
  * Get the platform dependent type of a sensor.
  *
- * \param sensor The SDL_Sensor object to inspect
+ * \param[inout] sensor The SDL_Sensor object to inspect
  * \returns the sensor platform dependent type, or -1 if `sensor` is NULL.
  *
  * \since This function is available since SDL 3.0.0.
@@ -255,7 +255,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetSensorNonPortableType(SDL_Sensor *sensor)
 /**
  * Get the instance ID of a sensor.
  *
- * \param sensor The SDL_Sensor object to inspect
+ * \param[inout] sensor The SDL_Sensor object to inspect
  * \returns the sensor instance ID, or 0 if `sensor` is NULL.
  *
  * \since This function is available since SDL 3.0.0.
@@ -267,8 +267,8 @@ extern SDL_DECLSPEC SDL_SensorID SDLCALL SDL_GetSensorInstanceID(SDL_Sensor *sen
  *
  * The number of values and interpretation of the data is sensor dependent.
  *
- * \param sensor The SDL_Sensor object to query
- * \param data A pointer filled with the current sensor state
+ * \param[inout] sensor The SDL_Sensor object to query
+ * \param[out] data A pointer filled with the current sensor state
  * \param num_values The number of values to write to data
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -280,7 +280,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetSensorData(SDL_Sensor *sensor, float *dat
 /**
  * Close a sensor previously opened with SDL_OpenSensor().
  *
- * \param sensor The SDL_Sensor object to close
+ * \param[inout] sensor The SDL_Sensor object to close
  *
  * \since This function is available since SDL 3.0.0.
  */

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -495,10 +495,10 @@ typedef void (SDLCALL *SDL_free_func)(void *mem);
 /**
  * Get the original set of SDL memory functions.
  *
- * \param malloc_func filled with malloc function
- * \param calloc_func filled with calloc function
- * \param realloc_func filled with realloc function
- * \param free_func filled with free function
+ * \param[out,opt] malloc_func filled with malloc function
+ * \param[out,opt] calloc_func filled with calloc function
+ * \param[out,opt] realloc_func filled with realloc function
+ * \param[out,opt] free_func filled with free function
  *
  * \since This function is available since SDL 3.0.0.
  */
@@ -510,10 +510,10 @@ extern SDL_DECLSPEC void SDLCALL SDL_GetOriginalMemoryFunctions(SDL_malloc_func 
 /**
  * Get the current set of SDL memory functions.
  *
- * \param malloc_func filled with malloc function
- * \param calloc_func filled with calloc function
- * \param realloc_func filled with realloc function
- * \param free_func filled with free function
+ * \param[out,opt] malloc_func filled with malloc function
+ * \param[out,opt] calloc_func filled with calloc function
+ * \param[out,opt] realloc_func filled with realloc function
+ * \param[out,opt] free_func filled with free function
  *
  * \since This function is available since SDL 3.0.0.
  */
@@ -525,10 +525,10 @@ extern SDL_DECLSPEC void SDLCALL SDL_GetMemoryFunctions(SDL_malloc_func *malloc_
 /**
  * Replace SDL's memory allocation functions with a custom set.
  *
- * \param malloc_func custom malloc function
- * \param calloc_func custom calloc function
- * \param realloc_func custom realloc function
- * \param free_func custom free function
+ * \param[in] malloc_func custom malloc function
+ * \param[in] calloc_func custom calloc function
+ * \param[in] realloc_func custom realloc function
+ * \param[in] free_func custom free function
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -552,7 +552,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetMemoryFunctions(SDL_malloc_func malloc_fu
  *
  * \param alignment the alignment requested
  * \param size the size to allocate
- * \returns a pointer to the aligned memory
+ * \returns[own] a pointer to the aligned memory
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -889,8 +889,8 @@ extern SDL_DECLSPEC wchar_t *SDLCALL SDL_wcsnstr(const wchar_t *haystack, const 
  * character; it does not care if the string is well-formed UTF-16 (or UTF-32,
  * depending on your platform's wchar_t size), or uses valid Unicode values.
  *
- * \param str1 The first string to compare. NULL is not permitted!
- * \param str2 The second string to compare. NULL is not permitted!
+ * \param[in] str1 The first string to compare. NULL is not permitted!
+ * \param[in] str2 The second string to compare. NULL is not permitted!
  * \returns less than zero if str1 is "less than" str2, greater than zero if
  *          str1 is "greater than" str2, and zero if the strings match
  *          exactly.
@@ -919,8 +919,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_wcscmp(const wchar_t *str1, const wchar_t *s
  * null-terminator character before this count), they will be considered
  * equal.
  *
- * \param str1 The first string to compare. NULL is not permitted!
- * \param str2 The second string to compare. NULL is not permitted!
+ * \param[in] str1 The first string to compare. NULL is not permitted!
+ * \param[in] str2 The second string to compare. NULL is not permitted!
  * \param maxlen The maximum number of wchar_t to compare.
  * \returns less than zero if str1 is "less than" str2, greater than zero if
  *          str1 is "greater than" str2, and zero if the strings match
@@ -950,8 +950,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_wcsncmp(const wchar_t *str1, const wchar_t *
  * CHARACTER), which is to say two strings of random bits may turn out to
  * match if they convert to the same amount of replacement characters.
  *
- * \param str1 The first string to compare. NULL is not permitted!
- * \param str2 The second string to compare. NULL is not permitted!
+ * \param[in] str1 The first string to compare. NULL is not permitted!
+ * \param[in] str2 The second string to compare. NULL is not permitted!
  * \returns less than zero if str1 is "less than" str2, greater than zero if
  *          str1 is "greater than" str2, and zero if the strings match
  *          exactly.
@@ -991,8 +991,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_wcscasecmp(const wchar_t *str1, const wchar_
  * null-terminator character before this number of bytes), they will be
  * considered equal.
  *
- * \param str1 The first string to compare. NULL is not permitted!
- * \param str2 The second string to compare. NULL is not permitted!
+ * \param[in] str1 The first string to compare. NULL is not permitted!
+ * \param[in] str2 The second string to compare. NULL is not permitted!
  * \param maxlen The maximum number of wchar_t values to compare.
  * \returns less than zero if str1 is "less than" str2, greater than zero if
  *          str1 is "greater than" str2, and zero if the strings match
@@ -1043,7 +1043,7 @@ extern SDL_DECLSPEC char *SDLCALL SDL_strupr(char *str);
  * malformed UTF-8!--and converts ASCII characters 'A' through 'Z' to their
  * lowercase equivalents in-place, returning the original `str` pointer.
  *
- * \param str The string to convert in-place.
+ * \param[inout] str The string to convert in-place.
  * \returns The `str` pointer passed into this function.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -1086,8 +1086,8 @@ extern SDL_DECLSPEC double SDLCALL SDL_strtod(const char *str, char **endp);
  * null-terminating character. Also due to the nature of UTF-8, this can be
  * used with SDL_qsort() to put strings in (roughly) alphabetical order.
  *
- * \param str1 The first string to compare. NULL is not permitted!
- * \param str2 The second string to compare. NULL is not permitted!
+ * \param[in] str1 The first string to compare. NULL is not permitted!
+ * \param[in] str2 The second string to compare. NULL is not permitted!
  * \returns less than zero if str1 is "less than" str2, greater than zero if
  *          str1 is "greater than" str2, and zero if the strings match
  *          exactly.
@@ -1115,8 +1115,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_strcmp(const char *str1, const char *str2);
  * match to this number of bytes (or both have matched to a null-terminator
  * character before this number of bytes), they will be considered equal.
  *
- * \param str1 The first string to compare. NULL is not permitted!
- * \param str2 The second string to compare. NULL is not permitted!
+ * \param[in] str1 The first string to compare. NULL is not permitted!
+ * \param[in] str2 The second string to compare. NULL is not permitted!
  * \param maxlen The maximum number of _bytes_ to compare.
  * \returns less than zero if str1 is "less than" str2, greater than zero if
  *          str1 is "greater than" str2, and zero if the strings match
@@ -1144,8 +1144,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_strncmp(const char *str1, const char *str2, 
  * CHARACTER), which is to say two strings of random bits may turn out to
  * match if they convert to the same amount of replacement characters.
  *
- * \param str1 The first string to compare. NULL is not permitted!
- * \param str2 The second string to compare. NULL is not permitted!
+ * \param[in] str1 The first string to compare. NULL is not permitted!
+ * \param[in] str2 The second string to compare. NULL is not permitted!
  * \returns less than zero if str1 is "less than" str2, greater than zero if
  *          str1 is "greater than" str2, and zero if the strings match
  *          exactly.
@@ -1183,8 +1183,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_strcasecmp(const char *str1, const char *str
  * match to this number of bytes (or both have matched to a null-terminator
  * character before this number of bytes), they will be considered equal.
  *
- * \param str1 The first string to compare. NULL is not permitted!
- * \param str2 The second string to compare. NULL is not permitted!
+ * \param[in] str1 The first string to compare. NULL is not permitted!
+ * \param[in] str2 The second string to compare. NULL is not permitted!
  * \param maxlen The maximum number of bytes to compare.
  * \returns less than zero if str1 is "less than" str2, greater than zero if
  *          str1 is "greater than" str2, and zero if the strings match

--- a/include/SDL3/SDL_storage.h
+++ b/include/SDL3/SDL_storage.h
@@ -101,9 +101,9 @@ typedef struct SDL_Storage SDL_Storage;
 /**
  * Opens up a read-only container for the application's filesystem.
  *
- * \param override a path to override the backend's default title root
+ * \param[in] override a path to override the backend's default title root
  * \param props a property list that may contain backend-specific information
- * \returns a title storage container on success or NULL on failure; call
+ * \returns[own] a title storage container on success or NULL on failure; call
  *          SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -123,10 +123,10 @@ extern SDL_DECLSPEC SDL_Storage *SDLCALL SDL_OpenTitleStorage(const char *overri
  * This allows the backend to properly batch file operations and flush them
  * when the container has been closed; ensuring safe and optimal save I/O.
  *
- * \param org the name of your organization
- * \param app the name of your application
+ * \param[in] org the name of your organization
+ * \param[in] app the name of your application
  * \param props a property list that may contain backend-specific information
- * \returns a user storage container on success or NULL on failure; call
+ * \returns[own] a user storage container on success or NULL on failure; call
  *          SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -148,9 +148,9 @@ extern SDL_DECLSPEC SDL_Storage *SDLCALL SDL_OpenUserStorage(const char *org, co
  * use SDL_OpenTitleStorage() for access to game data and
  * SDL_OpenUserStorage() for access to user data.
  *
- * \param path the base path prepended to all storage paths, or NULL for no
+ * \param[in] path the base path prepended to all storage paths, or NULL for no
  *             base path
- * \returns a filesystem storage container on success or NULL on failure; call
+ * \returns[own] a filesystem storage container on success or NULL on failure; call
  *          SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -173,9 +173,9 @@ extern SDL_DECLSPEC SDL_Storage *SDLCALL SDL_OpenFileStorage(const char *path);
  * should use the built-in implementations in SDL, like SDL_OpenTitleStorage()
  * or SDL_OpenUserStorage().
  *
- * \param iface the function table to be used by this container
- * \param userdata the pointer that will be passed to the store interface
- * \returns a storage container on success or NULL on failure; call
+ * \param[in] iface the function table to be used by this container
+ * \param[inout] userdata the pointer that will be passed to the store interface
+ * \returns[own] a storage container on success or NULL on failure; call
  *          SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -192,7 +192,7 @@ extern SDL_DECLSPEC SDL_Storage *SDLCALL SDL_OpenStorage(const SDL_StorageInterf
 /**
  * Closes and frees a storage container.
  *
- * \param storage a storage container to close
+ * \param[inout] storage a storage container to close
  * \returns 0 if the container was freed with no errors, a negative value
  *          otherwise; call SDL_GetError() for more information. Even if the
  *          function returns an error, the container data will be freed; the
@@ -214,7 +214,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_CloseStorage(SDL_Storage *storage);
  * SDL_TRUE - however, it is not recommended to spinwait on this call, as the
  * backend may depend on a synchronous message loop.
  *
- * \param storage a storage container to query
+ * \param[inout] storage a storage container to query
  * \returns SDL_TRUE if the container is ready, SDL_FALSE otherwise
  *
  * \since This function is available since SDL 3.0.0.
@@ -224,9 +224,9 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_StorageReady(SDL_Storage *storage);
 /**
  * Query the size of a file within a storage container.
  *
- * \param storage a storage container to query
- * \param path the relative path of the file to query
- * \param length a pointer to be filled with the file's length
+ * \param[inout] storage a storage container to query
+ * \param[in] path the relative path of the file to query
+ * \param[out,opt] length a pointer to be filled with the file's length
  * \returns 0 if the file could be queried, a negative value otherwise; call
  *          SDL_GetError() for more information.
  *
@@ -241,9 +241,9 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetStorageFileSize(SDL_Storage *storage, con
  * Synchronously read a file from a storage container into a client-provided
  * buffer.
  *
- * \param storage a storage container to read from
- * \param path the relative path of the file to read
- * \param destination a client-provided buffer to read the file into
+ * \param[inout] storage a storage container to read from
+ * \param[in] path the relative path of the file to read
+ * \param[out] destination a client-provided buffer to read the file into
  * \param length the length of the destination buffer
  * \returns 0 if the file was read, a negative value otherwise; call
  *          SDL_GetError() for more information.
@@ -259,9 +259,9 @@ extern SDL_DECLSPEC int SDLCALL SDL_ReadStorageFile(SDL_Storage *storage, const 
 /**
  * Synchronously write a file from client memory into a storage container.
  *
- * \param storage a storage container to write to
- * \param path the relative path of the file to write
- * \param source a client-provided buffer to write from
+ * \param[inout] storage a storage container to write to
+ * \param[in] path the relative path of the file to write
+ * \param[in] source a client-provided buffer to write from
  * \param length the length of the source buffer
  * \returns 0 if the file was written, a negative value otherwise; call
  *          SDL_GetError() for more information.
@@ -277,8 +277,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_WriteStorageFile(SDL_Storage *storage, const
 /**
  * Create a directory in a writable storage container.
  *
- * \param storage a storage container
- * \param path the path of the directory to create
+ * \param[inout] storage a storage container
+ * \param[in] path the path of the directory to create
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -295,10 +295,10 @@ extern SDL_DECLSPEC int SDLCALL SDL_CreateStorageDirectory(SDL_Storage *storage,
  * callback, called once for each directory entry, until all results have been
  * provided or the callback returns <= 0.
  *
- * \param storage a storage container
- * \param path the path of the directory to enumerate
- * \param callback a function that is called for each entry in the directory
- * \param userdata a pointer that is passed to `callback`
+ * \param[inout] storage a storage container
+ * \param[in] path the path of the directory to enumerate
+ * \param[in] callback a function that is called for each entry in the directory
+ * \param[inout] userdata a pointer that is passed to `callback`
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -311,8 +311,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_EnumerateStorageDirectory(SDL_Storage *stora
 /**
  * Remove a file or an empty directory in a writable storage container.
  *
- * \param storage a storage container
- * \param path the path of the directory to enumerate
+ * \param[inout] storage a storage container
+ * \param[in] path the path of the directory to enumerate
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -325,9 +325,9 @@ extern SDL_DECLSPEC int SDLCALL SDL_RemoveStoragePath(SDL_Storage *storage, cons
 /**
  * Rename a file or directory in a writable storage container.
  *
- * \param storage a storage container
- * \param oldpath the old path
- * \param newpath the new path
+ * \param[inout] storage a storage container
+ * \param[in] oldpath the old path
+ * \param[in] newpath the new path
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -340,9 +340,9 @@ extern SDL_DECLSPEC int SDLCALL SDL_RenameStoragePath(SDL_Storage *storage, cons
 /**
  * Get information about a filesystem path in a storage container.
  *
- * \param storage a storage container
- * \param path the path to query
- * \param info a pointer filled in with information about the path, or NULL to
+ * \param[inout] storage a storage container
+ * \param[in] path the path to query
+ * \param[out,opt] info a pointer filled in with information about the path, or NULL to
  *             check for the existence of a file
  * \returns 0 on success or a negative error code if the file doesn't exist,
  *          or another failure; call SDL_GetError() for more information.
@@ -356,7 +356,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetStoragePathInfo(SDL_Storage *storage, con
 /**
  * Queries the remaining space in a storage container.
  *
- * \param storage a storage container to query
+ * \param[inout] storage a storage container to query
  * \returns the amount of remaining space, in bytes
  *
  * \since This function is available since SDL 3.0.0.
@@ -385,14 +385,14 @@ extern SDL_DECLSPEC Uint64 SDLCALL SDL_GetStorageSpaceRemaining(SDL_Storage *sto
  *
  * You must free the returned pointer with SDL_free() when done with it.
  *
- * \param storage a storage container
- * \param path the path of the directory to enumerate
- * \param pattern the pattern that files in the directory must match. Can be
+ * \param[inout] storage a storage container
+ * \param[in] path the path of the directory to enumerate
+ * \param[in,opt] pattern the pattern that files in the directory must match. Can be
  *                NULL.
  * \param flags `SDL_GLOB_*` bitflags that affect this search.
- * \param count on return, will be set to the number of items in the returned
+ * \param[out,opt] count on return, will be set to the number of items in the returned
  *              array. Can be NULL.
- * \returns an array of strings on success or NULL on failure; call
+ * \returns[own] an array of strings on success or NULL on failure; call
  *          SDL_GetError() for more information. The caller should pass the
  *          returned pointer to SDL_free when done with it.
  *

--- a/include/SDL3/SDL_surface.h
+++ b/include/SDL3/SDL_surface.h
@@ -148,7 +148,7 @@ typedef struct SDL_Surface
  * \param width the width of the surface
  * \param height the height of the surface
  * \param format the SDL_PixelFormatEnum for the new surface's pixel format.
- * \returns the new SDL_Surface structure that is created or NULL if it fails;
+ * \returns[own] the new SDL_Surface structure that is created or NULL if it fails;
  *          call SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -171,12 +171,12 @@ extern SDL_DECLSPEC SDL_Surface *SDLCALL SDL_CreateSurface(int width, int height
  * You may pass NULL for pixels and 0 for pitch to create a surface that you
  * will fill in with valid values later.
  *
- * \param pixels a pointer to existing pixel data
+ * \param[inout] pixels a pointer to existing pixel data
  * \param width the width of the surface
  * \param height the height of the surface
  * \param pitch the number of bytes between each row, including padding
  * \param format the SDL_PixelFormatEnum for the new surface's pixel format.
- * \returns the new SDL_Surface structure that is created or NULL if it fails;
+ * \returns[own] the new SDL_Surface structure that is created or NULL if it fails;
  *          call SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -191,7 +191,7 @@ extern SDL_DECLSPEC SDL_Surface *SDLCALL SDL_CreateSurfaceFrom(void *pixels, int
  *
  * It is safe to pass NULL to this function.
  *
- * \param surface the SDL_Surface to free.
+ * \param[inout] surface the SDL_Surface to free.
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -225,7 +225,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_DestroySurface(SDL_Surface *surface);
  *   where N is a floating point scale factor applied in linear space, and
  *   "none", which disables tone mapping. This defaults to "chrome".
  *
- * \param surface the SDL_Surface structure to query
+ * \param[inout] surface the SDL_Surface structure to query
  * \returns a valid property ID on success or 0 on failure; call
  *          SDL_GetError() for more information.
  *
@@ -247,7 +247,7 @@ extern SDL_DECLSPEC SDL_PropertiesID SDLCALL SDL_GetSurfaceProperties(SDL_Surfac
  * Setting the colorspace doesn't change the pixels, only how they are
  * interpreted in color operations.
  *
- * \param surface the SDL_Surface structure to update
+ * \param[inout] surface the SDL_Surface structure to update
  * \param colorspace an SDL_ColorSpace value describing the surface colorspace
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -263,8 +263,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetSurfaceColorspace(SDL_Surface *surface, S
  * formats, SDL_COLORSPACE_HDR10 for 10-bit formats, SDL_COLORSPACE_SRGB for
  * other RGB surfaces and SDL_COLORSPACE_BT709_FULL for YUV textures.
  *
- * \param surface the SDL_Surface structure to query
- * \param colorspace a pointer filled in with an SDL_ColorSpace value
+ * \param[inout] surface the SDL_Surface structure to query
+ * \param[out] colorspace a pointer filled in with an SDL_ColorSpace value
  *                   describing the surface colorspace
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -278,8 +278,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetSurfaceColorspace(SDL_Surface *surface, S
  *
  * A single palette can be shared with many surfaces.
  *
- * \param surface the SDL_Surface structure to update
- * \param palette the SDL_Palette structure to use
+ * \param[inout] surface the SDL_Surface structure to update
+ * \param[in] palette the SDL_Palette structure to use
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -299,7 +299,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetSurfacePalette(SDL_Surface *surface, SDL_
  * 0, then you can read and write to the surface at any time, and the pixel
  * format of the surface will not change.
  *
- * \param surface the SDL_Surface structure to be locked
+ * \param[inout] surface the SDL_Surface structure to be locked
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -313,7 +313,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_LockSurface(SDL_Surface *surface);
 /**
  * Release a surface after directly accessing the pixels.
  *
- * \param surface the SDL_Surface structure to be unlocked
+ * \param[inout] surface the SDL_Surface structure to be unlocked
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -327,10 +327,10 @@ extern SDL_DECLSPEC void SDLCALL SDL_UnlockSurface(SDL_Surface *surface);
  * The new surface should be freed with SDL_DestroySurface(). Not doing so
  * will result in a memory leak.
  *
- * \param src the data stream for the surface
+ * \param[inout] src the data stream for the surface
  * \param closeio if SDL_TRUE, calls SDL_CloseIO() on `src` before returning,
  *                even in the case of an error
- * \returns a pointer to a new SDL_Surface structure or NULL if there was an
+ * \returns[own] a pointer to a new SDL_Surface structure or NULL if there was an
  *          error; call SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -347,7 +347,7 @@ extern SDL_DECLSPEC SDL_Surface *SDLCALL SDL_LoadBMP_IO(SDL_IOStream *src, SDL_b
  * The new surface should be freed with SDL_DestroySurface(). Not doing so
  * will result in a memory leak.
  *
- * \param file the BMP file to load
+ * \param[in] file the BMP file to load
  * \returns a pointer to a new SDL_Surface structure or NULL if there was an
  *          error; call SDL_GetError() for more information.
  *
@@ -368,8 +368,8 @@ extern SDL_DECLSPEC SDL_Surface *SDLCALL SDL_LoadBMP(const char *file);
  * surface before they are saved. YUV and paletted 1-bit and 4-bit formats are
  * not supported.
  *
- * \param surface the SDL_Surface structure containing the image to be saved
- * \param dst a data stream to save to
+ * \param[inout] surface the SDL_Surface structure containing the image to be saved
+ * \param[out] dst a data stream to save to
  * \param closeio if SDL_TRUE, calls SDL_CloseIO() on `dst` before returning,
  *                even in the case of an error
  * \returns 0 on success or a negative error code on failure; call
@@ -391,8 +391,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_SaveBMP_IO(SDL_Surface *surface, SDL_IOStrea
  * surface before they are saved. YUV and paletted 1-bit and 4-bit formats are
  * not supported.
  *
- * \param surface the SDL_Surface structure containing the image to be saved
- * \param file a file to save to
+ * \param[inout] surface the SDL_Surface structure containing the image to be saved
+ * \param[in] file a file to save to
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -409,7 +409,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SaveBMP(SDL_Surface *surface, const char *fi
  * If RLE is enabled, color key and alpha blending blits are much faster, but
  * the surface must be locked before directly accessing the pixels.
  *
- * \param surface the SDL_Surface structure to optimize
+ * \param[inout] surface the SDL_Surface structure to optimize
  * \param flag 0 to disable, non-zero to enable RLE acceleration
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -427,7 +427,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetSurfaceRLE(SDL_Surface *surface, int flag
  *
  * It is safe to pass a NULL `surface` here; it will return SDL_FALSE.
  *
- * \param surface the SDL_Surface structure to query
+ * \param[inout] surface the SDL_Surface structure to query
  * \returns SDL_TRUE if the surface is RLE enabled, SDL_FALSE otherwise.
  *
  * \since This function is available since SDL 3.0.0.
@@ -449,7 +449,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_SurfaceHasRLE(SDL_Surface *surface);
  * RLE acceleration can substantially speed up blitting of images with large
  * horizontal runs of transparent pixels. See SDL_SetSurfaceRLE() for details.
  *
- * \param surface the SDL_Surface structure to update
+ * \param[inout] surface the SDL_Surface structure to update
  * \param flag SDL_TRUE to enable color key, SDL_FALSE to disable color key
  * \param key the transparent pixel
  * \returns 0 on success or a negative error code on failure; call
@@ -467,7 +467,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetSurfaceColorKey(SDL_Surface *surface, int
  *
  * It is safe to pass a NULL `surface` here; it will return SDL_FALSE.
  *
- * \param surface the SDL_Surface structure to query
+ * \param[inout] surface the SDL_Surface structure to query
  * \returns SDL_TRUE if the surface has a color key, SDL_FALSE otherwise.
  *
  * \since This function is available since SDL 3.0.0.
@@ -485,8 +485,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_SurfaceHasColorKey(SDL_Surface *surface
  *
  * If the surface doesn't have color key enabled this function returns -1.
  *
- * \param surface the SDL_Surface structure to query
- * \param key a pointer filled in with the transparent pixel
+ * \param[inout] surface the SDL_Surface structure to query
+ * \param[out] key a pointer filled in with the transparent pixel
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -506,7 +506,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetSurfaceColorKey(SDL_Surface *surface, Uin
  *
  * `srcC = srcC * (color / 255)`
  *
- * \param surface the SDL_Surface structure to update
+ * \param[inout] surface the SDL_Surface structure to update
  * \param r the red color value multiplied into blit operations
  * \param g the green color value multiplied into blit operations
  * \param b the blue color value multiplied into blit operations
@@ -524,10 +524,10 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetSurfaceColorMod(SDL_Surface *surface, Uin
 /**
  * Get the additional color value multiplied into blit operations.
  *
- * \param surface the SDL_Surface structure to query
- * \param r a pointer filled in with the current red color value
- * \param g a pointer filled in with the current green color value
- * \param b a pointer filled in with the current blue color value
+ * \param[inout] surface the SDL_Surface structure to query
+ * \param[out,opt] r a pointer filled in with the current red color value
+ * \param[out,opt] g a pointer filled in with the current green color value
+ * \param[out,opt] b a pointer filled in with the current blue color value
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -546,7 +546,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetSurfaceColorMod(SDL_Surface *surface, Uin
  *
  * `srcA = srcA * (alpha / 255)`
  *
- * \param surface the SDL_Surface structure to update
+ * \param[inout] surface the SDL_Surface structure to update
  * \param alpha the alpha value multiplied into blit operations
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -561,8 +561,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetSurfaceAlphaMod(SDL_Surface *surface, Uin
 /**
  * Get the additional alpha value used in blit operations.
  *
- * \param surface the SDL_Surface structure to query
- * \param alpha a pointer filled in with the current alpha value
+ * \param[inout] surface the SDL_Surface structure to query
+ * \param[out,opt] alpha a pointer filled in with the current alpha value
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -580,7 +580,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetSurfaceAlphaMod(SDL_Surface *surface, Uin
  * existing data, the blendmode of the SOURCE surface should be set to
  * `SDL_BLENDMODE_NONE`.
  *
- * \param surface the SDL_Surface structure to update
+ * \param[inout] surface the SDL_Surface structure to update
  * \param blendMode the SDL_BlendMode to use for blit blending
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -594,8 +594,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetSurfaceBlendMode(SDL_Surface *surface, SD
 /**
  * Get the blend mode used for blit operations.
  *
- * \param surface the SDL_Surface structure to query
- * \param blendMode a pointer filled in with the current SDL_BlendMode
+ * \param[inout] surface the SDL_Surface structure to query
+ * \param[out,opt] blendMode a pointer filled in with the current SDL_BlendMode
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -614,8 +614,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetSurfaceBlendMode(SDL_Surface *surface, SD
  * Note that blits are automatically clipped to the edges of the source and
  * destination surfaces.
  *
- * \param surface the SDL_Surface structure to be clipped
- * \param rect the SDL_Rect structure representing the clipping rectangle, or
+ * \param[inout] surface the SDL_Surface structure to be clipped
+ * \param[in,opt] rect the SDL_Rect structure representing the clipping rectangle, or
  *             NULL to disable clipping
  * \returns SDL_TRUE if the rectangle intersects the surface, otherwise
  *          SDL_FALSE and blits will be completely clipped.
@@ -632,9 +632,9 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_SetSurfaceClipRect(SDL_Surface *surface
  * When `surface` is the destination of a blit, only the area within the clip
  * rectangle is drawn into.
  *
- * \param surface the SDL_Surface structure representing the surface to be
+ * \param[inout] surface the SDL_Surface structure representing the surface to be
  *                clipped
- * \param rect an SDL_Rect structure filled in with the clipping rectangle for
+ * \param[out,opt] rect an SDL_Rect structure filled in with the clipping rectangle for
  *             the surface
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -648,7 +648,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetSurfaceClipRect(SDL_Surface *surface, SDL
 /**
  * Flip a surface vertically or horizontally.
  *
- * \param surface the surface to flip
+ * \param[inout] surface the surface to flip
  * \param flip the direction to flip
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -662,8 +662,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_FlipSurface(SDL_Surface *surface, SDL_FlipMo
  *
  * The returned surface should be freed with SDL_DestroySurface().
  *
- * \param surface the surface to duplicate.
- * \returns a copy of the surface, or NULL on failure; call SDL_GetError() for
+ * \param[inout] surface the surface to duplicate.
+ * \returns[own] a copy of the surface, or NULL on failure; call SDL_GetError() for
  *          more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -680,10 +680,10 @@ extern SDL_DECLSPEC SDL_Surface *SDLCALL SDL_DuplicateSurface(SDL_Surface *surfa
  * surface. The new, optimized surface can then be used as the source for
  * future blits, making them faster.
  *
- * \param surface the existing SDL_Surface structure to convert
- * \param format the SDL_PixelFormat structure that the new surface is
+ * \param[inout] surface the existing SDL_Surface structure to convert
+ * \param[in] format the SDL_PixelFormat structure that the new surface is
  *               optimized for
- * \returns the new SDL_Surface structure that is created or NULL if it fails;
+ * \returns[own] the new SDL_Surface structure that is created or NULL if it fails;
  *          call SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -703,9 +703,9 @@ extern SDL_DECLSPEC SDL_Surface *SDLCALL SDL_ConvertSurface(SDL_Surface *surface
  * it might be easier to call but it doesn't have access to palette
  * information for the destination surface, in case that would be important.
  *
- * \param surface the existing SDL_Surface structure to convert
+ * \param[inout] surface the existing SDL_Surface structure to convert
  * \param pixel_format the new pixel format
- * \returns the new SDL_Surface structure that is created or NULL if it fails;
+ * \returns[own] the new SDL_Surface structure that is created or NULL if it fails;
  *          call SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -724,11 +724,11 @@ extern SDL_DECLSPEC SDL_Surface *SDLCALL SDL_ConvertSurfaceFormat(SDL_Surface *s
  * and returns the new surface. This will perform any pixel format and
  * colorspace conversion needed.
  *
- * \param surface the existing SDL_Surface structure to convert
+ * \param[inout] surface the existing SDL_Surface structure to convert
  * \param pixel_format the new pixel format
  * \param colorspace the new colorspace
  * \param props an SDL_PropertiesID with additional color properties, or 0
- * \returns the new SDL_Surface structure that is created or NULL if it fails;
+ * \returns[own] the new SDL_Surface structure that is created or NULL if it fails;
  *          call SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -745,10 +745,10 @@ extern SDL_DECLSPEC SDL_Surface *SDLCALL SDL_ConvertSurfaceFormatAndColorspace(S
  * \param width the width of the block to copy, in pixels
  * \param height the height of the block to copy, in pixels
  * \param src_format an SDL_PixelFormatEnum value of the `src` pixels format
- * \param src a pointer to the source pixels
+ * \param[in] src a pointer to the source pixels
  * \param src_pitch the pitch of the source pixels, in bytes
  * \param dst_format an SDL_PixelFormatEnum value of the `dst` pixels format
- * \param dst a pointer to be filled in with new pixel data
+ * \param[out] dst a pointer to be filled in with new pixel data
  * \param dst_pitch the pitch of the destination pixels, in bytes
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -770,14 +770,14 @@ extern SDL_DECLSPEC int SDLCALL SDL_ConvertPixels(int width, int height, SDL_Pix
  *                       the `src` pixels
  * \param src_properties an SDL_PropertiesID with additional source color
  *                       properties, or 0
- * \param src a pointer to the source pixels
+ * \param[in] src a pointer to the source pixels
  * \param src_pitch the pitch of the source pixels, in bytes
  * \param dst_format an SDL_PixelFormatEnum value of the `dst` pixels format
  * \param dst_colorspace an SDL_ColorSpace value describing the colorspace of
  *                       the `dst` pixels
  * \param dst_properties an SDL_PropertiesID with additional destination color
  *                       properties, or 0
- * \param dst a pointer to be filled in with new pixel data
+ * \param[out] dst a pointer to be filled in with new pixel data
  * \param dst_pitch the pitch of the destination pixels, in bytes
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -798,10 +798,10 @@ extern SDL_DECLSPEC int SDLCALL SDL_ConvertPixelsAndColorspace(int width, int he
  * \param width the width of the block to convert, in pixels
  * \param height the height of the block to convert, in pixels
  * \param src_format an SDL_PixelFormatEnum value of the `src` pixels format
- * \param src a pointer to the source pixels
+ * \param[in] src a pointer to the source pixels
  * \param src_pitch the pitch of the source pixels, in bytes
  * \param dst_format an SDL_PixelFormatEnum value of the `dst` pixels format
- * \param dst a pointer to be filled in with premultiplied pixel data
+ * \param[out] dst a pointer to be filled in with premultiplied pixel data
  * \param dst_pitch the pitch of the destination pixels, in bytes
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -822,8 +822,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_PremultiplyAlpha(int width, int height, SDL_
  * SDL_SetSurfaceClipRect()), then this function will fill based on the
  * intersection of the clip rectangle and `rect`.
  *
- * \param dst the SDL_Surface structure that is the drawing target
- * \param rect the SDL_Rect structure representing the rectangle to fill, or
+ * \param[inout] dst the SDL_Surface structure that is the drawing target
+ * \param[in,opt] rect the SDL_Rect structure representing the rectangle to fill, or
  *             NULL to fill the entire surface
  * \param color the color to fill with
  * \returns 0 on success or a negative error code on failure; call
@@ -847,8 +847,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_FillSurfaceRect(SDL_Surface *dst, const SDL_
  * SDL_SetSurfaceClipRect()), then this function will fill based on the
  * intersection of the clip rectangle and `rect`.
  *
- * \param dst the SDL_Surface structure that is the drawing target
- * \param rects an array of SDL_Rects representing the rectangles to fill.
+ * \param[inout] dst the SDL_Surface structure that is the drawing target
+ * \param[in] rects an array of SDL_Rects representing the rectangles to fill.
  * \param count the number of rectangles in the array
  * \param color the color to fill with
  * \returns 0 on success or a negative error code on failure; call
@@ -913,11 +913,11 @@ extern SDL_DECLSPEC int SDLCALL SDL_FillSurfaceRects(SDL_Surface *dst, const SDL
  *       source color key.
  * ```
  *
- * \param src the SDL_Surface structure to be copied from
- * \param srcrect the SDL_Rect structure representing the rectangle to be
+ * \param[inout] src the SDL_Surface structure to be copied from
+ * \param[in,opt] srcrect the SDL_Rect structure representing the rectangle to be
  *                copied, or NULL to copy the entire surface
- * \param dst the SDL_Surface structure that is the blit target
- * \param dstrect the SDL_Rect structure representing the x and y position in
+ * \param[inout] dst the SDL_Surface structure that is the blit target
+ * \param[out,opt] dstrect the SDL_Rect structure representing the x and y position in
  *                the destination surface. On input the width and height are
  *                ignored (taken from srcrect), and on output this is filled
  *                in with the actual rectangle used after clipping.
@@ -940,11 +940,11 @@ extern SDL_DECLSPEC int SDLCALL SDL_BlitSurface(SDL_Surface *src, const SDL_Rect
  * This is a semi-private blit function and it performs low-level surface
  * blitting, assuming the input rectangles have already been clipped.
  *
- * \param src the SDL_Surface structure to be copied from
- * \param srcrect the SDL_Rect structure representing the rectangle to be
+ * \param[inout] src the SDL_Surface structure to be copied from
+ * \param[in,opt] srcrect the SDL_Rect structure representing the rectangle to be
  *                copied, or NULL to copy the entire surface
- * \param dst the SDL_Surface structure that is the blit target
- * \param dstrect the SDL_Rect structure representing the target rectangle in
+ * \param[inout] dst the SDL_Surface structure that is the blit target
+ * \param[out,opt] dstrect the SDL_Rect structure representing the target rectangle in
  *                the destination surface
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -965,11 +965,11 @@ extern SDL_DECLSPEC int SDLCALL SDL_BlitSurfaceUnchecked(SDL_Surface *src, const
  * Using SDL_SCALEMODE_NEAREST: fast, low quality. Using SDL_SCALEMODE_LINEAR:
  * bilinear scaling, slower, better quality, only 32BPP.
  *
- * \param src the SDL_Surface structure to be copied from
- * \param srcrect the SDL_Rect structure representing the rectangle to be
+ * \param[inout] src the SDL_Surface structure to be copied from
+ * \param[in,opt] srcrect the SDL_Rect structure representing the rectangle to be
  *                copied
- * \param dst the SDL_Surface structure that is the blit target
- * \param dstrect the SDL_Rect structure representing the target rectangle in
+ * \param[inout] dst the SDL_Surface structure that is the blit target
+ * \param[in,opt] dstrect the SDL_Rect structure representing the target rectangle in
  *                the destination surface
  * \param scaleMode scale algorithm to be used
  * \returns 0 on success or a negative error code on failure; call
@@ -985,11 +985,11 @@ extern SDL_DECLSPEC int SDLCALL SDL_SoftStretch(SDL_Surface *src, const SDL_Rect
  * Perform a scaled blit to a destination surface, which may be of a different
  * format.
  *
- * \param src the SDL_Surface structure to be copied from
- * \param srcrect the SDL_Rect structure representing the rectangle to be
+ * \param[inout] src the SDL_Surface structure to be copied from
+ * \param[in,opt] srcrect the SDL_Rect structure representing the rectangle to be
  *                copied
- * \param dst the SDL_Surface structure that is the blit target
- * \param dstrect the SDL_Rect structure representing the target rectangle in
+ * \param[inout] dst the SDL_Surface structure that is the blit target
+ * \param[in,opt] dstrect the SDL_Rect structure representing the target rectangle in
  *                the destination surface, filled with the actual rectangle
  *                used after clipping
  * \param scaleMode the SDL_ScaleMode to be used
@@ -1012,11 +1012,11 @@ extern SDL_DECLSPEC int SDLCALL SDL_BlitSurfaceScaled(SDL_Surface *src, const SD
  * This is a semi-private function and it performs low-level surface blitting,
  * assuming the input rectangles have already been clipped.
  *
- * \param src the SDL_Surface structure to be copied from
- * \param srcrect the SDL_Rect structure representing the rectangle to be
+ * \param[inout] src the SDL_Surface structure to be copied from
+ * \param[in,opt] srcrect the SDL_Rect structure representing the rectangle to be
  *                copied
- * \param dst the SDL_Surface structure that is the blit target
- * \param dstrect the SDL_Rect structure representing the target rectangle in
+ * \param[inout] dst the SDL_Surface structure that is the blit target
+ * \param[in,opt] dstrect the SDL_Rect structure representing the target rectangle in
  *                the destination surface
  * \param scaleMode scale algorithm to be used
  * \returns 0 on success or a negative error code on failure; call
@@ -1041,16 +1041,16 @@ extern SDL_DECLSPEC int SDLCALL SDL_BlitSurfaceUncheckedScaled(SDL_Surface *src,
  * Like SDL_GetRGBA, this uses the entire 0..255 range when converting color
  * components from pixel formats with less than 8 bits per RGB component.
  *
- * \param surface the surface to read
+ * \param[inout] surface the surface to read
  * \param x the horizontal coordinate, 0 <= x < width
  * \param y the vertical coordinate, 0 <= y < height
- * \param r a pointer filled in with the red channel, 0-255, or NULL to ignore
+ * \param[out,opt] r a pointer filled in with the red channel, 0-255, or NULL to ignore
  *          this channel
- * \param g a pointer filled in with the green channel, 0-255, or NULL to
+ * \param[out,opt] g a pointer filled in with the green channel, 0-255, or NULL to
  *          ignore this channel
- * \param b a pointer filled in with the blue channel, 0-255, or NULL to
+ * \param[out,opt] b a pointer filled in with the blue channel, 0-255, or NULL to
  *          ignore this channel
- * \param a a pointer filled in with the alpha channel, 0-255, or NULL to
+ * \param[out,opt] a a pointer filled in with the alpha channel, 0-255, or NULL to
  *          ignore this channel
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.

--- a/include/SDL3/SDL_system.h
+++ b/include/SDL3/SDL_system.h
@@ -80,8 +80,8 @@ typedef SDL_bool (SDLCALL *SDL_WindowsMessageHook)(void *userdata, MSG *msg);
  * message should continue to be processed, or SDL_FALSE to prevent further
  * processing.
  *
- * \param callback The SDL_WindowsMessageHook function to call.
- * \param userdata a pointer to pass to every iteration of `callback`
+ * \param[in] callback The SDL_WindowsMessageHook function to call.
+ * \param[inout,opt] userdata a pointer to pass to every iteration of `callback`
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -120,8 +120,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_Direct3D9GetAdapterIndex(SDL_DisplayID displ
  * DX11 device and swap chain.
  *
  * \param displayID the instance of the display to query
- * \param adapterIndex a pointer to be filled in with the adapter index
- * \param outputIndex a pointer to be filled in with the output index
+ * \param[out] adapterIndex a pointer to be filled in with the adapter index
+ * \param[out] outputIndex a pointer to be filled in with the output index
  * \returns SDL_TRUE on success or SDL_FALSE on failure; call SDL_GetError()
  *          for more information.
  *
@@ -145,8 +145,8 @@ typedef SDL_bool (SDLCALL *SDL_X11EventHook)(void *userdata, XEvent *xevent);
  * should continue to be processed, or SDL_FALSE to prevent further
  * processing.
  *
- * \param callback The SDL_X11EventHook function to call.
- * \param userdata a pointer to pass to every iteration of `callback`
+ * \param[in] callback The SDL_X11EventHook function to call.
+ * \param[inout,opt] userdata a pointer to pass to every iteration of `callback`
  *
  * \since This function is available since SDL 3.0.0.
  */
@@ -216,11 +216,11 @@ extern SDL_DECLSPEC int SDLCALL SDL_LinuxSetThreadPriorityAndPolicy(Sint64 threa
  *
  * https://wiki.libsdl.org/SDL3/README/main-functions
  *
- * \param window the window for which the animation callback should be set
+ * \param[inout] window the window for which the animation callback should be set
  * \param interval the number of frames after which **callback** will be
  *                 called
- * \param callback the function to call for every frame.
- * \param callbackParam a pointer that is passed to `callback`.
+ * \param[in] callback the function to call for every frame.
+ * \param[inout,opt] callbackParam a pointer that is passed to `callback`.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -402,7 +402,7 @@ extern SDL_DECLSPEC const char * SDLCALL SDL_AndroidGetInternalStoragePath(void)
  *
  * If external storage is currently unavailable, this will return 0.
  *
- * \param state filled with the current state of external storage. 0 if
+ * \param[out] state filled with the current state of external storage. 0 if
  *              external storage is currently unavailable.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -453,9 +453,9 @@ typedef void (SDLCALL *SDL_AndroidRequestPermissionCallback)(void *userdata, con
  * like memory running out. Normally there will be a yes or no to the request
  * through the callback.
  *
- * \param permission The permission to request.
- * \param cb The callback to trigger when the request has a response.
- * \param userdata An app-controlled pointer that is passed to the callback.
+ * \param[in] permission The permission to request.
+ * \param[in] cb The callback to trigger when the request has a response.
+ * \param[inout,opt] userdata An app-controlled pointer that is passed to the callback.
  * \returns zero if the request was submitted, -1 if there was an error
  *          submitting. The result of the request is only ever reported
  *          through the callback, not this return value.
@@ -480,7 +480,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_AndroidRequestPermission(const char *permiss
  *
  * https://developer.android.com/reference/android/view/Gravity
  *
- * \param message text message to be shown
+ * \param[in] message text message to be shown
  * \param duration 0=short, 1=long
  * \param gravity where the notification should appear on the screen.
  * \param xoffset set this parameter only when gravity >=0
@@ -746,7 +746,7 @@ typedef struct XUser *XUserHandle;
  * XTaskQueueCloseHandle to reduce the reference count to avoid a resource
  * leak.
  *
- * \param outTaskQueue a pointer to be filled in with task queue handle.
+ * \param[out] outTaskQueue a pointer to be filled in with task queue handle.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -760,7 +760,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GDKGetTaskQueue(XTaskQueueHandle * outTaskQu
  * This is effectively a synchronous version of XUserAddAsync, which always
  * prefers the default user and allows a sign-in UI.
  *
- * \param outUserHandle a pointer to be filled in with the default user
+ * \param[out] outUserHandle a pointer to be filled in with the default user
  *                      handle.
  * \returns 0 if success, -1 if any error occurs.
  *

--- a/include/SDL3/SDL_thread.h
+++ b/include/SDL3/SDL_thread.h
@@ -292,12 +292,12 @@ extern SDL_DECLSPEC SDL_Thread * SDLCALL SDL_CreateThreadWithProperties(SDL_Prop
 /**
  * The actual entry point for SDL_CreateThread.
  *
- * \param fn the SDL_ThreadFunction function to call in the new thread
- * \param name the name of the thread
- * \param data a pointer that is passed to `fn`
- * \param pfnBeginThread the C runtime's _beginthreadex (or whatnot). Can be NULL.
- * \param pfnEndThread the C runtime's _endthreadex (or whatnot). Can be NULL.
- * \returns an opaque pointer to the new thread object on success, NULL if the
+ * \param[in] fn the SDL_ThreadFunction function to call in the new thread
+ * \param[in] name the name of the thread
+ * \param[inout,opt] data a pointer that is passed to `fn`
+ * \param[in,opt] pfnBeginThread the C runtime's _beginthreadex (or whatnot). Can be NULL.
+ * \param[in,opt] pfnEndThread the C runtime's _endthreadex (or whatnot). Can be NULL.
+ * \returns[own] an opaque pointer to the new thread object on success, NULL if the
  *          new thread could not be created; call SDL_GetError() for more
  *          information.
  *
@@ -309,8 +309,8 @@ extern SDL_DECLSPEC SDL_Thread *SDLCALL SDL_CreateThreadRuntime(SDL_ThreadFuncti
  * The actual entry point for SDL_CreateThreadWithProperties.
  *
  * \param props the properties to use
- * \param pfnBeginThread the C runtime's _beginthreadex (or whatnot). Can be NULL.
- * \param pfnEndThread the C runtime's _endthreadex (or whatnot). Can be NULL.
+ * \param[in,opt] pfnBeginThread the C runtime's _beginthreadex (or whatnot). Can be NULL.
+ * \param[in,opt] pfnEndThread the C runtime's _endthreadex (or whatnot). Can be NULL.
  * \returns an opaque pointer to the new thread object on success, NULL if the
  *          new thread could not be created; call SDL_GetError() for more
  *          information.
@@ -334,7 +334,7 @@ extern SDL_DECLSPEC SDL_Thread *SDLCALL SDL_CreateThreadWithPropertiesRuntime(SD
  * This is internal memory, not to be freed by the caller, and remains valid
  * until the specified thread is cleaned up by SDL_WaitThread().
  *
- * \param thread the thread to query
+ * \param[inout] thread the thread to query
  * \returns a pointer to a UTF-8 string that names the specified thread, or
  *          NULL if it doesn't have a name.
  *
@@ -367,7 +367,7 @@ extern SDL_DECLSPEC SDL_ThreadID SDLCALL SDL_GetCurrentThreadID(void);
  * If SDL is running on a platform that does not support threads the return
  * value will always be zero.
  *
- * \param thread the thread to query
+ * \param[inout] thread the thread to query
  * \returns the ID of the specified thread, or the ID of the current thread if
  *          `thread` is NULL.
  *
@@ -414,9 +414,9 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetThreadPriority(SDL_ThreadPriority priorit
  * Note that the thread pointer is freed by this function and is not valid
  * afterward.
  *
- * \param thread the SDL_Thread pointer that was returned from the
+ * \param[inout] thread the SDL_Thread pointer that was returned from the
  *               SDL_CreateThread() call that started this thread
- * \param status pointer to an integer that will receive the value returned
+ * \param[out,opt] status pointer to an integer that will receive the value returned
  *               from the thread function by its 'return', or NULL to not
  *               receive such value back.
  *
@@ -453,7 +453,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_WaitThread(SDL_Thread * thread, int *status
  *
  * It is safe to pass NULL to this function; it is a no-op.
  *
- * \param thread the SDL_Thread pointer that was returned from the
+ * \param[inout] thread the SDL_Thread pointer that was returned from the
  *               SDL_CreateThread() call that started this thread
  *
  * \since This function is available since SDL 3.0.0.
@@ -503,8 +503,8 @@ extern SDL_DECLSPEC void * SDLCALL SDL_GetTLS(SDL_TLSID id);
  * where its parameter `value` is what was passed as `value` to SDL_SetTLS().
  *
  * \param id the thread local storage ID
- * \param value the value to associate with the ID for the current thread
- * \param destructor a function called when the thread exits, to free the
+ * \param[in] value the value to associate with the ID for the current thread
+ * \param[in] destructor a function called when the thread exits, to free the
  *                   value
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.

--- a/include/SDL3/SDL_time.h
+++ b/include/SDL3/SDL_time.h
@@ -91,9 +91,9 @@ typedef enum SDL_TimeFormat
  * formats can change, usually because the user has changed a system
  * preference outside of your program.
  *
- * \param dateFormat a pointer to the SDL_DateFormat to hold the returned date
+ * \param[out,opt] dateFormat a pointer to the SDL_DateFormat to hold the returned date
  *                   format, may be NULL
- * \param timeFormat a pointer to the SDL_TimeFormat to hold the returned time
+ * \param[out,opt] timeFormat a pointer to the SDL_TimeFormat to hold the returned time
  *                   format, may be NULL
  * \returns 0 on success or -1 on error; call SDL_GetError() for more
  *          information.
@@ -106,7 +106,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetDateTimeLocalePreferences(SDL_DateFormat 
  * Gets the current value of the system realtime clock in nanoseconds since
  * Jan 1, 1970 in Universal Coordinated Time (UTC).
  *
- * \param ticks the SDL_Time to hold the returned tick count
+ * \param[out,opt] ticks the SDL_Time to hold the returned tick count
  * \returns 0 on success or -1 on error; call SDL_GetError() for more
  *          information.
  *
@@ -119,7 +119,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetCurrentTime(SDL_Time *ticks);
  * the SDL_DateTime format.
  *
  * \param ticks the SDL_Time to be converted
- * \param dt the resulting SDL_DateTime
+ * \param[out] dt the resulting SDL_DateTime
  * \param localTime the resulting SDL_DateTime will be expressed in local time
  *                  if true, otherwise it will be in Universal Coordinated
  *                  Time (UTC)
@@ -136,8 +136,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_TimeToDateTime(SDL_Time ticks, SDL_DateTime 
  * This function ignores the day_of_week member of the SDL_DateTime struct, so
  * it may remain unset.
  *
- * \param dt the source SDL_DateTime
- * \param ticks the resulting SDL_Time
+ * \param[in] dt the source SDL_DateTime
+ * \param[out] ticks the resulting SDL_Time
  * \returns 0 on success or -1 on error; call SDL_GetError() for more
  *          information.
  *
@@ -152,9 +152,9 @@ extern SDL_DECLSPEC int SDLCALL SDL_DateTimeToTime(const SDL_DateTime *dt, SDL_T
  * This function fills in the two 32-bit values of the FILETIME structure.
  *
  * \param ticks the time to convert
- * \param dwLowDateTime a pointer filled in with the low portion of the
+ * \param[out,opt] dwLowDateTime a pointer filled in with the low portion of the
  *                      Windows FILETIME value
- * \param dwHighDateTime a pointer filled in with the high portion of the
+ * \param[out,opt] dwHighDateTime a pointer filled in with the high portion of the
  *                       Windows FILETIME value
  *
  * \since This function is available since SDL 3.0.0.

--- a/include/SDL3/SDL_timer.h
+++ b/include/SDL3/SDL_timer.h
@@ -177,9 +177,9 @@ typedef Uint32 SDL_TimerID;
  * callback needs to adjust for variances.
  *
  * \param interval the timer delay, in milliseconds, passed to `callback`
- * \param callback the SDL_TimerCallback function to call when the specified
+ * \param[in] callback the SDL_TimerCallback function to call when the specified
  *                 `interval` elapses
- * \param param a pointer that is passed to `callback`
+ * \param[inout,opt] param a pointer that is passed to `callback`
  * \returns a timer ID or 0 if an error occurs; call SDL_GetError() for more
  *          information.
  *

--- a/include/SDL3/SDL_touch.h
+++ b/include/SDL3/SDL_touch.h
@@ -83,9 +83,9 @@ typedef struct SDL_Finger
  * Therefore the returned list might be empty, although devices are available.
  * After using all devices at least once the number will be correct.
  *
- * \param count a pointer filled in with the number of devices returned, can
+ * \param[out,opt] count a pointer filled in with the number of devices returned, can
  *              be NULL.
- * \returns a 0 terminated array of touch device IDs which should be freed
+ * \returns[own] a 0 terminated array of touch device IDs which should be freed
  *          with SDL_free(), or NULL on error; call SDL_GetError() for more
  *          details.
  *
@@ -120,9 +120,9 @@ extern SDL_DECLSPEC SDL_TouchDeviceType SDLCALL SDL_GetTouchDeviceType(SDL_Touch
  * Get a list of active fingers for a given touch device.
  *
  * \param touchID the ID of a touch device
- * \param count a pointer filled in with the number of fingers returned, can
+ * \param[out,opt] count a pointer filled in with the number of fingers returned, can
  *              be NULL.
- * \returns a NULL terminated array of SDL_Finger pointers which should be
+ * \returns[own] a NULL terminated array of SDL_Finger pointers which should be
  *          freed with SDL_free(), or NULL on error; call SDL_GetError() for
  *          more details.
  *

--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -372,8 +372,8 @@ extern SDL_DECLSPEC SDL_SystemTheme SDLCALL SDL_GetSystemTheme(void);
 /**
  * Get a list of currently connected displays.
  *
- * \param count a pointer filled in with the number of displays returned
- * \returns a 0 terminated array of display instance IDs which should be freed
+ * \param[out,opt] count a pointer filled in with the number of displays returned
+ * \returns[own] a 0 terminated array of display instance IDs which should be freed
  *          with SDL_free(), or NULL on error; call SDL_GetError() for more
  *          details.
  *
@@ -454,7 +454,7 @@ extern SDL_DECLSPEC const char *SDLCALL SDL_GetDisplayName(SDL_DisplayID display
  * The primary display is always located at (0,0).
  *
  * \param displayID the instance ID of the display to query
- * \param rect the SDL_Rect structure filled in with the display bounds
+ * \param[out] rect the SDL_Rect structure filled in with the display bounds
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -478,7 +478,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetDisplayBounds(SDL_DisplayID displayID, SD
  * non-fullscreen window.
  *
  * \param displayID the instance ID of the display to query
- * \param rect the SDL_Rect structure filled in with the display bounds
+ * \param[out] rect the SDL_Rect structure filled in with the display bounds
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -546,8 +546,8 @@ extern SDL_DECLSPEC float SDLCALL SDL_GetDisplayContentScale(SDL_DisplayID displ
  * - pixel density -> lowest to highest
  *
  * \param displayID the instance ID of the display to query
- * \param count a pointer filled in with the number of display modes returned
- * \returns a NULL terminated array of display mode pointers which should be
+ * \param[out,opt] count a pointer filled in with the number of display modes returned
+ * \returns[own] a NULL terminated array of display mode pointers which should be
  *          freed with SDL_free(), or NULL on error; call SDL_GetError() for
  *          more details.
  *
@@ -626,7 +626,7 @@ extern SDL_DECLSPEC const SDL_DisplayMode *SDLCALL SDL_GetCurrentDisplayMode(SDL
 /**
  * Get the display containing a point.
  *
- * \param point the point to query
+ * \param[in] point the point to query
  * \returns the instance ID of the display containing the point or 0 on
  *          failure; call SDL_GetError() for more information.
  *
@@ -640,7 +640,7 @@ extern SDL_DECLSPEC SDL_DisplayID SDLCALL SDL_GetDisplayForPoint(const SDL_Point
 /**
  * Get the display primarily containing a rect.
  *
- * \param rect the rect to query
+ * \param[in] rect the rect to query
  * \returns the instance ID of the display entirely containing the rect or
  *          closest to the center of the rect on success or 0 on failure; call
  *          SDL_GetError() for more information.
@@ -655,7 +655,7 @@ extern SDL_DECLSPEC SDL_DisplayID SDLCALL SDL_GetDisplayForRect(const SDL_Rect *
 /**
  * Get the display associated with a window.
  *
- * \param window the window to query
+ * \param[inout] window the window to query
  * \returns the instance ID of the display containing the center of the window
  *          on success or 0 on failure; call SDL_GetError() for more
  *          information.
@@ -674,7 +674,7 @@ extern SDL_DECLSPEC SDL_DisplayID SDLCALL SDL_GetDisplayForWindow(SDL_Window *wi
  * 1920x1080 and it has a high density back buffer of 3840x2160 pixels, it
  * would have a pixel density of 2.0.
  *
- * \param window the window to query
+ * \param[inout] window the window to query
  * \returns the pixel density or 0.0f on failure; call SDL_GetError() for more
  *          information.
  *
@@ -698,7 +698,7 @@ extern SDL_DECLSPEC float SDLCALL SDL_GetWindowPixelDensity(SDL_Window *window);
  * updated when that setting is changed, or the window moves to a display with
  * a different scale setting.
  *
- * \param window the window to query
+ * \param[inout] window the window to query
  * \returns the display scale, or 0.0f on failure; call SDL_GetError() for
  *          more information.
  *
@@ -723,8 +723,8 @@ extern SDL_DECLSPEC float SDLCALL SDL_GetWindowDisplayScale(SDL_Window *window);
  * SDL_EVENT_WINDOOW_PIXEL_SIZE_CHANGED event will be emitted with the new
  * mode dimensions.
  *
- * \param window the window to affect
- * \param mode a pointer to the display mode to use, which can be NULL for
+ * \param[inout] window the window to affect
+ * \param[in,opt] mode a pointer to the display mode to use, which can be NULL for
  *             borderless fullscreen desktop mode, or one of the fullscreen
  *             modes returned by SDL_GetFullscreenDisplayModes() to set an
  *             exclusive fullscreen mode.
@@ -742,7 +742,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowFullscreenMode(SDL_Window *window, 
 /**
  * Query the display mode to use when a window is visible at fullscreen.
  *
- * \param window the window to query
+ * \param[inout] window the window to query
  * \returns a pointer to the exclusive fullscreen mode to use or NULL for
  *          borderless fullscreen desktop mode
  *
@@ -758,8 +758,8 @@ extern SDL_DECLSPEC const SDL_DisplayMode *SDLCALL SDL_GetWindowFullscreenMode(S
  *
  * Data returned should be freed with SDL_free.
  *
- * \param window the window to query
- * \param size the size of the ICC profile
+ * \param[inout] window the window to query
+ * \param[out] size the size of the ICC profile
  * \returns the raw ICC profile data on success or NULL on failure; call
  *          SDL_GetError() for more information.
  *
@@ -770,7 +770,7 @@ extern SDL_DECLSPEC void *SDLCALL SDL_GetWindowICCProfile(SDL_Window *window, si
 /**
  * Get the pixel format associated with the window.
  *
- * \param window the window to query
+ * \param[inout] window the window to query
  * \returns the pixel format of the window on success or
  *          SDL_PIXELFORMAT_UNKNOWN on failure; call SDL_GetError() for more
  *          information.
@@ -827,11 +827,11 @@ extern SDL_DECLSPEC Uint32 SDLCALL SDL_GetWindowPixelFormat(SDL_Window *window);
  * loader or link to a dynamic library version. This limitation may be removed
  * in a future version of SDL.
  *
- * \param title the title of the window, in UTF-8 encoding
+ * \param[in] title the title of the window, in UTF-8 encoding
  * \param w the width of the window
  * \param h the height of the window
  * \param flags 0, or one or more SDL_WindowFlags OR'd together
- * \returns the window that was created or NULL on failure; call
+ * \returns[own] the window that was created or NULL on failure; call
  *          SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -876,7 +876,7 @@ extern SDL_DECLSPEC SDL_Window *SDLCALL SDL_CreateWindow(const char *title, int 
  * If the parent window is destroyed, any child popup windows will be
  * recursively destroyed as well.
  *
- * \param parent the parent of the window, must not be NULL
+ * \param[inout] parent the parent of the window, must not be NULL
  * \param offset_x the x position of the popup window relative to the origin
  *                 of the parent
  * \param offset_y the y position of the popup window relative to the origin
@@ -885,7 +885,7 @@ extern SDL_DECLSPEC SDL_Window *SDLCALL SDL_CreateWindow(const char *title, int 
  * \param h the height of the window
  * \param flags SDL_WINDOW_TOOLTIP or SDL_WINDOW_POPUP_MENU, and zero or more
  *              additional SDL_WindowFlags OR'd together.
- * \returns the window that was created or NULL on failure; call
+ * \returns[own] the window that was created or NULL on failure; call
  *          SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1002,7 +1002,7 @@ extern SDL_DECLSPEC SDL_Window *SDLCALL SDL_CreatePopupWindow(SDL_Window *parent
  * SDL_ShowWindow().
  *
  * \param props the properties to use
- * \returns the window that was created or NULL on failure; call
+ * \returns[own] the window that was created or NULL on failure; call
  *          SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1053,7 +1053,7 @@ extern SDL_DECLSPEC SDL_Window *SDLCALL SDL_CreateWindowWithProperties(SDL_Prope
  * The numeric ID is what SDL_WindowEvent references, and is necessary to map
  * these events to specific SDL_Window objects.
  *
- * \param window the window to query
+ * \param[inout] window the window to query
  * \returns the ID of the window on success or 0 on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1082,7 +1082,7 @@ extern SDL_DECLSPEC SDL_Window *SDLCALL SDL_GetWindowFromID(SDL_WindowID id);
 /**
  * Get parent of a window.
  *
- * \param window the window to query
+ * \param[inout] window the window to query
  * \returns the parent of the window on success or NULL if the window has no
  *          parent.
  *
@@ -1183,7 +1183,7 @@ extern SDL_DECLSPEC SDL_Window *SDLCALL SDL_GetWindowParent(SDL_Window *window);
  * - `SDL_PROP_WINDOW_X11_WINDOW_NUMBER`: the X11 Window associated with the
  *   window
  *
- * \param window the window to query
+ * \param[inout] window the window to query
  * \returns a valid property ID on success or 0 on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1226,7 +1226,7 @@ extern SDL_DECLSPEC SDL_PropertiesID SDLCALL SDL_GetWindowProperties(SDL_Window 
 /**
  * Get the window flags.
  *
- * \param window the window to query
+ * \param[inout] window the window to query
  * \returns a mask of the SDL_WindowFlags associated with `window`
  *
  * \since This function is available since SDL 3.0.0.
@@ -1246,8 +1246,8 @@ extern SDL_DECLSPEC SDL_WindowFlags SDLCALL SDL_GetWindowFlags(SDL_Window *windo
  *
  * This string is expected to be in UTF-8 encoding.
  *
- * \param window the window to change
- * \param title the desired window title in UTF-8 format
+ * \param[inout] window the window to change
+ * \param[in] title the desired window title in UTF-8 format
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1260,7 +1260,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowTitle(SDL_Window *window, const cha
 /**
  * Get the title of a window.
  *
- * \param window the window to query
+ * \param[inout] window the window to query
  * \returns the title of the window in UTF-8 format or "" if there is no
  *          title.
  *
@@ -1273,8 +1273,8 @@ extern SDL_DECLSPEC const char *SDLCALL SDL_GetWindowTitle(SDL_Window *window);
 /**
  * Set the icon for a window.
  *
- * \param window the window to change
- * \param icon an SDL_Surface structure containing the icon for the window
+ * \param[inout] window the window to change
+ * \param[inout] icon an SDL_Surface structure containing the icon for the window
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1307,7 +1307,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowIcon(SDL_Window *window, SDL_Surfac
  * Additionally, as this is just a request, it can be denied by the windowing
  * system.
  *
- * \param window the window to reposition
+ * \param[inout] window the window to reposition
  * \param x the x coordinate of the window, or `SDL_WINDOWPOS_CENTERED` or
  *          `SDL_WINDOWPOS_UNDEFINED`
  * \param y the y coordinate of the window, or `SDL_WINDOWPOS_CENTERED` or
@@ -1331,9 +1331,9 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowPosition(SDL_Window *window, int x,
  * If you do not need the value for one of the positions a NULL may be passed
  * in the `x` or `y` parameter.
  *
- * \param window the window to query
- * \param x a pointer filled in with the x position of the window, may be NULL
- * \param y a pointer filled in with the y position of the window, may be NULL
+ * \param[inout] window the window to query
+ * \param[out,opt] x a pointer filled in with the x position of the window, may be NULL
+ * \param[out,opt] y a pointer filled in with the y position of the window, may be NULL
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1368,7 +1368,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetWindowPosition(SDL_Window *window, int *x
  * content area to remain within the usable desktop bounds). Additionally, as
  * this is just a request, it can be denied by the windowing system.
  *
- * \param window the window to change
+ * \param[inout] window the window to change
  * \param w the width of the window, must be > 0
  * \param h the height of the window, must be > 0
  * \returns 0 on success or a negative error code on failure; call
@@ -1392,9 +1392,9 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowSize(SDL_Window *window, int w, int
  * window is on a high pixel density display. Use SDL_GetWindowSizeInPixels()
  * or SDL_GetRenderOutputSize() to get the real client area size in pixels.
  *
- * \param window the window to query the width and height from
- * \param w a pointer filled in with the width of the window, may be NULL
- * \param h a pointer filled in with the height of the window, may be NULL
+ * \param[inout] window the window to query the width and height from
+ * \param[out,opt] w a pointer filled in with the width of the window, may be NULL
+ * \param[out,opt] h a pointer filled in with the height of the window, may be NULL
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1421,15 +1421,15 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetWindowSize(SDL_Window *window, int *w, in
  *
  * This function also returns -1 if getting the information is not supported.
  *
- * \param window the window to query the size values of the border
+ * \param[inout] window the window to query the size values of the border
  *               (decorations) from
- * \param top pointer to variable for storing the size of the top border; NULL
+ * \param[out,opt] top pointer to variable for storing the size of the top border; NULL
  *            is permitted
- * \param left pointer to variable for storing the size of the left border;
+ * \param[out,opt] left pointer to variable for storing the size of the left border;
  *             NULL is permitted
- * \param bottom pointer to variable for storing the size of the bottom
+ * \param[out,opt] bottom pointer to variable for storing the size of the bottom
  *               border; NULL is permitted
- * \param right pointer to variable for storing the size of the right border;
+ * \param[out,opt] right pointer to variable for storing the size of the right border;
  *              NULL is permitted
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1443,9 +1443,9 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetWindowBordersSize(SDL_Window *window, int
 /**
  * Get the size of a window's client area, in pixels.
  *
- * \param window the window from which the drawable size should be queried
- * \param w a pointer to variable for storing the width in pixels, may be NULL
- * \param h a pointer to variable for storing the height in pixels, may be
+ * \param[inout] window the window from which the drawable size should be queried
+ * \param[out,opt] w a pointer to variable for storing the width in pixels, may be NULL
+ * \param[out,opt] h a pointer to variable for storing the height in pixels, may be
  *          NULL
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1460,7 +1460,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetWindowSizeInPixels(SDL_Window *window, in
 /**
  * Set the minimum size of a window's client area.
  *
- * \param window the window to change
+ * \param[inout] window the window to change
  * \param min_w the minimum width of the window, or 0 for no limit
  * \param min_h the minimum height of the window, or 0 for no limit
  * \returns 0 on success or a negative error code on failure; call
@@ -1476,10 +1476,10 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowMinimumSize(SDL_Window *window, int
 /**
  * Get the minimum size of a window's client area.
  *
- * \param window the window to query
- * \param w a pointer filled in with the minimum width of the window, may be
+ * \param[inout] window the window to query
+ * \param[out,opt] w a pointer filled in with the minimum width of the window, may be
  *          NULL
- * \param h a pointer filled in with the minimum height of the window, may be
+ * \param[out,opt] h a pointer filled in with the minimum height of the window, may be
  *          NULL
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1494,7 +1494,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetWindowMinimumSize(SDL_Window *window, int
 /**
  * Set the maximum size of a window's client area.
  *
- * \param window the window to change
+ * \param[inout] window the window to change
  * \param max_w the maximum width of the window, or 0 for no limit
  * \param max_h the maximum height of the window, or 0 for no limit
  * \returns 0 on success or a negative error code on failure; call
@@ -1510,10 +1510,10 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowMaximumSize(SDL_Window *window, int
 /**
  * Get the maximum size of a window's client area.
  *
- * \param window the window to query
- * \param w a pointer filled in with the maximum width of the window, may be
+ * \param[inout] window the window to query
+ * \param[out,opt] w a pointer filled in with the maximum width of the window, may be
  *          NULL
- * \param h a pointer filled in with the maximum height of the window, may be
+ * \param[out,opt] h a pointer filled in with the maximum height of the window, may be
  *          NULL
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1534,7 +1534,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetWindowMaximumSize(SDL_Window *window, int
  *
  * You can't change the border state of a fullscreen window.
  *
- * \param window the window of which to change the border state
+ * \param[inout] window the window of which to change the border state
  * \param bordered SDL_FALSE to remove border, SDL_TRUE to add border
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1554,7 +1554,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowBordered(SDL_Window *window, SDL_bo
  *
  * You can't change the resizable state of a fullscreen window.
  *
- * \param window the window of which to change the resizable state
+ * \param[inout] window the window of which to change the resizable state
  * \param resizable SDL_TRUE to allow resizing, SDL_FALSE to disallow
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1571,7 +1571,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowResizable(SDL_Window *window, SDL_b
  * This will add or remove the window's `SDL_WINDOW_ALWAYS_ON_TOP` flag. This
  * will bring the window to the front and keep the window above the rest.
  *
- * \param window The window of which to change the always on top state
+ * \param[inout] window The window of which to change the always on top state
  * \param on_top SDL_TRUE to set the window always on top, SDL_FALSE to
  *               disable
  * \returns 0 on success or a negative error code on failure; call
@@ -1586,7 +1586,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowAlwaysOnTop(SDL_Window *window, SDL
 /**
  * Show a window.
  *
- * \param window the window to show
+ * \param[inout] window the window to show
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1600,7 +1600,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_ShowWindow(SDL_Window *window);
 /**
  * Hide a window.
  *
- * \param window the window to hide
+ * \param[inout] window the window to hide
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1613,7 +1613,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_HideWindow(SDL_Window *window);
 /**
  * Raise a window above other windows and set the input focus.
  *
- * \param window the window to raise
+ * \param[inout] window the window to raise
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1641,7 +1641,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_RaiseWindow(SDL_Window *window);
  * manager. Win32 and macOS enforce the constraints when maximizing, while X11
  * and Wayland window managers may vary.
  *
- * \param window the window to maximize
+ * \param[inout] window the window to maximize
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1665,7 +1665,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_MaximizeWindow(SDL_Window *window);
  * emitted. Note that, as this is just a request, the windowing system can
  * deny the state change.
  *
- * \param window the window to minimize
+ * \param[inout] window the window to minimize
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1690,7 +1690,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_MinimizeWindow(SDL_Window *window);
  * emitted. Note that, as this is just a request, the windowing system can
  * deny the state change.
  *
- * \param window the window to restore
+ * \param[inout] window the window to restore
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1718,7 +1718,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_RestoreWindow(SDL_Window *window);
  * SDL_EVENT_WINDOW_LEAVE_FULLSCREEN event will be emitted. Note that, as this
  * is just a request, it can be denied by the windowing system.
  *
- * \param window the window to change
+ * \param[inout] window the window to change
  * \param fullscreen SDL_TRUE for fullscreen mode, SDL_FALSE for windowed mode
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1743,7 +1743,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowFullscreen(SDL_Window *window, SDL_
  *
  * On windowing systems where changes are immediate, this does nothing.
  *
- * \param window the window for which to wait for the pending state to be
+ * \param[inout] window the window for which to wait for the pending state to be
  *               applied
  * \returns 0 on success, a positive value if the operation timed out before
  *          the window was in the requested state, or a negative error code on
@@ -1764,7 +1764,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SyncWindow(SDL_Window *window);
 /**
  * Return whether the window has a surface associated with it.
  *
- * \param window the window to query
+ * \param[inout] window the window to query
  * \returns SDL_TRUE if there is a surface associated with the window, or
  *          SDL_FALSE otherwise.
  *
@@ -1788,7 +1788,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_WindowHasSurface(SDL_Window *window);
  *
  * This function is affected by `SDL_HINT_FRAMEBUFFER_ACCELERATION`.
  *
- * \param window the window to query
+ * \param[inout] window the window to query
  * \returns the surface associated with the window, or NULL on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1809,7 +1809,7 @@ extern SDL_DECLSPEC SDL_Surface *SDLCALL SDL_GetWindowSurface(SDL_Window *window
  *
  * This function is equivalent to the SDL 1.2 API SDL_Flip().
  *
- * \param window the window to update
+ * \param[inout] window the window to update
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1833,8 +1833,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_UpdateWindowSurface(SDL_Window *window);
  * update more of the screen (or all of the screen!), depending on what method
  * SDL uses to send pixels to the system.
  *
- * \param window the window to update
- * \param rects an array of SDL_Rect structures representing areas of the
+ * \param[inout] window the window to update
+ * \param[in] rects an array of SDL_Rect structures representing areas of the
  *              surface to copy, in pixels
  * \param numrects the number of rectangles
  * \returns 0 on success or a negative error code on failure; call
@@ -1850,7 +1850,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_UpdateWindowSurfaceRects(SDL_Window *window,
 /**
  * Destroy the surface associated with the window.
  *
- * \param window the window to update
+ * \param[inout] window the window to update
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -1880,7 +1880,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_DestroyWindowSurface(SDL_Window *window);
  * If the caller enables a grab while another window is currently grabbed, the
  * other window loses its grab in favor of the caller's window.
  *
- * \param window The window for which the keyboard grab mode should be set.
+ * \param[inout] window The window for which the keyboard grab mode should be set.
  * \param grabbed This is SDL_TRUE to grab keyboard, and SDL_FALSE to release.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1897,7 +1897,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowKeyboardGrab(SDL_Window *window, SD
  *
  * Mouse grab confines the mouse cursor to the window.
  *
- * \param window The window for which the mouse grab mode should be set.
+ * \param[inout] window The window for which the mouse grab mode should be set.
  * \param grabbed This is SDL_TRUE to grab mouse, and SDL_FALSE to release.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1912,7 +1912,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowMouseGrab(SDL_Window *window, SDL_b
 /**
  * Get a window's keyboard grab mode.
  *
- * \param window the window to query
+ * \param[inout] window the window to query
  * \returns SDL_TRUE if keyboard is grabbed, and SDL_FALSE otherwise.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1924,7 +1924,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GetWindowKeyboardGrab(SDL_Window *windo
 /**
  * Get a window's mouse grab mode.
  *
- * \param window the window to query
+ * \param[inout] window the window to query
  * \returns SDL_TRUE if mouse is grabbed, and SDL_FALSE otherwise.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1951,8 +1951,8 @@ extern SDL_DECLSPEC SDL_Window *SDLCALL SDL_GetGrabbedWindow(void);
  * Note that this does NOT grab the cursor, it only defines the area a cursor
  * is restricted to when the window has mouse focus.
  *
- * \param window The window that will be associated with the barrier.
- * \param rect A rectangle area in window-relative coordinates. If NULL the
+ * \param[inout] window The window that will be associated with the barrier.
+ * \param[in,opt] rect A rectangle area in window-relative coordinates. If NULL the
  *             barrier for the specified window will be destroyed.
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -1967,7 +1967,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowMouseRect(SDL_Window *window, const
 /**
  * Get the mouse confinement rectangle of a window.
  *
- * \param window The window to query
+ * \param[inout] window The window to query
  * \returns A pointer to the mouse confinement rectangle of a window, or NULL
  *          if there isn't one.
  *
@@ -1985,7 +1985,7 @@ extern SDL_DECLSPEC const SDL_Rect *SDLCALL SDL_GetWindowMouseRect(SDL_Window *w
  *
  * This function also returns -1 if setting the opacity isn't supported.
  *
- * \param window the window which will be made transparent or opaque
+ * \param[inout] window the window which will be made transparent or opaque
  * \param opacity the opacity value (0.0f - transparent, 1.0f - opaque)
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -2006,8 +2006,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowOpacity(SDL_Window *window, float o
  *
  * This function also returns -1 if an invalid window was provided.
  *
- * \param window the window to get the current opacity value from
- * \param out_opacity the float filled in (0.0f - transparent, 1.0f - opaque)
+ * \param[inout] window the window to get the current opacity value from
+ * \param[out,opt] out_opacity the float filled in (0.0f - transparent, 1.0f - opaque)
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -2027,8 +2027,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetWindowOpacity(SDL_Window *window, float *
  * Setting a window as modal to a parent that is a descendent of the modal
  * window results in undefined behavior.
  *
- * \param modal_window the window that should be set modal
- * \param parent_window the parent window for the modal window
+ * \param[inout] modal_window the window that should be set modal
+ * \param[inout,opt] parent_window the parent window for the modal window
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -2043,7 +2043,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowModalFor(SDL_Window *modal_window, 
  * this with caution, as you might give focus to a window that is completely
  * obscured by other windows.
  *
- * \param window the window that should get the input focus
+ * \param[inout] window the window that should get the input focus
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -2056,7 +2056,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowInputFocus(SDL_Window *window);
 /**
  * Set whether the window may have input focus.
  *
- * \param window the window to set focusable state
+ * \param[inout] window the window to set focusable state
  * \param focusable SDL_TRUE to allow input focus, SDL_FALSE to not allow
  *                  input focus
  * \returns 0 on success or a negative error code on failure; call
@@ -2078,7 +2078,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowFocusable(SDL_Window *window, SDL_b
  * On platforms or desktops where this is unsupported, this function does
  * nothing.
  *
- * \param window the window for which the menu will be displayed
+ * \param[inout] window the window for which the menu will be displayed
  * \param x the x coordinate of the menu, relative to the origin (top-left) of
  *          the client area
  * \param y the y coordinate of the menu, relative to the origin (top-left) of
@@ -2157,9 +2157,9 @@ typedef SDL_HitTestResult (SDLCALL *SDL_HitTest)(SDL_Window *win,
  * can fire at any time, you should try to keep your callback efficient,
  * devoid of allocations, etc.
  *
- * \param window the window to set hit-testing on
- * \param callback the function to call when doing a hit-test
- * \param callback_data an app-defined void pointer passed to **callback**
+ * \param[inout] window the window to set hit-testing on
+ * \param[in] callback the function to call when doing a hit-test
+ * \param[inout,opt] callback_data an app-defined void pointer passed to **callback**
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -2181,8 +2181,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowHitTest(SDL_Window *window, SDL_Hit
  *
  * The window must have been created with the SDL_WINDOW_TRANSPARENT flag.
  *
- * \param window the window
- * \param shape the surface representing the shape of the window, or NULL to
+ * \param[inout] window the window
+ * \param[inout,opt] shape the surface representing the shape of the window, or NULL to
  *              remove any current shape
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -2194,7 +2194,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowShape(SDL_Window *window, SDL_Surfa
 /**
  * Request a window to demand attention from the user.
  *
- * \param window the window to be flashed
+ * \param[inout] window the window to be flashed
  * \param operation the flash operation
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -2212,7 +2212,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_FlashWindow(SDL_Window *window, SDL_FlashOpe
  * If `window` is NULL, this function will return immediately after setting
  * the SDL error message to "Invalid window". See SDL_GetError().
  *
- * \param window the window to destroy
+ * \param[inout] window the window to destroy
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -2288,7 +2288,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_DisableScreenSaver(void);
  * If you do this, you need to retrieve all of the GL functions used in your
  * program from the dynamic library using SDL_GL_GetProcAddress().
  *
- * \param path the platform dependent OpenGL library name, or NULL to open the
+ * \param[in,opt] path the platform dependent OpenGL library name, or NULL to open the
  *             default OpenGL library
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
@@ -2341,7 +2341,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GL_LoadLibrary(const char *path);
  *   code. This will ensure the proper calling convention is followed on
  *   platforms where this matters (Win32) thereby avoiding stack corruption.
  *
- * \param proc the name of an OpenGL function
+ * \param[in] proc the name of an OpenGL function
  * \returns a pointer to the named OpenGL function. The returned pointer
  *          should be cast to the appropriate function signature.
  *
@@ -2360,7 +2360,7 @@ extern SDL_DECLSPEC SDL_FunctionPointer SDLCALL SDL_GL_GetProcAddress(const char
  * points for EGL functions. This is useful to provide to an EGL API and
  * extension loader.
  *
- * \param proc the name of an EGL function
+ * \param[in] proc the name of an EGL function
  * \returns a pointer to the named EGL function. The returned pointer should
  *          be cast to the appropriate function signature.
  *
@@ -2393,7 +2393,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_GL_UnloadLibrary(void);
  * context and save that information somewhere instead of calling the function
  * every time you need to know.
  *
- * \param extension the name of the extension to check
+ * \param[in] extension the name of the extension to check
  * \returns SDL_TRUE if the extension is supported, SDL_FALSE otherwise.
  *
  * \since This function is available since SDL 3.0.0.
@@ -2434,7 +2434,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GL_SetAttribute(SDL_GLattr attr, int value);
  * Get the actual value for an attribute from the current context.
  *
  * \param attr an SDL_GLattr enum value specifying the OpenGL attribute to get
- * \param value a pointer filled in with the current value of `attr`
+ * \param[out] value a pointer filled in with the current value of `attr`
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -2456,7 +2456,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GL_GetAttribute(SDL_GLattr attr, int *value)
  *
  * SDL_GLContext is an alias for `void *`. It's opaque to the application.
  *
- * \param window the window to associate with the context
+ * \param[inout] window the window to associate with the context
  * \returns the OpenGL context associated with `window` or NULL on error; call
  *          SDL_GetError() for more details.
  *
@@ -2472,8 +2472,8 @@ extern SDL_DECLSPEC SDL_GLContext SDLCALL SDL_GL_CreateContext(SDL_Window *windo
  *
  * The context must have been created with a compatible window.
  *
- * \param window the window to associate with the context
- * \param context the OpenGL context to associate with the window
+ * \param[inout] window the window to associate with the context
+ * \param[out] context the OpenGL context to associate with the window
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -2528,7 +2528,7 @@ extern SDL_DECLSPEC SDL_EGLConfig SDLCALL SDL_EGL_GetCurrentEGLConfig(void);
 /**
  * Get the EGL surface associated with the window.
  *
- * \param window the window to query
+ * \param[inout] window the window to query
  * \returns the EGLSurface pointer associated with the window, or NULL on
  *          failure.
  *
@@ -2549,11 +2549,11 @@ extern SDL_DECLSPEC SDL_EGLSurface SDLCALL SDL_EGL_GetWindowEGLSurface(SDL_Windo
  *
  * NOTE: These callback pointers will be reset after SDL_GL_ResetAttributes.
  *
- * \param platformAttribCallback Callback for attributes to pass to
+ * \param[in] platformAttribCallback Callback for attributes to pass to
  *                               eglGetPlatformDisplay.
- * \param surfaceAttribCallback Callback for attributes to pass to
+ * \param[in] surfaceAttribCallback Callback for attributes to pass to
  *                              eglCreateSurface.
- * \param contextAttribCallback Callback for attributes to pass to
+ * \param[in] contextAttribCallback Callback for attributes to pass to
  *                              eglCreateContext.
  *
  * \since This function is available since SDL 3.0.0.
@@ -2597,7 +2597,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GL_SetSwapInterval(int interval);
  * If the system can't determine the swap interval, or there isn't a valid
  * current context, this function will set *interval to 0 as a safe default.
  *
- * \param interval Output interval value. 0 if there is no vertical retrace
+ * \param[out] interval Output interval value. 0 if there is no vertical retrace
  *                 synchronization, 1 if the buffer swap is synchronized with
  *                 the vertical retrace, and -1 if late swaps happen
  *                 immediately instead of waiting for the next retrace
@@ -2620,7 +2620,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GL_GetSwapInterval(int *interval);
  * glBindFramebuffer(), this is the default and you won't have to do anything
  * extra.
  *
- * \param window the window to change
+ * \param[inout] window the window to change
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -2631,7 +2631,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GL_SwapWindow(SDL_Window *window);
 /**
  * Delete an OpenGL context.
  *
- * \param context the OpenGL context to be deleted
+ * \param[inout] context the OpenGL context to be deleted
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *

--- a/include/SDL3/SDL_vulkan.h
+++ b/include/SDL3/SDL_vulkan.h
@@ -93,7 +93,7 @@ struct VkAllocationCallbacks;
  * supported. Either do not link to the Vulkan loader or link to a dynamic
  * library version.
  *
- * \param path The platform dependent Vulkan loader library name or NULL
+ * \param[in] path The platform dependent Vulkan loader library name or NULL
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
@@ -147,7 +147,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_Vulkan_UnloadLibrary(void);
  *
  * You should not free the returned array; it is owned by SDL.
  *
- * \param count a pointer filled in with the number of extensions returned.
+ * \param[out,opt] count a pointer filled in with the number of extensions returned.
  * \returns An array of extension name strings on success, NULL on error.
  *
  * \since This function is available since SDL 3.0.0.
@@ -166,11 +166,11 @@ extern SDL_DECLSPEC char const* const* SDLCALL SDL_Vulkan_GetInstanceExtensions(
  * If `allocator` is NULL, Vulkan will use the system default allocator. This
  * argument is passed directly to Vulkan and isn't used by SDL itself.
  *
- * \param window The window to which to attach the Vulkan surface
- * \param instance The Vulkan instance handle
- * \param allocator A VkAllocationCallbacks struct, which lets the app set the
+ * \param[inout] window The window to which to attach the Vulkan surface
+ * \param[inout] instance The Vulkan instance handle
+ * \param[in,opt] allocator A VkAllocationCallbacks struct, which lets the app set the
  *                  allocator that creates the surface. Can be NULL.
- * \param surface A pointer to a VkSurfaceKHR handle to output the newly
+ * \param[inout] surface A pointer to a VkSurfaceKHR handle to output the newly
  *                created surface
  * \returns SDL_TRUE on success, SDL_FALSE on error.
  *
@@ -197,9 +197,9 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_Vulkan_CreateSurface(SDL_Window *window
  * If `allocator` is NULL, Vulkan will use the system default allocator. This
  * argument is passed directly to Vulkan and isn't used by SDL itself.
  *
- * \param instance The Vulkan instance handle
- * \param surface VkSurfaceKHR handle to destroy
- * \param allocator A VkAllocationCallbacks struct, which lets the app set the
+ * \param[inout] instance The Vulkan instance handle
+ * \param[inout] surface VkSurfaceKHR handle to destroy
+ * \param[in,opt] allocator A VkAllocationCallbacks struct, which lets the app set the
  *                  allocator that destroys the surface. Can be NULL.
  *
  * \since This function is available since SDL 3.0.0.


### PR DESCRIPTION
This PR adds annotations to the documentation of the functions' parameters and return value, since C pointers do not convey information about ownership, among other things. The annotations are written next to \params and \returns inside square brackets (eg. \params[out,own] only for relevant pointer values, with the supported annotations being:

in - Parameters that the function reads from.
out - Parameters that the function writes to, no matter the initial value (ie. output parameters).
inout - Parameters that the function modifies according to their value. Different from out parameters, these need to be initialized beforehand.

opt - Parameters that can be null.
own - Parameters that need to be disposed of with SDL_free/other deallocation function after being used.

own can also be applied to pointers returned by functions, with the same meaning that it carries for parameters.

The possible combinations are as following: [in], [out], [inout], [in, opt], [out, opt], [inout, opt], [out, own] .
Notice there can be at most two annotations per value, to make the parsing process as simple as possible (which is the reason for having inout instead of in, out).

The wiki parser can skip the [] in \params and \returns (if present) to keep the output the same as before this PR, or you can parse the annotations if that is of interest.

With the annotations accepted, we should now have more information when parsing the headers to generate bindings.

If there are more annotations that should be considered, I'm open to implementing them.