### PR TITLE
Document Android Archive and remove library creation support from Gradle project

### DIFF
--- a/android-project/app/build.gradle
+++ b/android-project/app/build.gradle
@@ -1,17 +1,11 @@
-def buildWithCMake = project.hasProperty('BUILD_WITH_CMAKE');
-def buildAsLibrary = project.hasProperty('BUILD_AS_LIBRARY');
-def buildAsApplication = !buildAsLibrary
-if (buildAsApplication) {
-    apply plugin: 'com.android.application'
-}
-else {
-    apply plugin: 'com.android.library'
+plugins {
+     id 'com.android.application'
 }
 
+def buildWithCMake = project.hasProperty('BUILD_WITH_CMAKE');
+
 android {
-    if (buildAsApplication) {
-        namespace "org.libsdl.app"
-    }
+    namespace "org.libsdl.app"
     compileSdkVersion 34
     defaultConfig {
         minSdkVersion 19
@@ -60,18 +54,6 @@ android {
     }
     lint {
         abortOnError false
-    }
-
-    if (buildAsLibrary) {
-        libraryVariants.all { variant ->
-            variant.outputs.each { output ->
-                def outputFile = output.outputFile
-                if (outputFile != null && outputFile.name.endsWith(".aar")) {
-                    def fileName = "org.libsdl.app.aar";
-                    output.outputFile = new File(outputFile.parent, fileName);
-                }
-            }
-        }
     }
 }
 

--- a/android-project/app/proguard-rules.pro
+++ b/android-project/app/proguard-rules.pro
@@ -5,7 +5,7 @@
 # directive in build.gradle.
 #
 # For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+#   https://developer.android.com/build/shrink-code
 
 # Add any project specific keep options here:
 

--- a/build-scripts/build-release.py
+++ b/build-scripts/build-release.py
@@ -609,6 +609,10 @@ class Releaser:
         aar_path =  self.dist_path / f"{self.project}-{self.version}.aar"
         added_global_files = False
         with zipfile.ZipFile(aar_path, "w", compression=zipfile.ZIP_DEFLATED) as zip_object:
+            install_txt = (self.root / "build-scripts/pkg-support/android/INSTALL.md.in").read_text()
+            install_txt = install_txt.replace("@PROJECT_VERSION@", self.version)
+            install_txt = install_txt.replace("@PROJECT_NAME@", self.project)
+            zip_object.writestr("INSTALL.md", install_txt)
             project_description = {
                 "name": self.project,
                 "version": self.version,

--- a/build-scripts/create-android-project.py
+++ b/build-scripts/create-android-project.py
@@ -114,7 +114,11 @@ def gradle_add_package_name(path: Path, package_name: str) -> None:
 
 def main() -> int:
     description = "Create a simple Android gradle project from input sources."
-    epilog = "You need to manually copy a prebuilt SDL3 Android archive into the project tree when using the aar variant."
+    epilog = textwrap.dedent("""\
+        You need to manually copy a prebuilt SDL3 Android archive into the project tree when using the aar variant.
+        
+        Any changes you have done to the sources in the Android project will be lost
+    """)
     parser = ArgumentParser(description=description, epilog=epilog, allow_abbrev=False)
     parser.add_argument("package_name", metavar="PACKAGENAME", help="Android package name (e.g. com.yourcompany.yourapp)")
     parser.add_argument("sources", metavar="SOURCE", nargs="*", help="Source code of your application. The files are copied to the output directory.")

--- a/build-scripts/pkg-support/android/INSTALL.md.in
+++ b/build-scripts/pkg-support/android/INSTALL.md.in
@@ -1,0 +1,58 @@
+
+This Android archive allows use of @PROJECT_NAME@ in your Android project, without needing to copy any SDL source.
+For integration with CMake/ndk-build, it uses [prefab](https://google.github.io/prefab/).
+
+Copy this archive (@PROJECT_NAME@-@PROJECT_VERSION@.aar) to a `app/libs` directory of your project.
+
+In `app/gradle.build` of your Android project, add:
+```
+android {
+    /* ... */
+    buildFeatures {
+        prefab true
+    }
+}
+dependencies {
+    implementation files('libs/@PROJECT_NAME@-@PROJECT_VERSION@.aar')
+    /* ... */
+}
+```
+
+If you're using CMake, add the following to your CMakeLists.txt:
+```
+find_package(@PROJECT_NAME@ REQUIRED CONFIG)
+target_link_libraries(yourgame PRIVATE @PROJECT_NAME@::@PROJECT_NAME@)
+```
+
+If you're using ndk-build, add the following somewhere after `LOCAL_MODULE := yourgame` to your `Android.mk` or `Application.mk`:
+```
+# https://google.github.io/prefab/build-systems.html
+
+# Add the prefab modules to the import path.
+$(call import-add-path,/out)
+
+# Import @PROJECT_NAME@ so we can depend on it.
+$(call import-module,prefab/@PROJECT_NAME@)
+```
+
+---
+
+For advanced users:
+
+If you want to build a 3rd party library outside Gradle,
+running the following command will extract the Android archive into a more common directory structure.
+```
+python @PROJECT_NAME@-@PROJECT_VERSION@.aar -o android_prefix
+```
+Add `--help` for a list of all available options.
+
+
+Look at the example programs in ./test (of the source archive), and check out online documentation:
+    https://wiki.libsdl.org/SDL3/FrontPage
+
+Join the SDL discourse server if you want to join the community:
+    https://discourse.libsdl.org/
+
+
+That's it!
+Sam Lantinga <slouken@libsdl.org>

--- a/docs/README-android.md
+++ b/docs/README-android.md
@@ -57,13 +57,14 @@ run:
 One limitation of this script is that all sources provided will be aggregated into
 a single directory, thus all your source files should have a unique name.
 
-Once the project is complete the script will tell you where the debug APK is located.
+Once the project is complete the script will tell you how to build the project.
 If you want to create a signed release APK, you can use the project created by this
 utility to generate it.
 
+Running the script with `--help` will list all available options, and their purposes.
+
 Finally, a word of caution: re running create-android-project.py wipes any changes you may have
 done in the build directory for the app!
-
 
 
 For more complex projects, follow these instructions:
@@ -121,6 +122,48 @@ Here's an explanation of the files in the Android project, so you can customize 
         src/main/res/values/strings.xml	- strings used in your application, including the application name
         src/main/java/org/libsdl/app/SDLActivity.java - the Java class handling the initialization and binding to SDL. Be very careful changing this, as the SDL library relies on this implementation. You should instead subclass this for your application.
 
+
+Using the SDL3 Android Archive (.aar)
+================================================================================
+
+The `create-android-project.py` script can
+./create-android-project.py com.yourcompany.yourapp < sources.list
+
+The Android archive allows use of SDL3 in your Android project, without needing to copy any SDL c or java source.
+For integration with CMake/ndk-build, it uses [prefab](https://google.github.io/prefab/).
+
+Copy the archive to a `app/libs` directory of your project and add the following to `app/gradle.build`:
+```
+android {
+    /* ... */
+    buildFeatures {
+        prefab true
+    }
+}
+dependencies {
+    implementation files('libs/@PROJECT_NAME@-@PROJECT_VERSION@.aar')
+    /* ... */
+}
+```
+
+If you're using CMake, add the following to your CMakeLists.txt:
+```
+find_package(@PROJECT_NAME@ REQUIRED CONFIG)
+target_link_libraries(yourgame PRIVATE @PROJECT_NAME@::@PROJECT_NAME@)
+```
+
+If you're using ndk-build, add the following somewhere after `LOCAL_MODULE := yourgame` to your `Android.mk` or `Application.mk`:
+```
+# https://google.github.io/prefab/build-systems.html
+
+# Add the prefab modules to the import path.
+$(call import-add-path,/out)
+
+# Import @PROJECT_NAME@ so we can depend on it.
+$(call import-module,prefab/@PROJECT_NAME@)
+```
+
+If you want to avoid adding the complete SDL source base as a subproject, or adding the Java sources of the bindings to your Android project
 
 Customizing your application name
 ================================================================================


### PR DESCRIPTION
Document creating a gradle project using Android aar archives, and remove aar generation support from the gradle files.
The android archive also includes a `INSTALL.md` text file documenting how to use the archive.

## Description

You can download an example SDL3 android archive here:
https://github.com/madebr/SDL/actions/runs/10201751044
## Existing Issue(s)
Closes #5717
