### PR TITLE
Set hint SDL_HINT_MAC_SCROLL_MOMENTUM version to SDL 3.1.4.

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2301,7 +2301,7 @@ extern "C" {
  *
  * This hint needs to be set before SDL_Init().
  *
- * \since This hint is available since SDL 3.0.0.
+ * \since This hint is available since SDL 3.1.4.
  */
 #define SDL_HINT_MAC_SCROLL_MOMENTUM "SDL_MAC_SCROLL_MOMENTUM"
 


### PR DESCRIPTION
This was added after 3.1.3 preview.