### PR TITLE
hidapi: fix 'conversion from 'size_t' to 'int', possible loss of data' of libusb functions

### DIFF
--- a/src/hidapi/libusb/hid.c
+++ b/src/hidapi/libusb/hid.c
@@ -1171,7 +1171,7 @@ static void *read_thread(void *param)
 		dev->device_handle,
 		dev->input_endpoint,
 		buf,
-		length,
+		(int) length,
 		read_callback,
 		dev,
 		5000/*timeout*/);
@@ -1598,7 +1598,7 @@ int HID_API_EXPORT hid_write(hid_device *dev, const unsigned char *data, size_t 
 		if (skipped_report_id)
 			length++;
 
-		return length;
+		return (int) length;
 	}
 	else {
 		/* Use the interrupt out endpoint */
@@ -1606,7 +1606,7 @@ int HID_API_EXPORT hid_write(hid_device *dev, const unsigned char *data, size_t 
 		res = libusb_interrupt_transfer(dev->device_handle,
 			dev->output_endpoint,
 			(unsigned char*)data,
-			length,
+			(int) length,
 			&actual_length, 1000);
 
 		if (res < 0)
@@ -1632,7 +1632,7 @@ static int return_data(hid_device *dev, unsigned char *data, size_t length)
 	dev->input_reports = rpt->next;
 	free(rpt->data);
 	free(rpt);
-	return len;
+	return (int) len;
 }
 
 static void cleanup_mutex(void *param)
@@ -1765,7 +1765,7 @@ int HID_API_EXPORT hid_send_feature_report(hid_device *dev, const unsigned char 
 	if (skipped_report_id)
 		length++;
 
-	return length;
+	return (int) length;
 }
 
 int HID_API_EXPORT hid_get_feature_report(hid_device *dev, unsigned char *data, size_t length)


### PR DESCRIPTION
These warnings popped up in `src/hidapi/libusb/hid.c` on MSVC.
The libusb functions accept an int where we are trying to pass a size_t.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
