### PR TITLE
Removed const qualifiers from SDL_CreateHashTable() parameter types

### DIFF
--- a/src/SDL_hashtable.c
+++ b/src/SDL_hashtable.c
@@ -55,10 +55,12 @@ struct SDL_HashTable
     bool stackable;
 };
 
-SDL_HashTable *SDL_CreateHashTable(void *data, const Uint32 num_buckets, const SDL_HashTable_HashFn hashfn,
-                                   const SDL_HashTable_KeyMatchFn keymatchfn,
-                                   const SDL_HashTable_NukeFn nukefn,
-                                   const bool stackable)
+SDL_HashTable *SDL_CreateHashTable(void *data,
+                                   Uint32 num_buckets,
+                                   SDL_HashTable_HashFn hashfn,
+                                   SDL_HashTable_KeyMatchFn keymatchfn,
+                                   SDL_HashTable_NukeFn nukefn,
+                                   bool stackable)
 {
     SDL_HashTable *table;
 

--- a/src/SDL_hashtable.h
+++ b/src/SDL_hashtable.h
@@ -30,11 +30,11 @@ typedef bool (*SDL_HashTable_KeyMatchFn)(const void *a, const void *b, void *dat
 typedef void (*SDL_HashTable_NukeFn)(const void *key, const void *value, void *data);
 
 extern SDL_HashTable *SDL_CreateHashTable(void *data,
-                                          const Uint32 num_buckets,
-                                          const SDL_HashTable_HashFn hashfn,
-                                          const SDL_HashTable_KeyMatchFn keymatchfn,
-                                          const SDL_HashTable_NukeFn nukefn,
-                                          const bool stackable);
+                                          Uint32 num_buckets,
+                                          SDL_HashTable_HashFn hashfn,
+                                          SDL_HashTable_KeyMatchFn keymatchfn,
+                                          SDL_HashTable_NukeFn nukefn,
+                                          bool stackable);
 
 extern void SDL_EmptyHashTable(SDL_HashTable *table);
 extern void SDL_DestroyHashTable(SDL_HashTable *table);


### PR DESCRIPTION
Decided in https://github.com/libsdl-org/SDL/issues/11032#issuecomment-2389656487