### PR TITLE
SDL_MetalViewEventWatch is a SDL_EventFilter and must return SDL_bool

### DIFF
--- a/src/video/cocoa/SDL_cocoametalview.m
+++ b/src/video/cocoa/SDL_cocoametalview.m
@@ -30,7 +30,7 @@
 
 #if defined(SDL_VIDEO_DRIVER_COCOA) && (defined(SDL_VIDEO_VULKAN) || defined(SDL_VIDEO_METAL))
 
-static int SDLCALL SDL_MetalViewEventWatch(void *userdata, SDL_Event *event)
+static SDL_bool SDLCALL SDL_MetalViewEventWatch(void *userdata, SDL_Event *event)
 {
     /* Update the drawable size when SDL receives a size changed event for
      * the window that contains the metal view. It would be nice to use
@@ -47,7 +47,7 @@ static int SDLCALL SDL_MetalViewEventWatch(void *userdata, SDL_Event *event)
             }
         }
     }
-    return 0;
+    return SDL_FALSE;
 }
 
 @implementation SDL3_cocoametalview


### PR DESCRIPTION
Found on ci by using [this modified workflow](https://github.com/madebr/SDL/commit/76c0b2f4c8af0bbc278e05aa1dc9c6b7f9a08efa).

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
