### PR TITLE
Renamed SDL_DisplayMode driverdata to internal

### DIFF
--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -74,6 +74,9 @@ typedef enum SDL_SystemTheme
     SDL_SYSTEM_THEME_DARK       /**< Dark colored system theme */
 } SDL_SystemTheme;
 
+/* Internal display mode data */
+typedef struct SDL_DisplayModeData SDL_DisplayModeData;
+
 /**
  * The structure that defines a display mode.
  *
@@ -95,7 +98,9 @@ typedef struct SDL_DisplayMode
     float refresh_rate;             /**< refresh rate (or 0.0f for unspecified) */
     int refresh_rate_numerator;     /**< precise refresh rate numerator (or 0 for unspecified) */
     int refresh_rate_denominator;   /**< precise refresh rate denominator */
-    void *driverdata;               /**< driver-specific data, initialize to 0 */
+
+    SDL_DisplayModeData *internal;  /**< Private */
+
 } SDL_DisplayMode;
 
 /**

--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -1144,7 +1144,7 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeSurfaceCreated)(JNIEnv *env, j
     SDL_LockMutex(Android_ActivityMutex);
 
     if (Android_Window) {
-        SDL_WindowData *data = Android_Window->driverdata;
+        SDL_WindowData *data = Android_Window->internal;
 
         data->native_window = Android_JNI_GetNativeWindow();
         if (data->native_window == NULL) {
@@ -1163,7 +1163,7 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeSurfaceChanged)(JNIEnv *env, j
 #ifdef SDL_VIDEO_OPENGL_EGL
     if (Android_Window) {
         SDL_VideoDevice *_this = SDL_GetVideoDevice();
-        SDL_WindowData *data = Android_Window->driverdata;
+        SDL_WindowData *data = Android_Window->internal;
 
         /* If the surface has been previously destroyed by onNativeSurfaceDestroyed, recreate it here */
         if (data->egl_surface == EGL_NO_SURFACE) {
@@ -1187,7 +1187,7 @@ retry:
     SDL_LockMutex(Android_ActivityMutex);
 
     if (Android_Window) {
-        SDL_WindowData *data = Android_Window->driverdata;
+        SDL_WindowData *data = Android_Window->internal;
 
         /* Wait for Main thread being paused and context un-activated to release 'egl_surface' */
         if (!data->backup_done) {

--- a/src/core/winrt/SDL_winrtapp_direct3d.cpp
+++ b/src/core/winrt/SDL_winrtapp_direct3d.cpp
@@ -108,7 +108,7 @@ static void WINRT_ProcessWindowSizeChange() // TODO: Pass an SDL_Window-identify
     if (coreWindow) {
         if (WINRT_GlobalSDLWindow) {
             SDL_Window *window = WINRT_GlobalSDLWindow;
-            SDL_WindowData *data = window->driverdata;
+            SDL_WindowData *data = window->internal;
 
             int x = (int)SDL_lroundf(data->coreWindow->Bounds.Left);
             int y = (int)SDL_lroundf(data->coreWindow->Bounds.Top);
@@ -228,7 +228,7 @@ void SDL_WinRTApp::OnOrientationChanged(Object ^ sender)
     // TODO, WinRT: do more extensive research into why orientation changes on Win 8.x don't need D3D changes, or if they might, in some cases
     SDL_Window *window = WINRT_GlobalSDLWindow;
     if (window) {
-        SDL_WindowData *data = window->driverdata;
+        SDL_WindowData *data = window->internal;
         int w = (int)SDL_floorf(data->coreWindow->Bounds.Width);
         int h = (int)SDL_floorf(data->coreWindow->Bounds.Height);
         SDL_SendWindowEvent(WINRT_GlobalSDLWindow, SDL_EVENT_WINDOW_RESIZED, w, h);

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -409,7 +409,7 @@ void SDL_SetDefaultCursor(SDL_Cursor *cursor)
             }
         }
 
-        if (mouse->FreeCursor && default_cursor->driverdata) {
+        if (mouse->FreeCursor && default_cursor->internal) {
             mouse->FreeCursor(default_cursor);
         } else {
             SDL_free(default_cursor);
@@ -1628,7 +1628,7 @@ void SDL_DestroyCursor(SDL_Cursor *cursor)
                 mouse->cursors = curr->next;
             }
 
-            if (mouse->FreeCursor && curr->driverdata) {
+            if (mouse->FreeCursor && curr->internal) {
                 mouse->FreeCursor(curr);
             } else {
                 SDL_free(curr);

--- a/src/events/SDL_mouse_c.h
+++ b/src/events/SDL_mouse_c.h
@@ -32,7 +32,7 @@
 struct SDL_Cursor
 {
     struct SDL_Cursor *next;
-    void *driverdata;
+    void *internal;
 };
 
 typedef struct
@@ -126,7 +126,7 @@ typedef struct
     SDL_bool cursor_shown;
 
     /* Driver-dependent data. */
-    void *driverdata;
+    void *internal;
 } SDL_Mouse;
 
 /* Initialize the mouse subsystem, called before the main video driver is initialized */

--- a/src/render/SDL_sysrender.h
+++ b/src/render/SDL_sysrender.h
@@ -88,7 +88,7 @@ struct SDL_Texture
 
     SDL_PropertiesID props;
 
-    void *driverdata; /**< Driver specific texture representation */
+    void *internal; /**< Driver specific texture representation */
 
     SDL_Texture *prev;
     SDL_Texture *next;
@@ -290,7 +290,7 @@ struct SDL_Renderer
 
     SDL_bool destroyed;   // already destroyed by SDL_DestroyWindow; just free this struct in SDL_DestroyRenderer.
 
-    void *driverdata;
+    void *internal;
 
     SDL_Renderer *next;
 };

--- a/src/render/direct3d/SDL_render_d3d.c
+++ b/src/render/direct3d/SDL_render_d3d.c
@@ -285,7 +285,7 @@ static int D3D_Reset(SDL_Renderer *renderer);
 
 static int D3D_ActivateRenderer(SDL_Renderer *renderer)
 {
-    D3D_RenderData *data = (D3D_RenderData *)renderer->driverdata;
+    D3D_RenderData *data = (D3D_RenderData *)renderer->internal;
     HRESULT result;
 
     if (data->updateSize) {
@@ -332,7 +332,7 @@ static int D3D_ActivateRenderer(SDL_Renderer *renderer)
 
 static void D3D_WindowEvent(SDL_Renderer *renderer, const SDL_WindowEvent *event)
 {
-    D3D_RenderData *data = (D3D_RenderData *)renderer->driverdata;
+    D3D_RenderData *data = (D3D_RenderData *)renderer->internal;
 
     if (event->type == SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED) {
         data->updateSize = SDL_TRUE;
@@ -389,7 +389,7 @@ static D3DBLENDOP GetBlendEquation(SDL_BlendOperation operation)
 
 static SDL_bool D3D_SupportsBlendMode(SDL_Renderer *renderer, SDL_BlendMode blendMode)
 {
-    D3D_RenderData *data = (D3D_RenderData *)renderer->driverdata;
+    D3D_RenderData *data = (D3D_RenderData *)renderer->internal;
     SDL_BlendFactor srcColorFactor = SDL_GetBlendModeSrcColorFactor(blendMode);
     SDL_BlendFactor srcAlphaFactor = SDL_GetBlendModeSrcAlphaFactor(blendMode);
     SDL_BlendOperation colorOperation = SDL_GetBlendModeColorOperation(blendMode);
@@ -523,7 +523,7 @@ static void D3D_DestroyTextureRep(D3D_TextureRep *texture)
 
 static int D3D_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL_PropertiesID create_props)
 {
-    D3D_RenderData *data = (D3D_RenderData *)renderer->driverdata;
+    D3D_RenderData *data = (D3D_RenderData *)renderer->internal;
     D3D_TextureData *texturedata;
     DWORD usage;
 
@@ -533,7 +533,7 @@ static int D3D_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL_P
     }
     texturedata->scaleMode = (texture->scaleMode == SDL_SCALEMODE_NEAREST) ? D3DTEXF_POINT : D3DTEXF_LINEAR;
 
-    texture->driverdata = texturedata;
+    texture->internal = texturedata;
 
     if (texture->access == SDL_TEXTUREACCESS_TARGET) {
         usage = D3DUSAGE_RENDERTARGET;
@@ -569,8 +569,8 @@ static int D3D_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL_P
 
 static int D3D_RecreateTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    D3D_RenderData *data = (D3D_RenderData *)renderer->driverdata;
-    D3D_TextureData *texturedata = (D3D_TextureData *)texture->driverdata;
+    D3D_RenderData *data = (D3D_RenderData *)renderer->internal;
+    D3D_TextureData *texturedata = (D3D_TextureData *)texture->internal;
 
     if (!texturedata) {
         return 0;
@@ -596,8 +596,8 @@ static int D3D_RecreateTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 static int D3D_UpdateTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                              const SDL_Rect *rect, const void *pixels, int pitch)
 {
-    D3D_RenderData *data = (D3D_RenderData *)renderer->driverdata;
-    D3D_TextureData *texturedata = (D3D_TextureData *)texture->driverdata;
+    D3D_RenderData *data = (D3D_RenderData *)renderer->internal;
+    D3D_TextureData *texturedata = (D3D_TextureData *)texture->internal;
 
     if (!texturedata) {
         return SDL_SetError("Texture is not currently available");
@@ -632,8 +632,8 @@ static int D3D_UpdateTextureYUV(SDL_Renderer *renderer, SDL_Texture *texture,
                                 const Uint8 *Uplane, int Upitch,
                                 const Uint8 *Vplane, int Vpitch)
 {
-    D3D_RenderData *data = (D3D_RenderData *)renderer->driverdata;
-    D3D_TextureData *texturedata = (D3D_TextureData *)texture->driverdata;
+    D3D_RenderData *data = (D3D_RenderData *)renderer->internal;
+    D3D_TextureData *texturedata = (D3D_TextureData *)texture->internal;
 
     if (!texturedata) {
         return SDL_SetError("Texture is not currently available");
@@ -655,8 +655,8 @@ static int D3D_UpdateTextureYUV(SDL_Renderer *renderer, SDL_Texture *texture,
 static int D3D_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                            const SDL_Rect *rect, void **pixels, int *pitch)
 {
-    D3D_RenderData *data = (D3D_RenderData *)renderer->driverdata;
-    D3D_TextureData *texturedata = (D3D_TextureData *)texture->driverdata;
+    D3D_RenderData *data = (D3D_RenderData *)renderer->internal;
+    D3D_TextureData *texturedata = (D3D_TextureData *)texture->internal;
     IDirect3DDevice9 *device = data->device;
 
     if (!texturedata) {
@@ -706,8 +706,8 @@ static int D3D_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
 
 static void D3D_UnlockTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    D3D_RenderData *data = (D3D_RenderData *)renderer->driverdata;
-    D3D_TextureData *texturedata = (D3D_TextureData *)texture->driverdata;
+    D3D_RenderData *data = (D3D_RenderData *)renderer->internal;
+    D3D_TextureData *texturedata = (D3D_TextureData *)texture->internal;
 
     if (!texturedata) {
         return;
@@ -736,7 +736,7 @@ static void D3D_UnlockTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 
 static void D3D_SetTextureScaleMode(SDL_Renderer *renderer, SDL_Texture *texture, SDL_ScaleMode scaleMode)
 {
-    D3D_TextureData *texturedata = (D3D_TextureData *)texture->driverdata;
+    D3D_TextureData *texturedata = (D3D_TextureData *)texture->internal;
 
     if (!texturedata) {
         return;
@@ -747,7 +747,7 @@ static void D3D_SetTextureScaleMode(SDL_Renderer *renderer, SDL_Texture *texture
 
 static int D3D_SetRenderTargetInternal(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    D3D_RenderData *data = (D3D_RenderData *)renderer->driverdata;
+    D3D_RenderData *data = (D3D_RenderData *)renderer->internal;
     D3D_TextureData *texturedata;
     D3D_TextureRep *texturerep;
     HRESULT result;
@@ -764,7 +764,7 @@ static int D3D_SetRenderTargetInternal(SDL_Renderer *renderer, SDL_Texture *text
         return 0;
     }
 
-    texturedata = (D3D_TextureData *)texture->driverdata;
+    texturedata = (D3D_TextureData *)texture->internal;
     if (!texturedata) {
         return SDL_SetError("Texture is not currently available");
     }
@@ -941,7 +941,7 @@ static void UpdateTextureScaleMode(D3D_RenderData *data, D3D_TextureData *textur
 
 static int SetupTextureState(D3D_RenderData *data, SDL_Texture *texture, D3D9_Shader *shader, const float **shader_params)
 {
-    D3D_TextureData *texturedata = (D3D_TextureData *)texture->driverdata;
+    D3D_TextureData *texturedata = (D3D_TextureData *)texture->internal;
 
     if (!texturedata) {
         return SDL_SetError("Texture is not currently available");
@@ -978,8 +978,8 @@ static int SetDrawState(D3D_RenderData *data, const SDL_RenderCommand *cmd)
 
     if (texture != data->drawstate.texture) {
 #if SDL_HAVE_YUV
-        D3D_TextureData *oldtexturedata = data->drawstate.texture ? (D3D_TextureData *)data->drawstate.texture->driverdata : NULL;
-        D3D_TextureData *newtexturedata = texture ? (D3D_TextureData *)texture->driverdata : NULL;
+        D3D_TextureData *oldtexturedata = data->drawstate.texture ? (D3D_TextureData *)data->drawstate.texture->internal : NULL;
+        D3D_TextureData *newtexturedata = texture ? (D3D_TextureData *)texture->internal : NULL;
 #endif
         D3D9_Shader shader = SHADER_NONE;
         const float *shader_params = NULL;
@@ -1021,7 +1021,7 @@ static int SetDrawState(D3D_RenderData *data, const SDL_RenderCommand *cmd)
 
         data->drawstate.texture = texture;
     } else if (texture) {
-        D3D_TextureData *texturedata = (D3D_TextureData *)texture->driverdata;
+        D3D_TextureData *texturedata = (D3D_TextureData *)texture->internal;
         UpdateDirtyTexture(data->device, &texturedata->texture);
 #if SDL_HAVE_YUV
         if (texturedata->yuv) {
@@ -1104,7 +1104,7 @@ static int SetDrawState(D3D_RenderData *data, const SDL_RenderCommand *cmd)
 
 static void D3D_InvalidateCachedState(SDL_Renderer *renderer)
 {
-    D3D_RenderData *data = (D3D_RenderData *)renderer->driverdata;
+    D3D_RenderData *data = (D3D_RenderData *)renderer->internal;
     data->drawstate.viewport_dirty = SDL_TRUE;
     data->drawstate.cliprect_enabled_dirty = SDL_TRUE;
     data->drawstate.cliprect_dirty = SDL_TRUE;
@@ -1116,7 +1116,7 @@ static void D3D_InvalidateCachedState(SDL_Renderer *renderer)
 
 static int D3D_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, void *vertices, size_t vertsize)
 {
-    D3D_RenderData *data = (D3D_RenderData *)renderer->driverdata;
+    D3D_RenderData *data = (D3D_RenderData *)renderer->internal;
     const int vboidx = data->currentVertexBuffer;
     IDirect3DVertexBuffer9 *vbo = NULL;
     const SDL_bool istarget = renderer->target != NULL;
@@ -1315,7 +1315,7 @@ static int D3D_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, v
 
 static SDL_Surface *D3D_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rect *rect)
 {
-    D3D_RenderData *data = (D3D_RenderData *)renderer->driverdata;
+    D3D_RenderData *data = (D3D_RenderData *)renderer->internal;
     D3DSURFACE_DESC desc;
     LPDIRECT3DSURFACE9 backBuffer;
     LPDIRECT3DSURFACE9 surface;
@@ -1372,7 +1372,7 @@ static SDL_Surface *D3D_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rect 
 
 static int D3D_RenderPresent(SDL_Renderer *renderer)
 {
-    D3D_RenderData *data = (D3D_RenderData *)renderer->driverdata;
+    D3D_RenderData *data = (D3D_RenderData *)renderer->internal;
     HRESULT result;
 
     if (!data->beginScene) {
@@ -1397,8 +1397,8 @@ static int D3D_RenderPresent(SDL_Renderer *renderer)
 
 static void D3D_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    D3D_RenderData *renderdata = (D3D_RenderData *)renderer->driverdata;
-    D3D_TextureData *data = (D3D_TextureData *)texture->driverdata;
+    D3D_RenderData *renderdata = (D3D_RenderData *)renderer->internal;
+    D3D_TextureData *data = (D3D_TextureData *)texture->internal;
 
     if (renderdata->drawstate.texture == texture) {
         renderdata->drawstate.texture = NULL;
@@ -1425,12 +1425,12 @@ static void D3D_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture)
     SDL_free(data->pixels);
 #endif
     SDL_free(data);
-    texture->driverdata = NULL;
+    texture->internal = NULL;
 }
 
 static void D3D_DestroyRenderer(SDL_Renderer *renderer)
 {
-    D3D_RenderData *data = (D3D_RenderData *)renderer->driverdata;
+    D3D_RenderData *data = (D3D_RenderData *)renderer->internal;
 
     if (data) {
         int i;
@@ -1473,7 +1473,7 @@ static void D3D_DestroyRenderer(SDL_Renderer *renderer)
 
 static int D3D_Reset(SDL_Renderer *renderer)
 {
-    D3D_RenderData *data = (D3D_RenderData *)renderer->driverdata;
+    D3D_RenderData *data = (D3D_RenderData *)renderer->internal;
     const Float4X4 d3dmatrix = MatrixIdentity();
     HRESULT result;
     SDL_Texture *texture;
@@ -1551,7 +1551,7 @@ static int D3D_Reset(SDL_Renderer *renderer)
 
 static int D3D_SetVSync(SDL_Renderer *renderer, const int vsync)
 {
-    D3D_RenderData *data = (D3D_RenderData *)renderer->driverdata;
+    D3D_RenderData *data = (D3D_RenderData *)renderer->internal;
 
     DWORD PresentationInterval;
     switch (vsync) {
@@ -1648,7 +1648,7 @@ int D3D_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_Propertie
     renderer->DestroyTexture = D3D_DestroyTexture;
     renderer->DestroyRenderer = D3D_DestroyRenderer;
     renderer->SetVSync = D3D_SetVSync;
-    renderer->driverdata = data;
+    renderer->internal = data;
     D3D_InvalidateCachedState(renderer);
 
     renderer->name = D3D_RenderDriver.name;

--- a/src/render/direct3d11/SDL_render_d3d11.c
+++ b/src/render/direct3d11/SDL_render_d3d11.c
@@ -325,7 +325,7 @@ static void D3D11_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture);
 
 static void D3D11_ReleaseAll(SDL_Renderer *renderer)
 {
-    D3D11_RenderData *data = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *data = (D3D11_RenderData *)renderer->internal;
     SDL_Texture *texture = NULL;
 
     /* Release all textures */
@@ -410,7 +410,7 @@ static void D3D11_ReleaseAll(SDL_Renderer *renderer)
 
 static void D3D11_DestroyRenderer(SDL_Renderer *renderer)
 {
-    D3D11_RenderData *data = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *data = (D3D11_RenderData *)renderer->internal;
     D3D11_ReleaseAll(renderer);
     if (data) {
         SDL_free(data);
@@ -465,7 +465,7 @@ static D3D11_BLEND_OP GetBlendEquation(SDL_BlendOperation operation)
 
 static ID3D11BlendState *D3D11_CreateBlendState(SDL_Renderer *renderer, SDL_BlendMode blendMode)
 {
-    D3D11_RenderData *data = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *data = (D3D11_RenderData *)renderer->internal;
     SDL_BlendFactor srcColorFactor = SDL_GetBlendModeSrcColorFactor(blendMode);
     SDL_BlendFactor srcAlphaFactor = SDL_GetBlendModeSrcAlphaFactor(blendMode);
     SDL_BlendOperation colorOperation = SDL_GetBlendModeColorOperation(blendMode);
@@ -514,7 +514,7 @@ static HRESULT D3D11_CreateDeviceResources(SDL_Renderer *renderer)
     typedef HRESULT(WINAPI * PFN_CREATE_DXGI_FACTORY2)(UINT flags, REFIID riid, void **ppFactory);
     PFN_CREATE_DXGI_FACTORY CreateDXGIFactoryFunc = NULL;
     PFN_CREATE_DXGI_FACTORY2 CreateDXGIFactory2Func = NULL;
-    D3D11_RenderData *data = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *data = (D3D11_RenderData *)renderer->internal;
     PFN_D3D11_CREATE_DEVICE D3D11CreateDeviceFunc;
     ID3D11Device *d3dDevice = NULL;
     ID3D11DeviceContext *d3dContext = NULL;
@@ -829,7 +829,7 @@ static BOOL D3D11_IsDisplayRotated90Degrees(DXGI_MODE_ROTATION rotation)
 
 static int D3D11_GetRotationForCurrentRenderTarget(SDL_Renderer *renderer)
 {
-    D3D11_RenderData *data = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *data = (D3D11_RenderData *)renderer->internal;
     if (data->currentOffscreenRenderTargetView) {
         return DXGI_MODE_ROTATION_IDENTITY;
     } else {
@@ -839,7 +839,7 @@ static int D3D11_GetRotationForCurrentRenderTarget(SDL_Renderer *renderer)
 
 static int D3D11_GetViewportAlignedD3DRect(SDL_Renderer *renderer, const SDL_Rect *sdlRect, D3D11_RECT *outRect, BOOL includeViewportOffset)
 {
-    D3D11_RenderData *data = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *data = (D3D11_RenderData *)renderer->internal;
     const int rotation = D3D11_GetRotationForCurrentRenderTarget(renderer);
     const SDL_Rect *viewport = &data->currentViewport;
 
@@ -882,7 +882,7 @@ static int D3D11_GetViewportAlignedD3DRect(SDL_Renderer *renderer, const SDL_Rec
 
 static HRESULT D3D11_CreateSwapChain(SDL_Renderer *renderer, int w, int h)
 {
-    D3D11_RenderData *data = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *data = (D3D11_RenderData *)renderer->internal;
 #ifdef SDL_PLATFORM_WINRT
     IUnknown *coreWindow = D3D11_GetCoreWindowFromSDLRenderer(renderer);
     const BOOL usingXAML = (!coreWindow);
@@ -1038,7 +1038,7 @@ done:
 
 static void D3D11_ReleaseMainRenderTargetView(SDL_Renderer *renderer)
 {
-    D3D11_RenderData *data = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *data = (D3D11_RenderData *)renderer->internal;
     ID3D11DeviceContext_OMSetRenderTargets(data->d3dContext, 0, NULL, NULL);
     SAFE_RELEASE(data->mainRenderTargetView);
 }
@@ -1077,7 +1077,7 @@ static HRESULT D3D11_HandleDeviceLost(SDL_Renderer *renderer)
 /* Initialize all resources that change when the window's size changes. */
 static HRESULT D3D11_CreateWindowSizeDependentResources(SDL_Renderer *renderer)
 {
-    D3D11_RenderData *data = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *data = (D3D11_RenderData *)renderer->internal;
     ID3D11Texture2D *backBuffer = NULL;
     HRESULT result = S_OK;
     int w, h;
@@ -1203,7 +1203,7 @@ void D3D11_Trim(SDL_Renderer *renderer)
 {
 #ifdef SDL_PLATFORM_WINRT
 #if NTDDI_VERSION > NTDDI_WIN8
-    D3D11_RenderData *data = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *data = (D3D11_RenderData *)renderer->internal;
     HRESULT result = S_OK;
     IDXGIDevice3 *dxgiDevice = NULL;
 
@@ -1221,7 +1221,7 @@ void D3D11_Trim(SDL_Renderer *renderer)
 
 static void D3D11_WindowEvent(SDL_Renderer *renderer, const SDL_WindowEvent *event)
 {
-    D3D11_RenderData *data = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *data = (D3D11_RenderData *)renderer->internal;
 
     if (event->type == SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED) {
         data->pixelSizeChanged = SDL_TRUE;
@@ -1260,7 +1260,7 @@ static int GetTextureProperty(SDL_PropertiesID props, const char *name, ID3D11Te
 
 static int D3D11_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL_PropertiesID create_props)
 {
-    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->internal;
     D3D11_TextureData *textureData;
     HRESULT result;
     DXGI_FORMAT textureFormat = SDLPixelFormatToDXGITextureFormat(texture->format, renderer->output_colorspace);
@@ -1278,7 +1278,7 @@ static int D3D11_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL
     }
     textureData->scaleMode = (texture->scaleMode == SDL_SCALEMODE_NEAREST) ? D3D11_FILTER_MIN_MAG_MIP_POINT : D3D11_FILTER_MIN_MAG_MIP_LINEAR;
 
-    texture->driverdata = textureData;
+    texture->internal = textureData;
 
     SDL_zero(textureDesc);
     textureDesc.Width = texture->w;
@@ -1465,7 +1465,7 @@ static int D3D11_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL
 static void D3D11_DestroyTexture(SDL_Renderer *renderer,
                                  SDL_Texture *texture)
 {
-    D3D11_TextureData *data = (D3D11_TextureData *)texture->driverdata;
+    D3D11_TextureData *data = (D3D11_TextureData *)texture->internal;
 
     if (!data) {
         return;
@@ -1484,7 +1484,7 @@ static void D3D11_DestroyTexture(SDL_Renderer *renderer,
     SDL_free(data->pixels);
 #endif
     SDL_free(data);
-    texture->driverdata = NULL;
+    texture->internal = NULL;
 }
 
 static int D3D11_UpdateTextureInternal(D3D11_RenderData *rendererData, ID3D11Texture2D *texture, int bpp, int x, int y, int w, int h, const void *pixels, int pitch)
@@ -1607,8 +1607,8 @@ static int D3D11_UpdateTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                                const SDL_Rect *rect, const void *srcPixels,
                                int srcPitch)
 {
-    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->driverdata;
-    D3D11_TextureData *textureData = (D3D11_TextureData *)texture->driverdata;
+    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->internal;
+    D3D11_TextureData *textureData = (D3D11_TextureData *)texture->internal;
 
     if (!textureData) {
         return SDL_SetError("Texture is not currently available");
@@ -1649,8 +1649,8 @@ static int D3D11_UpdateTextureYUV(SDL_Renderer *renderer, SDL_Texture *texture,
                                   const Uint8 *Uplane, int Upitch,
                                   const Uint8 *Vplane, int Vpitch)
 {
-    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->driverdata;
-    D3D11_TextureData *textureData = (D3D11_TextureData *)texture->driverdata;
+    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->internal;
+    D3D11_TextureData *textureData = (D3D11_TextureData *)texture->internal;
 
     if (!textureData) {
         return SDL_SetError("Texture is not currently available");
@@ -1673,8 +1673,8 @@ static int D3D11_UpdateTextureNV(SDL_Renderer *renderer, SDL_Texture *texture,
                                  const Uint8 *Yplane, int Ypitch,
                                  const Uint8 *UVplane, int UVpitch)
 {
-    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->driverdata;
-    D3D11_TextureData *textureData = (D3D11_TextureData *)texture->driverdata;
+    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->internal;
+    D3D11_TextureData *textureData = (D3D11_TextureData *)texture->internal;
     ID3D11Texture2D *stagingTexture;
     const Uint8 *src;
     Uint8 *dst;
@@ -1785,8 +1785,8 @@ static int D3D11_UpdateTextureNV(SDL_Renderer *renderer, SDL_Texture *texture,
 static int D3D11_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                              const SDL_Rect *rect, void **pixels, int *pitch)
 {
-    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->driverdata;
-    D3D11_TextureData *textureData = (D3D11_TextureData *)texture->driverdata;
+    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->internal;
+    D3D11_TextureData *textureData = (D3D11_TextureData *)texture->internal;
     HRESULT result = S_OK;
     D3D11_TEXTURE2D_DESC stagingTextureDesc;
     D3D11_MAPPED_SUBRESOURCE textureMemory;
@@ -1867,8 +1867,8 @@ static int D3D11_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
 
 static void D3D11_UnlockTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->driverdata;
-    D3D11_TextureData *textureData = (D3D11_TextureData *)texture->driverdata;
+    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->internal;
+    D3D11_TextureData *textureData = (D3D11_TextureData *)texture->internal;
 
     if (!textureData) {
         return;
@@ -1904,7 +1904,7 @@ static void D3D11_UnlockTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 
 static void D3D11_SetTextureScaleMode(SDL_Renderer *renderer, SDL_Texture *texture, SDL_ScaleMode scaleMode)
 {
-    D3D11_TextureData *textureData = (D3D11_TextureData *)texture->driverdata;
+    D3D11_TextureData *textureData = (D3D11_TextureData *)texture->internal;
 
     if (!textureData) {
         return;
@@ -1915,7 +1915,7 @@ static void D3D11_SetTextureScaleMode(SDL_Renderer *renderer, SDL_Texture *textu
 
 static int D3D11_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->internal;
     D3D11_TextureData *textureData = NULL;
 
     if (!texture) {
@@ -1923,7 +1923,7 @@ static int D3D11_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
         return 0;
     }
 
-    textureData = (D3D11_TextureData *)texture->driverdata;
+    textureData = (D3D11_TextureData *)texture->internal;
 
     if (!textureData->mainTextureRenderTargetView) {
         return SDL_SetError("specified texture is not a render target");
@@ -1977,7 +1977,7 @@ static int D3D11_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, S
     int count = indices ? num_indices : num_vertices;
     VertexPositionColor *verts = (VertexPositionColor *)SDL_AllocateRenderVertices(renderer, count * sizeof(VertexPositionColor), 0, &cmd->data.draw.first);
     SDL_bool convert_color = SDL_RenderingLinearSpace(renderer);
-    D3D11_TextureData *textureData = texture ? (D3D11_TextureData *)texture->driverdata : NULL;
+    D3D11_TextureData *textureData = texture ? (D3D11_TextureData *)texture->internal : NULL;
     float u_scale = textureData ? (float)texture->w / textureData->w : 0.0f;
     float v_scale = textureData ? (float)texture->h / textureData->h : 0.0f;
 
@@ -2027,7 +2027,7 @@ static int D3D11_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, S
 static int D3D11_UpdateVertexBuffer(SDL_Renderer *renderer,
                                     const void *vertexData, size_t dataSizeInBytes)
 {
-    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->internal;
     HRESULT result = S_OK;
     const int vbidx = rendererData->currentVertexBuffer;
     const UINT stride = sizeof(VertexPositionColor);
@@ -2095,7 +2095,7 @@ static int D3D11_UpdateVertexBuffer(SDL_Renderer *renderer,
 
 static int D3D11_UpdateViewport(SDL_Renderer *renderer)
 {
-    D3D11_RenderData *data = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *data = (D3D11_RenderData *)renderer->internal;
     const SDL_Rect *viewport = &data->currentViewport;
     Float4X4 projection;
     Float4X4 view;
@@ -2187,7 +2187,7 @@ static int D3D11_UpdateViewport(SDL_Renderer *renderer)
 
 static ID3D11RenderTargetView *D3D11_GetCurrentRenderTargetView(SDL_Renderer *renderer)
 {
-    D3D11_RenderData *data = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *data = (D3D11_RenderData *)renderer->internal;
     if (data->currentOffscreenRenderTargetView) {
         return data->currentOffscreenRenderTargetView;
     } else {
@@ -2205,7 +2205,7 @@ static void D3D11_SetupShaderConstants(SDL_Renderer *renderer, const SDL_RenderC
     constants->color_scale = cmd->data.draw.color_scale;
 
     if (texture) {
-        D3D11_TextureData *textureData = (D3D11_TextureData *)texture->driverdata;
+        D3D11_TextureData *textureData = (D3D11_TextureData *)texture->internal;
 
         switch (texture->format) {
         case SDL_PIXELFORMAT_YV12:
@@ -2263,7 +2263,7 @@ static int D3D11_SetDrawState(SDL_Renderer *renderer, const SDL_RenderCommand *c
                               ID3D11SamplerState *sampler, const Float4X4 *matrix)
 
 {
-    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->internal;
     const Float4X4 *newmatrix = matrix ? matrix : &rendererData->identity;
     ID3D11RasterizerState *rasterizerState;
     ID3D11RenderTargetView *renderTargetView = D3D11_GetCurrentRenderTargetView(renderer);
@@ -2413,8 +2413,8 @@ static int D3D11_SetDrawState(SDL_Renderer *renderer, const SDL_RenderCommand *c
 static int D3D11_SetCopyState(SDL_Renderer *renderer, const SDL_RenderCommand *cmd, const Float4X4 *matrix)
 {
     SDL_Texture *texture = cmd->data.draw.texture;
-    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->driverdata;
-    D3D11_TextureData *textureData = (D3D11_TextureData *)texture->driverdata;
+    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->internal;
+    D3D11_TextureData *textureData = (D3D11_TextureData *)texture->internal;
     ID3D11SamplerState *textureSampler;
     PixelShaderConstants constants;
 
@@ -2461,14 +2461,14 @@ static int D3D11_SetCopyState(SDL_Renderer *renderer, const SDL_RenderCommand *c
 
 static void D3D11_DrawPrimitives(SDL_Renderer *renderer, D3D11_PRIMITIVE_TOPOLOGY primitiveTopology, const size_t vertexStart, const size_t vertexCount)
 {
-    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->internal;
     ID3D11DeviceContext_IASetPrimitiveTopology(rendererData->d3dContext, primitiveTopology);
     ID3D11DeviceContext_Draw(rendererData->d3dContext, (UINT)vertexCount, (UINT)vertexStart);
 }
 
 static void D3D11_InvalidateCachedState(SDL_Renderer *renderer)
 {
-    D3D11_RenderData *data = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *data = (D3D11_RenderData *)renderer->internal;
     data->currentRenderTargetView = NULL;
     data->currentRasterizerState = NULL;
     data->currentBlendState = NULL;
@@ -2481,7 +2481,7 @@ static void D3D11_InvalidateCachedState(SDL_Renderer *renderer)
 
 static int D3D11_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, void *vertices, size_t vertsize)
 {
-    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *rendererData = (D3D11_RenderData *)renderer->internal;
     const int viewportRotation = D3D11_GetRotationForCurrentRenderTarget(renderer);
 
     if (rendererData->pixelSizeChanged) {
@@ -2606,7 +2606,7 @@ static int D3D11_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd,
 
 static SDL_Surface *D3D11_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rect *rect)
 {
-    D3D11_RenderData *data = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *data = (D3D11_RenderData *)renderer->internal;
     ID3D11RenderTargetView *renderTargetView = NULL;
     ID3D11Texture2D *backBuffer = NULL;
     ID3D11Texture2D *stagingTexture = NULL;
@@ -2698,7 +2698,7 @@ done:
 
 static int D3D11_RenderPresent(SDL_Renderer *renderer)
 {
-    D3D11_RenderData *data = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *data = (D3D11_RenderData *)renderer->internal;
     HRESULT result;
     DXGI_PRESENT_PARAMETERS parameters;
 
@@ -2744,7 +2744,7 @@ static int D3D11_RenderPresent(SDL_Renderer *renderer)
 
 static int D3D11_SetVSync(SDL_Renderer *renderer, const int vsync)
 {
-    D3D11_RenderData *data = (D3D11_RenderData *)renderer->driverdata;
+    D3D11_RenderData *data = (D3D11_RenderData *)renderer->internal;
 
 #if SDL_WINAPI_FAMILY_PHONE
     /* VSync is required in Windows Phone, at least for Win Phone 8.0 and 8.1.
@@ -2824,7 +2824,7 @@ static int D3D11_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_
     renderer->DestroyTexture = D3D11_DestroyTexture;
     renderer->DestroyRenderer = D3D11_DestroyRenderer;
     renderer->SetVSync = D3D11_SetVSync;
-    renderer->driverdata = data;
+    renderer->internal = data;
     D3D11_InvalidateCachedState(renderer);
 
     renderer->name = D3D11_RenderDriver.name;

--- a/src/render/direct3d12/SDL_render_d3d12.c
+++ b/src/render/direct3d12/SDL_render_d3d12.c
@@ -442,7 +442,7 @@ static void D3D12_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture);
 
 static void D3D12_ReleaseAll(SDL_Renderer *renderer)
 {
-    D3D12_RenderData *data = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *data = (D3D12_RenderData *)renderer->internal;
     SDL_Texture *texture = NULL;
 
     SDL_PropertiesID props = SDL_GetRendererProperties(renderer);
@@ -556,7 +556,7 @@ static void D3D12_WaitForGPU(D3D12_RenderData *data)
 
 static D3D12_CPU_DESCRIPTOR_HANDLE D3D12_GetCurrentRenderTargetView(SDL_Renderer *renderer)
 {
-    D3D12_RenderData *data = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *data = (D3D12_RenderData *)renderer->internal;
     D3D12_CPU_DESCRIPTOR_HANDLE rtvDescriptor;
 
     if (data->textureRenderTarget) {
@@ -634,7 +634,7 @@ static int D3D12_IssueBatch(D3D12_RenderData *data)
 
 static void D3D12_DestroyRenderer(SDL_Renderer *renderer)
 {
-    D3D12_RenderData *data = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *data = (D3D12_RenderData *)renderer->internal;
     D3D12_WaitForGPU(data);
     D3D12_ReleaseAll(renderer);
     if (data) {
@@ -721,7 +721,7 @@ static D3D12_PipelineState *D3D12_CreatePipelineState(SDL_Renderer *renderer,
         { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 8, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
         { "COLOR", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, 16, D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA, 0 },
     };
-    D3D12_RenderData *data = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *data = (D3D12_RenderData *)renderer->internal;
     D3D12_GRAPHICS_PIPELINE_STATE_DESC pipelineDesc;
     ID3D12PipelineState *pipelineState = NULL;
     D3D12_PipelineState *pipelineStates;
@@ -838,7 +838,7 @@ static HRESULT D3D12_CreateDeviceResources(SDL_Renderer *renderer)
     typedef HANDLE(WINAPI * PFN_CREATE_EVENT_EX)(LPSECURITY_ATTRIBUTES lpEventAttributes, LPCWSTR lpName, DWORD dwFlags, DWORD dwDesiredAccess);
     PFN_CREATE_EVENT_EX CreateEventExFunc;
 
-    D3D12_RenderData *data = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *data = (D3D12_RenderData *)renderer->internal;
     ID3D12Device *d3dDevice = NULL;
     HRESULT result = S_OK;
     UINT creationFlags = 0;
@@ -1219,7 +1219,7 @@ static BOOL D3D12_IsDisplayRotated90Degrees(DXGI_MODE_ROTATION rotation)
 
 static int D3D12_GetRotationForCurrentRenderTarget(SDL_Renderer *renderer)
 {
-    D3D12_RenderData *data = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *data = (D3D12_RenderData *)renderer->internal;
     if (data->textureRenderTarget) {
         return DXGI_MODE_ROTATION_IDENTITY;
     } else {
@@ -1229,7 +1229,7 @@ static int D3D12_GetRotationForCurrentRenderTarget(SDL_Renderer *renderer)
 
 static int D3D12_GetViewportAlignedD3DRect(SDL_Renderer *renderer, const SDL_Rect *sdlRect, D3D12_RECT *outRect, BOOL includeViewportOffset)
 {
-    D3D12_RenderData *data = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *data = (D3D12_RenderData *)renderer->internal;
     const int rotation = D3D12_GetRotationForCurrentRenderTarget(renderer);
     const SDL_Rect *viewport = &data->currentViewport;
 
@@ -1273,7 +1273,7 @@ static int D3D12_GetViewportAlignedD3DRect(SDL_Renderer *renderer, const SDL_Rec
 #if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
 static HRESULT D3D12_CreateSwapChain(SDL_Renderer *renderer, int w, int h)
 {
-    D3D12_RenderData *data = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *data = (D3D12_RenderData *)renderer->internal;
     IDXGISwapChain1 *swapChain = NULL;
     HRESULT result = S_OK;
 
@@ -1419,7 +1419,7 @@ D3D12_HandleDeviceLost(SDL_Renderer *renderer)
 /* Initialize all resources that change when the window's size changes. */
 static HRESULT D3D12_CreateWindowSizeDependentResources(SDL_Renderer *renderer)
 {
-    D3D12_RenderData *data = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *data = (D3D12_RenderData *)renderer->internal;
     HRESULT result = S_OK;
     int i, w, h;
 
@@ -1545,7 +1545,7 @@ done:
 /* This method is called when the window's size changes. */
 static HRESULT D3D12_UpdateForWindowSizeChange(SDL_Renderer *renderer)
 {
-    D3D12_RenderData *data = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *data = (D3D12_RenderData *)renderer->internal;
     /* If the GPU has previous work, wait for it to be done first */
     D3D12_WaitForGPU(data);
     return D3D12_CreateWindowSizeDependentResources(renderer);
@@ -1553,7 +1553,7 @@ static HRESULT D3D12_UpdateForWindowSizeChange(SDL_Renderer *renderer)
 
 static void D3D12_WindowEvent(SDL_Renderer *renderer, const SDL_WindowEvent *event)
 {
-    D3D12_RenderData *data = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *data = (D3D12_RenderData *)renderer->internal;
 
     if (event->type == SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED) {
         data->pixelSizeChanged = SDL_TRUE;
@@ -1580,7 +1580,7 @@ static SDL_bool D3D12_SupportsBlendMode(SDL_Renderer *renderer, SDL_BlendMode bl
 
 static SIZE_T D3D12_GetAvailableSRVIndex(SDL_Renderer *renderer)
 {
-    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->internal;
     if (rendererData->srvPoolHead) {
         SIZE_T index = rendererData->srvPoolHead->index;
         rendererData->srvPoolHead = (D3D12_SRVPoolNode *)(rendererData->srvPoolHead->next);
@@ -1593,7 +1593,7 @@ static SIZE_T D3D12_GetAvailableSRVIndex(SDL_Renderer *renderer)
 
 static void D3D12_FreeSRVIndex(SDL_Renderer *renderer, SIZE_T index)
 {
-    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->internal;
     rendererData->srvPoolNodes[index].next = rendererData->srvPoolHead;
     rendererData->srvPoolHead = &rendererData->srvPoolNodes[index];
 }
@@ -1612,7 +1612,7 @@ static int GetTextureProperty(SDL_PropertiesID props, const char *name, ID3D12Re
 
 static int D3D12_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL_PropertiesID create_props)
 {
-    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->internal;
     D3D12_TextureData *textureData;
     HRESULT result;
     DXGI_FORMAT textureFormat = SDLPixelFormatToDXGITextureFormat(texture->format, renderer->output_colorspace);
@@ -1630,7 +1630,7 @@ static int D3D12_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL
     }
     textureData->scaleMode = (texture->scaleMode == SDL_SCALEMODE_NEAREST) ? D3D12_FILTER_MIN_MAG_MIP_POINT : D3D12_FILTER_MIN_MAG_MIP_LINEAR;
 
-    texture->driverdata = textureData;
+    texture->internal = textureData;
     textureData->mainTextureFormat = textureFormat;
 
     SDL_zero(textureDesc);
@@ -1834,8 +1834,8 @@ static int D3D12_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL
 static void D3D12_DestroyTexture(SDL_Renderer *renderer,
                                  SDL_Texture *texture)
 {
-    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->driverdata;
-    D3D12_TextureData *textureData = (D3D12_TextureData *)texture->driverdata;
+    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->internal;
+    D3D12_TextureData *textureData = (D3D12_TextureData *)texture->internal;
 
     if (!textureData) {
         return;
@@ -1861,7 +1861,7 @@ static void D3D12_DestroyTexture(SDL_Renderer *renderer,
     SDL_free(textureData->pixels);
 #endif
     SDL_free(textureData);
-    texture->driverdata = NULL;
+    texture->internal = NULL;
 }
 
 static int D3D12_UpdateTextureInternal(D3D12_RenderData *rendererData, ID3D12Resource *texture, int plane, int x, int y, int w, int h, const void *pixels, int pitch, D3D12_RESOURCE_STATES *resourceState)
@@ -2006,8 +2006,8 @@ static int D3D12_UpdateTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                                const SDL_Rect *rect, const void *srcPixels,
                                int srcPitch)
 {
-    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->driverdata;
-    D3D12_TextureData *textureData = (D3D12_TextureData *)texture->driverdata;
+    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->internal;
+    D3D12_TextureData *textureData = (D3D12_TextureData *)texture->internal;
 
     if (!textureData) {
         return SDL_SetError("Texture is not currently available");
@@ -2056,8 +2056,8 @@ static int D3D12_UpdateTextureYUV(SDL_Renderer *renderer, SDL_Texture *texture,
                                   const Uint8 *Uplane, int Upitch,
                                   const Uint8 *Vplane, int Vpitch)
 {
-    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->driverdata;
-    D3D12_TextureData *textureData = (D3D12_TextureData *)texture->driverdata;
+    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->internal;
+    D3D12_TextureData *textureData = (D3D12_TextureData *)texture->internal;
 
     if (!textureData) {
         return SDL_SetError("Texture is not currently available");
@@ -2080,8 +2080,8 @@ static int D3D12_UpdateTextureNV(SDL_Renderer *renderer, SDL_Texture *texture,
                                  const Uint8 *Yplane, int Ypitch,
                                  const Uint8 *UVplane, int UVpitch)
 {
-    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->driverdata;
-    D3D12_TextureData *textureData = (D3D12_TextureData *)texture->driverdata;
+    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->internal;
+    D3D12_TextureData *textureData = (D3D12_TextureData *)texture->internal;
 
     if (!textureData) {
         return SDL_SetError("Texture is not currently available");
@@ -2101,8 +2101,8 @@ static int D3D12_UpdateTextureNV(SDL_Renderer *renderer, SDL_Texture *texture,
 static int D3D12_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                              const SDL_Rect *rect, void **pixels, int *pitch)
 {
-    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->driverdata;
-    D3D12_TextureData *textureData = (D3D12_TextureData *)texture->driverdata;
+    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->internal;
+    D3D12_TextureData *textureData = (D3D12_TextureData *)texture->internal;
     HRESULT result = S_OK;
 
     D3D12_RESOURCE_DESC textureDesc;
@@ -2221,8 +2221,8 @@ static int D3D12_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
 
 static void D3D12_UnlockTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->driverdata;
-    D3D12_TextureData *textureData = (D3D12_TextureData *)texture->driverdata;
+    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->internal;
+    D3D12_TextureData *textureData = (D3D12_TextureData *)texture->internal;
 
     D3D12_RESOURCE_DESC textureDesc;
     D3D12_SUBRESOURCE_FOOTPRINT pitchedDesc;
@@ -2300,7 +2300,7 @@ static void D3D12_UnlockTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 
 static void D3D12_SetTextureScaleMode(SDL_Renderer *renderer, SDL_Texture *texture, SDL_ScaleMode scaleMode)
 {
-    D3D12_TextureData *textureData = (D3D12_TextureData *)texture->driverdata;
+    D3D12_TextureData *textureData = (D3D12_TextureData *)texture->internal;
 
     if (!textureData) {
         return;
@@ -2311,7 +2311,7 @@ static void D3D12_SetTextureScaleMode(SDL_Renderer *renderer, SDL_Texture *textu
 
 static int D3D12_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->internal;
     D3D12_TextureData *textureData = NULL;
 
     if (!texture) {
@@ -2326,7 +2326,7 @@ static int D3D12_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
         return 0;
     }
 
-    textureData = (D3D12_TextureData *)texture->driverdata;
+    textureData = (D3D12_TextureData *)texture->internal;
 
     if (!textureData->mainTextureRenderTargetView.ptr) {
         return SDL_SetError("specified texture is not a render target");
@@ -2385,7 +2385,7 @@ static int D3D12_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, S
     int count = indices ? num_indices : num_vertices;
     VertexPositionColor *verts = (VertexPositionColor *)SDL_AllocateRenderVertices(renderer, count * sizeof(VertexPositionColor), 0, &cmd->data.draw.first);
     SDL_bool convert_color = SDL_RenderingLinearSpace(renderer);
-    D3D12_TextureData *textureData = texture ? (D3D12_TextureData *)texture->driverdata : NULL;
+    D3D12_TextureData *textureData = texture ? (D3D12_TextureData *)texture->internal : NULL;
     float u_scale = textureData ? (float)texture->w / textureData->w : 0.0f;
     float v_scale = textureData ? (float)texture->h / textureData->h : 0.0f;
 
@@ -2435,7 +2435,7 @@ static int D3D12_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, S
 static int D3D12_UpdateVertexBuffer(SDL_Renderer *renderer,
                                     const void *vertexData, size_t dataSizeInBytes)
 {
-    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->internal;
     HRESULT result = S_OK;
     const int vbidx = rendererData->currentVertexBuffer;
     UINT8 *vertexBufferData = NULL;
@@ -2484,7 +2484,7 @@ static int D3D12_UpdateVertexBuffer(SDL_Renderer *renderer,
 
 static int D3D12_UpdateViewport(SDL_Renderer *renderer)
 {
-    D3D12_RenderData *data = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *data = (D3D12_RenderData *)renderer->internal;
     const SDL_Rect *viewport = &data->currentViewport;
     Float4X4 projection;
     Float4X4 view;
@@ -2583,7 +2583,7 @@ static void D3D12_SetupShaderConstants(SDL_Renderer *renderer, const SDL_RenderC
     constants->color_scale = cmd->data.draw.color_scale;
 
     if (texture) {
-        D3D12_TextureData *textureData = (D3D12_TextureData *)texture->driverdata;
+        D3D12_TextureData *textureData = (D3D12_TextureData *)texture->internal;
 
         switch (texture->format) {
         case SDL_PIXELFORMAT_YV12:
@@ -2641,7 +2641,7 @@ static int D3D12_SetDrawState(SDL_Renderer *renderer, const SDL_RenderCommand *c
                               D3D12_CPU_DESCRIPTOR_HANDLE *sampler, const Float4X4 *matrix)
 
 {
-    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->internal;
     const Float4X4 *newmatrix = matrix ? matrix : &rendererData->identity;
     D3D12_CPU_DESCRIPTOR_HANDLE renderTargetView = D3D12_GetCurrentRenderTargetView(renderer);
     const SDL_BlendMode blendMode = cmd->data.draw.blend;
@@ -2788,8 +2788,8 @@ static int D3D12_SetDrawState(SDL_Renderer *renderer, const SDL_RenderCommand *c
 static int D3D12_SetCopyState(SDL_Renderer *renderer, const SDL_RenderCommand *cmd, const Float4X4 *matrix)
 {
     SDL_Texture *texture = cmd->data.draw.texture;
-    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->driverdata;
-    D3D12_TextureData *textureData = (D3D12_TextureData *)texture->driverdata;
+    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->internal;
+    D3D12_TextureData *textureData = (D3D12_TextureData *)texture->internal;
     D3D12_CPU_DESCRIPTOR_HANDLE *textureSampler;
     PixelShaderConstants constants;
 
@@ -2842,14 +2842,14 @@ static int D3D12_SetCopyState(SDL_Renderer *renderer, const SDL_RenderCommand *c
 
 static void D3D12_DrawPrimitives(SDL_Renderer *renderer, D3D12_PRIMITIVE_TOPOLOGY primitiveTopology, const size_t vertexStart, const size_t vertexCount)
 {
-    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->internal;
     D3D_CALL(rendererData->commandList, IASetPrimitiveTopology, primitiveTopology);
     D3D_CALL(rendererData->commandList, DrawInstanced, (UINT)vertexCount, 1, (UINT)vertexStart, 0);
 }
 
 static void D3D12_InvalidateCachedState(SDL_Renderer *renderer)
 {
-    D3D12_RenderData *data = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *data = (D3D12_RenderData *)renderer->internal;
     data->currentRenderTargetView.ptr = 0;
     data->currentShaderResource.ptr = 0;
     data->currentSampler.ptr = 0;
@@ -2859,7 +2859,7 @@ static void D3D12_InvalidateCachedState(SDL_Renderer *renderer)
 
 static int D3D12_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, void *vertices, size_t vertsize)
 {
-    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *rendererData = (D3D12_RenderData *)renderer->internal;
     const int viewportRotation = D3D12_GetRotationForCurrentRenderTarget(renderer);
 
     if (rendererData->pixelSizeChanged) {
@@ -2995,7 +2995,7 @@ static int D3D12_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd,
 
 static SDL_Surface *D3D12_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rect *rect)
 {
-    D3D12_RenderData *data = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *data = (D3D12_RenderData *)renderer->internal;
     ID3D12Resource *backBuffer = NULL;
     ID3D12Resource *readbackBuffer = NULL;
     HRESULT result;
@@ -3142,7 +3142,7 @@ done:
 
 static int D3D12_RenderPresent(SDL_Renderer *renderer)
 {
-    D3D12_RenderData *data = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *data = (D3D12_RenderData *)renderer->internal;
     HRESULT result;
 
     /* Transition the render target to present state */
@@ -3212,7 +3212,7 @@ static int D3D12_RenderPresent(SDL_Renderer *renderer)
 
 static int D3D12_SetVSync(SDL_Renderer *renderer, const int vsync)
 {
-    D3D12_RenderData *data = (D3D12_RenderData *)renderer->driverdata;
+    D3D12_RenderData *data = (D3D12_RenderData *)renderer->internal;
 
     if (vsync < 0) {
         return SDL_Unsupported();
@@ -3281,7 +3281,7 @@ int D3D12_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_Propert
     renderer->DestroyTexture = D3D12_DestroyTexture;
     renderer->DestroyRenderer = D3D12_DestroyRenderer;
     renderer->SetVSync = D3D12_SetVSync;
-    renderer->driverdata = data;
+    renderer->internal = data;
     D3D12_InvalidateCachedState(renderer);
 
     renderer->name = D3D12_RenderDriver.name;

--- a/src/render/metal/SDL_render_metal.m
+++ b/src/render/metal/SDL_render_metal.m
@@ -440,7 +440,7 @@ static inline id<MTLRenderPipelineState> ChoosePipelineState(METAL_RenderData *d
 
 static SDL_bool METAL_ActivateRenderCommandEncoder(SDL_Renderer *renderer, MTLLoadAction load, MTLClearColor *clear_color, id<MTLBuffer> vertex_buffer)
 {
-    METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->driverdata;
+    METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->internal;
 
     /* Our SetRenderTarget just signals that the next render operation should
      * set up a new render pass. This is where that work happens. */
@@ -448,7 +448,7 @@ static SDL_bool METAL_ActivateRenderCommandEncoder(SDL_Renderer *renderer, MTLLo
         id<MTLTexture> mtltexture = nil;
 
         if (renderer->target != NULL) {
-            METAL_TextureData *texdata = (__bridge METAL_TextureData *)renderer->target->driverdata;
+            METAL_TextureData *texdata = (__bridge METAL_TextureData *)renderer->target->internal;
             mtltexture = texdata.mtltexture;
         } else {
             if (data.mtlbackbuffer == nil) {
@@ -512,7 +512,7 @@ static void METAL_WindowEvent(SDL_Renderer *renderer, const SDL_WindowEvent *eve
 static int METAL_GetOutputSize(SDL_Renderer *renderer, int *w, int *h)
 {
     @autoreleasepool {
-        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->driverdata;
+        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->internal;
         if (w) {
             *w = (int)data.mtllayer.drawableSize.width;
         }
@@ -624,7 +624,7 @@ size_t GetYCbCRtoRGBConversionMatrix(SDL_Colorspace colorspace, int w, int h, in
 static int METAL_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL_PropertiesID create_props)
 {
     @autoreleasepool {
-        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->driverdata;
+        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->internal;
         MTLPixelFormat pixfmt;
         MTLTextureDescriptor *mtltexdesc;
         id<MTLTexture> mtltexture = nil, mtltextureUv = nil;
@@ -766,7 +766,7 @@ static int METAL_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL
             texturedata.conversionBufferOffset = offset;
         }
 #endif
-        texture->driverdata = (void *)CFBridgingRetain(texturedata);
+        texture->internal = (void *)CFBridgingRetain(texturedata);
 
         return 0;
     }
@@ -796,7 +796,7 @@ static int METAL_UpdateTextureInternal(SDL_Renderer *renderer, METAL_TextureData
                                        id<MTLTexture> texture, SDL_Rect rect, int slice,
                                        const void *pixels, int pitch)
 {
-    METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->driverdata;
+    METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->internal;
     SDL_Rect stagingrect = { 0, 0, rect.w, rect.h };
     MTLTextureDescriptor *desc;
     id<MTLTexture> stagingtex;
@@ -864,7 +864,7 @@ static int METAL_UpdateTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                                const SDL_Rect *rect, const void *pixels, int pitch)
 {
     @autoreleasepool {
-        METAL_TextureData *texturedata = (__bridge METAL_TextureData *)texture->driverdata;
+        METAL_TextureData *texturedata = (__bridge METAL_TextureData *)texture->internal;
 
         if (METAL_UpdateTextureInternal(renderer, texturedata, texturedata.mtltexture, *rect, 0, pixels, pitch) < 0) {
             return -1;
@@ -914,7 +914,7 @@ static int METAL_UpdateTextureYUV(SDL_Renderer *renderer, SDL_Texture *texture,
                                   const Uint8 *Vplane, int Vpitch)
 {
     @autoreleasepool {
-        METAL_TextureData *texturedata = (__bridge METAL_TextureData *)texture->driverdata;
+        METAL_TextureData *texturedata = (__bridge METAL_TextureData *)texture->internal;
         const int Uslice = 0;
         const int Vslice = 1;
         SDL_Rect UVrect = { rect->x / 2, rect->y / 2, (rect->w + 1) / 2, (rect->h + 1) / 2 };
@@ -946,7 +946,7 @@ static int METAL_UpdateTextureNV(SDL_Renderer *renderer, SDL_Texture *texture,
                                  const Uint8 *UVplane, int UVpitch)
 {
     @autoreleasepool {
-        METAL_TextureData *texturedata = (__bridge METAL_TextureData *)texture->driverdata;
+        METAL_TextureData *texturedata = (__bridge METAL_TextureData *)texture->internal;
         SDL_Rect UVrect = { rect->x / 2, rect->y / 2, (rect->w + 1) / 2, (rect->h + 1) / 2 };
 
         /* Bail out if we're supposed to update an empty rectangle */
@@ -973,8 +973,8 @@ static int METAL_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                              const SDL_Rect *rect, void **pixels, int *pitch)
 {
     @autoreleasepool {
-        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->driverdata;
-        METAL_TextureData *texturedata = (__bridge METAL_TextureData *)texture->driverdata;
+        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->internal;
+        METAL_TextureData *texturedata = (__bridge METAL_TextureData *)texture->internal;
         int buffersize = 0;
         id<MTLBuffer> lockedbuffer = nil;
 
@@ -1008,8 +1008,8 @@ static int METAL_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
 static void METAL_UnlockTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 {
     @autoreleasepool {
-        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->driverdata;
-        METAL_TextureData *texturedata = (__bridge METAL_TextureData *)texture->driverdata;
+        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->internal;
+        METAL_TextureData *texturedata = (__bridge METAL_TextureData *)texture->internal;
         id<MTLBlitCommandEncoder> blitcmd;
         SDL_Rect rect = texturedata.lockedrect;
         int pitch = SDL_BYTESPERPIXEL(texture->format) * rect.w;
@@ -1095,8 +1095,8 @@ static void METAL_UnlockTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 static void METAL_SetTextureScaleMode(SDL_Renderer *renderer, SDL_Texture *texture, SDL_ScaleMode scaleMode)
 {
     @autoreleasepool {
-        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->driverdata;
-        METAL_TextureData *texturedata = (__bridge METAL_TextureData *)texture->driverdata;
+        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->internal;
+        METAL_TextureData *texturedata = (__bridge METAL_TextureData *)texture->internal;
 
         if (scaleMode == SDL_SCALEMODE_NEAREST) {
             texturedata.mtlsampler = data.mtlsamplernearest;
@@ -1109,7 +1109,7 @@ static void METAL_SetTextureScaleMode(SDL_Renderer *renderer, SDL_Texture *textu
 static int METAL_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
 {
     @autoreleasepool {
-        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->driverdata;
+        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->internal;
 
         if (data.mtlcmdencoder) {
             /* End encoding for the previous render target so we can set up a new
@@ -1399,7 +1399,7 @@ static void SetupShaderConstants(SDL_Renderer *renderer, const SDL_RenderCommand
 
 static SDL_bool SetDrawState(SDL_Renderer *renderer, const SDL_RenderCommand *cmd, const SDL_MetalFragmentFunction shader, PixelShaderConstants *shader_constants, const size_t constants_offset, id<MTLBuffer> mtlbufvertex, METAL_DrawStateCache *statecache)
 {
-    METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->driverdata;
+    METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->internal;
     const SDL_BlendMode blend = cmd->data.draw.blend;
     size_t first = cmd->data.draw.first;
     id<MTLRenderPipelineState> newpipeline;
@@ -1491,9 +1491,9 @@ static SDL_bool SetDrawState(SDL_Renderer *renderer, const SDL_RenderCommand *cm
 static SDL_bool SetCopyState(SDL_Renderer *renderer, const SDL_RenderCommand *cmd, const size_t constants_offset,
                              id<MTLBuffer> mtlbufvertex, METAL_DrawStateCache *statecache)
 {
-    METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->driverdata;
+    METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->internal;
     SDL_Texture *texture = cmd->data.draw.texture;
-    METAL_TextureData *texturedata = (__bridge METAL_TextureData *)texture->driverdata;
+    METAL_TextureData *texturedata = (__bridge METAL_TextureData *)texture->internal;
     PixelShaderConstants constants;
 
     SetupShaderConstants(renderer, cmd, texture, &constants);
@@ -1505,7 +1505,7 @@ static SDL_bool SetCopyState(SDL_Renderer *renderer, const SDL_RenderCommand *cm
     if (texture != statecache->texture) {
         METAL_TextureData *oldtexturedata = NULL;
         if (statecache->texture) {
-            oldtexturedata = (__bridge METAL_TextureData *)statecache->texture->driverdata;
+            oldtexturedata = (__bridge METAL_TextureData *)statecache->texture->internal;
         }
         if (!oldtexturedata || (texturedata.mtlsampler != oldtexturedata.mtlsampler)) {
             [data.mtlcmdencoder setFragmentSamplerState:texturedata.mtlsampler atIndex:0];
@@ -1531,7 +1531,7 @@ static void METAL_InvalidateCachedState(SDL_Renderer *renderer)
 static int METAL_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, void *vertices, size_t vertsize)
 {
     @autoreleasepool {
-        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->driverdata;
+        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->internal;
         id<MTLBuffer> mtlbufvertex = nil;
         METAL_DrawStateCache statecache;
         SDL_zero(statecache);
@@ -1680,7 +1680,7 @@ static int METAL_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd,
 static SDL_Surface *METAL_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rect *rect)
 {
     @autoreleasepool {
-        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->driverdata;
+        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->internal;
         id<MTLTexture> mtltexture;
         MTLRegion mtlregion;
         Uint32 format;
@@ -1745,7 +1745,7 @@ static SDL_Surface *METAL_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rec
 static int METAL_RenderPresent(SDL_Renderer *renderer)
 {
     @autoreleasepool {
-        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->driverdata;
+        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->internal;
         SDL_bool ready = SDL_TRUE;
 
         // If we don't have a command buffer, we can't present, so activate to get one.
@@ -1785,16 +1785,16 @@ static int METAL_RenderPresent(SDL_Renderer *renderer)
 static void METAL_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 {
     @autoreleasepool {
-        CFBridgingRelease(texture->driverdata);
-        texture->driverdata = NULL;
+        CFBridgingRelease(texture->internal);
+        texture->internal = NULL;
     }
 }
 
 static void METAL_DestroyRenderer(SDL_Renderer *renderer)
 {
     @autoreleasepool {
-        if (renderer->driverdata) {
-            METAL_RenderData *data = CFBridgingRelease(renderer->driverdata);
+        if (renderer->internal) {
+            METAL_RenderData *data = CFBridgingRelease(renderer->internal);
 
             if (data.mtlcmdencoder != nil) {
                 [data.mtlcmdencoder endEncoding];
@@ -1814,7 +1814,7 @@ static void METAL_DestroyRenderer(SDL_Renderer *renderer)
 static void *METAL_GetMetalLayer(SDL_Renderer *renderer)
 {
     @autoreleasepool {
-        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->driverdata;
+        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->internal;
         return (__bridge void *)data.mtllayer;
     }
 }
@@ -1827,7 +1827,7 @@ static void *METAL_GetMetalCommandEncoder(SDL_Renderer *renderer)
         //  usable for presentation. Check your return values!
         METAL_RenderData *data;
         METAL_ActivateRenderCommandEncoder(renderer, MTLLoadActionLoad, NULL, nil);
-        data = (__bridge METAL_RenderData *)renderer->driverdata;
+        data = (__bridge METAL_RenderData *)renderer->internal;
         return (__bridge void *)data.mtlcmdencoder;
     }
 }
@@ -1836,7 +1836,7 @@ static int METAL_SetVSync(SDL_Renderer *renderer, const int vsync)
 {
 #if (defined(SDL_PLATFORM_MACOS) && defined(MAC_OS_X_VERSION_10_13)) || TARGET_OS_MACCATALYST
     if (@available(macOS 10.13, *)) {
-        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->driverdata;
+        METAL_RenderData *data = (__bridge METAL_RenderData *)renderer->internal;
         switch (vsync) {
         case 0:
             data.mtllayer.displaySyncEnabled = NO;
@@ -2012,7 +2012,7 @@ static int METAL_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_
             return SDL_SetError("METAL_RenderData alloc/init failed");
         }
 
-        renderer->driverdata = (void *)CFBridgingRetain(data);
+        renderer->internal = (void *)CFBridgingRetain(data);
         METAL_InvalidateCachedState(renderer);
         renderer->window = window;
 

--- a/src/render/opengl/SDL_render_gl.c
+++ b/src/render/opengl/SDL_render_gl.c
@@ -173,7 +173,7 @@ static const char *GL_TranslateError(GLenum error)
 
 static void GL_ClearErrors(SDL_Renderer *renderer)
 {
-    GL_RenderData *data = (GL_RenderData *)renderer->driverdata;
+    GL_RenderData *data = (GL_RenderData *)renderer->internal;
 
     if (!data->debug_enabled) {
         return;
@@ -198,7 +198,7 @@ static void GL_ClearErrors(SDL_Renderer *renderer)
 
 static int GL_CheckAllErrors(const char *prefix, SDL_Renderer *renderer, const char *file, int line, const char *function)
 {
-    GL_RenderData *data = (GL_RenderData *)renderer->driverdata;
+    GL_RenderData *data = (GL_RenderData *)renderer->internal;
     int ret = 0;
 
     if (!data->debug_enabled) {
@@ -259,7 +259,7 @@ static int GL_LoadFunctions(GL_RenderData *data)
 
 static int GL_ActivateRenderer(SDL_Renderer *renderer)
 {
-    GL_RenderData *data = (GL_RenderData *)renderer->driverdata;
+    GL_RenderData *data = (GL_RenderData *)renderer->internal;
 
     if (SDL_GL_GetCurrentContext() != data->context) {
         if (SDL_GL_MakeCurrent(renderer->window, data->context) < 0) {
@@ -275,7 +275,7 @@ static int GL_ActivateRenderer(SDL_Renderer *renderer)
 static void APIENTRY GL_HandleDebugMessage(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const char *message, const void *userParam)
 {
     SDL_Renderer *renderer = (SDL_Renderer *)userParam;
-    GL_RenderData *data = (GL_RenderData *)renderer->driverdata;
+    GL_RenderData *data = (GL_RenderData *)renderer->internal;
 
     if (type == GL_DEBUG_TYPE_ERROR_ARB) {
         /* Record this error */
@@ -329,7 +329,7 @@ static void GL_WindowEvent(SDL_Renderer *renderer, const SDL_WindowEvent *event)
      */
     if (event->type == SDL_EVENT_WINDOW_RESIZED ||
         event->type == SDL_EVENT_WINDOW_MOVED) {
-        GL_RenderData *data = (GL_RenderData *)renderer->driverdata;
+        GL_RenderData *data = (GL_RenderData *)renderer->internal;
         data->drawstate.viewport_dirty = SDL_TRUE;
     }
 }
@@ -441,7 +441,7 @@ static SDL_bool convert_format(Uint32 pixel_format, GLint *internalFormat, GLenu
 
 static int GL_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL_PropertiesID create_props)
 {
-    GL_RenderData *renderdata = (GL_RenderData *)renderer->driverdata;
+    GL_RenderData *renderdata = (GL_RenderData *)renderer->internal;
     const GLenum textype = renderdata->textype;
     GL_TextureData *data;
     GLint internalFormat;
@@ -510,7 +510,7 @@ static int GL_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL_Pr
             return -1;
         }
     }
-    texture->driverdata = data;
+    texture->internal = data;
 
     if (renderdata->GL_ARB_texture_non_power_of_two_supported) {
         texture_w = texture->w;
@@ -692,9 +692,9 @@ static int GL_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL_Pr
 static int GL_UpdateTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                             const SDL_Rect *rect, const void *pixels, int pitch)
 {
-    GL_RenderData *renderdata = (GL_RenderData *)renderer->driverdata;
+    GL_RenderData *renderdata = (GL_RenderData *)renderer->internal;
     const GLenum textype = renderdata->textype;
-    GL_TextureData *data = (GL_TextureData *)texture->driverdata;
+    GL_TextureData *data = (GL_TextureData *)texture->internal;
     const int texturebpp = SDL_BYTESPERPIXEL(texture->format);
 
     SDL_assert_release(texturebpp != 0); /* otherwise, division by zero later. */
@@ -757,9 +757,9 @@ static int GL_UpdateTextureYUV(SDL_Renderer *renderer, SDL_Texture *texture,
                                const Uint8 *Uplane, int Upitch,
                                const Uint8 *Vplane, int Vpitch)
 {
-    GL_RenderData *renderdata = (GL_RenderData *)renderer->driverdata;
+    GL_RenderData *renderdata = (GL_RenderData *)renderer->internal;
     const GLenum textype = renderdata->textype;
-    GL_TextureData *data = (GL_TextureData *)texture->driverdata;
+    GL_TextureData *data = (GL_TextureData *)texture->internal;
 
     GL_ActivateRenderer(renderer);
 
@@ -792,9 +792,9 @@ static int GL_UpdateTextureNV(SDL_Renderer *renderer, SDL_Texture *texture,
                               const Uint8 *Yplane, int Ypitch,
                               const Uint8 *UVplane, int UVpitch)
 {
-    GL_RenderData *renderdata = (GL_RenderData *)renderer->driverdata;
+    GL_RenderData *renderdata = (GL_RenderData *)renderer->internal;
     const GLenum textype = renderdata->textype;
-    GL_TextureData *data = (GL_TextureData *)texture->driverdata;
+    GL_TextureData *data = (GL_TextureData *)texture->internal;
 
     GL_ActivateRenderer(renderer);
 
@@ -820,7 +820,7 @@ static int GL_UpdateTextureNV(SDL_Renderer *renderer, SDL_Texture *texture,
 static int GL_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                           const SDL_Rect *rect, void **pixels, int *pitch)
 {
-    GL_TextureData *data = (GL_TextureData *)texture->driverdata;
+    GL_TextureData *data = (GL_TextureData *)texture->internal;
 
     data->locked_rect = *rect;
     *pixels =
@@ -832,7 +832,7 @@ static int GL_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
 
 static void GL_UnlockTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    GL_TextureData *data = (GL_TextureData *)texture->driverdata;
+    GL_TextureData *data = (GL_TextureData *)texture->internal;
     const SDL_Rect *rect;
     void *pixels;
 
@@ -845,9 +845,9 @@ static void GL_UnlockTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 
 static void GL_SetTextureScaleMode(SDL_Renderer *renderer, SDL_Texture *texture, SDL_ScaleMode scaleMode)
 {
-    GL_RenderData *renderdata = (GL_RenderData *)renderer->driverdata;
+    GL_RenderData *renderdata = (GL_RenderData *)renderer->internal;
     const GLenum textype = renderdata->textype;
-    GL_TextureData *data = (GL_TextureData *)texture->driverdata;
+    GL_TextureData *data = (GL_TextureData *)texture->internal;
     GLenum glScaleMode = (scaleMode == SDL_SCALEMODE_NEAREST) ? GL_NEAREST : GL_LINEAR;
 
     renderdata->glBindTexture(textype, data->texture);
@@ -877,7 +877,7 @@ static void GL_SetTextureScaleMode(SDL_Renderer *renderer, SDL_Texture *texture,
 
 static int GL_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    GL_RenderData *data = (GL_RenderData *)renderer->driverdata;
+    GL_RenderData *data = (GL_RenderData *)renderer->internal;
     GL_TextureData *texturedata;
     GLenum status;
 
@@ -894,7 +894,7 @@ static int GL_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
         return 0;
     }
 
-    texturedata = (GL_TextureData *)texture->driverdata;
+    texturedata = (GL_TextureData *)texture->internal;
     data->glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, texturedata->fbo->FBO);
     /* TODO: check if texture pixel format allows this operation */
     data->glFramebufferTexture2DEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, data->textype, texturedata->texture, 0);
@@ -990,7 +990,7 @@ static int GL_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL_
     }
 
     if (texture) {
-        texturedata = (GL_TextureData *)texture->driverdata;
+        texturedata = (GL_TextureData *)texture->internal;
     }
 
     cmd->data.draw.count = count;
@@ -1144,7 +1144,7 @@ static int SetDrawState(GL_RenderData *data, const SDL_RenderCommand *cmd, const
 static int SetCopyState(GL_RenderData *data, const SDL_RenderCommand *cmd)
 {
     SDL_Texture *texture = cmd->data.draw.texture;
-    const GL_TextureData *texturedata = (GL_TextureData *)texture->driverdata;
+    const GL_TextureData *texturedata = (GL_TextureData *)texture->internal;
 
     SetDrawState(data, cmd, texturedata->shader, texturedata->shader_params);
 
@@ -1182,7 +1182,7 @@ static int SetCopyState(GL_RenderData *data, const SDL_RenderCommand *cmd)
 
 static void GL_InvalidateCachedState(SDL_Renderer *renderer)
 {
-    GL_DrawStateCache *cache = &((GL_RenderData *)renderer->driverdata)->drawstate;
+    GL_DrawStateCache *cache = &((GL_RenderData *)renderer->internal)->drawstate;
     cache->viewport_dirty = SDL_TRUE;
     cache->texture = NULL;
     cache->drawablew = 0;
@@ -1202,7 +1202,7 @@ static void GL_InvalidateCachedState(SDL_Renderer *renderer)
 static int GL_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, void *vertices, size_t vertsize)
 {
     /* !!! FIXME: it'd be nice to use a vertex buffer instead of immediate mode... */
-    GL_RenderData *data = (GL_RenderData *)renderer->driverdata;
+    GL_RenderData *data = (GL_RenderData *)renderer->internal;
 
     if (GL_ActivateRenderer(renderer) < 0) {
         return -1;
@@ -1449,7 +1449,7 @@ static int GL_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, vo
 
 static SDL_Surface *GL_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rect *rect)
 {
-    GL_RenderData *data = (GL_RenderData *)renderer->driverdata;
+    GL_RenderData *data = (GL_RenderData *)renderer->internal;
     SDL_PixelFormat format = renderer->target ? renderer->target->format : SDL_PIXELFORMAT_ARGB8888;
     GLint internalFormat;
     GLenum targetFormat, type;
@@ -1510,8 +1510,8 @@ static int GL_RenderPresent(SDL_Renderer *renderer)
 
 static void GL_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    GL_RenderData *renderdata = (GL_RenderData *)renderer->driverdata;
-    GL_TextureData *data = (GL_TextureData *)texture->driverdata;
+    GL_RenderData *renderdata = (GL_RenderData *)renderer->internal;
+    GL_TextureData *data = (GL_TextureData *)texture->internal;
 
     GL_ActivateRenderer(renderer);
 
@@ -1545,12 +1545,12 @@ static void GL_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 #endif
     SDL_free(data->pixels);
     SDL_free(data);
-    texture->driverdata = NULL;
+    texture->internal = NULL;
 }
 
 static void GL_DestroyRenderer(SDL_Renderer *renderer)
 {
-    GL_RenderData *data = (GL_RenderData *)renderer->driverdata;
+    GL_RenderData *data = (GL_RenderData *)renderer->internal;
 
     if (data) {
         if (data->context) {
@@ -1671,7 +1671,7 @@ static int GL_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_Pro
     renderer->DestroyTexture = GL_DestroyTexture;
     renderer->DestroyRenderer = GL_DestroyRenderer;
     renderer->SetVSync = GL_SetVSync;
-    renderer->driverdata = data;
+    renderer->internal = data;
     GL_InvalidateCachedState(renderer);
     renderer->window = window;
 

--- a/src/render/opengles2/SDL_render_gles2.c
+++ b/src/render/opengles2/SDL_render_gles2.c
@@ -213,7 +213,7 @@ static const char *GL_TranslateError(GLenum error)
 
 static void GL_ClearErrors(SDL_Renderer *renderer)
 {
-    GLES2_RenderData *data = (GLES2_RenderData *)renderer->driverdata;
+    GLES2_RenderData *data = (GLES2_RenderData *)renderer->internal;
 
     if (!data->debug_enabled) {
         return;
@@ -225,7 +225,7 @@ static void GL_ClearErrors(SDL_Renderer *renderer)
 
 static int GL_CheckAllErrors(const char *prefix, SDL_Renderer *renderer, const char *file, int line, const char *function)
 {
-    GLES2_RenderData *data = (GLES2_RenderData *)renderer->driverdata;
+    GLES2_RenderData *data = (GLES2_RenderData *)renderer->internal;
     int ret = 0;
 
     if (!data->debug_enabled) {
@@ -301,7 +301,7 @@ static GLES2_FBOList *GLES2_GetFBO(GLES2_RenderData *data, Uint32 w, Uint32 h)
 
 static int GLES2_ActivateRenderer(SDL_Renderer *renderer)
 {
-    GLES2_RenderData *data = (GLES2_RenderData *)renderer->driverdata;
+    GLES2_RenderData *data = (GLES2_RenderData *)renderer->internal;
 
     if (SDL_GL_GetCurrentContext() != data->context) {
         /* Null out the current program to ensure we set it again */
@@ -319,7 +319,7 @@ static int GLES2_ActivateRenderer(SDL_Renderer *renderer)
 
 static void GLES2_WindowEvent(SDL_Renderer *renderer, const SDL_WindowEvent *event)
 {
-    GLES2_RenderData *data = (GLES2_RenderData *)renderer->driverdata;
+    GLES2_RenderData *data = (GLES2_RenderData *)renderer->internal;
 
     if (event->type == SDL_EVENT_WINDOW_MINIMIZED) {
         /* According to Apple documentation, we need to finish drawing NOW! */
@@ -375,7 +375,7 @@ static GLenum GetBlendEquation(SDL_BlendOperation operation)
 
 static SDL_bool GLES2_SupportsBlendMode(SDL_Renderer *renderer, SDL_BlendMode blendMode)
 {
-    GLES2_RenderData *data = (GLES2_RenderData *)renderer->driverdata;
+    GLES2_RenderData *data = (GLES2_RenderData *)renderer->internal;
 
     SDL_BlendFactor srcColorFactor = SDL_GetBlendModeSrcColorFactor(blendMode);
     SDL_BlendFactor srcAlphaFactor = SDL_GetBlendModeSrcAlphaFactor(blendMode);
@@ -1032,7 +1032,7 @@ static int SetDrawState(GLES2_RenderData *data, const SDL_RenderCommand *cmd, co
 
 static int SetCopyState(SDL_Renderer *renderer, const SDL_RenderCommand *cmd, void *vertices)
 {
-    GLES2_RenderData *data = (GLES2_RenderData *)renderer->driverdata;
+    GLES2_RenderData *data = (GLES2_RenderData *)renderer->internal;
     GLES2_ImageSource sourceType = GLES2_IMAGESOURCE_TEXTURE_ABGR;
     SDL_Texture *texture = cmd->data.draw.texture;
     int ret;
@@ -1156,7 +1156,7 @@ static int SetCopyState(SDL_Renderer *renderer, const SDL_RenderCommand *cmd, vo
     ret = SetDrawState(data, cmd, sourceType, vertices);
 
     if (texture != data->drawstate.texture) {
-        GLES2_TextureData *tdata = (GLES2_TextureData *)texture->driverdata;
+        GLES2_TextureData *tdata = (GLES2_TextureData *)texture->internal;
 #if SDL_HAVE_YUV
         if (tdata->yuv) {
             data->glActiveTexture(GL_TEXTURE2);
@@ -1182,7 +1182,7 @@ static int SetCopyState(SDL_Renderer *renderer, const SDL_RenderCommand *cmd, vo
 
 static void GLES2_InvalidateCachedState(SDL_Renderer *renderer)
 {
-    GLES2_DrawStateCache *cache = &((GLES2_RenderData *)renderer->driverdata)->drawstate;
+    GLES2_DrawStateCache *cache = &((GLES2_RenderData *)renderer->internal)->drawstate;
     cache->viewport_dirty = SDL_TRUE;
     cache->texture = NULL;
     cache->blend = SDL_BLENDMODE_INVALID;
@@ -1197,7 +1197,7 @@ static void GLES2_InvalidateCachedState(SDL_Renderer *renderer)
 
 static int GLES2_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, void *vertices, size_t vertsize)
 {
-    GLES2_RenderData *data = (GLES2_RenderData *)renderer->driverdata;
+    GLES2_RenderData *data = (GLES2_RenderData *)renderer->internal;
     const SDL_bool colorswap = (renderer->target && (renderer->target->format == SDL_PIXELFORMAT_BGRA32 || renderer->target->format == SDL_PIXELFORMAT_BGRX32));
 
 #if USE_VERTEX_BUFFER_OBJECTS
@@ -1399,7 +1399,7 @@ static int GLES2_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd,
 
 static void GLES2_DestroyRenderer(SDL_Renderer *renderer)
 {
-    GLES2_RenderData *data = (GLES2_RenderData *)renderer->driverdata;
+    GLES2_RenderData *data = (GLES2_RenderData *)renderer->internal;
 
     /* Deallocate everything */
     if (data) {
@@ -1449,7 +1449,7 @@ static void GLES2_DestroyRenderer(SDL_Renderer *renderer)
 
 static int GLES2_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL_PropertiesID create_props)
 {
-    GLES2_RenderData *renderdata = (GLES2_RenderData *)renderer->driverdata;
+    GLES2_RenderData *renderdata = (GLES2_RenderData *)renderer->internal;
     GLES2_TextureData *data;
     GLenum format;
     GLenum type;
@@ -1618,7 +1618,7 @@ static int GLES2_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL
             return -1;
         }
     }
-    texture->driverdata = data;
+    texture->internal = data;
     renderdata->glActiveTexture(GL_TEXTURE0);
     renderdata->glBindTexture(data->texture_type, data->texture);
     renderdata->glTexParameteri(data->texture_type, GL_TEXTURE_MIN_FILTER, scaleMode);
@@ -1635,7 +1635,7 @@ static int GLES2_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL
     SDL_SetNumberProperty(SDL_GetTextureProperties(texture), SDL_PROP_TEXTURE_OPENGLES2_TEXTURE_TARGET_NUMBER, data->texture_type);
 
     if (texture->access == SDL_TEXTUREACCESS_TARGET) {
-        data->fbo = GLES2_GetFBO((GLES2_RenderData *)renderer->driverdata, texture->w, texture->h);
+        data->fbo = GLES2_GetFBO((GLES2_RenderData *)renderer->internal, texture->w, texture->h);
     } else {
         data->fbo = NULL;
     }
@@ -1681,8 +1681,8 @@ static int GLES2_TexSubImage2D(GLES2_RenderData *data, GLenum target, GLint xoff
 static int GLES2_UpdateTexture(SDL_Renderer *renderer, SDL_Texture *texture, const SDL_Rect *rect,
                                const void *pixels, int pitch)
 {
-    GLES2_RenderData *data = (GLES2_RenderData *)renderer->driverdata;
-    GLES2_TextureData *tdata = (GLES2_TextureData *)texture->driverdata;
+    GLES2_RenderData *data = (GLES2_RenderData *)renderer->internal;
+    GLES2_TextureData *tdata = (GLES2_TextureData *)texture->internal;
 
     GLES2_ActivateRenderer(renderer);
 
@@ -1762,8 +1762,8 @@ static int GLES2_UpdateTextureYUV(SDL_Renderer *renderer, SDL_Texture *texture,
                                   const Uint8 *Uplane, int Upitch,
                                   const Uint8 *Vplane, int Vpitch)
 {
-    GLES2_RenderData *data = (GLES2_RenderData *)renderer->driverdata;
-    GLES2_TextureData *tdata = (GLES2_TextureData *)texture->driverdata;
+    GLES2_RenderData *data = (GLES2_RenderData *)renderer->internal;
+    GLES2_TextureData *tdata = (GLES2_TextureData *)texture->internal;
 
     GLES2_ActivateRenderer(renderer);
 
@@ -1812,8 +1812,8 @@ static int GLES2_UpdateTextureNV(SDL_Renderer *renderer, SDL_Texture *texture,
                                  const Uint8 *Yplane, int Ypitch,
                                  const Uint8 *UVplane, int UVpitch)
 {
-    GLES2_RenderData *data = (GLES2_RenderData *)renderer->driverdata;
-    GLES2_TextureData *tdata = (GLES2_TextureData *)texture->driverdata;
+    GLES2_RenderData *data = (GLES2_RenderData *)renderer->internal;
+    GLES2_TextureData *tdata = (GLES2_TextureData *)texture->internal;
 
     GLES2_ActivateRenderer(renderer);
 
@@ -1851,7 +1851,7 @@ static int GLES2_UpdateTextureNV(SDL_Renderer *renderer, SDL_Texture *texture,
 static int GLES2_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture, const SDL_Rect *rect,
                              void **pixels, int *pitch)
 {
-    GLES2_TextureData *tdata = (GLES2_TextureData *)texture->driverdata;
+    GLES2_TextureData *tdata = (GLES2_TextureData *)texture->internal;
 
     /* Retrieve the buffer/pitch for the specified region */
     *pixels = (Uint8 *)tdata->pixel_data +
@@ -1864,7 +1864,7 @@ static int GLES2_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture, const
 
 static void GLES2_UnlockTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    GLES2_TextureData *tdata = (GLES2_TextureData *)texture->driverdata;
+    GLES2_TextureData *tdata = (GLES2_TextureData *)texture->internal;
     SDL_Rect rect;
 
     /* We do whole texture updates, at least for now */
@@ -1877,8 +1877,8 @@ static void GLES2_UnlockTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 
 static void GLES2_SetTextureScaleMode(SDL_Renderer *renderer, SDL_Texture *texture, SDL_ScaleMode scaleMode)
 {
-    GLES2_RenderData *renderdata = (GLES2_RenderData *)renderer->driverdata;
-    GLES2_TextureData *data = (GLES2_TextureData *)texture->driverdata;
+    GLES2_RenderData *renderdata = (GLES2_RenderData *)renderer->internal;
+    GLES2_TextureData *data = (GLES2_TextureData *)texture->internal;
     GLenum glScaleMode = (scaleMode == SDL_SCALEMODE_NEAREST) ? GL_NEAREST : GL_LINEAR;
 
 #if SDL_HAVE_YUV
@@ -1908,7 +1908,7 @@ static void GLES2_SetTextureScaleMode(SDL_Renderer *renderer, SDL_Texture *textu
 
 static int GLES2_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    GLES2_RenderData *data = (GLES2_RenderData *)renderer->driverdata;
+    GLES2_RenderData *data = (GLES2_RenderData *)renderer->internal;
     GLES2_TextureData *texturedata = NULL;
     GLenum status;
 
@@ -1917,7 +1917,7 @@ static int GLES2_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
     if (!texture) {
         data->glBindFramebuffer(GL_FRAMEBUFFER, data->window_framebuffer);
     } else {
-        texturedata = (GLES2_TextureData *)texture->driverdata;
+        texturedata = (GLES2_TextureData *)texture->internal;
         data->glBindFramebuffer(GL_FRAMEBUFFER, texturedata->fbo->FBO);
         /* TODO: check if texture pixel format allows this operation */
         data->glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, texturedata->texture_type, texturedata->texture, 0);
@@ -1932,8 +1932,8 @@ static int GLES2_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
 
 static void GLES2_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    GLES2_RenderData *data = (GLES2_RenderData *)renderer->driverdata;
-    GLES2_TextureData *tdata = (GLES2_TextureData *)texture->driverdata;
+    GLES2_RenderData *data = (GLES2_RenderData *)renderer->internal;
+    GLES2_TextureData *tdata = (GLES2_TextureData *)texture->internal;
 
     GLES2_ActivateRenderer(renderer);
 
@@ -1959,13 +1959,13 @@ static void GLES2_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 #endif
         SDL_free(tdata->pixel_data);
         SDL_free(tdata);
-        texture->driverdata = NULL;
+        texture->internal = NULL;
     }
 }
 
 static SDL_Surface *GLES2_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rect *rect)
 {
-    GLES2_RenderData *data = (GLES2_RenderData *)renderer->driverdata;
+    GLES2_RenderData *data = (GLES2_RenderData *)renderer->internal;
     SDL_PixelFormat format = renderer->target ? renderer->target->format : SDL_PIXELFORMAT_RGBA32;
     int w, h;
     SDL_Surface *surface;
@@ -2091,7 +2091,7 @@ static int GLES2_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_
     if (!data) {
         goto error;
     }
-    renderer->driverdata = data;
+    renderer->internal = data;
     GLES2_InvalidateCachedState(renderer);
     renderer->window = window;
 

--- a/src/render/ps2/SDL_render_ps2.c
+++ b/src/render/ps2/SDL_render_ps2.c
@@ -145,7 +145,7 @@ static int PS2_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL_P
         return -1;
     }
 
-    texture->driverdata = ps2_tex;
+    texture->internal = ps2_tex;
 
     return 0;
 }
@@ -153,7 +153,7 @@ static int PS2_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL_P
 static int PS2_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                            const SDL_Rect *rect, void **pixels, int *pitch)
 {
-    GSTEXTURE *ps2_texture = (GSTEXTURE *)texture->driverdata;
+    GSTEXTURE *ps2_texture = (GSTEXTURE *)texture->internal;
 
     *pixels =
         (void *)((Uint8 *)ps2_texture->Mem + rect->y * ps2_texture->Width * SDL_BYTESPERPIXEL(texture->format) +
@@ -164,8 +164,8 @@ static int PS2_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
 
 static void PS2_UnlockTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    GSTEXTURE *ps2_texture = (GSTEXTURE *)texture->driverdata;
-    PS2_RenderData *data = (PS2_RenderData *)renderer->driverdata;
+    GSTEXTURE *ps2_texture = (GSTEXTURE *)texture->internal;
+    PS2_RenderData *data = (PS2_RenderData *)renderer->internal;
 
     gsKit_TexManager_invalidate(data->gsGlobal, ps2_texture);
 }
@@ -197,7 +197,7 @@ static int PS2_UpdateTexture(SDL_Renderer *renderer, SDL_Texture *texture,
 
 static void PS2_SetTextureScaleMode(SDL_Renderer *renderer, SDL_Texture *texture, SDL_ScaleMode scaleMode)
 {
-    GSTEXTURE *ps2_texture = (GSTEXTURE *)texture->driverdata;
+    GSTEXTURE *ps2_texture = (GSTEXTURE *)texture->internal;
     /*
      set texture filtering according to scaleMode
      supported hint values are nearest (0, default) or linear (1)
@@ -217,7 +217,7 @@ static int PS2_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
 
 static int PS2_QueueSetViewport(SDL_Renderer *renderer, SDL_RenderCommand *cmd)
 {
-    PS2_RenderData *data = (PS2_RenderData *)renderer->driverdata;
+    PS2_RenderData *data = (PS2_RenderData *)renderer->internal;
     const SDL_Rect *viewport = &cmd->data.viewport.rect;
     data->viewport = (SDL_Rect *)viewport;
 
@@ -235,7 +235,7 @@ static int PS2_QueueNoOp(SDL_Renderer *renderer, SDL_RenderCommand *cmd)
 
 static int PS2_QueueDrawPoints(SDL_Renderer *renderer, SDL_RenderCommand *cmd, const SDL_FPoint *points, int count)
 {
-    PS2_RenderData *data = (PS2_RenderData *)renderer->driverdata;
+    PS2_RenderData *data = (PS2_RenderData *)renderer->internal;
     GSPRIMPOINT *vertices = (GSPRIMPOINT *)SDL_AllocateRenderVertices(renderer, count * sizeof(GSPRIMPOINT), 4, &cmd->data.draw.first);
     gs_rgbaq rgbaq;
     int i;
@@ -262,7 +262,7 @@ static int PS2_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL
 {
     int i;
     int count = indices ? num_indices : num_vertices;
-    PS2_RenderData *data = (PS2_RenderData *)renderer->driverdata;
+    PS2_RenderData *data = (PS2_RenderData *)renderer->internal;
     const float color_scale = cmd->data.draw.color_scale;
 
     cmd->data.draw.count = count;
@@ -270,7 +270,7 @@ static int PS2_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL
 
     if (texture) {
         GSPRIMUVPOINT *vertices = (GSPRIMUVPOINT *) SDL_AllocateRenderVertices(renderer, count * sizeof(GSPRIMUVPOINT), 4, &cmd->data.draw.first);
-        GSTEXTURE *ps2_tex = (GSTEXTURE *) texture->driverdata;
+        GSTEXTURE *ps2_tex = (GSTEXTURE *) texture->internal;
 
         if (!vertices) {
             return -1;
@@ -343,7 +343,7 @@ static int PS2_RenderSetViewPort(SDL_Renderer *renderer, SDL_RenderCommand *cmd)
 
 static int PS2_RenderSetClipRect(SDL_Renderer *renderer, SDL_RenderCommand *cmd)
 {
-    PS2_RenderData *data = (PS2_RenderData *)renderer->driverdata;
+    PS2_RenderData *data = (PS2_RenderData *)renderer->internal;
     SDL_Rect *viewport = data->viewport;
 
     const SDL_Rect *rect = &cmd->data.cliprect.rect;
@@ -362,7 +362,7 @@ static int PS2_RenderSetClipRect(SDL_Renderer *renderer, SDL_RenderCommand *cmd)
 
 static int PS2_RenderSetDrawColor(SDL_Renderer *renderer, SDL_RenderCommand *cmd)
 {
-    PS2_RenderData *data = (PS2_RenderData *)renderer->driverdata;
+    PS2_RenderData *data = (PS2_RenderData *)renderer->internal;
 
     data->drawColor = float_GS_SETREG_RGBAQ(&cmd->data.color.color, cmd->data.color.color_scale);
     return 0;
@@ -373,7 +373,7 @@ static int PS2_RenderClear(SDL_Renderer *renderer, SDL_RenderCommand *cmd)
     int offsetX, offsetY;
     SDL_Rect *viewport;
 
-    PS2_RenderData *data = (PS2_RenderData *)renderer->driverdata;
+    PS2_RenderData *data = (PS2_RenderData *)renderer->internal;
 
     /* Clear the screen, so let's put default viewport */
     gsKit_set_scissor(data->gsGlobal, GS_SCISSOR_RESET);
@@ -449,14 +449,14 @@ static void PS2_SetBlendMode(PS2_RenderData *data, int blendMode)
 
 static int PS2_RenderGeometry(SDL_Renderer *renderer, void *vertices, SDL_RenderCommand *cmd)
 {
-    PS2_RenderData *data = (PS2_RenderData *)renderer->driverdata;
+    PS2_RenderData *data = (PS2_RenderData *)renderer->internal;
     const size_t count = cmd->data.draw.count;
 
     PS2_SetBlendMode(data, cmd->data.draw.blend);
 
     if (cmd->data.draw.texture) {
         const GSPRIMUVPOINT *verts = (GSPRIMUVPOINT *) (vertices + cmd->data.draw.first);
-        GSTEXTURE *ps2_tex = (GSTEXTURE *)cmd->data.draw.texture->driverdata;
+        GSTEXTURE *ps2_tex = (GSTEXTURE *)cmd->data.draw.texture->internal;
 
         gsKit_TexManager_bind(data->gsGlobal, ps2_tex);
         gsKit_prim_list_triangle_goraud_texture_uv_3d(data->gsGlobal, ps2_tex, count, verts);
@@ -470,7 +470,7 @@ static int PS2_RenderGeometry(SDL_Renderer *renderer, void *vertices, SDL_Render
 
 int PS2_RenderLines(SDL_Renderer *renderer, void *vertices, SDL_RenderCommand *cmd)
 {
-    PS2_RenderData *data = (PS2_RenderData *)renderer->driverdata;
+    PS2_RenderData *data = (PS2_RenderData *)renderer->internal;
     const size_t count = cmd->data.draw.count;
     const GSPRIMPOINT *verts = (GSPRIMPOINT *)(vertices + cmd->data.draw.first);
 
@@ -483,7 +483,7 @@ int PS2_RenderLines(SDL_Renderer *renderer, void *vertices, SDL_RenderCommand *c
 
 int PS2_RenderPoints(SDL_Renderer *renderer, void *vertices, SDL_RenderCommand *cmd)
 {
-    PS2_RenderData *data = (PS2_RenderData *)renderer->driverdata;
+    PS2_RenderData *data = (PS2_RenderData *)renderer->internal;
     const size_t count = cmd->data.draw.count;
     const GSPRIMPOINT *verts = (GSPRIMPOINT *)(vertices + cmd->data.draw.first);
 
@@ -555,7 +555,7 @@ static int PS2_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, v
 
 static int PS2_RenderPresent(SDL_Renderer *renderer)
 {
-    PS2_RenderData *data = (PS2_RenderData *)renderer->driverdata;
+    PS2_RenderData *data = (PS2_RenderData *)renderer->internal;
 
     if (data->gsGlobal->DoubleBuffering == GS_SETTING_OFF) {
         if (data->vsync == -1) { // Dynamic
@@ -581,8 +581,8 @@ static int PS2_RenderPresent(SDL_Renderer *renderer)
 
 static void PS2_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    GSTEXTURE *ps2_texture = (GSTEXTURE *)texture->driverdata;
-    PS2_RenderData *data = (PS2_RenderData *)renderer->driverdata;
+    GSTEXTURE *ps2_texture = (GSTEXTURE *)texture->internal;
+    PS2_RenderData *data = (PS2_RenderData *)renderer->internal;
 
     if (!data) {
         return;
@@ -597,12 +597,12 @@ static void PS2_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 
     SDL_aligned_free(ps2_texture->Mem);
     SDL_free(ps2_texture);
-    texture->driverdata = NULL;
+    texture->internal = NULL;
 }
 
 static void PS2_DestroyRenderer(SDL_Renderer *renderer)
 {
-    PS2_RenderData *data = (PS2_RenderData *)renderer->driverdata;
+    PS2_RenderData *data = (PS2_RenderData *)renderer->internal;
 
     if (data) {
         gsKit_clear(data->gsGlobal, GS_BLACK);
@@ -620,7 +620,7 @@ static void PS2_DestroyRenderer(SDL_Renderer *renderer)
 
 static int PS2_SetVSync(SDL_Renderer *renderer, const int vsync)
 {
-    PS2_RenderData *data = (PS2_RenderData *)renderer->driverdata;
+    PS2_RenderData *data = (PS2_RenderData *)renderer->internal;
     switch (vsync) {
     case -1:
     case 0:
@@ -709,7 +709,7 @@ static int PS2_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_Pr
     renderer->DestroyTexture = PS2_DestroyTexture;
     renderer->DestroyRenderer = PS2_DestroyRenderer;
     renderer->SetVSync = PS2_SetVSync;
-    renderer->driverdata = data;
+    renderer->internal = data;
     PS2_InvalidateCachedState(renderer);
     renderer->window = window;
 

--- a/src/render/software/SDL_render_sw.c
+++ b/src/render/software/SDL_render_sw.c
@@ -53,7 +53,7 @@ typedef struct
 
 static SDL_Surface *SW_ActivateRenderer(SDL_Renderer *renderer)
 {
-    SW_RenderData *data = (SW_RenderData *)renderer->driverdata;
+    SW_RenderData *data = (SW_RenderData *)renderer->internal;
 
     if (!data->surface) {
         data->surface = data->window;
@@ -69,7 +69,7 @@ static SDL_Surface *SW_ActivateRenderer(SDL_Renderer *renderer)
 
 static void SW_WindowEvent(SDL_Renderer *renderer, const SDL_WindowEvent *event)
 {
-    SW_RenderData *data = (SW_RenderData *)renderer->driverdata;
+    SW_RenderData *data = (SW_RenderData *)renderer->internal;
 
     if (event->type == SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED) {
         data->surface = NULL;
@@ -79,7 +79,7 @@ static void SW_WindowEvent(SDL_Renderer *renderer, const SDL_WindowEvent *event)
 
 static int SW_GetOutputSize(SDL_Renderer *renderer, int *w, int *h)
 {
-    SW_RenderData *data = (SW_RenderData *)renderer->driverdata;
+    SW_RenderData *data = (SW_RenderData *)renderer->internal;
 
     if (data->surface) {
         if (w) {
@@ -107,7 +107,7 @@ static int SW_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL_Pr
     if (!SDL_SurfaceValid(surface)) {
         return SDL_SetError("Cannot create surface");
     }
-    texture->driverdata = surface;
+    texture->internal = surface;
     r = (Uint8)SDL_roundf(SDL_clamp(texture->color.r, 0.0f, 1.0f) * 255.0f);
     g = (Uint8)SDL_roundf(SDL_clamp(texture->color.g, 0.0f, 1.0f) * 255.0f);
     b = (Uint8)SDL_roundf(SDL_clamp(texture->color.b, 0.0f, 1.0f) * 255.0f);
@@ -129,7 +129,7 @@ static int SW_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL_Pr
 static int SW_UpdateTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                             const SDL_Rect *rect, const void *pixels, int pitch)
 {
-    SDL_Surface *surface = (SDL_Surface *)texture->driverdata;
+    SDL_Surface *surface = (SDL_Surface *)texture->internal;
     Uint8 *src, *dst;
     int row;
     size_t length;
@@ -156,7 +156,7 @@ static int SW_UpdateTexture(SDL_Renderer *renderer, SDL_Texture *texture,
 static int SW_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                           const SDL_Rect *rect, void **pixels, int *pitch)
 {
-    SDL_Surface *surface = (SDL_Surface *)texture->driverdata;
+    SDL_Surface *surface = (SDL_Surface *)texture->internal;
 
     *pixels =
         (void *)((Uint8 *)surface->pixels + rect->y * surface->pitch +
@@ -175,10 +175,10 @@ static void SW_SetTextureScaleMode(SDL_Renderer *renderer, SDL_Texture *texture,
 
 static int SW_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    SW_RenderData *data = (SW_RenderData *)renderer->driverdata;
+    SW_RenderData *data = (SW_RenderData *)renderer->internal;
 
     if (texture) {
-        data->surface = (SDL_Surface *)texture->driverdata;
+        data->surface = (SDL_Surface *)texture->internal;
     } else {
         data->surface = data->window;
     }
@@ -317,7 +317,7 @@ static int SW_RenderCopyEx(SDL_Renderer *renderer, SDL_Surface *surface, SDL_Tex
                            const SDL_Rect *srcrect, const SDL_Rect *final_rect,
                            const double angle, const SDL_FPoint *center, const SDL_FlipMode flip, float scale_x, float scale_y)
 {
-    SDL_Surface *src = (SDL_Surface *)texture->driverdata;
+    SDL_Surface *src = (SDL_Surface *)texture->internal;
     SDL_Rect tmp_rect;
     SDL_Surface *src_clone, *src_rotated, *src_scaled;
     SDL_Surface *mask = NULL, *mask_rotated = NULL;
@@ -624,7 +624,7 @@ static void PrepTextureForCopy(const SDL_RenderCommand *cmd, SW_DrawStateCache *
     const Uint8 a = drawstate->color.a;
     const SDL_BlendMode blend = cmd->data.draw.blend;
     SDL_Texture *texture = cmd->data.draw.texture;
-    SDL_Surface *surface = (SDL_Surface *)texture->driverdata;
+    SDL_Surface *surface = (SDL_Surface *)texture->internal;
     const SDL_bool colormod = ((r & g & b) != 0xFF);
     const SDL_bool alphamod = (a != 0xFF);
     const SDL_bool blending = ((blend == SDL_BLENDMODE_ADD) || (blend == SDL_BLENDMODE_MOD) || (blend == SDL_BLENDMODE_MUL));
@@ -812,7 +812,7 @@ static int SW_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, vo
             const SDL_Rect *srcrect = verts;
             SDL_Rect *dstrect = verts + 1;
             SDL_Texture *texture = cmd->data.draw.texture;
-            SDL_Surface *src = (SDL_Surface *)texture->driverdata;
+            SDL_Surface *src = (SDL_Surface *)texture->internal;
 
             SetDrawState(surface, &drawstate);
 
@@ -900,7 +900,7 @@ static int SW_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, vo
             SetDrawState(surface, &drawstate);
 
             if (texture) {
-                SDL_Surface *src = (SDL_Surface *)texture->driverdata;
+                SDL_Surface *src = (SDL_Surface *)texture->internal;
 
                 GeometryCopyData *ptr = (GeometryCopyData *)verts;
 
@@ -996,7 +996,7 @@ static int SW_RenderPresent(SDL_Renderer *renderer)
 
 static void SW_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    SDL_Surface *surface = (SDL_Surface *)texture->driverdata;
+    SDL_Surface *surface = (SDL_Surface *)texture->internal;
 
     SDL_DestroySurface(surface);
 }
@@ -1004,7 +1004,7 @@ static void SW_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 static void SW_DestroyRenderer(SDL_Renderer *renderer)
 {
     SDL_Window *window = renderer->window;
-    SW_RenderData *data = (SW_RenderData *)renderer->driverdata;
+    SW_RenderData *data = (SW_RenderData *)renderer->internal;
 
     if (window) {
         SDL_DestroyWindowSurface(window);
@@ -1147,7 +1147,7 @@ int SW_CreateRendererForSurface(SDL_Renderer *renderer, SDL_Surface *surface, SD
     renderer->RenderPresent = SW_RenderPresent;
     renderer->DestroyTexture = SW_DestroyTexture;
     renderer->DestroyRenderer = SW_DestroyRenderer;
-    renderer->driverdata = data;
+    renderer->internal = data;
     SW_InvalidateCachedState(renderer);
 
     renderer->name = SW_RenderDriver.name;

--- a/src/render/vitagxm/SDL_render_vita_gxm.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm.c
@@ -134,7 +134,7 @@ static int PixelFormatToVITAFMT(Uint32 format)
 
 void StartDrawing(SDL_Renderer *renderer)
 {
-    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->driverdata;
+    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->internal;
     if (data->drawing) {
         return;
     }
@@ -162,7 +162,7 @@ void StartDrawing(SDL_Renderer *renderer)
             &data->displaySurface[data->backBufferIndex],
             &data->depthSurface);
     } else {
-        VITA_GXM_TextureData *vita_texture = (VITA_GXM_TextureData *)renderer->target->driverdata;
+        VITA_GXM_TextureData *vita_texture = (VITA_GXM_TextureData *)renderer->target->internal;
 
         sceGxmBeginScene(
             data->gxm_context,
@@ -182,7 +182,7 @@ void StartDrawing(SDL_Renderer *renderer)
 
 static int VITA_GXM_SetVSync(SDL_Renderer *renderer, const int vsync)
 {
-    VITA_GXM_RenderData *data = renderer->driverdata;
+    VITA_GXM_RenderData *data = renderer->internal;
     if (vsync) {
         data->displayData.wait_vblank = SDL_TRUE;
     } else {
@@ -231,7 +231,7 @@ static int VITA_GXM_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, S
     renderer->DestroyRenderer = VITA_GXM_DestroyRenderer;
     renderer->SetVSync = VITA_GXM_SetVSync;
 
-    renderer->driverdata = data;
+    renderer->internal = data;
     VITA_GXM_InvalidateCachedState(renderer);
     renderer->window = window;
 
@@ -273,7 +273,7 @@ static SDL_bool VITA_GXM_SupportsBlendMode(SDL_Renderer *renderer, SDL_BlendMode
 
 static int VITA_GXM_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL_PropertiesID create_props)
 {
-    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->driverdata;
+    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->internal;
     VITA_GXM_TextureData *vita_texture = (VITA_GXM_TextureData *)SDL_calloc(1, sizeof(VITA_GXM_TextureData));
 
     if (!vita_texture) {
@@ -296,7 +296,7 @@ static int VITA_GXM_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, 
         return SDL_OutOfMemory();
     }
 
-    texture->driverdata = vita_texture;
+    texture->internal = vita_texture;
 
     VITA_GXM_SetTextureScaleMode(renderer, texture, texture->scaleMode);
 
@@ -310,7 +310,7 @@ static int VITA_GXM_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, 
 
 static void VITA_GXM_SetYUVProfile(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->driverdata;
+    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->internal;
     int ret = 0;
     if (SDL_ISCOLORSPACE_MATRIX_BT601(texture->colorspace)) {
         if (SDL_ISCOLORSPACE_LIMITED_RANGE(texture->colorspace)) {
@@ -336,7 +336,7 @@ static void VITA_GXM_SetYUVProfile(SDL_Renderer *renderer, SDL_Texture *texture)
 static int VITA_GXM_UpdateTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                                   const SDL_Rect *rect, const void *pixels, int pitch)
 {
-    VITA_GXM_TextureData *vita_texture = (VITA_GXM_TextureData *)texture->driverdata;
+    VITA_GXM_TextureData *vita_texture = (VITA_GXM_TextureData *)texture->internal;
     Uint8 *dst;
     int row, length, dpitch;
 
@@ -457,7 +457,7 @@ static int VITA_GXM_UpdateTextureYUV(SDL_Renderer *renderer, SDL_Texture *textur
     {
         void *Udst;
         void *Vdst;
-        VITA_GXM_TextureData *vita_texture = (VITA_GXM_TextureData *)texture->driverdata;
+        VITA_GXM_TextureData *vita_texture = (VITA_GXM_TextureData *)texture->internal;
         int uv_pitch = (dpitch + 1) / 2;
 
         // skip Y plane
@@ -529,7 +529,7 @@ static int VITA_GXM_UpdateTextureNV(SDL_Renderer *renderer, SDL_Texture *texture
     // UV plane
     {
         void *UVdst;
-        VITA_GXM_TextureData *vita_texture = (VITA_GXM_TextureData *)texture->driverdata;
+        VITA_GXM_TextureData *vita_texture = (VITA_GXM_TextureData *)texture->internal;
         int uv_pitch = 2 * ((dpitch + 1) / 2);
 
         // skip Y plane
@@ -559,8 +559,8 @@ static int VITA_GXM_UpdateTextureNV(SDL_Renderer *renderer, SDL_Texture *texture
 static int VITA_GXM_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                                 const SDL_Rect *rect, void **pixels, int *pitch)
 {
-    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->driverdata;
-    VITA_GXM_TextureData *vita_texture = (VITA_GXM_TextureData *)texture->driverdata;
+    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->internal;
+    VITA_GXM_TextureData *vita_texture = (VITA_GXM_TextureData *)texture->internal;
 
     *pixels =
         (void *)((Uint8 *)gxm_texture_get_datap(vita_texture->tex) + (rect->y * vita_texture->pitch) + rect->x * SDL_BYTESPERPIXEL(texture->format));
@@ -583,7 +583,7 @@ static void VITA_GXM_UnlockTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 
 static void VITA_GXM_SetTextureScaleMode(SDL_Renderer *renderer, SDL_Texture *texture, SDL_ScaleMode scaleMode)
 {
-    VITA_GXM_TextureData *vita_texture = (VITA_GXM_TextureData *)texture->driverdata;
+    VITA_GXM_TextureData *vita_texture = (VITA_GXM_TextureData *)texture->internal;
 
     /*
      set texture filtering according to scaleMode
@@ -640,7 +640,7 @@ static int VITA_GXM_QueueNoOp(SDL_Renderer *renderer, SDL_RenderCommand *cmd)
 
 static int VITA_GXM_QueueSetDrawColor(SDL_Renderer *renderer, SDL_RenderCommand *cmd)
 {
-    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->driverdata;
+    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->internal;
 
     data->drawstate.color.r = cmd->data.color.color.r * cmd->data.color.color_scale;
     data->drawstate.color.g = cmd->data.color.color.g * cmd->data.color.color_scale;
@@ -652,7 +652,7 @@ static int VITA_GXM_QueueSetDrawColor(SDL_Renderer *renderer, SDL_RenderCommand 
 
 static int VITA_GXM_QueueDrawPoints(SDL_Renderer *renderer, SDL_RenderCommand *cmd, const SDL_FPoint *points, int count)
 {
-    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->driverdata;
+    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->internal;
 
     SDL_FColor color = data->drawstate.color;
 
@@ -674,7 +674,7 @@ static int VITA_GXM_QueueDrawPoints(SDL_Renderer *renderer, SDL_RenderCommand *c
 
 static int VITA_GXM_QueueDrawLines(SDL_Renderer *renderer, SDL_RenderCommand *cmd, const SDL_FPoint *points, int count)
 {
-    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->driverdata;
+    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->internal;
     SDL_FColor color = data->drawstate.color;
 
     color_vertex *vertex = (color_vertex *)pool_malloc(
@@ -702,7 +702,7 @@ static int VITA_GXM_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd
                                   int num_vertices, const void *indices, int num_indices, int size_indices,
                                   float scale_x, float scale_y)
 {
-    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->driverdata;
+    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->internal;
     int i;
     int count = indices ? num_indices : num_vertices;
     const float color_scale = cmd->data.draw.color_scale;
@@ -711,7 +711,7 @@ static int VITA_GXM_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd
     size_indices = indices ? size_indices : 0;
 
     if (texture) {
-        VITA_GXM_TextureData *vita_texture = (VITA_GXM_TextureData *)texture->driverdata;
+        VITA_GXM_TextureData *vita_texture = (VITA_GXM_TextureData *)texture->internal;
         texture_vertex *vertices;
 
         vertices = (texture_vertex *)pool_malloc(
@@ -801,7 +801,7 @@ static int VITA_GXM_RenderClear(SDL_Renderer *renderer, SDL_RenderCommand *cmd)
     void *color_buffer;
     SDL_FColor color;
 
-    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->driverdata;
+    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->internal;
     unset_clip_rectangle(data);
 
     // set clear shaders
@@ -910,7 +910,7 @@ static int SetDrawState(VITA_GXM_RenderData *data, const SDL_RenderCommand *cmd)
 
     if (texture != data->drawstate.texture) {
         if (texture) {
-            VITA_GXM_TextureData *vita_texture = (VITA_GXM_TextureData *)cmd->data.draw.texture->driverdata;
+            VITA_GXM_TextureData *vita_texture = (VITA_GXM_TextureData *)cmd->data.draw.texture->internal;
             sceGxmSetFragmentTexture(data->gxm_context, 0, &vita_texture->tex->gxm_tex);
         }
         data->drawstate.texture = texture;
@@ -929,7 +929,7 @@ static void VITA_GXM_InvalidateCachedState(SDL_Renderer *renderer)
 
 static int VITA_GXM_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, void *vertices, size_t vertsize)
 {
-    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->driverdata;
+    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->internal;
     StartDrawing(renderer);
 
     data->drawstate.target = renderer->target;
@@ -1123,7 +1123,7 @@ static SDL_Surface *VITA_GXM_RenderReadPixels(SDL_Renderer *renderer, const SDL_
 
 static int VITA_GXM_RenderPresent(SDL_Renderer *renderer)
 {
-    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->driverdata;
+    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->internal;
     SceCommonDialogUpdateParam updateParam;
 
     data->displayData.address = data->displayBufferData[data->backBufferIndex];
@@ -1165,8 +1165,8 @@ static int VITA_GXM_RenderPresent(SDL_Renderer *renderer)
 
 static void VITA_GXM_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->driverdata;
-    VITA_GXM_TextureData *vita_texture = (VITA_GXM_TextureData *)texture->driverdata;
+    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->internal;
+    VITA_GXM_TextureData *vita_texture = (VITA_GXM_TextureData *)texture->internal;
 
     if (!data) {
         return;
@@ -1186,12 +1186,12 @@ static void VITA_GXM_DestroyTexture(SDL_Renderer *renderer, SDL_Texture *texture
 
     SDL_free(vita_texture);
 
-    texture->driverdata = NULL;
+    texture->internal = NULL;
 }
 
 static void VITA_GXM_DestroyRenderer(SDL_Renderer *renderer)
 {
-    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->driverdata;
+    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->internal;
     if (data) {
         if (!data->initialized) {
             return;

--- a/src/render/vitagxm/SDL_render_vita_gxm_tools.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm_tools.c
@@ -374,7 +374,7 @@ int gxm_init(SDL_Renderer *renderer)
         .colorMask = SCE_GXM_COLOR_MASK_ALL
     };
 
-    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->driverdata;
+    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->internal;
 
     SceGxmInitializeParams initializeParams;
     SDL_memset(&initializeParams, 0, sizeof(SceGxmInitializeParams));
@@ -858,7 +858,7 @@ int gxm_init(SDL_Renderer *renderer)
 
 void gxm_finish(SDL_Renderer *renderer)
 {
-    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->driverdata;
+    VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->internal;
 
     // wait until rendering is done
     sceGxmFinish(data->gxm_context);

--- a/src/render/vulkan/SDL_render_vulkan.c
+++ b/src/render/vulkan/SDL_render_vulkan.c
@@ -459,7 +459,7 @@ static void VULKAN_DestroyAll(SDL_Renderer *renderer)
     if (renderer == NULL) {
         return;
     }
-    rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    rendererData = (VULKAN_RenderData *)renderer->internal;
     if (rendererData == NULL) {
         return;
     }
@@ -858,7 +858,7 @@ static void VULKAN_RecordPipelineImageBarrier(VULKAN_RenderData *rendererData, V
 
 static VkResult VULKAN_AcquireNextSwapchainImage(SDL_Renderer *renderer)
 {
-    VULKAN_RenderData *rendererData = ( VULKAN_RenderData * )renderer->driverdata;
+    VULKAN_RenderData *rendererData = ( VULKAN_RenderData * )renderer->internal;
 
     VkResult result;
 
@@ -956,7 +956,7 @@ static void VULKAN_EnsureCommandBuffer(VULKAN_RenderData *rendererData)
 
 static SDL_bool VULKAN_ActivateCommandBuffer(SDL_Renderer *renderer, VkAttachmentLoadOp loadOp, VkClearColorValue *clearColor, VULKAN_DrawStateCache *stateCache)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
 
     VULKAN_EnsureCommandBuffer(rendererData);
 
@@ -1061,7 +1061,7 @@ static VkResult VULKAN_IssueBatch(VULKAN_RenderData *rendererData)
 
 static void VULKAN_DestroyRenderer(SDL_Renderer *renderer)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     if (rendererData) {
         if (rendererData->device != VK_NULL_HANDLE) {
             vkDeviceWaitIdle(rendererData->device);
@@ -1121,7 +1121,7 @@ static VkBlendOp GetBlendOp(SDL_BlendOperation operation)
 static VULKAN_PipelineState *VULKAN_CreatePipelineState(SDL_Renderer *renderer,
     VULKAN_Shader shader, VkPipelineLayout pipelineLayout, VkDescriptorSetLayout descriptorSetLayout, SDL_BlendMode blendMode, VkPrimitiveTopology topology, VkFormat format)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     VULKAN_PipelineState *pipelineStates;
     VkPipeline pipeline = VK_NULL_HANDLE;
     VkResult result = VK_SUCCESS;
@@ -1675,7 +1675,7 @@ static VkResult VULKAN_CreateDeviceResources(SDL_Renderer *renderer, SDL_Propert
         VK_KHR_BIND_MEMORY_2_EXTENSION_NAME,
         VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME,
     };
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     SDL_VideoDevice *device = SDL_GetVideoDevice();
     VkResult result = VK_SUCCESS;
     PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr = NULL;
@@ -1949,7 +1949,7 @@ static VkResult VULKAN_CreateDeviceResources(SDL_Renderer *renderer, SDL_Propert
 static VkResult VULKAN_CreateFramebuffersAndRenderPasses(SDL_Renderer *renderer, int w, int h,
     VkFormat format, int imageViewCount, VkImageView *imageViews, VkFramebuffer *framebuffers, VkRenderPass renderPasses[SDL_VULKAN_NUM_RENDERPASSES])
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *) renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *) renderer->internal;
     VkResult result;
 
     VkAttachmentDescription attachmentDescription = { 0 };
@@ -2034,7 +2034,7 @@ static VkResult VULKAN_CreateFramebuffersAndRenderPasses(SDL_Renderer *renderer,
 
 static VkResult VULKAN_CreateSwapChain(SDL_Renderer *renderer, int w, int h)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     VkResult result = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(rendererData->physicalDevice, rendererData->surface, &rendererData->surfaceCapabilities);
     if (result != VK_SUCCESS) {
         SDL_LogError(SDL_LOG_CATEGORY_RENDER, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR(): %s\n", SDL_Vulkan_GetResultString(result));
@@ -2419,7 +2419,7 @@ static VkResult VULKAN_CreateSwapChain(SDL_Renderer *renderer, int w, int h)
 /* Initialize all resources that change when the window's size changes. */
 static VkResult VULKAN_CreateWindowSizeDependentResources(SDL_Renderer *renderer)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     VkResult result = VK_SUCCESS;
     int w, h;
 
@@ -2445,7 +2445,7 @@ static VkResult VULKAN_CreateWindowSizeDependentResources(SDL_Renderer *renderer
 /* This method is called when the window's size changes. */
 static VkResult VULKAN_UpdateForWindowSizeChange(SDL_Renderer *renderer)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     /* If the GPU has previous work, wait for it to be done first */
     VULKAN_WaitForGPU(rendererData);
 
@@ -2454,7 +2454,7 @@ static VkResult VULKAN_UpdateForWindowSizeChange(SDL_Renderer *renderer)
 
 static void VULKAN_WindowEvent(SDL_Renderer *renderer, const SDL_WindowEvent *event)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
 
     if (event->type == SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED) {
         rendererData->recreateSwapchain = SDL_TRUE;
@@ -2483,7 +2483,7 @@ static SDL_bool VULKAN_SupportsBlendMode(SDL_Renderer *renderer, SDL_BlendMode b
 
 static int VULKAN_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL_PropertiesID create_props)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     VULKAN_TextureData *textureData;
     VkResult result;
     VkFormat textureFormat = SDLPixelFormatToVkTextureFormat(texture->format, renderer->output_colorspace);
@@ -2498,7 +2498,7 @@ static int VULKAN_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SD
     if (!textureData) {
         return -1;
     }
-    texture->driverdata = textureData;
+    texture->internal = textureData;
     if (SDL_COLORSPACETRANSFER(texture->colorspace) == SDL_TRANSFER_CHARACTERISTICS_SRGB) {
         textureData->shader = SHADER_RGB;
     } else {
@@ -2665,8 +2665,8 @@ static int VULKAN_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SD
 static void VULKAN_DestroyTexture(SDL_Renderer *renderer,
                                  SDL_Texture *texture)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
-    VULKAN_TextureData *textureData = (VULKAN_TextureData *)texture->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
+    VULKAN_TextureData *textureData = (VULKAN_TextureData *)texture->internal;
 
     if (!textureData) {
         return;
@@ -2711,7 +2711,7 @@ static void VULKAN_DestroyTexture(SDL_Renderer *renderer,
     }
 
     SDL_free(textureData);
-    texture->driverdata = NULL;
+    texture->internal = NULL;
 }
 
 static VkResult VULKAN_UpdateTextureInternal(VULKAN_RenderData *rendererData, VkImage image, VkFormat format, int plane, int x, int y, int w, int h, const void *pixels, int pitch, VkImageLayout *imageLayout)
@@ -2811,8 +2811,8 @@ static int VULKAN_UpdateTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                                const SDL_Rect *rect, const void *srcPixels,
                                int srcPitch)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
-    VULKAN_TextureData *textureData = (VULKAN_TextureData *)texture->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
+    VULKAN_TextureData *textureData = (VULKAN_TextureData *)texture->internal;
 
     if (!textureData) {
         return SDL_SetError("Texture is not currently available");
@@ -2860,8 +2860,8 @@ static int VULKAN_UpdateTextureYUV(SDL_Renderer *renderer, SDL_Texture *texture,
                                   const Uint8 *Uplane, int Upitch,
                                   const Uint8 *Vplane, int Vpitch)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
-    VULKAN_TextureData *textureData = (VULKAN_TextureData *)texture->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
+    VULKAN_TextureData *textureData = (VULKAN_TextureData *)texture->internal;
 
     if (!textureData) {
         return SDL_SetError("Texture is not currently available");
@@ -2884,8 +2884,8 @@ static int VULKAN_UpdateTextureNV(SDL_Renderer *renderer, SDL_Texture *texture,
                                  const Uint8 *Yplane, int Ypitch,
                                  const Uint8 *UVplane, int UVpitch)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
-    VULKAN_TextureData *textureData = (VULKAN_TextureData *)texture->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
+    VULKAN_TextureData *textureData = (VULKAN_TextureData *)texture->internal;
 
     if (!textureData) {
         return SDL_SetError("Texture is not currently available");
@@ -2905,8 +2905,8 @@ static int VULKAN_UpdateTextureNV(SDL_Renderer *renderer, SDL_Texture *texture,
 static int VULKAN_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                              const SDL_Rect *rect, void **pixels, int *pitch)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
-    VULKAN_TextureData *textureData = (VULKAN_TextureData *)texture->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
+    VULKAN_TextureData *textureData = (VULKAN_TextureData *)texture->internal;
     VkResult result;
     if (!textureData) {
         return SDL_SetError("Texture is not currently available");
@@ -2946,8 +2946,8 @@ static int VULKAN_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
 
 static void VULKAN_UnlockTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
-    VULKAN_TextureData *textureData = (VULKAN_TextureData *)texture->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
+    VULKAN_TextureData *textureData = (VULKAN_TextureData *)texture->internal;
 
     if (!textureData) {
         return;
@@ -2999,7 +2999,7 @@ static void VULKAN_UnlockTexture(SDL_Renderer *renderer, SDL_Texture *texture)
 
 static void VULKAN_SetTextureScaleMode(SDL_Renderer *renderer, SDL_Texture *texture, SDL_ScaleMode scaleMode)
 {
-    VULKAN_TextureData *textureData = (VULKAN_TextureData *)texture->driverdata;
+    VULKAN_TextureData *textureData = (VULKAN_TextureData *)texture->internal;
 
     if (!textureData) {
         return;
@@ -3010,7 +3010,7 @@ static void VULKAN_SetTextureScaleMode(SDL_Renderer *renderer, SDL_Texture *text
 
 static int VULKAN_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     VULKAN_TextureData *textureData = NULL;
 
     VULKAN_EnsureCommandBuffer(rendererData);
@@ -3031,7 +3031,7 @@ static int VULKAN_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
         return 0;
     }
 
-    textureData = (VULKAN_TextureData *)texture->driverdata;
+    textureData = (VULKAN_TextureData *)texture->internal;
 
     if (textureData->mainImage.imageView == VK_NULL_HANDLE) {
         return SDL_SetError("specified texture is not a render target");
@@ -3089,7 +3089,7 @@ static int VULKAN_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, 
     int count = indices ? num_indices : num_vertices;
     VertexPositionColor *verts = (VertexPositionColor *)SDL_AllocateRenderVertices(renderer, count * sizeof(VertexPositionColor), 0, &cmd->data.draw.first);
     SDL_bool convert_color = SDL_RenderingLinearSpace(renderer);
-    VULKAN_TextureData *textureData = texture ? (VULKAN_TextureData *)texture->driverdata : NULL;
+    VULKAN_TextureData *textureData = texture ? (VULKAN_TextureData *)texture->internal : NULL;
     float u_scale = textureData ? (float)texture->w / textureData->width : 0.0f;
     float v_scale = textureData ? (float)texture->h / textureData->height : 0.0f;
 
@@ -3139,7 +3139,7 @@ static int VULKAN_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, 
 static SDL_bool VULKAN_UpdateVertexBuffer(SDL_Renderer *renderer,
                                     const void *vertexData, size_t dataSizeInBytes, VULKAN_DrawStateCache *stateCache)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     const int vbidx = rendererData->currentVertexBuffer;
     VULKAN_Buffer *vertexBuffer;
 
@@ -3176,7 +3176,7 @@ static SDL_bool VULKAN_UpdateVertexBuffer(SDL_Renderer *renderer,
 
 static int VULKAN_UpdateViewport(SDL_Renderer *renderer)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     const SDL_Rect *viewport = &rendererData->currentViewport;
     Float4X4 projection;
     Float4X4 view;
@@ -3220,7 +3220,7 @@ static int VULKAN_UpdateViewport(SDL_Renderer *renderer)
 
 static int VULKAN_UpdateClipRect(SDL_Renderer *renderer)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     const SDL_Rect *viewport = &rendererData->currentViewport;
 
     VkRect2D scissor;
@@ -3372,7 +3372,7 @@ static VkResult VULKAN_CreateDescriptorSetAndPipelineLayout(VULKAN_RenderData *r
 static VkDescriptorSet VULKAN_AllocateDescriptorSet(SDL_Renderer *renderer, VULKAN_Shader shader, VkDescriptorSetLayout descriptorSetLayout,
     VkSampler sampler, VkBuffer constantBuffer, VkDeviceSize constantBufferOffset, VkImageView imageView)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     uint32_t currentDescriptorPoolIndex = rendererData->currentDescriptorPoolIndex;
     VkDescriptorPool descriptorPool = rendererData->descriptorPools[rendererData->currentCommandBufferIndex][currentDescriptorPoolIndex];
 
@@ -3468,7 +3468,7 @@ static SDL_bool VULKAN_SetDrawState(SDL_Renderer *renderer, const SDL_RenderComm
     const PixelShaderConstants *shader_constants, VkPrimitiveTopology topology, VkImageView imageView, VkSampler sampler, const Float4X4 *matrix, VULKAN_DrawStateCache *stateCache)
 
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     const SDL_BlendMode blendMode = cmd->data.draw.blend;
     VkFormat format = rendererData->surfaceFormat.format;
     const Float4X4 *newmatrix = matrix ? matrix : &rendererData->identity;
@@ -3616,8 +3616,8 @@ static SDL_bool VULKAN_SetDrawState(SDL_Renderer *renderer, const SDL_RenderComm
 static SDL_bool VULKAN_SetCopyState(SDL_Renderer *renderer, const SDL_RenderCommand *cmd, const Float4X4 *matrix, VULKAN_DrawStateCache *stateCache)
 {
     SDL_Texture *texture = cmd->data.draw.texture;
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
-    VULKAN_TextureData *textureData = (VULKAN_TextureData *)texture->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
+    VULKAN_TextureData *textureData = (VULKAN_TextureData *)texture->internal;
     VkSampler textureSampler = VK_NULL_HANDLE;
     PixelShaderConstants constants;
     VkDescriptorSetLayout descriptorSetLayout = (textureData->descriptorSetLayoutYcbcr != VK_NULL_HANDLE) ? textureData->descriptorSetLayoutYcbcr : rendererData->descriptorSetLayout;
@@ -3663,20 +3663,20 @@ static SDL_bool VULKAN_SetCopyState(SDL_Renderer *renderer, const SDL_RenderComm
 
 static void VULKAN_DrawPrimitives(SDL_Renderer *renderer, VkPrimitiveTopology primitiveTopology, const size_t vertexStart, const size_t vertexCount)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     vkCmdDraw(rendererData->currentCommandBuffer, (uint32_t)vertexCount, 1, (uint32_t)vertexStart, 0);
 }
 
 static void VULKAN_InvalidateCachedState(SDL_Renderer *renderer)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     rendererData->currentPipelineState = NULL;
     rendererData->cliprectDirty = SDL_TRUE;
 }
 
 static int VULKAN_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, void *vertices, size_t vertsize)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     VULKAN_DrawStateCache stateCache;
     SDL_memset(&stateCache, 0, sizeof(stateCache));
 
@@ -3805,7 +3805,7 @@ static int VULKAN_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd
 
 static SDL_Surface* VULKAN_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rect *rect)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     VkImage backBuffer;
     VkImageLayout *imageLayout;
     VULKAN_Buffer readbackBuffer;
@@ -3901,7 +3901,7 @@ static SDL_Surface* VULKAN_RenderReadPixels(SDL_Renderer *renderer, const SDL_Re
 
 static int VULKAN_AddVulkanRenderSemaphores(SDL_Renderer *renderer, Uint32 wait_stage_mask, Sint64 wait_semaphore, Sint64 signal_semaphore)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
 
     if (wait_semaphore) {
         if (rendererData->waitRenderSemaphoreCount == rendererData->waitRenderSemaphoreMax) {
@@ -3943,7 +3943,7 @@ static int VULKAN_AddVulkanRenderSemaphores(SDL_Renderer *renderer, Uint32 wait_
 
 static int VULKAN_RenderPresent(SDL_Renderer *renderer)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     VkResult result = VK_SUCCESS;
     if (rendererData->currentCommandBuffer) {
 
@@ -4035,7 +4035,7 @@ static int VULKAN_RenderPresent(SDL_Renderer *renderer)
 
 static int VULKAN_SetVSync(SDL_Renderer *renderer, const int vsync)
 {
-    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->driverdata;
+    VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
 
     switch (vsync) {
     case -1:
@@ -4101,7 +4101,7 @@ static int VULKAN_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL
     renderer->DestroyTexture = VULKAN_DestroyTexture;
     renderer->DestroyRenderer = VULKAN_DestroyRenderer;
     renderer->SetVSync = VULKAN_SetVSync;
-    renderer->driverdata = rendererData;
+    renderer->internal = rendererData;
     VULKAN_InvalidateCachedState(renderer);
 
     renderer->name = VULKAN_RenderDriver.name;

--- a/src/video/SDL_egl_c.h
+++ b/src/video/SDL_egl_c.h
@@ -150,19 +150,19 @@ extern int SDL_EGL_SetErrorEx(const char *message, const char *eglFunctionName, 
 #define SDL_EGL_SwapWindow_impl(BACKEND)                                                        \
     int BACKEND##_GLES_SwapWindow(SDL_VideoDevice *_this, SDL_Window *window)                                    \
     {                                                                                           \
-        return SDL_EGL_SwapBuffers(_this, window->driverdata->egl_surface);                     \
+        return SDL_EGL_SwapBuffers(_this, window->internal->egl_surface);                     \
     }
 
 #define SDL_EGL_MakeCurrent_impl(BACKEND)                                                                                          \
     int BACKEND##_GLES_MakeCurrent(SDL_VideoDevice *_this, SDL_Window *window, SDL_GLContext context)                                               \
     {                                                                                                                              \
-        return SDL_EGL_MakeCurrent(_this, window ? window->driverdata->egl_surface : EGL_NO_SURFACE, context); \
+        return SDL_EGL_MakeCurrent(_this, window ? window->internal->egl_surface : EGL_NO_SURFACE, context); \
     }
 
 #define SDL_EGL_CreateContext_impl(BACKEND)                                                     \
     SDL_GLContext BACKEND##_GLES_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)                       \
     {                                                                                           \
-        return SDL_EGL_CreateContext(_this, window->driverdata->egl_surface);                   \
+        return SDL_EGL_CreateContext(_this, window->internal->egl_surface);                   \
     }
 
 #endif /* SDL_VIDEO_OPENGL_EGL */

--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -112,7 +112,7 @@ struct SDL_Window
 
     SDL_PropertiesID props;
 
-    SDL_WindowData *driverdata;
+    SDL_WindowData *internal;
 
     SDL_Window *prev;
     SDL_Window *next;
@@ -154,7 +154,7 @@ struct SDL_VideoDisplay
 
     SDL_PropertiesID props;
 
-    SDL_DisplayData *driverdata;
+    SDL_DisplayData *internal;
 };
 
 /* Video device flags */
@@ -456,7 +456,7 @@ struct SDL_VideoDevice
 
     /* * * */
     /* Data private to this driver */
-    SDL_VideoData *driverdata;
+    SDL_VideoData *internal;
     struct SDL_GLDriverData *gl_data;
 
 #ifdef SDL_VIDEO_OPENGL_EGL

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -839,10 +839,10 @@ void SDL_DelVideoDisplay(SDL_DisplayID displayID, SDL_bool send_event)
     SDL_DestroyProperties(display->props);
     SDL_free(display->name);
     SDL_ResetFullscreenDisplayModes(display);
-    SDL_free(display->desktop_mode.driverdata);
-    display->desktop_mode.driverdata = NULL;
-    SDL_free(display->driverdata);
-    display->driverdata = NULL;
+    SDL_free(display->desktop_mode.internal);
+    display->desktop_mode.internal = NULL;
+    SDL_free(display->internal);
+    display->internal = NULL;
     SDL_free(display);
 
     if (display_index < (_this->num_displays - 1)) {
@@ -932,7 +932,7 @@ SDL_DisplayData *SDL_GetDisplayDriverData(SDL_DisplayID displayID)
 
     CHECK_DISPLAY_MAGIC(display, NULL);
 
-    return display->driverdata;
+    return display->internal;
 }
 
 SDL_DisplayData *SDL_GetDisplayDriverDataForWindow(SDL_Window *window)
@@ -1216,8 +1216,8 @@ void SDL_ResetFullscreenDisplayModes(SDL_VideoDisplay *display)
     int i;
 
     for (i = display->num_fullscreen_modes; i--;) {
-        SDL_free(display->fullscreen_modes[i].driverdata);
-        display->fullscreen_modes[i].driverdata = NULL;
+        SDL_free(display->fullscreen_modes[i].internal);
+        display->fullscreen_modes[i].internal = NULL;
     }
     SDL_free(display->fullscreen_modes);
     display->fullscreen_modes = NULL;
@@ -1335,8 +1335,8 @@ void SDL_SetDesktopDisplayMode(SDL_VideoDisplay *display, const SDL_DisplayMode 
 
     SDL_copyp(&last_mode, &display->desktop_mode);
 
-    if (display->desktop_mode.driverdata) {
-        SDL_free(display->desktop_mode.driverdata);
+    if (display->desktop_mode.internal) {
+        SDL_free(display->desktop_mode.internal);
     }
     SDL_copyp(&display->desktop_mode, mode);
     display->desktop_mode.displayID = display->id;

--- a/src/video/android/SDL_androidevents.c
+++ b/src/video/android/SDL_androidevents.c
@@ -44,7 +44,7 @@ static void android_egl_context_restore(SDL_Window *window)
 {
     if (window) {
         SDL_Event event;
-        SDL_WindowData *data = window->driverdata;
+        SDL_WindowData *data = window->internal;
         SDL_GL_MakeCurrent(window, NULL);
         if (SDL_GL_MakeCurrent(window, (SDL_GLContext)data->egl_context) < 0) {
             /* The context is no longer valid, create a new one */
@@ -68,7 +68,7 @@ static void android_egl_context_backup(SDL_Window *window)
     if (window) {
         int interval = 0;
         /* Keep a copy of the EGL Context so we can try to restore it when we resume */
-        SDL_WindowData *data = window->driverdata;
+        SDL_WindowData *data = window->internal;
         data->egl_context = SDL_GL_GetCurrentContext();
 
         /* Save/Restore the swap interval / vsync */
@@ -93,7 +93,7 @@ static void android_egl_context_backup(SDL_Window *window)
 
 void Android_PumpEvents_Blocking(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
 
     if (videodata->isPaused) {
 #ifdef SDL_VIDEO_OPENGL_EGL
@@ -162,7 +162,7 @@ void Android_PumpEvents_Blocking(SDL_VideoDevice *_this)
 
 void Android_PumpEvents_NonBlocking(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     static int backup_context = 0;
 
     if (videodata->isPaused) {

--- a/src/video/android/SDL_androidgl.c
+++ b/src/video/android/SDL_androidgl.c
@@ -38,7 +38,7 @@
 int Android_GLES_MakeCurrent(SDL_VideoDevice *_this, SDL_Window *window, SDL_GLContext context)
 {
     if (window && context) {
-        return SDL_EGL_MakeCurrent(_this, window->driverdata->egl_surface, context);
+        return SDL_EGL_MakeCurrent(_this, window->internal->egl_surface, context);
     } else {
         return SDL_EGL_MakeCurrent(_this, NULL, NULL);
     }
@@ -50,7 +50,7 @@ SDL_GLContext Android_GLES_CreateContext(SDL_VideoDevice *_this, SDL_Window *win
 
     Android_ActivityMutex_Lock_Running();
 
-    ret = SDL_EGL_CreateContext(_this, window->driverdata->egl_surface);
+    ret = SDL_EGL_CreateContext(_this, window->internal->egl_surface);
 
     SDL_UnlockMutex(Android_ActivityMutex);
 
@@ -70,7 +70,7 @@ int Android_GLES_SwapWindow(SDL_VideoDevice *_this, SDL_Window *window)
 
     /*_this->egl_data->eglWaitNative(EGL_CORE_NATIVE_ENGINE);
     _this->egl_data->eglWaitGL();*/
-    retval = SDL_EGL_SwapBuffers(_this, window->driverdata->egl_surface);
+    retval = SDL_EGL_SwapBuffers(_this, window->internal->egl_surface);
 
     SDL_UnlockMutex(Android_ActivityMutex);
 

--- a/src/video/android/SDL_androidmouse.c
+++ b/src/video/android/SDL_androidmouse.c
@@ -64,7 +64,7 @@ static SDL_Cursor *Android_WrapCursor(int custom_cursor, int system_cursor)
         if (data) {
             data->custom_cursor = custom_cursor;
             data->system_cursor = system_cursor;
-            cursor->driverdata = data;
+            cursor->internal = data;
         } else {
             SDL_free(cursor);
             cursor = NULL;
@@ -104,11 +104,11 @@ static SDL_Cursor *Android_CreateSystemCursor(SDL_SystemCursor id)
 
 static void Android_FreeCursor(SDL_Cursor *cursor)
 {
-    SDL_AndroidCursorData *data = (SDL_AndroidCursorData *)cursor->driverdata;
+    SDL_AndroidCursorData *data = (SDL_AndroidCursorData *)cursor->internal;
     if (data->custom_cursor != 0) {
         Android_JNI_DestroyCustomCursor(data->custom_cursor);
     }
-    SDL_free(cursor->driverdata);
+    SDL_free(cursor->internal);
     SDL_free(cursor);
 }
 
@@ -139,7 +139,7 @@ static int Android_ShowCursor(SDL_Cursor *cursor)
         cursor = Android_CreateEmptyCursor();
     }
     if (cursor) {
-        SDL_AndroidCursorData *data = (SDL_AndroidCursorData *)cursor->driverdata;
+        SDL_AndroidCursorData *data = (SDL_AndroidCursorData *)cursor->internal;
         if (data->custom_cursor) {
             if (!Android_JNI_SetCustomCursor(data->custom_cursor)) {
                 return SDL_Unsupported();

--- a/src/video/android/SDL_androidvideo.c
+++ b/src/video/android/SDL_androidvideo.c
@@ -75,7 +75,7 @@ static int Android_SuspendScreenSaver(SDL_VideoDevice *_this)
 
 static void Android_DeleteDevice(SDL_VideoDevice *device)
 {
-    SDL_free(device->driverdata);
+    SDL_free(device->internal);
     SDL_free(device);
 }
 
@@ -97,7 +97,7 @@ static SDL_VideoDevice *Android_CreateDevice(void)
         return NULL;
     }
 
-    device->driverdata = data;
+    device->internal = data;
     device->system_theme = Android_SystemTheme;
 
     /* Set the function pointers */
@@ -167,7 +167,7 @@ VideoBootStrap Android_bootstrap = {
 
 int Android_VideoInit(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     SDL_DisplayID displayID;
     SDL_VideoDisplay *display;
     SDL_DisplayMode mode;
@@ -181,7 +181,6 @@ int Android_VideoInit(SDL_VideoDevice *_this)
     mode.w = Android_DeviceWidth;
     mode.h = Android_DeviceHeight;
     mode.refresh_rate = Android_ScreenRate;
-    mode.driverdata = NULL;
 
     displayID = SDL_AddBasicVideoDisplay(&mode);
     if (displayID == 0) {

--- a/src/video/android/SDL_androidvulkan.c
+++ b/src/video/android/SDL_androidvulkan.c
@@ -128,7 +128,7 @@ int Android_Vulkan_CreateSurface(SDL_VideoDevice *_this,
                                  const struct VkAllocationCallbacks *allocator,
                                  VkSurfaceKHR *surface)
 {
-    SDL_WindowData *windowData = window->driverdata;
+    SDL_WindowData *windowData = window->internal;
     PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr =
         (PFN_vkGetInstanceProcAddr)_this->vulkan_config.vkGetInstanceProcAddr;
     PFN_vkCreateAndroidSurfaceKHR vkCreateAndroidSurfaceKHR =

--- a/src/video/android/SDL_androidwindow.c
+++ b/src/video/android/SDL_androidwindow.c
@@ -90,7 +90,7 @@ int Android_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Propert
     SDL_SetPointerProperty(SDL_GetWindowProperties(window), SDL_PROP_WINDOW_ANDROID_SURFACE_POINTER, data->egl_surface);
 #endif
 
-    window->driverdata = data;
+    window->internal = data;
     Android_Window = window;
 
 endfunction:
@@ -128,7 +128,7 @@ int Android_SetWindowFullscreen(SDL_VideoDevice *_this, SDL_Window *window, SDL_
             goto endfunction;
         }
 
-        data = window->driverdata;
+        data = window->internal;
         if (!data || !data->native_window) {
             if (data && !data->native_window) {
                 SDL_SetError("Missing native window");
@@ -175,8 +175,8 @@ void Android_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
     if (window == Android_Window) {
         Android_Window = NULL;
 
-        if (window->driverdata) {
-            SDL_WindowData *data = window->driverdata;
+        if (window->internal) {
+            SDL_WindowData *data = window->internal;
 
 #ifdef SDL_VIDEO_OPENGL_EGL
             if (data->egl_surface != EGL_NO_SURFACE) {
@@ -187,8 +187,8 @@ void Android_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
             if (data->native_window) {
                 ANativeWindow_release(data->native_window);
             }
-            SDL_free(window->driverdata);
-            window->driverdata = NULL;
+            SDL_free(window->internal);
+            window->internal = NULL;
         }
     }
 

--- a/src/video/cocoa/SDL_cocoaclipboard.m
+++ b/src/video/cocoa/SDL_cocoaclipboard.m
@@ -93,7 +93,7 @@ void Cocoa_CheckClipboardUpdate(SDL_CocoaVideoData *data)
 int Cocoa_SetClipboardData(SDL_VideoDevice *_this)
 {
     @autoreleasepool {
-        SDL_CocoaVideoData *data = (__bridge SDL_CocoaVideoData *)_this->driverdata;
+        SDL_CocoaVideoData *data = (__bridge SDL_CocoaVideoData *)_this->internal;
         NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
         NSPasteboardItem *newItem = [NSPasteboardItem new];
         NSMutableArray *utiTypes = [NSMutableArray new];

--- a/src/video/cocoa/SDL_cocoaevents.m
+++ b/src/video/cocoa/SDL_cocoaevents.m
@@ -35,7 +35,7 @@ static SDL_Window *FindSDLWindowForNSWindow(NSWindow *win)
     SDL_VideoDevice *device = SDL_GetVideoDevice();
     if (device && device->windows) {
         for (sdlwindow = device->windows; sdlwindow; sdlwindow = sdlwindow->next) {
-            NSWindow *nswindow = ((__bridge SDL_CocoaWindowData *)sdlwindow->driverdata).nswindow;
+            NSWindow *nswindow = ((__bridge SDL_CocoaWindowData *)sdlwindow->internal).nswindow;
             if (win == nswindow) {
                 return sdlwindow;
             }
@@ -565,7 +565,7 @@ int Cocoa_PumpEventsUntilDate(SDL_VideoDevice *_this, NSDate *expiration, bool a
 {
     /* Run any existing modal sessions. */
     for (SDL_Window *w = _this->windows; w; w = w->next) {
-        SDL_CocoaWindowData *data = (__bridge SDL_CocoaWindowData *)w->driverdata;
+        SDL_CocoaWindowData *data = (__bridge SDL_CocoaWindowData *)w->internal;
         if (data.modal_session) {
             [NSApp runModalSession:data.modal_session];
         }
@@ -620,7 +620,7 @@ void Cocoa_SendWakeupEvent(SDL_VideoDevice *_this, SDL_Window *window)
                                             location:NSMakePoint(0, 0)
                                        modifierFlags:0
                                            timestamp:0.0
-                                        windowNumber:((__bridge SDL_CocoaWindowData *)window->driverdata).window_number
+                                        windowNumber:((__bridge SDL_CocoaWindowData *)window->internal).window_number
                                              context:nil
                                              subtype:0
                                                data1:0
@@ -633,7 +633,7 @@ void Cocoa_SendWakeupEvent(SDL_VideoDevice *_this, SDL_Window *window)
 int Cocoa_SuspendScreenSaver(SDL_VideoDevice *_this)
 {
     @autoreleasepool {
-        SDL_CocoaVideoData *data = (__bridge SDL_CocoaVideoData *)_this->driverdata;
+        SDL_CocoaVideoData *data = (__bridge SDL_CocoaVideoData *)_this->internal;
 
         if (data.screensaver_assertion) {
             IOPMAssertionRelease(data.screensaver_assertion);

--- a/src/video/cocoa/SDL_cocoakeyboard.m
+++ b/src/video/cocoa/SDL_cocoakeyboard.m
@@ -328,7 +328,7 @@ static void UpdateKeymap(SDL_CocoaVideoData *data, SDL_bool send_event)
 
 void Cocoa_InitKeyboard(SDL_VideoDevice *_this)
 {
-    SDL_CocoaVideoData *data = (__bridge SDL_CocoaVideoData *)_this->driverdata;
+    SDL_CocoaVideoData *data = (__bridge SDL_CocoaVideoData *)_this->internal;
 
     UpdateKeymap(data, SDL_FALSE);
 
@@ -348,8 +348,8 @@ int Cocoa_StartTextInput(SDL_VideoDevice *_this, SDL_Window *window)
 {
     @autoreleasepool {
         NSView *parentView;
-        SDL_CocoaVideoData *data = (__bridge SDL_CocoaVideoData *)_this->driverdata;
-        NSWindow *nswindow = ((__bridge SDL_CocoaWindowData *)window->driverdata).nswindow;
+        SDL_CocoaVideoData *data = (__bridge SDL_CocoaVideoData *)_this->internal;
+        NSWindow *nswindow = ((__bridge SDL_CocoaWindowData *)window->internal).nswindow;
 
         parentView = [nswindow contentView];
 
@@ -375,7 +375,7 @@ int Cocoa_StartTextInput(SDL_VideoDevice *_this, SDL_Window *window)
 int Cocoa_StopTextInput(SDL_VideoDevice *_this, SDL_Window *window)
 {
     @autoreleasepool {
-        SDL_CocoaVideoData *data = (__bridge SDL_CocoaVideoData *)_this->driverdata;
+        SDL_CocoaVideoData *data = (__bridge SDL_CocoaVideoData *)_this->internal;
 
         if (data && data.fieldEdit) {
             [data.fieldEdit removeFromSuperview];
@@ -387,7 +387,7 @@ int Cocoa_StopTextInput(SDL_VideoDevice *_this, SDL_Window *window)
 
 int Cocoa_UpdateTextInputArea(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_CocoaVideoData *data = (__bridge SDL_CocoaVideoData *)_this->driverdata;
+    SDL_CocoaVideoData *data = (__bridge SDL_CocoaVideoData *)_this->internal;
     if (data.fieldEdit) {
         [data.fieldEdit setInputRect:&window->text_input_rect];
     }
@@ -398,7 +398,7 @@ void Cocoa_HandleKeyEvent(SDL_VideoDevice *_this, NSEvent *event)
 {
     unsigned short scancode;
     SDL_Scancode code;
-    SDL_CocoaVideoData *data = _this ? ((__bridge SDL_CocoaVideoData *)_this->driverdata) : nil;
+    SDL_CocoaVideoData *data = _this ? ((__bridge SDL_CocoaVideoData *)_this->internal) : nil;
     if (!data) {
         return; /* can happen when returning from fullscreen Space on shutdown */
     }

--- a/src/video/cocoa/SDL_cocoamessagebox.m
+++ b/src/video/cocoa/SDL_cocoamessagebox.m
@@ -42,7 +42,7 @@
 
         /* Retain the NSWindow because we'll show the alert later on the main thread */
         if (window) {
-            nswindow = ((__bridge SDL_CocoaWindowData *)window->driverdata).nswindow;
+            nswindow = ((__bridge SDL_CocoaWindowData *)window->internal).nswindow;
         } else {
             nswindow = nil;
         }

--- a/src/video/cocoa/SDL_cocoametalview.m
+++ b/src/video/cocoa/SDL_cocoametalview.m
@@ -133,7 +133,7 @@ static int SDLCALL SDL_MetalViewEventWatch(void *userdata, SDL_Event *event)
 SDL_MetalView Cocoa_Metal_CreateView(SDL_VideoDevice *_this, SDL_Window *window)
 {
     @autoreleasepool {
-        SDL_CocoaWindowData *data = (__bridge SDL_CocoaWindowData *)window->driverdata;
+        SDL_CocoaWindowData *data = (__bridge SDL_CocoaWindowData *)window->internal;
         NSView *view = data.nswindow.contentView;
         BOOL highDPI = (window->flags & SDL_WINDOW_HIGH_PIXEL_DENSITY) != 0;
         BOOL opaque = (window->flags & SDL_WINDOW_TRANSPARENT) == 0;

--- a/src/video/cocoa/SDL_cocoaopengl.m
+++ b/src/video/cocoa/SDL_cocoaopengl.m
@@ -138,7 +138,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
 - (void)setWindow:(SDL_Window *)newWindow
 {
     if (self->window) {
-        SDL_CocoaWindowData *oldwindowdata = (__bridge SDL_CocoaWindowData *)self->window->driverdata;
+        SDL_CocoaWindowData *oldwindowdata = (__bridge SDL_CocoaWindowData *)self->window->internal;
 
         /* Make sure to remove us from the old window's context list, or we'll get scheduled updates from it too. */
         NSMutableArray *contexts = oldwindowdata.nscontexts;
@@ -150,7 +150,7 @@ static CVReturn DisplayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeSt
     self->window = newWindow;
 
     if (newWindow) {
-        SDL_CocoaWindowData *windowdata = (__bridge SDL_CocoaWindowData *)newWindow->driverdata;
+        SDL_CocoaWindowData *windowdata = (__bridge SDL_CocoaWindowData *)newWindow->internal;
         NSView *contentview = windowdata.sdlContentView;
 
         /* Now sign up for scheduled updates for the new window. */
@@ -258,7 +258,7 @@ SDL_GLContext Cocoa_GL_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
 {
     @autoreleasepool {
         SDL_VideoDisplay *display = SDL_GetVideoDisplayForWindow(window);
-        SDL_DisplayData *displaydata = (SDL_DisplayData *)display->driverdata;
+        SDL_DisplayData *displaydata = (SDL_DisplayData *)display->internal;
         NSOpenGLPixelFormatAttribute attr[32];
         NSOpenGLPixelFormat *fmt;
         SDLOpenGLContext *context;
@@ -490,7 +490,7 @@ int Cocoa_GL_SwapWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
     @autoreleasepool {
         SDLOpenGLContext *nscontext = (__bridge SDLOpenGLContext *)SDL_GL_GetCurrentContext();
-        SDL_CocoaVideoData *videodata = (__bridge SDL_CocoaVideoData *)_this->driverdata;
+        SDL_CocoaVideoData *videodata = (__bridge SDL_CocoaVideoData *)_this->internal;
         const int setting = SDL_AtomicGet(&nscontext->swapIntervalSetting);
 
         if (setting == 0) {

--- a/src/video/cocoa/SDL_cocoaopengles.m
+++ b/src/video/cocoa/SDL_cocoaopengles.m
@@ -61,7 +61,7 @@ SDL_GLContext Cocoa_GLES_CreateContext(SDL_VideoDevice *_this, SDL_Window *windo
 {
     @autoreleasepool {
         SDL_GLContext context;
-        SDL_CocoaWindowData *data = (__bridge SDL_CocoaWindowData *)window->driverdata;
+        SDL_CocoaWindowData *data = (__bridge SDL_CocoaWindowData *)window->internal;
 
 #ifdef SDL_VIDEO_OPENGL_CGL
         if (_this->gl_config.profile_mask != SDL_GL_CONTEXT_PROFILE_ES) {
@@ -102,14 +102,14 @@ int Cocoa_GLES_DeleteContext(SDL_VideoDevice *_this, SDL_GLContext context)
 int Cocoa_GLES_SwapWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
     @autoreleasepool {
-        return SDL_EGL_SwapBuffers(_this, ((__bridge SDL_CocoaWindowData *)window->driverdata).egl_surface);
+        return SDL_EGL_SwapBuffers(_this, ((__bridge SDL_CocoaWindowData *)window->internal).egl_surface);
     }
 }
 
 int Cocoa_GLES_MakeCurrent(SDL_VideoDevice *_this, SDL_Window *window, SDL_GLContext context)
 {
     @autoreleasepool {
-        return SDL_EGL_MakeCurrent(_this, window ? ((__bridge SDL_CocoaWindowData *)window->driverdata).egl_surface : EGL_NO_SURFACE, context);
+        return SDL_EGL_MakeCurrent(_this, window ? ((__bridge SDL_CocoaWindowData *)window->internal).egl_surface : EGL_NO_SURFACE, context);
     }
 }
 
@@ -118,7 +118,7 @@ int Cocoa_GLES_SetupWindow(SDL_VideoDevice *_this, SDL_Window *window)
     @autoreleasepool {
         NSView *v;
         /* The current context is lost in here; save it and reset it. */
-        SDL_CocoaWindowData *windowdata = (__bridge SDL_CocoaWindowData *)window->driverdata;
+        SDL_CocoaWindowData *windowdata = (__bridge SDL_CocoaWindowData *)window->internal;
         SDL_Window *current_win = SDL_GL_GetCurrentWindow();
         SDL_GLContext current_ctx = SDL_GL_GetCurrentContext();
 
@@ -149,7 +149,7 @@ int Cocoa_GLES_SetupWindow(SDL_VideoDevice *_this, SDL_Window *window)
 SDL_EGLSurface Cocoa_GLES_GetEGLSurface(SDL_VideoDevice *_this, SDL_Window *window)
 {
     @autoreleasepool {
-        return ((__bridge SDL_CocoaWindowData *)window->driverdata).egl_surface;
+        return ((__bridge SDL_CocoaWindowData *)window->internal).egl_surface;
     }
 }
 

--- a/src/video/cocoa/SDL_cocoashape.m
+++ b/src/video/cocoa/SDL_cocoashape.m
@@ -28,7 +28,7 @@
 
 int Cocoa_UpdateWindowShape(SDL_VideoDevice *_this, SDL_Window *window, SDL_Surface *shape)
 {
-    SDL_CocoaWindowData *data = (__bridge SDL_CocoaWindowData *)window->driverdata;
+    SDL_CocoaWindowData *data = (__bridge SDL_CocoaWindowData *)window->internal;
     BOOL ignoresMouseEvents = NO;
 
     if (shape) {

--- a/src/video/cocoa/SDL_cocoavideo.m
+++ b/src/video/cocoa/SDL_cocoavideo.m
@@ -52,7 +52,7 @@ static void Cocoa_DeleteDevice(SDL_VideoDevice *device)
         if (device->wakeup_lock) {
             SDL_DestroyMutex(device->wakeup_lock);
         }
-        CFBridgingRelease(device->driverdata);
+        CFBridgingRelease(device->internal);
         SDL_free(device);
     }
 }
@@ -76,7 +76,7 @@ static SDL_VideoDevice *Cocoa_CreateDevice(void)
             SDL_free(device);
             return NULL;
         }
-        device->driverdata = (SDL_VideoData *)CFBridgingRetain(data);
+        device->internal = (SDL_VideoData *)CFBridgingRetain(data);
         device->wakeup_lock = SDL_CreateMutex();
         device->system_theme = Cocoa_GetSystemTheme();
 
@@ -195,7 +195,7 @@ VideoBootStrap COCOA_bootstrap = {
 int Cocoa_VideoInit(SDL_VideoDevice *_this)
 {
     @autoreleasepool {
-        SDL_CocoaVideoData *data = (__bridge SDL_CocoaVideoData *)_this->driverdata;
+        SDL_CocoaVideoData *data = (__bridge SDL_CocoaVideoData *)_this->internal;
 
         Cocoa_InitModes(_this);
         Cocoa_InitKeyboard(_this);
@@ -223,7 +223,7 @@ int Cocoa_VideoInit(SDL_VideoDevice *_this)
 void Cocoa_VideoQuit(SDL_VideoDevice *_this)
 {
     @autoreleasepool {
-        SDL_CocoaVideoData *data = (__bridge SDL_CocoaVideoData *)_this->driverdata;
+        SDL_CocoaVideoData *data = (__bridge SDL_CocoaVideoData *)_this->internal;
         Cocoa_QuitModes(_this);
         Cocoa_QuitKeyboard(_this);
         Cocoa_QuitMouse(_this);

--- a/src/video/cocoa/SDL_cocoavulkan.m
+++ b/src/video/cocoa/SDL_cocoavulkan.m
@@ -255,7 +255,7 @@ int Cocoa_Vulkan_CreateSurface(SDL_VideoDevice *_this,
 
     if (window->flags & SDL_WINDOW_EXTERNAL) {
         @autoreleasepool {
-            SDL_CocoaWindowData *data = (__bridge SDL_CocoaWindowData *)window->driverdata;
+            SDL_CocoaWindowData *data = (__bridge SDL_CocoaWindowData *)window->internal;
             if (![data.sdlContentView.layer isKindOfClass:[CAMetalLayer class]]) {
                 [data.sdlContentView setLayer:[CAMetalLayer layer]];
             }

--- a/src/video/emscripten/SDL_emscriptenframebuffer.c
+++ b/src/video/emscripten/SDL_emscriptenframebuffer.c
@@ -34,7 +34,7 @@ int Emscripten_CreateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *windo
     int w, h;
 
     /* Free the old framebuffer surface */
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     surface = data->surface;
     SDL_DestroySurface(surface);
 
@@ -58,7 +58,7 @@ int Emscripten_UpdateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *windo
 {
     SDL_Surface *surface;
 
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     surface = data->surface;
     if (!surface) {
         return SDL_SetError("Couldn't find framebuffer surface for window");
@@ -152,7 +152,7 @@ int Emscripten_UpdateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *windo
 
 void Emscripten_DestroyWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
 
     SDL_DestroySurface(data->surface);
     data->surface = NULL;

--- a/src/video/emscripten/SDL_emscriptenmouse.c
+++ b/src/video/emscripten/SDL_emscriptenmouse.c
@@ -54,7 +54,7 @@ static SDL_Cursor *Emscripten_CreateCursorFromString(const char *cursor_str, SDL
 
         curdata->system_cursor = cursor_str;
         curdata->is_custom = is_custom;
-        cursor->driverdata = curdata;
+        cursor->internal = curdata;
     }
 
     return cursor;
@@ -127,13 +127,13 @@ static void Emscripten_FreeCursor(SDL_Cursor *cursor)
 {
     Emscripten_CursorData *curdata;
     if (cursor) {
-        curdata = (Emscripten_CursorData *)cursor->driverdata;
+        curdata = (Emscripten_CursorData *)cursor->internal;
 
         if (curdata) {
             if (curdata->is_custom) {
                 SDL_free((char *)curdata->system_cursor);
             }
-            SDL_free(cursor->driverdata);
+            SDL_free(cursor->internal);
         }
 
         SDL_free(cursor);
@@ -144,8 +144,8 @@ static int Emscripten_ShowCursor(SDL_Cursor *cursor)
 {
     Emscripten_CursorData *curdata;
     if (SDL_GetMouseFocus() != NULL) {
-        if (cursor && cursor->driverdata) {
-            curdata = (Emscripten_CursorData *)cursor->driverdata;
+        if (cursor && cursor->internal) {
+            curdata = (Emscripten_CursorData *)cursor->internal;
 
             if (curdata->system_cursor) {
                 /* *INDENT-OFF* */ /* clang-format off */
@@ -181,7 +181,7 @@ static int Emscripten_SetRelativeMouseMode(SDL_bool enabled)
             return -1;
         }
 
-        window_data = window->driverdata;
+        window_data = window->internal;
 
         if (emscripten_request_pointerlock(window_data->canvas_id, 1) >= EMSCRIPTEN_RESULT_SUCCESS) {
             return 0;

--- a/src/video/emscripten/SDL_emscriptenopengles.c
+++ b/src/video/emscripten/SDL_emscriptenopengles.c
@@ -88,7 +88,7 @@ SDL_GLContext Emscripten_GLES_CreateContext(SDL_VideoDevice *_this, SDL_Window *
     if (_this->gl_config.major_version == 3)
         attribs.majorVersion = 2; /* WebGL 2.0 ~= GLES 3.0 */
 
-    window_data = window->driverdata;
+    window_data = window->internal;
 
     if (window_data->gl_context) {
         SDL_SetError("Cannot create multiple webgl contexts per window");
@@ -118,7 +118,7 @@ int Emscripten_GLES_DeleteContext(SDL_VideoDevice *_this, SDL_GLContext context)
 
     /* remove the context from its window */
     for (window = _this->windows; window; window = window->next) {
-        SDL_WindowData *window_data = window->driverdata;
+        SDL_WindowData *window_data = window->internal;
 
         if (window_data->gl_context == context) {
             window_data->gl_context = NULL;
@@ -142,7 +142,7 @@ int Emscripten_GLES_MakeCurrent(SDL_VideoDevice *_this, SDL_Window *window, SDL_
 {
     /* it isn't possible to reuse contexts across canvases */
     if (window && context) {
-        SDL_WindowData *window_data = window->driverdata;
+        SDL_WindowData *window_data = window->internal;
 
         if (context != window_data->gl_context) {
             return SDL_SetError("Cannot make context current to another window");

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -230,7 +230,7 @@ static int Emscripten_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, S
     wdata->window = window;
 
     /* Setup driver data for this window */
-    window->driverdata = wdata;
+    window->internal = wdata;
 
     /* One window, it always has focus */
     SDL_SetMouseFocus(window);
@@ -246,8 +246,8 @@ static void Emscripten_SetWindowSize(SDL_VideoDevice *_this, SDL_Window *window)
 {
     SDL_WindowData *data;
 
-    if (window->driverdata) {
-        data = window->driverdata;
+    if (window->internal) {
+        data = window->internal;
         /* update pixel ratio */
         if (window->flags & SDL_WINDOW_HIGH_PIXEL_DENSITY) {
             data->pixel_ratio = emscripten_get_device_pixel_ratio();
@@ -266,8 +266,8 @@ static void Emscripten_SetWindowSize(SDL_VideoDevice *_this, SDL_Window *window)
 static void Emscripten_GetWindowSizeInPixels(SDL_VideoDevice *_this, SDL_Window *window, int *w, int *h)
 {
     SDL_WindowData *data;
-    if (window->driverdata) {
-        data = window->driverdata;
+    if (window->internal) {
+        data = window->internal;
         *w = SDL_lroundf(window->w * data->pixel_ratio);
         *h = SDL_lroundf(window->h * data->pixel_ratio);
     }
@@ -277,8 +277,8 @@ static void Emscripten_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
     SDL_WindowData *data;
 
-    if (window->driverdata) {
-        data = window->driverdata;
+    if (window->internal) {
+        data = window->internal;
 
         Emscripten_UnregisterEventHandlers(data);
 
@@ -286,8 +286,8 @@ static void Emscripten_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
         emscripten_set_canvas_element_size(data->canvas_id, 0, 0);
         SDL_free(data->canvas_id);
 
-        SDL_free(window->driverdata);
-        window->driverdata = NULL;
+        SDL_free(window->internal);
+        window->internal = NULL;
     }
 }
 
@@ -296,8 +296,8 @@ static int Emscripten_SetWindowFullscreen(SDL_VideoDevice *_this, SDL_Window *wi
     SDL_WindowData *data;
     int res = -1;
 
-    if (window->driverdata) {
-        data = window->driverdata;
+    if (window->internal) {
+        data = window->internal;
 
         if (fullscreen) {
             EmscriptenFullscreenStrategy strategy;

--- a/src/video/haiku/SDL_bframebuffer.cc
+++ b/src/video/haiku/SDL_bframebuffer.cc
@@ -36,7 +36,7 @@ extern "C" {
 #endif
 
 static SDL_INLINE SDL_BWin *_ToBeWin(SDL_Window *window) {
-    return (SDL_BWin *)(window->driverdata);
+    return (SDL_BWin *)(window->internal);
 }
 
 static SDL_INLINE SDL_BLooper *_GetBeLooper() {

--- a/src/video/haiku/SDL_bmodes.cc
+++ b/src/video/haiku/SDL_bmodes.cc
@@ -41,7 +41,7 @@ extern "C" {
 #define WRAP_BMODE 1 /* FIXME: Some debate as to whether this is necessary */
 
 #if WRAP_BMODE
-/* This wrapper is here so that the driverdata can be freed without freeing
+/* This wrapper is here so that the internal can be freed without freeing
    the display_mode structure */
 struct SDL_DisplayModeData {
     display_mode *bmode;
@@ -49,7 +49,7 @@ struct SDL_DisplayModeData {
 #endif
 
 static SDL_INLINE SDL_BWin *_ToBeWin(SDL_Window *window) {
-    return (SDL_BWin *)(window->driverdata);
+    return (SDL_BWin *)(window->internal);
 }
 
 static SDL_INLINE SDL_BLooper *_GetBeLooper() {
@@ -58,9 +58,9 @@ static SDL_INLINE SDL_BLooper *_GetBeLooper() {
 
 static SDL_INLINE display_mode * _ExtractBMode(SDL_DisplayMode *mode) {
 #if WRAP_BMODE
-    return ((SDL_DisplayModeData *)mode->driverdata)->bmode;
+    return mode->internal->bmode;
 #else
-    return (display_mode *)(mode->driverdata);
+    return (display_mode *)mode->internal;
 #endif
 }
 
@@ -173,14 +173,12 @@ static void _BDisplayModeToSdlDisplayMode(display_mode *bmode, SDL_DisplayMode *
     get_refresh_rate(*bmode, &mode->refresh_rate_numerator, &mode->refresh_rate_denominator);
 
 #if WRAP_BMODE
-    SDL_DisplayModeData *data = (SDL_DisplayModeData*)SDL_calloc(1,
-        sizeof(SDL_DisplayModeData));
+    SDL_DisplayModeData *data = (SDL_DisplayModeData*)SDL_calloc(1, sizeof(SDL_DisplayModeData));
     data->bmode = bmode;
 
-    mode->driverdata = data;
-
+    mode->internal = data;
 #else
-    mode->driverdata = bmode;
+    mode->internal = bmode;
 #endif
 
     /* Set the format */

--- a/src/video/haiku/SDL_bopengl.cc
+++ b/src/video/haiku/SDL_bopengl.cc
@@ -36,7 +36,7 @@ extern "C" {
 
 
 static SDL_INLINE SDL_BWin *_ToBeWin(SDL_Window *window) {
-    return (SDL_BWin *)(window->driverdata);
+    return (SDL_BWin *)(window->internal);
 }
 
 static SDL_INLINE SDL_BLooper *_GetBeLooper() {

--- a/src/video/haiku/SDL_bvideo.cc
+++ b/src/video/haiku/SDL_bvideo.cc
@@ -44,7 +44,7 @@ extern "C" {
 #include "../../events/SDL_mouse_c.h"
 
 static SDL_INLINE SDL_BWin *_ToBeWin(SDL_Window *window) {
-    return (SDL_BWin *)(window->driverdata);
+    return (SDL_BWin *)(window->internal);
 }
 
 static SDL_VideoDevice * HAIKU_CreateDevice(void)
@@ -54,7 +54,7 @@ static SDL_VideoDevice * HAIKU_CreateDevice(void)
     /* Initialize all variables that we clean on shutdown */
     device = (SDL_VideoDevice *) SDL_calloc(1, sizeof(SDL_VideoDevice));
 
-    device->driverdata = NULL; /* FIXME: Is this the cause of some of the
+    device->internal = NULL; /* FIXME: Is this the cause of some of the
                                   SDL_Quit() errors? */
 
 /* TODO: Figure out if any initialization needs to go here */
@@ -116,7 +116,7 @@ VideoBootStrap HAIKU_bootstrap = {
 
 void HAIKU_DeleteDevice(SDL_VideoDevice * device)
 {
-    SDL_free(device->driverdata);
+    SDL_free(device->internal);
     SDL_free(device);
 }
 
@@ -155,7 +155,7 @@ static SDL_Cursor * HAIKU_CreateSystemCursor(SDL_SystemCursor id)
 
     SDL_Cursor *cursor = (SDL_Cursor *) SDL_calloc(1, sizeof(*cursor));
     if (cursor) {
-        cursor->driverdata = (void *)new BCursor(cursorId);
+        cursor->internal = (void *)new BCursor(cursorId);
     }
 
     return cursor;
@@ -168,8 +168,8 @@ static SDL_Cursor * HAIKU_CreateDefaultCursor()
 
 static void HAIKU_FreeCursor(SDL_Cursor * cursor)
 {
-    if (cursor->driverdata) {
-        delete (BCursor*) cursor->driverdata;
+    if (cursor->internal) {
+        delete (BCursor*) cursor->internal;
     }
     SDL_free(cursor);
 }
@@ -190,7 +190,7 @@ static SDL_Cursor * HAIKU_CreateCursor(SDL_Surface * surface, int hot_x, int hot
 
     cursor = (SDL_Cursor *) SDL_calloc(1, sizeof(*cursor));
     if (cursor) {
-        cursor->driverdata = (void *)new BCursor(cursorBitmap, BPoint(hot_x, hot_y));
+        cursor->internal = (void *)new BCursor(cursorBitmap, BPoint(hot_x, hot_y));
     } else {
         return NULL;
     }
@@ -207,7 +207,7 @@ static int HAIKU_ShowCursor(SDL_Cursor *cursor)
 	}
 
 	if (cursor) {
-		BCursor *hCursor = (BCursor*)cursor->driverdata;
+		BCursor *hCursor = (BCursor*)cursor->internal;
 		be_app->SetCursor(hCursor);
 	} else {
 		BCursor *hCursor = new BCursor(B_CURSOR_ID_NO_CURSOR);

--- a/src/video/haiku/SDL_bwindow.cc
+++ b/src/video/haiku/SDL_bwindow.cc
@@ -32,7 +32,7 @@ extern "C" {
 #endif
 
 static SDL_INLINE SDL_BWin *_ToBeWin(SDL_Window *window) {
-    return (SDL_BWin *)(window->driverdata);
+    return (SDL_BWin *)(window->internal);
 }
 
 static SDL_INLINE SDL_BLooper *_GetBeLooper() {
@@ -69,7 +69,7 @@ static int _InitWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Propertie
         return -1;
     }
 
-    window->driverdata = (SDL_WindowData *)bwin;
+    window->internal = (SDL_WindowData *)bwin;
     int32 winID = _GetBeLooper()->GetID(window);
     bwin->SetID(winID);
 
@@ -194,7 +194,7 @@ void HAIKU_DestroyWindow(SDL_VideoDevice *_this, SDL_Window * window) {
     _ToBeWin(window)->LockLooper();    /* This MUST be locked */
     _GetBeLooper()->ClearID(_ToBeWin(window));
     _ToBeWin(window)->Quit();
-    window->driverdata = NULL;
+    window->internal = NULL;
 }
 
 #ifdef __cplusplus

--- a/src/video/kmsdrm/SDL_kmsdrmmouse.c
+++ b/src/video/kmsdrm/SDL_kmsdrmmouse.c
@@ -58,12 +58,12 @@ static SDL_Cursor *KMSDRM_CreateDefaultCursor(void)
     return SDL_CreateCursor(default_cdata, default_cmask, DEFAULT_CWIDTH, DEFAULT_CHEIGHT, DEFAULT_CHOTX, DEFAULT_CHOTY);
 }
 
-/* Given a display's driverdata, destroy the cursor BO for it.
+/* Given a display's internal, destroy the cursor BO for it.
    To be called from KMSDRM_DestroyWindow(), as that's where we
-   destroy the driverdata for the window's display. */
+   destroy the internal for the window's display. */
 void KMSDRM_DestroyCursorBO(SDL_VideoDevice *_this, SDL_VideoDisplay *display)
 {
-    SDL_DisplayData *dispdata = display->driverdata;
+    SDL_DisplayData *dispdata = display->internal;
 
     /* Destroy the curso GBM BO. */
     if (dispdata->cursor_bo) {
@@ -73,15 +73,15 @@ void KMSDRM_DestroyCursorBO(SDL_VideoDevice *_this, SDL_VideoDisplay *display)
     }
 }
 
-/* Given a display's driverdata, create the cursor BO for it.
+/* Given a display's internal, create the cursor BO for it.
    To be called from KMSDRM_CreateWindow(), as that's where we
    build a window and assign a display to it. */
 int KMSDRM_CreateCursorBO(SDL_VideoDisplay *display)
 {
 
     SDL_VideoDevice *dev = SDL_GetVideoDevice();
-    SDL_VideoData *viddata = dev->driverdata;
-    SDL_DisplayData *dispdata = display->driverdata;
+    SDL_VideoData *viddata = dev->internal;
+    SDL_DisplayData *dispdata = display->internal;
 
     if (!KMSDRM_gbm_device_is_format_supported(viddata->gbm_dev,
                                                GBM_FORMAT_ARGB8888,
@@ -116,9 +116,9 @@ int KMSDRM_CreateCursorBO(SDL_VideoDisplay *display)
 static int KMSDRM_RemoveCursorFromBO(SDL_VideoDisplay *display)
 {
     int ret = 0;
-    SDL_DisplayData *dispdata = display->driverdata;
+    SDL_DisplayData *dispdata = display->internal;
     SDL_VideoDevice *video_device = SDL_GetVideoDevice();
-    SDL_VideoData *viddata = video_device->driverdata;
+    SDL_VideoData *viddata = video_device->internal;
 
     ret = KMSDRM_drmModeSetCursor(viddata->drm_fd,
                                   dispdata->crtc->crtc_id, 0, 0, 0);
@@ -133,10 +133,10 @@ static int KMSDRM_RemoveCursorFromBO(SDL_VideoDisplay *display)
 /* Dump a cursor buffer to a display's DRM cursor BO.  */
 static int KMSDRM_DumpCursorToBO(SDL_VideoDisplay *display, SDL_Cursor *cursor)
 {
-    SDL_DisplayData *dispdata = display->driverdata;
-    KMSDRM_CursorData *curdata = (KMSDRM_CursorData *)cursor->driverdata;
+    SDL_DisplayData *dispdata = display->internal;
+    KMSDRM_CursorData *curdata = (KMSDRM_CursorData *)cursor->internal;
     SDL_VideoDevice *video_device = SDL_GetVideoDevice();
-    SDL_VideoData *viddata = video_device->driverdata;
+    SDL_VideoData *viddata = video_device->internal;
 
     uint32_t bo_handle;
     size_t bo_stride;
@@ -210,15 +210,15 @@ static void KMSDRM_FreeCursor(SDL_Cursor *cursor)
 
     /* Even if the cursor is not ours, free it. */
     if (cursor) {
-        curdata = (KMSDRM_CursorData *)cursor->driverdata;
+        curdata = (KMSDRM_CursorData *)cursor->internal;
         /* Free cursor buffer */
         if (curdata->buffer) {
             SDL_free(curdata->buffer);
             curdata->buffer = NULL;
         }
         /* Free cursor itself */
-        if (cursor->driverdata) {
-            SDL_free(cursor->driverdata);
+        if (cursor->internal) {
+            SDL_free(cursor->internal);
         }
         SDL_free(cursor);
     }
@@ -269,7 +269,7 @@ static SDL_Cursor *KMSDRM_CreateCursor(SDL_Surface *surface, int hot_x, int hot_
                          surface->format, surface->pixels, surface->pitch,
                          SDL_PIXELFORMAT_ARGB8888, curdata->buffer, surface->w * 4);
 
-    cursor->driverdata = curdata;
+    cursor->internal = curdata;
 
     ret = cursor;
 
@@ -383,7 +383,7 @@ static int KMSDRM_WarpMouse(SDL_Window *window, float x, float y)
 void KMSDRM_InitMouse(SDL_VideoDevice *_this, SDL_VideoDisplay *display)
 {
     SDL_Mouse *mouse = SDL_GetMouse();
-    SDL_DisplayData *dispdata = display->driverdata;
+    SDL_DisplayData *dispdata = display->internal;
 
     mouse->CreateCursor = KMSDRM_CreateCursor;
     mouse->ShowCursor = KMSDRM_ShowCursor;

--- a/src/video/kmsdrm/SDL_kmsdrmopengles.c
+++ b/src/video/kmsdrm/SDL_kmsdrmopengles.c
@@ -54,7 +54,7 @@ int KMSDRM_GLES_LoadLibrary(SDL_VideoDevice *_this, const char *path)
        so gbm dev isn't yet created when this is called, AND we can't alter the
        call order in SDL_CreateWindow(). */
 #if 0
-    NativeDisplayType display = (NativeDisplayType)_this->driverdata->gbm_dev;
+    NativeDisplayType display = (NativeDisplayType)_this->internal->gbm_dev;
     return SDL_EGL_LoadLibrary(_this, path, display, EGL_PLATFORM_GBM_MESA);
 #endif
     return 0;
@@ -86,9 +86,9 @@ SDL_EGL_CreateContext_impl(KMSDRM)
 
 int KMSDRM_GLES_SwapWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *windata = window->driverdata;
+    SDL_WindowData *windata = window->internal;
     SDL_DisplayData *dispdata = SDL_GetDisplayDriverDataForWindow(window);
-    SDL_VideoData *viddata = _this->driverdata;
+    SDL_VideoData *viddata = _this->internal;
     KMSDRM_FBInfo *fb_info;
     int ret = 0;
 

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.h
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.h
@@ -110,9 +110,9 @@ struct SDL_DisplayData
     drmModeCrtc *saved_crtc; /* CRTC to restore on quit */
     SDL_bool saved_vrr;
 
-    /* DRM & GBM cursor stuff lives here, not in an SDL_Cursor's driverdata struct,
+    /* DRM & GBM cursor stuff lives here, not in an SDL_Cursor's internal struct,
        because setting/unsetting up these is done on window creation/destruction,
-       where we may not have an SDL_Cursor at all (so no SDL_Cursor driverdata).
+       where we may not have an SDL_Cursor at all (so no SDL_Cursor internal).
        There's only one cursor GBM BO because we only support one cursor. */
     struct gbm_bo *cursor_bo;
     int cursor_bo_drm_fd;
@@ -126,7 +126,7 @@ struct SDL_WindowData
     SDL_VideoData *viddata;
     /* SDL internals expect EGL surface to be here, and in KMSDRM the GBM surface is
        what supports the EGL surface on the driver side, so all these surfaces and buffers
-       are expected to be here, in the struct pointed by SDL_Window driverdata pointer:
+       are expected to be here, in the struct pointed by SDL_Window internal pointer:
        this one. So don't try to move these to dispdata!  */
     struct gbm_surface *gs;
     struct gbm_bo *bo;

--- a/src/video/n3ds/SDL_n3dsframebuffer.c
+++ b/src/video/n3ds/SDL_n3dsframebuffer.c
@@ -67,7 +67,7 @@ int SDL_N3DS_CreateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window,
 
 int SDL_N3DS_UpdateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, const SDL_Rect *rects, int numrects)
 {
-    SDL_WindowData *drv_data = window->driverdata;
+    SDL_WindowData *drv_data = window->internal;
     SDL_Surface *surface;
     u16 width, height;
     void *framebuffer;

--- a/src/video/n3ds/SDL_n3dstouch.c
+++ b/src/video/n3ds/SDL_n3dstouch.c
@@ -54,7 +54,7 @@ void N3DS_QuitTouch(void)
 
 void N3DS_PollTouch(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *driverdata = (SDL_VideoData *)_this->driverdata;
+    SDL_VideoData *internal = (SDL_VideoData *)_this->internal;
     touchPosition touch;
     SDL_Window *window;
     SDL_VideoDisplay *display;
@@ -63,7 +63,7 @@ void N3DS_PollTouch(SDL_VideoDevice *_this)
     hidTouchRead(&touch);
     pressed = (touch.px != 0 || touch.py != 0);
 
-    display = SDL_GetVideoDisplay(driverdata->touch_display);
+    display = SDL_GetVideoDisplay(internal->touch_display);
     window = display ? display->fullscreen_window : NULL;
 
     if (pressed != was_pressed) {

--- a/src/video/n3ds/SDL_n3dsvideo.c
+++ b/src/video/n3ds/SDL_n3dsvideo.c
@@ -67,7 +67,7 @@ static const struct
 
 static void N3DS_DeleteDevice(SDL_VideoDevice *device)
 {
-    SDL_free(device->driverdata);
+    SDL_free(device->internal);
     SDL_free(device);
 }
 
@@ -89,7 +89,7 @@ static SDL_VideoDevice *N3DS_CreateDevice(void)
         return NULL;
     }
 
-    device->driverdata = phdata;
+    device->internal = phdata;
 
     device->VideoInit = N3DS_VideoInit;
     device->VideoQuit = N3DS_VideoQuit;
@@ -122,13 +122,13 @@ VideoBootStrap N3DS_bootstrap = { N3DSVID_DRIVER_NAME, "N3DS Video Driver", N3DS
 
 static int N3DS_VideoInit(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *driverdata = (SDL_VideoData *)_this->driverdata;
+    SDL_VideoData *internal = (SDL_VideoData *)_this->internal;
 
     gfxInit(GSP_RGBA8_OES, GSP_RGBA8_OES, false);
     hidInit();
 
-    driverdata->top_display = AddN3DSDisplay(GFX_TOP);
-    driverdata->touch_display = AddN3DSDisplay(GFX_BOTTOM);
+    internal->top_display = AddN3DSDisplay(GFX_TOP);
+    internal->touch_display = AddN3DSDisplay(GFX_BOTTOM);
 
     N3DS_InitTouch();
     N3DS_SwkbInit();
@@ -160,12 +160,12 @@ static int AddN3DSDisplay(gfxScreen_t screen)
     mode.h = GSP_SCREEN_WIDTH;
     mode.refresh_rate = 60.0f;
     mode.format = SDL_PIXELFORMAT_RGBA8888;
-    mode.driverdata = modedata;
+    mode.internal = modedata;
     modedata->fmt = GSP_RGBA8_OES;
 
     display.name = (screen == GFX_TOP) ? "N3DS top screen" : "N3DS bottom screen";
     display.desktop_mode = mode;
-    display.driverdata = display_driver_data;
+    display.internal = display_driver_data;
 
     return SDL_AddVideoDisplay(&display, SDL_FALSE);
 }
@@ -181,7 +181,7 @@ static void N3DS_VideoQuit(SDL_VideoDevice *_this)
 
 static int N3DS_GetDisplayModes(SDL_VideoDevice *_this, SDL_VideoDisplay *display)
 {
-    SDL_DisplayData *displaydata = display->driverdata;
+    SDL_DisplayData *displaydata = display->internal;
     SDL_DisplayModeData *modedata;
     SDL_DisplayMode mode;
     int i;
@@ -196,7 +196,7 @@ static int N3DS_GetDisplayModes(SDL_VideoDevice *_this, SDL_VideoDisplay *displa
         mode.h = GSP_SCREEN_WIDTH;
         mode.refresh_rate = 60.0f;
         mode.format = format_map[i].pixfmt;
-        mode.driverdata = modedata;
+        mode.internal = modedata;
         modedata->fmt = format_map[i].gspfmt;
 
         if (!SDL_AddFullscreenDisplayMode(display, &mode)) {
@@ -209,8 +209,8 @@ static int N3DS_GetDisplayModes(SDL_VideoDevice *_this, SDL_VideoDisplay *displa
 
 static int N3DS_SetDisplayMode(SDL_VideoDevice *_this, SDL_VideoDisplay *display, SDL_DisplayMode *mode)
 {
-    SDL_DisplayData *displaydata = display->driverdata;
-    SDL_DisplayModeData *modedata = mode->driverdata;
+    SDL_DisplayData *displaydata = display->internal;
+    SDL_DisplayModeData *modedata = mode->internal;
 
     gfxSetScreenFormat(displaydata->screen, modedata->fmt);
     return 0;
@@ -218,7 +218,7 @@ static int N3DS_SetDisplayMode(SDL_VideoDevice *_this, SDL_VideoDisplay *display
 
 static int N3DS_GetDisplayBounds(SDL_VideoDevice *_this, SDL_VideoDisplay *display, SDL_Rect *rect)
 {
-    SDL_DisplayData *driver_data = display->driverdata;
+    SDL_DisplayData *driver_data = display->internal;
 
     if (!driver_data) {
         return -1;
@@ -240,7 +240,7 @@ static int N3DS_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Pro
     }
     display_data = SDL_GetDisplayDriverDataForWindow(window);
     window_data->screen = display_data->screen;
-    window->driverdata = window_data;
+    window->internal = window_data;
     SDL_SetKeyboardFocus(window);
     return 0;
 }
@@ -250,7 +250,7 @@ static void N3DS_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
     if (!window) {
         return;
     }
-    SDL_free(window->driverdata);
+    SDL_free(window->internal);
 }
 
 #endif /* SDL_VIDEO_DRIVER_N3DS */

--- a/src/video/ngage/SDL_ngageevents.cpp
+++ b/src/video/ngage/SDL_ngageevents.cpp
@@ -44,7 +44,7 @@ int HandleWsEvent(SDL_VideoDevice *_this, const TWsEvent &aWsEvent);
 
 void NGAGE_PumpEvents(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
 
     while (data->NGAGE_WsEventStatus != KRequestPending) {
         data->NGAGE_WsSession.GetEvent(data->NGAGE_WsEvent);
@@ -149,7 +149,7 @@ static SDL_Scancode ConvertScancode(SDL_VideoDevice *_this, int key)
 
 int HandleWsEvent(SDL_VideoDevice *_this, const TWsEvent &aWsEvent)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     int posted = 0;
 
     switch (aWsEvent.Type()) {

--- a/src/video/ngage/SDL_ngageframebuffer.cpp
+++ b/src/video/ngage/SDL_ngageframebuffer.cpp
@@ -46,7 +46,7 @@ void RedrawWindowL(SDL_VideoDevice *_this);
 
 int SDL_NGAGE_CreateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, SDL_PixelFormat *format, void **pixels, int *pitch)
 {
-    SDL_VideoData *phdata = _this->driverdata;
+    SDL_VideoData *phdata = _this->internal;
     SDL_Surface *surface;
     const SDL_PixelFormat surface_format = SDL_PIXELFORMAT_XRGB4444;
     int w, h;
@@ -199,7 +199,7 @@ int GetBpp(TDisplayMode displaymode)
 
 void DrawBackground(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *phdata = _this->driverdata;
+    SDL_VideoData *phdata = _this->internal;
     /* Draw background */
     TUint16 *screenBuffer = (TUint16 *)phdata->NGAGE_FrameBuffer;
     /* Draw black background */
@@ -208,7 +208,7 @@ void DrawBackground(SDL_VideoDevice *_this)
 
 void DirectDraw(SDL_VideoDevice *_this, int numrects, SDL_Rect *rects, TUint16 *screenBuffer)
 {
-    SDL_VideoData *phdata = _this->driverdata;
+    SDL_VideoData *phdata = _this->internal;
     SDL_Surface *screen = (SDL_Surface *)SDL_GetWindowData(_this->windows, NGAGE_SURFACE);
 
     TInt i;
@@ -333,7 +333,7 @@ void DirectDraw(SDL_VideoDevice *_this, int numrects, SDL_Rect *rects, TUint16 *
 
 void DirectUpdate(SDL_VideoDevice *_this, int numrects, SDL_Rect *rects)
 {
-    SDL_VideoData *phdata = _this->driverdata;
+    SDL_VideoData *phdata = _this->internal;
 
     if (!phdata->NGAGE_IsWindowFocused) {
         SDL_PauseAudio(1);
@@ -368,7 +368,7 @@ void DirectUpdate(SDL_VideoDevice *_this, int numrects, SDL_Rect *rects)
 
 void RedrawWindowL(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *phdata = _this->driverdata;
+    SDL_VideoData *phdata = _this->internal;
     SDL_Surface *screen = (SDL_Surface *)SDL_GetWindowData(_this->windows, NGAGE_SURFACE);
 
     int w = screen->w;

--- a/src/video/ngage/SDL_ngagevideo.cpp
+++ b/src/video/ngage/SDL_ngagevideo.cpp
@@ -54,7 +54,7 @@ static void NGAGE_VideoQuit(SDL_VideoDevice *_this);
 
 static void NGAGE_DeleteDevice(SDL_VideoDevice *device)
 {
-    SDL_VideoData *phdata = device->driverdata;
+    SDL_VideoData *phdata = device->internal;
 
     if (phdata) {
         /* Free Epoc resources */
@@ -129,7 +129,7 @@ static SDL_VideoDevice *NGAGE_CreateDevice(void)
     device->DestroyWindow = NGAGE_DestroyWindow;
 
     /* N-Gage specific data */
-    device->driverdata = phdata;
+    device->internal = phdata;
 
     return device;
 }

--- a/src/video/ngage/SDL_ngagewindow.cpp
+++ b/src/video/ngage/SDL_ngagewindow.cpp
@@ -40,7 +40,7 @@ int NGAGE_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Propertie
         return -1;
     }
 
-    window->driverdata = ngage_window;
+    window->internal = ngage_window;
 
     if (window->x == SDL_WINDOWPOS_UNDEFINED) {
         window->x = 0;
@@ -59,13 +59,13 @@ int NGAGE_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Propertie
 
 void NGAGE_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    NGAGE_Window *ngage_window = (NGAGE_Window *)window->driverdata;
+    NGAGE_Window *ngage_window = (NGAGE_Window *)window->internal;
 
     if (ngage_window) {
         SDL_free(ngage_window);
     }
 
-    window->driverdata = NULL;
+    window->internal = NULL;
 }
 
 /*****************************************************************************/
@@ -74,7 +74,7 @@ void NGAGE_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
 
 void DisableKeyBlocking(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *phdata = _this->driverdata;
+    SDL_VideoData *phdata = _this->internal;
     TRawEvent event;
 
     event.Set((TRawEvent::TType) /*EDisableKeyBlock*/ 51);
@@ -83,7 +83,7 @@ void DisableKeyBlocking(SDL_VideoDevice *_this)
 
 void ConstructWindowL(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *phdata = _this->driverdata;
+    SDL_VideoData *phdata = _this->internal;
     TInt error;
 
     error = phdata->NGAGE_WsSession.Connect();

--- a/src/video/offscreen/SDL_offscreenopengles.c
+++ b/src/video/offscreen/SDL_offscreenopengles.c
@@ -56,7 +56,7 @@ int OFFSCREEN_GLES_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 
 SDL_GLContext OFFSCREEN_GLES_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *offscreen_window = window->driverdata;
+    SDL_WindowData *offscreen_window = window->internal;
 
     SDL_GLContext context;
     context = SDL_EGL_CreateContext(_this, offscreen_window->egl_surface);
@@ -67,7 +67,7 @@ SDL_GLContext OFFSCREEN_GLES_CreateContext(SDL_VideoDevice *_this, SDL_Window *w
 int OFFSCREEN_GLES_MakeCurrent(SDL_VideoDevice *_this, SDL_Window *window, SDL_GLContext context)
 {
     if (window) {
-        EGLSurface egl_surface = window->driverdata->egl_surface;
+        EGLSurface egl_surface = window->internal->egl_surface;
         return SDL_EGL_MakeCurrent(_this, egl_surface, context);
     } else {
         return SDL_EGL_MakeCurrent(_this, NULL, NULL);
@@ -76,7 +76,7 @@ int OFFSCREEN_GLES_MakeCurrent(SDL_VideoDevice *_this, SDL_Window *window, SDL_G
 
 int OFFSCREEN_GLES_SwapWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *offscreen_wind = window->driverdata;
+    SDL_WindowData *offscreen_wind = window->internal;
 
     return SDL_EGL_SwapBuffers(_this, offscreen_wind->egl_surface);
 }

--- a/src/video/offscreen/SDL_offscreenwindow.c
+++ b/src/video/offscreen/SDL_offscreenwindow.c
@@ -36,7 +36,7 @@ int OFFSCREEN_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prope
         return -1;
     }
 
-    window->driverdata = offscreen_window;
+    window->internal = offscreen_window;
 
     if (window->x == SDL_WINDOWPOS_UNDEFINED) {
         window->x = 0;
@@ -71,7 +71,7 @@ int OFFSCREEN_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prope
 
 void OFFSCREEN_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *offscreen_window = window->driverdata;
+    SDL_WindowData *offscreen_window = window->internal;
 
     if (offscreen_window) {
 #ifdef SDL_VIDEO_OPENGL_EGL
@@ -80,7 +80,7 @@ void OFFSCREEN_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
         SDL_free(offscreen_window);
     }
 
-    window->driverdata = NULL;
+    window->internal = NULL;
 }
 
 void OFFSCREEN_SetWindowSize(SDL_VideoDevice *_this, SDL_Window *window)

--- a/src/video/psp/SDL_pspgl.c
+++ b/src/video/psp/SDL_pspgl.c
@@ -70,7 +70,7 @@ static EGLint height = 272;
 SDL_GLContext PSP_GL_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
 {
 
-    SDL_WindowData *wdata = window->driverdata;
+    SDL_WindowData *wdata = window->internal;
 
     EGLint attribs[32];
     EGLDisplay display;
@@ -167,7 +167,7 @@ int PSP_GL_SwapWindow(SDL_VideoDevice *_this, SDL_Window *window)
 
 int PSP_GL_DeleteContext(SDL_VideoDevice *_this, SDL_GLContext context)
 {
-    SDL_VideoData *phdata = _this->driverdata;
+    SDL_VideoData *phdata = _this->internal;
     EGLBoolean status;
 
     if (phdata->egl_initialized != SDL_TRUE) {

--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -44,7 +44,7 @@ static SDL_bool PSP_initialized = SDL_FALSE;
 
 static void PSP_Destroy(SDL_VideoDevice *device)
 {
-    SDL_free(device->driverdata);
+    SDL_free(device->internal);
     SDL_free(device);
 }
 
@@ -75,7 +75,7 @@ static SDL_VideoDevice *PSP_Create()
     }
     device->gl_data = gldata;
 
-    device->driverdata = phdata;
+    device->internal = phdata;
 
     phdata->egl_initialized = SDL_TRUE;
 
@@ -204,7 +204,7 @@ int PSP_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesI
     }
 
     /* Setup driver data for this window */
-    window->driverdata = wdata;
+    window->internal = wdata;
 
     SDL_SetKeyboardFocus(window);
 

--- a/src/video/qnx/SDL_qnxgl.c
+++ b/src/video/qnx/SDL_qnxgl.c
@@ -165,7 +165,7 @@ SDL_FunctionPointer glGetProcAddress(SDL_VideoDevice *_this, const char *proc)
  */
 SDL_GLContext glCreateContext(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    window_impl_t   *impl = (window_impl_t *)window->driverdata;
+    window_impl_t   *impl = (window_impl_t *)window->internal;
     EGLContext      context;
     EGLSurface      surface;
 
@@ -228,7 +228,7 @@ int glSetSwapInterval(SDL_VideoDevice *_this, int interval)
 int glSwapWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
     /* !!! FIXME: should we migrate this all over to use SDL_egl.c? */
-    window_impl_t   *impl = (window_impl_t *)window->driverdata;
+    window_impl_t   *impl = (window_impl_t *)window->internal;
     return eglSwapBuffers(egl_disp, impl->surface) == EGL_TRUE ? 0 : -1;
 }
 
@@ -245,7 +245,7 @@ int glMakeCurrent(SDL_VideoDevice *_this, SDL_Window *window, SDL_GLContext cont
     EGLSurface      surface = NULL;
 
     if (window) {
-        impl = (window_impl_t *)window->driverdata;
+        impl = (window_impl_t *)window->internal;
         surface = impl->surface;
     }
 

--- a/src/video/qnx/SDL_qnxvideo.c
+++ b/src/video/qnx/SDL_qnxvideo.c
@@ -130,7 +130,7 @@ static int createWindow(SDL_VideoDevice *_this, SDL_Window *window)
         goto fail;
     }
 
-    window->driverdata = impl;
+    window->internal = impl;
     return 0;
 
 fail:
@@ -155,7 +155,7 @@ fail:
 static int createWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window * window, SDL_PixelFormat * format,
                         void ** pixels, int *pitch)
 {
-    window_impl_t   *impl = (window_impl_t *)window->driverdata;
+    window_impl_t   *impl = (window_impl_t *)window->internal;
     screen_buffer_t buffer;
 
     // Get a pointer to the buffer's memory.
@@ -190,7 +190,7 @@ static int createWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window * window, 
 static int updateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, const SDL_Rect *rects,
                         int numrects)
 {
-    window_impl_t   *impl = (window_impl_t *)window->driverdata;
+    window_impl_t   *impl = (window_impl_t *)window->internal;
     screen_buffer_t buffer;
 
     if (screen_get_window_property_pv(impl->window, SCREEN_PROPERTY_BUFFERS,
@@ -243,7 +243,7 @@ static void pumpEvents(SDL_VideoDevice *_this)
  */
 static void setWindowSize(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    window_impl_t   *impl = (window_impl_t *)window->driverdata;
+    window_impl_t   *impl = (window_impl_t *)window->internal;
     int             size[2];
 
     size[0] = window->floating.w;
@@ -260,7 +260,7 @@ static void setWindowSize(SDL_VideoDevice *_this, SDL_Window *window)
  */
 static void showWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    window_impl_t   *impl = (window_impl_t *)window->driverdata;
+    window_impl_t   *impl = (window_impl_t *)window->internal;
     const int       visible = 1;
 
     screen_set_window_property_iv(impl->window, SCREEN_PROPERTY_VISIBLE,
@@ -274,7 +274,7 @@ static void showWindow(SDL_VideoDevice *_this, SDL_Window *window)
  */
 static void hideWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    window_impl_t   *impl = (window_impl_t *)window->driverdata;
+    window_impl_t   *impl = (window_impl_t *)window->internal;
     const int       visible = 0;
 
     screen_set_window_property_iv(impl->window, SCREEN_PROPERTY_VISIBLE,
@@ -288,11 +288,11 @@ static void hideWindow(SDL_VideoDevice *_this, SDL_Window *window)
  */
 static void destroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    window_impl_t   *impl = (window_impl_t *)window->driverdata;
+    window_impl_t   *impl = (window_impl_t *)window->internal;
 
     if (impl) {
         screen_destroy_window(impl->window);
-        window->driverdata = NULL;
+        window->internal = NULL;
     }
 }
 
@@ -318,7 +318,7 @@ static SDL_VideoDevice *createDevice()
         return NULL;
     }
 
-    device->driverdata = NULL;
+    device->internal = NULL;
     device->VideoInit = videoInit;
     device->VideoQuit = videoQuit;
     device->CreateSDLWindow = createWindow;

--- a/src/video/raspberry/SDL_rpimouse.c
+++ b/src/video/raspberry/SDL_rpimouse.c
@@ -92,7 +92,7 @@ static SDL_Cursor *RPI_CreateCursor(SDL_Surface *surface, int hot_x, int hot_y)
     ret = vc_dispmanx_resource_write_data(curdata->resource, VC_IMAGE_ARGB8888, surface->pitch, surface->pixels, &dst_rect);
     SDL_assert(ret == DISPMANX_SUCCESS);
 
-    cursor->driverdata = curdata;
+    cursor->internal = curdata;
 
     return cursor;
 }
@@ -117,7 +117,7 @@ static int RPI_ShowCursor(SDL_Cursor *cursor)
 
     if (cursor != global_cursor) {
         if (global_cursor) {
-            curdata = (RPI_CursorData *)global_cursor->driverdata;
+            curdata = (RPI_CursorData *)global_cursor->internal;
             if (curdata && curdata->element > DISPMANX_NO_HANDLE) {
                 update = vc_dispmanx_update_start(0);
                 SDL_assert(update);
@@ -135,7 +135,7 @@ static int RPI_ShowCursor(SDL_Cursor *cursor)
         return 0;
     }
 
-    curdata = (RPI_CursorData *)cursor->driverdata;
+    curdata = (RPI_CursorData *)cursor->internal;
     if (!curdata) {
         return -1;
     }
@@ -187,7 +187,7 @@ static void RPI_FreeCursor(SDL_Cursor *cursor)
     RPI_CursorData *curdata;
 
     if (cursor) {
-        curdata = (RPI_CursorData *)cursor->driverdata;
+        curdata = (RPI_CursorData *)cursor->internal;
 
         if (curdata) {
             if (curdata->element != DISPMANX_NO_HANDLE) {
@@ -204,7 +204,7 @@ static void RPI_FreeCursor(SDL_Cursor *cursor)
                 SDL_assert(ret == DISPMANX_SUCCESS);
             }
 
-            SDL_free(cursor->driverdata);
+            SDL_free(cursor->internal);
         }
         SDL_free(cursor);
         if (cursor == global_cursor) {
@@ -222,11 +222,11 @@ static int RPI_WarpMouseGlobalGraphically(float x, float y)
     VC_RECT_T src_rect;
     SDL_Mouse *mouse = SDL_GetMouse();
 
-    if (!mouse || !mouse->cur_cursor || !mouse->cur_cursor->driverdata) {
+    if (!mouse || !mouse->cur_cursor || !mouse->cur_cursor->internal) {
         return 0;
     }
 
-    curdata = (RPI_CursorData *)mouse->cur_cursor->driverdata;
+    curdata = (RPI_CursorData *)mouse->cur_cursor->internal;
     if (curdata->element == DISPMANX_NO_HANDLE) {
         return 0;
     }
@@ -271,7 +271,7 @@ static int RPI_WarpMouseGlobal(float x, float y)
 {
     SDL_Mouse *mouse = SDL_GetMouse();
 
-    if (!mouse || !mouse->cur_cursor || !mouse->cur_cursor->driverdata) {
+    if (!mouse || !mouse->cur_cursor || !mouse->cur_cursor->internal) {
         return 0;
     }
 

--- a/src/video/raspberry/SDL_rpimouse.h
+++ b/src/video/raspberry/SDL_rpimouse.h
@@ -33,7 +33,7 @@ struct _RPI_CursorData
     int w, h;
 };
 
-#define SDL_RPI_CURSORDATA(curs) RPI_CursorData *curdata = (RPI_CursorData *)((curs) ? (curs)->driverdata : NULL)
+#define SDL_RPI_CURSORDATA(curs) RPI_CursorData *curdata = (RPI_CursorData *)((curs) ? (curs)->internal : NULL)
 
 extern void RPI_InitMouse(SDL_VideoDevice *_this);
 extern void RPI_QuitMouse(SDL_VideoDevice *_this);

--- a/src/video/raspberry/SDL_rpiopengles.c
+++ b/src/video/raspberry/SDL_rpiopengles.c
@@ -41,7 +41,7 @@ int RPI_GLES_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 
 int RPI_GLES_SwapWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *wdata = window->driverdata;
+    SDL_WindowData *wdata = window->internal;
 
     if (!(_this->egl_data->eglSwapBuffers(_this->egl_data->egl_display, wdata->egl_surface))) {
         SDL_LogError(SDL_LOG_CATEGORY_VIDEO, "eglSwapBuffers failed.");

--- a/src/video/raspberry/SDL_rpivideo.c
+++ b/src/video/raspberry/SDL_rpivideo.c
@@ -47,7 +47,7 @@
 
 static void RPI_Destroy(SDL_VideoDevice *device)
 {
-    SDL_free(device->driverdata);
+    SDL_free(device->internal);
     SDL_free(device);
 }
 
@@ -93,7 +93,7 @@ static SDL_VideoDevice *RPI_Create()
         return NULL;
     }
 
-    device->driverdata = phdata;
+    device->internal = phdata;
 
     /* Setup amount of available displays */
     device->num_displays = 0;
@@ -181,7 +181,7 @@ static void AddDispManXDisplay(const int display_id)
 
     data->dispman_display = handle;
 
-    display.driverdata = data;
+    display.internal = data;
 
     SDL_AddVideoDisplay(&display, SDL_FALSE);
 }
@@ -244,7 +244,7 @@ int RPI_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesI
         return -1;
     }
     display = SDL_GetVideoDisplayForWindow(window);
-    displaydata = display->driverdata;
+    displaydata = display->internal;
 
     /* Windows have one size for now */
     window->w = display->desktop_mode.w;
@@ -305,7 +305,7 @@ int RPI_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesI
     }
 
     /* Setup driver data for this window */
-    window->driverdata = wdata;
+    window->internal = wdata;
 
     /* One window, it always has focus */
     SDL_SetMouseFocus(window);
@@ -317,7 +317,7 @@ int RPI_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesI
 
 void RPI_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     SDL_DisplayData *displaydata = SDL_GetDisplayDriverDataForWindow(window);
 
     if (data) {
@@ -339,7 +339,7 @@ void RPI_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
         }
 #endif
         SDL_free(data);
-        window->driverdata = NULL;
+        window->internal = NULL;
     }
 }
 

--- a/src/video/riscos/SDL_riscosframebuffer.c
+++ b/src/video/riscos/SDL_riscosframebuffer.c
@@ -32,7 +32,7 @@
 
 int RISCOS_CreateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, SDL_PixelFormat *format, void **pixels, int *pitch)
 {
-    SDL_WindowData *driverdata = window->driverdata;
+    SDL_WindowData *internal = window->internal;
     const char *sprite_name = "display";
     unsigned int sprite_mode;
     _kernel_oserror *error;
@@ -50,7 +50,7 @@ int RISCOS_CreateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, S
     mode = SDL_GetCurrentDisplayMode(SDL_GetDisplayForWindow(window));
     if ((SDL_ISPIXELFORMAT_PACKED(mode->format) || SDL_ISPIXELFORMAT_ARRAY(mode->format))) {
         *format = mode->format;
-        sprite_mode = (unsigned int)mode->driverdata;
+        sprite_mode = (unsigned int)mode->internal;
     } else {
         *format = SDL_PIXELFORMAT_XBGR8888;
         sprite_mode = (1 | (90 << 1) | (90 << 14) | (6 << 27));
@@ -61,19 +61,19 @@ int RISCOS_CreateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, S
 
     /* Allocate the sprite area */
     size = sizeof(sprite_area) + sizeof(sprite_header) + ((*pitch) * h);
-    driverdata->fb_area = SDL_malloc(size);
-    if (!driverdata->fb_area) {
+    internal->fb_area = SDL_malloc(size);
+    if (!internal->fb_area) {
         return -1;
     }
 
-    driverdata->fb_area->size = size;
-    driverdata->fb_area->count = 0;
-    driverdata->fb_area->start = 16;
-    driverdata->fb_area->end = 16;
+    internal->fb_area->size = size;
+    internal->fb_area->count = 0;
+    internal->fb_area->start = 16;
+    internal->fb_area->end = 16;
 
     /* Create the actual image */
     regs.r[0] = 256 + 15;
-    regs.r[1] = (int)driverdata->fb_area;
+    regs.r[1] = (int)internal->fb_area;
     regs.r[2] = (int)sprite_name;
     regs.r[3] = 0;
     regs.r[4] = w;
@@ -81,25 +81,25 @@ int RISCOS_CreateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, S
     regs.r[6] = sprite_mode;
     error = _kernel_swi(OS_SpriteOp, &regs, &regs);
     if (error) {
-        SDL_free(driverdata->fb_area);
+        SDL_free(internal->fb_area);
         return SDL_SetError("Unable to create sprite: %s (%i)", error->errmess, error->errnum);
     }
 
-    driverdata->fb_sprite = (sprite_header *)(((Uint8 *)driverdata->fb_area) + driverdata->fb_area->start);
-    *pixels = ((Uint8 *)driverdata->fb_sprite) + driverdata->fb_sprite->image_offset;
+    internal->fb_sprite = (sprite_header *)(((Uint8 *)internal->fb_area) + internal->fb_area->start);
+    *pixels = ((Uint8 *)internal->fb_sprite) + internal->fb_sprite->image_offset;
 
     return 0;
 }
 
 int RISCOS_UpdateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, const SDL_Rect *rects, int numrects)
 {
-    SDL_WindowData *driverdata = window->driverdata;
+    SDL_WindowData *internal = window->internal;
     _kernel_swi_regs regs;
     _kernel_oserror *error;
 
     regs.r[0] = 512 + 52;
-    regs.r[1] = (int)driverdata->fb_area;
-    regs.r[2] = (int)driverdata->fb_sprite;
+    regs.r[1] = (int)internal->fb_area;
+    regs.r[2] = (int)internal->fb_sprite;
     regs.r[3] = 0; /* window->x << 1; */
     regs.r[4] = 0; /* window->y << 1; */
     regs.r[5] = 0x50;
@@ -115,13 +115,13 @@ int RISCOS_UpdateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, c
 
 void RISCOS_DestroyWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *driverdata = window->driverdata;
+    SDL_WindowData *internal = window->internal;
 
-    if (driverdata->fb_area) {
-        SDL_free(driverdata->fb_area);
-        driverdata->fb_area = NULL;
+    if (internal->fb_area) {
+        SDL_free(internal->fb_area);
+        internal->fb_area = NULL;
     }
-    driverdata->fb_sprite = NULL;
+    internal->fb_sprite = NULL;
 }
 
 #endif /* SDL_VIDEO_DRIVER_RISCOS */

--- a/src/video/riscos/SDL_riscosmodes.c
+++ b/src/video/riscos/SDL_riscosmodes.c
@@ -218,8 +218,8 @@ int RISCOS_InitModes(SDL_VideoDevice *_this)
     }
 
     size = measure_mode_block(current_mode);
-    mode.driverdata = copy_memory(current_mode, size, size);
-    if (!mode.driverdata) {
+    mode.internal = copy_memory(current_mode, size, size);
+    if (!mode.internal) {
         return -1;
     }
 
@@ -267,14 +267,14 @@ int RISCOS_GetDisplayModes(SDL_VideoDevice *_this, SDL_VideoDisplay *display)
             continue;
         }
 
-        mode.driverdata = convert_mode_block(pos + 4);
-        if (!mode.driverdata) {
+        mode.internal = convert_mode_block(pos + 4);
+        if (!mode.internal) {
             SDL_free(block);
             return -1;
         }
 
         if (!SDL_AddFullscreenDisplayMode(display, &mode)) {
-            SDL_free(mode.driverdata);
+            SDL_free(mode.internal);
         }
     }
 
@@ -290,7 +290,7 @@ int RISCOS_SetDisplayMode(SDL_VideoDevice *_this, SDL_VideoDisplay *display, SDL
     int i;
 
     regs.r[0] = 0;
-    regs.r[1] = (int)mode->driverdata;
+    regs.r[1] = (int)mode->internal;
     error = _kernel_swi(OS_ScreenMode, &regs, &regs);
     if (error) {
         return SDL_SetError("Unable to set the current screen mode: %s (%i)", error->errmess, error->errnum);

--- a/src/video/riscos/SDL_riscosmouse.c
+++ b/src/video/riscos/SDL_riscosmouse.c
@@ -33,7 +33,7 @@ static SDL_Cursor *RISCOS_CreateDefaultCursor()
     SDL_Cursor *cursor = SDL_calloc(1, sizeof(*cursor));
     if (cursor) {
         /* NULL is used to indicate the default cursor */
-        cursor->driverdata = NULL;
+        cursor->internal = NULL;
     }
 
     return cursor;

--- a/src/video/riscos/SDL_riscosvideo.c
+++ b/src/video/riscos/SDL_riscosvideo.c
@@ -46,7 +46,7 @@ static void RISCOS_VideoQuit(SDL_VideoDevice *_this);
 
 static void RISCOS_DeleteDevice(SDL_VideoDevice *device)
 {
-    SDL_free(device->driverdata);
+    SDL_free(device->internal);
     SDL_free(device);
 }
 
@@ -68,7 +68,7 @@ static SDL_VideoDevice *RISCOS_CreateDevice(void)
         return NULL;
     }
 
-    device->driverdata = data;
+    device->internal = data;
 
     /* Set the function pointers */
     device->VideoInit = RISCOS_VideoInit;
@@ -101,7 +101,7 @@ VideoBootStrap RISCOS_bootstrap = {
 
 static int RISCOS_VideoInit(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
 
     if (RISCOS_InitEvents(_this) < 0) {
         return -1;

--- a/src/video/riscos/SDL_riscoswindow.c
+++ b/src/video/riscos/SDL_riscoswindow.c
@@ -30,31 +30,27 @@
 
 int RISCOS_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesID create_props)
 {
-    SDL_WindowData *driverdata;
+    SDL_WindowData *data;
 
-    driverdata = (SDL_WindowData *)SDL_calloc(1, sizeof(*driverdata));
-    if (!driverdata) {
+    data = (SDL_WindowData *)SDL_calloc(1, sizeof(*data));
+    if (!data) {
         return -1;
     }
-    driverdata->window = window;
+    data->window = window;
 
     SDL_SetMouseFocus(window);
 
     /* All done! */
-    window->driverdata = driverdata;
+    window->internal = data;
     return 0;
 }
 
 void RISCOS_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *driverdata = window->driverdata;
-
-    if (!driverdata) {
-        return;
+    if (window->internal) {
+        SDL_free(window->internal);
+        window->internal = NULL;
     }
-
-    SDL_free(driverdata);
-    window->driverdata = NULL;
 }
 
 #endif /* SDL_VIDEO_DRIVER_RISCOS */

--- a/src/video/uikit/SDL_uikitappdelegate.m
+++ b/src/video/uikit/SDL_uikitappdelegate.m
@@ -491,7 +491,7 @@ static UIImage *SDL_LoadLaunchImageNamed(NSString *name, int screenh)
     if (_this) {
         SDL_Window *window = NULL;
         for (window = _this->windows; window != NULL; window = window->next) {
-            SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *)window->driverdata;
+            SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *)window->internal;
             if (data != nil) {
                 return data.uiwindow;
             }

--- a/src/video/uikit/SDL_uikitclipboard.m
+++ b/src/video/uikit/SDL_uikitclipboard.m
@@ -73,7 +73,7 @@ void UIKit_InitClipboard(SDL_VideoDevice *_this)
 {
 #ifndef SDL_PLATFORM_TVOS
     @autoreleasepool {
-        SDL_UIKitVideoData *data = (__bridge SDL_UIKitVideoData *)_this->driverdata;
+        SDL_UIKitVideoData *data = (__bridge SDL_UIKitVideoData *)_this->internal;
         NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
 
         id observer = [center addObserverForName:UIPasteboardChangedNotification
@@ -91,7 +91,7 @@ void UIKit_InitClipboard(SDL_VideoDevice *_this)
 void UIKit_QuitClipboard(SDL_VideoDevice *_this)
 {
     @autoreleasepool {
-        SDL_UIKitVideoData *data = (__bridge SDL_UIKitVideoData *)_this->driverdata;
+        SDL_UIKitVideoData *data = (__bridge SDL_UIKitVideoData *)_this->internal;
 
         if (data.pasteboardObserver != nil) {
             [[NSNotificationCenter defaultCenter] removeObserver:data.pasteboardObserver];

--- a/src/video/uikit/SDL_uikitmessagebox.m
+++ b/src/video/uikit/SDL_uikitmessagebox.m
@@ -93,7 +93,7 @@ static BOOL UIKit_ShowMessageBoxAlertController(const SDL_MessageBoxData *messag
     }
 
     if (messageboxdata->window) {
-        SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *)messageboxdata->window->driverdata;
+        SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *)messageboxdata->window->internal;
         window = data.uiwindow;
     }
 

--- a/src/video/uikit/SDL_uikitmetalview.m
+++ b/src/video/uikit/SDL_uikitmetalview.m
@@ -75,7 +75,7 @@
 SDL_MetalView UIKit_Metal_CreateView(SDL_VideoDevice *_this, SDL_Window *window)
 {
     @autoreleasepool {
-        SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *)window->driverdata;
+        SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *)window->internal;
         CGFloat scale = 1.0;
         SDL_uikitmetalview *metalview;
 

--- a/src/video/uikit/SDL_uikitmodes.m
+++ b/src/video/uikit/SDL_uikitmodes.m
@@ -114,7 +114,7 @@ static int UIKit_AllocateDisplayModeData(SDL_DisplayMode *mode,
         data.uiscreenmode = uiscreenmode;
     }
 
-    mode->driverdata = (void *)CFBridgingRetain(data);
+    mode->internal = (void *)CFBridgingRetain(data);
 
     return 0;
 }
@@ -122,9 +122,9 @@ static int UIKit_AllocateDisplayModeData(SDL_DisplayMode *mode,
 
 static void UIKit_FreeDisplayModeData(SDL_DisplayMode *mode)
 {
-    if (mode->driverdata != NULL) {
-        CFRelease(mode->driverdata);
-        mode->driverdata = NULL;
+    if (mode->internal != NULL) {
+        CFRelease(mode->internal);
+        mode->internal = NULL;
     }
 }
 
@@ -266,7 +266,7 @@ int UIKit_AddDisplay(UIScreen *uiscreen, SDL_bool send_event)
         return SDL_OutOfMemory();
     }
 
-    display.driverdata = (SDL_DisplayData *)CFBridgingRetain(data);
+    display.internal = (SDL_DisplayData *)CFBridgingRetain(data);
     if (SDL_AddVideoDisplay(&display, send_event) == 0) {
         return -1;
     }
@@ -298,7 +298,7 @@ int UIKit_AddDisplay(SDL_bool send_event){
         return SDL_OutOfMemory();
     }
 
-    display.driverdata = (SDL_DisplayData *)CFBridgingRetain(data);
+    display.internal = (SDL_DisplayData *)CFBridgingRetain(data);
     if (SDL_AddVideoDisplay(&display, send_event) == 0) {
         return -1;
     }
@@ -317,11 +317,11 @@ void UIKit_DelDisplay(UIScreen *uiscreen, SDL_bool send_event)
     if (displays) {
         for (i = 0; displays[i]; ++i) {
             SDL_VideoDisplay *display = SDL_GetVideoDisplay(displays[i]);
-            SDL_UIKitDisplayData *data = (__bridge SDL_UIKitDisplayData *)display->driverdata;
+            SDL_UIKitDisplayData *data = (__bridge SDL_UIKitDisplayData *)display->internal;
 
             if (data && data.uiscreen == uiscreen) {
-                CFRelease(display->driverdata);
-                display->driverdata = NULL;
+                CFRelease(display->internal);
+                display->internal = NULL;
                 SDL_DelVideoDisplay(displays[i], send_event);
                 break;
             }
@@ -372,7 +372,7 @@ int UIKit_GetDisplayModes(SDL_VideoDevice *_this, SDL_VideoDisplay *display)
 {
 #ifndef SDL_PLATFORM_VISIONOS
     @autoreleasepool {
-        SDL_UIKitDisplayData *data = (__bridge SDL_UIKitDisplayData *)display->driverdata;
+        SDL_UIKitDisplayData *data = (__bridge SDL_UIKitDisplayData *)display->internal;
 
         SDL_bool isLandscape = UIKit_IsDisplayLandscape(data.uiscreen);
         SDL_bool addRotation = (data.uiscreen == [UIScreen mainScreen]);
@@ -408,10 +408,10 @@ int UIKit_SetDisplayMode(SDL_VideoDevice *_this, SDL_VideoDisplay *display, SDL_
 {
 #ifndef SDL_PLATFORM_VISIONOS
     @autoreleasepool {
-        SDL_UIKitDisplayData *data = (__bridge SDL_UIKitDisplayData *)display->driverdata;
+        SDL_UIKitDisplayData *data = (__bridge SDL_UIKitDisplayData *)display->internal;
 
 #ifndef SDL_PLATFORM_TVOS
-        SDL_UIKitDisplayModeData *modedata = (__bridge SDL_UIKitDisplayModeData *)mode->driverdata;
+        SDL_UIKitDisplayModeData *modedata = (__bridge SDL_UIKitDisplayModeData *)mode->internal;
         [data.uiscreen setCurrentMode:modedata.uiscreenmode];
 #endif
 
@@ -437,7 +437,7 @@ int UIKit_SetDisplayMode(SDL_VideoDevice *_this, SDL_VideoDisplay *display, SDL_
 int UIKit_GetDisplayUsableBounds(SDL_VideoDevice *_this, SDL_VideoDisplay *display, SDL_Rect *rect)
 {
     @autoreleasepool {
-        SDL_UIKitDisplayData *data = (__bridge SDL_UIKitDisplayData *)display->driverdata;
+        SDL_UIKitDisplayData *data = (__bridge SDL_UIKitDisplayData *)display->internal;
 #ifdef SDL_PLATFORM_VISIONOS
         CGRect frame = CGRectMake(0, 0, SDL_XR_SCREENWIDTH, SDL_XR_SCREENHEIGHT);
 #else
@@ -477,9 +477,9 @@ void UIKit_QuitModes(SDL_VideoDevice *_this)
                 UIKit_FreeDisplayModeData(mode);
             }
 
-            if (display->driverdata != NULL) {
-                CFRelease(display->driverdata);
-                display->driverdata = NULL;
+            if (display->internal != NULL) {
+                CFRelease(display->internal);
+                display->internal = NULL;
             }
         }
     }

--- a/src/video/uikit/SDL_uikitopengles.m
+++ b/src/video/uikit/SDL_uikitopengles.m
@@ -113,7 +113,7 @@ SDL_GLContext UIKit_GL_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
     @autoreleasepool {
         SDLEAGLContext *context = nil;
         SDL_uikitopenglview *view;
-        SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *)window->driverdata;
+        SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *)window->internal;
         CGRect frame = UIKit_ComputeViewFrame(window, data.uiwindow.screen);
         EAGLSharegroup *sharegroup = nil;
         CGFloat scale = 1.0;
@@ -184,7 +184,7 @@ SDL_GLContext UIKit_GL_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
             return NULL;
         }
 
-        /* We return a +1'd context. The window's driverdata owns the view (via
+        /* We return a +1'd context. The window's internal owns the view (via
          * MakeCurrent.) */
         return (SDL_GLContext)CFBridgingRetain(context);
     }

--- a/src/video/uikit/SDL_uikitvideo.m
+++ b/src/video/uikit/SDL_uikitvideo.m
@@ -53,8 +53,8 @@ static void UIKit_VideoQuit(SDL_VideoDevice *_this);
 static void UIKit_DeleteDevice(SDL_VideoDevice *device)
 {
     @autoreleasepool {
-        if (device->driverdata){
-            CFRelease(device->driverdata);
+        if (device->internal){
+            CFRelease(device->internal);
         }
         SDL_free(device);
     }
@@ -74,7 +74,7 @@ static SDL_VideoDevice *UIKit_CreateDevice(void)
 
         data = [SDL_UIKitVideoData new];
 
-        device->driverdata = (SDL_VideoData *)CFBridgingRetain(data);
+        device->internal = (SDL_VideoData *)CFBridgingRetain(data);
         device->system_theme = UIKit_GetSystemTheme();
 
         /* Set the function pointers */
@@ -212,7 +212,7 @@ CGRect UIKit_ComputeViewFrame(SDL_Window *window){
 #else
 CGRect UIKit_ComputeViewFrame(SDL_Window *window, UIScreen *screen)
 {
-    SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *)window->driverdata;
+    SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *)window->internal;
     CGRect frame = screen.bounds;
 
     /* Use the UIWindow bounds instead of the UIScreen bounds, when possible.
@@ -256,7 +256,7 @@ void UIKit_ForceUpdateHomeIndicator(void)
     /* Force the main SDL window to re-evaluate home indicator state */
     SDL_Window *focus = SDL_GetKeyboardFocus();
     if (focus) {
-        SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *)focus->driverdata;
+        SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *)focus->internal;
         if (data != nil) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability-new"

--- a/src/video/uikit/SDL_uikitview.m
+++ b/src/video/uikit/SDL_uikitview.m
@@ -103,7 +103,7 @@ extern int SDL_AppleTVRemoteOpenedAsJoystick;
     /* Remove ourself from the old window. */
     if (sdlwindow) {
         SDL_uikitview *view = nil;
-        data = (__bridge SDL_UIKitWindowData *)sdlwindow->driverdata;
+        data = (__bridge SDL_UIKitWindowData *)sdlwindow->internal;
 
         [data.views removeObject:self];
 
@@ -122,7 +122,7 @@ extern int SDL_AppleTVRemoteOpenedAsJoystick;
 
     /* Add ourself to the new window. */
     if (window) {
-        data = (__bridge SDL_UIKitWindowData *)window->driverdata;
+        data = (__bridge SDL_UIKitWindowData *)window->internal;
 
         /* Make sure the SDL window has a strong reference to this view. */
         [data.views addObject:self];

--- a/src/video/uikit/SDL_uikitviewcontroller.m
+++ b/src/video/uikit/SDL_uikitviewcontroller.m
@@ -165,7 +165,7 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 #ifdef SDL_PLATFORM_VISIONOS
     displayLink.preferredFramesPerSecond = 90 / animationInterval;      //TODO: Get frame max frame rate on visionOS
 #elif defined(__IPHONE_10_3)
-    SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *)window->driverdata;
+    SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *)window->internal;
 
     if ([displayLink respondsToSelector:@selector(preferredFramesPerSecond)] && data != nil && data.uiwindow != nil && [data.uiwindow.screen respondsToSelector:@selector(maximumFramesPerSecond)]) {
         displayLink.preferredFramesPerSecond = data.uiwindow.screen.maximumFramesPerSecond / animationInterval;
@@ -511,7 +511,7 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 
 - (void)updateKeyboard
 {
-    SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *) window->driverdata;
+    SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *) window->internal;
 
     CGAffineTransform t = self.view.transform;
     CGPoint offset = CGPointMake(0.0, 0.0);
@@ -581,12 +581,12 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 
 static SDL_uikitviewcontroller *GetWindowViewController(SDL_Window *window)
 {
-    if (!window || !window->driverdata) {
+    if (!window || !window->internal) {
         SDL_SetError("Invalid window");
         return nil;
     }
 
-    SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *)window->driverdata;
+    SDL_UIKitWindowData *data = (__bridge SDL_UIKitWindowData *)window->internal;
 
     return data.viewcontroller;
 }

--- a/src/video/vita/SDL_vitaframebuffer.c
+++ b/src/video/vita/SDL_vitaframebuffer.c
@@ -65,7 +65,7 @@ void vita_gpu_free(SceUID uid)
 
 int VITA_CreateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, SDL_PixelFormat *format, void **pixels, int *pitch)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     SceDisplayFrameBuf framebuf;
 
     *format = SDL_PIXELFORMAT_ABGR8888;
@@ -101,7 +101,7 @@ int VITA_UpdateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, con
 
 void VITA_DestroyWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
 
     if (!data) {
         /* The window wasn't fully initialized */

--- a/src/video/vita/SDL_vitagl_pvr.c
+++ b/src/video/vita/SDL_vitagl_pvr.c
@@ -93,7 +93,7 @@ SDL_GLContext VITA_GL_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
     _this->gl_config.minor_version = 0;
     _this->gl_config.profile_mask = SDL_GL_CONTEXT_PROFILE_ES;
 
-    context = SDL_EGL_CreateContext(_this, window->driverdata->egl_surface);
+    context = SDL_EGL_CreateContext(_this, window->internal->egl_surface);
 
     if (context != NULL) {
         FB_WIDTH = window->w;

--- a/src/video/vita/SDL_vitagles.c
+++ b/src/video/vita/SDL_vitagles.c
@@ -80,7 +80,7 @@ static EGLint height = 544;
 SDL_GLContext VITA_GLES_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
 {
 
-    SDL_WindowData *wdata = window->driverdata;
+    SDL_WindowData *wdata = window->internal;
 
     EGLint attribs[32];
     EGLDisplay display;
@@ -193,7 +193,7 @@ int VITA_GLES_SwapWindow(SDL_VideoDevice *_this, SDL_Window *window)
 
 int VITA_GLES_DeleteContext(SDL_VideoDevice *_this, SDL_GLContext context)
 {
-    SDL_VideoData *phdata = _this->driverdata;
+    SDL_VideoData *phdata = _this->internal;
     EGLBoolean status;
 
     if (phdata->egl_initialized != SDL_TRUE) {

--- a/src/video/vita/SDL_vitagles_pvr.c
+++ b/src/video/vita/SDL_vitagles_pvr.c
@@ -69,13 +69,13 @@ int VITA_GLES_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 
 SDL_GLContext VITA_GLES_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    return SDL_EGL_CreateContext(_this, window->driverdata->egl_surface);
+    return SDL_EGL_CreateContext(_this, window->internal->egl_surface);
 }
 
 int VITA_GLES_MakeCurrent(SDL_VideoDevice *_this, SDL_Window *window, SDL_GLContext context)
 {
     if (window && context) {
-        return SDL_EGL_MakeCurrent(_this, window->driverdata->egl_surface, context);
+        return SDL_EGL_MakeCurrent(_this, window->internal->egl_surface, context);
     } else {
         return SDL_EGL_MakeCurrent(_this, NULL, NULL);
     }
@@ -83,11 +83,11 @@ int VITA_GLES_MakeCurrent(SDL_VideoDevice *_this, SDL_Window *window, SDL_GLCont
 
 int VITA_GLES_SwapWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     if (videodata->ime_active) {
         sceImeUpdate();
     }
-    return SDL_EGL_SwapBuffers(_this, window->driverdata->egl_surface);
+    return SDL_EGL_SwapBuffers(_this, window->internal->egl_surface);
 }
 
 #endif /* SDL_VIDEO_DRIVER_VITA && SDL_VIDEO_VITA_PVR */

--- a/src/video/vita/SDL_vitavideo.c
+++ b/src/video/vita/SDL_vitavideo.c
@@ -55,7 +55,7 @@ SDL_Window *Vita_Window;
 
 static void VITA_Destroy(SDL_VideoDevice *device)
 {
-    SDL_free(device->driverdata);
+    SDL_free(device->internal);
     SDL_free(device);
 }
 
@@ -91,7 +91,7 @@ static SDL_VideoDevice *VITA_Create()
 #endif
     phdata->ime_active = SDL_FALSE;
 
-    device->driverdata = phdata;
+    device->internal = phdata;
 
     /* Setup amount of available displays and current display */
     device->num_displays = 0;
@@ -234,7 +234,7 @@ int VITA_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Properties
     }
 
     /* Setup driver data for this window */
-    window->driverdata = wdata;
+    window->internal = wdata;
 
     // Vita can only have one window
     if (Vita_Window) {
@@ -328,13 +328,13 @@ void VITA_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
     SDL_WindowData *data;
 
-    data = window->driverdata;
+    data = window->internal;
     if (data) {
         // TODO: should we destroy egl context? No one sane should recreate ogl window as non-ogl
         SDL_free(data);
     }
 
-    window->driverdata = NULL;
+    window->internal = NULL;
     Vita_Window = NULL;
 }
 
@@ -413,7 +413,7 @@ void VITA_ImeEventHandler(void *arg, const SceImeEventData *e)
 
 void VITA_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     SceInt32 res;
 
 #ifdef SDL_VIDEO_VITA_PVR
@@ -475,7 +475,7 @@ void VITA_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window)
 void VITA_HideScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window)
 {
 #ifndef SDL_VIDEO_VITA_PVR
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
 
     SceCommonDialogStatus dialogStatus = sceImeDialogGetStatus();
 
@@ -496,7 +496,7 @@ void VITA_HideScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window)
 SDL_bool VITA_IsScreenKeyboardShown(SDL_VideoDevice *_this, SDL_Window *window)
 {
 #ifdef SDL_VIDEO_VITA_PVR
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     return videodata->ime_active;
 #else
     SceCommonDialogStatus dialogStatus = sceImeDialogGetStatus();
@@ -507,7 +507,7 @@ SDL_bool VITA_IsScreenKeyboardShown(SDL_VideoDevice *_this, SDL_Window *window)
 void VITA_PumpEvents(SDL_VideoDevice *_this)
 {
 #ifndef SDL_VIDEO_VITA_PVR
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
 #endif
 
     if (_this->suspend_screensaver) {

--- a/src/video/vivante/SDL_vivantevideo.c
+++ b/src/video/vivante/SDL_vivantevideo.c
@@ -37,7 +37,7 @@
 
 static void VIVANTE_Destroy(SDL_VideoDevice *device)
 {
-    SDL_free(device->driverdata);
+    SDL_free(device->internal);
     SDL_free(device);
 }
 
@@ -59,7 +59,7 @@ static SDL_VideoDevice *VIVANTE_Create()
         return NULL;
     }
 
-    device->driverdata = data;
+    device->internal = data;
 
     /* Setup amount of available displays */
     device->num_displays = 0;
@@ -116,7 +116,7 @@ VideoBootStrap VIVANTE_bootstrap = {
 
 static int VIVANTE_AddVideoDisplays(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     SDL_VideoDisplay display;
     SDL_DisplayMode mode;
     SDL_DisplayData *data;
@@ -156,7 +156,7 @@ static int VIVANTE_AddVideoDisplays(SDL_VideoDevice *_this)
     SDL_zero(display);
     display.name = VIVANTE_GetDisplayName(_this);
     display.desktop_mode = mode;
-    display.driverdata = data;
+    display.internal = data;
     if (SDL_AddVideoDisplay(&display, SDL_FALSE) == 0) {
         return -1;
     }
@@ -165,7 +165,7 @@ static int VIVANTE_AddVideoDisplays(SDL_VideoDevice *_this)
 
 int VIVANTE_VideoInit(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
 
 #ifdef SDL_VIDEO_DRIVER_VIVANTE_VDK
     videodata->vdk_private = vdkInitialize();
@@ -217,7 +217,7 @@ int VIVANTE_VideoInit(SDL_VideoDevice *_this)
 
 void VIVANTE_VideoQuit(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
 
 #ifdef SDL_INPUT_LINUXEV
     SDL_EVDEV_Quit();
@@ -240,7 +240,7 @@ void VIVANTE_VideoQuit(SDL_VideoDevice *_this)
 
 int VIVANTE_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesID create_props)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     SDL_DisplayData *displaydata;
     SDL_WindowData *data;
 
@@ -253,7 +253,7 @@ int VIVANTE_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Propert
     }
 
     /* Setup driver data for this window */
-    window->driverdata = data;
+    window->internal = data;
 
     SDL_PropertiesID props = SDL_GetWindowProperties(window);
     SDL_SetPointerProperty(props, SDL_PROP_WINDOW_VIVANTE_DISPLAY_POINTER, displaydata->native_display);
@@ -286,10 +286,10 @@ int VIVANTE_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Propert
 
 void VIVANTE_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     SDL_WindowData *data;
 
-    data = window->driverdata;
+    data = window->internal;
     if (data) {
 #ifdef SDL_VIDEO_OPENGL_EGL
         if (data->egl_surface != EGL_NO_SURFACE) {
@@ -307,13 +307,13 @@ void VIVANTE_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
 
         SDL_free(data);
     }
-    window->driverdata = NULL;
+    window->internal = NULL;
 }
 
 void VIVANTE_SetWindowTitle(SDL_VideoDevice *_this, SDL_Window *window)
 {
 #ifdef SDL_VIDEO_DRIVER_VIVANTE_VDK
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     vdkSetWindowTitle(data->native_window, window->title);
 #endif
 }
@@ -332,7 +332,7 @@ void VIVANTE_SetWindowSize(SDL_VideoDevice *_this, SDL_Window *window)
 void VIVANTE_ShowWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
 #ifdef SDL_VIDEO_DRIVER_VIVANTE_VDK
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     vdkShowWindow(data->native_window);
 #endif
     SDL_SetMouseFocus(window);
@@ -342,7 +342,7 @@ void VIVANTE_ShowWindow(SDL_VideoDevice *_this, SDL_Window *window)
 void VIVANTE_HideWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
 #ifdef SDL_VIDEO_DRIVER_VIVANTE_VDK
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     vdkHideWindow(data->native_window);
 #endif
     SDL_SetMouseFocus(NULL);

--- a/src/video/wayland/SDL_waylandclipboard.c
+++ b/src/video/wayland/SDL_waylandclipboard.c
@@ -31,7 +31,7 @@
 
 int Wayland_SetClipboardData(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *video_data = _this->driverdata;
+    SDL_VideoData *video_data = _this->internal;
     SDL_WaylandDataDevice *data_device = NULL;
     int status = 0;
 
@@ -56,7 +56,7 @@ int Wayland_SetClipboardData(SDL_VideoDevice *_this)
 
 void *Wayland_GetClipboardData(SDL_VideoDevice *_this, const char *mime_type, size_t *length)
 {
-    SDL_VideoData *video_data = _this->driverdata;
+    SDL_VideoData *video_data = _this->internal;
     SDL_WaylandDataDevice *data_device = NULL;
     void *buffer = NULL;
 
@@ -74,7 +74,7 @@ void *Wayland_GetClipboardData(SDL_VideoDevice *_this, const char *mime_type, si
 
 SDL_bool Wayland_HasClipboardData(SDL_VideoDevice *_this, const char *mime_type)
 {
-    SDL_VideoData *video_data = _this->driverdata;
+    SDL_VideoData *video_data = _this->internal;
     SDL_WaylandDataDevice *data_device = NULL;
     SDL_bool result = SDL_FALSE;
 
@@ -105,7 +105,7 @@ const char **Wayland_GetTextMimeTypes(SDL_VideoDevice *_this, size_t *num_mime_t
 
 int Wayland_SetPrimarySelectionText(SDL_VideoDevice *_this, const char *text)
 {
-    SDL_VideoData *video_data = _this->driverdata;
+    SDL_VideoData *video_data = _this->internal;
     SDL_WaylandPrimarySelectionDevice *primary_selection_device = NULL;
     int status = -1;
 
@@ -132,7 +132,7 @@ int Wayland_SetPrimarySelectionText(SDL_VideoDevice *_this, const char *text)
 
 char *Wayland_GetPrimarySelectionText(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *video_data = _this->driverdata;
+    SDL_VideoData *video_data = _this->internal;
     SDL_WaylandPrimarySelectionDevice *primary_selection_device = NULL;
     char *text = NULL;
     size_t length = 0;
@@ -155,7 +155,7 @@ char *Wayland_GetPrimarySelectionText(SDL_VideoDevice *_this)
 
 SDL_bool Wayland_HasPrimarySelectionText(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *video_data = _this->driverdata;
+    SDL_VideoData *video_data = _this->internal;
     SDL_WaylandPrimarySelectionDevice *primary_selection_device = NULL;
     SDL_bool result = SDL_FALSE;
 

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -346,7 +346,7 @@ static struct wl_callback_listener sync_listener = {
 
 void Wayland_SendWakeupEvent(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_VideoData *d = _this->driverdata;
+    SDL_VideoData *d = _this->internal;
 
     /* Queue a sync event to unblock the event queue fd if it's empty and being waited on.
      * TODO: Maybe use a pipe to avoid the compositor roundtrip?
@@ -376,7 +376,7 @@ static int dispatch_queued_events(SDL_VideoData *viddata)
 
 int Wayland_WaitEventTimeout(SDL_VideoDevice *_this, Sint64 timeoutNS)
 {
-    SDL_VideoData *d = _this->driverdata;
+    SDL_VideoData *d = _this->internal;
     struct SDL_WaylandInput *input = d->input;
     SDL_bool key_repeat_active = SDL_FALSE;
 
@@ -452,7 +452,7 @@ int Wayland_WaitEventTimeout(SDL_VideoDevice *_this, Sint64 timeoutNS)
 
 void Wayland_PumpEvents(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *d = _this->driverdata;
+    SDL_VideoData *d = _this->internal;
     struct SDL_WaylandInput *input = d->input;
     int err;
 
@@ -1893,10 +1893,10 @@ SDL_WaylandDataSource *Wayland_data_source_create(SDL_VideoDevice *_this)
     SDL_VideoData *driver_data = NULL;
     struct wl_data_source *id = NULL;
 
-    if (!_this || !_this->driverdata) {
+    if (!_this || !_this->internal) {
         SDL_SetError("Video driver uninitialized");
     } else {
-        driver_data = _this->driverdata;
+        driver_data = _this->internal;
 
         if (driver_data->data_device_manager) {
             id = wl_data_device_manager_create_data_source(
@@ -1926,10 +1926,10 @@ SDL_WaylandPrimarySelectionSource *Wayland_primary_selection_source_create(SDL_V
     SDL_VideoData *driver_data = NULL;
     struct zwp_primary_selection_source_v1 *id = NULL;
 
-    if (!_this || !_this->driverdata) {
+    if (!_this || !_this->internal) {
         SDL_SetError("Video driver uninitialized");
     } else {
-        driver_data = _this->driverdata;
+        driver_data = _this->internal;
 
         if (driver_data->primary_selection_device_manager) {
             id = zwp_primary_selection_device_manager_v1_create_source(
@@ -3129,7 +3129,7 @@ static const struct zwp_locked_pointer_v1_listener locked_pointer_listener = {
 
 int Wayland_input_lock_pointer(struct SDL_WaylandInput *input, SDL_Window *window)
 {
-    SDL_WindowData *w = window->driverdata;
+    SDL_WindowData *w = window->internal;
     SDL_VideoData *d = input->display;
 
     if (!d->pointer_constraints || !input->pointer) {
@@ -3157,7 +3157,7 @@ int Wayland_input_lock_pointer(struct SDL_WaylandInput *input, SDL_Window *windo
 
 int Wayland_input_unlock_pointer(struct SDL_WaylandInput *input, SDL_Window *window)
 {
-    SDL_WindowData *w = window->driverdata;
+    SDL_WindowData *w = window->internal;
 
     if (w->locked_pointer) {
         zwp_locked_pointer_v1_destroy(w->locked_pointer);
@@ -3172,7 +3172,7 @@ int Wayland_input_unlock_pointer(struct SDL_WaylandInput *input, SDL_Window *win
 
 static void pointer_confine_destroy(SDL_Window *window)
 {
-    SDL_WindowData *w = window->driverdata;
+    SDL_WindowData *w = window->internal;
     if (w->confined_pointer) {
         zwp_confined_pointer_v1_destroy(w->confined_pointer);
         w->confined_pointer = NULL;
@@ -3263,7 +3263,7 @@ static const struct zwp_confined_pointer_v1_listener confined_pointer_listener =
 
 int Wayland_input_confine_pointer(struct SDL_WaylandInput *input, SDL_Window *window)
 {
-    SDL_WindowData *w = window->driverdata;
+    SDL_WindowData *w = window->internal;
     SDL_VideoData *d = input->display;
     struct zwp_confined_pointer_v1 *confined_pointer;
     struct wl_region *confine_rect;
@@ -3337,7 +3337,7 @@ int Wayland_input_unconfine_pointer(struct SDL_WaylandInput *input, SDL_Window *
 
 int Wayland_input_grab_keyboard(SDL_Window *window, struct SDL_WaylandInput *input)
 {
-    SDL_WindowData *w = window->driverdata;
+    SDL_WindowData *w = window->internal;
     SDL_VideoData *d = input->display;
 
     if (!d->key_inhibitor_manager) {
@@ -3358,7 +3358,7 @@ int Wayland_input_grab_keyboard(SDL_Window *window, struct SDL_WaylandInput *inp
 
 int Wayland_input_ungrab_keyboard(SDL_Window *window)
 {
-    SDL_WindowData *w = window->driverdata;
+    SDL_WindowData *w = window->internal;
 
     if (w->key_inhibitor) {
         zwp_keyboard_shortcuts_inhibitor_v1_destroy(w->key_inhibitor);

--- a/src/video/wayland/SDL_waylandkeyboard.c
+++ b/src/video/wayland/SDL_waylandkeyboard.c
@@ -31,8 +31,8 @@
 int Wayland_InitKeyboard(SDL_VideoDevice *_this)
 {
 #ifdef SDL_USE_IME
-    SDL_VideoData *driverdata = _this->driverdata;
-    if (!driverdata->text_input_manager) {
+    SDL_VideoData *internal = _this->internal;
+    if (!internal->text_input_manager) {
         SDL_IME_Init();
     }
 #endif
@@ -44,8 +44,8 @@ int Wayland_InitKeyboard(SDL_VideoDevice *_this)
 void Wayland_QuitKeyboard(SDL_VideoDevice *_this)
 {
 #ifdef SDL_USE_IME
-    SDL_VideoData *driverdata = _this->driverdata;
-    if (!driverdata->text_input_manager) {
+    SDL_VideoData *internal = _this->internal;
+    if (!internal->text_input_manager) {
         SDL_IME_Quit();
     }
 #endif
@@ -53,10 +53,10 @@ void Wayland_QuitKeyboard(SDL_VideoDevice *_this)
 
 int Wayland_StartTextInput(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_VideoData *driverdata = _this->driverdata;
-    struct SDL_WaylandInput *input = driverdata->input;
+    SDL_VideoData *internal = _this->internal;
+    struct SDL_WaylandInput *input = internal->input;
 
-    if (driverdata->text_input_manager) {
+    if (internal->text_input_manager) {
         if (input && input->text_input) {
             const SDL_Rect *rect = &input->text_input->cursor_rect;
 
@@ -88,10 +88,10 @@ int Wayland_StartTextInput(SDL_VideoDevice *_this, SDL_Window *window)
 
 int Wayland_StopTextInput(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_VideoData *driverdata = _this->driverdata;
-    struct SDL_WaylandInput *input = driverdata->input;
+    SDL_VideoData *internal = _this->internal;
+    struct SDL_WaylandInput *input = internal->input;
 
-    if (driverdata->text_input_manager) {
+    if (internal->text_input_manager) {
         if (input && input->text_input) {
             zwp_text_input_v3_disable(input->text_input->text_input);
             zwp_text_input_v3_commit(input->text_input->text_input);
@@ -112,9 +112,9 @@ int Wayland_StopTextInput(SDL_VideoDevice *_this, SDL_Window *window)
 
 int Wayland_UpdateTextInputArea(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_VideoData *driverdata = _this->driverdata;
-    if (driverdata->text_input_manager) {
-        struct SDL_WaylandInput *input = driverdata->input;
+    SDL_VideoData *internal = _this->internal;
+    if (internal->text_input_manager) {
+        struct SDL_WaylandInput *input = internal->input;
         if (input && input->text_input) {
             if (!SDL_RectsEqual(&window->text_input_rect, &input->text_input->cursor_rect)) {
                 SDL_copyp(&input->text_input->cursor_rect, &window->text_input_rect);
@@ -142,9 +142,9 @@ SDL_bool Wayland_HasScreenKeyboardSupport(SDL_VideoDevice *_this)
      * _only_ way to get text input. So, in addition to checking for the text
      * input protocol, make sure we don't have any physical keyboards either.
      */
-    SDL_VideoData *driverdata = _this->driverdata;
-    SDL_bool haskeyboard = (driverdata->input != NULL) && (driverdata->input->keyboard != NULL);
-    SDL_bool hastextmanager = (driverdata->text_input_manager != NULL);
+    SDL_VideoData *internal = _this->internal;
+    SDL_bool haskeyboard = (internal->input != NULL) && (internal->input->keyboard != NULL);
+    SDL_bool hastextmanager = (internal->text_input_manager != NULL);
     return !haskeyboard && hastextmanager;
 }
 

--- a/src/video/wayland/SDL_waylandopengles.c
+++ b/src/video/wayland/SDL_waylandopengles.c
@@ -37,7 +37,7 @@
 int Wayland_GLES_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 {
     int ret;
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
 
     ret = SDL_EGL_LoadLibrary(_this, path, (NativeDisplayType)data->display, _this->gl_config.egl_platform);
 
@@ -50,8 +50,8 @@ int Wayland_GLES_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 SDL_GLContext Wayland_GLES_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
 {
     SDL_GLContext context;
-    context = SDL_EGL_CreateContext(_this, window->driverdata->egl_surface);
-    WAYLAND_wl_display_flush(_this->driverdata->display);
+    context = SDL_EGL_CreateContext(_this, window->internal->egl_surface);
+    WAYLAND_wl_display_flush(_this->internal->display);
 
     return context;
 }
@@ -104,7 +104,7 @@ int Wayland_GLES_GetSwapInterval(SDL_VideoDevice *_this, int *interval)
 
 int Wayland_GLES_SwapWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     const int swap_interval = _this->egl_data->egl_swapinterval;
 
     /* For windows that we know are hidden, skip swaps entirely, if we don't do
@@ -122,7 +122,7 @@ int Wayland_GLES_SwapWindow(SDL_VideoDevice *_this, SDL_Window *window)
 
     /* Control swap interval ourselves. See comments on Wayland_GLES_SetSwapInterval */
     if (swap_interval != 0 && data->surface_status == WAYLAND_SURFACE_STATUS_SHOWN) {
-        SDL_VideoData *videodata = _this->driverdata;
+        SDL_VideoData *videodata = _this->internal;
         struct wl_display *display = videodata->display;
         /* 20hz, so we'll progress even if throttled to zero. */
         const Uint64 max_wait = SDL_GetTicksNS() + (SDL_NS_PER_SECOND / 20);
@@ -176,12 +176,12 @@ int Wayland_GLES_MakeCurrent(SDL_VideoDevice *_this, SDL_Window *window, SDL_GLC
     int ret;
 
     if (window && context) {
-        ret = SDL_EGL_MakeCurrent(_this, window->driverdata->egl_surface, context);
+        ret = SDL_EGL_MakeCurrent(_this, window->internal->egl_surface, context);
     } else {
         ret = SDL_EGL_MakeCurrent(_this, NULL, NULL);
     }
 
-    WAYLAND_wl_display_flush(_this->driverdata->display);
+    WAYLAND_wl_display_flush(_this->internal->display);
 
     _this->egl_data->eglSwapInterval(_this->egl_data->egl_display, 0); /* see comments on Wayland_GLES_SetSwapInterval. */
 
@@ -191,13 +191,13 @@ int Wayland_GLES_MakeCurrent(SDL_VideoDevice *_this, SDL_Window *window, SDL_GLC
 int Wayland_GLES_DeleteContext(SDL_VideoDevice *_this, SDL_GLContext context)
 {
     SDL_EGL_DeleteContext(_this, context);
-    WAYLAND_wl_display_flush(_this->driverdata->display);
+    WAYLAND_wl_display_flush(_this->internal->display);
     return 0;
 }
 
 EGLSurface Wayland_GLES_GetEGLSurface(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *windowdata = window->driverdata;
+    SDL_WindowData *windowdata = window->internal;
 
     return windowdata->egl_surface;
 }

--- a/src/video/wayland/SDL_waylandshmbuffer.c
+++ b/src/video/wayland/SDL_waylandshmbuffer.c
@@ -117,7 +117,7 @@ static struct wl_buffer_listener buffer_listener = {
 int Wayland_AllocSHMBuffer(int width, int height, struct Wayland_SHMBuffer *shmBuffer)
 {
     SDL_VideoDevice *vd = SDL_GetVideoDevice();
-    SDL_VideoData *data = vd->driverdata;
+    SDL_VideoData *data = vd->internal;
     struct wl_shm_pool *shm_pool;
     const Uint32 SHM_FMT = WL_SHM_FORMAT_ARGB8888;
 

--- a/src/video/wayland/SDL_waylandvulkan.c
+++ b/src/video/wayland/SDL_waylandvulkan.c
@@ -134,7 +134,7 @@ int Wayland_Vulkan_CreateSurface(SDL_VideoDevice *_this,
                                  const struct VkAllocationCallbacks *allocator,
                                  VkSurfaceKHR *surface)
 {
-    SDL_WindowData *windowData = window->driverdata;
+    SDL_WindowData *windowData = window->internal;
     PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr =
         (PFN_vkGetInstanceProcAddr)_this->vulkan_config.vkGetInstanceProcAddr;
     PFN_vkCreateWaylandSurfaceKHR vkCreateWaylandSurfaceKHR =
@@ -200,7 +200,7 @@ SDL_bool Wayland_Vulkan_GetPresentationSupport(SDL_VideoDevice *_this,
 
     return vkGetPhysicalDeviceWaylandPresentationSupportKHR(physicalDevice,
                                                             queueFamilyIndex,
-                                                            _this->driverdata->display);
+                                                            _this->internal->display);
 }
 
 #endif

--- a/src/video/windows/SDL_windowsclipboard.c
+++ b/src/video/windows/SDL_windowsclipboard.c
@@ -48,7 +48,7 @@ static BOOL WIN_OpenClipboard(SDL_VideoDevice *_this)
     HWND hwnd = NULL;
 
     if (_this->windows) {
-        hwnd = _this->windows->driverdata->hwnd;
+        hwnd = _this->windows->internal->hwnd;
     }
     for (attempt = 0; attempt < MAX_ATTEMPTS; ++attempt) {
         if (OpenClipboard(hwnd)) {
@@ -213,7 +213,7 @@ static int WIN_SetClipboardText(SDL_VideoDevice *_this, const char *mime_type)
 
 int WIN_SetClipboardData(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     size_t i;
     int result = 0;
 

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -294,7 +294,7 @@ static void WIN_CheckAsyncMouseRelease(Uint64 timestamp, SDL_WindowData *data)
 
 static void WIN_UpdateFocus(SDL_Window *window, SDL_bool expect_focus)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     HWND hwnd = data->hwnd;
     SDL_bool had_focus = (SDL_GetKeyboardFocus() == window);
     SDL_bool has_focus = (GetForegroundWindow() == hwnd);
@@ -431,7 +431,7 @@ static SDL_WindowData *WIN_GetWindowDataFromHWND(HWND hwnd)
 
     if (_this) {
         for (window = _this->windows; window; window = window->next) {
-            SDL_WindowData *data = window->driverdata;
+            SDL_WindowData *data = window->internal;
             if (data && data->hwnd == hwnd) {
                 return data;
             }
@@ -445,7 +445,7 @@ LRESULT CALLBACK
 WIN_KeyboardHookProc(int nCode, WPARAM wParam, LPARAM lParam)
 {
     KBDLLHOOKSTRUCT *hookData = (KBDLLHOOKSTRUCT *)lParam;
-    SDL_VideoData *data = SDL_GetVideoDevice()->driverdata;
+    SDL_VideoData *data = SDL_GetVideoDevice()->internal;
     SDL_Scancode scanCode;
 
     if (nCode < 0 || nCode != HC_ACTION) {
@@ -537,7 +537,7 @@ static void WIN_HandleRawMouseInput(Uint64 timestamp, SDL_VideoData *data, HANDL
     }
 
     SDL_MouseID mouseID = (SDL_MouseID)(uintptr_t)hDevice;
-    SDL_WindowData *windowdata = window->driverdata;
+    SDL_WindowData *windowdata = window->internal;
 
     if ((rawmouse->usFlags & 0x01) == MOUSE_MOVE_RELATIVE) {
         if (rawmouse->lLastX || rawmouse->lLastY) {
@@ -738,7 +738,7 @@ static void WIN_HandleRawKeyboardInput(Uint64 timestamp, SDL_VideoData *data, HA
 
 void WIN_PollRawInput(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     UINT size, i, count, total = 0;
     RAWINPUT *input;
     Uint64 now;
@@ -2099,7 +2099,7 @@ static void WIN_UpdateClipCursorForWindows()
 
     if (_this) {
         for (window = _this->windows; window; window = window->next) {
-            SDL_WindowData *data = window->driverdata;
+            SDL_WindowData *data = window->internal;
             if (data) {
                 if (data->skip_update_clipcursor) {
                     data->skip_update_clipcursor = SDL_FALSE;
@@ -2117,7 +2117,7 @@ static void WIN_UpdateMouseCapture()
     SDL_Window *focusWindow = SDL_GetKeyboardFocus();
 
     if (focusWindow && (focusWindow->flags & SDL_WINDOW_MOUSE_CAPTURE)) {
-        SDL_WindowData *data = focusWindow->driverdata;
+        SDL_WindowData *data = focusWindow->internal;
 
         if (!data->mouse_tracked) {
             POINT cursorPos;
@@ -2201,7 +2201,7 @@ int WIN_WaitEventTimeout(SDL_VideoDevice *_this, Sint64 timeoutNS)
 
 void WIN_SendWakeupEvent(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     PostMessage(data->hwnd, data->videodata->_SDL_WAKEUP, 0, 0);
 }
 

--- a/src/video/windows/SDL_windowsframebuffer.c
+++ b/src/video/windows/SDL_windowsframebuffer.c
@@ -26,7 +26,7 @@
 
 int WIN_CreateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, SDL_PixelFormat *format, void **pixels, int *pitch)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     SDL_bool isstack;
     size_t size;
     LPBITMAPINFO info;
@@ -100,7 +100,7 @@ int WIN_CreateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, SDL_
 
 int WIN_UpdateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, const SDL_Rect *rects, int numrects)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     int i;
 
     for (i = 0; i < numrects; ++i) {
@@ -112,7 +112,7 @@ int WIN_UpdateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, cons
 
 void WIN_DestroyWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
 
     if (!data) {
         /* The window wasn't fully initialized */

--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -58,7 +58,7 @@ static void IME_SetTextInputArea(SDL_VideoData *videodata, HWND hwnd, const SDL_
 void WIN_InitKeyboard(SDL_VideoDevice *_this)
 {
 #ifndef SDL_DISABLE_WINDOWS_IME
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
 
     data->ime_candlistindexbase = 1;
     data->ime_composition_length = 32 * sizeof(WCHAR);
@@ -154,7 +154,7 @@ void WIN_UpdateKeymap(SDL_bool send_event)
 void WIN_QuitKeyboard(SDL_VideoDevice *_this)
 {
 #ifndef SDL_DISABLE_WINDOWS_IME
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
 
     IME_Quit(data);
 
@@ -201,8 +201,8 @@ int WIN_StartTextInput(SDL_VideoDevice *_this, SDL_Window *window)
     WIN_ResetDeadKeys();
 
 #ifndef SDL_DISABLE_WINDOWS_IME
-    HWND hwnd = window->driverdata->hwnd;
-    SDL_VideoData *videodata = _this->driverdata;
+    HWND hwnd = window->internal->hwnd;
+    SDL_VideoData *videodata = _this->internal;
     IME_Init(videodata, window);
     IME_Enable(videodata, hwnd);
 
@@ -217,8 +217,8 @@ int WIN_StopTextInput(SDL_VideoDevice *_this, SDL_Window *window)
     WIN_ResetDeadKeys();
 
 #ifndef SDL_DISABLE_WINDOWS_IME
-    HWND hwnd = window->driverdata->hwnd;
-    SDL_VideoData *videodata = _this->driverdata;
+    HWND hwnd = window->internal->hwnd;
+    SDL_VideoData *videodata = _this->internal;
     IME_Init(videodata, window);
     IME_Disable(videodata, hwnd);
 #endif /* !SDL_DISABLE_WINDOWS_IME */
@@ -228,8 +228,8 @@ int WIN_StopTextInput(SDL_VideoDevice *_this, SDL_Window *window)
 
 int WIN_UpdateTextInputArea(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_VideoData *videodata = _this->driverdata;
-    SDL_WindowData *data = window->driverdata;
+    SDL_VideoData *videodata = _this->internal;
+    SDL_WindowData *data = window->internal;
 
     IME_SetTextInputArea(videodata, data->hwnd, &window->text_input_rect, window->text_input_cursor);
     return 0;
@@ -238,7 +238,7 @@ int WIN_UpdateTextInputArea(SDL_VideoDevice *_this, SDL_Window *window)
 int WIN_ClearComposition(SDL_VideoDevice *_this, SDL_Window *window)
 {
 #ifndef SDL_DISABLE_WINDOWS_IME
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
 
     IME_ClearComposition(videodata);
 #endif
@@ -303,7 +303,7 @@ static void IME_SendClearComposition(SDL_VideoData *videodata);
 
 static int IME_Init(SDL_VideoData *videodata, SDL_Window *window)
 {
-    HWND hwnd = window->driverdata->hwnd;
+    HWND hwnd = window->internal->hwnd;
 
     if (videodata->ime_initialized) {
         return 0;
@@ -627,7 +627,7 @@ static void IME_SetupAPI(SDL_VideoData *videodata)
 
 static void IME_SetWindow(SDL_VideoData *videodata, SDL_Window *window)
 {
-    HWND hwnd = window->driverdata->hwnd;
+    HWND hwnd = window->internal->hwnd;
 
     if (hwnd != videodata->ime_hwnd_current) {
         videodata->ime_hwnd_current = hwnd;
@@ -1120,7 +1120,7 @@ SDL_bool WIN_HandleIMEMessage(HWND hwnd, UINT msg, WPARAM wParam, LPARAM *lParam
 
 void WIN_UpdateIMECandidates(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
 
     if (videodata->ime_update_candidates) {
         IME_GetCandidateList(videodata, videodata->ime_hwnd_current);

--- a/src/video/windows/SDL_windowsmessagebox.c
+++ b/src/video/windows/SDL_windowsmessagebox.c
@@ -870,7 +870,7 @@ static int WIN_ShowOldMessageBox(const SDL_MessageBoxData *messageboxdata, int *
     /* If we have a parent window, get the Instance and HWND for them
      * so that our little dialog gets exclusive focus at all times. */
     if (messageboxdata->window) {
-        ParentWindow = messageboxdata->window->driverdata->hwnd;
+        ParentWindow = messageboxdata->window->internal->hwnd;
     }
 
     result = DialogBoxIndirectParam(NULL, (DLGTEMPLATE *)dialog->lpDialog, ParentWindow, MessageBoxDialogProc, (LPARAM)messageboxdata);
@@ -951,7 +951,7 @@ int WIN_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonID)
     /* If we have a parent window, get the Instance and HWND for them
        so that our little dialog gets exclusive focus at all times. */
     if (messageboxdata->window) {
-        ParentWindow = messageboxdata->window->driverdata->hwnd;
+        ParentWindow = messageboxdata->window->internal->hwnd;
     }
 
     wmessage = WIN_UTF8ToStringW(messageboxdata->message);

--- a/src/video/windows/SDL_windowsmodes.c
+++ b/src/video/windows/SDL_windowsmodes.c
@@ -40,7 +40,7 @@
 
 static void WIN_UpdateDisplayMode(SDL_VideoDevice *_this, LPCWSTR deviceName, DWORD index, SDL_DisplayMode *mode)
 {
-    SDL_DisplayModeData *data = (SDL_DisplayModeData *)mode->driverdata;
+    SDL_DisplayModeData *data = (SDL_DisplayModeData *)mode->internal;
     HDC hdc;
 
     data->DeviceMode.dmFields = (DM_BITSPERPEL | DM_PELSWIDTH | DM_PELSHEIGHT | DM_DISPLAYFREQUENCY | DM_DISPLAYFLAGS);
@@ -116,7 +116,7 @@ static void *WIN_GetDXGIOutput(SDL_VideoDevice *_this, const WCHAR *DeviceName)
     void *retval = NULL;
 
 #ifdef HAVE_DXGI_H
-    const SDL_VideoData *videodata = (const SDL_VideoData *)_this->driverdata;
+    const SDL_VideoData *videodata = (const SDL_VideoData *)_this->internal;
     int nAdapter, nOutput;
     IDXGIAdapter *pDXGIAdapter;
     IDXGIOutput *pDXGIOutput;
@@ -247,7 +247,7 @@ static void WIN_GetRefreshRate(void *dxgi_output, DEVMODE *mode, int *numerator,
 
 static float WIN_GetContentScale(SDL_VideoDevice *_this, HMONITOR hMonitor)
 {
-    const SDL_VideoData *videodata = (const SDL_VideoData *)_this->driverdata;
+    const SDL_VideoData *videodata = (const SDL_VideoData *)_this->internal;
     int dpi = 0;
 
     if (videodata->GetDpiForMonitor) {
@@ -288,7 +288,7 @@ static SDL_bool WIN_GetDisplayMode(SDL_VideoDevice *_this, void *dxgi_output, HM
     }
 
     SDL_zerop(mode);
-    mode->driverdata = data;
+    mode->internal = data;
     data->DeviceMode = devmode;
 
     mode->format = SDL_PIXELFORMAT_UNKNOWN;
@@ -513,7 +513,7 @@ done:
 static float WIN_GetSDRWhitePoint(SDL_VideoDevice *_this, HMONITOR hMonitor)
 {
     DISPLAYCONFIG_PATH_INFO path_info;
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     float SDR_white_level = 1.0f;
 
     if (WIN_GetMonitorPathInfo(videodata, hMonitor, &path_info)) {
@@ -574,12 +574,12 @@ static void WIN_AddDisplay(SDL_VideoDevice *_this, HMONITOR hMonitor, const MONI
     // ready to be added to allow any displays that we can't fully query to be
     // removed
     for (i = 0; i < _this->num_displays; ++i) {
-        SDL_DisplayData *driverdata = _this->displays[i]->driverdata;
-        if (SDL_wcscmp(driverdata->DeviceName, info->szDevice) == 0) {
+        SDL_DisplayData *internal = _this->displays[i]->internal;
+        if (SDL_wcscmp(internal->DeviceName, info->szDevice) == 0) {
             SDL_bool moved = (index != i);
             SDL_bool changed_bounds = SDL_FALSE;
 
-            if (driverdata->state != DisplayRemoved) {
+            if (internal->state != DisplayRemoved) {
                 /* We've already enumerated this display, don't move it */
                 return;
             }
@@ -598,8 +598,8 @@ static void WIN_AddDisplay(SDL_VideoDevice *_this, HMONITOR hMonitor, const MONI
                 i = index;
             }
 
-            driverdata->MonitorHandle = hMonitor;
-            driverdata->state = DisplayUnchanged;
+            internal->MonitorHandle = hMonitor;
+            internal->state = DisplayUnchanged;
 
             if (!_this->setting_display_mode) {
                 SDL_VideoDisplay *existing_display = _this->displays[i];
@@ -608,9 +608,9 @@ static void WIN_AddDisplay(SDL_VideoDevice *_this, HMONITOR hMonitor, const MONI
                 SDL_ResetFullscreenDisplayModes(existing_display);
                 SDL_SetDesktopDisplayMode(existing_display, &mode);
                 if (WIN_GetDisplayBounds(_this, existing_display, &bounds) == 0 &&
-                    SDL_memcmp(&driverdata->bounds, &bounds, sizeof(bounds)) != 0) {
+                    SDL_memcmp(&internal->bounds, &bounds, sizeof(bounds)) != 0) {
                     changed_bounds = SDL_TRUE;
-                    SDL_copyp(&driverdata->bounds, &bounds);
+                    SDL_copyp(&internal->bounds, &bounds);
                 }
                 if (moved || changed_bounds) {
                     SDL_SendDisplayEvent(existing_display, SDL_EVENT_DISPLAY_MOVED, 0, 0);
@@ -636,7 +636,7 @@ static void WIN_AddDisplay(SDL_VideoDevice *_this, HMONITOR hMonitor, const MONI
     displaydata->state = DisplayAdded;
 
     SDL_zero(display);
-    display.name = WIN_GetDisplayNameVista(_this->driverdata, info->szDevice);
+    display.name = WIN_GetDisplayNameVista(_this->internal, info->szDevice);
     if (!display.name) {
         DISPLAY_DEVICEW device;
         SDL_zero(device);
@@ -651,7 +651,7 @@ static void WIN_AddDisplay(SDL_VideoDevice *_this, HMONITOR hMonitor, const MONI
     display.current_orientation = current_orientation;
     display.content_scale = content_scale;
     display.device = _this;
-    display.driverdata = displaydata;
+    display.internal = displaydata;
     WIN_GetDisplayBounds(_this, &display, &displaydata->bounds);
 #ifdef HAVE_DXGI1_6_H
     WIN_GetHDRProperties(_this, hMonitor, &display.HDR);
@@ -718,7 +718,7 @@ int WIN_InitModes(SDL_VideoDevice *_this)
 
 int WIN_GetDisplayBounds(SDL_VideoDevice *_this, SDL_VideoDisplay *display, SDL_Rect *rect)
 {
-    const SDL_DisplayData *data = display->driverdata;
+    const SDL_DisplayData *data = display->internal;
     MONITORINFO minfo;
     BOOL rc;
 
@@ -740,7 +740,7 @@ int WIN_GetDisplayBounds(SDL_VideoDevice *_this, SDL_VideoDisplay *display, SDL_
 
 int WIN_GetDisplayUsableBounds(SDL_VideoDevice *_this, SDL_VideoDisplay *display, SDL_Rect *rect)
 {
-    const SDL_DisplayData *data = display->driverdata;
+    const SDL_DisplayData *data = display->internal;
     MONITORINFO minfo;
     BOOL rc;
 
@@ -762,7 +762,7 @@ int WIN_GetDisplayUsableBounds(SDL_VideoDevice *_this, SDL_VideoDisplay *display
 
 int WIN_GetDisplayModes(SDL_VideoDevice *_this, SDL_VideoDisplay *display)
 {
-    SDL_DisplayData *data = display->driverdata;
+    SDL_DisplayData *data = display->internal;
     void *dxgi_output;
     DWORD i;
     SDL_DisplayMode mode;
@@ -775,15 +775,15 @@ int WIN_GetDisplayModes(SDL_VideoDevice *_this, SDL_VideoDisplay *display)
         }
         if (SDL_ISPIXELFORMAT_INDEXED(mode.format)) {
             /* We don't support palettized modes now */
-            SDL_free(mode.driverdata);
+            SDL_free(mode.internal);
             continue;
         }
         if (mode.format != SDL_PIXELFORMAT_UNKNOWN) {
             if (!SDL_AddFullscreenDisplayMode(display, &mode)) {
-                SDL_free(mode.driverdata);
+                SDL_free(mode.internal);
             }
         } else {
-            SDL_free(mode.driverdata);
+            SDL_free(mode.internal);
         }
     }
 
@@ -795,7 +795,7 @@ int WIN_GetDisplayModes(SDL_VideoDevice *_this, SDL_VideoDisplay *display)
 #ifdef DEBUG_MODES
 static void WIN_LogMonitor(SDL_VideoDevice *_this, HMONITOR mon)
 {
-    const SDL_VideoData *vid_data = (const SDL_VideoData *)_this->driverdata;
+    const SDL_VideoData *vid_data = (const SDL_VideoData *)_this->internal;
     MONITORINFOEX minfo;
     UINT xdpi = 0, ydpi = 0;
     char *name_utf8;
@@ -824,8 +824,8 @@ static void WIN_LogMonitor(SDL_VideoDevice *_this, HMONITOR mon)
 
 int WIN_SetDisplayMode(SDL_VideoDevice *_this, SDL_VideoDisplay *display, SDL_DisplayMode *mode)
 {
-    SDL_DisplayData *displaydata = display->driverdata;
-    SDL_DisplayModeData *data = (SDL_DisplayModeData *)mode->driverdata;
+    SDL_DisplayData *displaydata = display->internal;
+    SDL_DisplayModeData *data = (SDL_DisplayModeData *)mode->internal;
     LONG status;
 
 #ifdef DEBUG_MODES
@@ -843,7 +843,7 @@ int WIN_SetDisplayMode(SDL_VideoDevice *_this, SDL_VideoDisplay *display, SDL_Di
            reset the monitor DPI to 192. (200% scaling)
 
        NOTE: these are temporary changes in DPI, not modifications to the Control Panel setting. */
-    if (mode->driverdata == display->desktop_mode.driverdata) {
+    if (mode->internal == display->desktop_mode.internal) {
 #ifdef DEBUG_MODES
         SDL_Log("WIN_SetDisplayMode: resetting to original resolution");
 #endif
@@ -890,8 +890,8 @@ void WIN_RefreshDisplays(SDL_VideoDevice *_this)
     // Mark all displays as potentially invalid to detect
     // entries that have actually been removed
     for (i = 0; i < _this->num_displays; ++i) {
-        SDL_DisplayData *driverdata = _this->displays[i]->driverdata;
-        driverdata->state = DisplayRemoved;
+        SDL_DisplayData *internal = _this->displays[i]->internal;
+        internal->state = DisplayRemoved;
     }
 
     // Enumerate displays to add any new ones and mark still
@@ -902,8 +902,8 @@ void WIN_RefreshDisplays(SDL_VideoDevice *_this)
     // in reverse as each delete takes effect immediately
     for (i = _this->num_displays - 1; i >= 0; --i) {
         SDL_VideoDisplay *display = _this->displays[i];
-        SDL_DisplayData *driverdata = display->driverdata;
-        if (driverdata->state == DisplayRemoved) {
+        SDL_DisplayData *internal = display->internal;
+        if (internal->state == DisplayRemoved) {
             SDL_DelVideoDisplay(display->id, SDL_TRUE);
         }
     }
@@ -911,8 +911,8 @@ void WIN_RefreshDisplays(SDL_VideoDevice *_this)
     // Send events for any newly added displays
     for (i = 0; i < _this->num_displays; ++i) {
         SDL_VideoDisplay *display = _this->displays[i];
-        SDL_DisplayData *driverdata = display->driverdata;
-        if (driverdata->state == DisplayAdded) {
+        SDL_DisplayData *internal = display->internal;
+        if (internal->state == DisplayAdded) {
             SDL_SendDisplayEvent(display, SDL_EVENT_DISPLAY_ADDED, 0, 0);
         }
     }

--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -38,7 +38,7 @@ static SDL_Cursor *WIN_CreateDefaultCursor()
 {
     SDL_Cursor *cursor = (SDL_Cursor *)SDL_calloc(1, sizeof(*cursor));
     if (cursor) {
-        cursor->driverdata = LoadCursor(NULL, IDC_ARROW);
+        cursor->internal = LoadCursor(NULL, IDC_ARROW);
     }
 
     return cursor;
@@ -187,7 +187,7 @@ static SDL_Cursor *WIN_CreateCursor(SDL_Surface *surface, int hot_x, int hot_y)
 
     cursor = (SDL_Cursor *)SDL_calloc(1, sizeof(*cursor));
     if (cursor) {
-        cursor->driverdata = hcursor;
+        cursor->internal = hcursor;
     } else {
         DestroyCursor(hcursor);
     }
@@ -283,7 +283,7 @@ static SDL_Cursor *WIN_CreateSystemCursor(SDL_SystemCursor id)
 
         hcursor = LoadCursor(NULL, name);
 
-        cursor->driverdata = hcursor;
+        cursor->internal = hcursor;
     }
 
     return cursor;
@@ -291,7 +291,7 @@ static SDL_Cursor *WIN_CreateSystemCursor(SDL_SystemCursor id)
 
 static void WIN_FreeCursor(SDL_Cursor *cursor)
 {
-    HCURSOR hcursor = (HCURSOR)cursor->driverdata;
+    HCURSOR hcursor = (HCURSOR)cursor->internal;
 
     DestroyCursor(hcursor);
     SDL_free(cursor);
@@ -303,7 +303,7 @@ static int WIN_ShowCursor(SDL_Cursor *cursor)
         cursor = SDL_blank_cursor;
     }
     if (cursor) {
-        SDL_cursor = (HCURSOR)cursor->driverdata;
+        SDL_cursor = (HCURSOR)cursor->internal;
     } else {
         SDL_cursor = NULL;
     }
@@ -336,7 +336,7 @@ void WIN_SetCursorPos(int x, int y)
 
 static int WIN_WarpMouse(SDL_Window *window, float x, float y)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     HWND hwnd = data->hwnd;
     POINT pt;
 
@@ -373,13 +373,13 @@ static int WIN_SetRelativeMouseMode(SDL_bool enabled)
 static int WIN_CaptureMouse(SDL_Window *window)
 {
     if (window) {
-        SDL_WindowData *data = window->driverdata;
+        SDL_WindowData *data = window->internal;
         SetCapture(data->hwnd);
     } else {
         SDL_Window *focus_window = SDL_GetMouseFocus();
 
         if (focus_window) {
-            SDL_WindowData *data = focus_window->driverdata;
+            SDL_WindowData *data = focus_window->internal;
             if (!data->mouse_tracked) {
                 SDL_SetMouseFocus(NULL);
             }

--- a/src/video/windows/SDL_windowsopengl.c
+++ b/src/video/windows/SDL_windowsopengl.c
@@ -567,7 +567,7 @@ static int WIN_GL_ChoosePixelFormatARB(SDL_VideoDevice *_this, int *iAttribs, fl
 /* actual work of WIN_GL_SetupWindow() happens here. */
 static int WIN_GL_SetupWindowInternal(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    HDC hdc = window->driverdata->hdc;
+    HDC hdc = window->internal->hdc;
     PIXELFORMATDESCRIPTOR pfd;
     int pixel_format = 0;
     int iAttribs[64];
@@ -705,7 +705,7 @@ SDL_bool WIN_GL_UseEGL(SDL_VideoDevice *_this)
 
 SDL_GLContext WIN_GL_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    HDC hdc = window->driverdata->hdc;
+    HDC hdc = window->internal->hdc;
     HGLRC context, share_context;
 
     if (_this->gl_config.profile_mask == SDL_GL_CONTEXT_PROFILE_ES && WIN_GL_UseEGL(_this)) {
@@ -851,7 +851,7 @@ int WIN_GL_MakeCurrent(SDL_VideoDevice *_this, SDL_Window *window, SDL_GLContext
         }
     }
 
-    hdc = window->driverdata->hdc;
+    hdc = window->internal->hdc;
     if (!_this->gl_data->wglMakeCurrent(hdc, (HGLRC)context)) {
         return WIN_SetError("wglMakeCurrent()");
     }
@@ -884,7 +884,7 @@ int WIN_GL_GetSwapInterval(SDL_VideoDevice *_this, int *interval)
 
 int WIN_GL_SwapWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    HDC hdc = window->driverdata->hdc;
+    HDC hdc = window->internal->hdc;
 
     if (!SwapBuffers(hdc)) {
         return WIN_SetError("SwapBuffers()");

--- a/src/video/windows/SDL_windowsopengles.c
+++ b/src/video/windows/SDL_windowsopengles.c
@@ -63,7 +63,7 @@ int WIN_GLES_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 SDL_GLContext WIN_GLES_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
 {
     SDL_GLContext context;
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
 
 #ifdef SDL_VIDEO_OPENGL_WGL
     if (_this->gl_config.profile_mask != SDL_GL_CONTEXT_PROFILE_ES &&
@@ -107,7 +107,7 @@ SDL_EGL_MakeCurrent_impl(WIN)
 int WIN_GLES_SetupWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
     /* The current context is lost in here; save it and reset it. */
-    SDL_WindowData *windowdata = window->driverdata;
+    SDL_WindowData *windowdata = window->internal;
     SDL_Window *current_win = SDL_GL_GetCurrentWindow();
     SDL_GLContext current_ctx = SDL_GL_GetCurrentContext();
 
@@ -136,7 +136,7 @@ int WIN_GLES_SetupWindow(SDL_VideoDevice *_this, SDL_Window *window)
 EGLSurface
 WIN_GLES_GetEGLSurface(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *windowdata = window->driverdata;
+    SDL_WindowData *windowdata = window->internal;
 
     return windowdata->egl_surface;
 }

--- a/src/video/windows/SDL_windowsrawinput.c
+++ b/src/video/windows/SDL_windowsrawinput.c
@@ -181,7 +181,7 @@ done:
 
 static int WIN_UpdateRawInputEnabled(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     Uint32 flags = 0;
     if (data->raw_mouse_enabled) {
         flags |= ENABLE_RAW_MOUSE_INPUT;
@@ -201,14 +201,14 @@ static int WIN_UpdateRawInputEnabled(SDL_VideoDevice *_this)
 
 int WIN_SetRawMouseEnabled(SDL_VideoDevice *_this, SDL_bool enabled)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     data->raw_mouse_enabled = enabled;
     return WIN_UpdateRawInputEnabled(_this);
 }
 
 int WIN_SetRawKeyboardEnabled(SDL_VideoDevice *_this, SDL_bool enabled)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     data->raw_keyboard_enabled = enabled;
     return WIN_UpdateRawInputEnabled(_this);
 }

--- a/src/video/windows/SDL_windowsshape.c
+++ b/src/video/windows/SDL_windowsshape.c
@@ -69,7 +69,7 @@ static HRGN GenerateSpanListRegion(SDL_Surface *shape, int offset_x, int offset_
 
 int WIN_UpdateWindowShape(SDL_VideoDevice *_this, SDL_Window *window, SDL_Surface *shape)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     HRGN mask = NULL;
 
     /* Generate a set of spans for the region */

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -93,7 +93,7 @@ extern void D3D12_XBOX_GetResolution(Uint32 *width, Uint32 *height);
 
 static void WIN_DeleteDevice(SDL_VideoDevice *device)
 {
-    SDL_VideoData *data = device->driverdata;
+    SDL_VideoData *data = device->internal;
 
     SDL_UnregisterApp();
 #if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
@@ -115,8 +115,8 @@ static void WIN_DeleteDevice(SDL_VideoDevice *device)
     if (device->wakeup_lock) {
         SDL_DestroyMutex(device->wakeup_lock);
     }
-    SDL_free(device->driverdata->rawinput);
-    SDL_free(device->driverdata);
+    SDL_free(device->internal->rawinput);
+    SDL_free(device->internal);
     SDL_free(device);
 }
 
@@ -138,7 +138,7 @@ static SDL_VideoDevice *WIN_CreateDevice(void)
         SDL_free(device);
         return NULL;
     }
-    device->driverdata = data;
+    device->internal = data;
     device->wakeup_lock = SDL_CreateMutex();
     device->system_theme = WIN_GetSystemTheme();
 
@@ -335,7 +335,7 @@ VideoBootStrap WINDOWS_bootstrap = {
 static BOOL WIN_DeclareDPIAwareUnaware(SDL_VideoDevice *_this)
 {
 #if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
 
     if (data->SetProcessDpiAwarenessContext) {
         return data->SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_UNAWARE);
@@ -350,7 +350,7 @@ static BOOL WIN_DeclareDPIAwareUnaware(SDL_VideoDevice *_this)
 static BOOL WIN_DeclareDPIAwareSystem(SDL_VideoDevice *_this)
 {
 #if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
 
     if (data->SetProcessDpiAwarenessContext) {
         /* Windows 10, version 1607 */
@@ -369,7 +369,7 @@ static BOOL WIN_DeclareDPIAwareSystem(SDL_VideoDevice *_this)
 static BOOL WIN_DeclareDPIAwarePerMonitor(SDL_VideoDevice *_this)
 {
 #if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
 
     if (data->SetProcessDpiAwarenessContext) {
         /* Windows 10, version 1607 */
@@ -391,7 +391,7 @@ static BOOL WIN_DeclareDPIAwarePerMonitorV2(SDL_VideoDevice *_this)
 #if defined(SDL_PLATFORM_XBOXONE) || defined(SDL_PLATFORM_XBOXSERIES)
     return FALSE;
 #else
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
 
     /* Declare DPI aware (may have been done in external code or a manifest, as well) */
     if (data->SetProcessDpiAwarenessContext) {
@@ -427,7 +427,7 @@ static BOOL WIN_DeclareDPIAwarePerMonitorV2(SDL_VideoDevice *_this)
 #ifdef HIGHDPI_DEBUG
 static const char *WIN_GetDPIAwareness(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
 
     if (data->GetThreadDpiAwarenessContext && data->AreDpiAwarenessContextsEqual) {
         DPI_AWARENESS_CONTEXT context = data->GetThreadDpiAwarenessContext();
@@ -466,7 +466,7 @@ static void WIN_InitDPIAwareness(SDL_VideoDevice *_this)
 
 int WIN_VideoInit(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
 
     WIN_InitDPIAwareness(_this);
 
@@ -642,7 +642,7 @@ SDL_bool SDL_DXGIGetOutputInfo(SDL_DisplayID displayID, int *adapterIndex, int *
     return SDL_FALSE;
 #else
     const SDL_VideoDevice *videodevice = SDL_GetVideoDevice();
-    const SDL_VideoData *videodata = videodevice ? videodevice->driverdata : NULL;
+    const SDL_VideoData *videodata = videodevice ? videodevice->internal : NULL;
     SDL_DisplayData *pData = SDL_GetDisplayDriverData(displayID);
     int nAdapter, nOutput;
     IDXGIAdapter *pDXGIAdapter;
@@ -720,7 +720,7 @@ SDL_SystemTheme WIN_GetSystemTheme(void)
 SDL_bool WIN_IsPerMonitorV2DPIAware(SDL_VideoDevice *_this)
 {
 #if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
 
     if (data->AreDpiAwarenessContextsEqual && data->GetThreadDpiAwarenessContext) {
         /* Windows 10, version 1607 */

--- a/src/video/windows/SDL_windowsvulkan.c
+++ b/src/video/windows/SDL_windowsvulkan.c
@@ -126,7 +126,7 @@ int WIN_Vulkan_CreateSurface(SDL_VideoDevice *_this,
                              const struct VkAllocationCallbacks *allocator,
                              VkSurfaceKHR *surface)
 {
-    SDL_WindowData *windowData = window->driverdata;
+    SDL_WindowData *windowData = window->internal;
     PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr =
         (PFN_vkGetInstanceProcAddr)_this->vulkan_config.vkGetInstanceProcAddr;
     PFN_vkCreateWin32SurfaceKHR vkCreateWin32SurfaceKHR =

--- a/src/video/winrt/SDL_winrtgamebar.cpp
+++ b/src/video/winrt/SDL_winrtgamebar.cpp
@@ -144,7 +144,7 @@ static void WINRT_HandleGameBarIsInputRedirected_NonMainThread(Platform::Object 
 
 void WINRT_InitGameBar(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *driverdata = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     IGameBarStatics_ *gameBar = WINRT_GetGameBar();
     if (gameBar) {
         /* GameBar.IsInputRedirected events can come in via something other than
@@ -157,26 +157,26 @@ void WINRT_InitGameBar(SDL_VideoDevice *_this)
         Windows::Foundation::EventHandler<Platform::Object ^> ^ handler =
             ref new Windows::Foundation::EventHandler<Platform::Object ^>(&WINRT_HandleGameBarIsInputRedirected_NonMainThread);
         __FIEventHandler_1_IInspectable *pHandler = reinterpret_cast<__FIEventHandler_1_IInspectable *>(handler);
-        gameBar->add_IsInputRedirectedChanged(pHandler, &driverdata->gameBarIsInputRedirectedToken);
+        gameBar->add_IsInputRedirectedChanged(pHandler, &data->gameBarIsInputRedirectedToken);
         gameBar->Release();
     }
 }
 
 void WINRT_QuitGameBar(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *driverdata;
+    SDL_VideoData *data;
     IGameBarStatics_ *gameBar;
-    if (!_this || !_this->driverdata) {
+    if (!_this || !_this->internal) {
         return;
     }
     gameBar = WINRT_GetGameBar();
     if (!gameBar) {
         return;
     }
-    driverdata = _this->driverdata;
-    if (driverdata->gameBarIsInputRedirectedToken.Value) {
-        gameBar->remove_IsInputRedirectedChanged(driverdata->gameBarIsInputRedirectedToken);
-        driverdata->gameBarIsInputRedirectedToken.Value = 0;
+    data = _this->internal;
+    if (data->gameBarIsInputRedirectedToken.Value) {
+        gameBar->remove_IsInputRedirectedChanged(data->gameBarIsInputRedirectedToken);
+        data->gameBarIsInputRedirectedToken.Value = 0;
     }
     WINRT_MainThreadDispatcher = nullptr;
     gameBar->Release();

--- a/src/video/winrt/SDL_winrtkeyboard.cpp
+++ b/src/video/winrt/SDL_winrtkeyboard.cpp
@@ -88,7 +88,7 @@ void WINRT_ProcessCharacterReceivedEvent(SDL_Window *window, Windows::UI::Core::
         return;
     }
 
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
 
     if (SDL_TextInputActive(window)) {
         /* Characters outside Unicode Basic Multilingual Plane (BMP)

--- a/src/video/winrt/SDL_winrtmouse.cpp
+++ b/src/video/winrt/SDL_winrtmouse.cpp
@@ -120,12 +120,12 @@ static SDL_Cursor *WINRT_CreateSystemCursor(SDL_SystemCursor id)
     if (cursor) {
         /* Create a pointer to a COM reference to a cursor.  The extra
            pointer is used (on top of the COM reference) to allow the cursor
-           to be referenced by the SDL_cursor's driverdata field, which is
+           to be referenced by the SDL_cursor's internal field, which is
            a void pointer.
         */
         CoreCursor ^ *theCursor = new CoreCursor ^ (nullptr);
         *theCursor = ref new CoreCursor(cursorType, 0);
-        cursor->driverdata = (void *)theCursor;
+        cursor->internal = (void *)theCursor;
     }
 
     return cursor;
@@ -138,8 +138,8 @@ static SDL_Cursor *WINRT_CreateDefaultCursor()
 
 static void WINRT_FreeCursor(SDL_Cursor *cursor)
 {
-    if (cursor->driverdata) {
-        CoreCursor ^ *theCursor = (CoreCursor ^ *)cursor->driverdata;
+    if (cursor->internal) {
+        CoreCursor ^ *theCursor = (CoreCursor ^ *)cursor->internal;
         *theCursor = nullptr; // Release the COM reference to the CoreCursor
         delete theCursor;     // Delete the pointer to the COM reference
     }
@@ -155,7 +155,7 @@ static int WINRT_ShowCursor(SDL_Cursor *cursor)
 
     CoreWindow ^ coreWindow = CoreWindow::GetForCurrentThread();
     if (cursor) {
-        CoreCursor ^ *theCursor = (CoreCursor ^ *)cursor->driverdata;
+        CoreCursor ^ *theCursor = (CoreCursor ^ *)cursor->internal;
         coreWindow->PointerCursor = *theCursor;
     } else {
         // HACK ALERT: TL;DR - Hiding the cursor in WinRT/UWP apps is weird, and

--- a/src/video/winrt/SDL_winrtopengles.cpp
+++ b/src/video/winrt/SDL_winrtopengles.cpp
@@ -54,7 +54,7 @@ static const int ANGLE_D3D_FEATURE_LEVEL_ANY = 0;
 extern "C" int
 WINRT_GLES_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 {
-    SDL_VideoData *video_data = _this->driverdata;
+    SDL_VideoData *video_data = _this->internal;
 
     if (SDL_EGL_LoadLibrary(_this, path, EGL_DEFAULT_DISPLAY, 0) != 0) {
         return -1;
@@ -186,7 +186,7 @@ WINRT_GLES_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 extern "C" void
 WINRT_GLES_UnloadLibrary(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *video_data = _this->driverdata;
+    SDL_VideoData *video_data = _this->internal;
 
     /* Release SDL's own COM reference to the ANGLE/WinRT IWinrtEglWindow */
     if (video_data->winrtEglWindow) {

--- a/src/video/winrt/SDL_winrtpointerinput.cpp
+++ b/src/video/winrt/SDL_winrtpointerinput.cpp
@@ -57,7 +57,7 @@ WINRT_TransformCursorPosition(SDL_Window *window,
         return rawPosition;
     }
 
-    SDL_WindowData *windowData = window->driverdata;
+    SDL_WindowData *windowData = window->internal;
     if (windowData->coreWindow == nullptr) {
         // For some reason, the window isn't associated with a CoreWindow.
         // This might end up being the case as XAML support is extended.

--- a/src/video/winrt/SDL_winrtvideo.cpp
+++ b/src/video/winrt/SDL_winrtvideo.cpp
@@ -89,8 +89,8 @@ SDL_Window *WINRT_GlobalSDLWindow = NULL;
 
 static void WINRT_DeleteDevice(SDL_VideoDevice *device)
 {
-    if (device->driverdata) {
-        SDL_VideoData *video_data = device->driverdata;
+    if (device->internal) {
+        SDL_VideoData *video_data = device->internal;
         if (video_data->winrtEglWindow) {
             video_data->winrtEglWindow->Release();
         }
@@ -116,7 +116,7 @@ static SDL_VideoDevice *WINRT_CreateDevice(void)
         SDL_free(device);
         return 0;
     }
-    device->driverdata = data;
+    device->internal = data;
 
     /* Set the function pointers */
     device->VideoInit = WINRT_VideoInit;
@@ -222,7 +222,7 @@ static void SDLCALL WINRT_SetDisplayOrientationsPreference(void *userdata, const
 
 int WINRT_VideoInit(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *driverdata = _this->driverdata;
+    SDL_VideoData *internal = _this->internal;
     if (WINRT_InitModes(_this) < 0) {
         return -1;
     }
@@ -234,9 +234,9 @@ int WINRT_VideoInit(SDL_VideoDevice *_this)
     WINRT_InitMouse(_this);
     WINRT_InitTouch(_this);
     WINRT_InitGameBar(_this);
-    if (driverdata) {
+    if (internal) {
         /* Initialize screensaver-disabling support */
-        driverdata->displayRequest = WINRT_CreateDisplayRequest(_this);
+        internal->displayRequest = WINRT_CreateDisplayRequest(_this);
     }
 
     /* Assume we have a mouse and keyboard */
@@ -466,10 +466,10 @@ static int WINRT_SetDisplayMode(SDL_VideoDevice *_this, SDL_VideoDisplay *displa
 
 void WINRT_VideoQuit(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *driverdata = _this->driverdata;
-    if (driverdata && driverdata->displayRequest) {
-        driverdata->displayRequest->Release();
-        driverdata->displayRequest = NULL;
+    SDL_VideoData *internal = _this->internal;
+    if (internal && internal->displayRequest) {
+        internal->displayRequest->Release();
+        internal->displayRequest = NULL;
     }
     WINRT_QuitGameBar(_this);
     WINRT_QuitMouse(_this);
@@ -481,7 +481,7 @@ extern "C" SDL_WindowFlags
 WINRT_DetectWindowFlags(SDL_Window *window)
 {
     SDL_WindowFlags latestFlags = 0;
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     bool is_fullscreen = false;
 
 #if SDL_WINRT_USE_APPLICATIONVIEW
@@ -592,7 +592,7 @@ int WINRT_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Propertie
     if (!data) {
         return SDL_OutOfMemory();
     }
-    window->driverdata = data;
+    window->internal = data;
     data->sdlWindow = window;
     data->high_surrogate = L'\0';
 
@@ -620,7 +620,7 @@ int WINRT_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Propertie
         data->egl_surface = EGL_NO_SURFACE;
     } else {
         /* OpenGL ES 2 was requested.  Set up an EGL surface. */
-        SDL_VideoData *video_data = _this->driverdata;
+        SDL_VideoData *video_data = _this->internal;
 
         /* Call SDL_EGL_ChooseConfig and eglCreateWindowSurface directly,
          * rather than via SDL_EGL_CreateSurface, as older versions of
@@ -735,7 +735,7 @@ int WINRT_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Propertie
 void WINRT_SetWindowSize(SDL_VideoDevice *_this, SDL_Window *window)
 {
 #if NTDDI_VERSION >= NTDDI_WIN10
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     const Windows::Foundation::Size size((float)window->floating.w, (float)window->floating.h);
     if (data->appView->TryResizeView(size)) {
         SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_RESIZED, window->floating.w, window->floating.h);
@@ -746,7 +746,7 @@ void WINRT_SetWindowSize(SDL_VideoDevice *_this, SDL_Window *window)
 int WINRT_SetWindowFullscreen(SDL_VideoDevice *_this, SDL_Window *window, SDL_VideoDisplay *display, SDL_FullscreenOp fullscreen)
 {
 #if NTDDI_VERSION >= NTDDI_WIN10
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     bool isWindowActive = WINRT_IsCoreWindowActive(data->coreWindow.Get());
     if (isWindowActive) {
         if (fullscreen) {
@@ -766,7 +766,7 @@ int WINRT_SetWindowFullscreen(SDL_VideoDevice *_this, SDL_Window *window, SDL_Vi
 
 void WINRT_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
 
     if (WINRT_GlobalSDLWindow == window) {
         WINRT_GlobalSDLWindow = NULL;
@@ -776,7 +776,7 @@ void WINRT_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
         // Delete the internal window data:
         delete data;
         data = NULL;
-        window->driverdata = NULL;
+        window->internal = NULL;
     }
 }
 
@@ -826,9 +826,9 @@ done:
 
 int WINRT_SuspendScreenSaver(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *driverdata = _this->driverdata;
-    if (driverdata && driverdata->displayRequest) {
-        ABI::Windows::System::Display::IDisplayRequest *displayRequest = (ABI::Windows::System::Display::IDisplayRequest *)driverdata->displayRequest;
+    SDL_VideoData *internal = _this->internal;
+    if (internal && internal->displayRequest) {
+        ABI::Windows::System::Display::IDisplayRequest *displayRequest = (ABI::Windows::System::Display::IDisplayRequest *)internal->displayRequest;
         if (_this->suspend_screensaver) {
             displayRequest->RequestActive();
         } else {

--- a/src/video/x11/SDL_x11clipboard.c
+++ b/src/video/x11/SDL_x11clipboard.c
@@ -40,7 +40,7 @@ static const char *text_mime_types[] = {
 /* Get any application owned window handle for clipboard association */
 static Window GetWindow(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
 
     /* We create an unmapped window that exists just to manage the clipboard,
        since X11 selection data is tied to a specific window and dies with it.
@@ -64,7 +64,7 @@ static Window GetWindow(SDL_VideoDevice *_this)
 static int SetSelectionData(SDL_VideoDevice *_this, Atom selection, SDL_ClipboardDataCallback callback,
                             void *userdata, const char **mime_types, size_t mime_count, Uint32 sequence)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     Display *display = videodata->display;
     Window window;
     SDLX11_ClipboardData *clipboard;
@@ -159,7 +159,7 @@ static SDL_bool WaitForSelection(SDL_VideoDevice *_this, Atom selection_type, SD
 static void *GetSelectionData(SDL_VideoDevice *_this, Atom selection_type,
                               const char *mime_type, size_t *length)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     Display *display = videodata->display;
     Window window;
     Window owner;
@@ -267,7 +267,7 @@ const char **X11_GetTextMimeTypes(SDL_VideoDevice *_this, size_t *num_mime_types
 
 int X11_SetClipboardData(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     Atom XA_CLIPBOARD = X11_XInternAtom(videodata->display, "CLIPBOARD", 0);
     if (XA_CLIPBOARD == None) {
         return SDL_SetError("Couldn't access X clipboard");
@@ -277,7 +277,7 @@ int X11_SetClipboardData(SDL_VideoDevice *_this)
 
 void *X11_GetClipboardData(SDL_VideoDevice *_this, const char *mime_type, size_t *length)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     Atom XA_CLIPBOARD = X11_XInternAtom(videodata->display, "CLIPBOARD", 0);
     if (XA_CLIPBOARD == None) {
         SDL_SetError("Couldn't access X clipboard");
@@ -328,7 +328,7 @@ SDL_bool X11_HasPrimarySelectionText(SDL_VideoDevice *_this)
 
 void X11_QuitClipboard(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     if (data->primary_selection.sequence == 0) {
         SDL_free(data->primary_selection.userdata);
     }

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -221,7 +221,7 @@ void SDL_SetX11EventHook(SDL_X11EventHook callback, void *userdata)
 #ifdef SDL_VIDEO_DRIVER_X11_SUPPORTS_GENERIC_EVENTS
 static void X11_HandleGenericEvent(SDL_VideoDevice *_this, XEvent *xev)
 {
-    SDL_VideoData *videodata = (SDL_VideoData *)_this->driverdata;
+    SDL_VideoData *videodata = (SDL_VideoData *)_this->internal;
 
     /* event is a union, so cookie == &event, but this is type safe. */
     XGenericEventCookie *cookie = &xev->xcookie;
@@ -236,7 +236,7 @@ static void X11_HandleGenericEvent(SDL_VideoDevice *_this, XEvent *xev)
 
 static unsigned X11_GetNumLockModifierMask(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     Display *display = videodata->display;
     unsigned num_mask = 0;
     int i, j;
@@ -261,7 +261,7 @@ static unsigned X11_GetNumLockModifierMask(SDL_VideoDevice *_this)
 
 static unsigned X11_GetScrollLockModifierMask(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     Display *display = videodata->display;
     unsigned num_mask = 0;
     int i, j;
@@ -286,7 +286,7 @@ static unsigned X11_GetScrollLockModifierMask(SDL_VideoDevice *_this)
 
 void X11_ReconcileKeyboardState(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     Display *display = videodata->display;
     char keys[32];
     int keycode;
@@ -393,7 +393,7 @@ static void X11_DispatchUnmapNotify(SDL_WindowData *data)
 
 static void DispatchWindowMove(SDL_VideoDevice *_this, const SDL_WindowData *data, const SDL_Point *point)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     SDL_Window *window = data->window;
     Display *display = videodata->display;
     XEvent evt;
@@ -424,7 +424,7 @@ static void ScheduleWindowMove(SDL_VideoDevice *_this, SDL_WindowData *data, con
 
 static void InitiateWindowResize(SDL_VideoDevice *_this, const SDL_WindowData *data, const SDL_Point *point, int direction)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     SDL_Window *window = data->window;
     Display *display = videodata->display;
     XEvent evt;
@@ -527,7 +527,7 @@ static void X11_UpdateUserTime(SDL_WindowData *data, const unsigned long latest)
 static void X11_HandleClipboardEvent(SDL_VideoDevice *_this, const XEvent *xevent)
 {
     int i;
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     Display *display = videodata->display;
 
     SDL_assert(videodata->clipboard_window != None);
@@ -666,7 +666,7 @@ static void X11_HandleClipboardEvent(SDL_VideoDevice *_this, const XEvent *xeven
 
 static void X11_HandleSettingsEvent(SDL_VideoDevice *_this, const XEvent *xevent)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
 
     SDL_assert(videodata->xsettings_window != None);
     SDL_assert(xevent->xany.window == videodata->xsettings_window);
@@ -726,7 +726,7 @@ static int XLookupStringAsUTF8(XKeyEvent *event_struct, char *buffer_return, int
 
 SDL_WindowData *X11_FindWindow(SDL_VideoDevice *_this, Window window)
 {
-    const SDL_VideoData *videodata = (SDL_VideoData *)_this->driverdata;
+    const SDL_VideoData *videodata = (SDL_VideoData *)_this->internal;
     int i;
 
     if (videodata && videodata->windowlist) {
@@ -742,7 +742,7 @@ SDL_WindowData *X11_FindWindow(SDL_VideoDevice *_this, Window window)
 
 void X11_HandleKeyEvent(SDL_VideoDevice *_this, SDL_WindowData *windowdata, SDL_KeyboardID keyboardID, XEvent *xevent)
 {
-    SDL_VideoData *videodata = (SDL_VideoData *)_this->driverdata;
+    SDL_VideoData *videodata = (SDL_VideoData *)_this->internal;
     Display *display = videodata->display;
     KeyCode keycode = xevent->xkey.keycode;
     KeySym keysym = NoSymbol;
@@ -842,7 +842,7 @@ void X11_HandleKeyEvent(SDL_VideoDevice *_this, SDL_WindowData *windowdata, SDL_
 void X11_HandleButtonPress(SDL_VideoDevice *_this, SDL_WindowData *windowdata, SDL_MouseID mouseID, int button, const float x, const float y, const unsigned long time)
 {
     SDL_Window *window = windowdata->window;
-    const SDL_VideoData *videodata = (SDL_VideoData *)_this->driverdata;
+    const SDL_VideoData *videodata = (SDL_VideoData *)_this->internal;
     Display *display = videodata->display;
     int xticks = 0, yticks = 0;
 #ifdef DEBUG_XEVENTS
@@ -879,7 +879,7 @@ void X11_HandleButtonPress(SDL_VideoDevice *_this, SDL_WindowData *windowdata, S
 void X11_HandleButtonRelease(SDL_VideoDevice *_this, SDL_WindowData *windowdata, SDL_MouseID mouseID, int button)
 {
     SDL_Window *window = windowdata->window;
-    const SDL_VideoData *videodata = (SDL_VideoData *)_this->driverdata;
+    const SDL_VideoData *videodata = (SDL_VideoData *)_this->internal;
     Display *display = videodata->display;
     /* The X server sends a Release event for each Press for wheels. Ignore them. */
     int xticks = 0, yticks = 0;
@@ -927,7 +927,7 @@ void X11_GetBorderValues(SDL_WindowData *data)
 
 static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     Display *display;
     SDL_WindowData *data;
     XClientMessageEvent m;
@@ -1097,7 +1097,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
 #ifdef SDL_VIDEO_DRIVER_X11_XFIXES
         {
             /* Only create the barriers if we have input focus */
-            SDL_WindowData *windowdata = data->window->driverdata;
+            SDL_WindowData *windowdata = data->window->internal;
             if ((data->pointer_barrier_active == SDL_TRUE) && windowdata->window->flags & SDL_WINDOW_INPUT_FOCUS) {
                 X11_ConfineCursorWithFlags(_this, windowdata->window, &windowdata->barrier_rect, X11_BARRIER_HANDLED_BY_EVENT);
             }
@@ -1800,7 +1800,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
 
 static void X11_HandleFocusChanges(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     int i;
 
     if (videodata && videodata->windowlist) {
@@ -1837,9 +1837,9 @@ static SDL_bool X11_PollEvent(Display *display, XEvent *event)
 
 void X11_SendWakeupEvent(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     Display *req_display = data->request_display;
-    Window xwindow = window->driverdata->xwindow;
+    Window xwindow = window->internal->xwindow;
     XClientMessageEvent event;
 
     SDL_memset(&event, 0, sizeof(XClientMessageEvent));
@@ -1857,7 +1857,7 @@ void X11_SendWakeupEvent(SDL_VideoDevice *_this, SDL_Window *window)
 
 int X11_WaitEventTimeout(SDL_VideoDevice *_this, Sint64 timeoutNS)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     Display *display;
     XEvent xevent;
     display = videodata->display;
@@ -1912,7 +1912,7 @@ int X11_WaitEventTimeout(SDL_VideoDevice *_this, Sint64 timeoutNS)
 
 void X11_PumpEvents(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     XEvent xevent;
     int i;
 
@@ -1920,10 +1920,10 @@ void X11_PumpEvents(SDL_VideoDevice *_this)
      * fullscreen. If there is no fullscreen window past the elapsed timeout, revert the mode switch.
      */
     for (i = 0; i < _this->num_displays; ++i) {
-        if (_this->displays[i]->driverdata->mode_switch_deadline_ns) {
+        if (_this->displays[i]->internal->mode_switch_deadline_ns) {
             if (_this->displays[i]->fullscreen_window) {
-                _this->displays[i]->driverdata->mode_switch_deadline_ns = 0;
-            } else if (SDL_GetTicksNS() >= _this->displays[i]->driverdata->mode_switch_deadline_ns) {
+                _this->displays[i]->internal->mode_switch_deadline_ns = 0;
+            } else if (SDL_GetTicksNS() >= _this->displays[i]->internal->mode_switch_deadline_ns) {
                 SDL_LogError(SDL_LOG_CATEGORY_VIDEO,
                              "Time out elapsed after mode switch on display %" SDL_PRIu32 " with no window becoming fullscreen; reverting", _this->displays[i]->id);
                 SDL_SetDisplayModeForDisplay(_this->displays[i], NULL);
@@ -1993,7 +1993,7 @@ void X11_PumpEvents(SDL_VideoDevice *_this)
 int X11_SuspendScreenSaver(SDL_VideoDevice *_this)
 {
 #ifdef SDL_VIDEO_DRIVER_X11_XSCRNSAVER
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     int dummy;
     int major_version, minor_version;
 #endif /* SDL_VIDEO_DRIVER_X11_XSCRNSAVER */

--- a/src/video/x11/SDL_x11framebuffer.c
+++ b/src/video/x11/SDL_x11framebuffer.c
@@ -50,7 +50,7 @@ static SDL_bool have_mitshm(Display *dpy)
 int X11_CreateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, SDL_PixelFormat *format,
                                 void **pixels, int *pitch)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
     XGCValues gcv;
     XVisualInfo vinfo;
@@ -145,7 +145,7 @@ int X11_CreateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, SDL_
 int X11_UpdateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, const SDL_Rect *rects,
                                 int numrects)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
     int i;
     int x, y, w, h;
@@ -223,7 +223,7 @@ int X11_UpdateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, cons
 
 void X11_DestroyWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display;
 
     if (!data) {

--- a/src/video/x11/SDL_x11keyboard.c
+++ b/src/video/x11/SDL_x11keyboard.c
@@ -83,7 +83,7 @@ static SDL_Scancode X11_KeyCodeToSDLScancode(SDL_VideoDevice *_this, KeyCode key
 
 KeySym X11_KeyCodeToSym(SDL_VideoDevice *_this, KeyCode keycode, unsigned char group, unsigned int mod_mask)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     KeySym keysym;
     unsigned int mods_ret[16];
 
@@ -125,7 +125,7 @@ KeySym X11_KeyCodeToSym(SDL_VideoDevice *_this, KeyCode keycode, unsigned char g
 
 int X11_InitKeyboard(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     int i = 0;
     int j = 0;
     int min_keycode, max_keycode;
@@ -343,7 +343,7 @@ void X11_UpdateKeymap(SDL_VideoDevice *_this, SDL_bool send_event)
         { SDL_KMOD_MODE | SDL_KMOD_SHIFT | SDL_KMOD_CAPS, Mod5Mask | ShiftMask | LockMask }
     };
 
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     int i;
     SDL_Scancode scancode;
     SDL_Keymap *keymap;
@@ -392,7 +392,7 @@ void X11_UpdateKeymap(SDL_VideoDevice *_this, SDL_bool send_event)
 
 void X11_QuitKeyboard(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
 
 #ifdef SDL_VIDEO_DRIVER_X11_HAS_XKBLOOKUPKEYSYM
     if (data->xkb) {
@@ -409,7 +409,7 @@ void X11_QuitKeyboard(SDL_VideoDevice *_this)
 static void X11_ResetXIM(SDL_VideoDevice *_this, SDL_Window *window)
 {
 #ifdef X_HAVE_UTF8_STRING
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
 
     if (data && data->ic) {
         /* Clear any partially entered dead keys */
@@ -447,13 +447,13 @@ int X11_UpdateTextInputArea(SDL_VideoDevice *_this, SDL_Window *window)
 
 SDL_bool X11_HasScreenKeyboardSupport(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     return videodata->is_steam_deck;
 }
 
 void X11_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
 
     if (videodata->is_steam_deck) {
         /* For more documentation of the URL parameters, see:
@@ -470,7 +470,7 @@ void X11_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window)
 
 void X11_HideScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
 
     if (videodata->is_steam_deck) {
         SDL_OpenURL("steam://close/keyboard");
@@ -480,7 +480,7 @@ void X11_HideScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window)
 
 SDL_bool X11_IsScreenKeyboardShown(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
 
     return videodata->steam_keyboard_open;
 }

--- a/src/video/x11/SDL_x11messagebox.c
+++ b/src/video/x11/SDL_x11messagebox.c
@@ -410,7 +410,7 @@ static int X11_MessageBoxCreateWindow(SDL_MessageBoxDataX11 *data)
 
     if (messageboxdata->window) {
         SDL_DisplayData *displaydata = SDL_GetDisplayDriverDataForWindow(messageboxdata->window);
-        windowdata = messageboxdata->window->driverdata;
+        windowdata = messageboxdata->window->internal;
         data->screen = displaydata->screen;
     } else {
         data->screen = DefaultScreen(display);
@@ -475,7 +475,7 @@ static int X11_MessageBoxCreateWindow(SDL_MessageBoxDataX11 *data)
         const SDL_VideoDevice *dev = SDL_GetVideoDevice();
         if (dev && dev->displays && dev->num_displays > 0) {
             const SDL_VideoDisplay *dpy = dev->displays[0];
-            const SDL_DisplayData *dpydata = dpy->driverdata;
+            const SDL_DisplayData *dpydata = dpy->internal;
             x = dpydata->x + ((dpy->current_mode->w - data->dialog_width) / 2);
             y = dpydata->y + ((dpy->current_mode->h - data->dialog_height) / 3);
         } else { /* oh well. This will misposition on a multi-head setup. Init first next time. */

--- a/src/video/x11/SDL_x11mouse.c
+++ b/src/video/x11/SDL_x11mouse.c
@@ -36,7 +36,7 @@ static SDL_Cursor *sys_cursors[SDL_HITTEST_RESIZE_LEFT + 1];
 
 static Display *GetDisplay(void)
 {
-    return SDL_GetVideoDevice()->driverdata->display;
+    return SDL_GetVideoDevice()->internal->display;
 }
 
 static Cursor X11_CreateEmptyCursor(void)
@@ -73,7 +73,7 @@ static SDL_Cursor *X11_CreateDefaultCursor(void)
     SDL_Cursor *cursor = SDL_calloc(1, sizeof(*cursor));
     if (cursor) {
         /* None is used to indicate the default cursor */
-        cursor->driverdata = (void *)(uintptr_t)None;
+        cursor->internal = (void *)(uintptr_t)None;
     }
     return cursor;
 }
@@ -206,7 +206,7 @@ static SDL_Cursor *X11_CreateCursor(SDL_Surface *surface, int hot_x, int hot_y)
         if (x11_cursor == None) {
             x11_cursor = X11_CreatePixmapCursor(surface, hot_x, hot_y);
         }
-        cursor->driverdata = (void *)(uintptr_t)x11_cursor;
+        cursor->internal = (void *)(uintptr_t)x11_cursor;
     }
 
     return cursor;
@@ -263,7 +263,7 @@ static SDL_Cursor *X11_CreateSystemCursor(SDL_SystemCursor id)
     if (x11_cursor != None) {
         cursor = SDL_calloc(1, sizeof(*cursor));
         if (cursor) {
-            cursor->driverdata = (void *)(uintptr_t)x11_cursor;
+            cursor->internal = (void *)(uintptr_t)x11_cursor;
         }
     }
 
@@ -272,7 +272,7 @@ static SDL_Cursor *X11_CreateSystemCursor(SDL_SystemCursor id)
 
 static void X11_FreeCursor(SDL_Cursor *cursor)
 {
-    Cursor x11_cursor = (Cursor)cursor->driverdata;
+    Cursor x11_cursor = (Cursor)cursor->internal;
 
     if (x11_cursor != None) {
         X11_XFreeCursor(GetDisplay(), x11_cursor);
@@ -285,7 +285,7 @@ static int X11_ShowCursor(SDL_Cursor *cursor)
     Cursor x11_cursor = 0;
 
     if (cursor) {
-        x11_cursor = (Cursor)cursor->driverdata;
+        x11_cursor = (Cursor)cursor->internal;
     } else {
         x11_cursor = X11_CreateEmptyCursor();
     }
@@ -297,7 +297,7 @@ static int X11_ShowCursor(SDL_Cursor *cursor)
         SDL_Window *window;
 
         for (window = video->windows; window; window = window->next) {
-            SDL_WindowData *data = window->driverdata;
+            SDL_WindowData *data = window->internal;
             if (data) {
                 if (x11_cursor != None) {
                     X11_XDefineCursor(display, data->xwindow, x11_cursor);
@@ -313,7 +313,7 @@ static int X11_ShowCursor(SDL_Cursor *cursor)
 
 static void X11_WarpMouseInternal(Window xwindow, float x, float y)
 {
-    SDL_VideoData *videodata = SDL_GetVideoDevice()->driverdata;
+    SDL_VideoData *videodata = SDL_GetVideoDevice()->internal;
     Display *display = videodata->display;
     SDL_Mouse *mouse = SDL_GetMouse();
     SDL_bool warp_hack = SDL_FALSE;
@@ -354,7 +354,7 @@ static void X11_WarpMouseInternal(Window xwindow, float x, float y)
 
 static int X11_WarpMouse(SDL_Window *window, float x, float y)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
 
 #ifdef SDL_VIDEO_DRIVER_X11_XFIXES
     /* If we have no barrier, we need to warp */
@@ -387,7 +387,7 @@ static int X11_CaptureMouse(SDL_Window *window)
     SDL_Window *mouse_focus = SDL_GetMouseFocus();
 
     if (window) {
-        SDL_WindowData *data = window->driverdata;
+        SDL_WindowData *data = window->internal;
 
         /* If XInput2 is handling the pointer input, non-confinement grabs will always fail with 'AlreadyGrabbed',
          * since the pointer is being grabbed by XInput2.
@@ -415,7 +415,7 @@ static int X11_CaptureMouse(SDL_Window *window)
 
 static SDL_MouseButtonFlags X11_GetGlobalMouseState(float *x, float *y)
 {
-    SDL_VideoData *videodata = SDL_GetVideoDevice()->driverdata;
+    SDL_VideoData *videodata = SDL_GetVideoDevice()->internal;
     SDL_DisplayID *displays;
     Display *display = GetDisplay();
     int i;
@@ -505,7 +505,7 @@ void X11_InitMouse(SDL_VideoDevice *_this)
 
 void X11_QuitMouse(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     SDL_XInput2DeviceInfo *i;
     SDL_XInput2DeviceInfo *next;
     int j;

--- a/src/video/x11/SDL_x11opengl.c
+++ b/src/video/x11/SDL_x11opengl.c
@@ -232,7 +232,7 @@ int X11_GL_LoadLibrary(SDL_VideoDevice *_this, const char *path)
         return SDL_SetError("Could not retrieve OpenGL functions");
     }
 
-    display = _this->driverdata->display;
+    display = _this->internal->display;
     if (!_this->gl_data->glXQueryExtension(display, &_this->gl_data->errorBase, &_this->gl_data->eventBase)) {
         return SDL_SetError("GLX is not supported");
     }
@@ -337,7 +337,7 @@ static SDL_bool HasExtension(const char *extension, const char *extensions)
 
 static void X11_GL_InitExtensions(SDL_VideoDevice *_this)
 {
-    Display *display = _this->driverdata->display;
+    Display *display = _this->internal->display;
     const int screen = DefaultScreen(display);
     XVisualInfo *vinfo = NULL;
     Window w = 0;
@@ -711,7 +711,7 @@ SDL_bool X11_GL_UseEGL(SDL_VideoDevice *_this)
 
 SDL_GLContext X11_GL_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
     int screen = SDL_GetDisplayDriverDataForWindow(window)->screen;
     XWindowAttributes xattr;
@@ -845,9 +845,9 @@ SDL_GLContext X11_GL_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
 
 int X11_GL_MakeCurrent(SDL_VideoDevice *_this, SDL_Window *window, SDL_GLContext context)
 {
-    Display *display = _this->driverdata->display;
+    Display *display = _this->internal->display;
     Window drawable =
-        (context ? window->driverdata->xwindow : None);
+        (context ? window->internal->xwindow : None);
     GLXContext glx_context = (GLXContext)context;
     int rc;
 
@@ -889,8 +889,8 @@ int X11_GL_SetSwapInterval(SDL_VideoDevice *_this, int interval)
     if ((interval < 0) && (!_this->gl_data->HAS_GLX_EXT_swap_control_tear)) {
         return SDL_SetError("Negative swap interval unsupported in this GL");
     } else if (_this->gl_data->glXSwapIntervalEXT) {
-        Display *display = _this->driverdata->display;
-        const SDL_WindowData *windowdata = SDL_GL_GetCurrentWindow()->driverdata;
+        Display *display = _this->internal->display;
+        const SDL_WindowData *windowdata = SDL_GL_GetCurrentWindow()->internal;
 
         Window drawable = windowdata->xwindow;
 
@@ -937,7 +937,7 @@ static SDL_GLSwapIntervalTearBehavior CheckSwapIntervalTearBehavior(SDL_VideoDev
         if (!_this->gl_data->HAS_GLX_EXT_swap_control_tear) {
             _this->gl_data->swap_interval_tear_behavior = SDL_SWAPINTERVALTEAR_UNKNOWN;
         } else {
-            Display *display = _this->driverdata->display;
+            Display *display = _this->internal->display;
             unsigned int allow_late_swap_tearing = 22;
             int original_val = (int) current_val;
 
@@ -978,8 +978,8 @@ static SDL_GLSwapIntervalTearBehavior CheckSwapIntervalTearBehavior(SDL_VideoDev
 int X11_GL_GetSwapInterval(SDL_VideoDevice *_this, int *interval)
 {
     if (_this->gl_data->glXSwapIntervalEXT) {
-        Display *display = _this->driverdata->display;
-        const SDL_WindowData *windowdata = SDL_GL_GetCurrentWindow()->driverdata;
+        Display *display = _this->internal->display;
+        const SDL_WindowData *windowdata = SDL_GL_GetCurrentWindow()->internal;
         Window drawable = windowdata->xwindow;
         unsigned int allow_late_swap_tearing = 0;
         unsigned int val = 0;
@@ -1025,7 +1025,7 @@ int X11_GL_GetSwapInterval(SDL_VideoDevice *_this, int *interval)
 
 int X11_GL_SwapWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
 
     _this->gl_data->glXSwapBuffers(display, data->xwindow);
@@ -1034,7 +1034,7 @@ int X11_GL_SwapWindow(SDL_VideoDevice *_this, SDL_Window *window)
 
 int X11_GL_DeleteContext(SDL_VideoDevice *_this, SDL_GLContext context)
 {
-    Display *display = _this->driverdata->display;
+    Display *display = _this->internal->display;
     GLXContext glx_context = (GLXContext)context;
 
     if (!_this->gl_data) {

--- a/src/video/x11/SDL_x11opengles.c
+++ b/src/video/x11/SDL_x11opengles.c
@@ -30,7 +30,7 @@
 
 int X11_GLES_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
 
     /* If the profile requested is not GL ES, switch over to X11_GL functions  */
     if ((_this->gl_config.profile_mask != SDL_GL_CONTEXT_PROFILE_ES) &&
@@ -107,7 +107,7 @@ XVisualInfo *X11_GLES_GetVisual(SDL_VideoDevice *_this, Display *display, int sc
 SDL_GLContext X11_GLES_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
 {
     SDL_GLContext context;
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
 
     X11_XSync(display, False);
@@ -119,7 +119,7 @@ SDL_GLContext X11_GLES_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
 
 SDL_EGLSurface X11_GLES_GetEGLSurface(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     return data->egl_surface;
 }
 

--- a/src/video/x11/SDL_x11pen.c
+++ b/src/video/x11/SDL_x11pen.c
@@ -104,7 +104,7 @@ int X11_PenIDFromDeviceID(int deviceid)
 
 static void pen_atoms_ensure_initialized(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = (SDL_VideoData *)_this->driverdata;
+    SDL_VideoData *data = (SDL_VideoData *)_this->internal;
 
     if (pen_atoms.initialized) {
         return;
@@ -124,7 +124,7 @@ static void pen_atoms_ensure_initialized(SDL_VideoDevice *_this)
    Returns number of Sint32s written (<= max_words), or 0 on error. */
 static size_t xinput2_pen_get_int_property(SDL_VideoDevice *_this, int deviceid, Atom property, Sint32 *dest, size_t max_words)
 {
-    const SDL_VideoData *data = (SDL_VideoData *)_this->driverdata;
+    const SDL_VideoData *data = (SDL_VideoData *)_this->internal;
     Atom type_return;
     int format_return;
     unsigned long num_items_return;
@@ -222,7 +222,7 @@ static SDL_bool xinput2_wacom_deviceid(SDL_VideoDevice *_this, int deviceid, Uin
 /* Heuristically determines if device is an eraser */
 static SDL_bool xinput2_pen_is_eraser(SDL_VideoDevice *_this, int deviceid, char *devicename)
 {
-    SDL_VideoData *data = (SDL_VideoData *)_this->driverdata;
+    SDL_VideoData *data = (SDL_VideoData *)_this->internal;
     char dev_name[PEN_ERASER_ID_MAXLEN];
     int k;
 
@@ -415,7 +415,7 @@ static SDL_bool xinput2_device_is_pen(SDL_VideoDevice *_this, const XIDeviceInfo
 
 void X11_InitPen(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = (SDL_VideoData *)_this->driverdata;
+    SDL_VideoData *data = (SDL_VideoData *)_this->internal;
     int i;
     XIDeviceInfo *device_info;
     int num_device_info;

--- a/src/video/x11/SDL_x11settings.c
+++ b/src/video/x11/SDL_x11settings.c
@@ -67,7 +67,7 @@ static void X11_XsettingsNotify(const char *name, XSettingsAction action, XSetti
 
 void X11_InitXsettings(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     SDLX11_SettingsData *xsettings_data = &data->xsettings_data;
 
     xsettings_data->xsettings = xsettings_client_new(data->display,
@@ -77,7 +77,7 @@ void X11_InitXsettings(SDL_VideoDevice *_this)
 
 void X11_QuitXsettings(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     SDLX11_SettingsData *xsettings_data = &data->xsettings_data;
 
     if (xsettings_data->xsettings) {
@@ -88,7 +88,7 @@ void X11_QuitXsettings(SDL_VideoDevice *_this)
 
 void X11_HandleXsettings(SDL_VideoDevice *_this, const XEvent *xevent)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     SDLX11_SettingsData *xsettings_data = &data->xsettings_data;
 
     if (xsettings_data->xsettings) {
@@ -100,7 +100,7 @@ void X11_HandleXsettings(SDL_VideoDevice *_this, const XEvent *xevent)
 }
 
 int X11_GetXsettingsIntKey(SDL_VideoDevice *_this, const char *key, int fallback_value) {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     SDLX11_SettingsData *xsettings_data = &data->xsettings_data;
     XSettingsSetting *setting = NULL;
     int res = fallback_value;

--- a/src/video/x11/SDL_x11shape.c
+++ b/src/video/x11/SDL_x11shape.c
@@ -58,7 +58,7 @@ int X11_UpdateWindowShape(SDL_VideoDevice *_this, SDL_Window *window, SDL_Surfac
     int result = -1;
 
 #ifdef SDL_VIDEO_DRIVER_X11_XSHAPE
-    SDL_WindowData *windowdata = window->driverdata;
+    SDL_WindowData *windowdata = window->internal;
 
     /* Generate a set of spans for the region */
     if (shape) {

--- a/src/video/x11/SDL_x11video.c
+++ b/src/video/x11/SDL_x11video.c
@@ -53,7 +53,7 @@ static int (*orig_x11_errhandler)(Display *, XErrorEvent *) = NULL;
 
 static void X11_DeleteDevice(SDL_VideoDevice *device)
 {
-    SDL_VideoData *data = device->driverdata;
+    SDL_VideoData *data = device->internal;
     if (device->vulkan_config.loader_handle) {
         device->Vulkan_UnloadLibrary(device);
     }
@@ -68,7 +68,7 @@ static void X11_DeleteDevice(SDL_VideoDevice *device)
     if (device->wakeup_lock) {
         SDL_DestroyMutex(device->wakeup_lock);
     }
-    SDL_free(device->driverdata);
+    SDL_free(device->internal);
     SDL_free(device);
 
     SDL_X11_UnloadSymbols();
@@ -140,7 +140,7 @@ static SDL_VideoDevice *X11_CreateDevice(void)
         SDL_free(device);
         return NULL;
     }
-    device->driverdata = data;
+    device->internal = data;
 
     data->global_mouse_changed = SDL_TRUE;
 
@@ -152,7 +152,7 @@ static SDL_VideoDevice *X11_CreateDevice(void)
     data->request_display = X11_XOpenDisplay(display);
     if (!data->request_display) {
         X11_XCloseDisplay(data->display);
-        SDL_free(device->driverdata);
+        SDL_free(device->internal);
         SDL_free(device);
         SDL_X11_UnloadSymbols();
         return NULL;
@@ -318,7 +318,7 @@ static int X11_CheckWindowManagerErrorHandler(Display *d, XErrorEvent *e)
 
 static void X11_CheckWindowManager(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     Display *display = data->display;
     Atom _NET_SUPPORTING_WM_CHECK;
     int status, real_format;
@@ -378,7 +378,7 @@ static void X11_CheckWindowManager(SDL_VideoDevice *_this)
 
 int X11_VideoInit(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
 
     /* Get the process PID to be associated to the window */
     data->pid = getpid();
@@ -465,7 +465,7 @@ int X11_VideoInit(SDL_VideoDevice *_this)
 
 void X11_VideoQuit(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
 
     if (data->clipboard_window) {
         X11_XDestroyWindow(data->display, data->clipboard_window);

--- a/src/video/x11/SDL_x11vulkan.c
+++ b/src/video/x11/SDL_x11vulkan.c
@@ -44,7 +44,7 @@ typedef uint32_t xcb_visualid_t;
 
 int X11_Vulkan_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 {
-    SDL_VideoData *videoData = _this->driverdata;
+    SDL_VideoData *videoData = _this->internal;
     VkExtensionProperties *extensions = NULL;
     Uint32 extensionCount = 0;
     SDL_bool hasSurfaceExtension = SDL_FALSE;
@@ -132,7 +132,7 @@ fail:
 
 void X11_Vulkan_UnloadLibrary(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *videoData = _this->driverdata;
+    SDL_VideoData *videoData = _this->internal;
     if (_this->vulkan_config.loader_handle) {
         if (videoData->vulkan_xlib_xcb_library) {
             SDL_UnloadObject(videoData->vulkan_xlib_xcb_library);
@@ -145,7 +145,7 @@ void X11_Vulkan_UnloadLibrary(SDL_VideoDevice *_this)
 char const* const* X11_Vulkan_GetInstanceExtensions(SDL_VideoDevice *_this,
                                           Uint32 *count)
 {
-    SDL_VideoData *videoData = _this->driverdata;
+    SDL_VideoData *videoData = _this->internal;
     if (videoData->vulkan_xlib_xcb_library) {
         static const char *const extensionsForXCB[] = {
             VK_KHR_SURFACE_EXTENSION_NAME,
@@ -173,8 +173,8 @@ int X11_Vulkan_CreateSurface(SDL_VideoDevice *_this,
                              const struct VkAllocationCallbacks *allocator,
                              VkSurfaceKHR *surface)
 {
-    SDL_VideoData *videoData = _this->driverdata;
-    SDL_WindowData *windowData = window->driverdata;
+    SDL_VideoData *videoData = _this->internal;
+    SDL_WindowData *windowData = window->internal;
     PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr;
     if (!_this->vulkan_config.loader_handle) {
         return SDL_SetError("Vulkan is not loaded");
@@ -237,7 +237,7 @@ SDL_bool X11_Vulkan_GetPresentationSupport(SDL_VideoDevice *_this,
                                            VkPhysicalDevice physicalDevice,
                                            Uint32 queueFamilyIndex)
 {
-    SDL_VideoData *videoData = _this->driverdata;
+    SDL_VideoData *videoData = _this->internal;
     PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr;
     const char *forced_visual_id;
     VisualID visualid;

--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -45,7 +45,7 @@
     if (!window) {                                                      \
         return SDL_SetError("Invalid window");                          \
     }                                                                   \
-    if (!window->driverdata) {                                          \
+    if (!window->internal) {                                          \
         return SDL_SetError("Invalid window driver data");              \
     }
 
@@ -53,7 +53,7 @@
     if (!_display) {                                                    \
         return SDL_SetError("Invalid display");                         \
     }                                                                   \
-    if (!_display->driverdata) {                                        \
+    if (!_display->internal) {                                        \
         return SDL_SetError("Invalid display driver data");             \
     }
 
@@ -86,8 +86,8 @@ static Bool X11_XIfEventTimeout(Display *display, XEvent *event_return, Bool (*p
 
 static SDL_bool X11_IsWindowMapped(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *data = window->driverdata;
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_WindowData *data = window->internal;
+    SDL_VideoData *videodata = _this->internal;
     XWindowAttributes attr;
 
     X11_XGetWindowAttributes(videodata->display, data->xwindow, &attr);
@@ -101,7 +101,7 @@ static SDL_bool X11_IsWindowMapped(SDL_VideoDevice *_this, SDL_Window *window)
 #if 0
 static SDL_bool X11_IsActionAllowed(SDL_Window *window, Atom action)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Atom _NET_WM_ALLOWED_ACTIONS = data->videodata->_NET_WM_ALLOWED_ACTIONS;
     Atom type;
     Display *display = data->videodata->display;
@@ -126,7 +126,7 @@ static SDL_bool X11_IsActionAllowed(SDL_Window *window, Atom action)
 
 void X11_SetNetWMState(SDL_VideoDevice *_this, Window xwindow, SDL_WindowFlags flags)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     Display *display = videodata->display;
     /* !!! FIXME: just dereference videodata below instead of copying to locals. */
     Atom _NET_WM_STATE = videodata->_NET_WM_STATE;
@@ -230,13 +230,13 @@ static void X11_SetKeyboardFocus(SDL_Window *window)
         topmost = topmost->parent;
     }
 
-    topmost->driverdata->keyboard_focus = window;
+    topmost->internal->keyboard_focus = window;
     SDL_SetKeyboardFocus(window);
 }
 
 Uint32 X11_GetNetWMState(SDL_VideoDevice *_this, SDL_Window *window, Window xwindow)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     Display *display = videodata->display;
     Atom _NET_WM_STATE = videodata->_NET_WM_STATE;
     Atom _NET_WM_STATE_HIDDEN = videodata->_NET_WM_STATE_HIDDEN;
@@ -322,7 +322,7 @@ Uint32 X11_GetNetWMState(SDL_VideoDevice *_this, SDL_Window *window, Window xwin
 
 static int SetupWindowData(SDL_VideoDevice *_this, SDL_Window *window, Window w)
 {
-    SDL_VideoData *videodata = _this->driverdata;
+    SDL_VideoData *videodata = _this->internal;
     SDL_DisplayData *displaydata = SDL_GetDisplayDriverDataForWindow(window);
     SDL_WindowData *data;
     int numwindows = videodata->numwindows;
@@ -417,7 +417,7 @@ static int SetupWindowData(SDL_VideoDevice *_this, SDL_Window *window, Window w)
     SDL_SetNumberProperty(props, SDL_PROP_WINDOW_X11_WINDOW_NUMBER, data->xwindow);
 
     /* All done! */
-    window->driverdata = data;
+    window->internal = data;
     return 0;
 }
 
@@ -464,7 +464,7 @@ int X11_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesI
         return 0;
     }
 
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     SDL_DisplayData *displaydata = SDL_GetDisplayDriverDataForWindow(window);
     if (!displaydata) {
         return SDL_SetError("Could not find display info");
@@ -752,7 +752,7 @@ int X11_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesI
         X11_XDestroyWindow(display, w);
         return -1;
     }
-    windowdata = window->driverdata;
+    windowdata = window->internal;
 
     /* Set the flag if the borders were forced on when creating a fullscreen window for later removal. */
     windowdata->fullscreen_borders_forced_on = !!(window->pending_flags & SDL_WINDOW_FULLSCREEN) &&
@@ -831,7 +831,7 @@ int X11_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesI
 
 char *X11_GetWindowTitle(SDL_VideoDevice *_this, Window xwindow)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     Display *display = data->display;
     int status, real_format;
     Atom real_type;
@@ -863,7 +863,7 @@ char *X11_GetWindowTitle(SDL_VideoDevice *_this, Window xwindow)
 
 void X11_SetWindowTitle(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Window xwindow = data->xwindow;
     Display *display = data->videodata->display;
     char *title = window->title ? window->title : "";
@@ -884,7 +884,7 @@ static int X11_CatchAnyError(Display *d, XErrorEvent *e)
  * Send MOVED and RESIZED window events */
 static int X11_SyncWindowTimeout(SDL_VideoDevice *_this, SDL_Window *window, Uint64 param_timeout)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
     int (*prev_handler)(Display *, XErrorEvent *);
     Uint64 timeout = 0;
@@ -953,7 +953,7 @@ static int X11_SyncWindowTimeout(SDL_VideoDevice *_this, SDL_Window *window, Uin
 
 int X11_SetWindowIcon(SDL_VideoDevice *_this, SDL_Window *window, SDL_Surface *icon)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
     Atom _NET_WM_ICON = data->videodata->_NET_WM_ICON;
     int rc = 0;
@@ -1011,7 +1011,7 @@ int X11_SetWindowIcon(SDL_VideoDevice *_this, SDL_Window *window, SDL_Surface *i
 
 void X11_UpdateWindowPosition(SDL_Window *window, SDL_bool use_current_position)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
     const int rel_x = use_current_position ? window->x : window->floating.x;
     const int rel_y = use_current_position ? window->y : window->floating.y;
@@ -1028,7 +1028,7 @@ void X11_UpdateWindowPosition(SDL_Window *window, SDL_bool use_current_position)
 int X11_SetWindowPosition(SDL_VideoDevice *_this, SDL_Window *window)
 {
     /* Sync any pending fullscreen or maximize events. */
-    if (window->driverdata->pending_operation & (X11_PENDING_OP_FULLSCREEN | X11_PENDING_OP_MAXIMIZE)) {
+    if (window->internal->pending_operation & (X11_PENDING_OP_FULLSCREEN | X11_PENDING_OP_MAXIMIZE)) {
         X11_SyncWindow(_this, window);
     }
 
@@ -1050,7 +1050,7 @@ int X11_SetWindowPosition(SDL_VideoDevice *_this, SDL_Window *window)
 
 static void X11_SetWMNormalHints(SDL_VideoDevice *_this, SDL_Window *window, XSizeHints *sizehints)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
     int dest_x, dest_y;
 
@@ -1083,7 +1083,7 @@ static void X11_SetWMNormalHints(SDL_VideoDevice *_this, SDL_Window *window, XSi
 
 void X11_SetWindowMinMax(SDL_Window *window, SDL_bool use_current)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
     XSizeHints *sizehints = X11_XAllocSizeHints();
     long hint_flags = 0;
@@ -1120,7 +1120,7 @@ void X11_SetWindowMinMax(SDL_Window *window, SDL_bool use_current)
 
 void X11_SetWindowMinimumSize(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    if (window->driverdata->pending_operation & X11_PENDING_OP_FULLSCREEN) {
+    if (window->internal->pending_operation & X11_PENDING_OP_FULLSCREEN) {
         X11_SyncWindow(_this, window);
     }
 
@@ -1131,7 +1131,7 @@ void X11_SetWindowMinimumSize(SDL_VideoDevice *_this, SDL_Window *window)
 
 void X11_SetWindowMaximumSize(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    if (window->driverdata->pending_operation & X11_PENDING_OP_FULLSCREEN) {
+    if (window->internal->pending_operation & X11_PENDING_OP_FULLSCREEN) {
         X11_SyncWindow(_this, window);
     }
 
@@ -1142,7 +1142,7 @@ void X11_SetWindowMaximumSize(SDL_VideoDevice *_this, SDL_Window *window)
 
 void X11_SetWindowAspectRatio(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    if (window->driverdata->pending_operation & X11_PENDING_OP_FULLSCREEN) {
+    if (window->internal->pending_operation & X11_PENDING_OP_FULLSCREEN) {
         X11_SyncWindow(_this, window);
     }
 
@@ -1153,7 +1153,7 @@ void X11_SetWindowAspectRatio(SDL_VideoDevice *_this, SDL_Window *window)
 
 void X11_SetWindowSize(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
 
     /* Wait for pending maximize operations to complete, or the window can end up in a weird,
@@ -1196,7 +1196,7 @@ void X11_SetWindowSize(SDL_VideoDevice *_this, SDL_Window *window)
 
 int X11_GetWindowBordersSize(SDL_VideoDevice *_this, SDL_Window *window, int *top, int *left, int *bottom, int *right)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
 
     *left = data->border_left;
     *right = data->border_right;
@@ -1208,7 +1208,7 @@ int X11_GetWindowBordersSize(SDL_VideoDevice *_this, SDL_Window *window, int *to
 
 int X11_SetWindowOpacity(SDL_VideoDevice *_this, SDL_Window *window, float opacity)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
     Atom _NET_WM_WINDOW_OPACITY = data->videodata->_NET_WM_WINDOW_OPACITY;
 
@@ -1226,9 +1226,9 @@ int X11_SetWindowOpacity(SDL_VideoDevice *_this, SDL_Window *window, float opaci
 
 int X11_SetWindowModalFor(SDL_VideoDevice *_this, SDL_Window *modal_window, SDL_Window *parent_window)
 {
-    SDL_WindowData *data = modal_window->driverdata;
-    SDL_WindowData *parent_data = parent_window ? parent_window->driverdata : NULL;
-    SDL_VideoData *video_data = _this->driverdata;
+    SDL_WindowData *data = modal_window->internal;
+    SDL_WindowData *parent_data = parent_window ? parent_window->internal : NULL;
+    SDL_VideoData *video_data = _this->internal;
     SDL_DisplayData *displaydata = SDL_GetDisplayDriverDataForWindow(modal_window);
     Display *display = video_data->display;
     Uint32 flags = modal_window->flags;
@@ -1271,7 +1271,7 @@ void X11_SetWindowBordered(SDL_VideoDevice *_this, SDL_Window *window, SDL_bool 
 {
     const SDL_bool focused = (window->flags & SDL_WINDOW_INPUT_FOCUS) ? SDL_TRUE : SDL_FALSE;
     const SDL_bool visible = (!(window->flags & SDL_WINDOW_HIDDEN)) ? SDL_TRUE : SDL_FALSE;
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     SDL_DisplayData *displaydata = SDL_GetDisplayDriverDataForWindow(window);
     Display *display = data->videodata->display;
     XEvent event;
@@ -1317,7 +1317,7 @@ void X11_SetWindowBordered(SDL_VideoDevice *_this, SDL_Window *window, SDL_bool 
 
 void X11_SetWindowResizable(SDL_VideoDevice *_this, SDL_Window *window, SDL_bool resizable)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
 
     if (data->pending_operation & X11_PENDING_OP_FULLSCREEN) {
         X11_SyncWindow(_this, window);
@@ -1331,7 +1331,7 @@ void X11_SetWindowResizable(SDL_VideoDevice *_this, SDL_Window *window, SDL_bool
 
 void X11_SetWindowAlwaysOnTop(SDL_VideoDevice *_this, SDL_Window *window, SDL_bool on_top)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     SDL_DisplayData *displaydata = SDL_GetDisplayDriverDataForWindow(window);
     Display *display = data->videodata->display;
     Atom _NET_WM_STATE = data->videodata->_NET_WM_STATE;
@@ -1360,7 +1360,7 @@ void X11_SetWindowAlwaysOnTop(SDL_VideoDevice *_this, SDL_Window *window, SDL_bo
 
 void X11_ShowWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
     SDL_bool bActivate = SDL_GetHintBoolean(SDL_HINT_WINDOW_ACTIVATE_WHEN_SHOWN, SDL_TRUE);
     XEvent event;
@@ -1435,7 +1435,7 @@ void X11_ShowWindow(SDL_VideoDevice *_this, SDL_Window *window)
 
 void X11_HideWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     SDL_DisplayData *displaydata = SDL_GetDisplayDriverDataForWindow(window);
     int screen = (displaydata ? displaydata->screen : 0);
     Display *display = data->videodata->display;
@@ -1472,7 +1472,7 @@ static int X11_SetWindowActive(SDL_VideoDevice *_this, SDL_Window *window)
 {
     CHECK_WINDOW_DATA(window);
 
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     SDL_DisplayData *displaydata = SDL_GetDisplayDriverDataForWindow(window);
     Display *display = data->videodata->display;
     Atom _NET_ACTIVE_WINDOW = data->videodata->_NET_ACTIVE_WINDOW;
@@ -1501,7 +1501,7 @@ static int X11_SetWindowActive(SDL_VideoDevice *_this, SDL_Window *window)
 
 void X11_RaiseWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
     SDL_bool bActivate = SDL_GetHintBoolean(SDL_HINT_WINDOW_ACTIVATE_WHEN_RAISED, SDL_TRUE);
 
@@ -1516,7 +1516,7 @@ static int X11_SetWindowMaximized(SDL_VideoDevice *_this, SDL_Window *window, SD
 {
     CHECK_WINDOW_DATA(window);
 
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     SDL_DisplayData *displaydata = SDL_GetDisplayDriverDataForWindow(window);
     Display *display = data->videodata->display;
     Atom _NET_WM_STATE = data->videodata->_NET_WM_STATE;
@@ -1575,19 +1575,19 @@ static int X11_SetWindowMaximized(SDL_VideoDevice *_this, SDL_Window *window, SD
 
 void X11_MaximizeWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    if (window->driverdata->pending_operation & (X11_PENDING_OP_FULLSCREEN | X11_PENDING_OP_MINIMIZE)) {
+    if (window->internal->pending_operation & (X11_PENDING_OP_FULLSCREEN | X11_PENDING_OP_MINIMIZE)) {
         SDL_SyncWindow(window);
     }
 
     if (!(window->flags & (SDL_WINDOW_FULLSCREEN | SDL_WINDOW_MINIMIZED))) {
-        window->driverdata->pending_operation |= X11_PENDING_OP_MAXIMIZE;
+        window->internal->pending_operation |= X11_PENDING_OP_MAXIMIZE;
         X11_SetWindowMaximized(_this, window, SDL_TRUE);
     }
 }
 
 void X11_MinimizeWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     SDL_DisplayData *displaydata = SDL_GetDisplayDriverDataForWindow(window);
     Display *display = data->videodata->display;
 
@@ -1599,18 +1599,18 @@ void X11_MinimizeWindow(SDL_VideoDevice *_this, SDL_Window *window)
 
 void X11_RestoreWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    if (window->driverdata->pending_operation & (X11_PENDING_OP_FULLSCREEN | X11_PENDING_OP_MAXIMIZE | X11_PENDING_OP_MINIMIZE)) {
+    if (window->internal->pending_operation & (X11_PENDING_OP_FULLSCREEN | X11_PENDING_OP_MAXIMIZE | X11_PENDING_OP_MINIMIZE)) {
         SDL_SyncWindow(window);
     }
 
     if (window->flags & (SDL_WINDOW_MINIMIZED | SDL_WINDOW_MAXIMIZED) ||
-        (window->driverdata->pending_operation & X11_PENDING_OP_MINIMIZE)) {
-        window->driverdata->pending_operation |= X11_PENDING_OP_RESTORE;
+        (window->internal->pending_operation & X11_PENDING_OP_MINIMIZE)) {
+        window->internal->pending_operation |= X11_PENDING_OP_RESTORE;
     }
 
     /* If the window was minimized while maximized, restore as maximized. */
-    const SDL_bool maximize = !!(window->flags & SDL_WINDOW_MINIMIZED) &&  window->driverdata->window_was_maximized;
-    window->driverdata->window_was_maximized = SDL_FALSE;
+    const SDL_bool maximize = !!(window->flags & SDL_WINDOW_MINIMIZED) &&  window->internal->window_was_maximized;
+    window->internal->window_was_maximized = SDL_FALSE;
     X11_SetWindowMaximized(_this, window, maximize);
     X11_ShowWindow(_this, window);
     X11_SetWindowActive(_this, window);
@@ -1622,8 +1622,8 @@ static int X11_SetWindowFullscreenViaWM(SDL_VideoDevice *_this, SDL_Window *wind
     CHECK_WINDOW_DATA(window);
     CHECK_DISPLAY_DATA(_display);
 
-    SDL_WindowData *data = window->driverdata;
-    SDL_DisplayData *displaydata = _display->driverdata;
+    SDL_WindowData *data = window->internal;
+    SDL_DisplayData *displaydata = _display->internal;
     Display *display = data->videodata->display;
     Atom _NET_WM_STATE = data->videodata->_NET_WM_STATE;
     Atom _NET_WM_STATE_FULLSCREEN = data->videodata->_NET_WM_STATE_FULLSCREEN;
@@ -1777,7 +1777,7 @@ static void X11_ReadProperty(SDL_x11Prop *p, Display *disp, Window w, Atom prop)
 
 void *X11_GetWindowICCProfile(SDL_VideoDevice *_this, SDL_Window *window, size_t *size)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
     XWindowAttributes attributes;
     Atom icc_profile_atom;
@@ -1825,7 +1825,7 @@ void *X11_GetWindowICCProfile(SDL_VideoDevice *_this, SDL_Window *window, size_t
 
 int X11_SetWindowMouseGrab(SDL_VideoDevice *_this, SDL_Window *window, SDL_bool grabbed)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display;
 
     if (!data) {
@@ -1894,7 +1894,7 @@ int X11_SetWindowMouseGrab(SDL_VideoDevice *_this, SDL_Window *window, SDL_bool 
 
 int X11_SetWindowKeyboardGrab(SDL_VideoDevice *_this, SDL_Window *window, SDL_bool grabbed)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display;
 
     if (!data) {
@@ -1923,7 +1923,7 @@ int X11_SetWindowKeyboardGrab(SDL_VideoDevice *_this, SDL_Window *window, SDL_bo
 
 void X11_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
 
     if (data) {
         SDL_VideoData *videodata = data->videodata;
@@ -1960,7 +1960,7 @@ void X11_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
         }
 #endif /* SDL_VIDEO_DRIVER_X11_XFIXES */
     }
-    window->driverdata = NULL;
+    window->internal = NULL;
 }
 
 int X11_SetWindowHitTest(SDL_Window *window, SDL_bool enabled)
@@ -1970,7 +1970,7 @@ int X11_SetWindowHitTest(SDL_Window *window, SDL_bool enabled)
 
 void X11_AcceptDragAndDrop(SDL_Window *window, SDL_bool accept)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
     Atom XdndAware = X11_XInternAtom(display, "XdndAware", False);
 
@@ -1985,7 +1985,7 @@ void X11_AcceptDragAndDrop(SDL_Window *window, SDL_bool accept)
 
 int X11_FlashWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_FlashOperation operation)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
     XWMHints *wmhints;
 
@@ -2063,7 +2063,7 @@ int SDL_X11_SetWindowTitle(Display *display, Window xwindow, char *title)
 
 void X11_ShowWindowSystemMenu(SDL_Window *window, int x, int y)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     SDL_DisplayData *displaydata = SDL_GetDisplayDriverDataForWindow(window);
     Display *display = data->videodata->display;
     Window root = RootWindow(display, displaydata->screen);
@@ -2093,23 +2093,23 @@ int X11_SyncWindow(SDL_VideoDevice *_this, SDL_Window *window)
 
     /* Allow time for any pending mode switches to complete. */
     for (int i = 0; i < _this->num_displays; ++i) {
-        if (_this->displays[i]->driverdata->mode_switch_deadline_ns &&
-            current_time < _this->displays[i]->driverdata->mode_switch_deadline_ns) {
-            timeout = SDL_max(_this->displays[i]->driverdata->mode_switch_deadline_ns - current_time, timeout);
+        if (_this->displays[i]->internal->mode_switch_deadline_ns &&
+            current_time < _this->displays[i]->internal->mode_switch_deadline_ns) {
+            timeout = SDL_max(_this->displays[i]->internal->mode_switch_deadline_ns - current_time, timeout);
         }
     }
 
     /* 100ms is fine for most cases, but, for some reason, maximizing
      * a window can take a very long time.
      */
-    timeout += window->driverdata->pending_operation & X11_PENDING_OP_MAXIMIZE ? SDL_MS_TO_NS(1000) : SDL_MS_TO_NS(100);
+    timeout += window->internal->pending_operation & X11_PENDING_OP_MAXIMIZE ? SDL_MS_TO_NS(1000) : SDL_MS_TO_NS(100);
 
     return X11_SyncWindowTimeout(_this, window, timeout);
 }
 
 int X11_SetWindowFocusable(SDL_VideoDevice *_this, SDL_Window *window, SDL_bool focusable)
 {
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
     XWMHints *wmhints;
 

--- a/src/video/x11/SDL_x11xfixes.c
+++ b/src/video/x11/SDL_x11xfixes.c
@@ -45,7 +45,7 @@ static SDL_bool xfixes_version_atleast(const int version, const int wantmajor, c
 
 void X11_InitXfixes(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
 
     int version = 0;
     int event, error;
@@ -93,7 +93,7 @@ int X11_SetWindowMouseRect(SDL_VideoDevice *_this, SDL_Window *window)
             X11_ConfineCursorWithFlags(_this, window, &window->mouse_rect, 0);
         } else {
             /* Save the state for when we get focus again */
-            SDL_WindowData *wdata = window->driverdata;
+            SDL_WindowData *wdata = window->internal;
 
             SDL_memcpy(&wdata->barrier_rect, &window->mouse_rect, sizeof(wdata->barrier_rect));
 
@@ -110,7 +110,7 @@ int X11_ConfineCursorWithFlags(SDL_VideoDevice *_this, SDL_Window *window, const
      * edges exactly match, a rectangle the cursor 'slips' out of the barrier.
      * To prevent that the lines for the barriers will span the whole screen.
      */
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     SDL_WindowData *wdata;
 
     if (!X11_XfixesIsInitialized()) {
@@ -123,7 +123,7 @@ int X11_ConfineCursorWithFlags(SDL_VideoDevice *_this, SDL_Window *window, const
     }
 
     SDL_assert(window != NULL);
-    wdata = window->driverdata;
+    wdata = window->internal;
 
     /* If user did not specify an area to confine, destroy the barrier that was/is assigned to
      * this window it was assigned */
@@ -196,9 +196,9 @@ int X11_ConfineCursorWithFlags(SDL_VideoDevice *_this, SDL_Window *window, const
 void X11_DestroyPointerBarrier(SDL_VideoDevice *_this, SDL_Window *window)
 {
     int i;
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     if (window) {
-        SDL_WindowData *wdata = window->driverdata;
+        SDL_WindowData *wdata = window->internal;
 
         for (i = 0; i < 4; i++) {
             if (wdata->barrier[i] > 0) {

--- a/src/video/x11/SDL_x11xinput2.c
+++ b/src/video/x11/SDL_x11xinput2.c
@@ -122,7 +122,7 @@ static void xinput2_normalize_touch_coordinates(SDL_Window *window, double in_x,
 SDL_bool X11_InitXinput2(SDL_VideoDevice *_this)
 {
 #ifdef SDL_VIDEO_DRIVER_X11_XINPUT2
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
 
     int version = 0;
     XIEventMask eventmask;
@@ -291,7 +291,7 @@ static void xinput2_pen_ensure_window(SDL_VideoDevice *_this, const SDL_Pen *pen
 void X11_HandleXinput2Event(SDL_VideoDevice *_this, XGenericEventCookie *cookie)
 {
 #ifdef SDL_VIDEO_DRIVER_X11_XINPUT2
-    SDL_VideoData *videodata = (SDL_VideoData *)_this->driverdata;
+    SDL_VideoData *videodata = (SDL_VideoData *)_this->internal;
 
     if (cookie->extension != xinput2_opcode) {
         return;
@@ -512,7 +512,7 @@ void X11_HandleXinput2Event(SDL_VideoDevice *_this, XGenericEventCookie *cookie)
             if (!mouse->relative_mode || mouse->relative_mode_warp) {
                 SDL_Window *window = xinput2_get_sdlwindow(videodata, xev->event);
                 if (window) {
-                    X11_ProcessHitTest(_this, window->driverdata, (float)xev->event_x, (float)xev->event_y, SDL_FALSE);
+                    X11_ProcessHitTest(_this, window->internal, (float)xev->event_x, (float)xev->event_y, SDL_FALSE);
                     SDL_SendMouseMotion(0, window, (SDL_MouseID)xev->sourceid, SDL_FALSE, (float)xev->event_x, (float)xev->event_y);
                 }
             }
@@ -567,8 +567,8 @@ void X11_Xinput2SelectTouch(SDL_VideoDevice *_this, SDL_Window *window)
         return;
     }
 
-    data = _this->driverdata;
-    window_data = window->driverdata;
+    data = _this->internal;
+    window_data = window->internal;
 
     eventmask.deviceid = XIAllMasterDevices;
     eventmask.mask_len = sizeof(mask);
@@ -594,10 +594,10 @@ int X11_Xinput2IsInitialized(void)
 
 SDL_bool X11_Xinput2SelectMouseAndKeyboard(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *windowdata = (SDL_WindowData *)window->driverdata;
+    SDL_WindowData *windowdata = (SDL_WindowData *)window->internal;
 
 #ifdef SDL_VIDEO_DRIVER_X11_XINPUT2
-    const SDL_VideoData *data = (SDL_VideoData *)_this->driverdata;
+    const SDL_VideoData *data = (SDL_VideoData *)_this->internal;
 
     if (X11_Xinput2IsInitialized()) {
         XIEventMask eventmask;
@@ -653,7 +653,7 @@ int X11_Xinput2IsMultitouchSupported(void)
 void X11_Xinput2GrabTouch(SDL_VideoDevice *_this, SDL_Window *window)
 {
 #ifdef SDL_VIDEO_DRIVER_X11_XINPUT2_SUPPORTS_MULTITOUCH
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
 
     unsigned char mask[4] = { 0, 0, 0, 0 };
@@ -683,7 +683,7 @@ void X11_Xinput2GrabTouch(SDL_VideoDevice *_this, SDL_Window *window)
 void X11_Xinput2UngrabTouch(SDL_VideoDevice *_this, SDL_Window *window)
 {
 #ifdef SDL_VIDEO_DRIVER_X11_XINPUT2_SUPPORTS_MULTITOUCH
-    SDL_WindowData *data = window->driverdata;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
 
     XIGrabModifiers mods;
@@ -730,7 +730,7 @@ static SDL_bool HasDeviceID(Uint32 deviceID, Uint32 *list, int count)
 void X11_Xinput2UpdateDevices(SDL_VideoDevice *_this, SDL_bool initial_check)
 {
 #ifdef SDL_VIDEO_DRIVER_X11_XINPUT2
-    SDL_VideoData *data = _this->driverdata;
+    SDL_VideoData *data = _this->internal;
     XIDeviceInfo *info;
     int ndevices;
     int old_keyboard_count = 0;


### PR DESCRIPTION
This is for consistency with SDL_Surface and gives it a type so we don't have to do casts in SDL code.

I considered switching to an ID and hashing the driver data, etc. but all of that involved a lot of internal code churn and this solution gives us flexibility in how we handle this in the future.

Fixes https://github.com/libsdl-org/SDL/issues/10198