### PR TITLE
PSP: Add on-screen keyboard support

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -567,7 +567,7 @@ int SDL_VideoInit(const char *driver_name)
         SDL_DisableScreenSaver();
     }
 
-#if !defined(SDL_VIDEO_DRIVER_N3DS)
+#if !defined(SDL_VIDEO_DRIVER_N3DS) && !defined(SDL_VIDEO_DRIVER_PSP)
     /* In the initial state we don't want to pop up an on-screen keyboard,
      * but we do want to allow text input from other mechanisms.
      */
@@ -581,7 +581,7 @@ int SDL_VideoInit(const char *driver_name)
             SDL_SetHint(SDL_HINT_ENABLE_SCREEN_KEYBOARD, NULL);
         }
     }
-#endif /* !SDL_VIDEO_DRIVER_N3DS */
+#endif /* !SDL_VIDEO_DRIVER_N3DS && !SDL_VIDEO_DRIVER_PSP */
 
     SDL_MousePostInit();
 

--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -39,6 +39,9 @@
 #include "SDL_pspvideo.h"
 #include "SDL_pspevents_c.h"
 #include "SDL_pspgl_c.h"
+#include <psputility.h>
+#include <pspgu.h>
+#include <pspdisplay.h>
 #include "../../render/psp/SDL_render_psp.h"
 
 #define SDL_WINDOWTEXTUREDATA "_SDL_WindowTextureData"
@@ -402,13 +405,79 @@ SDL_bool PSP_GetWindowWMInfo(_THIS, SDL_Window * window, struct SDL_SysWMinfo *i
 #endif
 
 
-/* TO Write Me */
-SDL_bool PSP_HasScreenKeyboardSupport(_THIS)
+
+SDL_bool PSP_HasScreenKeyboardSupport(SDL_VideoDevice *_this)
 {
-    return SDL_FALSE;
+    return SDL_TRUE;
 }
-void PSP_ShowScreenKeyboard(_THIS, SDL_Window *window)
+
+void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window)
 {
+    char list[0x20000] __attribute__((aligned(64)));  // Needed for sceGuStart to work
+    int i;
+    int done = 0;
+    int input_text_length = 32; // SDL_SendKeyboardText supports up to 32 characters per event
+    unsigned short outtext[input_text_length];
+    char text_string[input_text_length];
+
+    SceUtilityOskData data;
+    SceUtilityOskParams params;
+
+    SDL_memset(outtext, 0, input_text_length * sizeof(unsigned short));
+
+    data.language = PSP_UTILITY_OSK_LANGUAGE_DEFAULT;
+    data.lines = 1;
+    data.unk_24 = 1;
+    data.inputtype = PSP_UTILITY_OSK_INPUTTYPE_ALL;
+    data.desc = NULL;
+    data.intext = NULL;
+    data.outtextlength = input_text_length;
+    data.outtextlimit = input_text_length;
+    data.outtext = outtext;
+
+    params.base.size = sizeof(params);
+    sceUtilityGetSystemParamInt(PSP_SYSTEMPARAM_ID_INT_LANGUAGE, &params.base.language);
+    sceUtilityGetSystemParamInt(PSP_SYSTEMPARAM_ID_INT_UNKNOWN, &params.base.buttonSwap);
+    params.base.graphicsThread = 17;
+    params.base.accessThread = 19;
+    params.base.fontThread = 18;
+    params.base.soundThread = 16;
+    params.datacount = 1;
+    params.data = &data;
+
+    sceUtilityOskInitStart(&params);
+
+    while(!done) {
+        sceGuStart(GU_DIRECT, list);
+        sceGuClearColor(0);
+        sceGuClearDepth(0);
+        sceGuClear(GU_COLOR_BUFFER_BIT|GU_DEPTH_BUFFER_BIT);
+        sceGuFinish();
+        sceGuSync(0,0);
+
+        switch(sceUtilityOskGetStatus())
+        {
+            case PSP_UTILITY_DIALOG_VISIBLE:
+                sceUtilityOskUpdate(1);
+                break;
+            case PSP_UTILITY_DIALOG_QUIT:
+                sceUtilityOskShutdownStart();
+                break;
+            case PSP_UTILITY_DIALOG_NONE:
+                done = 1;
+                break;
+            default :
+                break;
+        }
+        sceDisplayWaitVblankStart();
+        sceGuSwapBuffers();
+    }
+
+    // Convert input list to string
+    for (i = 0; i < input_text_length; i++) {
+        text_string[i] = outtext[i];
+    }
+    SDL_SendKeyboardText((const char *) text_string);
 }
 void PSP_HideScreenKeyboard(_THIS, SDL_Window *window)
 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This adds support for the integrated on screen keyboard for the Playstation Portable in SDL2.

## Description
<!--- Describe your changes in detail -->
This is a little bit more disruptive than is normally expected for OSKs in SDL, since it locks up the main thread. I was not able to make it work in another way unfortunately, but it works quite well. Not sure how it affect playing music or sounds.

Once we have this merged, I can port it up to SDL3 as well.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
