### PR TITLE
Refresh cursor visibility when relative-mode hint is set

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2509,9 +2509,10 @@ extern "C" {
  * A variable controlling whether the hardware cursor stays visible when
  * relative mode is active.
  *
- * This variable can be set to the following values: "0" - The cursor will be
- * hidden while relative mode is active (default) "1" - The cursor will remain
- * visible while relative mode is active
+ * This variable can be set to the following values: 
+ *
+ * - "0" - The cursor will be hidden while relative mode is active (default) 
+ * - "1" - The cursor will remain visible while relative mode is active
  *
  * Note that for systems without raw hardware inputs, relative mode is
  * implemented using warping, so the hardware cursor will visibly warp between

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2511,8 +2511,8 @@ extern "C" {
  *
  * This variable can be set to the following values: 
  *
- * - "0" - The cursor will be hidden while relative mode is active (default) 
- * - "1" - The cursor will remain visible while relative mode is active
+ * - "0": The cursor will be hidden while relative mode is active (default) 
+ * - "1": The cursor will remain visible while relative mode is active
  *
  * Note that for systems without raw hardware inputs, relative mode is
  * implemented using warping, so the hardware cursor will visibly warp between

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -200,6 +200,8 @@ static void SDLCALL SDL_MouseRelativeCursorVisibleChanged(void *userdata, const 
     SDL_Mouse *mouse = (SDL_Mouse *)userdata;
 
     mouse->relative_mode_cursor_visible = SDL_GetStringBoolean(hint, false);
+    
+    SDL_SetCursor(NULL); // Update cursor visibility
 }
 
 // Public functions


### PR DESCRIPTION
A one-liner fix. Also fix formatting in the doc comments. 