### PR TITLE
v4l2: return success if the device is ready

### DIFF
--- a/src/camera/v4l2/SDL_camera_v4l2.c
+++ b/src/camera/v4l2/SDL_camera_v4l2.c
@@ -107,6 +107,8 @@ static bool V4L2_WaitDevice(SDL_Camera *device)
         rc = select(fd + 1, &fds, NULL, NULL, &tv);
         if ((rc == -1) && (errno == EINTR)) {
             rc = 0;  // pretend it was a timeout, keep looping.
+        } else if (rc > 0) {
+            return true;
         }
 
         // Thread is requested to shut down


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If the device signals that it is ready, we should return success. I am not sure why it worked in some situations before, so I suspect `device->shutdown` might be set wrongly somewhere, but not sure.
This enables me to use obs virtual camera (v4l2 loopback) and some more configurations of my webcam.


refs:
- https://www.kernel.org/doc/html/v5.6/media/uapi/v4l/func-select.html#return-value
- https://github.com/obsproject/obs-studio/blob/16b8e9c3fe48e2dadfa0723cc162e842936bbab8/plugins/linux-v4l2/v4l2-input.c#L221

## Existing Issue(s)
looks like #10698 describes this.
