### PR TITLE
Add hint for mouse events using RawInput

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -3474,6 +3474,20 @@ extern "C" {
 #define SDL_HINT_WINDOWS_RAW_KEYBOARD   "SDL_WINDOWS_RAW_KEYBOARD"
 
 /**
+ * A variable controlling whether raw mouse events are used on Windows.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "0": The Windows message loop is used for mouse events. (default)
+ * - "1": Low latency raw mouse events are used.
+ *
+ * This hint can be set anytime.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_WINDOWS_RAW_MOUSE   "SDL_WINDOWS_RAW_MOUSE"
+
+/**
  * A variable controlling whether SDL uses Critical Sections for mutexes on
  * Windows.
  *

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -58,6 +58,13 @@ static void SDLCALL UpdateWindowsRawKeyboard(void *userdata, const char *name, c
     WIN_SetRawKeyboardEnabled(_this, enabled);
 }
 
+static void SDLCALL UpdateWindowsRawMouse(void *userdata, const char *name, const char *oldValue, const char *newValue)
+{
+    SDL_VideoDevice *_this = (SDL_VideoDevice *)userdata;
+    SDL_bool enabled = SDL_GetStringBoolean(newValue, SDL_FALSE);
+    WIN_SetRawMouseEnabled(_this, enabled);
+}
+
 static void SDLCALL UpdateWindowsEnableMessageLoop(void *userdata, const char *name, const char *oldValue, const char *newValue)
 {
     g_WindowsEnableMessageLoop = SDL_GetStringBoolean(newValue, SDL_TRUE);
@@ -473,6 +480,7 @@ int WIN_VideoInit(SDL_VideoDevice *_this)
 #endif
 
     SDL_AddHintCallback(SDL_HINT_WINDOWS_RAW_KEYBOARD, UpdateWindowsRawKeyboard, _this);
+    SDL_AddHintCallback(SDL_HINT_WINDOWS_RAW_MOUSE, UpdateWindowsRawMouse, _this);
     SDL_AddHintCallback(SDL_HINT_WINDOWS_ENABLE_MESSAGELOOP, UpdateWindowsEnableMessageLoop, NULL);
     SDL_AddHintCallback(SDL_HINT_WINDOWS_ENABLE_MENU_MNEMONICS, UpdateWindowsEnableMenuMnemonics, NULL);
     SDL_AddHintCallback(SDL_HINT_WINDOW_FRAME_USABLE_WHILE_CURSOR_HIDDEN, UpdateWindowFrameUsableWhileCursorHidden, NULL);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
SDL uses RawInput for mouse events when relative mode is enabled. However, there isn't a way to use RawInput for mouse events without relative mode, and given that there is a hint `SDL_HINT_WINDOWS_RAW_KEYBOARD` that exists, might as well provide it for the mouse for consistency.

I don't know how tests would look like for this hint, please suggest anything if applicable.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
