### PR TITLE
wgl: Fix risky retrieval of OpenGL 1.1 function pointers on Windows

### DIFF
--- a/src/video/windows/SDL_windowsopengl.c
+++ b/src/video/windows/SDL_windowsopengl.c
@@ -216,11 +216,11 @@ SDL_FunctionPointer WIN_GL_GetProcAddress(SDL_VideoDevice *_this, const char *pr
 {
     SDL_FunctionPointer func;
 
-    /* This is to pick up extensions */
-    func = (SDL_FunctionPointer)_this->gl_data->wglGetProcAddress(proc);
+    /* This is to pick up normal GL functions */
+    func = (SDL_FunctionPointer)GetProcAddress((HMODULE)_this->gl_config.dll_handle, proc);
     if (!func) {
-        /* This is probably a normal GL function */
-        func = (SDL_FunctionPointer)GetProcAddress((HMODULE)_this->gl_config.dll_handle, proc);
+        /* This is probably an extension */
+        func = (SDL_FunctionPointer)_this->gl_data->wglGetProcAddress(proc);
     }
     return func;
 }


### PR DESCRIPTION
On Windows, the standard `opengl32.dll` library implements the OpenGL version 1.1 specification, exporting functions whose calls are forwarded either to the OpenGL implementation in the video card driver (the so-called "installable client driver", aka ICD), if available, or to the standard software renderer, known as "GDI Generic". Functions of newer versions of the OpenGL specification are available through the `wglGetProcAddress()` function, which also implements the extension mechanism. The problem is that, apparently, for OpenGL 1.1 functions it can return an internal implementation routine on some drivers (for example, if the lookup table incorrectly contains the name of such a function), which will not work on the user's side.

Long story short: if `opengl32.dll` exports a function, then it should be used regardless of whatever value `wglGetProcAddress()` returns by its name.

See also:
https://github.com/opentk/opentk/issues/282
http://web.archive.org/web/20150826002618/https://www.opentk.com/node/4015
https://www.khronos.org/opengl/wiki/Talk:Platform_specifics:_Windows
https://stackoverflow.com/questions/25214519/opengl-1-0-and-1-1-function-pointers-on-windows
https://stackoverflow.com/questions/65734384/how-opengl-icd-on-windows-loads-opengl-1-0-and-1-1-functions