### PR TITLE
examples now using SDL_ALPHA_OPAQUE(_FLOAT) for opaque alpha value

### DIFF
--- a/docs/README-wayland.md
+++ b/docs/README-wayland.md
@@ -212,7 +212,7 @@ int main(int argc, char *argv[])
         SDL_SetWindowSize(sdlWindow, SDL_lround(640. * scale), SDL_lround(480. * scale));
 
         if (qtWindow.isVisible()) {
-            SDL_SetRenderDrawColor(sdlRenderer, 0, 0, 255, 255);
+            SDL_SetRenderDrawColor(sdlRenderer, 0, 0, 255, SDL_ALPHA_OPAQUE);
             SDL_RenderClear(sdlRenderer);
             SDL_RenderPresent(sdlRenderer);
         } else {

--- a/examples/camera/01-read-and-draw/read-and-draw.c
+++ b/examples/camera/01-read-and-draw/read-and-draw.c
@@ -93,7 +93,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
         SDL_ReleaseCameraFrame(camera, frame);
     }
 
-    SDL_SetRenderDrawColor(renderer, 0x99, 0x99, 0x99, 255);
+    SDL_SetRenderDrawColor(renderer, 0x99, 0x99, 0x99, SDL_ALPHA_OPAQUE);
     SDL_RenderClear(renderer);
     if (texture) {  /* draw the latest camera frame, if available. */
         SDL_RenderTexture(renderer, texture, NULL, NULL);

--- a/examples/game/01-snake/snake.c
+++ b/examples/game/01-snake/snake.c
@@ -257,7 +257,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     }
 
     r.w = r.h = SNAKE_BLOCK_SIZE_IN_PIXELS;
-    SDL_SetRenderDrawColor(as->renderer, 0, 0, 0, 255);
+    SDL_SetRenderDrawColor(as->renderer, 0, 0, 0, SDL_ALPHA_OPAQUE);
     SDL_RenderClear(as->renderer);
     for (i = 0; i < SNAKE_GAME_WIDTH; i++) {
         for (j = 0; j < SNAKE_GAME_HEIGHT; j++) {
@@ -266,13 +266,13 @@ SDL_AppResult SDL_AppIterate(void *appstate)
                 continue;
             set_rect_xy_(&r, i, j);
             if (ct == SNAKE_CELL_FOOD)
-                SDL_SetRenderDrawColor(as->renderer, 80, 80, 255, 255);
+                SDL_SetRenderDrawColor(as->renderer, 80, 80, 255, SDL_ALPHA_OPAQUE);
             else /* body */
-                SDL_SetRenderDrawColor(as->renderer, 0, 128, 0, 255);
+                SDL_SetRenderDrawColor(as->renderer, 0, 128, 0, SDL_ALPHA_OPAQUE);
             SDL_RenderFillRect(as->renderer, &r);
         }
     }
-    SDL_SetRenderDrawColor(as->renderer, 255, 255, 0, 255); /*head*/
+    SDL_SetRenderDrawColor(as->renderer, 255, 255, 0, SDL_ALPHA_OPAQUE); /*head*/
     set_rect_xy_(&r, ctx->head_xpos, ctx->head_ypos);
     SDL_RenderFillRect(as->renderer, &r);
     SDL_RenderPresent(as->renderer);

--- a/examples/pen/01-drawing-lines/drawing-lines.c
+++ b/examples/pen/01-drawing-lines/drawing-lines.c
@@ -45,7 +45,7 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
 
     /* just blank the render target to gray to start. */
     SDL_SetRenderTarget(renderer, render_target);
-    SDL_SetRenderDrawColor(renderer, 100, 100, 100, 255);
+    SDL_SetRenderDrawColor(renderer, 100, 100, 100, SDL_ALPHA_OPAQUE);
     SDL_RenderClear(renderer);
     SDL_SetRenderTarget(renderer, NULL);
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
@@ -90,7 +90,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
 {
     /* make sure we're drawing to the window and not the render target */
     SDL_SetRenderTarget(renderer, NULL);
-    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, SDL_ALPHA_OPAQUE);
     SDL_RenderClear(renderer);  /* just in case. */
     SDL_RenderTexture(renderer, render_target, NULL, NULL);
     SDL_RenderPresent(renderer);

