### PR TITLE
Remove a duplicate definition in SDL_joystick.h

### DIFF
--- a/include/SDL3/SDL_joystick.h
+++ b/include/SDL3/SDL_joystick.h
@@ -821,8 +821,6 @@ extern SDL_DECLSPEC const char * SDLCALL SDL_GetJoystickSerial(SDL_Joystick *joy
  */
 extern SDL_DECLSPEC SDL_JoystickType SDLCALL SDL_GetJoystickType(SDL_Joystick *joystick);
 
-extern SDL_DECLSPEC SDL_GUID SDLCALL SDL_GUIDFromString(const char *pchGUID);
-
 /**
  * Get the device information encoded in a SDL_GUID structure.
  *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR removes a duplicate definition in `SDL_joystick.h` which already exists in `SDL_guid.h`.
