### PR TITLE
Fix issue #11328

### DIFF
--- a/include/SDL3/SDL_vulkan.h
+++ b/include/SDL3/SDL_vulkan.h
@@ -258,4 +258,7 @@ extern SDL_DECLSPEC bool SDLCALL SDL_Vulkan_GetPresentationSupport(VkInstance in
 #endif
 #include <SDL3/SDL_close_code.h>
 
+#undef VK_DEFINE_HANDLE
+#undef VK_DEFINE_NON_DISPATCHABLE_HANDLE
+
 #endif /* SDL_vulkan_h_ */

--- a/include/SDL3/SDL_vulkan.h
+++ b/include/SDL3/SDL_vulkan.h
@@ -69,6 +69,10 @@ VK_DEFINE_HANDLE(VkPhysicalDevice)
 VK_DEFINE_NON_DISPATCHABLE_HANDLE(VkSurfaceKHR)
 struct VkAllocationCallbacks;
 
+/* Make sure to undef to avoid issues in case of later vulkan include */
+#undef VK_DEFINE_HANDLE
+#undef VK_DEFINE_NON_DISPATCHABLE_HANDLE
+
 #endif /* !NO_SDL_VULKAN_TYPEDEFS */
 
 /**
@@ -257,8 +261,5 @@ extern SDL_DECLSPEC bool SDLCALL SDL_Vulkan_GetPresentationSupport(VkInstance in
 }
 #endif
 #include <SDL3/SDL_close_code.h>
-
-#undef VK_DEFINE_HANDLE
-#undef VK_DEFINE_NON_DISPATCHABLE_HANDLE
 
 #endif /* SDL_vulkan_h_ */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add the lines
```cpp
#undef VK_DEFINE_HANDLER
#undef VK_DEFINE_NON_DISPATCHABLE_HANDLE
```
At the end of `SDL_vulkan.h` to allow `vulkan/vulkan.h` to define `VK_NULL_HANDLE` (and certainly other stuff as well) properly for C++ and `vulkan/vulkan.hpp`.

This change was tested using https://github.com/feelamee/sdl-bug-with-vulkan-cpp-api (for checking compilation errors) and SDL's testvulkan on x86-64 archlinux, and compiled with gcc.

## Existing Issue(s)
Fix to issue #11328
