### PR TITLE
camera: Fix corrupted CoreMedia input

### DIFF
--- a/src/camera/coremedia/SDL_camera_coremedia.m
+++ b/src/camera/coremedia/SDL_camera_coremedia.m
@@ -308,6 +308,8 @@ static int COREMEDIA_OpenDevice(SDL_CameraDevice *device, const SDL_CameraSpec *
         return SDL_SetError("Cannot create AVCaptureVideoDataOutput");
     }
 
+    output.videoSettings = @{};
+
     char threadname[64];
     SDL_GetCameraThreadName(device, threadname, sizeof (threadname));
     dispatch_queue_t queue = dispatch_queue_create(threadname, NULL);


### PR DESCRIPTION
Before:

![image](https://github.com/libsdl-org/SDL/assets/91440203/3fa97fe4-4f22-4462-8333-85c8d21146d2)

After

![image](https://github.com/libsdl-org/SDL/assets/91440203/15c54c12-34b2-451d-ab24-f143cbf1fe70)


## Description

`AVCaptureVideoDataOutput.videoSettings` should be initialized to zero to receive frames matching the device format. On my setup this was defaulting to `2vuy`, which broke testcamera because it was expecting the same format as the capture device (`420v`).

See: https://developer.apple.com/documentation/avfoundation/avcapturevideodataoutput/1389945-videosettings?language=objc

I also added a parameter to select a specific camera by name with running testcamera.

All the cameras I could find output NV12 frames so I wasn't able to test with other pixel formats.

## Existing Issue(s)

Noticed here: https://github.com/libsdl-org/SDL/issues/9930#issuecomment-2141060439




