### PR TITLE
add alternate raw mouse motion events with windows implementation

### DIFF
--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -158,6 +158,9 @@ typedef enum SDL_EventType
     SDL_EVENT_MOUSE_WHEEL,             /**< Mouse wheel motion */
     SDL_EVENT_MOUSE_ADDED,             /**< A new mouse has been inserted into the system */
     SDL_EVENT_MOUSE_REMOVED,           /**< A mouse has been removed */
+    SDL_EVENT_MOUSE_RAW_MOTION,        /**< Mouse moved (raw motion deltas) */
+    SDL_EVENT_MOUSE_RAW_BUTTON,        /**< Mouse click (raw button delta) */
+    SDL_EVENT_MOUSE_RAW_SCROLL,         /**< Mouse wheel (raw scroll deltas) */
 
     /* Joystick events */
     SDL_EVENT_JOYSTICK_AXIS_MOTION  = 0x600, /**< Joystick axis motion */
@@ -431,6 +434,23 @@ typedef struct SDL_MouseMotionEvent
 } SDL_MouseMotionEvent;
 
 /**
+ * Mouse raw motion and wheel event structure (event.maxis.*)
+ *
+ * \since This struct is available since SDL 3.0.0.
+ */
+typedef struct SDL_MouseRawAxisEvent
+{
+    SDL_EventType type; /**< SDL_EVENT_MOUSE_RAW_MOTION or SDL_EVENT_MOUSE_RAW_SCROLL */
+    Uint32 reserved;
+    Uint64 timestamp;   /**< In nanoseconds, populated using SDL_GetTicksNS() */
+    SDL_MouseID which;  /**< The mouse instance id, SDL_TOUCH_MOUSEID, or SDL_PEN_MOUSEID */
+    int dx;             /**< The axis delta value in the X direction */
+    int dy;             /**< The axis delta value in the Y direction */
+    float ux;           /**< The denominator unit in the X direction */
+    float uy;           /**< The denominator unit in the Y direction */
+} SDL_MouseRawAxisEvent;
+
+/**
  * Mouse button event structure (event.button.*)
  *
  * \since This struct is available since SDL 3.1.3.
@@ -449,6 +469,21 @@ typedef struct SDL_MouseButtonEvent
     float x;            /**< X coordinate, relative to window */
     float y;            /**< Y coordinate, relative to window */
 } SDL_MouseButtonEvent;
+
+/**
+ * Mouse raw button event structure (event.mbutton.*)
+ *
+ * \since This struct is available since SDL 3.0.0.
+ */
+typedef struct SDL_MouseRawButtonEvent
+{
+    SDL_EventType type; /**< SDL_EVENT_MOUSE_RAW_BUTTON */
+    Uint32 reserved;
+    Uint64 timestamp;   /**< In nanoseconds, populated using SDL_GetTicksNS() */
+    SDL_MouseID which;  /**< The mouse instance id, SDL_TOUCH_MOUSEID, or SDL_PEN_MOUSEID */
+    Uint8 button;       /**< The mouse button index */
+    Uint8 state;        /**< SDL_PRESSED or SDL_RELEASED */
+} SDL_MouseRawButtonEvent;
 
 /**
  * Mouse wheel event structure (event.wheel.*)
@@ -958,6 +993,8 @@ typedef union SDL_Event
     SDL_MouseMotionEvent motion;            /**< Mouse motion event data */
     SDL_MouseButtonEvent button;            /**< Mouse button event data */
     SDL_MouseWheelEvent wheel;              /**< Mouse wheel event data */
+    SDL_MouseRawAxisEvent maxis;            /**< Mouse raw axis event data (motion or wheel deltas) */
+    SDL_MouseRawButtonEvent mbutton;        /**< Mouse raw button event data */
     SDL_JoyDeviceEvent jdevice;             /**< Joystick device change event data */
     SDL_JoyAxisEvent jaxis;                 /**< Joystick axis event data */
     SDL_JoyBallEvent jball;                 /**< Joystick ball event data */

