### PR TITLE
SDL_assert: add support for aarch64-w64-mingw32

### DIFF
--- a/include/SDL_assert.h
+++ b/include/SDL_assert.h
@@ -61,6 +61,8 @@ assert can have unique static variables associated with it.
     #define SDL_TriggerBreakpoint() __asm__ __volatile__ ( "brk #22\n\t" )
 #elif defined(__APPLE__) && defined(__arm__)
     #define SDL_TriggerBreakpoint() __asm__ __volatile__ ( "bkpt #22\n\t" )
+#elif defined(_WIN32) && ((defined(__GNUC__) || defined(__clang__)) && (defined(__arm64__) || defined(__aarch64__)) )
+    #define SDL_TriggerBreakpoint() __asm__ __volatile__ ( "brk #0xF000\n\t" )
 #elif defined(__386__) && defined(__WATCOMC__)
     #define SDL_TriggerBreakpoint() { _asm { int 0x03 } }
 #elif defined(HAVE_SIGNAL_H) && !defined(__WATCOMC__)


### PR DESCRIPTION
GCC 15 development branch provides an experimental support for Windows on ARM64, which will be officially released next year, according to latest news. I tried to compile SDL2 with this new compiler but I got a problem into SDL_assert.h because it couldn't find the right platform. However, it has been easy to fix and I included it into this PR. 
More details can be also found here:
https://learn.microsoft.com/en-us/cpp/intrinsics/debugbreak?view=msvc-170
 
![immagine](https://github.com/libsdl-org/SDL/assets/30959007/3939c62c-dcf7-48b6-9884-d9eb438bc30d)

Probably, this tiny fix also needs to be imported into SDL3 development branch.