### PR TITLE
Renamed SDL_INIT_INTERFACE() to SDL_InitInterface()

### DIFF
--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -932,7 +932,7 @@ The functions SDL_GetJoysticks(), SDL_GetJoystickNameForID(), SDL_GetJoystickPat
 
 SDL_AttachVirtualJoystick() now returns the joystick instance ID instead of a device index, and returns 0 if there was an error.
 
-SDL_VirtualJoystickDesc version should not be set to SDL_VIRTUAL_JOYSTICK_DESC_VERSION, instead the structure should be initialized using SDL_INIT_INTERFACE().
+SDL_VirtualJoystickDesc version should not be set to SDL_VIRTUAL_JOYSTICK_DESC_VERSION, instead the structure should be initialized using SDL_InitInterface().
 
 The following functions have been renamed:
 * SDL_JoystickAttachVirtualEx() => SDL_AttachVirtualJoystick()
@@ -1593,7 +1593,7 @@ SDL_IOStream *SDL_RWFromFP(FILE *fp, SDL_bool autoclose)
         return NULL;
     }
 
-    SDL_INIT_INTERFACE(&iface);
+    SDL_InitInterface(&iface);
     /* There's no stdio_size because SDL_GetIOSize emulates it the same way we'd do it for stdio anyhow. */
     iface.seek = stdio_seek;
     iface.read = stdio_read;

--- a/include/SDL3/SDL_iostream.h
+++ b/include/SDL3/SDL_iostream.h
@@ -83,11 +83,11 @@ typedef enum SDL_IOWhence
  * already offers several common types of I/O streams, via functions like
  * SDL_IOFromFile() and SDL_IOFromMem().
  *
- * This structure should be initialized using SDL_INIT_INTERFACE()
+ * This structure should be initialized using SDL_InitInterface()
  *
  * \since This struct is available since SDL 3.0.0.
  *
