### PR TITLE
Fix warnings: calloc-transposed-args

### DIFF
--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -2710,7 +2710,7 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeFileDialog)(
 
         // Convert fileList to string
         size_t count = (*env)->GetArrayLength(env, fileList);
-        char **charFileList = SDL_calloc(sizeof(char*), count + 1);
+        char **charFileList = SDL_calloc(count + 1, sizeof(char*));
 
         if (charFileList == NULL) {
             mAndroidFileDialogData.callback(mAndroidFileDialogData.userdata, NULL, -1);

--- a/src/core/freebsd/SDL_evdev_kbd_freebsd.c
+++ b/src/core/freebsd/SDL_evdev_kbd_freebsd.c
@@ -241,9 +241,9 @@ SDL_EVDEV_keyboard_state *SDL_EVDEV_kbd_init(void)
 
     kbd->shift_state = 0;
 
-    kbd->accents = SDL_calloc(sizeof(accentmap_t), 1);
-    kbd->key_map = SDL_calloc(sizeof(keymap_t), 1);
-    kbd->kbInfo = SDL_calloc(sizeof(keyboard_info_t), 1);
+    kbd->accents = SDL_calloc(1, sizeof(accentmap_t));
+    kbd->key_map = SDL_calloc(1, sizeof(keymap_t));
+    kbd->kbInfo = SDL_calloc(1, sizeof(keyboard_info_t));
 
     ioctl(kbd->console_fd, KDGKBINFO, kbd->kbInfo);
     ioctl(kbd->console_fd, CONS_MOUSECTL, &mData);

--- a/src/core/openbsd/SDL_wscons_kbd.c
+++ b/src/core/openbsd/SDL_wscons_kbd.c
@@ -435,7 +435,7 @@ static SDL_WSCONS_input_data *SDL_WSCONS_Init_Keyboard(const char *dev)
     input->keyboardID = SDL_GetNextObjectID();
     SDL_AddKeyboard(input->keyboardID, NULL, false);
 
-    input->keymap.map = SDL_calloc(sizeof(struct wscons_keymap), KS_NUMKEYCODES);
+    input->keymap.map = SDL_calloc(KS_NUMKEYCODES, sizeof(struct wscons_keymap));
     if (!input->keymap.map) {
         SDL_free(input);
         return NULL;

--- a/src/dialog/unix/SDL_portaldialog.c
+++ b/src/dialog/unix/SDL_portaldialog.c
@@ -96,7 +96,7 @@ static void DBus_AppendFilter(SDL_DBusContext *dbus, DBusMessageIter *parent, co
         dbus->message_iter_open_container(&filter_array, DBUS_TYPE_STRUCT, NULL, &filter_array_entry);
         dbus->message_iter_append_basic(&filter_array_entry, DBUS_TYPE_UINT32, &zero);
 
-        glob_pattern = SDL_calloc(sizeof(char), max_len);
+        glob_pattern = SDL_calloc(max_len, sizeof(char));
         if (!glob_pattern) {
             goto cleanup;
         }

--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -1086,7 +1086,7 @@ SDL_Joystick *SDL_OpenJoystick(SDL_JoystickID instance_id)
     }
 
     // Create and initialize the joystick
-    joystick = (SDL_Joystick *)SDL_calloc(sizeof(*joystick), 1);
+    joystick = (SDL_Joystick *)SDL_calloc(1, sizeof(*joystick));
     if (!joystick) {
         SDL_UnlockJoysticks();
         return NULL;

--- a/src/joystick/linux/SDL_sysjoystick.c
+++ b/src/joystick/linux/SDL_sysjoystick.c
@@ -2335,7 +2335,7 @@ static bool LINUX_JoystickGetGamepadMapping(int device_index, SDL_GamepadMapping
 
     /* We temporarily open the device to check how it's configured. Make
        a fake SDL_Joystick object to do so. */
-    joystick = (SDL_Joystick *)SDL_calloc(sizeof(*joystick), 1);
+    joystick = (SDL_Joystick *)SDL_calloc(1, sizeof(*joystick));
     if (!joystick) {
         return false;
     }

--- a/src/render/vulkan/SDL_render_vulkan.c
+++ b/src/render/vulkan/SDL_render_vulkan.c
@@ -1599,7 +1599,7 @@ static bool VULKAN_DeviceExtensionsFound(VULKAN_RenderData *rendererData, int ex
         return false;
     }
     if (extensionCount > 0 ) {
-        VkExtensionProperties *extensionProperties = (VkExtensionProperties *)SDL_calloc(sizeof(VkExtensionProperties), extensionCount);
+        VkExtensionProperties *extensionProperties = (VkExtensionProperties *)SDL_calloc(extensionCount, sizeof(VkExtensionProperties));
         result = vkEnumerateDeviceExtensionProperties(rendererData->physicalDevice, NULL, &extensionCount, extensionProperties);
         if (result != VK_SUCCESS ) {
             SDL_LogError(SDL_LOG_CATEGORY_RENDER, "vkEnumerateDeviceExtensionProperties): %s.\n", SDL_Vulkan_GetResultString(result));
@@ -2356,8 +2356,8 @@ static VkResult VULKAN_CreateSwapChain(SDL_Renderer *renderer, int w, int h)
         }
         SDL_free(rendererData->renderingFinishedSemaphores);
     }
-    rendererData->imageAvailableSemaphores = (VkSemaphore *)SDL_calloc(sizeof(VkSemaphore), rendererData->swapchainImageCount);
-    rendererData->renderingFinishedSemaphores = (VkSemaphore *)SDL_calloc(sizeof(VkSemaphore), rendererData->swapchainImageCount);
+    rendererData->imageAvailableSemaphores = (VkSemaphore *)SDL_calloc(rendererData->swapchainImageCount, sizeof(VkSemaphore));
+    rendererData->renderingFinishedSemaphores = (VkSemaphore *)SDL_calloc(rendererData->swapchainImageCount, sizeof(VkSemaphore));
     for (uint32_t i = 0; i < rendererData->swapchainImageCount; i++) {
         rendererData->imageAvailableSemaphores[i] = VULKAN_CreateSemaphore(rendererData);
         if (rendererData->imageAvailableSemaphores[i] == VK_NULL_HANDLE) {

--- a/src/sensor/SDL_sensor.c
+++ b/src/sensor/SDL_sensor.c
@@ -321,7 +321,7 @@ SDL_Sensor *SDL_OpenSensor(SDL_SensorID instance_id)
     }
 
     // Create and initialize the sensor
-    sensor = (SDL_Sensor *)SDL_calloc(sizeof(*sensor), 1);
+    sensor = (SDL_Sensor *)SDL_calloc(1, sizeof(*sensor));
     if (!sensor) {
         SDL_UnlockSensors();
         return NULL;

--- a/src/video/gdk/SDL_gdktextinput.cpp
+++ b/src/video/gdk/SDL_gdktextinput.cpp
@@ -123,7 +123,7 @@ static void CALLBACK GDK_InternalTextEntryCallback(XAsyncBlock *asyncBlock)
         SDL_SetError("XGameUiShowTextEntryResultSize failure with HRESULT of %08X", hR);
     } else if (resultSize > 0) {
         // +1 to be super sure that the buffer will be null terminated
-        resultBuffer = (char *)SDL_calloc(sizeof(*resultBuffer), 1 + (size_t)resultSize);
+        resultBuffer = (char *)SDL_calloc(1 + (size_t)resultSize, sizeof(*resultBuffer));
         if (resultBuffer) {
             // still pass the original size that we got from ResultSize
             if (FAILED(hR = XGameUiShowTextEntryResult(

--- a/test/testdropfile.c
+++ b/test/testdropfile.c
@@ -57,7 +57,7 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
     if (!SDLTest_CommonInit(state)) {
         goto onerror;
     }
-    dialog = SDL_calloc(sizeof(dropfile_dialog), 1);
+    dialog = SDL_calloc(1, sizeof(dropfile_dialog));
     if (!dialog) {
         goto onerror;
     }

--- a/test/testffmpeg_vulkan.c
+++ b/test/testffmpeg_vulkan.c
@@ -221,7 +221,7 @@ static int createInstance(VulkanVideoContext *context)
     {
         uint32_t extensionCount;
         if (context->vkEnumerateInstanceExtensionProperties(NULL, &extensionCount, NULL) == VK_SUCCESS && extensionCount > 0) {
-            VkExtensionProperties *extensionProperties = SDL_calloc(sizeof(VkExtensionProperties), extensionCount);
+            VkExtensionProperties *extensionProperties = SDL_calloc(extensionCount, sizeof(VkExtensionProperties));
             if (context->vkEnumerateInstanceExtensionProperties(NULL, &extensionCount, extensionProperties) == VK_SUCCESS) {
                 for (uint32_t i = 0; i < SDL_arraysize(optional_extensions); ++i) {
                     for (uint32_t j = 0; j < extensionCount; ++j) {
@@ -595,7 +595,7 @@ static int createDevice(VulkanVideoContext *context)
     {
         uint32_t extensionCount;
         if (context->vkEnumerateDeviceExtensionProperties(context->physicalDevice, NULL, &extensionCount, NULL) == VK_SUCCESS && extensionCount > 0) {
-            VkExtensionProperties *extensionProperties = SDL_calloc(sizeof(VkExtensionProperties), extensionCount);
+            VkExtensionProperties *extensionProperties = SDL_calloc(extensionCount, sizeof(VkExtensionProperties));
             if (context->vkEnumerateDeviceExtensionProperties(context->physicalDevice, NULL, &extensionCount, extensionProperties) == VK_SUCCESS) {
                 for (uint32_t i = 0; i < SDL_arraysize(optional_extensions); ++i) {
                     for (uint32_t j = 0; j < extensionCount; ++j) {


### PR DESCRIPTION
`calloc-transposed-args` warnings appear, when the parameters for `nmemb` and `size` are passed to `calloc()` in reversed order. (This is recognized by where `sizeof()` is called)

First commit fixes all `calloc-transposed-args` warnings I could find during SDL compilation on my platform and could test.

Second commit should fix these warnings on other platforms, which I could **not** test.
These were found with a regex search: `calloc[\s]*\([\s]*sizeof[\s]*\(`


Here are the warnings which were fixed in the first commit:
```c
/path/to/SDL-git/src/joystick/SDL_joystick.c: In function ‘SDL_OpenJoystick_REAL’:
/path/to/SDL-git/src/joystick/SDL_joystick.c:1089:49: warning: ‘SDL_calloc_REAL’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
 1089 |     joystick = (SDL_Joystick *)SDL_calloc(sizeof(*joystick), 1);
      |                                                 ^
/path/to/SDL-git/src/joystick/SDL_joystick.c:1089:49: note: earlier argument should specify number of elements, later size of each element


/path/to/SDL-git/src/sensor/SDL_sensor.c: In function ‘SDL_OpenSensor_REAL’:
/path/to/SDL-git/src/sensor/SDL_sensor.c:324:45: warning: ‘SDL_calloc_REAL’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
  324 |     sensor = (SDL_Sensor *)SDL_calloc(sizeof(*sensor), 1);
      |                                             ^
/path/to/SDL-git/src/sensor/SDL_sensor.c:324:45: note: earlier argument should specify number of elements, later size of each element


/path/to/SDL-git/src/render/vulkan/SDL_render_vulkan.c: In function ‘VULKAN_DeviceExtensionsFound’:
/path/to/SDL-git/src/render/vulkan/SDL_render_vulkan.c:1602:97: warning: ‘SDL_calloc_REAL’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
 1602 |         VkExtensionProperties *extensionProperties = (VkExtensionProperties *)SDL_calloc(sizeof(VkExtensionProperties), extensionCount);
      |                                                                                                 ^~~~~~~~~~~~~~~~~~~~~
/path/to/SDL-git/src/render/vulkan/SDL_render_vulkan.c:1602:97: note: earlier argument should specify number of elements, later size of each element


/path/to/SDL-git/src/render/vulkan/SDL_render_vulkan.c: In function ‘VULKAN_CreateSwapChain’:
/path/to/SDL-git/src/render/vulkan/SDL_render_vulkan.c:2359:79: warning: ‘SDL_calloc_REAL’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
 2359 |     rendererData->imageAvailableSemaphores = (VkSemaphore *)SDL_calloc(sizeof(VkSemaphore), rendererData->swapchainImageCount);
      |                                                                               ^~~~~~~~~~~
/path/to/SDL-git/src/render/vulkan/SDL_render_vulkan.c:2359:79: note: earlier argument should specify number of elements, later size of each element


/path/to/SDL-git/src/render/vulkan/SDL_render_vulkan.c:2360:82: warning: ‘SDL_calloc_REAL’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
 2360 |     rendererData->renderingFinishedSemaphores = (VkSemaphore *)SDL_calloc(sizeof(VkSemaphore), rendererData->swapchainImageCount);
      |                                                                                  ^~~~~~~~~~~
/path/to/SDL-git/src/render/vulkan/SDL_render_vulkan.c:2360:82: note: earlier argument should specify number of elements, later size of each element


/path/to/SDL-git/src/joystick/linux/SDL_sysjoystick.c: In function ‘LINUX_JoystickGetGamepadMapping’:
/path/to/SDL-git/src/joystick/linux/SDL_sysjoystick.c:2338:49: warning: ‘SDL_calloc_REAL’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
 2338 |     joystick = (SDL_Joystick *)SDL_calloc(sizeof(*joystick), 1);
      |                                                 ^
/path/to/SDL-git/src/joystick/linux/SDL_sysjoystick.c:2338:49: note: earlier argument should specify number of elements, later size of each element


/path/to/SDL-git/src/dialog/unix/SDL_portaldialog.c: In function ‘DBus_AppendFilter’:
/path/to/SDL-git/src/dialog/unix/SDL_portaldialog.c:99:42: warning: ‘SDL_calloc_REAL’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
   99 |         glob_pattern = SDL_calloc(sizeof(char), max_len);
      |                                          ^~~~
/path/to/SDL-git/src/dialog/unix/SDL_portaldialog.c:99:42: note: earlier argument should specify number of elements, later size of each element


/path/to/SDL-git/test/testdropfile.c: In function ‘SDL_AppInit’:
/path/to/SDL-git/test/testdropfile.c:60:32: warning: ‘SDL_calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
   60 |     dialog = SDL_calloc(sizeof(dropfile_dialog), 1);
      |                                ^~~~~~~~~~~~~~~
/path/to/SDL-git/test/testdropfile.c:60:32: note: earlier argument should specify number of elements, later size of each element


/path/to/SDL-git/test/testffmpeg_vulkan.c: In function ‘createInstance’:
/path/to/SDL-git/test/testffmpeg_vulkan.c:224:76: warning: ‘SDL_calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
  224 |             VkExtensionProperties *extensionProperties = SDL_calloc(sizeof(VkExtensionProperties), extensionCount);
      |                                                                            ^~~~~~~~~~~~~~~~~~~~~
/path/to/SDL-git/test/testffmpeg_vulkan.c:224:76: note: earlier argument should specify number of elements, later size of each element


/path/to/SDL-git/test/testffmpeg_vulkan.c: In function ‘createDevice’:
/path/to/SDL-git/test/testffmpeg_vulkan.c:598:76: warning: ‘SDL_calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
  598 |             VkExtensionProperties *extensionProperties = SDL_calloc(sizeof(VkExtensionProperties), extensionCount);
      |                                                                            ^~~~~~~~~~~~~~~~~~~~~
/path/to/SDL-git/test/testffmpeg_vulkan.c:598:76: note: earlier argument should specify number of elements, later size of each element
```