### PR TITLE
Drag Enter & Drag Exit

### DIFF
--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -217,6 +217,8 @@ typedef enum SDL_EventType
     SDL_EVENT_DROP_BEGIN,                /**< A new set of drops is beginning (NULL filename) */
     SDL_EVENT_DROP_COMPLETE,             /**< Current set of drops is now complete (NULL filename) */
     SDL_EVENT_DROP_POSITION,             /**< Position while moving over the window */
+    SDL_EVENT_DRAG_ENTER,                /**< Drag event started */
+    SDL_EVENT_DRAG_EXIT,                 /**< Drag event ended */
 
     /* Audio hotplug events */
     SDL_EVENT_AUDIO_DEVICE_ADDED = 0x1100,  /**< A new audio device is available */
@@ -784,7 +786,7 @@ typedef struct SDL_PenButtonEvent
  */
 typedef struct SDL_DropEvent
 {
-    SDL_EventType type; /**< SDL_EVENT_DROP_BEGIN or SDL_EVENT_DROP_FILE or SDL_EVENT_DROP_TEXT or SDL_EVENT_DROP_COMPLETE or SDL_EVENT_DROP_POSITION */
+    SDL_EventType type; /**< SDL_EVENT_DROP_BEGIN or SDL_EVENT_DROP_FILE or SDL_EVENT_DROP_TEXT or SDL_EVENT_DROP_COMPLETE or SDL_EVENT_DROP_POSITION or SDL_EVENT_DRAG_ENTER or SDL_EVENT_DRAG_EXIT */
     Uint32 reserved;
     Uint64 timestamp;   /**< In nanoseconds, populated using SDL_GetTicksNS() */
     SDL_WindowID windowID;    /**< The window that was dropped on, if any */

--- a/src/events/SDL_dropevents_c.h
+++ b/src/events/SDL_dropevents_c.h
@@ -23,6 +23,8 @@
 #ifndef SDL_dropevents_c_h_
 #define SDL_dropevents_c_h_
 
+extern int SDL_SendDragEnter(SDL_Window *window);
+extern int SDL_SendDragExit(SDL_Window *window);
 extern int SDL_SendDropFile(SDL_Window *window, const char *source, const char *file);
 extern int SDL_SendDropPosition(SDL_Window *window, float x, float y);
 extern int SDL_SendDropText(SDL_Window *window, const char *text);

--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -232,6 +232,8 @@ static void SDL_TransferTemporaryMemoryToEvent(SDL_EventEntry *event)
     case SDL_EVENT_DROP_TEXT:
     case SDL_EVENT_DROP_COMPLETE:
     case SDL_EVENT_DROP_POSITION:
+    case SDL_EVENT_DRAG_ENTER:
+    case SDL_EVENT_DRAG_EXIT:
         SDL_LinkTemporaryMemoryToEvent(event, event->event.drop.source);
         SDL_LinkTemporaryMemoryToEvent(event, event->event.drop.data);
         break;
@@ -760,6 +762,12 @@ static void SDL_LogEvent(const SDL_Event *event)
         PRINT_DROP_EVENT(event);
         break;
         SDL_EVENT_CASE(SDL_EVENT_DROP_POSITION)
+        PRINT_DROP_EVENT(event);
+        break;
+        SDL_EVENT_CASE(SDL_EVENT_DRAG_ENTER)
+        PRINT_DROP_EVENT(event);
+        break;
+        SDL_EVENT_CASE(SDL_EVENT_DRAG_EXIT)
         PRINT_DROP_EVENT(event);
         break;
 #undef PRINT_DROP_EVENT

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1886,6 +1886,12 @@ static void SDLTest_PrintEvent(const SDL_Event *event)
     case SDL_EVENT_DROP_COMPLETE:
         SDL_Log("SDL EVENT: Drag and drop ending");
         break;
+    case SDL_EVENT_DRAG_ENTER:
+        SDL_Log("SDL EVENT: Drag and drop enter");
+        break;
+    case SDL_EVENT_DRAG_EXIT:
+        SDL_Log("SDL EVENT: Drag and drop exit");
+        break;
     case SDL_EVENT_QUIT:
         SDL_Log("SDL EVENT: Quit requested");
         break;

--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -99,6 +99,7 @@ struct SDL_Window
     SDL_bool restore_on_show; /* Child was hidden recursively by the parent, restore when shown. */
     SDL_bool is_destroying;
     SDL_bool is_dropping; /* drag/drop in progress, expecting SDL_SendDropComplete(). */
+    SDL_bool is_dragging; /* dragging in progress, expecting SDL_SendDragExit(). */
 
     int safe_inset_left;
     int safe_inset_right;

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -89,6 +89,7 @@
 /* Handle drag-and-drop of files onto the SDL window. */
 - (NSDragOperation)draggingEntered:(id<NSDraggingInfo>)sender;
 - (NSDragOperation)draggingUpdated:(id<NSDraggingInfo>)sender;
+- (NSDragOperation)draggingExited:(id <NSDraggingInfo>)sender;
 - (BOOL)performDragOperation:(id<NSDraggingInfo>)sender;
 - (BOOL)wantsPeriodicDraggingUpdates;
 - (BOOL)validateMenuItem:(NSMenuItem *)menuItem;
@@ -166,8 +167,12 @@
 - (NSDragOperation)draggingEntered:(id<NSDraggingInfo>)sender
 {
     if (([sender draggingSourceOperationMask] & NSDragOperationGeneric) == NSDragOperationGeneric) {
+        SDL_Window *sdlwindow = [self findSDLWindow];
+        SDL_SendDragEnter(sdlwindow);
         return NSDragOperationGeneric;
     } else if (([sender draggingSourceOperationMask] & NSDragOperationCopy) == NSDragOperationCopy) {
+        SDL_Window *sdlwindow = [self findSDLWindow];
+        SDL_SendDragEnter(sdlwindow);
         return NSDragOperationCopy;
     }
 
@@ -195,6 +200,13 @@
     }
 
     return NSDragOperationNone; /* no idea what to do with this, reject it. */
+}
+
+- (NSDragOperation)draggingExited:(id <NSDraggingInfo>)sender
+{
+    SDL_Window *sdlwindow = [self findSDLWindow];
+    SDL_SendDragExit(sdlwindow);
+    return NSDragOperationNone;
 }
 
 - (BOOL)performDragOperation:(id<NSDraggingInfo>)sender

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -2045,6 +2045,8 @@ static void data_device_handle_enter(void *data, struct wl_data_device *wl_data_
                 data_device->dnd_window = NULL;
             }
         }
