### PR TITLE
SDL_RWFromFile: On Apple platforms, offer a hint to not look in resource dirs.

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -3093,6 +3093,27 @@ extern "C" {
  */
 #define SDL_HINT_SHUTDOWN_DBUS_ON_QUIT "SDL_SHUTDOWN_DBUS_ON_QUIT"
 
+/**
+ * Specify if SDL_RWFromFile should use the resource dir on Apple platforms.
+ *
+ * SDL2 has always done this on Apple platforms, but it can be surprising to
+ * try opening a path to discover that SDL adjusts the path to elsewhere, so
+ * this hint allows that behavior to be disabled.
+ *
+ * If running from a App Bundle, this will be MyApp.app/Contents/Resources.
+ * If running as a normal Unix-like process, this will be the directory where
+ * the running binary lives. Setting this hint to 0 avoids this and just
+ * uses the requested path as-is.
+ *
+ * This variable can be set to the following values:
+ *
+ * - "0": SDL will not use the app resource directory.
+ * - "1": SDL will use the app's resource directory (default).
+ *
+ * This hint is available since SDL 2.32.0.
+ */
+#define SDL_HINT_APPLE_RWFROMFILE_USE_RESOURCES "SDL_APPLE_RWFROMFILE_USE_RESOURCES"
+
 
 /**
  * An enumeration of hint priorities

--- a/src/file/cocoa/SDL_rwopsbundlesupport.m
+++ b/src/file/cocoa/SDL_rwopsbundlesupport.m
@@ -24,6 +24,7 @@
 #import <Foundation/Foundation.h>
 
 #include "SDL_rwopsbundlesupport.h"
+#include "SDL_hints.h"
 
 /* For proper OS X applications, the resources are contained inside the application bundle.
  So the strategy is to first check the application bundle for the file, then fallback to the current working directory.
@@ -40,6 +41,11 @@ FILE *SDL_OpenFPFromBundleOrFallback(const char *file, const char *mode)
         NSString *resource_path;
         NSString *ns_string_file_component;
         NSString *full_path_with_file_to_try;
+
+        /* if the app doesn't want this app bundle behavior, just use the path as-is. */
+        if (!SDL_GetHintBoolean(SDL_HINT_APPLE_RWFROMFILE_USE_RESOURCES, SDL_TRUE)) {
+            return fopen(file, mode);
+        }
 
         /* If the file mode is writable, skip all the bundle stuff because generally the bundle is read-only. */
         if (SDL_strchr(mode, 'r') == NULL) {


### PR DESCRIPTION
This is the SDL2 branch solution. In SDL3, this behavior is removed by #10420, but here for backwards compatibility, this offers a hint to turn off the usual behavior.

Fixes #8403.

