### PR TITLE
[SDL2] Fix order of events in case audio buffer size changes

### DIFF
--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -700,8 +700,6 @@ static int SDLCALL SDL_RunAudio(void *userdata)
 
     /* Loop, filling the audio buffers */
     while (!SDL_AtomicGet(&device->shutdown)) {
-        data_len = device->callbackspec.size;
-
         /* Fill the current buffer with sound */
         if (!device->stream && SDL_AtomicGet(&device->enabled)) {
             data = current_audio.impl.GetDeviceBuf(device);
@@ -727,6 +725,8 @@ static int SDLCALL SDL_RunAudio(void *userdata)
         if (data == NULL) {
             data = device->work_buffer;
         }
+
+        data_len = device->callbackspec.size;
 
         /* !!! FIXME: this should be LockDevice. */
         SDL_LockMutex(device->mixer_lock);


### PR DESCRIPTION
Assign the length of audio buffer after obtaining the audio buffer.

## Description
See https://github.com/libsdl-org/SDL/issues/11122#issuecomment-2484053860

## Existing Issue(s)
This resolves #11122
