### PR TITLE
SDL_stdinc.h: provide a prototype for strdup for __clang_analyzer__ case

### DIFF
--- a/.github/workflows/create-test-plan.py
+++ b/.github/workflows/create-test-plan.py
@@ -632,7 +632,6 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool) -> JobDeta
             ))
             job.shared_lib = SharedLibType.SO_0
             job.static_lib = StaticLibType.A
-            job.clang_tidy = False
         case SdlPlatform.N3ds:
             job.shared = False
             job.apt_packages = ["ninja-build", "binutils"]

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -4244,6 +4244,9 @@ size_t wcslcpy(wchar_t *dst, const wchar_t *src, size_t size);
 size_t wcslcat(wchar_t *dst, const wchar_t *src, size_t size);
 #endif
 
+/* strdup is not ANSI but POSIX, and its prototype might be hidden... */
+char *strdup(const char *str);
+
 /* Starting LLVM 16, the analyser errors out if these functions do not have
    their prototype defined (clang-diagnostic-implicit-function-declaration) */
 #include <stdio.h>


### PR DESCRIPTION
Because strdup is not ANSI but POSIX, and its prototype might be hidden..

... and re-enable clang-tidy in CI for LoongArch64.

Fixes:  https://github.com/libsdl-org/SDL/issues/11219.
