### PR TITLE
Use __declspec(dllimport) in function declarations when not building SDL

### DIFF
--- a/include/SDL3/SDL_begin_code.h
+++ b/include/SDL3/SDL_begin_code.h
@@ -57,7 +57,7 @@
 #  ifdef DLL_EXPORT
 #   define SDL_DECLSPEC __declspec(dllexport)
 #  else
-#   define SDL_DECLSPEC
+#   define SDL_DECLSPEC __declspec(dllimport)
 #  endif
 # else
 #  if defined(__GNUC__) && __GNUC__ >= 4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`__declspec(dllimport)`  allows msvc to produce more efficient machine code for a client importing dll symbols. I am guessing this was not set because it was possible to statically link SDL in the past, but it seems that there is no static library provided in the release binaries and it is the expectation one use SDL3.dll?

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