--- a/examples/renderer/01-clear/clear.c
+++ b/examples/renderer/01-clear/clear.c
@@ -49,7 +49,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     const float red = (float) (0.5 + 0.5 * SDL_sin(now));
     const float green = (float) (0.5 + 0.5 * SDL_sin(now + SDL_PI_D * 2 / 3));
     const float blue = (float) (0.5 + 0.5 * SDL_sin(now + SDL_PI_D * 4 / 3));
-    SDL_SetRenderDrawColorFloat(renderer, red, green, blue, 1.0f);  /* new color, full alpha. */
+    SDL_SetRenderDrawColorFloat(renderer, red, green, blue, SDL_ALPHA_OPAQUE_FLOAT);  /* new color, full alpha. */
 
     /* clear the window to the draw color. */
     SDL_RenderClear(renderer);

--- a/examples/renderer/02-primitives/primitives.c
+++ b/examples/renderer/02-primitives/primitives.c
@@ -55,22 +55,22 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     SDL_FRect rect;
 
     /* as you can see from this, rendering draws over whatever was drawn before it. */
-    SDL_SetRenderDrawColor(renderer, 33, 33, 33, 255);  /* dark gray, full alpha */
+    SDL_SetRenderDrawColor(renderer, 33, 33, 33, SDL_ALPHA_OPAQUE);  /* dark gray, full alpha */
     SDL_RenderClear(renderer);  /* start with a blank canvas. */
 
     /* draw a filled rectangle in the middle of the canvas. */
-    SDL_SetRenderDrawColor(renderer, 0, 0, 255, 255);  /* blue, full alpha */
+    SDL_SetRenderDrawColor(renderer, 0, 0, 255, SDL_ALPHA_OPAQUE);  /* blue, full alpha */
     rect.x = rect.y = 100;
     rect.w = 440;
     rect.h = 280;
     SDL_RenderFillRect(renderer, &rect);
 
     /* draw some points across the canvas. */
-    SDL_SetRenderDrawColor(renderer, 255, 0, 0, 255);  /* red, full alpha */
+    SDL_SetRenderDrawColor(renderer, 255, 0, 0, SDL_ALPHA_OPAQUE);  /* red, full alpha */
     SDL_RenderPoints(renderer, points, SDL_arraysize(points));
 
     /* draw a unfilled rectangle in-set a little bit. */
-    SDL_SetRenderDrawColor(renderer, 0, 255, 0, 255);  /* green, full alpha */
+    SDL_SetRenderDrawColor(renderer, 0, 255, 0, SDL_ALPHA_OPAQUE);  /* green, full alpha */
     rect.x += 30;
     rect.y += 30;
     rect.w -= 60;
@@ -78,7 +78,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     SDL_RenderRect(renderer, &rect);
 
     /* draw two lines in an X across the whole canvas. */
-    SDL_SetRenderDrawColor(renderer, 255, 255, 0, 255);  /* yellow, full alpha */
+    SDL_SetRenderDrawColor(renderer, 255, 255, 0, SDL_ALPHA_OPAQUE);  /* yellow, full alpha */
     SDL_RenderLine(renderer, 0, 0, 640, 480);
     SDL_RenderLine(renderer, 0, 480, 640, 0);
 

--- a/examples/renderer/03-lines/lines.c
+++ b/examples/renderer/03-lines/lines.c
@@ -56,18 +56,18 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     };
 
     /* as you can see from this, rendering draws over whatever was drawn before it. */
-    SDL_SetRenderDrawColor(renderer, 100, 100, 100, 255);  /* grey, full alpha */
+    SDL_SetRenderDrawColor(renderer, 100, 100, 100, SDL_ALPHA_OPAQUE);  /* grey, full alpha */
     SDL_RenderClear(renderer);  /* start with a blank canvas. */
 
     /* You can draw lines, one at a time, like these brown ones... */
