### PR TITLE
Fixed crashes handling D3D11/12 device lost in testsprite

### DIFF
--- a/test/testsprite.c
+++ b/test/testsprite.c
@@ -21,6 +21,7 @@
 #define MAX_SPEED   1
 
 static SDLTest_CommonState *state;
+static const char *icon = "icon.bmp";
 static int num_sprites;
 static SDL_Texture **sprites;
 static bool cycle_color;
@@ -56,6 +57,9 @@ static int LoadSprite(const char *file)
 
     for (i = 0; i < state->num_windows; ++i) {
         /* This does the SDL_LoadBMP step repeatedly, but that's OK for test code. */
+        if (sprites[i]) {
+            SDL_DestroyTexture(sprites[i]);
+        }
         sprites[i] = LoadTexture(state->renderers[i], file, true, &w, &h);
         sprite_w = (float)w;
         sprite_h = (float)h;
@@ -390,7 +394,6 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
     SDL_Rect safe_area;
     int i;
     Uint64 seed;
-    const char *icon = "icon.bmp";
 
     /* Initialize parameters */
     num_sprites = NUM_SPRITES;
@@ -553,6 +556,9 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
 
 SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
 {
+    if (event->type == SDL_EVENT_RENDER_DEVICE_RESET) {
+        LoadSprite(icon);
+    }
     return SDLTest_CommonEventMainCallbacks(state, event);
 }
 


### PR DESCRIPTION
You can test this using "dxcap -forcetdr"