### PR TITLE
SDL_systime.c: missing include for PSP toolchain

### DIFF
--- a/src/time/psp/SDL_systime.c
+++ b/src/time/psp/SDL_systime.c
@@ -22,6 +22,7 @@
 
 #ifdef SDL_TIME_PSP
 
+#include <psptypes.h>
 #include <psprtc.h>
 #include <psputility_sysparam.h>
 


### PR DESCRIPTION
SDL3 failed to build with the current version of the pspdev toolchain, because of this missing header. No idea when it changed.

## Description
Added `#include <psptypes.h>` to `SDL_systime.c`

## Existing Issue(s)
- N/A