### PR TITLE
Explicity specify C source file in VS examples

### DIFF
--- a/VisualC/examples/audio/01-simple-playback/01-simple-playback.vcxproj
+++ b/VisualC/examples/audio/01-simple-playback/01-simple-playback.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\audio\01-simple-playback\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\audio\01-simple-playback\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\audio\01-simple-playback\simple-playback.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/VisualC/examples/audio/02-simple-playback-callback/02-simple-playback-callback.vcxproj
+++ b/VisualC/examples/audio/02-simple-playback-callback/02-simple-playback-callback.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\audio\02-simple-playback-callback\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\audio\02-simple-playback-callback\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\audio\02-simple-playback-callback\simple-playback-callback.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/VisualC/examples/audio/03-load-wav/03-load-wav.vcxproj
+++ b/VisualC/examples/audio/03-load-wav/03-load-wav.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\audio\03-load-wav\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\audio\03-load-wav\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\audio\03-load-wav\load-wav.c" />
     <Content Include="$(SolutionDir)\..\test\sample.wav" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/VisualC/examples/camera/01-read-and-draw/01-read-and-draw.vcxproj
+++ b/VisualC/examples/camera/01-read-and-draw/01-read-and-draw.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\camera\01-read-and-draw\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\camera\01-read-and-draw\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\camera\01-read-and-draw\read-and-draw.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/VisualC/examples/game/01-snake/01-snake.vcxproj
+++ b/VisualC/examples/game/01-snake/01-snake.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\game\01-snake\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\game\01-snake\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\game\01-snake\snake.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/VisualC/examples/game/02-woodeneye-008/02-woodeneye-008.vcxproj
+++ b/VisualC/examples/game/02-woodeneye-008/02-woodeneye-008.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\game\02-woodeneye-008\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\game\02-woodeneye-008\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\game\02-woodeneye-008\woodeneye-008.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/VisualC/examples/game/03-infinite-monkeys/03-infinite-monkeys.vcxproj
+++ b/VisualC/examples/game/03-infinite-monkeys/03-infinite-monkeys.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\game\03-infinite-monkeys\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\game\03-infinite-monkeys\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\game\03-infinite-monkeys\infinite-monkeys.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/VisualC/examples/generate.py
+++ b/VisualC/examples/generate.py
@@ -4,7 +4,8 @@ import uuid
 
 REPOSITORY_ROOT = pathlib.Path(__file__).parent.parent.parent
 
-def generate(category, example_name):
+
+def generate(category, example_name, c_source_file):
     guid = str(uuid.uuid4()).upper()
     text = f"""
 <?xml version="1.0" encoding="utf-8"?>
@@ -16,7 +17,7 @@ def generate(category, example_name):
   <Import Project="$(VCTargetsPath)\\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\\..\\examples\\{category}\\{example_name}\\README.txt" />
-    <ClCompile Include="$(SolutionDir)\\..\\examples\\{category}\\{example_name}\\*.c" />
+    <ClCompile Include="$(SolutionDir)\\..\\examples\\{category}\\{example_name}\\{c_source_file}" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\\Microsoft.Cpp.targets" />
 </Project>
@@ -34,12 +35,19 @@ def generate(category, example_name):
         f.write(text)
 
 
+def get_c_source_filename(example_dir: pathlib.Path):
+    """Gets the one and only C source file name in the directory of the example."""
+    c_files = [f.name for f in example_dir.iterdir() if f.name.endswith(".c")]
+    assert len(c_files) == 1
+    return c_files[0]
+
+
 def main():
     path = REPOSITORY_ROOT / "examples"
     for category in path.iterdir():
         if category.is_dir():
             for example in category.iterdir():
-                generate(category.name, example.name)
+                generate(category.name, example.name, get_c_source_filename(example))
 
 
 if __name__ == "__main__":

--- a/VisualC/examples/generate.py
+++ b/VisualC/examples/generate.py
@@ -4,7 +4,7 @@ import uuid
 
 REPOSITORY_ROOT = pathlib.Path(__file__).parent.parent.parent
 
-def generate(x, y):
+def generate(category, example_name):
     guid = str(uuid.uuid4()).upper()
     text = f"""
 <?xml version="1.0" encoding="utf-8"?>
@@ -15,31 +15,31 @@ def generate(x, y):
   <Import Project="$(VCTargetsPath)\\Microsoft.Cpp.Default.props" />
   <Import Project="$(VCTargetsPath)\\Microsoft.Cpp.props" />
   <ItemGroup>
