### PR TITLE
Fix error handling of SDL_AddHintCallback

### DIFF
--- a/src/SDL_hints.c
+++ b/src/SDL_hints.c
@@ -282,6 +282,8 @@ int SDL_AddHintCallback(const char *name, SDL_HintCallback callback, void *userd
         hint = (SDL_Hint *)SDL_malloc(sizeof(*hint));
         if (!hint) {
             SDL_free(entry);
+            SDL_UnlockProperties(hints);
+            return -1;
         } else {
             hint->value = NULL;
             hint->priority = SDL_HINT_DEFAULT;


### PR DESCRIPTION
## Description
Return immediately if allocation fails to avoid use after free of `entry`, null pointer dereference of `hint` and calling the user callback.

## Existing Issue(s)
None
