### PR TITLE
SDL_GetClosestFullscreenDisplayMode(): Rename parameter `mode` to `closest`

### DIFF
--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -2210,7 +2210,6 @@ The following functions have been renamed:
 * SDL_SetWindowDisplayMode() => SDL_SetWindowFullscreenMode(), returns bool
 
 The following functions have been removed:
-* SDL_GetClosestFullscreenDisplayMode()
 * SDL_GetDisplayDPI() - not reliable across platforms, approximately replaced by multiplying SDL_GetWindowDisplayScale() times 160 on iPhone and Android, and 96 on other platforms.
 * SDL_GetDisplayMode()
 * SDL_GetNumDisplayModes() - replaced with SDL_GetFullscreenDisplayModes()

--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -665,7 +665,7 @@ extern SDL_DECLSPEC SDL_DisplayMode ** SDLCALL SDL_GetFullscreenDisplayModes(SDL
  *                     for the desktop refresh rate.
  * \param include_high_density_modes boolean to include high density modes in
  *                                   the search.
- * \param mode a pointer filled in with the closest display mode equal to or
+ * \param closest a pointer filled in with the closest display mode equal to or
  *             larger than the desired mode.
  * \returns true on success or false on failure; call SDL_GetError() for more
  *          information.
@@ -675,7 +675,7 @@ extern SDL_DECLSPEC SDL_DisplayMode ** SDLCALL SDL_GetFullscreenDisplayModes(SDL
  * \sa SDL_GetDisplays
  * \sa SDL_GetFullscreenDisplayModes
  */
-extern SDL_DECLSPEC bool SDLCALL SDL_GetClosestFullscreenDisplayMode(SDL_DisplayID displayID, int w, int h, float refresh_rate, bool include_high_density_modes, SDL_DisplayMode *mode);
+extern SDL_DECLSPEC bool SDLCALL SDL_GetClosestFullscreenDisplayMode(SDL_DisplayID displayID, int w, int h, float refresh_rate, bool include_high_density_modes, SDL_DisplayMode *closest);
 
 /**
  * Get information about the desktop's display mode.

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1319,14 +1319,16 @@ SDL_DisplayMode **SDL_GetFullscreenDisplayModes(SDL_DisplayID displayID, int *co
 
 bool SDL_GetClosestFullscreenDisplayMode(SDL_DisplayID displayID, int w, int h, float refresh_rate, bool include_high_density_modes, SDL_DisplayMode *result)
 {
+    if (!result) {
+        return SDL_InvalidParamError("closest"); // Parameter `result` is called `closest` in the header.
+    }
+
     const SDL_DisplayMode *mode, *closest = NULL;
     float aspect_ratio;
     int i;
     SDL_VideoDisplay *display = SDL_GetVideoDisplay(displayID);
 
-    if (result) {
-        SDL_zerop(result);
-    }
+    SDL_zerop(result);
 
     CHECK_DISPLAY_MAGIC(display, false);
 
@@ -1378,9 +1380,9 @@ bool SDL_GetClosestFullscreenDisplayMode(SDL_DisplayID displayID, int w, int h, 
     if (!closest) {
         return SDL_SetError("Couldn't find any matching video modes");
     }
-    if (result) {
-        SDL_copyp(result, closest);
-    }
+
+    SDL_copyp(result, closest);
+
     return true;
 }
 


### PR DESCRIPTION
This commit does the following:
- SDL_GetClosestFullscreenDisplayMode(): Renames parameter `mode` to `closest`.

- Inside SDL_GetClosestFullscreenDisplayMode(): Checks, if the parameter is NULL at the beginning of the function.
(It doesn't really make sense to call the function without a valid parameter. It just returns true/false if there is/isn't a closest mode, but doesn't set any.)

- README-migration.md: SDL_GetClosestFullscreenDisplayMode() was listed as removed. This commit deletes this entry.