### PR TITLE
Switch pixel format loss fields to number of bits

### DIFF
--- a/include/SDL3/SDL_pixels.h
+++ b/include/SDL3/SDL_pixels.h
@@ -751,10 +751,10 @@ typedef struct SDL_PixelFormat
     Uint32 Gmask;
     Uint32 Bmask;
     Uint32 Amask;
-    Uint8 Rloss;
-    Uint8 Gloss;
-    Uint8 Bloss;
-    Uint8 Aloss;
+    Uint8 Rbits;
+    Uint8 Gbits;
+    Uint8 Bbits;
+    Uint8 Abits;
     Uint8 Rshift;
     Uint8 Gshift;
     Uint8 Bshift;

--- a/src/test/SDL_test_compare.c
+++ b/src/test/SDL_test_compare.c
@@ -38,10 +38,10 @@ LogErrorFormat(const char *name, const SDL_PixelFormat *format)
 {
   SDLTest_LogError("%s: %08d %s, %u bits/%u bytes per pixel", name, format->format, SDL_GetPixelFormatName(format->format),
                    format->bits_per_pixel, format->bytes_per_pixel);
-  SDLTest_LogError("%s: R mask %08" SDL_PRIx32 ", loss %u, shift %u", name, format->Rmask, format->Rloss, format->Rshift);
-  SDLTest_LogError("%s: G mask %08" SDL_PRIx32 ", loss %u, shift %u", name, format->Gmask, format->Gloss, format->Gshift);
-  SDLTest_LogError("%s: B mask %08" SDL_PRIx32 ", loss %u, shift %u", name, format->Bmask, format->Bloss, format->Bshift);
-  SDLTest_LogError("%s: A mask %08" SDL_PRIx32 ", loss %u, shift %u", name, format->Amask, format->Aloss, format->Ashift);
+  SDLTest_LogError("%s: R mask %08" SDL_PRIx32 ", bits %u, shift %u", name, format->Rmask, format->Rbits, format->Rshift);
+  SDLTest_LogError("%s: G mask %08" SDL_PRIx32 ", bits %u, shift %u", name, format->Gmask, format->Gbits, format->Gshift);
+  SDLTest_LogError("%s: B mask %08" SDL_PRIx32 ", bits %u, shift %u", name, format->Bmask, format->Bbits, format->Bshift);
+  SDLTest_LogError("%s: A mask %08" SDL_PRIx32 ", bits %u, shift %u", name, format->Amask, format->Abits, format->Ashift);
 }
 
 /* Compare surfaces */

--- a/src/video/SDL_RLEaccel.c
+++ b/src/video/SDL_RLEaccel.c
@@ -373,12 +373,12 @@
  * Set a pixel value using the given format, except that the alpha value is
  * placed in the top byte. This is the format used for RLE with alpha.
  */
