### PR TITLE
Fixed the incorrect touch device IDs on the Vita

### DIFF
--- a/src/video/vita/SDL_vitatouch.c
+++ b/src/video/vita/SDL_vitatouch.c
@@ -70,8 +70,8 @@ void VITA_InitTouch(void)
     }
 
     // Support passing both front and back touch devices in events
-    SDL_AddTouch((SDL_TouchID)0, SDL_TOUCH_DEVICE_DIRECT, "Front");
-    SDL_AddTouch((SDL_TouchID)1, SDL_TOUCH_DEVICE_INDIRECT_ABSOLUTE, "Back");
+    SDL_AddTouch((SDL_TouchID)1, SDL_TOUCH_DEVICE_DIRECT, "Front");
+    SDL_AddTouch((SDL_TouchID)2, SDL_TOUCH_DEVICE_INDIRECT_ABSOLUTE, "Back");
 }
 
 void VITA_QuitTouch(void)


### PR DESCRIPTION
~~NOTE: I am in process of local testing of the thing, I will turn this into ready-to-merge PR once I confirm the thing works on my end perfectly.~~ I found another bug, going to report it separately, This one let's just merge.

## Description
- Begining of device ID with 0 violates the SDL's specification that means the 0 is an error, invalid, failure, etc. But on Vita here it's an actual device...
- Replacing 0 and 1 with 1 and 2 to resolve this violation.

## Existing Issue(s)
#9830
