### PR TITLE
Fix C4090: 'function': different 'const' qualifiers

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -11023,7 +11023,7 @@ static Uint8 VULKAN_INTERNAL_CreateInstance(VulkanRenderer *renderer)
     instanceExtensionNames = SDL_stack_alloc(
         const char *,
         instanceExtensionCount + 4);
-    SDL_memcpy(instanceExtensionNames, originalInstanceExtensionNames, instanceExtensionCount * sizeof(const char *));
+    SDL_memcpy((void *)instanceExtensionNames, originalInstanceExtensionNames, instanceExtensionCount * sizeof(const char *));
 
     // Core since 1.1
     instanceExtensionNames[instanceExtensionCount++] =
@@ -11431,7 +11431,7 @@ static Uint8 VULKAN_INTERNAL_CreateLogicalDevice(
         &deviceCreateInfo,
         NULL,
         &renderer->logicalDevice);
-    SDL_stack_free(deviceExtensions);
+    SDL_stack_free((void *)deviceExtensions);
     VULKAN_ERROR_CHECK(vulkanResult, vkCreateDevice, 0)
 
     // Load vkDevice entry points


### PR DESCRIPTION
This warning showed up with cl 19.29.30154 (from Visual Studio 2019)

@thatcosmonaut 
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
