### PR TITLE
Improve support for private platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -966,8 +966,8 @@ if(SDL_LIBC)
     bcopy
     calloc ceil ceilf copysign copysignf cos cosf
     _Exit exp expf
-    fabs fabsf floor floorf fmod fmodf fopen64 free fseeko fseeko64
-    getenv
+    fabs fabsf fdatasync floor floorf fmod fmodf fopen64 free fseeko fseeko64
+    getenv gethostname
     _i64toa index itoa
     log log10 log10f logf lround lroundf _ltoa
     malloc memcmp memcpy memmove memset modf modff

--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -94,10 +94,6 @@ typedef enum SDL_EventType
 
     SDL_EVENT_SYSTEM_THEME_CHANGED, /**< The system theme changed */
 
-    /* FIXME: Where do we put these? And how many should we have? */
-    SDL_EVENT_PRIVATE_RESERVED0,
-    SDL_EVENT_PRIVATE_RESERVED1,
-
     /* Display events */
     /* 0x150 was SDL_DISPLAYEVENT, reserve the number for sdl2-compat */
     SDL_EVENT_DISPLAY_ORIENTATION = 0x151,   /**< Display orientation has changed to data1 */
@@ -232,6 +228,12 @@ typedef enum SDL_EventType
     /* Render events */
     SDL_EVENT_RENDER_TARGETS_RESET = 0x2000, /**< The render targets have been reset and their contents need to be updated */
     SDL_EVENT_RENDER_DEVICE_RESET, /**< The device has been reset and all textures need to be recreated */
+
+    /* Reserved events for private platforms */
+    SDL_EVENT_PRIVATE0 = 0x4000,
+    SDL_EVENT_PRIVATE1,
+    SDL_EVENT_PRIVATE2,
+    SDL_EVENT_PRIVATE3,
 
     /* Internal events */
     SDL_EVENT_POLL_SENTINEL = 0x7F00, /**< Signals the end of an event poll cycle */

--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -94,6 +94,10 @@ typedef enum SDL_EventType
 
     SDL_EVENT_SYSTEM_THEME_CHANGED, /**< The system theme changed */
 
+    /* FIXME: Where do we put these? And how many should we have? */
+    SDL_EVENT_PRIVATE_RESERVED0,
+    SDL_EVENT_PRIVATE_RESERVED1,
+
     /* Display events */
     /* 0x150 was SDL_DISPLAYEVENT, reserve the number for sdl2-compat */
     SDL_EVENT_DISPLAY_ORIENTATION = 0x151,   /**< Display orientation has changed to data1 */

--- a/include/SDL3/SDL_main.h
+++ b/include/SDL3/SDL_main.h
@@ -49,7 +49,7 @@
 #include <SDL3/SDL_events.h>
 
 #ifndef SDL_MAIN_HANDLED
-    #if defined(SDL_PLATFORM_PRIVATE)
+    #if defined(SDL_PLATFORM_PRIVATE_MAIN)
         /* Private platforms may have their own ideas about entry points. */
         #include "SDL_main_private.h"
 

--- a/include/SDL3/SDL_main.h
+++ b/include/SDL3/SDL_main.h
@@ -49,7 +49,11 @@
 #include <SDL3/SDL_events.h>
 
 #ifndef SDL_MAIN_HANDLED
-    #ifdef SDL_PLATFORM_WIN32
+    #if defined(SDL_PLATFORM_PRIVATE)
+        /* Private platforms may have their own ideas about entry points. */
+        #include "SDL_main_private.h"
+
+    #elif defined(SDL_PLATFORM_WIN32)
         /* On Windows SDL provides WinMain(), which parses the command line and passes
            the arguments to your main function.
 

--- a/include/SDL3/SDL_main_impl.h
+++ b/include/SDL3/SDL_main_impl.h
@@ -68,7 +68,11 @@
        unless the real entry point needs to be somewhere else entirely, like Android where it's in Java code */
     #if (!defined(SDL_MAIN_USE_CALLBACKS) || defined(SDL_MAIN_CALLBACK_STANDARD)) && !defined(SDL_MAIN_EXPORTED)
 
