### PR TITLE
Check if SDL_GetKeyboardFocus is null in X11/Wayland events

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -381,7 +381,8 @@ int Wayland_WaitEventTimeout(SDL_VideoDevice *_this, Sint64 timeoutNS)
     WAYLAND_wl_display_flush(d->display);
 
 #ifdef SDL_USE_IME
-    if (!d->text_input_manager && SDL_TextInputActive(SDL_GetKeyboardFocus())) {
+    SDL_Window *keyboard_focus = SDL_GetKeyboardFocus();
+    if (!d->text_input_manager && keyboard_focus && SDL_TextInputActive(keyboard_focus)) {
         SDL_IME_PumpEvents();
     }
 #endif
@@ -454,7 +455,8 @@ void Wayland_PumpEvents(SDL_VideoDevice *_this)
     int err;
 
 #ifdef SDL_USE_IME
-    if (!d->text_input_manager && SDL_TextInputActive(SDL_GetKeyboardFocus())) {
+    SDL_Window *keyboard_focus = SDL_GetKeyboardFocus();
+    if (!d->text_input_manager && keyboard_focus && SDL_TextInputActive(keyboard_focus)) {
         SDL_IME_PumpEvents();
     }
 #endif
@@ -1649,7 +1651,8 @@ static void keyboard_handle_key(void *data, struct wl_keyboard *keyboard,
     Wayland_UpdateImplicitGrabSerial(input, serial);
 
     if (state == WL_KEYBOARD_KEY_STATE_PRESSED) {
-        if (SDL_TextInputActive(SDL_GetKeyboardFocus())) {
+        SDL_Window *keyboard_focus = SDL_GetKeyboardFocus();
+        if (keyboard_focus && SDL_TextInputActive(keyboard_focus)) {
             has_text = keyboard_input_get_text(text, input, key, SDL_PRESSED, &handled_by_ime);
         }
     } else {

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -2024,7 +2024,8 @@ int X11_WaitEventTimeout(SDL_VideoDevice *_this, Sint64 timeoutNS)
     X11_DispatchEvent(_this, &xevent);
 
 #ifdef SDL_USE_IME
-    if (SDL_TextInputActive(SDL_GetKeyboardFocus())) {
+    SDL_Window *keyboard_focus = SDL_GetKeyboardFocus();
+    if (keyboard_focus && SDL_TextInputActive(keyboard_focus)) {
         SDL_IME_PumpEvents();
     }
 #endif
@@ -2084,7 +2085,8 @@ void X11_PumpEvents(SDL_VideoDevice *_this)
     }
 
 #ifdef SDL_USE_IME
-    if (SDL_TextInputActive(SDL_GetKeyboardFocus())) {
+    SDL_Window *keyboard_focus = SDL_GetKeyboardFocus();
+    if (keyboard_focus && SDL_TextInputActive(keyboard_focus)) {
         SDL_IME_PumpEvents();
     }
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
SDL sets `Invalid window` error if `SDL_PumpEvents` is called while the keyboard is not focused.

This PR fixes it by checking if `SDL_GetKeyboardFocus` returns null before calling `SDL_TextInputActive`. I think there may be a better fix but it does the trick for me.

## Existing Issue(s)

Probably none since this change got pushed only recently?