### PR TITLE
x11vulkan: Use the correct SONAME of libX11-xcb.so.1 on Linux, etc.

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -3979,7 +3979,7 @@ extern "C" {
 /**
  * Specify the XCB library to load for the X11 driver.
  *
- * This defaults to "libX11-xcb.so"
+ * The default is platform-specific, often "libX11-xcb.so.1".
  *
  * This hint should be set before initializing the video subsystem.
  *

--- a/src/video/x11/SDL_x11vulkan.c
+++ b/src/video/x11/SDL_x11vulkan.c
@@ -33,8 +33,10 @@
 
 #ifdef SDL_PLATFORM_OPENBSD
 #define DEFAULT_VULKAN "libvulkan.so"
+#define DEFAULT_X11_XCB "libX11-xcb.so"
 #else
 #define DEFAULT_VULKAN "libvulkan.so.1"
+#define DEFAULT_X11_XCB "libX11-xcb.so.1"
 #endif
 
 /*
@@ -109,7 +111,7 @@ bool X11_Vulkan_LoadLibrary(SDL_VideoDevice *_this, const char *path)
     } else {
         const char *libX11XCBLibraryName = SDL_GetHint(SDL_HINT_X11_XCB_LIBRARY);
         if (!libX11XCBLibraryName || !*libX11XCBLibraryName) {
-            libX11XCBLibraryName = "libX11-xcb.so";
+            libX11XCBLibraryName = DEFAULT_X11_XCB;
         }
         videoData->vulkan_xlib_xcb_library = SDL_LoadObject(libX11XCBLibraryName);
         if (!videoData->vulkan_xlib_xcb_library) {


### PR DESCRIPTION
## Description

On most Unix platforms supported by SDL, the canonical name used to load a library at runtime includes its ABI major version, and the name without a version is not guaranteed to exist on non-developer systems. libX11-xcb.so.1 is correct on Linux, and probably on other Unix platforms like FreeBSD.

A notable exception is OpenBSD, which apparently does not use ABI-suffixed names, so continue to use libX11-xcb.so there.

## Existing Issue(s)

#10677 

---

I believe this is correct, but it's untested: I don't know how to arrange for SDL3 to be on the relevant code path. I think it would be necessary to use a driver that implements `VK_KHR_XCB_SURFACE_EXTENSION_NAME` but not `VK_KHR_SURFACE_EXTENSION_NAME`.