### PR TITLE
[RFC] clipboard: update the supported mime types when it's an external update

### DIFF
--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -845,6 +845,9 @@ typedef struct SDL_ClipboardEvent
     SDL_EventType type; /**< SDL_EVENT_CLIPBOARD_UPDATE */
     Uint32 reserved;
     Uint64 timestamp;   /**< In nanoseconds, populated using SDL_GetTicksNS() */
+    bool owner;       /**< are we owning the clipboard (internal update) */
+    Sint32 n_mime_types;     /**< number of mime types */
+    const char **mime_types; /**< current mime types */
 } SDL_ClipboardEvent;
 
 /**

--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -1377,7 +1377,8 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeAccel)(
 JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeClipboardChanged)(
     JNIEnv *env, jclass jcls)
 {
-    SDL_SendClipboardUpdate();
+    // TODO: compute new mime types
+    SDL_SendClipboardUpdate(false, NULL, 0);
 }
 
 // Low memory

--- a/src/events/SDL_clipboardevents.c
+++ b/src/events/SDL_clipboardevents.c
@@ -25,12 +25,17 @@
 #include "SDL_events_c.h"
 #include "SDL_clipboardevents_c.h"
 
-void SDL_SendClipboardUpdate(void)
+void SDL_SendClipboardUpdate(bool owner, char **mime_types, size_t n_mime_types)
 {
     if (SDL_EventEnabled(SDL_EVENT_CLIPBOARD_UPDATE)) {
         SDL_Event event;
         event.type = SDL_EVENT_CLIPBOARD_UPDATE;
-        event.clipboard.timestamp = 0;
+
+        SDL_ClipboardEvent *cevent = &event.clipboard;
+        cevent->timestamp = 0;
+        cevent->owner = owner;
+        cevent->mime_types = (const char **)mime_types;
+        cevent->n_mime_types = (Uint32)n_mime_types;
         SDL_PushEvent(&event);
     }
 }

--- a/src/events/SDL_clipboardevents_c.h
+++ b/src/events/SDL_clipboardevents_c.h
@@ -23,6 +23,6 @@
 #ifndef SDL_clipboardevents_c_h_
 #define SDL_clipboardevents_c_h_
 
-extern void SDL_SendClipboardUpdate(void);
+extern void SDL_SendClipboardUpdate(bool owner, char **mime_types, size_t n_mime_types);
 
 #endif // SDL_clipboardevents_c_h_

--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -235,6 +235,9 @@ static void SDL_TransferTemporaryMemoryToEvent(SDL_EventEntry *event)
         SDL_LinkTemporaryMemoryToEvent(event, event->event.drop.source);
         SDL_LinkTemporaryMemoryToEvent(event, event->event.drop.data);
         break;
+    case SDL_EVENT_CLIPBOARD_UPDATE:
+        SDL_LinkTemporaryMemoryToEvent(event, event->event.clipboard.mime_types);
+        break;
     default:
         break;
     }

--- a/src/video/SDL_clipboard_c.h
+++ b/src/video/SDL_clipboard_c.h
@@ -39,4 +39,7 @@ extern bool SDL_HasInternalClipboardData(SDL_VideoDevice *_this, const char *mim
 // General purpose clipboard text callback
 const void * SDLCALL SDL_ClipboardTextCallback(void *userdata, const char *mime_type, size_t *size);
 
+void SDLCALL SDL_FreeClipboardMimeTypes(SDL_VideoDevice *_this);
+char ** SDLCALL SDL_CopyClipboardMimeTypes(const char **clipboard_mime_types, size_t num_mime_types, bool temporary);
+
 #endif // SDL_clipboard_c_h_

--- a/src/video/cocoa/SDL_cocoaclipboard.m
+++ b/src/video/cocoa/SDL_cocoaclipboard.m
@@ -83,7 +83,8 @@ void Cocoa_CheckClipboardUpdate(SDL_CocoaVideoData *data)
         count = [pasteboard changeCount];
         if (count != data.clipboard_count) {
             if (data.clipboard_count) {
-                SDL_SendClipboardUpdate();
+                // TODO: compute mime types
+                SDL_SendClipboardUpdate(false, NULL, 0);
             }
             data.clipboard_count = count;
         }

--- a/src/video/uikit/SDL_uikitclipboard.m
+++ b/src/video/uikit/SDL_uikitclipboard.m
@@ -80,7 +80,8 @@ void UIKit_InitClipboard(SDL_VideoDevice *_this)
                                           object:nil
                                            queue:nil
                                       usingBlock:^(NSNotification *note) {
-                                        SDL_SendClipboardUpdate();
+                                        // TODO: compute mime types
+                                        SDL_SendClipboardUpdate(false, NULL, 0);
                                       }];
 
         data.pasteboardObserver = observer;

--- a/src/video/x11/SDL_x11clipboard.c
+++ b/src/video/x11/SDL_x11clipboard.c
@@ -38,7 +38,7 @@ static const char *text_mime_types[] = {
 };
 
 // Get any application owned window handle for clipboard association
-static Window GetWindow(SDL_VideoDevice *_this)
+Window GetWindow(SDL_VideoDevice *_this)
 {
     SDL_VideoData *data = _this->internal;
 

--- a/src/video/x11/SDL_x11clipboard.h
+++ b/src/video/x11/SDL_x11clipboard.h
@@ -41,5 +41,6 @@ extern bool X11_SetPrimarySelectionText(SDL_VideoDevice *_this, const char *text
 extern char *X11_GetPrimarySelectionText(SDL_VideoDevice *_this);
 extern bool X11_HasPrimarySelectionText(SDL_VideoDevice *_this);
 extern void X11_QuitClipboard(SDL_VideoDevice *_this);
+Window GetWindow(SDL_VideoDevice *_this);
 
 #endif // SDL_x11clipboard_h_

--- a/src/video/x11/SDL_x11video.c
+++ b/src/video/x11/SDL_x11video.c
@@ -403,6 +403,7 @@ static bool X11_VideoInit(SDL_VideoDevice *_this)
     GET_ATOM(_NET_WM_STATE_ABOVE);
     GET_ATOM(_NET_WM_STATE_SKIP_TASKBAR);
     GET_ATOM(_NET_WM_STATE_SKIP_PAGER);
+    GET_ATOM(_NET_WM_MOVERESIZE);
     GET_ATOM(_NET_WM_STATE_MODAL);
     GET_ATOM(_NET_WM_ALLOWED_ACTIONS);
     GET_ATOM(_NET_WM_ACTION_FULLSCREEN);
@@ -420,6 +421,9 @@ static bool X11_VideoInit(SDL_VideoDevice *_this)
     GET_ATOM(CLIPBOARD);
     GET_ATOM(INCR);
     GET_ATOM(SDL_SELECTION);
+    GET_ATOM(TARGETS);
+    GET_ATOM(SDL_FORMATS);
+    GET_ATOM(XdndAware);
     GET_ATOM(XdndEnter);
     GET_ATOM(XdndPosition);
     GET_ATOM(XdndStatus);

--- a/src/video/x11/SDL_x11video.h
+++ b/src/video/x11/SDL_x11video.h
@@ -82,6 +82,7 @@ struct SDL_VideoData
         Atom _NET_WM_STATE_SKIP_TASKBAR;
         Atom _NET_WM_STATE_SKIP_PAGER;
         Atom _NET_WM_STATE_MODAL;
+        Atom _NET_WM_MOVERESIZE;
         Atom _NET_WM_ALLOWED_ACTIONS;
         Atom _NET_WM_ACTION_FULLSCREEN;
         Atom _NET_WM_NAME;
@@ -98,6 +99,9 @@ struct SDL_VideoData
         Atom CLIPBOARD;
         Atom INCR;
         Atom SDL_SELECTION;
+        Atom TARGETS;
+        Atom SDL_FORMATS;
+        Atom XdndAware;
         Atom XdndEnter;
         Atom XdndPosition;
         Atom XdndStatus;

--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -2001,7 +2001,7 @@ void X11_AcceptDragAndDrop(SDL_Window *window, bool accept)
 {
     SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
-    Atom XdndAware = X11_XInternAtom(display, "XdndAware", False);
+    Atom XdndAware = data->videodata->atoms.XdndAware;
 
     if (accept) {
         Atom xdnd_version = 5;

--- a/src/video/x11/SDL_x11xfixes.c
+++ b/src/video/x11/SDL_x11xfixes.c
@@ -51,7 +51,7 @@ void X11_InitXfixes(SDL_VideoDevice *_this)
     int event, error;
     int fixes_opcode;
 
-    Atom XA_CLIPBOARD = X11_XInternAtom(data->display, "CLIPBOARD", 0);
+    Atom XA_CLIPBOARD = data->atoms.CLIPBOARD;
 
     if (!SDL_X11_HAVE_XFIXES ||
         !X11_XQueryExtension(data->display, "XFIXES", &fixes_opcode, &event, &error)) {


### PR DESCRIPTION
This patch modifies the clipboard handling so that when we receive an external clipboard update, if we call `SDL_GetClipboardMimeTypes()` during the treatment of a `SDL_EVENT_CLIPBOARD_UPDATE` it will return the available mime types.

## Description
This patch codes updates of the array of mime types in the `SDL_VideoDevice` when we receive an external clipboard change notification.

This PR is for comments, I'm open to other solutions like having the new mime types contained in the `SDL_ClipboardEvent`. Most platform have a notion of clipboard owner, perhaps that should also be indicated in the clipboard event so that we know if it's an internal or external update.

## Existing Issue(s)
This should solve #10598 at least with what we do in FreeRDP.
