### PR TITLE
gpu: vulkan: Fix an uninitialised structure in SDL_BlitGPUTexture()

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -8949,6 +8949,7 @@ static void VULKAN_Blit(
     // Using BeginRenderPass to clear because vkCmdClearColorImage requires barriers anyway
     if (info->load_op == SDL_GPU_LOADOP_CLEAR) {
         SDL_GPUColorTargetInfo targetInfo;
+        SDL_zero(targetInfo);
         targetInfo.texture = info->destination.texture;
         targetInfo.mip_level = info->destination.mip_level;
         targetInfo.layer_or_depth_plane = info->destination.layer_or_depth_plane;


### PR DESCRIPTION
The SDL_GPUColorTargetInfo structure needs to be zeroed, as otherwise we can end up trying to create a resolve_texture which doesn't exist, causing a rather difficult-to-debug segfault when calling SDL_BlitGPUTexture() with a load op of SDL_GPU_LOADOP_CLEAR.