### PR TITLE
Fixed a typo in the function name in the documentation for SDL_EGL_GetProcAddress in SDL_video.h

### DIFF
--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -2522,7 +2522,7 @@ extern SDL_DECLSPEC SDL_FunctionPointer SDLCALL SDL_GL_GetProcAddress(const char
  *
  * \since This function is available since SDL 3.0.0.
  *
- * \sa SDL_GL_GetCurrentEGLDisplay
+ * \sa SDL_EGL_GetCurrentEGLDisplay
  */
 extern SDL_DECLSPEC SDL_FunctionPointer SDLCALL SDL_EGL_GetProcAddress(const char *proc);
 


### PR DESCRIPTION
Fixed a typo in the function name in the documentation for SDL_EGL_GetProcAddress
