### PR TITLE
Use the initial position and size as the target display for windows created as fullscreen

### DIFF
--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -53,6 +53,7 @@ struct SDL_Window
     float display_scale;
     SDL_bool external_graphics_context;
     SDL_bool fullscreen_exclusive;  /* The window is currently fullscreen exclusive */
+    SDL_DisplayID initial_fullscreen_display; /* The target fullscreen display if the window is created fullscreen. */
     SDL_DisplayID last_fullscreen_exclusive_display;  /* The last fullscreen_exclusive display */
     SDL_DisplayID last_displayID;
 

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -495,7 +495,14 @@ static void X11_DispatchMapNotify(SDL_WindowData *data)
 {
     SDL_Window *window = data->window;
     SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_RESTORED, 0, 0);
-    SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_SHOWN, 0, 0);
+
+    /* Sending this event can trigger calls that call into X11_ShowWindow, so don't send it
+     * if this is received while already in that function. The event will be sent later in
+     * that case.
+     */
+    if (!data->in_show_sequence) {
+        SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_SHOWN, 0, 0);
+    }
     if (!(window->flags & SDL_WINDOW_HIDDEN) && (window->flags & SDL_WINDOW_INPUT_FOCUS)) {
         SDL_UpdateWindowGrab(window);
     }

--- a/src/video/x11/SDL_x11window.h
+++ b/src/video/x11/SDL_x11window.h
@@ -97,6 +97,7 @@ struct SDL_WindowData
         X11_PENDING_OP_RESIZE = 0x20
     } pending_operation;
 
+    SDL_bool in_show_sequence;
     SDL_bool window_was_maximized;
     SDL_bool disable_size_position_events;
     SDL_bool previous_borders_nonzero;


### PR DESCRIPTION
When creating windows with the fullscreen flag initially set, use the initial size and position of the window to determine the target fullscreen display before the window manager can resize or change the position of the window, as the initial coordinates are just a request and it may be placed elsewhere, especially if the window is larger than the usable bounds of the target display, or when using the Wayland backend, where there is absolutely no control over non-fullscreen window placement.

X11 also needs a sync point between entering fullscreen and the positioning move, as racy behavior may cause the compositor to refuse to move the window if it deems that it doesn't fit on the target based on the non-windowed size should the move be processed before the enter fullscreen request.

Fixes #9915