### PR TITLE
Add an API for argument parsing to SDL3_test

### DIFF
--- a/include/SDL3/SDL_test_common.h
+++ b/include/SDL3/SDL_test_common.h
@@ -53,6 +53,27 @@ typedef Uint32 SDLTest_VerboseFlags;
 #define VERBOSE_AUDIO   0x00000010
 #define VERBOSE_MOTION  0x00000020
 
+/* !< Function pointer parsing one argument at argv[index], returning the number of parsed arguments,
+ *    or a negative value when the argument is invalid */
+typedef int (*SDLTest_ParseArgumentsFp)(void *data, char **argv, int index);
+
+/* !< Finalize the argument parser. */
+typedef void (*SDLTest_FinalizeArgumentParserFp)(void *arg);
+
+typedef struct SDLTest_ArgumentParser
+{
+    /* !< Parse an argument. */
+    SDLTest_ParseArgumentsFp parse_arguments;
+    /* !< Finalize this argument parser. Called once before parsing the first argument. */
+    SDLTest_FinalizeArgumentParserFp finalize;
+    /* !< Null-terminated array of arguments. Printed when running with --help. */
+    const char **usage;
+    /* !< User data, passed to all callbacks. */
+    void *data;
+    /* !< Next argument parser. */
+    struct SDLTest_ArgumentParser *next;
+} SDLTest_ArgumentParser;
+
 typedef struct
 {
     /* SDL init flags */
@@ -134,6 +155,12 @@ typedef struct
     SDL_Rect confine;
     SDL_bool hide_cursor;
 
+    /* Options info */
+    SDLTest_ArgumentParser common_argparser;
+    SDLTest_ArgumentParser video_argparser;
+    SDLTest_ArgumentParser audio_argparser;
+
+    SDLTest_ArgumentParser *argparser;
 } SDLTest_CommonState;
 
 #include <SDL3/SDL_begin_code.h>

