### PR TITLE
SDL_windows.h: set _WIN32_WINNT to 0xA00 if dxgi1_6.h is available

### DIFF
--- a/src/core/windows/SDL_windows.h
+++ b/src/core/windows/SDL_windows.h
@@ -36,7 +36,7 @@
 #endif
 #undef WINVER
 #undef _WIN32_WINNT
-#if SDL_VIDEO_RENDER_D3D12
+#if SDL_VIDEO_RENDER_D3D12 || defined(HAVE_DXGI1_6_H)
 #define _WIN32_WINNT 0xA00 /* For D3D12, 0xA00 is required */
 #elif defined(HAVE_SHELLSCALINGAPI_H)
 #define _WIN32_WINNT 0x603 /* For DPI support */


### PR DESCRIPTION
to make sure `DISPLAYCONFIG_SDR_WHITE_LEVEL` is visible to us.
