### PR TITLE
Always Use Next Display Index

### DIFF
--- a/src/video/windows/SDL_windowsmodes.c
+++ b/src/video/windows/SDL_windowsmodes.c
@@ -377,11 +377,10 @@ static void WIN_AddDisplay(_THIS, HMONITOR hMonitor, const MONITORINFOEXW *info,
     display.driverdata = displaydata;
     WIN_GetDisplayBounds(_this, &display, &displaydata->bounds);
     index = SDL_AddVideoDisplay(&display, send_event);
-    SDL_assert(index == *display_index);
     SDL_free(display.name);
 
 done:
-    *display_index += 1;
+    *display_index = index + 1;
 }
 
 typedef struct _WIN_AddDisplaysData


### PR DESCRIPTION
## Description
WIN_AddDisplay asserted that the returned index is the expected next one in the list. This can be an unexpected number when displays are add and removed in a batch (eg, Remote Desktop disconnect and reconnect). Instead always just make use of the next index, even if it is not the expected next index value. 

## Existing Issue(s)
This fixes issue #9105