### PR TITLE
Add missing includes to SDL_process.h

### DIFF
--- a/include/SDL3/SDL_process.h
+++ b/include/SDL3/SDL_process.h
@@ -43,7 +43,10 @@
 #ifndef SDL_process_h_
 #define SDL_process_h_
 
+#include <SDL3/SDL_stdinc.h>
 #include <SDL3/SDL_error.h>
+#include <SDL3/SDL_iostream.h>
+#include <SDL3/SDL_properties.h>
 
 #include <SDL3/SDL_begin_code.h>
 /* Set up for C function definitions, even when using C++ */


### PR DESCRIPTION
SDL_process.h requires symbols from these includes, but didn't include them.