### PR TITLE
sdl2-config.in: use backtics instead of $() for older shells

### DIFF
--- a/sdl2-config.in
+++ b/sdl2-config.in
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 # Get the canonical path of the folder containing this script
-bindir=$(cd -P -- "$(dirname -- "$0")" && printf '%s\n' "$(pwd -P)")
+bindir=`cd -P -- "\`dirname -- "$0"\`" && printf '%s\n' "\`pwd -P\`"`
 
 # Calculate the canonical path of the prefix, relative to the folder of this script
-prefix=$(cd -P -- "$bindir/@bin_prefix_relpath@" && printf '%s\n' "$(pwd -P)")
+prefix=`cd -P -- "$bindir/@bin_prefix_relpath@" && printf '%s\n' "\`pwd -P\`"`
 exec_prefix=@exec_prefix@
 exec_prefix_set=no
 libdir=@libdir@


### PR DESCRIPTION
/bin/sh of Solaris does not understand $()



<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
Fixes https://github.com/libsdl-org/SDL/issues/10092