### PR TITLE
GPU: vulkan: Respect swapchain minImageCount

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -4618,6 +4618,10 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
         swapchainData->imageCount = swapchainSupportDetails.capabilities.maxImageCount;
     }
 
+    if (swapchainData->imageCount < swapchainSupportDetails.capabilities.minImageCount) {
+        swapchainData->imageCount = swapchainSupportDetails.capabilities.minImageCount;
+    }
+
     if (swapchainData->presentMode == VK_PRESENT_MODE_MAILBOX_KHR) {
         /* Required for proper triple-buffering.
          * Note that this is below the above maxImageCount check!


### PR DESCRIPTION
The default value of MAX_FRAMES_IN_FLIGHT (3) may be less than the minImageCount returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR() on some setups. For example, the Intel IVB Vulkan driver on Wayland returns a minImageCount of 4, resulting in the following validation warning:

```
VUID-VkSwapchainCreateInfoKHR-presentMode-02839(ERROR / SPEC): msgNum: -76493605 - Validation Error:
[ VUID-VkSwapchainCreateInfoKHR-presentMode-02839 ] | MessageID = 0xfb70ccdb | vkCreateSwapchainKHR(): 
pCreateInfo->minImageCount 3, which is outside the bounds returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR() (i.e. minImageCount = 4, maxImageCount = 0).
The Vulkan spec states: If presentMode is not VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR nor VK_PRESENT_MODE_SHARED_CONTINUOUS_REFRESH_KHR, then minImageCount must be greater than or equal to the value returned in the minImageCount member of the VkSurfaceCapabilitiesKHR structure returned by vkGetPhysicalDeviceSurfaceCapabilitiesKHR for the surface
(https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkSwapchainCreateInfoKHR-presentMode-02839)
    Objects: 0
```

Use the minimum image count in that case, as it's as close as we'll get to our preferred value. Note also that, unlike maxImageCount, minImageCount is never 0 (the spec states it is always at least 1), so we don't need a similar check to see if it applies.