### PR TITLE
Supress Metal warning when compiling against macOS 10.11-10.13

### DIFF
--- a/src/video/khronos/vulkan/vulkan_metal.h
+++ b/src/video/khronos/vulkan/vulkan_metal.h
@@ -88,8 +88,11 @@ typedef void* MTLTexture_id;
 
 typedef struct __IOSurface* IOSurfaceRef;
 #ifdef __OBJC__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
 @protocol MTLSharedEvent;
 typedef __unsafe_unretained id<MTLSharedEvent> MTLSharedEvent_id;
+#pragma clang diagnostic pop
 #else
 typedef void* MTLSharedEvent_id;
 #endif


### PR DESCRIPTION
When targeting versions 10.13, you will receive this warning/error:

In both SDL_cocoavulkan.m and SDL_cocoavideo.m:
SDL/src/video/khronos/vulkan/vulkan_metal.h:92:32: 'MTLSharedEvent' is only available on macOS 10.14 or newer

This is the last remaining issue that will cause CI/CD to fail when we set the target to older apple platforms.

## Existing Issue(s)
See https://github.com/libsdl-org/SDL/issues/11371
