### PR TITLE
Add SDL_VIDEO_DOUBLE_BUFFER support to the Wayland backend.

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -2213,6 +2213,7 @@ extern "C" {
  * Since it's driver-specific, it's only supported where possible and
  * implemented. Currently supported the following drivers:
  *
+ * - Wayland (wayland)
  * - KMSDRM (kmsdrm)
  * - Raspberry Pi (raspberrypi)
  */

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -1963,6 +1963,11 @@ int Wayland_CreateWindow(_THIS, SDL_Window *window)
         }
     }
 
+    data->double_buffer = SDL_FALSE;
+    if (SDL_GetHintBoolean(SDL_HINT_VIDEO_DOUBLE_BUFFER, SDL_FALSE)) {
+        data->double_buffer = SDL_TRUE;
+    }
+
     data->outputs = NULL;
     data->num_outputs = 0;
 

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -116,6 +116,7 @@ typedef struct
     SDL_bool is_fullscreen;
     SDL_bool in_fullscreen_transition;
     Uint32 fullscreen_flags;
+    SDL_bool double_buffer; 
 } SDL_WindowData;
 
 extern void Wayland_ShowWindow(_THIS, SDL_Window *window);


### PR DESCRIPTION
## Description
This makes the Wayland backend honor the **SDL_VIDEO_DOUBLE_BUFFER** environment variable.

This does the same as in the KMS/DRM backend: if we want low latency, we must wait immediately after issuing a pageflip.

Since waiting wastes CPU, this is disabled by default (user must export `SDL_VIDEO_DOUBLE_BUFFER = 1`) but it's a very good feature to have for precise gaming, and for emulation of old systems where immediate response is needed for proper gameplay.

To easily notice the difference this provides, enable the system cursor (which is updated on it's own plane with no lag at all) and a software cursor at the same time, and move them both to see how the software cursor lags behind way less with `SDL_VIDEO_DOUBLE_BUFFER = 0`.
I do this on Scummvm, but any program that sets a software cursor will do.

It has been tested with several wlroots-based Wayland compositors (Sway, Labwc, Wayfire) and works perfectly well.

