### PR TITLE
SDL2 emscripten: don't consume key down/up events if the user disabled them

### DIFF
--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -794,7 +794,7 @@ static EM_BOOL Emscripten_HandleKey(int eventType, const EmscriptenKeyboardEvent
 {
     const SDL_Keycode keycode = Emscripten_MapKeyCode(keyEvent);
     SDL_Scancode scancode = Emscripten_MapScanCode(keyEvent->code);
-    SDL_bool prevent_default = SDL_TRUE;
+    SDL_bool prevent_default = SDL_GetEventState(eventType == EMSCRIPTEN_EVENT_KEYDOWN ? SDL_KEYDOWN : SDL_KEYUP) == SDL_ENABLE;
     SDL_bool is_nav_key = SDL_FALSE;
 
     if (scancode == SDL_SCANCODE_UNKNOWN) {


### PR DESCRIPTION
## Description
SDL consumes key down/up events regardless of the user have enabled or disabled them, which causes text input html elements not to work whenever there is an SDL canvas on screen. This patch initializes `prevent_default` to first check if `SDL_KEYDOWN` or `SDL_KEYUP` events are enabled or not (depending on the emscripten event being emitted).

The downside for this is that the user might have `SDL_KEYDOWN` and `SDL_KEYUP` disabled, but have `SDL_TEXTINPUT` enabled. We can add an extra check for `SDL_TEXTINPUT`, but I think that this is a bad configuration anyways.

## Existing Issue(s)
Closes https://github.com/libsdl-org/SDL/issues/7681