### PR TITLE
haiku: No more chdir to executable's directory at startup in SDL3.

### DIFF
--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -798,6 +798,18 @@ The following functions have been removed:
 
 ## SDL_init.h
 
+On Haiku OS, SDL no longer sets the current working directory to the executable's path during SDL_Init(). If you need this functionality, the fastest solution is to add this code directly after the call to SDL_Init:
+
+```c
+{
+    char *path = SDL_GetBasePath();
+    if (path) {
+        chdir(path);
+        SDL_free(path);
+    }
+}
+```
+
 The following symbols have been renamed:
 * SDL_INIT_GAMECONTROLLER => SDL_INIT_GAMEPAD
 

--- a/src/core/haiku/SDL_BeApp.cc
+++ b/src/core/haiku/SDL_BeApp.cc
@@ -117,21 +117,6 @@ static int StartBeLooper()
         } while ((!be_app) || be_app->IsLaunching());
     }
 
-     /* Change working directory to that of executable */
-    app_info info;
-    if (B_OK == be_app->GetAppInfo(&info)) {
-        entry_ref ref = info.ref;
-        BEntry entry;
-        if (B_OK == entry.SetTo(&ref)) {
-            BPath path;
-            if (B_OK == path.SetTo(&entry)) {
-                if (B_OK == path.GetParent(&path)) {
-                    chdir(path.Path());
-                }
-            }
-        }
-    }
-
     SDL_Looper = new SDL_BLooper("SDLLooper");
     SDL_Looper->Run();
     return (0);


### PR DESCRIPTION
Use SDL_GetBaseDir() to find this directory instead.

Reference Issue #8403.
Fixes #7596.

