### PR TITLE
Fix xsettings list copy

### DIFF
--- a/src/video/x11/xsettings-client.c
+++ b/src/video/x11/xsettings-client.c
@@ -691,7 +691,11 @@ xsettings_list_copy (XSettingsList *list)
       if (new_iter)
         new_iter->next = new_node;
       else
-        new = new_node;
+        {
+          new = new_node;
+          new->next = NULL;
+        }
+
 
       new_iter = new_node;
 


### PR DESCRIPTION
## Description

If there is only 1 element in the list or memory allocation fails on the 2nd iteration then new->next is uninitialised. Any operation on the list will follow this uninitialised pointer.

@ebassi  I don't know where you get this version of xsettings.c from, could you propagate this fix upstream?

## Existing Issue(s)
None.  This function is not used in SDL.
