### PR TITLE
Add padding for non-32-bit-aligned types in structs

### DIFF
--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -381,6 +381,9 @@ typedef struct SDL_TextEditingCandidatesEvent
     Sint32 num_candidates;      /**< The number of strings in `candidates` */
     Sint32 selected_candidate;  /**< The index of the selected candidate, or -1 if no candidate is selected */
     SDL_bool horizontal;          /**< SDL_TRUE if the list is horizontal, SDL_FALSE if it's vertical */
+    Uint8 padding1;
+    Uint8 padding2;
+    Uint8 padding3;
 } SDL_TextEditingCandidatesEvent;
 
 /**

--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -627,7 +627,8 @@ typedef struct SDL_GPUSamplerCreateInfo
     float maxAnisotropy;
     SDL_bool anisotropyEnable;
     SDL_bool compareEnable;
-    Uint16 padding;
+    Uint8 padding1;
+    Uint8 padding2;
     SDL_GPUCompareOp compareOp;
     float minLod;
     float maxLod;

--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -508,6 +508,9 @@ typedef struct SDL_GPUDepthStencilValue
 {
     float depth;
     Uint8 stencil;
+    Uint8 padding1;
+    Uint8 padding2;
+    Uint8 padding3;
 } SDL_GPUDepthStencilValue;
 
 typedef struct SDL_GPUViewport
@@ -621,9 +624,10 @@ typedef struct SDL_GPUSamplerCreateInfo
     SDL_GPUSamplerAddressMode addressModeV;
     SDL_GPUSamplerAddressMode addressModeW;
     float mipLodBias;
-    SDL_bool anisotropyEnable;
     float maxAnisotropy;
+    SDL_bool anisotropyEnable;
     SDL_bool compareEnable;
+    Uint16 padding;
     SDL_GPUCompareOp compareOp;
     float minLod;
     float maxLod;
@@ -666,6 +670,9 @@ typedef struct SDL_GPUStencilOpState
 typedef struct SDL_GPUColorAttachmentBlendState
 {
     SDL_bool blendEnable;
+    Uint8 padding1;
+    Uint8 padding2;
+    Uint8 padding3;
     SDL_GPUBlendFactor srcColorBlendFactor;
     SDL_GPUBlendFactor dstColorBlendFactor;
     SDL_GPUBlendOp colorBlendOp;
@@ -735,6 +742,9 @@ typedef struct SDL_GPURasterizerState
     SDL_GPUCullMode cullMode;
     SDL_GPUFrontFace frontFace;
     SDL_bool depthBiasEnable;
+    Uint8 padding1;
+    Uint8 padding2;
+    Uint8 padding3;
     float depthBiasConstantFactor;
     float depthBiasClamp;
     float depthBiasSlopeFactor;
@@ -750,13 +760,15 @@ typedef struct SDL_GPUDepthStencilState
 {
     SDL_bool depthTestEnable;
     SDL_bool depthWriteEnable;
-    SDL_GPUCompareOp compareOp;
     SDL_bool stencilTestEnable;
+    Uint8 padding1;
+    SDL_GPUCompareOp compareOp;
     SDL_GPUStencilOpState backStencilState;
     SDL_GPUStencilOpState frontStencilState;
     Uint8 compareMask;
     Uint8 writeMask;
     Uint8 reference;
+    Uint8 padding2;
 } SDL_GPUDepthStencilState;
 
 typedef struct SDL_GPUColorAttachmentDescription
@@ -770,6 +782,9 @@ typedef struct SDL_GPUGraphicsPipelineAttachmentInfo
     SDL_GPUColorAttachmentDescription *colorAttachmentDescriptions;
     Uint32 colorAttachmentCount;
     SDL_bool hasDepthStencilAttachment;
+    Uint8 padding1;
+    Uint8 padding2;
+    Uint8 padding3;
     SDL_GPUTextureFormat depthStencilFormat;
 } SDL_GPUGraphicsPipelineAttachmentInfo;
 
@@ -843,6 +858,9 @@ typedef struct SDL_GPUColorAttachmentInfo
 
     /* if SDL_TRUE, cycles the texture if the texture is bound and loadOp is not LOAD */
     SDL_bool cycle;
+    Uint8 padding1;
+    Uint8 padding2;
+    Uint8 padding3;
 } SDL_GPUColorAttachmentInfo;
 
 typedef struct SDL_GPUDepthStencilAttachmentInfo
@@ -905,6 +923,9 @@ typedef struct SDL_GPUDepthStencilAttachmentInfo
 
     /* if SDL_TRUE, cycles the texture if the texture is bound and any load ops are not LOAD */
     SDL_bool cycle;
+    Uint8 padding1;
+    Uint8 padding2;
+    Uint8 padding3;
 } SDL_GPUDepthStencilAttachmentInfo;
 
 /* Binding structs */
@@ -927,6 +948,9 @@ typedef struct SDL_GPUStorageBufferWriteOnlyBinding
 
     /* if SDL_TRUE, cycles the buffer if it is bound. */
     SDL_bool cycle;
+    Uint8 padding1;
+    Uint8 padding2;
+    Uint8 padding3;
 } SDL_GPUStorageBufferWriteOnlyBinding;
 
 typedef struct SDL_GPUStorageTextureWriteOnlyBinding
@@ -937,6 +961,9 @@ typedef struct SDL_GPUStorageTextureWriteOnlyBinding
 
     /* if SDL_TRUE, cycles the texture if the texture is bound. */
     SDL_bool cycle;
+    Uint8 padding1;
+    Uint8 padding2;
+    Uint8 padding3;
 } SDL_GPUStorageTextureWriteOnlyBinding;
 
 /* Functions */


### PR DESCRIPTION
This was causing interop issues.