### PR TITLE
Fix -Wformat-pedantic warnings in test projects

### DIFF
--- a/test/testautomation_events.c
+++ b/test/testautomation_events.c
@@ -94,7 +94,7 @@ static int SDLCALL events_pushPumpAndPollUserevent(void *arg)
     SDLTest_AssertCheck((void *)&g_userdataValue1 == event_out.user.data1, "Check SDL_Event.user.data1, expected: %p, got: %p", (void *)&g_userdataValue1, event_out.user.data1);
     SDLTest_AssertCheck((void *)&g_userdataValue2 == event_out.user.data2, "Check SDL_Event.user.data2, expected: %p, got: %p", (void *)&g_userdataValue2, event_out.user.data2);
     event_window = SDL_GetWindowFromEvent(&event_out);
-    SDLTest_AssertCheck(NULL == SDL_GetWindowFromEvent(&event_out), "Check SDL_GetWindowFromEvent returns the window id from a user event, expected: NULL, got: %p", event_window);
+    SDLTest_AssertCheck(NULL == SDL_GetWindowFromEvent(&event_out), "Check SDL_GetWindowFromEvent returns the window id from a user event, expected: NULL, got: %p", (void *)event_window);
 
     /* Need to finish getting all events and sentinel, otherwise other tests that rely on event are in bad state */
     SDL_FlushEvents(SDL_EVENT_FIRST, SDL_EVENT_LAST);

--- a/test/testautomation_properties.c
+++ b/test/testautomation_properties.c
@@ -263,7 +263,7 @@ static int SDLCALL properties_testCopy(void *arg)
 
     data = SDL_GetPointerProperty(b, "data", NULL);
     SDLTest_AssertCheck(data == &a,
-        "Checking data property, got %p, expected %p", data, &a);
+        "Checking data property, got %p, expected %p", data, (void *)&a);
 
     data = SDL_GetPointerProperty(b, "cleanup", NULL);
     SDLTest_AssertCheck(data == NULL,

--- a/test/testautomation_stdlib.c
+++ b/test/testautomation_stdlib.c
@@ -1228,9 +1228,9 @@ stdlib_strpbrk(void *arg)
             SDLTest_AssertPass("About to call SDL_strpbrk(\"%s\", \"%s\")", input, test_cases[i].accept);
             result = SDL_strpbrk(input, test_cases[i].accept);
             if (test_cases[i].expected[j] < 0) {
-                SDLTest_AssertCheck(result == NULL, "Expected NULL, got %p", result);
+                SDLTest_AssertCheck(result == NULL, "Expected NULL, got %p", (void *)result);
             } else {
-                SDLTest_AssertCheck(result == test_cases[i].input + test_cases[i].expected[j], "Expected %p, got %p", test_cases[i].input + test_cases[i].expected[j], result);
+                SDLTest_AssertCheck(result == test_cases[i].input + test_cases[i].expected[j], "Expected %p, got %p", (void *)(test_cases[i].input + test_cases[i].expected[j]), (void *)result);
                 input = test_cases[i].input + test_cases[i].expected[j] + 1;
             }
         }
@@ -1243,14 +1243,14 @@ static int SDLCALL stdlib_wcstol(void *arg)
     const long long_max = (~0UL) >> 1;
     const long long_min = ((~0UL) >> 1) + 1UL;
 
