### PR TITLE
GPU: Fix swap chain resize for d3d12

### DIFF
--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -6109,8 +6109,8 @@ static bool D3D12_INTERNAL_ResizeSwapchainIfNeeded(
         HRESULT res = IDXGISwapChain_ResizeBuffers(
             windowData->swapchain,
             0, // Keep buffer count the same
-            swapchainDesc.BufferDesc.Width,
-            swapchainDesc.BufferDesc.Height,
+            w,
+            h,
             DXGI_FORMAT_UNKNOWN, // Keep the old format
             renderer->supportsTearing ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0);
         ERROR_CHECK_RETURN("Could not resize swapchain buffers", 0)


### PR DESCRIPTION
## Description
While trying out SDL GPU I discovered that resizing the window would not resize the swap chain.
After digging into the code I found that the implementation for d3d12 was resizing the swap chain to the old size instead of the new window size.

Simple enough fix, just pass the new window size when resizing the swap chain.
