### PR TITLE
Remove the inconsistent and lag-causing usleep call in SDL_fcitx.c

### DIFF
--- a/src/core/linux/SDL_fcitx.c
+++ b/src/core/linux/SDL_fcitx.c
@@ -485,7 +485,6 @@ void SDL_Fcitx_PumpEvents(void)
 
     while (dbus->connection_dispatch(conn) == DBUS_DISPATCH_DATA_REMAINS) {
         /* Do nothing, actual work happens in DBus_MessageFilter */
-        usleep(10);
     }
 }
 


### PR DESCRIPTION
This PR removes the `usleep(10)` call from `SDL_fcitx.c`. Besides being inconsistent with other similar parts of SDL, this call was causing performance issues.

## Description
The additional sleeping code is likely the cause of lag (or for Minetest, a regression). In `SDL_ibus.c`, the respective code never sleeps and works well: (not tested, but nobody complained about this code anyways)
https://github.com/libsdl-org/SDL/blob/0fc3574464326b05568f4804d88cbeb66848f3ea/src/core/linux/SDL_ibus.c#L750-L761

However, `SDL_fcitx.c` does sleep and creates additional lag:
https://github.com/libsdl-org/SDL/blob/0fc3574464326b05568f4804d88cbeb66848f3ea/src/core/linux/SDL_fcitx.c#L479-L490

## Tests done

I did the tests on a virtual machine (QEMU, Arch Linux x86_64) with https://github.com/minetest/minetest/commit/9a1501ae89ffe79c38dbd6756c9e7ed647dd7dc1 under the following settings:
* Without fcitx: No lag w/ or w/o patch applied
* With fcitx but w/o IME configured: No lag w/ or w/o patch applied
* With fcitx and an IME ([fcitx5 Chinese pinyin](https://archlinux.org/packages/extra/x86_64/fcitx5-chinese-addons/)): Lag if not applied, no lag if applied

The lag is measured using the wrapper function added in https://github.com/minetest/minetest/pull/14563/commits/6d2aa6f2d2f252e9a1007382ad9fe2bbb17dea56. If the delay is more than 50 milliseconds (i.e. 3 frames in 60 fps), it is considered a lag and is logged.

## Existing Issue(s)
Fixes minetest/minetest#14544

