### PR TITLE
testcolorspace.c: Fix unreachable code warning

### DIFF
--- a/test/testcolorspace.c
+++ b/test/testcolorspace.c
@@ -126,10 +126,6 @@ static void PrevRenderer(void)
 
 static void NextStage(void)
 {
-    if (StageCount <= 0) {
-        return;
-    }
-
     ++stage_index;
     if (stage_index == StageCount) {
         stage_index = 0;


### PR DESCRIPTION
```c
/path/to/SDL-git/test/testcolorspace.c:130:9: warning: 'return' will never be executed [-Wunreachable-code-return]
  130 |         return;
      |         ^~~~~~
```

`StageCount` is an enum constant with a current value of `8`.
The check `StageCount <= 0` can probably be removed.
```c
enum
{
    StageClearBackground,
    StageDrawBackground,
    StageTextureBackground,
    StageTargetBackground,
    StageBlendDrawing,
    StageBlendTexture,
    StageGradientDrawing,
    StageGradientTexture,
    StageCount
};
```
```c
if (StageCount <= 0) {
    return;
}
```
This assumes that the elements in the enum will not change drastically in the future.
