### PR TITLE
wayland: Set the initial min/max limits on non-libdecor windows durin…

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -1379,6 +1379,8 @@ void Wayland_ShowWindow(_THIS, SDL_Window *window)
             data->shell_surface.xdg.roleobj.toplevel = xdg_surface_get_toplevel(data->shell_surface.xdg.surface);
             xdg_toplevel_set_app_id(data->shell_surface.xdg.roleobj.toplevel, c->classname);
             xdg_toplevel_add_listener(data->shell_surface.xdg.roleobj.toplevel, &toplevel_listener_xdg, data);
+
+            SetMinMaxDimensions(window, SDL_FALSE);
         }
     }
 


### PR DESCRIPTION
…g a show operation

Libdecor windows will have this done during the first frame configure, but bare xdg-toplevel windows need it set explicitly, or a non-resizable window might be able to be resized.

Fixes #9982
