### PR TITLE
Check window fullscreen flag in SDL_GetWindowSizeInPixels

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -3028,7 +3028,7 @@ int SDL_GetWindowSizeInPixels(SDL_Window *window, int *w, int *h)
 
         SDL_GetWindowSize(window, w, h);
 
-        if (SDL_GetWindowFullscreenModeInternal(window)) {
+        if ((window->flags & SDL_WINDOW_FULLSCREEN) && SDL_GetWindowFullscreenModeInternal(window)) {
             mode = SDL_GetCurrentDisplayMode(displayID);
         } else {
             mode = SDL_GetDesktopDisplayMode(displayID);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`SDL_GetWindowFullscreenModeInternal` returns non-null even when the window is not in fullscreen, if full screen display mode is previously set through `SDL_SetWindowFullscreenMode`.

This PR fixes it by checking window flag before calling `SDL_GetWindowFullscreenModeInternal`.