-    <None Include="$(SolutionDir)\\..\\examples\\{x}\\{y}\\README.txt" />
-    <ClCompile Include="$(SolutionDir)\\..\\examples\\{x}\\{y}\\*.c" />
+    <None Include="$(SolutionDir)\\..\\examples\\{category}\\{example_name}\\README.txt" />
+    <ClCompile Include="$(SolutionDir)\\..\\examples\\{category}\\{example_name}\\*.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\\Microsoft.Cpp.targets" />
 </Project>
 """.strip()
 
-    file_name = REPOSITORY_ROOT / "VisualC" / "examples" / x / y / f"{y}.vcxproj"
-    
-    if file_name.exists():
-        print("Skipping:", file_name)
+    project_file = REPOSITORY_ROOT / "VisualC" / "examples" / category / example_name / f"{example_name}.vcxproj"
+
+    if project_file.exists():
+        print("Skipping:", project_file)
         return
 
-    print("Generating file:", file_name)
-    os.makedirs(file_name.parent, exist_ok=True)
-    with open(file_name, "w", encoding="utf-8") as f:
+    print("Generating file:", project_file)
+    os.makedirs(project_file.parent, exist_ok=True)
+    with open(project_file, "w", encoding="utf-8") as f:
         f.write(text)
 
 
 def main():
     path = REPOSITORY_ROOT / "examples"
-    for x in path.iterdir():
-        if x.is_dir():
-            for y in x.iterdir():
-                generate(x.name, y.name)
+    for category in path.iterdir():
+        if category.is_dir():
+            for example in category.iterdir():
+                generate(category.name, example.name)
 
 
 if __name__ == "__main__":

--- a/VisualC/examples/pen/01-drawing-lines/01-drawing-lines.vcxproj
+++ b/VisualC/examples/pen/01-drawing-lines/01-drawing-lines.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\pen\01-drawing-lines\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\pen\01-drawing-lines\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\pen\01-drawing-lines\drawing-lines.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/VisualC/examples/renderer/01-clear/01-clear.vcxproj
+++ b/VisualC/examples/renderer/01-clear/01-clear.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\renderer\01-clear\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\renderer\01-clear\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\renderer\01-clear\clear.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/VisualC/examples/renderer/02-primitives/02-primitives.vcxproj
+++ b/VisualC/examples/renderer/02-primitives/02-primitives.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\renderer\02-primitives\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\renderer\02-primitives\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\renderer\02-primitives\primitives.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/VisualC/examples/renderer/03-lines/03-lines.vcxproj
+++ b/VisualC/examples/renderer/03-lines/03-lines.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\renderer\03-lines\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\renderer\03-lines\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\renderer\03-lines\lines.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/VisualC/examples/renderer/04-points/04-points.vcxproj
+++ b/VisualC/examples/renderer/04-points/04-points.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\renderer\04-points\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\renderer\04-points\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\renderer\04-points\points.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/VisualC/examples/renderer/05-rectangles/05-rectangles.vcxproj
+++ b/VisualC/examples/renderer/05-rectangles/05-rectangles.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\renderer\05-rectangles\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\renderer\05-rectangles\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\renderer\05-rectangles\rectangles.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/VisualC/examples/renderer/06-textures/06-textures.vcxproj
+++ b/VisualC/examples/renderer/06-textures/06-textures.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\renderer\06-textures\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\renderer\06-textures\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\renderer\06-textures\textures.c" />
     <Content Include="$(SolutionDir)\..\test\sample.bmp" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/VisualC/examples/renderer/07-streaming-textures/07-streaming-textures.vcxproj
+++ b/VisualC/examples/renderer/07-streaming-textures/07-streaming-textures.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\renderer\07-streaming-textures\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\renderer\07-streaming-textures\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\renderer\07-streaming-textures\streaming-textures.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/VisualC/examples/renderer/08-rotating-textures/08-rotating-textures.vcxproj
+++ b/VisualC/examples/renderer/08-rotating-textures/08-rotating-textures.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\renderer\08-rotating-textures\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\renderer\08-rotating-textures\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\renderer\08-rotating-textures\rotating-textures.c" />
     <Content Include="$(SolutionDir)\..\test\sample.bmp" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/VisualC/examples/renderer/09-scaling-textures/09-scaling-textures.vcxproj
+++ b/VisualC/examples/renderer/09-scaling-textures/09-scaling-textures.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\renderer\09-scaling-textures\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\renderer\09-scaling-textures\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\renderer\09-scaling-textures\scaling-textures.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/VisualC/examples/renderer/10-geometry/10-geometry.vcxproj
+++ b/VisualC/examples/renderer/10-geometry/10-geometry.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\renderer\10-geometry\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\renderer\10-geometry\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\renderer\10-geometry\geometry.c" />
     <Content Include="$(SolutionDir)\..\test\sample.bmp" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/VisualC/examples/renderer/11-color-mods/11-color-mods.vcxproj
+++ b/VisualC/examples/renderer/11-color-mods/11-color-mods.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\renderer\11-color-mods\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\renderer\11-color-mods\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\renderer\11-color-mods\color-mods.c" />
     <Content Include="$(SolutionDir)\..\test\sample.bmp" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/VisualC/examples/renderer/14-viewport/14-viewport.vcxproj
+++ b/VisualC/examples/renderer/14-viewport/14-viewport.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\renderer\14-viewport\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\renderer\14-viewport\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\renderer\14-viewport\viewport.c" />
     <Content Include="$(SolutionDir)\..\test\sample.bmp" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/VisualC/examples/renderer/15-cliprect/15-cliprect.vcxproj
+++ b/VisualC/examples/renderer/15-cliprect/15-cliprect.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\renderer\15-cliprect\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\renderer\15-cliprect\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\renderer\15-cliprect\cliprect.c" />
     <Content Include="$(SolutionDir)\..\test\sample.bmp" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/VisualC/examples/renderer/17-read-pixels/17-read-pixels.vcxproj
+++ b/VisualC/examples/renderer/17-read-pixels/17-read-pixels.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\renderer\17-read-pixels\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\renderer\17-read-pixels\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\renderer\17-read-pixels\read-pixels.c" />
     <Content Include="$(SolutionDir)\..\test\sample.bmp" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/VisualC/examples/renderer/18-debug-text/18-debug-text.vcxproj
+++ b/VisualC/examples/renderer/18-debug-text/18-debug-text.vcxproj
@@ -7,7 +7,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ItemGroup>
     <None Include="$(SolutionDir)\..\examples\renderer\18-debug-text\README.txt" />
-    <ClCompile Include="$(SolutionDir)\..\examples\renderer\18-debug-text\*.c" />
+    <ClCompile Include="$(SolutionDir)\..\examples\renderer\18-debug-text\debug-text.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removes the wildcard from `<ClCompile>`  to prevent visual studio warnings. Instead, the C source file name is explicitly specified when generating the project files.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
- https://github.com/libsdl-org/SDL/pull/11255#issuecomment-2445169931