### PR TITLE
Filter Android drivers according to SDL_***_DISABLED macros to help reduce APK size

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -37,6 +37,7 @@ LOCAL_SRC_FILES := \
 	$(wildcard $(LOCAL_PATH)/src/file/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/haptic/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/haptic/android/*.c) \
+	$(wildcard $(LOCAL_PATH)/src/haptic/dummy/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/hidapi/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/hidapi/android/*.cpp) \
 	$(wildcard $(LOCAL_PATH)/src/joystick/*.c) \
@@ -58,6 +59,7 @@ LOCAL_SRC_FILES := \
 	$(wildcard $(LOCAL_PATH)/src/filesystem/posix/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/sensor/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/sensor/android/*.c) \
+	$(wildcard $(LOCAL_PATH)/src/sensor/dummy/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/render/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/render/*/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/stdlib/*.c) \

--- a/include/build_config/SDL_build_config_android.h
+++ b/include/build_config/SDL_build_config_android.h
@@ -140,19 +140,26 @@
 #define HAVE_CLOCK_GETTIME  1
 
 /* Enable various audio drivers */
+#ifndef SDL_AUDIO_DISABLED
 #define SDL_AUDIO_DRIVER_ANDROID    1
 #define SDL_AUDIO_DRIVER_OPENSLES   1
 #define SDL_AUDIO_DRIVER_AAUDIO     1
-#define SDL_AUDIO_DRIVER_DUMMY  1
+#endif /* SDL_AUDIO_DISABLED */
 
 /* Enable various input drivers */
+#ifndef SDL_JOYSTICK_DISABLED
 #define SDL_JOYSTICK_ANDROID    1
 #define SDL_JOYSTICK_HIDAPI     1
 #define SDL_JOYSTICK_VIRTUAL    1
+#endif /* SDL_JOYSTICK_DISABLED */
+#ifndef SDL_HAPTIC_DISABLED
 #define SDL_HAPTIC_ANDROID  1
+#endif /* SDL_HAPTIC_DISABLED */
 
 /* Enable sensor driver */
+#ifndef SDL_SENSOR_DISABLED
 #define SDL_SENSOR_ANDROID  1
+#endif /* SDL_SENSOR_DISABLED */
 
 /* Enable various shared object loading systems */
 #define SDL_LOADSO_DLOPEN   1
@@ -192,8 +199,9 @@
 #define SDL_FSOPS_POSIX 1
 
 /* Enable the camera driver */
+#ifndef SDL_CAMERA_DISABLED
 #define SDL_CAMERA_DRIVER_ANDROID 1
-#define SDL_CAMERA_DRIVER_DUMMY 1
+#endif /* SDL_CAMERA_DISABLED */
 
 /* Enable nl_langinfo and high-res file times on version 26 and higher. */
 #if __ANDROID_API__ >= 26

--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -1041,7 +1041,11 @@ JNIEXPORT jint JNICALL SDL_JAVA_CONTROLLER_INTERFACE(onNativePadDown)(
     JNIEnv *env, jclass jcls,
     jint device_id, jint keycode)
 {
+#ifdef SDL_JOYSTICK_ANDROID
     return Android_OnPadDown(device_id, keycode);
+#else
+    return -1;
+#endif /* SDL_JOYSTICK_ANDROID */
 }
 
 /* Padup */
@@ -1049,7 +1053,11 @@ JNIEXPORT jint JNICALL SDL_JAVA_CONTROLLER_INTERFACE(onNativePadUp)(
     JNIEnv *env, jclass jcls,
     jint device_id, jint keycode)
 {
+#ifdef SDL_JOYSTICK_ANDROID
     return Android_OnPadUp(device_id, keycode);
+#else
+    return -1;
+#endif /* SDL_JOYSTICK_ANDROID */
 }
 
 /* Joy */
@@ -1057,7 +1065,9 @@ JNIEXPORT void JNICALL SDL_JAVA_CONTROLLER_INTERFACE(onNativeJoy)(
     JNIEnv *env, jclass jcls,
     jint device_id, jint axis, jfloat value)
 {
+#ifdef SDL_JOYSTICK_ANDROID
     Android_OnJoy(device_id, axis, value);
+#endif /* SDL_JOYSTICK_ANDROID */
 }
 
 /* POV Hat */
@@ -1065,7 +1075,9 @@ JNIEXPORT void JNICALL SDL_JAVA_CONTROLLER_INTERFACE(onNativeHat)(
     JNIEnv *env, jclass jcls,
     jint device_id, jint hat_id, jint x, jint y)
 {
+#ifdef SDL_JOYSTICK_ANDROID
     Android_OnHat(device_id, hat_id, x, y);
+#endif /* SDL_JOYSTICK_ANDROID */
 }
 
 JNIEXPORT jint JNICALL SDL_JAVA_CONTROLLER_INTERFACE(nativeAddJoystick)(
@@ -1075,6 +1087,7 @@ JNIEXPORT jint JNICALL SDL_JAVA_CONTROLLER_INTERFACE(nativeAddJoystick)(
     jint button_mask, jint naxes, jint axis_mask, jint nhats, jboolean can_rumble)
 {
     int retval;
+#ifdef SDL_JOYSTICK_ANDROID
     const char *name = (*env)->GetStringUTFChars(env, device_name, NULL);
     const char *desc = (*env)->GetStringUTFChars(env, device_desc, NULL);
 
@@ -1082,7 +1095,9 @@ JNIEXPORT jint JNICALL SDL_JAVA_CONTROLLER_INTERFACE(nativeAddJoystick)(
 
     (*env)->ReleaseStringUTFChars(env, device_name, name);
     (*env)->ReleaseStringUTFChars(env, device_desc, desc);
-
+#else
+    retval = -1;
+#endif /* SDL_JOYSTICK_ANDROID */
     return retval;
 }
 
@@ -1090,26 +1105,37 @@ JNIEXPORT jint JNICALL SDL_JAVA_CONTROLLER_INTERFACE(nativeRemoveJoystick)(
     JNIEnv *env, jclass jcls,
     jint device_id)
 {
+#ifdef SDL_JOYSTICK_ANDROID
     return Android_RemoveJoystick(device_id);
+#else
+    return -1;
+#endif /* SDL_JOYSTICK_ANDROID */
 }
 
 JNIEXPORT jint JNICALL SDL_JAVA_CONTROLLER_INTERFACE(nativeAddHaptic)(
     JNIEnv *env, jclass jcls, jint device_id, jstring device_name)
 {
     int retval;
+#ifdef SDL_HAPTIC_ANDROID
     const char *name = (*env)->GetStringUTFChars(env, device_name, NULL);
 
     retval = Android_AddHaptic(device_id, name);
 
     (*env)->ReleaseStringUTFChars(env, device_name, name);
-
+#else
+    retval = -1;
+#endif /* SDL_HAPTIC_ANDROID */
     return retval;
 }
 
 JNIEXPORT jint JNICALL SDL_JAVA_CONTROLLER_INTERFACE(nativeRemoveHaptic)(
     JNIEnv *env, jclass jcls, jint device_id)
 {
+#ifdef SDL_HAPTIC_ANDROID
     return Android_RemoveHaptic(device_id);
+#else
+    return -1;
+#endif
 }
 
 /* Called from surfaceCreated() */


### PR DESCRIPTION
Defines such as SDL_SENSOR_DISABLED don't make much difference (about 2k) to the final build. This patch will exclude respective drivers from the build-config to further reduce build size. A total of 177k can be saved, with SDL_LEAN_AND_MEAN that's 542k, which is a considerable saving and results in a much more compact APK for anyone looking to strip out unwanted systems. Fixes #9947