### PR TITLE
SDL_windowsmodes.c: Fix MSVC builds against SDKs older than 10.0.17134.0

### DIFF
--- a/src/video/windows/SDL_windowsmodes.c
+++ b/src/video/windows/SDL_windowsmodes.c
@@ -513,7 +513,12 @@ static float WIN_GetSDRWhitePoint(SDL_VideoDevice *_this, HMONITOR hMonitor)
     float SDR_white_level = 1.0f;
 
     if (WIN_GetMonitorPathInfo(videodata, hMonitor, &path_info)) {
-        DISPLAYCONFIG_SDR_WHITE_LEVEL white_level;
+        /* workarounds for https://github.com/libsdl-org/SDL/issues/11193 */
+        struct SDL_DISPLAYCONFIG_SDR_WHITE_LEVEL {
+          DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+          ULONG SDRWhiteLevel;
+        } white_level;
+        #define DISPLAYCONFIG_DEVICE_INFO_GET_SDR_WHITE_LEVEL 11
 
         SDL_zero(white_level);
         white_level.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SDR_WHITE_LEVEL;


### PR DESCRIPTION
workaround the missing DISPLAYCONFIG_DEVICE_INFO_GET_SDR_WHITE_LEVEL enum value
and DISPLAYCONFIG_SDR_WHITE_LEVEL struct.

Fixes: https://github.com/libsdl-org/SDL/issues/11193
Closes:  https://github.com/libsdl-org/SDL/pull/11205
