### PR TITLE
wayland: implement the pointer warp protocol

### DIFF
--- a/src/video/wayland/SDL_waylandmouse.c
+++ b/src/video/wayland/SDL_waylandmouse.c
@@ -38,6 +38,7 @@
 #include "cursor-shape-v1-client-protocol.h"
 #include "pointer-constraints-unstable-v1-client-protocol.h"
 #include "viewporter-client-protocol.h"
+#include "pointer-warp-v1-client-protocol.h"
 
 #include "../../SDL_hints_c.h"
 
@@ -775,7 +776,12 @@ static bool Wayland_WarpMouse(SDL_Window *window, float x, float y)
     SDL_WindowData *wind = window->internal;
     struct SDL_WaylandInput *input = d->input;
 
-    if (d->pointer_constraints) {
+    if (d->pointer_warp) {
+        // it's a protocol error to warp the pointer outside of the surface, so clamp the position
+        const wl_fixed_t f_x = wl_fixed_from_double(SDL_clamp(x / wind->pointer_scale.x, 0, window->w));
+        const wl_fixed_t f_y = wl_fixed_from_double(SDL_clamp(y / wind->pointer_scale.y, 0, window->h));
+        wp_pointer_warp_v1_warp_pointer(d->pointer_warp, wind->surface, input->pointer, f_x, f_y, input->pointer_enter_serial);
+    } else if (d->pointer_constraints) {
         const bool toggle_lock = !wind->locked_pointer;
 
         /* The pointer confinement protocol allows setting a hint to warp the pointer,

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -64,6 +64,7 @@
 #include "xdg-output-unstable-v1-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
 #include "xdg-toplevel-icon-v1-client-protocol.h"
+#include "pointer-warp-v1-client-protocol.h"
 
 #ifdef HAVE_LIBDECOR_H
 #include <libdecor.h>
@@ -1201,6 +1202,8 @@ static void display_handle_global(void *data, struct wl_registry *registry, uint
         kde_output_order_v1_add_listener(d->kde_output_order, &kde_output_order_listener, d);
     } else if (SDL_strcmp(interface, "frog_color_management_factory_v1") == 0) {
         d->frog_color_management_factory_v1 = wl_registry_bind(d->registry, id, &frog_color_management_factory_v1_interface, 1);
+    } else if (SDL_strcmp(interface, "wp_pointer_warp_v1") == 0) {
+        d->pointer_warp = wl_registry_bind(d->registry, id, &wp_pointer_warp_v1_interface, 1);
     }
 }
 
@@ -1479,6 +1482,11 @@ static void Wayland_VideoCleanup(SDL_VideoDevice *_this)
     if (data->frog_color_management_factory_v1) {
         frog_color_management_factory_v1_destroy(data->frog_color_management_factory_v1);
         data->frog_color_management_factory_v1 = NULL;
+    }
+
+    if (data->pointer_warp) {
+        wp_pointer_warp_v1_destroy(data->pointer_warp);
+        data->pointer_warp = NULL;
     }
 
     if (data->compositor) {

--- a/src/video/wayland/SDL_waylandvideo.h
+++ b/src/video/wayland/SDL_waylandvideo.h
@@ -66,6 +66,7 @@ struct SDL_VideoData
     } shell;
     struct zwp_relative_pointer_manager_v1 *relative_pointer_manager;
     struct zwp_pointer_constraints_v1 *pointer_constraints;
+    struct wp_pointer_warp_v1 *pointer_warp;
     struct wp_cursor_shape_manager_v1 *cursor_shape_manager;
     struct wl_data_device_manager *data_device_manager;
     struct zwp_primary_selection_device_manager_v1 *primary_selection_device_manager;

--- a/wayland-protocols/pointer-warp-v1.xml
+++ b/wayland-protocols/pointer-warp-v1.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="pointer_warp_v1">
+  <copyright>
+    Copyright 2024 Neal Gompa
+    Copyright 2024 Xaver Hugl
+    Copyright 2024 Matthias Klumpp
+    Copyright 2024 Vlad Zahorodnii
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="wp_pointer_warp_v1" version="1">
+    <description summary="warp the pointer to a location on a surface">
+      This global interface allows applications to request the pointer to be
+      moved to a position relative to a wl_surface.
+
+      Warning! The protocol described in this file is currently in the testing
+      phase. Backward compatible changes may be added together with the
+      corresponding interface version bump. Backward incompatible changes can
+      only be done by creating a new major version of the extension.
+    </description>
+
+    <enum name="error">
+      <entry name="out_of_bounds_position" value="1"
+        summary="the requested position is outside of the surface"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the warp manager">
+        Destroy the pointer warp manager.
+      </description>
+    </request>
+
+    <request name="warp_pointer">
+      <description summary="center the pointer">
+        Request the compositor to move the pointer to a surface-local position.
+        Whether or not the compositor honors the request is implementation defined,
+        it may for example ignore it if the surface doesn't have keyboard or pointer
+        focus, or if the serial of the last enter event isn't correct.
+
+        If the requested position is outside of the surface bounds, the
+        out_of_bounds_position error is emitted.
+      </description>
+      <arg name="surface" type="object" interface="wl_surface"
+           summary="surface to warp the pointer on"/>
+      <arg name="pointer" type="object" interface="wl_pointer"
+           summary="the pointer that should be warped"/>
+      <arg name="x" type="fixed"/>
+      <arg name="y" type="fixed"/>
+      <arg name="serial" type="uint" summary="serial number of the enter event"/>
+    </request>
+  </interface>
+</protocol>


### PR DESCRIPTION
The pointer warp protocol allows us to warp the pointer to a different position on the surface, without any hacks like locking and unlocking the pointer

wayland-protocols MR: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/337