### PR TITLE
android: Default to custom theme in styles.xml

### DIFF
--- a/android-project/app/src/main/AndroidManifest.xml
+++ b/android-project/app/src/main/AndroidManifest.xml
@@ -69,7 +69,7 @@
     <application android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"
         android:allowBackup="true"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+        android:theme="@style/AppTheme"
         android:hardwareAccelerated="true" >
 
         <!-- Example of setting SDL hints from AndroidManifest.xml:

--- a/android-project/app/src/main/res/values/styles.xml
+++ b/android-project/app/src/main/res/values/styles.xml
@@ -1,8 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
-
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="android:Theme.Holo.Light.DarkActionBar">
+    <style name="AppTheme" parent="android:Theme.NoTitleBar.Fullscreen">
         <!-- Customize your theme here. -->
     </style>
-
 </resources>


### PR DESCRIPTION
Custom theme file exists in project, but is not used by app, which is kinda unintuitive. Using it by default so people who not familiar with Android development won't spend lots of time troubleshooting.
