### PR TITLE
`SDL_GetMouseNameForID()`: Set an error message for invalid mouse IDs.

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -389,6 +389,7 @@ const char *SDL_GetMouseNameForID(SDL_MouseID instance_id)
 {
     int mouse_index = SDL_GetMouseIndex(instance_id);
     if (mouse_index < 0) {
+        SDL_SetError("Mouse %" SDL_PRIu32 " not found", instance_id);
         return NULL;
     }
     return SDL_GetPersistentString(SDL_mice[mouse_index].name);


### PR DESCRIPTION
Currently `SDL_GetMouseNameForID()` doesn't set an error message, when passing an invalid mouse ID:
```c
if(!SDL_GetMouseNameForID(99)) {
    printf("Error \"%s\"", SDL_GetError());
}
```
Prints
```c
""
```

This commits sets an error message when the function fails.

The style of the message is inspired by a similar joystick error message:
https://github.com/libsdl-org/SDL/blob/68cc173d9293e890ba93feaed1d3dc17742aa9b3/src/joystick/SDL_joystick.c#L515
