### PR TITLE
GPU: Compile Metal shader source from NSString

### DIFF
--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -740,8 +740,12 @@ static MetalLibraryFunction METAL_INTERNAL_CompileShader(
     id<MTLFunction> function;
 
     if (format == SDL_GPU_SHADERFORMAT_MSL) {
+        NSString *codeString = [[NSString alloc]
+            initWithBytes:code
+                   length:codeSize
+                 encoding:NSUTF8StringEncoding];
         library = [renderer->device
-            newLibraryWithSource:@((const char *)code)
+            newLibraryWithSource:codeString
                          options:nil
                            error:&error];
     } else if (format == SDL_GPU_SHADERFORMAT_METALLIB) {


### PR DESCRIPTION
## Description

Using the `@()` syntax to construct an `NSString` assumes the parenthesized pointer is null-terminated, but the Metal shader source included in `render/sdlgpu/shaders/metal.h` is not null-terminated.

Quoting the clang documentation on Objective-C literals:

> When the type of the parenthesized expression is `(char *)` or `(const char *)`, the result of the boxed expression is a pointer to an `NSString` object containing equivalent character data, which is assumed to be `\0`-terminated and UTF-8 encoded.

Because the `@()` syntax assumes null-termination, it may read garbage data after the shader source (up to the next null byte), which can then cause the Metal shader compiler to fail. To prevent this, instead of using the `@()` boxing syntax, we explicitly construct an `NSString` using the string length passed by the caller.

## Example of the Issue

```
2024-09-02 07:31:29.766512-0500 testrendercopyex[30107:1813987] Compiler failed to build request
Process 30107 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
    frame #0: 0x0000000100e7e738 libSDL3.0.dylib`METAL_INTERNAL_CompileShader(renderer=0x000000013af08b00, format=16, code="#include <metal_stdlib>\n#include <simd/simd.h>\n\nusing namespace metal;\n\nstruct _18\n{\n    float4x4 _m0;\n    float4 _m1;\n    float2 _m2;\n};\n\nstruct main0_out\n{\n    float4 m_35 [[user(locn0)]];\n    float4 gl_Position [[position]];\n};\n\nstruct main0_in\n{\n    float2 m_25 [[attribute(0)]];\n    float4 m_37 [[attribute(1)]];\n};\n\nvertex main0_out main0(main0_in in [[stage_in]], constant _18& _20 [[buffer(0)]])\n{\n    main0_out out = {};\n    out.gl_Position = _20._m0 * float4(in.m_25, 0.0, 1.0);\n    out.m_35 = in.m_37;\n    return out;\n}\n\n\U00000014\U00000002", codeSize=532, entryPointName="main0") at SDL_gpu_metal.m:760:9
   757 	   }
   758 	
   759 	   if (library == nil) {
-> 760 	       SDL_LogError(
   761 	           SDL_LOG_CATEGORY_GPU,
   762 	           "Creating MTLLibrary failed: %s",
   763 	           [[error description] cStringUsingEncoding:[NSString defaultCStringEncoding]]);
Target 0: (testrendercopyex) stopped.
(lldb) po code
"#include <metal_stdlib>\n#include <simd/simd.h>\n\nusing namespace metal;\n\nstruct _18\n{\n    float4x4 _m0;\n    float4 _m1;\n    float2 _m2;\n};\n\nstruct main0_out\n{\n    float4 m_35 [[user(locn0)]];\n    float4 gl_Position [[position]];\n};\n\nstruct main0_in\n{\n    float2 m_25 [[attribute(0)]];\n    float4 m_37 [[attribute(1)]];\n};\n\nvertex main0_out main0(main0_in in [[stage_in]], constant _18& _20 [[buffer(0)]])\n{\n    main0_out out = {};\n    out.gl_Position = _20._m0 * float4(in.m_25, 0.0, 1.0);\n    out.m_35 = in.m_37;\n    return out;\n}\n\n\U00000014\U00000002"
```

As you can see, at the end of the `code` variable are two bytes `\U00000014\U00000002` that cause the Metal compiler to fail.