### PR TITLE
gpu: Use versioning instead of properties for struct extensions

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -1140,10 +1140,13 @@ typedef struct SDL_GPUIndirectDispatchCommand
  *
  * \since This function is available since SDL 3.0.0
  *
+ * \sa SDL_INIT_INTERFACE
  * \sa SDL_CreateGPUSampler
  */
 typedef struct SDL_GPUSamplerCreateInfo
 {
+    Uint32 version;                            /**< The version of this interface */
+
     SDL_GPUFilter min_filter;                  /**< The minification filter to apply to lookups. */
     SDL_GPUFilter mag_filter;                  /**< The magnification filter to apply to lookups. */
     SDL_GPUSamplerMipmapMode mipmap_mode;      /**< The mipmap filter to apply to lookups. */
@@ -1157,10 +1160,6 @@ typedef struct SDL_GPUSamplerCreateInfo
     float max_lod;                             /**< Clamps the maximum of the computed LOD value. */
     bool enable_anisotropy;                /**< true to enable anisotropic filtering. */
     bool enable_compare;                   /**< true to enable comparison against a reference value during lookups. */
-    Uint8 padding1;
-    Uint8 padding2;
-
-    SDL_PropertiesID props;                    /**< A properties ID for extensions. Should be 0 if no extensions are needed. */
 } SDL_GPUSamplerCreateInfo;
 
 /**
@@ -1267,10 +1266,13 @@ typedef struct SDL_GPUColorTargetBlendState
  *
  * \since This struct is available since SDL 3.0.0
  *
+ * \sa SDL_INIT_INTERFACE
  * \sa SDL_CreateGPUShader
  */
 typedef struct SDL_GPUShaderCreateInfo
 {
+    Uint32 version;               /**< The version of this interface */
+
     size_t code_size;             /**< The size in bytes of the code pointed to. */
     const Uint8 *code;            /**< A pointer to shader code. */
     const char *entrypoint;       /**< A pointer to a null-terminated UTF-8 string specifying the entry point function name for the shader. */
@@ -1280,8 +1282,6 @@ typedef struct SDL_GPUShaderCreateInfo
     Uint32 num_storage_textures;  /**< The number of storage textures defined in the shader. */
     Uint32 num_storage_buffers;   /**< The number of storage buffers defined in the shader. */
     Uint32 num_uniform_buffers;   /**< The number of uniform buffers defined in the shader. */
-
-    SDL_PropertiesID props;       /**< A properties ID for extensions. Should be 0 if no extensions are needed. */
 } SDL_GPUShaderCreateInfo;
 
 /**
@@ -1293,10 +1293,13 @@ typedef struct SDL_GPUShaderCreateInfo
  *
  * \since This struct is available since SDL 3.0.0
  *
+ * \sa SDL_INIT_INTERFACE
  * \sa SDL_CreateGPUTexture
  */
 typedef struct SDL_GPUTextureCreateInfo
 {
+    Uint32 version;                   /**< The version of this interface */
+
     SDL_GPUTextureType type;          /**< The base dimensionality of the texture. */
     SDL_GPUTextureFormat format;      /**< The pixel format of the texture. */
     SDL_GPUTextureUsageFlags usage;   /**< How the texture is intended to be used by the client. */
@@ -1305,8 +1308,6 @@ typedef struct SDL_GPUTextureCreateInfo
     Uint32 layer_count_or_depth;      /**< The layer count or depth of the texture. This value is treated as a layer count on 2D array textures, and as a depth value on 3D textures. */
     Uint32 num_levels;                /**< The number of mip levels in the texture. */
     SDL_GPUSampleCount sample_count;  /**< The number of samples per texel. Only applies if the texture is used as a render target. */
-
-    SDL_PropertiesID props;           /**< A properties ID for extensions. Should be 0 if no extensions are needed. */
 } SDL_GPUTextureCreateInfo;
 
 #define SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_R_FLOAT       "SDL.gpu.createtexture.d3d12.clear.r"
@@ -1324,14 +1325,15 @@ typedef struct SDL_GPUTextureCreateInfo
  *
  * \since This struct is available since SDL 3.0.0
  *
