### PR TITLE
Prefer Vulkan even on Windows

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -155,11 +155,11 @@ static const SDL_GPUBootstrap *backends[] = {
 #ifdef SDL_GPU_METAL
     &MetalDriver,
 #endif
-#ifdef SDL_GPU_D3D12
-    &D3D12Driver,
-#endif
 #ifdef SDL_GPU_VULKAN
     &VulkanDriver,
+#endif
+#ifdef SDL_GPU_D3D12
+    &D3D12Driver,
 #endif
 #ifdef SDL_GPU_D3D11
     &D3D11Driver,


### PR DESCRIPTION
Especially as of #10910 the Vulkan backend is profoundly more optimal than D3D12 in both performance and memory usage. Seeing as we'll need to do significant rewrites to optimize D3D12 memory management and descriptor usage, we should just bump Vulkan to the top of the preference list to put our best foot forward. We can always revisit this once optimizations are completed.