### PR TITLE
 JANITORIAL: Fix typos in comments in various files

### DIFF
--- a/docs/README-documentation-rules.md
+++ b/docs/README-documentation-rules.md
@@ -17,7 +17,7 @@ rules we need to obey to cooperate with those scripts.
 ## The wiki and headers share the same text.
 
 There is a massive Perl script (`build-scripts/wikiheaders.pl`, hereafter
-refered to as "wikiheaders") that can read both the wiki and the public
+referred to as "wikiheaders") that can read both the wiki and the public
 headers, and move changes in one across to the other.
 
 If you prefer to use the wiki, go ahead and edit there. If you prefer to use

--- a/docs/README-emscripten.md
+++ b/docs/README-emscripten.md
@@ -110,7 +110,7 @@ to actually run if main() were to continue on, since we're just
 getting started.
 
 There's a lot of little details that are beyond the scope of this
-document, but that's the biggest intial set of hurdles to porting
+document, but that's the biggest initial set of hurdles to porting
 your app to the web.
 
 

--- a/docs/README-gdk.md
+++ b/docs/README-gdk.md
@@ -151,7 +151,7 @@ In general, the same process in the Windows GDK instructions work. There are jus
 * For Xbox Series consoles, use the Gaming.Xbox.Scarlett.x64 target
 * The Xbox One target sets the `SDL_PLATFORM_XBOXONE` define and the Xbox Series target sets the `SDL_PLATFORM_XBOXSERIES` define
 * You don't need to link against the Xbox.Services Thunks lib nor include that dll in your package (it doesn't exist for Xbox)
-* The shader blobs for Xbox are created in a pre-build step for the Xbox targets, rather than included in the source (due to NDA and version compatability reasons)
+* The shader blobs for Xbox are created in a pre-build step for the Xbox targets, rather than included in the source (due to NDA and version compatibility reasons)
 * To create a package, use:
   `makepkg pack /f PackageLayout.xml /lt /d . /pd Package`
 * To install the package, use:

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -70,7 +70,7 @@ The SDL 1.2 audio compatibility API has also been removed, as it was a simplifie
 
 SDL3 will not implicitly initialize the audio subsystem on your behalf if you open a device without doing so. Please explicitly call SDL_Init(SDL_INIT_AUDIO) at some point.
 
-SDL2 refered to audio devices that record sound as "capture" devices, and ones that play sound to speakers as "output" devices. In SDL3, we've changed this terminology to be "recording" devices and "playback" devices, which we hope is more clear.
+SDL2 referred to audio devices that record sound as "capture" devices, and ones that play sound to speakers as "output" devices. In SDL3, we've changed this terminology to be "recording" devices and "playback" devices, which we hope is more clear.
 
 SDL3's audio subsystem offers an enormous amount of power over SDL2, but if you just want a simple migration of your existing code, you can ignore most of it. The simplest migration path from SDL2 looks something like this:
 
@@ -1918,7 +1918,7 @@ a corresponding event has been received:
 * SDL_RestoreWindow() (SDL_EVENT_WINDOW_RESTORED)
 * SDL_SetWindowFullscreen() (SDL_EVENT_WINDOW_ENTER_FULLSCREEN / SDL_EVENT_WINDOW_LEAVE_FULLSCREEN)
 
-If it is required that operations be applied immediately after one of the preceeding calls, the `SDL_SyncWindow()` function
+If it is required that operations be applied immediately after one of the preceding calls, the `SDL_SyncWindow()` function
 will attempt to wait until all pending window operations have completed. The `SDL_HINT_VIDEO_SYNC_WINDOW_OPERATIONS` hint
 can also be set to automatically synchronize after all calls to an asynchronous window operation, mimicking the behavior
 of SDL 2. Be aware that synchronizing can potentially block for long periods of time, as it may have to wait for window

