### PR TITLE
Rename hint string literal SDL_HINT_MAC_SCROLL_MOMENTUM

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2303,7 +2303,7 @@ extern "C" {
  *
  * \since This hint is available since SDL 3.0.0.
  */
-#define SDL_HINT_MAC_SCROLL_MOMENTUM "SDL_HINT_MAC_SCROLL_MOMENTUM"
+#define SDL_HINT_MAC_SCROLL_MOMENTUM "SDL_MAC_SCROLL_MOMENTUM"
 
 /**
  * Request SDL_AppIterate() be called at a specific rate.


### PR DESCRIPTION
Replacing `SDL_HINT_` with just `SDL_` in string literal for hint `SDL_HINT_MAC_SCROLL_MOMENTUM`.

This hint was added in c2b98e21bade35bcccba249f5e74ba08d5b88e5a
after the 3.1.3 preview