### PR TITLE
render: Integrate fix-shaders.sh into build-shaders.sh

### DIFF
--- a/src/render/gpu/shaders/.gitignore
+++ b/src/render/gpu/shaders/.gitignore
@@ -1,3 +1,4 @@
 *.hlsl
 *.metal
 *.spv
+*.tmp.h

--- a/src/render/gpu/shaders/fix-shaders.sh
+++ b/src/render/gpu/shaders/fix-shaders.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-#
-# Update generated shader code to fix compiler warnings
-
-sed -i '' 's,^const,static const,' *.h
-sed -i '' 's,const unsigned,const signed,' *.dxbc.h


### PR DESCRIPTION
* render: Integrate fix-shaders.sh into build-shaders.sh
    
    By writing the fxc and dxc output to a temporary file and then
    converting that temporary file to the desired filename, we avoid
    the incompatible semantics of sed -i on GNU systems (sed -i does not
    create a backup filename, and does not take an argument unless it is
    "bundled") and macOS (sed -i requires an argument, possibly empty).
    
    Resolves: https://github.com/libsdl-org/SDL/issues/10878

---

Please test on whatever platform @slouken is using (macOS?) before merging!