### PR TITLE
Log app ID as SYSTEM/INFO during initialization

### DIFF
--- a/src/SDL.c
+++ b/src/SDL.c
@@ -267,6 +267,7 @@ void SDL_InitMainThread(void)
         SDL_LogInfo(SDL_LOG_CATEGORY_SYSTEM, "App version: %s", value ? value : "<unspecified>");
         value = SDL_GetAppMetadataProperty(SDL_PROP_APP_METADATA_IDENTIFIER_STRING);
         SDL_LogInfo(SDL_LOG_CATEGORY_SYSTEM, "App ID: %s", value ? value : "<unspecified>");
+        SDL_LogInfo(SDL_LOG_CATEGORY_SYSTEM, "SDL revision: %s", SDL_REVISION);
 
         done_info = true;
     }

--- a/src/SDL.c
+++ b/src/SDL.c
@@ -251,10 +251,25 @@ void SDL_SetMainReady(void)
 // Initialize all the subsystems that require initialization before threads start
 void SDL_InitMainThread(void)
 {
+    static bool done_info = false;
+
     SDL_InitTLSData();
     SDL_InitEnvironment();
     SDL_InitTicks();
     SDL_InitFilesystem();
+
+    if (!done_info) {
+        const char *value;
+
+        value = SDL_GetAppMetadataProperty(SDL_PROP_APP_METADATA_NAME_STRING);
+        SDL_LogInfo(SDL_LOG_CATEGORY_SYSTEM, "App name: %s", value);
+        value = SDL_GetAppMetadataProperty(SDL_PROP_APP_METADATA_VERSION_STRING);
+        SDL_LogInfo(SDL_LOG_CATEGORY_SYSTEM, "App version: %s", value ? value : "<unspecified>");
+        value = SDL_GetAppMetadataProperty(SDL_PROP_APP_METADATA_IDENTIFIER_STRING);
+        SDL_LogInfo(SDL_LOG_CATEGORY_SYSTEM, "App ID: %s", value ? value : "<unspecified>");
+
+        done_info = true;
+    }
 }
 
 static void SDL_QuitMainThread(void)


### PR DESCRIPTION
This is not shown by default, but will be shown when using SDL_LOGGING=system=info or higher, where it will hopefully nudge app authors towards initializing this information.