### PR TITLE
Windows process: escape backslashes that appear before double quotes

### DIFF
--- a/src/process/windows/SDL_windowsprocess.c
+++ b/src/process/windows/SDL_windowsprocess.c
@@ -127,7 +127,7 @@ static bool join_arguments(const char * const *args, char **args_out)
                 break;
             case '\\':
                 result[i_out++] = *a;
-                if (*(a + 1) == '"' || *(a + 1) == '\0') {
+                if (a[1] == '"' || a[1] == '\0') {
                     result[i_out++] = *a;
                 }
                 break;

--- a/src/process/windows/SDL_windowsprocess.c
+++ b/src/process/windows/SDL_windowsprocess.c
@@ -97,7 +97,7 @@ static bool join_arguments(const char * const *args, char **args_out)
                 break;
             case '\\':
                 /* only escape backslashes that precede a double quote */
-                len += (*(a + 1) == '"' || *(a + 1) == '\0') ? 2 : 1;
+                len += (a[1] == '"' || a[1] == '\0') ? 2 : 1;
                 break;
             default:
                 len += 1;

--- a/src/process/windows/SDL_windowsprocess.c
+++ b/src/process/windows/SDL_windowsprocess.c
@@ -95,6 +95,10 @@ static bool join_arguments(const char * const *args, char **args_out)
             case '"':
                 len += 2;
                 break;
+            case '\\':
+                /* only escape backslashes that precede a double quote */
+                len += (*(a + 1) == '"' || *(a + 1) == '\0') ? 2 : 1;
+                break;
             default:
                 len += 1;
                 break;
@@ -120,6 +124,12 @@ static bool join_arguments(const char * const *args, char **args_out)
             case '"':
                 result[i_out++] = '\\';
                 result[i_out++] = *a;
+                break;
+            case '\\':
+                result[i_out++] = *a;
+                if (*(a + 1) == '"' || *(a + 1) == '\0') {
+                    result[i_out++] = *a;
+                }
                 break;
             default:
                 result[i_out++] = *a;

--- a/test/testprocess.c
+++ b/test/testprocess.c
@@ -130,6 +130,9 @@ static int SDLCALL process_testArguments(void *arg)
         "'a' 'b' 'c'",
         "%d%%%s",
         "\\t\\c",
+        "evil\\",
+        "a\\b\"c\\",
+        "\"\\^&|<>%", /* characters with a special meaning */
         NULL
     };
     SDL_Process *process = NULL;


### PR DESCRIPTION
## Description

In the Windows implementation of processes, the arguments only had their double quotes escaped. Backslashes that appear before quotes (but not ones that don't!) also needed to be escaped. This PR fixes that, and adds some extra tests with quotes, backslashes, and other symbols that may have an impact if escaping is not done properly.

## Existing Issue(s)

Fixes #10831
