### PR TITLE
[PS2SDK]: Remove some parameters from EXTRA_CFLAGS and ps2_drivers from ci.

### DIFF
--- a/.github/workflows/ps2.yaml
+++ b/.github/workflows/ps2.yaml
@@ -13,15 +13,6 @@ jobs:
         apk update 
         apk add cmake gmp mpc1 mpfr4 ninja pkgconf make git
 
-    # To be removed once ps2_drivers is part of PS2DEV
-    - name: Install ps2_drivers lib
-      run: |
-        git clone https://github.com/fjtrujy/ps2_drivers.git
-        cd ps2_drivers
-        make -j $(getconf _NPROCESSORS_ONLN) clean
-        make -j $(getconf _NPROCESSORS_ONLN)
-        make -j $(getconf _NPROCESSORS_ONLN) install
-
     - name: Configure (CMake)
       run: |
         cmake -S . -B build -G Ninja \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2725,7 +2725,7 @@ elseif(PSP)
   endif()
 
 elseif(PS2)
-  list(APPEND EXTRA_CFLAGS "-DPS2" "-D__PS2__" "-I$ENV{PS2SDK}/ports/include" "-I$ENV{PS2DEV}/gsKit/include")
+  list(APPEND EXTRA_CFLAGS "-I$ENV{PS2DEV}/gsKit/include")
 
   file(GLOB PS2_MAIN_SOURCES ${SDL2_SOURCE_DIR}/src/main/ps2/*.c)
   set(SDLMAIN_SOURCES ${SDLMAIN_SOURCES} ${PS2_MAIN_SOURCES})


### PR DESCRIPTION
This pr removes some parameters from EXTRA_CFLAGS as we have a new cmake ported by myself on [ps2sdk repository](https://github.com/ps2dev/ps2sdk/blob/master/samples/ps2dev.cmake) also removes the ps2_drivers from ci
