### PR TITLE
Fix memory leak in SDL_IOFromFile()

### DIFF
--- a/src/file/SDL_iostream.c
+++ b/src/file/SDL_iostream.c
@@ -600,7 +600,7 @@ SDL_IOStream *SDL_IOFromFile(const char *file, const char *mode)
 
     void *iodata = NULL;
     if (Android_JNI_FileOpen(&iodata, file, mode) < 0) {
-        SDL_CloseIO(iostr);
+        Android_JNI_FileClose(iodata);
         return NULL;
     }
 
@@ -629,7 +629,7 @@ SDL_IOStream *SDL_IOFromFile(const char *file, const char *mode)
     }
 
     if (windows_file_open(iodata, file, mode) < 0) {
-        SDL_CloseIO(iostr);
+        windows_file_close(iodata);
         return NULL;
     }
 


### PR DESCRIPTION
## Description

If `Android_JNI_FileOpen()` or `windows_file_open()` fail, `SDL_CloseIO(iostr)` does nothing because `iostr` is NULL and `iodata` is leaked.

## Existing Issue(s)
None
