### PR TITLE
Use SDLCALL calling convention in SDL_test

### DIFF
--- a/include/SDL3/SDL_test_assert.h
+++ b/include/SDL3/SDL_test_assert.h
@@ -54,7 +54,7 @@ extern "C" {
  * \param assertCondition Evaluated condition or variable to assert; fail (==0) or pass (!=0).
  * \param assertDescription Message to log with the assert describing it.
  */
-void SDLTest_Assert(int assertCondition, SDL_PRINTF_FORMAT_STRING const char *assertDescription, ...) SDL_PRINTF_VARARG_FUNC(2);
+void SDLCALL SDLTest_Assert(int assertCondition, SDL_PRINTF_FORMAT_STRING const char *assertDescription, ...) SDL_PRINTF_VARARG_FUNC(2);
 
 /*
  * Assert for test cases that logs but does not break execution flow on failures. Updates assertion counters.
@@ -64,32 +64,31 @@ void SDLTest_Assert(int assertCondition, SDL_PRINTF_FORMAT_STRING const char *as
  *
  * \returns the assertCondition so it can be used to externally to break execution flow if desired.
  */
-int SDLTest_AssertCheck(int assertCondition, SDL_PRINTF_FORMAT_STRING const char *assertDescription, ...) SDL_PRINTF_VARARG_FUNC(2);
+int SDLCALL SDLTest_AssertCheck(int assertCondition, SDL_PRINTF_FORMAT_STRING const char *assertDescription, ...) SDL_PRINTF_VARARG_FUNC(2);
 
 /*
  * Explicitly pass without checking an assertion condition. Updates assertion counter.
  *
  * \param assertDescription Message to log with the assert describing it.
  */
-void SDLTest_AssertPass(SDL_PRINTF_FORMAT_STRING const char *assertDescription, ...) SDL_PRINTF_VARARG_FUNC(1);
+void SDLCALL SDLTest_AssertPass(SDL_PRINTF_FORMAT_STRING const char *assertDescription, ...) SDL_PRINTF_VARARG_FUNC(1);
 
 /*
  * Resets the assert summary counters to zero.
  */
-void SDLTest_ResetAssertSummary(void);
+void SDLCALL SDLTest_ResetAssertSummary(void);
 
 /*
  * Logs summary of all assertions (total, pass, fail) since last reset as INFO or ERROR.
  */
-void SDLTest_LogAssertSummary(void);
-
+void SDLCALL SDLTest_LogAssertSummary(void);
 
 /*
  * Converts the current assert summary state to a test result.
  *
  * \returns TEST_RESULT_PASSED, TEST_RESULT_FAILED, or TEST_RESULT_NO_ASSERT
  */
-int SDLTest_AssertSummaryToTestResult(void);
+int SDLCALL SDLTest_AssertSummaryToTestResult(void);
 
 #ifdef __cplusplus
 }

--- a/include/SDL3/SDL_test_common.h
+++ b/include/SDL3/SDL_test_common.h
@@ -55,10 +55,10 @@ typedef Uint32 SDLTest_VerboseFlags;
 
 /* !< Function pointer parsing one argument at argv[index], returning the number of parsed arguments,
  *    or a negative value when the argument is invalid */
-typedef int (*SDLTest_ParseArgumentsFp)(void *data, char **argv, int index);
+typedef int (SDLCALL *SDLTest_ParseArgumentsFp)(void *data, char **argv, int index);
 
 /* !< Finalize the argument parser. */
