### PR TITLE
audio: Add channel remapping to SDL_AudioSpec and SDL_AudioStream.

### DIFF
--- a/src/audio/SDL_audiocvt.c
+++ b/src/audio/SDL_audiocvt.c
@@ -162,6 +162,7 @@ static void SwizzleAudio(const int num_frames, void *dst, const void *src, int c
             } \
         } else { \
             Uint##bits tmp[SDL_MAX_CHANNEL_MAP_SIZE]; \
+            SDL_zeroa(tmp); \
             SDL_assert(SDL_arraysize(tmp) >= channels); \
             for (int i = 0; i < num_frames; i++, tsrc += channels, tdst += channels) { \
                 for (int ch = 0; ch < channels; ch++) { \

--- a/src/audio/SDL_audioqueue.c
+++ b/src/audio/SDL_audioqueue.c
@@ -23,8 +23,6 @@
 #include "SDL_audioqueue.h"
 #include "SDL_sysaudio.h"
 
-#define AUDIO_SPECS_EQUAL(x, y) (((x).format == (y).format) && ((x).channels == (y).channels) && ((x).freq == (y).freq))
-
 typedef struct SDL_MemoryPool SDL_MemoryPool;
 
 struct SDL_MemoryPool
@@ -285,7 +283,7 @@ void SDL_AddTrackToAudioQueue(SDL_AudioQueue *queue, SDL_AudioTrack *track)
 
     if (tail) {
         // If the spec has changed, make sure to flush the previous track
-        if (!AUDIO_SPECS_EQUAL(tail->spec, track->spec)) {
+        if (!SDL_AudioSpecsEqual(&tail->spec, &track->spec)) {
             FlushAudioTrack(tail);
         }
 
@@ -319,7 +317,7 @@ int SDL_WriteToAudioQueue(SDL_AudioQueue *queue, const SDL_AudioSpec *spec, cons
     SDL_AudioTrack *track = queue->tail;
 
     if (track) {
-        if (!AUDIO_SPECS_EQUAL(track->spec, *spec)) {
+        if (!SDL_AudioSpecsEqual(&track->spec, spec)) {
             FlushAudioTrack(track);
         }
     } else {
@@ -514,7 +512,7 @@ static const Uint8 *PeekIntoAudioQueueFuture(SDL_AudioQueue *queue, Uint8 *data,
 }
 
 const Uint8 *SDL_ReadFromAudioQueue(SDL_AudioQueue *queue,
-                                    Uint8 *dst, SDL_AudioFormat dst_format, int dst_channels,
+                                    Uint8 *dst, SDL_AudioFormat dst_format, int dst_channels, const Uint8 *dst_map,
                                     int past_frames, int present_frames, int future_frames,
                                     Uint8 *scratch)
 {
@@ -526,6 +524,7 @@ const Uint8 *SDL_ReadFromAudioQueue(SDL_AudioQueue *queue,
 
     SDL_AudioFormat src_format = track->spec.format;
     int src_channels = track->spec.channels;
+    const Uint8 *src_map = track->spec.use_channel_map ? track->spec.channel_map : NULL;
 
     size_t src_frame_size = SDL_AUDIO_BYTESIZE(src_format) * src_channels;
     size_t dst_frame_size = SDL_AUDIO_BYTESIZE(dst_format) * dst_channels;
@@ -553,7 +552,7 @@ const Uint8 *SDL_ReadFromAudioQueue(SDL_AudioQueue *queue,
         // Do we still need to copy/convert the data?
         if (dst) {
             ConvertAudio(past_frames + present_frames + future_frames, ptr,
-                         src_format, src_channels, dst, dst_format, dst_channels, scratch);
+                         src_format, src_channels, src_map, dst, dst_format, dst_channels, dst_map, scratch);
             ptr = dst;
         }
 
@@ -571,19 +570,19 @@ const Uint8 *SDL_ReadFromAudioQueue(SDL_AudioQueue *queue,
     Uint8 *ptr = dst;
 
     if (src_past_bytes) {
-        ConvertAudio(past_frames, PeekIntoAudioQueuePast(queue, scratch, src_past_bytes), src_format, src_channels, dst, dst_format, dst_channels, scratch);
+        ConvertAudio(past_frames, PeekIntoAudioQueuePast(queue, scratch, src_past_bytes), src_format, src_channels, src_map, dst, dst_format, dst_channels, dst_map, scratch);
         dst += dst_past_bytes;
         scratch += dst_past_bytes;
     }
 
     if (src_present_bytes) {
-        ConvertAudio(present_frames, ReadFromAudioQueue(queue, scratch, src_present_bytes), src_format, src_channels, dst, dst_format, dst_channels, scratch);
+        ConvertAudio(present_frames, ReadFromAudioQueue(queue, scratch, src_present_bytes), src_format, src_channels, src_map, dst, dst_format, dst_channels, dst_map, scratch);
         dst += dst_present_bytes;
         scratch += dst_present_bytes;
     }
 
     if (src_future_bytes) {
-        ConvertAudio(future_frames, PeekIntoAudioQueueFuture(queue, scratch, src_future_bytes), src_format, src_channels, dst, dst_format, dst_channels, scratch);
+        ConvertAudio(future_frames, PeekIntoAudioQueueFuture(queue, scratch, src_future_bytes), src_format, src_channels, src_map, dst, dst_format, dst_channels, dst_map, scratch);
         dst += dst_future_bytes;
         scratch += dst_future_bytes;
     }

--- a/src/audio/SDL_audioqueue.h
+++ b/src/audio/SDL_audioqueue.h
@@ -67,7 +67,7 @@ void *SDL_BeginAudioQueueIter(SDL_AudioQueue *queue);
 size_t SDL_NextAudioQueueIter(SDL_AudioQueue *queue, void **inout_iter, SDL_AudioSpec *out_spec, SDL_bool *out_flushed);
 
 const Uint8 *SDL_ReadFromAudioQueue(SDL_AudioQueue *queue,
-                                    Uint8 *dst, SDL_AudioFormat dst_format, int dst_channels,
+                                    Uint8 *dst, SDL_AudioFormat dst_format, int dst_channels, const Uint8 *dst_map,
                                     int past_frames, int present_frames, int future_frames,
                                     Uint8 *scratch);
 

--- a/src/audio/SDL_sysaudio.h
+++ b/src/audio/SDL_sysaudio.h
@@ -48,8 +48,6 @@
 #define DEFAULT_AUDIO_RECORDING_CHANNELS 1
 #define DEFAULT_AUDIO_RECORDING_FREQUENCY 44100
 
-#define AUDIO_SPECS_EQUAL(x, y) (((x).format == (y).format) && ((x).channels == (y).channels) && ((x).freq == (y).freq))
-
 typedef struct SDL_AudioDevice SDL_AudioDevice;
 typedef struct SDL_LogicalAudioDevice SDL_LogicalAudioDevice;
 
@@ -113,9 +111,19 @@ extern void ConvertAudioToFloat(float *dst, const void *src, int num_samples, SD
 extern void ConvertAudioFromFloat(void *dst, const float *src, int num_samples, SDL_AudioFormat dst_fmt);
 extern void ConvertAudioSwapEndian(void* dst, const void* src, int num_samples, int bitsize);
 
+extern SDL_bool SDL_ChannelMapIsDefault(const Uint8 *map, int channels);
+extern SDL_bool SDL_ChannelMapIsBogus(const Uint8 *map, int channels);
+
 // this gets used from the audio device threads. It has rules, don't use this if you don't know how to use it!
-extern void ConvertAudio(int num_frames, const void *src, SDL_AudioFormat src_format, int src_channels,
-                         void *dst, SDL_AudioFormat dst_format, int dst_channels, void* scratch);
+extern void ConvertAudio(int num_frames,
+                         const void *src, SDL_AudioFormat src_format, int src_channels, const Uint8 *src_map,
+                         void *dst, SDL_AudioFormat dst_format, int dst_channels, const Uint8 *dst_map,
+                         void* scratch);
+
+// Compare two SDL_AudioSpecs, return SDL_TRUE if they match exactly.
+// Using SDL_memcmp directly isn't safe, since potential padding (and unused parts of the channel map) might not be initialized.
+extern SDL_bool SDL_AudioSpecsEqual(const SDL_AudioSpec *a, const SDL_AudioSpec *b);
+
 
 // Special case to let something in SDL_audiocvt.c access something in SDL_audio.c. Don't use this.
 extern void OnAudioStreamCreated(SDL_AudioStream *stream);

--- a/src/audio/pulseaudio/SDL_pulseaudio.c
+++ b/src/audio/pulseaudio/SDL_pulseaudio.c
@@ -789,6 +789,7 @@ static SDL_AudioFormat PulseFormatToSDLFormat(pa_sample_format_t format)
 static void AddPulseAudioDevice(const SDL_bool recording, const char *description, const char *name, const uint32_t index, const pa_sample_spec *sample_spec)
 {
     SDL_AudioSpec spec;
+    SDL_zero(spec);
     spec.format = PulseFormatToSDLFormat(sample_spec->format);
     spec.channels = sample_spec->channels;
     spec.freq = sample_spec->rate;

--- a/src/audio/qnx/SDL_qsa_audio.c
+++ b/src/audio/qnx/SDL_qsa_audio.c
@@ -363,6 +363,7 @@ static void QSA_DetectDevices(SDL_AudioDevice **default_playback, SDL_AudioDevic
 
                 if (status == EOK) {
                     SDL_AudioSpec spec;
+                    SDL_zero(spec);
                     SDL_AudioSpec *pspec = &spec;
                     snd_pcm_channel_setup_t csetup;
                     SDL_zero(csetup);

--- a/test/loopwave.c
+++ b/test/loopwave.c
@@ -114,7 +114,7 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create audio stream: %s\n", SDL_GetError());
         return SDL_APP_FAILURE;
     }
-    SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(stream));
+    SDL_ResumeAudioStreamDevice(stream);
 
     return SDL_APP_CONTINUE;
 }

--- a/test/testaudiostreamdynamicresample.c
+++ b/test/testaudiostreamdynamicresample.c
@@ -109,6 +109,7 @@ static void queue_audio()
     int retval = 0;
     SDL_AudioSpec new_spec;
 
+    SDL_zero(new_spec);
     new_spec.format = spec.format;
     new_spec.channels = (int) sliders[2].value;
     new_spec.freq = (int) sliders[1].value;

--- a/test/testautomation_audio.c
+++ b/test/testautomation_audio.c
@@ -181,7 +181,7 @@ static int audio_initOpenCloseQuitAudio(void *arg)
             SDLTest_AssertCheck(result == 0, "Validate result value; expected: 0 got: %d", result);
 
             /* Set spec */
-            SDL_memset(&desired, 0, sizeof(desired));
+            SDL_zero(desired);
             switch (j) {
             case 0:
                 /* Set standard desired spec */
@@ -272,7 +272,7 @@ static int audio_pauseUnpauseAudio(void *arg)
             SDLTest_AssertCheck(result == 0, "Validate result value; expected: 0 got: %d", result);
 
             /* Set spec */
-            SDL_memset(&desired, 0, sizeof(desired));
+            SDL_zero(desired);
             switch (j) {
             case 0:
                 /* Set standard desired spec */
@@ -496,6 +496,9 @@ static int audio_buildAudioStream(void *arg)
     SDL_AudioSpec spec2;
     int i, ii, j, jj, k, kk;
 
+    SDL_zero(spec1);
+    SDL_zero(spec2);
+
     /* Call Quit */
     SDL_QuitSubSystem(SDL_INIT_AUDIO);
     SDLTest_AssertPass("Call to SDL_QuitSubSystem(SDL_INIT_AUDIO)");
@@ -566,6 +569,9 @@ static int audio_buildAudioStreamNegative(void *arg)
     SDL_AudioSpec spec2;
     int i;
     char message[256];
+
+    SDL_zero(spec1);
+    SDL_zero(spec2);
 
     /* Valid format */
     spec1.format = SDL_AUDIO_S8;
@@ -677,6 +683,9 @@ static int audio_convertAudio(void *arg)
     int c;
     char message[128];
     int i, ii, j, jj, k, kk;
+
+    SDL_zero(spec1);
+    SDL_zero(spec2);
 
     /* Iterate over bitmask that determines which parameters are modified in the conversion */
     for (c = 1; c < 8; c++) {
@@ -995,6 +1004,9 @@ static int audio_resampleLoss(void *arg)
     double sum_squared_value = 0;
     double signal_to_noise = 0;
 
+    SDL_zero(tmpspec1);
+    SDL_zero(tmpspec2);
+
     SDLTest_AssertPass("Test resampling of %i s %i Hz %f phase sine wave from sampling rate of %i Hz to %i Hz",
                        spec->time, spec->freq, spec->phase, spec->rate_in, spec->rate_out);
 
@@ -1147,6 +1159,9 @@ static int audio_convertAccuracy(void *arg)
         int tmp_len, dst_len;
         int ret;
 
+        SDL_zero(src_spec);
+        SDL_zero(tmp_spec);
+
         SDL_AudioFormat format = formats[i];
         const char* format_name = format_names[i];
 
@@ -1237,6 +1252,10 @@ static int audio_formatChange(void *arg)
     double target_max_error = 0.02;
     double target_signal_to_noise = 75.0;
     int sine_freq = 500;
+
+    SDL_zero(spec1);
+    SDL_zero(spec2);
+    SDL_zero(spec3);
 
     spec1.format = SDL_AUDIO_F32;
     spec1.channels = 1;

--- a/test/testffmpeg.c
+++ b/test/testffmpeg.c
@@ -1167,7 +1167,7 @@ static AVCodecContext *OpenAudioStream(AVFormatContext *ic, int stream, const AV
         return NULL;
     }
 
-    SDL_AudioSpec spec = { SDL_AUDIO_F32, codecpar->ch_layout.nb_channels, codecpar->sample_rate };
+    SDL_AudioSpec spec = { SDL_AUDIO_F32, codecpar->ch_layout.nb_channels, codecpar->sample_rate, SDL_FALSE };
     audio = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, NULL, NULL);
     if (audio) {
         SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(audio));
@@ -1240,7 +1240,7 @@ static void InterleaveAudio(AVFrame *frame, const SDL_AudioSpec *spec)
 static void HandleAudioFrame(AVFrame *frame)
 {
     if (audio) {
-        SDL_AudioSpec spec = { GetAudioFormat(frame->format), frame->ch_layout.nb_channels, frame->sample_rate };
+        SDL_AudioSpec spec = { GetAudioFormat(frame->format), frame->ch_layout.nb_channels, frame->sample_rate, SDL_FALSE };
         SDL_SetAudioStreamFormat(audio, &spec, NULL);
 
         if (frame->ch_layout.nb_channels > 1 && IsPlanarAudioFormat(frame->format)) {


### PR DESCRIPTION
This wasn't as hard as I thought, although I suspect we could get some optimization wins out of special-casing some common swizzle operations and datatypes, possibly with some SIMD, but I haven't profiled this yet.

Now you can do things like this, as a simple example, in loopwave:

```diff
diff --git a/test/loopwave.c b/test/loopwave.c
index 9cd24fae9..cb19300c0 100644
--- a/test/loopwave.c
+++ b/test/loopwave.c
@@ -109,6 +109,10 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
 
     SDL_Log("Using audio driver: %s\n", SDL_GetCurrentAudioDriver());
 
+    wave.spec.use_channel_map = SDL_TRUE;
+    wave.spec.channel_map[0] = 1;
+    wave.spec.channel_map[1] = 0;
+
     stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &wave.spec, NULL, NULL);
     if (!stream) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create audio stream: %s\n", SDL_GetError());
```

And then load a stereo .wav and listen to it with reversed channels. Or set both values to 0 to listen to the left channel duplicated to both channels.

The primary interface to this is SDL_AudioStream, which will shuffle input and output channels separately. This is useful for apps that provide data in a different order, or devices that want data in a different order, or both at the same time, but also good for anywhere you might need channel order changed and can pass data through an AudioStream to get it. Set the SDL_AudioSpec details and Put/Get stream data as usual.

The cost for _not_ using this is a handful of extra `if` statements and about 40 bytes more per SDL_AudioSpec; there isn't a lot of new overhead for a feature most things won't need.

I opted to hardcode a 32-item array in SDL_AudioSpec for this; I started with a single pointer (NULL for default), but allocations for this were a nightmare, since these structs get copied around a lot and that pointer is going to get double-free'd by accident. That locks a hard limit of 32 channels into SDL3's audio API, but that's 4x what we currently offer and unlikely to be surpassed by consumer hardware any time soon. But our dreams of Dolby Atmos 128-speaker configurations in movie theaters using SDL3 die today.  :)

The ALSA backend has been updated to remove its custom swizzle code in favor of just reporting its channel mapping needs at device open time and letting the audio streams that feed it do the conversion.

Feedback on this is _definitely_ welcome.

Fixes #8367.
