### PR TITLE
stdinc: Document some APIs; remove SDL_RESTRICT in favor of doc comments

### DIFF
--- a/include/SDL3/SDL_begin_code.h
+++ b/include/SDL3/SDL_begin_code.h
@@ -225,13 +225,3 @@
 #define SDL_ALLOC_SIZE2(p1, p2)
 #endif
 #endif /* SDL_ALLOC_SIZE2 not defined */
-
-#ifndef SDL_RESTRICT
-#if defined(__GNUC__)
-#define SDL_RESTRICT __restrict__
-#elif defined(_MSC_VER)
-#define SDL_RESTRICT __restrict
-#else
-#define SDL_RESTRICT
-#endif
-#endif

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -1227,6 +1227,22 @@ extern SDL_DECLSPEC int SDLCALL SDL_tolower(int x);
 extern SDL_DECLSPEC Uint16 SDLCALL SDL_crc16(Uint16 crc, const void *data, size_t len);
 extern SDL_DECLSPEC Uint32 SDLCALL SDL_crc32(Uint32 crc, const void *data, size_t len);
 
+/**
+ * Copy non-overlapping memory.
+ *
+ * The memory regions must not overlap. If they do, use SDL_memmove() instead.
+ *
+ * \param dst The destination memory region. Must not be NULL, and must not overlap with `src`.
+ * \param src The source memory region. Must not be NULL, and must not overlap with `dst`.
+ * \param len The length in bytes of both `dst` and `src`.
+ * \returns `dst`.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_memmove
+ */
 extern SDL_DECLSPEC void * SDLCALL SDL_memcpy(SDL_OUT_BYTECAP(len) void *dst, SDL_IN_BYTECAP(len) const void *src, size_t len);
 
 /* Take advantage of compiler optimizations for memcpy */
