### PR TITLE
Rename SDL_Swap(16|32|64)(LE|BE) to SDL_Swap(LE|BE)(16|32|64)

### DIFF
--- a/build-scripts/SDL_migration.cocci
+++ b/build-scripts/SDL_migration.cocci
@@ -3282,3 +3282,33 @@ typedef SDL_Colour, SDL_Color;
 @@
 - SDL_SYSTEM_CURSOR_WINDOW_LEFT
 + SDL_SYSTEM_CURSOR_W_RESIZE
+@@
+@@
+- SDL_SwapLE16
++ SDL_Swap16LE
+  (...)
+@@
+@@
+- SDL_SwapLE32
++ SDL_Swap32LE
+  (...)
+@@
+@@
+- SDL_SwapBE16
++ SDL_Swap16BE
+  (...)
+@@
+@@
+- SDL_SwapBE32
++ SDL_Swap32BE
+  (...)
+@@
+@@
+- SDL_SwapLE64
++ SDL_Swap64LE
+  (...)
+@@
+@@
+- SDL_SwapBE64
++ SDL_Swap64BE
+  (...)

--- a/build-scripts/rename_api.py
+++ b/build-scripts/rename_api.py
@@ -24,7 +24,7 @@ def main():
 
     # Check whether we can still modify the ABI
     version_header = pathlib.Path( SDL_INCLUDE_DIR / "SDL_version.h" ).read_text()
-    if not re.search("SDL_MINOR_VERSION\s+[01]\s", version_header):
+    if not re.search(r"SDL_MINOR_VERSION\s+[01]\s", version_header):
         raise Exception("ABI is frozen, symbols cannot be renamed")
 
     # Find the symbol in the headers
@@ -239,8 +239,8 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(fromfile_prefix_chars='@')
     parser.add_argument("--skip-header-check", action="store_true")
-    parser.add_argument("header");
-    parser.add_argument("type", choices=["enum", "function", "hint", "structure", "symbol"]);
+    parser.add_argument("header")
+    parser.add_argument("type", choices=["enum", "function", "hint", "structure", "symbol"])
     parser.add_argument("args", nargs="*")
     args = parser.parse_args()
 

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -310,6 +310,16 @@ SDL_SIMDAlloc(), SDL_SIMDRealloc(), and SDL_SIMDFree() have been removed. You ca
 The following functions have been renamed:
 * SDL_SIMDGetAlignment() => SDL_GetSIMDAlignment()
 
+## SDL_endian.h
+
+The following functions have been renamed:
+* SDL_SwapBE16() => SDL_Swap16BE()
+* SDL_SwapBE32() => SDL_Swap32BE()
+* SDL_SwapBE64() => SDL_Swap64BE()
+* SDL_SwapLE16() => SDL_Swap16LE()
+* SDL_SwapLE32() => SDL_Swap32LE()
+* SDL_SwapLE64() => SDL_Swap64LE()
+
 ## SDL_error.h
 
 The following functions have been removed:

--- a/include/SDL3/SDL_endian.h
+++ b/include/SDL3/SDL_endian.h
@@ -326,7 +326,7 @@ SDL_FORCE_INLINE float SDL_SwapFloat(float x)
  * Byte-swap an unsigned 16-bit number.
  *
  * This will always byte-swap the value, whether it's currently in the native
- * byteorder of the system or not. You should use SDL_SwapLE16 or SDL_SwapBE16
+ * byteorder of the system or not. You should use SDL_Swap16LE or SDL_Swap16BE
  * instead, in most cases.
  *
  * Note that this is a forced-inline function in a header, and not a public
@@ -347,7 +347,7 @@ SDL_FORCE_INLINE Uint16 SDL_Swap16(Uint16 x) { return x_but_byteswapped; }
  * Byte-swap an unsigned 32-bit number.
  *
  * This will always byte-swap the value, whether it's currently in the native
- * byteorder of the system or not. You should use SDL_SwapLE32 or SDL_SwapBE32
+ * byteorder of the system or not. You should use SDL_Swap32LE or SDL_Swap32BE
  * instead, in most cases.
  *
  * Note that this is a forced-inline function in a header, and not a public
@@ -368,7 +368,7 @@ SDL_FORCE_INLINE Uint32 SDL_Swap32(Uint32 x) { return x_but_byteswapped; }
  * Byte-swap an unsigned 64-bit number.
  *
  * This will always byte-swap the value, whether it's currently in the native
- * byteorder of the system or not. You should use SDL_SwapLE64 or SDL_SwapBE64
+ * byteorder of the system or not. You should use SDL_Swap64LE or SDL_Swap64BE
  * instead, in most cases.
  *
  * Note that this is a forced-inline function in a header, and not a public
@@ -397,7 +397,7 @@ SDL_FORCE_INLINE Uint32 SDL_Swap64(Uint64 x) { return x_but_byteswapped; }
  *
  * \since This macro is available since SDL 3.0.0.
  */
-#define SDL_SwapLE16(x) SwapOnlyIfNecessary(x)
+#define SDL_Swap16LE(x) SwapOnlyIfNecessary(x)
 
 /**
  * Swap a 32-bit value from littleendian to native byte order.
@@ -411,7 +411,7 @@ SDL_FORCE_INLINE Uint32 SDL_Swap64(Uint64 x) { return x_but_byteswapped; }
  *
  * \since This macro is available since SDL 3.0.0.
  */