--- a/include/SDL3/SDL_test_harness.h
+++ b/include/SDL3/SDL_test_harness.h
@@ -101,15 +101,15 @@ typedef struct SDLTest_TestSuiteReference {
 
 
 /*
- * Generates a random run seed string for the harness. The generated seed will contain alphanumeric characters (0-9A-Z).
+ * Generates a random run seed string for the harness. The generated seed
+ * will contain alphanumeric characters (0-9A-Z).
  *
- * Note: The returned string needs to be deallocated by the caller.
+ * \param buffer Buffer in which to generate the random seed. Must have a capacity of at least length + 1 characters.
+ * \param length Number of alphanumeric characters to write to buffer, must be >0
  *
- * \param length The length of the seed string to generate
- *
- * \returns the generated seed string
+ * \returns A null-terminated seed string and equal to the in put buffer on success, NULL on failure
  */
-char *SDLTest_GenerateRunSeed(const int length);
+char *SDLTest_GenerateRunSeed(char *buffer, int length);
 
 /*
  * Execute a test suite using the given run seed and execution key.

--- a/include/SDL3/SDL_test_harness.h
+++ b/include/SDL3/SDL_test_harness.h
@@ -63,7 +63,7 @@ extern "C" {
 #define TEST_RESULT_SETUP_FAILURE       4
 
 /* !< Function pointer to a test case setup function (run before every test) */
-typedef void (*SDLTest_TestCaseSetUpFp)(void *arg);
+typedef void (*SDLTest_TestCaseSetUpFp)(void **arg);
 
 /* !< Function pointer to a test case function */
 typedef int (*SDLTest_TestCaseFp)(void *arg);

--- a/include/SDL3/SDL_test_harness.h
+++ b/include/SDL3/SDL_test_harness.h
@@ -112,18 +112,37 @@ typedef struct SDLTest_TestSuiteReference {
 char *SDLTest_GenerateRunSeed(char *buffer, int length);
 
 /*
- * Execute a test suite using the given run seed and execution key.
+ * Holds information about the execution of test suites.
+ * */
+typedef struct SDLTest_TestSuiteRunner SDLTest_TestSuiteRunner;
+
+/*
+ * Create a new test suite runner, that will execute the given test suites.
+ * It will register the harness cli arguments to the common SDL state.
  *
- * \param testSuites Suites containing the test case.
- * \param userRunSeed Custom run seed provided by user, or NULL to autogenerate one.
- * \param userExecKey Custom execution key provided by user, or 0 to autogenerate one.
- * \param filter Filter specification. NULL disables. Case sensitive.
- * \param testIterations Number of iterations to run each test case.
- * \param randomOrder allow to run suites and tests in random order when there is no filter
+ * \param state Common SDL state on which to register CLI arguments.
+ * \param testSuites NULL-terminated test suites containing test cases.
  *
  * \returns the test run result: 0 when all tests passed, 1 if any tests failed.
  */
-int SDLTest_RunSuites(SDLTest_TestSuiteReference *testSuites[], const char *userRunSeed, Uint64 userExecKey, const char *filter, int testIterations, SDL_bool randomOrder);
+SDLTest_TestSuiteRunner * SDLTest_CreateTestSuiteRunner(SDLTest_CommonState *state, SDLTest_TestSuiteReference *testSuites[]);
+
+/*
+ * Destroy a test suite runner.
+ * It will unregister the harness cli arguments to the common SDL state.
+ *
+ * \param runner The runner that should be destroyed.
+ */
+void SDLTest_DestroyTestSuiteRunner(SDLTest_TestSuiteRunner *runner);
+
+/*
+ * Execute a test suite, using the configured run seed, execution key, filter, etc.
+ *
+ * \param runner The runner that should be executed.
+ *
+ * \returns the test run result: 0 when all tests passed, 1 if any tests failed.
+ */
+int SDLTest_ExecuteTestSuiteRunner(SDLTest_TestSuiteRunner *runner);
 
 
 /* Ends C function definitions when using C++ */

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -30,7 +30,9 @@ static const char *common_usage[] = {
     "[-h | --help]",
     "[--trackmem]",
     "[--randmem]",
+    "[--info all|video|modes|render|event|event_motion]",
     "[--log all|error|system|audio|video|render|input]",
+    NULL
 };
 
 static const char *video_usage[] = {
@@ -50,7 +52,6 @@ static const char *video_usage[] = {
     "[--hide-cursor]",
     "[--high-pixel-density]",
     "[--icon icon.bmp]",
-    "[--info all|video|modes|render|event|event_motion]",
     "[--input-focus]",
     "[--keyboard-grab]",
     "[--logical-presentation disabled|match|stretch|letterbox|overscan|integer_scale]",
@@ -73,13 +74,17 @@ static const char *video_usage[] = {
     "[--utility]",
     "[--video driver]",
     "[--gpu driver]",
-    "[--vsync]"
+    "[--vsync]",
+    NULL
 };
 
 /* !!! FIXME: Float32? Sint32? */
 static const char *audio_usage[] = {
-    "[--audio driver]", "[--rate N]", "[--format U8|S8|S16|S16LE|S16BE|S32|S32LE|S32BE|F32|F32LE|F32BE]",
-    "[--channels N]"
+    "[--audio driver]",
+    "[--rate N]",
+    "[--format U8|S8|S16|S16LE|S16BE|S32|S32LE|S32BE|F32|F32LE|F32BE]",
+    "[--channels N]",
+    NULL
 };
 
 static void SDL_snprintfcat(SDL_OUT_Z_CAP(maxlen) char *text, size_t maxlen, SDL_PRINTF_FORMAT_STRING const char *fmt, ...)
@@ -92,6 +97,586 @@ static void SDL_snprintfcat(SDL_OUT_Z_CAP(maxlen) char *text, size_t maxlen, SDL
     maxlen -= length;
     (void)SDL_vsnprintf(text, maxlen, fmt, ap);
     va_end(ap);
+}
+
+static void SDLTest_CommonArgParserFinalize(void *data)
+{
+    SDLTest_CommonState *state = data;
+
+    if (!(state->flags & SDL_INIT_VIDEO)) {
+        state->video_argparser.usage = NULL;
+    }
+    if (!(state->flags & SDL_INIT_AUDIO)) {
+        state->audio_argparser.usage = NULL;
+    }
+}
+
+#define SEARCHARG(dim)                  \
+    while (*(dim) && *(dim) != ',') {   \
+        ++(dim);                        \
+    }                                   \
+    if (!*(dim)) {                      \
+        return -1;                      \
+    }                                   \
+    *(dim)++ = '\0';
+
+static int SDLTest_CommonStateParseCommonArguments(void *data, char **argv, int index)
+{
+    SDLTest_CommonState *state = data;
+
+    if ((SDL_strcasecmp(argv[index], "-h") == 0) || (SDL_strcasecmp(argv[index], "--help") == 0)) {
+        /* Print the usage message */
+        return -1;
+    }
+    if (SDL_strcasecmp(argv[index], "--trackmem") == 0) {
+        /* Already handled in SDLTest_CommonCreateState() */
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--randmem") == 0) {
+        /* Already handled in SDLTest_CommonCreateState() */
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--log") == 0) {
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        if (SDL_strcasecmp(argv[index], "all") == 0) {
+            SDL_SetLogPriorities(SDL_LOG_PRIORITY_VERBOSE);
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "error") == 0) {
+            SDL_SetLogPriority(SDL_LOG_CATEGORY_ERROR, SDL_LOG_PRIORITY_VERBOSE);
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "system") == 0) {
+            SDL_SetLogPriority(SDL_LOG_CATEGORY_SYSTEM, SDL_LOG_PRIORITY_VERBOSE);
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "audio") == 0) {
+            SDL_SetLogPriority(SDL_LOG_CATEGORY_AUDIO, SDL_LOG_PRIORITY_VERBOSE);
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "video") == 0) {
+            SDL_SetLogPriority(SDL_LOG_CATEGORY_VIDEO, SDL_LOG_PRIORITY_VERBOSE);
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "render") == 0) {
+            SDL_SetLogPriority(SDL_LOG_CATEGORY_RENDER, SDL_LOG_PRIORITY_VERBOSE);
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "input") == 0) {
+            SDL_SetLogPriority(SDL_LOG_CATEGORY_INPUT, SDL_LOG_PRIORITY_VERBOSE);
+            return 2;
+        }
+        return -1;
+    }
+
+    if (SDL_strcasecmp(argv[index], "--info") == 0) {
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        if (SDL_strcasecmp(argv[index], "all") == 0) {
+            state->verbose |=
+                (VERBOSE_VIDEO | VERBOSE_MODES | VERBOSE_RENDER |
+                 VERBOSE_EVENT);
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "video") == 0) {
+            state->verbose |= VERBOSE_VIDEO;
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "modes") == 0) {
+            state->verbose |= VERBOSE_MODES;
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "render") == 0) {
+            state->verbose |= VERBOSE_RENDER;
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "event") == 0) {
+            state->verbose |= VERBOSE_EVENT;
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "event_motion") == 0) {
+            state->verbose |= (VERBOSE_EVENT | VERBOSE_MOTION);
+            return 2;
+        }
+        return -1;
+    }
+    if (SDL_strcmp(argv[index], "-NSDocumentRevisionsDebugMode") == 0) {
+        /* Debug flag sent by Xcode */
+        return 2;
+    }
+    return 0;
+}
+
+static int SDLTest_CommonStateParseVideoArguments(void *data, char **argv, int index)
+{
+    SDLTest_CommonState *state = data;
+
+    if (!(state->flags & SDL_INIT_VIDEO)) {
+        return 0;
+    }
+
+    if (SDL_strcasecmp(argv[index], "--video") == 0) {
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        state->videodriver = argv[index];
+        SDL_SetHint(SDL_HINT_VIDEO_DRIVER, state->videodriver);
+        return 2;
+    }
+    if (SDL_strcasecmp(argv[index], "--renderer") == 0) {
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        state->renderdriver = argv[index];
+        SDL_SetHint(SDL_HINT_RENDER_DRIVER, state->renderdriver);
+        return 2;
+    }
+    if (SDL_strcasecmp(argv[index], "--gldebug") == 0) {
+        state->gl_debug = 1;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--display") == 0) {
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        state->display_index = SDL_atoi(argv[index]);
+        return 2;
+    }
+    if (SDL_strcasecmp(argv[index], "--metal-window") == 0) {
+        state->window_flags |= SDL_WINDOW_METAL;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--opengl-window") == 0) {
+        state->window_flags |= SDL_WINDOW_OPENGL;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--vulkan-window") == 0) {
+        state->window_flags |= SDL_WINDOW_VULKAN;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--fullscreen") == 0) {
+        state->window_flags |= SDL_WINDOW_FULLSCREEN;
+        state->fullscreen_exclusive = SDL_TRUE;
+        state->num_windows = 1;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--fullscreen-desktop") == 0) {
+        state->window_flags |= SDL_WINDOW_FULLSCREEN;
+        state->fullscreen_exclusive = SDL_FALSE;
+        state->num_windows = 1;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--windows") == 0) {
+        ++index;
+        if (!argv[index] || !SDL_isdigit((unsigned char) *argv[index])) {
+            return -1;
+        }
+        if (!(state->window_flags & SDL_WINDOW_FULLSCREEN)) {
+            state->num_windows = SDL_atoi(argv[index]);
+        }
+        return 2;
+    }
+    if (SDL_strcasecmp(argv[index], "--title") == 0) {
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        state->window_title = argv[index];
+        return 2;
+    }
+    if (SDL_strcasecmp(argv[index], "--icon") == 0) {
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        state->window_icon = argv[index];
+        return 2;
+    }
+    if (SDL_strcasecmp(argv[index], "--center") == 0) {
+        state->window_x = SDL_WINDOWPOS_CENTERED;
+        state->window_y = SDL_WINDOWPOS_CENTERED;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--position") == 0) {
+        char *x, *y;
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        x = argv[index];
+        y = argv[index];
+        while (*y && *y != ',') {
+            ++y;
+        }
+        if (!*y) {
+            return -1;
+        }
+        *y++ = '\0';
+        state->window_x = SDL_atoi(x);
+        state->window_y = SDL_atoi(y);
+        return 2;
+    }
+    if (SDL_strcasecmp(argv[index], "--confine-cursor") == 0) {
+        char *x, *y, *w, *h;
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        x = argv[index];
+        y = argv[index];
+        SEARCHARG(y)
+        w = y;
+        SEARCHARG(w)
+        h = w;
+        SEARCHARG(h)
+        state->confine.x = SDL_atoi(x);
+        state->confine.y = SDL_atoi(y);
+        state->confine.w = SDL_atoi(w);
+        state->confine.h = SDL_atoi(h);
+        return 2;
+    }
+    if (SDL_strcasecmp(argv[index], "--usable-bounds") == 0) {
+        state->fill_usable_bounds = SDL_TRUE;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--geometry") == 0) {
+        char *w, *h;
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        w = argv[index];
+        h = argv[index];
+        while (*h && *h != 'x') {
+            ++h;
+        }
+        if (!*h) {
+            return -1;
+        }
+        *h++ = '\0';
+        state->window_w = SDL_atoi(w);
+        state->window_h = SDL_atoi(h);
+        return 2;
+    }
+    if (SDL_strcasecmp(argv[index], "--min-geometry") == 0) {
+        char *w, *h;
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        w = argv[index];
+        h = argv[index];
+        while (*h && *h != 'x') {
+            ++h;
+        }
+        if (!*h) {
+            return -1;
+        }
+        *h++ = '\0';
+        state->window_minW = SDL_atoi(w);
+        state->window_minH = SDL_atoi(h);
+        return 2;
+    }
+    if (SDL_strcasecmp(argv[index], "--max-geometry") == 0) {
+        char *w, *h;
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        w = argv[index];
+        h = argv[index];
+        while (*h && *h != 'x') {
+            ++h;
+        }
+        if (!*h) {
+            return -1;
+        }
+        *h++ = '\0';
+        state->window_maxW = SDL_atoi(w);
+        state->window_maxH = SDL_atoi(h);
+        return 2;
+    }
+    if (SDL_strcasecmp(argv[index], "--aspect") == 0) {
+        char *min_aspect, *max_aspect;
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        min_aspect = argv[index];
+        max_aspect = argv[index];
+        while (*max_aspect && *max_aspect != '-') {
+            ++max_aspect;
+        }
+        if (*max_aspect) {
+            *max_aspect++ = '\0';
+        } else {
+            max_aspect = min_aspect;
+        }
+        state->window_min_aspect = (float)SDL_atof(min_aspect);
+        state->window_max_aspect = (float)SDL_atof(max_aspect);
+        return 2;
+    }
+    if (SDL_strcasecmp(argv[index], "--logical") == 0) {
+        char *w, *h;
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        w = argv[index];
+        h = argv[index];
+        while (*h && *h != 'x') {
+            ++h;
+        }
+        if (!*h) {
+            return -1;
+        }
+        *h++ = '\0';
+        state->logical_w = SDL_atoi(w);
+        state->logical_h = SDL_atoi(h);
+        return 2;
+    }
+    if (SDL_strcasecmp(argv[index], "--high-pixel-density") == 0) {
+        state->window_flags |= SDL_WINDOW_HIGH_PIXEL_DENSITY;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--auto-scale-content") == 0) {
+        state->auto_scale_content = SDL_TRUE;
+
+        if (state->logical_presentation == SDL_LOGICAL_PRESENTATION_DISABLED) {
+            state->logical_presentation = SDL_LOGICAL_PRESENTATION_STRETCH;
+        }
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--logical-presentation") == 0) {
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        if (SDL_strcasecmp(argv[index], "disabled") == 0) {
+            state->logical_presentation = SDL_LOGICAL_PRESENTATION_DISABLED;
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "stretch") == 0) {
+            state->logical_presentation = SDL_LOGICAL_PRESENTATION_STRETCH;
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "letterbox") == 0) {
+            state->logical_presentation = SDL_LOGICAL_PRESENTATION_LETTERBOX;
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "overscan") == 0) {
+            state->logical_presentation = SDL_LOGICAL_PRESENTATION_OVERSCAN;
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "integer_scale") == 0) {
+            state->logical_presentation = SDL_LOGICAL_PRESENTATION_INTEGER_SCALE;
+            return 2;
+        }
+        return -1;
+    }
+    if (SDL_strcasecmp(argv[index], "--logical-scale-quality") == 0) {
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        if (SDL_strcasecmp(argv[index], "nearest") == 0) {
+            state->logical_scale_mode = SDL_SCALEMODE_NEAREST;
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "linear") == 0) {
+            state->logical_scale_mode = SDL_SCALEMODE_LINEAR;
+            return 2;
+        }
+        return -1;
+    }
+    if (SDL_strcasecmp(argv[index], "--scale") == 0) {
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        state->scale = (float) SDL_atof(argv[index]);
+        return 2;
+    }
+    if (SDL_strcasecmp(argv[index], "--depth") == 0) {
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        state->depth = SDL_atoi(argv[index]);
+        return 2;
+    }
+    if (SDL_strcasecmp(argv[index], "--refresh") == 0) {
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        state->refresh_rate = (float) SDL_atof(argv[index]);
+        return 2;
+    }
+    if (SDL_strcasecmp(argv[index], "--vsync") == 0) {
+        state->render_vsync = 1;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--noframe") == 0) {
+        state->window_flags |= SDL_WINDOW_BORDERLESS;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--resizable") == 0) {
+        state->window_flags |= SDL_WINDOW_RESIZABLE;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--transparent") == 0) {
+        state->window_flags |= SDL_WINDOW_TRANSPARENT;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--always-on-top") == 0) {
+        state->window_flags |= SDL_WINDOW_ALWAYS_ON_TOP;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--minimize") == 0) {
+        state->window_flags |= SDL_WINDOW_MINIMIZED;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--maximize") == 0) {
+        state->window_flags |= SDL_WINDOW_MAXIMIZED;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--hidden") == 0) {
+        state->window_flags |= SDL_WINDOW_HIDDEN;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--input-focus") == 0) {
+        state->window_flags |= SDL_WINDOW_INPUT_FOCUS;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--mouse-focus") == 0) {
+        state->window_flags |= SDL_WINDOW_MOUSE_FOCUS;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--flash-on-focus-loss") == 0) {
+        state->flash_on_focus_loss = SDL_TRUE;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--grab") == 0) {
+        state->window_flags |= SDL_WINDOW_MOUSE_GRABBED;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--keyboard-grab") == 0) {
+        state->window_flags |= SDL_WINDOW_KEYBOARD_GRABBED;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--utility") == 0) {
+        state->window_flags |= SDL_WINDOW_UTILITY;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--hide-cursor") == 0) {
+        state->hide_cursor = SDL_TRUE;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--gpu") == 0) {
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        state->gpudriver = argv[index];
+        SDL_SetHint(SDL_HINT_GPU_DRIVER, state->gpudriver);
+        return 2;
+    }
+    return 0;
+}
+
+static int SDLTest_CommonStateParseAudioArguments(void *data, char **argv, int index)
+{
+    SDLTest_CommonState *state = data;
+
+    if (!(state->flags & SDL_INIT_AUDIO)) {
+        return 0;
+    }
+    if (SDL_strcasecmp(argv[index], "--audio") == 0) {
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        state->audiodriver = argv[index];
+        SDL_SetHint(SDL_HINT_AUDIO_DRIVER, state->audiodriver);
+        return 2;
+    }
+    if (SDL_strcasecmp(argv[index], "--rate") == 0) {
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        state->audio_freq = SDL_atoi(argv[index]);
+        return 2;
+    }
+    if (SDL_strcasecmp(argv[index], "--format") == 0) {
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        if (SDL_strcasecmp(argv[index], "U8") == 0) {
+            state->audio_format = SDL_AUDIO_U8;
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "S8") == 0) {
+            state->audio_format = SDL_AUDIO_S8;
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "S16") == 0) {
+            state->audio_format = SDL_AUDIO_S16;
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "S16LE") == 0) {
+            state->audio_format = SDL_AUDIO_S16LE;
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "S16BE") == 0) {
+            state->audio_format = SDL_AUDIO_S16BE;
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "S32") == 0) {
+            state->audio_format = SDL_AUDIO_S32;
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "S32LE") == 0) {
+            state->audio_format = SDL_AUDIO_S32LE;
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "S32BE") == 0) {
+            state->audio_format = SDL_AUDIO_S32BE;
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "F32") == 0) {
+            state->audio_format = SDL_AUDIO_F32;
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "F32LE") == 0) {
+            state->audio_format = SDL_AUDIO_F32LE;
+            return 2;
+        }
+        if (SDL_strcasecmp(argv[index], "F32BE") == 0) {
+            state->audio_format = SDL_AUDIO_F32BE;
+            return 2;
+        }
+        return -1;
+    }
+    if (SDL_strcasecmp(argv[index], "--channels") == 0) {
+        ++index;
+        if (!argv[index]) {
+            return -1;
+        }
+        state->audio_channels = (Uint8) SDL_atoi(argv[index]);
+        return 2;
+    }
+    return 0;
 }
 
 SDLTest_CommonState *SDLTest_CommonCreateState(char **argv, SDL_InitFlags flags)
