### PR TITLE
Fix VisualC-GDK build

### DIFF
--- a/VisualC-GDK/SDL/SDL.vcxproj
+++ b/VisualC-GDK/SDL/SDL.vcxproj
@@ -503,7 +503,7 @@
     <ClCompile Include="..\..\src\dialog\SDL_dialog_utils.c" />
     <ClCompile Include="..\..\src\filesystem\SDL_filesystem.c" />
     <ClCompile Include="..\..\src\filesystem\windows\SDL_sysfsops.c" />
-    <ClCompile Include="..\..\src\main\gdk\SDL_sysmain_runapp.cpp">
+    <ClCompile Include="..\..\src\main\gdk\SDL_sysmain_runapp.cpp" />
     <ClCompile Include="..\..\src\main\generic\SDL_sysmain_callbacks.c" />
     <ClCompile Include="..\..\src\main\SDL_main_callbacks.c" />
     <ClCompile Include="..\..\src\main\SDL_runapp.c" />

--- a/VisualC-GDK/tests/testgdk/src/testgdk.cpp
+++ b/VisualC-GDK/tests/testgdk/src/testgdk.cpp
@@ -309,7 +309,7 @@ loop()
     /* Check for events */
     while (SDL_PollEvent(&event)) {
         if (event.type == SDL_EVENT_KEY_DOWN && !event.key.repeat) {
-            SDL_Log("Initial SDL_EVENT_KEY_DOWN: %s", SDL_GetScancodeName(event.key.keysym.scancode));
+            SDL_Log("Initial SDL_EVENT_KEY_DOWN: %s", SDL_GetScancodeName(event.key.scancode));
         }
 #if defined(SDL_PLATFORM_XBOXONE) || defined(SDL_PLATFORM_XBOXSERIES)
         /* On Xbox, ignore the keydown event because the features aren't supported */

--- a/src/core/SDL_core_unsupported.c
+++ b/src/core/SDL_core_unsupported.c
@@ -227,13 +227,3 @@ Sint32 JNI_OnLoad(void *vm, void *reserved)
     return -1; /* JNI_ERR */
 }
 #endif
-
-// !!! FIXME: this probably belongs in src/filesystem/gdk
-#if defined(SDL_PLATFORM_XBOXONE) || defined(SDL_PLATFORM_XBOXSERIES)
-const char *SDL_GetUserFolder(SDL_Folder folder)
-{
-    (void)folder;
-    SDL_Unsupported();
-    return NULL;
-}
-#endif

--- a/src/core/gdk/SDL_gdk.cpp
+++ b/src/core/gdk/SDL_gdk.cpp
@@ -74,6 +74,66 @@ void GDK_DispatchTaskQueue(void)
 }
 
 extern "C"
+int GDK_RegisterChangeNotifications(void)
+{
+    /* Register suspend/resume handling */
+    plmSuspendComplete = CreateEventEx(nullptr, nullptr, 0, EVENT_MODIFY_STATE | SYNCHRONIZE);
+    if (!plmSuspendComplete) {
+        SDL_SetError("[GDK] Unable to create plmSuspendComplete event");
+        return -1;
+    }
+    auto rascn = [](BOOLEAN quiesced, PVOID context) {
+        SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "[GDK] in RegisterAppStateChangeNotification handler");
+        if (quiesced) {
+            ResetEvent(plmSuspendComplete);
+            SDL_SendAppEvent(SDL_EVENT_DID_ENTER_BACKGROUND);
+
+            // To defer suspension, we must wait to exit this callback.
+            // IMPORTANT: The app must call SDL_GDKSuspendComplete() to release this lock.
+            (void)WaitForSingleObject(plmSuspendComplete, INFINITE);
+
+            SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "[GDK] in RegisterAppStateChangeNotification handler: plmSuspendComplete event signaled.");
+        } else {
+            SDL_SendAppEvent(SDL_EVENT_WILL_ENTER_FOREGROUND);
+        }
+    };
+    if (RegisterAppStateChangeNotification(rascn, NULL, &hPLM)) {
+        SDL_SetError("[GDK] Unable to call RegisterAppStateChangeNotification");
+        return -1;
+    }
+
+    /* Register constrain/unconstrain handling */
+    auto raccn = [](BOOLEAN constrained, PVOID context) {
+        SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, "[GDK] in RegisterAppConstrainedChangeNotification handler");
+        SDL_VideoDevice *_this = SDL_GetVideoDevice();
+        if (_this) {
+            if (constrained) {
+                SDL_SetKeyboardFocus(NULL);
+            } else {
+                SDL_SetKeyboardFocus(_this->windows);
+            }
+        }
+    };
+    if (RegisterAppConstrainedChangeNotification(raccn, NULL, &hCPLM)) {
+        SDL_SetError("[GDK] Unable to call RegisterAppConstrainedChangeNotification");
+        return -1;
+    }
+
+    return 0;
+}
+
+extern "C"
+void GDK_UnregisterChangeNotifications(void)
+{
+    /* Unregister suspend/resume handling */
+    UnregisterAppStateChangeNotification(hPLM);
+    CloseHandle(plmSuspendComplete);
+
+    /* Unregister constrain/unconstrain handling */
+    UnregisterAppConstrainedChangeNotification(hCPLM);
+}
+
+extern "C"
 void SDL_GDKSuspendComplete()
 {
     if (plmSuspendComplete) {

--- a/src/core/gdk/SDL_gdk.h
+++ b/src/core/gdk/SDL_gdk.h
@@ -22,3 +22,7 @@
 
 /* This is called from WIN_PumpEvents on GDK */
 extern void GDK_DispatchTaskQueue(void);
+
+extern int GDK_RegisterChangeNotifications(void);
+
+extern void GDK_UnregisterChangeNotifications(void);

--- a/src/filesystem/gdk/SDL_sysfilesystem.cpp
+++ b/src/filesystem/gdk/SDL_sysfilesystem.cpp
@@ -23,7 +23,9 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /* System dependent filesystem routines                                */
 
+extern "C" {
 #include "../SDL_sysfilesystem.h"
+}
 
 #include "../../core/windows/SDL_windows.h"
 #include <SDL3/SDL_hints.h>
@@ -133,5 +135,11 @@ char *SDL_SYS_GetPrefPath(const char *org, const char *app)
     return folderPath;
 }
 
+/* TODO */
+char *SDL_SYS_GetUserFolder(SDL_Folder folder)
+{
+    SDL_Unsupported();
+    return NULL;
+}
 
 /* vi: set ts=4 sw=4 expandtab: */

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1004,6 +1004,7 @@ static SDL_bool SkipAltGrLeftControl(WPARAM wParam, LPARAM lParam)
         return SDL_FALSE;
     }
 
