### PR TITLE
Added headers to some SDL_test_*.h files

### DIFF
--- a/include/SDL3/SDL_test_assert.h
+++ b/include/SDL3/SDL_test_assert.h
@@ -34,6 +34,8 @@
 #ifndef SDL_test_assert_h_
 #define SDL_test_assert_h_
 
+#include <SDL3/SDL_stdinc.h>
+
 #include <SDL3/SDL_begin_code.h>
 /* Set up for C function definitions, even when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_test_font.h
+++ b/include/SDL3/SDL_test_font.h
@@ -30,6 +30,10 @@
 #ifndef SDL_test_font_h_
 #define SDL_test_font_h_
 
+#include <SDL3/SDL_stdinc.h>
+#include <SDL3/SDL_rect.h>
+#include <SDL3/SDL_render.h>
+
 #include <SDL3/SDL_begin_code.h>
 /* Set up for C function definitions, even when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_test_fuzzer.h
+++ b/include/SDL3/SDL_test_fuzzer.h
@@ -34,6 +34,8 @@
 #ifndef SDL_test_fuzzer_h_
 #define SDL_test_fuzzer_h_
 
+#include <SDL3/SDL_stdinc.h>
+
 #include <SDL3/SDL_begin_code.h>
 /* Set up for C function definitions, even when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_test_harness.h
+++ b/include/SDL3/SDL_test_harness.h
@@ -36,6 +36,8 @@
 #ifndef SDL_test_h_arness_h
 #define SDL_test_h_arness_h
 
+#include <SDL3/SDL_stdinc.h>
+
 #include <SDL3/SDL_begin_code.h>
 /* Set up for C function definitions, even when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_test_log.h
+++ b/include/SDL3/SDL_test_log.h
@@ -36,6 +36,8 @@
 #ifndef SDL_test_log_h_
 #define SDL_test_log_h_
 
+#include <SDL3/SDL_stdinc.h>
+
 #include <SDL3/SDL_begin_code.h>
 /* Set up for C function definitions, even when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_test_md5.h
+++ b/include/SDL3/SDL_test_md5.h
@@ -56,6 +56,8 @@
 #ifndef SDL_test_md5_h_
 #define SDL_test_md5_h_
 
+#include <SDL3/SDL_stdinc.h>
+
 #include <SDL3/SDL_begin_code.h>
 /* Set up for C function definitions, even when using C++ */
 #ifdef __cplusplus


### PR DESCRIPTION
Some `SDL_test_*.h` files were missing some headers:
```c
/path/to/SDL-git/include/SDL3/SDL_test_assert.h:55:42: error: unknown type name ‘SDL_PRINTF_FORMAT_STRING’

/path/to/SDL-git/include/SDL3/SDL_test_font.h:55:1: error: unknown type name ‘SDL_bool’
/path/to/SDL-git/include/SDL3/SDL_test_font.h:55:32: error: unknown type name ‘SDL_Renderer’
/path/to/SDL-git/include/SDL3/SDL_test_font.h:76:5: error: unknown type name ‘SDL_FRect’
/path/to/SDL-git/include/SDL3/SDL_test_font.h:136:89: error: unknown type name ‘size_t’

/path/to/SDL-git/include/SDL3/SDL_test_fuzzer.h:60:25: error: unknown type name ‘Uint64’

/path/to/SDL-git/include/SDL3/SDL_test_harness.h:124:90: error: unknown type name ‘Uint64’

/path/to/SDL-git/include/SDL3/SDL_test_log.h:50:18: error: unknown type name ‘SDL_PRINTF_FORMAT_STRING’

/path/to/SDL-git/include/SDL3/SDL_test_md5.h:68:11: error: unknown type name ‘Uint32’
```

This commit adds those.