### PR TITLE
Rewrite/fix bugs in `SDL_strtol` and friends

### DIFF
--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -1499,21 +1499,18 @@ extern SDL_DECLSPEC int SDLCALL SDL_wcsncasecmp(const wchar_t *str1, const wchar
 /**
  * Parse a `long` from a wide string.
  *
- * This function makes fewer guarantees than the C runtime `wcstol`:
+ * If `str` starts with whitespace, then those whitespace characters are skipped before attempting to parse the number.
  *
- * - Only the bases 10 and 16 are guaranteed to be supported. The behavior for
- *   other bases is unspecified.
- * - It is unspecified what this function returns when the parsed integer does
- *   not fit inside a `long`.
+ * If the parsed number does not fit inside a `long`, the result is clamped to the minimum and maximum representable `long` values.
  *
  * \param str The null-terminated wide string to read. Must not be NULL.
  * \param endp If not NULL, the address of the first invalid wide character
  *             (i.e. the next character after the parsed number) will be
  *             written to this pointer.
- * \param base The base of the integer to read. The values 0, 10 and 16 are
- *             supported. If 0, the base will be inferred from the integer's
- *             prefix.
- * \returns The parsed `long`.
+ * \param base The base of the integer to read. Supported values are 0 and 2 to 36 inclusive.
+ *             If 0, the base will be inferred from the number's
+ *             prefix (0x for hexadecimal, 0 for octal, decimal otherwise).
+ * \returns The parsed `long`, or 0 if no number could be parsed.
  *
  * \threadsafety It is safe to call this function from any thread.
  *
@@ -1826,7 +1823,7 @@ extern SDL_DECLSPEC long long SDLCALL SDL_strtoll(const char *str, char **endp, 
  * - Only the bases 10 and 16 are guaranteed to be supported. The behavior for
  *   other bases is unspecified.
  * - It is unspecified what this function returns when the parsed integer does
- *   not fit inside a `long long`.
+ *   not fit inside an `unsigned long long`.
  *
  * \param str The null-terminated string to read. Must not be NULL.
  * \param endp If not NULL, the address of the first invalid character (i.e.

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -1719,21 +1719,18 @@ extern SDL_DECLSPEC double SDLCALL SDL_atof(const char *str);
 /**
  * Parse a `long` from a string.
  *
- * This function makes fewer guarantees than the C runtime `strtol`:
+ * If `str` starts with whitespace, then those whitespace characters are skipped before attempting to parse the number.
  *
- * - Only the bases 10 and 16 are guaranteed to be supported. The behavior for
- *   other bases is unspecified.
- * - It is unspecified what this function returns when the parsed integer does
- *   not fit inside a `long`.
+ * If the parsed number does not fit inside a `long`, the result is clamped to the minimum and maximum representable `long` values.
  *
  * \param str The null-terminated string to read. Must not be NULL.
  * \param endp If not NULL, the address of the first invalid character (i.e.
  *             the next character after the parsed number) will be written to
  *             this pointer.
- * \param base The base of the integer to read. The values 0, 10 and 16 are
- *             supported. If 0, the base will be inferred from the integer's
- *             prefix.
- * \returns The parsed `long`.
+ * \param base The base of the integer to read. Supported values are 0 and 2 to 36 inclusive.
+ *             If 0, the base will be inferred from the number's
+ *             prefix (0x for hexadecimal, 0 for octal, decimal otherwise).
+ * \returns The parsed `long`, or 0 if no number could be parsed.
  *
  * \threadsafety It is safe to call this function from any thread.
  *
@@ -1753,21 +1750,19 @@ extern SDL_DECLSPEC long SDLCALL SDL_strtol(const char *str, char **endp, int ba
 /**
  * Parse an `unsigned long` from a string.
  *
- * This function makes fewer guarantees than the C runtime `strtoul`:
+ * If `str` starts with whitespace, then those whitespace characters are skipped before attempting to parse the number.
  *
- * - Only the bases 10 and 16 are guaranteed to be supported. The behavior for
- *   other bases is unspecified.
- * - It is unspecified what this function returns when the parsed integer does
- *   not fit inside an `unsigned long`.
+ * If the parsed number does not fit inside an `unsigned long`,
+ * the result is clamped to the maximum representable `unsigned long` value.
  *
  * \param str The null-terminated string to read. Must not be NULL.
  * \param endp If not NULL, the address of the first invalid character (i.e.
  *             the next character after the parsed number) will be written to
  *             this pointer.
- * \param base The base of the integer to read. The values 0, 10 and 16 are
- *             supported. If 0, the base will be inferred from the integer's
- *             prefix.
- * \returns The parsed `unsigned long`.
+ * \param base The base of the integer to read. Supported values are 0 and 2 to 36 inclusive.
+ *             If 0, the base will be inferred from the number's
+ *             prefix (0x for hexadecimal, 0 for octal, decimal otherwise).
+ * \returns The parsed `unsigned long`, or 0 if no number could be parsed.
  *
  * \threadsafety It is safe to call this function from any thread.
  *
@@ -1786,21 +1781,18 @@ extern SDL_DECLSPEC unsigned long SDLCALL SDL_strtoul(const char *str, char **en
 /**
  * Parse a `long long` from a string.
  *
- * This function makes fewer guarantees than the C runtime `strtoll`:
+ * If `str` starts with whitespace, then those whitespace characters are skipped before attempting to parse the number.
  *
- * - Only the bases 10 and 16 are guaranteed to be supported. The behavior for
- *   other bases is unspecified.
- * - It is unspecified what this function returns when the parsed integer does
- *   not fit inside a `long long`.
+ * If the parsed number does not fit inside a `long long`, the result is clamped to the minimum and maximum representable `long long` values.
  *
  * \param str The null-terminated string to read. Must not be NULL.
  * \param endp If not NULL, the address of the first invalid character (i.e.
  *             the next character after the parsed number) will be written to
  *             this pointer.
- * \param base The base of the integer to read. The values 0, 10 and 16 are
- *             supported. If 0, the base will be inferred from the integer's
- *             prefix.
- * \returns The parsed `long long`.
+ * \param base The base of the integer to read. Supported values are 0 and 2 to 36 inclusive.
+ *             If 0, the base will be inferred from the number's
+ *             prefix (0x for hexadecimal, 0 for octal, decimal otherwise).
+ * \returns The parsed `long long`, or 0 if no number could be parsed.
  *
  * \threadsafety It is safe to call this function from any thread.
  *
@@ -1831,7 +1823,7 @@ extern SDL_DECLSPEC long long SDLCALL SDL_strtoll(const char *str, char **endp, 
  * \param base The base of the integer to read. Supported values are 0 and 2 to 36 inclusive.
  *             If 0, the base will be inferred from the number's
  *             prefix (0x for hexadecimal, 0 for octal, decimal otherwise).
- * \returns The parsed `unsigned long long`.
+ * \returns The parsed `unsigned long long`, or 0 if no number could be parsed.
  *
  * \threadsafety It is safe to call this function from any thread.
  *
@@ -1861,7 +1853,7 @@ extern SDL_DECLSPEC unsigned long long SDLCALL SDL_strtoull(const char *str, cha
  * \param endp If not NULL, the address of the first invalid character (i.e.
  *             the next character after the parsed number) will be written to
  *             this pointer.
- * \returns The parsed `double`.
+ * \returns The parsed `double`, or 0 if no number could be parsed.
  *
  * \threadsafety It is safe to call this function from any thread.
  *

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -587,6 +587,7 @@ typedef struct SDL_alignment_test
     void *b;
 } SDL_alignment_test;
 SDL_COMPILE_TIME_ASSERT(struct_alignment, sizeof(SDL_alignment_test) == (2 * sizeof(void *)));
+SDL_COMPILE_TIME_ASSERT(two_s_complement, (int)~(int)0 == (int)(-1));
 #endif /* DOXYGEN_SHOULD_IGNORE_THIS */
 /** \endcond */
 

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -1819,20 +1819,18 @@ extern SDL_DECLSPEC long long SDLCALL SDL_strtoll(const char *str, char **endp, 
 /**
  * Parse an `unsigned long long` from a string.
  *
- * This function makes fewer guarantees than the C runtime `strtoull`:
+ * If `str` starts with whitespace, then those whitespace characters are skipped before attempting to parse the number.
  *
- * - Only the bases 10 and 16 are guaranteed to be supported. The behavior for
- *   other bases is unspecified.
- * - It is unspecified what this function returns when the parsed integer does
- *   not fit inside an `unsigned long long`.
+ * If the parsed number does not fit inside an `unsigned long long`,
+ * the result is clamped to the maximum representable `unsigned long long` value.
  *
  * \param str The null-terminated string to read. Must not be NULL.
  * \param endp If not NULL, the address of the first invalid character (i.e.
  *             the next character after the parsed number) will be written to
  *             this pointer.
- * \param base The base of the integer to read. The values 0, 10 and 16 are
- *             supported. If 0, the base will be inferred from the integer's
- *             prefix.
+ * \param base The base of the integer to read. Supported values are 0 and 2 to 36 inclusive.
+ *             If 0, the base will be inferred from the number's
+ *             prefix (0x for hexadecimal, 0 for octal, decimal otherwise).
  * \returns The parsed `unsigned long long`.
  *
  * \threadsafety It is safe to call this function from any thread.

--- a/src/events/SDL_pen_c.h
+++ b/src/events/SDL_pen_c.h
@@ -24,7 +24,6 @@
 #ifndef SDL_pen_c_h_
 #define SDL_pen_c_h_
 
-#include "../../include/SDL3/SDL_pen.h"
 #include "SDL_mouse_c.h"
 
 typedef Uint32 SDL_PenCapabilityFlags;

--- a/src/stdlib/SDL_string.c
+++ b/src/stdlib/SDL_string.c
@@ -389,8 +389,13 @@ static size_t SDL_ScanUnsignedLongLongInternal(const char *text, int count, int 
         } while (count == 0 || (text - text_start) != count);
     }
     if (text == number_start) {
-        // no number was parsed, and thus no characters were consumed
-        text = text_start;
+        if (radix == 16 && text > text_start && (*(text - 1) == 'x' || *(text - 1) == 'X')) {
+            // the string was "0x"; consume the '0' but not the 'x'
+            --text;
+        } else {
+            // no number was parsed, and thus no characters were consumed
+            text = text_start;
+        }
     }
     if (overflow) {
         if (negative) {
@@ -478,8 +483,13 @@ static size_t SDL_ScanUnsignedLongLongInternalW(const wchar_t *text, int count, 
         } while (count == 0 || (text - text_start) != count);
     }
     if (text == number_start) {
-        // no number was parsed, and thus no characters were consumed
-        text = text_start;
+        if (radix == 16 && text > text_start && (*(text - 1) == 'x' || *(text - 1) == 'X')) {
+            // the string was "0x"; consume the '0' but not the 'x'
+            --text;
+        } else {
+            // no number was parsed, and thus no characters were consumed
+            text = text_start;
+        }
     }
     if (overflow) {
         if (negative) {
@@ -656,8 +666,7 @@ static size_t SDL_ScanFloat(const char *text, double *valuep)
     if (text == number_start) {
         // no number was parsed, and thus no characters were consumed
         text = text_start;
-    }
-    if (negative) {
+    } else if (negative) {
         value = -value;
     }
     *valuep = value;

--- a/src/stdlib/SDL_string.c
+++ b/src/stdlib/SDL_string.c
@@ -513,7 +513,7 @@ static size_t SDL_ScanLong(const char *text, int count, int radix, long *valuep)
     } else if (value > long_max) {
         value = long_max;
     }
-    *valuep = value;
+    *valuep = (long)value;
     return len;
 }
 #endif
@@ -535,7 +535,7 @@ static size_t SDL_ScanLongW(const wchar_t *text, int count, int radix, long *val
     } else if (value > long_max) {
         value = long_max;
     }
-    *valuep = value;
+    *valuep = (long)value;
     return len;
 }
 #endif
@@ -558,7 +558,7 @@ static size_t SDL_ScanUnsignedLong(const char *text, int count, int radix, unsig
     } else if (value > ulong_max) {
         value = ulong_max;
     }
-    *valuep = value;
+    *valuep = (unsigned long)value;
     return len;
 }
 #endif
@@ -581,7 +581,7 @@ static size_t SDL_ScanUintPtrT(const char *text, uintptr_t *valuep)
     } else if (value > uintptr_max) {
         value = uintptr_max;
     }
-    *valuep = value;
+    *valuep = (uintptr_t)value;
     return len;
 }
 #endif

--- a/test/testautomation_stdlib.c
+++ b/test/testautomation_stdlib.c
@@ -1347,6 +1347,129 @@ static int SDLCALL stdlib_wcstol(void *arg)
     return TEST_COMPLETED;
 }
 
+static int SDLCALL stdlib_strtoull(void *arg)
+{
+    const char *text;
+    unsigned long long result;
+    char *endp;
+    unsigned long long expected_result;
+    char *expected_endp;
+
+    // infer decimal
+
+    text = "\t  123abcxyz"; // skip leading space
+    expected_result = 123;
+    expected_endp = (char *)text + 6;
+    result = SDL_strtoull(text, &endp, 0);
+    SDLTest_AssertPass("Call to SDL_strtoull(\"\\t  123abcxyz\", &endp, 0)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %llu, got: %llu", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = "+123abcxyz";
+    expected_result = 123;
+    expected_endp = (char *)text + 4;
+    result = SDL_strtoull(text, &endp, 0);
+    SDLTest_AssertPass("Call to SDL_strtoull(\"+123abcxyz\", &endp, 0)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %llu, got: %llu", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = "-123abcxyz";
+    expected_result = 0ULL - 123;
+    expected_endp = (char *)text + 4;
+    result = SDL_strtoull(text, &endp, 0);
+    SDLTest_AssertPass("Call to SDL_strtoull(\"-123abcxyz\", &endp, 0)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %llu, got: %llu", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = "9999999999999999999999999999999999999999abcxyz";
+    expected_result = ~0ULL; // ULLONG_MAX
+    expected_endp = (char *)text + 40;
+    result = SDL_strtoull(text, &endp, 0);
+    SDLTest_AssertPass("Call to SDL_strtoull(\"9999999999999999999999999999999999999999abcxyz\", &endp, 0)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %llu, got: %llu", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = "-9999999999999999999999999999999999999999abcxyz";
+    expected_result = ~0ULL; // ULLONG_MAX
+    expected_endp = (char *)text + 41;
+    result = SDL_strtoull(text, &endp, 0);
+    SDLTest_AssertPass("Call to SDL_strtoull(\"-9999999999999999999999999999999999999999abcxyz\", &endp, 0)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %llu, got: %llu", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    // infer hexadecimal
+
+    text = "0x123abcxyz";
+    expected_result = 0x123abc;
+    expected_endp = (char *)text + 8;
+    result = SDL_strtoull(text, &endp, 0);
+    SDLTest_AssertPass("Call to SDL_strtoull(\"0x123abcxyz\", &endp, 0)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %llu, got: %llu", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = "0X123ABCXYZ"; // uppercase X
+    expected_result = 0x123abc;
+    expected_endp = (char *)text + 8;
+    result = SDL_strtoull(text, &endp, 0);
+    SDLTest_AssertPass("Call to SDL_strtoull(\"0X123ABCXYZ\", &endp, 0)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %llu, got: %llu", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    // infer octal
+
+    text = "0123abcxyz";
+    expected_result = 0123;
+    expected_endp = (char *)text + 4;
+    result = SDL_strtoull(text, &endp, 0);
+    SDLTest_AssertPass("Call to SDL_strtoull(\"0123abcxyz\", &endp, 0)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %llu, got: %llu", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    // arbitrary bases
+
+    text = "00110011";
+    expected_result = 51;
+    expected_endp = (char *)text + 8;
+    result = SDL_strtoull(text, &endp, 2);
+    SDLTest_AssertPass("Call to SDL_strtoull(\"00110011\", &endp, 2)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %llu, got: %llu", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = "-uvwxyz";
+    expected_result = -991;
+    expected_endp = (char *)text + 3;
+    result = SDL_strtoull(text, &endp, 32);
+    SDLTest_AssertPass("Call to SDL_strtoull(\"-uvwxyz\", &endp, 32)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %llu, got: %llu", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = "ZzZzZzZzZzZzZzZzZzZzZzZzZ";
+    expected_result = ~0ULL; // ULLONG_MAX
+    expected_endp = (char *)text + 25;
+    result = SDL_strtoull(text, &endp, 36);
+    SDLTest_AssertPass("Call to SDL_strtoull(\"ZzZzZzZzZzZzZzZzZzZzZzZzZ\", &endp, 36)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %llu, got: %llu", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = "-0";
+    expected_result = 0;
+    expected_endp = (char *)text + 2;
+    result = SDL_strtoull(text, &endp, 10);
+    SDLTest_AssertPass("Call to SDL_strtoull(\"-0\", &endp, 10)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %llu, got: %llu", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = " +0x"; // invalid hexadecimal
+    expected_result = 0;
+    expected_endp = (char *)text;
+    result = SDL_strtoull(text, &endp, 0);
+    SDLTest_AssertPass("Call to SDL_strtoull(\" +0x\", &endp, 0)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %llu, got: %llu", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    return TEST_COMPLETED;
+}
+
 /* ================= Test References ================== */
 
 /* Standard C routine test cases */
@@ -1398,6 +1521,10 @@ static const SDLTest_TestCaseReference stdlibTest_wcstol = {
     stdlib_wcstol, "stdlib_wcstol", "Calls to SDL_wcstol", TEST_ENABLED
 };
 
+static const SDLTest_TestCaseReference stdlibTest_strtoull = {
+    stdlib_strtoull, "stdlib_strtoull", "Calls to SDL_strtoull", TEST_ENABLED
+};
+
 /* Sequence of Standard C routine test cases */
 static const SDLTest_TestCaseReference *stdlibTests[] = {
     &stdlibTest_strnlen,
@@ -1412,6 +1539,7 @@ static const SDLTest_TestCaseReference *stdlibTests[] = {
     &stdlibTest_iconv,
     &stdlibTest_strpbrk,
     &stdlibTest_wcstol,
+    &stdlibTest_strtoull,
     NULL
 };
 

--- a/test/testautomation_stdlib.c
+++ b/test/testautomation_stdlib.c
@@ -1624,6 +1624,57 @@ static int SDLCALL stdlib_strtoull(void *arg)
     return TEST_COMPLETED;
 }
 
+static int SDLCALL stdlib_strtod(void *arg)
+{
+    const char *text;
+    double result;
+    char *endp;
+    double expected_result;
+    char *expected_endp;
+
+    text = "\t  123.75abcxyz"; // skip leading space
+    expected_result = 123.75;
+    expected_endp = (char *)text + 9;
+    result = SDL_strtod(text, &endp);
+    SDLTest_AssertPass("Call to SDL_strtod(\"\\t  123.75abcxyz\", &endp)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %f, got: %f", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = "+999.555";
+    expected_result = 999.555;
+    expected_endp = (char *)text + 8;
+    result = SDL_strtod(text, &endp);
+    SDLTest_AssertPass("Call to SDL_strtod(\"+999.555\", &endp)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %f, got: %f", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = "-999.555";
+    expected_result = -999.555;
+    expected_endp = (char *)text + 8;
+    result = SDL_strtod(text, &endp);
+    SDLTest_AssertPass("Call to SDL_strtod(\"-999.555\", &endp)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %f, got: %f", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = "-0"; // signed zero
+    expected_result = -0.0;
+    expected_endp = (char *)text + 2;
+    result = SDL_strtod(text, &endp);
+    SDLTest_AssertPass("Call to SDL_strtod(\"-0.0\", &endp)");
+    SDLTest_AssertCheck((1.0 / result) == (1.0 / expected_result), "Check result value, expected: %f, got: %f", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = " - 1"; // invalid input
+    expected_result = 0.0;
+    expected_endp = (char *)text;
+    result = SDL_strtod(text, &endp);
+    SDLTest_AssertPass("Call to SDL_strtod(\" - 1\", &endp)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %f, got: %f", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    return TEST_COMPLETED;
+}
+
 /* ================= Test References ================== */
 
 /* Standard C routine test cases */
@@ -1679,6 +1730,10 @@ static const SDLTest_TestCaseReference stdlibTest_strtoull = {
     stdlib_strtoull, "stdlib_strtoull", "Calls to SDL_strtoull, SDL_strtol, SDL_strtoul and SDL_strtoll", TEST_ENABLED
 };
 
+static const SDLTest_TestCaseReference stdlibTest_strtod = {
+    stdlib_strtod, "stdlib_strtod", "Calls to SDL_strtod", TEST_ENABLED
+};
+
 /* Sequence of Standard C routine test cases */
 static const SDLTest_TestCaseReference *stdlibTests[] = {
     &stdlibTest_strnlen,
@@ -1694,6 +1749,7 @@ static const SDLTest_TestCaseReference *stdlibTests[] = {
     &stdlibTest_strpbrk,
     &stdlibTest_wcstol,
     &stdlibTest_strtoull,
+    &stdlibTest_strtod,
     NULL
 };
 

--- a/test/testautomation_stdlib.c
+++ b/test/testautomation_stdlib.c
@@ -726,6 +726,7 @@ static int SDLCALL stdlib_sscanf(void *arg)
     long long_output, expected_long_output;
     long long long_long_output, expected_long_long_output;
     size_t size_output, expected_size_output;
+    uintptr_t uintptr_output, expected_uintptr_output;
     char text[128], text2[128];
 
     expected_output = output = 123;
@@ -788,6 +789,15 @@ static int SDLCALL stdlib_sscanf(void *arg)
     result = SDL_sscanf(text, "%zu", &size_output);
     SDLTest_AssertPass("Call to SDL_sscanf(\"%s\", \"%%zu\", &output)", text);
     SDLTest_AssertCheck(expected_size_output == size_output, "Check output, expected: %zu, got: %zu", expected_size_output, size_output);
+    SDLTest_AssertCheck(expected_result == result, "Check return value, expected: %i, got: %i", expected_result, result);
+
+    uintptr_output = 123;
+    expected_uintptr_output = 0x1234567;
+    expected_result = 1;
+    result = SDL_snprintf(text, sizeof(text), "%p", expected_uintptr_output);
+    result = SDL_sscanf(text, "%p", &uintptr_output);
+    SDLTest_AssertPass("Call to SDL_sscanf(\"%s\", \"%%p\", &output)", text);
+    SDLTest_AssertCheck(expected_uintptr_output == uintptr_output, "Check output, expected: %p, got: %p", expected_uintptr_output, uintptr_output);
     SDLTest_AssertCheck(expected_result == result, "Check return value, expected: %i, got: %i", expected_result, result);
 
     expected_result = 1;

--- a/test/testautomation_stdlib.c
+++ b/test/testautomation_stdlib.c
@@ -10,7 +10,6 @@
 /**
  * Call to SDL_strnlen
  */
-#undef SDL_strnlen
 static int SDLCALL stdlib_strnlen(void *arg)
 {
     size_t result;
@@ -38,7 +37,6 @@ static int SDLCALL stdlib_strnlen(void *arg)
 /**
  * Call to SDL_strlcpy
  */
-#undef SDL_strlcpy
 static int SDLCALL stdlib_strlcpy(void *arg)
 {
     size_t result;
@@ -135,7 +133,6 @@ static int SDLCALL stdlib_strstr(void *arg)
 /**
  * Call to SDL_snprintf
  */
-#undef SDL_snprintf
 static int SDLCALL stdlib_snprintf(void *arg)
 {
     int result;
@@ -381,7 +378,6 @@ static int SDLCALL stdlib_snprintf(void *arg)
 /**
  * Call to SDL_swprintf
  */
-#undef SDL_swprintf
 static int SDLCALL stdlib_swprintf(void *arg)
 {
     int result;
@@ -720,7 +716,6 @@ static int SDLCALL stdlib_getsetenv(void *arg)
 /**
  * Call to SDL_sscanf
  */
-#undef SDL_sscanf
 static int SDLCALL stdlib_sscanf(void *arg)
 {
     int output;
@@ -1228,6 +1223,130 @@ stdlib_strpbrk(void *arg)
     }
     return TEST_COMPLETED;
 }
+
+static int SDLCALL stdlib_wcstol(void *arg)
+{
+    const wchar_t *text;
+    long result;
+    wchar_t *endp;
+    long expected_result;
+    wchar_t *expected_endp;
+
+    // infer decimal
+
+    text = L"\t  123abcxyz"; // skip leading space
+    expected_result = 123;
+    expected_endp = (wchar_t *)text + 6;
+    result = SDL_wcstol(text, &endp, 0);
+    SDLTest_AssertPass("Call to SDL_wcstol(L\"\\t  123abcxyz\", &endp, 0)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %ld, got: %ld", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = L"+123abcxyz";
+    expected_result = 123;
+    expected_endp = (wchar_t *)text + 4;
+    result = SDL_wcstol(text, &endp, 0);
+    SDLTest_AssertPass("Call to SDL_wcstol(L\"+123abcxyz\", &endp, 0)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %ld, got: %ld", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = L"-123abcxyz";
+    expected_result = -123;
+    expected_endp = (wchar_t *)text + 4;
+    result = SDL_wcstol(text, &endp, 0);
+    SDLTest_AssertPass("Call to SDL_wcstol(L\"-123abcxyz\", &endp, 0)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %ld, got: %ld", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = L"99999999999999999999abcxyz";
+    expected_result = (~0UL) >> 1; // LONG_MAX
+    expected_endp = (wchar_t *)text + 20;
+    result = SDL_wcstol(text, &endp, 0);
+    SDLTest_AssertPass("Call to SDL_wcstol(L\"99999999999999999999abcxyz\", &endp, 0)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %ld, got: %ld", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = L"-99999999999999999999abcxyz";
+    expected_result = ((~0UL) >> 1) + 1UL; // LONG_MIN
+    expected_endp = (wchar_t *)text + 21;
+    result = SDL_wcstol(text, &endp, 0);
+    SDLTest_AssertPass("Call to SDL_wcstol(L\"-99999999999999999999abcxyz\", &endp, 0)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %ld, got: %ld", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    // infer hexadecimal
+
+    text = L"0x123abcxyz";
+    expected_result = 0x123abc;
+    expected_endp = (wchar_t *)text + 8;
+    result = SDL_wcstol(text, &endp, 0);
+    SDLTest_AssertPass("Call to SDL_wcstol(L\"0x123abcxyz\", &endp, 0)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %ld, got: %ld", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = L"0X123ABCXYZ"; // uppercase X
+    expected_result = 0x123abc;
+    expected_endp = (wchar_t *)text + 8;
+    result = SDL_wcstol(text, &endp, 0);
+    SDLTest_AssertPass("Call to SDL_wcstol(L\"0X123ABCXYZ\", &endp, 0)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %ld, got: %ld", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    // infer octal
+
+    text = L"0123abcxyz";
+    expected_result = 0123;
+    expected_endp = (wchar_t *)text + 4;
+    result = SDL_wcstol(text, &endp, 0);
+    SDLTest_AssertPass("Call to SDL_wcstol(L\"0123abcxyz\", &endp, 0)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %ld, got: %ld", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    // arbitrary bases
+
+    text = L"00110011";
+    expected_result = 51;
+    expected_endp = (wchar_t *)text + 8;
+    result = SDL_wcstol(text, &endp, 2);
+    SDLTest_AssertPass("Call to SDL_wcstol(L\"00110011\", &endp, 2)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %ld, got: %ld", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = L"-uvwxyz";
+    expected_result = -991;
+    expected_endp = (wchar_t *)text + 3;
+    result = SDL_wcstol(text, &endp, 32);
+    SDLTest_AssertPass("Call to SDL_wcstol(L\"-uvwxyz\", &endp, 32)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %ld, got: %ld", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = L"ZzZzZzZzZzZzZ";
+    expected_result = (~0UL) >> 1; // LONG_MAX;
+    expected_endp = (wchar_t *)text + 13;
+    result = SDL_wcstol(text, &endp, 36);
+    SDLTest_AssertPass("Call to SDL_wcstol(L\"ZzZzZzZzZzZzZ\", &endp, 36)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %ld, got: %ld", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = L"-0";
+    expected_result = 0;
+    expected_endp = (wchar_t *)text + 2;
+    result = SDL_wcstol(text, &endp, 10);
+    SDLTest_AssertPass("Call to SDL_wcstol(L\"-0\", &endp, 10)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %ld, got: %ld", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    text = L" +0x"; // invalid hexadecimal
+    expected_result = 0;
+    expected_endp = (wchar_t *)text;
+    result = SDL_wcstol(text, &endp, 0);
+    SDLTest_AssertPass("Call to SDL_wcstol(L\" +0x\", &endp, 0)");
+    SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %ld, got: %ld", expected_result, result);
+    SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+    return TEST_COMPLETED;
+}
+
 /* ================= Test References ================== */
 
 /* Standard C routine test cases */
@@ -1275,6 +1394,10 @@ static const SDLTest_TestCaseReference stdlibTest_strpbrk = {
     stdlib_strpbrk, "stdlib_strpbrk", "Calls to SDL_strpbrk", TEST_ENABLED
 };
 
+static const SDLTest_TestCaseReference stdlibTest_wcstol = {
+    stdlib_wcstol, "stdlib_wcstol", "Calls to SDL_wcstol", TEST_ENABLED
+};
+
 /* Sequence of Standard C routine test cases */
 static const SDLTest_TestCaseReference *stdlibTests[] = {
     &stdlibTest_strnlen,
@@ -1288,6 +1411,7 @@ static const SDLTest_TestCaseReference *stdlibTests[] = {
     &stdlibTestOverflow,
     &stdlibTest_iconv,
     &stdlibTest_strpbrk,
+    &stdlibTest_wcstol,
     NULL
 };
 

--- a/test/testautomation_stdlib.c
+++ b/test/testautomation_stdlib.c
@@ -4,7 +4,6 @@
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_test.h>
 #include "testautomation_suites.h"
-#include "SDL_build_config.h"
 
 /* Test case functions */
 
@@ -1272,11 +1271,6 @@ static int SDLCALL stdlib_wcstol(void *arg)
     WCSTOL_TEST_CASE(L"-0", 10, 0, 2);
     WCSTOL_TEST_CASE(L" - 1", 0, 0, 0); // invalid input
 
-#ifndef HAVE_WCSTOL
-    // implementation-defined
-    WCSTOL_TEST_CASE(L" +0x", 0, 0, 3);
-#endif
-
     // values near the bounds of the type
     if (sizeof(long) == 4) {
         WCSTOL_TEST_CASE(L"2147483647", 10, 2147483647, 10);
@@ -1327,11 +1321,6 @@ static int SDLCALL stdlib_strtox(void *arg)
     STRTOX_TEST_CASE(SDL_strtoull, unsigned long long, "%llu", "-0", 10, 0, 2);
     STRTOX_TEST_CASE(SDL_strtoull, unsigned long long, "%llu", " - 1", 0, 0, 0); // invalid input
 
-#ifndef HAVE_STRTOULL
-    // implementation-defined
-    STRTOX_TEST_CASE(SDL_strtoull, unsigned long long, "%llu", " +0x", 0, 0, 3);
-#endif
-
     // We know that SDL_strtol, SDL_strtoul and SDL_strtoll share the same code path as SDL_strtoull under the hood,
     // so the most interesting test cases are those close to the bounds of the integer type.
 
@@ -1349,11 +1338,6 @@ static int SDLCALL stdlib_strtox(void *arg)
         STRTOX_TEST_CASE(SDL_strtoul, unsigned long, "%lu", "4294967295", 10, 4294967295, 10);
         STRTOX_TEST_CASE(SDL_strtoul, unsigned long, "%lu", "4294967296", 10, 4294967295, 10);
         STRTOX_TEST_CASE(SDL_strtoul, unsigned long, "%lu", "-4294967295", 10, 1, 11);
-#ifndef HAVE_STRTOUL
-        // implementation-defined
-        STRTOX_TEST_CASE(SDL_strtoul, unsigned long, "%lu", "-4294967296", 10, 4294967295, 11);
-        STRTOX_TEST_CASE(SDL_strtoul, unsigned long, "%lu", "-9999999999999999999999999999999999999999", 10, 4294967295, 41);
-#endif
     }
 
     if (sizeof(long long) == 8) {
@@ -1366,11 +1350,6 @@ static int SDLCALL stdlib_strtox(void *arg)
         STRTOX_TEST_CASE(SDL_strtoull, unsigned long long, "%llu", "18446744073709551615", 10, 18446744073709551615ULL, 20);
         STRTOX_TEST_CASE(SDL_strtoull, unsigned long long, "%llu", "18446744073709551616", 10, 18446744073709551615ULL, 20);
         STRTOX_TEST_CASE(SDL_strtoull, unsigned long long, "%llu", "-18446744073709551615", 10, 1, 21);
-#ifndef HAVE_STRTOULL
-        // implementation-defined
-        STRTOX_TEST_CASE(SDL_strtoull, unsigned long long, "%llu", "-18446744073709551616", 10, 18446744073709551615ULL, 21);
-        STRTOX_TEST_CASE(SDL_strtoull, unsigned long long, "%llu", "-9999999999999999999999999999999999999999", 10, 18446744073709551615ULL, 41);
-#endif
     }
 
 #undef STRTOX_TEST_CASE
@@ -1380,25 +1359,19 @@ static int SDLCALL stdlib_strtox(void *arg)
 
 static int SDLCALL stdlib_strtod(void *arg)
 {
-#define STRTOD_TEST_CASE(str, expected_result, expected_endp_offset) do {                                                                              \
-        const char *s = str;                                                                                                                           \
-        double r, expected_r = expected_result;                                                                                                        \
-        char *ep, *expected_ep = (char *)s + expected_endp_offset;                                                                                     \
-        r = SDL_strtod(s, &ep);                                                                                                                        \
-        SDLTest_AssertPass("Call to SDL_strtod(" #str ", &endp)");                                                                                     \
-        SDLTest_AssertCheck(r == expected_r && (r != 0.0 || 1.0 / r == 1.0 / expected_r), "Check result value, expected: %f, got: %f", expected_r, r); \
-        SDLTest_AssertCheck(ep == expected_ep, "Check endp value, expected: %p, got: %p", expected_ep, ep);                                            \
+#define STRTOD_TEST_CASE(str, expected_result, expected_endp_offset) do {                                   \
+        const char *s = str;                                                                                \
+        double r, expected_r = expected_result;                                                             \
+        char *ep, *expected_ep = (char *)s + expected_endp_offset;                                          \
+        r = SDL_strtod(s, &ep);                                                                             \
+        SDLTest_AssertPass("Call to SDL_strtod(" #str ", &endp)");                                          \
+        SDLTest_AssertCheck(r == expected_r, "Check result value, expected: %f, got: %f", expected_r, r);   \
+        SDLTest_AssertCheck(ep == expected_ep, "Check endp value, expected: %p, got: %p", expected_ep, ep); \
     } while (0)
 
     STRTOD_TEST_CASE("\t  123.75abcxyz", 123.75, 9); // skip leading space
     STRTOD_TEST_CASE("+999.555", 999.555, 8);
     STRTOD_TEST_CASE("-999.555", -999.555, 8);
-
-#ifndef HAVE_STRTOD
-    // implementation-defined
-    STRTOD_TEST_CASE("-0", -0.0, 2);
-    STRTOD_TEST_CASE(" - 1", 0.0, 0); // invalid input
-#endif
 
 #undef STRTOD_TEST_CASE
 

--- a/test/testautomation_stdlib.c
+++ b/test/testautomation_stdlib.c
@@ -1467,6 +1467,126 @@ static int SDLCALL stdlib_strtoull(void *arg)
     SDLTest_AssertCheck(result == expected_result, "Check result value, expected: %llu, got: %llu", expected_result, result);
     SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
 
+    // We know that SDL_strtol, SDL_strtoul and SDL_strtoll share the same code path as SDL_strtoull under the hood,
+    // so the most interesting test cases are those close to the bounds of the integer type.
+
+    // For simplicity, we only run long/long long tests when they are 32-bit/64-bit respectively.
+    // Since the tests are run against a variety of targets, this should be fine in practice.
+
+    // SDL_strtol (32-bit)
+    if (sizeof(long) == 4) {
+        long lresult;
+        long expected_lresult;
+
+        text = "2147483647";
+        expected_lresult = 2147483647;
+        expected_endp = (char *)text + 10;
+        lresult = SDL_strtol(text, &endp, 0);
+        SDLTest_AssertPass("Call to SDL_strtol(\"2147483647\", &endp, 0)");
+        SDLTest_AssertCheck(lresult == expected_lresult, "Check result value, expected: %ld, got: %ld", expected_lresult, lresult);
+        SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+        text = "2147483648";
+        expected_lresult = 2147483647;
+        expected_endp = (char *)text + 10;
+        lresult = SDL_strtol(text, &endp, 0);
+        SDLTest_AssertPass("Call to SDL_strtol(\"2147483648\", &endp, 0)");
+        SDLTest_AssertCheck(lresult == expected_lresult, "Check result value, expected: %ld, got: %ld", expected_lresult, lresult);
+        SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+        text = "-2147483648";
+        expected_lresult = -2147483648;
+        expected_endp = (char *)text + 11;
+        lresult = SDL_strtol(text, &endp, 0);
+        SDLTest_AssertPass("Call to SDL_strtol(\"-2147483648\", &endp, 0)");
+        SDLTest_AssertCheck(lresult == expected_lresult, "Check result value, expected: %ld, got: %ld", expected_lresult, lresult);
+        SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+        text = "-2147483649";
+        expected_lresult = -2147483648;
+        expected_endp = (char *)text + 11;
+        lresult = SDL_strtol(text, &endp, 0);
+        SDLTest_AssertPass("Call to SDL_strtol(\"-2147483649\", &endp, 0)");
+        SDLTest_AssertCheck(lresult == expected_lresult, "Check result value, expected: %ld, got: %ld", expected_lresult, lresult);
+        SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+    }
+
+    // SDL_strtoul (32-bit)
+    if (sizeof(unsigned long) == 4) {
+        unsigned long ulresult;
+        unsigned long expected_ulresult;
+
+        text = "4294967295";
+        expected_ulresult = 4294967295;
+        expected_endp = (char *)text + 10;
+        ulresult = SDL_strtoul(text, &endp, 0);
+        SDLTest_AssertPass("Call to SDL_strtoul(\"4294967295\", &endp, 0)");
+        SDLTest_AssertCheck(ulresult == expected_ulresult, "Check result value, expected: %lu, got: %lu", expected_ulresult, ulresult);
+        SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+        text = "4294967296";
+        expected_ulresult = 4294967295;
+        expected_endp = (char *)text + 10;
+        ulresult = SDL_strtoul(text, &endp, 0);
+        SDLTest_AssertPass("Call to SDL_strtoul(\"4294967296\", &endp, 0)");
+        SDLTest_AssertCheck(ulresult == expected_ulresult, "Check result value, expected: %lu, got: %lu", expected_ulresult, ulresult);
+        SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+        text = "-4294967295";
+        expected_ulresult = 1;
+        expected_endp = (char *)text + 11;
+        ulresult = SDL_strtoul(text, &endp, 0);
+        SDLTest_AssertPass("Call to SDL_strtoul(\"-4294967295\", &endp, 0)");
+        SDLTest_AssertCheck(ulresult == expected_ulresult, "Check result value, expected: %lu, got: %lu", expected_ulresult, ulresult);
+        SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+        text = "-4294967296";
+        expected_ulresult = 4294967295;
+        expected_endp = (char *)text + 11;
+        ulresult = SDL_strtoul(text, &endp, 0);
+        SDLTest_AssertPass("Call to SDL_strtoul(\"-4294967296\", &endp, 0)");
+        SDLTest_AssertCheck(ulresult == expected_ulresult, "Check result value, expected: %lu, got: %lu", expected_ulresult, ulresult);
+        SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+    }
+
+    // SDL_strtoll (64-bit)
+    if (sizeof(long long) == 8) {
+        long long llresult;
+        long long expected_llresult;
+
+        text = "9223372036854775807";
+        expected_llresult = 9223372036854775807;
+        expected_endp = (char *)text + 19;
+        llresult = SDL_strtoll(text, &endp, 0);
+        SDLTest_AssertPass("Call to SDL_strtoll(\"9223372036854775807\", &endp, 0)");
+        SDLTest_AssertCheck(llresult == expected_llresult, "Check result value, expected: %lld, got: %lld", expected_llresult, llresult);
+        SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+        text = "9223372036854775808";
+        expected_llresult = 9223372036854775807;
+        expected_endp = (char *)text + 19;
+        llresult = SDL_strtoll(text, &endp, 0);
+        SDLTest_AssertPass("Call to SDL_strtoll(\"9223372036854775808\", &endp, 0)");
+        SDLTest_AssertCheck(llresult == expected_llresult, "Check result value, expected: %lld, got: %lld", expected_llresult, llresult);
+        SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+        text = "-9223372036854775808";
+        expected_llresult = -9223372036854775807 - 1;
+        expected_endp = (char *)text + 20;
+        llresult = SDL_strtoll(text, &endp, 0);
+        SDLTest_AssertPass("Call to SDL_strtoll(\"-9223372036854775808\", &endp, 0)");
+        SDLTest_AssertCheck(llresult == expected_llresult, "Check result value, expected: %lld, got: %lld", expected_llresult, llresult);
+        SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+        text = "-9223372036854775809";
+        expected_llresult = -9223372036854775807 - 1;
+        expected_endp = (char *)text + 20;
+        llresult = SDL_strtoll(text, &endp, 0);
+        SDLTest_AssertPass("Call to SDL_strtoll(\"-9223372036854775809\", &endp, 0)");
+        SDLTest_AssertCheck(llresult == expected_llresult, "Check result value, expected: %lld, got: %lld", expected_llresult, llresult);
+        SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+    }
+
     return TEST_COMPLETED;
 }
 
@@ -1522,7 +1642,7 @@ static const SDLTest_TestCaseReference stdlibTest_wcstol = {
 };
 
 static const SDLTest_TestCaseReference stdlibTest_strtoull = {
-    stdlib_strtoull, "stdlib_strtoull", "Calls to SDL_strtoull", TEST_ENABLED
+    stdlib_strtoull, "stdlib_strtoull", "Calls to SDL_strtoull, SDL_strtol, SDL_strtoul and SDL_strtoll", TEST_ENABLED
 };
 
 /* Sequence of Standard C routine test cases */

--- a/test/testautomation_stdlib.c
+++ b/test/testautomation_stdlib.c
@@ -1509,6 +1509,14 @@ static int SDLCALL stdlib_strtoull(void *arg)
         SDLTest_AssertPass("Call to SDL_strtol(\"-2147483649\", &endp, 0)");
         SDLTest_AssertCheck(lresult == expected_lresult, "Check result value, expected: %ld, got: %ld", expected_lresult, lresult);
         SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+        text = "-9999999999999999999999999999999999999999";
+        expected_lresult = -2147483648;
+        expected_endp = (char *)text + 41;
+        lresult = SDL_strtol(text, &endp, 0);
+        SDLTest_AssertPass("Call to SDL_strtol(\"-9999999999999999999999999999999999999999\", &endp, 0)");
+        SDLTest_AssertCheck(lresult == expected_lresult, "Check result value, expected: %ld, got: %ld", expected_lresult, lresult);
+        SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
     }
 
     // SDL_strtoul (32-bit)
@@ -1547,6 +1555,14 @@ static int SDLCALL stdlib_strtoull(void *arg)
         SDLTest_AssertPass("Call to SDL_strtoul(\"-4294967296\", &endp, 0)");
         SDLTest_AssertCheck(ulresult == expected_ulresult, "Check result value, expected: %lu, got: %lu", expected_ulresult, ulresult);
         SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+        text = "-9999999999999999999999999999999999999999";
+        expected_ulresult = 4294967295;
+        expected_endp = (char *)text + 41;
+        ulresult = SDL_strtoul(text, &endp, 0);
+        SDLTest_AssertPass("Call to SDL_strtoul(\"-9999999999999999999999999999999999999999\", &endp, 0)");
+        SDLTest_AssertCheck(ulresult == expected_ulresult, "Check result value, expected: %lu, got: %lu", expected_ulresult, ulresult);
+        SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
     }
 
     // SDL_strtoll (64-bit)
@@ -1583,6 +1599,14 @@ static int SDLCALL stdlib_strtoull(void *arg)
         expected_endp = (char *)text + 20;
         llresult = SDL_strtoll(text, &endp, 0);
         SDLTest_AssertPass("Call to SDL_strtoll(\"-9223372036854775809\", &endp, 0)");
+        SDLTest_AssertCheck(llresult == expected_llresult, "Check result value, expected: %lld, got: %lld", expected_llresult, llresult);
+        SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
+
+        text = "-9999999999999999999999999999999999999999";
+        expected_llresult = -9223372036854775807 - 1;
+        expected_endp = (char *)text + 41;
+        llresult = SDL_strtoll(text, &endp, 0);
+        SDLTest_AssertPass("Call to SDL_strtoll(\"-9999999999999999999999999999999999999999\", &endp, 0)");
         SDLTest_AssertCheck(llresult == expected_llresult, "Check result value, expected: %lld, got: %lld", expected_llresult, llresult);
         SDLTest_AssertCheck(endp == expected_endp, "Check endp value, expected: %p, got: %p", expected_endp, endp);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I believe this fixes all the unintended bugs in

- `SDL_strtol`,
- `SDL_strtoul`,
- `SDL_strtoll`,
- `SDL_strtoull`, and
- `SDL_wcstol`.

In addition, it also adds support for octals and other bases. See the test cases for examples. Covering every single edge case and combination of important parameters would be impractical but I believe this makes the implementations for these functions compliant with the libc specs ([strtol/strtoll](https://pubs.opengroup.org/onlinepubs/9799919799.2024edition/functions/strtol.html), [strtoul/strtoull](https://pubs.opengroup.org/onlinepubs/9799919799.2024edition/functions/strtoul.html), [wcstol](https://pubs.opengroup.org/onlinepubs/9799919799.2024edition/functions/wcstol.html)).

It also improves `SDL_strtod` slightly (use `unsigned long long` to parse the integer part; handle leading whitespace and positive signs).

I ran the tests with an SDL built with `-DSDL_LIBC=OFF`.

The core implementation itself is probably not as good as what you could get if you outright stole it from something like musl, but it works.

I don't actually program a lot in C so please let me know if anything I wrote looks off or unconventional. Note that I also added a compile-time assert that asserts that signed integers use two's complement. I'm not even sure if SDL would otherwise support one's complement or other crazy representations, but I felt this was necessary since `#include <limits.h>` isn't guaranteed to be available and obtaining numeric limits without it would be inconvenient otherwise. If you have any other suggestions I'd be eager to hear them out.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #10750