### PR TITLE
tests: Fix tests when run with the --high-pixel-density flag

### DIFF
--- a/test/testaudio.c
+++ b/test/testaudio.c
@@ -1119,6 +1119,7 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
     Thing *thing = NULL;
 
     saw_event = true;
+    SDL_ConvertEventToRenderCoordinates(SDL_GetRenderer(SDL_GetWindowFromEvent(event)), event);
 
     switch (event->type) {
         case SDL_EVENT_MOUSE_MOTION:

--- a/test/testaudiostreamdynamicresample.c
+++ b/test/testaudiostreamdynamicresample.c
@@ -184,6 +184,20 @@ static const char *AudioChansToStr(const int channels)
     return "?";
 }
 
+static void scale_mouse_coords(SDL_FPoint *p)
+{
+    SDL_Window *window = SDL_GetMouseFocus();
+    if (window) {
+        int w, p_w;
+        float scale;
+        SDL_GetWindowSize(window, &w, NULL);
+        SDL_GetWindowSizeInPixels(window, &p_w, NULL);
+        scale = (float)p_w / (float)w;
+        p->x *= scale;
+        p->y *= scale;
+    }
+}
+
 static void loop(void)
 {
     int i, j;
@@ -228,6 +242,7 @@ static void loop(void)
     }
 
     if (SDL_GetMouseState(&p.x, &p.y) & SDL_BUTTON_LMASK) {
+        scale_mouse_coords(&p);
         if (active_slider == -1) {
             for (i = 0; i < NUM_SLIDERS; ++i) {
                 if (SDL_PointInRectFloat(&p, &sliders[i].area)) {

--- a/test/testhittesting.c
+++ b/test/testhittesting.c
@@ -33,16 +33,24 @@ static SDL_HitTestResult SDLCALL
 hitTest(SDL_Window *window, const SDL_Point *pt, void *data)
 {
     int i;
-    int w, h;
+    int w, h, p_w;
+    SDL_Point adj_pt;
+    float scale;
+
+    SDL_GetWindowSize(window, &w, &h);
+    SDL_GetWindowSizeInPixels(window, &p_w, NULL);
+
+    scale = (float)p_w / (float)w;
+
+    adj_pt.x = (int)SDL_floorf(pt->x * scale);
+    adj_pt.y = (int)SDL_floorf(pt->y * scale);
 
     for (i = 0; i < numareas; i++) {
-        if (SDL_PointInRect(pt, &areas[i])) {
+        if (SDL_PointInRect(&adj_pt, &areas[i])) {
             SDL_Log("HIT-TEST: DRAGGABLE\n");
             return SDL_HITTEST_DRAGGABLE;
         }
     }
-
-    SDL_GetWindowSize(window, &w, &h);
 
 #define REPORT_RESIZE_HIT(name)                  \
     {                                            \

--- a/test/testintersections.c
+++ b/test/testintersections.c
@@ -211,6 +211,7 @@ static void loop(void *arg)
     /* Check for events */
     while (SDL_PollEvent(&event)) {
         SDLTest_CommonEvent(state, &event, done);
+        SDL_ConvertEventToRenderCoordinates(SDL_GetRenderer(SDL_GetWindowFromEvent(&event)), &event);
         switch (event.type) {
         case SDL_EVENT_MOUSE_BUTTON_DOWN:
             mouse_begin_x = event.button.x;

--- a/test/testmanymouse.c
+++ b/test/testmanymouse.c
@@ -184,7 +184,7 @@ static void HandleMouseAdded(SDL_MouseID instance_id)
     SDL_Window *window = state->windows[0];
     int i, w = 0, h = 0;
 
-    SDL_GetWindowSize(window, &w, &h);
+    SDL_GetWindowSizeInPixels(window, &w, &h);
 
     for (i = 0; i < SDL_arraysize(mice); ++i) {
         MouseState *mouse_state = &mice[i];
@@ -237,7 +237,7 @@ static void HandleMouseMotion(SDL_MouseMotionEvent *event)
 
     ActivateMouse(event->which);
 
-    SDL_GetWindowSize(window, &w, &h);
+    SDL_GetWindowSizeInPixels(window, &w, &h);
 
     for (i = 0; i < SDL_arraysize(mice); ++i) {
         MouseState *mouse_state = &mice[i];

--- a/test/testoverlay.c
+++ b/test/testoverlay.c
@@ -255,6 +255,7 @@ static void loop(void)
     /* Check for events */
     while (SDL_PollEvent(&event)) {
         SDLTest_CommonEvent(state, &event, &done);
+        SDL_ConvertEventToRenderCoordinates(SDL_GetRenderer(SDL_GetWindowFromEvent(&event)), &event);
 
         switch (event.type) {
         case SDL_EVENT_WINDOW_RESIZED:

--- a/test/testwm.c
+++ b/test/testwm.c
@@ -165,6 +165,7 @@ static void loop(void)
 
     while (SDL_PollEvent(&event)) {
         SDLTest_CommonEvent(state, &event, &done);
+        SDL_ConvertEventToRenderCoordinates(SDL_GetRenderer(SDL_GetWindowFromEvent(&event)), &event);
 
         if (event.type == SDL_EVENT_WINDOW_RESIZED) {
             SDL_Window *window = SDL_GetWindowFromEvent(&event);


### PR DESCRIPTION
Scales pointer coordinates where needed to fix the following tests when run with the --high-pixel-density flag:

- testaudio
- testaudiostreamdynamicresample
- testhittesting
- testintersections
- testmanymouse
- testoverlay
- testwm

Addresses problematic tests as noted in #10875 
