### PR TITLE
x11: Ensure that the initial window position is sent in the event of …

### DIFF
--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -1808,6 +1808,11 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
                         X11_XMoveWindow(display, data->xwindow, data->window->floating.x - data->border_left, data->window->floating.y - data->border_top);
                         X11_XResizeWindow(display, data->xwindow, data->window->floating.w, data->window->floating.h);
                     }
+                } else if (data->in_initial_configuration) {
+                    /* Don't clear this for 0 borders in the initial configuration sequence,
+                     * or the final position won't be sent later.
+                     */
+                    data->disable_size_position_events = SDL_TRUE;
                 }
             }
             if (!(data->window->flags & SDL_WINDOW_FULLSCREEN) && data->toggle_borders) {

--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -1419,6 +1419,10 @@ void X11_ShowWindow(SDL_VideoDevice *_this, SDL_Window *window)
      * Don't emit size and position events during the initial configure events, they will be sent afterwards, when the
      * final coordinates are available to avoid sending garbage values.
      */
+    int target_x = window->floating.x;
+    int target_y = window->floating.y;
+
+    data->in_initial_configuration = SDL_TRUE;
     data->disable_size_position_events = SDL_TRUE;
     X11_XSync(display, False);
     X11_PumpEvents(_this);
@@ -1430,15 +1434,16 @@ void X11_ShowWindow(SDL_VideoDevice *_this, SDL_Window *window)
         SDL_GlobalToRelativeForWindow(data->window, x, y, &x, &y);
 
         /* If the borders appeared, this happened automatically in the event system, otherwise, set the position now. */
-        if (data->disable_size_position_events && (window->x != x || window->y != y)) {
+        if (data->disable_size_position_events) {
             data->pending_operation = X11_PENDING_OP_MOVE;
-            X11_XMoveWindow(display, data->xwindow, window->x, window->y);
+            X11_XMoveWindow(display, data->xwindow, target_x, target_y);
         }
 
         SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_RESIZED, data->last_xconfigure.width, data->last_xconfigure.height);
         SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_MOVED, x, y);
     }
 
+    data->in_initial_configuration = SDL_FALSE;
     data->disable_size_position_events = SDL_FALSE;
 }
 

--- a/src/video/x11/SDL_x11window.h
+++ b/src/video/x11/SDL_x11window.h
@@ -99,6 +99,7 @@ struct SDL_WindowData
 
     SDL_bool window_was_maximized;
     SDL_bool disable_size_position_events;
+    SDL_bool in_initial_configuration;
     SDL_bool previous_borders_nonzero;
     SDL_bool toggle_borders;
     SDL_HitTestResult hit_test_result;


### PR DESCRIPTION
…a border size of 0

In the event of an extents event with a border size of 0, the flag disabling the sending of size/position events will be cleared, but the window position will not be updated. Ensure that the initial position is sent after the initial configure event if it wasn't sent during the border extents event.
