### PR TITLE
Define SDL_DIALOG_DUMMY in SDL_build_config_xbox.h

### DIFF
--- a/include/build_config/SDL_build_config_xbox.h
+++ b/include/build_config/SDL_build_config_xbox.h
@@ -228,4 +228,7 @@
 /* Enable the camera driver (src/camera/dummy/\*.c) */
 #define SDL_CAMERA_DRIVER_DUMMY  1
 
+/* Enable dialog subsystem */
+#define SDL_DIALOG_DUMMY 1
+
 #endif /* SDL_build_config_wingdk_h_ */


### PR DESCRIPTION
Fixes link error for Xbox builds.