### PR TITLE
SDL_realloc() with size 0 now always defaults to size 1

### DIFF
--- a/src/stdlib/SDL_malloc.c
+++ b/src/stdlib/SDL_malloc.c
@@ -6461,7 +6461,7 @@ void *SDL_realloc(void *ptr, size_t size)
 {
     void *mem;
 
-    if (!ptr && !size) {
+    if (!size) {
         size = 1;
     }
 


### PR DESCRIPTION
In `SDL_realloc()`, when `size` is `0`, it is changed to `1`, but only if `ptr` is `NULL`:
https://github.com/libsdl-org/SDL/blob/1ba99c53d48ec1f1f7c58b20326fc0c964ce5aa2/src/stdlib/SDL_malloc.c#L6460-L6468

This could be a problem, when calling `SDL_realloc()` with size 0 and a valid `ptr`. Then `size` would stay `0`,
`realloc(ptr, 0)` would be called and then the return value would be implementation-defined:
```c
void *ptr1 = SDL_realloc(NULL, 0); // OK, size is changed to 1

const size_t some_value = 123;
void *ptr2 = SDL_malloc(some_value);
if (ptr2) {
    void *ptr3 = SDL_realloc(ptr2, 0); // <===== implementation-defined return value
}
```