### PR TITLE
WIN_AdjustWindowRectWithStyle: silence gcc maybe-uninitialized warnings

### DIFF
--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -206,6 +206,8 @@ static int WIN_AdjustWindowRectWithStyle(SDL_Window *window, DWORD style, DWORD 
         default:
             /* Should never be here */
             SDL_assert_release(SDL_FALSE);
+            *width = 0;
+            *height = 0;
     }
 
     /* Copy the client size in pixels into this rect structure,


### PR DESCRIPTION
warnings from gcc-7.5:

```
/tmp/SDL3/src/video/windows/SDL_windowswindow.c: In function 'WIN_SetWindowPositionInternal':
/tmp/SDL3/src/video/windows/SDL_windowswindow.c:216:17: warning: 'h' may be used uninitialized in this function [-Wmaybe-uninitialized]
     rect.bottom = *height;
     ~~~~~~~~~~~~^~~~~~~~~
/tmp/SDL3/src/video/windows/SDL_windowswindow.c:320:12: note: 'h' was declared here
     int w, h;
            ^
/tmp/SDL3/src/video/windows/SDL_windowswindow.c:215:16: warning: 'w' may be used uninitialized in this function [-Wmaybe-uninitialized]
     rect.right = *width;
     ~~~~~~~~~~~^~~~~~~~
/tmp/SDL3/src/video/windows/SDL_windowswindow.c:320:9: note: 'w' was declared here
     int w, h;
         ^
```