-#define SDL_SwapLE32(x) SwapOnlyIfNecessary(x)
+#define SDL_Swap32LE(x) SwapOnlyIfNecessary(x)
 
 /**
  * Swap a 64-bit value from littleendian to native byte order.
@@ -425,7 +425,7 @@ SDL_FORCE_INLINE Uint32 SDL_Swap64(Uint64 x) { return x_but_byteswapped; }
  *
  * \since This macro is available since SDL 3.0.0.
  */
-#define SDL_SwapLE64(x) SwapOnlyIfNecessary(x)
+#define SDL_Swap64LE(x) SwapOnlyIfNecessary(x)
 
 /**
  * Swap a floating point value from littleendian to native byte order.
@@ -453,7 +453,7 @@ SDL_FORCE_INLINE Uint32 SDL_Swap64(Uint64 x) { return x_but_byteswapped; }
  *
  * \since This macro is available since SDL 3.0.0.
  */
-#define SDL_SwapBE16(x) SwapOnlyIfNecessary(x)
+#define SDL_Swap16BE(x) SwapOnlyIfNecessary(x)
 
 /**
  * Swap a 32-bit value from bigendian to native byte order.
@@ -467,7 +467,7 @@ SDL_FORCE_INLINE Uint32 SDL_Swap64(Uint64 x) { return x_but_byteswapped; }
  *
  * \since This macro is available since SDL 3.0.0.
  */
-#define SDL_SwapBE32(x) SwapOnlyIfNecessary(x)
+#define SDL_Swap32BE(x) SwapOnlyIfNecessary(x)
 
 /**
  * Swap a 64-bit value from bigendian to native byte order.
@@ -481,7 +481,7 @@ SDL_FORCE_INLINE Uint32 SDL_Swap64(Uint64 x) { return x_but_byteswapped; }
  *
  * \since This macro is available since SDL 3.0.0.
  */
-#define SDL_SwapBE64(x) SwapOnlyIfNecessary(x)
+#define SDL_Swap64BE(x) SwapOnlyIfNecessary(x)
 
 /**
  * Swap a floating point value from bigendian to native byte order.
@@ -498,22 +498,22 @@ SDL_FORCE_INLINE Uint32 SDL_Swap64(Uint64 x) { return x_but_byteswapped; }
 #define SDL_SwapFloatBE(x) SwapOnlyIfNecessary(x)
 
 #elif SDL_BYTEORDER == SDL_LIL_ENDIAN
-#define SDL_SwapLE16(x)     (x)
-#define SDL_SwapLE32(x)     (x)
-#define SDL_SwapLE64(x)     (x)
+#define SDL_Swap16LE(x)     (x)
+#define SDL_Swap32LE(x)     (x)
+#define SDL_Swap64LE(x)     (x)
 #define SDL_SwapFloatLE(x)  (x)
-#define SDL_SwapBE16(x)     SDL_Swap16(x)
-#define SDL_SwapBE32(x)     SDL_Swap32(x)
-#define SDL_SwapBE64(x)     SDL_Swap64(x)
+#define SDL_Swap16BE(x)     SDL_Swap16(x)
+#define SDL_Swap32BE(x)     SDL_Swap32(x)
+#define SDL_Swap64BE(x)     SDL_Swap64(x)
 #define SDL_SwapFloatBE(x)  SDL_SwapFloat(x)
 #else
-#define SDL_SwapLE16(x)     SDL_Swap16(x)
-#define SDL_SwapLE32(x)     SDL_Swap32(x)
-#define SDL_SwapLE64(x)     SDL_Swap64(x)
+#define SDL_Swap16LE(x)     SDL_Swap16(x)
+#define SDL_Swap32LE(x)     SDL_Swap32(x)
+#define SDL_Swap64LE(x)     SDL_Swap64(x)
 #define SDL_SwapFloatLE(x)  SDL_SwapFloat(x)
-#define SDL_SwapBE16(x)     (x)
-#define SDL_SwapBE32(x)     (x)
-#define SDL_SwapBE64(x)     (x)
+#define SDL_Swap16BE(x)     (x)
+#define SDL_Swap32BE(x)     (x)
+#define SDL_Swap64BE(x)     (x)
 #define SDL_SwapFloatBE(x)  (x)
 #endif
 

--- a/include/SDL3/SDL_oldnames.h
+++ b/include/SDL3/SDL_oldnames.h
@@ -74,6 +74,14 @@
 /* ##SDL_cpuinfo.h */
 #define SDL_SIMDGetAlignment SDL_GetSIMDAlignment
 
+/* ##SDL_endian.h */
+#define SDL_SwapBE16 SDL_Swap16BE
+#define SDL_SwapBE32 SDL_Swap32BE
+#define SDL_SwapBE64 SDL_Swap64BE
+#define SDL_SwapLE16 SDL_Swap16LE
+#define SDL_SwapLE32 SDL_Swap32LE
+#define SDL_SwapLE64 SDL_Swap64LE
+
 /* ##SDL_events.h */
 #define SDL_APP_DIDENTERBACKGROUND SDL_EVENT_DID_ENTER_BACKGROUND
 #define SDL_APP_DIDENTERFOREGROUND SDL_EVENT_DID_ENTER_FOREGROUND
@@ -613,6 +621,14 @@
 
 /* ##SDL_cpuinfo.h */
 #define SDL_SIMDGetAlignment SDL_SIMDGetAlignment_renamed_SDL_GetSIMDAlignment
