### PR TITLE
Replaced SDL_GetRendererInfo() with SDL_GetRendererName()

### DIFF
--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -1143,6 +1143,8 @@ SDL_CreateRenderer()'s flags parameter has been removed. See specific flags belo
 
 SDL_CreateWindowAndRenderer() now takes the window title as the first parameter.
 
+SDL_GetRendererInfo() has been removed, the name of a renderer can be retrieved using SDL_GetRendererName(), and the other information is available as properties on the renderer.
+
 Mouse and touch events are no longer filtered to change their coordinates, instead you
 can call SDL_ConvertEventToRenderCoordinates() to explicitly map event coordinates into
 the rendering viewport.

--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -71,18 +71,6 @@ extern "C" {
 #define SDL_SOFTWARE_RENDERER   "software"
 
 /**
- * Information on the capabilities of a render driver or context.
- *
- * \since This struct is available since SDL 3.0.0.
- */
-typedef struct SDL_RendererInfo
-{
-    const char *name;           /**< The name of the renderer */
-    int num_texture_formats;    /**< The number of available texture formats */
-    const SDL_PixelFormatEnum *texture_formats; /**< The available texture formats */
-} SDL_RendererInfo;
-
-/**
  * Vertex structure.
  *
  * \since This struct is available since SDL 3.0.0.
@@ -225,7 +213,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_CreateWindowAndRenderer(const char *title, i
  * \sa SDL_DestroyRenderer
  * \sa SDL_GetNumRenderDrivers
  * \sa SDL_GetRenderDriver
- * \sa SDL_GetRendererInfo
+ * \sa SDL_GetRendererName
  */
 extern SDL_DECLSPEC SDL_Renderer * SDLCALL SDL_CreateRenderer(SDL_Window *window, const char *name);
 
@@ -276,7 +264,7 @@ extern SDL_DECLSPEC SDL_Renderer * SDLCALL SDL_CreateRenderer(SDL_Window *window
  * \sa SDL_CreateRenderer
  * \sa SDL_CreateSoftwareRenderer
  * \sa SDL_DestroyRenderer
- * \sa SDL_GetRendererInfo
+ * \sa SDL_GetRendererName
  */
 extern SDL_DECLSPEC SDL_Renderer * SDLCALL SDL_CreateRendererWithProperties(SDL_PropertiesID props);
 
@@ -334,20 +322,19 @@ extern SDL_DECLSPEC SDL_Renderer *SDLCALL SDL_GetRenderer(SDL_Window *window);
 extern SDL_DECLSPEC SDL_Window *SDLCALL SDL_GetRenderWindow(SDL_Renderer *renderer);
 
 /**
- * Get information about a rendering context.
+ * Get the name of a renderer.
+ *
+ * The returned string follows the SDL_GetStringRule.
  *
  * \param renderer the rendering context
- * \param info an SDL_RendererInfo structure filled with information about the
- *             current renderer
- * \returns 0 on success or a negative error code on failure; call
- *          SDL_GetError() for more information.
+ * \returns the name of the selected renderer, or NULL if the renderer is invalid.
  *
  * \since This function is available since SDL 3.0.0.
  *
  * \sa SDL_CreateRenderer
  * \sa SDL_CreateRendererWithProperties
  */
-extern SDL_DECLSPEC int SDLCALL SDL_GetRendererInfo(SDL_Renderer *renderer, SDL_RendererInfo *info);
+extern SDL_DECLSPEC const char *SDLCALL SDL_GetRendererName(SDL_Renderer *renderer);
 
 /**
  * Get the properties associated with a renderer.
@@ -362,6 +349,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetRendererInfo(SDL_Renderer *renderer, SDL_
  * - `SDL_PROP_RENDERER_VSYNC_NUMBER`: the current vsync setting
  * - `SDL_PROP_RENDERER_MAX_TEXTURE_SIZE_NUMBER`: the maximum texture width
  *   and height
+ * - `SDL_PROP_RENDERER_TEXTURE_FORMATS_POINTER`: a (const SDL_PixelFormatEnum *) array of pixel formats, terminated with SDL_PIXELFORMAT_UNKNOWN, representing the available texture formats for this renderer.
  * - `SDL_PROP_RENDERER_OUTPUT_COLORSPACE_NUMBER`: an SDL_ColorSpace value
  *   describing the colorspace for output to the display, defaults to
  *   SDL_COLORSPACE_SRGB.
@@ -433,6 +421,7 @@ extern SDL_DECLSPEC SDL_PropertiesID SDLCALL SDL_GetRendererProperties(SDL_Rende
 #define SDL_PROP_RENDERER_SURFACE_POINTER                           "SDL.renderer.surface"
 #define SDL_PROP_RENDERER_VSYNC_NUMBER                              "SDL.renderer.vsync"
 #define SDL_PROP_RENDERER_MAX_TEXTURE_SIZE_NUMBER                   "SDL.renderer.max_texture_size"
+#define SDL_PROP_RENDERER_TEXTURE_FORMATS_POINTER                   "SDL.renderer.texture_formats"
 #define SDL_PROP_RENDERER_OUTPUT_COLORSPACE_NUMBER                  "SDL.renderer.output_colorspace"
 #define SDL_PROP_RENDERER_HDR_ENABLED_BOOLEAN                       "SDL.renderer.HDR_enabled"
 #define SDL_PROP_RENDERER_SDR_WHITE_POINT_FLOAT                     "SDL.renderer.SDR_white_point"

--- a/src/core/winrt/SDL_winrtapp_direct3d.cpp
+++ b/src/core/winrt/SDL_winrtapp_direct3d.cpp
@@ -137,7 +137,7 @@ static void WINRT_ProcessWindowSizeChange() // TODO: Pass an SDL_Window-identify
             }
 #endif
 
-            const Uint32 latestFlags = WINRT_DetectWindowFlags(window);
+            const SDL_WindowFlags latestFlags = WINRT_DetectWindowFlags(window);
             if (latestFlags & SDL_WINDOW_MAXIMIZED) {
                 SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_MAXIMIZED, 0, 0);
             } else {
@@ -479,7 +479,7 @@ void SDL_WinRTApp::OnVisibilityChanged(CoreWindow ^ sender, VisibilityChangedEve
     m_windowVisible = args->Visible;
     if (WINRT_GlobalSDLWindow) {
         SDL_bool wasSDLWindowSurfaceValid = WINRT_GlobalSDLWindow->surface_valid;
-        Uint32 latestWindowFlags = WINRT_DetectWindowFlags(WINRT_GlobalSDLWindow);
+        SDL_WindowFlags latestWindowFlags = WINRT_DetectWindowFlags(WINRT_GlobalSDLWindow);
         if (args->Visible) {
             SDL_SendWindowEvent(WINRT_GlobalSDLWindow, SDL_EVENT_WINDOW_SHOWN, 0, 0);
             SDL_SendWindowEvent(WINRT_GlobalSDLWindow, SDL_EVENT_WINDOW_FOCUS_GAINED, 0, 0);
@@ -612,7 +612,7 @@ void SDL_WinRTApp::OnSuspending(Platform::Object ^ sender, SuspendingEventArgs ^
 #if SDL_VIDEO_RENDER_D3D11
         if (WINRT_GlobalSDLWindow) {
             SDL_Renderer *renderer = SDL_GetRenderer(WINRT_GlobalSDLWindow);
-            if (renderer && (SDL_strcmp(renderer->info.name, "direct3d11") == 0)) {
+            if (renderer && (SDL_strcmp(renderer->name, "direct3d11") == 0)) {
                 D3D11_Trim(renderer);
             }
         }

--- a/src/dynapi/SDL_dynapi.sym
+++ b/src/dynapi/SDL_dynapi.sym
@@ -402,7 +402,7 @@ SDL3_0.0.0 {
     SDL_GetRenderWindow;
     SDL_GetRenderer;
     SDL_GetRendererFromTexture;
-    SDL_GetRendererInfo;
+    SDL_GetRendererName;
     SDL_GetRendererProperties;
     SDL_GetRevision;
     SDL_GetSIMDAlignment;

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -427,7 +427,7 @@
 #define SDL_GetRenderWindow SDL_GetRenderWindow_REAL
 #define SDL_GetRenderer SDL_GetRenderer_REAL
 #define SDL_GetRendererFromTexture SDL_GetRendererFromTexture_REAL
-#define SDL_GetRendererInfo SDL_GetRendererInfo_REAL
+#define SDL_GetRendererName SDL_GetRendererName_REAL
 #define SDL_GetRendererProperties SDL_GetRendererProperties_REAL
 #define SDL_GetRevision SDL_GetRevision_REAL
 #define SDL_GetSIMDAlignment SDL_GetSIMDAlignment_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -447,7 +447,7 @@ SDL_DYNAPI_PROC(int,SDL_GetRenderViewport,(SDL_Renderer *a, SDL_Rect *b),(a,b),r
 SDL_DYNAPI_PROC(SDL_Window*,SDL_GetRenderWindow,(SDL_Renderer *a),(a),return)
 SDL_DYNAPI_PROC(SDL_Renderer*,SDL_GetRenderer,(SDL_Window *a),(a),return)
 SDL_DYNAPI_PROC(SDL_Renderer*,SDL_GetRendererFromTexture,(SDL_Texture *a),(a),return)
-SDL_DYNAPI_PROC(int,SDL_GetRendererInfo,(SDL_Renderer *a, SDL_RendererInfo *b),(a,b),return)
+SDL_DYNAPI_PROC(const char *,SDL_GetRendererName,(SDL_Renderer *a),(a),return)
 SDL_DYNAPI_PROC(SDL_PropertiesID,SDL_GetRendererProperties,(SDL_Renderer *a),(a),return)
 SDL_DYNAPI_PROC(const char*,SDL_GetRevision,(void),(),return)
 SDL_DYNAPI_PROC(size_t,SDL_GetSIMDAlignment,(void),(),return)

--- a/src/render/SDL_sysrender.h
+++ b/src/render/SDL_sysrender.h
@@ -214,7 +214,9 @@ struct SDL_Renderer
     int (*AddVulkanRenderSemaphores)(SDL_Renderer *renderer, Uint32 wait_stage_mask, Sint64 wait_semaphore, Sint64 signal_semaphore);
 
     /* The current renderer info */
-    SDL_RendererInfo info;
+    const char *name;
+    SDL_PixelFormatEnum *texture_formats;
+    int num_texture_formats;
     SDL_bool software;
 
     /* The window associated with the renderer */

--- a/src/render/direct3d/SDL_render_d3d.c
+++ b/src/render/direct3d/SDL_render_d3d.c
@@ -1645,7 +1645,7 @@ int D3D_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_Propertie
     renderer->driverdata = data;
     D3D_InvalidateCachedState(renderer);
 
-    renderer->info.name = D3D_RenderDriver.name;
+    renderer->name = D3D_RenderDriver.name;
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_ARGB8888);
 
     SDL_GetWindowSizeInPixels(window, &w, &h);

--- a/src/render/direct3d11/SDL_render_d3d11.c
+++ b/src/render/direct3d11/SDL_render_d3d11.c
@@ -2820,7 +2820,7 @@ static int D3D11_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_
     renderer->driverdata = data;
     D3D11_InvalidateCachedState(renderer);
 
-    renderer->info.name = D3D11_RenderDriver.name;
+    renderer->name = D3D11_RenderDriver.name;
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_ARGB8888);
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_XRGB8888);
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_XBGR2101010);

