### PR TITLE
README-ios.md: Add info about UIApplicationSupportsIndirectInputEvents on iOS 17

### DIFF
--- a/docs/README-ios.md
+++ b/docs/README-ios.md
@@ -140,6 +140,8 @@ Notes -- Mouse
 
 iOS now supports Bluetooth mice on iPad, but by default will provide the mouse input as touch. In order for SDL to see the real mouse events, you should set the key UIApplicationSupportsIndirectInputEvents to true in your Info.plist
 
+From iOS 17 onward, the key now defaults to true.
+
 
 Notes -- Reading and Writing files
 ==============================================================================


### PR DESCRIPTION
From the [docs]:(https://developer.apple.com/documentation/bundleresources/information_property_list/uiapplicationsupportsindirectinputevents)

> In iOS 17 and later, the system defaults to supporting indirect input events, meaning it treats your app the same as if you specify YES.

## Description
Added info about it

## Existing Issue(s)

