### PR TITLE
Add Cammus C12 VID & PID to wheel device list.

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -391,6 +391,7 @@ static Uint32 initial_wheel_devices[] = {
     MAKE_VIDPID(0x2433, 0xf303), /* Asetek SimSports La Prima Wheelbase */
     MAKE_VIDPID(0x2433, 0xf306), /* Asetek SimSports Tony Kannan Wheelbase */
     MAKE_VIDPID(0x3416, 0x0301), /* Cammus C5 Wheelbase */
+    MAKE_VIDPID(0x3416, 0x0302), /* Cammus C12 Wheelbase */
     MAKE_VIDPID(0x346e, 0x0000), /* Moza R16/R21 Wheelbase */
     MAKE_VIDPID(0x346e, 0x0002), /* Moza R9 Wheelbase */
     MAKE_VIDPID(0x346e, 0x0004), /* Moza R5 Wheelbase */


### PR DESCRIPTION
Add Cammus C12 in the SDL wheel list to enable wheel detection for them.

## Description
With this Cammus C12 Wheel Base can be detected as a wheel in SDL
VID/PID: `0x3416, 0x0302`