### PR TITLE
add SDL_RenderTextureAffine

### DIFF
--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -2088,6 +2088,36 @@ extern SDL_DECLSPEC bool SDLCALL SDL_RenderTextureRotated(SDL_Renderer *renderer
                                                      SDL_FlipMode flip);
 
 /**
+ * Copy a portion of the source texture to the current rendering target, with
+ * affine transform, at subpixel precision.
+ *
+ * \param renderer the renderer which should copy parts of a texture.
+ * \param texture the source texture.
+ * \param srcrect a pointer to the source rectangle, or NULL for the entire
+ *                texture.
+ * \param origin a pointer to a point indicating where the top-left corner of 
+                 srcrect should be mapped to, or NULL for the rendering 
+                 target's origin.
+ * \param right a pointer to a point indicating where the top-right corner of
+                srcrect should be mapped to, or NULL for the rendering 
+                target's top-right corner.
+ * \param down a pointer to a point indicating where the bottom-left corner 
+               of srcrect should be mapped to, or NULL for the rendering 
+               target's bottom-left corner.
+ * \returns true on success or false on failure; call SDL_GetError() for more
+ *          information.
+ *
+ * \threadsafety You may only call this function from the main thread.
+ *
+ * \since This function is available since SDL 3.0.0.
+ *
+ * \sa SDL_RenderTexture
+ */
+extern SDL_DECLSPEC bool SDLCALL SDL_RenderTextureAffine(SDL_Renderer *renderer, SDL_Texture *texture,
+                                                     const SDL_FRect *srcrect, const SDL_FPoint *origin,
+                                                     const SDL_FPoint *right, const SDL_FPoint *down);
+
+/**
  * Tile a portion of the texture to the current rendering target at subpixel
  * precision.
  *


### PR DESCRIPTION
Closes #11279 

This is the lowest-possible overhead API for planar texture copy, leaving the responsibility of calculating the points entirely to the users, allowing them to perform flips, stretches, shears, and rotations by calculating the basis vectors directly.

```c
bool SDL_RenderTextureAffine(
    SDL_Renderer *renderer, 
    SDL_Texture *texture,
    const SDL_FRect *srcrect,
    const SDL_FPoint *origin,
    const SDL_FPoint *right,
    const SDL_FPoint *down
)
```

Type | Name | Description
-- | -- | --
SDL_Renderer * | renderer | the renderer which should copy parts of a texture.
SDL_Texture * | texture | the source texture.
const SDL_FRect * | srcrect | a pointer to the source rectangle, or NULL for the entire texture.
const SDL_FPoint * | origin | a pointer to a point indicating the location the top-left corner of srcrect should be mapped to, or NULL for the rendering target's origin.
const SDL_FPoint * | right | a pointer to a point indicating the location the top-right corner of srcrect should be mapped to, or NULL for the rendering target's top-right corner.
const SDL_FPoint * | down | a pointer to a point indicating the location the bottom-left corner of srcrect should be mapped to, or NULL for the rendering target's bottom-left corner.

![image](https://github.com/user-attachments/assets/a4753e65-2d3f-4aa7-a36c-899a1d8e07d9)

