### PR TITLE
Resolve g++-14 build failures in pipewire code

### DIFF
--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -56,7 +56,7 @@ static SDL_bool pipewire_initialized = SDL_FALSE;
 static const char *(*PIPEWIRE_pw_get_library_version)(void);
 static void (*PIPEWIRE_pw_init)(int *, char ***);
 static void (*PIPEWIRE_pw_deinit)(void);
-static struct pw_main_loop *(*PIPEWIRE_pw_main_loop_new)(struct pw_main_loop *loop);
+static struct pw_main_loop *(*PIPEWIRE_pw_main_loop_new)(const struct spa_dict *loop);
 static struct pw_loop *(*PIPEWIRE_pw_main_loop_get_loop)(struct pw_main_loop *loop);
 static int (*PIPEWIRE_pw_main_loop_run)(struct pw_main_loop *loop);
 static int (*PIPEWIRE_pw_main_loop_quit)(struct pw_main_loop *loop);

--- a/src/camera/pipewire/SDL_camera_pipewire.c
+++ b/src/camera/pipewire/SDL_camera_pipewire.c
@@ -61,7 +61,7 @@ static const char *(*PIPEWIRE_pw_get_library_version)(void);
 static bool (*PIPEWIRE_pw_check_library_version)(int major, int minor, int micro);
 static void (*PIPEWIRE_pw_init)(int *, char ***);
 static void (*PIPEWIRE_pw_deinit)(void);
-static struct pw_main_loop *(*PIPEWIRE_pw_main_loop_new)(struct pw_main_loop *loop);
+static struct pw_main_loop *(*PIPEWIRE_pw_main_loop_new)(const struct spa_dict *loop);
 static struct pw_loop *(*PIPEWIRE_pw_main_loop_get_loop)(struct pw_main_loop *loop);
 static int (*PIPEWIRE_pw_main_loop_run)(struct pw_main_loop *loop);
 static int (*PIPEWIRE_pw_main_loop_quit)(struct pw_main_loop *loop);


### PR DESCRIPTION
g++-13 complains:

```
SDL_pipewire.c:129:42: warning: assignment to "struct pw_main_loop *
(*)(struct pw_main_loop *)" from incompatible pointer type "struct
pw_main_loop * (*)(const struct spa_dict *)"
[-Wincompatible-pointer-types]
 129 | #define SDL_PIPEWIRE_SYM(x) PIPEWIRE_##x = x
SDL_pipewire.c:148:5: note: in expansion of macro "SDL_PIPEWIRE_SYM"
 148 |     SDL_PIPEWIRE_SYM(pw_main_loop_new);
```

g++-14 complains:

```
SDL_pipewire.c:129:42: error: assignment to "struct pw_main_loop *
(*)(const struct pw_main_loop *)" from incompatible pointer type
"struct pw_main_loop * (*)(const struct spa_dict *)"
[-Wincompatible-pointer-types]
```

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
