### PR TITLE
(N3DS) Add support for 3D rendering

### DIFF
--- a/src/video/n3ds/SDL_n3dsvideo.h
+++ b/src/video/n3ds/SDL_n3dsvideo.h
@@ -29,13 +29,19 @@
 
 struct SDL_VideoData
 {
-    int top_display;
+    int top_left_display;
+    int top_right_display;
     int touch_display;
+
+    // The following two variables keep track of if it is ready to swap the buffers
+    bool top_left_ready;
+    bool top_right_ready;
 };
 
 struct SDL_WindowData
 {
     gfxScreen_t screen; /**< Keeps track of which N3DS screen is targeted */
+    gfx3dSide_t side;
 };
 
 #endif // SDL_n3dsvideo_h_


### PR DESCRIPTION
## Description
3DS has support for 3D rendering, but that access to that functionality is absent in SDL.
I've added support for that by adding a secondary screen that renders to it if `gfxIs3D` is enabled. Otherwise the left/right screen will just render, right screen takes priority, but if right screen isn't rendered to, then the left screen will render.

## Existing Issue(s)
https://discourse.libsdl.org/t/dual-screen-rendering-on-the-n3ds-sdl3/55549/2
