### PR TITLE
Fix typos

### DIFF
--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -1827,9 +1827,9 @@ But if you're migrating your code which uses masks, you probably have a format i
 
 SDL_BlitSurface() and SDL_BlitSurfaceScaled() now have a const `dstrect` parameter and do not fill it in with the final destination rectangle.
 
-SDL_BlitSurfaceScaled() and SDL_BlitSurfaceUncheckedScaled() now take a scale paramater.
+SDL_BlitSurfaceScaled() and SDL_BlitSurfaceUncheckedScaled() now take a scale parameter.
 
-SDL_SoftStretch() now takes a scale paramater.
+SDL_SoftStretch() now takes a scale parameter.
 
 SDL_PixelFormat is used instead of Uint32 for API functions that refer to pixel format by enumerated value.
 

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2497,7 +2497,7 @@ extern "C" {
  * system while relative mode is active, in case the desired confinement state
  * became out-of-sync due to interference from other running programs.
  *
- * The variable can be integers representing miliseconds between each refresh.
+ * The variable can be integers representing milliseconds between each refresh.
  * A value of zero means SDL will not automatically refresh the confinement.
  * The default value varies depending on the operating system, this variable
  * might not have any effects on inapplicable platforms such as those without

--- a/src/atomic/SDL_spinlock.c
+++ b/src/atomic/SDL_spinlock.c
@@ -129,14 +129,14 @@ SDL_bool SDL_TryLockSpinlock(SDL_SpinLock *lock)
 #elif defined(PS2)
     uint32_t oldintr;
     bool res = false;
-    // disable interuption
+    // disable interruption
     oldintr = DIntr();
 
     if (*lock == 0) {
         *lock = 1;
         res = true;
     }
-    // enable interuption
+    // enable interruption
     if (oldintr) {
         EIntr();
     }

--- a/src/audio/SDL_audiocvt.c
+++ b/src/audio/SDL_audiocvt.c
@@ -1013,7 +1013,7 @@ static bool GetAudioStreamDataInternal(SDL_AudioStream *stream, void *buf, int o
     // Calculate the number of input frames necessary for this request.
     // Because resampling happens "between" frames, The same number of output_frames
     // can require a different number of input_frames, depending on the resample_offset.
-    // Infact, input_frames can sometimes even be zero when upsampling.
+    // In fact, input_frames can sometimes even be zero when upsampling.
     const int input_frames = (int) SDL_GetResamplerInputFrames(output_frames, resample_rate, stream->resample_offset);
 
     const int padding_frames = SDL_GetResamplerPaddingFrames(resample_rate);

--- a/src/audio/dummy/SDL_dummyaudio.h
+++ b/src/audio/dummy/SDL_dummyaudio.h
@@ -28,7 +28,7 @@
 struct SDL_PrivateAudioData
 {
     Uint8 *mixbuf;   // The file descriptor for the audio device
-    Uint32 io_delay; // miliseconds to sleep in WaitDevice.
+    Uint32 io_delay; // milliseconds to sleep in WaitDevice.
 };
 
 #endif // SDL_dummyaudio_h_

--- a/src/camera/SDL_camera.c
+++ b/src/camera/SDL_camera.c
@@ -116,7 +116,7 @@ bool SDL_AddCameraFormat(CameraFormatAddData *data, SDL_PixelFormat format, SDL_
 static bool ZombieWaitDevice(SDL_Camera *device)
 {
     if (!SDL_GetAtomicInt(&device->shutdown)) {
-        // !!! FIXME: this is bad for several reasons (uses double, could be precalculated, doesn't track elasped time).
+        // !!! FIXME: this is bad for several reasons (uses double, could be precalculated, doesn't track elapsed time).
         const double duration = ((double) device->actual_spec.framerate_denominator / ((double) device->actual_spec.framerate_numerator));
         SDL_Delay((Uint32) (duration * 1000.0));
     }

--- a/src/camera/android/SDL_camera_android.c
+++ b/src/camera/android/SDL_camera_android.c
@@ -194,7 +194,7 @@ static const char *MediaStatusStr(const media_status_t rc)
 {
     switch (rc) {
         case AMEDIA_OK: return "no error";
-        case AMEDIACODEC_ERROR_INSUFFICIENT_RESOURCE: return "insuffient resources";
+        case AMEDIACODEC_ERROR_INSUFFICIENT_RESOURCE: return "insufficient resources";
         case AMEDIACODEC_ERROR_RECLAIMED: return "reclaimed";
         case AMEDIA_ERROR_UNKNOWN: return "unknown error";
         case AMEDIA_ERROR_MALFORMED: return "malformed";

--- a/src/core/linux/SDL_evdev.c
+++ b/src/core/linux/SDL_evdev.c
@@ -352,9 +352,9 @@ void SDL_EVDEV_Poll(void)
                     }
 
                     /* BTN_TOUCH event value 1 indicates there is contact with
-                       a touchscreen or trackpad (earlist finger's current
+                       a touchscreen or trackpad (earliest finger's current
                        position is sent in EV_ABS ABS_X/ABS_Y, switching to
-                       next finger after earlist is released) */
+                       next finger after earliest is released) */
                     if (item->is_touchscreen && event->code == BTN_TOUCH) {
                         if (item->touchscreen_data->max_slots == 1) {
                             if (event->value) {

--- a/src/core/windows/SDL_windows.h
+++ b/src/core/windows/SDL_windows.h
@@ -161,7 +161,7 @@ extern BOOL WIN_IsRectEmpty(const RECT *rect);
 
 extern SDL_AudioFormat SDL_WaveFormatExToSDLFormat(WAVEFORMATEX *waveformat);
 
-// WideCharToMultiByte, but with some WinXP manangement.
+// WideCharToMultiByte, but with some WinXP management.
 extern int WIN_WideCharToMultiByte(UINT CodePage, DWORD dwFlags, LPCWCH lpWideCharStr, int cchWideChar, LPSTR lpMultiByteStr, int cbMultiByte, LPCCH lpDefaultChar, LPBOOL lpUsedDefaultChar);
 
 // Ends C function definitions when using C++

--- a/src/dialog/SDL_dialog_utils.h
+++ b/src/dialog/SDL_dialog_utils.h
@@ -46,7 +46,7 @@ char *convert_filter(const SDL_DialogFileFilter filter, NameTransform ntf,
                      const char *suffix, const char *ext_prefix,
                      const char *ext_separator, const char *ext_suffix);
 
-// Converts the extenstion list of a filter into a single string.
+// Converts the extension list of a filter into a single string.
 // <prefix>[extension]{<separator>[extension]...}<suffix>
 char *convert_ext_list(const char *list, const char *prefix,
                        const char *separator, const char *suffix);

--- a/src/dynapi/gendynapi.py
+++ b/src/dynapi/gendynapi.py
@@ -85,7 +85,7 @@ def main():
                     ignore_wiki_documentation = False
                 continue
 
-            # Discard wiki documentions blocks.
+            # Discard wiki documentations blocks.
             if line.startswith("#ifdef SDL_WIKI_DOCUMENTATION_SECTION"):
                 ignore_wiki_documentation = True
                 continue

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -888,7 +888,7 @@ struct D3D12UniformBuffer
     Uint32 currentBlockSize;
 };
 
-// Foward function declarations
+// Forward function declarations
 
 static void D3D12_ReleaseWindow(SDL_GPURenderer *driverData, SDL_Window *window);
 static void D3D12_Wait(SDL_GPURenderer *driverData);

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -2408,7 +2408,7 @@ static void VULKAN_INTERNAL_TrackUniformBuffer(
  *
  * This strategy imposes certain limitations on resource usage flags.
  * For example, a texture cannot have both the SAMPLER and GRAPHICS_STORAGE usage flags,
- * because then it is imposible for the backend to infer which default usage mode the texture should use.
+ * because then it is impossible for the backend to infer which default usage mode the texture should use.
  *
  * Sync hazards can be detected by setting VK_KHRONOS_VALIDATION_VALIDATE_SYNC=1 when using validation layers.
  */

--- a/src/hidapi/hidapi/hidapi.h
+++ b/src/hidapi/hidapi/hidapi.h
@@ -64,7 +64,7 @@
 #define HID_API_AS_STR(x) HID_API_AS_STR_IMPL(x)
 #define HID_API_TO_VERSION_STR(v1, v2, v3) HID_API_AS_STR(v1.v2.v3)
 
-/** @brief Coverts a version as Major/Minor/Patch into a number:
+/** @brief Converts a version as Major/Minor/Patch into a number:
 	<8 bit major><16 bit minor><8 bit patch>.
 
 	This macro was added in version 0.12.0.

--- a/src/hidapi/ios/hid.m
+++ b/src/hidapi/ios/hid.m
@@ -403,7 +403,7 @@ typedef enum
 			NSLog( @"CoreBluetooth BLE hardware is powered on and ready" );
 
 			// at startup, if we have no already attached peripherals, do a 20s scan for new unpaired devices,
-			// otherwise callers should occaisionally do additional scans. we don't want to continuously be
+			// otherwise callers should occasionally do additional scans. we don't want to continuously be
 			// scanning because it drains battery, causes other nearby people to have a hard time pairing their
 			// Steam Controllers, and may also trigger firmware weirdness when a device attempts to start
 			// the pairing sequence multiple times concurrently

--- a/src/hidapi/mac/hid.c
+++ b/src/hidapi/mac/hid.c
@@ -1424,7 +1424,7 @@ void HID_API_EXPORT hid_close(hid_device *dev)
 
 	   UPD: The crash part was true in/until some version of macOS.
 	   Starting with macOS 10.15, there is an opposite effect in some environments:
-	   crash happenes if IOHIDDeviceClose() is not called.
+	   crash happens if IOHIDDeviceClose() is not called.
 	   Not leaking a resource in all tested environments.
 	*/
 	if (is_macos_10_10_or_greater || !dev->disconnected) {

--- a/src/hidapi/windows/hidapi_descriptor_reconstruct.c
+++ b/src/hidapi/windows/hidapi_descriptor_reconstruct.c
@@ -401,7 +401,7 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 				collection_node_idx = coll_child_order[collection_node_idx][0];
 
 				// In a HID Report Descriptor, the first usage declared is the most preferred usage for the control.
-				// While the order in the WIN32 capabiliy strutures is the opposite:
+				// While the order in the WIN32 capability strutures is the opposite:
 				// Here the preferred usage is the last aliased usage in the sequence.
 
 				if (link_collection_nodes[collection_node_idx].IsAlias && (firstDelimiterNode == NULL)) {
@@ -491,7 +491,7 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 			list_node = rd_search_main_item_list_for_bit_position(first_bit, (rd_main_items) rt_idx, pp_data->caps[caps_idx].ReportID, &coll_begin);
 
 			// In a HID Report Descriptor, the first usage declared is the most preferred usage for the control.
-			// While the order in the WIN32 capabiliy strutures is the opposite:
+			// While the order in the WIN32 capability strutures is the opposite:
 			// Here the preferred usage is the last aliased usage in the sequence.
 
 			if (pp_data->caps[caps_idx].IsAlias && (firstDelimiterNode == NULL)) {

--- a/src/hidapi/windows/hidapi_descriptor_reconstruct.c
+++ b/src/hidapi/windows/hidapi_descriptor_reconstruct.c
@@ -405,7 +405,7 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 				// Here the preferred usage is the last aliased usage in the sequence.
 
 				if (link_collection_nodes[collection_node_idx].IsAlias && (firstDelimiterNode == NULL)) {
-					// Alliased Collection (First node in link_collection_nodes -> Last entry in report descriptor output)
+					// Aliased Collection (First node in link_collection_nodes -> Last entry in report descriptor output)
 					firstDelimiterNode = main_item_list;
 					coll_begin_lookup[collection_node_idx] = rd_append_main_item_node(0, 0, rd_item_node_collection, 0, collection_node_idx, rd_delimiter_usage, 0, &main_item_list);
 					coll_begin_lookup[collection_node_idx] = rd_append_main_item_node(0, 0, rd_item_node_collection, 0, collection_node_idx, rd_delimiter_close, 0, &main_item_list);
@@ -431,7 +431,7 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 				collection_node_idx = coll_child_order[collection_node_idx][nextChild];
 												
 				if (link_collection_nodes[collection_node_idx].IsAlias && (firstDelimiterNode == NULL)) {
-					// Alliased Collection (First node in link_collection_nodes -> Last entry in report descriptor output)
+					// Aliased Collection (First node in link_collection_nodes -> Last entry in report descriptor output)
 					firstDelimiterNode = main_item_list;
 					coll_begin_lookup[collection_node_idx] = rd_append_main_item_node(0, 0, rd_item_node_collection, 0, collection_node_idx, rd_delimiter_usage, 0, &main_item_list);
 					coll_begin_lookup[collection_node_idx] = rd_append_main_item_node(0, 0, rd_item_node_collection, 0, collection_node_idx, rd_delimiter_close, 0, &main_item_list);
@@ -495,7 +495,7 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 			// Here the preferred usage is the last aliased usage in the sequence.
 
 			if (pp_data->caps[caps_idx].IsAlias && (firstDelimiterNode == NULL)) {
-				// Alliased Usage (First node in pp_data->caps -> Last entry in report descriptor output)
+				// Aliased Usage (First node in pp_data->caps -> Last entry in report descriptor output)
 				firstDelimiterNode = list_node;
 				rd_insert_main_item_node(first_bit, last_bit, rd_item_node_cap, caps_idx, pp_data->caps[caps_idx].LinkCollection, rd_delimiter_usage, pp_data->caps[caps_idx].ReportID, &list_node);
 				rd_insert_main_item_node(first_bit, last_bit, rd_item_node_cap, caps_idx, pp_data->caps[caps_idx].LinkCollection, rd_delimiter_close, pp_data->caps[caps_idx].ReportID, &list_node);
@@ -504,7 +504,7 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 				rd_insert_main_item_node(first_bit, last_bit, rd_item_node_cap, caps_idx, pp_data->caps[caps_idx].LinkCollection, rd_delimiter_usage, pp_data->caps[caps_idx].ReportID, &list_node);
 			}
 			else if (!pp_data->caps[caps_idx].IsAlias && (firstDelimiterNode != NULL)) {
-				// Alliased Collection (Last node in pp_data->caps -> First entry in report descriptor output)
+				// Aliased Collection (Last node in pp_data->caps -> First entry in report descriptor output)
 				rd_insert_main_item_node(first_bit, last_bit, rd_item_node_cap, caps_idx, pp_data->caps[caps_idx].LinkCollection, rd_delimiter_usage, pp_data->caps[caps_idx].ReportID, &list_node);
 				rd_insert_main_item_node(first_bit, last_bit, rd_item_node_cap, caps_idx, pp_data->caps[caps_idx].LinkCollection, rd_delimiter_open, pp_data->caps[caps_idx].ReportID, &list_node);
 				firstDelimiterNode = NULL;

--- a/src/hidapi/windows/hidapi_descriptor_reconstruct.c
+++ b/src/hidapi/windows/hidapi_descriptor_reconstruct.c
@@ -401,7 +401,7 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 				collection_node_idx = coll_child_order[collection_node_idx][0];
 
 				// In a HID Report Descriptor, the first usage declared is the most preferred usage for the control.
-				// While the order in the WIN32 capability strutures is the opposite:
+				// While the order in the WIN32 capability structures is the opposite:
 				// Here the preferred usage is the last aliased usage in the sequence.
 
 				if (link_collection_nodes[collection_node_idx].IsAlias && (firstDelimiterNode == NULL)) {
@@ -491,7 +491,7 @@ int hid_winapi_descriptor_reconstruct_pp_data(void *preparsed_data, unsigned cha
 			list_node = rd_search_main_item_list_for_bit_position(first_bit, (rd_main_items) rt_idx, pp_data->caps[caps_idx].ReportID, &coll_begin);
 
 			// In a HID Report Descriptor, the first usage declared is the most preferred usage for the control.
-			// While the order in the WIN32 capability strutures is the opposite:
+			// While the order in the WIN32 capability structures is the opposite:
 			// Here the preferred usage is the last aliased usage in the sequence.
 
 			if (pp_data->caps[caps_idx].IsAlias && (firstDelimiterNode == NULL)) {

--- a/src/hidapi/windows/pp_data_dump/pp_data_dump.c
+++ b/src/hidapi/windows/pp_data_dump/pp_data_dump.c
@@ -85,8 +85,8 @@ void dump_hidp_link_collection_node(FILE* file, phid_pp_link_collection_node pco
 	fprintf(file, "pp_data->LinkCollectionArray[%u]->NumberOfChildren   = %hu\n", coll_idx, pcoll->NumberOfChildren);
 	fprintf(file, "pp_data->LinkCollectionArray[%u]->NextSibling        = %hu\n", coll_idx, pcoll->NextSibling);
 	fprintf(file, "pp_data->LinkCollectionArray[%u]->FirstChild         = %hu\n", coll_idx, pcoll->FirstChild);
-	// The compilers are not consistent on ULONG-bit-fields: They lose the unsinged or define them as int.
-	// Thus just always cast them to unsinged int, which should be fine, as the biggest bit-field is 28 bit
+	// The compilers are not consistent on ULONG-bit-fields: They lose the unsigned or define them as int.
+	// Thus just always cast them to unsigned int, which should be fine, as the biggest bit-field is 28 bit
 	fprintf(file, "pp_data->LinkCollectionArray[%u]->CollectionType     = %u\n", coll_idx, (unsigned int)(pcoll->CollectionType));
 	fprintf(file, "pp_data->LinkCollectionArray[%u]->IsAlias            = %u\n", coll_idx, (unsigned int)(pcoll->IsAlias));
 	fprintf(file, "pp_data->LinkCollectionArray[%u]->Reserved           = 0x%08X\n", coll_idx, (unsigned int)(pcoll->Reserved));

--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -213,7 +213,7 @@ static Uint32 initial_blacklist_devices[] = {
     // Microsoft Nano Transceiver v2.0
     MAKE_VIDPID(0x045e, 0x0800),
 
-    MAKE_VIDPID(0x046d, 0xc30a), // Logitech, Inc. iTouch Composite keboard
+    MAKE_VIDPID(0x046d, 0xc30a), // Logitech, Inc. iTouch Composite keyboard
 
     MAKE_VIDPID(0x04d9, 0xa0df), // Tek Syndicate Mouse (E-Signal USB Gaming Mouse)
 

--- a/src/joystick/hidapi/steam/controller_structs.h
+++ b/src/joystick/hidapi/steam/controller_structs.h
@@ -112,7 +112,7 @@ typedef struct {
 	int16_t dur_ms; 			// Duration of tone / rumble (if applicable) (neg = infinite)
 
 	uint16_t noise_intensity;
-	uint16_t lfo_freq; 			// Drives both tone and rumble geneators
+	uint16_t lfo_freq; 			// Drives both tone and rumble generators
 	uint8_t lfo_depth; 			// percentage, typically 100
 	uint8_t rand_tone_gain; 	// Randomize each LFO cycle's gain
 	uint8_t script_id; 			// Used w/ dBgain for scripted haptics

--- a/src/libm/e_log.c
+++ b/src/libm/e_log.c
@@ -16,7 +16,7 @@
 #endif
 
 /* __ieee754_log(x)
- * Return the logrithm of x
+ * Return the logarithm of x
  *
  * Method :
  *   1. Argument Reduction: find k and f such that

--- a/src/libm/e_sqrt.c
+++ b/src/libm/e_sqrt.c
@@ -331,7 +331,7 @@ B.  sqrt(x) by Reciproot Iteration
 
 	Let x0 and x1 be the leading and the trailing 32-bit words of
 	a floating point number x (in IEEE double format) respectively
-	(see section A). By performing shifs and subtracts on x0 and y0,
+	(see section A). By performing shifts and subtracts on x0 and y0,
 	we obtain a 7.8-bit approximation of 1/sqrt(x) as follows.
 
 	    k := 0x5fe80000 - (x0>>1);

--- a/src/libm/e_sqrt.c
+++ b/src/libm/e_sqrt.c
@@ -281,7 +281,7 @@ A.  sqrt(x) by Newton Iteration
 	This formula has one division fewer than the one above; however,
 	it requires more multiplications and additions. Also x must be
 	scaled in advance to avoid spurious overflow in evaluating the
-	expression 3y*y+x. Hence it is not recommended uless division
+	expression 3y*y+x. Hence it is not recommended unless division
 	is slow. If division is very slow, then one should use the
 	reciproot algorithm given in section B.
 

--- a/src/libm/k_rem_pio2.c
+++ b/src/libm/k_rem_pio2.c
@@ -48,7 +48,7 @@
  *			64-bit  precision	2
  *			113-bit precision	3
  *		The actual value is the sum of them. Thus for 113-bit
- *		precison, one may have to do something like:
+ *		precision, one may have to do something like:
  *
  *		long double t,w,r_head, r_tail;
  *		t = (long double)y[2] + (long double)y[1];

--- a/src/libm/k_rem_pio2.c
+++ b/src/libm/k_rem_pio2.c
@@ -41,7 +41,7 @@
  *			z    = (z-x[i])*2**24
  *
  *
- *	y[]	ouput result in an array of double precision numbers.
+ *	y[]	output result in an array of double precision numbers.
  *		The dimension of y[] is:
  *			24-bit  precision	1
  *			53-bit  precision	2

--- a/src/misc/ios/SDL_sysurl.m
+++ b/src/misc/ios/SDL_sysurl.m
@@ -31,7 +31,7 @@ bool SDL_SYS_OpenURL(const char *url)
     @autoreleasepool {
 
 #ifdef SDL_PLATFORM_VISIONOS
-        return SDL_Unsupported();  // openURL is not suported on visionOS
+        return SDL_Unsupported();  // openURL is not supported on visionOS
 #else
         NSString *nsstr = [NSString stringWithUTF8String:url];
         NSURL *nsurl = [NSURL URLWithString:nsstr];

--- a/src/stdlib/SDL_malloc.c
+++ b/src/stdlib/SDL_malloc.c
@@ -1709,7 +1709,7 @@ static FORCEINLINE void* win32direct_mmap(size_t size) {
   return (ptr != 0)? ptr: MFAIL;
 }
 
-/* This function supports releasing coalesed segments */
+/* This function supports releasing coalesced segments */
 static FORCEINLINE int win32munmap(void* ptr, size_t size) {
   MEMORY_BASIC_INFORMATION minfo;
   char* cptr = (char*)ptr;

--- a/src/stdlib/SDL_malloc.c
+++ b/src/stdlib/SDL_malloc.c
@@ -6246,7 +6246,7 @@ History:
         Wolfram Gloger (Gloger@lrz.uni-muenchen.de).
       * Use last_remainder in more cases.
       * Pack bins using idea from  colin@nyx10.cs.du.edu
-      * Use ordered bins instead of best-fit threshhold
+      * Use ordered bins instead of best-fit threshold
       * Eliminate block-local decls to simplify tracing and debugging.
       * Support another case of realloc via move into top
       * Fix error occurring when initial sbrk_base not word-aligned.

--- a/src/stdlib/SDL_malloc.c
+++ b/src/stdlib/SDL_malloc.c
@@ -6249,7 +6249,7 @@ History:
       * Use ordered bins instead of best-fit threshhold
       * Eliminate block-local decls to simplify tracing and debugging.
       * Support another case of realloc via move into top
-      * Fix error occuring when initial sbrk_base not word-aligned.
+      * Fix error occurring when initial sbrk_base not word-aligned.
       * Rely on page size for units instead of SBRK_UNIT to
         avoid surprises about sbrk alignment conventions.
       * Add mallinfo, mallopt. Thanks to Raymond Nijssen

--- a/src/stdlib/SDL_malloc.c
+++ b/src/stdlib/SDL_malloc.c
@@ -4712,7 +4712,7 @@ void* dlmalloc(size_t bytes) {
 
 void dlfree(void* mem) {
   /*
-     Consolidate freed chunks with preceeding or succeeding bordering
+     Consolidate freed chunks with preceding or succeeding bordering
      free chunks, if they exist, and then place in a bin.  Intermixed
      with special cases for top, dv, mmapped chunks, and usage errors.
   */

--- a/src/stdlib/SDL_malloc.c
+++ b/src/stdlib/SDL_malloc.c
@@ -1797,7 +1797,7 @@ static FORCEINLINE int win32munmap(void* ptr, size_t size) {
     #define CALL_MREMAP(addr, osz, nsz, mv)     MFAIL
 #endif /* HAVE_MMAP && HAVE_MREMAP */
 
-/* mstate bit set if continguous morecore disabled or failed */
+/* mstate bit set if contiguous morecore disabled or failed */
 #define USE_NONCONTIGUOUS_BIT (4U)
 
 /* segment bit set in create_mspace_with_base */

--- a/src/stdlib/SDL_random.c
+++ b/src/stdlib/SDL_random.c
@@ -96,7 +96,7 @@ Sint32 SDL_rand_r(Uint64 *state, Sint32 n)
 
     if (n < 0) {
         // The algorithm looks like it works for numbers < 0 but it has an
-        // infintesimal chance of returning a value out of range.
+        // infinitesimal chance of returning a value out of range.
         // Returning -SDL_rand(abs(n)) blows up at INT_MIN instead.
         // It's easier to just say no.
         return 0;

--- a/src/test/SDL_test_harness.c
+++ b/src/test/SDL_test_harness.c
@@ -523,7 +523,7 @@ int SDLTest_ExecuteTestSuiteRunner(SDLTest_TestSuiteRunner *runner)
 
     /* Mix the list of suites to run them in random order */
     {
-        /* Exclude last test "subsystemsTestSuite" which is said to interfer with other tests */
+        /* Exclude last test "subsystemsTestSuite" which is said to interfere with other tests */
         nbSuites--;
 
         if (runner->user.execKey != 0) {

--- a/src/time/SDL_time.c
+++ b/src/time/SDL_time.c
@@ -195,7 +195,7 @@ SDL_bool SDL_DateTimeToTime(const SDL_DateTime *dt, SDL_Time *ticks)
 void SDL_TimeToWindows(SDL_Time ticks, Uint32 *dwLowDateTime, Uint32 *dwHighDateTime)
 {
     /* Convert nanoseconds to Win32 ticks.
-     * SDL_Time has a range of roughly 292 years, so even SDL_MIN_TIME can't underflow thw Win32 epoch.
+     * SDL_Time has a range of roughly 292 years, so even SDL_MIN_TIME can't underflow the Win32 epoch.
      */
     const Uint64 wtime = (Uint64)((ticks / 100) + DELTA_EPOCH_1601_100NS);
 

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2896,8 +2896,8 @@ SDL_bool SDL_SetWindowSize(SDL_Window *window, int w, int h)
         return SDL_InvalidParamError("h");
     }
 
-    // It is possible for the aspect ratio contraints to not satisfy the size constraints.
-    // The size constraints will override the aspect ratio contraints so we will apply the
+    // It is possible for the aspect ratio constraints to not satisfy the size constraints.
+    // The size constraints will override the aspect ratio constraints so we will apply the
     // the aspect ratio constraints first
     float new_aspect = w / (float)h;
     if (window->max_aspect > 0.0f && new_aspect > window->max_aspect) {

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -1048,7 +1048,7 @@ static void touch_handler_up(void *data, struct wl_touch *touch, uint32_t serial
             SDL_SendTouch(Wayland_GetTouchTimestamp(input, timestamp), (SDL_TouchID)(uintptr_t)touch,
                           (SDL_FingerID)(id + 1), window_data->sdlwindow, false, x, y, 0.0f);
 
-            /* If the seat lacks pointer focus, the seat's keyboard focus is another window or NULL, this window curently
+            /* If the seat lacks pointer focus, the seat's keyboard focus is another window or NULL, this window currently
              * has mouse focus, and the surface has no active touch events, consider mouse focus to be lost.
              */
             if (!input->pointer_focus && input->keyboard_focus != window_data &&

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -617,7 +617,7 @@ static void UpdateWindowFullscreen(SDL_Window *window, bool fullscreen)
             SDL_UpdateFullscreenMode(window, SDL_FULLSCREEN_OP_ENTER, false);
 
             /* Set the output for exclusive fullscreen windows when entering fullscreen from a
-             * compositor event, or if the fullscreen paramaters were changed between the initial
+             * compositor event, or if the fullscreen parameters were changed between the initial
              * fullscreen request and now, to ensure that the window is on the correct output,
              * as requested by the client.
              */

--- a/src/video/x11/edid.h
+++ b/src/video/x11/edid.h
@@ -122,7 +122,7 @@ struct MonitorInfo
 
     int width_mm;        // -1 if not specified
     int height_mm;       // -1 if not specified
-    double aspect_ratio; // -1.0 if not specififed
+    double aspect_ratio; // -1.0 if not specified
 
     double gamma; // -1.0 if not specified
 

--- a/src/video/yuv2rgb/yuv_rgb.h
+++ b/src/video/yuv2rgb/yuv_rgb.h
@@ -17,7 +17,7 @@
 // is suboptimal for image quality, but by far the fastest method.
 
 // For all methods, width and height should be even, if not, the last row/column of the result image won't be affected.
-// For sse methods, if the width if not divisable by 32, the last (width%32) pixels of each line won't be affected.
+// For sse methods, if the width if not divisible by 32, the last (width%32) pixels of each line won't be affected.
 
 /*#include <stdint.h>*/
 

--- a/src/video/yuv2rgb/yuv_rgb_sse.h
+++ b/src/video/yuv2rgb/yuv_rgb_sse.h
@@ -3,7 +3,7 @@
 #include "yuv_rgb_common.h"
 
 // yuv to rgb, sse implementation
-// pointers must be 16 byte aligned, and strides must be divisable by 16
+// pointers must be 16 byte aligned, and strides must be divisible by 16
 void yuv420_rgb565_sse(
         uint32_t width, uint32_t height,
         const uint8_t *y, const uint8_t *u, const uint8_t *v, uint32_t y_stride, uint32_t uv_stride,

--- a/src/video/yuv2rgb/yuv_rgb_std.h
+++ b/src/video/yuv2rgb/yuv_rgb_std.h
@@ -14,7 +14,7 @@
 // is suboptimal for image quality, but by far the fastest method.
 
 // For all methods, width and height should be even, if not, the last row/column of the result image won't be affected.
-// For sse methods, if the width if not divisable by 32, the last (width%32) pixels of each line won't be affected.
+// For sse methods, if the width if not divisible by 32, the last (width%32) pixels of each line won't be affected.
 
 /*#include <stdint.h>*/
 

--- a/test/testaudio.c
+++ b/test/testaudio.c
@@ -454,11 +454,11 @@ static void PoofThing_ondrag(Thing *thing, int button, float x, float y)
 static void PoofThing_ontick(Thing *thing, Uint64 now)
 {
     const int lifetime = POOF_LIFETIME;
-    const int elasped = (int) (now - thing->createticks);
-    if (elasped > lifetime) {
+    const int elapsed = (int) (now - thing->createticks);
+    if (elapsed > lifetime) {
         DestroyThing(thing);
     } else {
-        const float pct = ((float) elasped) / ((float) lifetime);
+        const float pct = ((float) elapsed) / ((float) lifetime);
         thing->a = (Uint8) (int) (255.0f - (pct * 255.0f));
         thing->scale = 1.0f - pct;  /* shrink to nothing! */
     }
@@ -962,13 +962,13 @@ static void PhysicalDeviceThing_ondrop(Thing *thing, int button, float x, float 
 static void PhysicalDeviceThing_ontick(Thing *thing, Uint64 now)
 {
     const int lifetime = POOF_LIFETIME;
-    const int elasped = (int) (now - thing->createticks);
-    if (elasped > lifetime) {
+    const int elapsed = (int) (now - thing->createticks);
+    if (elapsed > lifetime) {
         thing->scale = 1.0f;
         thing->a = 255;
         thing->ontick = NULL;  /* no more ticking. */
     } else {
-        const float pct = ((float) elasped) / ((float) lifetime);
+        const float pct = ((float) elapsed) / ((float) lifetime);
         thing->a = (Uint8) (int) (pct * 255.0f);
         thing->scale = pct;  /* grow to normal size */
     }


### PR DESCRIPTION
Fix typos in comments and in one case in a returned error ("insuffient -> insufficient" https://github.com/libsdl-org/SDL/commit/fb273eb72ab596d3c354915039e22b832f294e6f)
`codespell src/ *.cpp *.h *.hpp --ignore-words-list unknwn,thid,algebric,statics,pixelX,pEvents,caf,ptd,parms,pEvent,parm,TextureRS,TE,HDA,LOD,datas,UE,xwindows,IIF`
