### PR TITLE
Fixed bug #10954: software renderer: examples/renderer/10-geometry mi…

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -4389,7 +4389,7 @@ bool SDL_RenderGeometry(SDL_Renderer *renderer,
 }
 
 #ifdef SDL_VIDEO_RENDER_SW
-static bool remap_one_indice(
+static int remap_one_indice(
     int prev,
     int k,
     SDL_Texture *texture,
@@ -4427,7 +4427,7 @@ static bool remap_one_indice(
     return prev;
 }
 
-static bool remap_indices(
+static int remap_indices(
     int prev[3],
     int k,
     SDL_Texture *texture,


### PR DESCRIPTION
…ssing a triangle

typo when changing return code from int to bool

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
