### PR TITLE
pipewire: Always destroy hotplug loop during deinitialization

### DIFF
--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -1215,6 +1215,7 @@ static void PIPEWIRE_DeinitializeStart(void)
 static void PIPEWIRE_Deinitialize(void)
 {
     if (pipewire_initialized) {
+        hotplug_loop_destroy();
         deinit_pipewire_library();
         pipewire_initialized = false;
     }
@@ -1230,7 +1231,6 @@ static bool PipewireInitialize(SDL_AudioDriverImpl *impl)
         pipewire_initialized = true;
 
         if (!hotplug_loop_init()) {
-            hotplug_loop_destroy();
             PIPEWIRE_Deinitialize();
             return false;
         }
@@ -1271,7 +1271,6 @@ static bool PIPEWIRE_PREFERRED_Init(SDL_AudioDriverImpl *impl)
     PIPEWIRE_pw_thread_loop_unlock(hotplug_loop);
 
     if (no_devices || !pipewire_core_version_at_least(1, 0, 0)) {
-        hotplug_loop_destroy();
         PIPEWIRE_Deinitialize();
         return false;
     }


### PR DESCRIPTION
We always need to destroy the hotplug loop and its associated resources (if created) before we can deinitialize and unload the Pipewire library.

In the happy path where everything worked correctly, this means we will call hotplug_loop_destroy() twice (once from PIPEWIRE_DeinitializeStart() and a second time from PIPEWIRE_Deinitialize()), but that's OK, because it's idempotent and so will do nothing the second time.

In error-handling code paths, this avoids needing to remember to call hotplug_loop_destroy() explicitly, which should make it easier to avoid bugs like #10787.