### PR TITLE
Switched SDL environment variables to hints

### DIFF
--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -759,6 +759,8 @@ The environment variables SDL_VIDEODRIVER and SDL_AUDIODRIVER have been renamed 
 
 The environment variables SDL_VIDEO_X11_WMCLASS and SDL_VIDEO_WAYLAND_WMCLASS have been removed and replaced by either using the appindentifier param to SDL_SetAppMetadata() or setting SDL_PROP_APP_METADATA_IDENTIFIER_STRING with SDL_SetAppMetadataProperty()
 
+The environment variable AUDIODEV is used exclusively to specify the audio device for the OSS and NetBSD audio drivers. Its use in the ALSA driver has been replaced with the hint SDL_HINT_AUDIO_ALSA_DEFAULT_DEVICE and in the sndio driver with the environment variable AUDIODEVICE.
+
 The following hints have been renamed:
 * SDL_HINT_VIDEODRIVER => SDL_VIDEO_DRIVER
 * SDL_HINT_AUDIODRIVER => SDL_HINT_AUDIO_DRIVER

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -801,6 +801,9 @@ The following hints have been removed:
 * SDL_HINT_XINPUT_USE_OLD_JOYSTICK_MAPPING
 * SDL_HINT_AUDIO_DEVICE_APP_NAME - replaced by either using the appname param to SDL_SetAppMetadata() or setting SDL_PROP_APP_METADATA_NAME_STRING with SDL_SetAppMetadataProperty()
 
+The following environment variables have been renamed:
+* SDL_PATH_DSP => AUDIODEV
+
 The following environment variables have been removed:
 * SDL_AUDIO_ALSA_DEBUG - replaced by setting the hint SDL_HINT_LOGGING to "audio=debug"
 * SDL_DUMMYAUDIODELAY - replaced with the hint SDL_HINT_AUDIO_DUMMY_TIMESCALE which allows scaling the audio time rather than specifying an absolute delay.

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -762,7 +762,7 @@ The environment variables SDL_VIDEO_X11_WMCLASS and SDL_VIDEO_WAYLAND_WMCLASS ha
 The environment variable AUDIODEV is used exclusively to specify the audio device for the OSS and NetBSD audio drivers. Its use in the ALSA driver has been replaced with the hint SDL_HINT_AUDIO_ALSA_DEFAULT_DEVICE and in the sndio driver with the environment variable AUDIODEVICE.
 
 The following hints have been renamed:
-* SDL_HINT_VIDEODRIVER => SDL_VIDEO_DRIVER
+* SDL_HINT_VIDEODRIVER => SDL_HINT_VIDEO_DRIVER
 * SDL_HINT_AUDIODRIVER => SDL_HINT_AUDIO_DRIVER
 * SDL_HINT_ALLOW_TOPMOST => SDL_HINT_WINDOW_ALLOW_TOPMOST
 * SDL_HINT_DIRECTINPUT_ENABLED => SDL_HINT_JOYSTICK_DIRECTINPUT
@@ -804,7 +804,9 @@ The following hints have been removed:
 * SDL_HINT_AUDIO_DEVICE_APP_NAME - replaced by either using the appname param to SDL_SetAppMetadata() or setting SDL_PROP_APP_METADATA_NAME_STRING with SDL_SetAppMetadataProperty()
 
 The following environment variables have been renamed:
+* SDL_AUDIODRIVER => SDL_AUDIO_DRIVER
 * SDL_PATH_DSP => AUDIODEV
+* SDL_VIDEODRIVER => SDL_VIDEO_DRIVER
 
 The following environment variables have been removed:
 * SDL_AUDIO_ALSA_DEBUG - replaced by setting the hint SDL_HINT_LOGGING to "audio=debug"
@@ -2005,7 +2007,7 @@ The following symbols have been renamed:
 
 Several video backends have had their names lower-cased ("kmsdrm", "rpi", "android", "psp", "ps2", "vita"). SDL already does a case-insensitive compare for SDL_HINT_VIDEO_DRIVER tests, but if your app is calling SDL_GetVideoDriver() or SDL_GetCurrentVideoDriver() and doing case-sensitive compares on those strings, please update your code.
 
