### PR TITLE
Compilation without vulkan: SDL_GPU_VULKAN is always defined, test against 0 or 1

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -127,7 +127,7 @@ static const SDL_GPUBootstrap *backends[] = {
 #ifdef SDL_GPU_D3D12
     &D3D12Driver,
 #endif
-#ifdef SDL_GPU_VULKAN
+#if defined(SDL_GPU_VULKAN) && SDL_GPU_VULKAN
     &VulkanDriver,
 #endif
 #ifdef SDL_GPU_D3D11

--- a/src/render/sdlgpu/SDL_shaders_gpu.c
+++ b/src/render/sdlgpu/SDL_shaders_gpu.c
@@ -33,7 +33,7 @@ typedef struct GPU_ShaderModuleSource
     SDL_GPUShaderFormat format;
 } GPU_ShaderModuleSource;
 
-#ifdef SDL_GPU_VULKAN
+#if defined(SDL_GPU_VULKAN) && SDL_GPU_VULKAN
 #define IF_VULKAN(...)     __VA_ARGS__
 #define HAVE_SPIRV_SHADERS 1
 #include "shaders/spir-v.h"


### PR DESCRIPTION

Compilation without vulkan: SDL_GPU_VULKAN is always defined, test against 0 or 1