### PR TITLE
Windows RawKeyboard: fix mixed up KeyUp and KeyDown events

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -706,7 +706,7 @@ static void WIN_HandleRawKeyboardInput(Uint64 timestamp, SDL_VideoData *data, HA
         return;
     }
 
-    bool down = ((rawkeyboard->Flags & RI_KEY_BREAK) != 0);
+    bool down = !(rawkeyboard->Flags & RI_KEY_BREAK);
     SDL_Scancode code;
     USHORT rawcode = rawkeyboard->MakeCode;
     if (data->pending_E1_key_sequence) {


### PR DESCRIPTION
RawKeyboard incorrectly checks the flag mixing up KeyUp and KeyDown events.

## Description
RI_KEY_BREAK indicates key is Up, not Down. Fixes a typo introduced during bool migration https://github.com/libsdl-org/SDL/commit/6fc6e3dc7eb55da70281f945bc11ee382c24e245
