### PR TITLE
wayland: Set EGL_SWAP_BEHAVIOR_PRESERVED_BIT on surface create

### DIFF
--- a/src/video/SDL_egl.c
+++ b/src/video/SDL_egl.c
@@ -816,6 +816,12 @@ static int SDL_EGL_PrivateChooseConfig(SDL_VideoDevice *_this, SDL_bool set_conf
         attribs[i++] = _this->egl_data->egl_surfacetype;
     }
 
+#ifdef EGL_SWAP_BEHAVIOR_PRESERVED_BIT
+    if (_this->egl_data->egl_swap_behavior_preserved_bit) {
+        attribs[i++] = EGL_SWAP_BEHAVIOR_PRESERVED_BIT;
+    }
+#endif
+
     attribs[i++] = EGL_NONE;
 
     SDL_assert(i < SDL_arraysize(attribs));

--- a/src/video/SDL_egl_c.h
+++ b/src/video/SDL_egl_c.h
@@ -69,7 +69,6 @@ typedef struct SDL_EGL_VideoData
     EGLConfig egl_config;
     int egl_swapinterval;
     int egl_swap_behavior_preserved_bit;
-    int egl_surfacetype;
     int egl_version_major, egl_version_minor;
     EGLint egl_required_visual_id;
     SDL_bool is_offscreen; /* whether EGL display was offscreen */

--- a/src/video/SDL_egl_c.h
+++ b/src/video/SDL_egl_c.h
@@ -68,6 +68,7 @@ typedef struct SDL_EGL_VideoData
     EGLDisplay egl_display;
     EGLConfig egl_config;
     int egl_swapinterval;
+    int egl_swap_behavior_preserved_bit;
     int egl_surfacetype;
     int egl_version_major, egl_version_minor;
     EGLint egl_required_visual_id;

--- a/src/video/wayland/SDL_waylandopengles.c
+++ b/src/video/wayland/SDL_waylandopengles.c
@@ -41,6 +41,8 @@ int Wayland_GLES_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 
     ret = SDL_EGL_LoadLibrary(_this, path, (NativeDisplayType)data->display, _this->gl_config.egl_platform);
 
+    _this->egl_data->egl_swap_behavior_preserved_bit = 1;
+
     Wayland_PumpEvents(_this);
     WAYLAND_wl_display_flush(data->display);
 


### PR DESCRIPTION
## Description
Set EGL_SWAP_BUFFERS_PRESERVE_BIT when using wayland wm. The working theory is that this was implicitly set on X clients but not on wayland clients.

### Note
Video coding is not my comfort zone so this fix is mostly me guessing on how we'd want to fix this and knowing about one line of code that does fix the problem. Please comment and set me on the right path if this is not how we want to solve this issue.

## Existing Issue(s)
Issue: #7647 