### PR TITLE
Remove redundant SDL_Vulkan_GetResultString() declaration

### DIFF
--- a/src/render/vulkan/SDL_render_vulkan.c
+++ b/src/render/vulkan/SDL_render_vulkan.c
@@ -39,8 +39,6 @@
 #include "../../video/SDL_pixels_c.h"
 #include "SDL_shaders_vulkan.h"
 
-extern const char *SDL_Vulkan_GetResultString(VkResult result);
-
 #define VULKAN_FUNCTIONS()                                              \
     VULKAN_DEVICE_FUNCTION(vkAcquireNextImageKHR)                       \
     VULKAN_DEVICE_FUNCTION(vkAllocateCommandBuffers)                    \


### PR DESCRIPTION
`SDL_Vulkan_GetResultString()` is already declared in `src/video/SDL_vulkan_internal.h`:
https://github.com/libsdl-org/SDL/blob/07fd88d2413db6157dd32d3659e4dbef68272b8e/src/video/SDL_vulkan_internal.h#L56