### PR TITLE
video: Disable relative warp emulation when warping the cursor after …

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1716,10 +1716,16 @@ extern SDL_WindowFlags WINRT_DetectWindowFlags(SDL_Window *window);
 static void SDL_RestoreMousePosition(SDL_Window *window)
 {
     float x, y;
+    SDL_Mouse *mouse = SDL_GetMouse();
 
     if (window == SDL_GetMouseFocus()) {
+        const SDL_bool prev_warp_val = mouse->warp_emulation_prohibited;
         SDL_GetMouseState(&x, &y);
+
+        /* Disable the warp emulation so it isn't accidentally activated on a fullscreen transitions. */
+        mouse->warp_emulation_prohibited = SDL_TRUE;
         SDL_WarpMouseInWindow(window, x, y);
+        mouse->warp_emulation_prohibited = prev_warp_val;
     }
 }
 


### PR DESCRIPTION
…a fullscreen transition

Otherwise, relative mode can be accidentally activated if the cursor is hidden.

Possible fix for #10413
