### PR TITLE
GPU: Rename struct members and parameters for SDL3 naming conventions

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -964,22 +964,22 @@ typedef struct SDL_GPUViewport
 
 typedef struct SDL_GPUTextureTransferInfo
 {
-    SDL_GPUTransferBuffer *transferBuffer;
-    Uint32 offset;      /* starting location of the image data */
-    Uint32 imagePitch;  /* number of pixels from one row to the next */
-    Uint32 imageHeight; /* number of rows from one layer/depth-slice to the next */
+    SDL_GPUTransferBuffer *transfer_buffer;
+    Uint32 offset;         /* starting location of the image data */
+    Uint32 pixels_per_row; /* number of pixels from one row to the next */
+    Uint32 rows_per_layer; /* number of rows from one layer/depth-slice to the next */
 } SDL_GPUTextureTransferInfo;
 
 typedef struct SDL_GPUTransferBufferLocation
 {
-    SDL_GPUTransferBuffer *transferBuffer;
+    SDL_GPUTransferBuffer *transfer_buffer;
     Uint32 offset;
 } SDL_GPUTransferBufferLocation;
 
 typedef struct SDL_GPUTextureLocation
 {
     SDL_GPUTexture *texture;
-    Uint32 mipLevel;
+    Uint32 mip_level;
     Uint32 layer;
     Uint32 x;
     Uint32 y;
@@ -989,7 +989,7 @@ typedef struct SDL_GPUTextureLocation
 typedef struct SDL_GPUTextureRegion
 {
     SDL_GPUTexture *texture;
-    Uint32 mipLevel;
+    Uint32 mip_level;
     Uint32 layer;
     Uint32 x;
     Uint32 y;
@@ -1002,8 +1002,8 @@ typedef struct SDL_GPUTextureRegion
 typedef struct SDL_GPUBlitRegion
 {
     SDL_GPUTexture *texture;
-    Uint32 mipLevel;
-    Uint32 layerOrDepthPlane;
+    Uint32 mip_level;
+    Uint32 layer_or_depth_plane;
     Uint32 x;
     Uint32 y;
     Uint32 w;
@@ -1023,54 +1023,54 @@ typedef struct SDL_GPUBufferRegion
     Uint32 size;
 } SDL_GPUBufferRegion;
 
-/* Note that the `firstVertex` and `firstInstance` parameters are NOT compatible with
+/* Note that the `first_vertex` and `first_instance` parameters are NOT compatible with
  * built-in vertex/instance ID variables in shaders (for example, SV_VertexID). If
  * your shader depends on these variables, the correlating draw call parameter MUST
  * be 0.
  */
 typedef struct SDL_GPUIndirectDrawCommand
 {
-    Uint32 vertexCount;   /* number of vertices to draw */
-    Uint32 instanceCount; /* number of instances to draw */
-    Uint32 firstVertex;   /* index of the first vertex to draw */
-    Uint32 firstInstance; /* ID of the first instance to draw */
+    Uint32 num_vertices;   /* number of vertices to draw */
+    Uint32 num_instances;  /* number of instances to draw */
+    Uint32 first_vertex;   /* index of the first vertex to draw */
+    Uint32 first_instance; /* ID of the first instance to draw */
 } SDL_GPUIndirectDrawCommand;
 
 typedef struct SDL_GPUIndexedIndirectDrawCommand
 {
-    Uint32 indexCount;    /* number of vertices to draw per instance */
-    Uint32 instanceCount; /* number of instances to draw */
-    Uint32 firstIndex;    /* base index within the index buffer */
-    Sint32 vertexOffset;  /* value added to vertex index before indexing into the vertex buffer */
-    Uint32 firstInstance; /* ID of the first instance to draw */
+    Uint32 num_indices;    /* number of vertices to draw per instance */
+    Uint32 num_instances;  /* number of instances to draw */
+    Uint32 first_index;    /* base index within the index buffer */
+    Sint32 vertex_offset;  /* value added to vertex index before indexing into the vertex buffer */
+    Uint32 first_instance; /* ID of the first instance to draw */
 } SDL_GPUIndexedIndirectDrawCommand;
 
 typedef struct SDL_GPUIndirectDispatchCommand
 {
-    Uint32 groupCountX;
-    Uint32 groupCountY;
-    Uint32 groupCountZ;
+    Uint32 groupcount_x;
+    Uint32 groupcount_y;
+    Uint32 groupcount_z;
 } SDL_GPUIndirectDispatchCommand;
 
 /* State structures */
 
 typedef struct SDL_GPUSamplerCreateInfo
 {
-    SDL_GPUFilter minFilter;
-    SDL_GPUFilter magFilter;
-    SDL_GPUSamplerMipmapMode mipmapMode;
-    SDL_GPUSamplerAddressMode addressModeU;
-    SDL_GPUSamplerAddressMode addressModeV;
-    SDL_GPUSamplerAddressMode addressModeW;
-    float mipLodBias;
-    float maxAnisotropy;
-    SDL_bool anisotropyEnable;
-    SDL_bool compareEnable;
+    SDL_GPUFilter min_filter;
+    SDL_GPUFilter mag_filter;
+    SDL_GPUSamplerMipmapMode mipmap_mode;
+    SDL_GPUSamplerAddressMode address_mode_u;
+    SDL_GPUSamplerAddressMode address_mode_v;
+    SDL_GPUSamplerAddressMode address_mode_w;
+    float mip_lod_bias;
+    float max_anisotropy;
+    SDL_bool enable_anisotropy;
+    SDL_bool enable_compare;
     Uint8 padding1;
     Uint8 padding2;
-    SDL_GPUCompareOp compareOp;
-    float minLod;
-    float maxLod;
+    SDL_GPUCompareOp compare_op;
+    float min_lod;
+    float max_lod;
 
     SDL_PropertiesID props;
 } SDL_GPUSamplerCreateInfo;
@@ -1078,9 +1078,9 @@ typedef struct SDL_GPUSamplerCreateInfo
 typedef struct SDL_GPUVertexBinding
 {
     Uint32 binding;
-    Uint32 stride;
-    SDL_GPUVertexInputRate inputRate;
-    Uint32 instanceStepRate; /* ignored unless inputRate is INSTANCE */
+    Uint32 pitch;
+    SDL_GPUVertexInputRate input_rate;
+    Uint32 instance_step_rate; /* ignored unless input_rate is INSTANCE */
 } SDL_GPUVertexBinding;
 
 typedef struct SDL_GPUVertexAttribute
@@ -1093,46 +1093,46 @@ typedef struct SDL_GPUVertexAttribute
 
 typedef struct SDL_GPUVertexInputState
 {
-    const SDL_GPUVertexBinding *vertexBindings;
-    Uint32 vertexBindingCount;
-    const SDL_GPUVertexAttribute *vertexAttributes;
-    Uint32 vertexAttributeCount;
+    const SDL_GPUVertexBinding *vertex_bindings;
+    Uint32 num_vertex_bindings;
+    const SDL_GPUVertexAttribute *vertex_attributes;
+    Uint32 num_vertex_attributes;
 } SDL_GPUVertexInputState;
 
 typedef struct SDL_GPUStencilOpState
 {
-    SDL_GPUStencilOp failOp;
-    SDL_GPUStencilOp passOp;
-    SDL_GPUStencilOp depthFailOp;
-    SDL_GPUCompareOp compareOp;
+    SDL_GPUStencilOp fail_op;
+    SDL_GPUStencilOp pass_op;
+    SDL_GPUStencilOp depth_fail_op;
+    SDL_GPUCompareOp compare_op;
 } SDL_GPUStencilOpState;
 
 typedef struct SDL_GPUColorAttachmentBlendState
 {
-    SDL_bool blendEnable;
+    SDL_bool enable_blend;
     Uint8 padding1;
     Uint8 padding2;
     Uint8 padding3;
-    SDL_GPUBlendFactor srcColorBlendFactor;
-    SDL_GPUBlendFactor dstColorBlendFactor;
-    SDL_GPUBlendOp colorBlendOp;
-    SDL_GPUBlendFactor srcAlphaBlendFactor;
-    SDL_GPUBlendFactor dstAlphaBlendFactor;
-    SDL_GPUBlendOp alphaBlendOp;
-    SDL_GPUColorComponentFlags colorWriteMask;
+    SDL_GPUBlendFactor src_color_blendfactor;
+    SDL_GPUBlendFactor dst_color_blendfactor;
+    SDL_GPUBlendOp color_blend_op;
+    SDL_GPUBlendFactor src_alpha_blendfactor;
+    SDL_GPUBlendFactor dst_alpha_blendfactor;
+    SDL_GPUBlendOp alpha_blend_op;
+    SDL_GPUColorComponentFlags color_write_mask;
 } SDL_GPUColorAttachmentBlendState;
 
 typedef struct SDL_GPUShaderCreateInfo
 {
-    size_t codeSize;
+    size_t code_size;
     const Uint8 *code;
-    const char *entryPointName;
+    const char *entrypoint_name;
     SDL_GPUShaderFormat format;
     SDL_GPUShaderStage stage;
-    Uint32 samplerCount;
-    Uint32 storageTextureCount;
-    Uint32 storageBufferCount;
-    Uint32 uniformBufferCount;
+    Uint32 num_samplers;
+    Uint32 num_storage_textures;
+    Uint32 num_storage_buffers;
+    Uint32 num_uniform_buffers;
 
     SDL_PropertiesID props;
 } SDL_GPUShaderCreateInfo;
@@ -1141,12 +1141,12 @@ typedef struct SDL_GPUTextureCreateInfo
 {
     SDL_GPUTextureType type;
     SDL_GPUTextureFormat format;
-    SDL_GPUTextureUsageFlags usageFlags;
+    SDL_GPUTextureUsageFlags usage_flags;
     Uint32 width;
     Uint32 height;
-    Uint32 layerCountOrDepth;
-    Uint32 levelCount;
-    SDL_GPUSampleCount sampleCount;
+    Uint32 layer_count_or_depth;
+    Uint32 num_levels;
+    SDL_GPUSampleCount sample_count;
 
     SDL_PropertiesID props;
 } SDL_GPUTextureCreateInfo;
@@ -1160,8 +1160,8 @@ typedef struct SDL_GPUTextureCreateInfo
 
 typedef struct SDL_GPUBufferCreateInfo
 {
-    SDL_GPUBufferUsageFlags usageFlags;
-    Uint32 sizeInBytes;
+    SDL_GPUBufferUsageFlags usage_flags;
+    Uint32 size;
 
     SDL_PropertiesID props;
 } SDL_GPUBufferCreateInfo;
@@ -1169,7 +1169,7 @@ typedef struct SDL_GPUBufferCreateInfo
 typedef struct SDL_GPUTransferBufferCreateInfo
 {
     SDL_GPUTransferBufferUsage usage;
-    Uint32 sizeInBytes;
+    Uint32 size;
 
     SDL_PropertiesID props;
 } SDL_GPUTransferBufferCreateInfo;
@@ -1178,35 +1178,35 @@ typedef struct SDL_GPUTransferBufferCreateInfo
 
 typedef struct SDL_GPURasterizerState
 {
-    SDL_GPUFillMode fillMode;
-    SDL_GPUCullMode cullMode;
+    SDL_GPUFillMode fill_mode;
+    SDL_GPUCullMode cull_mode;
     SDL_GPUFrontFace frontFace;
-    SDL_bool depthBiasEnable;
+    SDL_bool enable_depth_bias;
     Uint8 padding1;
     Uint8 padding2;
     Uint8 padding3;
-    float depthBiasConstantFactor;
-    float depthBiasClamp;
-    float depthBiasSlopeFactor;
+    float depth_bias_constant_factor;
+    float depth_bias_clamp;
+    float depth_bias_slope_factor;
 } SDL_GPURasterizerState;
 
 typedef struct SDL_GPUMultisampleState
 {
-    SDL_GPUSampleCount sampleCount;
-    Uint32 sampleMask;
+    SDL_GPUSampleCount sample_count;
+    Uint32 sample_mask;
 } SDL_GPUMultisampleState;
 
 typedef struct SDL_GPUDepthStencilState
 {
-    SDL_bool depthTestEnable;
-    SDL_bool depthWriteEnable;
-    SDL_bool stencilTestEnable;
+    SDL_bool enable_depth_test;
+    SDL_bool enable_depth_write;
+    SDL_bool enable_stencil_test;
     Uint8 padding1;
-    SDL_GPUCompareOp compareOp;
-    SDL_GPUStencilOpState backStencilState;
-    SDL_GPUStencilOpState frontStencilState;
-    Uint8 compareMask;
-    Uint8 writeMask;
+    SDL_GPUCompareOp compare_op;
+    SDL_GPUStencilOpState back_stencil_state;
+    SDL_GPUStencilOpState front_stencil_state;
+    Uint8 compare_mask;
+    Uint8 write_mask;
     Uint8 padding2;
     Uint8 padding3;
 } SDL_GPUDepthStencilState;
@@ -1214,48 +1214,48 @@ typedef struct SDL_GPUDepthStencilState
 typedef struct SDL_GPUColorAttachmentDescription
 {
     SDL_GPUTextureFormat format;
-    SDL_GPUColorAttachmentBlendState blendState;
+    SDL_GPUColorAttachmentBlendState blend_state;
 } SDL_GPUColorAttachmentDescription;
 
 typedef struct SDL_GPUGraphicsPipelineAttachmentInfo
 {
-    const SDL_GPUColorAttachmentDescription *colorAttachmentDescriptions;
-    Uint32 colorAttachmentCount;
-    SDL_bool hasDepthStencilAttachment;
+    const SDL_GPUColorAttachmentDescription *color_attachment_descriptions;
+    Uint32 num_color_attachments;
+    SDL_bool has_depth_stencil_attachment;
     Uint8 padding1;
     Uint8 padding2;
     Uint8 padding3;
-    SDL_GPUTextureFormat depthStencilFormat;
+    SDL_GPUTextureFormat depth_stencil_format;
 } SDL_GPUGraphicsPipelineAttachmentInfo;
 
 typedef struct SDL_GPUGraphicsPipelineCreateInfo
 {
-    SDL_GPUShader *vertexShader;
-    SDL_GPUShader *fragmentShader;
-    SDL_GPUVertexInputState vertexInputState;
-    SDL_GPUPrimitiveType primitiveType;
-    SDL_GPURasterizerState rasterizerState;
-    SDL_GPUMultisampleState multisampleState;
-    SDL_GPUDepthStencilState depthStencilState;
-    SDL_GPUGraphicsPipelineAttachmentInfo attachmentInfo;
+    SDL_GPUShader *vertex_shader;
+    SDL_GPUShader *fragment_shader;
+    SDL_GPUVertexInputState vertex_input_state;
+    SDL_GPUPrimitiveType primitive_type;
+    SDL_GPURasterizerState rasterizer_state;
+    SDL_GPUMultisampleState multisample_state;
+    SDL_GPUDepthStencilState depth_stencil_state;
+    SDL_GPUGraphicsPipelineAttachmentInfo attachment_info;
 
     SDL_PropertiesID props;
 } SDL_GPUGraphicsPipelineCreateInfo;
 
 typedef struct SDL_GPUComputePipelineCreateInfo
 {
-    size_t codeSize;
+    size_t code_size;
     const Uint8 *code;
-    const char *entryPointName;
+    const char *entrypoint_name;
     SDL_GPUShaderFormat format;
-    Uint32 readOnlyStorageTextureCount;
-    Uint32 readOnlyStorageBufferCount;
-    Uint32 writeOnlyStorageTextureCount;
-    Uint32 writeOnlyStorageBufferCount;
-    Uint32 uniformBufferCount;
-    Uint32 threadCountX;
-    Uint32 threadCountY;
-    Uint32 threadCountZ;
+    Uint32 num_readonly_storage_textures;
+    Uint32 num_readonly_storage_buffers;
+    Uint32 num_writeonly_storage_textures;
+    Uint32 num_writeonly_storage_buffers;
+    Uint32 num_uniform_buffers;
+    Uint32 threadcount_x;
+    Uint32 threadcount_y;
+    Uint32 threadcount_z;
 
     SDL_PropertiesID props;
 } SDL_GPUComputePipelineCreateInfo;
@@ -1264,11 +1264,11 @@ typedef struct SDL_GPUColorAttachmentInfo
 {
     /* The texture that will be used as a color attachment by a render pass. */
     SDL_GPUTexture *texture;
-    Uint32 mipLevel;
-    Uint32 layerOrDepthPlane; /* For 3D textures, you can bind an individual depth plane as an attachment. */
+    Uint32 mip_level;
+    Uint32 layer_or_depth_plane; /* For 3D textures, you can bind an individual depth plane as an attachment. */
 
     /* Can be ignored by RenderPass if CLEAR is not used */
-    SDL_FColor clearColor;
+    SDL_FColor clear_color;
 
     /* Determines what is done with the texture at the beginning of the render pass.
      *
@@ -1282,7 +1282,7 @@ typedef struct SDL_GPUColorAttachmentInfo
      *     The driver will do whatever it wants with the texture memory.
      *     This is a good option if you know that every single pixel will be touched in the render pass.
      */
-    SDL_GPULoadOp loadOp;
+    SDL_GPULoadOp load_op;
 
     /* Determines what is done with the texture at the end of the render pass.
      *
@@ -1293,9 +1293,9 @@ typedef struct SDL_GPUColorAttachmentInfo
      *     The driver will do whatever it wants with the texture memory.
      *     This is often a good option for depth/stencil textures.
      */
-    SDL_GPUStoreOp storeOp;
+    SDL_GPUStoreOp store_op;
 
-    /* if SDL_TRUE, cycles the texture if the texture is bound and loadOp is not LOAD */
+    /* if SDL_TRUE, cycles the texture if the texture is bound and load_op is not LOAD */
     SDL_bool cycle;
     Uint8 padding1;
     Uint8 padding2;
@@ -1308,7 +1308,7 @@ typedef struct SDL_GPUDepthStencilAttachmentInfo
     SDL_GPUTexture *texture;
 
     /* Can be ignored by the render pass if CLEAR is not used */
-    SDL_GPUDepthStencilValue depthStencilClearValue;
+    SDL_GPUDepthStencilValue clear_value;
 
     /* Determines what is done with the depth values at the beginning of the render pass.
      *
@@ -1322,7 +1322,7 @@ typedef struct SDL_GPUDepthStencilAttachmentInfo
      *     The driver will do whatever it wants with the memory.
      *     This is a good option if you know that every single pixel will be touched in the render pass.
      */
-    SDL_GPULoadOp loadOp;
+    SDL_GPULoadOp load_op;
 
     /* Determines what is done with the depth values at the end of the render pass.
      *
@@ -1333,7 +1333,7 @@ typedef struct SDL_GPUDepthStencilAttachmentInfo
      *     The driver will do whatever it wants with the texture memory.
      *     This is often a good option for depth/stencil textures.
      */
-    SDL_GPUStoreOp storeOp;
+    SDL_GPUStoreOp store_op;
 
     /* Determines what is done with the stencil values at the beginning of the render pass.
      *
@@ -1347,7 +1347,7 @@ typedef struct SDL_GPUDepthStencilAttachmentInfo
      *     The driver will do whatever it wants with the memory.
      *     This is a good option if you know that every single pixel will be touched in the render pass.
      */
-    SDL_GPULoadOp stencilLoadOp;
+    SDL_GPULoadOp stencil_load_op;
 
     /* Determines what is done with the stencil values at the end of the render pass.
      *
@@ -1358,7 +1358,7 @@ typedef struct SDL_GPUDepthStencilAttachmentInfo
      *     The driver will do whatever it wants with the texture memory.
      *     This is often a good option for depth/stencil textures.
      */
-    SDL_GPUStoreOp stencilStoreOp;
+    SDL_GPUStoreOp stencil_store_op;
 
     /* if SDL_TRUE, cycles the texture if the texture is bound and any load ops are not LOAD */
     SDL_bool cycle;
@@ -1395,7 +1395,7 @@ typedef struct SDL_GPUStorageBufferWriteOnlyBinding
 typedef struct SDL_GPUStorageTextureWriteOnlyBinding
 {
     SDL_GPUTexture *texture;
-    Uint32 mipLevel;
+    Uint32 mip_level;
     Uint32 layer;
 
     /* if SDL_TRUE, cycles the texture if the texture is bound. */
@@ -1412,9 +1412,9 @@ typedef struct SDL_GPUStorageTextureWriteOnlyBinding
 /**
  * Creates a GPU context.
  *
- * \param formatFlags a bitflag indicating which shader formats the app is
+ * \param format_flags a bitflag indicating which shader formats the app is
  *                    able to provide.
- * \param debugMode enable debug mode properties and validations.
+ * \param debug_mode enable debug mode properties and validations.
  * \param name the preferred GPU driver, or NULL to let SDL pick the optimal
  *             driver.
  * \returns a GPU context on success or NULL on failure.
@@ -1425,8 +1425,8 @@ typedef struct SDL_GPUStorageTextureWriteOnlyBinding
  * \sa SDL_DestroyGPUDevice
  */
 extern SDL_DECLSPEC SDL_GPUDevice *SDLCALL SDL_CreateGPUDevice(
-    SDL_GPUShaderFormat formatFlags,
-    SDL_bool debugMode,
+    SDL_GPUShaderFormat format_flags,
+    SDL_bool debug_mode,
     const char *name);
 
 /**
@@ -1542,8 +1542,7 @@ extern SDL_DECLSPEC SDL_GPUDriver SDLCALL SDL_GetGPUDriver(SDL_GPUDevice *device
  *   textures
  *
  * \param device a GPU Context.
- * \param computePipelineCreateInfo a struct describing the state of the
- *                                  requested compute pipeline.
+ * \param createinfo a struct describing the state of the compute pipeline to create.
  * \returns a compute pipeline object on success, or NULL on failure.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1553,14 +1552,13 @@ extern SDL_DECLSPEC SDL_GPUDriver SDLCALL SDL_GetGPUDriver(SDL_GPUDevice *device
  */
 extern SDL_DECLSPEC SDL_GPUComputePipeline *SDLCALL SDL_CreateGPUComputePipeline(
     SDL_GPUDevice *device,
-    const SDL_GPUComputePipelineCreateInfo *computePipelineCreateInfo);
+    const SDL_GPUComputePipelineCreateInfo *createinfo);
 
 /**
  * Creates a pipeline object to be used in a graphics workflow.
  *
  * \param device a GPU Context.
- * \param pipelineCreateInfo a struct describing the state of the desired
- *                           graphics pipeline.
+ * \param createinfo a struct describing the state of the graphics pipeline to create.
  * \returns a graphics pipeline object on success, or NULL on failure.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1571,15 +1569,14 @@ extern SDL_DECLSPEC SDL_GPUComputePipeline *SDLCALL SDL_CreateGPUComputePipeline
  */
 extern SDL_DECLSPEC SDL_GPUGraphicsPipeline *SDLCALL SDL_CreateGPUGraphicsPipeline(
     SDL_GPUDevice *device,
-    const SDL_GPUGraphicsPipelineCreateInfo *pipelineCreateInfo);
+    const SDL_GPUGraphicsPipelineCreateInfo *createinfo);
 
 /**
  * Creates a sampler object to be used when binding textures in a graphics
  * workflow.
  *
  * \param device a GPU Context.
- * \param samplerCreateInfo a struct describing the state of the desired
- *                          sampler.
+ * \param createinfo a struct describing the state of the sampler to create.
  * \returns a sampler object on success, or NULL on failure.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1590,7 +1587,7 @@ extern SDL_DECLSPEC SDL_GPUGraphicsPipeline *SDLCALL SDL_CreateGPUGraphicsPipeli
  */
 extern SDL_DECLSPEC SDL_GPUSampler *SDLCALL SDL_CreateGPUSampler(
     SDL_GPUDevice *device,
-    const SDL_GPUSamplerCreateInfo *samplerCreateInfo);
+    const SDL_GPUSamplerCreateInfo *createinfo);
 
 /**
  * Creates a shader to be used when creating a graphics pipeline.
@@ -1648,8 +1645,7 @@ extern SDL_DECLSPEC SDL_GPUSampler *SDLCALL SDL_CreateGPUSampler(
  *   information from the SDL_GPUPipeline.
  *
  * \param device a GPU Context.
- * \param shaderCreateInfo a struct describing the state of the desired
- *                         shader.
+ * \param createinfo a struct describing the state of the shader to create.
  * \returns a shader object on success, or NULL on failure.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1659,7 +1655,7 @@ extern SDL_DECLSPEC SDL_GPUSampler *SDLCALL SDL_CreateGPUSampler(
  */
 extern SDL_DECLSPEC SDL_GPUShader *SDLCALL SDL_CreateGPUShader(
     SDL_GPUDevice *device,
-    const SDL_GPUShaderCreateInfo *shaderCreateInfo);
+    const SDL_GPUShaderCreateInfo *createinfo);
 
 /**
  * Creates a texture object to be used in graphics or compute workflows.
@@ -1675,8 +1671,7 @@ extern SDL_DECLSPEC SDL_GPUShader *SDLCALL SDL_CreateGPUShader(
  * count.
  *
  * \param device a GPU Context.
- * \param textureCreateInfo a struct describing the state of the texture to
- *                          create.
+ * \param createinfo a struct describing the state of the texture to create.
  * \returns a texture object on success, or NULL on failure.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1694,7 +1689,7 @@ extern SDL_DECLSPEC SDL_GPUShader *SDLCALL SDL_CreateGPUShader(
  */
 extern SDL_DECLSPEC SDL_GPUTexture *SDLCALL SDL_CreateGPUTexture(
     SDL_GPUDevice *device,
-    const SDL_GPUTextureCreateInfo *textureCreateInfo);
+    const SDL_GPUTextureCreateInfo *createinfo);
 
 /**
  * Creates a buffer object to be used in graphics or compute workflows.
@@ -1706,8 +1701,7 @@ extern SDL_DECLSPEC SDL_GPUTexture *SDLCALL SDL_CreateGPUTexture(
  * buffer cannot have both the VERTEX and INDEX flags.
  *
  * \param device a GPU Context.
- * \param bufferCreateInfo a struct describing the state of the buffer to
- *                         create.
+ * \param createinfo a struct describing the state of the buffer to create.
  * \returns a buffer object on success, or NULL on failure.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1728,15 +1722,14 @@ extern SDL_DECLSPEC SDL_GPUTexture *SDLCALL SDL_CreateGPUTexture(
  */
 extern SDL_DECLSPEC SDL_GPUBuffer *SDLCALL SDL_CreateGPUBuffer(
     SDL_GPUDevice *device,
-    const SDL_GPUBufferCreateInfo *bufferCreateInfo);
+    const SDL_GPUBufferCreateInfo *createinfo);
 
 /**
  * Creates a transfer buffer to be used when uploading to or downloading from
  * graphics resources.
  *
  * \param device a GPU Context.
- * \param transferBufferCreateInfo a struct describing the state of the
- *                                 transfer buffer to create.
+ * \param createinfo a struct describing the state of the transfer buffer to create.
  * \returns a transfer buffer on success, or NULL on failure.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1749,7 +1742,7 @@ extern SDL_DECLSPEC SDL_GPUBuffer *SDLCALL SDL_CreateGPUBuffer(
  */
 extern SDL_DECLSPEC SDL_GPUTransferBuffer *SDLCALL SDL_CreateGPUTransferBuffer(
     SDL_GPUDevice *device,
-    const SDL_GPUTransferBufferCreateInfo *transferBufferCreateInfo);
+    const SDL_GPUTransferBufferCreateInfo *createinfo);
 
 /* Debug Naming */
 
@@ -1790,13 +1783,13 @@ extern SDL_DECLSPEC void SDLCALL SDL_SetGPUTextureName(
  *
  * Useful for debugging.
  *
- * \param commandBuffer a command buffer.
+ * \param command_buffer a command buffer.
  * \param text a UTF-8 string constant to insert as the label.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_InsertGPUDebugLabel(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const char *text);
 
 /**
@@ -1813,7 +1806,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_InsertGPUDebugLabel(
  * pass rather than the command buffer. For best results, if you push a debug
  * group during a pass, always pop it in the same pass.
  *
- * \param commandBuffer a command buffer.
+ * \param command_buffer a command buffer.
  * \param name a UTF-8 string constant that names the group.
  *
  * \since This function is available since SDL 3.0.0.
@@ -1821,20 +1814,20 @@ extern SDL_DECLSPEC void SDLCALL SDL_InsertGPUDebugLabel(
  * \sa SDL_PopGPUDebugGroup
  */
 extern SDL_DECLSPEC void SDLCALL SDL_PushGPUDebugGroup(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const char *name);
 
 /**
  * Ends the most-recently pushed debug group.
  *
- * \param commandBuffer a command buffer.
+ * \param command_buffer a command buffer.
  *
  * \since This function is available since SDL 3.0.0.
  *
  * \sa SDL_PushGPUDebugGroup
  */
 extern SDL_DECLSPEC void SDLCALL SDL_PopGPUDebugGroup(
-    SDL_GPUCommandBuffer *commandBuffer);
+    SDL_GPUCommandBuffer *command_buffer);
 
 /* Disposal */
 
@@ -1886,13 +1879,13 @@ extern SDL_DECLSPEC void SDLCALL SDL_ReleaseGPUBuffer(
  * You must not reference the transfer buffer after calling this function.
  *
  * \param device a GPU context.
- * \param transferBuffer a transfer buffer to be destroyed.
+ * \param transfer_buffer a transfer buffer to be destroyed.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_ReleaseGPUTransferBuffer(
     SDL_GPUDevice *device,
-    SDL_GPUTransferBuffer *transferBuffer);
+    SDL_GPUTransferBuffer *transfer_buffer);
 
 /**
  * Frees the given compute pipeline as soon as it is safe to do so.
@@ -1900,13 +1893,13 @@ extern SDL_DECLSPEC void SDLCALL SDL_ReleaseGPUTransferBuffer(
  * You must not reference the compute pipeline after calling this function.
  *
  * \param device a GPU context.
- * \param computePipeline a compute pipeline to be destroyed.
+ * \param compute_pipeline a compute pipeline to be destroyed.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_ReleaseGPUComputePipeline(
     SDL_GPUDevice *device,
-    SDL_GPUComputePipeline *computePipeline);
+    SDL_GPUComputePipeline *compute_pipeline);
 
 /**
  * Frees the given shader as soon as it is safe to do so.
@@ -1928,13 +1921,13 @@ extern SDL_DECLSPEC void SDLCALL SDL_ReleaseGPUShader(
  * You must not reference the graphics pipeline after calling this function.
  *
  * \param device a GPU context.
- * \param graphicsPipeline a graphics pipeline to be destroyed.
+ * \param graphics_pipeline a graphics pipeline to be destroyed.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_ReleaseGPUGraphicsPipeline(
     SDL_GPUDevice *device,
-    SDL_GPUGraphicsPipeline *graphicsPipeline);
+    SDL_GPUGraphicsPipeline *graphics_pipeline);
 
 /**
  * Acquire a command buffer.
@@ -1980,54 +1973,54 @@ extern SDL_DECLSPEC SDL_GPUCommandBuffer *SDLCALL SDL_AcquireGPUCommandBuffer(
  *
  * Subsequent draw calls will use this uniform data.
  *
- * \param commandBuffer a command buffer.
- * \param slotIndex the vertex uniform slot to push data to.
+ * \param command_buffer a command buffer.
+ * \param slot_index the vertex uniform slot to push data to.
  * \param data client data to write.
- * \param dataLengthInBytes the length of the data to write.
+ * \param length the length of the data to write.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_PushGPUVertexUniformData(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 slotIndex,
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 slot_index,
     const void *data,
-    Uint32 dataLengthInBytes);
+    Uint32 length);
 
 /**
  * Pushes data to a fragment uniform slot on the command buffer.
  *
  * Subsequent draw calls will use this uniform data.
  *
- * \param commandBuffer a command buffer.
- * \param slotIndex the fragment uniform slot to push data to.
+ * \param command_buffer a command buffer.
+ * \param slot_index the fragment uniform slot to push data to.
  * \param data client data to write.
- * \param dataLengthInBytes the length of the data to write.
+ * \param length the length of the data to write.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_PushGPUFragmentUniformData(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 slotIndex,
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 slot_index,
     const void *data,
-    Uint32 dataLengthInBytes);
+    Uint32 length);
 
 /**
  * Pushes data to a uniform slot on the command buffer.
  *
  * Subsequent draw calls will use this uniform data.
  *
- * \param commandBuffer a command buffer.
- * \param slotIndex the uniform slot to push data to.
+ * \param command_buffer a command buffer.
+ * \param slot_index the uniform slot to push data to.
  * \param data client data to write.
- * \param dataLengthInBytes the length of the data to write.
+ * \param length the length of the data to write.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_PushGPUComputeUniformData(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 slotIndex,
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 slot_index,
     const void *data,
-    Uint32 dataLengthInBytes);
+    Uint32 length);
 
 /*
  * A NOTE ON CYCLING
@@ -2081,12 +2074,12 @@ extern SDL_DECLSPEC void SDLCALL SDL_PushGPUComputeUniformData(
  * is called. You cannot begin another render pass, or begin a compute pass or
  * copy pass until you have ended the render pass.
  *
- * \param commandBuffer a command buffer.
- * \param colorAttachmentInfos an array of texture subresources with
+ * \param command_buffer a command buffer.
+ * \param color_attachment_infos an array of texture subresources with
  *                             corresponding clear values and load/store ops.
- * \param colorAttachmentCount the number of color attachments in the
- *                             colorAttachmentInfos array.
- * \param depthStencilAttachmentInfo a texture subresource with corresponding
+ * \param num_color_attachments the number of color attachments in the
+ *                             color_attachment_infos array.
+ * \param depth_stencil_attachment_info a texture subresource with corresponding
  *                                   clear value and load/store ops, may be
  *                                   NULL.
  * \returns a render pass handle.
@@ -2096,54 +2089,54 @@ extern SDL_DECLSPEC void SDLCALL SDL_PushGPUComputeUniformData(
  * \sa SDL_EndGPURenderPass
  */
 extern SDL_DECLSPEC SDL_GPURenderPass *SDLCALL SDL_BeginGPURenderPass(
-    SDL_GPUCommandBuffer *commandBuffer,
-    const SDL_GPUColorAttachmentInfo *colorAttachmentInfos,
-    Uint32 colorAttachmentCount,
-    const SDL_GPUDepthStencilAttachmentInfo *depthStencilAttachmentInfo);
+    SDL_GPUCommandBuffer *command_buffer,
+    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
+    Uint32 num_color_attachments,
+    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info);
 
 /**
  * Binds a graphics pipeline on a render pass to be used in rendering.
  *
  * A graphics pipeline must be bound before making any draw calls.
  *
- * \param renderPass a render pass handle.
- * \param graphicsPipeline the graphics pipeline to bind.
+ * \param render_pass a render pass handle.
+ * \param graphics_pipeline the graphics pipeline to bind.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_BindGPUGraphicsPipeline(
-    SDL_GPURenderPass *renderPass,
-    SDL_GPUGraphicsPipeline *graphicsPipeline);
+    SDL_GPURenderPass *render_pass,
+    SDL_GPUGraphicsPipeline *graphics_pipeline);
 
 /**
  * Sets the current viewport state on a command buffer.
  *
- * \param renderPass a render pass handle.
+ * \param render_pass a render pass handle.
  * \param viewport the viewport to set.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_SetGPUViewport(
-    SDL_GPURenderPass *renderPass,
+    SDL_GPURenderPass *render_pass,
     const SDL_GPUViewport *viewport);
 
 /**
  * Sets the current scissor state on a command buffer.
  *
- * \param renderPass a render pass handle.
+ * \param render_pass a render pass handle.
  * \param scissor the scissor area to set.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_SetGPUScissor(
-    SDL_GPURenderPass *renderPass,
+    SDL_GPURenderPass *render_pass,
     const SDL_Rect *scissor);
 
 /**
  * Sets the current blend constants on a command buffer.
  *
- * \param renderPass a render pass handle.
- * \param blendConstants the blend constant color.
+ * \param render_pass a render pass handle.
+ * \param blend_constants the blend constant color.
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -2151,74 +2144,74 @@ extern SDL_DECLSPEC void SDLCALL SDL_SetGPUScissor(
  * \sa SDL_GPU_BLENDFACTOR_ONE_MINUS_CONSTANT_COLOR
  */
 extern SDL_DECLSPEC void SDLCALL SDL_SetGPUBlendConstants(
-    SDL_GPURenderPass *renderPass,
-    SDL_FColor blendConstants);
+    SDL_GPURenderPass *render_pass,
+    SDL_FColor blend_constants);
 
 /**
  * Sets the current stencil reference value on a command buffer.
  *
- * \param renderPass a render pass handle.
+ * \param render_pass a render pass handle.
  * \param reference the stencil reference value to set.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_SetGPUStencilReference(
-    SDL_GPURenderPass *renderPass,
+    SDL_GPURenderPass *render_pass,
     Uint8 reference);
 
 /**
  * Binds vertex buffers on a command buffer for use with subsequent draw
  * calls.
  *
- * \param renderPass a render pass handle.
- * \param firstBinding the starting bind point for the vertex buffers.
- * \param pBindings an array of SDL_GPUBufferBinding structs containing vertex
+ * \param render_pass a render pass handle.
+ * \param first_binding the starting bind point for the vertex buffers.
+ * \param bindings an array of SDL_GPUBufferBinding structs containing vertex
  *                  buffers and offset values.
- * \param bindingCount the number of bindings in the pBindings array.
+ * \param num_bindings the number of bindings in the bindings array.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_BindGPUVertexBuffers(
-    SDL_GPURenderPass *renderPass,
-    Uint32 firstBinding,
-    const SDL_GPUBufferBinding *pBindings,
-    Uint32 bindingCount);
+    SDL_GPURenderPass *render_pass,
+    Uint32 first_binding,
+    const SDL_GPUBufferBinding *bindings,
+    Uint32 num_bindings);
 
 /**
  * Binds an index buffer on a command buffer for use with subsequent draw
  * calls.
  *
- * \param renderPass a render pass handle.
+ * \param render_pass a render pass handle.
  * \param pBinding a pointer to a struct containing an index buffer and
  *                 offset.
- * \param indexElementSize whether the index values in the buffer are 16- or
+ * \param index_element_size whether the index values in the buffer are 16- or
  *                         32-bit.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_BindGPUIndexBuffer(
-    SDL_GPURenderPass *renderPass,
+    SDL_GPURenderPass *render_pass,
     const SDL_GPUBufferBinding *pBinding,
-    SDL_GPUIndexElementSize indexElementSize);
+    SDL_GPUIndexElementSize index_element_size);
 
 /**
  * Binds texture-sampler pairs for use on the vertex shader.
  *
  * The textures must have been created with SDL_GPU_TEXTUREUSAGE_SAMPLER.
  *
- * \param renderPass a render pass handle.
- * \param firstSlot the vertex sampler slot to begin binding from.
- * \param textureSamplerBindings an array of texture-sampler binding structs.
- * \param bindingCount the number of texture-sampler pairs to bind from the
+ * \param render_pass a render pass handle.
+ * \param first_slot the vertex sampler slot to begin binding from.
+ * \param texture_sampler_bindings an array of texture-sampler binding structs.
+ * \param num_bindings the number of texture-sampler pairs to bind from the
  *                     array.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_BindGPUVertexSamplers(
-    SDL_GPURenderPass *renderPass,
-    Uint32 firstSlot,
-    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
-    Uint32 bindingCount);
+    SDL_GPURenderPass *render_pass,
+    Uint32 first_slot,
+    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
+    Uint32 num_bindings);
 
 /**
  * Binds storage textures for use on the vertex shader.
@@ -2226,18 +2219,18 @@ extern SDL_DECLSPEC void SDLCALL SDL_BindGPUVertexSamplers(
  * These textures must have been created with
  * SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ.
  *
- * \param renderPass a render pass handle.
- * \param firstSlot the vertex storage texture slot to begin binding from.
- * \param storageTextures an array of storage textures.
- * \param bindingCount the number of storage texture to bind from the array.
+ * \param render_pass a render pass handle.
+ * \param first_slot the vertex storage texture slot to begin binding from.
+ * \param storage_textures an array of storage textures.
+ * \param num_bindings the number of storage texture to bind from the array.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_BindGPUVertexStorageTextures(
-    SDL_GPURenderPass *renderPass,
-    Uint32 firstSlot,
-    SDL_GPUTexture *const *storageTextures,
-    Uint32 bindingCount);
+    SDL_GPURenderPass *render_pass,
+    Uint32 first_slot,
+    SDL_GPUTexture *const *storage_textures,
+    Uint32 num_bindings);
 
 /**
  * Binds storage buffers for use on the vertex shader.
@@ -2245,37 +2238,37 @@ extern SDL_DECLSPEC void SDLCALL SDL_BindGPUVertexStorageTextures(
  * These buffers must have been created with
  * SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ.
  *
- * \param renderPass a render pass handle.
- * \param firstSlot the vertex storage buffer slot to begin binding from.
- * \param storageBuffers an array of buffers.
- * \param bindingCount the number of buffers to bind from the array.
+ * \param render_pass a render pass handle.
+ * \param first_slot the vertex storage buffer slot to begin binding from.
+ * \param storage_buffers an array of buffers.
+ * \param num_bindings the number of buffers to bind from the array.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_BindGPUVertexStorageBuffers(
-    SDL_GPURenderPass *renderPass,
-    Uint32 firstSlot,
-    SDL_GPUBuffer *const *storageBuffers,
-    Uint32 bindingCount);
+    SDL_GPURenderPass *render_pass,
+    Uint32 first_slot,
+    SDL_GPUBuffer *const *storage_buffers,
+    Uint32 num_bindings);
 
 /**
  * Binds texture-sampler pairs for use on the fragment shader.
  *
  * The textures must have been created with SDL_GPU_TEXTUREUSAGE_SAMPLER.
  *
- * \param renderPass a render pass handle.
- * \param firstSlot the fragment sampler slot to begin binding from.
- * \param textureSamplerBindings an array of texture-sampler binding structs.
- * \param bindingCount the number of texture-sampler pairs to bind from the
+ * \param render_pass a render pass handle.
+ * \param first_slot the fragment sampler slot to begin binding from.
+ * \param texture_sampler_bindings an array of texture-sampler binding structs.
+ * \param num_bindings the number of texture-sampler pairs to bind from the
  *                     array.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_BindGPUFragmentSamplers(
-    SDL_GPURenderPass *renderPass,
-    Uint32 firstSlot,
-    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
-    Uint32 bindingCount);
+    SDL_GPURenderPass *render_pass,
+    Uint32 first_slot,
+    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
+    Uint32 num_bindings);
 
 /**
  * Binds storage textures for use on the fragment shader.
@@ -2283,18 +2276,18 @@ extern SDL_DECLSPEC void SDLCALL SDL_BindGPUFragmentSamplers(
  * These textures must have been created with
  * SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ.
  *
- * \param renderPass a render pass handle.
- * \param firstSlot the fragment storage texture slot to begin binding from.
- * \param storageTextures an array of storage textures.
- * \param bindingCount the number of storage textures to bind from the array.
+ * \param render_pass a render pass handle.
+ * \param first_slot the fragment storage texture slot to begin binding from.
+ * \param storage_textures an array of storage textures.
+ * \param num_bindings the number of storage textures to bind from the array.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_BindGPUFragmentStorageTextures(
-    SDL_GPURenderPass *renderPass,
-    Uint32 firstSlot,
-    SDL_GPUTexture *const *storageTextures,
-    Uint32 bindingCount);
+    SDL_GPURenderPass *render_pass,
+    Uint32 first_slot,
+    SDL_GPUTexture *const *storage_textures,
+    Uint32 num_bindings);
 
 /**
  * Binds storage buffers for use on the fragment shader.
@@ -2302,18 +2295,18 @@ extern SDL_DECLSPEC void SDLCALL SDL_BindGPUFragmentStorageTextures(
  * These buffers must have been created with
  * SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ.
  *
- * \param renderPass a render pass handle.
- * \param firstSlot the fragment storage buffer slot to begin binding from.
- * \param storageBuffers an array of storage buffers.
- * \param bindingCount the number of storage buffers to bind from the array.
+ * \param render_pass a render pass handle.
+ * \param first_slot the fragment storage buffer slot to begin binding from.
+ * \param storage_buffers an array of storage buffers.
+ * \param num_bindings the number of storage buffers to bind from the array.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_BindGPUFragmentStorageBuffers(
-    SDL_GPURenderPass *renderPass,
-    Uint32 firstSlot,
-    SDL_GPUBuffer *const *storageBuffers,
-    Uint32 bindingCount);
+    SDL_GPURenderPass *render_pass,
+    Uint32 first_slot,
+    SDL_GPUBuffer *const *storage_buffers,
+    Uint32 num_bindings);
 
 /* Drawing */
 
@@ -2323,53 +2316,53 @@ extern SDL_DECLSPEC void SDLCALL SDL_BindGPUFragmentStorageBuffers(
  *
  * You must not call this function before binding a graphics pipeline.
  *
- * Note that the `firstVertex` and `firstInstance` parameters are NOT
+ * Note that the `first_vertex` and `first_instance` parameters are NOT
  * compatible with built-in vertex/instance ID variables in shaders (for
  * example, SV_VertexID). If your shader depends on these variables, the
  * correlating draw call parameter MUST be 0.
  *
- * \param renderPass a render pass handle.
- * \param indexCount the number of vertices to draw per instance.
- * \param instanceCount the number of instances to draw.
- * \param firstIndex the starting index within the index buffer.
- * \param vertexOffset value added to vertex index before indexing into the
+ * \param render_pass a render pass handle.
+ * \param num_indices the number of vertices to draw per instance.
+ * \param num_instances the number of instances to draw.
+ * \param first_index the starting index within the index buffer.
+ * \param vertex_offset value added to vertex index before indexing into the
  *                     vertex buffer.
- * \param firstInstance the ID of the first instance to draw.
+ * \param first_instance the ID of the first instance to draw.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_DrawGPUIndexedPrimitives(
-    SDL_GPURenderPass *renderPass,
-    Uint32 indexCount,
-    Uint32 instanceCount,
-    Uint32 firstIndex,
-    Sint32 vertexOffset,
-    Uint32 firstInstance);
+    SDL_GPURenderPass *render_pass,
+    Uint32 num_indices,
+    Uint32 num_instances,
+    Uint32 first_index,
+    Sint32 vertex_offset,
+    Uint32 first_instance);
 
 /**
  * Draws data using bound graphics state.
  *
  * You must not call this function before binding a graphics pipeline.
  *
- * Note that the `firstVertex` and `firstInstance` parameters are NOT
+ * Note that the `first_vertex` and `first_instance` parameters are NOT
  * compatible with built-in vertex/instance ID variables in shaders (for
  * example, SV_VertexID). If your shader depends on these variables, the
  * correlating draw call parameter MUST be 0.
  *
- * \param renderPass a render pass handle.
- * \param vertexCount the number of vertices to draw.
- * \param instanceCount the number of instances that will be drawn.
- * \param firstVertex the index of the first vertex to draw.
- * \param firstInstance the ID of the first instance to draw.
+ * \param render_pass a render pass handle.
+ * \param num_vertices the number of vertices to draw.
+ * \param num_instances the number of instances that will be drawn.
+ * \param first_vertex the index of the first vertex to draw.
+ * \param first_instance the ID of the first instance to draw.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_DrawGPUPrimitives(
-    SDL_GPURenderPass *renderPass,
-    Uint32 vertexCount,
-    Uint32 instanceCount,
-    Uint32 firstVertex,
-    Uint32 firstInstance);
+    SDL_GPURenderPass *render_pass,
+    Uint32 num_vertices,
+    Uint32 num_instances,
+    Uint32 first_vertex,
+    Uint32 first_instance);
 
 /**
  * Draws data using bound graphics state and with draw parameters set from a
@@ -2378,21 +2371,21 @@ extern SDL_DECLSPEC void SDLCALL SDL_DrawGPUPrimitives(
  * The buffer layout should match the layout of SDL_GPUIndirectDrawCommand.
  * You must not call this function before binding a graphics pipeline.
  *
- * \param renderPass a render pass handle.
+ * \param render_pass a render pass handle.
  * \param buffer a buffer containing draw parameters.
- * \param offsetInBytes the offset to start reading from the draw buffer.
- * \param drawCount the number of draw parameter sets that should be read from
+ * \param offset the offset to start reading from the draw buffer.
+ * \param draw_count the number of draw parameter sets that should be read from
  *                  the draw buffer.
- * \param stride the byte stride between sets of draw parameters.
+ * \param pitch the byte pitch between sets of draw parameters.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_DrawGPUPrimitivesIndirect(
-    SDL_GPURenderPass *renderPass,
+    SDL_GPURenderPass *render_pass,
     SDL_GPUBuffer *buffer,
-    Uint32 offsetInBytes,
-    Uint32 drawCount,
-    Uint32 stride);
+    Uint32 offset,
+    Uint32 draw_count,
+    Uint32 pitch);
 
 /**
  * Draws data using bound graphics state with an index buffer enabled and with
@@ -2402,21 +2395,21 @@ extern SDL_DECLSPEC void SDLCALL SDL_DrawGPUPrimitivesIndirect(
  * SDL_GPUIndexedIndirectDrawCommand. You must not call this function before
  * binding a graphics pipeline.
  *
- * \param renderPass a render pass handle.
+ * \param render_pass a render pass handle.
  * \param buffer a buffer containing draw parameters.
- * \param offsetInBytes the offset to start reading from the draw buffer.
- * \param drawCount the number of draw parameter sets that should be read from
+ * \param offset the offset to start reading from the draw buffer.
+ * \param draw_count the number of draw parameter sets that should be read from
  *                  the draw buffer.
- * \param stride the byte stride between sets of draw parameters.
+ * \param pitch the byte pitch between sets of draw parameters.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_DrawGPUIndexedPrimitivesIndirect(
-    SDL_GPURenderPass *renderPass,
+    SDL_GPURenderPass *render_pass,
     SDL_GPUBuffer *buffer,
-    Uint32 offsetInBytes,
-    Uint32 drawCount,
-    Uint32 stride);
+    Uint32 offset,
+    Uint32 draw_count,
+    Uint32 pitch);
 
 /**
  * Ends the given render pass.
@@ -2424,12 +2417,12 @@ extern SDL_DECLSPEC void SDLCALL SDL_DrawGPUIndexedPrimitivesIndirect(
  * All bound graphics state on the render pass command buffer is unset. The
  * render pass handle is now invalid.
  *
- * \param renderPass a render pass handle.
+ * \param render_pass a render pass handle.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_EndGPURenderPass(
-    SDL_GPURenderPass *renderPass);
+    SDL_GPURenderPass *render_pass);
 
 /* Compute Pass */
 
@@ -2449,14 +2442,14 @@ extern SDL_DECLSPEC void SDLCALL SDL_EndGPURenderPass(
  * dispatch, you MUST end the current compute pass and begin a new one before
  * you can safely access the data.
  *
- * \param commandBuffer a command buffer.
- * \param storageTextureBindings an array of writeable storage texture binding
+ * \param command_buffer a command buffer.
+ * \param storage_texture_bindings an array of writeable storage texture binding
  *                               structs.
- * \param storageTextureBindingCount the number of storage textures to bind
+ * \param num_storage_texture_bindings the number of storage textures to bind
  *                                   from the array.
- * \param storageBufferBindings an array of writeable storage buffer binding
+ * \param storage_buffer_bindings an array of writeable storage buffer binding
  *                              structs.
- * \param storageBufferBindingCount the number of storage buffers to bind from
+ * \param num_storage_buffer_bindings the number of storage buffers to bind from
  *                                  the array.
  * \returns a compute pass handle.
  *
@@ -2465,23 +2458,23 @@ extern SDL_DECLSPEC void SDLCALL SDL_EndGPURenderPass(
  * \sa SDL_EndGPUComputePass
  */
 extern SDL_DECLSPEC SDL_GPUComputePass *SDLCALL SDL_BeginGPUComputePass(
-    SDL_GPUCommandBuffer *commandBuffer,
-    const SDL_GPUStorageTextureWriteOnlyBinding *storageTextureBindings,
-    Uint32 storageTextureBindingCount,
-    const SDL_GPUStorageBufferWriteOnlyBinding *storageBufferBindings,
-    Uint32 storageBufferBindingCount);
+    SDL_GPUCommandBuffer *command_buffer,
+    const SDL_GPUStorageTextureWriteOnlyBinding *storage_texture_bindings,
+    Uint32 num_storage_texture_bindings,
+    const SDL_GPUStorageBufferWriteOnlyBinding *storage_buffer_bindings,
+    Uint32 num_storage_buffer_bindings);
 
 /**
  * Binds a compute pipeline on a command buffer for use in compute dispatch.
  *
- * \param computePass a compute pass handle.
- * \param computePipeline a compute pipeline to bind.
+ * \param compute_pass a compute pass handle.
+ * \param compute_pipeline a compute pipeline to bind.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_BindGPUComputePipeline(
-    SDL_GPUComputePass *computePass,
-    SDL_GPUComputePipeline *computePipeline);
+    SDL_GPUComputePass *compute_pass,
+    SDL_GPUComputePipeline *compute_pipeline);
 
 /**
  * Binds storage textures as readonly for use on the compute pipeline.
@@ -2489,18 +2482,18 @@ extern SDL_DECLSPEC void SDLCALL SDL_BindGPUComputePipeline(
  * These textures must have been created with
  * SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ.
  *
- * \param computePass a compute pass handle.
- * \param firstSlot the compute storage texture slot to begin binding from.
- * \param storageTextures an array of storage textures.
- * \param bindingCount the number of storage textures to bind from the array.
+ * \param compute_pass a compute pass handle.
+ * \param first_slot the compute storage texture slot to begin binding from.
+ * \param storage_textures an array of storage textures.
+ * \param num_bindings the number of storage textures to bind from the array.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_BindGPUComputeStorageTextures(
-    SDL_GPUComputePass *computePass,
-    Uint32 firstSlot,
-    SDL_GPUTexture *const *storageTextures,
-    Uint32 bindingCount);
+    SDL_GPUComputePass *compute_pass,
+    Uint32 first_slot,
+    SDL_GPUTexture *const *storage_textures,
+    Uint32 num_bindings);
 
 /**
  * Binds storage buffers as readonly for use on the compute pipeline.
@@ -2508,18 +2501,18 @@ extern SDL_DECLSPEC void SDLCALL SDL_BindGPUComputeStorageTextures(
  * These buffers must have been created with
  * SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ.
  *
- * \param computePass a compute pass handle.
- * \param firstSlot the compute storage buffer slot to begin binding from.
- * \param storageBuffers an array of storage buffer binding structs.
- * \param bindingCount the number of storage buffers to bind from the array.
+ * \param compute_pass a compute pass handle.
+ * \param first_slot the compute storage buffer slot to begin binding from.
+ * \param storage_buffers an array of storage buffer binding structs.
+ * \param num_bindings the number of storage buffers to bind from the array.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_BindGPUComputeStorageBuffers(
-    SDL_GPUComputePass *computePass,
-    Uint32 firstSlot,
-    SDL_GPUBuffer *const *storageBuffers,
-    Uint32 bindingCount);
+    SDL_GPUComputePass *compute_pass,
+    Uint32 first_slot,
+    SDL_GPUBuffer *const *storage_buffers,
+    Uint32 num_bindings);
 
 /**
  * Dispatches compute work.
@@ -2531,21 +2524,21 @@ extern SDL_DECLSPEC void SDLCALL SDL_BindGPUComputeStorageBuffers(
  * guarantee of which order the writes will occur. If the write order matters,
  * you MUST end the compute pass and begin another one.
  *
- * \param computePass a compute pass handle.
- * \param groupCountX number of local workgroups to dispatch in the X
+ * \param compute_pass a compute pass handle.
+ * \param groupcount_x number of local workgroups to dispatch in the X
  *                    dimension.
- * \param groupCountY number of local workgroups to dispatch in the Y
+ * \param groupcount_y number of local workgroups to dispatch in the Y
  *                    dimension.
- * \param groupCountZ number of local workgroups to dispatch in the Z
+ * \param groupcount_z number of local workgroups to dispatch in the Z
  *                    dimension.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_DispatchGPUCompute(
-    SDL_GPUComputePass *computePass,
-    Uint32 groupCountX,
-    Uint32 groupCountY,
-    Uint32 groupCountZ);
+    SDL_GPUComputePass *compute_pass,
+    Uint32 groupcount_x,
+    Uint32 groupcount_y,
+    Uint32 groupcount_z);
 
 /**
  * Dispatches compute work with parameters set from a buffer.
@@ -2559,16 +2552,16 @@ extern SDL_DECLSPEC void SDLCALL SDL_DispatchGPUCompute(
  * guarantee of which order the writes will occur. If the write order matters,
  * you MUST end the compute pass and begin another one.
  *
- * \param computePass a compute pass handle.
+ * \param compute_pass a compute pass handle.
  * \param buffer a buffer containing dispatch parameters.
- * \param offsetInBytes the offset to start reading from the dispatch buffer.
+ * \param offset the offset to start reading from the dispatch buffer.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_DispatchGPUComputeIndirect(
-    SDL_GPUComputePass *computePass,
+    SDL_GPUComputePass *compute_pass,
     SDL_GPUBuffer *buffer,
-    Uint32 offsetInBytes);
+    Uint32 offset);
 
 /**
  * Ends the current compute pass.
@@ -2576,12 +2569,12 @@ extern SDL_DECLSPEC void SDLCALL SDL_DispatchGPUComputeIndirect(
  * All bound compute state on the command buffer is unset. The compute pass
  * handle is now invalid.
  *
- * \param computePass a compute pass handle.
+ * \param compute_pass a compute pass handle.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_EndGPUComputePass(
-    SDL_GPUComputePass *computePass);
+    SDL_GPUComputePass *compute_pass);
 
 /* TransferBuffer Data */
 
@@ -2591,7 +2584,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_EndGPUComputePass(
  * You must unmap the transfer buffer before encoding upload commands.
  *
  * \param device a GPU context.
- * \param transferBuffer a transfer buffer.
+ * \param transfer_buffer a transfer buffer.
  * \param cycle if SDL_TRUE, cycles the transfer buffer if it is bound.
  * \returns the address of the mapped transfer buffer memory.
  *
@@ -2599,20 +2592,20 @@ extern SDL_DECLSPEC void SDLCALL SDL_EndGPUComputePass(
  */
 extern SDL_DECLSPEC void *SDLCALL SDL_MapGPUTransferBuffer(
     SDL_GPUDevice *device,
-    SDL_GPUTransferBuffer *transferBuffer,
+    SDL_GPUTransferBuffer *transfer_buffer,
     SDL_bool cycle);
 
 /**
  * Unmaps a previously mapped transfer buffer.
  *
  * \param device a GPU context.
- * \param transferBuffer a previously mapped transfer buffer.
+ * \param transfer_buffer a previously mapped transfer buffer.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_UnmapGPUTransferBuffer(
     SDL_GPUDevice *device,
-    SDL_GPUTransferBuffer *transferBuffer);
+    SDL_GPUTransferBuffer *transfer_buffer);
 
 /* Copy Pass */
 
@@ -2623,13 +2616,13 @@ extern SDL_DECLSPEC void SDLCALL SDL_UnmapGPUTransferBuffer(
  * inside a copy pass. You must not begin another copy pass, or a render pass
  * or compute pass before ending the copy pass.
  *
- * \param commandBuffer a command buffer.
+ * \param command_buffer a command buffer.
  * \returns a copy pass handle.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC SDL_GPUCopyPass *SDLCALL SDL_BeginGPUCopyPass(
-    SDL_GPUCommandBuffer *commandBuffer);
+    SDL_GPUCommandBuffer *command_buffer);
 
 /**
  * Uploads data from a transfer buffer to a texture.
@@ -2640,7 +2633,7 @@ extern SDL_DECLSPEC SDL_GPUCopyPass *SDLCALL SDL_BeginGPUCopyPass(
  * You must align the data in the transfer buffer to a multiple of the texel
  * size of the texture format.
  *
- * \param copyPass a copy pass handle.
+ * \param copy_pass a copy pass handle.
  * \param source the source transfer buffer with image layout information.
  * \param destination the destination texture region.
  * \param cycle if SDL_TRUE, cycles the texture if the texture is bound,
@@ -2649,7 +2642,7 @@ extern SDL_DECLSPEC SDL_GPUCopyPass *SDLCALL SDL_BeginGPUCopyPass(
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_UploadToGPUTexture(
-    SDL_GPUCopyPass *copyPass,
+    SDL_GPUCopyPass *copy_pass,
     const SDL_GPUTextureTransferInfo *source,
     const SDL_GPUTextureRegion *destination,
     SDL_bool cycle);
@@ -2662,7 +2655,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_UploadToGPUTexture(
  * The upload occurs on the GPU timeline. You may assume that the upload has
  * finished in subsequent commands.
  *
- * \param copyPass a copy pass handle.
+ * \param copy_pass a copy pass handle.
  * \param source the source transfer buffer with offset.
  * \param destination the destination buffer with offset and size.
  * \param cycle if SDL_TRUE, cycles the buffer if it is bound, otherwise
@@ -2671,7 +2664,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_UploadToGPUTexture(
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_UploadToGPUBuffer(
-    SDL_GPUCopyPass *copyPass,
+    SDL_GPUCopyPass *copy_pass,
     const SDL_GPUTransferBufferLocation *source,
     const SDL_GPUBufferRegion *destination,
     SDL_bool cycle);
@@ -2682,7 +2675,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_UploadToGPUBuffer(
  * This copy occurs on the GPU timeline. You may assume the copy has finished
  * in subsequent commands.
  *
- * \param copyPass a copy pass handle.
+ * \param copy_pass a copy pass handle.
  * \param source a source texture region.
  * \param destination a destination texture region.
  * \param w the width of the region to copy.
@@ -2694,7 +2687,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_UploadToGPUBuffer(
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_CopyGPUTextureToTexture(
-    SDL_GPUCopyPass *copyPass,
+    SDL_GPUCopyPass *copy_pass,
     const SDL_GPUTextureLocation *source,
     const SDL_GPUTextureLocation *destination,
     Uint32 w,
@@ -2710,7 +2703,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_CopyGPUTextureToTexture(
  * This copy occurs on the GPU timeline. You may assume the copy has finished
  * in subsequent commands.
  *
- * \param copyPass a copy pass handle.
+ * \param copy_pass a copy pass handle.
  * \param source the buffer and offset to copy from.
  * \param destination the buffer and offset to copy to.
  * \param size the length of the buffer to copy.
@@ -2720,7 +2713,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_CopyGPUTextureToTexture(
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_CopyGPUBufferToBuffer(
-    SDL_GPUCopyPass *copyPass,
+    SDL_GPUCopyPass *copy_pass,
     const SDL_GPUBufferLocation *source,
     const SDL_GPUBufferLocation *destination,
     Uint32 size,
@@ -2732,7 +2725,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_CopyGPUBufferToBuffer(
  * This data is not guaranteed to be copied until the command buffer fence is
  * signaled.
  *
- * \param copyPass a copy pass handle.
+ * \param copy_pass a copy pass handle.
  * \param source the source texture region.
  * \param destination the destination transfer buffer with image layout
  *                    information.
@@ -2740,7 +2733,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_CopyGPUBufferToBuffer(
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_DownloadFromGPUTexture(
-    SDL_GPUCopyPass *copyPass,
+    SDL_GPUCopyPass *copy_pass,
     const SDL_GPUTextureRegion *source,
     const SDL_GPUTextureTransferInfo *destination);
 
@@ -2750,39 +2743,39 @@ extern SDL_DECLSPEC void SDLCALL SDL_DownloadFromGPUTexture(
  * This data is not guaranteed to be copied until the command buffer fence is
  * signaled.
  *
- * \param copyPass a copy pass handle.
+ * \param copy_pass a copy pass handle.
  * \param source the source buffer with offset and size.
  * \param destination the destination transfer buffer with offset.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_DownloadFromGPUBuffer(
-    SDL_GPUCopyPass *copyPass,
+    SDL_GPUCopyPass *copy_pass,
     const SDL_GPUBufferRegion *source,
     const SDL_GPUTransferBufferLocation *destination);
 
 /**
  * Ends the current copy pass.
  *
- * \param copyPass a copy pass handle.
+ * \param copy_pass a copy pass handle.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_EndGPUCopyPass(
-    SDL_GPUCopyPass *copyPass);
+    SDL_GPUCopyPass *copy_pass);
 
 /**
  * Generates mipmaps for the given texture.
  *
  * This function must not be called inside of any pass.
  *
- * \param commandBuffer a commandBuffer.
+ * \param command_buffer a command_buffer.
  * \param texture a texture with more than 1 mip level.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_GenerateMipmapsForGPUTexture(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     SDL_GPUTexture *texture);
 
 /**
@@ -2790,22 +2783,22 @@ extern SDL_DECLSPEC void SDLCALL SDL_GenerateMipmapsForGPUTexture(
  *
  * This function must not be called inside of any pass.
  *
- * \param commandBuffer a command buffer.
+ * \param command_buffer a command buffer.
  * \param source the texture region to copy from.
  * \param destination the texture region to copy to.
- * \param flipMode the flip mode for the source texture region.
- * \param filterMode the filter mode that will be used when blitting.
+ * \param flip_mode the flip mode for the source texture region.
+ * \param filter the filter mode that will be used when blitting.
  * \param cycle if SDL_TRUE, cycles the destination texture if the destination
  *              texture is bound, otherwise overwrites the data.
  *
  * \since This function is available since SDL 3.0.0.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_BlitGPUTexture(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUBlitRegion *source,
     const SDL_GPUBlitRegion *destination,
-    SDL_FlipMode flipMode,
-    SDL_GPUFilter filterMode,
+    SDL_FlipMode flip_mode,
+    SDL_GPUFilter filter,
     SDL_bool cycle);
 
 /* Submission/Presentation */
@@ -2817,7 +2810,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_BlitGPUTexture(
  *
  * \param device a GPU context.
  * \param window an SDL_Window.
- * \param swapchainComposition the swapchain composition to check.
+ * \param swapchain_composition the swapchain composition to check.
  * \returns SDL_TRUE if supported, SDL_FALSE if unsupported (or on error).
  *
  * \since This function is available since SDL 3.0.0.
@@ -2827,7 +2820,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_BlitGPUTexture(
 extern SDL_DECLSPEC SDL_bool SDLCALL SDL_WindowSupportsGPUSwapchainComposition(
     SDL_GPUDevice *device,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchainComposition);
+    SDL_GPUSwapchainComposition swapchain_composition);
 
 /**
  * Determines whether a presentation mode is supported by the window.
@@ -2836,7 +2829,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_WindowSupportsGPUSwapchainComposition(
  *
  * \param device a GPU context.
  * \param window an SDL_Window.
- * \param presentMode the presentation mode to check.
+ * \param present_mode the presentation mode to check.
  * \returns SDL_TRUE if supported, SDL_FALSE if unsupported (or on error).
  *
  * \since This function is available since SDL 3.0.0.
@@ -2846,7 +2839,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_WindowSupportsGPUSwapchainComposition(
 extern SDL_DECLSPEC SDL_bool SDLCALL SDL_WindowSupportsGPUPresentMode(
     SDL_GPUDevice *device,
     SDL_Window *window,
-    SDL_GPUPresentMode presentMode);
+    SDL_GPUPresentMode present_mode);
 
 /**
  * Claims a window, creating a swapchain structure for it.
@@ -2901,8 +2894,8 @@ extern SDL_DECLSPEC void SDLCALL SDL_ReleaseWindowFromGPUDevice(
  *
  * \param device a GPU context.
  * \param window an SDL_Window that has been claimed.
- * \param swapchainComposition the desired composition of the swapchain.
- * \param presentMode the desired present mode for the swapchain.
+ * \param swapchain_composition the desired composition of the swapchain.
+ * \param present_mode the desired present mode for the swapchain.
  * \returns SDL_TRUE if successful, SDL_FALSE on error.
  *
  * \since This function is available since SDL 3.0.0.
@@ -2913,8 +2906,8 @@ extern SDL_DECLSPEC void SDLCALL SDL_ReleaseWindowFromGPUDevice(
 extern SDL_DECLSPEC SDL_bool SDLCALL SDL_SetGPUSwapchainParameters(
     SDL_GPUDevice *device,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchainComposition,
-    SDL_GPUPresentMode presentMode);
+    SDL_GPUSwapchainComposition swapchain_composition,
+    SDL_GPUPresentMode present_mode);
 
 /**
  * Obtains the texture format of the swapchain for the given window.
@@ -2940,10 +2933,10 @@ extern SDL_DECLSPEC SDL_GPUTextureFormat SDLCALL SDL_GetGPUSwapchainTextureForma
  * and must not be freed by the user. You MUST NOT call this function from any
  * thread other than the one that created the window.
  *
- * \param commandBuffer a command buffer.
+ * \param command_buffer a command buffer.
  * \param window a window that has been claimed.
- * \param pWidth a pointer filled in with the swapchain width.
- * \param pHeight a pointer filled in with the swapchain height.
+ * \param w a pointer filled in with the swapchain width.
+ * \param h a pointer filled in with the swapchain height.
  * \returns a swapchain texture.
  *
  * \since This function is available since SDL 3.0.0.
@@ -2953,10 +2946,10 @@ extern SDL_DECLSPEC SDL_GPUTextureFormat SDLCALL SDL_GetGPUSwapchainTextureForma
  * \sa SDL_SubmitGPUCommandBufferAndAcquireFence
  */
 extern SDL_DECLSPEC SDL_GPUTexture *SDLCALL SDL_AcquireGPUSwapchainTexture(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     SDL_Window *window,
-    Uint32 *pWidth,
-    Uint32 *pHeight);
+    Uint32 *w,
+    Uint32 *h);
 
 /**
  * Submits a command buffer so its commands can be processed on the GPU.
@@ -2968,7 +2961,7 @@ extern SDL_DECLSPEC SDL_GPUTexture *SDLCALL SDL_AcquireGPUSwapchainTexture(
  * All commands in the submission are guaranteed to begin executing before any
  * command in a subsequent submission begins executing.
  *
- * \param commandBuffer a command buffer.
+ * \param command_buffer a command buffer.
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -2977,7 +2970,7 @@ extern SDL_DECLSPEC SDL_GPUTexture *SDLCALL SDL_AcquireGPUSwapchainTexture(
  * \sa SDL_SubmitGPUCommandBufferAndAcquireFence
  */
 extern SDL_DECLSPEC void SDLCALL SDL_SubmitGPUCommandBuffer(
-    SDL_GPUCommandBuffer *commandBuffer);
+    SDL_GPUCommandBuffer *command_buffer);
 
 /**
  * Submits a command buffer so its commands can be processed on the GPU, and
@@ -2991,7 +2984,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_SubmitGPUCommandBuffer(
  * All commands in the submission are guaranteed to begin executing before any
  * command in a subsequent submission begins executing.
  *
- * \param commandBuffer a command buffer.
+ * \param command_buffer a command buffer.
  * \returns a fence associated with the command buffer.
  *
  * \since This function is available since SDL 3.0.0.
@@ -3002,7 +2995,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_SubmitGPUCommandBuffer(
  * \sa SDL_ReleaseGPUFence
  */
 extern SDL_DECLSPEC SDL_GPUFence *SDLCALL SDL_SubmitGPUCommandBufferAndAcquireFence(
-    SDL_GPUCommandBuffer *commandBuffer);
+    SDL_GPUCommandBuffer *command_buffer);
 
 /**
  * Blocks the thread until the GPU is completely idle.
@@ -3020,10 +3013,10 @@ extern SDL_DECLSPEC void SDLCALL SDL_WaitForGPUIdle(
  * Blocks the thread until the given fences are signaled.
  *
  * \param device a GPU context.
- * \param waitAll if 0, wait for any fence to be signaled, if 1, wait for all
+ * \param wait_all if 0, wait for any fence to be signaled, if 1, wait for all
  *                fences to be signaled.
- * \param pFences an array of fences to wait on.
- * \param fenceCount the number of fences in the pFences array.
+ * \param fences an array of fences to wait on.
+ * \param num_fences the number of fences in the fences array.
  *
  * \since This function is available since SDL 3.0.0.
  *
@@ -3032,9 +3025,9 @@ extern SDL_DECLSPEC void SDLCALL SDL_WaitForGPUIdle(
  */
 extern SDL_DECLSPEC void SDLCALL SDL_WaitForGPUFences(
     SDL_GPUDevice *device,
-    SDL_bool waitAll,
-    SDL_GPUFence *const *pFences,
-    Uint32 fenceCount);
+    SDL_bool wait_all,
+    SDL_GPUFence *const *fences,
+    Uint32 num_fences);
 
 /**
  * Checks the status of a fence.
@@ -3070,7 +3063,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_ReleaseGPUFence(
 /**
  * Obtains the texel block size for a texture format.
  *
- * \param textureFormat the texture format you want to know the texel size of.
+ * \param format the texture format you want to know the texel size of.
  * \returns the texel block size of the texture format.
  *
  * \since This function is available since SDL 3.0.0.
@@ -3078,7 +3071,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_ReleaseGPUFence(
  * \sa SDL_UploadToGPUTexture
  */
 extern SDL_DECLSPEC Uint32 SDLCALL SDL_GPUTextureFormatTexelBlockSize(
-    SDL_GPUTextureFormat textureFormat);
+    SDL_GPUTextureFormat format);
 
 /**
  * Determines whether a texture format is supported for a given type and
@@ -3103,7 +3096,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GPUTextureSupportsFormat(
  *
  * \param device a GPU context.
  * \param format the texture format to check.
- * \param sampleCount the sample count to check.
+ * \param sample_count the sample count to check.
  * \returns a hardware-specific version of min(preferred, possible).
  *
  * \since This function is available since SDL 3.0.0.
@@ -3111,7 +3104,7 @@ extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GPUTextureSupportsFormat(
 extern SDL_DECLSPEC SDL_bool SDLCALL SDL_GPUTextureSupportsSampleCount(
     SDL_GPUDevice *device,
     SDL_GPUTextureFormat format,
-    SDL_GPUSampleCount sampleCount);
+    SDL_GPUSampleCount sample_count);
 
 #ifdef SDL_PLATFORM_GDK
 

--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -494,7 +494,7 @@ typedef enum SDL_GPUTextureType
  * Specifies the sample count of a texture.
  *
  * Used in multisampling. Note that this value only applies when the texture
- * is used as a render pass attachment.
+ * is used as a render target.
  *
  * \since This enum is available since SDL 3.0.0
  *
@@ -751,8 +751,7 @@ typedef enum SDL_GPUStencilOp
 } SDL_GPUStencilOp;
 
 /**
- * Specifies the operator to be used when pixels in a render pass texture
- * attachment are blended with existing pixels in the texture.
+ * Specifies the operator to be used when pixels in a render target are blended with existing pixels in the texture.
  *
  * The source color is the value written by the fragment shader. The
  * destination color is the value currently existing in the texture.
@@ -771,8 +770,7 @@ typedef enum SDL_GPUBlendOp
 } SDL_GPUBlendOp;
 
 /**
- * Specifies a blending factor to be used when pixels in a render pass texture
- * attachment are blended with existing pixels in the texture.
+ * Specifies a blending factor to be used when pixels in a render target are blended with existing pixels in the texture.
  *
  * The source color is the value written by the fragment shader. The
  * destination color is the value currently existing in the texture.
@@ -958,8 +956,8 @@ typedef struct SDL_GPUViewport
     float y;
     float w;
     float h;
-    float minDepth;
-    float maxDepth;
+    float min_depth;
+    float max_depth;
 } SDL_GPUViewport;
 
 typedef struct SDL_GPUTextureTransferInfo
@@ -1107,7 +1105,7 @@ typedef struct SDL_GPUStencilOpState
     SDL_GPUCompareOp compare_op;
 } SDL_GPUStencilOpState;
 
-typedef struct SDL_GPUColorAttachmentBlendState
+typedef struct SDL_GPUColorTargetBlendState
 {
     SDL_bool enable_blend;
     Uint8 padding1;
@@ -1120,13 +1118,13 @@ typedef struct SDL_GPUColorAttachmentBlendState
     SDL_GPUBlendFactor dst_alpha_blendfactor;
     SDL_GPUBlendOp alpha_blend_op;
     SDL_GPUColorComponentFlags color_write_mask;
-} SDL_GPUColorAttachmentBlendState;
+} SDL_GPUColorTargetBlendState;
 
 typedef struct SDL_GPUShaderCreateInfo
 {
     size_t code_size;
     const Uint8 *code;
-    const char *entrypoint_name;
+    const char *entrypoint;
     SDL_GPUShaderFormat format;
     SDL_GPUShaderStage stage;
     Uint32 num_samplers;
@@ -1141,7 +1139,7 @@ typedef struct SDL_GPUTextureCreateInfo
 {
     SDL_GPUTextureType type;
     SDL_GPUTextureFormat format;
-    SDL_GPUTextureUsageFlags usage_flags;
+    SDL_GPUTextureUsageFlags usage;
     Uint32 width;
     Uint32 height;
     Uint32 layer_count_or_depth;
@@ -1160,7 +1158,7 @@ typedef struct SDL_GPUTextureCreateInfo
 
 typedef struct SDL_GPUBufferCreateInfo
 {
-    SDL_GPUBufferUsageFlags usage_flags;
+    SDL_GPUBufferUsageFlags usage;
     Uint32 size;
 
     SDL_PropertiesID props;
@@ -1180,7 +1178,7 @@ typedef struct SDL_GPURasterizerState
 {
     SDL_GPUFillMode fill_mode;
     SDL_GPUCullMode cull_mode;
-    SDL_GPUFrontFace frontFace;
+    SDL_GPUFrontFace front_face;
     SDL_bool enable_depth_bias;
     Uint8 padding1;
     Uint8 padding2;
@@ -1211,22 +1209,22 @@ typedef struct SDL_GPUDepthStencilState
     Uint8 padding3;
 } SDL_GPUDepthStencilState;
 
-typedef struct SDL_GPUColorAttachmentDescription
+typedef struct SDL_GPUColorTargetDescription
 {
     SDL_GPUTextureFormat format;
-    SDL_GPUColorAttachmentBlendState blend_state;
-} SDL_GPUColorAttachmentDescription;
+    SDL_GPUColorTargetBlendState blend_state;
+} SDL_GPUColorTargetDescription;
 
-typedef struct SDL_GPUGraphicsPipelineAttachmentInfo
+typedef struct SDL_GpuGraphicsPipelineTargetInfo
 {
-    const SDL_GPUColorAttachmentDescription *color_attachment_descriptions;
-    Uint32 num_color_attachments;
-    SDL_bool has_depth_stencil_attachment;
+    const SDL_GPUColorTargetDescription *color_target_descriptions;
+    Uint32 num_color_targets;
+    SDL_bool has_depth_stencil_target;
     Uint8 padding1;
     Uint8 padding2;
     Uint8 padding3;
     SDL_GPUTextureFormat depth_stencil_format;
-} SDL_GPUGraphicsPipelineAttachmentInfo;
+} SDL_GpuGraphicsPipelineTargetInfo;
 
 typedef struct SDL_GPUGraphicsPipelineCreateInfo
 {
@@ -1237,7 +1235,7 @@ typedef struct SDL_GPUGraphicsPipelineCreateInfo
     SDL_GPURasterizerState rasterizer_state;
     SDL_GPUMultisampleState multisample_state;
     SDL_GPUDepthStencilState depth_stencil_state;
-    SDL_GPUGraphicsPipelineAttachmentInfo attachment_info;
+    SDL_GpuGraphicsPipelineTargetInfo target_info;
 
     SDL_PropertiesID props;
 } SDL_GPUGraphicsPipelineCreateInfo;
@@ -1246,7 +1244,7 @@ typedef struct SDL_GPUComputePipelineCreateInfo
 {
     size_t code_size;
     const Uint8 *code;
-    const char *entrypoint_name;
+    const char *entrypoint;
     SDL_GPUShaderFormat format;
     Uint32 num_readonly_storage_textures;
     Uint32 num_readonly_storage_buffers;
@@ -1260,12 +1258,12 @@ typedef struct SDL_GPUComputePipelineCreateInfo
     SDL_PropertiesID props;
 } SDL_GPUComputePipelineCreateInfo;
 
-typedef struct SDL_GPUColorAttachmentInfo
+typedef struct SDL_GPUColorTargetInfo
 {
-    /* The texture that will be used as a color attachment by a render pass. */
+    /* The texture that will be used as a color target by a render pass. */
     SDL_GPUTexture *texture;
     Uint32 mip_level;
-    Uint32 layer_or_depth_plane; /* For 3D textures, you can bind an individual depth plane as an attachment. */
+    Uint32 layer_or_depth_plane; /* For 3D textures, you can bind an individual depth plane as a target. */
 
     /* Can be ignored by RenderPass if CLEAR is not used */
     SDL_FColor clear_color;
@@ -1300,11 +1298,11 @@ typedef struct SDL_GPUColorAttachmentInfo
     Uint8 padding1;
     Uint8 padding2;
     Uint8 padding3;
-} SDL_GPUColorAttachmentInfo;
+} SDL_GPUColorTargetInfo;
 
-typedef struct SDL_GPUDepthStencilAttachmentInfo
+typedef struct SDL_GPUDepthStencilTargetInfo
 {
-    /* The texture that will be used as the depth stencil attachment by a render pass. */
+    /* The texture that will be used as the depth stencil target by a render pass. */
     SDL_GPUTexture *texture;
 
     /* Can be ignored by the render pass if CLEAR is not used */
@@ -1365,7 +1363,7 @@ typedef struct SDL_GPUDepthStencilAttachmentInfo
     Uint8 padding1;
     Uint8 padding2;
     Uint8 padding3;
-} SDL_GPUDepthStencilAttachmentInfo;
+} SDL_GPUDepthStencilTargetInfo;
 
 /* Binding structs */
 
@@ -2046,7 +2044,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_PushGPUComputeUniformData(
  * to worry about overwriting any data that is not yet uploaded.
  *
  * Another example: If you are using a texture in a render pass every frame, this can cause a data dependency between frames.
- * If you set cycle to SDL_TRUE in the ColorAttachmentInfo struct, you can prevent this data dependency.
+ * If you set cycle to SDL_TRUE in the SDL_GPUColorTargetInfo struct, you can prevent this data dependency.
  *
  * Cycling will never undefine already bound data.
  * When cycling, all data in the resource is considered to be undefined for subsequent commands until that data is written again.
@@ -2075,11 +2073,11 @@ extern SDL_DECLSPEC void SDLCALL SDL_PushGPUComputeUniformData(
  * copy pass until you have ended the render pass.
  *
  * \param command_buffer a command buffer.
- * \param color_attachment_infos an array of texture subresources with
+ * \param color_target_infos an array of texture subresources with
  *                             corresponding clear values and load/store ops.
- * \param num_color_attachments the number of color attachments in the
- *                             color_attachment_infos array.
- * \param depth_stencil_attachment_info a texture subresource with corresponding
+ * \param num_color_targets the number of color targets in the
+ *                             color_target_infos array.
+ * \param depth_stencil_target_info a texture subresource with corresponding
  *                                   clear value and load/store ops, may be
  *                                   NULL.
  * \returns a render pass handle.
@@ -2090,9 +2088,9 @@ extern SDL_DECLSPEC void SDLCALL SDL_PushGPUComputeUniformData(
  */
 extern SDL_DECLSPEC SDL_GPURenderPass *SDLCALL SDL_BeginGPURenderPass(
     SDL_GPUCommandBuffer *command_buffer,
-    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
-    Uint32 num_color_attachments,
-    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info);
+    const SDL_GPUColorTargetInfo *color_target_infos,
+    Uint32 num_color_targets,
+    const SDL_GPUDepthStencilTargetInfo *depth_stencil_target_info);
 
 /**
  * Binds a graphics pipeline on a render pass to be used in rendering.
@@ -2182,7 +2180,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_BindGPUVertexBuffers(
  * calls.
  *
  * \param render_pass a render pass handle.
- * \param pBinding a pointer to a struct containing an index buffer and
+ * \param binding a pointer to a struct containing an index buffer and
  *                 offset.
  * \param index_element_size whether the index values in the buffer are 16- or
  *                         32-bit.
@@ -2191,7 +2189,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_BindGPUVertexBuffers(
  */
 extern SDL_DECLSPEC void SDLCALL SDL_BindGPUIndexBuffer(
     SDL_GPURenderPass *render_pass,
-    const SDL_GPUBufferBinding *pBinding,
+    const SDL_GPUBufferBinding *binding,
     SDL_GPUIndexElementSize index_element_size);
 
 /**

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -70,7 +70,7 @@ SDL_DYNAPI_PROC(SDL_JoystickID,SDL_AttachVirtualJoystick,(const SDL_VirtualJoyst
 SDL_DYNAPI_PROC(SDL_bool,SDL_AudioDevicePaused,(SDL_AudioDeviceID a),(a),return)
 SDL_DYNAPI_PROC(SDL_GPUComputePass*,SDL_BeginGPUComputePass,(SDL_GPUCommandBuffer *a, const SDL_GPUStorageTextureWriteOnlyBinding *b, Uint32 c, const SDL_GPUStorageBufferWriteOnlyBinding *d, Uint32 e),(a,b,c,d,e),return)
 SDL_DYNAPI_PROC(SDL_GPUCopyPass*,SDL_BeginGPUCopyPass,(SDL_GPUCommandBuffer *a),(a),return)
-SDL_DYNAPI_PROC(SDL_GPURenderPass*,SDL_BeginGPURenderPass,(SDL_GPUCommandBuffer *a, const SDL_GPUColorAttachmentInfo *b, Uint32 c, const SDL_GPUDepthStencilAttachmentInfo *d),(a,b,c,d),return)
+SDL_DYNAPI_PROC(SDL_GPURenderPass*,SDL_BeginGPURenderPass,(SDL_GPUCommandBuffer *a, const SDL_GPUColorTargetInfo *b, Uint32 c, const SDL_GPUDepthStencilTargetInfo *d),(a,b,c,d),return)
 SDL_DYNAPI_PROC(SDL_bool,SDL_BindAudioStream,(SDL_AudioDeviceID a, SDL_AudioStream *b),(a,b),return)
 SDL_DYNAPI_PROC(SDL_bool,SDL_BindAudioStreams,(SDL_AudioDeviceID a, SDL_AudioStream **b, int c),(a,b,c),return)
 SDL_DYNAPI_PROC(void,SDL_BindGPUComputePipeline,(SDL_GPUComputePass *a, SDL_GPUComputePipeline *b),(a,b),)

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -29,28 +29,28 @@
     }
 
 #define CHECK_COMMAND_BUFFER                                       \
-    if (((CommandBufferCommonHeader *)commandBuffer)->submitted) { \
+    if (((CommandBufferCommonHeader *)command_buffer)->submitted) { \
         SDL_assert_release(!"Command buffer already submitted!");  \
         return;                                                    \
     }
 
 #define CHECK_COMMAND_BUFFER_RETURN_NULL                           \
-    if (((CommandBufferCommonHeader *)commandBuffer)->submitted) { \
+    if (((CommandBufferCommonHeader *)command_buffer)->submitted) { \
         SDL_assert_release(!"Command buffer already submitted!");  \
         return NULL;                                               \
     }
 
 #define CHECK_ANY_PASS_IN_PROGRESS(msg, retval)                                 \
     if (                                                                        \
-        ((CommandBufferCommonHeader *)commandBuffer)->renderPass.inProgress ||  \
-        ((CommandBufferCommonHeader *)commandBuffer)->computePass.inProgress || \
-        ((CommandBufferCommonHeader *)commandBuffer)->copyPass.inProgress) {    \
+        ((CommandBufferCommonHeader *)command_buffer)->render_pass.inProgress ||  \
+        ((CommandBufferCommonHeader *)command_buffer)->compute_pass.inProgress || \
+        ((CommandBufferCommonHeader *)command_buffer)->copy_pass.inProgress) {    \
         SDL_assert_release(!msg);                                               \
         return retval;                                                          \
     }
 
 #define CHECK_RENDERPASS                                     \
-    if (!((Pass *)renderPass)->inProgress) {                 \
+    if (!((Pass *)render_pass)->inProgress) {                 \
         SDL_assert_release(!"Render pass not in progress!"); \
         return;                                              \
     }
@@ -62,7 +62,7 @@
     }
 
 #define CHECK_COMPUTEPASS                                     \
-    if (!((Pass *)computePass)->inProgress) {                 \
+    if (!((Pass *)compute_pass)->inProgress) {                 \
         SDL_assert_release(!"Compute pass not in progress!"); \
         return;                                               \
     }
@@ -74,7 +74,7 @@
     }
 
 #define CHECK_COPYPASS                                     \
-    if (!((Pass *)copyPass)->inProgress) {                 \
+    if (!((Pass *)copy_pass)->inProgress) {                 \
         SDL_assert_release(!"Copy pass not in progress!"); \
         return;                                            \
     }
@@ -98,22 +98,22 @@
     }
 
 #define COMMAND_BUFFER_DEVICE \
-    ((CommandBufferCommonHeader *)commandBuffer)->device
+    ((CommandBufferCommonHeader *)command_buffer)->device
 
 #define RENDERPASS_COMMAND_BUFFER \
-    ((Pass *)renderPass)->commandBuffer
+    ((Pass *)render_pass)->command_buffer
 
 #define RENDERPASS_DEVICE \
     ((CommandBufferCommonHeader *)RENDERPASS_COMMAND_BUFFER)->device
 
 #define COMPUTEPASS_COMMAND_BUFFER \
-    ((Pass *)computePass)->commandBuffer
+    ((Pass *)compute_pass)->command_buffer
 
 #define COMPUTEPASS_DEVICE \
     ((CommandBufferCommonHeader *)COMPUTEPASS_COMMAND_BUFFER)->device
 
 #define COPYPASS_COMMAND_BUFFER \
-    ((Pass *)copyPass)->commandBuffer
+    ((Pass *)copy_pass)->command_buffer
 
 #define COPYPASS_DEVICE \
     ((CommandBufferCommonHeader *)COPYPASS_COMMAND_BUFFER)->device
@@ -170,29 +170,29 @@ SDL_GPUGraphicsPipeline *SDL_GPU_FetchBlitPipeline(
     SDL_zero(blitPipelineCreateInfo);
 
     SDL_zero(colorAttachmentDesc);
-    colorAttachmentDesc.blendState.colorWriteMask = 0xF;
+    colorAttachmentDesc.blend_state.color_write_mask = 0xF;
     colorAttachmentDesc.format = destinationFormat;
 
-    blitPipelineCreateInfo.attachmentInfo.colorAttachmentDescriptions = &colorAttachmentDesc;
-    blitPipelineCreateInfo.attachmentInfo.colorAttachmentCount = 1;
-    blitPipelineCreateInfo.attachmentInfo.depthStencilFormat = SDL_GPU_TEXTUREFORMAT_D16_UNORM; // arbitrary
-    blitPipelineCreateInfo.attachmentInfo.hasDepthStencilAttachment = false;
+    blitPipelineCreateInfo.attachment_info.color_attachment_descriptions = &colorAttachmentDesc;
+    blitPipelineCreateInfo.attachment_info.num_color_attachments = 1;
+    blitPipelineCreateInfo.attachment_info.depth_stencil_format = SDL_GPU_TEXTUREFORMAT_D16_UNORM; // arbitrary
+    blitPipelineCreateInfo.attachment_info.has_depth_stencil_attachment = false;
 
-    blitPipelineCreateInfo.vertexShader = blitVertexShader;
+    blitPipelineCreateInfo.vertex_shader = blitVertexShader;
     if (sourceTextureType == SDL_GPU_TEXTURETYPE_CUBE) {
-        blitPipelineCreateInfo.fragmentShader = blitFromCubeShader;
+        blitPipelineCreateInfo.fragment_shader = blitFromCubeShader;
     } else if (sourceTextureType == SDL_GPU_TEXTURETYPE_2D_ARRAY) {
-        blitPipelineCreateInfo.fragmentShader = blitFrom2DArrayShader;
+        blitPipelineCreateInfo.fragment_shader = blitFrom2DArrayShader;
     } else if (sourceTextureType == SDL_GPU_TEXTURETYPE_3D) {
-        blitPipelineCreateInfo.fragmentShader = blitFrom3DShader;
+        blitPipelineCreateInfo.fragment_shader = blitFrom3DShader;
     } else {
-        blitPipelineCreateInfo.fragmentShader = blitFrom2DShader;
+        blitPipelineCreateInfo.fragment_shader = blitFrom2DShader;
     }
 
-    blitPipelineCreateInfo.multisampleState.sampleCount = SDL_GPU_SAMPLECOUNT_1;
-    blitPipelineCreateInfo.multisampleState.sampleMask = 0xFFFFFFFF;
+    blitPipelineCreateInfo.multisample_state.sample_count = SDL_GPU_SAMPLECOUNT_1;
+    blitPipelineCreateInfo.multisample_state.sample_mask = 0xFFFFFFFF;
 
-    blitPipelineCreateInfo.primitiveType = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
+    blitPipelineCreateInfo.primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
 
     pipeline = SDL_CreateGPUGraphicsPipeline(
         device,
@@ -220,11 +220,11 @@ SDL_GPUGraphicsPipeline *SDL_GPU_FetchBlitPipeline(
 }
 
 void SDL_GPU_BlitCommon(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUBlitRegion *source,
     const SDL_GPUBlitRegion *destination,
-    SDL_FlipMode flipMode,
-    SDL_GPUFilter filterMode,
+    SDL_FlipMode flip_mode,
+    SDL_GPUFilter filter,
     bool cycle,
     SDL_GPUSampler *blitLinearSampler,
     SDL_GPUSampler *blitNearestSampler,
@@ -237,8 +237,8 @@ void SDL_GPU_BlitCommon(
     Uint32 *blitPipelineCount,
     Uint32 *blitPipelineCapacity)
 {
-    CommandBufferCommonHeader *cmdbufHeader = (CommandBufferCommonHeader *)commandBuffer;
-    SDL_GPURenderPass *renderPass;
+    CommandBufferCommonHeader *cmdbufHeader = (CommandBufferCommonHeader *)command_buffer;
+    SDL_GPURenderPass *render_pass;
     TextureCommonHeader *srcHeader = (TextureCommonHeader *)source->texture;
     TextureCommonHeader *dstHeader = (TextureCommonHeader *)destination->texture;
     SDL_GPUGraphicsPipeline *blitPipeline;
@@ -268,25 +268,25 @@ void SDL_GPU_BlitCommon(
 
     // If the entire destination is blitted, we don't have to load
     if (
-        dstHeader->info.layerCountOrDepth == 1 &&
-        dstHeader->info.levelCount == 1 &&
+        dstHeader->info.layer_count_or_depth == 1 &&
+        dstHeader->info.num_levels == 1 &&
         dstHeader->info.type != SDL_GPU_TEXTURETYPE_3D &&
         destination->w == dstHeader->info.width &&
         destination->h == dstHeader->info.height) {
-        colorAttachmentInfo.loadOp = SDL_GPU_LOADOP_DONT_CARE;
+        colorAttachmentInfo.load_op = SDL_GPU_LOADOP_DONT_CARE;
     } else {
-        colorAttachmentInfo.loadOp = SDL_GPU_LOADOP_LOAD;
+        colorAttachmentInfo.load_op = SDL_GPU_LOADOP_LOAD;
     }
 
-    colorAttachmentInfo.storeOp = SDL_GPU_STOREOP_STORE;
+    colorAttachmentInfo.store_op = SDL_GPU_STOREOP_STORE;
 
     colorAttachmentInfo.texture = destination->texture;
-    colorAttachmentInfo.mipLevel = destination->mipLevel;
-    colorAttachmentInfo.layerOrDepthPlane = destination->layerOrDepthPlane;
+    colorAttachmentInfo.mip_level = destination->mip_level;
+    colorAttachmentInfo.layer_or_depth_plane = destination->layer_or_depth_plane;
     colorAttachmentInfo.cycle = cycle;
 
-    renderPass = SDL_BeginGPURenderPass(
-        commandBuffer,
+    render_pass = SDL_BeginGPURenderPass(
+        command_buffer,
         &colorAttachmentInfo,
         1,
         NULL);
@@ -299,50 +299,50 @@ void SDL_GPU_BlitCommon(
     viewport.maxDepth = 1;
 
     SDL_SetGPUViewport(
-        renderPass,
+        render_pass,
         &viewport);
 
     SDL_BindGPUGraphicsPipeline(
-        renderPass,
+        render_pass,
         blitPipeline);
 
     textureSamplerBinding.texture = source->texture;
     textureSamplerBinding.sampler =
-        filterMode == SDL_GPU_FILTER_NEAREST ? blitNearestSampler : blitLinearSampler;
+        filter == SDL_GPU_FILTER_NEAREST ? blitNearestSampler : blitLinearSampler;
 
     SDL_BindGPUFragmentSamplers(
-        renderPass,
+        render_pass,
         0,
         &textureSamplerBinding,
         1);
 
-    blitFragmentUniforms.left = (float)source->x / (srcHeader->info.width >> source->mipLevel);
-    blitFragmentUniforms.top = (float)source->y / (srcHeader->info.height >> source->mipLevel);
-    blitFragmentUniforms.width = (float)source->w / (srcHeader->info.width >> source->mipLevel);
-    blitFragmentUniforms.height = (float)source->h / (srcHeader->info.height >> source->mipLevel);
-    blitFragmentUniforms.mipLevel = source->mipLevel;
+    blitFragmentUniforms.left = (float)source->x / (srcHeader->info.width >> source->mip_level);
+    blitFragmentUniforms.top = (float)source->y / (srcHeader->info.height >> source->mip_level);
+    blitFragmentUniforms.width = (float)source->w / (srcHeader->info.width >> source->mip_level);
+    blitFragmentUniforms.height = (float)source->h / (srcHeader->info.height >> source->mip_level);
+    blitFragmentUniforms.mip_level = source->mip_level;
 
-    layerDivisor = (srcHeader->info.type == SDL_GPU_TEXTURETYPE_3D) ? srcHeader->info.layerCountOrDepth : 1;
-    blitFragmentUniforms.layerOrDepth = (float)source->layerOrDepthPlane / layerDivisor;
+    layerDivisor = (srcHeader->info.type == SDL_GPU_TEXTURETYPE_3D) ? srcHeader->info.layer_count_or_depth : 1;
+    blitFragmentUniforms.layerOrDepth = (float)source->layer_or_depth_plane / layerDivisor;
 
-    if (flipMode & SDL_FLIP_HORIZONTAL) {
+    if (flip_mode & SDL_FLIP_HORIZONTAL) {
         blitFragmentUniforms.left += blitFragmentUniforms.width;
         blitFragmentUniforms.width *= -1;
     }
 
-    if (flipMode & SDL_FLIP_VERTICAL) {
+    if (flip_mode & SDL_FLIP_VERTICAL) {
         blitFragmentUniforms.top += blitFragmentUniforms.height;
         blitFragmentUniforms.height *= -1;
     }
 
     SDL_PushGPUFragmentUniformData(
-        commandBuffer,
+        command_buffer,
         0,
         &blitFragmentUniforms,
         sizeof(blitFragmentUniforms));
 
-    SDL_DrawGPUPrimitives(renderPass, 3, 1, 0, 0);
-    SDL_EndGPURenderPass(renderPass);
+    SDL_DrawGPUPrimitives(render_pass, 3, 1, 0, 0);
+    SDL_EndGPURenderPass(render_pass);
 }
 
 // Driver Functions
@@ -350,7 +350,7 @@ void SDL_GPU_BlitCommon(
 static SDL_GPUDriver SDL_GPUSelectBackend(
     SDL_VideoDevice *_this,
     const char *gpudriver,
-    SDL_GPUShaderFormat formatFlags)
+    SDL_GPUShaderFormat format_flags)
 {
     Uint32 i;
 
@@ -358,7 +358,7 @@ static SDL_GPUDriver SDL_GPUSelectBackend(
     if (gpudriver != NULL) {
         for (i = 0; backends[i]; i += 1) {
             if (SDL_strcasecmp(gpudriver, backends[i]->Name) == 0) {
-                if (!(backends[i]->shaderFormats & formatFlags)) {
+                if (!(backends[i]->shaderFormats & format_flags)) {
                     SDL_LogError(SDL_LOG_CATEGORY_GPU, "Required shader format for backend %s not provided!", gpudriver);
                     return SDL_GPU_DRIVER_INVALID;
                 }
@@ -373,7 +373,7 @@ static SDL_GPUDriver SDL_GPUSelectBackend(
     }
 
     for (i = 0; backends[i]; i += 1) {
-        if ((backends[i]->shaderFormats & formatFlags) == 0) {
+        if ((backends[i]->shaderFormats & format_flags) == 0) {
             // Don't select a backend which doesn't support the app's shaders.
             continue;
         }
@@ -387,31 +387,31 @@ static SDL_GPUDriver SDL_GPUSelectBackend(
 }
 
 SDL_GPUDevice *SDL_CreateGPUDevice(
-    SDL_GPUShaderFormat formatFlags,
-    SDL_bool debugMode,
+    SDL_GPUShaderFormat format_flags,
+    SDL_bool debug_mode,
     const char *name)
 {
     SDL_GPUDevice *result;
     SDL_PropertiesID props = SDL_CreateProperties();
-    if (formatFlags & SDL_GPU_SHADERFORMAT_PRIVATE) {
+    if (format_flags & SDL_GPU_SHADERFORMAT_PRIVATE) {
         SDL_SetBooleanProperty(props, SDL_PROP_GPU_DEVICE_CREATE_SHADERS_PRIVATE_BOOL, true);
     }
-    if (formatFlags & SDL_GPU_SHADERFORMAT_SPIRV) {
+    if (format_flags & SDL_GPU_SHADERFORMAT_SPIRV) {
         SDL_SetBooleanProperty(props, SDL_PROP_GPU_DEVICE_CREATE_SHADERS_SPIRV_BOOL, true);
     }
-    if (formatFlags & SDL_GPU_SHADERFORMAT_DXBC) {
+    if (format_flags & SDL_GPU_SHADERFORMAT_DXBC) {
         SDL_SetBooleanProperty(props, SDL_PROP_GPU_DEVICE_CREATE_SHADERS_DXBC_BOOL, true);
     }
-    if (formatFlags & SDL_GPU_SHADERFORMAT_DXIL) {
+    if (format_flags & SDL_GPU_SHADERFORMAT_DXIL) {
         SDL_SetBooleanProperty(props, SDL_PROP_GPU_DEVICE_CREATE_SHADERS_DXIL_BOOL, true);
     }
-    if (formatFlags & SDL_GPU_SHADERFORMAT_MSL) {
+    if (format_flags & SDL_GPU_SHADERFORMAT_MSL) {
         SDL_SetBooleanProperty(props, SDL_PROP_GPU_DEVICE_CREATE_SHADERS_MSL_BOOL, true);
     }
-    if (formatFlags & SDL_GPU_SHADERFORMAT_METALLIB) {
+    if (format_flags & SDL_GPU_SHADERFORMAT_METALLIB) {
         SDL_SetBooleanProperty(props, SDL_PROP_GPU_DEVICE_CREATE_SHADERS_METALLIB_BOOL, true);
     }
-    SDL_SetBooleanProperty(props, SDL_PROP_GPU_DEVICE_CREATE_DEBUGMODE_BOOL, debugMode);
+    SDL_SetBooleanProperty(props, SDL_PROP_GPU_DEVICE_CREATE_DEBUGMODE_BOOL, debug_mode);
     SDL_SetStringProperty(props, SDL_PROP_GPU_DEVICE_CREATE_NAME_STRING, name);
     result = SDL_CreateGPUDeviceWithProperties(props);
     SDL_DestroyProperties(props);
@@ -420,8 +420,8 @@ SDL_GPUDevice *SDL_CreateGPUDevice(
 
 SDL_GPUDevice *SDL_CreateGPUDeviceWithProperties(SDL_PropertiesID props)
 {
-    SDL_GPUShaderFormat formatFlags = 0;
-    bool debugMode;
+    SDL_GPUShaderFormat format_flags = 0;
+    bool debug_mode;
     bool preferLowPower;
 
     int i;
@@ -436,25 +436,25 @@ SDL_GPUDevice *SDL_CreateGPUDeviceWithProperties(SDL_PropertiesID props)
     }
 
     if (SDL_GetBooleanProperty(props, SDL_PROP_GPU_DEVICE_CREATE_SHADERS_PRIVATE_BOOL, false)) {
-        formatFlags |= SDL_GPU_SHADERFORMAT_PRIVATE;
+        format_flags |= SDL_GPU_SHADERFORMAT_PRIVATE;
     }
     if (SDL_GetBooleanProperty(props, SDL_PROP_GPU_DEVICE_CREATE_SHADERS_SPIRV_BOOL, false)) {
-        formatFlags |= SDL_GPU_SHADERFORMAT_SPIRV;
+        format_flags |= SDL_GPU_SHADERFORMAT_SPIRV;
     }
     if (SDL_GetBooleanProperty(props, SDL_PROP_GPU_DEVICE_CREATE_SHADERS_DXBC_BOOL, false)) {
-        formatFlags |= SDL_GPU_SHADERFORMAT_DXBC;
+        format_flags |= SDL_GPU_SHADERFORMAT_DXBC;
     }
     if (SDL_GetBooleanProperty(props, SDL_PROP_GPU_DEVICE_CREATE_SHADERS_DXIL_BOOL, false)) {
-        formatFlags |= SDL_GPU_SHADERFORMAT_DXIL;
+        format_flags |= SDL_GPU_SHADERFORMAT_DXIL;
     }
     if (SDL_GetBooleanProperty(props, SDL_PROP_GPU_DEVICE_CREATE_SHADERS_MSL_BOOL, false)) {
-        formatFlags |= SDL_GPU_SHADERFORMAT_MSL;
+        format_flags |= SDL_GPU_SHADERFORMAT_MSL;
     }
     if (SDL_GetBooleanProperty(props, SDL_PROP_GPU_DEVICE_CREATE_SHADERS_METALLIB_BOOL, false)) {
-        formatFlags |= SDL_GPU_SHADERFORMAT_METALLIB;
+        format_flags |= SDL_GPU_SHADERFORMAT_METALLIB;
     }
 
-    debugMode = SDL_GetBooleanProperty(props, SDL_PROP_GPU_DEVICE_CREATE_DEBUGMODE_BOOL, true);
+    debug_mode = SDL_GetBooleanProperty(props, SDL_PROP_GPU_DEVICE_CREATE_DEBUGMODE_BOOL, true);
     preferLowPower = SDL_GetBooleanProperty(props, SDL_PROP_GPU_DEVICE_CREATE_PREFERLOWPOWER_BOOL, false);
 
     gpudriver = SDL_GetHint(SDL_HINT_GPU_DRIVER);
@@ -462,15 +462,15 @@ SDL_GPUDevice *SDL_CreateGPUDeviceWithProperties(SDL_PropertiesID props)
         gpudriver = SDL_GetStringProperty(props, SDL_PROP_GPU_DEVICE_CREATE_NAME_STRING, NULL);
     }
 
-    selectedBackend = SDL_GPUSelectBackend(_this, gpudriver, formatFlags);
+    selectedBackend = SDL_GPUSelectBackend(_this, gpudriver, format_flags);
     if (selectedBackend != SDL_GPU_DRIVER_INVALID) {
         for (i = 0; backends[i]; i += 1) {
             if (backends[i]->backendflag == selectedBackend) {
-                result = backends[i]->CreateDevice(debugMode, preferLowPower, props);
+                result = backends[i]->CreateDevice(debug_mode, preferLowPower, props);
                 if (result != NULL) {
                     result->backend = backends[i]->backendflag;
                     result->shaderFormats = backends[i]->shaderFormats;
-                    result->debugMode = debugMode;
+                    result->debug_mode = debug_mode;
                     break;
                 }
             }
@@ -494,9 +494,9 @@ SDL_GPUDriver SDL_GetGPUDriver(SDL_GPUDevice *device)
 }
 
 Uint32 SDL_GPUTextureFormatTexelBlockSize(
-    SDL_GPUTextureFormat textureFormat)
+    SDL_GPUTextureFormat format)
 {
-    switch (textureFormat) {
+    switch (format) {
     case SDL_GPU_TEXTUREFORMAT_BC1_RGBA_UNORM:
     case SDL_GPU_TEXTUREFORMAT_BC1_RGBA_UNORM_SRGB:
     case SDL_GPU_TEXTUREFORMAT_BC4_R_UNORM:
@@ -563,7 +563,7 @@ SDL_bool SDL_GPUTextureSupportsFormat(
 {
     CHECK_DEVICE_MAGIC(device, false);
 
-    if (device->debugMode) {
+    if (device->debug_mode) {
         CHECK_TEXTUREFORMAT_ENUM_INVALID(format, false)
     }
 
@@ -577,49 +577,49 @@ SDL_bool SDL_GPUTextureSupportsFormat(
 SDL_bool SDL_GPUTextureSupportsSampleCount(
     SDL_GPUDevice *device,
     SDL_GPUTextureFormat format,
-    SDL_GPUSampleCount sampleCount)
+    SDL_GPUSampleCount sample_count)
 {
     CHECK_DEVICE_MAGIC(device, 0);
 
-    if (device->debugMode) {
+    if (device->debug_mode) {
         CHECK_TEXTUREFORMAT_ENUM_INVALID(format, 0)
     }
 
     return device->SupportsSampleCount(
         device->driverData,
         format,
-        sampleCount);
+        sample_count);
 }
 
 // State Creation
 
 SDL_GPUComputePipeline *SDL_CreateGPUComputePipeline(
     SDL_GPUDevice *device,
-    const SDL_GPUComputePipelineCreateInfo *computePipelineCreateInfo)
+    const SDL_GPUComputePipelineCreateInfo *createinfo)
 {
     CHECK_DEVICE_MAGIC(device, NULL);
-    if (computePipelineCreateInfo == NULL) {
-        SDL_InvalidParamError("computePipelineCreateInfo");
+    if (createinfo == NULL) {
+        SDL_InvalidParamError("createinfo");
         return NULL;
     }
 
-    if (device->debugMode) {
-        if (!(computePipelineCreateInfo->format & device->shaderFormats)) {
+    if (device->debug_mode) {
+        if (!(createinfo->format & device->shaderFormats)) {
             SDL_assert_release(!"Incompatible shader format for GPU backend");
             return NULL;
         }
 
-        if (computePipelineCreateInfo->writeOnlyStorageTextureCount > MAX_COMPUTE_WRITE_TEXTURES) {
+        if (createinfo->num_writeonly_storage_textures > MAX_COMPUTE_WRITE_TEXTURES) {
             SDL_assert_release(!"Compute pipeline write-only texture count cannot be higher than 8!");
             return NULL;
         }
-        if (computePipelineCreateInfo->writeOnlyStorageBufferCount > MAX_COMPUTE_WRITE_BUFFERS) {
+        if (createinfo->num_writeonly_storage_buffers > MAX_COMPUTE_WRITE_BUFFERS) {
             SDL_assert_release(!"Compute pipeline write-only buffer count cannot be higher than 8!");
             return NULL;
         }
-        if (computePipelineCreateInfo->threadCountX == 0 ||
-            computePipelineCreateInfo->threadCountY == 0 ||
-            computePipelineCreateInfo->threadCountZ == 0) {
+        if (createinfo->threadcount_x == 0 ||
+            createinfo->threadcount_y == 0 ||
+            createinfo->threadcount_z == 0) {
             SDL_assert_release(!"Compute pipeline threadCount dimensions must be at least 1!");
             return NULL;
         }
@@ -627,7 +627,7 @@ SDL_GPUComputePipeline *SDL_CreateGPUComputePipeline(
 
     return device->CreateComputePipeline(
         device->driverData,
-        computePipelineCreateInfo);
+        createinfo);
 }
 
 SDL_GPUGraphicsPipeline *SDL_CreateGPUGraphicsPipeline(
@@ -640,17 +640,17 @@ SDL_GPUGraphicsPipeline *SDL_CreateGPUGraphicsPipeline(
         return NULL;
     }
 
-    if (device->debugMode) {
-        for (Uint32 i = 0; i < graphicsPipelineCreateInfo->attachmentInfo.colorAttachmentCount; i += 1) {
-            CHECK_TEXTUREFORMAT_ENUM_INVALID(graphicsPipelineCreateInfo->attachmentInfo.colorAttachmentDescriptions[i].format, NULL);
-            if (IsDepthFormat(graphicsPipelineCreateInfo->attachmentInfo.colorAttachmentDescriptions[i].format)) {
+    if (device->debug_mode) {
+        for (Uint32 i = 0; i < graphicsPipelineCreateInfo->attachment_info.num_color_attachments; i += 1) {
+            CHECK_TEXTUREFORMAT_ENUM_INVALID(graphicsPipelineCreateInfo->attachment_info.color_attachment_descriptions[i].format, NULL);
+            if (IsDepthFormat(graphicsPipelineCreateInfo->attachment_info.color_attachment_descriptions[i].format)) {
                 SDL_assert_release(!"Color attachment formats cannot be a depth format!");
                 return NULL;
             }
         }
-        if (graphicsPipelineCreateInfo->attachmentInfo.hasDepthStencilAttachment) {
-            CHECK_TEXTUREFORMAT_ENUM_INVALID(graphicsPipelineCreateInfo->attachmentInfo.depthStencilFormat, NULL);
-            if (!IsDepthFormat(graphicsPipelineCreateInfo->attachmentInfo.depthStencilFormat)) {
+        if (graphicsPipelineCreateInfo->attachment_info.has_depth_stencil_attachment) {
+            CHECK_TEXTUREFORMAT_ENUM_INVALID(graphicsPipelineCreateInfo->attachment_info.depth_stencil_format, NULL);
+            if (!IsDepthFormat(graphicsPipelineCreateInfo->attachment_info.depth_stencil_format)) {
                 SDL_assert_release(!"Depth-stencil attachment format must be a depth format!");
                 return NULL;
             }
@@ -664,31 +664,31 @@ SDL_GPUGraphicsPipeline *SDL_CreateGPUGraphicsPipeline(
 
 SDL_GPUSampler *SDL_CreateGPUSampler(
     SDL_GPUDevice *device,
-    const SDL_GPUSamplerCreateInfo *samplerCreateInfo)
+    const SDL_GPUSamplerCreateInfo *createinfo)
 {
     CHECK_DEVICE_MAGIC(device, NULL);
-    if (samplerCreateInfo == NULL) {
-        SDL_InvalidParamError("samplerCreateInfo");
+    if (createinfo == NULL) {
+        SDL_InvalidParamError("createinfo");
         return NULL;
     }
 
     return device->CreateSampler(
         device->driverData,
-        samplerCreateInfo);
+        createinfo);
 }
 
 SDL_GPUShader *SDL_CreateGPUShader(
     SDL_GPUDevice *device,
-    const SDL_GPUShaderCreateInfo *shaderCreateInfo)
+    const SDL_GPUShaderCreateInfo *createinfo)
 {
     CHECK_DEVICE_MAGIC(device, NULL);
-    if (shaderCreateInfo == NULL) {
-        SDL_InvalidParamError("shaderCreateInfo");
+    if (createinfo == NULL) {
+        SDL_InvalidParamError("createinfo");
         return NULL;
     }
 
-    if (device->debugMode) {
-        if (!(shaderCreateInfo->format & device->shaderFormats)) {
+    if (device->debug_mode) {
+        if (!(createinfo->format & device->shaderFormats)) {
             SDL_assert_release(!"Incompatible shader format for GPU backend");
             return NULL;
         }
@@ -696,109 +696,109 @@ SDL_GPUShader *SDL_CreateGPUShader(
 
     return device->CreateShader(
         device->driverData,
-        shaderCreateInfo);
+        createinfo);
 }
 
 SDL_GPUTexture *SDL_CreateGPUTexture(
     SDL_GPUDevice *device,
-    const SDL_GPUTextureCreateInfo *textureCreateInfo)
+    const SDL_GPUTextureCreateInfo *createinfo)
 {
     CHECK_DEVICE_MAGIC(device, NULL);
-    if (textureCreateInfo == NULL) {
-        SDL_InvalidParamError("textureCreateInfo");
+    if (createinfo == NULL) {
+        SDL_InvalidParamError("createinfo");
         return NULL;
     }
 
-    if (device->debugMode) {
+    if (device->debug_mode) {
         bool failed = false;
 
         const Uint32 MAX_2D_DIMENSION = 16384;
         const Uint32 MAX_3D_DIMENSION = 2048;
 
         // Common checks for all texture types
-        CHECK_TEXTUREFORMAT_ENUM_INVALID(textureCreateInfo->format, NULL)
+        CHECK_TEXTUREFORMAT_ENUM_INVALID(createinfo->format, NULL)
 
-        if (textureCreateInfo->width <= 0 || textureCreateInfo->height <= 0 || textureCreateInfo->layerCountOrDepth <= 0) {
-            SDL_assert_release(!"For any texture: width, height, and layerCountOrDepth must be >= 1");
+        if (createinfo->width <= 0 || createinfo->height <= 0 || createinfo->layer_count_or_depth <= 0) {
+            SDL_assert_release(!"For any texture: width, height, and layer_count_or_depth must be >= 1");
             failed = true;
         }
-        if (textureCreateInfo->levelCount <= 0) {
-            SDL_assert_release(!"For any texture: levelCount must be >= 1");
+        if (createinfo->num_levels <= 0) {
+            SDL_assert_release(!"For any texture: num_levels must be >= 1");
             failed = true;
         }
-        if ((textureCreateInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ) && (textureCreateInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_SAMPLER)) {
-            SDL_assert_release(!"For any texture: usageFlags cannot contain both GRAPHICS_STORAGE_READ and SAMPLER");
+        if ((createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ) && (createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_SAMPLER)) {
+            SDL_assert_release(!"For any texture: usage_flags cannot contain both GRAPHICS_STORAGE_READ and SAMPLER");
             failed = true;
         }
-        if (IsDepthFormat(textureCreateInfo->format) && (textureCreateInfo->usageFlags & ~(SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER))) {
-            SDL_assert_release(!"For depth textures: usageFlags cannot contain any flags except for DEPTH_STENCIL_TARGET and SAMPLER");
+        if (IsDepthFormat(createinfo->format) && (createinfo->usage_flags & ~(SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER))) {
+            SDL_assert_release(!"For depth textures: usage_flags cannot contain any flags except for DEPTH_STENCIL_TARGET and SAMPLER");
             failed = true;
         }
-        if (IsIntegerFormat(textureCreateInfo->format) && (textureCreateInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_SAMPLER)) {
-            SDL_assert_release(!"For any texture: usageFlags cannot contain SAMPLER for textures with an integer format");
+        if (IsIntegerFormat(createinfo->format) && (createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_SAMPLER)) {
+            SDL_assert_release(!"For any texture: usage_flags cannot contain SAMPLER for textures with an integer format");
             failed = true;
         }
 
-        if (textureCreateInfo->type == SDL_GPU_TEXTURETYPE_CUBE) {
+        if (createinfo->type == SDL_GPU_TEXTURETYPE_CUBE) {
             // Cubemap validation
-            if (textureCreateInfo->width != textureCreateInfo->height) {
+            if (createinfo->width != createinfo->height) {
                 SDL_assert_release(!"For cube textures: width and height must be identical");
                 failed = true;
             }
-            if (textureCreateInfo->width > MAX_2D_DIMENSION || textureCreateInfo->height > MAX_2D_DIMENSION) {
+            if (createinfo->width > MAX_2D_DIMENSION || createinfo->height > MAX_2D_DIMENSION) {
                 SDL_assert_release(!"For cube textures: width and height must be <= 16384");
                 failed = true;
             }
-            if (textureCreateInfo->layerCountOrDepth != 6) {
-                SDL_assert_release(!"For cube textures: layerCountOrDepth must be 6");
+            if (createinfo->layer_count_or_depth != 6) {
+                SDL_assert_release(!"For cube textures: layer_count_or_depth must be 6");
                 failed = true;
             }
-            if (textureCreateInfo->sampleCount > SDL_GPU_SAMPLECOUNT_1) {
-                SDL_assert_release(!"For cube textures: sampleCount must be SDL_GPU_SAMPLECOUNT_1");
+            if (createinfo->sample_count > SDL_GPU_SAMPLECOUNT_1) {
+                SDL_assert_release(!"For cube textures: sample_count must be SDL_GPU_SAMPLECOUNT_1");
                 failed = true;
             }
-            if (!SDL_GPUTextureSupportsFormat(device, textureCreateInfo->format, SDL_GPU_TEXTURETYPE_CUBE, textureCreateInfo->usageFlags)) {
-                SDL_assert_release(!"For cube textures: the format is unsupported for the given usageFlags");
+            if (!SDL_GPUTextureSupportsFormat(device, createinfo->format, SDL_GPU_TEXTURETYPE_CUBE, createinfo->usage_flags)) {
+                SDL_assert_release(!"For cube textures: the format is unsupported for the given usage_flags");
                 failed = true;
             }
-        } else if (textureCreateInfo->type == SDL_GPU_TEXTURETYPE_3D) {
+        } else if (createinfo->type == SDL_GPU_TEXTURETYPE_3D) {
             // 3D Texture Validation
-            if (textureCreateInfo->width > MAX_3D_DIMENSION || textureCreateInfo->height > MAX_3D_DIMENSION || textureCreateInfo->layerCountOrDepth > MAX_3D_DIMENSION) {
-                SDL_assert_release(!"For 3D textures: width, height, and layerCountOrDepth must be <= 2048");
+            if (createinfo->width > MAX_3D_DIMENSION || createinfo->height > MAX_3D_DIMENSION || createinfo->layer_count_or_depth > MAX_3D_DIMENSION) {
+                SDL_assert_release(!"For 3D textures: width, height, and layer_count_or_depth must be <= 2048");
                 failed = true;
             }
-            if (textureCreateInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
-                SDL_assert_release(!"For 3D textures: usageFlags must not contain DEPTH_STENCIL_TARGET");
+            if (createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
+                SDL_assert_release(!"For 3D textures: usage_flags must not contain DEPTH_STENCIL_TARGET");
                 failed = true;
             }
-            if (textureCreateInfo->sampleCount > SDL_GPU_SAMPLECOUNT_1) {
-                SDL_assert_release(!"For 3D textures: sampleCount must be SDL_GPU_SAMPLECOUNT_1");
+            if (createinfo->sample_count > SDL_GPU_SAMPLECOUNT_1) {
+                SDL_assert_release(!"For 3D textures: sample_count must be SDL_GPU_SAMPLECOUNT_1");
                 failed = true;
             }
-            if (!SDL_GPUTextureSupportsFormat(device, textureCreateInfo->format, SDL_GPU_TEXTURETYPE_3D, textureCreateInfo->usageFlags)) {
-                SDL_assert_release(!"For 3D textures: the format is unsupported for the given usageFlags");
+            if (!SDL_GPUTextureSupportsFormat(device, createinfo->format, SDL_GPU_TEXTURETYPE_3D, createinfo->usage_flags)) {
+                SDL_assert_release(!"For 3D textures: the format is unsupported for the given usage_flags");
                 failed = true;
             }
         } else {
-            if (textureCreateInfo->type == SDL_GPU_TEXTURETYPE_2D_ARRAY) {
+            if (createinfo->type == SDL_GPU_TEXTURETYPE_2D_ARRAY) {
                 // Array Texture Validation
-                if (textureCreateInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
-                    SDL_assert_release(!"For array textures: usageFlags must not contain DEPTH_STENCIL_TARGET");
+                if (createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
+                    SDL_assert_release(!"For array textures: usage_flags must not contain DEPTH_STENCIL_TARGET");
                     failed = true;
                 }
-                if (textureCreateInfo->sampleCount > SDL_GPU_SAMPLECOUNT_1) {
-                    SDL_assert_release(!"For array textures: sampleCount must be SDL_GPU_SAMPLECOUNT_1");
+                if (createinfo->sample_count > SDL_GPU_SAMPLECOUNT_1) {
+                    SDL_assert_release(!"For array textures: sample_count must be SDL_GPU_SAMPLECOUNT_1");
                     failed = true;
                 }
             } else {
                 // 2D Texture Validation
-                if (textureCreateInfo->sampleCount > SDL_GPU_SAMPLECOUNT_1 && textureCreateInfo->levelCount > 1) {
-                    SDL_assert_release(!"For 2D textures: if sampleCount is >= SDL_GPU_SAMPLECOUNT_1, then levelCount must be 1");
+                if (createinfo->sample_count > SDL_GPU_SAMPLECOUNT_1 && createinfo->num_levels > 1) {
+                    SDL_assert_release(!"For 2D textures: if sample_count is >= SDL_GPU_SAMPLECOUNT_1, then num_levels must be 1");
                     failed = true;
                 }
             }
-            if (!SDL_GPUTextureSupportsFormat(device, textureCreateInfo->format, SDL_GPU_TEXTURETYPE_2D, textureCreateInfo->usageFlags)) {
-                SDL_assert_release(!"For 2D textures: the format is unsupported for the given usageFlags");
+            if (!SDL_GPUTextureSupportsFormat(device, createinfo->format, SDL_GPU_TEXTURETYPE_2D, createinfo->usage_flags)) {
+                SDL_assert_release(!"For 2D textures: the format is unsupported for the given usage_flags");
                 failed = true;
             }
         }
@@ -810,39 +810,39 @@ SDL_GPUTexture *SDL_CreateGPUTexture(
 
     return device->CreateTexture(
         device->driverData,
-        textureCreateInfo);
+        createinfo);
 }
 
 SDL_GPUBuffer *SDL_CreateGPUBuffer(
     SDL_GPUDevice *device,
-    const SDL_GPUBufferCreateInfo *bufferCreateInfo)
+    const SDL_GPUBufferCreateInfo *createinfo)
 {
     CHECK_DEVICE_MAGIC(device, NULL);
-    if (bufferCreateInfo == NULL) {
-        SDL_InvalidParamError("bufferCreateInfo");
+    if (createinfo == NULL) {
+        SDL_InvalidParamError("createinfo");
         return NULL;
     }
 
     return device->CreateBuffer(
         device->driverData,
-        bufferCreateInfo->usageFlags,
-        bufferCreateInfo->sizeInBytes);
+        createinfo->usage_flags,
+        createinfo->size);
 }
 
 SDL_GPUTransferBuffer *SDL_CreateGPUTransferBuffer(
     SDL_GPUDevice *device,
-    const SDL_GPUTransferBufferCreateInfo *transferBufferCreateInfo)
+    const SDL_GPUTransferBufferCreateInfo *createinfo)
 {
     CHECK_DEVICE_MAGIC(device, NULL);
-    if (transferBufferCreateInfo == NULL) {
-        SDL_InvalidParamError("transferBufferCreateInfo");
+    if (createinfo == NULL) {
+        SDL_InvalidParamError("createinfo");
         return NULL;
     }
 
     return device->CreateTransferBuffer(
         device->driverData,
-        transferBufferCreateInfo->usage,
-        transferBufferCreateInfo->sizeInBytes);
+        createinfo->usage,
+        createinfo->size);
 }
 
 // Debug Naming
@@ -888,11 +888,11 @@ void SDL_SetGPUTextureName(
 }
 
 void SDL_InsertGPUDebugLabel(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const char *text)
 {
-    if (commandBuffer == NULL) {
-        SDL_InvalidParamError("commandBuffer");
+    if (command_buffer == NULL) {
+        SDL_InvalidParamError("command_buffer");
         return;
     }
     if (text == NULL) {
@@ -900,21 +900,21 @@ void SDL_InsertGPUDebugLabel(
         return;
     }
 
-    if (COMMAND_BUFFER_DEVICE->debugMode) {
+    if (COMMAND_BUFFER_DEVICE->debug_mode) {
         CHECK_COMMAND_BUFFER
     }
 
     COMMAND_BUFFER_DEVICE->InsertDebugLabel(
-        commandBuffer,
+        command_buffer,
         text);
 }
 
 void SDL_PushGPUDebugGroup(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const char *name)
 {
-    if (commandBuffer == NULL) {
-        SDL_InvalidParamError("commandBuffer");
+    if (command_buffer == NULL) {
+        SDL_InvalidParamError("command_buffer");
         return;
     }
     if (name == NULL) {
@@ -922,29 +922,29 @@ void SDL_PushGPUDebugGroup(
         return;
     }
 
-    if (COMMAND_BUFFER_DEVICE->debugMode) {
+    if (COMMAND_BUFFER_DEVICE->debug_mode) {
         CHECK_COMMAND_BUFFER
     }
 
     COMMAND_BUFFER_DEVICE->PushDebugGroup(
-        commandBuffer,
+        command_buffer,
         name);
 }
 
 void SDL_PopGPUDebugGroup(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
-    if (commandBuffer == NULL) {
-        SDL_InvalidParamError("commandBuffer");
+    if (command_buffer == NULL) {
+        SDL_InvalidParamError("command_buffer");
         return;
     }
 
-    if (COMMAND_BUFFER_DEVICE->debugMode) {
+    if (COMMAND_BUFFER_DEVICE->debug_mode) {
         CHECK_COMMAND_BUFFER
     }
 
     COMMAND_BUFFER_DEVICE->PopDebugGroup(
-        commandBuffer);
+        command_buffer);
 }
 
 // Disposal
@@ -993,16 +993,16 @@ void SDL_ReleaseGPUBuffer(
 
 void SDL_ReleaseGPUTransferBuffer(
     SDL_GPUDevice *device,
-    SDL_GPUTransferBuffer *transferBuffer)
+    SDL_GPUTransferBuffer *transfer_buffer)
 {
     CHECK_DEVICE_MAGIC(device, );
-    if (transferBuffer == NULL) {
+    if (transfer_buffer == NULL) {
         return;
     }
 
     device->ReleaseTransferBuffer(
         device->driverData,
-        transferBuffer);
+        transfer_buffer);
 }
 
 void SDL_ReleaseGPUShader(
@@ -1021,30 +1021,30 @@ void SDL_ReleaseGPUShader(
 
 void SDL_ReleaseGPUComputePipeline(
     SDL_GPUDevice *device,
-    SDL_GPUComputePipeline *computePipeline)
+    SDL_GPUComputePipeline *compute_pipeline)
 {
     CHECK_DEVICE_MAGIC(device, );
-    if (computePipeline == NULL) {
+    if (compute_pipeline == NULL) {
         return;
     }
 
     device->ReleaseComputePipeline(
         device->driverData,
-        computePipeline);
+        compute_pipeline);
 }
 
 void SDL_ReleaseGPUGraphicsPipeline(
     SDL_GPUDevice *device,
-    SDL_GPUGraphicsPipeline *graphicsPipeline)
+    SDL_GPUGraphicsPipeline *graphics_pipeline)
 {
     CHECK_DEVICE_MAGIC(device, );
-    if (graphicsPipeline == NULL) {
+    if (graphics_pipeline == NULL) {
         return;
     }
 
     device->ReleaseGraphicsPipeline(
         device->driverData,
-        graphicsPipeline);
+        graphics_pipeline);
 }
 
 // Command Buffer
@@ -1052,43 +1052,43 @@ void SDL_ReleaseGPUGraphicsPipeline(
 SDL_GPUCommandBuffer *SDL_AcquireGPUCommandBuffer(
     SDL_GPUDevice *device)
 {
-    SDL_GPUCommandBuffer *commandBuffer;
+    SDL_GPUCommandBuffer *command_buffer;
     CommandBufferCommonHeader *commandBufferHeader;
 
     CHECK_DEVICE_MAGIC(device, NULL);
 
-    commandBuffer = device->AcquireCommandBuffer(
+    command_buffer = device->AcquireCommandBuffer(
         device->driverData);
 
-    if (commandBuffer == NULL) {
+    if (command_buffer == NULL) {
         return NULL;
     }
 
-    commandBufferHeader = (CommandBufferCommonHeader *)commandBuffer;
+    commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
     commandBufferHeader->device = device;
-    commandBufferHeader->renderPass.commandBuffer = commandBuffer;
-    commandBufferHeader->renderPass.inProgress = false;
+    commandBufferHeader->render_pass.command_buffer = command_buffer;
+    commandBufferHeader->render_pass.inProgress = false;
     commandBufferHeader->graphicsPipelineBound = false;
-    commandBufferHeader->computePass.commandBuffer = commandBuffer;
-    commandBufferHeader->computePass.inProgress = false;
+    commandBufferHeader->compute_pass.command_buffer = command_buffer;
+    commandBufferHeader->compute_pass.inProgress = false;
     commandBufferHeader->computePipelineBound = false;
-    commandBufferHeader->copyPass.commandBuffer = commandBuffer;
-    commandBufferHeader->copyPass.inProgress = false;
+    commandBufferHeader->copy_pass.command_buffer = command_buffer;
+    commandBufferHeader->copy_pass.inProgress = false;
     commandBufferHeader->submitted = false;
 
-    return commandBuffer;
+    return command_buffer;
 }
 
 // Uniforms
 
 void SDL_PushGPUVertexUniformData(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 slotIndex,
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 slot_index,
     const void *data,
-    Uint32 dataLengthInBytes)
+    Uint32 length)
 {
-    if (commandBuffer == NULL) {
-        SDL_InvalidParamError("commandBuffer");
+    if (command_buffer == NULL) {
+        SDL_InvalidParamError("command_buffer");
         return;
     }
     if (data == NULL) {
@@ -1096,25 +1096,25 @@ void SDL_PushGPUVertexUniformData(
         return;
     }
 
-    if (COMMAND_BUFFER_DEVICE->debugMode) {
+    if (COMMAND_BUFFER_DEVICE->debug_mode) {
         CHECK_COMMAND_BUFFER
     }
 
     COMMAND_BUFFER_DEVICE->PushVertexUniformData(
-        commandBuffer,
-        slotIndex,
+        command_buffer,
+        slot_index,
         data,
-        dataLengthInBytes);
+        length);
 }
 
 void SDL_PushGPUFragmentUniformData(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 slotIndex,
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 slot_index,
     const void *data,
-    Uint32 dataLengthInBytes)
+    Uint32 length)
 {
-    if (commandBuffer == NULL) {
-        SDL_InvalidParamError("commandBuffer");
+    if (command_buffer == NULL) {
+        SDL_InvalidParamError("command_buffer");
         return;
     }
     if (data == NULL) {
@@ -1122,25 +1122,25 @@ void SDL_PushGPUFragmentUniformData(
         return;
     }
 
-    if (COMMAND_BUFFER_DEVICE->debugMode) {
+    if (COMMAND_BUFFER_DEVICE->debug_mode) {
         CHECK_COMMAND_BUFFER
     }
 
     COMMAND_BUFFER_DEVICE->PushFragmentUniformData(
-        commandBuffer,
-        slotIndex,
+        command_buffer,
+        slot_index,
         data,
-        dataLengthInBytes);
+        length);
 }
 
 void SDL_PushGPUComputeUniformData(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 slotIndex,
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 slot_index,
     const void *data,
-    Uint32 dataLengthInBytes)
+    Uint32 length)
 {
-    if (commandBuffer == NULL) {
-        SDL_InvalidParamError("commandBuffer");
+    if (command_buffer == NULL) {
+        SDL_InvalidParamError("command_buffer");
         return;
     }
     if (data == NULL) {
@@ -1148,96 +1148,96 @@ void SDL_PushGPUComputeUniformData(
         return;
     }
 
-    if (COMMAND_BUFFER_DEVICE->debugMode) {
+    if (COMMAND_BUFFER_DEVICE->debug_mode) {
         CHECK_COMMAND_BUFFER
     }
 
     COMMAND_BUFFER_DEVICE->PushComputeUniformData(
-        commandBuffer,
-        slotIndex,
+        command_buffer,
+        slot_index,
         data,
-        dataLengthInBytes);
+        length);
 }
 
 // Render Pass
 
 SDL_GPURenderPass *SDL_BeginGPURenderPass(
-    SDL_GPUCommandBuffer *commandBuffer,
-    const SDL_GPUColorAttachmentInfo *colorAttachmentInfos,
-    Uint32 colorAttachmentCount,
-    const SDL_GPUDepthStencilAttachmentInfo *depthStencilAttachmentInfo)
+    SDL_GPUCommandBuffer *command_buffer,
+    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
+    Uint32 num_color_attachments,
+    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info)
 {
     CommandBufferCommonHeader *commandBufferHeader;
 
-    if (commandBuffer == NULL) {
-        SDL_InvalidParamError("commandBuffer");
+    if (command_buffer == NULL) {
+        SDL_InvalidParamError("command_buffer");
         return NULL;
     }
-    if (colorAttachmentInfos == NULL && colorAttachmentCount > 0) {
-        SDL_InvalidParamError("colorAttachmentInfos");
-        return NULL;
-    }
-
-    if (colorAttachmentCount > MAX_COLOR_TARGET_BINDINGS) {
-        SDL_SetError("colorAttachmentCount exceeds MAX_COLOR_TARGET_BINDINGS");
+    if (color_attachment_infos == NULL && num_color_attachments > 0) {
+        SDL_InvalidParamError("color_attachment_infos");
         return NULL;
     }
 
-    if (COMMAND_BUFFER_DEVICE->debugMode) {
+    if (num_color_attachments > MAX_COLOR_TARGET_BINDINGS) {
+        SDL_SetError("num_color_attachments exceeds MAX_COLOR_TARGET_BINDINGS");
+        return NULL;
+    }
+
+    if (COMMAND_BUFFER_DEVICE->debug_mode) {
         CHECK_COMMAND_BUFFER_RETURN_NULL
         CHECK_ANY_PASS_IN_PROGRESS("Cannot begin render pass during another pass!", NULL)
 
-        for (Uint32 i = 0; i < colorAttachmentCount; i += 1) {
-            if (colorAttachmentInfos[i].cycle && colorAttachmentInfos[i].loadOp == SDL_GPU_LOADOP_LOAD) {
+        for (Uint32 i = 0; i < num_color_attachments; i += 1) {
+            if (color_attachment_infos[i].cycle && color_attachment_infos[i].load_op == SDL_GPU_LOADOP_LOAD) {
                 SDL_assert_release(!"Cannot cycle color attachment when load op is LOAD!");
             }
         }
 
-        if (depthStencilAttachmentInfo != NULL && depthStencilAttachmentInfo->cycle && (depthStencilAttachmentInfo->loadOp == SDL_GPU_LOADOP_LOAD || depthStencilAttachmentInfo->loadOp == SDL_GPU_LOADOP_LOAD)) {
+        if (depth_stencil_attachment_info != NULL && depth_stencil_attachment_info->cycle && (depth_stencil_attachment_info->load_op == SDL_GPU_LOADOP_LOAD || depth_stencil_attachment_info->load_op == SDL_GPU_LOADOP_LOAD)) {
             SDL_assert_release(!"Cannot cycle depth attachment when load op or stencil load op is LOAD!");
         }
     }
 
     COMMAND_BUFFER_DEVICE->BeginRenderPass(
-        commandBuffer,
-        colorAttachmentInfos,
-        colorAttachmentCount,
-        depthStencilAttachmentInfo);
+        command_buffer,
+        color_attachment_infos,
+        num_color_attachments,
+        depth_stencil_attachment_info);
 
-    commandBufferHeader = (CommandBufferCommonHeader *)commandBuffer;
-    commandBufferHeader->renderPass.inProgress = true;
-    return (SDL_GPURenderPass *)&(commandBufferHeader->renderPass);
+    commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
+    commandBufferHeader->render_pass.inProgress = true;
+    return (SDL_GPURenderPass *)&(commandBufferHeader->render_pass);
 }
 
 void SDL_BindGPUGraphicsPipeline(
-    SDL_GPURenderPass *renderPass,
-    SDL_GPUGraphicsPipeline *graphicsPipeline)
+    SDL_GPURenderPass *render_pass,
+    SDL_GPUGraphicsPipeline *graphics_pipeline)
 {
     CommandBufferCommonHeader *commandBufferHeader;
 
-    if (renderPass == NULL) {
-        SDL_InvalidParamError("renderPass");
+    if (render_pass == NULL) {
+        SDL_InvalidParamError("render_pass");
         return;
     }
-    if (graphicsPipeline == NULL) {
-        SDL_InvalidParamError("graphicsPipeline");
+    if (graphics_pipeline == NULL) {
+        SDL_InvalidParamError("graphics_pipeline");
         return;
     }
 
     RENDERPASS_DEVICE->BindGraphicsPipeline(
         RENDERPASS_COMMAND_BUFFER,
-        graphicsPipeline);
+        graphics_pipeline);
 
     commandBufferHeader = (CommandBufferCommonHeader *)RENDERPASS_COMMAND_BUFFER;
     commandBufferHeader->graphicsPipelineBound = true;
 }
 
 void SDL_SetGPUViewport(
-    SDL_GPURenderPass *renderPass,
+    SDL_GPURenderPass *render_pass,
     const SDL_GPUViewport *viewport)
 {
-    if (renderPass == NULL) {
-        SDL_InvalidParamError("renderPass");
+    if (render_pass == NULL) {
+        SDL_InvalidParamError("render_pass");
         return;
     }
     if (viewport == NULL) {
@@ -1245,7 +1245,7 @@ void SDL_SetGPUViewport(
         return;
     }
 
-    if (RENDERPASS_DEVICE->debugMode) {
+    if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS
     }
 
@@ -1255,11 +1255,11 @@ void SDL_SetGPUViewport(
 }
 
 void SDL_SetGPUScissor(
-    SDL_GPURenderPass *renderPass,
+    SDL_GPURenderPass *render_pass,
     const SDL_Rect *scissor)
 {
-    if (renderPass == NULL) {
-        SDL_InvalidParamError("renderPass");
+    if (render_pass == NULL) {
+        SDL_InvalidParamError("render_pass");
         return;
     }
     if (scissor == NULL) {
@@ -1267,7 +1267,7 @@ void SDL_SetGPUScissor(
         return;
     }
 
-    if (RENDERPASS_DEVICE->debugMode) {
+    if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS
     }
 
@@ -1277,33 +1277,33 @@ void SDL_SetGPUScissor(
 }
 
 void SDL_SetGPUBlendConstants(
-    SDL_GPURenderPass *renderPass,
-    SDL_FColor blendConstants)
+    SDL_GPURenderPass *render_pass,
+    SDL_FColor blend_constants)
 {
-    if (renderPass == NULL) {
-        SDL_InvalidParamError("renderPass");
+    if (render_pass == NULL) {
+        SDL_InvalidParamError("render_pass");
         return;
     }
 
-    if (RENDERPASS_DEVICE->debugMode) {
+    if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS
     }
 
     RENDERPASS_DEVICE->SetBlendConstants(
         RENDERPASS_COMMAND_BUFFER,
-        blendConstants);
+        blend_constants);
 }
 
 void SDL_SetGPUStencilReference(
-    SDL_GPURenderPass *renderPass,
+    SDL_GPURenderPass *render_pass,
     Uint8 reference)
 {
-    if (renderPass == NULL) {
-        SDL_InvalidParamError("renderPass");
+    if (render_pass == NULL) {
+        SDL_InvalidParamError("render_pass");
         return;
     }
 
-    if (RENDERPASS_DEVICE->debugMode) {
+    if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS
     }
 
@@ -1313,38 +1313,38 @@ void SDL_SetGPUStencilReference(
 }
 
 void SDL_BindGPUVertexBuffers(
-    SDL_GPURenderPass *renderPass,
-    Uint32 firstBinding,
-    const SDL_GPUBufferBinding *pBindings,
-    Uint32 bindingCount)
+    SDL_GPURenderPass *render_pass,
+    Uint32 first_binding,
+    const SDL_GPUBufferBinding *bindings,
+    Uint32 num_bindings)
 {
-    if (renderPass == NULL) {
-        SDL_InvalidParamError("renderPass");
+    if (render_pass == NULL) {
+        SDL_InvalidParamError("render_pass");
         return;
     }
-    if (pBindings == NULL && bindingCount > 0) {
-        SDL_InvalidParamError("pBindings");
+    if (bindings == NULL && num_bindings > 0) {
+        SDL_InvalidParamError("bindings");
         return;
     }
 
-    if (RENDERPASS_DEVICE->debugMode) {
+    if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS
     }
 
     RENDERPASS_DEVICE->BindVertexBuffers(
         RENDERPASS_COMMAND_BUFFER,
-        firstBinding,
-        pBindings,
-        bindingCount);
+        first_binding,
+        bindings,
+        num_bindings);
 }
 
 void SDL_BindGPUIndexBuffer(
-    SDL_GPURenderPass *renderPass,
+    SDL_GPURenderPass *render_pass,
     const SDL_GPUBufferBinding *pBinding,
-    SDL_GPUIndexElementSize indexElementSize)
+    SDL_GPUIndexElementSize index_element_size)
 {
-    if (renderPass == NULL) {
-        SDL_InvalidParamError("renderPass");
+    if (render_pass == NULL) {
+        SDL_InvalidParamError("render_pass");
         return;
     }
     if (pBinding == NULL) {
@@ -1352,233 +1352,233 @@ void SDL_BindGPUIndexBuffer(
         return;
     }
 
-    if (RENDERPASS_DEVICE->debugMode) {
+    if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS
     }
 
     RENDERPASS_DEVICE->BindIndexBuffer(
         RENDERPASS_COMMAND_BUFFER,
         pBinding,
-        indexElementSize);
+        index_element_size);
 }
 
 void SDL_BindGPUVertexSamplers(
-    SDL_GPURenderPass *renderPass,
-    Uint32 firstSlot,
-    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
-    Uint32 bindingCount)
+    SDL_GPURenderPass *render_pass,
+    Uint32 first_slot,
+    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
+    Uint32 num_bindings)
 {
-    if (renderPass == NULL) {
-        SDL_InvalidParamError("renderPass");
+    if (render_pass == NULL) {
+        SDL_InvalidParamError("render_pass");
         return;
     }
-    if (textureSamplerBindings == NULL && bindingCount > 0) {
-        SDL_InvalidParamError("textureSamplerBindings");
+    if (texture_sampler_bindings == NULL && num_bindings > 0) {
+        SDL_InvalidParamError("texture_sampler_bindings");
         return;
     }
 
-    if (RENDERPASS_DEVICE->debugMode) {
+    if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS
     }
 
     RENDERPASS_DEVICE->BindVertexSamplers(
         RENDERPASS_COMMAND_BUFFER,
-        firstSlot,
-        textureSamplerBindings,
-        bindingCount);
+        first_slot,
+        texture_sampler_bindings,
+        num_bindings);
 }
 
 void SDL_BindGPUVertexStorageTextures(
-    SDL_GPURenderPass *renderPass,
-    Uint32 firstSlot,
-    SDL_GPUTexture *const *storageTextures,
-    Uint32 bindingCount)
+    SDL_GPURenderPass *render_pass,
+    Uint32 first_slot,
+    SDL_GPUTexture *const *storage_textures,
+    Uint32 num_bindings)
 {
-    if (renderPass == NULL) {
-        SDL_InvalidParamError("renderPass");
+    if (render_pass == NULL) {
+        SDL_InvalidParamError("render_pass");
         return;
     }
-    if (storageTextures == NULL && bindingCount > 0) {
-        SDL_InvalidParamError("storageTextures");
+    if (storage_textures == NULL && num_bindings > 0) {
+        SDL_InvalidParamError("storage_textures");
         return;
     }
 
-    if (RENDERPASS_DEVICE->debugMode) {
+    if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS
     }
 
     RENDERPASS_DEVICE->BindVertexStorageTextures(
         RENDERPASS_COMMAND_BUFFER,
-        firstSlot,
-        storageTextures,
-        bindingCount);
+        first_slot,
+        storage_textures,
+        num_bindings);
 }
 
 void SDL_BindGPUVertexStorageBuffers(
-    SDL_GPURenderPass *renderPass,
-    Uint32 firstSlot,
-    SDL_GPUBuffer *const *storageBuffers,
-    Uint32 bindingCount)
+    SDL_GPURenderPass *render_pass,
+    Uint32 first_slot,
+    SDL_GPUBuffer *const *storage_buffers,
+    Uint32 num_bindings)
 {
-    if (renderPass == NULL) {
-        SDL_InvalidParamError("renderPass");
+    if (render_pass == NULL) {
+        SDL_InvalidParamError("render_pass");
         return;
     }
-    if (storageBuffers == NULL && bindingCount > 0) {
-        SDL_InvalidParamError("storageBuffers");
+    if (storage_buffers == NULL && num_bindings > 0) {
+        SDL_InvalidParamError("storage_buffers");
         return;
     }
 
-    if (RENDERPASS_DEVICE->debugMode) {
+    if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS
     }
 
     RENDERPASS_DEVICE->BindVertexStorageBuffers(
         RENDERPASS_COMMAND_BUFFER,
-        firstSlot,
-        storageBuffers,
-        bindingCount);
+        first_slot,
+        storage_buffers,
+        num_bindings);
 }
 
 void SDL_BindGPUFragmentSamplers(
-    SDL_GPURenderPass *renderPass,
-    Uint32 firstSlot,
-    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
-    Uint32 bindingCount)
+    SDL_GPURenderPass *render_pass,
+    Uint32 first_slot,
+    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
+    Uint32 num_bindings)
 {
-    if (renderPass == NULL) {
-        SDL_InvalidParamError("renderPass");
+    if (render_pass == NULL) {
+        SDL_InvalidParamError("render_pass");
         return;
     }
-    if (textureSamplerBindings == NULL && bindingCount > 0) {
-        SDL_InvalidParamError("textureSamplerBindings");
+    if (texture_sampler_bindings == NULL && num_bindings > 0) {
+        SDL_InvalidParamError("texture_sampler_bindings");
         return;
     }
 
-    if (RENDERPASS_DEVICE->debugMode) {
+    if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS
     }
 
     RENDERPASS_DEVICE->BindFragmentSamplers(
         RENDERPASS_COMMAND_BUFFER,
-        firstSlot,
-        textureSamplerBindings,
-        bindingCount);
+        first_slot,
+        texture_sampler_bindings,
+        num_bindings);
 }
 
 void SDL_BindGPUFragmentStorageTextures(
-    SDL_GPURenderPass *renderPass,
-    Uint32 firstSlot,
-    SDL_GPUTexture *const *storageTextures,
-    Uint32 bindingCount)
+    SDL_GPURenderPass *render_pass,
+    Uint32 first_slot,
+    SDL_GPUTexture *const *storage_textures,
+    Uint32 num_bindings)
 {
-    if (renderPass == NULL) {
-        SDL_InvalidParamError("renderPass");
+    if (render_pass == NULL) {
+        SDL_InvalidParamError("render_pass");
         return;
     }
-    if (storageTextures == NULL && bindingCount > 0) {
-        SDL_InvalidParamError("storageTextures");
+    if (storage_textures == NULL && num_bindings > 0) {
+        SDL_InvalidParamError("storage_textures");
         return;
     }
 
-    if (RENDERPASS_DEVICE->debugMode) {
+    if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS
     }
 
     RENDERPASS_DEVICE->BindFragmentStorageTextures(
         RENDERPASS_COMMAND_BUFFER,
-        firstSlot,
-        storageTextures,
-        bindingCount);
+        first_slot,
+        storage_textures,
+        num_bindings);
 }
 
 void SDL_BindGPUFragmentStorageBuffers(
-    SDL_GPURenderPass *renderPass,
-    Uint32 firstSlot,
-    SDL_GPUBuffer *const *storageBuffers,
-    Uint32 bindingCount)
+    SDL_GPURenderPass *render_pass,
+    Uint32 first_slot,
+    SDL_GPUBuffer *const *storage_buffers,
+    Uint32 num_bindings)
 {
-    if (renderPass == NULL) {
-        SDL_InvalidParamError("renderPass");
+    if (render_pass == NULL) {
+        SDL_InvalidParamError("render_pass");
         return;
     }
-    if (storageBuffers == NULL && bindingCount > 0) {
-        SDL_InvalidParamError("storageBuffers");
+    if (storage_buffers == NULL && num_bindings > 0) {
+        SDL_InvalidParamError("storage_buffers");
         return;
     }
 
-    if (RENDERPASS_DEVICE->debugMode) {
+    if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS
     }
 
     RENDERPASS_DEVICE->BindFragmentStorageBuffers(
         RENDERPASS_COMMAND_BUFFER,
-        firstSlot,
-        storageBuffers,
-        bindingCount);
+        first_slot,
+        storage_buffers,
+        num_bindings);
 }
 
 void SDL_DrawGPUIndexedPrimitives(
-    SDL_GPURenderPass *renderPass,
-    Uint32 indexCount,
-    Uint32 instanceCount,
-    Uint32 firstIndex,
-    Sint32 vertexOffset,
-    Uint32 firstInstance)
+    SDL_GPURenderPass *render_pass,
+    Uint32 num_indices,
+    Uint32 num_instances,
+    Uint32 first_index,
+    Sint32 vertex_offset,
+    Uint32 first_instance)
 {
-    if (renderPass == NULL) {
-        SDL_InvalidParamError("renderPass");
+    if (render_pass == NULL) {
+        SDL_InvalidParamError("render_pass");
         return;
     }
 
-    if (RENDERPASS_DEVICE->debugMode) {
+    if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS
         CHECK_GRAPHICS_PIPELINE_BOUND
     }
 
     RENDERPASS_DEVICE->DrawIndexedPrimitives(
         RENDERPASS_COMMAND_BUFFER,
-        indexCount,
-        instanceCount,
-        firstIndex,
-        vertexOffset,
-        firstInstance);
+        num_indices,
+        num_instances,
+        first_index,
+        vertex_offset,
+        first_instance);
 }
 
 void SDL_DrawGPUPrimitives(
-    SDL_GPURenderPass *renderPass,
-    Uint32 vertexCount,
-    Uint32 instanceCount,
-    Uint32 firstVertex,
-    Uint32 firstInstance)
+    SDL_GPURenderPass *render_pass,
+    Uint32 num_vertices,
+    Uint32 num_instances,
+    Uint32 first_vertex,
+    Uint32 first_instance)
 {
-    if (renderPass == NULL) {
-        SDL_InvalidParamError("renderPass");
+    if (render_pass == NULL) {
+        SDL_InvalidParamError("render_pass");
         return;
     }
 
-    if (RENDERPASS_DEVICE->debugMode) {
+    if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS
         CHECK_GRAPHICS_PIPELINE_BOUND
     }
 
     RENDERPASS_DEVICE->DrawPrimitives(
         RENDERPASS_COMMAND_BUFFER,
-        vertexCount,
-        instanceCount,
-        firstVertex,
-        firstInstance);
+        num_vertices,
+        num_instances,
+        first_vertex,
+        first_instance);
 }
 
 void SDL_DrawGPUPrimitivesIndirect(
-    SDL_GPURenderPass *renderPass,
+    SDL_GPURenderPass *render_pass,
     SDL_GPUBuffer *buffer,
-    Uint32 offsetInBytes,
-    Uint32 drawCount,
-    Uint32 stride)
+    Uint32 offset,
+    Uint32 draw_count,
+    Uint32 pitch)
 {
-    if (renderPass == NULL) {
-        SDL_InvalidParamError("renderPass");
+    if (render_pass == NULL) {
+        SDL_InvalidParamError("render_pass");
         return;
     }
     if (buffer == NULL) {
@@ -1586,7 +1586,7 @@ void SDL_DrawGPUPrimitivesIndirect(
         return;
     }
 
-    if (RENDERPASS_DEVICE->debugMode) {
+    if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS
         CHECK_GRAPHICS_PIPELINE_BOUND
     }
@@ -1594,20 +1594,20 @@ void SDL_DrawGPUPrimitivesIndirect(
     RENDERPASS_DEVICE->DrawPrimitivesIndirect(
         RENDERPASS_COMMAND_BUFFER,
         buffer,
-        offsetInBytes,
-        drawCount,
-        stride);
+        offset,
+        draw_count,
+        pitch);
 }
 
 void SDL_DrawGPUIndexedPrimitivesIndirect(
-    SDL_GPURenderPass *renderPass,
+    SDL_GPURenderPass *render_pass,
     SDL_GPUBuffer *buffer,
-    Uint32 offsetInBytes,
-    Uint32 drawCount,
-    Uint32 stride)
+    Uint32 offset,
+    Uint32 draw_count,
+    Uint32 pitch)
 {
-    if (renderPass == NULL) {
-        SDL_InvalidParamError("renderPass");
+    if (render_pass == NULL) {
+        SDL_InvalidParamError("render_pass");
         return;
     }
     if (buffer == NULL) {
@@ -1615,7 +1615,7 @@ void SDL_DrawGPUIndexedPrimitivesIndirect(
         return;
     }
 
-    if (RENDERPASS_DEVICE->debugMode) {
+    if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS
         CHECK_GRAPHICS_PIPELINE_BOUND
     }
@@ -1623,22 +1623,22 @@ void SDL_DrawGPUIndexedPrimitivesIndirect(
     RENDERPASS_DEVICE->DrawIndexedPrimitivesIndirect(
         RENDERPASS_COMMAND_BUFFER,
         buffer,
-        offsetInBytes,
-        drawCount,
-        stride);
+        offset,
+        draw_count,
+        pitch);
 }
 
 void SDL_EndGPURenderPass(
-    SDL_GPURenderPass *renderPass)
+    SDL_GPURenderPass *render_pass)
 {
     CommandBufferCommonHeader *commandBufferCommonHeader;
 
-    if (renderPass == NULL) {
-        SDL_InvalidParamError("renderPass");
+    if (render_pass == NULL) {
+        SDL_InvalidParamError("render_pass");
         return;
     }
 
-    if (RENDERPASS_DEVICE->debugMode) {
+    if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS
     }
 
@@ -1646,171 +1646,171 @@ void SDL_EndGPURenderPass(
         RENDERPASS_COMMAND_BUFFER);
 
     commandBufferCommonHeader = (CommandBufferCommonHeader *)RENDERPASS_COMMAND_BUFFER;
-    commandBufferCommonHeader->renderPass.inProgress = false;
+    commandBufferCommonHeader->render_pass.inProgress = false;
     commandBufferCommonHeader->graphicsPipelineBound = false;
 }
 
 // Compute Pass
 
 SDL_GPUComputePass *SDL_BeginGPUComputePass(
-    SDL_GPUCommandBuffer *commandBuffer,
-    const SDL_GPUStorageTextureWriteOnlyBinding *storageTextureBindings,
-    Uint32 storageTextureBindingCount,
-    const SDL_GPUStorageBufferWriteOnlyBinding *storageBufferBindings,
-    Uint32 storageBufferBindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    const SDL_GPUStorageTextureWriteOnlyBinding *storage_texture_bindings,
+    Uint32 num_storage_texture_bindings,
+    const SDL_GPUStorageBufferWriteOnlyBinding *storage_buffer_bindings,
+    Uint32 num_storage_buffer_bindings)
 {
     CommandBufferCommonHeader *commandBufferHeader;
 
-    if (commandBuffer == NULL) {
-        SDL_InvalidParamError("commandBuffer");
+    if (command_buffer == NULL) {
+        SDL_InvalidParamError("command_buffer");
         return NULL;
     }
-    if (storageTextureBindings == NULL && storageTextureBindingCount > 0) {
-        SDL_InvalidParamError("storageTextureBindings");
+    if (storage_texture_bindings == NULL && num_storage_texture_bindings > 0) {
+        SDL_InvalidParamError("storage_texture_bindings");
         return NULL;
     }
-    if (storageBufferBindings == NULL && storageBufferBindingCount > 0) {
-        SDL_InvalidParamError("storageBufferBindings");
+    if (storage_buffer_bindings == NULL && num_storage_buffer_bindings > 0) {
+        SDL_InvalidParamError("storage_buffer_bindings");
         return NULL;
     }
-    if (storageTextureBindingCount > MAX_COMPUTE_WRITE_TEXTURES) {
-        SDL_InvalidParamError("storageTextureBindingCount");
+    if (num_storage_texture_bindings > MAX_COMPUTE_WRITE_TEXTURES) {
+        SDL_InvalidParamError("num_storage_texture_bindings");
         return NULL;
     }
-    if (storageBufferBindingCount > MAX_COMPUTE_WRITE_BUFFERS) {
-        SDL_InvalidParamError("storageBufferBindingCount");
+    if (num_storage_buffer_bindings > MAX_COMPUTE_WRITE_BUFFERS) {
+        SDL_InvalidParamError("num_storage_buffer_bindings");
         return NULL;
     }
-    if (COMMAND_BUFFER_DEVICE->debugMode) {
+    if (COMMAND_BUFFER_DEVICE->debug_mode) {
         CHECK_COMMAND_BUFFER_RETURN_NULL
         CHECK_ANY_PASS_IN_PROGRESS("Cannot begin compute pass during another pass!", NULL)
     }
 
     COMMAND_BUFFER_DEVICE->BeginComputePass(
-        commandBuffer,
-        storageTextureBindings,
-        storageTextureBindingCount,
-        storageBufferBindings,
-        storageBufferBindingCount);
+        command_buffer,
+        storage_texture_bindings,
+        num_storage_texture_bindings,
+        storage_buffer_bindings,
+        num_storage_buffer_bindings);
 
-    commandBufferHeader = (CommandBufferCommonHeader *)commandBuffer;
-    commandBufferHeader->computePass.inProgress = true;
-    return (SDL_GPUComputePass *)&(commandBufferHeader->computePass);
+    commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
+    commandBufferHeader->compute_pass.inProgress = true;
+    return (SDL_GPUComputePass *)&(commandBufferHeader->compute_pass);
 }
 
 void SDL_BindGPUComputePipeline(
-    SDL_GPUComputePass *computePass,
-    SDL_GPUComputePipeline *computePipeline)
+    SDL_GPUComputePass *compute_pass,
+    SDL_GPUComputePipeline *compute_pipeline)
 {
     CommandBufferCommonHeader *commandBufferHeader;
 
-    if (computePass == NULL) {
-        SDL_InvalidParamError("computePass");
+    if (compute_pass == NULL) {
+        SDL_InvalidParamError("compute_pass");
         return;
     }
-    if (computePipeline == NULL) {
-        SDL_InvalidParamError("computePipeline");
+    if (compute_pipeline == NULL) {
+        SDL_InvalidParamError("compute_pipeline");
         return;
     }
 
-    if (COMPUTEPASS_DEVICE->debugMode) {
+    if (COMPUTEPASS_DEVICE->debug_mode) {
         CHECK_COMPUTEPASS
     }
 
     COMPUTEPASS_DEVICE->BindComputePipeline(
         COMPUTEPASS_COMMAND_BUFFER,
-        computePipeline);
+        compute_pipeline);
 
     commandBufferHeader = (CommandBufferCommonHeader *)COMPUTEPASS_COMMAND_BUFFER;
     commandBufferHeader->computePipelineBound = true;
 }
 
 void SDL_BindGPUComputeStorageTextures(
-    SDL_GPUComputePass *computePass,
-    Uint32 firstSlot,
-    SDL_GPUTexture *const *storageTextures,
-    Uint32 bindingCount)
+    SDL_GPUComputePass *compute_pass,
+    Uint32 first_slot,
+    SDL_GPUTexture *const *storage_textures,
+    Uint32 num_bindings)
 {
-    if (computePass == NULL) {
-        SDL_InvalidParamError("computePass");
+    if (compute_pass == NULL) {
+        SDL_InvalidParamError("compute_pass");
         return;
     }
-    if (storageTextures == NULL && bindingCount > 0) {
-        SDL_InvalidParamError("storageTextures");
+    if (storage_textures == NULL && num_bindings > 0) {
+        SDL_InvalidParamError("storage_textures");
         return;
     }
 
-    if (COMPUTEPASS_DEVICE->debugMode) {
+    if (COMPUTEPASS_DEVICE->debug_mode) {
         CHECK_COMPUTEPASS
     }
 
     COMPUTEPASS_DEVICE->BindComputeStorageTextures(
         COMPUTEPASS_COMMAND_BUFFER,
-        firstSlot,
-        storageTextures,
-        bindingCount);
+        first_slot,
+        storage_textures,
+        num_bindings);
 }
 
 void SDL_BindGPUComputeStorageBuffers(
-    SDL_GPUComputePass *computePass,
-    Uint32 firstSlot,
-    SDL_GPUBuffer *const *storageBuffers,
-    Uint32 bindingCount)
+    SDL_GPUComputePass *compute_pass,
+    Uint32 first_slot,
+    SDL_GPUBuffer *const *storage_buffers,
+    Uint32 num_bindings)
 {
-    if (computePass == NULL) {
-        SDL_InvalidParamError("computePass");
+    if (compute_pass == NULL) {
+        SDL_InvalidParamError("compute_pass");
         return;
     }
-    if (storageBuffers == NULL && bindingCount > 0) {
-        SDL_InvalidParamError("storageBuffers");
+    if (storage_buffers == NULL && num_bindings > 0) {
+        SDL_InvalidParamError("storage_buffers");
         return;
     }
 
-    if (COMPUTEPASS_DEVICE->debugMode) {
+    if (COMPUTEPASS_DEVICE->debug_mode) {
         CHECK_COMPUTEPASS
     }
 
     COMPUTEPASS_DEVICE->BindComputeStorageBuffers(
         COMPUTEPASS_COMMAND_BUFFER,
-        firstSlot,
-        storageBuffers,
-        bindingCount);
+        first_slot,
+        storage_buffers,
+        num_bindings);
 }
 
 void SDL_DispatchGPUCompute(
-    SDL_GPUComputePass *computePass,
-    Uint32 groupCountX,
-    Uint32 groupCountY,
-    Uint32 groupCountZ)
+    SDL_GPUComputePass *compute_pass,
+    Uint32 groupcount_x,
+    Uint32 groupcount_y,
+    Uint32 groupcount_z)
 {
-    if (computePass == NULL) {
-        SDL_InvalidParamError("computePass");
+    if (compute_pass == NULL) {
+        SDL_InvalidParamError("compute_pass");
         return;
     }
 
-    if (COMPUTEPASS_DEVICE->debugMode) {
+    if (COMPUTEPASS_DEVICE->debug_mode) {
         CHECK_COMPUTEPASS
         CHECK_COMPUTE_PIPELINE_BOUND
     }
 
     COMPUTEPASS_DEVICE->DispatchCompute(
         COMPUTEPASS_COMMAND_BUFFER,
-        groupCountX,
-        groupCountY,
-        groupCountZ);
+        groupcount_x,
+        groupcount_y,
+        groupcount_z);
 }
 
 void SDL_DispatchGPUComputeIndirect(
-    SDL_GPUComputePass *computePass,
+    SDL_GPUComputePass *compute_pass,
     SDL_GPUBuffer *buffer,
-    Uint32 offsetInBytes)
+    Uint32 offset)
 {
-    if (computePass == NULL) {
-        SDL_InvalidParamError("computePass");
+    if (compute_pass == NULL) {
+        SDL_InvalidParamError("compute_pass");
         return;
     }
 
-    if (COMPUTEPASS_DEVICE->debugMode) {
+    if (COMPUTEPASS_DEVICE->debug_mode) {
         CHECK_COMPUTEPASS
         CHECK_COMPUTE_PIPELINE_BOUND
     }
@@ -1818,20 +1818,20 @@ void SDL_DispatchGPUComputeIndirect(
     COMPUTEPASS_DEVICE->DispatchComputeIndirect(
         COMPUTEPASS_COMMAND_BUFFER,
         buffer,
-        offsetInBytes);
+        offset);
 }
 
 void SDL_EndGPUComputePass(
-    SDL_GPUComputePass *computePass)
+    SDL_GPUComputePass *compute_pass)
 {
     CommandBufferCommonHeader *commandBufferCommonHeader;
 
-    if (computePass == NULL) {
-        SDL_InvalidParamError("computePass");
+    if (compute_pass == NULL) {
+        SDL_InvalidParamError("compute_pass");
         return;
     }
 
-    if (COMPUTEPASS_DEVICE->debugMode) {
+    if (COMPUTEPASS_DEVICE->debug_mode) {
         CHECK_COMPUTEPASS
     }
 
@@ -1839,7 +1839,7 @@ void SDL_EndGPUComputePass(
         COMPUTEPASS_COMMAND_BUFFER);
 
     commandBufferCommonHeader = (CommandBufferCommonHeader *)COMPUTEPASS_COMMAND_BUFFER;
-    commandBufferCommonHeader->computePass.inProgress = false;
+    commandBufferCommonHeader->compute_pass.inProgress = false;
     commandBufferCommonHeader->computePipelineBound = false;
 }
 
@@ -1847,69 +1847,69 @@ void SDL_EndGPUComputePass(
 
 void *SDL_MapGPUTransferBuffer(
     SDL_GPUDevice *device,
-    SDL_GPUTransferBuffer *transferBuffer,
+    SDL_GPUTransferBuffer *transfer_buffer,
     SDL_bool cycle)
 {
     CHECK_DEVICE_MAGIC(device, NULL);
-    if (transferBuffer == NULL) {
-        SDL_InvalidParamError("transferBuffer");
+    if (transfer_buffer == NULL) {
+        SDL_InvalidParamError("transfer_buffer");
         return NULL;
     }
 
     return device->MapTransferBuffer(
         device->driverData,
-        transferBuffer,
+        transfer_buffer,
         cycle);
 }
 
 void SDL_UnmapGPUTransferBuffer(
     SDL_GPUDevice *device,
-    SDL_GPUTransferBuffer *transferBuffer)
+    SDL_GPUTransferBuffer *transfer_buffer)
 {
     CHECK_DEVICE_MAGIC(device, );
-    if (transferBuffer == NULL) {
-        SDL_InvalidParamError("transferBuffer");
+    if (transfer_buffer == NULL) {
+        SDL_InvalidParamError("transfer_buffer");
         return;
     }
 
     device->UnmapTransferBuffer(
         device->driverData,
-        transferBuffer);
+        transfer_buffer);
 }
 
 // Copy Pass
 
 SDL_GPUCopyPass *SDL_BeginGPUCopyPass(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
     CommandBufferCommonHeader *commandBufferHeader;
 
-    if (commandBuffer == NULL) {
-        SDL_InvalidParamError("commandBuffer");
+    if (command_buffer == NULL) {
+        SDL_InvalidParamError("command_buffer");
         return NULL;
     }
 
-    if (COMMAND_BUFFER_DEVICE->debugMode) {
+    if (COMMAND_BUFFER_DEVICE->debug_mode) {
         CHECK_COMMAND_BUFFER_RETURN_NULL
         CHECK_ANY_PASS_IN_PROGRESS("Cannot begin copy pass during another pass!", NULL)
     }
 
     COMMAND_BUFFER_DEVICE->BeginCopyPass(
-        commandBuffer);
+        command_buffer);
 
-    commandBufferHeader = (CommandBufferCommonHeader *)commandBuffer;
-    commandBufferHeader->copyPass.inProgress = true;
-    return (SDL_GPUCopyPass *)&(commandBufferHeader->copyPass);
+    commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
+    commandBufferHeader->copy_pass.inProgress = true;
+    return (SDL_GPUCopyPass *)&(commandBufferHeader->copy_pass);
 }
 
 void SDL_UploadToGPUTexture(
-    SDL_GPUCopyPass *copyPass,
+    SDL_GPUCopyPass *copy_pass,
     const SDL_GPUTextureTransferInfo *source,
     const SDL_GPUTextureRegion *destination,
     SDL_bool cycle)
 {
-    if (copyPass == NULL) {
-        SDL_InvalidParamError("copyPass");
+    if (copy_pass == NULL) {
+        SDL_InvalidParamError("copy_pass");
         return;
     }
     if (source == NULL) {
@@ -1921,7 +1921,7 @@ void SDL_UploadToGPUTexture(
         return;
     }
 
-    if (COPYPASS_DEVICE->debugMode) {
+    if (COPYPASS_DEVICE->debug_mode) {
         CHECK_COPYPASS
     }
 
@@ -1933,13 +1933,13 @@ void SDL_UploadToGPUTexture(
 }
 
 void SDL_UploadToGPUBuffer(
-    SDL_GPUCopyPass *copyPass,
+    SDL_GPUCopyPass *copy_pass,
     const SDL_GPUTransferBufferLocation *source,
     const SDL_GPUBufferRegion *destination,
     SDL_bool cycle)
 {
-    if (copyPass == NULL) {
-        SDL_InvalidParamError("copyPass");
+    if (copy_pass == NULL) {
+        SDL_InvalidParamError("copy_pass");
         return;
     }
     if (source == NULL) {
@@ -1959,7 +1959,7 @@ void SDL_UploadToGPUBuffer(
 }
 
 void SDL_CopyGPUTextureToTexture(
-    SDL_GPUCopyPass *copyPass,
+    SDL_GPUCopyPass *copy_pass,
     const SDL_GPUTextureLocation *source,
     const SDL_GPUTextureLocation *destination,
     Uint32 w,
@@ -1967,8 +1967,8 @@ void SDL_CopyGPUTextureToTexture(
     Uint32 d,
     SDL_bool cycle)
 {
-    if (copyPass == NULL) {
-        SDL_InvalidParamError("copyPass");
+    if (copy_pass == NULL) {
+        SDL_InvalidParamError("copy_pass");
         return;
     }
     if (source == NULL) {
@@ -1991,14 +1991,14 @@ void SDL_CopyGPUTextureToTexture(
 }
 
 void SDL_CopyGPUBufferToBuffer(
-    SDL_GPUCopyPass *copyPass,
+    SDL_GPUCopyPass *copy_pass,
     const SDL_GPUBufferLocation *source,
     const SDL_GPUBufferLocation *destination,
     Uint32 size,
     SDL_bool cycle)
 {
-    if (copyPass == NULL) {
-        SDL_InvalidParamError("copyPass");
+    if (copy_pass == NULL) {
+        SDL_InvalidParamError("copy_pass");
         return;
     }
     if (source == NULL) {
@@ -2019,12 +2019,12 @@ void SDL_CopyGPUBufferToBuffer(
 }
 
 void SDL_DownloadFromGPUTexture(
-    SDL_GPUCopyPass *copyPass,
+    SDL_GPUCopyPass *copy_pass,
     const SDL_GPUTextureRegion *source,
     const SDL_GPUTextureTransferInfo *destination)
 {
-    if (copyPass == NULL) {
-        SDL_InvalidParamError("copyPass");
+    if (copy_pass == NULL) {
+        SDL_InvalidParamError("copy_pass");
         return;
     }
     if (source == NULL) {
@@ -2043,12 +2043,12 @@ void SDL_DownloadFromGPUTexture(
 }
 
 void SDL_DownloadFromGPUBuffer(
-    SDL_GPUCopyPass *copyPass,
+    SDL_GPUCopyPass *copy_pass,
     const SDL_GPUBufferRegion *source,
     const SDL_GPUTransferBufferLocation *destination)
 {
-    if (copyPass == NULL) {
-        SDL_InvalidParamError("copyPass");
+    if (copy_pass == NULL) {
+        SDL_InvalidParamError("copy_pass");
         return;
     }
     if (source == NULL) {
@@ -2067,29 +2067,29 @@ void SDL_DownloadFromGPUBuffer(
 }
 
 void SDL_EndGPUCopyPass(
-    SDL_GPUCopyPass *copyPass)
+    SDL_GPUCopyPass *copy_pass)
 {
-    if (copyPass == NULL) {
-        SDL_InvalidParamError("copyPass");
+    if (copy_pass == NULL) {
+        SDL_InvalidParamError("copy_pass");
         return;
     }
 
-    if (COPYPASS_DEVICE->debugMode) {
+    if (COPYPASS_DEVICE->debug_mode) {
         CHECK_COPYPASS
     }
 
     COPYPASS_DEVICE->EndCopyPass(
         COPYPASS_COMMAND_BUFFER);
 
-    ((CommandBufferCommonHeader *)COPYPASS_COMMAND_BUFFER)->copyPass.inProgress = false;
+    ((CommandBufferCommonHeader *)COPYPASS_COMMAND_BUFFER)->copy_pass.inProgress = false;
 }
 
 void SDL_GenerateMipmapsForGPUTexture(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     SDL_GPUTexture *texture)
 {
-    if (commandBuffer == NULL) {
-        SDL_InvalidParamError("commandBuffer");
+    if (command_buffer == NULL) {
+        SDL_InvalidParamError("command_buffer");
         return;
     }
     if (texture == NULL) {
@@ -2097,37 +2097,37 @@ void SDL_GenerateMipmapsForGPUTexture(
         return;
     }
 
-    if (COMMAND_BUFFER_DEVICE->debugMode) {
+    if (COMMAND_BUFFER_DEVICE->debug_mode) {
         CHECK_COMMAND_BUFFER
         CHECK_ANY_PASS_IN_PROGRESS("Cannot generate mipmaps during a pass!", )
 
         TextureCommonHeader *header = (TextureCommonHeader *)texture;
-        if (header->info.levelCount <= 1) {
-            SDL_assert_release(!"Cannot generate mipmaps for texture with levelCount <= 1!");
+        if (header->info.num_levels <= 1) {
+            SDL_assert_release(!"Cannot generate mipmaps for texture with num_levels <= 1!");
             return;
         }
 
-        if (!(header->info.usageFlags & SDL_GPU_TEXTUREUSAGE_SAMPLER) || !(header->info.usageFlags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET)) {
+        if (!(header->info.usage_flags & SDL_GPU_TEXTUREUSAGE_SAMPLER) || !(header->info.usage_flags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET)) {
             SDL_assert_release(!"GenerateMipmaps texture must be created with SAMPLER and COLOR_TARGET usage flags!");
             return;
         }
     }
 
     COMMAND_BUFFER_DEVICE->GenerateMipmaps(
-        commandBuffer,
+        command_buffer,
         texture);
 }
 
 void SDL_BlitGPUTexture(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUBlitRegion *source,
     const SDL_GPUBlitRegion *destination,
-    SDL_FlipMode flipMode,
-    SDL_GPUFilter filterMode,
+    SDL_FlipMode flip_mode,
+    SDL_GPUFilter filter,
     SDL_bool cycle)
 {
-    if (commandBuffer == NULL) {
-        SDL_InvalidParamError("commandBuffer");
+    if (command_buffer == NULL) {
+        SDL_InvalidParamError("command_buffer");
         return;
     }
     if (source == NULL) {
@@ -2139,7 +2139,7 @@ void SDL_BlitGPUTexture(
         return;
     }
 
-    if (COMMAND_BUFFER_DEVICE->debugMode) {
+    if (COMMAND_BUFFER_DEVICE->debug_mode) {
         CHECK_COMMAND_BUFFER
         CHECK_ANY_PASS_IN_PROGRESS("Cannot blit during a pass!", )
 
@@ -2152,11 +2152,11 @@ void SDL_BlitGPUTexture(
             SDL_assert_release(!"Blit source and destination textures must be non-NULL");
             return; // attempting to proceed will crash
         }
-        if ((srcHeader->info.usageFlags & SDL_GPU_TEXTUREUSAGE_SAMPLER) == 0) {
+        if ((srcHeader->info.usage_flags & SDL_GPU_TEXTUREUSAGE_SAMPLER) == 0) {
             SDL_assert_release(!"Blit source texture must be created with the SAMPLER usage flag");
             failed = true;
         }
-        if ((dstHeader->info.usageFlags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) == 0) {
+        if ((dstHeader->info.usage_flags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) == 0) {
             SDL_assert_release(!"Blit destination texture must be created with the COLOR_TARGET usage flag");
             failed = true;
         }
@@ -2175,11 +2175,11 @@ void SDL_BlitGPUTexture(
     }
 
     COMMAND_BUFFER_DEVICE->Blit(
-        commandBuffer,
+        command_buffer,
         source,
         destination,
-        flipMode,
-        filterMode,
+        flip_mode,
+        filter,
         cycle);
 }
 
@@ -2188,7 +2188,7 @@ void SDL_BlitGPUTexture(
 SDL_bool SDL_WindowSupportsGPUSwapchainComposition(
     SDL_GPUDevice *device,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchainComposition)
+    SDL_GPUSwapchainComposition swapchain_composition)
 {
     CHECK_DEVICE_MAGIC(device, false);
     if (window == NULL) {
@@ -2196,20 +2196,20 @@ SDL_bool SDL_WindowSupportsGPUSwapchainComposition(
         return false;
     }
 
-    if (device->debugMode) {
-        CHECK_SWAPCHAINCOMPOSITION_ENUM_INVALID(swapchainComposition, false)
+    if (device->debug_mode) {
+        CHECK_SWAPCHAINCOMPOSITION_ENUM_INVALID(swapchain_composition, false)
     }
 
     return device->SupportsSwapchainComposition(
         device->driverData,
         window,
-        swapchainComposition);
+        swapchain_composition);
 }
 
 SDL_bool SDL_WindowSupportsGPUPresentMode(
     SDL_GPUDevice *device,
     SDL_Window *window,
-    SDL_GPUPresentMode presentMode)
+    SDL_GPUPresentMode present_mode)
 {
     CHECK_DEVICE_MAGIC(device, false);
     if (window == NULL) {
@@ -2217,14 +2217,14 @@ SDL_bool SDL_WindowSupportsGPUPresentMode(
         return false;
     }
 
-    if (device->debugMode) {
-        CHECK_PRESENTMODE_ENUM_INVALID(presentMode, false)
+    if (device->debug_mode) {
+        CHECK_PRESENTMODE_ENUM_INVALID(present_mode, false)
     }
 
     return device->SupportsPresentMode(
         device->driverData,
         window,
-        presentMode);
+        present_mode);
 }
 
 SDL_bool SDL_ClaimWindowForGPUDevice(
@@ -2260,8 +2260,8 @@ void SDL_ReleaseWindowFromGPUDevice(
 SDL_bool SDL_SetGPUSwapchainParameters(
     SDL_GPUDevice *device,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchainComposition,
-    SDL_GPUPresentMode presentMode)
+    SDL_GPUSwapchainComposition swapchain_composition,
+    SDL_GPUPresentMode present_mode)
 {
     CHECK_DEVICE_MAGIC(device, false);
     if (window == NULL) {
@@ -2269,16 +2269,16 @@ SDL_bool SDL_SetGPUSwapchainParameters(
         return false;
     }
 
-    if (device->debugMode) {
-        CHECK_SWAPCHAINCOMPOSITION_ENUM_INVALID(swapchainComposition, false)
-        CHECK_PRESENTMODE_ENUM_INVALID(presentMode, false)
+    if (device->debug_mode) {
+        CHECK_SWAPCHAINCOMPOSITION_ENUM_INVALID(swapchain_composition, false)
+        CHECK_PRESENTMODE_ENUM_INVALID(present_mode, false)
     }
 
     return device->SetSwapchainParameters(
         device->driverData,
         window,
-        swapchainComposition,
-        presentMode);
+        swapchain_composition,
+        present_mode);
 }
 
 SDL_GPUTextureFormat SDL_GetGPUSwapchainTextureFormat(
@@ -2297,56 +2297,56 @@ SDL_GPUTextureFormat SDL_GetGPUSwapchainTextureFormat(
 }
 
 SDL_GPUTexture *SDL_AcquireGPUSwapchainTexture(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     SDL_Window *window,
-    Uint32 *pWidth,
-    Uint32 *pHeight)
+    Uint32 *w,
+    Uint32 *h)
 {
-    if (commandBuffer == NULL) {
-        SDL_InvalidParamError("commandBuffer");
+    if (command_buffer == NULL) {
+        SDL_InvalidParamError("command_buffer");
         return NULL;
     }
     if (window == NULL) {
         SDL_InvalidParamError("window");
         return NULL;
     }
-    if (pWidth == NULL) {
-        SDL_InvalidParamError("pWidth");
+    if (w == NULL) {
+        SDL_InvalidParamError("w");
         return NULL;
     }
-    if (pHeight == NULL) {
-        SDL_InvalidParamError("pHeight");
+    if (h == NULL) {
+        SDL_InvalidParamError("h");
         return NULL;
     }
 
-    if (COMMAND_BUFFER_DEVICE->debugMode) {
+    if (COMMAND_BUFFER_DEVICE->debug_mode) {
         CHECK_COMMAND_BUFFER_RETURN_NULL
         CHECK_ANY_PASS_IN_PROGRESS("Cannot acquire a swapchain texture during a pass!", NULL)
     }
 
     return COMMAND_BUFFER_DEVICE->AcquireSwapchainTexture(
-        commandBuffer,
+        command_buffer,
         window,
-        pWidth,
-        pHeight);
+        w,
+        h);
 }
 
 void SDL_SubmitGPUCommandBuffer(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
-    CommandBufferCommonHeader *commandBufferHeader = (CommandBufferCommonHeader *)commandBuffer;
+    CommandBufferCommonHeader *commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
 
-    if (commandBuffer == NULL) {
-        SDL_InvalidParamError("commandBuffer");
+    if (command_buffer == NULL) {
+        SDL_InvalidParamError("command_buffer");
         return;
     }
 
-    if (COMMAND_BUFFER_DEVICE->debugMode) {
+    if (COMMAND_BUFFER_DEVICE->debug_mode) {
         CHECK_COMMAND_BUFFER
         if (
-            commandBufferHeader->renderPass.inProgress ||
-            commandBufferHeader->computePass.inProgress ||
-            commandBufferHeader->copyPass.inProgress) {
+            commandBufferHeader->render_pass.inProgress ||
+            commandBufferHeader->compute_pass.inProgress ||
+            commandBufferHeader->copy_pass.inProgress) {
             SDL_assert_release(!"Cannot submit command buffer while a pass is in progress!");
             return;
         }
@@ -2355,25 +2355,25 @@ void SDL_SubmitGPUCommandBuffer(
     commandBufferHeader->submitted = true;
 
     COMMAND_BUFFER_DEVICE->Submit(
-        commandBuffer);
+        command_buffer);
 }
 
 SDL_GPUFence *SDL_SubmitGPUCommandBufferAndAcquireFence(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
-    CommandBufferCommonHeader *commandBufferHeader = (CommandBufferCommonHeader *)commandBuffer;
+    CommandBufferCommonHeader *commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
 
-    if (commandBuffer == NULL) {
-        SDL_InvalidParamError("commandBuffer");
+    if (command_buffer == NULL) {
+        SDL_InvalidParamError("command_buffer");
         return NULL;
     }
 
-    if (COMMAND_BUFFER_DEVICE->debugMode) {
+    if (COMMAND_BUFFER_DEVICE->debug_mode) {
         CHECK_COMMAND_BUFFER_RETURN_NULL
         if (
-            commandBufferHeader->renderPass.inProgress ||
-            commandBufferHeader->computePass.inProgress ||
-            commandBufferHeader->copyPass.inProgress) {
+            commandBufferHeader->render_pass.inProgress ||
+            commandBufferHeader->compute_pass.inProgress ||
+            commandBufferHeader->copy_pass.inProgress) {
             SDL_assert_release(!"Cannot submit command buffer while a pass is in progress!");
             return NULL;
         }
@@ -2382,7 +2382,7 @@ SDL_GPUFence *SDL_SubmitGPUCommandBufferAndAcquireFence(
     commandBufferHeader->submitted = true;
 
     return COMMAND_BUFFER_DEVICE->SubmitAndAcquireFence(
-        commandBuffer);
+        command_buffer);
 }
 
 void SDL_WaitForGPUIdle(
@@ -2396,21 +2396,21 @@ void SDL_WaitForGPUIdle(
 
 void SDL_WaitForGPUFences(
     SDL_GPUDevice *device,
-    SDL_bool waitAll,
-    SDL_GPUFence *const *pFences,
-    Uint32 fenceCount)
+    SDL_bool wait_all,
+    SDL_GPUFence *const *fences,
+    Uint32 num_fences)
 {
     CHECK_DEVICE_MAGIC(device, );
-    if (pFences == NULL && fenceCount > 0) {
-        SDL_InvalidParamError("pFences");
+    if (fences == NULL && num_fences > 0) {
+        SDL_InvalidParamError("fences");
         return;
     }
 
     device->WaitForFences(
         device->driverData,
-        waitAll,
-        pFences,
-        fenceCount);
+        wait_all,
+        fences,
+        num_fences);
 }
 
 SDL_bool SDL_QueryGPUFence(

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -42,39 +42,39 @@
 
 #define CHECK_ANY_PASS_IN_PROGRESS(msg, retval)                                 \
     if (                                                                        \
-        ((CommandBufferCommonHeader *)command_buffer)->render_pass.inProgress ||  \
-        ((CommandBufferCommonHeader *)command_buffer)->compute_pass.inProgress || \
-        ((CommandBufferCommonHeader *)command_buffer)->copy_pass.inProgress) {    \
+        ((CommandBufferCommonHeader *)command_buffer)->render_pass.in_progress ||  \
+        ((CommandBufferCommonHeader *)command_buffer)->compute_pass.in_progress || \
+        ((CommandBufferCommonHeader *)command_buffer)->copy_pass.in_progress) {    \
         SDL_assert_release(!msg);                                               \
         return retval;                                                          \
     }
 
 #define CHECK_RENDERPASS                                     \
-    if (!((Pass *)render_pass)->inProgress) {                 \
+    if (!((Pass *)render_pass)->in_progress) {                 \
         SDL_assert_release(!"Render pass not in progress!"); \
         return;                                              \
     }
 
 #define CHECK_GRAPHICS_PIPELINE_BOUND                                                       \
-    if (!((CommandBufferCommonHeader *)RENDERPASS_COMMAND_BUFFER)->graphicsPipelineBound) { \
+    if (!((CommandBufferCommonHeader *)RENDERPASS_COMMAND_BUFFER)->graphics_pipeline_bound) { \
         SDL_assert_release(!"Graphics pipeline not bound!");                                \
         return;                                                                             \
     }
 
 #define CHECK_COMPUTEPASS                                     \
-    if (!((Pass *)compute_pass)->inProgress) {                 \
+    if (!((Pass *)compute_pass)->in_progress) {                 \
         SDL_assert_release(!"Compute pass not in progress!"); \
         return;                                               \
     }
 
 #define CHECK_COMPUTE_PIPELINE_BOUND                                                        \
-    if (!((CommandBufferCommonHeader *)COMPUTEPASS_COMMAND_BUFFER)->computePipelineBound) { \
+    if (!((CommandBufferCommonHeader *)COMPUTEPASS_COMMAND_BUFFER)->compute_pipeline_bound) { \
         SDL_assert_release(!"Compute pipeline not bound!");                                 \
         return;                                                                             \
     }
 
 #define CHECK_COPYPASS                                     \
-    if (!((Pass *)copy_pass)->inProgress) {                 \
+    if (!((Pass *)copy_pass)->in_progress) {                 \
         SDL_assert_release(!"Copy pass not in progress!"); \
         return;                                            \
     }
@@ -140,63 +140,63 @@ static const SDL_GPUBootstrap *backends[] = {
 
 SDL_GPUGraphicsPipeline *SDL_GPU_FetchBlitPipeline(
     SDL_GPUDevice *device,
-    SDL_GPUTextureType sourceTextureType,
-    SDL_GPUTextureFormat destinationFormat,
-    SDL_GPUShader *blitVertexShader,
-    SDL_GPUShader *blitFrom2DShader,
-    SDL_GPUShader *blitFrom2DArrayShader,
-    SDL_GPUShader *blitFrom3DShader,
-    SDL_GPUShader *blitFromCubeShader,
-    BlitPipelineCacheEntry **blitPipelines,
-    Uint32 *blitPipelineCount,
-    Uint32 *blitPipelineCapacity)
+    SDL_GPUTextureType source_texture_type,
+    SDL_GPUTextureFormat destination_format,
+    SDL_GPUShader *blit_vertex_shader,
+    SDL_GPUShader *blit_from_2d_shader,
+    SDL_GPUShader *blit_from_2d_array_shader,
+    SDL_GPUShader *blit_from_3d_shader,
+    SDL_GPUShader *blit_from_cube_shader,
+    BlitPipelineCacheEntry **blit_pipelines,
+    Uint32 *blit_pipeline_count,
+    Uint32 *blit_pipeline_capacity)
 {
-    SDL_GPUGraphicsPipelineCreateInfo blitPipelineCreateInfo;
-    SDL_GPUColorAttachmentDescription colorAttachmentDesc;
+    SDL_GPUGraphicsPipelineCreateInfo blit_pipeline_create_info;
+    SDL_GPUColorTargetDescription color_target_desc;
     SDL_GPUGraphicsPipeline *pipeline;
 
-    if (blitPipelineCount == NULL) {
+    if (blit_pipeline_count == NULL) {
         // use pre-created, format-agnostic pipelines
-        return (*blitPipelines)[sourceTextureType].pipeline;
+        return (*blit_pipelines)[source_texture_type].pipeline;
     }
 
-    for (Uint32 i = 0; i < *blitPipelineCount; i += 1) {
-        if ((*blitPipelines)[i].type == sourceTextureType && (*blitPipelines)[i].format == destinationFormat) {
-            return (*blitPipelines)[i].pipeline;
+    for (Uint32 i = 0; i < *blit_pipeline_count; i += 1) {
+        if ((*blit_pipelines)[i].type == source_texture_type && (*blit_pipelines)[i].format == destination_format) {
+            return (*blit_pipelines)[i].pipeline;
         }
     }
 
     // No pipeline found, we'll need to make one!
-    SDL_zero(blitPipelineCreateInfo);
+    SDL_zero(blit_pipeline_create_info);
 
-    SDL_zero(colorAttachmentDesc);
-    colorAttachmentDesc.blend_state.color_write_mask = 0xF;
-    colorAttachmentDesc.format = destinationFormat;
+    SDL_zero(color_target_desc);
+    color_target_desc.blend_state.color_write_mask = 0xF;
+    color_target_desc.format = destination_format;
 
-    blitPipelineCreateInfo.attachment_info.color_attachment_descriptions = &colorAttachmentDesc;
-    blitPipelineCreateInfo.attachment_info.num_color_attachments = 1;
-    blitPipelineCreateInfo.attachment_info.depth_stencil_format = SDL_GPU_TEXTUREFORMAT_D16_UNORM; // arbitrary
-    blitPipelineCreateInfo.attachment_info.has_depth_stencil_attachment = false;
+    blit_pipeline_create_info.target_info.color_target_descriptions = &color_target_desc;
+    blit_pipeline_create_info.target_info.num_color_targets = 1;
+    blit_pipeline_create_info.target_info.depth_stencil_format = SDL_GPU_TEXTUREFORMAT_D16_UNORM; // arbitrary
+    blit_pipeline_create_info.target_info.has_depth_stencil_target = false;
 
-    blitPipelineCreateInfo.vertex_shader = blitVertexShader;
-    if (sourceTextureType == SDL_GPU_TEXTURETYPE_CUBE) {
-        blitPipelineCreateInfo.fragment_shader = blitFromCubeShader;
-    } else if (sourceTextureType == SDL_GPU_TEXTURETYPE_2D_ARRAY) {
-        blitPipelineCreateInfo.fragment_shader = blitFrom2DArrayShader;
-    } else if (sourceTextureType == SDL_GPU_TEXTURETYPE_3D) {
-        blitPipelineCreateInfo.fragment_shader = blitFrom3DShader;
+    blit_pipeline_create_info.vertex_shader = blit_vertex_shader;
+    if (source_texture_type == SDL_GPU_TEXTURETYPE_CUBE) {
+        blit_pipeline_create_info.fragment_shader = blit_from_cube_shader;
+    } else if (source_texture_type == SDL_GPU_TEXTURETYPE_2D_ARRAY) {
+        blit_pipeline_create_info.fragment_shader = blit_from_2d_array_shader;
+    } else if (source_texture_type == SDL_GPU_TEXTURETYPE_3D) {
+        blit_pipeline_create_info.fragment_shader = blit_from_3d_shader;
     } else {
-        blitPipelineCreateInfo.fragment_shader = blitFrom2DShader;
+        blit_pipeline_create_info.fragment_shader = blit_from_2d_shader;
     }
 
-    blitPipelineCreateInfo.multisample_state.sample_count = SDL_GPU_SAMPLECOUNT_1;
-    blitPipelineCreateInfo.multisample_state.sample_mask = 0xFFFFFFFF;
+    blit_pipeline_create_info.multisample_state.sample_count = SDL_GPU_SAMPLECOUNT_1;
+    blit_pipeline_create_info.multisample_state.sample_mask = 0xFFFFFFFF;
 
-    blitPipelineCreateInfo.primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
+    blit_pipeline_create_info.primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
 
     pipeline = SDL_CreateGPUGraphicsPipeline(
         device,
-        &blitPipelineCreateInfo);
+        &blit_pipeline_create_info);
 
     if (pipeline == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create graphics pipeline for blit");
@@ -205,16 +205,16 @@ SDL_GPUGraphicsPipeline *SDL_GPU_FetchBlitPipeline(
 
     // Cache the new pipeline
     EXPAND_ARRAY_IF_NEEDED(
-        (*blitPipelines),
+        (*blit_pipelines),
         BlitPipelineCacheEntry,
-        *blitPipelineCount + 1,
-        *blitPipelineCapacity,
-        *blitPipelineCapacity * 2)
+        *blit_pipeline_count + 1,
+        *blit_pipeline_capacity,
+        *blit_pipeline_capacity * 2)
 
-    (*blitPipelines)[*blitPipelineCount].pipeline = pipeline;
-    (*blitPipelines)[*blitPipelineCount].type = sourceTextureType;
-    (*blitPipelines)[*blitPipelineCount].format = destinationFormat;
-    *blitPipelineCount += 1;
+    (*blit_pipelines)[*blit_pipeline_count].pipeline = pipeline;
+    (*blit_pipelines)[*blit_pipeline_count].type = source_texture_type;
+    (*blit_pipelines)[*blit_pipeline_count].format = destination_format;
+    *blit_pipeline_count += 1;
 
     return pipeline;
 }
@@ -226,68 +226,68 @@ void SDL_GPU_BlitCommon(
     SDL_FlipMode flip_mode,
     SDL_GPUFilter filter,
     bool cycle,
-    SDL_GPUSampler *blitLinearSampler,
-    SDL_GPUSampler *blitNearestSampler,
-    SDL_GPUShader *blitVertexShader,
-    SDL_GPUShader *blitFrom2DShader,
-    SDL_GPUShader *blitFrom2DArrayShader,
-    SDL_GPUShader *blitFrom3DShader,
-    SDL_GPUShader *blitFromCubeShader,
-    BlitPipelineCacheEntry **blitPipelines,
-    Uint32 *blitPipelineCount,
-    Uint32 *blitPipelineCapacity)
+    SDL_GPUSampler *blit_linear_sampler,
+    SDL_GPUSampler *blit_nearest_sampler,
+    SDL_GPUShader *blit_vertex_shader,
+    SDL_GPUShader *blit_from_2d_shader,
+    SDL_GPUShader *blit_from_2d_array_shader,
+    SDL_GPUShader *blit_from_3d_shader,
+    SDL_GPUShader *blit_from_cube_shader,
+    BlitPipelineCacheEntry **blit_pipelines,
+    Uint32 *blit_pipeline_count,
+    Uint32 *blit_pipeline_capacity)
 {
     CommandBufferCommonHeader *cmdbufHeader = (CommandBufferCommonHeader *)command_buffer;
     SDL_GPURenderPass *render_pass;
-    TextureCommonHeader *srcHeader = (TextureCommonHeader *)source->texture;
-    TextureCommonHeader *dstHeader = (TextureCommonHeader *)destination->texture;
-    SDL_GPUGraphicsPipeline *blitPipeline;
-    SDL_GPUColorAttachmentInfo colorAttachmentInfo;
+    TextureCommonHeader *src_header = (TextureCommonHeader *)source->texture;
+    TextureCommonHeader *dst_header = (TextureCommonHeader *)destination->texture;
+    SDL_GPUGraphicsPipeline *blit_pipeline;
+    SDL_GPUColorTargetInfo color_target_info;
     SDL_GPUViewport viewport;
-    SDL_GPUTextureSamplerBinding textureSamplerBinding;
-    BlitFragmentUniforms blitFragmentUniforms;
-    Uint32 layerDivisor;
+    SDL_GPUTextureSamplerBinding texture_sampler_binding;
+    BlitFragmentUniforms blit_fragment_uniforms;
+    Uint32 layer_divisor;
 
-    blitPipeline = SDL_GPU_FetchBlitPipeline(
+    blit_pipeline = SDL_GPU_FetchBlitPipeline(
         cmdbufHeader->device,
-        srcHeader->info.type,
-        dstHeader->info.format,
-        blitVertexShader,
-        blitFrom2DShader,
-        blitFrom2DArrayShader,
-        blitFrom3DShader,
-        blitFromCubeShader,
-        blitPipelines,
-        blitPipelineCount,
-        blitPipelineCapacity);
+        src_header->info.type,
+        dst_header->info.format,
+        blit_vertex_shader,
+        blit_from_2d_shader,
+        blit_from_2d_array_shader,
+        blit_from_3d_shader,
+        blit_from_cube_shader,
+        blit_pipelines,
+        blit_pipeline_count,
+        blit_pipeline_capacity);
 
-    if (blitPipeline == NULL) {
+    if (blit_pipeline == NULL) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "Could not fetch blit pipeline");
         return;
     }
 
     // If the entire destination is blitted, we don't have to load
     if (
-        dstHeader->info.layer_count_or_depth == 1 &&
-        dstHeader->info.num_levels == 1 &&
-        dstHeader->info.type != SDL_GPU_TEXTURETYPE_3D &&
-        destination->w == dstHeader->info.width &&
-        destination->h == dstHeader->info.height) {
-        colorAttachmentInfo.load_op = SDL_GPU_LOADOP_DONT_CARE;
+        dst_header->info.layer_count_or_depth == 1 &&
+        dst_header->info.num_levels == 1 &&
+        dst_header->info.type != SDL_GPU_TEXTURETYPE_3D &&
+        destination->w == dst_header->info.width &&
+        destination->h == dst_header->info.height) {
+        color_target_info.load_op = SDL_GPU_LOADOP_DONT_CARE;
     } else {
-        colorAttachmentInfo.load_op = SDL_GPU_LOADOP_LOAD;
+        color_target_info.load_op = SDL_GPU_LOADOP_LOAD;
     }
 
-    colorAttachmentInfo.store_op = SDL_GPU_STOREOP_STORE;
+    color_target_info.store_op = SDL_GPU_STOREOP_STORE;
 
-    colorAttachmentInfo.texture = destination->texture;
-    colorAttachmentInfo.mip_level = destination->mip_level;
-    colorAttachmentInfo.layer_or_depth_plane = destination->layer_or_depth_plane;
-    colorAttachmentInfo.cycle = cycle;
+    color_target_info.texture = destination->texture;
+    color_target_info.mip_level = destination->mip_level;
+    color_target_info.layer_or_depth_plane = destination->layer_or_depth_plane;
+    color_target_info.cycle = cycle;
 
     render_pass = SDL_BeginGPURenderPass(
         command_buffer,
-        &colorAttachmentInfo,
+        &color_target_info,
         1,
         NULL);
 
@@ -295,8 +295,8 @@ void SDL_GPU_BlitCommon(
     viewport.y = (float)destination->y;
     viewport.w = (float)destination->w;
     viewport.h = (float)destination->h;
-    viewport.minDepth = 0;
-    viewport.maxDepth = 1;
+    viewport.min_depth = 0;
+    viewport.max_depth = 1;
 
     SDL_SetGPUViewport(
         render_pass,
@@ -304,42 +304,42 @@ void SDL_GPU_BlitCommon(
 
     SDL_BindGPUGraphicsPipeline(
         render_pass,
-        blitPipeline);
+        blit_pipeline);
 
-    textureSamplerBinding.texture = source->texture;
-    textureSamplerBinding.sampler =
-        filter == SDL_GPU_FILTER_NEAREST ? blitNearestSampler : blitLinearSampler;
+    texture_sampler_binding.texture = source->texture;
+    texture_sampler_binding.sampler =
+        filter == SDL_GPU_FILTER_NEAREST ? blit_nearest_sampler : blit_linear_sampler;
 
     SDL_BindGPUFragmentSamplers(
         render_pass,
         0,
-        &textureSamplerBinding,
+        &texture_sampler_binding,
         1);
 
-    blitFragmentUniforms.left = (float)source->x / (srcHeader->info.width >> source->mip_level);
-    blitFragmentUniforms.top = (float)source->y / (srcHeader->info.height >> source->mip_level);
-    blitFragmentUniforms.width = (float)source->w / (srcHeader->info.width >> source->mip_level);
-    blitFragmentUniforms.height = (float)source->h / (srcHeader->info.height >> source->mip_level);
-    blitFragmentUniforms.mip_level = source->mip_level;
+    blit_fragment_uniforms.left = (float)source->x / (src_header->info.width >> source->mip_level);
+    blit_fragment_uniforms.top = (float)source->y / (src_header->info.height >> source->mip_level);
+    blit_fragment_uniforms.width = (float)source->w / (src_header->info.width >> source->mip_level);
+    blit_fragment_uniforms.height = (float)source->h / (src_header->info.height >> source->mip_level);
+    blit_fragment_uniforms.mip_level = source->mip_level;
 
-    layerDivisor = (srcHeader->info.type == SDL_GPU_TEXTURETYPE_3D) ? srcHeader->info.layer_count_or_depth : 1;
-    blitFragmentUniforms.layerOrDepth = (float)source->layer_or_depth_plane / layerDivisor;
+    layer_divisor = (src_header->info.type == SDL_GPU_TEXTURETYPE_3D) ? src_header->info.layer_count_or_depth : 1;
+    blit_fragment_uniforms.layer_or_depth = (float)source->layer_or_depth_plane / layer_divisor;
 
     if (flip_mode & SDL_FLIP_HORIZONTAL) {
-        blitFragmentUniforms.left += blitFragmentUniforms.width;
-        blitFragmentUniforms.width *= -1;
+        blit_fragment_uniforms.left += blit_fragment_uniforms.width;
+        blit_fragment_uniforms.width *= -1;
     }
 
     if (flip_mode & SDL_FLIP_VERTICAL) {
-        blitFragmentUniforms.top += blitFragmentUniforms.height;
-        blitFragmentUniforms.height *= -1;
+        blit_fragment_uniforms.top += blit_fragment_uniforms.height;
+        blit_fragment_uniforms.height *= -1;
     }
 
     SDL_PushGPUFragmentUniformData(
         command_buffer,
         0,
-        &blitFragmentUniforms,
-        sizeof(blitFragmentUniforms));
+        &blit_fragment_uniforms,
+        sizeof(blit_fragment_uniforms));
 
     SDL_DrawGPUPrimitives(render_pass, 3, 1, 0, 0);
     SDL_EndGPURenderPass(render_pass);
@@ -357,8 +357,8 @@ static SDL_GPUDriver SDL_GPUSelectBackend(
     // Environment/Properties override...
     if (gpudriver != NULL) {
         for (i = 0; backends[i]; i += 1) {
-            if (SDL_strcasecmp(gpudriver, backends[i]->Name) == 0) {
-                if (!(backends[i]->shaderFormats & format_flags)) {
+            if (SDL_strcasecmp(gpudriver, backends[i]->name) == 0) {
+                if (!(backends[i]->shader_formats & format_flags)) {
                     SDL_LogError(SDL_LOG_CATEGORY_GPU, "Required shader format for backend %s not provided!", gpudriver);
                     return SDL_GPU_DRIVER_INVALID;
                 }
@@ -373,7 +373,7 @@ static SDL_GPUDriver SDL_GPUSelectBackend(
     }
 
     for (i = 0; backends[i]; i += 1) {
-        if ((backends[i]->shaderFormats & format_flags) == 0) {
+        if ((backends[i]->shader_formats & format_flags) == 0) {
             // Don't select a backend which doesn't support the app's shaders.
             continue;
         }
@@ -469,7 +469,7 @@ SDL_GPUDevice *SDL_CreateGPUDeviceWithProperties(SDL_PropertiesID props)
                 result = backends[i]->CreateDevice(debug_mode, preferLowPower, props);
                 if (result != NULL) {
                     result->backend = backends[i]->backendflag;
-                    result->shaderFormats = backends[i]->shaderFormats;
+                    result->shader_formats = backends[i]->shader_formats;
                     result->debug_mode = debug_mode;
                     break;
                 }
@@ -604,7 +604,7 @@ SDL_GPUComputePipeline *SDL_CreateGPUComputePipeline(
     }
 
     if (device->debug_mode) {
-        if (!(createinfo->format & device->shaderFormats)) {
+        if (!(createinfo->format & device->shader_formats)) {
             SDL_assert_release(!"Incompatible shader format for GPU backend");
             return NULL;
         }
@@ -641,17 +641,17 @@ SDL_GPUGraphicsPipeline *SDL_CreateGPUGraphicsPipeline(
     }
 
     if (device->debug_mode) {
-        for (Uint32 i = 0; i < graphicsPipelineCreateInfo->attachment_info.num_color_attachments; i += 1) {
-            CHECK_TEXTUREFORMAT_ENUM_INVALID(graphicsPipelineCreateInfo->attachment_info.color_attachment_descriptions[i].format, NULL);
-            if (IsDepthFormat(graphicsPipelineCreateInfo->attachment_info.color_attachment_descriptions[i].format)) {
-                SDL_assert_release(!"Color attachment formats cannot be a depth format!");
+        for (Uint32 i = 0; i < graphicsPipelineCreateInfo->target_info.num_color_targets; i += 1) {
+            CHECK_TEXTUREFORMAT_ENUM_INVALID(graphicsPipelineCreateInfo->target_info.color_target_descriptions[i].format, NULL);
+            if (IsDepthFormat(graphicsPipelineCreateInfo->target_info.color_target_descriptions[i].format)) {
+                SDL_assert_release(!"Color target formats cannot be a depth format!");
                 return NULL;
             }
         }
-        if (graphicsPipelineCreateInfo->attachment_info.has_depth_stencil_attachment) {
-            CHECK_TEXTUREFORMAT_ENUM_INVALID(graphicsPipelineCreateInfo->attachment_info.depth_stencil_format, NULL);
-            if (!IsDepthFormat(graphicsPipelineCreateInfo->attachment_info.depth_stencil_format)) {
-                SDL_assert_release(!"Depth-stencil attachment format must be a depth format!");
+        if (graphicsPipelineCreateInfo->target_info.has_depth_stencil_target) {
+            CHECK_TEXTUREFORMAT_ENUM_INVALID(graphicsPipelineCreateInfo->target_info.depth_stencil_format, NULL);
+            if (!IsDepthFormat(graphicsPipelineCreateInfo->target_info.depth_stencil_format)) {
+                SDL_assert_release(!"Depth-stencil target format must be a depth format!");
                 return NULL;
             }
         }
@@ -688,7 +688,7 @@ SDL_GPUShader *SDL_CreateGPUShader(
     }
 
     if (device->debug_mode) {
-        if (!(createinfo->format & device->shaderFormats)) {
+        if (!(createinfo->format & device->shader_formats)) {
             SDL_assert_release(!"Incompatible shader format for GPU backend");
             return NULL;
         }
@@ -726,16 +726,16 @@ SDL_GPUTexture *SDL_CreateGPUTexture(
             SDL_assert_release(!"For any texture: num_levels must be >= 1");
             failed = true;
         }
-        if ((createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ) && (createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_SAMPLER)) {
-            SDL_assert_release(!"For any texture: usage_flags cannot contain both GRAPHICS_STORAGE_READ and SAMPLER");
+        if ((createinfo->usage & SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ) && (createinfo->usage & SDL_GPU_TEXTUREUSAGE_SAMPLER)) {
+            SDL_assert_release(!"For any texture: usage cannot contain both GRAPHICS_STORAGE_READ and SAMPLER");
             failed = true;
         }
-        if (IsDepthFormat(createinfo->format) && (createinfo->usage_flags & ~(SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER))) {
-            SDL_assert_release(!"For depth textures: usage_flags cannot contain any flags except for DEPTH_STENCIL_TARGET and SAMPLER");
+        if (IsDepthFormat(createinfo->format) && (createinfo->usage & ~(SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER))) {
+            SDL_assert_release(!"For depth textures: usage cannot contain any flags except for DEPTH_STENCIL_TARGET and SAMPLER");
             failed = true;
         }
-        if (IsIntegerFormat(createinfo->format) && (createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_SAMPLER)) {
-            SDL_assert_release(!"For any texture: usage_flags cannot contain SAMPLER for textures with an integer format");
+        if (IsIntegerFormat(createinfo->format) && (createinfo->usage & SDL_GPU_TEXTUREUSAGE_SAMPLER)) {
+            SDL_assert_release(!"For any texture: usage cannot contain SAMPLER for textures with an integer format");
             failed = true;
         }
 
@@ -757,8 +757,8 @@ SDL_GPUTexture *SDL_CreateGPUTexture(
                 SDL_assert_release(!"For cube textures: sample_count must be SDL_GPU_SAMPLECOUNT_1");
                 failed = true;
             }
-            if (!SDL_GPUTextureSupportsFormat(device, createinfo->format, SDL_GPU_TEXTURETYPE_CUBE, createinfo->usage_flags)) {
-                SDL_assert_release(!"For cube textures: the format is unsupported for the given usage_flags");
+            if (!SDL_GPUTextureSupportsFormat(device, createinfo->format, SDL_GPU_TEXTURETYPE_CUBE, createinfo->usage)) {
+                SDL_assert_release(!"For cube textures: the format is unsupported for the given usage");
                 failed = true;
             }
         } else if (createinfo->type == SDL_GPU_TEXTURETYPE_3D) {
@@ -767,23 +767,23 @@ SDL_GPUTexture *SDL_CreateGPUTexture(
                 SDL_assert_release(!"For 3D textures: width, height, and layer_count_or_depth must be <= 2048");
                 failed = true;
             }
-            if (createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
-                SDL_assert_release(!"For 3D textures: usage_flags must not contain DEPTH_STENCIL_TARGET");
+            if (createinfo->usage & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
+                SDL_assert_release(!"For 3D textures: usage must not contain DEPTH_STENCIL_TARGET");
                 failed = true;
             }
             if (createinfo->sample_count > SDL_GPU_SAMPLECOUNT_1) {
                 SDL_assert_release(!"For 3D textures: sample_count must be SDL_GPU_SAMPLECOUNT_1");
                 failed = true;
             }
-            if (!SDL_GPUTextureSupportsFormat(device, createinfo->format, SDL_GPU_TEXTURETYPE_3D, createinfo->usage_flags)) {
-                SDL_assert_release(!"For 3D textures: the format is unsupported for the given usage_flags");
+            if (!SDL_GPUTextureSupportsFormat(device, createinfo->format, SDL_GPU_TEXTURETYPE_3D, createinfo->usage)) {
+                SDL_assert_release(!"For 3D textures: the format is unsupported for the given usage");
                 failed = true;
             }
         } else {
             if (createinfo->type == SDL_GPU_TEXTURETYPE_2D_ARRAY) {
                 // Array Texture Validation
-                if (createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
-                    SDL_assert_release(!"For array textures: usage_flags must not contain DEPTH_STENCIL_TARGET");
+                if (createinfo->usage & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
+                    SDL_assert_release(!"For array textures: usage must not contain DEPTH_STENCIL_TARGET");
                     failed = true;
                 }
                 if (createinfo->sample_count > SDL_GPU_SAMPLECOUNT_1) {
@@ -797,8 +797,8 @@ SDL_GPUTexture *SDL_CreateGPUTexture(
                     failed = true;
                 }
             }
-            if (!SDL_GPUTextureSupportsFormat(device, createinfo->format, SDL_GPU_TEXTURETYPE_2D, createinfo->usage_flags)) {
-                SDL_assert_release(!"For 2D textures: the format is unsupported for the given usage_flags");
+            if (!SDL_GPUTextureSupportsFormat(device, createinfo->format, SDL_GPU_TEXTURETYPE_2D, createinfo->usage)) {
+                SDL_assert_release(!"For 2D textures: the format is unsupported for the given usage");
                 failed = true;
             }
         }
@@ -825,7 +825,7 @@ SDL_GPUBuffer *SDL_CreateGPUBuffer(
 
     return device->CreateBuffer(
         device->driverData,
-        createinfo->usage_flags,
+        createinfo->usage,
         createinfo->size);
 }
 
@@ -1067,13 +1067,13 @@ SDL_GPUCommandBuffer *SDL_AcquireGPUCommandBuffer(
     commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
     commandBufferHeader->device = device;
     commandBufferHeader->render_pass.command_buffer = command_buffer;
-    commandBufferHeader->render_pass.inProgress = false;
-    commandBufferHeader->graphicsPipelineBound = false;
+    commandBufferHeader->render_pass.in_progress = false;
+    commandBufferHeader->graphics_pipeline_bound = false;
     commandBufferHeader->compute_pass.command_buffer = command_buffer;
-    commandBufferHeader->compute_pass.inProgress = false;
-    commandBufferHeader->computePipelineBound = false;
+    commandBufferHeader->compute_pass.in_progress = false;
+    commandBufferHeader->compute_pipeline_bound = false;
     commandBufferHeader->copy_pass.command_buffer = command_buffer;
-    commandBufferHeader->copy_pass.inProgress = false;
+    commandBufferHeader->copy_pass.in_progress = false;
     commandBufferHeader->submitted = false;
 
     return command_buffer;
@@ -1163,9 +1163,9 @@ void SDL_PushGPUComputeUniformData(
 
 SDL_GPURenderPass *SDL_BeginGPURenderPass(
     SDL_GPUCommandBuffer *command_buffer,
-    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
-    Uint32 num_color_attachments,
-    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info)
+    const SDL_GPUColorTargetInfo *color_target_infos,
+    Uint32 num_color_targets,
+    const SDL_GPUDepthStencilTargetInfo *depth_stencil_target_info)
 {
     CommandBufferCommonHeader *commandBufferHeader;
 
@@ -1173,13 +1173,13 @@ SDL_GPURenderPass *SDL_BeginGPURenderPass(
         SDL_InvalidParamError("command_buffer");
         return NULL;
     }
-    if (color_attachment_infos == NULL && num_color_attachments > 0) {
-        SDL_InvalidParamError("color_attachment_infos");
+    if (color_target_infos == NULL && num_color_targets > 0) {
+        SDL_InvalidParamError("color_target_infos");
         return NULL;
     }
 
-    if (num_color_attachments > MAX_COLOR_TARGET_BINDINGS) {
-        SDL_SetError("num_color_attachments exceeds MAX_COLOR_TARGET_BINDINGS");
+    if (num_color_targets > MAX_COLOR_TARGET_BINDINGS) {
+        SDL_SetError("num_color_targets exceeds MAX_COLOR_TARGET_BINDINGS");
         return NULL;
     }
 
@@ -1187,25 +1187,25 @@ SDL_GPURenderPass *SDL_BeginGPURenderPass(
         CHECK_COMMAND_BUFFER_RETURN_NULL
         CHECK_ANY_PASS_IN_PROGRESS("Cannot begin render pass during another pass!", NULL)
 
-        for (Uint32 i = 0; i < num_color_attachments; i += 1) {
-            if (color_attachment_infos[i].cycle && color_attachment_infos[i].load_op == SDL_GPU_LOADOP_LOAD) {
-                SDL_assert_release(!"Cannot cycle color attachment when load op is LOAD!");
+        for (Uint32 i = 0; i < num_color_targets; i += 1) {
+            if (color_target_infos[i].cycle && color_target_infos[i].load_op == SDL_GPU_LOADOP_LOAD) {
+                SDL_assert_release(!"Cannot cycle color target when load op is LOAD!");
             }
         }
 
-        if (depth_stencil_attachment_info != NULL && depth_stencil_attachment_info->cycle && (depth_stencil_attachment_info->load_op == SDL_GPU_LOADOP_LOAD || depth_stencil_attachment_info->load_op == SDL_GPU_LOADOP_LOAD)) {
-            SDL_assert_release(!"Cannot cycle depth attachment when load op or stencil load op is LOAD!");
+        if (depth_stencil_target_info != NULL && depth_stencil_target_info->cycle && (depth_stencil_target_info->load_op == SDL_GPU_LOADOP_LOAD || depth_stencil_target_info->load_op == SDL_GPU_LOADOP_LOAD)) {
+            SDL_assert_release(!"Cannot cycle depth target when load op or stencil load op is LOAD!");
         }
     }
 
     COMMAND_BUFFER_DEVICE->BeginRenderPass(
         command_buffer,
-        color_attachment_infos,
-        num_color_attachments,
-        depth_stencil_attachment_info);
+        color_target_infos,
+        num_color_targets,
+        depth_stencil_target_info);
 
     commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
-    commandBufferHeader->render_pass.inProgress = true;
+    commandBufferHeader->render_pass.in_progress = true;
     return (SDL_GPURenderPass *)&(commandBufferHeader->render_pass);
 }
 
@@ -1229,7 +1229,7 @@ void SDL_BindGPUGraphicsPipeline(
         graphics_pipeline);
 
     commandBufferHeader = (CommandBufferCommonHeader *)RENDERPASS_COMMAND_BUFFER;
-    commandBufferHeader->graphicsPipelineBound = true;
+    commandBufferHeader->graphics_pipeline_bound = true;
 }
 
 void SDL_SetGPUViewport(
@@ -1340,15 +1340,15 @@ void SDL_BindGPUVertexBuffers(
 
 void SDL_BindGPUIndexBuffer(
     SDL_GPURenderPass *render_pass,
-    const SDL_GPUBufferBinding *pBinding,
+    const SDL_GPUBufferBinding *binding,
     SDL_GPUIndexElementSize index_element_size)
 {
     if (render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
-    if (pBinding == NULL) {
-        SDL_InvalidParamError("pBinding");
+    if (binding == NULL) {
+        SDL_InvalidParamError("binding");
         return;
     }
 
@@ -1358,7 +1358,7 @@ void SDL_BindGPUIndexBuffer(
 
     RENDERPASS_DEVICE->BindIndexBuffer(
         RENDERPASS_COMMAND_BUFFER,
-        pBinding,
+        binding,
         index_element_size);
 }
 
@@ -1646,8 +1646,8 @@ void SDL_EndGPURenderPass(
         RENDERPASS_COMMAND_BUFFER);
 
     commandBufferCommonHeader = (CommandBufferCommonHeader *)RENDERPASS_COMMAND_BUFFER;
-    commandBufferCommonHeader->render_pass.inProgress = false;
-    commandBufferCommonHeader->graphicsPipelineBound = false;
+    commandBufferCommonHeader->render_pass.in_progress = false;
+    commandBufferCommonHeader->graphics_pipeline_bound = false;
 }
 
 // Compute Pass
@@ -1694,7 +1694,7 @@ SDL_GPUComputePass *SDL_BeginGPUComputePass(
         num_storage_buffer_bindings);
 
     commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
-    commandBufferHeader->compute_pass.inProgress = true;
+    commandBufferHeader->compute_pass.in_progress = true;
     return (SDL_GPUComputePass *)&(commandBufferHeader->compute_pass);
 }
 
@@ -1722,7 +1722,7 @@ void SDL_BindGPUComputePipeline(
         compute_pipeline);
 
     commandBufferHeader = (CommandBufferCommonHeader *)COMPUTEPASS_COMMAND_BUFFER;
-    commandBufferHeader->computePipelineBound = true;
+    commandBufferHeader->compute_pipeline_bound = true;
 }
 
 void SDL_BindGPUComputeStorageTextures(
@@ -1839,8 +1839,8 @@ void SDL_EndGPUComputePass(
         COMPUTEPASS_COMMAND_BUFFER);
 
     commandBufferCommonHeader = (CommandBufferCommonHeader *)COMPUTEPASS_COMMAND_BUFFER;
-    commandBufferCommonHeader->compute_pass.inProgress = false;
-    commandBufferCommonHeader->computePipelineBound = false;
+    commandBufferCommonHeader->compute_pass.in_progress = false;
+    commandBufferCommonHeader->compute_pipeline_bound = false;
 }
 
 // TransferBuffer Data
@@ -1898,7 +1898,7 @@ SDL_GPUCopyPass *SDL_BeginGPUCopyPass(
         command_buffer);
 
     commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
-    commandBufferHeader->copy_pass.inProgress = true;
+    commandBufferHeader->copy_pass.in_progress = true;
     return (SDL_GPUCopyPass *)&(commandBufferHeader->copy_pass);
 }
 
@@ -2081,7 +2081,7 @@ void SDL_EndGPUCopyPass(
     COPYPASS_DEVICE->EndCopyPass(
         COPYPASS_COMMAND_BUFFER);
 
-    ((CommandBufferCommonHeader *)COPYPASS_COMMAND_BUFFER)->copy_pass.inProgress = false;
+    ((CommandBufferCommonHeader *)COPYPASS_COMMAND_BUFFER)->copy_pass.in_progress = false;
 }
 
 void SDL_GenerateMipmapsForGPUTexture(
@@ -2107,7 +2107,7 @@ void SDL_GenerateMipmapsForGPUTexture(
             return;
         }
 
-        if (!(header->info.usage_flags & SDL_GPU_TEXTUREUSAGE_SAMPLER) || !(header->info.usage_flags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET)) {
+        if (!(header->info.usage & SDL_GPU_TEXTUREUSAGE_SAMPLER) || !(header->info.usage & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET)) {
             SDL_assert_release(!"GenerateMipmaps texture must be created with SAMPLER and COLOR_TARGET usage flags!");
             return;
         }
@@ -2152,11 +2152,11 @@ void SDL_BlitGPUTexture(
             SDL_assert_release(!"Blit source and destination textures must be non-NULL");
             return; // attempting to proceed will crash
         }
-        if ((srcHeader->info.usage_flags & SDL_GPU_TEXTUREUSAGE_SAMPLER) == 0) {
+        if ((srcHeader->info.usage & SDL_GPU_TEXTUREUSAGE_SAMPLER) == 0) {
             SDL_assert_release(!"Blit source texture must be created with the SAMPLER usage flag");
             failed = true;
         }
-        if ((dstHeader->info.usage_flags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) == 0) {
+        if ((dstHeader->info.usage & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) == 0) {
             SDL_assert_release(!"Blit destination texture must be created with the COLOR_TARGET usage flag");
             failed = true;
         }
@@ -2344,9 +2344,9 @@ void SDL_SubmitGPUCommandBuffer(
     if (COMMAND_BUFFER_DEVICE->debug_mode) {
         CHECK_COMMAND_BUFFER
         if (
-            commandBufferHeader->render_pass.inProgress ||
-            commandBufferHeader->compute_pass.inProgress ||
-            commandBufferHeader->copy_pass.inProgress) {
+            commandBufferHeader->render_pass.in_progress ||
+            commandBufferHeader->compute_pass.in_progress ||
+            commandBufferHeader->copy_pass.in_progress) {
             SDL_assert_release(!"Cannot submit command buffer while a pass is in progress!");
             return;
         }
@@ -2371,9 +2371,9 @@ SDL_GPUFence *SDL_SubmitGPUCommandBufferAndAcquireFence(
     if (COMMAND_BUFFER_DEVICE->debug_mode) {
         CHECK_COMMAND_BUFFER_RETURN_NULL
         if (
-            commandBufferHeader->render_pass.inProgress ||
-            commandBufferHeader->compute_pass.inProgress ||
-            commandBufferHeader->copy_pass.inProgress) {
+            commandBufferHeader->render_pass.in_progress ||
+            commandBufferHeader->compute_pass.in_progress ||
+            commandBufferHeader->copy_pass.in_progress) {
             SDL_assert_release(!"Cannot submit command buffer while a pass is in progress!");
             return NULL;
         }

--- a/src/gpu/SDL_sysgpu.h
+++ b/src/gpu/SDL_sysgpu.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
   Simple DirectMedia Layer
   Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
 

--- a/src/gpu/SDL_sysgpu.h
+++ b/src/gpu/SDL_sysgpu.h
@@ -28,18 +28,18 @@
 
 typedef struct Pass
 {
-    SDL_GPUCommandBuffer *commandBuffer;
+    SDL_GPUCommandBuffer *command_buffer;
     bool inProgress;
 } Pass;
 
 typedef struct CommandBufferCommonHeader
 {
     SDL_GPUDevice *device;
-    Pass renderPass;
+    Pass render_pass;
     bool graphicsPipelineBound;
-    Pass computePass;
+    Pass compute_pass;
     bool computePipelineBound;
-    Pass copyPass;
+    Pass copy_pass;
     bool submitted;
 } CommandBufferCommonHeader;
 
@@ -56,7 +56,7 @@ typedef struct BlitFragmentUniforms
     float width;
     float height;
 
-    Uint32 mipLevel;
+    Uint32 mip_level;
     float layerOrDepth;
 } BlitFragmentUniforms;
 
@@ -262,11 +262,11 @@ SDL_GPUGraphicsPipeline *SDL_GPU_FetchBlitPipeline(
     Uint32 *blitPipelineCapacity);
 
 void SDL_GPU_BlitCommon(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUBlitRegion *source,
     const SDL_GPUBlitRegion *destination,
-    SDL_FlipMode flipMode,
-    SDL_GPUFilter filterMode,
+    SDL_FlipMode flip_mode,
+    SDL_GPUFilter filter,
     bool cycle,
     SDL_GPUSampler *blitLinearSampler,
     SDL_GPUSampler *blitNearestSampler,
@@ -297,33 +297,33 @@ struct SDL_GPUDevice
 
     SDL_GPUComputePipeline *(*CreateComputePipeline)(
         SDL_GPURenderer *driverData,
-        const SDL_GPUComputePipelineCreateInfo *pipelineCreateInfo);
+        const SDL_GPUComputePipelineCreateInfo *createinfo);
 
     SDL_GPUGraphicsPipeline *(*CreateGraphicsPipeline)(
         SDL_GPURenderer *driverData,
-        const SDL_GPUGraphicsPipelineCreateInfo *pipelineCreateInfo);
+        const SDL_GPUGraphicsPipelineCreateInfo *createinfo);
 
     SDL_GPUSampler *(*CreateSampler)(
         SDL_GPURenderer *driverData,
-        const SDL_GPUSamplerCreateInfo *samplerCreateInfo);
+        const SDL_GPUSamplerCreateInfo *createinfo);
 
     SDL_GPUShader *(*CreateShader)(
         SDL_GPURenderer *driverData,
-        const SDL_GPUShaderCreateInfo *shaderCreateInfo);
+        const SDL_GPUShaderCreateInfo *createinfo);
 
     SDL_GPUTexture *(*CreateTexture)(
         SDL_GPURenderer *driverData,
-        const SDL_GPUTextureCreateInfo *textureCreateInfo);
+        const SDL_GPUTextureCreateInfo *createinfo);
 
     SDL_GPUBuffer *(*CreateBuffer)(
         SDL_GPURenderer *driverData,
-        SDL_GPUBufferUsageFlags usageFlags,
-        Uint32 sizeInBytes);
+        SDL_GPUBufferUsageFlags usage_flags,
+        Uint32 size);
 
     SDL_GPUTransferBuffer *(*CreateTransferBuffer)(
         SDL_GPURenderer *driverData,
         SDL_GPUTransferBufferUsage usage,
-        Uint32 sizeInBytes);
+        Uint32 size);
 
     // Debug Naming
 
@@ -338,15 +338,15 @@ struct SDL_GPUDevice
         const char *text);
 
     void (*InsertDebugLabel)(
-        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUCommandBuffer *command_buffer,
         const char *text);
 
     void (*PushDebugGroup)(
-        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUCommandBuffer *command_buffer,
         const char *name);
 
     void (*PopDebugGroup)(
-        SDL_GPUCommandBuffer *commandBuffer);
+        SDL_GPUCommandBuffer *command_buffer);
 
     // Disposal
 
@@ -364,7 +364,7 @@ struct SDL_GPUDevice
 
     void (*ReleaseTransferBuffer)(
         SDL_GPURenderer *driverData,
-        SDL_GPUTransferBuffer *transferBuffer);
+        SDL_GPUTransferBuffer *transfer_buffer);
 
     void (*ReleaseShader)(
         SDL_GPURenderer *driverData,
@@ -372,206 +372,206 @@ struct SDL_GPUDevice
 
     void (*ReleaseComputePipeline)(
         SDL_GPURenderer *driverData,
-        SDL_GPUComputePipeline *computePipeline);
+        SDL_GPUComputePipeline *compute_pipeline);
 
     void (*ReleaseGraphicsPipeline)(
         SDL_GPURenderer *driverData,
-        SDL_GPUGraphicsPipeline *graphicsPipeline);
+        SDL_GPUGraphicsPipeline *graphics_pipeline);
 
     // Render Pass
 
     void (*BeginRenderPass)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        const SDL_GPUColorAttachmentInfo *colorAttachmentInfos,
-        Uint32 colorAttachmentCount,
-        const SDL_GPUDepthStencilAttachmentInfo *depthStencilAttachmentInfo);
+        SDL_GPUCommandBuffer *command_buffer,
+        const SDL_GPUColorAttachmentInfo *color_attachment_infos,
+        Uint32 num_color_attachments,
+        const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info);
 
     void (*BindGraphicsPipeline)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        SDL_GPUGraphicsPipeline *graphicsPipeline);
+        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUGraphicsPipeline *graphics_pipeline);
 
     void (*SetViewport)(
-        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUCommandBuffer *command_buffer,
         const SDL_GPUViewport *viewport);
 
     void (*SetScissor)(
-        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUCommandBuffer *command_buffer,
         const SDL_Rect *scissor);
 
     void (*SetBlendConstants)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        SDL_FColor blendConstants);
+        SDL_GPUCommandBuffer *command_buffer,
+        SDL_FColor blend_constants);
 
     void (*SetStencilReference)(
-        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUCommandBuffer *command_buffer,
         Uint8 reference);
 
     void (*BindVertexBuffers)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        Uint32 firstBinding,
-        const SDL_GPUBufferBinding *pBindings,
-        Uint32 bindingCount);
+        SDL_GPUCommandBuffer *command_buffer,
+        Uint32 first_binding,
+        const SDL_GPUBufferBinding *bindings,
+        Uint32 num_bindings);
 
     void (*BindIndexBuffer)(
-        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUCommandBuffer *command_buffer,
         const SDL_GPUBufferBinding *pBinding,
-        SDL_GPUIndexElementSize indexElementSize);
+        SDL_GPUIndexElementSize index_element_size);
 
     void (*BindVertexSamplers)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        Uint32 firstSlot,
-        const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
-        Uint32 bindingCount);
+        SDL_GPUCommandBuffer *command_buffer,
+        Uint32 first_slot,
+        const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
+        Uint32 num_bindings);
 
     void (*BindVertexStorageTextures)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        Uint32 firstSlot,
-        SDL_GPUTexture *const *storageTextures,
-        Uint32 bindingCount);
+        SDL_GPUCommandBuffer *command_buffer,
+        Uint32 first_slot,
+        SDL_GPUTexture *const *storage_textures,
+        Uint32 num_bindings);
 
     void (*BindVertexStorageBuffers)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        Uint32 firstSlot,
-        SDL_GPUBuffer *const *storageBuffers,
-        Uint32 bindingCount);
+        SDL_GPUCommandBuffer *command_buffer,
+        Uint32 first_slot,
+        SDL_GPUBuffer *const *storage_buffers,
+        Uint32 num_bindings);
 
     void (*BindFragmentSamplers)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        Uint32 firstSlot,
-        const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
-        Uint32 bindingCount);
+        SDL_GPUCommandBuffer *command_buffer,
+        Uint32 first_slot,
+        const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
+        Uint32 num_bindings);
 
     void (*BindFragmentStorageTextures)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        Uint32 firstSlot,
-        SDL_GPUTexture *const *storageTextures,
-        Uint32 bindingCount);
+        SDL_GPUCommandBuffer *command_buffer,
+        Uint32 first_slot,
+        SDL_GPUTexture *const *storage_textures,
+        Uint32 num_bindings);
 
     void (*BindFragmentStorageBuffers)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        Uint32 firstSlot,
-        SDL_GPUBuffer *const *storageBuffers,
-        Uint32 bindingCount);
+        SDL_GPUCommandBuffer *command_buffer,
+        Uint32 first_slot,
+        SDL_GPUBuffer *const *storage_buffers,
+        Uint32 num_bindings);
 
     void (*PushVertexUniformData)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        Uint32 slotIndex,
+        SDL_GPUCommandBuffer *command_buffer,
+        Uint32 slot_index,
         const void *data,
-        Uint32 dataLengthInBytes);
+        Uint32 length);
 
     void (*PushFragmentUniformData)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        Uint32 slotIndex,
+        SDL_GPUCommandBuffer *command_buffer,
+        Uint32 slot_index,
         const void *data,
-        Uint32 dataLengthInBytes);
+        Uint32 length);
 
     void (*DrawIndexedPrimitives)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        Uint32 indexCount,
-        Uint32 instanceCount,
-        Uint32 firstIndex,
-        Sint32 vertexOffset,
-        Uint32 firstInstance);
+        SDL_GPUCommandBuffer *command_buffer,
+        Uint32 num_indices,
+        Uint32 num_instances,
+        Uint32 first_index,
+        Sint32 vertex_offset,
+        Uint32 first_instance);
 
     void (*DrawPrimitives)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        Uint32 vertexCount,
-        Uint32 instanceCount,
-        Uint32 firstVertex,
-        Uint32 firstInstance);
+        SDL_GPUCommandBuffer *command_buffer,
+        Uint32 num_vertices,
+        Uint32 num_instances,
+        Uint32 first_vertex,
+        Uint32 first_instance);
 
     void (*DrawPrimitivesIndirect)(
-        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUCommandBuffer *command_buffer,
         SDL_GPUBuffer *buffer,
-        Uint32 offsetInBytes,
-        Uint32 drawCount,
-        Uint32 stride);
+        Uint32 offset,
+        Uint32 draw_count,
+        Uint32 pitch);
 
     void (*DrawIndexedPrimitivesIndirect)(
-        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUCommandBuffer *command_buffer,
         SDL_GPUBuffer *buffer,
-        Uint32 offsetInBytes,
-        Uint32 drawCount,
-        Uint32 stride);
+        Uint32 offset,
+        Uint32 draw_count,
+        Uint32 pitch);
 
     void (*EndRenderPass)(
-        SDL_GPUCommandBuffer *commandBuffer);
+        SDL_GPUCommandBuffer *command_buffer);
 
     // Compute Pass
 
     void (*BeginComputePass)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        const SDL_GPUStorageTextureWriteOnlyBinding *storageTextureBindings,
-        Uint32 storageTextureBindingCount,
-        const SDL_GPUStorageBufferWriteOnlyBinding *storageBufferBindings,
-        Uint32 storageBufferBindingCount);
+        SDL_GPUCommandBuffer *command_buffer,
+        const SDL_GPUStorageTextureWriteOnlyBinding *storage_texture_bindings,
+        Uint32 num_storage_texture_bindings,
+        const SDL_GPUStorageBufferWriteOnlyBinding *storage_buffer_bindings,
+        Uint32 num_storage_buffer_bindings);
 
     void (*BindComputePipeline)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        SDL_GPUComputePipeline *computePipeline);
+        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUComputePipeline *compute_pipeline);
 
     void (*BindComputeStorageTextures)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        Uint32 firstSlot,
-        SDL_GPUTexture *const *storageTextures,
-        Uint32 bindingCount);
+        SDL_GPUCommandBuffer *command_buffer,
+        Uint32 first_slot,
+        SDL_GPUTexture *const *storage_textures,
+        Uint32 num_bindings);
 
     void (*BindComputeStorageBuffers)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        Uint32 firstSlot,
-        SDL_GPUBuffer *const *storageBuffers,
-        Uint32 bindingCount);
+        SDL_GPUCommandBuffer *command_buffer,
+        Uint32 first_slot,
+        SDL_GPUBuffer *const *storage_buffers,
+        Uint32 num_bindings);
 
     void (*PushComputeUniformData)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        Uint32 slotIndex,
+        SDL_GPUCommandBuffer *command_buffer,
+        Uint32 slot_index,
         const void *data,
-        Uint32 dataLengthInBytes);
+        Uint32 length);
 
     void (*DispatchCompute)(
-        SDL_GPUCommandBuffer *commandBuffer,
-        Uint32 groupCountX,
-        Uint32 groupCountY,
-        Uint32 groupCountZ);
+        SDL_GPUCommandBuffer *command_buffer,
+        Uint32 groupcount_x,
+        Uint32 groupcount_y,
+        Uint32 groupcount_z);
 
     void (*DispatchComputeIndirect)(
-        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUCommandBuffer *command_buffer,
         SDL_GPUBuffer *buffer,
-        Uint32 offsetInBytes);
+        Uint32 offset);
 
     void (*EndComputePass)(
-        SDL_GPUCommandBuffer *commandBuffer);
+        SDL_GPUCommandBuffer *command_buffer);
 
     // TransferBuffer Data
 
     void *(*MapTransferBuffer)(
         SDL_GPURenderer *device,
-        SDL_GPUTransferBuffer *transferBuffer,
+        SDL_GPUTransferBuffer *transfer_buffer,
         bool cycle);
 
     void (*UnmapTransferBuffer)(
         SDL_GPURenderer *device,
-        SDL_GPUTransferBuffer *transferBuffer);
+        SDL_GPUTransferBuffer *transfer_buffer);
 
     // Copy Pass
 
     void (*BeginCopyPass)(
-        SDL_GPUCommandBuffer *commandBuffer);
+        SDL_GPUCommandBuffer *command_buffer);
 
     void (*UploadToTexture)(
-        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUCommandBuffer *command_buffer,
         const SDL_GPUTextureTransferInfo *source,
         const SDL_GPUTextureRegion *destination,
         bool cycle);
 
     void (*UploadToBuffer)(
-        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUCommandBuffer *command_buffer,
         const SDL_GPUTransferBufferLocation *source,
         const SDL_GPUBufferRegion *destination,
         bool cycle);
 
     void (*CopyTextureToTexture)(
-        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUCommandBuffer *command_buffer,
         const SDL_GPUTextureLocation *source,
         const SDL_GPUTextureLocation *destination,
         Uint32 w,
@@ -580,35 +580,35 @@ struct SDL_GPUDevice
         bool cycle);
 
     void (*CopyBufferToBuffer)(
-        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUCommandBuffer *command_buffer,
         const SDL_GPUBufferLocation *source,
         const SDL_GPUBufferLocation *destination,
         Uint32 size,
         bool cycle);
 
     void (*GenerateMipmaps)(
-        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUCommandBuffer *command_buffer,
         SDL_GPUTexture *texture);
 
     void (*DownloadFromTexture)(
-        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUCommandBuffer *command_buffer,
         const SDL_GPUTextureRegion *source,
         const SDL_GPUTextureTransferInfo *destination);
 
     void (*DownloadFromBuffer)(
-        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUCommandBuffer *command_buffer,
         const SDL_GPUBufferRegion *source,
         const SDL_GPUTransferBufferLocation *destination);
 
     void (*EndCopyPass)(
-        SDL_GPUCommandBuffer *commandBuffer);
+        SDL_GPUCommandBuffer *command_buffer);
 
     void (*Blit)(
-        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUCommandBuffer *command_buffer,
         const SDL_GPUBlitRegion *source,
         const SDL_GPUBlitRegion *destination,
-        SDL_FlipMode flipMode,
-        SDL_GPUFilter filterMode,
+        SDL_FlipMode flip_mode,
+        SDL_GPUFilter filter,
         bool cycle);
 
     // Submission/Presentation
@@ -616,12 +616,12 @@ struct SDL_GPUDevice
     bool (*SupportsSwapchainComposition)(
         SDL_GPURenderer *driverData,
         SDL_Window *window,
-        SDL_GPUSwapchainComposition swapchainComposition);
+        SDL_GPUSwapchainComposition swapchain_composition);
 
     bool (*SupportsPresentMode)(
         SDL_GPURenderer *driverData,
         SDL_Window *window,
-        SDL_GPUPresentMode presentMode);
+        SDL_GPUPresentMode present_mode);
 
     bool (*ClaimWindow)(
         SDL_GPURenderer *driverData,
@@ -634,8 +634,8 @@ struct SDL_GPUDevice
     bool (*SetSwapchainParameters)(
         SDL_GPURenderer *driverData,
         SDL_Window *window,
-        SDL_GPUSwapchainComposition swapchainComposition,
-        SDL_GPUPresentMode presentMode);
+        SDL_GPUSwapchainComposition swapchain_composition,
+        SDL_GPUPresentMode present_mode);
 
     SDL_GPUTextureFormat (*GetSwapchainTextureFormat)(
         SDL_GPURenderer *driverData,
@@ -645,25 +645,25 @@ struct SDL_GPUDevice
         SDL_GPURenderer *driverData);
 
     SDL_GPUTexture *(*AcquireSwapchainTexture)(
-        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUCommandBuffer *command_buffer,
         SDL_Window *window,
-        Uint32 *pWidth,
-        Uint32 *pHeight);
+        Uint32 *w,
+        Uint32 *h);
 
     void (*Submit)(
-        SDL_GPUCommandBuffer *commandBuffer);
+        SDL_GPUCommandBuffer *command_buffer);
 
     SDL_GPUFence *(*SubmitAndAcquireFence)(
-        SDL_GPUCommandBuffer *commandBuffer);
+        SDL_GPUCommandBuffer *command_buffer);
 
     void (*Wait)(
         SDL_GPURenderer *driverData);
 
     void (*WaitForFences)(
         SDL_GPURenderer *driverData,
-        bool waitAll,
-        SDL_GPUFence *const *pFences,
-        Uint32 fenceCount);
+        bool wait_all,
+        SDL_GPUFence *const *fences,
+        Uint32 num_fences);
 
     bool (*QueryFence)(
         SDL_GPURenderer *driverData,
@@ -693,7 +693,7 @@ struct SDL_GPUDevice
     SDL_GPUDriver backend;
 
     // Store this for SDL_gpu.c's debug layer
-    bool debugMode;
+    bool debug_mode;
     SDL_GPUShaderFormat shaderFormats;
 };
 
@@ -784,7 +784,7 @@ typedef struct SDL_GPUBootstrap
     const SDL_GPUDriver backendflag;
     const SDL_GPUShaderFormat shaderFormats;
     bool (*PrepareDriver)(SDL_VideoDevice *_this);
-    SDL_GPUDevice *(*CreateDevice)(bool debugMode, bool preferLowPower, SDL_PropertiesID props);
+    SDL_GPUDevice *(*CreateDevice)(bool debug_mode, bool preferLowPower, SDL_PropertiesID props);
 } SDL_GPUBootstrap;
 
 #ifdef __cplusplus

--- a/src/gpu/SDL_sysgpu.h
+++ b/src/gpu/SDL_sysgpu.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
   Simple DirectMedia Layer
   Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
 
@@ -29,16 +29,16 @@
 typedef struct Pass
 {
     SDL_GPUCommandBuffer *command_buffer;
-    bool inProgress;
+    bool in_progress;
 } Pass;
 
 typedef struct CommandBufferCommonHeader
 {
     SDL_GPUDevice *device;
     Pass render_pass;
-    bool graphicsPipelineBound;
+    bool graphics_pipeline_bound;
     Pass compute_pass;
-    bool computePipelineBound;
+    bool compute_pipeline_bound;
     Pass copy_pass;
     bool submitted;
 } CommandBufferCommonHeader;
@@ -57,7 +57,7 @@ typedef struct BlitFragmentUniforms
     float height;
 
     Uint32 mip_level;
-    float layerOrDepth;
+    float layer_or_depth;
 } BlitFragmentUniforms;
 
 typedef struct BlitPipelineCacheEntry
@@ -262,10 +262,10 @@ SDL_GPUGraphicsPipeline *SDL_GPU_FetchBlitPipeline(
     Uint32 *blitPipelineCapacity);
 
 void SDL_GPU_BlitCommon(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBlitRegion *source,
     const SDL_GPUBlitRegion *destination,
-    SDL_FlipMode flip_mode,
+    SDL_FlipMode flipMode,
     SDL_GPUFilter filter,
     bool cycle,
     SDL_GPUSampler *blitLinearSampler,
@@ -317,7 +317,7 @@ struct SDL_GPUDevice
 
     SDL_GPUBuffer *(*CreateBuffer)(
         SDL_GPURenderer *driverData,
-        SDL_GPUBufferUsageFlags usage_flags,
+        SDL_GPUBufferUsageFlags usageFlags,
         Uint32 size);
 
     SDL_GPUTransferBuffer *(*CreateTransferBuffer)(
@@ -338,15 +338,15 @@ struct SDL_GPUDevice
         const char *text);
 
     void (*InsertDebugLabel)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const char *text);
 
     void (*PushDebugGroup)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const char *name);
 
     void (*PopDebugGroup)(
-        SDL_GPUCommandBuffer *command_buffer);
+        SDL_GPUCommandBuffer *commandBuffer);
 
     // Disposal
 
@@ -364,7 +364,7 @@ struct SDL_GPUDevice
 
     void (*ReleaseTransferBuffer)(
         SDL_GPURenderer *driverData,
-        SDL_GPUTransferBuffer *transfer_buffer);
+        SDL_GPUTransferBuffer *transferBuffer);
 
     void (*ReleaseShader)(
         SDL_GPURenderer *driverData,
@@ -372,206 +372,206 @@ struct SDL_GPUDevice
 
     void (*ReleaseComputePipeline)(
         SDL_GPURenderer *driverData,
-        SDL_GPUComputePipeline *compute_pipeline);
+        SDL_GPUComputePipeline *computePipeline);
 
     void (*ReleaseGraphicsPipeline)(
         SDL_GPURenderer *driverData,
-        SDL_GPUGraphicsPipeline *graphics_pipeline);
+        SDL_GPUGraphicsPipeline *graphicsPipeline);
 
     // Render Pass
 
     void (*BeginRenderPass)(
-        SDL_GPUCommandBuffer *command_buffer,
-        const SDL_GPUColorAttachmentInfo *color_attachment_infos,
-        Uint32 num_color_attachments,
-        const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info);
+        SDL_GPUCommandBuffer *commandBuffer,
+        const SDL_GPUColorTargetInfo *colorTargetInfos,
+        Uint32 numColorTargets,
+        const SDL_GPUDepthStencilTargetInfo *depthStencilTargetInfo);
 
     void (*BindGraphicsPipeline)(
-        SDL_GPUCommandBuffer *command_buffer,
-        SDL_GPUGraphicsPipeline *graphics_pipeline);
+        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUGraphicsPipeline *graphicsPipeline);
 
     void (*SetViewport)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const SDL_GPUViewport *viewport);
 
     void (*SetScissor)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const SDL_Rect *scissor);
 
     void (*SetBlendConstants)(
-        SDL_GPUCommandBuffer *command_buffer,
-        SDL_FColor blend_constants);
+        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_FColor blendConstants);
 
     void (*SetStencilReference)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         Uint8 reference);
 
     void (*BindVertexBuffers)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 first_binding,
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 firstBinding,
         const SDL_GPUBufferBinding *bindings,
-        Uint32 num_bindings);
+        Uint32 numBindings);
 
     void (*BindIndexBuffer)(
-        SDL_GPUCommandBuffer *command_buffer,
-        const SDL_GPUBufferBinding *pBinding,
-        SDL_GPUIndexElementSize index_element_size);
+        SDL_GPUCommandBuffer *commandBuffer,
+        const SDL_GPUBufferBinding *binding,
+        SDL_GPUIndexElementSize indexElementSize);
 
     void (*BindVertexSamplers)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 first_slot,
-        const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
-        Uint32 num_bindings);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 firstSlot,
+        const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
+        Uint32 numBindings);
 
     void (*BindVertexStorageTextures)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 first_slot,
-        SDL_GPUTexture *const *storage_textures,
-        Uint32 num_bindings);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 firstSlot,
+        SDL_GPUTexture *const *storageTextures,
+        Uint32 numBindings);
 
     void (*BindVertexStorageBuffers)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 first_slot,
-        SDL_GPUBuffer *const *storage_buffers,
-        Uint32 num_bindings);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 firstSlot,
+        SDL_GPUBuffer *const *storageBuffers,
+        Uint32 numBindings);
 
     void (*BindFragmentSamplers)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 first_slot,
-        const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
-        Uint32 num_bindings);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 firstSlot,
+        const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
+        Uint32 numBindings);
 
     void (*BindFragmentStorageTextures)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 first_slot,
-        SDL_GPUTexture *const *storage_textures,
-        Uint32 num_bindings);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 firstSlot,
+        SDL_GPUTexture *const *storageTextures,
+        Uint32 numBindings);
 
     void (*BindFragmentStorageBuffers)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 first_slot,
-        SDL_GPUBuffer *const *storage_buffers,
-        Uint32 num_bindings);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 firstSlot,
+        SDL_GPUBuffer *const *storageBuffers,
+        Uint32 numBindings);
 
     void (*PushVertexUniformData)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 slot_index,
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 slotIndex,
         const void *data,
         Uint32 length);
 
     void (*PushFragmentUniformData)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 slot_index,
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 slotIndex,
         const void *data,
         Uint32 length);
 
     void (*DrawIndexedPrimitives)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 num_indices,
-        Uint32 num_instances,
-        Uint32 first_index,
-        Sint32 vertex_offset,
-        Uint32 first_instance);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 numIndices,
+        Uint32 numInstances,
+        Uint32 firstIndex,
+        Sint32 vertexOffset,
+        Uint32 firstInstance);
 
     void (*DrawPrimitives)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 num_vertices,
-        Uint32 num_instances,
-        Uint32 first_vertex,
-        Uint32 first_instance);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 numVertices,
+        Uint32 numInstances,
+        Uint32 firstVertex,
+        Uint32 firstInstance);
 
     void (*DrawPrimitivesIndirect)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         SDL_GPUBuffer *buffer,
         Uint32 offset,
-        Uint32 draw_count,
+        Uint32 drawCount,
         Uint32 pitch);
 
     void (*DrawIndexedPrimitivesIndirect)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         SDL_GPUBuffer *buffer,
         Uint32 offset,
-        Uint32 draw_count,
+        Uint32 drawCount,
         Uint32 pitch);
 
     void (*EndRenderPass)(
-        SDL_GPUCommandBuffer *command_buffer);
+        SDL_GPUCommandBuffer *commandBuffer);
 
     // Compute Pass
 
     void (*BeginComputePass)(
-        SDL_GPUCommandBuffer *command_buffer,
-        const SDL_GPUStorageTextureWriteOnlyBinding *storage_texture_bindings,
-        Uint32 num_storage_texture_bindings,
-        const SDL_GPUStorageBufferWriteOnlyBinding *storage_buffer_bindings,
-        Uint32 num_storage_buffer_bindings);
+        SDL_GPUCommandBuffer *commandBuffer,
+        const SDL_GPUStorageTextureWriteOnlyBinding *storageTextureBindings,
+        Uint32 numStorageTextureBindings,
+        const SDL_GPUStorageBufferWriteOnlyBinding *storageBufferBindings,
+        Uint32 numStorageBufferBindings);
 
     void (*BindComputePipeline)(
-        SDL_GPUCommandBuffer *command_buffer,
-        SDL_GPUComputePipeline *compute_pipeline);
+        SDL_GPUCommandBuffer *commandBuffer,
+        SDL_GPUComputePipeline *computePipeline);
 
     void (*BindComputeStorageTextures)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 first_slot,
-        SDL_GPUTexture *const *storage_textures,
-        Uint32 num_bindings);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 firstSlot,
+        SDL_GPUTexture *const *storageTextures,
+        Uint32 numBindings);
 
     void (*BindComputeStorageBuffers)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 first_slot,
-        SDL_GPUBuffer *const *storage_buffers,
-        Uint32 num_bindings);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 firstSlot,
+        SDL_GPUBuffer *const *storageBuffers,
+        Uint32 numBindings);
 
     void (*PushComputeUniformData)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 slot_index,
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 slotIndex,
         const void *data,
         Uint32 length);
 
     void (*DispatchCompute)(
-        SDL_GPUCommandBuffer *command_buffer,
-        Uint32 groupcount_x,
-        Uint32 groupcount_y,
-        Uint32 groupcount_z);
+        SDL_GPUCommandBuffer *commandBuffer,
+        Uint32 groupcountX,
+        Uint32 groupcountY,
+        Uint32 groupcountZ);
 
     void (*DispatchComputeIndirect)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         SDL_GPUBuffer *buffer,
         Uint32 offset);
 
     void (*EndComputePass)(
-        SDL_GPUCommandBuffer *command_buffer);
+        SDL_GPUCommandBuffer *commandBuffer);
 
     // TransferBuffer Data
 
     void *(*MapTransferBuffer)(
         SDL_GPURenderer *device,
-        SDL_GPUTransferBuffer *transfer_buffer,
+        SDL_GPUTransferBuffer *transferBuffer,
         bool cycle);
 
     void (*UnmapTransferBuffer)(
         SDL_GPURenderer *device,
-        SDL_GPUTransferBuffer *transfer_buffer);
+        SDL_GPUTransferBuffer *transferBuffer);
 
     // Copy Pass
 
     void (*BeginCopyPass)(
-        SDL_GPUCommandBuffer *command_buffer);
+        SDL_GPUCommandBuffer *commandBuffer);
 
     void (*UploadToTexture)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const SDL_GPUTextureTransferInfo *source,
         const SDL_GPUTextureRegion *destination,
         bool cycle);
 
     void (*UploadToBuffer)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const SDL_GPUTransferBufferLocation *source,
         const SDL_GPUBufferRegion *destination,
         bool cycle);
 
     void (*CopyTextureToTexture)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const SDL_GPUTextureLocation *source,
         const SDL_GPUTextureLocation *destination,
         Uint32 w,
@@ -580,34 +580,34 @@ struct SDL_GPUDevice
         bool cycle);
 
     void (*CopyBufferToBuffer)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const SDL_GPUBufferLocation *source,
         const SDL_GPUBufferLocation *destination,
         Uint32 size,
         bool cycle);
 
     void (*GenerateMipmaps)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         SDL_GPUTexture *texture);
 
     void (*DownloadFromTexture)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const SDL_GPUTextureRegion *source,
         const SDL_GPUTextureTransferInfo *destination);
 
     void (*DownloadFromBuffer)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const SDL_GPUBufferRegion *source,
         const SDL_GPUTransferBufferLocation *destination);
 
     void (*EndCopyPass)(
-        SDL_GPUCommandBuffer *command_buffer);
+        SDL_GPUCommandBuffer *commandBuffer);
 
     void (*Blit)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         const SDL_GPUBlitRegion *source,
         const SDL_GPUBlitRegion *destination,
-        SDL_FlipMode flip_mode,
+        SDL_FlipMode flipMode,
         SDL_GPUFilter filter,
         bool cycle);
 
@@ -616,12 +616,12 @@ struct SDL_GPUDevice
     bool (*SupportsSwapchainComposition)(
         SDL_GPURenderer *driverData,
         SDL_Window *window,
-        SDL_GPUSwapchainComposition swapchain_composition);
+        SDL_GPUSwapchainComposition swapchainComposition);
 
     bool (*SupportsPresentMode)(
         SDL_GPURenderer *driverData,
         SDL_Window *window,
-        SDL_GPUPresentMode present_mode);
+        SDL_GPUPresentMode presentMode);
 
     bool (*ClaimWindow)(
         SDL_GPURenderer *driverData,
@@ -634,8 +634,8 @@ struct SDL_GPUDevice
     bool (*SetSwapchainParameters)(
         SDL_GPURenderer *driverData,
         SDL_Window *window,
-        SDL_GPUSwapchainComposition swapchain_composition,
-        SDL_GPUPresentMode present_mode);
+        SDL_GPUSwapchainComposition swapchainComposition,
+        SDL_GPUPresentMode presentMode);
 
     SDL_GPUTextureFormat (*GetSwapchainTextureFormat)(
         SDL_GPURenderer *driverData,
@@ -645,25 +645,25 @@ struct SDL_GPUDevice
         SDL_GPURenderer *driverData);
 
     SDL_GPUTexture *(*AcquireSwapchainTexture)(
-        SDL_GPUCommandBuffer *command_buffer,
+        SDL_GPUCommandBuffer *commandBuffer,
         SDL_Window *window,
         Uint32 *w,
         Uint32 *h);
 
     void (*Submit)(
-        SDL_GPUCommandBuffer *command_buffer);
+        SDL_GPUCommandBuffer *commandBuffer);
 
     SDL_GPUFence *(*SubmitAndAcquireFence)(
-        SDL_GPUCommandBuffer *command_buffer);
+        SDL_GPUCommandBuffer *commandBuffer);
 
     void (*Wait)(
         SDL_GPURenderer *driverData);
 
     void (*WaitForFences)(
         SDL_GPURenderer *driverData,
-        bool wait_all,
+        bool waitAll,
         SDL_GPUFence *const *fences,
-        Uint32 num_fences);
+        Uint32 numFences);
 
     bool (*QueryFence)(
         SDL_GPURenderer *driverData,
@@ -694,7 +694,7 @@ struct SDL_GPUDevice
 
     // Store this for SDL_gpu.c's debug layer
     bool debug_mode;
-    SDL_GPUShaderFormat shaderFormats;
+    SDL_GPUShaderFormat shader_formats;
 };
 
 #define ASSIGN_DRIVER_FUNC(func, name) \
@@ -780,11 +780,11 @@ struct SDL_GPUDevice
 
 typedef struct SDL_GPUBootstrap
 {
-    const char *Name;
+    const char *name;
     const SDL_GPUDriver backendflag;
-    const SDL_GPUShaderFormat shaderFormats;
+    const SDL_GPUShaderFormat shader_formats;
     bool (*PrepareDriver)(SDL_VideoDevice *_this);
-    SDL_GPUDevice *(*CreateDevice)(bool debug_mode, bool preferLowPower, SDL_PropertiesID props);
+    SDL_GPUDevice *(*CreateDevice)(bool debug_mode, bool prefer_low_power, SDL_PropertiesID props);
 } SDL_GPUBootstrap;
 
 #ifdef __cplusplus

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -120,20 +120,20 @@ static const GUID D3D_IID_DXGI_DEBUG_ALL = { 0xe48ae283, 0xda80, 0x490b, { 0x87,
 #define TRACK_RESOURCE(resource, type, array, count, capacity) \
     Uint32 i;                                                  \
                                                                \
-    for (i = 0; i < command_buffer->count; i += 1) {            \
-        if (command_buffer->array[i] == resource) {             \
+    for (i = 0; i < commandBuffer->count; i += 1) {            \
+        if (commandBuffer->array[i] == resource) {             \
             return;                                            \
         }                                                      \
     }                                                          \
                                                                \
-    if (command_buffer->count == command_buffer->capacity) {     \
-        command_buffer->capacity += 1;                          \
-        command_buffer->array = SDL_realloc(                    \
-            command_buffer->array,                              \
-            command_buffer->capacity * sizeof(type));           \
+    if (commandBuffer->count == commandBuffer->capacity) {     \
+        commandBuffer->capacity += 1;                          \
+        commandBuffer->array = SDL_realloc(                    \
+            commandBuffer->array,                              \
+            commandBuffer->capacity * sizeof(type));           \
     }                                                          \
-    command_buffer->array[command_buffer->count] = resource;     \
-    command_buffer->count += 1;                                 \
+    commandBuffer->array[commandBuffer->count] = resource;     \
+    commandBuffer->count += 1;                                 \
     SDL_AtomicIncRef(&resource->referenceCount);
 
 // Forward Declarations
@@ -1000,7 +1000,7 @@ static void D3D11_DestroyDevice(
 // Resource tracking
 
 static void D3D11_INTERNAL_TrackBuffer(
-    D3D11CommandBuffer *command_buffer,
+    D3D11CommandBuffer *commandBuffer,
     D3D11Buffer *buffer)
 {
     TRACK_RESOURCE(
@@ -1012,7 +1012,7 @@ static void D3D11_INTERNAL_TrackBuffer(
 }
 
 static void D3D11_INTERNAL_TrackTransferBuffer(
-    D3D11CommandBuffer *command_buffer,
+    D3D11CommandBuffer *commandBuffer,
     D3D11TransferBuffer *buffer)
 {
     TRACK_RESOURCE(
@@ -1024,7 +1024,7 @@ static void D3D11_INTERNAL_TrackTransferBuffer(
 }
 
 static void D3D11_INTERNAL_TrackTexture(
-    D3D11CommandBuffer *command_buffer,
+    D3D11CommandBuffer *commandBuffer,
     D3D11Texture *texture)
 {
     TRACK_RESOURCE(

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -120,20 +120,20 @@ static const GUID D3D_IID_DXGI_DEBUG_ALL = { 0xe48ae283, 0xda80, 0x490b, { 0x87,
 #define TRACK_RESOURCE(resource, type, array, count, capacity) \
     Uint32 i;                                                  \
                                                                \
-    for (i = 0; i < commandBuffer->count; i += 1) {            \
-        if (commandBuffer->array[i] == resource) {             \
+    for (i = 0; i < command_buffer->count; i += 1) {            \
+        if (command_buffer->array[i] == resource) {             \
             return;                                            \
         }                                                      \
     }                                                          \
                                                                \
-    if (commandBuffer->count == commandBuffer->capacity) {     \
-        commandBuffer->capacity += 1;                          \
-        commandBuffer->array = SDL_realloc(                    \
-            commandBuffer->array,                              \
-            commandBuffer->capacity * sizeof(type));           \
+    if (command_buffer->count == command_buffer->capacity) {     \
+        command_buffer->capacity += 1;                          \
+        command_buffer->array = SDL_realloc(                    \
+            command_buffer->array,                              \
+            command_buffer->capacity * sizeof(type));           \
     }                                                          \
-    commandBuffer->array[commandBuffer->count] = resource;     \
-    commandBuffer->count += 1;                                 \
+    command_buffer->array[command_buffer->count] = resource;     \
+    command_buffer->count += 1;                                 \
     SDL_AtomicIncRef(&resource->referenceCount);
 
 // Forward Declarations
@@ -361,29 +361,29 @@ static D3D11_TEXTURE_ADDRESS_MODE SDLToD3D11_SamplerAddressMode[] = {
 
 static D3D11_FILTER SDLToD3D11_Filter(const SDL_GPUSamplerCreateInfo *createInfo)
 {
-    if (createInfo->minFilter == SDL_GPU_FILTER_LINEAR) {
-        if (createInfo->magFilter == SDL_GPU_FILTER_LINEAR) {
-            if (createInfo->mipmapMode == SDL_GPU_SAMPLERMIPMAPMODE_LINEAR) {
+    if (createInfo->min_filter == SDL_GPU_FILTER_LINEAR) {
+        if (createInfo->mag_filter == SDL_GPU_FILTER_LINEAR) {
+            if (createInfo->mipmap_mode == SDL_GPU_SAMPLERMIPMAPMODE_LINEAR) {
                 return D3D11_FILTER_MIN_MAG_MIP_LINEAR;
             } else {
                 return D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT;
             }
         } else {
-            if (createInfo->mipmapMode == SDL_GPU_SAMPLERMIPMAPMODE_LINEAR) {
+            if (createInfo->mipmap_mode == SDL_GPU_SAMPLERMIPMAPMODE_LINEAR) {
                 return D3D11_FILTER_MIN_LINEAR_MAG_POINT_MIP_LINEAR;
             } else {
                 return D3D11_FILTER_MIN_LINEAR_MAG_MIP_POINT;
             }
         }
     } else {
-        if (createInfo->magFilter == SDL_GPU_FILTER_LINEAR) {
-            if (createInfo->mipmapMode == SDL_GPU_SAMPLERMIPMAPMODE_LINEAR) {
+        if (createInfo->mag_filter == SDL_GPU_FILTER_LINEAR) {
+            if (createInfo->mipmap_mode == SDL_GPU_SAMPLERMIPMAPMODE_LINEAR) {
                 return D3D11_FILTER_MIN_POINT_MAG_MIP_LINEAR;
             } else {
                 return D3D11_FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT;
             }
         } else {
-            if (createInfo->mipmapMode == SDL_GPU_SAMPLERMIPMAPMODE_LINEAR) {
+            if (createInfo->mipmap_mode == SDL_GPU_SAMPLERMIPMAPMODE_LINEAR) {
                 return D3D11_FILTER_MIN_MAG_POINT_MIP_LINEAR;
             } else {
                 return D3D11_FILTER_MIN_MAG_MIP_POINT;
@@ -437,7 +437,7 @@ struct D3D11Texture
     ID3D11ShaderResourceView *shaderView;
 
     D3D11TextureSubresource *subresources;
-    Uint32 subresourceCount; /* layerCount * levelCount */
+    Uint32 subresourceCount; /* layerCount * num_levels */
 
     SDL_AtomicInt referenceCount;
 };
@@ -454,8 +454,8 @@ typedef struct D3D11WindowData
     IDXGISwapChain *swapchain;
     D3D11Texture texture;
     D3D11TextureContainer textureContainer;
-    SDL_GPUPresentMode presentMode;
-    SDL_GPUSwapchainComposition swapchainComposition;
+    SDL_GPUPresentMode present_mode;
+    SDL_GPUSwapchainComposition swapchain_composition;
     DXGI_FORMAT swapchainFormat;
     DXGI_COLOR_SPACE_TYPE swapchainColorSpace;
     SDL_GPUFence *inFlightFences[MAX_FRAMES_IN_FLIGHT];
@@ -468,10 +468,10 @@ typedef struct D3D11Shader
     void *bytecode;
     size_t bytecodeSize;
 
-    Uint32 samplerCount;
-    Uint32 uniformBufferCount;
-    Uint32 storageBufferCount;
-    Uint32 storageTextureCount;
+    Uint32 num_samplers;
+    Uint32 num_uniform_buffers;
+    Uint32 num_storage_buffers;
+    Uint32 num_storage_textures;
 } D3D11Shader;
 
 typedef struct D3D11GraphicsPipeline
@@ -480,17 +480,17 @@ typedef struct D3D11GraphicsPipeline
     DXGI_FORMAT colorAttachmentFormats[MAX_COLOR_TARGET_BINDINGS];
     ID3D11BlendState *colorAttachmentBlendState;
 
-    SDL_GPUMultisampleState multisampleState;
+    SDL_GPUMultisampleState multisample_state;
 
-    Uint8 hasDepthStencilAttachment;
+    Uint8 has_depth_stencil_attachment;
     DXGI_FORMAT depthStencilAttachmentFormat;
-    ID3D11DepthStencilState *depthStencilState;
+    ID3D11DepthStencilState *depth_stencil_state;
 
-    SDL_GPUPrimitiveType primitiveType;
-    ID3D11RasterizerState *rasterizerState;
+    SDL_GPUPrimitiveType primitive_type;
+    ID3D11RasterizerState *rasterizer_state;
 
-    ID3D11VertexShader *vertexShader;
-    ID3D11PixelShader *fragmentShader;
+    ID3D11VertexShader *vertex_shader;
+    ID3D11PixelShader *fragment_shader;
 
     ID3D11InputLayout *inputLayout;
     Uint32 *vertexStrides;
@@ -510,11 +510,11 @@ typedef struct D3D11ComputePipeline
 {
     ID3D11ComputeShader *computeShader;
 
-    Uint32 readOnlyStorageTextureCount;
-    Uint32 writeOnlyStorageTextureCount;
-    Uint32 readOnlyStorageBufferCount;
-    Uint32 writeOnlyStorageBufferCount;
-    Uint32 uniformBufferCount;
+    Uint32 num_readonly_storage_textures;
+    Uint32 num_writeonly_storage_textures;
+    Uint32 num_readonly_storage_buffers;
+    Uint32 num_writeonly_storage_buffers;
+    Uint32 num_uniform_buffers;
 } D3D11ComputePipeline;
 
 typedef struct D3D11Buffer
@@ -612,9 +612,9 @@ typedef struct D3D11CommandBuffer
     Uint32 windowDataCapacity;
 
     // Render Pass
-    D3D11GraphicsPipeline *graphicsPipeline;
+    D3D11GraphicsPipeline *graphics_pipeline;
     Uint8 stencilRef;
-    SDL_FColor blendConstants;
+    SDL_FColor blend_constants;
 
     // Render Pass MSAA resolve
     D3D11Texture *colorTargetResolveTexture[MAX_COLOR_TARGET_BINDINGS];
@@ -623,7 +623,7 @@ typedef struct D3D11CommandBuffer
     DXGI_FORMAT colorTargetMsaaFormat[MAX_COLOR_TARGET_BINDINGS];
 
     // Compute Pass
-    D3D11ComputePipeline *computePipeline;
+    D3D11ComputePipeline *compute_pipeline;
 
     // Debug Annotation
     ID3DUserDefinedAnnotation *annotation;
@@ -710,7 +710,7 @@ struct D3D11Renderer
     void *dxgi_dll;
     void *dxgidebug_dll;
 
-    Uint8 debugMode;
+    Uint8 debug_mode;
     BOOL supportsTearing;
     Uint8 supportsFlipDiscard;
 
@@ -833,11 +833,11 @@ static void D3D11_INTERNAL_LogError(
 // Helper Functions
 
 static inline Uint32 D3D11_INTERNAL_CalcSubresource(
-    Uint32 mipLevel,
+    Uint32 mip_level,
     Uint32 layer,
     Uint32 numLevels)
 {
-    return mipLevel + (layer * numLevels);
+    return mip_level + (layer * numLevels);
 }
 
 static inline Uint32 D3D11_INTERNAL_NextHighestAlignment(
@@ -932,14 +932,14 @@ static void D3D11_DestroyDevice(
 
     // Release command buffer infrastructure
     for (Uint32 i = 0; i < renderer->availableCommandBufferCount; i += 1) {
-        D3D11CommandBuffer *commandBuffer = renderer->availableCommandBuffers[i];
-        if (commandBuffer->annotation) {
-            ID3DUserDefinedAnnotation_Release(commandBuffer->annotation);
+        D3D11CommandBuffer *command_buffer = renderer->availableCommandBuffers[i];
+        if (command_buffer->annotation) {
+            ID3DUserDefinedAnnotation_Release(command_buffer->annotation);
         }
-        ID3D11DeviceContext_Release(commandBuffer->context);
-        SDL_free(commandBuffer->usedBuffers);
-        SDL_free(commandBuffer->usedTransferBuffers);
-        SDL_free(commandBuffer);
+        ID3D11DeviceContext_Release(command_buffer->context);
+        SDL_free(command_buffer->usedBuffers);
+        SDL_free(command_buffer->usedTransferBuffers);
+        SDL_free(command_buffer);
     }
     SDL_free(renderer->availableCommandBuffers);
     SDL_free(renderer->submittedCommandBuffers);
@@ -1000,7 +1000,7 @@ static void D3D11_DestroyDevice(
 // Resource tracking
 
 static void D3D11_INTERNAL_TrackBuffer(
-    D3D11CommandBuffer *commandBuffer,
+    D3D11CommandBuffer *command_buffer,
     D3D11Buffer *buffer)
 {
     TRACK_RESOURCE(
@@ -1012,7 +1012,7 @@ static void D3D11_INTERNAL_TrackBuffer(
 }
 
 static void D3D11_INTERNAL_TrackTransferBuffer(
-    D3D11CommandBuffer *commandBuffer,
+    D3D11CommandBuffer *command_buffer,
     D3D11TransferBuffer *buffer)
 {
     TRACK_RESOURCE(
@@ -1024,7 +1024,7 @@ static void D3D11_INTERNAL_TrackTransferBuffer(
 }
 
 static void D3D11_INTERNAL_TrackTexture(
-    D3D11CommandBuffer *commandBuffer,
+    D3D11CommandBuffer *command_buffer,
     D3D11Texture *texture)
 {
     TRACK_RESOURCE(
@@ -1036,25 +1036,25 @@ static void D3D11_INTERNAL_TrackTexture(
 }
 
 static void D3D11_INTERNAL_TrackUniformBuffer(
-    D3D11CommandBuffer *commandBuffer,
+    D3D11CommandBuffer *command_buffer,
     D3D11UniformBuffer *uniformBuffer)
 {
     Uint32 i;
-    for (i = 0; i < commandBuffer->usedUniformBufferCount; i += 1) {
-        if (commandBuffer->usedUniformBuffers[i] == uniformBuffer) {
+    for (i = 0; i < command_buffer->usedUniformBufferCount; i += 1) {
+        if (command_buffer->usedUniformBuffers[i] == uniformBuffer) {
             return;
         }
     }
 
-    if (commandBuffer->usedUniformBufferCount == commandBuffer->usedUniformBufferCapacity) {
-        commandBuffer->usedUniformBufferCapacity += 1;
-        commandBuffer->usedUniformBuffers = SDL_realloc(
-            commandBuffer->usedUniformBuffers,
-            commandBuffer->usedUniformBufferCapacity * sizeof(D3D11UniformBuffer *));
+    if (command_buffer->usedUniformBufferCount == command_buffer->usedUniformBufferCapacity) {
+        command_buffer->usedUniformBufferCapacity += 1;
+        command_buffer->usedUniformBuffers = SDL_realloc(
+            command_buffer->usedUniformBuffers,
+            command_buffer->usedUniformBufferCapacity * sizeof(D3D11UniformBuffer *));
     }
 
-    commandBuffer->usedUniformBuffers[commandBuffer->usedUniformBufferCount] = uniformBuffer;
-    commandBuffer->usedUniformBufferCount += 1;
+    command_buffer->usedUniformBuffers[command_buffer->usedUniformBufferCount] = uniformBuffer;
+    command_buffer->usedUniformBufferCount += 1;
 }
 
 // Disposal
@@ -1161,7 +1161,7 @@ static void D3D11_ReleaseBuffer(
 
 static void D3D11_ReleaseTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transferBuffer)
+    SDL_GPUTransferBuffer *transfer_buffer)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
 
@@ -1174,7 +1174,7 @@ static void D3D11_ReleaseTransferBuffer(
         renderer->transferBufferContainersToDestroyCapacity,
         renderer->transferBufferContainersToDestroyCapacity + 1);
 
-    renderer->transferBufferContainersToDestroy[renderer->transferBufferContainersToDestroyCount] = (D3D11TransferBufferContainer *)transferBuffer;
+    renderer->transferBufferContainersToDestroy[renderer->transferBufferContainersToDestroyCount] = (D3D11TransferBufferContainer *)transfer_buffer;
     renderer->transferBufferContainersToDestroyCount += 1;
 
     SDL_UnlockMutex(renderer->contextLock);
@@ -1211,9 +1211,9 @@ static void D3D11_ReleaseShader(
 
 static void D3D11_ReleaseComputePipeline(
     SDL_GPURenderer *driverData,
-    SDL_GPUComputePipeline *computePipeline)
+    SDL_GPUComputePipeline *compute_pipeline)
 {
-    D3D11ComputePipeline *d3d11ComputePipeline = (D3D11ComputePipeline *)computePipeline;
+    D3D11ComputePipeline *d3d11ComputePipeline = (D3D11ComputePipeline *)compute_pipeline;
 
     ID3D11ComputeShader_Release(d3d11ComputePipeline->computeShader);
 
@@ -1222,14 +1222,14 @@ static void D3D11_ReleaseComputePipeline(
 
 static void D3D11_ReleaseGraphicsPipeline(
     SDL_GPURenderer *driverData,
-    SDL_GPUGraphicsPipeline *graphicsPipeline)
+    SDL_GPUGraphicsPipeline *graphics_pipeline)
 {
     (void)driverData; // used by other backends
-    D3D11GraphicsPipeline *d3d11GraphicsPipeline = (D3D11GraphicsPipeline *)graphicsPipeline;
+    D3D11GraphicsPipeline *d3d11GraphicsPipeline = (D3D11GraphicsPipeline *)graphics_pipeline;
 
     ID3D11BlendState_Release(d3d11GraphicsPipeline->colorAttachmentBlendState);
-    ID3D11DepthStencilState_Release(d3d11GraphicsPipeline->depthStencilState);
-    ID3D11RasterizerState_Release(d3d11GraphicsPipeline->rasterizerState);
+    ID3D11DepthStencilState_Release(d3d11GraphicsPipeline->depth_stencil_state);
+    ID3D11RasterizerState_Release(d3d11GraphicsPipeline->rasterizer_state);
 
     if (d3d11GraphicsPipeline->inputLayout) {
         ID3D11InputLayout_Release(d3d11GraphicsPipeline->inputLayout);
@@ -1238,8 +1238,8 @@ static void D3D11_ReleaseGraphicsPipeline(
         SDL_free(d3d11GraphicsPipeline->vertexStrides);
     }
 
-    ID3D11VertexShader_Release(d3d11GraphicsPipeline->vertexShader);
-    ID3D11PixelShader_Release(d3d11GraphicsPipeline->fragmentShader);
+    ID3D11VertexShader_Release(d3d11GraphicsPipeline->vertex_shader);
+    ID3D11PixelShader_Release(d3d11GraphicsPipeline->fragment_shader);
 
     SDL_free(d3d11GraphicsPipeline);
 }
@@ -1264,14 +1264,14 @@ static ID3D11BlendState *D3D11_INTERNAL_FetchBlendState(
     blendDesc.IndependentBlendEnable = TRUE;
 
     for (Uint32 i = 0; i < numColorAttachments; i += 1) {
-        blendDesc.RenderTarget[i].BlendEnable = colorAttachments[i].blendState.blendEnable;
-        blendDesc.RenderTarget[i].BlendOp = SDLToD3D11_BlendOp[colorAttachments[i].blendState.colorBlendOp];
-        blendDesc.RenderTarget[i].BlendOpAlpha = SDLToD3D11_BlendOp[colorAttachments[i].blendState.alphaBlendOp];
-        blendDesc.RenderTarget[i].DestBlend = SDLToD3D11_BlendFactor[colorAttachments[i].blendState.dstColorBlendFactor];
-        blendDesc.RenderTarget[i].DestBlendAlpha = SDLToD3D11_BlendFactorAlpha[colorAttachments[i].blendState.dstAlphaBlendFactor];
-        blendDesc.RenderTarget[i].RenderTargetWriteMask = colorAttachments[i].blendState.colorWriteMask;
-        blendDesc.RenderTarget[i].SrcBlend = SDLToD3D11_BlendFactor[colorAttachments[i].blendState.srcColorBlendFactor];
-        blendDesc.RenderTarget[i].SrcBlendAlpha = SDLToD3D11_BlendFactorAlpha[colorAttachments[i].blendState.srcAlphaBlendFactor];
+        blendDesc.RenderTarget[i].BlendEnable = colorAttachments[i].blend_state.enable_blend;
+        blendDesc.RenderTarget[i].BlendOp = SDLToD3D11_BlendOp[colorAttachments[i].blend_state.color_blend_op];
+        blendDesc.RenderTarget[i].BlendOpAlpha = SDLToD3D11_BlendOp[colorAttachments[i].blend_state.alpha_blend_op];
+        blendDesc.RenderTarget[i].DestBlend = SDLToD3D11_BlendFactor[colorAttachments[i].blend_state.dst_color_blendfactor];
+        blendDesc.RenderTarget[i].DestBlendAlpha = SDLToD3D11_BlendFactorAlpha[colorAttachments[i].blend_state.dst_alpha_blendfactor];
+        blendDesc.RenderTarget[i].RenderTargetWriteMask = colorAttachments[i].blend_state.color_write_mask;
+        blendDesc.RenderTarget[i].SrcBlend = SDLToD3D11_BlendFactor[colorAttachments[i].blend_state.src_color_blendfactor];
+        blendDesc.RenderTarget[i].SrcBlendAlpha = SDLToD3D11_BlendFactorAlpha[colorAttachments[i].blend_state.src_alpha_blendfactor];
     }
 
     res = ID3D11Device_CreateBlendState(
@@ -1285,7 +1285,7 @@ static ID3D11BlendState *D3D11_INTERNAL_FetchBlendState(
 
 static ID3D11DepthStencilState *D3D11_INTERNAL_FetchDepthStencilState(
     D3D11Renderer *renderer,
-    SDL_GPUDepthStencilState depthStencilState)
+    SDL_GPUDepthStencilState depth_stencil_state)
 {
     ID3D11DepthStencilState *result;
     D3D11_DEPTH_STENCIL_DESC dsDesc;
@@ -1294,23 +1294,23 @@ static ID3D11DepthStencilState *D3D11_INTERNAL_FetchDepthStencilState(
     /* Create a new depth-stencil state.
      * The spec says the driver will not create duplicate states, so there's no need to cache.
      */
-    dsDesc.DepthEnable = depthStencilState.depthTestEnable;
-    dsDesc.StencilEnable = depthStencilState.stencilTestEnable;
-    dsDesc.DepthFunc = SDLToD3D11_CompareOp[depthStencilState.compareOp];
-    dsDesc.DepthWriteMask = (depthStencilState.depthWriteEnable ? D3D11_DEPTH_WRITE_MASK_ALL : D3D11_DEPTH_WRITE_MASK_ZERO);
+    dsDesc.DepthEnable = depth_stencil_state.enable_depth_test;
+    dsDesc.StencilEnable = depth_stencil_state.enable_stencil_test;
+    dsDesc.DepthFunc = SDLToD3D11_CompareOp[depth_stencil_state.compare_op];
+    dsDesc.DepthWriteMask = (depth_stencil_state.enable_depth_write ? D3D11_DEPTH_WRITE_MASK_ALL : D3D11_DEPTH_WRITE_MASK_ZERO);
 
-    dsDesc.BackFace.StencilFunc = SDLToD3D11_CompareOp[depthStencilState.backStencilState.compareOp];
-    dsDesc.BackFace.StencilDepthFailOp = SDLToD3D11_StencilOp[depthStencilState.backStencilState.depthFailOp];
-    dsDesc.BackFace.StencilFailOp = SDLToD3D11_StencilOp[depthStencilState.backStencilState.failOp];
-    dsDesc.BackFace.StencilPassOp = SDLToD3D11_StencilOp[depthStencilState.backStencilState.passOp];
+    dsDesc.BackFace.StencilFunc = SDLToD3D11_CompareOp[depth_stencil_state.back_stencil_state.compare_op];
+    dsDesc.BackFace.StencilDepthFailOp = SDLToD3D11_StencilOp[depth_stencil_state.back_stencil_state.depth_fail_op];
+    dsDesc.BackFace.StencilFailOp = SDLToD3D11_StencilOp[depth_stencil_state.back_stencil_state.fail_op];
+    dsDesc.BackFace.StencilPassOp = SDLToD3D11_StencilOp[depth_stencil_state.back_stencil_state.pass_op];
 
-    dsDesc.FrontFace.StencilFunc = SDLToD3D11_CompareOp[depthStencilState.frontStencilState.compareOp];
-    dsDesc.FrontFace.StencilDepthFailOp = SDLToD3D11_StencilOp[depthStencilState.frontStencilState.depthFailOp];
-    dsDesc.FrontFace.StencilFailOp = SDLToD3D11_StencilOp[depthStencilState.frontStencilState.failOp];
-    dsDesc.FrontFace.StencilPassOp = SDLToD3D11_StencilOp[depthStencilState.frontStencilState.passOp];
+    dsDesc.FrontFace.StencilFunc = SDLToD3D11_CompareOp[depth_stencil_state.front_stencil_state.compare_op];
+    dsDesc.FrontFace.StencilDepthFailOp = SDLToD3D11_StencilOp[depth_stencil_state.front_stencil_state.depth_fail_op];
+    dsDesc.FrontFace.StencilFailOp = SDLToD3D11_StencilOp[depth_stencil_state.front_stencil_state.fail_op];
+    dsDesc.FrontFace.StencilPassOp = SDLToD3D11_StencilOp[depth_stencil_state.front_stencil_state.pass_op];
 
-    dsDesc.StencilReadMask = depthStencilState.compareMask;
-    dsDesc.StencilWriteMask = depthStencilState.writeMask;
+    dsDesc.StencilReadMask = depth_stencil_state.compare_mask;
+    dsDesc.StencilWriteMask = depth_stencil_state.write_mask;
 
     res = ID3D11Device_CreateDepthStencilState(
         renderer->device,
@@ -1323,7 +1323,7 @@ static ID3D11DepthStencilState *D3D11_INTERNAL_FetchDepthStencilState(
 
 static ID3D11RasterizerState *D3D11_INTERNAL_FetchRasterizerState(
     D3D11Renderer *renderer,
-    SDL_GPURasterizerState rasterizerState)
+    SDL_GPURasterizerState rasterizer_state)
 {
     ID3D11RasterizerState *result;
     D3D11_RASTERIZER_DESC rasterizerDesc;
@@ -1333,15 +1333,15 @@ static ID3D11RasterizerState *D3D11_INTERNAL_FetchRasterizerState(
      * The spec says the driver will not create duplicate states, so there's no need to cache.
      */
     rasterizerDesc.AntialiasedLineEnable = FALSE;
-    rasterizerDesc.CullMode = SDLToD3D11_CullMode[rasterizerState.cullMode];
-    rasterizerDesc.DepthBias = SDL_lroundf(rasterizerState.depthBiasConstantFactor);
-    rasterizerDesc.DepthBiasClamp = rasterizerState.depthBiasClamp;
+    rasterizerDesc.CullMode = SDLToD3D11_CullMode[rasterizer_state.cull_mode];
+    rasterizerDesc.DepthBias = SDL_lroundf(rasterizer_state.depth_bias_constant_factor);
+    rasterizerDesc.DepthBiasClamp = rasterizer_state.depth_bias_clamp;
     rasterizerDesc.DepthClipEnable = TRUE;
-    rasterizerDesc.FillMode = (rasterizerState.fillMode == SDL_GPU_FILLMODE_FILL) ? D3D11_FILL_SOLID : D3D11_FILL_WIREFRAME;
-    rasterizerDesc.FrontCounterClockwise = (rasterizerState.frontFace == SDL_GPU_FRONTFACE_COUNTER_CLOCKWISE);
+    rasterizerDesc.FillMode = (rasterizer_state.fill_mode == SDL_GPU_FILLMODE_FILL) ? D3D11_FILL_SOLID : D3D11_FILL_WIREFRAME;
+    rasterizerDesc.FrontCounterClockwise = (rasterizer_state.frontFace == SDL_GPU_FRONTFACE_COUNTER_CLOCKWISE);
     rasterizerDesc.MultisampleEnable = TRUE; // only applies to MSAA render targets
     rasterizerDesc.ScissorEnable = TRUE;
-    rasterizerDesc.SlopeScaledDepthBias = rasterizerState.depthBiasSlopeFactor;
+    rasterizerDesc.SlopeScaledDepthBias = rasterizer_state.depth_bias_slope_factor;
 
     res = ID3D11Device_CreateRasterizerState(
         renderer->device,
@@ -1379,37 +1379,37 @@ static ID3D11InputLayout *D3D11_INTERNAL_FetchInputLayout(
     HRESULT res;
 
     // Don't bother creating/fetching an input layout if there are no attributes.
-    if (inputState.vertexAttributeCount == 0) {
+    if (inputState.num_vertex_attributes == 0) {
         return NULL;
     }
 
     // Allocate an array of vertex elements
     elementDescs = SDL_stack_alloc(
         D3D11_INPUT_ELEMENT_DESC,
-        inputState.vertexAttributeCount);
+        inputState.num_vertex_attributes);
 
     // Create the array of input elements
-    for (Uint32 i = 0; i < inputState.vertexAttributeCount; i += 1) {
-        elementDescs[i].AlignedByteOffset = inputState.vertexAttributes[i].offset;
-        elementDescs[i].Format = SDLToD3D11_VertexFormat[inputState.vertexAttributes[i].format];
-        elementDescs[i].InputSlot = inputState.vertexAttributes[i].binding;
+    for (Uint32 i = 0; i < inputState.num_vertex_attributes; i += 1) {
+        elementDescs[i].AlignedByteOffset = inputState.vertex_attributes[i].offset;
+        elementDescs[i].Format = SDLToD3D11_VertexFormat[inputState.vertex_attributes[i].format];
+        elementDescs[i].InputSlot = inputState.vertex_attributes[i].binding;
 
         bindingIndex = D3D11_INTERNAL_FindIndexOfVertexBinding(
             elementDescs[i].InputSlot,
-            inputState.vertexBindings,
-            inputState.vertexBindingCount);
-        elementDescs[i].InputSlotClass = SDLToD3D11_VertexInputRate[inputState.vertexBindings[bindingIndex].inputRate];
+            inputState.vertex_bindings,
+            inputState.num_vertex_bindings);
+        elementDescs[i].InputSlotClass = SDLToD3D11_VertexInputRate[inputState.vertex_bindings[bindingIndex].input_rate];
         // The spec requires this to be 0 for per-vertex data
-        elementDescs[i].InstanceDataStepRate = (inputState.vertexBindings[bindingIndex].inputRate == SDL_GPU_VERTEXINPUTRATE_INSTANCE) ? inputState.vertexBindings[bindingIndex].instanceStepRate : 0;
+        elementDescs[i].InstanceDataStepRate = (inputState.vertex_bindings[bindingIndex].input_rate == SDL_GPU_VERTEXINPUTRATE_INSTANCE) ? inputState.vertex_bindings[bindingIndex].instance_step_rate : 0;
 
-        elementDescs[i].SemanticIndex = inputState.vertexAttributes[i].location;
+        elementDescs[i].SemanticIndex = inputState.vertex_attributes[i].location;
         elementDescs[i].SemanticName = "TEXCOORD";
     }
 
     res = ID3D11Device_CreateInputLayout(
         renderer->device,
         elementDescs,
-        inputState.vertexAttributeCount,
+        inputState.num_vertex_attributes,
         shaderBytes,
         shaderByteLength,
         &result);
@@ -1434,8 +1434,8 @@ static ID3D11DeviceChild *D3D11_INTERNAL_CreateID3D11Shader(
     D3D11Renderer *renderer,
     Uint32 stage,
     const Uint8 *code,
-    size_t codeSize,
-    const char *entryPointName,
+    size_t code_size,
+    const char *entrypoint_name,
     void **pBytecode,
     size_t *pBytecodeSize)
 {
@@ -1447,7 +1447,7 @@ static ID3D11DeviceChild *D3D11_INTERNAL_CreateID3D11Shader(
         res = ID3D11Device_CreateVertexShader(
             renderer->device,
             code,
-            codeSize,
+            code_size,
             NULL,
             (ID3D11VertexShader **)&handle);
         if (FAILED(res)) {
@@ -1458,7 +1458,7 @@ static ID3D11DeviceChild *D3D11_INTERNAL_CreateID3D11Shader(
         res = ID3D11Device_CreatePixelShader(
             renderer->device,
             code,
-            codeSize,
+            code_size,
             NULL,
             (ID3D11PixelShader **)&handle);
         if (FAILED(res)) {
@@ -1469,7 +1469,7 @@ static ID3D11DeviceChild *D3D11_INTERNAL_CreateID3D11Shader(
         res = ID3D11Device_CreateComputeShader(
             renderer->device,
             code,
-            codeSize,
+            code_size,
             NULL,
             (ID3D11ComputeShader **)&handle);
         if (FAILED(res)) {
@@ -1479,9 +1479,9 @@ static ID3D11DeviceChild *D3D11_INTERNAL_CreateID3D11Shader(
     }
 
     if (pBytecode != NULL) {
-        *pBytecode = SDL_malloc(codeSize);
-        SDL_memcpy(*pBytecode, code, codeSize);
-        *pBytecodeSize = codeSize;
+        *pBytecode = SDL_malloc(code_size);
+        SDL_memcpy(*pBytecode, code, code_size);
+        *pBytecodeSize = code_size;
     }
 
     return handle;
@@ -1489,7 +1489,7 @@ static ID3D11DeviceChild *D3D11_INTERNAL_CreateID3D11Shader(
 
 static SDL_GPUComputePipeline *D3D11_CreateComputePipeline(
     SDL_GPURenderer *driverData,
-    const SDL_GPUComputePipelineCreateInfo *pipelineCreateInfo)
+    const SDL_GPUComputePipelineCreateInfo *createinfo)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
     ID3D11ComputeShader *shader;
@@ -1498,9 +1498,9 @@ static SDL_GPUComputePipeline *D3D11_CreateComputePipeline(
     shader = (ID3D11ComputeShader *)D3D11_INTERNAL_CreateID3D11Shader(
         renderer,
         SDL_GPU_SHADERSTAGE_COMPUTE,
-        pipelineCreateInfo->code,
-        pipelineCreateInfo->codeSize,
-        pipelineCreateInfo->entryPointName,
+        createinfo->code,
+        createinfo->code_size,
+        createinfo->entrypoint_name,
         NULL,
         NULL);
     if (shader == NULL) {
@@ -1510,11 +1510,11 @@ static SDL_GPUComputePipeline *D3D11_CreateComputePipeline(
 
     pipeline = SDL_malloc(sizeof(D3D11ComputePipeline));
     pipeline->computeShader = shader;
-    pipeline->readOnlyStorageTextureCount = pipelineCreateInfo->readOnlyStorageTextureCount;
-    pipeline->writeOnlyStorageTextureCount = pipelineCreateInfo->writeOnlyStorageTextureCount;
-    pipeline->readOnlyStorageBufferCount = pipelineCreateInfo->readOnlyStorageBufferCount;
-    pipeline->writeOnlyStorageBufferCount = pipelineCreateInfo->writeOnlyStorageBufferCount;
-    pipeline->uniformBufferCount = pipelineCreateInfo->uniformBufferCount;
+    pipeline->num_readonly_storage_textures = createinfo->num_readonly_storage_textures;
+    pipeline->num_writeonly_storage_textures = createinfo->num_writeonly_storage_textures;
+    pipeline->num_readonly_storage_buffers = createinfo->num_readonly_storage_buffers;
+    pipeline->num_writeonly_storage_buffers = createinfo->num_writeonly_storage_buffers;
+    pipeline->num_uniform_buffers = createinfo->num_uniform_buffers;
     // thread counts are ignored in d3d11
 
     return (SDL_GPUComputePipeline *)pipeline;
@@ -1522,68 +1522,68 @@ static SDL_GPUComputePipeline *D3D11_CreateComputePipeline(
 
 static SDL_GPUGraphicsPipeline *D3D11_CreateGraphicsPipeline(
     SDL_GPURenderer *driverData,
-    const SDL_GPUGraphicsPipelineCreateInfo *pipelineCreateInfo)
+    const SDL_GPUGraphicsPipelineCreateInfo *createinfo)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
-    D3D11Shader *vertShader = (D3D11Shader *)pipelineCreateInfo->vertexShader;
-    D3D11Shader *fragShader = (D3D11Shader *)pipelineCreateInfo->fragmentShader;
+    D3D11Shader *vertShader = (D3D11Shader *)createinfo->vertex_shader;
+    D3D11Shader *fragShader = (D3D11Shader *)createinfo->fragment_shader;
     D3D11GraphicsPipeline *pipeline = SDL_malloc(sizeof(D3D11GraphicsPipeline));
 
     // Blend
 
     pipeline->colorAttachmentBlendState = D3D11_INTERNAL_FetchBlendState(
         renderer,
-        pipelineCreateInfo->attachmentInfo.colorAttachmentCount,
-        pipelineCreateInfo->attachmentInfo.colorAttachmentDescriptions);
+        createinfo->attachment_info.num_color_attachments,
+        createinfo->attachment_info.color_attachment_descriptions);
 
-    pipeline->numColorAttachments = pipelineCreateInfo->attachmentInfo.colorAttachmentCount;
+    pipeline->numColorAttachments = createinfo->attachment_info.num_color_attachments;
     for (Sint32 i = 0; i < pipeline->numColorAttachments; i += 1) {
-        pipeline->colorAttachmentFormats[i] = SDLToD3D11_TextureFormat[pipelineCreateInfo->attachmentInfo.colorAttachmentDescriptions[i].format];
+        pipeline->colorAttachmentFormats[i] = SDLToD3D11_TextureFormat[createinfo->attachment_info.color_attachment_descriptions[i].format];
     }
 
     // Multisample
 
-    pipeline->multisampleState = pipelineCreateInfo->multisampleState;
+    pipeline->multisample_state = createinfo->multisample_state;
 
     // Depth-Stencil
 
-    pipeline->depthStencilState = D3D11_INTERNAL_FetchDepthStencilState(
+    pipeline->depth_stencil_state = D3D11_INTERNAL_FetchDepthStencilState(
         renderer,
-        pipelineCreateInfo->depthStencilState);
+        createinfo->depth_stencil_state);
 
-    pipeline->hasDepthStencilAttachment = pipelineCreateInfo->attachmentInfo.hasDepthStencilAttachment;
-    pipeline->depthStencilAttachmentFormat = SDLToD3D11_TextureFormat[pipelineCreateInfo->attachmentInfo.depthStencilFormat];
+    pipeline->has_depth_stencil_attachment = createinfo->attachment_info.has_depth_stencil_attachment;
+    pipeline->depthStencilAttachmentFormat = SDLToD3D11_TextureFormat[createinfo->attachment_info.depth_stencil_format];
 
     // Rasterizer
 
-    pipeline->primitiveType = pipelineCreateInfo->primitiveType;
-    pipeline->rasterizerState = D3D11_INTERNAL_FetchRasterizerState(
+    pipeline->primitive_type = createinfo->primitive_type;
+    pipeline->rasterizer_state = D3D11_INTERNAL_FetchRasterizerState(
         renderer,
-        pipelineCreateInfo->rasterizerState);
+        createinfo->rasterizer_state);
 
     // Shaders
 
-    pipeline->vertexShader = (ID3D11VertexShader *)vertShader->handle;
-    ID3D11VertexShader_AddRef(pipeline->vertexShader);
+    pipeline->vertex_shader = (ID3D11VertexShader *)vertShader->handle;
+    ID3D11VertexShader_AddRef(pipeline->vertex_shader);
 
-    pipeline->fragmentShader = (ID3D11PixelShader *)fragShader->handle;
-    ID3D11PixelShader_AddRef(pipeline->fragmentShader);
+    pipeline->fragment_shader = (ID3D11PixelShader *)fragShader->handle;
+    ID3D11PixelShader_AddRef(pipeline->fragment_shader);
 
     // Input Layout
 
     pipeline->inputLayout = D3D11_INTERNAL_FetchInputLayout(
         renderer,
-        pipelineCreateInfo->vertexInputState,
+        createinfo->vertex_input_state,
         vertShader->bytecode,
         vertShader->bytecodeSize);
 
-    if (pipelineCreateInfo->vertexInputState.vertexBindingCount > 0) {
+    if (createinfo->vertex_input_state.num_vertex_bindings > 0) {
         pipeline->vertexStrides = SDL_malloc(
             sizeof(Uint32) *
-            pipelineCreateInfo->vertexInputState.vertexBindingCount);
+            createinfo->vertex_input_state.num_vertex_bindings);
 
-        for (Uint32 i = 0; i < pipelineCreateInfo->vertexInputState.vertexBindingCount; i += 1) {
-            pipeline->vertexStrides[i] = pipelineCreateInfo->vertexInputState.vertexBindings[i].stride;
+        for (Uint32 i = 0; i < createinfo->vertex_input_state.num_vertex_bindings; i += 1) {
+            pipeline->vertexStrides[i] = createinfo->vertex_input_state.vertex_bindings[i].pitch;
         }
     } else {
         pipeline->vertexStrides = NULL;
@@ -1591,15 +1591,15 @@ static SDL_GPUGraphicsPipeline *D3D11_CreateGraphicsPipeline(
 
     // Resource layout
 
-    pipeline->vertexSamplerCount = vertShader->samplerCount;
-    pipeline->vertexStorageTextureCount = vertShader->storageTextureCount;
-    pipeline->vertexStorageBufferCount = vertShader->storageBufferCount;
-    pipeline->vertexUniformBufferCount = vertShader->uniformBufferCount;
+    pipeline->vertexSamplerCount = vertShader->num_samplers;
+    pipeline->vertexStorageTextureCount = vertShader->num_storage_textures;
+    pipeline->vertexStorageBufferCount = vertShader->num_storage_buffers;
+    pipeline->vertexUniformBufferCount = vertShader->num_uniform_buffers;
 
-    pipeline->fragmentSamplerCount = fragShader->samplerCount;
-    pipeline->fragmentStorageTextureCount = fragShader->storageTextureCount;
-    pipeline->fragmentStorageBufferCount = fragShader->storageBufferCount;
-    pipeline->fragmentUniformBufferCount = fragShader->uniformBufferCount;
+    pipeline->fragmentSamplerCount = fragShader->num_samplers;
+    pipeline->fragmentStorageTextureCount = fragShader->num_storage_textures;
+    pipeline->fragmentStorageBufferCount = fragShader->num_storage_buffers;
+    pipeline->fragmentUniformBufferCount = fragShader->num_uniform_buffers;
 
     return (SDL_GPUGraphicsPipeline *)pipeline;
 }
@@ -1611,7 +1611,7 @@ static void D3D11_INTERNAL_SetBufferName(
     D3D11Buffer *buffer,
     const char *text)
 {
-    if (renderer->debugMode) {
+    if (renderer->debug_mode) {
         ID3D11DeviceChild_SetPrivateData(
             buffer->handle,
             &D3D_IID_D3DDebugObjectName,
@@ -1629,7 +1629,7 @@ static void D3D11_SetBufferName(
     D3D11BufferContainer *container = (D3D11BufferContainer *)buffer;
     size_t textLength = SDL_strlen(text) + 1;
 
-    if (renderer->debugMode) {
+    if (renderer->debug_mode) {
         container->debugName = SDL_realloc(
             container->debugName,
             textLength);
@@ -1653,7 +1653,7 @@ static void D3D11_INTERNAL_SetTextureName(
     D3D11Texture *texture,
     const char *text)
 {
-    if (renderer->debugMode) {
+    if (renderer->debug_mode) {
         ID3D11DeviceChild_SetPrivateData(
             texture->handle,
             &D3D_IID_D3DDebugObjectName,
@@ -1671,7 +1671,7 @@ static void D3D11_SetTextureName(
     D3D11TextureContainer *container = (D3D11TextureContainer *)texture;
     size_t textLength = SDL_strlen(text) + 1;
 
-    if (renderer->debugMode) {
+    if (renderer->debug_mode) {
         container->debugName = SDL_realloc(
             container->debugName,
             textLength);
@@ -1729,10 +1729,10 @@ static bool D3D11_INTERNAL_StrToWStr(
 }
 
 static void D3D11_InsertDebugLabel(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const char *text)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
 
     if (d3d11CommandBuffer->annotation == NULL) {
@@ -1748,10 +1748,10 @@ static void D3D11_InsertDebugLabel(
 }
 
 static void D3D11_PushDebugGroup(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const char *name)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
 
     if (d3d11CommandBuffer->annotation == NULL) {
@@ -1767,9 +1767,9 @@ static void D3D11_PushDebugGroup(
 }
 
 static void D3D11_PopDebugGroup(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     if (d3d11CommandBuffer->annotation == NULL) {
         return;
     }
@@ -1780,7 +1780,7 @@ static void D3D11_PopDebugGroup(
 
 static SDL_GPUSampler *D3D11_CreateSampler(
     SDL_GPURenderer *driverData,
-    const SDL_GPUSamplerCreateInfo *samplerCreateInfo)
+    const SDL_GPUSamplerCreateInfo *createinfo)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
     D3D11_SAMPLER_DESC samplerDesc;
@@ -1788,15 +1788,15 @@ static SDL_GPUSampler *D3D11_CreateSampler(
     D3D11Sampler *d3d11Sampler;
     HRESULT res;
 
-    samplerDesc.AddressU = SDLToD3D11_SamplerAddressMode[samplerCreateInfo->addressModeU];
-    samplerDesc.AddressV = SDLToD3D11_SamplerAddressMode[samplerCreateInfo->addressModeV];
-    samplerDesc.AddressW = SDLToD3D11_SamplerAddressMode[samplerCreateInfo->addressModeW];
-    samplerDesc.ComparisonFunc = (samplerCreateInfo->compareEnable ? SDLToD3D11_CompareOp[samplerCreateInfo->compareOp] : SDLToD3D11_CompareOp[SDL_GPU_COMPAREOP_ALWAYS]);
-    samplerDesc.MaxAnisotropy = (samplerCreateInfo->anisotropyEnable ? (UINT)samplerCreateInfo->maxAnisotropy : 0);
-    samplerDesc.Filter = SDLToD3D11_Filter(samplerCreateInfo);
-    samplerDesc.MaxLOD = samplerCreateInfo->maxLod;
-    samplerDesc.MinLOD = samplerCreateInfo->minLod;
-    samplerDesc.MipLODBias = samplerCreateInfo->mipLodBias;
+    samplerDesc.AddressU = SDLToD3D11_SamplerAddressMode[createinfo->address_mode_u];
+    samplerDesc.AddressV = SDLToD3D11_SamplerAddressMode[createinfo->address_mode_v];
+    samplerDesc.AddressW = SDLToD3D11_SamplerAddressMode[createinfo->address_mode_w];
+    samplerDesc.ComparisonFunc = (createinfo->enable_compare ? SDLToD3D11_CompareOp[createinfo->compare_op] : SDLToD3D11_CompareOp[SDL_GPU_COMPAREOP_ALWAYS]);
+    samplerDesc.MaxAnisotropy = (createinfo->enable_anisotropy ? (UINT)createinfo->max_anisotropy : 0);
+    samplerDesc.Filter = SDLToD3D11_Filter(createinfo);
+    samplerDesc.MaxLOD = createinfo->max_lod;
+    samplerDesc.MinLOD = createinfo->min_lod;
+    samplerDesc.MipLODBias = createinfo->mip_lod_bias;
     SDL_zeroa(samplerDesc.BorderColor); // arbitrary, unused
 
     res = ID3D11Device_CreateSamplerState(
@@ -1813,7 +1813,7 @@ static SDL_GPUSampler *D3D11_CreateSampler(
 
 SDL_GPUShader *D3D11_CreateShader(
     SDL_GPURenderer *driverData,
-    const SDL_GPUShaderCreateInfo *shaderCreateInfo)
+    const SDL_GPUShaderCreateInfo *createinfo)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
     ID3D11DeviceChild *handle;
@@ -1823,23 +1823,23 @@ SDL_GPUShader *D3D11_CreateShader(
 
     handle = D3D11_INTERNAL_CreateID3D11Shader(
         renderer,
-        shaderCreateInfo->stage,
-        shaderCreateInfo->code,
-        shaderCreateInfo->codeSize,
-        shaderCreateInfo->entryPointName,
-        shaderCreateInfo->stage == SDL_GPU_SHADERSTAGE_VERTEX ? &bytecode : NULL,
-        shaderCreateInfo->stage == SDL_GPU_SHADERSTAGE_VERTEX ? &bytecodeSize : NULL);
+        createinfo->stage,
+        createinfo->code,
+        createinfo->code_size,
+        createinfo->entrypoint_name,
+        createinfo->stage == SDL_GPU_SHADERSTAGE_VERTEX ? &bytecode : NULL,
+        createinfo->stage == SDL_GPU_SHADERSTAGE_VERTEX ? &bytecodeSize : NULL);
     if (!handle) {
         return NULL;
     }
 
     shader = (D3D11Shader *)SDL_calloc(1, sizeof(D3D11Shader));
     shader->handle = handle;
-    shader->samplerCount = shaderCreateInfo->samplerCount;
-    shader->storageBufferCount = shaderCreateInfo->storageBufferCount;
-    shader->storageTextureCount = shaderCreateInfo->storageTextureCount;
-    shader->uniformBufferCount = shaderCreateInfo->uniformBufferCount;
-    if (shaderCreateInfo->stage == SDL_GPU_SHADERSTAGE_VERTEX) {
+    shader->num_samplers = createinfo->num_samplers;
+    shader->num_storage_buffers = createinfo->num_storage_buffers;
+    shader->num_storage_textures = createinfo->num_storage_textures;
+    shader->num_uniform_buffers = createinfo->num_uniform_buffers;
+    if (createinfo->stage == SDL_GPU_SHADERSTAGE_VERTEX) {
         // Store the raw bytecode and its length for creating InputLayouts
         shader->bytecode = bytecode;
         shader->bytecodeSize = bytecodeSize;
@@ -1860,27 +1860,27 @@ static D3D11Texture *D3D11_INTERNAL_CreateTexture(
     D3D11Texture *d3d11Texture;
     HRESULT res;
 
-    isColorTarget = createInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
-    isDepthStencil = createInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET;
+    isColorTarget = createInfo->usage_flags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
+    isDepthStencil = createInfo->usage_flags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET;
     needsSRV =
-        (createInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_SAMPLER) ||
-        (createInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ) ||
-        (createInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ);
+        (createInfo->usage_flags & SDL_GPU_TEXTUREUSAGE_SAMPLER) ||
+        (createInfo->usage_flags & SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ) ||
+        (createInfo->usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ);
     needSubresourceUAV =
-        (createInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE);
-    isMultisample = createInfo->sampleCount > SDL_GPU_SAMPLECOUNT_1;
-    isStaging = createInfo->usageFlags == 0;
+        (createInfo->usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE);
+    isMultisample = createInfo->sample_count > SDL_GPU_SAMPLECOUNT_1;
+    isStaging = createInfo->usage_flags == 0;
     isMippable =
-        createInfo->levelCount > 1 &&
-        (createInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_SAMPLER) &&
-        (createInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET);
+        createInfo->num_levels > 1 &&
+        (createInfo->usage_flags & SDL_GPU_TEXTUREUSAGE_SAMPLER) &&
+        (createInfo->usage_flags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET);
     format = SDLToD3D11_TextureFormat[createInfo->format];
     if (isDepthStencil) {
         format = D3D11_INTERNAL_GetTypelessFormat(format);
     }
 
-    Uint32 layerCount = createInfo->type == SDL_GPU_TEXTURETYPE_3D ? 1 : createInfo->layerCountOrDepth;
-    Uint32 depth = createInfo->type == SDL_GPU_TEXTURETYPE_3D ? createInfo->layerCountOrDepth : 1;
+    Uint32 layerCount = createInfo->type == SDL_GPU_TEXTURETYPE_3D ? 1 : createInfo->layer_count_or_depth;
+    Uint32 depth = createInfo->type == SDL_GPU_TEXTURETYPE_3D ? createInfo->layer_count_or_depth : 1;
 
     if (createInfo->type != SDL_GPU_TEXTURETYPE_3D) {
         D3D11_TEXTURE2D_DESC desc2D;
@@ -1904,7 +1904,7 @@ static D3D11Texture *D3D11_INTERNAL_CreateTexture(
         desc2D.ArraySize = layerCount;
         desc2D.CPUAccessFlags = isStaging ? D3D11_CPU_ACCESS_WRITE : 0;
         desc2D.Format = format;
-        desc2D.MipLevels = createInfo->levelCount;
+        desc2D.MipLevels = createInfo->num_levels;
         desc2D.MiscFlags = 0;
         desc2D.SampleDesc.Count = 1;
         desc2D.SampleDesc.Quality = 0;
@@ -1975,7 +1975,7 @@ static D3D11Texture *D3D11_INTERNAL_CreateTexture(
         desc3D.Depth = depth;
         desc3D.CPUAccessFlags = isStaging ? D3D11_CPU_ACCESS_WRITE : 0;
         desc3D.Format = format;
-        desc3D.MipLevels = createInfo->levelCount;
+        desc3D.MipLevels = createInfo->num_levels;
         desc3D.MiscFlags = isMippable ? D3D11_RESOURCE_MISC_GENERATE_MIPS : 0;
         desc3D.Usage = isStaging ? D3D11_USAGE_STAGING : D3D11_USAGE_DEFAULT;
 
@@ -2014,16 +2014,16 @@ static D3D11Texture *D3D11_INTERNAL_CreateTexture(
     d3d11Texture->container = NULL;
     d3d11Texture->containerIndex = 0;
 
-    d3d11Texture->subresourceCount = createInfo->levelCount * layerCount;
+    d3d11Texture->subresourceCount = createInfo->num_levels * layerCount;
     d3d11Texture->subresources = SDL_malloc(
         d3d11Texture->subresourceCount * sizeof(D3D11TextureSubresource));
 
     for (Uint32 layerIndex = 0; layerIndex < layerCount; layerIndex += 1) {
-        for (Uint32 levelIndex = 0; levelIndex < createInfo->levelCount; levelIndex += 1) {
+        for (Uint32 levelIndex = 0; levelIndex < createInfo->num_levels; levelIndex += 1) {
             Uint32 subresourceIndex = D3D11_INTERNAL_CalcSubresource(
                 levelIndex,
                 layerIndex,
-                createInfo->levelCount);
+                createInfo->num_levels);
 
             d3d11Texture->subresources[subresourceIndex].parent = d3d11Texture;
             d3d11Texture->subresources[subresourceIndex].layer = layerIndex;
@@ -2053,7 +2053,7 @@ static D3D11Texture *D3D11_INTERNAL_CreateTexture(
                 desc2D.Format = format;
                 desc2D.MipLevels = 1;
                 desc2D.MiscFlags = 0;
-                desc2D.SampleDesc.Count = SDLToD3D11_SampleCount[createInfo->sampleCount];
+                desc2D.SampleDesc.Count = SDLToD3D11_SampleCount[createInfo->sample_count];
                 desc2D.SampleDesc.Quality = (UINT)D3D11_STANDARD_MULTISAMPLE_PATTERN;
                 desc2D.Usage = D3D11_USAGE_DEFAULT;
 
@@ -2165,7 +2165,7 @@ static D3D11Texture *D3D11_INTERNAL_CreateTexture(
 static bool D3D11_SupportsSampleCount(
     SDL_GPURenderer *driverData,
     SDL_GPUTextureFormat format,
-    SDL_GPUSampleCount sampleCount)
+    SDL_GPUSampleCount sample_count)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
     Uint32 levels;
@@ -2173,7 +2173,7 @@ static bool D3D11_SupportsSampleCount(
     HRESULT res = ID3D11Device_CheckMultisampleQualityLevels(
         renderer->device,
         SDLToD3D11_TextureFormat[format],
-        SDLToD3D11_SampleCount[sampleCount],
+        SDLToD3D11_SampleCount[sample_count],
         &levels);
 
     return SUCCEEDED(res) && levels > 0;
@@ -2181,7 +2181,7 @@ static bool D3D11_SupportsSampleCount(
 
 static SDL_GPUTexture *D3D11_CreateTexture(
     SDL_GPURenderer *driverData,
-    const SDL_GPUTextureCreateInfo *textureCreateInfo)
+    const SDL_GPUTextureCreateInfo *createinfo)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
     D3D11TextureContainer *container;
@@ -2189,7 +2189,7 @@ static SDL_GPUTexture *D3D11_CreateTexture(
 
     texture = D3D11_INTERNAL_CreateTexture(
         renderer,
-        textureCreateInfo,
+        createinfo,
         NULL);
 
     if (texture == NULL) {
@@ -2198,7 +2198,7 @@ static SDL_GPUTexture *D3D11_CreateTexture(
     }
 
     container = SDL_malloc(sizeof(D3D11TextureContainer));
-    container->header.info = *textureCreateInfo;
+    container->header.info = *createinfo;
     container->canBeCycled = 1;
     container->activeTexture = texture;
     container->textureCapacity = 1;
@@ -2250,7 +2250,7 @@ static void D3D11_INTERNAL_CycleActiveTexture(
 
     container->activeTexture = container->textures[container->textureCount - 1];
 
-    if (renderer->debugMode && container->debugName != NULL) {
+    if (renderer->debug_mode && container->debugName != NULL) {
         D3D11_INTERNAL_SetTextureName(
             renderer,
             container->activeTexture,
@@ -2266,7 +2266,7 @@ static D3D11TextureSubresource *D3D11_INTERNAL_FetchTextureSubresource(
     Uint32 index = D3D11_INTERNAL_CalcSubresource(
         level,
         layer,
-        container->header.info.levelCount);
+        container->header.info.num_levels);
     return &container->activeTexture->subresources[index];
 }
 
@@ -2302,7 +2302,7 @@ static D3D11TextureSubresource *D3D11_INTERNAL_PrepareTextureSubresourceForWrite
 static D3D11Buffer *D3D11_INTERNAL_CreateBuffer(
     D3D11Renderer *renderer,
     D3D11_BUFFER_DESC *bufferDesc,
-    Uint32 sizeInBytes)
+    Uint32 size)
 {
     ID3D11Buffer *bufferHandle;
     ID3D11UnorderedAccessView *uav = NULL;
@@ -2311,7 +2311,7 @@ static D3D11Buffer *D3D11_INTERNAL_CreateBuffer(
     HRESULT res;
 
     // Storage buffers have to be 4-aligned, so might as well align them all
-    sizeInBytes = D3D11_INTERNAL_NextHighestAlignment(sizeInBytes, 4);
+    size = D3D11_INTERNAL_NextHighestAlignment(size, 4);
 
     res = ID3D11Device_CreateBuffer(
         renderer->device,
@@ -2328,7 +2328,7 @@ static D3D11Buffer *D3D11_INTERNAL_CreateBuffer(
         uavDesc.Format = DXGI_FORMAT_R32_TYPELESS;
         uavDesc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;
         uavDesc.Buffer.FirstElement = 0;
-        uavDesc.Buffer.NumElements = sizeInBytes / sizeof(Uint32);
+        uavDesc.Buffer.NumElements = size / sizeof(Uint32);
         uavDesc.Buffer.Flags = D3D11_BUFFER_UAV_FLAG_RAW;
 
         res = ID3D11Device_CreateUnorderedAccessView(
@@ -2347,7 +2347,7 @@ static D3D11Buffer *D3D11_INTERNAL_CreateBuffer(
         srvDesc.Format = DXGI_FORMAT_R32_TYPELESS;
         srvDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFEREX;
         srvDesc.BufferEx.FirstElement = 0;
-        srvDesc.BufferEx.NumElements = sizeInBytes / sizeof(Uint32);
+        srvDesc.BufferEx.NumElements = size / sizeof(Uint32);
         srvDesc.BufferEx.Flags = D3D11_BUFFEREX_SRV_FLAG_RAW;
 
         res = ID3D11Device_CreateShaderResourceView(
@@ -2363,7 +2363,7 @@ static D3D11Buffer *D3D11_INTERNAL_CreateBuffer(
 
     d3d11Buffer = SDL_malloc(sizeof(D3D11Buffer));
     d3d11Buffer->handle = bufferHandle;
-    d3d11Buffer->size = sizeInBytes;
+    d3d11Buffer->size = size;
     d3d11Buffer->uav = uav;
     d3d11Buffer->srv = srv;
     SDL_AtomicSet(&d3d11Buffer->referenceCount, 0);
@@ -2373,8 +2373,8 @@ static D3D11Buffer *D3D11_INTERNAL_CreateBuffer(
 
 static SDL_GPUBuffer *D3D11_CreateBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUBufferUsageFlags usageFlags,
-    Uint32 sizeInBytes)
+    SDL_GPUBufferUsageFlags usage_flags,
+    Uint32 size)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
     D3D11BufferContainer *container;
@@ -2382,32 +2382,32 @@ static SDL_GPUBuffer *D3D11_CreateBuffer(
     D3D11_BUFFER_DESC bufferDesc;
 
     bufferDesc.BindFlags = 0;
-    if (usageFlags & SDL_GPU_BUFFERUSAGE_VERTEX) {
+    if (usage_flags & SDL_GPU_BUFFERUSAGE_VERTEX) {
         bufferDesc.BindFlags |= D3D11_BIND_VERTEX_BUFFER;
     }
-    if (usageFlags & SDL_GPU_BUFFERUSAGE_INDEX) {
+    if (usage_flags & SDL_GPU_BUFFERUSAGE_INDEX) {
         bufferDesc.BindFlags |= D3D11_BIND_INDEX_BUFFER;
     }
-    if (usageFlags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
+    if (usage_flags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
         bufferDesc.BindFlags |= D3D11_BIND_UNORDERED_ACCESS;
     }
 
-    if (usageFlags & (SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ |
+    if (usage_flags & (SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ |
                       SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ |
                       SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE)) {
         bufferDesc.BindFlags |= D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_SHADER_RESOURCE;
     }
 
-    bufferDesc.ByteWidth = sizeInBytes;
+    bufferDesc.ByteWidth = size;
     bufferDesc.Usage = D3D11_USAGE_DEFAULT;
     bufferDesc.CPUAccessFlags = 0;
     bufferDesc.StructureByteStride = 0;
     bufferDesc.MiscFlags = 0;
 
-    if (usageFlags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
+    if (usage_flags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
         bufferDesc.MiscFlags |= D3D11_RESOURCE_MISC_DRAWINDIRECT_ARGS;
     }
-    if (usageFlags & (SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ |
+    if (usage_flags & (SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ |
                       SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ |
                       SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE)) {
         bufferDesc.MiscFlags |= D3D11_RESOURCE_MISC_BUFFER_ALLOW_RAW_VIEWS;
@@ -2416,7 +2416,7 @@ static SDL_GPUBuffer *D3D11_CreateBuffer(
     buffer = D3D11_INTERNAL_CreateBuffer(
         renderer,
         &bufferDesc,
-        sizeInBytes);
+        size);
 
     if (buffer == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create buffer!");
@@ -2438,7 +2438,7 @@ static SDL_GPUBuffer *D3D11_CreateBuffer(
 
 static D3D11UniformBuffer *D3D11_INTERNAL_CreateUniformBuffer(
     D3D11Renderer *renderer,
-    Uint32 sizeInBytes)
+    Uint32 size)
 {
     D3D11UniformBuffer *uniformBuffer;
     ID3D11Buffer *buffer;
@@ -2446,7 +2446,7 @@ static D3D11UniformBuffer *D3D11_INTERNAL_CreateUniformBuffer(
     HRESULT res;
 
     bufferDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
-    bufferDesc.ByteWidth = sizeInBytes;
+    bufferDesc.ByteWidth = size;
     bufferDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
     bufferDesc.MiscFlags = 0;
     bufferDesc.StructureByteStride = 0;
@@ -2496,7 +2496,7 @@ static void D3D11_INTERNAL_CycleActiveBuffer(
 
     container->activeBuffer = container->buffers[container->bufferCount - 1];
 
-    if (renderer->debugMode && container->debugName != NULL) {
+    if (renderer->debug_mode && container->debugName != NULL) {
         D3D11_INTERNAL_SetBufferName(
             renderer,
             container->activeBuffer,
@@ -2522,30 +2522,30 @@ static D3D11Buffer *D3D11_INTERNAL_PrepareBufferForWrite(
 
 static D3D11TransferBuffer *D3D11_INTERNAL_CreateTransferBuffer(
     D3D11Renderer *renderer,
-    Uint32 sizeInBytes)
+    Uint32 size)
 {
-    D3D11TransferBuffer *transferBuffer = SDL_malloc(sizeof(D3D11TransferBuffer));
+    D3D11TransferBuffer *transfer_buffer = SDL_malloc(sizeof(D3D11TransferBuffer));
 
-    transferBuffer->data = (Uint8 *)SDL_malloc(sizeInBytes);
-    transferBuffer->size = sizeInBytes;
-    SDL_AtomicSet(&transferBuffer->referenceCount, 0);
+    transfer_buffer->data = (Uint8 *)SDL_malloc(size);
+    transfer_buffer->size = size;
+    SDL_AtomicSet(&transfer_buffer->referenceCount, 0);
 
-    transferBuffer->bufferDownloads = NULL;
-    transferBuffer->bufferDownloadCount = 0;
-    transferBuffer->bufferDownloadCapacity = 0;
+    transfer_buffer->bufferDownloads = NULL;
+    transfer_buffer->bufferDownloadCount = 0;
+    transfer_buffer->bufferDownloadCapacity = 0;
 
-    transferBuffer->textureDownloads = NULL;
-    transferBuffer->textureDownloadCount = 0;
-    transferBuffer->textureDownloadCapacity = 0;
+    transfer_buffer->textureDownloads = NULL;
+    transfer_buffer->textureDownloadCount = 0;
+    transfer_buffer->textureDownloadCapacity = 0;
 
-    return transferBuffer;
+    return transfer_buffer;
 }
 
 // This actually returns a container handle so we can rotate buffers on Cycle.
 static SDL_GPUTransferBuffer *D3D11_CreateTransferBuffer(
     SDL_GPURenderer *driverData,
     SDL_GPUTransferBufferUsage usage, // ignored on D3D11
-    Uint32 sizeInBytes)
+    Uint32 size)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
     D3D11TransferBufferContainer *container = (D3D11TransferBufferContainer *)SDL_malloc(sizeof(D3D11TransferBufferContainer));
@@ -2557,7 +2557,7 @@ static SDL_GPUTransferBuffer *D3D11_CreateTransferBuffer(
 
     container->buffers[0] = D3D11_INTERNAL_CreateTransferBuffer(
         renderer,
-        sizeInBytes);
+        size);
 
     container->activeBuffer = container->buffers[0];
 
@@ -2596,11 +2596,11 @@ static void D3D11_INTERNAL_CycleActiveTransferBuffer(
 
 static void *D3D11_MapTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transferBuffer,
+    SDL_GPUTransferBuffer *transfer_buffer,
     bool cycle)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
-    D3D11TransferBufferContainer *container = (D3D11TransferBufferContainer *)transferBuffer;
+    D3D11TransferBufferContainer *container = (D3D11TransferBufferContainer *)transfer_buffer;
     D3D11TransferBuffer *buffer = container->activeBuffer;
 
     // Rotate the transfer buffer if necessary
@@ -2618,35 +2618,35 @@ static void *D3D11_MapTransferBuffer(
 
 static void D3D11_UnmapTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transferBuffer)
+    SDL_GPUTransferBuffer *transfer_buffer)
 {
     // no-op
     (void)driverData;
-    (void)transferBuffer;
+    (void)transfer_buffer;
 }
 
 // Copy Pass
 
 static void D3D11_BeginCopyPass(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
     // no-op
 }
 
 static void D3D11_UploadToTexture(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUTextureTransferInfo *source,
     const SDL_GPUTextureRegion *destination,
     bool cycle)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
-    D3D11TransferBufferContainer *srcTransferContainer = (D3D11TransferBufferContainer *)source->transferBuffer;
+    D3D11TransferBufferContainer *srcTransferContainer = (D3D11TransferBufferContainer *)source->transfer_buffer;
     D3D11TransferBuffer *srcTransferBuffer = srcTransferContainer->activeBuffer;
     D3D11TextureContainer *dstTextureContainer = (D3D11TextureContainer *)destination->texture;
     SDL_GPUTextureFormat dstFormat = dstTextureContainer->header.info.format;
-    Uint32 bufferStride = source->imagePitch;
-    Uint32 bufferImageHeight = source->imageHeight;
+    Uint32 bufferStride = source->pixels_per_row;
+    Uint32 bufferImageHeight = source->rows_per_layer;
     Sint32 w = destination->w;
     Sint32 h = destination->h;
     D3D11Texture *stagingTexture;
@@ -2657,7 +2657,7 @@ static void D3D11_UploadToTexture(
         renderer,
         dstTextureContainer,
         destination->layer,
-        destination->mipLevel,
+        destination->mip_level,
         cycle);
 
     Sint32 blockSize = Texture_GetBlockSize(dstFormat);
@@ -2684,11 +2684,11 @@ static void D3D11_UploadToTexture(
 
     stagingTextureCreateInfo.width = w;
     stagingTextureCreateInfo.height = h;
-    stagingTextureCreateInfo.layerCountOrDepth = 1;
-    stagingTextureCreateInfo.levelCount = 1;
+    stagingTextureCreateInfo.layer_count_or_depth = 1;
+    stagingTextureCreateInfo.num_levels = 1;
     stagingTextureCreateInfo.type = SDL_GPU_TEXTURETYPE_2D;
-    stagingTextureCreateInfo.usageFlags = 0;
-    stagingTextureCreateInfo.sampleCount = SDL_GPU_SAMPLECOUNT_1;
+    stagingTextureCreateInfo.usage_flags = 0;
+    stagingTextureCreateInfo.sample_count = SDL_GPU_SAMPLECOUNT_1;
     stagingTextureCreateInfo.format = dstFormat;
 
     initialData.pSysMem = srcTransferBuffer->data + source->offset;
@@ -2724,14 +2724,14 @@ static void D3D11_UploadToTexture(
 }
 
 static void D3D11_UploadToBuffer(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUTransferBufferLocation *source,
     const SDL_GPUBufferRegion *destination,
     bool cycle)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
-    D3D11TransferBufferContainer *transferContainer = (D3D11TransferBufferContainer *)source->transferBuffer;
+    D3D11TransferBufferContainer *transferContainer = (D3D11TransferBufferContainer *)source->transfer_buffer;
     D3D11TransferBuffer *d3d11TransferBuffer = transferContainer->activeBuffer;
     D3D11BufferContainer *bufferContainer = (D3D11BufferContainer *)destination->buffer;
     D3D11Buffer *d3d11Buffer = D3D11_INTERNAL_PrepareBufferForWrite(
@@ -2781,13 +2781,13 @@ static void D3D11_UploadToBuffer(
 }
 
 static void D3D11_DownloadFromTexture(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUTextureRegion *source,
     const SDL_GPUTextureTransferInfo *destination)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11Renderer *renderer = d3d11CommandBuffer->renderer;
-    D3D11TransferBufferContainer *dstTransferContainer = (D3D11TransferBufferContainer *)destination->transferBuffer;
+    D3D11TransferBufferContainer *dstTransferContainer = (D3D11TransferBufferContainer *)destination->transfer_buffer;
     D3D11TransferBuffer *d3d11TransferBuffer = dstTransferContainer->activeBuffer;
     D3D11TextureContainer *srcTextureContainer = (D3D11TextureContainer *)source->texture;
     SDL_GPUTextureFormat srcFormat = srcTextureContainer->header.info.format;
@@ -2796,10 +2796,10 @@ static void D3D11_DownloadFromTexture(
     D3D11TextureSubresource *textureSubresource = D3D11_INTERNAL_FetchTextureSubresource(
         srcTextureContainer,
         source->layer,
-        source->mipLevel);
+        source->mip_level);
     D3D11TextureDownload *textureDownload;
-    Uint32 bufferStride = destination->imagePitch;
-    Uint32 bufferImageHeight = destination->imageHeight;
+    Uint32 bufferStride = destination->pixels_per_row;
+    Uint32 bufferImageHeight = destination->rows_per_layer;
     Uint32 bytesPerRow, bytesPerDepthSlice;
     D3D11_BOX srcBox = { source->x, source->y, source->z, source->x + source->w, source->y + source->h, source->z + source->d };
     HRESULT res;
@@ -2886,13 +2886,13 @@ static void D3D11_DownloadFromTexture(
 }
 
 static void D3D11_DownloadFromBuffer(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUBufferRegion *source,
     const SDL_GPUTransferBufferLocation *destination)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11Renderer *renderer = d3d11CommandBuffer->renderer;
-    D3D11TransferBufferContainer *dstTransferContainer = (D3D11TransferBufferContainer *)destination->transferBuffer;
+    D3D11TransferBufferContainer *dstTransferContainer = (D3D11TransferBufferContainer *)destination->transfer_buffer;
     D3D11TransferBuffer *d3d11TransferBuffer = dstTransferContainer->activeBuffer;
     D3D11BufferContainer *srcBufferContainer = (D3D11BufferContainer *)source->buffer;
     D3D11BufferDownload *bufferDownload;
@@ -2944,7 +2944,7 @@ static void D3D11_DownloadFromBuffer(
 }
 
 static void D3D11_CopyTextureToTexture(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUTextureLocation *source,
     const SDL_GPUTextureLocation *destination,
     Uint32 w,
@@ -2952,7 +2952,7 @@ static void D3D11_CopyTextureToTexture(
     Uint32 d,
     bool cycle)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
     D3D11TextureContainer *srcContainer = (D3D11TextureContainer *)source->texture;
     D3D11TextureContainer *dstContainer = (D3D11TextureContainer *)destination->texture;
@@ -2962,13 +2962,13 @@ static void D3D11_CopyTextureToTexture(
     D3D11TextureSubresource *srcSubresource = D3D11_INTERNAL_FetchTextureSubresource(
         srcContainer,
         source->layer,
-        source->mipLevel);
+        source->mip_level);
 
     D3D11TextureSubresource *dstSubresource = D3D11_INTERNAL_PrepareTextureSubresourceForWrite(
         renderer,
         dstContainer,
         destination->layer,
-        destination->mipLevel,
+        destination->mip_level,
         cycle);
 
     ID3D11DeviceContext1_CopySubresourceRegion(
@@ -2987,13 +2987,13 @@ static void D3D11_CopyTextureToTexture(
 }
 
 static void D3D11_CopyBufferToBuffer(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUBufferLocation *source,
     const SDL_GPUBufferLocation *destination,
     Uint32 size,
     bool cycle)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
     D3D11BufferContainer *srcBufferContainer = (D3D11BufferContainer *)source->buffer;
     D3D11BufferContainer *dstBufferContainer = (D3D11BufferContainer *)destination->buffer;
@@ -3021,10 +3021,10 @@ static void D3D11_CopyBufferToBuffer(
 }
 
 static void D3D11_GenerateMipmaps(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     SDL_GPUTexture *texture)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11TextureContainer *d3d11TextureContainer = (D3D11TextureContainer *)texture;
 
     ID3D11DeviceContext1_GenerateMips(
@@ -3037,7 +3037,7 @@ static void D3D11_GenerateMipmaps(
 }
 
 static void D3D11_EndCopyPass(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
     // no-op
 }
@@ -3048,7 +3048,7 @@ static void D3D11_INTERNAL_AllocateCommandBuffers(
     D3D11Renderer *renderer,
     Uint32 allocateCount)
 {
-    D3D11CommandBuffer *commandBuffer;
+    D3D11CommandBuffer *command_buffer;
     HRESULT res;
 
     renderer->availableCommandBufferCapacity += allocateCount;
@@ -3058,50 +3058,50 @@ static void D3D11_INTERNAL_AllocateCommandBuffers(
         sizeof(D3D11CommandBuffer *) * renderer->availableCommandBufferCapacity);
 
     for (Uint32 i = 0; i < allocateCount; i += 1) {
-        commandBuffer = SDL_calloc(1, sizeof(D3D11CommandBuffer));
-        commandBuffer->renderer = renderer;
+        command_buffer = SDL_calloc(1, sizeof(D3D11CommandBuffer));
+        command_buffer->renderer = renderer;
 
         // Deferred Device Context
         res = ID3D11Device1_CreateDeferredContext1(
             renderer->device,
             0,
-            &commandBuffer->context);
+            &command_buffer->context);
         ERROR_CHECK("Could not create deferred context");
 
         // Initialize debug annotation support, if available
         ID3D11DeviceContext_QueryInterface(
-            commandBuffer->context,
+            command_buffer->context,
             &D3D_IID_ID3DUserDefinedAnnotation,
-            (void **)&commandBuffer->annotation);
+            (void **)&command_buffer->annotation);
 
         // Window handling
-        commandBuffer->windowDataCapacity = 1;
-        commandBuffer->windowDataCount = 0;
-        commandBuffer->windowDatas = SDL_malloc(
-            commandBuffer->windowDataCapacity * sizeof(D3D11WindowData *));
+        command_buffer->windowDataCapacity = 1;
+        command_buffer->windowDataCount = 0;
+        command_buffer->windowDatas = SDL_malloc(
+            command_buffer->windowDataCapacity * sizeof(D3D11WindowData *));
 
         // Reference Counting
-        commandBuffer->usedBufferCapacity = 4;
-        commandBuffer->usedBufferCount = 0;
-        commandBuffer->usedBuffers = SDL_malloc(
-            commandBuffer->usedBufferCapacity * sizeof(D3D11Buffer *));
+        command_buffer->usedBufferCapacity = 4;
+        command_buffer->usedBufferCount = 0;
+        command_buffer->usedBuffers = SDL_malloc(
+            command_buffer->usedBufferCapacity * sizeof(D3D11Buffer *));
 
-        commandBuffer->usedTransferBufferCapacity = 4;
-        commandBuffer->usedTransferBufferCount = 0;
-        commandBuffer->usedTransferBuffers = SDL_malloc(
-            commandBuffer->usedTransferBufferCapacity * sizeof(D3D11TransferBuffer *));
+        command_buffer->usedTransferBufferCapacity = 4;
+        command_buffer->usedTransferBufferCount = 0;
+        command_buffer->usedTransferBuffers = SDL_malloc(
+            command_buffer->usedTransferBufferCapacity * sizeof(D3D11TransferBuffer *));
 
-        commandBuffer->usedTextureCapacity = 4;
-        commandBuffer->usedTextureCount = 0;
-        commandBuffer->usedTextures = SDL_malloc(
-            commandBuffer->usedTextureCapacity * sizeof(D3D11Texture *));
+        command_buffer->usedTextureCapacity = 4;
+        command_buffer->usedTextureCount = 0;
+        command_buffer->usedTextures = SDL_malloc(
+            command_buffer->usedTextureCapacity * sizeof(D3D11Texture *));
 
-        commandBuffer->usedUniformBufferCapacity = 4;
-        commandBuffer->usedUniformBufferCount = 0;
-        commandBuffer->usedUniformBuffers = SDL_malloc(
-            commandBuffer->usedUniformBufferCapacity * sizeof(D3D11UniformBuffer *));
+        command_buffer->usedUniformBufferCapacity = 4;
+        command_buffer->usedUniformBufferCount = 0;
+        command_buffer->usedUniformBuffers = SDL_malloc(
+            command_buffer->usedUniformBufferCapacity * sizeof(D3D11UniformBuffer *));
 
-        renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = commandBuffer;
+        renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = command_buffer;
         renderer->availableCommandBufferCount += 1;
     }
 }
@@ -3109,7 +3109,7 @@ static void D3D11_INTERNAL_AllocateCommandBuffers(
 static D3D11CommandBuffer *D3D11_INTERNAL_GetInactiveCommandBufferFromPool(
     D3D11Renderer *renderer)
 {
-    D3D11CommandBuffer *commandBuffer;
+    D3D11CommandBuffer *command_buffer;
 
     if (renderer->availableCommandBufferCount == 0) {
         D3D11_INTERNAL_AllocateCommandBuffers(
@@ -3117,10 +3117,10 @@ static D3D11CommandBuffer *D3D11_INTERNAL_GetInactiveCommandBufferFromPool(
             renderer->availableCommandBufferCapacity);
     }
 
-    commandBuffer = renderer->availableCommandBuffers[renderer->availableCommandBufferCount - 1];
+    command_buffer = renderer->availableCommandBuffers[renderer->availableCommandBufferCount - 1];
     renderer->availableCommandBufferCount -= 1;
 
-    return commandBuffer;
+    return command_buffer;
 }
 
 static bool D3D11_INTERNAL_CreateFence(
@@ -3158,9 +3158,9 @@ static bool D3D11_INTERNAL_CreateFence(
 }
 
 static bool D3D11_INTERNAL_AcquireFence(
-    D3D11CommandBuffer *commandBuffer)
+    D3D11CommandBuffer *command_buffer)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
     D3D11Fence *fence;
 
@@ -3181,8 +3181,8 @@ static bool D3D11_INTERNAL_AcquireFence(
     SDL_UnlockMutex(renderer->fenceLock);
 
     // Associate the fence with the command buffer
-    commandBuffer->fence = fence;
-    (void)SDL_AtomicIncRef(&commandBuffer->fence->referenceCount);
+    command_buffer->fence = fence;
+    (void)SDL_AtomicIncRef(&command_buffer->fence->referenceCount);
 
     return true;
 }
@@ -3191,58 +3191,58 @@ static SDL_GPUCommandBuffer *D3D11_AcquireCommandBuffer(
     SDL_GPURenderer *driverData)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
-    D3D11CommandBuffer *commandBuffer;
+    D3D11CommandBuffer *command_buffer;
     Uint32 i;
 
     SDL_LockMutex(renderer->acquireCommandBufferLock);
 
-    commandBuffer = D3D11_INTERNAL_GetInactiveCommandBufferFromPool(renderer);
-    commandBuffer->graphicsPipeline = NULL;
-    commandBuffer->stencilRef = 0;
-    commandBuffer->blendConstants = (SDL_FColor){ 1.0f, 1.0f, 1.0f, 1.0f };
-    commandBuffer->computePipeline = NULL;
+    command_buffer = D3D11_INTERNAL_GetInactiveCommandBufferFromPool(renderer);
+    command_buffer->graphics_pipeline = NULL;
+    command_buffer->stencilRef = 0;
+    command_buffer->blend_constants = (SDL_FColor){ 1.0f, 1.0f, 1.0f, 1.0f };
+    command_buffer->compute_pipeline = NULL;
     for (i = 0; i < MAX_COLOR_TARGET_BINDINGS; i += 1) {
-        commandBuffer->colorTargetResolveTexture[i] = NULL;
-        commandBuffer->colorTargetResolveSubresourceIndex[i] = 0;
-        commandBuffer->colorTargetMsaaHandle[i] = NULL;
-        commandBuffer->colorTargetMsaaFormat[i] = DXGI_FORMAT_UNKNOWN;
+        command_buffer->colorTargetResolveTexture[i] = NULL;
+        command_buffer->colorTargetResolveSubresourceIndex[i] = 0;
+        command_buffer->colorTargetMsaaHandle[i] = NULL;
+        command_buffer->colorTargetMsaaFormat[i] = DXGI_FORMAT_UNKNOWN;
     }
 
     for (i = 0; i < MAX_UNIFORM_BUFFERS_PER_STAGE; i += 1) {
-        commandBuffer->vertexUniformBuffers[i] = NULL;
-        commandBuffer->fragmentUniformBuffers[i] = NULL;
-        commandBuffer->computeUniformBuffers[i] = NULL;
+        command_buffer->vertexUniformBuffers[i] = NULL;
+        command_buffer->fragmentUniformBuffers[i] = NULL;
+        command_buffer->computeUniformBuffers[i] = NULL;
     }
 
-    commandBuffer->needVertexSamplerBind = true;
-    commandBuffer->needVertexResourceBind = true;
-    commandBuffer->needVertexUniformBufferBind = true;
-    commandBuffer->needFragmentSamplerBind = true;
-    commandBuffer->needFragmentResourceBind = true;
-    commandBuffer->needFragmentUniformBufferBind = true;
-    commandBuffer->needComputeUAVBind = true;
-    commandBuffer->needComputeSRVBind = true;
-    commandBuffer->needComputeUniformBufferBind = true;
+    command_buffer->needVertexSamplerBind = true;
+    command_buffer->needVertexResourceBind = true;
+    command_buffer->needVertexUniformBufferBind = true;
+    command_buffer->needFragmentSamplerBind = true;
+    command_buffer->needFragmentResourceBind = true;
+    command_buffer->needFragmentUniformBufferBind = true;
+    command_buffer->needComputeUAVBind = true;
+    command_buffer->needComputeSRVBind = true;
+    command_buffer->needComputeUniformBufferBind = true;
 
-    SDL_zeroa(commandBuffer->vertexSamplers);
-    SDL_zeroa(commandBuffer->vertexShaderResourceViews);
-    SDL_zeroa(commandBuffer->fragmentSamplers);
-    SDL_zeroa(commandBuffer->fragmentShaderResourceViews);
-    SDL_zeroa(commandBuffer->computeShaderResourceViews);
-    SDL_zeroa(commandBuffer->computeUnorderedAccessViews);
+    SDL_zeroa(command_buffer->vertexSamplers);
+    SDL_zeroa(command_buffer->vertexShaderResourceViews);
+    SDL_zeroa(command_buffer->fragmentSamplers);
+    SDL_zeroa(command_buffer->fragmentShaderResourceViews);
+    SDL_zeroa(command_buffer->computeShaderResourceViews);
+    SDL_zeroa(command_buffer->computeUnorderedAccessViews);
 
-    D3D11_INTERNAL_AcquireFence(commandBuffer);
-    commandBuffer->autoReleaseFence = 1;
+    D3D11_INTERNAL_AcquireFence(command_buffer);
+    command_buffer->autoReleaseFence = 1;
 
     SDL_UnlockMutex(renderer->acquireCommandBufferLock);
 
-    return (SDL_GPUCommandBuffer *)commandBuffer;
+    return (SDL_GPUCommandBuffer *)command_buffer;
 }
 
 static D3D11UniformBuffer *D3D11_INTERNAL_AcquireUniformBufferFromPool(
-    D3D11CommandBuffer *commandBuffer)
+    D3D11CommandBuffer *command_buffer)
 {
-    D3D11Renderer *renderer = commandBuffer->renderer;
+    D3D11Renderer *renderer = command_buffer->renderer;
     D3D11UniformBuffer *uniformBuffer;
 
     SDL_LockMutex(renderer->acquireUniformBufferLock);
@@ -3258,7 +3258,7 @@ static D3D11UniformBuffer *D3D11_INTERNAL_AcquireUniformBufferFromPool(
 
     SDL_UnlockMutex(renderer->acquireUniformBufferLock);
 
-    D3D11_INTERNAL_TrackUniformBuffer(commandBuffer, uniformBuffer);
+    D3D11_INTERNAL_TrackUniformBuffer(command_buffer, uniformBuffer);
 
     return uniformBuffer;
 }
@@ -3285,9 +3285,9 @@ static void D3D11_INTERNAL_ReturnUniformBufferToPool(
 static void D3D11_INTERNAL_PushUniformData(
     D3D11CommandBuffer *d3d11CommandBuffer,
     SDL_GPUShaderStage shaderStage,
-    Uint32 slotIndex,
+    Uint32 slot_index,
     const void *data,
-    Uint32 dataLengthInBytes)
+    Uint32 length)
 {
     D3D11Renderer *renderer = d3d11CommandBuffer->renderer;
     D3D11UniformBuffer *d3d11UniformBuffer;
@@ -3295,23 +3295,23 @@ static void D3D11_INTERNAL_PushUniformData(
     HRESULT res;
 
     if (shaderStage == SDL_GPU_SHADERSTAGE_VERTEX) {
-        if (d3d11CommandBuffer->vertexUniformBuffers[slotIndex] == NULL) {
-            d3d11CommandBuffer->vertexUniformBuffers[slotIndex] = D3D11_INTERNAL_AcquireUniformBufferFromPool(
+        if (d3d11CommandBuffer->vertexUniformBuffers[slot_index] == NULL) {
+            d3d11CommandBuffer->vertexUniformBuffers[slot_index] = D3D11_INTERNAL_AcquireUniformBufferFromPool(
                 d3d11CommandBuffer);
         }
-        d3d11UniformBuffer = d3d11CommandBuffer->vertexUniformBuffers[slotIndex];
+        d3d11UniformBuffer = d3d11CommandBuffer->vertexUniformBuffers[slot_index];
     } else if (shaderStage == SDL_GPU_SHADERSTAGE_FRAGMENT) {
-        if (d3d11CommandBuffer->fragmentUniformBuffers[slotIndex] == NULL) {
-            d3d11CommandBuffer->fragmentUniformBuffers[slotIndex] = D3D11_INTERNAL_AcquireUniformBufferFromPool(
+        if (d3d11CommandBuffer->fragmentUniformBuffers[slot_index] == NULL) {
+            d3d11CommandBuffer->fragmentUniformBuffers[slot_index] = D3D11_INTERNAL_AcquireUniformBufferFromPool(
                 d3d11CommandBuffer);
         }
-        d3d11UniformBuffer = d3d11CommandBuffer->fragmentUniformBuffers[slotIndex];
+        d3d11UniformBuffer = d3d11CommandBuffer->fragmentUniformBuffers[slot_index];
     } else if (shaderStage == SDL_GPU_SHADERSTAGE_COMPUTE) {
-        if (d3d11CommandBuffer->computeUniformBuffers[slotIndex] == NULL) {
-            d3d11CommandBuffer->computeUniformBuffers[slotIndex] = D3D11_INTERNAL_AcquireUniformBufferFromPool(
+        if (d3d11CommandBuffer->computeUniformBuffers[slot_index] == NULL) {
+            d3d11CommandBuffer->computeUniformBuffers[slot_index] = D3D11_INTERNAL_AcquireUniformBufferFromPool(
                 d3d11CommandBuffer);
         }
-        d3d11UniformBuffer = d3d11CommandBuffer->computeUniformBuffers[slotIndex];
+        d3d11UniformBuffer = d3d11CommandBuffer->computeUniformBuffers[slot_index];
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
         return;
@@ -3319,7 +3319,7 @@ static void D3D11_INTERNAL_PushUniformData(
 
     d3d11UniformBuffer->currentBlockSize =
         D3D11_INTERNAL_NextHighestAlignment(
-            dataLengthInBytes,
+            length,
             256);
 
     // If there is no more room, acquire a new uniform buffer
@@ -3336,11 +3336,11 @@ static void D3D11_INTERNAL_PushUniformData(
         d3d11UniformBuffer->writeOffset = 0;
 
         if (shaderStage == SDL_GPU_SHADERSTAGE_VERTEX) {
-            d3d11CommandBuffer->vertexUniformBuffers[slotIndex] = d3d11UniformBuffer;
+            d3d11CommandBuffer->vertexUniformBuffers[slot_index] = d3d11UniformBuffer;
         } else if (shaderStage == SDL_GPU_SHADERSTAGE_FRAGMENT) {
-            d3d11CommandBuffer->fragmentUniformBuffers[slotIndex] = d3d11UniformBuffer;
+            d3d11CommandBuffer->fragmentUniformBuffers[slot_index] = d3d11UniformBuffer;
         } else if (shaderStage == SDL_GPU_SHADERSTAGE_COMPUTE) {
-            d3d11CommandBuffer->computeUniformBuffers[slotIndex] = d3d11UniformBuffer;
+            d3d11CommandBuffer->computeUniformBuffers[slot_index] = d3d11UniformBuffer;
         } else {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
         }
@@ -3365,7 +3365,7 @@ static void D3D11_INTERNAL_PushUniformData(
     SDL_memcpy(
         (Uint8 *)d3d11UniformBuffer->mappedData + d3d11UniformBuffer->writeOffset,
         data,
-        dataLengthInBytes);
+        length);
 
     d3d11UniformBuffer->writeOffset += d3d11UniformBuffer->currentBlockSize;
 
@@ -3381,10 +3381,10 @@ static void D3D11_INTERNAL_PushUniformData(
 }
 
 static void D3D11_SetViewport(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUViewport *viewport)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11_VIEWPORT vp = {
         viewport->x,
         viewport->y,
@@ -3401,10 +3401,10 @@ static void D3D11_SetViewport(
 }
 
 static void D3D11_SetScissor(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_Rect *scissor)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11_RECT rect = {
         scissor->x,
         scissor->y,
@@ -3419,46 +3419,46 @@ static void D3D11_SetScissor(
 }
 
 static void D3D11_SetBlendConstants(
-    SDL_GPUCommandBuffer *commandBuffer,
-    SDL_FColor blendConstants)
+    SDL_GPUCommandBuffer *command_buffer,
+    SDL_FColor blend_constants)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
-    FLOAT blendFactor[4] = { blendConstants.r, blendConstants.g, blendConstants.b, blendConstants.a };
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    FLOAT blendFactor[4] = { blend_constants.r, blend_constants.g, blend_constants.b, blend_constants.a };
 
-    d3d11CommandBuffer->blendConstants = blendConstants;
+    d3d11CommandBuffer->blend_constants = blend_constants;
 
-    if (d3d11CommandBuffer->graphicsPipeline != NULL) {
+    if (d3d11CommandBuffer->graphics_pipeline != NULL) {
         ID3D11DeviceContext_OMSetBlendState(
             d3d11CommandBuffer->context,
-            d3d11CommandBuffer->graphicsPipeline->colorAttachmentBlendState,
+            d3d11CommandBuffer->graphics_pipeline->colorAttachmentBlendState,
             blendFactor,
-            d3d11CommandBuffer->graphicsPipeline->multisampleState.sampleMask);
+            d3d11CommandBuffer->graphics_pipeline->multisample_state.sample_mask);
     }
 }
 
 static void D3D11_SetStencilReference(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     Uint8 reference)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
 
     d3d11CommandBuffer->stencilRef = reference;
 
-    if (d3d11CommandBuffer->graphicsPipeline != NULL) {
+    if (d3d11CommandBuffer->graphics_pipeline != NULL) {
         ID3D11DeviceContext_OMSetDepthStencilState(
             d3d11CommandBuffer->context,
-            d3d11CommandBuffer->graphicsPipeline->depthStencilState,
+            d3d11CommandBuffer->graphics_pipeline->depth_stencil_state,
             reference);
     }
 }
 
 static void D3D11_BeginRenderPass(
-    SDL_GPUCommandBuffer *commandBuffer,
-    const SDL_GPUColorAttachmentInfo *colorAttachmentInfos,
-    Uint32 colorAttachmentCount,
-    const SDL_GPUDepthStencilAttachmentInfo *depthStencilAttachmentInfo)
+    SDL_GPUCommandBuffer *command_buffer,
+    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
+    Uint32 num_color_attachments,
+    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
     ID3D11RenderTargetView *rtvs[MAX_COLOR_TARGET_BINDINGS];
     ID3D11DepthStencilView *dsv = NULL;
@@ -3481,14 +3481,14 @@ static void D3D11_BeginRenderPass(
     }
 
     // Set up the new color target bindings
-    for (Uint32 i = 0; i < colorAttachmentCount; i += 1) {
-        D3D11TextureContainer *container = (D3D11TextureContainer *)colorAttachmentInfos[i].texture;
+    for (Uint32 i = 0; i < num_color_attachments; i += 1) {
+        D3D11TextureContainer *container = (D3D11TextureContainer *)color_attachment_infos[i].texture;
         D3D11TextureSubresource *subresource = D3D11_INTERNAL_PrepareTextureSubresourceForWrite(
             renderer,
             container,
-            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorAttachmentInfos[i].layerOrDepthPlane,
-            colorAttachmentInfos[i].mipLevel,
-            colorAttachmentInfos[i].cycle);
+            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : color_attachment_infos[i].layer_or_depth_plane,
+            color_attachment_infos[i].mip_level,
+            color_attachment_infos[i].cycle);
 
         if (subresource->msaaHandle != NULL) {
             d3d11CommandBuffer->colorTargetResolveTexture[i] = subresource->parent;
@@ -3498,21 +3498,21 @@ static void D3D11_BeginRenderPass(
 
             rtvs[i] = subresource->msaaTargetView;
         } else {
-            Uint32 rtvIndex = container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? colorAttachmentInfos[i].layerOrDepthPlane : 0;
+            Uint32 rtvIndex = container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? color_attachment_infos[i].layer_or_depth_plane : 0;
             rtvs[i] = subresource->colorTargetViews[rtvIndex];
         }
 
-        if (colorAttachmentInfos[i].loadOp == SDL_GPU_LOADOP_CLEAR) {
-            float clearColor[] = {
-                colorAttachmentInfos[i].clearColor.r,
-                colorAttachmentInfos[i].clearColor.g,
-                colorAttachmentInfos[i].clearColor.b,
-                colorAttachmentInfos[i].clearColor.a
+        if (color_attachment_infos[i].load_op == SDL_GPU_LOADOP_CLEAR) {
+            float clear_color[] = {
+                color_attachment_infos[i].clear_color.r,
+                color_attachment_infos[i].clear_color.g,
+                color_attachment_infos[i].clear_color.b,
+                color_attachment_infos[i].clear_color.a
             };
             ID3D11DeviceContext_ClearRenderTargetView(
                 d3d11CommandBuffer->context,
                 rtvs[i],
-                clearColor);
+                clear_color);
         }
 
         D3D11_INTERNAL_TrackTexture(
@@ -3521,14 +3521,14 @@ static void D3D11_BeginRenderPass(
     }
 
     // Get the DSV for the depth stencil attachment, if applicable
-    if (depthStencilAttachmentInfo != NULL) {
-        D3D11TextureContainer *container = (D3D11TextureContainer *)depthStencilAttachmentInfo->texture;
+    if (depth_stencil_attachment_info != NULL) {
+        D3D11TextureContainer *container = (D3D11TextureContainer *)depth_stencil_attachment_info->texture;
         D3D11TextureSubresource *subresource = D3D11_INTERNAL_PrepareTextureSubresourceForWrite(
             renderer,
             container,
             0,
             0,
-            depthStencilAttachmentInfo->cycle);
+            depth_stencil_attachment_info->cycle);
 
         dsv = subresource->depthStencilTargetView;
 
@@ -3540,16 +3540,16 @@ static void D3D11_BeginRenderPass(
     // Actually set the RTs
     ID3D11DeviceContext_OMSetRenderTargets(
         d3d11CommandBuffer->context,
-        colorAttachmentCount,
-        colorAttachmentCount > 0 ? rtvs : NULL,
+        num_color_attachments,
+        num_color_attachments > 0 ? rtvs : NULL,
         dsv);
 
-    if (depthStencilAttachmentInfo != NULL) {
+    if (depth_stencil_attachment_info != NULL) {
         D3D11_CLEAR_FLAG dsClearFlags = 0;
-        if (depthStencilAttachmentInfo->loadOp == SDL_GPU_LOADOP_CLEAR) {
+        if (depth_stencil_attachment_info->load_op == SDL_GPU_LOADOP_CLEAR) {
             dsClearFlags |= D3D11_CLEAR_DEPTH;
         }
-        if (depthStencilAttachmentInfo->stencilLoadOp == SDL_GPU_LOADOP_CLEAR) {
+        if (depth_stencil_attachment_info->stencil_load_op == SDL_GPU_LOADOP_CLEAR) {
             dsClearFlags |= D3D11_CLEAR_STENCIL;
         }
 
@@ -3558,16 +3558,16 @@ static void D3D11_BeginRenderPass(
                 d3d11CommandBuffer->context,
                 dsv,
                 dsClearFlags,
-                depthStencilAttachmentInfo->depthStencilClearValue.depth,
-                depthStencilAttachmentInfo->depthStencilClearValue.stencil);
+                depth_stencil_attachment_info->clear_value.depth,
+                depth_stencil_attachment_info->clear_value.stencil);
         }
     }
 
     // The viewport cannot be larger than the smallest attachment.
-    for (Uint32 i = 0; i < colorAttachmentCount; i += 1) {
-        D3D11TextureContainer *container = (D3D11TextureContainer *)colorAttachmentInfos[i].texture;
-        Uint32 w = container->header.info.width >> colorAttachmentInfos[i].mipLevel;
-        Uint32 h = container->header.info.height >> colorAttachmentInfos[i].mipLevel;
+    for (Uint32 i = 0; i < num_color_attachments; i += 1) {
+        D3D11TextureContainer *container = (D3D11TextureContainer *)color_attachment_infos[i].texture;
+        Uint32 w = container->header.info.width >> color_attachment_infos[i].mip_level;
+        Uint32 h = container->header.info.height >> color_attachment_infos[i].mip_level;
 
         if (w < vpWidth) {
             vpWidth = w;
@@ -3578,8 +3578,8 @@ static void D3D11_BeginRenderPass(
         }
     }
 
-    if (depthStencilAttachmentInfo != NULL) {
-        D3D11TextureContainer *container = (D3D11TextureContainer *)depthStencilAttachmentInfo->texture;
+    if (depth_stencil_attachment_info != NULL) {
+        D3D11TextureContainer *container = (D3D11TextureContainer *)depth_stencil_attachment_info->texture;
         Uint32 w = container->header.info.width;
         Uint32 h = container->header.info.height;
 
@@ -3601,7 +3601,7 @@ static void D3D11_BeginRenderPass(
     viewport.maxDepth = 1;
 
     D3D11_SetViewport(
-        commandBuffer,
+        command_buffer,
         &viewport);
 
     scissorRect.x = 0;
@@ -3610,47 +3610,47 @@ static void D3D11_BeginRenderPass(
     scissorRect.h = (int)vpHeight;
 
     D3D11_SetScissor(
-        commandBuffer,
+        command_buffer,
         &scissorRect);
 
     D3D11_SetStencilReference(
-        commandBuffer,
+        command_buffer,
         0);
 
     D3D11_SetBlendConstants(
-        commandBuffer,
+        command_buffer,
         (SDL_FColor){ 1.0f, 1.0f, 1.0f, 1.0f });
 }
 
 static void D3D11_BindGraphicsPipeline(
-    SDL_GPUCommandBuffer *commandBuffer,
-    SDL_GPUGraphicsPipeline *graphicsPipeline)
+    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUGraphicsPipeline *graphics_pipeline)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
-    D3D11GraphicsPipeline *pipeline = (D3D11GraphicsPipeline *)graphicsPipeline;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11GraphicsPipeline *pipeline = (D3D11GraphicsPipeline *)graphics_pipeline;
     FLOAT blendFactor[4] = {
-        d3d11CommandBuffer->blendConstants.r,
-        d3d11CommandBuffer->blendConstants.g,
-        d3d11CommandBuffer->blendConstants.b,
-        d3d11CommandBuffer->blendConstants.a
+        d3d11CommandBuffer->blend_constants.r,
+        d3d11CommandBuffer->blend_constants.g,
+        d3d11CommandBuffer->blend_constants.b,
+        d3d11CommandBuffer->blend_constants.a
     };
 
-    d3d11CommandBuffer->graphicsPipeline = pipeline;
+    d3d11CommandBuffer->graphics_pipeline = pipeline;
 
     ID3D11DeviceContext_OMSetBlendState(
         d3d11CommandBuffer->context,
         pipeline->colorAttachmentBlendState,
         blendFactor,
-        pipeline->multisampleState.sampleMask);
+        pipeline->multisample_state.sample_mask);
 
     ID3D11DeviceContext_OMSetDepthStencilState(
         d3d11CommandBuffer->context,
-        pipeline->depthStencilState,
+        pipeline->depth_stencil_state,
         d3d11CommandBuffer->stencilRef);
 
     ID3D11DeviceContext_IASetPrimitiveTopology(
         d3d11CommandBuffer->context,
-        SDLToD3D11_PrimitiveType[pipeline->primitiveType]);
+        SDLToD3D11_PrimitiveType[pipeline->primitive_type]);
 
     ID3D11DeviceContext_IASetInputLayout(
         d3d11CommandBuffer->context,
@@ -3658,17 +3658,17 @@ static void D3D11_BindGraphicsPipeline(
 
     ID3D11DeviceContext_RSSetState(
         d3d11CommandBuffer->context,
-        pipeline->rasterizerState);
+        pipeline->rasterizer_state);
 
     ID3D11DeviceContext_VSSetShader(
         d3d11CommandBuffer->context,
-        pipeline->vertexShader,
+        pipeline->vertex_shader,
         NULL,
         0);
 
     ID3D11DeviceContext_PSSetShader(
         d3d11CommandBuffer->context,
-        pipeline->fragmentShader,
+        pipeline->fragment_shader,
         NULL,
         0);
 
@@ -3693,32 +3693,32 @@ static void D3D11_BindGraphicsPipeline(
 }
 
 static void D3D11_BindVertexBuffers(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstBinding,
-    const SDL_GPUBufferBinding *pBindings,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_binding,
+    const SDL_GPUBufferBinding *bindings,
+    Uint32 num_bindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        D3D11Buffer *currentBuffer = ((D3D11BufferContainer *)pBindings[i].buffer)->activeBuffer;
-        d3d11CommandBuffer->vertexBuffers[firstBinding + i] = currentBuffer->handle;
-        d3d11CommandBuffer->vertexBufferOffsets[firstBinding + i] = pBindings[i].offset;
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        D3D11Buffer *currentBuffer = ((D3D11BufferContainer *)bindings[i].buffer)->activeBuffer;
+        d3d11CommandBuffer->vertexBuffers[first_binding + i] = currentBuffer->handle;
+        d3d11CommandBuffer->vertexBufferOffsets[first_binding + i] = bindings[i].offset;
         D3D11_INTERNAL_TrackBuffer(d3d11CommandBuffer, currentBuffer);
     }
 
     d3d11CommandBuffer->vertexBufferCount =
-        SDL_max(d3d11CommandBuffer->vertexBufferCount, firstBinding + bindingCount);
+        SDL_max(d3d11CommandBuffer->vertexBufferCount, first_binding + num_bindings);
 
     d3d11CommandBuffer->needVertexBufferBind = true;
 }
 
 static void D3D11_BindIndexBuffer(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUBufferBinding *pBinding,
-    SDL_GPUIndexElementSize indexElementSize)
+    SDL_GPUIndexElementSize index_element_size)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11Buffer *d3d11Buffer = ((D3D11BufferContainer *)pBinding->buffer)->activeBuffer;
 
     D3D11_INTERNAL_TrackBuffer(d3d11CommandBuffer, d3d11Buffer);
@@ -3726,29 +3726,29 @@ static void D3D11_BindIndexBuffer(
     ID3D11DeviceContext_IASetIndexBuffer(
         d3d11CommandBuffer->context,
         d3d11Buffer->handle,
-        SDLToD3D11_IndexType[indexElementSize],
+        SDLToD3D11_IndexType[index_element_size],
         (UINT)pBinding->offset);
 }
 
 static void D3D11_BindVertexSamplers(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
+    Uint32 num_bindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)textureSamplerBindings[i].texture;
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)texture_sampler_bindings[i].texture;
 
         D3D11_INTERNAL_TrackTexture(
             d3d11CommandBuffer,
             textureContainer->activeTexture);
 
-        d3d11CommandBuffer->vertexSamplers[firstSlot + i] =
-            ((D3D11Sampler *)textureSamplerBindings[i].sampler)->handle;
+        d3d11CommandBuffer->vertexSamplers[first_slot + i] =
+            ((D3D11Sampler *)texture_sampler_bindings[i].sampler)->handle;
 
-        d3d11CommandBuffer->vertexShaderResourceViews[firstSlot + i] =
+        d3d11CommandBuffer->vertexShaderResourceViews[first_slot + i] =
             textureContainer->activeTexture->shaderView;
     }
 
@@ -3757,71 +3757,71 @@ static void D3D11_BindVertexSamplers(
 }
 
 static void D3D11_BindVertexStorageTextures(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    SDL_GPUTexture *const *storageTextures,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    SDL_GPUTexture *const *storage_textures,
+    Uint32 num_bindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)storageTextures[i];
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)storage_textures[i];
 
         D3D11_INTERNAL_TrackTexture(
             d3d11CommandBuffer,
             textureContainer->activeTexture);
 
-        d3d11CommandBuffer->vertexShaderResourceViews[firstSlot + i +
-                                                      d3d11CommandBuffer->graphicsPipeline->vertexSamplerCount] = textureContainer->activeTexture->shaderView;
+        d3d11CommandBuffer->vertexShaderResourceViews[first_slot + i +
+                                                      d3d11CommandBuffer->graphics_pipeline->vertexSamplerCount] = textureContainer->activeTexture->shaderView;
     }
 
     d3d11CommandBuffer->needVertexResourceBind = true;
 }
 
 static void D3D11_BindVertexStorageBuffers(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    SDL_GPUBuffer *const *storageBuffers,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    SDL_GPUBuffer *const *storage_buffers,
+    Uint32 num_bindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11BufferContainer *bufferContainer;
     Uint32 i;
 
-    for (i = 0; i < bindingCount; i += 1) {
-        bufferContainer = (D3D11BufferContainer *)storageBuffers[i];
+    for (i = 0; i < num_bindings; i += 1) {
+        bufferContainer = (D3D11BufferContainer *)storage_buffers[i];
 
         D3D11_INTERNAL_TrackBuffer(
             d3d11CommandBuffer,
             bufferContainer->activeBuffer);
 
-        d3d11CommandBuffer->vertexShaderResourceViews[firstSlot + i +
-                                                      d3d11CommandBuffer->graphicsPipeline->vertexSamplerCount +
-                                                      d3d11CommandBuffer->graphicsPipeline->vertexStorageTextureCount] = bufferContainer->activeBuffer->srv;
+        d3d11CommandBuffer->vertexShaderResourceViews[first_slot + i +
+                                                      d3d11CommandBuffer->graphics_pipeline->vertexSamplerCount +
+                                                      d3d11CommandBuffer->graphics_pipeline->vertexStorageTextureCount] = bufferContainer->activeBuffer->srv;
     }
 
     d3d11CommandBuffer->needVertexResourceBind = true;
 }
 
 static void D3D11_BindFragmentSamplers(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
+    Uint32 num_bindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)textureSamplerBindings[i].texture;
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)texture_sampler_bindings[i].texture;
 
         D3D11_INTERNAL_TrackTexture(
             d3d11CommandBuffer,
             textureContainer->activeTexture);
 
-        d3d11CommandBuffer->fragmentSamplers[firstSlot + i] =
-            ((D3D11Sampler *)textureSamplerBindings[i].sampler)->handle;
+        d3d11CommandBuffer->fragmentSamplers[first_slot + i] =
+            ((D3D11Sampler *)texture_sampler_bindings[i].sampler)->handle;
 
-        d3d11CommandBuffer->fragmentShaderResourceViews[firstSlot + i] =
+        d3d11CommandBuffer->fragmentShaderResourceViews[first_slot + i] =
             textureContainer->activeTexture->shaderView;
     }
 
@@ -3830,227 +3830,227 @@ static void D3D11_BindFragmentSamplers(
 }
 
 static void D3D11_BindFragmentStorageTextures(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    SDL_GPUTexture *const *storageTextures,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    SDL_GPUTexture *const *storage_textures,
+    Uint32 num_bindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)storageTextures[i];
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)storage_textures[i];
 
         D3D11_INTERNAL_TrackTexture(
             d3d11CommandBuffer,
             textureContainer->activeTexture);
 
-        d3d11CommandBuffer->fragmentShaderResourceViews[firstSlot + i +
-                                                        d3d11CommandBuffer->graphicsPipeline->fragmentSamplerCount] = textureContainer->activeTexture->shaderView;
+        d3d11CommandBuffer->fragmentShaderResourceViews[first_slot + i +
+                                                        d3d11CommandBuffer->graphics_pipeline->fragmentSamplerCount] = textureContainer->activeTexture->shaderView;
     }
 
     d3d11CommandBuffer->needFragmentResourceBind = true;
 }
 
 static void D3D11_BindFragmentStorageBuffers(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    SDL_GPUBuffer *const *storageBuffers,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    SDL_GPUBuffer *const *storage_buffers,
+    Uint32 num_bindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11BufferContainer *bufferContainer;
     Uint32 i;
 
-    for (i = 0; i < bindingCount; i += 1) {
-        bufferContainer = (D3D11BufferContainer *)storageBuffers[i];
+    for (i = 0; i < num_bindings; i += 1) {
+        bufferContainer = (D3D11BufferContainer *)storage_buffers[i];
 
         D3D11_INTERNAL_TrackBuffer(
             d3d11CommandBuffer,
             bufferContainer->activeBuffer);
 
-        d3d11CommandBuffer->fragmentShaderResourceViews[firstSlot + i +
-                                                        d3d11CommandBuffer->graphicsPipeline->fragmentSamplerCount +
-                                                        d3d11CommandBuffer->graphicsPipeline->fragmentStorageTextureCount] = bufferContainer->activeBuffer->srv;
+        d3d11CommandBuffer->fragmentShaderResourceViews[first_slot + i +
+                                                        d3d11CommandBuffer->graphics_pipeline->fragmentSamplerCount +
+                                                        d3d11CommandBuffer->graphics_pipeline->fragmentStorageTextureCount] = bufferContainer->activeBuffer->srv;
     }
 
     d3d11CommandBuffer->needFragmentResourceBind = true;
 }
 
 static void D3D11_INTERNAL_BindGraphicsResources(
-    D3D11CommandBuffer *commandBuffer)
+    D3D11CommandBuffer *command_buffer)
 {
-    D3D11GraphicsPipeline *graphicsPipeline = commandBuffer->graphicsPipeline;
+    D3D11GraphicsPipeline *graphics_pipeline = command_buffer->graphics_pipeline;
 
     Uint32 vertexResourceCount =
-        graphicsPipeline->vertexSamplerCount +
-        graphicsPipeline->vertexStorageTextureCount +
-        graphicsPipeline->vertexStorageBufferCount;
+        graphics_pipeline->vertexSamplerCount +
+        graphics_pipeline->vertexStorageTextureCount +
+        graphics_pipeline->vertexStorageBufferCount;
 
     Uint32 fragmentResourceCount =
-        graphicsPipeline->fragmentSamplerCount +
-        graphicsPipeline->fragmentStorageTextureCount +
-        graphicsPipeline->fragmentStorageBufferCount;
+        graphics_pipeline->fragmentSamplerCount +
+        graphics_pipeline->fragmentStorageTextureCount +
+        graphics_pipeline->fragmentStorageBufferCount;
 
     ID3D11Buffer *nullBuf = NULL;
     Uint32 offsetInConstants, blockSizeInConstants, i;
 
-    if (commandBuffer->needVertexBufferBind) {
+    if (command_buffer->needVertexBufferBind) {
         ID3D11DeviceContext_IASetVertexBuffers(
-            commandBuffer->context,
+            command_buffer->context,
             0,
-            commandBuffer->vertexBufferCount,
-            commandBuffer->vertexBuffers,
-            graphicsPipeline->vertexStrides,
-            commandBuffer->vertexBufferOffsets);
+            command_buffer->vertexBufferCount,
+            command_buffer->vertexBuffers,
+            graphics_pipeline->vertexStrides,
+            command_buffer->vertexBufferOffsets);
     }
 
-    if (commandBuffer->needVertexSamplerBind) {
-        if (graphicsPipeline->vertexSamplerCount > 0) {
+    if (command_buffer->needVertexSamplerBind) {
+        if (graphics_pipeline->vertexSamplerCount > 0) {
             ID3D11DeviceContext_VSSetSamplers(
-                commandBuffer->context,
+                command_buffer->context,
                 0,
-                graphicsPipeline->vertexSamplerCount,
-                commandBuffer->vertexSamplers);
+                graphics_pipeline->vertexSamplerCount,
+                command_buffer->vertexSamplers);
         }
 
-        commandBuffer->needVertexSamplerBind = false;
+        command_buffer->needVertexSamplerBind = false;
     }
 
-    if (commandBuffer->needVertexResourceBind) {
+    if (command_buffer->needVertexResourceBind) {
         if (vertexResourceCount > 0) {
             ID3D11DeviceContext_VSSetShaderResources(
-                commandBuffer->context,
+                command_buffer->context,
                 0,
                 vertexResourceCount,
-                commandBuffer->vertexShaderResourceViews);
+                command_buffer->vertexShaderResourceViews);
         }
 
-        commandBuffer->needVertexResourceBind = false;
+        command_buffer->needVertexResourceBind = false;
     }
 
-    if (commandBuffer->needVertexUniformBufferBind) {
-        for (i = 0; i < graphicsPipeline->vertexUniformBufferCount; i += 1) {
+    if (command_buffer->needVertexUniformBufferBind) {
+        for (i = 0; i < graphics_pipeline->vertexUniformBufferCount; i += 1) {
             /* stupid workaround for god awful D3D11 drivers
              * see: https://learn.microsoft.com/en-us/windows/win32/api/d3d11_1/nf-d3d11_1-id3d11devicecontext1-vssetconstantbuffers1#calling-vssetconstantbuffers1-with-command-list-emulation
              */
             ID3D11DeviceContext1_VSSetConstantBuffers(
-                commandBuffer->context,
+                command_buffer->context,
                 i,
                 1,
                 &nullBuf);
 
-            offsetInConstants = commandBuffer->vertexUniformBuffers[i]->drawOffset / 16;
-            blockSizeInConstants = commandBuffer->vertexUniformBuffers[i]->currentBlockSize / 16;
+            offsetInConstants = command_buffer->vertexUniformBuffers[i]->drawOffset / 16;
+            blockSizeInConstants = command_buffer->vertexUniformBuffers[i]->currentBlockSize / 16;
 
             ID3D11DeviceContext1_VSSetConstantBuffers1(
-                commandBuffer->context,
+                command_buffer->context,
                 i,
                 1,
-                &commandBuffer->vertexUniformBuffers[i]->buffer,
+                &command_buffer->vertexUniformBuffers[i]->buffer,
                 &offsetInConstants,
                 &blockSizeInConstants);
         }
 
-        commandBuffer->needVertexUniformBufferBind = false;
+        command_buffer->needVertexUniformBufferBind = false;
     }
 
-    if (commandBuffer->needFragmentSamplerBind) {
-        if (graphicsPipeline->fragmentSamplerCount > 0) {
+    if (command_buffer->needFragmentSamplerBind) {
+        if (graphics_pipeline->fragmentSamplerCount > 0) {
             ID3D11DeviceContext_PSSetSamplers(
-                commandBuffer->context,
+                command_buffer->context,
                 0,
-                graphicsPipeline->fragmentSamplerCount,
-                commandBuffer->fragmentSamplers);
+                graphics_pipeline->fragmentSamplerCount,
+                command_buffer->fragmentSamplers);
         }
 
-        commandBuffer->needFragmentSamplerBind = false;
+        command_buffer->needFragmentSamplerBind = false;
     }
 
-    if (commandBuffer->needFragmentResourceBind) {
+    if (command_buffer->needFragmentResourceBind) {
         if (fragmentResourceCount > 0) {
             ID3D11DeviceContext_PSSetShaderResources(
-                commandBuffer->context,
+                command_buffer->context,
                 0,
                 fragmentResourceCount,
-                commandBuffer->fragmentShaderResourceViews);
+                command_buffer->fragmentShaderResourceViews);
         }
 
-        commandBuffer->needFragmentResourceBind = false;
+        command_buffer->needFragmentResourceBind = false;
     }
 
-    if (commandBuffer->needFragmentUniformBufferBind) {
-        for (i = 0; i < graphicsPipeline->fragmentUniformBufferCount; i += 1) {
+    if (command_buffer->needFragmentUniformBufferBind) {
+        for (i = 0; i < graphics_pipeline->fragmentUniformBufferCount; i += 1) {
             /* stupid workaround for god awful D3D11 drivers
              * see: https://learn.microsoft.com/en-us/windows/win32/api/d3d11_1/nf-d3d11_1-id3d11devicecontext1-pssetconstantbuffers1#calling-pssetconstantbuffers1-with-command-list-emulation
              */
             ID3D11DeviceContext1_PSSetConstantBuffers(
-                commandBuffer->context,
+                command_buffer->context,
                 i,
                 1,
                 &nullBuf);
 
-            offsetInConstants = commandBuffer->fragmentUniformBuffers[i]->drawOffset / 16;
-            blockSizeInConstants = commandBuffer->fragmentUniformBuffers[i]->currentBlockSize / 16;
+            offsetInConstants = command_buffer->fragmentUniformBuffers[i]->drawOffset / 16;
+            blockSizeInConstants = command_buffer->fragmentUniformBuffers[i]->currentBlockSize / 16;
 
             ID3D11DeviceContext1_PSSetConstantBuffers1(
-                commandBuffer->context,
+                command_buffer->context,
                 i,
                 1,
-                &commandBuffer->fragmentUniformBuffers[i]->buffer,
+                &command_buffer->fragmentUniformBuffers[i]->buffer,
                 &offsetInConstants,
                 &blockSizeInConstants);
         }
 
-        commandBuffer->needFragmentUniformBufferBind = false;
+        command_buffer->needFragmentUniformBufferBind = false;
     }
 }
 
 static void D3D11_DrawIndexedPrimitives(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 indexCount,
-    Uint32 instanceCount,
-    Uint32 firstIndex,
-    Sint32 vertexOffset,
-    Uint32 firstInstance)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 num_indices,
+    Uint32 num_instances,
+    Uint32 first_index,
+    Sint32 vertex_offset,
+    Uint32 first_instance)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11_INTERNAL_BindGraphicsResources(d3d11CommandBuffer);
 
     ID3D11DeviceContext_DrawIndexedInstanced(
         d3d11CommandBuffer->context,
-        indexCount,
-        instanceCount,
-        firstIndex,
-        vertexOffset,
-        firstInstance);
+        num_indices,
+        num_instances,
+        first_index,
+        vertex_offset,
+        first_instance);
 }
 
 static void D3D11_DrawPrimitives(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 vertexCount,
-    Uint32 instanceCount,
-    Uint32 firstVertex,
-    Uint32 firstInstance)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 num_vertices,
+    Uint32 num_instances,
+    Uint32 first_vertex,
+    Uint32 first_instance)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11_INTERNAL_BindGraphicsResources(d3d11CommandBuffer);
 
     ID3D11DeviceContext_DrawInstanced(
         d3d11CommandBuffer->context,
-        vertexCount,
-        instanceCount,
-        firstVertex,
-        firstInstance);
+        num_vertices,
+        num_instances,
+        first_vertex,
+        first_instance);
 }
 
 static void D3D11_DrawPrimitivesIndirect(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     SDL_GPUBuffer *buffer,
-    Uint32 offsetInBytes,
-    Uint32 drawCount,
-    Uint32 stride)
+    Uint32 offset,
+    Uint32 draw_count,
+    Uint32 pitch)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11_INTERNAL_BindGraphicsResources(d3d11CommandBuffer);
 
     D3D11Buffer *d3d11Buffer = ((D3D11BufferContainer *)buffer)->activeBuffer;
@@ -4058,24 +4058,24 @@ static void D3D11_DrawPrimitivesIndirect(
     /* D3D11: "We have multi-draw at home!"
      * Multi-draw at home:
      */
-    for (Uint32 i = 0; i < drawCount; i += 1) {
+    for (Uint32 i = 0; i < draw_count; i += 1) {
         ID3D11DeviceContext_DrawInstancedIndirect(
             d3d11CommandBuffer->context,
             d3d11Buffer->handle,
-            offsetInBytes + (stride * i));
+            offset + (pitch * i));
     }
 
     D3D11_INTERNAL_TrackBuffer(d3d11CommandBuffer, d3d11Buffer);
 }
 
 static void D3D11_DrawIndexedPrimitivesIndirect(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     SDL_GPUBuffer *buffer,
-    Uint32 offsetInBytes,
-    Uint32 drawCount,
-    Uint32 stride)
+    Uint32 offset,
+    Uint32 draw_count,
+    Uint32 pitch)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11_INTERNAL_BindGraphicsResources(d3d11CommandBuffer);
 
     D3D11Buffer *d3d11Buffer = ((D3D11BufferContainer *)buffer)->activeBuffer;
@@ -4083,20 +4083,20 @@ static void D3D11_DrawIndexedPrimitivesIndirect(
     /* D3D11: "We have multi-draw at home!"
      * Multi-draw at home:
      */
-    for (Uint32 i = 0; i < drawCount; i += 1) {
+    for (Uint32 i = 0; i < draw_count; i += 1) {
         ID3D11DeviceContext_DrawIndexedInstancedIndirect(
             d3d11CommandBuffer->context,
             d3d11Buffer->handle,
-            offsetInBytes + (stride * i));
+            offset + (pitch * i));
     }
 
     D3D11_INTERNAL_TrackBuffer(d3d11CommandBuffer, d3d11Buffer);
 }
 
 static void D3D11_EndRenderPass(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     Uint32 i;
 
     // Set render target slots to NULL to avoid NULL set behavior
@@ -4133,53 +4133,53 @@ static void D3D11_EndRenderPass(
 }
 
 static void D3D11_PushVertexUniformData(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 slotIndex,
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 slot_index,
     const void *data,
-    Uint32 dataLengthInBytes)
+    Uint32 length)
 {
     D3D11_INTERNAL_PushUniformData(
-        (D3D11CommandBuffer *)commandBuffer,
+        (D3D11CommandBuffer *)command_buffer,
         SDL_GPU_SHADERSTAGE_VERTEX,
-        slotIndex,
+        slot_index,
         data,
-        dataLengthInBytes);
+        length);
 }
 
 static void D3D11_PushFragmentUniformData(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 slotIndex,
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 slot_index,
     const void *data,
-    Uint32 dataLengthInBytes)
+    Uint32 length)
 {
     D3D11_INTERNAL_PushUniformData(
-        (D3D11CommandBuffer *)commandBuffer,
+        (D3D11CommandBuffer *)command_buffer,
         SDL_GPU_SHADERSTAGE_FRAGMENT,
-        slotIndex,
+        slot_index,
         data,
-        dataLengthInBytes);
+        length);
 }
 
 // Blit
 
 static void D3D11_Blit(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUBlitRegion *source,
     const SDL_GPUBlitRegion *destination,
-    SDL_FlipMode flipMode,
-    SDL_GPUFilter filterMode,
+    SDL_FlipMode flip_mode,
+    SDL_GPUFilter filter,
     bool cycle)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
     BlitPipelineCacheEntry *blitPipelines = &renderer->blitPipelines[0];
 
     SDL_GPU_BlitCommon(
-        commandBuffer,
+        command_buffer,
         source,
         destination,
-        flipMode,
-        filterMode,
+        flip_mode,
+        filter,
         cycle,
         renderer->blitLinearSampler,
         renderer->blitNearestSampler,
@@ -4196,31 +4196,31 @@ static void D3D11_Blit(
 // Compute State
 
 static void D3D11_BeginComputePass(
-    SDL_GPUCommandBuffer *commandBuffer,
-    const SDL_GPUStorageTextureWriteOnlyBinding *storageTextureBindings,
-    Uint32 storageTextureBindingCount,
-    const SDL_GPUStorageBufferWriteOnlyBinding *storageBufferBindings,
-    Uint32 storageBufferBindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    const SDL_GPUStorageTextureWriteOnlyBinding *storage_texture_bindings,
+    Uint32 num_storage_texture_bindings,
+    const SDL_GPUStorageBufferWriteOnlyBinding *storage_buffer_bindings,
+    Uint32 num_storage_buffer_bindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11TextureContainer *textureContainer;
     D3D11TextureSubresource *textureSubresource;
     D3D11BufferContainer *bufferContainer;
     D3D11Buffer *buffer;
     Uint32 i;
 
-    for (i = 0; i < storageTextureBindingCount; i += 1) {
-        textureContainer = (D3D11TextureContainer *)storageTextureBindings[i].texture;
-        if (!(textureContainer->header.info.usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE)) {
+    for (i = 0; i < num_storage_texture_bindings; i += 1) {
+        textureContainer = (D3D11TextureContainer *)storage_texture_bindings[i].texture;
+        if (!(textureContainer->header.info.usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE)) {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Attempted to bind read-only texture as compute write texture");
         }
 
         textureSubresource = D3D11_INTERNAL_PrepareTextureSubresourceForWrite(
             d3d11CommandBuffer->renderer,
             textureContainer,
-            storageTextureBindings[i].layer,
-            storageTextureBindings[i].mipLevel,
-            storageTextureBindings[i].cycle);
+            storage_texture_bindings[i].layer,
+            storage_texture_bindings[i].mip_level,
+            storage_texture_bindings[i].cycle);
 
         D3D11_INTERNAL_TrackTexture(
             d3d11CommandBuffer,
@@ -4229,32 +4229,32 @@ static void D3D11_BeginComputePass(
         d3d11CommandBuffer->computeUnorderedAccessViews[i] = textureSubresource->uav;
     }
 
-    for (i = 0; i < storageBufferBindingCount; i += 1) {
-        bufferContainer = (D3D11BufferContainer *)storageBufferBindings[i].buffer;
+    for (i = 0; i < num_storage_buffer_bindings; i += 1) {
+        bufferContainer = (D3D11BufferContainer *)storage_buffer_bindings[i].buffer;
 
         buffer = D3D11_INTERNAL_PrepareBufferForWrite(
             d3d11CommandBuffer->renderer,
             bufferContainer,
-            storageBufferBindings[i].cycle);
+            storage_buffer_bindings[i].cycle);
 
         D3D11_INTERNAL_TrackBuffer(
             d3d11CommandBuffer,
             buffer);
 
-        d3d11CommandBuffer->computeUnorderedAccessViews[i + storageTextureBindingCount] = buffer->uav;
+        d3d11CommandBuffer->computeUnorderedAccessViews[i + num_storage_texture_bindings] = buffer->uav;
     }
 
     d3d11CommandBuffer->needComputeUAVBind = true;
 }
 
 static void D3D11_BindComputePipeline(
-    SDL_GPUCommandBuffer *commandBuffer,
-    SDL_GPUComputePipeline *computePipeline)
+    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUComputePipeline *compute_pipeline)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
-    D3D11ComputePipeline *pipeline = (D3D11ComputePipeline *)computePipeline;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
+    D3D11ComputePipeline *pipeline = (D3D11ComputePipeline *)compute_pipeline;
 
-    d3d11CommandBuffer->computePipeline = pipeline;
+    d3d11CommandBuffer->compute_pipeline = pipeline;
 
     ID3D11DeviceContext_CSSetShader(
         d3d11CommandBuffer->context,
@@ -4263,7 +4263,7 @@ static void D3D11_BindComputePipeline(
         0);
 
     // Acquire uniform buffers if necessary
-    for (Uint32 i = 0; i < pipeline->uniformBufferCount; i += 1) {
+    for (Uint32 i = 0; i < pipeline->num_uniform_buffers; i += 1) {
         if (d3d11CommandBuffer->computeUniformBuffers[i] == NULL) {
             d3d11CommandBuffer->computeUniformBuffers[i] = D3D11_INTERNAL_AcquireUniformBufferFromPool(
                 d3d11CommandBuffer);
@@ -4274,21 +4274,21 @@ static void D3D11_BindComputePipeline(
 }
 
 static void D3D11_BindComputeStorageTextures(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    SDL_GPUTexture *const *storageTextures,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    SDL_GPUTexture *const *storage_textures,
+    Uint32 num_bindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)storageTextures[i];
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        D3D11TextureContainer *textureContainer = (D3D11TextureContainer *)storage_textures[i];
 
         D3D11_INTERNAL_TrackTexture(
             d3d11CommandBuffer,
             textureContainer->activeTexture);
 
-        d3d11CommandBuffer->computeShaderResourceViews[firstSlot + i] =
+        d3d11CommandBuffer->computeShaderResourceViews[first_slot + i] =
             textureContainer->activeTexture->shaderView;
     }
 
@@ -4296,128 +4296,128 @@ static void D3D11_BindComputeStorageTextures(
 }
 
 static void D3D11_BindComputeStorageBuffers(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    SDL_GPUBuffer *const *storageBuffers,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    SDL_GPUBuffer *const *storage_buffers,
+    Uint32 num_bindings)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11BufferContainer *bufferContainer;
     Uint32 i;
 
-    for (i = 0; i < bindingCount; i += 1) {
-        bufferContainer = (D3D11BufferContainer *)storageBuffers[i];
+    for (i = 0; i < num_bindings; i += 1) {
+        bufferContainer = (D3D11BufferContainer *)storage_buffers[i];
 
         D3D11_INTERNAL_TrackBuffer(
             d3d11CommandBuffer,
             bufferContainer->activeBuffer);
 
-        d3d11CommandBuffer->computeShaderResourceViews[firstSlot + i +
-                                                       d3d11CommandBuffer->computePipeline->readOnlyStorageTextureCount] = bufferContainer->activeBuffer->srv;
+        d3d11CommandBuffer->computeShaderResourceViews[first_slot + i +
+                                                       d3d11CommandBuffer->compute_pipeline->num_readonly_storage_textures] = bufferContainer->activeBuffer->srv;
     }
 
     d3d11CommandBuffer->needComputeSRVBind = true;
 }
 
 static void D3D11_PushComputeUniformData(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 slotIndex,
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 slot_index,
     const void *data,
-    Uint32 dataLengthInBytes)
+    Uint32 length)
 {
     D3D11_INTERNAL_PushUniformData(
-        (D3D11CommandBuffer *)commandBuffer,
+        (D3D11CommandBuffer *)command_buffer,
         SDL_GPU_SHADERSTAGE_COMPUTE,
-        slotIndex,
+        slot_index,
         data,
-        dataLengthInBytes);
+        length);
 }
 
 static void D3D11_INTERNAL_BindComputeResources(
-    D3D11CommandBuffer *commandBuffer)
+    D3D11CommandBuffer *command_buffer)
 {
-    D3D11ComputePipeline *computePipeline = commandBuffer->computePipeline;
+    D3D11ComputePipeline *compute_pipeline = command_buffer->compute_pipeline;
 
     Uint32 readOnlyResourceCount =
-        computePipeline->readOnlyStorageTextureCount +
-        computePipeline->readOnlyStorageBufferCount;
+        compute_pipeline->num_readonly_storage_textures +
+        compute_pipeline->num_readonly_storage_buffers;
 
     Uint32 writeOnlyResourceCount =
-        computePipeline->writeOnlyStorageTextureCount +
-        computePipeline->writeOnlyStorageBufferCount;
+        compute_pipeline->num_writeonly_storage_textures +
+        compute_pipeline->num_writeonly_storage_buffers;
 
     ID3D11Buffer *nullBuf = NULL;
     Uint32 offsetInConstants, blockSizeInConstants, i;
 
-    if (commandBuffer->needComputeUAVBind) {
+    if (command_buffer->needComputeUAVBind) {
         ID3D11DeviceContext_CSSetUnorderedAccessViews(
-            commandBuffer->context,
+            command_buffer->context,
             0,
             writeOnlyResourceCount,
-            commandBuffer->computeUnorderedAccessViews,
+            command_buffer->computeUnorderedAccessViews,
             NULL);
 
-        commandBuffer->needComputeUAVBind = false;
+        command_buffer->needComputeUAVBind = false;
     }
 
-    if (commandBuffer->needComputeSRVBind) {
+    if (command_buffer->needComputeSRVBind) {
         ID3D11DeviceContext_CSSetShaderResources(
-            commandBuffer->context,
+            command_buffer->context,
             0,
             readOnlyResourceCount,
-            commandBuffer->computeShaderResourceViews);
+            command_buffer->computeShaderResourceViews);
 
-        commandBuffer->needComputeSRVBind = false;
+        command_buffer->needComputeSRVBind = false;
     }
 
-    if (commandBuffer->needComputeUniformBufferBind) {
-        for (i = 0; i < computePipeline->uniformBufferCount; i += 1) {
+    if (command_buffer->needComputeUniformBufferBind) {
+        for (i = 0; i < compute_pipeline->num_uniform_buffers; i += 1) {
             /* stupid workaround for god awful D3D11 drivers
              * see: https://learn.microsoft.com/en-us/windows/win32/api/d3d11_1/nf-d3d11_1-id3d11devicecontext1-vssetconstantbuffers1#calling-vssetconstantbuffers1-with-command-list-emulation
              */
             ID3D11DeviceContext1_CSSetConstantBuffers(
-                commandBuffer->context,
+                command_buffer->context,
                 i,
                 1,
                 &nullBuf);
 
-            offsetInConstants = commandBuffer->computeUniformBuffers[i]->drawOffset / 16;
-            blockSizeInConstants = commandBuffer->computeUniformBuffers[i]->currentBlockSize / 16;
+            offsetInConstants = command_buffer->computeUniformBuffers[i]->drawOffset / 16;
+            blockSizeInConstants = command_buffer->computeUniformBuffers[i]->currentBlockSize / 16;
 
             ID3D11DeviceContext1_CSSetConstantBuffers1(
-                commandBuffer->context,
+                command_buffer->context,
                 i,
                 1,
-                &commandBuffer->computeUniformBuffers[i]->buffer,
+                &command_buffer->computeUniformBuffers[i]->buffer,
                 &offsetInConstants,
                 &blockSizeInConstants);
         }
-        commandBuffer->needComputeUniformBufferBind = false;
+        command_buffer->needComputeUniformBufferBind = false;
     }
 }
 
 static void D3D11_DispatchCompute(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 groupCountX,
-    Uint32 groupCountY,
-    Uint32 groupCountZ)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 groupcount_x,
+    Uint32 groupcount_y,
+    Uint32 groupcount_z)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11_INTERNAL_BindComputeResources(d3d11CommandBuffer);
 
     ID3D11DeviceContext_Dispatch(
         d3d11CommandBuffer->context,
-        groupCountX,
-        groupCountY,
-        groupCountZ);
+        groupcount_x,
+        groupcount_y,
+        groupcount_z);
 }
 
 static void D3D11_DispatchComputeIndirect(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     SDL_GPUBuffer *buffer,
-    Uint32 offsetInBytes)
+    Uint32 offset)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11Buffer *d3d11Buffer = ((D3D11BufferContainer *)buffer)->activeBuffer;
 
     D3D11_INTERNAL_BindComputeResources(d3d11CommandBuffer);
@@ -4425,15 +4425,15 @@ static void D3D11_DispatchComputeIndirect(
     ID3D11DeviceContext_DispatchIndirect(
         d3d11CommandBuffer->context,
         d3d11Buffer->handle,
-        offsetInBytes);
+        offset);
 
     D3D11_INTERNAL_TrackBuffer(d3d11CommandBuffer, d3d11Buffer);
 }
 
 static void D3D11_EndComputePass(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
 
     // reset UAV slots to avoid NULL set behavior
     // https://learn.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11devicecontext-cssetshaderresources
@@ -4444,7 +4444,7 @@ static void D3D11_EndComputePass(
         nullUAVs,
         NULL);
 
-    d3d11CommandBuffer->computePipeline = NULL;
+    d3d11CommandBuffer->compute_pipeline = NULL;
 
     // Reset bind state
     SDL_zeroa(d3d11CommandBuffer->computeUnorderedAccessViews);
@@ -4495,7 +4495,7 @@ static void D3D11_ReleaseFence(
 
 static void D3D11_INTERNAL_MapAndCopyBufferDownload(
     D3D11Renderer *renderer,
-    D3D11TransferBuffer *transferBuffer,
+    D3D11TransferBuffer *transfer_buffer,
     D3D11BufferDownload *bufferDownload)
 {
     D3D11_MAPPED_SUBRESOURCE subres;
@@ -4512,7 +4512,7 @@ static void D3D11_INTERNAL_MapAndCopyBufferDownload(
     ERROR_CHECK_RETURN("Failed to map staging buffer", )
 
     SDL_memcpy(
-        ((Uint8 *)transferBuffer->data) + bufferDownload->dstOffset,
+        ((Uint8 *)transfer_buffer->data) + bufferDownload->dstOffset,
         ((Uint8 *)subres.pData),
         bufferDownload->size);
 
@@ -4527,7 +4527,7 @@ static void D3D11_INTERNAL_MapAndCopyBufferDownload(
 
 static void D3D11_INTERNAL_MapAndCopyTextureDownload(
     D3D11Renderer *renderer,
-    D3D11TransferBuffer *transferBuffer,
+    D3D11TransferBuffer *transfer_buffer,
     D3D11TextureDownload *textureDownload)
 {
     D3D11_MAPPED_SUBRESOURCE subres;
@@ -4550,7 +4550,7 @@ static void D3D11_INTERNAL_MapAndCopyTextureDownload(
 
         for (row = 0; row < textureDownload->height; row += 1) {
             SDL_memcpy(
-                transferBuffer->data + dataPtrOffset,
+                transfer_buffer->data + dataPtrOffset,
                 (Uint8 *)subres.pData + (depth * subres.DepthPitch) + (row * subres.RowPitch),
                 textureDownload->bytesPerRow);
             dataPtrOffset += textureDownload->bytesPerRow;
@@ -4569,71 +4569,71 @@ static void D3D11_INTERNAL_MapAndCopyTextureDownload(
 
 static void D3D11_INTERNAL_CleanCommandBuffer(
     D3D11Renderer *renderer,
-    D3D11CommandBuffer *commandBuffer)
+    D3D11CommandBuffer *command_buffer)
 {
     Uint32 i, j;
 
     // Perform deferred download map and copy
 
-    for (i = 0; i < commandBuffer->usedTransferBufferCount; i += 1) {
-        D3D11TransferBuffer *transferBuffer = commandBuffer->usedTransferBuffers[i];
+    for (i = 0; i < command_buffer->usedTransferBufferCount; i += 1) {
+        D3D11TransferBuffer *transfer_buffer = command_buffer->usedTransferBuffers[i];
 
-        for (j = 0; j < transferBuffer->bufferDownloadCount; j += 1) {
+        for (j = 0; j < transfer_buffer->bufferDownloadCount; j += 1) {
             D3D11_INTERNAL_MapAndCopyBufferDownload(
                 renderer,
-                transferBuffer,
-                &transferBuffer->bufferDownloads[j]);
+                transfer_buffer,
+                &transfer_buffer->bufferDownloads[j]);
         }
 
-        for (j = 0; j < transferBuffer->textureDownloadCount; j += 1) {
+        for (j = 0; j < transfer_buffer->textureDownloadCount; j += 1) {
             D3D11_INTERNAL_MapAndCopyTextureDownload(
                 renderer,
-                transferBuffer,
-                &transferBuffer->textureDownloads[j]);
+                transfer_buffer,
+                &transfer_buffer->textureDownloads[j]);
         }
 
-        transferBuffer->bufferDownloadCount = 0;
-        transferBuffer->textureDownloadCount = 0;
+        transfer_buffer->bufferDownloadCount = 0;
+        transfer_buffer->textureDownloadCount = 0;
     }
 
     // Uniform buffers are now available
 
     SDL_LockMutex(renderer->acquireUniformBufferLock);
 
-    for (i = 0; i < commandBuffer->usedUniformBufferCount; i += 1) {
+    for (i = 0; i < command_buffer->usedUniformBufferCount; i += 1) {
         D3D11_INTERNAL_ReturnUniformBufferToPool(
             renderer,
-            commandBuffer->usedUniformBuffers[i]);
+            command_buffer->usedUniformBuffers[i]);
     }
-    commandBuffer->usedUniformBufferCount = 0;
+    command_buffer->usedUniformBufferCount = 0;
 
     SDL_UnlockMutex(renderer->acquireUniformBufferLock);
 
     // Reference Counting
 
-    for (i = 0; i < commandBuffer->usedBufferCount; i += 1) {
-        (void)SDL_AtomicDecRef(&commandBuffer->usedBuffers[i]->referenceCount);
+    for (i = 0; i < command_buffer->usedBufferCount; i += 1) {
+        (void)SDL_AtomicDecRef(&command_buffer->usedBuffers[i]->referenceCount);
     }
-    commandBuffer->usedBufferCount = 0;
+    command_buffer->usedBufferCount = 0;
 
-    for (i = 0; i < commandBuffer->usedTransferBufferCount; i += 1) {
-        (void)SDL_AtomicDecRef(&commandBuffer->usedTransferBuffers[i]->referenceCount);
+    for (i = 0; i < command_buffer->usedTransferBufferCount; i += 1) {
+        (void)SDL_AtomicDecRef(&command_buffer->usedTransferBuffers[i]->referenceCount);
     }
-    commandBuffer->usedTransferBufferCount = 0;
+    command_buffer->usedTransferBufferCount = 0;
 
-    for (i = 0; i < commandBuffer->usedTextureCount; i += 1) {
-        (void)SDL_AtomicDecRef(&commandBuffer->usedTextures[i]->referenceCount);
+    for (i = 0; i < command_buffer->usedTextureCount; i += 1) {
+        (void)SDL_AtomicDecRef(&command_buffer->usedTextures[i]->referenceCount);
     }
-    commandBuffer->usedTextureCount = 0;
+    command_buffer->usedTextureCount = 0;
 
     // Reset presentation
-    commandBuffer->windowDataCount = 0;
+    command_buffer->windowDataCount = 0;
 
     // The fence is now available (unless SubmitAndAcquireFence was called)
-    if (commandBuffer->autoReleaseFence) {
+    if (command_buffer->autoReleaseFence) {
         D3D11_ReleaseFence(
             (SDL_GPURenderer *)renderer,
-            (SDL_GPUFence *)commandBuffer->fence);
+            (SDL_GPUFence *)command_buffer->fence);
     }
 
     // Return command buffer to pool
@@ -4644,13 +4644,13 @@ static void D3D11_INTERNAL_CleanCommandBuffer(
             renderer->availableCommandBuffers,
             renderer->availableCommandBufferCapacity * sizeof(D3D11CommandBuffer *));
     }
-    renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = commandBuffer;
+    renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = command_buffer;
     renderer->availableCommandBufferCount += 1;
     SDL_UnlockMutex(renderer->acquireCommandBufferLock);
 
     // Remove this command buffer from the submitted list
     for (i = 0; i < renderer->submittedCommandBufferCount; i += 1) {
-        if (renderer->submittedCommandBuffers[i] == commandBuffer) {
+        if (renderer->submittedCommandBuffers[i] == command_buffer) {
             renderer->submittedCommandBuffers[i] = renderer->submittedCommandBuffers[renderer->submittedCommandBufferCount - 1];
             renderer->submittedCommandBufferCount -= 1;
         }
@@ -4735,26 +4735,26 @@ static void D3D11_INTERNAL_WaitForFence(
 
 static void D3D11_WaitForFences(
     SDL_GPURenderer *driverData,
-    bool waitAll,
-    SDL_GPUFence *const *pFences,
-    Uint32 fenceCount)
+    bool wait_all,
+    SDL_GPUFence *const *fences,
+    Uint32 num_fences)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
     D3D11Fence *fence;
     BOOL queryData;
     HRESULT res = S_FALSE;
 
-    if (waitAll) {
-        for (Uint32 i = 0; i < fenceCount; i += 1) {
-            fence = (D3D11Fence *)pFences[i];
+    if (wait_all) {
+        for (Uint32 i = 0; i < num_fences; i += 1) {
+            fence = (D3D11Fence *)fences[i];
             D3D11_INTERNAL_WaitForFence(renderer, fence);
         }
     } else {
         SDL_LockMutex(renderer->contextLock);
 
         while (res != S_OK) {
-            for (Uint32 i = 0; i < fenceCount; i += 1) {
-                fence = (D3D11Fence *)pFences[i];
+            for (Uint32 i = 0; i < num_fences; i += 1) {
+                fence = (D3D11Fence *)fences[i];
                 res = ID3D11DeviceContext_GetData(
                     renderer->immediateContext,
                     (ID3D11Asynchronous *)fence->handle,
@@ -4892,8 +4892,8 @@ static bool D3D11_INTERNAL_InitializeSwapchainTexture(
 static bool D3D11_INTERNAL_CreateSwapchain(
     D3D11Renderer *renderer,
     D3D11WindowData *windowData,
-    SDL_GPUSwapchainComposition swapchainComposition,
-    SDL_GPUPresentMode presentMode)
+    SDL_GPUSwapchainComposition swapchain_composition,
+    SDL_GPUPresentMode present_mode)
 {
     HWND dxgiHandle;
     int width, height;
@@ -4915,7 +4915,7 @@ static bool D3D11_INTERNAL_CreateSwapchain(
     // Get the window size
     SDL_GetWindowSize(windowData->window, &width, &height);
 
-    swapchainFormat = SwapchainCompositionToTextureFormat[swapchainComposition];
+    swapchainFormat = SwapchainCompositionToTextureFormat[swapchain_composition];
 
     // Initialize the swapchain buffer descriptor
     swapchainDesc.BufferDesc.Width = 0;
@@ -4984,7 +4984,7 @@ static bool D3D11_INTERNAL_CreateSwapchain(
         IDXGIFactory1_Release(pParent);
     }
 
-    if (swapchainComposition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR) {
+    if (swapchain_composition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR) {
         // Set the color space, support already verified if we hit this block
         IDXGISwapChain3_QueryInterface(
             swapchain,
@@ -4993,17 +4993,17 @@ static bool D3D11_INTERNAL_CreateSwapchain(
 
         IDXGISwapChain3_SetColorSpace1(
             swapchain3,
-            SwapchainCompositionToColorSpace[swapchainComposition]);
+            SwapchainCompositionToColorSpace[swapchain_composition]);
 
         IDXGISwapChain3_Release(swapchain3);
     }
 
     // Initialize the swapchain data
     windowData->swapchain = swapchain;
-    windowData->presentMode = presentMode;
-    windowData->swapchainComposition = swapchainComposition;
+    windowData->present_mode = present_mode;
+    windowData->swapchain_composition = swapchain_composition;
     windowData->swapchainFormat = swapchainFormat;
-    windowData->swapchainColorSpace = SwapchainCompositionToColorSpace[swapchainComposition];
+    windowData->swapchainColorSpace = SwapchainCompositionToColorSpace[swapchain_composition];
     windowData->frameCounter = 0;
 
     for (i = 0; i < MAX_FRAMES_IN_FLIGHT; i += 1) {
@@ -5017,7 +5017,7 @@ static bool D3D11_INTERNAL_CreateSwapchain(
             renderer,
             swapchain,
             swapchainFormat,
-            (swapchainComposition == SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR) ? DXGI_FORMAT_B8G8R8A8_UNORM_SRGB : windowData->swapchainFormat,
+            (swapchain_composition == SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR) ? DXGI_FORMAT_B8G8R8A8_UNORM_SRGB : windowData->swapchainFormat,
             &windowData->texture)) {
         IDXGISwapChain_Release(swapchain);
         return false;
@@ -5032,12 +5032,12 @@ static bool D3D11_INTERNAL_CreateSwapchain(
     windowData->textureContainer.textureCount = 1;
     windowData->textureContainer.textureCapacity = 1;
 
-    windowData->textureContainer.header.info.layerCountOrDepth = 1;
-    windowData->textureContainer.header.info.format = SwapchainCompositionToSDLTextureFormat[windowData->swapchainComposition];
+    windowData->textureContainer.header.info.layer_count_or_depth = 1;
+    windowData->textureContainer.header.info.format = SwapchainCompositionToSDLTextureFormat[windowData->swapchain_composition];
     windowData->textureContainer.header.info.type = SDL_GPU_TEXTURETYPE_2D;
-    windowData->textureContainer.header.info.levelCount = 1;
-    windowData->textureContainer.header.info.sampleCount = SDL_GPU_SAMPLECOUNT_1;
-    windowData->textureContainer.header.info.usageFlags = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
+    windowData->textureContainer.header.info.num_levels = 1;
+    windowData->textureContainer.header.info.sample_count = SDL_GPU_SAMPLECOUNT_1;
+    windowData->textureContainer.header.info.usage_flags = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
 
     windowData->texture.container = &windowData->textureContainer;
     windowData->texture.containerIndex = 0;
@@ -5071,14 +5071,14 @@ static bool D3D11_INTERNAL_ResizeSwapchain(
         renderer,
         windowData->swapchain,
         windowData->swapchainFormat,
-        (windowData->swapchainComposition == SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR) ? DXGI_FORMAT_B8G8R8A8_UNORM_SRGB : windowData->swapchainFormat,
+        (windowData->swapchain_composition == SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR) ? DXGI_FORMAT_B8G8R8A8_UNORM_SRGB : windowData->swapchainFormat,
         &windowData->texture);
 }
 
 static bool D3D11_SupportsSwapchainComposition(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchainComposition)
+    SDL_GPUSwapchainComposition swapchain_composition)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
     DXGI_FORMAT format;
@@ -5087,7 +5087,7 @@ static bool D3D11_SupportsSwapchainComposition(
     Uint32 colorSpaceSupport;
     HRESULT res;
 
-    format = SwapchainCompositionToTextureFormat[swapchainComposition];
+    format = SwapchainCompositionToTextureFormat[swapchain_composition];
 
     res = ID3D11Device_CheckFormatSupport(
         renderer->device,
@@ -5109,14 +5109,14 @@ static bool D3D11_SupportsSwapchainComposition(
     }
 
     // Check the color space support if necessary
-    if (swapchainComposition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR) {
+    if (swapchain_composition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR) {
         if (SUCCEEDED(IDXGISwapChain3_QueryInterface(
                 windowData->swapchain,
                 &D3D_IID_IDXGISwapChain3,
                 (void **)&swapchain3))) {
             IDXGISwapChain3_CheckColorSpaceSupport(
                 swapchain3,
-                SwapchainCompositionToColorSpace[swapchainComposition],
+                SwapchainCompositionToColorSpace[swapchain_composition],
                 &colorSpaceSupport);
 
             IDXGISwapChain3_Release(swapchain3);
@@ -5136,11 +5136,11 @@ static bool D3D11_SupportsSwapchainComposition(
 static bool D3D11_SupportsPresentMode(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUPresentMode presentMode)
+    SDL_GPUPresentMode present_mode)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
     (void)window; // used by other backends
-    switch (presentMode) {
+    switch (present_mode) {
     case SDL_GPU_PRESENTMODE_IMMEDIATE:
     case SDL_GPU_PRESENTMODE_VSYNC:
         return true;
@@ -5252,16 +5252,16 @@ static void D3D11_ReleaseWindow(
 }
 
 static SDL_GPUTexture *D3D11_AcquireSwapchainTexture(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     SDL_Window *window,
-    Uint32 *pWidth,
-    Uint32 *pHeight)
+    Uint32 *w,
+    Uint32 *h)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
     D3D11WindowData *windowData;
     DXGI_SWAP_CHAIN_DESC swapchainDesc;
-    int w, h;
+    int windowW, windowH;
     HRESULT res;
 
     windowData = D3D11_INTERNAL_FetchWindowData(window);
@@ -5271,19 +5271,20 @@ static SDL_GPUTexture *D3D11_AcquireSwapchainTexture(
 
     // Check for window size changes and resize the swapchain if needed.
     IDXGISwapChain_GetDesc(windowData->swapchain, &swapchainDesc);
-    SDL_GetWindowSize(window, &w, &h);
+    SDL_GetWindowSize(window, &windowW, &windowH);
+    SDL_Log("%d x %d", windowW, windowH);
 
-    if ((UINT)w != swapchainDesc.BufferDesc.Width || (UINT)h != swapchainDesc.BufferDesc.Height) {
+    if ((UINT)windowW != swapchainDesc.BufferDesc.Width || (UINT)windowH != swapchainDesc.BufferDesc.Height) {
         res = D3D11_INTERNAL_ResizeSwapchain(
             renderer,
             windowData,
-            w,
-            h);
+            windowW,
+            windowH);
         ERROR_CHECK_RETURN("Could not resize swapchain", NULL);
     }
 
     if (windowData->inFlightFences[windowData->frameCounter] != NULL) {
-        if (windowData->presentMode == SDL_GPU_PRESENTMODE_VSYNC) {
+        if (windowData->present_mode == SDL_GPU_PRESENTMODE_VSYNC) {
             // In VSYNC mode, block until the least recent presented frame is done
             D3D11_WaitForFences(
                 (SDL_GPURenderer *)renderer,
@@ -5318,12 +5319,12 @@ static SDL_GPUTexture *D3D11_AcquireSwapchainTexture(
     ERROR_CHECK_RETURN("Could not acquire swapchain!", NULL);
 
     // Send the dimensions to the out parameters.
-    *pWidth = w;
-    *pHeight = h;
+    *w = windowW;
+    *h = windowH;
 
     // Update the texture container dimensions
-    windowData->textureContainer.header.info.width = w;
-    windowData->textureContainer.header.info.height = h;
+    windowData->textureContainer.header.info.width = windowW;
+    windowData->textureContainer.header.info.height = windowH;
 
     // Set up presentation
     if (d3d11CommandBuffer->windowDataCount == d3d11CommandBuffer->windowDataCapacity) {
@@ -5356,8 +5357,8 @@ static SDL_GPUTextureFormat D3D11_GetSwapchainTextureFormat(
 static bool D3D11_SetSwapchainParameters(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchainComposition,
-    SDL_GPUPresentMode presentMode)
+    SDL_GPUSwapchainComposition swapchain_composition,
+    SDL_GPUPresentMode present_mode)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
     D3D11WindowData *windowData = D3D11_INTERNAL_FetchWindowData(window);
@@ -5367,19 +5368,19 @@ static bool D3D11_SetSwapchainParameters(
         return false;
     }
 
-    if (!D3D11_SupportsSwapchainComposition(driverData, window, swapchainComposition)) {
+    if (!D3D11_SupportsSwapchainComposition(driverData, window, swapchain_composition)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Swapchain composition not supported!");
         return false;
     }
 
-    if (!D3D11_SupportsPresentMode(driverData, window, presentMode)) {
+    if (!D3D11_SupportsPresentMode(driverData, window, present_mode)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Present mode not supported!");
         return false;
     }
 
     if (
-        swapchainComposition != windowData->swapchainComposition ||
-        presentMode != windowData->presentMode) {
+        swapchain_composition != windowData->swapchain_composition ||
+        present_mode != windowData->present_mode) {
         D3D11_Wait(driverData);
 
         // Recreate the swapchain
@@ -5390,8 +5391,8 @@ static bool D3D11_SetSwapchainParameters(
         return D3D11_INTERNAL_CreateSwapchain(
             renderer,
             windowData,
-            swapchainComposition,
-            presentMode);
+            swapchain_composition,
+            present_mode);
     }
 
     return true;
@@ -5400,9 +5401,9 @@ static bool D3D11_SetSwapchainParameters(
 // Submission
 
 static void D3D11_Submit(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11Renderer *renderer = (D3D11Renderer *)d3d11CommandBuffer->renderer;
     ID3D11CommandList *commandList;
     HRESULT res;
@@ -5470,14 +5471,14 @@ static void D3D11_Submit(
         D3D11WindowData *windowData = d3d11CommandBuffer->windowDatas[i];
 
         Uint32 syncInterval = 1;
-        if (windowData->presentMode == SDL_GPU_PRESENTMODE_IMMEDIATE ||
-            (renderer->supportsFlipDiscard && windowData->presentMode == SDL_GPU_PRESENTMODE_MAILBOX)) {
+        if (windowData->present_mode == SDL_GPU_PRESENTMODE_IMMEDIATE ||
+            (renderer->supportsFlipDiscard && windowData->present_mode == SDL_GPU_PRESENTMODE_MAILBOX)) {
             syncInterval = 0;
         }
 
         Uint32 presentFlags = 0;
         if (renderer->supportsTearing &&
-            windowData->presentMode == SDL_GPU_PRESENTMODE_IMMEDIATE) {
+            windowData->present_mode == SDL_GPU_PRESENTMODE_IMMEDIATE) {
             presentFlags = DXGI_PRESENT_ALLOW_TEARING;
         }
 
@@ -5517,13 +5518,13 @@ static void D3D11_Submit(
 }
 
 static SDL_GPUFence *D3D11_SubmitAndAcquireFence(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
-    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)commandBuffer;
+    D3D11CommandBuffer *d3d11CommandBuffer = (D3D11CommandBuffer *)command_buffer;
     D3D11Fence *fence = d3d11CommandBuffer->fence;
 
     d3d11CommandBuffer->autoReleaseFence = 0;
-    D3D11_Submit(commandBuffer);
+    D3D11_Submit(command_buffer);
 
     return (SDL_GPUFence *)fence;
 }
@@ -5532,7 +5533,7 @@ static void D3D11_Wait(
     SDL_GPURenderer *driverData)
 {
     D3D11Renderer *renderer = (D3D11Renderer *)driverData;
-    D3D11CommandBuffer *commandBuffer;
+    D3D11CommandBuffer *command_buffer;
 
     /*
      * Wait for all submitted command buffers to complete.
@@ -5547,8 +5548,8 @@ static void D3D11_Wait(
     SDL_LockMutex(renderer->contextLock); // This effectively acts as a lock around submittedCommandBuffers
 
     for (Sint32 i = renderer->submittedCommandBufferCount - 1; i >= 0; i -= 1) {
-        commandBuffer = renderer->submittedCommandBuffers[i];
-        D3D11_INTERNAL_CleanCommandBuffer(renderer, commandBuffer);
+        command_buffer = renderer->submittedCommandBuffers[i];
+        D3D11_INTERNAL_CleanCommandBuffer(renderer, command_buffer);
     }
 
     D3D11_INTERNAL_PerformPendingDestroys(renderer);
@@ -5744,10 +5745,10 @@ static void D3D11_INTERNAL_InitBlitPipelines(
     // Fullscreen vertex shader
     SDL_zero(shaderCreateInfo);
     shaderCreateInfo.code = (Uint8 *)D3D11_FullscreenVert;
-    shaderCreateInfo.codeSize = sizeof(D3D11_FullscreenVert);
+    shaderCreateInfo.code_size = sizeof(D3D11_FullscreenVert);
     shaderCreateInfo.stage = SDL_GPU_SHADERSTAGE_VERTEX;
     shaderCreateInfo.format = SDL_GPU_SHADERFORMAT_DXBC;
-    shaderCreateInfo.entryPointName = "main";
+    shaderCreateInfo.entrypoint_name = "main";
 
     fullscreenVertexShader = D3D11_CreateShader(
         (SDL_GPURenderer *)renderer,
@@ -5759,10 +5760,10 @@ static void D3D11_INTERNAL_InitBlitPipelines(
 
     // BlitFrom2D pixel shader
     shaderCreateInfo.code = (Uint8 *)D3D11_BlitFrom2D;
-    shaderCreateInfo.codeSize = sizeof(D3D11_BlitFrom2D);
+    shaderCreateInfo.code_size = sizeof(D3D11_BlitFrom2D);
     shaderCreateInfo.stage = SDL_GPU_SHADERSTAGE_FRAGMENT;
-    shaderCreateInfo.samplerCount = 1;
-    shaderCreateInfo.uniformBufferCount = 1;
+    shaderCreateInfo.num_samplers = 1;
+    shaderCreateInfo.num_uniform_buffers = 1;
 
     blitFrom2DPixelShader = D3D11_CreateShader(
         (SDL_GPURenderer *)renderer,
@@ -5774,7 +5775,7 @@ static void D3D11_INTERNAL_InitBlitPipelines(
 
     // BlitFrom2DArray pixel shader
     shaderCreateInfo.code = (Uint8 *)D3D11_BlitFrom2DArray;
-    shaderCreateInfo.codeSize = sizeof(D3D11_BlitFrom2DArray);
+    shaderCreateInfo.code_size = sizeof(D3D11_BlitFrom2DArray);
 
     blitFrom2DArrayPixelShader = D3D11_CreateShader(
         (SDL_GPURenderer *)renderer,
@@ -5786,7 +5787,7 @@ static void D3D11_INTERNAL_InitBlitPipelines(
 
     // BlitFrom3D pixel shader
     shaderCreateInfo.code = (Uint8 *)D3D11_BlitFrom3D;
-    shaderCreateInfo.codeSize = sizeof(D3D11_BlitFrom3D);
+    shaderCreateInfo.code_size = sizeof(D3D11_BlitFrom3D);
 
     blitFrom3DPixelShader = D3D11_CreateShader(
         (SDL_GPURenderer *)renderer,
@@ -5798,7 +5799,7 @@ static void D3D11_INTERNAL_InitBlitPipelines(
 
     // BlitFromCube pixel shader
     shaderCreateInfo.code = (Uint8 *)D3D11_BlitFromCube;
-    shaderCreateInfo.codeSize = sizeof(D3D11_BlitFromCube);
+    shaderCreateInfo.code_size = sizeof(D3D11_BlitFromCube);
 
     blitFromCubePixelShader = D3D11_CreateShader(
         (SDL_GPURenderer *)renderer,
@@ -5812,21 +5813,21 @@ static void D3D11_INTERNAL_InitBlitPipelines(
     SDL_zero(blitPipelineCreateInfo);
 
     SDL_zero(colorAttachmentDesc);
-    colorAttachmentDesc.blendState.colorWriteMask = 0xF;
+    colorAttachmentDesc.blend_state.color_write_mask = 0xF;
     colorAttachmentDesc.format = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM; // format doesn't matter in d3d11
 
-    blitPipelineCreateInfo.attachmentInfo.colorAttachmentDescriptions = &colorAttachmentDesc;
-    blitPipelineCreateInfo.attachmentInfo.colorAttachmentCount = 1;
-    blitPipelineCreateInfo.attachmentInfo.depthStencilFormat = SDL_GPU_TEXTUREFORMAT_D16_UNORM; // arbitrary
-    blitPipelineCreateInfo.attachmentInfo.hasDepthStencilAttachment = false;
+    blitPipelineCreateInfo.attachment_info.color_attachment_descriptions = &colorAttachmentDesc;
+    blitPipelineCreateInfo.attachment_info.num_color_attachments = 1;
+    blitPipelineCreateInfo.attachment_info.depth_stencil_format = SDL_GPU_TEXTUREFORMAT_D16_UNORM; // arbitrary
+    blitPipelineCreateInfo.attachment_info.has_depth_stencil_attachment = false;
 
-    blitPipelineCreateInfo.vertexShader = fullscreenVertexShader;
-    blitPipelineCreateInfo.fragmentShader = blitFrom2DPixelShader;
+    blitPipelineCreateInfo.vertex_shader = fullscreenVertexShader;
+    blitPipelineCreateInfo.fragment_shader = blitFrom2DPixelShader;
 
-    blitPipelineCreateInfo.multisampleState.sampleCount = SDL_GPU_SAMPLECOUNT_1;
-    blitPipelineCreateInfo.multisampleState.sampleMask = 0xFFFFFFFF;
+    blitPipelineCreateInfo.multisample_state.sample_count = SDL_GPU_SAMPLECOUNT_1;
+    blitPipelineCreateInfo.multisample_state.sample_mask = 0xFFFFFFFF;
 
-    blitPipelineCreateInfo.primitiveType = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
+    blitPipelineCreateInfo.primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
 
     blitPipeline = D3D11_CreateGraphicsPipeline(
         (SDL_GPURenderer *)renderer,
@@ -5841,7 +5842,7 @@ static void D3D11_INTERNAL_InitBlitPipelines(
     renderer->blitPipelines[SDL_GPU_TEXTURETYPE_2D].format = SDL_GPU_TEXTUREFORMAT_INVALID;
 
     // BlitFrom2DArrayPipeline
-    blitPipelineCreateInfo.fragmentShader = blitFrom2DArrayPixelShader;
+    blitPipelineCreateInfo.fragment_shader = blitFrom2DArrayPixelShader;
     blitPipeline = D3D11_CreateGraphicsPipeline(
         (SDL_GPURenderer *)renderer,
         &blitPipelineCreateInfo);
@@ -5855,7 +5856,7 @@ static void D3D11_INTERNAL_InitBlitPipelines(
     renderer->blitPipelines[SDL_GPU_TEXTURETYPE_2D_ARRAY].format = SDL_GPU_TEXTUREFORMAT_INVALID;
 
     // BlitFrom3DPipeline
-    blitPipelineCreateInfo.fragmentShader = blitFrom3DPixelShader;
+    blitPipelineCreateInfo.fragment_shader = blitFrom3DPixelShader;
     blitPipeline = D3D11_CreateGraphicsPipeline(
         (SDL_GPURenderer *)renderer,
         &blitPipelineCreateInfo);
@@ -5869,7 +5870,7 @@ static void D3D11_INTERNAL_InitBlitPipelines(
     renderer->blitPipelines[SDL_GPU_TEXTURETYPE_3D].format = SDL_GPU_TEXTUREFORMAT_INVALID;
 
     // BlitFromCubePipeline
-    blitPipelineCreateInfo.fragmentShader = blitFromCubePixelShader;
+    blitPipelineCreateInfo.fragment_shader = blitFromCubePixelShader;
     blitPipeline = D3D11_CreateGraphicsPipeline(
         (SDL_GPURenderer *)renderer,
         &blitPipelineCreateInfo);
@@ -5883,17 +5884,17 @@ static void D3D11_INTERNAL_InitBlitPipelines(
     renderer->blitPipelines[SDL_GPU_TEXTURETYPE_CUBE].format = SDL_GPU_TEXTUREFORMAT_INVALID;
 
     // Create samplers
-    samplerCreateInfo.addressModeU = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-    samplerCreateInfo.addressModeV = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-    samplerCreateInfo.addressModeW = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-    samplerCreateInfo.anisotropyEnable = 0;
-    samplerCreateInfo.compareEnable = 0;
-    samplerCreateInfo.magFilter = SDL_GPU_FILTER_NEAREST;
-    samplerCreateInfo.minFilter = SDL_GPU_FILTER_NEAREST;
-    samplerCreateInfo.mipmapMode = SDL_GPU_SAMPLERMIPMAPMODE_NEAREST;
-    samplerCreateInfo.mipLodBias = 0.0f;
-    samplerCreateInfo.minLod = 0;
-    samplerCreateInfo.maxLod = 1000;
+    samplerCreateInfo.address_mode_u = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+    samplerCreateInfo.address_mode_v = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+    samplerCreateInfo.address_mode_w = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+    samplerCreateInfo.enable_anisotropy = 0;
+    samplerCreateInfo.enable_compare = 0;
+    samplerCreateInfo.mag_filter = SDL_GPU_FILTER_NEAREST;
+    samplerCreateInfo.min_filter = SDL_GPU_FILTER_NEAREST;
+    samplerCreateInfo.mipmap_mode = SDL_GPU_SAMPLERMIPMAPMODE_NEAREST;
+    samplerCreateInfo.mip_lod_bias = 0.0f;
+    samplerCreateInfo.min_lod = 0;
+    samplerCreateInfo.max_lod = 1000;
 
     renderer->blitNearestSampler = D3D11_CreateSampler(
         (SDL_GPURenderer *)renderer,
@@ -5903,9 +5904,9 @@ static void D3D11_INTERNAL_InitBlitPipelines(
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create blit nearest sampler!");
     }
 
-    samplerCreateInfo.magFilter = SDL_GPU_FILTER_LINEAR;
-    samplerCreateInfo.minFilter = SDL_GPU_FILTER_LINEAR;
-    samplerCreateInfo.mipmapMode = SDL_GPU_SAMPLERMIPMAPMODE_LINEAR;
+    samplerCreateInfo.mag_filter = SDL_GPU_FILTER_LINEAR;
+    samplerCreateInfo.min_filter = SDL_GPU_FILTER_LINEAR;
+    samplerCreateInfo.mipmap_mode = SDL_GPU_SAMPLERMIPMAPMODE_LINEAR;
 
     renderer->blitLinearSampler = D3D11_CreateSampler(
         (SDL_GPURenderer *)renderer,
@@ -5934,7 +5935,7 @@ static void D3D11_INTERNAL_DestroyBlitPipelines(
     }
 }
 
-static SDL_GPUDevice *D3D11_CreateDevice(bool debugMode, bool preferLowPower, SDL_PropertiesID props)
+static SDL_GPUDevice *D3D11_CreateDevice(bool debug_mode, bool preferLowPower, SDL_PropertiesID props)
 {
     D3D11Renderer *renderer;
     PFN_CREATE_DXGI_FACTORY1 CreateDXGIFactoryFunc;
@@ -6024,7 +6025,7 @@ static SDL_GPUDevice *D3D11_CreateDevice(bool debugMode, bool preferLowPower, SD
     IDXGIAdapter1_GetDesc1(renderer->adapter, &adapterDesc);
 
     // Initialize the DXGI debug layer, if applicable
-    if (debugMode) {
+    if (debug_mode) {
         D3D11_INTERNAL_TryInitializeDXGIDebug(renderer);
     }
 
@@ -6046,7 +6047,7 @@ static SDL_GPUDevice *D3D11_CreateDevice(bool debugMode, bool preferLowPower, SD
 
     // Set up device flags
     flags = D3D11_CREATE_DEVICE_BGRA_SUPPORT;
-    if (debugMode) {
+    if (debug_mode) {
         flags |= D3D11_CREATE_DEVICE_DEBUG;
     }
 
@@ -6064,11 +6065,11 @@ tryCreateDevice:
         &d3d11Device,
         NULL,
         &renderer->immediateContext);
-    if (FAILED(res) && debugMode) {
+    if (FAILED(res) && debug_mode) {
         // If device creation failed, and we're in debug mode, remove the debug flag and try again.
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "Creating device in debug mode failed with error " HRESULT_FMT ". Trying non-debug.", res);
         flags &= ~D3D11_CREATE_DEVICE_DEBUG;
-        debugMode = 0;
+        debug_mode = 0;
         goto tryCreateDevice;
     }
 
@@ -6117,7 +6118,7 @@ tryCreateDevice:
     renderer->windowLock = SDL_CreateMutex();
 
     // Initialize miscellaneous renderer members
-    renderer->debugMode = (flags & D3D11_CREATE_DEVICE_DEBUG);
+    renderer->debug_mode = (flags & D3D11_CREATE_DEVICE_DEBUG);
 
     // Create command buffer pool
     D3D11_INTERNAL_AllocateCommandBuffers(renderer, 2);

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -1632,24 +1632,24 @@ static void D3D12_INTERNAL_BufferTransitionToDefaultUsage(
 #define TRACK_RESOURCE(resource, type, array, count, capacity) \
     Uint32 i;                                                  \
                                                                \
-    for (i = 0; i < command_buffer->count; i += 1) {            \
-        if (command_buffer->array[i] == resource) {             \
+    for (i = 0; i < commandBuffer->count; i += 1) {            \
+        if (commandBuffer->array[i] == resource) {             \
             return;                                            \
         }                                                      \
     }                                                          \
                                                                \
-    if (command_buffer->count == command_buffer->capacity) {     \
-        command_buffer->capacity += 1;                          \
-        command_buffer->array = (type *)SDL_realloc(            \
-            command_buffer->array,                              \
-            command_buffer->capacity * sizeof(type));           \
+    if (commandBuffer->count == commandBuffer->capacity) {     \
+        commandBuffer->capacity += 1;                          \
+        commandBuffer->array = (type *)SDL_realloc(            \
+            commandBuffer->array,                              \
+            commandBuffer->capacity * sizeof(type));           \
     }                                                          \
-    command_buffer->array[command_buffer->count] = resource;     \
-    command_buffer->count += 1;                                 \
+    commandBuffer->array[commandBuffer->count] = resource;     \
+    commandBuffer->count += 1;                                 \
     SDL_AtomicIncRef(&resource->referenceCount);
 
 static void D3D12_INTERNAL_TrackTexture(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12Texture *texture)
 {
     TRACK_RESOURCE(
@@ -1661,7 +1661,7 @@ static void D3D12_INTERNAL_TrackTexture(
 }
 
 static void D3D12_INTERNAL_TrackBuffer(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12Buffer *buffer)
 {
     TRACK_RESOURCE(
@@ -1673,7 +1673,7 @@ static void D3D12_INTERNAL_TrackBuffer(
 }
 
 static void D3D12_INTERNAL_TrackSampler(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12Sampler *sampler)
 {
     TRACK_RESOURCE(
@@ -1685,7 +1685,7 @@ static void D3D12_INTERNAL_TrackSampler(
 }
 
 static void D3D12_INTERNAL_TrackGraphicsPipeline(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12GraphicsPipeline *graphicsPipeline)
 {
     TRACK_RESOURCE(
@@ -1697,7 +1697,7 @@ static void D3D12_INTERNAL_TrackGraphicsPipeline(
 }
 
 static void D3D12_INTERNAL_TrackComputePipeline(
-    D3D12CommandBuffer *command_buffer,
+    D3D12CommandBuffer *commandBuffer,
     D3D12ComputePipeline *computePipeline)
 {
     TRACK_RESOURCE(

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -384,16 +384,16 @@ static D3D12_TEXTURE_ADDRESS_MODE SDLToD3D12_SamplerAddressMode[] = {
 };
 
 static D3D12_FILTER SDLToD3D12_Filter(
-    SDL_GPUFilter minFilter,
-    SDL_GPUFilter magFilter,
-    SDL_GPUSamplerMipmapMode mipmapMode,
+    SDL_GPUFilter min_filter,
+    SDL_GPUFilter mag_filter,
+    SDL_GPUSamplerMipmapMode mipmap_mode,
     bool comparisonEnabled,
     bool anisotropyEnabled)
 {
     D3D12_FILTER result = D3D12_ENCODE_BASIC_FILTER(
-        (minFilter == SDL_GPU_FILTER_LINEAR) ? 1 : 0,
-        (magFilter == SDL_GPU_FILTER_LINEAR) ? 1 : 0,
-        (mipmapMode == SDL_GPU_SAMPLERMIPMAPMODE_LINEAR) ? 1 : 0,
+        (min_filter == SDL_GPU_FILTER_LINEAR) ? 1 : 0,
+        (mag_filter == SDL_GPU_FILTER_LINEAR) ? 1 : 0,
+        (mipmap_mode == SDL_GPU_SAMPLERMIPMAPMODE_LINEAR) ? 1 : 0,
         comparisonEnabled ? 1 : 0);
 
     if (anisotropyEnabled) {
@@ -493,7 +493,7 @@ struct D3D12Texture
     Uint32 containerIndex;
 
     D3D12TextureSubresource *subresources;
-    Uint32 subresourceCount; /* layerCount * levelCount */
+    Uint32 subresourceCount; /* layerCount * num_levels */
 
     ID3D12Resource *resource;
     D3D12CPUDescriptor srvHandle;
@@ -517,8 +517,8 @@ typedef struct D3D12WindowData
 #else
     IDXGISwapChain3 *swapchain;
 #endif
-    SDL_GPUPresentMode presentMode;
-    SDL_GPUSwapchainComposition swapchainComposition;
+    SDL_GPUPresentMode present_mode;
+    SDL_GPUSwapchainComposition swapchain_composition;
     DXGI_COLOR_SPACE_TYPE swapchainColorSpace;
     Uint32 frameCounter;
 
@@ -557,7 +557,7 @@ struct D3D12Renderer
 
     ID3D12CommandQueue *commandQueue;
 
-    bool debugMode;
+    bool debug_mode;
     bool GPUUploadHeapSupported;
     // FIXME: these might not be necessary since we're not using custom heaps
     bool UMA;
@@ -742,10 +742,10 @@ struct D3D12Shader
     void *bytecode;
     size_t bytecodeSize;
 
-    Uint32 samplerCount;
-    Uint32 uniformBufferCount;
-    Uint32 storageBufferCount;
-    Uint32 storageTextureCount;
+    Uint32 num_samplers;
+    Uint32 num_uniform_buffers;
+    Uint32 num_storage_buffers;
+    Uint32 num_storage_textures;
 };
 
 typedef struct D3D12GraphicsRootSignature
@@ -771,7 +771,7 @@ struct D3D12GraphicsPipeline
 {
     ID3D12PipelineState *pipelineState;
     D3D12GraphicsRootSignature *rootSignature;
-    SDL_GPUPrimitiveType primitiveType;
+    SDL_GPUPrimitiveType primitive_type;
 
     Uint32 vertexStrides[MAX_BUFFER_BINDINGS];
 
@@ -804,11 +804,11 @@ struct D3D12ComputePipeline
     ID3D12PipelineState *pipelineState;
     D3D12ComputeRootSignature *rootSignature;
 
-    Uint32 readOnlyStorageTextureCount;
-    Uint32 readOnlyStorageBufferCount;
-    Uint32 writeOnlyStorageTextureCount;
-    Uint32 writeOnlyStorageBufferCount;
-    Uint32 uniformBufferCount;
+    Uint32 num_readonly_storage_textures;
+    Uint32 num_readonly_storage_buffers;
+    Uint32 num_writeonly_storage_textures;
+    Uint32 num_writeonly_storage_buffers;
+    Uint32 num_uniform_buffers;
 
     SDL_AtomicInt referenceCount;
 };
@@ -843,7 +843,7 @@ struct D3D12Buffer
 
 struct D3D12BufferContainer
 {
-    SDL_GPUBufferUsageFlags usageFlags;
+    SDL_GPUBufferUsageFlags usage_flags;
     Uint32 size;
     D3D12BufferType type;
 
@@ -870,7 +870,7 @@ struct D3D12UniformBuffer
 
 static void D3D12_ReleaseWindow(SDL_GPURenderer *driverData, SDL_Window *window);
 static void D3D12_Wait(SDL_GPURenderer *driverData);
-static void D3D12_WaitForFences(SDL_GPURenderer *driverData, bool waitAll, SDL_GPUFence *const *pFences, Uint32 fenceCount);
+static void D3D12_WaitForFences(SDL_GPURenderer *driverData, bool wait_all, SDL_GPUFence *const *fences, Uint32 num_fences);
 static void D3D12_INTERNAL_ReleaseBlitPipelines(SDL_GPURenderer *driverData);
 
 // Helpers
@@ -954,7 +954,7 @@ static void D3D12_INTERNAL_SetResourceName(
     ID3D12Resource *resource,
     const char *text)
 {
-    if (renderer->debugMode) {
+    if (renderer->debug_mode) {
         ID3D12DeviceChild_SetPrivateData(
             resource,
             D3D_GUID(D3D_IID_D3DDebugObjectName),
@@ -1159,13 +1159,13 @@ static void D3D12_INTERNAL_DestroyGraphicsRootSignature(
 }
 
 static void D3D12_INTERNAL_DestroyGraphicsPipeline(
-    D3D12GraphicsPipeline *graphicsPipeline)
+    D3D12GraphicsPipeline *graphics_pipeline)
 {
-    if (graphicsPipeline->pipelineState) {
-        ID3D12PipelineState_Release(graphicsPipeline->pipelineState);
+    if (graphics_pipeline->pipelineState) {
+        ID3D12PipelineState_Release(graphics_pipeline->pipelineState);
     }
-    D3D12_INTERNAL_DestroyGraphicsRootSignature(graphicsPipeline->rootSignature);
-    SDL_free(graphicsPipeline);
+    D3D12_INTERNAL_DestroyGraphicsRootSignature(graphics_pipeline->rootSignature);
+    SDL_free(graphics_pipeline);
 }
 
 static void D3D12_INTERNAL_DestroyComputeRootSignature(
@@ -1181,13 +1181,13 @@ static void D3D12_INTERNAL_DestroyComputeRootSignature(
 }
 
 static void D3D12_INTERNAL_DestroyComputePipeline(
-    D3D12ComputePipeline *computePipeline)
+    D3D12ComputePipeline *compute_pipeline)
 {
-    if (computePipeline->pipelineState) {
-        ID3D12PipelineState_Release(computePipeline->pipelineState);
+    if (compute_pipeline->pipelineState) {
+        ID3D12PipelineState_Release(compute_pipeline->pipelineState);
     }
-    D3D12_INTERNAL_DestroyComputeRootSignature(computePipeline->rootSignature);
-    SDL_free(computePipeline);
+    D3D12_INTERNAL_DestroyComputeRootSignature(compute_pipeline->rootSignature);
+    SDL_free(compute_pipeline);
 }
 
 static void D3D12_INTERNAL_ReleaseFenceToPool(
@@ -1242,26 +1242,26 @@ static void D3D12_INTERNAL_DestroyDescriptorHeap(D3D12DescriptorHeap *descriptor
     SDL_free(descriptorHeap);
 }
 
-static void D3D12_INTERNAL_DestroyCommandBuffer(D3D12CommandBuffer *commandBuffer)
+static void D3D12_INTERNAL_DestroyCommandBuffer(D3D12CommandBuffer *command_buffer)
 {
-    if (!commandBuffer) {
+    if (!command_buffer) {
         return;
     }
-    if (commandBuffer->graphicsCommandList) {
-        ID3D12GraphicsCommandList_Release(commandBuffer->graphicsCommandList);
+    if (command_buffer->graphicsCommandList) {
+        ID3D12GraphicsCommandList_Release(command_buffer->graphicsCommandList);
     }
-    if (commandBuffer->commandAllocator) {
-        ID3D12CommandAllocator_Release(commandBuffer->commandAllocator);
+    if (command_buffer->commandAllocator) {
+        ID3D12CommandAllocator_Release(command_buffer->commandAllocator);
     }
-    SDL_free(commandBuffer->presentDatas);
-    SDL_free(commandBuffer->usedTextures);
-    SDL_free(commandBuffer->usedBuffers);
-    SDL_free(commandBuffer->usedSamplers);
-    SDL_free(commandBuffer->usedGraphicsPipelines);
-    SDL_free(commandBuffer->usedComputePipelines);
-    SDL_free(commandBuffer->usedUniformBuffers);
-    SDL_free(commandBuffer->textureDownloads);
-    SDL_free(commandBuffer);
+    SDL_free(command_buffer->presentDatas);
+    SDL_free(command_buffer->usedTextures);
+    SDL_free(command_buffer->usedBuffers);
+    SDL_free(command_buffer->usedSamplers);
+    SDL_free(command_buffer->usedGraphicsPipelines);
+    SDL_free(command_buffer->usedComputePipelines);
+    SDL_free(command_buffer->usedUniformBuffers);
+    SDL_free(command_buffer->textureDownloads);
+    SDL_free(command_buffer);
 }
 
 static void D3D12_INTERNAL_DestroyFence(D3D12Fence *fence)
@@ -1431,15 +1431,15 @@ static void D3D12_DestroyDevice(SDL_GPUDevice *device)
 // Barriers
 
 static inline Uint32 D3D12_INTERNAL_CalcSubresource(
-    Uint32 mipLevel,
+    Uint32 mip_level,
     Uint32 layer,
     Uint32 numLevels)
 {
-    return mipLevel + (layer * numLevels);
+    return mip_level + (layer * numLevels);
 }
 
 static void D3D12_INTERNAL_ResourceBarrier(
-    D3D12CommandBuffer *commandBuffer,
+    D3D12CommandBuffer *command_buffer,
     D3D12_RESOURCE_STATES sourceState,
     D3D12_RESOURCE_STATES destinationState,
     ID3D12Resource *resource,
@@ -1471,43 +1471,43 @@ static void D3D12_INTERNAL_ResourceBarrier(
 
     if (numBarriers > 0) {
         ID3D12GraphicsCommandList_ResourceBarrier(
-            commandBuffer->graphicsCommandList,
+            command_buffer->graphicsCommandList,
             numBarriers,
             barrierDesc);
     }
 }
 
 static void D3D12_INTERNAL_TextureSubresourceBarrier(
-    D3D12CommandBuffer *commandBuffer,
+    D3D12CommandBuffer *command_buffer,
     D3D12_RESOURCE_STATES sourceState,
     D3D12_RESOURCE_STATES destinationState,
     D3D12TextureSubresource *textureSubresource)
 {
     D3D12_INTERNAL_ResourceBarrier(
-        commandBuffer,
+        command_buffer,
         sourceState,
         destinationState,
         textureSubresource->parent->resource,
         textureSubresource->index,
-        textureSubresource->parent->container->header.info.usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE);
+        textureSubresource->parent->container->header.info.usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE);
 }
 
 static D3D12_RESOURCE_STATES D3D12_INTERNAL_DefaultTextureResourceState(
-    SDL_GPUTextureUsageFlags usageFlags)
+    SDL_GPUTextureUsageFlags usage_flags)
 {
     // NOTE: order matters here!
 
-    if (usageFlags & SDL_GPU_TEXTUREUSAGE_SAMPLER) {
+    if (usage_flags & SDL_GPU_TEXTUREUSAGE_SAMPLER) {
         return D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE;
-    } else if (usageFlags & SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ) {
+    } else if (usage_flags & SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ) {
         return D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE;
-    } else if (usageFlags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
+    } else if (usage_flags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
         return D3D12_RESOURCE_STATE_RENDER_TARGET;
-    } else if (usageFlags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
+    } else if (usage_flags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
         return D3D12_RESOURCE_STATE_DEPTH_WRITE;
-    } else if (usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ) {
+    } else if (usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ) {
         return D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
-    } else if (usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
+    } else if (usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
         return D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Texture has no default usage mode!");
@@ -1516,50 +1516,50 @@ static D3D12_RESOURCE_STATES D3D12_INTERNAL_DefaultTextureResourceState(
 }
 
 static void D3D12_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
-    D3D12CommandBuffer *commandBuffer,
+    D3D12CommandBuffer *command_buffer,
     D3D12_RESOURCE_STATES destinationUsageMode,
     D3D12TextureSubresource *textureSubresource)
 {
     D3D12_INTERNAL_TextureSubresourceBarrier(
-        commandBuffer,
-        D3D12_INTERNAL_DefaultTextureResourceState(textureSubresource->parent->container->header.info.usageFlags),
+        command_buffer,
+        D3D12_INTERNAL_DefaultTextureResourceState(textureSubresource->parent->container->header.info.usage_flags),
         destinationUsageMode,
         textureSubresource);
 }
 
 static void D3D12_INTERNAL_TextureTransitionFromDefaultUsage(
-    D3D12CommandBuffer *commandBuffer,
+    D3D12CommandBuffer *command_buffer,
     D3D12_RESOURCE_STATES destinationUsageMode,
     D3D12Texture *texture)
 {
     for (Uint32 i = 0; i < texture->subresourceCount; i += 1) {
         D3D12_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
-            commandBuffer,
+            command_buffer,
             destinationUsageMode,
             &texture->subresources[i]);
     }
 }
 
 static void D3D12_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
-    D3D12CommandBuffer *commandBuffer,
+    D3D12CommandBuffer *command_buffer,
     D3D12_RESOURCE_STATES sourceUsageMode,
     D3D12TextureSubresource *textureSubresource)
 {
     D3D12_INTERNAL_TextureSubresourceBarrier(
-        commandBuffer,
+        command_buffer,
         sourceUsageMode,
-        D3D12_INTERNAL_DefaultTextureResourceState(textureSubresource->parent->container->header.info.usageFlags),
+        D3D12_INTERNAL_DefaultTextureResourceState(textureSubresource->parent->container->header.info.usage_flags),
         textureSubresource);
 }
 
 static void D3D12_INTERNAL_TextureTransitionToDefaultUsage(
-    D3D12CommandBuffer *commandBuffer,
+    D3D12CommandBuffer *command_buffer,
     D3D12_RESOURCE_STATES sourceUsageMode,
     D3D12Texture *texture)
 {
     for (Uint32 i = 0; i < texture->subresourceCount; i += 1) {
         D3D12_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
-            commandBuffer,
+            command_buffer,
             sourceUsageMode,
             &texture->subresources[i]);
     }
@@ -1568,17 +1568,17 @@ static void D3D12_INTERNAL_TextureTransitionToDefaultUsage(
 static D3D12_RESOURCE_STATES D3D12_INTERNAL_DefaultBufferResourceState(
     D3D12Buffer *buffer)
 {
-    if (buffer->container->usageFlags & SDL_GPU_BUFFERUSAGE_VERTEX) {
+    if (buffer->container->usage_flags & SDL_GPU_BUFFERUSAGE_VERTEX) {
         return D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER;
-    } else if (buffer->container->usageFlags & SDL_GPU_BUFFERUSAGE_INDEX) {
+    } else if (buffer->container->usage_flags & SDL_GPU_BUFFERUSAGE_INDEX) {
         return D3D12_RESOURCE_STATE_INDEX_BUFFER;
-    } else if (buffer->container->usageFlags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
+    } else if (buffer->container->usage_flags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
         return D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT;
-    } else if (buffer->container->usageFlags & SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ) {
+    } else if (buffer->container->usage_flags & SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ) {
         return D3D12_RESOURCE_STATE_ALL_SHADER_RESOURCE;
-    } else if (buffer->container->usageFlags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ) {
+    } else if (buffer->container->usage_flags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ) {
         return D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE;
-    } else if (buffer->container->usageFlags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE) {
+    } else if (buffer->container->usage_flags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE) {
         return D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Buffer has no default usage mode!");
@@ -1587,41 +1587,41 @@ static D3D12_RESOURCE_STATES D3D12_INTERNAL_DefaultBufferResourceState(
 }
 
 static void D3D12_INTERNAL_BufferBarrier(
-    D3D12CommandBuffer *commandBuffer,
+    D3D12CommandBuffer *command_buffer,
     D3D12_RESOURCE_STATES sourceState,
     D3D12_RESOURCE_STATES destinationState,
     D3D12Buffer *buffer)
 {
     D3D12_INTERNAL_ResourceBarrier(
-        commandBuffer,
+        command_buffer,
         buffer->transitioned ? sourceState : D3D12_RESOURCE_STATE_COMMON,
         destinationState,
         buffer->handle,
         0,
-        buffer->container->usageFlags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE);
+        buffer->container->usage_flags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE);
 
     buffer->transitioned = true;
 }
 
 static void D3D12_INTERNAL_BufferTransitionFromDefaultUsage(
-    D3D12CommandBuffer *commandBuffer,
+    D3D12CommandBuffer *command_buffer,
     D3D12_RESOURCE_STATES destinationState,
     D3D12Buffer *buffer)
 {
     D3D12_INTERNAL_BufferBarrier(
-        commandBuffer,
+        command_buffer,
         D3D12_INTERNAL_DefaultBufferResourceState(buffer),
         destinationState,
         buffer);
 }
 
 static void D3D12_INTERNAL_BufferTransitionToDefaultUsage(
-    D3D12CommandBuffer *commandBuffer,
+    D3D12CommandBuffer *command_buffer,
     D3D12_RESOURCE_STATES sourceState,
     D3D12Buffer *buffer)
 {
     D3D12_INTERNAL_BufferBarrier(
-        commandBuffer,
+        command_buffer,
         sourceState,
         D3D12_INTERNAL_DefaultBufferResourceState(buffer),
         buffer);
@@ -1632,24 +1632,24 @@ static void D3D12_INTERNAL_BufferTransitionToDefaultUsage(
 #define TRACK_RESOURCE(resource, type, array, count, capacity) \
     Uint32 i;                                                  \
                                                                \
-    for (i = 0; i < commandBuffer->count; i += 1) {            \
-        if (commandBuffer->array[i] == resource) {             \
+    for (i = 0; i < command_buffer->count; i += 1) {            \
+        if (command_buffer->array[i] == resource) {             \
             return;                                            \
         }                                                      \
     }                                                          \
                                                                \
-    if (commandBuffer->count == commandBuffer->capacity) {     \
-        commandBuffer->capacity += 1;                          \
-        commandBuffer->array = (type *)SDL_realloc(            \
-            commandBuffer->array,                              \
-            commandBuffer->capacity * sizeof(type));           \
+    if (command_buffer->count == command_buffer->capacity) {     \
+        command_buffer->capacity += 1;                          \
+        command_buffer->array = (type *)SDL_realloc(            \
+            command_buffer->array,                              \
+            command_buffer->capacity * sizeof(type));           \
     }                                                          \
-    commandBuffer->array[commandBuffer->count] = resource;     \
-    commandBuffer->count += 1;                                 \
+    command_buffer->array[command_buffer->count] = resource;     \
+    command_buffer->count += 1;                                 \
     SDL_AtomicIncRef(&resource->referenceCount);
 
 static void D3D12_INTERNAL_TrackTexture(
-    D3D12CommandBuffer *commandBuffer,
+    D3D12CommandBuffer *command_buffer,
     D3D12Texture *texture)
 {
     TRACK_RESOURCE(
@@ -1661,7 +1661,7 @@ static void D3D12_INTERNAL_TrackTexture(
 }
 
 static void D3D12_INTERNAL_TrackBuffer(
-    D3D12CommandBuffer *commandBuffer,
+    D3D12CommandBuffer *command_buffer,
     D3D12Buffer *buffer)
 {
     TRACK_RESOURCE(
@@ -1673,7 +1673,7 @@ static void D3D12_INTERNAL_TrackBuffer(
 }
 
 static void D3D12_INTERNAL_TrackSampler(
-    D3D12CommandBuffer *commandBuffer,
+    D3D12CommandBuffer *command_buffer,
     D3D12Sampler *sampler)
 {
     TRACK_RESOURCE(
@@ -1685,11 +1685,11 @@ static void D3D12_INTERNAL_TrackSampler(
 }
 
 static void D3D12_INTERNAL_TrackGraphicsPipeline(
-    D3D12CommandBuffer *commandBuffer,
-    D3D12GraphicsPipeline *graphicsPipeline)
+    D3D12CommandBuffer *command_buffer,
+    D3D12GraphicsPipeline *graphics_pipeline)
 {
     TRACK_RESOURCE(
-        graphicsPipeline,
+        graphics_pipeline,
         D3D12GraphicsPipeline *,
         usedGraphicsPipelines,
         usedGraphicsPipelineCount,
@@ -1697,11 +1697,11 @@ static void D3D12_INTERNAL_TrackGraphicsPipeline(
 }
 
 static void D3D12_INTERNAL_TrackComputePipeline(
-    D3D12CommandBuffer *commandBuffer,
-    D3D12ComputePipeline *computePipeline)
+    D3D12CommandBuffer *command_buffer,
+    D3D12ComputePipeline *compute_pipeline)
 {
     TRACK_RESOURCE(
-        computePipeline,
+        compute_pipeline,
         D3D12ComputePipeline *,
         usedComputePipelines,
         usedComputePipelineCount,
@@ -1771,11 +1771,11 @@ static D3D12DescriptorHeap *D3D12_INTERNAL_CreateDescriptorHeap(
 }
 
 static D3D12DescriptorHeap *D3D12_INTERNAL_AcquireDescriptorHeapFromPool(
-    D3D12CommandBuffer *commandBuffer,
+    D3D12CommandBuffer *command_buffer,
     D3D12_DESCRIPTOR_HEAP_TYPE descriptorHeapType)
 {
     D3D12DescriptorHeap *result;
-    D3D12Renderer *renderer = commandBuffer->renderer;
+    D3D12Renderer *renderer = command_buffer->renderer;
     D3D12DescriptorHeapPool *pool = &renderer->descriptorHeapPools[descriptorHeapType];
 
     SDL_LockMutex(pool->lock);
@@ -1835,8 +1835,8 @@ static void D3D12_INTERNAL_ReturnDescriptorHeapToPool(
  */
 static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
     D3D12Renderer *renderer,
-    D3D12Shader *vertexShader,
-    D3D12Shader *fragmentShader)
+    D3D12Shader *vertex_shader,
+    D3D12Shader *fragment_shader)
 {
     // FIXME: I think the max can be smaller...
     D3D12_ROOT_PARAMETER rootParameters[MAX_ROOT_SIGNATURE_PARAMETERS];
@@ -1870,10 +1870,10 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
         d3d12GraphicsRootSignature->fragmentUniformBufferRootIndex[i] = -1;
     }
 
-    if (vertexShader->samplerCount > 0) {
+    if (vertex_shader->num_samplers > 0) {
         // Vertex Samplers
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER;
-        descriptorRange.NumDescriptors = vertexShader->samplerCount;
+        descriptorRange.NumDescriptors = vertex_shader->num_samplers;
         descriptorRange.BaseShaderRegister = 0;
         descriptorRange.RegisterSpace = 0;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
@@ -1889,7 +1889,7 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
         parameterCount += 1;
 
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-        descriptorRange.NumDescriptors = vertexShader->samplerCount;
+        descriptorRange.NumDescriptors = vertex_shader->num_samplers;
         descriptorRange.BaseShaderRegister = 0;
         descriptorRange.RegisterSpace = 0;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
@@ -1905,11 +1905,11 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
         parameterCount += 1;
     }
 
-    if (vertexShader->storageTextureCount) {
+    if (vertex_shader->num_storage_textures) {
         // Vertex storage textures
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-        descriptorRange.NumDescriptors = vertexShader->storageTextureCount;
-        descriptorRange.BaseShaderRegister = vertexShader->samplerCount;
+        descriptorRange.NumDescriptors = vertex_shader->num_storage_textures;
+        descriptorRange.BaseShaderRegister = vertex_shader->num_samplers;
         descriptorRange.RegisterSpace = 0;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
         descriptorRanges[rangeCount] = descriptorRange;
@@ -1924,12 +1924,12 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
         parameterCount += 1;
     }
 
-    if (vertexShader->storageBufferCount) {
+    if (vertex_shader->num_storage_buffers) {
 
         // Vertex storage buffers
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-        descriptorRange.NumDescriptors = vertexShader->storageBufferCount;
-        descriptorRange.BaseShaderRegister = vertexShader->samplerCount + vertexShader->storageTextureCount;
+        descriptorRange.NumDescriptors = vertex_shader->num_storage_buffers;
+        descriptorRange.BaseShaderRegister = vertex_shader->num_samplers + vertex_shader->num_storage_textures;
         descriptorRange.RegisterSpace = 0;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
         descriptorRanges[rangeCount] = descriptorRange;
@@ -1945,7 +1945,7 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
     }
 
     // Vertex Uniforms
-    for (Uint32 i = 0; i < vertexShader->uniformBufferCount; i += 1) {
+    for (Uint32 i = 0; i < vertex_shader->num_uniform_buffers; i += 1) {
         rootParameter.ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
         rootParameter.Descriptor.ShaderRegister = i;
         rootParameter.Descriptor.RegisterSpace = 1;
@@ -1955,10 +1955,10 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
         parameterCount += 1;
     }
 
-    if (fragmentShader->samplerCount) {
+    if (fragment_shader->num_samplers) {
         // Fragment Samplers
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER;
-        descriptorRange.NumDescriptors = fragmentShader->samplerCount;
+        descriptorRange.NumDescriptors = fragment_shader->num_samplers;
         descriptorRange.BaseShaderRegister = 0;
         descriptorRange.RegisterSpace = 2;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
@@ -1974,7 +1974,7 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
         parameterCount += 1;
 
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-        descriptorRange.NumDescriptors = fragmentShader->samplerCount;
+        descriptorRange.NumDescriptors = fragment_shader->num_samplers;
         descriptorRange.BaseShaderRegister = 0;
         descriptorRange.RegisterSpace = 2;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
@@ -1990,11 +1990,11 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
         parameterCount += 1;
     }
 
-    if (fragmentShader->storageTextureCount) {
+    if (fragment_shader->num_storage_textures) {
         // Fragment Storage Textures
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-        descriptorRange.NumDescriptors = fragmentShader->storageTextureCount;
-        descriptorRange.BaseShaderRegister = fragmentShader->samplerCount;
+        descriptorRange.NumDescriptors = fragment_shader->num_storage_textures;
+        descriptorRange.BaseShaderRegister = fragment_shader->num_samplers;
         descriptorRange.RegisterSpace = 2;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
         descriptorRanges[rangeCount] = descriptorRange;
@@ -2009,11 +2009,11 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
         parameterCount += 1;
     }
 
-    if (fragmentShader->storageBufferCount) {
+    if (fragment_shader->num_storage_buffers) {
         // Fragment Storage Buffers
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-        descriptorRange.NumDescriptors = fragmentShader->storageBufferCount;
-        descriptorRange.BaseShaderRegister = fragmentShader->samplerCount + fragmentShader->storageTextureCount;
+        descriptorRange.NumDescriptors = fragment_shader->num_storage_buffers;
+        descriptorRange.BaseShaderRegister = fragment_shader->num_samplers + fragment_shader->num_storage_textures;
         descriptorRange.RegisterSpace = 2;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
         descriptorRanges[rangeCount] = descriptorRange;
@@ -2029,7 +2029,7 @@ static D3D12GraphicsRootSignature *D3D12_INTERNAL_CreateGraphicsRootSignature(
     }
 
     // Fragment Uniforms
-    for (Uint32 i = 0; i < fragmentShader->uniformBufferCount; i += 1) {
+    for (Uint32 i = 0; i < fragment_shader->num_uniform_buffers; i += 1) {
         rootParameter.ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
         rootParameter.Descriptor.ShaderRegister = i;
         rootParameter.Descriptor.RegisterSpace = 3;
@@ -2094,18 +2094,18 @@ static bool D3D12_INTERNAL_CreateShaderBytecode(
     Uint32 stage,
     SDL_GPUShaderFormat format,
     const Uint8 *code,
-    size_t codeSize,
-    const char *entryPointName,
+    size_t code_size,
+    const char *entrypoint_name,
     void **pBytecode,
     size_t *pBytecodeSize)
 {
     if (pBytecode != NULL) {
-        *pBytecode = SDL_malloc(codeSize);
+        *pBytecode = SDL_malloc(code_size);
         if (!*pBytecode) {
             return false;
         }
-        SDL_memcpy(*pBytecode, code, codeSize);
-        *pBytecodeSize = codeSize;
+        SDL_memcpy(*pBytecode, code, code_size);
+        *pBytecodeSize = code_size;
     }
 
     return true;
@@ -2141,9 +2141,9 @@ static D3D12ComputeRootSignature *D3D12_INTERNAL_CreateComputeRootSignature(
         d3d12ComputeRootSignature->uniformBufferRootIndex[i] = -1;
     }
 
-    if (createInfo->readOnlyStorageTextureCount) {
+    if (createInfo->num_readonly_storage_textures) {
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-        descriptorRange.NumDescriptors = createInfo->readOnlyStorageTextureCount;
+        descriptorRange.NumDescriptors = createInfo->num_readonly_storage_textures;
         descriptorRange.BaseShaderRegister = 0;
         descriptorRange.RegisterSpace = 0;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
@@ -2159,10 +2159,10 @@ static D3D12ComputeRootSignature *D3D12_INTERNAL_CreateComputeRootSignature(
         parameterCount += 1;
     }
 
-    if (createInfo->readOnlyStorageBufferCount) {
+    if (createInfo->num_readonly_storage_buffers) {
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-        descriptorRange.NumDescriptors = createInfo->readOnlyStorageBufferCount;
-        descriptorRange.BaseShaderRegister = createInfo->readOnlyStorageTextureCount;
+        descriptorRange.NumDescriptors = createInfo->num_readonly_storage_buffers;
+        descriptorRange.BaseShaderRegister = createInfo->num_readonly_storage_textures;
         descriptorRange.RegisterSpace = 0;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
         descriptorRanges[rangeCount] = descriptorRange;
@@ -2177,9 +2177,9 @@ static D3D12ComputeRootSignature *D3D12_INTERNAL_CreateComputeRootSignature(
         parameterCount += 1;
     }
 
-    if (createInfo->writeOnlyStorageTextureCount) {
+    if (createInfo->num_writeonly_storage_textures) {
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
-        descriptorRange.NumDescriptors = createInfo->writeOnlyStorageTextureCount;
+        descriptorRange.NumDescriptors = createInfo->num_writeonly_storage_textures;
         descriptorRange.BaseShaderRegister = 0;
         descriptorRange.RegisterSpace = 1;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
@@ -2195,10 +2195,10 @@ static D3D12ComputeRootSignature *D3D12_INTERNAL_CreateComputeRootSignature(
         parameterCount += 1;
     }
 
-    if (createInfo->writeOnlyStorageBufferCount) {
+    if (createInfo->num_writeonly_storage_buffers) {
         descriptorRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
-        descriptorRange.NumDescriptors = createInfo->writeOnlyStorageBufferCount;
-        descriptorRange.BaseShaderRegister = createInfo->writeOnlyStorageTextureCount;
+        descriptorRange.NumDescriptors = createInfo->num_writeonly_storage_buffers;
+        descriptorRange.BaseShaderRegister = createInfo->num_writeonly_storage_textures;
         descriptorRange.RegisterSpace = 1;
         descriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
         descriptorRanges[rangeCount] = descriptorRange;
@@ -2213,7 +2213,7 @@ static D3D12ComputeRootSignature *D3D12_INTERNAL_CreateComputeRootSignature(
         parameterCount += 1;
     }
 
-    for (Uint32 i = 0; i < createInfo->uniformBufferCount; i += 1) {
+    for (Uint32 i = 0; i < createInfo->num_uniform_buffers; i += 1) {
         rootParameter.ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
         rootParameter.Descriptor.ShaderRegister = i;
         rootParameter.Descriptor.RegisterSpace = 2;
@@ -2272,7 +2272,7 @@ static D3D12ComputeRootSignature *D3D12_INTERNAL_CreateComputeRootSignature(
 
 static SDL_GPUComputePipeline *D3D12_CreateComputePipeline(
     SDL_GPURenderer *driverData,
-    const SDL_GPUComputePipelineCreateInfo *pipelineCreateInfo)
+    const SDL_GPUComputePipelineCreateInfo *createinfo)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
     void *bytecode;
@@ -2282,10 +2282,10 @@ static SDL_GPUComputePipeline *D3D12_CreateComputePipeline(
     if (!D3D12_INTERNAL_CreateShaderBytecode(
             renderer,
             SDL_GPU_SHADERSTAGE_COMPUTE,
-            pipelineCreateInfo->format,
-            pipelineCreateInfo->code,
-            pipelineCreateInfo->codeSize,
-            pipelineCreateInfo->entryPointName,
+            createinfo->format,
+            createinfo->code,
+            createinfo->code_size,
+            createinfo->entrypoint_name,
             &bytecode,
             &bytecodeSize)) {
         return NULL;
@@ -2293,7 +2293,7 @@ static SDL_GPUComputePipeline *D3D12_CreateComputePipeline(
 
     D3D12ComputeRootSignature *rootSignature = D3D12_INTERNAL_CreateComputeRootSignature(
         renderer,
-        pipelineCreateInfo);
+        createinfo);
 
     if (rootSignature == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Could not create root signature!");
@@ -2322,37 +2322,37 @@ static SDL_GPUComputePipeline *D3D12_CreateComputePipeline(
         return NULL;
     }
 
-    D3D12ComputePipeline *computePipeline =
+    D3D12ComputePipeline *compute_pipeline =
         (D3D12ComputePipeline *)SDL_calloc(1, sizeof(D3D12ComputePipeline));
 
-    if (!computePipeline) {
+    if (!compute_pipeline) {
         ID3D12PipelineState_Release(pipelineState);
         SDL_free(bytecode);
         return NULL;
     }
 
-    computePipeline->pipelineState = pipelineState;
-    computePipeline->rootSignature = rootSignature;
-    computePipeline->readOnlyStorageTextureCount = pipelineCreateInfo->readOnlyStorageTextureCount;
-    computePipeline->readOnlyStorageBufferCount = pipelineCreateInfo->readOnlyStorageBufferCount;
-    computePipeline->writeOnlyStorageTextureCount = pipelineCreateInfo->writeOnlyStorageTextureCount;
-    computePipeline->writeOnlyStorageBufferCount = pipelineCreateInfo->writeOnlyStorageBufferCount;
-    computePipeline->uniformBufferCount = pipelineCreateInfo->uniformBufferCount;
-    SDL_AtomicSet(&computePipeline->referenceCount, 0);
+    compute_pipeline->pipelineState = pipelineState;
+    compute_pipeline->rootSignature = rootSignature;
+    compute_pipeline->num_readonly_storage_textures = createinfo->num_readonly_storage_textures;
+    compute_pipeline->num_readonly_storage_buffers = createinfo->num_readonly_storage_buffers;
+    compute_pipeline->num_writeonly_storage_textures = createinfo->num_writeonly_storage_textures;
+    compute_pipeline->num_writeonly_storage_buffers = createinfo->num_writeonly_storage_buffers;
+    compute_pipeline->num_uniform_buffers = createinfo->num_uniform_buffers;
+    SDL_AtomicSet(&compute_pipeline->referenceCount, 0);
 
-    return (SDL_GPUComputePipeline *)computePipeline;
+    return (SDL_GPUComputePipeline *)compute_pipeline;
 }
 
-static bool D3D12_INTERNAL_ConvertRasterizerState(SDL_GPURasterizerState rasterizerState, D3D12_RASTERIZER_DESC *desc)
+static bool D3D12_INTERNAL_ConvertRasterizerState(SDL_GPURasterizerState rasterizer_state, D3D12_RASTERIZER_DESC *desc)
 {
     if (!desc) {
         return false;
     }
 
-    desc->FillMode = SDLToD3D12_FillMode[rasterizerState.fillMode];
-    desc->CullMode = SDLToD3D12_CullMode[rasterizerState.cullMode];
+    desc->FillMode = SDLToD3D12_FillMode[rasterizer_state.fill_mode];
+    desc->CullMode = SDLToD3D12_CullMode[rasterizer_state.cull_mode];
 
-    switch (rasterizerState.frontFace) {
+    switch (rasterizer_state.frontFace) {
     case SDL_GPU_FRONTFACE_COUNTER_CLOCKWISE:
         desc->FrontCounterClockwise = TRUE;
         break;
@@ -2363,10 +2363,10 @@ static bool D3D12_INTERNAL_ConvertRasterizerState(SDL_GPURasterizerState rasteri
         return false;
     }
 
-    if (rasterizerState.depthBiasEnable) {
-        desc->DepthBias = SDL_lroundf(rasterizerState.depthBiasConstantFactor);
-        desc->DepthBiasClamp = rasterizerState.depthBiasClamp;
-        desc->SlopeScaledDepthBias = rasterizerState.depthBiasSlopeFactor;
+    if (rasterizer_state.enable_depth_bias) {
+        desc->DepthBias = SDL_lroundf(rasterizer_state.depth_bias_constant_factor);
+        desc->DepthBiasClamp = rasterizer_state.depth_bias_clamp;
+        desc->SlopeScaledDepthBias = rasterizer_state.depth_bias_slope_factor;
     } else {
         desc->DepthBias = 0;
         desc->DepthBiasClamp = 0.0f;
@@ -2407,19 +2407,19 @@ static bool D3D12_INTERNAL_ConvertBlendState(
         rtBlendDesc.LogicOp = D3D12_LOGIC_OP_NOOP;
         rtBlendDesc.RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
 
-        // If attachmentInfo has more blend states, you can set IndependentBlendEnable to TRUE and assign different blend states to each render target slot
-        if (i < pipelineInfo->attachmentInfo.colorAttachmentCount) {
+        // If attachment_info has more blend states, you can set IndependentBlendEnable to TRUE and assign different blend states to each render target slot
+        if (i < pipelineInfo->attachment_info.num_color_attachments) {
 
-            SDL_GPUColorAttachmentBlendState sdlBlendState = pipelineInfo->attachmentInfo.colorAttachmentDescriptions[i].blendState;
+            SDL_GPUColorAttachmentBlendState sdlBlendState = pipelineInfo->attachment_info.color_attachment_descriptions[i].blend_state;
 
-            rtBlendDesc.BlendEnable = sdlBlendState.blendEnable;
-            rtBlendDesc.SrcBlend = SDLToD3D12_BlendFactor[sdlBlendState.srcColorBlendFactor];
-            rtBlendDesc.DestBlend = SDLToD3D12_BlendFactor[sdlBlendState.dstColorBlendFactor];
-            rtBlendDesc.BlendOp = SDLToD3D12_BlendOp[sdlBlendState.colorBlendOp];
-            rtBlendDesc.SrcBlendAlpha = SDLToD3D12_BlendFactorAlpha[sdlBlendState.srcAlphaBlendFactor];
-            rtBlendDesc.DestBlendAlpha = SDLToD3D12_BlendFactorAlpha[sdlBlendState.dstAlphaBlendFactor];
-            rtBlendDesc.BlendOpAlpha = SDLToD3D12_BlendOp[sdlBlendState.alphaBlendOp];
-            rtBlendDesc.RenderTargetWriteMask = sdlBlendState.colorWriteMask;
+            rtBlendDesc.BlendEnable = sdlBlendState.enable_blend;
+            rtBlendDesc.SrcBlend = SDLToD3D12_BlendFactor[sdlBlendState.src_color_blendfactor];
+            rtBlendDesc.DestBlend = SDLToD3D12_BlendFactor[sdlBlendState.dst_color_blendfactor];
+            rtBlendDesc.BlendOp = SDLToD3D12_BlendOp[sdlBlendState.color_blend_op];
+            rtBlendDesc.SrcBlendAlpha = SDLToD3D12_BlendFactorAlpha[sdlBlendState.src_alpha_blendfactor];
+            rtBlendDesc.DestBlendAlpha = SDLToD3D12_BlendFactorAlpha[sdlBlendState.dst_alpha_blendfactor];
+            rtBlendDesc.BlendOpAlpha = SDLToD3D12_BlendOp[sdlBlendState.alpha_blend_op];
+            rtBlendDesc.RenderTargetWriteMask = sdlBlendState.color_write_mask;
 
             if (i > 0) {
                 blendDesc->IndependentBlendEnable = TRUE;
@@ -2432,48 +2432,48 @@ static bool D3D12_INTERNAL_ConvertBlendState(
     return true;
 }
 
-static bool D3D12_INTERNAL_ConvertDepthStencilState(SDL_GPUDepthStencilState depthStencilState, D3D12_DEPTH_STENCIL_DESC *desc)
+static bool D3D12_INTERNAL_ConvertDepthStencilState(SDL_GPUDepthStencilState depth_stencil_state, D3D12_DEPTH_STENCIL_DESC *desc)
 {
     if (desc == NULL) {
         return false;
     }
 
-    desc->DepthEnable = depthStencilState.depthTestEnable == true ? TRUE : FALSE;
-    desc->DepthWriteMask = depthStencilState.depthWriteEnable == true ? D3D12_DEPTH_WRITE_MASK_ALL : D3D12_DEPTH_WRITE_MASK_ZERO;
-    desc->DepthFunc = SDLToD3D12_CompareOp[depthStencilState.compareOp];
-    desc->StencilEnable = depthStencilState.stencilTestEnable == true ? TRUE : FALSE;
-    desc->StencilReadMask = depthStencilState.compareMask;
-    desc->StencilWriteMask = depthStencilState.writeMask;
+    desc->DepthEnable = depth_stencil_state.enable_depth_test == true ? TRUE : FALSE;
+    desc->DepthWriteMask = depth_stencil_state.enable_depth_write == true ? D3D12_DEPTH_WRITE_MASK_ALL : D3D12_DEPTH_WRITE_MASK_ZERO;
+    desc->DepthFunc = SDLToD3D12_CompareOp[depth_stencil_state.compare_op];
+    desc->StencilEnable = depth_stencil_state.enable_stencil_test == true ? TRUE : FALSE;
+    desc->StencilReadMask = depth_stencil_state.compare_mask;
+    desc->StencilWriteMask = depth_stencil_state.write_mask;
 
-    desc->FrontFace.StencilFailOp = SDLToD3D12_StencilOp[depthStencilState.frontStencilState.failOp];
-    desc->FrontFace.StencilDepthFailOp = SDLToD3D12_StencilOp[depthStencilState.frontStencilState.depthFailOp];
-    desc->FrontFace.StencilPassOp = SDLToD3D12_StencilOp[depthStencilState.frontStencilState.passOp];
-    desc->FrontFace.StencilFunc = SDLToD3D12_CompareOp[depthStencilState.frontStencilState.compareOp];
+    desc->FrontFace.StencilFailOp = SDLToD3D12_StencilOp[depth_stencil_state.front_stencil_state.fail_op];
+    desc->FrontFace.StencilDepthFailOp = SDLToD3D12_StencilOp[depth_stencil_state.front_stencil_state.depth_fail_op];
+    desc->FrontFace.StencilPassOp = SDLToD3D12_StencilOp[depth_stencil_state.front_stencil_state.pass_op];
+    desc->FrontFace.StencilFunc = SDLToD3D12_CompareOp[depth_stencil_state.front_stencil_state.compare_op];
 
-    desc->BackFace.StencilFailOp = SDLToD3D12_StencilOp[depthStencilState.backStencilState.failOp];
-    desc->BackFace.StencilDepthFailOp = SDLToD3D12_StencilOp[depthStencilState.backStencilState.depthFailOp];
-    desc->BackFace.StencilPassOp = SDLToD3D12_StencilOp[depthStencilState.backStencilState.passOp];
-    desc->BackFace.StencilFunc = SDLToD3D12_CompareOp[depthStencilState.backStencilState.compareOp];
+    desc->BackFace.StencilFailOp = SDLToD3D12_StencilOp[depth_stencil_state.back_stencil_state.fail_op];
+    desc->BackFace.StencilDepthFailOp = SDLToD3D12_StencilOp[depth_stencil_state.back_stencil_state.depth_fail_op];
+    desc->BackFace.StencilPassOp = SDLToD3D12_StencilOp[depth_stencil_state.back_stencil_state.pass_op];
+    desc->BackFace.StencilFunc = SDLToD3D12_CompareOp[depth_stencil_state.back_stencil_state.compare_op];
 
     return true;
 }
 
-static bool D3D12_INTERNAL_ConvertVertexInputState(SDL_GPUVertexInputState vertexInputState, D3D12_INPUT_ELEMENT_DESC *desc, const char *semantic)
+static bool D3D12_INTERNAL_ConvertVertexInputState(SDL_GPUVertexInputState vertex_input_state, D3D12_INPUT_ELEMENT_DESC *desc, const char *semantic)
 {
-    if (desc == NULL || vertexInputState.vertexAttributeCount == 0) {
+    if (desc == NULL || vertex_input_state.num_vertex_attributes == 0) {
         return false;
     }
 
-    for (Uint32 i = 0; i < vertexInputState.vertexAttributeCount; i += 1) {
-        SDL_GPUVertexAttribute attribute = vertexInputState.vertexAttributes[i];
+    for (Uint32 i = 0; i < vertex_input_state.num_vertex_attributes; i += 1) {
+        SDL_GPUVertexAttribute attribute = vertex_input_state.vertex_attributes[i];
 
         desc[i].SemanticName = semantic;
         desc[i].SemanticIndex = attribute.location;
         desc[i].Format = SDLToD3D12_VertexFormat[attribute.format];
         desc[i].InputSlot = attribute.binding;
         desc[i].AlignedByteOffset = attribute.offset;
-        desc[i].InputSlotClass = SDLToD3D12_InputRate[vertexInputState.vertexBindings[attribute.binding].inputRate];
-        desc[i].InstanceDataStepRate = (vertexInputState.vertexBindings[attribute.binding].inputRate == SDL_GPU_VERTEXINPUTRATE_INSTANCE) ? vertexInputState.vertexBindings[attribute.binding].instanceStepRate : 0;
+        desc[i].InputSlotClass = SDLToD3D12_InputRate[vertex_input_state.vertex_bindings[attribute.binding].input_rate];
+        desc[i].InstanceDataStepRate = (vertex_input_state.vertex_bindings[attribute.binding].input_rate == SDL_GPU_VERTEXINPUTRATE_INSTANCE) ? vertex_input_state.vertex_bindings[attribute.binding].instance_step_rate : 0;
     }
 
     return true;
@@ -2513,11 +2513,11 @@ static void D3D12_INTERNAL_AssignCpuDescriptorHandle(
 
 static SDL_GPUGraphicsPipeline *D3D12_CreateGraphicsPipeline(
     SDL_GPURenderer *driverData,
-    const SDL_GPUGraphicsPipelineCreateInfo *pipelineCreateInfo)
+    const SDL_GPUGraphicsPipelineCreateInfo *createinfo)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
-    D3D12Shader *vertShader = (D3D12Shader *)pipelineCreateInfo->vertexShader;
-    D3D12Shader *fragShader = (D3D12Shader *)pipelineCreateInfo->fragmentShader;
+    D3D12Shader *vertShader = (D3D12Shader *)createinfo->vertex_shader;
+    D3D12Shader *fragShader = (D3D12Shader *)createinfo->fragment_shader;
 
     D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc;
     SDL_zero(psoDesc);
@@ -2527,21 +2527,21 @@ static SDL_GPUGraphicsPipeline *D3D12_CreateGraphicsPipeline(
     psoDesc.PS.BytecodeLength = fragShader->bytecodeSize;
 
     D3D12_INPUT_ELEMENT_DESC inputElementDescs[D3D12_IA_VERTEX_INPUT_STRUCTURE_ELEMENT_COUNT];
-    if (pipelineCreateInfo->vertexInputState.vertexAttributeCount > 0) {
+    if (createinfo->vertex_input_state.num_vertex_attributes > 0) {
         psoDesc.InputLayout.pInputElementDescs = inputElementDescs;
-        psoDesc.InputLayout.NumElements = pipelineCreateInfo->vertexInputState.vertexAttributeCount;
-        D3D12_INTERNAL_ConvertVertexInputState(pipelineCreateInfo->vertexInputState, inputElementDescs, renderer->semantic);
+        psoDesc.InputLayout.NumElements = createinfo->vertex_input_state.num_vertex_attributes;
+        D3D12_INTERNAL_ConvertVertexInputState(createinfo->vertex_input_state, inputElementDescs, renderer->semantic);
     }
 
     psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
 
-    if (!D3D12_INTERNAL_ConvertRasterizerState(pipelineCreateInfo->rasterizerState, &psoDesc.RasterizerState)) {
+    if (!D3D12_INTERNAL_ConvertRasterizerState(createinfo->rasterizer_state, &psoDesc.RasterizerState)) {
         return NULL;
     }
-    if (!D3D12_INTERNAL_ConvertBlendState(pipelineCreateInfo, &psoDesc.BlendState)) {
+    if (!D3D12_INTERNAL_ConvertBlendState(createinfo, &psoDesc.BlendState)) {
         return NULL;
     }
-    if (!D3D12_INTERNAL_ConvertDepthStencilState(pipelineCreateInfo->depthStencilState, &psoDesc.DepthStencilState)) {
+    if (!D3D12_INTERNAL_ConvertDepthStencilState(createinfo->depth_stencil_state, &psoDesc.DepthStencilState)) {
         return NULL;
     }
 
@@ -2551,13 +2551,13 @@ static SDL_GPUGraphicsPipeline *D3D12_CreateGraphicsPipeline(
     }
 
     psoDesc.SampleMask = UINT_MAX;
-    psoDesc.SampleDesc.Count = SDLToD3D12_SampleCount[pipelineCreateInfo->multisampleState.sampleCount];
+    psoDesc.SampleDesc.Count = SDLToD3D12_SampleCount[createinfo->multisample_state.sample_count];
     psoDesc.SampleDesc.Quality = 0;
 
-    psoDesc.DSVFormat = SDLToD3D12_TextureFormat[pipelineCreateInfo->attachmentInfo.depthStencilFormat];
-    psoDesc.NumRenderTargets = pipelineCreateInfo->attachmentInfo.colorAttachmentCount;
-    for (uint32_t i = 0; i < pipelineCreateInfo->attachmentInfo.colorAttachmentCount; i += 1) {
-        psoDesc.RTVFormats[i] = SDLToD3D12_TextureFormat[pipelineCreateInfo->attachmentInfo.colorAttachmentDescriptions[i].format];
+    psoDesc.DSVFormat = SDLToD3D12_TextureFormat[createinfo->attachment_info.depth_stencil_format];
+    psoDesc.NumRenderTargets = createinfo->attachment_info.num_color_attachments;
+    for (uint32_t i = 0; i < createinfo->attachment_info.num_color_attachments; i += 1) {
+        psoDesc.RTVFormats[i] = SDLToD3D12_TextureFormat[createinfo->attachment_info.color_attachment_descriptions[i].format];
     }
 
     // Assuming some default values or further initialization
@@ -2595,21 +2595,21 @@ static SDL_GPUGraphicsPipeline *D3D12_CreateGraphicsPipeline(
 
     pipeline->pipelineState = pipelineState;
 
-    for (Uint32 i = 0; i < pipelineCreateInfo->vertexInputState.vertexBindingCount; i += 1) {
-        pipeline->vertexStrides[i] = pipelineCreateInfo->vertexInputState.vertexBindings[i].stride;
+    for (Uint32 i = 0; i < createinfo->vertex_input_state.num_vertex_bindings; i += 1) {
+        pipeline->vertexStrides[i] = createinfo->vertex_input_state.vertex_bindings[i].pitch;
     }
 
-    pipeline->primitiveType = pipelineCreateInfo->primitiveType;
+    pipeline->primitive_type = createinfo->primitive_type;
 
-    pipeline->vertexSamplerCount = vertShader->samplerCount;
-    pipeline->vertexStorageTextureCount = vertShader->storageTextureCount;
-    pipeline->vertexStorageBufferCount = vertShader->storageBufferCount;
-    pipeline->vertexUniformBufferCount = vertShader->uniformBufferCount;
+    pipeline->vertexSamplerCount = vertShader->num_samplers;
+    pipeline->vertexStorageTextureCount = vertShader->num_storage_textures;
+    pipeline->vertexStorageBufferCount = vertShader->num_storage_buffers;
+    pipeline->vertexUniformBufferCount = vertShader->num_uniform_buffers;
 
-    pipeline->fragmentSamplerCount = fragShader->samplerCount;
-    pipeline->fragmentStorageTextureCount = fragShader->storageTextureCount;
-    pipeline->fragmentStorageBufferCount = fragShader->storageBufferCount;
-    pipeline->fragmentUniformBufferCount = fragShader->uniformBufferCount;
+    pipeline->fragmentSamplerCount = fragShader->num_samplers;
+    pipeline->fragmentStorageTextureCount = fragShader->num_storage_textures;
+    pipeline->fragmentStorageBufferCount = fragShader->num_storage_buffers;
+    pipeline->fragmentUniformBufferCount = fragShader->num_uniform_buffers;
 
     SDL_AtomicSet(&pipeline->referenceCount, 0);
     return (SDL_GPUGraphicsPipeline *)pipeline;
@@ -2617,7 +2617,7 @@ static SDL_GPUGraphicsPipeline *D3D12_CreateGraphicsPipeline(
 
 static SDL_GPUSampler *D3D12_CreateSampler(
     SDL_GPURenderer *driverData,
-    const SDL_GPUSamplerCreateInfo *samplerCreateInfo)
+    const SDL_GPUSamplerCreateInfo *createinfo)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
     D3D12Sampler *sampler = (D3D12Sampler *)SDL_calloc(1, sizeof(D3D12Sampler));
@@ -2627,19 +2627,19 @@ static SDL_GPUSampler *D3D12_CreateSampler(
     D3D12_SAMPLER_DESC samplerDesc;
 
     samplerDesc.Filter = SDLToD3D12_Filter(
-        samplerCreateInfo->minFilter,
-        samplerCreateInfo->magFilter,
-        samplerCreateInfo->mipmapMode,
-        samplerCreateInfo->compareEnable,
-        samplerCreateInfo->anisotropyEnable);
-    samplerDesc.AddressU = SDLToD3D12_SamplerAddressMode[samplerCreateInfo->addressModeU];
-    samplerDesc.AddressV = SDLToD3D12_SamplerAddressMode[samplerCreateInfo->addressModeV];
-    samplerDesc.AddressW = SDLToD3D12_SamplerAddressMode[samplerCreateInfo->addressModeW];
-    samplerDesc.MaxAnisotropy = (Uint32)samplerCreateInfo->maxAnisotropy;
-    samplerDesc.ComparisonFunc = SDLToD3D12_CompareOp[samplerCreateInfo->compareOp];
-    samplerDesc.MinLOD = samplerCreateInfo->minLod;
-    samplerDesc.MaxLOD = samplerCreateInfo->maxLod;
-    samplerDesc.MipLODBias = samplerCreateInfo->mipLodBias;
+        createinfo->min_filter,
+        createinfo->mag_filter,
+        createinfo->mipmap_mode,
+        createinfo->enable_compare,
+        createinfo->enable_anisotropy);
+    samplerDesc.AddressU = SDLToD3D12_SamplerAddressMode[createinfo->address_mode_u];
+    samplerDesc.AddressV = SDLToD3D12_SamplerAddressMode[createinfo->address_mode_v];
+    samplerDesc.AddressW = SDLToD3D12_SamplerAddressMode[createinfo->address_mode_w];
+    samplerDesc.MaxAnisotropy = (Uint32)createinfo->max_anisotropy;
+    samplerDesc.ComparisonFunc = SDLToD3D12_CompareOp[createinfo->compare_op];
+    samplerDesc.MinLOD = createinfo->min_lod;
+    samplerDesc.MaxLOD = createinfo->max_lod;
+    samplerDesc.MipLODBias = createinfo->mip_lod_bias;
     samplerDesc.BorderColor[0] = 0;
     samplerDesc.BorderColor[1] = 0;
     samplerDesc.BorderColor[2] = 0;
@@ -2655,14 +2655,14 @@ static SDL_GPUSampler *D3D12_CreateSampler(
         &samplerDesc,
         sampler->handle.cpuHandle);
 
-    sampler->createInfo = *samplerCreateInfo;
+    sampler->createInfo = *createinfo;
     SDL_AtomicSet(&sampler->referenceCount, 0);
     return (SDL_GPUSampler *)sampler;
 }
 
 static SDL_GPUShader *D3D12_CreateShader(
     SDL_GPURenderer *driverData,
-    const SDL_GPUShaderCreateInfo *shaderCreateInfo)
+    const SDL_GPUShaderCreateInfo *createinfo)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
     void *bytecode;
@@ -2671,11 +2671,11 @@ static SDL_GPUShader *D3D12_CreateShader(
 
     if (!D3D12_INTERNAL_CreateShaderBytecode(
             renderer,
-            shaderCreateInfo->stage,
-            shaderCreateInfo->format,
-            shaderCreateInfo->code,
-            shaderCreateInfo->codeSize,
-            shaderCreateInfo->entryPointName,
+            createinfo->stage,
+            createinfo->format,
+            createinfo->code,
+            createinfo->code_size,
+            createinfo->entrypoint_name,
             &bytecode,
             &bytecodeSize)) {
         return NULL;
@@ -2685,10 +2685,10 @@ static SDL_GPUShader *D3D12_CreateShader(
         SDL_free(bytecode);
         return NULL;
     }
-    shader->samplerCount = shaderCreateInfo->samplerCount;
-    shader->storageBufferCount = shaderCreateInfo->storageBufferCount;
-    shader->storageTextureCount = shaderCreateInfo->storageTextureCount;
-    shader->uniformBufferCount = shaderCreateInfo->uniformBufferCount;
+    shader->num_samplers = createinfo->num_samplers;
+    shader->num_storage_buffers = createinfo->num_storage_buffers;
+    shader->num_storage_textures = createinfo->num_storage_textures;
+    shader->num_uniform_buffers = createinfo->num_uniform_buffers;
 
     shader->bytecode = bytecode;
     shader->bytecodeSize = bytecodeSize;
@@ -2698,7 +2698,7 @@ static SDL_GPUShader *D3D12_CreateShader(
 
 static D3D12Texture *D3D12_INTERNAL_CreateTexture(
     D3D12Renderer *renderer,
-    const SDL_GPUTextureCreateInfo *textureCreateInfo,
+    const SDL_GPUTextureCreateInfo *createinfo,
     bool isSwapchainTexture)
 {
     D3D12Texture *texture;
@@ -2717,26 +2717,26 @@ static D3D12Texture *D3D12_INTERNAL_CreateTexture(
         return NULL;
     }
 
-    Uint32 layerCount = textureCreateInfo->type == SDL_GPU_TEXTURETYPE_3D ? 1 : textureCreateInfo->layerCountOrDepth;
-    Uint32 depth = textureCreateInfo->type == SDL_GPU_TEXTURETYPE_3D ? textureCreateInfo->layerCountOrDepth : 1;
+    Uint32 layerCount = createinfo->type == SDL_GPU_TEXTURETYPE_3D ? 1 : createinfo->layer_count_or_depth;
+    Uint32 depth = createinfo->type == SDL_GPU_TEXTURETYPE_3D ? createinfo->layer_count_or_depth : 1;
 
-    if (textureCreateInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
+    if (createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
         resourceFlags |= D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
         useClearValue = true;
-        clearValue.Color[0] = SDL_GetFloatProperty(textureCreateInfo->props, SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_R_FLOAT, 0);
-        clearValue.Color[1] = SDL_GetFloatProperty(textureCreateInfo->props, SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_G_FLOAT, 0);
-        clearValue.Color[2] = SDL_GetFloatProperty(textureCreateInfo->props, SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_B_FLOAT, 0);
-        clearValue.Color[3] = SDL_GetFloatProperty(textureCreateInfo->props, SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_A_FLOAT, 0);
+        clearValue.Color[0] = SDL_GetFloatProperty(createinfo->props, SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_R_FLOAT, 0);
+        clearValue.Color[1] = SDL_GetFloatProperty(createinfo->props, SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_G_FLOAT, 0);
+        clearValue.Color[2] = SDL_GetFloatProperty(createinfo->props, SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_B_FLOAT, 0);
+        clearValue.Color[3] = SDL_GetFloatProperty(createinfo->props, SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_A_FLOAT, 0);
     }
 
-    if (textureCreateInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
+    if (createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
         resourceFlags |= D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
         useClearValue = true;
-        clearValue.DepthStencil.Depth = SDL_GetFloatProperty(textureCreateInfo->props, SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_DEPTH_FLOAT, 0);
-        clearValue.DepthStencil.Stencil = (UINT8)SDL_GetNumberProperty(textureCreateInfo->props, SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_STENCIL_UINT8, 0);
+        clearValue.DepthStencil.Depth = SDL_GetFloatProperty(createinfo->props, SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_DEPTH_FLOAT, 0);
+        clearValue.DepthStencil.Stencil = (UINT8)SDL_GetNumberProperty(createinfo->props, SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_STENCIL_UINT8, 0);
     }
 
-    if (textureCreateInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
+    if (createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
         resourceFlags |= D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     }
 
@@ -2748,14 +2748,14 @@ static D3D12Texture *D3D12_INTERNAL_CreateTexture(
 
     heapFlags = isSwapchainTexture ? D3D12_HEAP_FLAG_ALLOW_DISPLAY : D3D12_HEAP_FLAG_NONE;
 
-    if (textureCreateInfo->type != SDL_GPU_TEXTURETYPE_3D) {
+    if (createinfo->type != SDL_GPU_TEXTURETYPE_3D) {
         desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
         desc.Alignment = isSwapchainTexture ? 0 : D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
-        desc.Width = textureCreateInfo->width;
-        desc.Height = textureCreateInfo->height;
-        desc.DepthOrArraySize = (UINT16)textureCreateInfo->layerCountOrDepth;
-        desc.MipLevels = (UINT16)textureCreateInfo->levelCount;
-        desc.Format = SDLToD3D12_TextureFormat[textureCreateInfo->format];
+        desc.Width = createinfo->width;
+        desc.Height = createinfo->height;
+        desc.DepthOrArraySize = (UINT16)createinfo->layer_count_or_depth;
+        desc.MipLevels = (UINT16)createinfo->num_levels;
+        desc.Format = SDLToD3D12_TextureFormat[createinfo->format];
         desc.SampleDesc.Count = 1;
         desc.SampleDesc.Quality = 0;
         desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN; // Apparently this is the most efficient choice
@@ -2763,18 +2763,18 @@ static D3D12Texture *D3D12_INTERNAL_CreateTexture(
     } else {
         desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE3D;
         desc.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
-        desc.Width = textureCreateInfo->width;
-        desc.Height = textureCreateInfo->height;
-        desc.DepthOrArraySize = (UINT16)textureCreateInfo->layerCountOrDepth;
-        desc.MipLevels = (UINT16)textureCreateInfo->levelCount;
-        desc.Format = SDLToD3D12_TextureFormat[textureCreateInfo->format];
+        desc.Width = createinfo->width;
+        desc.Height = createinfo->height;
+        desc.DepthOrArraySize = (UINT16)createinfo->layer_count_or_depth;
+        desc.MipLevels = (UINT16)createinfo->num_levels;
+        desc.Format = SDLToD3D12_TextureFormat[createinfo->format];
         desc.SampleDesc.Count = 1;
         desc.SampleDesc.Quality = 0;
         desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
         desc.Flags = resourceFlags;
     }
 
-    initialState = isSwapchainTexture ? D3D12_RESOURCE_STATE_PRESENT : D3D12_INTERNAL_DefaultTextureResourceState(textureCreateInfo->usageFlags);
+    initialState = isSwapchainTexture ? D3D12_RESOURCE_STATE_PRESENT : D3D12_INTERNAL_DefaultTextureResourceState(createinfo->usage_flags);
     clearValue.Format = desc.Format;
 
     res = ID3D12Device_CreateCommittedResource(
@@ -2795,9 +2795,9 @@ static D3D12Texture *D3D12_INTERNAL_CreateTexture(
     texture->resource = handle;
 
     // Create the SRV if applicable
-    if ((textureCreateInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_SAMPLER) ||
-        (textureCreateInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ) ||
-        (textureCreateInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ)) {
+    if ((createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_SAMPLER) ||
+        (createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ) ||
+        (createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ)) {
         D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc;
 
         D3D12_INTERNAL_AssignCpuDescriptorHandle(
@@ -2805,30 +2805,30 @@ static D3D12Texture *D3D12_INTERNAL_CreateTexture(
             D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
             &texture->srvHandle);
 
-        srvDesc.Format = SDLToD3D12_TextureFormat[textureCreateInfo->format];
+        srvDesc.Format = SDLToD3D12_TextureFormat[createinfo->format];
         srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
 
-        if (textureCreateInfo->type == SDL_GPU_TEXTURETYPE_CUBE) {
+        if (createinfo->type == SDL_GPU_TEXTURETYPE_CUBE) {
             srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURECUBE;
-            srvDesc.TextureCube.MipLevels = textureCreateInfo->levelCount;
+            srvDesc.TextureCube.MipLevels = createinfo->num_levels;
             srvDesc.TextureCube.MostDetailedMip = 0;
             srvDesc.TextureCube.ResourceMinLODClamp = 0;
-        } else if (textureCreateInfo->type == SDL_GPU_TEXTURETYPE_2D_ARRAY) {
+        } else if (createinfo->type == SDL_GPU_TEXTURETYPE_2D_ARRAY) {
             srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DARRAY;
-            srvDesc.Texture2DArray.MipLevels = textureCreateInfo->levelCount;
+            srvDesc.Texture2DArray.MipLevels = createinfo->num_levels;
             srvDesc.Texture2DArray.MostDetailedMip = 0;
             srvDesc.Texture2DArray.FirstArraySlice = 0;
             srvDesc.Texture2DArray.ArraySize = layerCount;
             srvDesc.Texture2DArray.ResourceMinLODClamp = 0;
             srvDesc.Texture2DArray.PlaneSlice = 0;
-        } else if (textureCreateInfo->type == SDL_GPU_TEXTURETYPE_3D) {
+        } else if (createinfo->type == SDL_GPU_TEXTURETYPE_3D) {
             srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE3D;
-            srvDesc.Texture3D.MipLevels = textureCreateInfo->levelCount;
+            srvDesc.Texture3D.MipLevels = createinfo->num_levels;
             srvDesc.Texture3D.MostDetailedMip = 0;
             srvDesc.Texture3D.ResourceMinLODClamp = 0; // default behavior
         } else {
             srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-            srvDesc.Texture2D.MipLevels = textureCreateInfo->levelCount;
+            srvDesc.Texture2D.MipLevels = createinfo->num_levels;
             srvDesc.Texture2D.MostDetailedMip = 0;
             srvDesc.Texture2D.PlaneSlice = 0;
             srvDesc.Texture2D.ResourceMinLODClamp = 0; // default behavior
@@ -2843,7 +2843,7 @@ static D3D12Texture *D3D12_INTERNAL_CreateTexture(
 
     SDL_AtomicSet(&texture->referenceCount, 0);
 
-    texture->subresourceCount = textureCreateInfo->levelCount * layerCount;
+    texture->subresourceCount = createinfo->num_levels * layerCount;
     texture->subresources = (D3D12TextureSubresource *)SDL_calloc(
         texture->subresourceCount, sizeof(D3D12TextureSubresource));
     if (!texture->subresources) {
@@ -2851,11 +2851,11 @@ static D3D12Texture *D3D12_INTERNAL_CreateTexture(
         return NULL;
     }
     for (Uint32 layerIndex = 0; layerIndex < layerCount; layerIndex += 1) {
-        for (Uint32 levelIndex = 0; levelIndex < textureCreateInfo->levelCount; levelIndex += 1) {
+        for (Uint32 levelIndex = 0; levelIndex < createinfo->num_levels; levelIndex += 1) {
             Uint32 subresourceIndex = D3D12_INTERNAL_CalcSubresource(
                 levelIndex,
                 layerIndex,
-                textureCreateInfo->levelCount);
+                createinfo->num_levels);
 
             texture->subresources[subresourceIndex].parent = texture;
             texture->subresources[subresourceIndex].layer = layerIndex;
@@ -2868,7 +2868,7 @@ static D3D12Texture *D3D12_INTERNAL_CreateTexture(
             texture->subresources[subresourceIndex].dsvHandle.heap = NULL;
 
             // Create RTV if needed
-            if (textureCreateInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
+            if (createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
                 texture->subresources[subresourceIndex].rtvHandles = (D3D12CPUDescriptor *)SDL_calloc(depth, sizeof(D3D12CPUDescriptor));
 
                 for (Uint32 depthIndex = 0; depthIndex < depth; depthIndex += 1) {
@@ -2879,15 +2879,15 @@ static D3D12Texture *D3D12_INTERNAL_CreateTexture(
                         D3D12_DESCRIPTOR_HEAP_TYPE_RTV,
                         &texture->subresources[subresourceIndex].rtvHandles[depthIndex]);
 
-                    rtvDesc.Format = SDLToD3D12_TextureFormat[textureCreateInfo->format];
+                    rtvDesc.Format = SDLToD3D12_TextureFormat[createinfo->format];
 
-                    if (textureCreateInfo->type == SDL_GPU_TEXTURETYPE_2D_ARRAY || textureCreateInfo->type == SDL_GPU_TEXTURETYPE_CUBE) {
+                    if (createinfo->type == SDL_GPU_TEXTURETYPE_2D_ARRAY || createinfo->type == SDL_GPU_TEXTURETYPE_CUBE) {
                         rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2DARRAY;
                         rtvDesc.Texture2DArray.MipSlice = levelIndex;
                         rtvDesc.Texture2DArray.FirstArraySlice = layerIndex;
                         rtvDesc.Texture2DArray.ArraySize = 1;
                         rtvDesc.Texture2DArray.PlaneSlice = 0;
-                    } else if (textureCreateInfo->type == SDL_GPU_TEXTURETYPE_3D) {
+                    } else if (createinfo->type == SDL_GPU_TEXTURETYPE_3D) {
                         rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE3D;
                         rtvDesc.Texture3D.MipSlice = levelIndex;
                         rtvDesc.Texture3D.FirstWSlice = depthIndex;
@@ -2907,7 +2907,7 @@ static D3D12Texture *D3D12_INTERNAL_CreateTexture(
             }
 
             // Create DSV if needed
-            if (textureCreateInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
+            if (createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
                 D3D12_DEPTH_STENCIL_VIEW_DESC dsvDesc;
 
                 D3D12_INTERNAL_AssignCpuDescriptorHandle(
@@ -2915,7 +2915,7 @@ static D3D12Texture *D3D12_INTERNAL_CreateTexture(
                     D3D12_DESCRIPTOR_HEAP_TYPE_DSV,
                     &texture->subresources[subresourceIndex].dsvHandle);
 
-                dsvDesc.Format = SDLToD3D12_TextureFormat[textureCreateInfo->format];
+                dsvDesc.Format = SDLToD3D12_TextureFormat[createinfo->format];
                 dsvDesc.Flags = (D3D12_DSV_FLAGS)0;
                 dsvDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
                 dsvDesc.Texture2D.MipSlice = levelIndex;
@@ -2928,7 +2928,7 @@ static D3D12Texture *D3D12_INTERNAL_CreateTexture(
             }
 
             // Create subresource UAV if necessary
-            if (textureCreateInfo->usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
+            if (createinfo->usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
                 D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc;
 
                 D3D12_INTERNAL_AssignCpuDescriptorHandle(
@@ -2936,14 +2936,14 @@ static D3D12Texture *D3D12_INTERNAL_CreateTexture(
                     D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
                     &texture->subresources[subresourceIndex].uavHandle);
 
-                uavDesc.Format = SDLToD3D12_TextureFormat[textureCreateInfo->format];
+                uavDesc.Format = SDLToD3D12_TextureFormat[createinfo->format];
 
-                if (textureCreateInfo->type == SDL_GPU_TEXTURETYPE_2D_ARRAY || textureCreateInfo->type == SDL_GPU_TEXTURETYPE_CUBE) {
+                if (createinfo->type == SDL_GPU_TEXTURETYPE_2D_ARRAY || createinfo->type == SDL_GPU_TEXTURETYPE_CUBE) {
                     uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE2DARRAY;
                     uavDesc.Texture2DArray.MipSlice = levelIndex;
                     uavDesc.Texture2DArray.FirstArraySlice = layerIndex;
                     uavDesc.Texture2DArray.ArraySize = 1;
-                } else if (textureCreateInfo->type == SDL_GPU_TEXTURETYPE_3D) {
+                } else if (createinfo->type == SDL_GPU_TEXTURETYPE_3D) {
                     uavDesc.ViewDimension = D3D12_UAV_DIMENSION_TEXTURE3D;
                     uavDesc.Texture3D.MipSlice = levelIndex;
                     uavDesc.Texture3D.FirstWSlice = 0;
@@ -2969,14 +2969,14 @@ static D3D12Texture *D3D12_INTERNAL_CreateTexture(
 
 static SDL_GPUTexture *D3D12_CreateTexture(
     SDL_GPURenderer *driverData,
-    const SDL_GPUTextureCreateInfo *textureCreateInfo)
+    const SDL_GPUTextureCreateInfo *createinfo)
 {
     D3D12TextureContainer *container = (D3D12TextureContainer *)SDL_calloc(1, sizeof(D3D12TextureContainer));
     if (!container) {
         return NULL;
     }
 
-    container->header.info = *textureCreateInfo;
+    container->header.info = *createinfo;
     container->textureCapacity = 1;
     container->textureCount = 1;
     container->textures = (D3D12Texture **)SDL_calloc(
@@ -2992,7 +2992,7 @@ static SDL_GPUTexture *D3D12_CreateTexture(
 
     D3D12Texture *texture = D3D12_INTERNAL_CreateTexture(
         (D3D12Renderer *)driverData,
-        textureCreateInfo,
+        createinfo,
         false);
 
     if (!texture) {
@@ -3012,8 +3012,8 @@ static SDL_GPUTexture *D3D12_CreateTexture(
 
 static D3D12Buffer *D3D12_INTERNAL_CreateBuffer(
     D3D12Renderer *renderer,
-    SDL_GPUBufferUsageFlags usageFlags,
-    Uint32 sizeInBytes,
+    SDL_GPUBufferUsageFlags usage_flags,
+    Uint32 size,
     D3D12BufferType type)
 {
     D3D12Buffer *buffer;
@@ -3034,11 +3034,11 @@ static D3D12Buffer *D3D12_INTERNAL_CreateBuffer(
         return NULL;
     }
 
-    if (usageFlags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE) {
+    if (usage_flags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE) {
         resourceFlags |= D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     }
 #if (defined(SDL_PLATFORM_XBOXONE) || defined(SDL_PLATFORM_XBOXSERIES))
-    if (usageFlags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
+    if (usage_flags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
         resourceFlags |= D3D12XBOX_RESOURCE_FLAG_ALLOW_INDIRECT_BUFFER;
     }
 #endif
@@ -3083,7 +3083,7 @@ static D3D12Buffer *D3D12_INTERNAL_CreateBuffer(
 
     desc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
     desc.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
-    desc.Width = sizeInBytes;
+    desc.Width = size;
     desc.Height = 1;
     desc.DepthOrArraySize = 1;
     desc.MipLevels = 1;
@@ -3115,7 +3115,7 @@ static D3D12Buffer *D3D12_INTERNAL_CreateBuffer(
     buffer->srvDescriptor.heap = NULL;
     buffer->cbvDescriptor.heap = NULL;
 
-    if (usageFlags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE) {
+    if (usage_flags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE) {
         D3D12_INTERNAL_AssignCpuDescriptorHandle(
             renderer,
             D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
@@ -3124,7 +3124,7 @@ static D3D12Buffer *D3D12_INTERNAL_CreateBuffer(
         uavDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
         uavDesc.Format = DXGI_FORMAT_R32_TYPELESS;
         uavDesc.Buffer.FirstElement = 0;
-        uavDesc.Buffer.NumElements = sizeInBytes / sizeof(Uint32);
+        uavDesc.Buffer.NumElements = size / sizeof(Uint32);
         uavDesc.Buffer.Flags = D3D12_BUFFER_UAV_FLAG_RAW;
         uavDesc.Buffer.CounterOffsetInBytes = 0; // TODO: support counters?
         uavDesc.Buffer.StructureByteStride = 0;
@@ -3139,8 +3139,8 @@ static D3D12Buffer *D3D12_INTERNAL_CreateBuffer(
     }
 
     if (
-        (usageFlags & SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ) ||
-        (usageFlags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ)) {
+        (usage_flags & SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ) ||
+        (usage_flags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ)) {
         D3D12_INTERNAL_AssignCpuDescriptorHandle(
             renderer,
             D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
@@ -3150,7 +3150,7 @@ static D3D12Buffer *D3D12_INTERNAL_CreateBuffer(
         srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
         srvDesc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
         srvDesc.Buffer.FirstElement = 0;
-        srvDesc.Buffer.NumElements = sizeInBytes / sizeof(Uint32);
+        srvDesc.Buffer.NumElements = size / sizeof(Uint32);
         srvDesc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_RAW;
         srvDesc.Buffer.StructureByteStride = 0;
 
@@ -3170,7 +3170,7 @@ static D3D12Buffer *D3D12_INTERNAL_CreateBuffer(
             &buffer->cbvDescriptor);
 
         cbvDesc.BufferLocation = ID3D12Resource_GetGPUVirtualAddress(handle);
-        cbvDesc.SizeInBytes = sizeInBytes;
+        cbvDesc.SizeInBytes = size;
 
         // Create CBV
         ID3D12Device_CreateConstantBufferView(
@@ -3209,8 +3209,8 @@ static D3D12Buffer *D3D12_INTERNAL_CreateBuffer(
 
 static D3D12BufferContainer *D3D12_INTERNAL_CreateBufferContainer(
     D3D12Renderer *renderer,
-    SDL_GPUBufferUsageFlags usageFlags,
-    Uint32 sizeInBytes,
+    SDL_GPUBufferUsageFlags usage_flags,
+    Uint32 size,
     D3D12BufferType type)
 {
     D3D12BufferContainer *container;
@@ -3221,8 +3221,8 @@ static D3D12BufferContainer *D3D12_INTERNAL_CreateBufferContainer(
         return NULL;
     }
 
-    container->usageFlags = usageFlags;
-    container->size = sizeInBytes;
+    container->usage_flags = usage_flags;
+    container->size = size;
     container->type = type;
 
     container->bufferCapacity = 1;
@@ -3237,8 +3237,8 @@ static D3D12BufferContainer *D3D12_INTERNAL_CreateBufferContainer(
 
     buffer = D3D12_INTERNAL_CreateBuffer(
         renderer,
-        usageFlags,
-        sizeInBytes,
+        usage_flags,
+        size,
         type);
 
     if (buffer == NULL) {
@@ -3258,25 +3258,25 @@ static D3D12BufferContainer *D3D12_INTERNAL_CreateBufferContainer(
 
 static SDL_GPUBuffer *D3D12_CreateBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUBufferUsageFlags usageFlags,
-    Uint32 sizeInBytes)
+    SDL_GPUBufferUsageFlags usage_flags,
+    Uint32 size)
 {
     return (SDL_GPUBuffer *)D3D12_INTERNAL_CreateBufferContainer(
         (D3D12Renderer *)driverData,
-        usageFlags,
-        sizeInBytes,
+        usage_flags,
+        size,
         D3D12_BUFFER_TYPE_GPU);
 }
 
 static SDL_GPUTransferBuffer *D3D12_CreateTransferBuffer(
     SDL_GPURenderer *driverData,
     SDL_GPUTransferBufferUsage usage,
-    Uint32 sizeInBytes)
+    Uint32 size)
 {
     return (SDL_GPUTransferBuffer *)D3D12_INTERNAL_CreateBufferContainer(
         (D3D12Renderer *)driverData,
         0,
-        sizeInBytes,
+        size,
         usage == SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD ? D3D12_BUFFER_TYPE_UPLOAD : D3D12_BUFFER_TYPE_DOWNLOAD);
 }
 
@@ -3291,7 +3291,7 @@ static void D3D12_SetBufferName(
     D3D12BufferContainer *container = (D3D12BufferContainer *)buffer;
     size_t textLength = SDL_strlen(text) + 1;
 
-    if (renderer->debugMode) {
+    if (renderer->debug_mode) {
         container->debugName = (char *)SDL_realloc(
             container->debugName,
             textLength);
@@ -3319,7 +3319,7 @@ static void D3D12_SetTextureName(
     D3D12TextureContainer *container = (D3D12TextureContainer *)texture;
     size_t textLength = SDL_strlen(text) + 1;
 
-    if (renderer->debugMode) {
+    if (renderer->debug_mode) {
         container->debugName = (char *)SDL_realloc(
             container->debugName,
             textLength);
@@ -3384,10 +3384,10 @@ static bool D3D12_INTERNAL_StrToWStr(
 }
 
 static void D3D12_InsertDebugLabel(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const char *text)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     wchar_t wstr[256];
     Uint32 convSize;
 
@@ -3408,10 +3408,10 @@ static void D3D12_InsertDebugLabel(
 }
 
 static void D3D12_PushDebugGroup(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const char *name)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     wchar_t wstr[256];
     Uint32 convSize;
 
@@ -3432,9 +3432,9 @@ static void D3D12_PushDebugGroup(
 }
 
 static void D3D12_PopDebugGroup(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     ID3D12GraphicsCommandList_EndEvent(d3d12CommandBuffer->graphicsCommandList);
 }
 
@@ -3488,10 +3488,10 @@ static void D3D12_ReleaseBuffer(
 
 static void D3D12_ReleaseTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transferBuffer)
+    SDL_GPUTransferBuffer *transfer_buffer)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
-    D3D12BufferContainer *transferBufferContainer = (D3D12BufferContainer *)transferBuffer;
+    D3D12BufferContainer *transferBufferContainer = (D3D12BufferContainer *)transfer_buffer;
 
     D3D12_INTERNAL_ReleaseBufferContainer(
         renderer,
@@ -3514,10 +3514,10 @@ static void D3D12_ReleaseShader(
 
 static void D3D12_ReleaseComputePipeline(
     SDL_GPURenderer *driverData,
-    SDL_GPUComputePipeline *computePipeline)
+    SDL_GPUComputePipeline *compute_pipeline)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
-    D3D12ComputePipeline *d3d12ComputePipeline = (D3D12ComputePipeline *)computePipeline;
+    D3D12ComputePipeline *d3d12ComputePipeline = (D3D12ComputePipeline *)compute_pipeline;
 
     SDL_LockMutex(renderer->disposeLock);
 
@@ -3536,10 +3536,10 @@ static void D3D12_ReleaseComputePipeline(
 
 static void D3D12_ReleaseGraphicsPipeline(
     SDL_GPURenderer *driverData,
-    SDL_GPUGraphicsPipeline *graphicsPipeline)
+    SDL_GPUGraphicsPipeline *graphics_pipeline)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
-    D3D12GraphicsPipeline *d3d12GraphicsPipeline = (D3D12GraphicsPipeline *)graphicsPipeline;
+    D3D12GraphicsPipeline *d3d12GraphicsPipeline = (D3D12GraphicsPipeline *)graphics_pipeline;
 
     SDL_LockMutex(renderer->disposeLock);
 
@@ -3576,10 +3576,10 @@ static void D3D12_INTERNAL_ReleaseBlitPipelines(SDL_GPURenderer *driverData)
 // Render Pass
 
 static void D3D12_SetViewport(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUViewport *viewport)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     D3D12_VIEWPORT d3d12Viewport;
     d3d12Viewport.TopLeftX = viewport->x;
     d3d12Viewport.TopLeftY = viewport->y;
@@ -3591,10 +3591,10 @@ static void D3D12_SetViewport(
 }
 
 static void D3D12_SetScissor(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_Rect *scissor)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     D3D12_RECT scissorRect;
     scissorRect.left = scissor->x;
     scissorRect.top = scissor->y;
@@ -3604,19 +3604,19 @@ static void D3D12_SetScissor(
 }
 
 static void D3D12_SetBlendConstants(
-    SDL_GPUCommandBuffer *commandBuffer,
-    SDL_FColor blendConstants)
+    SDL_GPUCommandBuffer *command_buffer,
+    SDL_FColor blend_constants)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
-    FLOAT blendFactor[4] = { blendConstants.r, blendConstants.g, blendConstants.b, blendConstants.a };
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    FLOAT blendFactor[4] = { blend_constants.r, blend_constants.g, blend_constants.b, blend_constants.a };
     ID3D12GraphicsCommandList_OMSetBlendFactor(d3d12CommandBuffer->graphicsCommandList, blendFactor);
 }
 
 static void D3D12_SetStencilReference(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     Uint8 reference
 ) {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     ID3D12GraphicsCommandList_OMSetStencilRef(d3d12CommandBuffer->graphicsCommandList, reference);
 }
 
@@ -3628,7 +3628,7 @@ static D3D12TextureSubresource *D3D12_INTERNAL_FetchTextureSubresource(
     Uint32 index = D3D12_INTERNAL_CalcSubresource(
         level,
         layer,
-        container->header.info.levelCount);
+        container->header.info.num_levels);
     return &container->activeTexture->subresources[index];
 }
 
@@ -3673,7 +3673,7 @@ static void D3D12_INTERNAL_CycleActiveTexture(
 
     container->activeTexture = texture;
 
-    if (renderer->debugMode && container->debugName != NULL) {
+    if (renderer->debug_mode && container->debugName != NULL) {
         D3D12_INTERNAL_SetResourceName(
             renderer,
             container->activeTexture->resource,
@@ -3682,7 +3682,7 @@ static void D3D12_INTERNAL_CycleActiveTexture(
 }
 
 static D3D12TextureSubresource *D3D12_INTERNAL_PrepareTextureSubresourceForWrite(
-    D3D12CommandBuffer *commandBuffer,
+    D3D12CommandBuffer *command_buffer,
     D3D12TextureContainer *container,
     Uint32 layer,
     Uint32 level,
@@ -3699,7 +3699,7 @@ static D3D12TextureSubresource *D3D12_INTERNAL_PrepareTextureSubresourceForWrite
         cycle &&
         SDL_AtomicGet(&subresource->parent->referenceCount) > 0) {
         D3D12_INTERNAL_CycleActiveTexture(
-            commandBuffer->renderer,
+            command_buffer->renderer,
             container);
 
         subresource = D3D12_INTERNAL_FetchTextureSubresource(
@@ -3709,7 +3709,7 @@ static D3D12TextureSubresource *D3D12_INTERNAL_PrepareTextureSubresourceForWrite
     }
 
     D3D12_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
-        commandBuffer,
+        command_buffer,
         destinationUsageMode,
         subresource);
 
@@ -3732,7 +3732,7 @@ static void D3D12_INTERNAL_CycleActiveBuffer(
     // No buffer handle is available, create a new one.
     D3D12Buffer *buffer = D3D12_INTERNAL_CreateBuffer(
         renderer,
-        container->usageFlags,
+        container->usage_flags,
         container->size,
         container->type);
 
@@ -3755,7 +3755,7 @@ static void D3D12_INTERNAL_CycleActiveBuffer(
 
     container->activeBuffer = buffer;
 
-    if (renderer->debugMode && container->debugName != NULL) {
+    if (renderer->debug_mode && container->debugName != NULL) {
         D3D12_INTERNAL_SetResourceName(
             renderer,
             container->activeBuffer->handle,
@@ -3764,7 +3764,7 @@ static void D3D12_INTERNAL_CycleActiveBuffer(
 }
 
 static D3D12Buffer *D3D12_INTERNAL_PrepareBufferForWrite(
-    D3D12CommandBuffer *commandBuffer,
+    D3D12CommandBuffer *command_buffer,
     D3D12BufferContainer *container,
     bool cycle,
     D3D12_RESOURCE_STATES destinationState)
@@ -3773,12 +3773,12 @@ static D3D12Buffer *D3D12_INTERNAL_PrepareBufferForWrite(
         cycle &&
         SDL_AtomicGet(&container->activeBuffer->referenceCount) > 0) {
         D3D12_INTERNAL_CycleActiveBuffer(
-            commandBuffer->renderer,
+            command_buffer->renderer,
             container);
     }
 
     D3D12_INTERNAL_BufferTransitionFromDefaultUsage(
-        commandBuffer,
+        command_buffer,
         destinationState,
         container->activeBuffer);
 
@@ -3786,20 +3786,20 @@ static D3D12Buffer *D3D12_INTERNAL_PrepareBufferForWrite(
 }
 
 static void D3D12_BeginRenderPass(
-    SDL_GPUCommandBuffer *commandBuffer,
-    const SDL_GPUColorAttachmentInfo *colorAttachmentInfos,
-    Uint32 colorAttachmentCount,
-    const SDL_GPUDepthStencilAttachmentInfo *depthStencilAttachmentInfo)
+    SDL_GPUCommandBuffer *command_buffer,
+    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
+    Uint32 num_color_attachments,
+    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
 
     Uint32 framebufferWidth = SDL_MAX_UINT32;
     Uint32 framebufferHeight = SDL_MAX_UINT32;
 
-    for (Uint32 i = 0; i < colorAttachmentCount; i += 1) {
-        D3D12TextureContainer *container = (D3D12TextureContainer *)colorAttachmentInfos[i].texture;
-        Uint32 h = container->header.info.height >> colorAttachmentInfos[i].mipLevel;
-        Uint32 w = container->header.info.width >> colorAttachmentInfos[i].mipLevel;
+    for (Uint32 i = 0; i < num_color_attachments; i += 1) {
+        D3D12TextureContainer *container = (D3D12TextureContainer *)color_attachment_infos[i].texture;
+        Uint32 h = container->header.info.height >> color_attachment_infos[i].mip_level;
+        Uint32 w = container->header.info.width >> color_attachment_infos[i].mip_level;
 
         // The framebuffer cannot be larger than the smallest attachment.
 
@@ -3811,14 +3811,14 @@ static void D3D12_BeginRenderPass(
             framebufferHeight = h;
         }
 
-        if (!(container->header.info.usageFlags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET)) {
+        if (!(container->header.info.usage_flags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET)) {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Color attachment texture was not designated as a color target!");
             return;
         }
     }
 
-    if (depthStencilAttachmentInfo != NULL) {
-        D3D12TextureContainer *container = (D3D12TextureContainer *)depthStencilAttachmentInfo->texture;
+    if (depth_stencil_attachment_info != NULL) {
+        D3D12TextureContainer *container = (D3D12TextureContainer *)depth_stencil_attachment_info->texture;
 
         Uint32 h = container->header.info.height;
         Uint32 w = container->header.info.width;
@@ -3834,7 +3834,7 @@ static void D3D12_BeginRenderPass(
         }
 
         // Fixme:
-        if (!(container->header.info.usageFlags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET)) {
+        if (!(container->header.info.usage_flags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET)) {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Depth stencil attachment texture was not designated as a depth target!");
             return;
         }
@@ -3842,31 +3842,31 @@ static void D3D12_BeginRenderPass(
 
     D3D12_CPU_DESCRIPTOR_HANDLE rtvs[MAX_COLOR_TARGET_BINDINGS];
 
-    for (Uint32 i = 0; i < colorAttachmentCount; i += 1) {
-        D3D12TextureContainer *container = (D3D12TextureContainer *)colorAttachmentInfos[i].texture;
+    for (Uint32 i = 0; i < num_color_attachments; i += 1) {
+        D3D12TextureContainer *container = (D3D12TextureContainer *)color_attachment_infos[i].texture;
         D3D12TextureSubresource *subresource = D3D12_INTERNAL_PrepareTextureSubresourceForWrite(
             d3d12CommandBuffer,
             container,
-            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorAttachmentInfos[i].layerOrDepthPlane,
-            colorAttachmentInfos[i].mipLevel,
-            colorAttachmentInfos[i].cycle,
+            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : color_attachment_infos[i].layer_or_depth_plane,
+            color_attachment_infos[i].mip_level,
+            color_attachment_infos[i].cycle,
             D3D12_RESOURCE_STATE_RENDER_TARGET);
 
-        Uint32 rtvIndex = container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? colorAttachmentInfos[i].layerOrDepthPlane : 0;
+        Uint32 rtvIndex = container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? color_attachment_infos[i].layer_or_depth_plane : 0;
         D3D12_CPU_DESCRIPTOR_HANDLE rtv =
             subresource->rtvHandles[rtvIndex].cpuHandle;
 
-        if (colorAttachmentInfos[i].loadOp == SDL_GPU_LOADOP_CLEAR) {
-            float clearColor[4];
-            clearColor[0] = colorAttachmentInfos[i].clearColor.r;
-            clearColor[1] = colorAttachmentInfos[i].clearColor.g;
-            clearColor[2] = colorAttachmentInfos[i].clearColor.b;
-            clearColor[3] = colorAttachmentInfos[i].clearColor.a;
+        if (color_attachment_infos[i].load_op == SDL_GPU_LOADOP_CLEAR) {
+            float clear_color[4];
+            clear_color[0] = color_attachment_infos[i].clear_color.r;
+            clear_color[1] = color_attachment_infos[i].clear_color.g;
+            clear_color[2] = color_attachment_infos[i].clear_color.b;
+            clear_color[3] = color_attachment_infos[i].clear_color.a;
 
             ID3D12GraphicsCommandList_ClearRenderTargetView(
                 d3d12CommandBuffer->graphicsCommandList,
                 rtv,
-                clearColor,
+                clear_color,
                 0,
                 NULL);
         }
@@ -3877,27 +3877,27 @@ static void D3D12_BeginRenderPass(
         D3D12_INTERNAL_TrackTexture(d3d12CommandBuffer, subresource->parent);
     }
 
-    d3d12CommandBuffer->colorAttachmentTextureSubresourceCount = colorAttachmentCount;
+    d3d12CommandBuffer->colorAttachmentTextureSubresourceCount = num_color_attachments;
 
     D3D12_CPU_DESCRIPTOR_HANDLE dsv;
-    if (depthStencilAttachmentInfo != NULL) {
-        D3D12TextureContainer *container = (D3D12TextureContainer *)depthStencilAttachmentInfo->texture;
+    if (depth_stencil_attachment_info != NULL) {
+        D3D12TextureContainer *container = (D3D12TextureContainer *)depth_stencil_attachment_info->texture;
         D3D12TextureSubresource *subresource = D3D12_INTERNAL_PrepareTextureSubresourceForWrite(
             d3d12CommandBuffer,
             container,
             0,
             0,
-            depthStencilAttachmentInfo->cycle,
+            depth_stencil_attachment_info->cycle,
             D3D12_RESOURCE_STATE_DEPTH_WRITE);
 
         if (
-            depthStencilAttachmentInfo->loadOp == SDL_GPU_LOADOP_CLEAR ||
-            depthStencilAttachmentInfo->stencilLoadOp == SDL_GPU_LOADOP_CLEAR) {
+            depth_stencil_attachment_info->load_op == SDL_GPU_LOADOP_CLEAR ||
+            depth_stencil_attachment_info->stencil_load_op == SDL_GPU_LOADOP_CLEAR) {
             D3D12_CLEAR_FLAGS clearFlags = (D3D12_CLEAR_FLAGS)0;
-            if (depthStencilAttachmentInfo->loadOp == SDL_GPU_LOADOP_CLEAR) {
+            if (depth_stencil_attachment_info->load_op == SDL_GPU_LOADOP_CLEAR) {
                 clearFlags |= D3D12_CLEAR_FLAG_DEPTH;
             }
-            if (depthStencilAttachmentInfo->stencilLoadOp == SDL_GPU_LOADOP_CLEAR) {
+            if (depth_stencil_attachment_info->stencil_load_op == SDL_GPU_LOADOP_CLEAR) {
                 clearFlags |= D3D12_CLEAR_FLAG_STENCIL;
             }
 
@@ -3905,8 +3905,8 @@ static void D3D12_BeginRenderPass(
                 d3d12CommandBuffer->graphicsCommandList,
                 subresource->dsvHandle.cpuHandle,
                 clearFlags,
-                depthStencilAttachmentInfo->depthStencilClearValue.depth,
-                depthStencilAttachmentInfo->depthStencilClearValue.stencil,
+                depth_stencil_attachment_info->clear_value.depth,
+                depth_stencil_attachment_info->clear_value.stencil,
                 0,
                 NULL);
         }
@@ -3918,10 +3918,10 @@ static void D3D12_BeginRenderPass(
 
     ID3D12GraphicsCommandList_OMSetRenderTargets(
         d3d12CommandBuffer->graphicsCommandList,
-        colorAttachmentCount,
+        num_color_attachments,
         rtvs,
         false,
-        (depthStencilAttachmentInfo == NULL) ? NULL : &dsv);
+        (depth_stencil_attachment_info == NULL) ? NULL : &dsv);
 
     // Set sensible default states
     SDL_GPUViewport defaultViewport;
@@ -3933,7 +3933,7 @@ static void D3D12_BeginRenderPass(
     defaultViewport.maxDepth = 1;
 
     D3D12_SetViewport(
-        commandBuffer,
+        command_buffer,
         &defaultViewport);
 
     SDL_Rect defaultScissor;
@@ -3943,48 +3943,48 @@ static void D3D12_BeginRenderPass(
     defaultScissor.h = (Sint32)framebufferHeight;
 
     D3D12_SetScissor(
-        commandBuffer,
+        command_buffer,
         &defaultScissor);
 
     D3D12_SetStencilReference(
-        commandBuffer,
+        command_buffer,
         0);
 
     D3D12_SetBlendConstants(
-        commandBuffer,
+        command_buffer,
         (SDL_FColor){ 1.0f, 1.0f, 1.0f, 1.0f });
 }
 
 static void D3D12_INTERNAL_TrackUniformBuffer(
-    D3D12CommandBuffer *commandBuffer,
+    D3D12CommandBuffer *command_buffer,
     D3D12UniformBuffer *uniformBuffer)
 {
     Uint32 i;
-    for (i = 0; i < commandBuffer->usedUniformBufferCount; i += 1) {
-        if (commandBuffer->usedUniformBuffers[i] == uniformBuffer) {
+    for (i = 0; i < command_buffer->usedUniformBufferCount; i += 1) {
+        if (command_buffer->usedUniformBuffers[i] == uniformBuffer) {
             return;
         }
     }
 
-    if (commandBuffer->usedUniformBufferCount == commandBuffer->usedUniformBufferCapacity) {
-        commandBuffer->usedUniformBufferCapacity += 1;
-        commandBuffer->usedUniformBuffers = (D3D12UniformBuffer **)SDL_realloc(
-            commandBuffer->usedUniformBuffers,
-            commandBuffer->usedUniformBufferCapacity * sizeof(D3D12UniformBuffer *));
+    if (command_buffer->usedUniformBufferCount == command_buffer->usedUniformBufferCapacity) {
+        command_buffer->usedUniformBufferCapacity += 1;
+        command_buffer->usedUniformBuffers = (D3D12UniformBuffer **)SDL_realloc(
+            command_buffer->usedUniformBuffers,
+            command_buffer->usedUniformBufferCapacity * sizeof(D3D12UniformBuffer *));
     }
 
-    commandBuffer->usedUniformBuffers[commandBuffer->usedUniformBufferCount] = uniformBuffer;
-    commandBuffer->usedUniformBufferCount += 1;
+    command_buffer->usedUniformBuffers[command_buffer->usedUniformBufferCount] = uniformBuffer;
+    command_buffer->usedUniformBufferCount += 1;
 
     D3D12_INTERNAL_TrackBuffer(
-        commandBuffer,
+        command_buffer,
         uniformBuffer->buffer);
 }
 
 static D3D12UniformBuffer *D3D12_INTERNAL_AcquireUniformBufferFromPool(
-    D3D12CommandBuffer *commandBuffer)
+    D3D12CommandBuffer *command_buffer)
 {
-    D3D12Renderer *renderer = commandBuffer->renderer;
+    D3D12Renderer *renderer = command_buffer->renderer;
     D3D12UniformBuffer *uniformBuffer;
 
     SDL_LockMutex(renderer->acquireUniformBufferLock);
@@ -4023,7 +4023,7 @@ static D3D12UniformBuffer *D3D12_INTERNAL_AcquireUniformBufferFromPool(
         (void **)&uniformBuffer->buffer->mapPointer);
     ERROR_CHECK_RETURN("Failed to map buffer pool!", NULL);
 
-    D3D12_INTERNAL_TrackUniformBuffer(commandBuffer, uniformBuffer);
+    D3D12_INTERNAL_TrackUniformBuffer(command_buffer, uniformBuffer);
 
     return uniformBuffer;
 }
@@ -4044,32 +4044,32 @@ static void D3D12_INTERNAL_ReturnUniformBufferToPool(
 }
 
 static void D3D12_INTERNAL_PushUniformData(
-    D3D12CommandBuffer *commandBuffer,
+    D3D12CommandBuffer *command_buffer,
     SDL_GPUShaderStage shaderStage,
-    Uint32 slotIndex,
+    Uint32 slot_index,
     const void *data,
-    Uint32 dataLengthInBytes)
+    Uint32 length)
 {
     D3D12UniformBuffer *uniformBuffer;
 
     if (shaderStage == SDL_GPU_SHADERSTAGE_VERTEX) {
-        if (commandBuffer->vertexUniformBuffers[slotIndex] == NULL) {
-            commandBuffer->vertexUniformBuffers[slotIndex] = D3D12_INTERNAL_AcquireUniformBufferFromPool(
-                commandBuffer);
+        if (command_buffer->vertexUniformBuffers[slot_index] == NULL) {
+            command_buffer->vertexUniformBuffers[slot_index] = D3D12_INTERNAL_AcquireUniformBufferFromPool(
+                command_buffer);
         }
-        uniformBuffer = commandBuffer->vertexUniformBuffers[slotIndex];
+        uniformBuffer = command_buffer->vertexUniformBuffers[slot_index];
     } else if (shaderStage == SDL_GPU_SHADERSTAGE_FRAGMENT) {
-        if (commandBuffer->fragmentUniformBuffers[slotIndex] == NULL) {
-            commandBuffer->fragmentUniformBuffers[slotIndex] = D3D12_INTERNAL_AcquireUniformBufferFromPool(
-                commandBuffer);
+        if (command_buffer->fragmentUniformBuffers[slot_index] == NULL) {
+            command_buffer->fragmentUniformBuffers[slot_index] = D3D12_INTERNAL_AcquireUniformBufferFromPool(
+                command_buffer);
         }
-        uniformBuffer = commandBuffer->fragmentUniformBuffers[slotIndex];
+        uniformBuffer = command_buffer->fragmentUniformBuffers[slot_index];
     } else if (shaderStage == SDL_GPU_SHADERSTAGE_COMPUTE) {
-        if (commandBuffer->computeUniformBuffers[slotIndex] == NULL) {
-            commandBuffer->computeUniformBuffers[slotIndex] = D3D12_INTERNAL_AcquireUniformBufferFromPool(
-                commandBuffer);
+        if (command_buffer->computeUniformBuffers[slot_index] == NULL) {
+            command_buffer->computeUniformBuffers[slot_index] = D3D12_INTERNAL_AcquireUniformBufferFromPool(
+                command_buffer);
         }
-        uniformBuffer = commandBuffer->computeUniformBuffers[slotIndex];
+        uniformBuffer = command_buffer->computeUniformBuffers[slot_index];
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
         return;
@@ -4077,7 +4077,7 @@ static void D3D12_INTERNAL_PushUniformData(
 
     uniformBuffer->currentBlockSize =
         D3D12_INTERNAL_Align(
-            dataLengthInBytes,
+            length,
             256);
 
     // If there is no more room, acquire a new uniform buffer
@@ -4088,17 +4088,17 @@ static void D3D12_INTERNAL_PushUniformData(
             NULL);
         uniformBuffer->buffer->mapPointer = NULL;
 
-        uniformBuffer = D3D12_INTERNAL_AcquireUniformBufferFromPool(commandBuffer);
+        uniformBuffer = D3D12_INTERNAL_AcquireUniformBufferFromPool(command_buffer);
 
         uniformBuffer->drawOffset = 0;
         uniformBuffer->writeOffset = 0;
 
         if (shaderStage == SDL_GPU_SHADERSTAGE_VERTEX) {
-            commandBuffer->vertexUniformBuffers[slotIndex] = uniformBuffer;
+            command_buffer->vertexUniformBuffers[slot_index] = uniformBuffer;
         } else if (shaderStage == SDL_GPU_SHADERSTAGE_FRAGMENT) {
-            commandBuffer->fragmentUniformBuffers[slotIndex] = uniformBuffer;
+            command_buffer->fragmentUniformBuffers[slot_index] = uniformBuffer;
         } else if (shaderStage == SDL_GPU_SHADERSTAGE_COMPUTE) {
-            commandBuffer->computeUniformBuffers[slotIndex] = uniformBuffer;
+            command_buffer->computeUniformBuffers[slot_index] = uniformBuffer;
         } else {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
         }
@@ -4109,27 +4109,27 @@ static void D3D12_INTERNAL_PushUniformData(
     SDL_memcpy(
         (Uint8 *)uniformBuffer->buffer->mapPointer + uniformBuffer->writeOffset,
         data,
-        dataLengthInBytes);
+        length);
 
     uniformBuffer->writeOffset += uniformBuffer->currentBlockSize;
 
     if (shaderStage == SDL_GPU_SHADERSTAGE_VERTEX) {
-        commandBuffer->needVertexUniformBufferBind[slotIndex] = true;
+        command_buffer->needVertexUniformBufferBind[slot_index] = true;
     } else if (shaderStage == SDL_GPU_SHADERSTAGE_FRAGMENT) {
-        commandBuffer->needFragmentUniformBufferBind[slotIndex] = true;
+        command_buffer->needFragmentUniformBufferBind[slot_index] = true;
     } else if (shaderStage == SDL_GPU_SHADERSTAGE_COMPUTE) {
-        commandBuffer->needComputeUniformBufferBind[slotIndex] = true;
+        command_buffer->needComputeUniformBufferBind[slot_index] = true;
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
     }
 }
 
 static void D3D12_BindGraphicsPipeline(
-    SDL_GPUCommandBuffer *commandBuffer,
-    SDL_GPUGraphicsPipeline *graphicsPipeline)
+    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUGraphicsPipeline *graphics_pipeline)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
-    D3D12GraphicsPipeline *pipeline = (D3D12GraphicsPipeline *)graphicsPipeline;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12GraphicsPipeline *pipeline = (D3D12GraphicsPipeline *)graphics_pipeline;
     Uint32 i;
 
     d3d12CommandBuffer->currentGraphicsPipeline = pipeline;
@@ -4137,7 +4137,7 @@ static void D3D12_BindGraphicsPipeline(
     // Set the pipeline state
     ID3D12GraphicsCommandList_SetPipelineState(d3d12CommandBuffer->graphicsCommandList, pipeline->pipelineState);
     ID3D12GraphicsCommandList_SetGraphicsRootSignature(d3d12CommandBuffer->graphicsCommandList, pipeline->rootSignature->handle);
-    ID3D12GraphicsCommandList_IASetPrimitiveTopology(d3d12CommandBuffer->graphicsCommandList, SDLToD3D12_PrimitiveType[pipeline->primitiveType]);
+    ID3D12GraphicsCommandList_IASetPrimitiveTopology(d3d12CommandBuffer->graphicsCommandList, SDLToD3D12_PrimitiveType[pipeline->primitive_type]);
 
     // Mark that bindings are needed
     d3d12CommandBuffer->needVertexSamplerBind = true;
@@ -4170,32 +4170,32 @@ static void D3D12_BindGraphicsPipeline(
 }
 
 static void D3D12_BindVertexBuffers(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstBinding,
-    const SDL_GPUBufferBinding *pBindings,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_binding,
+    const SDL_GPUBufferBinding *bindings,
+    Uint32 num_bindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        D3D12Buffer *currentBuffer = ((D3D12BufferContainer *)pBindings[i].buffer)->activeBuffer;
-        d3d12CommandBuffer->vertexBuffers[firstBinding + i] = currentBuffer;
-        d3d12CommandBuffer->vertexBufferOffsets[firstBinding + i] = pBindings[i].offset;
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        D3D12Buffer *currentBuffer = ((D3D12BufferContainer *)bindings[i].buffer)->activeBuffer;
+        d3d12CommandBuffer->vertexBuffers[first_binding + i] = currentBuffer;
+        d3d12CommandBuffer->vertexBufferOffsets[first_binding + i] = bindings[i].offset;
         D3D12_INTERNAL_TrackBuffer(d3d12CommandBuffer, currentBuffer);
     }
 
     d3d12CommandBuffer->vertexBufferCount =
-        SDL_max(d3d12CommandBuffer->vertexBufferCount, firstBinding + bindingCount);
+        SDL_max(d3d12CommandBuffer->vertexBufferCount, first_binding + num_bindings);
 
     d3d12CommandBuffer->needVertexBufferBind = true;
 }
 
 static void D3D12_BindIndexBuffer(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUBufferBinding *pBinding,
-    SDL_GPUIndexElementSize indexElementSize)
+    SDL_GPUIndexElementSize index_element_size)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     D3D12Buffer *buffer = ((D3D12BufferContainer *)pBinding->buffer)->activeBuffer;
     D3D12_INDEX_BUFFER_VIEW view;
 
@@ -4204,7 +4204,7 @@ static void D3D12_BindIndexBuffer(
     view.BufferLocation = buffer->virtualAddress + pBinding->offset;
     view.SizeInBytes = buffer->container->size - pBinding->offset;
     view.Format =
-        indexElementSize == SDL_GPU_INDEXELEMENTSIZE_16BIT ? DXGI_FORMAT_R16_UINT : DXGI_FORMAT_R32_UINT;
+        index_element_size == SDL_GPU_INDEXELEMENTSIZE_16BIT ? DXGI_FORMAT_R16_UINT : DXGI_FORMAT_R32_UINT;
 
     ID3D12GraphicsCommandList_IASetIndexBuffer(
         d3d12CommandBuffer->graphicsCommandList,
@@ -4212,16 +4212,16 @@ static void D3D12_BindIndexBuffer(
 }
 
 static void D3D12_BindVertexSamplers(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
+    Uint32 num_bindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        D3D12TextureContainer *container = (D3D12TextureContainer *)textureSamplerBindings[i].texture;
-        D3D12Sampler *sampler = (D3D12Sampler *)textureSamplerBindings[i].sampler;
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        D3D12TextureContainer *container = (D3D12TextureContainer *)texture_sampler_bindings[i].texture;
+        D3D12Sampler *sampler = (D3D12Sampler *)texture_sampler_bindings[i].sampler;
 
         D3D12_INTERNAL_TrackTexture(
             d3d12CommandBuffer,
@@ -4231,65 +4231,65 @@ static void D3D12_BindVertexSamplers(
             d3d12CommandBuffer,
             sampler);
 
-        d3d12CommandBuffer->vertexSamplers[firstSlot + i] = sampler;
-        d3d12CommandBuffer->vertexSamplerTextures[firstSlot + i] = container->activeTexture;
+        d3d12CommandBuffer->vertexSamplers[first_slot + i] = sampler;
+        d3d12CommandBuffer->vertexSamplerTextures[first_slot + i] = container->activeTexture;
     }
 
     d3d12CommandBuffer->needVertexSamplerBind = true;
 }
 
 static void D3D12_BindVertexStorageTextures(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    SDL_GPUTexture *const *storageTextures,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    SDL_GPUTexture *const *storage_textures,
+    Uint32 num_bindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        D3D12TextureContainer *container = (D3D12TextureContainer *)storageTextures[i];
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        D3D12TextureContainer *container = (D3D12TextureContainer *)storage_textures[i];
         D3D12Texture *texture = container->activeTexture;
 
         D3D12_INTERNAL_TrackTexture(d3d12CommandBuffer, texture);
 
-        d3d12CommandBuffer->vertexStorageTextures[firstSlot + i] = texture;
+        d3d12CommandBuffer->vertexStorageTextures[first_slot + i] = texture;
     }
 
     d3d12CommandBuffer->needVertexStorageTextureBind = true;
 }
 
 static void D3D12_BindVertexStorageBuffers(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    SDL_GPUBuffer *const *storageBuffers,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    SDL_GPUBuffer *const *storage_buffers,
+    Uint32 num_bindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        D3D12BufferContainer *container = (D3D12BufferContainer *)storageBuffers[i];
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        D3D12BufferContainer *container = (D3D12BufferContainer *)storage_buffers[i];
 
         D3D12_INTERNAL_TrackBuffer(
             d3d12CommandBuffer,
             container->activeBuffer);
 
-        d3d12CommandBuffer->vertexStorageBuffers[firstSlot + i] = container->activeBuffer;
+        d3d12CommandBuffer->vertexStorageBuffers[first_slot + i] = container->activeBuffer;
     }
 
     d3d12CommandBuffer->needVertexStorageBufferBind = true;
 }
 
 static void D3D12_BindFragmentSamplers(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
+    Uint32 num_bindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        D3D12TextureContainer *container = (D3D12TextureContainer *)textureSamplerBindings[i].texture;
-        D3D12Sampler *sampler = (D3D12Sampler *)textureSamplerBindings[i].sampler;
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        D3D12TextureContainer *container = (D3D12TextureContainer *)texture_sampler_bindings[i].texture;
+        D3D12Sampler *sampler = (D3D12Sampler *)texture_sampler_bindings[i].sampler;
 
         D3D12_INTERNAL_TrackTexture(
             d3d12CommandBuffer,
@@ -4299,94 +4299,94 @@ static void D3D12_BindFragmentSamplers(
             d3d12CommandBuffer,
             sampler);
 
-        d3d12CommandBuffer->fragmentSamplers[firstSlot + i] = sampler;
-        d3d12CommandBuffer->fragmentSamplerTextures[firstSlot + i] = container->activeTexture;
+        d3d12CommandBuffer->fragmentSamplers[first_slot + i] = sampler;
+        d3d12CommandBuffer->fragmentSamplerTextures[first_slot + i] = container->activeTexture;
     }
 
     d3d12CommandBuffer->needFragmentSamplerBind = true;
 }
 
 static void D3D12_BindFragmentStorageTextures(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    SDL_GPUTexture *const *storageTextures,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    SDL_GPUTexture *const *storage_textures,
+    Uint32 num_bindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        D3D12TextureContainer *container = (D3D12TextureContainer *)storageTextures[i];
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        D3D12TextureContainer *container = (D3D12TextureContainer *)storage_textures[i];
         D3D12Texture *texture = container->activeTexture;
 
         D3D12_INTERNAL_TrackTexture(d3d12CommandBuffer, texture);
 
-        d3d12CommandBuffer->fragmentStorageTextures[firstSlot + i] = texture;
+        d3d12CommandBuffer->fragmentStorageTextures[first_slot + i] = texture;
     }
 
     d3d12CommandBuffer->needFragmentStorageTextureBind = true;
 }
 
 static void D3D12_BindFragmentStorageBuffers(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    SDL_GPUBuffer *const *storageBuffers,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    SDL_GPUBuffer *const *storage_buffers,
+    Uint32 num_bindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        D3D12BufferContainer *container = (D3D12BufferContainer *)storageBuffers[i];
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        D3D12BufferContainer *container = (D3D12BufferContainer *)storage_buffers[i];
 
         D3D12_INTERNAL_TrackBuffer(
             d3d12CommandBuffer,
             container->activeBuffer);
 
-        d3d12CommandBuffer->fragmentStorageBuffers[firstSlot + i] = container->activeBuffer;
+        d3d12CommandBuffer->fragmentStorageBuffers[first_slot + i] = container->activeBuffer;
     }
 
     d3d12CommandBuffer->needFragmentStorageBufferBind = true;
 }
 
 static void D3D12_PushVertexUniformData(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 slotIndex,
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 slot_index,
     const void *data,
-    Uint32 dataLengthInBytes)
+    Uint32 length)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
 
     D3D12_INTERNAL_PushUniformData(
         d3d12CommandBuffer,
         SDL_GPU_SHADERSTAGE_VERTEX,
-        slotIndex,
+        slot_index,
         data,
-        dataLengthInBytes);
+        length);
 }
 
 static void D3D12_PushFragmentUniformData(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 slotIndex,
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 slot_index,
     const void *data,
-    Uint32 dataLengthInBytes)
+    Uint32 length)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
 
     D3D12_INTERNAL_PushUniformData(
         d3d12CommandBuffer,
         SDL_GPU_SHADERSTAGE_FRAGMENT,
-        slotIndex,
+        slot_index,
         data,
-        dataLengthInBytes);
+        length);
 }
 
 static void D3D12_INTERNAL_WriteGPUDescriptors(
-    D3D12CommandBuffer *commandBuffer,
+    D3D12CommandBuffer *command_buffer,
     D3D12_DESCRIPTOR_HEAP_TYPE heapType,
     D3D12_CPU_DESCRIPTOR_HANDLE *resourceDescriptorHandles,
     Uint32 resourceHandleCount,
     D3D12_GPU_DESCRIPTOR_HANDLE *gpuBaseDescriptor)
 {
-    D3D12DescriptorHeap *heap = commandBuffer->gpuDescriptorHeaps[heapType];
+    D3D12DescriptorHeap *heap = command_buffer->gpuDescriptorHeaps[heapType];
     D3D12_CPU_DESCRIPTOR_HANDLE gpuHeapCpuHandle;
 
     // FIXME: need to error on overflow
@@ -4395,7 +4395,7 @@ static void D3D12_INTERNAL_WriteGPUDescriptors(
 
     for (Uint32 i = 0; i < resourceHandleCount; i += 1) {
         ID3D12Device_CopyDescriptorsSimple(
-            commandBuffer->renderer->device,
+            command_buffer->renderer->device,
             1,
             gpuHeapCpuHandle,
             resourceDescriptorHandles[i],
@@ -4407,283 +4407,283 @@ static void D3D12_INTERNAL_WriteGPUDescriptors(
 }
 
 static void D3D12_INTERNAL_BindGraphicsResources(
-    D3D12CommandBuffer *commandBuffer)
+    D3D12CommandBuffer *command_buffer)
 {
-    D3D12GraphicsPipeline *graphicsPipeline = commandBuffer->currentGraphicsPipeline;
+    D3D12GraphicsPipeline *graphics_pipeline = command_buffer->currentGraphicsPipeline;
 
     D3D12_CPU_DESCRIPTOR_HANDLE cpuHandles[MAX_TEXTURE_SAMPLERS_PER_STAGE];
     D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptorHandle;
     D3D12_VERTEX_BUFFER_VIEW vertexBufferViews[MAX_BUFFER_BINDINGS];
 
-    if (commandBuffer->needVertexBufferBind) {
-        for (Uint32 i = 0; i < commandBuffer->vertexBufferCount; i += 1) {
-            vertexBufferViews[i].BufferLocation = commandBuffer->vertexBuffers[i]->virtualAddress + commandBuffer->vertexBufferOffsets[i];
-            vertexBufferViews[i].SizeInBytes = commandBuffer->vertexBuffers[i]->container->size - commandBuffer->vertexBufferOffsets[i];
-            vertexBufferViews[i].StrideInBytes = graphicsPipeline->vertexStrides[i];
+    if (command_buffer->needVertexBufferBind) {
+        for (Uint32 i = 0; i < command_buffer->vertexBufferCount; i += 1) {
+            vertexBufferViews[i].BufferLocation = command_buffer->vertexBuffers[i]->virtualAddress + command_buffer->vertexBufferOffsets[i];
+            vertexBufferViews[i].SizeInBytes = command_buffer->vertexBuffers[i]->container->size - command_buffer->vertexBufferOffsets[i];
+            vertexBufferViews[i].StrideInBytes = graphics_pipeline->vertexStrides[i];
         }
 
         ID3D12GraphicsCommandList_IASetVertexBuffers(
-            commandBuffer->graphicsCommandList,
+            command_buffer->graphicsCommandList,
             0,
-            commandBuffer->vertexBufferCount,
+            command_buffer->vertexBufferCount,
             vertexBufferViews);
     }
 
-    if (commandBuffer->needVertexSamplerBind) {
-        if (graphicsPipeline->vertexSamplerCount > 0) {
-            for (Uint32 i = 0; i < graphicsPipeline->vertexSamplerCount; i += 1) {
-                cpuHandles[i] = commandBuffer->vertexSamplers[i]->handle.cpuHandle;
+    if (command_buffer->needVertexSamplerBind) {
+        if (graphics_pipeline->vertexSamplerCount > 0) {
+            for (Uint32 i = 0; i < graphics_pipeline->vertexSamplerCount; i += 1) {
+                cpuHandles[i] = command_buffer->vertexSamplers[i]->handle.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                commandBuffer,
+                command_buffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER,
                 cpuHandles,
-                graphicsPipeline->vertexSamplerCount,
+                graphics_pipeline->vertexSamplerCount,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(
-                commandBuffer->graphicsCommandList,
-                graphicsPipeline->rootSignature->vertexSamplerRootIndex,
+                command_buffer->graphicsCommandList,
+                graphics_pipeline->rootSignature->vertexSamplerRootIndex,
                 gpuDescriptorHandle);
 
-            for (Uint32 i = 0; i < graphicsPipeline->vertexSamplerCount; i += 1) {
-                cpuHandles[i] = commandBuffer->vertexSamplerTextures[i]->srvHandle.cpuHandle;
+            for (Uint32 i = 0; i < graphics_pipeline->vertexSamplerCount; i += 1) {
+                cpuHandles[i] = command_buffer->vertexSamplerTextures[i]->srvHandle.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                commandBuffer,
+                command_buffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
                 cpuHandles,
-                graphicsPipeline->vertexSamplerCount,
+                graphics_pipeline->vertexSamplerCount,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(
-                commandBuffer->graphicsCommandList,
-                graphicsPipeline->rootSignature->vertexSamplerTextureRootIndex,
+                command_buffer->graphicsCommandList,
+                graphics_pipeline->rootSignature->vertexSamplerTextureRootIndex,
                 gpuDescriptorHandle);
         }
-        commandBuffer->needVertexSamplerBind = false;
+        command_buffer->needVertexSamplerBind = false;
     }
 
-    if (commandBuffer->needVertexStorageTextureBind) {
-        if (graphicsPipeline->vertexStorageTextureCount > 0) {
-            for (Uint32 i = 0; i < graphicsPipeline->vertexStorageTextureCount; i += 1) {
-                cpuHandles[i] = commandBuffer->vertexStorageTextures[i]->srvHandle.cpuHandle;
+    if (command_buffer->needVertexStorageTextureBind) {
+        if (graphics_pipeline->vertexStorageTextureCount > 0) {
+            for (Uint32 i = 0; i < graphics_pipeline->vertexStorageTextureCount; i += 1) {
+                cpuHandles[i] = command_buffer->vertexStorageTextures[i]->srvHandle.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                commandBuffer,
+                command_buffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
                 cpuHandles,
-                graphicsPipeline->vertexStorageTextureCount,
+                graphics_pipeline->vertexStorageTextureCount,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(
-                commandBuffer->graphicsCommandList,
-                graphicsPipeline->rootSignature->vertexStorageTextureRootIndex,
+                command_buffer->graphicsCommandList,
+                graphics_pipeline->rootSignature->vertexStorageTextureRootIndex,
                 gpuDescriptorHandle);
         }
-        commandBuffer->needVertexStorageTextureBind = false;
+        command_buffer->needVertexStorageTextureBind = false;
     }
 
-    if (commandBuffer->needVertexStorageBufferBind) {
-        if (graphicsPipeline->vertexStorageBufferCount > 0) {
-            for (Uint32 i = 0; i < graphicsPipeline->vertexStorageBufferCount; i += 1) {
-                cpuHandles[i] = commandBuffer->vertexStorageBuffers[i]->srvDescriptor.cpuHandle;
+    if (command_buffer->needVertexStorageBufferBind) {
+        if (graphics_pipeline->vertexStorageBufferCount > 0) {
+            for (Uint32 i = 0; i < graphics_pipeline->vertexStorageBufferCount; i += 1) {
+                cpuHandles[i] = command_buffer->vertexStorageBuffers[i]->srvDescriptor.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                commandBuffer,
+                command_buffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
                 cpuHandles,
-                graphicsPipeline->vertexStorageBufferCount,
+                graphics_pipeline->vertexStorageBufferCount,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(
-                commandBuffer->graphicsCommandList,
-                graphicsPipeline->rootSignature->vertexStorageBufferRootIndex,
+                command_buffer->graphicsCommandList,
+                graphics_pipeline->rootSignature->vertexStorageBufferRootIndex,
                 gpuDescriptorHandle);
         }
-        commandBuffer->needVertexStorageBufferBind = false;
+        command_buffer->needVertexStorageBufferBind = false;
     }
 
     for (Uint32 i = 0; i < MAX_UNIFORM_BUFFERS_PER_STAGE; i += 1) {
-        if (commandBuffer->needVertexUniformBufferBind[i]) {
-            if (graphicsPipeline->vertexUniformBufferCount > i) {
+        if (command_buffer->needVertexUniformBufferBind[i]) {
+            if (graphics_pipeline->vertexUniformBufferCount > i) {
                 ID3D12GraphicsCommandList_SetGraphicsRootConstantBufferView(
-                    commandBuffer->graphicsCommandList,
-                    graphicsPipeline->rootSignature->vertexUniformBufferRootIndex[i],
-                    commandBuffer->vertexUniformBuffers[i]->buffer->virtualAddress + commandBuffer->vertexUniformBuffers[i]->drawOffset);
+                    command_buffer->graphicsCommandList,
+                    graphics_pipeline->rootSignature->vertexUniformBufferRootIndex[i],
+                    command_buffer->vertexUniformBuffers[i]->buffer->virtualAddress + command_buffer->vertexUniformBuffers[i]->drawOffset);
             }
-            commandBuffer->needVertexUniformBufferBind[i] = false;
+            command_buffer->needVertexUniformBufferBind[i] = false;
         }
     }
 
-    if (commandBuffer->needFragmentSamplerBind) {
-        if (graphicsPipeline->fragmentSamplerCount > 0) {
-            for (Uint32 i = 0; i < graphicsPipeline->fragmentSamplerCount; i += 1) {
-                cpuHandles[i] = commandBuffer->fragmentSamplers[i]->handle.cpuHandle;
+    if (command_buffer->needFragmentSamplerBind) {
+        if (graphics_pipeline->fragmentSamplerCount > 0) {
+            for (Uint32 i = 0; i < graphics_pipeline->fragmentSamplerCount; i += 1) {
+                cpuHandles[i] = command_buffer->fragmentSamplers[i]->handle.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                commandBuffer,
+                command_buffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER,
                 cpuHandles,
-                graphicsPipeline->fragmentSamplerCount,
+                graphics_pipeline->fragmentSamplerCount,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(
-                commandBuffer->graphicsCommandList,
-                graphicsPipeline->rootSignature->fragmentSamplerRootIndex,
+                command_buffer->graphicsCommandList,
+                graphics_pipeline->rootSignature->fragmentSamplerRootIndex,
                 gpuDescriptorHandle);
 
-            for (Uint32 i = 0; i < graphicsPipeline->fragmentSamplerCount; i += 1) {
-                cpuHandles[i] = commandBuffer->fragmentSamplerTextures[i]->srvHandle.cpuHandle;
+            for (Uint32 i = 0; i < graphics_pipeline->fragmentSamplerCount; i += 1) {
+                cpuHandles[i] = command_buffer->fragmentSamplerTextures[i]->srvHandle.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                commandBuffer,
+                command_buffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
                 cpuHandles,
-                graphicsPipeline->fragmentSamplerCount,
+                graphics_pipeline->fragmentSamplerCount,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(
-                commandBuffer->graphicsCommandList,
-                graphicsPipeline->rootSignature->fragmentSamplerTextureRootIndex,
+                command_buffer->graphicsCommandList,
+                graphics_pipeline->rootSignature->fragmentSamplerTextureRootIndex,
                 gpuDescriptorHandle);
         }
-        commandBuffer->needFragmentSamplerBind = false;
+        command_buffer->needFragmentSamplerBind = false;
     }
 
-    if (commandBuffer->needFragmentStorageTextureBind) {
-        if (graphicsPipeline->fragmentStorageTextureCount > 0) {
-            for (Uint32 i = 0; i < graphicsPipeline->fragmentStorageTextureCount; i += 1) {
-                cpuHandles[i] = commandBuffer->fragmentStorageTextures[i]->srvHandle.cpuHandle;
+    if (command_buffer->needFragmentStorageTextureBind) {
+        if (graphics_pipeline->fragmentStorageTextureCount > 0) {
+            for (Uint32 i = 0; i < graphics_pipeline->fragmentStorageTextureCount; i += 1) {
+                cpuHandles[i] = command_buffer->fragmentStorageTextures[i]->srvHandle.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                commandBuffer,
+                command_buffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
                 cpuHandles,
-                graphicsPipeline->fragmentStorageTextureCount,
+                graphics_pipeline->fragmentStorageTextureCount,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(
-                commandBuffer->graphicsCommandList,
-                graphicsPipeline->rootSignature->fragmentStorageTextureRootIndex,
+                command_buffer->graphicsCommandList,
+                graphics_pipeline->rootSignature->fragmentStorageTextureRootIndex,
                 gpuDescriptorHandle);
         }
-        commandBuffer->needFragmentStorageTextureBind = false;
+        command_buffer->needFragmentStorageTextureBind = false;
     }
 
-    if (commandBuffer->needFragmentStorageBufferBind) {
-        if (graphicsPipeline->fragmentStorageBufferCount > 0) {
-            for (Uint32 i = 0; i < graphicsPipeline->fragmentStorageBufferCount; i += 1) {
-                cpuHandles[i] = commandBuffer->fragmentStorageBuffers[i]->srvDescriptor.cpuHandle;
+    if (command_buffer->needFragmentStorageBufferBind) {
+        if (graphics_pipeline->fragmentStorageBufferCount > 0) {
+            for (Uint32 i = 0; i < graphics_pipeline->fragmentStorageBufferCount; i += 1) {
+                cpuHandles[i] = command_buffer->fragmentStorageBuffers[i]->srvDescriptor.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                commandBuffer,
+                command_buffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
                 cpuHandles,
-                graphicsPipeline->fragmentStorageBufferCount,
+                graphics_pipeline->fragmentStorageBufferCount,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetGraphicsRootDescriptorTable(
-                commandBuffer->graphicsCommandList,
-                graphicsPipeline->rootSignature->fragmentStorageBufferRootIndex,
+                command_buffer->graphicsCommandList,
+                graphics_pipeline->rootSignature->fragmentStorageBufferRootIndex,
                 gpuDescriptorHandle);
         }
-        commandBuffer->needFragmentStorageBufferBind = false;
+        command_buffer->needFragmentStorageBufferBind = false;
     }
 
     for (Uint32 i = 0; i < MAX_UNIFORM_BUFFERS_PER_STAGE; i += 1) {
-        if (commandBuffer->needFragmentUniformBufferBind[i]) {
-            if (graphicsPipeline->fragmentUniformBufferCount > i) {
+        if (command_buffer->needFragmentUniformBufferBind[i]) {
+            if (graphics_pipeline->fragmentUniformBufferCount > i) {
                 ID3D12GraphicsCommandList_SetGraphicsRootConstantBufferView(
-                    commandBuffer->graphicsCommandList,
-                    graphicsPipeline->rootSignature->fragmentUniformBufferRootIndex[i],
-                    commandBuffer->fragmentUniformBuffers[i]->buffer->virtualAddress + commandBuffer->fragmentUniformBuffers[i]->drawOffset);
+                    command_buffer->graphicsCommandList,
+                    graphics_pipeline->rootSignature->fragmentUniformBufferRootIndex[i],
+                    command_buffer->fragmentUniformBuffers[i]->buffer->virtualAddress + command_buffer->fragmentUniformBuffers[i]->drawOffset);
             }
-            commandBuffer->needFragmentUniformBufferBind[i] = false;
+            command_buffer->needFragmentUniformBufferBind[i] = false;
         }
     }
 }
 
 static void D3D12_DrawIndexedPrimitives(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 indexCount,
-    Uint32 instanceCount,
-    Uint32 firstIndex,
-    Sint32 vertexOffset,
-    Uint32 firstInstance)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 num_indices,
+    Uint32 num_instances,
+    Uint32 first_index,
+    Sint32 vertex_offset,
+    Uint32 first_instance)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     D3D12_INTERNAL_BindGraphicsResources(d3d12CommandBuffer);
 
     ID3D12GraphicsCommandList_DrawIndexedInstanced(
         d3d12CommandBuffer->graphicsCommandList,
-        indexCount,
-        instanceCount,
-        firstIndex,
-        vertexOffset,
-        firstInstance);
+        num_indices,
+        num_instances,
+        first_index,
+        vertex_offset,
+        first_instance);
 }
 
 static void D3D12_DrawPrimitives(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 vertexCount,
-    Uint32 instanceCount,
-    Uint32 firstVertex,
-    Uint32 firstInstance)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 num_vertices,
+    Uint32 num_instances,
+    Uint32 first_vertex,
+    Uint32 first_instance)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     D3D12_INTERNAL_BindGraphicsResources(d3d12CommandBuffer);
 
     ID3D12GraphicsCommandList_DrawInstanced(
         d3d12CommandBuffer->graphicsCommandList,
-        vertexCount,
-        instanceCount,
-        firstVertex,
-        firstInstance);
+        num_vertices,
+        num_instances,
+        first_vertex,
+        first_instance);
 }
 
 static void D3D12_DrawPrimitivesIndirect(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     SDL_GPUBuffer *buffer,
-    Uint32 offsetInBytes,
-    Uint32 drawCount,
-    Uint32 stride)
+    Uint32 offset,
+    Uint32 draw_count,
+    Uint32 pitch)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     D3D12Buffer *d3d12Buffer = ((D3D12BufferContainer *)buffer)->activeBuffer;
 
     D3D12_INTERNAL_BindGraphicsResources(d3d12CommandBuffer);
 
-    if (stride == sizeof(SDL_GPUIndirectDrawCommand)) {
+    if (pitch == sizeof(SDL_GPUIndirectDrawCommand)) {
         // Real multi-draw!
         ID3D12GraphicsCommandList_ExecuteIndirect(
             d3d12CommandBuffer->graphicsCommandList,
             d3d12CommandBuffer->renderer->indirectDrawCommandSignature,
-            drawCount,
+            draw_count,
             d3d12Buffer->handle,
-            offsetInBytes,
+            offset,
             NULL,
             0);
     } else {
         /* Fake multi-draw...
          * FIXME: we could make this real multi-draw
-         * if we have a lookup to get command signature per stride value
+         * if we have a lookup to get command signature per pitch value
          */
-        for (Uint32 i = 0; i < drawCount; i += 1) {
+        for (Uint32 i = 0; i < draw_count; i += 1) {
             ID3D12GraphicsCommandList_ExecuteIndirect(
                 d3d12CommandBuffer->graphicsCommandList,
                 d3d12CommandBuffer->renderer->indirectDrawCommandSignature,
                 1,
                 d3d12Buffer->handle,
-                offsetInBytes + (stride * i),
+                offset + (pitch * i),
                 NULL,
                 0);
         }
@@ -4691,39 +4691,39 @@ static void D3D12_DrawPrimitivesIndirect(
 }
 
 static void D3D12_DrawIndexedPrimitivesIndirect(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     SDL_GPUBuffer *buffer,
-    Uint32 offsetInBytes,
-    Uint32 drawCount,
-    Uint32 stride)
+    Uint32 offset,
+    Uint32 draw_count,
+    Uint32 pitch)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     D3D12Buffer *d3d12Buffer = ((D3D12BufferContainer *)buffer)->activeBuffer;
 
     D3D12_INTERNAL_BindGraphicsResources(d3d12CommandBuffer);
 
-    if (stride == sizeof(SDL_GPUIndexedIndirectDrawCommand)) {
+    if (pitch == sizeof(SDL_GPUIndexedIndirectDrawCommand)) {
         // Real multi-draw!
         ID3D12GraphicsCommandList_ExecuteIndirect(
             d3d12CommandBuffer->graphicsCommandList,
             d3d12CommandBuffer->renderer->indirectIndexedDrawCommandSignature,
-            drawCount,
+            draw_count,
             d3d12Buffer->handle,
-            offsetInBytes,
+            offset,
             NULL,
             0);
     } else {
         /* Fake multi-draw...
          * FIXME: we could make this real multi-draw
-         * if we have a lookup to get command signature per stride value
+         * if we have a lookup to get command signature per pitch value
          */
-        for (Uint32 i = 0; i < drawCount; i += 1) {
+        for (Uint32 i = 0; i < draw_count; i += 1) {
             ID3D12GraphicsCommandList_ExecuteIndirect(
                 d3d12CommandBuffer->graphicsCommandList,
                 d3d12CommandBuffer->renderer->indirectIndexedDrawCommandSignature,
                 1,
                 d3d12Buffer->handle,
-                offsetInBytes + (stride * i),
+                offset + (pitch * i),
                 NULL,
                 0);
         }
@@ -4731,9 +4731,9 @@ static void D3D12_DrawIndexedPrimitivesIndirect(
 }
 
 static void D3D12_EndRenderPass(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     Uint32 i;
 
     for (i = 0; i < d3d12CommandBuffer->colorAttachmentTextureSubresourceCount; i += 1) {
@@ -4786,34 +4786,34 @@ static void D3D12_EndRenderPass(
 // Compute Pass
 
 static void D3D12_BeginComputePass(
-    SDL_GPUCommandBuffer *commandBuffer,
-    const SDL_GPUStorageTextureWriteOnlyBinding *storageTextureBindings,
-    Uint32 storageTextureBindingCount,
-    const SDL_GPUStorageBufferWriteOnlyBinding *storageBufferBindings,
-    Uint32 storageBufferBindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    const SDL_GPUStorageTextureWriteOnlyBinding *storage_texture_bindings,
+    Uint32 num_storage_texture_bindings,
+    const SDL_GPUStorageBufferWriteOnlyBinding *storage_buffer_bindings,
+    Uint32 num_storage_buffer_bindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
 
-    d3d12CommandBuffer->computeWriteOnlyStorageTextureSubresourceCount = storageTextureBindingCount;
-    d3d12CommandBuffer->computeWriteOnlyStorageBufferCount = storageBufferBindingCount;
+    d3d12CommandBuffer->computeWriteOnlyStorageTextureSubresourceCount = num_storage_texture_bindings;
+    d3d12CommandBuffer->computeWriteOnlyStorageBufferCount = num_storage_buffer_bindings;
 
     /* Write-only resources will be actually bound in BindComputePipeline
      * after the root signature is set.
      * We also have to scan to see which barriers we actually need because depth slices aren't separate subresources
      */
-    if (storageTextureBindingCount > 0) {
-        for (Uint32 i = 0; i < storageTextureBindingCount; i += 1) {
-            D3D12TextureContainer *container = (D3D12TextureContainer *)storageTextureBindings[i].texture;
-            if (!(container->header.info.usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE)) {
+    if (num_storage_texture_bindings > 0) {
+        for (Uint32 i = 0; i < num_storage_texture_bindings; i += 1) {
+            D3D12TextureContainer *container = (D3D12TextureContainer *)storage_texture_bindings[i].texture;
+            if (!(container->header.info.usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE)) {
                 SDL_LogError(SDL_LOG_CATEGORY_GPU, "Attempted to bind read-only texture as compute write texture");
             }
 
             D3D12TextureSubresource *subresource = D3D12_INTERNAL_PrepareTextureSubresourceForWrite(
                 d3d12CommandBuffer,
                 container,
-                storageTextureBindings[i].layer,
-                storageTextureBindings[i].mipLevel,
-                storageTextureBindings[i].cycle,
+                storage_texture_bindings[i].layer,
+                storage_texture_bindings[i].mip_level,
+                storage_texture_bindings[i].cycle,
                 D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 
             d3d12CommandBuffer->computeWriteOnlyStorageTextureSubresources[i] = subresource;
@@ -4824,16 +4824,16 @@ static void D3D12_BeginComputePass(
         }
     }
 
-    if (storageBufferBindingCount > 0) {
-        for (Uint32 i = 0; i < storageBufferBindingCount; i += 1) {
-            D3D12BufferContainer *container = (D3D12BufferContainer *)storageBufferBindings[i].buffer;
-            if (!(container->usageFlags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE)) {
+    if (num_storage_buffer_bindings > 0) {
+        for (Uint32 i = 0; i < num_storage_buffer_bindings; i += 1) {
+            D3D12BufferContainer *container = (D3D12BufferContainer *)storage_buffer_bindings[i].buffer;
+            if (!(container->usage_flags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE)) {
                 SDL_LogError(SDL_LOG_CATEGORY_GPU, "Attempted to bind read-only texture as compute write texture");
             }
             D3D12Buffer *buffer = D3D12_INTERNAL_PrepareBufferForWrite(
                 d3d12CommandBuffer,
                 container,
-                storageBufferBindings[i].cycle,
+                storage_buffer_bindings[i].cycle,
                 D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 
             d3d12CommandBuffer->computeWriteOnlyStorageBuffers[i] = buffer;
@@ -4846,11 +4846,11 @@ static void D3D12_BeginComputePass(
 }
 
 static void D3D12_BindComputePipeline(
-    SDL_GPUCommandBuffer *commandBuffer,
-    SDL_GPUComputePipeline *computePipeline)
+    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUComputePipeline *compute_pipeline)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
-    D3D12ComputePipeline *pipeline = (D3D12ComputePipeline *)computePipeline;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12ComputePipeline *pipeline = (D3D12ComputePipeline *)compute_pipeline;
     D3D12_CPU_DESCRIPTOR_HANDLE cpuHandles[MAX_TEXTURE_SAMPLERS_PER_STAGE];
     D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptorHandle;
 
@@ -4871,7 +4871,7 @@ static void D3D12_BindComputePipeline(
         d3d12CommandBuffer->needComputeUniformBufferBind[i] = true;
     }
 
-    for (Uint32 i = 0; i < pipeline->uniformBufferCount; i += 1) {
+    for (Uint32 i = 0; i < pipeline->num_uniform_buffers; i += 1) {
         if (d3d12CommandBuffer->computeUniformBuffers[i] == NULL) {
             d3d12CommandBuffer->computeUniformBuffers[i] = D3D12_INTERNAL_AcquireUniformBufferFromPool(
                 d3d12CommandBuffer);
@@ -4881,8 +4881,8 @@ static void D3D12_BindComputePipeline(
     D3D12_INTERNAL_TrackComputePipeline(d3d12CommandBuffer, pipeline);
 
     // Bind write-only resources after setting root signature
-    if (pipeline->writeOnlyStorageTextureCount > 0) {
-        for (Uint32 i = 0; i < pipeline->writeOnlyStorageTextureCount; i += 1) {
+    if (pipeline->num_writeonly_storage_textures > 0) {
+        for (Uint32 i = 0; i < pipeline->num_writeonly_storage_textures; i += 1) {
             cpuHandles[i] = d3d12CommandBuffer->computeWriteOnlyStorageTextureSubresources[i]->uavHandle.cpuHandle;
         }
 
@@ -4899,8 +4899,8 @@ static void D3D12_BindComputePipeline(
             gpuDescriptorHandle);
     }
 
-    if (pipeline->writeOnlyStorageBufferCount > 0) {
-        for (Uint32 i = 0; i < pipeline->writeOnlyStorageBufferCount; i += 1) {
+    if (pipeline->num_writeonly_storage_buffers > 0) {
+        for (Uint32 i = 0; i < pipeline->num_writeonly_storage_buffers; i += 1) {
             cpuHandles[i] = d3d12CommandBuffer->computeWriteOnlyStorageBuffers[i]->uavDescriptor.cpuHandle;
         }
 
@@ -4919,23 +4919,23 @@ static void D3D12_BindComputePipeline(
 }
 
 static void D3D12_BindComputeStorageTextures(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    SDL_GPUTexture *const *storageTextures,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    SDL_GPUTexture *const *storage_textures,
+    Uint32 num_bindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        if (d3d12CommandBuffer->computeReadOnlyStorageTextures[firstSlot + i] != NULL) {
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        if (d3d12CommandBuffer->computeReadOnlyStorageTextures[first_slot + i] != NULL) {
             D3D12_INTERNAL_TextureTransitionToDefaultUsage(
                 d3d12CommandBuffer,
                 D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-                d3d12CommandBuffer->computeReadOnlyStorageTextures[firstSlot + i]);
+                d3d12CommandBuffer->computeReadOnlyStorageTextures[first_slot + i]);
         }
 
-        D3D12TextureContainer *container = (D3D12TextureContainer *)storageTextures[i];
-        d3d12CommandBuffer->computeReadOnlyStorageTextures[firstSlot + i] = container->activeTexture;
+        D3D12TextureContainer *container = (D3D12TextureContainer *)storage_textures[i];
+        d3d12CommandBuffer->computeReadOnlyStorageTextures[first_slot + i] = container->activeTexture;
 
         D3D12_INTERNAL_TextureTransitionFromDefaultUsage(
             d3d12CommandBuffer,
@@ -4951,25 +4951,25 @@ static void D3D12_BindComputeStorageTextures(
 }
 
 static void D3D12_BindComputeStorageBuffers(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    SDL_GPUBuffer *const *storageBuffers,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    SDL_GPUBuffer *const *storage_buffers,
+    Uint32 num_bindings)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        if (d3d12CommandBuffer->computeReadOnlyStorageBuffers[firstSlot + i] != NULL) {
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        if (d3d12CommandBuffer->computeReadOnlyStorageBuffers[first_slot + i] != NULL) {
             D3D12_INTERNAL_BufferTransitionToDefaultUsage(
                 d3d12CommandBuffer,
                 D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
-                d3d12CommandBuffer->computeReadOnlyStorageBuffers[firstSlot + i]);
+                d3d12CommandBuffer->computeReadOnlyStorageBuffers[first_slot + i]);
         }
 
-        D3D12BufferContainer *container = (D3D12BufferContainer *)storageBuffers[i];
+        D3D12BufferContainer *container = (D3D12BufferContainer *)storage_buffers[i];
         D3D12Buffer *buffer = container->activeBuffer;
 
-        d3d12CommandBuffer->computeReadOnlyStorageBuffers[firstSlot + i] = buffer;
+        d3d12CommandBuffer->computeReadOnlyStorageBuffers[first_slot + i] = buffer;
 
         D3D12_INTERNAL_BufferTransitionFromDefaultUsage(
             d3d12CommandBuffer,
@@ -4985,106 +4985,106 @@ static void D3D12_BindComputeStorageBuffers(
 }
 
 static void D3D12_PushComputeUniformData(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 slotIndex,
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 slot_index,
     const void *data,
-    Uint32 dataLengthInBytes)
+    Uint32 length)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
 
     D3D12_INTERNAL_PushUniformData(
         d3d12CommandBuffer,
         SDL_GPU_SHADERSTAGE_COMPUTE,
-        slotIndex,
+        slot_index,
         data,
-        dataLengthInBytes);
+        length);
 }
 
 static void D3D12_INTERNAL_BindComputeResources(
-    D3D12CommandBuffer *commandBuffer)
+    D3D12CommandBuffer *command_buffer)
 {
-    D3D12ComputePipeline *computePipeline = commandBuffer->currentComputePipeline;
+    D3D12ComputePipeline *compute_pipeline = command_buffer->currentComputePipeline;
 
     D3D12_CPU_DESCRIPTOR_HANDLE cpuHandles[MAX_TEXTURE_SAMPLERS_PER_STAGE];
     D3D12_GPU_DESCRIPTOR_HANDLE gpuDescriptorHandle;
 
-    if (commandBuffer->needComputeReadOnlyStorageTextureBind) {
-        if (computePipeline->readOnlyStorageTextureCount > 0) {
-            for (Uint32 i = 0; i < computePipeline->readOnlyStorageTextureCount; i += 1) {
-                cpuHandles[i] = commandBuffer->computeReadOnlyStorageTextures[i]->srvHandle.cpuHandle;
+    if (command_buffer->needComputeReadOnlyStorageTextureBind) {
+        if (compute_pipeline->num_readonly_storage_textures > 0) {
+            for (Uint32 i = 0; i < compute_pipeline->num_readonly_storage_textures; i += 1) {
+                cpuHandles[i] = command_buffer->computeReadOnlyStorageTextures[i]->srvHandle.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                commandBuffer,
+                command_buffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
                 cpuHandles,
-                computePipeline->readOnlyStorageTextureCount,
+                compute_pipeline->num_readonly_storage_textures,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetComputeRootDescriptorTable(
-                commandBuffer->graphicsCommandList,
-                computePipeline->rootSignature->readOnlyStorageTextureRootIndex,
+                command_buffer->graphicsCommandList,
+                compute_pipeline->rootSignature->readOnlyStorageTextureRootIndex,
                 gpuDescriptorHandle);
         }
-        commandBuffer->needComputeReadOnlyStorageTextureBind = false;
+        command_buffer->needComputeReadOnlyStorageTextureBind = false;
     }
 
-    if (commandBuffer->needComputeReadOnlyStorageBufferBind) {
-        if (computePipeline->readOnlyStorageBufferCount > 0) {
-            for (Uint32 i = 0; i < computePipeline->readOnlyStorageBufferCount; i += 1) {
-                cpuHandles[i] = commandBuffer->computeReadOnlyStorageBuffers[i]->srvDescriptor.cpuHandle;
+    if (command_buffer->needComputeReadOnlyStorageBufferBind) {
+        if (compute_pipeline->num_readonly_storage_buffers > 0) {
+            for (Uint32 i = 0; i < compute_pipeline->num_readonly_storage_buffers; i += 1) {
+                cpuHandles[i] = command_buffer->computeReadOnlyStorageBuffers[i]->srvDescriptor.cpuHandle;
             }
 
             D3D12_INTERNAL_WriteGPUDescriptors(
-                commandBuffer,
+                command_buffer,
                 D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
                 cpuHandles,
-                computePipeline->readOnlyStorageBufferCount,
+                compute_pipeline->num_readonly_storage_buffers,
                 &gpuDescriptorHandle);
 
             ID3D12GraphicsCommandList_SetComputeRootDescriptorTable(
-                commandBuffer->graphicsCommandList,
-                computePipeline->rootSignature->readOnlyStorageBufferRootIndex,
+                command_buffer->graphicsCommandList,
+                compute_pipeline->rootSignature->readOnlyStorageBufferRootIndex,
                 gpuDescriptorHandle);
         }
-        commandBuffer->needComputeReadOnlyStorageBufferBind = false;
+        command_buffer->needComputeReadOnlyStorageBufferBind = false;
     }
 
     for (Uint32 i = 0; i < MAX_UNIFORM_BUFFERS_PER_STAGE; i += 1) {
-        if (commandBuffer->needComputeUniformBufferBind[i]) {
-            if (computePipeline->uniformBufferCount > i) {
+        if (command_buffer->needComputeUniformBufferBind[i]) {
+            if (compute_pipeline->num_uniform_buffers > i) {
                 ID3D12GraphicsCommandList_SetComputeRootConstantBufferView(
-                    commandBuffer->graphicsCommandList,
-                    computePipeline->rootSignature->uniformBufferRootIndex[i],
-                    commandBuffer->computeUniformBuffers[i]->buffer->virtualAddress + commandBuffer->computeUniformBuffers[i]->drawOffset);
+                    command_buffer->graphicsCommandList,
+                    compute_pipeline->rootSignature->uniformBufferRootIndex[i],
+                    command_buffer->computeUniformBuffers[i]->buffer->virtualAddress + command_buffer->computeUniformBuffers[i]->drawOffset);
             }
         }
-        commandBuffer->needComputeUniformBufferBind[i] = false;
+        command_buffer->needComputeUniformBufferBind[i] = false;
     }
 }
 
 static void D3D12_DispatchCompute(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 groupCountX,
-    Uint32 groupCountY,
-    Uint32 groupCountZ)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 groupcount_x,
+    Uint32 groupcount_y,
+    Uint32 groupcount_z)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
 
     D3D12_INTERNAL_BindComputeResources(d3d12CommandBuffer);
     ID3D12GraphicsCommandList_Dispatch(
         d3d12CommandBuffer->graphicsCommandList,
-        groupCountX,
-        groupCountY,
-        groupCountZ);
+        groupcount_x,
+        groupcount_y,
+        groupcount_z);
 }
 
 static void D3D12_DispatchComputeIndirect(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     SDL_GPUBuffer *buffer,
-    Uint32 offsetInBytes)
+    Uint32 offset)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     D3D12Buffer *d3d12Buffer = ((D3D12BufferContainer *)buffer)->activeBuffer;
 
     D3D12_INTERNAL_BindComputeResources(d3d12CommandBuffer);
@@ -5093,15 +5093,15 @@ static void D3D12_DispatchComputeIndirect(
         d3d12CommandBuffer->renderer->indirectDispatchCommandSignature,
         1,
         d3d12Buffer->handle,
-        offsetInBytes,
+        offset,
         NULL,
         0);
 }
 
 static void D3D12_EndComputePass(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
 
     for (Uint32 i = 0; i < d3d12CommandBuffer->computeWriteOnlyStorageTextureSubresourceCount; i += 1) {
         if (d3d12CommandBuffer->computeWriteOnlyStorageTextureSubresources[i]) {
@@ -5156,11 +5156,11 @@ static void D3D12_EndComputePass(
 
 static void *D3D12_MapTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transferBuffer,
+    SDL_GPUTransferBuffer *transfer_buffer,
     bool cycle)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
-    D3D12BufferContainer *container = (D3D12BufferContainer *)transferBuffer;
+    D3D12BufferContainer *container = (D3D12BufferContainer *)transfer_buffer;
     void *dataPointer;
 
     if (
@@ -5187,10 +5187,10 @@ static void *D3D12_MapTransferBuffer(
 
 static void D3D12_UnmapTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transferBuffer)
+    SDL_GPUTransferBuffer *transfer_buffer)
 {
     (void)driverData;
-    D3D12BufferContainer *container = (D3D12BufferContainer *)transferBuffer;
+    D3D12BufferContainer *container = (D3D12BufferContainer *)transfer_buffer;
 
     // Upload buffers are persistently mapped, download buffers are not
     if (container->type == D3D12_BUFFER_TYPE_DOWNLOAD) {
@@ -5204,27 +5204,27 @@ static void D3D12_UnmapTransferBuffer(
 // Copy Pass
 
 static void D3D12_BeginCopyPass(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
     // no-op
-    (void)commandBuffer;
+    (void)command_buffer;
 }
 
 static void D3D12_UploadToTexture(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUTextureTransferInfo *source,
     const SDL_GPUTextureRegion *destination,
     bool cycle)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
-    D3D12BufferContainer *transferBufferContainer = (D3D12BufferContainer *)source->transferBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12BufferContainer *transferBufferContainer = (D3D12BufferContainer *)source->transfer_buffer;
     D3D12Buffer *temporaryBuffer = NULL;
     D3D12_TEXTURE_COPY_LOCATION sourceLocation;
     D3D12_TEXTURE_COPY_LOCATION destinationLocation;
-    Uint32 pixelsPerRow = source->imagePitch;
+    Uint32 pixelsPerRow = source->pixels_per_row;
     Uint32 rowPitch;
     Uint32 alignedRowPitch;
-    Uint32 rowsPerSlice = source->imageHeight;
+    Uint32 rowsPerSlice = source->rows_per_layer;
     Uint32 bytesPerSlice;
     bool needsRealignment;
     bool needsPlacementCopy;
@@ -5236,7 +5236,7 @@ static void D3D12_UploadToTexture(
         d3d12CommandBuffer,
         textureContainer,
         destination->layer,
-        destination->mipLevel,
+        destination->mip_level,
         cycle,
         D3D12_RESOURCE_STATE_COPY_DEST);
 
@@ -5387,13 +5387,13 @@ static void D3D12_UploadToTexture(
 }
 
 static void D3D12_UploadToBuffer(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUTransferBufferLocation *source,
     const SDL_GPUBufferRegion *destination,
     bool cycle)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
-    D3D12BufferContainer *transferBufferContainer = (D3D12BufferContainer *)source->transferBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
+    D3D12BufferContainer *transferBufferContainer = (D3D12BufferContainer *)source->transfer_buffer;
     D3D12BufferContainer *bufferContainer = (D3D12BufferContainer *)destination->buffer;
 
     // The transfer buffer does not need a barrier, it is synced by the client.
@@ -5422,7 +5422,7 @@ static void D3D12_UploadToBuffer(
 }
 
 static void D3D12_CopyTextureToTexture(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUTextureLocation *source,
     const SDL_GPUTextureLocation *destination,
     Uint32 w,
@@ -5430,20 +5430,20 @@ static void D3D12_CopyTextureToTexture(
     Uint32 d,
     bool cycle)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     D3D12_TEXTURE_COPY_LOCATION sourceLocation;
     D3D12_TEXTURE_COPY_LOCATION destinationLocation;
 
     D3D12TextureSubresource *sourceSubresource = D3D12_INTERNAL_FetchTextureSubresource(
         (D3D12TextureContainer *)source->texture,
         source->layer,
-        source->mipLevel);
+        source->mip_level);
 
     D3D12TextureSubresource *destinationSubresource = D3D12_INTERNAL_PrepareTextureSubresourceForWrite(
         d3d12CommandBuffer,
         (D3D12TextureContainer *)destination->texture,
         destination->layer,
-        destination->mipLevel,
+        destination->mip_level,
         cycle,
         D3D12_RESOURCE_STATE_COPY_DEST);
 
@@ -5491,13 +5491,13 @@ static void D3D12_CopyTextureToTexture(
 }
 
 static void D3D12_CopyBufferToBuffer(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUBufferLocation *source,
     const SDL_GPUBufferLocation *destination,
     Uint32 size,
     bool cycle)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     D3D12BufferContainer *sourceContainer = (D3D12BufferContainer *)source->buffer;
     D3D12BufferContainer *destinationContainer = (D3D12BufferContainer *)destination->buffer;
 
@@ -5536,17 +5536,17 @@ static void D3D12_CopyBufferToBuffer(
 }
 
 static void D3D12_DownloadFromTexture(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUTextureRegion *source,
     const SDL_GPUTextureTransferInfo *destination)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     D3D12_TEXTURE_COPY_LOCATION sourceLocation;
     D3D12_TEXTURE_COPY_LOCATION destinationLocation;
-    Uint32 pixelsPerRow = destination->imagePitch;
+    Uint32 pixelsPerRow = destination->pixels_per_row;
     Uint32 rowPitch;
     Uint32 alignedRowPitch;
-    Uint32 rowsPerSlice = destination->imageHeight;
+    Uint32 rowsPerSlice = destination->rows_per_layer;
     bool needsRealignment;
     bool needsPlacementCopy;
     D3D12TextureDownload *textureDownload = NULL;
@@ -5554,8 +5554,8 @@ static void D3D12_DownloadFromTexture(
     D3D12TextureSubresource *sourceSubresource = D3D12_INTERNAL_FetchTextureSubresource(
         sourceContainer,
         source->layer,
-        source->mipLevel);
-    D3D12BufferContainer *destinationContainer = (D3D12BufferContainer *)destination->transferBuffer;
+        source->mip_level);
+    D3D12BufferContainer *destinationContainer = (D3D12BufferContainer *)destination->transfer_buffer;
     D3D12Buffer *destinationBuffer = destinationContainer->activeBuffer;
 
     /* D3D12 requires texture data row pitch to be 256 byte aligned, which is obviously insane.
@@ -5675,13 +5675,13 @@ static void D3D12_DownloadFromTexture(
 }
 
 static void D3D12_DownloadFromBuffer(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUBufferRegion *source,
     const SDL_GPUTransferBufferLocation *destination)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     D3D12BufferContainer *sourceContainer = (D3D12BufferContainer *)source->buffer;
-    D3D12BufferContainer *destinationContainer = (D3D12BufferContainer *)destination->transferBuffer;
+    D3D12BufferContainer *destinationContainer = (D3D12BufferContainer *)destination->transfer_buffer;
 
     D3D12Buffer *sourceBuffer = sourceContainer->activeBuffer;
     D3D12_INTERNAL_BufferTransitionFromDefaultUsage(
@@ -5709,17 +5709,17 @@ static void D3D12_DownloadFromBuffer(
 }
 
 static void D3D12_EndCopyPass(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
     // no-op
-    (void)commandBuffer;
+    (void)command_buffer;
 }
 
 static void D3D12_GenerateMipmaps(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     SDL_GPUTexture *texture)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     D3D12Renderer *renderer = d3d12CommandBuffer->renderer;
     D3D12TextureContainer *container = (D3D12TextureContainer *)texture;
     SDL_GPUGraphicsPipeline *blitPipeline;
@@ -5744,27 +5744,27 @@ static void D3D12_GenerateMipmaps(
     }
 
     // We have to do this one subresource at a time
-    for (Uint32 layerOrDepthIndex = 0; layerOrDepthIndex < container->header.info.layerCountOrDepth; layerOrDepthIndex += 1) {
-        for (Uint32 levelIndex = 1; levelIndex < container->header.info.levelCount; levelIndex += 1) {
+    for (Uint32 layerOrDepthIndex = 0; layerOrDepthIndex < container->header.info.layer_count_or_depth; layerOrDepthIndex += 1) {
+        for (Uint32 levelIndex = 1; levelIndex < container->header.info.num_levels; levelIndex += 1) {
 
             srcRegion.texture = texture;
-            srcRegion.mipLevel = levelIndex - 1;
-            srcRegion.layerOrDepthPlane = layerOrDepthIndex;
+            srcRegion.mip_level = levelIndex - 1;
+            srcRegion.layer_or_depth_plane = layerOrDepthIndex;
             srcRegion.x = 0;
             srcRegion.y = 0;
             srcRegion.w = container->header.info.width >> (levelIndex - 1);
             srcRegion.h = container->header.info.height >> (levelIndex - 1);
 
             dstRegion.texture = texture;
-            dstRegion.mipLevel = levelIndex;
-            dstRegion.layerOrDepthPlane = layerOrDepthIndex;
+            dstRegion.mip_level = levelIndex;
+            dstRegion.layer_or_depth_plane = layerOrDepthIndex;
             dstRegion.x = 0;
             dstRegion.y = 0;
             dstRegion.w = container->header.info.width >> levelIndex;
             dstRegion.h = container->header.info.height >> levelIndex;
 
             SDL_BlitGPUTexture(
-                commandBuffer,
+                command_buffer,
                 &srcRegion,
                 &dstRegion,
                 SDL_FLIP_NONE,
@@ -5777,22 +5777,22 @@ static void D3D12_GenerateMipmaps(
 }
 
 static void D3D12_Blit(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUBlitRegion *source,
     const SDL_GPUBlitRegion *destination,
-    SDL_FlipMode flipMode,
-    SDL_GPUFilter filterMode,
+    SDL_FlipMode flip_mode,
+    SDL_GPUFilter filter,
     bool cycle)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     D3D12Renderer *renderer = (D3D12Renderer *)d3d12CommandBuffer->renderer;
 
     SDL_GPU_BlitCommon(
-        commandBuffer,
+        command_buffer,
         source,
         destination,
-        flipMode,
-        filterMode,
+        flip_mode,
+        filter,
         cycle,
         renderer->blitLinearSampler,
         renderer->blitNearestSampler,
@@ -5818,12 +5818,12 @@ static D3D12WindowData *D3D12_INTERNAL_FetchWindowData(
 static bool D3D12_SupportsSwapchainComposition(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchainComposition)
+    SDL_GPUSwapchainComposition swapchain_composition)
 {
 #if defined(SDL_PLATFORM_XBOXONE) || defined(SDL_PLATFORM_XBOXSERIES)
     // FIXME: HDR support would be nice to add, but it seems complicated...
-    return swapchainComposition == SDL_GPU_SWAPCHAINCOMPOSITION_SDR ||
-           swapchainComposition == SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR;
+    return swapchain_composition == SDL_GPU_SWAPCHAINCOMPOSITION_SDR ||
+           swapchain_composition == SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR;
 #else
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
     DXGI_FORMAT format;
@@ -5831,7 +5831,7 @@ static bool D3D12_SupportsSwapchainComposition(
     Uint32 colorSpaceSupport;
     HRESULT res;
 
-    format = SwapchainCompositionToTextureFormat[swapchainComposition];
+    format = SwapchainCompositionToTextureFormat[swapchain_composition];
 
     formatSupport.Format = format;
     res = ID3D12Device_CheckFeatureSupport(
@@ -5855,10 +5855,10 @@ static bool D3D12_SupportsSwapchainComposition(
     }
 
     // Check the color space support if necessary
-    if (swapchainComposition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR) {
+    if (swapchain_composition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR) {
         IDXGISwapChain3_CheckColorSpaceSupport(
             windowData->swapchain,
-            SwapchainCompositionToColorSpace[swapchainComposition],
+            SwapchainCompositionToColorSpace[swapchain_composition],
             &colorSpaceSupport);
 
         if (!(colorSpaceSupport & DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG_PRESENT)) {
@@ -5873,12 +5873,12 @@ static bool D3D12_SupportsSwapchainComposition(
 static bool D3D12_SupportsPresentMode(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUPresentMode presentMode)
+    SDL_GPUPresentMode present_mode)
 {
     (void)driverData;
     (void)window;
 
-    switch (presentMode) {
+    switch (present_mode) {
     case SDL_GPU_PRESENTMODE_IMMEDIATE:
     case SDL_GPU_PRESENTMODE_VSYNC:
         return true;
@@ -5898,8 +5898,8 @@ static bool D3D12_SupportsPresentMode(
 static bool D3D12_INTERNAL_CreateSwapchain(
     D3D12Renderer *renderer,
     D3D12WindowData *windowData,
-    SDL_GPUSwapchainComposition swapchainComposition,
-    SDL_GPUPresentMode presentMode)
+    SDL_GPUSwapchainComposition swapchain_composition,
+    SDL_GPUPresentMode present_mode)
 {
     int width, height;
     SDL_GPUTextureCreateInfo createInfo;
@@ -5913,10 +5913,10 @@ static bool D3D12_INTERNAL_CreateSwapchain(
     createInfo.type = SDL_GPU_TEXTURETYPE_2D;
     createInfo.width = width;
     createInfo.height = height;
-    createInfo.format = SwapchainCompositionToSDLTextureFormat[swapchainComposition];
-    createInfo.usageFlags = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
-    createInfo.layerCountOrDepth = 1;
-    createInfo.levelCount = 1;
+    createInfo.format = SwapchainCompositionToSDLTextureFormat[swapchain_composition];
+    createInfo.usage_flags = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
+    createInfo.layer_count_or_depth = 1;
+    createInfo.num_levels = 1;
 
     for (Uint32 i = 0; i < MAX_FRAMES_IN_FLIGHT; i += 1) {
         texture = D3D12_INTERNAL_CreateTexture(renderer, &createInfo, true);
@@ -5930,8 +5930,8 @@ static bool D3D12_INTERNAL_CreateSwapchain(
     }
 
     // Initialize the swapchain data
-    windowData->presentMode = presentMode;
-    windowData->swapchainComposition = swapchainComposition;
+    windowData->present_mode = present_mode;
+    windowData->swapchain_composition = swapchain_composition;
     windowData->swapchainColorSpace = DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
     windowData->frameCounter = 0;
     windowData->swapchainWidth = width;
@@ -5993,8 +5993,8 @@ static bool D3D12_INTERNAL_ResizeSwapchainIfNeeded(
         D3D12_INTERNAL_CreateSwapchain(
             renderer,
             windowData,
-            windowData->swapchainComposition,
-            windowData->presentMode);
+            windowData->swapchain_composition,
+            windowData->present_mode);
     }
 
     return true;
@@ -6048,11 +6048,11 @@ static bool D3D12_INTERNAL_InitializeSwapchainTexture(
     ID3D12Resource_GetDesc(swapchainTexture, &textureDesc);
     pTextureContainer->header.info.width = (Uint32)textureDesc.Width;
     pTextureContainer->header.info.height = (Uint32)textureDesc.Height;
-    pTextureContainer->header.info.layerCountOrDepth = 1;
-    pTextureContainer->header.info.levelCount = 1;
+    pTextureContainer->header.info.layer_count_or_depth = 1;
+    pTextureContainer->header.info.num_levels = 1;
     pTextureContainer->header.info.type = SDL_GPU_TEXTURETYPE_2D;
-    pTextureContainer->header.info.usageFlags = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
-    pTextureContainer->header.info.sampleCount = SDL_GPU_SAMPLECOUNT_1;
+    pTextureContainer->header.info.usage_flags = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
+    pTextureContainer->header.info.sample_count = SDL_GPU_SAMPLECOUNT_1;
     pTextureContainer->header.info.format = SwapchainCompositionToSDLTextureFormat[composition];
 
     pTextureContainer->debugName = NULL;
@@ -6159,7 +6159,7 @@ static bool D3D12_INTERNAL_ResizeSwapchainIfNeeded(
             if (!D3D12_INTERNAL_InitializeSwapchainTexture(
                     renderer,
                     windowData->swapchain,
-                    windowData->swapchainComposition,
+                    windowData->swapchain_composition,
                     i,
                     &windowData->textureContainers[i])) {
                 return false;
@@ -6196,8 +6196,8 @@ static void D3D12_INTERNAL_DestroySwapchain(
 static bool D3D12_INTERNAL_CreateSwapchain(
     D3D12Renderer *renderer,
     D3D12WindowData *windowData,
-    SDL_GPUSwapchainComposition swapchainComposition,
-    SDL_GPUPresentMode presentMode)
+    SDL_GPUSwapchainComposition swapchain_composition,
+    SDL_GPUPresentMode present_mode)
 {
     HWND dxgiHandle;
     int width, height;
@@ -6219,7 +6219,7 @@ static bool D3D12_INTERNAL_CreateSwapchain(
     // Get the window size
     SDL_GetWindowSize(windowData->window, &width, &height);
 
-    swapchainFormat = SwapchainCompositionToTextureFormat[swapchainComposition];
+    swapchainFormat = SwapchainCompositionToTextureFormat[swapchain_composition];
 
     // Initialize the swapchain buffer descriptor
     swapchainDesc.Width = 0;
@@ -6270,11 +6270,11 @@ static bool D3D12_INTERNAL_CreateSwapchain(
     IDXGISwapChain1_Release(swapchain);
     ERROR_CHECK_RETURN("Could not create IDXGISwapChain3", 0);
 
-    if (swapchainComposition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR) {
+    if (swapchain_composition != SDL_GPU_SWAPCHAINCOMPOSITION_SDR) {
         // Support already verified if we hit this block
         IDXGISwapChain3_SetColorSpace1(
             swapchain3,
-            SwapchainCompositionToColorSpace[swapchainComposition]);
+            SwapchainCompositionToColorSpace[swapchain_composition]);
     }
 
     /*
@@ -6312,9 +6312,9 @@ static bool D3D12_INTERNAL_CreateSwapchain(
 
     // Initialize the swapchain data
     windowData->swapchain = swapchain3;
-    windowData->presentMode = presentMode;
-    windowData->swapchainComposition = swapchainComposition;
-    windowData->swapchainColorSpace = SwapchainCompositionToColorSpace[swapchainComposition];
+    windowData->present_mode = present_mode;
+    windowData->swapchain_composition = swapchain_composition;
+    windowData->swapchainColorSpace = SwapchainCompositionToColorSpace[swapchain_composition];
     windowData->frameCounter = 0;
 
     // Precache blit pipelines for the swapchain format
@@ -6322,7 +6322,7 @@ static bool D3D12_INTERNAL_CreateSwapchain(
         SDL_GPU_FetchBlitPipeline(
             renderer->sdlGPUDevice,
             (SDL_GPUTextureType)i,
-            SwapchainCompositionToSDLTextureFormat[swapchainComposition],
+            SwapchainCompositionToSDLTextureFormat[swapchain_composition],
             renderer->blitVertexShader,
             renderer->blitFrom2DShader,
             renderer->blitFrom2DArrayShader,
@@ -6340,7 +6340,7 @@ static bool D3D12_INTERNAL_CreateSwapchain(
         if (!D3D12_INTERNAL_InitializeSwapchainTexture(
                 renderer,
                 swapchain3,
-                swapchainComposition,
+                swapchain_composition,
                 i,
                 &windowData->textureContainers[i])) {
             IDXGISwapChain3_Release(swapchain3);
@@ -6436,8 +6436,8 @@ static void D3D12_ReleaseWindow(
 static bool D3D12_SetSwapchainParameters(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchainComposition,
-    SDL_GPUPresentMode presentMode)
+    SDL_GPUSwapchainComposition swapchain_composition,
+    SDL_GPUPresentMode present_mode)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
     D3D12WindowData *windowData = D3D12_INTERNAL_FetchWindowData(window);
@@ -6447,19 +6447,19 @@ static bool D3D12_SetSwapchainParameters(
         return false;
     }
 
-    if (!D3D12_SupportsSwapchainComposition(driverData, window, swapchainComposition)) {
+    if (!D3D12_SupportsSwapchainComposition(driverData, window, swapchain_composition)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Swapchain composition not supported!");
         return false;
     }
 
-    if (!D3D12_SupportsPresentMode(driverData, window, presentMode)) {
+    if (!D3D12_SupportsPresentMode(driverData, window, present_mode)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Present mode not supported!");
         return false;
     }
 
     if (
-        swapchainComposition != windowData->swapchainComposition ||
-        presentMode != windowData->presentMode) {
+        swapchain_composition != windowData->swapchain_composition ||
+        present_mode != windowData->present_mode) {
         D3D12_Wait(driverData);
 
         // Recreate the swapchain
@@ -6470,8 +6470,8 @@ static bool D3D12_SetSwapchainParameters(
         return D3D12_INTERNAL_CreateSwapchain(
             renderer,
             windowData,
-            swapchainComposition,
-            presentMode);
+            swapchain_composition,
+            present_mode);
     }
 
     return true;
@@ -6537,13 +6537,13 @@ static D3D12Fence *D3D12_INTERNAL_AcquireFence(
 static void D3D12_INTERNAL_AllocateCommandBuffer(
     D3D12Renderer *renderer)
 {
-    D3D12CommandBuffer *commandBuffer;
+    D3D12CommandBuffer *command_buffer;
     HRESULT res;
     ID3D12CommandAllocator *commandAllocator;
     ID3D12GraphicsCommandList *commandList;
 
-    commandBuffer = (D3D12CommandBuffer *)SDL_calloc(1, sizeof(D3D12CommandBuffer));
-    if (!commandBuffer) {
+    command_buffer = (D3D12CommandBuffer *)SDL_calloc(1, sizeof(D3D12CommandBuffer));
+    if (!command_buffer) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create ID3D12CommandList. Out of Memory");
         return;
     }
@@ -6555,10 +6555,10 @@ static void D3D12_INTERNAL_AllocateCommandBuffer(
         (void **)&commandAllocator);
     if (FAILED(res)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create ID3D12CommandAllocator");
-        D3D12_INTERNAL_DestroyCommandBuffer(commandBuffer);
+        D3D12_INTERNAL_DestroyCommandBuffer(command_buffer);
         return;
     }
-    commandBuffer->commandAllocator = commandAllocator;
+    command_buffer->commandAllocator = commandAllocator;
 
     res = ID3D12Device_CreateCommandList(
         renderer->device,
@@ -6571,67 +6571,67 @@ static void D3D12_INTERNAL_AllocateCommandBuffer(
 
     if (FAILED(res)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create ID3D12CommandList");
-        D3D12_INTERNAL_DestroyCommandBuffer(commandBuffer);
+        D3D12_INTERNAL_DestroyCommandBuffer(command_buffer);
         return;
     }
-    commandBuffer->graphicsCommandList = commandList;
+    command_buffer->graphicsCommandList = commandList;
 
-    commandBuffer->renderer = renderer;
-    commandBuffer->inFlightFence = NULL;
+    command_buffer->renderer = renderer;
+    command_buffer->inFlightFence = NULL;
 
     // Window handling
-    commandBuffer->presentDataCapacity = 1;
-    commandBuffer->presentDataCount = 0;
-    commandBuffer->presentDatas = (D3D12PresentData *)SDL_calloc(
-        commandBuffer->presentDataCapacity, sizeof(D3D12PresentData));
+    command_buffer->presentDataCapacity = 1;
+    command_buffer->presentDataCount = 0;
+    command_buffer->presentDatas = (D3D12PresentData *)SDL_calloc(
+        command_buffer->presentDataCapacity, sizeof(D3D12PresentData));
 
     // Resource tracking
-    commandBuffer->usedTextureCapacity = 4;
-    commandBuffer->usedTextureCount = 0;
-    commandBuffer->usedTextures = (D3D12Texture **)SDL_calloc(
-        commandBuffer->usedTextureCapacity, sizeof(D3D12Texture *));
+    command_buffer->usedTextureCapacity = 4;
+    command_buffer->usedTextureCount = 0;
+    command_buffer->usedTextures = (D3D12Texture **)SDL_calloc(
+        command_buffer->usedTextureCapacity, sizeof(D3D12Texture *));
 
-    commandBuffer->usedBufferCapacity = 4;
-    commandBuffer->usedBufferCount = 0;
-    commandBuffer->usedBuffers = (D3D12Buffer **)SDL_calloc(
-        commandBuffer->usedBufferCapacity, sizeof(D3D12Buffer *));
+    command_buffer->usedBufferCapacity = 4;
+    command_buffer->usedBufferCount = 0;
+    command_buffer->usedBuffers = (D3D12Buffer **)SDL_calloc(
+        command_buffer->usedBufferCapacity, sizeof(D3D12Buffer *));
 
-    commandBuffer->usedSamplerCapacity = 4;
-    commandBuffer->usedSamplerCount = 0;
-    commandBuffer->usedSamplers = (D3D12Sampler **)SDL_calloc(
-        commandBuffer->usedSamplerCapacity, sizeof(D3D12Sampler *));
+    command_buffer->usedSamplerCapacity = 4;
+    command_buffer->usedSamplerCount = 0;
+    command_buffer->usedSamplers = (D3D12Sampler **)SDL_calloc(
+        command_buffer->usedSamplerCapacity, sizeof(D3D12Sampler *));
 
-    commandBuffer->usedGraphicsPipelineCapacity = 4;
-    commandBuffer->usedGraphicsPipelineCount = 0;
-    commandBuffer->usedGraphicsPipelines = (D3D12GraphicsPipeline **)SDL_calloc(
-        commandBuffer->usedGraphicsPipelineCapacity, sizeof(D3D12GraphicsPipeline *));
+    command_buffer->usedGraphicsPipelineCapacity = 4;
+    command_buffer->usedGraphicsPipelineCount = 0;
+    command_buffer->usedGraphicsPipelines = (D3D12GraphicsPipeline **)SDL_calloc(
+        command_buffer->usedGraphicsPipelineCapacity, sizeof(D3D12GraphicsPipeline *));
 
-    commandBuffer->usedComputePipelineCapacity = 4;
-    commandBuffer->usedComputePipelineCount = 0;
-    commandBuffer->usedComputePipelines = (D3D12ComputePipeline **)SDL_calloc(
-        commandBuffer->usedComputePipelineCapacity, sizeof(D3D12ComputePipeline *));
+    command_buffer->usedComputePipelineCapacity = 4;
+    command_buffer->usedComputePipelineCount = 0;
+    command_buffer->usedComputePipelines = (D3D12ComputePipeline **)SDL_calloc(
+        command_buffer->usedComputePipelineCapacity, sizeof(D3D12ComputePipeline *));
 
-    commandBuffer->usedUniformBufferCapacity = 4;
-    commandBuffer->usedUniformBufferCount = 0;
-    commandBuffer->usedUniformBuffers = (D3D12UniformBuffer **)SDL_calloc(
-        commandBuffer->usedUniformBufferCapacity, sizeof(D3D12UniformBuffer *));
+    command_buffer->usedUniformBufferCapacity = 4;
+    command_buffer->usedUniformBufferCount = 0;
+    command_buffer->usedUniformBuffers = (D3D12UniformBuffer **)SDL_calloc(
+        command_buffer->usedUniformBufferCapacity, sizeof(D3D12UniformBuffer *));
 
-    commandBuffer->textureDownloadCapacity = 4;
-    commandBuffer->textureDownloadCount = 0;
-    commandBuffer->textureDownloads = (D3D12TextureDownload **)SDL_calloc(
-        commandBuffer->textureDownloadCapacity, sizeof(D3D12TextureDownload *));
+    command_buffer->textureDownloadCapacity = 4;
+    command_buffer->textureDownloadCount = 0;
+    command_buffer->textureDownloads = (D3D12TextureDownload **)SDL_calloc(
+        command_buffer->textureDownloadCapacity, sizeof(D3D12TextureDownload *));
 
     if (
-        (!commandBuffer->presentDatas) ||
-        (!commandBuffer->usedTextures) ||
-        (!commandBuffer->usedBuffers) ||
-        (!commandBuffer->usedSamplers) ||
-        (!commandBuffer->usedGraphicsPipelines) ||
-        (!commandBuffer->usedComputePipelines) ||
-        (!commandBuffer->usedUniformBuffers) ||
-        (!commandBuffer->textureDownloads)) {
+        (!command_buffer->presentDatas) ||
+        (!command_buffer->usedTextures) ||
+        (!command_buffer->usedBuffers) ||
+        (!command_buffer->usedSamplers) ||
+        (!command_buffer->usedGraphicsPipelines) ||
+        (!command_buffer->usedComputePipelines) ||
+        (!command_buffer->usedUniformBuffers) ||
+        (!command_buffer->textureDownloads)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create ID3D12CommandList. Out of Memory");
-        D3D12_INTERNAL_DestroyCommandBuffer(commandBuffer);
+        D3D12_INTERNAL_DestroyCommandBuffer(command_buffer);
         return;
     }
 
@@ -6641,117 +6641,117 @@ static void D3D12_INTERNAL_AllocateCommandBuffer(
 
     if (!resizedAvailableCommandBuffers) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create ID3D12CommandList. Out of Memory");
-        D3D12_INTERNAL_DestroyCommandBuffer(commandBuffer);
+        D3D12_INTERNAL_DestroyCommandBuffer(command_buffer);
         return;
     }
     // Add to inactive command buffer array
     renderer->availableCommandBufferCapacity += 1;
     renderer->availableCommandBuffers = resizedAvailableCommandBuffers;
 
-    renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = commandBuffer;
+    renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = command_buffer;
     renderer->availableCommandBufferCount += 1;
 }
 
 static D3D12CommandBuffer *D3D12_INTERNAL_AcquireCommandBufferFromPool(
     D3D12Renderer *renderer)
 {
-    D3D12CommandBuffer *commandBuffer;
+    D3D12CommandBuffer *command_buffer;
 
     if (renderer->availableCommandBufferCount == 0) {
         D3D12_INTERNAL_AllocateCommandBuffer(renderer);
     }
 
-    commandBuffer = renderer->availableCommandBuffers[renderer->availableCommandBufferCount - 1];
+    command_buffer = renderer->availableCommandBuffers[renderer->availableCommandBufferCount - 1];
     renderer->availableCommandBufferCount -= 1;
 
-    return commandBuffer;
+    return command_buffer;
 }
 
 static SDL_GPUCommandBuffer *D3D12_AcquireCommandBuffer(
     SDL_GPURenderer *driverData)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
-    D3D12CommandBuffer *commandBuffer;
+    D3D12CommandBuffer *command_buffer;
     ID3D12DescriptorHeap *heaps[2];
     SDL_zeroa(heaps);
 
     SDL_LockMutex(renderer->acquireCommandBufferLock);
-    commandBuffer = D3D12_INTERNAL_AcquireCommandBufferFromPool(renderer);
+    command_buffer = D3D12_INTERNAL_AcquireCommandBufferFromPool(renderer);
     SDL_UnlockMutex(renderer->acquireCommandBufferLock);
 
-    if (commandBuffer == NULL) {
+    if (command_buffer == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to acquire command buffer!");
         return NULL;
     }
 
     // Set the descriptor heaps!
-    commandBuffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV] =
-        D3D12_INTERNAL_AcquireDescriptorHeapFromPool(commandBuffer, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+    command_buffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV] =
+        D3D12_INTERNAL_AcquireDescriptorHeapFromPool(command_buffer, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 
-    if (!commandBuffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV]) {
+    if (!command_buffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV]) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to acquire descriptor heap!");
-        D3D12_INTERNAL_DestroyCommandBuffer(commandBuffer);
+        D3D12_INTERNAL_DestroyCommandBuffer(command_buffer);
         return NULL;
     }
 
-    commandBuffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER] =
-        D3D12_INTERNAL_AcquireDescriptorHeapFromPool(commandBuffer, D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
+    command_buffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER] =
+        D3D12_INTERNAL_AcquireDescriptorHeapFromPool(command_buffer, D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
 
-    if (!commandBuffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER]) {
+    if (!command_buffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER]) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to acquire descriptor heap!");
-        D3D12_INTERNAL_DestroyCommandBuffer(commandBuffer);
+        D3D12_INTERNAL_DestroyCommandBuffer(command_buffer);
         return NULL;
     }
 
-    heaps[0] = commandBuffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV]->handle;
-    heaps[1] = commandBuffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER]->handle;
+    heaps[0] = command_buffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV]->handle;
+    heaps[1] = command_buffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER]->handle;
 
     ID3D12GraphicsCommandList_SetDescriptorHeaps(
-        commandBuffer->graphicsCommandList,
+        command_buffer->graphicsCommandList,
         2,
         heaps);
 
     // Set the bind state
-    commandBuffer->currentGraphicsPipeline = NULL;
+    command_buffer->currentGraphicsPipeline = NULL;
 
-    SDL_zeroa(commandBuffer->colorAttachmentTextureSubresources);
-    commandBuffer->colorAttachmentTextureSubresourceCount = 0;
-    commandBuffer->depthStencilTextureSubresource = NULL;
+    SDL_zeroa(command_buffer->colorAttachmentTextureSubresources);
+    command_buffer->colorAttachmentTextureSubresourceCount = 0;
+    command_buffer->depthStencilTextureSubresource = NULL;
 
-    SDL_zeroa(commandBuffer->vertexBuffers);
-    SDL_zeroa(commandBuffer->vertexBufferOffsets);
-    commandBuffer->vertexBufferCount = 0;
+    SDL_zeroa(command_buffer->vertexBuffers);
+    SDL_zeroa(command_buffer->vertexBufferOffsets);
+    command_buffer->vertexBufferCount = 0;
 
-    SDL_zeroa(commandBuffer->vertexSamplerTextures);
-    SDL_zeroa(commandBuffer->vertexSamplers);
-    SDL_zeroa(commandBuffer->vertexStorageTextures);
-    SDL_zeroa(commandBuffer->vertexStorageBuffers);
-    SDL_zeroa(commandBuffer->vertexUniformBuffers);
+    SDL_zeroa(command_buffer->vertexSamplerTextures);
+    SDL_zeroa(command_buffer->vertexSamplers);
+    SDL_zeroa(command_buffer->vertexStorageTextures);
+    SDL_zeroa(command_buffer->vertexStorageBuffers);
+    SDL_zeroa(command_buffer->vertexUniformBuffers);
 
-    SDL_zeroa(commandBuffer->fragmentSamplerTextures);
-    SDL_zeroa(commandBuffer->fragmentSamplers);
-    SDL_zeroa(commandBuffer->fragmentStorageTextures);
-    SDL_zeroa(commandBuffer->fragmentStorageBuffers);
-    SDL_zeroa(commandBuffer->fragmentUniformBuffers);
+    SDL_zeroa(command_buffer->fragmentSamplerTextures);
+    SDL_zeroa(command_buffer->fragmentSamplers);
+    SDL_zeroa(command_buffer->fragmentStorageTextures);
+    SDL_zeroa(command_buffer->fragmentStorageBuffers);
+    SDL_zeroa(command_buffer->fragmentUniformBuffers);
 
-    SDL_zeroa(commandBuffer->computeReadOnlyStorageTextures);
-    SDL_zeroa(commandBuffer->computeReadOnlyStorageBuffers);
-    SDL_zeroa(commandBuffer->computeWriteOnlyStorageTextureSubresources);
-    SDL_zeroa(commandBuffer->computeWriteOnlyStorageBuffers);
-    SDL_zeroa(commandBuffer->computeUniformBuffers);
+    SDL_zeroa(command_buffer->computeReadOnlyStorageTextures);
+    SDL_zeroa(command_buffer->computeReadOnlyStorageBuffers);
+    SDL_zeroa(command_buffer->computeWriteOnlyStorageTextureSubresources);
+    SDL_zeroa(command_buffer->computeWriteOnlyStorageBuffers);
+    SDL_zeroa(command_buffer->computeUniformBuffers);
 
-    commandBuffer->autoReleaseFence = true;
+    command_buffer->autoReleaseFence = true;
 
-    return (SDL_GPUCommandBuffer *)commandBuffer;
+    return (SDL_GPUCommandBuffer *)command_buffer;
 }
 
 static SDL_GPUTexture *D3D12_AcquireSwapchainTexture(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     SDL_Window *window,
-    Uint32 *pWidth,
-    Uint32 *pHeight)
+    Uint32 *w,
+    Uint32 *h)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     D3D12Renderer *renderer = d3d12CommandBuffer->renderer;
     D3D12WindowData *windowData;
     Uint32 swapchainIndex;
@@ -6768,7 +6768,7 @@ static SDL_GPUTexture *D3D12_AcquireSwapchainTexture(
     ERROR_CHECK_RETURN("Could not resize swapchain", NULL);
 
     if (windowData->inFlightFences[windowData->frameCounter] != NULL) {
-        if (windowData->presentMode == SDL_GPU_PRESENTMODE_VSYNC) {
+        if (windowData->present_mode == SDL_GPU_PRESENTMODE_VSYNC) {
             // In VSYNC mode, block until the least recent presented frame is done
             D3D12_WaitForFences(
                 (SDL_GPURenderer *)renderer,
@@ -6812,8 +6812,8 @@ static SDL_GPUTexture *D3D12_AcquireSwapchainTexture(
 #endif
 
     // Send the dimensions to the out parameters.
-    *pWidth = windowData->textureContainers[swapchainIndex].header.info.width;
-    *pHeight = windowData->textureContainers[swapchainIndex].header.info.height;
+    *w = windowData->textureContainers[swapchainIndex].header.info.width;
+    *h = windowData->textureContainers[swapchainIndex].header.info.height;
 
     // Set up presentation
     if (d3d12CommandBuffer->presentDataCount == d3d12CommandBuffer->presentDataCapacity) {
@@ -6904,7 +6904,7 @@ static void D3D12_INTERNAL_PerformPendingDestroys(D3D12Renderer *renderer)
 }
 
 static void D3D12_INTERNAL_CopyTextureDownload(
-    D3D12CommandBuffer *commandBuffer,
+    D3D12CommandBuffer *command_buffer,
     D3D12TextureDownload *download)
 {
     Uint8 *sourcePtr;
@@ -6955,87 +6955,87 @@ static void D3D12_INTERNAL_CopyTextureDownload(
 
 static void D3D12_INTERNAL_CleanCommandBuffer(
     D3D12Renderer *renderer,
-    D3D12CommandBuffer *commandBuffer)
+    D3D12CommandBuffer *command_buffer)
 {
     Uint32 i;
     HRESULT res;
 
     // Perform deferred texture data copies
 
-    for (i = 0; i < commandBuffer->textureDownloadCount; i += 1) {
+    for (i = 0; i < command_buffer->textureDownloadCount; i += 1) {
         D3D12_INTERNAL_CopyTextureDownload(
-            commandBuffer,
-            commandBuffer->textureDownloads[i]);
-        SDL_free(commandBuffer->textureDownloads[i]);
+            command_buffer,
+            command_buffer->textureDownloads[i]);
+        SDL_free(command_buffer->textureDownloads[i]);
     }
-    commandBuffer->textureDownloadCount = 0;
+    command_buffer->textureDownloadCount = 0;
 
-    res = ID3D12CommandAllocator_Reset(commandBuffer->commandAllocator);
+    res = ID3D12CommandAllocator_Reset(command_buffer->commandAllocator);
     ERROR_CHECK("Could not reset command allocator")
 
     res = ID3D12GraphicsCommandList_Reset(
-        commandBuffer->graphicsCommandList,
-        commandBuffer->commandAllocator,
+        command_buffer->graphicsCommandList,
+        command_buffer->commandAllocator,
         NULL);
     ERROR_CHECK("Could not reset graphicsCommandList")
 
     // Return descriptor heaps to pool
     D3D12_INTERNAL_ReturnDescriptorHeapToPool(
         renderer,
-        commandBuffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV]);
+        command_buffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV]);
     D3D12_INTERNAL_ReturnDescriptorHeapToPool(
         renderer,
-        commandBuffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER]);
+        command_buffer->gpuDescriptorHeaps[D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER]);
 
     // Uniform buffers are now available
     SDL_LockMutex(renderer->acquireUniformBufferLock);
 
-    for (i = 0; i < commandBuffer->usedUniformBufferCount; i += 1) {
+    for (i = 0; i < command_buffer->usedUniformBufferCount; i += 1) {
         D3D12_INTERNAL_ReturnUniformBufferToPool(
             renderer,
-            commandBuffer->usedUniformBuffers[i]);
+            command_buffer->usedUniformBuffers[i]);
     }
-    commandBuffer->usedUniformBufferCount = 0;
+    command_buffer->usedUniformBufferCount = 0;
 
     SDL_UnlockMutex(renderer->acquireUniformBufferLock);
 
     // TODO: More reference counting
 
-    for (i = 0; i < commandBuffer->usedTextureCount; i += 1) {
-        (void)SDL_AtomicDecRef(&commandBuffer->usedTextures[i]->referenceCount);
+    for (i = 0; i < command_buffer->usedTextureCount; i += 1) {
+        (void)SDL_AtomicDecRef(&command_buffer->usedTextures[i]->referenceCount);
     }
-    commandBuffer->usedTextureCount = 0;
+    command_buffer->usedTextureCount = 0;
 
-    for (i = 0; i < commandBuffer->usedBufferCount; i += 1) {
-        (void)SDL_AtomicDecRef(&commandBuffer->usedBuffers[i]->referenceCount);
+    for (i = 0; i < command_buffer->usedBufferCount; i += 1) {
+        (void)SDL_AtomicDecRef(&command_buffer->usedBuffers[i]->referenceCount);
     }
-    commandBuffer->usedBufferCount = 0;
+    command_buffer->usedBufferCount = 0;
 
-    for (i = 0; i < commandBuffer->usedSamplerCount; i += 1) {
-        (void)SDL_AtomicDecRef(&commandBuffer->usedSamplers[i]->referenceCount);
+    for (i = 0; i < command_buffer->usedSamplerCount; i += 1) {
+        (void)SDL_AtomicDecRef(&command_buffer->usedSamplers[i]->referenceCount);
     }
-    commandBuffer->usedSamplerCount = 0;
+    command_buffer->usedSamplerCount = 0;
 
-    for (i = 0; i < commandBuffer->usedGraphicsPipelineCount; i += 1) {
-        (void)SDL_AtomicDecRef(&commandBuffer->usedGraphicsPipelines[i]->referenceCount);
+    for (i = 0; i < command_buffer->usedGraphicsPipelineCount; i += 1) {
+        (void)SDL_AtomicDecRef(&command_buffer->usedGraphicsPipelines[i]->referenceCount);
     }
-    commandBuffer->usedGraphicsPipelineCount = 0;
+    command_buffer->usedGraphicsPipelineCount = 0;
 
-    for (i = 0; i < commandBuffer->usedComputePipelineCount; i += 1) {
-        (void)SDL_AtomicDecRef(&commandBuffer->usedComputePipelines[i]->referenceCount);
+    for (i = 0; i < command_buffer->usedComputePipelineCount; i += 1) {
+        (void)SDL_AtomicDecRef(&command_buffer->usedComputePipelines[i]->referenceCount);
     }
-    commandBuffer->usedComputePipelineCount = 0;
+    command_buffer->usedComputePipelineCount = 0;
 
     // Reset presentation
-    commandBuffer->presentDataCount = 0;
+    command_buffer->presentDataCount = 0;
 
     // The fence is now available (unless SubmitAndAcquireFence was called)
-    if (commandBuffer->autoReleaseFence) {
+    if (command_buffer->autoReleaseFence) {
         D3D12_ReleaseFence(
             (SDL_GPURenderer *)renderer,
-            (SDL_GPUFence *)commandBuffer->inFlightFence);
+            (SDL_GPUFence *)command_buffer->inFlightFence);
 
-        commandBuffer->inFlightFence = NULL;
+        command_buffer->inFlightFence = NULL;
     }
 
     // Return command buffer to pool
@@ -7048,14 +7048,14 @@ static void D3D12_INTERNAL_CleanCommandBuffer(
             renderer->availableCommandBufferCapacity * sizeof(D3D12CommandBuffer *));
     }
 
-    renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = commandBuffer;
+    renderer->availableCommandBuffers[renderer->availableCommandBufferCount] = command_buffer;
     renderer->availableCommandBufferCount += 1;
 
     SDL_UnlockMutex(renderer->acquireCommandBufferLock);
 
     // Remove this command buffer from the submitted list
     for (i = 0; i < renderer->submittedCommandBufferCount; i += 1) {
-        if (renderer->submittedCommandBuffers[i] == commandBuffer) {
+        if (renderer->submittedCommandBuffers[i] == command_buffer) {
             renderer->submittedCommandBuffers[i] = renderer->submittedCommandBuffers[renderer->submittedCommandBufferCount - 1];
             renderer->submittedCommandBufferCount -= 1;
         }
@@ -7063,9 +7063,9 @@ static void D3D12_INTERNAL_CleanCommandBuffer(
 }
 
 static void D3D12_Submit(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     D3D12Renderer *renderer = d3d12CommandBuffer->renderer;
     ID3D12CommandList *commandLists[1];
     HRESULT res;
@@ -7171,20 +7171,20 @@ static void D3D12_Submit(
 
         D3D12XBOX_PRESENT_PARAMETERS presentParams;
         SDL_zero(presentParams);
-        presentParams.Flags = (windowData->presentMode == SDL_GPU_PRESENTMODE_IMMEDIATE) ? D3D12XBOX_PRESENT_FLAG_IMMEDIATE : D3D12XBOX_PRESENT_FLAG_NONE;
+        presentParams.Flags = (windowData->present_mode == SDL_GPU_PRESENTMODE_IMMEDIATE) ? D3D12XBOX_PRESENT_FLAG_IMMEDIATE : D3D12XBOX_PRESENT_FLAG_NONE;
 
         renderer->commandQueue->PresentX(1, &planeParams, &presentParams);
 #else
         // NOTE: flip discard always supported since DXGI 1.4 is required
         Uint32 syncInterval = 1;
-        if (windowData->presentMode == SDL_GPU_PRESENTMODE_IMMEDIATE ||
-            windowData->presentMode == SDL_GPU_PRESENTMODE_MAILBOX) {
+        if (windowData->present_mode == SDL_GPU_PRESENTMODE_IMMEDIATE ||
+            windowData->present_mode == SDL_GPU_PRESENTMODE_MAILBOX) {
             syncInterval = 0;
         }
 
         Uint32 presentFlags = 0;
         if (renderer->supportsTearing &&
-            windowData->presentMode == SDL_GPU_PRESENTMODE_IMMEDIATE) {
+            windowData->present_mode == SDL_GPU_PRESENTMODE_IMMEDIATE) {
             presentFlags = DXGI_PRESENT_ALLOW_TEARING;
         }
 
@@ -7219,11 +7219,11 @@ static void D3D12_Submit(
 }
 
 static SDL_GPUFence *D3D12_SubmitAndAcquireFence(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
-    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)command_buffer;
     d3d12CommandBuffer->autoReleaseFence = false;
-    D3D12_Submit(commandBuffer);
+    D3D12_Submit(command_buffer);
     return (SDL_GPUFence *)d3d12CommandBuffer->inFlightFence;
 }
 
@@ -7275,19 +7275,19 @@ static void D3D12_Wait(
 
 static void D3D12_WaitForFences(
     SDL_GPURenderer *driverData,
-    bool waitAll,
-    SDL_GPUFence *const *pFences,
-    Uint32 fenceCount)
+    bool wait_all,
+    SDL_GPUFence *const *fences,
+    Uint32 num_fences)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
     D3D12Fence *fence;
-    HANDLE *events = SDL_stack_alloc(HANDLE, fenceCount);
+    HANDLE *events = SDL_stack_alloc(HANDLE, num_fences);
     HRESULT res;
 
     SDL_LockMutex(renderer->submitLock);
 
-    for (Uint32 i = 0; i < fenceCount; i += 1) {
-        fence = (D3D12Fence *)pFences[i];
+    for (Uint32 i = 0; i < num_fences; i += 1) {
+        fence = (D3D12Fence *)fences[i];
 
         res = ID3D12Fence_SetEventOnCompletion(
             fence->handle,
@@ -7299,9 +7299,9 @@ static void D3D12_WaitForFences(
     }
 
     WaitForMultipleObjects(
-        fenceCount,
+        num_fences,
         events,
-        waitAll,
+        wait_all,
         INFINITE);
 
     // Check for cleanups
@@ -7383,7 +7383,7 @@ static bool D3D12_SupportsTextureFormat(
 static bool D3D12_SupportsSampleCount(
     SDL_GPURenderer *driverData,
     SDL_GPUTextureFormat format,
-    SDL_GPUSampleCount sampleCount)
+    SDL_GPUSampleCount sample_count)
 {
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
     D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS featureData;
@@ -7395,7 +7395,7 @@ static bool D3D12_SupportsSampleCount(
     featureData.Flags = (D3D12_MULTISAMPLE_QUALITY_LEVEL_FLAGS)0;
 #endif
     featureData.Format = SDLToD3D12_TextureFormat[format];
-    featureData.SampleCount = SDLToD3D12_SampleCount[sampleCount];
+    featureData.SampleCount = SDLToD3D12_SampleCount[sample_count];
     res = ID3D12Device_CheckFeatureSupport(
         renderer->device,
         D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS,
@@ -7419,10 +7419,10 @@ static void D3D12_INTERNAL_InitBlitResources(
     // Fullscreen vertex shader
     SDL_zero(shaderCreateInfo);
     shaderCreateInfo.code = (Uint8 *)D3D12_FullscreenVert;
-    shaderCreateInfo.codeSize = sizeof(D3D12_FullscreenVert);
+    shaderCreateInfo.code_size = sizeof(D3D12_FullscreenVert);
     shaderCreateInfo.stage = SDL_GPU_SHADERSTAGE_VERTEX;
     shaderCreateInfo.format = SDL_GPU_SHADERFORMAT_DXBC;
-    shaderCreateInfo.entryPointName = "main";
+    shaderCreateInfo.entrypoint_name = "main";
 
     renderer->blitVertexShader = D3D12_CreateShader(
         (SDL_GPURenderer *)renderer,
@@ -7434,10 +7434,10 @@ static void D3D12_INTERNAL_InitBlitResources(
 
     // BlitFrom2D pixel shader
     shaderCreateInfo.code = (Uint8 *)D3D12_BlitFrom2D;
-    shaderCreateInfo.codeSize = sizeof(D3D12_BlitFrom2D);
+    shaderCreateInfo.code_size = sizeof(D3D12_BlitFrom2D);
     shaderCreateInfo.stage = SDL_GPU_SHADERSTAGE_FRAGMENT;
-    shaderCreateInfo.samplerCount = 1;
-    shaderCreateInfo.uniformBufferCount = 1;
+    shaderCreateInfo.num_samplers = 1;
+    shaderCreateInfo.num_uniform_buffers = 1;
 
     renderer->blitFrom2DShader = D3D12_CreateShader(
         (SDL_GPURenderer *)renderer,
@@ -7449,7 +7449,7 @@ static void D3D12_INTERNAL_InitBlitResources(
 
     // BlitFrom2DArray pixel shader
     shaderCreateInfo.code = (Uint8 *)D3D12_BlitFrom2DArray;
-    shaderCreateInfo.codeSize = sizeof(D3D12_BlitFrom2DArray);
+    shaderCreateInfo.code_size = sizeof(D3D12_BlitFrom2DArray);
 
     renderer->blitFrom2DArrayShader = D3D12_CreateShader(
         (SDL_GPURenderer *)renderer,
@@ -7461,7 +7461,7 @@ static void D3D12_INTERNAL_InitBlitResources(
 
     // BlitFrom3D pixel shader
     shaderCreateInfo.code = (Uint8 *)D3D12_BlitFrom3D;
-    shaderCreateInfo.codeSize = sizeof(D3D12_BlitFrom3D);
+    shaderCreateInfo.code_size = sizeof(D3D12_BlitFrom3D);
 
     renderer->blitFrom3DShader = D3D12_CreateShader(
         (SDL_GPURenderer *)renderer,
@@ -7473,7 +7473,7 @@ static void D3D12_INTERNAL_InitBlitResources(
 
     // BlitFromCube pixel shader
     shaderCreateInfo.code = (Uint8 *)D3D12_BlitFromCube;
-    shaderCreateInfo.codeSize = sizeof(D3D12_BlitFromCube);
+    shaderCreateInfo.code_size = sizeof(D3D12_BlitFromCube);
 
     renderer->blitFromCubeShader = D3D12_CreateShader(
         (SDL_GPURenderer *)renderer,
@@ -7484,19 +7484,19 @@ static void D3D12_INTERNAL_InitBlitResources(
     }
 
     // Create samplers
-    samplerCreateInfo.addressModeU = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-    samplerCreateInfo.addressModeV = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-    samplerCreateInfo.addressModeW = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
-    samplerCreateInfo.anisotropyEnable = 0;
-    samplerCreateInfo.compareEnable = 0;
-    samplerCreateInfo.magFilter = SDL_GPU_FILTER_NEAREST;
-    samplerCreateInfo.minFilter = SDL_GPU_FILTER_NEAREST;
-    samplerCreateInfo.mipmapMode = SDL_GPU_SAMPLERMIPMAPMODE_NEAREST;
-    samplerCreateInfo.mipLodBias = 0.0f;
-    samplerCreateInfo.minLod = 0;
-    samplerCreateInfo.maxLod = 1000;
-    samplerCreateInfo.maxAnisotropy = 1.0f;
-    samplerCreateInfo.compareOp = SDL_GPU_COMPAREOP_ALWAYS;
+    samplerCreateInfo.address_mode_u = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+    samplerCreateInfo.address_mode_v = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+    samplerCreateInfo.address_mode_w = SDL_GPU_SAMPLERADDRESSMODE_CLAMP_TO_EDGE;
+    samplerCreateInfo.enable_anisotropy = 0;
+    samplerCreateInfo.enable_compare = 0;
+    samplerCreateInfo.mag_filter = SDL_GPU_FILTER_NEAREST;
+    samplerCreateInfo.min_filter = SDL_GPU_FILTER_NEAREST;
+    samplerCreateInfo.mipmap_mode = SDL_GPU_SAMPLERMIPMAPMODE_NEAREST;
+    samplerCreateInfo.mip_lod_bias = 0.0f;
+    samplerCreateInfo.min_lod = 0;
+    samplerCreateInfo.max_lod = 1000;
+    samplerCreateInfo.max_anisotropy = 1.0f;
+    samplerCreateInfo.compare_op = SDL_GPU_COMPAREOP_ALWAYS;
 
     renderer->blitNearestSampler = D3D12_CreateSampler(
         (SDL_GPURenderer *)renderer,
@@ -7506,9 +7506,9 @@ static void D3D12_INTERNAL_InitBlitResources(
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create blit nearest sampler!");
     }
 
-    samplerCreateInfo.magFilter = SDL_GPU_FILTER_LINEAR;
-    samplerCreateInfo.minFilter = SDL_GPU_FILTER_LINEAR;
-    samplerCreateInfo.mipmapMode = SDL_GPU_SAMPLERMIPMAPMODE_LINEAR;
+    samplerCreateInfo.mag_filter = SDL_GPU_FILTER_LINEAR;
+    samplerCreateInfo.min_filter = SDL_GPU_FILTER_LINEAR;
+    samplerCreateInfo.mipmap_mode = SDL_GPU_SAMPLERMIPMAPMODE_LINEAR;
 
     renderer->blitLinearSampler = D3D12_CreateSampler(
         (SDL_GPURenderer *)renderer,
@@ -7737,7 +7737,7 @@ static void D3D12_INTERNAL_TryInitializeD3D12DebugInfoQueue(D3D12Renderer *rende
 }
 #endif
 
-static SDL_GPUDevice *D3D12_CreateDevice(bool debugMode, bool preferLowPower, SDL_PropertiesID props)
+static SDL_GPUDevice *D3D12_CreateDevice(bool debug_mode, bool preferLowPower, SDL_PropertiesID props)
 {
     SDL_GPUDevice *result;
     D3D12Renderer *renderer;
@@ -7770,7 +7770,7 @@ static SDL_GPUDevice *D3D12_CreateDevice(bool debugMode, bool preferLowPower, SD
 
 #ifdef HAVE_IDXGIINFOQUEUE
     // Initialize the DXGI debug layer, if applicable
-    if (debugMode) {
+    if (debug_mode) {
         D3D12_INTERNAL_TryInitializeDXGIDebug(renderer);
     }
 #endif
@@ -7897,7 +7897,7 @@ static SDL_GPUDevice *D3D12_CreateDevice(bool debugMode, bool preferLowPower, SD
     }
 
     // Initialize the D3D12 debug layer, if applicable
-    if (debugMode) {
+    if (debug_mode) {
         D3D12_INTERNAL_TryInitializeD3D12Debug(renderer);
     }
 
@@ -7916,7 +7916,7 @@ static SDL_GPUDevice *D3D12_CreateDevice(bool debugMode, bool preferLowPower, SD
 #if defined(SDL_PLATFORM_XBOXSERIES)
         createDeviceParams.DisableDXR = TRUE;
 #endif
-        if (debugMode) {
+        if (debug_mode) {
             createDeviceParams.ProcessDebugFlags = D3D12XBOX_PROCESS_DEBUG_FLAG_DEBUG;
         }
 
@@ -7964,7 +7964,7 @@ static SDL_GPUDevice *D3D12_CreateDevice(bool debugMode, bool preferLowPower, SD
     }
 
     // Initialize the D3D12 debug info queue, if applicable
-    if (debugMode) {
+    if (debug_mode) {
         D3D12_INTERNAL_TryInitializeD3D12DebugInfoQueue(renderer);
     }
 #endif
@@ -8200,7 +8200,7 @@ static SDL_GPUDevice *D3D12_CreateDevice(bool debugMode, bool preferLowPower, SD
     renderer->fenceLock = SDL_CreateMutex();
     renderer->disposeLock = SDL_CreateMutex();
 
-    renderer->debugMode = debugMode;
+    renderer->debug_mode = debug_mode;
 
     renderer->semantic = SDL_GetStringProperty(props, SDL_PROP_GPU_DEVICE_CREATE_D3D12_SEMANTIC_NAME_STRING, "TEXCOORD");
 
@@ -8217,7 +8217,7 @@ static SDL_GPUDevice *D3D12_CreateDevice(bool debugMode, bool preferLowPower, SD
 
     ASSIGN_DRIVER(D3D12)
     result->driverData = (SDL_GPURenderer *)renderer;
-    result->debugMode = debugMode;
+    result->debug_mode = debug_mode;
     renderer->sdlGPUDevice = result;
 
     return result;

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -37,20 +37,20 @@
 #define TRACK_RESOURCE(resource, type, array, count, capacity) \
     Uint32 i;                                                  \
                                                                \
-    for (i = 0; i < command_buffer->count; i += 1) {           \
-        if (command_buffer->array[i] == resource) {            \
+    for (i = 0; i < commandBuffer->count; i += 1) {            \
+        if (commandBuffer->array[i] == resource) {             \
             return;                                            \
         }                                                      \
     }                                                          \
                                                                \
-    if (command_buffer->count == command_buffer->capacity) {   \
-        command_buffer->capacity += 1;                         \
-        command_buffer->array = SDL_realloc(                   \
-            command_buffer->array,                             \
-            command_buffer->capacity * sizeof(type));          \
+    if (commandBuffer->count == commandBuffer->capacity) {     \
+        commandBuffer->capacity += 1;                          \
+        commandBuffer->array = SDL_realloc(                    \
+            commandBuffer->array,                              \
+            commandBuffer->capacity * sizeof(type));           \
     }                                                          \
-    command_buffer->array[command_buffer->count] = resource;   \
-    command_buffer->count += 1;                                \
+    commandBuffer->array[commandBuffer->count] = resource;     \
+    commandBuffer->count += 1;                                 \
     SDL_AtomicIncRef(&resource->referenceCount);
 
 // Blit Shaders
@@ -695,7 +695,7 @@ static void METAL_DestroyDevice(SDL_GPUDevice *device)
 // Resource tracking
 
 static void METAL_INTERNAL_TrackBuffer(
-    MetalCommandBuffer *command_buffer,
+    MetalCommandBuffer *commandBuffer,
     MetalBuffer *buffer)
 {
     TRACK_RESOURCE(
@@ -707,7 +707,7 @@ static void METAL_INTERNAL_TrackBuffer(
 }
 
 static void METAL_INTERNAL_TrackTexture(
-    MetalCommandBuffer *command_buffer,
+    MetalCommandBuffer *commandBuffer,
     MetalTexture *texture)
 {
     TRACK_RESOURCE(

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -580,7 +580,7 @@ struct VulkanBuffer
     VulkanMemoryUsedRegion *usedRegion;
 
     VulkanBufferType type;
-    SDL_GPUBufferUsageFlags usage_flags;
+    SDL_GPUBufferUsageFlags usageFlags;
 
     SDL_AtomicInt referenceCount; // Tracks command buffer usage
 
@@ -630,11 +630,11 @@ typedef struct VulkanSampler
 typedef struct VulkanShader
 {
     VkShaderModule shaderModule;
-    const char *entrypoint_name;
-    Uint32 num_samplers;
-    Uint32 num_storage_textures;
-    Uint32 num_storage_buffers;
-    Uint32 num_uniform_buffers;
+    const char *entrypointName;
+    Uint32 numSamplers;
+    Uint32 numStorageTextures;
+    Uint32 numStorageBuffers;
+    Uint32 numUniformBuffers;
     SDL_AtomicInt referenceCount;
 } VulkanShader;
 
@@ -675,11 +675,11 @@ struct VulkanTexture
 
     Uint32 depth;
     Uint32 layerCount;
-    Uint32 num_levels;
-    VkSampleCountFlagBits sample_count; // NOTE: This refers to the sample count of a render target pass using this texture, not the actual sample count of the texture
+    Uint32 numLevels;
+    VkSampleCountFlagBits sampleCount; // NOTE: This refers to the sample count of a render target pass using this texture, not the actual sample count of the texture
     VkFormat format;
     VkComponentMapping swizzle;
-    SDL_GPUTextureUsageFlags usage_flags;
+    SDL_GPUTextureUsageFlags usageFlags;
     VkImageAspectFlags aspectFlags;
 
     Uint32 subresourceCount;
@@ -765,7 +765,7 @@ typedef struct VulkanSwapchainData
     VkFormat format;
     VkColorSpaceKHR colorSpace;
     VkComponentMapping swapchainSwizzle;
-    VkPresentModeKHR present_mode;
+    VkPresentModeKHR presentMode;
     bool usingFallbackFormat;
 
     // Swapchain images
@@ -783,8 +783,8 @@ typedef struct VulkanSwapchainData
 typedef struct WindowData
 {
     SDL_Window *window;
-    SDL_GPUSwapchainComposition swapchain_composition;
-    SDL_GPUPresentMode present_mode;
+    SDL_GPUSwapchainComposition swapchainComposition;
+    SDL_GPUPresentMode presentMode;
     VulkanSwapchainData *swapchainData;
     bool needsSwapchainRecreate;
 } WindowData;
@@ -864,12 +864,12 @@ typedef struct VulkanGraphicsPipelineResourceLayout
 typedef struct VulkanGraphicsPipeline
 {
     VkPipeline pipeline;
-    SDL_GPUPrimitiveType primitive_type;
+    SDL_GPUPrimitiveType primitiveType;
 
     VulkanGraphicsPipelineResourceLayout resourceLayout;
 
-    VulkanShader *vertex_shader;
-    VulkanShader *fragment_shader;
+    VulkanShader *vertexShader;
+    VulkanShader *fragmentShader;
 
     SDL_AtomicInt referenceCount;
 } VulkanGraphicsPipeline;
@@ -886,11 +886,11 @@ typedef struct VulkanComputePipelineResourceLayout
      */
     DescriptorSetPool descriptorSetPools[3];
 
-    Uint32 num_readonly_storage_textures;
-    Uint32 num_readonly_storage_buffers;
-    Uint32 num_writeonly_storage_textures;
-    Uint32 num_writeonly_storage_buffers;
-    Uint32 num_uniform_buffers;
+    Uint32 numReadonlyStorageTextures;
+    Uint32 numReadonlyStorageBuffers;
+    Uint32 numWriteonlyStorageTextures;
+    Uint32 numWriteonlyStorageBuffers;
+    Uint32 numUniformBuffers;
 } VulkanComputePipelineResourceLayout;
 
 typedef struct VulkanComputePipeline
@@ -904,17 +904,17 @@ typedef struct VulkanComputePipeline
 typedef struct RenderPassColorTargetDescription
 {
     VkFormat format;
-    SDL_GPULoadOp load_op;
-    SDL_GPUStoreOp store_op;
+    SDL_GPULoadOp loadOp;
+    SDL_GPUStoreOp storeOp;
 } RenderPassColorTargetDescription;
 
 typedef struct RenderPassDepthStencilTargetDescription
 {
     VkFormat format;
-    SDL_GPULoadOp load_op;
-    SDL_GPUStoreOp store_op;
-    SDL_GPULoadOp stencil_load_op;
-    SDL_GPUStoreOp stencil_store_op;
+    SDL_GPULoadOp loadOp;
+    SDL_GPUStoreOp storeOp;
+    SDL_GPULoadOp stencilLoadOp;
+    SDL_GPUStoreOp stencilStoreOp;
 } RenderPassDepthStencilTargetDescription;
 
 typedef struct CommandPoolHashTableKey
@@ -925,7 +925,7 @@ typedef struct CommandPoolHashTableKey
 typedef struct RenderPassHashTableKey
 {
     RenderPassColorTargetDescription colorTargetDescriptions[MAX_COLOR_TARGET_BINDINGS];
-    Uint32 num_color_attachments;
+    Uint32 numColorTargets;
     RenderPassDepthStencilTargetDescription depthStencilTargetDescription;
     VkSampleCountFlagBits colorAttachmentSampleCount;
 } RenderPassHashTableKey;
@@ -939,7 +939,7 @@ typedef struct FramebufferHashTableKey
 {
     VkImageView colorAttachmentViews[MAX_COLOR_TARGET_BINDINGS];
     VkImageView colorMultiSampleAttachmentViews[MAX_COLOR_TARGET_BINDINGS];
-    Uint32 num_color_attachments;
+    Uint32 numColorTargets;
     VkImageView depthStencilAttachmentView;
     Uint32 width;
     Uint32 height;
@@ -971,7 +971,7 @@ typedef struct VulkanCommandBuffer
     CommandBufferCommonHeader common;
     VulkanRenderer *renderer;
 
-    VkCommandBuffer command_buffer;
+    VkCommandBuffer commandBuffer;
     VulkanCommandPool *commandPool;
 
     VulkanPresentData *presentDatas;
@@ -1000,7 +1000,7 @@ typedef struct VulkanCommandBuffer
 
     VkViewport currentViewport;
     VkRect2D currentScissor;
-    float blend_constants[4];
+    float blendConstants[4];
     Uint8 stencilRef;
 
     // Resource bind state
@@ -1113,7 +1113,7 @@ struct VulkanRenderer
     Uint8 outofBARMemoryWarning;
     Uint8 fillModeOnlyWarning;
 
-    bool debug_mode;
+    bool debugMode;
     bool preferLowPower;
     VulkanExtensions supports;
     bool supportsDebugUtils;
@@ -1205,11 +1205,11 @@ struct VulkanRenderer
 // Forward declarations
 
 static Uint8 VULKAN_INTERNAL_DefragmentMemory(VulkanRenderer *renderer);
-static void VULKAN_INTERNAL_BeginCommandBuffer(VulkanRenderer *renderer, VulkanCommandBuffer *command_buffer);
+static void VULKAN_INTERNAL_BeginCommandBuffer(VulkanRenderer *renderer, VulkanCommandBuffer *commandBuffer);
 static void VULKAN_ReleaseWindow(SDL_GPURenderer *driverData, SDL_Window *window);
 static void VULKAN_Wait(SDL_GPURenderer *driverData);
-static void VULKAN_WaitForFences(SDL_GPURenderer *driverData, bool wait_all, SDL_GPUFence *const *fences, Uint32 num_fences);
-static void VULKAN_Submit(SDL_GPUCommandBuffer *command_buffer);
+static void VULKAN_WaitForFences(SDL_GPURenderer *driverData, bool waitAll, SDL_GPUFence *const *fences, Uint32 numFences);
+static void VULKAN_Submit(SDL_GPUCommandBuffer *commandBuffer);
 static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
     VulkanRenderer *renderer,
     Uint32 width,
@@ -1217,8 +1217,8 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
     Uint32 depth,
     SDL_GPUTextureType type,
     Uint32 layerCount,
-    Uint32 num_levels,
-    VkSampleCountFlagBits sample_count,
+    Uint32 numLevels,
+    VkSampleCountFlagBits sampleCount,
     VkFormat format,
     VkComponentMapping swizzle,
     VkImageAspectFlags aspectMask,
@@ -2453,10 +2453,10 @@ static void VULKAN_INTERNAL_TrackSampler(
 
 static void VULKAN_INTERNAL_TrackGraphicsPipeline(
     VulkanCommandBuffer *command_buffer,
-    VulkanGraphicsPipeline *graphics_pipeline)
+    VulkanGraphicsPipeline *graphicsPipeline)
 {
     TRACK_RESOURCE(
-        graphics_pipeline,
+        graphicsPipeline,
         VulkanGraphicsPipeline *,
         usedGraphicsPipelines,
         usedGraphicsPipelineCount,
@@ -2465,10 +2465,10 @@ static void VULKAN_INTERNAL_TrackGraphicsPipeline(
 
 static void VULKAN_INTERNAL_TrackComputePipeline(
     VulkanCommandBuffer *command_buffer,
-    VulkanComputePipeline *compute_pipeline)
+    VulkanComputePipeline *computePipeline)
 {
     TRACK_RESOURCE(
-        compute_pipeline,
+        computePipeline,
         VulkanComputePipeline *,
         usedComputePipelines,
         usedComputePipelineCount,
@@ -2489,27 +2489,27 @@ static void VULKAN_INTERNAL_TrackFramebuffer(
 }
 
 static void VULKAN_INTERNAL_TrackUniformBuffer(
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanUniformBuffer *uniformBuffer)
 {
     Uint32 i;
-    for (i = 0; i < command_buffer->usedUniformBufferCount; i += 1) {
-        if (command_buffer->usedUniformBuffers[i] == uniformBuffer) {
+    for (i = 0; i < commandBuffer->usedUniformBufferCount; i += 1) {
+        if (commandBuffer->usedUniformBuffers[i] == uniformBuffer) {
             return;
         }
     }
 
-    if (command_buffer->usedUniformBufferCount == command_buffer->usedUniformBufferCapacity) {
-        command_buffer->usedUniformBufferCapacity += 1;
-        command_buffer->usedUniformBuffers = SDL_realloc(
-            command_buffer->usedUniformBuffers,
-            command_buffer->usedUniformBufferCapacity * sizeof(VulkanUniformBuffer *));
+    if (commandBuffer->usedUniformBufferCount == commandBuffer->usedUniformBufferCapacity) {
+        commandBuffer->usedUniformBufferCapacity += 1;
+        commandBuffer->usedUniformBuffers = SDL_realloc(
+            commandBuffer->usedUniformBuffers,
+            commandBuffer->usedUniformBufferCapacity * sizeof(VulkanUniformBuffer *));
     }
-    command_buffer->usedUniformBuffers[command_buffer->usedUniformBufferCount] = uniformBuffer;
-    command_buffer->usedUniformBufferCount += 1;
+    commandBuffer->usedUniformBuffers[commandBuffer->usedUniformBufferCount] = uniformBuffer;
+    commandBuffer->usedUniformBufferCount += 1;
 
     VULKAN_INTERNAL_TrackBuffer(
-        command_buffer,
+        commandBuffer,
         uniformBuffer->bufferHandle->vulkanBuffer);
 }
 
@@ -2554,7 +2554,7 @@ static void VULKAN_INTERNAL_TrackUniformBuffer(
 
 static void VULKAN_INTERNAL_BufferMemoryBarrier(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanBufferUsageMode sourceUsageMode,
     VulkanBufferUsageMode destinationUsageMode,
     VulkanBuffer *buffer)
@@ -2632,7 +2632,7 @@ static void VULKAN_INTERNAL_BufferMemoryBarrier(
     }
 
     renderer->vkCmdPipelineBarrier(
-        command_buffer->command_buffer,
+        commandBuffer->commandBuffer,
         srcStages,
         dstStages,
         0,
@@ -2648,7 +2648,7 @@ static void VULKAN_INTERNAL_BufferMemoryBarrier(
 
 static void VULKAN_INTERNAL_TextureSubresourceMemoryBarrier(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanTextureUsageMode sourceUsageMode,
     VulkanTextureUsageMode destinationUsageMode,
     VulkanTextureSubresource *textureSubresource)
@@ -2755,7 +2755,7 @@ static void VULKAN_INTERNAL_TextureSubresourceMemoryBarrier(
     }
 
     renderer->vkCmdPipelineBarrier(
-        command_buffer->command_buffer,
+        commandBuffer->commandBuffer,
         srcStages,
         dstStages,
         0,
@@ -2774,17 +2774,17 @@ static VulkanBufferUsageMode VULKAN_INTERNAL_DefaultBufferUsageMode(
 {
     // NOTE: order matters here!
 
-    if (buffer->usage_flags & SDL_GPU_BUFFERUSAGE_VERTEX) {
+    if (buffer->usageFlags & SDL_GPU_BUFFERUSAGE_VERTEX) {
         return VULKAN_BUFFER_USAGE_MODE_VERTEX_READ;
-    } else if (buffer->usage_flags & SDL_GPU_BUFFERUSAGE_INDEX) {
+    } else if (buffer->usageFlags & SDL_GPU_BUFFERUSAGE_INDEX) {
         return VULKAN_BUFFER_USAGE_MODE_INDEX_READ;
-    } else if (buffer->usage_flags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
+    } else if (buffer->usageFlags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
         return VULKAN_BUFFER_USAGE_MODE_INDIRECT;
-    } else if (buffer->usage_flags & SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ) {
+    } else if (buffer->usageFlags & SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ) {
         return VULKAN_BUFFER_USAGE_MODE_GRAPHICS_STORAGE_READ;
-    } else if (buffer->usage_flags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ) {
+    } else if (buffer->usageFlags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ) {
         return VULKAN_BUFFER_USAGE_MODE_COMPUTE_STORAGE_READ;
-    } else if (buffer->usage_flags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE) {
+    } else if (buffer->usageFlags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE) {
         return VULKAN_BUFFER_USAGE_MODE_COMPUTE_STORAGE_READ_WRITE;
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Buffer has no default usage mode!");
@@ -2798,17 +2798,17 @@ static VulkanTextureUsageMode VULKAN_INTERNAL_DefaultTextureUsageMode(
     // NOTE: order matters here!
     // NOTE: graphics storage bits and sampler bit are mutually exclusive!
 
-    if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_SAMPLER) {
+    if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_SAMPLER) {
         return VULKAN_TEXTURE_USAGE_MODE_SAMPLER;
-    } else if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ) {
+    } else if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ) {
         return VULKAN_TEXTURE_USAGE_MODE_GRAPHICS_STORAGE_READ;
-    } else if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
+    } else if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
         return VULKAN_TEXTURE_USAGE_MODE_COLOR_ATTACHMENT;
-    } else if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
+    } else if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
         return VULKAN_TEXTURE_USAGE_MODE_DEPTH_STENCIL_ATTACHMENT;
-    } else if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ) {
+    } else if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ) {
         return VULKAN_TEXTURE_USAGE_MODE_COMPUTE_STORAGE_READ;
-    } else if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
+    } else if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
         return VULKAN_TEXTURE_USAGE_MODE_COMPUTE_STORAGE_READ_WRITE;
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Texture has no default usage mode!");
@@ -2818,13 +2818,13 @@ static VulkanTextureUsageMode VULKAN_INTERNAL_DefaultTextureUsageMode(
 
 static void VULKAN_INTERNAL_BufferTransitionFromDefaultUsage(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanBufferUsageMode destinationUsageMode,
     VulkanBuffer *buffer)
 {
     VULKAN_INTERNAL_BufferMemoryBarrier(
         renderer,
-        command_buffer,
+        commandBuffer,
         VULKAN_INTERNAL_DefaultBufferUsageMode(buffer),
         destinationUsageMode,
         buffer);
@@ -2832,13 +2832,13 @@ static void VULKAN_INTERNAL_BufferTransitionFromDefaultUsage(
 
 static void VULKAN_INTERNAL_BufferTransitionToDefaultUsage(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanBufferUsageMode sourceUsageMode,
     VulkanBuffer *buffer)
 {
     VULKAN_INTERNAL_BufferMemoryBarrier(
         renderer,
-        command_buffer,
+        commandBuffer,
         sourceUsageMode,
         VULKAN_INTERNAL_DefaultBufferUsageMode(buffer),
         buffer);
@@ -2846,13 +2846,13 @@ static void VULKAN_INTERNAL_BufferTransitionToDefaultUsage(
 
 static void VULKAN_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanTextureUsageMode destinationUsageMode,
     VulkanTextureSubresource *textureSubresource)
 {
     VULKAN_INTERNAL_TextureSubresourceMemoryBarrier(
         renderer,
-        command_buffer,
+        commandBuffer,
         VULKAN_INTERNAL_DefaultTextureUsageMode(textureSubresource->parent),
         destinationUsageMode,
         textureSubresource);
@@ -2860,14 +2860,14 @@ static void VULKAN_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
 
 static void VULKAN_INTERNAL_TextureTransitionFromDefaultUsage(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanTextureUsageMode destinationUsageMode,
     VulkanTexture *texture)
 {
     for (Uint32 i = 0; i < texture->subresourceCount; i += 1) {
         VULKAN_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
             renderer,
-            command_buffer,
+            commandBuffer,
             destinationUsageMode,
             &texture->subresources[i]);
     }
@@ -2875,13 +2875,13 @@ static void VULKAN_INTERNAL_TextureTransitionFromDefaultUsage(
 
 static void VULKAN_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanTextureUsageMode sourceUsageMode,
     VulkanTextureSubresource *textureSubresource)
 {
     VULKAN_INTERNAL_TextureSubresourceMemoryBarrier(
         renderer,
-        command_buffer,
+        commandBuffer,
         sourceUsageMode,
         VULKAN_INTERNAL_DefaultTextureUsageMode(textureSubresource->parent),
         textureSubresource);
@@ -2889,7 +2889,7 @@ static void VULKAN_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
 
 static void VULKAN_INTERNAL_TextureTransitionToDefaultUsage(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanTextureUsageMode sourceUsageMode,
     VulkanTexture *texture)
 {
@@ -2897,7 +2897,7 @@ static void VULKAN_INTERNAL_TextureTransitionToDefaultUsage(
     for (Uint32 i = 0; i < texture->subresourceCount; i += 1) {
         VULKAN_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
             renderer,
-            command_buffer,
+            commandBuffer,
             sourceUsageMode,
             &texture->subresources[i]);
     }
@@ -2953,7 +2953,7 @@ static void VULKAN_INTERNAL_RemoveFramebuffersContainingView(
 
     while (SDL_IterateHashTable(renderer->framebufferHashTable, (const void **)&key, (const void **)&value, &iter)) {
         bool remove = false;
-        for (Uint32 i = 0; i < key->num_color_attachments; i += 1) {
+        for (Uint32 i = 0; i < key->numColorTargets; i += 1) {
             if (key->colorAttachmentViews[i] == view) {
                 remove = true;
             }
@@ -2990,7 +2990,7 @@ static void VULKAN_INTERNAL_DestroyTexture(
 {
     // Clean up subresources
     for (Uint32 subresourceIndex = 0; subresourceIndex < texture->subresourceCount; subresourceIndex += 1) {
-        if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
+        if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
             for (Uint32 depthIndex = 0; depthIndex < texture->depth; depthIndex += 1) {
                 VULKAN_INTERNAL_RemoveFramebuffersContainingView(
                     renderer,
@@ -3013,14 +3013,14 @@ static void VULKAN_INTERNAL_DestroyTexture(
             SDL_free(texture->subresources[subresourceIndex].renderTargetViews);
         }
 
-        if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
+        if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
             renderer->vkDestroyImageView(
                 renderer->logicalDevice,
                 texture->subresources[subresourceIndex].computeWriteView,
                 NULL);
         }
 
-        if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
+        if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
             renderer->vkDestroyImageView(
                 renderer->logicalDevice,
                 texture->subresources[subresourceIndex].depthStencilView,
@@ -3068,7 +3068,7 @@ static void VULKAN_INTERNAL_DestroyCommandPool(
     VulkanCommandPool *commandPool)
 {
     Uint32 i;
-    VulkanCommandBuffer *command_buffer;
+    VulkanCommandBuffer *commandBuffer;
 
     renderer->vkDestroyCommandPool(
         renderer->logicalDevice,
@@ -3076,21 +3076,21 @@ static void VULKAN_INTERNAL_DestroyCommandPool(
         NULL);
 
     for (i = 0; i < commandPool->inactiveCommandBufferCount; i += 1) {
-        command_buffer = commandPool->inactiveCommandBuffers[i];
+        commandBuffer = commandPool->inactiveCommandBuffers[i];
 
-        SDL_free(command_buffer->presentDatas);
-        SDL_free(command_buffer->waitSemaphores);
-        SDL_free(command_buffer->signalSemaphores);
-        SDL_free(command_buffer->boundDescriptorSetDatas);
-        SDL_free(command_buffer->usedBuffers);
-        SDL_free(command_buffer->usedTextures);
-        SDL_free(command_buffer->usedSamplers);
-        SDL_free(command_buffer->usedGraphicsPipelines);
-        SDL_free(command_buffer->usedComputePipelines);
-        SDL_free(command_buffer->usedFramebuffers);
-        SDL_free(command_buffer->usedUniformBuffers);
+        SDL_free(commandBuffer->presentDatas);
+        SDL_free(commandBuffer->waitSemaphores);
+        SDL_free(commandBuffer->signalSemaphores);
+        SDL_free(commandBuffer->boundDescriptorSetDatas);
+        SDL_free(commandBuffer->usedBuffers);
+        SDL_free(commandBuffer->usedTextures);
+        SDL_free(commandBuffer->usedSamplers);
+        SDL_free(commandBuffer->usedGraphicsPipelines);
+        SDL_free(commandBuffer->usedComputePipelines);
+        SDL_free(commandBuffer->usedFramebuffers);
+        SDL_free(commandBuffer->usedUniformBuffers);
 
-        SDL_free(command_buffer);
+        SDL_free(commandBuffer);
     }
 
     SDL_free(commandPool->inactiveCommandBuffers);
@@ -3127,60 +3127,60 @@ static void VULKAN_INTERNAL_DestroyDescriptorSetPool(
 
 static void VULKAN_INTERNAL_DestroyGraphicsPipeline(
     VulkanRenderer *renderer,
-    VulkanGraphicsPipeline *graphics_pipeline)
+    VulkanGraphicsPipeline *graphicsPipeline)
 {
     Uint32 i;
 
     renderer->vkDestroyPipeline(
         renderer->logicalDevice,
-        graphics_pipeline->pipeline,
+        graphicsPipeline->pipeline,
         NULL);
 
     renderer->vkDestroyPipelineLayout(
         renderer->logicalDevice,
-        graphics_pipeline->resourceLayout.pipelineLayout,
+        graphicsPipeline->resourceLayout.pipelineLayout,
         NULL);
 
     for (i = 0; i < 4; i += 1) {
         VULKAN_INTERNAL_DestroyDescriptorSetPool(
             renderer,
-            &graphics_pipeline->resourceLayout.descriptorSetPools[i]);
+            &graphicsPipeline->resourceLayout.descriptorSetPools[i]);
     }
 
-    (void)SDL_AtomicDecRef(&graphics_pipeline->vertex_shader->referenceCount);
-    (void)SDL_AtomicDecRef(&graphics_pipeline->fragment_shader->referenceCount);
+    (void)SDL_AtomicDecRef(&graphicsPipeline->vertexShader->referenceCount);
+    (void)SDL_AtomicDecRef(&graphicsPipeline->fragmentShader->referenceCount);
 
-    SDL_free(graphics_pipeline);
+    SDL_free(graphicsPipeline);
 }
 
 static void VULKAN_INTERNAL_DestroyComputePipeline(
     VulkanRenderer *renderer,
-    VulkanComputePipeline *compute_pipeline)
+    VulkanComputePipeline *computePipeline)
 {
     Uint32 i;
 
     renderer->vkDestroyPipeline(
         renderer->logicalDevice,
-        compute_pipeline->pipeline,
+        computePipeline->pipeline,
         NULL);
 
     renderer->vkDestroyPipelineLayout(
         renderer->logicalDevice,
-        compute_pipeline->resourceLayout.pipelineLayout,
+        computePipeline->resourceLayout.pipelineLayout,
         NULL);
 
     for (i = 0; i < 3; i += 1) {
         VULKAN_INTERNAL_DestroyDescriptorSetPool(
             renderer,
-            &compute_pipeline->resourceLayout.descriptorSetPools[i]);
+            &computePipeline->resourceLayout.descriptorSetPools[i]);
     }
 
     renderer->vkDestroyShaderModule(
         renderer->logicalDevice,
-        compute_pipeline->shaderModule,
+        computePipeline->shaderModule,
         NULL);
 
-    SDL_free(compute_pipeline);
+    SDL_free(computePipeline);
 }
 
 static void VULKAN_INTERNAL_DestroyShader(
@@ -3192,7 +3192,7 @@ static void VULKAN_INTERNAL_DestroyShader(
         vulkanShader->shaderModule,
         NULL);
 
-    SDL_free((void *)vulkanShader->entrypoint_name);
+    SDL_free((void *)vulkanShader->entrypointName);
     SDL_free(vulkanShader);
 }
 
@@ -3300,22 +3300,22 @@ static Uint32 VULKAN_INTERNAL_RenderPassHashFunction(
      * is taken from Josh Bloch's "Effective Java".
      * (https://stackoverflow.com/a/113600/12492383)
      */
-    const Uint32 HASH_FACTOR = 31;
+    const Uint32 hashFactor = 31;
     Uint32 result = 1;
 
-    for (Uint32 i = 0; i < hashTableKey->num_color_attachments; i += 1) {
-        result = result * HASH_FACTOR + hashTableKey->colorTargetDescriptions[i].load_op;
-        result = result * HASH_FACTOR + hashTableKey->colorTargetDescriptions[i].store_op;
-        result = result * HASH_FACTOR + hashTableKey->colorTargetDescriptions[i].format;
+    for (Uint32 i = 0; i < hashTableKey->numColorTargets; i += 1) {
+        result = result * hashFactor + hashTableKey->colorTargetDescriptions[i].loadOp;
+        result = result * hashFactor + hashTableKey->colorTargetDescriptions[i].storeOp;
+        result = result * hashFactor + hashTableKey->colorTargetDescriptions[i].format;
     }
 
-    result = result * HASH_FACTOR + hashTableKey->depthStencilTargetDescription.load_op;
-    result = result * HASH_FACTOR + hashTableKey->depthStencilTargetDescription.store_op;
-    result = result * HASH_FACTOR + hashTableKey->depthStencilTargetDescription.stencil_load_op;
-    result = result * HASH_FACTOR + hashTableKey->depthStencilTargetDescription.stencil_store_op;
-    result = result * HASH_FACTOR + hashTableKey->depthStencilTargetDescription.format;
+    result = result * hashFactor + hashTableKey->depthStencilTargetDescription.loadOp;
+    result = result * hashFactor + hashTableKey->depthStencilTargetDescription.storeOp;
+    result = result * hashFactor + hashTableKey->depthStencilTargetDescription.stencilLoadOp;
+    result = result * hashFactor + hashTableKey->depthStencilTargetDescription.stencilStoreOp;
+    result = result * hashFactor + hashTableKey->depthStencilTargetDescription.format;
 
-    result = result * HASH_FACTOR + hashTableKey->colorAttachmentSampleCount;
+    result = result * hashFactor + hashTableKey->colorAttachmentSampleCount;
 
     return result;
 }
@@ -3328,7 +3328,7 @@ static bool VULKAN_INTERNAL_RenderPassHashKeyMatch(
     RenderPassHashTableKey *a = (RenderPassHashTableKey *)aKey;
     RenderPassHashTableKey *b = (RenderPassHashTableKey *)bKey;
 
-    if (a->num_color_attachments != b->num_color_attachments) {
+    if (a->numColorTargets != b->numColorTargets) {
         return 0;
     }
 
@@ -3336,16 +3336,16 @@ static bool VULKAN_INTERNAL_RenderPassHashKeyMatch(
         return 0;
     }
 
-    for (Uint32 i = 0; i < a->num_color_attachments; i += 1) {
+    for (Uint32 i = 0; i < a->numColorTargets; i += 1) {
         if (a->colorTargetDescriptions[i].format != b->colorTargetDescriptions[i].format) {
             return 0;
         }
 
-        if (a->colorTargetDescriptions[i].load_op != b->colorTargetDescriptions[i].load_op) {
+        if (a->colorTargetDescriptions[i].loadOp != b->colorTargetDescriptions[i].loadOp) {
             return 0;
         }
 
-        if (a->colorTargetDescriptions[i].store_op != b->colorTargetDescriptions[i].store_op) {
+        if (a->colorTargetDescriptions[i].storeOp != b->colorTargetDescriptions[i].storeOp) {
             return 0;
         }
     }
@@ -3354,19 +3354,19 @@ static bool VULKAN_INTERNAL_RenderPassHashKeyMatch(
         return 0;
     }
 
-    if (a->depthStencilTargetDescription.load_op != b->depthStencilTargetDescription.load_op) {
+    if (a->depthStencilTargetDescription.loadOp != b->depthStencilTargetDescription.loadOp) {
         return 0;
     }
 
-    if (a->depthStencilTargetDescription.store_op != b->depthStencilTargetDescription.store_op) {
+    if (a->depthStencilTargetDescription.storeOp != b->depthStencilTargetDescription.storeOp) {
         return 0;
     }
 
-    if (a->depthStencilTargetDescription.stencil_load_op != b->depthStencilTargetDescription.stencil_load_op) {
+    if (a->depthStencilTargetDescription.stencilLoadOp != b->depthStencilTargetDescription.stencilLoadOp) {
         return 0;
     }
 
-    if (a->depthStencilTargetDescription.stencil_store_op != b->depthStencilTargetDescription.stencil_store_op) {
+    if (a->depthStencilTargetDescription.stencilStoreOp != b->depthStencilTargetDescription.stencilStoreOp) {
         return 0;
     }
 
@@ -3395,17 +3395,17 @@ static Uint32 VULKAN_INTERNAL_FramebufferHashFunction(
      * is taken from Josh Bloch's "Effective Java".
      * (https://stackoverflow.com/a/113600/12492383)
      */
-    const Uint32 HASH_FACTOR = 31;
+    const Uint32 hashFactor = 31;
     Uint32 result = 1;
 
-    for (Uint32 i = 0; i < hashTableKey->num_color_attachments; i += 1) {
-        result = result * HASH_FACTOR + (Uint32)(uintptr_t)hashTableKey->colorAttachmentViews[i];
-        result = result * HASH_FACTOR + (Uint32)(uintptr_t)hashTableKey->colorMultiSampleAttachmentViews[i];
+    for (Uint32 i = 0; i < hashTableKey->numColorTargets; i += 1) {
+        result = result * hashFactor + (Uint32)(uintptr_t)hashTableKey->colorAttachmentViews[i];
+        result = result * hashFactor + (Uint32)(uintptr_t)hashTableKey->colorMultiSampleAttachmentViews[i];
     }
 
-    result = result * HASH_FACTOR + (Uint32)(uintptr_t)hashTableKey->depthStencilAttachmentView;
-    result = result * HASH_FACTOR + hashTableKey->width;
-    result = result * HASH_FACTOR + hashTableKey->height;
+    result = result * hashFactor + (Uint32)(uintptr_t)hashTableKey->depthStencilAttachmentView;
+    result = result * hashFactor + hashTableKey->width;
+    result = result * hashFactor + hashTableKey->height;
 
     return result;
 }
@@ -3418,11 +3418,11 @@ static bool VULKAN_INTERNAL_FramebufferHashKeyMatch(
     FramebufferHashTableKey *a = (FramebufferHashTableKey *)aKey;
     FramebufferHashTableKey *b = (FramebufferHashTableKey *)bKey;
 
-    if (a->num_color_attachments != b->num_color_attachments) {
+    if (a->numColorTargets != b->numColorTargets) {
         return 0;
     }
 
-    for (Uint32 i = 0; i < a->num_color_attachments; i += 1) {
+    for (Uint32 i = 0; i < a->numColorTargets; i += 1) {
         if (a->colorAttachmentViews[i] != b->colorAttachmentViews[i]) {
             return 0;
         }
@@ -3574,8 +3574,8 @@ static void VULKAN_INTERNAL_InitializeDescriptorSetPool(
 
 static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
     VulkanRenderer *renderer,
-    VulkanShader *vertex_shader,
-    VulkanShader *fragment_shader,
+    VulkanShader *vertexShader,
+    VulkanShader *fragmentShader,
     VulkanGraphicsPipelineResourceLayout *pipelineResourceLayout)
 {
     VkDescriptorSetLayoutBinding descriptorSetLayoutBindings[MAX_TEXTURE_SAMPLERS_PER_STAGE + MAX_STORAGE_TEXTURES_PER_STAGE + MAX_STORAGE_BUFFERS_PER_STAGE];
@@ -3586,15 +3586,15 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
     VkResult vulkanResult;
     Uint32 i;
 
-    pipelineResourceLayout->vertexSamplerCount = vertex_shader->num_samplers;
-    pipelineResourceLayout->vertexStorageTextureCount = vertex_shader->num_storage_textures;
-    pipelineResourceLayout->vertexStorageBufferCount = vertex_shader->num_storage_buffers;
-    pipelineResourceLayout->vertexUniformBufferCount = vertex_shader->num_uniform_buffers;
+    pipelineResourceLayout->vertexSamplerCount = vertexShader->numSamplers;
+    pipelineResourceLayout->vertexStorageTextureCount = vertexShader->numStorageTextures;
+    pipelineResourceLayout->vertexStorageBufferCount = vertexShader->numStorageBuffers;
+    pipelineResourceLayout->vertexUniformBufferCount = vertexShader->numUniformBuffers;
 
-    pipelineResourceLayout->fragmentSamplerCount = fragment_shader->num_samplers;
-    pipelineResourceLayout->fragmentStorageTextureCount = fragment_shader->num_storage_textures;
-    pipelineResourceLayout->fragmentStorageBufferCount = fragment_shader->num_storage_buffers;
-    pipelineResourceLayout->fragmentUniformBufferCount = fragment_shader->num_uniform_buffers;
+    pipelineResourceLayout->fragmentSamplerCount = fragmentShader->numSamplers;
+    pipelineResourceLayout->fragmentStorageTextureCount = fragmentShader->numStorageTextures;
+    pipelineResourceLayout->fragmentStorageBufferCount = fragmentShader->numStorageBuffers;
+    pipelineResourceLayout->fragmentUniformBufferCount = fragmentShader->numUniformBuffers;
 
     // Vertex Resources
 
@@ -3603,9 +3603,9 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
     descriptorSetLayoutCreateInfo.flags = 0;
     descriptorSetLayoutCreateInfo.pBindings = NULL;
     descriptorSetLayoutCreateInfo.bindingCount =
-        vertex_shader->num_samplers +
-        vertex_shader->num_storage_textures +
-        vertex_shader->num_storage_buffers;
+        vertexShader->numSamplers +
+        vertexShader->numStorageTextures +
+        vertexShader->numStorageBuffers;
 
     descriptorSetPool = &pipelineResourceLayout->descriptorSetPools[0];
 
@@ -3616,7 +3616,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
         descriptorSetPool->descriptorInfos = SDL_malloc(
             descriptorSetPool->descriptorInfoCount * sizeof(VulkanDescriptorInfo));
 
-        for (i = 0; i < vertex_shader->num_samplers; i += 1) {
+        for (i = 0; i < vertexShader->numSamplers; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
@@ -3627,7 +3627,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
             descriptorSetPool->descriptorInfos[i].stageFlag = VK_SHADER_STAGE_VERTEX_BIT;
         }
 
-        for (i = vertex_shader->num_samplers; i < vertex_shader->num_samplers + vertex_shader->num_storage_textures; i += 1) {
+        for (i = vertexShader->numSamplers; i < vertexShader->numSamplers + vertexShader->numStorageTextures; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
@@ -3638,7 +3638,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
             descriptorSetPool->descriptorInfos[i].stageFlag = VK_SHADER_STAGE_VERTEX_BIT;
         }
 
-        for (i = vertex_shader->num_samplers + vertex_shader->num_storage_textures; i < descriptorSetLayoutCreateInfo.bindingCount; i += 1) {
+        for (i = vertexShader->numSamplers + vertexShader->numStorageTextures; i < descriptorSetLayoutCreateInfo.bindingCount; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
@@ -3679,7 +3679,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
         descriptorSetPool->descriptorInfos = SDL_malloc(
             descriptorSetPool->descriptorInfoCount * sizeof(VulkanDescriptorInfo));
 
-        for (i = 0; i < vertex_shader->num_uniform_buffers; i += 1) {
+        for (i = 0; i < vertexShader->numUniformBuffers; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
@@ -3711,9 +3711,9 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
     descriptorSetPool = &pipelineResourceLayout->descriptorSetPools[2];
 
     descriptorSetLayoutCreateInfo.bindingCount =
-        fragment_shader->num_samplers +
-        fragment_shader->num_storage_textures +
-        fragment_shader->num_storage_buffers;
+        fragmentShader->numSamplers +
+        fragmentShader->numStorageTextures +
+        fragmentShader->numStorageBuffers;
 
     descriptorSetLayoutCreateInfo.pBindings = NULL;
 
@@ -3724,7 +3724,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
         descriptorSetPool->descriptorInfos = SDL_malloc(
             descriptorSetPool->descriptorInfoCount * sizeof(VulkanDescriptorInfo));
 
-        for (i = 0; i < fragment_shader->num_samplers; i += 1) {
+        for (i = 0; i < fragmentShader->numSamplers; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
@@ -3735,7 +3735,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
             descriptorSetPool->descriptorInfos[i].stageFlag = VK_SHADER_STAGE_FRAGMENT_BIT;
         }
 
-        for (i = fragment_shader->num_samplers; i < fragment_shader->num_samplers + fragment_shader->num_storage_textures; i += 1) {
+        for (i = fragmentShader->numSamplers; i < fragmentShader->numSamplers + fragmentShader->numStorageTextures; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
@@ -3746,7 +3746,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
             descriptorSetPool->descriptorInfos[i].stageFlag = VK_SHADER_STAGE_FRAGMENT_BIT;
         }
 
-        for (i = fragment_shader->num_samplers + fragment_shader->num_storage_textures; i < descriptorSetLayoutCreateInfo.bindingCount; i += 1) {
+        for (i = fragmentShader->numSamplers + fragmentShader->numStorageTextures; i < descriptorSetLayoutCreateInfo.bindingCount; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
@@ -3789,7 +3789,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
         descriptorSetPool->descriptorInfos = SDL_malloc(
             descriptorSetPool->descriptorInfoCount * sizeof(VulkanDescriptorInfo));
 
-        for (i = 0; i < fragment_shader->num_uniform_buffers; i += 1) {
+        for (i = 0; i < fragmentShader->numUniformBuffers; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
@@ -3859,11 +3859,11 @@ static bool VULKAN_INTERNAL_InitializeComputePipelineResourceLayout(
     VkResult vulkanResult;
     Uint32 i;
 
-    pipelineResourceLayout->num_readonly_storage_textures = createinfo->num_readonly_storage_textures;
-    pipelineResourceLayout->num_readonly_storage_buffers = createinfo->num_readonly_storage_buffers;
-    pipelineResourceLayout->num_writeonly_storage_textures = createinfo->num_writeonly_storage_textures;
-    pipelineResourceLayout->num_writeonly_storage_buffers = createinfo->num_writeonly_storage_buffers;
-    pipelineResourceLayout->num_uniform_buffers = createinfo->num_uniform_buffers;
+    pipelineResourceLayout->numReadonlyStorageTextures = createinfo->num_readonly_storage_textures;
+    pipelineResourceLayout->numReadonlyStorageBuffers = createinfo->num_readonly_storage_buffers;
+    pipelineResourceLayout->numWriteonlyStorageTextures = createinfo->num_writeonly_storage_textures;
+    pipelineResourceLayout->numWriteonlyStorageBuffers = createinfo->num_writeonly_storage_buffers;
+    pipelineResourceLayout->numUniformBuffers = createinfo->num_uniform_buffers;
 
     // Read-only resources
 
@@ -4053,7 +4053,7 @@ static bool VULKAN_INTERNAL_InitializeComputePipelineResourceLayout(
 static VulkanBuffer *VULKAN_INTERNAL_CreateBuffer(
     VulkanRenderer *renderer,
     VkDeviceSize size,
-    SDL_GPUBufferUsageFlags usage_flags,
+    SDL_GPUBufferUsageFlags usageFlags,
     VulkanBufferType type)
 {
     VulkanBuffer *buffer;
@@ -4062,21 +4062,21 @@ static VulkanBuffer *VULKAN_INTERNAL_CreateBuffer(
     VkBufferUsageFlags vulkanUsageFlags = 0;
     Uint8 bindResult;
 
-    if (usage_flags & SDL_GPU_BUFFERUSAGE_VERTEX) {
+    if (usageFlags & SDL_GPU_BUFFERUSAGE_VERTEX) {
         vulkanUsageFlags |= VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
     }
 
-    if (usage_flags & SDL_GPU_BUFFERUSAGE_INDEX) {
+    if (usageFlags & SDL_GPU_BUFFERUSAGE_INDEX) {
         vulkanUsageFlags |= VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
     }
 
-    if (usage_flags & (SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ |
+    if (usageFlags & (SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ |
                       SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ |
                       SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE)) {
         vulkanUsageFlags |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     }
 
-    if (usage_flags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
+    if (usageFlags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
         vulkanUsageFlags |= VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
     }
 
@@ -4090,7 +4090,7 @@ static VulkanBuffer *VULKAN_INTERNAL_CreateBuffer(
     buffer = SDL_malloc(sizeof(VulkanBuffer));
 
     buffer->size = size;
-    buffer->usage_flags = usage_flags;
+    buffer->usageFlags = usageFlags;
     buffer->type = type;
     buffer->markedForDestroy = 0;
     buffer->transitioned = false;
@@ -4142,7 +4142,7 @@ static VulkanBuffer *VULKAN_INTERNAL_CreateBuffer(
 static VulkanBufferHandle *VULKAN_INTERNAL_CreateBufferHandle(
     VulkanRenderer *renderer,
     VkDeviceSize size,
-    SDL_GPUBufferUsageFlags usage_flags,
+    SDL_GPUBufferUsageFlags usageFlags,
     VulkanBufferType type)
 {
     VulkanBufferHandle *bufferHandle;
@@ -4151,7 +4151,7 @@ static VulkanBufferHandle *VULKAN_INTERNAL_CreateBufferHandle(
     buffer = VULKAN_INTERNAL_CreateBuffer(
         renderer,
         size,
-        usage_flags,
+        usageFlags,
         type);
 
     if (buffer == NULL) {
@@ -4171,7 +4171,7 @@ static VulkanBufferHandle *VULKAN_INTERNAL_CreateBufferHandle(
 static VulkanBufferContainer *VULKAN_INTERNAL_CreateBufferContainer(
     VulkanRenderer *renderer,
     VkDeviceSize size,
-    SDL_GPUBufferUsageFlags usage_flags,
+    SDL_GPUBufferUsageFlags usageFlags,
     VulkanBufferType type)
 {
     VulkanBufferContainer *bufferContainer;
@@ -4180,7 +4180,7 @@ static VulkanBufferContainer *VULKAN_INTERNAL_CreateBufferContainer(
     bufferHandle = VULKAN_INTERNAL_CreateBufferHandle(
         renderer,
         size,
-        usage_flags,
+        usageFlags,
         type);
 
     if (bufferHandle == NULL) {
@@ -4206,11 +4206,11 @@ static VulkanBufferContainer *VULKAN_INTERNAL_CreateBufferContainer(
 // Texture Subresource Utilities
 
 static Uint32 VULKAN_INTERNAL_GetTextureSubresourceIndex(
-    Uint32 mip_level,
+    Uint32 mipLevel,
     Uint32 layer,
     Uint32 numLevels)
 {
-    return mip_level + (layer * numLevels);
+    return mipLevel + (layer * numLevels);
 }
 
 static VulkanTextureSubresource *VULKAN_INTERNAL_FetchTextureSubresource(
@@ -4435,13 +4435,13 @@ static bool VULKAN_INTERNAL_VerifySwapSurfaceFormat(
 }
 
 static bool VULKAN_INTERNAL_VerifySwapPresentMode(
-    VkPresentModeKHR present_mode,
+    VkPresentModeKHR presentMode,
     VkPresentModeKHR *availablePresentModes,
     Uint32 availablePresentModesLength)
 {
     Uint32 i;
     for (i = 0; i < availablePresentModesLength; i += 1) {
-        if (availablePresentModes[i] == present_mode) {
+        if (availablePresentModes[i] == presentMode) {
             return true;
         }
     }
@@ -4461,17 +4461,17 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
     bool hasValidSwapchainComposition, hasValidPresentMode;
     Sint32 drawableWidth, drawableHeight;
     Uint32 i;
-    SDL_VideoDevice *_this = SDL_GetVideoDevice();
+    SDL_VideoDevice *this = SDL_GetVideoDevice();
 
-    SDL_assert(_this && _this->Vulkan_CreateSurface);
+    SDL_assert(this && this->Vulkan_CreateSurface);
 
     swapchainData = SDL_malloc(sizeof(VulkanSwapchainData));
     swapchainData->frameCounter = 0;
 
     // Each swapchain must have its own surface.
 
-    if (!_this->Vulkan_CreateSurface(
-            _this,
+    if (!this->Vulkan_CreateSurface(
+            this,
             windowData->window,
             renderer->instance,
             NULL, // FIXME: VAllocationCallbacks
@@ -4523,9 +4523,9 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
 
     // Verify that we can use the requested composition and present mode
 
-    swapchainData->format = SwapchainCompositionToFormat[windowData->swapchain_composition];
-    swapchainData->colorSpace = SwapchainCompositionToColorSpace[windowData->swapchain_composition];
-    swapchainData->swapchainSwizzle = SwapchainCompositionSwizzle[windowData->swapchain_composition];
+    swapchainData->format = SwapchainCompositionToFormat[windowData->swapchainComposition];
+    swapchainData->colorSpace = SwapchainCompositionToColorSpace[windowData->swapchainComposition];
+    swapchainData->swapchainSwizzle = SwapchainCompositionSwizzle[windowData->swapchainComposition];
     swapchainData->usingFallbackFormat = false;
 
     hasValidSwapchainComposition = VULKAN_INTERNAL_VerifySwapSurfaceFormat(
@@ -4536,7 +4536,7 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
 
     if (!hasValidSwapchainComposition) {
         // Let's try again with the fallback format...
-        swapchainData->format = SwapchainCompositionToFallbackFormat[windowData->swapchain_composition];
+        swapchainData->format = SwapchainCompositionToFallbackFormat[windowData->swapchainComposition];
         swapchainData->usingFallbackFormat = true;
         hasValidSwapchainComposition = VULKAN_INTERNAL_VerifySwapSurfaceFormat(
             swapchainData->format,
@@ -4545,9 +4545,9 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
             swapchainSupportDetails.formatsLength);
     }
 
-    swapchainData->present_mode = SDLToVK_PresentMode[windowData->present_mode];
+    swapchainData->presentMode = SDLToVK_PresentMode[windowData->presentMode];
     hasValidPresentMode = VULKAN_INTERNAL_VerifySwapPresentMode(
-        swapchainData->present_mode,
+        swapchainData->presentMode,
         swapchainSupportDetails.presentModes,
         swapchainSupportDetails.presentModesLength);
 
@@ -4624,7 +4624,7 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
         swapchainData->imageCount = swapchainSupportDetails.capabilities.minImageCount;
     }
 
-    if (swapchainData->present_mode == VK_PRESENT_MODE_MAILBOX_KHR) {
+    if (swapchainData->presentMode == VK_PRESENT_MODE_MAILBOX_KHR) {
         /* Required for proper triple-buffering.
          * Note that this is below the above maxImageCount check!
          * If the driver advertises MAILBOX but does not support 3 swap
@@ -4652,7 +4652,7 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
     swapchainCreateInfo.pQueueFamilyIndices = NULL;
     swapchainCreateInfo.preTransform = swapchainSupportDetails.capabilities.currentTransform;
     swapchainCreateInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
-    swapchainCreateInfo.presentMode = swapchainData->present_mode;
+    swapchainCreateInfo.presentMode = swapchainData->presentMode;
     swapchainCreateInfo.clipped = VK_TRUE;
     swapchainCreateInfo.oldSwapchain = VK_NULL_HANDLE;
 
@@ -4714,12 +4714,12 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
         swapchainData->textureContainers[i].header.info.height = drawableHeight;
         swapchainData->textureContainers[i].header.info.layer_count_or_depth = 1;
         swapchainData->textureContainers[i].header.info.format = SwapchainCompositionToSDLFormat(
-            windowData->swapchain_composition,
+            windowData->swapchainComposition,
             swapchainData->usingFallbackFormat);
         swapchainData->textureContainers[i].header.info.type = SDL_GPU_TEXTURETYPE_2D;
         swapchainData->textureContainers[i].header.info.num_levels = 1;
         swapchainData->textureContainers[i].header.info.sample_count = SDL_GPU_SAMPLECOUNT_1;
-        swapchainData->textureContainers[i].header.info.usage_flags = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
+        swapchainData->textureContainers[i].header.info.usage = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
 
         swapchainData->textureContainers[i].activeTextureHandle = SDL_malloc(sizeof(VulkanTextureHandle));
 
@@ -4737,9 +4737,9 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
         swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->type = SDL_GPU_TEXTURETYPE_2D;
         swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->depth = 1;
         swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->layerCount = 1;
-        swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->num_levels = 1;
-        swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->sample_count = VK_SAMPLE_COUNT_1_BIT;
-        swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->usage_flags =
+        swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->numLevels = 1;
+        swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->sampleCount = VK_SAMPLE_COUNT_1_BIT;
+        swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->usageFlags =
             SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
         swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->aspectFlags = VK_IMAGE_ASPECT_COLOR_BIT;
         SDL_AtomicSet(&swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->referenceCount, 0);
@@ -4795,7 +4795,7 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
 
 static void VULKAN_INTERNAL_BeginCommandBuffer(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer)
+    VulkanCommandBuffer *commandBuffer)
 {
     VkCommandBufferBeginInfo beginInfo;
     VkResult result;
@@ -4807,7 +4807,7 @@ static void VULKAN_INTERNAL_BeginCommandBuffer(
     beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
 
     result = renderer->vkBeginCommandBuffer(
-        command_buffer->command_buffer,
+        commandBuffer->commandBuffer,
         &beginInfo);
 
     if (result != VK_SUCCESS) {
@@ -4817,12 +4817,12 @@ static void VULKAN_INTERNAL_BeginCommandBuffer(
 
 static void VULKAN_INTERNAL_EndCommandBuffer(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer)
+    VulkanCommandBuffer *commandBuffer)
 {
     VkResult result;
 
     result = renderer->vkEndCommandBuffer(
-        command_buffer->command_buffer);
+        commandBuffer->commandBuffer);
 
     if (result != VK_SUCCESS) {
         LogVulkanResultAsError("vkEndCommandBuffer", result);
@@ -4993,7 +4993,7 @@ static VkDescriptorSet VULKAN_INTERNAL_FetchDescriptorSet(
 
 static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer)
+    VulkanCommandBuffer *commandBuffer)
 {
     VulkanGraphicsPipelineResourceLayout *resourceLayout;
     VkWriteDescriptorSet *writeDescriptorSets;
@@ -5006,14 +5006,14 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
     Uint32 imageInfoCount = 0;
     Uint32 i;
 
-    resourceLayout = &command_buffer->currentGraphicsPipeline->resourceLayout;
+    resourceLayout = &commandBuffer->currentGraphicsPipeline->resourceLayout;
 
-    if (command_buffer->needNewVertexResourceDescriptorSet) {
+    if (commandBuffer->needNewVertexResourceDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[0];
 
-        command_buffer->vertexResourceDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        commandBuffer->vertexResourceDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            command_buffer,
+            commandBuffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
@@ -5030,12 +5030,12 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = command_buffer->vertexResourceDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->vertexResourceDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pBufferInfo = NULL;
 
-            imageInfos[imageInfoCount].sampler = command_buffer->vertexSamplers[i]->sampler;
-            imageInfos[imageInfoCount].imageView = command_buffer->vertexSamplerTextures[i]->fullView;
+            imageInfos[imageInfoCount].sampler = commandBuffer->vertexSamplers[i]->sampler;
+            imageInfos[imageInfoCount].imageView = commandBuffer->vertexSamplerTextures[i]->fullView;
             imageInfos[imageInfoCount].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
             currentWriteDescriptorSet->pImageInfo = &imageInfos[imageInfoCount];
@@ -5052,12 +5052,12 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = resourceLayout->vertexSamplerCount + i;
-            currentWriteDescriptorSet->dstSet = command_buffer->vertexResourceDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->vertexResourceDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pBufferInfo = NULL;
 
             imageInfos[imageInfoCount].sampler = VK_NULL_HANDLE;
-            imageInfos[imageInfoCount].imageView = command_buffer->vertexStorageTextures[i]->fullView;
+            imageInfos[imageInfoCount].imageView = commandBuffer->vertexStorageTextures[i]->fullView;
             imageInfos[imageInfoCount].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
             currentWriteDescriptorSet->pImageInfo = &imageInfos[imageInfoCount];
@@ -5074,11 +5074,11 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = resourceLayout->vertexSamplerCount + resourceLayout->vertexStorageTextureCount + i;
-            currentWriteDescriptorSet->dstSet = command_buffer->vertexResourceDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->vertexResourceDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = command_buffer->vertexStorageBuffers[i]->buffer;
+            bufferInfos[bufferInfoCount].buffer = commandBuffer->vertexStorageBuffers[i]->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = VK_WHOLE_SIZE;
 
@@ -5095,12 +5095,12 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             NULL);
 
         renderer->vkCmdBindDescriptorSets(
-            command_buffer->command_buffer,
+            commandBuffer->commandBuffer,
             VK_PIPELINE_BIND_POINT_GRAPHICS,
             resourceLayout->pipelineLayout,
             0,
             1,
-            &command_buffer->vertexResourceDescriptorSet,
+            &commandBuffer->vertexResourceDescriptorSet,
             0,
             NULL);
 
@@ -5108,15 +5108,15 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        command_buffer->needNewVertexResourceDescriptorSet = false;
+        commandBuffer->needNewVertexResourceDescriptorSet = false;
     }
 
-    if (command_buffer->needNewVertexUniformDescriptorSet) {
+    if (commandBuffer->needNewVertexUniformDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[1];
 
-        command_buffer->vertexUniformDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        commandBuffer->vertexUniformDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            command_buffer,
+            commandBuffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
@@ -5132,11 +5132,11 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = command_buffer->vertexUniformDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->vertexUniformDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = command_buffer->vertexUniformBuffers[i]->bufferHandle->vulkanBuffer->buffer;
+            bufferInfos[bufferInfoCount].buffer = commandBuffer->vertexUniformBuffers[i]->bufferHandle->vulkanBuffer->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = MAX_UBO_SECTION_SIZE;
 
@@ -5156,34 +5156,34 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        command_buffer->needNewVertexUniformDescriptorSet = false;
-        command_buffer->needNewVertexUniformOffsets = true;
+        commandBuffer->needNewVertexUniformDescriptorSet = false;
+        commandBuffer->needNewVertexUniformOffsets = true;
     }
 
-    if (command_buffer->needNewVertexUniformOffsets) {
+    if (commandBuffer->needNewVertexUniformOffsets) {
         for (i = 0; i < resourceLayout->vertexUniformBufferCount; i += 1) {
-            dynamicOffsets[i] = command_buffer->vertexUniformBuffers[i]->drawOffset;
+            dynamicOffsets[i] = commandBuffer->vertexUniformBuffers[i]->drawOffset;
         }
 
         renderer->vkCmdBindDescriptorSets(
-            command_buffer->command_buffer,
+            commandBuffer->commandBuffer,
             VK_PIPELINE_BIND_POINT_GRAPHICS,
             resourceLayout->pipelineLayout,
             1,
             1,
-            &command_buffer->vertexUniformDescriptorSet,
+            &commandBuffer->vertexUniformDescriptorSet,
             resourceLayout->vertexUniformBufferCount,
             dynamicOffsets);
 
-        command_buffer->needNewVertexUniformOffsets = false;
+        commandBuffer->needNewVertexUniformOffsets = false;
     }
 
-    if (command_buffer->needNewFragmentResourceDescriptorSet) {
+    if (commandBuffer->needNewFragmentResourceDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[2];
 
-        command_buffer->fragmentResourceDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        commandBuffer->fragmentResourceDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            command_buffer,
+            commandBuffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
@@ -5200,12 +5200,12 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = command_buffer->fragmentResourceDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->fragmentResourceDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pBufferInfo = NULL;
 
-            imageInfos[imageInfoCount].sampler = command_buffer->fragmentSamplers[i]->sampler;
-            imageInfos[imageInfoCount].imageView = command_buffer->fragmentSamplerTextures[i]->fullView;
+            imageInfos[imageInfoCount].sampler = commandBuffer->fragmentSamplers[i]->sampler;
+            imageInfos[imageInfoCount].imageView = commandBuffer->fragmentSamplerTextures[i]->fullView;
             imageInfos[imageInfoCount].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
             currentWriteDescriptorSet->pImageInfo = &imageInfos[imageInfoCount];
@@ -5222,12 +5222,12 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = resourceLayout->fragmentSamplerCount + i;
-            currentWriteDescriptorSet->dstSet = command_buffer->fragmentResourceDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->fragmentResourceDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pBufferInfo = NULL;
 
             imageInfos[imageInfoCount].sampler = VK_NULL_HANDLE;
-            imageInfos[imageInfoCount].imageView = command_buffer->fragmentStorageTextures[i]->fullView;
+            imageInfos[imageInfoCount].imageView = commandBuffer->fragmentStorageTextures[i]->fullView;
             imageInfos[imageInfoCount].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
             currentWriteDescriptorSet->pImageInfo = &imageInfos[imageInfoCount];
@@ -5244,11 +5244,11 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = resourceLayout->fragmentSamplerCount + resourceLayout->fragmentStorageTextureCount + i;
-            currentWriteDescriptorSet->dstSet = command_buffer->fragmentResourceDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->fragmentResourceDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = command_buffer->fragmentStorageBuffers[i]->buffer;
+            bufferInfos[bufferInfoCount].buffer = commandBuffer->fragmentStorageBuffers[i]->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = VK_WHOLE_SIZE;
 
@@ -5265,12 +5265,12 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             NULL);
 
         renderer->vkCmdBindDescriptorSets(
-            command_buffer->command_buffer,
+            commandBuffer->commandBuffer,
             VK_PIPELINE_BIND_POINT_GRAPHICS,
             resourceLayout->pipelineLayout,
             2,
             1,
-            &command_buffer->fragmentResourceDescriptorSet,
+            &commandBuffer->fragmentResourceDescriptorSet,
             0,
             NULL);
 
@@ -5278,15 +5278,15 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        command_buffer->needNewFragmentResourceDescriptorSet = false;
+        commandBuffer->needNewFragmentResourceDescriptorSet = false;
     }
 
-    if (command_buffer->needNewFragmentUniformDescriptorSet) {
+    if (commandBuffer->needNewFragmentUniformDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[3];
 
-        command_buffer->fragmentUniformDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        commandBuffer->fragmentUniformDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            command_buffer,
+            commandBuffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
@@ -5302,11 +5302,11 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = command_buffer->fragmentUniformDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->fragmentUniformDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = command_buffer->fragmentUniformBuffers[i]->bufferHandle->vulkanBuffer->buffer;
+            bufferInfos[bufferInfoCount].buffer = commandBuffer->fragmentUniformBuffers[i]->bufferHandle->vulkanBuffer->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = MAX_UBO_SECTION_SIZE;
 
@@ -5326,79 +5326,79 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        command_buffer->needNewFragmentUniformDescriptorSet = false;
-        command_buffer->needNewFragmentUniformOffsets = true;
+        commandBuffer->needNewFragmentUniformDescriptorSet = false;
+        commandBuffer->needNewFragmentUniformOffsets = true;
     }
 
-    if (command_buffer->needNewFragmentUniformOffsets) {
+    if (commandBuffer->needNewFragmentUniformOffsets) {
         for (i = 0; i < resourceLayout->fragmentUniformBufferCount; i += 1) {
-            dynamicOffsets[i] = command_buffer->fragmentUniformBuffers[i]->drawOffset;
+            dynamicOffsets[i] = commandBuffer->fragmentUniformBuffers[i]->drawOffset;
         }
 
         renderer->vkCmdBindDescriptorSets(
-            command_buffer->command_buffer,
+            commandBuffer->commandBuffer,
             VK_PIPELINE_BIND_POINT_GRAPHICS,
             resourceLayout->pipelineLayout,
             3,
             1,
-            &command_buffer->fragmentUniformDescriptorSet,
+            &commandBuffer->fragmentUniformDescriptorSet,
             resourceLayout->fragmentUniformBufferCount,
             dynamicOffsets);
 
-        command_buffer->needNewFragmentUniformOffsets = false;
+        commandBuffer->needNewFragmentUniformOffsets = false;
     }
 }
 
 static void VULKAN_DrawIndexedPrimitives(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 num_indices,
-    Uint32 num_instances,
-    Uint32 first_index,
-    Sint32 vertex_offset,
-    Uint32 first_instance)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 numIndices,
+    Uint32 numInstances,
+    Uint32 firstIndex,
+    Sint32 vertexOffset,
+    Uint32 firstInstance)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_BindGraphicsDescriptorSets(renderer, vulkanCommandBuffer);
 
     renderer->vkCmdDrawIndexed(
-        vulkanCommandBuffer->command_buffer,
-        num_indices,
-        num_instances,
-        first_index,
-        vertex_offset,
-        first_instance);
+        vulkanCommandBuffer->commandBuffer,
+        numIndices,
+        numInstances,
+        firstIndex,
+        vertexOffset,
+        firstInstance);
 }
 
 static void VULKAN_DrawPrimitives(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 num_vertices,
-    Uint32 num_instances,
-    Uint32 first_vertex,
-    Uint32 first_instance)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 numVertices,
+    Uint32 numInstances,
+    Uint32 firstVertex,
+    Uint32 firstInstance)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_BindGraphicsDescriptorSets(renderer, vulkanCommandBuffer);
 
     renderer->vkCmdDraw(
-        vulkanCommandBuffer->command_buffer,
-        num_vertices,
-        num_instances,
-        first_vertex,
-        first_instance);
+        vulkanCommandBuffer->commandBuffer,
+        numVertices,
+        numInstances,
+        firstVertex,
+        firstInstance);
 }
 
 static void VULKAN_DrawPrimitivesIndirect(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUBuffer *buffer,
     Uint32 offset,
-    Uint32 draw_count,
+    Uint32 drawCount,
     Uint32 pitch)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBuffer *vulkanBuffer = ((VulkanBufferContainer *)buffer)->activeBufferHandle->vulkanBuffer;
     Uint32 i;
@@ -5408,16 +5408,16 @@ static void VULKAN_DrawPrimitivesIndirect(
     if (renderer->supportsMultiDrawIndirect) {
         // Real multi-draw!
         renderer->vkCmdDrawIndirect(
-            vulkanCommandBuffer->command_buffer,
+            vulkanCommandBuffer->commandBuffer,
             vulkanBuffer->buffer,
             offset,
-            draw_count,
+            drawCount,
             pitch);
     } else {
         // Fake multi-draw...
-        for (i = 0; i < draw_count; i += 1) {
+        for (i = 0; i < drawCount; i += 1) {
             renderer->vkCmdDrawIndirect(
-                vulkanCommandBuffer->command_buffer,
+                vulkanCommandBuffer->commandBuffer,
                 vulkanBuffer->buffer,
                 offset + (pitch * i),
                 1,
@@ -5429,13 +5429,13 @@ static void VULKAN_DrawPrimitivesIndirect(
 }
 
 static void VULKAN_DrawIndexedPrimitivesIndirect(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUBuffer *buffer,
     Uint32 offset,
-    Uint32 draw_count,
+    Uint32 drawCount,
     Uint32 pitch)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBuffer *vulkanBuffer = ((VulkanBufferContainer *)buffer)->activeBufferHandle->vulkanBuffer;
     Uint32 i;
@@ -5445,16 +5445,16 @@ static void VULKAN_DrawIndexedPrimitivesIndirect(
     if (renderer->supportsMultiDrawIndirect) {
         // Real multi-draw!
         renderer->vkCmdDrawIndexedIndirect(
-            vulkanCommandBuffer->command_buffer,
+            vulkanCommandBuffer->commandBuffer,
             vulkanBuffer->buffer,
             offset,
-            draw_count,
+            drawCount,
             pitch);
     } else {
         // Fake multi-draw...
-        for (i = 0; i < draw_count; i += 1) {
+        for (i = 0; i < drawCount; i += 1) {
             renderer->vkCmdDrawIndexedIndirect(
-                vulkanCommandBuffer->command_buffer,
+                vulkanCommandBuffer->commandBuffer,
                 vulkanBuffer->buffer,
                 offset + (pitch * i),
                 1,
@@ -5474,7 +5474,7 @@ static void VULKAN_INTERNAL_SetBufferName(
 {
     VkDebugUtilsObjectNameInfoEXT nameInfo;
 
-    if (renderer->debug_mode && renderer->supportsDebugUtils) {
+    if (renderer->debugMode && renderer->supportsDebugUtils) {
         nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
         nameInfo.pNext = NULL;
         nameInfo.pObjectName = text;
@@ -5496,7 +5496,7 @@ static void VULKAN_SetBufferName(
     VulkanBufferContainer *container = (VulkanBufferContainer *)buffer;
     size_t textLength = SDL_strlen(text) + 1;
 
-    if (renderer->debug_mode && renderer->supportsDebugUtils) {
+    if (renderer->debugMode && renderer->supportsDebugUtils) {
         container->debugName = SDL_realloc(
             container->debugName,
             textLength);
@@ -5522,7 +5522,7 @@ static void VULKAN_INTERNAL_SetTextureName(
 {
     VkDebugUtilsObjectNameInfoEXT nameInfo;
 
-    if (renderer->debug_mode && renderer->supportsDebugUtils) {
+    if (renderer->debugMode && renderer->supportsDebugUtils) {
         nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
         nameInfo.pNext = NULL;
         nameInfo.pObjectName = text;
@@ -5544,7 +5544,7 @@ static void VULKAN_SetTextureName(
     VulkanTextureContainer *container = (VulkanTextureContainer *)texture;
     size_t textLength = SDL_strlen(text) + 1;
 
-    if (renderer->debug_mode && renderer->supportsDebugUtils) {
+    if (renderer->debugMode && renderer->supportsDebugUtils) {
         container->debugName = SDL_realloc(
             container->debugName,
             textLength);
@@ -5564,10 +5564,10 @@ static void VULKAN_SetTextureName(
 }
 
 static void VULKAN_InsertDebugLabel(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const char *text)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VkDebugUtilsLabelEXT labelInfo;
 
@@ -5577,16 +5577,16 @@ static void VULKAN_InsertDebugLabel(
         labelInfo.pLabelName = text;
 
         renderer->vkCmdInsertDebugUtilsLabelEXT(
-            vulkanCommandBuffer->command_buffer,
+            vulkanCommandBuffer->commandBuffer,
             &labelInfo);
     }
 }
 
 static void VULKAN_PushDebugGroup(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const char *name)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VkDebugUtilsLabelEXT labelInfo;
 
@@ -5596,19 +5596,19 @@ static void VULKAN_PushDebugGroup(
         labelInfo.pLabelName = name;
 
         renderer->vkCmdBeginDebugUtilsLabelEXT(
-            vulkanCommandBuffer->command_buffer,
+            vulkanCommandBuffer->commandBuffer,
             &labelInfo);
     }
 }
 
 static void VULKAN_PopDebugGroup(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     if (renderer->supportsDebugUtils) {
-        renderer->vkCmdEndDebugUtilsLabelEXT(vulkanCommandBuffer->command_buffer);
+        renderer->vkCmdEndDebugUtilsLabelEXT(vulkanCommandBuffer->commandBuffer);
     }
 }
 
@@ -5619,8 +5619,8 @@ static VulkanTextureHandle *VULKAN_INTERNAL_CreateTextureHandle(
     Uint32 depth,
     SDL_GPUTextureType type,
     Uint32 layerCount,
-    Uint32 num_levels,
-    VkSampleCountFlagBits sample_count,
+    Uint32 numLevels,
+    VkSampleCountFlagBits sampleCount,
     VkFormat format,
     VkComponentMapping swizzle,
     VkImageAspectFlags aspectMask,
@@ -5637,8 +5637,8 @@ static VulkanTextureHandle *VULKAN_INTERNAL_CreateTextureHandle(
         depth,
         type,
         layerCount,
-        num_levels,
-        sample_count,
+        numLevels,
+        sampleCount,
         format,
         swizzle,
         aspectMask,
@@ -5666,8 +5666,8 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
     Uint32 depth,
     SDL_GPUTextureType type,
     Uint32 layerCount,
-    Uint32 num_levels,
-    VkSampleCountFlagBits sample_count,
+    Uint32 numLevels,
+    VkSampleCountFlagBits sampleCount,
     VkFormat format,
     VkComponentMapping swizzle,
     VkImageAspectFlags aspectMask,
@@ -5718,9 +5718,9 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
     imageCreateInfo.extent.width = width;
     imageCreateInfo.extent.height = height;
     imageCreateInfo.extent.depth = depth;
-    imageCreateInfo.mipLevels = num_levels;
+    imageCreateInfo.mipLevels = numLevels;
     imageCreateInfo.arrayLayers = layerCount;
-    imageCreateInfo.samples = isMSAAColorTarget || VULKAN_INTERNAL_IsVulkanDepthFormat(format) ? sample_count : VK_SAMPLE_COUNT_1_BIT;
+    imageCreateInfo.samples = isMSAAColorTarget || VULKAN_INTERNAL_IsVulkanDepthFormat(format) ? sampleCount : VK_SAMPLE_COUNT_1_BIT;
     imageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
     imageCreateInfo.usage = vkUsageFlags;
     imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
@@ -5767,7 +5767,7 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
         imageViewCreateInfo.components = swizzle;
         imageViewCreateInfo.subresourceRange.aspectMask = aspectMask;
         imageViewCreateInfo.subresourceRange.baseMipLevel = 0;
-        imageViewCreateInfo.subresourceRange.levelCount = num_levels;
+        imageViewCreateInfo.subresourceRange.levelCount = numLevels;
         imageViewCreateInfo.subresourceRange.baseArrayLayer = 0;
         imageViewCreateInfo.subresourceRange.layerCount = layerCount;
 
@@ -5799,27 +5799,27 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
     texture->depth = depth;
     texture->format = format;
     texture->swizzle = swizzle;
-    texture->num_levels = num_levels;
+    texture->numLevels = numLevels;
     texture->layerCount = layerCount;
-    texture->sample_count = sample_count;
-    texture->usage_flags = textureUsageFlags;
+    texture->sampleCount = sampleCount;
+    texture->usageFlags = textureUsageFlags;
     texture->aspectFlags = aspectMask;
     SDL_AtomicSet(&texture->referenceCount, 0);
 
     // Define slices
     texture->subresourceCount =
         texture->layerCount *
-        texture->num_levels;
+        texture->numLevels;
 
     texture->subresources = SDL_malloc(
         texture->subresourceCount * sizeof(VulkanTextureSubresource));
 
     for (Uint32 i = 0; i < texture->layerCount; i += 1) {
-        for (Uint32 j = 0; j < texture->num_levels; j += 1) {
+        for (Uint32 j = 0; j < texture->numLevels; j += 1) {
             Uint32 subresourceIndex = VULKAN_INTERNAL_GetTextureSubresourceIndex(
                 j,
                 i,
-                texture->num_levels);
+                texture->numLevels);
 
             texture->subresources[subresourceIndex].renderTargetViews = NULL;
             texture->subresources[subresourceIndex].computeWriteView = VK_NULL_HANDLE;
@@ -5877,7 +5877,7 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
             texture->subresources[subresourceIndex].transitioned = false;
 
             if (
-                sample_count > VK_SAMPLE_COUNT_1_BIT &&
+                sampleCount > VK_SAMPLE_COUNT_1_BIT &&
                 isRenderTarget &&
                 !isMSAAColorTarget &&
                 !VULKAN_INTERNAL_IsVulkanDepthFormat(texture->format)) {
@@ -5889,7 +5889,7 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
                     0,
                     1,
                     1,
-                    sample_count,
+                    sampleCount,
                     texture->format,
                     texture->swizzle,
                     aspectMask,
@@ -5922,7 +5922,7 @@ static void VULKAN_INTERNAL_CycleActiveBuffer(
     bufferContainer->activeBufferHandle = VULKAN_INTERNAL_CreateBufferHandle(
         renderer,
         bufferContainer->activeBufferHandle->vulkanBuffer->size,
-        bufferContainer->activeBufferHandle->vulkanBuffer->usage_flags,
+        bufferContainer->activeBufferHandle->vulkanBuffer->usageFlags,
         bufferContainer->activeBufferHandle->vulkanBuffer->type);
 
     bufferContainer->activeBufferHandle->container = bufferContainer;
@@ -5938,7 +5938,7 @@ static void VULKAN_INTERNAL_CycleActiveBuffer(
     bufferContainer->bufferCount += 1;
 
     if (
-        renderer->debug_mode &&
+        renderer->debugMode &&
         renderer->supportsDebugUtils &&
         bufferContainer->debugName != NULL) {
         VULKAN_INTERNAL_SetBufferName(
@@ -5970,12 +5970,12 @@ static void VULKAN_INTERNAL_CycleActiveTexture(
         textureContainer->activeTextureHandle->vulkanTexture->depth,
         textureContainer->activeTextureHandle->vulkanTexture->type,
         textureContainer->activeTextureHandle->vulkanTexture->layerCount,
-        textureContainer->activeTextureHandle->vulkanTexture->num_levels,
-        textureContainer->activeTextureHandle->vulkanTexture->sample_count,
+        textureContainer->activeTextureHandle->vulkanTexture->numLevels,
+        textureContainer->activeTextureHandle->vulkanTexture->sampleCount,
         textureContainer->activeTextureHandle->vulkanTexture->format,
         textureContainer->activeTextureHandle->vulkanTexture->swizzle,
         textureContainer->activeTextureHandle->vulkanTexture->aspectFlags,
-        textureContainer->activeTextureHandle->vulkanTexture->usage_flags,
+        textureContainer->activeTextureHandle->vulkanTexture->usageFlags,
         false);
 
     textureContainer->activeTextureHandle->container = textureContainer;
@@ -5991,7 +5991,7 @@ static void VULKAN_INTERNAL_CycleActiveTexture(
     textureContainer->textureCount += 1;
 
     if (
-        renderer->debug_mode &&
+        renderer->debugMode &&
         renderer->supportsDebugUtils &&
         textureContainer->debugName != NULL) {
         VULKAN_INTERNAL_SetTextureName(
@@ -6003,7 +6003,7 @@ static void VULKAN_INTERNAL_CycleActiveTexture(
 
 static VulkanBuffer *VULKAN_INTERNAL_PrepareBufferForWrite(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanBufferContainer *bufferContainer,
     bool cycle,
     VulkanBufferUsageMode destinationUsageMode)
@@ -6018,7 +6018,7 @@ static VulkanBuffer *VULKAN_INTERNAL_PrepareBufferForWrite(
 
     VULKAN_INTERNAL_BufferTransitionFromDefaultUsage(
         renderer,
-        command_buffer,
+        commandBuffer,
         destinationUsageMode,
         bufferContainer->activeBufferHandle->vulkanBuffer);
 
@@ -6027,7 +6027,7 @@ static VulkanBuffer *VULKAN_INTERNAL_PrepareBufferForWrite(
 
 static VulkanTextureSubresource *VULKAN_INTERNAL_PrepareTextureSubresourceForWrite(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanTextureContainer *textureContainer,
     Uint32 layer,
     Uint32 level,
@@ -6056,7 +6056,7 @@ static VulkanTextureSubresource *VULKAN_INTERNAL_PrepareTextureSubresourceForWri
     // always do barrier because of layout transitions
     VULKAN_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
         renderer,
-        command_buffer,
+        commandBuffer,
         destinationUsageMode,
         textureSubresource);
 
@@ -6065,10 +6065,10 @@ static VulkanTextureSubresource *VULKAN_INTERNAL_PrepareTextureSubresourceForWri
 
 static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
-    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
-    Uint32 num_color_attachments,
-    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info)
+    VulkanCommandBuffer *commandBuffer,
+    const SDL_GPUColorTargetInfo *colorTargetInfos,
+    Uint32 numColorTargets,
+    const SDL_GPUDepthStencilTargetInfo *depthStencilTargetInfo)
 {
     VkResult vulkanResult;
     VkAttachmentDescription attachmentDescriptions[2 * MAX_COLOR_TARGET_BINDINGS + 1];
@@ -6077,7 +6077,7 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
     VkAttachmentReference depthStencilAttachmentReference;
     VkRenderPassCreateInfo renderPassCreateInfo;
     VkSubpassDescription subpass;
-    VkRenderPass render_pass;
+    VkRenderPass renderPass;
     Uint32 i;
 
     Uint32 attachmentDescriptionCount = 0;
@@ -6086,17 +6086,17 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
 
     VulkanTexture *texture = NULL;
 
-    for (i = 0; i < num_color_attachments; i += 1) {
-        texture = ((VulkanTextureContainer *)color_attachment_infos[i].texture)->activeTextureHandle->vulkanTexture;
+    for (i = 0; i < numColorTargets; i += 1) {
+        texture = ((VulkanTextureContainer *)colorTargetInfos[i].texture)->activeTextureHandle->vulkanTexture;
 
-        if (texture->sample_count > VK_SAMPLE_COUNT_1_BIT) {
+        if (texture->sampleCount > VK_SAMPLE_COUNT_1_BIT) {
             // Resolve attachment and multisample attachment
 
             attachmentDescriptions[attachmentDescriptionCount].flags = 0;
             attachmentDescriptions[attachmentDescriptionCount].format = texture->format;
             attachmentDescriptions[attachmentDescriptionCount].samples =
                 VK_SAMPLE_COUNT_1_BIT;
-            attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[color_attachment_infos[i].load_op];
+            attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[colorTargetInfos[i].load_op];
             attachmentDescriptions[attachmentDescriptionCount].storeOp =
                 VK_ATTACHMENT_STORE_OP_STORE; // Always store the resolve texture
             attachmentDescriptions[attachmentDescriptionCount].stencilLoadOp =
@@ -6118,9 +6118,9 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
 
             attachmentDescriptions[attachmentDescriptionCount].flags = 0;
             attachmentDescriptions[attachmentDescriptionCount].format = texture->format;
-            attachmentDescriptions[attachmentDescriptionCount].samples = texture->sample_count;
-            attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[color_attachment_infos[i].load_op];
-            attachmentDescriptions[attachmentDescriptionCount].storeOp = SDLToVK_StoreOp[color_attachment_infos[i].store_op];
+            attachmentDescriptions[attachmentDescriptionCount].samples = texture->sampleCount;
+            attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[colorTargetInfos[i].load_op];
+            attachmentDescriptions[attachmentDescriptionCount].storeOp = SDLToVK_StoreOp[colorTargetInfos[i].store_op];
             attachmentDescriptions[attachmentDescriptionCount].stencilLoadOp =
                 VK_ATTACHMENT_LOAD_OP_DONT_CARE;
             attachmentDescriptions[attachmentDescriptionCount].stencilStoreOp =
@@ -6142,7 +6142,7 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
             attachmentDescriptions[attachmentDescriptionCount].format = texture->format;
             attachmentDescriptions[attachmentDescriptionCount].samples =
                 VK_SAMPLE_COUNT_1_BIT;
-            attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[color_attachment_infos[i].load_op];
+            attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[colorTargetInfos[i].load_op];
             attachmentDescriptions[attachmentDescriptionCount].storeOp =
                 VK_ATTACHMENT_STORE_OP_STORE; // Always store non-MSAA textures
             attachmentDescriptions[attachmentDescriptionCount].stencilLoadOp =
@@ -6167,24 +6167,24 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
     subpass.flags = 0;
     subpass.inputAttachmentCount = 0;
     subpass.pInputAttachments = NULL;
-    subpass.colorAttachmentCount = num_color_attachments;
+    subpass.colorAttachmentCount = numColorTargets;
     subpass.pColorAttachments = colorAttachmentReferences;
     subpass.preserveAttachmentCount = 0;
     subpass.pPreserveAttachments = NULL;
 
-    if (depth_stencil_attachment_info == NULL) {
+    if (depthStencilTargetInfo == NULL) {
         subpass.pDepthStencilAttachment = NULL;
     } else {
-        texture = ((VulkanTextureContainer *)depth_stencil_attachment_info->texture)->activeTextureHandle->vulkanTexture;
+        texture = ((VulkanTextureContainer *)depthStencilTargetInfo->texture)->activeTextureHandle->vulkanTexture;
 
         attachmentDescriptions[attachmentDescriptionCount].flags = 0;
         attachmentDescriptions[attachmentDescriptionCount].format = texture->format;
-        attachmentDescriptions[attachmentDescriptionCount].samples = texture->sample_count;
+        attachmentDescriptions[attachmentDescriptionCount].samples = texture->sampleCount;
 
-        attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[depth_stencil_attachment_info->load_op];
-        attachmentDescriptions[attachmentDescriptionCount].storeOp = SDLToVK_StoreOp[depth_stencil_attachment_info->store_op];
-        attachmentDescriptions[attachmentDescriptionCount].stencilLoadOp = SDLToVK_LoadOp[depth_stencil_attachment_info->stencil_load_op];
-        attachmentDescriptions[attachmentDescriptionCount].stencilStoreOp = SDLToVK_StoreOp[depth_stencil_attachment_info->stencil_store_op];
+        attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[depthStencilTargetInfo->load_op];
+        attachmentDescriptions[attachmentDescriptionCount].storeOp = SDLToVK_StoreOp[depthStencilTargetInfo->store_op];
+        attachmentDescriptions[attachmentDescriptionCount].stencilLoadOp = SDLToVK_LoadOp[depthStencilTargetInfo->stencil_load_op];
+        attachmentDescriptions[attachmentDescriptionCount].stencilStoreOp = SDLToVK_StoreOp[depthStencilTargetInfo->stencil_store_op];
         attachmentDescriptions[attachmentDescriptionCount].initialLayout =
             VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
         attachmentDescriptions[attachmentDescriptionCount].finalLayout =
@@ -6201,7 +6201,7 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
         attachmentDescriptionCount += 1;
     }
 
-    if (texture != NULL && texture->sample_count > VK_SAMPLE_COUNT_1_BIT) {
+    if (texture != NULL && texture->sampleCount > VK_SAMPLE_COUNT_1_BIT) {
         subpass.pResolveAttachments = resolveReferences;
     } else {
         subpass.pResolveAttachments = NULL;
@@ -6221,29 +6221,29 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
         renderer->logicalDevice,
         &renderPassCreateInfo,
         NULL,
-        &render_pass);
+        &renderPass);
 
     if (vulkanResult != VK_SUCCESS) {
-        render_pass = VK_NULL_HANDLE;
+        renderPass = VK_NULL_HANDLE;
         LogVulkanResultAsError("vkCreateRenderPass", vulkanResult);
     }
 
-    return render_pass;
+    return renderPass;
 }
 
 static VkRenderPass VULKAN_INTERNAL_CreateTransientRenderPass(
     VulkanRenderer *renderer,
-    SDL_GPUGraphicsPipelineAttachmentInfo attachment_info,
-    VkSampleCountFlagBits sample_count)
+    SDL_GpuGraphicsPipelineTargetInfo attachmentInfo,
+    VkSampleCountFlagBits sampleCount)
 {
     VkAttachmentDescription attachmentDescriptions[2 * MAX_COLOR_TARGET_BINDINGS + 1];
     VkAttachmentReference colorAttachmentReferences[MAX_COLOR_TARGET_BINDINGS];
     VkAttachmentReference resolveReferences[MAX_COLOR_TARGET_BINDINGS + 1];
     VkAttachmentReference depthStencilAttachmentReference;
-    SDL_GPUColorAttachmentDescription attachmentDescription;
+    SDL_GPUColorTargetDescription attachmentDescription;
     VkSubpassDescription subpass;
     VkRenderPassCreateInfo renderPassCreateInfo;
-    VkRenderPass render_pass;
+    VkRenderPass renderPass;
     VkResult result;
 
     Uint32 multisampling = 0;
@@ -6252,10 +6252,10 @@ static VkRenderPass VULKAN_INTERNAL_CreateTransientRenderPass(
     Uint32 resolveReferenceCount = 0;
     Uint32 i;
 
-    for (i = 0; i < attachment_info.num_color_attachments; i += 1) {
-        attachmentDescription = attachment_info.color_attachment_descriptions[i];
+    for (i = 0; i < attachmentInfo.num_color_targets; i += 1) {
+        attachmentDescription = attachmentInfo.color_target_descriptions[i];
 
-        if (sample_count > VK_SAMPLE_COUNT_1_BIT) {
+        if (sampleCount > VK_SAMPLE_COUNT_1_BIT) {
             multisampling = 1;
 
             // Resolve attachment and multisample attachment
@@ -6278,7 +6278,7 @@ static VkRenderPass VULKAN_INTERNAL_CreateTransientRenderPass(
 
             attachmentDescriptions[attachmentDescriptionCount].flags = 0;
             attachmentDescriptions[attachmentDescriptionCount].format = SDLToVK_SurfaceFormat[attachmentDescription.format];
-            attachmentDescriptions[attachmentDescriptionCount].samples = sample_count;
+            attachmentDescriptions[attachmentDescriptionCount].samples = sampleCount;
 
             attachmentDescriptions[attachmentDescriptionCount].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
             attachmentDescriptions[attachmentDescriptionCount].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
@@ -6325,16 +6325,16 @@ static VkRenderPass VULKAN_INTERNAL_CreateTransientRenderPass(
     subpass.flags = 0;
     subpass.inputAttachmentCount = 0;
     subpass.pInputAttachments = NULL;
-    subpass.colorAttachmentCount = attachment_info.num_color_attachments;
+    subpass.colorAttachmentCount = attachmentInfo.num_color_targets;
     subpass.pColorAttachments = colorAttachmentReferences;
     subpass.preserveAttachmentCount = 0;
     subpass.pPreserveAttachments = NULL;
 
-    if (attachment_info.has_depth_stencil_attachment) {
+    if (attachmentInfo.has_depth_stencil_target) {
         attachmentDescriptions[attachmentDescriptionCount].flags = 0;
         attachmentDescriptions[attachmentDescriptionCount].format =
-            SDLToVK_SurfaceFormat[attachment_info.depth_stencil_format];
-        attachmentDescriptions[attachmentDescriptionCount].samples = sample_count;
+            SDLToVK_SurfaceFormat[attachmentInfo.depth_stencil_format];
+        attachmentDescriptions[attachmentDescriptionCount].samples = sampleCount;
 
         attachmentDescriptions[attachmentDescriptionCount].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
         attachmentDescriptions[attachmentDescriptionCount].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
@@ -6378,14 +6378,14 @@ static VkRenderPass VULKAN_INTERNAL_CreateTransientRenderPass(
         renderer->logicalDevice,
         &renderPassCreateInfo,
         NULL,
-        &render_pass);
+        &renderPass);
 
     if (result != VK_SUCCESS) {
-        render_pass = VK_NULL_HANDLE;
+        renderPass = VK_NULL_HANDLE;
         LogVulkanResultAsError("vkCreateRenderPass", result);
     }
 
-    return render_pass;
+    return renderPass;
 }
 
 static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
@@ -6396,7 +6396,7 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
     Uint32 i;
     VkSampleCountFlagBits actualSampleCount;
 
-    VulkanGraphicsPipeline *graphics_pipeline = (VulkanGraphicsPipeline *)SDL_malloc(sizeof(VulkanGraphicsPipeline));
+    VulkanGraphicsPipeline *graphicsPipeline = (VulkanGraphicsPipeline *)SDL_malloc(sizeof(VulkanGraphicsPipeline));
     VkGraphicsPipelineCreateInfo vkPipelineCreateInfo;
 
     VkPipelineShaderStageCreateInfo shaderStageCreateInfos[2];
@@ -6417,13 +6417,13 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
     VkPipelineMultisampleStateCreateInfo multisampleStateCreateInfo;
 
     VkPipelineDepthStencilStateCreateInfo depthStencilStateCreateInfo;
-    VkStencilOpState front_stencil_state;
-    VkStencilOpState back_stencil_state;
+    VkStencilOpState frontStencilState;
+    VkStencilOpState backStencilState;
 
     VkPipelineColorBlendStateCreateInfo colorBlendStateCreateInfo;
     VkPipelineColorBlendAttachmentState *colorBlendAttachmentStates = SDL_stack_alloc(
         VkPipelineColorBlendAttachmentState,
-        createinfo->attachment_info.num_color_attachments);
+        createinfo->target_info.num_color_targets);
 
     static const VkDynamicState dynamicStates[] = {
         VK_DYNAMIC_STATE_VIEWPORT,
@@ -6445,7 +6445,7 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
 
     VkRenderPass transientRenderPass = VULKAN_INTERNAL_CreateTransientRenderPass(
         renderer,
-        createinfo->attachment_info,
+        createinfo->target_info,
         actualSampleCount);
 
     // Dynamic state
@@ -6458,26 +6458,26 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
 
     // Shader stages
 
-    graphics_pipeline->vertex_shader = (VulkanShader *)createinfo->vertex_shader;
-    SDL_AtomicIncRef(&graphics_pipeline->vertex_shader->referenceCount);
+    graphicsPipeline->vertexShader = (VulkanShader *)createinfo->vertex_shader;
+    SDL_AtomicIncRef(&graphicsPipeline->vertexShader->referenceCount);
 
     shaderStageCreateInfos[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStageCreateInfos[0].pNext = NULL;
     shaderStageCreateInfos[0].flags = 0;
     shaderStageCreateInfos[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-    shaderStageCreateInfos[0].module = graphics_pipeline->vertex_shader->shaderModule;
-    shaderStageCreateInfos[0].pName = graphics_pipeline->vertex_shader->entrypoint_name;
+    shaderStageCreateInfos[0].module = graphicsPipeline->vertexShader->shaderModule;
+    shaderStageCreateInfos[0].pName = graphicsPipeline->vertexShader->entrypointName;
     shaderStageCreateInfos[0].pSpecializationInfo = NULL;
 
-    graphics_pipeline->fragment_shader = (VulkanShader *)createinfo->fragment_shader;
-    SDL_AtomicIncRef(&graphics_pipeline->fragment_shader->referenceCount);
+    graphicsPipeline->fragmentShader = (VulkanShader *)createinfo->fragment_shader;
+    SDL_AtomicIncRef(&graphicsPipeline->fragmentShader->referenceCount);
 
     shaderStageCreateInfos[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStageCreateInfos[1].pNext = NULL;
     shaderStageCreateInfos[1].flags = 0;
     shaderStageCreateInfos[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-    shaderStageCreateInfos[1].module = graphics_pipeline->fragment_shader->shaderModule;
-    shaderStageCreateInfos[1].pName = graphics_pipeline->fragment_shader->entrypoint_name;
+    shaderStageCreateInfos[1].module = graphicsPipeline->fragmentShader->shaderModule;
+    shaderStageCreateInfos[1].pName = graphicsPipeline->fragmentShader->entrypointName;
     shaderStageCreateInfos[1].pSpecializationInfo = NULL;
 
     // Vertex input
@@ -6535,7 +6535,7 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
     inputAssemblyStateCreateInfo.primitiveRestartEnable = VK_FALSE;
     inputAssemblyStateCreateInfo.topology = SDLToVK_PrimitiveType[createinfo->primitive_type];
 
-    graphics_pipeline->primitive_type = createinfo->primitive_type;
+    graphicsPipeline->primitiveType = createinfo->primitive_type;
 
     // Viewport
 
@@ -6560,7 +6560,7 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
         renderer,
         createinfo->rasterizer_state.fill_mode);
     rasterizationStateCreateInfo.cullMode = SDLToVK_CullMode[createinfo->rasterizer_state.cull_mode];
-    rasterizationStateCreateInfo.frontFace = SDLToVK_FrontFace[createinfo->rasterizer_state.frontFace];
+    rasterizationStateCreateInfo.frontFace = SDLToVK_FrontFace[createinfo->rasterizer_state.front_face];
     rasterizationStateCreateInfo.depthBiasEnable =
         createinfo->rasterizer_state.enable_depth_bias;
     rasterizationStateCreateInfo.depthBiasConstantFactor =
@@ -6586,25 +6586,25 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
 
     // Depth Stencil State
 
-    front_stencil_state.failOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.front_stencil_state.fail_op];
-    front_stencil_state.passOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.front_stencil_state.pass_op];
-    front_stencil_state.depthFailOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.front_stencil_state.depth_fail_op];
-    front_stencil_state.compareOp = SDLToVK_CompareOp[createinfo->depth_stencil_state.front_stencil_state.compare_op];
-    front_stencil_state.compareMask =
+    frontStencilState.failOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.front_stencil_state.fail_op];
+    frontStencilState.passOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.front_stencil_state.pass_op];
+    frontStencilState.depthFailOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.front_stencil_state.depth_fail_op];
+    frontStencilState.compareOp = SDLToVK_CompareOp[createinfo->depth_stencil_state.front_stencil_state.compare_op];
+    frontStencilState.compareMask =
         createinfo->depth_stencil_state.compare_mask;
-    front_stencil_state.writeMask =
+    frontStencilState.writeMask =
         createinfo->depth_stencil_state.write_mask;
-    front_stencil_state.reference = 0;
+    frontStencilState.reference = 0;
 
-    back_stencil_state.failOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.back_stencil_state.fail_op];
-    back_stencil_state.passOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.back_stencil_state.pass_op];
-    back_stencil_state.depthFailOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.back_stencil_state.depth_fail_op];
-    back_stencil_state.compareOp = SDLToVK_CompareOp[createinfo->depth_stencil_state.back_stencil_state.compare_op];
-    back_stencil_state.compareMask =
+    backStencilState.failOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.back_stencil_state.fail_op];
+    backStencilState.passOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.back_stencil_state.pass_op];
+    backStencilState.depthFailOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.back_stencil_state.depth_fail_op];
+    backStencilState.compareOp = SDLToVK_CompareOp[createinfo->depth_stencil_state.back_stencil_state.compare_op];
+    backStencilState.compareMask =
         createinfo->depth_stencil_state.compare_mask;
-    back_stencil_state.writeMask =
+    backStencilState.writeMask =
         createinfo->depth_stencil_state.write_mask;
-    back_stencil_state.reference = 0;
+    backStencilState.reference = 0;
 
     depthStencilStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
     depthStencilStateCreateInfo.pNext = NULL;
@@ -6617,33 +6617,33 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
     depthStencilStateCreateInfo.depthBoundsTestEnable = VK_FALSE;
     depthStencilStateCreateInfo.stencilTestEnable =
         createinfo->depth_stencil_state.enable_stencil_test;
-    depthStencilStateCreateInfo.front = front_stencil_state;
-    depthStencilStateCreateInfo.back = back_stencil_state;
+    depthStencilStateCreateInfo.front = frontStencilState;
+    depthStencilStateCreateInfo.back = backStencilState;
     depthStencilStateCreateInfo.minDepthBounds = 0; // unused
     depthStencilStateCreateInfo.maxDepthBounds = 0; // unused
 
     // Color Blend
 
-    for (i = 0; i < createinfo->attachment_info.num_color_attachments; i += 1) {
-        SDL_GPUColorAttachmentBlendState blend_state = createinfo->attachment_info.color_attachment_descriptions[i].blend_state;
+    for (i = 0; i < createinfo->target_info.num_color_targets; i += 1) {
+        SDL_GPUColorTargetBlendState blendState = createinfo->target_info.color_target_descriptions[i].blend_state;
 
         colorBlendAttachmentStates[i].blendEnable =
-            blend_state.enable_blend;
-        colorBlendAttachmentStates[i].srcColorBlendFactor = SDLToVK_BlendFactor[blend_state.src_color_blendfactor];
-        colorBlendAttachmentStates[i].dstColorBlendFactor = SDLToVK_BlendFactor[blend_state.dst_color_blendfactor];
-        colorBlendAttachmentStates[i].colorBlendOp = SDLToVK_BlendOp[blend_state.color_blend_op];
-        colorBlendAttachmentStates[i].srcAlphaBlendFactor = SDLToVK_BlendFactor[blend_state.src_alpha_blendfactor];
-        colorBlendAttachmentStates[i].dstAlphaBlendFactor = SDLToVK_BlendFactor[blend_state.dst_alpha_blendfactor];
-        colorBlendAttachmentStates[i].alphaBlendOp = SDLToVK_BlendOp[blend_state.alpha_blend_op];
+            blendState.enable_blend;
+        colorBlendAttachmentStates[i].srcColorBlendFactor = SDLToVK_BlendFactor[blendState.src_color_blendfactor];
+        colorBlendAttachmentStates[i].dstColorBlendFactor = SDLToVK_BlendFactor[blendState.dst_color_blendfactor];
+        colorBlendAttachmentStates[i].colorBlendOp = SDLToVK_BlendOp[blendState.color_blend_op];
+        colorBlendAttachmentStates[i].srcAlphaBlendFactor = SDLToVK_BlendFactor[blendState.src_alpha_blendfactor];
+        colorBlendAttachmentStates[i].dstAlphaBlendFactor = SDLToVK_BlendFactor[blendState.dst_alpha_blendfactor];
+        colorBlendAttachmentStates[i].alphaBlendOp = SDLToVK_BlendOp[blendState.alpha_blend_op];
         colorBlendAttachmentStates[i].colorWriteMask =
-            blend_state.color_write_mask;
+            blendState.color_write_mask;
     }
 
     colorBlendStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
     colorBlendStateCreateInfo.pNext = NULL;
     colorBlendStateCreateInfo.flags = 0;
     colorBlendStateCreateInfo.attachmentCount =
-        createinfo->attachment_info.num_color_attachments;
+        createinfo->target_info.num_color_targets;
     colorBlendStateCreateInfo.pAttachments =
         colorBlendAttachmentStates;
     colorBlendStateCreateInfo.blendConstants[0] = 1.0f;
@@ -6659,14 +6659,14 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
 
     if (!VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
             renderer,
-            graphics_pipeline->vertex_shader,
-            graphics_pipeline->fragment_shader,
-            &graphics_pipeline->resourceLayout)) {
+            graphicsPipeline->vertexShader,
+            graphicsPipeline->fragmentShader,
+            &graphicsPipeline->resourceLayout)) {
         SDL_stack_free(vertexInputBindingDescriptions);
         SDL_stack_free(vertexInputAttributeDescriptions);
         SDL_stack_free(colorBlendAttachmentStates);
         SDL_stack_free(divisorDescriptions);
-        SDL_free(graphics_pipeline);
+        SDL_free(graphicsPipeline);
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to initialize pipeline resource layout!");
         return NULL;
     }
@@ -6687,7 +6687,7 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
     vkPipelineCreateInfo.pDepthStencilState = &depthStencilStateCreateInfo;
     vkPipelineCreateInfo.pColorBlendState = &colorBlendStateCreateInfo;
     vkPipelineCreateInfo.pDynamicState = &dynamicStateCreateInfo;
-    vkPipelineCreateInfo.layout = graphics_pipeline->resourceLayout.pipelineLayout;
+    vkPipelineCreateInfo.layout = graphicsPipeline->resourceLayout.pipelineLayout;
     vkPipelineCreateInfo.renderPass = transientRenderPass;
     vkPipelineCreateInfo.subpass = 0;
     vkPipelineCreateInfo.basePipelineHandle = VK_NULL_HANDLE;
@@ -6700,7 +6700,7 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
         1,
         &vkPipelineCreateInfo,
         NULL,
-        &graphics_pipeline->pipeline);
+        &graphicsPipeline->pipeline);
 
     SDL_stack_free(vertexInputBindingDescriptions);
     SDL_stack_free(vertexInputAttributeDescriptions);
@@ -6713,15 +6713,15 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
         NULL);
 
     if (vulkanResult != VK_SUCCESS) {
-        SDL_free(graphics_pipeline);
+        SDL_free(graphicsPipeline);
         LogVulkanResultAsError("vkCreateGraphicsPipelines", vulkanResult);
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create graphics pipeline!");
         return NULL;
     }
 
-    SDL_AtomicSet(&graphics_pipeline->referenceCount, 0);
+    SDL_AtomicSet(&graphicsPipeline->referenceCount, 0);
 
-    return (SDL_GPUGraphicsPipeline *)graphics_pipeline;
+    return (SDL_GPUGraphicsPipeline *)graphicsPipeline;
 }
 
 static SDL_GPUComputePipeline *VULKAN_CreateComputePipeline(
@@ -6766,7 +6766,7 @@ static SDL_GPUComputePipeline *VULKAN_CreateComputePipeline(
     pipelineShaderStageCreateInfo.flags = 0;
     pipelineShaderStageCreateInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     pipelineShaderStageCreateInfo.module = vulkanComputePipeline->shaderModule;
-    pipelineShaderStageCreateInfo.pName = createinfo->entrypoint_name;
+    pipelineShaderStageCreateInfo.pName = createinfo->entrypoint;
     pipelineShaderStageCreateInfo.pSpecializationInfo = NULL;
 
     if (!VULKAN_INTERNAL_InitializeComputePipelineResourceLayout(
@@ -6900,14 +6900,14 @@ static SDL_GPUShader *VULKAN_CreateShader(
         return NULL;
     }
 
-    entryPointNameLength = SDL_strlen(createinfo->entrypoint_name) + 1;
-    vulkanShader->entrypoint_name = SDL_malloc(entryPointNameLength);
-    SDL_utf8strlcpy((char *)vulkanShader->entrypoint_name, createinfo->entrypoint_name, entryPointNameLength);
+    entryPointNameLength = SDL_strlen(createinfo->entrypoint) + 1;
+    vulkanShader->entrypointName = SDL_malloc(entryPointNameLength);
+    SDL_utf8strlcpy((char *)vulkanShader->entrypointName, createinfo->entrypoint, entryPointNameLength);
 
-    vulkanShader->num_samplers = createinfo->num_samplers;
-    vulkanShader->num_storage_textures = createinfo->num_storage_textures;
-    vulkanShader->num_storage_buffers = createinfo->num_storage_buffers;
-    vulkanShader->num_uniform_buffers = createinfo->num_uniform_buffers;
+    vulkanShader->numSamplers = createinfo->num_samplers;
+    vulkanShader->numStorageTextures = createinfo->num_storage_textures;
+    vulkanShader->numStorageBuffers = createinfo->num_storage_buffers;
+    vulkanShader->numUniformBuffers = createinfo->num_uniform_buffers;
 
     SDL_AtomicSet(&vulkanShader->referenceCount, 0);
 
@@ -6917,11 +6917,11 @@ static SDL_GPUShader *VULKAN_CreateShader(
 static bool VULKAN_SupportsSampleCount(
     SDL_GPURenderer *driverData,
     SDL_GPUTextureFormat format,
-    SDL_GPUSampleCount sample_count)
+    SDL_GPUSampleCount sampleCount)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
     VkSampleCountFlags bits = IsDepthFormat(format) ? renderer->physicalDeviceProperties.properties.limits.framebufferDepthSampleCounts : renderer->physicalDeviceProperties.properties.limits.framebufferColorSampleCounts;
-    VkSampleCountFlagBits vkSampleCount = SDLToVK_SampleCount[sample_count];
+    VkSampleCountFlagBits vkSampleCount = SDLToVK_SampleCount[sampleCount];
     return !!(bits & vkSampleCount);
 }
 
@@ -6962,7 +6962,7 @@ static SDL_GPUTexture *VULKAN_CreateTexture(
         format,
         swizzle,
         imageAspectFlags,
-        createinfo->usage_flags,
+        createinfo->usage,
         false);
 
     if (textureHandle == NULL) {
@@ -6988,13 +6988,13 @@ static SDL_GPUTexture *VULKAN_CreateTexture(
 
 static SDL_GPUBuffer *VULKAN_CreateBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUBufferUsageFlags usage_flags,
+    SDL_GPUBufferUsageFlags usageFlags,
     Uint32 size)
 {
     return (SDL_GPUBuffer *)VULKAN_INTERNAL_CreateBufferContainer(
         (VulkanRenderer *)driverData,
         (VkDeviceSize)size,
-        usage_flags,
+        usageFlags,
         VULKAN_BUFFER_TYPE_GPU);
 }
 
@@ -7162,10 +7162,10 @@ static void VULKAN_ReleaseBuffer(
 
 static void VULKAN_ReleaseTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transfer_buffer)
+    SDL_GPUTransferBuffer *transferBuffer)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)transfer_buffer;
+    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)transferBuffer;
 
     VULKAN_INTERNAL_ReleaseBufferContainer(
         renderer,
@@ -7196,10 +7196,10 @@ static void VULKAN_ReleaseShader(
 
 static void VULKAN_ReleaseComputePipeline(
     SDL_GPURenderer *driverData,
-    SDL_GPUComputePipeline *compute_pipeline)
+    SDL_GPUComputePipeline *computePipeline)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    VulkanComputePipeline *vulkanComputePipeline = (VulkanComputePipeline *)compute_pipeline;
+    VulkanComputePipeline *vulkanComputePipeline = (VulkanComputePipeline *)computePipeline;
 
     SDL_LockMutex(renderer->disposeLock);
 
@@ -7218,10 +7218,10 @@ static void VULKAN_ReleaseComputePipeline(
 
 static void VULKAN_ReleaseGraphicsPipeline(
     SDL_GPURenderer *driverData,
-    SDL_GPUGraphicsPipeline *graphics_pipeline)
+    SDL_GPUGraphicsPipeline *graphicsPipeline)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    VulkanGraphicsPipeline *vulkanGraphicsPipeline = (VulkanGraphicsPipeline *)graphics_pipeline;
+    VulkanGraphicsPipeline *vulkanGraphicsPipeline = (VulkanGraphicsPipeline *)graphicsPipeline;
 
     SDL_LockMutex(renderer->disposeLock);
 
@@ -7242,41 +7242,41 @@ static void VULKAN_ReleaseGraphicsPipeline(
 
 static VkRenderPass VULKAN_INTERNAL_FetchRenderPass(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
-    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
-    Uint32 num_color_attachments,
-    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info)
+    VulkanCommandBuffer *commandBuffer,
+    const SDL_GPUColorTargetInfo *colorTargetInfos,
+    Uint32 numColorTargets,
+    const SDL_GPUDepthStencilTargetInfo *depthStencilTargetInfo)
 {
     VulkanRenderPassHashTableValue *renderPassWrapper = NULL;
     VkRenderPass renderPassHandle;
     RenderPassHashTableKey key;
     Uint32 i;
 
-    for (i = 0; i < num_color_attachments; i += 1) {
-        key.colorTargetDescriptions[i].format = ((VulkanTextureContainer *)color_attachment_infos[i].texture)->activeTextureHandle->vulkanTexture->format;
-        key.colorTargetDescriptions[i].load_op = color_attachment_infos[i].load_op;
-        key.colorTargetDescriptions[i].store_op = color_attachment_infos[i].store_op;
+    for (i = 0; i < numColorTargets; i += 1) {
+        key.colorTargetDescriptions[i].format = ((VulkanTextureContainer *)colorTargetInfos[i].texture)->activeTextureHandle->vulkanTexture->format;
+        key.colorTargetDescriptions[i].loadOp = colorTargetInfos[i].load_op;
+        key.colorTargetDescriptions[i].storeOp = colorTargetInfos[i].store_op;
     }
 
     key.colorAttachmentSampleCount = VK_SAMPLE_COUNT_1_BIT;
-    if (num_color_attachments > 0) {
-        key.colorAttachmentSampleCount = ((VulkanTextureContainer *)color_attachment_infos[0].texture)->activeTextureHandle->vulkanTexture->sample_count;
+    if (numColorTargets > 0) {
+        key.colorAttachmentSampleCount = ((VulkanTextureContainer *)colorTargetInfos[0].texture)->activeTextureHandle->vulkanTexture->sampleCount;
     }
 
-    key.num_color_attachments = num_color_attachments;
+    key.numColorTargets = numColorTargets;
 
-    if (depth_stencil_attachment_info == NULL) {
+    if (depthStencilTargetInfo == NULL) {
         key.depthStencilTargetDescription.format = 0;
-        key.depthStencilTargetDescription.load_op = SDL_GPU_LOADOP_DONT_CARE;
-        key.depthStencilTargetDescription.store_op = SDL_GPU_STOREOP_DONT_CARE;
-        key.depthStencilTargetDescription.stencil_load_op = SDL_GPU_LOADOP_DONT_CARE;
-        key.depthStencilTargetDescription.stencil_store_op = SDL_GPU_STOREOP_DONT_CARE;
+        key.depthStencilTargetDescription.loadOp = SDL_GPU_LOADOP_DONT_CARE;
+        key.depthStencilTargetDescription.storeOp = SDL_GPU_STOREOP_DONT_CARE;
+        key.depthStencilTargetDescription.stencilLoadOp = SDL_GPU_LOADOP_DONT_CARE;
+        key.depthStencilTargetDescription.stencilStoreOp = SDL_GPU_STOREOP_DONT_CARE;
     } else {
-        key.depthStencilTargetDescription.format = ((VulkanTextureContainer *)depth_stencil_attachment_info->texture)->activeTextureHandle->vulkanTexture->format;
-        key.depthStencilTargetDescription.load_op = depth_stencil_attachment_info->load_op;
-        key.depthStencilTargetDescription.store_op = depth_stencil_attachment_info->store_op;
-        key.depthStencilTargetDescription.stencil_load_op = depth_stencil_attachment_info->stencil_load_op;
-        key.depthStencilTargetDescription.stencil_store_op = depth_stencil_attachment_info->stencil_store_op;
+        key.depthStencilTargetDescription.format = ((VulkanTextureContainer *)depthStencilTargetInfo->texture)->activeTextureHandle->vulkanTexture->format;
+        key.depthStencilTargetDescription.loadOp = depthStencilTargetInfo->load_op;
+        key.depthStencilTargetDescription.storeOp = depthStencilTargetInfo->store_op;
+        key.depthStencilTargetDescription.stencilLoadOp = depthStencilTargetInfo->stencil_load_op;
+        key.depthStencilTargetDescription.stencilStoreOp = depthStencilTargetInfo->stencil_store_op;
     }
 
     SDL_LockMutex(renderer->renderPassFetchLock);
@@ -7294,10 +7294,10 @@ static VkRenderPass VULKAN_INTERNAL_FetchRenderPass(
 
     renderPassHandle = VULKAN_INTERNAL_CreateRenderPass(
         renderer,
-        command_buffer,
-        color_attachment_infos,
-        num_color_attachments,
-        depth_stencil_attachment_info);
+        commandBuffer,
+        colorTargetInfos,
+        numColorTargets,
+        depthStencilTargetInfo);
 
     if (renderPassHandle == VK_NULL_HANDLE) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create VkRenderPass!");
@@ -7324,10 +7324,10 @@ static VkRenderPass VULKAN_INTERNAL_FetchRenderPass(
 
 static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
     VulkanRenderer *renderer,
-    VkRenderPass render_pass,
-    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
-    Uint32 num_color_attachments,
-    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info,
+    VkRenderPass renderPass,
+    const SDL_GPUColorTargetInfo *colorTargetInfos,
+    Uint32 numColorTargets,
+    const SDL_GPUDepthStencilTargetInfo *depthStencilTargetInfo,
     Uint32 width,
     Uint32 height)
 {
@@ -7344,17 +7344,17 @@ static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
         key.colorMultiSampleAttachmentViews[i] = VK_NULL_HANDLE;
     }
 
-    key.num_color_attachments = num_color_attachments;
+    key.numColorTargets = numColorTargets;
 
-    for (i = 0; i < num_color_attachments; i += 1) {
-        VulkanTextureContainer *container = (VulkanTextureContainer *)color_attachment_infos[i].texture;
+    for (i = 0; i < numColorTargets; i += 1) {
+        VulkanTextureContainer *container = (VulkanTextureContainer *)colorTargetInfos[i].texture;
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_FetchTextureSubresource(
             container,
-            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : color_attachment_infos[i].layer_or_depth_plane,
-            color_attachment_infos[i].mip_level);
+            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorTargetInfos[i].layer_or_depth_plane,
+            colorTargetInfos[i].mip_level);
 
         Uint32 rtvIndex =
-            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? color_attachment_infos[i].layer_or_depth_plane : 0;
+            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? colorTargetInfos[i].layer_or_depth_plane : 0;
         key.colorAttachmentViews[i] = subresource->renderTargetViews[rtvIndex];
 
         if (subresource->msaaTexHandle != NULL) {
@@ -7362,11 +7362,11 @@ static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
         }
     }
 
-    if (depth_stencil_attachment_info == NULL) {
+    if (depthStencilTargetInfo == NULL) {
         key.depthStencilAttachmentView = VK_NULL_HANDLE;
     } else {
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_FetchTextureSubresource(
-            (VulkanTextureContainer *)depth_stencil_attachment_info->texture,
+            (VulkanTextureContainer *)depthStencilTargetInfo->texture,
             0,
             0);
         key.depthStencilAttachmentView = subresource->depthStencilView;
@@ -7394,15 +7394,15 @@ static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
 
     // Create a new framebuffer
 
-    for (i = 0; i < num_color_attachments; i += 1) {
-        VulkanTextureContainer *container = (VulkanTextureContainer *)color_attachment_infos[i].texture;
+    for (i = 0; i < numColorTargets; i += 1) {
+        VulkanTextureContainer *container = (VulkanTextureContainer *)colorTargetInfos[i].texture;
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_FetchTextureSubresource(
             container,
-            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : color_attachment_infos[i].layer_or_depth_plane,
-            color_attachment_infos[i].mip_level);
+            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorTargetInfos[i].layer_or_depth_plane,
+            colorTargetInfos[i].mip_level);
 
         Uint32 rtvIndex =
-            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? color_attachment_infos[i].layer_or_depth_plane : 0;
+            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? colorTargetInfos[i].layer_or_depth_plane : 0;
 
         imageViewAttachments[attachmentCount] =
             subresource->renderTargetViews[rtvIndex];
@@ -7417,9 +7417,9 @@ static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
         }
     }
 
-    if (depth_stencil_attachment_info != NULL) {
+    if (depthStencilTargetInfo != NULL) {
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_FetchTextureSubresource(
-            (VulkanTextureContainer *)depth_stencil_attachment_info->texture,
+            (VulkanTextureContainer *)depthStencilTargetInfo->texture,
             0,
             0);
         imageViewAttachments[attachmentCount] = subresource->depthStencilView;
@@ -7430,7 +7430,7 @@ static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
     framebufferInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
     framebufferInfo.pNext = NULL;
     framebufferInfo.flags = 0;
-    framebufferInfo.renderPass = render_pass;
+    framebufferInfo.renderPass = renderPass;
     framebufferInfo.attachmentCount = attachmentCount;
     framebufferInfo.pAttachments = imageViewAttachments;
     framebufferInfo.width = key.width;
@@ -7466,15 +7466,15 @@ static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
 }
 
 static void VULKAN_INTERNAL_SetCurrentViewport(
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     const SDL_GPUViewport *viewport)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
 
     vulkanCommandBuffer->currentViewport.x = viewport->x;
     vulkanCommandBuffer->currentViewport.width = viewport->w;
-    vulkanCommandBuffer->currentViewport.minDepth = viewport->minDepth;
-    vulkanCommandBuffer->currentViewport.maxDepth = viewport->maxDepth;
+    vulkanCommandBuffer->currentViewport.minDepth = viewport->min_depth;
+    vulkanCommandBuffer->currentViewport.maxDepth = viewport->max_depth;
 
     // Viewport flip for consistency with other backends
     // FIXME: need moltenVK hack
@@ -7483,10 +7483,10 @@ static void VULKAN_INTERNAL_SetCurrentViewport(
 }
 
 static void VULKAN_SetViewport(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUViewport *viewport)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_SetCurrentViewport(
@@ -7494,7 +7494,7 @@ static void VULKAN_SetViewport(
         viewport);
 
     renderer->vkCmdSetViewport(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         0,
         1,
         &vulkanCommandBuffer->currentViewport);
@@ -7511,10 +7511,10 @@ static void VULKAN_INTERNAL_SetCurrentScissor(
 }
 
 static void VULKAN_SetScissor(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_Rect *scissor)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_SetCurrentScissor(
@@ -7522,7 +7522,7 @@ static void VULKAN_SetScissor(
         scissor);
 
     renderer->vkCmdSetScissor(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         0,
         1,
         &vulkanCommandBuffer->currentScissor);
@@ -7530,28 +7530,28 @@ static void VULKAN_SetScissor(
 
 static void VULKAN_INTERNAL_SetCurrentBlendConstants(
     VulkanCommandBuffer *vulkanCommandBuffer,
-    SDL_FColor blend_constants)
+    SDL_FColor blendConstants)
 {
-    vulkanCommandBuffer->blend_constants[0] = blend_constants.r;
-    vulkanCommandBuffer->blend_constants[1] = blend_constants.g;
-    vulkanCommandBuffer->blend_constants[2] = blend_constants.b;
-    vulkanCommandBuffer->blend_constants[3] = blend_constants.a;
+    vulkanCommandBuffer->blendConstants[0] = blendConstants.r;
+    vulkanCommandBuffer->blendConstants[1] = blendConstants.g;
+    vulkanCommandBuffer->blendConstants[2] = blendConstants.b;
+    vulkanCommandBuffer->blendConstants[3] = blendConstants.a;
 }
 
 static void VULKAN_SetBlendConstants(
-    SDL_GPUCommandBuffer *command_buffer,
-    SDL_FColor blend_constants)
+    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_FColor blendConstants)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_SetCurrentBlendConstants(
         vulkanCommandBuffer,
-        blend_constants);
+        blendConstants);
 
     renderer->vkCmdSetBlendConstants(
-        vulkanCommandBuffer->command_buffer,
-        vulkanCommandBuffer->blend_constants);
+        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->blendConstants);
 }
 
 static void VULKAN_INTERNAL_SetCurrentStencilReference(
@@ -7562,10 +7562,10 @@ static void VULKAN_INTERNAL_SetCurrentStencilReference(
 }
 
 static void VULKAN_SetStencilReference(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     Uint8 reference)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_SetCurrentStencilReference(
@@ -7573,27 +7573,27 @@ static void VULKAN_SetStencilReference(
         reference);
 
     renderer->vkCmdSetStencilReference(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         VK_STENCIL_FACE_FRONT_AND_BACK,
         reference);
 }
 
 static void VULKAN_BindVertexSamplers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
+    Uint32 numBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)texture_sampler_bindings[i].texture;
-        vulkanCommandBuffer->vertexSamplerTextures[first_slot + i] = textureContainer->activeTextureHandle->vulkanTexture;
-        vulkanCommandBuffer->vertexSamplers[first_slot + i] = (VulkanSampler *)texture_sampler_bindings[i].sampler;
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)textureSamplerBindings[i].texture;
+        vulkanCommandBuffer->vertexSamplerTextures[firstSlot + i] = textureContainer->activeTextureHandle->vulkanTexture;
+        vulkanCommandBuffer->vertexSamplers[firstSlot + i] = (VulkanSampler *)textureSamplerBindings[i].sampler;
 
         VULKAN_INTERNAL_TrackSampler(
             vulkanCommandBuffer,
-            (VulkanSampler *)texture_sampler_bindings[i].sampler);
+            (VulkanSampler *)textureSamplerBindings[i].sampler);
 
         VULKAN_INTERNAL_TrackTexture(
             vulkanCommandBuffer,
@@ -7604,17 +7604,17 @@ static void VULKAN_BindVertexSamplers(
 }
 
 static void VULKAN_BindVertexStorageTextures(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUTexture *const *storage_textures,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUTexture *const *storageTextures,
+    Uint32 numBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storage_textures[i];
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storageTextures[i];
 
-        vulkanCommandBuffer->vertexStorageTextures[first_slot + i] = textureContainer->activeTextureHandle->vulkanTexture;
+        vulkanCommandBuffer->vertexStorageTextures[firstSlot + i] = textureContainer->activeTextureHandle->vulkanTexture;
 
         VULKAN_INTERNAL_TrackTexture(
             vulkanCommandBuffer,
@@ -7625,19 +7625,19 @@ static void VULKAN_BindVertexStorageTextures(
 }
 
 static void VULKAN_BindVertexStorageBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUBuffer *const *storage_buffers,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUBuffer *const *storageBuffers,
+    Uint32 numBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanBufferContainer *bufferContainer;
     Uint32 i;
 
-    for (i = 0; i < num_bindings; i += 1) {
-        bufferContainer = (VulkanBufferContainer *)storage_buffers[i];
+    for (i = 0; i < numBindings; i += 1) {
+        bufferContainer = (VulkanBufferContainer *)storageBuffers[i];
 
-        vulkanCommandBuffer->vertexStorageBuffers[first_slot + i] = bufferContainer->activeBufferHandle->vulkanBuffer;
+        vulkanCommandBuffer->vertexStorageBuffers[firstSlot + i] = bufferContainer->activeBufferHandle->vulkanBuffer;
 
         VULKAN_INTERNAL_TrackBuffer(
             vulkanCommandBuffer,
@@ -7648,21 +7648,21 @@ static void VULKAN_BindVertexStorageBuffers(
 }
 
 static void VULKAN_BindFragmentSamplers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
+    Uint32 numBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)texture_sampler_bindings[i].texture;
-        vulkanCommandBuffer->fragmentSamplerTextures[first_slot + i] = textureContainer->activeTextureHandle->vulkanTexture;
-        vulkanCommandBuffer->fragmentSamplers[first_slot + i] = (VulkanSampler *)texture_sampler_bindings[i].sampler;
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)textureSamplerBindings[i].texture;
+        vulkanCommandBuffer->fragmentSamplerTextures[firstSlot + i] = textureContainer->activeTextureHandle->vulkanTexture;
+        vulkanCommandBuffer->fragmentSamplers[firstSlot + i] = (VulkanSampler *)textureSamplerBindings[i].sampler;
 
         VULKAN_INTERNAL_TrackSampler(
             vulkanCommandBuffer,
-            (VulkanSampler *)texture_sampler_bindings[i].sampler);
+            (VulkanSampler *)textureSamplerBindings[i].sampler);
 
         VULKAN_INTERNAL_TrackTexture(
             vulkanCommandBuffer,
@@ -7673,17 +7673,17 @@ static void VULKAN_BindFragmentSamplers(
 }
 
 static void VULKAN_BindFragmentStorageTextures(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUTexture *const *storage_textures,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUTexture *const *storageTextures,
+    Uint32 numBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storage_textures[i];
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storageTextures[i];
 
-        vulkanCommandBuffer->fragmentStorageTextures[first_slot + i] =
+        vulkanCommandBuffer->fragmentStorageTextures[firstSlot + i] =
             textureContainer->activeTextureHandle->vulkanTexture;
 
         VULKAN_INTERNAL_TrackTexture(
@@ -7695,19 +7695,19 @@ static void VULKAN_BindFragmentStorageTextures(
 }
 
 static void VULKAN_BindFragmentStorageBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUBuffer *const *storage_buffers,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUBuffer *const *storageBuffers,
+    Uint32 numBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanBufferContainer *bufferContainer;
     Uint32 i;
 
-    for (i = 0; i < num_bindings; i += 1) {
-        bufferContainer = (VulkanBufferContainer *)storage_buffers[i];
+    for (i = 0; i < numBindings; i += 1) {
+        bufferContainer = (VulkanBufferContainer *)storageBuffers[i];
 
-        vulkanCommandBuffer->fragmentStorageBuffers[first_slot + i] = bufferContainer->activeBufferHandle->vulkanBuffer;
+        vulkanCommandBuffer->fragmentStorageBuffers[firstSlot + i] = bufferContainer->activeBufferHandle->vulkanBuffer;
 
         VULKAN_INTERNAL_TrackBuffer(
             vulkanCommandBuffer,
@@ -7718,9 +7718,9 @@ static void VULKAN_BindFragmentStorageBuffers(
 }
 
 static VulkanUniformBuffer *VULKAN_INTERNAL_AcquireUniformBufferFromPool(
-    VulkanCommandBuffer *command_buffer)
+    VulkanCommandBuffer *commandBuffer)
 {
-    VulkanRenderer *renderer = command_buffer->renderer;
+    VulkanRenderer *renderer = commandBuffer->renderer;
     VulkanUniformBuffer *uniformBuffer;
 
     SDL_LockMutex(renderer->acquireUniformBufferLock);
@@ -7736,7 +7736,7 @@ static VulkanUniformBuffer *VULKAN_INTERNAL_AcquireUniformBufferFromPool(
 
     SDL_UnlockMutex(renderer->acquireUniformBufferLock);
 
-    VULKAN_INTERNAL_TrackUniformBuffer(command_buffer, uniformBuffer);
+    VULKAN_INTERNAL_TrackUniformBuffer(commandBuffer, uniformBuffer);
 
     return uniformBuffer;
 }
@@ -7760,37 +7760,37 @@ static void VULKAN_INTERNAL_ReturnUniformBufferToPool(
 }
 
 static void VULKAN_INTERNAL_PushUniformData(
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanUniformBufferStage uniformBufferStage,
-    Uint32 slot_index,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
     Uint32 blockSize =
         VULKAN_INTERNAL_NextHighestAlignment32(
             length,
-            command_buffer->renderer->minUBOAlignment);
+            commandBuffer->renderer->minUBOAlignment);
 
     VulkanUniformBuffer *uniformBuffer;
 
     if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_VERTEX) {
-        if (command_buffer->vertexUniformBuffers[slot_index] == NULL) {
-            command_buffer->vertexUniformBuffers[slot_index] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
-                command_buffer);
+        if (commandBuffer->vertexUniformBuffers[slotIndex] == NULL) {
+            commandBuffer->vertexUniformBuffers[slotIndex] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
+                commandBuffer);
         }
-        uniformBuffer = command_buffer->vertexUniformBuffers[slot_index];
+        uniformBuffer = commandBuffer->vertexUniformBuffers[slotIndex];
     } else if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_FRAGMENT) {
-        if (command_buffer->fragmentUniformBuffers[slot_index] == NULL) {
-            command_buffer->fragmentUniformBuffers[slot_index] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
-                command_buffer);
+        if (commandBuffer->fragmentUniformBuffers[slotIndex] == NULL) {
+            commandBuffer->fragmentUniformBuffers[slotIndex] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
+                commandBuffer);
         }
-        uniformBuffer = command_buffer->fragmentUniformBuffers[slot_index];
+        uniformBuffer = commandBuffer->fragmentUniformBuffers[slotIndex];
     } else if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_COMPUTE) {
-        if (command_buffer->computeUniformBuffers[slot_index] == NULL) {
-            command_buffer->computeUniformBuffers[slot_index] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
-                command_buffer);
+        if (commandBuffer->computeUniformBuffers[slotIndex] == NULL) {
+            commandBuffer->computeUniformBuffers[slotIndex] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
+                commandBuffer);
         }
-        uniformBuffer = command_buffer->computeUniformBuffers[slot_index];
+        uniformBuffer = commandBuffer->computeUniformBuffers[slotIndex];
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
         return;
@@ -7798,20 +7798,20 @@ static void VULKAN_INTERNAL_PushUniformData(
 
     // If there is no more room, acquire a new uniform buffer
     if (uniformBuffer->writeOffset + blockSize + MAX_UBO_SECTION_SIZE >= uniformBuffer->bufferHandle->vulkanBuffer->size) {
-        uniformBuffer = VULKAN_INTERNAL_AcquireUniformBufferFromPool(command_buffer);
+        uniformBuffer = VULKAN_INTERNAL_AcquireUniformBufferFromPool(commandBuffer);
 
         uniformBuffer->drawOffset = 0;
         uniformBuffer->writeOffset = 0;
 
         if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_VERTEX) {
-            command_buffer->vertexUniformBuffers[slot_index] = uniformBuffer;
-            command_buffer->needNewVertexUniformDescriptorSet = true;
+            commandBuffer->vertexUniformBuffers[slotIndex] = uniformBuffer;
+            commandBuffer->needNewVertexUniformDescriptorSet = true;
         } else if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_FRAGMENT) {
-            command_buffer->fragmentUniformBuffers[slot_index] = uniformBuffer;
-            command_buffer->needNewFragmentUniformDescriptorSet = true;
+            commandBuffer->fragmentUniformBuffers[slotIndex] = uniformBuffer;
+            commandBuffer->needNewFragmentUniformDescriptorSet = true;
         } else if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_COMPUTE) {
-            command_buffer->computeUniformBuffers[slot_index] = uniformBuffer;
-            command_buffer->needNewComputeUniformDescriptorSet = true;
+            commandBuffer->computeUniformBuffers[slotIndex] = uniformBuffer;
+            commandBuffer->needNewComputeUniformDescriptorSet = true;
         } else {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
             return;
@@ -7833,11 +7833,11 @@ static void VULKAN_INTERNAL_PushUniformData(
     uniformBuffer->writeOffset += blockSize;
 
     if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_VERTEX) {
-        command_buffer->needNewVertexUniformOffsets = true;
+        commandBuffer->needNewVertexUniformOffsets = true;
     } else if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_FRAGMENT) {
-        command_buffer->needNewFragmentUniformOffsets = true;
+        commandBuffer->needNewFragmentUniformOffsets = true;
     } else if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_COMPUTE) {
-        command_buffer->needNewComputeUniformOffsets = true;
+        commandBuffer->needNewComputeUniformOffsets = true;
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
         return;
@@ -7845,19 +7845,19 @@ static void VULKAN_INTERNAL_PushUniformData(
 }
 
 static void VULKAN_BeginRenderPass(
-    SDL_GPUCommandBuffer *command_buffer,
-    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
-    Uint32 num_color_attachments,
-    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info)
+    SDL_GPUCommandBuffer *commandBuffer,
+    const SDL_GPUColorTargetInfo *colorTargetInfos,
+    Uint32 numColorTargets,
+    const SDL_GPUDepthStencilTargetInfo *depthStencilTargetInfo)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
-    VkRenderPass render_pass;
+    VkRenderPass renderPass;
     VulkanFramebuffer *framebuffer;
 
     Uint32 w, h;
     VkClearValue *clearValues;
-    Uint32 clearCount = num_color_attachments;
+    Uint32 clearCount = numColorTargets;
     Uint32 multisampleAttachmentCount = 0;
     Uint32 totalColorAttachmentCount = 0;
     Uint32 i;
@@ -7866,11 +7866,11 @@ static void VULKAN_BeginRenderPass(
     Uint32 framebufferWidth = UINT32_MAX;
     Uint32 framebufferHeight = UINT32_MAX;
 
-    for (i = 0; i < num_color_attachments; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)color_attachment_infos[i].texture;
+    for (i = 0; i < numColorTargets; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)colorTargetInfos[i].texture;
 
-        w = textureContainer->activeTextureHandle->vulkanTexture->dimensions.width >> color_attachment_infos[i].mip_level;
-        h = textureContainer->activeTextureHandle->vulkanTexture->dimensions.height >> color_attachment_infos[i].mip_level;
+        w = textureContainer->activeTextureHandle->vulkanTexture->dimensions.width >> colorTargetInfos[i].mip_level;
+        h = textureContainer->activeTextureHandle->vulkanTexture->dimensions.height >> colorTargetInfos[i].mip_level;
 
         // The framebuffer cannot be larger than the smallest attachment.
 
@@ -7883,14 +7883,14 @@ static void VULKAN_BeginRenderPass(
         }
 
         // FIXME: validate this in gpu.c
-        if (!(textureContainer->header.info.usage_flags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET)) {
+        if (!(textureContainer->header.info.usage & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET)) {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Color attachment texture was not designated as a target!");
             return;
         }
     }
 
-    if (depth_stencil_attachment_info != NULL) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)depth_stencil_attachment_info->texture;
+    if (depthStencilTargetInfo != NULL) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)depthStencilTargetInfo->texture;
 
         w = textureContainer->activeTextureHandle->vulkanTexture->dimensions.width;
         h = textureContainer->activeTextureHandle->vulkanTexture->dimensions.height;
@@ -7906,21 +7906,21 @@ static void VULKAN_BeginRenderPass(
         }
 
         // FIXME: validate this in gpu.c
-        if (!(textureContainer->header.info.usage_flags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET)) {
+        if (!(textureContainer->header.info.usage & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET)) {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Depth stencil attachment texture was not designated as a target!");
             return;
         }
     }
 
-    for (i = 0; i < num_color_attachments; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)color_attachment_infos[i].texture;
+    for (i = 0; i < numColorTargets; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)colorTargetInfos[i].texture;
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_PrepareTextureSubresourceForWrite(
             renderer,
             vulkanCommandBuffer,
             textureContainer,
-            textureContainer->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : color_attachment_infos[i].layer_or_depth_plane,
-            color_attachment_infos[i].mip_level,
-            color_attachment_infos[i].cycle,
+            textureContainer->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorTargetInfos[i].layer_or_depth_plane,
+            colorTargetInfos[i].mip_level,
+            colorTargetInfos[i].cycle,
             VULKAN_TEXTURE_USAGE_MODE_COLOR_ATTACHMENT);
 
         if (subresource->msaaTexHandle != NULL) {
@@ -7941,17 +7941,17 @@ static void VULKAN_BeginRenderPass(
         // TODO: do we need to track the msaa texture? or is it implicitly only used when the regular texture is used?
     }
 
-    vulkanCommandBuffer->colorAttachmentSubresourceCount = num_color_attachments;
+    vulkanCommandBuffer->colorAttachmentSubresourceCount = numColorTargets;
 
-    if (depth_stencil_attachment_info != NULL) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)depth_stencil_attachment_info->texture;
+    if (depthStencilTargetInfo != NULL) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)depthStencilTargetInfo->texture;
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_PrepareTextureSubresourceForWrite(
             renderer,
             vulkanCommandBuffer,
             textureContainer,
             0,
             0,
-            depth_stencil_attachment_info->cycle,
+            depthStencilTargetInfo->cycle,
             VULKAN_TEXTURE_USAGE_MODE_DEPTH_STENCIL_ATTACHMENT);
 
         clearCount += 1;
@@ -7963,19 +7963,19 @@ static void VULKAN_BeginRenderPass(
 
     // Fetch required render objects
 
-    render_pass = VULKAN_INTERNAL_FetchRenderPass(
+    renderPass = VULKAN_INTERNAL_FetchRenderPass(
         renderer,
         vulkanCommandBuffer,
-        color_attachment_infos,
-        num_color_attachments,
-        depth_stencil_attachment_info);
+        colorTargetInfos,
+        numColorTargets,
+        depthStencilTargetInfo);
 
     framebuffer = VULKAN_INTERNAL_FetchFramebuffer(
         renderer,
-        render_pass,
-        color_attachment_infos,
-        num_color_attachments,
-        depth_stencil_attachment_info,
+        renderPass,
+        colorTargetInfos,
+        numColorTargets,
+        depthStencilTargetInfo,
         framebufferWidth,
         framebufferHeight);
 
@@ -7985,40 +7985,40 @@ static void VULKAN_BeginRenderPass(
 
     clearValues = SDL_stack_alloc(VkClearValue, clearCount);
 
-    totalColorAttachmentCount = num_color_attachments + multisampleAttachmentCount;
+    totalColorAttachmentCount = numColorTargets + multisampleAttachmentCount;
 
     for (i = 0; i < totalColorAttachmentCount; i += 1) {
-        clearValues[i].color.float32[0] = color_attachment_infos[i].clear_color.r;
-        clearValues[i].color.float32[1] = color_attachment_infos[i].clear_color.g;
-        clearValues[i].color.float32[2] = color_attachment_infos[i].clear_color.b;
-        clearValues[i].color.float32[3] = color_attachment_infos[i].clear_color.a;
+        clearValues[i].color.float32[0] = colorTargetInfos[i].clear_color.r;
+        clearValues[i].color.float32[1] = colorTargetInfos[i].clear_color.g;
+        clearValues[i].color.float32[2] = colorTargetInfos[i].clear_color.b;
+        clearValues[i].color.float32[3] = colorTargetInfos[i].clear_color.a;
 
-        VulkanTextureContainer *container = (VulkanTextureContainer *)color_attachment_infos[i].texture;
+        VulkanTextureContainer *container = (VulkanTextureContainer *)colorTargetInfos[i].texture;
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_FetchTextureSubresource(
             container,
-            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : color_attachment_infos[i].layer_or_depth_plane,
-            color_attachment_infos[i].mip_level);
+            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorTargetInfos[i].layer_or_depth_plane,
+            colorTargetInfos[i].mip_level);
 
-        if (subresource->parent->sample_count > VK_SAMPLE_COUNT_1_BIT) {
-            clearValues[i + 1].color.float32[0] = color_attachment_infos[i].clear_color.r;
-            clearValues[i + 1].color.float32[1] = color_attachment_infos[i].clear_color.g;
-            clearValues[i + 1].color.float32[2] = color_attachment_infos[i].clear_color.b;
-            clearValues[i + 1].color.float32[3] = color_attachment_infos[i].clear_color.a;
+        if (subresource->parent->sampleCount > VK_SAMPLE_COUNT_1_BIT) {
+            clearValues[i + 1].color.float32[0] = colorTargetInfos[i].clear_color.r;
+            clearValues[i + 1].color.float32[1] = colorTargetInfos[i].clear_color.g;
+            clearValues[i + 1].color.float32[2] = colorTargetInfos[i].clear_color.b;
+            clearValues[i + 1].color.float32[3] = colorTargetInfos[i].clear_color.a;
             i += 1;
         }
     }
 
-    if (depth_stencil_attachment_info != NULL) {
+    if (depthStencilTargetInfo != NULL) {
         clearValues[totalColorAttachmentCount].depthStencil.depth =
-            depth_stencil_attachment_info->clear_value.depth;
+            depthStencilTargetInfo->clear_value.depth;
         clearValues[totalColorAttachmentCount].depthStencil.stencil =
-            depth_stencil_attachment_info->clear_value.stencil;
+            depthStencilTargetInfo->clear_value.stencil;
     }
 
     VkRenderPassBeginInfo renderPassBeginInfo;
     renderPassBeginInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
     renderPassBeginInfo.pNext = NULL;
-    renderPassBeginInfo.renderPass = render_pass;
+    renderPassBeginInfo.renderPass = renderPass;
     renderPassBeginInfo.framebuffer = framebuffer->framebuffer;
     renderPassBeginInfo.pClearValues = clearValues;
     renderPassBeginInfo.clearValueCount = clearCount;
@@ -8028,7 +8028,7 @@ static void VULKAN_BeginRenderPass(
     renderPassBeginInfo.renderArea.offset.y = 0;
 
     renderer->vkCmdBeginRenderPass(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         &renderPassBeginInfo,
         VK_SUBPASS_CONTENTS_INLINE);
 
@@ -8040,8 +8040,8 @@ static void VULKAN_BeginRenderPass(
     defaultViewport.y = 0;
     defaultViewport.w = (float)framebufferWidth;
     defaultViewport.h = (float)framebufferHeight;
-    defaultViewport.minDepth = 0;
-    defaultViewport.maxDepth = 1;
+    defaultViewport.min_depth = 0;
+    defaultViewport.max_depth = 1;
 
     VULKAN_INTERNAL_SetCurrentViewport(
         vulkanCommandBuffer,
@@ -8066,15 +8066,15 @@ static void VULKAN_BeginRenderPass(
 }
 
 static void VULKAN_BindGraphicsPipeline(
-    SDL_GPUCommandBuffer *command_buffer,
-    SDL_GPUGraphicsPipeline *graphics_pipeline)
+    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUGraphicsPipeline *graphicsPipeline)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
-    VulkanGraphicsPipeline *pipeline = (VulkanGraphicsPipeline *)graphics_pipeline;
+    VulkanGraphicsPipeline *pipeline = (VulkanGraphicsPipeline *)graphicsPipeline;
 
     renderer->vkCmdBindPipeline(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         VK_PIPELINE_BIND_POINT_GRAPHICS,
         pipeline->pipeline);
 
@@ -8083,23 +8083,23 @@ static void VULKAN_BindGraphicsPipeline(
     VULKAN_INTERNAL_TrackGraphicsPipeline(vulkanCommandBuffer, pipeline);
 
     renderer->vkCmdSetViewport(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         0,
         1,
         &vulkanCommandBuffer->currentViewport);
 
     renderer->vkCmdSetScissor(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         0,
         1,
         &vulkanCommandBuffer->currentScissor);
 
     renderer->vkCmdSetBlendConstants(
-        vulkanCommandBuffer->command_buffer,
-        vulkanCommandBuffer->blend_constants);
+        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->blendConstants);
 
     renderer->vkCmdSetStencilReference(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         VK_STENCIL_FACE_FRONT_AND_BACK,
         vulkanCommandBuffer->stencilRef);
 
@@ -8128,19 +8128,19 @@ static void VULKAN_BindGraphicsPipeline(
 }
 
 static void VULKAN_BindVertexBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_binding,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstBinding,
     const SDL_GPUBufferBinding *bindings,
-    Uint32 num_bindings)
+    Uint32 numBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBuffer *currentVulkanBuffer;
-    VkBuffer *buffers = SDL_stack_alloc(VkBuffer, num_bindings);
-    VkDeviceSize *offsets = SDL_stack_alloc(VkDeviceSize, num_bindings);
+    VkBuffer *buffers = SDL_stack_alloc(VkBuffer, numBindings);
+    VkDeviceSize *offsets = SDL_stack_alloc(VkDeviceSize, numBindings);
     Uint32 i;
 
-    for (i = 0; i < num_bindings; i += 1) {
+    for (i = 0; i < numBindings; i += 1) {
         currentVulkanBuffer = ((VulkanBufferContainer *)bindings[i].buffer)->activeBufferHandle->vulkanBuffer;
         buffers[i] = currentVulkanBuffer->buffer;
         offsets[i] = (VkDeviceSize)bindings[i].offset;
@@ -8148,9 +8148,9 @@ static void VULKAN_BindVertexBuffers(
     }
 
     renderer->vkCmdBindVertexBuffers(
-        vulkanCommandBuffer->command_buffer,
-        first_binding,
-        num_bindings,
+        vulkanCommandBuffer->commandBuffer,
+        firstBinding,
+        numBindings,
         buffers,
         offsets);
 
@@ -8159,64 +8159,64 @@ static void VULKAN_BindVertexBuffers(
 }
 
 static void VULKAN_BindIndexBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
-    const SDL_GPUBufferBinding *pBinding,
-    SDL_GPUIndexElementSize index_element_size)
+    SDL_GPUCommandBuffer *commandBuffer,
+    const SDL_GPUBufferBinding *binding,
+    SDL_GPUIndexElementSize indexElementSize)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
-    VulkanBuffer *vulkanBuffer = ((VulkanBufferContainer *)pBinding->buffer)->activeBufferHandle->vulkanBuffer;
+    VulkanBuffer *vulkanBuffer = ((VulkanBufferContainer *)binding->buffer)->activeBufferHandle->vulkanBuffer;
 
     VULKAN_INTERNAL_TrackBuffer(vulkanCommandBuffer, vulkanBuffer);
 
     renderer->vkCmdBindIndexBuffer(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         vulkanBuffer->buffer,
-        (VkDeviceSize)pBinding->offset,
-        SDLToVK_IndexType[index_element_size]);
+        (VkDeviceSize)binding->offset,
+        SDLToVK_IndexType[indexElementSize]);
 }
 
 static void VULKAN_PushVertexUniformData(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 slot_index,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
 
     VULKAN_INTERNAL_PushUniformData(
         vulkanCommandBuffer,
         VULKAN_UNIFORM_BUFFER_STAGE_VERTEX,
-        slot_index,
+        slotIndex,
         data,
         length);
 }
 
 static void VULKAN_PushFragmentUniformData(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 slot_index,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
 
     VULKAN_INTERNAL_PushUniformData(
         vulkanCommandBuffer,
         VULKAN_UNIFORM_BUFFER_STAGE_FRAGMENT,
-        slot_index,
+        slotIndex,
         data,
         length);
 }
 
 static void VULKAN_EndRenderPass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     Uint32 i;
 
     renderer->vkCmdEndRenderPass(
-        vulkanCommandBuffer->command_buffer);
+        vulkanCommandBuffer->commandBuffer);
 
     for (i = 0; i < vulkanCommandBuffer->colorAttachmentSubresourceCount; i += 1) {
         VULKAN_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
@@ -8259,23 +8259,23 @@ static void VULKAN_EndRenderPass(
 }
 
 static void VULKAN_BeginComputePass(
-    SDL_GPUCommandBuffer *command_buffer,
-    const SDL_GPUStorageTextureWriteOnlyBinding *storage_texture_bindings,
-    Uint32 num_storage_texture_bindings,
-    const SDL_GPUStorageBufferWriteOnlyBinding *storage_buffer_bindings,
-    Uint32 num_storage_buffer_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    const SDL_GPUStorageTextureWriteOnlyBinding *storageTextureBindings,
+    Uint32 numStorageTextureBindings,
+    const SDL_GPUStorageBufferWriteOnlyBinding *storageBufferBindings,
+    Uint32 numStorageBufferBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanBufferContainer *bufferContainer;
     VulkanBuffer *buffer;
     Uint32 i;
 
-    vulkanCommandBuffer->writeOnlyComputeStorageTextureSubresourceCount = num_storage_texture_bindings;
+    vulkanCommandBuffer->writeOnlyComputeStorageTextureSubresourceCount = numStorageTextureBindings;
 
-    for (i = 0; i < num_storage_texture_bindings; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storage_texture_bindings[i].texture;
-        if (!(textureContainer->activeTextureHandle->vulkanTexture->usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE)) {
+    for (i = 0; i < numStorageTextureBindings; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storageTextureBindings[i].texture;
+        if (!(textureContainer->activeTextureHandle->vulkanTexture->usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE)) {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Attempted to bind read-only texture as compute write texture");
         }
 
@@ -8283,9 +8283,9 @@ static void VULKAN_BeginComputePass(
             renderer,
             vulkanCommandBuffer,
             textureContainer,
-            storage_texture_bindings[i].layer,
-            storage_texture_bindings[i].mip_level,
-            storage_texture_bindings[i].cycle,
+            storageTextureBindings[i].layer,
+            storageTextureBindings[i].mip_level,
+            storageTextureBindings[i].cycle,
             VULKAN_TEXTURE_USAGE_MODE_COMPUTE_STORAGE_READ_WRITE);
 
         vulkanCommandBuffer->writeOnlyComputeStorageTextureSubresources[i] = subresource;
@@ -8295,13 +8295,13 @@ static void VULKAN_BeginComputePass(
             subresource->parent);
     }
 
-    for (i = 0; i < num_storage_buffer_bindings; i += 1) {
-        bufferContainer = (VulkanBufferContainer *)storage_buffer_bindings[i].buffer;
+    for (i = 0; i < numStorageBufferBindings; i += 1) {
+        bufferContainer = (VulkanBufferContainer *)storageBufferBindings[i].buffer;
         buffer = VULKAN_INTERNAL_PrepareBufferForWrite(
             renderer,
             vulkanCommandBuffer,
             bufferContainer,
-            storage_buffer_bindings[i].cycle,
+            storageBufferBindings[i].cycle,
             VULKAN_BUFFER_USAGE_MODE_COMPUTE_STORAGE_READ);
 
         vulkanCommandBuffer->writeOnlyComputeStorageBuffers[i] = buffer;
@@ -8313,15 +8313,15 @@ static void VULKAN_BeginComputePass(
 }
 
 static void VULKAN_BindComputePipeline(
-    SDL_GPUCommandBuffer *command_buffer,
-    SDL_GPUComputePipeline *compute_pipeline)
+    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUComputePipeline *computePipeline)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
-    VulkanComputePipeline *vulkanComputePipeline = (VulkanComputePipeline *)compute_pipeline;
+    VulkanComputePipeline *vulkanComputePipeline = (VulkanComputePipeline *)computePipeline;
 
     renderer->vkCmdBindPipeline(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         VK_PIPELINE_BIND_POINT_COMPUTE,
         vulkanComputePipeline->pipeline);
 
@@ -8330,7 +8330,7 @@ static void VULKAN_BindComputePipeline(
     VULKAN_INTERNAL_TrackComputePipeline(vulkanCommandBuffer, vulkanComputePipeline);
 
     // Acquire uniform buffers if necessary
-    for (Uint32 i = 0; i < vulkanComputePipeline->resourceLayout.num_uniform_buffers; i += 1) {
+    for (Uint32 i = 0; i < vulkanComputePipeline->resourceLayout.numUniformBuffers; i += 1) {
         if (vulkanCommandBuffer->computeUniformBuffers[i] == NULL) {
             vulkanCommandBuffer->computeUniformBuffers[i] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
                 vulkanCommandBuffer);
@@ -8345,26 +8345,26 @@ static void VULKAN_BindComputePipeline(
 }
 
 static void VULKAN_BindComputeStorageTextures(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUTexture *const *storage_textures,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUTexture *const *storageTextures,
+    Uint32 numBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
 
-    for (Uint32 i = 0; i < num_bindings; i += 1) {
-        if (vulkanCommandBuffer->readOnlyComputeStorageTextures[first_slot + i] != NULL) {
+    for (Uint32 i = 0; i < numBindings; i += 1) {
+        if (vulkanCommandBuffer->readOnlyComputeStorageTextures[firstSlot + i] != NULL) {
             VULKAN_INTERNAL_TextureTransitionToDefaultUsage(
                 renderer,
                 vulkanCommandBuffer,
                 VULKAN_TEXTURE_USAGE_MODE_COMPUTE_STORAGE_READ,
-                vulkanCommandBuffer->readOnlyComputeStorageTextures[first_slot + i]);
+                vulkanCommandBuffer->readOnlyComputeStorageTextures[firstSlot + i]);
         }
 
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storage_textures[i];
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storageTextures[i];
 
-        vulkanCommandBuffer->readOnlyComputeStorageTextures[first_slot + i] =
+        vulkanCommandBuffer->readOnlyComputeStorageTextures[firstSlot + i] =
             textureContainer->activeTextureHandle->vulkanTexture;
 
         VULKAN_INTERNAL_TextureTransitionFromDefaultUsage(
@@ -8382,28 +8382,28 @@ static void VULKAN_BindComputeStorageTextures(
 }
 
 static void VULKAN_BindComputeStorageBuffers(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 first_slot,
-    SDL_GPUBuffer *const *storage_buffers,
-    Uint32 num_bindings)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 firstSlot,
+    SDL_GPUBuffer *const *storageBuffers,
+    Uint32 numBindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanBufferContainer *bufferContainer;
     Uint32 i;
 
-    for (i = 0; i < num_bindings; i += 1) {
-        if (vulkanCommandBuffer->readOnlyComputeStorageBuffers[first_slot + i] != NULL) {
+    for (i = 0; i < numBindings; i += 1) {
+        if (vulkanCommandBuffer->readOnlyComputeStorageBuffers[firstSlot + i] != NULL) {
             VULKAN_INTERNAL_BufferTransitionToDefaultUsage(
                 renderer,
                 vulkanCommandBuffer,
                 VULKAN_BUFFER_USAGE_MODE_COMPUTE_STORAGE_READ,
-                vulkanCommandBuffer->readOnlyComputeStorageBuffers[first_slot + i]);
+                vulkanCommandBuffer->readOnlyComputeStorageBuffers[firstSlot + i]);
         }
 
-        bufferContainer = (VulkanBufferContainer *)storage_buffers[i];
+        bufferContainer = (VulkanBufferContainer *)storageBuffers[i];
 
-        vulkanCommandBuffer->readOnlyComputeStorageBuffers[first_slot + i] = bufferContainer->activeBufferHandle->vulkanBuffer;
+        vulkanCommandBuffer->readOnlyComputeStorageBuffers[firstSlot + i] = bufferContainer->activeBufferHandle->vulkanBuffer;
 
         VULKAN_INTERNAL_BufferTransitionFromDefaultUsage(
             renderer,
@@ -8420,24 +8420,24 @@ static void VULKAN_BindComputeStorageBuffers(
 }
 
 static void VULKAN_PushComputeUniformData(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 slot_index,
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 slotIndex,
     const void *data,
     Uint32 length)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
 
     VULKAN_INTERNAL_PushUniformData(
         vulkanCommandBuffer,
         VULKAN_UNIFORM_BUFFER_STAGE_COMPUTE,
-        slot_index,
+        slotIndex,
         data,
         length);
 }
 
 static void VULKAN_INTERNAL_BindComputeDescriptorSets(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer)
+    VulkanCommandBuffer *commandBuffer)
 {
     VulkanComputePipelineResourceLayout *resourceLayout;
     VkWriteDescriptorSet *writeDescriptorSets;
@@ -8450,22 +8450,22 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
     Uint32 imageInfoCount = 0;
     Uint32 i;
 
-    resourceLayout = &command_buffer->currentComputePipeline->resourceLayout;
+    resourceLayout = &commandBuffer->currentComputePipeline->resourceLayout;
 
-    if (command_buffer->needNewComputeReadOnlyDescriptorSet) {
+    if (commandBuffer->needNewComputeReadOnlyDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[0];
 
-        command_buffer->computeReadOnlyDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        commandBuffer->computeReadOnlyDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            command_buffer,
+            commandBuffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
             VkWriteDescriptorSet,
-            resourceLayout->num_readonly_storage_textures +
-                resourceLayout->num_readonly_storage_buffers);
+            resourceLayout->numReadonlyStorageTextures +
+                resourceLayout->numReadonlyStorageBuffers);
 
-        for (i = 0; i < resourceLayout->num_readonly_storage_textures; i += 1) {
+        for (i = 0; i < resourceLayout->numReadonlyStorageTextures; i += 1) {
             currentWriteDescriptorSet = &writeDescriptorSets[i];
             currentWriteDescriptorSet->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
             currentWriteDescriptorSet->pNext = NULL;
@@ -8473,12 +8473,12 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = command_buffer->computeReadOnlyDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->computeReadOnlyDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pBufferInfo = NULL;
 
             imageInfos[imageInfoCount].sampler = VK_NULL_HANDLE;
-            imageInfos[imageInfoCount].imageView = command_buffer->readOnlyComputeStorageTextures[i]->fullView;
+            imageInfos[imageInfoCount].imageView = commandBuffer->readOnlyComputeStorageTextures[i]->fullView;
             imageInfos[imageInfoCount].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
             currentWriteDescriptorSet->pImageInfo = &imageInfos[imageInfoCount];
@@ -8486,20 +8486,20 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
             imageInfoCount += 1;
         }
 
-        for (i = 0; i < resourceLayout->num_readonly_storage_buffers; i += 1) {
-            currentWriteDescriptorSet = &writeDescriptorSets[resourceLayout->num_readonly_storage_textures + i];
+        for (i = 0; i < resourceLayout->numReadonlyStorageBuffers; i += 1) {
+            currentWriteDescriptorSet = &writeDescriptorSets[resourceLayout->numReadonlyStorageTextures + i];
 
             currentWriteDescriptorSet->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
             currentWriteDescriptorSet->pNext = NULL;
             currentWriteDescriptorSet->descriptorCount = 1;
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
             currentWriteDescriptorSet->dstArrayElement = 0;
-            currentWriteDescriptorSet->dstBinding = resourceLayout->num_readonly_storage_textures + i;
-            currentWriteDescriptorSet->dstSet = command_buffer->computeReadOnlyDescriptorSet;
+            currentWriteDescriptorSet->dstBinding = resourceLayout->numReadonlyStorageTextures + i;
+            currentWriteDescriptorSet->dstSet = commandBuffer->computeReadOnlyDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = command_buffer->readOnlyComputeStorageBuffers[i]->buffer;
+            bufferInfos[bufferInfoCount].buffer = commandBuffer->readOnlyComputeStorageBuffers[i]->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = VK_WHOLE_SIZE;
 
@@ -8510,18 +8510,18 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
 
         renderer->vkUpdateDescriptorSets(
             renderer->logicalDevice,
-            resourceLayout->num_readonly_storage_textures + resourceLayout->num_readonly_storage_buffers,
+            resourceLayout->numReadonlyStorageTextures + resourceLayout->numReadonlyStorageBuffers,
             writeDescriptorSets,
             0,
             NULL);
 
         renderer->vkCmdBindDescriptorSets(
-            command_buffer->command_buffer,
+            commandBuffer->commandBuffer,
             VK_PIPELINE_BIND_POINT_COMPUTE,
             resourceLayout->pipelineLayout,
             0,
             1,
-            &command_buffer->computeReadOnlyDescriptorSet,
+            &commandBuffer->computeReadOnlyDescriptorSet,
             0,
             NULL);
 
@@ -8529,23 +8529,23 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        command_buffer->needNewComputeReadOnlyDescriptorSet = false;
+        commandBuffer->needNewComputeReadOnlyDescriptorSet = false;
     }
 
-    if (command_buffer->needNewComputeWriteOnlyDescriptorSet) {
+    if (commandBuffer->needNewComputeWriteOnlyDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[1];
 
-        command_buffer->computeWriteOnlyDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        commandBuffer->computeWriteOnlyDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            command_buffer,
+            commandBuffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
             VkWriteDescriptorSet,
-            resourceLayout->num_writeonly_storage_textures +
-                resourceLayout->num_writeonly_storage_buffers);
+            resourceLayout->numWriteonlyStorageTextures +
+                resourceLayout->numWriteonlyStorageBuffers);
 
-        for (i = 0; i < resourceLayout->num_writeonly_storage_textures; i += 1) {
+        for (i = 0; i < resourceLayout->numWriteonlyStorageTextures; i += 1) {
             currentWriteDescriptorSet = &writeDescriptorSets[i];
 
             currentWriteDescriptorSet->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
@@ -8554,12 +8554,12 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = command_buffer->computeWriteOnlyDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->computeWriteOnlyDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pBufferInfo = NULL;
 
             imageInfos[imageInfoCount].sampler = VK_NULL_HANDLE;
-            imageInfos[imageInfoCount].imageView = command_buffer->writeOnlyComputeStorageTextureSubresources[i]->computeWriteView;
+            imageInfos[imageInfoCount].imageView = commandBuffer->writeOnlyComputeStorageTextureSubresources[i]->computeWriteView;
             imageInfos[imageInfoCount].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
             currentWriteDescriptorSet->pImageInfo = &imageInfos[imageInfoCount];
@@ -8567,20 +8567,20 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
             imageInfoCount += 1;
         }
 
-        for (i = 0; i < resourceLayout->num_writeonly_storage_buffers; i += 1) {
-            currentWriteDescriptorSet = &writeDescriptorSets[resourceLayout->num_writeonly_storage_textures + i];
+        for (i = 0; i < resourceLayout->numWriteonlyStorageBuffers; i += 1) {
+            currentWriteDescriptorSet = &writeDescriptorSets[resourceLayout->numWriteonlyStorageTextures + i];
 
             currentWriteDescriptorSet->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
             currentWriteDescriptorSet->pNext = NULL;
             currentWriteDescriptorSet->descriptorCount = 1;
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
             currentWriteDescriptorSet->dstArrayElement = 0;
-            currentWriteDescriptorSet->dstBinding = resourceLayout->num_writeonly_storage_textures + i;
-            currentWriteDescriptorSet->dstSet = command_buffer->computeWriteOnlyDescriptorSet;
+            currentWriteDescriptorSet->dstBinding = resourceLayout->numWriteonlyStorageTextures + i;
+            currentWriteDescriptorSet->dstSet = commandBuffer->computeWriteOnlyDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = command_buffer->writeOnlyComputeStorageBuffers[i]->buffer;
+            bufferInfos[bufferInfoCount].buffer = commandBuffer->writeOnlyComputeStorageBuffers[i]->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = VK_WHOLE_SIZE;
 
@@ -8591,18 +8591,18 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
 
         renderer->vkUpdateDescriptorSets(
             renderer->logicalDevice,
-            resourceLayout->num_writeonly_storage_textures + resourceLayout->num_writeonly_storage_buffers,
+            resourceLayout->numWriteonlyStorageTextures + resourceLayout->numWriteonlyStorageBuffers,
             writeDescriptorSets,
             0,
             NULL);
 
         renderer->vkCmdBindDescriptorSets(
-            command_buffer->command_buffer,
+            commandBuffer->commandBuffer,
             VK_PIPELINE_BIND_POINT_COMPUTE,
             resourceLayout->pipelineLayout,
             1,
             1,
-            &command_buffer->computeWriteOnlyDescriptorSet,
+            &commandBuffer->computeWriteOnlyDescriptorSet,
             0,
             NULL);
 
@@ -8610,22 +8610,22 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        command_buffer->needNewComputeWriteOnlyDescriptorSet = false;
+        commandBuffer->needNewComputeWriteOnlyDescriptorSet = false;
     }
 
-    if (command_buffer->needNewComputeUniformDescriptorSet) {
+    if (commandBuffer->needNewComputeUniformDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[2];
 
-        command_buffer->computeUniformDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        commandBuffer->computeUniformDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            command_buffer,
+            commandBuffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
             VkWriteDescriptorSet,
-            resourceLayout->num_uniform_buffers);
+            resourceLayout->numUniformBuffers);
 
-        for (i = 0; i < resourceLayout->num_uniform_buffers; i += 1) {
+        for (i = 0; i < resourceLayout->numUniformBuffers; i += 1) {
             currentWriteDescriptorSet = &writeDescriptorSets[i];
 
             currentWriteDescriptorSet->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
@@ -8634,11 +8634,11 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = command_buffer->computeUniformDescriptorSet;
+            currentWriteDescriptorSet->dstSet = commandBuffer->computeUniformDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = command_buffer->computeUniformBuffers[i]->bufferHandle->vulkanBuffer->buffer;
+            bufferInfos[bufferInfoCount].buffer = commandBuffer->computeUniformBuffers[i]->bufferHandle->vulkanBuffer->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = MAX_UBO_SECTION_SIZE;
 
@@ -8649,7 +8649,7 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
 
         renderer->vkUpdateDescriptorSets(
             renderer->logicalDevice,
-            resourceLayout->num_uniform_buffers,
+            resourceLayout->numUniformBuffers,
             writeDescriptorSets,
             0,
             NULL);
@@ -8658,60 +8658,60 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        command_buffer->needNewComputeUniformDescriptorSet = false;
-        command_buffer->needNewComputeUniformOffsets = true;
+        commandBuffer->needNewComputeUniformDescriptorSet = false;
+        commandBuffer->needNewComputeUniformOffsets = true;
     }
 
-    if (command_buffer->needNewComputeUniformOffsets) {
-        for (i = 0; i < resourceLayout->num_uniform_buffers; i += 1) {
-            dynamicOffsets[i] = command_buffer->computeUniformBuffers[i]->drawOffset;
+    if (commandBuffer->needNewComputeUniformOffsets) {
+        for (i = 0; i < resourceLayout->numUniformBuffers; i += 1) {
+            dynamicOffsets[i] = commandBuffer->computeUniformBuffers[i]->drawOffset;
         }
 
         renderer->vkCmdBindDescriptorSets(
-            command_buffer->command_buffer,
+            commandBuffer->commandBuffer,
             VK_PIPELINE_BIND_POINT_COMPUTE,
             resourceLayout->pipelineLayout,
             2,
             1,
-            &command_buffer->computeUniformDescriptorSet,
-            resourceLayout->num_uniform_buffers,
+            &commandBuffer->computeUniformDescriptorSet,
+            resourceLayout->numUniformBuffers,
             dynamicOffsets);
 
-        command_buffer->needNewComputeUniformOffsets = false;
+        commandBuffer->needNewComputeUniformOffsets = false;
     }
 }
 
 static void VULKAN_DispatchCompute(
-    SDL_GPUCommandBuffer *command_buffer,
-    Uint32 groupcount_x,
-    Uint32 groupcount_y,
-    Uint32 groupcount_z)
+    SDL_GPUCommandBuffer *commandBuffer,
+    Uint32 groupcountX,
+    Uint32 groupcountY,
+    Uint32 groupcountZ)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_BindComputeDescriptorSets(renderer, vulkanCommandBuffer);
 
     renderer->vkCmdDispatch(
-        vulkanCommandBuffer->command_buffer,
-        groupcount_x,
-        groupcount_y,
-        groupcount_z);
+        vulkanCommandBuffer->commandBuffer,
+        groupcountX,
+        groupcountY,
+        groupcountZ);
 }
 
 static void VULKAN_DispatchComputeIndirect(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUBuffer *buffer,
     Uint32 offset)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBuffer *vulkanBuffer = ((VulkanBufferContainer *)buffer)->activeBufferHandle->vulkanBuffer;
 
     VULKAN_INTERNAL_BindComputeDescriptorSets(renderer, vulkanCommandBuffer);
 
     renderer->vkCmdDispatchIndirect(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         vulkanBuffer->buffer,
         offset);
 
@@ -8719,9 +8719,9 @@ static void VULKAN_DispatchComputeIndirect(
 }
 
 static void VULKAN_EndComputePass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     Uint32 i;
 
     for (i = 0; i < vulkanCommandBuffer->writeOnlyComputeStorageTextureSubresourceCount; i += 1) {
@@ -8779,11 +8779,11 @@ static void VULKAN_EndComputePass(
 
 static void *VULKAN_MapTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transfer_buffer,
+    SDL_GPUTransferBuffer *transferBuffer,
     bool cycle)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)transfer_buffer;
+    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)transferBuffer;
 
     if (
         cycle &&
@@ -8802,27 +8802,27 @@ static void *VULKAN_MapTransferBuffer(
 
 static void VULKAN_UnmapTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transfer_buffer)
+    SDL_GPUTransferBuffer *transferBuffer)
 {
     // no-op because transfer buffers are persistently mapped
     (void)driverData;
-    (void)transfer_buffer;
+    (void)transferBuffer;
 }
 
 static void VULKAN_BeginCopyPass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
     // no-op
-    (void)command_buffer;
+    (void)commandBuffer;
 }
 
 static void VULKAN_UploadToTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTextureTransferInfo *source,
     const SDL_GPUTextureRegion *destination,
     bool cycle)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)source->transfer_buffer;
     VulkanTextureContainer *vulkanTextureContainer = (VulkanTextureContainer *)destination->texture;
@@ -8855,7 +8855,7 @@ static void VULKAN_UploadToTexture(
     imageCopy.bufferImageHeight = source->rows_per_layer;
 
     renderer->vkCmdCopyBufferToImage(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         transferBufferContainer->activeBufferHandle->vulkanBuffer->buffer,
         vulkanTextureSubresource->parent->image,
         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
@@ -8873,12 +8873,12 @@ static void VULKAN_UploadToTexture(
 }
 
 static void VULKAN_UploadToBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTransferBufferLocation *source,
     const SDL_GPUBufferRegion *destination,
     bool cycle)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)source->transfer_buffer;
     VulkanBufferContainer *bufferContainer = (VulkanBufferContainer *)destination->buffer;
@@ -8898,7 +8898,7 @@ static void VULKAN_UploadToBuffer(
     bufferCopy.size = destination->size;
 
     renderer->vkCmdCopyBuffer(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         transferBufferContainer->activeBufferHandle->vulkanBuffer->buffer,
         vulkanBuffer->buffer,
         1,
@@ -8917,11 +8917,11 @@ static void VULKAN_UploadToBuffer(
 // Readback
 
 static void VULKAN_DownloadFromTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTextureRegion *source,
     const SDL_GPUTextureTransferInfo *destination)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)source->texture;
     VulkanTextureSubresource *vulkanTextureSubresource;
@@ -8955,7 +8955,7 @@ static void VULKAN_DownloadFromTexture(
     imageCopy.bufferImageHeight = destination->rows_per_layer;
 
     renderer->vkCmdCopyImageToBuffer(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         vulkanTextureSubresource->parent->image,
         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
         transferBufferContainer->activeBufferHandle->vulkanBuffer->buffer,
@@ -8973,11 +8973,11 @@ static void VULKAN_DownloadFromTexture(
 }
 
 static void VULKAN_DownloadFromBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBufferRegion *source,
     const SDL_GPUTransferBufferLocation *destination)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanBufferContainer *bufferContainer = (VulkanBufferContainer *)source->buffer;
     VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)destination->transfer_buffer;
@@ -8996,7 +8996,7 @@ static void VULKAN_DownloadFromBuffer(
     bufferCopy.size = source->size;
 
     renderer->vkCmdCopyBuffer(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         bufferContainer->activeBufferHandle->vulkanBuffer->buffer,
         transferBufferContainer->activeBufferHandle->vulkanBuffer->buffer,
         1,
@@ -9013,7 +9013,7 @@ static void VULKAN_DownloadFromBuffer(
 }
 
 static void VULKAN_CopyTextureToTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUTextureLocation *source,
     const SDL_GPUTextureLocation *destination,
     Uint32 w,
@@ -9021,7 +9021,7 @@ static void VULKAN_CopyTextureToTexture(
     Uint32 d,
     bool cycle)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanTextureSubresource *srcSubresource;
     VulkanTextureSubresource *dstSubresource;
@@ -9066,7 +9066,7 @@ static void VULKAN_CopyTextureToTexture(
     imageCopy.extent.depth = d;
 
     renderer->vkCmdCopyImage(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         srcSubresource->parent->image,
         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
         dstSubresource->parent->image,
@@ -9091,13 +9091,13 @@ static void VULKAN_CopyTextureToTexture(
 }
 
 static void VULKAN_CopyBufferToBuffer(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBufferLocation *source,
     const SDL_GPUBufferLocation *destination,
     Uint32 size,
     bool cycle)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBufferContainer *srcContainer = (VulkanBufferContainer *)source->buffer;
     VulkanBufferContainer *dstContainer = (VulkanBufferContainer *)destination->buffer;
@@ -9121,7 +9121,7 @@ static void VULKAN_CopyBufferToBuffer(
     bufferCopy.size = size;
 
     renderer->vkCmdCopyBuffer(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         srcContainer->activeBufferHandle->vulkanBuffer->buffer,
         dstBuffer->buffer,
         1,
@@ -9144,10 +9144,10 @@ static void VULKAN_CopyBufferToBuffer(
 }
 
 static void VULKAN_GenerateMipmaps(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_GPUTexture *texture)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanTexture *vulkanTexture = ((VulkanTextureContainer *)texture)->activeTextureHandle->vulkanTexture;
     VulkanTextureSubresource *srcTextureSubresource;
@@ -9156,18 +9156,18 @@ static void VULKAN_GenerateMipmaps(
 
     // Blit each slice sequentially. Barriers, barriers everywhere!
     for (Uint32 layerOrDepthIndex = 0; layerOrDepthIndex < vulkanTexture->layerCount; layerOrDepthIndex += 1)
-        for (Uint32 level = 1; level < vulkanTexture->num_levels; level += 1) {
+        for (Uint32 level = 1; level < vulkanTexture->numLevels; level += 1) {
             Uint32 layer = vulkanTexture->type == SDL_GPU_TEXTURETYPE_3D ? 0 : layerOrDepthIndex;
             Uint32 depth = vulkanTexture->type == SDL_GPU_TEXTURETYPE_3D ? layerOrDepthIndex : 0;
 
             Uint32 srcSubresourceIndex = VULKAN_INTERNAL_GetTextureSubresourceIndex(
                 level - 1,
                 layer,
-                vulkanTexture->num_levels);
+                vulkanTexture->numLevels);
             Uint32 dstSubresourceIndex = VULKAN_INTERNAL_GetTextureSubresourceIndex(
                 level,
                 layer,
-                vulkanTexture->num_levels);
+                vulkanTexture->numLevels);
 
             srcTextureSubresource = &vulkanTexture->subresources[srcSubresourceIndex];
             dstTextureSubresource = &vulkanTexture->subresources[dstSubresourceIndex];
@@ -9211,7 +9211,7 @@ static void VULKAN_GenerateMipmaps(
             blit.dstSubresource.mipLevel = level;
 
             renderer->vkCmdBlitImage(
-                vulkanCommandBuffer->command_buffer,
+                vulkanCommandBuffer->commandBuffer,
                 vulkanTexture->image,
                 VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                 vulkanTexture->image,
@@ -9238,21 +9238,21 @@ static void VULKAN_GenerateMipmaps(
 }
 
 static void VULKAN_EndCopyPass(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
     // no-op
-    (void)command_buffer;
+    (void)commandBuffer;
 }
 
 static void VULKAN_Blit(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBlitRegion *source,
     const SDL_GPUBlitRegion *destination,
-    SDL_FlipMode flip_mode,
+    SDL_FlipMode flipMode,
     SDL_GPUFilter filter,
     bool cycle)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     TextureCommonHeader *srcHeader = (TextureCommonHeader *)source->texture;
     TextureCommonHeader *dstHeader = (TextureCommonHeader *)destination->texture;
@@ -9294,14 +9294,14 @@ static void VULKAN_Blit(
     region.srcOffsets[1].y = source->y + source->h;
     region.srcOffsets[1].z = srcDepth + 1;
 
-    if (flip_mode & SDL_FLIP_HORIZONTAL) {
+    if (flipMode & SDL_FLIP_HORIZONTAL) {
         // flip the x positions
         swap = region.srcOffsets[0].x;
         region.srcOffsets[0].x = region.srcOffsets[1].x;
         region.srcOffsets[1].x = swap;
     }
 
-    if (flip_mode & SDL_FLIP_VERTICAL) {
+    if (flipMode & SDL_FLIP_VERTICAL) {
         // flip the y positions
         swap = region.srcOffsets[0].y;
         region.srcOffsets[0].y = region.srcOffsets[1].y;
@@ -9320,7 +9320,7 @@ static void VULKAN_Blit(
     region.dstOffsets[1].z = dstDepth + 1;
 
     renderer->vkCmdBlitImage(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         srcSubresource->parent->image,
         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
         dstSubresource->parent->image,
@@ -9354,7 +9354,7 @@ static void VULKAN_INTERNAL_AllocateCommandBuffers(
     VkResult vulkanResult;
     Uint32 i;
     VkCommandBuffer *commandBuffers = SDL_stack_alloc(VkCommandBuffer, allocateCount);
-    VulkanCommandBuffer *command_buffer;
+    VulkanCommandBuffer *commandBuffer;
 
     vulkanCommandPool->inactiveCommandBufferCapacity += allocateCount;
 
@@ -9381,100 +9381,100 @@ static void VULKAN_INTERNAL_AllocateCommandBuffers(
     }
 
     for (i = 0; i < allocateCount; i += 1) {
-        command_buffer = SDL_malloc(sizeof(VulkanCommandBuffer));
-        command_buffer->renderer = renderer;
-        command_buffer->commandPool = vulkanCommandPool;
-        command_buffer->command_buffer = commandBuffers[i];
+        commandBuffer = SDL_malloc(sizeof(VulkanCommandBuffer));
+        commandBuffer->renderer = renderer;
+        commandBuffer->commandPool = vulkanCommandPool;
+        commandBuffer->commandBuffer = commandBuffers[i];
 
-        command_buffer->inFlightFence = VK_NULL_HANDLE;
+        commandBuffer->inFlightFence = VK_NULL_HANDLE;
 
         // Presentation tracking
 
-        command_buffer->presentDataCapacity = 1;
-        command_buffer->presentDataCount = 0;
-        command_buffer->presentDatas = SDL_malloc(
-            command_buffer->presentDataCapacity * sizeof(VulkanPresentData));
+        commandBuffer->presentDataCapacity = 1;
+        commandBuffer->presentDataCount = 0;
+        commandBuffer->presentDatas = SDL_malloc(
+            commandBuffer->presentDataCapacity * sizeof(VulkanPresentData));
 
-        command_buffer->waitSemaphoreCapacity = 1;
-        command_buffer->waitSemaphoreCount = 0;
-        command_buffer->waitSemaphores = SDL_malloc(
-            command_buffer->waitSemaphoreCapacity * sizeof(VkSemaphore));
+        commandBuffer->waitSemaphoreCapacity = 1;
+        commandBuffer->waitSemaphoreCount = 0;
+        commandBuffer->waitSemaphores = SDL_malloc(
+            commandBuffer->waitSemaphoreCapacity * sizeof(VkSemaphore));
 
-        command_buffer->signalSemaphoreCapacity = 1;
-        command_buffer->signalSemaphoreCount = 0;
-        command_buffer->signalSemaphores = SDL_malloc(
-            command_buffer->signalSemaphoreCapacity * sizeof(VkSemaphore));
+        commandBuffer->signalSemaphoreCapacity = 1;
+        commandBuffer->signalSemaphoreCount = 0;
+        commandBuffer->signalSemaphores = SDL_malloc(
+            commandBuffer->signalSemaphoreCapacity * sizeof(VkSemaphore));
 
         // Descriptor set tracking
 
-        command_buffer->boundDescriptorSetDataCapacity = 16;
-        command_buffer->boundDescriptorSetDataCount = 0;
-        command_buffer->boundDescriptorSetDatas = SDL_malloc(
-            command_buffer->boundDescriptorSetDataCapacity * sizeof(DescriptorSetData));
+        commandBuffer->boundDescriptorSetDataCapacity = 16;
+        commandBuffer->boundDescriptorSetDataCount = 0;
+        commandBuffer->boundDescriptorSetDatas = SDL_malloc(
+            commandBuffer->boundDescriptorSetDataCapacity * sizeof(DescriptorSetData));
 
         // Resource bind tracking
 
-        command_buffer->needNewVertexResourceDescriptorSet = true;
-        command_buffer->needNewVertexUniformDescriptorSet = true;
-        command_buffer->needNewVertexUniformOffsets = true;
-        command_buffer->needNewFragmentResourceDescriptorSet = true;
-        command_buffer->needNewFragmentUniformDescriptorSet = true;
-        command_buffer->needNewFragmentUniformOffsets = true;
+        commandBuffer->needNewVertexResourceDescriptorSet = true;
+        commandBuffer->needNewVertexUniformDescriptorSet = true;
+        commandBuffer->needNewVertexUniformOffsets = true;
+        commandBuffer->needNewFragmentResourceDescriptorSet = true;
+        commandBuffer->needNewFragmentUniformDescriptorSet = true;
+        commandBuffer->needNewFragmentUniformOffsets = true;
 
-        command_buffer->needNewComputeWriteOnlyDescriptorSet = true;
-        command_buffer->needNewComputeReadOnlyDescriptorSet = true;
-        command_buffer->needNewComputeUniformDescriptorSet = true;
-        command_buffer->needNewComputeUniformOffsets = true;
+        commandBuffer->needNewComputeWriteOnlyDescriptorSet = true;
+        commandBuffer->needNewComputeReadOnlyDescriptorSet = true;
+        commandBuffer->needNewComputeUniformDescriptorSet = true;
+        commandBuffer->needNewComputeUniformOffsets = true;
 
-        command_buffer->vertexResourceDescriptorSet = VK_NULL_HANDLE;
-        command_buffer->vertexUniformDescriptorSet = VK_NULL_HANDLE;
-        command_buffer->fragmentResourceDescriptorSet = VK_NULL_HANDLE;
-        command_buffer->fragmentUniformDescriptorSet = VK_NULL_HANDLE;
+        commandBuffer->vertexResourceDescriptorSet = VK_NULL_HANDLE;
+        commandBuffer->vertexUniformDescriptorSet = VK_NULL_HANDLE;
+        commandBuffer->fragmentResourceDescriptorSet = VK_NULL_HANDLE;
+        commandBuffer->fragmentUniformDescriptorSet = VK_NULL_HANDLE;
 
-        command_buffer->computeReadOnlyDescriptorSet = VK_NULL_HANDLE;
-        command_buffer->computeWriteOnlyDescriptorSet = VK_NULL_HANDLE;
-        command_buffer->computeUniformDescriptorSet = VK_NULL_HANDLE;
+        commandBuffer->computeReadOnlyDescriptorSet = VK_NULL_HANDLE;
+        commandBuffer->computeWriteOnlyDescriptorSet = VK_NULL_HANDLE;
+        commandBuffer->computeUniformDescriptorSet = VK_NULL_HANDLE;
 
         // Resource tracking
 
-        command_buffer->usedBufferCapacity = 4;
-        command_buffer->usedBufferCount = 0;
-        command_buffer->usedBuffers = SDL_malloc(
-            command_buffer->usedBufferCapacity * sizeof(VulkanBuffer *));
+        commandBuffer->usedBufferCapacity = 4;
+        commandBuffer->usedBufferCount = 0;
+        commandBuffer->usedBuffers = SDL_malloc(
+            commandBuffer->usedBufferCapacity * sizeof(VulkanBuffer *));
 
-        command_buffer->usedTextureCapacity = 4;
-        command_buffer->usedTextureCount = 0;
-        command_buffer->usedTextures = SDL_malloc(
-            command_buffer->usedTextureCapacity * sizeof(VulkanTexture *));
+        commandBuffer->usedTextureCapacity = 4;
+        commandBuffer->usedTextureCount = 0;
+        commandBuffer->usedTextures = SDL_malloc(
+            commandBuffer->usedTextureCapacity * sizeof(VulkanTexture *));
 
-        command_buffer->usedSamplerCapacity = 4;
-        command_buffer->usedSamplerCount = 0;
-        command_buffer->usedSamplers = SDL_malloc(
-            command_buffer->usedSamplerCapacity * sizeof(VulkanSampler *));
+        commandBuffer->usedSamplerCapacity = 4;
+        commandBuffer->usedSamplerCount = 0;
+        commandBuffer->usedSamplers = SDL_malloc(
+            commandBuffer->usedSamplerCapacity * sizeof(VulkanSampler *));
 
-        command_buffer->usedGraphicsPipelineCapacity = 4;
-        command_buffer->usedGraphicsPipelineCount = 0;
-        command_buffer->usedGraphicsPipelines = SDL_malloc(
-            command_buffer->usedGraphicsPipelineCapacity * sizeof(VulkanGraphicsPipeline *));
+        commandBuffer->usedGraphicsPipelineCapacity = 4;
+        commandBuffer->usedGraphicsPipelineCount = 0;
+        commandBuffer->usedGraphicsPipelines = SDL_malloc(
+            commandBuffer->usedGraphicsPipelineCapacity * sizeof(VulkanGraphicsPipeline *));
 
-        command_buffer->usedComputePipelineCapacity = 4;
-        command_buffer->usedComputePipelineCount = 0;
-        command_buffer->usedComputePipelines = SDL_malloc(
-            command_buffer->usedComputePipelineCapacity * sizeof(VulkanComputePipeline *));
+        commandBuffer->usedComputePipelineCapacity = 4;
+        commandBuffer->usedComputePipelineCount = 0;
+        commandBuffer->usedComputePipelines = SDL_malloc(
+            commandBuffer->usedComputePipelineCapacity * sizeof(VulkanComputePipeline *));
 
-        command_buffer->usedFramebufferCapacity = 4;
-        command_buffer->usedFramebufferCount = 0;
-        command_buffer->usedFramebuffers = SDL_malloc(
-            command_buffer->usedFramebufferCapacity * sizeof(VulkanFramebuffer *));
+        commandBuffer->usedFramebufferCapacity = 4;
+        commandBuffer->usedFramebufferCount = 0;
+        commandBuffer->usedFramebuffers = SDL_malloc(
+            commandBuffer->usedFramebufferCapacity * sizeof(VulkanFramebuffer *));
 
-        command_buffer->usedUniformBufferCapacity = 4;
-        command_buffer->usedUniformBufferCount = 0;
-        command_buffer->usedUniformBuffers = SDL_malloc(
-            command_buffer->usedUniformBufferCapacity * sizeof(VulkanUniformBuffer *));
+        commandBuffer->usedUniformBufferCapacity = 4;
+        commandBuffer->usedUniformBufferCount = 0;
+        commandBuffer->usedUniformBuffers = SDL_malloc(
+            commandBuffer->usedUniformBufferCapacity * sizeof(VulkanUniformBuffer *));
 
         // Pool it!
 
-        vulkanCommandPool->inactiveCommandBuffers[vulkanCommandPool->inactiveCommandBufferCount] = command_buffer;
+        vulkanCommandPool->inactiveCommandBuffers[vulkanCommandPool->inactiveCommandBufferCount] = commandBuffer;
         vulkanCommandPool->inactiveCommandBufferCount += 1;
     }
 
@@ -9547,7 +9547,7 @@ static VulkanCommandBuffer *VULKAN_INTERNAL_GetInactiveCommandBufferFromPool(
 {
     VulkanCommandPool *commandPool =
         VULKAN_INTERNAL_FetchCommandPool(renderer, threadID);
-    VulkanCommandBuffer *command_buffer;
+    VulkanCommandBuffer *commandBuffer;
 
     if (commandPool == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to fetch command pool!");
@@ -9561,10 +9561,10 @@ static VulkanCommandBuffer *VULKAN_INTERNAL_GetInactiveCommandBufferFromPool(
             commandPool->inactiveCommandBufferCapacity);
     }
 
-    command_buffer = commandPool->inactiveCommandBuffers[commandPool->inactiveCommandBufferCount - 1];
+    commandBuffer = commandPool->inactiveCommandBuffers[commandPool->inactiveCommandBufferCount - 1];
     commandPool->inactiveCommandBufferCount -= 1;
 
-    return command_buffer;
+    return commandBuffer;
 }
 
 static SDL_GPUCommandBuffer *VULKAN_AcquireCommandBuffer(
@@ -9578,87 +9578,87 @@ static SDL_GPUCommandBuffer *VULKAN_AcquireCommandBuffer(
 
     SDL_LockMutex(renderer->acquireCommandBufferLock);
 
-    VulkanCommandBuffer *command_buffer =
+    VulkanCommandBuffer *commandBuffer =
         VULKAN_INTERNAL_GetInactiveCommandBufferFromPool(renderer, threadID);
 
     SDL_UnlockMutex(renderer->acquireCommandBufferLock);
 
-    if (command_buffer == NULL) {
+    if (commandBuffer == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to acquire command buffer!");
         return NULL;
     }
 
     // Reset state
 
-    command_buffer->currentComputePipeline = NULL;
-    command_buffer->currentGraphicsPipeline = NULL;
+    commandBuffer->currentComputePipeline = NULL;
+    commandBuffer->currentGraphicsPipeline = NULL;
 
     for (i = 0; i < MAX_COLOR_TARGET_BINDINGS; i += 1) {
-        command_buffer->colorAttachmentSubresources[i] = NULL;
+        commandBuffer->colorAttachmentSubresources[i] = NULL;
     }
 
     for (i = 0; i < MAX_UNIFORM_BUFFERS_PER_STAGE; i += 1) {
-        command_buffer->vertexUniformBuffers[i] = NULL;
-        command_buffer->fragmentUniformBuffers[i] = NULL;
-        command_buffer->computeUniformBuffers[i] = NULL;
+        commandBuffer->vertexUniformBuffers[i] = NULL;
+        commandBuffer->fragmentUniformBuffers[i] = NULL;
+        commandBuffer->computeUniformBuffers[i] = NULL;
     }
 
-    command_buffer->depthStencilAttachmentSubresource = NULL;
+    commandBuffer->depthStencilAttachmentSubresource = NULL;
 
-    command_buffer->needNewVertexResourceDescriptorSet = true;
-    command_buffer->needNewVertexUniformDescriptorSet = true;
-    command_buffer->needNewVertexUniformOffsets = true;
-    command_buffer->needNewFragmentResourceDescriptorSet = true;
-    command_buffer->needNewFragmentUniformDescriptorSet = true;
-    command_buffer->needNewFragmentUniformOffsets = true;
+    commandBuffer->needNewVertexResourceDescriptorSet = true;
+    commandBuffer->needNewVertexUniformDescriptorSet = true;
+    commandBuffer->needNewVertexUniformOffsets = true;
+    commandBuffer->needNewFragmentResourceDescriptorSet = true;
+    commandBuffer->needNewFragmentUniformDescriptorSet = true;
+    commandBuffer->needNewFragmentUniformOffsets = true;
 
-    command_buffer->needNewComputeReadOnlyDescriptorSet = true;
-    command_buffer->needNewComputeUniformDescriptorSet = true;
-    command_buffer->needNewComputeUniformOffsets = true;
+    commandBuffer->needNewComputeReadOnlyDescriptorSet = true;
+    commandBuffer->needNewComputeUniformDescriptorSet = true;
+    commandBuffer->needNewComputeUniformOffsets = true;
 
-    command_buffer->vertexResourceDescriptorSet = VK_NULL_HANDLE;
-    command_buffer->vertexUniformDescriptorSet = VK_NULL_HANDLE;
-    command_buffer->fragmentResourceDescriptorSet = VK_NULL_HANDLE;
-    command_buffer->fragmentUniformDescriptorSet = VK_NULL_HANDLE;
+    commandBuffer->vertexResourceDescriptorSet = VK_NULL_HANDLE;
+    commandBuffer->vertexUniformDescriptorSet = VK_NULL_HANDLE;
+    commandBuffer->fragmentResourceDescriptorSet = VK_NULL_HANDLE;
+    commandBuffer->fragmentUniformDescriptorSet = VK_NULL_HANDLE;
 
-    command_buffer->computeReadOnlyDescriptorSet = VK_NULL_HANDLE;
-    command_buffer->computeWriteOnlyDescriptorSet = VK_NULL_HANDLE;
-    command_buffer->computeUniformDescriptorSet = VK_NULL_HANDLE;
+    commandBuffer->computeReadOnlyDescriptorSet = VK_NULL_HANDLE;
+    commandBuffer->computeWriteOnlyDescriptorSet = VK_NULL_HANDLE;
+    commandBuffer->computeUniformDescriptorSet = VK_NULL_HANDLE;
 
-    SDL_zeroa(command_buffer->vertexSamplerTextures);
-    SDL_zeroa(command_buffer->vertexSamplers);
-    SDL_zeroa(command_buffer->vertexStorageTextures);
-    SDL_zeroa(command_buffer->vertexStorageBuffers);
+    SDL_zeroa(commandBuffer->vertexSamplerTextures);
+    SDL_zeroa(commandBuffer->vertexSamplers);
+    SDL_zeroa(commandBuffer->vertexStorageTextures);
+    SDL_zeroa(commandBuffer->vertexStorageBuffers);
 
-    SDL_zeroa(command_buffer->fragmentSamplerTextures);
-    SDL_zeroa(command_buffer->fragmentSamplers);
-    SDL_zeroa(command_buffer->fragmentStorageTextures);
-    SDL_zeroa(command_buffer->fragmentStorageBuffers);
+    SDL_zeroa(commandBuffer->fragmentSamplerTextures);
+    SDL_zeroa(commandBuffer->fragmentSamplers);
+    SDL_zeroa(commandBuffer->fragmentStorageTextures);
+    SDL_zeroa(commandBuffer->fragmentStorageBuffers);
 
-    SDL_zeroa(command_buffer->writeOnlyComputeStorageTextureSubresources);
-    command_buffer->writeOnlyComputeStorageTextureSubresourceCount = 0;
-    SDL_zeroa(command_buffer->writeOnlyComputeStorageBuffers);
-    SDL_zeroa(command_buffer->readOnlyComputeStorageTextures);
-    SDL_zeroa(command_buffer->readOnlyComputeStorageBuffers);
+    SDL_zeroa(commandBuffer->writeOnlyComputeStorageTextureSubresources);
+    commandBuffer->writeOnlyComputeStorageTextureSubresourceCount = 0;
+    SDL_zeroa(commandBuffer->writeOnlyComputeStorageBuffers);
+    SDL_zeroa(commandBuffer->readOnlyComputeStorageTextures);
+    SDL_zeroa(commandBuffer->readOnlyComputeStorageBuffers);
 
-    command_buffer->autoReleaseFence = 1;
+    commandBuffer->autoReleaseFence = 1;
 
-    command_buffer->isDefrag = 0;
+    commandBuffer->isDefrag = 0;
 
     /* Reset the command buffer here to avoid resets being called
      * from a separate thread than where the command buffer was acquired
      */
     result = renderer->vkResetCommandBuffer(
-        command_buffer->command_buffer,
+        commandBuffer->commandBuffer,
         VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT);
 
     if (result != VK_SUCCESS) {
         LogVulkanResultAsError("vkResetCommandBuffer", result);
     }
 
-    VULKAN_INTERNAL_BeginCommandBuffer(renderer, command_buffer);
+    VULKAN_INTERNAL_BeginCommandBuffer(renderer, commandBuffer);
 
-    return (SDL_GPUCommandBuffer *)command_buffer;
+    return (SDL_GPUCommandBuffer *)commandBuffer;
 }
 
 static bool VULKAN_QueryFence(
@@ -9734,7 +9734,7 @@ static SDL_bool VULKAN_INTERNAL_OnWindowResize(void *userdata, SDL_Event *e)
 static bool VULKAN_SupportsSwapchainComposition(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchain_composition)
+    SDL_GPUSwapchainComposition swapchainComposition)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
     WindowData *windowData = VULKAN_INTERNAL_FetchWindowData(window);
@@ -9756,16 +9756,16 @@ static bool VULKAN_SupportsSwapchainComposition(
             &supportDetails)) {
 
         result = VULKAN_INTERNAL_VerifySwapSurfaceFormat(
-            SwapchainCompositionToFormat[swapchain_composition],
-            SwapchainCompositionToColorSpace[swapchain_composition],
+            SwapchainCompositionToFormat[swapchainComposition],
+            SwapchainCompositionToColorSpace[swapchainComposition],
             supportDetails.formats,
             supportDetails.formatsLength);
 
         if (!result) {
             // Let's try again with the fallback format...
             result = VULKAN_INTERNAL_VerifySwapSurfaceFormat(
-                SwapchainCompositionToFallbackFormat[swapchain_composition],
-                SwapchainCompositionToColorSpace[swapchain_composition],
+                SwapchainCompositionToFallbackFormat[swapchainComposition],
+                SwapchainCompositionToColorSpace[swapchainComposition],
                 supportDetails.formats,
                 supportDetails.formatsLength);
         }
@@ -9780,7 +9780,7 @@ static bool VULKAN_SupportsSwapchainComposition(
 static bool VULKAN_SupportsPresentMode(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUPresentMode present_mode)
+    SDL_GPUPresentMode presentMode)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
     WindowData *windowData = VULKAN_INTERNAL_FetchWindowData(window);
@@ -9802,7 +9802,7 @@ static bool VULKAN_SupportsPresentMode(
             &supportDetails)) {
 
         result = VULKAN_INTERNAL_VerifySwapPresentMode(
-            SDLToVK_PresentMode[present_mode],
+            SDLToVK_PresentMode[presentMode],
             supportDetails.presentModes,
             supportDetails.presentModesLength);
 
@@ -9823,8 +9823,8 @@ static bool VULKAN_ClaimWindow(
     if (windowData == NULL) {
         windowData = SDL_malloc(sizeof(WindowData));
         windowData->window = window;
-        windowData->present_mode = SDL_GPU_PRESENTMODE_VSYNC;
-        windowData->swapchain_composition = SDL_GPU_SWAPCHAINCOMPOSITION_SDR;
+        windowData->presentMode = SDL_GPU_PRESENTMODE_VSYNC;
+        windowData->swapchainComposition = SDL_GPU_SWAPCHAINCOMPOSITION_SDR;
 
         if (VULKAN_INTERNAL_CreateSwapchain(renderer, windowData)) {
             SDL_SetPointerProperty(SDL_GetWindowProperties(window), WINDOW_PROPERTY_DATA, windowData);
@@ -9918,12 +9918,12 @@ static bool VULKAN_INTERNAL_RecreateSwapchain(
 }
 
 static SDL_GPUTexture *VULKAN_AcquireSwapchainTexture(
-    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUCommandBuffer *commandBuffer,
     SDL_Window *window,
     Uint32 *w,
     Uint32 *h)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     Uint32 swapchainImageIndex;
     WindowData *windowData;
@@ -9957,7 +9957,7 @@ static SDL_GPUTexture *VULKAN_AcquireSwapchainTexture(
     }
 
     if (swapchainData->inFlightFences[swapchainData->frameCounter] != NULL) {
-        if (swapchainData->present_mode == VK_PRESENT_MODE_FIFO_KHR) {
+        if (swapchainData->presentMode == VK_PRESENT_MODE_FIFO_KHR) {
             // In VSYNC mode, block until the least recent presented frame is done
             VULKAN_WaitForFences(
                 (SDL_GPURenderer *)renderer,
@@ -10048,7 +10048,7 @@ static SDL_GPUTexture *VULKAN_AcquireSwapchainTexture(
     imageBarrier.subresourceRange.layerCount = 1;
 
     renderer->vkCmdPipelineBarrier(
-        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->commandBuffer,
         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
         0,
@@ -10121,15 +10121,15 @@ static SDL_GPUTextureFormat VULKAN_GetSwapchainTextureFormat(
     }
 
     return SwapchainCompositionToSDLFormat(
-        windowData->swapchain_composition,
+        windowData->swapchainComposition,
         windowData->swapchainData->usingFallbackFormat);
 }
 
 static bool VULKAN_SetSwapchainParameters(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchain_composition,
-    SDL_GPUPresentMode present_mode)
+    SDL_GPUSwapchainComposition swapchainComposition,
+    SDL_GPUPresentMode presentMode)
 {
     WindowData *windowData = VULKAN_INTERNAL_FetchWindowData(window);
 
@@ -10138,18 +10138,18 @@ static bool VULKAN_SetSwapchainParameters(
         return false;
     }
 
-    if (!VULKAN_SupportsSwapchainComposition(driverData, window, swapchain_composition)) {
+    if (!VULKAN_SupportsSwapchainComposition(driverData, window, swapchainComposition)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Swapchain composition not supported!");
         return false;
     }
 
-    if (!VULKAN_SupportsPresentMode(driverData, window, present_mode)) {
+    if (!VULKAN_SupportsPresentMode(driverData, window, presentMode)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Present mode not supported!");
         return false;
     }
 
-    windowData->present_mode = present_mode;
-    windowData->swapchain_composition = swapchain_composition;
+    windowData->presentMode = presentMode;
+    windowData->swapchainComposition = swapchainComposition;
 
     return VULKAN_INTERNAL_RecreateSwapchain(
         (VulkanRenderer *)driverData,
@@ -10295,23 +10295,23 @@ static void VULKAN_INTERNAL_PerformPendingDestroys(
 
 static void VULKAN_INTERNAL_CleanCommandBuffer(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer)
+    VulkanCommandBuffer *commandBuffer)
 {
     Uint32 i;
     DescriptorSetData *descriptorSetData;
 
-    if (command_buffer->autoReleaseFence) {
+    if (commandBuffer->autoReleaseFence) {
         VULKAN_ReleaseFence(
             (SDL_GPURenderer *)renderer,
-            (SDL_GPUFence *)command_buffer->inFlightFence);
+            (SDL_GPUFence *)commandBuffer->inFlightFence);
 
-        command_buffer->inFlightFence = NULL;
+        commandBuffer->inFlightFence = NULL;
     }
 
     // Bound descriptor sets are now available
 
-    for (i = 0; i < command_buffer->boundDescriptorSetDataCount; i += 1) {
-        descriptorSetData = &command_buffer->boundDescriptorSetDatas[i];
+    for (i = 0; i < commandBuffer->boundDescriptorSetDataCount; i += 1) {
+        descriptorSetData = &commandBuffer->boundDescriptorSetDatas[i];
 
         SDL_LockMutex(descriptorSetData->descriptorSetPool->lock);
 
@@ -10328,62 +10328,62 @@ static void VULKAN_INTERNAL_CleanCommandBuffer(
         SDL_UnlockMutex(descriptorSetData->descriptorSetPool->lock);
     }
 
-    command_buffer->boundDescriptorSetDataCount = 0;
+    commandBuffer->boundDescriptorSetDataCount = 0;
 
     // Uniform buffers are now available
 
     SDL_LockMutex(renderer->acquireUniformBufferLock);
 
-    for (i = 0; i < command_buffer->usedUniformBufferCount; i += 1) {
+    for (i = 0; i < commandBuffer->usedUniformBufferCount; i += 1) {
         VULKAN_INTERNAL_ReturnUniformBufferToPool(
             renderer,
-            command_buffer->usedUniformBuffers[i]);
+            commandBuffer->usedUniformBuffers[i]);
     }
-    command_buffer->usedUniformBufferCount = 0;
+    commandBuffer->usedUniformBufferCount = 0;
 
     SDL_UnlockMutex(renderer->acquireUniformBufferLock);
 
     // Decrement reference counts
 
-    for (i = 0; i < command_buffer->usedBufferCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedBuffers[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedBufferCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedBuffers[i]->referenceCount);
     }
-    command_buffer->usedBufferCount = 0;
+    commandBuffer->usedBufferCount = 0;
 
-    for (i = 0; i < command_buffer->usedTextureCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedTextures[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedTextureCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedTextures[i]->referenceCount);
     }
-    command_buffer->usedTextureCount = 0;
+    commandBuffer->usedTextureCount = 0;
 
-    for (i = 0; i < command_buffer->usedSamplerCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedSamplers[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedSamplerCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedSamplers[i]->referenceCount);
     }
-    command_buffer->usedSamplerCount = 0;
+    commandBuffer->usedSamplerCount = 0;
 
-    for (i = 0; i < command_buffer->usedGraphicsPipelineCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedGraphicsPipelines[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedGraphicsPipelineCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedGraphicsPipelines[i]->referenceCount);
     }
-    command_buffer->usedGraphicsPipelineCount = 0;
+    commandBuffer->usedGraphicsPipelineCount = 0;
 
-    for (i = 0; i < command_buffer->usedComputePipelineCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedComputePipelines[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedComputePipelineCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedComputePipelines[i]->referenceCount);
     }
-    command_buffer->usedComputePipelineCount = 0;
+    commandBuffer->usedComputePipelineCount = 0;
 
-    for (i = 0; i < command_buffer->usedFramebufferCount; i += 1) {
-        (void)SDL_AtomicDecRef(&command_buffer->usedFramebuffers[i]->referenceCount);
+    for (i = 0; i < commandBuffer->usedFramebufferCount; i += 1) {
+        (void)SDL_AtomicDecRef(&commandBuffer->usedFramebuffers[i]->referenceCount);
     }
-    command_buffer->usedFramebufferCount = 0;
+    commandBuffer->usedFramebufferCount = 0;
 
     // Reset presentation data
 
-    command_buffer->presentDataCount = 0;
-    command_buffer->waitSemaphoreCount = 0;
-    command_buffer->signalSemaphoreCount = 0;
+    commandBuffer->presentDataCount = 0;
+    commandBuffer->waitSemaphoreCount = 0;
+    commandBuffer->signalSemaphoreCount = 0;
 
     // Reset defrag state
 
-    if (command_buffer->isDefrag) {
+    if (commandBuffer->isDefrag) {
         renderer->defragInProgress = 0;
     }
 
@@ -10391,21 +10391,21 @@ static void VULKAN_INTERNAL_CleanCommandBuffer(
 
     SDL_LockMutex(renderer->acquireCommandBufferLock);
 
-    if (command_buffer->commandPool->inactiveCommandBufferCount == command_buffer->commandPool->inactiveCommandBufferCapacity) {
-        command_buffer->commandPool->inactiveCommandBufferCapacity += 1;
-        command_buffer->commandPool->inactiveCommandBuffers = SDL_realloc(
-            command_buffer->commandPool->inactiveCommandBuffers,
-            command_buffer->commandPool->inactiveCommandBufferCapacity * sizeof(VulkanCommandBuffer *));
+    if (commandBuffer->commandPool->inactiveCommandBufferCount == commandBuffer->commandPool->inactiveCommandBufferCapacity) {
+        commandBuffer->commandPool->inactiveCommandBufferCapacity += 1;
+        commandBuffer->commandPool->inactiveCommandBuffers = SDL_realloc(
+            commandBuffer->commandPool->inactiveCommandBuffers,
+            commandBuffer->commandPool->inactiveCommandBufferCapacity * sizeof(VulkanCommandBuffer *));
     }
 
-    command_buffer->commandPool->inactiveCommandBuffers[command_buffer->commandPool->inactiveCommandBufferCount] = command_buffer;
-    command_buffer->commandPool->inactiveCommandBufferCount += 1;
+    commandBuffer->commandPool->inactiveCommandBuffers[commandBuffer->commandPool->inactiveCommandBufferCount] = commandBuffer;
+    commandBuffer->commandPool->inactiveCommandBufferCount += 1;
 
     SDL_UnlockMutex(renderer->acquireCommandBufferLock);
 
     // Remove this command buffer from the submitted list
     for (i = 0; i < renderer->submittedCommandBufferCount; i += 1) {
-        if (renderer->submittedCommandBuffers[i] == command_buffer) {
+        if (renderer->submittedCommandBuffers[i] == commandBuffer) {
             renderer->submittedCommandBuffers[i] = renderer->submittedCommandBuffers[renderer->submittedCommandBufferCount - 1];
             renderer->submittedCommandBufferCount -= 1;
         }
@@ -10414,23 +10414,23 @@ static void VULKAN_INTERNAL_CleanCommandBuffer(
 
 static void VULKAN_WaitForFences(
     SDL_GPURenderer *driverData,
-    bool wait_all,
+    bool waitAll,
     SDL_GPUFence *const *fences,
-    Uint32 num_fences)
+    Uint32 numFences)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    VkFence *vkFences = SDL_stack_alloc(VkFence, num_fences);
+    VkFence *vkFences = SDL_stack_alloc(VkFence, numFences);
     VkResult result;
 
-    for (Uint32 i = 0; i < num_fences; i += 1) {
+    for (Uint32 i = 0; i < numFences; i += 1) {
         vkFences[i] = ((VulkanFenceHandle *)fences[i])->fence;
     }
 
     result = renderer->vkWaitForFences(
         renderer->logicalDevice,
-        num_fences,
+        numFences,
         vkFences,
-        wait_all,
+        waitAll,
         UINT64_MAX);
 
     if (result != VK_SUCCESS) {
@@ -10462,7 +10462,7 @@ static void VULKAN_Wait(
     SDL_GPURenderer *driverData)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    VulkanCommandBuffer *command_buffer;
+    VulkanCommandBuffer *commandBuffer;
     VkResult result;
     Sint32 i;
 
@@ -10476,8 +10476,8 @@ static void VULKAN_Wait(
     SDL_LockMutex(renderer->submitLock);
 
     for (i = renderer->submittedCommandBufferCount - 1; i >= 0; i -= 1) {
-        command_buffer = renderer->submittedCommandBuffers[i];
-        VULKAN_INTERNAL_CleanCommandBuffer(renderer, command_buffer);
+        commandBuffer = renderer->submittedCommandBuffers[i];
+        VULKAN_INTERNAL_CleanCommandBuffer(renderer, commandBuffer);
     }
 
     VULKAN_INTERNAL_PerformPendingDestroys(renderer);
@@ -10486,22 +10486,22 @@ static void VULKAN_Wait(
 }
 
 static SDL_GPUFence *VULKAN_SubmitAndAcquireFence(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
     VulkanCommandBuffer *vulkanCommandBuffer;
 
-    vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     vulkanCommandBuffer->autoReleaseFence = 0;
 
-    VULKAN_Submit(command_buffer);
+    VULKAN_Submit(commandBuffer);
 
     return (SDL_GPUFence *)vulkanCommandBuffer->inFlightFence;
 }
 
 static void VULKAN_Submit(
-    SDL_GPUCommandBuffer *command_buffer)
+    SDL_GPUCommandBuffer *commandBuffer)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VkSubmitInfo submitInfo;
     VkPresentInfoKHR presentInfo;
@@ -10545,7 +10545,7 @@ static void VULKAN_Submit(
     submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
     submitInfo.pNext = NULL;
     submitInfo.commandBufferCount = 1;
-    submitInfo.pCommandBuffers = &vulkanCommandBuffer->command_buffer;
+    submitInfo.pCommandBuffers = &vulkanCommandBuffer->commandBuffer;
 
     submitInfo.pWaitDstStageMask = waitStages;
     submitInfo.pWaitSemaphores = vulkanCommandBuffer->waitSemaphores;
@@ -10670,7 +10670,7 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
     VulkanTexture *newTexture;
     VkBufferCopy bufferCopy;
     VkImageCopy imageCopy;
-    VulkanCommandBuffer *command_buffer;
+    VulkanCommandBuffer *commandBuffer;
     VulkanTextureSubresource *srcSubresource;
     VulkanTextureSubresource *dstSubresource;
     Uint32 i, subresourceIndex;
@@ -10679,12 +10679,12 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
 
     renderer->defragInProgress = 1;
 
-    command_buffer = (VulkanCommandBuffer *)VULKAN_AcquireCommandBuffer((SDL_GPURenderer *)renderer);
-    if (command_buffer == NULL) {
+    commandBuffer = (VulkanCommandBuffer *)VULKAN_AcquireCommandBuffer((SDL_GPURenderer *)renderer);
+    if (commandBuffer == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create defrag command buffer!");
         return 0;
     }
-    command_buffer->isDefrag = 1;
+    commandBuffer->isDefrag = 1;
 
     allocation = renderer->allocationsToDefrag[renderer->allocationsToDefragCount - 1];
     renderer->allocationsToDefragCount -= 1;
@@ -10697,12 +10697,12 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
         currentRegion = allocation->usedRegions[i];
 
         if (currentRegion->isBuffer && !currentRegion->vulkanBuffer->markedForDestroy) {
-            currentRegion->vulkanBuffer->usage_flags |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+            currentRegion->vulkanBuffer->usageFlags |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
 
             newBuffer = VULKAN_INTERNAL_CreateBuffer(
                 renderer,
                 currentRegion->vulkanBuffer->size,
-                currentRegion->vulkanBuffer->usage_flags,
+                currentRegion->vulkanBuffer->usageFlags,
                 currentRegion->vulkanBuffer->type);
 
             if (newBuffer == NULL) {
@@ -10711,7 +10711,7 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
             }
 
             if (
-                renderer->debug_mode &&
+                renderer->debugMode &&
                 renderer->supportsDebugUtils &&
                 currentRegion->vulkanBuffer->handle != NULL &&
                 currentRegion->vulkanBuffer->handle->container != NULL &&
@@ -10727,13 +10727,13 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
                 currentRegion->vulkanBuffer->type == VULKAN_BUFFER_TYPE_GPU && currentRegion->vulkanBuffer->transitioned) {
                 VULKAN_INTERNAL_BufferTransitionFromDefaultUsage(
                     renderer,
-                    command_buffer,
+                    commandBuffer,
                     VULKAN_BUFFER_USAGE_MODE_COPY_SOURCE,
                     currentRegion->vulkanBuffer);
 
                 VULKAN_INTERNAL_BufferTransitionFromDefaultUsage(
                     renderer,
-                    command_buffer,
+                    commandBuffer,
                     VULKAN_BUFFER_USAGE_MODE_COPY_DESTINATION,
                     newBuffer);
 
@@ -10742,7 +10742,7 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
                 bufferCopy.size = currentRegion->resourceSize;
 
                 renderer->vkCmdCopyBuffer(
-                    command_buffer->command_buffer,
+                    commandBuffer->commandBuffer,
                     currentRegion->vulkanBuffer->buffer,
                     newBuffer->buffer,
                     1,
@@ -10750,12 +10750,12 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
 
                 VULKAN_INTERNAL_BufferTransitionToDefaultUsage(
                     renderer,
-                    command_buffer,
+                    commandBuffer,
                     VULKAN_BUFFER_USAGE_MODE_COPY_DESTINATION,
                     newBuffer);
 
-                VULKAN_INTERNAL_TrackBuffer(command_buffer, currentRegion->vulkanBuffer);
-                VULKAN_INTERNAL_TrackBuffer(command_buffer, newBuffer);
+                VULKAN_INTERNAL_TrackBuffer(commandBuffer, currentRegion->vulkanBuffer);
+                VULKAN_INTERNAL_TrackBuffer(commandBuffer, newBuffer);
             }
 
             // re-point original container to new buffer
@@ -10774,12 +10774,12 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
                 currentRegion->vulkanTexture->depth,
                 currentRegion->vulkanTexture->type,
                 currentRegion->vulkanTexture->layerCount,
-                currentRegion->vulkanTexture->num_levels,
-                currentRegion->vulkanTexture->sample_count,
+                currentRegion->vulkanTexture->numLevels,
+                currentRegion->vulkanTexture->sampleCount,
                 currentRegion->vulkanTexture->format,
                 currentRegion->vulkanTexture->swizzle,
                 currentRegion->vulkanTexture->aspectFlags,
-                currentRegion->vulkanTexture->usage_flags,
+                currentRegion->vulkanTexture->usageFlags,
                 currentRegion->vulkanTexture->isMSAAColorTarget);
 
             if (newTexture == NULL) {
@@ -10794,7 +10794,7 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
 
                 // Set debug name if it exists
                 if (
-                    renderer->debug_mode &&
+                    renderer->debugMode &&
                     renderer->supportsDebugUtils &&
                     srcSubresource->parent->handle != NULL &&
                     srcSubresource->parent->handle->container != NULL &&
@@ -10808,13 +10808,13 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
                 if (srcSubresource->transitioned) {
                     VULKAN_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
                         renderer,
-                        command_buffer,
+                        commandBuffer,
                         VULKAN_TEXTURE_USAGE_MODE_COPY_SOURCE,
                         srcSubresource);
 
                     VULKAN_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
                         renderer,
-                        command_buffer,
+                        commandBuffer,
                         VULKAN_TEXTURE_USAGE_MODE_COPY_DESTINATION,
                         dstSubresource);
 
@@ -10837,7 +10837,7 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
                     imageCopy.dstSubresource.mipLevel = dstSubresource->level;
 
                     renderer->vkCmdCopyImage(
-                        command_buffer->command_buffer,
+                        commandBuffer->commandBuffer,
                         currentRegion->vulkanTexture->image,
                         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                         newTexture->image,
@@ -10847,12 +10847,12 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
 
                     VULKAN_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
                         renderer,
-                        command_buffer,
+                        commandBuffer,
                         VULKAN_TEXTURE_USAGE_MODE_COPY_DESTINATION,
                         dstSubresource);
 
-                    VULKAN_INTERNAL_TrackTexture(command_buffer, srcSubresource->parent);
-                    VULKAN_INTERNAL_TrackTexture(command_buffer, dstSubresource->parent);
+                    VULKAN_INTERNAL_TrackTexture(commandBuffer, srcSubresource->parent);
+                    VULKAN_INTERNAL_TrackTexture(commandBuffer, dstSubresource->parent);
                 }
             }
 
@@ -10868,7 +10868,7 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
     SDL_UnlockMutex(renderer->allocatorLock);
 
     VULKAN_Submit(
-        (SDL_GPUCommandBuffer *)command_buffer);
+        (SDL_GPUCommandBuffer *)commandBuffer);
 
     return 1;
 }
@@ -11185,7 +11185,7 @@ static Uint8 VULKAN_INTERNAL_CreateInstance(VulkanRenderer *renderer)
     createInfo.ppEnabledLayerNames = layerNames;
     createInfo.enabledExtensionCount = instanceExtensionCount;
     createInfo.ppEnabledExtensionNames = instanceExtensionNames;
-    if (renderer->debug_mode) {
+    if (renderer->debugMode) {
         createInfo.enabledLayerCount = SDL_arraysize(layerNames);
         if (!VULKAN_INTERNAL_CheckValidationLayers(
                 layerNames,
@@ -11623,13 +11623,13 @@ static bool VULKAN_INTERNAL_PrepareVulkan(
     return true;
 }
 
-static bool VULKAN_PrepareDriver(SDL_VideoDevice *_this)
+static bool VULKAN_PrepareDriver(SDL_VideoDevice *this)
 {
     // Set up dummy VulkanRenderer
     VulkanRenderer *renderer;
     Uint8 result;
 
-    if (_this->Vulkan_CreateSurface == NULL) {
+    if (this->Vulkan_CreateSurface == NULL) {
         return false;
     }
 
@@ -11650,7 +11650,7 @@ static bool VULKAN_PrepareDriver(SDL_VideoDevice *_this)
     return result;
 }
 
-static SDL_GPUDevice *VULKAN_CreateDevice(bool debug_mode, bool preferLowPower, SDL_PropertiesID props)
+static SDL_GPUDevice *VULKAN_CreateDevice(bool debugMode, bool preferLowPower, SDL_PropertiesID props)
 {
     VulkanRenderer *renderer;
 
@@ -11668,7 +11668,7 @@ static SDL_GPUDevice *VULKAN_CreateDevice(bool debug_mode, bool preferLowPower, 
 
     renderer = (VulkanRenderer *)SDL_malloc(sizeof(VulkanRenderer));
     SDL_memset(renderer, '\0', sizeof(VulkanRenderer));
-    renderer->debug_mode = debug_mode;
+    renderer->debugMode = debugMode;
     renderer->preferLowPower = preferLowPower;
 
     if (!VULKAN_INTERNAL_PrepareVulkan(renderer)) {

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -580,7 +580,7 @@ struct VulkanBuffer
     VulkanMemoryUsedRegion *usedRegion;
 
     VulkanBufferType type;
-    SDL_GPUBufferUsageFlags usageFlags;
+    SDL_GPUBufferUsageFlags usage_flags;
 
     SDL_AtomicInt referenceCount; // Tracks command buffer usage
 
@@ -630,11 +630,11 @@ typedef struct VulkanSampler
 typedef struct VulkanShader
 {
     VkShaderModule shaderModule;
-    const char *entryPointName;
-    Uint32 samplerCount;
-    Uint32 storageTextureCount;
-    Uint32 storageBufferCount;
-    Uint32 uniformBufferCount;
+    const char *entrypoint_name;
+    Uint32 num_samplers;
+    Uint32 num_storage_textures;
+    Uint32 num_storage_buffers;
+    Uint32 num_uniform_buffers;
     SDL_AtomicInt referenceCount;
 } VulkanShader;
 
@@ -675,11 +675,11 @@ struct VulkanTexture
 
     Uint32 depth;
     Uint32 layerCount;
-    Uint32 levelCount;
-    VkSampleCountFlagBits sampleCount; // NOTE: This refers to the sample count of a render target pass using this texture, not the actual sample count of the texture
+    Uint32 num_levels;
+    VkSampleCountFlagBits sample_count; // NOTE: This refers to the sample count of a render target pass using this texture, not the actual sample count of the texture
     VkFormat format;
     VkComponentMapping swizzle;
-    SDL_GPUTextureUsageFlags usageFlags;
+    SDL_GPUTextureUsageFlags usage_flags;
     VkImageAspectFlags aspectFlags;
 
     Uint32 subresourceCount;
@@ -765,7 +765,7 @@ typedef struct VulkanSwapchainData
     VkFormat format;
     VkColorSpaceKHR colorSpace;
     VkComponentMapping swapchainSwizzle;
-    VkPresentModeKHR presentMode;
+    VkPresentModeKHR present_mode;
     bool usingFallbackFormat;
 
     // Swapchain images
@@ -783,8 +783,8 @@ typedef struct VulkanSwapchainData
 typedef struct WindowData
 {
     SDL_Window *window;
-    SDL_GPUSwapchainComposition swapchainComposition;
-    SDL_GPUPresentMode presentMode;
+    SDL_GPUSwapchainComposition swapchain_composition;
+    SDL_GPUPresentMode present_mode;
     VulkanSwapchainData *swapchainData;
     bool needsSwapchainRecreate;
 } WindowData;
@@ -864,12 +864,12 @@ typedef struct VulkanGraphicsPipelineResourceLayout
 typedef struct VulkanGraphicsPipeline
 {
     VkPipeline pipeline;
-    SDL_GPUPrimitiveType primitiveType;
+    SDL_GPUPrimitiveType primitive_type;
 
     VulkanGraphicsPipelineResourceLayout resourceLayout;
 
-    VulkanShader *vertexShader;
-    VulkanShader *fragmentShader;
+    VulkanShader *vertex_shader;
+    VulkanShader *fragment_shader;
 
     SDL_AtomicInt referenceCount;
 } VulkanGraphicsPipeline;
@@ -886,11 +886,11 @@ typedef struct VulkanComputePipelineResourceLayout
      */
     DescriptorSetPool descriptorSetPools[3];
 
-    Uint32 readOnlyStorageTextureCount;
-    Uint32 readOnlyStorageBufferCount;
-    Uint32 writeOnlyStorageTextureCount;
-    Uint32 writeOnlyStorageBufferCount;
-    Uint32 uniformBufferCount;
+    Uint32 num_readonly_storage_textures;
+    Uint32 num_readonly_storage_buffers;
+    Uint32 num_writeonly_storage_textures;
+    Uint32 num_writeonly_storage_buffers;
+    Uint32 num_uniform_buffers;
 } VulkanComputePipelineResourceLayout;
 
 typedef struct VulkanComputePipeline
@@ -904,17 +904,17 @@ typedef struct VulkanComputePipeline
 typedef struct RenderPassColorTargetDescription
 {
     VkFormat format;
-    SDL_GPULoadOp loadOp;
-    SDL_GPUStoreOp storeOp;
+    SDL_GPULoadOp load_op;
+    SDL_GPUStoreOp store_op;
 } RenderPassColorTargetDescription;
 
 typedef struct RenderPassDepthStencilTargetDescription
 {
     VkFormat format;
-    SDL_GPULoadOp loadOp;
-    SDL_GPUStoreOp storeOp;
-    SDL_GPULoadOp stencilLoadOp;
-    SDL_GPUStoreOp stencilStoreOp;
+    SDL_GPULoadOp load_op;
+    SDL_GPUStoreOp store_op;
+    SDL_GPULoadOp stencil_load_op;
+    SDL_GPUStoreOp stencil_store_op;
 } RenderPassDepthStencilTargetDescription;
 
 typedef struct CommandPoolHashTableKey
@@ -925,7 +925,7 @@ typedef struct CommandPoolHashTableKey
 typedef struct RenderPassHashTableKey
 {
     RenderPassColorTargetDescription colorTargetDescriptions[MAX_COLOR_TARGET_BINDINGS];
-    Uint32 colorAttachmentCount;
+    Uint32 num_color_attachments;
     RenderPassDepthStencilTargetDescription depthStencilTargetDescription;
     VkSampleCountFlagBits colorAttachmentSampleCount;
 } RenderPassHashTableKey;
@@ -939,7 +939,7 @@ typedef struct FramebufferHashTableKey
 {
     VkImageView colorAttachmentViews[MAX_COLOR_TARGET_BINDINGS];
     VkImageView colorMultiSampleAttachmentViews[MAX_COLOR_TARGET_BINDINGS];
-    Uint32 colorAttachmentCount;
+    Uint32 num_color_attachments;
     VkImageView depthStencilAttachmentView;
     Uint32 width;
     Uint32 height;
@@ -971,7 +971,7 @@ typedef struct VulkanCommandBuffer
     CommandBufferCommonHeader common;
     VulkanRenderer *renderer;
 
-    VkCommandBuffer commandBuffer;
+    VkCommandBuffer command_buffer;
     VulkanCommandPool *commandPool;
 
     VulkanPresentData *presentDatas;
@@ -1000,7 +1000,7 @@ typedef struct VulkanCommandBuffer
 
     VkViewport currentViewport;
     VkRect2D currentScissor;
-    float blendConstants[4];
+    float blend_constants[4];
     Uint8 stencilRef;
 
     // Resource bind state
@@ -1113,7 +1113,7 @@ struct VulkanRenderer
     Uint8 outofBARMemoryWarning;
     Uint8 fillModeOnlyWarning;
 
-    bool debugMode;
+    bool debug_mode;
     bool preferLowPower;
     VulkanExtensions supports;
     bool supportsDebugUtils;
@@ -1205,11 +1205,11 @@ struct VulkanRenderer
 // Forward declarations
 
 static Uint8 VULKAN_INTERNAL_DefragmentMemory(VulkanRenderer *renderer);
-static void VULKAN_INTERNAL_BeginCommandBuffer(VulkanRenderer *renderer, VulkanCommandBuffer *commandBuffer);
+static void VULKAN_INTERNAL_BeginCommandBuffer(VulkanRenderer *renderer, VulkanCommandBuffer *command_buffer);
 static void VULKAN_ReleaseWindow(SDL_GPURenderer *driverData, SDL_Window *window);
 static void VULKAN_Wait(SDL_GPURenderer *driverData);
-static void VULKAN_WaitForFences(SDL_GPURenderer *driverData, bool waitAll, SDL_GPUFence *const *pFences, Uint32 fenceCount);
-static void VULKAN_Submit(SDL_GPUCommandBuffer *commandBuffer);
+static void VULKAN_WaitForFences(SDL_GPURenderer *driverData, bool wait_all, SDL_GPUFence *const *fences, Uint32 num_fences);
+static void VULKAN_Submit(SDL_GPUCommandBuffer *command_buffer);
 static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
     VulkanRenderer *renderer,
     Uint32 width,
@@ -1217,8 +1217,8 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
     Uint32 depth,
     SDL_GPUTextureType type,
     Uint32 layerCount,
-    Uint32 levelCount,
-    VkSampleCountFlagBits sampleCount,
+    Uint32 num_levels,
+    VkSampleCountFlagBits sample_count,
     VkFormat format,
     VkComponentMapping swizzle,
     VkImageAspectFlags aspectMask,
@@ -2381,42 +2381,42 @@ static Uint8 VULKAN_INTERNAL_BindMemoryForBuffer(
 #define ADD_TO_ARRAY_UNIQUE(resource, type, array, count, capacity) \
     Uint32 i;                                                       \
                                                                     \
-    for (i = 0; i < commandBuffer->count; i += 1) {                 \
-        if (commandBuffer->array[i] == resource) {                  \
+    for (i = 0; i < command_buffer->count; i += 1) {                 \
+        if (command_buffer->array[i] == resource) {                  \
             return;                                                 \
         }                                                           \
     }                                                               \
                                                                     \
-    if (commandBuffer->count == commandBuffer->capacity) {          \
-        commandBuffer->capacity += 1;                               \
-        commandBuffer->array = SDL_realloc(                         \
-            commandBuffer->array,                                   \
-            commandBuffer->capacity * sizeof(type));                \
+    if (command_buffer->count == command_buffer->capacity) {          \
+        command_buffer->capacity += 1;                               \
+        command_buffer->array = SDL_realloc(                         \
+            command_buffer->array,                                   \
+            command_buffer->capacity * sizeof(type));                \
     }                                                               \
-    commandBuffer->array[commandBuffer->count] = resource;          \
-    commandBuffer->count += 1;
+    command_buffer->array[command_buffer->count] = resource;          \
+    command_buffer->count += 1;
 
 #define TRACK_RESOURCE(resource, type, array, count, capacity) \
     Uint32 i;                                                  \
                                                                \
-    for (i = 0; i < commandBuffer->count; i += 1) {            \
-        if (commandBuffer->array[i] == resource) {             \
+    for (i = 0; i < command_buffer->count; i += 1) {            \
+        if (command_buffer->array[i] == resource) {             \
             return;                                            \
         }                                                      \
     }                                                          \
                                                                \
-    if (commandBuffer->count == commandBuffer->capacity) {     \
-        commandBuffer->capacity += 1;                          \
-        commandBuffer->array = SDL_realloc(                    \
-            commandBuffer->array,                              \
-            commandBuffer->capacity * sizeof(type));           \
+    if (command_buffer->count == command_buffer->capacity) {     \
+        command_buffer->capacity += 1;                          \
+        command_buffer->array = SDL_realloc(                    \
+            command_buffer->array,                              \
+            command_buffer->capacity * sizeof(type));           \
     }                                                          \
-    commandBuffer->array[commandBuffer->count] = resource;     \
-    commandBuffer->count += 1;                                 \
+    command_buffer->array[command_buffer->count] = resource;     \
+    command_buffer->count += 1;                                 \
     SDL_AtomicIncRef(&resource->referenceCount);
 
 static void VULKAN_INTERNAL_TrackBuffer(
-    VulkanCommandBuffer *commandBuffer,
+    VulkanCommandBuffer *command_buffer,
     VulkanBuffer *buffer)
 {
     TRACK_RESOURCE(
@@ -2428,7 +2428,7 @@ static void VULKAN_INTERNAL_TrackBuffer(
 }
 
 static void VULKAN_INTERNAL_TrackTexture(
-    VulkanCommandBuffer *commandBuffer,
+    VulkanCommandBuffer *command_buffer,
     VulkanTexture *texture)
 {
     TRACK_RESOURCE(
@@ -2440,7 +2440,7 @@ static void VULKAN_INTERNAL_TrackTexture(
 }
 
 static void VULKAN_INTERNAL_TrackSampler(
-    VulkanCommandBuffer *commandBuffer,
+    VulkanCommandBuffer *command_buffer,
     VulkanSampler *sampler)
 {
     TRACK_RESOURCE(
@@ -2452,11 +2452,11 @@ static void VULKAN_INTERNAL_TrackSampler(
 }
 
 static void VULKAN_INTERNAL_TrackGraphicsPipeline(
-    VulkanCommandBuffer *commandBuffer,
-    VulkanGraphicsPipeline *graphicsPipeline)
+    VulkanCommandBuffer *command_buffer,
+    VulkanGraphicsPipeline *graphics_pipeline)
 {
     TRACK_RESOURCE(
-        graphicsPipeline,
+        graphics_pipeline,
         VulkanGraphicsPipeline *,
         usedGraphicsPipelines,
         usedGraphicsPipelineCount,
@@ -2464,11 +2464,11 @@ static void VULKAN_INTERNAL_TrackGraphicsPipeline(
 }
 
 static void VULKAN_INTERNAL_TrackComputePipeline(
-    VulkanCommandBuffer *commandBuffer,
-    VulkanComputePipeline *computePipeline)
+    VulkanCommandBuffer *command_buffer,
+    VulkanComputePipeline *compute_pipeline)
 {
     TRACK_RESOURCE(
-        computePipeline,
+        compute_pipeline,
         VulkanComputePipeline *,
         usedComputePipelines,
         usedComputePipelineCount,
@@ -2477,7 +2477,7 @@ static void VULKAN_INTERNAL_TrackComputePipeline(
 
 static void VULKAN_INTERNAL_TrackFramebuffer(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *commandBuffer,
+    VulkanCommandBuffer *command_buffer,
     VulkanFramebuffer *framebuffer)
 {
     TRACK_RESOURCE(
@@ -2489,27 +2489,27 @@ static void VULKAN_INTERNAL_TrackFramebuffer(
 }
 
 static void VULKAN_INTERNAL_TrackUniformBuffer(
-    VulkanCommandBuffer *commandBuffer,
+    VulkanCommandBuffer *command_buffer,
     VulkanUniformBuffer *uniformBuffer)
 {
     Uint32 i;
-    for (i = 0; i < commandBuffer->usedUniformBufferCount; i += 1) {
-        if (commandBuffer->usedUniformBuffers[i] == uniformBuffer) {
+    for (i = 0; i < command_buffer->usedUniformBufferCount; i += 1) {
+        if (command_buffer->usedUniformBuffers[i] == uniformBuffer) {
             return;
         }
     }
 
-    if (commandBuffer->usedUniformBufferCount == commandBuffer->usedUniformBufferCapacity) {
-        commandBuffer->usedUniformBufferCapacity += 1;
-        commandBuffer->usedUniformBuffers = SDL_realloc(
-            commandBuffer->usedUniformBuffers,
-            commandBuffer->usedUniformBufferCapacity * sizeof(VulkanUniformBuffer *));
+    if (command_buffer->usedUniformBufferCount == command_buffer->usedUniformBufferCapacity) {
+        command_buffer->usedUniformBufferCapacity += 1;
+        command_buffer->usedUniformBuffers = SDL_realloc(
+            command_buffer->usedUniformBuffers,
+            command_buffer->usedUniformBufferCapacity * sizeof(VulkanUniformBuffer *));
     }
-    commandBuffer->usedUniformBuffers[commandBuffer->usedUniformBufferCount] = uniformBuffer;
-    commandBuffer->usedUniformBufferCount += 1;
+    command_buffer->usedUniformBuffers[command_buffer->usedUniformBufferCount] = uniformBuffer;
+    command_buffer->usedUniformBufferCount += 1;
 
     VULKAN_INTERNAL_TrackBuffer(
-        commandBuffer,
+        command_buffer,
         uniformBuffer->bufferHandle->vulkanBuffer);
 }
 
@@ -2554,7 +2554,7 @@ static void VULKAN_INTERNAL_TrackUniformBuffer(
 
 static void VULKAN_INTERNAL_BufferMemoryBarrier(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *commandBuffer,
+    VulkanCommandBuffer *command_buffer,
     VulkanBufferUsageMode sourceUsageMode,
     VulkanBufferUsageMode destinationUsageMode,
     VulkanBuffer *buffer)
@@ -2632,7 +2632,7 @@ static void VULKAN_INTERNAL_BufferMemoryBarrier(
     }
 
     renderer->vkCmdPipelineBarrier(
-        commandBuffer->commandBuffer,
+        command_buffer->command_buffer,
         srcStages,
         dstStages,
         0,
@@ -2648,7 +2648,7 @@ static void VULKAN_INTERNAL_BufferMemoryBarrier(
 
 static void VULKAN_INTERNAL_TextureSubresourceMemoryBarrier(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *commandBuffer,
+    VulkanCommandBuffer *command_buffer,
     VulkanTextureUsageMode sourceUsageMode,
     VulkanTextureUsageMode destinationUsageMode,
     VulkanTextureSubresource *textureSubresource)
@@ -2755,7 +2755,7 @@ static void VULKAN_INTERNAL_TextureSubresourceMemoryBarrier(
     }
 
     renderer->vkCmdPipelineBarrier(
-        commandBuffer->commandBuffer,
+        command_buffer->command_buffer,
         srcStages,
         dstStages,
         0,
@@ -2774,17 +2774,17 @@ static VulkanBufferUsageMode VULKAN_INTERNAL_DefaultBufferUsageMode(
 {
     // NOTE: order matters here!
 
-    if (buffer->usageFlags & SDL_GPU_BUFFERUSAGE_VERTEX) {
+    if (buffer->usage_flags & SDL_GPU_BUFFERUSAGE_VERTEX) {
         return VULKAN_BUFFER_USAGE_MODE_VERTEX_READ;
-    } else if (buffer->usageFlags & SDL_GPU_BUFFERUSAGE_INDEX) {
+    } else if (buffer->usage_flags & SDL_GPU_BUFFERUSAGE_INDEX) {
         return VULKAN_BUFFER_USAGE_MODE_INDEX_READ;
-    } else if (buffer->usageFlags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
+    } else if (buffer->usage_flags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
         return VULKAN_BUFFER_USAGE_MODE_INDIRECT;
-    } else if (buffer->usageFlags & SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ) {
+    } else if (buffer->usage_flags & SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ) {
         return VULKAN_BUFFER_USAGE_MODE_GRAPHICS_STORAGE_READ;
-    } else if (buffer->usageFlags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ) {
+    } else if (buffer->usage_flags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ) {
         return VULKAN_BUFFER_USAGE_MODE_COMPUTE_STORAGE_READ;
-    } else if (buffer->usageFlags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE) {
+    } else if (buffer->usage_flags & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE) {
         return VULKAN_BUFFER_USAGE_MODE_COMPUTE_STORAGE_READ_WRITE;
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Buffer has no default usage mode!");
@@ -2798,17 +2798,17 @@ static VulkanTextureUsageMode VULKAN_INTERNAL_DefaultTextureUsageMode(
     // NOTE: order matters here!
     // NOTE: graphics storage bits and sampler bit are mutually exclusive!
 
-    if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_SAMPLER) {
+    if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_SAMPLER) {
         return VULKAN_TEXTURE_USAGE_MODE_SAMPLER;
-    } else if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ) {
+    } else if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_GRAPHICS_STORAGE_READ) {
         return VULKAN_TEXTURE_USAGE_MODE_GRAPHICS_STORAGE_READ;
-    } else if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
+    } else if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
         return VULKAN_TEXTURE_USAGE_MODE_COLOR_ATTACHMENT;
-    } else if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
+    } else if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
         return VULKAN_TEXTURE_USAGE_MODE_DEPTH_STENCIL_ATTACHMENT;
-    } else if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ) {
+    } else if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_READ) {
         return VULKAN_TEXTURE_USAGE_MODE_COMPUTE_STORAGE_READ;
-    } else if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
+    } else if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
         return VULKAN_TEXTURE_USAGE_MODE_COMPUTE_STORAGE_READ_WRITE;
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Texture has no default usage mode!");
@@ -2818,13 +2818,13 @@ static VulkanTextureUsageMode VULKAN_INTERNAL_DefaultTextureUsageMode(
 
 static void VULKAN_INTERNAL_BufferTransitionFromDefaultUsage(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *commandBuffer,
+    VulkanCommandBuffer *command_buffer,
     VulkanBufferUsageMode destinationUsageMode,
     VulkanBuffer *buffer)
 {
     VULKAN_INTERNAL_BufferMemoryBarrier(
         renderer,
-        commandBuffer,
+        command_buffer,
         VULKAN_INTERNAL_DefaultBufferUsageMode(buffer),
         destinationUsageMode,
         buffer);
@@ -2832,13 +2832,13 @@ static void VULKAN_INTERNAL_BufferTransitionFromDefaultUsage(
 
 static void VULKAN_INTERNAL_BufferTransitionToDefaultUsage(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *commandBuffer,
+    VulkanCommandBuffer *command_buffer,
     VulkanBufferUsageMode sourceUsageMode,
     VulkanBuffer *buffer)
 {
     VULKAN_INTERNAL_BufferMemoryBarrier(
         renderer,
-        commandBuffer,
+        command_buffer,
         sourceUsageMode,
         VULKAN_INTERNAL_DefaultBufferUsageMode(buffer),
         buffer);
@@ -2846,13 +2846,13 @@ static void VULKAN_INTERNAL_BufferTransitionToDefaultUsage(
 
 static void VULKAN_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *commandBuffer,
+    VulkanCommandBuffer *command_buffer,
     VulkanTextureUsageMode destinationUsageMode,
     VulkanTextureSubresource *textureSubresource)
 {
     VULKAN_INTERNAL_TextureSubresourceMemoryBarrier(
         renderer,
-        commandBuffer,
+        command_buffer,
         VULKAN_INTERNAL_DefaultTextureUsageMode(textureSubresource->parent),
         destinationUsageMode,
         textureSubresource);
@@ -2860,14 +2860,14 @@ static void VULKAN_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
 
 static void VULKAN_INTERNAL_TextureTransitionFromDefaultUsage(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *commandBuffer,
+    VulkanCommandBuffer *command_buffer,
     VulkanTextureUsageMode destinationUsageMode,
     VulkanTexture *texture)
 {
     for (Uint32 i = 0; i < texture->subresourceCount; i += 1) {
         VULKAN_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
             renderer,
-            commandBuffer,
+            command_buffer,
             destinationUsageMode,
             &texture->subresources[i]);
     }
@@ -2875,13 +2875,13 @@ static void VULKAN_INTERNAL_TextureTransitionFromDefaultUsage(
 
 static void VULKAN_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *commandBuffer,
+    VulkanCommandBuffer *command_buffer,
     VulkanTextureUsageMode sourceUsageMode,
     VulkanTextureSubresource *textureSubresource)
 {
     VULKAN_INTERNAL_TextureSubresourceMemoryBarrier(
         renderer,
-        commandBuffer,
+        command_buffer,
         sourceUsageMode,
         VULKAN_INTERNAL_DefaultTextureUsageMode(textureSubresource->parent),
         textureSubresource);
@@ -2889,7 +2889,7 @@ static void VULKAN_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
 
 static void VULKAN_INTERNAL_TextureTransitionToDefaultUsage(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *commandBuffer,
+    VulkanCommandBuffer *command_buffer,
     VulkanTextureUsageMode sourceUsageMode,
     VulkanTexture *texture)
 {
@@ -2897,7 +2897,7 @@ static void VULKAN_INTERNAL_TextureTransitionToDefaultUsage(
     for (Uint32 i = 0; i < texture->subresourceCount; i += 1) {
         VULKAN_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
             renderer,
-            commandBuffer,
+            command_buffer,
             sourceUsageMode,
             &texture->subresources[i]);
     }
@@ -2953,7 +2953,7 @@ static void VULKAN_INTERNAL_RemoveFramebuffersContainingView(
 
     while (SDL_IterateHashTable(renderer->framebufferHashTable, (const void **)&key, (const void **)&value, &iter)) {
         bool remove = false;
-        for (Uint32 i = 0; i < key->colorAttachmentCount; i += 1) {
+        for (Uint32 i = 0; i < key->num_color_attachments; i += 1) {
             if (key->colorAttachmentViews[i] == view) {
                 remove = true;
             }
@@ -2990,7 +2990,7 @@ static void VULKAN_INTERNAL_DestroyTexture(
 {
     // Clean up subresources
     for (Uint32 subresourceIndex = 0; subresourceIndex < texture->subresourceCount; subresourceIndex += 1) {
-        if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
+        if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET) {
             for (Uint32 depthIndex = 0; depthIndex < texture->depth; depthIndex += 1) {
                 VULKAN_INTERNAL_RemoveFramebuffersContainingView(
                     renderer,
@@ -3013,14 +3013,14 @@ static void VULKAN_INTERNAL_DestroyTexture(
             SDL_free(texture->subresources[subresourceIndex].renderTargetViews);
         }
 
-        if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
+        if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) {
             renderer->vkDestroyImageView(
                 renderer->logicalDevice,
                 texture->subresources[subresourceIndex].computeWriteView,
                 NULL);
         }
 
-        if (texture->usageFlags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
+        if (texture->usage_flags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
             renderer->vkDestroyImageView(
                 renderer->logicalDevice,
                 texture->subresources[subresourceIndex].depthStencilView,
@@ -3068,7 +3068,7 @@ static void VULKAN_INTERNAL_DestroyCommandPool(
     VulkanCommandPool *commandPool)
 {
     Uint32 i;
-    VulkanCommandBuffer *commandBuffer;
+    VulkanCommandBuffer *command_buffer;
 
     renderer->vkDestroyCommandPool(
         renderer->logicalDevice,
@@ -3076,21 +3076,21 @@ static void VULKAN_INTERNAL_DestroyCommandPool(
         NULL);
 
     for (i = 0; i < commandPool->inactiveCommandBufferCount; i += 1) {
-        commandBuffer = commandPool->inactiveCommandBuffers[i];
+        command_buffer = commandPool->inactiveCommandBuffers[i];
 
-        SDL_free(commandBuffer->presentDatas);
-        SDL_free(commandBuffer->waitSemaphores);
-        SDL_free(commandBuffer->signalSemaphores);
-        SDL_free(commandBuffer->boundDescriptorSetDatas);
-        SDL_free(commandBuffer->usedBuffers);
-        SDL_free(commandBuffer->usedTextures);
-        SDL_free(commandBuffer->usedSamplers);
-        SDL_free(commandBuffer->usedGraphicsPipelines);
-        SDL_free(commandBuffer->usedComputePipelines);
-        SDL_free(commandBuffer->usedFramebuffers);
-        SDL_free(commandBuffer->usedUniformBuffers);
+        SDL_free(command_buffer->presentDatas);
+        SDL_free(command_buffer->waitSemaphores);
+        SDL_free(command_buffer->signalSemaphores);
+        SDL_free(command_buffer->boundDescriptorSetDatas);
+        SDL_free(command_buffer->usedBuffers);
+        SDL_free(command_buffer->usedTextures);
+        SDL_free(command_buffer->usedSamplers);
+        SDL_free(command_buffer->usedGraphicsPipelines);
+        SDL_free(command_buffer->usedComputePipelines);
+        SDL_free(command_buffer->usedFramebuffers);
+        SDL_free(command_buffer->usedUniformBuffers);
 
-        SDL_free(commandBuffer);
+        SDL_free(command_buffer);
     }
 
     SDL_free(commandPool->inactiveCommandBuffers);
@@ -3127,60 +3127,60 @@ static void VULKAN_INTERNAL_DestroyDescriptorSetPool(
 
 static void VULKAN_INTERNAL_DestroyGraphicsPipeline(
     VulkanRenderer *renderer,
-    VulkanGraphicsPipeline *graphicsPipeline)
+    VulkanGraphicsPipeline *graphics_pipeline)
 {
     Uint32 i;
 
     renderer->vkDestroyPipeline(
         renderer->logicalDevice,
-        graphicsPipeline->pipeline,
+        graphics_pipeline->pipeline,
         NULL);
 
     renderer->vkDestroyPipelineLayout(
         renderer->logicalDevice,
-        graphicsPipeline->resourceLayout.pipelineLayout,
+        graphics_pipeline->resourceLayout.pipelineLayout,
         NULL);
 
     for (i = 0; i < 4; i += 1) {
         VULKAN_INTERNAL_DestroyDescriptorSetPool(
             renderer,
-            &graphicsPipeline->resourceLayout.descriptorSetPools[i]);
+            &graphics_pipeline->resourceLayout.descriptorSetPools[i]);
     }
 
-    (void)SDL_AtomicDecRef(&graphicsPipeline->vertexShader->referenceCount);
-    (void)SDL_AtomicDecRef(&graphicsPipeline->fragmentShader->referenceCount);
+    (void)SDL_AtomicDecRef(&graphics_pipeline->vertex_shader->referenceCount);
+    (void)SDL_AtomicDecRef(&graphics_pipeline->fragment_shader->referenceCount);
 
-    SDL_free(graphicsPipeline);
+    SDL_free(graphics_pipeline);
 }
 
 static void VULKAN_INTERNAL_DestroyComputePipeline(
     VulkanRenderer *renderer,
-    VulkanComputePipeline *computePipeline)
+    VulkanComputePipeline *compute_pipeline)
 {
     Uint32 i;
 
     renderer->vkDestroyPipeline(
         renderer->logicalDevice,
-        computePipeline->pipeline,
+        compute_pipeline->pipeline,
         NULL);
 
     renderer->vkDestroyPipelineLayout(
         renderer->logicalDevice,
-        computePipeline->resourceLayout.pipelineLayout,
+        compute_pipeline->resourceLayout.pipelineLayout,
         NULL);
 
     for (i = 0; i < 3; i += 1) {
         VULKAN_INTERNAL_DestroyDescriptorSetPool(
             renderer,
-            &computePipeline->resourceLayout.descriptorSetPools[i]);
+            &compute_pipeline->resourceLayout.descriptorSetPools[i]);
     }
 
     renderer->vkDestroyShaderModule(
         renderer->logicalDevice,
-        computePipeline->shaderModule,
+        compute_pipeline->shaderModule,
         NULL);
 
-    SDL_free(computePipeline);
+    SDL_free(compute_pipeline);
 }
 
 static void VULKAN_INTERNAL_DestroyShader(
@@ -3192,7 +3192,7 @@ static void VULKAN_INTERNAL_DestroyShader(
         vulkanShader->shaderModule,
         NULL);
 
-    SDL_free((void *)vulkanShader->entryPointName);
+    SDL_free((void *)vulkanShader->entrypoint_name);
     SDL_free(vulkanShader);
 }
 
@@ -3303,16 +3303,16 @@ static Uint32 VULKAN_INTERNAL_RenderPassHashFunction(
     const Uint32 HASH_FACTOR = 31;
     Uint32 result = 1;
 
-    for (Uint32 i = 0; i < hashTableKey->colorAttachmentCount; i += 1) {
-        result = result * HASH_FACTOR + hashTableKey->colorTargetDescriptions[i].loadOp;
-        result = result * HASH_FACTOR + hashTableKey->colorTargetDescriptions[i].storeOp;
+    for (Uint32 i = 0; i < hashTableKey->num_color_attachments; i += 1) {
+        result = result * HASH_FACTOR + hashTableKey->colorTargetDescriptions[i].load_op;
+        result = result * HASH_FACTOR + hashTableKey->colorTargetDescriptions[i].store_op;
         result = result * HASH_FACTOR + hashTableKey->colorTargetDescriptions[i].format;
     }
 
-    result = result * HASH_FACTOR + hashTableKey->depthStencilTargetDescription.loadOp;
-    result = result * HASH_FACTOR + hashTableKey->depthStencilTargetDescription.storeOp;
-    result = result * HASH_FACTOR + hashTableKey->depthStencilTargetDescription.stencilLoadOp;
-    result = result * HASH_FACTOR + hashTableKey->depthStencilTargetDescription.stencilStoreOp;
+    result = result * HASH_FACTOR + hashTableKey->depthStencilTargetDescription.load_op;
+    result = result * HASH_FACTOR + hashTableKey->depthStencilTargetDescription.store_op;
+    result = result * HASH_FACTOR + hashTableKey->depthStencilTargetDescription.stencil_load_op;
+    result = result * HASH_FACTOR + hashTableKey->depthStencilTargetDescription.stencil_store_op;
     result = result * HASH_FACTOR + hashTableKey->depthStencilTargetDescription.format;
 
     result = result * HASH_FACTOR + hashTableKey->colorAttachmentSampleCount;
@@ -3328,7 +3328,7 @@ static bool VULKAN_INTERNAL_RenderPassHashKeyMatch(
     RenderPassHashTableKey *a = (RenderPassHashTableKey *)aKey;
     RenderPassHashTableKey *b = (RenderPassHashTableKey *)bKey;
 
-    if (a->colorAttachmentCount != b->colorAttachmentCount) {
+    if (a->num_color_attachments != b->num_color_attachments) {
         return 0;
     }
 
@@ -3336,16 +3336,16 @@ static bool VULKAN_INTERNAL_RenderPassHashKeyMatch(
         return 0;
     }
 
-    for (Uint32 i = 0; i < a->colorAttachmentCount; i += 1) {
+    for (Uint32 i = 0; i < a->num_color_attachments; i += 1) {
         if (a->colorTargetDescriptions[i].format != b->colorTargetDescriptions[i].format) {
             return 0;
         }
 
-        if (a->colorTargetDescriptions[i].loadOp != b->colorTargetDescriptions[i].loadOp) {
+        if (a->colorTargetDescriptions[i].load_op != b->colorTargetDescriptions[i].load_op) {
             return 0;
         }
 
-        if (a->colorTargetDescriptions[i].storeOp != b->colorTargetDescriptions[i].storeOp) {
+        if (a->colorTargetDescriptions[i].store_op != b->colorTargetDescriptions[i].store_op) {
             return 0;
         }
     }
@@ -3354,19 +3354,19 @@ static bool VULKAN_INTERNAL_RenderPassHashKeyMatch(
         return 0;
     }
 
-    if (a->depthStencilTargetDescription.loadOp != b->depthStencilTargetDescription.loadOp) {
+    if (a->depthStencilTargetDescription.load_op != b->depthStencilTargetDescription.load_op) {
         return 0;
     }
 
-    if (a->depthStencilTargetDescription.storeOp != b->depthStencilTargetDescription.storeOp) {
+    if (a->depthStencilTargetDescription.store_op != b->depthStencilTargetDescription.store_op) {
         return 0;
     }
 
-    if (a->depthStencilTargetDescription.stencilLoadOp != b->depthStencilTargetDescription.stencilLoadOp) {
+    if (a->depthStencilTargetDescription.stencil_load_op != b->depthStencilTargetDescription.stencil_load_op) {
         return 0;
     }
 
-    if (a->depthStencilTargetDescription.stencilStoreOp != b->depthStencilTargetDescription.stencilStoreOp) {
+    if (a->depthStencilTargetDescription.stencil_store_op != b->depthStencilTargetDescription.stencil_store_op) {
         return 0;
     }
 
@@ -3398,7 +3398,7 @@ static Uint32 VULKAN_INTERNAL_FramebufferHashFunction(
     const Uint32 HASH_FACTOR = 31;
     Uint32 result = 1;
 
-    for (Uint32 i = 0; i < hashTableKey->colorAttachmentCount; i += 1) {
+    for (Uint32 i = 0; i < hashTableKey->num_color_attachments; i += 1) {
         result = result * HASH_FACTOR + (Uint32)(uintptr_t)hashTableKey->colorAttachmentViews[i];
         result = result * HASH_FACTOR + (Uint32)(uintptr_t)hashTableKey->colorMultiSampleAttachmentViews[i];
     }
@@ -3418,11 +3418,11 @@ static bool VULKAN_INTERNAL_FramebufferHashKeyMatch(
     FramebufferHashTableKey *a = (FramebufferHashTableKey *)aKey;
     FramebufferHashTableKey *b = (FramebufferHashTableKey *)bKey;
 
-    if (a->colorAttachmentCount != b->colorAttachmentCount) {
+    if (a->num_color_attachments != b->num_color_attachments) {
         return 0;
     }
 
-    for (Uint32 i = 0; i < a->colorAttachmentCount; i += 1) {
+    for (Uint32 i = 0; i < a->num_color_attachments; i += 1) {
         if (a->colorAttachmentViews[i] != b->colorAttachmentViews[i]) {
             return 0;
         }
@@ -3574,8 +3574,8 @@ static void VULKAN_INTERNAL_InitializeDescriptorSetPool(
 
 static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
     VulkanRenderer *renderer,
-    VulkanShader *vertexShader,
-    VulkanShader *fragmentShader,
+    VulkanShader *vertex_shader,
+    VulkanShader *fragment_shader,
     VulkanGraphicsPipelineResourceLayout *pipelineResourceLayout)
 {
     VkDescriptorSetLayoutBinding descriptorSetLayoutBindings[MAX_TEXTURE_SAMPLERS_PER_STAGE + MAX_STORAGE_TEXTURES_PER_STAGE + MAX_STORAGE_BUFFERS_PER_STAGE];
@@ -3586,15 +3586,15 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
     VkResult vulkanResult;
     Uint32 i;
 
-    pipelineResourceLayout->vertexSamplerCount = vertexShader->samplerCount;
-    pipelineResourceLayout->vertexStorageTextureCount = vertexShader->storageTextureCount;
-    pipelineResourceLayout->vertexStorageBufferCount = vertexShader->storageBufferCount;
-    pipelineResourceLayout->vertexUniformBufferCount = vertexShader->uniformBufferCount;
+    pipelineResourceLayout->vertexSamplerCount = vertex_shader->num_samplers;
+    pipelineResourceLayout->vertexStorageTextureCount = vertex_shader->num_storage_textures;
+    pipelineResourceLayout->vertexStorageBufferCount = vertex_shader->num_storage_buffers;
+    pipelineResourceLayout->vertexUniformBufferCount = vertex_shader->num_uniform_buffers;
 
-    pipelineResourceLayout->fragmentSamplerCount = fragmentShader->samplerCount;
-    pipelineResourceLayout->fragmentStorageTextureCount = fragmentShader->storageTextureCount;
-    pipelineResourceLayout->fragmentStorageBufferCount = fragmentShader->storageBufferCount;
-    pipelineResourceLayout->fragmentUniformBufferCount = fragmentShader->uniformBufferCount;
+    pipelineResourceLayout->fragmentSamplerCount = fragment_shader->num_samplers;
+    pipelineResourceLayout->fragmentStorageTextureCount = fragment_shader->num_storage_textures;
+    pipelineResourceLayout->fragmentStorageBufferCount = fragment_shader->num_storage_buffers;
+    pipelineResourceLayout->fragmentUniformBufferCount = fragment_shader->num_uniform_buffers;
 
     // Vertex Resources
 
@@ -3603,9 +3603,9 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
     descriptorSetLayoutCreateInfo.flags = 0;
     descriptorSetLayoutCreateInfo.pBindings = NULL;
     descriptorSetLayoutCreateInfo.bindingCount =
-        vertexShader->samplerCount +
-        vertexShader->storageTextureCount +
-        vertexShader->storageBufferCount;
+        vertex_shader->num_samplers +
+        vertex_shader->num_storage_textures +
+        vertex_shader->num_storage_buffers;
 
     descriptorSetPool = &pipelineResourceLayout->descriptorSetPools[0];
 
@@ -3616,7 +3616,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
         descriptorSetPool->descriptorInfos = SDL_malloc(
             descriptorSetPool->descriptorInfoCount * sizeof(VulkanDescriptorInfo));
 
-        for (i = 0; i < vertexShader->samplerCount; i += 1) {
+        for (i = 0; i < vertex_shader->num_samplers; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
@@ -3627,7 +3627,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
             descriptorSetPool->descriptorInfos[i].stageFlag = VK_SHADER_STAGE_VERTEX_BIT;
         }
 
-        for (i = vertexShader->samplerCount; i < vertexShader->samplerCount + vertexShader->storageTextureCount; i += 1) {
+        for (i = vertex_shader->num_samplers; i < vertex_shader->num_samplers + vertex_shader->num_storage_textures; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
@@ -3638,7 +3638,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
             descriptorSetPool->descriptorInfos[i].stageFlag = VK_SHADER_STAGE_VERTEX_BIT;
         }
 
-        for (i = vertexShader->samplerCount + vertexShader->storageTextureCount; i < descriptorSetLayoutCreateInfo.bindingCount; i += 1) {
+        for (i = vertex_shader->num_samplers + vertex_shader->num_storage_textures; i < descriptorSetLayoutCreateInfo.bindingCount; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
@@ -3679,7 +3679,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
         descriptorSetPool->descriptorInfos = SDL_malloc(
             descriptorSetPool->descriptorInfoCount * sizeof(VulkanDescriptorInfo));
 
-        for (i = 0; i < vertexShader->uniformBufferCount; i += 1) {
+        for (i = 0; i < vertex_shader->num_uniform_buffers; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
@@ -3711,9 +3711,9 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
     descriptorSetPool = &pipelineResourceLayout->descriptorSetPools[2];
 
     descriptorSetLayoutCreateInfo.bindingCount =
-        fragmentShader->samplerCount +
-        fragmentShader->storageTextureCount +
-        fragmentShader->storageBufferCount;
+        fragment_shader->num_samplers +
+        fragment_shader->num_storage_textures +
+        fragment_shader->num_storage_buffers;
 
     descriptorSetLayoutCreateInfo.pBindings = NULL;
 
@@ -3724,7 +3724,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
         descriptorSetPool->descriptorInfos = SDL_malloc(
             descriptorSetPool->descriptorInfoCount * sizeof(VulkanDescriptorInfo));
 
-        for (i = 0; i < fragmentShader->samplerCount; i += 1) {
+        for (i = 0; i < fragment_shader->num_samplers; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
@@ -3735,7 +3735,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
             descriptorSetPool->descriptorInfos[i].stageFlag = VK_SHADER_STAGE_FRAGMENT_BIT;
         }
 
-        for (i = fragmentShader->samplerCount; i < fragmentShader->samplerCount + fragmentShader->storageTextureCount; i += 1) {
+        for (i = fragment_shader->num_samplers; i < fragment_shader->num_samplers + fragment_shader->num_storage_textures; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
@@ -3746,7 +3746,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
             descriptorSetPool->descriptorInfos[i].stageFlag = VK_SHADER_STAGE_FRAGMENT_BIT;
         }
 
-        for (i = fragmentShader->samplerCount + fragmentShader->storageTextureCount; i < descriptorSetLayoutCreateInfo.bindingCount; i += 1) {
+        for (i = fragment_shader->num_samplers + fragment_shader->num_storage_textures; i < descriptorSetLayoutCreateInfo.bindingCount; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
@@ -3789,7 +3789,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
         descriptorSetPool->descriptorInfos = SDL_malloc(
             descriptorSetPool->descriptorInfoCount * sizeof(VulkanDescriptorInfo));
 
-        for (i = 0; i < fragmentShader->uniformBufferCount; i += 1) {
+        for (i = 0; i < fragment_shader->num_uniform_buffers; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
@@ -3848,7 +3848,7 @@ static bool VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
 
 static bool VULKAN_INTERNAL_InitializeComputePipelineResourceLayout(
     VulkanRenderer *renderer,
-    const SDL_GPUComputePipelineCreateInfo *pipelineCreateInfo,
+    const SDL_GPUComputePipelineCreateInfo *createinfo,
     VulkanComputePipelineResourceLayout *pipelineResourceLayout)
 {
     VkDescriptorSetLayoutBinding descriptorSetLayoutBindings[MAX_UNIFORM_BUFFERS_PER_STAGE];
@@ -3859,11 +3859,11 @@ static bool VULKAN_INTERNAL_InitializeComputePipelineResourceLayout(
     VkResult vulkanResult;
     Uint32 i;
 
-    pipelineResourceLayout->readOnlyStorageTextureCount = pipelineCreateInfo->readOnlyStorageTextureCount;
-    pipelineResourceLayout->readOnlyStorageBufferCount = pipelineCreateInfo->readOnlyStorageBufferCount;
-    pipelineResourceLayout->writeOnlyStorageTextureCount = pipelineCreateInfo->writeOnlyStorageTextureCount;
-    pipelineResourceLayout->writeOnlyStorageBufferCount = pipelineCreateInfo->writeOnlyStorageBufferCount;
-    pipelineResourceLayout->uniformBufferCount = pipelineCreateInfo->uniformBufferCount;
+    pipelineResourceLayout->num_readonly_storage_textures = createinfo->num_readonly_storage_textures;
+    pipelineResourceLayout->num_readonly_storage_buffers = createinfo->num_readonly_storage_buffers;
+    pipelineResourceLayout->num_writeonly_storage_textures = createinfo->num_writeonly_storage_textures;
+    pipelineResourceLayout->num_writeonly_storage_buffers = createinfo->num_writeonly_storage_buffers;
+    pipelineResourceLayout->num_uniform_buffers = createinfo->num_uniform_buffers;
 
     // Read-only resources
 
@@ -3872,8 +3872,8 @@ static bool VULKAN_INTERNAL_InitializeComputePipelineResourceLayout(
     descriptorSetLayoutCreateInfo.flags = 0;
     descriptorSetLayoutCreateInfo.pBindings = NULL;
     descriptorSetLayoutCreateInfo.bindingCount =
-        pipelineCreateInfo->readOnlyStorageTextureCount +
-        pipelineCreateInfo->readOnlyStorageBufferCount;
+        createinfo->num_readonly_storage_textures +
+        createinfo->num_readonly_storage_buffers;
 
     descriptorSetPool = &pipelineResourceLayout->descriptorSetPools[0];
 
@@ -3884,7 +3884,7 @@ static bool VULKAN_INTERNAL_InitializeComputePipelineResourceLayout(
         descriptorSetPool->descriptorInfos = SDL_malloc(
             descriptorSetPool->descriptorInfoCount * sizeof(VulkanDescriptorInfo));
 
-        for (i = 0; i < pipelineCreateInfo->readOnlyStorageTextureCount; i += 1) {
+        for (i = 0; i < createinfo->num_readonly_storage_textures; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
@@ -3895,7 +3895,7 @@ static bool VULKAN_INTERNAL_InitializeComputePipelineResourceLayout(
             descriptorSetPool->descriptorInfos[i].stageFlag = VK_SHADER_STAGE_COMPUTE_BIT;
         }
 
-        for (i = pipelineCreateInfo->readOnlyStorageTextureCount; i < descriptorSetLayoutCreateInfo.bindingCount; i += 1) {
+        for (i = createinfo->num_readonly_storage_textures; i < descriptorSetLayoutCreateInfo.bindingCount; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
@@ -3925,8 +3925,8 @@ static bool VULKAN_INTERNAL_InitializeComputePipelineResourceLayout(
     // Write-only resources
 
     descriptorSetLayoutCreateInfo.bindingCount =
-        pipelineCreateInfo->writeOnlyStorageTextureCount +
-        pipelineCreateInfo->writeOnlyStorageBufferCount;
+        createinfo->num_writeonly_storage_textures +
+        createinfo->num_writeonly_storage_buffers;
 
     descriptorSetLayoutCreateInfo.pBindings = NULL;
 
@@ -3939,7 +3939,7 @@ static bool VULKAN_INTERNAL_InitializeComputePipelineResourceLayout(
         descriptorSetPool->descriptorInfos = SDL_malloc(
             descriptorSetPool->descriptorInfoCount * sizeof(VulkanDescriptorInfo));
 
-        for (i = 0; i < pipelineCreateInfo->writeOnlyStorageTextureCount; i += 1) {
+        for (i = 0; i < createinfo->num_writeonly_storage_textures; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
@@ -3950,7 +3950,7 @@ static bool VULKAN_INTERNAL_InitializeComputePipelineResourceLayout(
             descriptorSetPool->descriptorInfos[i].stageFlag = VK_SHADER_STAGE_COMPUTE_BIT;
         }
 
-        for (i = pipelineCreateInfo->writeOnlyStorageTextureCount; i < descriptorSetLayoutCreateInfo.bindingCount; i += 1) {
+        for (i = createinfo->num_writeonly_storage_textures; i < descriptorSetLayoutCreateInfo.bindingCount; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
@@ -3981,7 +3981,7 @@ static bool VULKAN_INTERNAL_InitializeComputePipelineResourceLayout(
 
     descriptorSetPool = &pipelineResourceLayout->descriptorSetPools[2];
 
-    descriptorSetLayoutCreateInfo.bindingCount = pipelineCreateInfo->uniformBufferCount;
+    descriptorSetLayoutCreateInfo.bindingCount = createinfo->num_uniform_buffers;
     descriptorSetLayoutCreateInfo.pBindings = NULL;
 
     descriptorSetPool->descriptorInfoCount = descriptorSetLayoutCreateInfo.bindingCount;
@@ -3991,7 +3991,7 @@ static bool VULKAN_INTERNAL_InitializeComputePipelineResourceLayout(
         descriptorSetPool->descriptorInfos = SDL_malloc(
             descriptorSetPool->descriptorInfoCount * sizeof(VulkanDescriptorInfo));
 
-        for (i = 0; i < pipelineCreateInfo->uniformBufferCount; i += 1) {
+        for (i = 0; i < createinfo->num_uniform_buffers; i += 1) {
             descriptorSetLayoutBindings[i].binding = i;
             descriptorSetLayoutBindings[i].descriptorCount = 1;
             descriptorSetLayoutBindings[i].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
@@ -4053,30 +4053,30 @@ static bool VULKAN_INTERNAL_InitializeComputePipelineResourceLayout(
 static VulkanBuffer *VULKAN_INTERNAL_CreateBuffer(
     VulkanRenderer *renderer,
     VkDeviceSize size,
-    SDL_GPUBufferUsageFlags usageFlags,
+    SDL_GPUBufferUsageFlags usage_flags,
     VulkanBufferType type)
 {
     VulkanBuffer *buffer;
     VkResult vulkanResult;
-    VkBufferCreateInfo bufferCreateInfo;
+    VkBufferCreateInfo createinfo;
     VkBufferUsageFlags vulkanUsageFlags = 0;
     Uint8 bindResult;
 
-    if (usageFlags & SDL_GPU_BUFFERUSAGE_VERTEX) {
+    if (usage_flags & SDL_GPU_BUFFERUSAGE_VERTEX) {
         vulkanUsageFlags |= VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
     }
 
-    if (usageFlags & SDL_GPU_BUFFERUSAGE_INDEX) {
+    if (usage_flags & SDL_GPU_BUFFERUSAGE_INDEX) {
         vulkanUsageFlags |= VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
     }
 
-    if (usageFlags & (SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ |
+    if (usage_flags & (SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ |
                       SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_READ |
                       SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE)) {
         vulkanUsageFlags |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     }
 
-    if (usageFlags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
+    if (usage_flags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
         vulkanUsageFlags |= VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
     }
 
@@ -4090,26 +4090,26 @@ static VulkanBuffer *VULKAN_INTERNAL_CreateBuffer(
     buffer = SDL_malloc(sizeof(VulkanBuffer));
 
     buffer->size = size;
-    buffer->usageFlags = usageFlags;
+    buffer->usage_flags = usage_flags;
     buffer->type = type;
     buffer->markedForDestroy = 0;
     buffer->transitioned = false;
 
-    bufferCreateInfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-    bufferCreateInfo.pNext = NULL;
-    bufferCreateInfo.flags = 0;
-    bufferCreateInfo.size = size;
-    bufferCreateInfo.usage = vulkanUsageFlags;
-    bufferCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    bufferCreateInfo.queueFamilyIndexCount = 1;
-    bufferCreateInfo.pQueueFamilyIndices = &renderer->queueFamilyIndex;
+    createinfo.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    createinfo.pNext = NULL;
+    createinfo.flags = 0;
+    createinfo.size = size;
+    createinfo.usage = vulkanUsageFlags;
+    createinfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    createinfo.queueFamilyIndexCount = 1;
+    createinfo.pQueueFamilyIndices = &renderer->queueFamilyIndex;
 
     // Set transfer bits so we can defrag
-    bufferCreateInfo.usage |= VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    createinfo.usage |= VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
 
     vulkanResult = renderer->vkCreateBuffer(
         renderer->logicalDevice,
-        &bufferCreateInfo,
+        &createinfo,
         NULL,
         &buffer->buffer);
     VULKAN_ERROR_CHECK(vulkanResult, vkCreateBuffer, 0)
@@ -4141,8 +4141,8 @@ static VulkanBuffer *VULKAN_INTERNAL_CreateBuffer(
 // Indirection so we can cleanly defrag buffers
 static VulkanBufferHandle *VULKAN_INTERNAL_CreateBufferHandle(
     VulkanRenderer *renderer,
-    VkDeviceSize sizeInBytes,
-    SDL_GPUBufferUsageFlags usageFlags,
+    VkDeviceSize size,
+    SDL_GPUBufferUsageFlags usage_flags,
     VulkanBufferType type)
 {
     VulkanBufferHandle *bufferHandle;
@@ -4150,8 +4150,8 @@ static VulkanBufferHandle *VULKAN_INTERNAL_CreateBufferHandle(
 
     buffer = VULKAN_INTERNAL_CreateBuffer(
         renderer,
-        sizeInBytes,
-        usageFlags,
+        size,
+        usage_flags,
         type);
 
     if (buffer == NULL) {
@@ -4170,8 +4170,8 @@ static VulkanBufferHandle *VULKAN_INTERNAL_CreateBufferHandle(
 
 static VulkanBufferContainer *VULKAN_INTERNAL_CreateBufferContainer(
     VulkanRenderer *renderer,
-    VkDeviceSize sizeInBytes,
-    SDL_GPUBufferUsageFlags usageFlags,
+    VkDeviceSize size,
+    SDL_GPUBufferUsageFlags usage_flags,
     VulkanBufferType type)
 {
     VulkanBufferContainer *bufferContainer;
@@ -4179,8 +4179,8 @@ static VulkanBufferContainer *VULKAN_INTERNAL_CreateBufferContainer(
 
     bufferHandle = VULKAN_INTERNAL_CreateBufferHandle(
         renderer,
-        sizeInBytes,
-        usageFlags,
+        size,
+        usage_flags,
         type);
 
     if (bufferHandle == NULL) {
@@ -4206,11 +4206,11 @@ static VulkanBufferContainer *VULKAN_INTERNAL_CreateBufferContainer(
 // Texture Subresource Utilities
 
 static Uint32 VULKAN_INTERNAL_GetTextureSubresourceIndex(
-    Uint32 mipLevel,
+    Uint32 mip_level,
     Uint32 layer,
     Uint32 numLevels)
 {
-    return mipLevel + (layer * numLevels);
+    return mip_level + (layer * numLevels);
 }
 
 static VulkanTextureSubresource *VULKAN_INTERNAL_FetchTextureSubresource(
@@ -4221,7 +4221,7 @@ static VulkanTextureSubresource *VULKAN_INTERNAL_FetchTextureSubresource(
     Uint32 index = VULKAN_INTERNAL_GetTextureSubresourceIndex(
         level,
         layer,
-        textureContainer->header.info.levelCount);
+        textureContainer->header.info.num_levels);
 
     return &textureContainer->activeTextureHandle->vulkanTexture->subresources[index];
 }
@@ -4435,13 +4435,13 @@ static bool VULKAN_INTERNAL_VerifySwapSurfaceFormat(
 }
 
 static bool VULKAN_INTERNAL_VerifySwapPresentMode(
-    VkPresentModeKHR presentMode,
+    VkPresentModeKHR present_mode,
     VkPresentModeKHR *availablePresentModes,
     Uint32 availablePresentModesLength)
 {
     Uint32 i;
     for (i = 0; i < availablePresentModesLength; i += 1) {
-        if (availablePresentModes[i] == presentMode) {
+        if (availablePresentModes[i] == present_mode) {
             return true;
         }
     }
@@ -4523,9 +4523,9 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
 
     // Verify that we can use the requested composition and present mode
 
-    swapchainData->format = SwapchainCompositionToFormat[windowData->swapchainComposition];
-    swapchainData->colorSpace = SwapchainCompositionToColorSpace[windowData->swapchainComposition];
-    swapchainData->swapchainSwizzle = SwapchainCompositionSwizzle[windowData->swapchainComposition];
+    swapchainData->format = SwapchainCompositionToFormat[windowData->swapchain_composition];
+    swapchainData->colorSpace = SwapchainCompositionToColorSpace[windowData->swapchain_composition];
+    swapchainData->swapchainSwizzle = SwapchainCompositionSwizzle[windowData->swapchain_composition];
     swapchainData->usingFallbackFormat = false;
 
     hasValidSwapchainComposition = VULKAN_INTERNAL_VerifySwapSurfaceFormat(
@@ -4536,7 +4536,7 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
 
     if (!hasValidSwapchainComposition) {
         // Let's try again with the fallback format...
-        swapchainData->format = SwapchainCompositionToFallbackFormat[windowData->swapchainComposition];
+        swapchainData->format = SwapchainCompositionToFallbackFormat[windowData->swapchain_composition];
         swapchainData->usingFallbackFormat = true;
         hasValidSwapchainComposition = VULKAN_INTERNAL_VerifySwapSurfaceFormat(
             swapchainData->format,
@@ -4545,9 +4545,9 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
             swapchainSupportDetails.formatsLength);
     }
 
-    swapchainData->presentMode = SDLToVK_PresentMode[windowData->presentMode];
+    swapchainData->present_mode = SDLToVK_PresentMode[windowData->present_mode];
     hasValidPresentMode = VULKAN_INTERNAL_VerifySwapPresentMode(
-        swapchainData->presentMode,
+        swapchainData->present_mode,
         swapchainSupportDetails.presentModes,
         swapchainSupportDetails.presentModesLength);
 
@@ -4571,7 +4571,7 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Device does not support requested swapchain composition!");
         }
         if (!hasValidPresentMode) {
-            SDL_LogError(SDL_LOG_CATEGORY_GPU, "Device does not support requested presentMode!");
+            SDL_LogError(SDL_LOG_CATEGORY_GPU, "Device does not support requested present_mode!");
         }
         return false;
     }
@@ -4624,7 +4624,7 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
         swapchainData->imageCount = swapchainSupportDetails.capabilities.minImageCount;
     }
 
-    if (swapchainData->presentMode == VK_PRESENT_MODE_MAILBOX_KHR) {
+    if (swapchainData->present_mode == VK_PRESENT_MODE_MAILBOX_KHR) {
         /* Required for proper triple-buffering.
          * Note that this is below the above maxImageCount check!
          * If the driver advertises MAILBOX but does not support 3 swap
@@ -4652,7 +4652,7 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
     swapchainCreateInfo.pQueueFamilyIndices = NULL;
     swapchainCreateInfo.preTransform = swapchainSupportDetails.capabilities.currentTransform;
     swapchainCreateInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
-    swapchainCreateInfo.presentMode = swapchainData->presentMode;
+    swapchainCreateInfo.presentMode = swapchainData->present_mode;
     swapchainCreateInfo.clipped = VK_TRUE;
     swapchainCreateInfo.oldSwapchain = VK_NULL_HANDLE;
 
@@ -4712,14 +4712,14 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
         swapchainData->textureContainers[i].canBeCycled = false;
         swapchainData->textureContainers[i].header.info.width = drawableWidth;
         swapchainData->textureContainers[i].header.info.height = drawableHeight;
-        swapchainData->textureContainers[i].header.info.layerCountOrDepth = 1;
+        swapchainData->textureContainers[i].header.info.layer_count_or_depth = 1;
         swapchainData->textureContainers[i].header.info.format = SwapchainCompositionToSDLFormat(
-            windowData->swapchainComposition,
+            windowData->swapchain_composition,
             swapchainData->usingFallbackFormat);
         swapchainData->textureContainers[i].header.info.type = SDL_GPU_TEXTURETYPE_2D;
-        swapchainData->textureContainers[i].header.info.levelCount = 1;
-        swapchainData->textureContainers[i].header.info.sampleCount = SDL_GPU_SAMPLECOUNT_1;
-        swapchainData->textureContainers[i].header.info.usageFlags = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
+        swapchainData->textureContainers[i].header.info.num_levels = 1;
+        swapchainData->textureContainers[i].header.info.sample_count = SDL_GPU_SAMPLECOUNT_1;
+        swapchainData->textureContainers[i].header.info.usage_flags = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
 
         swapchainData->textureContainers[i].activeTextureHandle = SDL_malloc(sizeof(VulkanTextureHandle));
 
@@ -4737,9 +4737,9 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
         swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->type = SDL_GPU_TEXTURETYPE_2D;
         swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->depth = 1;
         swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->layerCount = 1;
-        swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->levelCount = 1;
-        swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->sampleCount = VK_SAMPLE_COUNT_1_BIT;
-        swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->usageFlags =
+        swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->num_levels = 1;
+        swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->sample_count = VK_SAMPLE_COUNT_1_BIT;
+        swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->usage_flags =
             SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
         swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->aspectFlags = VK_IMAGE_ASPECT_COLOR_BIT;
         SDL_AtomicSet(&swapchainData->textureContainers[i].activeTextureHandle->vulkanTexture->referenceCount, 0);
@@ -4795,7 +4795,7 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
 
 static void VULKAN_INTERNAL_BeginCommandBuffer(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *commandBuffer)
+    VulkanCommandBuffer *command_buffer)
 {
     VkCommandBufferBeginInfo beginInfo;
     VkResult result;
@@ -4807,7 +4807,7 @@ static void VULKAN_INTERNAL_BeginCommandBuffer(
     beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
 
     result = renderer->vkBeginCommandBuffer(
-        commandBuffer->commandBuffer,
+        command_buffer->command_buffer,
         &beginInfo);
 
     if (result != VK_SUCCESS) {
@@ -4817,12 +4817,12 @@ static void VULKAN_INTERNAL_BeginCommandBuffer(
 
 static void VULKAN_INTERNAL_EndCommandBuffer(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *commandBuffer)
+    VulkanCommandBuffer *command_buffer)
 {
     VkResult result;
 
     result = renderer->vkEndCommandBuffer(
-        commandBuffer->commandBuffer);
+        command_buffer->command_buffer);
 
     if (result != VK_SUCCESS) {
         LogVulkanResultAsError("vkEndCommandBuffer", result);
@@ -4993,7 +4993,7 @@ static VkDescriptorSet VULKAN_INTERNAL_FetchDescriptorSet(
 
 static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *commandBuffer)
+    VulkanCommandBuffer *command_buffer)
 {
     VulkanGraphicsPipelineResourceLayout *resourceLayout;
     VkWriteDescriptorSet *writeDescriptorSets;
@@ -5006,14 +5006,14 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
     Uint32 imageInfoCount = 0;
     Uint32 i;
 
-    resourceLayout = &commandBuffer->currentGraphicsPipeline->resourceLayout;
+    resourceLayout = &command_buffer->currentGraphicsPipeline->resourceLayout;
 
-    if (commandBuffer->needNewVertexResourceDescriptorSet) {
+    if (command_buffer->needNewVertexResourceDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[0];
 
-        commandBuffer->vertexResourceDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        command_buffer->vertexResourceDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            commandBuffer,
+            command_buffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
@@ -5030,12 +5030,12 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = commandBuffer->vertexResourceDescriptorSet;
+            currentWriteDescriptorSet->dstSet = command_buffer->vertexResourceDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pBufferInfo = NULL;
 
-            imageInfos[imageInfoCount].sampler = commandBuffer->vertexSamplers[i]->sampler;
-            imageInfos[imageInfoCount].imageView = commandBuffer->vertexSamplerTextures[i]->fullView;
+            imageInfos[imageInfoCount].sampler = command_buffer->vertexSamplers[i]->sampler;
+            imageInfos[imageInfoCount].imageView = command_buffer->vertexSamplerTextures[i]->fullView;
             imageInfos[imageInfoCount].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
             currentWriteDescriptorSet->pImageInfo = &imageInfos[imageInfoCount];
@@ -5052,12 +5052,12 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = resourceLayout->vertexSamplerCount + i;
-            currentWriteDescriptorSet->dstSet = commandBuffer->vertexResourceDescriptorSet;
+            currentWriteDescriptorSet->dstSet = command_buffer->vertexResourceDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pBufferInfo = NULL;
 
             imageInfos[imageInfoCount].sampler = VK_NULL_HANDLE;
-            imageInfos[imageInfoCount].imageView = commandBuffer->vertexStorageTextures[i]->fullView;
+            imageInfos[imageInfoCount].imageView = command_buffer->vertexStorageTextures[i]->fullView;
             imageInfos[imageInfoCount].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
             currentWriteDescriptorSet->pImageInfo = &imageInfos[imageInfoCount];
@@ -5074,11 +5074,11 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = resourceLayout->vertexSamplerCount + resourceLayout->vertexStorageTextureCount + i;
-            currentWriteDescriptorSet->dstSet = commandBuffer->vertexResourceDescriptorSet;
+            currentWriteDescriptorSet->dstSet = command_buffer->vertexResourceDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = commandBuffer->vertexStorageBuffers[i]->buffer;
+            bufferInfos[bufferInfoCount].buffer = command_buffer->vertexStorageBuffers[i]->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = VK_WHOLE_SIZE;
 
@@ -5095,12 +5095,12 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             NULL);
 
         renderer->vkCmdBindDescriptorSets(
-            commandBuffer->commandBuffer,
+            command_buffer->command_buffer,
             VK_PIPELINE_BIND_POINT_GRAPHICS,
             resourceLayout->pipelineLayout,
             0,
             1,
-            &commandBuffer->vertexResourceDescriptorSet,
+            &command_buffer->vertexResourceDescriptorSet,
             0,
             NULL);
 
@@ -5108,15 +5108,15 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        commandBuffer->needNewVertexResourceDescriptorSet = false;
+        command_buffer->needNewVertexResourceDescriptorSet = false;
     }
 
-    if (commandBuffer->needNewVertexUniformDescriptorSet) {
+    if (command_buffer->needNewVertexUniformDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[1];
 
-        commandBuffer->vertexUniformDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        command_buffer->vertexUniformDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            commandBuffer,
+            command_buffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
@@ -5132,11 +5132,11 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = commandBuffer->vertexUniformDescriptorSet;
+            currentWriteDescriptorSet->dstSet = command_buffer->vertexUniformDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = commandBuffer->vertexUniformBuffers[i]->bufferHandle->vulkanBuffer->buffer;
+            bufferInfos[bufferInfoCount].buffer = command_buffer->vertexUniformBuffers[i]->bufferHandle->vulkanBuffer->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = MAX_UBO_SECTION_SIZE;
 
@@ -5156,34 +5156,34 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        commandBuffer->needNewVertexUniformDescriptorSet = false;
-        commandBuffer->needNewVertexUniformOffsets = true;
+        command_buffer->needNewVertexUniformDescriptorSet = false;
+        command_buffer->needNewVertexUniformOffsets = true;
     }
 
-    if (commandBuffer->needNewVertexUniformOffsets) {
+    if (command_buffer->needNewVertexUniformOffsets) {
         for (i = 0; i < resourceLayout->vertexUniformBufferCount; i += 1) {
-            dynamicOffsets[i] = commandBuffer->vertexUniformBuffers[i]->drawOffset;
+            dynamicOffsets[i] = command_buffer->vertexUniformBuffers[i]->drawOffset;
         }
 
         renderer->vkCmdBindDescriptorSets(
-            commandBuffer->commandBuffer,
+            command_buffer->command_buffer,
             VK_PIPELINE_BIND_POINT_GRAPHICS,
             resourceLayout->pipelineLayout,
             1,
             1,
-            &commandBuffer->vertexUniformDescriptorSet,
+            &command_buffer->vertexUniformDescriptorSet,
             resourceLayout->vertexUniformBufferCount,
             dynamicOffsets);
 
-        commandBuffer->needNewVertexUniformOffsets = false;
+        command_buffer->needNewVertexUniformOffsets = false;
     }
 
-    if (commandBuffer->needNewFragmentResourceDescriptorSet) {
+    if (command_buffer->needNewFragmentResourceDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[2];
 
-        commandBuffer->fragmentResourceDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        command_buffer->fragmentResourceDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            commandBuffer,
+            command_buffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
@@ -5200,12 +5200,12 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = commandBuffer->fragmentResourceDescriptorSet;
+            currentWriteDescriptorSet->dstSet = command_buffer->fragmentResourceDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pBufferInfo = NULL;
 
-            imageInfos[imageInfoCount].sampler = commandBuffer->fragmentSamplers[i]->sampler;
-            imageInfos[imageInfoCount].imageView = commandBuffer->fragmentSamplerTextures[i]->fullView;
+            imageInfos[imageInfoCount].sampler = command_buffer->fragmentSamplers[i]->sampler;
+            imageInfos[imageInfoCount].imageView = command_buffer->fragmentSamplerTextures[i]->fullView;
             imageInfos[imageInfoCount].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
             currentWriteDescriptorSet->pImageInfo = &imageInfos[imageInfoCount];
@@ -5222,12 +5222,12 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = resourceLayout->fragmentSamplerCount + i;
-            currentWriteDescriptorSet->dstSet = commandBuffer->fragmentResourceDescriptorSet;
+            currentWriteDescriptorSet->dstSet = command_buffer->fragmentResourceDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pBufferInfo = NULL;
 
             imageInfos[imageInfoCount].sampler = VK_NULL_HANDLE;
-            imageInfos[imageInfoCount].imageView = commandBuffer->fragmentStorageTextures[i]->fullView;
+            imageInfos[imageInfoCount].imageView = command_buffer->fragmentStorageTextures[i]->fullView;
             imageInfos[imageInfoCount].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
             currentWriteDescriptorSet->pImageInfo = &imageInfos[imageInfoCount];
@@ -5244,11 +5244,11 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = resourceLayout->fragmentSamplerCount + resourceLayout->fragmentStorageTextureCount + i;
-            currentWriteDescriptorSet->dstSet = commandBuffer->fragmentResourceDescriptorSet;
+            currentWriteDescriptorSet->dstSet = command_buffer->fragmentResourceDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = commandBuffer->fragmentStorageBuffers[i]->buffer;
+            bufferInfos[bufferInfoCount].buffer = command_buffer->fragmentStorageBuffers[i]->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = VK_WHOLE_SIZE;
 
@@ -5265,12 +5265,12 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             NULL);
 
         renderer->vkCmdBindDescriptorSets(
-            commandBuffer->commandBuffer,
+            command_buffer->command_buffer,
             VK_PIPELINE_BIND_POINT_GRAPHICS,
             resourceLayout->pipelineLayout,
             2,
             1,
-            &commandBuffer->fragmentResourceDescriptorSet,
+            &command_buffer->fragmentResourceDescriptorSet,
             0,
             NULL);
 
@@ -5278,15 +5278,15 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        commandBuffer->needNewFragmentResourceDescriptorSet = false;
+        command_buffer->needNewFragmentResourceDescriptorSet = false;
     }
 
-    if (commandBuffer->needNewFragmentUniformDescriptorSet) {
+    if (command_buffer->needNewFragmentUniformDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[3];
 
-        commandBuffer->fragmentUniformDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        command_buffer->fragmentUniformDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            commandBuffer,
+            command_buffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
@@ -5302,11 +5302,11 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = commandBuffer->fragmentUniformDescriptorSet;
+            currentWriteDescriptorSet->dstSet = command_buffer->fragmentUniformDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = commandBuffer->fragmentUniformBuffers[i]->bufferHandle->vulkanBuffer->buffer;
+            bufferInfos[bufferInfoCount].buffer = command_buffer->fragmentUniformBuffers[i]->bufferHandle->vulkanBuffer->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = MAX_UBO_SECTION_SIZE;
 
@@ -5326,79 +5326,79 @@ static void VULKAN_INTERNAL_BindGraphicsDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        commandBuffer->needNewFragmentUniformDescriptorSet = false;
-        commandBuffer->needNewFragmentUniformOffsets = true;
+        command_buffer->needNewFragmentUniformDescriptorSet = false;
+        command_buffer->needNewFragmentUniformOffsets = true;
     }
 
-    if (commandBuffer->needNewFragmentUniformOffsets) {
+    if (command_buffer->needNewFragmentUniformOffsets) {
         for (i = 0; i < resourceLayout->fragmentUniformBufferCount; i += 1) {
-            dynamicOffsets[i] = commandBuffer->fragmentUniformBuffers[i]->drawOffset;
+            dynamicOffsets[i] = command_buffer->fragmentUniformBuffers[i]->drawOffset;
         }
 
         renderer->vkCmdBindDescriptorSets(
-            commandBuffer->commandBuffer,
+            command_buffer->command_buffer,
             VK_PIPELINE_BIND_POINT_GRAPHICS,
             resourceLayout->pipelineLayout,
             3,
             1,
-            &commandBuffer->fragmentUniformDescriptorSet,
+            &command_buffer->fragmentUniformDescriptorSet,
             resourceLayout->fragmentUniformBufferCount,
             dynamicOffsets);
 
-        commandBuffer->needNewFragmentUniformOffsets = false;
+        command_buffer->needNewFragmentUniformOffsets = false;
     }
 }
 
 static void VULKAN_DrawIndexedPrimitives(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 indexCount,
-    Uint32 instanceCount,
-    Uint32 firstIndex,
-    Sint32 vertexOffset,
-    Uint32 firstInstance)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 num_indices,
+    Uint32 num_instances,
+    Uint32 first_index,
+    Sint32 vertex_offset,
+    Uint32 first_instance)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_BindGraphicsDescriptorSets(renderer, vulkanCommandBuffer);
 
     renderer->vkCmdDrawIndexed(
-        vulkanCommandBuffer->commandBuffer,
-        indexCount,
-        instanceCount,
-        firstIndex,
-        vertexOffset,
-        firstInstance);
+        vulkanCommandBuffer->command_buffer,
+        num_indices,
+        num_instances,
+        first_index,
+        vertex_offset,
+        first_instance);
 }
 
 static void VULKAN_DrawPrimitives(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 vertexCount,
-    Uint32 instanceCount,
-    Uint32 firstVertex,
-    Uint32 firstInstance)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 num_vertices,
+    Uint32 num_instances,
+    Uint32 first_vertex,
+    Uint32 first_instance)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_BindGraphicsDescriptorSets(renderer, vulkanCommandBuffer);
 
     renderer->vkCmdDraw(
-        vulkanCommandBuffer->commandBuffer,
-        vertexCount,
-        instanceCount,
-        firstVertex,
-        firstInstance);
+        vulkanCommandBuffer->command_buffer,
+        num_vertices,
+        num_instances,
+        first_vertex,
+        first_instance);
 }
 
 static void VULKAN_DrawPrimitivesIndirect(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     SDL_GPUBuffer *buffer,
-    Uint32 offsetInBytes,
-    Uint32 drawCount,
-    Uint32 stride)
+    Uint32 offset,
+    Uint32 draw_count,
+    Uint32 pitch)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBuffer *vulkanBuffer = ((VulkanBufferContainer *)buffer)->activeBufferHandle->vulkanBuffer;
     Uint32 i;
@@ -5408,20 +5408,20 @@ static void VULKAN_DrawPrimitivesIndirect(
     if (renderer->supportsMultiDrawIndirect) {
         // Real multi-draw!
         renderer->vkCmdDrawIndirect(
-            vulkanCommandBuffer->commandBuffer,
+            vulkanCommandBuffer->command_buffer,
             vulkanBuffer->buffer,
-            offsetInBytes,
-            drawCount,
-            stride);
+            offset,
+            draw_count,
+            pitch);
     } else {
         // Fake multi-draw...
-        for (i = 0; i < drawCount; i += 1) {
+        for (i = 0; i < draw_count; i += 1) {
             renderer->vkCmdDrawIndirect(
-                vulkanCommandBuffer->commandBuffer,
+                vulkanCommandBuffer->command_buffer,
                 vulkanBuffer->buffer,
-                offsetInBytes + (stride * i),
+                offset + (pitch * i),
                 1,
-                stride);
+                pitch);
         }
     }
 
@@ -5429,13 +5429,13 @@ static void VULKAN_DrawPrimitivesIndirect(
 }
 
 static void VULKAN_DrawIndexedPrimitivesIndirect(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     SDL_GPUBuffer *buffer,
-    Uint32 offsetInBytes,
-    Uint32 drawCount,
-    Uint32 stride)
+    Uint32 offset,
+    Uint32 draw_count,
+    Uint32 pitch)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBuffer *vulkanBuffer = ((VulkanBufferContainer *)buffer)->activeBufferHandle->vulkanBuffer;
     Uint32 i;
@@ -5445,20 +5445,20 @@ static void VULKAN_DrawIndexedPrimitivesIndirect(
     if (renderer->supportsMultiDrawIndirect) {
         // Real multi-draw!
         renderer->vkCmdDrawIndexedIndirect(
-            vulkanCommandBuffer->commandBuffer,
+            vulkanCommandBuffer->command_buffer,
             vulkanBuffer->buffer,
-            offsetInBytes,
-            drawCount,
-            stride);
+            offset,
+            draw_count,
+            pitch);
     } else {
         // Fake multi-draw...
-        for (i = 0; i < drawCount; i += 1) {
+        for (i = 0; i < draw_count; i += 1) {
             renderer->vkCmdDrawIndexedIndirect(
-                vulkanCommandBuffer->commandBuffer,
+                vulkanCommandBuffer->command_buffer,
                 vulkanBuffer->buffer,
-                offsetInBytes + (stride * i),
+                offset + (pitch * i),
                 1,
-                stride);
+                pitch);
         }
     }
 
@@ -5474,7 +5474,7 @@ static void VULKAN_INTERNAL_SetBufferName(
 {
     VkDebugUtilsObjectNameInfoEXT nameInfo;
 
-    if (renderer->debugMode && renderer->supportsDebugUtils) {
+    if (renderer->debug_mode && renderer->supportsDebugUtils) {
         nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
         nameInfo.pNext = NULL;
         nameInfo.pObjectName = text;
@@ -5496,7 +5496,7 @@ static void VULKAN_SetBufferName(
     VulkanBufferContainer *container = (VulkanBufferContainer *)buffer;
     size_t textLength = SDL_strlen(text) + 1;
 
-    if (renderer->debugMode && renderer->supportsDebugUtils) {
+    if (renderer->debug_mode && renderer->supportsDebugUtils) {
         container->debugName = SDL_realloc(
             container->debugName,
             textLength);
@@ -5522,7 +5522,7 @@ static void VULKAN_INTERNAL_SetTextureName(
 {
     VkDebugUtilsObjectNameInfoEXT nameInfo;
 
-    if (renderer->debugMode && renderer->supportsDebugUtils) {
+    if (renderer->debug_mode && renderer->supportsDebugUtils) {
         nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
         nameInfo.pNext = NULL;
         nameInfo.pObjectName = text;
@@ -5544,7 +5544,7 @@ static void VULKAN_SetTextureName(
     VulkanTextureContainer *container = (VulkanTextureContainer *)texture;
     size_t textLength = SDL_strlen(text) + 1;
 
-    if (renderer->debugMode && renderer->supportsDebugUtils) {
+    if (renderer->debug_mode && renderer->supportsDebugUtils) {
         container->debugName = SDL_realloc(
             container->debugName,
             textLength);
@@ -5564,10 +5564,10 @@ static void VULKAN_SetTextureName(
 }
 
 static void VULKAN_InsertDebugLabel(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const char *text)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VkDebugUtilsLabelEXT labelInfo;
 
@@ -5577,16 +5577,16 @@ static void VULKAN_InsertDebugLabel(
         labelInfo.pLabelName = text;
 
         renderer->vkCmdInsertDebugUtilsLabelEXT(
-            vulkanCommandBuffer->commandBuffer,
+            vulkanCommandBuffer->command_buffer,
             &labelInfo);
     }
 }
 
 static void VULKAN_PushDebugGroup(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const char *name)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VkDebugUtilsLabelEXT labelInfo;
 
@@ -5596,19 +5596,19 @@ static void VULKAN_PushDebugGroup(
         labelInfo.pLabelName = name;
 
         renderer->vkCmdBeginDebugUtilsLabelEXT(
-            vulkanCommandBuffer->commandBuffer,
+            vulkanCommandBuffer->command_buffer,
             &labelInfo);
     }
 }
 
 static void VULKAN_PopDebugGroup(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     if (renderer->supportsDebugUtils) {
-        renderer->vkCmdEndDebugUtilsLabelEXT(vulkanCommandBuffer->commandBuffer);
+        renderer->vkCmdEndDebugUtilsLabelEXT(vulkanCommandBuffer->command_buffer);
     }
 }
 
@@ -5619,8 +5619,8 @@ static VulkanTextureHandle *VULKAN_INTERNAL_CreateTextureHandle(
     Uint32 depth,
     SDL_GPUTextureType type,
     Uint32 layerCount,
-    Uint32 levelCount,
-    VkSampleCountFlagBits sampleCount,
+    Uint32 num_levels,
+    VkSampleCountFlagBits sample_count,
     VkFormat format,
     VkComponentMapping swizzle,
     VkImageAspectFlags aspectMask,
@@ -5637,8 +5637,8 @@ static VulkanTextureHandle *VULKAN_INTERNAL_CreateTextureHandle(
         depth,
         type,
         layerCount,
-        levelCount,
-        sampleCount,
+        num_levels,
+        sample_count,
         format,
         swizzle,
         aspectMask,
@@ -5666,8 +5666,8 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
     Uint32 depth,
     SDL_GPUTextureType type,
     Uint32 layerCount,
-    Uint32 levelCount,
-    VkSampleCountFlagBits sampleCount,
+    Uint32 num_levels,
+    VkSampleCountFlagBits sample_count,
     VkFormat format,
     VkComponentMapping swizzle,
     VkImageAspectFlags aspectMask,
@@ -5718,9 +5718,9 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
     imageCreateInfo.extent.width = width;
     imageCreateInfo.extent.height = height;
     imageCreateInfo.extent.depth = depth;
-    imageCreateInfo.mipLevels = levelCount;
+    imageCreateInfo.mipLevels = num_levels;
     imageCreateInfo.arrayLayers = layerCount;
-    imageCreateInfo.samples = isMSAAColorTarget || VULKAN_INTERNAL_IsVulkanDepthFormat(format) ? sampleCount : VK_SAMPLE_COUNT_1_BIT;
+    imageCreateInfo.samples = isMSAAColorTarget || VULKAN_INTERNAL_IsVulkanDepthFormat(format) ? sample_count : VK_SAMPLE_COUNT_1_BIT;
     imageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
     imageCreateInfo.usage = vkUsageFlags;
     imageCreateInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
@@ -5767,7 +5767,7 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
         imageViewCreateInfo.components = swizzle;
         imageViewCreateInfo.subresourceRange.aspectMask = aspectMask;
         imageViewCreateInfo.subresourceRange.baseMipLevel = 0;
-        imageViewCreateInfo.subresourceRange.levelCount = levelCount;
+        imageViewCreateInfo.subresourceRange.levelCount = num_levels;
         imageViewCreateInfo.subresourceRange.baseArrayLayer = 0;
         imageViewCreateInfo.subresourceRange.layerCount = layerCount;
 
@@ -5799,27 +5799,27 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
     texture->depth = depth;
     texture->format = format;
     texture->swizzle = swizzle;
-    texture->levelCount = levelCount;
+    texture->num_levels = num_levels;
     texture->layerCount = layerCount;
-    texture->sampleCount = sampleCount;
-    texture->usageFlags = textureUsageFlags;
+    texture->sample_count = sample_count;
+    texture->usage_flags = textureUsageFlags;
     texture->aspectFlags = aspectMask;
     SDL_AtomicSet(&texture->referenceCount, 0);
 
     // Define slices
     texture->subresourceCount =
         texture->layerCount *
-        texture->levelCount;
+        texture->num_levels;
 
     texture->subresources = SDL_malloc(
         texture->subresourceCount * sizeof(VulkanTextureSubresource));
 
     for (Uint32 i = 0; i < texture->layerCount; i += 1) {
-        for (Uint32 j = 0; j < texture->levelCount; j += 1) {
+        for (Uint32 j = 0; j < texture->num_levels; j += 1) {
             Uint32 subresourceIndex = VULKAN_INTERNAL_GetTextureSubresourceIndex(
                 j,
                 i,
-                texture->levelCount);
+                texture->num_levels);
 
             texture->subresources[subresourceIndex].renderTargetViews = NULL;
             texture->subresources[subresourceIndex].computeWriteView = VK_NULL_HANDLE;
@@ -5877,7 +5877,7 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
             texture->subresources[subresourceIndex].transitioned = false;
 
             if (
-                sampleCount > VK_SAMPLE_COUNT_1_BIT &&
+                sample_count > VK_SAMPLE_COUNT_1_BIT &&
                 isRenderTarget &&
                 !isMSAAColorTarget &&
                 !VULKAN_INTERNAL_IsVulkanDepthFormat(texture->format)) {
@@ -5889,7 +5889,7 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
                     0,
                     1,
                     1,
-                    sampleCount,
+                    sample_count,
                     texture->format,
                     texture->swizzle,
                     aspectMask,
@@ -5922,7 +5922,7 @@ static void VULKAN_INTERNAL_CycleActiveBuffer(
     bufferContainer->activeBufferHandle = VULKAN_INTERNAL_CreateBufferHandle(
         renderer,
         bufferContainer->activeBufferHandle->vulkanBuffer->size,
-        bufferContainer->activeBufferHandle->vulkanBuffer->usageFlags,
+        bufferContainer->activeBufferHandle->vulkanBuffer->usage_flags,
         bufferContainer->activeBufferHandle->vulkanBuffer->type);
 
     bufferContainer->activeBufferHandle->container = bufferContainer;
@@ -5938,7 +5938,7 @@ static void VULKAN_INTERNAL_CycleActiveBuffer(
     bufferContainer->bufferCount += 1;
 
     if (
-        renderer->debugMode &&
+        renderer->debug_mode &&
         renderer->supportsDebugUtils &&
         bufferContainer->debugName != NULL) {
         VULKAN_INTERNAL_SetBufferName(
@@ -5970,12 +5970,12 @@ static void VULKAN_INTERNAL_CycleActiveTexture(
         textureContainer->activeTextureHandle->vulkanTexture->depth,
         textureContainer->activeTextureHandle->vulkanTexture->type,
         textureContainer->activeTextureHandle->vulkanTexture->layerCount,
-        textureContainer->activeTextureHandle->vulkanTexture->levelCount,
-        textureContainer->activeTextureHandle->vulkanTexture->sampleCount,
+        textureContainer->activeTextureHandle->vulkanTexture->num_levels,
+        textureContainer->activeTextureHandle->vulkanTexture->sample_count,
         textureContainer->activeTextureHandle->vulkanTexture->format,
         textureContainer->activeTextureHandle->vulkanTexture->swizzle,
         textureContainer->activeTextureHandle->vulkanTexture->aspectFlags,
-        textureContainer->activeTextureHandle->vulkanTexture->usageFlags,
+        textureContainer->activeTextureHandle->vulkanTexture->usage_flags,
         false);
 
     textureContainer->activeTextureHandle->container = textureContainer;
@@ -5991,7 +5991,7 @@ static void VULKAN_INTERNAL_CycleActiveTexture(
     textureContainer->textureCount += 1;
 
     if (
-        renderer->debugMode &&
+        renderer->debug_mode &&
         renderer->supportsDebugUtils &&
         textureContainer->debugName != NULL) {
         VULKAN_INTERNAL_SetTextureName(
@@ -6003,7 +6003,7 @@ static void VULKAN_INTERNAL_CycleActiveTexture(
 
 static VulkanBuffer *VULKAN_INTERNAL_PrepareBufferForWrite(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *commandBuffer,
+    VulkanCommandBuffer *command_buffer,
     VulkanBufferContainer *bufferContainer,
     bool cycle,
     VulkanBufferUsageMode destinationUsageMode)
@@ -6018,7 +6018,7 @@ static VulkanBuffer *VULKAN_INTERNAL_PrepareBufferForWrite(
 
     VULKAN_INTERNAL_BufferTransitionFromDefaultUsage(
         renderer,
-        commandBuffer,
+        command_buffer,
         destinationUsageMode,
         bufferContainer->activeBufferHandle->vulkanBuffer);
 
@@ -6027,7 +6027,7 @@ static VulkanBuffer *VULKAN_INTERNAL_PrepareBufferForWrite(
 
 static VulkanTextureSubresource *VULKAN_INTERNAL_PrepareTextureSubresourceForWrite(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *commandBuffer,
+    VulkanCommandBuffer *command_buffer,
     VulkanTextureContainer *textureContainer,
     Uint32 layer,
     Uint32 level,
@@ -6056,7 +6056,7 @@ static VulkanTextureSubresource *VULKAN_INTERNAL_PrepareTextureSubresourceForWri
     // always do barrier because of layout transitions
     VULKAN_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
         renderer,
-        commandBuffer,
+        command_buffer,
         destinationUsageMode,
         textureSubresource);
 
@@ -6065,10 +6065,10 @@ static VulkanTextureSubresource *VULKAN_INTERNAL_PrepareTextureSubresourceForWri
 
 static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *commandBuffer,
-    const SDL_GPUColorAttachmentInfo *colorAttachmentInfos,
-    Uint32 colorAttachmentCount,
-    const SDL_GPUDepthStencilAttachmentInfo *depthStencilAttachmentInfo)
+    VulkanCommandBuffer *command_buffer,
+    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
+    Uint32 num_color_attachments,
+    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info)
 {
     VkResult vulkanResult;
     VkAttachmentDescription attachmentDescriptions[2 * MAX_COLOR_TARGET_BINDINGS + 1];
@@ -6077,7 +6077,7 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
     VkAttachmentReference depthStencilAttachmentReference;
     VkRenderPassCreateInfo renderPassCreateInfo;
     VkSubpassDescription subpass;
-    VkRenderPass renderPass;
+    VkRenderPass render_pass;
     Uint32 i;
 
     Uint32 attachmentDescriptionCount = 0;
@@ -6086,17 +6086,17 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
 
     VulkanTexture *texture = NULL;
 
-    for (i = 0; i < colorAttachmentCount; i += 1) {
-        texture = ((VulkanTextureContainer *)colorAttachmentInfos[i].texture)->activeTextureHandle->vulkanTexture;
+    for (i = 0; i < num_color_attachments; i += 1) {
+        texture = ((VulkanTextureContainer *)color_attachment_infos[i].texture)->activeTextureHandle->vulkanTexture;
 
-        if (texture->sampleCount > VK_SAMPLE_COUNT_1_BIT) {
+        if (texture->sample_count > VK_SAMPLE_COUNT_1_BIT) {
             // Resolve attachment and multisample attachment
 
             attachmentDescriptions[attachmentDescriptionCount].flags = 0;
             attachmentDescriptions[attachmentDescriptionCount].format = texture->format;
             attachmentDescriptions[attachmentDescriptionCount].samples =
                 VK_SAMPLE_COUNT_1_BIT;
-            attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[colorAttachmentInfos[i].loadOp];
+            attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[color_attachment_infos[i].load_op];
             attachmentDescriptions[attachmentDescriptionCount].storeOp =
                 VK_ATTACHMENT_STORE_OP_STORE; // Always store the resolve texture
             attachmentDescriptions[attachmentDescriptionCount].stencilLoadOp =
@@ -6118,9 +6118,9 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
 
             attachmentDescriptions[attachmentDescriptionCount].flags = 0;
             attachmentDescriptions[attachmentDescriptionCount].format = texture->format;
-            attachmentDescriptions[attachmentDescriptionCount].samples = texture->sampleCount;
-            attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[colorAttachmentInfos[i].loadOp];
-            attachmentDescriptions[attachmentDescriptionCount].storeOp = SDLToVK_StoreOp[colorAttachmentInfos[i].storeOp];
+            attachmentDescriptions[attachmentDescriptionCount].samples = texture->sample_count;
+            attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[color_attachment_infos[i].load_op];
+            attachmentDescriptions[attachmentDescriptionCount].storeOp = SDLToVK_StoreOp[color_attachment_infos[i].store_op];
             attachmentDescriptions[attachmentDescriptionCount].stencilLoadOp =
                 VK_ATTACHMENT_LOAD_OP_DONT_CARE;
             attachmentDescriptions[attachmentDescriptionCount].stencilStoreOp =
@@ -6142,7 +6142,7 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
             attachmentDescriptions[attachmentDescriptionCount].format = texture->format;
             attachmentDescriptions[attachmentDescriptionCount].samples =
                 VK_SAMPLE_COUNT_1_BIT;
-            attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[colorAttachmentInfos[i].loadOp];
+            attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[color_attachment_infos[i].load_op];
             attachmentDescriptions[attachmentDescriptionCount].storeOp =
                 VK_ATTACHMENT_STORE_OP_STORE; // Always store non-MSAA textures
             attachmentDescriptions[attachmentDescriptionCount].stencilLoadOp =
@@ -6167,24 +6167,24 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
     subpass.flags = 0;
     subpass.inputAttachmentCount = 0;
     subpass.pInputAttachments = NULL;
-    subpass.colorAttachmentCount = colorAttachmentCount;
+    subpass.colorAttachmentCount = num_color_attachments;
     subpass.pColorAttachments = colorAttachmentReferences;
     subpass.preserveAttachmentCount = 0;
     subpass.pPreserveAttachments = NULL;
 
-    if (depthStencilAttachmentInfo == NULL) {
+    if (depth_stencil_attachment_info == NULL) {
         subpass.pDepthStencilAttachment = NULL;
     } else {
-        texture = ((VulkanTextureContainer *)depthStencilAttachmentInfo->texture)->activeTextureHandle->vulkanTexture;
+        texture = ((VulkanTextureContainer *)depth_stencil_attachment_info->texture)->activeTextureHandle->vulkanTexture;
 
         attachmentDescriptions[attachmentDescriptionCount].flags = 0;
         attachmentDescriptions[attachmentDescriptionCount].format = texture->format;
-        attachmentDescriptions[attachmentDescriptionCount].samples = texture->sampleCount;
+        attachmentDescriptions[attachmentDescriptionCount].samples = texture->sample_count;
 
-        attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[depthStencilAttachmentInfo->loadOp];
-        attachmentDescriptions[attachmentDescriptionCount].storeOp = SDLToVK_StoreOp[depthStencilAttachmentInfo->storeOp];
-        attachmentDescriptions[attachmentDescriptionCount].stencilLoadOp = SDLToVK_LoadOp[depthStencilAttachmentInfo->stencilLoadOp];
-        attachmentDescriptions[attachmentDescriptionCount].stencilStoreOp = SDLToVK_StoreOp[depthStencilAttachmentInfo->stencilStoreOp];
+        attachmentDescriptions[attachmentDescriptionCount].loadOp = SDLToVK_LoadOp[depth_stencil_attachment_info->load_op];
+        attachmentDescriptions[attachmentDescriptionCount].storeOp = SDLToVK_StoreOp[depth_stencil_attachment_info->store_op];
+        attachmentDescriptions[attachmentDescriptionCount].stencilLoadOp = SDLToVK_LoadOp[depth_stencil_attachment_info->stencil_load_op];
+        attachmentDescriptions[attachmentDescriptionCount].stencilStoreOp = SDLToVK_StoreOp[depth_stencil_attachment_info->stencil_store_op];
         attachmentDescriptions[attachmentDescriptionCount].initialLayout =
             VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
         attachmentDescriptions[attachmentDescriptionCount].finalLayout =
@@ -6201,7 +6201,7 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
         attachmentDescriptionCount += 1;
     }
 
-    if (texture != NULL && texture->sampleCount > VK_SAMPLE_COUNT_1_BIT) {
+    if (texture != NULL && texture->sample_count > VK_SAMPLE_COUNT_1_BIT) {
         subpass.pResolveAttachments = resolveReferences;
     } else {
         subpass.pResolveAttachments = NULL;
@@ -6221,20 +6221,20 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
         renderer->logicalDevice,
         &renderPassCreateInfo,
         NULL,
-        &renderPass);
+        &render_pass);
 
     if (vulkanResult != VK_SUCCESS) {
-        renderPass = VK_NULL_HANDLE;
+        render_pass = VK_NULL_HANDLE;
         LogVulkanResultAsError("vkCreateRenderPass", vulkanResult);
     }
 
-    return renderPass;
+    return render_pass;
 }
 
 static VkRenderPass VULKAN_INTERNAL_CreateTransientRenderPass(
     VulkanRenderer *renderer,
-    SDL_GPUGraphicsPipelineAttachmentInfo attachmentInfo,
-    VkSampleCountFlagBits sampleCount)
+    SDL_GPUGraphicsPipelineAttachmentInfo attachment_info,
+    VkSampleCountFlagBits sample_count)
 {
     VkAttachmentDescription attachmentDescriptions[2 * MAX_COLOR_TARGET_BINDINGS + 1];
     VkAttachmentReference colorAttachmentReferences[MAX_COLOR_TARGET_BINDINGS];
@@ -6243,7 +6243,7 @@ static VkRenderPass VULKAN_INTERNAL_CreateTransientRenderPass(
     SDL_GPUColorAttachmentDescription attachmentDescription;
     VkSubpassDescription subpass;
     VkRenderPassCreateInfo renderPassCreateInfo;
-    VkRenderPass renderPass;
+    VkRenderPass render_pass;
     VkResult result;
 
     Uint32 multisampling = 0;
@@ -6252,10 +6252,10 @@ static VkRenderPass VULKAN_INTERNAL_CreateTransientRenderPass(
     Uint32 resolveReferenceCount = 0;
     Uint32 i;
 
-    for (i = 0; i < attachmentInfo.colorAttachmentCount; i += 1) {
-        attachmentDescription = attachmentInfo.colorAttachmentDescriptions[i];
+    for (i = 0; i < attachment_info.num_color_attachments; i += 1) {
+        attachmentDescription = attachment_info.color_attachment_descriptions[i];
 
-        if (sampleCount > VK_SAMPLE_COUNT_1_BIT) {
+        if (sample_count > VK_SAMPLE_COUNT_1_BIT) {
             multisampling = 1;
 
             // Resolve attachment and multisample attachment
@@ -6278,7 +6278,7 @@ static VkRenderPass VULKAN_INTERNAL_CreateTransientRenderPass(
 
             attachmentDescriptions[attachmentDescriptionCount].flags = 0;
             attachmentDescriptions[attachmentDescriptionCount].format = SDLToVK_SurfaceFormat[attachmentDescription.format];
-            attachmentDescriptions[attachmentDescriptionCount].samples = sampleCount;
+            attachmentDescriptions[attachmentDescriptionCount].samples = sample_count;
 
             attachmentDescriptions[attachmentDescriptionCount].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
             attachmentDescriptions[attachmentDescriptionCount].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
@@ -6325,16 +6325,16 @@ static VkRenderPass VULKAN_INTERNAL_CreateTransientRenderPass(
     subpass.flags = 0;
     subpass.inputAttachmentCount = 0;
     subpass.pInputAttachments = NULL;
-    subpass.colorAttachmentCount = attachmentInfo.colorAttachmentCount;
+    subpass.colorAttachmentCount = attachment_info.num_color_attachments;
     subpass.pColorAttachments = colorAttachmentReferences;
     subpass.preserveAttachmentCount = 0;
     subpass.pPreserveAttachments = NULL;
 
-    if (attachmentInfo.hasDepthStencilAttachment) {
+    if (attachment_info.has_depth_stencil_attachment) {
         attachmentDescriptions[attachmentDescriptionCount].flags = 0;
         attachmentDescriptions[attachmentDescriptionCount].format =
-            SDLToVK_SurfaceFormat[attachmentInfo.depthStencilFormat];
-        attachmentDescriptions[attachmentDescriptionCount].samples = sampleCount;
+            SDLToVK_SurfaceFormat[attachment_info.depth_stencil_format];
+        attachmentDescriptions[attachmentDescriptionCount].samples = sample_count;
 
         attachmentDescriptions[attachmentDescriptionCount].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
         attachmentDescriptions[attachmentDescriptionCount].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
@@ -6378,34 +6378,34 @@ static VkRenderPass VULKAN_INTERNAL_CreateTransientRenderPass(
         renderer->logicalDevice,
         &renderPassCreateInfo,
         NULL,
-        &renderPass);
+        &render_pass);
 
     if (result != VK_SUCCESS) {
-        renderPass = VK_NULL_HANDLE;
+        render_pass = VK_NULL_HANDLE;
         LogVulkanResultAsError("vkCreateRenderPass", result);
     }
 
-    return renderPass;
+    return render_pass;
 }
 
 static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
     SDL_GPURenderer *driverData,
-    const SDL_GPUGraphicsPipelineCreateInfo *pipelineCreateInfo)
+    const SDL_GPUGraphicsPipelineCreateInfo *createinfo)
 {
     VkResult vulkanResult;
     Uint32 i;
     VkSampleCountFlagBits actualSampleCount;
 
-    VulkanGraphicsPipeline *graphicsPipeline = (VulkanGraphicsPipeline *)SDL_malloc(sizeof(VulkanGraphicsPipeline));
+    VulkanGraphicsPipeline *graphics_pipeline = (VulkanGraphicsPipeline *)SDL_malloc(sizeof(VulkanGraphicsPipeline));
     VkGraphicsPipelineCreateInfo vkPipelineCreateInfo;
 
     VkPipelineShaderStageCreateInfo shaderStageCreateInfos[2];
 
     VkPipelineVertexInputStateCreateInfo vertexInputStateCreateInfo;
     VkPipelineVertexInputDivisorStateCreateInfoEXT divisorStateCreateInfo;
-    VkVertexInputBindingDescription *vertexInputBindingDescriptions = SDL_stack_alloc(VkVertexInputBindingDescription, pipelineCreateInfo->vertexInputState.vertexBindingCount);
-    VkVertexInputAttributeDescription *vertexInputAttributeDescriptions = SDL_stack_alloc(VkVertexInputAttributeDescription, pipelineCreateInfo->vertexInputState.vertexAttributeCount);
-    VkVertexInputBindingDivisorDescriptionEXT *divisorDescriptions = SDL_stack_alloc(VkVertexInputBindingDivisorDescriptionEXT, pipelineCreateInfo->vertexInputState.vertexBindingCount);
+    VkVertexInputBindingDescription *vertexInputBindingDescriptions = SDL_stack_alloc(VkVertexInputBindingDescription, createinfo->vertex_input_state.num_vertex_bindings);
+    VkVertexInputAttributeDescription *vertexInputAttributeDescriptions = SDL_stack_alloc(VkVertexInputAttributeDescription, createinfo->vertex_input_state.num_vertex_attributes);
+    VkVertexInputBindingDivisorDescriptionEXT *divisorDescriptions = SDL_stack_alloc(VkVertexInputBindingDivisorDescriptionEXT, createinfo->vertex_input_state.num_vertex_bindings);
     Uint32 divisorDescriptionCount = 0;
 
     VkPipelineInputAssemblyStateCreateInfo inputAssemblyStateCreateInfo;
@@ -6417,13 +6417,13 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
     VkPipelineMultisampleStateCreateInfo multisampleStateCreateInfo;
 
     VkPipelineDepthStencilStateCreateInfo depthStencilStateCreateInfo;
-    VkStencilOpState frontStencilState;
-    VkStencilOpState backStencilState;
+    VkStencilOpState front_stencil_state;
+    VkStencilOpState back_stencil_state;
 
     VkPipelineColorBlendStateCreateInfo colorBlendStateCreateInfo;
     VkPipelineColorBlendAttachmentState *colorBlendAttachmentStates = SDL_stack_alloc(
         VkPipelineColorBlendAttachmentState,
-        pipelineCreateInfo->attachmentInfo.colorAttachmentCount);
+        createinfo->attachment_info.num_color_attachments);
 
     static const VkDynamicState dynamicStates[] = {
         VK_DYNAMIC_STATE_VIEWPORT,
@@ -6439,13 +6439,13 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
 
     actualSampleCount = VULKAN_INTERNAL_GetMaxMultiSampleCount(
         renderer,
-        SDLToVK_SampleCount[pipelineCreateInfo->multisampleState.sampleCount]);
+        SDLToVK_SampleCount[createinfo->multisample_state.sample_count]);
 
     // Create a "compatible" render pass
 
     VkRenderPass transientRenderPass = VULKAN_INTERNAL_CreateTransientRenderPass(
         renderer,
-        pipelineCreateInfo->attachmentInfo,
+        createinfo->attachment_info,
         actualSampleCount);
 
     // Dynamic state
@@ -6458,62 +6458,62 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
 
     // Shader stages
 
-    graphicsPipeline->vertexShader = (VulkanShader *)pipelineCreateInfo->vertexShader;
-    SDL_AtomicIncRef(&graphicsPipeline->vertexShader->referenceCount);
+    graphics_pipeline->vertex_shader = (VulkanShader *)createinfo->vertex_shader;
+    SDL_AtomicIncRef(&graphics_pipeline->vertex_shader->referenceCount);
 
     shaderStageCreateInfos[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStageCreateInfos[0].pNext = NULL;
     shaderStageCreateInfos[0].flags = 0;
     shaderStageCreateInfos[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-    shaderStageCreateInfos[0].module = graphicsPipeline->vertexShader->shaderModule;
-    shaderStageCreateInfos[0].pName = graphicsPipeline->vertexShader->entryPointName;
+    shaderStageCreateInfos[0].module = graphics_pipeline->vertex_shader->shaderModule;
+    shaderStageCreateInfos[0].pName = graphics_pipeline->vertex_shader->entrypoint_name;
     shaderStageCreateInfos[0].pSpecializationInfo = NULL;
 
-    graphicsPipeline->fragmentShader = (VulkanShader *)pipelineCreateInfo->fragmentShader;
-    SDL_AtomicIncRef(&graphicsPipeline->fragmentShader->referenceCount);
+    graphics_pipeline->fragment_shader = (VulkanShader *)createinfo->fragment_shader;
+    SDL_AtomicIncRef(&graphics_pipeline->fragment_shader->referenceCount);
 
     shaderStageCreateInfos[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     shaderStageCreateInfos[1].pNext = NULL;
     shaderStageCreateInfos[1].flags = 0;
     shaderStageCreateInfos[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-    shaderStageCreateInfos[1].module = graphicsPipeline->fragmentShader->shaderModule;
-    shaderStageCreateInfos[1].pName = graphicsPipeline->fragmentShader->entryPointName;
+    shaderStageCreateInfos[1].module = graphics_pipeline->fragment_shader->shaderModule;
+    shaderStageCreateInfos[1].pName = graphics_pipeline->fragment_shader->entrypoint_name;
     shaderStageCreateInfos[1].pSpecializationInfo = NULL;
 
     // Vertex input
 
-    for (i = 0; i < pipelineCreateInfo->vertexInputState.vertexBindingCount; i += 1) {
-        vertexInputBindingDescriptions[i].binding = pipelineCreateInfo->vertexInputState.vertexBindings[i].binding;
-        vertexInputBindingDescriptions[i].inputRate = SDLToVK_VertexInputRate[pipelineCreateInfo->vertexInputState.vertexBindings[i].inputRate];
-        vertexInputBindingDescriptions[i].stride = pipelineCreateInfo->vertexInputState.vertexBindings[i].stride;
+    for (i = 0; i < createinfo->vertex_input_state.num_vertex_bindings; i += 1) {
+        vertexInputBindingDescriptions[i].binding = createinfo->vertex_input_state.vertex_bindings[i].binding;
+        vertexInputBindingDescriptions[i].inputRate = SDLToVK_VertexInputRate[createinfo->vertex_input_state.vertex_bindings[i].input_rate];
+        vertexInputBindingDescriptions[i].stride = createinfo->vertex_input_state.vertex_bindings[i].pitch;
 
-        if (pipelineCreateInfo->vertexInputState.vertexBindings[i].inputRate == SDL_GPU_VERTEXINPUTRATE_INSTANCE) {
+        if (createinfo->vertex_input_state.vertex_bindings[i].input_rate == SDL_GPU_VERTEXINPUTRATE_INSTANCE) {
             divisorDescriptionCount += 1;
         }
     }
 
-    for (i = 0; i < pipelineCreateInfo->vertexInputState.vertexAttributeCount; i += 1) {
-        vertexInputAttributeDescriptions[i].binding = pipelineCreateInfo->vertexInputState.vertexAttributes[i].binding;
-        vertexInputAttributeDescriptions[i].format = SDLToVK_VertexFormat[pipelineCreateInfo->vertexInputState.vertexAttributes[i].format];
-        vertexInputAttributeDescriptions[i].location = pipelineCreateInfo->vertexInputState.vertexAttributes[i].location;
-        vertexInputAttributeDescriptions[i].offset = pipelineCreateInfo->vertexInputState.vertexAttributes[i].offset;
+    for (i = 0; i < createinfo->vertex_input_state.num_vertex_attributes; i += 1) {
+        vertexInputAttributeDescriptions[i].binding = createinfo->vertex_input_state.vertex_attributes[i].binding;
+        vertexInputAttributeDescriptions[i].format = SDLToVK_VertexFormat[createinfo->vertex_input_state.vertex_attributes[i].format];
+        vertexInputAttributeDescriptions[i].location = createinfo->vertex_input_state.vertex_attributes[i].location;
+        vertexInputAttributeDescriptions[i].offset = createinfo->vertex_input_state.vertex_attributes[i].offset;
     }
 
     vertexInputStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
     vertexInputStateCreateInfo.pNext = NULL;
     vertexInputStateCreateInfo.flags = 0;
-    vertexInputStateCreateInfo.vertexBindingDescriptionCount = pipelineCreateInfo->vertexInputState.vertexBindingCount;
+    vertexInputStateCreateInfo.vertexBindingDescriptionCount = createinfo->vertex_input_state.num_vertex_bindings;
     vertexInputStateCreateInfo.pVertexBindingDescriptions = vertexInputBindingDescriptions;
-    vertexInputStateCreateInfo.vertexAttributeDescriptionCount = pipelineCreateInfo->vertexInputState.vertexAttributeCount;
+    vertexInputStateCreateInfo.vertexAttributeDescriptionCount = createinfo->vertex_input_state.num_vertex_attributes;
     vertexInputStateCreateInfo.pVertexAttributeDescriptions = vertexInputAttributeDescriptions;
 
     if (divisorDescriptionCount > 0) {
         divisorDescriptionCount = 0;
 
-        for (i = 0; i < pipelineCreateInfo->vertexInputState.vertexBindingCount; i += 1) {
-            if (pipelineCreateInfo->vertexInputState.vertexBindings[i].inputRate == SDL_GPU_VERTEXINPUTRATE_INSTANCE) {
-                divisorDescriptions[divisorDescriptionCount].binding = pipelineCreateInfo->vertexInputState.vertexBindings[i].binding;
-                divisorDescriptions[divisorDescriptionCount].divisor = pipelineCreateInfo->vertexInputState.vertexBindings[i].instanceStepRate;
+        for (i = 0; i < createinfo->vertex_input_state.num_vertex_bindings; i += 1) {
+            if (createinfo->vertex_input_state.vertex_bindings[i].input_rate == SDL_GPU_VERTEXINPUTRATE_INSTANCE) {
+                divisorDescriptions[divisorDescriptionCount].binding = createinfo->vertex_input_state.vertex_bindings[i].binding;
+                divisorDescriptions[divisorDescriptionCount].divisor = createinfo->vertex_input_state.vertex_bindings[i].instance_step_rate;
 
                 divisorDescriptionCount += 1;
             }
@@ -6533,9 +6533,9 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
     inputAssemblyStateCreateInfo.pNext = NULL;
     inputAssemblyStateCreateInfo.flags = 0;
     inputAssemblyStateCreateInfo.primitiveRestartEnable = VK_FALSE;
-    inputAssemblyStateCreateInfo.topology = SDLToVK_PrimitiveType[pipelineCreateInfo->primitiveType];
+    inputAssemblyStateCreateInfo.topology = SDLToVK_PrimitiveType[createinfo->primitive_type];
 
-    graphicsPipeline->primitiveType = pipelineCreateInfo->primitiveType;
+    graphics_pipeline->primitive_type = createinfo->primitive_type;
 
     // Viewport
 
@@ -6558,17 +6558,17 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
     rasterizationStateCreateInfo.rasterizerDiscardEnable = VK_FALSE;
     rasterizationStateCreateInfo.polygonMode = SDLToVK_PolygonMode(
         renderer,
-        pipelineCreateInfo->rasterizerState.fillMode);
-    rasterizationStateCreateInfo.cullMode = SDLToVK_CullMode[pipelineCreateInfo->rasterizerState.cullMode];
-    rasterizationStateCreateInfo.frontFace = SDLToVK_FrontFace[pipelineCreateInfo->rasterizerState.frontFace];
+        createinfo->rasterizer_state.fill_mode);
+    rasterizationStateCreateInfo.cullMode = SDLToVK_CullMode[createinfo->rasterizer_state.cull_mode];
+    rasterizationStateCreateInfo.frontFace = SDLToVK_FrontFace[createinfo->rasterizer_state.frontFace];
     rasterizationStateCreateInfo.depthBiasEnable =
-        pipelineCreateInfo->rasterizerState.depthBiasEnable;
+        createinfo->rasterizer_state.enable_depth_bias;
     rasterizationStateCreateInfo.depthBiasConstantFactor =
-        pipelineCreateInfo->rasterizerState.depthBiasConstantFactor;
+        createinfo->rasterizer_state.depth_bias_constant_factor;
     rasterizationStateCreateInfo.depthBiasClamp =
-        pipelineCreateInfo->rasterizerState.depthBiasClamp;
+        createinfo->rasterizer_state.depth_bias_clamp;
     rasterizationStateCreateInfo.depthBiasSlopeFactor =
-        pipelineCreateInfo->rasterizerState.depthBiasSlopeFactor;
+        createinfo->rasterizer_state.depth_bias_slope_factor;
     rasterizationStateCreateInfo.lineWidth = 1.0f;
 
     // Multisample
@@ -6580,70 +6580,70 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
     multisampleStateCreateInfo.sampleShadingEnable = VK_FALSE;
     multisampleStateCreateInfo.minSampleShading = 1.0f;
     multisampleStateCreateInfo.pSampleMask =
-        &pipelineCreateInfo->multisampleState.sampleMask;
+        &createinfo->multisample_state.sample_mask;
     multisampleStateCreateInfo.alphaToCoverageEnable = VK_FALSE;
     multisampleStateCreateInfo.alphaToOneEnable = VK_FALSE;
 
     // Depth Stencil State
 
-    frontStencilState.failOp = SDLToVK_StencilOp[pipelineCreateInfo->depthStencilState.frontStencilState.failOp];
-    frontStencilState.passOp = SDLToVK_StencilOp[pipelineCreateInfo->depthStencilState.frontStencilState.passOp];
-    frontStencilState.depthFailOp = SDLToVK_StencilOp[pipelineCreateInfo->depthStencilState.frontStencilState.depthFailOp];
-    frontStencilState.compareOp = SDLToVK_CompareOp[pipelineCreateInfo->depthStencilState.frontStencilState.compareOp];
-    frontStencilState.compareMask =
-        pipelineCreateInfo->depthStencilState.compareMask;
-    frontStencilState.writeMask =
-        pipelineCreateInfo->depthStencilState.writeMask;
-    frontStencilState.reference = 0;
+    front_stencil_state.failOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.front_stencil_state.fail_op];
+    front_stencil_state.passOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.front_stencil_state.pass_op];
+    front_stencil_state.depthFailOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.front_stencil_state.depth_fail_op];
+    front_stencil_state.compareOp = SDLToVK_CompareOp[createinfo->depth_stencil_state.front_stencil_state.compare_op];
+    front_stencil_state.compareMask =
+        createinfo->depth_stencil_state.compare_mask;
+    front_stencil_state.writeMask =
+        createinfo->depth_stencil_state.write_mask;
+    front_stencil_state.reference = 0;
 
-    backStencilState.failOp = SDLToVK_StencilOp[pipelineCreateInfo->depthStencilState.backStencilState.failOp];
-    backStencilState.passOp = SDLToVK_StencilOp[pipelineCreateInfo->depthStencilState.backStencilState.passOp];
-    backStencilState.depthFailOp = SDLToVK_StencilOp[pipelineCreateInfo->depthStencilState.backStencilState.depthFailOp];
-    backStencilState.compareOp = SDLToVK_CompareOp[pipelineCreateInfo->depthStencilState.backStencilState.compareOp];
-    backStencilState.compareMask =
-        pipelineCreateInfo->depthStencilState.compareMask;
-    backStencilState.writeMask =
-        pipelineCreateInfo->depthStencilState.writeMask;
-    backStencilState.reference = 0;
+    back_stencil_state.failOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.back_stencil_state.fail_op];
+    back_stencil_state.passOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.back_stencil_state.pass_op];
+    back_stencil_state.depthFailOp = SDLToVK_StencilOp[createinfo->depth_stencil_state.back_stencil_state.depth_fail_op];
+    back_stencil_state.compareOp = SDLToVK_CompareOp[createinfo->depth_stencil_state.back_stencil_state.compare_op];
+    back_stencil_state.compareMask =
+        createinfo->depth_stencil_state.compare_mask;
+    back_stencil_state.writeMask =
+        createinfo->depth_stencil_state.write_mask;
+    back_stencil_state.reference = 0;
 
     depthStencilStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
     depthStencilStateCreateInfo.pNext = NULL;
     depthStencilStateCreateInfo.flags = 0;
     depthStencilStateCreateInfo.depthTestEnable =
-        pipelineCreateInfo->depthStencilState.depthTestEnable;
+        createinfo->depth_stencil_state.enable_depth_test;
     depthStencilStateCreateInfo.depthWriteEnable =
-        pipelineCreateInfo->depthStencilState.depthWriteEnable;
-    depthStencilStateCreateInfo.depthCompareOp = SDLToVK_CompareOp[pipelineCreateInfo->depthStencilState.compareOp];
+        createinfo->depth_stencil_state.enable_depth_write;
+    depthStencilStateCreateInfo.depthCompareOp = SDLToVK_CompareOp[createinfo->depth_stencil_state.compare_op];
     depthStencilStateCreateInfo.depthBoundsTestEnable = VK_FALSE;
     depthStencilStateCreateInfo.stencilTestEnable =
-        pipelineCreateInfo->depthStencilState.stencilTestEnable;
-    depthStencilStateCreateInfo.front = frontStencilState;
-    depthStencilStateCreateInfo.back = backStencilState;
+        createinfo->depth_stencil_state.enable_stencil_test;
+    depthStencilStateCreateInfo.front = front_stencil_state;
+    depthStencilStateCreateInfo.back = back_stencil_state;
     depthStencilStateCreateInfo.minDepthBounds = 0; // unused
     depthStencilStateCreateInfo.maxDepthBounds = 0; // unused
 
     // Color Blend
 
-    for (i = 0; i < pipelineCreateInfo->attachmentInfo.colorAttachmentCount; i += 1) {
-        SDL_GPUColorAttachmentBlendState blendState = pipelineCreateInfo->attachmentInfo.colorAttachmentDescriptions[i].blendState;
+    for (i = 0; i < createinfo->attachment_info.num_color_attachments; i += 1) {
+        SDL_GPUColorAttachmentBlendState blend_state = createinfo->attachment_info.color_attachment_descriptions[i].blend_state;
 
         colorBlendAttachmentStates[i].blendEnable =
-            blendState.blendEnable;
-        colorBlendAttachmentStates[i].srcColorBlendFactor = SDLToVK_BlendFactor[blendState.srcColorBlendFactor];
-        colorBlendAttachmentStates[i].dstColorBlendFactor = SDLToVK_BlendFactor[blendState.dstColorBlendFactor];
-        colorBlendAttachmentStates[i].colorBlendOp = SDLToVK_BlendOp[blendState.colorBlendOp];
-        colorBlendAttachmentStates[i].srcAlphaBlendFactor = SDLToVK_BlendFactor[blendState.srcAlphaBlendFactor];
-        colorBlendAttachmentStates[i].dstAlphaBlendFactor = SDLToVK_BlendFactor[blendState.dstAlphaBlendFactor];
-        colorBlendAttachmentStates[i].alphaBlendOp = SDLToVK_BlendOp[blendState.alphaBlendOp];
+            blend_state.enable_blend;
+        colorBlendAttachmentStates[i].srcColorBlendFactor = SDLToVK_BlendFactor[blend_state.src_color_blendfactor];
+        colorBlendAttachmentStates[i].dstColorBlendFactor = SDLToVK_BlendFactor[blend_state.dst_color_blendfactor];
+        colorBlendAttachmentStates[i].colorBlendOp = SDLToVK_BlendOp[blend_state.color_blend_op];
+        colorBlendAttachmentStates[i].srcAlphaBlendFactor = SDLToVK_BlendFactor[blend_state.src_alpha_blendfactor];
+        colorBlendAttachmentStates[i].dstAlphaBlendFactor = SDLToVK_BlendFactor[blend_state.dst_alpha_blendfactor];
+        colorBlendAttachmentStates[i].alphaBlendOp = SDLToVK_BlendOp[blend_state.alpha_blend_op];
         colorBlendAttachmentStates[i].colorWriteMask =
-            blendState.colorWriteMask;
+            blend_state.color_write_mask;
     }
 
     colorBlendStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
     colorBlendStateCreateInfo.pNext = NULL;
     colorBlendStateCreateInfo.flags = 0;
     colorBlendStateCreateInfo.attachmentCount =
-        pipelineCreateInfo->attachmentInfo.colorAttachmentCount;
+        createinfo->attachment_info.num_color_attachments;
     colorBlendStateCreateInfo.pAttachments =
         colorBlendAttachmentStates;
     colorBlendStateCreateInfo.blendConstants[0] = 1.0f;
@@ -6659,14 +6659,14 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
 
     if (!VULKAN_INTERNAL_InitializeGraphicsPipelineResourceLayout(
             renderer,
-            graphicsPipeline->vertexShader,
-            graphicsPipeline->fragmentShader,
-            &graphicsPipeline->resourceLayout)) {
+            graphics_pipeline->vertex_shader,
+            graphics_pipeline->fragment_shader,
+            &graphics_pipeline->resourceLayout)) {
         SDL_stack_free(vertexInputBindingDescriptions);
         SDL_stack_free(vertexInputAttributeDescriptions);
         SDL_stack_free(colorBlendAttachmentStates);
         SDL_stack_free(divisorDescriptions);
-        SDL_free(graphicsPipeline);
+        SDL_free(graphics_pipeline);
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to initialize pipeline resource layout!");
         return NULL;
     }
@@ -6687,7 +6687,7 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
     vkPipelineCreateInfo.pDepthStencilState = &depthStencilStateCreateInfo;
     vkPipelineCreateInfo.pColorBlendState = &colorBlendStateCreateInfo;
     vkPipelineCreateInfo.pDynamicState = &dynamicStateCreateInfo;
-    vkPipelineCreateInfo.layout = graphicsPipeline->resourceLayout.pipelineLayout;
+    vkPipelineCreateInfo.layout = graphics_pipeline->resourceLayout.pipelineLayout;
     vkPipelineCreateInfo.renderPass = transientRenderPass;
     vkPipelineCreateInfo.subpass = 0;
     vkPipelineCreateInfo.basePipelineHandle = VK_NULL_HANDLE;
@@ -6700,7 +6700,7 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
         1,
         &vkPipelineCreateInfo,
         NULL,
-        &graphicsPipeline->pipeline);
+        &graphics_pipeline->pipeline);
 
     SDL_stack_free(vertexInputBindingDescriptions);
     SDL_stack_free(vertexInputAttributeDescriptions);
@@ -6713,30 +6713,30 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
         NULL);
 
     if (vulkanResult != VK_SUCCESS) {
-        SDL_free(graphicsPipeline);
+        SDL_free(graphics_pipeline);
         LogVulkanResultAsError("vkCreateGraphicsPipelines", vulkanResult);
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create graphics pipeline!");
         return NULL;
     }
 
-    SDL_AtomicSet(&graphicsPipeline->referenceCount, 0);
+    SDL_AtomicSet(&graphics_pipeline->referenceCount, 0);
 
-    return (SDL_GPUGraphicsPipeline *)graphicsPipeline;
+    return (SDL_GPUGraphicsPipeline *)graphics_pipeline;
 }
 
 static SDL_GPUComputePipeline *VULKAN_CreateComputePipeline(
     SDL_GPURenderer *driverData,
-    const SDL_GPUComputePipelineCreateInfo *pipelineCreateInfo)
+    const SDL_GPUComputePipelineCreateInfo *createinfo)
 {
     VkShaderModuleCreateInfo shaderModuleCreateInfo;
-    VkComputePipelineCreateInfo computePipelineCreateInfo;
+    VkComputePipelineCreateInfo vkShaderCreateInfo;
     VkPipelineShaderStageCreateInfo pipelineShaderStageCreateInfo;
     VkResult vulkanResult;
     Uint32 i;
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
     VulkanComputePipeline *vulkanComputePipeline;
 
-    if (pipelineCreateInfo->format != SDL_GPU_SHADERFORMAT_SPIRV) {
+    if (createinfo->format != SDL_GPU_SHADERFORMAT_SPIRV) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Incompatible shader format for Vulkan!");
         return NULL;
     }
@@ -6745,8 +6745,8 @@ static SDL_GPUComputePipeline *VULKAN_CreateComputePipeline(
     shaderModuleCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
     shaderModuleCreateInfo.pNext = NULL;
     shaderModuleCreateInfo.flags = 0;
-    shaderModuleCreateInfo.codeSize = pipelineCreateInfo->codeSize;
-    shaderModuleCreateInfo.pCode = (Uint32 *)pipelineCreateInfo->code;
+    shaderModuleCreateInfo.codeSize = createinfo->code_size;
+    shaderModuleCreateInfo.pCode = (Uint32 *)createinfo->code;
 
     vulkanResult = renderer->vkCreateShaderModule(
         renderer->logicalDevice,
@@ -6766,12 +6766,12 @@ static SDL_GPUComputePipeline *VULKAN_CreateComputePipeline(
     pipelineShaderStageCreateInfo.flags = 0;
     pipelineShaderStageCreateInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     pipelineShaderStageCreateInfo.module = vulkanComputePipeline->shaderModule;
-    pipelineShaderStageCreateInfo.pName = pipelineCreateInfo->entryPointName;
+    pipelineShaderStageCreateInfo.pName = createinfo->entrypoint_name;
     pipelineShaderStageCreateInfo.pSpecializationInfo = NULL;
 
     if (!VULKAN_INTERNAL_InitializeComputePipelineResourceLayout(
             renderer,
-            pipelineCreateInfo,
+            createinfo,
             &vulkanComputePipeline->resourceLayout)) {
         renderer->vkDestroyShaderModule(
             renderer->logicalDevice,
@@ -6781,20 +6781,20 @@ static SDL_GPUComputePipeline *VULKAN_CreateComputePipeline(
         return NULL;
     }
 
-    computePipelineCreateInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
-    computePipelineCreateInfo.pNext = NULL;
-    computePipelineCreateInfo.flags = 0;
-    computePipelineCreateInfo.stage = pipelineShaderStageCreateInfo;
-    computePipelineCreateInfo.layout =
+    vkShaderCreateInfo.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+    vkShaderCreateInfo.pNext = NULL;
+    vkShaderCreateInfo.flags = 0;
+    vkShaderCreateInfo.stage = pipelineShaderStageCreateInfo;
+    vkShaderCreateInfo.layout =
         vulkanComputePipeline->resourceLayout.pipelineLayout;
-    computePipelineCreateInfo.basePipelineHandle = (VkPipeline)VK_NULL_HANDLE;
-    computePipelineCreateInfo.basePipelineIndex = 0;
+    vkShaderCreateInfo.basePipelineHandle = (VkPipeline)VK_NULL_HANDLE;
+    vkShaderCreateInfo.basePipelineIndex = 0;
 
     vulkanResult = renderer->vkCreateComputePipelines(
         renderer->logicalDevice,
         (VkPipelineCache)VK_NULL_HANDLE,
         1,
-        &computePipelineCreateInfo,
+        &vkShaderCreateInfo,
         NULL,
         &vulkanComputePipeline->pipeline);
 
@@ -6827,7 +6827,7 @@ static SDL_GPUComputePipeline *VULKAN_CreateComputePipeline(
 
 static SDL_GPUSampler *VULKAN_CreateSampler(
     SDL_GPURenderer *driverData,
-    const SDL_GPUSamplerCreateInfo *samplerCreateInfo)
+    const SDL_GPUSamplerCreateInfo *createinfo)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
     VulkanSampler *vulkanSampler = SDL_malloc(sizeof(VulkanSampler));
@@ -6837,19 +6837,19 @@ static SDL_GPUSampler *VULKAN_CreateSampler(
     vkSamplerCreateInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
     vkSamplerCreateInfo.pNext = NULL;
     vkSamplerCreateInfo.flags = 0;
-    vkSamplerCreateInfo.magFilter = SDLToVK_Filter[samplerCreateInfo->magFilter];
-    vkSamplerCreateInfo.minFilter = SDLToVK_Filter[samplerCreateInfo->minFilter];
-    vkSamplerCreateInfo.mipmapMode = SDLToVK_SamplerMipmapMode[samplerCreateInfo->mipmapMode];
-    vkSamplerCreateInfo.addressModeU = SDLToVK_SamplerAddressMode[samplerCreateInfo->addressModeU];
-    vkSamplerCreateInfo.addressModeV = SDLToVK_SamplerAddressMode[samplerCreateInfo->addressModeV];
-    vkSamplerCreateInfo.addressModeW = SDLToVK_SamplerAddressMode[samplerCreateInfo->addressModeW];
-    vkSamplerCreateInfo.mipLodBias = samplerCreateInfo->mipLodBias;
-    vkSamplerCreateInfo.anisotropyEnable = samplerCreateInfo->anisotropyEnable;
-    vkSamplerCreateInfo.maxAnisotropy = samplerCreateInfo->maxAnisotropy;
-    vkSamplerCreateInfo.compareEnable = samplerCreateInfo->compareEnable;
-    vkSamplerCreateInfo.compareOp = SDLToVK_CompareOp[samplerCreateInfo->compareOp];
-    vkSamplerCreateInfo.minLod = samplerCreateInfo->minLod;
-    vkSamplerCreateInfo.maxLod = samplerCreateInfo->maxLod;
+    vkSamplerCreateInfo.magFilter = SDLToVK_Filter[createinfo->mag_filter];
+    vkSamplerCreateInfo.minFilter = SDLToVK_Filter[createinfo->min_filter];
+    vkSamplerCreateInfo.mipmapMode = SDLToVK_SamplerMipmapMode[createinfo->mipmap_mode];
+    vkSamplerCreateInfo.addressModeU = SDLToVK_SamplerAddressMode[createinfo->address_mode_u];
+    vkSamplerCreateInfo.addressModeV = SDLToVK_SamplerAddressMode[createinfo->address_mode_v];
+    vkSamplerCreateInfo.addressModeW = SDLToVK_SamplerAddressMode[createinfo->address_mode_w];
+    vkSamplerCreateInfo.mipLodBias = createinfo->mip_lod_bias;
+    vkSamplerCreateInfo.anisotropyEnable = createinfo->enable_anisotropy;
+    vkSamplerCreateInfo.maxAnisotropy = createinfo->max_anisotropy;
+    vkSamplerCreateInfo.compareEnable = createinfo->enable_compare;
+    vkSamplerCreateInfo.compareOp = SDLToVK_CompareOp[createinfo->compare_op];
+    vkSamplerCreateInfo.minLod = createinfo->min_lod;
+    vkSamplerCreateInfo.maxLod = createinfo->max_lod;
     vkSamplerCreateInfo.borderColor = VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK; // arbitrary, unused
     vkSamplerCreateInfo.unnormalizedCoordinates = VK_FALSE;
 
@@ -6872,7 +6872,7 @@ static SDL_GPUSampler *VULKAN_CreateSampler(
 
 static SDL_GPUShader *VULKAN_CreateShader(
     SDL_GPURenderer *driverData,
-    const SDL_GPUShaderCreateInfo *shaderCreateInfo)
+    const SDL_GPUShaderCreateInfo *createinfo)
 {
     VulkanShader *vulkanShader;
     VkResult vulkanResult;
@@ -6884,8 +6884,8 @@ static SDL_GPUShader *VULKAN_CreateShader(
     vkShaderModuleCreateInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
     vkShaderModuleCreateInfo.pNext = NULL;
     vkShaderModuleCreateInfo.flags = 0;
-    vkShaderModuleCreateInfo.codeSize = shaderCreateInfo->codeSize;
-    vkShaderModuleCreateInfo.pCode = (Uint32 *)shaderCreateInfo->code;
+    vkShaderModuleCreateInfo.codeSize = createinfo->code_size;
+    vkShaderModuleCreateInfo.pCode = (Uint32 *)createinfo->code;
 
     vulkanResult = renderer->vkCreateShaderModule(
         renderer->logicalDevice,
@@ -6900,14 +6900,14 @@ static SDL_GPUShader *VULKAN_CreateShader(
         return NULL;
     }
 
-    entryPointNameLength = SDL_strlen(shaderCreateInfo->entryPointName) + 1;
-    vulkanShader->entryPointName = SDL_malloc(entryPointNameLength);
-    SDL_utf8strlcpy((char *)vulkanShader->entryPointName, shaderCreateInfo->entryPointName, entryPointNameLength);
+    entryPointNameLength = SDL_strlen(createinfo->entrypoint_name) + 1;
+    vulkanShader->entrypoint_name = SDL_malloc(entryPointNameLength);
+    SDL_utf8strlcpy((char *)vulkanShader->entrypoint_name, createinfo->entrypoint_name, entryPointNameLength);
 
-    vulkanShader->samplerCount = shaderCreateInfo->samplerCount;
-    vulkanShader->storageTextureCount = shaderCreateInfo->storageTextureCount;
-    vulkanShader->storageBufferCount = shaderCreateInfo->storageBufferCount;
-    vulkanShader->uniformBufferCount = shaderCreateInfo->uniformBufferCount;
+    vulkanShader->num_samplers = createinfo->num_samplers;
+    vulkanShader->num_storage_textures = createinfo->num_storage_textures;
+    vulkanShader->num_storage_buffers = createinfo->num_storage_buffers;
+    vulkanShader->num_uniform_buffers = createinfo->num_uniform_buffers;
 
     SDL_AtomicSet(&vulkanShader->referenceCount, 0);
 
@@ -6917,33 +6917,33 @@ static SDL_GPUShader *VULKAN_CreateShader(
 static bool VULKAN_SupportsSampleCount(
     SDL_GPURenderer *driverData,
     SDL_GPUTextureFormat format,
-    SDL_GPUSampleCount sampleCount)
+    SDL_GPUSampleCount sample_count)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
     VkSampleCountFlags bits = IsDepthFormat(format) ? renderer->physicalDeviceProperties.properties.limits.framebufferDepthSampleCounts : renderer->physicalDeviceProperties.properties.limits.framebufferColorSampleCounts;
-    VkSampleCountFlagBits vkSampleCount = SDLToVK_SampleCount[sampleCount];
+    VkSampleCountFlagBits vkSampleCount = SDLToVK_SampleCount[sample_count];
     return !!(bits & vkSampleCount);
 }
 
 static SDL_GPUTexture *VULKAN_CreateTexture(
     SDL_GPURenderer *driverData,
-    const SDL_GPUTextureCreateInfo *textureCreateInfo)
+    const SDL_GPUTextureCreateInfo *createinfo)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
     VkImageAspectFlags imageAspectFlags;
-    Uint8 isDepthFormat = IsDepthFormat(textureCreateInfo->format);
+    Uint8 isDepthFormat = IsDepthFormat(createinfo->format);
     VkFormat format;
     VkComponentMapping swizzle;
     VulkanTextureContainer *container;
     VulkanTextureHandle *textureHandle;
 
-    format = SDLToVK_SurfaceFormat[textureCreateInfo->format];
-    swizzle = SDLToVK_SurfaceSwizzle[textureCreateInfo->format];
+    format = SDLToVK_SurfaceFormat[createinfo->format];
+    swizzle = SDLToVK_SurfaceSwizzle[createinfo->format];
 
     if (isDepthFormat) {
         imageAspectFlags = VK_IMAGE_ASPECT_DEPTH_BIT;
 
-        if (IsStencilFormat(textureCreateInfo->format)) {
+        if (IsStencilFormat(createinfo->format)) {
             imageAspectFlags |= VK_IMAGE_ASPECT_STENCIL_BIT;
         }
     } else {
@@ -6952,17 +6952,17 @@ static SDL_GPUTexture *VULKAN_CreateTexture(
 
     textureHandle = VULKAN_INTERNAL_CreateTextureHandle(
         renderer,
-        textureCreateInfo->width,
-        textureCreateInfo->height,
-        textureCreateInfo->type == SDL_GPU_TEXTURETYPE_3D ? textureCreateInfo->layerCountOrDepth : 1,
-        textureCreateInfo->type,
-        textureCreateInfo->type == SDL_GPU_TEXTURETYPE_3D ? 1 : textureCreateInfo->layerCountOrDepth,
-        textureCreateInfo->levelCount,
-        SDLToVK_SampleCount[textureCreateInfo->sampleCount],
+        createinfo->width,
+        createinfo->height,
+        createinfo->type == SDL_GPU_TEXTURETYPE_3D ? createinfo->layer_count_or_depth : 1,
+        createinfo->type,
+        createinfo->type == SDL_GPU_TEXTURETYPE_3D ? 1 : createinfo->layer_count_or_depth,
+        createinfo->num_levels,
+        SDLToVK_SampleCount[createinfo->sample_count],
         format,
         swizzle,
         imageAspectFlags,
-        textureCreateInfo->usageFlags,
+        createinfo->usage_flags,
         false);
 
     if (textureHandle == NULL) {
@@ -6971,7 +6971,7 @@ static SDL_GPUTexture *VULKAN_CreateTexture(
     }
 
     container = SDL_malloc(sizeof(VulkanTextureContainer));
-    container->header.info = *textureCreateInfo;
+    container->header.info = *createinfo;
     container->canBeCycled = 1;
     container->activeTextureHandle = textureHandle;
     container->textureCapacity = 1;
@@ -6988,25 +6988,25 @@ static SDL_GPUTexture *VULKAN_CreateTexture(
 
 static SDL_GPUBuffer *VULKAN_CreateBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUBufferUsageFlags usageFlags,
-    Uint32 sizeInBytes)
+    SDL_GPUBufferUsageFlags usage_flags,
+    Uint32 size)
 {
     return (SDL_GPUBuffer *)VULKAN_INTERNAL_CreateBufferContainer(
         (VulkanRenderer *)driverData,
-        (VkDeviceSize)sizeInBytes,
-        usageFlags,
+        (VkDeviceSize)size,
+        usage_flags,
         VULKAN_BUFFER_TYPE_GPU);
 }
 
 static VulkanUniformBuffer *VULKAN_INTERNAL_CreateUniformBuffer(
     VulkanRenderer *renderer,
-    Uint32 sizeInBytes)
+    Uint32 size)
 {
     VulkanUniformBuffer *uniformBuffer = SDL_malloc(sizeof(VulkanUniformBuffer));
 
     uniformBuffer->bufferHandle = VULKAN_INTERNAL_CreateBufferHandle(
         renderer,
-        (VkDeviceSize)sizeInBytes,
+        (VkDeviceSize)size,
         0,
         VULKAN_BUFFER_TYPE_UNIFORM);
 
@@ -7019,11 +7019,11 @@ static VulkanUniformBuffer *VULKAN_INTERNAL_CreateUniformBuffer(
 static SDL_GPUTransferBuffer *VULKAN_CreateTransferBuffer(
     SDL_GPURenderer *driverData,
     SDL_GPUTransferBufferUsage usage, // ignored on Vulkan
-    Uint32 sizeInBytes)
+    Uint32 size)
 {
     return (SDL_GPUTransferBuffer *)VULKAN_INTERNAL_CreateBufferContainer(
         (VulkanRenderer *)driverData,
-        (VkDeviceSize)sizeInBytes,
+        (VkDeviceSize)size,
         0,
         VULKAN_BUFFER_TYPE_TRANSFER);
 }
@@ -7162,10 +7162,10 @@ static void VULKAN_ReleaseBuffer(
 
 static void VULKAN_ReleaseTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transferBuffer)
+    SDL_GPUTransferBuffer *transfer_buffer)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)transferBuffer;
+    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)transfer_buffer;
 
     VULKAN_INTERNAL_ReleaseBufferContainer(
         renderer,
@@ -7196,10 +7196,10 @@ static void VULKAN_ReleaseShader(
 
 static void VULKAN_ReleaseComputePipeline(
     SDL_GPURenderer *driverData,
-    SDL_GPUComputePipeline *computePipeline)
+    SDL_GPUComputePipeline *compute_pipeline)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    VulkanComputePipeline *vulkanComputePipeline = (VulkanComputePipeline *)computePipeline;
+    VulkanComputePipeline *vulkanComputePipeline = (VulkanComputePipeline *)compute_pipeline;
 
     SDL_LockMutex(renderer->disposeLock);
 
@@ -7218,10 +7218,10 @@ static void VULKAN_ReleaseComputePipeline(
 
 static void VULKAN_ReleaseGraphicsPipeline(
     SDL_GPURenderer *driverData,
-    SDL_GPUGraphicsPipeline *graphicsPipeline)
+    SDL_GPUGraphicsPipeline *graphics_pipeline)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    VulkanGraphicsPipeline *vulkanGraphicsPipeline = (VulkanGraphicsPipeline *)graphicsPipeline;
+    VulkanGraphicsPipeline *vulkanGraphicsPipeline = (VulkanGraphicsPipeline *)graphics_pipeline;
 
     SDL_LockMutex(renderer->disposeLock);
 
@@ -7242,41 +7242,41 @@ static void VULKAN_ReleaseGraphicsPipeline(
 
 static VkRenderPass VULKAN_INTERNAL_FetchRenderPass(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *commandBuffer,
-    const SDL_GPUColorAttachmentInfo *colorAttachmentInfos,
-    Uint32 colorAttachmentCount,
-    const SDL_GPUDepthStencilAttachmentInfo *depthStencilAttachmentInfo)
+    VulkanCommandBuffer *command_buffer,
+    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
+    Uint32 num_color_attachments,
+    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info)
 {
     VulkanRenderPassHashTableValue *renderPassWrapper = NULL;
     VkRenderPass renderPassHandle;
     RenderPassHashTableKey key;
     Uint32 i;
 
-    for (i = 0; i < colorAttachmentCount; i += 1) {
-        key.colorTargetDescriptions[i].format = ((VulkanTextureContainer *)colorAttachmentInfos[i].texture)->activeTextureHandle->vulkanTexture->format;
-        key.colorTargetDescriptions[i].loadOp = colorAttachmentInfos[i].loadOp;
-        key.colorTargetDescriptions[i].storeOp = colorAttachmentInfos[i].storeOp;
+    for (i = 0; i < num_color_attachments; i += 1) {
+        key.colorTargetDescriptions[i].format = ((VulkanTextureContainer *)color_attachment_infos[i].texture)->activeTextureHandle->vulkanTexture->format;
+        key.colorTargetDescriptions[i].load_op = color_attachment_infos[i].load_op;
+        key.colorTargetDescriptions[i].store_op = color_attachment_infos[i].store_op;
     }
 
     key.colorAttachmentSampleCount = VK_SAMPLE_COUNT_1_BIT;
-    if (colorAttachmentCount > 0) {
-        key.colorAttachmentSampleCount = ((VulkanTextureContainer *)colorAttachmentInfos[0].texture)->activeTextureHandle->vulkanTexture->sampleCount;
+    if (num_color_attachments > 0) {
+        key.colorAttachmentSampleCount = ((VulkanTextureContainer *)color_attachment_infos[0].texture)->activeTextureHandle->vulkanTexture->sample_count;
     }
 
-    key.colorAttachmentCount = colorAttachmentCount;
+    key.num_color_attachments = num_color_attachments;
 
-    if (depthStencilAttachmentInfo == NULL) {
+    if (depth_stencil_attachment_info == NULL) {
         key.depthStencilTargetDescription.format = 0;
-        key.depthStencilTargetDescription.loadOp = SDL_GPU_LOADOP_DONT_CARE;
-        key.depthStencilTargetDescription.storeOp = SDL_GPU_STOREOP_DONT_CARE;
-        key.depthStencilTargetDescription.stencilLoadOp = SDL_GPU_LOADOP_DONT_CARE;
-        key.depthStencilTargetDescription.stencilStoreOp = SDL_GPU_STOREOP_DONT_CARE;
+        key.depthStencilTargetDescription.load_op = SDL_GPU_LOADOP_DONT_CARE;
+        key.depthStencilTargetDescription.store_op = SDL_GPU_STOREOP_DONT_CARE;
+        key.depthStencilTargetDescription.stencil_load_op = SDL_GPU_LOADOP_DONT_CARE;
+        key.depthStencilTargetDescription.stencil_store_op = SDL_GPU_STOREOP_DONT_CARE;
     } else {
-        key.depthStencilTargetDescription.format = ((VulkanTextureContainer *)depthStencilAttachmentInfo->texture)->activeTextureHandle->vulkanTexture->format;
-        key.depthStencilTargetDescription.loadOp = depthStencilAttachmentInfo->loadOp;
-        key.depthStencilTargetDescription.storeOp = depthStencilAttachmentInfo->storeOp;
-        key.depthStencilTargetDescription.stencilLoadOp = depthStencilAttachmentInfo->stencilLoadOp;
-        key.depthStencilTargetDescription.stencilStoreOp = depthStencilAttachmentInfo->stencilStoreOp;
+        key.depthStencilTargetDescription.format = ((VulkanTextureContainer *)depth_stencil_attachment_info->texture)->activeTextureHandle->vulkanTexture->format;
+        key.depthStencilTargetDescription.load_op = depth_stencil_attachment_info->load_op;
+        key.depthStencilTargetDescription.store_op = depth_stencil_attachment_info->store_op;
+        key.depthStencilTargetDescription.stencil_load_op = depth_stencil_attachment_info->stencil_load_op;
+        key.depthStencilTargetDescription.stencil_store_op = depth_stencil_attachment_info->stencil_store_op;
     }
 
     SDL_LockMutex(renderer->renderPassFetchLock);
@@ -7294,10 +7294,10 @@ static VkRenderPass VULKAN_INTERNAL_FetchRenderPass(
 
     renderPassHandle = VULKAN_INTERNAL_CreateRenderPass(
         renderer,
-        commandBuffer,
-        colorAttachmentInfos,
-        colorAttachmentCount,
-        depthStencilAttachmentInfo);
+        command_buffer,
+        color_attachment_infos,
+        num_color_attachments,
+        depth_stencil_attachment_info);
 
     if (renderPassHandle == VK_NULL_HANDLE) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create VkRenderPass!");
@@ -7324,10 +7324,10 @@ static VkRenderPass VULKAN_INTERNAL_FetchRenderPass(
 
 static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
     VulkanRenderer *renderer,
-    VkRenderPass renderPass,
-    const SDL_GPUColorAttachmentInfo *colorAttachmentInfos,
-    Uint32 colorAttachmentCount,
-    const SDL_GPUDepthStencilAttachmentInfo *depthStencilAttachmentInfo,
+    VkRenderPass render_pass,
+    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
+    Uint32 num_color_attachments,
+    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info,
     Uint32 width,
     Uint32 height)
 {
@@ -7344,17 +7344,17 @@ static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
         key.colorMultiSampleAttachmentViews[i] = VK_NULL_HANDLE;
     }
 
-    key.colorAttachmentCount = colorAttachmentCount;
+    key.num_color_attachments = num_color_attachments;
 
-    for (i = 0; i < colorAttachmentCount; i += 1) {
-        VulkanTextureContainer *container = (VulkanTextureContainer *)colorAttachmentInfos[i].texture;
+    for (i = 0; i < num_color_attachments; i += 1) {
+        VulkanTextureContainer *container = (VulkanTextureContainer *)color_attachment_infos[i].texture;
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_FetchTextureSubresource(
             container,
-            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorAttachmentInfos[i].layerOrDepthPlane,
-            colorAttachmentInfos[i].mipLevel);
+            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : color_attachment_infos[i].layer_or_depth_plane,
+            color_attachment_infos[i].mip_level);
 
         Uint32 rtvIndex =
-            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? colorAttachmentInfos[i].layerOrDepthPlane : 0;
+            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? color_attachment_infos[i].layer_or_depth_plane : 0;
         key.colorAttachmentViews[i] = subresource->renderTargetViews[rtvIndex];
 
         if (subresource->msaaTexHandle != NULL) {
@@ -7362,11 +7362,11 @@ static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
         }
     }
 
-    if (depthStencilAttachmentInfo == NULL) {
+    if (depth_stencil_attachment_info == NULL) {
         key.depthStencilAttachmentView = VK_NULL_HANDLE;
     } else {
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_FetchTextureSubresource(
-            (VulkanTextureContainer *)depthStencilAttachmentInfo->texture,
+            (VulkanTextureContainer *)depth_stencil_attachment_info->texture,
             0,
             0);
         key.depthStencilAttachmentView = subresource->depthStencilView;
@@ -7394,15 +7394,15 @@ static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
 
     // Create a new framebuffer
 
-    for (i = 0; i < colorAttachmentCount; i += 1) {
-        VulkanTextureContainer *container = (VulkanTextureContainer *)colorAttachmentInfos[i].texture;
+    for (i = 0; i < num_color_attachments; i += 1) {
+        VulkanTextureContainer *container = (VulkanTextureContainer *)color_attachment_infos[i].texture;
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_FetchTextureSubresource(
             container,
-            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorAttachmentInfos[i].layerOrDepthPlane,
-            colorAttachmentInfos[i].mipLevel);
+            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : color_attachment_infos[i].layer_or_depth_plane,
+            color_attachment_infos[i].mip_level);
 
         Uint32 rtvIndex =
-            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? colorAttachmentInfos[i].layerOrDepthPlane : 0;
+            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? color_attachment_infos[i].layer_or_depth_plane : 0;
 
         imageViewAttachments[attachmentCount] =
             subresource->renderTargetViews[rtvIndex];
@@ -7417,9 +7417,9 @@ static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
         }
     }
 
-    if (depthStencilAttachmentInfo != NULL) {
+    if (depth_stencil_attachment_info != NULL) {
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_FetchTextureSubresource(
-            (VulkanTextureContainer *)depthStencilAttachmentInfo->texture,
+            (VulkanTextureContainer *)depth_stencil_attachment_info->texture,
             0,
             0);
         imageViewAttachments[attachmentCount] = subresource->depthStencilView;
@@ -7430,7 +7430,7 @@ static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
     framebufferInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
     framebufferInfo.pNext = NULL;
     framebufferInfo.flags = 0;
-    framebufferInfo.renderPass = renderPass;
+    framebufferInfo.renderPass = render_pass;
     framebufferInfo.attachmentCount = attachmentCount;
     framebufferInfo.pAttachments = imageViewAttachments;
     framebufferInfo.width = key.width;
@@ -7466,10 +7466,10 @@ static VulkanFramebuffer *VULKAN_INTERNAL_FetchFramebuffer(
 }
 
 static void VULKAN_INTERNAL_SetCurrentViewport(
-    VulkanCommandBuffer *commandBuffer,
+    VulkanCommandBuffer *command_buffer,
     const SDL_GPUViewport *viewport)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
 
     vulkanCommandBuffer->currentViewport.x = viewport->x;
     vulkanCommandBuffer->currentViewport.width = viewport->w;
@@ -7483,10 +7483,10 @@ static void VULKAN_INTERNAL_SetCurrentViewport(
 }
 
 static void VULKAN_SetViewport(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUViewport *viewport)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_SetCurrentViewport(
@@ -7494,7 +7494,7 @@ static void VULKAN_SetViewport(
         viewport);
 
     renderer->vkCmdSetViewport(
-        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->command_buffer,
         0,
         1,
         &vulkanCommandBuffer->currentViewport);
@@ -7511,10 +7511,10 @@ static void VULKAN_INTERNAL_SetCurrentScissor(
 }
 
 static void VULKAN_SetScissor(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_Rect *scissor)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_SetCurrentScissor(
@@ -7522,7 +7522,7 @@ static void VULKAN_SetScissor(
         scissor);
 
     renderer->vkCmdSetScissor(
-        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->command_buffer,
         0,
         1,
         &vulkanCommandBuffer->currentScissor);
@@ -7530,28 +7530,28 @@ static void VULKAN_SetScissor(
 
 static void VULKAN_INTERNAL_SetCurrentBlendConstants(
     VulkanCommandBuffer *vulkanCommandBuffer,
-    SDL_FColor blendConstants)
+    SDL_FColor blend_constants)
 {
-    vulkanCommandBuffer->blendConstants[0] = blendConstants.r;
-    vulkanCommandBuffer->blendConstants[1] = blendConstants.g;
-    vulkanCommandBuffer->blendConstants[2] = blendConstants.b;
-    vulkanCommandBuffer->blendConstants[3] = blendConstants.a;
+    vulkanCommandBuffer->blend_constants[0] = blend_constants.r;
+    vulkanCommandBuffer->blend_constants[1] = blend_constants.g;
+    vulkanCommandBuffer->blend_constants[2] = blend_constants.b;
+    vulkanCommandBuffer->blend_constants[3] = blend_constants.a;
 }
 
 static void VULKAN_SetBlendConstants(
-    SDL_GPUCommandBuffer *commandBuffer,
-    SDL_FColor blendConstants)
+    SDL_GPUCommandBuffer *command_buffer,
+    SDL_FColor blend_constants)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_SetCurrentBlendConstants(
         vulkanCommandBuffer,
-        blendConstants);
+        blend_constants);
 
     renderer->vkCmdSetBlendConstants(
-        vulkanCommandBuffer->commandBuffer,
-        vulkanCommandBuffer->blendConstants);
+        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->blend_constants);
 }
 
 static void VULKAN_INTERNAL_SetCurrentStencilReference(
@@ -7562,10 +7562,10 @@ static void VULKAN_INTERNAL_SetCurrentStencilReference(
 }
 
 static void VULKAN_SetStencilReference(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     Uint8 reference)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_SetCurrentStencilReference(
@@ -7573,27 +7573,27 @@ static void VULKAN_SetStencilReference(
         reference);
 
     renderer->vkCmdSetStencilReference(
-        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->command_buffer,
         VK_STENCIL_FACE_FRONT_AND_BACK,
         reference);
 }
 
 static void VULKAN_BindVertexSamplers(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
+    Uint32 num_bindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)textureSamplerBindings[i].texture;
-        vulkanCommandBuffer->vertexSamplerTextures[firstSlot + i] = textureContainer->activeTextureHandle->vulkanTexture;
-        vulkanCommandBuffer->vertexSamplers[firstSlot + i] = (VulkanSampler *)textureSamplerBindings[i].sampler;
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)texture_sampler_bindings[i].texture;
+        vulkanCommandBuffer->vertexSamplerTextures[first_slot + i] = textureContainer->activeTextureHandle->vulkanTexture;
+        vulkanCommandBuffer->vertexSamplers[first_slot + i] = (VulkanSampler *)texture_sampler_bindings[i].sampler;
 
         VULKAN_INTERNAL_TrackSampler(
             vulkanCommandBuffer,
-            (VulkanSampler *)textureSamplerBindings[i].sampler);
+            (VulkanSampler *)texture_sampler_bindings[i].sampler);
 
         VULKAN_INTERNAL_TrackTexture(
             vulkanCommandBuffer,
@@ -7604,17 +7604,17 @@ static void VULKAN_BindVertexSamplers(
 }
 
 static void VULKAN_BindVertexStorageTextures(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    SDL_GPUTexture *const *storageTextures,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    SDL_GPUTexture *const *storage_textures,
+    Uint32 num_bindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storageTextures[i];
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storage_textures[i];
 
-        vulkanCommandBuffer->vertexStorageTextures[firstSlot + i] = textureContainer->activeTextureHandle->vulkanTexture;
+        vulkanCommandBuffer->vertexStorageTextures[first_slot + i] = textureContainer->activeTextureHandle->vulkanTexture;
 
         VULKAN_INTERNAL_TrackTexture(
             vulkanCommandBuffer,
@@ -7625,19 +7625,19 @@ static void VULKAN_BindVertexStorageTextures(
 }
 
 static void VULKAN_BindVertexStorageBuffers(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    SDL_GPUBuffer *const *storageBuffers,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    SDL_GPUBuffer *const *storage_buffers,
+    Uint32 num_bindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanBufferContainer *bufferContainer;
     Uint32 i;
 
-    for (i = 0; i < bindingCount; i += 1) {
-        bufferContainer = (VulkanBufferContainer *)storageBuffers[i];
+    for (i = 0; i < num_bindings; i += 1) {
+        bufferContainer = (VulkanBufferContainer *)storage_buffers[i];
 
-        vulkanCommandBuffer->vertexStorageBuffers[firstSlot + i] = bufferContainer->activeBufferHandle->vulkanBuffer;
+        vulkanCommandBuffer->vertexStorageBuffers[first_slot + i] = bufferContainer->activeBufferHandle->vulkanBuffer;
 
         VULKAN_INTERNAL_TrackBuffer(
             vulkanCommandBuffer,
@@ -7648,21 +7648,21 @@ static void VULKAN_BindVertexStorageBuffers(
 }
 
 static void VULKAN_BindFragmentSamplers(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    const SDL_GPUTextureSamplerBinding *textureSamplerBindings,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
+    Uint32 num_bindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)textureSamplerBindings[i].texture;
-        vulkanCommandBuffer->fragmentSamplerTextures[firstSlot + i] = textureContainer->activeTextureHandle->vulkanTexture;
-        vulkanCommandBuffer->fragmentSamplers[firstSlot + i] = (VulkanSampler *)textureSamplerBindings[i].sampler;
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)texture_sampler_bindings[i].texture;
+        vulkanCommandBuffer->fragmentSamplerTextures[first_slot + i] = textureContainer->activeTextureHandle->vulkanTexture;
+        vulkanCommandBuffer->fragmentSamplers[first_slot + i] = (VulkanSampler *)texture_sampler_bindings[i].sampler;
 
         VULKAN_INTERNAL_TrackSampler(
             vulkanCommandBuffer,
-            (VulkanSampler *)textureSamplerBindings[i].sampler);
+            (VulkanSampler *)texture_sampler_bindings[i].sampler);
 
         VULKAN_INTERNAL_TrackTexture(
             vulkanCommandBuffer,
@@ -7673,17 +7673,17 @@ static void VULKAN_BindFragmentSamplers(
 }
 
 static void VULKAN_BindFragmentStorageTextures(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    SDL_GPUTexture *const *storageTextures,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    SDL_GPUTexture *const *storage_textures,
+    Uint32 num_bindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storageTextures[i];
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storage_textures[i];
 
-        vulkanCommandBuffer->fragmentStorageTextures[firstSlot + i] =
+        vulkanCommandBuffer->fragmentStorageTextures[first_slot + i] =
             textureContainer->activeTextureHandle->vulkanTexture;
 
         VULKAN_INTERNAL_TrackTexture(
@@ -7695,19 +7695,19 @@ static void VULKAN_BindFragmentStorageTextures(
 }
 
 static void VULKAN_BindFragmentStorageBuffers(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    SDL_GPUBuffer *const *storageBuffers,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    SDL_GPUBuffer *const *storage_buffers,
+    Uint32 num_bindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanBufferContainer *bufferContainer;
     Uint32 i;
 
-    for (i = 0; i < bindingCount; i += 1) {
-        bufferContainer = (VulkanBufferContainer *)storageBuffers[i];
+    for (i = 0; i < num_bindings; i += 1) {
+        bufferContainer = (VulkanBufferContainer *)storage_buffers[i];
 
-        vulkanCommandBuffer->fragmentStorageBuffers[firstSlot + i] = bufferContainer->activeBufferHandle->vulkanBuffer;
+        vulkanCommandBuffer->fragmentStorageBuffers[first_slot + i] = bufferContainer->activeBufferHandle->vulkanBuffer;
 
         VULKAN_INTERNAL_TrackBuffer(
             vulkanCommandBuffer,
@@ -7718,9 +7718,9 @@ static void VULKAN_BindFragmentStorageBuffers(
 }
 
 static VulkanUniformBuffer *VULKAN_INTERNAL_AcquireUniformBufferFromPool(
-    VulkanCommandBuffer *commandBuffer)
+    VulkanCommandBuffer *command_buffer)
 {
-    VulkanRenderer *renderer = commandBuffer->renderer;
+    VulkanRenderer *renderer = command_buffer->renderer;
     VulkanUniformBuffer *uniformBuffer;
 
     SDL_LockMutex(renderer->acquireUniformBufferLock);
@@ -7736,7 +7736,7 @@ static VulkanUniformBuffer *VULKAN_INTERNAL_AcquireUniformBufferFromPool(
 
     SDL_UnlockMutex(renderer->acquireUniformBufferLock);
 
-    VULKAN_INTERNAL_TrackUniformBuffer(commandBuffer, uniformBuffer);
+    VULKAN_INTERNAL_TrackUniformBuffer(command_buffer, uniformBuffer);
 
     return uniformBuffer;
 }
@@ -7760,37 +7760,37 @@ static void VULKAN_INTERNAL_ReturnUniformBufferToPool(
 }
 
 static void VULKAN_INTERNAL_PushUniformData(
-    VulkanCommandBuffer *commandBuffer,
+    VulkanCommandBuffer *command_buffer,
     VulkanUniformBufferStage uniformBufferStage,
-    Uint32 slotIndex,
+    Uint32 slot_index,
     const void *data,
-    Uint32 dataLengthInBytes)
+    Uint32 length)
 {
     Uint32 blockSize =
         VULKAN_INTERNAL_NextHighestAlignment32(
-            dataLengthInBytes,
-            commandBuffer->renderer->minUBOAlignment);
+            length,
+            command_buffer->renderer->minUBOAlignment);
 
     VulkanUniformBuffer *uniformBuffer;
 
     if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_VERTEX) {
-        if (commandBuffer->vertexUniformBuffers[slotIndex] == NULL) {
-            commandBuffer->vertexUniformBuffers[slotIndex] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
-                commandBuffer);
+        if (command_buffer->vertexUniformBuffers[slot_index] == NULL) {
+            command_buffer->vertexUniformBuffers[slot_index] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
+                command_buffer);
         }
-        uniformBuffer = commandBuffer->vertexUniformBuffers[slotIndex];
+        uniformBuffer = command_buffer->vertexUniformBuffers[slot_index];
     } else if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_FRAGMENT) {
-        if (commandBuffer->fragmentUniformBuffers[slotIndex] == NULL) {
-            commandBuffer->fragmentUniformBuffers[slotIndex] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
-                commandBuffer);
+        if (command_buffer->fragmentUniformBuffers[slot_index] == NULL) {
+            command_buffer->fragmentUniformBuffers[slot_index] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
+                command_buffer);
         }
-        uniformBuffer = commandBuffer->fragmentUniformBuffers[slotIndex];
+        uniformBuffer = command_buffer->fragmentUniformBuffers[slot_index];
     } else if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_COMPUTE) {
-        if (commandBuffer->computeUniformBuffers[slotIndex] == NULL) {
-            commandBuffer->computeUniformBuffers[slotIndex] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
-                commandBuffer);
+        if (command_buffer->computeUniformBuffers[slot_index] == NULL) {
+            command_buffer->computeUniformBuffers[slot_index] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
+                command_buffer);
         }
-        uniformBuffer = commandBuffer->computeUniformBuffers[slotIndex];
+        uniformBuffer = command_buffer->computeUniformBuffers[slot_index];
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
         return;
@@ -7798,20 +7798,20 @@ static void VULKAN_INTERNAL_PushUniformData(
 
     // If there is no more room, acquire a new uniform buffer
     if (uniformBuffer->writeOffset + blockSize + MAX_UBO_SECTION_SIZE >= uniformBuffer->bufferHandle->vulkanBuffer->size) {
-        uniformBuffer = VULKAN_INTERNAL_AcquireUniformBufferFromPool(commandBuffer);
+        uniformBuffer = VULKAN_INTERNAL_AcquireUniformBufferFromPool(command_buffer);
 
         uniformBuffer->drawOffset = 0;
         uniformBuffer->writeOffset = 0;
 
         if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_VERTEX) {
-            commandBuffer->vertexUniformBuffers[slotIndex] = uniformBuffer;
-            commandBuffer->needNewVertexUniformDescriptorSet = true;
+            command_buffer->vertexUniformBuffers[slot_index] = uniformBuffer;
+            command_buffer->needNewVertexUniformDescriptorSet = true;
         } else if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_FRAGMENT) {
-            commandBuffer->fragmentUniformBuffers[slotIndex] = uniformBuffer;
-            commandBuffer->needNewFragmentUniformDescriptorSet = true;
+            command_buffer->fragmentUniformBuffers[slot_index] = uniformBuffer;
+            command_buffer->needNewFragmentUniformDescriptorSet = true;
         } else if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_COMPUTE) {
-            commandBuffer->computeUniformBuffers[slotIndex] = uniformBuffer;
-            commandBuffer->needNewComputeUniformDescriptorSet = true;
+            command_buffer->computeUniformBuffers[slot_index] = uniformBuffer;
+            command_buffer->needNewComputeUniformDescriptorSet = true;
         } else {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
             return;
@@ -7828,16 +7828,16 @@ static void VULKAN_INTERNAL_PushUniformData(
     SDL_memcpy(
         dst,
         data,
-        dataLengthInBytes);
+        length);
 
     uniformBuffer->writeOffset += blockSize;
 
     if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_VERTEX) {
-        commandBuffer->needNewVertexUniformOffsets = true;
+        command_buffer->needNewVertexUniformOffsets = true;
     } else if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_FRAGMENT) {
-        commandBuffer->needNewFragmentUniformOffsets = true;
+        command_buffer->needNewFragmentUniformOffsets = true;
     } else if (uniformBufferStage == VULKAN_UNIFORM_BUFFER_STAGE_COMPUTE) {
-        commandBuffer->needNewComputeUniformOffsets = true;
+        command_buffer->needNewComputeUniformOffsets = true;
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Unrecognized shader stage!");
         return;
@@ -7845,19 +7845,19 @@ static void VULKAN_INTERNAL_PushUniformData(
 }
 
 static void VULKAN_BeginRenderPass(
-    SDL_GPUCommandBuffer *commandBuffer,
-    const SDL_GPUColorAttachmentInfo *colorAttachmentInfos,
-    Uint32 colorAttachmentCount,
-    const SDL_GPUDepthStencilAttachmentInfo *depthStencilAttachmentInfo)
+    SDL_GPUCommandBuffer *command_buffer,
+    const SDL_GPUColorAttachmentInfo *color_attachment_infos,
+    Uint32 num_color_attachments,
+    const SDL_GPUDepthStencilAttachmentInfo *depth_stencil_attachment_info)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
-    VkRenderPass renderPass;
+    VkRenderPass render_pass;
     VulkanFramebuffer *framebuffer;
 
     Uint32 w, h;
     VkClearValue *clearValues;
-    Uint32 clearCount = colorAttachmentCount;
+    Uint32 clearCount = num_color_attachments;
     Uint32 multisampleAttachmentCount = 0;
     Uint32 totalColorAttachmentCount = 0;
     Uint32 i;
@@ -7866,11 +7866,11 @@ static void VULKAN_BeginRenderPass(
     Uint32 framebufferWidth = UINT32_MAX;
     Uint32 framebufferHeight = UINT32_MAX;
 
-    for (i = 0; i < colorAttachmentCount; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)colorAttachmentInfos[i].texture;
+    for (i = 0; i < num_color_attachments; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)color_attachment_infos[i].texture;
 
-        w = textureContainer->activeTextureHandle->vulkanTexture->dimensions.width >> colorAttachmentInfos[i].mipLevel;
-        h = textureContainer->activeTextureHandle->vulkanTexture->dimensions.height >> colorAttachmentInfos[i].mipLevel;
+        w = textureContainer->activeTextureHandle->vulkanTexture->dimensions.width >> color_attachment_infos[i].mip_level;
+        h = textureContainer->activeTextureHandle->vulkanTexture->dimensions.height >> color_attachment_infos[i].mip_level;
 
         // The framebuffer cannot be larger than the smallest attachment.
 
@@ -7883,14 +7883,14 @@ static void VULKAN_BeginRenderPass(
         }
 
         // FIXME: validate this in gpu.c
-        if (!(textureContainer->header.info.usageFlags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET)) {
+        if (!(textureContainer->header.info.usage_flags & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET)) {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Color attachment texture was not designated as a target!");
             return;
         }
     }
 
-    if (depthStencilAttachmentInfo != NULL) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)depthStencilAttachmentInfo->texture;
+    if (depth_stencil_attachment_info != NULL) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)depth_stencil_attachment_info->texture;
 
         w = textureContainer->activeTextureHandle->vulkanTexture->dimensions.width;
         h = textureContainer->activeTextureHandle->vulkanTexture->dimensions.height;
@@ -7906,21 +7906,21 @@ static void VULKAN_BeginRenderPass(
         }
 
         // FIXME: validate this in gpu.c
-        if (!(textureContainer->header.info.usageFlags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET)) {
+        if (!(textureContainer->header.info.usage_flags & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET)) {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Depth stencil attachment texture was not designated as a target!");
             return;
         }
     }
 
-    for (i = 0; i < colorAttachmentCount; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)colorAttachmentInfos[i].texture;
+    for (i = 0; i < num_color_attachments; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)color_attachment_infos[i].texture;
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_PrepareTextureSubresourceForWrite(
             renderer,
             vulkanCommandBuffer,
             textureContainer,
-            textureContainer->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorAttachmentInfos[i].layerOrDepthPlane,
-            colorAttachmentInfos[i].mipLevel,
-            colorAttachmentInfos[i].cycle,
+            textureContainer->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : color_attachment_infos[i].layer_or_depth_plane,
+            color_attachment_infos[i].mip_level,
+            color_attachment_infos[i].cycle,
             VULKAN_TEXTURE_USAGE_MODE_COLOR_ATTACHMENT);
 
         if (subresource->msaaTexHandle != NULL) {
@@ -7941,17 +7941,17 @@ static void VULKAN_BeginRenderPass(
         // TODO: do we need to track the msaa texture? or is it implicitly only used when the regular texture is used?
     }
 
-    vulkanCommandBuffer->colorAttachmentSubresourceCount = colorAttachmentCount;
+    vulkanCommandBuffer->colorAttachmentSubresourceCount = num_color_attachments;
 
-    if (depthStencilAttachmentInfo != NULL) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)depthStencilAttachmentInfo->texture;
+    if (depth_stencil_attachment_info != NULL) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)depth_stencil_attachment_info->texture;
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_PrepareTextureSubresourceForWrite(
             renderer,
             vulkanCommandBuffer,
             textureContainer,
             0,
             0,
-            depthStencilAttachmentInfo->cycle,
+            depth_stencil_attachment_info->cycle,
             VULKAN_TEXTURE_USAGE_MODE_DEPTH_STENCIL_ATTACHMENT);
 
         clearCount += 1;
@@ -7963,19 +7963,19 @@ static void VULKAN_BeginRenderPass(
 
     // Fetch required render objects
 
-    renderPass = VULKAN_INTERNAL_FetchRenderPass(
+    render_pass = VULKAN_INTERNAL_FetchRenderPass(
         renderer,
         vulkanCommandBuffer,
-        colorAttachmentInfos,
-        colorAttachmentCount,
-        depthStencilAttachmentInfo);
+        color_attachment_infos,
+        num_color_attachments,
+        depth_stencil_attachment_info);
 
     framebuffer = VULKAN_INTERNAL_FetchFramebuffer(
         renderer,
-        renderPass,
-        colorAttachmentInfos,
-        colorAttachmentCount,
-        depthStencilAttachmentInfo,
+        render_pass,
+        color_attachment_infos,
+        num_color_attachments,
+        depth_stencil_attachment_info,
         framebufferWidth,
         framebufferHeight);
 
@@ -7985,40 +7985,40 @@ static void VULKAN_BeginRenderPass(
 
     clearValues = SDL_stack_alloc(VkClearValue, clearCount);
 
-    totalColorAttachmentCount = colorAttachmentCount + multisampleAttachmentCount;
+    totalColorAttachmentCount = num_color_attachments + multisampleAttachmentCount;
 
     for (i = 0; i < totalColorAttachmentCount; i += 1) {
-        clearValues[i].color.float32[0] = colorAttachmentInfos[i].clearColor.r;
-        clearValues[i].color.float32[1] = colorAttachmentInfos[i].clearColor.g;
-        clearValues[i].color.float32[2] = colorAttachmentInfos[i].clearColor.b;
-        clearValues[i].color.float32[3] = colorAttachmentInfos[i].clearColor.a;
+        clearValues[i].color.float32[0] = color_attachment_infos[i].clear_color.r;
+        clearValues[i].color.float32[1] = color_attachment_infos[i].clear_color.g;
+        clearValues[i].color.float32[2] = color_attachment_infos[i].clear_color.b;
+        clearValues[i].color.float32[3] = color_attachment_infos[i].clear_color.a;
 
-        VulkanTextureContainer *container = (VulkanTextureContainer *)colorAttachmentInfos[i].texture;
+        VulkanTextureContainer *container = (VulkanTextureContainer *)color_attachment_infos[i].texture;
         VulkanTextureSubresource *subresource = VULKAN_INTERNAL_FetchTextureSubresource(
             container,
-            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : colorAttachmentInfos[i].layerOrDepthPlane,
-            colorAttachmentInfos[i].mipLevel);
+            container->header.info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : color_attachment_infos[i].layer_or_depth_plane,
+            color_attachment_infos[i].mip_level);
 
-        if (subresource->parent->sampleCount > VK_SAMPLE_COUNT_1_BIT) {
-            clearValues[i + 1].color.float32[0] = colorAttachmentInfos[i].clearColor.r;
-            clearValues[i + 1].color.float32[1] = colorAttachmentInfos[i].clearColor.g;
-            clearValues[i + 1].color.float32[2] = colorAttachmentInfos[i].clearColor.b;
-            clearValues[i + 1].color.float32[3] = colorAttachmentInfos[i].clearColor.a;
+        if (subresource->parent->sample_count > VK_SAMPLE_COUNT_1_BIT) {
+            clearValues[i + 1].color.float32[0] = color_attachment_infos[i].clear_color.r;
+            clearValues[i + 1].color.float32[1] = color_attachment_infos[i].clear_color.g;
+            clearValues[i + 1].color.float32[2] = color_attachment_infos[i].clear_color.b;
+            clearValues[i + 1].color.float32[3] = color_attachment_infos[i].clear_color.a;
             i += 1;
         }
     }
 
-    if (depthStencilAttachmentInfo != NULL) {
+    if (depth_stencil_attachment_info != NULL) {
         clearValues[totalColorAttachmentCount].depthStencil.depth =
-            depthStencilAttachmentInfo->depthStencilClearValue.depth;
+            depth_stencil_attachment_info->clear_value.depth;
         clearValues[totalColorAttachmentCount].depthStencil.stencil =
-            depthStencilAttachmentInfo->depthStencilClearValue.stencil;
+            depth_stencil_attachment_info->clear_value.stencil;
     }
 
     VkRenderPassBeginInfo renderPassBeginInfo;
     renderPassBeginInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
     renderPassBeginInfo.pNext = NULL;
-    renderPassBeginInfo.renderPass = renderPass;
+    renderPassBeginInfo.renderPass = render_pass;
     renderPassBeginInfo.framebuffer = framebuffer->framebuffer;
     renderPassBeginInfo.pClearValues = clearValues;
     renderPassBeginInfo.clearValueCount = clearCount;
@@ -8028,7 +8028,7 @@ static void VULKAN_BeginRenderPass(
     renderPassBeginInfo.renderArea.offset.y = 0;
 
     renderer->vkCmdBeginRenderPass(
-        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->command_buffer,
         &renderPassBeginInfo,
         VK_SUBPASS_CONTENTS_INLINE);
 
@@ -8066,15 +8066,15 @@ static void VULKAN_BeginRenderPass(
 }
 
 static void VULKAN_BindGraphicsPipeline(
-    SDL_GPUCommandBuffer *commandBuffer,
-    SDL_GPUGraphicsPipeline *graphicsPipeline)
+    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUGraphicsPipeline *graphics_pipeline)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
-    VulkanGraphicsPipeline *pipeline = (VulkanGraphicsPipeline *)graphicsPipeline;
+    VulkanGraphicsPipeline *pipeline = (VulkanGraphicsPipeline *)graphics_pipeline;
 
     renderer->vkCmdBindPipeline(
-        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->command_buffer,
         VK_PIPELINE_BIND_POINT_GRAPHICS,
         pipeline->pipeline);
 
@@ -8083,23 +8083,23 @@ static void VULKAN_BindGraphicsPipeline(
     VULKAN_INTERNAL_TrackGraphicsPipeline(vulkanCommandBuffer, pipeline);
 
     renderer->vkCmdSetViewport(
-        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->command_buffer,
         0,
         1,
         &vulkanCommandBuffer->currentViewport);
 
     renderer->vkCmdSetScissor(
-        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->command_buffer,
         0,
         1,
         &vulkanCommandBuffer->currentScissor);
 
     renderer->vkCmdSetBlendConstants(
-        vulkanCommandBuffer->commandBuffer,
-        vulkanCommandBuffer->blendConstants);
+        vulkanCommandBuffer->command_buffer,
+        vulkanCommandBuffer->blend_constants);
 
     renderer->vkCmdSetStencilReference(
-        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->command_buffer,
         VK_STENCIL_FACE_FRONT_AND_BACK,
         vulkanCommandBuffer->stencilRef);
 
@@ -8128,29 +8128,29 @@ static void VULKAN_BindGraphicsPipeline(
 }
 
 static void VULKAN_BindVertexBuffers(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstBinding,
-    const SDL_GPUBufferBinding *pBindings,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_binding,
+    const SDL_GPUBufferBinding *bindings,
+    Uint32 num_bindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBuffer *currentVulkanBuffer;
-    VkBuffer *buffers = SDL_stack_alloc(VkBuffer, bindingCount);
-    VkDeviceSize *offsets = SDL_stack_alloc(VkDeviceSize, bindingCount);
+    VkBuffer *buffers = SDL_stack_alloc(VkBuffer, num_bindings);
+    VkDeviceSize *offsets = SDL_stack_alloc(VkDeviceSize, num_bindings);
     Uint32 i;
 
-    for (i = 0; i < bindingCount; i += 1) {
-        currentVulkanBuffer = ((VulkanBufferContainer *)pBindings[i].buffer)->activeBufferHandle->vulkanBuffer;
+    for (i = 0; i < num_bindings; i += 1) {
+        currentVulkanBuffer = ((VulkanBufferContainer *)bindings[i].buffer)->activeBufferHandle->vulkanBuffer;
         buffers[i] = currentVulkanBuffer->buffer;
-        offsets[i] = (VkDeviceSize)pBindings[i].offset;
+        offsets[i] = (VkDeviceSize)bindings[i].offset;
         VULKAN_INTERNAL_TrackBuffer(vulkanCommandBuffer, currentVulkanBuffer);
     }
 
     renderer->vkCmdBindVertexBuffers(
-        vulkanCommandBuffer->commandBuffer,
-        firstBinding,
-        bindingCount,
+        vulkanCommandBuffer->command_buffer,
+        first_binding,
+        num_bindings,
         buffers,
         offsets);
 
@@ -8159,64 +8159,64 @@ static void VULKAN_BindVertexBuffers(
 }
 
 static void VULKAN_BindIndexBuffer(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUBufferBinding *pBinding,
-    SDL_GPUIndexElementSize indexElementSize)
+    SDL_GPUIndexElementSize index_element_size)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBuffer *vulkanBuffer = ((VulkanBufferContainer *)pBinding->buffer)->activeBufferHandle->vulkanBuffer;
 
     VULKAN_INTERNAL_TrackBuffer(vulkanCommandBuffer, vulkanBuffer);
 
     renderer->vkCmdBindIndexBuffer(
-        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->command_buffer,
         vulkanBuffer->buffer,
         (VkDeviceSize)pBinding->offset,
-        SDLToVK_IndexType[indexElementSize]);
+        SDLToVK_IndexType[index_element_size]);
 }
 
 static void VULKAN_PushVertexUniformData(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 slotIndex,
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 slot_index,
     const void *data,
-    Uint32 dataLengthInBytes)
+    Uint32 length)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
 
     VULKAN_INTERNAL_PushUniformData(
         vulkanCommandBuffer,
         VULKAN_UNIFORM_BUFFER_STAGE_VERTEX,
-        slotIndex,
+        slot_index,
         data,
-        dataLengthInBytes);
+        length);
 }
 
 static void VULKAN_PushFragmentUniformData(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 slotIndex,
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 slot_index,
     const void *data,
-    Uint32 dataLengthInBytes)
+    Uint32 length)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
 
     VULKAN_INTERNAL_PushUniformData(
         vulkanCommandBuffer,
         VULKAN_UNIFORM_BUFFER_STAGE_FRAGMENT,
-        slotIndex,
+        slot_index,
         data,
-        dataLengthInBytes);
+        length);
 }
 
 static void VULKAN_EndRenderPass(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     Uint32 i;
 
     renderer->vkCmdEndRenderPass(
-        vulkanCommandBuffer->commandBuffer);
+        vulkanCommandBuffer->command_buffer);
 
     for (i = 0; i < vulkanCommandBuffer->colorAttachmentSubresourceCount; i += 1) {
         VULKAN_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
@@ -8259,23 +8259,23 @@ static void VULKAN_EndRenderPass(
 }
 
 static void VULKAN_BeginComputePass(
-    SDL_GPUCommandBuffer *commandBuffer,
-    const SDL_GPUStorageTextureWriteOnlyBinding *storageTextureBindings,
-    Uint32 storageTextureBindingCount,
-    const SDL_GPUStorageBufferWriteOnlyBinding *storageBufferBindings,
-    Uint32 storageBufferBindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    const SDL_GPUStorageTextureWriteOnlyBinding *storage_texture_bindings,
+    Uint32 num_storage_texture_bindings,
+    const SDL_GPUStorageBufferWriteOnlyBinding *storage_buffer_bindings,
+    Uint32 num_storage_buffer_bindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanBufferContainer *bufferContainer;
     VulkanBuffer *buffer;
     Uint32 i;
 
-    vulkanCommandBuffer->writeOnlyComputeStorageTextureSubresourceCount = storageTextureBindingCount;
+    vulkanCommandBuffer->writeOnlyComputeStorageTextureSubresourceCount = num_storage_texture_bindings;
 
-    for (i = 0; i < storageTextureBindingCount; i += 1) {
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storageTextureBindings[i].texture;
-        if (!(textureContainer->activeTextureHandle->vulkanTexture->usageFlags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE)) {
+    for (i = 0; i < num_storage_texture_bindings; i += 1) {
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storage_texture_bindings[i].texture;
+        if (!(textureContainer->activeTextureHandle->vulkanTexture->usage_flags & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE)) {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Attempted to bind read-only texture as compute write texture");
         }
 
@@ -8283,9 +8283,9 @@ static void VULKAN_BeginComputePass(
             renderer,
             vulkanCommandBuffer,
             textureContainer,
-            storageTextureBindings[i].layer,
-            storageTextureBindings[i].mipLevel,
-            storageTextureBindings[i].cycle,
+            storage_texture_bindings[i].layer,
+            storage_texture_bindings[i].mip_level,
+            storage_texture_bindings[i].cycle,
             VULKAN_TEXTURE_USAGE_MODE_COMPUTE_STORAGE_READ_WRITE);
 
         vulkanCommandBuffer->writeOnlyComputeStorageTextureSubresources[i] = subresource;
@@ -8295,13 +8295,13 @@ static void VULKAN_BeginComputePass(
             subresource->parent);
     }
 
-    for (i = 0; i < storageBufferBindingCount; i += 1) {
-        bufferContainer = (VulkanBufferContainer *)storageBufferBindings[i].buffer;
+    for (i = 0; i < num_storage_buffer_bindings; i += 1) {
+        bufferContainer = (VulkanBufferContainer *)storage_buffer_bindings[i].buffer;
         buffer = VULKAN_INTERNAL_PrepareBufferForWrite(
             renderer,
             vulkanCommandBuffer,
             bufferContainer,
-            storageBufferBindings[i].cycle,
+            storage_buffer_bindings[i].cycle,
             VULKAN_BUFFER_USAGE_MODE_COMPUTE_STORAGE_READ);
 
         vulkanCommandBuffer->writeOnlyComputeStorageBuffers[i] = buffer;
@@ -8313,15 +8313,15 @@ static void VULKAN_BeginComputePass(
 }
 
 static void VULKAN_BindComputePipeline(
-    SDL_GPUCommandBuffer *commandBuffer,
-    SDL_GPUComputePipeline *computePipeline)
+    SDL_GPUCommandBuffer *command_buffer,
+    SDL_GPUComputePipeline *compute_pipeline)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
-    VulkanComputePipeline *vulkanComputePipeline = (VulkanComputePipeline *)computePipeline;
+    VulkanComputePipeline *vulkanComputePipeline = (VulkanComputePipeline *)compute_pipeline;
 
     renderer->vkCmdBindPipeline(
-        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->command_buffer,
         VK_PIPELINE_BIND_POINT_COMPUTE,
         vulkanComputePipeline->pipeline);
 
@@ -8330,7 +8330,7 @@ static void VULKAN_BindComputePipeline(
     VULKAN_INTERNAL_TrackComputePipeline(vulkanCommandBuffer, vulkanComputePipeline);
 
     // Acquire uniform buffers if necessary
-    for (Uint32 i = 0; i < vulkanComputePipeline->resourceLayout.uniformBufferCount; i += 1) {
+    for (Uint32 i = 0; i < vulkanComputePipeline->resourceLayout.num_uniform_buffers; i += 1) {
         if (vulkanCommandBuffer->computeUniformBuffers[i] == NULL) {
             vulkanCommandBuffer->computeUniformBuffers[i] = VULKAN_INTERNAL_AcquireUniformBufferFromPool(
                 vulkanCommandBuffer);
@@ -8345,26 +8345,26 @@ static void VULKAN_BindComputePipeline(
 }
 
 static void VULKAN_BindComputeStorageTextures(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    SDL_GPUTexture *const *storageTextures,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    SDL_GPUTexture *const *storage_textures,
+    Uint32 num_bindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
 
-    for (Uint32 i = 0; i < bindingCount; i += 1) {
-        if (vulkanCommandBuffer->readOnlyComputeStorageTextures[firstSlot + i] != NULL) {
+    for (Uint32 i = 0; i < num_bindings; i += 1) {
+        if (vulkanCommandBuffer->readOnlyComputeStorageTextures[first_slot + i] != NULL) {
             VULKAN_INTERNAL_TextureTransitionToDefaultUsage(
                 renderer,
                 vulkanCommandBuffer,
                 VULKAN_TEXTURE_USAGE_MODE_COMPUTE_STORAGE_READ,
-                vulkanCommandBuffer->readOnlyComputeStorageTextures[firstSlot + i]);
+                vulkanCommandBuffer->readOnlyComputeStorageTextures[first_slot + i]);
         }
 
-        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storageTextures[i];
+        VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)storage_textures[i];
 
-        vulkanCommandBuffer->readOnlyComputeStorageTextures[firstSlot + i] =
+        vulkanCommandBuffer->readOnlyComputeStorageTextures[first_slot + i] =
             textureContainer->activeTextureHandle->vulkanTexture;
 
         VULKAN_INTERNAL_TextureTransitionFromDefaultUsage(
@@ -8382,28 +8382,28 @@ static void VULKAN_BindComputeStorageTextures(
 }
 
 static void VULKAN_BindComputeStorageBuffers(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 firstSlot,
-    SDL_GPUBuffer *const *storageBuffers,
-    Uint32 bindingCount)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 first_slot,
+    SDL_GPUBuffer *const *storage_buffers,
+    Uint32 num_bindings)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanBufferContainer *bufferContainer;
     Uint32 i;
 
-    for (i = 0; i < bindingCount; i += 1) {
-        if (vulkanCommandBuffer->readOnlyComputeStorageBuffers[firstSlot + i] != NULL) {
+    for (i = 0; i < num_bindings; i += 1) {
+        if (vulkanCommandBuffer->readOnlyComputeStorageBuffers[first_slot + i] != NULL) {
             VULKAN_INTERNAL_BufferTransitionToDefaultUsage(
                 renderer,
                 vulkanCommandBuffer,
                 VULKAN_BUFFER_USAGE_MODE_COMPUTE_STORAGE_READ,
-                vulkanCommandBuffer->readOnlyComputeStorageBuffers[firstSlot + i]);
+                vulkanCommandBuffer->readOnlyComputeStorageBuffers[first_slot + i]);
         }
 
-        bufferContainer = (VulkanBufferContainer *)storageBuffers[i];
+        bufferContainer = (VulkanBufferContainer *)storage_buffers[i];
 
-        vulkanCommandBuffer->readOnlyComputeStorageBuffers[firstSlot + i] = bufferContainer->activeBufferHandle->vulkanBuffer;
+        vulkanCommandBuffer->readOnlyComputeStorageBuffers[first_slot + i] = bufferContainer->activeBufferHandle->vulkanBuffer;
 
         VULKAN_INTERNAL_BufferTransitionFromDefaultUsage(
             renderer,
@@ -8420,24 +8420,24 @@ static void VULKAN_BindComputeStorageBuffers(
 }
 
 static void VULKAN_PushComputeUniformData(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 slotIndex,
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 slot_index,
     const void *data,
-    Uint32 dataLengthInBytes)
+    Uint32 length)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
 
     VULKAN_INTERNAL_PushUniformData(
         vulkanCommandBuffer,
         VULKAN_UNIFORM_BUFFER_STAGE_COMPUTE,
-        slotIndex,
+        slot_index,
         data,
-        dataLengthInBytes);
+        length);
 }
 
 static void VULKAN_INTERNAL_BindComputeDescriptorSets(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *commandBuffer)
+    VulkanCommandBuffer *command_buffer)
 {
     VulkanComputePipelineResourceLayout *resourceLayout;
     VkWriteDescriptorSet *writeDescriptorSets;
@@ -8450,22 +8450,22 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
     Uint32 imageInfoCount = 0;
     Uint32 i;
 
-    resourceLayout = &commandBuffer->currentComputePipeline->resourceLayout;
+    resourceLayout = &command_buffer->currentComputePipeline->resourceLayout;
 
-    if (commandBuffer->needNewComputeReadOnlyDescriptorSet) {
+    if (command_buffer->needNewComputeReadOnlyDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[0];
 
-        commandBuffer->computeReadOnlyDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        command_buffer->computeReadOnlyDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            commandBuffer,
+            command_buffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
             VkWriteDescriptorSet,
-            resourceLayout->readOnlyStorageTextureCount +
-                resourceLayout->readOnlyStorageBufferCount);
+            resourceLayout->num_readonly_storage_textures +
+                resourceLayout->num_readonly_storage_buffers);
 
-        for (i = 0; i < resourceLayout->readOnlyStorageTextureCount; i += 1) {
+        for (i = 0; i < resourceLayout->num_readonly_storage_textures; i += 1) {
             currentWriteDescriptorSet = &writeDescriptorSets[i];
             currentWriteDescriptorSet->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
             currentWriteDescriptorSet->pNext = NULL;
@@ -8473,12 +8473,12 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = commandBuffer->computeReadOnlyDescriptorSet;
+            currentWriteDescriptorSet->dstSet = command_buffer->computeReadOnlyDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pBufferInfo = NULL;
 
             imageInfos[imageInfoCount].sampler = VK_NULL_HANDLE;
-            imageInfos[imageInfoCount].imageView = commandBuffer->readOnlyComputeStorageTextures[i]->fullView;
+            imageInfos[imageInfoCount].imageView = command_buffer->readOnlyComputeStorageTextures[i]->fullView;
             imageInfos[imageInfoCount].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
             currentWriteDescriptorSet->pImageInfo = &imageInfos[imageInfoCount];
@@ -8486,20 +8486,20 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
             imageInfoCount += 1;
         }
 
-        for (i = 0; i < resourceLayout->readOnlyStorageBufferCount; i += 1) {
-            currentWriteDescriptorSet = &writeDescriptorSets[resourceLayout->readOnlyStorageTextureCount + i];
+        for (i = 0; i < resourceLayout->num_readonly_storage_buffers; i += 1) {
+            currentWriteDescriptorSet = &writeDescriptorSets[resourceLayout->num_readonly_storage_textures + i];
 
             currentWriteDescriptorSet->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
             currentWriteDescriptorSet->pNext = NULL;
             currentWriteDescriptorSet->descriptorCount = 1;
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
             currentWriteDescriptorSet->dstArrayElement = 0;
-            currentWriteDescriptorSet->dstBinding = resourceLayout->readOnlyStorageTextureCount + i;
-            currentWriteDescriptorSet->dstSet = commandBuffer->computeReadOnlyDescriptorSet;
+            currentWriteDescriptorSet->dstBinding = resourceLayout->num_readonly_storage_textures + i;
+            currentWriteDescriptorSet->dstSet = command_buffer->computeReadOnlyDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = commandBuffer->readOnlyComputeStorageBuffers[i]->buffer;
+            bufferInfos[bufferInfoCount].buffer = command_buffer->readOnlyComputeStorageBuffers[i]->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = VK_WHOLE_SIZE;
 
@@ -8510,18 +8510,18 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
 
         renderer->vkUpdateDescriptorSets(
             renderer->logicalDevice,
-            resourceLayout->readOnlyStorageTextureCount + resourceLayout->readOnlyStorageBufferCount,
+            resourceLayout->num_readonly_storage_textures + resourceLayout->num_readonly_storage_buffers,
             writeDescriptorSets,
             0,
             NULL);
 
         renderer->vkCmdBindDescriptorSets(
-            commandBuffer->commandBuffer,
+            command_buffer->command_buffer,
             VK_PIPELINE_BIND_POINT_COMPUTE,
             resourceLayout->pipelineLayout,
             0,
             1,
-            &commandBuffer->computeReadOnlyDescriptorSet,
+            &command_buffer->computeReadOnlyDescriptorSet,
             0,
             NULL);
 
@@ -8529,23 +8529,23 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        commandBuffer->needNewComputeReadOnlyDescriptorSet = false;
+        command_buffer->needNewComputeReadOnlyDescriptorSet = false;
     }
 
-    if (commandBuffer->needNewComputeWriteOnlyDescriptorSet) {
+    if (command_buffer->needNewComputeWriteOnlyDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[1];
 
-        commandBuffer->computeWriteOnlyDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        command_buffer->computeWriteOnlyDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            commandBuffer,
+            command_buffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
             VkWriteDescriptorSet,
-            resourceLayout->writeOnlyStorageTextureCount +
-                resourceLayout->writeOnlyStorageBufferCount);
+            resourceLayout->num_writeonly_storage_textures +
+                resourceLayout->num_writeonly_storage_buffers);
 
-        for (i = 0; i < resourceLayout->writeOnlyStorageTextureCount; i += 1) {
+        for (i = 0; i < resourceLayout->num_writeonly_storage_textures; i += 1) {
             currentWriteDescriptorSet = &writeDescriptorSets[i];
 
             currentWriteDescriptorSet->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
@@ -8554,12 +8554,12 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = commandBuffer->computeWriteOnlyDescriptorSet;
+            currentWriteDescriptorSet->dstSet = command_buffer->computeWriteOnlyDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pBufferInfo = NULL;
 
             imageInfos[imageInfoCount].sampler = VK_NULL_HANDLE;
-            imageInfos[imageInfoCount].imageView = commandBuffer->writeOnlyComputeStorageTextureSubresources[i]->computeWriteView;
+            imageInfos[imageInfoCount].imageView = command_buffer->writeOnlyComputeStorageTextureSubresources[i]->computeWriteView;
             imageInfos[imageInfoCount].imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
             currentWriteDescriptorSet->pImageInfo = &imageInfos[imageInfoCount];
@@ -8567,20 +8567,20 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
             imageInfoCount += 1;
         }
 
-        for (i = 0; i < resourceLayout->writeOnlyStorageBufferCount; i += 1) {
-            currentWriteDescriptorSet = &writeDescriptorSets[resourceLayout->writeOnlyStorageTextureCount + i];
+        for (i = 0; i < resourceLayout->num_writeonly_storage_buffers; i += 1) {
+            currentWriteDescriptorSet = &writeDescriptorSets[resourceLayout->num_writeonly_storage_textures + i];
 
             currentWriteDescriptorSet->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
             currentWriteDescriptorSet->pNext = NULL;
             currentWriteDescriptorSet->descriptorCount = 1;
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
             currentWriteDescriptorSet->dstArrayElement = 0;
-            currentWriteDescriptorSet->dstBinding = resourceLayout->writeOnlyStorageTextureCount + i;
-            currentWriteDescriptorSet->dstSet = commandBuffer->computeWriteOnlyDescriptorSet;
+            currentWriteDescriptorSet->dstBinding = resourceLayout->num_writeonly_storage_textures + i;
+            currentWriteDescriptorSet->dstSet = command_buffer->computeWriteOnlyDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = commandBuffer->writeOnlyComputeStorageBuffers[i]->buffer;
+            bufferInfos[bufferInfoCount].buffer = command_buffer->writeOnlyComputeStorageBuffers[i]->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = VK_WHOLE_SIZE;
 
@@ -8591,18 +8591,18 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
 
         renderer->vkUpdateDescriptorSets(
             renderer->logicalDevice,
-            resourceLayout->writeOnlyStorageTextureCount + resourceLayout->writeOnlyStorageBufferCount,
+            resourceLayout->num_writeonly_storage_textures + resourceLayout->num_writeonly_storage_buffers,
             writeDescriptorSets,
             0,
             NULL);
 
         renderer->vkCmdBindDescriptorSets(
-            commandBuffer->commandBuffer,
+            command_buffer->command_buffer,
             VK_PIPELINE_BIND_POINT_COMPUTE,
             resourceLayout->pipelineLayout,
             1,
             1,
-            &commandBuffer->computeWriteOnlyDescriptorSet,
+            &command_buffer->computeWriteOnlyDescriptorSet,
             0,
             NULL);
 
@@ -8610,22 +8610,22 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        commandBuffer->needNewComputeWriteOnlyDescriptorSet = false;
+        command_buffer->needNewComputeWriteOnlyDescriptorSet = false;
     }
 
-    if (commandBuffer->needNewComputeUniformDescriptorSet) {
+    if (command_buffer->needNewComputeUniformDescriptorSet) {
         descriptorSetPool = &resourceLayout->descriptorSetPools[2];
 
-        commandBuffer->computeUniformDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
+        command_buffer->computeUniformDescriptorSet = VULKAN_INTERNAL_FetchDescriptorSet(
             renderer,
-            commandBuffer,
+            command_buffer,
             descriptorSetPool);
 
         writeDescriptorSets = SDL_stack_alloc(
             VkWriteDescriptorSet,
-            resourceLayout->uniformBufferCount);
+            resourceLayout->num_uniform_buffers);
 
-        for (i = 0; i < resourceLayout->uniformBufferCount; i += 1) {
+        for (i = 0; i < resourceLayout->num_uniform_buffers; i += 1) {
             currentWriteDescriptorSet = &writeDescriptorSets[i];
 
             currentWriteDescriptorSet->sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
@@ -8634,11 +8634,11 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
             currentWriteDescriptorSet->descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
             currentWriteDescriptorSet->dstArrayElement = 0;
             currentWriteDescriptorSet->dstBinding = i;
-            currentWriteDescriptorSet->dstSet = commandBuffer->computeUniformDescriptorSet;
+            currentWriteDescriptorSet->dstSet = command_buffer->computeUniformDescriptorSet;
             currentWriteDescriptorSet->pTexelBufferView = NULL;
             currentWriteDescriptorSet->pImageInfo = NULL;
 
-            bufferInfos[bufferInfoCount].buffer = commandBuffer->computeUniformBuffers[i]->bufferHandle->vulkanBuffer->buffer;
+            bufferInfos[bufferInfoCount].buffer = command_buffer->computeUniformBuffers[i]->bufferHandle->vulkanBuffer->buffer;
             bufferInfos[bufferInfoCount].offset = 0;
             bufferInfos[bufferInfoCount].range = MAX_UBO_SECTION_SIZE;
 
@@ -8649,7 +8649,7 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
 
         renderer->vkUpdateDescriptorSets(
             renderer->logicalDevice,
-            resourceLayout->uniformBufferCount,
+            resourceLayout->num_uniform_buffers,
             writeDescriptorSets,
             0,
             NULL);
@@ -8658,70 +8658,70 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
         bufferInfoCount = 0;
         imageInfoCount = 0;
 
-        commandBuffer->needNewComputeUniformDescriptorSet = false;
-        commandBuffer->needNewComputeUniformOffsets = true;
+        command_buffer->needNewComputeUniformDescriptorSet = false;
+        command_buffer->needNewComputeUniformOffsets = true;
     }
 
-    if (commandBuffer->needNewComputeUniformOffsets) {
-        for (i = 0; i < resourceLayout->uniformBufferCount; i += 1) {
-            dynamicOffsets[i] = commandBuffer->computeUniformBuffers[i]->drawOffset;
+    if (command_buffer->needNewComputeUniformOffsets) {
+        for (i = 0; i < resourceLayout->num_uniform_buffers; i += 1) {
+            dynamicOffsets[i] = command_buffer->computeUniformBuffers[i]->drawOffset;
         }
 
         renderer->vkCmdBindDescriptorSets(
-            commandBuffer->commandBuffer,
+            command_buffer->command_buffer,
             VK_PIPELINE_BIND_POINT_COMPUTE,
             resourceLayout->pipelineLayout,
             2,
             1,
-            &commandBuffer->computeUniformDescriptorSet,
-            resourceLayout->uniformBufferCount,
+            &command_buffer->computeUniformDescriptorSet,
+            resourceLayout->num_uniform_buffers,
             dynamicOffsets);
 
-        commandBuffer->needNewComputeUniformOffsets = false;
+        command_buffer->needNewComputeUniformOffsets = false;
     }
 }
 
 static void VULKAN_DispatchCompute(
-    SDL_GPUCommandBuffer *commandBuffer,
-    Uint32 groupCountX,
-    Uint32 groupCountY,
-    Uint32 groupCountZ)
+    SDL_GPUCommandBuffer *command_buffer,
+    Uint32 groupcount_x,
+    Uint32 groupcount_y,
+    Uint32 groupcount_z)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_BindComputeDescriptorSets(renderer, vulkanCommandBuffer);
 
     renderer->vkCmdDispatch(
-        vulkanCommandBuffer->commandBuffer,
-        groupCountX,
-        groupCountY,
-        groupCountZ);
+        vulkanCommandBuffer->command_buffer,
+        groupcount_x,
+        groupcount_y,
+        groupcount_z);
 }
 
 static void VULKAN_DispatchComputeIndirect(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     SDL_GPUBuffer *buffer,
-    Uint32 offsetInBytes)
+    Uint32 offset)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBuffer *vulkanBuffer = ((VulkanBufferContainer *)buffer)->activeBufferHandle->vulkanBuffer;
 
     VULKAN_INTERNAL_BindComputeDescriptorSets(renderer, vulkanCommandBuffer);
 
     renderer->vkCmdDispatchIndirect(
-        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->command_buffer,
         vulkanBuffer->buffer,
-        offsetInBytes);
+        offset);
 
     VULKAN_INTERNAL_TrackBuffer(vulkanCommandBuffer, vulkanBuffer);
 }
 
 static void VULKAN_EndComputePass(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     Uint32 i;
 
     for (i = 0; i < vulkanCommandBuffer->writeOnlyComputeStorageTextureSubresourceCount; i += 1) {
@@ -8779,11 +8779,11 @@ static void VULKAN_EndComputePass(
 
 static void *VULKAN_MapTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transferBuffer,
+    SDL_GPUTransferBuffer *transfer_buffer,
     bool cycle)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)transferBuffer;
+    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)transfer_buffer;
 
     if (
         cycle &&
@@ -8802,29 +8802,29 @@ static void *VULKAN_MapTransferBuffer(
 
 static void VULKAN_UnmapTransferBuffer(
     SDL_GPURenderer *driverData,
-    SDL_GPUTransferBuffer *transferBuffer)
+    SDL_GPUTransferBuffer *transfer_buffer)
 {
     // no-op because transfer buffers are persistently mapped
     (void)driverData;
-    (void)transferBuffer;
+    (void)transfer_buffer;
 }
 
 static void VULKAN_BeginCopyPass(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
     // no-op
-    (void)commandBuffer;
+    (void)command_buffer;
 }
 
 static void VULKAN_UploadToTexture(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUTextureTransferInfo *source,
     const SDL_GPUTextureRegion *destination,
     bool cycle)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
-    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)source->transferBuffer;
+    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)source->transfer_buffer;
     VulkanTextureContainer *vulkanTextureContainer = (VulkanTextureContainer *)destination->texture;
     VulkanTextureSubresource *vulkanTextureSubresource;
     VkBufferImageCopy imageCopy;
@@ -8836,7 +8836,7 @@ static void VULKAN_UploadToTexture(
         vulkanCommandBuffer,
         vulkanTextureContainer,
         destination->layer,
-        destination->mipLevel,
+        destination->mip_level,
         cycle,
         VULKAN_TEXTURE_USAGE_MODE_COPY_DESTINATION);
 
@@ -8849,13 +8849,13 @@ static void VULKAN_UploadToTexture(
     imageCopy.imageSubresource.aspectMask = vulkanTextureSubresource->parent->aspectFlags;
     imageCopy.imageSubresource.baseArrayLayer = destination->layer;
     imageCopy.imageSubresource.layerCount = 1;
-    imageCopy.imageSubresource.mipLevel = destination->mipLevel;
+    imageCopy.imageSubresource.mipLevel = destination->mip_level;
     imageCopy.bufferOffset = source->offset;
-    imageCopy.bufferRowLength = source->imagePitch;
-    imageCopy.bufferImageHeight = source->imageHeight;
+    imageCopy.bufferRowLength = source->pixels_per_row;
+    imageCopy.bufferImageHeight = source->rows_per_layer;
 
     renderer->vkCmdCopyBufferToImage(
-        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->command_buffer,
         transferBufferContainer->activeBufferHandle->vulkanBuffer->buffer,
         vulkanTextureSubresource->parent->image,
         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
@@ -8873,14 +8873,14 @@ static void VULKAN_UploadToTexture(
 }
 
 static void VULKAN_UploadToBuffer(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUTransferBufferLocation *source,
     const SDL_GPUBufferRegion *destination,
     bool cycle)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
-    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)source->transferBuffer;
+    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)source->transfer_buffer;
     VulkanBufferContainer *bufferContainer = (VulkanBufferContainer *)destination->buffer;
     VkBufferCopy bufferCopy;
 
@@ -8898,7 +8898,7 @@ static void VULKAN_UploadToBuffer(
     bufferCopy.size = destination->size;
 
     renderer->vkCmdCopyBuffer(
-        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->command_buffer,
         transferBufferContainer->activeBufferHandle->vulkanBuffer->buffer,
         vulkanBuffer->buffer,
         1,
@@ -8917,20 +8917,20 @@ static void VULKAN_UploadToBuffer(
 // Readback
 
 static void VULKAN_DownloadFromTexture(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUTextureRegion *source,
     const SDL_GPUTextureTransferInfo *destination)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanTextureContainer *textureContainer = (VulkanTextureContainer *)source->texture;
     VulkanTextureSubresource *vulkanTextureSubresource;
-    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)destination->transferBuffer;
+    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)destination->transfer_buffer;
     VkBufferImageCopy imageCopy;
     vulkanTextureSubresource = VULKAN_INTERNAL_FetchTextureSubresource(
         textureContainer,
         source->layer,
-        source->mipLevel);
+        source->mip_level);
 
     // Note that the transfer buffer does not need a barrier, as it is synced by the client
 
@@ -8949,13 +8949,13 @@ static void VULKAN_DownloadFromTexture(
     imageCopy.imageSubresource.aspectMask = vulkanTextureSubresource->parent->aspectFlags;
     imageCopy.imageSubresource.baseArrayLayer = source->layer;
     imageCopy.imageSubresource.layerCount = 1;
-    imageCopy.imageSubresource.mipLevel = source->mipLevel;
+    imageCopy.imageSubresource.mipLevel = source->mip_level;
     imageCopy.bufferOffset = destination->offset;
-    imageCopy.bufferRowLength = destination->imagePitch;
-    imageCopy.bufferImageHeight = destination->imageHeight;
+    imageCopy.bufferRowLength = destination->pixels_per_row;
+    imageCopy.bufferImageHeight = destination->rows_per_layer;
 
     renderer->vkCmdCopyImageToBuffer(
-        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->command_buffer,
         vulkanTextureSubresource->parent->image,
         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
         transferBufferContainer->activeBufferHandle->vulkanBuffer->buffer,
@@ -8973,14 +8973,14 @@ static void VULKAN_DownloadFromTexture(
 }
 
 static void VULKAN_DownloadFromBuffer(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUBufferRegion *source,
     const SDL_GPUTransferBufferLocation *destination)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanBufferContainer *bufferContainer = (VulkanBufferContainer *)source->buffer;
-    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)destination->transferBuffer;
+    VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)destination->transfer_buffer;
     VkBufferCopy bufferCopy;
 
     // Note that transfer buffer does not need a barrier, as it is synced by the client
@@ -8996,7 +8996,7 @@ static void VULKAN_DownloadFromBuffer(
     bufferCopy.size = source->size;
 
     renderer->vkCmdCopyBuffer(
-        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->command_buffer,
         bufferContainer->activeBufferHandle->vulkanBuffer->buffer,
         transferBufferContainer->activeBufferHandle->vulkanBuffer->buffer,
         1,
@@ -9013,7 +9013,7 @@ static void VULKAN_DownloadFromBuffer(
 }
 
 static void VULKAN_CopyTextureToTexture(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUTextureLocation *source,
     const SDL_GPUTextureLocation *destination,
     Uint32 w,
@@ -9021,7 +9021,7 @@ static void VULKAN_CopyTextureToTexture(
     Uint32 d,
     bool cycle)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanTextureSubresource *srcSubresource;
     VulkanTextureSubresource *dstSubresource;
@@ -9030,14 +9030,14 @@ static void VULKAN_CopyTextureToTexture(
     srcSubresource = VULKAN_INTERNAL_FetchTextureSubresource(
         (VulkanTextureContainer *)source->texture,
         source->layer,
-        source->mipLevel);
+        source->mip_level);
 
     dstSubresource = VULKAN_INTERNAL_PrepareTextureSubresourceForWrite(
         renderer,
         vulkanCommandBuffer,
         (VulkanTextureContainer *)destination->texture,
         destination->layer,
-        destination->mipLevel,
+        destination->mip_level,
         cycle,
         VULKAN_TEXTURE_USAGE_MODE_COPY_DESTINATION);
 
@@ -9053,20 +9053,20 @@ static void VULKAN_CopyTextureToTexture(
     imageCopy.srcSubresource.aspectMask = srcSubresource->parent->aspectFlags;
     imageCopy.srcSubresource.baseArrayLayer = source->layer;
     imageCopy.srcSubresource.layerCount = 1;
-    imageCopy.srcSubresource.mipLevel = source->mipLevel;
+    imageCopy.srcSubresource.mipLevel = source->mip_level;
     imageCopy.dstOffset.x = destination->x;
     imageCopy.dstOffset.y = destination->y;
     imageCopy.dstOffset.z = destination->z;
     imageCopy.dstSubresource.aspectMask = dstSubresource->parent->aspectFlags;
     imageCopy.dstSubresource.baseArrayLayer = destination->layer;
     imageCopy.dstSubresource.layerCount = 1;
-    imageCopy.dstSubresource.mipLevel = destination->mipLevel;
+    imageCopy.dstSubresource.mipLevel = destination->mip_level;
     imageCopy.extent.width = w;
     imageCopy.extent.height = h;
     imageCopy.extent.depth = d;
 
     renderer->vkCmdCopyImage(
-        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->command_buffer,
         srcSubresource->parent->image,
         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
         dstSubresource->parent->image,
@@ -9091,13 +9091,13 @@ static void VULKAN_CopyTextureToTexture(
 }
 
 static void VULKAN_CopyBufferToBuffer(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUBufferLocation *source,
     const SDL_GPUBufferLocation *destination,
     Uint32 size,
     bool cycle)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanBufferContainer *srcContainer = (VulkanBufferContainer *)source->buffer;
     VulkanBufferContainer *dstContainer = (VulkanBufferContainer *)destination->buffer;
@@ -9121,7 +9121,7 @@ static void VULKAN_CopyBufferToBuffer(
     bufferCopy.size = size;
 
     renderer->vkCmdCopyBuffer(
-        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->command_buffer,
         srcContainer->activeBufferHandle->vulkanBuffer->buffer,
         dstBuffer->buffer,
         1,
@@ -9144,10 +9144,10 @@ static void VULKAN_CopyBufferToBuffer(
 }
 
 static void VULKAN_GenerateMipmaps(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     SDL_GPUTexture *texture)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VulkanTexture *vulkanTexture = ((VulkanTextureContainer *)texture)->activeTextureHandle->vulkanTexture;
     VulkanTextureSubresource *srcTextureSubresource;
@@ -9156,18 +9156,18 @@ static void VULKAN_GenerateMipmaps(
 
     // Blit each slice sequentially. Barriers, barriers everywhere!
     for (Uint32 layerOrDepthIndex = 0; layerOrDepthIndex < vulkanTexture->layerCount; layerOrDepthIndex += 1)
-        for (Uint32 level = 1; level < vulkanTexture->levelCount; level += 1) {
+        for (Uint32 level = 1; level < vulkanTexture->num_levels; level += 1) {
             Uint32 layer = vulkanTexture->type == SDL_GPU_TEXTURETYPE_3D ? 0 : layerOrDepthIndex;
             Uint32 depth = vulkanTexture->type == SDL_GPU_TEXTURETYPE_3D ? layerOrDepthIndex : 0;
 
             Uint32 srcSubresourceIndex = VULKAN_INTERNAL_GetTextureSubresourceIndex(
                 level - 1,
                 layer,
-                vulkanTexture->levelCount);
+                vulkanTexture->num_levels);
             Uint32 dstSubresourceIndex = VULKAN_INTERNAL_GetTextureSubresourceIndex(
                 level,
                 layer,
-                vulkanTexture->levelCount);
+                vulkanTexture->num_levels);
 
             srcTextureSubresource = &vulkanTexture->subresources[srcSubresourceIndex];
             dstTextureSubresource = &vulkanTexture->subresources[dstSubresourceIndex];
@@ -9211,7 +9211,7 @@ static void VULKAN_GenerateMipmaps(
             blit.dstSubresource.mipLevel = level;
 
             renderer->vkCmdBlitImage(
-                vulkanCommandBuffer->commandBuffer,
+                vulkanCommandBuffer->command_buffer,
                 vulkanTexture->image,
                 VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                 vulkanTexture->image,
@@ -9238,42 +9238,42 @@ static void VULKAN_GenerateMipmaps(
 }
 
 static void VULKAN_EndCopyPass(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
     // no-op
-    (void)commandBuffer;
+    (void)command_buffer;
 }
 
 static void VULKAN_Blit(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUBlitRegion *source,
     const SDL_GPUBlitRegion *destination,
-    SDL_FlipMode flipMode,
-    SDL_GPUFilter filterMode,
+    SDL_FlipMode flip_mode,
+    SDL_GPUFilter filter,
     bool cycle)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     TextureCommonHeader *srcHeader = (TextureCommonHeader *)source->texture;
     TextureCommonHeader *dstHeader = (TextureCommonHeader *)destination->texture;
     VkImageBlit region;
-    Uint32 srcLayer = srcHeader->info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : source->layerOrDepthPlane;
-    Uint32 srcDepth = srcHeader->info.type == SDL_GPU_TEXTURETYPE_3D ? source->layerOrDepthPlane : 0;
-    Uint32 dstLayer = dstHeader->info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : destination->layerOrDepthPlane;
-    Uint32 dstDepth = dstHeader->info.type == SDL_GPU_TEXTURETYPE_3D ? destination->layerOrDepthPlane : 0;
+    Uint32 srcLayer = srcHeader->info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : source->layer_or_depth_plane;
+    Uint32 srcDepth = srcHeader->info.type == SDL_GPU_TEXTURETYPE_3D ? source->layer_or_depth_plane : 0;
+    Uint32 dstLayer = dstHeader->info.type == SDL_GPU_TEXTURETYPE_3D ? 0 : destination->layer_or_depth_plane;
+    Uint32 dstDepth = dstHeader->info.type == SDL_GPU_TEXTURETYPE_3D ? destination->layer_or_depth_plane : 0;
     int32_t swap;
 
     VulkanTextureSubresource *srcSubresource = VULKAN_INTERNAL_FetchTextureSubresource(
         (VulkanTextureContainer *)source->texture,
         srcLayer,
-        source->mipLevel);
+        source->mip_level);
 
     VulkanTextureSubresource *dstSubresource = VULKAN_INTERNAL_PrepareTextureSubresourceForWrite(
         renderer,
         vulkanCommandBuffer,
         (VulkanTextureContainer *)destination->texture,
         dstLayer,
-        destination->mipLevel,
+        destination->mip_level,
         cycle,
         VULKAN_TEXTURE_USAGE_MODE_COPY_DESTINATION);
 
@@ -9294,14 +9294,14 @@ static void VULKAN_Blit(
     region.srcOffsets[1].y = source->y + source->h;
     region.srcOffsets[1].z = srcDepth + 1;
 
-    if (flipMode & SDL_FLIP_HORIZONTAL) {
+    if (flip_mode & SDL_FLIP_HORIZONTAL) {
         // flip the x positions
         swap = region.srcOffsets[0].x;
         region.srcOffsets[0].x = region.srcOffsets[1].x;
         region.srcOffsets[1].x = swap;
     }
 
-    if (flipMode & SDL_FLIP_VERTICAL) {
+    if (flip_mode & SDL_FLIP_VERTICAL) {
         // flip the y positions
         swap = region.srcOffsets[0].y;
         region.srcOffsets[0].y = region.srcOffsets[1].y;
@@ -9320,14 +9320,14 @@ static void VULKAN_Blit(
     region.dstOffsets[1].z = dstDepth + 1;
 
     renderer->vkCmdBlitImage(
-        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->command_buffer,
         srcSubresource->parent->image,
         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
         dstSubresource->parent->image,
         VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
         1,
         &region,
-        SDLToVK_Filter[filterMode]);
+        SDLToVK_Filter[filter]);
 
     VULKAN_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
         renderer,
@@ -9354,7 +9354,7 @@ static void VULKAN_INTERNAL_AllocateCommandBuffers(
     VkResult vulkanResult;
     Uint32 i;
     VkCommandBuffer *commandBuffers = SDL_stack_alloc(VkCommandBuffer, allocateCount);
-    VulkanCommandBuffer *commandBuffer;
+    VulkanCommandBuffer *command_buffer;
 
     vulkanCommandPool->inactiveCommandBufferCapacity += allocateCount;
 
@@ -9381,100 +9381,100 @@ static void VULKAN_INTERNAL_AllocateCommandBuffers(
     }
 
     for (i = 0; i < allocateCount; i += 1) {
-        commandBuffer = SDL_malloc(sizeof(VulkanCommandBuffer));
-        commandBuffer->renderer = renderer;
-        commandBuffer->commandPool = vulkanCommandPool;
-        commandBuffer->commandBuffer = commandBuffers[i];
+        command_buffer = SDL_malloc(sizeof(VulkanCommandBuffer));
+        command_buffer->renderer = renderer;
+        command_buffer->commandPool = vulkanCommandPool;
+        command_buffer->command_buffer = commandBuffers[i];
 
-        commandBuffer->inFlightFence = VK_NULL_HANDLE;
+        command_buffer->inFlightFence = VK_NULL_HANDLE;
 
         // Presentation tracking
 
-        commandBuffer->presentDataCapacity = 1;
-        commandBuffer->presentDataCount = 0;
-        commandBuffer->presentDatas = SDL_malloc(
-            commandBuffer->presentDataCapacity * sizeof(VulkanPresentData));
+        command_buffer->presentDataCapacity = 1;
+        command_buffer->presentDataCount = 0;
+        command_buffer->presentDatas = SDL_malloc(
+            command_buffer->presentDataCapacity * sizeof(VulkanPresentData));
 
-        commandBuffer->waitSemaphoreCapacity = 1;
-        commandBuffer->waitSemaphoreCount = 0;
-        commandBuffer->waitSemaphores = SDL_malloc(
-            commandBuffer->waitSemaphoreCapacity * sizeof(VkSemaphore));
+        command_buffer->waitSemaphoreCapacity = 1;
+        command_buffer->waitSemaphoreCount = 0;
+        command_buffer->waitSemaphores = SDL_malloc(
+            command_buffer->waitSemaphoreCapacity * sizeof(VkSemaphore));
 
-        commandBuffer->signalSemaphoreCapacity = 1;
-        commandBuffer->signalSemaphoreCount = 0;
-        commandBuffer->signalSemaphores = SDL_malloc(
-            commandBuffer->signalSemaphoreCapacity * sizeof(VkSemaphore));
+        command_buffer->signalSemaphoreCapacity = 1;
+        command_buffer->signalSemaphoreCount = 0;
+        command_buffer->signalSemaphores = SDL_malloc(
+            command_buffer->signalSemaphoreCapacity * sizeof(VkSemaphore));
 
         // Descriptor set tracking
 
-        commandBuffer->boundDescriptorSetDataCapacity = 16;
-        commandBuffer->boundDescriptorSetDataCount = 0;
-        commandBuffer->boundDescriptorSetDatas = SDL_malloc(
-            commandBuffer->boundDescriptorSetDataCapacity * sizeof(DescriptorSetData));
+        command_buffer->boundDescriptorSetDataCapacity = 16;
+        command_buffer->boundDescriptorSetDataCount = 0;
+        command_buffer->boundDescriptorSetDatas = SDL_malloc(
+            command_buffer->boundDescriptorSetDataCapacity * sizeof(DescriptorSetData));
 
         // Resource bind tracking
 
-        commandBuffer->needNewVertexResourceDescriptorSet = true;
-        commandBuffer->needNewVertexUniformDescriptorSet = true;
-        commandBuffer->needNewVertexUniformOffsets = true;
-        commandBuffer->needNewFragmentResourceDescriptorSet = true;
-        commandBuffer->needNewFragmentUniformDescriptorSet = true;
-        commandBuffer->needNewFragmentUniformOffsets = true;
+        command_buffer->needNewVertexResourceDescriptorSet = true;
+        command_buffer->needNewVertexUniformDescriptorSet = true;
+        command_buffer->needNewVertexUniformOffsets = true;
+        command_buffer->needNewFragmentResourceDescriptorSet = true;
+        command_buffer->needNewFragmentUniformDescriptorSet = true;
+        command_buffer->needNewFragmentUniformOffsets = true;
 
-        commandBuffer->needNewComputeWriteOnlyDescriptorSet = true;
-        commandBuffer->needNewComputeReadOnlyDescriptorSet = true;
-        commandBuffer->needNewComputeUniformDescriptorSet = true;
-        commandBuffer->needNewComputeUniformOffsets = true;
+        command_buffer->needNewComputeWriteOnlyDescriptorSet = true;
+        command_buffer->needNewComputeReadOnlyDescriptorSet = true;
+        command_buffer->needNewComputeUniformDescriptorSet = true;
+        command_buffer->needNewComputeUniformOffsets = true;
 
-        commandBuffer->vertexResourceDescriptorSet = VK_NULL_HANDLE;
-        commandBuffer->vertexUniformDescriptorSet = VK_NULL_HANDLE;
-        commandBuffer->fragmentResourceDescriptorSet = VK_NULL_HANDLE;
-        commandBuffer->fragmentUniformDescriptorSet = VK_NULL_HANDLE;
+        command_buffer->vertexResourceDescriptorSet = VK_NULL_HANDLE;
+        command_buffer->vertexUniformDescriptorSet = VK_NULL_HANDLE;
+        command_buffer->fragmentResourceDescriptorSet = VK_NULL_HANDLE;
+        command_buffer->fragmentUniformDescriptorSet = VK_NULL_HANDLE;
 
-        commandBuffer->computeReadOnlyDescriptorSet = VK_NULL_HANDLE;
-        commandBuffer->computeWriteOnlyDescriptorSet = VK_NULL_HANDLE;
-        commandBuffer->computeUniformDescriptorSet = VK_NULL_HANDLE;
+        command_buffer->computeReadOnlyDescriptorSet = VK_NULL_HANDLE;
+        command_buffer->computeWriteOnlyDescriptorSet = VK_NULL_HANDLE;
+        command_buffer->computeUniformDescriptorSet = VK_NULL_HANDLE;
 
         // Resource tracking
 
-        commandBuffer->usedBufferCapacity = 4;
-        commandBuffer->usedBufferCount = 0;
-        commandBuffer->usedBuffers = SDL_malloc(
-            commandBuffer->usedBufferCapacity * sizeof(VulkanBuffer *));
+        command_buffer->usedBufferCapacity = 4;
+        command_buffer->usedBufferCount = 0;
+        command_buffer->usedBuffers = SDL_malloc(
+            command_buffer->usedBufferCapacity * sizeof(VulkanBuffer *));
 
-        commandBuffer->usedTextureCapacity = 4;
-        commandBuffer->usedTextureCount = 0;
-        commandBuffer->usedTextures = SDL_malloc(
-            commandBuffer->usedTextureCapacity * sizeof(VulkanTexture *));
+        command_buffer->usedTextureCapacity = 4;
+        command_buffer->usedTextureCount = 0;
+        command_buffer->usedTextures = SDL_malloc(
+            command_buffer->usedTextureCapacity * sizeof(VulkanTexture *));
 
-        commandBuffer->usedSamplerCapacity = 4;
-        commandBuffer->usedSamplerCount = 0;
-        commandBuffer->usedSamplers = SDL_malloc(
-            commandBuffer->usedSamplerCapacity * sizeof(VulkanSampler *));
+        command_buffer->usedSamplerCapacity = 4;
+        command_buffer->usedSamplerCount = 0;
+        command_buffer->usedSamplers = SDL_malloc(
+            command_buffer->usedSamplerCapacity * sizeof(VulkanSampler *));
 
-        commandBuffer->usedGraphicsPipelineCapacity = 4;
-        commandBuffer->usedGraphicsPipelineCount = 0;
-        commandBuffer->usedGraphicsPipelines = SDL_malloc(
-            commandBuffer->usedGraphicsPipelineCapacity * sizeof(VulkanGraphicsPipeline *));
+        command_buffer->usedGraphicsPipelineCapacity = 4;
+        command_buffer->usedGraphicsPipelineCount = 0;
+        command_buffer->usedGraphicsPipelines = SDL_malloc(
+            command_buffer->usedGraphicsPipelineCapacity * sizeof(VulkanGraphicsPipeline *));
 
-        commandBuffer->usedComputePipelineCapacity = 4;
-        commandBuffer->usedComputePipelineCount = 0;
-        commandBuffer->usedComputePipelines = SDL_malloc(
-            commandBuffer->usedComputePipelineCapacity * sizeof(VulkanComputePipeline *));
+        command_buffer->usedComputePipelineCapacity = 4;
+        command_buffer->usedComputePipelineCount = 0;
+        command_buffer->usedComputePipelines = SDL_malloc(
+            command_buffer->usedComputePipelineCapacity * sizeof(VulkanComputePipeline *));
 
-        commandBuffer->usedFramebufferCapacity = 4;
-        commandBuffer->usedFramebufferCount = 0;
-        commandBuffer->usedFramebuffers = SDL_malloc(
-            commandBuffer->usedFramebufferCapacity * sizeof(VulkanFramebuffer *));
+        command_buffer->usedFramebufferCapacity = 4;
+        command_buffer->usedFramebufferCount = 0;
+        command_buffer->usedFramebuffers = SDL_malloc(
+            command_buffer->usedFramebufferCapacity * sizeof(VulkanFramebuffer *));
 
-        commandBuffer->usedUniformBufferCapacity = 4;
-        commandBuffer->usedUniformBufferCount = 0;
-        commandBuffer->usedUniformBuffers = SDL_malloc(
-            commandBuffer->usedUniformBufferCapacity * sizeof(VulkanUniformBuffer *));
+        command_buffer->usedUniformBufferCapacity = 4;
+        command_buffer->usedUniformBufferCount = 0;
+        command_buffer->usedUniformBuffers = SDL_malloc(
+            command_buffer->usedUniformBufferCapacity * sizeof(VulkanUniformBuffer *));
 
         // Pool it!
 
-        vulkanCommandPool->inactiveCommandBuffers[vulkanCommandPool->inactiveCommandBufferCount] = commandBuffer;
+        vulkanCommandPool->inactiveCommandBuffers[vulkanCommandPool->inactiveCommandBufferCount] = command_buffer;
         vulkanCommandPool->inactiveCommandBufferCount += 1;
     }
 
@@ -9547,7 +9547,7 @@ static VulkanCommandBuffer *VULKAN_INTERNAL_GetInactiveCommandBufferFromPool(
 {
     VulkanCommandPool *commandPool =
         VULKAN_INTERNAL_FetchCommandPool(renderer, threadID);
-    VulkanCommandBuffer *commandBuffer;
+    VulkanCommandBuffer *command_buffer;
 
     if (commandPool == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to fetch command pool!");
@@ -9561,10 +9561,10 @@ static VulkanCommandBuffer *VULKAN_INTERNAL_GetInactiveCommandBufferFromPool(
             commandPool->inactiveCommandBufferCapacity);
     }
 
-    commandBuffer = commandPool->inactiveCommandBuffers[commandPool->inactiveCommandBufferCount - 1];
+    command_buffer = commandPool->inactiveCommandBuffers[commandPool->inactiveCommandBufferCount - 1];
     commandPool->inactiveCommandBufferCount -= 1;
 
-    return commandBuffer;
+    return command_buffer;
 }
 
 static SDL_GPUCommandBuffer *VULKAN_AcquireCommandBuffer(
@@ -9578,87 +9578,87 @@ static SDL_GPUCommandBuffer *VULKAN_AcquireCommandBuffer(
 
     SDL_LockMutex(renderer->acquireCommandBufferLock);
 
-    VulkanCommandBuffer *commandBuffer =
+    VulkanCommandBuffer *command_buffer =
         VULKAN_INTERNAL_GetInactiveCommandBufferFromPool(renderer, threadID);
 
     SDL_UnlockMutex(renderer->acquireCommandBufferLock);
 
-    if (commandBuffer == NULL) {
+    if (command_buffer == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to acquire command buffer!");
         return NULL;
     }
 
     // Reset state
 
-    commandBuffer->currentComputePipeline = NULL;
-    commandBuffer->currentGraphicsPipeline = NULL;
+    command_buffer->currentComputePipeline = NULL;
+    command_buffer->currentGraphicsPipeline = NULL;
 
     for (i = 0; i < MAX_COLOR_TARGET_BINDINGS; i += 1) {
-        commandBuffer->colorAttachmentSubresources[i] = NULL;
+        command_buffer->colorAttachmentSubresources[i] = NULL;
     }
 
     for (i = 0; i < MAX_UNIFORM_BUFFERS_PER_STAGE; i += 1) {
-        commandBuffer->vertexUniformBuffers[i] = NULL;
-        commandBuffer->fragmentUniformBuffers[i] = NULL;
-        commandBuffer->computeUniformBuffers[i] = NULL;
+        command_buffer->vertexUniformBuffers[i] = NULL;
+        command_buffer->fragmentUniformBuffers[i] = NULL;
+        command_buffer->computeUniformBuffers[i] = NULL;
     }
 
-    commandBuffer->depthStencilAttachmentSubresource = NULL;
+    command_buffer->depthStencilAttachmentSubresource = NULL;
 
-    commandBuffer->needNewVertexResourceDescriptorSet = true;
-    commandBuffer->needNewVertexUniformDescriptorSet = true;
-    commandBuffer->needNewVertexUniformOffsets = true;
-    commandBuffer->needNewFragmentResourceDescriptorSet = true;
-    commandBuffer->needNewFragmentUniformDescriptorSet = true;
-    commandBuffer->needNewFragmentUniformOffsets = true;
+    command_buffer->needNewVertexResourceDescriptorSet = true;
+    command_buffer->needNewVertexUniformDescriptorSet = true;
+    command_buffer->needNewVertexUniformOffsets = true;
+    command_buffer->needNewFragmentResourceDescriptorSet = true;
+    command_buffer->needNewFragmentUniformDescriptorSet = true;
+    command_buffer->needNewFragmentUniformOffsets = true;
 
-    commandBuffer->needNewComputeReadOnlyDescriptorSet = true;
-    commandBuffer->needNewComputeUniformDescriptorSet = true;
-    commandBuffer->needNewComputeUniformOffsets = true;
+    command_buffer->needNewComputeReadOnlyDescriptorSet = true;
+    command_buffer->needNewComputeUniformDescriptorSet = true;
+    command_buffer->needNewComputeUniformOffsets = true;
 
-    commandBuffer->vertexResourceDescriptorSet = VK_NULL_HANDLE;
-    commandBuffer->vertexUniformDescriptorSet = VK_NULL_HANDLE;
-    commandBuffer->fragmentResourceDescriptorSet = VK_NULL_HANDLE;
-    commandBuffer->fragmentUniformDescriptorSet = VK_NULL_HANDLE;
+    command_buffer->vertexResourceDescriptorSet = VK_NULL_HANDLE;
+    command_buffer->vertexUniformDescriptorSet = VK_NULL_HANDLE;
+    command_buffer->fragmentResourceDescriptorSet = VK_NULL_HANDLE;
+    command_buffer->fragmentUniformDescriptorSet = VK_NULL_HANDLE;
 
-    commandBuffer->computeReadOnlyDescriptorSet = VK_NULL_HANDLE;
-    commandBuffer->computeWriteOnlyDescriptorSet = VK_NULL_HANDLE;
-    commandBuffer->computeUniformDescriptorSet = VK_NULL_HANDLE;
+    command_buffer->computeReadOnlyDescriptorSet = VK_NULL_HANDLE;
+    command_buffer->computeWriteOnlyDescriptorSet = VK_NULL_HANDLE;
+    command_buffer->computeUniformDescriptorSet = VK_NULL_HANDLE;
 
-    SDL_zeroa(commandBuffer->vertexSamplerTextures);
-    SDL_zeroa(commandBuffer->vertexSamplers);
-    SDL_zeroa(commandBuffer->vertexStorageTextures);
-    SDL_zeroa(commandBuffer->vertexStorageBuffers);
+    SDL_zeroa(command_buffer->vertexSamplerTextures);
+    SDL_zeroa(command_buffer->vertexSamplers);
+    SDL_zeroa(command_buffer->vertexStorageTextures);
+    SDL_zeroa(command_buffer->vertexStorageBuffers);
 
-    SDL_zeroa(commandBuffer->fragmentSamplerTextures);
-    SDL_zeroa(commandBuffer->fragmentSamplers);
-    SDL_zeroa(commandBuffer->fragmentStorageTextures);
-    SDL_zeroa(commandBuffer->fragmentStorageBuffers);
+    SDL_zeroa(command_buffer->fragmentSamplerTextures);
+    SDL_zeroa(command_buffer->fragmentSamplers);
+    SDL_zeroa(command_buffer->fragmentStorageTextures);
+    SDL_zeroa(command_buffer->fragmentStorageBuffers);
 
-    SDL_zeroa(commandBuffer->writeOnlyComputeStorageTextureSubresources);
-    commandBuffer->writeOnlyComputeStorageTextureSubresourceCount = 0;
-    SDL_zeroa(commandBuffer->writeOnlyComputeStorageBuffers);
-    SDL_zeroa(commandBuffer->readOnlyComputeStorageTextures);
-    SDL_zeroa(commandBuffer->readOnlyComputeStorageBuffers);
+    SDL_zeroa(command_buffer->writeOnlyComputeStorageTextureSubresources);
+    command_buffer->writeOnlyComputeStorageTextureSubresourceCount = 0;
+    SDL_zeroa(command_buffer->writeOnlyComputeStorageBuffers);
+    SDL_zeroa(command_buffer->readOnlyComputeStorageTextures);
+    SDL_zeroa(command_buffer->readOnlyComputeStorageBuffers);
 
-    commandBuffer->autoReleaseFence = 1;
+    command_buffer->autoReleaseFence = 1;
 
-    commandBuffer->isDefrag = 0;
+    command_buffer->isDefrag = 0;
 
     /* Reset the command buffer here to avoid resets being called
      * from a separate thread than where the command buffer was acquired
      */
     result = renderer->vkResetCommandBuffer(
-        commandBuffer->commandBuffer,
+        command_buffer->command_buffer,
         VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT);
 
     if (result != VK_SUCCESS) {
         LogVulkanResultAsError("vkResetCommandBuffer", result);
     }
 
-    VULKAN_INTERNAL_BeginCommandBuffer(renderer, commandBuffer);
+    VULKAN_INTERNAL_BeginCommandBuffer(renderer, command_buffer);
 
-    return (SDL_GPUCommandBuffer *)commandBuffer;
+    return (SDL_GPUCommandBuffer *)command_buffer;
 }
 
 static bool VULKAN_QueryFence(
@@ -9734,7 +9734,7 @@ static SDL_bool VULKAN_INTERNAL_OnWindowResize(void *userdata, SDL_Event *e)
 static bool VULKAN_SupportsSwapchainComposition(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchainComposition)
+    SDL_GPUSwapchainComposition swapchain_composition)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
     WindowData *windowData = VULKAN_INTERNAL_FetchWindowData(window);
@@ -9756,16 +9756,16 @@ static bool VULKAN_SupportsSwapchainComposition(
             &supportDetails)) {
 
         result = VULKAN_INTERNAL_VerifySwapSurfaceFormat(
-            SwapchainCompositionToFormat[swapchainComposition],
-            SwapchainCompositionToColorSpace[swapchainComposition],
+            SwapchainCompositionToFormat[swapchain_composition],
+            SwapchainCompositionToColorSpace[swapchain_composition],
             supportDetails.formats,
             supportDetails.formatsLength);
 
         if (!result) {
             // Let's try again with the fallback format...
             result = VULKAN_INTERNAL_VerifySwapSurfaceFormat(
-                SwapchainCompositionToFallbackFormat[swapchainComposition],
-                SwapchainCompositionToColorSpace[swapchainComposition],
+                SwapchainCompositionToFallbackFormat[swapchain_composition],
+                SwapchainCompositionToColorSpace[swapchain_composition],
                 supportDetails.formats,
                 supportDetails.formatsLength);
         }
@@ -9780,7 +9780,7 @@ static bool VULKAN_SupportsSwapchainComposition(
 static bool VULKAN_SupportsPresentMode(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUPresentMode presentMode)
+    SDL_GPUPresentMode present_mode)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
     WindowData *windowData = VULKAN_INTERNAL_FetchWindowData(window);
@@ -9802,7 +9802,7 @@ static bool VULKAN_SupportsPresentMode(
             &supportDetails)) {
 
         result = VULKAN_INTERNAL_VerifySwapPresentMode(
-            SDLToVK_PresentMode[presentMode],
+            SDLToVK_PresentMode[present_mode],
             supportDetails.presentModes,
             supportDetails.presentModesLength);
 
@@ -9823,8 +9823,8 @@ static bool VULKAN_ClaimWindow(
     if (windowData == NULL) {
         windowData = SDL_malloc(sizeof(WindowData));
         windowData->window = window;
-        windowData->presentMode = SDL_GPU_PRESENTMODE_VSYNC;
-        windowData->swapchainComposition = SDL_GPU_SWAPCHAINCOMPOSITION_SDR;
+        windowData->present_mode = SDL_GPU_PRESENTMODE_VSYNC;
+        windowData->swapchain_composition = SDL_GPU_SWAPCHAINCOMPOSITION_SDR;
 
         if (VULKAN_INTERNAL_CreateSwapchain(renderer, windowData)) {
             SDL_SetPointerProperty(SDL_GetWindowProperties(window), WINDOW_PROPERTY_DATA, windowData);
@@ -9918,12 +9918,12 @@ static bool VULKAN_INTERNAL_RecreateSwapchain(
 }
 
 static SDL_GPUTexture *VULKAN_AcquireSwapchainTexture(
-    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUCommandBuffer *command_buffer,
     SDL_Window *window,
-    Uint32 *pWidth,
-    Uint32 *pHeight)
+    Uint32 *w,
+    Uint32 *h)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     Uint32 swapchainImageIndex;
     WindowData *windowData;
@@ -9957,7 +9957,7 @@ static SDL_GPUTexture *VULKAN_AcquireSwapchainTexture(
     }
 
     if (swapchainData->inFlightFences[swapchainData->frameCounter] != NULL) {
-        if (swapchainData->presentMode == VK_PRESENT_MODE_FIFO_KHR) {
+        if (swapchainData->present_mode == VK_PRESENT_MODE_FIFO_KHR) {
             // In VSYNC mode, block until the least recent presented frame is done
             VULKAN_WaitForFences(
                 (SDL_GPURenderer *)renderer,
@@ -10048,7 +10048,7 @@ static SDL_GPUTexture *VULKAN_AcquireSwapchainTexture(
     imageBarrier.subresourceRange.layerCount = 1;
 
     renderer->vkCmdPipelineBarrier(
-        vulkanCommandBuffer->commandBuffer,
+        vulkanCommandBuffer->command_buffer,
         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
         VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
         0,
@@ -10098,8 +10098,8 @@ static SDL_GPUTexture *VULKAN_AcquireSwapchainTexture(
         swapchainData->renderFinishedSemaphore[swapchainData->frameCounter];
     vulkanCommandBuffer->signalSemaphoreCount += 1;
 
-    *pWidth = swapchainData->textureContainers[swapchainData->frameCounter].header.info.width;
-    *pHeight = swapchainData->textureContainers[swapchainData->frameCounter].header.info.height;
+    *w = swapchainData->textureContainers[swapchainData->frameCounter].header.info.width;
+    *h = swapchainData->textureContainers[swapchainData->frameCounter].header.info.height;
 
     return (SDL_GPUTexture *)swapchainTextureContainer;
 }
@@ -10121,15 +10121,15 @@ static SDL_GPUTextureFormat VULKAN_GetSwapchainTextureFormat(
     }
 
     return SwapchainCompositionToSDLFormat(
-        windowData->swapchainComposition,
+        windowData->swapchain_composition,
         windowData->swapchainData->usingFallbackFormat);
 }
 
 static bool VULKAN_SetSwapchainParameters(
     SDL_GPURenderer *driverData,
     SDL_Window *window,
-    SDL_GPUSwapchainComposition swapchainComposition,
-    SDL_GPUPresentMode presentMode)
+    SDL_GPUSwapchainComposition swapchain_composition,
+    SDL_GPUPresentMode present_mode)
 {
     WindowData *windowData = VULKAN_INTERNAL_FetchWindowData(window);
 
@@ -10138,18 +10138,18 @@ static bool VULKAN_SetSwapchainParameters(
         return false;
     }
 
-    if (!VULKAN_SupportsSwapchainComposition(driverData, window, swapchainComposition)) {
+    if (!VULKAN_SupportsSwapchainComposition(driverData, window, swapchain_composition)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Swapchain composition not supported!");
         return false;
     }
 
-    if (!VULKAN_SupportsPresentMode(driverData, window, presentMode)) {
+    if (!VULKAN_SupportsPresentMode(driverData, window, present_mode)) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Present mode not supported!");
         return false;
     }
 
-    windowData->presentMode = presentMode;
-    windowData->swapchainComposition = swapchainComposition;
+    windowData->present_mode = present_mode;
+    windowData->swapchain_composition = swapchain_composition;
 
     return VULKAN_INTERNAL_RecreateSwapchain(
         (VulkanRenderer *)driverData,
@@ -10295,23 +10295,23 @@ static void VULKAN_INTERNAL_PerformPendingDestroys(
 
 static void VULKAN_INTERNAL_CleanCommandBuffer(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *commandBuffer)
+    VulkanCommandBuffer *command_buffer)
 {
     Uint32 i;
     DescriptorSetData *descriptorSetData;
 
-    if (commandBuffer->autoReleaseFence) {
+    if (command_buffer->autoReleaseFence) {
         VULKAN_ReleaseFence(
             (SDL_GPURenderer *)renderer,
-            (SDL_GPUFence *)commandBuffer->inFlightFence);
+            (SDL_GPUFence *)command_buffer->inFlightFence);
 
-        commandBuffer->inFlightFence = NULL;
+        command_buffer->inFlightFence = NULL;
     }
 
     // Bound descriptor sets are now available
 
-    for (i = 0; i < commandBuffer->boundDescriptorSetDataCount; i += 1) {
-        descriptorSetData = &commandBuffer->boundDescriptorSetDatas[i];
+    for (i = 0; i < command_buffer->boundDescriptorSetDataCount; i += 1) {
+        descriptorSetData = &command_buffer->boundDescriptorSetDatas[i];
 
         SDL_LockMutex(descriptorSetData->descriptorSetPool->lock);
 
@@ -10328,62 +10328,62 @@ static void VULKAN_INTERNAL_CleanCommandBuffer(
         SDL_UnlockMutex(descriptorSetData->descriptorSetPool->lock);
     }
 
-    commandBuffer->boundDescriptorSetDataCount = 0;
+    command_buffer->boundDescriptorSetDataCount = 0;
 
     // Uniform buffers are now available
 
     SDL_LockMutex(renderer->acquireUniformBufferLock);
 
-    for (i = 0; i < commandBuffer->usedUniformBufferCount; i += 1) {
+    for (i = 0; i < command_buffer->usedUniformBufferCount; i += 1) {
         VULKAN_INTERNAL_ReturnUniformBufferToPool(
             renderer,
-            commandBuffer->usedUniformBuffers[i]);
+            command_buffer->usedUniformBuffers[i]);
     }
-    commandBuffer->usedUniformBufferCount = 0;
+    command_buffer->usedUniformBufferCount = 0;
 
     SDL_UnlockMutex(renderer->acquireUniformBufferLock);
 
     // Decrement reference counts
 
-    for (i = 0; i < commandBuffer->usedBufferCount; i += 1) {
-        (void)SDL_AtomicDecRef(&commandBuffer->usedBuffers[i]->referenceCount);
+    for (i = 0; i < command_buffer->usedBufferCount; i += 1) {
+        (void)SDL_AtomicDecRef(&command_buffer->usedBuffers[i]->referenceCount);
     }
-    commandBuffer->usedBufferCount = 0;
+    command_buffer->usedBufferCount = 0;
 
-    for (i = 0; i < commandBuffer->usedTextureCount; i += 1) {
-        (void)SDL_AtomicDecRef(&commandBuffer->usedTextures[i]->referenceCount);
+    for (i = 0; i < command_buffer->usedTextureCount; i += 1) {
+        (void)SDL_AtomicDecRef(&command_buffer->usedTextures[i]->referenceCount);
     }
-    commandBuffer->usedTextureCount = 0;
+    command_buffer->usedTextureCount = 0;
 
-    for (i = 0; i < commandBuffer->usedSamplerCount; i += 1) {
-        (void)SDL_AtomicDecRef(&commandBuffer->usedSamplers[i]->referenceCount);
+    for (i = 0; i < command_buffer->usedSamplerCount; i += 1) {
+        (void)SDL_AtomicDecRef(&command_buffer->usedSamplers[i]->referenceCount);
     }
-    commandBuffer->usedSamplerCount = 0;
+    command_buffer->usedSamplerCount = 0;
 
-    for (i = 0; i < commandBuffer->usedGraphicsPipelineCount; i += 1) {
-        (void)SDL_AtomicDecRef(&commandBuffer->usedGraphicsPipelines[i]->referenceCount);
+    for (i = 0; i < command_buffer->usedGraphicsPipelineCount; i += 1) {
+        (void)SDL_AtomicDecRef(&command_buffer->usedGraphicsPipelines[i]->referenceCount);
     }
-    commandBuffer->usedGraphicsPipelineCount = 0;
+    command_buffer->usedGraphicsPipelineCount = 0;
 
-    for (i = 0; i < commandBuffer->usedComputePipelineCount; i += 1) {
-        (void)SDL_AtomicDecRef(&commandBuffer->usedComputePipelines[i]->referenceCount);
+    for (i = 0; i < command_buffer->usedComputePipelineCount; i += 1) {
+        (void)SDL_AtomicDecRef(&command_buffer->usedComputePipelines[i]->referenceCount);
     }
-    commandBuffer->usedComputePipelineCount = 0;
+    command_buffer->usedComputePipelineCount = 0;
 
-    for (i = 0; i < commandBuffer->usedFramebufferCount; i += 1) {
-        (void)SDL_AtomicDecRef(&commandBuffer->usedFramebuffers[i]->referenceCount);
+    for (i = 0; i < command_buffer->usedFramebufferCount; i += 1) {
+        (void)SDL_AtomicDecRef(&command_buffer->usedFramebuffers[i]->referenceCount);
     }
-    commandBuffer->usedFramebufferCount = 0;
+    command_buffer->usedFramebufferCount = 0;
 
     // Reset presentation data
 
-    commandBuffer->presentDataCount = 0;
-    commandBuffer->waitSemaphoreCount = 0;
-    commandBuffer->signalSemaphoreCount = 0;
+    command_buffer->presentDataCount = 0;
+    command_buffer->waitSemaphoreCount = 0;
+    command_buffer->signalSemaphoreCount = 0;
 
     // Reset defrag state
 
-    if (commandBuffer->isDefrag) {
+    if (command_buffer->isDefrag) {
         renderer->defragInProgress = 0;
     }
 
@@ -10391,21 +10391,21 @@ static void VULKAN_INTERNAL_CleanCommandBuffer(
 
     SDL_LockMutex(renderer->acquireCommandBufferLock);
 
-    if (commandBuffer->commandPool->inactiveCommandBufferCount == commandBuffer->commandPool->inactiveCommandBufferCapacity) {
-        commandBuffer->commandPool->inactiveCommandBufferCapacity += 1;
-        commandBuffer->commandPool->inactiveCommandBuffers = SDL_realloc(
-            commandBuffer->commandPool->inactiveCommandBuffers,
-            commandBuffer->commandPool->inactiveCommandBufferCapacity * sizeof(VulkanCommandBuffer *));
+    if (command_buffer->commandPool->inactiveCommandBufferCount == command_buffer->commandPool->inactiveCommandBufferCapacity) {
+        command_buffer->commandPool->inactiveCommandBufferCapacity += 1;
+        command_buffer->commandPool->inactiveCommandBuffers = SDL_realloc(
+            command_buffer->commandPool->inactiveCommandBuffers,
+            command_buffer->commandPool->inactiveCommandBufferCapacity * sizeof(VulkanCommandBuffer *));
     }
 
-    commandBuffer->commandPool->inactiveCommandBuffers[commandBuffer->commandPool->inactiveCommandBufferCount] = commandBuffer;
-    commandBuffer->commandPool->inactiveCommandBufferCount += 1;
+    command_buffer->commandPool->inactiveCommandBuffers[command_buffer->commandPool->inactiveCommandBufferCount] = command_buffer;
+    command_buffer->commandPool->inactiveCommandBufferCount += 1;
 
     SDL_UnlockMutex(renderer->acquireCommandBufferLock);
 
     // Remove this command buffer from the submitted list
     for (i = 0; i < renderer->submittedCommandBufferCount; i += 1) {
-        if (renderer->submittedCommandBuffers[i] == commandBuffer) {
+        if (renderer->submittedCommandBuffers[i] == command_buffer) {
             renderer->submittedCommandBuffers[i] = renderer->submittedCommandBuffers[renderer->submittedCommandBufferCount - 1];
             renderer->submittedCommandBufferCount -= 1;
         }
@@ -10414,30 +10414,30 @@ static void VULKAN_INTERNAL_CleanCommandBuffer(
 
 static void VULKAN_WaitForFences(
     SDL_GPURenderer *driverData,
-    bool waitAll,
-    SDL_GPUFence *const *pFences,
-    Uint32 fenceCount)
+    bool wait_all,
+    SDL_GPUFence *const *fences,
+    Uint32 num_fences)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    VkFence *fences = SDL_stack_alloc(VkFence, fenceCount);
+    VkFence *vkFences = SDL_stack_alloc(VkFence, num_fences);
     VkResult result;
 
-    for (Uint32 i = 0; i < fenceCount; i += 1) {
-        fences[i] = ((VulkanFenceHandle *)pFences[i])->fence;
+    for (Uint32 i = 0; i < num_fences; i += 1) {
+        vkFences[i] = ((VulkanFenceHandle *)fences[i])->fence;
     }
 
     result = renderer->vkWaitForFences(
         renderer->logicalDevice,
-        fenceCount,
-        fences,
-        waitAll,
+        num_fences,
+        vkFences,
+        wait_all,
         UINT64_MAX);
 
     if (result != VK_SUCCESS) {
         LogVulkanResultAsError("vkWaitForFences", result);
     }
 
-    SDL_stack_free(fences);
+    SDL_stack_free(vkFences);
 
     SDL_LockMutex(renderer->submitLock);
 
@@ -10462,7 +10462,7 @@ static void VULKAN_Wait(
     SDL_GPURenderer *driverData)
 {
     VulkanRenderer *renderer = (VulkanRenderer *)driverData;
-    VulkanCommandBuffer *commandBuffer;
+    VulkanCommandBuffer *command_buffer;
     VkResult result;
     Sint32 i;
 
@@ -10476,8 +10476,8 @@ static void VULKAN_Wait(
     SDL_LockMutex(renderer->submitLock);
 
     for (i = renderer->submittedCommandBufferCount - 1; i >= 0; i -= 1) {
-        commandBuffer = renderer->submittedCommandBuffers[i];
-        VULKAN_INTERNAL_CleanCommandBuffer(renderer, commandBuffer);
+        command_buffer = renderer->submittedCommandBuffers[i];
+        VULKAN_INTERNAL_CleanCommandBuffer(renderer, command_buffer);
     }
 
     VULKAN_INTERNAL_PerformPendingDestroys(renderer);
@@ -10486,22 +10486,22 @@ static void VULKAN_Wait(
 }
 
 static SDL_GPUFence *VULKAN_SubmitAndAcquireFence(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
     VulkanCommandBuffer *vulkanCommandBuffer;
 
-    vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     vulkanCommandBuffer->autoReleaseFence = 0;
 
-    VULKAN_Submit(commandBuffer);
+    VULKAN_Submit(command_buffer);
 
     return (SDL_GPUFence *)vulkanCommandBuffer->inFlightFence;
 }
 
 static void VULKAN_Submit(
-    SDL_GPUCommandBuffer *commandBuffer)
+    SDL_GPUCommandBuffer *command_buffer)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)command_buffer;
     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
     VkSubmitInfo submitInfo;
     VkPresentInfoKHR presentInfo;
@@ -10545,7 +10545,7 @@ static void VULKAN_Submit(
     submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
     submitInfo.pNext = NULL;
     submitInfo.commandBufferCount = 1;
-    submitInfo.pCommandBuffers = &vulkanCommandBuffer->commandBuffer;
+    submitInfo.pCommandBuffers = &vulkanCommandBuffer->command_buffer;
 
     submitInfo.pWaitDstStageMask = waitStages;
     submitInfo.pWaitSemaphores = vulkanCommandBuffer->waitSemaphores;
@@ -10670,7 +10670,7 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
     VulkanTexture *newTexture;
     VkBufferCopy bufferCopy;
     VkImageCopy imageCopy;
-    VulkanCommandBuffer *commandBuffer;
+    VulkanCommandBuffer *command_buffer;
     VulkanTextureSubresource *srcSubresource;
     VulkanTextureSubresource *dstSubresource;
     Uint32 i, subresourceIndex;
@@ -10679,12 +10679,12 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
 
     renderer->defragInProgress = 1;
 
-    commandBuffer = (VulkanCommandBuffer *)VULKAN_AcquireCommandBuffer((SDL_GPURenderer *)renderer);
-    if (commandBuffer == NULL) {
+    command_buffer = (VulkanCommandBuffer *)VULKAN_AcquireCommandBuffer((SDL_GPURenderer *)renderer);
+    if (command_buffer == NULL) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to create defrag command buffer!");
         return 0;
     }
-    commandBuffer->isDefrag = 1;
+    command_buffer->isDefrag = 1;
 
     allocation = renderer->allocationsToDefrag[renderer->allocationsToDefragCount - 1];
     renderer->allocationsToDefragCount -= 1;
@@ -10697,12 +10697,12 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
         currentRegion = allocation->usedRegions[i];
 
         if (currentRegion->isBuffer && !currentRegion->vulkanBuffer->markedForDestroy) {
-            currentRegion->vulkanBuffer->usageFlags |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+            currentRegion->vulkanBuffer->usage_flags |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
 
             newBuffer = VULKAN_INTERNAL_CreateBuffer(
                 renderer,
                 currentRegion->vulkanBuffer->size,
-                currentRegion->vulkanBuffer->usageFlags,
+                currentRegion->vulkanBuffer->usage_flags,
                 currentRegion->vulkanBuffer->type);
 
             if (newBuffer == NULL) {
@@ -10711,7 +10711,7 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
             }
 
             if (
-                renderer->debugMode &&
+                renderer->debug_mode &&
                 renderer->supportsDebugUtils &&
                 currentRegion->vulkanBuffer->handle != NULL &&
                 currentRegion->vulkanBuffer->handle->container != NULL &&
@@ -10727,13 +10727,13 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
                 currentRegion->vulkanBuffer->type == VULKAN_BUFFER_TYPE_GPU && currentRegion->vulkanBuffer->transitioned) {
                 VULKAN_INTERNAL_BufferTransitionFromDefaultUsage(
                     renderer,
-                    commandBuffer,
+                    command_buffer,
                     VULKAN_BUFFER_USAGE_MODE_COPY_SOURCE,
                     currentRegion->vulkanBuffer);
 
                 VULKAN_INTERNAL_BufferTransitionFromDefaultUsage(
                     renderer,
-                    commandBuffer,
+                    command_buffer,
                     VULKAN_BUFFER_USAGE_MODE_COPY_DESTINATION,
                     newBuffer);
 
@@ -10742,7 +10742,7 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
                 bufferCopy.size = currentRegion->resourceSize;
 
                 renderer->vkCmdCopyBuffer(
-                    commandBuffer->commandBuffer,
+                    command_buffer->command_buffer,
                     currentRegion->vulkanBuffer->buffer,
                     newBuffer->buffer,
                     1,
@@ -10750,12 +10750,12 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
 
                 VULKAN_INTERNAL_BufferTransitionToDefaultUsage(
                     renderer,
-                    commandBuffer,
+                    command_buffer,
                     VULKAN_BUFFER_USAGE_MODE_COPY_DESTINATION,
                     newBuffer);
 
-                VULKAN_INTERNAL_TrackBuffer(commandBuffer, currentRegion->vulkanBuffer);
-                VULKAN_INTERNAL_TrackBuffer(commandBuffer, newBuffer);
+                VULKAN_INTERNAL_TrackBuffer(command_buffer, currentRegion->vulkanBuffer);
+                VULKAN_INTERNAL_TrackBuffer(command_buffer, newBuffer);
             }
 
             // re-point original container to new buffer
@@ -10774,12 +10774,12 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
                 currentRegion->vulkanTexture->depth,
                 currentRegion->vulkanTexture->type,
                 currentRegion->vulkanTexture->layerCount,
-                currentRegion->vulkanTexture->levelCount,
-                currentRegion->vulkanTexture->sampleCount,
+                currentRegion->vulkanTexture->num_levels,
+                currentRegion->vulkanTexture->sample_count,
                 currentRegion->vulkanTexture->format,
                 currentRegion->vulkanTexture->swizzle,
                 currentRegion->vulkanTexture->aspectFlags,
-                currentRegion->vulkanTexture->usageFlags,
+                currentRegion->vulkanTexture->usage_flags,
                 currentRegion->vulkanTexture->isMSAAColorTarget);
 
             if (newTexture == NULL) {
@@ -10794,7 +10794,7 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
 
                 // Set debug name if it exists
                 if (
-                    renderer->debugMode &&
+                    renderer->debug_mode &&
                     renderer->supportsDebugUtils &&
                     srcSubresource->parent->handle != NULL &&
                     srcSubresource->parent->handle->container != NULL &&
@@ -10808,13 +10808,13 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
                 if (srcSubresource->transitioned) {
                     VULKAN_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
                         renderer,
-                        commandBuffer,
+                        command_buffer,
                         VULKAN_TEXTURE_USAGE_MODE_COPY_SOURCE,
                         srcSubresource);
 
                     VULKAN_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
                         renderer,
-                        commandBuffer,
+                        command_buffer,
                         VULKAN_TEXTURE_USAGE_MODE_COPY_DESTINATION,
                         dstSubresource);
 
@@ -10837,7 +10837,7 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
                     imageCopy.dstSubresource.mipLevel = dstSubresource->level;
 
                     renderer->vkCmdCopyImage(
-                        commandBuffer->commandBuffer,
+                        command_buffer->command_buffer,
                         currentRegion->vulkanTexture->image,
                         VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                         newTexture->image,
@@ -10847,12 +10847,12 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
 
                     VULKAN_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
                         renderer,
-                        commandBuffer,
+                        command_buffer,
                         VULKAN_TEXTURE_USAGE_MODE_COPY_DESTINATION,
                         dstSubresource);
 
-                    VULKAN_INTERNAL_TrackTexture(commandBuffer, srcSubresource->parent);
-                    VULKAN_INTERNAL_TrackTexture(commandBuffer, dstSubresource->parent);
+                    VULKAN_INTERNAL_TrackTexture(command_buffer, srcSubresource->parent);
+                    VULKAN_INTERNAL_TrackTexture(command_buffer, dstSubresource->parent);
                 }
             }
 
@@ -10868,7 +10868,7 @@ static Uint8 VULKAN_INTERNAL_DefragmentMemory(
     SDL_UnlockMutex(renderer->allocatorLock);
 
     VULKAN_Submit(
-        (SDL_GPUCommandBuffer *)commandBuffer);
+        (SDL_GPUCommandBuffer *)command_buffer);
 
     return 1;
 }
@@ -11185,7 +11185,7 @@ static Uint8 VULKAN_INTERNAL_CreateInstance(VulkanRenderer *renderer)
     createInfo.ppEnabledLayerNames = layerNames;
     createInfo.enabledExtensionCount = instanceExtensionCount;
     createInfo.ppEnabledExtensionNames = instanceExtensionNames;
-    if (renderer->debugMode) {
+    if (renderer->debug_mode) {
         createInfo.enabledLayerCount = SDL_arraysize(layerNames);
         if (!VULKAN_INTERNAL_CheckValidationLayers(
                 layerNames,
@@ -11650,7 +11650,7 @@ static bool VULKAN_PrepareDriver(SDL_VideoDevice *_this)
     return result;
 }
 
-static SDL_GPUDevice *VULKAN_CreateDevice(bool debugMode, bool preferLowPower, SDL_PropertiesID props)
+static SDL_GPUDevice *VULKAN_CreateDevice(bool debug_mode, bool preferLowPower, SDL_PropertiesID props)
 {
     VulkanRenderer *renderer;
 
@@ -11668,7 +11668,7 @@ static SDL_GPUDevice *VULKAN_CreateDevice(bool debugMode, bool preferLowPower, S
 
     renderer = (VulkanRenderer *)SDL_malloc(sizeof(VulkanRenderer));
     SDL_memset(renderer, '\0', sizeof(VulkanRenderer));
-    renderer->debugMode = debugMode;
+    renderer->debug_mode = debug_mode;
     renderer->preferLowPower = preferLowPower;
 
     if (!VULKAN_INTERNAL_PrepareVulkan(renderer)) {

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -2381,42 +2381,42 @@ static Uint8 VULKAN_INTERNAL_BindMemoryForBuffer(
 #define ADD_TO_ARRAY_UNIQUE(resource, type, array, count, capacity) \
     Uint32 i;                                                       \
                                                                     \
-    for (i = 0; i < command_buffer->count; i += 1) {                 \
-        if (command_buffer->array[i] == resource) {                  \
+    for (i = 0; i < commandBuffer->count; i += 1) {                 \
+        if (commandBuffer->array[i] == resource) {                  \
             return;                                                 \
         }                                                           \
     }                                                               \
                                                                     \
-    if (command_buffer->count == command_buffer->capacity) {          \
-        command_buffer->capacity += 1;                               \
-        command_buffer->array = SDL_realloc(                         \
-            command_buffer->array,                                   \
-            command_buffer->capacity * sizeof(type));                \
+    if (commandBuffer->count == commandBuffer->capacity) {          \
+        commandBuffer->capacity += 1;                               \
+        commandBuffer->array = SDL_realloc(                         \
+            commandBuffer->array,                                   \
+            commandBuffer->capacity * sizeof(type));                \
     }                                                               \
-    command_buffer->array[command_buffer->count] = resource;          \
-    command_buffer->count += 1;
+    commandBuffer->array[commandBuffer->count] = resource;          \
+    commandBuffer->count += 1;
 
 #define TRACK_RESOURCE(resource, type, array, count, capacity) \
     Uint32 i;                                                  \
                                                                \
-    for (i = 0; i < command_buffer->count; i += 1) {            \
-        if (command_buffer->array[i] == resource) {             \
+    for (i = 0; i < commandBuffer->count; i += 1) {            \
+        if (commandBuffer->array[i] == resource) {             \
             return;                                            \
         }                                                      \
     }                                                          \
                                                                \
-    if (command_buffer->count == command_buffer->capacity) {     \
-        command_buffer->capacity += 1;                          \
-        command_buffer->array = SDL_realloc(                    \
-            command_buffer->array,                              \
-            command_buffer->capacity * sizeof(type));           \
+    if (commandBuffer->count == commandBuffer->capacity) {     \
+        commandBuffer->capacity += 1;                          \
+        commandBuffer->array = SDL_realloc(                    \
+            commandBuffer->array,                              \
+            commandBuffer->capacity * sizeof(type));           \
     }                                                          \
-    command_buffer->array[command_buffer->count] = resource;     \
-    command_buffer->count += 1;                                 \
+    commandBuffer->array[commandBuffer->count] = resource;     \
+    commandBuffer->count += 1;                                 \
     SDL_AtomicIncRef(&resource->referenceCount);
 
 static void VULKAN_INTERNAL_TrackBuffer(
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanBuffer *buffer)
 {
     TRACK_RESOURCE(
@@ -2428,7 +2428,7 @@ static void VULKAN_INTERNAL_TrackBuffer(
 }
 
 static void VULKAN_INTERNAL_TrackTexture(
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanTexture *texture)
 {
     TRACK_RESOURCE(
@@ -2440,7 +2440,7 @@ static void VULKAN_INTERNAL_TrackTexture(
 }
 
 static void VULKAN_INTERNAL_TrackSampler(
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanSampler *sampler)
 {
     TRACK_RESOURCE(
@@ -2452,7 +2452,7 @@ static void VULKAN_INTERNAL_TrackSampler(
 }
 
 static void VULKAN_INTERNAL_TrackGraphicsPipeline(
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanGraphicsPipeline *graphicsPipeline)
 {
     TRACK_RESOURCE(
@@ -2464,7 +2464,7 @@ static void VULKAN_INTERNAL_TrackGraphicsPipeline(
 }
 
 static void VULKAN_INTERNAL_TrackComputePipeline(
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanComputePipeline *computePipeline)
 {
     TRACK_RESOURCE(
@@ -2477,7 +2477,7 @@ static void VULKAN_INTERNAL_TrackComputePipeline(
 
 static void VULKAN_INTERNAL_TrackFramebuffer(
     VulkanRenderer *renderer,
-    VulkanCommandBuffer *command_buffer,
+    VulkanCommandBuffer *commandBuffer,
     VulkanFramebuffer *framebuffer)
 {
     TRACK_RESOURCE(

--- a/src/render/sdlgpu/SDL_pipeline_gpu.c
+++ b/src/render/sdlgpu/SDL_pipeline_gpu.c
@@ -97,7 +97,7 @@ void GPU_DestroyPipelineCache(GPU_PipelineCache *cache)
 
 static SDL_GPUGraphicsPipeline *MakePipeline(SDL_GPUDevice *device, GPU_Shaders *shaders, const GPU_PipelineParameters *params)
 {
-    SDL_GPUColorAttachmentDescription ad;
+    SDL_GPUColorTargetDescription ad;
     SDL_zero(ad);
     ad.format = params->attachment_format;
 
@@ -113,9 +113,9 @@ static SDL_GPUGraphicsPipeline *MakePipeline(SDL_GPUDevice *device, GPU_Shaders 
 
     SDL_GPUGraphicsPipelineCreateInfo pci;
     SDL_zero(pci);
-    pci.attachment_info.has_depth_stencil_attachment = false;
-    pci.attachment_info.num_color_attachments = 1;
-    pci.attachment_info.color_attachment_descriptions = &ad;
+    pci.target_info.has_depth_stencil_target = false;
+    pci.target_info.num_color_targets = 1;
+    pci.target_info.color_target_descriptions = &ad;
     pci.vertex_shader = GPU_GetVertexShader(shaders, params->vert_shader);
     pci.fragment_shader = GPU_GetFragmentShader(shaders, params->frag_shader);
     pci.multisample_state.sample_count = SDL_GPU_SAMPLECOUNT_1;
@@ -124,7 +124,7 @@ static SDL_GPUGraphicsPipeline *MakePipeline(SDL_GPUDevice *device, GPU_Shaders 
 
     pci.rasterizer_state.cull_mode = SDL_GPU_CULLMODE_NONE;
     pci.rasterizer_state.fill_mode = SDL_GPU_FILLMODE_FILL;
-    pci.rasterizer_state.frontFace = SDL_GPU_FRONTFACE_COUNTER_CLOCKWISE;
+    pci.rasterizer_state.front_face = SDL_GPU_FRONTFACE_COUNTER_CLOCKWISE;
 
     SDL_GPUVertexBinding bind;
     SDL_zero(bind);

--- a/src/render/sdlgpu/SDL_pipeline_gpu.c
+++ b/src/render/sdlgpu/SDL_pipeline_gpu.c
@@ -102,29 +102,29 @@ static SDL_GPUGraphicsPipeline *MakePipeline(SDL_GPUDevice *device, GPU_Shaders 
     ad.format = params->attachment_format;
 
     SDL_BlendMode blend = params->blend_mode;
-    ad.blendState.blendEnable = blend != 0;
-    ad.blendState.colorWriteMask = 0xF;
-    ad.blendState.alphaBlendOp = GPU_ConvertBlendOperation(SDL_GetBlendModeAlphaOperation(blend));
-    ad.blendState.dstAlphaBlendFactor = GPU_ConvertBlendFactor(SDL_GetBlendModeDstAlphaFactor(blend));
-    ad.blendState.srcAlphaBlendFactor = GPU_ConvertBlendFactor(SDL_GetBlendModeSrcAlphaFactor(blend));
-    ad.blendState.colorBlendOp = GPU_ConvertBlendOperation(SDL_GetBlendModeColorOperation(blend));
-    ad.blendState.dstColorBlendFactor = GPU_ConvertBlendFactor(SDL_GetBlendModeDstColorFactor(blend));
-    ad.blendState.srcColorBlendFactor = GPU_ConvertBlendFactor(SDL_GetBlendModeSrcColorFactor(blend));
+    ad.blend_state.enable_blend = blend != 0;
+    ad.blend_state.color_write_mask = 0xF;
+    ad.blend_state.alpha_blend_op = GPU_ConvertBlendOperation(SDL_GetBlendModeAlphaOperation(blend));
+    ad.blend_state.dst_alpha_blendfactor = GPU_ConvertBlendFactor(SDL_GetBlendModeDstAlphaFactor(blend));
+    ad.blend_state.src_alpha_blendfactor = GPU_ConvertBlendFactor(SDL_GetBlendModeSrcAlphaFactor(blend));
+    ad.blend_state.color_blend_op = GPU_ConvertBlendOperation(SDL_GetBlendModeColorOperation(blend));
+    ad.blend_state.dst_color_blendfactor = GPU_ConvertBlendFactor(SDL_GetBlendModeDstColorFactor(blend));
+    ad.blend_state.src_color_blendfactor = GPU_ConvertBlendFactor(SDL_GetBlendModeSrcColorFactor(blend));
 
     SDL_GPUGraphicsPipelineCreateInfo pci;
     SDL_zero(pci);
-    pci.attachmentInfo.hasDepthStencilAttachment = false;
-    pci.attachmentInfo.colorAttachmentCount = 1;
-    pci.attachmentInfo.colorAttachmentDescriptions = &ad;
-    pci.vertexShader = GPU_GetVertexShader(shaders, params->vert_shader);
-    pci.fragmentShader = GPU_GetFragmentShader(shaders, params->frag_shader);
-    pci.multisampleState.sampleCount = SDL_GPU_SAMPLECOUNT_1;
-    pci.multisampleState.sampleMask = 0xFFFF;
-    pci.primitiveType = params->primitive_type;
+    pci.attachment_info.has_depth_stencil_attachment = false;
+    pci.attachment_info.num_color_attachments = 1;
+    pci.attachment_info.color_attachment_descriptions = &ad;
+    pci.vertex_shader = GPU_GetVertexShader(shaders, params->vert_shader);
+    pci.fragment_shader = GPU_GetFragmentShader(shaders, params->frag_shader);
+    pci.multisample_state.sample_count = SDL_GPU_SAMPLECOUNT_1;
+    pci.multisample_state.sample_mask = 0xFFFF;
+    pci.primitive_type = params->primitive_type;
 
-    pci.rasterizerState.cullMode = SDL_GPU_CULLMODE_NONE;
-    pci.rasterizerState.fillMode = SDL_GPU_FILLMODE_FILL;
-    pci.rasterizerState.frontFace = SDL_GPU_FRONTFACE_COUNTER_CLOCKWISE;
+    pci.rasterizer_state.cull_mode = SDL_GPU_CULLMODE_NONE;
+    pci.rasterizer_state.fill_mode = SDL_GPU_FILLMODE_FILL;
+    pci.rasterizer_state.frontFace = SDL_GPU_FRONTFACE_COUNTER_CLOCKWISE;
 
     SDL_GPUVertexBinding bind;
     SDL_zero(bind);
@@ -150,16 +150,16 @@ static SDL_GPUGraphicsPipeline *MakePipeline(SDL_GPUDevice *device, GPU_Shaders 
     // Position
     attribs[num_attribs].location = num_attribs;
     attribs[num_attribs].format = SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2;
-    attribs[num_attribs].offset = bind.stride;
-    bind.stride += 2 * sizeof(float);
+    attribs[num_attribs].offset = bind.pitch;
+    bind.pitch += 2 * sizeof(float);
     num_attribs++;
 
     if (have_attr_color) {
         // Color
         attribs[num_attribs].location = num_attribs;
         attribs[num_attribs].format = SDL_GPU_VERTEXELEMENTFORMAT_FLOAT4;
-        attribs[num_attribs].offset = bind.stride;
-        bind.stride += 4 * sizeof(float);
+        attribs[num_attribs].offset = bind.pitch;
+        bind.pitch += 4 * sizeof(float);
         num_attribs++;
     }
 
@@ -167,15 +167,15 @@ static SDL_GPUGraphicsPipeline *MakePipeline(SDL_GPUDevice *device, GPU_Shaders 
         // UVs
         attribs[num_attribs].location = num_attribs;
         attribs[num_attribs].format = SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2;
-        attribs[num_attribs].offset = bind.stride;
-        bind.stride += 2 * sizeof(float);
+        attribs[num_attribs].offset = bind.pitch;
+        bind.pitch += 2 * sizeof(float);
         num_attribs++;
     }
 
-    pci.vertexInputState.vertexAttributeCount = num_attribs;
-    pci.vertexInputState.vertexAttributes = attribs;
-    pci.vertexInputState.vertexBindingCount = 1;
-    pci.vertexInputState.vertexBindings = &bind;
+    pci.vertex_input_state.num_vertex_attributes = num_attribs;
+    pci.vertex_input_state.vertex_attributes = attribs;
+    pci.vertex_input_state.num_vertex_bindings = 1;
+    pci.vertex_input_state.vertex_bindings = &bind;
 
     return SDL_CreateGPUGraphicsPipeline(device, &pci);
 }

--- a/src/render/sdlgpu/SDL_render_gpu.c
+++ b/src/render/sdlgpu/SDL_render_gpu.c
@@ -69,7 +69,7 @@ typedef struct GPU_RenderData
         SDL_GPURenderPass *render_pass;
         SDL_Texture *render_target;
         SDL_GPUCommandBuffer *command_buffer;
-        SDL_GPUColorAttachmentInfo color_attachment;
+        SDL_GPUColorTargetInfo color_attachment;
         SDL_GPUViewport viewport;
         SDL_Rect scissor;
         SDL_FColor draw_color;
@@ -221,7 +221,7 @@ static bool GPU_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL_
     tci.format = format;
     tci.layer_count_or_depth = 1;
     tci.num_levels = 1;
-    tci.usage_flags = usage;
+    tci.usage = usage;
     tci.width = texture->w;
     tci.height = texture->h;
     tci.sample_count = SDL_GPU_SAMPLECOUNT_1;
@@ -608,7 +608,7 @@ static bool InitVertexBuffer(GPU_RenderData *data, Uint32 size)
     SDL_GPUBufferCreateInfo bci;
     SDL_zero(bci);
     bci.size = size;
-    bci.usage_flags = SDL_GPU_BUFFERUSAGE_VERTEX;
+    bci.usage = SDL_GPU_BUFFERUSAGE_VERTEX;
 
     data->vertices.buffer = SDL_CreateGPUBuffer(data->device, &bci);
 
@@ -938,7 +938,7 @@ static bool CreateBackbuffer(GPU_RenderData *data, Uint32 w, Uint32 h, SDL_GPUTe
     tci.layer_count_or_depth = 1;
     tci.num_levels = 1;
     tci.sample_count = SDL_GPU_SAMPLECOUNT_1;
-    tci.usage_flags = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER;
+    tci.usage = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER;
 
     data->backbuffer.texture = SDL_CreateGPUTexture(data->device, &tci);
     data->backbuffer.width = w;
@@ -1286,8 +1286,8 @@ static bool GPU_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_P
     data->state.draw_color.g = 1.0f;
     data->state.draw_color.b = 1.0f;
     data->state.draw_color.a = 1.0f;
-    data->state.viewport.minDepth = 0;
-    data->state.viewport.maxDepth = 1;
+    data->state.viewport.min_depth = 0;
+    data->state.viewport.max_depth = 1;
     data->state.command_buffer = SDL_AcquireGPUCommandBuffer(data->device);
 
     int w, h;

--- a/src/render/sdlgpu/SDL_shaders_gpu.c
+++ b/src/render/sdlgpu/SDL_shaders_gpu.c
@@ -167,12 +167,12 @@ static SDL_GPUShader *CompileShader(const GPU_ShaderSources *sources, SDL_GPUDev
 
     SDL_GPUShaderCreateInfo sci = { 0 };
     sci.code = sms->code;
-    sci.codeSize = sms->code_len;
+    sci.code_size = sms->code_len;
     sci.format = sms->format;
     // FIXME not sure if this is correct
-    sci.entryPointName = driver == SDL_GPU_DRIVER_METAL ? "main0" : "main";
-    sci.samplerCount = sources->num_samplers;
-    sci.uniformBufferCount = sources->num_uniform_buffers;
+    sci.entrypoint_name = driver == SDL_GPU_DRIVER_METAL ? "main0" : "main";
+    sci.num_samplers = sources->num_samplers;
+    sci.num_uniform_buffers = sources->num_uniform_buffers;
     sci.stage = stage;
 
     return SDL_CreateGPUShader(device, &sci);

--- a/src/render/sdlgpu/SDL_shaders_gpu.c
+++ b/src/render/sdlgpu/SDL_shaders_gpu.c
@@ -170,7 +170,7 @@ static SDL_GPUShader *CompileShader(const GPU_ShaderSources *sources, SDL_GPUDev
     sci.code_size = sms->code_len;
     sci.format = sms->format;
     // FIXME not sure if this is correct
-    sci.entrypoint_name = driver == SDL_GPU_DRIVER_METAL ? "main0" : "main";
+    sci.entrypoint = driver == SDL_GPU_DRIVER_METAL ? "main0" : "main";
     sci.num_samplers = sources->num_samplers;
     sci.num_uniform_buffers = sources->num_uniform_buffers;
     sci.stage = stage;

--- a/test/testgpu_simple_clear.c
+++ b/test/testgpu_simple_clear.c
@@ -92,12 +92,12 @@ SDL_AppResult SDL_AppIterate(void *appstate)
 		SDL_GPUColorAttachmentInfo colorAttachmentInfo;
         SDL_zero(colorAttachmentInfo);
 		colorAttachmentInfo.texture = swapchainTexture;
-		colorAttachmentInfo.clearColor.r = (float)(0.5 + 0.5 * SDL_sin(currentTime));
-		colorAttachmentInfo.clearColor.g = (float)(0.5 + 0.5 * SDL_sin(currentTime + SDL_PI_D * 2 / 3));
-		colorAttachmentInfo.clearColor.b = (float)(0.5 + 0.5 * SDL_sin(currentTime + SDL_PI_D * 4 / 3));;
-		colorAttachmentInfo.clearColor.a = 1.0f;
-		colorAttachmentInfo.loadOp = SDL_GPU_LOADOP_CLEAR;
-		colorAttachmentInfo.storeOp = SDL_GPU_STOREOP_STORE;
+		colorAttachmentInfo.clear_color.r = (float)(0.5 + 0.5 * SDL_sin(currentTime));
+		colorAttachmentInfo.clear_color.g = (float)(0.5 + 0.5 * SDL_sin(currentTime + SDL_PI_D * 2 / 3));
+		colorAttachmentInfo.clear_color.b = (float)(0.5 + 0.5 * SDL_sin(currentTime + SDL_PI_D * 4 / 3));;
+		colorAttachmentInfo.clear_color.a = 1.0f;
+		colorAttachmentInfo.load_op = SDL_GPU_LOADOP_CLEAR;
+		colorAttachmentInfo.store_op = SDL_GPU_STOREOP_STORE;
 
 		renderPass = SDL_BeginGPURenderPass(cmdbuf, &colorAttachmentInfo, 1, NULL);
 		SDL_EndGPURenderPass(renderPass);

--- a/test/testgpu_simple_clear.c
+++ b/test/testgpu_simple_clear.c
@@ -89,17 +89,17 @@ SDL_AppResult SDL_AppIterate(void *appstate)
 	if (swapchainTexture != NULL) {
         const double currentTime = (double)SDL_GetPerformanceCounter() / SDL_GetPerformanceFrequency();
         SDL_GPURenderPass *renderPass;
-		SDL_GPUColorAttachmentInfo colorAttachmentInfo;
-        SDL_zero(colorAttachmentInfo);
-		colorAttachmentInfo.texture = swapchainTexture;
-		colorAttachmentInfo.clear_color.r = (float)(0.5 + 0.5 * SDL_sin(currentTime));
-		colorAttachmentInfo.clear_color.g = (float)(0.5 + 0.5 * SDL_sin(currentTime + SDL_PI_D * 2 / 3));
-		colorAttachmentInfo.clear_color.b = (float)(0.5 + 0.5 * SDL_sin(currentTime + SDL_PI_D * 4 / 3));;
-		colorAttachmentInfo.clear_color.a = 1.0f;
-		colorAttachmentInfo.load_op = SDL_GPU_LOADOP_CLEAR;
-		colorAttachmentInfo.store_op = SDL_GPU_STOREOP_STORE;
+		SDL_GPUColorTargetInfo color_target_info;
+        SDL_zero(color_target_info);
+		color_target_info.texture = swapchainTexture;
+		color_target_info.clear_color.r = (float)(0.5 + 0.5 * SDL_sin(currentTime));
+		color_target_info.clear_color.g = (float)(0.5 + 0.5 * SDL_sin(currentTime + SDL_PI_D * 2 / 3));
+		color_target_info.clear_color.b = (float)(0.5 + 0.5 * SDL_sin(currentTime + SDL_PI_D * 4 / 3));;
+		color_target_info.clear_color.a = 1.0f;
+		color_target_info.load_op = SDL_GPU_LOADOP_CLEAR;
+		color_target_info.store_op = SDL_GPU_STOREOP_STORE;
 
-		renderPass = SDL_BeginGPURenderPass(cmdbuf, &colorAttachmentInfo, 1, NULL);
+		renderPass = SDL_BeginGPURenderPass(cmdbuf, &color_target_info, 1, NULL);
 		SDL_EndGPURenderPass(renderPass);
 	}
 
@@ -122,4 +122,3 @@ void SDL_AppQuit(void *appstate)
 	SDL_DestroyGPUDevice(gpu_device);
     SDLTest_CommonQuit(state);
 }
-

--- a/test/testgpu_spinning_cube.c
+++ b/test/testgpu_spinning_cube.c
@@ -256,10 +256,10 @@ CreateDepthTexture(Uint32 drawablew, Uint32 drawableh)
     depthtex_createinfo.format = SDL_GPU_TEXTUREFORMAT_D16_UNORM;
     depthtex_createinfo.width = drawablew;
     depthtex_createinfo.height = drawableh;
-    depthtex_createinfo.layerCountOrDepth = 1;
-    depthtex_createinfo.levelCount = 1;
-    depthtex_createinfo.sampleCount = render_state.sample_count;
-    depthtex_createinfo.usageFlags = SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET;
+    depthtex_createinfo.layer_count_or_depth = 1;
+    depthtex_createinfo.num_levels = 1;
+    depthtex_createinfo.sample_count = render_state.sample_count;
+    depthtex_createinfo.usage_flags = SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET;
     depthtex_createinfo.props = 0;
 
     result = SDL_CreateGPUTexture(gpu_device, &depthtex_createinfo);
@@ -282,10 +282,10 @@ CreateMSAATexture(Uint32 drawablew, Uint32 drawableh)
     msaatex_createinfo.format = SDL_GetGPUSwapchainTextureFormat(gpu_device, state->windows[0]);
     msaatex_createinfo.width = drawablew;
     msaatex_createinfo.height = drawableh;
-    msaatex_createinfo.layerCountOrDepth = 1;
-    msaatex_createinfo.levelCount = 1;
-    msaatex_createinfo.sampleCount = render_state.sample_count;
-    msaatex_createinfo.usageFlags = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER;
+    msaatex_createinfo.layer_count_or_depth = 1;
+    msaatex_createinfo.num_levels = 1;
+    msaatex_createinfo.sample_count = render_state.sample_count;
+    msaatex_createinfo.usage_flags = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER;
     msaatex_createinfo.props = 0;
 
     result = SDL_CreateGPUTexture(gpu_device, &msaatex_createinfo);
@@ -364,15 +364,15 @@ Render(SDL_Window *window, const int windownum)
     /* Set up the pass */
 
     SDL_zero(color_attachment);
-    color_attachment.clearColor.a = 1.0f;
-    color_attachment.loadOp = SDL_GPU_LOADOP_CLEAR;
-    color_attachment.storeOp = SDL_GPU_STOREOP_STORE;
+    color_attachment.clear_color.a = 1.0f;
+    color_attachment.load_op = SDL_GPU_LOADOP_CLEAR;
+    color_attachment.store_op = SDL_GPU_STOREOP_STORE;
     color_attachment.texture = winstate->tex_msaa ? winstate->tex_msaa : swapchain;
 
     SDL_zero(depth_attachment);
-    depth_attachment.depthStencilClearValue.depth = 1.0f;
-    depth_attachment.loadOp = SDL_GPU_LOADOP_CLEAR;
-    depth_attachment.storeOp = SDL_GPU_STOREOP_DONT_CARE;
+    depth_attachment.clear_value.depth = 1.0f;
+    depth_attachment.load_op = SDL_GPU_LOADOP_CLEAR;
+    depth_attachment.store_op = SDL_GPU_STOREOP_DONT_CARE;
     depth_attachment.texture = winstate->tex_depth;
     depth_attachment.cycle = SDL_TRUE;
 
@@ -414,33 +414,33 @@ static SDL_GPUShader*
 load_shader(SDL_bool is_vertex)
 {
     SDL_GPUShaderCreateInfo createinfo;
-    createinfo.samplerCount = 0;
-    createinfo.storageBufferCount = 0;
-    createinfo.storageTextureCount = 0;
-    createinfo.uniformBufferCount = is_vertex ? 1 : 0;
+    createinfo.num_samplers = 0;
+    createinfo.num_storage_buffers = 0;
+    createinfo.num_storage_textures = 0;
+    createinfo.num_uniform_buffers = is_vertex ? 1 : 0;
     createinfo.props = 0;
 
     SDL_GPUDriver backend = SDL_GetGPUDriver(gpu_device);
     if (backend == SDL_GPU_DRIVER_D3D11) {
         createinfo.format = SDL_GPU_SHADERFORMAT_DXBC;
         createinfo.code = is_vertex ? D3D11_CubeVert : D3D11_CubeFrag;
-        createinfo.codeSize = is_vertex ? SDL_arraysize(D3D11_CubeVert) : SDL_arraysize(D3D11_CubeFrag);
-        createinfo.entryPointName = is_vertex ? "VSMain" : "PSMain";
+        createinfo.code_size = is_vertex ? SDL_arraysize(D3D11_CubeVert) : SDL_arraysize(D3D11_CubeFrag);
+        createinfo.entrypoint_name = is_vertex ? "VSMain" : "PSMain";
     } else if (backend == SDL_GPU_DRIVER_D3D12) {
         createinfo.format = SDL_GPU_SHADERFORMAT_DXIL;
         createinfo.code = is_vertex ? D3D12_CubeVert : D3D12_CubeFrag;
-        createinfo.codeSize = is_vertex ? SDL_arraysize(D3D12_CubeVert) : SDL_arraysize(D3D12_CubeFrag);
-        createinfo.entryPointName = is_vertex ? "VSMain" : "PSMain";
+        createinfo.code_size = is_vertex ? SDL_arraysize(D3D12_CubeVert) : SDL_arraysize(D3D12_CubeFrag);
+        createinfo.entrypoint_name = is_vertex ? "VSMain" : "PSMain";
     } else if (backend == SDL_GPU_DRIVER_METAL) {
         createinfo.format = SDL_GPU_SHADERFORMAT_METALLIB;
         createinfo.code = is_vertex ? cube_vert_metallib : cube_frag_metallib;
-        createinfo.codeSize = is_vertex ? cube_vert_metallib_len : cube_frag_metallib_len;
-        createinfo.entryPointName = is_vertex ? "vs_main" : "fs_main";
+        createinfo.code_size = is_vertex ? cube_vert_metallib_len : cube_frag_metallib_len;
+        createinfo.entrypoint_name = is_vertex ? "vs_main" : "fs_main";
     } else {
         createinfo.format = SDL_GPU_SHADERFORMAT_SPIRV;
         createinfo.code = is_vertex ? cube_vert_spv : cube_frag_spv;
-        createinfo.codeSize = is_vertex ? cube_vert_spv_len : cube_frag_spv_len;
-        createinfo.entryPointName = "main";
+        createinfo.code_size = is_vertex ? cube_vert_spv_len : cube_frag_spv_len;
+        createinfo.entrypoint_name = "main";
     }
 
     createinfo.stage = is_vertex ? SDL_GPU_SHADERSTAGE_VERTEX : SDL_GPU_SHADERSTAGE_FRAGMENT;
@@ -492,8 +492,8 @@ init_render_state(int msaa)
 
     /* Create buffers */
 
-    buffer_desc.usageFlags = SDL_GPU_BUFFERUSAGE_VERTEX;
-    buffer_desc.sizeInBytes = sizeof(vertex_data);
+    buffer_desc.usage_flags = SDL_GPU_BUFFERUSAGE_VERTEX;
+    buffer_desc.size = sizeof(vertex_data);
     buffer_desc.props = 0;
     render_state.buf_vertex = SDL_CreateGPUBuffer(
         gpu_device,
@@ -504,7 +504,7 @@ init_render_state(int msaa)
     SDL_SetGPUBufferName(gpu_device, render_state.buf_vertex, "космонавт");
 
     transfer_buffer_desc.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
-    transfer_buffer_desc.sizeInBytes = sizeof(vertex_data);
+    transfer_buffer_desc.size = sizeof(vertex_data);
     transfer_buffer_desc.props = 0;
     buf_transfer = SDL_CreateGPUTransferBuffer(
         gpu_device,
@@ -519,7 +519,7 @@ init_render_state(int msaa)
 
     cmd = SDL_AcquireGPUCommandBuffer(gpu_device);
     copy_pass = SDL_BeginGPUCopyPass(cmd);
-    buf_location.transferBuffer = buf_transfer;
+    buf_location.transfer_buffer = buf_transfer;
     buf_location.offset = 0;
     dst_region.buffer = render_state.buf_vertex;
     dst_region.offset = 0;
@@ -545,36 +545,36 @@ init_render_state(int msaa)
 
     color_attachment_desc.format = SDL_GetGPUSwapchainTextureFormat(gpu_device, state->windows[0]);
 
-    color_attachment_desc.blendState.blendEnable = 0;
-    color_attachment_desc.blendState.alphaBlendOp = SDL_GPU_BLENDOP_ADD;
-    color_attachment_desc.blendState.colorBlendOp = SDL_GPU_BLENDOP_ADD;
-    color_attachment_desc.blendState.colorWriteMask = 0xF;
-    color_attachment_desc.blendState.srcAlphaBlendFactor = SDL_GPU_BLENDFACTOR_ONE;
-    color_attachment_desc.blendState.dstAlphaBlendFactor = SDL_GPU_BLENDFACTOR_ZERO;
-    color_attachment_desc.blendState.srcColorBlendFactor = SDL_GPU_BLENDFACTOR_ONE;
-    color_attachment_desc.blendState.dstColorBlendFactor = SDL_GPU_BLENDFACTOR_ZERO;
+    color_attachment_desc.blend_state.enable_blend = 0;
+    color_attachment_desc.blend_state.alpha_blend_op = SDL_GPU_BLENDOP_ADD;
+    color_attachment_desc.blend_state.color_blend_op = SDL_GPU_BLENDOP_ADD;
+    color_attachment_desc.blend_state.color_write_mask = 0xF;
+    color_attachment_desc.blend_state.src_alpha_blendfactor = SDL_GPU_BLENDFACTOR_ONE;
+    color_attachment_desc.blend_state.dst_alpha_blendfactor = SDL_GPU_BLENDFACTOR_ZERO;
+    color_attachment_desc.blend_state.src_color_blendfactor = SDL_GPU_BLENDFACTOR_ONE;
+    color_attachment_desc.blend_state.dst_color_blendfactor = SDL_GPU_BLENDFACTOR_ZERO;
 
-    pipelinedesc.attachmentInfo.colorAttachmentCount = 1;
-    pipelinedesc.attachmentInfo.colorAttachmentDescriptions = &color_attachment_desc;
-    pipelinedesc.attachmentInfo.depthStencilFormat = SDL_GPU_TEXTUREFORMAT_D16_UNORM;
-    pipelinedesc.attachmentInfo.hasDepthStencilAttachment = SDL_TRUE;
+    pipelinedesc.attachment_info.num_color_attachments = 1;
+    pipelinedesc.attachment_info.color_attachment_descriptions = &color_attachment_desc;
+    pipelinedesc.attachment_info.depth_stencil_format = SDL_GPU_TEXTUREFORMAT_D16_UNORM;
+    pipelinedesc.attachment_info.has_depth_stencil_attachment = SDL_TRUE;
 
-    pipelinedesc.depthStencilState.depthTestEnable = 1;
-    pipelinedesc.depthStencilState.depthWriteEnable = 1;
-    pipelinedesc.depthStencilState.compareOp = SDL_GPU_COMPAREOP_LESS_OR_EQUAL;
+    pipelinedesc.depth_stencil_state.enable_depth_test = 1;
+    pipelinedesc.depth_stencil_state.enable_depth_write = 1;
+    pipelinedesc.depth_stencil_state.compare_op = SDL_GPU_COMPAREOP_LESS_OR_EQUAL;
 
-    pipelinedesc.multisampleState.sampleCount = render_state.sample_count;
-    pipelinedesc.multisampleState.sampleMask = 0xF;
+    pipelinedesc.multisample_state.sample_count = render_state.sample_count;
+    pipelinedesc.multisample_state.sample_mask = 0xF;
 
-    pipelinedesc.primitiveType = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
+    pipelinedesc.primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
 
-    pipelinedesc.vertexShader = vertex_shader;
-    pipelinedesc.fragmentShader = fragment_shader;
+    pipelinedesc.vertex_shader = vertex_shader;
+    pipelinedesc.fragment_shader = fragment_shader;
 
     vertex_binding.binding = 0;
-    vertex_binding.inputRate = SDL_GPU_VERTEXINPUTRATE_VERTEX;
-    vertex_binding.instanceStepRate = 0;
-    vertex_binding.stride = sizeof(VertexData);
+    vertex_binding.input_rate = SDL_GPU_VERTEXINPUTRATE_VERTEX;
+    vertex_binding.instance_step_rate = 0;
+    vertex_binding.pitch = sizeof(VertexData);
 
     vertex_attributes[0].binding = 0;
     vertex_attributes[0].format = SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3;
@@ -586,10 +586,10 @@ init_render_state(int msaa)
     vertex_attributes[1].location = 1;
     vertex_attributes[1].offset = sizeof(float) * 3;
 
-    pipelinedesc.vertexInputState.vertexBindingCount = 1;
-    pipelinedesc.vertexInputState.vertexBindings = &vertex_binding;
-    pipelinedesc.vertexInputState.vertexAttributeCount = 2;
-    pipelinedesc.vertexInputState.vertexAttributes = (SDL_GPUVertexAttribute*) &vertex_attributes;
+    pipelinedesc.vertex_input_state.num_vertex_bindings = 1;
+    pipelinedesc.vertex_input_state.vertex_bindings = &vertex_binding;
+    pipelinedesc.vertex_input_state.num_vertex_attributes = 2;
+    pipelinedesc.vertex_input_state.vertex_attributes = (SDL_GPUVertexAttribute*) &vertex_attributes;
 
     pipelinedesc.props = 0;
 


### PR DESCRIPTION
This is a mass renaming to convert all GPU parameters and struct members into snake_case. Additionally, some parameters were renamed to make the APIs more SDL-ish (e.g. `somethingCount` -> `num_somethings`), reduce redundancy (`sizeInBytes` -> `size`), or remove vestigial Vulkan-isms (`pFences` -> `fences`).

While this is mostly straightforward, there are a handful of odd edge cases. `layer_count_or_depth` doesn't follow the `num_` prefix convention, but it's not entirely clear how we'd rephrase it. Is `blendfactor` one or two words? Should `mip_level` be renamed to `level`? And so forth... Would appreciate some opinions on this.

It'd also be nice to clean up some of the massive inconsistency this is causing in the backends between camelCase and snake_case, but that doesn't affect the public API so it's not necessarily a blocker.