--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -390,6 +390,7 @@ static void SDL_LogEvent(const SDL_Event *event)
     // sensor/mouse/pen/finger motion are spammy, ignore these if they aren't demanded.
     if ((SDL_EventLoggingVerbosity < 2) &&
         ((event->type == SDL_EVENT_MOUSE_MOTION) ||
+         (event->type == SDL_EVENT_MOUSE_RAW_MOTION) ||
          (event->type == SDL_EVENT_FINGER_MOTION) ||
          (event->type == SDL_EVENT_PEN_AXIS) ||
          (event->type == SDL_EVENT_PEN_MOTION) ||
@@ -1704,6 +1705,12 @@ void SDL_SetEventEnabled(Uint32 type, bool enabled)
         if (type == SDL_EVENT_DROP_FILE || type == SDL_EVENT_DROP_TEXT) {
             SDL_ToggleDragAndDropSupport();
         }
+
+        if (type == SDL_EVENT_MOUSE_RAW_MOTION || 
+            type == SDL_EVENT_MOUSE_RAW_SCROLL || 
+            type == SDL_EVENT_MOUSE_RAW_BUTTON) {
+            SDL_UpdateRawMouseDataEnabled();
+        }
     }
 }
 
@@ -1791,6 +1798,9 @@ bool SDL_InitEvents(void)
         return false;
     }
 
+    SDL_SetEventEnabled(SDL_EVENT_MOUSE_RAW_MOTION, false);
+    SDL_SetEventEnabled(SDL_EVENT_MOUSE_RAW_SCROLL, false);
+    SDL_SetEventEnabled(SDL_EVENT_MOUSE_RAW_BUTTON, false);
     SDL_InitQuit();
 
     return true;

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -588,6 +588,34 @@ void SDL_SendMouseMotion(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouse
     SDL_PrivateSendMouseMotion(timestamp, window, mouseID, relative, x, y);
 }
 
+void SDL_SendRawMouseAxis(Uint64 timestamp, SDL_MouseID mouseID, int dx, int dy, float ux, float uy, SDL_EventType type)
+{
+    if (SDL_EventEnabled(type)) {
+        SDL_Event event;
+        event.type = type;
+        event.common.timestamp = timestamp;
+        event.maxis.which = mouseID;
+        event.maxis.dx = dx;
+        event.maxis.dy = dy;
+        event.maxis.ux = ux;
+        event.maxis.uy = uy;
+        SDL_PushEvent(&event);
+    }
+}
+
+void SDL_SendRawMouseButton(Uint64 timestamp, SDL_MouseID mouseID, Uint8 state, Uint8 button)
+{
+    if (SDL_EventEnabled(SDL_EVENT_MOUSE_RAW_BUTTON)) {
+        SDL_Event event;
+        event.type = SDL_EVENT_MOUSE_RAW_BUTTON;
+        event.common.timestamp = timestamp;
+        event.mbutton.which = mouseID;
+        event.mbutton.button = button;
+        event.mbutton.state = state;
+        SDL_PushEvent(&event);
+    }
+}
+
 static void ConstrainMousePosition(SDL_Mouse *mouse, SDL_Window *window, float *x, float *y)
 {
     /* make sure that the pointers find themselves inside the windows,

--- a/src/events/SDL_mouse_c.h
+++ b/src/events/SDL_mouse_c.h
@@ -167,6 +167,12 @@ extern bool SDL_UpdateMouseCapture(bool force_release);
 // Send a mouse motion event
 extern void SDL_SendMouseMotion(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouseID, bool relative, float x, float y);
 
+/* Send a raw mouse motion or scroll event */
+extern void SDL_SendRawMouseAxis(Uint64 timestamp, SDL_MouseID mouseID, int dx, int dy, float ux, float uy, SDL_EventType type);
+
+/* Send a raw mouse button event */
+extern void SDL_SendRawMouseButton(Uint64 timestamp, SDL_MouseID mouseID, Uint8 state, Uint8 button);
+
 // Send a mouse button event
 extern void SDL_SendMouseButton(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouseID, Uint8 button, bool down);
 

--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -380,6 +380,9 @@ struct SDL_VideoDevice
     // Display the system-level window menu
     void (*ShowWindowSystemMenu)(SDL_Window *window, int x, int y);
 
+    /* Re-synchronize platform raw input subscription */
+    bool (*RefreshRawInput)(SDL_VideoDevice *_this);
+
     /* * * */
     // Data common to all drivers
     SDL_ThreadID thread;
@@ -579,6 +582,7 @@ extern SDL_Window *SDL_GetToplevelForKeyboardFocus(void);
 extern bool SDL_ShouldAllowTopmost(void);
 
 extern void SDL_ToggleDragAndDropSupport(void);
+extern void SDL_UpdateRawMouseDataEnabled(void);
 
 extern SDL_TextInputType SDL_GetTextInputType(SDL_PropertiesID props);
 extern SDL_Capitalization SDL_GetTextInputCapitalization(SDL_PropertiesID props);

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2112,6 +2112,13 @@ void SDL_ToggleDragAndDropSupport(void)
     }
 }
 
