### PR TITLE
Throttle tickle reports to PS4/PS5 controllers

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_ps4.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps4.c
@@ -1307,6 +1307,7 @@ static bool HIDAPI_DriverPS4_UpdateDevice(SDL_HIDAPI_Device *device)
             if (now >= (ctx->last_packet + BLUETOOTH_DISCONNECT_TIMEOUT_MS)) {
                 // Send an empty output report to tickle the Bluetooth stack
                 HIDAPI_DriverPS4_TickleBluetooth(device);
+                ctx->last_packet = now;
             }
         } else {
             // Reconnect the Bluetooth device once the USB device is gone

--- a/src/joystick/hidapi/SDL_hidapi_ps5.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps5.c
@@ -1553,6 +1553,7 @@ static bool HIDAPI_DriverPS5_UpdateDevice(SDL_HIDAPI_Device *device)
             if (now >= (ctx->last_packet + BLUETOOTH_DISCONNECT_TIMEOUT_MS)) {
                 // Send an empty output report to tickle the Bluetooth stack
                 HIDAPI_DriverPS5_TickleBluetooth(device);
+                ctx->last_packet = now;
             }
         } else {
             // Reconnect the Bluetooth device once the USB device is gone


### PR DESCRIPTION
## Description
I hit a hang when disconnecting a PS5 controller that seemed to be caused by a buildup of the empty output reports submitted by `HIDAPI_DriverPS5_TickleBluetooth()`. I haven't been able to reproduce it again, but I think the issue was that we were calling `HIDAPI_DriverPS5_TickleBluetooth()` every time the application polls for events once the initial 500 ms quiet period occurred. Since there's throttling in the HIDAPI rumble thread (no more than 1 per 10 ms), it's possible for these to queue forever if the application is polling faster than every 10 ms and the controller stops reporting input.

(The following is from SDL2, but it looks like same bug affects SDL3)

The event loop thread is sleeping in a loop waiting for the rumble thread to drop `device->rumble_pending` to 0.
```
KERNELBASE!SleepEx+0x68
SDL2!SDL_Delay_REAL+0x74 [C:\projects\moonlight-deps\SDL\src\timer\windows\SDL_systimer.c @ 164] 
SDL2!HIDAPI_DelDevice+0xe0 [C:\projects\moonlight-deps\SDL\src\joystick\hidapi\SDL_hidapijoystick.c @ 990] 
SDL2!HIDAPI_UpdateDeviceList+0x1ac [C:\projects\moonlight-deps\SDL\src\joystick\hidapi\SDL_hidapijoystick.c @ 1150] 
SDL2!HIDAPI_JoystickDetect+0x38 [C:\projects\moonlight-deps\SDL\src\joystick\hidapi\SDL_hidapijoystick.c @ 1322] 
SDL2!SDL_JoystickUpdate_REAL+0x23c [C:\projects\moonlight-deps\SDL\src\joystick\SDL_joystick.c @ 2221] 
SDL2!SDL_PumpEventsInternal+0x50 [C:\projects\moonlight-deps\SDL\src\events\SDL_events.c @ 933] 
SDL2!SDL_WaitEventTimeout_Device+0xb4 [C:\projects\moonlight-deps\SDL\src\events\SDL_events.c @ 1012] 
SDL2!SDL_WaitEventTimeout_REAL+0x43c [C:\projects\moonlight-deps\SDL\src\events\SDL_events.c @ 1148] 
```

Meanwhile the rumble thread is _also_ sleeping due to the 10 ms throttle between rumble messages.
```
KERNELBASE!SleepEx+0x68
SDL2!SDL_Delay_REAL+0x74 [C:\projects\moonlight-deps\SDL\src\timer\windows\SDL_systimer.c @ 164] 
SDL2!SDL_HIDAPI_RumbleThread+0xc4 [C:\projects\moonlight-deps\SDL\src\joystick\hidapi\SDL_hidapi_rumble.c @ 97] 
SDL2!SDL_RunThread+0x30 [C:\projects\moonlight-deps\SDL\src\thread\SDL_thread.c @ 333] 
SDL2!RunThread+0x8 [C:\projects\moonlight-deps\SDL\src\thread\windows\SDL_systhread.c @ 51] 
SDL2!RunThreadViaCreateThread+0x14 [C:\projects\moonlight-deps\SDL\src\thread\windows\SDL_systhread.c @ 65] 
```

There are tons of these rumble messages pending for the device:
```
0:000> ?? device->rumble_pending
struct SDL_atomic_t
   +0x000 value            : 0n523341
```

and they all look like the PS5 tickle packet:
```
0:021> dx -r1 ((SDL2!SDL_HIDAPI_RumbleRequest *)0x1d0c3e72aa0)
((SDL2!SDL_HIDAPI_RumbleRequest *)0x1d0c3e72aa0)                 : 0x1d0c3e72aa0 [Type: SDL_HIDAPI_RumbleRequest *]
    [+0x000] device           : 0x1d0a4b2a5a0 [Type: _SDL_HIDAPI_Device *]
    [+0x008] data             [Type: unsigned char [128]]
    [+0x088] size             : 78 [Type: int]
    [+0x090] callback         : 0x0 : 0x0 [Type: void (__cdecl*)(void *)]
    [+0x098] userdata         : 0x0 [Type: void *]
    [+0x0a0] prev             : 0x1d0c3e72ec0 [Type: SDL_HIDAPI_RumbleRequest *]
0:000> dx -r1 (*((SDL2!unsigned char (*)[128])0x1d0c3e72268))
(*((SDL2!unsigned char (*)[128])0x1d0c3e72268))                 [Type: unsigned char [128]]
    [0]              : 0x31 [Type: unsigned char]
    [1]              : 0x2 [Type: unsigned char]
    [2]              : 0x0 [Type: unsigned char]
    [3]              : 0x0 [Type: unsigned char]
    [4]              : 0x0 [Type: unsigned char]
    ... (all zeros)
```

Due to the 10 ms throttling between rumble messages, it would take us almost 1.5 _hours_ to send all those messages. 

## Fix

The fix is pretty simple. We just reset the `last_packet` time when we send a tickle to throttle ourselves to one per 500 ms.

The only concern I have is that I'm not sure if it's possible to have both `is_bluetooth` and `is_nacon_dongle` be true for a single device. I don't think the code currently works properly in that case today though, since we'd attempt to tickle the controller then immediately disconnect without waiting for a response.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
