### PR TITLE
Changed return type of func SDL_GetWindowPixelFormat

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2012,7 +2012,7 @@ void *SDL_GetWindowICCProfile(SDL_Window *window, size_t *size)
     return _this->GetWindowICCProfile(_this, window, size);
 }
 
-Uint32 SDL_GetWindowPixelFormat(SDL_Window *window)
+SDL_PixelFormat SDL_GetWindowPixelFormat(SDL_Window *window)
 {
     SDL_DisplayID displayID;
     const SDL_DisplayMode *mode;


### PR DESCRIPTION
Changed return type of func SDL_GetWindowPixelFormat from Uint32 to SDL_PixelFormat.
Fixed Issue:https://github.com/libsdl-org/SDL/issues/10257

