### PR TITLE
SDL_GetWindowOpacity() directly returns the opacity instead of using an out parameter.

### DIFF
--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -2043,8 +2043,9 @@ SDL_GL_GetDrawableSize() has been removed. SDL_GetWindowSizeInPixels() can be us
 
 The SDL_WINDOW_TOOLTIP and SDL_WINDOW_POPUP_MENU window flags are now supported on Windows, Mac (Cocoa), X11, and Wayland. Creating windows with these flags must happen via the `SDL_CreatePopupWindow()` function. This function requires passing in the handle to a valid parent window for the popup, and the popup window is positioned relative to the parent.
 
-
 SDL_WindowFlags is used instead of Uint32 for API functions that refer to window flags, and has been extended to 64 bits.
+
+SDL_GetWindowOpacity() directly returns the opacity instead of using an out parameter.
 
 The following functions have been renamed:
 * SDL_GL_DeleteContext() => SDL_GL_DestroyContext()

--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -2143,23 +2143,18 @@ extern SDL_DECLSPEC int SDLCALL SDL_SetWindowOpacity(SDL_Window *window, float o
 /**
  * Get the opacity of a window.
  *
- * If transparency isn't supported on this platform, opacity will be reported
+ * If transparency isn't supported on this platform, opacity will be returned
  * as 1.0f without error.
  *
- * The parameter `opacity` is ignored if it is NULL.
- *
- * This function also returns -1 if an invalid window was provided.
- *
  * \param window the window to get the current opacity value from.
- * \param out_opacity the float filled in (0.0f - transparent, 1.0f - opaque).
- * \returns 0 on success or a negative error code on failure; call
+ * \returns the opacity, (0.0f - transparent, 1.0f - opaque), or a negative error code on failure; call
  *          SDL_GetError() for more information.
  *
  * \since This function is available since SDL 3.0.0.
  *
  * \sa SDL_SetWindowOpacity
  */
-extern SDL_DECLSPEC int SDLCALL SDL_GetWindowOpacity(SDL_Window *window, float *out_opacity);
+extern SDL_DECLSPEC float SDLCALL SDL_GetWindowOpacity(SDL_Window *window);
 
 /**
  * Set the window as a modal to a parent window.

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -524,7 +524,7 @@ SDL_DYNAPI_PROC(int,SDL_GetWindowMaximumSize,(SDL_Window *a, int *b, int *c),(a,
 SDL_DYNAPI_PROC(int,SDL_GetWindowMinimumSize,(SDL_Window *a, int *b, int *c),(a,b,c),return)
 SDL_DYNAPI_PROC(SDL_bool,SDL_GetWindowMouseGrab,(SDL_Window *a),(a),return)
 SDL_DYNAPI_PROC(const SDL_Rect*,SDL_GetWindowMouseRect,(SDL_Window *a),(a),return)
-SDL_DYNAPI_PROC(int,SDL_GetWindowOpacity,(SDL_Window *a, float *b),(a,b),return)
+SDL_DYNAPI_PROC(float,SDL_GetWindowOpacity,(SDL_Window *a),(a),return)
 SDL_DYNAPI_PROC(SDL_Window*,SDL_GetWindowParent,(SDL_Window *a),(a),return)
 SDL_DYNAPI_PROC(float,SDL_GetWindowPixelDensity,(SDL_Window *a),(a),return)
 SDL_DYNAPI_PROC(SDL_PixelFormat,SDL_GetWindowPixelFormat,(SDL_Window *a),(a),return)

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -2216,15 +2216,13 @@ int SDLTest_CommonEventMainCallbacks(SDLTest_CommonState *state, const SDL_Event
                 /* Ctrl-O (or Ctrl-Shift-O) changes window opacity. */
                 SDL_Window *window = SDL_GetWindowFromID(event->key.windowID);
                 if (window) {
-                    float opacity;
-                    if (SDL_GetWindowOpacity(window, &opacity) == 0) {
-                        if (withShift) {
-                            opacity += 0.20f;
-                        } else {
-                            opacity -= 0.20f;
-                        }
-                        SDL_SetWindowOpacity(window, opacity);
+                    float opacity = SDL_GetWindowOpacity(window);
+                    if (withShift) {
+                        opacity += 0.20f;
+                    } else {
+                        opacity -= 0.20f;
                     }
+                    SDL_SetWindowOpacity(window, opacity);
                 }
             }
             break;

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -3504,15 +3504,11 @@ int SDL_SetWindowOpacity(SDL_Window *window, float opacity)
     return retval;
 }
 
-int SDL_GetWindowOpacity(SDL_Window *window, float *out_opacity)
+float SDL_GetWindowOpacity(SDL_Window *window)
 {
-    CHECK_WINDOW_MAGIC(window, -1);
+    CHECK_WINDOW_MAGIC(window, -1.0f);
 
-    if (out_opacity) {
-        *out_opacity = window->opacity;
-    }
-
-    return 0;
+    return window->opacity;
 }
 
 int SDL_SetWindowModalFor(SDL_Window *modal_window, SDL_Window *parent_window)


### PR DESCRIPTION
Fixes https://github.com/libsdl-org/SDL/issues/10286