### PR TITLE
SDL_render_psp.c: Fix crash in PSP_DestroyRenderer()

### DIFF
--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -1261,8 +1261,6 @@ static void PSP_DestroyRenderer(SDL_Renderer *renderer)
             return;
         }
 
-        StartDrawing(renderer);
-
         sceKernelDisableSubIntr(PSP_VBLANK_INT, 0);
         sceKernelReleaseSubIntrHandler(PSP_VBLANK_INT, 0);
         sceDisplayWaitVblankStart();


### PR DESCRIPTION
I fixed a crash being caused by `SDL_DestroyRenderer()` on PSP.

## Description
- I removed a call to `StartDrawing()` in in `PSP_DestroyRenderer()` because it was causing a crash. I've attached an image of the backtrace in GDB, but I don't know much else. It looks like `psp_texture` is becomes a null pointer
 and becomes dereferenced in the function `TextureBindAsTarget()`.

## Existing Issue(s)
- N/A

![Screenshot_20240603_172640](https://github.com/libsdl-org/SDL/assets/6947463/a003d38e-ba73-45ed-b3bb-8a05bacc2450)