### PR TITLE
Fix bug with SDL_ShowMessageBox not working with wayland

### DIFF
--- a/src/video/wayland/SDL_waylandmessagebox.c
+++ b/src/video/wayland/SDL_waylandmessagebox.c
@@ -83,7 +83,7 @@ static bool get_zenity_version(int *major, int *minor)
         return SDL_SetError("pipe() failed: %s", strerror(errno));
     }
 
-    if (run_zenity(argv, fd_pipe) == 0) {
+    if (!run_zenity(argv, fd_pipe) == 0) {
         FILE *outputfp = NULL;
         char version_str[ZENITY_VERSION_LEN];
         char *version_ptr = NULL, *end_ptr = NULL;

--- a/src/video/wayland/SDL_waylandmessagebox.c
+++ b/src/video/wayland/SDL_waylandmessagebox.c
@@ -83,7 +83,7 @@ static bool get_zenity_version(int *major, int *minor)
         return SDL_SetError("pipe() failed: %s", strerror(errno));
     }
 
-    if (!run_zenity(argv, fd_pipe) == 0) {
+    if (run_zenity(argv, fd_pipe)) {
         FILE *outputfp = NULL;
         char version_str[ZENITY_VERSION_LEN];
         char *version_ptr = NULL, *end_ptr = NULL;


### PR DESCRIPTION
## Description
I'm new to SDL and I wanted to write a quick HelloWorld program that just displays a box and closes the application.

I couldn't get it to work with SDL_GetError() returning "No message system available" so I spent some hours searching through docs and googling to see if someone had a similar issue. There were few github issues and everything I found had been created years ago and dealt with SDL2, not SDL3.

After nothing being helpful I just decided to debug the issue myself and almost immediately found that for some reason even though run_zenity() returns success, the if block that should follow doesn't execute, and instead get_zenity_version() just returns failure with a comment stating that run_zenity() should have already set the error message by calling SDL_SetError() (which it didn't, since it returned success).

I'm pretty sure the condition is simply wrong, and it should either be
```c
if (run_zenity(arb, fd_pipe) == true)
```
or
```c
if (!run_zenity(arb, fd_pipe) == 0)
```
however I have no idea how this wasn't caught earlier if that's the case. Maybe not many projects use wayland.

This bug also caused test/testmessage to return errors. After my change the test displays message boxes.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/10809
