### PR TITLE
GPU Metal: Fix uninitialized memory access crash in `BeginRenderPass`

### DIFF
--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -3407,7 +3407,7 @@ static bool METAL_ClaimWindow(
         MetalWindowData *windowData = METAL_INTERNAL_FetchWindowData(window);
 
         if (windowData == NULL) {
-            windowData = (MetalWindowData *)SDL_malloc(sizeof(MetalWindowData));
+            windowData = (MetalWindowData *)SDL_calloc(1, sizeof(MetalWindowData));
             windowData->window = window;
 
             if (METAL_INTERNAL_CreateSwapchain(renderer, windowData, SDL_GPU_SWAPCHAINCOMPOSITION_SDR, SDL_GPU_PRESENTMODE_VSYNC)) {


### PR DESCRIPTION
This PR fixes uninitialized memory access in `METAL_BeginRenderPass` when using SDL_gpu with the Metal backend.

## Description

I tried to integrate SDL_gpu into my project but even the [SDL_gpu_examples](https://github.com/TheSpydog/SDL_gpu_examples) files were always crashing. I tracked it down to the uninitilaized memory access in `METAL_BeginRenderPass` `texture->msaaHandle` with the help of clang's AddressSanitizer. With ASan `msaaHandle` will be filled with `0xbebebebe`.

<img width="836" alt="image" src="https://github.com/user-attachments/assets/ab99ec15-aa66-4f64-81aa-058c6ab98785">

https://github.com/libsdl-org/SDL/blob/5d5a685a8004fe8ceaf3dc5b3e9b431b32603e4b/src/gpu/metal/SDL_gpu_metal.m#L2083

This memory is allocated in `METAL_ClaimWindow` with `SDL_malloc` and not all fields are initialized.
https://github.com/libsdl-org/SDL/blob/5d5a685a8004fe8ceaf3dc5b3e9b431b32603e4b/src/gpu/metal/SDL_gpu_metal.m#L3410

After looking into other backends I noticed d3d12 is using `SDL_calloc` to allocate the window data structure. This is what I am doing in this PR as well.

https://github.com/libsdl-org/SDL/blob/5d5a685a8004fe8ceaf3dc5b3e9b431b32603e4b/src/gpu/d3d12/SDL_gpu_d3d12.c#L6326-L6329

But d3d11 and vulkan are using the same uninitialized `malloc` allocation as metal. I don't have a device to test d3d11 and vulkan so I can't verify if those backends have the same issue.

https://github.com/libsdl-org/SDL/blob/31a5f3b8335fca088a8f182f323b8d9a236fb5d3/src/gpu/d3d11/SDL_gpu_d3d11.c#L5102-L5103
https://github.com/libsdl-org/SDL/blob/31a5f3b8335fca088a8f182f323b8d9a236fb5d3/src/gpu/vulkan/SDL_gpu_vulkan.c#L9711-L9714

## Repro steps

Here is a minimal example that will crash when compiled with `-fsanitize=address` on MacOS with SDL_gpu.

```c
#include <SDL3/SDL.h>

int main() {
  if (!SDL_Init(SDL_INIT_VIDEO)) {
    SDL_Log("SDL_Init failed: %s", SDL_GetError());
    return 1;
  }

  SDL_GPUDevice *device = SDL_CreateGPUDevice(SDL_GPU_SHADERFORMAT_MSL, SDL_TRUE, NULL);
  if (device == NULL) {
    SDL_Log("GPUCreateDevice failed");
    return 1;
  }

  SDL_Window *window = SDL_CreateWindow("App", 640, 480, 0);
  if (window == NULL) {
    SDL_Log("CreateWindow failed: %s", SDL_GetError());
    return 1;
  }

  if (!SDL_ClaimWindowForGPUDevice(device, window)) {
    SDL_Log("GPUClaimWindow failed");
    return 1;
  }

  bool quit = false;

  while (!quit) {
    SDL_Event evt;
    while (SDL_PollEvent(&evt)) {
      if (evt.type == SDL_EVENT_QUIT) {
        quit = true;
      }
    }

    SDL_GPUCommandBuffer* cmdbuf = SDL_AcquireGPUCommandBuffer(device);
    if (cmdbuf == NULL) {
      SDL_Log("GPUAcquireCommandBuffer failed");
      return 1;
    }

    Uint32 w, h;
    SDL_GPUTexture* swapchainTexture = SDL_AcquireGPUSwapchainTexture(cmdbuf, window, &w, &h);
    if (swapchainTexture != NULL) {
      SDL_GPUColorAttachmentInfo colorAttachmentInfo = { 0 };
      colorAttachmentInfo.texture = swapchainTexture;
      colorAttachmentInfo.clearColor = (SDL_FColor){ 0.3f, 0.4f, 0.5f, 1.0f };
      colorAttachmentInfo.loadOp = SDL_GPU_LOADOP_CLEAR;
      colorAttachmentInfo.storeOp = SDL_GPU_STOREOP_STORE;

      SDL_GPURenderPass* renderPass = SDL_BeginGPURenderPass(cmdbuf, &colorAttachmentInfo, 1, NULL);
      SDL_EndGPURenderPass(renderPass);
    }

    SDL_SubmitGPUCommandBuffer(cmdbuf);
  }

  SDL_ReleaseWindowFromGPUDevice(device, window);
  SDL_DestroyWindow(window);
  SDL_DestroyGPUDevice(device);

  return 0;
}
```