### PR TITLE
Update SDLActivity.java

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -790,6 +790,11 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
                                 window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
                                 SDLActivity.mFullscreenModeActive = false;
                             }
+                             if (Build.VERSION.SDK_INT >= 28 /* Android 9 (Pie) */) {
+                                window.getAttributes().layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+                            }
+
+                            
                         }
                     } else {
                         Log.e(TAG, "error handling message, getContext() returned no Activity");


### PR DESCRIPTION
Fix Full immersive mode in Android 9 and higher.

LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
will make sure to use all the screen when  the fullscreen flag is enabled.

The other option is 
LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS will work in some cases but in devices that have a camera in the middle this flag will not work.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
