### PR TITLE
VisualC-GDK: fix tests on Xbox

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -1244,8 +1244,10 @@ extern "C" {
  *
  * The variable can be set to the following values:
  *
- * - "0": GameInput is not used. (default)
+ * - "0": GameInput is not used.
  * - "1": GameInput is used.
+ *
+ * The default is "1" on GDK platforms, and "0" otherwise.
  *
  * This hint should be set before SDL is initialized.
  *

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -6105,6 +6105,8 @@ static bool D3D12_INTERNAL_CreateSwapchain(
     windowData->swapchainComposition = swapchain_composition;
     windowData->swapchainColorSpace = DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
     windowData->frameCounter = 0;
+    windowData->width = width;
+    windowData->height = height;
 
     // Precache blit pipelines for the swapchain format
     for (Uint32 i = 0; i < 5; i += 1) {

--- a/src/joystick/gdk/SDL_gameinputjoystick.c
+++ b/src/joystick/gdk/SDL_gameinputjoystick.c
@@ -28,6 +28,13 @@
 #define COBJMACROS
 #include <gameinput.h>
 
+// Default value for SDL_HINT_JOYSTICK_GAMEINPUT
+#if defined(SDL_PLATFORM_GDK)
+#define SDL_GAMEINPUT_DEFAULT true
+#else
+#define SDL_GAMEINPUT_DEFAULT false
+#endif
+
 enum
 {
     SDL_GAMEPAD_BUTTON_GAMEINPUT_SHARE = 11
@@ -234,7 +241,7 @@ static bool GAMEINPUT_JoystickInit(void)
 {
     HRESULT hR;
 
-    if (!SDL_GetHintBoolean(SDL_HINT_JOYSTICK_GAMEINPUT, false)) {
+    if (!SDL_GetHintBoolean(SDL_HINT_JOYSTICK_GAMEINPUT, SDL_GAMEINPUT_DEFAULT)) {
         return true;
     }
 

--- a/test/testcontroller.c
+++ b/test/testcontroller.c
@@ -2005,6 +2005,10 @@ int main(int argc, char *argv[])
     SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
     SDL_SetHint(SDL_HINT_JOYSTICK_LINUX_DEADZONES, "1");
 
+#if SDL_PLATFORM_GDK
+    SDL_SetHint(SDL_HINT_JOYSTICK_GAMEINPUT, "1");
+#endif
+
     /* Enable input debug logging */
     SDL_SetLogPriority(SDL_LOG_CATEGORY_INPUT, SDL_LOG_PRIORITY_DEBUG);
 

--- a/test/testcontroller.c
+++ b/test/testcontroller.c
@@ -2005,10 +2005,6 @@ int main(int argc, char *argv[])
     SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
     SDL_SetHint(SDL_HINT_JOYSTICK_LINUX_DEADZONES, "1");
 
-#if SDL_PLATFORM_GDK
-    SDL_SetHint(SDL_HINT_JOYSTICK_GAMEINPUT, "1");
-#endif
-
     /* Enable input debug logging */
     SDL_SetLogPriority(SDL_LOG_CATEGORY_INPUT, SDL_LOG_PRIORITY_DEBUG);
 


### PR DESCRIPTION
Tests included in VisualC-GDK now default to the GPU renderer, but crash on Xbox because the swap chain size isn't set, causing the backbuffer texture creation to fail.

The second change just enables the GameInput joystick driver in `testcontroller`, which is the only system driver initialized on Xbox right now.