### PR TITLE
Fix SDL_PRIs64 to use standard PRId64

### DIFF
--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -440,8 +440,8 @@ typedef Sint64 SDL_Time;
 #ifndef SDL_PRIs64
 #if defined(SDL_PLATFORM_WINDOWS)
 #define SDL_PRIs64 "I64d"
-#elif defined(PRIs64)
-#define SDL_PRIs64 PRIs64
+#elif defined(PRId64)
+#define SDL_PRIs64 PRId64
 #elif defined(__LP64__) && !defined(SDL_PLATFORM_APPLE) && !defined(__EMSCRIPTEN__)
 #define SDL_PRIs64 "ld"
 #else


### PR DESCRIPTION
SDL_PRI**s**64 tried to default to PRI**s**64 but the correct macro is PRI**d**64.

SDL_PRIs32 already correctly uses PRId32. I tried to use PRIs64 and found SDL 2 and 3 also try to use it.