+
+/* ##SDL_endian.h */
+#define SDL_SwapBE16 SDL_SwapBE16_renamed_SDL_Swap16BE
+#define SDL_SwapBE32 SDL_SwapBE32_renamed_SDL_Swap32BE
+#define SDL_SwapBE64 SDL_SwapBE64_renamed_SDL_Swap64BE
+#define SDL_SwapLE16 SDL_SwapLE16_renamed_SDL_Swap16LE
+#define SDL_SwapLE32 SDL_SwapLE32_renamed_SDL_Swap32LE
+#define SDL_SwapLE64 SDL_SwapLE64_renamed_SDL_Swap64LE
 
 /* ##SDL_events.h */
 #define SDL_APP_DIDENTERBACKGROUND SDL_APP_DIDENTERBACKGROUND_renamed_SDL_EVENT_DID_ENTER_BACKGROUND

--- a/src/audio/SDL_mixer.c
+++ b/src/audio/SDL_mixer.c
@@ -144,9 +144,9 @@ int SDL_MixAudio(Uint8 *dst, const Uint8 *src, SDL_AudioFormat format,
 
         len /= 2;
         while (len--) {
-            src1 = SDL_SwapLE16(*(Sint16 *)src);
+            src1 = SDL_Swap16LE(*(Sint16 *)src);
             ADJUST_VOLUME(Sint16, src1, volume);
-            src2 = SDL_SwapLE16(*(Sint16 *)dst);
+            src2 = SDL_Swap16LE(*(Sint16 *)dst);
             src += 2;
             dst_sample = src1 + src2;
             if (dst_sample > max_audioval) {
@@ -154,7 +154,7 @@ int SDL_MixAudio(Uint8 *dst, const Uint8 *src, SDL_AudioFormat format,
             } else if (dst_sample < min_audioval) {
                 dst_sample = min_audioval;
             }
-            *(Sint16 *)dst = SDL_SwapLE16((Sint16)dst_sample);
+            *(Sint16 *)dst = SDL_Swap16LE((Sint16)dst_sample);
             dst += 2;
         }
     } break;
@@ -168,9 +168,9 @@ int SDL_MixAudio(Uint8 *dst, const Uint8 *src, SDL_AudioFormat format,
 
         len /= 2;
         while (len--) {
-            src1 = SDL_SwapBE16(*(Sint16 *)src);
+            src1 = SDL_Swap16BE(*(Sint16 *)src);
             ADJUST_VOLUME(Sint16, src1, volume);
-            src2 = SDL_SwapBE16(*(Sint16 *)dst);
+            src2 = SDL_Swap16BE(*(Sint16 *)dst);
             src += 2;
             dst_sample = src1 + src2;
             if (dst_sample > max_audioval) {
@@ -178,7 +178,7 @@ int SDL_MixAudio(Uint8 *dst, const Uint8 *src, SDL_AudioFormat format,
             } else if (dst_sample < min_audioval) {
                 dst_sample = min_audioval;
             }
-            *(Sint16 *)dst = SDL_SwapBE16((Sint16)dst_sample);
+            *(Sint16 *)dst = SDL_Swap16BE((Sint16)dst_sample);
             dst += 2;
         }
     } break;
@@ -194,17 +194,17 @@ int SDL_MixAudio(Uint8 *dst, const Uint8 *src, SDL_AudioFormat format,
 
         len /= 4;
         while (len--) {
-            src1 = (Sint64)((Sint32)SDL_SwapLE32(*src32));
+            src1 = (Sint64)((Sint32)SDL_Swap32LE(*src32));
             src32++;
             ADJUST_VOLUME(Sint64, src1, volume);
-            src2 = (Sint64)((Sint32)SDL_SwapLE32(*dst32));
+            src2 = (Sint64)((Sint32)SDL_Swap32LE(*dst32));
             dst_sample = src1 + src2;
             if (dst_sample > max_audioval) {
                 dst_sample = max_audioval;
             } else if (dst_sample < min_audioval) {
                 dst_sample = min_audioval;
             }
-            *(dst32++) = SDL_SwapLE32((Uint32)((Sint32)dst_sample));
+            *(dst32++) = SDL_Swap32LE((Uint32)((Sint32)dst_sample));
         }
     } break;
 
@@ -219,17 +219,17 @@ int SDL_MixAudio(Uint8 *dst, const Uint8 *src, SDL_AudioFormat format,
 
         len /= 4;
         while (len--) {
-            src1 = (Sint64)((Sint32)SDL_SwapBE32(*src32));
+            src1 = (Sint64)((Sint32)SDL_Swap32BE(*src32));
             src32++;
             ADJUST_VOLUME(Sint64, src1, volume);
-            src2 = (Sint64)((Sint32)SDL_SwapBE32(*dst32));
+            src2 = (Sint64)((Sint32)SDL_Swap32BE(*dst32));
             dst_sample = src1 + src2;
             if (dst_sample > max_audioval) {
                 dst_sample = max_audioval;
             } else if (dst_sample < min_audioval) {
                 dst_sample = min_audioval;
             }
-            *(dst32++) = SDL_SwapBE32((Uint32)((Sint32)dst_sample));
+            *(dst32++) = SDL_Swap32BE((Uint32)((Sint32)dst_sample));
         }
     } break;
 

--- a/src/audio/SDL_wave.c
+++ b/src/audio/SDL_wave.c
@@ -1527,8 +1527,8 @@ static int WaveNextChunk(SDL_IOStream *src, WaveChunk *chunk)
         return -1;
     }
 
-    chunk->fourcc = SDL_SwapLE32(chunkheader[0]);
-    chunk->length = SDL_SwapLE32(chunkheader[1]);
+    chunk->fourcc = SDL_Swap32LE(chunkheader[0]);
+    chunk->length = SDL_Swap32LE(chunkheader[1]);
     chunk->position = nextposition + 8;
 
     return 0;

--- a/src/file/SDL_iostream.c
+++ b/src/file/SDL_iostream.c
@@ -1140,7 +1140,7 @@ SDL_bool SDL_ReadU16LE(SDL_IOStream *src, Uint16 *value)
         result = SDL_TRUE;
     }
     if (value) {
-        *value = SDL_SwapLE16(data);
+        *value = SDL_Swap16LE(data);
     }
     return result;
 }
