### PR TITLE
Don't set the borderless flag if we're about to go fullscreen.

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2254,6 +2254,7 @@ SDL_Window *SDL_CreateWindowWithProperties(SDL_PropertiesID props)
         window->y = bounds.y;
         window->w = bounds.w;
         window->h = bounds.h;
+        window->pending_flags |= SDL_WINDOW_FULLSCREEN;
         flags |= SDL_WINDOW_FULLSCREEN;
     }
 


### PR DESCRIPTION
This prevents the GNOME window manager from moving the window to a different display before the window goes fullscreen.

Fixes https://github.com/libsdl-org/SDL/issues/9915