### PR TITLE
SDL_rwops.c: stdio_seek - skip API call for RW_SEEK_CUR with 0 offset

### DIFF
--- a/src/file/SDL_rwops.c
+++ b/src/file/SDL_rwops.c
@@ -369,6 +369,7 @@ stdio_size(SDL_RWops * context)
 static Sint64 SDLCALL stdio_seek(SDL_RWops *context, Sint64 offset, int whence)
 {
     int stdiowhence;
+    SDL_bool is_noop;
 
     switch (whence) {
     case RW_SEEK_SET:
@@ -390,7 +391,10 @@ static Sint64 SDLCALL stdio_seek(SDL_RWops *context, Sint64 offset, int whence)
     }
 #endif
 
-    if (fseek(context->hidden.stdio.fp, (fseek_off_t)offset, stdiowhence) == 0) {
+    /* don't make a possibly-costly API call for the noop seek from SDL_RWtell */
+    is_noop = (whence == RW_SEEK_CUR && offset == 0);
+
+    if (is_noop || fseek(context->hidden.stdio.fp, (fseek_off_t)offset, stdiowhence) == 0) {
         Sint64 pos = ftell(context->hidden.stdio.fp);
         if (pos < 0) {
             return SDL_SetError("Couldn't get stream offset");


### PR DESCRIPTION
## Description
This is the SDL2 side of a PR optimizing the stdio implementation of `SDL_RWseek(..., 0, RW_SEEK_CUR)`.

I did not change any implementations other than stdio because I am confident that `fseek(fp, 0, SEEK_CUR)` is a no-op, and I'm not certain about the other implementations. It's also possible that the underlying API is better optimized on other platforms, but we have a confirmed 1-minute hang on 3DS resulting from `fseek` getting called by `SDL_RWtell`.

Please feel free to alter my branch, it exists only for the sake of this PR.

## Existing Issue(s)
#10556 (fixes SDL2 side only)