### PR TITLE
Update mingw Makefile

### DIFF
--- a/mingw/pkg-support/Makefile
+++ b/mingw/pkg-support/Makefile
@@ -13,7 +13,12 @@ native:
 
 cross:
 	for arch in $(ARCHITECTURES); do \
-	    make install-package arch=$$arch prefix=$(CROSS_PATH)/$$arch; \
+		if [ "$$arch" = "i686-w64-mingw32" ]; then \
+			CROSS_PATH="/mingw32"; \
+		elif [ "$$arch" = "x86_64-w64-mingw32" ]; then \
+			CROSS_PATH="/mingw64"; \
+		fi; \
+		make install-package arch=$$arch prefix=$$CROSS_PATH/$$arch; \
 	done
 
 install-package:

--- a/mingw/pkg-support/Makefile
+++ b/mingw/pkg-support/Makefile
@@ -1,7 +1,6 @@
 #
 # Makefile for installing the mingw32 version of the SDL library
 
-CROSS_PATH := /usr/local
 ARCHITECTURES := i686-w64-mingw32 x86_64-w64-mingw32
 
 all install:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`make cross` keeps giving me an error:
`*** ERROR: i686-w64-mingw32 or /usr/local/i686-w64-mingw32 does not exist!`
`*** ERROR: x86_64-w64-mingw32 or /usr/local/x86_64-w64-mingw32 does not exist!`

msys64 directory has these inside "mingw32" and "mingw64" respectively.

this **PR** addresses the issue and lets `make cross` work how it is supposed to.
## Existing Issue(s)

so...
- "msys64/mingw32"
- "msys64/mingw64"
- "msys64/usr"
**AND**...
- "msys64/mingw32/i686-w64-mingw32"
- "msys64/mingw64/x86_64-w64-mingw32"

have the directories:
1. bin
2. include
3. lib
4. share

I am not sure if this is suppose to install in just all or only 2, or just "msys64/usr" or what....

it would be great to know exactly where these are supposed to be installed (copy/pasted if necessary).
<!--- If it fixes an open issue, please link to the issue here. -->
