### PR TITLE
Fix name discrepancy in Android JNI

### DIFF
--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -64,10 +64,10 @@ JNIEXPORT jstring JNICALL SDL_JAVA_INTERFACE(nativeGetVersion)(
 JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(nativeSetupJNI)(
     JNIEnv *env, jclass cls);
 
-JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(nativeInitSDLThread)(
+JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(nativeInitMainThread)(
     JNIEnv *env, jclass cls);
 
-JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(nativeCleanupSDLThread)(
+JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(nativeCleanupMainThread)(
     JNIEnv *env, jclass cls);
 
 JNIEXPORT int JNICALL SDL_JAVA_INTERFACE(nativeRunMain)(
@@ -194,8 +194,8 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeFileDialog)(
 static JNINativeMethod SDLActivity_tab[] = {
     { "nativeGetVersion", "()Ljava/lang/String;", SDL_JAVA_INTERFACE(nativeGetVersion) },
     { "nativeSetupJNI", "()I", SDL_JAVA_INTERFACE(nativeSetupJNI) },
-    { "nativeInitSDLThread", "()V", SDL_JAVA_INTERFACE(nativeInitSDLThread) },
-    { "nativeCleanupSDLThread", "()V", SDL_JAVA_INTERFACE(nativeCleanupSDLThread) },
+    { "nativeInitMainThread", "()V", SDL_JAVA_INTERFACE(nativeInitMainThread) },
+    { "nativeCleanupMainThread", "()V", SDL_JAVA_INTERFACE(nativeCleanupMainThread) },
     { "nativeRunMain", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)I", SDL_JAVA_INTERFACE(nativeRunMain) },
     { "onNativeDropFile", "(Ljava/lang/String;)V", SDL_JAVA_INTERFACE(onNativeDropFile) },
     { "nativeSetScreenResolution", "(IIIIFF)V", SDL_JAVA_INTERFACE(nativeSetScreenResolution) },
@@ -772,7 +772,7 @@ JNIEXPORT jboolean JNICALL SDL_JAVA_INTERFACE(nativeAllowRecreateActivity)(
     return SDL_AtomicGet(&bAllowRecreateActivity);
 }
 
-JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(nativeInitSDLThread)(
+JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(nativeInitMainThread)(
     JNIEnv *env, jclass jcls)
 {
     __android_log_print(ANDROID_LOG_VERBOSE, "SDL", "nativeInitSDLThread() %d time", run_count);
@@ -785,7 +785,7 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(nativeInitSDLThread)(
     Android_JNI_SetEnv(env);
 }
 
-JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(nativeCleanupSDLThread)(
+JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(nativeCleanupMainThread)(
     JNIEnv *env, jclass jcls)
 {
     /* This is a Java thread, it doesn't need to be Detached from the JVM.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
https://github.com/libsdl-org/SDL/blob/e3cf20e1cc5645646f7216733e97b4c7660d2df8/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java#L1042-L1043

It's `nativeInitMainThread`/`nativeCleanupMainThread` in Java part, but `nativeInitSDLThread`/`nativeCleanupSDLThread` in C.

This PR fixes the name discrepancy between these two.

Here is a crash log:
```
08-05 20:10:24.694 20307 20307 W sh.ppy.osulazer: CheckJNI: method to register "nativeInitSDLThread" not in the given class. This is slow, consider changing your RegisterNatives calls.

08-05 20:10:24.695 20307 20307 E sh.ppy.osulazer: Failed to register native method org.libsdl.app.SDLActivity.nativeInitSDLThread()V in /data/app/~~ui-_rds_eyAnV7UtSGX8PQ==/sh.ppy.osulazer-soF48SUniHmqmHAgvAGNdw==/base.apk
```