### PR TITLE
Allow sorting KMSDRM and X11 displays via the display priority hint

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -3149,13 +3149,14 @@ extern "C" {
  * prioritized in the list of displays, as exposed by calling
  * SDL_GetDisplays(), with the first listed becoming the primary display. The
  * naming convention can vary depending on the environment, but it is usually
- * a connector name (e.g. 'DP-1', 'DP-2', 'HDMI-1', etc...).
+ * a connector name (e.g. 'DP-1', 'DP-2', 'HDMI-A-1',etc...).
  *
- * On X11 and Wayland desktops, the connector names associated with displays
+ * On Wayland and X11 desktops, the connector names associated with displays
  * can typically be found by using the `xrandr` utility.
  *
  * This hint is currently supported on the following drivers:
  *
+ * - KMSDRM (kmsdrm)
  * - Wayland (wayland)
  *
  * This hint should be set before SDL is initialized.

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -3158,6 +3158,7 @@ extern "C" {
  *
  * - KMSDRM (kmsdrm)
  * - Wayland (wayland)
+ * - X11 (x11)
  *
  * This hint should be set before SDL is initialized.
  *

--- a/src/video/kmsdrm/SDL_kmsdrmsym.h
+++ b/src/video/kmsdrm/SDL_kmsdrmsym.h
@@ -63,6 +63,8 @@ SDL_KMSDRM_SYM_OPT(int,drmModeAddFB2WithModifiers,(int fd, uint32_t width,
                          const uint32_t pitches[4], const uint32_t offsets[4],
                          const uint64_t modifier[4], uint32_t *buf_id, uint32_t flags))
 
+SDL_KMSDRM_SYM_OPT(const char *,drmModeGetConnectorTypeName,(uint32_t connector_type))
+
 SDL_KMSDRM_SYM(int,drmModeRmFB,(int fd, uint32_t bufferId))
 SDL_KMSDRM_SYM(drmModeFBPtr,drmModeGetFB,(int fd, uint32_t buf))
 SDL_KMSDRM_SYM(drmModeCrtcPtr,drmModeGetCrtc,(int fd, uint32_t crtcId))

--- a/src/video/x11/SDL_x11modes.h
+++ b/src/video/x11/SDL_x11modes.h
@@ -38,6 +38,7 @@ struct SDL_DisplayData
 
 #ifdef SDL_VIDEO_DRIVER_X11_XRANDR
     RROutput xrandr_output;
+    char connector_name[16];
 #endif
 };
 


### PR DESCRIPTION
This has the side effect of providing more descriptive names for KMSDRM displays, if the `drmModeGetConnectorTypeName` functionality is present.