### PR TITLE
GPU: MSAA fixes

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -959,6 +959,10 @@ SDL_GPUTexture *SDL_CreateGPUTexture(
                     SDL_assert_release(!"For array textures: usage must not contain DEPTH_STENCIL_TARGET");
                     failed = true;
                 }
+                if (createinfo->sample_count > SDL_GPU_SAMPLECOUNT_1) {
+                    SDL_assert_release(!"For array textures: sample_count must be SDL_GPU_SAMPLECOUNT_1");
+                    failed = true;
+                }
             }
             if (createinfo->sample_count > SDL_GPU_SAMPLECOUNT_1 && createinfo->num_levels > 1) {
                 SDL_assert_release(!"For 2D multisample textures: num_levels must be 1");
@@ -1377,6 +1381,9 @@ SDL_GPURenderPass *SDL_BeginGPURenderPass(
                     }
                     if (resolveTextureHeader->info.type == SDL_GPU_TEXTURETYPE_3D) {
                         SDL_assert_release(!"Resolve texture must not be of TEXTURETYPE_3D!");
+                    }
+                    if (!(resolveTextureHeader->info.usage & SDL_GPU_TEXTUREUSAGE_COLOR_TARGET)) {
+                        SDL_assert_release(!"Resolve texture usage must include COLOR_TARGET!");
                     }
                 }
             }

