### PR TITLE
Android.mk: allow to compile with storage functions

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -65,6 +65,8 @@ LOCAL_SRC_FILES := \
 	$(wildcard $(LOCAL_PATH)/src/render/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/render/*/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/stdlib/*.c) \
+	$(wildcard $(LOCAL_PATH)/src/storage/*.c) \
+	$(wildcard $(LOCAL_PATH)/src/storage/generic/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/thread/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/thread/pthread/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/time/*.c) \


### PR DESCRIPTION
otherwise it fails compilation with: 

```
SharedLibrary  : libSDL3.so
ld.lld: error: version script assignment of 'SDL3_0.0.0' to symbol 'SDL_CloseStorage' failed: symbol not defined
ld.lld: error: version script assignment of 'SDL3_0.0.0' to symbol 'SDL_CopyStorageFile' failed: symbol not defined
and so on ...
```