### PR TITLE
Fix/gdk build

### DIFF
--- a/VisualC/SDL/SDL.vcxproj.filters
+++ b/VisualC/SDL/SDL.vcxproj.filters
@@ -198,6 +198,7 @@
     </Filter>
     <Filter Include="time\windows">
       <UniqueIdentifier>{0000d7fda065b13b0ca4ab262c380000}</UniqueIdentifier>
+    </Filter>
     <Filter Include="gpu">
       <UniqueIdentifier>{098fbef9-d8a0-4b3b-b57b-d157d395335d}</UniqueIdentifier>
     </Filter>
@@ -909,6 +910,7 @@
     </ClInclude>
     <ClInclude Include="..\..\src\video\offscreen\SDL_offscreenwindow.h">
       <Filter>video\offscreen</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\SDL3\SDL_gpu.h">
       <Filter>API Headers</Filter>
     </ClInclude>

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -3199,7 +3199,10 @@ static SDL_GPUCommandBuffer *D3D11_AcquireCommandBuffer(
     commandBuffer = D3D11_INTERNAL_GetInactiveCommandBufferFromPool(renderer);
     commandBuffer->graphicsPipeline = NULL;
     commandBuffer->stencilRef = 0;
-    commandBuffer->blendConstants = (SDL_FColor){ 1.0f, 1.0f, 1.0f, 1.0f };
+    commandBuffer->blendConstants.r = 1.0f;
+    commandBuffer->blendConstants.g = 1.0f;
+    commandBuffer->blendConstants.b = 1.0f;
+    commandBuffer->blendConstants.a = 1.0f;
     commandBuffer->computePipeline = NULL;
     for (i = 0; i < MAX_COLOR_TARGET_BINDINGS; i += 1) {
         commandBuffer->colorTargetResolveTexture[i] = NULL;
@@ -3617,9 +3620,15 @@ static void D3D11_BeginRenderPass(
         commandBuffer,
         0);
 
+    SDL_FColor blendConstants;
+    blendConstants.r = 1.0f;
+    blendConstants.g = 1.0f;
+    blendConstants.b = 1.0f;
+    blendConstants.a = 1.0f;
+
     D3D11_SetBlendConstants(
         commandBuffer,
-        (SDL_FColor){ 1.0f, 1.0f, 1.0f, 1.0f });
+        blendConstants);
 }
 
 static void D3D11_BindGraphicsPipeline(

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -3950,9 +3950,15 @@ static void D3D12_BeginRenderPass(
         commandBuffer,
         0);
 
+    SDL_FColor blendConstants;
+    blendConstants.r = 1.0f;
+    blendConstants.g = 1.0f;
+    blendConstants.b = 1.0f;
+    blendConstants.a = 1.0f;
+
     D3D12_SetBlendConstants(
         commandBuffer,
-        (SDL_FColor){ 1.0f, 1.0f, 1.0f, 1.0f });
+        blendConstants);
 }
 
 static void D3D12_INTERNAL_TrackUniformBuffer(

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -3038,7 +3038,7 @@ static D3D12Buffer *D3D12_INTERNAL_CreateBuffer(
         resourceFlags |= D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
     }
 #if (defined(SDL_PLATFORM_XBOXONE) || defined(SDL_PLATFORM_XBOXSERIES))
-    if (usage & SDL_GPU_BUFFERUSAGE_INDIRECT) {
+    if (usageFlags & SDL_GPU_BUFFERUSAGE_INDIRECT) {
         resourceFlags |= D3D12XBOX_RESOURCE_FLAG_ALLOW_INDIRECT_BUFFER;
     }
 #endif
@@ -5828,8 +5828,8 @@ static bool D3D12_SupportsSwapchainComposition(
 {
 #if defined(SDL_PLATFORM_XBOXONE) || defined(SDL_PLATFORM_XBOXSERIES)
     // FIXME: HDR support would be nice to add, but it seems complicated...
-    return swapchain_composition == SDL_GPU_SWAPCHAINCOMPOSITION_SDR ||
-           swapchain_composition == SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR;
+    return swapchainComposition == SDL_GPU_SWAPCHAINCOMPOSITION_SDR ||
+           swapchainComposition == SDL_GPU_SWAPCHAINCOMPOSITION_SDR_LINEAR;
 #else
     D3D12Renderer *renderer = (D3D12Renderer *)driverData;
     DXGI_FORMAT format;
@@ -5937,7 +5937,7 @@ static bool D3D12_INTERNAL_CreateSwapchain(
 
     // Initialize the swapchain data
     windowData->present_mode = present_mode;
-    windowData->swapchain_composition = swapchain_composition;
+    windowData->swapchainComposition = swapchain_composition;
     windowData->swapchainColorSpace = DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
     windowData->frameCounter = 0;
     windowData->swapchainWidth = width;
@@ -5999,7 +5999,7 @@ static bool D3D12_INTERNAL_ResizeSwapchainIfNeeded(
         D3D12_INTERNAL_CreateSwapchain(
             renderer,
             windowData,
-            windowData->swapchain_composition,
+            windowData->swapchainComposition,
             windowData->present_mode);
     }
 
@@ -7525,7 +7525,7 @@ static void D3D12_INTERNAL_InitBlitResources(
     }
 }
 
-static bool D3D12_PrepareDriver(SDL_VideoDevice *this)
+static bool D3D12_PrepareDriver(SDL_VideoDevice *_this)
 {
 #if defined(SDL_PLATFORM_XBOXONE) || defined(SDL_PLATFORM_XBOXSERIES)
     return true;
@@ -7922,7 +7922,7 @@ static SDL_GPUDevice *D3D12_CreateDevice(bool debugMode, bool preferLowPower, SD
 #if defined(SDL_PLATFORM_XBOXSERIES)
         createDeviceParams.DisableDXR = TRUE;
 #endif
-        if (debug_mode) {
+        if (debugMode) {
             createDeviceParams.ProcessDebugFlags = D3D12XBOX_PROCESS_DEBUG_FLAG_DEBUG;
         }
 

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -2153,6 +2153,7 @@ static void METAL_BeginRenderPass(
         Uint32 vpHeight = UINT_MAX;
         SDL_GPUViewport viewport;
         SDL_Rect scissorRect;
+        SDL_FColor blendConstants;
 
         for (Uint32 i = 0; i < numColorTargets; i += 1) {
             MetalTextureContainer *container = (MetalTextureContainer *)colorTargetInfos[i].texture;
@@ -2268,9 +2269,13 @@ static void METAL_BeginRenderPass(
         scissorRect.h = vpHeight;
         METAL_SetScissor(commandBuffer, &scissorRect);
 
+        blendConstants.r = 1.0f;
+        blendConstants.g = 1.0f;
+        blendConstants.b = 1.0f;
+        blendConstants.a = 1.0f;
         METAL_SetBlendConstants(
             commandBuffer,
-            (SDL_FColor){ 1.0f, 1.0f, 1.0f, 1.0f });
+            blendConstants);
 
         METAL_SetStencilReference(
             commandBuffer,

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -7863,6 +7863,7 @@ static void VULKAN_BeginRenderPass(
     Uint32 i;
     SDL_GPUViewport defaultViewport;
     SDL_Rect defaultScissor;
+    SDL_FColor defaultBlendConstants;
     Uint32 framebufferWidth = UINT32_MAX;
     Uint32 framebufferHeight = UINT32_MAX;
 
@@ -8056,9 +8057,14 @@ static void VULKAN_BeginRenderPass(
         vulkanCommandBuffer,
         &defaultScissor);
 
+    defaultBlendConstants.r = 1.0f;
+    defaultBlendConstants.g = 1.0f;
+    defaultBlendConstants.b = 1.0f;
+    defaultBlendConstants.a = 1.0f;
+
     VULKAN_INTERNAL_SetCurrentBlendConstants(
         vulkanCommandBuffer,
-        (SDL_FColor){ 1.0f, 1.0f, 1.0f, 1.0f });
+        defaultBlendConstants);
 
     VULKAN_INTERNAL_SetCurrentStencilReference(
         vulkanCommandBuffer,

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -4461,17 +4461,17 @@ static bool VULKAN_INTERNAL_CreateSwapchain(
     bool hasValidSwapchainComposition, hasValidPresentMode;
     Sint32 drawableWidth, drawableHeight;
     Uint32 i;
-    SDL_VideoDevice *this = SDL_GetVideoDevice();
+    SDL_VideoDevice *_this = SDL_GetVideoDevice();
 
-    SDL_assert(this && this->Vulkan_CreateSurface);
+    SDL_assert(_this && _this->Vulkan_CreateSurface);
 
     swapchainData = SDL_malloc(sizeof(VulkanSwapchainData));
     swapchainData->frameCounter = 0;
 
     // Each swapchain must have its own surface.
 
-    if (!this->Vulkan_CreateSurface(
-            this,
+    if (!_this->Vulkan_CreateSurface(
+            _this,
             windowData->window,
             renderer->instance,
             NULL, // FIXME: VAllocationCallbacks
@@ -11629,13 +11629,13 @@ static bool VULKAN_INTERNAL_PrepareVulkan(
     return true;
 }
 
-static bool VULKAN_PrepareDriver(SDL_VideoDevice *this)
+static bool VULKAN_PrepareDriver(SDL_VideoDevice *_this)
 {
     // Set up dummy VulkanRenderer
     VulkanRenderer *renderer;
     Uint8 result;
 
-    if (this->Vulkan_CreateSurface == NULL) {
+    if (_this->Vulkan_CreateSurface == NULL) {
         return false;
     }
 


### PR DESCRIPTION
These are updates to #10704 and #10730.

## Description
With #10704, when targeting Xbox/GDK, the compiler complains about `error C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax`.

Some changes in #10730 do not compile on Xbox. I also undid the rename of `_this` parameters to `this`.

The third commit fixes the VisualC project filter. Don't we all love editing XML by hand...