--- a/src/render/direct3d12/SDL_render_d3d12.c
+++ b/src/render/direct3d12/SDL_render_d3d12.c
@@ -3274,7 +3274,7 @@ int D3D12_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_Propert
     renderer->driverdata = data;
     D3D12_InvalidateCachedState(renderer);
 
-    renderer->info.name = D3D12_RenderDriver.name;
+    renderer->name = D3D12_RenderDriver.name;
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_ARGB8888);
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_XRGB8888);
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_XBGR2101010);

--- a/src/render/metal/SDL_render_metal.m
+++ b/src/render/metal/SDL_render_metal.m
@@ -2147,7 +2147,7 @@ static int METAL_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_
         renderer->GetMetalLayer = METAL_GetMetalLayer;
         renderer->GetMetalCommandEncoder = METAL_GetMetalCommandEncoder;
 
-        renderer->info.name = METAL_RenderDriver.name;
+        renderer->name = METAL_RenderDriver.name;
         SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_ARGB8888);
         SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_ABGR8888);
         SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_XBGR2101010);

--- a/src/render/opengl/SDL_render_gl.c
+++ b/src/render/opengl/SDL_render_gl.c
@@ -1675,7 +1675,7 @@ static int GL_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_Pro
     GL_InvalidateCachedState(renderer);
     renderer->window = window;
 
