### PR TITLE
SDL_iostream.c: stdio_seek - skip API call for SEEK_CUR with 0 offset

### DIFF
--- a/src/file/SDL_iostream.c
+++ b/src/file/SDL_iostream.c
@@ -339,6 +339,7 @@ static Sint64 SDLCALL stdio_seek(void *userdata, Sint64 offset, SDL_IOWhence whe
 {
     IOStreamStdioData *iodata = (IOStreamStdioData *) userdata;
     int stdiowhence;
+    SDL_bool is_noop;
 
     switch (whence) {
     case SDL_IO_SEEK_SET:
@@ -360,7 +361,10 @@ static Sint64 SDLCALL stdio_seek(void *userdata, Sint64 offset, SDL_IOWhence whe
     }
 #endif
 
-    if (fseek(iodata->fp, (fseek_off_t)offset, stdiowhence) == 0) {
+    /* don't make a possibly-costly API call for the noop seek from SDL_TellIO */
+    is_noop = (whence == SDL_IO_SEEK_CUR && offset == 0);
+
+    if (is_noop || fseek(iodata->fp, (fseek_off_t)offset, stdiowhence) == 0) {
         const Sint64 pos = ftell(iodata->fp);
         if (pos < 0) {
             return SDL_SetError("Couldn't get stream offset");

--- a/src/file/SDL_iostream.c
+++ b/src/file/SDL_iostream.c
@@ -339,7 +339,6 @@ static Sint64 SDLCALL stdio_seek(void *userdata, Sint64 offset, SDL_IOWhence whe
 {
     IOStreamStdioData *iodata = (IOStreamStdioData *) userdata;
     int stdiowhence;
-    SDL_bool is_noop;
 
     switch (whence) {
     case SDL_IO_SEEK_SET:
@@ -362,7 +361,7 @@ static Sint64 SDLCALL stdio_seek(void *userdata, Sint64 offset, SDL_IOWhence whe
 #endif
 
     /* don't make a possibly-costly API call for the noop seek from SDL_TellIO */
-    is_noop = (whence == SDL_IO_SEEK_CUR && offset == 0);
+    const SDL_bool is_noop = (whence == SDL_IO_SEEK_CUR) && (offset == 0);
 
     if (is_noop || fseek(iodata->fp, (fseek_off_t)offset, stdiowhence) == 0) {
         const Sint64 pos = ftell(iodata->fp);


### PR DESCRIPTION
## Description
This is the SDL3 side of a PR optimizing the stdio implementation of `SDL_SeekIO(..., 0, SDL_IO_SEEK_CUR)`.

I did not change any implementations other than stdio because I am confident that `fseek(fp, 0, SEEK_CUR)` is a no-op, and I'm not certain about the other implementations. It's also possible that the underlying API is better optimized on other platforms.

Please feel free to alter my branch, it exists only for the sake of this PR.

## Existing Issue(s)
#10556 (fixes SDL3 side only)