### PR TITLE
wayland: Check for frog-fifo-v1 to enable Wayland by default

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -376,6 +376,7 @@ typedef struct
 {
     bool has_fifo_v1;
     bool has_commit_timing_v1;
+    bool has_frog_fifo_v1;
 } SDL_WaylandPreferredData;
 
 static void wayland_preferred_check_handle_global(void *data, struct wl_registry *registry, uint32_t id,
@@ -387,6 +388,8 @@ static void wayland_preferred_check_handle_global(void *data, struct wl_registry
         d->has_fifo_v1 = true;
     } else if (SDL_strcmp(interface, "wp_commit_timing_manager_v1") == 0) {
         d->has_commit_timing_v1 = true;
+    } else if (SDL_strcmp(interface, "frog_fifo_manager_v1") == 0) {
+        d->has_frog_fifo_v1 = true;
     }
 }
 
@@ -416,7 +419,7 @@ static bool Wayland_IsPreferred(struct wl_display *display)
 
     wl_registry_destroy(registry);
 
-    return preferred_data.has_fifo_v1 && preferred_data.has_commit_timing_v1;
+    return (preferred_data.has_fifo_v1 && preferred_data.has_commit_timing_v1) || preferred_data.has_frog_fifo_v1;
 }
 
 static SDL_VideoDevice *Wayland_CreateDevice(bool require_preferred_protocols)


### PR DESCRIPTION
Enable Wayland by default if frog-fifo-v1 is supported.

See #9383
