### PR TITLE
SDL2: Fix warning for Android NDK compiler: "function declaration without a…

### DIFF
--- a/Xcode-iOS/Demos/src/fireworks.c
+++ b/Xcode-iOS/Demos/src/fireworks.c
@@ -52,9 +52,9 @@ void spawnTrailFromEmitter(struct particle *emitter);
 void spawnEmitterParticle(GLfloat x, GLfloat y);
 void explodeEmitter(struct particle *emitter);
 void initializeParticles(void);
-void initializeTexture();
+void initializeTexture(void);
 int nextPowerOfTwo(int x);
-void drawParticles();
+void drawParticles(void);
 void stepParticles(double deltaTime);
 
 /*  helper function (used in texture loading)
@@ -159,7 +159,7 @@ stepParticles(double deltaTime)
     This draws all the particles shown on screen
 */
 void
-drawParticles()
+drawParticles(void)
 {
 
     /* draw the background */
@@ -324,7 +324,7 @@ initializeParticles(void)
     loads the particle texture
  */
 void
-initializeTexture()
+initializeTexture(void)
 {
 
     int bpp;                    /* texture bits per pixel */

--- a/Xcode-iOS/Demos/src/keyboard.c
+++ b/Xcode-iOS/Demos/src/keyboard.c
@@ -196,7 +196,7 @@ loadFont(void)
 }
 
 void
-draw()
+draw(void)
 {
     SDL_SetRenderDrawColor(renderer, bg_color.r, bg_color.g, bg_color.b, bg_color.a);
     SDL_RenderClear(renderer);

--- a/src/audio/arts/SDL_artsaudio.c
+++ b/src/audio/arts/SDL_artsaudio.c
@@ -86,7 +86,7 @@ static struct
 
 #undef SDL_ARTS_SYM
 
-static void UnloadARTSLibrary()
+static void UnloadARTSLibrary(void)
 {
     if (arts_handle) {
         SDL_UnloadObject(arts_handle);
@@ -119,7 +119,7 @@ static int LoadARTSLibrary(void)
 
 #else
 
-static void UnloadARTSLibrary()
+static void UnloadARTSLibrary(void)
 {
     return;
 }

--- a/src/audio/esd/SDL_esdaudio.c
+++ b/src/audio/esd/SDL_esdaudio.c
@@ -64,7 +64,7 @@ static struct
 
 #undef SDL_ESD_SYM
 
-static void UnloadESDLibrary()
+static void UnloadESDLibrary(void)
 {
     if (esd_handle) {
         SDL_UnloadObject(esd_handle);
@@ -96,7 +96,7 @@ static int LoadESDLibrary(void)
 
 #else
 
-static void UnloadESDLibrary()
+static void UnloadESDLibrary(void)
 {
     return;
 }

--- a/src/audio/fusionsound/SDL_fsaudio.c
+++ b/src/audio/fusionsound/SDL_fsaudio.c
@@ -77,7 +77,7 @@ static struct
 
 #undef SDL_FS_SYM
 
-static void UnloadFusionSoundLibrary()
+static void UnloadFusionSoundLibrary(void)
 {
     if (fs_handle) {
         SDL_UnloadObject(fs_handle);
@@ -110,7 +110,7 @@ static int LoadFusionSoundLibrary(void)
 
 #else
 
-static void UnloadFusionSoundLibrary()
+static void UnloadFusionSoundLibrary(void)
 {
     return;
 }

--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -142,13 +142,13 @@ static int pipewire_dlsym(const char *fn, void **addr)
         return -1;                                             \
     }
 
-static int load_pipewire_library()
+static int load_pipewire_library(void)
 {
     pipewire_handle = SDL_LoadObject(pipewire_library);
     return pipewire_handle ? 0 : -1;
 }
 
-static void unload_pipewire_library()
+static void unload_pipewire_library(void)
 {
     if (pipewire_handle) {
         SDL_UnloadObject(pipewire_handle);
@@ -160,18 +160,18 @@ static void unload_pipewire_library()
 
 #define SDL_PIPEWIRE_SYM(x) PIPEWIRE_##x = x
 
-static int load_pipewire_library()
+static int load_pipewire_library(void)
 {
     return 0;
 }
 
-static void unload_pipewire_library()
+static void unload_pipewire_library(void)
 { /* Nothing to do */
 }
 
 #endif /* SDL_AUDIO_DRIVER_PIPEWIRE_DYNAMIC */
 
-static int load_pipewire_syms()
+static int load_pipewire_syms(void)
 {
     SDL_PIPEWIRE_SYM(pw_get_library_version);
     SDL_PIPEWIRE_SYM(pw_init);
@@ -212,7 +212,7 @@ SDL_FORCE_INLINE SDL_bool pipewire_version_at_least(int major, int minor, int pa
            (pipewire_version_major > major || pipewire_version_minor > minor || pipewire_version_patch >= patch);
 }
 
-static int init_pipewire_library()
+static int init_pipewire_library(void)
 {
     if (!load_pipewire_library()) {
         if (!load_pipewire_syms()) {
@@ -234,7 +234,7 @@ static int init_pipewire_library()
     return -1;
 }
 
-static void deinit_pipewire_library()
+static void deinit_pipewire_library(void)
 {
     PIPEWIRE_pw_deinit();
     unload_pipewire_library();
@@ -340,7 +340,7 @@ static void io_list_remove(Uint32 id)
     }
 }
 
-static void io_list_sort()
+static void io_list_sort(void)
 {
     struct io_node *default_sink = NULL, *default_source = NULL;
     struct io_node *n, *temp;
@@ -365,7 +365,7 @@ static void io_list_sort()
     }
 }
 
-static void io_list_clear()
+static void io_list_clear(void)
 {
     struct io_node *n, *temp;
 
@@ -426,7 +426,7 @@ static void pending_list_remove(Uint32 id)
     }
 }
 
-static void pending_list_clear()
+static void pending_list_clear(void)
 {
     struct node_object *node, *temp;
 
@@ -751,7 +751,7 @@ static const struct pw_registry_events registry_events = { PW_VERSION_REGISTRY_E
                                                            .global_remove = registry_event_remove_callback };
 
 /* The hotplug thread */
-static int hotplug_loop_init()
+static int hotplug_loop_init(void)
 {
     int res;
 
@@ -794,7 +794,7 @@ static int hotplug_loop_init()
     return 0;
 }
 
-static void hotplug_loop_destroy()
+static void hotplug_loop_destroy(void)
 {
     if (hotplug_loop) {
         PIPEWIRE_pw_thread_loop_stop(hotplug_loop);
@@ -836,7 +836,7 @@ static void hotplug_loop_destroy()
     }
 }
 
-static void PIPEWIRE_DetectDevices()
+static void PIPEWIRE_DetectDevices(void)
 {
     struct io_node *io;
 
@@ -1342,7 +1342,7 @@ failed:
     return ret;
 }
 
-static void PIPEWIRE_Deinitialize()
+static void PIPEWIRE_Deinitialize(void)
 {
     if (pipewire_initialized) {
         hotplug_loop_destroy();

--- a/src/audio/pulseaudio/SDL_pulseaudio.c
+++ b/src/audio/pulseaudio/SDL_pulseaudio.c
@@ -885,7 +885,7 @@ static int SDLCALL HotplugThread(void *data)
     return 0;
 }
 
-static void PULSEAUDIO_DetectDevices()
+static void PULSEAUDIO_DetectDevices(void)
 {
     SDL_sem *ready_sem = SDL_CreateSemaphore(0);
 

--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -842,18 +842,18 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeDropFile)(
 }
 
 /* Lock / Unlock Mutex */
-void Android_ActivityMutex_Lock()
+void Android_ActivityMutex_Lock(void)
 {
     SDL_LockMutex(Android_ActivityMutex);
 }
 
-void Android_ActivityMutex_Unlock()
+void Android_ActivityMutex_Unlock(void)
 {
     SDL_UnlockMutex(Android_ActivityMutex);
 }
 
 /* Lock the Mutex when the Activity is in its 'Running' state */
-void Android_ActivityMutex_Lock_Running()
+void Android_ActivityMutex_Lock_Running(void)
 {
     int pauseSignaled = 0;
     int resumeSignaled = 0;
@@ -1439,13 +1439,13 @@ void Android_JNI_SetOrientation(int w, int h, int resizable, const char *hint)
     (*env)->DeleteLocalRef(env, jhint);
 }
 
-void Android_JNI_MinizeWindow()
+void Android_JNI_MinizeWindow(void)
 {
     JNIEnv *env = Android_JNI_GetEnv();
     (*env)->CallStaticVoidMethod(env, mActivityClass, midMinimizeWindow);
 }
 
-SDL_bool Android_JNI_ShouldMinimizeOnFocusLoss()
+SDL_bool Android_JNI_ShouldMinimizeOnFocusLoss(void)
 {
     JNIEnv *env = Android_JNI_GetEnv();
     return (*env)->CallStaticBooleanMethod(env, mActivityClass, midShouldMinimizeOnFocusLoss);
@@ -1879,7 +1879,7 @@ static SDL_bool Android_JNI_ExceptionOccurred(SDL_bool silent)
     return SDL_FALSE;
 }
 
-static void Internal_Android_Create_AssetManager()
+static void Internal_Android_Create_AssetManager(void)
 {
 
     struct LocalReferenceHolder refs = LocalReferenceHolder_Setup(__FUNCTION__);
@@ -1918,7 +1918,7 @@ static void Internal_Android_Create_AssetManager()
     LocalReferenceHolder_Cleanup(&refs);
 }
 
-static void Internal_Android_Destroy_AssetManager()
+static void Internal_Android_Destroy_AssetManager(void)
 {
     JNIEnv *env = Android_JNI_GetEnv();
 
@@ -2153,7 +2153,7 @@ int Android_JNI_GetPowerInfo(int *plugged, int *charged, int *battery, int *seco
 }
 
 /* Add all touch devices */
-void Android_JNI_InitTouch()
+void Android_JNI_InitTouch(void)
 {
     JNIEnv *env = Android_JNI_GetEnv();
     (*env)->CallStaticVoidMethod(env, mActivityClass, midInitTouch);

--- a/src/core/freebsd/SDL_evdev_kbd_freebsd.c
+++ b/src/core/freebsd/SDL_evdev_kbd_freebsd.c
@@ -134,7 +134,7 @@ static void kbd_cleanup_signal_action(int signum, siginfo_t *info, void *ucontex
     SDL_EVDEV_kbd_reraise_signal(signum);
 }
 
-static void kbd_unregister_emerg_cleanup()
+static void kbd_unregister_emerg_cleanup(void)
 {
     int tabidx, signum;
 

--- a/src/core/linux/SDL_evdev_kbd.c
+++ b/src/core/linux/SDL_evdev_kbd.c
@@ -214,7 +214,7 @@ static void kbd_cleanup_signal_action(int signum, siginfo_t *info, void *ucontex
     SDL_EVDEV_kbd_reraise_signal(signum);
 }
 
-static void kbd_unregister_emerg_cleanup()
+static void kbd_unregister_emerg_cleanup(void)
 {
     int tabidx, signum;
 

--- a/src/core/linux/SDL_fcitx.c
+++ b/src/core/linux/SDL_fcitx.c
@@ -55,7 +55,7 @@ typedef struct _FcitxClient
 
 static FcitxClient fcitx_client;
 
-static char *GetAppName()
+static char *GetAppName(void)
 {
 #if defined(__LINUX__) || defined(__FREEBSD__)
     char *spot;
@@ -368,7 +368,7 @@ static Uint32 Fcitx_ModState(void)
     return fcitx_mods;
 }
 
-SDL_bool SDL_Fcitx_Init()
+SDL_bool SDL_Fcitx_Init(void)
 {
     fcitx_client.dbus = SDL_DBus_GetContext();
 
@@ -380,7 +380,7 @@ SDL_bool SDL_Fcitx_Init()
     return FcitxClientCreateIC(&fcitx_client);
 }
 
-void SDL_Fcitx_Quit()
+void SDL_Fcitx_Quit(void)
 {
     FcitxClientICCallMethod(&fcitx_client, "DestroyIC");
     if (fcitx_client.ic_path) {

--- a/src/core/linux/SDL_ime.c
+++ b/src/core/linux/SDL_ime.c
@@ -40,7 +40,7 @@ static _SDL_IME_ProcessKeyEvent SDL_IME_ProcessKeyEvent_Real = NULL;
 static _SDL_IME_UpdateTextRect SDL_IME_UpdateTextRect_Real = NULL;
 static _SDL_IME_PumpEvents SDL_IME_PumpEvents_Real = NULL;
 
-static void InitIME()
+static void InitIME(void)
 {
     static SDL_bool inited = SDL_FALSE;
 #ifdef HAVE_FCITX
@@ -142,7 +142,7 @@ void SDL_IME_UpdateTextRect(const SDL_Rect *rect)
     }
 }
 
-void SDL_IME_PumpEvents()
+void SDL_IME_PumpEvents(void)
 {
     if (SDL_IME_PumpEvents_Real) {
         SDL_IME_PumpEvents_Real();

--- a/src/core/linux/SDL_threadprio.c
+++ b/src/core/linux/SDL_threadprio.c
@@ -79,7 +79,7 @@ static SDL_bool realtime_portal_supported(DBusConnection *conn)
                                               "RTTimeUSecMax", DBUS_TYPE_INT64, &res);
 }
 
-static void set_rtkit_interface()
+static void set_rtkit_interface(void)
 {
     SDL_DBusContext *dbus = SDL_DBus_GetContext();
 
@@ -108,7 +108,7 @@ static DBusConnection *get_rtkit_dbus_connection()
     return NULL;
 }
 
-static void rtkit_initialize()
+static void rtkit_initialize(void)
 {
     DBusConnection *dbus_conn;
 
@@ -134,7 +134,7 @@ static void rtkit_initialize()
     }
 }
 
-static SDL_bool rtkit_initialize_realtime_thread()
+static SDL_bool rtkit_initialize_realtime_thread(void)
 {
     // Following is an excerpt from rtkit README that outlines the requirements
     // a thread must meet before making rtkit requests:

--- a/src/core/openbsd/SDL_wscons_kbd.c
+++ b/src/core/openbsd/SDL_wscons_kbd.c
@@ -449,7 +449,7 @@ static SDL_WSCONS_input_data *SDL_WSCONS_Init_Keyboard(const char *dev)
     return input;
 }
 
-void SDL_WSCONS_Init()
+void SDL_WSCONS_Init(void)
 {
     inputs[0] = SDL_WSCONS_Init_Keyboard("/dev/wskbd0");
     inputs[1] = SDL_WSCONS_Init_Keyboard("/dev/wskbd1");
@@ -460,7 +460,7 @@ void SDL_WSCONS_Init()
     return;
 }
 
-void SDL_WSCONS_Quit()
+void SDL_WSCONS_Quit(void)
 {
     int i = 0;
     SDL_WSCONS_input_data *input = NULL;
@@ -921,7 +921,7 @@ static void updateKeyboard(SDL_WSCONS_input_data *input)
     }
 }
 
-void SDL_WSCONS_PumpEvents()
+void SDL_WSCONS_PumpEvents(void)
 {
     int i = 0;
     for (i = 0; i < 4; i++) {

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -1239,7 +1239,7 @@ void SDL_SIMDFree(void *ptr)
 
 #include <stdio.h>
 
-int main()
+int main(void)
 {
     printf("CPU count: %d\n", SDL_GetCPUCount());
     printf("CPU type: %s\n", SDL_GetCPUType());

--- a/src/hidapi/libusb/hid.c
+++ b/src/hidapi/libusb/hid.c
@@ -519,7 +519,7 @@ static struct usb_string_cache_entry *usb_string_cache = NULL;
 static size_t usb_string_cache_size = 0;
 static size_t usb_string_cache_insert_pos = 0;
 
-static int usb_string_cache_grow()
+static int usb_string_cache_grow(void)
 {
 	struct usb_string_cache_entry *new_cache;
 	size_t allocSize;
@@ -537,7 +537,7 @@ static int usb_string_cache_grow()
 	return 0;
 }
 
-static void usb_string_cache_destroy()
+static void usb_string_cache_destroy(void)
 {
 	size_t i;
 	for (i = 0; i < usb_string_cache_insert_pos; i++) {

--- a/src/hidapi/mac/hid.c
+++ b/src/hidapi/mac/hid.c
@@ -504,7 +504,7 @@ int HID_API_EXPORT hid_exit(void)
 	return 0;
 }
 
-static void process_pending_events() {
+static void process_pending_events(void) {
 	SInt32 res;
 	do {
 		res = CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.001, FALSE);

--- a/src/hidapi/windows/hid.c
+++ b/src/hidapi/windows/hid.c
@@ -264,7 +264,7 @@ static void register_error(hid_device *device, const char *op)
 }
 
 #ifndef HIDAPI_USE_DDK
-static int lookup_functions()
+static int lookup_functions(void)
 {
 	lib_handle = LoadLibrary(TEXT("hid.dll"));
 	if (lib_handle) {

--- a/src/joystick/hidapi/SDL_hidapijoystick.c
+++ b/src/joystick/hidapi/SDL_hidapijoystick.c
@@ -1008,7 +1008,7 @@ static void HIDAPI_DelDevice(SDL_HIDAPI_Device *device)
     }
 }
 
-static SDL_bool HIDAPI_CreateCombinedJoyCons()
+static SDL_bool HIDAPI_CreateCombinedJoyCons(void)
 {
     SDL_HIDAPI_Device *device, *combined;
     SDL_HIDAPI_Device *joycons[2] = { NULL, NULL };

--- a/src/joystick/ps2/SDL_sysjoystick.c
+++ b/src/joystick/ps2/SDL_sysjoystick.c
@@ -133,13 +133,13 @@ static int PS2_JoystickInit(void)
 }
 
 /* Function to return the number of joystick devices plugged in right now */
-static int PS2_JoystickGetCount()
+static int PS2_JoystickGetCount(void)
 {
     return (int)enabled_pads;
 }
 
 /* Function to cause any queued joystick insertions to be processed */
-static void PS2_JoystickDetect()
+static void PS2_JoystickDetect(void)
 {
 }
 

--- a/src/joystick/vita/SDL_sysjoystick.c
+++ b/src/joystick/vita/SDL_sysjoystick.c
@@ -145,12 +145,12 @@ int VITA_JoystickInit(void)
     return SDL_numjoysticks;
 }
 
-int VITA_JoystickGetCount()
+int VITA_JoystickGetCount(void)
 {
     return SDL_numjoysticks;
 }
 
-void VITA_JoystickDetect()
+void VITA_JoystickDetect(void)
 {
 }
 

--- a/src/joystick/windows/SDL_rawinputjoystick.c
+++ b/src/joystick/windows/SDL_rawinputjoystick.c
@@ -331,7 +331,7 @@ static struct
 static SDL_bool xinput_device_change = SDL_TRUE;
 static SDL_bool xinput_state_dirty = SDL_TRUE;
 
-static void RAWINPUT_UpdateXInput()
+static void RAWINPUT_UpdateXInput(void)
 {
     DWORD user_index;
     if (xinput_device_change) {
@@ -371,7 +371,7 @@ static void RAWINPUT_MarkXInputSlotFree(Uint8 xinput_slot)
         xinput_state[xinput_slot].used = SDL_FALSE;
     }
 }
-static SDL_bool RAWINPUT_MissingXInputSlot()
+static SDL_bool RAWINPUT_MissingXInputSlot(void)
 {
     int ii;
     for (ii = 0; ii < SDL_arraysize(xinput_state); ii++) {
@@ -556,7 +556,7 @@ static void RAWINPUT_MarkWindowsGamingInputSlotFree(WindowsGamingInputGamepadSta
     wgi_slot->correlated_context = NULL;
 }
 
-static SDL_bool RAWINPUT_MissingWindowsGamingInputSlot()
+static SDL_bool RAWINPUT_MissingWindowsGamingInputSlot(void)
 {
     int ii;
     for (ii = 0; ii < wgi_state.per_gamepad_count; ii++) {
@@ -567,7 +567,7 @@ static SDL_bool RAWINPUT_MissingWindowsGamingInputSlot()
     return SDL_FALSE;
 }
 
-static void RAWINPUT_UpdateWindowsGamingInput()
+static void RAWINPUT_UpdateWindowsGamingInput(void)
 {
     int ii;
     if (!wgi_state.gamepad_statics) {
@@ -1050,7 +1050,7 @@ static int RAWINPUT_JoystickGetCount(void)
     return SDL_RAWINPUT_numjoysticks;
 }
 
-SDL_bool RAWINPUT_IsEnabled()
+SDL_bool RAWINPUT_IsEnabled(void)
 {
     return SDL_RAWINPUT_inited && !SDL_RAWINPUT_remote_desktop;
 }
@@ -2087,7 +2087,7 @@ int RAWINPUT_RegisterNotifications(HWND hWnd)
     return 0;
 }
 
-int RAWINPUT_UnregisterNotifications()
+int RAWINPUT_UnregisterNotifications(void)
 {
     int i;
     RAWINPUTDEVICE rid[SDL_arraysize(subscribed_devices)];

--- a/src/joystick/windows/SDL_windows_gaming_input.c
+++ b/src/joystick/windows/SDL_windows_gaming_input.c
@@ -216,7 +216,7 @@ static SDL_bool SDL_IsXInputDevice(Uint16 vendor, Uint16 product)
     return SDL_FALSE;
 }
 
-static void WGI_LoadRawGameControllerStatics()
+static void WGI_LoadRawGameControllerStatics(void)
 {
     WindowsCreateStringReference_t WindowsCreateStringReferenceFunc = NULL;
     RoGetActivationFactory_t RoGetActivationFactoryFunc = NULL;
@@ -247,7 +247,7 @@ static void WGI_LoadRawGameControllerStatics()
     }
 }
 
-static void WGI_LoadOtherControllerStatics()
+static void WGI_LoadOtherControllerStatics(void)
 {
     WindowsCreateStringReference_t WindowsCreateStringReferenceFunc = NULL;
     RoGetActivationFactory_t RoGetActivationFactoryFunc = NULL;

--- a/src/joystick/windows/SDL_xinputjoystick.c
+++ b/src/joystick/windows/SDL_xinputjoystick.c
@@ -41,7 +41,7 @@ extern "C" {
  */
 static SDL_bool s_bXInputEnabled = SDL_TRUE;
 
-static SDL_bool SDL_XInputUseOldJoystickMapping()
+static SDL_bool SDL_XInputUseOldJoystickMapping(void)
 {
 #ifdef __WINRT__
     /* TODO: remove this __WINRT__ block, but only after integrating with UWP/WinRT's HID API */

--- a/src/main/ps2/SDL_ps2_main.c
+++ b/src/main/ps2/SDL_ps2_main.c
@@ -23,7 +23,7 @@
 #undef main
 #endif
 
-__attribute__((weak)) void reset_IOP()
+__attribute__((weak)) void reset_IOP(void)
 {
     SifInitRpc(0);
     while (!SifIopReset(NULL, 0)) {
@@ -32,7 +32,7 @@ __attribute__((weak)) void reset_IOP()
     }
 }
 
-static void prepare_IOP()
+static void prepare_IOP(void)
 {
     reset_IOP();
     SifInitRpc(0);
@@ -41,12 +41,12 @@ static void prepare_IOP()
     sbv_patch_fileio();
 }
 
-static void init_drivers()
+static void init_drivers(void)
 {
 	init_ps2_filesystem_driver();
 }
 
-static void deinit_drivers()
+static void deinit_drivers(void)
 {
 	deinit_ps2_filesystem_driver();
 }

--- a/src/render/ps2/SDL_render_ps2.c
+++ b/src/render/ps2/SDL_render_ps2.c
@@ -55,7 +55,7 @@ typedef struct
 static int vsync_sema_id = 0;
 
 /* PRIVATE METHODS */
-static int vsync_handler()
+static int vsync_handler(void)
 {
     iSignalSema(vsync_sema_id);
 

--- a/src/stdlib/SDL_malloc.c
+++ b/src/stdlib/SDL_malloc.c
@@ -4472,7 +4472,7 @@ struct mallinfo dlmallinfo(void) {
 }
 #endif /* NO_MALLINFO */
 
-void dlmalloc_stats() {
+void dlmalloc_stats(void) {
   internal_malloc_stats(gm);
 }
 

--- a/src/stdlib/SDL_mslibc.c
+++ b/src/stdlib/SDL_mslibc.c
@@ -120,12 +120,12 @@ localexit:
     /* *INDENT-ON* */
 }
 
-void _ftol2_sse()
+void _ftol2_sse(void)
 {
     _ftol();
 }
 
-void _ftol2()
+void _ftol2(void)
 {
     _ftol();
 }

--- a/src/test/SDL_test_assert.c
+++ b/src/test/SDL_test_assert.c
@@ -107,7 +107,7 @@ void SDLTest_AssertPass(SDL_PRINTF_FORMAT_STRING const char *assertDescription, 
 /*
  * Resets the assert summary counters to zero.
  */
-void SDLTest_ResetAssertSummary()
+void SDLTest_ResetAssertSummary(void)
 {
     SDLTest_AssertsPassed = 0;
     SDLTest_AssertsFailed = 0;
@@ -117,7 +117,7 @@ void SDLTest_ResetAssertSummary()
  * Logs summary of all assertions (total, pass, fail) since last reset
  * as INFO (failed==0) or ERROR (failed > 0).
  */
-void SDLTest_LogAssertSummary()
+void SDLTest_LogAssertSummary(void)
 {
     int totalAsserts = SDLTest_AssertsPassed + SDLTest_AssertsFailed;
     if (SDLTest_AssertsFailed == 0) {
@@ -130,7 +130,7 @@ void SDLTest_LogAssertSummary()
 /*
  * Converts the current assert state into a test result
  */
-int SDLTest_AssertSummaryToTestResult()
+int SDLTest_AssertSummaryToTestResult(void)
 {
     if (SDLTest_AssertsFailed > 0) {
         return TEST_RESULT_FAILED;

--- a/src/test/SDL_test_fuzzer.c
+++ b/src/test/SDL_test_fuzzer.c
@@ -68,54 +68,54 @@ void SDLTest_FuzzerInit(Uint64 execKey)
     fuzzerInvocationCounter = 0;
 }
 
-int SDLTest_GetFuzzerInvocationCount()
+int SDLTest_GetFuzzerInvocationCount(void)
 {
     return fuzzerInvocationCounter;
 }
 
-Uint8 SDLTest_RandomUint8()
+Uint8 SDLTest_RandomUint8(void)
 {
     fuzzerInvocationCounter++;
 
     return (Uint8)SDLTest_RandomInt(&rndContext) & 0x000000FF;
 }
 
-Sint8 SDLTest_RandomSint8()
+Sint8 SDLTest_RandomSint8(void)
 {
     fuzzerInvocationCounter++;
 
     return (Sint8)SDLTest_RandomInt(&rndContext) & 0x000000FF;
 }
 
-Uint16 SDLTest_RandomUint16()
+Uint16 SDLTest_RandomUint16(void)
 {
     fuzzerInvocationCounter++;
 
     return (Uint16)SDLTest_RandomInt(&rndContext) & 0x0000FFFF;
 }
 
-Sint16 SDLTest_RandomSint16()
+Sint16 SDLTest_RandomSint16(void)
 {
     fuzzerInvocationCounter++;
 
     return (Sint16)SDLTest_RandomInt(&rndContext) & 0x0000FFFF;
 }
 
-Sint32 SDLTest_RandomSint32()
+Sint32 SDLTest_RandomSint32(void)
 {
     fuzzerInvocationCounter++;
 
     return (Sint32)SDLTest_RandomInt(&rndContext);
 }
 
-Uint32 SDLTest_RandomUint32()
+Uint32 SDLTest_RandomUint32(void)
 {
     fuzzerInvocationCounter++;
 
     return (Uint32)SDLTest_RandomInt(&rndContext);
 }
 
-Uint64 SDLTest_RandomUint64()
+Uint64 SDLTest_RandomUint64(void)
 {
     union
     {
@@ -132,7 +132,7 @@ Uint64 SDLTest_RandomUint64()
     return value.v64;
 }
 
-Sint64 SDLTest_RandomSint64()
+Sint64 SDLTest_RandomSint64(void)
 {
     union
     {
@@ -425,24 +425,24 @@ Sint64 SDLTest_RandomSint64BoundaryValue(Sint64 boundary1, Sint64 boundary2, SDL
                                                 validDomain);
 }
 
-float SDLTest_RandomUnitFloat()
+float SDLTest_RandomUnitFloat(void)
 {
     return SDLTest_RandomUint32() / (float)UINT_MAX;
 }
 
-float SDLTest_RandomFloat()
+float SDLTest_RandomFloat(void)
 {
     return (float)(SDLTest_RandomUnitDouble() * 2.0 * (double)FLT_MAX - (double)(FLT_MAX));
 }
 
 double
-SDLTest_RandomUnitDouble()
+SDLTest_RandomUnitDouble(void)
 {
     return (double)(SDLTest_RandomUint64() >> 11) * (1.0 / 9007199254740992.0);
 }
 
 double
-SDLTest_RandomDouble()
+SDLTest_RandomDouble(void)
 {
     double r = 0.0;
     double s = 1.0;
@@ -456,7 +456,7 @@ SDLTest_RandomDouble()
     return r;
 }
 
-char *SDLTest_RandomAsciiString()
+char *SDLTest_RandomAsciiString(void)
 {
     return SDLTest_RandomAsciiStringWithMaximumLength(255);
 }

--- a/src/test/SDL_test_harness.c
+++ b/src/test/SDL_test_harness.c
@@ -339,7 +339,7 @@ static void SDLTest_LogTestSuiteSummary(SDLTest_TestSuiteReference *testSuites)
 #endif
 
 /* Gets a timer value in seconds */
-static float GetClock()
+static float GetClock(void)
 {
     float currentClock = SDL_GetPerformanceCounter() / (float)SDL_GetPerformanceFrequency();
     return currentClock;

--- a/src/test/SDL_test_imageBlit.c
+++ b/src/test/SDL_test_imageBlit.c
@@ -540,7 +540,7 @@ static const SDLTest_SurfaceImage_t SDLTest_imageBlit = {
 /**
  * \brief Returns the Blit test image as SDL_Surface.
  */
-SDL_Surface *SDLTest_ImageBlit()
+SDL_Surface *SDLTest_ImageBlit(void)
 {
     SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imageBlit.pixel_data,
@@ -1014,7 +1014,7 @@ static const SDLTest_SurfaceImage_t SDLTest_imageBlitColor = {
 /**
  * \brief Returns the BlitColor test image as SDL_Surface.
  */
-SDL_Surface *SDLTest_ImageBlitColor()
+SDL_Surface *SDLTest_ImageBlitColor(void)
 {
     SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imageBlitColor.pixel_data,
@@ -1651,7 +1651,7 @@ static const SDLTest_SurfaceImage_t SDLTest_imageBlitAlpha = {
 /**
  * \brief Returns the BlitAlpha test image as SDL_Surface.
  */
-SDL_Surface *SDLTest_ImageBlitAlpha()
+SDL_Surface *SDLTest_ImageBlitAlpha(void)
 {
     SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imageBlitAlpha.pixel_data,

--- a/src/test/SDL_test_imageBlitBlend.c
+++ b/src/test/SDL_test_imageBlitBlend.c
@@ -580,7 +580,7 @@ static const SDLTest_SurfaceImage_t SDLTest_imageBlitBlendAdd = {
 /**
  * \brief Returns the BlitBlendAdd test image as SDL_Surface.
  */
-SDL_Surface *SDLTest_ImageBlitBlendAdd()
+SDL_Surface *SDLTest_ImageBlitBlendAdd(void)
 {
     SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imageBlitBlendAdd.pixel_data,
@@ -1171,7 +1171,7 @@ static const SDLTest_SurfaceImage_t SDLTest_imageBlitBlend = {
 /**
  * \brief Returns the BlitBlend test image as SDL_Surface.
  */
-SDL_Surface *SDLTest_ImageBlitBlend()
+SDL_Surface *SDLTest_ImageBlitBlend(void)
 {
     SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imageBlitBlend.pixel_data,
@@ -1592,7 +1592,7 @@ static const SDLTest_SurfaceImage_t SDLTest_imageBlitBlendMod = {
 /**
  * \brief Returns the BlitBlendMod test image as SDL_Surface.
  */
-SDL_Surface *SDLTest_ImageBlitBlendMod()
+SDL_Surface *SDLTest_ImageBlitBlendMod(void)
 {
     SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imageBlitBlendMod.pixel_data,
@@ -2396,7 +2396,7 @@ static const SDLTest_SurfaceImage_t SDLTest_imageBlitBlendNone = {
 /**
  * \brief Returns the BlitBlendNone test image as SDL_Surface.
  */
-SDL_Surface *SDLTest_ImageBlitBlendNone()
+SDL_Surface *SDLTest_ImageBlitBlendNone(void)
 {
     SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imageBlitBlendNone.pixel_data,
@@ -2932,7 +2932,7 @@ static const SDLTest_SurfaceImage_t SDLTest_imageBlitBlendAll = {
 /**
  * \brief Returns the BlitBlendAll test image as SDL_Surface.
  */
-SDL_Surface *SDLTest_ImageBlitBlendAll()
+SDL_Surface *SDLTest_ImageBlitBlendAll(void)
 {
     SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imageBlitBlendAll.pixel_data,

--- a/src/test/SDL_test_imageFace.c
+++ b/src/test/SDL_test_imageFace.c
@@ -223,7 +223,7 @@ static const SDLTest_SurfaceImage_t SDLTest_imageFace = {
 /**
  * \brief Returns the Face test image as SDL_Surface.
  */
-SDL_Surface *SDLTest_ImageFace()
+SDL_Surface *SDLTest_ImageFace(void)
 {
     SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imageFace.pixel_data,

--- a/src/test/SDL_test_imagePrimitives.c
+++ b/src/test/SDL_test_imagePrimitives.c
@@ -504,7 +504,7 @@ static const SDLTest_SurfaceImage_t SDLTest_imagePrimitives = {
 /**
  * \brief Returns the Primitives test image as SDL_Surface.
  */
-SDL_Surface *SDLTest_ImagePrimitives()
+SDL_Surface *SDLTest_ImagePrimitives(void)
 {
     SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imagePrimitives.pixel_data,

--- a/src/test/SDL_test_imagePrimitivesBlend.c
+++ b/src/test/SDL_test_imagePrimitivesBlend.c
@@ -677,7 +677,7 @@ static const SDLTest_SurfaceImage_t SDLTest_imagePrimitivesBlend = {
 /**
  * \brief Returns the PrimitivesBlend test image as SDL_Surface.
  */
-SDL_Surface *SDLTest_ImagePrimitivesBlend()
+SDL_Surface *SDLTest_ImagePrimitivesBlend(void)
 {
     SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormatFrom(
         (void *)SDLTest_imagePrimitivesBlend.pixel_data,

--- a/src/test/SDL_test_memory.c
+++ b/src/test/SDL_test_memory.c
@@ -195,7 +195,7 @@ static void SDLCALL SDLTest_TrackedFree(void *ptr)
     SDL_free_orig(ptr);
 }
 
-int SDLTest_TrackAllocations()
+int SDLTest_TrackAllocations(void)
 {
     if (SDL_malloc_orig) {
         return 0;
@@ -220,7 +220,7 @@ int SDLTest_TrackAllocations()
     return 0;
 }
 
-void SDLTest_LogAllocations()
+void SDLTest_LogAllocations(void)
 {
     char *message = NULL;
     size_t message_size = 0;

--- a/src/video/SDL_blit.c
+++ b/src/video/SDL_blit.c
@@ -103,7 +103,7 @@ static int SDLCALL SDL_SoftBlit(SDL_Surface *src, SDL_Rect *srcrect,
 #ifdef __MACOSX__
 #include <sys/sysctl.h>
 
-static SDL_bool SDL_UseAltivecPrefetch()
+static SDL_bool SDL_UseAltivecPrefetch(void)
 {
     const char key[] = "hw.l3cachesize";
     u_int64_t result = 0;

--- a/src/video/SDL_stretch.c
+++ b/src/video/SDL_stretch.c
@@ -367,7 +367,7 @@ static void printf_128(const char *str, __m128i var)
 }
 #endif
 
-static SDL_INLINE int hasSSE2()
+static SDL_INLINE int hasSSE2(void)
 {
     static int val = -1;
     if (val != -1) {

--- a/src/video/android/SDL_androidmouse.c
+++ b/src/video/android/SDL_androidmouse.c
@@ -78,7 +78,7 @@ static SDL_Cursor *Android_WrapCursor(int custom_cursor, int system_cursor)
     return cursor;
 }
 
-static SDL_Cursor *Android_CreateDefaultCursor()
+static SDL_Cursor *Android_CreateDefaultCursor(void)
 {
     return Android_WrapCursor(0, SDL_SYSTEM_CURSOR_ARROW);
 }
@@ -116,7 +116,7 @@ static void Android_FreeCursor(SDL_Cursor *cursor)
     SDL_free(cursor);
 }
 
-static SDL_Cursor *Android_CreateEmptyCursor()
+static SDL_Cursor *Android_CreateEmptyCursor(void)
 {
     if (!empty_cursor) {
         SDL_Surface *empty_surface = SDL_CreateRGBSurfaceWithFormat(0, 1, 1, 32, SDL_PIXELFORMAT_ARGB8888);
@@ -129,7 +129,7 @@ static SDL_Cursor *Android_CreateEmptyCursor()
     return empty_cursor;
 }
 
-static void Android_DestroyEmptyCursor()
+static void Android_DestroyEmptyCursor(void)
 {
     if (empty_cursor) {
         Android_FreeCursor(empty_cursor);

--- a/src/video/directfb/SDL_DirectFB_render.c
+++ b/src/video/directfb/SDL_DirectFB_render.c
@@ -561,7 +561,7 @@ static void DirectFB_UnlockTexture(SDL_Renderer * renderer, SDL_Texture * textur
     }
 }
 
-static void DirectFB_SetTextureScaleMode()
+static void DirectFB_SetTextureScaleMode(void)
 {
 }
 

--- a/src/video/dummy/SDL_nullvideo.c
+++ b/src/video/dummy/SDL_nullvideo.c
@@ -131,7 +131,7 @@ VideoBootStrap DUMMY_evdev_bootstrap = {
     NULL /* no ShowMessageBox implementation */
 };
 void SDL_EVDEV_Init(void);
-void SDL_EVDEV_Poll();
+void SDL_EVDEV_Poll(void);
 void SDL_EVDEV_Quit(void);
 static void DUMMY_EVDEV_Poll(_THIS)
 {

--- a/src/video/emscripten/SDL_emscriptenmouse.c
+++ b/src/video/emscripten/SDL_emscriptenmouse.c
@@ -222,7 +222,7 @@ static int Emscripten_SetRelativeMouseMode(SDL_bool enabled)
     return -1;
 }
 
-void Emscripten_InitMouse()
+void Emscripten_InitMouse(void)
 {
     SDL_Mouse *mouse = SDL_GetMouse();
 
@@ -236,7 +236,7 @@ void Emscripten_InitMouse()
     SDL_SetDefaultCursor(Emscripten_CreateDefaultCursor());
 }
 
-void Emscripten_FiniMouse()
+void Emscripten_FiniMouse(void)
 {
 }
 

--- a/src/video/n3ds/SDL_n3dsswkb.c
+++ b/src/video/n3ds/SDL_n3dsswkb.c
@@ -30,17 +30,17 @@
 static SwkbdState sw_keyboard;
 const static size_t BUFFER_SIZE = 256;
 
-void N3DS_SwkbInit()
+void N3DS_SwkbInit(void)
 {
     swkbdInit(&sw_keyboard, SWKBD_TYPE_NORMAL, 2, -1);
 }
 
-void N3DS_SwkbPoll()
+void N3DS_SwkbPoll(void)
 {
     return;
 }
 
-void N3DS_SwkbQuit()
+void N3DS_SwkbQuit(void)
 {
     return;
 }

--- a/src/video/raspberry/SDL_rpivideo.c
+++ b/src/video/raspberry/SDL_rpivideo.c
@@ -56,7 +56,7 @@ static void RPI_Destroy(SDL_VideoDevice *device)
     SDL_free(device);
 }
 
-static int RPI_GetRefreshRate()
+static int RPI_GetRefreshRate(void)
 {
     TV_DISPLAY_STATE_T tvstate;
     if (vc_tv_get_display_state(&tvstate) == 0) {

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -79,7 +79,7 @@ static void Wayland_VideoQuit(_THIS);
 
 /* Find out what class name we should use
  * Based on src/video/x11/SDL_x11video.c */
-static char *get_classname()
+static char *get_classname(void)
 {
     /* !!! FIXME: this is probably wrong, albeit harmless in many common cases. From protocol spec:
         "The surface class identifies the general class of applications

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -330,7 +330,7 @@ static SDL_Scancode WindowsScanCodeToSDLScanCode(LPARAM lParam, WPARAM wParam)
 }
 
 #if !defined(__XBOXONE__) && !defined(__XBOXSERIES__)
-static SDL_bool WIN_ShouldIgnoreFocusClick()
+static SDL_bool WIN_ShouldIgnoreFocusClick(void)
 {
     return !SDL_GetHintBoolean(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, SDL_FALSE);
 }
@@ -1797,7 +1797,7 @@ WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 }
 
 #if !defined(__XBOXONE__) && !defined(__XBOXSERIES__)
-static void WIN_UpdateClipCursorForWindows()
+static void WIN_UpdateClipCursorForWindows(void)
 {
     SDL_VideoDevice *_this = SDL_GetVideoDevice();
     SDL_Window *window;
@@ -1819,7 +1819,7 @@ static void WIN_UpdateClipCursorForWindows()
     }
 }
 
-static void WIN_UpdateMouseCapture()
+static void WIN_UpdateMouseCapture(void)
 {
     SDL_Window *focusWindow = SDL_GetKeyboardFocus();
 
@@ -2093,7 +2093,7 @@ int SDL_RegisterApp(const char *name, Uint32 style, void *hInst)
 }
 
 /* Unregisters the windowclass registered in SDL_RegisterApp above. */
-void SDL_UnregisterApp()
+void SDL_UnregisterApp(void)
 {
     WNDCLASSEX wcex;
 

--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -166,7 +166,7 @@ void WIN_QuitKeyboard(_THIS)
 #endif /* !SDL_DISABLE_WINDOWS_IME */
 }
 
-void WIN_ResetDeadKeys()
+void WIN_ResetDeadKeys(void)
 {
     /*
     if a deadkey has been typed, but not the next character (which the deadkey might modify),
@@ -367,7 +367,7 @@ static void UILess_ReleaseSinks(SDL_VideoData *videodata);
 static void UILess_EnableUIUpdates(SDL_VideoData *videodata);
 static void UILess_DisableUIUpdates(SDL_VideoData *videodata);
 
-static SDL_bool WIN_ShouldShowNativeUI()
+static SDL_bool WIN_ShouldShowNativeUI(void)
 {
     return SDL_GetHintBoolean(SDL_HINT_IME_SHOW_UI, SDL_FALSE);
 }

--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -474,7 +474,7 @@ static void WIN_SetLinearMouseScale(int mouse_speed)
     }
 }
 
-void WIN_UpdateMouseSystemScale()
+void WIN_UpdateMouseSystemScale(void)
 {
     int mouse_speed;
     int params[3] = { 0, 0, 0 };

--- a/src/video/x11/SDL_x11video.c
+++ b/src/video/x11/SDL_x11video.c
@@ -50,7 +50,7 @@ static int X11_VideoInit(_THIS);
 static void X11_VideoQuit(_THIS);
 
 /* Find out what class name we should use */
-static char *get_classname()
+static char *get_classname(void)
 {
     char *spot;
 #if defined(__LINUX__) || defined(__FREEBSD__)

--- a/src/video/x11/SDL_x11xfixes.c
+++ b/src/video/x11/SDL_x11xfixes.c
@@ -74,12 +74,12 @@ void X11_InitXfixes(_THIS)
     xfixes_initialized = 1;
 }
 
-int X11_XfixesIsInitialized()
+int X11_XfixesIsInitialized(void)
 {
     return xfixes_initialized;
 }
 
-int X11_GetXFixesSelectionNotifyEvent()
+int X11_GetXFixesSelectionNotifyEvent(void)
 {
     return xfixes_selection_notify_event;
 }

--- a/src/video/x11/SDL_x11xinput2.c
+++ b/src/video/x11/SDL_x11xinput2.c
@@ -453,7 +453,7 @@ void X11_Xinput2SelectTouch(_THIS, SDL_Window *window)
 #endif
 }
 
-int X11_Xinput2IsInitialized()
+int X11_Xinput2IsInitialized(void)
 {
 #ifdef SDL_VIDEO_DRIVER_X11_XINPUT2
     return xinput2_initialized;
@@ -462,7 +462,7 @@ int X11_Xinput2IsInitialized()
 #endif
 }
 
-int X11_Xinput2IsMultitouchSupported()
+int X11_Xinput2IsMultitouchSupported(void)
 {
 #ifdef SDL_VIDEO_DRIVER_X11_XINPUT2_SUPPORTS_MULTITOUCH
     return xinput2_initialized && xinput2_multitouch_supported;

--- a/test/checkkeys.c
+++ b/test/checkkeys.c
@@ -107,7 +107,7 @@ print_modifiers(char **text, size_t *maxlen)
 }
 
 static void
-PrintModifierState()
+PrintModifierState(void)
 {
     char message[512];
     char *spot;
@@ -166,7 +166,7 @@ PrintText(const char *eventtype, const char *text)
     SDL_Log("%s Text (%s): \"%s%s\"\n", eventtype, expanded, *text == '"' ? "\\" : "", text);
 }
 
-void loop()
+void loop(void)
 {
     SDL_Event event;
     /* Check for events */

--- a/test/checkkeysthreads.c
+++ b/test/checkkeysthreads.c
@@ -103,7 +103,7 @@ print_modifiers(char **text, size_t *maxlen)
 }
 
 static void
-PrintModifierState()
+PrintModifierState(void)
 {
     char message[512];
     char *spot;
@@ -162,7 +162,7 @@ PrintText(const char *eventtype, const char *text)
     SDL_Log("%s Text (%s): \"%s%s\"\n", eventtype, expanded, *text == '"' ? "\\" : "", text);
 }
 
-void loop()
+void loop(void)
 {
     SDL_Event event;
     /* Check for events */

--- a/test/loopwave.c
+++ b/test/loopwave.c
@@ -46,7 +46,7 @@ quit(int rc)
 }
 
 static void
-close_audio()
+close_audio(void)
 {
     if (device != 0) {
         SDL_CloseAudioDevice(device);
@@ -55,7 +55,7 @@ close_audio()
 }
 
 static void
-open_audio()
+open_audio(void)
 {
     /* Initialize fillerup() variables */
     device = SDL_OpenAudioDevice(NULL, SDL_FALSE, &wave.spec, NULL, 0);
@@ -70,7 +70,7 @@ open_audio()
 }
 
 #ifndef __EMSCRIPTEN__
-static void reopen_audio()
+static void reopen_audio(void)
 {
     close_audio();
     open_audio();
@@ -103,7 +103,7 @@ fillerup(void *unused, Uint8 *stream, int len)
 static int done = 0;
 
 #ifdef __EMSCRIPTEN__
-void loop()
+void loop(void)
 {
     if (done || (SDL_GetAudioDeviceStatus(device) != SDL_AUDIO_PLAYING)) {
         emscripten_cancel_main_loop();

--- a/test/loopwavequeue.c
+++ b/test/loopwavequeue.c
@@ -48,7 +48,7 @@ void poked(int sig)
     done = 1;
 }
 
-void loop()
+void loop(void)
 {
 #ifdef __EMSCRIPTEN__
     if (done || (SDL_GetAudioStatus() != SDL_AUDIO_PLAYING)) {

--- a/test/testatomic.c
+++ b/test/testatomic.c
@@ -31,7 +31,7 @@ tf(SDL_bool _tf)
     return f;
 }
 
-static void RunBasicTest()
+static void RunBasicTest(void)
 {
     int value;
     SDL_SpinLock lock = 0;
@@ -153,7 +153,7 @@ static void runAdder(void)
     SDL_Log("Finished in %f sec\n", (end - start) / 1000.f);
 }
 
-static void RunEpicTest()
+static void RunEpicTest(void)
 {
     int b;
     atomicValue v;

--- a/test/testaudiocapture.c
+++ b/test/testaudiocapture.c
@@ -24,7 +24,7 @@ static SDL_AudioDeviceID devid_in = 0;
 static SDL_AudioDeviceID devid_out = 0;
 
 static void
-loop()
+loop(void)
 {
     SDL_bool please_quit = SDL_FALSE;
     SDL_Event e;

--- a/test/testaudiohotplug.c
+++ b/test/testaudiohotplug.c
@@ -81,7 +81,7 @@ devtypestr(int iscapture)
 }
 
 static void
-iteration()
+iteration(void)
 {
     SDL_Event e;
     SDL_AudioDeviceID dev;
@@ -124,7 +124,7 @@ iteration()
 }
 
 #ifdef __EMSCRIPTEN__
-void loop()
+void loop(void)
 {
     if (done)
         emscripten_cancel_main_loop();

--- a/test/testautomation_audio.c
+++ b/test/testautomation_audio.c
@@ -96,7 +96,7 @@ static SDL_bool DriverIsProblematic(const char *driver)
  * \sa https://wiki.libsdl.org/SDL_QuitSubSystem
  * \sa https://wiki.libsdl.org/SDL_InitSubSystem
  */
-int audio_quitInitAudioSubSystem()
+int audio_quitInitAudioSubSystem(void)
 {
     /* Stop SDL audio subsystem */
     SDL_QuitSubSystem(SDL_INIT_AUDIO);
@@ -114,7 +114,7 @@ int audio_quitInitAudioSubSystem()
  * \sa https://wiki.libsdl.org/SDL_InitAudio
  * \sa https://wiki.libsdl.org/SDL_QuitAudio
  */
-int audio_initQuitAudio()
+int audio_initQuitAudio(void)
 {
     int result;
     int i, iMax;
@@ -195,7 +195,7 @@ int audio_initQuitAudio()
  * \sa https://wiki.libsdl.org/SDL_CloseAudio
  * \sa https://wiki.libsdl.org/SDL_QuitAudio
  */
-int audio_initOpenCloseQuitAudio()
+int audio_initOpenCloseQuitAudio(void)
 {
     int result, expectedResult;
     int i, iMax, j, k;
@@ -318,7 +318,7 @@ int audio_initOpenCloseQuitAudio()
  *
  * \sa https://wiki.libsdl.org/SDL_PauseAudio
  */
-int audio_pauseUnpauseAudio()
+int audio_pauseUnpauseAudio(void)
 {
     int result;
     int i, iMax, j, k, l;
@@ -474,7 +474,7 @@ int audio_pauseUnpauseAudio()
  * \sa https://wiki.libsdl.org/SDL_GetNumAudioDevices
  * \sa https://wiki.libsdl.org/SDL_GetAudioDeviceName
  */
-int audio_enumerateAndNameAudioDevices()
+int audio_enumerateAndNameAudioDevices(void)
 {
     int t, tt;
     int i, n, nn;
@@ -532,7 +532,7 @@ int audio_enumerateAndNameAudioDevices()
  * \sa https://wiki.libsdl.org/SDL_GetNumAudioDevices
  * \sa https://wiki.libsdl.org/SDL_GetAudioDeviceName
  */
-int audio_enumerateAndNameAudioDevicesNegativeTests()
+int audio_enumerateAndNameAudioDevicesNegativeTests(void)
 {
     int t;
     int i, j, no, nc;
@@ -578,7 +578,7 @@ int audio_enumerateAndNameAudioDevicesNegativeTests()
  * \sa https://wiki.libsdl.org/SDL_GetNumAudioDrivers
  * \sa https://wiki.libsdl.org/SDL_GetAudioDriver
  */
-int audio_printAudioDrivers()
+int audio_printAudioDrivers(void)
 {
     int i, n;
     const char *name;
@@ -608,7 +608,7 @@ int audio_printAudioDrivers()
  *
  * \sa https://wiki.libsdl.org/SDL_GetCurrentAudioDriver
  */
-int audio_printCurrentAudioDriver()
+int audio_printCurrentAudioDriver(void)
 {
     /* Check current audio driver */
     const char *name = SDL_GetCurrentAudioDriver();
@@ -639,7 +639,7 @@ int _audioFrequencies[] = { 11025, 22050, 44100, 48000 };
  *
  * \sa https://wiki.libsdl.org/SDL_BuildAudioCVT
  */
-int audio_buildAudioCVT()
+int audio_buildAudioCVT(void)
 {
     int result;
     SDL_AudioCVT cvt;
@@ -703,7 +703,7 @@ int audio_buildAudioCVT()
  *
  * \sa https://wiki.libsdl.org/SDL_BuildAudioCVT
  */
-int audio_buildAudioCVTNegative()
+int audio_buildAudioCVTNegative(void)
 {
     const char *expectedError = "Parameter 'cvt' is invalid";
     const char *error;
@@ -798,7 +798,7 @@ int audio_buildAudioCVTNegative()
  *
  * \sa https://wiki.libsdl.org/SDL_GetAudioStatus
  */
-int audio_getAudioStatus()
+int audio_getAudioStatus(void)
 {
     SDL_AudioStatus result;
 
@@ -817,7 +817,7 @@ int audio_getAudioStatus()
  *
  * \sa https://wiki.libsdl.org/SDL_GetAudioStatus
  */
-int audio_openCloseAndGetAudioStatus()
+int audio_openCloseAndGetAudioStatus(void)
 {
     SDL_AudioStatus result;
     int i;
@@ -878,7 +878,7 @@ int audio_openCloseAndGetAudioStatus()
  * \sa https://wiki.libsdl.org/SDL_LockAudioDevice
  * \sa https://wiki.libsdl.org/SDL_UnlockAudioDevice
  */
-int audio_lockUnlockOpenAudioDevice()
+int audio_lockUnlockOpenAudioDevice(void)
 {
     int i;
     int count;
@@ -942,7 +942,7 @@ int audio_lockUnlockOpenAudioDevice()
  * \sa https://wiki.libsdl.org/SDL_BuildAudioCVT
  * \sa https://wiki.libsdl.org/SDL_ConvertAudio
  */
-int audio_convertAudio()
+int audio_convertAudio(void)
 {
     int result;
     SDL_AudioCVT cvt;
@@ -1043,7 +1043,7 @@ int audio_convertAudio()
  *
  * \sa https://wiki.libsdl.org/SDL_AudioDeviceConnected
  */
-int audio_openCloseAudioDeviceConnected()
+int audio_openCloseAudioDeviceConnected(void)
 {
     int result = -1;
     int i;
@@ -1118,7 +1118,7 @@ static double sine_wave_sample(const Sint64 idx, const Sint64 rate, const Sint64
  * \sa https://wiki.libsdl.org/SDL_BuildAudioCVT
  * \sa https://wiki.libsdl.org/SDL_ConvertAudio
  */
-int audio_resampleLoss()
+int audio_resampleLoss(void)
 {
   /* Note: always test long input time (>= 5s from experience) in some test
    * cases because an improper implementation may suffer from low resampling

--- a/test/testautomation_keyboard.c
+++ b/test/testautomation_keyboard.c
@@ -102,7 +102,7 @@ int keyboard_getKeyFromName(void *arg)
 /*
  * Local helper to check for the invalid scancode error message
  */
-void _checkInvalidScancodeError()
+void _checkInvalidScancodeError(void)
 {
     const char *expectedError = "Parameter 'scancode' is invalid";
     const char *error;
@@ -574,7 +574,7 @@ int keyboard_getScancodeFromName(void *arg)
 /*
  * Local helper to check for the invalid scancode error message
  */
-void _checkInvalidNameError()
+void _checkInvalidNameError(void)
 {
     const char *expectedError = "Parameter 'name' is invalid";
     const char *error;

--- a/test/testautomation_log.c
+++ b/test/testautomation_log.c
@@ -21,7 +21,7 @@ static void EnableTestLog(int *message_count)
     SDL_LogSetOutputFunction(TestLogOutput, message_count);
 }
 
-static void DisableTestLog()
+static void DisableTestLog(void)
 {
     SDL_LogSetOutputFunction(original_function, original_userdata);
 }

--- a/test/testautomation_subsystems.c
+++ b/test/testautomation_subsystems.c
@@ -40,7 +40,7 @@ static void subsystemsTearDown(void *arg)
  * \sa SDL_QuitSubSystem
  *
  */
-static int subsystems_referenceCount()
+static int subsystems_referenceCount(void)
 {
     const int system = SDL_INIT_VIDEO;
     int result;
@@ -90,7 +90,7 @@ static int subsystems_referenceCount()
  * \sa SDL_QuitSubSystem
  *
  */
-static int subsystems_dependRefCountInitAllQuitByOne()
+static int subsystems_dependRefCountInitAllQuitByOne(void)
 {
     int result;
     /* Ensure that we start with reset subsystems. */
@@ -128,7 +128,7 @@ static int subsystems_dependRefCountInitAllQuitByOne()
  * \sa SDL_QuitSubSystem
  *
  */
-static int subsystems_dependRefCountInitByOneQuitAll()
+static int subsystems_dependRefCountInitByOneQuitAll(void)
 {
     int result;
     /* Ensure that we start with reset subsystems. */
@@ -163,7 +163,7 @@ static int subsystems_dependRefCountInitByOneQuitAll()
  * \sa SDL_QuitSubSystem
  *
  */
-static int subsystems_dependRefCountWithExtraInit()
+static int subsystems_dependRefCountWithExtraInit(void)
 {
     int result;
     /* Ensure that we start with reset subsystems. */

--- a/test/testautomation_surface.c
+++ b/test/testautomation_surface.c
@@ -81,7 +81,7 @@ void _surfaceTearDown(void *arg)
 /**
  * Helper that clears the test surface
  */
-void _clearTestSurface()
+void _clearTestSurface(void)
 {
     int ret;
     Uint32 color;

--- a/test/testautomation_video.c
+++ b/test/testautomation_video.c
@@ -624,7 +624,7 @@ int video_getWindowDisplayMode(void *arg)
 }
 
 /* Helper function that checks for an 'Invalid window' error */
-void _checkInvalidWindowError()
+void _checkInvalidWindowError(void)
 {
     const char *invalidWindowError = "Invalid window";
     char *lastError;
@@ -1300,7 +1300,7 @@ int video_getSetWindowPosition(void *arg)
 }
 
 /* Helper function that checks for an 'Invalid parameter' error */
-void _checkInvalidParameterError()
+void _checkInvalidParameterError(void)
 {
     const char *invalidParameterError = "Parameter";
     char *lastError;

--- a/test/testcustomcursor.c
+++ b/test/testcustomcursor.c
@@ -148,7 +148,7 @@ quit(int rc)
     exit(rc);
 }
 
-void loop()
+void loop(void)
 {
     int i;
     SDL_Event event;

--- a/test/testdraw2.c
+++ b/test/testdraw2.c
@@ -174,7 +174,7 @@ void DrawRects(SDL_Renderer *renderer)
     }
 }
 
-void loop()
+void loop(void)
 {
     Uint32 now;
     int i;

--- a/test/testdrawchessboard.c
+++ b/test/testdrawchessboard.c
@@ -28,7 +28,7 @@ SDL_Renderer *renderer;
 SDL_Surface *surface;
 int done;
 
-void DrawChessBoard()
+void DrawChessBoard(void)
 {
     int row = 0, column = 0, x = 0;
     SDL_Rect rect, darea;
@@ -53,7 +53,7 @@ void DrawChessBoard()
     SDL_RenderPresent(renderer);
 }
 
-void loop()
+void loop(void)
 {
     SDL_Event e;
     while (SDL_PollEvent(&e)) {

--- a/test/testgamecontroller.c
+++ b/test/testgamecontroller.c
@@ -107,7 +107,7 @@ static int virtual_axis_start_x;
 static int virtual_axis_start_y;
 static SDL_GameControllerButton virtual_button_active = SDL_CONTROLLER_BUTTON_INVALID;
 
-static void UpdateWindowTitle()
+static void UpdateWindowTitle(void)
 {
     if (!window) {
         return;
@@ -329,7 +329,7 @@ typedef struct
     Uint8 ucLedBlue;                  /* 46 */
 } DS5EffectsState_t;
 
-static void CyclePS5TriggerEffect()
+static void CyclePS5TriggerEffect(void)
 {
     DS5EffectsState_t state;
 
@@ -351,7 +351,7 @@ static void CyclePS5TriggerEffect()
     SDL_GameControllerSendEffect(gamecontroller, &state, sizeof(state));
 }
 
-static SDL_bool ShowingFront()
+static SDL_bool ShowingFront(void)
 {
     SDL_bool showing_front = SDL_TRUE;
     int i;
@@ -394,7 +394,7 @@ static int SDLCALL VirtualControllerSetLED(void *userdata, Uint8 red, Uint8 gree
     return 0;
 }
 
-static void OpenVirtualController()
+static void OpenVirtualController(void)
 {
     SDL_VirtualJoystickDesc desc;
     int virtual_index;
@@ -420,7 +420,7 @@ static void OpenVirtualController()
     }
 }
 
-static void CloseVirtualController()
+static void CloseVirtualController(void)
 {
     int i;
 

--- a/test/testgeometry.c
+++ b/test/testgeometry.c
@@ -62,7 +62,7 @@ int LoadSprite(const char *file)
     return 0;
 }
 
-void loop()
+void loop(void)
 {
     int i;
     SDL_Event event;

--- a/test/testgl2.c
+++ b/test/testgl2.c
@@ -78,7 +78,7 @@ quit(int rc)
 }
 
 static void
-Render()
+Render(void)
 {
     static float color[8][3] = {
         { 1.0, 1.0, 0.0 },

--- a/test/testgles.c
+++ b/test/testgles.c
@@ -49,7 +49,7 @@ quit(int rc)
 }
 
 static void
-Render()
+Render(void)
 {
     static GLubyte color[8][4] = { { 255, 0, 0, 0 },
                                    { 255, 0, 0, 255 },

--- a/test/testgles2.c
+++ b/test/testgles2.c
@@ -569,7 +569,7 @@ render_thread_fn(void *render_ctx)
 }
 
 static void
-loop_threaded()
+loop_threaded(void)
 {
     SDL_Event event;
     int i;
@@ -598,7 +598,7 @@ loop_threaded()
 #endif
 
 static void
-loop()
+loop(void)
 {
     SDL_Event event;
     int i;

--- a/test/testgles2_sdf.c
+++ b/test/testgles2_sdf.c
@@ -325,7 +325,7 @@ int done;
 Uint32 frames;
 shader_data *datas;
 
-void loop()
+void loop(void)
 {
     SDL_Event event;
     int i;

--- a/test/testime.c
+++ b/test/testime.c
@@ -333,7 +333,7 @@ static Sint32 unifont_draw_glyph(Uint32 codepoint, int rendererID, SDL_Rect *dst
     return unifontGlyph[codepoint].width;
 }
 
-static void unifont_cleanup()
+static void unifont_cleanup(void)
 {
     int i, j;
     for (i = 0; i < state->num_windows; ++i) {
@@ -425,12 +425,12 @@ Uint32 utf8_decode(char *p, size_t len)
     return codepoint;
 }
 
-void usage()
+void usage(void)
 {
     SDL_Log("usage: testime [--font fontfile]\n");
 }
 
-void InitInput()
+void InitInput(void)
 {
     /* Prepare a rect for text input */
     textRect.x = textRect.y = 100;
@@ -444,7 +444,7 @@ void InitInput()
     SDL_StartTextInput();
 }
 
-void CleanupVideo()
+void CleanupVideo(void)
 {
     SDL_StopTextInput();
 #ifdef HAVE_SDL_TTF
@@ -597,7 +597,7 @@ void _Redraw(int rendererID)
     SDL_SetTextInputRect(&markedRect);
 }
 
-void Redraw()
+void Redraw(void)
 {
     int i;
     for (i = 0; i < state->num_windows; ++i) {

--- a/test/testintersections.c
+++ b/test/testintersections.c
@@ -208,7 +208,7 @@ DrawRectRectIntersections(SDL_Renderer *renderer)
     }
 }
 
-void loop()
+void loop(void)
 {
     int i;
     SDL_Event event;

--- a/test/testmultiaudio.c
+++ b/test/testmultiaudio.c
@@ -53,7 +53,7 @@ play_through_once(void *arg, Uint8 *stream, int len)
     }
 }
 
-void loop()
+void loop(void)
 {
     if (SDL_AtomicGet(&cbd[0].done)) {
 #ifdef __EMSCRIPTEN__

--- a/test/testoffscreen.c
+++ b/test/testoffscreen.c
@@ -32,7 +32,7 @@ static int width = 640;
 static int height = 480;
 static unsigned int max_frames = 200;
 
-void draw()
+void draw(void)
 {
     SDL_Rect Rect;
 
@@ -50,7 +50,7 @@ void draw()
     SDL_RenderPresent(renderer);
 }
 
-void save_surface_to_bmp()
+void save_surface_to_bmp(void)
 {
     SDL_Surface *surface;
     Uint32 r_mask, g_mask, b_mask, a_mask;
@@ -71,7 +71,7 @@ void save_surface_to_bmp()
     SDL_FreeSurface(surface);
 }
 
-void loop()
+void loop(void)
 {
     SDL_Event event;
 

--- a/test/testoverlay2.c
+++ b/test/testoverlay2.c
@@ -178,7 +178,7 @@ PrintUsage(char *argv0)
     SDL_Log("\n");
 }
 
-void loop()
+void loop(void)
 {
     SDL_Event event;
 

--- a/test/testrelative.c
+++ b/test/testrelative.c
@@ -35,7 +35,7 @@ DrawRects(SDL_Renderer *renderer)
 }
 
 static void
-loop()
+loop(void)
 {
     /* Check for events */
     while (SDL_PollEvent(&event)) {

--- a/test/testrendercopyex.c
+++ b/test/testrendercopyex.c
@@ -87,7 +87,7 @@ void Draw(DrawState *s)
     /* SDL_Delay(10); */
 }
 
-void loop()
+void loop(void)
 {
     int i;
     SDL_Event event;

--- a/test/testrendertarget.c
+++ b/test/testrendertarget.c
@@ -173,7 +173,7 @@ Draw(DrawState *s)
     return SDL_TRUE;
 }
 
-void loop()
+void loop(void)
 {
     int i;
     SDL_Event event;

--- a/test/testscale.c
+++ b/test/testscale.c
@@ -78,7 +78,7 @@ void Draw(DrawState *s)
     SDL_RenderPresent(s->renderer);
 }
 
-void loop()
+void loop(void)
 {
     int i;
     SDL_Event event;

--- a/test/testshader.c
+++ b/test/testshader.c
@@ -228,7 +228,7 @@ static void DestroyShaderProgram(ShaderData *data)
     }
 }
 
-static SDL_bool InitShaders()
+static SDL_bool InitShaders(void)
 {
     int i;
 
@@ -282,7 +282,7 @@ static SDL_bool InitShaders()
     return SDL_TRUE;
 }
 
-static void QuitShaders()
+static void QuitShaders(void)
 {
     int i;
 

--- a/test/testsprite2.c
+++ b/test/testsprite2.c
@@ -392,7 +392,7 @@ void MoveSprites(SDL_Renderer *renderer, SDL_Texture *sprite)
     SDL_RenderPresent(renderer);
 }
 
-static void MoveAllSprites()
+static void MoveAllSprites(void)
 {
     int i;
 
@@ -404,7 +404,7 @@ static void MoveAllSprites()
     }
 }
 
-void loop()
+void loop(void)
 {
     Uint32 now;
     SDL_Event event;

--- a/test/testspriteminimal.c
+++ b/test/testspriteminimal.c
@@ -43,7 +43,7 @@ quit(int rc)
     exit(rc);
 }
 
-void MoveSprites()
+void MoveSprites(void)
 {
     int i;
     int window_w = WINDOW_WIDTH;
@@ -77,7 +77,7 @@ void MoveSprites()
     SDL_RenderPresent(renderer);
 }
 
-void loop()
+void loop(void)
 {
     SDL_Event event;
 

--- a/test/teststreaming.c
+++ b/test/teststreaming.c
@@ -94,7 +94,7 @@ void UpdateTexture(SDL_Texture *texture)
     SDL_UnlockTexture(texture);
 }
 
-void loop()
+void loop(void)
 {
     SDL_Event event;
 

--- a/test/testviewport.c
+++ b/test/testviewport.c
@@ -95,7 +95,7 @@ void DrawOnViewport(SDL_Renderer *renderer)
     SDL_RenderSetClipRect(renderer, NULL);
 }
 
-void loop()
+void loop(void)
 {
     SDL_Event event;
     int i;

--- a/test/testwm2.c
+++ b/test/testwm2.c
@@ -143,7 +143,7 @@ draw_modes_menu(SDL_Window *window, SDL_Renderer *renderer, SDL_Rect viewport)
     }
 }
 
-void loop()
+void loop(void)
 {
     int i;
     SDL_Event event;


### PR DESCRIPTION
Fix warning for Android NDK compiler: "function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]"

## Description
<!--- Describe your changes in detail -->

https://stackoverflow.com/questions/42125/warning-error-function-declaration-isnt-a-prototype

In C int foo() and int foo(void) are different functions. int foo() accepts an arbitrary number of arguments, while int foo(void) accepts 0 arguments. In C++ they mean the same thing. I suggest that you use void consistently when you mean no arguments.