### PR TITLE
Refactor iOS text input activation to better work with hardware keyboards

### DIFF
--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -352,6 +352,7 @@ struct SDL_VideoDevice
     bool (*HasScreenKeyboardSupport)(SDL_VideoDevice *_this);
     void (*ShowScreenKeyboard)(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesID props);
     void (*HideScreenKeyboard)(SDL_VideoDevice *_this, SDL_Window *window);
+    void (*SetTextInputProperties)(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesID props);
     bool (*IsScreenKeyboardShown)(SDL_VideoDevice *_this, SDL_Window *window);
 
     // Clipboard

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -5294,6 +5294,10 @@ bool SDL_StartTextInputWithProperties(SDL_Window *window, SDL_PropertiesID props
         }
     }
 
+    if (_this->SetTextInputProperties) {
+        _this->SetTextInputProperties(_this, window, props);
+    }
+
     // Show the on-screen keyboard, if desired
     if (AutoShowingScreenKeyboard() && !SDL_ScreenKeyboardShown(window)) {
         if (_this->ShowScreenKeyboard) {

--- a/src/video/uikit/SDL_uikitvideo.m
+++ b/src/video/uikit/SDL_uikitvideo.m
@@ -99,6 +99,7 @@ static SDL_VideoDevice *UIKit_CreateDevice(void)
         device->HasScreenKeyboardSupport = UIKit_HasScreenKeyboardSupport;
         device->StartTextInput = UIKit_StartTextInput;
         device->StopTextInput = UIKit_StopTextInput;
+        device->SetTextInputProperties = UIKit_SetTextInputProperties;
         device->IsScreenKeyboardShown = UIKit_IsScreenKeyboardShown;
         device->UpdateTextInputArea = UIKit_UpdateTextInputArea;
 #endif

--- a/src/video/uikit/SDL_uikitvideo.m
+++ b/src/video/uikit/SDL_uikitvideo.m
@@ -97,8 +97,8 @@ static SDL_VideoDevice *UIKit_CreateDevice(void)
 
 #ifdef SDL_IPHONE_KEYBOARD
         device->HasScreenKeyboardSupport = UIKit_HasScreenKeyboardSupport;
-        device->ShowScreenKeyboard = UIKit_ShowScreenKeyboard;
-        device->HideScreenKeyboard = UIKit_HideScreenKeyboard;
+        device->StartTextInput = UIKit_StartTextInput;
+        device->StopTextInput = UIKit_StopTextInput;
         device->IsScreenKeyboardShown = UIKit_IsScreenKeyboardShown;
         device->UpdateTextInputArea = UIKit_UpdateTextInputArea;
 #endif

--- a/src/video/uikit/SDL_uikitviewcontroller.h
+++ b/src/video/uikit/SDL_uikitviewcontroller.h
@@ -90,6 +90,7 @@
 bool UIKit_HasScreenKeyboardSupport(SDL_VideoDevice *_this);
 bool UIKit_StartTextInput(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesID props);
 bool UIKit_StopTextInput(SDL_VideoDevice *_this, SDL_Window *window);
+void UIKit_SetTextInputProperties(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesID props);
 bool UIKit_IsScreenKeyboardShown(SDL_VideoDevice *_this, SDL_Window *window);
 bool UIKit_UpdateTextInputArea(SDL_VideoDevice *_this, SDL_Window *window);
 #endif

--- a/src/video/uikit/SDL_uikitviewcontroller.h
+++ b/src/video/uikit/SDL_uikitviewcontroller.h
@@ -69,8 +69,8 @@
 #endif
 
 #ifdef SDL_IPHONE_KEYBOARD
-- (void)showKeyboard;
-- (void)hideKeyboard;
+- (bool)startTextInput;
+- (bool)stopTextInput;
 - (void)initKeyboard;
 - (void)deinitKeyboard;
 
@@ -79,7 +79,7 @@
 
 - (void)updateKeyboard;
 
-@property(nonatomic, assign, getter=isKeyboardVisible) BOOL keyboardVisible;
+@property(nonatomic, assign, getter=isTextFieldFocused) BOOL textFieldFocused;
 @property(nonatomic, assign) SDL_Rect textInputRect;
 @property(nonatomic, assign) int keyboardHeight;
 #endif
@@ -88,8 +88,8 @@
 
 #ifdef SDL_IPHONE_KEYBOARD
 bool UIKit_HasScreenKeyboardSupport(SDL_VideoDevice *_this);
-void UIKit_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesID props);
-void UIKit_HideScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window);
+bool UIKit_StartTextInput(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesID props);
+bool UIKit_StopTextInput(SDL_VideoDevice *_this, SDL_Window *window);
 bool UIKit_IsScreenKeyboardShown(SDL_VideoDevice *_this, SDL_Window *window);
 bool UIKit_UpdateTextInputArea(SDL_VideoDevice *_this, SDL_Window *window);
 #endif

