### PR TITLE
cmake: use `FULL` install directory variants in pkg-config file

### DIFF
--- a/cmake/sdl3.pc.in
+++ b/cmake/sdl3.pc.in
@@ -1,7 +1,7 @@
 prefix=@SDL_PKGCONFIG_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: sdl3
 Description: Simple DirectMedia Layer is a cross-platform multimedia library designed to provide low level access to audio, keyboard, mouse, joystick, 3D hardware via OpenGL, and 2D video framebuffer.


### PR DESCRIPTION
## Description

Instead of manually prepending the install prefix to `CMAKE_INSTALL_<dir>` (which may already be an absolute path), we can let cmake do it for us

See https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html#result-variables for documentation about this

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
