### PR TITLE
[SDL3] SDL_mslibc.c: revert PR/10303 changes

### DIFF
--- a/src/stdlib/SDL_mslibc.c
+++ b/src/stdlib/SDL_mslibc.c
@@ -36,7 +36,7 @@ __declspec(selectany) int _fltused = 1;
 #ifdef _M_IX86
 
 /* Float to long */
-void __declspec(naked) _ftol(void)
+void __declspec(naked) _ftol()
 {
     /* *INDENT-OFF* */
     __asm {
@@ -85,18 +85,18 @@ localexit:
     /* *INDENT-ON* */
 }
 
-void _ftol2_sse(void)
+void _ftol2_sse()
 {
     _ftol();
 }
 
-void _ftol2(void)
+void _ftol2()
 {
     _ftol();
 }
 
 /* 64-bit math operators for 32-bit systems */
-void __declspec(naked) _allmul(void)
+void __declspec(naked) _allmul()
 {
     /* *INDENT-OFF* */
     __asm {
@@ -124,7 +124,7 @@ hard:
     /* *INDENT-ON* */
 }
 
-void __declspec(naked) _alldiv(void)
+void __declspec(naked) _alldiv()
 {
     /* *INDENT-OFF* */
     __asm {
@@ -210,7 +210,7 @@ L8:
     /* *INDENT-ON* */
 }
 
-void __declspec(naked) _aulldiv(void)
+void __declspec(naked) _aulldiv()
 {
     /* *INDENT-OFF* */
     __asm {
@@ -266,7 +266,7 @@ L2:
     /* *INDENT-ON* */
 }
 
-void __declspec(naked) _allrem(void)
+void __declspec(naked) _allrem()
 {
     /* *INDENT-OFF* */
     __asm {
@@ -351,7 +351,7 @@ L8:
     /* *INDENT-ON* */
 }
 
-void __declspec(naked) _aullrem(void)
+void __declspec(naked) _aullrem()
 {
     /* *INDENT-OFF* */
     __asm {
@@ -408,7 +408,7 @@ L2:
     /* *INDENT-ON* */
 }
 
-void __declspec(naked) _alldvrm(void)
+void __declspec(naked) _alldvrm()
 {
     /* *INDENT-OFF* */
     __asm {
@@ -516,7 +516,7 @@ L8:
     /* *INDENT-ON* */
 }
 
-void __declspec(naked) _aulldvrm(void)
+void __declspec(naked) _aulldvrm()
 {
     /* *INDENT-OFF* */
     __asm {
@@ -587,7 +587,7 @@ L2:
     /* *INDENT-ON* */
 }
 
-void __declspec(naked) _allshl(void)
+void __declspec(naked) _allshl()
 {
     /* *INDENT-OFF* */
     __asm {
@@ -612,7 +612,7 @@ RETZERO:
     /* *INDENT-ON* */
 }
 
-void __declspec(naked) _allshr(void)
+void __declspec(naked) _allshr()
 {
     /* *INDENT-OFF* */
     __asm {
@@ -637,7 +637,7 @@ RETSIGN:
     /* *INDENT-ON* */
 }
 
-void __declspec(naked) _aullshr(void)
+void __declspec(naked) _aullshr()
 {
     /* *INDENT-OFF* */
     __asm {


### PR DESCRIPTION
This reverts parts of PR/#10303 applied to SDL_mslibc.c functions.
We should keep them as `()` because their signatures are already wrong
and they work only because they are marked with `naked` attributes.

(CC: @akk0rd87)