@@ -1241,6 +1257,23 @@ extern SDL_DECLSPEC void * SDLCALL SDL_memcpy(SDL_OUT_BYTECAP(len) void *dst, SD
     { SDL_COMPILE_TIME_ASSERT(SDL_copyp, sizeof (*(dst)) == sizeof (*(src))); }             \
     SDL_memcpy((dst), (src), sizeof(*(src)))
 
+/**
+ * Copy memory.
+ *
+ * It is okay for the memory regions to overlap.
+ * If you are confident that the regions never overlap, using SDL_memset() may improve performance.
+ *
+ * \param dst The destination memory region. Must not be NULL.
+ * \param src The source memory region. Must not be NULL.
+ * \param len The length in bytes of both `dst` and `src`.
+ * \returns `dst`.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_memcpy
+ */
 extern SDL_DECLSPEC void * SDLCALL SDL_memmove(SDL_OUT_BYTECAP(len) void *dst, SDL_IN_BYTECAP(len) const void *src, size_t len);
 
 /* Take advantage of compiler optimizations for memmove */
@@ -1270,8 +1303,52 @@ extern SDL_DECLSPEC int SDLCALL SDL_memcmp(const void *s1, const void *s2, size_
 
 extern SDL_DECLSPEC size_t SDLCALL SDL_wcslen(const wchar_t *wstr);
 extern SDL_DECLSPEC size_t SDLCALL SDL_wcsnlen(const wchar_t *wstr, size_t maxlen);
+
+/**
+ * Copy a wide string.
+ *
+ * This function copies `maxlen` - 1 wide characters from `src` to `dst`, then appends a null terminator.
+ *
+ * `src` and `dst` must not overlap.
+ *
+ * If `maxlen` is 0, no wide characters are copied and no null terminator is written.
+ *
+ * \param dst The destination buffer. Must not be NULL, and must not overlap with `src`.
+ * \param src The null-terminated wide string to copy. Must not be NULL, and must not overlap with `dst`.
+ * \param maxlen The length (in wide characters) of the destination buffer.
+ * \returns The length (in wide characters, excluding the null terminator) of `src`.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_wcslcat
+ */
 extern SDL_DECLSPEC size_t SDLCALL SDL_wcslcpy(SDL_OUT_Z_CAP(maxlen) wchar_t *dst, const wchar_t *src, size_t maxlen);
+
+/**
+ * Concatenate wide strings.
+ *
+ * This function appends up to `maxlen` - SDL_wcslen(dst) - 1 wide characters from `src`
+ * to the end of the wide string in `dst`, then appends a null terminator.
+ *
+ * `src` and `dst` must not overlap.
+ *
+ * If `maxlen` - SDL_wcslen(dst) - 1 is less than or equal to 0, then `dst` is unmodified.
+ *
+ * \param dst The destination buffer already containing the first null-terminated wide string. Must not be NULL and must not overlap with `src`.
+ * \param src The second null-terminated wide string. Must not be NULL, and must not overlap with `dst`.
+ * \param maxlen The length (in wide characters) of the destination buffer.
+ * \returns The length (in wide characters, excluding the null terminator) of the string in `dst` plus the length of `src`.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_wcslcpy
+ */
 extern SDL_DECLSPEC size_t SDLCALL SDL_wcslcat(SDL_INOUT_Z_CAP(maxlen) wchar_t *dst, const wchar_t *src, size_t maxlen);
+
 extern SDL_DECLSPEC wchar_t * SDLCALL SDL_wcsdup(const wchar_t *wstr);
 extern SDL_DECLSPEC wchar_t * SDLCALL SDL_wcsstr(const wchar_t *haystack, const wchar_t *needle);
 extern SDL_DECLSPEC wchar_t * SDLCALL SDL_wcsnstr(const wchar_t *haystack, const wchar_t *needle, size_t maxlen);
@@ -1402,9 +1479,81 @@ extern SDL_DECLSPEC long SDLCALL SDL_wcstol(const wchar_t *str, wchar_t **endp, 
 
 extern SDL_DECLSPEC size_t SDLCALL SDL_strlen(const char *str);
 extern SDL_DECLSPEC size_t SDLCALL SDL_strnlen(const char *str, size_t maxlen);
+
+/**
+ * Copy a string.
+ *
+ * This function copies up to `maxlen` - 1 characters from `src` to `dst`, then appends a null terminator.
+ *
+ * `src` and `dst` must not overlap.
+ *
+ * If `maxlen` is 0, no characters are copied and no null terminator is written.
+ *
+ * If you want to copy an UTF-8 string but need to ensure that multi-byte sequences are not truncated,
+ * consider using SDL_utf8strlcpy().
+ *
+ * \param dst The destination buffer. Must not be NULL, and must not overlap with `src`.
+ * \param src The null-terminated string to copy. Must not be NULL, and must not overlap with `dst`.
+ * \param maxlen The length (in characters) of the destination buffer.
+ * \returns The length (in characters, excluding the null terminator) of `src`.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_strlcat
+ * \sa SDL_utf8strlcpy
+ */
 extern SDL_DECLSPEC size_t SDLCALL SDL_strlcpy(SDL_OUT_Z_CAP(maxlen) char *dst, const char *src, size_t maxlen);
+
+/**
+ * Copy an UTF-8 string.
+ *
+ * This function copies up to `dst_bytes` - 1 bytes from `src` to `dst`
+ * while also ensuring that the string written to `dst`
+ * does not end in a truncated multi-byte sequence. Finally, it appends a null terminator.
+ *
+ * `src` and `dst` must not overlap.
+ *
+ * Note that unlike SDL_strlcpy(), `dst_bytes` must not be 0. Also note that unlike SDL_strlcpy(),
+ * this function returns the number of bytes written, not the length of `src`.
+ *
+ * \param dst The destination buffer. Must not be NULL, and must not overlap with `src`.
+ * \param src The null-terminated UTF-8 string to copy. Must not be NULL, and must not overlap with `dst`.
+ * \param dst_bytes The length (in bytes) of the destination buffer. Must not be 0.
+ * \returns The number of bytes written, excluding the null terminator.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_strlcpy
+ */
 extern SDL_DECLSPEC size_t SDLCALL SDL_utf8strlcpy(SDL_OUT_Z_CAP(dst_bytes) char *dst, const char *src, size_t dst_bytes);
+
+/**
+ * Concatenate strings.
+ *
+ * This function appends up to `maxlen` - SDL_strlen(dst) - 1 characters from `src`
+ * to the end of the string in `dst`, then appends a null terminator.
+ *
+ * `src` and `dst` must not overlap.
+ *
+ * If `maxlen` - SDL_strlen(dst) - 1 is less than or equal to 0, then `dst` is unmodified.
+ *
+ * \param dst The destination buffer already containing the first null-terminated string. Must not be NULL and must not overlap with `src`.
+ * \param src The second null-terminated string. Must not be NULL, and must not overlap with `dst`.
+ * \param maxlen The length (in characters) of the destination buffer.
+ * \returns The length (in characters, excluding the null terminator) of the string in `dst` plus the length of `src`.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_strlcpy
+ */
 extern SDL_DECLSPEC size_t SDLCALL SDL_strlcat(SDL_INOUT_Z_CAP(maxlen) char *dst, const char *src, size_t maxlen);
+
 extern SDL_DECLSPEC SDL_MALLOC char * SDLCALL SDL_strdup(const char *str);
 extern SDL_DECLSPEC SDL_MALLOC char * SDLCALL SDL_strndup(const char *str, size_t maxlen);
 extern SDL_DECLSPEC char * SDLCALL SDL_strrev(char *str);

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -508,7 +508,7 @@ typedef Sint64 SDL_Time;
 #define SDL_SCANF_VARARG_FUNC( fmtargnumber )
 #define SDL_SCANF_VARARG_FUNCV( fmtargnumber )
 #define SDL_WPRINTF_VARARG_FUNC( fmtargnumber )
-#define SDL_WSCANF_VARARG_FUNC( fmtargnumber )
+#define SDL_WPRINTF_VARARG_FUNCV( fmtargnumber )
 #else
 #if defined(_MSC_VER) && (_MSC_VER >= 1600) /* VS 2010 and above */
 #include <sal.h>
@@ -538,14 +538,14 @@ typedef Sint64 SDL_Time;
 #define SDL_SCANF_VARARG_FUNC( fmtargnumber ) __attribute__ (( format( __scanf__, fmtargnumber, fmtargnumber+1 )))
 #define SDL_SCANF_VARARG_FUNCV( fmtargnumber ) __attribute__(( format( __scanf__, fmtargnumber, 0 )))
 #define SDL_WPRINTF_VARARG_FUNC( fmtargnumber ) /* __attribute__ (( format( __wprintf__, fmtargnumber, fmtargnumber+1 ))) */
-#define SDL_WSCANF_VARARG_FUNC( fmtargnumber ) /* __attribute__ (( format( __wscanf__, fmtargnumber, fmtargnumber+1 ))) */
+#define SDL_WPRINTF_VARARG_FUNCV( fmtargnumber ) /* __attribute__ (( format( __wprintf__, fmtargnumber, 0 ))) */
 #else
 #define SDL_PRINTF_VARARG_FUNC( fmtargnumber )
 #define SDL_PRINTF_VARARG_FUNCV( fmtargnumber )
 #define SDL_SCANF_VARARG_FUNC( fmtargnumber )
 #define SDL_SCANF_VARARG_FUNCV( fmtargnumber )
 #define SDL_WPRINTF_VARARG_FUNC( fmtargnumber )
-#define SDL_WSCANF_VARARG_FUNC( fmtargnumber )
+#define SDL_WPRINTF_VARARG_FUNCV( fmtargnumber )
 #endif
 #endif /* SDL_DISABLE_ANALYZE_MACROS */
 
@@ -1849,10 +1849,10 @@ extern SDL_DECLSPEC char * SDLCALL SDL_UCS4ToUTF8(Uint32 codepoint, char *dst);
 
 extern SDL_DECLSPEC int SDLCALL SDL_sscanf(const char *text, SDL_SCANF_FORMAT_STRING const char *fmt, ...) SDL_SCANF_VARARG_FUNC(2);
 extern SDL_DECLSPEC int SDLCALL SDL_vsscanf(const char *text, SDL_SCANF_FORMAT_STRING const char *fmt, va_list ap) SDL_SCANF_VARARG_FUNCV(2);
-extern SDL_DECLSPEC int SDLCALL SDL_snprintf(SDL_OUT_Z_CAP(maxlen) char *text, size_t maxlen, SDL_PRINTF_FORMAT_STRING const char *fmt, ... ) SDL_PRINTF_VARARG_FUNC(3);
-extern SDL_DECLSPEC int SDLCALL SDL_swprintf(SDL_OUT_Z_CAP(maxlen) wchar_t *text, size_t maxlen, SDL_PRINTF_FORMAT_STRING const wchar_t *fmt, ... ) SDL_WPRINTF_VARARG_FUNC(3);
+extern SDL_DECLSPEC int SDLCALL SDL_snprintf(SDL_OUT_Z_CAP(maxlen) char *text, size_t maxlen, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(3);
+extern SDL_DECLSPEC int SDLCALL SDL_swprintf(SDL_OUT_Z_CAP(maxlen) wchar_t *text, size_t maxlen, SDL_PRINTF_FORMAT_STRING const wchar_t *fmt, ...) SDL_WPRINTF_VARARG_FUNC(3);
 extern SDL_DECLSPEC int SDLCALL SDL_vsnprintf(SDL_OUT_Z_CAP(maxlen) char *text, size_t maxlen, SDL_PRINTF_FORMAT_STRING const char *fmt, va_list ap) SDL_PRINTF_VARARG_FUNCV(3);
-extern SDL_DECLSPEC int SDLCALL SDL_vswprintf(SDL_OUT_Z_CAP(maxlen) wchar_t *text, size_t maxlen, const wchar_t *fmt, va_list ap);
+extern SDL_DECLSPEC int SDLCALL SDL_vswprintf(SDL_OUT_Z_CAP(maxlen) wchar_t *text, size_t maxlen, SDL_PRINTF_FORMAT_STRING const wchar_t *fmt, va_list ap) SDL_WPRINTF_VARARG_FUNCV(3);
 extern SDL_DECLSPEC int SDLCALL SDL_asprintf(char **strp, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(2);
 extern SDL_DECLSPEC int SDLCALL SDL_vasprintf(char **strp, SDL_PRINTF_FORMAT_STRING const char *fmt, va_list ap) SDL_PRINTF_VARARG_FUNCV(2);
 

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -1475,6 +1475,30 @@ extern SDL_DECLSPEC int SDLCALL SDL_wcscasecmp(const wchar_t *str1, const wchar_
  */
 extern SDL_DECLSPEC int SDLCALL SDL_wcsncasecmp(const wchar_t *str1, const wchar_t *str2, size_t maxlen);
 
+/**
+ * Parse a `long` from a wide string.
+ *
+ * This function makes fewer guarantees than the C runtime `wcstol`:
+ *
+ * - Only the bases 10 and 16 are guaranteed to be supported. The behavior for other bases is unspecified.
+ * - It is unspecified what this function returns when the parsed integer does not fit inside a `long`.
+ *
+ * `str` and `endp` must not overlap.
+ *
+ * \param str The null-terminated wide string to read. Must not be NULL and must not overlap with `endp`.
+ * \param endp If not NULL, the address of the first invalid wide character
+ *             (i.e. the next character after the parsed number) will be written to this pointer.
+ *             Must not overlap with `dst`.
+ * \param base The base of the integer to read. The values 0, 10 and 16 are supported.
+ *             If 0, the base will be inferred from the integer's prefix.
+ * \returns The parsed `long`.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_strtol
+ */
 extern SDL_DECLSPEC long SDLCALL SDL_wcstol(const wchar_t *str, wchar_t **endp, int base);
 
 extern SDL_DECLSPEC size_t SDLCALL SDL_strlen(const char *str);
@@ -1616,12 +1640,211 @@ extern SDL_DECLSPEC char * SDLCALL SDL_ultoa(unsigned long value, char *str, int
 extern SDL_DECLSPEC char * SDLCALL SDL_lltoa(Sint64 value, char *str, int radix);
 extern SDL_DECLSPEC char * SDLCALL SDL_ulltoa(Uint64 value, char *str, int radix);
 
+/**
+ * Parse an `int` from a string.
+ *
+ * The result of calling `SDL_atoi(str)` is equivalent to `(int)SDL_strtol(str, NULL, 10)`.
+ *
+ * \param str The null-terminated string to read. Must not be NULL.
+ * \returns The parsed `int`.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_atof
+ * \sa SDL_strtol
+ * \sa SDL_strtoul
+ * \sa SDL_strtoll
+ * \sa SDL_strtoull
+ * \sa SDL_strtod
+ * \sa SDL_itoa
+ */
 extern SDL_DECLSPEC int SDLCALL SDL_atoi(const char *str);
+
+/**
+ * Parse a `double` from a string.
+ *
+ * The result of calling `SDL_atoi(str)` is equivalent to `SDL_strtod(str, NULL)`.
+ *
+ * \param str The null-terminated string to read. Must not be NULL.
+ * \returns The parsed `double`.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_atoi
+ * \sa SDL_strtol
+ * \sa SDL_strtoul
+ * \sa SDL_strtoll
+ * \sa SDL_strtoull
+ * \sa SDL_strtod
+ */
 extern SDL_DECLSPEC double SDLCALL SDL_atof(const char *str);
+
+/**
+ * Parse a `long` from a string.
+ *
+ * This function makes fewer guarantees than the C runtime `strtol`:
+ *
+ * - Only the bases 10 and 16 are guaranteed to be supported. The behavior for other bases is unspecified.
+ * - It is unspecified what this function returns when the parsed integer does not fit inside a `long`.
+ *
+ * `str` and `endp` must not overlap.
+ *
+ * \param str The null-terminated string to read. Must not be NULL and must not overlap with `endp`.
+ * \param endp If not NULL, the address of the first invalid character
+ *             (i.e. the next character after the parsed number) will be written to this pointer.
+ *             Must not overlap with `dst`.
+ * \param base The base of the integer to read. The values 0, 10 and 16 are supported.
+ *             If 0, the base will be inferred from the integer's prefix.
+ * \returns The parsed `long`.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_atoi
+ * \sa SDL_atof
+ * \sa SDL_strtoul
+ * \sa SDL_strtoll
+ * \sa SDL_strtoull
+ * \sa SDL_strtod
+ * \sa SDL_ltoa
+ * \sa SDL_wcstol
+ */
 extern SDL_DECLSPEC long SDLCALL SDL_strtol(const char *str, char **endp, int base);
+
+/**
+ * Parse an `unsigned long` from a string.
+ *
+ * This function makes fewer guarantees than the C runtime `strtoul`:
+ *
+ * - Only the bases 10 and 16 are guaranteed to be supported. The behavior for other bases is unspecified.
+ * - It is unspecified what this function returns when the parsed integer does not fit inside an `unsigned long`.
+ *
+ * `str` and `endp` must not overlap.
+ *
+ * \param str The null-terminated string to read. Must not be NULL and must not overlap with `endp`.
+ * \param endp If not NULL, the address of the first invalid character
+ *             (i.e. the next character after the parsed number) will be written to this pointer.
+ *             Must not overlap with `dst`.
+ * \param base The base of the integer to read. The values 0, 10 and 16 are supported.
+ *             If 0, the base will be inferred from the integer's prefix.
+ * \returns The parsed `unsigned long`.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_atoi
+ * \sa SDL_atof
+ * \sa SDL_strtol
+ * \sa SDL_strtoll
+ * \sa SDL_strtoull
+ * \sa SDL_strtod
+ * \sa SDL_ultoa
+ */
 extern SDL_DECLSPEC unsigned long SDLCALL SDL_strtoul(const char *str, char **endp, int base);
+
+/**
+ * Parse an Sint64 from a string.
+ *
+ * This function makes fewer guarantees than the C runtime `strtoll`:
+ *
+ * - Only the bases 10 and 16 are guaranteed to be supported. The behavior for other bases is unspecified.
+ * - It is unspecified what this function returns when the parsed integer does not fit inside a `long long`.
+ *
+ * Also note that unlike the C runtime `strtoll`, this function returns an Sint64, not a `long long`.
+ *
+ * `str` and `endp` must not overlap.
+ *
+ * \param str The null-terminated string to read. Must not be NULL and must not overlap with `endp`.
+ * \param endp If not NULL, the address of the first invalid character
+ *             (i.e. the next character after the parsed number) will be written to this pointer.
+ *             Must not overlap with `dst`.
+ * \param base The base of the integer to read. The values 0, 10 and 16 are supported.
+ *             If 0, the base will be inferred from the integer's prefix.
+ * \returns The parsed Sint64.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_atoi
+ * \sa SDL_atof
+ * \sa SDL_strtol
+ * \sa SDL_strtoul
+ * \sa SDL_strtoull
+ * \sa SDL_strtod
+ * \sa SDL_lltoa
+ */
 extern SDL_DECLSPEC Sint64 SDLCALL SDL_strtoll(const char *str, char **endp, int base);
+
+/**
+ * Parse a Uint64 from a string.
+ *
+ * This function makes fewer guarantees than the C runtime `strtoull`:
+ *
+ * - Only the bases 10 and 16 are guaranteed to be supported. The behavior for other bases is unspecified.
+ * - It is unspecified what this function returns when the parsed integer does not fit inside a `long long`.
+ *
+ * Also note that unlike the C runtime `strtoull`, this function returns a Uint64, not an `unsigned long long`.
+ *
+ * `str` and `endp` must not overlap.
+ *
+ * \param str The null-terminated string to read. Must not be NULL and must not overlap with `endp`.
+ * \param endp If not NULL, the address of the first invalid character
+ *             (i.e. the next character after the parsed number) will be written to this pointer.
+ *             Must not overlap with `dst`.
+ * \param base The base of the integer to read. The values 0, 10 and 16 are supported.
+ *             If 0, the base will be inferred from the integer's prefix.
+ * \returns The parsed Uint64.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_atoi
+ * \sa SDL_atof
+ * \sa SDL_strtol
+ * \sa SDL_strtoll
+ * \sa SDL_strtoul
+ * \sa SDL_strtod
+ * \sa SDL_ulltoa
+ */
 extern SDL_DECLSPEC Uint64 SDLCALL SDL_strtoull(const char *str, char **endp, int base);
+
+/**
+ * Parse a `double` from a string.
+ *
+ * This function makes fewer guarantees than the C runtime `strtod`:
+ *
+ * - Only decimal notation is guaranteed to be supported.
+ *   The handling of scientific and hexadecimal notation is unspecified.
+ * - Whether or not INF and NAN can be parsed is unspecified.
+ * - The precision of the result is unspecified.
+ *
+ * `str` and `endp` must not overlap.
+ *
+ * \param str The null-terminated string to read. Must not be NULL and must not overlap with `endp`.
+ * \param endp If not NULL, the address of the first invalid character
+ *             (i.e. the next character after the parsed number) will be written to this pointer.
+ *             Must not overlap with `dst`.
+ * \returns The parsed `double`.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_atoi
+ * \sa SDL_atof
+ * \sa SDL_strtol
+ * \sa SDL_strtoll
+ * \sa SDL_strtoul
+ * \sa SDL_strtoull
+ */
 extern SDL_DECLSPEC double SDLCALL SDL_strtod(const char *str, char **endp);
 
 /**

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -1756,7 +1756,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_strncasecmp(const char *str1, const char *st
  *
  * \since This function is available since SDL 3.0.0.
  */
-extern SDL_DECLSPEC char * SDLCALL SDL_strpbrk(const char * SDL_RESTRICT str, const char * SDL_RESTRICT breakset);
+extern SDL_DECLSPEC char * SDLCALL SDL_strpbrk(const char *str, const char *breakset);
 
 /**
  * The Unicode REPLACEMENT CHARACTER codepoint.

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -1261,7 +1261,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_memcpy(SDL_OUT_BYTECAP(len) void *dst, SD
  * Copy memory.
  *
  * It is okay for the memory regions to overlap.
- * If you are confident that the regions never overlap, using SDL_memset() may improve performance.
+ * If you are confident that the regions never overlap, using SDL_memcpy() may improve performance.
  *
  * \param dst The destination memory region. Must not be NULL.
  * \param src The source memory region. Must not be NULL.
@@ -1483,12 +1483,9 @@ extern SDL_DECLSPEC int SDLCALL SDL_wcsncasecmp(const wchar_t *str1, const wchar
  * - Only the bases 10 and 16 are guaranteed to be supported. The behavior for other bases is unspecified.
  * - It is unspecified what this function returns when the parsed integer does not fit inside a `long`.
  *
- * `str` and `endp` must not overlap.
- *
- * \param str The null-terminated wide string to read. Must not be NULL and must not overlap with `endp`.
+ * \param str The null-terminated wide string to read. Must not be NULL.
  * \param endp If not NULL, the address of the first invalid wide character
  *             (i.e. the next character after the parsed number) will be written to this pointer.
- *             Must not overlap with `dst`.
  * \param base The base of the integer to read. The values 0, 10 and 16 are supported.
  *             If 0, the base will be inferred from the integer's prefix.
  * \returns The parsed `long`.
@@ -1508,8 +1505,6 @@ extern SDL_DECLSPEC size_t SDLCALL SDL_strnlen(const char *str, size_t maxlen);
  * Copy a string.
  *
  * This function copies up to `maxlen` - 1 characters from `src` to `dst`, then appends a null terminator.
- *
- * `src` and `dst` must not overlap.
  *
  * If `maxlen` is 0, no characters are copied and no null terminator is written.
  *
@@ -1539,8 +1534,7 @@ extern SDL_DECLSPEC size_t SDLCALL SDL_strlcpy(SDL_OUT_Z_CAP(maxlen) char *dst, 
  *
  * `src` and `dst` must not overlap.
  *
- * Note that unlike SDL_strlcpy(), `dst_bytes` must not be 0. Also note that unlike SDL_strlcpy(),
- * this function returns the number of bytes written, not the length of `src`.
+ * Note that unlike SDL_strlcpy(), this function returns the number of bytes written, not the length of `src`.
  *
  * \param dst The destination buffer. Must not be NULL, and must not overlap with `src`.
  * \param src The null-terminated UTF-8 string to copy. Must not be NULL, and must not overlap with `dst`.
@@ -1665,7 +1659,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_atoi(const char *str);
 /**
  * Parse a `double` from a string.
  *
- * The result of calling `SDL_atoi(str)` is equivalent to `SDL_strtod(str, NULL)`.
+ * The result of calling `SDL_atof(str)` is equivalent to `SDL_strtod(str, NULL)`.
  *
  * \param str The null-terminated string to read. Must not be NULL.
  * \returns The parsed `double`.
@@ -1691,12 +1685,9 @@ extern SDL_DECLSPEC double SDLCALL SDL_atof(const char *str);
  * - Only the bases 10 and 16 are guaranteed to be supported. The behavior for other bases is unspecified.
  * - It is unspecified what this function returns when the parsed integer does not fit inside a `long`.
  *
- * `str` and `endp` must not overlap.
- *
- * \param str The null-terminated string to read. Must not be NULL and must not overlap with `endp`.
+ * \param str The null-terminated string to read. Must not be NULL.
  * \param endp If not NULL, the address of the first invalid character
  *             (i.e. the next character after the parsed number) will be written to this pointer.
- *             Must not overlap with `dst`.
  * \param base The base of the integer to read. The values 0, 10 and 16 are supported.
  *             If 0, the base will be inferred from the integer's prefix.
  * \returns The parsed `long`.
@@ -1724,12 +1715,9 @@ extern SDL_DECLSPEC long SDLCALL SDL_strtol(const char *str, char **endp, int ba
  * - Only the bases 10 and 16 are guaranteed to be supported. The behavior for other bases is unspecified.
  * - It is unspecified what this function returns when the parsed integer does not fit inside an `unsigned long`.
  *
- * `str` and `endp` must not overlap.
- *
- * \param str The null-terminated string to read. Must not be NULL and must not overlap with `endp`.
+ * \param str The null-terminated string to read. Must not be NULL.
  * \param endp If not NULL, the address of the first invalid character
  *             (i.e. the next character after the parsed number) will be written to this pointer.
- *             Must not overlap with `dst`.
  * \param base The base of the integer to read. The values 0, 10 and 16 are supported.
  *             If 0, the base will be inferred from the integer's prefix.
  * \returns The parsed `unsigned long`.
@@ -1758,12 +1746,9 @@ extern SDL_DECLSPEC unsigned long SDLCALL SDL_strtoul(const char *str, char **en
  *
  * Also note that unlike the C runtime `strtoll`, this function returns an Sint64, not a `long long`.
  *
- * `str` and `endp` must not overlap.
- *
- * \param str The null-terminated string to read. Must not be NULL and must not overlap with `endp`.
+ * \param str The null-terminated string to read. Must not be NULL.
  * \param endp If not NULL, the address of the first invalid character
  *             (i.e. the next character after the parsed number) will be written to this pointer.
- *             Must not overlap with `dst`.
  * \param base The base of the integer to read. The values 0, 10 and 16 are supported.
  *             If 0, the base will be inferred from the integer's prefix.
  * \returns The parsed Sint64.
@@ -1792,12 +1777,9 @@ extern SDL_DECLSPEC Sint64 SDLCALL SDL_strtoll(const char *str, char **endp, int
  *
  * Also note that unlike the C runtime `strtoull`, this function returns a Uint64, not an `unsigned long long`.
  *
- * `str` and `endp` must not overlap.
- *
- * \param str The null-terminated string to read. Must not be NULL and must not overlap with `endp`.
+ * \param str The null-terminated string to read. Must not be NULL.
  * \param endp If not NULL, the address of the first invalid character
  *             (i.e. the next character after the parsed number) will be written to this pointer.
- *             Must not overlap with `dst`.
  * \param base The base of the integer to read. The values 0, 10 and 16 are supported.
  *             If 0, the base will be inferred from the integer's prefix.
  * \returns The parsed Uint64.
@@ -1826,12 +1808,9 @@ extern SDL_DECLSPEC Uint64 SDLCALL SDL_strtoull(const char *str, char **endp, in
  * - Whether or not INF and NAN can be parsed is unspecified.
  * - The precision of the result is unspecified.
  *
- * `str` and `endp` must not overlap.
- *
- * \param str The null-terminated string to read. Must not be NULL and must not overlap with `endp`.
+ * \param str The null-terminated string to read. Must not be NULL.
  * \param endp If not NULL, the address of the first invalid character
  *             (i.e. the next character after the parsed number) will be written to this pointer.
- *             Must not overlap with `dst`.
  * \returns The parsed `double`.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -1969,9 +1948,9 @@ extern SDL_DECLSPEC int SDLCALL SDL_strncasecmp(const char *str1, const char *st
  * Searches a string for the first occurence of any character contained in a
  * breakset, and returns a pointer from the string to that character.
  *
- * \param str The null-terminated string to be searched.
+ * \param str The null-terminated string to be searched. Must not be NULL, and must not overlap with `breakset`.
  * \param breakset A null-terminated string containing the list of characters
- *                 to look for.
+ *                 to look for. Must not be NULL, and must not overlap with `str`.
  * \returns A pointer to the location, in str, of the first occurence of a
  *          character present in the breakset, or NULL if none is found.
  *

--- a/src/dynapi/gendynapi.py
+++ b/src/dynapi/gendynapi.py
@@ -180,7 +180,6 @@ def main():
             func = re.sub(r" SDL_RELEASE\(.*\)", "", func);
             func = re.sub(r" SDL_RELEASE_SHARED\(.*\)", "", func);
             func = re.sub(r" SDL_RELEASE_GENERIC\(.*\)", "", func);
-            func = func.replace(" SDL_RESTRICT", "");
 
             # Should be a valid function here
             match = reg_parsing_function.match(func)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I found some spare time to document a few of the SDL_stdinc.h APIs ~~and add missing SDL_RESTRICT qualifiers to match the libc function signatures.~~

~~I also added `SDL_RESTRICT` qualifiers to the corresponding implementations. Let me know if you believe there are any problems with doing this.~~

Update: The `SDL_RESTRICT` macro has now been removed entirely in favor of documenting aliasing invariants in doc comments.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
