### PR TITLE
Fix memory leak in stdcpp systhread implementation

### DIFF
--- a/src/thread/stdcpp/SDL_systhread.cpp
+++ b/src/thread/stdcpp/SDL_systhread.cpp
@@ -121,8 +121,12 @@ SDL_SYS_WaitThread(SDL_Thread *thread)
 
     try {
         std::thread *cpp_thread = (std::thread *)thread->handle;
-        if (cpp_thread->joinable()) {
-            cpp_thread->join();
+        if (cpp_thread) {
+            if (cpp_thread->joinable()) {
+                cpp_thread->join();
+            }
+            delete cpp_thread;
+            thread->handle = nullptr;
         }
     } catch (std::system_error &) {
         // An error occurred when joining the thread.  SDL_WaitThread does not,
@@ -140,8 +144,12 @@ SDL_SYS_DetachThread(SDL_Thread *thread)
 
     try {
         std::thread *cpp_thread = (std::thread *)thread->handle;
-        if (cpp_thread->joinable()) {
-            cpp_thread->detach();
+        if (cpp_thread) {
+            if (cpp_thread->joinable()) {
+                cpp_thread->detach();
+            }
+            delete cpp_thread;
+            thread->handle = nullptr;
         }
     } catch (std::system_error &) {
         // An error occurred when detaching the thread.  SDL_DetachThread does not,


### PR DESCRIPTION
In the c++thread implementation, the allocated `std::thread` objects were never deleted after joining/detaching.