### PR TITLE
Fix multiple definitions of SDL_assert* when SDL_WIKI_DOCUMENTATION_SECTION is defined

### DIFF
--- a/include/SDL3/SDL_assert.h
+++ b/include/SDL3/SDL_assert.h
@@ -366,10 +366,9 @@ extern SDL_DECLSPEC SDL_AssertState SDLCALL SDL_ReportAssertion(SDL_AssertData *
  * \since This macro is available since SDL 3.0.0.
  */
 #define SDL_assert_paranoid(condition) SDL_disabled_assert(condition)
-#endif
 
 /* Enable various levels of assertions. */
-#if SDL_ASSERT_LEVEL == 0   /* assertions disabled */
+#elif SDL_ASSERT_LEVEL == 0   /* assertions disabled */
 #   define SDL_assert(condition) SDL_disabled_assert(condition)
 #   define SDL_assert_release(condition) SDL_disabled_assert(condition)
 #   define SDL_assert_paranoid(condition) SDL_disabled_assert(condition)


### PR DESCRIPTION
This fixes multiple definitions of SDL_assert* in SDL_assert.h when SDL_WIKI_DOCUMENTATION_SECTION is defined.

(This is currently required for my SDL header parser/binding generator to work)