### PR TITLE
Prevent last error overwrite in windows_file_open

### DIFF
--- a/src/file/SDL_iostream.c
+++ b/src/file/SDL_iostream.c
@@ -134,7 +134,9 @@ static HANDLE SDLCALL windows_file_open(const char *filename, const char *mode)
 
     if (h == INVALID_HANDLE_VALUE) {
         char *error;
+        DWORD last_error = GetLastError();
         if (SDL_asprintf(&error, "Couldn't open %s", filename) > 0) {
+            SetLastError(last_error);
             WIN_SetError(error);
             SDL_free(error);
         } else {

--- a/src/file/SDL_iostream.c
+++ b/src/file/SDL_iostream.c
@@ -88,6 +88,7 @@ static HANDLE SDLCALL windows_file_open(const char *filename, const char *mode)
     UINT old_error_mode;
 #endif
     HANDLE h;
+    DWORD last_error;
     DWORD r_right, w_right;
     DWORD must_exist, truncate;
     int a_mode;
@@ -124,6 +125,7 @@ static HANDLE SDLCALL windows_file_open(const char *filename, const char *mode)
                        (must_exist | truncate | a_mode),
                        FILE_ATTRIBUTE_NORMAL,
                        NULL);
+        last_error = GetLastError();
         SDL_free(str);
     }
 
@@ -134,7 +136,6 @@ static HANDLE SDLCALL windows_file_open(const char *filename, const char *mode)
 
     if (h == INVALID_HANDLE_VALUE) {
         char *error;
-        DWORD last_error = GetLastError();
         if (SDL_asprintf(&error, "Couldn't open %s", filename) > 0) {
             SetLastError(last_error);
             WIN_SetError(error);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Prevent any win32 function used in SDL_asprintf from affecting the CreateFileW result. This is possible through calling SDL_SetMemoryFunctions with callbacks utilizing win32 functions.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
