### PR TITLE
Add bounds checks in SDL_qsort

### DIFF
--- a/src/stdlib/SDL_qsort.c
+++ b/src/stdlib/SDL_qsort.c
@@ -333,7 +333,7 @@ typedef struct { char * first; char * last; } stack_entry;
     char *test;					\
     /* Find the right place for |first|.	\
      * My apologies for var reuse. */		\
-    for (test=first-size;compare(userdata,test,first)>0;test-=size) ;	\
+    for (test=first-size;test>(char*)base&&compare(userdata,test,first)>0;test-=size) ;	\
     test+=size;					\
     if (test!=first) {				\
       /* Shift everything in [test,first)	\
@@ -418,6 +418,7 @@ static void qsort_r_nonaligned(void *base, size_t nmemb, size_t size,
     while (1) {
       /* Select pivot */
       { char * mid=first+size*((last-first)/size >> 1);
+        if (mid>=last) break;
         Pivot(SWAP_nonaligned,size);
         memcpy(pivot,mid,size);
       }
@@ -449,6 +450,7 @@ static void qsort_r_aligned(void *base, size_t nmemb, size_t size,
     while (1) {
       /* Select pivot */
       { char * mid=first+size*((last-first)/size >> 1);
+        if (mid>=last) break;
         Pivot(SWAP_aligned,size);
         memcpy(pivot,mid,size);
       }
@@ -484,6 +486,7 @@ fprintf(stderr,"Doing %d:%d: ",
 #endif
       /* Select pivot */
       { char * mid=first+WORD_BYTES*((last-first) / (2*WORD_BYTES));
+        if (mid>=last) break;
         Pivot(SWAP_words,WORD_BYTES);
         *(int*)pivot=*(int*)mid;
 #ifdef DEBUG_QSORT
@@ -506,7 +509,7 @@ fprintf(stderr, "after partitioning first=#%lu last=#%lu\n", (first-(char*)base)
     /* Find the right place for |first|. My apologies for var reuse */
     int *pl=(int*)(first-WORD_BYTES),*pr=(int*)first;
     *(int*)pivot=*(int*)first;
-    for (;compare(userdata,pl,pivot)>0;pr=pl,--pl) {
+    for (;pl>(int*)base&&compare(userdata,pl,pivot)>0;pr=pl,--pl) {
       *pr=*pl; }
     if (pr!=(int*)first) *pr=*(int*)pivot;
   }


### PR DESCRIPTION
## Description
Updating qsort implementation fixed only part of the non-transitive compare issue.
Using such a compare function should be considered a user code bug, but I believe it's better not to crash the whole program.
I set up a fuzzer and found a few unchecked memory reads and writes. With the proposed changes, qsort will not crash with invalid compare functions.
Fuzzer source code: [fuzzer.zip](https://github.com/user-attachments/files/15907303/fuzzer.zip)
