### PR TITLE
pipewire: Give hotplug threads a more indicative name

### DIFF
--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -723,7 +723,7 @@ static bool hotplug_loop_init(void)
     spa_list_init(&hotplug_pending_list);
     spa_list_init(&hotplug_io_list);
 
-    hotplug_loop = PIPEWIRE_pw_thread_loop_new("SDLAudioHotplug", NULL);
+    hotplug_loop = PIPEWIRE_pw_thread_loop_new("SDLPwAudioPlug", NULL);
     if (!hotplug_loop) {
         return SDL_SetError("Pipewire: Failed to create hotplug detection loop (%i)", errno);
     }

--- a/src/camera/pipewire/SDL_camera_pipewire.c
+++ b/src/camera/pipewire/SDL_camera_pipewire.c
@@ -981,7 +981,7 @@ static bool hotplug_loop_init(void)
 
     hotplug.have_1_0_5 = PIPEWIRE_pw_check_library_version(1,0,5);
 
-    hotplug.loop = PIPEWIRE_pw_thread_loop_new("SDLAudioHotplug", NULL);
+    hotplug.loop = PIPEWIRE_pw_thread_loop_new("SDLPwCameraPlug", NULL);
     if (!hotplug.loop) {
         return SDL_SetError("Pipewire: Failed to create hotplug detection loop (%i)", errno);
     }


### PR DESCRIPTION
When debugging crash reports, it's helpful to know which thread is associated with which external library.

Linux limits the length of a thread name to 15 bytes (not including the zero-termination), so abbreviate Pipewire to "pw" and hotplug to "plug" to fit the desired information into the allowed space.

---

Follow-up for #10738. cc @ttimo @slouken 