### PR TITLE
Remove `createSDLMainRunnable()` in favour of `main()` to fix multiple issues when providing custom main/runnable code

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -1032,6 +1032,8 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     // C functions we call
     public static native String nativeGetVersion();
     public static native int nativeSetupJNI();
+    public static native void nativeInitMainThread();
+    public static native void nativeCleanupMainThread();
     public static native int nativeRunMain(String library, String function, Object arguments);
     public static native void nativeLowMemory();
     public static native void nativeSendQuit();
@@ -2112,7 +2114,9 @@ class SDLMain implements Runnable {
 
         Log.v("SDL", "Running main function " + function + " from library " + library);
 
+        SDLActivity.nativeInitMainThread();
         SDLActivity.nativeRunMain(library, function, arguments);
+        SDLActivity.nativeCleanupMainThread();
 
         Log.v("SDL", "Finished main function");
 

--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -262,16 +262,6 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
         Log.v("SDL", "Finished main function");
     }
 
-
-    /**
-     * This method creates a Runnable which invokes SDL_main. The default implementation
-     * uses the getMainSharedObject() and getMainFunction() methods to invoke native
-     * code from the specified shared library.
-     */
-    protected Runnable createSDLMainRunnable() {
-        return new SDLMain();
-    }
-
     /**
      * This method returns the name of the shared object with the application entry point
      * It can be overridden by derived classes.
@@ -855,7 +845,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
                     // Start up the C app thread and enable sensor input for the first time
                     // FIXME: Why aren't we enabling sensor input at start?
 
-                    mSDLThread = new Thread(SDLActivity.mSingleton.createSDLMainRunnable(), "SDLThread");
+                    mSDLThread = new Thread(new SDLMain(), "SDLThread");
                     mSurface.enableSensor(Sensor.TYPE_ACCELEROMETER, true);
                     mSDLThread.start();
 

--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -2108,10 +2108,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
 class SDLMain implements Runnable {
     @Override
     public void run() {
-        // Runs SDL_main()
-        String library = SDLActivity.mSingleton.getMainSharedObject();
-        String function = SDLActivity.mSingleton.getMainFunction();
-        String[] arguments = SDLActivity.mSingleton.getArguments();
+        // Runs SDLActivity.main()
 
         try {
             android.os.Process.setThreadPriority(android.os.Process.THREAD_PRIORITY_DISPLAY);

--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -247,6 +247,23 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     }
 
     /**
+     * The application entry point, called on a dedicated thread (SDLThread).
+     * The default implementation uses the getMainSharedObject() and getMainFunction() methods
+     * to invoke native code from the specified shared library.
+     * It can be overridden by derived classes.
+     */
+    protected void main() {
+        String library = SDLActivity.mSingleton.getMainSharedObject();
+        String function = SDLActivity.mSingleton.getMainFunction();
+        String[] arguments = SDLActivity.mSingleton.getArguments();
+
+        Log.v("SDL", "Running main function " + function + " from library " + library);
+        SDLActivity.nativeRunMain(library, function, arguments);
+        Log.v("SDL", "Finished main function");
+    }
+
+
+    /**
      * This method creates a Runnable which invokes SDL_main. The default implementation
      * uses the getMainSharedObject() and getMainFunction() methods to invoke native
      * code from the specified shared library.
@@ -2112,13 +2129,9 @@ class SDLMain implements Runnable {
             Log.v("SDL", "modify thread properties failed " + e.toString());
         }
 
-        Log.v("SDL", "Running main function " + function + " from library " + library);
-
         SDLActivity.nativeInitMainThread();
-        SDLActivity.nativeRunMain(library, function, arguments);
+        SDLActivity.mSingleton.main();
         SDLActivity.nativeCleanupMainThread();
-
-        Log.v("SDL", "Finished main function");
 
         if (SDLActivity.mSingleton != null && !SDLActivity.mSingleton.isFinishing()) {
             // Let's finish the Activity


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Moves the initialisation code from `nativeRunMain()` to separate methods to allow a better way to customised the SDL_main entry point for non-native applications (eg. C#).

`createSDLMainRunnable()` has been removed in favour of just a regular `main()` method.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->

- Fixes https://github.com/libsdl-org/SDL/issues/9652

## TODO
- [ ] check that the code compiles
- [ ] test the code
- [ ] documentation updates