-        #if defined(SDL_PLATFORM_WINDOWS)
+        #if defined(SDL_PLATFORM_PRIVATE)
+            /* Private platforms may have their own ideas about entry points. */
+            #include "SDL_main_impl_private.h"
+
+        #elif defined(SDL_PLATFORM_WINDOWS)
 
             /* these defines/typedefs are needed for the WinMain() definition */
             #ifndef WINAPI

--- a/include/SDL3/SDL_main_impl.h
+++ b/include/SDL3/SDL_main_impl.h
@@ -68,7 +68,7 @@
        unless the real entry point needs to be somewhere else entirely, like Android where it's in Java code */
     #if (!defined(SDL_MAIN_USE_CALLBACKS) || defined(SDL_MAIN_CALLBACK_STANDARD)) && !defined(SDL_MAIN_EXPORTED)
 
-        #if defined(SDL_PLATFORM_PRIVATE)
+        #if defined(SDL_PLATFORM_PRIVATE_MAIN)
             /* Private platforms may have their own ideas about entry points. */
             #include "SDL_main_impl_private.h"
 

--- a/include/build_config/SDL_build_config.h
+++ b/include/build_config/SDL_build_config.h
@@ -31,7 +31,9 @@
  */
 
 /* Add any platform that doesn't build using the configure system. */
-#if defined(SDL_PLATFORM_WIN32)
+#if defined(SDL_PLATFORM_PRIVATE)
+#include "SDL_build_config_private.h"
+#elif defined(SDL_PLATFORM_WIN32)
 #include "SDL_build_config_windows.h"
 #elif defined(SDL_PLATFORM_WINGDK)
 #include "SDL_build_config_wingdk.h"

--- a/include/build_config/SDL_build_config.h.cmake
+++ b/include/build_config/SDL_build_config.h.cmake
@@ -75,8 +75,10 @@
 #cmakedefine HAVE_MALLOC 1
 #cmakedefine HAVE_CALLOC 1
 #cmakedefine HAVE_REALLOC 1
+#cmakedefine HAVE_FDATASYNC 1
 #cmakedefine HAVE_FREE 1
 #cmakedefine HAVE_GETENV 1
+#cmakedefine HAVE_GETHOSTNAME 1
 #cmakedefine HAVE_SETENV 1
 #cmakedefine HAVE_PUTENV 1
 #cmakedefine HAVE_UNSETENV 1

--- a/include/build_config/SDL_build_config_android.h
+++ b/include/build_config/SDL_build_config_android.h
@@ -57,8 +57,10 @@
 #define HAVE_MALLOC 1
 #define HAVE_CALLOC 1
 #define HAVE_REALLOC    1
+#define HAVE_FDATASYNC 1
 #define HAVE_FREE   1
 #define HAVE_GETENV 1
+#define HAVE_GETHOSTNAME 1
 #define HAVE_PUTENV 1
 #define HAVE_SETENV 1
 #define HAVE_UNSETENV   1

--- a/include/build_config/SDL_build_config_emscripten.h
+++ b/include/build_config/SDL_build_config_emscripten.h
@@ -60,8 +60,10 @@
 #define HAVE_MALLOC 1
 #define HAVE_CALLOC 1
 #define HAVE_REALLOC 1
+#define HAVE_FDATASYNC 1
 #define HAVE_FREE 1
 #define HAVE_GETENV 1
+#define HAVE_GETHOSTNAME 1
 #define HAVE_SETENV 1
 #define HAVE_PUTENV 1
 #define HAVE_UNSETENV 1

--- a/include/build_config/SDL_build_config_ios.h
+++ b/include/build_config/SDL_build_config_ios.h
@@ -49,8 +49,10 @@
 #define HAVE_MALLOC 1
 #define HAVE_CALLOC 1
 #define HAVE_REALLOC    1
+#define HAVE_FDATASYNC 1
 #define HAVE_FREE   1
 #define HAVE_GETENV 1
+#define HAVE_GETHOSTNAME 1
 #define HAVE_PUTENV 1
 #define HAVE_SETENV 1
 #define HAVE_UNSETENV   1

--- a/include/build_config/SDL_build_config_macos.h
+++ b/include/build_config/SDL_build_config_macos.h
@@ -54,8 +54,10 @@
 #define HAVE_MALLOC 1
 #define HAVE_CALLOC 1
 #define HAVE_REALLOC    1
