### PR TITLE
SDL_stdinc.h: _Bool macro definition

### DIFF
--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -47,18 +47,20 @@
 #include <inttypes.h>
 #endif
 #include <stdarg.h>
+
 #ifndef __cplusplus
-#ifdef SDL_DEFINE_STDBOOL
-#ifndef __bool_true_false_are_defined
-#define __bool_true_false_are_defined 1
-#define bool  uint8_t
-#define false 0
-#define true  1
+# if defined(SDL_DEFINE_STDBOOL) && defined(__STDC_VERSION__) && __STDC_VERSION__ < 202311L
+#  ifndef __bool_true_false_are_defined
+#   define __bool_true_false_are_defined 1
+#   define bool  uint8_t
+#   define false 0
+#   define true  1
+#  endif
+# else
+#  include <stdbool.h>
+# endif
 #endif
-#else
-#include <stdbool.h>
-#endif
-#endif
+
 #include <stdint.h>
 #include <string.h>
 #include <wchar.h>


### PR DESCRIPTION
There are warnings when compiling with `C89` and only definig `bool`, `false` and `true`, but not `_Bool` before any SDL header inclusion:
```c
/path/to/SDL-git/include/SDL3/SDL_atomic.h:98:21: warning: '_Bool' is a C99 extension [-Wc99-extensions]
   98 | extern SDL_DECLSPEC bool SDLCALL SDL_TryLockSpinlock(SDL_SpinLock *lock);
      |                     ^
/usr/lib/clang/18/include/stdbool.h:20:14: note: expanded from macro 'bool'
   20 | #define bool _Bool
      |              ^
```
When defining all 4, there are no warnings.

`__bool_true_false_are_defined` expects `_Bool` to be defined.
First change adds `_Bool`.

Second change:
Replacing `uint8_t` with `unsigned char` for the boolean definition:
- The bool-definition code block can then be copied and pasted before any SDL header is included, without the dependency on the  `uint8_t` type.
