### PR TITLE
Allow linear interpolation of the font textures

### DIFF
--- a/src/test/SDL_test_font.c
+++ b/src/test/SDL_test_font.c
@@ -3239,8 +3239,6 @@ bool SDLTest_DrawCharacter(SDL_Renderer *renderer, float x, float y, Uint32 c)
         if (cache->charTextureCache[ci] == NULL) {
             return false;
         }
-
-        SDL_SetTextureScaleMode(cache->charTextureCache[ci], SDL_SCALEMODE_NEAREST);
     }
 
     /*


### PR DESCRIPTION
With the recent changes to logical presentation, this is necessary for the font to look good when scaled.

Fixes https://github.com/libsdl-org/SDL/issues/11123