### PR TITLE
clipboard: add SDL_ClipboardMimeTypes

### DIFF
--- a/include/SDL3/SDL_clipboard.h
+++ b/include/SDL3/SDL_clipboard.h
@@ -43,6 +43,20 @@ extern "C" {
 /* Function prototypes */
 
 /**
+ *  Retrieve the list of mime types available in the clipboard.
+ *
+ * \param num_mime_types a pointer filled with the number of mime types. May be NULL.
+ * \returns a null terminated array of strings with mime types, or NULL on
+ *          failure; call SDL_GetError() for more information. This should be
+ *          freed with SDL_free() when it is no longer needed.
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_SetClipboardData
+ */
+extern SDL_DECLSPEC char ** SDLCALL SDL_GetClipboardMimeTypes(size_t *num_mime_types);
+
+/**
  * Put UTF-8 text into the clipboard.
  *
  * \param text the text to store in the clipboard.

--- a/src/dynapi/SDL_dynapi.sym
+++ b/src/dynapi/SDL_dynapi.sym
@@ -248,6 +248,7 @@ SDL3_0.0.0 {
     SDL_GetCameraSupportedFormats;
     SDL_GetCameras;
     SDL_GetClipboardData;
+    SDL_GetClipboardMimeTypes;
     SDL_GetClipboardText;
     SDL_GetClosestFullscreenDisplayMode;
     SDL_GetCurrentAudioDriver;

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -273,6 +273,7 @@
 #define SDL_GetCameraSupportedFormats SDL_GetCameraSupportedFormats_REAL
 #define SDL_GetCameras SDL_GetCameras_REAL
 #define SDL_GetClipboardData SDL_GetClipboardData_REAL
+#define SDL_GetClipboardMimeTypes SDL_GetClipboardMimeTypes_REAL
 #define SDL_GetClipboardText SDL_GetClipboardText_REAL
 #define SDL_GetClosestFullscreenDisplayMode SDL_GetClosestFullscreenDisplayMode_REAL
 #define SDL_GetCurrentAudioDriver SDL_GetCurrentAudioDriver_REAL
@@ -1033,7 +1034,7 @@
 #define SDL_aligned_free SDL_aligned_free_REAL
 #define SDL_asin SDL_asin_REAL
 #define SDL_asinf SDL_asinf_REAL
-#define SDL_asprintf    SDL_asprintf_REAL
+#define SDL_asprintf SDL_asprintf_REAL
 #define SDL_atan SDL_atan_REAL
 #define SDL_atan2 SDL_atan2_REAL
 #define SDL_atan2f SDL_atan2f_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -294,6 +294,7 @@ SDL_DYNAPI_PROC(SDL_PropertiesID,SDL_GetCameraProperties,(SDL_Camera *a),(a),ret
 SDL_DYNAPI_PROC(SDL_CameraSpec**,SDL_GetCameraSupportedFormats,(SDL_CameraID a, int *b),(a,b),return)
 SDL_DYNAPI_PROC(SDL_CameraID*,SDL_GetCameras,(int *a),(a),return)
 SDL_DYNAPI_PROC(void*,SDL_GetClipboardData,(const char *a, size_t *b),(a,b),return)
+SDL_DYNAPI_PROC(char **,SDL_GetClipboardMimeTypes,(size_t *a),(a),return)
 SDL_DYNAPI_PROC(char*,SDL_GetClipboardText,(void),(),return)
 SDL_DYNAPI_PROC(bool,SDL_GetClosestFullscreenDisplayMode,(SDL_DisplayID a, int b, int c, float d, bool e, SDL_DisplayMode *f),(a,b,c,d,e,f),return)
 SDL_DYNAPI_PROC(const char*,SDL_GetCurrentAudioDriver,(void),(),return)


### PR DESCRIPTION

## Description
This function allows to retrieve the available mime types without doing any synthesizing.

## Existing Issue(s)

None, but we'd need that in FreeRDP