### PR TITLE
wayland: Fix broken dead key behavior

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -1622,11 +1622,9 @@ static void keyboard_handle_key(void *data, struct wl_keyboard *keyboard,
         keyboard_input_get_text(text, input, key, SDL_RELEASED, &handled_by_ime);
     }
 
-    if (!handled_by_ime) {
-        scancode = Wayland_get_scancode_from_key(input, key + 8);
-        Wayland_HandleModifierKeys(input, scancode, state == WL_KEYBOARD_KEY_STATE_PRESSED);
-        SDL_SendKeyboardKeyIgnoreModifiers(Wayland_GetKeyboardTimestamp(input, time), input->keyboard_id, state == WL_KEYBOARD_KEY_STATE_PRESSED ? SDL_PRESSED : SDL_RELEASED, scancode);
-    }
+    scancode = Wayland_get_scancode_from_key(input, key + 8);
+    Wayland_HandleModifierKeys(input, scancode, state == WL_KEYBOARD_KEY_STATE_PRESSED);
+    SDL_SendKeyboardKeyIgnoreModifiers(Wayland_GetKeyboardTimestamp(input, time), input->keyboard_id, state == WL_KEYBOARD_KEY_STATE_PRESSED ? SDL_PRESSED : SDL_RELEASED, scancode);
 
     if (state == WL_KEYBOARD_KEY_STATE_PRESSED) {
         if (has_text && !(SDL_GetModState() & SDL_KMOD_CTRL)) {

--- a/src/video/wayland/SDL_waylandkeyboard.h
+++ b/src/video/wayland/SDL_waylandkeyboard.h
@@ -28,7 +28,6 @@ typedef struct SDL_WaylandTextInput
     struct zwp_text_input_v3 *text_input;
     SDL_Rect cursor_rect;
     SDL_bool has_preedit;
-    SDL_bool is_enabled;
 } SDL_WaylandTextInput;
 
 extern int Wayland_InitKeyboard(SDL_VideoDevice *_this);

--- a/src/video/wayland/SDL_waylandsym.h
+++ b/src/video/wayland/SDL_waylandsym.h
@@ -144,6 +144,7 @@ SDL_WAYLAND_SYM(enum xkb_state_component, xkb_state_update_mask, (struct xkb_sta
                       xkb_layout_index_t locked_layout) )
 SDL_WAYLAND_SYM(struct xkb_compose_table *, xkb_compose_table_new_from_locale, (struct xkb_context *,\
                       const char *locale, enum xkb_compose_compile_flags) )
+SDL_WAYLAND_SYM(void, xkb_compose_state_reset, (struct xkb_compose_state *) )
 SDL_WAYLAND_SYM(void, xkb_compose_table_unref, (struct xkb_compose_table *) )
 SDL_WAYLAND_SYM(struct xkb_compose_state *, xkb_compose_state_new, (struct xkb_compose_table *, enum xkb_compose_state_flags) )
 SDL_WAYLAND_SYM(void, xkb_compose_state_unref, (struct xkb_compose_state *) )


### PR DESCRIPTION
This fixes numerous problems regarding dead keys on Wayland. Most notably, Wayland was enforcing dead keys on SDL_KEYDOWN and SDL_KEYUP events, which caused unresponsiveness on keys that were mapped to dead keys (tilde on US-Intl is most notable for this, commonly used as a console key).

When starting text input, not all state was reset properly. The text input protocol requires to be re-enabled every time text input changes, which SDL did not do. Also, XKB compose state was not reset at all, causing composite and dead keys to carry over from when text input was disabled.

Manual cherry-pick of #9983, as it was easier to manually apply vs trying to untangle the resulting merge mess when cherry-picking forward.
