### PR TITLE
Support SDL_EVENT_DROP_TEXT in Wayland

### DIFF
--- a/src/video/wayland/SDL_waylanddatamanager.c
+++ b/src/video/wayland/SDL_waylanddatamanager.c
@@ -381,6 +381,9 @@ void *Wayland_data_offer_receive(SDL_WaylandDataOffer *offer,
         }
         close(pipefd[0]);
     }
+    SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
+                 ". In Wayland_data_offer_receive for '%s', buffer (%ld) at %p\n",
+                 mime_type, *length, buffer);
     return buffer;
 }
 
@@ -414,6 +417,9 @@ void *Wayland_primary_selection_offer_receive(SDL_WaylandPrimarySelectionOffer *
         }
         close(pipefd[0]);
     }
+    SDL_LogDebug(SDL_LOG_CATEGORY_INPUT,
+                 ". In Wayland_primary_selection_offer_receive for '%s', buffer (%ld) at %p\n",
+                 mime_type, *length, buffer);
     return buffer;
 }
 

--- a/src/video/wayland/SDL_waylanddatamanager.h
+++ b/src/video/wayland/SDL_waylanddatamanager.h
@@ -85,6 +85,7 @@ typedef struct
     uint32_t drag_serial;
     SDL_WaylandDataOffer *drag_offer;
     SDL_WaylandDataOffer *selection_offer;
+    SDL_bool has_mime_file, has_mime_text;
     SDL_Window *dnd_window;
 
     /* Clipboard and Primary Selection */


### PR DESCRIPTION
## Description
- In `src/video/wayland/SDL_waylanddatamanager.c`, Log `data_offer_receive` and `primary_selection_offer_receive`,
- In `src/video/wayland/SDL_waylanddatamanager.h`, Split FILE vs TEXT offers : booleans `has_mime_text`  and `has_mime_file`,
- In `src/video/wayland/SDL_waylandevents.c`, Log `data_device`, `data_offer`, `primary_selection_device` and `primary_selection_offer` events, Record FILE vs TEXT offers during `data_device_handle_enter` for use in `data_device_handle_drop`, Handle `text/plain;charset=utf-8` data offer in `data_device_handle_drop`.

## Existing Issue(s)
This is the best I can propose at this point :
- On the one hand, it works for Exult Studio dragging and dropping shapes into Exult, and it works when the Drag and Drop source is any tool of the LibreOffice family into `testdropfile`. I have not found any Drag and Drop capable Text Editor using Wayland.
- On the other hand, it does not work when dragging and dropping text from the Firefox browser or the Chromium browser into `testdropfile`.
With Firefox as source, `testdropfile` sees the `data_offer`, `enter`, `motion` and `drop` events as expected, but the `wl_data_offer_receive` call returns empty, the data is apparently held in the `primary_selection` instead. Mysteriously, however, Dragging and Dropping a _second_ time the still selected text area from Firefox now works, the `wl_data_offer_receive` succeeds.
With Chromium as source, `testdropfile` does not see any `data_offer`, `enter`, `motion` or `drop` event, only a `primary_selection_offer`. Finally, however, Chromium with experimental `Ozone` driving `Wayland` works.
