### PR TITLE
Remove incorrect asserts from SDL_InitPixelFormatDetails()

### DIFF
--- a/src/video/SDL_pixels.c
+++ b/src/video/SDL_pixels.c
@@ -593,9 +593,7 @@ static int SDL_InitPixelFormatDetails(SDL_PixelFormatDetails *details, SDL_Pixel
     SDL_zerop(details);
     details->format = format;
     details->bits_per_pixel = (Uint8)bpp;
-    SDL_assert(SDL_BITSPERPIXEL(format) == details->bits_per_pixel);
     details->bytes_per_pixel = (Uint8)((bpp + 7) / 8);
-    SDL_assert(SDL_BYTESPERPIXEL(format) == details->bytes_per_pixel);
 
     details->Rmask = Rmask;
     details->Rshift = 0;


### PR DESCRIPTION
The SDL_Surface rework in #10201 adds some extra checks that the pixel format enum matches the SDL_PixelFormatDetails struct, which is largely filled in with values from SDL_GetMasksForPixelFormat().

However, there are a few cases where these do not match:
- Indexed 1-, 2-, and 4-bit formats encode a bytes_per_pixel of 0, but SDL_GetMasksForPixelFormat() gives a value of 1.
- Packed formats, like SDL_PIXELFORMAT_XRGB8888 encode a bits_per_pixel of the number of used bits (24), but SDL_GetMasksForPixelFormat() includes the padding byte, giving a total of 32.

We could change the encoding of these in the enum, or change what we store in the details struct to match, but I suspect we'd either break something that relies on it, or lose some (_maybe_ useful?) information. In the meantime, this gets the tests working again.