### PR TITLE
gdk: show dialog when xgameruntime.dll is not installed

### DIFF
--- a/src/main/gdk/SDL_sysmain_runapp.cpp
+++ b/src/main/gdk/SDL_sysmain_runapp.cpp
@@ -126,7 +126,11 @@ int SDL_RunApp(int, char**, SDL_main_func mainFunction, void *reserved)
         XGameRuntimeUninitialize();
     } else {
 #ifdef SDL_PLATFORM_WINGDK
-        SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Fatal Error", "[GDK] Could not initialize - aborting", NULL);
+        if (hr == E_GAMERUNTIME_DLL_NOT_FOUND) {
+            SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Fatal Error", "[GDK] Gaming Runtime library not found (xgameruntime.dll)", NULL);
+        } else {
+            SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Fatal Error", "[GDK] Could not initialize - aborting", NULL);
+        }
 #else
         SDL_assert_always(0 && "[GDK] Could not initialize - aborting");
 #endif


### PR DESCRIPTION
In https://github.com/libsdl-org/SDL/pull/8847#issuecomment-2128390589 I saw a unhelpful "[GDK] Could not initialize - aborting" dialog message.
This patch should show `[GDK] Gaming Runtime library not found (xgameruntime.dll)` instead.

`build-scripts/setup-gdk-desktop.py` does not install any runtime libraries either, so it's safe to assume other people will encounter this scenario too.

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
