### PR TITLE
macOS: Add a hint for smooth momentum values in SDL_EVENT_MOUSE_WHEEL events

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2234,7 +2234,7 @@ extern "C" {
  *   (default)
  * - "1": The application may remain in the background when launched.
  *
- * This hint should be set before applicationDidFinishLaunching() is called.
+ * This hint needs to be set before SDL_Init().
  *
  * \since This hint is available since SDL 3.0.0.
  */
@@ -2288,7 +2288,7 @@ extern "C" {
  * - "0": The mouse wheel events will have no momentum. (default)
  * - "1": The mouse wheel events will have momentum.
  *
- * This hint should be set before applicationDidFinishLaunching() is called.
+ * This hint needs to be set before SDL_Init().
  *
  * \since This hint is available since SDL 3.0.0.
  */

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2280,6 +2280,21 @@ extern "C" {
 #define SDL_HINT_MAC_OPENGL_ASYNC_DISPATCH "SDL_MAC_OPENGL_ASYNC_DISPATCH"
 
 /**
+ * A variable controlling whether SDL_EVENT_MOUSE_WHEEL event values will have
+ * momentum on macOS.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "0": The mouse wheel events will have no momentum. (default)
+ * - "1": The mouse wheel events will have momentum.
+ *
+ * This hint should be set before applicationDidFinishLaunching() is called.
+ *
+ * \since This hint is available since SDL 3.0.0.
+ */
+#define SDL_HINT_MAC_SCROLL_MOMENTUM "SDL_HINT_MAC_SCROLL_MOMENTUM"
+
+/**
  * Request SDL_AppIterate() be called at a specific rate.
  *
  * This number is in Hz, so "60" means try to iterate 60 times per second.

--- a/src/video/cocoa/SDL_cocoaevents.m
+++ b/src/video/cocoa/SDL_cocoaevents.m
@@ -106,8 +106,10 @@ static void Cocoa_DispatchEvent(NSEvent *theEvent)
 
 + (void)registerUserDefaults
 {
+    BOOL momentumScrollSupported = (BOOL)SDL_GetHintBoolean(SDL_HINT_MAC_SCROLL_MOMENTUM, false);
+
     NSDictionary *appDefaults = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                                          [NSNumber numberWithBool:NO], @"AppleMomentumScrollSupported",
+                                                          [NSNumber numberWithBool:momentumScrollSupported], @"AppleMomentumScrollSupported",
                                                           [NSNumber numberWithBool:NO], @"ApplePressAndHoldEnabled",
                                                           [NSNumber numberWithBool:YES], @"ApplePersistenceIgnoreState",
                                                           nil];


### PR DESCRIPTION
This PR adds a new hint for smooth momentum values in SDL_EVENT_MOUSE_WHEEL events on MacOS.

## Description
When scrolling on a touchpad on MacOS the scroll values usually contain momentum inside all native applications. But inside SDL the scroll values were without momentum. This PR adds a simple hint to control `"AppleMomentumScrollSupported"` MacOS API for requesting the native momentum.

Please let me know if there is a better name for the hint or if you have better wording for the documentation part.

### Demo

Here is a simple "browser" test application with scrolling to see the difference.

| Momentum | Video |
|--------|--------|
| OFF | <video src="https://github.com/user-attachments/assets/9d71ea5e-82b1-4d04-b211-84f10bf5f977"> |
| ON | <video src="https://github.com/user-attachments/assets/399c759c-635e-4ea6-8abb-190f964b468d"> | 

## Existing Issue(s)
fixes #2176 which mentions adding a hint for this in SDL 3.0.