### PR TITLE
testmanymouse: enable raw keyboard events on Windows

### DIFF
--- a/test/testmanymouse.c
+++ b/test/testmanymouse.c
@@ -507,6 +507,9 @@ int main(int argc, char *argv[])
     /* Log all events, including mouse motion */
     SDL_SetHint(SDL_HINT_EVENT_LOGGING, "2");
 
+    /* Support for multiple keyboards requires raw keyboard events on Windows */
+    SDL_SetHint(SDL_HINT_WINDOWS_RAW_KEYBOARD, "1");
+
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, SDL_INIT_VIDEO);
     if (!state) {


### PR DESCRIPTION
This is required for supporting multiple keyboards on Windows.

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
