### PR TITLE
render: Don't try to rebuild D3D11, D3D12, Metal shaders without spirv-cross

### DIFF
--- a/src/render/gpu/shaders/build-shaders.sh
+++ b/src/render/gpu/shaders/build-shaders.sh
@@ -10,8 +10,8 @@ which dxc &>/dev/null && HAVE_DXC=1 || HAVE_DXC=0
 [ "$HAVE_FXC" != 0 ] || echo "fxc not in PATH; D3D11 shaders will not be rebuilt"
 [ "$HAVE_DXC" != 0 ] || echo "dxc not in PATH; D3D12 shaders will not be rebuilt"
 
-USE_FXC=${USE_FXC:-HAVE_FXC}
-USE_DXC=${USE_DXC:-HAVE_DXC}
+USE_FXC=${USE_FXC:-$HAVE_FXC}
+USE_DXC=${USE_DXC:-$HAVE_DXC}
 
 spirv_bundle="spir-v.h"
 dxbc50_bundle="dxbc50.h"


### PR DESCRIPTION
* render: Fix detection of fxc, dxc in build-shaders.sh
    
    We want `$USE_FXC` to default to the result of evaluating the variable
    `$HAVE_FXC`, not the literal string `HAVE_FXC`, and the same for dxc.

* render: Don't try to rebuild D3D11, D3D12, Metal shaders without spirv-cross

---

Related to #10878. Context for this is that Debian requires source code for everything we ship, so I can't include SDL in Debian without being able to compile at least the subset of the shaders that are actively used in Debian from their original .vert/.frag files. We don't currently have spirv-cross available, but we also don't actually need it, because D3D11, D3D12 and Metal are not relevant on Linux.