### PR TITLE
wayland: Send fake warp coordinates when emulating warps with relativ…

### DIFF
--- a/src/video/wayland/SDL_waylandmouse.c
+++ b/src/video/wayland/SDL_waylandmouse.c
@@ -659,6 +659,7 @@ static void Wayland_WarpMouse(SDL_Window *window, int x, int y)
             Wayland_input_lock_pointer(input);
             input->relative_mode_override = SDL_TRUE;
         }
+        SDL_SendMouseMotion(window, 0, 0, x, y);
     }
 }
 


### PR DESCRIPTION
…e mode

Send the fake warp coordinates when emulating warps with relative mode to ensure that it appears that the cursor is always reset to where the application expects it to be.

Fixes cases where games can continue moving the camera if the mouse is lifted during motion.

Fixes #10547
