### PR TITLE
Add a basic ShowMessageBox implementation for PSP

### DIFF
--- a/src/video/psp/SDL_pspmessagebox.c
+++ b/src/video/psp/SDL_pspmessagebox.c
@@ -58,7 +58,7 @@ int PSP_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonID)
 	int status;
 
 	/* check if it's possible to do a messagebox now */
-	if (SDL_WasInit(SDL_INIT_VIDEO) == 0 || SDL_GetKeyboardFocus() == NULL)
+	if (SDL_GetKeyboardFocus() == NULL)
 		return SDL_SetError("No video context is available");
 
 	/* configure dialog */

--- a/src/video/psp/SDL_pspmessagebox.c
+++ b/src/video/psp/SDL_pspmessagebox.c
@@ -53,7 +53,7 @@ static void configure_dialog(pspUtilityMsgDialogParams *dialog, size_t dialog_si
 
 int PSP_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonID)
 {
-	static unsigned char list[0x20000] __attribute__((aligned(64)));
+	unsigned char list[0x20000] __attribute__((aligned(64)));
 	pspUtilityMsgDialogParams dialog;
 	int status;
 

--- a/src/video/psp/SDL_pspmessagebox.c
+++ b/src/video/psp/SDL_pspmessagebox.c
@@ -1,0 +1,114 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include "SDL_internal.h"
+
+#ifdef SDL_VIDEO_DRIVER_PSP
+
+#include "SDL_pspvideo.h"
+#include "SDL_pspmessagebox.h"
+#include <psputility.h>
+#include <pspgu.h>
+#include <pspdisplay.h>
+#include <pspthreadman.h>
+#include <pspkernel.h>
+
+static void configure_dialog(pspUtilityMsgDialogParams *dialog, size_t dialog_size)
+{
+	/* clear structure and setup size */
+	SDL_memset(dialog, 0, dialog_size);
+	dialog->base.size = dialog_size;
+
+	/* set language */
+	sceUtilityGetSystemParamInt(PSP_SYSTEMPARAM_ID_INT_LANGUAGE, &dialog->base.language);
+
+	/* set X/O swap */
+	sceUtilityGetSystemParamInt(PSP_SYSTEMPARAM_ID_INT_UNKNOWN, &dialog->base.buttonSwap);
+
+	/* set thread priorities */
+	/* TODO: understand how these work */
+	dialog->base.soundThread = 0x10;
+	dialog->base.graphicsThread = 0x11;
+	dialog->base.fontThread = 0x12;
+	dialog->base.accessThread = 0x13;
+}
+
+int PSP_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonID)
+{
+	pspUtilityMsgDialogParams dialog;
+	int status;
+
+	/* configure dialog */
+	configure_dialog(&dialog, sizeof(dialog));
+
+	/* setup dialog options for text */
+	dialog.mode = PSP_UTILITY_MSGDIALOG_MODE_TEXT;
+	dialog.options = PSP_UTILITY_MSGDIALOG_OPTION_TEXT;
+
+	/* copy the message in, 512 bytes max */
+	SDL_snprintf(dialog.message, sizeof(dialog.message), "%s\r\n\r\n%s", messageboxdata->title, messageboxdata->message);
+
+	/* too many buttons */
+	if (messageboxdata->numbuttons > 2)
+		return -1;
+
+	/* we only have two options, "yes/no" or "ok" */
+	if (messageboxdata->numbuttons == 2)
+		dialog.options |= PSP_UTILITY_MSGDIALOG_OPTION_YESNO_BUTTONS | PSP_UTILITY_MSGDIALOG_OPTION_DEFAULT_NO;
+
+	/* start dialog */
+	if (sceUtilityMsgDialogInitStart(&dialog) != 0)
+		return -1;
+
+	/* loop while the dialog is active */
+	status = PSP_UTILITY_DIALOG_NONE;
+	do
+	{
+		status = sceUtilityMsgDialogGetStatus();
+
+		switch (status)
+		{
+			case PSP_UTILITY_DIALOG_VISIBLE:
+				sceUtilityMsgDialogUpdate(1);
+				break;
+
+			case PSP_UTILITY_DIALOG_QUIT:
+				sceUtilityMsgDialogShutdownStart();
+				break;
+		}
+
+		sceDisplayWaitVblankStart();
+		sceGuSwapBuffers();
+
+	} while (status != PSP_UTILITY_DIALOG_NONE);
+
+	/* success */
+	if (dialog.buttonPressed == PSP_UTILITY_MSGDIALOG_RESULT_YES)
+		*buttonID = messageboxdata->buttons[0].buttonID;
+	else if (dialog.buttonPressed == PSP_UTILITY_MSGDIALOG_RESULT_NO)
+		*buttonID = messageboxdata->buttons[1].buttonID;
+	else
+		*buttonID = messageboxdata->buttons[0].buttonID;
+
+	return 0;
+}
+
+#endif /* SDL_VIDEO_DRIVER_PSP */

--- a/src/video/psp/SDL_pspmessagebox.c
+++ b/src/video/psp/SDL_pspmessagebox.c
@@ -57,8 +57,8 @@ int PSP_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonID)
 	pspUtilityMsgDialogParams dialog;
 	int status;
 
