### PR TITLE
Use more stringent criteria for entering warp emulation mode

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2309,7 +2309,8 @@ extern "C" {
  * A variable controlling whether warping a hidden mouse cursor will activate
  * relative mouse mode.
  *
- * When this hint is set and the mouse cursor is hidden, SDL will emulate
+ * When this hint is set, the mouse cursor is hidden, and multiple warps to
+ * the window center occur within a short time period, SDL will emulate
  * mouse warps using relative mouse mode. This can provide smoother and more
  * reliable mouse motion for some older games, which continuously calculate
  * the distance travelled by the mouse pointer and warp it back to the center
@@ -2318,9 +2319,8 @@ extern "C" {
  * Note that relative mouse mode may have different mouse acceleration
  * behavior than pointer warps.
  *
- * If your game or application needs to warp the mouse cursor while hidden for
- * other purposes, such as drawing a software cursor, it should disable this
- * hint.
+ * If your application needs to repeatedly warp the hidden mouse cursor at a
+ * high-frequency for other purposes, it should disable this hint.
  *
  * The variable can be set to the following values:
  *

--- a/src/events/SDL_mouse_c.h
+++ b/src/events/SDL_mouse_c.h
@@ -97,6 +97,7 @@ typedef struct
     SDL_bool warp_emulation_hint;
     SDL_bool warp_emulation_active;
     SDL_bool warp_emulation_prohibited;
+    Uint64 last_center_warp_time_ns;
     int relative_mode_clip_interval;
     SDL_bool enable_normal_speed_scale;
     float normal_speed_scale;
@@ -183,6 +184,7 @@ extern void SDL_PerformWarpMouseInWindow(SDL_Window *window, float x, float y, S
 extern int SDL_SetRelativeMouseMode(SDL_bool enabled);
 extern SDL_bool SDL_GetRelativeMouseMode(void);
 extern void SDL_UpdateRelativeMouseMode(void);
+extern void SDL_DisableMouseWarpEmulation(void);
 
 /* TODO RECONNECT: Set mouse state to "zero" */
 #if 0

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -3784,6 +3784,12 @@ int SDL_SetWindowRelativeMouseMode(SDL_Window *window, SDL_bool enabled)
 {
     CHECK_WINDOW_MAGIC(window, -1);
 
+    /* If the app toggles relative mode directly, it probably shouldn't
+     * also be emulating it using repeated mouse warps, so disable
+     * mouse warp emulation by default.
+     */
+    SDL_DisableMouseWarpEmulation();
+
     if (enabled == SDL_GetWindowRelativeMouseMode(window)) {
         return 0;
     }


### PR DESCRIPTION
Require more than one warp to the window center within a certain timespan (currently 30ms, but can be tweaked) to better avoid erroneously entering warp emulation mode.

This also correctly resets the warp emulation mode activation if the window loses and regains focus.

Closes #10413