@@ -149,6 +734,25 @@ SDLTest_CommonState *SDLTest_CommonCreateState(char **argv, SDL_InitFlags flags)
     state->gl_accelerated = -1;
     state->gl_debug = 0;
 
+    state->common_argparser.parse_arguments = SDLTest_CommonStateParseCommonArguments;
+    state->common_argparser.finalize = SDLTest_CommonArgParserFinalize;
+    state->common_argparser.usage = common_usage;
+    state->common_argparser.data = state;
+    state->common_argparser.next = &state->video_argparser;
+
+    state->video_argparser.parse_arguments = SDLTest_CommonStateParseVideoArguments;
+    state->video_argparser.finalize = NULL;
+    state->video_argparser.usage = video_usage;
+    state->video_argparser.data = state;
+    state->video_argparser.next = &state->audio_argparser;
+
+    state->audio_argparser.parse_arguments = SDLTest_CommonStateParseAudioArguments;
+    state->audio_argparser.finalize = NULL;
+    state->audio_argparser.usage = audio_usage;
+    state->audio_argparser.data = state;
+
+    state->argparser = &state->common_argparser;
+
     return state;
 }
 
@@ -157,596 +761,42 @@ void SDLTest_CommonDestroyState(SDLTest_CommonState *state) {
     SDLTest_LogAllocations();
 }
 
