### PR TITLE
testevdev: Associate HID reports for pedals with their other test data

### DIFF
--- a/test/testevdev.c
+++ b/test/testevdev.c
@@ -2003,6 +2003,8 @@ static const GuessTest guess_tests[] =
       .ev = { 0x09 },
       /* X, Y, Z */
       .abs = { 0x07 },
+      .hid_report_descriptor_length = sizeof (vrs_pedals_hid_report_descriptor),
+      .hid_report_descriptor = &vrs_pedals_hid_report_descriptor[0],
     },
     { /* https://github.com/ValveSoftware/Proton/issues/5126 */
       .name = "Heusinkveld Heusinkveld Sim Pedals Ultimate",
@@ -2019,6 +2021,8 @@ static const GuessTest guess_tests[] =
       .ev = { 0x09 },
       /* RX, RY, RZ */
       .abs = { 0x38 },
+      .hid_report_descriptor_length = sizeof (heusinkveld_pedals_hid_report_descriptor),
+      .hid_report_descriptor = &heusinkveld_pedals_hid_report_descriptor[0],
     },
     { /* https://github.com/ValveSoftware/Proton/issues/5126 */
       .name = "Vitaly [mega_mozg] Naidentsev ODDOR-handbrake",

--- a/test/testevdev.c
+++ b/test/testevdev.c
@@ -247,7 +247,6 @@ static unsigned char steam_deck_oled_js_hid_report_descriptor[] =
 SDL_COMPILE_TIME_ASSERT (steam_deck_oled_js,
                          sizeof (steam_deck_oled_js_hid_report_descriptor) == 38);
 
-#if 0 /* unused for now */
 static unsigned char vrs_pedals_hid_report_descriptor[] =
 {
     /* Generic Desktop / Joystick */
@@ -265,7 +264,6 @@ static unsigned char vrs_pedals_hid_report_descriptor[] =
     0x09, 0x01, 0x81, 0x02, 0xc0, 0xc0,
 };
 SDL_COMPILE_TIME_ASSERT (vrs_pedals, sizeof (vrs_pedals_hid_report_descriptor) == 0136);
-#endif
 
 static unsigned char thinkpad_usb_keyboard_hid_report_descriptor[] =
 {
@@ -313,7 +311,6 @@ static unsigned char thinkpad_usb_trackpoint_hid_report_descriptor[] =
 };
 SDL_COMPILE_TIME_ASSERT (thinkpad_usb_trackpoint, sizeof (thinkpad_usb_trackpoint_hid_report_descriptor) == 185);
 
-#if 0 /* unused for now */
 static unsigned char heusinkveld_pedals_hid_report_descriptor[] =
 {
     /* Generic Desktop / Joystick */
@@ -327,7 +324,6 @@ static unsigned char heusinkveld_pedals_hid_report_descriptor[] =
     0x01, 0xc0,
 };
 SDL_COMPILE_TIME_ASSERT (heusinkveld_pedals, sizeof (heusinkveld_pedals_hid_report_descriptor) == 072);
-#endif
 
 static unsigned char fanatec_handbrake_hid_report_descriptor[] =
 {


### PR DESCRIPTION
* Revert "testevdev.c:  comment out two unused data to fix build."
    
    This reverts commit e4f53e6b214cf476c9ad4b035ead97fb62da81c0.
    We'll use these in the next commit.

* testevdev: Associate HID reports for pedals with their other test data
    
    This is how these globals were intended to have been used, similar to
    what we already did for the Fanatec device.
    
    Fixes: 3772d6cc "testevdev: Add raw HID report descriptors where available"