### PR TITLE
testprocess: More debug logging

### DIFF
--- a/test/testprocess.c
+++ b/test/testprocess.c
@@ -466,7 +466,10 @@ static int process_testStdinToStdout(void *arg)
             }
             amount_written = SDL_WriteIO(process_stdin, text_in + total_written, text_in_size - total_written);
             if (log_this_iteration) {
-                SDLTest_Log("SDL_WriteIO() -> %u (%dth time)", (unsigned)amount_written, iteration_count);
+                SDLTest_Log("SDL_WriteIO() -> %u (%dth time), total written %u",
+                            (unsigned)amount_written,
+                            iteration_count,
+                            (unsigned)(total_written + amount_written));
             }
             if (amount_written == 0) {
                 io_status = SDL_GetIOStatus(process_stdin);
@@ -480,6 +483,9 @@ static int process_testStdinToStdout(void *arg)
             if (total_written == text_in_size) {
                 SDLTest_Log("All data written to stdin");
             }
+            else if (total_written > text_in_size) {
+                SDLTest_Log("Too much data written?!");
+            }
         }
 
         /* FIXME: this needs a rate limit */
@@ -488,7 +494,10 @@ static int process_testStdinToStdout(void *arg)
         }
         amount_read = SDL_ReadIO(process_stdout, local_buffer, sizeof(local_buffer));
         if (log_this_iteration) {
-            SDLTest_Log("SDL_ReadIO() -> %u (%dth time)", (unsigned)amount_read, iteration_count);
+            SDLTest_Log("SDL_ReadIO() -> %u (%dth time), total read %u",
+                        (unsigned)amount_read,
+                        iteration_count,
+                        (unsigned)(total_read + amount_read));
         }
         if (amount_read == 0) {
             io_status = SDL_GetIOStatus(process_stdout);

--- a/test/testprocess.c
+++ b/test/testprocess.c
@@ -454,7 +454,7 @@ static int process_testStdinToStdout(void *arg)
 
     total_written = 0;
     total_read = 0;
-    for (;;) {
+    for (iteration_count = 0; true; iteration_count++) {
         int log_this_iteration = (iteration_count % 32) == 32;
         char local_buffer[16 * 4094];
         size_t amount_read;

--- a/test/testprocess.c
+++ b/test/testprocess.c
@@ -477,6 +477,9 @@ static int process_testStdinToStdout(void *arg)
             }
             total_written += amount_written;
             SDL_FlushIO(process_stdin);
+            if (total_written == text_in_size) {
+                SDLTest_Log("All data written to stdin");
+            }
         }
 
         /* FIXME: this needs a rate limit */

--- a/test/testprocess.c
+++ b/test/testprocess.c
@@ -455,7 +455,7 @@ static int process_testStdinToStdout(void *arg)
     total_written = 0;
     total_read = 0;
     for (iteration_count = 0; true; iteration_count++) {
-        int log_this_iteration = (iteration_count % 32) == 0;
+        bool log_this_iteration = true;
         char local_buffer[16 * 4094];
         size_t amount_read;
         SDL_IOStatus io_status;

--- a/test/testprocess.c
+++ b/test/testprocess.c
@@ -455,7 +455,7 @@ static int process_testStdinToStdout(void *arg)
     total_written = 0;
     total_read = 0;
     for (iteration_count = 0; true; iteration_count++) {
-        int log_this_iteration = (iteration_count % 32) == 32;
+        int log_this_iteration = (iteration_count % 32) == 0;
         char local_buffer[16 * 4094];
         size_t amount_read;
         SDL_IOStatus io_status;


### PR DESCRIPTION
Attempting to debug #11006.

* testprocess: Update iteration count as (presumably) intended

* testprocess: Show log messages as (presumably) intended
    
    The result of the `%` operator will be in the range 0 to 31, so it would
    never be 32, but it can be 0.

* testprocess: Log a message when all data has been written
    
    This will make it more obvious when writing has finished and we are only
    waiting for reading.

* testprocess: Log on every iteration

* testprocess: Improve debug logging