### PR TITLE
Add SDL_SaveFile and SDL_SaveFile_IO functions

### DIFF
--- a/include/SDL3/SDL_iostream.h
+++ b/include/SDL3/SDL_iostream.h
@@ -664,6 +664,7 @@ extern SDL_DECLSPEC bool SDLCALL SDL_FlushIO(SDL_IOStream *context);
  * \since This function is available since SDL 3.1.3.
  *
  * \sa SDL_LoadFile
+ * \sa SDL_SaveFile_IO
  */
 extern SDL_DECLSPEC void * SDLCALL SDL_LoadFile_IO(SDL_IOStream *src, size_t *datasize, bool closeio);
 
@@ -684,8 +685,45 @@ extern SDL_DECLSPEC void * SDLCALL SDL_LoadFile_IO(SDL_IOStream *src, size_t *da
  * \since This function is available since SDL 3.1.3.
  *
  * \sa SDL_LoadFile_IO
+ * \sa SDL_SaveFile
  */
 extern SDL_DECLSPEC void * SDLCALL SDL_LoadFile(const char *file, size_t *datasize);
+
+/**
+ * Save all the data into an SDL data stream.
+ *
+ * \param src the SDL_IOStream to write all data to.
+ * \param data the data to be written. If datasize is 0, may be NULL or a
+ *        invalid pointer.
+ * \param datasize the number of bytes to be written.
+ * \param closeio if true, calls SDL_CloseIO() on `src` before returning, even
+ *                in the case of an error.
+ * \returns true on success or false on failure; call SDL_GetError() for more
+ *          information.
+ *
+ * \since This function is available since SDL 3.1.3.
+ *
+ * \sa SDL_SaveFile
+ * \sa SDL_LoadFile_IO
+ */
+extern SDL_DECLSPEC bool SDLCALL SDL_SaveFile_IO(SDL_IOStream *src, const void *data, size_t datasize, bool closeio);
+
+/**
+ * Save all the data into a file path.
+ *
+ * \param file the path to read all available data from.
+ * \param data the data to be written. If datasize is 0, may be NULL or a
+ *        invalid pointer.
+ * \param datasize the number of bytes to be written.
+ * \returns true on success or false on failure; call SDL_GetError() for more
+ *          information.
+ *
+ * \since This function is available since SDL 3.1.3.
+ *
+ * \sa SDL_SaveFile_IO
+ * \sa SDL_LoadFile
+ */
+extern SDL_DECLSPEC bool SDLCALL SDL_SaveFile(const char *file, const void *data, size_t datasize);
 
 /**
  *  \name Read endian functions

--- a/src/dynapi/SDL_dynapi.sym
+++ b/src/dynapi/SDL_dynapi.sym
@@ -1184,6 +1184,8 @@ SDL3_0.0.0 {
     SDL_RenderDebugText;
     SDL_GetSandbox;
     SDL_CancelGPUCommandBuffer;
+    SDL_SaveFile_IO;
+    SDL_SaveFile;
     # extra symbols go here (don't modify this line)
   local: *;
 };

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -1209,3 +1209,5 @@
 #define SDL_RenderDebugText SDL_RenderDebugText_REAL
 #define SDL_GetSandbox SDL_GetSandbox_REAL
 #define SDL_CancelGPUCommandBuffer SDL_CancelGPUCommandBuffer_REAL
+#define SDL_SaveFile_IO SDL_SaveFile_IO_REAL
+#define SDL_SaveFile SDL_SaveFile_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -1215,3 +1215,5 @@ SDL_DYNAPI_PROC(SDL_LogOutputFunction,SDL_GetDefaultLogOutputFunction,(void),(),
 SDL_DYNAPI_PROC(bool,SDL_RenderDebugText,(SDL_Renderer *a,float b,float c,const char *d),(a,b,c,d),return)
 SDL_DYNAPI_PROC(SDL_Sandbox,SDL_GetSandbox,(void),(),return)
 SDL_DYNAPI_PROC(bool,SDL_CancelGPUCommandBuffer,(SDL_GPUCommandBuffer *a),(a),return)
+SDL_DYNAPI_PROC(bool,SDL_SaveFile_IO,(SDL_IOStream *a,const void *b,size_t c,bool d),(a,b,c,d),return)
+SDL_DYNAPI_PROC(bool,SDL_SaveFile,(const char *a,const void *b,size_t c),(a,b,c),return)


### PR DESCRIPTION
## Description

This adds the following convenience functions:
- `bool SDL_SaveFile_IO(SDL_IOStream *src, const void *data, size_t datasize, bool closeio);`
- `bool SDL_SaveFile(const char *file, const void *data, size_t datasize);`

They work similarly to their "Load" counterparts.

## Existing Issue(s)

Closes #11421
