### PR TITLE
SDL_test_memory.h: Added void to function prototype

### DIFF
--- a/include/SDL3/SDL_test_memory.h
+++ b/include/SDL3/SDL_test_memory.h
@@ -49,7 +49,7 @@ void SDLTest_TrackAllocations(void);
  *
  * \note This implicitly calls SDLTest_TrackAllocations()
  */
-void SDLTest_RandFillAllocations();
+void SDLTest_RandFillAllocations(void);
 
 /**
  * Print a log of any outstanding allocations


### PR DESCRIPTION
```c
/path/to/SDL-git/include/SDL3/SDL_test_memory.h:52:33: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
   52 | void SDLTest_RandFillAllocations();
      |                                 ^
      |                                  void
```