### PR TITLE
hidapi: update hid_write() for windows from mainstream.

### DIFF
--- a/src/hidapi/windows/hid.c
+++ b/src/hidapi/windows/hid.c
@@ -1282,7 +1282,7 @@ int HID_API_EXPORT HID_API_CALL hid_write(hid_device *dev, const unsigned char *
 		length = dev->output_report_length;
 	}
 
-	res = WriteFile(dev->device_handle, buf, (DWORD) length, NULL, &dev->write_ol);
+	res = WriteFile(dev->device_handle, buf, (DWORD) length, &bytes_written, &dev->write_ol);
 
 	if (!res) {
 		if (GetLastError() != ERROR_IO_PENDING) {
@@ -1291,6 +1291,9 @@ int HID_API_EXPORT HID_API_CALL hid_write(hid_device *dev, const unsigned char *
 			goto end_of_function;
 		}
 		overlapped = TRUE;
+	} else {
+		/* WriteFile() succeeded synchronously. */
+		function_result = bytes_written;
 	}
 
 	if (overlapped) {


### PR DESCRIPTION
Returns bytes_written if WriteFile returns synchronously
Relevant mainstream discussions:
	https://github.com/libusb/hidapi/pull/697
	https://github.com/libusb/hidapi/issues/695

If this gets in, SDL2 branch might need some similar touch (I won't..)