@@ -1159,7 +1159,7 @@ SDL_bool SDL_ReadU16BE(SDL_IOStream *src, Uint16 *value)
         result = SDL_TRUE;
     }
     if (value) {
-        *value = SDL_SwapBE16(data);
+        *value = SDL_Swap16BE(data);
     }
     return result;
 }
@@ -1178,7 +1178,7 @@ SDL_bool SDL_ReadU32LE(SDL_IOStream *src, Uint32 *value)
         result = SDL_TRUE;
     }
     if (value) {
-        *value = SDL_SwapLE32(data);
+        *value = SDL_Swap32LE(data);
     }
     return result;
 }
@@ -1197,7 +1197,7 @@ SDL_bool SDL_ReadU32BE(SDL_IOStream *src, Uint32 *value)
         result = SDL_TRUE;
     }
     if (value) {
-        *value = SDL_SwapBE32(data);
+        *value = SDL_Swap32BE(data);
     }
     return result;
 }
@@ -1216,7 +1216,7 @@ SDL_bool SDL_ReadU64LE(SDL_IOStream *src, Uint64 *value)
         result = SDL_TRUE;
     }
     if (value) {
-        *value = SDL_SwapLE64(data);
+        *value = SDL_Swap64LE(data);
     }
     return result;
 }
@@ -1235,7 +1235,7 @@ SDL_bool SDL_ReadU64BE(SDL_IOStream *src, Uint64 *value)
         result = SDL_TRUE;
     }
     if (value) {
-        *value = SDL_SwapBE64(data);
+        *value = SDL_Swap64BE(data);
     }
     return result;
 }
@@ -1257,7 +1257,7 @@ SDL_bool SDL_WriteS8(SDL_IOStream *dst, Sint8 value)
 
 SDL_bool SDL_WriteU16LE(SDL_IOStream *dst, Uint16 value)
 {
-    const Uint16 swapped = SDL_SwapLE16(value);
+    const Uint16 swapped = SDL_Swap16LE(value);
     return (SDL_WriteIO(dst, &swapped, sizeof(swapped)) == sizeof(swapped));
 }
 
@@ -1268,7 +1268,7 @@ SDL_bool SDL_WriteS16LE(SDL_IOStream *dst, Sint16 value)
 
 SDL_bool SDL_WriteU16BE(SDL_IOStream *dst, Uint16 value)
 {
-    const Uint16 swapped = SDL_SwapBE16(value);
+    const Uint16 swapped = SDL_Swap16BE(value);
     return (SDL_WriteIO(dst, &swapped, sizeof(swapped)) == sizeof(swapped));
 }
 
@@ -1279,7 +1279,7 @@ SDL_bool SDL_WriteS16BE(SDL_IOStream *dst, Sint16 value)
 
 SDL_bool SDL_WriteU32LE(SDL_IOStream *dst, Uint32 value)
 {
-    const Uint32 swapped = SDL_SwapLE32(value);
+    const Uint32 swapped = SDL_Swap32LE(value);
     return (SDL_WriteIO(dst, &swapped, sizeof(swapped)) == sizeof(swapped));
 }
 
@@ -1290,7 +1290,7 @@ SDL_bool SDL_WriteS32LE(SDL_IOStream *dst, Sint32 value)
 
 SDL_bool SDL_WriteU32BE(SDL_IOStream *dst, Uint32 value)
 {
-    const Uint32 swapped = SDL_SwapBE32(value);
+    const Uint32 swapped = SDL_Swap32BE(value);
     return (SDL_WriteIO(dst, &swapped, sizeof(swapped)) == sizeof(swapped));
 }
 
@@ -1301,7 +1301,7 @@ SDL_bool SDL_WriteS32BE(SDL_IOStream *dst, Sint32 value)
 
 SDL_bool SDL_WriteU64LE(SDL_IOStream *dst, Uint64 value)
 {
-    const Uint64 swapped = SDL_SwapLE64(value);
+    const Uint64 swapped = SDL_Swap64LE(value);
     return (SDL_WriteIO(dst, &swapped, sizeof(swapped)) == sizeof(swapped));
 }
 
@@ -1312,7 +1312,7 @@ SDL_bool SDL_WriteS64LE(SDL_IOStream *dst, Sint64 value)
 
 SDL_bool SDL_WriteU64BE(SDL_IOStream *dst, Uint64 value)
 {
-    const Uint64 swapped = SDL_SwapBE64(value);
+    const Uint64 swapped = SDL_Swap64BE(value);
     return (SDL_WriteIO(dst, &swapped, sizeof(swapped)) == sizeof(swapped));
 }
 

