### PR TITLE
Fix warning: redefinition of typedef 'SDLTest_TestSuiteRunner'

### DIFF
--- a/src/test/SDL_test_harness.c
+++ b/src/test/SDL_test_harness.c
@@ -47,7 +47,7 @@
 /* Final result message format */
 #define SDLTEST_FINAL_RESULT_FORMAT COLOR_YELLOW ">>> %s '%s':" COLOR_END " %s\n"
 
-typedef struct SDLTest_TestSuiteRunner {
+struct SDLTest_TestSuiteRunner {
     struct
     {
         SDLTest_TestSuiteReference **testSuites;
@@ -59,7 +59,7 @@ typedef struct SDLTest_TestSuiteRunner {
     } user;
 
     SDLTest_ArgumentParser argparser;
-} SDLTest_TestSuiteRunner;
+};
 
 /* ! Timeout for single test case execution */
 static Uint32 SDLTest_TestCaseTimeout = 3600;;


### PR DESCRIPTION
```c
/path/to/SDL-git/src/test/SDL_test_harness.c:62:3: warning: redefinition of typedef 'SDLTest_TestSuiteRunner' is a C11 feature [-Wtypedef-redefinition]
   62 | } SDLTest_TestSuiteRunner;
      |   ^
/path/to/SDL-git/include/SDL3/SDL_test_harness.h:117:40: note: previous definition is here
  117 | typedef struct SDLTest_TestSuiteRunner SDLTest_TestSuiteRunner;
      |                                        ^
```