### PR TITLE
Fix testoffscreen.c: bool literal returned from 'main'

### DIFF
--- a/test/testoffscreen.c
+++ b/test/testoffscreen.c
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
     if (!SDL_InitSubSystem(SDL_INIT_VIDEO)) {
         SDL_Log("Couldn't initialize the offscreen video driver: %s\n",
                 SDL_GetError());
-        return SDL_FALSE;
+        return 1;
     }
 
     /* If OPENGL fails to init it will fallback to using a framebuffer for rendering */
@@ -121,7 +121,7 @@ int main(int argc, char *argv[])
 
     if (!window) {
         SDL_Log("Couldn't create window: %s\n", SDL_GetError());
-        return SDL_FALSE;
+        return 1;
     }
 
     renderer = SDL_CreateRenderer(window, NULL);
@@ -129,7 +129,7 @@ int main(int argc, char *argv[])
     if (!renderer) {
         SDL_Log("Couldn't create renderer: %s\n",
                 SDL_GetError());
-        return SDL_FALSE;
+        return 1;
     }
 
     SDL_RenderClear(renderer);


### PR DESCRIPTION
```c
/path/to/SDL-git/test/testoffscreen.c:116:9: warning: bool literal returned from 'main' [-Wmain]
  116 |         return SDL_FALSE;
      |         ^      ~~~~~~~~~
/path/to/SDL-git/test/testoffscreen.c:124:9: warning: bool literal returned from 'main' [-Wmain]
  124 |         return SDL_FALSE;
      |         ^      ~~~~~~~~~
/path/to/SDL-git/test/testoffscreen.c:132:9: warning: bool literal returned from 'main' [-Wmain]
  132 |         return SDL_FALSE;
      |         ^      ~~~~~~~~~
```