### PR TITLE
Wayland message box: improve zenity argument handling

### DIFF
--- a/src/video/wayland/SDL_waylandmessagebox.c
+++ b/src/video/wayland/SDL_waylandmessagebox.c
@@ -123,14 +123,14 @@ bool Wayland_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *butto
         argv[argc++] = "--title";
         argv[argc++] = messageboxdata->title;
     } else {
-        argv[argc++] = "--title=\"\"";
+        argv[argc++] = "--title=";
     }
 
     if (messageboxdata->message && messageboxdata->message[0]) {
         argv[argc++] = "--text";
         argv[argc++] = messageboxdata->message;
     } else {
-        argv[argc++] = "--text=\"\"";
+        argv[argc++] = "--text=";
     }
 
     for (i = 0; i < messageboxdata->numbuttons; ++i) {
@@ -143,7 +143,7 @@ bool Wayland_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *butto
             argv[argc++] = "--extra-button";
             argv[argc++] = messageboxdata->buttons[i].text;
         } else {
-            argv[argc++] = "--extra-button=\"\"";
+            argv[argc++] = "--extra-button=";
         }
     }
     if (messageboxdata->numbuttons == 0) {

--- a/src/video/wayland/SDL_waylandmessagebox.c
+++ b/src/video/wayland/SDL_waylandmessagebox.c
@@ -146,6 +146,9 @@ bool Wayland_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *butto
             argv[argc++] = "--extra-button=\"\"";
         }
     }
+    if (messageboxdata->numbuttons == 0) {
+        argv[argc++] = "--extra-button=OK";
+    }
     argv[argc] = NULL;
 
     SDL_PropertiesID props = SDL_CreateProperties();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When no extra buttons are passed to zenity with `--question --switch`
arguments it fails to show anything, however, SDL3 still reports
success. To handle this case, we pass an additional "OK" button.

The double quotes were passed literally to the zenity arguments which
resulted in the message box displaying literal `""` when no text was
given. The empty string is more logical in this case, e.g., the empty
title results in the message box having lesser height.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
