### PR TITLE
Allow defining custom SDL_SINT64_C and SDL_UINT64_C macros

### DIFF
--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -256,6 +256,8 @@ void *alloca(size_t);
      (SDL_static_cast(Uint32, SDL_static_cast(Uint8, (C))) << 16) | \
      (SDL_static_cast(Uint32, SDL_static_cast(Uint8, (D))) << 24))
 
+#if !(defined(SDL_SINT64_C) && defined(SDL_UINT64_C))
+
 #ifdef SDL_WIKI_DOCUMENTATION_SECTION
 
 /**
@@ -296,6 +298,8 @@ void *alloca(size_t);
 #else
 #define SDL_SINT64_C(c)  c ## LL
 #define SDL_UINT64_C(c)  c ## ULL
+#endif
+
 #endif
 
 /**

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -300,7 +300,7 @@ void *alloca(size_t);
 #define SDL_UINT64_C(c)  c ## ULL
 #endif
 
-#endif
+#endif /* !(defined(SDL_SINT64_C) && defined(SDL_UINT64_C)) */
 
 /**
  *  \name Basic data types


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Allows defining custom `SDL_SINT64_C(c)` and `SDL_UINT64_C(c)` macros. Similar to how you can currently [define custom `SDL_PRIs64`](https://github.com/libsdl-org/SDL/blob/a04fda211c296162301ff09359796b72414aa535/include/SDL3/SDL_stdinc.h#L426-L435), etc macros.

This is useful for getting equivalent binding generation on windows and unix. See our troubles in https://github.com/ppy/SDL3-CS/pull/169.