-typedef void (*SDLTest_FinalizeArgumentParserFp)(void *arg);
+typedef void (SDLCALL *SDLTest_FinalizeArgumentParserFp)(void *arg);
 
 typedef struct SDLTest_ArgumentParser
 {
@@ -179,7 +179,7 @@ extern "C" {
  *
  * \returns a newly allocated common state object.
  */
-SDLTest_CommonState *SDLTest_CommonCreateState(char **argv, SDL_InitFlags flags);
+SDLTest_CommonState *SDLCALL SDLTest_CommonCreateState(char **argv, SDL_InitFlags flags);
 
 /**
  * Free the common state object.
@@ -188,7 +188,7 @@ SDLTest_CommonState *SDLTest_CommonCreateState(char **argv, SDL_InitFlags flags)
  *
  * \param state The common state object to destroy
  */
-void SDLTest_CommonDestroyState(SDLTest_CommonState *state);
+void SDLCALL SDLTest_CommonDestroyState(SDLTest_CommonState *state);
 
 /**
  * Process one common argument.
@@ -198,7 +198,7 @@ void SDLTest_CommonDestroyState(SDLTest_CommonState *state);
  *
  * \returns the number of arguments processed (i.e. 1 for --fullscreen, 2 for --video [videodriver], or -1 on error.
  */
-int SDLTest_CommonArg(SDLTest_CommonState *state, int index);
+int SDLCALL SDLTest_CommonArg(SDLTest_CommonState *state, int index);
 
 
 /**
@@ -213,7 +213,7 @@ int SDLTest_CommonArg(SDLTest_CommonState *state, int index);
  * \param argv0 argv[0], as passed to main/SDL_main.
  * \param options an array of strings for application specific options. The last element of the array should be NULL.
  */
-void SDLTest_CommonLogUsage(SDLTest_CommonState *state, const char *argv0, const char **options);
+void SDLCALL SDLTest_CommonLogUsage(SDLTest_CommonState *state, const char *argv0, const char **options);
 
 /**
  * Open test window.
@@ -222,7 +222,7 @@ void SDLTest_CommonLogUsage(SDLTest_CommonState *state, const char *argv0, const
  *
  * \returns SDL_TRUE if initialization succeeded, false otherwise
  */
-SDL_bool SDLTest_CommonInit(SDLTest_CommonState *state);
+SDL_bool SDLCALL SDLTest_CommonInit(SDLTest_CommonState *state);
 
 /**
  * Easy argument handling when test app doesn't need any custom args.
@@ -233,7 +233,7 @@ SDL_bool SDLTest_CommonInit(SDLTest_CommonState *state);
  *
  * \returns SDL_FALSE if app should quit, true otherwise.
  */
-SDL_bool SDLTest_CommonDefaultArgs(SDLTest_CommonState *state, const int argc, char **argv);
+SDL_bool SDLCALL SDLTest_CommonDefaultArgs(SDLTest_CommonState *state, const int argc, char **argv);
 
 /**
  * Print the details of an event.
@@ -242,7 +242,7 @@ SDL_bool SDLTest_CommonDefaultArgs(SDLTest_CommonState *state, const int argc, c
  *
  * \param event The event to print.
  */
-void SDLTest_PrintEvent(const SDL_Event *event);
+void SDLCALL SDLTest_PrintEvent(const SDL_Event *event);
 
 /**
  * Common event handler for test windows if you use a standard SDL_main.
@@ -251,7 +251,7 @@ void SDLTest_PrintEvent(const SDL_Event *event);
  * \param event The event to handle.
  * \param done Flag indicating we are done.
  */
-void SDLTest_CommonEvent(SDLTest_CommonState *state, SDL_Event *event, int *done);
+void SDLCALL SDLTest_CommonEvent(SDLTest_CommonState *state, SDL_Event *event, int *done);
 
 /**
  * Common event handler for test windows if you use SDL_AppEvent.
@@ -262,7 +262,7 @@ void SDLTest_CommonEvent(SDLTest_CommonState *state, SDL_Event *event, int *done
  * \param event The event to handle.
  * \returns Value suitable for returning from SDL_AppEvent().
  */
-SDL_AppResult SDLTest_CommonEventMainCallbacks(SDLTest_CommonState *state, const SDL_Event *event);
+SDL_AppResult SDLCALL SDLTest_CommonEventMainCallbacks(SDLTest_CommonState *state, const SDL_Event *event);
 
 /**
  * Close test window.
@@ -270,7 +270,7 @@ SDL_AppResult SDLTest_CommonEventMainCallbacks(SDLTest_CommonState *state, const
  * \param state The common state used to create test window.
  *
  */
-void SDLTest_CommonQuit(SDLTest_CommonState *state);
+void SDLCALL SDLTest_CommonQuit(SDLTest_CommonState *state);
 
 /**
  * Draws various window information (position, size, etc.) to the renderer.
@@ -280,7 +280,7 @@ void SDLTest_CommonQuit(SDLTest_CommonState *state);
  * \param usedHeight Returns the height used, so the caller can draw more below.
  *
  */
-void SDLTest_CommonDrawWindowInfo(SDL_Renderer *renderer, SDL_Window *window, float *usedHeight);
+void SDLCALL SDLTest_CommonDrawWindowInfo(SDL_Renderer *renderer, SDL_Window *window, float *usedHeight);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_test_compare.h
+++ b/include/SDL3/SDL_test_compare.h
@@ -53,7 +53,7 @@ extern "C" {
  *
  * \returns 0 if comparison succeeded, >0 (=number of pixels for which the comparison failed) if comparison failed, -1 if any of the surfaces were NULL, -2 if the surface sizes differ.
  */
-int SDLTest_CompareSurfaces(SDL_Surface *surface, SDL_Surface *referenceSurface, int allowable_error);
+int SDLCALL SDLTest_CompareSurfaces(SDL_Surface *surface, SDL_Surface *referenceSurface, int allowable_error);
 
 /**
  * Compares 2 memory blocks for equality
@@ -67,7 +67,7 @@ int SDLTest_CompareSurfaces(SDL_Surface *surface, SDL_Surface *referenceSurface,
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern int SDLTest_CompareMemory(const void *actual, size_t size_actual, const void *reference, size_t size_reference);
+int SDLCALL SDLTest_CompareMemory(const void *actual, size_t size_actual, const void *reference, size_t size_reference);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_test_crc32.h
+++ b/include/SDL3/SDL_test_crc32.h
@@ -40,7 +40,6 @@
 extern "C" {
 #endif
 
-
 /* ------------ Definitions --------- */
 
 /* Definition shared by all CRC routines */
@@ -79,7 +78,6 @@ extern "C" {
  */
 int SDLCALL SDLTest_Crc32Init(SDLTest_Crc32Context *crcContext);
 
-
 /*
  * calculate a crc32 from a data block
  *
@@ -98,7 +96,6 @@ int SDLCALL SDLTest_Crc32CalcStart(SDLTest_Crc32Context *crcContext, CrcUint32 *
 int SDLCALL SDLTest_Crc32CalcEnd(SDLTest_Crc32Context *crcContext, CrcUint32 *crc32);
 int SDLCALL SDLTest_Crc32CalcBuffer(SDLTest_Crc32Context *crcContext, CrcUint8 *inBuf, CrcUint32 inLen, CrcUint32 *crc32);
 
-
 /*
  * clean up CRC context
  *
@@ -109,7 +106,6 @@ int SDLCALL SDLTest_Crc32CalcBuffer(SDLTest_Crc32Context *crcContext, CrcUint8 *
 */
 
 int SDLCALL SDLTest_Crc32Done(SDLTest_Crc32Context *crcContext);
-
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_test_crc32.h
+++ b/include/SDL3/SDL_test_crc32.h
@@ -77,7 +77,7 @@ extern "C" {
  * \returns 0 for OK, -1 on error
  *
  */
- int SDLTest_Crc32Init(SDLTest_Crc32Context *crcContext);
+int SDLCALL SDLTest_Crc32Init(SDLTest_Crc32Context *crcContext);
 
 
 /*
@@ -91,12 +91,12 @@ extern "C" {
  * \returns 0 for OK, -1 on error
  *
  */
-int SDLTest_Crc32Calc(SDLTest_Crc32Context *crcContext, CrcUint8 *inBuf, CrcUint32 inLen, CrcUint32 *crc32);
+int SDLCALL SDLTest_Crc32Calc(SDLTest_Crc32Context *crcContext, CrcUint8 *inBuf, CrcUint32 inLen, CrcUint32 *crc32);
 
 /* Same routine broken down into three steps */
-int SDLTest_Crc32CalcStart(SDLTest_Crc32Context *crcContext, CrcUint32 *crc32);
-int SDLTest_Crc32CalcEnd(SDLTest_Crc32Context *crcContext, CrcUint32 *crc32);
-int SDLTest_Crc32CalcBuffer(SDLTest_Crc32Context *crcContext, CrcUint8 *inBuf, CrcUint32 inLen, CrcUint32 *crc32);
+int SDLCALL SDLTest_Crc32CalcStart(SDLTest_Crc32Context *crcContext, CrcUint32 *crc32);
+int SDLCALL SDLTest_Crc32CalcEnd(SDLTest_Crc32Context *crcContext, CrcUint32 *crc32);
+int SDLCALL SDLTest_Crc32CalcBuffer(SDLTest_Crc32Context *crcContext, CrcUint8 *inBuf, CrcUint32 inLen, CrcUint32 *crc32);
 
 
 /*
@@ -108,7 +108,7 @@ int SDLTest_Crc32CalcBuffer(SDLTest_Crc32Context *crcContext, CrcUint8 *inBuf, C
  *
 */
 
-int SDLTest_Crc32Done(SDLTest_Crc32Context *crcContext);
+int SDLCALL SDLTest_Crc32Done(SDLTest_Crc32Context *crcContext);
 
 
 /* Ends C function definitions when using C++ */

--- a/include/SDL3/SDL_test_font.h
+++ b/include/SDL3/SDL_test_font.h
@@ -56,7 +56,7 @@ extern int FONT_CHARACTER_SIZE;
  *
  *  \returns SDL_TRUE on success, SDL_FALSE on failure.
  */
-SDL_bool SDLTest_DrawCharacter(SDL_Renderer *renderer, float x, float y, Uint32 c);
+SDL_bool SDLCALL SDLTest_DrawCharacter(SDL_Renderer *renderer, float x, float y, Uint32 c);
 
 /*
  *  Draw a UTF-8 string in the currently set font.
@@ -70,7 +70,7 @@ SDL_bool SDLTest_DrawCharacter(SDL_Renderer *renderer, float x, float y, Uint32 
  *
  *  \returns SDL_TRUE on success, SDL_FALSE on failure.
  */
-SDL_bool SDLTest_DrawString(SDL_Renderer *renderer, float x, float y, const char *s);
+SDL_bool SDLCALL SDLTest_DrawString(SDL_Renderer *renderer, float x, float y, const char *s);
 
 /*
  *  Data used for multi-line text output
@@ -95,7 +95,7 @@ typedef struct SDLTest_TextWindow
  *
  *  \since This function is available since SDL 3.0.0.
  */
-SDLTest_TextWindow *SDLTest_TextWindowCreate(float x, float y, float w, float h);
+SDLTest_TextWindow * SDLCALL SDLTest_TextWindowCreate(float x, float y, float w, float h);
 
 /*
  *  Display a multi-line text output window
@@ -107,7 +107,7 @@ SDLTest_TextWindow *SDLTest_TextWindowCreate(float x, float y, float w, float h)
  *
  *  \since This function is available since SDL 3.0.0.
  */
-void SDLTest_TextWindowDisplay(SDLTest_TextWindow *textwin, SDL_Renderer *renderer);
+void SDLCALL SDLTest_TextWindowDisplay(SDLTest_TextWindow *textwin, SDL_Renderer *renderer);
 
 /*
  *  Add text to a multi-line text output window
@@ -122,7 +122,7 @@ void SDLTest_TextWindowDisplay(SDLTest_TextWindow *textwin, SDL_Renderer *render
  *
  *  \since This function is available since SDL 3.0.0.
  */
-void SDLTest_TextWindowAddText(SDLTest_TextWindow *textwin, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(2);
+void SDLCALL SDLTest_TextWindowAddText(SDLTest_TextWindow *textwin, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(2);
 
 /*
  *  Add text to a multi-line text output window
@@ -137,7 +137,7 @@ void SDLTest_TextWindowAddText(SDLTest_TextWindow *textwin, SDL_PRINTF_FORMAT_ST
  *
  *  \since This function is available since SDL 3.0.0.
  */
-void SDLTest_TextWindowAddTextWithLength(SDLTest_TextWindow *textwin, const char *text, size_t len);
+void SDLCALL SDLTest_TextWindowAddTextWithLength(SDLTest_TextWindow *textwin, const char *text, size_t len);
 
 /*
  *  Clear the text in a multi-line text output window
@@ -146,7 +146,7 @@ void SDLTest_TextWindowAddTextWithLength(SDLTest_TextWindow *textwin, const char
  *
  *  \since This function is available since SDL 3.0.0.
  */
-void SDLTest_TextWindowClear(SDLTest_TextWindow *textwin);
+void SDLCALL SDLTest_TextWindowClear(SDLTest_TextWindow *textwin);
 
 /*
  *  Free the storage associated with a multi-line text output window
@@ -155,12 +155,12 @@ void SDLTest_TextWindowClear(SDLTest_TextWindow *textwin);
  *
  *  \since This function is available since SDL 3.0.0.
  */
-void SDLTest_TextWindowDestroy(SDLTest_TextWindow *textwin);
+void SDLCALL SDLTest_TextWindowDestroy(SDLTest_TextWindow *textwin);
 
 /*
  *  Cleanup textures used by font drawing functions.
  */
-void SDLTest_CleanupTextDrawing(void);
+void SDLCALL SDLTest_CleanupTextDrawing(void);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_test_fuzzer.h
+++ b/include/SDL3/SDL_test_fuzzer.h
@@ -59,7 +59,7 @@ extern "C" {
  * \param execKey Execution "Key" that initializes the random number generator uniquely for the test.
  *
  */
-void SDLTest_FuzzerInit(Uint64 execKey);
+void SDLCALL SDLTest_FuzzerInit(Uint64 execKey);
 
 
 /**
@@ -67,14 +67,14 @@ void SDLTest_FuzzerInit(Uint64 execKey);
  *
  * \returns a generated integer
  */
-Uint8 SDLTest_RandomUint8(void);
+Uint8 SDLCALL SDLTest_RandomUint8(void);
 
 /**
  * Returns a random Sint8
  *
  * \returns a generated signed integer
  */
-Sint8 SDLTest_RandomSint8(void);
+Sint8 SDLCALL SDLTest_RandomSint8(void);
 
 
 /**
@@ -82,14 +82,14 @@ Sint8 SDLTest_RandomSint8(void);
  *
  * \returns a generated integer
  */
-Uint16 SDLTest_RandomUint16(void);
+Uint16 SDLCALL SDLTest_RandomUint16(void);
 
 /**
  * Returns a random Sint16
  *
  * \returns a generated signed integer
  */
-Sint16 SDLTest_RandomSint16(void);
+Sint16 SDLCALL SDLTest_RandomSint16(void);
 
 
 /**
@@ -97,7 +97,7 @@ Sint16 SDLTest_RandomSint16(void);
  *
  * \returns a generated integer
  */
-Sint32 SDLTest_RandomSint32(void);
+Sint32 SDLCALL SDLTest_RandomSint32(void);
 
 
 /**
@@ -105,7 +105,7 @@ Sint32 SDLTest_RandomSint32(void);
  *
  * \returns a generated integer
  */
-Uint32 SDLTest_RandomUint32(void);
+Uint32 SDLCALL SDLTest_RandomUint32(void);
 
 /**
  * Returns random Uint64.
@@ -120,29 +120,29 @@ Uint64 SDLTest_RandomUint64(void);
  *
  * \returns a generated signed integer
  */
-Sint64 SDLTest_RandomSint64(void);
+Sint64 SDLCALL SDLTest_RandomSint64(void);
 
 /**
  * \returns a random float in range [0.0 - 1.0]
  */
-float SDLTest_RandomUnitFloat(void);
+float SDLCALL SDLTest_RandomUnitFloat(void);
 
 /**
  * \returns a random double in range [0.0 - 1.0]
  */
-double SDLTest_RandomUnitDouble(void);
+double SDLCALL SDLTest_RandomUnitDouble(void);
 
 /**
  * \returns a random float.
  *
  */
-float SDLTest_RandomFloat(void);
+float SDLCALL SDLTest_RandomFloat(void);
 
 /**
  * \returns a random double.
  *
  */
-double SDLTest_RandomDouble(void);
+double SDLCALL SDLTest_RandomDouble(void);
 
 /**
  * Returns a random boundary value for Uint8 within the given boundaries.
@@ -163,7 +163,7 @@ double SDLTest_RandomDouble(void);
  *
  * \returns a random boundary value for the given range and domain or 0 with error set
  */
-Uint8 SDLTest_RandomUint8BoundaryValue(Uint8 boundary1, Uint8 boundary2, SDL_bool validDomain);
+Uint8 SDLCALL SDLTest_RandomUint8BoundaryValue(Uint8 boundary1, Uint8 boundary2, SDL_bool validDomain);
 
 /**
  * Returns a random boundary value for Uint16 within the given boundaries.
@@ -184,7 +184,7 @@ Uint8 SDLTest_RandomUint8BoundaryValue(Uint8 boundary1, Uint8 boundary2, SDL_boo
  *
  * \returns a random boundary value for the given range and domain or 0 with error set
  */
-Uint16 SDLTest_RandomUint16BoundaryValue(Uint16 boundary1, Uint16 boundary2, SDL_bool validDomain);
+Uint16 SDLCALL SDLTest_RandomUint16BoundaryValue(Uint16 boundary1, Uint16 boundary2, SDL_bool validDomain);
 
 /**
  * Returns a random boundary value for Uint32 within the given boundaries.
@@ -205,7 +205,7 @@ Uint16 SDLTest_RandomUint16BoundaryValue(Uint16 boundary1, Uint16 boundary2, SDL
  *
  * \returns a random boundary value for the given range and domain or 0 with error set
  */
-Uint32 SDLTest_RandomUint32BoundaryValue(Uint32 boundary1, Uint32 boundary2, SDL_bool validDomain);
+Uint32 SDLCALL SDLTest_RandomUint32BoundaryValue(Uint32 boundary1, Uint32 boundary2, SDL_bool validDomain);
 
 /**
  * Returns a random boundary value for Uint64 within the given boundaries.
@@ -226,7 +226,7 @@ Uint32 SDLTest_RandomUint32BoundaryValue(Uint32 boundary1, Uint32 boundary2, SDL
  *
  * \returns a random boundary value for the given range and domain or 0 with error set
  */
-Uint64 SDLTest_RandomUint64BoundaryValue(Uint64 boundary1, Uint64 boundary2, SDL_bool validDomain);
+Uint64 SDLCALL SDLTest_RandomUint64BoundaryValue(Uint64 boundary1, Uint64 boundary2, SDL_bool validDomain);
 
 /**
  * Returns a random boundary value for Sint8 within the given boundaries.
@@ -247,7 +247,7 @@ Uint64 SDLTest_RandomUint64BoundaryValue(Uint64 boundary1, Uint64 boundary2, SDL
  *
  * \returns a random boundary value for the given range and domain or SINT8_MIN with error set
  */
-Sint8 SDLTest_RandomSint8BoundaryValue(Sint8 boundary1, Sint8 boundary2, SDL_bool validDomain);
+Sint8 SDLCALL SDLTest_RandomSint8BoundaryValue(Sint8 boundary1, Sint8 boundary2, SDL_bool validDomain);
 
 
 /**
@@ -269,7 +269,7 @@ Sint8 SDLTest_RandomSint8BoundaryValue(Sint8 boundary1, Sint8 boundary2, SDL_boo
  *
  * \returns a random boundary value for the given range and domain or SINT16_MIN with error set
  */
-Sint16 SDLTest_RandomSint16BoundaryValue(Sint16 boundary1, Sint16 boundary2, SDL_bool validDomain);
+Sint16 SDLCALL SDLTest_RandomSint16BoundaryValue(Sint16 boundary1, Sint16 boundary2, SDL_bool validDomain);
 
 /**
  * Returns a random boundary value for Sint32 within the given boundaries.
@@ -290,7 +290,7 @@ Sint16 SDLTest_RandomSint16BoundaryValue(Sint16 boundary1, Sint16 boundary2, SDL
  *
  * \returns a random boundary value for the given range and domain or SINT32_MIN with error set
  */
-Sint32 SDLTest_RandomSint32BoundaryValue(Sint32 boundary1, Sint32 boundary2, SDL_bool validDomain);
+Sint32 SDLCALL SDLTest_RandomSint32BoundaryValue(Sint32 boundary1, Sint32 boundary2, SDL_bool validDomain);
 
 /**
  * Returns a random boundary value for Sint64 within the given boundaries.
@@ -311,7 +311,7 @@ Sint32 SDLTest_RandomSint32BoundaryValue(Sint32 boundary1, Sint32 boundary2, SDL
  *
  * \returns a random boundary value for the given range and domain or SINT64_MIN with error set
  */
-Sint64 SDLTest_RandomSint64BoundaryValue(Sint64 boundary1, Sint64 boundary2, SDL_bool validDomain);
+Sint64 SDLCALL SDLTest_RandomSint64BoundaryValue(Sint64 boundary1, Sint64 boundary2, SDL_bool validDomain);
 
 
 /**
@@ -325,7 +325,7 @@ Sint64 SDLTest_RandomSint64BoundaryValue(Sint64 boundary1, Sint64 boundary2, SDL
  *
  * \returns a generated random integer in range
  */
-Sint32 SDLTest_RandomIntegerInRange(Sint32 min, Sint32 max);
+Sint32 SDLCALL SDLTest_RandomIntegerInRange(Sint32 min, Sint32 max);
 
 
 /**
@@ -337,7 +337,7 @@ Sint32 SDLTest_RandomIntegerInRange(Sint32 min, Sint32 max);
  *
  * \returns a newly allocated random string; or NULL if length was invalid or string could not be allocated.
  */
-char *SDLTest_RandomAsciiString(void);
+char * SDLCALL SDLTest_RandomAsciiString(void);
 
 
 /**
@@ -351,7 +351,7 @@ char *SDLTest_RandomAsciiString(void);
  *
  * \returns a newly allocated random string; or NULL if maxLength was invalid or string could not be allocated.
  */
-char *SDLTest_RandomAsciiStringWithMaximumLength(int maxLength);
+char * SDLCALL SDLTest_RandomAsciiStringWithMaximumLength(int maxLength);
 
 
 /**
@@ -365,14 +365,14 @@ char *SDLTest_RandomAsciiStringWithMaximumLength(int maxLength);
  *
  * \returns a newly allocated random string; or NULL if size was invalid or string could not be allocated.
  */
-char *SDLTest_RandomAsciiStringOfSize(int size);
+char * SDLCALL SDLTest_RandomAsciiStringOfSize(int size);
 
 /**
  * Get the invocation count for the fuzzer since last ...FuzzerInit.
  *
  * \returns the invocation count.
  */
-int SDLTest_GetFuzzerInvocationCount(void);
+int SDLCALL SDLTest_GetFuzzerInvocationCount(void);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_test_fuzzer.h
+++ b/include/SDL3/SDL_test_fuzzer.h
@@ -42,11 +42,9 @@
 extern "C" {
 #endif
 
-
 /*
   Based on GSOC code by Markus Kauppila <markus.kauppila@gmail.com>
 */
-
 
 /**
  * Note: The fuzzer implementation uses a static instance of random context
@@ -60,7 +58,6 @@ extern "C" {
  *
  */
 void SDLCALL SDLTest_FuzzerInit(Uint64 execKey);
-
 
 /**
  * Returns a random Uint8
@@ -76,7 +73,6 @@ Uint8 SDLCALL SDLTest_RandomUint8(void);
  */
 Sint8 SDLCALL SDLTest_RandomSint8(void);
 
-
 /**
  * Returns a random Uint16
  *
@@ -91,14 +87,12 @@ Uint16 SDLCALL SDLTest_RandomUint16(void);
  */
 Sint16 SDLCALL SDLTest_RandomSint16(void);
 
-
 /**
  * Returns a random integer
  *
  * \returns a generated integer
  */
 Sint32 SDLCALL SDLTest_RandomSint32(void);
-
 
 /**
  * Returns a random positive integer
@@ -113,7 +107,6 @@ Uint32 SDLCALL SDLTest_RandomUint32(void);
  * \returns a generated integer
  */
 Uint64 SDLTest_RandomUint64(void);
-
 
 /**
  * Returns random Sint64.
@@ -249,7 +242,6 @@ Uint64 SDLCALL SDLTest_RandomUint64BoundaryValue(Uint64 boundary1, Uint64 bounda
  */
 Sint8 SDLCALL SDLTest_RandomSint8BoundaryValue(Sint8 boundary1, Sint8 boundary2, SDL_bool validDomain);
 
-
 /**
  * Returns a random boundary value for Sint16 within the given boundaries.
  * Boundaries are inclusive, see the usage examples below. If validDomain
@@ -313,7 +305,6 @@ Sint32 SDLCALL SDLTest_RandomSint32BoundaryValue(Sint32 boundary1, Sint32 bounda
  */
 Sint64 SDLCALL SDLTest_RandomSint64BoundaryValue(Sint64 boundary1, Sint64 boundary2, SDL_bool validDomain);
 
-
 /**
  * Returns integer in range [min, max] (inclusive).
  * Min and max values can be negative values.
@@ -327,7 +318,6 @@ Sint64 SDLCALL SDLTest_RandomSint64BoundaryValue(Sint64 boundary1, Sint64 bounda
  */
 Sint32 SDLCALL SDLTest_RandomIntegerInRange(Sint32 min, Sint32 max);
 
-
 /**
  * Generates random null-terminated string. The minimum length for
  * the string is 1 character, maximum length for the string is 255
@@ -338,7 +328,6 @@ Sint32 SDLCALL SDLTest_RandomIntegerInRange(Sint32 min, Sint32 max);
  * \returns a newly allocated random string; or NULL if length was invalid or string could not be allocated.
  */
 char * SDLCALL SDLTest_RandomAsciiString(void);
-
 
 /**
  * Generates random null-terminated string. The maximum length for
@@ -352,7 +341,6 @@ char * SDLCALL SDLTest_RandomAsciiString(void);
  * \returns a newly allocated random string; or NULL if maxLength was invalid or string could not be allocated.
  */
 char * SDLCALL SDLTest_RandomAsciiStringWithMaximumLength(int maxLength);
-
 
 /**
  * Generates random null-terminated string. The length for

--- a/include/SDL3/SDL_test_harness.h
+++ b/include/SDL3/SDL_test_harness.h
@@ -44,7 +44,6 @@
 extern "C" {
 #endif
 
-
 /* ! Definitions for test case structures */
 #define TEST_ENABLED  1
 #define TEST_DISABLED 0

--- a/include/SDL3/SDL_test_harness.h
+++ b/include/SDL3/SDL_test_harness.h
@@ -63,13 +63,13 @@ extern "C" {
 #define TEST_RESULT_SETUP_FAILURE       4
 
 /* !< Function pointer to a test case setup function (run before every test) */
-typedef void (*SDLTest_TestCaseSetUpFp)(void **arg);
+typedef void (SDLCALL *SDLTest_TestCaseSetUpFp)(void **arg);
 
 /* !< Function pointer to a test case function */
-typedef int (*SDLTest_TestCaseFp)(void *arg);
+typedef int (SDLCALL *SDLTest_TestCaseFp)(void *arg);
 
 /* !< Function pointer to a test case teardown function (run after every test) */
-typedef void  (*SDLTest_TestCaseTearDownFp)(void *arg);
+typedef void  (SDLCALL *SDLTest_TestCaseTearDownFp)(void *arg);
 
 /*
  * Holds information about a single test case.
@@ -109,7 +109,7 @@ typedef struct SDLTest_TestSuiteReference {
  *
  * \returns A null-terminated seed string and equal to the in put buffer on success, NULL on failure
  */
-char *SDLTest_GenerateRunSeed(char *buffer, int length);
+char * SDLCALL SDLTest_GenerateRunSeed(char *buffer, int length);
 
 /*
  * Holds information about the execution of test suites.
@@ -125,7 +125,7 @@ typedef struct SDLTest_TestSuiteRunner SDLTest_TestSuiteRunner;
  *
  * \returns the test run result: 0 when all tests passed, 1 if any tests failed.
  */
-SDLTest_TestSuiteRunner * SDLTest_CreateTestSuiteRunner(SDLTest_CommonState *state, SDLTest_TestSuiteReference *testSuites[]);
+SDLTest_TestSuiteRunner * SDLCALL SDLTest_CreateTestSuiteRunner(SDLTest_CommonState *state, SDLTest_TestSuiteReference *testSuites[]);
 
 /*
  * Destroy a test suite runner.
@@ -133,7 +133,7 @@ SDLTest_TestSuiteRunner * SDLTest_CreateTestSuiteRunner(SDLTest_CommonState *sta
  *
  * \param runner The runner that should be destroyed.
  */
-void SDLTest_DestroyTestSuiteRunner(SDLTest_TestSuiteRunner *runner);
+void SDLCALL SDLTest_DestroyTestSuiteRunner(SDLTest_TestSuiteRunner *runner);
 
 /*
  * Execute a test suite, using the configured run seed, execution key, filter, etc.
@@ -142,8 +142,7 @@ void SDLTest_DestroyTestSuiteRunner(SDLTest_TestSuiteRunner *runner);
  *
  * \returns the test run result: 0 when all tests passed, 1 if any tests failed.
  */
-int SDLTest_ExecuteTestSuiteRunner(SDLTest_TestSuiteRunner *runner);
-
+int SDLCALL SDLTest_ExecuteTestSuiteRunner(SDLTest_TestSuiteRunner *runner);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_test_log.h
+++ b/include/SDL3/SDL_test_log.h
@@ -49,14 +49,14 @@ extern "C" {
  *
  * \param fmt Message to be logged
  */
-void SDLTest_Log(SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(1);
+void SDLCALL SDLTest_Log(SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(1);
 
 /**
  * Prints given message with a timestamp in the TEST category and the ERROR priority.
  *
  * \param fmt Message to be logged
  */
-void SDLTest_LogError(SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(1);
+void SDLCALL SDLTest_LogError(SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(1);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_test_md5.h
+++ b/include/SDL3/SDL_test_md5.h
@@ -67,15 +67,15 @@ extern "C" {
 /* ------------ Definitions --------- */
 
 /* typedef a 32-bit type */
-  typedef Uint32 MD5UINT4;
+typedef Uint32 MD5UINT4;
 
 /* Data structure for MD5 (Message-Digest) computation */
-  typedef struct SDLTest_Md5Context {
-    MD5UINT4  i[2];     /* number of _bits_ handled mod 2^64 */
-    MD5UINT4  buf[4];       /* scratch buffer */
-    unsigned char in[64];   /* input buffer */
+typedef struct SDLTest_Md5Context {
+    MD5UINT4 i[2];              /* number of _bits_ handled mod 2^64 */
+    MD5UINT4 buf[4];            /* scratch buffer */
+    unsigned char in[64];       /* input buffer */
     unsigned char digest[16];   /* actual digest after Md5Final call */
-  } SDLTest_Md5Context;
+} SDLTest_Md5Context;
 
 /* ---------- Function Prototypes ------------- */
 
@@ -103,7 +103,6 @@ void SDLCALL SDLTest_Md5Init(SDLTest_Md5Context *mdContext);
  */
 void SDLCALL SDLTest_Md5Update(SDLTest_Md5Context *mdContext, unsigned char *inBuf,
                  unsigned int inLen);
-
 
 /**
  * complete digest computation

--- a/include/SDL3/SDL_test_md5.h
+++ b/include/SDL3/SDL_test_md5.h
@@ -88,8 +88,7 @@ extern "C" {
  *       mdContext. Call before each new use of the context -
  *       all fields are set to zero.
  */
- void SDLTest_Md5Init(SDLTest_Md5Context *mdContext);
-
+void SDLCALL SDLTest_Md5Init(SDLTest_Md5Context *mdContext);
 
 /**
  * update digest from variable length data
@@ -101,9 +100,8 @@ extern "C" {
  * Note: The function updates the message-digest context to account
  *       for the presence of each of the characters inBuf[0..inLen-1]
  *       in the message whose digest is being computed.
-*/
-
- void SDLTest_Md5Update(SDLTest_Md5Context *mdContext, unsigned char *inBuf,
+ */
+void SDLCALL SDLTest_Md5Update(SDLTest_Md5Context *mdContext, unsigned char *inBuf,
                  unsigned int inLen);
 
 
@@ -115,10 +113,8 @@ extern "C" {
  * Note: The function terminates the message-digest computation and
  *       ends with the desired message digest in mdContext.digest[0..15].
  *       Always call before using the digest[] variable.
-*/
-
- void SDLTest_Md5Final(SDLTest_Md5Context *mdContext);
-
+ */
+void SDLCALL SDLTest_Md5Final(SDLTest_Md5Context *mdContext);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_test_memory.h
+++ b/include/SDL3/SDL_test_memory.h
@@ -36,28 +36,26 @@
 extern "C" {
 #endif
 
-
 /**
  * Start tracking SDL memory allocations
  *
  * \note This should be called before any other SDL functions for complete tracking coverage
  */
-void SDLTest_TrackAllocations(void);
+void SDLCALL SDLTest_TrackAllocations(void);
 
 /**
  * Fill allocations with random data
  *
  * \note This implicitly calls SDLTest_TrackAllocations()
  */
-void SDLTest_RandFillAllocations(void);
+void SDLCALL SDLTest_RandFillAllocations(void);
 
 /**
  * Print a log of any outstanding allocations
  *
  * \note This can be called after SDL_Quit()
  */
-void SDLTest_LogAllocations(void);
-
+void SDLCALL SDLTest_LogAllocations(void);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -99,7 +99,7 @@ static void SDL_snprintfcat(SDL_OUT_Z_CAP(maxlen) char *text, size_t maxlen, SDL
     va_end(ap);
 }
 
-static void SDLTest_CommonArgParserFinalize(void *data)
+static void SDLCALL SDLTest_CommonArgParserFinalize(void *data)
 {
     SDLTest_CommonState *state = data;
 
@@ -120,7 +120,7 @@ static void SDLTest_CommonArgParserFinalize(void *data)
     }                                   \
     *(dim)++ = '\0';
 
-static int SDLTest_CommonStateParseCommonArguments(void *data, char **argv, int index)
+static int SDLCALL SDLTest_CommonStateParseCommonArguments(void *data, char **argv, int index)
 {
     SDLTest_CommonState *state = data;
 
@@ -212,7 +212,7 @@ static int SDLTest_CommonStateParseCommonArguments(void *data, char **argv, int 
     return 0;
 }
 
-static int SDLTest_CommonStateParseVideoArguments(void *data, char **argv, int index)
+static int SDLCALL SDLTest_CommonStateParseVideoArguments(void *data, char **argv, int index)
 {
     SDLTest_CommonState *state = data;
 
@@ -593,7 +593,7 @@ static int SDLTest_CommonStateParseVideoArguments(void *data, char **argv, int i
     return 0;
 }
 
-static int SDLTest_CommonStateParseAudioArguments(void *data, char **argv, int index)
+static int SDLCALL SDLTest_CommonStateParseAudioArguments(void *data, char **argv, int index)
 {
     SDLTest_CommonState *state = data;
 
@@ -1971,7 +1971,7 @@ typedef struct
     size_t size;
 } SDLTest_ClipboardData;
 
-static void SDLTest_ScreenShotClipboardCleanup(void *context)
+static void SDLCALL SDLTest_ScreenShotClipboardCleanup(void *context)
 {
     SDLTest_ClipboardData *data = (SDLTest_ClipboardData *)context;
 
@@ -1983,7 +1983,7 @@ static void SDLTest_ScreenShotClipboardCleanup(void *context)
     SDL_free(data);
 }
 
-static const void *SDLTest_ScreenShotClipboardProvider(void *context, const char *mime_type, size_t *size)
+static const void * SDLCALL SDLTest_ScreenShotClipboardProvider(void *context, const char *mime_type, size_t *size)
 {
     SDLTest_ClipboardData *data = (SDLTest_ClipboardData *)context;
 

--- a/src/test/SDL_test_harness.c
+++ b/src/test/SDL_test_harness.c
@@ -792,7 +792,7 @@ int SDLTest_ExecuteTestSuiteRunner(SDLTest_TestSuiteRunner *runner)
     return runResult;
 }
 
-static int SDLTest_TestSuiteCommonArg(void *data, char **argv, int index)
+static int SDLCALL SDLTest_TestSuiteCommonArg(void *data, char **argv, int index)
 {
     SDLTest_TestSuiteRunner *runner = data;
 

--- a/test/testautomation_audio.c
+++ b/test/testautomation_audio.c
@@ -19,7 +19,7 @@
 
 /* Fixture */
 
-static void audioSetUp(void **arg)
+static void SDLCALL audioSetUp(void **arg)
 {
     /* Start SDL audio subsystem */
     SDL_bool ret = SDL_InitSubSystem(SDL_INIT_AUDIO);
@@ -30,7 +30,7 @@ static void audioSetUp(void **arg)
     }
 }
 
-static void audioTearDown(void *arg)
+static void SDLCALL audioTearDown(void *arg)
 {
     /* Remove a possibly created file from SDL disk writer audio driver; ignore errors */
     (void)remove("sdlaudio.raw");
@@ -64,7 +64,7 @@ static SDL_AudioDeviceID g_audio_id = 0;
  * \sa SDL_QuitSubSystem
  * \sa SDL_InitSubSystem
  */
-static int audio_quitInitAudioSubSystem(void *arg)
+static int SDLCALL audio_quitInitAudioSubSystem(void *arg)
 {
     /* Stop SDL audio subsystem */
     SDL_QuitSubSystem(SDL_INIT_AUDIO);
@@ -82,7 +82,7 @@ static int audio_quitInitAudioSubSystem(void *arg)
  * \sa SDL_InitAudio
  * \sa SDL_QuitAudio
  */
-static int audio_initQuitAudio(void *arg)
+static int SDLCALL audio_initQuitAudio(void *arg)
 {
     int result;
     int i, iMax;
@@ -145,7 +145,7 @@ static int audio_initQuitAudio(void *arg)
  * \sa SDL_CloseAudioDevice
  * \sa SDL_QuitAudio
  */
-static int audio_initOpenCloseQuitAudio(void *arg)
+static int SDLCALL audio_initOpenCloseQuitAudio(void *arg)
 {
     int result;
     int i, iMax, j, k;
@@ -235,7 +235,7 @@ static int audio_initOpenCloseQuitAudio(void *arg)
  * \sa SDL_PauseAudioDevice
  * \sa SDL_PlayAudioDevice
  */
-static int audio_pauseUnpauseAudio(void *arg)
+static int SDLCALL audio_pauseUnpauseAudio(void *arg)
 {
     int iMax;
     int i, j /*, k, l*/;
@@ -361,7 +361,7 @@ static int audio_pauseUnpauseAudio(void *arg)
  * \sa SDL_GetNumAudioDevices
  * \sa SDL_GetAudioDeviceName
  */
-static int audio_enumerateAndNameAudioDevices(void *arg)
+static int SDLCALL audio_enumerateAndNameAudioDevices(void *arg)
 {
     int t;
     int i, n;
@@ -400,7 +400,7 @@ static int audio_enumerateAndNameAudioDevices(void *arg)
  * \sa SDL_GetNumAudioDevices
  * \sa SDL_GetAudioDeviceName
  */
-static int audio_enumerateAndNameAudioDevicesNegativeTests(void *arg)
+static int SDLCALL audio_enumerateAndNameAudioDevicesNegativeTests(void *arg)
 {
     return TEST_COMPLETED;  /* nothing in here atm since these interfaces changed in SDL3. */
 }
@@ -411,7 +411,7 @@ static int audio_enumerateAndNameAudioDevicesNegativeTests(void *arg)
  * \sa SDL_GetNumAudioDrivers
  * \sa SDL_GetAudioDriver
  */
-static int audio_printAudioDrivers(void *arg)
+static int SDLCALL audio_printAudioDrivers(void *arg)
 {
     int i, n;
     const char *name;
@@ -441,7 +441,7 @@ static int audio_printAudioDrivers(void *arg)
  *
  * \sa SDL_GetCurrentAudioDriver
  */
-static int audio_printCurrentAudioDriver(void *arg)
+static int SDLCALL audio_printCurrentAudioDriver(void *arg)
 {
     /* Check current audio driver */
     const char *name = SDL_GetCurrentAudioDriver();
@@ -495,7 +495,7 @@ SDL_COMPILE_TIME_ASSERT(SDL_AUDIO_F32BE_FORMAT, SDL_AUDIO_F32BE == (SDL_AUDIO_F3
  *
  * \sa SDL_GetAudioFormatName
  */
-static int audio_getAudioFormatName(void *arg)
+static int SDLCALL audio_getAudioFormatName(void *arg)
 {
     const char *error;
     int i;
@@ -547,7 +547,7 @@ static int audio_getAudioFormatName(void *arg)
  *
  * \sa SDL_CreateAudioStream
  */
-static int audio_buildAudioStream(void *arg)
+static int SDLCALL audio_buildAudioStream(void *arg)
 {
     SDL_AudioStream *stream;
     SDL_AudioSpec spec1;
@@ -619,7 +619,7 @@ static int audio_buildAudioStream(void *arg)
  *
  * \sa SDL_CreateAudioStream
  */
-static int audio_buildAudioStreamNegative(void *arg)
+static int SDLCALL audio_buildAudioStreamNegative(void *arg)
 {
     const char *error;
     SDL_AudioStream *stream;
@@ -702,7 +702,7 @@ static int audio_buildAudioStreamNegative(void *arg)
  *
  * \sa SDL_GetAudioDeviceStatus
  */
-static int audio_getAudioStatus(void *arg)
+static int SDLCALL audio_getAudioStatus(void *arg)
 {
     return TEST_COMPLETED;  /* no longer a thing in SDL3. */
 }
@@ -712,7 +712,7 @@ static int audio_getAudioStatus(void *arg)
  *
  * \sa SDL_GetAudioStatus
  */
-static int audio_openCloseAndGetAudioStatus(void *arg)
+static int SDLCALL audio_openCloseAndGetAudioStatus(void *arg)
 {
     return TEST_COMPLETED;  /* not a thing in SDL3. */
 }
@@ -723,7 +723,7 @@ static int audio_openCloseAndGetAudioStatus(void *arg)
  * \sa SDL_LockAudioDevice
  * \sa SDL_UnlockAudioDevice
  */
-static int audio_lockUnlockOpenAudioDevice(void *arg)
+static int SDLCALL audio_lockUnlockOpenAudioDevice(void *arg)
 {
     return TEST_COMPLETED;  /* not a thing in SDL3 */
 }
@@ -733,7 +733,7 @@ static int audio_lockUnlockOpenAudioDevice(void *arg)
  *
  * \sa SDL_CreateAudioStream
  */
-static int audio_convertAudio(void *arg)
+static int SDLCALL audio_convertAudio(void *arg)
 {
     SDL_AudioStream *stream;
     SDL_AudioSpec spec1;
@@ -870,7 +870,7 @@ static int audio_convertAudio(void *arg)
  *
  * \sa SDL_AudioDeviceConnected
  */
-static int audio_openCloseAudioDeviceConnected(void *arg)
+static int SDLCALL audio_openCloseAudioDeviceConnected(void *arg)
 {
     return TEST_COMPLETED;  /* not a thing in SDL3. */
 }
@@ -1017,7 +1017,7 @@ static int convert_audio_chunks(SDL_AudioStream* stream, const void* src, int sr
  * \sa https://wiki.libsdl.org/SDL_FlushAudioStream
  * \sa https://wiki.libsdl.org/SDL_GetAudioStreamData
  */
-static int audio_resampleLoss(void *arg)
+static int SDLCALL audio_resampleLoss(void *arg)
 {
   /* Note: always test long input time (>= 5s from experience) in some test
    * cases because an improper implementation may suffer from low resampling
@@ -1156,7 +1156,7 @@ static int audio_resampleLoss(void *arg)
  *
  * \sa SDL_ConvertAudioSamples
  */
-static int audio_convertAccuracy(void *arg)
+static int SDLCALL audio_convertAccuracy(void *arg)
 {
     static SDL_AudioFormat formats[] = { SDL_AUDIO_S8, SDL_AUDIO_U8, SDL_AUDIO_S16, SDL_AUDIO_S32 };
     static const char* format_names[] = { "S8", "U8", "S16", "S32" };
@@ -1294,7 +1294,7 @@ static int audio_convertAccuracy(void *arg)
  *
  * \sa SDL_SetAudioStreamFormat
  */
-static int audio_formatChange(void *arg)
+static int SDLCALL audio_formatChange(void *arg)
 {
     int i;
     SDL_AudioSpec spec1, spec2, spec3;

--- a/test/testautomation_blit.c
+++ b/test/testautomation_blit.c
@@ -40,7 +40,7 @@ Uint32 getRandomUint32() {
 /*
  * Resets PRNG state to initialize tests using PRNG
  */
-void blitSetUp(void **arg) {
+void SDLCALL blitSetUp(void **arg) {
     rngState[0] = 1;
     rngState[1] = 2;
 }
@@ -96,7 +96,7 @@ Uint32 hashSurfacePixels(SDL_Surface * surface) {
  * Tests rendering a rainbow gradient background onto a blank surface, then rendering a sprite with complex geometry and
  * transparency on top of said surface, and comparing the result to known accurate renders with a hash.
  */
-int blit_testExampleApplicationRender(void *arg) {
+static int SDLCALL blit_testExampleApplicationRender(void *arg) {
     const int width = 32;
     const int height = 32;
     const Uint32 correct_hash = 0xe345d7a7;
@@ -123,7 +123,7 @@ int blit_testExampleApplicationRender(void *arg) {
  * different source and destination pixel formats, without an alpha shuffle, at SVGA resolution. Compares to known
  * accurate renders with a hash.
  */
-int blit_testRandomToRandomSVGA(void *arg) {
+static int SDLCALL blit_testRandomToRandomSVGA(void *arg) {
     const int width = 800;
     const int height = 600;
     const Uint32 correct_hash = 0x42140c5f;
@@ -152,7 +152,7 @@ int blit_testRandomToRandomSVGA(void *arg) {
  * shift operations between the different source and destination pixel formats, including an alpha shuffle. Compares to
  * known accurate renders with a hash.
  */
-int blit_testRandomToRandomSVGAMultipleIterations(void *arg) {
+static int SDLCALL blit_testRandomToRandomSVGAMultipleIterations(void *arg) {
     const int width = 800;
     const int height = 600;
     const int blit_width = 15;

--- a/test/testautomation_clipboard.c
+++ b/test/testautomation_clipboard.c
@@ -9,7 +9,7 @@
 
 static int clipboard_update_count;
 
-static SDL_bool ClipboardEventWatch(void *userdata, SDL_Event *event)
+static SDL_bool SDLCALL ClipboardEventWatch(void *userdata, SDL_Event *event)
 {
     if (event->type == SDL_EVENT_CLIPBOARD_UPDATE) {
         ++clipboard_update_count;
@@ -39,7 +39,7 @@ typedef struct
 
 static int clipboard_callback_count;
 
-static const void *ClipboardDataCallback(void *userdata, const char *mime_type, size_t *length)
+static const void * SDLCALL ClipboardDataCallback(void *userdata, const char *mime_type, size_t *length)
 {
     TestClipboardData *test_data = (TestClipboardData *)userdata;
 
@@ -66,7 +66,7 @@ static const void *ClipboardDataCallback(void *userdata, const char *mime_type, 
 
 static int clipboard_cleanup_count;
 
-static void ClipboardCleanupCallback(void *userdata)
+static void SDLCALL ClipboardCleanupCallback(void *userdata)
 {
     ++clipboard_cleanup_count;
 }
@@ -79,7 +79,7 @@ static void ClipboardCleanupCallback(void *userdata)
  * \sa SDL_GetClipboardData
  * \sa SDL_SetClipboardData
  */
-static int clipboard_testClipboardDataFunctions(void *arg)
+static int SDLCALL clipboard_testClipboardDataFunctions(void *arg)
 {
     int result = -1;
     SDL_bool boolResult;
@@ -400,7 +400,7 @@ static int clipboard_testClipboardDataFunctions(void *arg)
  * \sa SDL_GetClipboardText
  * \sa SDL_SetClipboardText
  */
-static int clipboard_testClipboardTextFunctions(void *arg)
+static int SDLCALL clipboard_testClipboardTextFunctions(void *arg)
 {
     char *textRef = SDLTest_RandomAsciiString();
     char *text = SDL_strdup(textRef);
@@ -484,7 +484,7 @@ static int clipboard_testClipboardTextFunctions(void *arg)
  * \sa SDL_GetPrimarySelectionText
  * \sa SDL_SetPrimarySelectionText
  */
-static int clipboard_testPrimarySelectionTextFunctions(void *arg)
+static int SDLCALL clipboard_testPrimarySelectionTextFunctions(void *arg)
 {
     char *textRef = SDLTest_RandomAsciiString();
     char *text = SDL_strdup(textRef);

--- a/test/testautomation_events.c
+++ b/test/testautomation_events.c
@@ -45,7 +45,7 @@ static SDL_bool SDLCALL events_sampleNullEventFilter(void *userdata, SDL_Event *
  * \sa SDL_PumpEvents
  * \sa SDL_PollEvent
  */
-static int events_pushPumpAndPollUserevent(void *arg)
+static int SDLCALL events_pushPumpAndPollUserevent(void *arg)
 {
     SDL_Event event_in;
     SDL_Event event_out;
@@ -109,7 +109,7 @@ static int events_pushPumpAndPollUserevent(void *arg)
  * \sa SDL_RemoveEventWatch
  *
  */
-static int events_addDelEventWatch(void *arg)
+static int SDLCALL events_addDelEventWatch(void *arg)
 {
     SDL_Event event;
 
@@ -159,7 +159,7 @@ static int events_addDelEventWatch(void *arg)
  * \sa SDL_RemoveEventWatch
  *
  */
-static int events_addDelEventWatchWithUserdata(void *arg)
+static int SDLCALL events_addDelEventWatchWithUserdata(void *arg)
 {
     SDL_Event event;
 

--- a/test/testautomation_guid.c
+++ b/test/testautomation_guid.c
@@ -74,7 +74,7 @@ upper_lower_to_bytestring(Uint8 *out, Uint64 upper, Uint64 lower)
  *
  * \sa SDL_StringToGUID
  */
-static int
+static int SDLCALL
 TestStringToGUID(void *arg)
 {
     int i;
@@ -99,7 +99,7 @@ TestStringToGUID(void *arg)
  *
  * \sa SDL_GUIDToString
  */
-static int
+static int SDLCALL
 TestGUIDToString(void *arg)
 {
     int i;

--- a/test/testautomation_hints.c
+++ b/test/testautomation_hints.c
@@ -50,7 +50,7 @@ static const int numHintsEnum = SDL_arraysize(HintsEnum);
 /**
  * Call to SDL_GetHint
  */
-static int hints_getHint(void *arg)
+static int SDLCALL hints_getHint(void *arg)
 {
     const char *result1;
     const char *result2;
@@ -79,7 +79,7 @@ static void SDLCALL hints_testHintChanged(void *userdata, const char *name, cons
 /**
  * Call to SDL_SetHint
  */
-static int hints_setHint(void *arg)
+static int SDLCALL hints_setHint(void *arg)
 {
     const char *testHint = "SDL_AUTOMATED_TEST_HINT";
     const char *originalValue;

--- a/test/testautomation_intrinsics.c
+++ b/test/testautomation_intrinsics.c
@@ -317,7 +317,7 @@ SDL_TARGETING("avx512f") static void kernel_floats_add_avx512f(float *dest, cons
 
 /* Test case functions */
 
-static int intrinsics_selftest(void *arg)
+static int SDLCALL intrinsics_selftest(void *arg)
 {
     {
         size_t size;
@@ -362,7 +362,7 @@ static int intrinsics_selftest(void *arg)
     return TEST_COMPLETED;
 }
 
-static int intrinsics_testMMX(void *arg)
+static int SDLCALL intrinsics_testMMX(void *arg)
 {
     if (SDL_HasMMX()) {
         SDLTest_AssertCheck(SDL_TRUE, "CPU of test machine has MMX support.");
@@ -390,7 +390,7 @@ static int intrinsics_testMMX(void *arg)
     return TEST_SKIPPED;
 }
 
-static int intrinsics_testSSE(void *arg)
+static int SDLCALL intrinsics_testSSE(void *arg)
 {
     if (SDL_HasSSE()) {
         SDLTest_AssertCheck(SDL_TRUE, "CPU of test machine has SSE support.");
@@ -418,7 +418,7 @@ static int intrinsics_testSSE(void *arg)
     return TEST_SKIPPED;
 }
 
-static int intrinsics_testSSE2(void *arg)
+static int SDLCALL intrinsics_testSSE2(void *arg)
 {
     if (SDL_HasSSE2()) {
         SDLTest_AssertCheck(SDL_TRUE, "CPU of test machine has SSE2 support.");
@@ -446,7 +446,7 @@ static int intrinsics_testSSE2(void *arg)
     return TEST_SKIPPED;
 }
 
-static int intrinsics_testSSE3(void *arg)
+static int SDLCALL intrinsics_testSSE3(void *arg)
 {
     if (SDL_HasSSE3()) {
         SDLTest_AssertCheck(SDL_TRUE, "CPU of test machine has SSE3 support.");
@@ -474,7 +474,7 @@ static int intrinsics_testSSE3(void *arg)
     return TEST_SKIPPED;
 }
 
-static int intrinsics_testSSE4_1(void *arg)
+static int SDLCALL intrinsics_testSSE4_1(void *arg)
 {
     if (SDL_HasSSE41()) {
         SDLTest_AssertCheck(SDL_TRUE, "CPU of test machine has SSE4.1 support.");
@@ -502,7 +502,7 @@ static int intrinsics_testSSE4_1(void *arg)
     return TEST_SKIPPED;
 }
 
-static int intrinsics_testSSE4_2(void *arg)
+static int SDLCALL intrinsics_testSSE4_2(void *arg)
 {
     if (SDL_HasSSE42()) {
         SDLTest_AssertCheck(SDL_TRUE, "CPU of test machine has SSE4.2 support.");
@@ -537,7 +537,7 @@ static int intrinsics_testSSE4_2(void *arg)
     return TEST_SKIPPED;
 }
 
-static int intrinsics_testAVX(void *arg)
+static int SDLCALL intrinsics_testAVX(void *arg)
 {
     if (SDL_HasAVX()) {
         SDLTest_AssertCheck(SDL_TRUE, "CPU of test machine has AVX support.");
@@ -565,7 +565,7 @@ static int intrinsics_testAVX(void *arg)
     return TEST_SKIPPED;
 }
 
-static int intrinsics_testAVX2(void *arg)
+static int SDLCALL intrinsics_testAVX2(void *arg)
 {
     if (SDL_HasAVX2()) {
         SDLTest_AssertCheck(SDL_TRUE, "CPU of test machine has AVX2 support.");
@@ -593,7 +593,7 @@ static int intrinsics_testAVX2(void *arg)
     return TEST_SKIPPED;
 }
 
-static int intrinsics_testAVX512F(void *arg)
+static int SDLCALL intrinsics_testAVX512F(void *arg)
 {
     if (SDL_HasAVX512F()) {
         SDLTest_AssertCheck(SDL_TRUE, "CPU of test machine has AVX512F support.");

--- a/test/testautomation_iostream.c
+++ b/test/testautomation_iostream.c
@@ -32,7 +32,7 @@ static const char IOStreamAlphabetString[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 /* Fixture */
 
-static void IOStreamSetUp(void **arg)
+static void SDLCALL IOStreamSetUp(void **arg)
 {
     size_t fileLen;
     FILE *handle;
@@ -75,7 +75,7 @@ static void IOStreamSetUp(void **arg)
     SDLTest_AssertPass("Creation of test file completed");
 }
 
-static void IOStreamTearDown(void *arg)
+static void SDLCALL IOStreamTearDown(void *arg)
 {
     int result;
 
@@ -204,7 +204,7 @@ static void testGenericIOStreamValidations(SDL_IOStream *rw, SDL_bool write)
  * \sa SDL_IOFromFile
  *
  */
-static int iostrm_testParamNegative(void *arg)
+static int SDLCALL iostrm_testParamNegative(void *arg)
 {
     SDL_IOStream *iostrm;
 
@@ -250,7 +250,7 @@ static int iostrm_testParamNegative(void *arg)
  * \sa SDL_IOFromMem
  * \sa SDL_CloseIO
  */
-static int iostrm_testMem(void *arg)
+static int SDLCALL iostrm_testMem(void *arg)
 {
     char mem[sizeof(IOStreamHelloWorldTestString)];
     SDL_IOStream *rw;
@@ -286,7 +286,7 @@ static int iostrm_testMem(void *arg)
  * \sa SDL_IOFromConstMem
  * \sa SDL_CloseIO
  */
-static int iostrm_testConstMem(void *arg)
+static int SDLCALL iostrm_testConstMem(void *arg)
 {
     SDL_IOStream *rw;
     int result;
@@ -318,7 +318,7 @@ static int iostrm_testConstMem(void *arg)
  * \sa SDL_IOFromDynamicMem
  * \sa SDL_CloseIO
  */
-static int iostrm_testDynamicMem(void *arg)
+static int SDLCALL iostrm_testDynamicMem(void *arg)
 {
     SDL_IOStream *rw;
     SDL_PropertiesID props;
@@ -367,7 +367,7 @@ static int iostrm_testDynamicMem(void *arg)
  * \sa SDL_IOFromFile
  * \sa SDL_CloseIO
  */
-static int iostrm_testFileRead(void *arg)
+static int SDLCALL iostrm_testFileRead(void *arg)
 {
     SDL_IOStream *rw;
     int result;
@@ -399,7 +399,7 @@ static int iostrm_testFileRead(void *arg)
  * \sa SDL_IOFromFile
  * \sa SDL_CloseIO
  */
-static int iostrm_testFileWrite(void *arg)
+static int SDLCALL iostrm_testFileWrite(void *arg)
 {
     SDL_IOStream *rw;
     int result;
@@ -431,7 +431,7 @@ static int iostrm_testFileWrite(void *arg)
  * \sa SDL_OpenIO
  * \sa SDL_CloseIO
  */
-static int iostrm_testAllocFree(void *arg)
+static int SDLCALL iostrm_testAllocFree(void *arg)
 {
     /* Allocate context */
     SDL_IOStreamInterface iface;
@@ -458,7 +458,7 @@ static int iostrm_testAllocFree(void *arg)
  * \sa SDL_IOFromMem
  * \sa SDL_IOFromFile
  */
-static int iostrm_testCompareRWFromMemWithRWFromFile(void *arg)
+static int SDLCALL iostrm_testCompareRWFromMemWithRWFromFile(void *arg)
 {
     int slen = 26;
     char buffer_file[27];
@@ -523,7 +523,7 @@ static int iostrm_testCompareRWFromMemWithRWFromFile(void *arg)
  * \sa SDL_ReadU16BE
  * \sa SDL_WriteU16BE
  */
-static int iostrm_testFileWriteReadEndian(void *arg)
+static int SDLCALL iostrm_testFileWriteReadEndian(void *arg)
 {
     SDL_IOStream *rw;
     Sint64 result;

--- a/test/testautomation_joystick.c
+++ b/test/testautomation_joystick.c
@@ -16,7 +16,7 @@
  *
  * \sa SDL_AttachVirtualJoystick
  */
-static int TestVirtualJoystick(void *arg)
+static int SDLCALL TestVirtualJoystick(void *arg)
 {
     SDL_VirtualJoystickDesc desc;
     SDL_Joystick *joystick = NULL;

--- a/test/testautomation_keyboard.c
+++ b/test/testautomation_keyboard.c
@@ -15,7 +15,7 @@
  *
  * \sa SDL_GetKeyboardState
  */
-static int keyboard_getKeyboardState(void *arg)
+static int SDLCALL keyboard_getKeyboardState(void *arg)
 {
     int numkeys;
     const Uint8 *state;
@@ -40,7 +40,7 @@ static int keyboard_getKeyboardState(void *arg)
  *
  * \sa SDL_GetKeyboardFocus
  */
-static int keyboard_getKeyboardFocus(void *arg)
+static int SDLCALL keyboard_getKeyboardFocus(void *arg)
 {
     /* Call, but ignore return value */
     SDL_GetKeyboardFocus();
@@ -54,7 +54,7 @@ static int keyboard_getKeyboardFocus(void *arg)
  *
  * \sa SDL_GetKeyFromName
  */
-static int keyboard_getKeyFromName(void *arg)
+static int SDLCALL keyboard_getKeyFromName(void *arg)
 {
     SDL_Keycode result;
 
@@ -119,7 +119,7 @@ static void checkInvalidScancodeError(void)
  *
  * \sa SDL_GetKeyFromScancode
  */
-static int keyboard_getKeyFromScancode(void *arg)
+static int SDLCALL keyboard_getKeyFromScancode(void *arg)
 {
     SDL_Keycode result;
 
@@ -157,7 +157,7 @@ static int keyboard_getKeyFromScancode(void *arg)
  *
  * \sa SDL_GetKeyName
  */
-static int keyboard_getKeyName(void *arg)
+static int SDLCALL keyboard_getKeyName(void *arg)
 {
     const char *result;
     const char *expected;
@@ -212,7 +212,7 @@ static int keyboard_getKeyName(void *arg)
  *
  * \sa SDL_GetScancodeName
  */
-static int keyboard_getScancodeNameNegative(void *arg)
+static int SDLCALL keyboard_getScancodeNameNegative(void *arg)
 {
     SDL_Scancode scancode;
     const char *result;
@@ -238,7 +238,7 @@ static int keyboard_getScancodeNameNegative(void *arg)
  *
  * \sa SDL_GetKeyName
  */
-static int keyboard_getKeyNameNegative(void *arg)
+static int SDLCALL keyboard_getKeyNameNegative(void *arg)
 {
     SDL_Keycode keycode;
     const char *result;
@@ -275,7 +275,7 @@ static int keyboard_getKeyNameNegative(void *arg)
  * \sa SDL_GetModState
  * \sa SDL_SetModState
  */
-static int keyboard_getSetModState(void *arg)
+static int SDLCALL keyboard_getSetModState(void *arg)
 {
     SDL_Keymod result;
     SDL_Keymod currentState;
@@ -334,7 +334,7 @@ static int keyboard_getSetModState(void *arg)
  * \sa SDL_StartTextInput
  * \sa SDL_StopTextInput
  */
-static int keyboard_startStopTextInput(void *arg)
+static int SDLCALL keyboard_startStopTextInput(void *arg)
 {
     SDL_Window *window = SDL_GetKeyboardFocus();
 
@@ -381,7 +381,7 @@ static void testSetTextInputArea(SDL_Window *window, SDL_Rect refRect)
  *
  * \sa SDL_SetTextInputArea
  */
-static int keyboard_setTextInputArea(void *arg)
+static int SDLCALL keyboard_setTextInputArea(void *arg)
 {
     SDL_Window *window = SDL_GetKeyboardFocus();
     SDL_Rect refRect;
@@ -461,7 +461,7 @@ static int keyboard_setTextInputArea(void *arg)
  *
  * \sa SDL_SetTextInputArea
  */
-static int keyboard_setTextInputAreaNegative(void *arg)
+static int SDLCALL keyboard_setTextInputAreaNegative(void *arg)
 {
     /* Some platforms set also an error message; prepare for checking it */
 #if defined(SDL_VIDEO_DRIVER_WINDOWS) || defined(SDL_VIDEO_DRIVER_ANDROID) || defined(SDL_VIDEO_DRIVER_COCOA)
@@ -499,7 +499,7 @@ static int keyboard_setTextInputAreaNegative(void *arg)
  * \sa SDL_GetScancodeFromName
  * \sa SDL_Keycode
  */
-static int keyboard_getScancodeFromName(void *arg)
+static int SDLCALL keyboard_getScancodeFromName(void *arg)
 {
     SDL_Scancode scancode;
 
@@ -570,7 +570,7 @@ static void checkInvalidNameError(void)
  * \sa SDL_GetScancodeFromName
  * \sa SDL_Keycode
  */
-static int keyboard_getScancodeFromNameNegative(void *arg)
+static int SDLCALL keyboard_getScancodeFromNameNegative(void *arg)
 {
     char *name;
     SDL_Scancode scancode;

--- a/test/testautomation_log.c
+++ b/test/testautomation_log.c
@@ -33,7 +33,7 @@ static void DisableTestLog(void)
 /**
  * Check SDL_HINT_LOGGING functionality
  */
-static int log_testHint(void *arg)
+static int SDLCALL log_testHint(void *arg)
 {
     int count;
 

--- a/test/testautomation_main.c
+++ b/test/testautomation_main.c
@@ -16,7 +16,7 @@
  * \sa SDL_Init
  * \sa SDL_Quit
  */
-static int main_testInitQuitSubSystem(void *arg)
+static int SDLCALL main_testInitQuitSubSystem(void *arg)
 {
     int i;
     int subsystems[] = { SDL_INIT_JOYSTICK, SDL_INIT_HAPTIC, SDL_INIT_GAMEPAD };
@@ -40,7 +40,7 @@ static int main_testInitQuitSubSystem(void *arg)
 }
 
 static const int joy_and_controller = SDL_INIT_JOYSTICK | SDL_INIT_GAMEPAD;
-static int main_testImpliedJoystickInit(void *arg)
+static int SDLCALL main_testImpliedJoystickInit(void *arg)
 {
     int initialized_system;
 
@@ -61,7 +61,7 @@ static int main_testImpliedJoystickInit(void *arg)
     return TEST_COMPLETED;
 }
 
-static int main_testImpliedJoystickQuit(void *arg)
+static int SDLCALL main_testImpliedJoystickQuit(void *arg)
 {
     int initialized_system;
 
@@ -90,7 +90,7 @@ static int main_testImpliedJoystickQuit(void *arg)
 #pragma GCC diagnostic ignored "-Wformat-zero-length"
 #endif
 
-static int
+static int SDLCALL
 main_testSetError(void *arg)
 {
     size_t i;

--- a/test/testautomation_math.c
+++ b/test/testautomation_math.c
@@ -232,7 +232,7 @@ helper_range(const char *func_name, d_to_d_func func)
  * Inputs: +/-Infinity.
  * Expected: Infinity is returned as-is.
  */
-static int
+static int SDLCALL
 floor_infCases(void *args)
 {
     double result;
@@ -254,7 +254,7 @@ floor_infCases(void *args)
  * Inputs: +/-0.0.
  * Expected: Zero is returned as-is.
  */
-static int
+static int SDLCALL
 floor_zeroCases(void *args)
 {
     const d_to_d zero_cases[] = {
@@ -268,7 +268,7 @@ floor_zeroCases(void *args)
  * Input: NAN.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 floor_nanCase(void *args)
 {
     const double result = SDL_floor(NAN);
@@ -282,7 +282,7 @@ floor_nanCase(void *args)
  * Inputs: integral values.
  * Expected: the input value is returned as-is.
  */
-static int
+static int SDLCALL
 floor_roundNumbersCases(void *args)
 {
     const d_to_d round_cases[] = {
@@ -302,7 +302,7 @@ floor_roundNumbersCases(void *args)
  * Inputs: fractional values.
  * Expected: the lower integral value is returned.
  */
-static int
+static int SDLCALL
 floor_fractionCases(void *args)
 {
     const d_to_d frac_cases[] = {
@@ -324,7 +324,7 @@ floor_fractionCases(void *args)
  * Inputs: values in the range [0, UINT32_MAX].
  * Expected: the input value is returned as-is.
  */
-static int
+static int SDLCALL
 floor_rangeTest(void *args)
 {
     return helper_range("Floor", SDL_floor);
@@ -336,7 +336,7 @@ floor_rangeTest(void *args)
  * Inputs: +/-Infinity.
  * Expected: Infinity is returned as-is.
  */
-static int
+static int SDLCALL
 ceil_infCases(void *args)
 {
     double result;
@@ -358,7 +358,7 @@ ceil_infCases(void *args)
  * Inputs: +/-0.0.
  * Expected: Zero is returned as-is.
  */
-static int
+static int SDLCALL
 ceil_zeroCases(void *args)
 {
     const d_to_d zero_cases[] = {
@@ -372,7 +372,7 @@ ceil_zeroCases(void *args)
  * Input: NAN.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 ceil_nanCase(void *args)
 {
     const double result = SDL_ceil(NAN);
@@ -386,7 +386,7 @@ ceil_nanCase(void *args)
  * Inputs: integral values.
  * Expected: the input value is returned as-is.
  */
-static int
+static int SDLCALL
 ceil_roundNumbersCases(void *args)
 {
     const d_to_d round_cases[] = {
@@ -406,7 +406,7 @@ ceil_roundNumbersCases(void *args)
  * Inputs: fractional values.
  * Expected: the higher integral value is returned.
  */
-static int
+static int SDLCALL
 ceil_fractionCases(void *args)
 {
     const d_to_d frac_cases[] = {
@@ -428,7 +428,7 @@ ceil_fractionCases(void *args)
  * Inputs: values in the range [0, UINT32_MAX].
  * Expected: the input value is returned as-is.
  */
-static int
+static int SDLCALL
 ceil_rangeTest(void *args)
 {
     return helper_range("Ceil", SDL_ceil);
@@ -440,7 +440,7 @@ ceil_rangeTest(void *args)
  * Inputs: +/-Infinity.
  * Expected: Infinity is returned as-is.
  */
-static int
+static int SDLCALL
 trunc_infCases(void *args)
 {
     double result;
@@ -462,7 +462,7 @@ trunc_infCases(void *args)
  * Inputs: +/-0.0.
  * Expected: Zero is returned as-is.
  */
-static int
+static int SDLCALL
 trunc_zeroCases(void *args)
 {
     const d_to_d zero_cases[] = {
@@ -476,7 +476,7 @@ trunc_zeroCases(void *args)
  * Input: NAN.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 trunc_nanCase(void *args)
 {
     const double result = SDL_trunc(NAN);
@@ -490,7 +490,7 @@ trunc_nanCase(void *args)
  * Inputs: integral values.
  * Expected: the input value is returned as-is.
  */
-static int
+static int SDLCALL
 trunc_roundNumbersCases(void *args)
 {
     const d_to_d round_cases[] = {
@@ -510,7 +510,7 @@ trunc_roundNumbersCases(void *args)
  * Inputs: fractional values.
  * Expected: the integral part is returned.
  */
-static int
+static int SDLCALL
 trunc_fractionCases(void *args)
 {
     const d_to_d frac_cases[] = {
@@ -532,7 +532,7 @@ trunc_fractionCases(void *args)
  * Inputs: values in the range [0, UINT32_MAX].
  * Expected: the input value is returned as-is.
  */
-static int
+static int SDLCALL
 trunc_rangeTest(void *args)
 {
     return helper_range("Trunc", SDL_trunc);
@@ -544,7 +544,7 @@ trunc_rangeTest(void *args)
  * Inputs: +/-Infinity.
  * Expected: Infinity is returned as-is.
  */
-static int
+static int SDLCALL
 round_infCases(void *args)
 {
     double result;
@@ -566,7 +566,7 @@ round_infCases(void *args)
  * Inputs: +/-0.0.
  * Expected: Zero is returned as-is.
  */
-static int
+static int SDLCALL
 round_zeroCases(void *args)
 {
     const d_to_d zero_cases[] = {
@@ -580,7 +580,7 @@ round_zeroCases(void *args)
  * Input: NAN.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 round_nanCase(void *args)
 {
     const double result = SDL_round(NAN);
@@ -594,7 +594,7 @@ round_nanCase(void *args)
  * Inputs: integral values.
  * Expected: the input value is returned as-is.
  */
-static int
+static int SDLCALL
 round_roundNumbersCases(void *args)
 {
     const d_to_d round_cases[] = {
@@ -614,7 +614,7 @@ round_roundNumbersCases(void *args)
  * Inputs: fractional values.
  * Expected: the nearest integral value is returned.
  */
-static int
+static int SDLCALL
 round_fractionCases(void *args)
 {
     const d_to_d frac_cases[] = {
@@ -636,7 +636,7 @@ round_fractionCases(void *args)
  * Inputs: values in the range [0, UINT32_MAX].
  * Expected: the input value is returned as-is.
  */
-static int
+static int SDLCALL
 round_rangeTest(void *args)
 {
     return helper_range("Round", SDL_round);
@@ -648,7 +648,7 @@ round_rangeTest(void *args)
  * Inputs: +/-Infinity.
  * Expected: Positive Infinity is returned.
  */
-static int
+static int SDLCALL
 fabs_infCases(void *args)
 {
     double result;
@@ -670,7 +670,7 @@ fabs_infCases(void *args)
  * Inputs: +/-0.0.
  * Expected: Positive zero is returned.
  */
-static int
+static int SDLCALL
 fabs_zeroCases(void *args)
 {
     const d_to_d zero_cases[] = {
@@ -684,7 +684,7 @@ fabs_zeroCases(void *args)
  * Input: NAN.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 fabs_nanCase(void *args)
 {
     const double result = SDL_fabs(NAN);
@@ -698,7 +698,7 @@ fabs_nanCase(void *args)
  * Inputs: values in the range [0, UINT32_MAX].
  * Expected: the input value is returned as-is.
  */
-static int
+static int SDLCALL
 fabs_rangeTest(void *args)
 {
     return helper_range("Fabs", SDL_fabs);
@@ -710,7 +710,7 @@ fabs_rangeTest(void *args)
  * Inputs: (+/-Infinity, +/-1.0).
  * Expected: Infinity with the sign of 1.0 is returned.
  */
-static int
+static int SDLCALL
 copysign_infCases(void *args)
 {
     double result;
@@ -742,7 +742,7 @@ copysign_infCases(void *args)
  * Inputs: (+/-0.0, +/-1.0).
  * Expected: 0.0 with the sign of 1.0 is returned.
  */
-static int
+static int SDLCALL
 copysign_zeroCases(void *args)
 {
     const dd_to_d zero_cases[] = {
@@ -759,7 +759,7 @@ copysign_zeroCases(void *args)
  * Expected: NAN with the sign of 1.0 is returned.
  * NOTE: On some platforms signed NAN is not supported, so we only check if the result is still NAN.
  */
-static int
+static int SDLCALL
 copysign_nanCases(void *args)
 {
     double result;
@@ -780,7 +780,7 @@ copysign_nanCases(void *args)
  * Inputs: values in the range [0, UINT32_MAX], +/-1.0.
  * Expected: the input value with the sign of 1.0 is returned.
  */
-static int
+static int SDLCALL
 copysign_rangeTest(void *args)
 {
     Uint32 i;
@@ -823,7 +823,7 @@ copysign_rangeTest(void *args)
  * Inputs: (+/-Infinity, +/-1.0).
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 fmod_divOfInfCases(void *args)
 {
     double result;
@@ -855,7 +855,7 @@ fmod_divOfInfCases(void *args)
  * Inputs: (+/-1.0, +/-Infinity).
  * Expected: 1.0 is returned as-is.
  */
-static int
+static int SDLCALL
 fmod_divByInfCases(void *args)
 {
     double result;
@@ -887,7 +887,7 @@ fmod_divByInfCases(void *args)
  * Inputs: (+/-0.0, +/-1.0).
  * Expected: Zero is returned as-is.
  */
-static int
+static int SDLCALL
 fmod_divOfZeroCases(void *args)
 {
     const dd_to_d zero_cases[] = {
@@ -903,7 +903,7 @@ fmod_divOfZeroCases(void *args)
  * Inputs: (+/-1.0, +/-0.0).
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 fmod_divByZeroCases(void *args)
 {
     double result;
@@ -935,7 +935,7 @@ fmod_divByZeroCases(void *args)
  * Inputs: all permutation of NAN and +/-1.0.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 fmod_nanCases(void *args)
 {
     double result;
@@ -967,7 +967,7 @@ fmod_nanCases(void *args)
  * Inputs: values within the domain of the function.
  * Expected: the correct result is returned.
  */
-static int
+static int SDLCALL
 fmod_regularCases(void *args)
 {
     const dd_to_d regular_cases[] = {
@@ -983,7 +983,7 @@ fmod_regularCases(void *args)
  * Inputs: values in the range [0, UINT32_MAX] divided by 1.0.
  * Expected: Positive zero is always returned.
  */
-static int
+static int SDLCALL
 fmod_rangeTest(void *args)
 {
     Uint32 i;
@@ -1018,7 +1018,7 @@ fmod_rangeTest(void *args)
  * Inputs: +/-Infinity.
  * Expected: Infinity is returned as-is.
  */
-static int
+static int SDLCALL
 exp_infCases(void *args)
 {
     double result;
@@ -1040,7 +1040,7 @@ exp_infCases(void *args)
  * Inputs: +/-0.0.
  * Expected: 1.0 is returned.
  */
-static int
+static int SDLCALL
 exp_zeroCases(void *args)
 {
     const d_to_d zero_cases[] = {
@@ -1055,7 +1055,7 @@ exp_zeroCases(void *args)
  * Expected: Infinity is returned.
  * NOTE: This test is skipped for double types larger than 64 bits.
  */
-static int
+static int SDLCALL
 exp_overflowCase(void *args)
 {
     double result;
@@ -1075,7 +1075,7 @@ exp_overflowCase(void *args)
  * Input: 1.0
  * Expected: The euler constant.
  */
-static int
+static int SDLCALL
 exp_baseCase(void *args)
 {
     const double result = SDL_exp(1.0);
@@ -1090,7 +1090,7 @@ exp_baseCase(void *args)
  * Inputs: values within the domain of the function.
  * Expected: the correct result is returned.
  */
-static int
+static int SDLCALL
 exp_regularCases(void *args)
 {
     /* Hexadecimal floating constants are not supported on C89 compilers */
@@ -1114,7 +1114,7 @@ exp_regularCases(void *args)
  * Inputs: Positive Infinity and +/-0.0.
  * Expected: Positive and negative Infinity respectively.
  */
-static int
+static int SDLCALL
 log_limitCases(void *args)
 {
     double result;
@@ -1141,7 +1141,7 @@ log_limitCases(void *args)
  * Inputs: 1.0 and the Euler constant.
  * Expected: 0.0 and 1.0 respectively.
  */
-static int
+static int SDLCALL
 log_baseCases(void *args)
 {
     double result;
@@ -1163,7 +1163,7 @@ log_baseCases(void *args)
  * Inputs: NAN and a negative value.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 log_nanCases(void *args)
 {
     double result;
@@ -1185,7 +1185,7 @@ log_nanCases(void *args)
  * Inputs: values within the domain of the function.
  * Expected: the correct result is returned.
  */
-static int
+static int SDLCALL
 log_regularCases(void *args)
 {
     const d_to_d regular_cases[] = {
@@ -1204,7 +1204,7 @@ log_regularCases(void *args)
  * Inputs: Positive Infinity and +/-0.0.
  * Expected: Positive and negative Infinity respectively.
  */
-static int
+static int SDLCALL
 log10_limitCases(void *args)
 {
     double result;
@@ -1231,7 +1231,7 @@ log10_limitCases(void *args)
  * Inputs: Powers of ten from 0 to 9.
  * Expected: the exact power of ten is returned.
  */
-static int
+static int SDLCALL
 log10_baseCases(void *args)
 {
     const d_to_d base_cases[] = {
@@ -1253,7 +1253,7 @@ log10_baseCases(void *args)
  * Inputs: NAN and a negative value.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 log10_nanCases(void *args)
 {
     double result;
@@ -1275,7 +1275,7 @@ log10_nanCases(void *args)
  * Inputs: values within the domain of the function.
  * Expected: the correct result is returned.
  */
-static int
+static int SDLCALL
 log10_regularCases(void *args)
 {
     const d_to_d regular_cases[] = {
@@ -1290,7 +1290,7 @@ log10_regularCases(void *args)
 
 /* SDL_modf tests functions */
 
-static int
+static int SDLCALL
 modf_baseCases(void *args)
 {
     double fractional, integral;
@@ -1314,7 +1314,7 @@ modf_baseCases(void *args)
  * Inputs: (-1.0, +/-Infinity).
  * Expected: 1.0 is returned.
  */
-static int
+static int SDLCALL
 pow_baseNOneExpInfCases(void *args)
 {
     double result;
@@ -1335,7 +1335,7 @@ pow_baseNOneExpInfCases(void *args)
  * Inputs: (+/-0.0, -Infinity).
  * Expected: Infinity is returned.
  */
-static int
+static int SDLCALL
 pow_baseZeroExpNInfCases(void *args)
 {
     double result;
@@ -1357,7 +1357,7 @@ pow_baseZeroExpNInfCases(void *args)
  * Inputs: (x, +/-Infinity) where x is not +/-0.0.
  * Expected: 0.0 when x < 1, Infinity when x > 1.
  */
-static int
+static int SDLCALL
 pow_expInfCases(void *args)
 {
     double result;
@@ -1391,7 +1391,7 @@ pow_expInfCases(void *args)
  * Inputs: (Positive Infinity, x) where x is not +/-0.0.
  * Expected: 0.0 when x is < 0, positive Infinity when x > 0.
  */
-static int
+static int SDLCALL
 pow_basePInfCases(void *args)
 {
     double result;
@@ -1427,7 +1427,7 @@ pow_basePInfCases(void *args)
  * - Negative Infinity when x is a positive odd integer,
  * - Positive Infinity when x is a positive even integer or positive non-integer.
  */
-static int
+static int SDLCALL
 pow_baseNInfCases(void *args)
 {
     double result;
@@ -1473,7 +1473,7 @@ pow_baseNInfCases(void *args)
  * - finite and non-integer exponent.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 pow_badOperationCase(void *args)
 {
     const double result = SDL_pow(-2.0, 4.2);
@@ -1487,7 +1487,7 @@ pow_badOperationCase(void *args)
  * Inputs: (1.0, NAN)
  * Expected: 1.0 is returned.
  */
-static int
+static int SDLCALL
 pow_base1ExpNanCase(void *args)
 {
     const double result = SDL_pow(1.0, NAN);
@@ -1501,7 +1501,7 @@ pow_base1ExpNanCase(void *args)
  * Inputs: (NAN, +/-0.0)
  * Expected: 1.0 is returned.
  */
-static int
+static int SDLCALL
 pow_baseNanExp0Cases(void *args)
 {
     double result;
@@ -1523,7 +1523,7 @@ pow_baseNanExp0Cases(void *args)
  * Inputs: NAN as base, exponent or both.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 pow_nanArgsCases(void *args)
 {
     double result;
@@ -1554,7 +1554,7 @@ pow_nanArgsCases(void *args)
  * - Negative Infinity with a negative exponent,
  * - -0.0 with a positive exponent.
  */
-static int
+static int SDLCALL
 pow_baseNZeroExpOddCases(void *args)
 {
     double result;
@@ -1578,7 +1578,7 @@ pow_baseNZeroExpOddCases(void *args)
  * - 0.0 with a positive exponent,
  * - Positive Infinity with a negative exponent.
  */
-static int
+static int SDLCALL
 pow_basePZeroExpOddCases(void *args)
 {
     double result;
@@ -1604,7 +1604,7 @@ pow_basePZeroExpOddCases(void *args)
  * - Positive Infinity if the exponent is negative,
  * - 0.0 if the exponent is positive.
  */
-static int
+static int SDLCALL
 pow_baseNZeroCases(void *args)
 {
     double result;
@@ -1640,7 +1640,7 @@ pow_baseNZeroCases(void *args)
  * - Positive Infinity if the exponent is negative,
  * - 0.0 if the exponent is positive.
  */
-static int
+static int SDLCALL
 pow_basePZeroCases(void *args)
 {
     double result;
@@ -1674,7 +1674,7 @@ pow_basePZeroCases(void *args)
  * Inputs: values within the domain of the function.
  * Expected: the correct result is returned.
  */
-static int
+static int SDLCALL
 pow_regularCases(void *args)
 {
     const dd_to_d regular_cases[] = {
@@ -1694,7 +1694,7 @@ pow_regularCases(void *args)
  * Inputs: (2.0, x), with x in range [0, 8].
  * Expected: the correct result is returned.
  */
-static int
+static int SDLCALL
 pow_powerOfTwo(void *args)
 {
     const dd_to_d power_of_two_cases[] = {
@@ -1714,7 +1714,7 @@ pow_powerOfTwo(void *args)
  * Inputs: values in the range [0, UINT32_MAX] to the power of +/-0.0.
  * Expected: 1.0 is always returned.
  */
-static int
+static int SDLCALL
 pow_rangeTest(void *args)
 {
     Uint32 i;
@@ -1757,7 +1757,7 @@ pow_rangeTest(void *args)
  * Input: Positive Infinity.
  * Expected: Positive Infinity is returned.
  */
-static int
+static int SDLCALL
 sqrt_infCase(void *args)
 {
     const double result = SDL_sqrt(INFINITY);
@@ -1771,7 +1771,7 @@ sqrt_infCase(void *args)
  * Input: NAN.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 sqrt_nanCase(void *args)
 {
     const double result = SDL_sqrt(NAN);
@@ -1785,7 +1785,7 @@ sqrt_nanCase(void *args)
  * Inputs: values outside the domain of the function.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 sqrt_outOfDomainCases(void *args)
 {
     double result;
@@ -1812,7 +1812,7 @@ sqrt_outOfDomainCases(void *args)
  * Inputs: +/-0.0 and 1.0.
  * Expected: the input value is returned as-is.
  */
-static int
+static int SDLCALL
 sqrt_baseCases(void *args)
 {
     const d_to_d base_cases[] = {
@@ -1827,7 +1827,7 @@ sqrt_baseCases(void *args)
  * Inputs: values within the domain of the function.
  * Expected: the correct result is returned.
  */
-static int
+static int SDLCALL
 sqrt_regularCases(void *args)
 {
     const d_to_d regular_cases[] = {
@@ -1848,7 +1848,7 @@ sqrt_regularCases(void *args)
  * Input: (+/-Infinity, 1).
  * Expected: Infinity is returned as-is.
  */
-static int
+static int SDLCALL
 scalbn_infCases(void *args)
 {
     double result;
@@ -1870,7 +1870,7 @@ scalbn_infCases(void *args)
  * Inputs: (+/-0.0, 1).
  * Expected: Zero is returned as-is.
  */
-static int
+static int SDLCALL
 scalbn_baseZeroCases(void *args)
 {
     double result;
@@ -1892,7 +1892,7 @@ scalbn_baseZeroCases(void *args)
  * Input: (x, 0)
  * Expected: x is returned as-is.
  */
-static int
+static int SDLCALL
 scalbn_expZeroCase(void *args)
 {
     const double result = SDL_scalbn(42.0, 0);
@@ -1906,7 +1906,7 @@ scalbn_expZeroCase(void *args)
  * Input: (NAN, x).
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 scalbn_nanCase(void *args)
 {
     const double result = SDL_scalbn(NAN, 2);
@@ -1921,7 +1921,7 @@ scalbn_nanCase(void *args)
  * Expected: the correct result is returned.
  * NOTE: This test depends on SDL_pow and FLT_RADIX.
  */
-static int
+static int SDLCALL
 scalbn_regularCases(void *args)
 {
     double result, expected;
@@ -1959,7 +1959,7 @@ scalbn_regularCases(void *args)
  * Inputs: +/-Infinity.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 cos_infCases(void *args)
 {
     double result;
@@ -1981,7 +1981,7 @@ cos_infCases(void *args)
  * Input: NAN.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 cos_nanCase(void *args)
 {
     const double result = SDL_cos(NAN);
@@ -1995,7 +1995,7 @@ cos_nanCase(void *args)
  * Inputs: +/-0.0 and +/-Pi.
  * Expected: +1.0 and -1.0 respectively.
  */
-static int
+static int SDLCALL
 cos_regularCases(void *args)
 {
     const d_to_d regular_cases[] = {
@@ -2011,7 +2011,7 @@ cos_regularCases(void *args)
  * Inputs: Angles between 1/10 and 9/10 of Pi (positive and negative).
  * Expected: The correct result is returned (+/-EPSILON).
  */
-static int
+static int SDLCALL
 cos_precisionTest(void *args)
 {
     const d_to_d precision_cases[] = {
@@ -2041,7 +2041,7 @@ cos_precisionTest(void *args)
  * Inputs: Values in the range [0, UINT32_MAX].
  * Expected: A value between 0 and 1 is returned.
  */
-static int
+static int SDLCALL
 cos_rangeTest(void *args)
 {
     Uint32 i;
@@ -2076,7 +2076,7 @@ cos_rangeTest(void *args)
  * Inputs: +/-Infinity.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 sin_infCases(void *args)
 {
     double result;
@@ -2098,7 +2098,7 @@ sin_infCases(void *args)
  * Input: NAN.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 sin_nanCase(void *args)
 {
     const double result = SDL_sin(NAN);
@@ -2112,7 +2112,7 @@ sin_nanCase(void *args)
  * Inputs: +/-0.0 and +/-Pi/2.
  * Expected: +/-0.0 and +/-1.0 respectively.
  */
-static int
+static int SDLCALL
 sin_regularCases(void *args)
 {
     const d_to_d regular_cases[] = {
@@ -2129,7 +2129,7 @@ sin_regularCases(void *args)
  * Expected: The correct result is returned (+/-EPSILON).
  * NOTE: +/-Pi/2 is tested in the regular cases.
  */
-static int
+static int SDLCALL
 sin_precisionTest(void *args)
 {
     const d_to_d precision_cases[] = {
@@ -2159,7 +2159,7 @@ sin_precisionTest(void *args)
  * Inputs: Values in the range [0, UINT32_MAX].
  * Expected: A value between 0 and 1 is returned.
  */
-static int
+static int SDLCALL
 sin_rangeTest(void *args)
 {
     Uint32 i;
@@ -2194,7 +2194,7 @@ sin_rangeTest(void *args)
  * Inputs: +/-Infinity.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 tan_infCases(void *args)
 {
     double result;
@@ -2216,7 +2216,7 @@ tan_infCases(void *args)
  * Input: NAN.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 tan_nanCase(void *args)
 {
     const double result = SDL_tan(NAN);
@@ -2230,7 +2230,7 @@ tan_nanCase(void *args)
  * Inputs: +/-0.0.
  * Expected: Zero is returned as-is.
  */
-static int
+static int SDLCALL
 tan_zeroCases(void *args)
 {
     const d_to_d regular_cases[] = {
@@ -2245,7 +2245,7 @@ tan_zeroCases(void *args)
  * Expected: The correct result is returned (+/-EPSILON).
  * NOTE: +/-Pi/2 is intentionally avoided as it returns garbage values.
  */
-static int
+static int SDLCALL
 tan_precisionTest(void *args)
 {
     const d_to_d precision_cases[] = {
@@ -2279,7 +2279,7 @@ tan_precisionTest(void *args)
  * Inputs: +/-1.0.
  * Expected: 0.0 and Pi respectively.
  */
-static int
+static int SDLCALL
 acos_limitCases(void *args)
 {
     double result;
@@ -2301,7 +2301,7 @@ acos_limitCases(void *args)
  * Inputs: Values outside the domain of [-1, 1].
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 acos_outOfDomainCases(void *args)
 {
     double result;
@@ -2323,7 +2323,7 @@ acos_outOfDomainCases(void *args)
  * Input: NAN.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 acos_nanCase(void *args)
 {
     const double result = SDL_acos(NAN);
@@ -2337,7 +2337,7 @@ acos_nanCase(void *args)
  * Inputs: Values between -0.9 and 0.9 with steps of 0.1.
  * Expected: The correct result is returned (+/-EPSILON).
  */
-static int
+static int SDLCALL
 acos_precisionTest(void *args)
 {
     const d_to_d precision_cases[] = {
@@ -2371,7 +2371,7 @@ acos_precisionTest(void *args)
  * Inputs: +/-1.0.
  * Expected: +/-Pi/2 is returned.
  */
-static int
+static int SDLCALL
 asin_limitCases(void *args)
 {
     double result;
@@ -2393,7 +2393,7 @@ asin_limitCases(void *args)
  * Inputs: Values outside the domain of [-1, 1].
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 asin_outOfDomainCases(void *args)
 {
     double result;
@@ -2415,7 +2415,7 @@ asin_outOfDomainCases(void *args)
  * Input: NAN.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 asin_nanCase(void *args)
 {
     const double result = SDL_asin(NAN);
@@ -2429,7 +2429,7 @@ asin_nanCase(void *args)
  * Inputs: Values between -0.9 and 0.9 with steps of 0.1.
  * Expected: The correct result is returned (+/-EPSILON).
  */
-static int
+static int SDLCALL
 asin_precisionTest(void *args)
 {
     const d_to_d precision_cases[] = {
@@ -2463,7 +2463,7 @@ asin_precisionTest(void *args)
  * Inputs: +/-Infinity.
  * Expected: +/-Pi/2 is returned.
  */
-static int
+static int SDLCALL
 atan_limitCases(void *args)
 {
     double result;
@@ -2487,7 +2487,7 @@ atan_limitCases(void *args)
  * Inputs: +/-0.0.
  * Expected: Zero is returned as-is.
  */
-static int
+static int SDLCALL
 atan_zeroCases(void *args)
 {
     double result;
@@ -2509,7 +2509,7 @@ atan_zeroCases(void *args)
  * Input: NAN.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 atan_nanCase(void *args)
 {
     const double result = SDL_atan(NAN);
@@ -2523,7 +2523,7 @@ atan_nanCase(void *args)
  * Inputs: Values corresponding to angles between 9Pi/20 and -9Pi/20 with steps of Pi/20.
  * Expected: The correct result is returned (+/-EPSILON).
  */
-static int
+static int SDLCALL
 atan_precisionTest(void *args)
 {
     const d_to_d precision_cases[] = {
@@ -2560,7 +2560,7 @@ atan_precisionTest(void *args)
  * - Pi if the second argument is negative zero.
  * - The sign is inherited from the first argument.
  */
-static int
+static int SDLCALL
 atan2_bothZeroCases(void *args)
 {
     const dd_to_d cases[] = {
@@ -2579,7 +2579,7 @@ atan2_bothZeroCases(void *args)
  * - Pi if the second argument is negative.
  * - The sign is inherited from the first argument.
  */
-static int
+static int SDLCALL
 atan2_yZeroCases(void *args)
 {
     const dd_to_d cases[] = {
@@ -2595,7 +2595,7 @@ atan2_yZeroCases(void *args)
  * Inputs: (+/-1.0, +/-0.0).
  * Expected: Pi/2 with the sign of the first argument.
  */
-static int
+static int SDLCALL
 atan2_xZeroCases(void *args)
 {
     const dd_to_d cases[] = {
@@ -2617,7 +2617,7 @@ atan2_xZeroCases(void *args)
  * - (-int, +inf) -> -Pi/4,
  * - (-int, -inf) -> Pi.
  */
-static int
+static int SDLCALL
 atan2_bothInfCases(void *args)
 {
     double result;
@@ -2649,7 +2649,7 @@ atan2_bothInfCases(void *args)
  * Inputs: (+/-Infinity, +/-1.0).
  * Expected: Pi/2 with the sign of the first argument.
  */
-static int
+static int SDLCALL
 atan2_yInfCases(void *args)
 {
     double result;
@@ -2683,7 +2683,7 @@ atan2_yInfCases(void *args)
  * - (+/-1.0, +inf) -> +/-0.0
  * - (+/-1.0, -inf) -> +/-Pi.
  */
-static int
+static int SDLCALL
 atan2_xInfCases(void *args)
 {
     double result;
@@ -2717,7 +2717,7 @@ atan2_xInfCases(void *args)
  * Inputs: NAN as either or both of the arguments.
  * Expected: NAN is returned.
  */
-static int
+static int SDLCALL
 atan2_nanCases(void *args)
 {
     double result;
@@ -2744,7 +2744,7 @@ atan2_nanCases(void *args)
  * Inputs: (y, x) with x and y positive.
  * Expected: Angle in the top right quadrant.
  */
-static int
+static int SDLCALL
 atan2_topRightQuadrantTest(void *args)
 {
     const dd_to_d top_right_cases[] = {
@@ -2759,7 +2759,7 @@ atan2_topRightQuadrantTest(void *args)
  * Inputs: (y, x) with x negative and y positive.
  * Expected: Angle in the top left quadrant.
  */
-static int
+static int SDLCALL
 atan2_topLeftQuadrantTest(void *args)
 {
     const dd_to_d top_left_cases[] = {
@@ -2774,7 +2774,7 @@ atan2_topLeftQuadrantTest(void *args)
  * Inputs: (y, x) with x positive and y negative.
  * Expected: Angle in the bottom right quadrant.
  */
-static int
+static int SDLCALL
 atan2_bottomRightQuadrantTest(void *args)
 {
     const dd_to_d bottom_right_cases[] = {
@@ -2789,7 +2789,7 @@ atan2_bottomRightQuadrantTest(void *args)
  * Inputs: (y, x) with x and y negative.
  * Expected: Angle in the bottom left quadrant.
  */
-static int
+static int SDLCALL
 atan2_bottomLeftQuadrantTest(void *args)
 {
     const dd_to_d bottom_left_cases[] = {

--- a/test/testautomation_mouse.c
+++ b/test/testautomation_mouse.c
@@ -28,7 +28,7 @@ static int mouseStateCheck(Uint32 state)
  * Check call to SDL_GetMouseState
  *
  */
-static int mouse_getMouseState(void *arg)
+static int SDLCALL mouse_getMouseState(void *arg)
 {
     float x;
     float y;
@@ -73,7 +73,7 @@ static int mouse_getMouseState(void *arg)
  * Check call to SDL_GetRelativeMouseState
  *
  */
-static int mouse_getRelativeMouseState(void *arg)
+static int SDLCALL mouse_getRelativeMouseState(void *arg)
 {
     float x;
     float y;
@@ -193,7 +193,7 @@ static SDL_Cursor *initArrowCursor(const char *image[])
  * \sa SDL_CreateCursor
  * \sa SDL_DestroyCursor
  */
-static int mouse_createFreeCursor(void *arg)
+static int SDLCALL mouse_createFreeCursor(void *arg)
 {
     SDL_Cursor *cursor;
 
@@ -219,7 +219,7 @@ static int mouse_createFreeCursor(void *arg)
  * \sa SDL_CreateColorCursor
  * \sa SDL_DestroyCursor
  */
-static int mouse_createFreeColorCursor(void *arg)
+static int SDLCALL mouse_createFreeColorCursor(void *arg)
 {
     SDL_Surface *face;
     SDL_Cursor *cursor;
@@ -275,7 +275,7 @@ static void changeCursorVisibility(SDL_bool state)
  *
  * \sa SDL_ShowCursor
  */
-static int mouse_showCursor(void *arg)
+static int SDLCALL mouse_showCursor(void *arg)
 {
     SDL_bool currentState;
 
@@ -300,7 +300,7 @@ static int mouse_showCursor(void *arg)
  *
  * \sa SDL_SetCursor
  */
-static int mouse_setCursor(void *arg)
+static int SDLCALL mouse_setCursor(void *arg)
 {
     SDL_Cursor *cursor;
 
@@ -333,7 +333,7 @@ static int mouse_setCursor(void *arg)
  *
  * \sa SDL_GetCursor
  */
-static int mouse_getCursor(void *arg)
+static int SDLCALL mouse_getCursor(void *arg)
 {
     SDL_Cursor *cursor;
 
@@ -379,7 +379,7 @@ static void destroyMouseSuiteTestWindow(SDL_Window *window)
  * \sa SDL_GetWindowRelativeMouseMode
  * \sa SDL_SetWindowRelativeMouseMode
  */
-static int mouse_getSetRelativeMouseMode(void *arg)
+static int SDLCALL mouse_getSetRelativeMouseMode(void *arg)
 {
     SDL_Window *window;
     int result;
@@ -443,7 +443,7 @@ static int mouse_getSetRelativeMouseMode(void *arg)
  *
  * \sa SDL_WarpMouseInWindow
  */
-static int mouse_warpMouseInWindow(void *arg)
+static int SDLCALL mouse_warpMouseInWindow(void *arg)
 {
     const int w = MOUSE_TESTWINDOW_WIDTH, h = MOUSE_TESTWINDOW_HEIGHT;
     int numPositions = 6;
@@ -506,7 +506,7 @@ static int mouse_warpMouseInWindow(void *arg)
  *
  * \sa SDL_GetMouseFocus
  */
-static int mouse_getMouseFocus(void *arg)
+static int SDLCALL mouse_getMouseFocus(void *arg)
 {
     const int w = MOUSE_TESTWINDOW_WIDTH, h = MOUSE_TESTWINDOW_HEIGHT;
     float x, y;
@@ -572,7 +572,7 @@ static int mouse_getMouseFocus(void *arg)
  *
  * \sa SDL_GetDefaultCursor
  */
-static int mouse_getDefaultCursor(void *arg)
+static int SDLCALL mouse_getDefaultCursor(void *arg)
 {
     SDL_Cursor *cursor;
 
@@ -589,7 +589,7 @@ static int mouse_getDefaultCursor(void *arg)
  *
  * \sa SDL_GetGlobalMouseState
  */
-static int mouse_getGlobalMouseState(void *arg)
+static int SDLCALL mouse_getGlobalMouseState(void *arg)
 {
     float x;
     float y;

--- a/test/testautomation_pixels.c
+++ b/test/testautomation_pixels.c
@@ -261,7 +261,7 @@ SDL_COMPILE_TIME_ASSERT(SDL_COLORSPACE_BT2020_FULL_FORMAT, SDL_COLORSPACE_BT2020
 /**
  * Call to SDL_GetPixelFormatDetails
  */
-static int pixels_getPixelFormatDetails(void *arg)
+static int SDLCALL pixels_getPixelFormatDetails(void *arg)
 {
     const char *unknownFormat = "SDL_PIXELFORMAT_UNKNOWN";
     const char *expectedError = "Unknown pixel format";
@@ -349,7 +349,7 @@ static int pixels_getPixelFormatDetails(void *arg)
  *
  * \sa SDL_GetPixelFormatName
  */
-static int pixels_getPixelFormatName(void *arg)
+static int SDLCALL pixels_getPixelFormatName(void *arg)
 {
     const char *unknownFormat = "SDL_PIXELFORMAT_UNKNOWN";
     const char *error;
@@ -417,7 +417,7 @@ static int pixels_getPixelFormatName(void *arg)
  * \sa SDL_CreatePalette
  * \sa SDL_DestroyPalette
  */
-static int pixels_allocFreePalette(void *arg)
+static int SDLCALL pixels_allocFreePalette(void *arg)
 {
     const char *expectedError = "Parameter 'ncolors' is invalid";
     const char *error;

--- a/test/testautomation_platform.c
+++ b/test/testautomation_platform.c
@@ -27,7 +27,7 @@ static int compareSizeOfType(size_t sizeoftype, size_t hardcodetype)
 /**
  * Tests type sizes.
  */
-static int platform_testTypes(void *arg)
+static int SDLCALL platform_testTypes(void *arg)
 {
     int ret;
 
@@ -49,7 +49,7 @@ static int platform_testTypes(void *arg)
 /**
  * Tests platform endianness and SDL_SwapXY functions.
  */
-static int platform_testEndianessAndSwap(void *arg)
+static int SDLCALL platform_testEndianessAndSwap(void *arg)
 {
     int real_byteorder;
     int real_floatwordorder = 0;
@@ -124,7 +124,7 @@ static int platform_testEndianessAndSwap(void *arg)
  * \sa SDL_GetRevision
  * \sa SDL_GetCPUCacheLineSize
  */
-static int platform_testGetFunctions(void *arg)
+static int SDLCALL platform_testGetFunctions(void *arg)
 {
     const char *platform;
     const char *revision;
@@ -172,7 +172,7 @@ static int platform_testGetFunctions(void *arg)
  * \sa SDL_HasSSE42
  * \sa SDL_HasAVX
  */
-static int platform_testHasFunctions(void *arg)
+static int SDLCALL platform_testHasFunctions(void *arg)
 {
     /* TODO: independently determine and compare values as well */
 
@@ -207,7 +207,7 @@ static int platform_testHasFunctions(void *arg)
  * Tests SDL_GetVersion
  * \sa SDL_GetVersion
  */
-static int platform_testGetVersion(void *arg)
+static int SDLCALL platform_testGetVersion(void *arg)
 {
     int linked = SDL_GetVersion();
     SDLTest_AssertCheck(linked >= SDL_VERSION,
@@ -221,7 +221,7 @@ static int platform_testGetVersion(void *arg)
 /**
  * Tests default SDL_Init
  */
-static int platform_testDefaultInit(void *arg)
+static int SDLCALL platform_testDefaultInit(void *arg)
 {
     SDL_bool ret;
     int subsystem;
@@ -246,7 +246,7 @@ static int platform_testDefaultInit(void *arg)
  * \sa SDL_SetError
  * \sa SDL_ClearError
  */
-static int platform_testGetSetClearError(void *arg)
+static int SDLCALL platform_testGetSetClearError(void *arg)
 {
     int result;
     const char *testError = "Testing";
@@ -295,7 +295,7 @@ static int platform_testGetSetClearError(void *arg)
  * Tests SDL_SetError with empty input
  * \sa SDL_SetError
  */
-static int platform_testSetErrorEmptyInput(void *arg)
+static int SDLCALL platform_testSetErrorEmptyInput(void *arg)
 {
     int result;
     const char *testError = "";
@@ -336,7 +336,7 @@ static int platform_testSetErrorEmptyInput(void *arg)
  * Tests SDL_SetError with invalid input
  * \sa SDL_SetError
  */
-static int platform_testSetErrorInvalidInput(void *arg)
+static int SDLCALL platform_testSetErrorInvalidInput(void *arg)
 {
     int result;
     const char *invalidError = "";
@@ -419,7 +419,7 @@ static int platform_testSetErrorInvalidInput(void *arg)
  * Tests SDL_GetPowerInfo
  * \sa SDL_GetPowerInfo
  */
-static int platform_testGetPowerInfo(void *arg)
+static int SDLCALL platform_testGetPowerInfo(void *arg)
 {
     SDL_PowerState state;
     SDL_PowerState stateAgain;

--- a/test/testautomation_properties.c
+++ b/test/testautomation_properties.c
@@ -23,7 +23,7 @@ static void SDLCALL count_foo_properties(void *userdata, SDL_PropertiesID props,
         ++(*count);
     }
 }
-static int properties_testBasic(void *arg)
+static int SDLCALL properties_testBasic(void *arg)
 {
     SDL_PropertiesID props;
     char key[2], expected_value[2];
@@ -219,7 +219,7 @@ static int properties_testBasic(void *arg)
 static void SDLCALL copy_cleanup(void *userdata, void *value)
 {
 }
-static int properties_testCopy(void *arg)
+static int SDLCALL properties_testCopy(void *arg)
 {
     SDL_PropertiesID a, b;
     int num;
@@ -282,7 +282,7 @@ static void SDLCALL cleanup(void *userdata, void *value)
     int *count = (int *)userdata;
     ++(*count);
 }
-static int properties_testCleanup(void *arg)
+static int SDLCALL properties_testCleanup(void *arg)
 {
     SDL_PropertiesID props;
     char key[2], expected_value[2];
@@ -319,7 +319,7 @@ struct properties_thread_data
     SDL_bool done;
     SDL_PropertiesID props;
 };
-static int properties_thread(void *arg)
+static int SDLCALL properties_thread(void *arg)
 {
     struct properties_thread_data *data = (struct properties_thread_data *)arg;
 
@@ -333,7 +333,7 @@ static int properties_thread(void *arg)
     SDL_UnlockProperties(data->props);
     return 0;
 }
-static int properties_testLocking(void *arg)
+static int SDLCALL properties_testLocking(void *arg)
 {
     struct properties_thread_data data;
     SDL_Thread *thread;

--- a/test/testautomation_rect.c
+++ b/test/testautomation_rect.c
@@ -64,7 +64,7 @@ static void validateIntersectRectAndLineResults(
  *
  * \sa SDL_GetRectAndLineIntersectionFloat
  */
-static int rect_testIntersectRectAndLineFloat(void *arg)
+static int SDLCALL rect_testIntersectRectAndLineFloat(void *arg)
 {
     SDL_FRect rect;
     float x1, y1;
@@ -101,7 +101,7 @@ static int rect_testIntersectRectAndLineFloat(void *arg)
  *
  * \sa SDL_GetRectAndLineIntersection
  */
-static int rect_testIntersectRectAndLine(void *arg)
+static int SDLCALL rect_testIntersectRectAndLine(void *arg)
 {
     SDL_Rect refRect = { 0, 0, 32, 32 };
     SDL_Rect rect;
@@ -181,7 +181,7 @@ static int rect_testIntersectRectAndLine(void *arg)
  *
  * \sa SDL_GetRectAndLineIntersection
  */
-static int rect_testIntersectRectAndLineInside(void *arg)
+static int SDLCALL rect_testIntersectRectAndLineInside(void *arg)
 {
     SDL_Rect refRect = { 0, 0, 32, 32 };
     SDL_Rect rect;
@@ -246,7 +246,7 @@ static int rect_testIntersectRectAndLineInside(void *arg)
  *
  * \sa SDL_GetRectAndLineIntersection
  */
-static int rect_testIntersectRectAndLineOutside(void *arg)
+static int SDLCALL rect_testIntersectRectAndLineOutside(void *arg)
 {
     SDL_Rect refRect = { 0, 0, 32, 32 };
     SDL_Rect rect;
@@ -299,7 +299,7 @@ static int rect_testIntersectRectAndLineOutside(void *arg)
  *
  * \sa SDL_GetRectAndLineIntersection
  */
-static int rect_testIntersectRectAndLineEmpty(void *arg)
+static int SDLCALL rect_testIntersectRectAndLineEmpty(void *arg)
 {
     SDL_Rect refRect;
     SDL_Rect rect;
@@ -332,7 +332,7 @@ static int rect_testIntersectRectAndLineEmpty(void *arg)
  *
  * \sa SDL_GetRectAndLineIntersection
  */
-static int rect_testIntersectRectAndLineParam(void *arg)
+static int SDLCALL rect_testIntersectRectAndLineParam(void *arg)
 {
     SDL_Rect rect = { 0, 0, 32, 32 };
     int x1 = rect.w / 2;
@@ -549,7 +549,7 @@ static void validateFRectEqualsResults(
  *
  * \sa SDL_GetRectIntersectionFloat
  */
-static int rect_testIntersectRectFloat(void *arg)
+static int SDLCALL rect_testIntersectRectFloat(void *arg)
 {
     SDL_FRect rectA;
     SDL_FRect rectB;
@@ -617,7 +617,7 @@ static int rect_testIntersectRectFloat(void *arg)
  *
  * \sa SDL_GetRectIntersection
  */
-static int rect_testIntersectRectInside(void *arg)
+static int SDLCALL rect_testIntersectRectInside(void *arg)
 {
     SDL_Rect refRectA = { 0, 0, 32, 32 };
     SDL_Rect refRectB;
@@ -644,7 +644,7 @@ static int rect_testIntersectRectInside(void *arg)
  *
  * \sa SDL_GetRectIntersection
  */
-static int rect_testIntersectRectOutside(void *arg)
+static int SDLCALL rect_testIntersectRectOutside(void *arg)
 {
     SDL_Rect refRectA = { 0, 0, 32, 32 };
     SDL_Rect refRectB;
@@ -671,7 +671,7 @@ static int rect_testIntersectRectOutside(void *arg)
  *
  * \sa SDL_GetRectIntersection
  */
-static int rect_testIntersectRectPartial(void *arg)
+static int SDLCALL rect_testIntersectRectPartial(void *arg)
 {
     SDL_Rect refRectA = { 0, 0, 32, 32 };
     SDL_Rect refRectB;
@@ -759,7 +759,7 @@ static int rect_testIntersectRectPartial(void *arg)
  *
  * \sa SDL_GetRectIntersection
  */
-static int rect_testIntersectRectPoint(void *arg)
+static int SDLCALL rect_testIntersectRectPoint(void *arg)
 {
     SDL_Rect refRectA = { 0, 0, 1, 1 };
     SDL_Rect refRectB = { 0, 0, 1, 1 };
@@ -805,7 +805,7 @@ static int rect_testIntersectRectPoint(void *arg)
  *
  * \sa SDL_GetRectIntersection
  */
-static int rect_testIntersectRectEmpty(void *arg)
+static int SDLCALL rect_testIntersectRectEmpty(void *arg)
 {
     SDL_Rect refRectA;
     SDL_Rect refRectB;
@@ -876,7 +876,7 @@ static int rect_testIntersectRectEmpty(void *arg)
  *
  * \sa SDL_GetRectIntersection
  */
-static int rect_testIntersectRectParam(void *arg)
+static int SDLCALL rect_testIntersectRectParam(void *arg)
 {
     SDL_Rect rectA;
     SDL_Rect rectB = { 0 };
@@ -905,7 +905,7 @@ static int rect_testIntersectRectParam(void *arg)
  *
  * \sa SDL_HasRectIntersection
  */
-static int rect_testHasIntersectionInside(void *arg)
+static int SDLCALL rect_testHasIntersectionInside(void *arg)
 {
     SDL_Rect refRectA = { 0, 0, 32, 32 };
     SDL_Rect refRectB;
@@ -931,7 +931,7 @@ static int rect_testHasIntersectionInside(void *arg)
  *
  * \sa SDL_HasRectIntersection
  */
-static int rect_testHasIntersectionOutside(void *arg)
+static int SDLCALL rect_testHasIntersectionOutside(void *arg)
 {
     SDL_Rect refRectA = { 0, 0, 32, 32 };
     SDL_Rect refRectB;
@@ -957,7 +957,7 @@ static int rect_testHasIntersectionOutside(void *arg)
  *
  * \sa SDL_HasRectIntersection
  */
-static int rect_testHasIntersectionPartial(void *arg)
+static int SDLCALL rect_testHasIntersectionPartial(void *arg)
 {
     SDL_Rect refRectA = { 0, 0, 32, 32 };
     SDL_Rect refRectB;
@@ -1023,7 +1023,7 @@ static int rect_testHasIntersectionPartial(void *arg)
  *
  * \sa SDL_HasRectIntersection
  */
-static int rect_testHasIntersectionPoint(void *arg)
+static int SDLCALL rect_testHasIntersectionPoint(void *arg)
 {
     SDL_Rect refRectA = { 0, 0, 1, 1 };
     SDL_Rect refRectB = { 0, 0, 1, 1 };
@@ -1068,7 +1068,7 @@ static int rect_testHasIntersectionPoint(void *arg)
  *
  * \sa SDL_HasRectIntersection
  */
-static int rect_testHasIntersectionEmpty(void *arg)
+static int SDLCALL rect_testHasIntersectionEmpty(void *arg)
 {
     SDL_Rect refRectA;
     SDL_Rect refRectB;
@@ -1125,7 +1125,7 @@ static int rect_testHasIntersectionEmpty(void *arg)
  *
  * \sa SDL_HasRectIntersection
  */
-static int rect_testHasIntersectionParam(void *arg)
+static int SDLCALL rect_testHasIntersectionParam(void *arg)
 {
     SDL_Rect rectA;
     SDL_Rect rectB = { 0 };
@@ -1147,7 +1147,7 @@ static int rect_testHasIntersectionParam(void *arg)
  *
  * \sa SDL_GetRectEnclosingPointsFloat
  */
-static int rect_testEnclosePointsFloat(void *arg)
+static int SDLCALL rect_testEnclosePointsFloat(void *arg)
 {
     SDL_FPoint fpts[3] = { { 1.25f, 2.5f }, { 1.75f, 3.75f }, { 3.5f, 3.0f } };
     int i, count = 3;
@@ -1180,7 +1180,7 @@ static int rect_testEnclosePointsFloat(void *arg)
  *
  * \sa SDL_GetRectEnclosingPoints
  */
-static int rect_testEnclosePoints(void *arg)
+static int SDLCALL rect_testEnclosePoints(void *arg)
 {
     const int numPoints = 16;
     SDL_Point refPoints[16];
@@ -1257,7 +1257,7 @@ static int rect_testEnclosePoints(void *arg)
  *
  * \sa SDL_GetRectEnclosingPoints
  */
-static int rect_testEnclosePointsRepeatedInput(void *arg)
+static int SDLCALL rect_testEnclosePointsRepeatedInput(void *arg)
 {
     const int numPoints = 8;
     const int halfPoints = 4;
@@ -1340,7 +1340,7 @@ static int rect_testEnclosePointsRepeatedInput(void *arg)
  *
  * \sa SDL_GetRectEnclosingPoints
  */
-static int rect_testEnclosePointsWithClipping(void *arg)
+static int SDLCALL rect_testEnclosePointsWithClipping(void *arg)
 {
     const int numPoints = 16;
     SDL_Point refPoints[16];
@@ -1446,7 +1446,7 @@ static int rect_testEnclosePointsWithClipping(void *arg)
  *
  * \sa SDL_GetRectEnclosingPoints
  */
-static int rect_testEnclosePointsParam(void *arg)
+static int SDLCALL rect_testEnclosePointsParam(void *arg)
 {
     SDL_Point points[1];
     int count;
@@ -1473,7 +1473,7 @@ static int rect_testEnclosePointsParam(void *arg)
  *
  * \sa SDL_GetRectUnion
  */
-static int rect_testUnionRectOutside(void *arg)
+static int SDLCALL rect_testUnionRectOutside(void *arg)
 {
     SDL_Rect refRectA, refRectB;
     SDL_Rect rectA, rectB;
@@ -1551,7 +1551,7 @@ static int rect_testUnionRectOutside(void *arg)
  *
  * \sa SDL_GetRectUnion
  */
-static int rect_testUnionRectEmpty(void *arg)
+static int SDLCALL rect_testUnionRectEmpty(void *arg)
 {
     SDL_Rect refRectA, refRectB;
     SDL_Rect rectA, rectB;
@@ -1615,7 +1615,7 @@ static int rect_testUnionRectEmpty(void *arg)
  *
  * \sa SDL_GetRectUnion
  */
-static int rect_testUnionRectInside(void *arg)
+static int SDLCALL rect_testUnionRectInside(void *arg)
 {
     SDL_Rect refRectA, refRectB;
     SDL_Rect rectA, rectB;
@@ -1686,7 +1686,7 @@ static int rect_testUnionRectInside(void *arg)
  *
  * \sa SDL_GetRectUnion
  */
-static int rect_testUnionRectParam(void *arg)
+static int SDLCALL rect_testUnionRectParam(void *arg)
 {
     SDL_Rect rectA, rectB = { 0 };
     SDL_Rect result;
@@ -1713,7 +1713,7 @@ static int rect_testUnionRectParam(void *arg)
  *
  * \sa SDL_RectEmptyFloat
  */
-static int rect_testRectEmptyFloat(void *arg)
+static int SDLCALL rect_testRectEmptyFloat(void *arg)
 {
     SDL_FRect rect;
     SDL_bool result;
@@ -1755,7 +1755,7 @@ static int rect_testRectEmptyFloat(void *arg)
  *
  * \sa SDL_RectEmpty
  */
-static int rect_testRectEmpty(void *arg)
+static int SDLCALL rect_testRectEmpty(void *arg)
 {
     SDL_Rect refRect;
     SDL_Rect rect;
@@ -1797,7 +1797,7 @@ static int rect_testRectEmpty(void *arg)
  *
  * \sa SDL_RectEmpty
  */
-static int rect_testRectEmptyParam(void *arg)
+static int SDLCALL rect_testRectEmptyParam(void *arg)
 {
     SDL_bool result;
 
@@ -1813,7 +1813,7 @@ static int rect_testRectEmptyParam(void *arg)
  *
  * \sa SDL_RectsEqual
  */
-static int rect_testRectEquals(void *arg)
+static int SDLCALL rect_testRectEquals(void *arg)
 {
     SDL_Rect refRectA;
     SDL_Rect refRectB;
@@ -1842,7 +1842,7 @@ static int rect_testRectEquals(void *arg)
  *
  * \sa SDL_RectsEqual
  */
-static int rect_testRectEqualsParam(void *arg)
+static int SDLCALL rect_testRectEqualsParam(void *arg)
 {
     SDL_Rect rectA;
     SDL_Rect rectB;
@@ -1874,7 +1874,7 @@ static int rect_testRectEqualsParam(void *arg)
  *
  * \sa SDL_RectsEqualFloat
  */
-static int rect_testFRectEquals(void *arg)
+static int SDLCALL rect_testFRectEquals(void *arg)
 {
     SDL_FRect refRectA;
     SDL_FRect refRectB;
@@ -1903,7 +1903,7 @@ static int rect_testFRectEquals(void *arg)
  *
  * \sa SDL_RectsEqualFloat
  */
-static int rect_testFRectEqualsParam(void *arg)
+static int SDLCALL rect_testFRectEqualsParam(void *arg)
 {
     SDL_FRect rectA;
     SDL_FRect rectB;

--- a/test/testautomation_render.c
+++ b/test/testautomation_render.c
@@ -44,7 +44,7 @@ static SDL_bool hasDrawColor(void);
 /**
  * Create software renderer for tests
  */
-static void InitCreateRenderer(void **arg)
+static void SDLCALL InitCreateRenderer(void **arg)
 {
     int width = 320, height = 240;
     const char *renderer_name = NULL;
@@ -68,7 +68,7 @@ static void InitCreateRenderer(void **arg)
 /**
  * Destroy renderer for tests
  */
-static void CleanupDestroyRenderer(void *arg)
+static void SDLCALL CleanupDestroyRenderer(void *arg)
 {
     if (renderer) {
         SDL_DestroyRenderer(renderer);
@@ -88,7 +88,7 @@ static void CleanupDestroyRenderer(void *arg)
  *
  * \sa SDL_GetNumRenderDrivers
  */
-static int render_testGetNumRenderDrivers(void *arg)
+static int SDLCALL render_testGetNumRenderDrivers(void *arg)
 {
     int n;
     n = SDL_GetNumRenderDrivers();
@@ -104,7 +104,7 @@ static int render_testGetNumRenderDrivers(void *arg)
  * \sa SDL_RenderLine
  *
  */
-static int render_testPrimitives(void *arg)
+static int SDLCALL render_testPrimitives(void *arg)
 {
     int ret;
     int x, y;
@@ -191,7 +191,7 @@ static int render_testPrimitives(void *arg)
  * \sa SDL_RenderLine
  *
  */
-static int render_testPrimitivesWithViewport(void *arg)
+static int SDLCALL render_testPrimitivesWithViewport(void *arg)
 {
     SDL_Rect viewport;
     SDL_Surface *surface;
@@ -233,7 +233,7 @@ static int render_testPrimitivesWithViewport(void *arg)
  * \sa SDL_RenderTexture
  * \sa SDL_DestroyTexture
  */
-static int render_testBlit(void *arg)
+static int SDLCALL render_testBlit(void *arg)
 {
     int ret;
     SDL_FRect rect;
@@ -296,7 +296,7 @@ static int render_testBlit(void *arg)
 /**
  * Tests tiled blitting routines.
  */
-static int render_testBlitTiled(void *arg)
+static int SDLCALL render_testBlitTiled(void *arg)
 {
     int ret;
     SDL_FRect rect;
@@ -438,7 +438,7 @@ static void Fill9GridReferenceSurface(SDL_Surface *surface, int left_width, int 
 /**
  *  Tests 9-grid blitting.
  */
-static int render_testBlit9Grid(void *arg)
+static int SDLCALL render_testBlit9Grid(void *arg)
 {
     SDL_Surface *referenceSurface = NULL;
     SDL_Surface *source = NULL;
@@ -625,7 +625,7 @@ static int render_testBlit9Grid(void *arg)
  * \sa SDL_RenderTexture
  * \sa SDL_DestroyTexture
  */
-static int render_testBlitColor(void *arg)
+static int SDLCALL render_testBlitColor(void *arg)
 {
     int ret;
     SDL_FRect rect;
@@ -949,7 +949,7 @@ static void testBlendMode(int mode)
 /**
  * Tests render operations with blend modes
  */
-static int render_testBlendModes(void *arg)
+static int SDLCALL render_testBlendModes(void *arg)
 {
     testBlendMode(-1);
     testBlendMode(-2);
@@ -967,7 +967,7 @@ static int render_testBlendModes(void *arg)
 /**
  * Test viewport
  */
-static int render_testViewport(void *arg)
+static int SDLCALL render_testViewport(void *arg)
 {
     SDL_Surface *referenceSurface;
     SDL_Rect viewport;
@@ -1024,7 +1024,7 @@ static int render_testViewport(void *arg)
 /**
  * Test clip rect
  */
-static int render_testClipRect(void *arg)
+static int SDLCALL render_testClipRect(void *arg)
 {
     SDL_Surface *referenceSurface;
     SDL_Rect cliprect;
@@ -1081,7 +1081,7 @@ static int render_testClipRect(void *arg)
 /**
  * Test logical size
  */
-static int render_testLogicalSize(void *arg)
+static int SDLCALL render_testLogicalSize(void *arg)
 {
     SDL_Surface *referenceSurface;
     SDL_Rect viewport;
@@ -1434,7 +1434,7 @@ clearScreen(void)
 /**
  * Tests geometry UV wrapping
  */
-static int render_testUVWrapping(void *arg)
+static int SDLCALL render_testUVWrapping(void *arg)
 {
     SDL_Vertex vertices[6];
     SDL_Vertex *verts = vertices;

--- a/test/testautomation_sdltest.c
+++ b/test/testautomation_sdltest.c
@@ -14,7 +14,7 @@
 /**
  * Calls to SDLTest_GenerateRunSeed()
  */
-static int sdltest_generateRunSeed(void *arg)
+static int SDLCALL sdltest_generateRunSeed(void *arg)
 {
     char buffer[32];
     char *result;
@@ -48,7 +48,7 @@ static int sdltest_generateRunSeed(void *arg)
 /**
  * Calls to SDLTest_GetFuzzerInvocationCount()
  */
-static int sdltest_getFuzzerInvocationCount(void *arg)
+static int SDLCALL sdltest_getFuzzerInvocationCount(void *arg)
 {
     Uint8 result;
     int fuzzerCount1, fuzzerCount2;
@@ -70,7 +70,7 @@ static int sdltest_getFuzzerInvocationCount(void *arg)
 /**
  * Calls to random number generators
  */
-static int sdltest_randomNumber(void *arg)
+static int SDLCALL sdltest_randomNumber(void *arg)
 {
     Sint64 result;
     double dresult;
@@ -137,7 +137,7 @@ static int sdltest_randomNumber(void *arg)
 /**
  * Calls to random boundary number generators for Uint8
  */
-static int sdltest_randomBoundaryNumberUint8(void *arg)
+static int SDLCALL sdltest_randomBoundaryNumberUint8(void *arg)
 {
     const char *expectedError = "That operation is not supported";
     const char *lastError;
@@ -246,7 +246,7 @@ static int sdltest_randomBoundaryNumberUint8(void *arg)
 /**
  * Calls to random boundary number generators for Uint16
  */
-static int sdltest_randomBoundaryNumberUint16(void *arg)
+static int SDLCALL sdltest_randomBoundaryNumberUint16(void *arg)
 {
     const char *expectedError = "That operation is not supported";
     const char *lastError;
@@ -355,7 +355,7 @@ static int sdltest_randomBoundaryNumberUint16(void *arg)
 /**
  * Calls to random boundary number generators for Uint32
  */
-static int sdltest_randomBoundaryNumberUint32(void *arg)
+static int SDLCALL sdltest_randomBoundaryNumberUint32(void *arg)
 {
     const char *expectedError = "That operation is not supported";
     const char *lastError;
@@ -464,7 +464,7 @@ static int sdltest_randomBoundaryNumberUint32(void *arg)
 /**
  * Calls to random boundary number generators for Uint64
  */
-static int sdltest_randomBoundaryNumberUint64(void *arg)
+static int SDLCALL sdltest_randomBoundaryNumberUint64(void *arg)
 {
     const char *expectedError = "That operation is not supported";
     const char *lastError;
@@ -573,7 +573,7 @@ static int sdltest_randomBoundaryNumberUint64(void *arg)
 /**
  * Calls to random boundary number generators for Sint8
  */
-static int sdltest_randomBoundaryNumberSint8(void *arg)
+static int SDLCALL sdltest_randomBoundaryNumberSint8(void *arg)
 {
     const char *expectedError = "That operation is not supported";
     const char *lastError;
@@ -682,7 +682,7 @@ static int sdltest_randomBoundaryNumberSint8(void *arg)
 /**
  * Calls to random boundary number generators for Sint16
  */
-static int sdltest_randomBoundaryNumberSint16(void *arg)
+static int SDLCALL sdltest_randomBoundaryNumberSint16(void *arg)
 {
     const char *expectedError = "That operation is not supported";
     const char *lastError;
@@ -791,7 +791,7 @@ static int sdltest_randomBoundaryNumberSint16(void *arg)
 /**
  * Calls to random boundary number generators for Sint32
  */
-static int sdltest_randomBoundaryNumberSint32(void *arg)
+static int SDLCALL sdltest_randomBoundaryNumberSint32(void *arg)
 {
     const char *expectedError = "That operation is not supported";
     const char *lastError;
@@ -907,7 +907,7 @@ static int sdltest_randomBoundaryNumberSint32(void *arg)
 /**
  * Calls to random boundary number generators for Sint64
  */
-static int sdltest_randomBoundaryNumberSint64(void *arg)
+static int SDLCALL sdltest_randomBoundaryNumberSint64(void *arg)
 {
     const char *expectedError = "That operation is not supported";
     const char *lastError;
@@ -1016,7 +1016,7 @@ static int sdltest_randomBoundaryNumberSint64(void *arg)
 /**
  * Calls to SDLTest_RandomIntegerInRange
  */
-static int sdltest_randomIntegerInRange(void *arg)
+static int SDLCALL sdltest_randomIntegerInRange(void *arg)
 {
     Sint32 min, max;
     Sint32 result;
@@ -1092,7 +1092,7 @@ static int sdltest_randomIntegerInRange(void *arg)
 /**
  * Calls to SDLTest_RandomAsciiString
  */
-static int sdltest_randomAsciiString(void *arg)
+static int SDLCALL sdltest_randomAsciiString(void *arg)
 {
     char *result;
     size_t len;
@@ -1124,7 +1124,7 @@ static int sdltest_randomAsciiString(void *arg)
 /**
  * Calls to SDLTest_RandomAsciiStringWithMaximumLength
  */
-static int sdltest_randomAsciiStringWithMaximumLength(void *arg)
+static int SDLCALL sdltest_randomAsciiStringWithMaximumLength(void *arg)
 {
     const char *expectedError = "Parameter 'maxLength' is invalid";
     const char *lastError;
@@ -1176,7 +1176,7 @@ static int sdltest_randomAsciiStringWithMaximumLength(void *arg)
 /**
  * Calls to SDLTest_RandomAsciiStringOfSize
  */
-static int sdltest_randomAsciiStringOfSize(void *arg)
+static int SDLCALL sdltest_randomAsciiStringOfSize(void *arg)
 {
     const char *expectedError = "Parameter 'size' is invalid";
     const char *lastError;

--- a/test/testautomation_stdlib.c
+++ b/test/testautomation_stdlib.c
@@ -11,7 +11,7 @@
  * Call to SDL_strnlen
  */
 #undef SDL_strnlen
-static int stdlib_strnlen(void *arg)
+static int SDLCALL stdlib_strnlen(void *arg)
 {
     size_t result;
     char *text_result;
@@ -39,7 +39,7 @@ static int stdlib_strnlen(void *arg)
  * Call to SDL_strlcpy
  */
 #undef SDL_strlcpy
-static int stdlib_strlcpy(void *arg)
+static int SDLCALL stdlib_strlcpy(void *arg)
 {
     size_t result;
     char text[1024];
@@ -63,7 +63,7 @@ static int stdlib_strlcpy(void *arg)
 /**
  * Call to SDL_strstr
  */
-static int stdlib_strstr(void *arg)
+static int SDLCALL stdlib_strstr(void *arg)
 {
     char *result;
     const char *text = "abcdef";
@@ -136,7 +136,7 @@ static int stdlib_strstr(void *arg)
  * Call to SDL_snprintf
  */
 #undef SDL_snprintf
-static int stdlib_snprintf(void *arg)
+static int SDLCALL stdlib_snprintf(void *arg)
 {
     int result;
     int predicted;
@@ -382,7 +382,7 @@ static int stdlib_snprintf(void *arg)
  * Call to SDL_swprintf
  */
 #undef SDL_swprintf
-static int stdlib_swprintf(void *arg)
+static int SDLCALL stdlib_swprintf(void *arg)
 {
     int result;
     int predicted;
@@ -548,7 +548,7 @@ static int stdlib_swprintf(void *arg)
 /**
  * Call to SDL_getenv and SDL_setenv
  */
-static int stdlib_getsetenv(void *arg)
+static int SDLCALL stdlib_getsetenv(void *arg)
 {
     const int nameLen = 16;
     char name[17];
@@ -721,7 +721,7 @@ static int stdlib_getsetenv(void *arg)
  * Call to SDL_sscanf
  */
 #undef SDL_sscanf
-static int stdlib_sscanf(void *arg)
+static int SDLCALL stdlib_sscanf(void *arg)
 {
     int output;
     int result;
@@ -889,7 +889,7 @@ static int stdlib_sscanf(void *arg)
 /**
  * Call to SDL_aligned_alloc
  */
-static int stdlib_aligned_alloc(void *arg)
+static int SDLCALL stdlib_aligned_alloc(void *arg)
 {
     size_t i, alignment;
     void *ptr;
@@ -945,7 +945,7 @@ static const overflow_test additions[] = {
     { SDL_SIZE_MAX, SDL_SIZE_MAX, 0, SDL_FALSE },
 };
 
-static int
+static int SDLCALL
 stdlib_overflow(void *arg)
 {
     size_t i;
@@ -1072,7 +1072,7 @@ static void format_for_description(char *buffer, size_t buflen, const char *text
     }
 }
 
-static int
+static int SDLCALL
 stdlib_iconv(void *arg)
 {
     struct {
@@ -1189,7 +1189,7 @@ stdlib_iconv(void *arg)
 }
 
 
-static int
+static int SDLCALL
 stdlib_strpbrk(void *arg)
 {
     struct {

--- a/test/testautomation_subsystems.c
+++ b/test/testautomation_subsystems.c
@@ -9,7 +9,7 @@
 
 /* Fixture */
 
-static void subsystemsSetUp(void **arg)
+static void SDLCALL subsystemsSetUp(void **arg)
 {
     /* Reset each one of the SDL subsystems */
     /* CHECKME: can we use SDL_Quit here, or this will break the flow of tests? */
@@ -23,7 +23,7 @@ static void subsystemsSetUp(void **arg)
     SDLTest_AssertCheck(SDL_WasInit(0) == 0, "Check result from SDL_WasInit(0)");
 }
 
-static void subsystemsTearDown(void *arg)
+static void SDLCALL subsystemsTearDown(void *arg)
 {
     /* Reset each one of the SDL subsystems */
     SDL_Quit();
@@ -40,7 +40,7 @@ static void subsystemsTearDown(void *arg)
  * \sa SDL_QuitSubSystem
  *
  */
-static int subsystems_referenceCount(void *arg)
+static int SDLCALL subsystems_referenceCount(void *arg)
 {
     const int system = SDL_INIT_VIDEO;
     int result;
@@ -90,7 +90,7 @@ static int subsystems_referenceCount(void *arg)
  * \sa SDL_QuitSubSystem
  *
  */
-static int subsystems_dependRefCountInitAllQuitByOne(void *arg)
+static int SDLCALL subsystems_dependRefCountInitAllQuitByOne(void *arg)
 {
     int result;
     /* Ensure that we start with reset subsystems. */
@@ -128,7 +128,7 @@ static int subsystems_dependRefCountInitAllQuitByOne(void *arg)
  * \sa SDL_QuitSubSystem
  *
  */
-static int subsystems_dependRefCountInitByOneQuitAll(void *arg)
+static int SDLCALL subsystems_dependRefCountInitByOneQuitAll(void *arg)
 {
     int result;
     /* Ensure that we start with reset subsystems. */
@@ -163,7 +163,7 @@ static int subsystems_dependRefCountInitByOneQuitAll(void *arg)
  * \sa SDL_QuitSubSystem
  *
  */
-static int subsystems_dependRefCountWithExtraInit(void *arg)
+static int SDLCALL subsystems_dependRefCountWithExtraInit(void *arg)
 {
     int result;
     /* Ensure that we start with reset subsystems. */

--- a/test/testautomation_surface.c
+++ b/test/testautomation_surface.c
@@ -41,7 +41,7 @@ static SDL_Surface *testSurface = NULL;
 /* Fixture */
 
 /* Create a 32-bit writable surface for blitting tests */
-static void surfaceSetUp(void **arg)
+static void SDLCALL surfaceSetUp(void **arg)
 {
     int result;
     SDL_BlendMode blendMode = SDL_BLENDMODE_NONE;
@@ -64,7 +64,7 @@ static void surfaceSetUp(void **arg)
     }
 }
 
-static void surfaceTearDown(void *arg)
+static void SDLCALL surfaceTearDown(void *arg)
 {
     SDL_DestroySurface(referenceSurface);
     referenceSurface = NULL;
@@ -316,7 +316,7 @@ static void AssertFileExist(const char *filename)
 /**
  * Tests sprite saving and loading
  */
-static int surface_testSaveLoadBitmap(void *arg)
+static int SDLCALL surface_testSaveLoadBitmap(void *arg)
 {
     int ret;
     const char *sampleFilename = "testSaveLoadBitmap.bmp";
@@ -363,7 +363,7 @@ static int surface_testSaveLoadBitmap(void *arg)
 /**
  *  Tests tiled blitting.
  */
-static int surface_testBlitTiled(void *arg)
+static int SDLCALL surface_testBlitTiled(void *arg)
 {
     SDL_Surface *face = NULL;
     SDL_Surface *testSurface2x = NULL;
@@ -488,7 +488,7 @@ static void Fill9GridReferenceSurface(SDL_Surface *surface, int left_width, int 
 /**
  *  Tests 9-grid blitting.
  */
-static int surface_testBlit9Grid(void *arg)
+static int SDLCALL surface_testBlit9Grid(void *arg)
 {
     SDL_Surface *source = NULL;
     int x, y;
@@ -610,7 +610,7 @@ static int surface_testBlit9Grid(void *arg)
 /**
  *  Tests blitting between multiple surfaces of the same format
  */
-static int surface_testBlitMultiple(void *arg)
+static int SDLCALL surface_testBlitMultiple(void *arg)
 {
     SDL_Surface *source, *surface;
     SDL_Palette *palette;
@@ -675,7 +675,7 @@ static int surface_testBlitMultiple(void *arg)
 /**
  *  Tests surface conversion.
  */
-static int surface_testSurfaceConversion(void *arg)
+static int SDLCALL surface_testSurfaceConversion(void *arg)
 {
     SDL_Surface *rface = NULL, *face = NULL;
     int ret = 0;
@@ -715,7 +715,7 @@ static int surface_testSurfaceConversion(void *arg)
 /**
  *  Tests surface conversion across all pixel formats.
  */
-static int surface_testCompleteSurfaceConversion(void *arg)
+static int SDLCALL surface_testCompleteSurfaceConversion(void *arg)
 {
     Uint32 pixel_formats[] = {
         SDL_PIXELFORMAT_INDEX8,
@@ -813,7 +813,7 @@ static int surface_testCompleteSurfaceConversion(void *arg)
 /**
  * Tests sprite loading. A failure case.
  */
-static int surface_testLoadFailure(void *arg)
+static int SDLCALL surface_testLoadFailure(void *arg)
 {
     SDL_Surface *face = SDL_LoadBMP("nonexistant.bmp");
     SDLTest_AssertCheck(face == NULL, "SDL_CreateLoadBmp");
@@ -824,7 +824,7 @@ static int surface_testLoadFailure(void *arg)
 /**
  * Tests some blitting routines.
  */
-static int surface_testBlit(void *arg)
+static int SDLCALL surface_testBlit(void *arg)
 {
     /* Basic blitting */
     testBlitBlendMode(SDL_BLENDMODE_NONE);
@@ -835,7 +835,7 @@ static int surface_testBlit(void *arg)
 /**
  * Tests some blitting routines with color mod
  */
-static int surface_testBlitColorMod(void *arg)
+static int SDLCALL surface_testBlitColorMod(void *arg)
 {
     /* Basic blitting with color mod */
     testBlitBlendMode(-1);
@@ -846,7 +846,7 @@ static int surface_testBlitColorMod(void *arg)
 /**
  * Tests some blitting routines with alpha mod
  */
-static int surface_testBlitAlphaMod(void *arg)
+static int SDLCALL surface_testBlitAlphaMod(void *arg)
 {
     /* Basic blitting with alpha mod */
     testBlitBlendMode(-2);
@@ -857,7 +857,7 @@ static int surface_testBlitAlphaMod(void *arg)
 /**
  * Tests some more blitting routines.
  */
-static int surface_testBlitBlendBlend(void *arg)
+static int SDLCALL surface_testBlitBlendBlend(void *arg)
 {
     /* Blend blitting */
     testBlitBlendMode(SDL_BLENDMODE_BLEND);
@@ -868,7 +868,7 @@ static int surface_testBlitBlendBlend(void *arg)
 /**
  * @brief Tests some more blitting routines.
  */
-static int surface_testBlitBlendPremultiplied(void *arg)
+static int SDLCALL surface_testBlitBlendPremultiplied(void *arg)
 {
    /* Blend premultiplied blitting */
    testBlitBlendMode(SDL_BLENDMODE_BLEND_PREMULTIPLIED);
@@ -879,7 +879,7 @@ static int surface_testBlitBlendPremultiplied(void *arg)
 /**
  * Tests some more blitting routines.
  */
-static int surface_testBlitBlendAdd(void *arg)
+static int SDLCALL surface_testBlitBlendAdd(void *arg)
 {
     /* Add blitting */
     testBlitBlendMode(SDL_BLENDMODE_ADD);
@@ -890,7 +890,7 @@ static int surface_testBlitBlendAdd(void *arg)
 /**
  * Tests some more blitting routines.
  */
-static int surface_testBlitBlendAddPremultiplied(void *arg)
+static int SDLCALL surface_testBlitBlendAddPremultiplied(void *arg)
 {
     /* Add premultiplied blitting */
     testBlitBlendMode(SDL_BLENDMODE_ADD_PREMULTIPLIED);
@@ -901,7 +901,7 @@ static int surface_testBlitBlendAddPremultiplied(void *arg)
 /**
  * Tests some more blitting routines.
  */
-static int surface_testBlitBlendMod(void *arg)
+static int SDLCALL surface_testBlitBlendMod(void *arg)
 {
     /* Mod blitting */
     testBlitBlendMode(SDL_BLENDMODE_MOD);
@@ -912,7 +912,7 @@ static int surface_testBlitBlendMod(void *arg)
 /**
  * Tests some more blitting routines.
  */
-static int surface_testBlitBlendMul(void *arg)
+static int SDLCALL surface_testBlitBlendMul(void *arg)
 {
     /* Mod blitting */
     testBlitBlendMode(SDL_BLENDMODE_MUL);
@@ -920,7 +920,7 @@ static int surface_testBlitBlendMul(void *arg)
     return TEST_COMPLETED;
 }
 
-static int surface_testOverflow(void *arg)
+static int SDLCALL surface_testOverflow(void *arg)
 {
     char buf[1024];
     const char *expectedError;
@@ -1135,7 +1135,7 @@ static int surface_testOverflow(void *arg)
     return TEST_COMPLETED;
 }
 
-static int surface_testFlip(void *arg)
+static int SDLCALL surface_testFlip(void *arg)
 {
     SDL_Surface *surface;
     Uint8 *pixels;
@@ -1182,7 +1182,7 @@ static int surface_testFlip(void *arg)
     return TEST_COMPLETED;
 }
 
-static int surface_testPalette(void *arg)
+static int SDLCALL surface_testPalette(void *arg)
 {
     SDL_Surface *source, *surface, *output;
     SDL_Palette *palette;
@@ -1266,7 +1266,7 @@ static int surface_testPalette(void *arg)
     return TEST_COMPLETED;
 }
 
-static int surface_testPalettization(void *arg)
+static int SDLCALL surface_testPalettization(void *arg)
 {
     const SDL_Color palette_colors[] = {
         { 0x80, 0x00, 0x00, 0xff },
@@ -1357,7 +1357,7 @@ static int surface_testPalettization(void *arg)
     return TEST_COMPLETED;
 }
 
-static int surface_testClearSurface(void *arg)
+static int SDLCALL surface_testClearSurface(void *arg)
 {
     SDL_PixelFormat formats[] = {
         SDL_PIXELFORMAT_ARGB8888, SDL_PIXELFORMAT_RGBA8888,
@@ -1405,7 +1405,7 @@ static int surface_testClearSurface(void *arg)
     return TEST_COMPLETED;
 }
 
-static int surface_testPremultiplyAlpha(void *arg)
+static int SDLCALL surface_testPremultiplyAlpha(void *arg)
 {
     SDL_PixelFormat formats[] = {
         SDL_PIXELFORMAT_ARGB8888, SDL_PIXELFORMAT_RGBA8888,

--- a/test/testautomation_time.c
+++ b/test/testautomation_time.c
@@ -13,7 +13,7 @@
 /**
  * Call to SDL_GetRealtimeClock
  */
-static int time_getRealtimeClock(void *arg)
+static int SDLCALL time_getRealtimeClock(void *arg)
 {
     int result;
     SDL_Time ticks;
@@ -28,7 +28,7 @@ static int time_getRealtimeClock(void *arg)
 /**
  * Test bidirectional SDL_DateTime conversions.
  */
-static int time_dateTimeConversion(void *arg)
+static int SDLCALL time_dateTimeConversion(void *arg)
 {
     int result;
     SDL_Time ticks[2];
@@ -103,7 +103,7 @@ static int time_dateTimeConversion(void *arg)
 /**
  * Test time utility functions.
  */
-static int time_dateTimeUtilities(void *arg)
+static int SDLCALL time_dateTimeUtilities(void *arg)
 {
     int result;
 

--- a/test/testautomation_timer.c
+++ b/test/testautomation_timer.c
@@ -20,7 +20,7 @@ static int g_timerCallbackCalled = 0;
 
 /* Fixture */
 
-static void timerSetUp(void **arg)
+static void SDLCALL timerSetUp(void **arg)
 {
     /* Start SDL timer subsystem */
     SDL_bool ret = SDL_InitSubSystem(SDL_INIT_TIMER);
@@ -36,7 +36,7 @@ static void timerSetUp(void **arg)
 /**
  * Call to SDL_GetPerformanceCounter
  */
-static int timer_getPerformanceCounter(void *arg)
+static int SDLCALL timer_getPerformanceCounter(void *arg)
 {
     Uint64 result;
 
@@ -50,7 +50,7 @@ static int timer_getPerformanceCounter(void *arg)
 /**
  * Call to SDL_GetPerformanceFrequency
  */
-static int timer_getPerformanceFrequency(void *arg)
+static int SDLCALL timer_getPerformanceFrequency(void *arg)
 {
     Uint64 result;
 
@@ -64,7 +64,7 @@ static int timer_getPerformanceFrequency(void *arg)
 /**
  * Call to SDL_Delay and SDL_GetTicks
  */
-static int timer_delayAndGetTicks(void *arg)
+static int SDLCALL timer_delayAndGetTicks(void *arg)
 {
     const int testDelay = 100;
     const int marginOfError = 25;
@@ -126,7 +126,7 @@ static Uint32 SDLCALL timerTestCallback(void *param, SDL_TimerID timerID, Uint32
 /**
  * Call to SDL_AddTimer and SDL_RemoveTimer
  */
-static int timer_addRemoveTimer(void *arg)
+static int SDLCALL timer_addRemoveTimer(void *arg)
 {
 #ifdef SDL_PLATFORM_EMSCRIPTEN
     SDLTest_Log("Timer callbacks on Emscripten require a main loop to handle events");

--- a/test/testautomation_video.c
+++ b/test/testautomation_video.c
@@ -98,7 +98,7 @@ static void destroyVideoSuiteTestWindow(SDL_Window *window)
 /**
  * Enable and disable screensaver while checking state
  */
-static int video_enableDisableScreensaver(void *arg)
+static int SDLCALL video_enableDisableScreensaver(void *arg)
 {
     SDL_bool initialResult;
     SDL_bool result;
@@ -149,7 +149,7 @@ static int video_enableDisableScreensaver(void *arg)
 /**
  * Tests the functionality of the SDL_CreateWindow function using different sizes
  */
-static int video_createWindowVariousSizes(void *arg)
+static int SDLCALL video_createWindowVariousSizes(void *arg)
 {
     SDL_Window *window;
     const char *title = "video_createWindowVariousSizes Test Window";
@@ -203,7 +203,7 @@ static int video_createWindowVariousSizes(void *arg)
 /**
  * Tests the functionality of the SDL_CreateWindow function using different flags
  */
-static int video_createWindowVariousFlags(void *arg)
+static int SDLCALL video_createWindowVariousFlags(void *arg)
 {
     SDL_Window *window;
     const char *title = "video_createWindowVariousFlags Test Window";
@@ -277,7 +277,7 @@ static int video_createWindowVariousFlags(void *arg)
 /**
  * Tests the functionality of the SDL_GetWindowFlags function
  */
-static int video_getWindowFlags(void *arg)
+static int SDLCALL video_getWindowFlags(void *arg)
 {
     SDL_Window *window;
     const char *title = "video_getWindowFlags Test Window";
@@ -304,7 +304,7 @@ static int video_getWindowFlags(void *arg)
 /**
  * Tests the functionality of the SDL_GetFullscreenDisplayModes function
  */
-static int video_getFullscreenDisplayModes(void *arg)
+static int SDLCALL video_getFullscreenDisplayModes(void *arg)
 {
     SDL_DisplayID *displays;
     SDL_DisplayMode **modes;
@@ -333,7 +333,7 @@ static int video_getFullscreenDisplayModes(void *arg)
 /**
  * Tests the functionality of the SDL_GetClosestFullscreenDisplayMode function against current resolution
  */
-static int video_getClosestDisplayModeCurrentResolution(void *arg)
+static int SDLCALL video_getClosestDisplayModeCurrentResolution(void *arg)
 {
     SDL_DisplayID *displays;
     SDL_DisplayMode **modes;
@@ -383,7 +383,7 @@ static int video_getClosestDisplayModeCurrentResolution(void *arg)
 /**
  * Tests the functionality of the SDL_GetClosestFullscreenDisplayMode function against random resolution
  */
-static int video_getClosestDisplayModeRandomResolution(void *arg)
+static int SDLCALL video_getClosestDisplayModeRandomResolution(void *arg)
 {
     SDL_DisplayID *displays;
     SDL_DisplayMode target;
@@ -424,7 +424,7 @@ static int video_getClosestDisplayModeRandomResolution(void *arg)
  *
  * \sa SDL_GetWindowFullscreenMode
  */
-static int video_getWindowDisplayMode(void *arg)
+static int SDLCALL video_getWindowDisplayMode(void *arg)
 {
     SDL_Window *window;
     const char *title = "video_getWindowDisplayMode Test Window";
@@ -468,7 +468,7 @@ static void checkInvalidWindowError(void)
  *
  * \sa SDL_GetWindowFullscreenMode
  */
-static int video_getWindowDisplayModeNegative(void *arg)
+static int SDLCALL video_getWindowDisplayModeNegative(void *arg)
 {
     const SDL_DisplayMode *mode;
 
@@ -553,7 +553,7 @@ static void setAndCheckWindowKeyboardGrabState(SDL_Window *window, SDL_bool desi
  * \sa SDL_SetWindowMouseGrab
  * \sa SDL_SetWindowKeyboardGrab
  */
-static int video_getSetWindowGrab(void *arg)
+static int SDLCALL video_getSetWindowGrab(void *arg)
 {
     const char *title = "video_getSetWindowGrab Test Window";
     SDL_Window *window;
@@ -672,7 +672,7 @@ static int video_getSetWindowGrab(void *arg)
  * \sa SDL_GetWindowID
  * \sa SDL_SetWindowFromID
  */
-static int video_getWindowId(void *arg)
+static int SDLCALL video_getWindowId(void *arg)
 {
     const char *title = "video_getWindowId Test Window";
     SDL_Window *window;
@@ -728,7 +728,7 @@ static int video_getWindowId(void *arg)
  *
  * \sa SDL_GetWindowPixelFormat
  */
-static int video_getWindowPixelFormat(void *arg)
+static int SDLCALL video_getWindowPixelFormat(void *arg)
 {
     const char *title = "video_getWindowPixelFormat Test Window";
     SDL_Window *window;
@@ -795,7 +795,7 @@ static SDL_bool getSizeFromEvent(int *w, int *h)
  * \sa SDL_GetWindowPosition
  * \sa SDL_SetWindowPosition
  */
-static int video_getSetWindowPosition(void *arg)
+static int SDLCALL video_getSetWindowPosition(void *arg)
 {
     const char *title = "video_getSetWindowPosition Test Window";
     SDL_Window *window;
@@ -995,7 +995,7 @@ static void checkInvalidParameterError(void)
  * \sa SDL_GetWindowSize
  * \sa SDL_SetWindowSize
  */
-static int video_getSetWindowSize(void *arg)
+static int SDLCALL video_getSetWindowSize(void *arg)
 {
     const char *title = "video_getSetWindowSize Test Window";
     SDL_Window *window;
@@ -1198,7 +1198,7 @@ null_tests:
  * Tests call to SDL_GetWindowMinimumSize and SDL_SetWindowMinimumSize
  *
  */
-static int video_getSetWindowMinimumSize(void *arg)
+static int SDLCALL video_getSetWindowMinimumSize(void *arg)
 {
     const char *title = "video_getSetWindowMinimumSize Test Window";
     SDL_Window *window;
@@ -1341,7 +1341,7 @@ static int video_getSetWindowMinimumSize(void *arg)
  * Tests call to SDL_GetWindowMaximumSize and SDL_SetWindowMaximumSize
  *
  */
-static int video_getSetWindowMaximumSize(void *arg)
+static int SDLCALL video_getSetWindowMaximumSize(void *arg)
 {
     const char *title = "video_getSetWindowMaximumSize Test Window";
     SDL_Window *window;
@@ -1481,7 +1481,7 @@ static int video_getSetWindowMaximumSize(void *arg)
  * \sa SDL_SetWindowData
  * \sa SDL_GetWindowData
  */
-static int video_getSetWindowData(void *arg)
+static int SDLCALL video_getSetWindowData(void *arg)
 {
     int returnValue = TEST_COMPLETED;
     const char *title = "video_setGetWindowData Test Window";
@@ -1673,7 +1673,7 @@ cleanup:
  * tests don't work in windowed mode and are unreliable in fullscreen mode, thus are disabled when using
  * the Wayland video driver. All that can be done is check that the windows are the expected size.
  */
-static int video_setWindowCenteredOnDisplay(void *arg)
+static int SDLCALL video_setWindowCenteredOnDisplay(void *arg)
 {
     SDL_DisplayID *displays;
     SDL_Window *window;
@@ -1905,7 +1905,7 @@ static int video_setWindowCenteredOnDisplay(void *arg)
  *       desktops, particularly tiling desktops, may not support the expected behavior,
  *       so don't be surprised if this fails.
  */
-static int video_getSetWindowState(void *arg)
+static int SDLCALL video_getSetWindowState(void *arg)
 {
     const char *title = "video_getSetWindowState Test Window";
     SDL_Window *window;
@@ -2256,7 +2256,7 @@ minimize_test:
     return skipFlags != (SDL_WINDOW_MAXIMIZED | SDL_WINDOW_MINIMIZED)  ? TEST_COMPLETED : TEST_SKIPPED;
 }
 
-static int video_createMinimized(void *arg)
+static int SDLCALL video_createMinimized(void *arg)
 {
     const char *title = "video_createMinimized Test Window";
     int result;
@@ -2295,7 +2295,7 @@ static int video_createMinimized(void *arg)
     return TEST_COMPLETED;
 }
 
-static int video_createMaximized(void *arg)
+static int SDLCALL video_createMaximized(void *arg)
 {
     const char *title = "video_createMaximized Test Window";
     int result;
@@ -2337,7 +2337,7 @@ static int video_createMaximized(void *arg)
 /**
  * Tests window surface functionality
  */
-static int video_getWindowSurface(void *arg)
+static int SDLCALL video_getWindowSurface(void *arg)
 {
     const char *title = "video_getWindowSurface Test Window";
     SDL_Window *window;


### PR DESCRIPTION
We need a known calling convention when using a pre-built SDL_test library.
e.g. using a pre-built x86 SDL3_test MSVC libraray, and building with `/Gr` for the `__fastcall` convention.
## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
