### PR TITLE
GDK build: PFN_D3D12_XBOX_CREATE_DEVICE not defined for Xbox One

### DIFF
--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -882,6 +882,11 @@ static ID3D12Device *s_Device;
 static ID3D12CommandQueue *s_CommandQueue;
 #endif
 
+#if defined(SDL_PLATFORM_XBOXONE)
+// This is not defined in d3d12_x.h.
+typedef HRESULT (D3DAPI* PFN_D3D12_XBOX_CREATE_DEVICE)(_In_opt_ IGraphicsUnknown*, _In_ const D3D12XBOX_CREATE_DEVICE_PARAMETERS*, _In_ REFIID, _Outptr_opt_ void**);
+#endif
+
 // Logging
 
 static void


### PR DESCRIPTION
For some reason only known to Microsoft, `PFN_D3D12_XBOX_CREATE_DEVICE` is defined in `d3d12_xs.h`, but not in `d3d12_x.h`.

Checked/compiled with two recent GDK releases, including the latest version.