--- a/docs/README-ps2.md
+++ b/docs/README-ps2.md
@@ -31,7 +31,7 @@ int main(int argc, char *argv[])
 ```
 For a release binary is recommendable to reset the IOP always.
 
-Remember to do a clean compilation everytime you enable or disable the `SDL_PS2_SKIP_IOP_RESET` otherwise the change won't be reflected.
+Remember to do a clean compilation every time you enable or disable the `SDL_PS2_SKIP_IOP_RESET` otherwise the change won't be reflected.
 
 ## Getting PS2 Dev
 [Installing PS2 Dev](https://github.com/ps2dev/ps2dev)

--- a/include/SDL3/SDL_camera.h
+++ b/include/SDL3/SDL_camera.h
@@ -249,7 +249,7 @@ extern SDL_DECLSPEC const char * SDLCALL SDL_GetCameraDeviceName(SDL_CameraDevic
  * Get the position of the camera in relation to the system.
  *
  * Most platforms will report UNKNOWN, but mobile devices, like phones, can
- * often make a distiction between cameras on the front of the device (that
+ * often make a distinction between cameras on the front of the device (that
  * points towards the user, for taking "selfies") and cameras on the back (for
  * filming in the direction the user is facing).
  *

--- a/include/SDL3/SDL_dialog.h
+++ b/include/SDL3/SDL_dialog.h
@@ -68,7 +68,7 @@ typedef struct SDL_DialogFileFilter
  *
  * If `filelist` is:
  *
- * - NULL, an error occured. Details can be obtained with SDL_GetError().
+ * - NULL, an error occurred. Details can be obtained with SDL_GetError().
  * - A pointer to NULL, the user either didn't choose any file or canceled the
  *   dialog.
  * - A pointer to non-`NULL`, the user chose one or more files. The argument
@@ -105,7 +105,7 @@ typedef void(SDLCALL *SDL_DialogFileCallback)(void *userdata, const char * const
  *
  * The callback will be invoked with a null-terminated list of files the user
  * chose. The list will be empty if the user canceled the dialog, and it will
- * be NULL if an error occured.
+ * be NULL if an error occurred.
  *
  * Note that the callback may be called from a different thread than the one
  * the function was invoked on.
@@ -122,7 +122,7 @@ typedef void(SDLCALL *SDL_DialogFileCallback)(void *userdata, const char * const
  *                 error occurs. The first argument is a null-terminated list
  *                 of C strings, representing the paths chosen by the user.
  *                 The list will be empty if the user canceled the dialog, and
- *                 it will be NULL if an error occured. If an error occured,
+ *                 it will be NULL if an error occurred. If an error occurred,
  *                 it can be fetched with SDL_GetError(). The second argument
  *                 is the userdata pointer passed to the function. The third
  *                 argument is the index of the filter selected by the user,
@@ -163,7 +163,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_ShowOpenFileDialog(SDL_DialogFileCallback c
  *
  * The callback will be invoked with a null-terminated list of files the user
  * chose. The list will be empty if the user canceled the dialog, and it will
- * be NULL if an error occured.
+ * be NULL if an error occurred.
  *
  * Note that the callback may be called from a different thread than the one
  * the function was invoked on.
@@ -179,7 +179,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_ShowOpenFileDialog(SDL_DialogFileCallback c
  *                 error occurs. The first argument is a null-terminated list
  *                 of C strings, representing the paths chosen by the user.
  *                 The list will be empty if the user canceled the dialog, and
- *                 it will be NULL if an error occured. If an error occured,
+ *                 it will be NULL if an error occurred. If an error occurred,
  *                 it can be fetched with SDL_GetError(). The second argument
  *                 is the userdata pointer passed to the function. The third
  *                 argument is the index of the filter selected by the user,
@@ -217,7 +217,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_ShowSaveFileDialog(SDL_DialogFileCallback c
  *
  * The callback will be invoked with a null-terminated list of files the user
  * chose. The list will be empty if the user canceled the dialog, and it will
- * be NULL if an error occured.
+ * be NULL if an error occurred.
  *
  * Note that the callback may be called from a different thread than the one
  * the function was invoked on.
@@ -234,7 +234,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_ShowSaveFileDialog(SDL_DialogFileCallback c
  *                 error occurs. The first argument is a null-terminated list
  *                 of C strings, representing the paths chosen by the user.
  *                 The list will be empty if the user canceled the dialog, and
- *                 it will be NULL if an error occured. If an error occured,
+ *                 it will be NULL if an error occurred. If an error occurred,
  *                 it can be fetched with SDL_GetError(). The second argument
  *                 is the userdata pointer passed to the function. The third
  *                 argument is always -1 for SDL_ShowOpenFolderDialog.

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -327,7 +327,7 @@ extern "C" {
  * latency or higher throughput AND ARE WILLING TO DEAL WITH what that might
  * require of the app), they can specify it.
  *
- * SDL will try to accomodate this value, but there is no promise you'll get
+ * SDL will try to accommodate this value, but there is no promise you'll get
  * the buffer size requested. Many platforms won't honor this request at all,
  * or might adjust it.
  *
@@ -1050,7 +1050,7 @@ extern "C" {
 #define SDL_HINT_JOYSTICK_ARCADESTICK_DEVICES_EXCLUDED "SDL_JOYSTICK_ARCADESTICK_DEVICES_EXCLUDED"
 
 /**
- * A variable containing a list of devices that should not be considerd
+ * A variable containing a list of devices that should not be considered
  * joysticks.
  *
  * The format of the string is a comma separated list of USB VID/PID pairs in
@@ -2590,7 +2590,7 @@ extern "C" {
  *
  * The variable can be set to the following values:
  *
- * - "0": Use the prefered OS device. (default)
+ * - "0": Use the preferred OS device. (default)
  * - "1": Select a low power device.
  *
  * This hint should be set before creating a renderer.

--- a/include/SDL3/SDL_keycode.h
+++ b/include/SDL3/SDL_keycode.h
@@ -314,7 +314,7 @@ typedef Uint16 SDL_Keymod;
 #define SDL_KMOD_NUM    0x1000u /**< the Num Lock key (may be located on an extended keypad) is down. */
 #define SDL_KMOD_CAPS   0x2000u /**< the Caps Lock key is down. */
 #define SDL_KMOD_MODE   0x4000u /**< the !AltGr key is down. */
-#define SDL_KMOD_SCROLL 0x8000u /**< the Scoll Lock key is down. */
+#define SDL_KMOD_SCROLL 0x8000u /**< the Scroll Lock key is down. */
 #define SDL_KMOD_CTRL   (SDL_KMOD_LCTRL | SDL_KMOD_RCTRL)   /**< Any Ctrl key is down. */
 #define SDL_KMOD_SHIFT  (SDL_KMOD_LSHIFT | SDL_KMOD_RSHIFT) /**< Any Shift key is down. */
 #define SDL_KMOD_ALT    (SDL_KMOD_LALT | SDL_KMOD_RALT)     /**< Any Alt key is down. */

--- a/src/audio/SDL_audiocvt.c
+++ b/src/audio/SDL_audiocvt.c
@@ -49,7 +49,7 @@
  *
  * These are listed in the order they are laid out in
  * memory, so "FL+FR" means "the front left speaker is
- * layed out in memory first, then the front right, then
+ * laid out in memory first, then the front right, then
  * it repeats for the next audio frame".
  *
  * 1 channel (mono) layout: FRONT

--- a/src/camera/mediafoundation/SDL_camera_mediafoundation.c
+++ b/src/camera/mediafoundation/SDL_camera_mediafoundation.c
@@ -362,7 +362,7 @@ static int MEDIAFOUNDATION_WaitDevice(SDL_CameraDevice *device)
         }
 
         // we currently ignore stream_flags format changes, but my _hope_ is that IMFSourceReader is handling this and
-        // will continue to give us the explictly-specified format we requested when opening the device, though, and
+        // will continue to give us the explicitly-specified format we requested when opening the device, though, and
         // we don't have to manually deal with it.
 
         if (sample != NULL) {

--- a/src/hidapi/linux/hid.c
+++ b/src/hidapi/linux/hid.c
@@ -291,7 +291,7 @@ static __u32 get_hid_report_bytes(const __u8 *rpt, size_t len, size_t num_bytes,
  * Skips all nested Collection, i.e. iterates until the end of current level Collection.
  *
  * The return value is non-0 when an end of current Collection is found,
- * 0 when error is occured (broken Descriptor, end of a Collection is found before its begin,
+ * 0 when error is occurred (broken Descriptor, end of a Collection is found before its begin,
  *  or no Collection is found at all).
  */
 static int hid_iterate_over_collection(const __u8 *report_descriptor, __u32 size, unsigned int *pos, int *data_len, int *key_size)

--- a/src/hidapi/netbsd/hid.c
+++ b/src/hidapi/netbsd/hid.c
@@ -234,7 +234,7 @@ static uint32_t get_hid_report_bytes(const uint8_t *rpt, size_t len, size_t num_
  * Skips all nested Collection, i.e. iterates until the end of current level Collection.
  *
  * The return value is non-0 when an end of current Collection is found,
- * 0 when error is occured (broken Descriptor, end of a Collection is found before its begin,
+ * 0 when error is occurred (broken Descriptor, end of a Collection is found before its begin,
  *  or no Collection is found at all).
  */
 static int hid_iterate_over_collection(const uint8_t *report_descriptor, uint32_t size, unsigned int *pos, int *data_len, int *key_size)

--- a/src/joystick/hidapi/steam/controller_structs.h
+++ b/src/joystick/hidapi/steam/controller_structs.h
@@ -158,7 +158,7 @@ typedef struct
 // message types within ValveInReport_t or the header itself.  Hopefully this should
 // be super rare and instead you should just add new message payloads to the union,
 // or just add fields to the end of existing payload structs which is expected to be 
-// safe in all code consuming these as they should just consume/copy upto the prior size 
+// safe in all code consuming these as they should just consume/copy up to the prior size 
 // they were aware of when processing.
 #define k_ValveInReportMsgVersion 0x01
 

--- a/src/stdlib/SDL_malloc.c
+++ b/src/stdlib/SDL_malloc.c
@@ -4276,7 +4276,7 @@ void* dlmalloc(size_t bytes) {
 
 void dlfree(void* mem) {
   /*
-     Consolidate freed chunks with preceeding or succeeding bordering
+     Consolidate freed chunks with preceding or succeeding bordering
      free chunks, if they exist, and then place in a bin.  Intermixed
      with special cases for top, dv, mmapped chunks, and usage errors.
   */
@@ -5113,10 +5113,10 @@ History:
         Wolfram Gloger (Gloger@lrz.uni-muenchen.de).
       * Use last_remainder in more cases.
       * Pack bins using idea from  colin@nyx10.cs.du.edu
-      * Use ordered bins instead of best-fit threshhold
+      * Use ordered bins instead of best-fit threshold
       * Eliminate block-local decls to simplify tracing and debugging.
       * Support another case of realloc via move into top
-      * Fix error occuring when initial sbrk_base not word-aligned.
+      * Fix error occurring when initial sbrk_base not word-aligned.
       * Rely on page size for units instead of SBRK_UNIT to
         avoid surprises about sbrk alignment conventions.
       * Add mallinfo, mallopt. Thanks to Raymond Nijssen

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -3428,7 +3428,7 @@ int SDL_SetWindowModalFor(SDL_Window *modal_window, SDL_Window *parent_window)
     const int ret = _this->SetWindowModalFor(_this, modal_window, parent_window);
 
     /* The existing parent might be needed when changing the modal status,
-     * so don't change the heirarchy until after setting the new modal state.
+     * so don't change the hierarchy until after setting the new modal state.
      */
     if (!ret) {
         SDL_SetWindowParent(modal_window, !ret ? parent_window : NULL);

--- a/test/testautomation.c
+++ b/test/testautomation.c
@@ -49,7 +49,7 @@ static SDLTest_TestSuiteReference *testSuites[] = {
     &timeTestSuite,
     &timerTestSuite,
     &videoTestSuite,
-    &subsystemsTestSuite, /* run last, not interfere with other test enviroment */
+    &subsystemsTestSuite, /* run last, not interfere with other test environment */
     NULL
 };
 


### PR DESCRIPTION
Fixed a bunch of misspelling in various files.

Those are all within comments