### PR TITLE
[SDL3] [PS2] Fix `SDL_GetBasePath`

### DIFF
--- a/src/filesystem/ps2/SDL_sysfilesystem.c
+++ b/src/filesystem/ps2/SDL_sysfilesystem.c
@@ -30,16 +30,14 @@
 
 char *SDL_GetBasePath(void)
 {
-    char *retval;
+    char *retval = NULL;
     size_t len;
     char cwd[FILENAME_MAX];
 
     getcwd(cwd, sizeof(cwd));
-    len = SDL_strlen(cwd) + 1;
+    len = SDL_strlen(cwd) + 2;
     retval = (char *)SDL_malloc(len);
-    if (retval) {
-        SDL_memcpy(retval, cwd, len);
-    }
+    SDL_snprintf(retval, len, "%s/", cwd);
 
     return retval;
 }


### PR DESCRIPTION
## Description

Previously the PS2Dev toolchain was returning an `/` at the end when calling `getcwd` now the toolchain is posix and it is not returning the `/` so, we need to add it.

PD: Now it has the same implementation as the PSP.

Cheers.
