### PR TITLE
Support SDL_EVENT_DROP_FILE and SDL_EVENT_DROP_TEXT in Windows

### DIFF
--- a/src/video/windows/SDL_windowsvideo.h
+++ b/src/video/windows/SDL_windowsvideo.h
@@ -379,6 +379,9 @@ struct SDL_VideoData
 {
     int render;
 
+    SDL_bool coinitialized;
+    SDL_bool oleinitialized;
+
     DWORD clipboard_count;
 
 #if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES) /* Xbox doesn't support user32/shcore*/

--- a/src/video/windows/SDL_windowswindow.h
+++ b/src/video/windows/SDL_windowswindow.h
@@ -48,6 +48,16 @@ typedef enum SDL_WindowEraseBackgroundMode
     SDL_ERASEBACKGROUNDMODE_ALWAYS,
 } SDL_WindowEraseBackgroundMode;
 
+typedef struct
+{
+    void **lpVtbl;
+    int refcount;
+    SDL_Window *window;
+    HWND hwnd;
+    UINT format_text;
+    UINT format_file;
+} SDLDropTarget;
+
 struct SDL_WindowData
 {
     SDL_Window *window;
@@ -89,6 +99,7 @@ struct SDL_WindowData
 
     /* Whether we retain the content of the window when changing state */
     UINT copybits_flag;
+    SDLDropTarget *drop_target;
 };
 
 extern int WIN_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesID create_props);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Remove `WM_DROPFILES` ( supports only `SDL_EVENT_DROP_FILE` ), use `IDropTarget` instead ( provides `SDL_EVENT_DROP_POSITION`, `SDL_EVENT_DROP_FILE` and `SDL_EVENT_DROP_TEXT` ).

## Description
<!--- Describe your changes in detail -->

- In `src/video/windows/SDL_windowsevents.c`, remove `WM_DROPFILES`
- In `src/video/windows/SDL_windowswindow.c + .h`,
Create `IDropTarget` and issue `SDL_SendDropPosition`,
Handle `text/uri-list` for `SDL_SendDropFile`, `text/plain;charset=utf-8` and `CF_UNICODE_TEXT` and `CF_TEXT` for `SDL_SendDropText`, `CF_HDROP` for `SDL_SendDropFile`.

## To be reviewed 

- The `IDropTarget` Drop OLE object requires a full `OleInitialize` in `WIN_AcceptDragAndDrop`, as `CoInitialize(Ex)` are not enough and cause a Memory Management Overflow error. Whereas `CoInitialize(Ex)` have a centralized support in SDL, `OleInitialize` has not. What is the position of the SDL Development Team about `OleInitialize` ?
- The Debug messages print `size_t` variables, using a cast to 64 bits and a `%lld` format for 32 and 64 bits support. Should they use `%zd` instead, like the test automation does, but which requires silencing the warnings `-Wformat` and `-Wformat-extra-args` ?
