### PR TITLE
Fix usage of ReLinker on Android

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -330,6 +330,10 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
             Log.v(TAG, "modify thread properties failed " + e.toString());
         }
 
+        // So we can call stuff from static callbacks
+        mSingleton = this;
+        SDL.setContext(this);
+
         // Load shared libraries
         String errorMsgBrokenLib = "";
         try {
@@ -383,10 +387,6 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
 
         // Initialize state
         SDL.initialize();
-
-        // So we can call stuff from static callbacks
-        mSingleton = this;
-        SDL.setContext(this);
 
         mClipboardHandler = new SDLClipboardHandler();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously, when loading libraries in `SDL.loadLibrary(...)`the saved context (`SDL.mContext`) was `null` and using relinker  always failed with throwing a null exception and fallbacking to the system loader.

Save context before we call `SDLActivity.loadLibaries()` -> `SDL.loadLibrary(...)` so relinker can be used.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->

none found