-SDL_VideoInit() and SDL_VideoQuit() have been removed. Instead you can call SDL_InitSubSystem() and SDL_QuitSubSystem() with SDL_INIT_VIDEO, which will properly refcount the subsystems. You can choose a specific video driver using SDL_VIDEO_DRIVER hint.
+SDL_VideoInit() and SDL_VideoQuit() have been removed. Instead you can call SDL_InitSubSystem() and SDL_QuitSubSystem() with SDL_INIT_VIDEO, which will properly refcount the subsystems. You can choose a specific video driver using SDL_HINT_VIDEO_DRIVER.
 
 Rather than iterating over displays using display index, there is a new function SDL_GetDisplays() to get the current list of displays, and functions which used to take a display index now take SDL_DisplayID, with an invalid ID being 0.
 ```c

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -815,6 +815,8 @@ The following environment variables have been removed:
 * SDL_HAPTIC_GAIN_MAX
 * SDL_HIDAPI_DISABLE_LIBUSB - replaced with the hint SDL_HINT_HIDAPI_LIBUSB
 * SDL_HIDAPI_JOYSTICK_DISABLE_UDEV - replaced with the hint SDL_HINT_HIDAPI_UDEV
+* SDL_INPUT_FREEBSD_KEEP_KBD - replaced with the hint SDL_HINT_MUTE_CONSOLE_KEYBOARD
+* SDL_INPUT_LINUX_KEEP_KBD - replaced with the hint SDL_HINT_MUTE_CONSOLE_KEYBOARD
 * VITA_DISABLE_TOUCH_BACK - replaced with the hint SDL_HINT_VITA_ENABLE_BACK_TOUCH
 * VITA_DISABLE_TOUCH_FRONT - replaced with the hint SDL_HINT_VITA_ENABLE_FRONT_TOUCH
 * VITA_MODULE_PATH - replaced with the hint SDL_HINT_VITA_MODULE_PATH

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -802,6 +802,7 @@ The following hints have been removed:
 * SDL_HINT_AUDIO_DEVICE_APP_NAME - replaced by either using the appname param to SDL_SetAppMetadata() or setting SDL_PROP_APP_METADATA_NAME_STRING with SDL_SetAppMetadataProperty()
 
 The following environment variables have been removed:
+* SDL_AUDIO_ALSA_DEBUG - replaced by setting the hint SDL_HINT_LOGGING to "audio=debug"
 * SDL_DUMMYAUDIODELAY - replaced with the hint SDL_HINT_AUDIO_DUMMY_TIMESCALE which allows scaling the audio time rather than specifying an absolute delay.
 
 The following functions have been removed:

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -808,6 +808,9 @@ The following environment variables have been renamed:
 
 The following environment variables have been removed:
 * SDL_AUDIO_ALSA_DEBUG - replaced by setting the hint SDL_HINT_LOGGING to "audio=debug"
+* SDL_DISKAUDIODELAY - replaced with the hint SDL_HINT_AUDIO_DISK_TIMESCALE which allows scaling the audio time rather than specifying an absolute delay.
+* SDL_DISKAUDIOFILE - replaced with the hint SDL_HINT_AUDIO_DISK_OUTPUT_FILE
+* SDL_DISKAUDIOFILEIN - replaced with the hint SDL_HINT_AUDIO_DISK_INPUT_FILE
 * SDL_DUMMYAUDIODELAY - replaced with the hint SDL_HINT_AUDIO_DUMMY_TIMESCALE which allows scaling the audio time rather than specifying an absolute delay.
 
 The following functions have been removed:

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -755,6 +755,23 @@ SDL_AddHintCallback() now returns a standard int result instead of void, returni
 
 Calling SDL_GetHint() with the name of the hint being changed from within a hint callback will now return the new value rather than the old value. The old value is still passed as a parameter to the hint callback.
 
+The environment variables SDL_VIDEODRIVER and SDL_AUDIODRIVER have been renamed to SDL_VIDEO_DRIVER and SDL_AUDIO_DRIVER.
+
+The environment variables SDL_VIDEO_X11_WMCLASS and SDL_VIDEO_WAYLAND_WMCLASS have been removed and replaced by either using the appindentifier param to SDL_SetAppMetadata() or setting SDL_PROP_APP_METADATA_IDENTIFIER_STRING with SDL_SetAppMetadataProperty()
+
+The following hints have been renamed:
+* SDL_HINT_VIDEODRIVER => SDL_VIDEO_DRIVER
+* SDL_HINT_AUDIODRIVER => SDL_HINT_AUDIO_DRIVER
+* SDL_HINT_ALLOW_TOPMOST => SDL_HINT_WINDOW_ALLOW_TOPMOST
+* SDL_HINT_DIRECTINPUT_ENABLED => SDL_HINT_JOYSTICK_DIRECTINPUT
+* SDL_HINT_GDK_TEXTINPUT_DEFAULT => SDL_HINT_GDK_TEXTINPUT_DEFAULT_TEXT
+* SDL_HINT_JOYSTICK_GAMECUBE_RUMBLE_BRAKE => SDL_HINT_JOYSTICK_HIDAPI_GAMECUBE_RUMBLE_BRAKE
+* SDL_HINT_LINUX_DIGITAL_HATS => SDL_HINT_JOYSTICK_LINUX_DIGITAL_HATS
+* SDL_HINT_LINUX_HAT_DEADZONES => SDL_HINT_JOYSTICK_LINUX_HAT_DEADZONES
+* SDL_HINT_LINUX_JOYSTICK_CLASSIC => SDL_HINT_JOYSTICK_LINUX_CLASSIC
+* SDL_HINT_LINUX_JOYSTICK_DEADZONES => SDL_HINT_JOYSTICK_LINUX_DEADZONES
+* SDL_HINT_VIDEO_WAYLAND_EMULATE_MOUSE_WARP => SDL_HINT_MOUSE_EMULATE_WARP_WITH_RELATIVE
+
 The following hints have been removed:
 * SDL_HINT_ACCELEROMETER_AS_JOYSTICK
 * SDL_HINT_ANDROID_BLOCK_ON_PAUSE_PAUSEAUDIO - the audio will be paused when the application is paused, and SDL_HINT_ANDROID_BLOCK_ON_PAUSE can be used to control that
@@ -784,20 +801,8 @@ The following hints have been removed:
 * SDL_HINT_XINPUT_USE_OLD_JOYSTICK_MAPPING
 * SDL_HINT_AUDIO_DEVICE_APP_NAME - replaced by either using the appname param to SDL_SetAppMetadata() or setting SDL_PROP_APP_METADATA_NAME_STRING with SDL_SetAppMetadataProperty()
 
-* Renamed hints SDL_HINT_VIDEODRIVER and SDL_HINT_AUDIODRIVER to SDL_HINT_VIDEO_DRIVER and SDL_HINT_AUDIO_DRIVER
-* Renamed environment variables SDL_VIDEODRIVER and SDL_AUDIODRIVER to SDL_VIDEO_DRIVER and SDL_AUDIO_DRIVER
-* The environment variables SDL_VIDEO_X11_WMCLASS and SDL_VIDEO_WAYLAND_WMCLASS have been removed and replaced by either using the appindentifier param to SDL_SetAppMetadata() or setting SDL_PROP_APP_METADATA_IDENTIFIER_STRING with SDL_SetAppMetadataProperty()
-
-The following hints have been renamed:
-* SDL_HINT_ALLOW_TOPMOST => SDL_HINT_WINDOW_ALLOW_TOPMOST
-* SDL_HINT_DIRECTINPUT_ENABLED => SDL_HINT_JOYSTICK_DIRECTINPUT
-* SDL_HINT_GDK_TEXTINPUT_DEFAULT => SDL_HINT_GDK_TEXTINPUT_DEFAULT_TEXT
-* SDL_HINT_JOYSTICK_GAMECUBE_RUMBLE_BRAKE => SDL_HINT_JOYSTICK_HIDAPI_GAMECUBE_RUMBLE_BRAKE
-* SDL_HINT_LINUX_DIGITAL_HATS => SDL_HINT_JOYSTICK_LINUX_DIGITAL_HATS
-* SDL_HINT_LINUX_HAT_DEADZONES => SDL_HINT_JOYSTICK_LINUX_HAT_DEADZONES
-* SDL_HINT_LINUX_JOYSTICK_CLASSIC => SDL_HINT_JOYSTICK_LINUX_CLASSIC
-* SDL_HINT_LINUX_JOYSTICK_DEADZONES => SDL_HINT_JOYSTICK_LINUX_DEADZONES
-* SDL_HINT_VIDEO_WAYLAND_EMULATE_MOUSE_WARP => SDL_HINT_MOUSE_EMULATE_WARP_WITH_RELATIVE
+The following environment variables have been removed:
+* SDL_DUMMYAUDIODELAY - replaced with the hint SDL_HINT_AUDIO_DUMMY_TIMESCALE which allows scaling the audio time rather than specifying an absolute delay.
 
 The following functions have been removed:
 * SDL_ClearHints() - replaced with SDL_ResetHints()

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -812,6 +812,12 @@ The following environment variables have been removed:
 * SDL_DISKAUDIOFILE - replaced with the hint SDL_HINT_AUDIO_DISK_OUTPUT_FILE
 * SDL_DISKAUDIOFILEIN - replaced with the hint SDL_HINT_AUDIO_DISK_INPUT_FILE
 * SDL_DUMMYAUDIODELAY - replaced with the hint SDL_HINT_AUDIO_DUMMY_TIMESCALE which allows scaling the audio time rather than specifying an absolute delay.
+* VITA_DISABLE_TOUCH_BACK - replaced with the hint SDL_HINT_VITA_ENABLE_BACK_TOUCH
+* VITA_DISABLE_TOUCH_FRONT - replaced with the hint SDL_HINT_VITA_ENABLE_FRONT_TOUCH
+* VITA_MODULE_PATH - replaced with the hint SDL_HINT_VITA_MODULE_PATH
+* VITA_PVR_OGL - replaced with the hint SDL_HINT_VITA_PVR_OPENGL
+* VITA_PVR_SKIP_INIT - replaced with the hint SDL_HINT_VITA_PVR_INIT
+* VITA_RESOLUTION - replaced with the hint SDL_HINT_VITA_RESOLUTION
 
 The following functions have been removed:
 * SDL_ClearHints() - replaced with SDL_ResetHints()

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -812,6 +812,8 @@ The following environment variables have been removed:
 * SDL_DISKAUDIOFILE - replaced with the hint SDL_HINT_AUDIO_DISK_OUTPUT_FILE
 * SDL_DISKAUDIOFILEIN - replaced with the hint SDL_HINT_AUDIO_DISK_INPUT_FILE
 * SDL_DUMMYAUDIODELAY - replaced with the hint SDL_HINT_AUDIO_DUMMY_TIMESCALE which allows scaling the audio time rather than specifying an absolute delay.
+* SDL_HIDAPI_DISABLE_LIBUSB - replaced with the hint SDL_HINT_HIDAPI_LIBUSB
+* SDL_HIDAPI_JOYSTICK_DISABLE_UDEV - replaced with the hint SDL_HINT_HIDAPI_UDEV
 * VITA_DISABLE_TOUCH_BACK - replaced with the hint SDL_HINT_VITA_ENABLE_BACK_TOUCH
 * VITA_DISABLE_TOUCH_FRONT - replaced with the hint SDL_HINT_VITA_ENABLE_FRONT_TOUCH
 * VITA_MODULE_PATH - replaced with the hint SDL_HINT_VITA_MODULE_PATH

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -812,6 +812,7 @@ The following environment variables have been removed:
 * SDL_DISKAUDIOFILE - replaced with the hint SDL_HINT_AUDIO_DISK_OUTPUT_FILE
 * SDL_DISKAUDIOFILEIN - replaced with the hint SDL_HINT_AUDIO_DISK_INPUT_FILE
 * SDL_DUMMYAUDIODELAY - replaced with the hint SDL_HINT_AUDIO_DUMMY_TIMESCALE which allows scaling the audio time rather than specifying an absolute delay.
+* SDL_HAPTIC_GAIN_MAX
 * SDL_HIDAPI_DISABLE_LIBUSB - replaced with the hint SDL_HINT_HIDAPI_LIBUSB
 * SDL_HIDAPI_JOYSTICK_DISABLE_UDEV - replaced with the hint SDL_HINT_HIDAPI_UDEV
 * VITA_DISABLE_TOUCH_BACK - replaced with the hint SDL_HINT_VITA_ENABLE_BACK_TOUCH

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -3374,6 +3374,17 @@ extern "C" {
 #define SDL_HINT_VITA_TOUCH_MOUSE_DEVICE    "SDL_VITA_TOUCH_MOUSE_DEVICE"
 
 /**
+ * A variable overriding the display index used in SDL_Vulkan_CreateSurface()
+ *
+ * The display index starts at 0, which is the default.
+ *
+ * This hint should be set before calling SDL_Vulkan_CreateSurface()
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_VULKAN_DISPLAY "SDL_VULKAN_DISPLAY"
+
+/**
  * Specify the Vulkan library to load.
  *
  * This hint should be set before creating a Vulkan window or calling SDL_Vulkan_LoadLibrary().

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2437,6 +2437,15 @@ extern "C" {
 #define SDL_HINT_NO_SIGNAL_HANDLERS   "SDL_NO_SIGNAL_HANDLERS"
 
 /**
+ * Specify the OpenGL library to load.
+ *
+ * This hint should be set before creating an OpenGL window or creating an OpenGL context.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_OPENGL_LIBRARY "SDL_OPENGL_LIBRARY"
+
+/**
  * A variable controlling what driver to use for OpenGL ES contexts.
  *
  * On some platforms, currently Windows and X11, OpenGL drivers may support
@@ -3340,6 +3349,15 @@ extern "C" {
  * \since This hint is available since SDL 3.0.0.
  */
 #define SDL_HINT_VITA_TOUCH_MOUSE_DEVICE    "SDL_VITA_TOUCH_MOUSE_DEVICE"
+
+/**
+ * Specify the Vulkan library to load.
+ *
+ * This hint should be set before creating a Vulkan window or calling SDL_Vulkan_LoadLibrary().
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_VULKAN_LIBRARY "SDL_VULKAN_LIBRARY"
 
 /**
  * A variable controlling how the fact chunk affects the loading of a WAVE

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -339,6 +339,17 @@ extern "C" {
 #define SDL_HINT_AUDIO_DRIVER "SDL_AUDIO_DRIVER"
 
 /**
+ * A variable controlling the audio rate when using the dummy audio driver.
+ *
+ * The dummy audio driver normally simulates real-time for the audio rate that was specified, but you can use this variable to adjust this rate higher or lower down to 0. The default value is "1.0".
+ *
+ * This hint should be set before an audio device is opened.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_AUDIO_DUMMY_TIMESCALE "SDL_AUDIO_DUMMY_TIMESCALE"
+
+/**
  * A variable controlling the default audio format.
  *
  * If the application doesn't specify the audio format when opening the device, this hint can be used to specify a default format that will be used.

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -198,6 +198,17 @@ extern "C" {
 #define SDL_HINT_APPLE_TV_REMOTE_ALLOW_ROTATION "SDL_APPLE_TV_REMOTE_ALLOW_ROTATION"
 
 /**
+ * Specify the default ALSA audio device name.
+ *
+ * This variable is a specific audio device to open when the "default" audio device is used. By default if 4 channel audio is requested, the "plug:surround40" device will be opened and if 6 channel audio is requested the "plug:surround51" device will be opened.
+ *
+ * This hint should be set before an audio device is opened.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_AUDIO_ALSA_DEFAULT_DEVICE "SDL_AUDIO_ALSA_DEFAULT_DEVICE"
+
+/**
  * A variable controlling the audio category on iOS and macOS.
  *
  * The variable can be set to the following values:

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -3038,6 +3038,18 @@ extern "C" {
 #define SDL_HINT_VIDEO_DRIVER "SDL_VIDEO_DRIVER"
 
 /**
+ * A variable controlling whether the dummy video driver saves output frames.
+ *
+ * - "0": Video frames are not saved to disk. (default)
+ * - "1": Video frames are saved to files in the format "SDL_windowX-Y.bmp", where X is the window ID, and Y is the frame number.
+ *
+ * This hint can be set anytime.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_VIDEO_DUMMY_SAVE_FRAMES "SDL_VIDEO_DUMMY_SAVE_FRAMES"
+
+/**
  * If eglGetPlatformDisplay fails, fall back to calling eglGetDisplay.
  *
  * The variable can be set to one of the following values:
@@ -3100,6 +3112,20 @@ extern "C" {
  * \since This hint is available since SDL 3.0.0.
  */
 #define SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS   "SDL_VIDEO_MINIMIZE_ON_FOCUS_LOSS"
+
+/**
+ * A variable controlling whether the offscreen video driver saves output frames.
+ *
+ * This only saves frames that are generated using software rendering, not accelerated OpenGL rendering.
+ *
+ * - "0": Video frames are not saved to disk. (default)
+ * - "1": Video frames are saved to files in the format "SDL_windowX-Y.bmp", where X is the window ID, and Y is the frame number.
+ *
+ * This hint can be set anytime.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_VIDEO_OFFSCREEN_SAVE_FRAMES "SDL_VIDEO_OFFSCREEN_SAVE_FRAMES"
 
 /**
  * A variable controlling whether all window operations will block until

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -3301,6 +3301,20 @@ extern "C" {
 #define SDL_HINT_VIDEO_X11_NET_WM_PING      "SDL_VIDEO_X11_NET_WM_PING"
 
 /**
+ * A variable controlling whether SDL uses DirectColor visuals.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "0": Disable DirectColor visuals.
+ * - "1": Enable DirectColor visuals. (default)
+ *
+ * This hint should be set before initializing the video subsystem.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_VIDEO_X11_NODIRECTCOLOR "SDL_VIDEO_X11_NODIRECTCOLOR"
+
+/**
  * A variable forcing the content scaling factor for X11 displays.
  *
  * The variable can be set to a floating point value in the range 1.0-10.0f

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -686,6 +686,21 @@ extern "C" {
 #define SDL_HINT_ENABLE_SCREEN_KEYBOARD "SDL_ENABLE_SCREEN_KEYBOARD"
 
 /**
+ * A variable containing a list of evdev devices to use if udev is not available.
+ *
+ * The list of devices is in the form:
+ *
+ *  deviceclass:path[,deviceclass:path[,...]]
+ *
+ * where device class is an integer representing the SDL_UDEV_deviceclass and path is the full path to the event device.
+ *
+ * This hint should be set before SDL is initialized.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_EVDEV_DEVICES "SDL_EVDEV_DEVICES"
+
+/**
  * A variable controlling verbosity of the logging of SDL events pushed onto
  * the internal queue.
  *

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -216,6 +216,17 @@ extern "C" {
 #define SDL_HINT_AUDIO_CATEGORY   "SDL_AUDIO_CATEGORY"
 
 /**
+ * A variable controlling the default audio channel count.
+ *
+ * If the application doesn't specify the audio channel count when opening the device, this hint can be used to specify a default channel count that will be used. This defaults to "1" for recording and "2" for playback devices.
+ *
+ * This hint should be set before an audio device is opened.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_AUDIO_CHANNELS "SDL_AUDIO_CHANNELS"
+
+/**
  * Specify an application icon name for an audio device.
  *
  * Some audio backends (such as Pulseaudio and Pipewire) allow you to set an
@@ -326,6 +337,41 @@ extern "C" {
  * \since This hint is available since SDL 3.0.0.
  */
 #define SDL_HINT_AUDIO_DRIVER "SDL_AUDIO_DRIVER"
+
+/**
+ * A variable controlling the default audio format.
+ *
+ * If the application doesn't specify the audio format when opening the device, this hint can be used to specify a default format that will be used.
+ *
+ * The variable can be set to the following values:
+ * - "U8": Unsigned 8-bit audio
+ * - "S8": Signed 8-bit audio
+ * - "S16LE": Signed 16-bit little-endian audio
+ * - "S16BE": Signed 16-bit big-endian audio
+ * - "S16": Signed 16-bit native-endian audio (default)
+ * - "S32LE": Signed 32-bit little-endian audio
+ * - "S32BE": Signed 32-bit big-endian audio
+ * - "S32": Signed 32-bit native-endian audio
+ * - "F32LE": Floating point little-endian audio
+ * - "F32BE": Floating point big-endian audio
+ * - "F32": Floating point native-endian audio
+ *
+ * This hint should be set before an audio device is opened.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_AUDIO_FORMAT "SDL_AUDIO_FORMAT"
+
+/**
+ * A variable controlling the default audio frequency.
+ *
+ * If the application doesn't specify the audio frequency when opening the device, this hint can be used to specify a default frequency that will be used. This defaults to "44100".
+ *
+ * This hint should be set before an audio device is opened.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_AUDIO_FREQUENCY "SDL_AUDIO_FREQUENCY"
 
 /**
  * A variable that causes SDL to not ignore audio "monitors".

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -931,6 +931,52 @@ extern "C" {
 #define SDL_HINT_GDK_TEXTINPUT_TITLE "SDL_GDK_TEXTINPUT_TITLE"
 
 /**
+ * A variable to control whether HIDAPI uses libusb for device access.
+ *
+ * By default libusb will only be used for a few devices that require direct USB access, and this can be controlled with SDL_HINT_HIDAPI_LIBUSB_WHITELIST.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "0": HIDAPI will not use libusb for device access.
+ * - "1": HIDAPI will use libusb for device access if available. (default)
+ *
+ * This hint should be set before SDL is initialized.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_HIDAPI_LIBUSB "SDL_HIDAPI_LIBUSB"
+
+/**
+ * A variable to control whether HIDAPI uses libusb only for whitelisted devices.
+ *
+ * By default libusb will only be used for a few devices that require direct USB access.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "0": HIDAPI will use libusb for all device access.
+ * - "1": HIDAPI will use libusb only for whitelisted devices. (default)
+ *
+ * This hint should be set before SDL is initialized.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_HIDAPI_LIBUSB_WHITELIST "SDL_HIDAPI_LIBUSB_WHITELIST"
+
+/**
+ * A variable to control whether HIDAPI uses udev for device detection.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "0": HIDAPI will poll for device changes.
+ * - "1": HIDAPI will use udev for device detection. (default)
+ *
+ * This hint should be set before SDL is initialized.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_HIDAPI_UDEV "SDL_HIDAPI_UDEV"
+
+/**
  * A variable to control whether SDL_hid_enumerate() enumerates all HID
  * devices or only controllers.
  *

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -336,6 +336,39 @@ extern "C" {
 #define SDL_HINT_AUDIO_DEVICE_STREAM_ROLE "SDL_AUDIO_DEVICE_STREAM_ROLE"
 
 /**
+ * Specify the input file when recording audio using the disk audio driver.
+ *
+ * This defaults to "sdlaudio-in.raw"
+ *
+ * This hint should be set before an audio device is opened.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_AUDIO_DISK_INPUT_FILE "SDL_AUDIO_DISK_INPUT_FILE"
+
+/**
+ * Specify the output file when playing audio using the disk audio driver.
+ *
+ * This defaults to "sdlaudio.raw"
+ *
+ * This hint should be set before an audio device is opened.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_AUDIO_DISK_OUTPUT_FILE "SDL_AUDIO_DISK_OUTPUT_FILE"
+
+/**
+ * A variable controlling the audio rate when using the disk audio driver.
+ *
+ * The disk audio driver normally simulates real-time for the audio rate that was specified, but you can use this variable to adjust this rate higher or lower down to 0. The default value is "1.0".
+ *
+ * This hint should be set before an audio device is opened.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_AUDIO_DISK_TIMESCALE "SDL_AUDIO_DISK_TIMESCALE"
+
+/**
  * A variable that specifies an audio backend to use.
  *
  * By default, SDL will try all available audio backends in a reasonable order

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -3341,6 +3341,17 @@ extern "C" {
 #define SDL_HINT_WAVE_FACT_CHUNK   "SDL_WAVE_FACT_CHUNK"
 
 /**
+ * A variable controlling the maximum number of chunks in a WAVE file.
+ *
+ * This sets an upper bound on the number of chunks in a WAVE file to avoid wasting time on malformed or corrupt WAVE files. This defaults to "10000".
+ *
+ * This hint should be set before calling SDL_LoadWAV() or SDL_LoadWAV_IO()
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_WAVE_CHUNK_LIMIT   "SDL_WAVE_CHUNK_LIMIT"
+
+/**
  * A variable controlling how the size of the RIFF chunk affects the loading
  * of a WAVE file.
  *
@@ -3351,7 +3362,7 @@ extern "C" {
  * Note that files that have trailing data unrelated to the WAVE file or
  * corrupt files may slow down the loading process without a reliable
  * boundary. By default, SDL stops after 10000 chunks to prevent wasting time.
- * Use the environment variable SDL_WAVE_CHUNK_LIMIT to adjust this value.
+ * Use SDL_HINT_WAVE_CHUNK_LIMIT to adjust this value.
  *
  * The variable can be set to the following values:
  *

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -3358,6 +3358,86 @@ extern "C" {
 #define SDL_HINT_VIDEO_X11_XRANDR           "SDL_VIDEO_X11_XRANDR"
 
 /**
+ * A variable controlling whether touch should be enabled on the back panel of the PlayStation Vita.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "0": Disable touch on the back panel.
+ * - "1": Enable touch on the back panel. (default)
+ *
+ * This hint should be set before SDL is initialized.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_VITA_ENABLE_BACK_TOUCH "SDL_VITA_ENABLE_BACK_TOUCH"
+
+/**
+ * A variable controlling whether touch should be enabled on the front panel of the PlayStation Vita.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "0": Disable touch on the front panel.
+ * - "1": Enable touch on the front panel. (default)
+ *
+ * This hint should be set before SDL is initialized.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_VITA_ENABLE_FRONT_TOUCH "SDL_VITA_ENABLE_FRONT_TOUCH"
+
+/**
+ * A variable controlling the module path on the PlayStation Vita.
+ *
+ * This hint defaults to "app0:module"
+ *
+ * This hint should be set before SDL is initialized.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_VITA_MODULE_PATH "SDL_VITA_MODULE_PATH"
+
+/**
+ * A variable controlling whether to perform PVR initialization on the PlayStation Vita.
+ *
+ * - "0": Skip PVR initialization.
+ * - "1": Perform the normal PVR initialization. (default)
+ *
+ * This hint should be set before SDL is initialized.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_VITA_PVR_INIT "SDL_VITA_PVR_INIT"
+
+/**
+ * A variable overriding the resolution reported on the PlayStation Vita.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "544": 544p (default)
+ * - "720": 725p for PSTV
+ * - "1080": 1088i for PSTV
+ *
+ * This hint should be set before SDL is initialized.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_VITA_RESOLUTION "SDL_VITA_RESOLUTION"
+
+/**
+ * A variable controlling whether OpenGL should be used instead of OpenGL ES on the PlayStation Vita.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "0": Use OpenGL ES. (default)
+ * - "1": Use OpenGL.
+ *
+ * This hint should be set before SDL is initialized.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_VITA_PVR_OPENGL "SDL_VITA_PVR_OPENGL"
+
+/**
  * A variable controlling which touchpad should generate synthetic mouse
  * events.
  *

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2483,6 +2483,22 @@ extern "C" {
 #define SDL_HINT_MOUSE_TOUCH_EVENTS    "SDL_MOUSE_TOUCH_EVENTS"
 
 /**
+ * A variable controlling whether the keyboard should be muted on the console.
+ *
+ * Normally the keyboard is muted while SDL applications are running so that keyboard input doesn't show up as key strokes on the console. This hint allows you to turn that off for debugging purposes.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "0": Allow keystrokes to go through to the console.
+ * - "1": Mute keyboard input so it doesn't show up on the console. (default)
+ *
+ * This hint should be set before SDL is initialized.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_MUTE_CONSOLE_KEYBOARD "SDL_MUTE_CONSOLE_KEYBOARD"
+
+/**
  * Tell SDL not to catch the SIGINT or SIGTERM signals on POSIX platforms.
  *
  * The variable can be set to the following values:

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -3863,6 +3863,17 @@ extern "C" {
 #define SDL_HINT_X11_WINDOW_TYPE "SDL_X11_WINDOW_TYPE"
 
 /**
+ * Specify the XCB library to load for the X11 driver.
+ *
+ * This defaults to "libX11-xcb.so"
+ *
+ * This hint should be set before initializing the video subsystem.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_X11_XCB_LIBRARY "SDL_X11_XCB_LIBRARY"
+
+/**
  * A variable controlling whether XInput should be used for controller
  * handling.
  *

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -3312,6 +3312,15 @@ extern "C" {
 #define SDL_HINT_VIDEO_X11_SCALING_FACTOR      "SDL_VIDEO_X11_SCALING_FACTOR"
 
 /**
+ * A variable forcing the visual ID used for X11 display modes.
+ *
+ * This hint should be set before initializing the video subsystem.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_VIDEO_X11_VISUALID "SDL_VIDEO_X11_VISUALID"
+
+/**
  * A variable forcing the visual ID chosen for new X11 windows.
  *
  * This hint should be set before creating a window.

--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -1577,9 +1577,9 @@ static void PrepareAudioFormat(SDL_bool recording, SDL_AudioSpec *spec)
     if (spec->freq == 0) {
         spec->freq = recording ? DEFAULT_AUDIO_RECORDING_FREQUENCY : DEFAULT_AUDIO_PLAYBACK_FREQUENCY;
 
-        const char *env = SDL_getenv("SDL_AUDIO_FREQUENCY");  // !!! FIXME: should be a hint?
-        if (env) {
-            const int val = SDL_atoi(env);
+        const char *hint = SDL_GetHint(SDL_HINT_AUDIO_FREQUENCY);
+        if (hint) {
+            const int val = SDL_atoi(hint);
             if (val > 0) {
                 spec->freq = val;
             }
@@ -1588,9 +1588,10 @@ static void PrepareAudioFormat(SDL_bool recording, SDL_AudioSpec *spec)
 
     if (spec->channels == 0) {
         spec->channels = recording ? DEFAULT_AUDIO_RECORDING_CHANNELS : DEFAULT_AUDIO_PLAYBACK_CHANNELS;;
-        const char *env = SDL_getenv("SDL_AUDIO_CHANNELS");
-        if (env) {
-            const int val = SDL_atoi(env);
+
+        const char *hint = SDL_GetHint(SDL_HINT_AUDIO_CHANNELS);
+        if (hint) {
+            const int val = SDL_atoi(hint);
             if (val > 0) {
                 spec->channels = val;
             }
@@ -1598,7 +1599,7 @@ static void PrepareAudioFormat(SDL_bool recording, SDL_AudioSpec *spec)
     }
 
     if (spec->format == 0) {
-        const SDL_AudioFormat val = ParseAudioFormatString(SDL_getenv("SDL_AUDIO_FORMAT"));
+        const SDL_AudioFormat val = ParseAudioFormatString(SDL_GetHint(SDL_HINT_AUDIO_FORMAT));
         spec->format = (val != 0) ? val : (recording ? DEFAULT_AUDIO_RECORDING_FORMAT : DEFAULT_AUDIO_PLAYBACK_FORMAT);
     }
 }

--- a/src/audio/SDL_audiodev.c
+++ b/src/audio/SDL_audiodev.c
@@ -87,10 +87,7 @@ static void SDL_EnumUnixAudioDevices_Internal(const SDL_bool recording, const SD
     }
 
     // Figure out what our audio device is
-    audiodev = SDL_getenv("SDL_PATH_DSP");
-    if (!audiodev) {
-        audiodev = SDL_getenv("AUDIODEV");
-    }
+    audiodev = SDL_getenv("AUDIODEV");
     if (!audiodev) {
         if (classic) {
             audiodev = SDL_PATH_DEV_AUDIO;

--- a/src/audio/SDL_wave.c
+++ b/src/audio/SDL_wave.c
@@ -1774,7 +1774,7 @@ static int WaveLoad(SDL_IOStream *src, WaveFile *file, SDL_AudioSpec *spec, Uint
     int result;
     Uint32 chunkcount = 0;
     Uint32 chunkcountlimit = 10000;
-    const char *envchunkcountlimit;
+    const char *hint;
     Sint64 RIFFstart, RIFFend, lastchunkpos;
     SDL_bool RIFFlengthknown = SDL_FALSE;
     WaveFormat *format = &file->format;
@@ -1787,10 +1787,10 @@ static int WaveLoad(SDL_IOStream *src, WaveFile *file, SDL_AudioSpec *spec, Uint
     SDL_zero(fmtchunk);
     SDL_zero(datachunk);
 
-    envchunkcountlimit = SDL_getenv("SDL_WAVE_CHUNK_LIMIT");
-    if (envchunkcountlimit) {
+    hint = SDL_GetHint(SDL_HINT_WAVE_CHUNK_LIMIT);
+    if (hint) {
         unsigned int count;
-        if (SDL_sscanf(envchunkcountlimit, "%u", &count) == 1) {
+        if (SDL_sscanf(hint, "%u", &count) == 1) {
             chunkcountlimit = count <= SDL_MAX_UINT32 ? count : SDL_MAX_UINT32;
         }
     }

--- a/src/audio/alsa/SDL_alsa_audio.c
+++ b/src/audio/alsa/SDL_alsa_audio.c
@@ -228,7 +228,7 @@ static const char *get_audio_device(void *handle, const int channels)
 
     ALSA_Device *dev = (ALSA_Device *)handle;
     if (SDL_strcmp(dev->name, "default") == 0) {
-        const char *device = SDL_getenv("AUDIODEV"); // Is there a standard variable name?
+        const char *device = SDL_GetHint(SDL_HINT_AUDIO_ALSA_DEFAULT_DEVICE);
         if (device) {
             return device;
         } else if (channels == 6) {

--- a/src/audio/alsa/SDL_alsa_audio.c
+++ b/src/audio/alsa/SDL_alsa_audio.c
@@ -426,16 +426,11 @@ static int ALSA_set_buffer_size(SDL_AudioDevice *device, snd_pcm_hw_params_t *pa
     device->sample_frames = persize;
 
     // This is useful for debugging
-    if (SDL_getenv("SDL_AUDIO_ALSA_DEBUG")) {
-        snd_pcm_uframes_t bufsize;
-
-        ALSA_snd_pcm_hw_params_get_buffer_size(hwparams, &bufsize);
-
-        SDL_LogError(SDL_LOG_CATEGORY_AUDIO,
-                     "ALSA: period size = %ld, periods = %u, buffer size = %lu",
-                     persize, periods, bufsize);
-    }
-
+    snd_pcm_uframes_t bufsize;
+    ALSA_snd_pcm_hw_params_get_buffer_size(hwparams, &bufsize);
+    SDL_LogDebug(SDL_LOG_CATEGORY_AUDIO,
+                 "ALSA: period size = %ld, periods = %u, buffer size = %lu",
+                 persize, periods, bufsize);
     return 0;
 }
 

--- a/src/audio/sndio/SDL_sndioaudio.c
+++ b/src/audio/sndio/SDL_sndioaudio.c
@@ -231,11 +231,8 @@ static int SNDIO_OpenDevice(SDL_AudioDevice *device)
         return -1;
     }
 
-    // !!! FIXME: we really should standardize this on a specific SDL hint.
-    const char *audiodev = SDL_getenv("AUDIODEV");
-
     // Recording devices must be non-blocking for SNDIO_FlushRecording
-    device->hidden->dev = SNDIO_sio_open(audiodev ? audiodev : SIO_DEVANY,
+    device->hidden->dev = SNDIO_sio_open(SIO_DEVANY,
                                          device->recording ? SIO_REC : SIO_PLAY, device->recording);
     if (!device->hidden->dev) {
         return SDL_SetError("sio_open() failed");

--- a/src/core/freebsd/SDL_evdev_kbd_freebsd.c
+++ b/src/core/freebsd/SDL_evdev_kbd_freebsd.c
@@ -264,8 +264,8 @@ SDL_EVDEV_keyboard_state *SDL_EVDEV_kbd_init(void)
             SDL_free(kbd->key_map);
             kbd->key_map = &keymap_default_us_acc;
         }
-        /* Allow inhibiting keyboard mute with env. variable for debugging etc. */
-        if (SDL_getenv("SDL_INPUT_FREEBSD_KEEP_KBD") == NULL) {
+
+        if (SDL_GetHintBoolean(SDL_HINT_MUTE_CONSOLE_KEYBOARD, SDL_TRUE)) {
             /* Take keyboard from console and open the actual keyboard device.
              * Ensures that the keystrokes do not leak through to the console.
              */

--- a/src/core/linux/SDL_evdev.c
+++ b/src/core/linux/SDL_evdev.c
@@ -198,7 +198,7 @@ int SDL_EVDEV_Init(void)
                where device class is an integer representing the
                SDL_UDEV_deviceclass and path is the full path to
                the event device. */
-            const char *devices = SDL_getenv("SDL_EVDEV_DEVICES");
+            const char *devices = SDL_GetHint(SDL_HINT_EVDEV_DEVICES);
             if (devices) {
                 /* Assume this is the old use of the env var and it is not in
                    ROM. */

--- a/src/core/linux/SDL_evdev_kbd.c
+++ b/src/core/linux/SDL_evdev_kbd.c
@@ -473,8 +473,7 @@ void SDL_EVDEV_kbd_set_muted(SDL_EVDEV_keyboard_state *state, SDL_bool muted)
     }
 
     if (muted) {
-        /* Allow inhibiting keyboard mute with env. variable for debugging etc. */
-        if (SDL_getenv("SDL_INPUT_LINUX_KEEP_KBD") == NULL) {
+        if (SDL_GetHintBoolean(SDL_HINT_MUTE_CONSOLE_KEYBOARD, SDL_TRUE)) {
             /* Mute the keyboard so keystrokes only generate evdev events
              * and do not leak through to the console
              */

--- a/src/haptic/SDL_haptic.c
+++ b/src/haptic/SDL_haptic.c
@@ -539,7 +539,7 @@ int SDL_SetHapticGain(SDL_Haptic *haptic, int gain)
         return SDL_SetError("Haptic: Gain must be between 0 and 100.");
     }
 
-    /* We use the envvar to get the maximum gain. */
+    /* The user can use an environment variable to override the max gain. */
     env = SDL_getenv("SDL_HAPTIC_GAIN_MAX");
     if (env) {
         max_gain = SDL_atoi(env);

--- a/src/hidapi/SDL_hidapi.c
+++ b/src/hidapi/SDL_hidapi.c
@@ -909,13 +909,13 @@ static SDL_bool IsInWhitelist(Uint16 vendor, Uint16 product)
 
 #if defined(HAVE_PLATFORM_BACKEND) || defined(HAVE_DRIVER_BACKEND)
 /* We have another way to get HID devices, so use the whitelist to get devices where libusb is preferred */
-#define SDL_HIDAPI_LIBUSB_WHITELIST_DEFAULT SDL_TRUE
+#define SDL_HINT_HIDAPI_LIBUSB_WHITELIST_DEFAULT SDL_TRUE
 #else
 /* libusb is the only way to get HID devices, so don't use the whitelist, get them all */
-#define SDL_HIDAPI_LIBUSB_WHITELIST_DEFAULT SDL_FALSE
+#define SDL_HINT_HIDAPI_LIBUSB_WHITELIST_DEFAULT SDL_FALSE
 #endif /* HAVE_PLATFORM_BACKEND || HAVE_DRIVER_BACKEND */
 
-static SDL_bool use_libusb_whitelist = SDL_HIDAPI_LIBUSB_WHITELIST_DEFAULT;
+static SDL_bool use_libusb_whitelist = SDL_HINT_HIDAPI_LIBUSB_WHITELIST_DEFAULT;
 
 /* Shared HIDAPI Implementation */
 
@@ -1140,9 +1140,9 @@ int SDL_hid_init(void)
     SDL_AddHintCallback(SDL_HINT_HIDAPI_IGNORE_DEVICES, IgnoredDevicesChanged, NULL);
 
 #ifdef SDL_USE_LIBUDEV
-    if (SDL_getenv("SDL_HIDAPI_JOYSTICK_DISABLE_UDEV") != NULL) {
+    if (!SDL_GetHintBoolean(SDL_HINT_HIDAPI_UDEV, SDL_TRUE)) {
         SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
-                     "udev disabled by SDL_HIDAPI_JOYSTICK_DISABLE_UDEV");
+                     "udev disabled by SDL_HINT_HIDAPI_UDEV");
         linux_enumeration_method = ENUMERATION_FALLBACK;
     } else if (SDL_DetectSandbox() != SDL_SANDBOX_NONE) {
         SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
@@ -1155,12 +1155,12 @@ int SDL_hid_init(void)
     }
 #endif
 
-    use_libusb_whitelist = SDL_GetHintBoolean("SDL_HIDAPI_LIBUSB_WHITELIST",
-                                              SDL_HIDAPI_LIBUSB_WHITELIST_DEFAULT);
+    use_libusb_whitelist = SDL_GetHintBoolean(SDL_HINT_HIDAPI_LIBUSB_WHITELIST,
+                                              SDL_HINT_HIDAPI_LIBUSB_WHITELIST_DEFAULT);
 #ifdef HAVE_LIBUSB
-    if (SDL_getenv("SDL_HIDAPI_DISABLE_LIBUSB") != NULL) {
+    if (!SDL_GetHintBoolean(SDL_HINT_HIDAPI_LIBUSB, SDL_TRUE)) {
         SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
-                     "libusb disabled by SDL_HIDAPI_DISABLE_LIBUSB");
+                     "libusb disabled with SDL_HINT_HIDAPI_LIBUSB");
         libusb_ctx.libhandle = NULL;
     } else {
         ++attempts;

--- a/src/joystick/hidapi/SDL_hidapijoystick.c
+++ b/src/joystick/hidapi/SDL_hidapijoystick.c
@@ -579,9 +579,9 @@ static int HIDAPI_JoystickInit(void)
 
 #ifdef SDL_USE_LIBUDEV
     if (linux_enumeration_method == ENUMERATION_UNSET) {
-        if (SDL_getenv("SDL_HIDAPI_JOYSTICK_DISABLE_UDEV") != NULL) {
+        if (!SDL_GetHintBoolean(SDL_HINT_HIDAPI_UDEV, SDL_TRUE)) {
             SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
-                         "udev disabled by SDL_HIDAPI_JOYSTICK_DISABLE_UDEV");
+                         "udev disabled by SDL_HINT_HIDAPI_UDEV");
             linux_enumeration_method = ENUMERATION_FALLBACK;
         } else if (SDL_DetectSandbox() != SDL_SANDBOX_NONE) {
             SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,

--- a/src/render/opengl/SDL_render_gl.c
+++ b/src/render/opengl/SDL_render_gl.c
@@ -1729,7 +1729,7 @@ static int GL_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_Pro
         data->glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS_ARB);
     }
 
-    hint = SDL_getenv("GL_ARB_texture_non_power_of_two");
+    hint = SDL_GetHint("GL_ARB_texture_non_power_of_two");
     if (!hint || *hint != '0') {
         SDL_bool isGL2 = SDL_FALSE;
         const char *verstr = (const char *)data->glGetString(GL_VERSION);

--- a/src/video/SDL_blit_N.c
+++ b/src/video/SDL_blit_N.c
@@ -36,14 +36,11 @@
 
 /* Functions to blit from N-bit surfaces to other surfaces */
 
-enum blit_features
-{
-    BLIT_FEATURE_NONE = 0,
-    BLIT_FEATURE_HAS_MMX = 1,
-    BLIT_FEATURE_HAS_ALTIVEC = 2,
-    BLIT_FEATURE_ALTIVEC_DONT_USE_PREFETCH = 4,
-    BLIT_FEATURE_HAS_ARM_SIMD = 8
-};
+#define BLIT_FEATURE_NONE                       0x00
+#define BLIT_FEATURE_HAS_MMX                    0x01
+#define BLIT_FEATURE_HAS_ALTIVEC                0x02
+#define BLIT_FEATURE_ALTIVEC_DONT_USE_PREFETCH  0x04
+#define BLIT_FEATURE_HAS_ARM_SIMD               0x08
 
 #ifdef SDL_ALTIVEC_BLITTERS
 #ifdef SDL_PLATFORM_MACOS
@@ -873,26 +870,18 @@ static void ConvertAltivec32to32_prefetch(SDL_BlitInfo *info)
     vec_dss(DST_CHAN_DEST);
 }
 
-static enum blit_features GetBlitFeatures(void)
+static Uint32 GetBlitFeatures(void)
 {
-    static enum blit_features features = -1;
-    if (features == (enum blit_features) - 1) {
-        /* Provide an override for testing .. */
-        const char *override = SDL_getenv("SDL_ALTIVEC_BLIT_FEATURES");
-        if (override) {
-            unsigned int features_as_uint = 0;
-            SDL_sscanf(override, "%u", &features_as_uint);
-            features = (enum blit_features)features_as_uint;
-        } else {
-            features = (0
-                        /* Feature 1 is has-MMX */
-                        | ((SDL_HasMMX()) ? BLIT_FEATURE_HAS_MMX : 0)
-                        /* Feature 2 is has-AltiVec */
-                        | ((SDL_HasAltiVec()) ? BLIT_FEATURE_HAS_ALTIVEC : 0)
-                        /* Feature 4 is dont-use-prefetch */
-                        /* !!!! FIXME: Check for G5 or later, not the cache size! Always prefetch on a G4. */
-                        | ((GetL3CacheSize() == 0) ? BLIT_FEATURE_ALTIVEC_DONT_USE_PREFETCH : 0));
-        }
+    static Uint32 features = ~0u;
+    if (features == ~0u) {
+        features = (0
+                    /* Feature 1 is has-MMX */
+                    | ((SDL_HasMMX()) ? BLIT_FEATURE_HAS_MMX : 0)
+                    /* Feature 2 is has-AltiVec */
+                    | ((SDL_HasAltiVec()) ? BLIT_FEATURE_HAS_ALTIVEC : 0)
+                    /* Feature 4 is dont-use-prefetch */
+                    /* !!!! FIXME: Check for G5 or later, not the cache size! Always prefetch on a G4. */
+                    | ((GetL3CacheSize() == 0) ? BLIT_FEATURE_ALTIVEC_DONT_USE_PREFETCH : 0));
     }
     return features;
 }

--- a/src/video/SDL_egl.c
+++ b/src/video/SDL_egl.c
@@ -189,14 +189,14 @@ SDL_bool SDL_EGL_HasExtension(SDL_VideoDevice *_this, SDL_EGL_ExtensionType type
         return SDL_FALSE;
     }
 
-    /* Extensions can be masked with an environment variable.
+    /* Extensions can be masked with a hint or environment variable.
      * Unlike the OpenGL override, this will use the set bits of an integer
      * to disable the extension.
      *  Bit   Action
      *  0     If set, the display extension is masked and not present to SDL.
      *  1     If set, the client extension is masked and not present to SDL.
      */
-    ext_override = SDL_getenv(ext);
+    ext_override = SDL_GetHint(ext);
     if (ext_override) {
         int disable_ext = SDL_atoi(ext_override);
         if (disable_ext & 0x01 && type == SDL_EGL_DISPLAY_EXTENSION) {

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -4292,8 +4292,8 @@ SDL_bool SDL_GL_ExtensionSupported(const char *extension)
     if (where || *extension == '\0') {
         return SDL_FALSE;
     }
-    /* See if there's an environment variable override */
-    start = SDL_getenv(extension);
+    /* See if there's a hint or environment variable override */
+    start = SDL_GetHint(extension);
     if (start && *start == '0') {
         return SDL_FALSE;
     }

--- a/src/video/SDL_vulkan_utils.c
+++ b/src/video/SDL_vulkan_utils.c
@@ -209,7 +209,7 @@ int SDL_Vulkan_Display_CreateSurface(void *vkGetInstanceProcAddr_,
         SDL_SetError(VK_KHR_DISPLAY_EXTENSION_NAME " extension is not enabled in the Vulkan instance.");
         goto error;
     }
-    chosenDisplayId = SDL_getenv("SDL_VULKAN_DISPLAY");
+    chosenDisplayId = SDL_GetHint(SDL_HINT_VULKAN_DISPLAY);
     if (chosenDisplayId) {
         displayId = SDL_atoi(chosenDisplayId);
     }

--- a/src/video/android/SDL_androidvulkan.c
+++ b/src/video/android/SDL_androidvulkan.c
@@ -49,7 +49,7 @@ int Android_Vulkan_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 
     /* Load the Vulkan loader library */
     if (!path) {
-        path = SDL_getenv("SDL_VULKAN_LIBRARY");
+        path = SDL_GetHint(SDL_HINT_VULKAN_LIBRARY);
     }
     if (!path) {
         path = "libvulkan.so";

--- a/src/video/cocoa/SDL_cocoaopengl.m
+++ b/src/video/cocoa/SDL_cocoaopengl.m
@@ -229,7 +229,7 @@ int Cocoa_GL_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 {
     /* Load the OpenGL library */
     if (path == NULL) {
-        path = SDL_getenv("SDL_OPENGL_LIBRARY");
+        path = SDL_GetHint(SDL_HINT_OPENGL_LIBRARY);
     }
     if (path == NULL) {
         path = DEFAULT_OPENGL;

--- a/src/video/cocoa/SDL_cocoavulkan.m
+++ b/src/video/cocoa/SDL_cocoavulkan.m
@@ -61,7 +61,7 @@ int Cocoa_Vulkan_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 
     /* Load the Vulkan loader library */
     if (!path) {
-        path = SDL_getenv("SDL_VULKAN_LIBRARY");
+        path = SDL_GetHint(SDL_HINT_VULKAN_LIBRARY);
     }
 
     if (!path) {

--- a/src/video/dummy/SDL_nullframebuffer.c
+++ b/src/video/dummy/SDL_nullframebuffer.c
@@ -61,7 +61,7 @@ int SDL_DUMMY_UpdateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window
     }
 
     /* Send the data to the display */
-    if (SDL_getenv("SDL_VIDEO_DUMMY_SAVE_FRAMES")) {
+    if (SDL_GetHintBoolean(SDL_HINT_VIDEO_DUMMY_SAVE_FRAMES, SDL_FALSE)) {
         char file[128];
         (void)SDL_snprintf(file, sizeof(file), "SDL_window%" SDL_PRIu32 "-%8.8d.bmp",
                            SDL_GetWindowID(window), ++frame_number);

--- a/src/video/kmsdrm/SDL_kmsdrmvulkan.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvulkan.c
@@ -56,7 +56,7 @@ int KMSDRM_Vulkan_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 
     /* Load the Vulkan library */
     if (!path) {
-        path = SDL_getenv("SDL_VULKAN_LIBRARY");
+        path = SDL_GetHint(SDL_HINT_VULKAN_LIBRARY);
     }
     if (!path) {
         path = DEFAULT_VULKAN;

--- a/src/video/ngage/SDL_ngageframebuffer.cpp
+++ b/src/video/ngage/SDL_ngageframebuffer.cpp
@@ -145,24 +145,7 @@ int SDL_NGAGE_CreateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window
 
 int SDL_NGAGE_UpdateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, const SDL_Rect *rects, int numrects)
 {
-    static int frame_number;
-    SDL_Surface *surface;
-
-    surface = (SDL_Surface *)SDL_GetWindowData(window, NGAGE_SURFACE);
-    if (!surface) {
-        return SDL_SetError("Couldn't find ngage surface for window");
-    }
-
-    /* Send the data to the display */
-    if (SDL_getenv("SDL_VIDEO_NGAGE_SAVE_FRAMES")) {
-        char file[128];
-        SDL_snprintf(file, sizeof(file), "SDL_window%d-%8.8d.bmp",
-                     (int)SDL_GetWindowID(window), ++frame_number);
-        SDL_SaveBMP(surface, file);
-    }
-
     DirectUpdate(_this, numrects, (SDL_Rect *)rects);
-
     return 0;
 }
 

--- a/src/video/offscreen/SDL_offscreenframebuffer.c
+++ b/src/video/offscreen/SDL_offscreenframebuffer.c
@@ -62,7 +62,7 @@ int SDL_OFFSCREEN_UpdateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *wi
     }
 
     /* Send the data to the display */
-    if (SDL_getenv("SDL_VIDEO_OFFSCREEN_SAVE_FRAMES")) {
+    if (SDL_GetHintBoolean(SDL_HINT_VIDEO_OFFSCREEN_SAVE_FRAMES, SDL_FALSE)) {
         char file[128];
         (void)SDL_snprintf(file, sizeof(file), "SDL_window%" SDL_PRIu32 "-%8.8d.bmp",
                            SDL_GetWindowID(window), ++frame_number);

--- a/src/video/offscreen/SDL_offscreenvulkan.c
+++ b/src/video/offscreen/SDL_offscreenvulkan.c
@@ -74,7 +74,7 @@ int OFFSCREEN_Vulkan_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 
     /* Load the Vulkan loader library */
     if (!path) {
-        path = SDL_getenv("SDL_VULKAN_LIBRARY");
+        path = SDL_GetHint(SDL_HINT_VULKAN_LIBRARY);
     }
 
 #if defined(SDL_PLATFORM_APPLE)

--- a/src/video/uikit/SDL_uikitvulkan.m
+++ b/src/video/uikit/SDL_uikitvulkan.m
@@ -59,7 +59,7 @@ int UIKit_Vulkan_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 
     /* Load the Vulkan loader library */
     if (!path) {
-        path = SDL_getenv("SDL_VULKAN_LIBRARY");
+        path = SDL_GetHint(SDL_HINT_VULKAN_LIBRARY);
     }
 
     if (!path) {

--- a/src/video/vita/SDL_vitagl_pvr.c
+++ b/src/video/vita/SDL_vitagl_pvr.c
@@ -46,13 +46,13 @@ static void getFBSize(int *width, int *height)
 int VITA_GL_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 {
     PVRSRV_PSP2_APPHINT hint;
-    const char *override = SDL_getenv("VITA_MODULE_PATH");
-    const char *skip_init = SDL_getenv("VITA_PVR_SKIP_INIT");
     char *default_path = "app0:module";
     char target_path[MAX_PATH];
 
-    if (!skip_init) { // we don't care about actual value
-        if (override) {
+    if (SDL_GetHintBoolean(SDL_HINT_VITA_PVR_INIT, SDL_TRUE)) {
+        const char *override = SDL_GetHint(SDL_HINT_VITA_MODULE_PATH);
+
+        if (override && *override) {
             default_path = override;
         }
 

--- a/src/video/vita/SDL_vitagles_pvr.c
+++ b/src/video/vita/SDL_vitagles_pvr.c
@@ -35,14 +35,13 @@
 int VITA_GLES_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 {
     PVRSRV_PSP2_APPHINT hint;
-    const char *override = SDL_getenv("VITA_MODULE_PATH");
-    const char *skip_init = SDL_getenv("VITA_PVR_SKIP_INIT");
     const char *default_path = "app0:module";
     char target_path[MAX_PATH];
 
-    if (!skip_init) { // we don't care about actual value
+    if (SDL_GetHintBoolean(SDL_HINT_VITA_PVR_INIT, SDL_TRUE)) {
+        const char *override = SDL_GetHint(SDL_HINT_VITA_MODULE_PATH);
 
-        if (override) {
+        if (override && *override) {
             default_path = override;
         }
 

--- a/src/video/vita/SDL_vitatouch.c
+++ b/src/video/vita/SDL_vitatouch.c
@@ -41,13 +41,13 @@ struct
     float range;
 } force_info[SCE_TOUCH_PORT_MAX_NUM];
 
-const char *disableFrontPoll = NULL;
-const char *disableBackPoll = NULL;
+static SDL_bool disableFrontPoll;
+static SDL_bool disableBackPoll;
 
 void VITA_InitTouch(void)
 {
-    disableFrontPoll = SDL_getenv("VITA_DISABLE_TOUCH_FRONT");
-    disableBackPoll = SDL_getenv("VITA_DISABLE_TOUCH_BACK");
+    disableFrontPoll = !SDL_GetHintBoolean(SDL_HINT_VITA_ENABLE_FRONT_TOUCH, SDL_TRUE);
+    disableBackPoll = !SDL_GetHintBoolean(SDL_HINT_VITA_ENABLE_BACK_TOUCH, SDL_TRUE);
 
     sceTouchSetSamplingState(SCE_TOUCH_PORT_FRONT, SCE_TOUCH_SAMPLING_STATE_START);
     sceTouchSetSamplingState(SCE_TOUCH_PORT_BACK, SCE_TOUCH_SAMPLING_STATE_START);
@@ -92,7 +92,7 @@ void VITA_PollTouch(void)
     SDL_memcpy(touch_old, touch, sizeof(touch_old));
 
     for (port = 0; port < SCE_TOUCH_PORT_MAX_NUM; port++) {
-        /** Skip polling of Touch Device if environment variable is set **/
+        /** Skip polling of Touch Device if hint is set **/
         if (((port == 0) && disableFrontPoll) || ((port == 1) && disableBackPoll)) {
             continue;
         }

--- a/src/video/vita/SDL_vitavideo.c
+++ b/src/video/vita/SDL_vitavideo.c
@@ -125,7 +125,7 @@ static SDL_VideoDevice *VITA_Create(void)
 
 #if defined(SDL_VIDEO_VITA_PIB) || defined(SDL_VIDEO_VITA_PVR)
 #ifdef SDL_VIDEO_VITA_PVR_OGL
-    if (SDL_getenv("VITA_PVR_OGL") != NULL) {
+    if (SDL_GetHintBoolean(SDL_HINT_VITA_PVR_OPENGL, SDL_FALSE)) {
         device->GL_LoadLibrary = VITA_GL_LoadLibrary;
         device->GL_CreateContext = VITA_GL_CreateContext;
         device->GL_GetProcAddress = VITA_GL_GetProcAddress;
@@ -170,19 +170,19 @@ int VITA_VideoInit(SDL_VideoDevice *_this)
 {
     SDL_DisplayMode mode;
 #ifdef SDL_VIDEO_VITA_PVR
-    const char *res = SDL_getenv("VITA_RESOLUTION");
+    const char *res = SDL_GetHint(SDL_HINT_VITA_RESOLUTION);
 #endif
     SDL_zero(mode);
 
 #ifdef SDL_VIDEO_VITA_PVR
     if (res) {
         /* 1088i for PSTV (Or Sharpscale) */
-        if (!SDL_strncmp(res, "1080", 4)) {
+        if (SDL_strncmp(res, "1080", 4) == 0) {
             mode.w = 1920;
             mode.h = 1088;
         }
         /* 725p for PSTV (Or Sharpscale) */
-        else if (!SDL_strncmp(res, "720", 3)) {
+        else if (SDL_strncmp(res, "720", 3) == 0) {
             mode.w = 1280;
             mode.h = 725;
         }
@@ -261,7 +261,8 @@ int VITA_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Properties
         win.windowSize = PSP2_WINDOW_960X544;
     }
     if (window->flags & SDL_WINDOW_OPENGL) {
-        if (SDL_getenv("VITA_PVR_OGL") != NULL) {
+        SDL_bool use_opengl = SDL_GetHintBoolean(SDL_HINT_VITA_PVR_OPENGL, SDL_FALSE);
+        if (use_opengl) {
             /* Set version to 2.1 and PROFILE to ES */
             temp_major = _this->gl_config.major_version;
             temp_minor = _this->gl_config.minor_version;
@@ -275,7 +276,7 @@ int VITA_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Properties
         if (wdata->egl_surface == EGL_NO_SURFACE) {
             return SDL_SetError("Could not create GLES window surface");
         }
-        if (SDL_getenv("VITA_PVR_OGL") != NULL) {
+        if (use_opengl) {
             /* Revert */
             _this->gl_config.major_version = temp_major;
             _this->gl_config.minor_version = temp_minor;

--- a/src/video/vivante/SDL_vivantevulkan.c
+++ b/src/video/vivante/SDL_vivantevulkan.c
@@ -47,7 +47,7 @@ int VIVANTE_Vulkan_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 
     /* Load the Vulkan loader library */
     if (!path) {
-        path = SDL_getenv("SDL_VULKAN_LIBRARY");
+        path = SDL_GetHint(SDL_HINT_VULKAN_LIBRARY);
     }
     if (!path) {
         /* If no path set, try Vivante fb vulkan driver explicitly */

--- a/src/video/wayland/SDL_waylandvulkan.c
+++ b/src/video/wayland/SDL_waylandvulkan.c
@@ -54,7 +54,7 @@ int Wayland_Vulkan_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 
     /* Load the Vulkan loader library */
     if (!path) {
-        path = SDL_getenv("SDL_VULKAN_LIBRARY");
+        path = SDL_GetHint(SDL_HINT_VULKAN_LIBRARY);
     }
     if (!path) {
         path = DEFAULT_VULKAN;

--- a/src/video/windows/SDL_windowsopengl.c
+++ b/src/video/windows/SDL_windowsopengl.c
@@ -110,7 +110,7 @@ int WIN_GL_LoadLibrary(SDL_VideoDevice *_this, const char *path)
     void *handle;
 
     if (path == NULL) {
-        path = SDL_getenv("SDL_OPENGL_LIBRARY");
+        path = SDL_GetHint(SDL_HINT_OPENGL_LIBRARY);
     }
     if (path == NULL) {
         path = DEFAULT_OPENGL;

--- a/src/video/windows/SDL_windowsvulkan.c
+++ b/src/video/windows/SDL_windowsvulkan.c
@@ -49,7 +49,7 @@ int WIN_Vulkan_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 
     /* Load the Vulkan loader library */
     if (!path) {
-        path = SDL_getenv("SDL_VULKAN_LIBRARY");
+        path = SDL_GetHint(SDL_HINT_VULKAN_LIBRARY);
     }
     if (!path) {
         path = "vulkan-1.dll";

--- a/src/video/x11/SDL_x11modes.c
+++ b/src/video/x11/SDL_x11modes.c
@@ -265,11 +265,11 @@ static float GetGlobalContentScale(SDL_VideoDevice *_this)
 
 static int get_visualinfo(Display *display, int screen, XVisualInfo *vinfo)
 {
-    const char *visual_id = SDL_getenv("SDL_VIDEO_X11_VISUALID");
+    const char *visual_id = SDL_GetHint(SDL_HINT_VIDEO_X11_VISUALID);
     int depth;
 
     /* Look for an exact visual, if requested */
-    if (visual_id) {
+    if (visual_id && *visual_id) {
         XVisualInfo *vi, template;
         int nvis;
 

--- a/src/video/x11/SDL_x11opengl.c
+++ b/src/video/x11/SDL_x11opengl.c
@@ -172,7 +172,7 @@ int X11_GL_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 
     /* Load the OpenGL library */
     if (path == NULL) {
-        path = SDL_getenv("SDL_OPENGL_LIBRARY");
+        path = SDL_GetHint(SDL_HINT_OPENGL_LIBRARY);
     }
     if (path == NULL) {
         path = DEFAULT_OPENGL;

--- a/src/video/x11/SDL_x11video.c
+++ b/src/video/x11/SDL_x11video.c
@@ -491,7 +491,10 @@ void X11_VideoQuit(SDL_VideoDevice *_this)
 
 SDL_bool X11_UseDirectColorVisuals(void)
 {
-    return (SDL_getenv("SDL_VIDEO_X11_NODIRECTCOLOR") == NULL);
+    if (SDL_GetHintBoolean(SDL_HINT_VIDEO_X11_NODIRECTCOLOR, SDL_FALSE)) {
+        return SDL_FALSE;
+    }
+    return SDL_TRUE;
 }
 
 #endif /* SDL_VIDEO_DRIVER_X11 */

--- a/src/video/x11/SDL_x11vulkan.c
+++ b/src/video/x11/SDL_x11vulkan.c
@@ -58,7 +58,7 @@ int X11_Vulkan_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 
     /* Load the Vulkan loader library */
     if (!path) {
-        path = SDL_getenv("SDL_VULKAN_LIBRARY");
+        path = SDL_GetHint(SDL_HINT_VULKAN_LIBRARY);
     }
     if (!path) {
         path = DEFAULT_VULKAN;

--- a/src/video/x11/SDL_x11vulkan.c
+++ b/src/video/x11/SDL_x11vulkan.c
@@ -107,8 +107,8 @@ int X11_Vulkan_LoadLibrary(SDL_VideoDevice *_this, const char *path)
         SDL_SetError("Installed Vulkan doesn't implement either the " VK_KHR_XCB_SURFACE_EXTENSION_NAME "extension or the " VK_KHR_XLIB_SURFACE_EXTENSION_NAME " extension");
         goto fail;
     } else {
-        const char *libX11XCBLibraryName = SDL_getenv("SDL_X11_XCB_LIBRARY");
-        if (!libX11XCBLibraryName) {
+        const char *libX11XCBLibraryName = SDL_GetHint(SDL_HINT_X11_XCB_LIBRARY);
+        if (!libX11XCBLibraryName || !*libX11XCBLibraryName) {
             libX11XCBLibraryName = "libX11-xcb.so";
         }
         videoData->vulkan_xlib_xcb_library = SDL_LoadObject(libX11XCBLibraryName);

--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -494,8 +494,9 @@ int X11_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesI
 #if defined(SDL_VIDEO_OPENGL_GLX) || defined(SDL_VIDEO_OPENGL_EGL)
     const int transparent = (window->flags & SDL_WINDOW_TRANSPARENT) ? SDL_TRUE : SDL_FALSE;
     const char *forced_visual_id = SDL_GetHint(SDL_HINT_VIDEO_X11_WINDOW_VISUALID);
+    const char *display_visual_id = SDL_GetHint(SDL_HINT_VIDEO_X11_VISUALID);
 
-    if (forced_visual_id && forced_visual_id[0] != '\0') {
+    if (forced_visual_id && *forced_visual_id) {
         XVisualInfo *vi, template;
         int nvis;
 
@@ -510,7 +511,7 @@ int X11_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesI
             return -1;
         }
     } else if ((window->flags & SDL_WINDOW_OPENGL) &&
-               !SDL_getenv("SDL_VIDEO_X11_VISUALID")) {
+               (!display_visual_id || !*display_visual_id)) {
         XVisualInfo *vinfo = NULL;
 
 #ifdef SDL_VIDEO_OPENGL_EGL


### PR DESCRIPTION
This PR goes through the places where SDL was using SDL_getenv() and should probably have been using a hint.

Most of these have been converted to hints, and a few have been dropped, with a couple of exceptions:

The `SDL_HAPTIC_GAIN_MAX` environment variable is documented as a user override for the maximum haptic gain, so I didn't touch that.

The `SDL_VIDEO_GL_DRIVER` and `SDL_VIDEO_EGL_DRIVER` environment variables are used by EGL, and I wasn't sure how to explain clearly why you'd set an OpenGL library that is used by EGL, and why this hint would be different from `SDL_HINT_OPENGL_LIBRARY`. @icculus, do you want to take a crack at that?

Fixes https://github.com/libsdl-org/SDL/issues/7702