### PR TITLE
SDL3: Fixed Cocoa_GL_CreateContext() not returning a context on success

### DIFF
--- a/src/video/cocoa/SDL_cocoaopengl.m
+++ b/src/video/cocoa/SDL_cocoaopengl.m
@@ -286,7 +286,7 @@ SDL_GLContext Cocoa_GL_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
             _this->GL_SwapWindow = Cocoa_GLES_SwapWindow;
             _this->GL_DestroyContext = Cocoa_GLES_DestroyContext;
 
-            if (Cocoa_GLES_LoadLibrary(_this, NULL) != 0) {
+            if (!Cocoa_GLES_LoadLibrary(_this, NULL)) {
                 return NULL;
             }
             return Cocoa_GLES_CreateContext(_this, window);


### PR DESCRIPTION
Fixed the usage of `Cocoa_GLES_LoadLibrary` in `Cocoa_GL_CreateContext()`. It was still using the old SDL2 style of return success/failure.

Fixes issue https://github.com/libsdl-org/SDL/issues/11175
