### PR TITLE
Removed SDL_PROP_SURFACE_COLORSPACE_NUMBER

### DIFF
--- a/include/SDL3/SDL_surface.h
+++ b/include/SDL3/SDL_surface.h
@@ -186,11 +186,6 @@ extern SDL_DECLSPEC void SDLCALL SDL_DestroySurface(SDL_Surface *surface);
  *
  * The following properties are understood by SDL:
  *
- * - `SDL_PROP_SURFACE_COLORSPACE_NUMBER`: an SDL_ColorSpace value describing
- *   the surface colorspace, defaults to SDL_COLORSPACE_SRGB_LINEAR for
- *   floating point formats, SDL_COLORSPACE_HDR10 for 10-bit formats,
- *   SDL_COLORSPACE_SRGB for other RGB surfaces and SDL_COLORSPACE_BT709_FULL
- *   for YUV surfaces.
  * - `SDL_PROP_SURFACE_SDR_WHITE_POINT_FLOAT`: for HDR10 and floating point
  *   surfaces, this defines the value of 100% diffuse white, with higher
  *   values being displayed in the High Dynamic Range headroom. This defaults
@@ -214,7 +209,6 @@ extern SDL_DECLSPEC void SDLCALL SDL_DestroySurface(SDL_Surface *surface);
  */
 extern SDL_DECLSPEC SDL_PropertiesID SDLCALL SDL_GetSurfaceProperties(SDL_Surface *surface);
 
-#define SDL_PROP_SURFACE_COLORSPACE_NUMBER                  "SDL.surface.colorspace"
 #define SDL_PROP_SURFACE_SDR_WHITE_POINT_FLOAT              "SDL.surface.SDR_white_point"
 #define SDL_PROP_SURFACE_HDR_HEADROOM_FLOAT                 "SDL.surface.HDR_headroom"
 #define SDL_PROP_SURFACE_TONEMAP_OPERATOR_STRING            "SDL.surface.tonemap"

--- a/src/video/SDL_blit.c
+++ b/src/video/SDL_blit.c
@@ -181,15 +181,8 @@ int SDL_CalculateBlit(SDL_Surface *surface)
     SDL_BlitFunc blit = NULL;
     SDL_BlitMap *map = &surface->internal->map;
     SDL_Surface *dst = map->dst;
-    SDL_Colorspace src_colorspace = SDL_GetSurfaceColorspace(surface);
-    SDL_Colorspace dst_colorspace = SDL_GetSurfaceColorspace(dst);
-
-    if (src_colorspace == SDL_COLORSPACE_UNKNOWN) {
-        return -1;
-    }
-    if (dst_colorspace == SDL_COLORSPACE_UNKNOWN) {
-        return -1;
-    }
+    SDL_Colorspace src_colorspace = surface->internal->colorspace;
+    SDL_Colorspace dst_colorspace = dst->internal->colorspace;
 
     /* We don't currently support blitting to < 8 bpp surfaces */
     if (SDL_BITSPERPIXEL(dst->format) < 8) {

--- a/src/video/SDL_blit_slow.c
+++ b/src/video/SDL_blit_slow.c
@@ -837,12 +837,8 @@ void SDL_Blit_Slow_Float(SDL_BlitInfo *info)
     float src_headroom;
     SDL_TonemapContext tonemap;
 
-    src_colorspace = SDL_GetSurfaceColorspace(info->src_surface);
-    dst_colorspace = SDL_GetSurfaceColorspace(info->dst_surface);
-    if (src_colorspace == SDL_COLORSPACE_UNKNOWN ||
-        dst_colorspace == SDL_COLORSPACE_UNKNOWN) {
-        return;
-    }
+    src_colorspace = info->src_surface->internal->colorspace;
+    dst_colorspace = info->dst_surface->internal->colorspace;
     src_primaries = SDL_COLORSPACEPRIMARIES(src_colorspace);
     dst_primaries = SDL_COLORSPACEPRIMARIES(dst_colorspace);
 

--- a/src/video/SDL_stretch.c
+++ b/src/video/SDL_stretch.c
@@ -44,7 +44,7 @@ int SDL_SoftStretch(SDL_Surface *src, const SDL_Rect *srcrect,
 
     if (src->format != dst->format) {
         // Slow!
-        SDL_Surface *src_tmp = SDL_ConvertSurfaceAndColorspace(src, dst->format, dst->internal->palette, SDL_GetSurfaceColorspace(dst), dst->internal->props);
+        SDL_Surface *src_tmp = SDL_ConvertSurfaceAndColorspace(src, dst->format, dst->internal->palette, dst->internal->colorspace, dst->internal->props);
         if (!src_tmp) {
             return -1;
         }
@@ -68,11 +68,10 @@ int SDL_SoftStretch(SDL_Surface *src, const SDL_Rect *srcrect,
         if (src_tmp && dst_tmp) {
             ret = SDL_SoftStretch(src_tmp, srcrect, dst_tmp, NULL, scaleMode);
             if (ret == 0) {
-                SDL_Colorspace dst_colorspace = SDL_GetSurfaceColorspace(dst);
                 SDL_ConvertPixelsAndColorspace(dstrect->w, dstrect->h,
                     dst_tmp->format, SDL_COLORSPACE_SRGB, 0,
                     dst_tmp->pixels, dst_tmp->pitch,
-                    dst->format, dst_colorspace, SDL_GetSurfaceProperties(dst),
+                    dst->format, dst->internal->colorspace, SDL_GetSurfaceProperties(dst),
                     (Uint8 *)dst->pixels + dstrect->y * dst->pitch + dstrect->x * SDL_BYTESPERPIXEL(dst->format), dst->pitch);
             }
         } else {

--- a/src/video/SDL_surface_c.h
+++ b/src/video/SDL_surface_c.h
@@ -46,6 +46,9 @@ struct SDL_SurfaceData
     /** detailed format for this surface */
     const SDL_PixelFormatDetails *format;
 
+    /** Pixel colorspace */
+    SDL_Colorspace colorspace;
+
     /** palette for indexed surfaces */
     SDL_Palette *palette;
 


### PR DESCRIPTION
Now that we have surface internal data, we can store it there. This slightly improves performance in the surface blitting paths.
