### PR TITLE
GPU: Metal vertex buffer indices should grow upward

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -1983,7 +1983,7 @@ extern SDL_DECLSPEC SDL_GPUSampler *SDLCALL SDL_CreateGPUSampler(
  * - [[texture]]: Sampled textures, followed by storage textures
  * - [[sampler]]: Samplers with indices corresponding to the sampled textures
  * - [[buffer]]: Uniform buffers, followed by storage buffers. Vertex buffer 0
- *   is bound at [[buffer(30)]], vertex buffer 1 at [[buffer(29)]], and so on.
+ *   is bound at [[buffer(14)]], vertex buffer 1 at [[buffer(15)]], and so on.
  *   Rather than manually authoring vertex buffer indices, use the
  *   [[stage_in]] attribute which will automatically use the vertex input
  *   information from the SDL_GPUPipeline.


### PR DESCRIPTION
In Metal, there's a single "namespace" for all buffers in a given stage. So vertex buffers, uniform buffers, and storage buffers compete for space in the 31 slots Metal provides.

Previously we were binding vertex buffers at index 30 and growing downward to avoid index collisions with other buffers. However, this is no longer necessary. We only support 4 uniform buffers and 8 storage buffers, so instead of having some awkward contortions in our indexing logic, we can just have the vertex buffers bindings start in the middle and grow upward.

@Akaricchi Could you check if this fixes the issue you were seeing on Metal?