- * \sa SDL_INIT_INTERFACE
+ * \sa SDL_InitInterface
  */
 typedef struct SDL_IOStreamInterface
 {
@@ -383,7 +383,7 @@ extern SDL_DECLSPEC SDL_IOStream * SDLCALL SDL_IOFromDynamicMem(void);
  * it around after this call.
  *
  * \param iface the interface that implements this SDL_IOStream, initialized
- *              using SDL_INIT_INTERFACE().
+ *              using SDL_InitInterface().
  * \param userdata the pointer that will be passed to the interface functions.
  * \returns a pointer to the allocated memory on success or NULL on failure;
  *          call SDL_GetError() for more information.
@@ -391,7 +391,7 @@ extern SDL_DECLSPEC SDL_IOStream * SDLCALL SDL_IOFromDynamicMem(void);
  * \since This function is available since SDL 3.0.0.
  *
  * \sa SDL_CloseIO
- * \sa SDL_INIT_INTERFACE
+ * \sa SDL_InitInterface
  * \sa SDL_IOFromConstMem
  * \sa SDL_IOFromFile
  * \sa SDL_IOFromMem

--- a/include/SDL3/SDL_joystick.h
+++ b/include/SDL3/SDL_joystick.h
@@ -415,13 +415,13 @@ typedef struct SDL_VirtualJoystickSensorDesc
 /**
  * The structure that describes a virtual joystick.
  *
- * This structure should be initialized using SDL_INIT_INTERFACE(). All
+ * This structure should be initialized using SDL_InitInterface(). All
  * elements of this structure are optional.
  *
  * \since This struct is available since SDL 3.0.0.
  *
  * \sa SDL_AttachVirtualJoystick
- * \sa SDL_INIT_INTERFACE
+ * \sa SDL_InitInterface
  * \sa SDL_VirtualJoystickSensorDesc
  * \sa SDL_VirtualJoystickTouchpadDesc
  */
@@ -471,7 +471,7 @@ SDL_COMPILE_TIME_ASSERT(SDL_VirtualJoystickDesc_SIZE,
 /**
  * Attach a new virtual joystick.
  *
- * \param desc joystick description, initialized using SDL_INIT_INTERFACE().
+ * \param desc joystick description, initialized using SDL_InitInterface().
  * \returns the joystick instance ID, or 0 on failure; call SDL_GetError() for
  *          more information.
  *

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -628,7 +628,7 @@ extern "C" {
  * ```c
  * SDL_IOStreamInterface iface;
  *
- * SDL_INIT_INTERFACE(&iface);
+ * SDL_InitInterface(&iface);
  *
  * // Fill in the interface function pointers with your implementation
  * iface.seek = ...
@@ -655,7 +655,7 @@ extern "C" {
  * \sa SDL_StorageInterface
  * \sa SDL_VirtualJoystickDesc
  */
-#define SDL_INIT_INTERFACE(iface)               \
+#define SDL_InitInterface(iface)                \
     do {                                        \
         SDL_zerop(iface);                       \
         (iface)->version = sizeof(*(iface));    \

--- a/include/SDL3/SDL_storage.h
+++ b/include/SDL3/SDL_storage.h
@@ -52,11 +52,11 @@ extern "C" {
  * It is not usually necessary to do this; SDL provides standard
  * implementations for many things you might expect to do with an SDL_Storage.
  *
- * This structure should be initialized using SDL_INIT_INTERFACE()
+ * This structure should be initialized using SDL_InitInterface()
  *
  * \since This struct is available since SDL 3.0.0.
  *
- * \sa SDL_INIT_INTERFACE
+ * \sa SDL_InitInterface
  */
 typedef struct SDL_StorageInterface
 {
@@ -197,7 +197,7 @@ extern SDL_DECLSPEC SDL_Storage * SDLCALL SDL_OpenFileStorage(const char *path);
  * it around after this call.
  *
  * \param iface the interface that implements this storage, initialized using
- *              SDL_INIT_INTERFACE().
+ *              SDL_InitInterface().
  * \param userdata the pointer that will be passed to the interface functions.
  * \returns a storage container on success or NULL on failure; call
  *          SDL_GetError() for more information.
@@ -207,7 +207,7 @@ extern SDL_DECLSPEC SDL_Storage * SDLCALL SDL_OpenFileStorage(const char *path);
  * \sa SDL_CloseStorage
  * \sa SDL_GetStorageFileSize
  * \sa SDL_GetStorageSpaceRemaining
- * \sa SDL_INIT_INTERFACE
+ * \sa SDL_InitInterface
  * \sa SDL_ReadStorageFile
  * \sa SDL_StorageReady
  * \sa SDL_WriteStorageFile

--- a/src/file/SDL_iostream.c
+++ b/src/file/SDL_iostream.c
@@ -300,7 +300,7 @@ SDL_IOStream *SDL_IOFromHandle(HANDLE handle, const char *mode, bool autoclose)
     }
 
     SDL_IOStreamInterface iface;
-    SDL_INIT_INTERFACE(&iface);
+    SDL_InitInterface(&iface);
     if (GetFileType(handle) == FILE_TYPE_DISK) {
         iface.size = windows_file_size;
         iface.seek = windows_file_seek;
@@ -489,7 +489,7 @@ SDL_IOStream *SDL_IOFromFP(FILE *fp, bool autoclose)
     }
 
     SDL_IOStreamInterface iface;
-    SDL_INIT_INTERFACE(&iface);
+    SDL_InitInterface(&iface);
     // There's no stdio_size because SDL_GetIOSize emulates it the same way we'd do it for stdio anyhow.
     iface.seek = stdio_seek;
     iface.read = stdio_read;
@@ -671,7 +671,7 @@ SDL_IOStream *SDL_IOFromFile(const char *file, const char *mode)
     }
 
     SDL_IOStreamInterface iface;
-    SDL_INIT_INTERFACE(&iface);
+    SDL_InitInterface(&iface);
     iface.size = Android_JNI_FileSize;
     iface.seek = Android_JNI_FileSeek;
     iface.read = Android_JNI_FileRead;
@@ -736,7 +736,7 @@ SDL_IOStream *SDL_IOFromMem(void *mem, size_t size)
     }
 
     SDL_IOStreamInterface iface;
-    SDL_INIT_INTERFACE(&iface);
+    SDL_InitInterface(&iface);
     iface.size = mem_size;
     iface.seek = mem_seek;
     iface.read = mem_read;
@@ -770,7 +770,7 @@ SDL_IOStream *SDL_IOFromConstMem(const void *mem, size_t size)
     }
 
     SDL_IOStreamInterface iface;
-    SDL_INIT_INTERFACE(&iface);
+    SDL_InitInterface(&iface);
     iface.size = mem_size;
     iface.seek = mem_seek;
     iface.read = mem_read;
@@ -870,7 +870,7 @@ SDL_IOStream *SDL_IOFromDynamicMem(void)
     }
 
     SDL_IOStreamInterface iface;
