### PR TITLE
SDL_test: add --gpu option

### DIFF
--- a/include/SDL3/SDL_test_common.h
+++ b/include/SDL3/SDL_test_common.h
@@ -91,6 +91,7 @@ typedef struct
     SDL_DisplayMode fullscreen_mode;
     int num_windows;
     SDL_Window **windows;
+    const char *gpudriver;
 
     /* Renderer info */
     const char *renderdriver;

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -72,6 +72,7 @@ static const char *video_usage[] = {
     "[--usable-bounds]",
     "[--utility]",
     "[--video driver]",
+    "[--gpu driver]",
     "[--vsync]"
 };
 
@@ -614,6 +615,15 @@ int SDLTest_CommonArg(SDLTest_CommonState *state, int index)
         if (SDL_strcasecmp(argv[index], "--hide-cursor") == 0) {
             state->hide_cursor = SDL_TRUE;
             return 1;
+        }
+        if (SDL_strcasecmp(argv[index], "--gpu") == 0) {
+            ++index;
+            if (!argv[index]) {
+                return -1;
+            }
+            state->gpudriver = argv[index];
+            SDL_SetHint(SDL_HINT_GPU_DRIVER, state->gpudriver);
+            return 2;
         }
     } else {
         if (SDL_strcasecmp(argv[index], "--info") == 0) {

--- a/test/testgpu_spinning_cube.c
+++ b/test/testgpu_spinning_cube.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 1997-2022 Sam Lantinga <slouken@libsdl.org>
+  Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages
@@ -470,7 +470,7 @@ init_render_state(int msaa)
     gpu_device = SDL_CreateGPUDevice(
         TESTGPU_SUPPORTED_FORMATS,
         SDL_TRUE,
-        NULL
+        state->gpudriver
     );
     CHECK_CREATE(gpu_device, "GPU device");
 


### PR DESCRIPTION
This adds a `--gpu <gpu-driver>` to all tests using SDL_test.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
Fixes #10626