### PR TITLE
Don't mix keyboard and mouse raw input timestamps

### DIFF
--- a/src/test/SDL_test_memory.c
+++ b/src/test/SDL_test_memory.c
@@ -385,16 +385,15 @@ void SDLTest_LogAllocations(void)
                     pSymbol->MaxNameLen = MAX_SYM_NAME;
                     IMAGEHLP_LINE64 dbg_line;
                     dbg_line.SizeOfStruct = sizeof(dbg_line);
+                    dbg_line.FileName = "";
+                    dbg_line.LineNumber = 0;
 
                     if (dyn_dbghelp.module) {
                         if (!dyn_dbghelp.pSymFromAddr(GetCurrentProcess(), entry->stack[stack_index], &dwDisplacement, pSymbol)) {
                             SDL_strlcpy(pSymbol->Name, "???", MAX_SYM_NAME);
                             dwDisplacement = 0;
                         }
-                        if (!dyn_dbghelp.pSymGetLineFromAddr64(GetCurrentProcess(), (DWORD64)entry->stack[stack_index], &lineColumn, &dbg_line)) {
-                            dbg_line.FileName = "";
-                            dbg_line.LineNumber = 0;
-                        }
+                        dyn_dbghelp.pSymGetLineFromAddr64(GetCurrentProcess(), (DWORD64)entry->stack[stack_index], &lineColumn, &dbg_line);
                     }
                     SDL_snprintf(stack_entry_description, sizeof(stack_entry_description), "%s+0x%I64x %s:%u", pSymbol->Name, dwDisplacement, dbg_line.FileName, (Uint32)dbg_line.LineNumber);
                 }

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -785,25 +785,31 @@ void WIN_PollRawInput(SDL_VideoDevice *_this)
 
     now = SDL_GetTicksNS();
     if (total > 0) {
-        Uint64 timestamp, increment;
+        Uint64 mouse_timestamp, mouse_increment;
         Uint64 delta = (now - data->last_rawinput_poll);
-        if (total > 1 && delta <= SDL_MS_TO_NS(100)) {
+        UINT total_mouse = 0;
+        for (i = 0, input = (RAWINPUT *)data->rawinput; i < total; ++i, input = NEXTRAWINPUTBLOCK(input)) {
+            if (input->header.dwType == RIM_TYPEMOUSE) {
+                ++total_mouse;
+            }
+        }
+        if (total_mouse > 1 && delta <= SDL_MS_TO_NS(100)) {
             /* We'll spread these events over the time since the last poll */
-            timestamp = data->last_rawinput_poll;
-            increment = delta / total;
+            mouse_timestamp = data->last_rawinput_poll;
+            mouse_increment = delta / total_mouse;
         } else {
             /* Do we want to track the update rate per device? */
-            timestamp = now;
-            increment = 0;
+            mouse_timestamp = now;
+            mouse_increment = 0;
         }
         for (i = 0, input = (RAWINPUT *)data->rawinput; i < total; ++i, input = NEXTRAWINPUTBLOCK(input)) {
-            timestamp += increment;
             if (input->header.dwType == RIM_TYPEMOUSE) {
                 RAWMOUSE *rawmouse = (RAWMOUSE *)((BYTE *)input + data->rawinput_offset);
-                WIN_HandleRawMouseInput(timestamp, data, input->header.hDevice, rawmouse);
+                mouse_timestamp += mouse_increment;
+                WIN_HandleRawMouseInput(mouse_timestamp, data, input->header.hDevice, rawmouse);
             } else if (input->header.dwType == RIM_TYPEKEYBOARD) {
                 RAWKEYBOARD *rawkeyboard = (RAWKEYBOARD *)((BYTE *)input + data->rawinput_offset);
-                WIN_HandleRawKeyboardInput(timestamp, data, input->header.hDevice, rawkeyboard);
+                WIN_HandleRawKeyboardInput(now, data, input->header.hDevice, rawkeyboard);
             }
         }
     }


### PR DESCRIPTION
We want to keep mouse timestamps consistently using the same interval, and it's helpful to know when multiple keyboard events come in at the same time.