### PR TITLE
Add version info when building CI/CD for apple platforms

### DIFF
--- a/.github/workflows/create-test-plan.py
+++ b/.github/workflows/create-test-plan.py
@@ -465,6 +465,7 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool) -> JobDeta
                     job.cmake_arguments.extend([
                         "-DCMAKE_SYSTEM_NAME=iOS",
                         "-DCMAKE_OSX_ARCHITECTURES=\"arm64\"",
+                        "-DCMAKE_OSX_DEPLOYMENT_TARGET=9.0",
                     ])
                 case SdlPlatform.Tvos:
                     if spec.xcode:
@@ -472,6 +473,7 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool) -> JobDeta
                     job.cmake_arguments.extend([
                         "-DCMAKE_SYSTEM_NAME=tvOS",
                         "-DCMAKE_OSX_ARCHITECTURES=\"arm64\"",
+                        "-DCMAKE_OSX_DEPLOYMENT_TARGET=9.0",
                     ])
         case SdlPlatform.MacOS:
             if spec.apple_framework:
@@ -480,6 +482,7 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool) -> JobDeta
                 job.test_pkg_config = False
                 job.cmake_arguments.extend((
                     "'-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64'",
+                    "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.11",
                     "-DSDL_FRAMEWORK=ON",
                 ))
                 job.shared_lib = SharedLibType.FRAMEWORK
@@ -487,6 +490,7 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool) -> JobDeta
                 job.clang_tidy = True
                 job.cmake_arguments.extend((
                     "-DCMAKE_OSX_ARCHITECTURES=arm64",
+                    "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.11",
                     "-DCLANG_TIDY_BINARY=$(brew --prefix llvm)/bin/clang-tidy",
                 ))
                 job.shared_lib = SharedLibType.DYLIB

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,7 @@ jobs:
               -DCMAKE_PREFIX_PATH="${{ steps.mount.outputs.mount_point }}"  \
               -DCMAKE_SYSTEM_NAME=Darwin                                    \
               -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"                      \
+              -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11                           \
               -Werror=dev                                                   \
               -B build_darwin
           cmake --build build_darwin --config Release --verbose
@@ -174,6 +175,7 @@ jobs:
               -DCMAKE_PREFIX_PATH="${{ steps.mount.outputs.mount_point }}/SDL3.xcframework/macos-arm64_x86_64"  \
               -DCMAKE_SYSTEM_NAME=Darwin                                                                        \
               -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"                                                          \
+              -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11                                                               \
               -Werror=dev                                                                                       \
               -B build_darwin_2
           cmake --build build_darwin --config Release --verbose
@@ -186,6 +188,7 @@ jobs:
               -DCMAKE_PREFIX_PATH="${{ steps.mount.outputs.mount_point }}"  \
               -DCMAKE_SYSTEM_NAME=iOS                                       \
               -DCMAKE_OSX_ARCHITECTURES="arm64"                             \
+              -DCMAKE_OSX_DEPLOYMENT_TARGET=9.0                             \
               -Werror=dev                                                   \
               -B build_ios
           cmake --build build_ios --config Release --verbose
@@ -198,6 +201,7 @@ jobs:
               -DCMAKE_PREFIX_PATH="${{ steps.mount.outputs.mount_point }}"  \
               -DCMAKE_SYSTEM_NAME=tvOS                                      \
               -DCMAKE_OSX_ARCHITECTURES="arm64"                             \
+              -DCMAKE_OSX_DEPLOYMENT_TARGET=9.0                             \
               -Werror=dev                                                   \
               -B build_tvos
           cmake --build build_tvos --config Release --verbose
@@ -213,6 +217,7 @@ jobs:
               -DCMAKE_SYSTEM_NAME=iOS                                       \
               -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"                      \
               -DCMAKE_OSX_SYSROOT="${sysroot}"                              \
+              -DCMAKE_OSX_DEPLOYMENT_TARGET=9.0                             \
               -Werror=dev                                                   \
               -B build_ios_simulator
           cmake --build build_ios_simulator --config Release --verbose
@@ -228,6 +233,7 @@ jobs:
               -DCMAKE_SYSTEM_NAME=tvOS                                      \
               -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"                      \
               -DCMAKE_OSX_SYSROOT="${sysroot}"                              \
+              -DCMAKE_OSX_DEPLOYMENT_TARGET=9.0                             \
               -Werror=dev                                                   \
               -B build_tvos_simulator
           cmake --build build_tvos_simulator --config Release --verbose