+ * \sa SDL_INIT_INTERFACE
  * \sa SDL_CreateGPUBuffer
  */
 typedef struct SDL_GPUBufferCreateInfo
 {
+    Uint32 version;                 /**< The version of this interface */
+
     SDL_GPUBufferUsageFlags usage;  /**< How the buffer is intended to be used by the client. */
     Uint32 size;                    /**< The size in bytes of the buffer. */
-
-    SDL_PropertiesID props;         /**< A properties ID for extensions. Should be 0 if no extensions are needed. */
 } SDL_GPUBufferCreateInfo;
 
 /**
@@ -1339,14 +1341,15 @@ typedef struct SDL_GPUBufferCreateInfo
  *
  * \since This struct is available since SDL 3.0.0
  *
+ * \sa SDL_INIT_INTERFACE
  * \sa SDL_CreateGPUTransferBuffer
  */
 typedef struct SDL_GPUTransferBufferCreateInfo
 {
+    Uint32 version;                    /**< The version of this interface */
+
     SDL_GPUTransferBufferUsage usage;  /**< How the transfer buffer is intended to be used by the client. */
     Uint32 size;                       /**< The size in bytes of the transfer buffer. */
-
-    SDL_PropertiesID props;            /**< A properties ID for extensions. Should be 0 if no extensions are needed. */
 } SDL_GPUTransferBufferCreateInfo;
 
 /* Pipeline state structures */
@@ -1452,10 +1455,13 @@ typedef struct SDL_GPUGraphicsPipelineTargetInfo
  *
  * \since This struct is available since SDL 3.0.0
  *