+#define HAVE_FDATASYNC 1
 #define HAVE_FREE   1
 #define HAVE_GETENV 1
+#define HAVE_GETHOSTNAME 1
 #define HAVE_SETENV 1
 #define HAVE_PUTENV 1
 #define HAVE_UNSETENV   1

--- a/include/build_config/SDL_build_config_windows.h
+++ b/include/build_config/SDL_build_config_windows.h
@@ -135,6 +135,7 @@ typedef unsigned int uintptr_t;
 #define HAVE_MALLOC 1
 #define HAVE_CALLOC 1
 #define HAVE_REALLOC 1
+#define HAVE_FDATASYNC 1
 #define HAVE_FREE 1
 #define HAVE_ABS 1
 #define HAVE_MEMSET 1

--- a/include/build_config/SDL_build_config_wingdk.h
+++ b/include/build_config/SDL_build_config_wingdk.h
@@ -75,6 +75,7 @@
 #define HAVE_LIBC   1
 #define HAVE_MALLOC 1
 #define HAVE_CALLOC 1
+#define HAVE_FDATASYNC 1
 #define HAVE_REALLOC 1
 #define HAVE_FREE 1
 #define HAVE_ABS 1

--- a/src/SDL.c
+++ b/src/SDL.c
@@ -663,7 +663,7 @@ const char *SDL_GetRevision(void)
 const char *SDL_GetPlatform(void)
 {
 #if defined(SDL_PLATFORM_PRIVATE)
-    #include "SDL_platform_private.h"
+    return SDL_PLATFORM_PRIVATE_NAME;
 #elif defined(SDL_PLATFORM_AIX)
     return "AIX";
 #elif defined(SDL_PLATFORM_ANDROID)

--- a/src/SDL.c
+++ b/src/SDL.c
@@ -662,7 +662,9 @@ const char *SDL_GetRevision(void)
 // Get the name of the platform
 const char *SDL_GetPlatform(void)
 {
-#if defined(SDL_PLATFORM_AIX)
+#if defined(SDL_PLATFORM_PRIVATE)
+    #include "SDL_platform_private.h"
+#elif defined(SDL_PLATFORM_AIX)
     return "AIX";
 #elif defined(SDL_PLATFORM_ANDROID)
     return "Android";

--- a/src/SDL_assert.c
+++ b/src/SDL_assert.c
@@ -245,8 +245,8 @@ static SDL_AssertState SDLCALL SDL_PromptAssertion(const SDL_AssertData *data, v
             state = (SDL_AssertState)selected;
         }
     } else {
-#ifdef SDL_PLATFORM_PRIVATE
-        #include "SDL_promptassertion_private.h"
+#ifdef SDL_PLATFORM_PRIVATE_ASSERT
+        SDL_PRIVATE_PROMPTASSERTION()
 #elif defined(SDL_PLATFORM_EMSCRIPTEN)
         // This is nasty, but we can't block on a custom UI.
         for (;;) {

--- a/src/SDL_assert.c
+++ b/src/SDL_assert.c
@@ -245,7 +245,9 @@ static SDL_AssertState SDLCALL SDL_PromptAssertion(const SDL_AssertData *data, v
             state = (SDL_AssertState)selected;
         }
     } else {
-#ifdef SDL_PLATFORM_EMSCRIPTEN
+#ifdef SDL_PLATFORM_PRIVATE
+        #include "SDL_promptassertion_private.h"
+#elif defined(SDL_PLATFORM_EMSCRIPTEN)
         // This is nasty, but we can't block on a custom UI.
         for (;;) {
             bool okay = true;

--- a/src/SDL_assert.c
+++ b/src/SDL_assert.c
@@ -246,7 +246,7 @@ static SDL_AssertState SDLCALL SDL_PromptAssertion(const SDL_AssertData *data, v
         }
     } else {
 #ifdef SDL_PLATFORM_PRIVATE_ASSERT
-        SDL_PRIVATE_PROMPTASSERTION()
+        SDL_PRIVATE_PROMPTASSERTION();
 #elif defined(SDL_PLATFORM_EMSCRIPTEN)
         // This is nasty, but we can't block on a custom UI.
         for (;;) {

--- a/src/SDL_assert.c
+++ b/src/SDL_assert.c
@@ -246,7 +246,7 @@ static SDL_AssertState SDLCALL SDL_PromptAssertion(const SDL_AssertData *data, v
         }
     } else {
 #ifdef SDL_PLATFORM_PRIVATE_ASSERT
-        SDL_PRIVATE_PROMPTASSERTION
+        SDL_PRIVATE_PROMPTASSERTION()
 #elif defined(SDL_PLATFORM_EMSCRIPTEN)
         // This is nasty, but we can't block on a custom UI.
         for (;;) {

--- a/src/SDL_assert.c
+++ b/src/SDL_assert.c
@@ -246,7 +246,7 @@ static SDL_AssertState SDLCALL SDL_PromptAssertion(const SDL_AssertData *data, v
         }
     } else {
 #ifdef SDL_PLATFORM_PRIVATE_ASSERT
-        SDL_PRIVATE_PROMPTASSERTION()
+        SDL_PRIVATE_PROMPTASSERTION
 #elif defined(SDL_PLATFORM_EMSCRIPTEN)
         // This is nasty, but we can't block on a custom UI.
         for (;;) {

--- a/src/SDL_utils.c
+++ b/src/SDL_utils.c
@@ -20,7 +20,7 @@
 */
 #include "SDL_internal.h"
 
-#if defined(SDL_PLATFORM_UNIX) || defined(SDL_PLATFORM_APPLE)
+#ifdef HAVE_GETHOSTNAME
 #include <unistd.h>
 #endif
 
@@ -299,7 +299,7 @@ int SDL_URIToLocal(const char *src, char *dst)
             const size_t src_len = hostname_end - (src + 1);
             size_t hostname_len;
 
-#if defined(SDL_PLATFORM_UNIX) || defined(SDL_PLATFORM_APPLE)
+#ifdef HAVE_GETHOSTNAME
             char hostname[257];
             if (gethostname(hostname, 255) == 0) {
                 hostname[256] = '\0';

--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -26,6 +26,9 @@
 
 // Available audio drivers
 static const AudioBootStrap *const bootstrap[] = {
+#ifdef SDL_AUDIO_DRIVER_PRIVATE
+    &PRIVATEAUDIO_bootstrap,
+#endif
 #ifdef SDL_AUDIO_DRIVER_PULSEAUDIO
 #ifdef SDL_AUDIO_DRIVER_PIPEWIRE
     &PIPEWIRE_PREFERRED_bootstrap,

--- a/src/audio/SDL_sysaudio.h
+++ b/src/audio/SDL_sysaudio.h
@@ -353,6 +353,7 @@ typedef struct AudioBootStrap
 } AudioBootStrap;
 
 // Not all of these are available in a given build. Use #ifdefs, etc.
+extern AudioBootStrap PRIVATEAUDIO_bootstrap;
 extern AudioBootStrap PIPEWIRE_PREFERRED_bootstrap;
 extern AudioBootStrap PIPEWIRE_bootstrap;
 extern AudioBootStrap PULSEAUDIO_bootstrap;

--- a/src/camera/SDL_syscamera.h
+++ b/src/camera/SDL_syscamera.h
@@ -27,8 +27,6 @@
 
 #define DEBUG_CAMERA 0
 
-typedef struct SDL_Camera SDL_Camera;
-
 /* Backends should call this as devices are added to the system (such as
    a USB camera being plugged in), and should also be called for
    for every device found during DetectDevices(). */

--- a/src/dynapi/SDL_dynapi.h
+++ b/src/dynapi/SDL_dynapi.h
@@ -43,7 +43,9 @@
 #include "TargetConditionals.h"
 #endif
 
-#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE // probably not useful on iOS.
+#if defined(SDL_PLATFORM_PRIVATE) // probably not useful on private platforms.
+#define SDL_DYNAMIC_API 0
+#elif defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE // probably not useful on iOS.
 #define SDL_DYNAMIC_API 0
 #elif defined(SDL_PLATFORM_ANDROID) // probably not useful on Android.
 #define SDL_DYNAMIC_API 0

--- a/src/file/SDL_iostream.c
+++ b/src/file/SDL_iostream.c
@@ -370,7 +370,7 @@ static int SDL_fdatasync(int fd)
     result = fcntl(fd, F_FULLFSYNC);
 #elif defined(SDL_PLATFORM_HAIKU)
     result = fsync(fd);
-#elif HAVE_FDATASYNC
+#elif defined(HAVE_FDATASYNC)
     result = fdatasync(fd);
 #endif
     return result;

--- a/src/file/SDL_iostream.c
+++ b/src/file/SDL_iostream.c
@@ -370,10 +370,8 @@ static int SDL_fdatasync(int fd)
     result = fcntl(fd, F_FULLFSYNC);
 #elif defined(SDL_PLATFORM_HAIKU)
     result = fsync(fd);
-#elif defined(_POSIX_SYNCHRONIZED_IO)  // POSIX defines this if fdatasync() exists, so we don't need a CMake test.
-#ifndef SDL_PLATFORM_RISCOS  // !!! FIXME: however, RISCOS doesn't have the symbol...maybe we need to link to an extra library or something?
+#elif HAVE_FDATASYNC
     result = fdatasync(fd);
-#endif
 #endif
     return result;
 }

--- a/src/joystick/SDL_gamepad_db.h
+++ b/src/joystick/SDL_gamepad_db.h
@@ -30,7 +30,7 @@
  */
 static const char *s_GamepadMappings[] = {
 #ifdef SDL_JOYSTICK_PRIVATE
-    #include "SDL_gamepad_db_private.h"
+    SDL_PRIVATE_GAMEPAD_DEFINITIONS()
 #endif
 #ifdef SDL_JOYSTICK_XINPUT
     "xinput,*,a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b10,leftshoulder:b4,leftstick:b8,lefttrigger:a2,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b9,righttrigger:a5,rightx:a3,righty:a4,start:b7,x:b2,y:b3,",

--- a/src/joystick/SDL_gamepad_db.h
+++ b/src/joystick/SDL_gamepad_db.h
@@ -30,7 +30,7 @@
  */
 static const char *s_GamepadMappings[] = {
 #ifdef SDL_JOYSTICK_PRIVATE
-    SDL_PRIVATE_GAMEPAD_DEFINITIONS()
+    SDL_PRIVATE_GAMEPAD_DEFINITIONS
 #endif
 #ifdef SDL_JOYSTICK_XINPUT
     "xinput,*,a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b10,leftshoulder:b4,leftstick:b8,lefttrigger:a2,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b9,righttrigger:a5,rightx:a3,righty:a4,start:b7,x:b2,y:b3,",

--- a/src/joystick/SDL_gamepad_db.h
+++ b/src/joystick/SDL_gamepad_db.h
@@ -29,6 +29,9 @@
    Alternatively, you can use the app located in test/controllermap
  */
 static const char *s_GamepadMappings[] = {
+#ifdef SDL_JOYSTICK_PRIVATE
+    #include "SDL_gamepad_db_private.h"
+#endif
 #ifdef SDL_JOYSTICK_XINPUT
     "xinput,*,a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b10,leftshoulder:b4,leftstick:b8,lefttrigger:a2,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b9,righttrigger:a5,rightx:a3,righty:a4,start:b7,x:b2,y:b3,",
 #endif

--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -52,6 +52,9 @@ static SDL_JoystickDriver *SDL_joystick_drivers[] = {
 #ifdef SDL_JOYSTICK_HIDAPI // Highest priority driver for supported devices
     &SDL_HIDAPI_JoystickDriver,
 #endif
+#ifdef SDL_JOYSTICK_PRIVATE
+    &SDL_PRIVATE_JoystickDriver,
+#endif
 #ifdef SDL_JOYSTICK_GAMEINPUT // Higher priority than other Windows drivers
     &SDL_GAMEINPUT_JoystickDriver,
 #endif

--- a/src/joystick/SDL_sysjoystick.h
+++ b/src/joystick/SDL_sysjoystick.h
@@ -240,6 +240,7 @@ typedef struct SDL_JoystickDriver
 #define SDL_LED_MIN_REPEAT_MS 5000
 
 // The available joystick drivers
+extern SDL_JoystickDriver SDL_PRIVATE_JoystickDriver;
 extern SDL_JoystickDriver SDL_ANDROID_JoystickDriver;
 extern SDL_JoystickDriver SDL_BSD_JoystickDriver;
 extern SDL_JoystickDriver SDL_DARWIN_JoystickDriver;

--- a/src/thread/pthread/SDL_systhread.c
+++ b/src/thread/pthread/SDL_systhread.c
@@ -26,7 +26,9 @@
 #include <pthread_np.h>
 #endif
 
+#ifdef HAVE_SIGNAL_H
 #include <signal.h>
+#endif
 #include <errno.h>
 
 #ifdef SDL_PLATFORM_LINUX
@@ -55,11 +57,13 @@
 #include <kernel/OS.h>
 #endif
 
+#ifdef HAVE_SIGNAL_H
 // List of signals to mask in the subthreads
 static const int sig_list[] = {
     SIGHUP, SIGINT, SIGQUIT, SIGPIPE, SIGALRM, SIGTERM, SIGCHLD, SIGWINCH,
     SIGVTALRM, SIGPROF, 0
 };
+#endif
 
 static void *RunThread(void *data)
 {
@@ -117,8 +121,10 @@ bool SDL_SYS_CreateThread(SDL_Thread *thread,
 
 void SDL_SYS_SetupThread(const char *name)
 {
+#ifdef HAVE_SIGNAL_H
     int i;
     sigset_t mask;
+#endif
 
     if (name) {
 #if (defined(SDL_PLATFORM_MACOS) || defined(SDL_PLATFORM_IOS) || defined(SDL_PLATFORM_LINUX)) && defined(HAVE_DLOPEN)
@@ -154,12 +160,14 @@ void SDL_SYS_SetupThread(const char *name)
 #endif
     }
 
+#ifdef HAVE_SIGNAL_H
     // Mask asynchronous signals for this thread
     sigemptyset(&mask);
     for (i = 0; sig_list[i]; ++i) {
         sigaddset(&mask, sig_list[i]);
     }
     pthread_sigmask(SIG_BLOCK, &mask, 0);
+#endif
 
 #ifdef PTHREAD_CANCEL_ASYNCHRONOUS
     // Allow ourselves to be asynchronously cancelled

--- a/src/video/SDL_egl.c
+++ b/src/video/SDL_egl.c
@@ -429,7 +429,7 @@ static bool SDL_EGL_LoadLibraryInternal(SDL_VideoDevice *_this, const char *egl_
 
     _this->egl_data->egl_dll_handle = egl_dll_handle;
 #ifdef SDL_VIDEO_DRIVER_VITA
-    _this->egl_data->opengl_dll_handle = opengl_dll_handle;
+    _this->egl_data->opengl_dll_handle = NULL;
 #endif
 
     // Load new function pointers

--- a/src/video/SDL_egl.c
+++ b/src/video/SDL_egl.c
@@ -428,9 +428,6 @@ static bool SDL_EGL_LoadLibraryInternal(SDL_VideoDevice *_this, const char *egl_
 #endif
 
     _this->egl_data->egl_dll_handle = egl_dll_handle;
-#ifdef SDL_VIDEO_DRIVER_VITA
-    _this->egl_data->opengl_dll_handle = NULL;
-#endif
 
     // Load new function pointers
     LOAD_FUNC(PFNEGLGETDISPLAYPROC, eglGetDisplay);

--- a/src/video/SDL_egl.c
+++ b/src/video/SDL_egl.c
@@ -300,7 +300,9 @@ void SDL_EGL_UnloadLibrary(SDL_VideoDevice *_this)
 static bool SDL_EGL_LoadLibraryInternal(SDL_VideoDevice *_this, const char *egl_path)
 {
     SDL_SharedObject *egl_dll_handle = NULL;
+#if !defined(SDL_VIDEO_STATIC_ANGLE) && !defined(SDL_VIDEO_DRIVER_VITA)
     SDL_SharedObject *opengl_dll_handle = NULL;
+#endif
     const char *path = NULL;
 #if defined(SDL_VIDEO_DRIVER_WINDOWS)
     const char *d3dcompiler;

--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -498,6 +498,7 @@ typedef struct VideoBootStrap
 } VideoBootStrap;
 
 // Not all of these are available in a given build. Use #ifdefs, etc.
+extern VideoBootStrap PRIVATE_bootstrap;
 extern VideoBootStrap COCOA_bootstrap;
 extern VideoBootStrap X11_bootstrap;
 extern VideoBootStrap WINDOWS_bootstrap;

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -71,6 +71,9 @@
 
 // Available video drivers
 static VideoBootStrap *bootstrap[] = {
+#ifdef SDL_VIDEO_DRIVER_PRIVATE
+    &PRIVATE_bootstrap,
+#endif
 #ifdef SDL_VIDEO_DRIVER_COCOA
     &COCOA_bootstrap,
 #endif


### PR DESCRIPTION
**What's this about?**

Historically, SDL ports for private (NDA'd) platforms have been developed by copy-pasting the public SDL repository into a separate repository, and then making all the platform-specific changes in that copied repo. This has proven difficult to maintain for several reasons:

* Updating the private repos requires carefully merging / rebasing on the public repo while preserving platform-specific commit history.
* Private repos cannot benefit from bug fixes and features in the public repo until an aforementioned merge takes place. As a result, they often end up lagging behind the latest public version.
* Non-platform-specific bug fixes made on the private branches sometimes don't make their way back to the public repository.

In a perfect world we could just have everything out in the public repo so there's one unified codebase, like we have for Xbox GDK. But I think the next-best option is to have the private code conditionally inlined and linked with the public source. That way only the secret stuff is locked away behind NDAs, and the vast majority of the library code is pulled from the public repo.

I have implemented such an approach here. This changeset is everything I needed to get the SDL console ports compiling+linking (and on one platform, running several test programs!) with SDL3. I was initially concerned with how invasive this would end up being, but as you can see, it's surprisingly minimal.

**How does this work on the SDL side?**

Almost all the platform-specific logic is contained within custom `SDL_sys*.c` files and implementations of the `PRIVATE_bootstrap` drivers. Anything that needs to be surfaced to the public source files is done so via a header file containing the code to inline. So for instance, `SDL_platform_private.h` might contain just:
```
return "SomePlatform";
```
Other files work similarly; `SDL_gamepad_db_private.h` contains only the platform-specific controller identifiers, and so forth.

The build system will automatically apply the `SDL_PLATFORM_PRIVATE` definition so we don't have to check for any specific compiler defines in `SDL_platform_defines.h`. (This is unfortunately necessary because certain platform holders are very sensitive about any public references to their platforms whatsoever.)

**How does this work on the developer's side?**

The setup looks like this:
```
git clone https://github.com/libsdl-org/SDL
git clone https://github.com/libsdl-org/SDL-privateplatformgoeshere
```

In the latter repo, there's a build project (e.g. `VisualC-MyPlatform/`) that pulls source files from the public SDL repo you just cloned, and adds any additional platform-specific source files. You then add that project as a Project Reference in your game's solution, add the private `include/` directory to your project's include search paths, and add the `SDL_PLATFORM_PRIVATE` preprocessor define. Then you can just build and run!

Since the repos are split, you can update public SDL as desired to get the latest and greatest, independent from the platform-specific stuff. The majority of the time this should work without a hitch, but in the event of a public/private build breakage, it should be pretty easy to track down the culprit. For maximum stability you can always pin the public repo to a specific tagged version.

**Is this approach future-proof?**

Given how little of the public source this touches, I'm feeling optimistic that we could handle pretty much any problem we may run into in the future. We have several tools at our disposal for adapting to new and exotic platforms -- `SDL_sys*.c`, inlining, and new drivers for joystick/video/audio.

There are some scenarios where we may have to get a bit more creative. Consider the scenario where a platform has a completely unique opinion on some common functionality where there's not an existing sys/bootstrap infrastructure in place. In that case, we can make a custom source file for that platform to replace the public implementation (e.g. `SDL_atomic_private.c` as a random example). Even if most of the code for that specific source file is copy-pasted from the public implementation, that's still an improvement over having the entire SDL project copy-pasted!

**What's left to do?**

~~I still need to figure out how to add checks for `HAVE_GETHOSTNAME` and `HAVE_FDATASYNC` to the CMake configure stage. These defines seem like they'd be generally useful, in addition to being necessary for certain platforms.~~

~~We also need to determine how to reserve some SDL event enums for private platform events. I wasn't sure where they should go in the order of SDL_Events, or how many we should reserve, but we definitely need at least a couple.~~

**In conclusion...**

Let me know if you have any questions! If we decide that this is the direction we want to go, or if you want to see what this looks like from the other side, then I'll share my WIP SDL3 ports on their respective private repos.
