### PR TITLE
ci: upload build config headers

### DIFF
--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -365,7 +365,9 @@ jobs:
         with:
           if-no-files-found: error
           name: '${{ matrix.platform.artifact }}'
-          path: build/dist/SDL3*
+          path: |
+            build/dist/SDL3*
+            build/include*
       - name: 'Upload minidumps'
         uses: actions/upload-artifact@v4
         if: ${{ always() && steps.tests.outcome == 'failure' && (matrix.platform.platform == 'msvc' || matrix.platform.platform == 'msys2') }}

--- a/android-project/app/src/main/AndroidManifest.xml
+++ b/android-project/app/src/main/AndroidManifest.xml
@@ -56,6 +56,12 @@
     <!-- Allow access to the vibrator -->
     <uses-permission android:name="android.permission.VIBRATE" />
 
+    <!-- Allow access to Internet -->
+    <!-- if you want to connect to the network or internet, uncomment this. -->
+    <!--
+    <uses-permission android:name="android.permission.INTERNET" />
+    -->
+
     <!-- Create a Java class extending SDLActivity and place it in a
          directory under app/src/main/java matching the package, e.g. app/src/main/java/com/gamemaker/game/MyGame.java
 

--- a/examples/game/01-snake/snake.c
+++ b/examples/game/01-snake/snake.c
@@ -310,6 +310,9 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
     }
 
     AppState *as = SDL_calloc(1, sizeof(AppState));
+    if (!as) {
+        return SDL_APP_FAILURE;
+    }
 
     *appstate = as;
 


### PR DESCRIPTION
After this change, `SDL_build_config.h` (and `SDL_revision.h`) generated by CMake will be in the GitHub artifacts.

This pr also:
- adds a null pointer check to the snake example
- add a disabled permission to the Android manifest to access the internet. This is a requirement for SDL3_net.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
