### PR TITLE
Fix window opacity update

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -3511,7 +3511,7 @@ bool SDL_SetWindowOpacity(SDL_Window *window, float opacity)
     }
 
     result = _this->SetWindowOpacity(_this, window, opacity);
-    if (result == 0) {
+    if (result) {
         window->opacity = opacity;
     }
 


### PR DESCRIPTION
SDL_GetWindowOpacity is always returning 1.0f, even if the opacity has been changed. It was caused by a wrong error check condition in the SDL_SetWindowOpacity, preventing the update of the opacity value.