### PR TITLE
Added includes to SDL_gpu.h

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -31,6 +31,11 @@
 #define SDL_GPU_H
 
 #include <SDL3/SDL_stdinc.h>
+#include <SDL3/SDL_properties.h>
+#include <SDL3/SDL_pixels.h>
+#include <SDL3/SDL_rect.h>
+#include <SDL3/SDL_surface.h>
+#include <SDL3/SDL_video.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
When compiling following code:
```c
#include <SDL3/SDL_gpu.h>
int main(void) {return 0;}
```
there are a bunch of "unknown type" errors:
```c
/path/to/SDL-git/include/SDL3/SDL_gpu.h:608:5: error: unknown type name ‘SDL_PropertiesID’
/path/to/SDL-git/include/SDL3/SDL_gpu.h:794:5: error: unknown type name ‘SDL_FColor’
/path/to/SDL-git/include/SDL3/SDL_gpu.h:1627:5: error: unknown type name ‘SDL_Rect’
/path/to/SDL-git/include/SDL3/SDL_gpu.h:2267:5: error: unknown type name ‘SDL_FlipMode’
/path/to/SDL-git/include/SDL3/SDL_gpu.h:2289:5: error: unknown type name ‘SDL_Window’
```

This commit adds the headers for these types to `SDL_gpu.h`.