### PR TITLE
Fix documentation references and update method usage for SDL_GetGamepadGUIDForID in SDL_gamepad.h

### DIFF
--- a/include/SDL3/SDL_gamepad.h
+++ b/include/SDL3/SDL_gamepad.h
@@ -564,8 +564,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetGamepadPlayerIndexForID(SDL_JoystickID in
  *
  * \since This function is available since SDL 3.0.0.
  *
- * \sa SDL_GetGamepadGUID
- * \sa SDL_GetGamepadGUIDString
+ * \sa SDL_GUIDToString
  * \sa SDL_GetGamepads
  */
 extern SDL_DECLSPEC SDL_GUID SDLCALL SDL_GetGamepadGUIDForID(SDL_JoystickID instance_id);


### PR DESCRIPTION
In the documentation for the SDL_GetGamepadGUIDForID method in the SDL_gamepad.h file, there are two references to the methods SDL_GetGamepadGUID and SDL_GetGamepadGUIDString, but there are no methods of its own. I replaced these two methods with the existing SDL_GUIDToString.