### PR TITLE
Fix warning: no function prototype

### DIFF
--- a/src/joystick/hidapi/SDL_hidapijoystick.c
+++ b/src/joystick/hidapi/SDL_hidapijoystick.c
@@ -1246,12 +1246,12 @@ static bool HIDAPI_IsEquivalentToDevice(Uint16 vendor_id, Uint16 product_id, SDL
     return false;
 }
 
-static bool HIDAPI_StartUpdatingDevices()
+static bool HIDAPI_StartUpdatingDevices(void)
 {
     return SDL_CompareAndSwapAtomicInt(&SDL_HIDAPI_updating_devices, false, true);
 }
 
-static void HIDAPI_FinishUpdatingDevices()
+static void HIDAPI_FinishUpdatingDevices(void)
 {
     SDL_SetAtomicInt(&SDL_HIDAPI_updating_devices, false);
 }

--- a/src/joystick/windows/SDL_rawinputjoystick_c.h
+++ b/src/joystick/windows/SDL_rawinputjoystick_c.h
@@ -22,11 +22,11 @@
 #include "../../core/windows/SDL_windows.h"
 
 // Return true if the RawInput driver is enabled
-extern bool RAWINPUT_IsEnabled();
+extern bool RAWINPUT_IsEnabled(void);
 
 // Registers for input events
 extern int RAWINPUT_RegisterNotifications(HWND hWnd);
-extern int RAWINPUT_UnregisterNotifications();
+extern int RAWINPUT_UnregisterNotifications(void);
 
 // Returns 0 if message was handled
 extern LRESULT CALLBACK RAWINPUT_WindowProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);

--- a/src/video/windows/SDL_windowsmouse.h
+++ b/src/video/windows/SDL_windowsmouse.h
@@ -29,6 +29,6 @@ extern HCURSOR SDL_cursor;
 extern void WIN_InitMouse(SDL_VideoDevice *_this);
 extern void WIN_QuitMouse(SDL_VideoDevice *_this);
 extern void WIN_SetCursorPos(int x, int y);
-extern void WIN_UpdateMouseSystemScale();
+extern void WIN_UpdateMouseSystemScale(void);
 
 #endif // SDL_windowsmouse_h_


### PR DESCRIPTION
Adding `void` to function prototypes.

Compiler: `MSVC`
Warning: `C4255`
Flag: `/w14255`
```c
C:\path\to\SDL-git\src\joystick\windows\SDL_rawinputjoystick_c.h(25,33): warning C4255: 'RAWINPUT_IsEnabled': no function prototype given: converting '()' to '(void)' (compiling source file ..\..\src\joystick\hidapi\SDL_hidapijoystick.c)
C:\path\to\SDL-git\src\joystick\windows\SDL_rawinputjoystick_c.h(29,46): warning C4255: 'RAWINPUT_UnregisterNotifications': no function prototype given: converting '()' to '(void)' (compiling source file ..\..\src\joystick\hidapi\SDL_hidapijoystick.c)
C:\path\to\SDL-git\src\video\windows\SDL_windowsmouse.h(32,41): warning C4255: 'WIN_UpdateMouseSystemScale': no function prototype given: converting '()' to '(void)' (compiling source file ..\..\src\render\direct3d\SDL_render_d3d.c)
```


Compiler: `Clang`
Warning/Flag: `-Wstrict-prototypes`
```c
/path/to/SDL-git/src/joystick/hidapi/SDL_hidapijoystick.c:1249:40: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
 1249 | static bool HIDAPI_StartUpdatingDevices()
      |                                        ^
      |                                         void
/path/to/SDL-git/src/joystick/hidapi/SDL_hidapijoystick.c:1254:41: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
 1254 | static void HIDAPI_FinishUpdatingDevices()
      |                                         ^
      |                                          void
```