### PR TITLE
video/openvr: Avoid type redefinition errors.

### DIFF
--- a/src/video/openvr/SDL_openvrvideo.h
+++ b/src/video/openvr/SDL_openvrvideo.h
@@ -15,6 +15,7 @@
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #endif
 
+#define USE_SDL
 #include "openvr_capi.h"
 
 #ifdef __GNUC__
@@ -35,7 +36,7 @@
 #endif
 
 
-typedef struct SDL_WindowData
+struct SDL_WindowData
 {
 #ifdef SDL_VIDEO_DRIVER_WINDOWS
     SDL_Window *window;
@@ -46,9 +47,9 @@ typedef struct SDL_WindowData
 #else
     int dummy;
 #endif
-} SDL_WindowData;
+};
 
-typedef struct SDL_VideoData {
+struct SDL_VideoData {
     void * openVRLIB;
     intptr_t vrtoken;
     intptr_t (*FN_VR_InitInternal)( EVRInitError *peError, EVRApplicationType eType );
@@ -97,13 +98,11 @@ typedef struct SDL_VideoData {
     EGLDisplay eglDpy;
     EGLContext eglCtx;
 #endif
-} SDL_VideoData;
+};
 
-
-typedef struct SDL_DisplayData
+struct SDL_DisplayData
 {
     int dummy;
-} SDL_DisplayData;
-
+};
 
 #endif

--- a/src/video/openvr/openvr_capi.h
+++ b/src/video/openvr/openvr_capi.h
@@ -46,6 +46,7 @@
 	#endif // OPENVR_API_EXPORTS
 #endif
 
+#ifndef USE_SDL
 #include <stdint.h>
 
 #if defined( __WIN32 )
@@ -53,14 +54,7 @@ typedef char bool;
 #else
 #include <stdbool.h>
 #endif
-
-typedef uint64_t PropertyContainerHandle_t;
-typedef uint32_t PropertyTypeTag_t;
-typedef uint64_t VRActionHandle_t;
-typedef uint64_t VRActionSetHandle_t;
-typedef uint64_t VRInputValueHandle_t;
-typedef uint64_t PathHandle_t;
-
+#endif // USE_SDL
 
 // OpenVR Constants
 
@@ -1837,10 +1831,6 @@ typedef enum EBlockQueueCreationFlag
 
 // OpenVR typedefs
 
-typedef uint32_t TrackedDeviceIndex_t;
-typedef uint32_t VRNotificationId;
-typedef uint64_t VROverlayHandle_t;
-
 typedef uint32_t PropertyTypeTag_t;
 typedef uint32_t SpatialAnchorHandle_t;
 typedef void * glSharedTextureHandle_t;
@@ -1851,7 +1841,6 @@ typedef uint32_t DriverId_t;
 typedef uint32_t TrackedDeviceIndex_t;
 typedef uint64_t WebConsoleHandle_t;
 typedef uint64_t PropertyContainerHandle_t;
-typedef uint32_t PropertyTypeTag_t;
 typedef PropertyContainerHandle_t DriverHandle_t;
 typedef uint64_t VRActionHandle_t;
 typedef uint64_t VRActionSetHandle_t;


### PR DESCRIPTION
Also, let SDL handle stdint.h and stdbool.h.

P.S.: Why does SDL_openvrvideo.h override and define `GL_APIENTRY`
and `GL_APICALL` as nothing for windows???
