### PR TITLE
SDL_Test: add SDLTest_LogEscapedString

### DIFF
--- a/include/SDL3/SDL_test_log.h
+++ b/include/SDL3/SDL_test_log.h
@@ -52,6 +52,16 @@ extern "C" {
 void SDLCALL SDLTest_Log(SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(1);
 
 /**
+ * Prints given prefix and buffer.
+ * Non-printible characters in the raw data are substituted by printible alternatives.
+ *
+ * \param prefix Prefix message.
+ * \param buffer Raw data to be escaped.
+ * \param size Number of bytes in buffer.
+ */
+void SDLCALL SDLTest_LogEscapedString(const char *prefix, const void *buffer, size_t size);
+
+/**
  * Prints given message with a timestamp in the TEST category and the ERROR priority.
  *
  * \param fmt Message to be logged

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -2543,29 +2543,31 @@ void SDLTest_CommonEvent(SDLTest_CommonState *state, SDL_Event *event, int *done
 
 void SDLTest_CommonQuit(SDLTest_CommonState *state)
 {
-    int i;
+    if (state) {
+        int i;
 
-    if (state->targets) {
-        for (i = 0; i < state->num_windows; ++i) {
-            if (state->targets[i]) {
-                SDL_DestroyTexture(state->targets[i]);
+        if (state->targets) {
+            for (i = 0; i < state->num_windows; ++i) {
+                if (state->targets[i]) {
+                    SDL_DestroyTexture(state->targets[i]);
+                }
             }
+            SDL_free(state->targets);
         }
-        SDL_free(state->targets);
-    }
-    if (state->renderers) {
-        for (i = 0; i < state->num_windows; ++i) {
-            if (state->renderers[i]) {
-                SDL_DestroyRenderer(state->renderers[i]);
+        if (state->renderers) {
+            for (i = 0; i < state->num_windows; ++i) {
+                if (state->renderers[i]) {
+                    SDL_DestroyRenderer(state->renderers[i]);
+                }
             }
+            SDL_free(state->renderers);
         }
-        SDL_free(state->renderers);
-    }
-    if (state->windows) {
-        for (i = 0; i < state->num_windows; i++) {
-            SDL_DestroyWindow(state->windows[i]);
+        if (state->windows) {
+            for (i = 0; i < state->num_windows; i++) {
+                SDL_DestroyWindow(state->windows[i]);
+            }
+            SDL_free(state->windows);
         }
-        SDL_free(state->windows);
     }
     SDL_Quit();
     SDLTest_CommonDestroyState(state);


### PR DESCRIPTION
`SDLTest_LogEscapedString` escapes non-printable characters.
Its behavior can be compared to python's `repr`.

For example, the multi-line string
```
Tests whether we can write to stdin and read from stdout
{'succes': true, 'message': 'Success!'}
Yippie ka yee
EOF
```
will be printed as `"Tests whether we can write to stdin and read from stdout\r\n{'succes': true, 'message': 'Success!'}\r\nYippie ka yee\r\nEOF"`

(this is a test case of the SDL_process pr)

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
