### PR TITLE
Add Thrustmaster TMX VID & PID to wheel device list.

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -366,6 +366,7 @@ static Uint32 initial_wheel_devices[] = {
     MAKE_VIDPID(0x044f, 0xb65e), // Thrustmaster T500RS
     MAKE_VIDPID(0x044f, 0xb664), // Thrustmaster TX (initial mode)
     MAKE_VIDPID(0x044f, 0xb669), // Thrustmaster TX (active mode)
+    MAKE_VIDPID(0x044f, 0xb67f), // Thrustmaster TMX
     MAKE_VIDPID(0x044f, 0xb691), // Thrustmaster TS-XW (initial mode)
     MAKE_VIDPID(0x044f, 0xb692), // Thrustmaster TS-XW (active mode)
     MAKE_VIDPID(0x0483, 0x0522), // Simagic Wheelbase (including M10, Alpha Mini, Alpha, Alpha U)


### PR DESCRIPTION
Add the Thrustmaster TMX to the SDL wheel list to allow it to be properly supported as a wheel.

## Description
The Thrustmaster TMX should now be properly detected as a wheel with SDL.

VID: `0x044F`
PID: `0xB67F`
