### PR TITLE
Remove unused includes

### DIFF
--- a/include/SDL3/SDL_audio.h
+++ b/include/SDL3/SDL_audio.h
@@ -94,7 +94,6 @@
 #include <SDL3/SDL_mutex.h>
 #include <SDL3/SDL_properties.h>
 #include <SDL3/SDL_iostream.h>
-#include <SDL3/SDL_thread.h>
 
 #include <SDL3/SDL_begin_code.h>
 /* Set up for C function definitions, even when using C++ */

--- a/include/SDL3/SDL_camera.h
+++ b/include/SDL3/SDL_camera.h
@@ -38,7 +38,6 @@
 #include <SDL3/SDL_pixels.h>
 #include <SDL3/SDL_properties.h>
 #include <SDL3/SDL_surface.h>
-#include <SDL3/SDL_video.h>
 
 #include <SDL3/SDL_begin_code.h>
 /* Set up for C function definitions, even when using C++ */

--- a/include/SDL3/SDL_guid.h
+++ b/include/SDL3/SDL_guid.h
@@ -32,7 +32,6 @@
 #define SDL_guid_h_
 
 #include <SDL3/SDL_stdinc.h>
-#include <SDL3/SDL_error.h>
 
 #include <SDL3/SDL_begin_code.h>
 /* Set up for C function definitions, even when using C++ */

--- a/include/SDL3/SDL_pen.h
+++ b/include/SDL3/SDL_pen.h
@@ -40,7 +40,6 @@
 #define SDL_pen_h_
 
 #include <SDL3/SDL_stdinc.h>
-#include <SDL3/SDL_error.h>
 
 /* Set up for C function definitions, even when using C++ */
 #ifdef __cplusplus

--- a/include/SDL3/SDL_system.h
+++ b/include/SDL3/SDL_system.h
@@ -31,7 +31,6 @@
 #include <SDL3/SDL_stdinc.h>
 #include <SDL3/SDL_error.h>
 #include <SDL3/SDL_keyboard.h>
-#include <SDL3/SDL_render.h>
 #include <SDL3/SDL_video.h>
 
 #include <SDL3/SDL_begin_code.h>

--- a/include/SDL3/SDL_thread.h
+++ b/include/SDL3/SDL_thread.h
@@ -34,7 +34,6 @@
 
 /* Thread synchronization primitives */
 #include <SDL3/SDL_atomic.h>
-#include <SDL3/SDL_mutex.h>
 
 #if defined(SDL_PLATFORM_WINDOWS)
 #include <process.h> /* _beginthreadex() and _endthreadex() */

--- a/include/SDL3/SDL_touch.h
+++ b/include/SDL3/SDL_touch.h
@@ -31,7 +31,6 @@
 #include <SDL3/SDL_stdinc.h>
 #include <SDL3/SDL_error.h>
 #include <SDL3/SDL_mouse.h>
-#include <SDL3/SDL_video.h>
 
 #include <SDL3/SDL_begin_code.h>
 /* Set up for C function definitions, even when using C++ */

--- a/include/SDL3/SDL_version.h
+++ b/include/SDL3/SDL_version.h
@@ -30,7 +30,6 @@
 #define SDL_version_h_
 
 #include <SDL3/SDL_stdinc.h>
-#include <SDL3/SDL_error.h>
 
 #include <SDL3/SDL_begin_code.h>
 /* Set up for C function definitions, even when using C++ */


### PR DESCRIPTION
As discussed in #10748, this removes unused includes. It only removes includes that are completely unused. Some includes appear to be unused but have symbols referenced to in comments, I didn't remove those in case it'd break a documentation processor.

This removes `stdinc.h` from some files. I'm not sure if you want to keep that even if it's unused.