### PR TITLE
renderer: Mark an already-destroyed renderer as freed

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -4595,8 +4595,8 @@ void SDL_DestroyRenderer(SDL_Renderer *renderer)
     // in either order.
     if (!renderer->destroyed) {
         SDL_DestroyRendererWithoutFreeing(renderer);
-        SDL_SetObjectValid(renderer, SDL_OBJECT_TYPE_RENDERER, SDL_FALSE);  // It's no longer magical...
     }
+    SDL_SetObjectValid(renderer, SDL_OBJECT_TYPE_RENDERER, SDL_FALSE);  // It's no longer magical...
 
     SDL_free(renderer->texture_formats);
     SDL_free(renderer);


### PR DESCRIPTION
It's possible to destroy an SDL_Renderer without freeing it using SDL_DestroyRendererWithoutFreeing(), which is used to make it possible to destroy windows and their renderers in either order. However, if a renderer has already been destroyed before it is freed (e.g., the window was destroyed before the renderer), the object is never marked invalid. This means the SDL_Renderer is reported as leaked, even if SDL_DestroyRenderer() is called.

SDL_GetWindowSurface() will trigger this, as the window texture is cleaned up _after_ the window destroys its associated renderer. This makes it impossible to use SDL_FRAMEBUFFER_ACCELERATION without triggering a leak warning.

Fix this by unconditionally marking the SDL_Renderer object as invalid in SDL_DestroyRenderer().