### PR TITLE
GPU: Add GPU subsystem to iOS build config

### DIFF
--- a/include/build_config/SDL_build_config_ios.h
+++ b/include/build_config/SDL_build_config_ios.h
@@ -197,15 +197,12 @@
 #endif
 
 #if SDL_PLATFORM_SUPPORTS_METAL
-#define SDL_VIDEO_RENDER_METAL  1
-#endif
-
-#if SDL_PLATFORM_SUPPORTS_METAL
-#define SDL_VIDEO_VULKAN 1
-#endif
-
-#if SDL_PLATFORM_SUPPORTS_METAL
 #define SDL_VIDEO_METAL 1
+#define SDL_GPU_METAL 1
+#define SDL_VIDEO_RENDER_METAL 1
+#define SDL_VIDEO_VULKAN 1
+#define SDL_GPU_VULKAN 1
+#define SDL_VIDEO_RENDER_GPU  1
 #endif
 
 /* Enable system power support */


### PR DESCRIPTION
Enables the GPU subsystem (with Vulkan and Metal drivers) and the GPU Render backend for iOS.

Since there's a handful of defines guarded by `SDL_PLATFORM_SUPPORTS_METAL`, I consolidated them all into a single `#if` block.