### PR TITLE
Fixed a typo in the link to the GetTouchFingers function

### DIFF
--- a/include/SDL3/SDL_touch.h
+++ b/include/SDL3/SDL_touch.h
@@ -59,7 +59,7 @@ typedef enum SDL_TouchDeviceType
  *
  * \since This struct is available since SDL 3.0.0.
  *
- * \sa SDL_GetTouchFinger
+ * \sa SDL_GetTouchFingers
  */
 typedef struct SDL_Finger
 {


### PR DESCRIPTION
The Finger framework documentation referred to a non-existent GetTouchFinger method