### PR TITLE
x11: Refresh the global cursor coordinates when confining the pointer

### DIFF
--- a/src/video/x11/SDL_x11mouse.c
+++ b/src/video/x11/SDL_x11mouse.c
@@ -412,6 +412,11 @@ static bool X11_CaptureMouse(SDL_Window *window)
             if (rc != GrabSuccess) {
                 return SDL_SetError("X server refused mouse capture");
             }
+
+            if (data->mouse_grabbed) {
+                // XGrabPointer can warp the cursor when confining, so update the coordinates.
+                data->videodata->global_mouse_changed = true;
+            }
         }
     } else if (mouse_focus) {
         SDL_UpdateWindowGrab(mouse_focus);


### PR DESCRIPTION
XGrabPointer can warp the cursor into the window when confining, so set the flag to refresh the global coordinates when queried.

Fixes #8090