--- a/src/gpu/d3d11/SDL_gpu_d3d11.c
+++ b/src/gpu/d3d11/SDL_gpu_d3d11.c
@@ -2081,29 +2081,21 @@ static D3D11Texture *D3D11_INTERNAL_CreateTexture(
                     D3D11_RENDER_TARGET_VIEW_DESC rtvDesc;
                     rtvDesc.Format = SDLToD3D11_TextureFormat[createInfo->format];
 
-                    if (isMultisample) {
-                        if (createInfo->type == SDL_GPU_TEXTURETYPE_2D) {
-                            rtvDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DMS;
-                        } else if (createInfo->type == SDL_GPU_TEXTURETYPE_2D_ARRAY) {
-                            rtvDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DMSARRAY;
-                            rtvDesc.Texture2DMSArray.FirstArraySlice = layerIndex;
-                            rtvDesc.Texture2DMSArray.ArraySize = 1;
-                        }
+                    if (createInfo->type == SDL_GPU_TEXTURETYPE_2D_ARRAY || createInfo->type == SDL_GPU_TEXTURETYPE_CUBE || createInfo->type == SDL_GPU_TEXTURETYPE_CUBE_ARRAY) {
+                        rtvDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
+                        rtvDesc.Texture2DArray.MipSlice = levelIndex;
+                        rtvDesc.Texture2DArray.FirstArraySlice = layerIndex;
+                        rtvDesc.Texture2DArray.ArraySize = 1;
+                    } else if (createInfo->type == SDL_GPU_TEXTURETYPE_3D) {
+                        rtvDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE3D;
+                        rtvDesc.Texture3D.MipSlice = levelIndex;
+                        rtvDesc.Texture3D.FirstWSlice = depthIndex;
+                        rtvDesc.Texture3D.WSize = 1;
+                    } else if (isMultisample) {
+                        rtvDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DMS;
                     } else {
-                        if (createInfo->type == SDL_GPU_TEXTURETYPE_2D_ARRAY || createInfo->type == SDL_GPU_TEXTURETYPE_CUBE || createInfo->type == SDL_GPU_TEXTURETYPE_CUBE_ARRAY) {
-                            rtvDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
-                            rtvDesc.Texture2DArray.MipSlice = levelIndex;
-                            rtvDesc.Texture2DArray.FirstArraySlice = layerIndex;
-                            rtvDesc.Texture2DArray.ArraySize = 1;
-                        } else if (createInfo->type == SDL_GPU_TEXTURETYPE_3D) {
-                            rtvDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE3D;
-                            rtvDesc.Texture3D.MipSlice = levelIndex;
-                            rtvDesc.Texture3D.FirstWSlice = depthIndex;
-                            rtvDesc.Texture3D.WSize = 1;
-                        } else {
-                            rtvDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
-                            rtvDesc.Texture2D.MipSlice = levelIndex;
-                        }
+                        rtvDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
+                        rtvDesc.Texture2D.MipSlice = levelIndex;
                     }
 
                     res = ID3D11Device_CreateRenderTargetView(

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -2957,31 +2957,23 @@ static D3D12Texture *D3D12_INTERNAL_CreateTexture(
 
                     rtvDesc.Format = SDLToD3D12_TextureFormat[createinfo->format];
 
-                    if (isMultisample) {
-                        if (createinfo->type == SDL_GPU_TEXTURETYPE_2D) {
-                            rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2DMS;
-                        } else if (createinfo->type == SDL_GPU_TEXTURETYPE_2D_ARRAY) {
-                            rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2DMSARRAY;
-                            rtvDesc.Texture2DMSArray.FirstArraySlice = layerIndex;
-                            rtvDesc.Texture2DMSArray.ArraySize = 1;
-                        }
+                    if (createinfo->type == SDL_GPU_TEXTURETYPE_2D_ARRAY || createinfo->type == SDL_GPU_TEXTURETYPE_CUBE || createinfo->type == SDL_GPU_TEXTURETYPE_CUBE_ARRAY) {
+                        rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2DARRAY;
+                        rtvDesc.Texture2DArray.MipSlice = levelIndex;
+                        rtvDesc.Texture2DArray.FirstArraySlice = layerIndex;
+                        rtvDesc.Texture2DArray.ArraySize = 1;
+                        rtvDesc.Texture2DArray.PlaneSlice = 0;
+                    } else if (createinfo->type == SDL_GPU_TEXTURETYPE_3D) {
+                        rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE3D;
+                        rtvDesc.Texture3D.MipSlice = levelIndex;
+                        rtvDesc.Texture3D.FirstWSlice = depthIndex;
+                        rtvDesc.Texture3D.WSize = 1;
+                    } else if (isMultisample) {
+                        rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2DMS;
                     } else {
-                        if (createinfo->type == SDL_GPU_TEXTURETYPE_2D_ARRAY || createinfo->type == SDL_GPU_TEXTURETYPE_CUBE || createinfo->type == SDL_GPU_TEXTURETYPE_CUBE_ARRAY) {
-                            rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2DARRAY;
-                            rtvDesc.Texture2DArray.MipSlice = levelIndex;
-                            rtvDesc.Texture2DArray.FirstArraySlice = layerIndex;
-                            rtvDesc.Texture2DArray.ArraySize = 1;
-                            rtvDesc.Texture2DArray.PlaneSlice = 0;
-                        } else if (createinfo->type == SDL_GPU_TEXTURETYPE_3D) {
-                            rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE3D;
-                            rtvDesc.Texture3D.MipSlice = levelIndex;
-                            rtvDesc.Texture3D.FirstWSlice = depthIndex;
-                            rtvDesc.Texture3D.WSize = 1;
-                        } else {
-                            rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
-                            rtvDesc.Texture2D.MipSlice = levelIndex;
-                            rtvDesc.Texture2D.PlaneSlice = 0;
-                        }
+                        rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
+                        rtvDesc.Texture2D.MipSlice = levelIndex;
+                        rtvDesc.Texture2D.PlaneSlice = 0;
                     }
 
                     ID3D12Device_CreateRenderTargetView(


### PR DESCRIPTION
This PR contains a few fixes for multisampling in the GPU API:
* Removes support for multisample 2D array textures; they're not supported on Metal until very recent iOS/tvOS versions, and they don't seem particularly useful in general.
* Adds a missing validation check to ensure MSAA resolve textures were created with the COLOR_TARGET usage flag.
* Fixes Metal multisample textures using the incorrect MTLTextureType. Resolves https://github.com/libsdl-org/SDL/issues/10891)
