### PR TITLE
pipewire : check minimum client library version early

### DIFF
--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -247,17 +247,29 @@ static int hotplug_init_seq_val;
 static bool hotplug_init_complete;
 static bool hotplug_events_enabled;
 
-static int pipewire_version_major;
-static int pipewire_version_minor;
-static int pipewire_version_patch;
+static int pipewire_core_version_major = 0;
+static int pipewire_core_version_minor = 0;
+static int pipewire_core_version_patch = 0;
+
+static int pipewire_client_version_major = 0;
+static int pipewire_client_version_minor = 0;
+static int pipewire_client_version_patch = 0;
+
 static char *pipewire_default_sink_id = NULL;
 static char *pipewire_default_source_id = NULL;
 
 static bool pipewire_core_version_at_least(int major, int minor, int patch)
 {
-    return (pipewire_version_major >= major) &&
-           (pipewire_version_major > major || pipewire_version_minor >= minor) &&
-           (pipewire_version_major > major || pipewire_version_minor > minor || pipewire_version_patch >= patch);
+    return (pipewire_core_version_major >= major) &&
+           (pipewire_core_version_major > major || pipewire_core_version_minor >= minor) &&
+           (pipewire_core_version_major > major || pipewire_core_version_minor > minor || pipewire_core_version_patch >= patch);
+}
+
+static bool pipewire_client_version_at_least(int major, int minor, int patch)
+{
+    return (pipewire_client_version_major >= major) &&
+           (pipewire_client_version_major > major || pipewire_client_version_minor >= minor) &&
+           (pipewire_client_version_major > major || pipewire_client_version_minor > minor || pipewire_client_version_patch >= patch);
 }
 
 // The active node list
@@ -408,10 +420,10 @@ static void core_events_hotplug_init_callback(void *object, uint32_t id, int seq
 
 static void core_events_hotplug_info_callback(void *data, const struct pw_core_info *info)
 {
-    if (SDL_sscanf(info->version, "%d.%d.%d", &pipewire_version_major, &pipewire_version_minor, &pipewire_version_patch) < 3) {
-        pipewire_version_major = 0;
-        pipewire_version_minor = 0;
-        pipewire_version_patch = 0;
+    if (SDL_sscanf(info->version, "%d.%d.%d", &pipewire_core_version_major, &pipewire_core_version_minor, &pipewire_core_version_patch) < 3) {
+        pipewire_core_version_major = 0;
+        pipewire_core_version_minor = 0;
+        pipewire_core_version_patch = 0;
     }
 }
 
@@ -1228,6 +1240,16 @@ static bool PipewireInitialize(SDL_AudioDriverImpl *impl)
         }
 
         pipewire_initialized = true;
+
+        if (SDL_sscanf(PIPEWIRE_pw_get_library_version(), "%d.%d.%d", &pipewire_client_version_major, &pipewire_client_version_minor, &pipewire_client_version_patch) < 3) {
+            unload_pipewire_library();
+            return false;
+        }
+
+        if (!pipewire_client_version_at_least(1, 0, 0)) {
+            unload_pipewire_library();
+            return false;
+        }
 
         if (!hotplug_loop_init()) {
             PIPEWIRE_Deinitialize();


### PR DESCRIPTION
Check the client version first, before we start the hotplug thread and check the core version.

We are seeing crashes on systems with pipewire 0.65, which we suspect has an issue not properly shutting down the hotplug thread once SDL decides to move on to another audio backend.

