### PR TITLE
SDL_EnumerateDirectory(): (posix) Fix return value when directory is invalid.

### DIFF
--- a/src/filesystem/posix/SDL_sysfsops.c
+++ b/src/filesystem/posix/SDL_sysfsops.c
@@ -40,8 +40,7 @@ bool SDL_SYS_EnumerateDirectory(const char *path, const char *dirname, SDL_Enume
 
     DIR *dir = opendir(path);
     if (!dir) {
-        SDL_SetError("Can't open directory: %s", strerror(errno));
-        return -1;
+        return SDL_SetError("Can't open directory: %s", strerror(errno));
     }
 
     struct dirent *ent;


### PR DESCRIPTION
Return `false` instead of `-1`.