-#define RLEPIXEL_FROM_RGBA(Pixel, fmt, r, g, b, a)   \
-    {                                                \
-        Pixel = ((r >> fmt->Rloss) << fmt->Rshift) | \
-                ((g >> fmt->Gloss) << fmt->Gshift) | \
-                ((b >> fmt->Bloss) << fmt->Bshift) | \
-                (a << 24);                           \
+#define RLEPIXEL_FROM_RGBA(Pixel, fmt, r, g, b, a)          \
+    {                                                       \
+        Pixel = ((r >> (8 - fmt->Rbits)) << fmt->Rshift) |  \
+                ((g >> (8 - fmt->Gbits)) << fmt->Gshift) |  \
+                ((b >> (8 - fmt->Bbits)) << fmt->Bshift) |  \
+                (a << 24);                                  \
     }
 
 /*
@@ -614,10 +614,10 @@ typedef struct
     Uint32 Gmask;
     Uint32 Bmask;
     Uint32 Amask;
-    Uint8 Rloss;
-    Uint8 Gloss;
-    Uint8 Bloss;
-    Uint8 Aloss;
+    Uint8 Rbits;
+    Uint8 Gbits;
+    Uint8 Bbits;
+    Uint8 Abits;
     Uint8 Rshift;
     Uint8 Gshift;
     Uint8 Bshift;
@@ -1091,10 +1091,10 @@ static int RLEAlphaSurface(SDL_Surface *surface)
         r->Gmask = df->Gmask;
         r->Bmask = df->Bmask;
         r->Amask = df->Amask;
-        r->Rloss = df->Rloss;
-        r->Gloss = df->Gloss;
-        r->Bloss = df->Bloss;
-        r->Aloss = df->Aloss;
+        r->Rbits = df->Rbits;
+        r->Gbits = df->Gbits;
+        r->Bbits = df->Bbits;
+        r->Abits = df->Abits;
         r->Rshift = df->Rshift;
         r->Gshift = df->Gshift;
         r->Bshift = df->Bshift;

--- a/src/video/SDL_blit.c
+++ b/src/video/SDL_blit.c
@@ -232,7 +232,8 @@ int SDL_CalculateBlit(SDL_Surface *surface)
     if (!blit) {
         if (map->identity && !(map->info.flags & ~SDL_COPY_RLE_DESIRED)) {
             blit = SDL_BlitCopy;
-        } else if (surface->format->Rloss > 8 || dst->format->Rloss > 8) {
+        } else if (SDL_ISPIXELFORMAT_10BIT(surface->format->format) ||
+                   SDL_ISPIXELFORMAT_10BIT(dst->format->format)) {
             blit = SDL_Blit_Slow;
         }
 #if SDL_HAVE_BLIT_0

--- a/src/video/SDL_blit.h
+++ b/src/video/SDL_blit.h
@@ -128,9 +128,9 @@ extern SDL_BlitFunc SDL_CalculateBlitA(SDL_Surface *surface);
 /* Load pixel of the specified format from a buffer and get its R-G-B values */
 #define RGB_FROM_PIXEL(Pixel, fmt, r, g, b)                                     \
     {                                                                           \
-        r = SDL_expand_byte[fmt->Rloss][((Pixel & fmt->Rmask) >> fmt->Rshift)]; \
-        g = SDL_expand_byte[fmt->Gloss][((Pixel & fmt->Gmask) >> fmt->Gshift)]; \
-        b = SDL_expand_byte[fmt->Bloss][((Pixel & fmt->Bmask) >> fmt->Bshift)]; \
+        r = SDL_expand_byte[fmt->Rbits][((Pixel & fmt->Rmask) >> fmt->Rshift)]; \
+        g = SDL_expand_byte[fmt->Gbits][((Pixel & fmt->Gmask) >> fmt->Gshift)]; \
+        b = SDL_expand_byte[fmt->Bbits][((Pixel & fmt->Bmask) >> fmt->Bshift)]; \
     }
 #define RGB_FROM_RGB565(Pixel, r, g, b)                   \
     {                                                     \
@@ -222,12 +222,12 @@ extern SDL_BlitFunc SDL_CalculateBlitA(SDL_Surface *surface);
     } while (0)
 
 /* Assemble R-G-B values into a specified pixel format and store them */
-#define PIXEL_FROM_RGB(Pixel, fmt, r, g, b)          \
-    {                                                \
-        Pixel = ((r >> fmt->Rloss) << fmt->Rshift) | \
-                ((g >> fmt->Gloss) << fmt->Gshift) | \
-                ((b >> fmt->Bloss) << fmt->Bshift) | \
-                fmt->Amask;                          \
+#define PIXEL_FROM_RGB(Pixel, fmt, r, g, b)                 \
+    {                                                       \
+        Pixel = ((r >> (8 - fmt->Rbits)) << fmt->Rshift) |  \
+                ((g >> (8 - fmt->Gbits)) << fmt->Gshift) |  \
+                ((b >> (8 - fmt->Bbits)) << fmt->Bshift) |  \
+                fmt->Amask;                                 \
     }
 #define RGB565_FROM_RGB(Pixel, r, g, b)                        \
     {                                                          \
@@ -340,10 +340,10 @@ extern SDL_BlitFunc SDL_CalculateBlitA(SDL_Surface *surface);
 /* FIXME: Should we rescale alpha into 0..255 here? */
 #define RGBA_FROM_PIXEL(Pixel, fmt, r, g, b, a)                                 \
     {                                                                           \
-        r = SDL_expand_byte[fmt->Rloss][((Pixel & fmt->Rmask) >> fmt->Rshift)]; \
-        g = SDL_expand_byte[fmt->Gloss][((Pixel & fmt->Gmask) >> fmt->Gshift)]; \
-        b = SDL_expand_byte[fmt->Bloss][((Pixel & fmt->Bmask) >> fmt->Bshift)]; \
-        a = SDL_expand_byte[fmt->Aloss][((Pixel & fmt->Amask) >> fmt->Ashift)]; \
+        r = SDL_expand_byte[fmt->Rbits][((Pixel & fmt->Rmask) >> fmt->Rshift)]; \
+        g = SDL_expand_byte[fmt->Gbits][((Pixel & fmt->Gmask) >> fmt->Gshift)]; \
+        b = SDL_expand_byte[fmt->Bbits][((Pixel & fmt->Bmask) >> fmt->Bshift)]; \
+        a = SDL_expand_byte[fmt->Abits][((Pixel & fmt->Amask) >> fmt->Ashift)]; \
     }
 #define RGBA_FROM_8888(Pixel, fmt, r, g, b, a)   \
     {                                            \
@@ -450,12 +450,12 @@ extern SDL_BlitFunc SDL_CalculateBlitA(SDL_Surface *surface);
     } while (0)
 
 /* FIXME: this isn't correct, especially for Alpha (maximum != 255) */
-#define PIXEL_FROM_RGBA(Pixel, fmt, r, g, b, a)      \
-    {                                                \
-        Pixel = ((r >> fmt->Rloss) << fmt->Rshift) | \
-                ((g >> fmt->Gloss) << fmt->Gshift) | \
-                ((b >> fmt->Bloss) << fmt->Bshift) | \
-                ((a >> fmt->Aloss) << fmt->Ashift);  \
+#define PIXEL_FROM_RGBA(Pixel, fmt, r, g, b, a)             \
+    {                                                       \
+        Pixel = ((r >> (8 - fmt->Rbits)) << fmt->Rshift) |  \
+                ((g >> (8 - fmt->Gbits)) << fmt->Gshift) |  \
+                ((b >> (8 - fmt->Bbits)) << fmt->Bshift) |  \
+                ((a >> (8 - fmt->Abits)) << fmt->Ashift);   \
     }
 #define ASSEMBLE_RGBA(buf, bpp, fmt, r, g, b, a)      \
     {                                                 \

--- a/src/video/SDL_blit_A.c
+++ b/src/video/SDL_blit_A.c
@@ -1360,7 +1360,7 @@ SDL_BlitFunc SDL_CalculateBlitA(SDL_Surface *surface)
         case 4:
             if (sf->Rmask == df->Rmask && sf->Gmask == df->Gmask && sf->Bmask == df->Bmask && sf->bytes_per_pixel == 4) {
 #ifdef SDL_MMX_INTRINSICS
-                if (sf->Rshift % 8 == 0 && sf->Gshift % 8 == 0 && sf->Bshift % 8 == 0 && sf->Ashift % 8 == 0 && sf->Aloss == 0) {
+                if (sf->Rshift % 8 == 0 && sf->Gshift % 8 == 0 && sf->Bshift % 8 == 0 && sf->Ashift % 8 == 0 && sf->Abits == 8) {
                     if (SDL_HasMMX()) {
                         return BlitRGBtoRGBPixelAlphaMMX;
                     }

--- a/src/video/SDL_blit_N.c
+++ b/src/video/SDL_blit_N.c
@@ -2066,7 +2066,7 @@ static void Blit_RGB555_ARGB1555(SDL_BlitInfo *info)
     int dstskip = info->dst_skip;
     SDL_PixelFormat *dstfmt = info->dst_fmt;
 
-    Uint16 mask = ((Uint32)info->a >> dstfmt->Aloss) << dstfmt->Ashift;
+    Uint16 mask = ((Uint32)info->a >> (8 - dstfmt->Abits)) << dstfmt->Ashift;
 
     while (height--) {
         /* *INDENT-OFF* */ /* clang-format off */
@@ -2188,7 +2188,7 @@ static void Blit4to4MaskAlpha(SDL_BlitInfo *info)
 
     if (dstfmt->Amask) {
         /* RGB->RGBA, SET_ALPHA */
-        Uint32 mask = ((Uint32)info->a >> dstfmt->Aloss) << dstfmt->Ashift;
+        Uint32 mask = ((Uint32)info->a >> (8 - dstfmt->Abits)) << dstfmt->Ashift;
 
         while (height--) {
             /* *INDENT-OFF* */ /* clang-format off */

--- a/src/video/SDL_pixels.c
+++ b/src/video/SDL_pixels.c
@@ -31,19 +31,19 @@
 /* Lookup tables to expand partial bytes to the full 0..255 range */
 
 static const Uint8 lookup_0[] = {
-    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255
+    255
 };
 
 static const Uint8 lookup_1[] = {
-    0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62, 64, 66, 68, 70, 72, 74, 76, 78, 80, 82, 84, 86, 88, 90, 92, 94, 96, 98, 100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124, 126, 128, 130, 132, 134, 136, 138, 140, 142, 144, 146, 148, 150, 152, 154, 156, 158, 160, 162, 164, 166, 168, 170, 172, 174, 176, 178, 180, 182, 184, 186, 188, 190, 192, 194, 196, 198, 200, 202, 204, 206, 208, 210, 212, 214, 216, 218, 220, 222, 224, 226, 228, 230, 232, 234, 236, 238, 240, 242, 244, 246, 248, 250, 252, 255
+    0, 255
 };
 
 static const Uint8 lookup_2[] = {
-    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 85, 89, 93, 97, 101, 105, 109, 113, 117, 121, 125, 129, 133, 137, 141, 145, 149, 153, 157, 161, 165, 170, 174, 178, 182, 186, 190, 194, 198, 202, 206, 210, 214, 218, 222, 226, 230, 234, 238, 242, 246, 250, 255
+    0, 85, 170, 255
 };
 
 static const Uint8 lookup_3[] = {
-    0, 8, 16, 24, 32, 41, 49, 57, 65, 74, 82, 90, 98, 106, 115, 123, 131, 139, 148, 156, 164, 172, 180, 189, 197, 205, 213, 222, 230, 238, 246, 255
+    0, 36, 72, 109, 145, 182, 218, 255
 };
 
 static const Uint8 lookup_4[] = {
@@ -51,19 +51,19 @@ static const Uint8 lookup_4[] = {
 };
 
 static const Uint8 lookup_5[] = {
-    0, 36, 72, 109, 145, 182, 218, 255
+    0, 8, 16, 24, 32, 41, 49, 57, 65, 74, 82, 90, 98, 106, 115, 123, 131, 139, 148, 156, 164, 172, 180, 189, 197, 205, 213, 222, 230, 238, 246, 255
 };
 
 static const Uint8 lookup_6[] = {
-    0, 85, 170, 255
+    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 85, 89, 93, 97, 101, 105, 109, 113, 117, 121, 125, 129, 133, 137, 141, 145, 149, 153, 157, 161, 165, 170, 174, 178, 182, 186, 190, 194, 198, 202, 206, 210, 214, 218, 222, 226, 230, 234, 238, 242, 246, 250, 255
 };
 
 static const Uint8 lookup_7[] = {
-    0, 255
+    0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62, 64, 66, 68, 70, 72, 74, 76, 78, 80, 82, 84, 86, 88, 90, 92, 94, 96, 98, 100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124, 126, 128, 130, 132, 134, 136, 138, 140, 142, 144, 146, 148, 150, 152, 154, 156, 158, 160, 162, 164, 166, 168, 170, 172, 174, 176, 178, 180, 182, 184, 186, 188, 190, 192, 194, 196, 198, 200, 202, 204, 206, 208, 210, 212, 214, 216, 218, 220, 222, 224, 226, 228, 230, 232, 234, 236, 238, 240, 242, 244, 246, 248, 250, 252, 255
 };
 
 static const Uint8 lookup_8[] = {
-    255
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255
 };
 
 const Uint8 *SDL_expand_byte[9] = {
@@ -639,49 +639,49 @@ int SDL_InitFormat(SDL_PixelFormat *format, SDL_PixelFormatEnum pixel_format)
 
     format->Rmask = Rmask;
     format->Rshift = 0;
-    format->Rloss = 8;
+    format->Rbits = 0;
     if (Rmask) {
         for (mask = Rmask; !(mask & 0x01); mask >>= 1) {
             ++format->Rshift;
         }
-        for (; (mask & 0x01) && format->Rloss; mask >>= 1) {
-            --format->Rloss;
+        for (; (mask & 0x01); mask >>= 1) {
+            ++format->Rbits;
         }
     }
 
     format->Gmask = Gmask;
     format->Gshift = 0;
-    format->Gloss = 8;
+    format->Gbits = 0;
     if (Gmask) {
         for (mask = Gmask; !(mask & 0x01); mask >>= 1) {
             ++format->Gshift;
         }
-        for (; (mask & 0x01) && format->Gloss; mask >>= 1) {
-            --format->Gloss;
+        for (; (mask & 0x01); mask >>= 1) {
+            ++format->Gbits;
         }
     }
 
     format->Bmask = Bmask;
     format->Bshift = 0;
-    format->Bloss = 8;
+    format->Bbits = 0;
     if (Bmask) {
         for (mask = Bmask; !(mask & 0x01); mask >>= 1) {
             ++format->Bshift;
         }
-        for (; (mask & 0x01) && format->Bloss; mask >>= 1) {
-            --format->Bloss;
+        for (; (mask & 0x01); mask >>= 1) {
+            ++format->Bbits;
         }
     }
 
     format->Amask = Amask;
     format->Ashift = 0;
-    format->Aloss = 8;
+    format->Abits = 0;
     if (Amask) {
         for (mask = Amask; !(mask & 0x01); mask >>= 1) {
             ++format->Ashift;
         }
-        for (; (mask & 0x01) && format->Aloss; mask >>= 1) {
-            --format->Aloss;
+        for (; (mask & 0x01); mask >>= 1) {
+            ++format->Abits;
         }
     }
 
@@ -1249,7 +1249,10 @@ Uint32 SDL_MapRGB(const SDL_PixelFormat *format, Uint8 r, Uint8 g, Uint8 b)
                (((Uint32)SDL_expand_byte_10[b]) << format->Bshift) |
                format->Amask;
     } else {
-        return (r >> format->Rloss) << format->Rshift | (g >> format->Gloss) << format->Gshift | (b >> format->Bloss) << format->Bshift | format->Amask;
+        return ((Uint32)(r >> (8 - format->Rbits))) << format->Rshift |
+               ((Uint32)(g >> (8 - format->Gbits))) << format->Gshift |
+               ((Uint32)(b >> (8 - format->Bbits))) << format->Bshift |
+               format->Amask;
     }
 }
 
@@ -1267,9 +1270,12 @@ Uint32 SDL_MapRGBA(const SDL_PixelFormat *format, Uint8 r, Uint8 g, Uint8 b,
         return (((Uint32)SDL_expand_byte_10[r]) << format->Rshift) |
                (((Uint32)SDL_expand_byte_10[g]) << format->Gshift) |
                (((Uint32)SDL_expand_byte_10[b]) << format->Bshift) |
-               ((Uint32)(a >> format->Aloss) << format->Ashift & format->Amask);
+               ((((Uint32)(a >> (8 - format->Abits))) << format->Ashift) & format->Amask);
     } else {
-        return (r >> format->Rloss) << format->Rshift | (g >> format->Gloss) << format->Gshift | (b >> format->Bloss) << format->Bshift | ((Uint32)(a >> format->Aloss) << format->Ashift & format->Amask);
+        return ((Uint32)(r >> (8 - format->Rbits))) << format->Rshift |
+               ((Uint32)(g >> (8 - format->Gbits))) << format->Gshift |
+               ((Uint32)(b >> (8 - format->Bbits))) << format->Bshift |
+               ((((Uint32)(a >> (8 - format->Abits))) << format->Ashift) & format->Amask);
     }
 }
 
@@ -1295,11 +1301,11 @@ void SDL_GetRGB(Uint32 pixel, const SDL_PixelFormat *format, Uint8 *r, Uint8 *g,
     } else {
         unsigned v;
         v = (pixel & format->Rmask) >> format->Rshift;
-        *r = SDL_expand_byte[format->Rloss][v];
+        *r = SDL_expand_byte[format->Rbits][v];
         v = (pixel & format->Gmask) >> format->Gshift;
-        *g = SDL_expand_byte[format->Gloss][v];
+        *g = SDL_expand_byte[format->Gbits][v];
         v = (pixel & format->Bmask) >> format->Bshift;
-        *b = SDL_expand_byte[format->Bloss][v];
+        *b = SDL_expand_byte[format->Bbits][v];
     }
 }
 
@@ -1324,17 +1330,17 @@ void SDL_GetRGBA(Uint32 pixel, const SDL_PixelFormat *format,
         v = (pixel & format->Bmask) >> format->Bshift;
         *b = (Uint8)(v >> 2);
         v = (pixel & format->Amask) >> format->Ashift;
-        *a = SDL_expand_byte[format->Aloss][v];
+        *a = SDL_expand_byte[format->Abits][v];
     } else {
         unsigned v;
         v = (pixel & format->Rmask) >> format->Rshift;
-        *r = SDL_expand_byte[format->Rloss][v];
+        *r = SDL_expand_byte[format->Rbits][v];
         v = (pixel & format->Gmask) >> format->Gshift;
-        *g = SDL_expand_byte[format->Gloss][v];
+        *g = SDL_expand_byte[format->Gbits][v];
         v = (pixel & format->Bmask) >> format->Bshift;
-        *b = SDL_expand_byte[format->Bloss][v];
+        *b = SDL_expand_byte[format->Bbits][v];
         v = (pixel & format->Amask) >> format->Ashift;
-        *a = SDL_expand_byte[format->Aloss][v];
+        *a = SDL_expand_byte[format->Abits][v];
     }
 }
 

--- a/test/testautomation_pixels.c
+++ b/test/testautomation_pixels.c
@@ -175,6 +175,11 @@ static int pixels_allocFreeFormat(void *arg)
                 if (!SDL_ISPIXELFORMAT_INDEXED(format)) {
                     masks = result->Rmask | result->Gmask | result->Bmask | result->Amask;
                     SDLTest_AssertCheck(masks > 0, "Verify value of result.[RGBA]mask combined; expected: >0, got %" SDL_PRIu32, masks);
+                    if (SDL_ISPIXELFORMAT_10BIT(format)) {
+                        SDLTest_AssertCheck(result->Rbits == 10 && result->Gbits == 10 && result->Bbits == 10, "Verify value of result.[RGB]bits; expected: 10, got %d/%d/%d", result->Rbits, result->Gbits, result->Bbits);
+                    } else if (SDL_BITSPERPIXEL(format) == 32) {
+                        SDLTest_AssertCheck(result->Rbits == 8 && result->Gbits == 8 && result->Bbits == 8, "Verify value of result.[RGB]bits; expected: 8, got %d/%d/%d", result->Rbits, result->Gbits, result->Bbits);
+                    }
                 }
             }
 


### PR DESCRIPTION
This makes more sense and handles pixel formats with > 8 bits per channel

Fixes https://github.com/libsdl-org/SDL/issues/10168