### PR TITLE
Windows event hook fix: All events are now sent to the hook during dispatch along with a reference to the SDL_Window.

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -956,6 +956,30 @@ extern "C" {
  */
 #define SDL_HINT_GDK_TEXTINPUT_TITLE "SDL_GDK_TEXTINPUT_TITLE"
 
+
+/**
+ * A variable describing the time at which Windows messages are sent to
+ * registered SDL_WindowsMessageHook callbacks.
+ *
+ * By default, the SDL event loop sends messages to the hook callback before
+ * message translation.  This means that events directly dispatched to the
+ * WindowProc from the OS (eg. all events during a modal resize) are not received.
+ * Setting this hint will cause such messages to be received by the hook function as well.
+ *
+ * The variable can be set to the following values:
+ *
+ *  - "0" (default):  The events are sent to the hook function from the event loop as described above.
+ *  - "1":  Events which are untranslatable are sent to the hook function from the WindowProc handler.  Messages
+ *    which translate successfully are sent to the hook from the event loop, and the translated values are sent
+ *    or dispatched to the WindowProc according to its return value. Both messages willl be received by the hook.
+ *
+ *    This hint should be set before SDL is initialized.
+ *
+ *    \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_HOOK_EVENTS_FROM_WINDOW_PROC "SDL_HOOK_EVENTS_FROM_WINDOW_PROC"
+
+
 /**
  * A variable to control whether HIDAPI uses libusb for device access.
  *

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -971,7 +971,7 @@ extern "C" {
  *  - "0" (default):  The events are sent to the hook function from the event loop as described above.
  *  - "1":  Events which are untranslatable are sent to the hook function from the WindowProc handler.  Messages
  *    which translate successfully are sent to the hook from the event loop, and the translated values are sent
- *    or dispatched to the WindowProc according to its return value. Both messages willl be received by the hook.
+ *    or dispatched to the WindowProc according to its return value. Both messages will be received by the hook.
  *
  *    This hint should be set before SDL is initialized.
  *

--- a/include/SDL3/SDL_system.h
+++ b/include/SDL3/SDL_system.h
@@ -58,10 +58,15 @@ typedef struct tagMSG MSG;
  * As this is processing a message directly from the Windows event loop, this
  * callback should do the minimum required work and return quickly.
  *
+ * If SDL_HINT_HOOK_EVENTS_FROM_WINDOW_PROC is not set before windows initialization,
+ * or the function returns SDL_TRUE, the return_val parameter is ignored.
+ * 
  * \param userdata the app-defined pointer provided to
  *                 SDL_SetWindowsMessageHook.
  * \param msg a pointer to a Win32 event structure to process.
- * \returns SDL_TRUE to let event continue on, SDL_FALSE to drop it.
+ * \param return_val a pointer to the value to return to the OS from WndProc for this message.
+ * \returns SDL_TRUE if SDL should perform default handling for this mesage, SDL_FALSE if it 
+ *                   skip default handling and immediately return instead.
  *
  * \threadsafety This may only be called (by SDL) from the thread handling the
  *               Windows event loop.
@@ -71,7 +76,7 @@ typedef struct tagMSG MSG;
  * \sa SDL_SetWindowsMessageHook
  * \sa SDL_HINT_WINDOWS_ENABLE_MESSAGELOOP
  */
-typedef SDL_bool (SDLCALL *SDL_WindowsMessageHook)(void *userdata, MSG *msg);
+typedef SDL_bool (SDLCALL *SDL_WindowsMessageHook)(void *userdata, MSG *msg, Sint64 *return_val);
 
 /**
  * Set a callback for every Windows message, run before TranslateMessage().

--- a/include/SDL3/SDL_system.h
+++ b/include/SDL3/SDL_system.h
@@ -63,7 +63,8 @@ typedef struct tagMSG MSG;
  * 
  * \param userdata the app-defined pointer provided to
  *                 SDL_SetWindowsMessageHook.
- * \param msg a pointer to a Win32 event structure to process.
+ * \param msg a pointer to a Win32 event structure to process. The time, pt, and lpPrivate fields are unuswed.
+ * \param window the SDL_Window this message is associated with, or NULL if unknown or the hint is not enabled.
  * \param return_val a pointer to the value to return to the OS from WndProc for this message.
  * \returns SDL_TRUE if SDL should perform default handling for this mesage, SDL_FALSE if it 
  *                   skip default handling and immediately return instead.
@@ -76,7 +77,7 @@ typedef struct tagMSG MSG;
  * \sa SDL_SetWindowsMessageHook
  * \sa SDL_HINT_WINDOWS_ENABLE_MESSAGELOOP
  */
-typedef SDL_bool (SDLCALL *SDL_WindowsMessageHook)(void *userdata, MSG *msg, Sint64 *return_val);
+typedef SDL_bool (SDLCALL *SDL_WindowsMessageHook)(void *userdata, MSG *msg, SDL_Window *window, Sint64 *return_val);
 
 /**
  * Set a callback for every Windows message, run before TranslateMessage().

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1054,14 +1054,14 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
     if (!data) {
         if (g_WindowsMessageHook && g_HookEventsFromWindowProc) {
             MSG m;
-            LRESULT return_val = 0;
+            Sint64 return_val = 0;
             memset(&m, 0, sizeof(MSG));
             m.hwnd = hwnd;
             m.message = msg;
             m.wParam = wParam;
             m.lParam = lParam;
             if (!g_WindowsMessageHook(g_WindowsMessageHookData, &m, NULL, &return_val)) {
-                return return_val;
+                return (LRESULT)return_val;
             }
         }
         return CallWindowProc(DefWindowProc, hwnd, msg, wParam, lParam);
@@ -1082,14 +1082,14 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
     // Invoke the WindowsMessageHook if set and WndProc-time hook hint is enabled.
     if (g_WindowsMessageHook && g_HookEventsFromWindowProc) {
         MSG m;
-        LRESULT return_val = 0;
+        Sint64 return_val = 0;
         memset(&m, 0, sizeof(MSG));
         m.hwnd = hwnd;
         m.message = msg;
         m.wParam = wParam;
         m.lParam = lParam;
         if (!g_WindowsMessageHook(g_WindowsMessageHookData, &m, data->window, &return_val)) {
-            return return_val;
+            return (LRESULT)return_val;
         }
     }
 
@@ -2218,7 +2218,7 @@ int WIN_WaitEventTimeout(SDL_VideoDevice *_this, Sint64 timeoutNS)
                 return 0;
             }
             if (g_WindowsMessageHook && !g_HookEventsFromWindowProc) {
-                LRESULT dummy = 0;
+                Sint64 dummy = 0;
                 if (!g_WindowsMessageHook(g_WindowsMessageHookData, &msg, NULL, &dummy)) {
                     return 1;
                 }
@@ -2265,7 +2265,7 @@ void WIN_PumpEvents(SDL_VideoDevice *_this)
 
         while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
             if (g_WindowsMessageHook && !g_HookEventsFromWindowProc) {
-                LRESULT dummy = 0;
+                Sint64 dummy = 0;
                 if (!g_WindowsMessageHook(g_WindowsMessageHookData, &msg, NULL, &dummy)) {
                     continue;
                 }

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1060,7 +1060,7 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
             m.message = msg;
             m.wParam = wParam;
             m.lParam = lParam;
-            if (!g_WindowsMessageHook(g_WindowsMessageHookData, &m, &return_val)) {
+            if (!g_WindowsMessageHook(g_WindowsMessageHookData, &m, NULL, &return_val)) {
                 return return_val;
             }
         }
@@ -1088,7 +1088,7 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
         m.message = msg;
         m.wParam = wParam;
         m.lParam = lParam;
-        if (!g_WindowsMessageHook(g_WindowsMessageHookData, &m, &return_val)) {
+        if (!g_WindowsMessageHook(g_WindowsMessageHookData, &m, data->window, &return_val)) {
             return return_val;
         }
     }
@@ -2219,7 +2219,7 @@ int WIN_WaitEventTimeout(SDL_VideoDevice *_this, Sint64 timeoutNS)
             }
             if (g_WindowsMessageHook && !g_HookEventsFromWindowProc) {
                 LRESULT dummy = 0;
-                if (!g_WindowsMessageHook(g_WindowsMessageHookData, &msg, &dummy)) {
+                if (!g_WindowsMessageHook(g_WindowsMessageHookData, &msg, NULL, &dummy)) {
                     return 1;
                 }
             }
@@ -2266,7 +2266,7 @@ void WIN_PumpEvents(SDL_VideoDevice *_this)
         while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
             if (g_WindowsMessageHook && !g_HookEventsFromWindowProc) {
                 LRESULT dummy = 0;
-                if (!g_WindowsMessageHook(g_WindowsMessageHookData, &msg, &dummy)) {
+                if (!g_WindowsMessageHook(g_WindowsMessageHookData, &msg, NULL, &dummy)) {
                     continue;
                 }
             }

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -50,6 +50,7 @@ static void WIN_VideoQuit(SDL_VideoDevice *_this);
 SDL_bool g_WindowsEnableMessageLoop = SDL_TRUE;
 SDL_bool g_WindowsEnableMenuMnemonics = SDL_FALSE;
 SDL_bool g_WindowFrameUsableWhileCursorHidden = SDL_TRUE;
+SDL_bool g_HookEventsFromWindowProc = SDL_FALSE;
 
 static void SDLCALL UpdateWindowsRawKeyboard(void *userdata, const char *name, const char *oldValue, const char *newValue)
 {
@@ -71,6 +72,11 @@ static void SDLCALL UpdateWindowsEnableMenuMnemonics(void *userdata, const char 
 static void SDLCALL UpdateWindowFrameUsableWhileCursorHidden(void *userdata, const char *name, const char *oldValue, const char *newValue)
 {
     g_WindowFrameUsableWhileCursorHidden = SDL_GetStringBoolean(newValue, SDL_TRUE);
+}
+
+static void SDLCALL UpdateHookEventsFromWindowProc(void *userdata, const char *name, const char *oldValue, const char *newValue)
+{
+    g_HookEventsFromWindowProc = SDL_GetStringBoolean(newValue, SDL_TRUE);
 }
 
 #if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
@@ -518,6 +524,7 @@ int WIN_VideoInit(SDL_VideoDevice *_this)
     SDL_AddHintCallback(SDL_HINT_WINDOWS_ENABLE_MESSAGELOOP, UpdateWindowsEnableMessageLoop, NULL);
     SDL_AddHintCallback(SDL_HINT_WINDOWS_ENABLE_MENU_MNEMONICS, UpdateWindowsEnableMenuMnemonics, NULL);
     SDL_AddHintCallback(SDL_HINT_WINDOW_FRAME_USABLE_WHILE_CURSOR_HIDDEN, UpdateWindowFrameUsableWhileCursorHidden, NULL);
+    SDL_AddHintCallback(SDL_HINT_HOOK_EVENTS_FROM_WINDOW_PROC, UpdateHookEventsFromWindowProc, NULL);
 
 #if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
     data->_SDL_WAKEUP = RegisterWindowMessageA("_SDL_WAKEUP");
@@ -541,6 +548,7 @@ void WIN_VideoQuit(SDL_VideoDevice *_this)
     SDL_DelHintCallback(SDL_HINT_WINDOWS_ENABLE_MESSAGELOOP, UpdateWindowsEnableMessageLoop, NULL);
     SDL_DelHintCallback(SDL_HINT_WINDOWS_ENABLE_MENU_MNEMONICS, UpdateWindowsEnableMenuMnemonics, NULL);
     SDL_DelHintCallback(SDL_HINT_WINDOW_FRAME_USABLE_WHILE_CURSOR_HIDDEN, UpdateWindowFrameUsableWhileCursorHidden, NULL);
+    SDL_DelHintCallback(SDL_HINT_HOOK_EVENTS_FROM_WINDOW_PROC, UpdateHookEventsFromWindowProc, NULL);
 
     WIN_SetRawMouseEnabled(_this, SDL_FALSE);
     WIN_SetRawKeyboardEnabled(_this, SDL_FALSE);

--- a/src/video/windows/SDL_windowsvideo.h
+++ b/src/video/windows/SDL_windowsvideo.h
@@ -491,6 +491,7 @@ struct SDL_VideoData
 extern SDL_bool g_WindowsEnableMessageLoop;
 extern SDL_bool g_WindowsEnableMenuMnemonics;
 extern SDL_bool g_WindowFrameUsableWhileCursorHidden;
+extern SDL_bool g_HookEventsFromWindowProc;
 
 typedef struct IDirect3D9 IDirect3D9;
 extern SDL_bool D3D_LoadDLL(void **pD3DDLL, IDirect3D9 **pDirect3D9Interface);


### PR DESCRIPTION
## Description

- Signature of `SDL_WindowsMessageHook()` changed to support return value and pass the `SDL_Window` in.

 old decl:  ` typedef SDL_bool (SDLCALL *SDL_WindowsMessageHook)(void *userdata, MSG *msg);`
 new decl: `typedef SDL_bool (SDLCALL *SDL_WindowsMessageHook)(void *userdata, MSG *msg, SDL_Window *window, Sint64 *return_val);`

- Modified the event loop and handler so that any message in the event queue can be delivered to the hook function, not just the ones that SDL dispatches.

- Added a pre-init hint to select between the old behavior and the new behavior.  

   The new behavior takes effect iff the pre-init hint SDL_HOOK_EVENTS_FROM_WINDOW_PROC is set.   It is currently set to SDL_FALSE per default (ie. default SDL2 behavior).  At some point during our conversations @playmer felt that this was a pure bugfix and so there was no need to enable or disable the behavior.  If this is still true, I can easily remove the hint, or set it to default SDL_TRUE.   However I realized there are two use cases which might be problems if it were mandatory:
   
   First, this change necessarily means that code that used to hook and listen to untranslated key codes will now receive the translated messages (since they are dispatched), as well as the original untranslated messages (since they are also dispatched), instead of just the untranslated ones.  This could potentially cause confusing double-key-strokes.   However, it is probably mitigated by the fact that there is a completely separate mechanism now for hooking key event, which most new code likely uses.
   
   Second, and more importantly, there are some fields in the `MSG` structure send to the event loop whose values are not available during event dispatch.  In particular there is no way for the WndProc function to know the original values of the `time` field, which gives a timestamp of event generation, or the `pt` field, which records the cursor position at event generation.  So, any code that relies on these fields will want to use the old behavior.   (One can imagine logging these fields for session playback or anti-cheat purposes in games, as well as other use cases...)  
   
   It might be possible to overcome this limitation by maintaining a queue  of this extra information as it comes into the event loop, and adding it back into the `MSG  ` sent to the hook function during WndProc.   But this may be too complex for too little compatibility, when it could simple be configurable.

## Existing Issue(s)

This PR intends to resolve https://github.com/libsdl-org/SDL/issues/10497
