### PR TITLE
Disable backface culling and use a constant rectangle winding order.

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -149,6 +149,8 @@ static const SDL_RenderDriver *render_drivers[] = {
 
 static SDL_Renderer *SDL_renderers;
 
+static const int rect_index_order[] = { 0, 1, 2, 0, 2, 3 };
+
 void SDL_QuitRender(void)
 {
     while (SDL_renderers) {
@@ -625,7 +627,6 @@ static bool QueueCmdFillRects(SDL_Renderer *renderer, const SDL_FRect *rects, co
                 const int num_indices = 6 * count;
                 const int size_indices = 4;
                 int cur_index = 0;
-                const int *rect_index_order = renderer->rect_index_order;
 
                 for (i = 0; i < count; ++i) {
                     float minx, miny, maxx, maxy;
@@ -1065,16 +1066,6 @@ SDL_Renderer *SDL_CreateRendererWithProperties(SDL_PropertiesID props)
     UpdatePixelViewport(renderer, &renderer->main_view);
     UpdatePixelClipRect(renderer, &renderer->main_view);
     UpdateMainViewDimensions(renderer);
-
-    // Default value, if not specified by the renderer back-end
-    if (renderer->rect_index_order[0] == 0 && renderer->rect_index_order[1] == 0) {
-        renderer->rect_index_order[0] = 0;
-        renderer->rect_index_order[1] = 1;
-        renderer->rect_index_order[2] = 2;
-        renderer->rect_index_order[3] = 0;
-        renderer->rect_index_order[4] = 2;
-        renderer->rect_index_order[5] = 3;
-    }
 
     // new textures start at zero, so we start at 1 so first render doesn't flush by accident.
     renderer->render_command_generation = 1;
@@ -3806,7 +3797,7 @@ static bool SDL_RenderTextureInternal(SDL_Renderer *renderer, SDL_Texture *textu
         float uv[8];
         const int uv_stride = 2 * sizeof(float);
         const int num_vertices = 4;
-        const int *indices = renderer->rect_index_order;
+        const int *indices = rect_index_order;
         const int num_indices = 6;
         const int size_indices = 4;
         float minu, minv, maxu, maxv;
@@ -3967,7 +3958,7 @@ bool SDL_RenderTextureRotated(SDL_Renderer *renderer, SDL_Texture *texture,
         float uv[8];
         const int uv_stride = 2 * sizeof(float);
         const int num_vertices = 4;
-        const int *indices = renderer->rect_index_order;
+        const int *indices = rect_index_order;
         const int num_indices = 6;
         const int size_indices = 4;
         float minu, minv, maxu, maxv;
@@ -4055,7 +4046,7 @@ static bool SDL_RenderTextureTiled_Wrap(SDL_Renderer *renderer, SDL_Texture *tex
     float uv[8];
     const int uv_stride = 2 * sizeof(float);
     const int num_vertices = 4;
-    const int *indices = renderer->rect_index_order;
+    const int *indices = rect_index_order;
     const int num_indices = 6;
     const int size_indices = 4;
     float minu, minv, maxu, maxv;

--- a/src/render/SDL_sysrender.h
+++ b/src/render/SDL_sysrender.h
@@ -259,9 +259,6 @@ struct SDL_Renderer
     // The method of drawing lines
     SDL_RenderLineMethod line_method;
 
-    // List of triangle indices to draw rects
-    int rect_index_order[6];
-
     // The list of textures
     SDL_Texture *textures;
     SDL_Texture *target;

--- a/src/render/gpu/SDL_render_gpu.c
+++ b/src/render/gpu/SDL_render_gpu.c
@@ -1266,13 +1266,6 @@ static bool GPU_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_P
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_RGBX32);
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_BGRX32);
 
-    renderer->rect_index_order[0] = 0;
-    renderer->rect_index_order[1] = 1;
-    renderer->rect_index_order[2] = 3;
-    renderer->rect_index_order[3] = 1;
-    renderer->rect_index_order[4] = 3;
-    renderer->rect_index_order[5] = 2;
-
     data->state.draw_color.r = 1.0f;
     data->state.draw_color.g = 1.0f;
     data->state.draw_color.b = 1.0f;

--- a/src/render/opengl/SDL_render_gl.c
+++ b/src/render/opengl/SDL_render_gl.c
@@ -1796,13 +1796,6 @@ static bool GL_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_Pr
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_UYVY);
 #endif
 
-    renderer->rect_index_order[0] = 0;
-    renderer->rect_index_order[1] = 1;
-    renderer->rect_index_order[2] = 3;
-    renderer->rect_index_order[3] = 1;
-    renderer->rect_index_order[4] = 3;
-    renderer->rect_index_order[5] = 2;
-
     if (SDL_GL_ExtensionSupported("GL_EXT_framebuffer_object")) {
         data->GL_EXT_framebuffer_object_supported = true;
         data->glGenFramebuffersEXT = (PFNGLGENFRAMEBUFFERSEXTPROC)

--- a/src/render/opengles2/SDL_render_gles2.c
+++ b/src/render/opengles2/SDL_render_gles2.c
@@ -2191,18 +2191,13 @@ static bool GLES2_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL
     }
 #endif
 
-    renderer->rect_index_order[0] = 0;
-    renderer->rect_index_order[1] = 1;
-    renderer->rect_index_order[2] = 3;
-    renderer->rect_index_order[3] = 1;
-    renderer->rect_index_order[4] = 3;
-    renderer->rect_index_order[5] = 2;
-
     if (SDL_GL_ExtensionSupported("GL_EXT_blend_minmax")) {
         data->GL_EXT_blend_minmax_supported = true;
     }
 
     // Set up parameters for rendering
+    data->glDisable(GL_DEPTH_TEST);
+    data->glDisable(GL_CULL_FACE);
     data->glActiveTexture(GL_TEXTURE0);
     data->glPixelStorei(GL_PACK_ALIGNMENT, 1);
     data->glPixelStorei(GL_UNPACK_ALIGNMENT, 1);

--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -1375,11 +1375,7 @@ static bool PSP_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_P
     sceGuEnable(GU_SCISSOR_TEST);
 
     // Backface culling
-    /*
-    FIXME: Culling probably un-needed ? It can conflict with SDL_RENDERCMD_GEOMETRY
-    sceGuFrontFace(GU_CCW);
-    sceGuEnable(GU_CULL_FACE);
-    */
+    sceGuDisable(GU_CULL_FACE);
 
     // Setup initial blend state
     ResetBlendState(&data->blendState);


### PR DESCRIPTION
This makes it so we don't have to surface the rectangle winding order for applications that want to use the raw geometry API.