### PR TITLE
Catch any objective C exceptions thrown in Cocoa_RegisterApp. Fixes #11437

### DIFF
--- a/src/video/cocoa/SDL_cocoaevents.h
+++ b/src/video/cocoa/SDL_cocoaevents.h
@@ -23,7 +23,7 @@
 #ifndef SDL_cocoaevents_h_
 #define SDL_cocoaevents_h_
 
-extern void Cocoa_RegisterApp(void);
+extern bool Cocoa_RegisterApp(void);
 extern Uint64 Cocoa_GetEventTimestamp(NSTimeInterval nsTimestamp);
 extern void Cocoa_PumpEvents(SDL_VideoDevice *_this);
 extern int Cocoa_WaitEventTimeout(SDL_VideoDevice *_this, Sint64 timeoutNS);

--- a/src/video/cocoa/SDL_cocoavideo.m
+++ b/src/video/cocoa/SDL_cocoavideo.m
@@ -63,7 +63,9 @@ static SDL_VideoDevice *Cocoa_CreateDevice(void)
         SDL_VideoDevice *device;
         SDL_CocoaVideoData *data;
 
-        Cocoa_RegisterApp();
+        if (!Cocoa_RegisterApp()) {
+            return NULL;
+        }
 
         // Initialize all variables that we clean on shutdown
         device = (SDL_VideoDevice *)SDL_calloc(1, sizeof(SDL_VideoDevice));


### PR DESCRIPTION
This fixes `SDL_Init(SDL_INIT_VIDEO)` throwing an exception on macos if called off the main thread

I don't actually know objective C so this may not be the best way to fix it, but I've verified that this does fix the issue for me. In my patch, Cocoa_RegisterApp sets a message with SDL_SetError, but when testing the fix SDL_GetError reported "SDL_Init failed: No available video device" instead, so maybe that SDL_SetError isn't necessary. Still, it's better than crashing.

## Existing Issue(s)
#11437 