### PR TITLE
GDK: Xbox should have input focus by default

### DIFF
--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -523,6 +523,7 @@ static int SetupWindowData(SDL_VideoDevice *_this, SDL_Window *window, HWND hwnd
 
 #if defined(SDL_PLATFORM_XBOXONE) || defined(SDL_PLATFORM_XBOXSERIES)
     window->flags |= SDL_WINDOW_INPUT_FOCUS;
+    SDL_SetKeyboardFocus(window);
 #else
     if (GetFocus() == hwnd) {
         window->flags |= SDL_WINDOW_INPUT_FOCUS;


### PR DESCRIPTION
Currently on Xbox GDK, windows do not have input focus by default. So unless you set the `SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS` hint or do something else to explicitly focus the window (e.g. press the Xbox guide button, then close the system menu), all input events will be ignored.

I went back to the SDL 2.24.x branch and found it has the same behavior, so I don't believe this is a regression. I think we just happened to get lucky because `testcontroller` sets the aforementioned hint, as does FNA and presumably any other engines/games that have shipped with SDL GDK.

This change brings Xbox in line with the Windows implementation directly below by explicitly setting the focus.