### PR TITLE
Android: don´t register HID jni table if SDL_HIDAPI_DISABLE is defined

### DIFF
--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -557,7 +557,9 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
     register_methods(env, "org/libsdl/app/SDLInputConnection", SDLInputConnection_tab, SDL_arraysize(SDLInputConnection_tab));
     register_methods(env, "org/libsdl/app/SDLAudioManager", SDLAudioManager_tab, SDL_arraysize(SDLAudioManager_tab));
     register_methods(env, "org/libsdl/app/SDLControllerManager", SDLControllerManager_tab, SDL_arraysize(SDLControllerManager_tab));
+#ifndef SDL_HIDAPI_DISABLED
     register_methods(env, "org/libsdl/app/HIDDeviceManager", HIDDeviceManager_tab, SDL_arraysize(HIDDeviceManager_tab));
+#endif
     SDL_AtomicSet(&bAllowRecreateActivity, false);
 
     return JNI_VERSION_1_4;


### PR DESCRIPTION
Android: don´t register HID jni table if SDL_HIDAPI_DISABLE is defined