### PR TITLE
GPU Vulkan: Use dedicated allocation for download buffers

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -2294,6 +2294,9 @@ extern SDL_DECLSPEC SDL_GPUBuffer *SDLCALL SDL_CreateGPUBuffer(
  * Creates a transfer buffer to be used when uploading to or downloading from
  * graphics resources.
  *
+ * Download buffers can be particularly expensive to create,
+ * so it is good practice to reuse them if data will be downloaded regularly.
+ *
  * \param device a GPU Context.
  * \param createinfo a struct describing the state of the transfer buffer to
  *                   create.


### PR DESCRIPTION
Resolves #11107 

There is an edge case as demonstrated by this pseudocode:
```
SDL_GPUBuffer* b;
SDL_GPUTransferBuffer* t;

// Frame 0:
cmdbuf0 = SDL_AcquireGPUCommandBuffer();
SDL_DownloadFromGPUBuffer(b, t);
fence0 = SDL_SubmitGPUCommandBufferAndAcquireFence(cmdbuf0);

 // Frame1:
cmdbuf1 = SDL_AcquireGPUCommandBuffer();
/* Do some rendering */
fence1 = SDL_SubmitGPUCommandBufferAndAcquireFence(cmdbuf1); // Defrag happens here

SDL_WaitGPUFence(fence0); // download is in cmdbuf0 so we wait on fence0
void* m = SDL_MapGPUTransferBuffer(t); // Defrag did not happen yet on GPU but transfer buffer points to the new buffer with garbage data
```

The solution is to allocate download buffers on their own dedicated memory blocks so they are not ever defragmented. Download buffers should be pre-allocated and cached under correct API usage so this won't be an issue unless the client does something very silly like allocate thousands of transfer buffers. 