### PR TITLE
[SDL2] Fix VisualC CMake package

### DIFF
--- a/VisualC/pkg-support/cmake/sdl2-config.cmake
+++ b/VisualC/pkg-support/cmake/sdl2-config.cmake
@@ -94,7 +94,7 @@ if(EXISTS "${_sdl2main_library}")
     endif()
     set(SDL2_SDL2main_FOUND TRUE)
 else()
-    set(SDL2_SDL2_FOUND FALSE)
+    set(SDL2_SDL2main_FOUND FALSE)
 endif()
 unset(_sdl2main_library)
 


### PR DESCRIPTION
## Description

When `SDL2main.lib` cannot be found, the component for `SDL2::SDL2` was set to not found instead of `SDL2::SDL2main`.

If possible, it should be cherry-picked to `2.30.x` since it also applies there.

## Existing Issue(s)

N/A