+#if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
     // Here is a trick: "Alt Gr" sends LCTRL, then RALT. We only
     // want the RALT message, so we try to see if the next message
     // is a RALT message. In that case, this is a false LCTRL!
@@ -1018,6 +1019,8 @@ static SDL_bool SkipAltGrLeftControl(WPARAM wParam, LPARAM lParam)
             }
         }
     }
+#endif /* !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES) */
+
     return SDL_FALSE;
 }
 
@@ -2299,9 +2302,9 @@ void WIN_PumpEvents(SDL_VideoDevice *_this)
 
     WIN_CheckKeyboardAndMouseHotplug(_this, SDL_FALSE);
 
-#endif /*!defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)*/
-
     WIN_UpdateIMECandidates(_this);
+
+#endif /*!defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)*/
 
 #ifdef SDL_PLATFORM_GDK
     GDK_DispatchTaskQueue();

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -104,12 +104,12 @@ static void WIN_DeleteDevice(SDL_VideoDevice *device)
         SDL_UnloadObject(data->shcoreDLL);
     }
 #endif
-#ifndef HAVE_DXGI_H
+#ifdef HAVE_DXGI_H
     if (data->pDXGIFactory) {
-        IDXGIFactory_Release(pDXGIFactory);
+        IDXGIFactory_Release(data->pDXGIFactory);
     }
     if (data->dxgiDLL) {
-        SDL_UnloadObject(pDXGIDLL);
+        SDL_UnloadObject(data->dxgiDLL);
     }
 #endif
     if (device->wakeup_lock) {

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -306,7 +306,7 @@ static SDL_VideoDevice *WIN_CreateDevice(void)
 
     device->StartTextInput = GDK_StartTextInput;
     device->StopTextInput = GDK_StopTextInput;
-    device->SetTextInputArea = GDK_SetTextInputArea;
+    device->UpdateTextInputArea = GDK_UpdateTextInputArea;
     device->ClearComposition = GDK_ClearComposition;
 
     device->HasScreenKeyboardSupport = GDK_HasScreenKeyboardSupport;

--- a/src/video/windows/SDL_windowsvideo.h
+++ b/src/video/windows/SDL_windowsvideo.h
@@ -345,6 +345,7 @@ typedef struct
     void *data;
 } TSFSink;
 
+#ifndef SDL_DISABLE_WINDOWS_IME
 /* Definition from Win98DDK version of IMM.H */
 typedef struct tagINPUTCONTEXT2
 {
@@ -370,6 +371,7 @@ typedef struct tagINPUTCONTEXT2
     DWORD fdwInit;
     DWORD dwReserve[3];
 } INPUTCONTEXT2, *PINPUTCONTEXT2, NEAR *NPINPUTCONTEXT2, FAR *LPINPUTCONTEXT2;
+#endif
 
 /* Private display data */
 
@@ -458,8 +460,10 @@ struct SDL_VideoData
     SDL_bool ime_horizontal_candidates;
 #endif
 
+#if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
     COMPOSITIONFORM ime_composition_area;
     CANDIDATEFORM ime_candidate_area;
+#endif /* !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES) */
 
 #ifndef SDL_DISABLE_WINDOWS_IME
     HKL ime_hkl;


### PR DESCRIPTION
A fresh round to update GDK builds to the latest version.

## Description

- adjusts for recent API changes
- moves setup code for app change notification to SDL_gdk.cpp since the data (handles) now live there
- conditionally disables some more types&calls not available on Xbox
- fixes DXGI cleanup code
