### PR TITLE
Add `void` to `run_colorspace_test()` function prototype

### DIFF
--- a/test/testyuv.c
+++ b/test/testyuv.c
@@ -239,7 +239,7 @@ done:
     return result;
 }
 
-static bool run_colorspace_test()
+static bool run_colorspace_test(void)
 {
     bool result = false;
     SDL_Window *window;


### PR DESCRIPTION
```c
/path/to/SDL-git/test/testyuv.c:242:32: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
  242 | static bool run_colorspace_test()
      |                                ^
      |                                 void
```