-    renderer->info.name = GL_RenderDriver.name;
+    renderer->name = GL_RenderDriver.name;
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_ARGB8888);
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_ABGR8888);
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_XRGB8888);

--- a/src/render/opengles2/SDL_render_gles2.c
+++ b/src/render/opengles2/SDL_render_gles2.c
@@ -2095,7 +2095,7 @@ static int GLES2_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_
     GLES2_InvalidateCachedState(renderer);
     renderer->window = window;
 
-    renderer->info.name = GLES2_RenderDriver.name;
+    renderer->name = GLES2_RenderDriver.name;
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_RGBA32);
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_BGRA32);
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_BGRX32);

--- a/src/render/ps2/SDL_render_ps2.c
+++ b/src/render/ps2/SDL_render_ps2.c
@@ -699,7 +699,7 @@ static int PS2_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_Pr
     PS2_InvalidateCachedState(renderer);
     renderer->window = window;
 
-    renderer->info.name = PS2_RenderDriver.name;
+    renderer->name = PS2_RenderDriver.name;
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_ABGR1555);
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_ABGR8888);
     SDL_SetNumberProperty(SDL_GetRendererProperties(renderer), SDL_PROP_RENDERER_MAX_TEXTURE_SIZE_NUMBER, 1024);

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -1326,7 +1326,7 @@ static int PSP_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_Pr
     PSP_InvalidateCachedState(renderer);
     renderer->window = window;
 
