### PR TITLE
Fix mouse button not changing in pen mouse emulation

### DIFF
--- a/src/events/SDL_pen.c
+++ b/src/events/SDL_pen.c
@@ -630,6 +630,11 @@ int SDL_SendPenTipEvent(Uint64 timestamp, SDL_PenID instance_id, Uint8 state)
         if (mouse_button == 0) {
             mouse_button = SDL_BUTTON_LEFT; /* No current button? Instead report left mouse button */
         }
+        /* A button may get released while drawing, but SDL_SendPenButton doesn't reset last_mouse_button
+           while touching the surface, so release and reset last_mouse_button on pen tip release */
+        if (pen->last.buttons == 0 && state == SDL_RELEASED) {
+            pen->last_mouse_button = 0;
+        }
     }
 
     switch (pen_mouse_emulation_mode) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes mouse emulation button not changing in the following situation:
1. Press a pen button
2. Start drawing
3. Release the pen button
4. Stop drawing

After these steps, touching the surface **without pressing a pen button** results in pen tip mouse button stuck with previously set mouse button with the pen button.

So, the patch resets `last_mouse_button` on pen tip release if no button is currently pressed.

## Existing Issue(s)

Probably none
