### PR TITLE
Removing extra semicolons

### DIFF
--- a/src/test/SDL_test_harness.c
+++ b/src/test/SDL_test_harness.c
@@ -62,7 +62,7 @@ struct SDLTest_TestSuiteRunner {
 };
 
 /* ! Timeout for single test case execution */
-static Uint32 SDLTest_TestCaseTimeout = 3600;;
+static Uint32 SDLTest_TestCaseTimeout = 3600;
 
 static const char *common_harness_usage[] = {
     "[--iterations #]",

--- a/src/video/x11/SDL_x11sym.h
+++ b/src/video/x11/SDL_x11sym.h
@@ -290,7 +290,7 @@ SDL_X11_SYM(Status,XIQueryVersion,(Display *a,int *b,int *c),(a,b,c),return)
 SDL_X11_SYM(XIEventMask*,XIGetSelectedEvents,(Display *a,Window b,int *c),(a,b,c),return)
 SDL_X11_SYM(Bool,XIGetClientPointer,(Display *a,Window b,int *c),(a,b,c),return)
 SDL_X11_SYM(Bool,XIWarpPointer,(Display *a,int b,Window c,Window d,double e,double f,int g,int h,double i,double j),(a,b,c,d,e,f,g,h,i,j),return)
-SDL_X11_SYM(Status,XIGetProperty,(Display *a,int b,Atom c,long d,long e,Bool f, Atom g, Atom *h, int *i, unsigned long *j, unsigned long *k, unsigned char **l),(a,b,c,d,e,f,g,h,i,j,k,l),return);
+SDL_X11_SYM(Status,XIGetProperty,(Display *a,int b,Atom c,long d,long e,Bool f, Atom g, Atom *h, int *i, unsigned long *j, unsigned long *k, unsigned char **l),(a,b,c,d,e,f,g,h,i,j,k,l),return)
 #endif
 
 // XRandR support


### PR DESCRIPTION
`clang` `-Wextra-semi`

Interesting fact:
The extra semicolon in `src/video/x11/SDL_x11sym.h` produced 44 warnings.