### PR TITLE
Pause and resume Android audio without taking device locks

### DIFF
--- a/src/audio/aaudio/SDL_aaudio.h
+++ b/src/audio/aaudio/SDL_aaudio.h
@@ -23,16 +23,7 @@
 #ifndef SDL_aaudio_h_
 #define SDL_aaudio_h_
 
-#ifdef SDL_AUDIO_DRIVER_AAUDIO
-
-void AAUDIO_ResumeDevices(void);
-void AAUDIO_PauseDevices(void);
-
-#else
-
-#define AAUDIO_ResumeDevices()
-#define AAUDIO_PauseDevices()
-
-#endif
+extern void AAUDIO_ResumeDevices(void);
+extern void AAUDIO_PauseDevices(void);
 
 #endif // SDL_aaudio_h_

--- a/src/audio/openslES/SDL_openslES.h
+++ b/src/audio/openslES/SDL_openslES.h
@@ -23,16 +23,7 @@
 #ifndef SDL_openslesaudio_h_
 #define SDL_openslesaudio_h_
 
-#ifdef SDL_AUDIO_DRIVER_OPENSLES
-
-void OPENSLES_ResumeDevices(void);
-void OPENSLES_PauseDevices(void);
-
-#else
-
-static void OPENSLES_ResumeDevices(void) {}
-static void OPENSLES_PauseDevices(void) {}
-
-#endif
+extern void OPENSLES_ResumeDevices(void);
+extern void OPENSLES_PauseDevices(void);
 
 #endif // SDL_openslesaudio_h_


### PR DESCRIPTION
The AAudio driver implemented pause/resume by dangerously locking the audio devices. If there was an audio hotplug event or a background thread tried to interact with the audio system, this could cause deadlocks.
