### PR TITLE
Remove SDL_DECLSPEC_FREE before SDL_DECLSPEC in gendynapi

### DIFF
--- a/src/dynapi/gendynapi.py
+++ b/src/dynapi/gendynapi.py
@@ -196,8 +196,8 @@ def main():
             #
             func_ret = func_ret.replace('extern', ' ')
             func_ret = func_ret.replace('SDLCALL', ' ')
-            func_ret = func_ret.replace('SDL_DECLSPEC', ' ')
             func_ret = func_ret.replace('SDL_DECLSPEC_FREE', ' ')
+            func_ret = func_ret.replace('SDL_DECLSPEC', ' ')
             # Remove trailing spaces in front of '*'
             tmp = ""
             while func_ret != tmp:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
It replaces `SDL_DECLSPEC_FREE` to ` _FREE` first, so removing `SDL_DECLSPEC_FREE` after that has no effect.

This PR fixes it by changing the order of replacing.