### PR TITLE
cmake: test for EGL and GLES on Windows, avoid EGL test on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2026,10 +2026,8 @@ elseif(WINDOWS)
     endif()
 
     if(SDL_OPENGLES)
-      set(SDL_VIDEO_OPENGL_EGL 1)
-      set(SDL_VIDEO_OPENGL_ES2 1)
-      set(SDL_VIDEO_RENDER_OGL_ES2 1)
-      set(HAVE_OPENGLES TRUE)
+      CheckEGL()
+      CheckOpenGLES()
     endif()
 
     if(SDL_VULKAN)

--- a/cmake/PreseedMSVCCache.cmake
+++ b/cmake/PreseedMSVCCache.cmake
@@ -1,5 +1,7 @@
 if(MSVC)
   function(SDL_Preseed_CMakeCache)
+    set(HAVE_OPENGLES_V1                                 ""    CACHE INTERNAL "Test HAVE_OPENGLES_V1")
+    set(HAVE_OPENGLES_V2                                 "1"   CACHE INTERNAL "Test HAVE_OPENGLES_V2")
     set(COMPILER_SUPPORTS_W3                             "1"   CACHE INTERNAL "Test /W3")
     set(COMPILER_SUPPORTS_FDIAGNOSTICS_COLOR_ALWAYS      ""    CACHE INTERNAL "Test COMPILER_SUPPORTS_FDIAGNOSTICS_COLOR_ALWAYS")
     set(HAVE_ALLOCA_H                                    ""    CACHE INTERNAL "Have include alloca.h")

--- a/cmake/sdlchecks.cmake
+++ b/cmake/sdlchecks.cmake
@@ -679,21 +679,25 @@ endmacro()
 # - PkgCheckModules
 macro(CheckEGL)
   if(SDL_OPENGL OR SDL_OPENGLES)
-    cmake_push_check_state()
-    find_package(OpenGL MODULE)
-    list(APPEND CMAKE_REQUIRED_INCLUDES ${OPENGL_EGL_INCLUDE_DIRS})
-    list(APPEND CMAKE_REQUIRED_INCLUDES "${SDL3_SOURCE_DIR}/src/video/khronos")
-    check_c_source_compiles("
-        #define EGL_API_FB
-        #define MESA_EGL_NO_X11_HEADERS
-        #define EGL_NO_X11
-        #include <EGL/egl.h>
-        #include <EGL/eglext.h>
-        int main (int argc, char** argv) { return 0; }" HAVE_OPENGL_EGL)
-    cmake_pop_check_state()
-    if(HAVE_OPENGL_EGL)
+    if(NOT MSVC)
+      cmake_push_check_state()
+      find_package(OpenGL MODULE)
+      list(APPEND CMAKE_REQUIRED_INCLUDES ${OPENGL_EGL_INCLUDE_DIRS})
+      list(APPEND CMAKE_REQUIRED_INCLUDES "${SDL3_SOURCE_DIR}/src/video/khronos")
+      check_c_source_compiles("
+          #define EGL_API_FB
+          #define MESA_EGL_NO_X11_HEADERS
+          #define EGL_NO_X11
+          #include <EGL/egl.h>
+          #include <EGL/eglext.h>
+          int main (int argc, char** argv) { return 0; }" HAVE_OPENGL_EGL)
+      cmake_pop_check_state()
+    endif()
+    if(MSVC OR HAVE_OPENGL_EGL)
       set(SDL_VIDEO_OPENGL_EGL 1)
-      sdl_link_dependency(egl INCLUDES ${OPENGL_EGL_INCLUDE_DIRS})
+      if(NOT MSVC)
+        sdl_link_dependency(egl INCLUDES ${OPENGL_EGL_INCLUDE_DIRS})
+      endif()
     endif()
   endif()
 endmacro()


### PR DESCRIPTION
For MSVC platforms, `SDL3/SDL_egl.h` has the following conditional to avoid including a system `EGL/egl.h`:
https://github.com/libsdl-org/SDL/blob/dd955332a2795d8b60731b1864eeab44341baf8d/include/SDL3/SDL_egl.h#L28

Perhaps this should include Windows platforms?

If a CMake test is preferred, we were only detecting egl.h for the unix platforms.
This pr adds a test for the Windows platform.
When using MSVC, it avoids a check for `<EGL/egl.h>` and `<EGL/eglext.h>` includes.

It adds checks for
- `<GLES/gl.h>` and `<GLES/glext.h>` includes in `CheckOpenGLES` for `SDL_VIDEO_OPENGL_ES`
- `<GLES2/gl2.h>` and `<GLES2/gl2ext.h>` includes in `CheckOpenGLES` for `SDL_VIDEO_OPENGL_ES2`

The MSVC behavior should be the same, but please review.


## Existing Issue(s)
Fixes https://github.com/libsdl-org/SDL/issues/11216
