### PR TITLE
pipewire: If hotplug initialization fails, clean up any partial success

### DIFF
--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -1252,6 +1252,7 @@ static bool PipewireInitialize(SDL_AudioDriverImpl *impl)
         }
 
         if (!hotplug_loop_init()) {
+            hotplug_loop_destroy();
             PIPEWIRE_Deinitialize();
             return false;
         }


### PR DESCRIPTION
## Description

hotplug_loop_init() calls pw_context_new(), which creates a thread internally (for the "data loop"). It also creates a thread of its own, the `hotplug_loop`.

Both of these threads are running code from libpipewire, so before we can allow the Pipewire library to be unloaded, we need to destroy the context with pw_context_destroy() and destroy the `hotplug_loop` with pw_thread_loop_destroy().

## Existing Issue(s)

Resolves: https://github.com/libsdl-org/SDL/issues/10787

---

This is a minimal solution to the reproducible crash described in https://github.com/libsdl-org/SDL/issues/10787#issue-2517517253 and the theoretical (non-reproduced) crash described in https://github.com/libsdl-org/SDL/issues/10787#issuecomment-2341871229.

A more maximal version of this would be to make `PIPEWIRE_Deinitialize()` repeat what `PIPEWIRE_DeinitializeStart()` would normally have done (even if that's redundant), so that calling `PIPEWIRE_Deinitialize()` is always a safe way to bail out from error conditions. That does involve a tiny amount of duplicated work (calling `hotplug_loop_destroy()` twice) in the happy path where `PIPEWIRE_DeinitializeStart()` was called first - but that seems harmless, because everything in `hotplug_loop_destroy()` is idempotent.

It seems worthwhile to get a minimal version into place before doing that refactor, though.

The original diff, against an older SDL snapshot that was used to reproduce #10787, was:

```
diff --git a/src/audio/pipewire/SDL_pipewire.c b/src/audio/pipewire/SDL_pipewire.c
index c258ed80d..cc779e132 100644
--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -1229,6 +1229,7 @@ static bool PipewireInitialize(SDL_AudioDriverImpl *impl)
         pipewire_initialized = true;
 
         if (hotplug_loop_init() < 0) {
+            hotplug_loop_destroy();
             PIPEWIRE_Deinitialize();
             return false;
         }
```

This is a forward-port, and has not been tested separately.