### PR TITLE
Fix KMSDRM double buffering.

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmopengles.c
+++ b/src/video/kmsdrm/SDL_kmsdrmopengles.c
@@ -194,7 +194,7 @@ int KMSDRM_GLES_SwapWindow(_THIS, SDL_Window *window)
            we have waited here, there won't be a pending pageflip so the
            WaitPageflip at the beginning of this function will be a no-op.
            Just leave it here and don't worry.
-           Run your SDL2 program with "SDL_KMSDRM_DOUBLE_BUFFER=1 <program_name>"
+           Run your SDL2 program with "SDL_VIDEO_DOUBLE_BUFFER=1 <program_name>"
            to enable this. */
         if (windata->double_buffer) {
             if (!KMSDRM_WaitPageflip(_this, windata)) {

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -1478,6 +1478,12 @@ int KMSDRM_CreateWindow(_THIS, SDL_Window *window)
     windata->viddata = viddata;
     window->driverdata = windata;
 
+    /* Do we want a double buffering scheme to get low video lag? */
+    windata->double_buffer = SDL_FALSE;
+    if (SDL_GetHintBoolean(SDL_HINT_VIDEO_DOUBLE_BUFFER, SDL_FALSE)) {
+        windata->double_buffer = SDL_TRUE;
+    }
+
     if (!is_vulkan && !vulkan_mode) { /* NON-Vulkan block. */
 
         /* Maybe you didn't ask for an OPENGL window, but that's what you will get.


### PR DESCRIPTION
## Description
At some point, the KMS/DRM backend double buffering feature stopped working in SDL2 because someone removed **SDL_KMSDRM_DOUBLE_BUFFER** environment variable (in favor of  **SDL_VIDEO_DOUBLE_BUFFER** I guess?) but didn't wire up the environment variable evaluation code in the KMS/DRM backend code.

This core simply fixes that so double buffering works again on the KMS/DRM backend.