### PR TITLE
Correct ibus include path

### DIFF
--- a/src/core/linux/SDL_ibus.h
+++ b/src/core/linux/SDL_ibus.h
@@ -26,7 +26,7 @@
 
 #ifdef HAVE_IBUS_IBUS_H
 #define SDL_USE_IBUS 1
-#include <ibus-1.0/ibus.h>
+#include <ibus.h>
 
 extern SDL_bool SDL_IBus_Init(void);
 extern void SDL_IBus_Quit(void);


### PR DESCRIPTION
`ibus-1.0.pc` adds `/usr/include/ibus-1.0` to the search path but not `/usr/include`, which makes the canonical include path `<ibus.h>` (you can confirm this by running `pkg-config ibus-1.0 --cflags` or by looking at https://github.com/ibus/ibus/blob/main/ibus-1.0.pc.in). Correcting the include path improves SDL's compatibility with third-party build scripts and build systems without requiring such ports to modify the SDL source code itself.