### PR TITLE
GPU: Fix D3D11/D3D12 vertex strides for multiple vertex buffers

### DIFF
--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -509,7 +509,7 @@ typedef struct D3D11GraphicsPipeline
     ID3D11PixelShader *fragmentShader;
 
     ID3D11InputLayout *inputLayout;
-    Uint32 *vertexStrides;
+    Uint32 vertexStrides[MAX_VERTEX_BUFFERS];
 
     Uint32 vertexSamplerCount;
     Uint32 vertexUniformBufferCount;
@@ -1258,9 +1258,6 @@ static void D3D11_ReleaseGraphicsPipeline(
     if (d3d11GraphicsPipeline->inputLayout) {
         ID3D11InputLayout_Release(d3d11GraphicsPipeline->inputLayout);
     }
-    if (d3d11GraphicsPipeline->vertexStrides) {
-        SDL_free(d3d11GraphicsPipeline->vertexStrides);
-    }
 
     ID3D11VertexShader_Release(d3d11GraphicsPipeline->vertexShader);
     ID3D11PixelShader_Release(d3d11GraphicsPipeline->fragmentShader);
@@ -1611,16 +1608,12 @@ static SDL_GPUGraphicsPipeline *D3D11_CreateGraphicsPipeline(
         vertShader->bytecode,
         vertShader->bytecodeSize);
 
+    SDL_zeroa(pipeline->vertexStrides);
     if (createinfo->vertex_input_state.num_vertex_buffers > 0) {
-        pipeline->vertexStrides = SDL_malloc(
-            sizeof(Uint32) *
-            createinfo->vertex_input_state.num_vertex_buffers);
-
         for (Uint32 i = 0; i < createinfo->vertex_input_state.num_vertex_buffers; i += 1) {
-            pipeline->vertexStrides[i] = createinfo->vertex_input_state.vertex_buffer_descriptions[i].pitch;
+            pipeline->vertexStrides[createinfo->vertex_input_state.vertex_buffer_descriptions[i].slot] =
+                createinfo->vertex_input_state.vertex_buffer_descriptions[i].pitch;
         }
-    } else {
-        pipeline->vertexStrides = NULL;
     }
 
     // Resource layout

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -2663,7 +2663,8 @@ static SDL_GPUGraphicsPipeline *D3D12_CreateGraphicsPipeline(
     pipeline->pipelineState = pipelineState;
 
     for (Uint32 i = 0; i < createinfo->vertex_input_state.num_vertex_buffers; i += 1) {
-        pipeline->vertexStrides[i] = createinfo->vertex_input_state.vertex_buffer_descriptions[i].pitch;
+        pipeline->vertexStrides[createinfo->vertex_input_state.vertex_buffer_descriptions[i].slot] =
+            createinfo->vertex_input_state.vertex_buffer_descriptions[i].pitch;
     }
 
     pipeline->primitiveType = createinfo->primitive_type;


### PR DESCRIPTION
This fixes some bad assumptions we had regarding vertex buffer strides.

For D3D11, this allows more vertex buffers to be bound than the current pipeline supports, addressing over-read issues that were causing errors like `D3D11 ERROR: ID3D11DeviceContext::IASetVertexBuffers: Vertex Buffer stride (-33686019) for slot 1 is too large`.

For both D3D11 and D3D12 this fixes an issue where non-contiguous vertex buffer slots were not getting their strides set correctly. They were assigning the stride based on the index of the vertex buffer description rather than its `slot`.