### PR TITLE
Add missing SDL_WPRINTF_VARARG_FUNCV in gendynapi.py

### DIFF
--- a/src/dynapi/gendynapi.py
+++ b/src/dynapi/gendynapi.py
@@ -167,6 +167,7 @@ def main():
             func = func.replace(" SDL_PRINTF_VARARG_FUNCV(2)", "");
             func = func.replace(" SDL_PRINTF_VARARG_FUNCV(3)", "");
             func = func.replace(" SDL_WPRINTF_VARARG_FUNC(3)", "");
+            func = func.replace(" SDL_WPRINTF_VARARG_FUNCV(3)", "");
             func = func.replace(" SDL_SCANF_VARARG_FUNC(2)", "");
             func = func.replace(" SDL_SCANF_VARARG_FUNCV(2)", "");
             func = func.replace(" SDL_ANALYZER_NORETURN", "");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds missing `SDL_WPRINTF_VARARG_FUNCV` since https://github.com/libsdl-org/SDL/commit/eda459ac49e290d1c33783ef48132d899c36504b to fix gendynapi.
