### PR TITLE
Fixed floating point rectangles to be mathematically correct.

### DIFF
--- a/include/SDL3/SDL_rect.h
+++ b/include/SDL3/SDL_rect.h
@@ -293,8 +293,8 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GetRectAndLineIntersection(const SDL_Re
  *
  * A point is considered part of a rectangle if both `p` and `r` are not NULL,
  * and `p`'s x and y coordinates are >= to the rectangle's top left corner,
- * and < the rectangle's x+w and y+h. So a 1x1 rectangle considers point (0,0)
- * as "inside" and (0,1) as not.
+ * and <= the rectangle's x+w and y+h. So a 1x1 rectangle considers point (0,0)
+ * and (0,1) as "inside" and (0,2) as not.
  *
  * Note that this is a forced-inline function in a header, and not a public
  * API function available in the SDL library (which is to say, the code is
@@ -311,15 +311,15 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GetRectAndLineIntersection(const SDL_Re
  */
 SDL_FORCE_INLINE SDL_bool SDL_PointInRectFloat(const SDL_FPoint *p, const SDL_FRect *r)
 {
-    return ( p && r && (p->x >= r->x) && (p->x < (r->x + r->w)) &&
-             (p->y >= r->y) && (p->y < (r->y + r->h)) ) ? SDL_TRUE : SDL_FALSE;
+    return ( p && r && (p->x >= r->x) && (p->x <= (r->x + r->w)) &&
+             (p->y >= r->y) && (p->y <= (r->y + r->h)) ) ? SDL_TRUE : SDL_FALSE;
 }
 
 /**
- * Determine whether a floating point rectangle has no area.
+ * Determine whether a floating point rectangle can contain any point.
  *
  * A rectangle is considered "empty" for this function if `r` is NULL, or if
- * `r`'s width and/or height are <= 0.0f.
+ * `r`'s width and/or height are < 0.0f.
  *
  * Note that this is a forced-inline function in a header, and not a public
  * API function available in the SDL library (which is to say, the code is
@@ -335,7 +335,7 @@ SDL_FORCE_INLINE SDL_bool SDL_PointInRectFloat(const SDL_FPoint *p, const SDL_FR
  */
 SDL_FORCE_INLINE SDL_bool SDL_RectEmptyFloat(const SDL_FRect *r)
 {
-    return ((!r) || (r->w <= 0.0f) || (r->h <= 0.0f)) ? SDL_TRUE : SDL_FALSE;
+    return ((!r) || (r->w < 0.0f) || (r->h < 0.0f)) ? SDL_TRUE : SDL_FALSE;
 }
 
 /**

--- a/src/video/SDL_rect.c
+++ b/src/video/SDL_rect.c
@@ -90,6 +90,7 @@ SDL_bool SDL_GetSpanEnclosingRect(int width, int height,
 #define SCALARTYPE               int
 #define BIGSCALARTYPE            Sint64
 #define COMPUTEOUTCODE           ComputeOutCode
+#define ENCLOSEPOINTS_EPSILON    1
 #define SDL_HASINTERSECTION      SDL_HasRectIntersection
 #define SDL_INTERSECTRECT        SDL_GetRectIntersection
 #define SDL_RECTEMPTY            SDL_RectEmpty
@@ -103,6 +104,7 @@ SDL_bool SDL_GetSpanEnclosingRect(int width, int height,
 #define SCALARTYPE               float
 #define BIGSCALARTYPE            double
 #define COMPUTEOUTCODE           ComputeOutCodeFloat
+#define ENCLOSEPOINTS_EPSILON    0.0f
 #define SDL_HASINTERSECTION      SDL_HasRectIntersectionFloat
 #define SDL_INTERSECTRECT        SDL_GetRectIntersectionFloat
 #define SDL_RECTEMPTY            SDL_RectEmptyFloat

--- a/src/video/SDL_rect_impl.h
+++ b/src/video/SDL_rect_impl.h
@@ -46,7 +46,7 @@ SDL_bool SDL_HASINTERSECTION(const RECTTYPE *A, const RECTTYPE *B)
     if (Bmax < Amax) {
         Amax = Bmax;
     }
-    if (Amax <= Amin) {
+    if ((Amax - ENCLOSEPOINTS_EPSILON) < Amin) {
         return SDL_FALSE;
     }
     /* Vertical intersection */
@@ -60,7 +60,7 @@ SDL_bool SDL_HASINTERSECTION(const RECTTYPE *A, const RECTTYPE *B)
     if (Bmax < Amax) {
         Amax = Bmax;
     }
-    if (Amax <= Amin) {
+    if ((Amax - ENCLOSEPOINTS_EPSILON) < Amin) {
         return SDL_FALSE;
     }
     return SDL_TRUE;
@@ -190,8 +190,8 @@ SDL_bool SDL_ENCLOSEPOINTS(const POINTTYPE *points, int count, const RECTTYPE *c
         SDL_bool added = SDL_FALSE;
         const SCALARTYPE clip_minx = clip->x;
         const SCALARTYPE clip_miny = clip->y;
-        const SCALARTYPE clip_maxx = clip->x + clip->w - 1;
-        const SCALARTYPE clip_maxy = clip->y + clip->h - 1;
+        const SCALARTYPE clip_maxx = clip->x + clip->w - ENCLOSEPOINTS_EPSILON;
+        const SCALARTYPE clip_maxy = clip->y + clip->h - ENCLOSEPOINTS_EPSILON;
 
         /* Special case for empty rectangle */
         if (SDL_RECTEMPTY(clip)) {
@@ -262,8 +262,8 @@ SDL_bool SDL_ENCLOSEPOINTS(const POINTTYPE *points, int count, const RECTTYPE *c
     if (result) {
         result->x = minx;
         result->y = miny;
-        result->w = (maxx - minx) + 1;
-        result->h = (maxy - miny) + 1;
+        result->w = (maxx - minx) + ENCLOSEPOINTS_EPSILON;
+        result->h = (maxy - miny) + ENCLOSEPOINTS_EPSILON;
     }
     return SDL_TRUE;
 }
@@ -322,8 +322,8 @@ SDL_bool SDL_INTERSECTRECTANDLINE(const RECTTYPE *rect, SCALARTYPE *X1, SCALARTY
     y2 = *Y2;
     rectx1 = rect->x;
     recty1 = rect->y;
-    rectx2 = rect->x + rect->w - 1;
-    recty2 = rect->y + rect->h - 1;
+    rectx2 = rect->x + rect->w - ENCLOSEPOINTS_EPSILON;
+    recty2 = rect->y + rect->h - ENCLOSEPOINTS_EPSILON;
 
     /* Check to see if entire line is inside rect */
     if (x1 >= rectx1 && x1 <= rectx2 && x2 >= rectx1 && x2 <= rectx2 &&
@@ -429,6 +429,7 @@ SDL_bool SDL_INTERSECTRECTANDLINE(const RECTTYPE *rect, SCALARTYPE *X1, SCALARTY
 #undef SCALARTYPE
 #undef BIGSCALARTYPE
 #undef COMPUTEOUTCODE
+#undef ENCLOSEPOINTS_EPSILON
 #undef SDL_HASINTERSECTION
 #undef SDL_INTERSECTRECT
 #undef SDL_RECTEMPTY

--- a/test/testautomation_rect.c
+++ b/test/testautomation_rect.c
@@ -1000,7 +1000,7 @@ static int rect_testEnclosePoints(void *arg)
     }
 
     /* Call function and validate - special case: no result requested */
-    anyEnclosedNoResult = SDL_GetRectEnclosingPoints((const SDL_Point *)points, numPoints, (const SDL_Rect *)NULL, (SDL_Rect *)NULL);
+    anyEnclosedNoResult = SDL_GetRectEnclosingPoints(points, numPoints, NULL, (SDL_Rect *)NULL);
     SDLTest_AssertCheck(expectedEnclosed == anyEnclosedNoResult,
                         "Check expected return value %s, got %s",
                         (expectedEnclosed == SDL_TRUE) ? "SDL_TRUE" : "SDL_FALSE",
@@ -1012,7 +1012,7 @@ static int rect_testEnclosePoints(void *arg)
     }
 
     /* Call function and validate */
-    anyEnclosed = SDL_GetRectEnclosingPoints((const SDL_Point *)points, numPoints, (const SDL_Rect *)NULL, &result);
+    anyEnclosed = SDL_GetRectEnclosingPoints(points, numPoints, NULL, &result);
     SDLTest_AssertCheck(expectedEnclosed == anyEnclosed,
                         "Check return value %s, got %s",
                         (expectedEnclosed == SDL_TRUE) ? "SDL_TRUE" : "SDL_FALSE",
@@ -1083,7 +1083,7 @@ static int rect_testEnclosePointsRepeatedInput(void *arg)
     }
 
     /* Call function and validate - special case: no result requested */
-    anyEnclosedNoResult = SDL_GetRectEnclosingPoints((const SDL_Point *)points, numPoints, (const SDL_Rect *)NULL, (SDL_Rect *)NULL);
+    anyEnclosedNoResult = SDL_GetRectEnclosingPoints(points, numPoints, NULL, (SDL_Rect *)NULL);
     SDLTest_AssertCheck(expectedEnclosed == anyEnclosedNoResult,
                         "Check return value %s, got %s",
                         (expectedEnclosed == SDL_TRUE) ? "SDL_TRUE" : "SDL_FALSE",
@@ -1095,7 +1095,7 @@ static int rect_testEnclosePointsRepeatedInput(void *arg)
     }
 
     /* Call function and validate */
-    anyEnclosed = SDL_GetRectEnclosingPoints((const SDL_Point *)points, numPoints, (const SDL_Rect *)NULL, &result);
+    anyEnclosed = SDL_GetRectEnclosingPoints(points, numPoints, NULL, &result);
     SDLTest_AssertCheck(expectedEnclosed == anyEnclosed,
                         "Check return value %s, got %s",
                         (expectedEnclosed == SDL_TRUE) ? "SDL_TRUE" : "SDL_FALSE",
@@ -1173,7 +1173,7 @@ static int rect_testEnclosePointsWithClipping(void *arg)
 
     /* Call function and validate - special case: no result requested */
     clip = refClip;
-    anyEnclosedNoResult = SDL_GetRectEnclosingPoints((const SDL_Point *)points, numPoints, (const SDL_Rect *)&clip, (SDL_Rect *)NULL);
+    anyEnclosedNoResult = SDL_GetRectEnclosingPoints(points, numPoints, &clip, NULL);
     SDLTest_AssertCheck(expectedEnclosed == anyEnclosedNoResult,
                         "Expected return value %s, got %s",
                         (expectedEnclosed == SDL_TRUE) ? "SDL_TRUE" : "SDL_FALSE",
@@ -1187,7 +1187,7 @@ static int rect_testEnclosePointsWithClipping(void *arg)
                         "Check that source clipping rectangle was not modified");
 
     /* Call function and validate */
-    anyEnclosed = SDL_GetRectEnclosingPoints((const SDL_Point *)points, numPoints, (const SDL_Rect *)&clip, &result);
+    anyEnclosed = SDL_GetRectEnclosingPoints(points, numPoints, &clip, &result);
     SDLTest_AssertCheck(expectedEnclosed == anyEnclosed,
                         "Check return value %s, got %s",
                         (expectedEnclosed == SDL_TRUE) ? "SDL_TRUE" : "SDL_FALSE",
@@ -1209,7 +1209,7 @@ static int rect_testEnclosePointsWithClipping(void *arg)
     clip.w = 0;
     clip.h = 0;
     expectedEnclosed = SDL_FALSE;
-    anyEnclosed = SDL_GetRectEnclosingPoints((const SDL_Point *)points, numPoints, (const SDL_Rect *)&clip, &result);
+    anyEnclosed = SDL_GetRectEnclosingPoints(points, numPoints, &clip, &result);
     SDLTest_AssertCheck(expectedEnclosed == anyEnclosed,
                         "Check return value %s, got %s",
                         (expectedEnclosed == SDL_TRUE) ? "SDL_TRUE" : "SDL_FALSE",
@@ -1232,14 +1232,14 @@ static int rect_testEnclosePointsParam(void *arg)
     SDL_bool anyEnclosed;
 
     /* invalid parameter combinations */
-    anyEnclosed = SDL_GetRectEnclosingPoints((SDL_Point *)NULL, 1, (const SDL_Rect *)&clip, &result);
+    anyEnclosed = SDL_GetRectEnclosingPoints((SDL_Point *)NULL, 1, &clip, &result);
     SDLTest_AssertCheck(anyEnclosed == SDL_FALSE, "Check that functions returns SDL_FALSE when 1st parameter is NULL");
-    anyEnclosed = SDL_GetRectEnclosingPoints((const SDL_Point *)points, 0, (const SDL_Rect *)&clip, &result);
+    anyEnclosed = SDL_GetRectEnclosingPoints(points, 0, &clip, &result);
     SDLTest_AssertCheck(anyEnclosed == SDL_FALSE, "Check that functions returns SDL_FALSE when 2nd parameter is 0");
     count = SDLTest_RandomIntegerInRange(-100, -1);
-    anyEnclosed = SDL_GetRectEnclosingPoints((const SDL_Point *)points, count, (const SDL_Rect *)&clip, &result);
+    anyEnclosed = SDL_GetRectEnclosingPoints(points, count, &clip, &result);
     SDLTest_AssertCheck(anyEnclosed == SDL_FALSE, "Check that functions returns SDL_FALSE when 2nd parameter is %i (negative)", count);
-    anyEnclosed = SDL_GetRectEnclosingPoints((SDL_Point *)NULL, 0, (const SDL_Rect *)&clip, &result);
+    anyEnclosed = SDL_GetRectEnclosingPoints((SDL_Point *)NULL, 0, &clip, &result);
     SDLTest_AssertCheck(anyEnclosed == SDL_FALSE, "Check that functions returns SDL_FALSE when 1st parameter is NULL and 2nd parameter was 0");
 
     return TEST_COMPLETED;

--- a/test/testautomation_rect.c
+++ b/test/testautomation_rect.c
@@ -1670,136 +1670,136 @@ static int rect_testFRectEqualsParam(void *arg)
 /* Rect test cases */
 
 /* SDL_GetRectAndLineIntersection */
-static const SDLTest_TestCaseReference rectTest1 = {
+static const SDLTest_TestCaseReference rectTestIntersectRectAndLine = {
     (SDLTest_TestCaseFp)rect_testIntersectRectAndLine, "rect_testIntersectRectAndLine", "Tests SDL_GetRectAndLineIntersection clipping cases", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest2 = {
+static const SDLTest_TestCaseReference rectTestIntersectRectAndLineInside = {
     (SDLTest_TestCaseFp)rect_testIntersectRectAndLineInside, "rect_testIntersectRectAndLineInside", "Tests SDL_GetRectAndLineIntersection with line fully contained in rect", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest3 = {
+static const SDLTest_TestCaseReference rectTestIntersectRectAndLineOutside = {
     (SDLTest_TestCaseFp)rect_testIntersectRectAndLineOutside, "rect_testIntersectRectAndLineOutside", "Tests SDL_GetRectAndLineIntersection with line fully outside of rect", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest4 = {
+static const SDLTest_TestCaseReference rectTestIntersectRectAndLineEmpty = {
     (SDLTest_TestCaseFp)rect_testIntersectRectAndLineEmpty, "rect_testIntersectRectAndLineEmpty", "Tests SDL_GetRectAndLineIntersection with empty rectangle ", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest5 = {
+static const SDLTest_TestCaseReference rectTestIntersectRectAndLineParam = {
     (SDLTest_TestCaseFp)rect_testIntersectRectAndLineParam, "rect_testIntersectRectAndLineParam", "Negative tests against SDL_GetRectAndLineIntersection with invalid parameters", TEST_ENABLED
 };
 
 /* SDL_GetRectIntersection */
-static const SDLTest_TestCaseReference rectTest6 = {
+static const SDLTest_TestCaseReference rectTestIntersectRectInside = {
     (SDLTest_TestCaseFp)rect_testIntersectRectInside, "rect_testIntersectRectInside", "Tests SDL_GetRectIntersection with B fully contained in A", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest7 = {
+static const SDLTest_TestCaseReference rectTestIntersectRectOutside = {
     (SDLTest_TestCaseFp)rect_testIntersectRectOutside, "rect_testIntersectRectOutside", "Tests SDL_GetRectIntersection with B fully outside of A", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest8 = {
+static const SDLTest_TestCaseReference rectTestIntersectRectPartial = {
     (SDLTest_TestCaseFp)rect_testIntersectRectPartial, "rect_testIntersectRectPartial", "Tests SDL_GetRectIntersection with B partially intersecting A", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest9 = {
+static const SDLTest_TestCaseReference rectTestIntersectRectPoint = {
     (SDLTest_TestCaseFp)rect_testIntersectRectPoint, "rect_testIntersectRectPoint", "Tests SDL_GetRectIntersection with 1x1 sized rectangles", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest10 = {
+static const SDLTest_TestCaseReference rectTestIntersectRectEmpty = {
     (SDLTest_TestCaseFp)rect_testIntersectRectEmpty, "rect_testIntersectRectEmpty", "Tests SDL_GetRectIntersection with empty rectangles", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest11 = {
+static const SDLTest_TestCaseReference rectTestIntersectRectParam = {
     (SDLTest_TestCaseFp)rect_testIntersectRectParam, "rect_testIntersectRectParam", "Negative tests against SDL_GetRectIntersection with invalid parameters", TEST_ENABLED
 };
 
 /* SDL_HasRectIntersection */
-static const SDLTest_TestCaseReference rectTest12 = {
+static const SDLTest_TestCaseReference rectTestHasIntersectionInside = {
     (SDLTest_TestCaseFp)rect_testHasIntersectionInside, "rect_testHasIntersectionInside", "Tests SDL_HasRectIntersection with B fully contained in A", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest13 = {
+static const SDLTest_TestCaseReference rectTestHasIntersectionOutside = {
     (SDLTest_TestCaseFp)rect_testHasIntersectionOutside, "rect_testHasIntersectionOutside", "Tests SDL_HasRectIntersection with B fully outside of A", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest14 = {
+static const SDLTest_TestCaseReference rectTestHasIntersectionPartial = {
     (SDLTest_TestCaseFp)rect_testHasIntersectionPartial, "rect_testHasIntersectionPartial", "Tests SDL_HasRectIntersection with B partially intersecting A", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest15 = {
+static const SDLTest_TestCaseReference rectTestHasIntersectionPoint = {
     (SDLTest_TestCaseFp)rect_testHasIntersectionPoint, "rect_testHasIntersectionPoint", "Tests SDL_HasRectIntersection with 1x1 sized rectangles", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest16 = {
+static const SDLTest_TestCaseReference rectTestHasIntersectionEmpty = {
     (SDLTest_TestCaseFp)rect_testHasIntersectionEmpty, "rect_testHasIntersectionEmpty", "Tests SDL_HasRectIntersection with empty rectangles", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest17 = {
+static const SDLTest_TestCaseReference rectTestHasIntersectionParam = {
     (SDLTest_TestCaseFp)rect_testHasIntersectionParam, "rect_testHasIntersectionParam", "Negative tests against SDL_HasRectIntersection with invalid parameters", TEST_ENABLED
 };
 
 /* SDL_GetRectEnclosingPoints */
-static const SDLTest_TestCaseReference rectTest18 = {
+static const SDLTest_TestCaseReference rectTestEnclosePoints = {
     (SDLTest_TestCaseFp)rect_testEnclosePoints, "rect_testEnclosePoints", "Tests SDL_GetRectEnclosingPoints without clipping", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest19 = {
+static const SDLTest_TestCaseReference rectTestEnclosePointsWithClipping = {
     (SDLTest_TestCaseFp)rect_testEnclosePointsWithClipping, "rect_testEnclosePointsWithClipping", "Tests SDL_GetRectEnclosingPoints with clipping", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest20 = {
+static const SDLTest_TestCaseReference rectTestEnclosePointsRepeatedInput = {
     (SDLTest_TestCaseFp)rect_testEnclosePointsRepeatedInput, "rect_testEnclosePointsRepeatedInput", "Tests SDL_GetRectEnclosingPoints with repeated input", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest21 = {
+static const SDLTest_TestCaseReference rectTestEnclosePointsParam = {
     (SDLTest_TestCaseFp)rect_testEnclosePointsParam, "rect_testEnclosePointsParam", "Negative tests against SDL_GetRectEnclosingPoints with invalid parameters", TEST_ENABLED
 };
 
 /* SDL_GetRectUnion */
-static const SDLTest_TestCaseReference rectTest22 = {
+static const SDLTest_TestCaseReference rectTestUnionRectInside = {
     (SDLTest_TestCaseFp)rect_testUnionRectInside, "rect_testUnionRectInside", "Tests SDL_GetRectUnion where rect B is inside rect A", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest23 = {
+static const SDLTest_TestCaseReference rectTestUnionRectOutside = {
     (SDLTest_TestCaseFp)rect_testUnionRectOutside, "rect_testUnionRectOutside", "Tests SDL_GetRectUnion where rect B is outside rect A", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest24 = {
+static const SDLTest_TestCaseReference rectTestUnionRectEmpty = {
     (SDLTest_TestCaseFp)rect_testUnionRectEmpty, "rect_testUnionRectEmpty", "Tests SDL_GetRectUnion where rect A or rect B are empty", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest25 = {
+static const SDLTest_TestCaseReference rectTestUnionRectParam = {
     (SDLTest_TestCaseFp)rect_testUnionRectParam, "rect_testUnionRectParam", "Negative tests against SDL_GetRectUnion with invalid parameters", TEST_ENABLED
 };
 
 /* SDL_RectEmpty */
-static const SDLTest_TestCaseReference rectTest26 = {
+static const SDLTest_TestCaseReference rectTestRectEmpty = {
     (SDLTest_TestCaseFp)rect_testRectEmpty, "rect_testRectEmpty", "Tests SDL_RectEmpty with various inputs", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest27 = {
+static const SDLTest_TestCaseReference rectTestRectEmptyParam = {
     (SDLTest_TestCaseFp)rect_testRectEmptyParam, "rect_testRectEmptyParam", "Negative tests against SDL_RectEmpty with invalid parameters", TEST_ENABLED
 };
 
 /* SDL_RectsEqual */
 
-static const SDLTest_TestCaseReference rectTest28 = {
+static const SDLTest_TestCaseReference rectTestRectEquals = {
     (SDLTest_TestCaseFp)rect_testRectEquals, "rect_testRectEquals", "Tests SDL_RectsEqual with various inputs", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest29 = {
+static const SDLTest_TestCaseReference rectTestRectEqualsParam = {
     (SDLTest_TestCaseFp)rect_testRectEqualsParam, "rect_testRectEqualsParam", "Negative tests against SDL_RectsEqual with invalid parameters", TEST_ENABLED
 };
 
 /* SDL_RectsEqualFloat */
 
-static const SDLTest_TestCaseReference rectTest30 = {
+static const SDLTest_TestCaseReference rectTestFRectEquals = {
     (SDLTest_TestCaseFp)rect_testFRectEquals, "rect_testFRectEquals", "Tests SDL_RectsEqualFloat with various inputs", TEST_ENABLED
 };
 
-static const SDLTest_TestCaseReference rectTest31 = {
+static const SDLTest_TestCaseReference rectTestFRectEqualsParam = {
     (SDLTest_TestCaseFp)rect_testFRectEqualsParam, "rect_testFRectEqualsParam", "Negative tests against SDL_RectsEqualFloat with invalid parameters", TEST_ENABLED
 };
 
@@ -1807,9 +1807,38 @@ static const SDLTest_TestCaseReference rectTest31 = {
  * Sequence of Rect test cases; functions that handle simple rectangles including overlaps and merges.
  */
 static const SDLTest_TestCaseReference *rectTests[] = {
-    &rectTest1, &rectTest2, &rectTest3, &rectTest4, &rectTest5, &rectTest6, &rectTest7, &rectTest8, &rectTest9, &rectTest10, &rectTest11, &rectTest12, &rectTest13, &rectTest14,
-    &rectTest15, &rectTest16, &rectTest17, &rectTest18, &rectTest19, &rectTest20, &rectTest21, &rectTest22, &rectTest23, &rectTest24, &rectTest25, &rectTest26, &rectTest27,
-    &rectTest28, &rectTest29, &rectTest30, &rectTest31, NULL
+    &rectTestIntersectRectAndLine,
+    &rectTestIntersectRectAndLineInside,
+    &rectTestIntersectRectAndLineOutside,
+    &rectTestIntersectRectAndLineEmpty,
+    &rectTestIntersectRectAndLineParam,
+    &rectTestIntersectRectInside,
+    &rectTestIntersectRectOutside,
+    &rectTestIntersectRectPartial,
+    &rectTestIntersectRectPoint,
+    &rectTestIntersectRectEmpty,
+    &rectTestIntersectRectParam,
+    &rectTestHasIntersectionInside,
+    &rectTestHasIntersectionOutside,
+    &rectTestHasIntersectionPartial,
+    &rectTestHasIntersectionPoint,
+    &rectTestHasIntersectionEmpty,
+    &rectTestHasIntersectionParam,
+    &rectTestEnclosePoints,
+    &rectTestEnclosePointsWithClipping,
+    &rectTestEnclosePointsRepeatedInput,
+    &rectTestEnclosePointsParam,
+    &rectTestUnionRectInside,
+    &rectTestUnionRectOutside,
+    &rectTestUnionRectEmpty,
+    &rectTestUnionRectParam,
+    &rectTestRectEmpty,
+    &rectTestRectEmptyParam,
+    &rectTestRectEquals,
+    &rectTestRectEqualsParam,
+    &rectTestFRectEquals,
+    &rectTestFRectEqualsParam,
+    NULL
 };
 
 /* Rect test suite (global) */


### PR DESCRIPTION
* A floating point rectangle contains all points >= x and <= x + w
* A floating point rectangle is only empty if it has negative width. The zero rectangle contains the zero point.
* Adjacent floating point rectangles intersect along their shared side

Fixes https://github.com/libsdl-org/SDL/issues/6791
