### PR TITLE
Fixed secondary screens on KMSDRM

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -1677,7 +1677,9 @@ int KMSDRM_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Properti
     SDL_SetKeyboardFocus(window);
 
     /* Tell the app that the window has moved to top-left. */
-    SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_MOVED, 0, 0);
+    SDL_Rect display_bounds;
+    SDL_GetDisplayBounds( SDL_GetDisplayForWindow(window), &display_bounds );
+    SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_MOVED, display_bounds.x, display_bounds.y);
 
     /* Allocated windata will be freed in KMSDRM_DestroyWindow,
        and KMSDRM_DestroyWindow() will be called by SDL_CreateWindow()

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -1678,7 +1678,7 @@ int KMSDRM_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Properti
 
     /* Tell the app that the window has moved to top-left. */
     SDL_Rect display_bounds;
-    SDL_GetDisplayBounds( SDL_GetDisplayForWindow(window), &display_bounds );
+    SDL_GetDisplayBounds(SDL_GetDisplayForWindow(window), &display_bounds);
     SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_MOVED, display_bounds.x, display_bounds.y);
 
     /* Allocated windata will be freed in KMSDRM_DestroyWindow,


### PR DESCRIPTION
The window couldn't be created on a secondary screen with KMSDRM backend. Its always was repositioned at 0,0.

## Description
The patch moves window too the top-leftt corner of a proper display it belongs to

## Existing Issue(s)
The window is always created on the first screen in KMSDRM backend