### PR TITLE
[SDL2] pthread: timespec.tv_nsec must be less then 1000000000 ns

### DIFF
--- a/src/thread/pthread/SDL_syscond.c
+++ b/src/thread/pthread/SDL_syscond.c
@@ -114,7 +114,7 @@ int SDL_CondWaitTimeout(SDL_cond *cond, SDL_mutex *mutex, Uint32 ms)
     abstime.tv_sec = delta.tv_sec + (ms / 1000);
     abstime.tv_nsec = (long)(delta.tv_usec + (ms % 1000) * 1000) * 1000;
 #endif
-    if (abstime.tv_nsec > 1000000000) {
+    if (abstime.tv_nsec >= 1000000000) {
         abstime.tv_sec += 1;
         abstime.tv_nsec -= 1000000000;
     }

--- a/src/thread/pthread/SDL_syssem.c
+++ b/src/thread/pthread/SDL_syssem.c
@@ -141,7 +141,7 @@ int SDL_SemWaitTimeout(SDL_sem *sem, Uint32 timeout)
 #endif
 
     /* Wrap the second if needed */
-    if (ts_timeout.tv_nsec > 1000000000) {
+    if (ts_timeout.tv_nsec >= 1000000000) {
         ts_timeout.tv_sec += 1;
         ts_timeout.tv_nsec -= 1000000000;
     }


### PR DESCRIPTION
SDL2 backport of #10262
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
