### PR TITLE
wayland: Use the compositor provided size during state transitions

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -157,6 +157,7 @@ struct SDL_WindowData
 
     SDL_DisplayID last_displayID;
     int fullscreen_deadline_count;
+    int maximized_deadline_count;
     Uint64 last_focus_event_time_ns;
     SDL_bool floating;
     SDL_bool suspended;
@@ -168,6 +169,7 @@ struct SDL_WindowData
     SDL_bool show_hide_sync_required;
     SDL_bool scale_to_display;
     SDL_bool modal_reparenting_required;
+    SDL_bool pending_restored_size;
     SDL_bool double_buffer;
 
     SDL_HitTestResult hit_test_result;


### PR DESCRIPTION
Always use the size sent by the compositor when transitioning back to the floating state on the xdg-toplevel path, unless the client explicitly requested a new floating size while the window was in a fixed-size state.

If a window is requested to be maximized or made fullscreen while an uncommitted size request is pending, the surface will first be committed so that the compositor will set the new size when the window is restored.

Fixes the window being wrongly resized when leaving the maximized state in KDE.

Fixes #10203 