-    renderer->info.name = PSP_RenderDriver.name;
+    renderer->name = PSP_RenderDriver.name;
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_BGR565);
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_ABGR1555);
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_ABGR4444);

--- a/src/render/software/SDL_render_sw.c
+++ b/src/render/software/SDL_render_sw.c
@@ -1158,7 +1158,7 @@ int SW_CreateRendererForSurface(SDL_Renderer *renderer, SDL_Surface *surface, SD
     renderer->driverdata = data;
     SW_InvalidateCachedState(renderer);
 
-    renderer->info.name = SW_RenderDriver.name;
+    renderer->name = SW_RenderDriver.name;
 
     SW_SelectBestFormats(renderer, surface->format->format);
 

--- a/src/render/vitagxm/SDL_render_vita_gxm.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm.c
@@ -235,7 +235,7 @@ static int VITA_GXM_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, S
     VITA_GXM_InvalidateCachedState(renderer);
     renderer->window = window;
 
-    renderer->info.name = VITA_GXM_RenderDriver.name;
+    renderer->name = VITA_GXM_RenderDriver.name;
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_ABGR8888);
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_ARGB8888);
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_RGB565);

--- a/src/render/vulkan/SDL_render_vulkan.c
+++ b/src/render/vulkan/SDL_render_vulkan.c
@@ -4101,7 +4101,7 @@ static int VULKAN_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL
     renderer->driverdata = rendererData;
     VULKAN_InvalidateCachedState(renderer);
 
