### PR TITLE
pthread: timespec.tv_nsec must be less then 1000000000 ns

### DIFF
--- a/src/thread/pthread/SDL_syscond.c
+++ b/src/thread/pthread/SDL_syscond.c
@@ -120,7 +120,7 @@ int SDL_WaitConditionTimeoutNS(SDL_Condition *cond, SDL_Mutex *mutex, Sint64 tim
     abstime.tv_sec = delta.tv_sec + (timeoutNS / SDL_NS_PER_SECOND);
     abstime.tv_nsec = SDL_US_TO_NS(delta.tv_usec) + (timeoutNS % SDL_NS_PER_SECOND);
 #endif
-    while (abstime.tv_nsec > 1000000000) {
+    while (abstime.tv_nsec >= 1000000000) {
         abstime.tv_sec += 1;
         abstime.tv_nsec -= 1000000000;
     }

--- a/src/thread/pthread/SDL_syssem.c
+++ b/src/thread/pthread/SDL_syssem.c
@@ -115,7 +115,7 @@ int SDL_WaitSemaphoreTimeoutNS(SDL_Semaphore *sem, Sint64 timeoutNS)
 #endif
 
     /* Wrap the second if needed */
-    while (ts_timeout.tv_nsec > 1000000000) {
+    while (ts_timeout.tv_nsec >= 1000000000) {
         ts_timeout.tv_sec += 1;
         ts_timeout.tv_nsec -= 1000000000;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
Fixes https://github.com/libsdl-org/SDL/issues/8576#issuecomment-2227124926