--- a/src/joystick/SDL_gamepad.c
+++ b/src/joystick/SDL_gamepad.c
@@ -599,8 +599,8 @@ static GamepadMapping_t *SDL_CreateMappingForAndroidGamepad(SDL_JoystickGUID gui
     int button_mask;
     int axis_mask;
 
-    button_mask = SDL_SwapLE16(*(Uint16 *)(&guid.data[sizeof(guid.data) - 4]));
-    axis_mask = SDL_SwapLE16(*(Uint16 *)(&guid.data[sizeof(guid.data) - 2]));
+    button_mask = SDL_Swap16LE(*(Uint16 *)(&guid.data[sizeof(guid.data) - 4]));
+    axis_mask = SDL_Swap16LE(*(Uint16 *)(&guid.data[sizeof(guid.data) - 2]));
     if (!button_mask && !axis_mask) {
         /* Accelerometer, shouldn't have a gamepad mapping */
         return NULL;

--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -2497,7 +2497,7 @@ SDL_bool SDL_JoystickEventsEnabled(void)
 void SDL_GetJoystickGUIDInfo(SDL_JoystickGUID guid, Uint16 *vendor, Uint16 *product, Uint16 *version, Uint16 *crc16)
 {
     Uint16 *guid16 = (Uint16 *)guid.data;
-    Uint16 bus = SDL_SwapLE16(guid16[0]);
+    Uint16 bus = SDL_Swap16LE(guid16[0]);
 
     if ((bus < ' ' || bus == SDL_HARDWARE_BUS_VIRTUAL) && guid16[3] == 0x0000 && guid16[5] == 0x0000) {
         /* This GUID fits the standard form:
@@ -2512,16 +2512,16 @@ void SDL_GetJoystickGUIDInfo(SDL_JoystickGUID guid, Uint16 *vendor, Uint16 *prod
          * 8-bit driver-dependent type info
          */
         if (vendor) {
-            *vendor = SDL_SwapLE16(guid16[2]);
+            *vendor = SDL_Swap16LE(guid16[2]);
         }
         if (product) {
-            *product = SDL_SwapLE16(guid16[4]);
+            *product = SDL_Swap16LE(guid16[4]);
         }
         if (version) {
-            *version = SDL_SwapLE16(guid16[6]);
+            *version = SDL_Swap16LE(guid16[6]);
         }
         if (crc16) {
-            *crc16 = SDL_SwapLE16(guid16[1]);
+            *crc16 = SDL_Swap16LE(guid16[1]);
         }
     } else if (bus < ' ' || bus == SDL_HARDWARE_BUS_VIRTUAL) {
         /* This GUID fits the unknown VID/PID form:
@@ -2539,7 +2539,7 @@ void SDL_GetJoystickGUIDInfo(SDL_JoystickGUID guid, Uint16 *vendor, Uint16 *prod
             *version = 0;
         }
         if (crc16) {
-            *crc16 = SDL_SwapLE16(guid16[1]);
+            *crc16 = SDL_Swap16LE(guid16[1]);
         }
     } else {
         if (vendor) {
@@ -2729,15 +2729,15 @@ SDL_JoystickGUID SDL_CreateJoystickGUID(Uint16 bus, Uint16 vendor, Uint16 produc
 
     /* We only need 16 bits for each of these; space them out to fill 128. */
     /* Byteswap so devices get same GUID on little/big endian platforms. */
-    *guid16++ = SDL_SwapLE16(bus);
-    *guid16++ = SDL_SwapLE16(crc);
+    *guid16++ = SDL_Swap16LE(bus);
+    *guid16++ = SDL_Swap16LE(crc);
 
     if (vendor) {
-        *guid16++ = SDL_SwapLE16(vendor);
+        *guid16++ = SDL_Swap16LE(vendor);
         *guid16++ = 0;
-        *guid16++ = SDL_SwapLE16(product);
+        *guid16++ = SDL_Swap16LE(product);
         *guid16++ = 0;
-        *guid16++ = SDL_SwapLE16(version);
+        *guid16++ = SDL_Swap16LE(version);
         guid.data[14] = driver_signature;
         guid.data[15] = driver_data;
     } else {
@@ -2764,28 +2764,28 @@ void SDL_SetJoystickGUIDVendor(SDL_JoystickGUID *guid, Uint16 vendor)
 {
     Uint16 *guid16 = (Uint16 *)guid->data;
 
-    guid16[2] = SDL_SwapLE16(vendor);
+    guid16[2] = SDL_Swap16LE(vendor);
 }
 
 void SDL_SetJoystickGUIDProduct(SDL_JoystickGUID *guid, Uint16 product)
 {
     Uint16 *guid16 = (Uint16 *)guid->data;
 
-    guid16[4] = SDL_SwapLE16(product);
+    guid16[4] = SDL_Swap16LE(product);
 }
 
 void SDL_SetJoystickGUIDVersion(SDL_JoystickGUID *guid, Uint16 version)
 {
     Uint16 *guid16 = (Uint16 *)guid->data;
 
-    guid16[6] = SDL_SwapLE16(version);
+    guid16[6] = SDL_Swap16LE(version);
 }
 
 void SDL_SetJoystickGUIDCRC(SDL_JoystickGUID *guid, Uint16 crc)
 {
     Uint16 *guid16 = (Uint16 *)guid->data;
 
-    guid16[1] = SDL_SwapLE16(crc);
+    guid16[1] = SDL_Swap16LE(crc);
 }
 
 SDL_GamepadType SDL_GetGamepadTypeFromVIDPID(Uint16 vendor, Uint16 product, const char *name, SDL_bool forUI)

--- a/src/joystick/android/SDL_sysjoystick.c
+++ b/src/joystick/android/SDL_sysjoystick.c
@@ -343,8 +343,8 @@ int Android_AddJoystick(int device_id, const char *name, const char *desc, int v
     /* Update the GUID with capability bits */
     {
         Uint16 *guid16 = (Uint16 *)guid.data;
-        guid16[6] = SDL_SwapLE16(button_mask);
-        guid16[7] = SDL_SwapLE16(axis_mask);
+        guid16[6] = SDL_Swap16LE(button_mask);
+        guid16[7] = SDL_Swap16LE(axis_mask);
     }
 
     item = (SDL_joylist_item *)SDL_malloc(sizeof(SDL_joylist_item));

--- a/src/joystick/hidapi/SDL_hidapi_ps3.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps3.c
@@ -340,7 +340,7 @@ static int HIDAPI_DriverPS3_SetJoystickSensorsEnabled(SDL_HIDAPI_Device *device,
 static float HIDAPI_DriverPS3_ScaleAccel(Sint16 value)
 {
     /* Accelerometer values are in big endian order */
-    value = SDL_SwapBE16(value);
+    value = SDL_Swap16BE(value);
     return ((float)(value - 511) / 113.0f) * SDL_STANDARD_GRAVITY;
 }
 

--- a/src/joystick/hidapi/SDL_hidapi_shield.c
+++ b/src/joystick/hidapi/SDL_hidapi_shield.c
@@ -345,14 +345,14 @@ static void HIDAPI_DriverShield_HandleStatePacketV103(SDL_Joystick *joystick, SD
         SDL_SendJoystickButton(timestamp, joystick, SDL_GAMEPAD_BUTTON_SHIELD_SHARE, (data[2] & 0x80) ? SDL_PRESSED : SDL_RELEASED);
     }
 
-    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFTX, SDL_SwapLE16(*(Sint16 *)&data[4]) - 0x8000);
-    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFTY, SDL_SwapLE16(*(Sint16 *)&data[6]) - 0x8000);
+    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFTX, SDL_Swap16LE(*(Sint16 *)&data[4]) - 0x8000);
+    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFTY, SDL_Swap16LE(*(Sint16 *)&data[6]) - 0x8000);
 
-    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTX, SDL_SwapLE16(*(Sint16 *)&data[8]) - 0x8000);
-    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTY, SDL_SwapLE16(*(Sint16 *)&data[10]) - 0x8000);
+    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTX, SDL_Swap16LE(*(Sint16 *)&data[8]) - 0x8000);
+    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTY, SDL_Swap16LE(*(Sint16 *)&data[10]) - 0x8000);
 
