### PR TITLE
[SDL2] Build a fake SDL2 library

### DIFF
--- a/build-scripts/fake/CMakeLists.txt
+++ b/build-scripts/fake/CMakeLists.txt
@@ -1,0 +1,132 @@
+cmake_minimum_required(VERSION 3.16)
+project(fake-SDL2 LANGUAGES C VERSION "2.31.0")
+
+get_filename_component(SDL2_ROOT "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+message(STATUS "SDL2 root directory = ${SDL2_ROOT}")
+
+include(CheckCCompilerFlag)
+include(CheckLinkerFlag)
+include(CMakePushCheckState)
+include(GNUInstallDirs)
+
+add_library(SDL2-Headers INTERFACE)
+target_include_directories(SDL2-Headers INTERFACE "$<BUILD_INTERFACE:${SDL2_ROOT}/include>")
+target_include_directories(SDL2-Headers INTERFACE "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+target_include_directories(SDL2-Headers INTERFACE "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/SDL2>")
+set_property(TARGET SDL2-Headers PROPERTY EXPORT_NAME "Headers")
+
+add_library(SDL2-fake SHARED
+  "fake.c"
+  "${SDL2_ROOT}/src/main/windows/version.rc"
+)
+target_link_libraries(SDL2-fake PUBLIC SDL2-Headers)
+target_include_directories(SDL2-fake PRIVATE "$<BUILD_INTERFACE:${SDL2_ROOT}/src>")
+set_property(TARGET SDL2-fake PROPERTY OUTPUT_NAME "SDL2")
+set_property(TARGET SDL2-fake PROPERTY DEFINE_SYMBOL "BUILD_DLL")
+set_property(TARGET SDL2-fake PROPERTY EXPORT_NAME "SDL2")
+
+add_library(SDL2main STATIC)
+target_link_libraries(SDL2main PRIVATE SDL2-Headers)
+if(WIN32)
+  target_sources(SDL2main PRIVATE "${SDL2_ROOT}/src/main/windows/SDL_windows_main.c")
+else()
+  target_sources(SDL2main PRIVATE "${SDL2_ROOT}/src/main/dummy/SDL_windows_main.c")
+endif()
+
+# Increment this if there is an incompatible change - but if that happens,
+# we should rename the library from SDL2 to SDL4, at which point this would
+# reset to 0 anyway.
+set(SDL_SO_VERSION_MAJOR "0")
+set(SDL_SO_VERSION_MINOR "${PROJECT_VERSION_MINOR}")
+set(SDL_SO_VERSION_PATCH "${PROJECT_VERSION_PATCH}")
+set(SDL_SO_VERSION "${SDL_SO_VERSION_MAJOR}.${SDL_SO_VERSION_MINOR}.${SDL_SO_VERSION_PATCH}")
+
+if(PROJECT_VERSION_MINOR MATCHES "[02468]$")
+  math(EXPR SDL_DYLIB_COMPAT_VERSION_MAJOR "100 * ${PROJECT_VERSION_MINOR} + 1")
+  set(SDL_DYLIB_COMPAT_VERSION_MINOR "0")
+  math(EXPR SDL_DYLIB_CURRENT_VERSION_MAJOR "${SDL_DYLIB_COMPAT_VERSION_MAJOR}")
+  set(SDL_DYLIB_CURRENT_VERSION_MINOR "${PROJECT_VERSION_PATCH}")
+else()
+  math(EXPR SDL_DYLIB_COMPAT_VERSION_MAJOR "100 * ${PROJECT_VERSION_MINOR} + ${PROJECT_VERSION_PATCH} + 1")
+  set(SDL_DYLIB_COMPAT_VERSION_MINOR "0")
+  math(EXPR SDL_DYLIB_CURRENT_VERSION_MAJOR "${SDL_DYLIB_COMPAT_VERSION_MAJOR}")
+  set(SDL_DYLIB_CURRENT_VERSION_MINOR "0")
+endif()
+set(SDL_DYLIB_CURRENT_VERSION_PATCH "0")
+set(SDL_DYLIB_COMPAT_VERSION_PATCH "0")
+
+set(SDL_DYLIB_CURRENT_VERSION "${SDL_DYLIB_CURRENT_VERSION_MAJOR}.${SDL_DYLIB_CURRENT_VERSION_MINOR}.${SDL_DYLIB_CURRENT_VERSION_PATCH}")
+set(SDL_DYLIB_COMPAT_VERSION "${SDL_DYLIB_COMPAT_VERSION_MAJOR}.${SDL_DYLIB_COMPAT_VERSION_MINOR}.${SDL_DYLIB_COMPAT_VERSION_PATCH}")
+
+message(DEBUG "SDL_SO_VERSION=${SDL_SO_VERSION} SDL_DYLIB_CURRENT_VERSION=${SDL_DYLIB_CURRENT_VERSION} SDL_DYLIB_COMPAT_VERSION=${SDL_DYLIB_COMPAT_VERSION}")
+
+if(APPLE)
+  cmake_minimum_required(VERSION 3.17)
+  set_target_properties(SDL2-fake PROPERTIES
+    MACOSX_RPATH TRUE
+    FRAMEWORK "${SDL_FRAMEWORK}"
+    SOVERSION "${SDL_SO_VERSION_MAJOR}"
+    MACHO_COMPATIBILITY_VERSION "${SDL_DYLIB_COMPAT_VERSION}"
+    MACHO_CURRENT_VERSION "${SDL_DYLIB_CURRENT_VERSION}"
+  )
+  if(SDL_FRAMEWORK)
+    set_target_properties(SDL2-fake PROPERTIES
+      PUBLIC_HEADER "${SDL2_INCLUDE_FILES}"
+      FRAMEWORK_VERSION "${SDL_FRAMEWORK_VERSION}"
+      MACOSX_FRAMEWORK_IDENTIFIER "org.libsdl.SDL2"
+      RESOURCE "${SDL_FRAMEWORK_RESOURCES}"
+    )
+  endif()
+elseif(UNIX AND NOT ANDROID)
+  set_target_properties(SDL2-fake PROPERTIES
+    VERSION "${SDL_SO_VERSION}"
+    SOVERSION "${SDL_SO_VERSION_MAJOR}"
+  )
+elseif(WIN32 OR CYGWIN)
+  set_target_properties(SDL2-fake PROPERTIES
+    PREFIX ""
+  )
+endif()
+
+if(MSVC)
+  set(CMAKE_INSTALLDIR "cmake")
+else()
+  set(CMAKE_INSTALLDIR "${CMAKE_INSTALL_LIBDIR}/cmake/SDL2")
+endif()
+
+
+file(GLOB SDL2_HEADERS "${SDL2_ROOT}/include/*.h")
+install(FILES ${SDL2_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/SDL2")
+install(TARGETS SDL2-fake SDL2-Headers SDL2main EXPORT SDL2-fake-exports
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+)
+install(EXPORT SDL2-fake-exports DESTINATION "${CMAKE_INSTALLDIR}" FILE "SDL2Config.cmake")
+
+set(prefix "\${pcfiledir}/../..")
+set(exec_prefix "\${pcfiledir}/../..")
+set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+if(MINGW)
+  if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+    target_link_libraries(SDL2main PUBLIC "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:-Wl,--undefined=_WinMain@16>")
+  else()
+    target_link_libraries(SDL2main PUBLIC "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:-Wl,--undefined=WinMain>")
+  endif()
+endif()
+if(WIN32)
+  set(SDL_LIBS "-lmingw32 -lSDL2main -lSDL2")
+else()
+  set(SDL_LIBS "-lSDL2")
+endif()
+configure_file("${SDL2_ROOT}/sdl2.pc.in" "sdl2.pc" @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sdl2.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+
+set(bin_prefix_relpath "..")
+set(ENABLE_SHARED_TRUE "")
+set(ENABLE_SHARED_FALSE "#")
+set(ENABLE_STATIC_TRUE "#")
+set(ENABLE_STATIC_FALSE "")
+configure_file("${SDL2_ROOT}/sdl2-config.in" "sdl2-config")
+install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/sdl2-config" DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/build-scripts/fake/fake.c
+++ b/build-scripts/fake/fake.c
@@ -1,0 +1,15 @@
+#define SDL_MAIN_HANDLED
+#include "SDL.h"
+#include "SDL_syswm.h"
+#include "SDL_main.h"
+#include "SDL_vulkan.h"
+
+#include <stdlib.h>
+
+#define SDL_DYNAPI_PROC(ret, name, fun_args, call_args, opt_ret) \
+    ret name fun_args                                            \
+    {                                                            \
+        abort();                                                 \
+    }
+#include "dynapi/SDL_dynapi_procs.h"
+#undef SDL_DYNAPI_PROC

--- a/build-scripts/test-versioning.sh
+++ b/build-scripts/test-versioning.sh
@@ -58,6 +58,14 @@ else
     not_ok "CMakeLists.txt $version disagrees with SDL_version.h $ref_version"
 fi
 
+version=$(sed -Ene 's/^project\(fake-SDL[0-9]+ LANGUAGES C VERSION "([0-9.]*)"\)$/\1/p' build-scripts/fake/CMakeLists.txt)
+
+if [ "$ref_version" = "$version" ]; then
+    ok "build-scripts/fake/CMakeLists.txt $version"
+else
+    not_ok "build-scripts/fake/CMakeLists.txt $version disagrees with SDL_version.h $ref_version"
+fi
+
 major=$(sed -ne 's/.*SDL_MAJOR_VERSION = \([0-9]*\);/\1/p' android-project/app/src/main/java/org/libsdl/app/SDLActivity.java)
 minor=$(sed -ne 's/.*SDL_MINOR_VERSION = \([0-9]*\);/\1/p' android-project/app/src/main/java/org/libsdl/app/SDLActivity.java)
 micro=$(sed -ne 's/.*SDL_MICRO_VERSION = \([0-9]*\);/\1/p' android-project/app/src/main/java/org/libsdl/app/SDLActivity.java)

--- a/build-scripts/update-version.sh
+++ b/build-scripts/update-version.sh
@@ -62,6 +62,8 @@ perl -w -pi -e 's/\A(set\(SDL_MAJOR_VERSION\s+)\d+/${1}'$MAJOR'/;' CMakeLists.tx
 perl -w -pi -e 's/\A(set\(SDL_MINOR_VERSION\s+)\d+/${1}'$MINOR'/;' CMakeLists.txt
 perl -w -pi -e 's/\A(set\(SDL_MICRO_VERSION\s+)\d+/${1}'$PATCH'/;' CMakeLists.txt
 
+perl -w -pi -e 's/\A(project\(fake-SDL[0-9]+ LANGUAGES C VERSION ")[0-9.]+/${1}'$NEWVERSION'/;' build-scripts/fake/CMakeLists.txt
+
 perl -w -pi -e 's/\A(.* SDL_MAJOR_VERSION = )\d+/${1}'$MAJOR'/;' android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
 perl -w -pi -e 's/\A(.* SDL_MINOR_VERSION = )\d+/${1}'$MINOR'/;' android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
 perl -w -pi -e 's/\A(.* SDL_MICRO_VERSION = )\d+/${1}'$PATCH'/;' android-project/app/src/main/java/org/libsdl/app/SDLActivity.java


### PR DESCRIPTION
This is useful on CI to quickly build a library from scratch where we don't care about the internals.

This is related to https://github.com/libsdl-org/SDL/issues/9580, but is not a header-only library:
it creates a shared SDL2 library that looks identical to the original, but aborts immediately when you try to run it.

I first tried plumbing this in `src/dynapi/SDL_dynapi.c` so it does not abort and forwards the calls to a "real" SDL2 library, like sdl2-compat does.
Perhaps @icculus has more success ;)

I'd like to use this for creating binary releases of the SDL2 satellite libraries such that they do not need to rebuild SDL2 for every VC/mingw architecture.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->

