### PR TITLE
Fix `SDL_StartTextInputWithProperties` not updating input type on android

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -1422,6 +1422,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
             mTextEdit.requestFocus();
 
             InputMethodManager imm = (InputMethodManager) SDL.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+            imm.restartInput(mTextEdit);
             imm.showSoftInput(mTextEdit, 0);
 
             mScreenKeyboardShown = true;

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -5297,7 +5297,7 @@ bool SDL_StartTextInputWithProperties(SDL_Window *window, SDL_PropertiesID props
     }
 
     // Show the on-screen keyboard, if desired
-    if (AutoShowingScreenKeyboard() && !SDL_ScreenKeyboardShown(window)) {
+    if (AutoShowingScreenKeyboard()) {
         if (_this->ShowScreenKeyboard) {
             _this->ShowScreenKeyboard(_this, window, props);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

RFC, not final PR. MVP that fixes this on Android.

Fixes `SDL_StartTextInputWithProperties` so that the requested `SDL_PROP_TEXTINPUT_TYPE_NUMBER` is always applied. Tested on Android. Previously, if a screen keyboard was already shown (eg. text input already active), the properties would be ignored.

This change allows the following application code to work:

```c
// user clicks a regular textbox so the app starts normal text input
SDL_StartTextInputWithProperties(window, /* SDL_TEXTINPUT_TYPE_TEXT */);
// Android: the screen keyboard is shown and has text type

// some time later

// user clicks a number textbox so the app wants to change the text input type
// importantly, SDL_StopTextInput() was not called
SDL_StartTextInputWithProperties(window, /* SDL_TEXTINPUT_TYPE_NUMBER */);
// Android: the screen keyboard is updated to have number type [fixed by this PR]
```

Does this series of calls make sense from an API standpoint? Do you think the application should call `SDL_StartTextInputWithProperties()` → `SDL_StopTextInput()` → `SDL_StartTextInputWithProperties()`? (Seems less ideal, as it might flick the keyboard unnecessarily.)

I've not checked that calling `ShowScreenKeyboard()` when the keyboard is already shown works as expected on other platforms (only Android is tested and updated).

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->

Calls to `SDL_StartTextInputWithProperties` when text input is already active will be ignored by android (the keyboard type presented to the user will not change).
- First noticed in https://github.com/ppy/osu-framework/pull/6408#discussion_r1834150548