### PR TITLE
Don't overwrite error in SDL_LoadFile() and set error in SDL_LoadWAV_IO()

### DIFF
--- a/src/audio/SDL_wave.c
+++ b/src/audio/SDL_wave.c
@@ -2093,7 +2093,8 @@ bool SDL_LoadWAV_IO(SDL_IOStream *src, bool closeio, SDL_AudioSpec *spec, Uint8 
 
     // Make sure we are passed a valid data source
     if (!src) {
-        goto done;  // Error may come from SDL_IOStream.
+        SDL_InvalidParamError("src");
+        goto done;
     } else if (!spec) {
         SDL_InvalidParamError("spec");
         goto done;
@@ -2132,6 +2133,19 @@ done:
 
 bool SDL_LoadWAV(const char *path, SDL_AudioSpec *spec, Uint8 **audio_buf, Uint32 *audio_len)
 {
-    return SDL_LoadWAV_IO(SDL_IOFromFile(path, "rb"), 1, spec, audio_buf, audio_len);
+    SDL_IOStream *stream = SDL_IOFromFile(path, "rb");
+    if (!stream) {
+        if (spec) {
+            SDL_zerop(spec);
+        }
+        if (audio_buf) {
+            *audio_buf = NULL;
+        }
+        if (audio_len) {
+            *audio_len = 0;
+        }
+        return false;
+    }
+    return SDL_LoadWAV_IO(stream, true, spec, audio_buf, audio_len);
 }
 

--- a/src/file/SDL_iostream.c
+++ b/src/file/SDL_iostream.c
@@ -1204,7 +1204,14 @@ done:
 
 void *SDL_LoadFile(const char *file, size_t *datasize)
 {
-    return SDL_LoadFile_IO(SDL_IOFromFile(file, "rb"), datasize, true);
+    SDL_IOStream *stream = SDL_IOFromFile(file, "rb");
+    if (!stream) {
+        if (datasize) {
+            *datasize = 0;
+        }
+        return NULL;
+    }
+    return SDL_LoadFile_IO(stream, datasize, true);
 }
 
 SDL_PropertiesID SDL_GetIOProperties(SDL_IOStream *context)

--- a/src/video/SDL_bmp.c
+++ b/src/video/SDL_bmp.c
@@ -593,7 +593,7 @@ SDL_Surface *SDL_LoadBMP(const char *file)
     if (!stream) {
         return NULL;
     }
-    return SDL_LoadBMP_IO(stream, 1);
+    return SDL_LoadBMP_IO(stream, true);
 }
 
 bool SDL_SaveBMP_IO(SDL_Surface *surface, SDL_IOStream *dst, bool closeio)

--- a/test/testshape.c
+++ b/test/testshape.c
@@ -60,7 +60,12 @@ int main(int argc, char *argv[])
             goto quit;
         }
     } else {
-        shape = SDL_LoadBMP_IO(SDL_IOFromConstMem(glass_bmp, sizeof(glass_bmp)), true);
+        SDL_IOStream *stream = SDL_IOFromConstMem(glass_bmp, sizeof(glass_bmp));
+        if (!stream) {
+            SDL_Log("Couldn't create iostream for glass.bmp: %s\n", SDL_GetError());
+            goto quit;
+        }
+        shape = SDL_LoadBMP_IO(stream, true);
         if (!shape) {
             SDL_Log("Couldn't load glass.bmp: %s\n", SDL_GetError());
             goto quit;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This fixes two issues similar to SDL_Load/SaveBMP() in https://github.com/libsdl-org/SDL/commit/b766c824bd9c7bc966ddc293beedd5a33b8c6cf2.

SDL_LoadFile() overwrote the error from SDL_IOFromFile() similar to SDL_LoadBMP().

SDL_LoadWAV_IO() didn't set an error if the iostream was NULL similar to SDL_SaveBMP_IO(). (Found inline IO function calls by searching for `_IO(SDL`).

There are two other minor fix commits.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
* https://github.com/libsdl-org/SDL/issues/11188 (SDL_LoadFile pointed out by AntTheAlchemist)