### PR TITLE
docs: Explain events for already plugged in controllers

### DIFF
--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -549,7 +549,12 @@ typedef struct SDL_JoyButtonEvent
 /**
  * Joystick device event structure (event.jdevice.*)
  *
+ * SDL will populate the event queue with JOYSTICK_ADDED events for devices that
+ * are already plugged in during SDL_Init.
+ *
  * \since This struct is available since SDL 3.0.0.
+ *
+ * \sa SDL_GamepadDeviceEvent
  */
 typedef struct SDL_JoyDeviceEvent
 {
@@ -615,7 +620,27 @@ typedef struct SDL_GamepadButtonEvent
 /**
  * Gamepad device event structure (event.gdevice.*)
  *
+ * Joysticks that are supported Gamepads receive both an SDL_JoyDeviceEvent and
+ * an SDL_GamepadDeviceEvent.
+ *
+ * SDL will populate the event queue with GAMEPAD_ADDED events for joysticks
+ * that are already plugged in duing SDL_Init and are recognized as Gamepads.
+ *
+ * GAMEPAD_ADDED events for controllers plugged in at the start of the program
+ * will not occur automatically if their mappings are added after calling
+ * SDL_Init.
+ *
+ * If you rely on GAMEPAD_ADDED events to tell you about controllers that are
+ * already plugged in at the start of the program, and you use
+ * SDL_AddGamepadMappingsFromFile to add support for additional controllers,
+ * you can ensure that you get GAMEPAD_ADDED events for all controllers if you
+ * load the mappings before calling SDL_Init.
+ *
  * \since This struct is available since SDL 3.0.0.
+ *
+ * \sa SDL_AddGamepadMappingsFromFile
+ * \sa SDL_HINT_GAMECONTROLLERCONFIG_FILE
+ * \sa SDL_JoyDeviceEvent
  */
 typedef struct SDL_GamepadDeviceEvent
 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Contrary to some online sources, SDL does generate events for joysticks already plugged in when the program starts. If you add support for additional gamepads via AddGamepadMappingsFromFile, the order is significant. We should clarify that.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
Not an issue, but this was discussed in the forum: https://discourse.libsdl.org/t/deviced-added-events-for-devices-plugged-in-at-game-start/55039
