### PR TITLE
SDL2: Display double-free and leak fix

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -677,9 +677,9 @@ void SDL_DelVideoDisplay(int index)
 
     SDL_SendDisplayEvent(&_this->displays[index], SDL_DISPLAYEVENT_DISCONNECTED, 0);
 
+    SDL_free(_this->displays[index].driverdata);
+    SDL_free(_this->displays[index].name);
     if (index < (_this->num_displays - 1)) {
-        SDL_free(_this->displays[index].driverdata);
-        SDL_free(_this->displays[index].name);
         SDL_memmove(&_this->displays[index], &_this->displays[index + 1], (_this->num_displays - index - 1) * sizeof(_this->displays[index]));
     }
     --_this->num_displays;

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -761,12 +761,11 @@ static void Wayland_free_display(SDL_VideoData *d, uint32_t id)
                 Wayland_RemoveOutputFromWindow(window->driverdata, data->output);
             }
 
-            SDL_DelVideoDisplay(i);
             if (data->xdg_output) {
                 zxdg_output_v1_destroy(data->xdg_output);
             }
             wl_output_destroy(data->output);
-            SDL_free(data);
+            SDL_DelVideoDisplay(i);
 
             /* Update the index for all remaining displays */
             num_displays -= 1;
@@ -1031,9 +1030,6 @@ static void Wayland_VideoCleanup(_THIS)
         }
 
         wl_output_destroy(((SDL_WaylandOutputData *)display->driverdata)->output);
-        SDL_free(display->driverdata);
-        display->driverdata = NULL;
-
         SDL_DelVideoDisplay(i);
     }
     data->output_list = NULL;


### PR DESCRIPTION
Fixes a double-free scenario on Wayland, and a memory leak in the video core where display names and driverdata may not be freed if the display is the last, or only, display in the list.

Fixes #10075