### PR TITLE
Fix warning for Android NDK compiler: "function declaration without a…

### DIFF
--- a/src/audio/SDL_audioresample.c
+++ b/src/audio/SDL_audioresample.c
@@ -453,7 +453,7 @@ static float Sinc(float *table, int x, int y)
 
 static Cubic ResamplerFilter[RESAMPLER_SAMPLES_PER_ZERO_CROSSING][RESAMPLER_SAMPLES_PER_FRAME];
 
-static void GenerateResamplerFilter()
+static void GenerateResamplerFilter(void)
 {
     enum
     {

--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -179,7 +179,7 @@ static int load_pipewire_syms(void)
     return 0;
 }
 
-static int init_pipewire_library()
+static int init_pipewire_library(void)
 {
     if (!load_pipewire_library()) {
         if (!load_pipewire_syms()) {

--- a/src/core/SDL_core_unsupported.c
+++ b/src/core/SDL_core_unsupported.c
@@ -97,7 +97,7 @@ void SDL_UnregisterApp(void)
 
 /* Returns SDL_WinRT_DeviceFamily enum */
 SDL_DECLSPEC int SDLCALL SDL_GetWinRTDeviceFamily(void);
-int SDL_GetWinRTDeviceFamily()
+int SDL_GetWinRTDeviceFamily(void)
 {
     SDL_Unsupported();
     return 0; /* SDL_WINRT_DEVICEFAMILY_UNKNOWN */
@@ -115,20 +115,20 @@ const char *SDL_GetWinRTFSPath(int pathType)
 #ifndef SDL_PLATFORM_ANDROID
 
 SDL_DECLSPEC void SDLCALL SDL_SendAndroidBackButton(void);
-void SDL_SendAndroidBackButton()
+void SDL_SendAndroidBackButton(void)
 {
     SDL_Unsupported();
 }
 
 SDL_DECLSPEC void *SDLCALL SDL_GetAndroidActivity(void);
-void *SDL_GetAndroidActivity()
+void *SDL_GetAndroidActivity(void)
 {
     SDL_Unsupported();
     return NULL;
 }
 
 SDL_DECLSPEC const char *SDLCALL SDL_GetAndroidCachePath(void);
-const char* SDL_GetAndroidCachePath()
+const char* SDL_GetAndroidCachePath(void)
 {
     SDL_Unsupported();
     return NULL;
@@ -136,7 +136,7 @@ const char* SDL_GetAndroidCachePath()
 
 
 SDL_DECLSPEC const char *SDLCALL SDL_GetAndroidExternalStoragePath(void);
-const char* SDL_GetAndroidExternalStoragePath()
+const char* SDL_GetAndroidExternalStoragePath(void)
 {
     SDL_Unsupported();
     return NULL;
@@ -156,7 +156,7 @@ const char *SDL_GetAndroidInternalStoragePath(void)
 }
 
 SDL_DECLSPEC void *SDLCALL SDL_GetAndroidJNIEnv(void);
-void *SDL_GetAndroidJNIEnv()
+void *SDL_GetAndroidJNIEnv(void)
 {
     SDL_Unsupported();
     return NULL;
@@ -192,20 +192,20 @@ int SDL_ShowAndroidToast(const char* message, int duration, int gravity, int xof
 }
 
 SDL_DECLSPEC int SDLCALL SDL_GetAndroidSDKVersion(void);
-int SDL_GetAndroidSDKVersion()
+int SDL_GetAndroidSDKVersion(void)
 {
     return SDL_Unsupported();
 }
 
 SDL_DECLSPEC SDL_bool SDLCALL SDL_IsAndroidTV(void);
-SDL_bool SDL_IsAndroidTV()
+SDL_bool SDL_IsAndroidTV(void)
 {
     SDL_Unsupported();
     return SDL_FALSE;
 }
 
 SDL_DECLSPEC SDL_bool SDLCALL SDL_IsChromebook(void);
-SDL_bool SDL_IsChromebook()
+SDL_bool SDL_IsChromebook(void)
 {
     SDL_Unsupported();
     return SDL_FALSE;

--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -898,18 +898,18 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeDropFile)(
 }
 
 /* Lock / Unlock Mutex */
-void Android_ActivityMutex_Lock()
+void Android_ActivityMutex_Lock(void)
 {
     SDL_LockMutex(Android_ActivityMutex);
 }
 
-void Android_ActivityMutex_Unlock()
+void Android_ActivityMutex_Unlock(void)
 {
     SDL_UnlockMutex(Android_ActivityMutex);
 }
 
 /* Lock the Mutex when the Activity is in its 'Running' state */
-void Android_ActivityMutex_Lock_Running()
+void Android_ActivityMutex_Lock_Running(void)
 {
     int pauseSignaled = 0;
     int resumeSignaled = 0;
@@ -1561,13 +1561,13 @@ void Android_JNI_SetOrientation(int w, int h, int resizable, const char *hint)
     (*env)->DeleteLocalRef(env, jhint);
 }
 
-void Android_JNI_MinizeWindow()
+void Android_JNI_MinizeWindow(void)
 {
     JNIEnv *env = Android_JNI_GetEnv();
     (*env)->CallStaticVoidMethod(env, mActivityClass, midMinimizeWindow);
 }
 
-SDL_bool Android_JNI_ShouldMinimizeOnFocusLoss()
+SDL_bool Android_JNI_ShouldMinimizeOnFocusLoss(void)
 {
     JNIEnv *env = Android_JNI_GetEnv();
     return (*env)->CallStaticBooleanMethod(env, mActivityClass, midShouldMinimizeOnFocusLoss);
@@ -1947,7 +1947,7 @@ static SDL_bool Android_JNI_ExceptionOccurred(SDL_bool silent)
     return SDL_FALSE;
 }
 
-static void Internal_Android_Create_AssetManager()
+static void Internal_Android_Create_AssetManager(void)
 {
 
     struct LocalReferenceHolder refs = LocalReferenceHolder_Setup(__FUNCTION__);
@@ -1986,7 +1986,7 @@ static void Internal_Android_Create_AssetManager()
     LocalReferenceHolder_Cleanup(&refs);
 }
 
-static void Internal_Android_Destroy_AssetManager()
+static void Internal_Android_Destroy_AssetManager(void)
 {
     JNIEnv *env = Android_JNI_GetEnv();
 
@@ -2206,7 +2206,7 @@ int Android_JNI_GetPowerInfo(int *plugged, int *charged, int *battery, int *seco
 }
 
 /* Add all touch devices */
-void Android_JNI_InitTouch()
+void Android_JNI_InitTouch(void)
 {
     JNIEnv *env = Android_JNI_GetEnv();
     (*env)->CallStaticVoidMethod(env, mActivityClass, midInitTouch);

--- a/src/core/freebsd/SDL_evdev_kbd_freebsd.c
+++ b/src/core/freebsd/SDL_evdev_kbd_freebsd.c
@@ -133,7 +133,7 @@ static void kbd_cleanup_signal_action(int signum, siginfo_t *info, void *ucontex
     SDL_EVDEV_kbd_reraise_signal(signum);
 }
 
-static void kbd_unregister_emerg_cleanup()
+static void kbd_unregister_emerg_cleanup(void)
 {
     int tabidx;
 

--- a/src/core/openbsd/SDL_wscons_kbd.c
+++ b/src/core/openbsd/SDL_wscons_kbd.c
@@ -452,7 +452,7 @@ static SDL_WSCONS_input_data *SDL_WSCONS_Init_Keyboard(const char *dev)
     return input;
 }
 
-void SDL_WSCONS_Init()
+void SDL_WSCONS_Init(void)
 {
     inputs[0] = SDL_WSCONS_Init_Keyboard("/dev/wskbd0");
     inputs[1] = SDL_WSCONS_Init_Keyboard("/dev/wskbd1");
@@ -463,7 +463,7 @@ void SDL_WSCONS_Init()
     return;
 }
 
-void SDL_WSCONS_Quit()
+void SDL_WSCONS_Quit(void)
 {
     int i = 0;
     SDL_WSCONS_input_data *input = NULL;
@@ -924,7 +924,7 @@ static void updateKeyboard(SDL_WSCONS_input_data *input)
     }
 }
 
-void SDL_WSCONS_PumpEvents()
+void SDL_WSCONS_PumpEvents(void)
 {
     int i = 0;
     for (i = 0; i < 4; i++) {

--- a/src/core/openbsd/SDL_wscons_mouse.c
+++ b/src/core/openbsd/SDL_wscons_mouse.c
@@ -35,7 +35,7 @@ typedef struct SDL_WSCONS_mouse_input_data
     SDL_MouseID mouseID;
 } SDL_WSCONS_mouse_input_data;
 
-SDL_WSCONS_mouse_input_data *SDL_WSCONS_Init_Mouse()
+SDL_WSCONS_mouse_input_data *SDL_WSCONS_Init_Mouse(void)
 {
 #ifdef WSMOUSEIO_SETVERSION
     int version = WSMOUSE_EVENT_VERSION;

--- a/src/core/unix/SDL_appid.c
+++ b/src/core/unix/SDL_appid.c
@@ -24,7 +24,7 @@
 #include "SDL_appid.h"
 #include <unistd.h>
 
-const char *SDL_GetExeName()
+const char *SDL_GetExeName(void)
 {
     static const char *proc_name = NULL;
 
@@ -57,7 +57,7 @@ const char *SDL_GetExeName()
     return proc_name;
 }
 
-const char *SDL_GetAppID()
+const char *SDL_GetAppID(void)
 {
     /* Always check the hint, as it may have changed */
     const char *id_str = SDL_GetHint(SDL_HINT_APP_ID);

--- a/src/hidapi/libusb/hid.c
+++ b/src/hidapi/libusb/hid.c
@@ -454,7 +454,7 @@ static struct usb_string_cache_entry *usb_string_cache = NULL;
 static size_t usb_string_cache_size = 0;
 static size_t usb_string_cache_insert_pos = 0;
 
-static int usb_string_cache_grow()
+static int usb_string_cache_grow(void)
 {
 	struct usb_string_cache_entry *new_cache;
 	size_t allocSize;
@@ -472,7 +472,7 @@ static int usb_string_cache_grow()
 	return 0;
 }
 
-static void usb_string_cache_destroy()
+static void usb_string_cache_destroy(void)
 {
 	size_t i;
 	for (i = 0; i < usb_string_cache_insert_pos; i++) {
@@ -486,7 +486,7 @@ static void usb_string_cache_destroy()
 	usb_string_cache_insert_pos = 0;
 }
 
-static struct usb_string_cache_entry *usb_string_cache_insert()
+static struct usb_string_cache_entry *usb_string_cache_insert(void)
 {
 	struct usb_string_cache_entry *new_entry = NULL;
 	if (usb_string_cache_insert_pos >= usb_string_cache_size) {

--- a/src/hidapi/windows/hid.c
+++ b/src/hidapi/windows/hid.c
@@ -119,7 +119,7 @@ static HMODULE hid_lib_handle = NULL;
 static HMODULE cfgmgr32_lib_handle = NULL;
 static BOOLEAN hidapi_initialized = FALSE;
 
-static void free_library_handles()
+static void free_library_handles(void)
 {
 	if (hid_lib_handle)
 		FreeLibrary(hid_lib_handle);
@@ -134,7 +134,7 @@ static void free_library_handles()
 # pragma GCC diagnostic ignored "-Wcast-function-type"
 #endif
 
-static int lookup_functions()
+static int lookup_functions(void)
 {
 	hid_lib_handle = LoadLibraryW(L"hid.dll");
 	if (hid_lib_handle == NULL) {
@@ -221,7 +221,7 @@ static BOOL IsWindowsVersionOrGreater(WORD wMajorVersion, WORD wMinorVersion, WO
 	return VerifyVersionInfoW(&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR, dwlConditionMask) != FALSE;
 }
 
-static hid_device *new_hid_device()
+static hid_device *new_hid_device(void)
 {
 	hid_device *dev = (hid_device*) calloc(1, sizeof(hid_device));
 

--- a/src/joystick/ps2/SDL_sysjoystick.c
+++ b/src/joystick/ps2/SDL_sysjoystick.c
@@ -131,13 +131,13 @@ static int PS2_JoystickInit(void)
 }
 
 /* Function to return the number of joystick devices plugged in right now */
-static int PS2_JoystickGetCount()
+static int PS2_JoystickGetCount(void)
 {
     return (int)enabled_pads;
 }
 
 /* Function to cause any queued joystick insertions to be processed */
-static void PS2_JoystickDetect()
+static void PS2_JoystickDetect(void)
 {
 }
 

--- a/src/joystick/vita/SDL_sysjoystick.c
+++ b/src/joystick/vita/SDL_sysjoystick.c
@@ -134,12 +134,12 @@ static int VITA_JoystickInit(void)
     return SDL_numjoysticks;
 }
 
-static int VITA_JoystickGetCount()
+static int VITA_JoystickGetCount(void)
 {
     return SDL_numjoysticks;
 }
 
-static void VITA_JoystickDetect()
+static void VITA_JoystickDetect(void)
 {
 }
 

--- a/src/joystick/windows/SDL_rawinputjoystick.c
+++ b/src/joystick/windows/SDL_rawinputjoystick.c
@@ -326,7 +326,7 @@ static struct
 static SDL_bool xinput_device_change = SDL_TRUE;
 static SDL_bool xinput_state_dirty = SDL_TRUE;
 
-static void RAWINPUT_UpdateXInput()
+static void RAWINPUT_UpdateXInput(void)
 {
     DWORD user_index;
     if (xinput_device_change) {
@@ -366,7 +366,7 @@ static void RAWINPUT_MarkXInputSlotFree(Uint8 xinput_slot)
         xinput_state[xinput_slot].used = SDL_FALSE;
     }
 }
-static SDL_bool RAWINPUT_MissingXInputSlot()
+static SDL_bool RAWINPUT_MissingXInputSlot(void)
 {
     int ii;
     for (ii = 0; ii < SDL_arraysize(xinput_state); ii++) {
@@ -561,7 +561,7 @@ static void RAWINPUT_MarkWindowsGamingInputSlotFree(WindowsGamingInputGamepadSta
     wgi_slot->correlated_context = NULL;
 }
 
-static SDL_bool RAWINPUT_MissingWindowsGamingInputSlot()
+static SDL_bool RAWINPUT_MissingWindowsGamingInputSlot(void)
 {
     int ii;
     for (ii = 0; ii < wgi_state.per_gamepad_count; ii++) {
@@ -572,7 +572,7 @@ static SDL_bool RAWINPUT_MissingWindowsGamingInputSlot()
     return SDL_FALSE;
 }
 
-static int RAWINPUT_UpdateWindowsGamingInput()
+static int RAWINPUT_UpdateWindowsGamingInput(void)
 {
     int ii;
     if (!wgi_state.gamepad_statics) {
@@ -1054,7 +1054,7 @@ static int RAWINPUT_JoystickGetCount(void)
     return SDL_RAWINPUT_numjoysticks;
 }
 
-SDL_bool RAWINPUT_IsEnabled()
+SDL_bool RAWINPUT_IsEnabled(void)
 {
     return SDL_RAWINPUT_inited && !SDL_RAWINPUT_remote_desktop;
 }
@@ -2102,7 +2102,7 @@ int RAWINPUT_RegisterNotifications(HWND hWnd)
     return 0;
 }
 
-int RAWINPUT_UnregisterNotifications()
+int RAWINPUT_UnregisterNotifications(void)
 {
     int i;
     RAWINPUTDEVICE rid[SDL_arraysize(subscribed_devices)];

--- a/src/joystick/windows/SDL_windows_gaming_input.c
+++ b/src/joystick/windows/SDL_windows_gaming_input.c
@@ -213,7 +213,7 @@ static SDL_bool SDL_IsXInputDevice(Uint16 vendor, Uint16 product)
     return SDL_FALSE;
 }
 
-static void WGI_LoadRawGameControllerStatics()
+static void WGI_LoadRawGameControllerStatics(void)
 {
     HRESULT hr;
     HSTRING_HEADER class_name_header;
@@ -228,7 +228,7 @@ static void WGI_LoadRawGameControllerStatics()
     }
 }
 
-static void WGI_LoadOtherControllerStatics()
+static void WGI_LoadOtherControllerStatics(void)
 {
     HRESULT hr;
     HSTRING_HEADER class_name_header;

--- a/src/main/SDL_main_callbacks.c
+++ b/src/main/SDL_main_callbacks.c
@@ -51,7 +51,7 @@ static void SDL_DispatchMainCallbackEvent(SDL_Event *event)
     }
 }
 
-static void SDL_DispatchMainCallbackEvents()
+static void SDL_DispatchMainCallbackEvents(void)
 {
     SDL_Event events[16];
 
@@ -81,7 +81,7 @@ static int SDLCALL SDL_MainCallbackEventWatcher(void *userdata, SDL_Event *event
     return 0;
 }
 
-SDL_bool SDL_HasMainCallbacks()
+SDL_bool SDL_HasMainCallbacks(void)
 {
     if (SDL_main_iteration_callback) {
         return SDL_TRUE;

--- a/src/main/ps2/SDL_sysmain_runapp.c
+++ b/src/main/ps2/SDL_sysmain_runapp.c
@@ -36,7 +36,7 @@
 #include <sbv_patches.h>
 #include <ps2_filesystem_driver.h>
 
-__attribute__((weak)) void reset_IOP()
+__attribute__((weak)) void reset_IOP(void)
 {
     SifInitRpc(0);
     while (!SifIopReset(NULL, 0)) {
@@ -45,7 +45,7 @@ __attribute__((weak)) void reset_IOP()
     }
 }
 
-static void prepare_IOP()
+static void prepare_IOP(void)
 {
     reset_IOP();
     SifInitRpc(0);
@@ -54,12 +54,12 @@ static void prepare_IOP()
     sbv_patch_fileio();
 }
 
-static void init_drivers()
+static void init_drivers(void)
 {
 	init_ps2_filesystem_driver();
 }
 
-static void deinit_drivers()
+static void deinit_drivers(void)
 {
 	deinit_ps2_filesystem_driver();
 }

--- a/src/render/SDL_d3dmath.c
+++ b/src/render/SDL_d3dmath.c
@@ -26,7 +26,7 @@
 
 /* Direct3D matrix math functions */
 
-Float4X4 MatrixIdentity()
+Float4X4 MatrixIdentity(void)
 {
     Float4X4 m;
     SDL_zero(m);

--- a/src/render/direct3d11/SDL_render_d3d11.c
+++ b/src/render/direct3d11/SDL_render_d3d11.c
@@ -808,7 +808,7 @@ done:
 
 #if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
 
-static DXGI_MODE_ROTATION D3D11_GetCurrentRotation()
+static DXGI_MODE_ROTATION D3D11_GetCurrentRotation(void)
 {
     /* FIXME */
     return DXGI_MODE_ROTATION_IDENTITY;

--- a/src/render/direct3d12/SDL_render_d3d12.c
+++ b/src/render/direct3d12/SDL_render_d3d12.c
@@ -1200,7 +1200,7 @@ done:
     return result;
 }
 
-static DXGI_MODE_ROTATION D3D12_GetCurrentRotation()
+static DXGI_MODE_ROTATION D3D12_GetCurrentRotation(void)
 {
     /* FIXME */
     return DXGI_MODE_ROTATION_IDENTITY;

--- a/src/render/ps2/SDL_render_ps2.c
+++ b/src/render/ps2/SDL_render_ps2.c
@@ -60,7 +60,7 @@ typedef struct
 static int vsync_sema_id = 0;
 
 /* PRIVATE METHODS */
-static int vsync_handler()
+static int vsync_handler(void)
 {
     iSignalSema(vsync_sema_id);
 

--- a/src/render/vulkan/SDL_render_vulkan.c
+++ b/src/render/vulkan/SDL_render_vulkan.c
@@ -1639,7 +1639,7 @@ static SDL_bool VULKAN_InstanceExtensionFound(VULKAN_RenderData *rendererData, c
     return SDL_FALSE;
 }
 
-static SDL_bool VULKAN_ValidationLayersFound()
+static SDL_bool VULKAN_ValidationLayersFound(void)
 {
     uint32_t instanceLayerCount = 0;
     uint32_t i;

--- a/src/stdlib/SDL_mslibc.c
+++ b/src/stdlib/SDL_mslibc.c
@@ -36,7 +36,7 @@ __declspec(selectany) int _fltused = 1;
 #ifdef _M_IX86
 
 /* Float to long */
-void __declspec(naked) _ftol()
+void __declspec(naked) _ftol(void)
 {
     /* *INDENT-OFF* */
     __asm {
@@ -85,18 +85,18 @@ localexit:
     /* *INDENT-ON* */
 }
 
-void _ftol2_sse()
+void _ftol2_sse(void)
 {
     _ftol();
 }
 
-void _ftol2()
+void _ftol2(void)
 {
     _ftol();
 }
 
 /* 64-bit math operators for 32-bit systems */
-void __declspec(naked) _allmul()
+void __declspec(naked) _allmul(void)
 {
     /* *INDENT-OFF* */
     __asm {
@@ -124,7 +124,7 @@ hard:
     /* *INDENT-ON* */
 }
 
-void __declspec(naked) _alldiv()
+void __declspec(naked) _alldiv(void)
 {
     /* *INDENT-OFF* */
     __asm {
@@ -210,7 +210,7 @@ L8:
     /* *INDENT-ON* */
 }
 
-void __declspec(naked) _aulldiv()
+void __declspec(naked) _aulldiv(void)
 {
     /* *INDENT-OFF* */
     __asm {
@@ -266,7 +266,7 @@ L2:
     /* *INDENT-ON* */
 }
 
-void __declspec(naked) _allrem()
+void __declspec(naked) _allrem(void)
 {
     /* *INDENT-OFF* */
     __asm {
@@ -351,7 +351,7 @@ L8:
     /* *INDENT-ON* */
 }
 
-void __declspec(naked) _aullrem()
+void __declspec(naked) _aullrem(void)
 {
     /* *INDENT-OFF* */
     __asm {
@@ -408,7 +408,7 @@ L2:
     /* *INDENT-ON* */
 }
 
-void __declspec(naked) _alldvrm()
+void __declspec(naked) _alldvrm(void)
 {
     /* *INDENT-OFF* */
     __asm {
@@ -516,7 +516,7 @@ L8:
     /* *INDENT-ON* */
 }
 
-void __declspec(naked) _aulldvrm()
+void __declspec(naked) _aulldvrm(void)
 {
     /* *INDENT-OFF* */
     __asm {
@@ -587,7 +587,7 @@ L2:
     /* *INDENT-ON* */
 }
 
-void __declspec(naked) _allshl()
+void __declspec(naked) _allshl(void)
 {
     /* *INDENT-OFF* */
     __asm {
@@ -612,7 +612,7 @@ RETZERO:
     /* *INDENT-ON* */
 }
 
-void __declspec(naked) _allshr()
+void __declspec(naked) _allshr(void)
 {
     /* *INDENT-OFF* */
     __asm {
@@ -637,7 +637,7 @@ RETSIGN:
     /* *INDENT-ON* */
 }
 
-void __declspec(naked) _aullshr()
+void __declspec(naked) _aullshr(void)
 {
     /* *INDENT-OFF* */
     __asm {

--- a/src/test/SDL_test_memory.c
+++ b/src/test/SDL_test_memory.c
@@ -323,7 +323,7 @@ dbghelp_failed:
                            SDLTest_TrackedFree);
 }
 
-void SDLTest_RandFillAllocations()
+void SDLTest_RandFillAllocations(void)
 {
     SDLTest_TrackAllocations();
 

--- a/src/timer/windows/SDL_systimer.c
+++ b/src/timer/windows/SDL_systimer.c
@@ -31,7 +31,7 @@ static void SDL_CleanupWaitableTimer(void *timer)
     CloseHandle(timer);
 }
 
-HANDLE SDL_GetWaitableTimer()
+HANDLE SDL_GetWaitableTimer(void)
 {
     static SDL_TLSID TLS_timer_handle;
     HANDLE timer;

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -694,7 +694,7 @@ SDL_SystemTheme SDL_GetSystemTheme(void)
     }
 }
 
-static void SDL_UpdateDesktopBounds()
+static void SDL_UpdateDesktopBounds(void)
 {
     SDL_Rect rect;
     SDL_zero(rect);

--- a/src/video/android/SDL_androidmouse.c
+++ b/src/video/android/SDL_androidmouse.c
@@ -74,7 +74,7 @@ static SDL_Cursor *Android_WrapCursor(int custom_cursor, int system_cursor)
     return cursor;
 }
 
-static SDL_Cursor *Android_CreateDefaultCursor()
+static SDL_Cursor *Android_CreateDefaultCursor(void)
 {
     return Android_WrapCursor(0, SDL_SYSTEM_CURSOR_DEFAULT);
 }
@@ -112,7 +112,7 @@ static void Android_FreeCursor(SDL_Cursor *cursor)
     SDL_free(cursor);
 }
 
-static SDL_Cursor *Android_CreateEmptyCursor()
+static SDL_Cursor *Android_CreateEmptyCursor(void)
 {
     if (!empty_cursor) {
         SDL_Surface *empty_surface = SDL_CreateSurface(1, 1, SDL_PIXELFORMAT_ARGB8888);
@@ -125,7 +125,7 @@ static SDL_Cursor *Android_CreateEmptyCursor()
     return empty_cursor;
 }
 
-static void Android_DestroyEmptyCursor()
+static void Android_DestroyEmptyCursor(void)
 {
     if (empty_cursor) {
         Android_FreeCursor(empty_cursor);

--- a/src/video/emscripten/SDL_emscriptenmouse.c
+++ b/src/video/emscripten/SDL_emscriptenmouse.c
@@ -60,7 +60,7 @@ static SDL_Cursor *Emscripten_CreateCursorFromString(const char *cursor_str, SDL
     return cursor;
 }
 
-static SDL_Cursor *Emscripten_CreateDefaultCursor()
+static SDL_Cursor *Emscripten_CreateDefaultCursor(void)
 {
     return Emscripten_CreateCursorFromString("default", SDL_FALSE);
 }
@@ -194,7 +194,7 @@ static int Emscripten_SetRelativeMouseMode(SDL_bool enabled)
     return -1;
 }
 
-void Emscripten_InitMouse()
+void Emscripten_InitMouse(void)
 {
     SDL_Mouse *mouse = SDL_GetMouse();
 
@@ -207,7 +207,7 @@ void Emscripten_InitMouse()
     SDL_SetDefaultCursor(Emscripten_CreateDefaultCursor());
 }
 
-void Emscripten_FiniMouse()
+void Emscripten_FiniMouse(void)
 {
 }
 

--- a/src/video/n3ds/SDL_n3dsswkb.c
+++ b/src/video/n3ds/SDL_n3dsswkb.c
@@ -30,17 +30,17 @@
 static SwkbdState sw_keyboard;
 const static size_t BUFFER_SIZE = 256;
 
-void N3DS_SwkbInit()
+void N3DS_SwkbInit(void)
 {
     swkbdInit(&sw_keyboard, SWKBD_TYPE_NORMAL, 2, -1);
 }
 
-void N3DS_SwkbPoll()
+void N3DS_SwkbPoll(void)
 {
     return;
 }
 
-void N3DS_SwkbQuit()
+void N3DS_SwkbQuit(void)
 {
     return;
 }

--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -48,7 +48,7 @@ static void PSP_Destroy(SDL_VideoDevice *device)
     SDL_free(device);
 }
 
-static SDL_VideoDevice *PSP_Create()
+static SDL_VideoDevice *PSP_Create(void)
 {
     SDL_VideoDevice *device;
     SDL_VideoData *phdata;

--- a/src/video/qnx/SDL_qnxvideo.c
+++ b/src/video/qnx/SDL_qnxvideo.c
@@ -309,7 +309,7 @@ static void deleteDevice(SDL_VideoDevice *device)
  * Creates the QNX video plugin used by SDL.
  * @return  Initialized device if successful, NULL otherwise
  */
-static SDL_VideoDevice *createDevice()
+static SDL_VideoDevice *createDevice(void)
 {
     SDL_VideoDevice *device;
 

--- a/src/video/raspberry/SDL_rpivideo.c
+++ b/src/video/raspberry/SDL_rpivideo.c
@@ -75,7 +75,7 @@ static void RPI_GetRefreshRate(int *numerator, int *denominator)
     *denominator = 1;
 }
 
-static SDL_VideoDevice *RPI_Create()
+static SDL_VideoDevice *RPI_Create(void)
 {
     SDL_VideoDevice *device;
     SDL_VideoData *phdata;

--- a/src/video/riscos/SDL_riscosmouse.c
+++ b/src/video/riscos/SDL_riscosmouse.c
@@ -28,7 +28,7 @@
 
 #include <kernel.h>
 
-static SDL_Cursor *RISCOS_CreateDefaultCursor()
+static SDL_Cursor *RISCOS_CreateDefaultCursor(void)
 {
     SDL_Cursor *cursor = SDL_calloc(1, sizeof(*cursor));
     if (cursor) {

--- a/src/video/vita/SDL_vitavideo.c
+++ b/src/video/vita/SDL_vitavideo.c
@@ -59,7 +59,7 @@ static void VITA_Destroy(SDL_VideoDevice *device)
     SDL_free(device);
 }
 
-static SDL_VideoDevice *VITA_Create()
+static SDL_VideoDevice *VITA_Create(void)
 {
     SDL_VideoDevice *device;
     SDL_VideoData *phdata;

--- a/src/video/vivante/SDL_vivantevideo.c
+++ b/src/video/vivante/SDL_vivantevideo.c
@@ -41,7 +41,7 @@ static void VIVANTE_Destroy(SDL_VideoDevice *device)
     SDL_free(device);
 }
 
-static SDL_VideoDevice *VIVANTE_Create()
+static SDL_VideoDevice *VIVANTE_Create(void)
 {
     SDL_VideoDevice *device;
     SDL_VideoData *data;

--- a/src/video/wayland/SDL_waylandmouse.c
+++ b/src/video/wayland/SDL_waylandmouse.c
@@ -272,7 +272,7 @@ static void Wayland_DBusInitCursorProperties(SDL_VideoData *vdata)
     }
 }
 
-static void Wayland_DBusFinishCursorProperties()
+static void Wayland_DBusFinishCursorProperties(void)
 {
     SDL_free(dbus_cursor_theme);
     dbus_cursor_theme = NULL;

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -89,7 +89,7 @@ enum WaylandModeScale
     WAYLAND_MODE_SCALE_NONE
 };
 
-static enum WaylandModeScale GetModeScaleMethod()
+static enum WaylandModeScale GetModeScaleMethod(void)
 {
     static enum WaylandModeScale scale_mode = WAYLAND_MODE_SCALE_UNDEFINED;
 

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -133,7 +133,7 @@ static void WIN_SetMessageTick(DWORD tick)
     message_tick = tick;
 }
 
-static Uint64 WIN_GetEventTimestamp()
+static Uint64 WIN_GetEventTimestamp(void)
 {
     Uint64 timestamp, now;
 
@@ -2090,7 +2090,7 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
 }
 
 #if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
-static void WIN_UpdateClipCursorForWindows()
+static void WIN_UpdateClipCursorForWindows(void)
 {
     SDL_VideoDevice *_this = SDL_GetVideoDevice();
     SDL_Window *window;
@@ -2112,7 +2112,7 @@ static void WIN_UpdateClipCursorForWindows()
     }
 }
 
-static void WIN_UpdateMouseCapture()
+static void WIN_UpdateMouseCapture(void)
 {
     SDL_Window *focusWindow = SDL_GetKeyboardFocus();
 
@@ -2408,7 +2408,7 @@ int SDL_RegisterApp(const char *name, Uint32 style, void *hInst)
 }
 
 /* Unregisters the windowclass registered in SDL_RegisterApp above. */
-void SDL_UnregisterApp()
+void SDL_UnregisterApp(void)
 {
     WNDCLASSEX wcex;
 

--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -165,7 +165,7 @@ void WIN_QuitKeyboard(SDL_VideoDevice *_this)
 #endif /* !SDL_DISABLE_WINDOWS_IME */
 }
 
-void WIN_ResetDeadKeys()
+void WIN_ResetDeadKeys(void)
 {
     /*
     if a deadkey has been typed, but not the next character (which the deadkey might modify),

--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -34,7 +34,7 @@ DWORD SDL_last_warp_time = 0;
 HCURSOR SDL_cursor = NULL;
 static SDL_Cursor *SDL_blank_cursor = NULL;
 
-static SDL_Cursor *WIN_CreateDefaultCursor()
+static SDL_Cursor *WIN_CreateDefaultCursor(void)
 {
     SDL_Cursor *cursor = (SDL_Cursor *)SDL_calloc(1, sizeof(*cursor));
     if (cursor) {
@@ -195,7 +195,7 @@ static SDL_Cursor *WIN_CreateCursor(SDL_Surface *surface, int hot_x, int hot_y)
     return cursor;
 }
 
-static SDL_Cursor *WIN_CreateBlankCursor()
+static SDL_Cursor *WIN_CreateBlankCursor(void)
 {
     SDL_Cursor *cursor = NULL;
     SDL_Surface *surface = SDL_CreateSurface(32, 32, SDL_PIXELFORMAT_ARGB8888);
@@ -522,7 +522,7 @@ static void WIN_SetLinearMouseScale(int mouse_speed)
     }
 }
 
-void WIN_UpdateMouseSystemScale()
+void WIN_UpdateMouseSystemScale(void)
 {
     int mouse_speed;
     int params[3] = { 0, 0, 0 };

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -352,7 +352,7 @@ static void SDLCALL WIN_MouseRelativeModeCenterChanged(void *userdata, const cha
     data->mouse_relative_mode_center = SDL_GetStringBoolean(hint, SDL_TRUE);
 }
 
-static SDL_WindowEraseBackgroundMode GetEraseBackgroundModeHint()
+static SDL_WindowEraseBackgroundMode GetEraseBackgroundModeHint(void)
 {
     const char *hint = SDL_GetHint(SDL_HINT_WINDOWS_ERASE_BACKGROUND_MODE);
     if (!hint)

--- a/src/video/x11/SDL_x11xfixes.c
+++ b/src/video/x11/SDL_x11xfixes.c
@@ -79,7 +79,7 @@ int X11_XfixesIsInitialized(void)
     return xfixes_initialized;
 }
 
-int X11_GetXFixesSelectionNotifyEvent()
+int X11_GetXFixesSelectionNotifyEvent(void)
 {
     return xfixes_selection_notify_event;
 }

--- a/test/testaudiostreamdynamicresample.c
+++ b/test/testaudiostreamdynamicresample.c
@@ -102,7 +102,7 @@ static void draw_textf(SDL_Renderer* renderer, int x, int y, const char* fmt, ..
     draw_text(renderer, x, y, text);
 }
 
-static void queue_audio()
+static void queue_audio(void)
 {
     Uint8* new_data = NULL;
     int new_len = 0;

--- a/test/testautomation_log.c
+++ b/test/testautomation_log.c
@@ -21,7 +21,7 @@ static void EnableTestLog(int *message_count)
     SDL_SetLogOutputFunction(TestLogOutput, message_count);
 }
 
-static void DisableTestLog()
+static void DisableTestLog(void)
 {
     SDL_SetLogOutputFunction(original_function, original_userdata);
 }

--- a/test/testgles.c
+++ b/test/testgles.c
@@ -50,7 +50,7 @@ quit(int rc)
 }
 
 static void
-Render()
+Render(void)
 {
     static GLubyte color[8][4] = { { 255, 0, 0, 0 },
                                    { 255, 0, 0, 255 },


### PR DESCRIPTION
Fix warning for Android NDK compiler: "function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]"

## Description
<!--- Describe your changes in detail -->
https://stackoverflow.com/questions/42125/warning-error-function-declaration-isnt-a-prototype

In C int foo() and int foo(void) are different functions. int foo() accepts an arbitrary number of arguments, while int foo(void) accepts 0 arguments. In C++ they mean the same thing.