### PR TITLE
GPU: fix build when SDL_GPU_DISABLED is set

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -562,7 +562,11 @@ const char * SDL_GetGPUDriver(int index)
         SDL_InvalidParamError("index");
         return NULL;
     }
+#ifndef SDL_GPU_DISABLED
     return backends[index]->name;
+#else
+    return NULL;
+#endif
 }
 
 const char * SDL_GetGPUDeviceDriver(SDL_GPUDevice *device)


### PR DESCRIPTION
Tiny fix for building with SDL_GPU_DISABLED since backends is not defined then.