### PR TITLE
Fix warnings shown when making SDL_bool a typedef of bool

### DIFF
--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -792,7 +792,7 @@ SDL_DYNAPI_PROC(int,SDL_SetStringProperty,(SDL_PropertiesID a, const char *b, co
 SDL_DYNAPI_PROC(int,SDL_SetSurfaceAlphaMod,(SDL_Surface *a, Uint8 b),(a,b),return)
 SDL_DYNAPI_PROC(int,SDL_SetSurfaceBlendMode,(SDL_Surface *a, SDL_BlendMode b),(a,b),return)
 SDL_DYNAPI_PROC(SDL_bool,SDL_SetSurfaceClipRect,(SDL_Surface *a, const SDL_Rect *b),(a,b),return)
-SDL_DYNAPI_PROC(int,SDL_SetSurfaceColorKey,(SDL_Surface *a, int b, Uint32 c),(a,b,c),return)
+SDL_DYNAPI_PROC(int,SDL_SetSurfaceColorKey,(SDL_Surface *a, SDL_bool b, Uint32 c),(a,b,c),return)
 SDL_DYNAPI_PROC(int,SDL_SetSurfaceColorMod,(SDL_Surface *a, Uint8 b, Uint8 c, Uint8 d),(a,b,c,d),return)
 SDL_DYNAPI_PROC(int,SDL_SetSurfaceColorspace,(SDL_Surface *a, SDL_Colorspace b),(a,b),return)
 SDL_DYNAPI_PROC(int,SDL_SetSurfacePalette,(SDL_Surface *a, SDL_Palette *b),(a,b),return)

--- a/src/render/vulkan/SDL_render_vulkan.c
+++ b/src/render/vulkan/SDL_render_vulkan.c
@@ -3720,7 +3720,7 @@ static int VULKAN_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd
         rendererData->recreateSwapchain = SDL_FALSE;
     }
 
-    if (VULKAN_UpdateVertexBuffer(renderer, vertices, vertsize, &stateCache) < 0) {
+    if (!VULKAN_UpdateVertexBuffer(renderer, vertices, vertsize, &stateCache)) {
         return -1;
     }
 

--- a/src/stdlib/SDL_stdlib.c
+++ b/src/stdlib/SDL_stdlib.c
@@ -272,7 +272,7 @@ float SDL_fmodf(float x, float y)
 #endif
 }
 
-SDL_bool SDL_isinf(double x)
+int SDL_isinf(double x)
 {
 #ifdef HAVE_ISINF
     return isinf(x);
@@ -281,7 +281,7 @@ SDL_bool SDL_isinf(double x)
 #endif
 }
 
-SDL_bool SDL_isinff(float x)
+int SDL_isinff(float x)
 {
 #ifdef HAVE_ISINF_FLOAT_MACRO
     return isinf(x);
@@ -292,7 +292,7 @@ SDL_bool SDL_isinff(float x)
 #endif
 }
 
-SDL_bool SDL_isnan(double x)
+int SDL_isnan(double x)
 {
 #ifdef HAVE_ISNAN
     return isnan(x);
@@ -301,7 +301,7 @@ SDL_bool SDL_isnan(double x)
 #endif
 }
 
-SDL_bool SDL_isnanf(float x)
+int SDL_isnanf(float x)
 {
 #ifdef HAVE_ISNAN_FLOAT_MACRO
     return isnan(x);

--- a/src/video/SDL_RLEaccel_c.h
+++ b/src/video/SDL_RLEaccel_c.h
@@ -27,6 +27,6 @@
 /* Useful functions and variables from SDL_RLEaccel.c */
 
 extern int SDL_RLESurface(SDL_Surface *surface);
-extern void SDL_UnRLESurface(SDL_Surface *surface, int recode);
+extern void SDL_UnRLESurface(SDL_Surface *surface, SDL_bool recode);
 
 #endif /* SDL_RLEaccel_c_h_ */

--- a/src/video/SDL_video_unsupported.c
+++ b/src/video/SDL_video_unsupported.c
@@ -43,7 +43,7 @@ void SDL_SetWindowsMessageHook(SDL_WindowsMessageHook callback, void *userdata)
 #endif /* SDL_PLATFORM_WIN32 || SDL_PLATFORM_GDK */
 
 SDL_DECLSPEC int SDLCALL SDL_GetDXGIOutputInfo(SDL_DisplayID displayID, int *adapterIndex, int *outputIndex);
-SDL_bool SDL_GetDXGIOutputInfo(SDL_DisplayID displayID, int *adapterIndex, int *outputIndex)
+int SDL_GetDXGIOutputInfo(SDL_DisplayID displayID, int *adapterIndex, int *outputIndex)
 {
     (void)displayID;
     (void)adapterIndex;


### PR DESCRIPTION
This fixes warnings, shown when making `SDL_bool` a typedef of `int`.

```patch
--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -210,7 +210,8 @@ void *alloca(size_t);
  * \sa SDL_TRUE
  * \sa SDL_FALSE
  */
-typedef int SDL_bool;
+#include <stdbool.h>
+typedef bool SDL_bool;
 
 /**
  * A signed 8-bit integer type.
  * 
```

It also makes all `SDL_is` return a `SDL_bool`.



## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