-    SDL_INIT_INTERFACE(&iface);
+    SDL_InitInterface(&iface);
     iface.size = dynamic_mem_size;
     iface.seek = dynamic_mem_seek;
     iface.read = dynamic_mem_read;
@@ -903,7 +903,7 @@ SDL_IOStream *SDL_OpenIO(const SDL_IOStreamInterface *iface, void *userdata)
     }
     if (iface->version < sizeof(*iface)) {
         // Update this to handle older versions of this interface
-        SDL_SetError("Invalid interface, should be initialized with SDL_INIT_INTERFACE()");
+        SDL_SetError("Invalid interface, should be initialized with SDL_InitInterface()");
         return NULL;
     }
 

--- a/src/joystick/virtual/SDL_virtualjoystick.c
+++ b/src/joystick/virtual/SDL_virtualjoystick.c
@@ -144,7 +144,7 @@ SDL_JoystickID SDL_JoystickAttachVirtualInner(const SDL_VirtualJoystickDesc *des
     }
     if (desc->version < sizeof(*desc)) {
         // Update this to handle older versions of this interface
-        SDL_SetError("Invalid desc, should be initialized with SDL_INIT_INTERFACE()");
+        SDL_SetError("Invalid desc, should be initialized with SDL_InitInterface()");
         return 0;
     }
 

--- a/src/storage/SDL_storage.c
+++ b/src/storage/SDL_storage.c
@@ -155,7 +155,7 @@ SDL_Storage *SDL_OpenStorage(const SDL_StorageInterface *iface, void *userdata)
     }
     if (iface->version < sizeof(*iface)) {
         // Update this to handle older versions of this interface
-        SDL_SetError("Invalid interface, should be initialized with SDL_INIT_INTERFACE()");
+        SDL_SetError("Invalid interface, should be initialized with SDL_InitInterface()");
         return NULL;
     }
 

--- a/test/testautomation_iostream.c
+++ b/test/testautomation_iostream.c
@@ -437,7 +437,7 @@ static int SDLCALL iostrm_testAllocFree(void *arg)
     SDL_IOStreamInterface iface;
     SDL_IOStream *rw;
 
-    SDL_INIT_INTERFACE(&iface);
+    SDL_InitInterface(&iface);
     rw = SDL_OpenIO(&iface, NULL);
     SDLTest_AssertPass("Call to SDL_OpenIO() succeeded");
     SDLTest_AssertCheck(rw != NULL, "Validate result from SDL_OpenIO() is not NULL");

--- a/test/testautomation_joystick.c
+++ b/test/testautomation_joystick.c
@@ -27,7 +27,7 @@ static int SDLCALL TestVirtualJoystick(void *arg)
 
     SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
 
-    SDL_INIT_INTERFACE(&desc);
+    SDL_InitInterface(&desc);
     desc.type = SDL_JOYSTICK_TYPE_GAMEPAD;
     desc.naxes = SDL_GAMEPAD_AXIS_COUNT;
     desc.nbuttons = SDL_GAMEPAD_BUTTON_COUNT;

--- a/test/testcontroller.c
+++ b/test/testcontroller.c
@@ -1159,7 +1159,7 @@ static void OpenVirtualGamepad(void)
         return;
     }
 
-    SDL_INIT_INTERFACE(&desc);
+    SDL_InitInterface(&desc);
     desc.type = SDL_JOYSTICK_TYPE_GAMEPAD;
     desc.naxes = SDL_GAMEPAD_AXIS_COUNT;
     desc.nbuttons = SDL_GAMEPAD_BUTTON_COUNT;


### PR DESCRIPTION

The name of the function macro `SDL_INIT_INTERFACE()` clashes a bit with the naming style of the init flags:
https://github.com/libsdl-org/SDL/blob/03ae792df35a15e80e16a41ea2cf19971fc8d8f6/include/SDL3/SDL_stdinc.h#L658-L662
https://github.com/libsdl-org/SDL/blob/03ae792df35a15e80e16a41ea2cf19971fc8d8f6/include/SDL3/SDL_init.h#L58-L67

This commit renames it to `SDL_InitInterface()`.

It can be argued that it then conflicts with the naming style of the type `SDL_InitFlags`, but there are already functions that start with `SDL_Init*()`, but there are no other names that start with `SDL_INIT_*` except the init flags.
```c
SDL_Init()
SDL_InitSubSystem()
SDL_InitHapticRumble()
```

The function macro name `SDL_InitInterface()` would fit better along the function names, than as `SDL_INIT_INTERFACE()` along the init flags.