### PR TITLE
Don't close file descriptors already handled by AddFileDescriptorCloseActions()

### DIFF
--- a/src/process/posix/SDL_posixprocess.c
+++ b/src/process/posix/SDL_posixprocess.c
@@ -219,25 +219,13 @@ bool SDL_SYS_CreateProcessWithProperties(SDL_Process *process, SDL_PropertiesID 
             SDL_SetError("posix_spawn_file_actions_adddup2 failed: %s", strerror(errno));
             goto posix_spawn_fail_all;
         }
-        if (posix_spawn_file_actions_addclose(&fa, fd) != 0) {
-            SDL_SetError("posix_spawn_file_actions_addclose failed: %s", strerror(errno));
-            goto posix_spawn_fail_all;
-        }
         break;
     case SDL_PROCESS_STDIO_APP:
         if (!CreatePipe(stdin_pipe)) {
             goto posix_spawn_fail_all;
         }
-        if (posix_spawn_file_actions_addclose(&fa, stdin_pipe[WRITE_END]) != 0) {
-            SDL_SetError("posix_spawn_file_actions_addclose failed: %s", strerror(errno));
-            goto posix_spawn_fail_all;
-        }
         if (posix_spawn_file_actions_adddup2(&fa, stdin_pipe[READ_END], STDIN_FILENO) != 0) {
             SDL_SetError("posix_spawn_file_actions_adddup2 failed: %s", strerror(errno));
-            goto posix_spawn_fail_all;
-        }
-        if (posix_spawn_file_actions_addclose(&fa, stdin_pipe[READ_END]) != 0) {
-            SDL_SetError("posix_spawn_file_actions_addclose failed: %s", strerror(errno));
             goto posix_spawn_fail_all;
         }
         break;
@@ -261,25 +249,13 @@ bool SDL_SYS_CreateProcessWithProperties(SDL_Process *process, SDL_PropertiesID 
             SDL_SetError("posix_spawn_file_actions_adddup2 failed: %s", strerror(errno));
             goto posix_spawn_fail_all;
         }
-        if (posix_spawn_file_actions_addclose(&fa, fd) != 0) {
-            SDL_SetError("posix_spawn_file_actions_addclose failed: %s", strerror(errno));
-            goto posix_spawn_fail_all;
-        }
         break;
     case SDL_PROCESS_STDIO_APP:
         if (!CreatePipe(stdout_pipe)) {
             goto posix_spawn_fail_all;
         }
-        if (posix_spawn_file_actions_addclose(&fa, stdout_pipe[READ_END]) != 0) {
-            SDL_SetError("posix_spawn_file_actions_addclose failed: %s", strerror(errno));
-            goto posix_spawn_fail_all;
-        }
         if (posix_spawn_file_actions_adddup2(&fa, stdout_pipe[WRITE_END], STDOUT_FILENO) != 0) {
             SDL_SetError("posix_spawn_file_actions_adddup2 failed: %s", strerror(errno));
-            goto posix_spawn_fail_all;
-        }
-        if (posix_spawn_file_actions_addclose(&fa, stdout_pipe[WRITE_END]) != 0) {
-            SDL_SetError("posix_spawn_file_actions_addclose failed: %s", strerror(errno));
             goto posix_spawn_fail_all;
         }
         break;
@@ -309,25 +285,13 @@ bool SDL_SYS_CreateProcessWithProperties(SDL_Process *process, SDL_PropertiesID 
                 SDL_SetError("posix_spawn_file_actions_adddup2 failed: %s", strerror(errno));
                 goto posix_spawn_fail_all;
             }
-            if (posix_spawn_file_actions_addclose(&fa, fd) != 0) {
-                SDL_SetError("posix_spawn_file_actions_addclose failed: %s", strerror(errno));
-                goto posix_spawn_fail_all;
-            }
             break;
         case SDL_PROCESS_STDIO_APP:
             if (!CreatePipe(stderr_pipe)) {
                 goto posix_spawn_fail_all;
             }
-            if (posix_spawn_file_actions_addclose(&fa, stderr_pipe[READ_END]) != 0) {
-                SDL_SetError("posix_spawn_file_actions_addclose failed: %s", strerror(errno));
-                goto posix_spawn_fail_all;
-            }
             if (posix_spawn_file_actions_adddup2(&fa, stderr_pipe[WRITE_END], STDERR_FILENO) != 0) {
                 SDL_SetError("posix_spawn_file_actions_adddup2 failed: %s", strerror(errno));
-                goto posix_spawn_fail_all;
-            }
-            if (posix_spawn_file_actions_addclose(&fa, stderr_pipe[WRITE_END]) != 0) {
-                SDL_SetError("posix_spawn_file_actions_addclose failed: %s", strerror(errno));
                 goto posix_spawn_fail_all;
             }
             break;

--- a/test/testprocess.c
+++ b/test/testprocess.c
@@ -1010,7 +1010,7 @@ static const SDLTest_TestCaseReference processTestBatBadButVulnerability = {
 };
 
 static const SDLTest_TestCaseReference processTestFileRedirection = {
-    process_testFileRedirection, "process_testFileRedirection", "Test redirection from/to files", TEST_DISABLED
+    process_testFileRedirection, "process_testFileRedirection", "Test redirection from/to files", TEST_ENABLED
 };
 
 static const SDLTest_TestCaseReference *processTests[] = {


### PR DESCRIPTION
Fixes https://github.com/libsdl-org/SDL/issues/10997