### PR TITLE
VITA: fix SDL_ShowMessageBox by using different memory type (SDL2)

### DIFF
--- a/src/render/vitagxm/SDL_render_vita_gxm_memory.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm_memory.c
@@ -31,6 +31,8 @@ void *vita_mem_alloc(unsigned int type, unsigned int size, unsigned int alignmen
 
     if (type == SCE_KERNEL_MEMBLOCK_TYPE_USER_CDRAM_RW) {
         size = ALIGN(size, 256 * 1024);
+    } else if (type == SCE_KERNEL_MEMBLOCK_TYPE_USER_MAIN_PHYCONT_NC_RW) {
+        size = ALIGN(size, 1024 * 1024);
     } else {
         size = ALIGN(size, 4 * 1024);
     }

--- a/src/render/vitagxm/SDL_render_vita_gxm_tools.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm_tools.c
@@ -1162,7 +1162,7 @@ void gxm_init_for_common_dialog(void)
     for (int i = 0; i < VITA_GXM_BUFFERS; i += 1) {
         buffer_for_common_dialog[i].displayData.wait_vblank = SDL_TRUE;
         buffer_for_common_dialog[i].displayData.address = vita_mem_alloc(
-            SCE_KERNEL_MEMBLOCK_TYPE_USER_CDRAM_RW,
+            SCE_KERNEL_MEMBLOCK_TYPE_USER_MAIN_PHYCONT_NC_RW,
             4 * VITA_GXM_SCREEN_STRIDE * VITA_GXM_SCREEN_HEIGHT,
             SCE_GXM_COLOR_SURFACE_ALIGNMENT,
             SCE_GXM_MEMORY_ATTRIB_READ | SCE_GXM_MEMORY_ATTRIB_WRITE,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Somehow it has gone unnoticed, that since implementing texture memory pool in vita gxm render, there was no gpu mem left for message boxes. This fixes it by using PHYCONT mem for them instead.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