--- a/src/video/uikit/SDL_uikitviewcontroller.m
+++ b/src/video/uikit/SDL_uikitviewcontroller.m
@@ -80,7 +80,6 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 
 #ifdef SDL_IPHONE_KEYBOARD
     SDLUITextField *textField;
-    BOOL showingKeyboard;
     BOOL hidingKeyboard;
     BOOL rotatingOrientation;
     NSString *committedText;
@@ -97,7 +96,6 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 
 #ifdef SDL_IPHONE_KEYBOARD
         [self initKeyboard];
-        showingKeyboard = NO;
         hidingKeyboard = NO;
         rotatingOrientation = NO;
 #endif
@@ -264,7 +262,7 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 
 @synthesize textInputRect;
 @synthesize keyboardHeight;
-@synthesize keyboardVisible;
+@synthesize textFieldFocused;
 
 // Set ourselves up as a UITextFieldDelegate
 - (void)initKeyboard
@@ -277,17 +275,13 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
     committedText = textField.text;
 
     textField.hidden = YES;
-    keyboardVisible = NO;
+    textFieldFocused = NO;
 
     NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
 #ifndef SDL_PLATFORM_TVOS
     [center addObserver:self
                selector:@selector(keyboardWillShow:)
                    name:UIKeyboardWillShowNotification
-                 object:nil];
-    [center addObserver:self
-               selector:@selector(keyboardDidShow:)
-                   name:UIKeyboardDidShowNotification
                  object:nil];
     [center addObserver:self
                selector:@selector(keyboardWillHide:)
@@ -343,8 +337,10 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 
     [view addSubview:textField];
 
-    if (keyboardVisible) {
-        [self showKeyboard];
+    if (textFieldFocused) {
+        /* startTextInput has been called before the text field was added to the view,
+         * call it again for the text field to actually become first responder. */
+        [self startTextInput];
     }
 }
 
@@ -368,9 +364,6 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
                       name:UIKeyboardWillShowNotification
                     object:nil];
     [center removeObserver:self
-                      name:UIKeyboardDidShowNotification
-                    object:nil];
-    [center removeObserver:self
                       name:UIKeyboardWillHideNotification
                     object:nil];
     [center removeObserver:self
@@ -382,7 +375,7 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
                     object:nil];
 }
 
-- (void)setKeyboardProperties:(SDL_PropertiesID) props
+- (void)setTextFieldProperties:(SDL_PropertiesID) props
 {
     textField.secureTextEntry = NO;
 
@@ -479,43 +472,36 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
     }
 }
 
