### PR TITLE
android: Fix activity pause/resume with external graphics context

### DIFF
--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -1226,7 +1226,7 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeSurfaceChanged)(JNIEnv *env, j
     SDL_LockMutex(Android_ActivityMutex);
 
 #ifdef SDL_VIDEO_OPENGL_EGL
-    if (Android_Window) {
+    if (Android_Window && (Android_Window->flags & SDL_WINDOW_OPENGL)) {
         SDL_VideoDevice *_this = SDL_GetVideoDevice();
         SDL_WindowData *data = Android_Window->internal;
 
@@ -1256,7 +1256,7 @@ retry:
         SDL_WindowData *data = Android_Window->internal;
 
         /* Wait for Main thread being paused and context un-activated to release 'egl_surface' */
-        if (!data->backup_done) {
+        if ((Android_Window->flags & SDL_WINDOW_OPENGL) && !data->backup_done) {
             nb_attempt -= 1;
             if (nb_attempt == 0) {
                 SDL_SetError("Try to release egl_surface with context probably still active");


### PR DESCRIPTION
This patch fixes two issues with pausing and resuming the Android activity when an external graphics context[^1] is used:

1. When pausing, don't wait for the EGL context to be backed up if a context wasn't created in the first place.

2. When resuming, don't recreate the EGL surface unless one was requested by the user when originally creating the window.

[^1]: SDL_PROP_WINDOW_CREATE_EXTERNAL_GRAPHICS_CONTEXT_BOOLEAN