### PR TITLE
fix microphone permission and feature flags being spread out

### DIFF
--- a/android-project/app/src/main/AndroidManifest.xml
+++ b/android-project/app/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
 
     <!-- Audio recording support -->
     <!-- if you want to record audio, uncomment this. -->
+    <!-- <uses-permission android:name="android.permission.RECORD_AUDIO" /> -->
     <!-- <uses-feature
         android:name="android.hardware.microphone"
         android:required="false" /> -->
@@ -54,9 +55,6 @@
 
     <!-- Allow access to the vibrator -->
     <uses-permission android:name="android.permission.VIBRATE" />
-
-    <!-- if you want to record audio, uncomment this. -->
-    <!-- <uses-permission android:name="android.permission.RECORD_AUDIO" /> -->
 
     <!-- Create a Java class extending SDLActivity and place it in a
          directory under app/src/main/java matching the package, e.g. app/src/main/java/com/gamemaker/game/MyGame.java


### PR DESCRIPTION
I lost some time on wondering why audio was only partly working, turns out I only had specified the feature usage, but not the permission, which was hiding a couple lines below in the manifest I copied from the sdl example.

## Description
Simply move 1 line up in the manifest and delete a redundant one.
This now mimics how Camera looks.