-    SDL_SetRenderDrawColor(renderer, 127, 49, 32, 255);
+    SDL_SetRenderDrawColor(renderer, 127, 49, 32, SDL_ALPHA_OPAQUE);
     SDL_RenderLine(renderer, 240, 450, 400, 450);
     SDL_RenderLine(renderer, 240, 356, 400, 356);
     SDL_RenderLine(renderer, 240, 356, 240, 450);
     SDL_RenderLine(renderer, 400, 356, 400, 450);
 
     /* You can also draw a series of connected lines in a single batch... */
-    SDL_SetRenderDrawColor(renderer, 0, 255, 0, 255);
+    SDL_SetRenderDrawColor(renderer, 0, 255, 0, SDL_ALPHA_OPAQUE);
     SDL_RenderLines(renderer, line_points, SDL_arraysize(line_points));
 
     /* here's a bunch of lines drawn out from a center point in a circle. */
@@ -76,7 +76,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
         const float size = 30.0f;
         const float x = 320.0f;
         const float y = 95.0f - (size / 2.0f);
-        SDL_SetRenderDrawColor(renderer, SDL_rand(256), SDL_rand(256), SDL_rand(256), 255);
+        SDL_SetRenderDrawColor(renderer, SDL_rand(256), SDL_rand(256), SDL_rand(256), SDL_ALPHA_OPAQUE);
         SDL_RenderLine(renderer, x, y, x + SDL_sinf((float) i) * size, y + SDL_cosf((float) i) * size);
     }
 

--- a/examples/renderer/04-points/points.c
+++ b/examples/renderer/04-points/points.c
@@ -97,9 +97,9 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     last_time = now;
 
     /* as you can see from this, rendering draws over whatever was drawn before it. */
-    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);  /* black, full alpha */
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, SDL_ALPHA_OPAQUE);  /* black, full alpha */
     SDL_RenderClear(renderer);  /* start with a blank canvas. */
-    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);  /* white, full alpha */
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, SDL_ALPHA_OPAQUE);  /* white, full alpha */
     SDL_RenderPoints(renderer, points, SDL_arraysize(points));  /* draw all the points! */
 
     /* You can also draw single points with SDL_RenderPoint(), but it's

--- a/examples/renderer/05-rectangles/rectangles.c
+++ b/examples/renderer/05-rectangles/rectangles.c
@@ -55,7 +55,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     const float scale = ((float) (((int) (now % 1000)) - 500) / 500.0f) * direction;
 
     /* as you can see from this, rendering draws over whatever was drawn before it. */
-    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);  /* black, full alpha */
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, SDL_ALPHA_OPAQUE);  /* black, full alpha */
     SDL_RenderClear(renderer);  /* start with a blank canvas. */
 
     /* Rectangles are comprised of set of X and Y coordinates, plus width and
@@ -66,7 +66,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     /* Let's draw a single rectangle (square, really). */
     rects[0].x = rects[0].y = 100;
     rects[0].w = rects[0].h = 100 + (100 * scale);
-    SDL_SetRenderDrawColor(renderer, 255, 0, 0, 255);  /* red, full alpha */
+    SDL_SetRenderDrawColor(renderer, 255, 0, 0, SDL_ALPHA_OPAQUE);  /* red, full alpha */
     SDL_RenderRect(renderer, &rects[0]);
 
     /* Now let's draw several rectangles with one function call. */
@@ -76,7 +76,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
         rects[i].x = (WINDOW_WIDTH - rects[i].w) / 2;  /* center it. */
         rects[i].y = (WINDOW_HEIGHT - rects[i].h) / 2;  /* center it. */
     }
-    SDL_SetRenderDrawColor(renderer, 0, 255, 0, 255);  /* green, full alpha */
+    SDL_SetRenderDrawColor(renderer, 0, 255, 0, SDL_ALPHA_OPAQUE);  /* green, full alpha */
     SDL_RenderRects(renderer, rects, 3);  /* draw three rectangles at once */
 
     /* those were rectangle _outlines_, really. You can also draw _filled_ rectangles! */
