### PR TITLE
Use an opaque struct typedef for SDL_GLContext

### DIFF
--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -200,7 +200,7 @@ typedef enum SDL_FlashOperation
  *
  * \sa SDL_GL_CreateContext
  */
-typedef void *SDL_GLContext;
+typedef struct SDL_GLContextState *SDL_GLContext;
 
 /**
  * Opaque EGL types.

--- a/src/video/windows/SDL_windowsopengl.c
+++ b/src/video/windows/SDL_windowsopengl.c
@@ -756,8 +756,8 @@ SDL_GLContext WIN_GL_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
         }
 
         /* Make the context current */
-        if (WIN_GL_MakeCurrent(_this, window, temp_context) < 0) {
-            WIN_GL_DeleteContext(_this, temp_context);
+        if (WIN_GL_MakeCurrent(_this, window, (SDL_GLContext)temp_context) < 0) {
+            WIN_GL_DeleteContext(_this, (SDL_GLContext)temp_context);
             return NULL;
         }
 
@@ -819,12 +819,12 @@ SDL_GLContext WIN_GL_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
         return NULL;
     }
 
-    if (WIN_GL_MakeCurrent(_this, window, context) < 0) {
-        WIN_GL_DeleteContext(_this, context);
+    if (WIN_GL_MakeCurrent(_this, window, (SDL_GLContext)context) < 0) {
+        WIN_GL_DeleteContext(_this, (SDL_GLContext)context);
         return NULL;
     }
 
-    return context;
+    return (SDL_GLContext)context;
 }
 
 int WIN_GL_MakeCurrent(SDL_VideoDevice *_this, SDL_Window *window, SDL_GLContext context)

--- a/src/video/x11/SDL_x11opengl.c
+++ b/src/video/x11/SDL_x11opengl.c
@@ -716,7 +716,8 @@ SDL_GLContext X11_GL_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
     XWindowAttributes xattr;
     XVisualInfo v, *vinfo;
     int n;
-    GLXContext context = NULL, share_context;
+    SDL_GLContext context = NULL;
+    GLXContext share_context;
     const int transparent = (window->flags & SDL_WINDOW_TRANSPARENT) ? SDL_TRUE : SDL_FALSE;
 
     if (_this->gl_config.share_with_current_context) {
@@ -741,7 +742,7 @@ SDL_GLContext X11_GL_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
             _this->gl_config.flags == 0 && !transparent) {
             /* Create legacy context */
             context =
-                _this->gl_data->glXCreateContext(display, vinfo, share_context, True);
+                (SDL_GLContext)_this->gl_data->glXCreateContext(display, vinfo, share_context, True);
         } else {
             /* max 14 attributes plus terminator */
             int attribs[15] = {
@@ -813,7 +814,7 @@ SDL_GLContext X11_GL_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
                     }
 
                     if (framebuffer_config) {
-                        context = _this->gl_data->glXCreateContextAttribsARB(display,
+                        context = (SDL_GLContext)_this->gl_data->glXCreateContextAttribsARB(display,
                                                                              framebuffer_config[0],
                                                                              share_context, True, attribs);
                         X11_XFree(framebuffer_config);


### PR DESCRIPTION
Using a struct typedef instead of a void pointer results in extra C typechecks.

<!--- Provide a general summary of your changes in the Title above -->

## Description
I only had to cast types in x11 and windows opengl code.

## Existing Issue(s)
Fixes #10025