-    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFT_TRIGGER, SDL_SwapLE16(*(Sint16 *)&data[12]) - 0x8000);
-    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHT_TRIGGER, SDL_SwapLE16(*(Sint16 *)&data[14]) - 0x8000);
+    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFT_TRIGGER, SDL_Swap16LE(*(Sint16 *)&data[12]) - 0x8000);
+    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHT_TRIGGER, SDL_Swap16LE(*(Sint16 *)&data[14]) - 0x8000);
 
     SDL_memcpy(ctx->last_state, data, SDL_min(size, sizeof(ctx->last_state)));
 }
@@ -433,14 +433,14 @@ static void HIDAPI_DriverShield_HandleStatePacketV104(SDL_Joystick *joystick, SD
         SDL_SendJoystickButton(timestamp, joystick, SDL_GAMEPAD_BUTTON_START, (data[4] & 0x01) ? SDL_PRESSED : SDL_RELEASED);
     }
 
-    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFTX, SDL_SwapLE16(*(Sint16 *)&data[9]) - 0x8000);
-    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFTY, SDL_SwapLE16(*(Sint16 *)&data[11]) - 0x8000);
+    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFTX, SDL_Swap16LE(*(Sint16 *)&data[9]) - 0x8000);
+    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFTY, SDL_Swap16LE(*(Sint16 *)&data[11]) - 0x8000);
 
-    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTX, SDL_SwapLE16(*(Sint16 *)&data[13]) - 0x8000);
-    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTY, SDL_SwapLE16(*(Sint16 *)&data[15]) - 0x8000);
+    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTX, SDL_Swap16LE(*(Sint16 *)&data[13]) - 0x8000);
+    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTY, SDL_Swap16LE(*(Sint16 *)&data[15]) - 0x8000);
 
