### PR TITLE
docs: fix window flags in README-migration.md

### DIFF
--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -2134,7 +2134,9 @@ SDL_CreateWindow() has been simplified and no longer takes a window position. Yo
     SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_Y_NUMBER, y);
     SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, width);
     SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, height);
-    SDL_SetNumberProperty(props, "flags", flags);
+    // For window flags you should use separate window creation properties,
+    // but for easier migration from SDL2 you can use the following:
+    SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_FLAGS_NUMBER, flags);
     pWindow = SDL_CreateWindowWithProperties(props);
     SDL_DestroyProperties(props);
     if (window) {


### PR DESCRIPTION
Use correct SDL macro instead of invalid "flags" string.

`SDL_PROP_WINDOW_CREATE_FLAGS_NUMBER` was introduced in #10545 to ease the migration and for internal usage.

I was porting my game to SDL3 and copied the example from the doc, I was confused for quite a while before realizing the "flags" property wasn't actually doing anything to the window :D
