### PR TITLE
render: use nearest pixel scaling for debug text

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -5407,10 +5407,14 @@ static bool CreateDebugTextAtlas(SDL_Renderer *renderer)
     SDL_assert((row < rows) || ((row == rows) && (column == 0)));  // make sure we didn't overflow the surface.
 
     // Convert temp surface into texture
-    renderer->debug_char_texture_atlas = SDL_CreateTextureFromSurface(renderer, atlas);
+    SDL_Texture *texture = SDL_CreateTextureFromSurface(renderer, atlas);
+    if (texture) {
+        SDL_SetTextureScaleMode(texture, SDL_SCALEMODE_NEAREST);
+        renderer->debug_char_texture_atlas = texture;
+    }
     SDL_DestroySurface(atlas);
 
-    return (renderer->debug_char_texture_atlas != NULL);
+    return texture != NULL;
 }
 
 static bool DrawDebugCharacter(SDL_Renderer *renderer, float x, float y, Uint32 c)


### PR DESCRIPTION
## Description

The debug text font is less legible when scaled linearly.

Before:

![2024-11-17T20:24:12](https://github.com/user-attachments/assets/6ae874b4-caa0-4fd9-af7e-b2250eb61541)

Afer:

![2024-11-17T20:23:46](https://github.com/user-attachments/assets/3ae8289b-e08e-41f4-a905-aba1d160f65f)
