### PR TITLE
Remove trailing comma in enum

### DIFF
--- a/include/SDL3/SDL_process.h
+++ b/include/SDL3/SDL_process.h
@@ -145,7 +145,7 @@ typedef enum SDL_ProcessIO
     SDL_PROCESS_STDIO_INHERITED,    /**< The I/O stream is inherited from the application. */
     SDL_PROCESS_STDIO_NULL,         /**< The I/O stream is ignored. */
     SDL_PROCESS_STDIO_APP,          /**< The I/O stream is connected to a new SDL_IOStream that the application can read or write */
-    SDL_PROCESS_STDIO_REDIRECT,     /**< The I/O stream is redirected to an existing SDL_IOStream. */
+    SDL_PROCESS_STDIO_REDIRECT      /**< The I/O stream is redirected to an existing SDL_IOStream. */
 } SDL_ProcessIO;
 
 /**


### PR DESCRIPTION
```c
/path/to/SDL-git/include/SDL3/SDL_process.h:148:31: warning: commas at the end of enumerator lists are a C99-specific feature [-Wc99-extensions]
  148 |     SDL_PROCESS_STDIO_REDIRECT,     /**< The I/O stream is redirected to an existing SDL_IOStream. */
      |                               ^
```