### PR TITLE
Fix typos in cmake

### DIFF
--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -209,8 +209,8 @@ function(target_get_dynamic_library DEST TARGET)
     endforeach()
   else()
     # 1. find the target library a file might be symbolic linking to
-    # 2. find all other files in the same folder that symolic link to it
-    # 3. sort all these files, and select the 1st item on Linux, and last on Macos
+    # 2. find all other files in the same folder that symbolic link to it
+    # 3. sort all these files, and select the 1st item on Linux, and last on macOS
     set(location_properties IMPORTED_LOCATION)
     if(CMAKE_BUILD_TYPE)
       list(APPEND location_properties IMPORTED_LOCATION_${CMAKE_BUILD_TYPE})
@@ -226,7 +226,7 @@ function(target_get_dynamic_library DEST TARGET)
     foreach(location_property ${location_properties})
       if(NOT result)
         get_target_property(library_path "${TARGET}" ${location_property})
-        message(DEBUG "get_target_property(${TARGET} ${location_propert}) -> ${library_path}")
+        message(DEBUG "get_target_property(${TARGET} ${location_property}) -> ${library_path}")
         if(EXISTS "${library_path}")
           get_filename_component(library_path "${library_path}" ABSOLUTE)
           while (IS_SYMLINK "${library_path}")

--- a/cmake/sdltargets.cmake
+++ b/cmake/sdltargets.cmake
@@ -28,7 +28,7 @@ function(sdl_sources)
   set_property(TARGET SDL3-collector APPEND PROPERTY INTERFACE_SOURCES ${ARGS_SHARED} ${ARGS_STATIC} ${ARGS_UNPARSED_ARGUMENTS})
 endfunction()
 
-# Use sdl_generic_link_dependency to describe a private depency of SDL3. All options are optional.
+# Use sdl_generic_link_dependency to describe a private dependency of SDL3. All options are optional.
 # Users should use sdl_link_dependency and sdl_test_link_dependency instead
 # - SHARED_TARGETS: shared targets to add this dependency to
 # - STATIC_TARGETS: static targets to add this dependency to
@@ -133,7 +133,7 @@ function(sdl_compile_options)
   endif()
 endfunction()
 
-# Use sdl_link_dependency to add incude directories to the SDL3 libraries.
+# Use sdl_link_dependency to add include directories to the SDL3 libraries.
 function(sdl_include_directories)
   cmake_parse_arguments(ARGS "SYSTEM;BEFORE;AFTER;PRIVATE;PUBLIC;INTERFACE;NO_EXPORT" "" "" ${ARGN})
   set(system "")


### PR DESCRIPTION
## Description
Fixes some typos in the cmake directory, including one that impacted a debug message.
