### PR TITLE
Fix vision os fake screen size

### DIFF
--- a/src/video/uikit/SDL_uikitmodes.h
+++ b/src/video/uikit/SDL_uikitmodes.h
@@ -56,10 +56,12 @@ extern void UIKit_QuitModes(SDL_VideoDevice *_this);
 extern int UIKit_GetDisplayUsableBounds(SDL_VideoDevice *_this, SDL_VideoDisplay *display, SDL_Rect *rect);
 
 // because visionOS does not have a screen
-// we create a fake 1080p display to maintain compatibility.
+// we create a fake display to maintain compatibility.
+// By default, a window measures 1280x720 pt.
+// https://developer.apple.com/design/human-interface-guidelines/windows#visionOS
 #ifdef SDL_PLATFORM_VISIONOS
-#define SDL_XR_SCREENWIDTH 1920
-#define SDL_XR_SCREENHEIGHT 1080
+#define SDL_XR_SCREENWIDTH 1280
+#define SDL_XR_SCREENHEIGHT 720
 #endif
 
 #endif /* SDL_uikitmodes_h_ */


### PR DESCRIPTION
It never really worked, as the value was arbitrary, digging apple docs showed the right values.

## Description
Swapped arbitrary values for actual apple provided values, tested. Works now.

## Existing Issue(s)
App window was wrong, showed half content, resizing was wrong.
