### PR TITLE
x11: Track cursor visibility internally

### DIFF
--- a/src/video/x11/SDL_x11mouse.c
+++ b/src/video/x11/SDL_x11mouse.c
@@ -30,6 +30,7 @@
 
 /* FIXME: Find a better place to put this... */
 static Cursor x11_empty_cursor = None;
+static SDL_bool x11_cursor_visible = SDL_TRUE;
 
 static Display *GetDisplay(void)
 {
@@ -298,6 +299,8 @@ static int X11_ShowCursor(SDL_Cursor *cursor)
         Display *display = GetDisplay();
         SDL_Window *window;
 
+        x11_cursor_visible = !!cursor;
+
         for (window = video->windows; window; window = window->next) {
             SDL_WindowData *data = (SDL_WindowData *)window->driverdata;
             if (data) {
@@ -317,12 +320,11 @@ static void WarpMouseInternal(Window xwindow, const int x, const int y)
 {
     SDL_VideoData *videodata = (SDL_VideoData *)SDL_GetVideoDevice()->driverdata;
     Display *display = videodata->display;
-    SDL_Mouse *mouse = SDL_GetMouse();
     int deviceid = 0;
     SDL_bool warp_hack = SDL_FALSE;
 
     /* XWayland will only warp the cursor if it is hidden, so this workaround is required. */
-    if (videodata->is_xwayland && mouse && mouse->cursor_shown) {
+    if (videodata->is_xwayland && x11_cursor_visible) {
         warp_hack = SDL_TRUE;
     }
 


### PR DESCRIPTION
Cursor visibility in the SDL input layer only reflects whether ShowCursor/HideCursor was called. In the case of relative mode, the cursor can be hidden, but the SDL_Mouse visibility flag will be true.

Track cursor visibility separately in the X11 driver. Fixes the cursor becoming visible when using the warping relative mode with XWayland.

(cherry picked from commit b0713a7d3047ca121c4257337da48cafbcbc44d4)

Fixes #10550 