-#define WCSTOL_TEST_CASE(str, base, expected_result, expected_endp_offset) do {                             \
-        const wchar_t *s = str;                                                                             \
-        long r, expected_r = expected_result;                                                               \
-        wchar_t *ep, *expected_ep = (wchar_t *)s + expected_endp_offset;                                    \
-        r = SDL_wcstol(s, &ep, base);                                                                       \
-        SDLTest_AssertPass("Call to SDL_wcstol(" #str ", &endp, " #base ")");                               \
-        SDLTest_AssertCheck(r == expected_r, "Check result value, expected: %ld, got: %ld", expected_r, r); \
-        SDLTest_AssertCheck(ep == expected_ep, "Check endp value, expected: %p, got: %p", expected_ep, ep); \
+#define WCSTOL_TEST_CASE(str, base, expected_result, expected_endp_offset) do {                                             \
+        const wchar_t *s = str;                                                                                             \
+        long r, expected_r = expected_result;                                                                               \
+        wchar_t *ep, *expected_ep = (wchar_t *)s + expected_endp_offset;                                                    \
+        r = SDL_wcstol(s, &ep, base);                                                                                       \
+        SDLTest_AssertPass("Call to SDL_wcstol(" #str ", &endp, " #base ")");                                               \
+        SDLTest_AssertCheck(r == expected_r, "Check result value, expected: %ld, got: %ld", expected_r, r);                 \
+        SDLTest_AssertCheck(ep == expected_ep, "Check endp value, expected: %p, got: %p", (void *)expected_ep, (void *)ep); \
     } while (0)
 
     // infer decimal
@@ -1300,7 +1300,7 @@ static int SDLCALL stdlib_strtox(void *arg)
         r = func_name(s, &ep, base);                                                                                             \
         SDLTest_AssertPass("Call to " #func_name "(" #str ", &endp, " #base ")");                                                \
         SDLTest_AssertCheck(r == expected_r, "Check result value, expected: " format_spec ", got: " format_spec, expected_r, r); \
-        SDLTest_AssertCheck(ep == expected_ep, "Check endp value, expected: %p, got: %p", expected_ep, ep);                      \
+        SDLTest_AssertCheck(ep == expected_ep, "Check endp value, expected: %p, got: %p", (void *)expected_ep, (void *)ep);      \
     } while (0)
 
     // infer decimal
@@ -1363,14 +1363,14 @@ static int SDLCALL stdlib_strtox(void *arg)
 
 static int SDLCALL stdlib_strtod(void *arg)
 {
-#define STRTOD_TEST_CASE(str, expected_result, expected_endp_offset) do {                                   \
-        const char *s = str;                                                                                \
-        double r, expected_r = expected_result;                                                             \
-        char *ep, *expected_ep = (char *)s + expected_endp_offset;                                          \
-        r = SDL_strtod(s, &ep);                                                                             \
-        SDLTest_AssertPass("Call to SDL_strtod(" #str ", &endp)");                                          \
-        SDLTest_AssertCheck(r == expected_r, "Check result value, expected: %f, got: %f", expected_r, r);   \
-        SDLTest_AssertCheck(ep == expected_ep, "Check endp value, expected: %p, got: %p", expected_ep, ep); \
+#define STRTOD_TEST_CASE(str, expected_result, expected_endp_offset) do {                                                   \
+        const char *s = str;                                                                                                \
+        double r, expected_r = expected_result;                                                                             \
+        char *ep, *expected_ep = (char *)s + expected_endp_offset;                                                          \
+        r = SDL_strtod(s, &ep);                                                                                             \
+        SDLTest_AssertPass("Call to SDL_strtod(" #str ", &endp)");                                                          \
+        SDLTest_AssertCheck(r == expected_r, "Check result value, expected: %f, got: %f", expected_r, r);                   \
+        SDLTest_AssertCheck(ep == expected_ep, "Check endp value, expected: %p, got: %p", (void *)expected_ep, (void *)ep); \
     } while (0)
 
     STRTOD_TEST_CASE("\t  123.75abcxyz", 123.75, 9); // skip leading space

--- a/test/testautomation_video.c
+++ b/test/testautomation_video.c
@@ -320,7 +320,7 @@ static int SDLCALL video_getFullscreenDisplayModes(void *arg)
         for (i = 0; displays[i]; ++i) {
             modes = SDL_GetFullscreenDisplayModes(displays[i], &count);
             SDLTest_AssertPass("Call to SDL_GetFullscreenDisplayModes(%" SDL_PRIu32 ")", displays[i]);
-            SDLTest_AssertCheck(modes != NULL, "Validate returned value from function; expected != NULL; got: %p", modes);
+            SDLTest_AssertCheck(modes != NULL, "Validate returned value from function; expected != NULL; got: %p", (void *)modes);
             SDLTest_AssertCheck(count >= 0, "Validate number of modes; expected: >= 0; got: %d", count);
             SDL_free(modes);
         }
@@ -435,7 +435,7 @@ static int SDLCALL video_getWindowDisplayMode(void *arg)
     if (window != NULL) {
         mode = SDL_GetWindowFullscreenMode(window);
         SDLTest_AssertPass("Call to SDL_GetWindowFullscreenMode()");
-        SDLTest_AssertCheck(mode == NULL, "Validate result value; expected: NULL, got: %p", mode);
+        SDLTest_AssertCheck(mode == NULL, "Validate result value; expected: NULL, got: %p", (void *)mode);
     }
 
     /* Clean up */
@@ -475,7 +475,7 @@ static int SDLCALL video_getWindowDisplayModeNegative(void *arg)
     /* Call against invalid window */
     mode = SDL_GetWindowFullscreenMode(NULL);
     SDLTest_AssertPass("Call to SDL_GetWindowFullscreenMode(window=NULL)");
-    SDLTest_AssertCheck(mode == NULL, "Validate result value; expected: NULL, got: %p", mode);
+    SDLTest_AssertCheck(mode == NULL, "Validate result value; expected: NULL, got: %p", (void *)mode);
     checkInvalidWindowError();
 
     return TEST_COMPLETED;

--- a/test/testloadso.c
+++ b/test/testloadso.c
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
                          symname, SDL_GetError());
             result = 4;
         } else {
-            SDL_Log("Found %s in %s at %p\n", symname, libname, fn);
+            SDL_Log("Found %s in %s at %p\n", symname, libname, (void *)fn);
             if (hello) {
                 SDL_Log("Calling function...\n");
                 fn("     HELLO, WORLD!\n");


### PR DESCRIPTION
Fixing warnings in test projects when calling `printf()` with format `%p` and a non-void pointer as argument.

Compiler: `Clang`
Flag: `-Wformat-pedantic`

1 warning in `test/testautomation_events.c`
```c
/path/to/SDL-git/test/testautomation_events.c:97:166: warning: format specifies type 'void *' but the argument has type 'SDL_Window *' (aka 'struct SDL_Window *') [-Wformat-pedantic]
   97 |     SDLTest_AssertCheck(NULL == SDL_GetWindowFromEvent(&event_out), "Check SDL_GetWindowFromEvent returns the window id from a user event, expected: NULL, got: %p", event_window);
      |                                                                                                                                                                 ~~   ^~~~~~~~~~~~
```

1 warning in `test/testautomation_properties.c`
```c
/path/to/SDL-git/test/testautomation_properties.c:266:62: warning: format specifies type 'void *' but the argument has type 'SDL_PropertiesID *' (aka 'unsigned int *') [-Wformat-pedantic]
  266 |         "Checking data property, got %p, expected %p", data, &a);
      |                                                   ~~         ^~
```

103 warnings in `test/testautomation_stdlib.c`. Most of those were hiding behind just a few macros.
```c
/path/to/SDL-git/test/testautomation_stdlib.c:1231:78: warning: format specifies type 'void *' but the argument has type 'char *' [-Wformat-pedantic]
 1231 |                 SDLTest_AssertCheck(result == NULL, "Expected NULL, got %p", result);
      |                                                                         ~~   ^~~~~~
      |                                                                         %s
/path/to/SDL-git/test/testautomation_stdlib.c:1233:119: warning: format specifies type 'void *' but the argument has type 'const char *' [-Wformat-pedantic]
 1233 |                 SDLTest_AssertCheck(result == test_cases[i].input + test_cases[i].expected[j], "Expected %p, got %p", test_cases[i].input + test_cases[i].expected[j], result);
      |                                                                                                          ~~           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                                          %s
/path/to/SDL-git/test/testautomation_stdlib.c:1233:168: warning: format specifies type 'void *' but the argument has type 'char *' [-Wformat-pedantic]
 1233 |                 SDLTest_AssertCheck(result == test_cases[i].input + test_cases[i].expected[j], "Expected %p, got %p", test_cases[i].input + test_cases[i].expected[j], result);
      |                                                                                                                  ~~                                                    ^~~~~~
      |                                                                                                                  %s
/path/to/SDL-git/test/testautomation_stdlib.c:1257:5: warning: format specifies type 'void *' but the argument has type 'wchar_t *' (aka 'int *') [-Wformat-pedantic]
 1257 |     WCSTOL_TEST_CASE(L"\t  123abcxyz", 0, 123, 6); // skip leading space
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL-git/test/testautomation_stdlib.c:1253:91: note: expanded from macro 'WCSTOL_TEST_CASE'
 1253 |         SDLTest_AssertCheck(ep == expected_ep, "Check endp value, expected: %p, got: %p", expected_ep, ep); \
      |                                                                             ~~            ^~~~~~~~~~~

/path/to/SDL-git/test/testautomation_stdlib.c:1307:5: warning: format specifies type 'void *' but the argument has type 'char *' [-Wformat-pedantic]
 1307 |     STRTOX_TEST_CASE(SDL_strtoull, unsigned long long, FMT_PRILLu, "\t  123abcxyz", 0, 123, 6); // skip leading space
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL-git/test/testautomation_stdlib.c:1303:91: note: expanded from macro 'STRTOX_TEST_CASE'
 1303 |         SDLTest_AssertCheck(ep == expected_ep, "Check endp value, expected: %p, got: %p", expected_ep, ep);                      \
      |                                                                             ~~            ^~~~~~~~~~~

/path/to/SDL-git/test/testautomation_stdlib.c:1376:5: warning: format specifies type 'void *' but the argument has type 'char *' [-Wformat-pedantic]
 1376 |     STRTOD_TEST_CASE("\t  123.75abcxyz", 123.75, 9); // skip leading space
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL-git/test/testautomation_stdlib.c:1373:91: note: expanded from macro 'STRTOD_TEST_CASE'
 1373 |         SDLTest_AssertCheck(ep == expected_ep, "Check endp value, expected: %p, got: %p", expected_ep, ep); \
      |                                                                             ~~            ^~~~~~~~~~~
...
...
...
```

3 warnings in `test/testautomation_video.c`
```c
/path/to/SDL-git/test/testautomation_video.c:323:116: warning: format specifies type 'void *' but the argument has type 'SDL_DisplayMode **' (aka 'struct SDL_DisplayMode **') [-Wformat-pedantic]
  323 |             SDLTest_AssertCheck(modes != NULL, "Validate returned value from function; expected != NULL; got: %p", modes);
      |                                                                                                               ~~   ^~~~~
/path/to/SDL-git/test/testautomation_video.c:438:93: warning: format specifies type 'void *' but the argument has type 'const SDL_DisplayMode *' (aka 'const struct SDL_DisplayMode *') [-Wformat-pedantic]
  438 |         SDLTest_AssertCheck(mode == NULL, "Validate result value; expected: NULL, got: %p", mode);
      |                                                                                        ~~   ^~~~
/path/to/SDL-git/test/testautomation_video.c:478:89: warning: format specifies type 'void *' but the argument has type 'const SDL_DisplayMode *' (aka 'const struct SDL_DisplayMode *') [-Wformat-pedantic]
  478 |     SDLTest_AssertCheck(mode == NULL, "Validate result value; expected: NULL, got: %p", mode);
      |                                                                                    ~~   ^~~~
```

1 warning `test/testloadso.c`
```c
/path/to/SDL-git/test/testloadso.c:99:65: warning: format specifies type 'void *' but the argument has type 'fntype' (aka 'int (*)(const char *)') [-Wformat-pedantic]
   99 |             SDL_Log("Found %s in %s at %p\n", symname, libname, fn);
      |                                        ~~                       ^~
```

There are still some `-Wformat-pedantic` warnings in `src/joystick/hidapi/SDL_hidapi_steam.c`:
```c
/path/to/SDL-git/src/joystick/hidapi/SDL_hidapi_steam.c:427:72: warning: format specifies type 'void *' but the argument has type 'SDL_hid_device *' (aka 'struct SDL_hid_device *') [-Wformat-pedantic]
  427 |             printf("GET_ATTRIBUTES_VALUES failed for controller %p\n", dev);
      |                                                                 ~~     ^~~
/path/to/SDL-git/src/joystick/hidapi/SDL_hidapi_steam.c:438:78: warning: format specifies type 'void *' but the argument has type 'SDL_hid_device *' (aka 'struct SDL_hid_device *') [-Wformat-pedantic]
  438 |             printf("Bad GET_ATTRIBUTES_VALUES response for controller %p\n", dev);
      |                                                                       ~~     ^~~
/path/to/SDL-git/src/joystick/hidapi/SDL_hidapi_steam.c:446:78: warning: format specifies type 'void *' but the argument has type 'SDL_hid_device *' (aka 'struct SDL_hid_device *') [-Wformat-pedantic]
  446 |             printf("Bad GET_ATTRIBUTES_VALUES response for controller %p\n", dev);
      |                                                                       ~~     ^~~
/path/to/SDL-git/src/joystick/hidapi/SDL_hidapi_steam.c:480:73: warning: format specifies type 'void *' but the argument has type 'SDL_hid_device *' (aka 'struct SDL_hid_device *') [-Wformat-pedantic]
  480 |             printf("CLEAR_DIGITAL_MAPPINGS failed for controller %p\n", dev);
      |                                                                  ~~     ^~~
/path/to/SDL-git/src/joystick/hidapi/SDL_hidapi_steam.c:492:72: warning: format specifies type 'void *' but the argument has type 'SDL_hid_device *' (aka 'struct SDL_hid_device *') [-Wformat-pedantic]
  492 |             printf("LOAD_DEFAULT_SETTINGS failed for controller %p\n", dev);
      |                                                                 ~~     ^~~
/path/to/SDL-git/src/joystick/hidapi/SDL_hidapi_steam.c:522:63: warning: format specifies type 'void *' but the argument has type 'SDL_hid_device *' (aka 'struct SDL_hid_device *') [-Wformat-pedantic]
  522 |             printf("SET_SETTINGS failed for controller %p\n", dev);
      |                                                        ~~     ^~~
```

I didn't fix these, because I wasn't sure if `src/joystick/hidapi/SDL_hidapi_steam.c` is considered external code from another library.
Btw, how can someone know, if some code is external? Is there always a comment and/or a copyright notice at the top?