-// reveal onscreen virtual keyboard
-- (void)showKeyboard
+/* requests the SDL text field to become focused and accept text input.
+ * also shows the onscreen virtual keyboard if no hardware keyboard is attached. */
+- (bool)startTextInput
 {
-    if (keyboardVisible) {
-        return;
+    textFieldFocused = YES;
+    if (!textField.window) {
+        /* textField has not been added to the view yet,
+         * we will try again when that happens. */
+        return true;
     }
 
-    keyboardVisible = YES;
-    if (textField.window) {
-        showingKeyboard = YES;
-        [textField becomeFirstResponder];
-    }
+    return [textField becomeFirstResponder];
 }
 
-// hide onscreen virtual keyboard
-- (void)hideKeyboard
+/* requests the SDL text field to lose focus and stop accepting text input.
+ * also hides the onscreen virtual keyboard if no hardware keyboard is attached. */
+- (bool)stopTextInput
 {
-    if (!keyboardVisible) {
-        return;
+    textFieldFocused = NO;
+    if (!textField.window) {
+        /* textField has not been added to the view yet,
+         * we will try again when that happens. */
+        return true;
     }
 
-    keyboardVisible = NO;
-    if (textField.window) {
-        hidingKeyboard = YES;
-        [textField resignFirstResponder];
-    }
+    return [textField resignFirstResponder];
 }
 
 - (void)keyboardWillShow:(NSNotification *)notification
 {
-    BOOL shouldStartTextInput = NO;
-
-    if (!SDL_TextInputActive(window) && !hidingKeyboard && !rotatingOrientation) {
-        shouldStartTextInput = YES;
-    }
-
-    showingKeyboard = YES;
 #ifndef SDL_PLATFORM_TVOS
     CGRect kbrect = [[notification userInfo][UIKeyboardFrameEndUserInfoKey] CGRectValue];
 
@@ -526,28 +512,29 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
     [self setKeyboardHeight:(int)kbrect.size.height];
 #endif
 
-    if (shouldStartTextInput) {
+    /* A keyboard hide transition has been interrupted with a show (keyboardWillHide has been called but keyboardDidHide didn't).
+     * since text input was stopped by the hide, we have to start it again. */
+    if (hidingKeyboard) {
         SDL_StartTextInput(window);
+        hidingKeyboard = NO;
     }
-}
-
-- (void)keyboardDidShow:(NSNotification *)notification
-{
-    showingKeyboard = NO;
 }
 
 - (void)keyboardWillHide:(NSNotification *)notification
 {
-    BOOL shouldStopTextInput = NO;
-
-    if (SDL_TextInputActive(window) && !showingKeyboard && !rotatingOrientation) {
-        shouldStopTextInput = YES;
-    }
-
     hidingKeyboard = YES;
     [self setKeyboardHeight:0];
 
-    if (shouldStopTextInput) {
+    /* When the user dismisses the software keyboard by the "hide" button in the bottom right corner,
+     * we want to reflect that on SDL_TextInputActive by calling SDL_StopTextInput...on certain conditions */
+    if (SDL_TextInputActive(window)
+        /* keyboardWillHide gets called when a hardware keyboard is attached,
+         * keep text input state active if hiding while there is a hardware keyboard.
+         * if the hardware keyboard gets detached, the software keyboard will appear anyway. */
+        && !SDL_HasKeyboard()
+        /* When the device changes orientation, a sequence of hide and show transitions are triggered.
+         * keep text input state active in this case. */
+        && !rotatingOrientation) {
         SDL_StopTextInput(window);
     }
 }
@@ -630,7 +617,6 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 
 - (void)setKeyboardHeight:(int)height
 {
-    keyboardVisible = height > 0;
     keyboardHeight = height;
     [self updateKeyboard];
 }
@@ -651,7 +637,7 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 - (BOOL)textFieldShouldReturn:(UITextField *)_textField
 {
     SDL_SendKeyboardKeyAutoRelease(0, SDL_SCANCODE_RETURN);
-    if (keyboardVisible &&
+    if (textFieldFocused &&
         SDL_GetHintBoolean(SDL_HINT_RETURN_KEY_HIDES_IME, false)) {
         SDL_StopTextInput(window);
     }
@@ -682,20 +668,20 @@ bool UIKit_HasScreenKeyboardSupport(SDL_VideoDevice *_this)
     return true;
 }
 
-void UIKit_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesID props)
+bool UIKit_StartTextInput(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesID props)
 {
     @autoreleasepool {
         SDL_uikitviewcontroller *vc = GetWindowViewController(window);
-        [vc setKeyboardProperties:props];
-        [vc showKeyboard];
+        [vc setTextFieldProperties:props];
+        return [vc startTextInput];
     }
 }
 
-void UIKit_HideScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window)
+bool UIKit_StopTextInput(SDL_VideoDevice *_this, SDL_Window *window)
 {
     @autoreleasepool {
         SDL_uikitviewcontroller *vc = GetWindowViewController(window);
-        [vc hideKeyboard];
+        return [vc stopTextInput];
     }
 }
 
@@ -704,7 +690,7 @@ bool UIKit_IsScreenKeyboardShown(SDL_VideoDevice *_this, SDL_Window *window)
     @autoreleasepool {
         SDL_uikitviewcontroller *vc = GetWindowViewController(window);
         if (vc != nil) {
-            return vc.keyboardVisible;
+            return vc.textFieldFocused;
         }
         return false;
     }
@@ -717,7 +703,7 @@ bool UIKit_UpdateTextInputArea(SDL_VideoDevice *_this, SDL_Window *window)
         if (vc != nil) {
             vc.textInputRect = window->text_input_rect;
 
-            if (vc.keyboardVisible) {
+            if (vc.textFieldFocused) {
                 [vc updateKeyboard];
             }
         }

--- a/src/video/uikit/SDL_uikitviewcontroller.m
+++ b/src/video/uikit/SDL_uikitviewcontroller.m
@@ -80,7 +80,6 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 
 #ifdef SDL_IPHONE_KEYBOARD
     SDLUITextField *textField;
-    BOOL hardwareKeyboard;
     BOOL showingKeyboard;
     BOOL hidingKeyboard;
     BOOL rotatingOrientation;
@@ -98,7 +97,6 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 
 #ifdef SDL_IPHONE_KEYBOARD
         [self initKeyboard];
-        hardwareKeyboard = NO;
         showingKeyboard = NO;
         hidingKeyboard = NO;
         rotatingOrientation = NO;

--- a/src/video/uikit/SDL_uikitviewcontroller.m
+++ b/src/video/uikit/SDL_uikitviewcontroller.m
@@ -470,6 +470,21 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
     } else {
         textField.enablesReturnKeyAutomatically = NO;
     }
+
+    if (!textField.window) {
+        /* textField has not been added to the view yet,
+         we don't have to do anything. */
+        return;
+    }
+
+    // the text field needs to be re-added to the view in order to update correctly.
+    UIView *superview = textField.superview;
+    [textField removeFromSuperview];
+    [superview addSubview:textField];
+
+    if (SDL_TextInputActive(window)) {
+        [textField becomeFirstResponder];
+    }
 }
 
 /* requests the SDL text field to become focused and accept text input.
@@ -672,7 +687,6 @@ bool UIKit_StartTextInput(SDL_VideoDevice *_this, SDL_Window *window, SDL_Proper
 {
     @autoreleasepool {
         SDL_uikitviewcontroller *vc = GetWindowViewController(window);
-        [vc setTextFieldProperties:props];
         return [vc startTextInput];
     }
 }
@@ -682,6 +696,14 @@ bool UIKit_StopTextInput(SDL_VideoDevice *_this, SDL_Window *window)
     @autoreleasepool {
         SDL_uikitviewcontroller *vc = GetWindowViewController(window);
         return [vc stopTextInput];
+    }
+}
+
+void UIKit_SetTextInputProperties(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesID props)
+{
+    @autoreleasepool {
+        SDL_uikitviewcontroller *vc = GetWindowViewController(window);
+        [vc setTextFieldProperties:props];
     }
 }
 


### PR DESCRIPTION
## Description

Text input in SDL's iOS implementation is directly activated by requesting the hidden `UITextField` to become first responder. Once it becomes first responder, a software keyboard is shown if there are no hardware keyboard is attached, and `textFieldTextDidChange` events are raised whenever text is inputted by a hardware/software keyboard.

SDL has been doing the `becomeFirstResponder`/`resignFirstResponder` calls in the `ShowScreenKeyboard`/`HideScreenKeyboard` path. These paths are controlled by the `AutoShowingScreenKeyboard()` function, which returns false when a hardware keyboard is attached (unless the `SDL_HINT_ENABLE_SCREEN_KEYBOARD` hint is set to 1), therefore the text fields never become first responder and no text input is allowed by hardware keyboard regardless of whether `SDL_StartTextInput` is called.

This is unexpected behaviour, the text field become/resign first responder calls should not be in the `ShowScreenKeyboard`/`HideScreenKeyboard` path, they should instead be in the `StartTextInput`/`StopTextInput` path, which makes more sense given what the logic actually does (make the text field first responder / focused to receive text input).

Therefore, I've refactored the flow surrounding text input activation to do as proposed above. 

I've also rewritten part of the logic of activating/deactivating text input in the `keyboardWillShow`/`keyboardWillHide` events so that it's clear why text input is stopped/started. As far as I can understand, text input should be stopped when the keyboard is hidden by user's request, unless one of these conditions are true:
 - text input was never activated in the first place.
 - a hardware keyboard is attached, as the user can still input text by the hardware keyboard (also when a hardware keyboard is connected while a software keyboard is present, the software keyboard automatically hides and `keyboardWillHide` is raised)
 - the device changes orientation, which can sometimes invoke a series of `keyboardWillHide`/`keyboardWillShow` calls: text input should remain activated in this case.

Also, if a `keyboardWillShow` transition is subsequently invoked before a `keyboardDidHide` call, this indicates that the hide has been interrupted with a show, and in that case we want to bring back text input.

One might ask why `checkKeys` still works with hardware keyboard despite the above, and the answer to that is that the program calls `SDL_StartTextInput` before the hardware keyboard is added by the GCKeyboard event flow. I've confirmed this by checking the state of `SDL_HasKeyboard()` when the function is called in the test app, and it returned false. I've changed the test to not start text input immediately, but if that is bad then I can revert that.

Also, worthy of note that iOS simulator does not send `GCKeyboardDidConnect`/`GCKeyboardDidDisconnect` notifications whenever a hardware keyboard is attached/detached by <kbd>Shift</kbd>+<kbd>Cmd</kbd>+<kbd>K</kbd> or the "Connect Hardware keyboard" menu item, and `GCKeyboard.coalescedKeyboard` is always not null/nil. Therefore it's impossible to test the "text input deactivates when user hides keyboard" behaviour on iOS simulator, due to `SDL_HasKeyboard()` always being true.

## Existing Issue(s)

- Resolves https://github.com/libsdl-org/SDL/issues/9624
- May (resolve) https://github.com/libsdl-org/SDL/issues/6465, I cannot reproduce the issues encountered there.