### PR TITLE
SDL_SetEventFilter: Don't flush good events

### DIFF
--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -1310,22 +1310,25 @@ int SDL_PushEvent(SDL_Event *event)
 
 void SDL_SetEventFilter(SDL_EventFilter filter, void *userdata)
 {
-    SDL_EventEntry *event;
+    SDL_EventEntry *event, *next;
     SDL_LockMutex(SDL_event_watchers_lock);
     {
         /* Set filter and discard pending events */
         SDL_EventOK.callback = filter;
         SDL_EventOK.userdata = userdata;
-        /* Flush all events not accpeted by the filter */
-        SDL_LockMutex(SDL_EventQ.lock);
-        {
-            for (event = SDL_EventQ.head; event; event = event->next) {
-                if (!filter(userdata, &event->event)) {
-                    SDL_CutEvent(event);
+        if (filter) {
+            /* Cut all events not accepted by the filter */
+            SDL_LockMutex(SDL_EventQ.lock);
+            {
+                for (event = SDL_EventQ.head; event; event = next) {
+                    next = event->next;
+                    if (!filter(userdata, &event->event)) {
+                        SDL_CutEvent(event);
+                    }
                 }
             }
+            SDL_UnlockMutex(SDL_EventQ.lock);
         }
-        SDL_UnlockMutex(SDL_EventQ.lock);
     }
     SDL_UnlockMutex(SDL_event_watchers_lock);
 }


### PR DESCRIPTION
This changes SDL_SetEventFilter to only cut events that don't pass the user filter instead of flushing the entire list.

This also prevents the event queue from being flushed when the user is removing a filter with `SDL_SetEventFilter(NULL, NULL)`.

Fixes #9592