+ * \sa SDL_INIT_INTERFACE
  * \sa SDL_CreateGPUGraphicsPipeline
  */
 typedef struct SDL_GPUGraphicsPipelineCreateInfo
 {
+    Uint32 version;                                 /**< The version of this interface */
+
     SDL_GPUShader *vertex_shader;                   /**< The vertex shader used by the graphics pipeline. */
     SDL_GPUShader *fragment_shader;                 /**< The fragment shader used by the graphics pipeline. */
     SDL_GPUVertexInputState vertex_input_state;     /**< The vertex layout of the graphics pipeline. */
@@ -1464,8 +1470,6 @@ typedef struct SDL_GPUGraphicsPipelineCreateInfo
     SDL_GPUMultisampleState multisample_state;      /**< The multisample state of the graphics pipeline. */
     SDL_GPUDepthStencilState depth_stencil_state;   /**< The depth-stencil state of the graphics pipeline. */
     SDL_GPUGraphicsPipelineTargetInfo target_info;  /**< Formats and blend modes for the render targets of the graphics pipeline. */
-
-    SDL_PropertiesID props;                         /**< A properties ID for extensions. Should be 0 if no extensions are needed. */
 } SDL_GPUGraphicsPipelineCreateInfo;
 
 /**
@@ -1473,10 +1477,13 @@ typedef struct SDL_GPUGraphicsPipelineCreateInfo
  *
  * \since This struct is available since SDL 3.0.0
  *
+ * \sa SDL_INIT_INTERFACE
  * \sa SDL_CreateGPUComputePipeline
  */
 typedef struct SDL_GPUComputePipelineCreateInfo
 {
+    Uint32 version;                         /**< The version of this interface */
+
     size_t code_size;                       /**< The size in bytes of the compute shader code pointed to. */
     const Uint8 *code;                      /**< A pointer to compute shader code. */
     const char *entrypoint;                 /**< A pointer to a null-terminated UTF-8 string specifying the entry point function name for the shader. */
@@ -1490,8 +1497,6 @@ typedef struct SDL_GPUComputePipelineCreateInfo
     Uint32 threadcount_x;                   /**< The number of threads in the X dimension. This should match the value in the shader. */
     Uint32 threadcount_y;                   /**< The number of threads in the Y dimension. This should match the value in the shader. */
     Uint32 threadcount_z;                   /**< The number of threads in the Z dimension. This should match the value in the shader. */
-
-    SDL_PropertiesID props;                 /**< A properties ID for extensions. Should be 0 if no extensions are needed. */
 } SDL_GPUComputePipelineCreateInfo;
 
 /**

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -688,6 +688,11 @@ SDL_GPUComputePipeline *SDL_CreateGPUComputePipeline(
         SDL_InvalidParamError("createinfo");
         return NULL;
     }
+    if (createinfo->version < sizeof(*createinfo)) {
+        // Update this to handle older versions of this interface
+        SDL_SetError("Invalid createinfo, should be initialized with SDL_INIT_INTERFACE()");
+        return NULL;
+    }
 
     if (device->debug_mode) {
         if (createinfo->format == SDL_GPU_SHADERFORMAT_INVALID) {
@@ -726,6 +731,11 @@ SDL_GPUGraphicsPipeline *SDL_CreateGPUGraphicsPipeline(
     CHECK_DEVICE_MAGIC(device, NULL);
     if (graphicsPipelineCreateInfo == NULL) {
         SDL_InvalidParamError("graphicsPipelineCreateInfo");
+        return NULL;
+    }
+    if (graphicsPipelineCreateInfo->version < sizeof(*graphicsPipelineCreateInfo)) {
+        // Update this to handle older versions of this interface
+        SDL_SetError("Invalid createinfo, should be initialized with SDL_INIT_INTERFACE()");
         return NULL;
     }
 
@@ -810,6 +820,11 @@ SDL_GPUSampler *SDL_CreateGPUSampler(
         SDL_InvalidParamError("createinfo");
         return NULL;
     }
+    if (createinfo->version < sizeof(*createinfo)) {
+        // Update this to handle older versions of this interface
+        SDL_SetError("Invalid createinfo, should be initialized with SDL_INIT_INTERFACE()");
+        return NULL;
+    }
 
     return device->CreateSampler(
         device->driverData,
@@ -823,6 +838,11 @@ SDL_GPUShader *SDL_CreateGPUShader(
     CHECK_DEVICE_MAGIC(device, NULL);
     if (createinfo == NULL) {
         SDL_InvalidParamError("createinfo");
+        return NULL;
+    }
+    if (createinfo->version < sizeof(*createinfo)) {
+        // Update this to handle older versions of this interface
+        SDL_SetError("Invalid createinfo, should be initialized with SDL_INIT_INTERFACE()");
         return NULL;
     }
 
@@ -989,6 +1009,11 @@ SDL_GPUBuffer *SDL_CreateGPUBuffer(
         SDL_InvalidParamError("createinfo");
         return NULL;
     }
+    if (createinfo->version < sizeof(*createinfo)) {
+        // Update this to handle older versions of this interface
+        SDL_SetError("Invalid createinfo, should be initialized with SDL_INIT_INTERFACE()");
+        return NULL;
+    }
 
     return device->CreateBuffer(
         device->driverData,
@@ -1003,6 +1028,11 @@ SDL_GPUTransferBuffer *SDL_CreateGPUTransferBuffer(
     CHECK_DEVICE_MAGIC(device, NULL);
     if (createinfo == NULL) {
         SDL_InvalidParamError("createinfo");
+        return NULL;
+    }
+    if (createinfo->version < sizeof(*createinfo)) {
+        // Update this to handle older versions of this interface
+        SDL_SetError("Invalid createinfo, should be initialized with SDL_INIT_INTERFACE()");
         return NULL;
     }
 

--- a/test/testgpu_spinning_cube.c
+++ b/test/testgpu_spinning_cube.c
@@ -253,6 +253,7 @@ CreateDepthTexture(Uint32 drawablew, Uint32 drawableh)
     SDL_GPUTextureCreateInfo createinfo;
     SDL_GPUTexture *result;
 
+    SDL_INIT_INTERFACE(&createinfo);
     createinfo.type = SDL_GPU_TEXTURETYPE_2D;
     createinfo.format = SDL_GPU_TEXTUREFORMAT_D16_UNORM;
     createinfo.width = drawablew;
@@ -261,7 +262,6 @@ CreateDepthTexture(Uint32 drawablew, Uint32 drawableh)
     createinfo.num_levels = 1;
     createinfo.sample_count = render_state.sample_count;
     createinfo.usage = SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET;
-    createinfo.props = 0;
 
     result = SDL_CreateGPUTexture(gpu_device, &createinfo);
     CHECK_CREATE(result, "Depth Texture")
@@ -279,6 +279,7 @@ CreateMSAATexture(Uint32 drawablew, Uint32 drawableh)
         return NULL;
     }
 
+    SDL_INIT_INTERFACE(&createinfo);
     createinfo.type = SDL_GPU_TEXTURETYPE_2D;
     createinfo.format = SDL_GetGPUSwapchainTextureFormat(gpu_device, state->windows[0]);
     createinfo.width = drawablew;
@@ -287,7 +288,6 @@ CreateMSAATexture(Uint32 drawablew, Uint32 drawableh)
     createinfo.num_levels = 1;
     createinfo.sample_count = render_state.sample_count;
     createinfo.usage = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET;
-    createinfo.props = 0;
 
     result = SDL_CreateGPUTexture(gpu_device, &createinfo);
     CHECK_CREATE(result, "MSAA Texture")
@@ -305,6 +305,7 @@ CreateResolveTexture(Uint32 drawablew, Uint32 drawableh)
         return NULL;
     }
 
+    SDL_INIT_INTERFACE(&createinfo);
     createinfo.type = SDL_GPU_TEXTURETYPE_2D;
     createinfo.format = SDL_GetGPUSwapchainTextureFormat(gpu_device, state->windows[0]);
     createinfo.width = drawablew;
@@ -313,7 +314,6 @@ CreateResolveTexture(Uint32 drawablew, Uint32 drawableh)
     createinfo.num_levels = 1;
     createinfo.sample_count = SDL_GPU_SAMPLECOUNT_1;
     createinfo.usage = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER;
-    createinfo.props = 0;
 
     result = SDL_CreateGPUTexture(gpu_device, &createinfo);
     CHECK_CREATE(result, "Resolve Texture")
@@ -457,11 +457,11 @@ static SDL_GPUShader*
 load_shader(bool is_vertex)
 {
     SDL_GPUShaderCreateInfo createinfo;
+    SDL_INIT_INTERFACE(&createinfo);
     createinfo.num_samplers = 0;
     createinfo.num_storage_buffers = 0;
     createinfo.num_storage_textures = 0;
     createinfo.num_uniform_buffers = is_vertex ? 1 : 0;
-    createinfo.props = 0;
 
     SDL_GPUShaderFormat format = SDL_GetGPUShaderFormats(gpu_device);
     if (format & SDL_GPU_SHADERFORMAT_DXBC) {
@@ -535,9 +535,9 @@ init_render_state(int msaa)
 
     /* Create buffers */
 
