### PR TITLE
PSP: Throw SDL_Quit event upon exit

### DIFF
--- a/src/main/psp/SDL_psp_main.c
+++ b/src/main/psp/SDL_psp_main.c
@@ -8,6 +8,8 @@
 #include "SDL_main.h"
 #include <pspkernel.h>
 #include <pspthreadman.h>
+#include "SDL_events.h"
+#include "SDL_timer.h"
 
 #ifdef main
 #undef main
@@ -28,7 +30,15 @@ PSP_MAIN_THREAD_ATTR(THREAD_ATTR_VFPU | THREAD_ATTR_USER);
 
 int sdl_psp_exit_callback(int arg1, int arg2, void *common)
 {
-    sceKernelExitGame();
+    SDL_Event exit_event;
+    SDL_QuitEvent quit;
+
+    quit.type = SDL_QUIT;
+    quit.timestamp = SDL_GetTicks();
+
+    exit_event.quit = quit;
+
+    SDL_PushEvent(&exit_event);
     return 0;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
At the moment closing an SDL2 based application on the Playstation Portable using the home button will forcefully exit. This makes the application unable to make sure that everything exited out fine.

With this change, the user can handle the home button close in a way that makes sense for them. They will be forced to do so, though, as otherwise the application will freeze when trying to exit. I don't see this as different from how SDL2 based applications which do not handle the close button being pressed on PC not exiting, though. I think this is acceptable.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
