### PR TITLE
Old env vars as fallback for SDL_VIDEO_DRIVER + SDL_AUDIO_DRIVER

### DIFF
--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -798,7 +798,7 @@ The following functions have been removed:
 
 Calling SDL_GetHint() with the name of the hint being changed from within a hint callback will now return the new value rather than the old value. The old value is still passed as a parameter to the hint callback.
 
-The environment variables SDL_VIDEODRIVER and SDL_AUDIODRIVER have been renamed to SDL_VIDEO_DRIVER and SDL_AUDIO_DRIVER.
+The environment variables SDL_VIDEODRIVER and SDL_AUDIODRIVER have been renamed to SDL_VIDEO_DRIVER and SDL_AUDIO_DRIVER, but the old names are still supported as a fallback.
 
 The environment variables SDL_VIDEO_X11_WMCLASS and SDL_VIDEO_WAYLAND_WMCLASS have been removed and replaced by either using the appindentifier param to SDL_SetAppMetadata() or setting SDL_PROP_APP_METADATA_IDENTIFIER_STRING with SDL_SetAppMetadataProperty()
 


### PR DESCRIPTION
Especially SDL_VIDEODRIVER is commonly used to use the native Wayland backend, so I think it's a good idea to keep supporting the old name instead of forcing users to find out that they now have to add an underscore..
Not sure how popular SDL_AUDIODRIVER is, but with all the audio backends that exist on Linux alone I'm sure some people use it to work around sound issues.

## Description

I'm not 100% sure what the best way to do this is, but the easiest way to do it cleanly seemed to be to implement a small wrapper around SDL_getenv() in SDL_hints.c that, if SDL_getenv() returned NULL for the given name (i.e. the "proper" SDL3 hint string), checks whether it was SDL_HINT_VIDEO_DRIVER or SDL_HINT_AUDIO_DRIVER and tries again with "SDL_VIDEODRIVER" and "SDL_AUDIODRIVER".

This is not overly generic and might in theory get a bit ugly if someone wanted to add fallbacks for many more environment variables, but:
- Doing it here makes sure that all the hint priority logic works as it should.  
  For example, if the program calls `SDL_SetHintWithPriority(SDL_HINT_VIDEO_DRIVER, "x11", SDL_HINT_OVERRIDE)`, that *will* override the environment variable, no matter how it's called - this would be a lot harder to do when implementing the fallback at the call-sites of `SDL_GetHint(SDL_HINT_VIDEO_DRIVER)` - but on the other hand, if the program uses normal SDL_SetHint() (or a priority < SDL_HINT_OVERRIDE), the fallback environment variable will override that just like the "proper" environment variable would
- Doing it here makes sure that SDL_ResetHint() takes the fallback env var into account
- It's simple
- I don't think that too many similar cases where one would want a fallback will turn up, so I guess it's good enough - and if not it can still be refactored

## Existing Issue(s)
Fixes #11115

----

Marking this as a draft until I've tested it a bit more