### PR TITLE
Adding void to empty function prototype parenthesis

### DIFF
--- a/src/core/unix/SDL_appid.h
+++ b/src/core/unix/SDL_appid.h
@@ -24,7 +24,7 @@ freely, subject to the following restrictions:
 #ifndef SDL_appid_h_
 #define SDL_appid_h_
 
-extern const char *SDL_GetExeName();
-extern const char *SDL_GetAppID();
+extern const char *SDL_GetExeName(void);
+extern const char *SDL_GetAppID(void);
 
 #endif // SDL_appid_h_

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -1254,7 +1254,7 @@ void SDL_PerformWarpMouseInWindow(SDL_Window *window, float x, float y, bool ign
     }
 }
 
-void SDL_DisableMouseWarpEmulation()
+void SDL_DisableMouseWarpEmulation(void)
 {
     SDL_Mouse *mouse = SDL_GetMouse();
 

--- a/src/video/x11/SDL_x11sym.h
+++ b/src/video/x11/SDL_x11sym.h
@@ -158,7 +158,7 @@ SDL_X11_SYM(Status,XmbTextListToTextProperty,(Display* a,char** b,int c,XICCEnco
 SDL_X11_SYM(Region,XCreateRegion,(void),(),return)
 SDL_X11_SYM(int,XUnionRectWithRegion,(XRectangle *a, Region b, Region c),(a,b,c), return)
 SDL_X11_SYM(void,XDestroyRegion,(Region),(a),)
-SDL_X11_SYM(void,XrmInitialize,(),(),)
+SDL_X11_SYM(void,XrmInitialize,(void),(),)
 SDL_X11_SYM(char*,XResourceManagerString,(Display *display),(display),)
 SDL_X11_SYM(XrmDatabase,XrmGetStringDatabase,(char *data),(data),)
 SDL_X11_SYM(void,XrmDestroyDatabase,(XrmDatabase db),(db),)

--- a/test/testautomation_blit.c
+++ b/test/testautomation_blit.c
@@ -33,7 +33,7 @@ Uint64 next(Uint64 state[2]) {
     return result;
 }
 static Uint64 rngState[2] = {1, 2};
-Uint32 getRandomUint32() {
+Uint32 getRandomUint32(void) {
     return (Uint32)next(rngState);
 }
 /* ================= Test Case Helper Functions ================== */

--- a/test/testgpu_spinning_cube.c
+++ b/test/testgpu_spinning_cube.c
@@ -619,7 +619,7 @@ init_render_state(int msaa)
 
 static int done = 0;
 
-void loop()
+void loop(void)
 {
     SDL_Event event;
     int i;

--- a/test/testrelative.c
+++ b/test/testrelative.c
@@ -35,7 +35,7 @@ static void DrawRects(SDL_Renderer *renderer)
     SDLTest_DrawString(renderer, 0.f, 0.f, "Relative Mode: Enabled");
 }
 
-static void CenterMouse()
+static void CenterMouse(void)
 {
     /* Warp the mouse back to the center of the window with input focus to use the
      * center point for calculating future motion deltas.


### PR DESCRIPTION
`clang` `-Wstrict-prototypes`
```c
/path/to/SDL-git/src/events/SDL_mouse.c:1257:35: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
 1257 | void SDL_DisableMouseWarpEmulation()
      |                                   ^
      |                                    void
/path/to/SDL-git/src/video/x11/SDL_x11sym.h:161:32: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
  161 | SDL_X11_SYM(void,XrmInitialize,(),(),)
      |                                ^
      |                                 void
/path/to/SDL-git/src/core/unix/SDL_appid.h:27:34: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
   27 | extern const char *SDL_GetExeName();
      |                                  ^
      |                                   void
/path/to/SDL-git/src/core/unix/SDL_appid.h:28:32: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
   28 | extern const char *SDL_GetAppID();
      |                                ^
      |                                 void
/path/to/SDL-git/test/testautomation_blit.c:36:23: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
   36 | Uint32 getRandomUint32() {
      |                       ^
      |                        void
/path/to/SDL-git/test/testrelative.c:38:24: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
   38 | static void CenterMouse()
      |                        ^
      |                         void
/path/to/SDL-git/test/testgpu_spinning_cube.c:622:10: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
  622 | void loop()
      |          ^
      |           void
```