### PR TITLE
SDL_migration.cocci: Fix renaming SDL_bool

### DIFF
--- a/build-scripts/SDL_migration.cocci
+++ b/build-scripts/SDL_migration.cocci
@@ -3689,6 +3689,7 @@ identifier func =~ "^(SDL_AddEventWatch|SDL_AddHintCallback|SDL_AddSurfaceAltern
 + SDL_GetNumLogicalCPUCores
   (...)
 @@
+typedef SDL_bool, bool;
 @@
 - SDL_bool
 + bool


### PR DESCRIPTION
SDL_bool wasn't renamed when using the coccinelle script. Specifying typedef like other data types in SDL_migration.cocci works.