### PR TITLE
explicit cast to int in SDL_bits

### DIFF
--- a/include/SDL3/SDL_bits.h
+++ b/include/SDL3/SDL_bits.h
@@ -85,7 +85,7 @@ SDL_FORCE_INLINE int SDL_MostSignificantBitIndex32(Uint32 x)
 #elif defined(_MSC_VER)
     unsigned long index;
     if (_BitScanReverse(&index, x)) {
-        return index;
+        return (int)index;
     }
     return -1;
 #else


### PR DESCRIPTION
## Context
Since SDL3, SDL_bits.h is included with SDL.h, which wasn't the case in SDL2. Because of this, when compiling with clang on windows(msvc) and using the _-Werror_ and _-Wsign-conversion_ flags, the compiler warns of an implicit sign conversion on 
_SDL_MostSignificantBitIndex32_ on source files that include <SDL/SDL3.h>.

## Description
The change adds an explicit cast to this specific case, which is the only code path that does not return an int direcly. Since the conversion is done anyways, I believe there's no harm in making it an explicit cast.

