### PR TITLE
[SDL2] wayland: Send exposure events when showing or resizing the window

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -1421,6 +1421,9 @@ void Wayland_ShowWindow(_THIS, SDL_Window *window)
      * HideWindow was called immediately before ShowWindow.
      */
     WAYLAND_wl_display_roundtrip(c->display);
+
+    /* Send an exposure event to signal that the client should draw. */
+    SDL_SendWindowEvent(window, SDL_WINDOWEVENT_EXPOSED, 0, 0);
 }
 
 static void Wayland_ReleasePopup(_THIS, SDL_Window *popup)
@@ -2094,6 +2097,7 @@ static void Wayland_HandleResize(SDL_Window *window, int width, int height, floa
         window->w = 0;
         window->h = 0;
         SDL_SendWindowEvent(window, SDL_WINDOWEVENT_RESIZED, width, height);
+        SDL_SendWindowEvent(window, SDL_WINDOWEVENT_EXPOSED, 0, 0);
         window->w = width;
         window->h = height;
         data->needs_resize_event = SDL_FALSE;


### PR DESCRIPTION
Clients may rely on this event to signal when they should redraw themselves, so send it when appropriate.

Fixes #10782
