### PR TITLE
Support indexed surfaces without palettes (thanks @sulix!)

### DIFF
--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -1632,6 +1632,8 @@ The `format` member of SDL_Surface is now an enumerated pixel format value. You 
 
 The userdata member of SDL_Surface has been replaced with a more general properties interface, which can be queried with SDL_GetSurfaceProperties()
 
+Indexed format surfaces no longer have a palette by default. Surfaces without a palette will copy the pixels untranslated between surfaces. You should use SDL_CreatePalette() to create a palette and call SDL_SetSurfacePalette() to associate it with the final indexed surface before copying it to color pixels.
+
 Removed the unused 'flags' parameter from SDL_ConvertSurface.
 
 SDL_CreateRGBSurface() and SDL_CreateRGBSurfaceWithFormat() have been combined into a new function SDL_CreateSurface().

--- a/src/video/SDL_bmp.c
+++ b/src/video/SDL_bmp.c
@@ -203,7 +203,6 @@ SDL_Surface *SDL_LoadBMP_IO(SDL_IOStream *src, SDL_bool closeio)
     Uint32 Gmask = 0;
     Uint32 Bmask = 0;
     Uint32 Amask = 0;
-    SDL_Palette *palette;
     Uint8 *bits;
     Uint8 *top, *end;
     SDL_bool topDown;
@@ -439,8 +438,10 @@ SDL_Surface *SDL_LoadBMP_IO(SDL_IOStream *src, SDL_bool closeio)
     }
 
     /* Load the palette, if any */
-    palette = SDL_GetSurfacePalette(surface);
-    if (palette) {
+    if (SDL_ISPIXELFORMAT_INDEXED(surface->format)) {
+        int max_colors = (1 << SDL_BITSPERPIXEL(surface->format));
+        SDL_Palette *palette;
+
         if (SDL_SeekIO(src, fp_offset + 14 + biSize, SDL_IO_SEEK_SET) < 0) {
             SDL_SetError("Error seeking in datastream");
             goto done;
@@ -455,12 +456,17 @@ SDL_Surface *SDL_LoadBMP_IO(SDL_IOStream *src, SDL_bool closeio)
             biClrUsed = 1 << biBitCount;
         }
 
-        if (biClrUsed > (Uint32)palette->ncolors) {
+        if (biClrUsed > (Uint32)max_colors) {
             biClrUsed = 1 << biBitCount; /* try forcing it? */
-            if (biClrUsed > (Uint32)palette->ncolors) {
+            if (biClrUsed > (Uint32)max_colors) {
                 SDL_SetError("Unsupported or incorrect biClrUsed field");
                 goto done;
             }
+        }
+
+        palette = SDL_CreatePalette(biClrUsed);
+        if (!palette) {
+            goto done;
         }
 
         if (biSize == 12) {
@@ -488,7 +494,9 @@ SDL_Surface *SDL_LoadBMP_IO(SDL_IOStream *src, SDL_bool closeio)
                 palette->colors[i].a = SDL_ALPHA_OPAQUE;
             }
         }
-        palette->ncolors = biClrUsed;
+
+        SDL_SetSurfacePalette(surface, palette);
+        SDL_DestroyPalette(palette);
     }
 
     /* Read the surface pixels.  Note that the bmp image is upside down */
@@ -515,7 +523,7 @@ SDL_Surface *SDL_LoadBMP_IO(SDL_IOStream *src, SDL_bool closeio)
         if (SDL_ReadIO(src, bits, surface->pitch) != (size_t)surface->pitch) {
             goto done;
         }
-        if (biBitCount == 8 && palette && biClrUsed < (1u << biBitCount)) {
+        if (biBitCount == 8 && surface->internal->palette && biClrUsed < (1u << biBitCount)) {
             for (i = 0; i < surface->w; ++i) {
                 if (bits[i] >= biClrUsed) {
                     SDL_SetError("A BMP image contains a pixel with a color out of the palette");

--- a/src/video/SDL_surface.c
+++ b/src/video/SDL_surface.c
@@ -158,25 +158,6 @@ static SDL_Surface *SDL_InitializeSurface(SDL_InternalSurface *mem, int width, i
     surface->internal->map.info.b = 0xFF;
     surface->internal->map.info.a = 0xFF;
 
-    if (SDL_ISPIXELFORMAT_INDEXED(surface->format)) {
-        SDL_Palette *palette = SDL_CreatePalette((1 << SDL_BITSPERPIXEL(surface->format)));
-        if (!palette) {
-            SDL_DestroySurface(surface);
-            return NULL;
-        }
-        if (palette->ncolors == 2) {
-            /* Create a black and white bitmap palette */
-            palette->colors[0].r = 0xFF;
-            palette->colors[0].g = 0xFF;
-            palette->colors[0].b = 0xFF;
-            palette->colors[1].r = 0x00;
-            palette->colors[1].g = 0x00;
-            palette->colors[1].b = 0x00;
-        }
-        SDL_SetSurfacePalette(surface, palette);
-        SDL_DestroyPalette(palette);
-    }
-
     if (colorspace != SDL_COLORSPACE_UNKNOWN &&
         colorspace != SDL_GetDefaultColorspaceForFormat(format)) {
         SDL_SetSurfaceColorspace(surface, colorspace);


### PR DESCRIPTION
Currently, all SDL_Surfaces with an indexed pixel format have an associated SDL_Palette. This palette either consists of entirely the colour black, or -- in the special case of 1-bit surfaces, black and white.

When an indexed surface is blitted to another indexed surface, a 'map' is generated from the source surface's palette to the destination surfaces palette, in order to preserve the look of the image if the palettes differ.

However, in most cases, applications will want to blit the raw index values, rather than translate to make the colours as similar as possible. For instance, the destination surface's palette may have been modified to fade the screen out.

This change allows an indexed surface to have no associated palette. If either the source or destination surface of a blit do not have a palette, then the raw indices are copied (assuming both have an indexed format).

This mimics better what happens with most other APIs (such as DirectDraw), where most users do not set a palette on any surface but the screen, whose palette is implicitly used for the whole application.