### PR TITLE
Fixed crash when the current mouse capture window is destroyed

### DIFF
--- a/src/events/SDL_windowevents.c
+++ b/src/events/SDL_windowevents.c
@@ -43,7 +43,7 @@ int SDL_SendWindowEvent(SDL_Window *window, SDL_EventType windowevent,
 {
     int posted;
 
-    if (!window) {
+    if (!SDL_ObjectValid(window, SDL_OBJECT_TYPE_WINDOW)) {
         return 0;
     }
     if (window->is_destroying && windowevent != SDL_EVENT_WINDOW_DESTROYED) {

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -4097,6 +4097,9 @@ void SDL_DestroyWindow(SDL_Window *window)
     if (SDL_GetKeyboardFocus() == window) {
         SDL_SetKeyboardFocus(NULL);
     }
+    if ((window->flags & SDL_WINDOW_MOUSE_CAPTURE)) {
+        SDL_UpdateMouseCapture(SDL_TRUE);
+    }
     if (SDL_GetMouseFocus() == window) {
         SDL_SetMouseFocus(NULL);
     }


### PR DESCRIPTION
Fixes https://github.com/libsdl-org/SDL/issues/10494