### PR TITLE
Make sure we call SDL_Quit() before SDLTest_CommonDestroyState()

### DIFF
--- a/include/SDL3/SDL_test_common.h
+++ b/include/SDL3/SDL_test_common.h
@@ -156,6 +156,8 @@ SDLTest_CommonState *SDLTest_CommonCreateState(char **argv, SDL_InitFlags flags)
 /**
  * Free the common state object.
  *
+ * You should call SDL_Quit() before calling this function.
+ *
  * \param state The common state object to destroy
  */
 void SDLTest_CommonDestroyState(SDLTest_CommonState *state);

--- a/test/loopwave.c
+++ b/test/loopwave.c
@@ -134,6 +134,7 @@ void SDL_AppQuit(void *appstate)
 {
     SDL_DestroyAudioStream(stream);
     SDL_free(wave.sound);
+    SDL_Quit();
     SDLTest_CommonDestroyState(state);
 }
 

--- a/test/testaudiorecording.c
+++ b/test/testaudiorecording.c
@@ -210,8 +210,8 @@ void SDL_AppQuit(void *appstate)
     SDL_DestroyAudioStream(stream_out);
     SDL_DestroyRenderer(renderer);
     SDL_DestroyWindow(window);
-    SDLTest_CommonDestroyState(state);
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
 }
 
 

--- a/test/testcamera.c
+++ b/test/testcamera.c
@@ -74,6 +74,7 @@ int SDL_AppInit(void **appstate, int argc, char *argv[])
                 NULL,
             };
             SDLTest_CommonLogUsage(state, argv[0], options);
+            SDL_Quit();
             SDLTest_CommonDestroyState(state);
             return 1;
         }

--- a/test/testevdev.c
+++ b/test/testevdev.c
@@ -2243,6 +2243,7 @@ int main(int argc, char *argv[])
 
     result = run_test() ? 0 : 1;
 
+    SDL_Quit();
     SDLTest_CommonDestroyState(state);
     return result;
 }

--- a/test/testfile.c
+++ b/test/testfile.c
@@ -58,6 +58,7 @@ iostrm_error_quit(unsigned line, SDL_IOStream *iostrm)
         SDL_CloseIO(iostrm);
     }
     cleanup();
+    SDL_Quit();
     SDLTest_CommonDestroyState(state);
     exit(1); /* quit with iostrm error (test failed) */
 }

--- a/test/testplatform.c
+++ b/test/testplatform.c
@@ -483,8 +483,8 @@ int main(int argc, char *argv[])
     status += Test64Bit(verbose);
     status += TestCPUInfo(verbose);
     status += TestAssertions(verbose);
-    SDL_Quit();
 
+    SDL_Quit();
     SDLTest_CommonDestroyState(state);
 
     return status;

--- a/test/testqsort.c
+++ b/test/testqsort.c
@@ -135,6 +135,7 @@ int main(int argc, char *argv[])
         test_sort("random sorted", nums, arraylen);
     }
 
+    SDL_Quit();
     SDLTest_CommonDestroyState(state);
 
     return 0;

--- a/test/testrwlock.c
+++ b/test/testrwlock.c
@@ -171,8 +171,8 @@ int main(int argc, char *argv[])
 
     SDL_Log("Reader threads have terminated, quitting!");
     SDL_DestroyRWLock(rwlock);
-    SDLTest_CommonDestroyState(state);
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
 
     return 0;
 }

--- a/test/testsensor.c
+++ b/test/testsensor.c
@@ -72,6 +72,7 @@ int main(int argc, char **argv)
     SDL_SetLogPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
 
     if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        SDL_Quit();
         SDLTest_CommonDestroyState(state);
         return 1;
     }
@@ -79,6 +80,7 @@ int main(int argc, char **argv)
     /* Load the SDL library */
     if (SDL_Init(SDL_INIT_SENSOR) < 0) {
         SDL_Log("Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_Quit();
         SDLTest_CommonDestroyState(state);
         return 1;
     }

--- a/test/teststreaming.c
+++ b/test/teststreaming.c
@@ -149,6 +149,7 @@ int main(int argc, char **argv)
     SDL_SetLogPriority(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO);
 
     if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        SDL_Quit();
         SDLTest_CommonDestroyState(state);
         return 1;
     }

--- a/test/testthread.c
+++ b/test/testthread.c
@@ -20,6 +20,7 @@
 #include <SDL3/SDL_test.h>
 
 static SDL_TLSID tls;
+static SDL_Thread *thread = NULL;
 static int alive = 0;
 static int testprio = 0;
 static SDLTest_CommonState *state;
@@ -83,13 +84,13 @@ killed(int sig)
     SDL_Log("Killed with SIGTERM, waiting 5 seconds to exit\n");
     SDL_Delay(5 * 1000);
     alive = 0;
+    SDL_WaitThread(thread, NULL);
     quit(0);
 }
 
 int main(int argc, char *argv[])
 {
     int i;
-    SDL_Thread *thread;
 
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, 0);

--- a/test/testthread.c
+++ b/test/testthread.c
@@ -28,8 +28,8 @@ static SDLTest_CommonState *state;
 static void
 quit(int rc)
 {
-    SDLTest_CommonDestroyState(state);
     SDL_Quit();
+    SDLTest_CommonDestroyState(state);
     /* Let 'main()' return normally */
     if (rc != 0) {
         exit(rc);

--- a/test/testyuv.c
+++ b/test/testyuv.c
@@ -396,6 +396,7 @@ int main(int argc, char **argv)
                 NULL,
             };
             SDLTest_CommonLogUsage(state, argv[0], options);
+            SDL_Quit();
             SDLTest_CommonDestroyState(state);
             return 1;
         }

--- a/test/torturethread.c
+++ b/test/torturethread.c
@@ -98,6 +98,7 @@ int main(int argc, char *argv[])
     }
 
     if (!SDLTest_CommonDefaultArgs(state, argc, argv)) {
+        SDL_Quit();
         SDLTest_CommonDestroyState(state);
         return 1;
     }


### PR DESCRIPTION
Also fixes the memory leak reported in https://github.com/libsdl-org/SDL/pull/10396#issuecomment-2254518947