### PR TITLE
SDL_render_psp.c: Fix crash in PSP_DestroyRenderer()

### DIFF
--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -1287,8 +1287,6 @@ static void PSP_DestroyRenderer(SDL_Renderer *renderer)
             return;
         }
 
-        StartDrawing(renderer);
-
         sceKernelDisableSubIntr(PSP_VBLANK_INT, 0);
         sceKernelReleaseSubIntrHandler(PSP_VBLANK_INT, 0);
         sceDisplayWaitVblankStart();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This backports the fix for a crash that can happen when running `SDL_DestroyRenderer()` on the Playstation Portable found here to SDL2: https://github.com/libsdl-org/SDL/pull/9961

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
