### PR TITLE
PSP: Throw SDL_EVENT_QUIT event upon exit

### DIFF
--- a/src/main/psp/SDL_sysmain_runapp.c
+++ b/src/main/psp/SDL_sysmain_runapp.c
@@ -27,6 +27,8 @@
 
 #include <pspkernel.h>
 #include <pspthreadman.h>
+#include "SDL3/SDL_events.h"
+#include "SDL3/SDL_timer.h"
 
 /* If application's main() is redefined as SDL_main, and libSDL_main is
    linked, then this file will create the standard exit callback,
@@ -43,7 +45,15 @@ PSP_MAIN_THREAD_ATTR(THREAD_ATTR_VFPU | THREAD_ATTR_USER);
 
 int sdl_psp_exit_callback(int arg1, int arg2, void *common)
 {
-    sceKernelExitGame();
+    SDL_Event exit_event;
+    SDL_QuitEvent quit;
+
+    quit.type = SDL_EVENT_QUIT;
+    quit.timestamp = SDL_GetTicks();
+
+    exit_event.quit = quit;
+
+    SDL_PushEvent(&exit_event);
     return 0;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
At the moment closing SDL3 applications on the PSP causes the application to be hard killed. I think instead if makes more sense to throw an SDL_EVENT_QUIT event, so the user can handle the exit logic like they would also have to do for other platforms. This is the SDL3 version of #1055.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
