### PR TITLE
Fixed unlocking a spinlock when it wasn't locked

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -10334,7 +10334,7 @@ static void VULKAN_INTERNAL_CleanCommandBuffer(
     for (i = 0; i < commandBuffer->boundDescriptorSetDataCount; i += 1) {
         descriptorSetData = &commandBuffer->boundDescriptorSetDatas[i];
 
-        SDL_TryLockSpinlock(&descriptorSetData->descriptorSetPool->lock);
+        SDL_LockSpinlock(&descriptorSetData->descriptorSetPool->lock);
 
         if (descriptorSetData->descriptorSetPool->inactiveDescriptorSetCount == descriptorSetData->descriptorSetPool->inactiveDescriptorSetCapacity) {
             descriptorSetData->descriptorSetPool->inactiveDescriptorSetCapacity *= 2;


### PR DESCRIPTION
If we're not checking the return value and handling the case where it's already locked, we should be doing an unconditional lock.

As an aside, @flibitijibibo, spinlocks are dangerous and probably not what you want here. 