### PR TITLE
Always set checked_monotonic_time when calling CheckMonotonicTime()

### DIFF
--- a/src/timer/unix/SDL_systimer.c
+++ b/src/timer/unix/SDL_systimer.c
@@ -73,7 +73,7 @@ static void CheckMonotonicTime(void)
     struct timespec value;
     if (clock_gettime(SDL_MONOTONIC_CLOCK, &value) == 0) {
         has_monotonic_time = true;
-    } else
+    }
 #elif defined(SDL_PLATFORM_APPLE)
     if (mach_timebase_info(&mach_base_info) == 0) {
         has_monotonic_time = true;


### PR DESCRIPTION
The function `CheckMonotonicTime()` doesn't set `checked_monotonic_time` to `true` if `clock_gettime()` succeedes, because of a trailing `else` statement in line 76:
https://github.com/libsdl-org/SDL/blob/020fb6889ccb5a8ac7e6b16e375de935514f09a6/src/timer/unix/SDL_systimer.c#L70-L83

This commit assumes, that the `checked_monotonic_time` variable should always be set, when the function `CheckMonotonicTime()` is called.

The last big rehaul of this function happened in 8121bbd083b5a568709305270b554f2add3ba4a1