-    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFT_TRIGGER, SDL_SwapLE16(*(Sint16 *)&data[19]) - 0x8000);
-    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHT_TRIGGER, SDL_SwapLE16(*(Sint16 *)&data[21]) - 0x8000);
+    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFT_TRIGGER, SDL_Swap16LE(*(Sint16 *)&data[19]) - 0x8000);
+    SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHT_TRIGGER, SDL_Swap16LE(*(Sint16 *)&data[21]) - 0x8000);
 
     if (ctx->last_state[17] != data[17]) {
         SDL_SendJoystickButton(timestamp, joystick, SDL_GAMEPAD_BUTTON_SHIELD_SHARE, (data[17] & 0x01) ? SDL_PRESSED : SDL_RELEASED);

--- a/src/joystick/hidapi/SDL_hidapi_xbox360.c
+++ b/src/joystick/hidapi/SDL_hidapi_xbox360.c
@@ -311,16 +311,16 @@ static void HIDAPI_DriverXbox360_HandleStatePacket(SDL_Joystick *joystick, SDL_D
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFT_TRIGGER, axis);
     axis = ((int)data[5] * 257) - 32768;
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHT_TRIGGER, axis);
-    axis = SDL_SwapLE16(*(Sint16 *)(&data[6]));
+    axis = SDL_Swap16LE(*(Sint16 *)(&data[6]));
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFTX, axis);
-    axis = SDL_SwapLE16(*(Sint16 *)(&data[8]));
+    axis = SDL_Swap16LE(*(Sint16 *)(&data[8]));
     if (invert_y_axes) {
         axis = ~axis;
     }
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFTY, axis);
-    axis = SDL_SwapLE16(*(Sint16 *)(&data[10]));
+    axis = SDL_Swap16LE(*(Sint16 *)(&data[10]));
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTX, axis);
-    axis = SDL_SwapLE16(*(Sint16 *)(&data[12]));
+    axis = SDL_Swap16LE(*(Sint16 *)(&data[12]));
     if (invert_y_axes) {
         axis = ~axis;
     }

--- a/src/joystick/hidapi/SDL_hidapi_xbox360w.c
+++ b/src/joystick/hidapi/SDL_hidapi_xbox360w.c
@@ -268,16 +268,16 @@ static void HIDAPI_DriverXbox360W_HandleStatePacket(SDL_Joystick *joystick, SDL_
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFT_TRIGGER, axis);
     axis = ((int)data[5] * 257) - 32768;
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHT_TRIGGER, axis);
-    axis = SDL_SwapLE16(*(Sint16 *)(&data[6]));
+    axis = SDL_Swap16LE(*(Sint16 *)(&data[6]));
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFTX, axis);
-    axis = SDL_SwapLE16(*(Sint16 *)(&data[8]));
+    axis = SDL_Swap16LE(*(Sint16 *)(&data[8]));
     if (invert_y_axes) {
         axis = ~axis;
     }
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFTY, axis);
-    axis = SDL_SwapLE16(*(Sint16 *)(&data[10]));
+    axis = SDL_Swap16LE(*(Sint16 *)(&data[10]));
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTX, axis);
-    axis = SDL_SwapLE16(*(Sint16 *)(&data[12]));
+    axis = SDL_Swap16LE(*(Sint16 *)(&data[12]));
     if (invert_y_axes) {
         axis = ~axis;
     }

--- a/src/joystick/hidapi/SDL_hidapi_xboxone.c
+++ b/src/joystick/hidapi/SDL_hidapi_xboxone.c
@@ -808,7 +808,7 @@ static void HIDAPI_DriverXboxOne_HandleStatePacket(SDL_Joystick *joystick, SDL_D
         }
     }
 
-    axis = ((int)SDL_SwapLE16(*(Sint16 *)(&data[2])) * 64) - 32768;
+    axis = ((int)SDL_Swap16LE(*(Sint16 *)(&data[2])) * 64) - 32768;
     if (axis == 32704) {
         axis = 32767;
     }
@@ -817,7 +817,7 @@ static void HIDAPI_DriverXboxOne_HandleStatePacket(SDL_Joystick *joystick, SDL_D
     }
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFT_TRIGGER, axis);
 
-    axis = ((int)SDL_SwapLE16(*(Sint16 *)(&data[4])) * 64) - 32768;
+    axis = ((int)SDL_Swap16LE(*(Sint16 *)(&data[4])) * 64) - 32768;
     if (axis == -32768 && size == 26 && (data[18] & 0x40)) {
         axis = 32767;
     }
@@ -826,13 +826,13 @@ static void HIDAPI_DriverXboxOne_HandleStatePacket(SDL_Joystick *joystick, SDL_D
     }
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHT_TRIGGER, axis);
 
-    axis = SDL_SwapLE16(*(Sint16 *)(&data[6]));
+    axis = SDL_Swap16LE(*(Sint16 *)(&data[6]));
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFTX, axis);
-    axis = SDL_SwapLE16(*(Sint16 *)(&data[8]));
+    axis = SDL_Swap16LE(*(Sint16 *)(&data[8]));
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFTY, ~axis);
-    axis = SDL_SwapLE16(*(Sint16 *)(&data[10]));
+    axis = SDL_Swap16LE(*(Sint16 *)(&data[10]));
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTX, axis);
-    axis = SDL_SwapLE16(*(Sint16 *)(&data[12]));
+    axis = SDL_Swap16LE(*(Sint16 *)(&data[12]));
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTY, ~axis);
 
     SDL_memcpy(ctx->last_state, data, SDL_min(size, sizeof(ctx->last_state)));
@@ -1028,25 +1028,25 @@ static void HIDAPI_DriverXboxOneBluetooth_HandleStatePacket(SDL_Joystick *joysti
         SDL_SendJoystickHat(timestamp, joystick, 0, hat);
     }
 
-    axis = ((int)SDL_SwapLE16(*(Sint16 *)(&data[9])) * 64) - 32768;
+    axis = ((int)SDL_Swap16LE(*(Sint16 *)(&data[9])) * 64) - 32768;
     if (axis == 32704) {
         axis = 32767;
     }
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFT_TRIGGER, axis);
 