@@ -84,7 +84,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     rects[0].y = 50;
     rects[0].w = 100 + (100 * scale);
     rects[0].h = 50 + (50 * scale);
-    SDL_SetRenderDrawColor(renderer, 0, 0, 255, 255);  /* blue, full alpha */
+    SDL_SetRenderDrawColor(renderer, 0, 0, 255, SDL_ALPHA_OPAQUE);  /* blue, full alpha */
     SDL_RenderFillRect(renderer, &rects[0]);
 
     /* ...and also fill a bunch of rectangles at once... */
@@ -96,7 +96,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
         rects[i].w = w;
         rects[i].h = h;
     }
-    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);  /* white, full alpha */
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, SDL_ALPHA_OPAQUE);  /* white, full alpha */
     SDL_RenderFillRects(renderer, rects, SDL_arraysize(rects));
 
     SDL_RenderPresent(renderer);  /* put it all on the screen! */

--- a/examples/renderer/06-textures/textures.c
+++ b/examples/renderer/06-textures/textures.c
@@ -86,7 +86,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     const float scale = ((float) (((int) (now % 1000)) - 500) / 500.0f) * direction;
 
     /* as you can see from this, rendering draws over whatever was drawn before it. */
-    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);  /* black, full alpha */
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, SDL_ALPHA_OPAQUE);  /* black, full alpha */
     SDL_RenderClear(renderer);  /* start with a blank canvas. */
 
     /* Just draw the static texture a few times. You can think of it like a

--- a/examples/renderer/07-streaming-textures/streaming-textures.c
+++ b/examples/renderer/07-streaming-textures/streaming-textures.c
@@ -83,7 +83,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     }
 
     /* as you can see from this, rendering draws over whatever was drawn before it. */
-    SDL_SetRenderDrawColor(renderer, 66, 66, 66, 255);  /* grey, full alpha */
+    SDL_SetRenderDrawColor(renderer, 66, 66, 66, SDL_ALPHA_OPAQUE);  /* grey, full alpha */
     SDL_RenderClear(renderer);  /* start with a blank canvas. */
 
     /* Just draw the static texture a few times. You can think of it like a

--- a/examples/renderer/08-rotating-textures/rotating-textures.c
+++ b/examples/renderer/08-rotating-textures/rotating-textures.c
@@ -86,7 +86,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     const float rotation = (((float) ((int) (now % 2000))) / 2000.0f) * 360.0f;
 
     /* as you can see from this, rendering draws over whatever was drawn before it. */
-    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);  /* black, full alpha */
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, SDL_ALPHA_OPAQUE);  /* black, full alpha */
     SDL_RenderClear(renderer);  /* start with a blank canvas. */
 
     /* Center this one, and draw it with some rotation so it spins! */

--- a/examples/renderer/09-scaling-textures/scaling-textures.c
+++ b/examples/renderer/09-scaling-textures/scaling-textures.c
@@ -86,7 +86,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     const float scale = ((float) (((int) (now % 1000)) - 500) / 500.0f) * direction;
 
     /* as you can see from this, rendering draws over whatever was drawn before it. */
-    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);  /* black, full alpha */
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, SDL_ALPHA_OPAQUE);  /* black, full alpha */
     SDL_RenderClear(renderer);  /* start with a blank canvas. */
 
     /* center this one and make it grow and shrink. */

--- a/examples/renderer/10-geometry/geometry.c
+++ b/examples/renderer/10-geometry/geometry.c
@@ -89,7 +89,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     int i;
 
     /* as you can see from this, rendering draws over whatever was drawn before it. */
-    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);  /* black, full alpha */
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, SDL_ALPHA_OPAQUE);  /* black, full alpha */
     SDL_RenderClear(renderer);  /* start with a blank canvas. */
 
     /* Draw a single triangle with a different color at each vertex. Center this one and make it grow and shrink. */