+
+        SDL_SendDragEnter(data_device->dnd_window);
     }
 }
 
@@ -2056,6 +2058,8 @@ static void data_device_handle_leave(void *data, struct wl_data_device *wl_data_
         Wayland_data_offer_destroy(data_device->drag_offer);
         data_device->drag_offer = NULL;
     }
+
+    SDL_SendDragExit(data_device->dnd_window);
 }
 
 static void data_device_handle_motion(void *data, struct wl_data_device *wl_data_device,

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -1346,7 +1346,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
                 data->xdnd_req = X11_PickTargetFromAtoms(display, xevent->xclient.data.l[2], xevent->xclient.data.l[3], xevent->xclient.data.l[4]);
             }
         }
-        else if (xevent.xclient.message_type == videodata->XdndLeave) {
+        else if (xevent->xclient.message_type == videodata->XdndLeave) {
 
             SDL_SendDragExit(data->window);
 

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -1324,6 +1324,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
 
         if (xevent->xclient.message_type == videodata->XdndEnter) {
 
+            SDL_SendDragEnter(data->window);
             SDL_bool use_list = xevent->xclient.data.l[1] & 1;
             data->xdnd_source = xevent->xclient.data.l[0];
             xdnd_version = (xevent->xclient.data.l[1] >> 24);
@@ -1344,6 +1345,11 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
                 /* pick from list of three */
                 data->xdnd_req = X11_PickTargetFromAtoms(display, xevent->xclient.data.l[2], xevent->xclient.data.l[3], xevent->xclient.data.l[4]);
             }
+        }
+        else if (xevent.xclient.message_type == videodata->XdndLeave) {
+
+            SDL_SendDragExit(data->window);
+
         } else if (xevent->xclient.message_type == videodata->XdndPosition) {
 
 #ifdef DEBUG_XEVENTS

--- a/src/video/x11/SDL_x11video.c
+++ b/src/video/x11/SDL_x11video.c
@@ -417,6 +417,7 @@ int X11_VideoInit(SDL_VideoDevice *_this)
     GET_ATOM(UTF8_STRING);
     GET_ATOM(PRIMARY);
     GET_ATOM(XdndEnter);
+    GET_ATOM(XdndLeave);
     GET_ATOM(XdndPosition);
     GET_ATOM(XdndStatus);
     GET_ATOM(XdndTypeList);

--- a/src/video/x11/SDL_x11video.h
+++ b/src/video/x11/SDL_x11video.h
@@ -95,6 +95,7 @@ struct SDL_VideoData
     Atom UTF8_STRING;
     Atom PRIMARY;
     Atom XdndEnter;
+    Atom XdndLeave;
     Atom XdndPosition;
     Atom XdndStatus;
     Atom XdndTypeList;


### PR DESCRIPTION
Provides Drag Enter and Drag Exit events for files being dragged
I'm opening this as a draft until Windows support is added

## Description
This adds the events:
SDL_EVENT_DRAG_ENTER
SDL_EVENT_DRAG_EXIT

The current supported platforms are:
Linux X11
Linux Wayland (TODO: testing needed)
MacOS

Planned platforms:
Windows (Requires #10415)

There are currently no errors on building for any platform when running it through Github Workflows

This code was originally coded for SDL2 so some style updates to the code might need to be done.