### PR TITLE
Make building SDL without X11 or Wayland harder

### DIFF
--- a/.github/workflows/create-test-plan.py
+++ b/.github/workflows/create-test-plan.py
@@ -608,7 +608,7 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool) -> JobDeta
             job.cmake_arguments.extend((
                 f"-DCMAKE_C_COMPILER={job.cc}",
                 f"-DCMAKE_CXX_COMPILER={job.cxx}",
-                "-DCMAKE_SYSTEM_NAME=Haiku",
+                "-DSDL_UNIX_CONSOLE_BUILD=ON",
             ))
             job.shared_lib = SharedLibType.SO_0
             job.static_lib = StaticLibType.A
@@ -621,6 +621,9 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool) -> JobDeta
             job.apt_packages = []
             job.shared_lib = SharedLibType.SO_0
             job.static_lib = StaticLibType.A
+            job.cmake_arguments.extend((
+                "-DSDL_UNIX_CONSOLE_BUILD=ON",
+            ))
         case SdlPlatform.LoongArch64:
             job.run_tests = False
             job.cc = "${LOONGARCH64_CC}"
@@ -628,6 +631,7 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool) -> JobDeta
             job.cmake_arguments.extend((
                 f"-DCMAKE_C_COMPILER={job.cc}",
                 f"-DCMAKE_CXX_COMPILER={job.cxx}",
+                "-DSDL_UNIX_CONSOLE_BUILD=ON",
                 "-DCMAKE_SYSTEM_NAME=Linux",
             ))
             job.shared_lib = SharedLibType.SO_0

--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -394,11 +394,21 @@ function(SDL_PrintSummary)
     message(STATUS "")
   endif()
 
-  if(UNIX AND NOT (ANDROID OR APPLE OR EMSCRIPTEN))
+  if(UNIX AND NOT (ANDROID OR APPLE OR EMSCRIPTEN OR HAIKU OR RISCOS))
     if(NOT (HAVE_X11 OR HAVE_WAYLAND))
-      message(STATUS "SDL is being built without a X11 or wayland video driver.")
-      message(STATUS "The library will not be able to create windows on most unix environments.")
-      message(STATUS "")
+      if(NOT SDL_UNIX_CONSOLE_BUILD)
+        message(FATAL_ERROR
+          "SDL could not find X11 or Wayland development libraries on your system. "
+          "This means SDL will not be able to create windows on a typical unix operating system. "
+          "Most likely, this is not wanted."
+          "\n"
+          "On Linux, install the packages listed at "
+          "https://github.com/libsdl-org/SDL/blob/main/docs/README-linux.md#build-dependencies "
+          "\n"
+          "If you really don't need desktop windows, the documentation tells you how to skip this check. "
+          "https://github.com/libsdl-org/SDL/blob/main/docs/README-cmake.md#cmake-fails-to-build-without-x11-or-wayland-support\n"
+        )
+      endif()
     endif()
   endif()
 endfunction()

--- a/docs/README-cmake.md
+++ b/docs/README-cmake.md
@@ -306,6 +306,14 @@ Configure your project with `-DSDL_LIBC=ON` to make use of sanitizers.
 
 ## CMake FAQ
 
+### CMake fails to build without X11 or Wayland support
+
+Install the required system packages prior to running CMake.
+See [README-linux][README-linux.md#build-dependencies] for the list of dependencies on Linux.
+Other unix operationg systems should provide similar packages.
+
+If you **really** don't need to show windows, add `-DSDL_UNIX_CONSOLE_BUILD=ON` to the CMake configure command.
+
 ### How do I copy a SDL3 dynamic library to another location?
 
 Use [CMake generator expressions](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#target-dependent-expressions).


### PR DESCRIPTION
It's still possible to build SDL by configuring with `-DSDL_NO_UNIX_DESKTOP_SANITY_CHECK=ON`

The error message is:
```console
CMake Error at cmake/macros.cmake:404 (message):
  SDL could not find X11 or Wayland development libraries on your system.
  This means SDL will not be able to create windows on a typical *nix
  operating system.  Most likely, this is not wanted.

  On Linux, install the packages listed at
  https://github.com/libsdl-org/SDL/blob/main/docs/README-linux.md#build-dependencies


  If you really don't need desktop windows, the documentation tells you how
  to skip this check.
  https://github.com/libsdl-org/SDL/blob/main/docs/README-cmake.md#cmake-fails-to-build-without-x11-or-wayland-support
```

Error on ci:
https://github.com/madebr/SDL/actions/runs/11485462451/job/31965601937#step:23:533


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