--- a/docs/README-cmake.md
+++ b/docs/README-cmake.md
@@ -226,29 +226,29 @@ CMake documentation: [link](https://cmake.org/cmake/help/latest/variable/CMAKE_O
 - for macOS, building a dylib and/or static library for x86_64 and arm64:
 
     ```bash
-    cmake ~/sdl -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
+    cmake ~/sdl -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11
 
 - for macOS, building an universal framework for x86_64 and arm64:
 
     ```bash
-    cmake ~/sdl -DSDL_FRAMEWORK=ON -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
+    cmake ~/sdl -DSDL_FRAMEWORK=ON -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11
 
 - for iOS-Simulator, using the latest, installed SDK:
 
     ```bash
-    cmake ~/sdl -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphonesimulator -DCMAKE_OSX_ARCHITECTURES=x86_64
+    cmake ~/sdl -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphonesimulator -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_DEPLOYMENT_TARGET=9.0
     ```
 
 - for iOS-Device, using the latest, installed SDK, 64-bit only
 
     ```bash
-    cmake ~/sdl -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphoneos -DCMAKE_OSX_ARCHITECTURES=arm64
+    cmake ~/sdl -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphoneos -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=9.0
     ```
 
 - for iOS-Device, using the latest, installed SDK, mixed 32/64 bit
 
     ```cmake
-    cmake ~/sdl -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphoneos -DCMAKE_OSX_ARCHITECTURES="arm64;armv7s"
+    cmake ~/sdl -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphoneos -DCMAKE_OSX_ARCHITECTURES="arm64;armv7s" -DCMAKE_OSX_DEPLOYMENT_TARGET=9.0
     ```
 
 - for iOS-Device, using a specific SDK revision (iOS 12.4, in this example):
@@ -260,19 +260,19 @@ CMake documentation: [link](https://cmake.org/cmake/help/latest/variable/CMAKE_O
 - for iOS-Simulator, using the latest, installed SDK, and building SDL test apps (as .app bundles):
 
     ```cmake
-    cmake ~/sdl -DSDL_TESTS=1 -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphonesimulator -DCMAKE_OSX_ARCHITECTURES=x86_64
+    cmake ~/sdl -DSDL_TESTS=1 -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphonesimulator -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_DEPLOYMENT_TARGET=9.0
     ```
 
 - for tvOS-Simulator, using the latest, installed SDK:
 
     ```cmake
-    cmake ~/sdl -DCMAKE_SYSTEM_NAME=tvOS -DCMAKE_OSX_SYSROOT=appletvsimulator -DCMAKE_OSX_ARCHITECTURES=x86_64
+    cmake ~/sdl -DCMAKE_SYSTEM_NAME=tvOS -DCMAKE_OSX_SYSROOT=appletvsimulator -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_DEPLOYMENT_TARGET=9.0
     ```
 
 - for tvOS-Device, using the latest, installed SDK:
 
     ```cmake
-    cmake ~/sdl -DCMAKE_SYSTEM_NAME=tvOS -DCMAKE_OSX_SYSROOT=appletvos -DCMAKE_OSX_ARCHITECTURES=arm64`
+    cmake ~/sdl -DCMAKE_SYSTEM_NAME=tvOS -DCMAKE_OSX_SYSROOT=appletvos -DCMAKE_OSX_ARCHITECTURES=arm64` -DCMAKE_OSX_DEPLOYMENT_TARGET=9.0
     ```
 
 - for QNX/aarch64, using the latest, installed SDK:

--- a/docs/README-macos.md
+++ b/docs/README-macos.md
@@ -13,7 +13,7 @@ To build SDL using the command line, use the CMake build script:
 ```bash
 mkdir build
 cd build
-cmake ..
+cmake .. -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11
 cmake --build .
 sudo cmake --install .
 ```
@@ -25,7 +25,7 @@ You can also build SDL as a Universal library (a single binary for both
 ```bash
 mkdir build
 cd build
-cmake .. "-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64"
+cmake .. "-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11
 cmake --build .
 sudo cmake --install .
 ```


### PR DESCRIPTION
Sets minimum OS version when building for macOS, iOS, and tvOS
See: https://github.com/libsdl-org/SDL/issues/11332 and https://github.com/libsdl-org/SDL/issues/11333

## Description
This sets the minimum version for the following platforms rather than using the newest:
macOS to 11.0 or higher (currently 14)
iOS to 13.0 or higher (currently 17)
tvOS to 13.0 or higher (currently 17)
Using the values suggested at https://github.com/libsdl-org/SDL/issues/11332#issuecomment-2438953930

## Existing Issue(s)
This has revealed a few issues with SDL GPU on older iOS/tvOS versions; already discussed in https://github.com/libsdl-org/SDL/issues/11333 and directly with TheSpyDog