### PR TITLE
render: Restore previous policy for converting window/render coordinates.

### DIFF
--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -1441,6 +1441,13 @@ extern SDL_DECLSPEC bool SDLCALL SDL_GetRenderLogicalPresentationRect(SDL_Render
 /**
  * Get a point in render coordinates when given a point in window coordinates.
  *
+ * This takes into account several states:
+ *
+ * - The window dimensions.
+ * - The logical presentation settings (SDL_SetRenderLogicalPresentation)
+ * - The scale (SDL_SetRenderScale)
+ * - The viewport (SDL_SetRenderViewport)
+ *
  * \param renderer the rendering context.
  * \param window_x the x coordinate in window coordinates.
  * \param window_y the y coordinate in window coordinates.
@@ -1461,6 +1468,13 @@ extern SDL_DECLSPEC bool SDLCALL SDL_RenderCoordinatesFromWindow(SDL_Renderer *r
 /**
  * Get a point in window coordinates when given a point in render coordinates.
  *
+ * This takes into account several states:
+ *
+ * - The window dimensions.
+ * - The logical presentation settings (SDL_SetRenderLogicalPresentation)
+ * - The scale (SDL_SetRenderScale)
+ * - The viewport (SDL_SetRenderViewport)
+ *
  * \param renderer the rendering context.
  * \param x the x coordinate in render coordinates.
  * \param y the y coordinate in render coordinates.
@@ -1477,11 +1491,19 @@ extern SDL_DECLSPEC bool SDLCALL SDL_RenderCoordinatesFromWindow(SDL_Renderer *r
  *
  * \sa SDL_SetRenderLogicalPresentation
  * \sa SDL_SetRenderScale
+ * \sa SDL_SetRenderViewport
  */
 extern SDL_DECLSPEC bool SDLCALL SDL_RenderCoordinatesToWindow(SDL_Renderer *renderer, float x, float y, float *window_x, float *window_y);
 
 /**
  * Convert the coordinates in an event to render coordinates.
+ *
+ * This takes into account several states:
+ *
+ * - The window dimensions.
+ * - The logical presentation settings (SDL_SetRenderLogicalPresentation)
+ * - The scale (SDL_SetRenderScale)
+ * - The viewport (SDL_SetRenderViewport)
  *
  * Touch coordinates are converted from normalized coordinates in the window
  * to non-normalized rendering coordinates.

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -2806,6 +2806,10 @@ bool SDL_RenderCoordinatesFromWindow(SDL_Renderer *renderer, float window_x, flo
         render_y = ((render_y - dst->y) * src->h) / dst->h;
     }
 
+    const SDL_RenderViewState *view = &renderer->main_view;
+    render_x = (render_x / view->scale.x) - view->viewport.x;
+    render_y = (render_y / view->scale.y) - view->viewport.y;
+
     if (x) {
         *x = render_x;
     }
@@ -2818,6 +2822,10 @@ bool SDL_RenderCoordinatesFromWindow(SDL_Renderer *renderer, float window_x, flo
 bool SDL_RenderCoordinatesToWindow(SDL_Renderer *renderer, float x, float y, float *window_x, float *window_y)
 {
     CHECK_RENDERER_MAGIC(renderer, false);
+
+    const SDL_RenderViewState *view = &renderer->main_view;
+    x = (view->viewport.x + x) * view->scale.x;
+    y = (view->viewport.y + y) * view->scale.y;
 
     // Convert from render coordinates to pixels within the window
     if (renderer->logical_presentation_mode != SDL_LOGICAL_PRESENTATION_DISABLED) {
@@ -2861,6 +2869,7 @@ bool SDL_ConvertEventToRenderCoordinates(SDL_Renderer *renderer, SDL_Event *even
                 }
 
                 // Convert from pixels within the view to render coordinates
+                scale = (scale / renderer->main_view.scale.x);
                 event->motion.xrel *= scale;
             }
             if (event->motion.yrel != 0.0f) {
@@ -2875,6 +2884,7 @@ bool SDL_ConvertEventToRenderCoordinates(SDL_Renderer *renderer, SDL_Event *even
                 }
 
                 // Convert from pixels within the view to render coordinates
+                scale = (scale / renderer->main_view.scale.y);
                 event->motion.yrel *= scale;
             }
         }


### PR DESCRIPTION
Before this commit, it would adjust for the logical presentation settings. Now, it works as it did before the logical presentation render target was removed: it takes current viewport and scale into account, as well.

Fixes #10978.
