### PR TITLE
Move default colorspace aliases into enum

### DIFF
--- a/include/SDL3/SDL_pixels.h
+++ b/include/SDL3/SDL_pixels.h
@@ -669,7 +669,7 @@ typedef enum SDL_Colorspace
                                  SDL_MATRIX_COEFFICIENTS_BT2020_NCL,
                                  SDL_CHROMA_LOCATION_LEFT), */
 
-    SDL_COLORSPACE_BT2020_FULL = 0x22102609u /**< Equivalent to DXGI_COLOR_SPACE_YCBCR_FULL_G22_LEFT_P2020 */
+    SDL_COLORSPACE_BT2020_FULL = 0x22102609u, /**< Equivalent to DXGI_COLOR_SPACE_YCBCR_FULL_G22_LEFT_P2020 */
         /* SDL_DEFINE_COLORSPACE(SDL_COLOR_TYPE_YCBCR,
                                  SDL_COLOR_RANGE_FULL,
                                  SDL_COLOR_PRIMARIES_BT2020,
@@ -677,14 +677,9 @@ typedef enum SDL_Colorspace
                                  SDL_MATRIX_COEFFICIENTS_BT2020_NCL,
                                  SDL_CHROMA_LOCATION_LEFT), */
 
+    SDL_COLORSPACE_RGB_DEFAULT = SDL_COLORSPACE_SRGB, /**< The default colorspace for RGB surfaces if no colorspace is specified */
+    SDL_COLORSPACE_YUV_DEFAULT = SDL_COLORSPACE_JPEG  /**< The default colorspace for YUV surfaces if no colorspace is specified */
 } SDL_Colorspace;
-
-
-/* The default colorspace for RGB surfaces if no colorspace is specified */
-#define SDL_COLORSPACE_RGB_DEFAULT  SDL_COLORSPACE_SRGB
-
-/* The default colorspace for YUV surfaces if no colorspace is specified */
-#define SDL_COLORSPACE_YUV_DEFAULT  SDL_COLORSPACE_JPEG
 
 /**
  * A structure that represents a color as RGBA components.


### PR DESCRIPTION
Related to https://github.com/libsdl-org/SDL/pull/10921

`SDL_Colorspace` enum constant aliases `SDL_COLORSPACE_RGB_DEFAULT` and `SDL_COLORSPACE_YUV_DEFAULT` don't appear in the wiki.
https://wiki.libsdl.org/SDL3/SDL_Colorspace

This commit moves them into the enum.