-    axis = ((int)SDL_SwapLE16(*(Sint16 *)(&data[11])) * 64) - 32768;
+    axis = ((int)SDL_Swap16LE(*(Sint16 *)(&data[11])) * 64) - 32768;
     if (axis == 32704) {
         axis = 32767;
     }
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHT_TRIGGER, axis);
 
-    axis = (int)SDL_SwapLE16(*(Uint16 *)(&data[1])) - 0x8000;
+    axis = (int)SDL_Swap16LE(*(Uint16 *)(&data[1])) - 0x8000;
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFTX, axis);
-    axis = (int)SDL_SwapLE16(*(Uint16 *)(&data[3])) - 0x8000;
+    axis = (int)SDL_Swap16LE(*(Uint16 *)(&data[3])) - 0x8000;
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFTY, axis);
-    axis = (int)SDL_SwapLE16(*(Uint16 *)(&data[5])) - 0x8000;
+    axis = (int)SDL_Swap16LE(*(Uint16 *)(&data[5])) - 0x8000;
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTX, axis);
-    axis = (int)SDL_SwapLE16(*(Uint16 *)(&data[7])) - 0x8000;
+    axis = (int)SDL_Swap16LE(*(Uint16 *)(&data[7])) - 0x8000;
     SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTY, axis);
 
     SDL_memcpy(ctx->last_state, data, SDL_min(size, sizeof(ctx->last_state)));
@@ -1359,10 +1359,10 @@ static SDL_bool HIDAPI_GIP_AcknowledgePacket(SDL_DriverXboxOne_Context *ctx, str
         SDL_zero(pkt);
         pkt.command = ack->command;
         pkt.options = GIP_OPT_INTERNAL;
-        pkt.length = SDL_SwapLE16((Uint16)(ack->chunk_offset + ack->packet_length));
+        pkt.length = SDL_Swap16LE((Uint16)(ack->chunk_offset + ack->packet_length));
 
         if ((ack->options & GIP_OPT_CHUNK) && ctx->chunk_buffer) {
-            pkt.remaining = SDL_SwapLE16((Uint16)(ctx->chunk_length - pkt.length));
+            pkt.remaining = SDL_Swap16LE((Uint16)(ctx->chunk_length - pkt.length));
         }
 
         return HIDAPI_GIP_SendPacket(ctx, &hdr, &pkt);

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -813,17 +813,17 @@ int WIN_SetWindowIcon(SDL_VideoDevice *_this, SDL_Window *window, SDL_Surface *i
 
     /* Write the BITMAPINFO header */
     bmi = (BITMAPINFOHEADER *)icon_bmp;
-    bmi->biSize = SDL_SwapLE32(sizeof(BITMAPINFOHEADER));
-    bmi->biWidth = SDL_SwapLE32(icon->w);
-    bmi->biHeight = SDL_SwapLE32(icon->h * 2);
-    bmi->biPlanes = SDL_SwapLE16(1);
-    bmi->biBitCount = SDL_SwapLE16(32);
-    bmi->biCompression = SDL_SwapLE32(BI_RGB);
-    bmi->biSizeImage = SDL_SwapLE32(icon->h * icon->w * sizeof(Uint32));
-    bmi->biXPelsPerMeter = SDL_SwapLE32(0);
-    bmi->biYPelsPerMeter = SDL_SwapLE32(0);
-    bmi->biClrUsed = SDL_SwapLE32(0);
-    bmi->biClrImportant = SDL_SwapLE32(0);
+    bmi->biSize = SDL_Swap32LE(sizeof(BITMAPINFOHEADER));
+    bmi->biWidth = SDL_Swap32LE(icon->w);
+    bmi->biHeight = SDL_Swap32LE(icon->h * 2);
+    bmi->biPlanes = SDL_Swap16LE(1);
+    bmi->biBitCount = SDL_Swap16LE(32);
+    bmi->biCompression = SDL_Swap32LE(BI_RGB);
+    bmi->biSizeImage = SDL_Swap32LE(icon->h * icon->w * sizeof(Uint32));
+    bmi->biXPelsPerMeter = SDL_Swap32LE(0);
+    bmi->biYPelsPerMeter = SDL_Swap32LE(0);
+    bmi->biClrUsed = SDL_Swap32LE(0);
+    bmi->biClrImportant = SDL_Swap32LE(0);
 
     /* Write the pixels upside down into the bitmap buffer */
     SDL_assert(icon->format->format == SDL_PIXELFORMAT_ARGB8888);

--- a/test/testevdev.c
+++ b/test/testevdev.c
@@ -1851,7 +1851,7 @@ static const GuessTest guess_tests[] =
  * an appropriate byteswapping function for the architecture's word size. */
 SDL_COMPILE_TIME_ASSERT(sizeof_long, sizeof(unsigned long) == 4 || sizeof(unsigned long) == 8);
 #define SwapLongLE(X) \
-    ((sizeof(unsigned long) == 4) ? SDL_SwapLE32(X) : SDL_SwapLE64(X))
+    ((sizeof(unsigned long) == 4) ? SDL_Swap32LE(X) : SDL_Swap64LE(X))
 
 static int
 run_test(void)


### PR DESCRIPTION
This commit was created by running:
```
build-scripts/rename_api.py SDL_endian.h function SDL_SwapLE16 SDL_Swap16LE SDL_SwapLE32 SDL_Swap32LE SDL_SwapBE16 SDL_Swap16BE SDL_SwapBE32 SDL_Swap32BE SDL_SwapLE64 SDL_Swap64LE SDL_SwapBE64 SLD_Swap64BE
```

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
Fixes #10007
