### PR TITLE
SDL_CreateDirectory(): directory tree creation for absolute paths for non-Windows platforms

### DIFF
--- a/src/filesystem/SDL_filesystem.c
+++ b/src/filesystem/SDL_filesystem.c
@@ -89,6 +89,9 @@ bool SDL_CreateDirectory(const char *path)
                 }
                 #else
                 const bool issep = (ch == '/');
+                if (issep && ((ptr - parents) == 0)) {
+                    continue; // it's just the root directory, skip it.
+                }
                 #endif
 
                 if (issep) {


### PR DESCRIPTION
On Windows it was already implemented.