### PR TITLE
test: Make blit_testExampleApplicationRender work on big endian

### DIFF
--- a/test/testautomation_images.c
+++ b/test/testautomation_images.c
@@ -2374,7 +2374,7 @@ SDL_Surface *SDLTest_ImageBlendingBackground(void)
     SDL_Surface *surface = SDL_CreateSurfaceFrom(
             SDLTest_imageRainbowBackground.width,
             SDLTest_imageRainbowBackground.height,
-            SDL_PIXELFORMAT_ARGB8888,
+            SDL_PIXELFORMAT_BGRA32,
             (void *)SDLTest_imageRainbowBackground.pixel_data,
             SDLTest_imageRainbowBackground.width * SDLTest_imageRainbowBackground.bytes_per_pixel);
     return surface;
@@ -2548,7 +2548,7 @@ SDL_Surface *SDLTest_ImageBlendingSprite(void)
     SDL_Surface *surface = SDL_CreateSurfaceFrom(
             SDLTest_imageTransparentSprite.width,
             SDLTest_imageTransparentSprite.height,
-            SDL_PIXELFORMAT_ARGB8888,
+            SDL_PIXELFORMAT_BGRA32,
             (void *)SDLTest_imageTransparentSprite.pixel_data,
             SDLTest_imageTransparentSprite.width * SDLTest_imageTransparentSprite.bytes_per_pixel);
     return surface;


### PR DESCRIPTION
Changed image data pixel format to BGRA32.

## Description

Tested on x86_64 and PowerPC.

## Existing Issue(s)

#10794 
