### PR TITLE
Add SDL_ShowFileDialogWithProperties with some more options

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -30,6 +30,7 @@ LOCAL_SRC_FILES := \
 	$(wildcard $(LOCAL_PATH)/src/core/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/core/android/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/cpuinfo/*.c) \
+	$(LOCAL_PATH)/src/dialog/SDL_dialog.c \
 	$(LOCAL_PATH)/src/dialog/SDL_dialog_utils.c \
 	$(LOCAL_PATH)/src/dialog/android/SDL_androiddialog.c \
 	$(wildcard $(LOCAL_PATH)/src/dynapi/*.c) \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2874,6 +2874,7 @@ endif()
 
 if (SDL_DIALOG)
   sdl_sources(${SDL3_SOURCE_DIR}/src/dialog/SDL_dialog_utils.c)
+  sdl_sources(${SDL3_SOURCE_DIR}/src/dialog/SDL_dialog.c)
   if(ANDROID)
     sdl_sources(${SDL3_SOURCE_DIR}/src/dialog/android/SDL_androiddialog.c)
     set(HAVE_SDL_DIALOG TRUE)

--- a/VisualC-GDK/SDL/SDL.vcxproj
+++ b/VisualC-GDK/SDL/SDL.vcxproj
@@ -517,6 +517,7 @@
     </ClCompile>
     <ClCompile Include="..\..\src\camera\dummy\SDL_camera_dummy.c" />
     <ClCompile Include="..\..\src\camera\SDL_camera.c" />
+    <ClCompile Include="..\..\src\dialog\SDL_dialog.c" />
     <ClCompile Include="..\..\src\dialog\SDL_dialog_utils.c" />
     <ClCompile Include="..\..\src\filesystem\SDL_filesystem.c" />
     <ClCompile Include="..\..\src\filesystem\windows\SDL_sysfsops.c" />

--- a/VisualC-GDK/SDL/SDL.vcxproj.filters
+++ b/VisualC-GDK/SDL/SDL.vcxproj.filters
@@ -7,6 +7,9 @@
     <ClCompile Include="..\..\src\dialog\SDL_dialog_utils.c">
       <Filter>dialog</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\dialog\SDL_dialog.c">
+      <Filter>dialog</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\filesystem\SDL_filesystem.c">
       <Filter>filesystem</Filter>
     </ClCompile>

--- a/VisualC/SDL/SDL.vcxproj
+++ b/VisualC/SDL/SDL.vcxproj
@@ -412,6 +412,7 @@
     <ClCompile Include="..\..\src\camera\dummy\SDL_camera_dummy.c" />
     <ClCompile Include="..\..\src\camera\mediafoundation\SDL_camera_mediafoundation.c" />
     <ClCompile Include="..\..\src\camera\SDL_camera.c" />
+    <ClCompile Include="..\..\src\dialog\SDL_dialog.c" />
     <ClCompile Include="..\..\src\dialog\SDL_dialog_utils.c" />
     <ClCompile Include="..\..\src\filesystem\SDL_filesystem.c" />
     <ClCompile Include="..\..\src\filesystem\windows\SDL_sysfsops.c" />

--- a/VisualC/SDL/SDL.vcxproj.filters
+++ b/VisualC/SDL/SDL.vcxproj.filters
@@ -950,6 +950,9 @@
     <ClCompile Include="..\..\src\camera\SDL_camera.c">
       <Filter>camera</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\dialog\SDL_dialog.c">
+      <Filter>dialog</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\dialog\SDL_dialog_utils.c">
       <Filter>dialog</Filter>
     </ClCompile>

--- a/include/SDL3/SDL_dialog.h
+++ b/include/SDL3/SDL_dialog.h
@@ -30,6 +30,7 @@
 
 #include <SDL3/SDL_stdinc.h>
 #include <SDL3/SDL_error.h>
+#include <SDL3/SDL_properties.h>
 #include <SDL3/SDL_video.h>
 
 #include <SDL3/SDL_begin_code.h>
@@ -55,6 +56,7 @@ extern "C" {
  * \sa SDL_ShowOpenFileDialog
  * \sa SDL_ShowSaveFileDialog
  * \sa SDL_ShowOpenFolderDialog
+ * \sa SDL_ShowFileDialogWithProperties
  */
 typedef struct SDL_DialogFileFilter
 {
@@ -93,13 +95,12 @@ typedef struct SDL_DialogFileFilter
  * \sa SDL_ShowOpenFileDialog
  * \sa SDL_ShowSaveFileDialog
  * \sa SDL_ShowOpenFolderDialog
+ * \sa SDL_ShowFileDialogWithProperties
  */
 typedef void (SDLCALL *SDL_DialogFileCallback)(void *userdata, const char * const *filelist, int filter);
 
 /**
  * Displays a dialog that lets the user select a file on their filesystem.
- *
- * This function should only be invoked from the main thread.
  *
  * This is an asynchronous function; it will return immediately, and the
  * result will be passed to the callback.
@@ -127,12 +128,17 @@ typedef void (SDLCALL *SDL_DialogFileCallback)(void *userdata, const char * cons
  *               Not all platforms support this option.
  * \param filters a list of filters, may be NULL. Not all platforms support
  *                this option, and platforms that do support it may allow the
- *                user to ignore the filters.
+ *                user to ignore the filters. If non-NULL, it must remain valid
+ *                at least until the callback is invoked.
  * \param nfilters the number of filters. Ignored if filters is NULL.
  * \param default_location the default folder or file to start the dialog at,
  *                         may be NULL. Not all platforms support this option.
  * \param allow_many if non-zero, the user will be allowed to select multiple
  *                   entries. Not all platforms support this option.
+ *
+ * \threadsafety This function should be called only from the main thread. The
+ *               callback may be invoked from the same thread or from a
+ *               different one, depending on the OS's constraints.
  *
  * \since This function is available since SDL 3.1.3.
  *
@@ -140,14 +146,13 @@ typedef void (SDLCALL *SDL_DialogFileCallback)(void *userdata, const char * cons
  * \sa SDL_DialogFileFilter
  * \sa SDL_ShowSaveFileDialog
  * \sa SDL_ShowOpenFolderDialog
+ * \sa SDL_ShowFileDialogWithProperties
  */
 extern SDL_DECLSPEC void SDLCALL SDL_ShowOpenFileDialog(SDL_DialogFileCallback callback, void *userdata, SDL_Window *window, const SDL_DialogFileFilter *filters, int nfilters, const char *default_location, bool allow_many);
 
 /**
  * Displays a dialog that lets the user choose a new or existing file on their
  * filesystem.
- *
- * This function should only be invoked from the main thread.
  *
  * This is an asynchronous function; it will return immediately, and the
  * result will be passed to the callback.
@@ -174,10 +179,15 @@ extern SDL_DECLSPEC void SDLCALL SDL_ShowOpenFileDialog(SDL_DialogFileCallback c
  *               Not all platforms support this option.
  * \param filters a list of filters, may be NULL. Not all platforms support
  *                this option, and platforms that do support it may allow the
- *                user to ignore the filters.
+ *                user to ignore the filters. If non-NULL, it must remain valid
+ *                at least until the callback is invoked.
  * \param nfilters the number of filters. Ignored if filters is NULL.
  * \param default_location the default folder or file to start the dialog at,
  *                         may be NULL. Not all platforms support this option.
+ *
+ * \threadsafety This function should be called only from the main thread. The
+ *               callback may be invoked from the same thread or from a
+ *               different one, depending on the OS's constraints.
  *
  * \since This function is available since SDL 3.1.3.
  *
@@ -185,13 +195,12 @@ extern SDL_DECLSPEC void SDLCALL SDL_ShowOpenFileDialog(SDL_DialogFileCallback c
  * \sa SDL_DialogFileFilter
  * \sa SDL_ShowOpenFileDialog
  * \sa SDL_ShowOpenFolderDialog
+ * \sa SDL_ShowFileDialogWithProperties
  */
 extern SDL_DECLSPEC void SDLCALL SDL_ShowSaveFileDialog(SDL_DialogFileCallback callback, void *userdata, SDL_Window *window, const SDL_DialogFileFilter *filters, int nfilters, const char *default_location);
 
 /**
  * Displays a dialog that lets the user select a folder on their filesystem.
- *
- * This function should only be invoked from the main thread.
  *
  * This is an asynchronous function; it will return immediately, and the
  * result will be passed to the callback.
@@ -222,13 +231,82 @@ extern SDL_DECLSPEC void SDLCALL SDL_ShowSaveFileDialog(SDL_DialogFileCallback c
  * \param allow_many if non-zero, the user will be allowed to select multiple
  *                   entries. Not all platforms support this option.
  *
+ * \threadsafety This function should be called only from the main thread. The
+ *               callback may be invoked from the same thread or from a
+ *               different one, depending on the OS's constraints.
+ *
  * \since This function is available since SDL 3.1.3.
  *
  * \sa SDL_DialogFileCallback
  * \sa SDL_ShowOpenFileDialog
  * \sa SDL_ShowSaveFileDialog
+ * \sa SDL_ShowFileDialogWithProperties
  */
 extern SDL_DECLSPEC void SDLCALL SDL_ShowOpenFolderDialog(SDL_DialogFileCallback callback, void *userdata, SDL_Window *window, const char *default_location, bool allow_many);
+
+typedef enum SDL_FileDialogType {
+  SDL_FILEDIALOG_OPENFILE,
+  SDL_FILEDIALOG_SAVEFILE,
+  SDL_FILEDIALOG_OPENFOLDER
+} SDL_FileDialogType;
+
+#define SDL_PROP_FILE_DIALOG_FILTERS_POINTER     "SDL.filedialog.filters"
+#define SDL_PROP_FILE_DIALOG_NFILTERS_NUMBER     "SDL.filedialog.nfilters"
+#define SDL_PROP_FILE_DIALOG_WINDOW_POINTER      "SDL.filedialog.window"
+#define SDL_PROP_FILE_DIALOG_LOCATION_STRING     "SDL.filedialog.location"
+#define SDL_PROP_FILE_DIALOG_MANY_BOOLEAN        "SDL.filedialog.many"
+#define SDL_PROP_FILE_DIALOG_TITLE_STRING        "SDL.filedialog.title"
+#define SDL_PROP_FILE_DIALOG_ACCEPT_STRING       "SDL.filedialog.accept"
+#define SDL_PROP_FILE_DIALOG_CANCEL_STRING       "SDL.filedialog.cancel"
+
+/**
+ * Create and launch a file dialog with the specified properties.
+ *
+ * These are the supported properties:
+ *
+ * - `SDL_PROP_FILE_DIALOG_FILTERS_POINTER`: a pointer to a list of
+ *   SDL_DialogFileFilter's, which will be used as filters for file-based
+ *   selections. Ignored if the dialog is an "Open Folder" dialog. If non-NULL,
+ *   the array of filters must remain valid at least until the callback is
+ *   invoked.
+ * - `SDL_PROP_FILE_DIALOG_NFILTERS_NUMBER`: the number of filters in the array
+ *   of filters, if it exists.
+ * - `SDL_PROP_FILE_DIALOG_WINDOW_POINTER`: the window that the dialog should
+ *   be modal for.
+ * - `SDL_PROP_FILE_DIALOG_LOCATION_STRING`: the default folder or file to
+ *   start the dialog at.
+ * - `SDL_PROP_FILE_DIALOG_MANY_BOOLEAN`: true to allow the user to select more
+ *   than one entry.
+ * - `SDL_PROP_FILE_DIALOG_TITLE_STRING`: the title for the dialog.
+ * - `SDL_PROP_FILE_DIALOG_ACCEPT_STRING`: the label that the accept button
+ *   should have.
+ * - `SDL_PROP_FILE_DIALOG_CANCEL_STRING`: the label that the cancel button
+ *   should have.
+ *
+ * Note that each platform may or may not support any of the properties.
+ *
+ * \param type the type of file dialog.
+ * \param callback a function pointer to be invoked when the user selects a
+ *                 file and accepts, or cancels the dialog, or an error
+ *                 occurs.
+ * \param userdata an optional pointer to pass extra data to the callback when
+ *                 it will be invoked.
+ * \param props the properties to use.
+ *
+ * \threadsafety This function should be called only from the main thread. The
+ *               callback may be invoked from the same thread or from a
+ *               different one, depending on the OS's constraints.
+ *
+ * \since This function is available since SDL 3.2.0.
+ *
+ * \sa SDL_FileDialogType
+ * \sa SDL_DialogFileCallback
+ * \sa SDL_DialogFileFilter
+ * \sa SDL_ShowOpenFileDialog
+ * \sa SDL_ShowSaveFileDialog
+ * \sa SDL_ShowOpenFolderDialog
+ */
+extern SDL_DECLSPEC void SDLCALL SDL_ShowFileDialogWithProperties(SDL_FileDialogType type, SDL_DialogFileCallback callback, void *userdata, SDL_PropertiesID props);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/src/dialog/SDL_dialog.c
+++ b/src/dialog/SDL_dialog.c
@@ -1,0 +1,103 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+#include "SDL_internal.h"
+
+#include "SDL_dialog.h"
+#include "SDL_dialog_utils.h"
+
+void SDL_ShowFileDialogWithProperties(SDL_FileDialogType type, SDL_DialogFileCallback callback, void *userdata, SDL_PropertiesID props)
+{
+    if (!callback) {
+        return;
+    }
+
+    SDL_DialogFileFilter *filters = SDL_GetPointerProperty(props, SDL_PROP_FILE_DIALOG_FILTERS_POINTER, NULL);
+    int nfilters = (int) SDL_GetNumberProperty(props, SDL_PROP_FILE_DIALOG_NFILTERS_NUMBER, -1);
+
+    if (filters && nfilters == -1) {
+        SDL_SetError("Set filter pointers, but didn't set number of filters (SDL_PROP_FILE_DIALOG_NFILTERS_NUMBER)");
+        callback(userdata, NULL, -1);
+        return;
+    }
+
+    const char *msg = validate_filters(filters, nfilters);
+
+    if (msg) {
+        SDL_SetError("Invalid dialog file filters: %s", msg);
+        callback(userdata, NULL, -1);
+        return;
+    }
+
+    switch (type) {
+    case SDL_FILEDIALOG_OPENFILE:
+    case SDL_FILEDIALOG_SAVEFILE:
+    case SDL_FILEDIALOG_OPENFOLDER:
+        SDL_SYS_ShowFileDialogWithProperties(type, callback, userdata, props);
+        break;
+
+    default:
+        SDL_SetError("Unsupported file dialog type: %d", (int) type);
+        callback(userdata, NULL, -1);
+        break;
+    };
+}
+
+void SDL_ShowOpenFileDialog(SDL_DialogFileCallback callback, void *userdata, SDL_Window *window, const SDL_DialogFileFilter *filters, int nfilters, const char *default_location, bool allow_many)
+{
+    SDL_PropertiesID props = SDL_CreateProperties();
+
+    SDL_SetPointerProperty(props, SDL_PROP_FILE_DIALOG_FILTERS_POINTER, (void *) filters);
+    SDL_SetNumberProperty(props, SDL_PROP_FILE_DIALOG_NFILTERS_NUMBER, nfilters);
+    SDL_SetPointerProperty(props, SDL_PROP_FILE_DIALOG_WINDOW_POINTER, window);
+    SDL_SetStringProperty(props, SDL_PROP_FILE_DIALOG_LOCATION_STRING, default_location);
+    SDL_SetBooleanProperty(props, SDL_PROP_FILE_DIALOG_MANY_BOOLEAN, allow_many);
+
+    SDL_ShowFileDialogWithProperties(SDL_FILEDIALOG_OPENFILE, callback, userdata, props);
+
+    SDL_DestroyProperties(props);
+}
+
+void SDL_ShowSaveFileDialog(SDL_DialogFileCallback callback, void *userdata, SDL_Window *window, const SDL_DialogFileFilter *filters, int nfilters, const char *default_location)
+{
+    SDL_PropertiesID props = SDL_CreateProperties();
+
+    SDL_SetPointerProperty(props, SDL_PROP_FILE_DIALOG_FILTERS_POINTER, (void *) filters);
+    SDL_SetNumberProperty(props, SDL_PROP_FILE_DIALOG_NFILTERS_NUMBER, nfilters);
+    SDL_SetPointerProperty(props, SDL_PROP_FILE_DIALOG_WINDOW_POINTER, window);
+    SDL_SetStringProperty(props, SDL_PROP_FILE_DIALOG_LOCATION_STRING, default_location);
+
+    SDL_ShowFileDialogWithProperties(SDL_FILEDIALOG_SAVEFILE, callback, userdata, props);
+
+    SDL_DestroyProperties(props);
+}
+
+void SDL_ShowOpenFolderDialog(SDL_DialogFileCallback callback, void *userdata, SDL_Window *window, const char *default_location, bool allow_many)
+{
+    SDL_PropertiesID props = SDL_CreateProperties();
+
+    SDL_SetPointerProperty(props, SDL_PROP_FILE_DIALOG_WINDOW_POINTER, window);
+    SDL_SetStringProperty(props, SDL_PROP_FILE_DIALOG_LOCATION_STRING, default_location);
+    SDL_SetBooleanProperty(props, SDL_PROP_FILE_DIALOG_MANY_BOOLEAN, allow_many);
+
+    SDL_ShowFileDialogWithProperties(SDL_FILEDIALOG_OPENFOLDER, callback, userdata, props);
+
+    SDL_DestroyProperties(props);
+}

--- a/src/dialog/SDL_dialog.h
+++ b/src/dialog/SDL_dialog.h
@@ -18,16 +18,5 @@
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
 */
-#include "SDL_internal.h"
 
-#include "../SDL_dialog.h"
-
-#ifdef SDL_DIALOG_DUMMY
-
-void SDL_SYS_ShowFileDialogWithProperties(SDL_FileDialogType type, SDL_DialogFileCallback callback, void *userdata, SDL_PropertiesID props)
-{
-  SDL_Unsupported();
-  callback(userdata, NULL, -1);
-}
-
-#endif // SDL_DIALOG_DUMMY
+void SDL_SYS_ShowFileDialogWithProperties(SDL_FileDialogType type, SDL_DialogFileCallback callback, void *userdata, SDL_PropertiesID props);

--- a/src/dialog/unix/SDL_portaldialog.h
+++ b/src/dialog/unix/SDL_portaldialog.h
@@ -21,9 +21,7 @@
 
 #include "SDL_internal.h"
 
-void SDL_Portal_ShowOpenFileDialog(SDL_DialogFileCallback callback, void* userdata, SDL_Window* window, const SDL_DialogFileFilter *filters, int nfilters, const char* default_location, bool allow_many);
-void SDL_Portal_ShowSaveFileDialog(SDL_DialogFileCallback callback, void* userdata, SDL_Window* window, const SDL_DialogFileFilter *filters, int nfilters, const char* default_location);
-void SDL_Portal_ShowOpenFolderDialog(SDL_DialogFileCallback callback, void* userdata, SDL_Window* window, const char* default_location, bool allow_many);
+void SDL_Portal_ShowFileDialogWithProperties(SDL_FileDialogType type, SDL_DialogFileCallback callback, void *userdata, SDL_PropertiesID props);
 
 /** @returns non-zero if available, zero if unavailable */
 bool SDL_Portal_detect(void);

--- a/src/dialog/unix/SDL_zenitydialog.h
+++ b/src/dialog/unix/SDL_zenitydialog.h
@@ -21,9 +21,7 @@
 
 #include "SDL_internal.h"
 
-extern void SDL_Zenity_ShowOpenFileDialog(SDL_DialogFileCallback callback, void* userdata, SDL_Window* window, const SDL_DialogFileFilter *filters, int nfilters, const char* default_location, bool allow_many);
-extern void SDL_Zenity_ShowSaveFileDialog(SDL_DialogFileCallback callback, void* userdata, SDL_Window* window, const SDL_DialogFileFilter *filters, int nfilters, const char* default_location);
-extern void SDL_Zenity_ShowOpenFolderDialog(SDL_DialogFileCallback callback, void* userdata, SDL_Window* window, const char* default_location, bool allow_many);
+extern void SDL_Zenity_ShowFileDialogWithProperties(SDL_FileDialogType type, SDL_DialogFileCallback callback, void *userdata, SDL_PropertiesID props);
 
 /** @returns non-zero if available, zero if unavailable */
 extern bool SDL_Zenity_detect(void);

--- a/src/dialog/windows/SDL_windowsdialog.c
+++ b/src/dialog/windows/SDL_windowsdialog.c
@@ -19,6 +19,7 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 #include "SDL_internal.h"
+#include "../SDL_dialog.h"
 #include "../SDL_dialog_utils.h"
 
 #include <windows.h>
@@ -32,7 +33,7 @@
 
 typedef struct
 {
-    int is_save;
+    bool is_save;
     const SDL_DialogFileFilter *filters;
     int nfilters;
     const char* default_file;
@@ -40,6 +41,9 @@ typedef struct
     DWORD flags;
     SDL_DialogFileCallback callback;
     void* userdata;
+    const char* title;
+    const char* accept;
+    const char* cancel;
 } winArgs;
 
 typedef struct
@@ -48,6 +52,9 @@ typedef struct
     SDL_DialogFileCallback callback;
     const char* default_folder;
     void* userdata;
+    const char* title;
+    const char* accept;
+    const char* cancel;
 } winFArgs;
 
 /** Converts dialog.nFilterIndex to SDL-compatible value */
@@ -60,7 +67,7 @@ int getFilterIndex(int as_reported_by_windows)
 void windows_ShowFileDialog(void *ptr)
 {
     winArgs *args = (winArgs *) ptr;
-    int is_save = args->is_save;
+    bool is_save = args->is_save;
     const SDL_DialogFileFilter *filters = args->filters;
     int nfilters = args->nfilters;
     const char* default_file = args->default_file;
@@ -68,6 +75,7 @@ void windows_ShowFileDialog(void *ptr)
     DWORD flags = args->flags;
     SDL_DialogFileCallback callback = args->callback;
     void* userdata = args->userdata;
+    const char *title = args->title;
 
     /* GetOpenFileName and GetSaveFileName have the same signature
        (yes, LPOPENFILENAMEW even for the save dialog) */
@@ -185,6 +193,34 @@ void windows_ShowFileDialog(void *ptr)
         SDL_free(filterlist);
     }
 
+    wchar_t *title_w = NULL;
+
+    if (title) {
+        int title_len = (int) SDL_strlen(title);
+
+        /* If the title is longer than 2GB, it might be exploitable. */
+        if (title_len < 0) {
+            title_len = 0;
+        }
+
+        int title_wlen = MultiByteToWideChar(CP_UTF8, 0, title, title_len, NULL, 0);
+
+        if (title_wlen < 0) {
+            title_wlen = 0;
+        }
+
+        title_w = (wchar_t *)SDL_malloc(title_wlen * sizeof(wchar_t));
+
+        if (!title_w) {
+            SDL_free(filter_wchar);
+            SDL_free(filebuffer);
+            callback(userdata, NULL, -1);
+            return;
+        }
+
+        MultiByteToWideChar(CP_UTF8, 0, title, title_len, title_w, title_wlen);
+    }
+
     OPENFILENAMEW dialog;
     dialog.lStructSize = sizeof(OPENFILENAME);
     dialog.hwndOwner = window;
@@ -197,7 +233,7 @@ void windows_ShowFileDialog(void *ptr)
     dialog.nMaxFile = SELECTLIST_SIZE;
     dialog.lpstrFileTitle = NULL;
     dialog.lpstrInitialDir = *initfolder ? initfolder : NULL;
-    dialog.lpstrTitle = NULL;
+    dialog.lpstrTitle = title_w;
     dialog.Flags = flags | OFN_EXPLORER | OFN_HIDEREADONLY | OFN_NOCHANGEDIR;
     dialog.nFileOffset = 0;
     dialog.nFileExtension = 0;
@@ -211,6 +247,7 @@ void windows_ShowFileDialog(void *ptr)
     BOOL result = pGetAnyFileName(&dialog);
 
     SDL_free(filter_wchar);
+    SDL_free(title_w);
 
     if (result) {
         if (!(flags & OFN_ALLOWMULTISELECT)) {
@@ -388,9 +425,36 @@ void windows_ShowFolderDialog(void* ptr)
     SDL_DialogFileCallback callback = args->callback;
     void *userdata = args->userdata;
     HWND parent = NULL;
+    const char *title = args->title;
 
     if (window) {
         parent = (HWND) SDL_GetPointerProperty(SDL_GetWindowProperties(window), SDL_PROP_WINDOW_WIN32_HWND_POINTER, NULL);
+    }
+
+    wchar_t *title_w = NULL;
+
+    if (title) {
+        int title_len = (int) SDL_strlen(title);
+
+        /* If the title is longer than 2GB, it might be exploitable. */
+        if (title_len < 0) {
+            title_len = 0;
+        }
+
+        int title_wlen = MultiByteToWideChar(CP_UTF8, 0, title, title_len, NULL, 0);
+
+        if (title_wlen < 0) {
+            title_wlen = 0;
+        }
+
+        title_w = (wchar_t *)SDL_malloc(title_wlen * sizeof(wchar_t));
+
+        if (!title_w) {
+            callback(userdata, NULL, -1);
+            return;
+        }
+
+        MultiByteToWideChar(CP_UTF8, 0, title, title_len, title_w, title_wlen);
     }
 
     wchar_t buffer[MAX_PATH];
@@ -398,15 +462,17 @@ void windows_ShowFolderDialog(void* ptr)
     BROWSEINFOW dialog;
     dialog.hwndOwner = parent;
     dialog.pidlRoot = NULL;
-    // Windows docs say this is `LPTSTR` - apparently it's actually `LPWSTR`
     dialog.pszDisplayName = buffer;
-    dialog.lpszTitle = NULL;
+    dialog.lpszTitle = title_w;
     dialog.ulFlags = BIF_USENEWUI;
     dialog.lpfn = browse_callback_proc;
     dialog.lParam = (LPARAM)args->default_folder;
     dialog.iImage = 0;
 
     LPITEMIDLIST lpItem = SHBrowseForFolderW(&dialog);
+
+    SDL_free(title_w);
+
     if (lpItem != NULL) {
         SHGetPathFromIDListW(lpItem, buffer);
         char *chosen_file = WIN_StringToUTF8W(buffer);
@@ -426,45 +492,7 @@ int windows_folder_dialog_thread(void* ptr)
     return 0;
 }
 
-void SDL_ShowOpenFileDialog(SDL_DialogFileCallback callback, void* userdata, SDL_Window* window, const SDL_DialogFileFilter *filters, int nfilters, const char* default_location, bool allow_many)
-{
-    winArgs *args;
-    SDL_Thread *thread;
-
-    if (SDL_GetHint(SDL_HINT_FILE_DIALOG_DRIVER) != NULL) {
-        SDL_Log("%s", SDL_GetHint(SDL_HINT_FILE_DIALOG_DRIVER));
-        SDL_SetError("File dialog driver unsupported");
-        callback(userdata, NULL, -1);
-        return;
-    }
-
-    args = (winArgs *)SDL_malloc(sizeof(*args));
-    if (args == NULL) {
-        callback(userdata, NULL, -1);
-        return;
-    }
-
-    args->is_save = 0;
-    args->filters = filters;
-    args->nfilters = nfilters;
-    args->default_file = default_location;
-    args->parent = window;
-    args->flags = (allow_many != false) ? OFN_ALLOWMULTISELECT : 0;
-    args->callback = callback;
-    args->userdata = userdata;
-
-    thread = SDL_CreateThread(windows_file_dialog_thread, "SDL_ShowOpenFileDialog", (void *) args);
-
-    if (thread == NULL) {
-        callback(userdata, NULL, -1);
-        SDL_free(args);
-        return;
-    }
-
-    SDL_DetachThread(thread);
-}
-
-void SDL_ShowSaveFileDialog(SDL_DialogFileCallback callback, void* userdata, SDL_Window* window, const SDL_DialogFileFilter *filters, int nfilters, const char* default_location)
+static void ShowFileDialog(SDL_DialogFileCallback callback, void* userdata, SDL_Window* window, const SDL_DialogFileFilter *filters, int nfilters, const char* default_location, bool allow_many, bool is_save, const char* title, const char* accept, const char* cancel)
 {
     winArgs *args;
     SDL_Thread *thread;
@@ -481,16 +509,19 @@ void SDL_ShowSaveFileDialog(SDL_DialogFileCallback callback, void* userdata, SDL
         return;
     }
 
-    args->is_save = 1;
+    args->is_save = is_save;
     args->filters = filters;
     args->nfilters = nfilters;
     args->default_file = default_location;
     args->parent = window;
-    args->flags = 0;
+    args->flags = allow_many ? OFN_ALLOWMULTISELECT : 0;
     args->callback = callback;
     args->userdata = userdata;
+    args->title = title;
+    args->accept = accept;
+    args->cancel = cancel;
 
-    thread = SDL_CreateThread(windows_file_dialog_thread, "SDL_ShowSaveFileDialog", (void *) args);
+    thread = SDL_CreateThread(windows_file_dialog_thread, "SDL_Windows_ShowFileDialog", (void *) args);
 
     if (thread == NULL) {
         callback(userdata, NULL, -1);
@@ -501,7 +532,7 @@ void SDL_ShowSaveFileDialog(SDL_DialogFileCallback callback, void* userdata, SDL
     SDL_DetachThread(thread);
 }
 
-void SDL_ShowOpenFolderDialog(SDL_DialogFileCallback callback, void* userdata, SDL_Window* window, const char* default_location, bool allow_many)
+void ShowFolderDialog(SDL_DialogFileCallback callback, void* userdata, SDL_Window* window, const char* default_location, bool allow_many, const char* title, const char* accept, const char* cancel)
 {
     winFArgs *args;
     SDL_Thread *thread;
@@ -522,8 +553,11 @@ void SDL_ShowOpenFolderDialog(SDL_DialogFileCallback callback, void* userdata, S
     args->callback = callback;
     args->default_folder = default_location;
     args->userdata = userdata;
+    args->title = title;
+    args->accept = accept;
+    args->cancel = cancel;
 
-    thread = SDL_CreateThread(windows_folder_dialog_thread, "SDL_ShowOpenFolderDialog", (void *) args);
+    thread = SDL_CreateThread(windows_folder_dialog_thread, "SDL_Windows_ShowFolderDialog", (void *) args);
 
     if (thread == NULL) {
         callback(userdata, NULL, -1);
@@ -532,4 +566,32 @@ void SDL_ShowOpenFolderDialog(SDL_DialogFileCallback callback, void* userdata, S
     }
 
     SDL_DetachThread(thread);
+}
+
+void SDL_SYS_ShowFileDialogWithProperties(SDL_FileDialogType type, SDL_DialogFileCallback callback, void *userdata, SDL_PropertiesID props)
+{
+    /* The internal functions will start threads, and the properties may be freed as soon as this function returns.
+       Save a copy of what we need before invoking the functions and starting the threads. */
+    SDL_Window* window = SDL_GetPointerProperty(props, SDL_PROP_FILE_DIALOG_WINDOW_POINTER, NULL);
+    SDL_DialogFileFilter *filters = SDL_GetPointerProperty(props, SDL_PROP_FILE_DIALOG_FILTERS_POINTER, NULL);
+    int nfilters = (int) SDL_GetNumberProperty(props, SDL_PROP_FILE_DIALOG_NFILTERS_NUMBER, 0);
+    bool allow_many = SDL_GetBooleanProperty(props, SDL_PROP_FILE_DIALOG_MANY_BOOLEAN, false);
+    const char* default_location = SDL_GetStringProperty(props, SDL_PROP_FILE_DIALOG_LOCATION_STRING, NULL);
+    const char* title = SDL_GetStringProperty(props, SDL_PROP_FILE_DIALOG_TITLE_STRING, NULL);
+    const char* accept = SDL_GetStringProperty(props, SDL_PROP_FILE_DIALOG_ACCEPT_STRING, NULL);
+    const char* cancel = SDL_GetStringProperty(props, SDL_PROP_FILE_DIALOG_CANCEL_STRING, NULL);
+    bool is_save = false;
+
+    switch (type) {
+    case SDL_FILEDIALOG_SAVEFILE:
+        is_save = true;
+        SDL_FALLTHROUGH;
+    case SDL_FILEDIALOG_OPENFILE:
+        ShowFileDialog(callback, userdata, window, filters, nfilters, default_location, allow_many, is_save, title, accept, cancel);
+        break;
+
+    case SDL_FILEDIALOG_OPENFOLDER:
+        ShowFolderDialog(callback, userdata, window, default_location, allow_many, title, accept, cancel);
+        break;
+    };
 }


### PR DESCRIPTION
## Description

- I've added a new function to create dialogs with properties: SDL_ShowFileDialogWithProperties. There is only one function for all dialog types; I've added an enum called SDL_FileDialogType instead.
- The old functions are now wrappers around SDL_ShowFileDialogWithProperties. This significantly simplifies the implementation on multiple platforms, which basically just regrouped all functions into one with different parameters.
- I've added three new options: setting the dialog's title, the accept button's label and the cancel button's label.
- I've fixed a few bugs and cleaned up the code a bit:
  - Zenity does, in fact, support modal dialogs. One just has to check the extended help for more options and discover the amazing(-ly poorly documented) `--attach` option. The only issue is that it supports only X11, so no Wayland support still.
  - Some code turned ugly with the boolean changes (think "if (mybool == true) { return true; } else { return false; }") so I cleaned that up where I saw it ("return mybool;").
  - I fixed up the documentation, specifically about threading and object lifetime.
  - Zenity now asks for confirmation before overwriting a file.

While deciding the names of the properties, I noticed that some boolean properties are typed as `SDL_PROP_..._BOOL` and others as `SDL_PROP_..._BOOLEAN` (RIP about the ABI freeze). I followed the second format, which seems to be more common.

## Existing Issue(s)

Closes #11133

---

I'd like to commend the only platform that supports every dialog option: **Haiku** (!). A close second is **Zenity** (!!), which managed to find the way to support everything as well, even modal dialogs, but only partially because it lacks Wayland support so I count it as half a point. Every other platform lacks at least one option completely: macOS and XDG Portals don't allow labeling the cancel button, Windows doesn't (I believe) allow labeling either button, and Android neither buttons nor dialog title, and no folder support at all as well (though those are probably not just relevant to the platform).