### PR TITLE
Fix `SDL_GetClipboardData()` for bitmap on Windows (SDL3). 

### DIFF
--- a/src/video/windows/SDL_windowsclipboard.c
+++ b/src/video/windows/SDL_windowsclipboard.c
@@ -41,6 +41,51 @@
 // Assume we can directly read and write BMP fields without byte swapping
 SDL_COMPILE_TIME_ASSERT(verify_byte_order, SDL_BYTEORDER == SDL_LIL_ENDIAN);
 
+static int WIN_GetPixelDataOffset(BITMAPINFOHEADER bih)
+{
+    int offset = 0;
+    // biSize Specifies the number of bytes required by the structure
+    // We expect to always be 40 because it should be packed
+    if (40 == bih.biSize && 40 == sizeof(BITMAPINFOHEADER))
+    {
+        //
+        // biBitCount Specifies the number of bits per pixel.
+        // Might exist some bit masks *after* the header and *before* the pixel offset
+        // we're looking, but only if we have more than
+        // 8 bits per pixel, so we need to ajust for that
+        //
+        if (bih.biBitCount > 8)
+        {
+            // If bih.biCompression is RBG we should NOT offset more
+
+            if (bih.biCompression == BI_BITFIELDS)
+            {
+                offset += 3 * sizeof(RGBQUAD);
+            } else if (bih.biCompression == 6 /* BI_ALPHABITFIELDS */) {
+                // Not common, but still right
+                offset += 4 * sizeof(RGBQUAD);
+            }
+        }
+    }
+
+    //
+    // biClrUsed Specifies the number of color indices in the color table that are actually used by the bitmap.
+    // If this value is zero, the bitmap uses the maximum number of colors
+    // corresponding to the value of the biBitCount member for the compression mode specified by biCompression.
+    // If biClrUsed is nonzero and the biBitCount member is less than 16
+    // the biClrUsed member specifies the actual number of colors
+    //
+    if (bih.biClrUsed > 0) {
+        offset += bih.biClrUsed * sizeof(RGBQUAD);
+    } else {
+        if (bih.biBitCount < 16) {
+            offset = offset + (sizeof(RGBQUAD) << bih.biBitCount);
+        }
+    }
+    return bih.biSize + offset;
+}
+
+
 static BOOL WIN_OpenClipboard(SDL_VideoDevice *_this)
 {
     // Retry to open the clipboard in case another application has it open
@@ -114,8 +159,9 @@ static void *WIN_ConvertDIBtoBMP(HANDLE hMem, size_t *size)
             BITMAPINFOHEADER *pbih = (BITMAPINFOHEADER *)dib;
             size_t bih_size = pbih->biSize + pbih->biClrUsed * sizeof(RGBQUAD);
             size_t dib_size = bih_size + pbih->biSizeImage;
+            int pixel_offset = WIN_GetPixelDataOffset(*pbih);
             if (dib_size <= mem_size) {
-                size_t bmp_size = sizeof(BITMAPFILEHEADER) + dib_size;
+                size_t bmp_size = sizeof(BITMAPFILEHEADER) + mem_size;
                 bmp = SDL_malloc(bmp_size);
                 if (bmp) {
                     BITMAPFILEHEADER *pbfh = (BITMAPFILEHEADER *)bmp;
@@ -123,7 +169,7 @@ static void *WIN_ConvertDIBtoBMP(HANDLE hMem, size_t *size)
                     pbfh->bfSize = (DWORD)bmp_size;
                     pbfh->bfReserved1 = 0;
                     pbfh->bfReserved2 = 0;
-                    pbfh->bfOffBits = (DWORD)(sizeof(BITMAPFILEHEADER) + bih_size);
+                    pbfh->bfOffBits = (DWORD)(sizeof(BITMAPFILEHEADER) + pixel_offset);
                     SDL_memcpy((Uint8 *)bmp + sizeof(BITMAPFILEHEADER), dib, dib_size);
                     *size = bmp_size;
                 }


### PR DESCRIPTION

## Description
Calling `SDL_GetClipboardData` on **Windows** may generate an incorrect bitmap file header for uncompressed bitmaps. This issue arises because SDL3 sometimes populates the `BITMAPFILEHEADER` with incorrect `bfOffBits` values, leading to corrupted bitmaps.

This PR addresses the problem by recalculating the pixel offset more accurately in the `WIN_GetPixelDataOffset` function, considering the presence of a palette array in the case of indexed bitmaps. Additionally, it corrects the usage of `biSizeImage`, taking into account that this [value can sometimes be zero](https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader) for uncompressed RGB bitmaps.

## Quick Test
To test this, compile and run the code on Windows. Take a screenshot and press the `V` key, then check the generated `clipboard.bmp` file.

```c
#include <SDL3/SDL.h>
#include <stdbool.h>

static void SDLTest_PasteScreenShot(void)
{
    const char *image_formats[] = {
        "image/png",
        "image/tiff",
        "image/bmp",
    };
    size_t i;

    for (i = 0; i < SDL_arraysize(image_formats); ++i) {
        size_t size;
        void *data = SDL_GetClipboardData(image_formats[i], &size);
        if (data) {
            char filename[16];
            SDL_IOStream *file;

            SDL_snprintf(filename, sizeof(filename), "clipboard.%s", image_formats[i] + 6);
            file = SDL_IOFromFile(filename, "w");
            if (file) {
                SDL_Log("Writing clipboard image to %s", filename);
                SDL_WriteIO(file, data, size);
                SDL_CloseIO(file);
            }
            SDL_free(data);
            return;
        }
    }
    SDL_Log("No supported screenshot data in the clipboard");
}

int main(int argc, char *argv[]) {
    SDL_Init(SDL_INIT_VIDEO);
    SDL_Window* window = SDL_CreateWindow("", 300, 200, 0);
    SDL_SetWindowTitle(window, "Window BMP Clipboard Test");
    bool quit = false;
    while (!quit) {
        SDL_Event event;
        while (SDL_PollEvent(&event)) {
            if (event.type == SDL_EVENT_KEY_DOWN && event.key.key == SDLK_V) {
                SDL_Log("Calling SDLTest_PasteScreenShot\n");
                SDLTest_PasteScreenShot();
            }
            else if (event.type == SDL_EVENT_QUIT) {
                quit = true;
            }
        }
        SDL_Delay(20);
    }
    SDL_Quit();
}
```
