### PR TITLE
[SDL2] SDL_mslibc.c: revert PR/10303 changes

### DIFF
--- a/src/stdlib/SDL_mslibc.c
+++ b/src/stdlib/SDL_mslibc.c
@@ -120,12 +120,12 @@ localexit:
     /* *INDENT-ON* */
 }
 
-void _ftol2_sse(void)
+void _ftol2_sse()
 {
     _ftol();
 }
 
-void _ftol2(void)
+void _ftol2()
 {
     _ftol();
 }


### PR DESCRIPTION
[SDL3] SDL_mslibc.c: revert PR/10303 changes

This reverts parts of PR/#10303 applied to SDL_mslibc.c functions.
We should keep them as `()` because their signatures are already wrong
and they work only because they are marked with `naked` attributes.

To be cherry-picked to 2.30.x after merge.

(CC: @akk0rd87)
