### PR TITLE
[SDL2] x11: Set correct clipboard target type in `SelectionRequest` handling

### DIFF
--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -676,9 +676,10 @@ static void X11_HandleClipboardEvent(_THIS, const XEvent *xevent)
                                            &overflow, &seln_data) == Success) {
                     if (seln_format != None) {
                         X11_XChangeProperty(display, req->requestor, req->property,
-                                            sevent.xselection.target, seln_format, PropModeReplace,
+                                            req->target, 8, PropModeReplace,
                                             seln_data, nbytes);
                         sevent.xselection.property = req->property;
+                        sevent.xselection.target = req->target;
                         X11_XFree(seln_data);
                         break;
                     } else {


### PR DESCRIPTION
Pasting from an SDL2 application to some targets (like chromium/electron-based applications) causes them to hang.

## Description
This was already fixed by #7703 for SDL3, but the change was never backported.
