### PR TITLE
android: Update window/surface pointers on change

### DIFF
--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -1211,6 +1211,7 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeSurfaceCreated)(JNIEnv *env, j
         SDL_WindowData *data = Android_Window->internal;
 
         data->native_window = Android_JNI_GetNativeWindow();
+        SDL_SetPointerProperty(SDL_GetWindowProperties(Android_Window), SDL_PROP_WINDOW_ANDROID_WINDOW_POINTER, data->native_window);
         if (data->native_window == NULL) {
             SDL_SetError("Could not fetch native window from UI thread");
         }
@@ -1232,6 +1233,7 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeSurfaceChanged)(JNIEnv *env, j
         /* If the surface has been previously destroyed by onNativeSurfaceDestroyed, recreate it here */
         if (data->egl_surface == EGL_NO_SURFACE) {
             data->egl_surface = SDL_EGL_CreateSurface(_this, Android_Window, (NativeWindowType)data->native_window);
+            SDL_SetPointerProperty(SDL_GetWindowProperties(Android_Window), SDL_PROP_WINDOW_ANDROID_SURFACE_POINTER, data->egl_surface);
         }
 
         /* GL Context handling is done in the event loop because this function is run from the Java thread */


### PR DESCRIPTION
## Description
When the native window or surface backing the SDL window changes, e.g., when the activity is resumed, we should also update the corresponding window pointer properties (SDL_PROP_WINDOW_ANDROID_{WINDOW,SURFACE} _POINTER) so that they remain in sync. Otherwise looking up these properties can return stale pointers, causing a crash.
