### PR TITLE
reword SDL_FlashWindow params

### DIFF
--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -2312,8 +2312,8 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowShape(SDL_Window *window, SDL_Surfa
 /**
  * Request a window to demand attention from the user.
  *
- * \param window the window to be flashed
- * \param operation the flash operation
+ * \param window the SDL_Window to be flashed
+ * \param operation the SDL_FlashOperation to perform
  * \returns 0 on success or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *


### PR DESCRIPTION
so they link the types in the wiki


I think it would be a good idea to
- either do this change for all the functions before 3.0
- or make the types in the function prototype links.

edit:
- or make all types related pages