### PR TITLE
Set version of new identifiers after 3.1.3 release to 3.1.6

### DIFF
--- a/include/SDL3/SDL_error.h
+++ b/include/SDL3/SDL_error.h
@@ -99,7 +99,7 @@ extern SDL_DECLSPEC bool SDLCALL SDL_SetError(SDL_PRINTF_FORMAT_STRING const cha
  *
  * \threadsafety It is safe to call this function from any thread.
  *
- * \since This function is available since SDL 3.1.4.
+ * \since This function is available since SDL 3.1.6.
  *
  * \sa SDL_ClearError
  * \sa SDL_GetError

--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -3722,7 +3722,7 @@ extern SDL_DECLSPEC bool SDLCALL SDL_GPUTextureSupportsSampleCount(
  * \param depth_or_layer_count depth for 3D textures or layer count otherwise.
  * \returns the size of a texture with this format and dimensions.
  *
- * \since This function is available since SDL 3.1.4.
+ * \since This function is available since SDL 3.1.6.
  */
 extern SDL_DECLSPEC Uint32 SDLCALL SDL_CalculateGPUTextureFormatSize(
     SDL_GPUTextureFormat format,

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2306,7 +2306,7 @@ extern "C" {
  *
  * This hint needs to be set before SDL_Init().
  *
- * \since This hint is available since SDL 3.1.4.
+ * \since This hint is available since SDL 3.1.6.
  */
 #define SDL_HINT_MAC_SCROLL_MOMENTUM "SDL_MAC_SCROLL_MOMENTUM"
 
@@ -3167,7 +3167,7 @@ extern "C" {
  *
  * This hint should be set before SDL is initialized.
  *
- * \since This hint is available since SDL 3.1.5.
+ * \since This hint is available since SDL 3.1.6.
  */
 #define SDL_HINT_VIDEO_DISPLAY_PRIORITY "SDL_VIDEO_DISPLAY_PRIORITY"
 

--- a/include/SDL3/SDL_log.h
+++ b/include/SDL3/SDL_log.h
@@ -480,7 +480,7 @@ typedef void (SDLCALL *SDL_LogOutputFunction)(void *userdata, int category, SDL_
  *
  * \threadsafety It is safe to call this function from any thread.
  *
- * \since This function is available since SDL 3.1.4.
+ * \since This function is available since SDL 3.1.6.
  *
  * \sa SDL_SetLogOutputFunction
  * \sa SDL_GetLogOutputFunction

--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -2469,7 +2469,7 @@ extern SDL_DECLSPEC bool SDLCALL SDL_GetRenderVSync(SDL_Renderer *renderer, int 
  *
  * The font is monospaced and square, so this applies to all characters.
  *
- * \since This macro is available since SDL 3.1.5.
+ * \since This macro is available since SDL 3.1.6.
  *
  * \sa SDL_RenderDebugText
  */
@@ -2509,7 +2509,7 @@ extern SDL_DECLSPEC bool SDLCALL SDL_GetRenderVSync(SDL_Renderer *renderer, int 
  *
  * \threadsafety You may only call this function from the main thread.
  *
- * \since This function is available since SDL 3.1.4.
+ * \since This function is available since SDL 3.1.6.
  *
  * \sa SDL_DEBUG_TEXT_FONT_CHARACTER_SIZE
  */

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -2564,7 +2564,7 @@ extern SDL_DECLSPEC Uint32 SDLCALL SDL_StepUTF8(const char **pstr, size_t *pslen
  *
  * \threadsafety It is safe to call this function from any thread.
  *
- * \since This function is available since SDL 3.1.4.
+ * \since This function is available since SDL 3.1.6.
  */
 extern SDL_DECLSPEC Uint32 SDLCALL SDL_StepBackUTF8(const char *start, const char **pstr);
 

--- a/include/SDL3/SDL_system.h
+++ b/include/SDL3/SDL_system.h
@@ -595,7 +595,7 @@ typedef enum SDL_Sandbox
  * \returns the application sandbox environment or SDL_SANDBOX_NONE if the
  *          application is not running in a sandbox environment.
  *
- * \since This function is available since SDL 3.1.4.
+ * \since This function is available since SDL 3.1.6.
  */
 extern SDL_DECLSPEC SDL_Sandbox SDLCALL SDL_GetSandbox(void);
 

--- a/include/SDL3/SDL_timer.h
+++ b/include/SDL3/SDL_timer.h
@@ -147,7 +147,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_DelayNS(Uint64 ns);
  *
  * \threadsafety It is safe to call this function from any thread.
  *
- * \since This function is available since SDL 3.1.4.
+ * \since This function is available since SDL 3.1.6.
  */
 extern SDL_DECLSPEC void SDLCALL SDL_DelayPrecise(Uint64 ns);
 


### PR DESCRIPTION
New identifiers, after the 3.1.3 pre-release are currently marked as either 3.1.4 or 3.1.5 or 3.1.6.

The new pre-release version will be 3.1.6.

This commit sets all those marked as 3.1.4 or 3.1.5 to 3.1.6.