-    renderer->info.name = VULKAN_RenderDriver.name;
+    renderer->name = VULKAN_RenderDriver.name;
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_ARGB8888);
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_XRGB8888);
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_XBGR2101010);

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1034,24 +1034,28 @@ static void SDLTest_PrintScaleMode(char *text, size_t maxlen, SDL_ScaleMode scal
 
 static void SDLTest_PrintRenderer(SDL_Renderer *renderer)
 {
-    SDL_RendererInfo info;
+    const char *name;
     int i;
     char text[1024];
     int max_texture_size;
+    const SDL_PixelFormatEnum *texture_formats;
 
-    SDL_GetRendererInfo(renderer, &info);
+    name = SDL_GetRendererName(renderer);
 
-    SDL_Log("  Renderer %s:\n", info.name);
+    SDL_Log("  Renderer %s:\n", name);
     SDL_Log("    VSync: %d\n", (int)SDL_GetNumberProperty(SDL_GetRendererProperties(renderer), SDL_PROP_RENDERER_VSYNC_NUMBER, 0));
 
-    (void)SDL_snprintf(text, sizeof(text), "    Texture formats (%d): ", info.num_texture_formats);
-    for (i = 0; i < info.num_texture_formats; ++i) {
-        if (i > 0) {
-            SDL_snprintfcat(text, sizeof(text), ", ");
+    texture_formats = (const SDL_PixelFormatEnum *)SDL_GetProperty(SDL_GetRendererProperties(renderer), SDL_PROP_RENDERER_TEXTURE_FORMATS_POINTER, NULL);
+    if (texture_formats) {
+        (void)SDL_snprintf(text, sizeof(text), "    Texture formats: ");
+        for (i = 0; texture_formats[i]; ++i) {
+            if (i > 0) {
+                SDL_snprintfcat(text, sizeof(text), ", ");
+            }
+            SDLTest_PrintPixelFormat(text, sizeof(text), texture_formats[i]);
         }
-        SDLTest_PrintPixelFormat(text, sizeof(text), info.texture_formats[i]);
+        SDL_Log("%s\n", text);
     }
-    SDL_Log("%s\n", text);
 
     max_texture_size = (int)SDL_GetNumberProperty(SDL_GetRendererProperties(renderer), SDL_PROP_RENDERER_MAX_TEXTURE_SIZE_NUMBER, 0);
     if (max_texture_size) {
@@ -2511,7 +2515,7 @@ void SDLTest_CommonDrawWindowInfo(SDL_Renderer *renderer, SDL_Window *window, fl
     float scaleX, scaleY;
     SDL_MouseButtonFlags flags;
     SDL_DisplayID windowDisplayID = SDL_GetDisplayForWindow(window);
-    SDL_RendererInfo info;
+    const char *name;
     SDL_RendererLogicalPresentation logical_presentation;
     SDL_ScaleMode logical_scale_mode;
 
@@ -2535,11 +2539,10 @@ void SDLTest_CommonDrawWindowInfo(SDL_Renderer *renderer, SDL_Window *window, fl
 
     SDL_SetRenderDrawColor(renderer, 170, 170, 170, 255);
 
-    if (0 == SDL_GetRendererInfo(renderer, &info)) {
-        (void)SDL_snprintf(text, sizeof(text), "SDL_GetRendererInfo: name: %s", info.name);
-        SDLTest_DrawString(renderer, 0.0f, textY, text);
-        textY += lineHeight;
-    }
+    name = SDL_GetRendererName(renderer);
+    (void)SDL_snprintf(text, sizeof(text), "SDL_GetRendererName: %s", name);
+    SDLTest_DrawString(renderer, 0.0f, textY, text);
+    textY += lineHeight;
 
     if (0 == SDL_GetRenderOutputSize(renderer, &w, &h)) {
         (void)SDL_snprintf(text, sizeof(text), "SDL_GetRenderOutputSize: %dx%d", w, h);

--- a/test/testcolorspace.c
+++ b/test/testcolorspace.c
@@ -76,7 +76,6 @@ static void UpdateHDRState(void)
 static void CreateRenderer(void)
 {
     SDL_PropertiesID props;
-    SDL_RendererInfo info;
 
     props = SDL_CreateProperties();
     SDL_SetProperty(props, SDL_PROP_RENDERER_CREATE_WINDOW_POINTER, window);
@@ -89,9 +88,8 @@ static void CreateRenderer(void)
         return;
     }
 
-    SDL_GetRendererInfo(renderer, &info);
-    SDL_Log("Created renderer %s\n", info.name);
-    renderer_name = info.name;
+    renderer_name = SDL_GetRendererName(renderer);
+    SDL_Log("Created renderer %s\n", renderer_name);
 
     UpdateHDRState();
 }

--- a/test/testffmpeg.c
+++ b/test/testffmpeg.c
@@ -111,7 +111,6 @@ static SDL_bool verbose;
 static SDL_bool CreateWindowAndRenderer(SDL_WindowFlags window_flags, const char *driver)
 {
     SDL_PropertiesID props;
-    SDL_RendererInfo info;
     SDL_bool useOpenGL = (driver && (SDL_strcmp(driver, "opengl") == 0 || SDL_strcmp(driver, "opengles2") == 0));
     SDL_bool useEGL = (driver && SDL_strcmp(driver, "opengles2") == 0);
     SDL_bool useVulkan = (driver && SDL_strcmp(driver, "vulkan") == 0);
@@ -177,9 +176,7 @@ static SDL_bool CreateWindowAndRenderer(SDL_WindowFlags window_flags, const char
         return SDL_FALSE;
     }
 
-    if (SDL_GetRendererInfo(renderer, &info) == 0) {
-        SDL_Log("Created renderer %s\n", info.name);
-    }
+    SDL_Log("Created renderer %s\n", SDL_GetRendererName(renderer));
 
 #ifdef HAVE_EGL
     if (useEGL) {


### PR DESCRIPTION
The texture formats are available via the SDL_PROP_RENDERER_TEXTURE_FORMATS_POINTER property

Fixes https://github.com/libsdl-org/SDL/issues/9851
