### PR TITLE
Comment typo fix: occured is not occurred

### DIFF
--- a/sdl2.m4
+++ b/sdl2.m4
@@ -197,7 +197,7 @@ int main(int argc, char *argv[])
           echo "*** If you have an old version installed, it is best to remove it, although"
           echo "*** you may also be able to get things to work by modifying LD_LIBRARY_PATH"],
         [ echo "*** The test program failed to compile or link. See the file config.log for the"
-          echo "*** exact error that occured. This usually means SDL was incorrectly installed"
+          echo "*** exact error that occurred. This usually means SDL was incorrectly installed"
           echo "*** or that you have moved SDL since it was installed. In the latter case, you"
           echo "*** may want to edit the sdl2-config script: $SDL2_CONFIG" ])
           CFLAGS="$ac_save_CFLAGS"


### PR DESCRIPTION
## Description
Fix a typo in sdl2.m4. occured -> occurred. blast007 pointed this out in [BZFlag](https://github.com/BZFlag-Dev/bzflag) [#359](https://github.com/BZFlag-Dev/bzflag/pull/359).

## Existing Issue(s)
N/A