+    SDL_INIT_INTERFACE(&buffer_desc);
     buffer_desc.usage = SDL_GPU_BUFFERUSAGE_VERTEX;
     buffer_desc.size = sizeof(vertex_data);
-    buffer_desc.props = 0;
     render_state.buf_vertex = SDL_CreateGPUBuffer(
         gpu_device,
         &buffer_desc
@@ -546,9 +546,9 @@ init_render_state(int msaa)
 
     SDL_SetGPUBufferName(gpu_device, render_state.buf_vertex, "космонавт");
 
+    SDL_INIT_INTERFACE(&transfer_buffer_desc);
     transfer_buffer_desc.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
     transfer_buffer_desc.size = sizeof(vertex_data);
-    transfer_buffer_desc.props = 0;
     buf_transfer = SDL_CreateGPUTransferBuffer(
         gpu_device,
         &transfer_buffer_desc
@@ -584,7 +584,7 @@ init_render_state(int msaa)
 
     /* Set up the graphics pipeline */
 
-    SDL_zero(pipelinedesc);
+    SDL_INIT_INTERFACE(&pipelinedesc);
     SDL_zero(color_target_desc);
 
     color_target_desc.format = SDL_GetGPUSwapchainTextureFormat(gpu_device, state->windows[0]);
@@ -624,8 +624,6 @@ init_render_state(int msaa)
     pipelinedesc.vertex_input_state.vertex_buffer_descriptions = &vertex_buffer_desc;
     pipelinedesc.vertex_input_state.num_vertex_attributes = 2;
     pipelinedesc.vertex_input_state.vertex_attributes = (SDL_GPUVertexAttribute*) &vertex_attributes;
-
-    pipelinedesc.props = 0;
 
     render_state.pipeline = SDL_CreateGPUGraphicsPipeline(gpu_device, &pipelinedesc);
     CHECK_CREATE(render_state.pipeline, "Render Pipeline")


### PR DESCRIPTION
Moves from SDL_PropertiesID to SDL_INTERFACE_INIT. One notable detail is that SDL typically uses this for _interfaces_ whereas GPU only needs extendability for create info, so this may not be _entirely_ what we want...? It's very uninvasive either way but after actually writing it I wasn't sure if we were misusing this feature.

Marked as draft because I haven't done the struct size checks.

Fixes #10829 if this is the way we want to go!