-#define SEARCHARG(dim)                  \
-    while (*(dim) && *(dim) != ',') {   \
-        ++(dim);                        \
-    }                                   \
-    if (!*(dim)) {                      \
-        return -1;                      \
-    }                                   \
-    *(dim)++ = '\0';
-
 int SDLTest_CommonArg(SDLTest_CommonState *state, int index)
 {
-    char **argv = state->argv;
+    SDLTest_ArgumentParser *argparser = state->argparser;
 
-    if ((SDL_strcasecmp(argv[index], "-h") == 0) || (SDL_strcasecmp(argv[index], "--help") == 0)) {
-        /* Print the usage message */
-        return -1;
-    }
-    if (SDL_strcasecmp(argv[index], "--trackmem") == 0) {
-        /* Already handled in SDLTest_CommonCreateState() */
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--randmem") == 0) {
-        /* Already handled in SDLTest_CommonCreateState() */
-        return 1;
-    }
-    if (SDL_strcasecmp(argv[index], "--log") == 0) {
-        ++index;
-        if (!argv[index]) {
-            return -1;
+    /* Go back and parse arguments as we go */
+    while (argparser) {
+        if (argparser->parse_arguments) {
+            int consumed = argparser->parse_arguments(argparser->data, state->argv, index);
+            if (consumed != 0) {
+                return consumed;
+            }
         }
-        if (SDL_strcasecmp(argv[index], "all") == 0) {
-            SDL_SetLogPriorities(SDL_LOG_PRIORITY_VERBOSE);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "error") == 0) {
-            SDL_SetLogPriority(SDL_LOG_CATEGORY_ERROR, SDL_LOG_PRIORITY_VERBOSE);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "system") == 0) {
-            SDL_SetLogPriority(SDL_LOG_CATEGORY_SYSTEM, SDL_LOG_PRIORITY_VERBOSE);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "audio") == 0) {
-            SDL_SetLogPriority(SDL_LOG_CATEGORY_AUDIO, SDL_LOG_PRIORITY_VERBOSE);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "video") == 0) {
-            SDL_SetLogPriority(SDL_LOG_CATEGORY_VIDEO, SDL_LOG_PRIORITY_VERBOSE);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "render") == 0) {
-            SDL_SetLogPriority(SDL_LOG_CATEGORY_RENDER, SDL_LOG_PRIORITY_VERBOSE);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "input") == 0) {
-            SDL_SetLogPriority(SDL_LOG_CATEGORY_INPUT, SDL_LOG_PRIORITY_VERBOSE);
-            return 2;
-        }
-        return -1;
-    }
-    if (state->flags & SDL_INIT_VIDEO) {
-        if (SDL_strcasecmp(argv[index], "--video") == 0) {
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            state->videodriver = argv[index];
-            SDL_SetHint(SDL_HINT_VIDEO_DRIVER, state->videodriver);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "--renderer") == 0) {
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            state->renderdriver = argv[index];
-            SDL_SetHint(SDL_HINT_RENDER_DRIVER, state->renderdriver);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "--gldebug") == 0) {
-            state->gl_debug = 1;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--info") == 0) {
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            if (SDL_strcasecmp(argv[index], "all") == 0) {
-                state->verbose |=
-                        (VERBOSE_VIDEO | VERBOSE_MODES | VERBOSE_RENDER |
-                         VERBOSE_EVENT);
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "video") == 0) {
-                state->verbose |= VERBOSE_VIDEO;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "modes") == 0) {
-                state->verbose |= VERBOSE_MODES;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "render") == 0) {
-                state->verbose |= VERBOSE_RENDER;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "event") == 0) {
-                state->verbose |= VERBOSE_EVENT;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "event_motion") == 0) {
-                state->verbose |= (VERBOSE_EVENT | VERBOSE_MOTION);
-                return 2;
-            }
-            return -1;
-        }
-        if (SDL_strcasecmp(argv[index], "--display") == 0) {
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            state->display_index = SDL_atoi(argv[index]);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "--metal-window") == 0) {
-            state->window_flags |= SDL_WINDOW_METAL;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--opengl-window") == 0) {
-            state->window_flags |= SDL_WINDOW_OPENGL;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--vulkan-window") == 0) {
-            state->window_flags |= SDL_WINDOW_VULKAN;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--fullscreen") == 0) {
-            state->window_flags |= SDL_WINDOW_FULLSCREEN;
-            state->fullscreen_exclusive = SDL_TRUE;
-            state->num_windows = 1;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--fullscreen-desktop") == 0) {
-            state->window_flags |= SDL_WINDOW_FULLSCREEN;
-            state->fullscreen_exclusive = SDL_FALSE;
-            state->num_windows = 1;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--windows") == 0) {
-            ++index;
-            if (!argv[index] || !SDL_isdigit((unsigned char) *argv[index])) {
-                return -1;
-            }
-            if (!(state->window_flags & SDL_WINDOW_FULLSCREEN)) {
-                state->num_windows = SDL_atoi(argv[index]);
-            }
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "--title") == 0) {
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            state->window_title = argv[index];
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "--icon") == 0) {
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            state->window_icon = argv[index];
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "--center") == 0) {
-            state->window_x = SDL_WINDOWPOS_CENTERED;
-            state->window_y = SDL_WINDOWPOS_CENTERED;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--position") == 0) {
-            char *x, *y;
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            x = argv[index];
-            y = argv[index];
-            while (*y && *y != ',') {
-                ++y;
-            }
-            if (!*y) {
-                return -1;
-            }
-            *y++ = '\0';
-            state->window_x = SDL_atoi(x);
-            state->window_y = SDL_atoi(y);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "--confine-cursor") == 0) {
-            char *x, *y, *w, *h;
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            x = argv[index];
-            y = argv[index];
-            SEARCHARG(y)
-            w = y;
-            SEARCHARG(w)
-            h = w;
-            SEARCHARG(h)
-            state->confine.x = SDL_atoi(x);
-            state->confine.y = SDL_atoi(y);
-            state->confine.w = SDL_atoi(w);
-            state->confine.h = SDL_atoi(h);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "--usable-bounds") == 0) {
-            state->fill_usable_bounds = SDL_TRUE;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--geometry") == 0) {
-            char *w, *h;
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            w = argv[index];
-            h = argv[index];
-            while (*h && *h != 'x') {
-                ++h;
-            }
-            if (!*h) {
-                return -1;
-            }
-            *h++ = '\0';
-            state->window_w = SDL_atoi(w);
-            state->window_h = SDL_atoi(h);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "--min-geometry") == 0) {
-            char *w, *h;
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            w = argv[index];
-            h = argv[index];
-            while (*h && *h != 'x') {
-                ++h;
-            }
-            if (!*h) {
-                return -1;
-            }
-            *h++ = '\0';
-            state->window_minW = SDL_atoi(w);
-            state->window_minH = SDL_atoi(h);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "--max-geometry") == 0) {
-            char *w, *h;
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            w = argv[index];
-            h = argv[index];
-            while (*h && *h != 'x') {
-                ++h;
-            }
-            if (!*h) {
-                return -1;
-            }
-            *h++ = '\0';
-            state->window_maxW = SDL_atoi(w);
-            state->window_maxH = SDL_atoi(h);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "--aspect") == 0) {
-            char *min_aspect, *max_aspect;
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            min_aspect = argv[index];
-            max_aspect = argv[index];
-            while (*max_aspect && *max_aspect != '-') {
-                ++max_aspect;
-            }
-            if (*max_aspect) {
-                *max_aspect++ = '\0';
-            } else {
-                max_aspect = min_aspect;
-            }
-            state->window_min_aspect = (float)SDL_atof(min_aspect);
-            state->window_max_aspect = (float)SDL_atof(max_aspect);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "--logical") == 0) {
-            char *w, *h;
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            w = argv[index];
-            h = argv[index];
-            while (*h && *h != 'x') {
-                ++h;
-            }
-            if (!*h) {
-                return -1;
-            }
-            *h++ = '\0';
-            state->logical_w = SDL_atoi(w);
-            state->logical_h = SDL_atoi(h);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "--high-pixel-density") == 0) {
-            state->window_flags |= SDL_WINDOW_HIGH_PIXEL_DENSITY;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--auto-scale-content") == 0) {
-            state->auto_scale_content = SDL_TRUE;
-
-            if (state->logical_presentation == SDL_LOGICAL_PRESENTATION_DISABLED) {
-                state->logical_presentation = SDL_LOGICAL_PRESENTATION_STRETCH;
-            }
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--logical-presentation") == 0) {
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            if (SDL_strcasecmp(argv[index], "disabled") == 0) {
-                state->logical_presentation = SDL_LOGICAL_PRESENTATION_DISABLED;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "stretch") == 0) {
-                state->logical_presentation = SDL_LOGICAL_PRESENTATION_STRETCH;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "letterbox") == 0) {
-                state->logical_presentation = SDL_LOGICAL_PRESENTATION_LETTERBOX;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "overscan") == 0) {
-                state->logical_presentation = SDL_LOGICAL_PRESENTATION_OVERSCAN;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "integer_scale") == 0) {
-                state->logical_presentation = SDL_LOGICAL_PRESENTATION_INTEGER_SCALE;
-                return 2;
-            }
-            return -1;
-        }
-        if (SDL_strcasecmp(argv[index], "--logical-scale-quality") == 0) {
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            if (SDL_strcasecmp(argv[index], "nearest") == 0) {
-                state->logical_scale_mode = SDL_SCALEMODE_NEAREST;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "linear") == 0) {
-                state->logical_scale_mode = SDL_SCALEMODE_LINEAR;
-                return 2;
-            }
-            return -1;
-        }
-        if (SDL_strcasecmp(argv[index], "--scale") == 0) {
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            state->scale = (float) SDL_atof(argv[index]);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "--depth") == 0) {
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            state->depth = SDL_atoi(argv[index]);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "--refresh") == 0) {
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            state->refresh_rate = (float) SDL_atof(argv[index]);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "--vsync") == 0) {
-            state->render_vsync = 1;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--noframe") == 0) {
-            state->window_flags |= SDL_WINDOW_BORDERLESS;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--resizable") == 0) {
-            state->window_flags |= SDL_WINDOW_RESIZABLE;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--transparent") == 0) {
-            state->window_flags |= SDL_WINDOW_TRANSPARENT;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--always-on-top") == 0) {
-            state->window_flags |= SDL_WINDOW_ALWAYS_ON_TOP;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--minimize") == 0) {
-            state->window_flags |= SDL_WINDOW_MINIMIZED;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--maximize") == 0) {
-            state->window_flags |= SDL_WINDOW_MAXIMIZED;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--hidden") == 0) {
-            state->window_flags |= SDL_WINDOW_HIDDEN;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--input-focus") == 0) {
-            state->window_flags |= SDL_WINDOW_INPUT_FOCUS;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--mouse-focus") == 0) {
-            state->window_flags |= SDL_WINDOW_MOUSE_FOCUS;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--flash-on-focus-loss") == 0) {
-            state->flash_on_focus_loss = SDL_TRUE;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--grab") == 0) {
-            state->window_flags |= SDL_WINDOW_MOUSE_GRABBED;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--keyboard-grab") == 0) {
-            state->window_flags |= SDL_WINDOW_KEYBOARD_GRABBED;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--utility") == 0) {
-            state->window_flags |= SDL_WINDOW_UTILITY;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--hide-cursor") == 0) {
-            state->hide_cursor = SDL_TRUE;
-            return 1;
-        }
-        if (SDL_strcasecmp(argv[index], "--gpu") == 0) {
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            state->gpudriver = argv[index];
-            SDL_SetHint(SDL_HINT_GPU_DRIVER, state->gpudriver);
-            return 2;
-        }
-    } else {
-        if (SDL_strcasecmp(argv[index], "--info") == 0) {
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            if (SDL_strcasecmp(argv[index], "all") == 0) {
-                state->verbose |= VERBOSE_EVENT;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "event") == 0) {
-                state->verbose |= VERBOSE_EVENT;
-                return 2;
-            }
-            return -1;
-        }
-    }
-
-    if (state->flags & SDL_INIT_AUDIO) {
-        if (SDL_strcasecmp(argv[index], "--audio") == 0) {
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            state->audiodriver = argv[index];
-            SDL_SetHint(SDL_HINT_AUDIO_DRIVER, state->audiodriver);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "--rate") == 0) {
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            state->audio_freq = SDL_atoi(argv[index]);
-            return 2;
-        }
-        if (SDL_strcasecmp(argv[index], "--format") == 0) {
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            if (SDL_strcasecmp(argv[index], "U8") == 0) {
-                state->audio_format = SDL_AUDIO_U8;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "S8") == 0) {
-                state->audio_format = SDL_AUDIO_S8;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "S16") == 0) {
-                state->audio_format = SDL_AUDIO_S16;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "S16LE") == 0) {
-                state->audio_format = SDL_AUDIO_S16LE;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "S16BE") == 0) {
-                state->audio_format = SDL_AUDIO_S16BE;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "S32") == 0) {
-                state->audio_format = SDL_AUDIO_S32;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "S32LE") == 0) {
-                state->audio_format = SDL_AUDIO_S32LE;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "S32BE") == 0) {
-                state->audio_format = SDL_AUDIO_S32BE;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "F32") == 0) {
-                state->audio_format = SDL_AUDIO_F32;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "F32LE") == 0) {
-                state->audio_format = SDL_AUDIO_F32LE;
-                return 2;
-            }
-            if (SDL_strcasecmp(argv[index], "F32BE") == 0) {
-                state->audio_format = SDL_AUDIO_F32BE;
-                return 2;
-            }
-            return -1;
-        }
-        if (SDL_strcasecmp(argv[index], "--channels") == 0) {
-            ++index;
-            if (!argv[index]) {
-                return -1;
-            }
-            state->audio_channels = (Uint8) SDL_atoi(argv[index]);
-            return 2;
-        }
-    }
-    if (SDL_strcmp(argv[index], "-NSDocumentRevisionsDebugMode") == 0) {
-        /* Debug flag sent by Xcode */
-        return 2;
+        argparser = argparser->next;
     }
     return 0;
 }
 
 void SDLTest_CommonLogUsage(SDLTest_CommonState *state, const char *argv0, const char **options)
 {
-    int i;
+    SDLTest_ArgumentParser *argparser;
 
     SDL_Log("USAGE: %s", argv0);
 
-    for (i = 0; i < SDL_arraysize(common_usage); i++) {
-        SDL_Log("    %s", common_usage[i]);
-    }
-
-    if (state->flags & SDL_INIT_VIDEO) {
-        for (i = 0; i < SDL_arraysize(video_usage); i++) {
-            SDL_Log("    %s", video_usage[i]);
+    for (argparser = state->argparser; argparser; argparser = argparser->next) {
+        if (argparser->finalize) {
+            argparser->finalize(argparser->data);
+        }
+        if (argparser->usage) {
+            int i;
+            for (i = 0; argparser->usage[i] != NULL; i++) {
+                SDL_Log("    %s", argparser->usage[i]);
+            }
         }
     }
-
-    if (state->flags & SDL_INIT_AUDIO) {
-        for (i = 0; i < SDL_arraysize(audio_usage); i++) {
-            SDL_Log("    %s", audio_usage[i]);
-        }
-    }
-
     if (options) {
+        int i;
         for (i = 0; options[i] != NULL; i++) {
             SDL_Log("    %s", options[i]);
         }

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -753,10 +753,6 @@ void SDLTest_CommonLogUsage(SDLTest_CommonState *state, const char *argv0, const
     }
 }
 
-static char *common_usage_video = NULL;
-static char *common_usage_audio = NULL;
-static char *common_usage_videoaudio = NULL;
-
 SDL_bool SDLTest_CommonDefaultArgs(SDLTest_CommonState *state, const int argc, char **argv)
 {
     int i = 1;
@@ -2498,13 +2494,6 @@ void SDLTest_CommonEvent(SDLTest_CommonState *state, SDL_Event *event, int *done
 void SDLTest_CommonQuit(SDLTest_CommonState *state)
 {
     int i;
-
-    SDL_free(common_usage_video);
-    SDL_free(common_usage_audio);
-    SDL_free(common_usage_videoaudio);
-    common_usage_video = NULL;
-    common_usage_audio = NULL;
-    common_usage_videoaudio = NULL;
 
     if (state->targets) {
         for (i = 0; i < state->num_windows; ++i) {

--- a/src/test/SDL_test_harness.c
+++ b/src/test/SDL_test_harness.c
@@ -50,32 +50,19 @@
 /* ! Timeout for single test case execution */
 static Uint32 SDLTest_TestCaseTimeout = 3600;
 
-/**
- * Generates a random run seed string for the harness. The generated seed
- * will contain alphanumeric characters (0-9A-Z).
- *
- * Note: The returned string needs to be deallocated by the caller.
- *
- * \param length The length of the seed string to generate
- *
- * \returns The generated seed string
- */
-char *SDLTest_GenerateRunSeed(const int length)
+char *SDLTest_GenerateRunSeed(char *buffer, int length)
 {
-    char *seed = NULL;
     Uint64 randomContext = SDL_GetPerformanceCounter();
     int counter;
+
+    if (!buffer) {
+        SDLTest_LogError("Input buffer must not be NULL.");
+        return NULL;
+    }
 
     /* Sanity check input */
     if (length <= 0) {
         SDLTest_LogError("The length of the harness seed must be >0.");
-        return NULL;
-    }
-
-    /* Allocate output buffer */
-    seed = (char *)SDL_malloc((length + 1) * sizeof(char));
-    if (!seed) {
-        SDLTest_LogError("SDL_malloc for run seed output buffer failed.");
         return NULL;
     }
 
@@ -88,11 +75,11 @@ char *SDLTest_GenerateRunSeed(const int length)
         } else {
             ch = (char)('A' + v - 10);
         }
-        seed[counter] = ch;
+        buffer[counter] = ch;
     }
-    seed[length] = '\0';
+    buffer[length] = '\0';
 
-    return seed;
+    return buffer;
 }
 
 /**
@@ -417,14 +404,11 @@ int SDLTest_RunSuites(SDLTest_TestSuiteReference *testSuites[], const char *user
 
     /* Generate run see if we don't have one already */
     if (!userRunSeed || userRunSeed[0] == '\0') {
-        char *tmp = SDLTest_GenerateRunSeed(16);
-        if (!tmp) {
+        runSeed = SDLTest_GenerateRunSeed(generatedSeed, 16);
+        if (!runSeed) {
             SDLTest_LogError("Generating a random seed failed");
             return 2;
         }
-        SDL_memcpy(generatedSeed, tmp, 16 + 1);
-        SDL_free(tmp);
-        runSeed = generatedSeed;
     } else {
         runSeed = userRunSeed;
     }

--- a/src/test/SDL_test_harness.c
+++ b/src/test/SDL_test_harness.c
@@ -237,6 +237,7 @@ static int SDLTest_RunTest(SDLTest_TestSuiteReference *testSuite, const SDLTest_
     int testCaseResult = 0;
     int testResult = 0;
     int fuzzerCount;
+    void *data = NULL;
 
     if (!testSuite || !testCase || !testSuite->name || !testCase->name) {
         SDLTest_LogError("Setup failure: testSuite or testCase references NULL");
@@ -259,7 +260,7 @@ static int SDLTest_RunTest(SDLTest_TestSuiteReference *testSuite, const SDLTest_
 
     /* Maybe run suite initializer function */
     if (testSuite->testSetUp) {
-        testSuite->testSetUp(0x0);
+        testSuite->testSetUp(&data);
         if (SDLTest_AssertSummaryToTestResult() == TEST_RESULT_FAILED) {
             SDLTest_LogError(SDLTEST_FINAL_RESULT_FORMAT, "Suite Setup", testSuite->name, COLOR_RED "Failed" COLOR_END);
             return TEST_RESULT_SETUP_FAILURE;
@@ -267,7 +268,7 @@ static int SDLTest_RunTest(SDLTest_TestSuiteReference *testSuite, const SDLTest_
     }
 
     /* Run test case function */
-    testCaseResult = testCase->testCase(0x0);
+    testCaseResult = testCase->testCase(data);
 
     /* Convert test execution result into harness result */
     if (testCaseResult == TEST_SKIPPED) {
@@ -286,7 +287,7 @@ static int SDLTest_RunTest(SDLTest_TestSuiteReference *testSuite, const SDLTest_
 
     /* Maybe run suite cleanup function (ignore failed asserts) */
     if (testSuite->testTearDown) {
-        testSuite->testTearDown(0x0);
+        testSuite->testTearDown(data);
     }
 
     /* Cancel timeout timer */

--- a/test/testautomation.c
+++ b/test/testautomation.c
@@ -19,6 +19,7 @@
 #include "testautomation_suites.h"
 
 static SDLTest_CommonState *state;
+static SDLTest_TestSuiteRunner *runner;
 
 /* All test suites */
 static SDLTest_TestSuiteReference *testSuites[] = {
@@ -55,6 +56,7 @@ static SDLTest_TestSuiteReference *testSuites[] = {
 static void
 quit(int rc)
 {
+    SDLTest_DestroyTestSuiteRunner(runner);
     SDLTest_CommonQuit(state);
     /* Let 'main()' return normally */
     if (rc != 0) {
@@ -65,14 +67,9 @@ quit(int rc)
 int main(int argc, char *argv[])
 {
     int result;
-    int testIterations = 1;
-    Uint64 userExecKey = 0;
-    char *userRunSeed = NULL;
-    char *filter = NULL;
     int i, done;
     SDL_Event event;
     int list = 0;
-    SDL_bool randomOrder = SDL_FALSE;
 
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, SDL_INIT_VIDEO | SDL_INIT_AUDIO);
@@ -83,6 +80,8 @@ int main(int argc, char *argv[])
     /* No need of windows (or update testautomation_mouse.c:mouse_getMouseFocus() */
     state->num_windows = 0;
 
+    runner = SDLTest_CreateTestSuiteRunner(state, testSuites);
+
     /* Parse commandline */
     for (i = 1; i < argc;) {
         int consumed;
@@ -90,46 +89,15 @@ int main(int argc, char *argv[])
         consumed = SDLTest_CommonArg(state, i);
         if (consumed == 0) {
             consumed = -1;
-            if (SDL_strcasecmp(argv[i], "--iterations") == 0) {
-                if (argv[i + 1]) {
-                    testIterations = SDL_atoi(argv[i + 1]);
-                    if (testIterations < 1) {
-                        testIterations = 1;
-                    }
-                    consumed = 2;
-                }
-            } else if (SDL_strcasecmp(argv[i], "--execKey") == 0) {
-                if (argv[i + 1]) {
-                    (void)SDL_sscanf(argv[i + 1], "%" SDL_PRIu64, &userExecKey);
-                    consumed = 2;
-                }
-            } else if (SDL_strcasecmp(argv[i], "--seed") == 0) {
-                if (argv[i + 1]) {
-                    userRunSeed = SDL_strdup(argv[i + 1]);
-                    consumed = 2;
-                }
-            } else if (SDL_strcasecmp(argv[i], "--filter") == 0) {
-                if (argv[i + 1]) {
-                    filter = SDL_strdup(argv[i + 1]);
-                    consumed = 2;
-                }
-            } else if (SDL_strcasecmp(argv[i], "--list") == 0) {
+
+            if (SDL_strcasecmp(argv[i], "--list") == 0) {
                 consumed = 1;
                 list = 1;
-            } else if (SDL_strcasecmp(argv[i], "--random-order") == 0) {
-                consumed = 1;
-                randomOrder = SDL_TRUE;
             }
-
         }
         if (consumed < 0) {
             static const char *options[] = {
-                "[--iterations #]",
-                "[--execKey #]",
-                "[--seed string]",
-                "[--filter suite_name|test_name]",
                 "[--list]",
-                "[--random-order]",
                 NULL };
             SDLTest_CommonLogUsage(state, argv[0], options);
             quit(1);
@@ -166,7 +134,7 @@ int main(int argc, char *argv[])
     }
 
     /* Call Harness */
-    result = SDLTest_RunSuites(testSuites, userRunSeed, userExecKey, filter, testIterations, randomOrder);
+    result = SDLTest_ExecuteTestSuiteRunner(runner);
 
     /* Empty event queue */
     done = 0;
@@ -176,10 +144,6 @@ int main(int argc, char *argv[])
         }
         SDL_Delay(10);
     }
-
-    /* Clean up */
-    SDL_free(userRunSeed);
-    SDL_free(filter);
 
     /* Shutdown everything */
     quit(0);

--- a/test/testautomation_audio.c
+++ b/test/testautomation_audio.c
@@ -19,7 +19,7 @@
 
 /* Fixture */
 
-static void audioSetUp(void *arg)
+static void audioSetUp(void **arg)
 {
     /* Start SDL audio subsystem */
     SDL_bool ret = SDL_InitSubSystem(SDL_INIT_AUDIO);

--- a/test/testautomation_blit.c
+++ b/test/testautomation_blit.c
@@ -40,7 +40,7 @@ Uint32 getRandomUint32() {
 /*
  * Resets PRNG state to initialize tests using PRNG
  */
-void blitSetUp(void *arg) {
+void blitSetUp(void **arg) {
     rngState[0] = 1;
     rngState[1] = 2;
 }

--- a/test/testautomation_iostream.c
+++ b/test/testautomation_iostream.c
@@ -32,7 +32,7 @@ static const char IOStreamAlphabetString[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 /* Fixture */
 
-static void IOStreamSetUp(void *arg)
+static void IOStreamSetUp(void **arg)
 {
     size_t fileLen;
     FILE *handle;

--- a/test/testautomation_render.c
+++ b/test/testautomation_render.c
@@ -44,7 +44,7 @@ static SDL_bool hasDrawColor(void);
 /**
  * Create software renderer for tests
  */
-static void InitCreateRenderer(void *arg)
+static void InitCreateRenderer(void **arg)
 {
     int width = 320, height = 240;
     const char *renderer_name = NULL;

--- a/test/testautomation_sdltest.c
+++ b/test/testautomation_sdltest.c
@@ -16,26 +16,30 @@
  */
 static int sdltest_generateRunSeed(void *arg)
 {
+    char buffer[32];
     char *result;
     size_t i, l;
     int j;
 
     for (i = 1; i <= 10; i += 3) {
-        result = SDLTest_GenerateRunSeed((int)i);
-        SDLTest_AssertPass("Call to SDLTest_GenerateRunSeed()");
+        result = SDLTest_GenerateRunSeed(buffer, (int)i);
+        SDLTest_AssertPass("Call to SDLTest_GenerateRunSeed(<buf>, %" SDL_PRIu64 ")", (Uint64)i);
         SDLTest_AssertCheck(result != NULL, "Verify returned value is not NULL");
         if (result != NULL) {
             l = SDL_strlen(result);
             SDLTest_AssertCheck(l == i, "Verify length of returned value is %d, got: %d", (int)i, (int)l);
-            SDL_free(result);
         }
     }
 
+    result = SDLTest_GenerateRunSeed(NULL, 10);
+    SDLTest_AssertPass("Call to SDLTest_GenerateRunSeed(NULL, 10)");
+    SDLTest_AssertCheck(result == NULL, "Verify returned value is NULL");
+
     /* Negative cases */
     for (j = -2; j <= 0; j++) {
-        result = SDLTest_GenerateRunSeed(j);
-        SDLTest_AssertPass("Call to SDLTest_GenerateRunSeed()");
-        SDLTest_AssertCheck(result == NULL, "Verify returned value is not NULL");
+        result = SDLTest_GenerateRunSeed(buffer, j);
+        SDLTest_AssertPass("Call to SDLTest_GenerateRunSeed(<buf>, %d)", j);
+        SDLTest_AssertCheck(result == NULL, "Verify returned value is NULL");
     }
 
     return TEST_COMPLETED;

--- a/test/testautomation_subsystems.c
+++ b/test/testautomation_subsystems.c
@@ -9,7 +9,7 @@
 
 /* Fixture */
 
-static void subsystemsSetUp(void *arg)
+static void subsystemsSetUp(void **arg)
 {
     /* Reset each one of the SDL subsystems */
     /* CHECKME: can we use SDL_Quit here, or this will break the flow of tests? */

--- a/test/testautomation_surface.c
+++ b/test/testautomation_surface.c
@@ -41,7 +41,7 @@ static SDL_Surface *testSurface = NULL;
 /* Fixture */
 
 /* Create a 32-bit writable surface for blitting tests */
-static void surfaceSetUp(void *arg)
+static void surfaceSetUp(void **arg)
 {
     int result;
     SDL_BlendMode blendMode = SDL_BLENDMODE_NONE;

--- a/test/testautomation_timer.c
+++ b/test/testautomation_timer.c
@@ -20,7 +20,7 @@ static int g_timerCallbackCalled = 0;
 
 /* Fixture */
 
-static void timerSetUp(void *arg)
+static void timerSetUp(void **arg)
 {
     /* Start SDL timer subsystem */
     SDL_bool ret = SDL_InitSubSystem(SDL_INIT_TIMER);

--- a/test/testmultiaudio.c
+++ b/test/testmultiaudio.c
@@ -142,7 +142,7 @@ int main(int argc, char **argv)
     SDLTest_CommonState *state;
 
     /* Initialize test framework */
-    state = SDLTest_CommonCreateState(argv, 0);
+    state = SDLTest_CommonCreateState(argv, SDL_INIT_AUDIO);
     if (!state) {
         return 1;
     }
@@ -171,7 +171,7 @@ int main(int argc, char **argv)
     }
 
     /* Load the SDL library */
-    if (!SDL_Init(SDL_INIT_AUDIO)) {
+    if (!SDLTest_CommonInit(state)) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
         return 1;
     }
@@ -197,8 +197,7 @@ int main(int argc, char **argv)
 
     SDL_free(filename);
 
-    SDL_Quit();
-    SDLTest_CommonDestroyState(state);
+    SDLTest_CommonQuit(state);
 
     return 0;
 }


### PR DESCRIPTION
By making an api for argument parsing, we can move argument parsing for testautomation into SDL_test.

This allows `SDLTest_RunSuites` to no longer need various arguments, and allows future refactoring of the test suite library without worrying too much about breaking the test suite api (it's used by SDL_image's test).


Tagging @1bsyl because he did recent work on the test suite library.

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
