### PR TITLE
Fix trailing doc comments in SDL_init.h

### DIFF
--- a/include/SDL3/SDL_init.h
+++ b/include/SDL3/SDL_init.h
@@ -89,9 +89,9 @@ typedef Uint32 SDL_InitFlags;
  */
 typedef enum SDL_AppResult
 {
-    SDL_APP_CONTINUE,   /** Value that requests that the app continue from the main callbacks. */
-    SDL_APP_SUCCESS,    /** Value that requests termination with success from the main callbacks. */
-    SDL_APP_FAILURE     /** Value that requests termination with error from the main callbacks. */
+    SDL_APP_CONTINUE,   /**< Value that requests that the app continue from the main callbacks. */
+    SDL_APP_SUCCESS,    /**< Value that requests termination with success from the main callbacks. */
+    SDL_APP_FAILURE     /**< Value that requests termination with error from the main callbacks. */
 } SDL_AppResult;
 
 typedef SDL_AppResult (SDLCALL *SDL_AppInit_func)(void **appstate, int argc, char *argv[]);


### PR DESCRIPTION
This fixes some recently added trailing doc comments in `SDL_init.h` to use the correct format for trailing doc comments.