### PR TITLE
[GPU] MinGW build fixes:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2943,7 +2943,7 @@ if(SDL_VIDEO)
   endif()
 endif()
 
-if(SDL_GPU)
+if(SDL_GPU AND NOT WINDOWS_STORE)
   if(HAVE_D3D11_H)
     sdl_glob_sources("${SDL3_SOURCE_DIR}/src/gpu/d3d11/*.c")
     set(SDL_GPU_D3D11 1)

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -1,4 +1,4 @@
-﻿/*
+/*
   Simple DirectMedia Layer
   Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
 

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -35,8 +35,7 @@
 
 #include "../SDL_sysgpu.h"
 
-// MinGW doesn't implement this yet
-#ifdef _WIN32
+#ifdef __IDXGIInfoQueue_INTERFACE_DEFINED__
 #define HAVE_IDXGIINFOQUEUE
 #endif
 


### PR DESCRIPTION
This fixes build against mingw-w64 version 8.0.3:

- CreateEventEx() is guarded by _WIN32_WINNT >= 0x0600:
  In SDL_gpu_d3d12.c, include core/windows/SDL_windows.h
  that defines _WIN32_WINNT properly to account for that
- DXGIInfoQueue stuff is not available in all toolchains
  such as mingw-w64 version 8.0.3
- SDL_gpu_d3d11.c: _WIN32 is always defined by MinGW, as
  is the case for all windows-targeting compilers, so it
  doesn't guarantee absence of DXGIInfoQueue stuff:
  rely on __IDXGIInfoQueue_INTERFACE_DEFINED__, as it is
  done elsewhere.

Fixes: https://github.com/libsdl-org/SDL/issues/10705 .
