### PR TITLE
.editorconfig: Remove excess apostrophe at *.cocci

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -65,5 +65,5 @@ tab_width = 4
 [{*.bat,*.rc}]
 end_of_line = crlf
 
-[*.cocci]'
+[*.cocci]
 insert_final_newline = true


### PR DESCRIPTION
Remove the excess apostrophe (') introduced by commit c4b471bd1314933fd726ef987d96c92c68033f99.

Some editors complain about it.