+void SDL_UpdateRawMouseDataEnabled(void)
+{
+    if (_this && _this->RefreshRawInput) {
+        _this->RefreshRawInput(_this);
+    }
+}
+
 SDL_Window **SDLCALL SDL_GetWindows(int *count)
 {
     if (count) {

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -526,6 +526,46 @@ static bool WIN_SwapButtons(HANDLE hDevice)
 
 static void WIN_HandleRawMouseInput(Uint64 timestamp, SDL_VideoData *data, HANDLE hDevice, RAWMOUSE *rawmouse)
 {
+    int xraw = (int)rawmouse->lLastX;
+    int yraw = (int)rawmouse->lLastY;
+    bool haveMotion = (xraw || yraw) ? true : false;
+    bool haveButton = (rawmouse->usButtonFlags) ? true : false;
+    bool isAbsolute = (rawmouse->usFlags & MOUSE_MOVE_ABSOLUTE) ? true : false;
+    SDL_MouseID mouseID = (SDL_MouseID)(uintptr_t)hDevice;
+    
+    if (SDL_EventEnabled(SDL_EVENT_MOUSE_RAW_MOTION)) {
+        if (haveMotion && !isAbsolute) {
+            SDL_SendRawMouseAxis(timestamp, mouseID, xraw, yraw, 1.0f, 1.0f, SDL_EVENT_MOUSE_RAW_MOTION);
+        }
+    }
+    
+    if (SDL_EventEnabled(SDL_EVENT_MOUSE_RAW_BUTTON)) {
+        if (haveButton) {
+            USHORT flagBits = rawmouse->usButtonFlags;
+            for (Uint8 i = 0; i < 10; ++i) {
+                if (flagBits & 1) {
+                    Uint8 state = (i & 1) ^ 1;
+                    Uint8 button = (i >> 1) + 1;
+                    SDL_SendRawMouseButton(timestamp, mouseID, state, button);
+                }
+                flagBits = flagBits >> 1;
+            }
+        }
+    }
+    
+    if (SDL_EventEnabled(SDL_EVENT_MOUSE_RAW_SCROLL)) {
+        if (haveButton) {
+            short amount = (short)rawmouse->usButtonData;
+            if (rawmouse->usButtonFlags & RI_MOUSE_WHEEL) {
+                SDL_SendRawMouseAxis(timestamp, mouseID, 0, (int)amount, 120.0f, 120.0f, SDL_EVENT_MOUSE_RAW_SCROLL);
+            } else if (rawmouse->usButtonFlags & RI_MOUSE_HWHEEL) {
+                SDL_SendRawMouseAxis(timestamp, mouseID, (int)amount, 0, 120.0f, 120.0f, SDL_EVENT_MOUSE_RAW_SCROLL);
+            }
+        }
+    }
+
+    // this check is for whether relative mode should also receive events from the rawinput stream,
+    // separate from whether or not the optional rawaxis/rawbutton events should be generated.
     if (!data->raw_mouse_enabled) {
         return;
     }
@@ -540,87 +580,86 @@ static void WIN_HandleRawMouseInput(Uint64 timestamp, SDL_VideoData *data, HANDL
         return;
     }
 
-    SDL_MouseID mouseID = (SDL_MouseID)(uintptr_t)hDevice;
     SDL_WindowData *windowdata = window->internal;
 
-    if ((rawmouse->usFlags & 0x01) == MOUSE_MOVE_RELATIVE) {
-        if (rawmouse->lLastX || rawmouse->lLastY) {
-            SDL_SendMouseMotion(timestamp, window, mouseID, true, (float)rawmouse->lLastX, (float)rawmouse->lLastY);
-        }
-    } else if (rawmouse->lLastX || rawmouse->lLastY) {
-        /* This is absolute motion, either using a tablet or mouse over RDP
-
-            Notes on how RDP appears to work, as of Windows 10 2004:
-            - SetCursorPos() calls are cached, with multiple calls coalesced into a single call that's sent to the RDP client. If the last call to SetCursorPos() has the same value as the last one that was sent to the client, it appears to be ignored and not sent. This means that we need to jitter the SetCursorPos() position slightly in order for the recentering to work correctly.
-            - User mouse motion is coalesced with SetCursorPos(), so the WM_INPUT positions we see will not necessarily match the position we requested with SetCursorPos().
-            - SetCursorPos() outside of the bounds of the focus window appears not to do anything.
-            - SetCursorPos() while the cursor is NULL doesn't do anything
-
-            We handle this by creating a safe area within the application window, and when the mouse leaves that safe area, we warp back to the opposite side. Any single motion > 50% of the safe area is assumed to be a warp and ignored.
-        */
-        bool remote_desktop = GetSystemMetrics(SM_REMOTESESSION) ? true : false;
-        bool virtual_desktop = (rawmouse->usFlags & MOUSE_VIRTUAL_DESKTOP) ? true : false;
-        bool normalized_coordinates = !(rawmouse->usFlags & 0x40) ? true : false;
-        int w = GetSystemMetrics(virtual_desktop ? SM_CXVIRTUALSCREEN : SM_CXSCREEN);
-        int h = GetSystemMetrics(virtual_desktop ? SM_CYVIRTUALSCREEN : SM_CYSCREEN);
-        int x = normalized_coordinates ? (int)(((float)rawmouse->lLastX / 65535.0f) * w) : (int)rawmouse->lLastX;
-        int y = normalized_coordinates ? (int)(((float)rawmouse->lLastY / 65535.0f) * h) : (int)rawmouse->lLastY;
-        int relX, relY;
-
-        // Calculate relative motion
-        if (data->last_raw_mouse_position.x == 0 && data->last_raw_mouse_position.y == 0) {
+    if (haveMotion) {
+        if (!isAbsolute) {
+            SDL_SendMouseMotion(timestamp, window, mouseID, true, (float)xraw, (float)yraw);
+        } else {
+            /* This is absolute motion, either using a tablet or mouse over RDP
+    
+                Notes on how RDP appears to work, as of Windows 10 2004:
+                - SetCursorPos() calls are cached, with multiple calls coalesced into a single call that's sent to the RDP client. If the last call to SetCursorPos() has the same value as the last one that was sent to the client, it appears to be ignored and not sent. This means that we need to jitter the SetCursorPos() position slightly in order for the recentering to work correctly.
+                - User mouse motion is coalesced with SetCursorPos(), so the WM_INPUT positions we see will not necessarily match the position we requested with SetCursorPos().
+                - SetCursorPos() outside of the bounds of the focus window appears not to do anything.
+                - SetCursorPos() while the cursor is NULL doesn't do anything
+    
+                We handle this by creating a safe area within the application window, and when the mouse leaves that safe area, we warp back to the opposite side. Any single motion > 50% of the safe area is assumed to be a warp and ignored.
+            */
+            bool remote_desktop = GetSystemMetrics(SM_REMOTESESSION) ? true : false;
+            bool virtual_desktop = (rawmouse->usFlags & MOUSE_VIRTUAL_DESKTOP) ? true : false;
+            bool raw_coordinates = (rawmouse->usFlags & 0x40) ? true : false;
+            int w = GetSystemMetrics(virtual_desktop ? SM_CXVIRTUALSCREEN : SM_CXSCREEN);
+            int h = GetSystemMetrics(virtual_desktop ? SM_CYVIRTUALSCREEN : SM_CYSCREEN);
+            int x = raw_coordinates ? (int)xraw : (int)(((float)xraw / 65535.0f) * w);
+            int y = raw_coordinates ? (int)yraw : (int)(((float)yraw / 65535.0f) * h);
+            int relX, relY;
+    
+            /* Calculate relative motion */
+            if (data->last_raw_mouse_position.x == 0 && data->last_raw_mouse_position.y == 0) {
+                data->last_raw_mouse_position.x = x;
+                data->last_raw_mouse_position.y = y;
+            }
+            relX = x - data->last_raw_mouse_position.x;
+            relY = y - data->last_raw_mouse_position.y;
+    
+            if (remote_desktop) {
+                if (!windowdata->in_title_click && !windowdata->focus_click_pending) {
+                    static int wobble;
+                    float floatX = (float)x / w;
+                    float floatY = (float)y / h;
+    
+                    /* See if the mouse is at the edge of the screen, or in the RDP title bar area */
+                    if (floatX <= 0.01f || floatX >= 0.99f || floatY <= 0.01f || floatY >= 0.99f || y < 32) {
+                        /* Wobble the cursor position so it's not ignored if the last warp didn't have any effect */
+                        RECT rect = windowdata->cursor_clipped_rect;
+                        int warpX = rect.left + ((rect.right - rect.left) / 2) + wobble;
+                        int warpY = rect.top + ((rect.bottom - rect.top) / 2);
+    
+                        WIN_SetCursorPos(warpX, warpY);
+    
+                        ++wobble;
+                        if (wobble > 1) {
+                            wobble = -1;
+                        }
+                    } else {
+                        /* Send relative motion if we didn't warp last frame (had good position data)
+                           We also sometimes get large deltas due to coalesced mouse motion and warping,
+                           so ignore those.
+                         */
+                        const int MAX_RELATIVE_MOTION = (h / 6);
+                        if (SDL_abs(relX) < MAX_RELATIVE_MOTION &&
+                            SDL_abs(relY) < MAX_RELATIVE_MOTION) {
+                            SDL_SendMouseMotion(timestamp, window, mouseID, true, (float)relX, (float)relY);
+                        }
+                    }
+                }
+            } else {
+                const int MAXIMUM_TABLET_RELATIVE_MOTION = 32;
+                if (SDL_abs(relX) > MAXIMUM_TABLET_RELATIVE_MOTION ||
+                    SDL_abs(relY) > MAXIMUM_TABLET_RELATIVE_MOTION) {
+                    /* Ignore this motion, probably a pen lift and drop */
+                } else {
+                    SDL_SendMouseMotion(timestamp, window, mouseID, true, (float)relX, (float)relY);
+                }
+            }
+    
             data->last_raw_mouse_position.x = x;
             data->last_raw_mouse_position.y = y;
         }
-        relX = x - data->last_raw_mouse_position.x;
-        relY = y - data->last_raw_mouse_position.y;
-
-        if (remote_desktop) {
-            if (!windowdata->in_title_click && !windowdata->focus_click_pending) {
-                static int wobble;
-                float floatX = (float)x / w;
-                float floatY = (float)y / h;
-
-                // See if the mouse is at the edge of the screen, or in the RDP title bar area
-                if (floatX <= 0.01f || floatX >= 0.99f || floatY <= 0.01f || floatY >= 0.99f || y < 32) {
-                    // Wobble the cursor position so it's not ignored if the last warp didn't have any effect
-                    RECT rect = windowdata->cursor_clipped_rect;
-                    int warpX = rect.left + ((rect.right - rect.left) / 2) + wobble;
-                    int warpY = rect.top + ((rect.bottom - rect.top) / 2);
-
-                    WIN_SetCursorPos(warpX, warpY);
-
-                    ++wobble;
-                    if (wobble > 1) {
-                        wobble = -1;
-                    }
-                } else {
-                    /* Send relative motion if we didn't warp last frame (had good position data)
-                       We also sometimes get large deltas due to coalesced mouse motion and warping,
-                       so ignore those.
-                     */
-                    const int MAX_RELATIVE_MOTION = (h / 6);
-                    if (SDL_abs(relX) < MAX_RELATIVE_MOTION &&
-                        SDL_abs(relY) < MAX_RELATIVE_MOTION) {
-                        SDL_SendMouseMotion(timestamp, window, mouseID, true, (float)relX, (float)relY);
-                    }
-                }
-            }
-        } else {
-            const int MAXIMUM_TABLET_RELATIVE_MOTION = 32;
-            if (SDL_abs(relX) > MAXIMUM_TABLET_RELATIVE_MOTION ||
-                SDL_abs(relY) > MAXIMUM_TABLET_RELATIVE_MOTION) {
-                // Ignore this motion, probably a pen lift and drop
-            } else {
-                SDL_SendMouseMotion(timestamp, window, mouseID, true, (float)relX, (float)relY);
-            }
-        }
-
-        data->last_raw_mouse_position.x = x;
-        data->last_raw_mouse_position.y = y;
     }
 
-    if (rawmouse->usButtonFlags) {
+    if (haveButton) {
         static struct {
             USHORT usButtonFlags;
             Uint8 button;

--- a/src/video/windows/SDL_windowsrawinput.c
+++ b/src/video/windows/SDL_windowsrawinput.c
@@ -29,6 +29,7 @@
 #include "SDL_windowsevents.h"
 
 #include "../../joystick/usb_ids.h"
+#include "../../events/SDL_events_c.h"
 
 #define ENABLE_RAW_MOUSE_INPUT      0x01
 #define ENABLE_RAW_KEYBOARD_INPUT   0x02
@@ -185,7 +186,10 @@ static bool WIN_UpdateRawInputEnabled(SDL_VideoDevice *_this)
 {
     SDL_VideoData *data = _this->internal;
     Uint32 flags = 0;
-    if (data->raw_mouse_enabled) {
+    if (SDL_EventEnabled(SDL_EVENT_MOUSE_RAW_MOTION) || 
+        SDL_EventEnabled(SDL_EVENT_MOUSE_RAW_SCROLL) ||
+        SDL_EventEnabled(SDL_EVENT_MOUSE_RAW_BUTTON) ||
+        data->raw_mouse_enabled) {
         flags |= ENABLE_RAW_MOUSE_INPUT;
     }
     if (data->raw_keyboard_enabled) {
@@ -237,6 +241,11 @@ bool WIN_SetRawKeyboardEnabled(SDL_VideoDevice *_this, bool enabled)
     return true;
 }
 
+bool WIN_RefreshRawInputEnabled(SDL_VideoDevice *_this)
+{
+    return WIN_UpdateRawInputEnabled(_this);
+}
+
 #else
 
 bool WIN_SetRawMouseEnabled(SDL_VideoDevice *_this, bool enabled)
@@ -249,6 +258,10 @@ bool WIN_SetRawKeyboardEnabled(SDL_VideoDevice *_this, bool enabled)
     return SDL_Unsupported();
 }
 
+bool WIN_RefreshRawInputEnabled(SDL_VideoDevice *_this)
+{
+    return SDL_Unsupported();
+}
 #endif // !SDL_PLATFORM_XBOXONE && !SDL_PLATFORM_XBOXSERIES
 
 #endif // SDL_VIDEO_DRIVER_WINDOWS

--- a/src/video/windows/SDL_windowsrawinput.h
+++ b/src/video/windows/SDL_windowsrawinput.h
@@ -25,5 +25,6 @@
 
 extern bool WIN_SetRawMouseEnabled(SDL_VideoDevice *_this, bool enabled);
 extern bool WIN_SetRawKeyboardEnabled(SDL_VideoDevice *_this, bool enabled);
+extern bool WIN_RefreshRawInputEnabled(SDL_VideoDevice *_this);
 
 #endif // SDL_windowsrawinput_h_

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -246,6 +246,7 @@ static SDL_VideoDevice *WIN_CreateDevice(void)
     device->OnWindowEnter = WIN_OnWindowEnter;
     device->SetWindowHitTest = WIN_SetWindowHitTest;
     device->AcceptDragAndDrop = WIN_AcceptDragAndDrop;
+    device->RefreshRawInput = WIN_RefreshRawInputEnabled;
     device->FlashWindow = WIN_FlashWindow;
     device->ShowWindowSystemMenu = WIN_ShowWindowSystemMenu;
     device->SetWindowFocusable = WIN_SetWindowFocusable;


### PR DESCRIPTION
Proof of concept that closes #7674. Other platforms can be implemented on a rolling basis but shouldn't be a blocker for merge.
