### PR TITLE
Remove SDL_PEN hints that are no longer used

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2609,54 +2609,6 @@ extern "C" {
 #define SDL_HINT_ORIENTATIONS "SDL_ORIENTATIONS"
 
 /**
- * A variable controlling whether pen mouse button emulation triggers only
- * when the pen touches the tablet surface.
- *
- * The variable can be set to the following values:
- *
- * - "0": The pen reports mouse button press/release immediately when the pen
- *   button is pressed/released, and the pen tip touching the surface counts
- *   as left mouse button press.
- * - "1": Mouse button presses are sent when the pen first touches the tablet
- *   (analogously for releases). Not pressing a pen button simulates mouse
- *   button 1, pressing the first pen button simulates mouse button 2 etc.; it
- *   is not possible to report multiple buttons as pressed at the same time.
- *   (default)
- *
- * This hint can be set anytime.
- *
- * \since This hint is available since SDL 3.0.0.
- */
-#define SDL_HINT_PEN_DELAY_MOUSE_BUTTON    "SDL_PEN_DELAY_MOUSE_BUTTON"
-
-/**
- * A variable controlling whether to treat pen movement as separate from mouse
- * movement.
- *
- * By default, pens report both SDL_MouseMotionEvent and SDL_PenMotionEvent
- * updates (analogously for button presses). This hint allows decoupling mouse
- * and pen updates.
- *
- * This variable toggles between the following behaviour:
- *
- * - "0": Pen acts as a mouse with mouse ID SDL_PEN_MOUSEID. (default) Use
- *   case: client application is not pen aware, user wants to use pen instead
- *   of mouse to interact.
- * - "1": Pen reports mouse clicks and movement events but does not update
- *   SDL-internal mouse state (buttons pressed, current mouse location). Use
- *   case: client application is not pen aware, user frequently alternates
- *   between pen and "real" mouse.
- * - "2": Pen reports no mouse events. Use case: pen-aware client application
- *   uses this hint to allow user to toggle between pen+mouse mode ("2") and
- *   pen-only mode ("1" or "0").
- *
- * This hint can be set anytime.
- *
- * \since This hint is available since SDL 3.0.0.
- */
-#define SDL_HINT_PEN_NOT_MOUSE    "SDL_PEN_NOT_MOUSE"
-
-/**
  * A variable controlling the use of a sentinel event when polling the event
  * queue.
  *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR removes SDL_PEN hints that are no longer used.