-	/* TODO: AGHHHHHhhhHH */
-	if (SDL_WasInit(SDL_INIT_VIDEO) == 0 || SDL_GL_GetCurrentContext() == NULL || SDL_GL_GetCurrentWindow() == NULL)
+	/* check if it's possible to do a messagebox now */
+	if (SDL_WasInit(SDL_INIT_VIDEO) == 0 || SDL_GetKeyboardFocus() == NULL)
 		return SDL_SetError("No video context is available");
 
 	/* configure dialog */
@@ -88,8 +88,11 @@ int PSP_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonID)
 	do
 	{
 		sceGuStart(GU_DIRECT, list);
+		sceGuClearColor(0);
+		sceGuClearDepth(0);
+		sceGuClear(GU_COLOR_BUFFER_BIT|GU_DEPTH_BUFFER_BIT);
 		sceGuFinish();
-		sceGuSync(GU_SYNC_WHAT_DONE, GU_SYNC_FINISH);
+		sceGuSync(0,0);
 
 		status = sceUtilityMsgDialogGetStatus();
 

--- a/src/video/psp/SDL_pspmessagebox.c
+++ b/src/video/psp/SDL_pspmessagebox.c
@@ -56,6 +56,10 @@ int PSP_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonID)
 	pspUtilityMsgDialogParams dialog;
 	int status;
 
+	/* TODO: AGHHHHHhhhHH */
+	if (SDL_WasInit(SDL_INIT_VIDEO) == 0 || SDL_GL_GetCurrentContext() == NULL || SDL_GL_GetCurrentWindow() == NULL)
+		return SDL_SetError("No video context is available");
+
 	/* configure dialog */
 	configure_dialog(&dialog, sizeof(dialog));
 
@@ -68,7 +72,7 @@ int PSP_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonID)
 
 	/* too many buttons */
 	if (messageboxdata->numbuttons > 2)
-		return -1;
+		return SDL_SetError("messageboxdata->numbuttons valid values are 0, 1, 2");
 
 	/* we only have two options, "yes/no" or "ok" */
 	if (messageboxdata->numbuttons == 2)
@@ -76,7 +80,7 @@ int PSP_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonID)
 
 	/* start dialog */
 	if (sceUtilityMsgDialogInitStart(&dialog) != 0)
-		return -1;
+		return SDL_SetError("sceUtilityMsgDialogInitStart() failed for some reason");
 
 	/* loop while the dialog is active */
 	status = PSP_UTILITY_DIALOG_NONE;

--- a/src/video/psp/SDL_pspmessagebox.c
+++ b/src/video/psp/SDL_pspmessagebox.c
@@ -53,6 +53,7 @@ static void configure_dialog(pspUtilityMsgDialogParams *dialog, size_t dialog_si
 
 int PSP_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonID)
 {
+	static unsigned char list[0x20000] __attribute__((aligned(64)));
 	pspUtilityMsgDialogParams dialog;
 	int status;
 
@@ -86,6 +87,10 @@ int PSP_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonID)
 	status = PSP_UTILITY_DIALOG_NONE;
 	do
 	{
+		sceGuStart(GU_DIRECT, list);
+		sceGuFinish();
+		sceGuSync(GU_SYNC_WHAT_DONE, GU_SYNC_FINISH);
+
 		status = sceUtilityMsgDialogGetStatus();
 
 		switch (status)

--- a/src/video/psp/SDL_pspmessagebox.h
+++ b/src/video/psp/SDL_pspmessagebox.h
@@ -1,0 +1,31 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#ifndef SDL_pspmessagebox_h_
+#define SDL_pspmessagebox_h_
+
+#if SDL_VIDEO_DRIVER_PSP
+
+int PSP_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonid);
+
+#endif /* SDL_VIDEO_DRIVER_PSP */
+
+#endif /* SDL_pspmessagebox_h_ */

--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -32,6 +32,7 @@
 #include "SDL_pspvideo.h"
 #include "SDL_pspevents_c.h"
 #include "SDL_pspgl_c.h"
+#include "SDL_pspmessagebox.h"
 
 /* unused
 static SDL_bool PSP_initialized = SDL_FALSE;
@@ -119,7 +120,7 @@ VideoBootStrap PSP_bootstrap = {
     "psp",
     "PSP Video Driver",
     PSP_Create,
-    NULL /* no ShowMessageBox implementation */
+    PSP_ShowMessageBox
 };
 
 /*****************************************************************************/


### PR DESCRIPTION
It's a basic implementation of SDL_ShowMessageBox on PSP.

## Description
I wrote this based on the [pspdev example](https://github.com/pspdev/pspsdk/blob/master/src/samples/utility/msgdialog/main.c) and [sharkwouter:SDL:psp-message-dialog](https://github.com/libsdl-org/SDL/compare/main...sharkwouter:SDL:psp-message-dialog). The one major caveat is that it doesn't work if the GL/GU backend has not been initialized yet, so it fails to satisfy the "works before SDL initialization" requirement. But it still works otherwise. I'm looking at ways to address that.

## Existing Issue(s)
- N/A
