### PR TITLE
cmake: remove SDL_STATIC_VCRT option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,20 +159,6 @@ if(WINDOWS OR MACOS OR IOS OR TVOS OR VISIONOS OR WATCHOS)
 endif()
 
 if(MSVC)
-  dep_option(SDL_STATIC_VCRT "Use /MT for static VC runtimes" ON "NOT WINDOWS_STORE" OFF)
-  if(SDL_STATIC_VCRT)
-    if(NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
-      set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-    endif()
-    foreach(flag_var
-        CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
-        CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
-      if(${flag_var} MATCHES "/MD")
-        string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-      endif()
-    endforeach()
-  endif()
-
   if(NOT SDL_LIBC)
     # Make sure /RTC1 is disabled, otherwise it will use functions from the CRT
     foreach(flag_var


### PR DESCRIPTION
projects are expected to use CMAKE_MSVC_RUNTIME_LIBRARY to select the runtime library.

With current CMake versions, this can be done with:

 -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=xxx

with xxx one of:
 "MultiThreaded"         -> -MT (static non-debug)
 "MultiThreadedDLL"      -> -MD (shared non-debug)
 "MultiThreadeDebug"     -> -MTd (static debug)
 "MultiThreadedDebugDLL" -> -MDd (shared debug)

See CMake documentation for more information:
https://cmake.org/cmake/help/latest/policy/CMP0091.html
https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
Closes https://github.com/libsdl-org/SDL_mixer/issues/621