### PR TITLE
SDL_CreateDirectory(): Clear error message when it succeeds after first failing

### DIFF
--- a/src/filesystem/SDL_filesystem.c
+++ b/src/filesystem/SDL_filesystem.c
@@ -107,6 +107,11 @@ bool SDL_CreateDirectory(const char *path)
         }
 
         SDL_free(parents);
+
+        // clear error message when all is good after some hiccups
+        if (retval) {
+            SDL_ClearError();
+        }
     }
     return retval;
 }


### PR DESCRIPTION
I noticed that sometimes `SDL_CreateDirectory()` sets an error message even if it returned true and directories were created.

This happens when creating a not yet existing directory tree.

Here is a small test case for `./testfilesystem`:

<details><summary>diff</summary>
<p>

```diff
diff --git a/test/testfilesystem.c b/test/testfilesystem.c
index 3a068a0f2..281699b75 100644
--- a/test/testfilesystem.c
+++ b/test/testfilesystem.c
@@ -133,8 +133,16 @@ int main(int argc, char *argv[])
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_CreateDirectory('testfilesystem-test/1') failed: %s", SDL_GetError());
         } else if (!SDL_CreateDirectory("testfilesystem-test/1")) {  /* THIS SHOULD NOT FAIL! Making a directory that already exists should succeed here. */
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_CreateDirectory('testfilesystem-test/1') failed: %s", SDL_GetError());
-        } else if (!SDL_CreateDirectory("testfilesystem-test/3/4/5/6")) {  /* THIS SHOULD NOT FAIL! Making a directory with missing parents succeed here. */
+        } else if (SDL_ClearError(),
+                   SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "INFO : SDL_GetError(): %s", SDL_GetError()),
+                   false) {
+            /**/
+        } else if (SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "INFO : Calling SDL_CreateDirectory(\"testfilesystem-test/3/4/5/6\");"),
+                   !SDL_CreateDirectory("testfilesystem-test/3/4/5/6")) { /* THIS SHOULD NOT FAIL! Making a directory with missing parents succeed here. */
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_CreateDirectory('testfilesystem-test/3/4/5/6') failed: %s", SDL_GetError());
+        } else if (SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "INFO : SDL_GetError(): %s", SDL_GetError()),
+                  false) {
+            /**/
         } else if (!SDL_RemovePath("testfilesystem-test/3/4/5/6")) {  /* THIS SHOULD NOT FAIL! Making a directory with missing parents succeed here. */
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_RemovePath('testfilesystem-test/3/4/5/6') failed: %s", SDL_GetError());
         } else if (!SDL_RemovePath("testfilesystem-test/3/4/5")) {  /* THIS SHOULD NOT FAIL! Making a directory with missing parents succeed here. */

```

</p>
</details> 

Which then outputs this at the end:
```
GLOB[218]: 'CMakeFiles/testaudiostreamdynamicresample.dir/testaudiostreamdynamicresample.c.o'
GLOB[219]: 'CMakeFiles/testaudiostreamdynamicresample.dir/testaudiostreamdynamicresample.c.o.d'
INFO : SDL_GetError(): 
INFO : Calling SDL_CreateDirectory("testfilesystem-test/3/4/5/6");
INFO : SDL_GetError(): Can't create directory: No such file or directory
```

True is returned with a set error message when `SDL_CreateDirectory()` internally first fails, but then eventually succeeds after getting everything sorted with all directory parents.

This commit checks at the end of the function if it succeeded after first failing and clears the error message.