--- a/examples/renderer/11-color-mods/color-mods.c
+++ b/examples/renderer/11-color-mods/color-mods.c
@@ -86,7 +86,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     const float blue = (float) (0.5 + 0.5 * SDL_sin(now + SDL_PI_D * 4 / 3));
 
     /* as you can see from this, rendering draws over whatever was drawn before it. */
-    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);  /* black, full alpha */
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, SDL_ALPHA_OPAQUE);  /* black, full alpha */
     SDL_RenderClear(renderer);  /* start with a blank canvas. */
 
     /* Just draw the static texture a few times. You can think of it like a

--- a/examples/renderer/14-viewport/viewport.c
+++ b/examples/renderer/14-viewport/viewport.c
@@ -86,7 +86,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
        window. It does _not_ scale rendering to fit the viewport. */
 
     /* as you can see from this, rendering draws over whatever was drawn before it. */
-    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);  /* black, full alpha */
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, SDL_ALPHA_OPAQUE);  /* black, full alpha */
     SDL_RenderClear(renderer);  /* start with a blank canvas. */
 
     /* Draw once with the whole window as the viewport. */

--- a/examples/renderer/15-cliprect/cliprect.c
+++ b/examples/renderer/15-cliprect/cliprect.c
@@ -116,7 +116,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     /* okay, now draw! */
 
     /* Note that SDL_RenderClear is _not_ affected by the clipping rectangle! */
-    SDL_SetRenderDrawColor(renderer, 33, 33, 33, 255);  /* grey, full alpha */
+    SDL_SetRenderDrawColor(renderer, 33, 33, 33, SDL_ALPHA_OPAQUE);  /* grey, full alpha */
     SDL_RenderClear(renderer);  /* start with a blank canvas. */
 
     /* stretch the texture across the entire window. Only the piece in the

--- a/examples/renderer/17-read-pixels/read-pixels.c
+++ b/examples/renderer/17-read-pixels/read-pixels.c
@@ -96,7 +96,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     const float rotation = (((float) ((int) (now % 2000))) / 2000.0f) * 360.0f;
 
     /* as you can see from this, rendering draws over whatever was drawn before it. */
-    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);  /* black, full alpha */
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, SDL_ALPHA_OPAQUE);  /* black, full alpha */
     SDL_RenderClear(renderer);  /* start with a blank canvas. */
 
     /* Center this one, and draw it with some rotation so it spins! */

--- a/examples/renderer/18-debug-text/debug-text.c
+++ b/examples/renderer/18-debug-text/debug-text.c
@@ -47,16 +47,16 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
 SDL_AppResult SDL_AppIterate(void *appstate)
 {
     /* as you can see from this, rendering draws over whatever was drawn before it. */
-    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);  /* black, full alpha */
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, SDL_ALPHA_OPAQUE);  /* black, full alpha */
     SDL_RenderClear(renderer);  /* start with a blank canvas. */
 
-    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);  /* white, full alpha */
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, SDL_ALPHA_OPAQUE);  /* white, full alpha */
     SDL_RenderDebugText(renderer, 272, 100, "Hello world!");
     SDL_RenderDebugText(renderer, 224, 150, "This is some debug text.");
 
-    SDL_SetRenderDrawColor(renderer, 51, 102, 255, 255);  /* light blue, full alpha */
+    SDL_SetRenderDrawColor(renderer, 51, 102, 255, SDL_ALPHA_OPAQUE);  /* light blue, full alpha */
     SDL_RenderDebugText(renderer, 184, 200, "You can do it in different colors.");
-    SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);  /* white, full alpha */
+    SDL_SetRenderDrawColor(renderer, 255, 255, 255, SDL_ALPHA_OPAQUE);  /* white, full alpha */
 
     SDL_SetRenderScale(renderer, 4.0f, 4.0f);
     SDL_RenderDebugText(renderer, 14, 65, "It can be scaled.");


### PR DESCRIPTION
The new official examples are great, but they use 255 for opaque value, whereas you have proper #defines for int and float.

Let's then use SDL_ALPHA_OPAQUE(_FLOAT), what do you think?
