### PR TITLE
wgl/glx: Fix attribute list for SDL_GL_FLOATBUFFERS

### DIFF
--- a/src/video/windows/SDL_windowsopengl.c
+++ b/src/video/windows/SDL_windowsopengl.c
@@ -641,6 +641,7 @@ static int WIN_GL_SetupWindowInternal(SDL_VideoDevice *_this, SDL_Window *window
     }
 
     if (_this->gl_config.floatbuffers) {
+        *iAttr++ = WGL_PIXEL_TYPE_ARB;
         *iAttr++ = WGL_TYPE_RGBA_FLOAT_ARB;
     }
 

--- a/src/video/x11/SDL_x11opengl.c
+++ b/src/video/x11/SDL_x11opengl.c
@@ -571,6 +571,7 @@ static int X11_GL_GetAttributes(SDL_VideoDevice *_this, Display *display, int sc
     }
 
     if (_this->gl_config.floatbuffers) {
+        attribs[i++] = GLX_RENDER_TYPE;
         attribs[i++] = GLX_RGBA_FLOAT_TYPE_ARB;
     }
 


### PR DESCRIPTION
This commit fixes the attribute list in the WGL and GLX code when requesting a floating point pixel format. The name of the attribute was missing in the list.

Should be fixed in SDL2 branch also.

Fixes libsdl-org#10189
