### PR TITLE
Render GPU: Don't call GetWindowSizeInPixels during RenderPreset

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -2564,6 +2564,10 @@ static void UpdateLogicalPresentation(SDL_Renderer *renderer)
 
     int iwidth, iheight;
     SDL_GetRenderOutputSize(renderer, &iwidth, &iheight);
+
+    renderer->window_pixel_w = iwidth;
+    renderer->window_pixel_h = iheight;
+
     const float output_w = (float)iwidth;
     const float output_h = (float)iheight;
     const float logical_w = renderer->logical_w;

--- a/src/render/SDL_sysrender.h
+++ b/src/render/SDL_sysrender.h
@@ -250,6 +250,9 @@ struct SDL_Renderer
     SDL_RenderViewState *view;
     SDL_RenderViewState main_view;
 
+    // Cache the window size in pixels
+    int window_pixel_w, window_pixel_h;
+
     // The window pixel to point coordinate scale
     SDL_FPoint dpi_scale;
 

--- a/src/render/gpu/SDL_render_gpu.c
+++ b/src/render/gpu/SDL_render_gpu.c
@@ -969,9 +969,6 @@ static bool GPU_RenderPresent(SDL_Renderer *renderer)
 
     SDL_GPUTextureFormat swapchain_fmt = SDL_GetGPUSwapchainTextureFormat(data->device, renderer->window);
 
-    int window_w, window_h;
-    SDL_GetWindowSizeInPixels(renderer->window, &window_w, &window_h);
-
     SDL_GPUBlitInfo blit_info;
     SDL_zero(blit_info);
 
@@ -979,16 +976,16 @@ static bool GPU_RenderPresent(SDL_Renderer *renderer)
     blit_info.source.w = data->backbuffer.width;
     blit_info.source.h = data->backbuffer.height;
     blit_info.destination.texture = swapchain;
-    blit_info.destination.w = window_w;
-    blit_info.destination.h = window_h;
+    blit_info.destination.w = renderer->main_view.pixel_w;
+    blit_info.destination.h = renderer->main_view.pixel_h;
     blit_info.load_op = SDL_GPU_LOADOP_DONT_CARE;
     blit_info.filter = SDL_GPU_FILTER_LINEAR;
 
     SDL_BlitGPUTexture(data->state.command_buffer, &blit_info);
 
-    if (window_w != data->backbuffer.width || window_h != data->backbuffer.height || swapchain_fmt != data->backbuffer.format) {
+    if (renderer->main_view.pixel_w != data->backbuffer.width || renderer->main_view.pixel_h != data->backbuffer.height || swapchain_fmt != data->backbuffer.format) {
         SDL_ReleaseGPUTexture(data->device, data->backbuffer.texture);
-        CreateBackbuffer(data, window_w, window_h, swapchain_fmt);
+        CreateBackbuffer(data, renderer->main_view.pixel_w, renderer->main_view.pixel_h, swapchain_fmt);
     }
 
 // *** FIXME ***

--- a/src/render/gpu/SDL_render_gpu.c
+++ b/src/render/gpu/SDL_render_gpu.c
@@ -976,16 +976,16 @@ static bool GPU_RenderPresent(SDL_Renderer *renderer)
     blit_info.source.w = data->backbuffer.width;
     blit_info.source.h = data->backbuffer.height;
     blit_info.destination.texture = swapchain;
-    blit_info.destination.w = renderer->main_view.pixel_w;
-    blit_info.destination.h = renderer->main_view.pixel_h;
+    blit_info.destination.w = renderer->window_pixel_w;
+    blit_info.destination.h = renderer->window_pixel_h;
     blit_info.load_op = SDL_GPU_LOADOP_DONT_CARE;
     blit_info.filter = SDL_GPU_FILTER_LINEAR;
 
     SDL_BlitGPUTexture(data->state.command_buffer, &blit_info);
 
-    if (renderer->main_view.pixel_w != data->backbuffer.width || renderer->main_view.pixel_h != data->backbuffer.height || swapchain_fmt != data->backbuffer.format) {
+    if (renderer->window_pixel_w != data->backbuffer.width || renderer->window_pixel_h != data->backbuffer.height || swapchain_fmt != data->backbuffer.format) {
         SDL_ReleaseGPUTexture(data->device, data->backbuffer.texture);
-        CreateBackbuffer(data, renderer->main_view.pixel_w, renderer->main_view.pixel_h, swapchain_fmt);
+        CreateBackbuffer(data, renderer->window_pixel_w, renderer->window_pixel_h, swapchain_fmt);
     }
 
 // *** FIXME ***


### PR DESCRIPTION
Resolves #10977 