### PR TITLE
gpu_vulkan: fix memory leak in VULKAN_CreateDevice

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -4854,6 +4854,7 @@ static void VULKAN_DestroyDevice(
     SDL_free(renderer->shadersToDestroy);
     SDL_free(renderer->samplersToDestroy);
     SDL_free(renderer->framebuffersToDestroy);
+    SDL_free(renderer->allocationsToDefrag);
 
     SDL_DestroyMutex(renderer->allocatorLock);
     SDL_DestroyMutex(renderer->disposeLock);


### PR DESCRIPTION
Partially addresses #10629. That one reports D3D12 leaks; turns out there is one in Vulkan as well.

cc @thatcosmonaut 