### PR TITLE
Avoid usage of `CreateEventEx` in D3D12 GPU backend.

### DIFF
--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -6849,7 +6849,11 @@ static D3D12Fence *D3D12_INTERNAL_AcquireFence(
             return NULL;
         }
         fence->handle = handle;
-        fence->event = CreateEventEx(NULL, 0, 0, EVENT_ALL_ACCESS);
+#if defined(SDL_PLATFORM_GDK) // CreateEventEx() arrived in Vista, so we need an #ifdef for XP.
+        fence->event = CreateEventEx(NULL, NULL, 0, EVENT_ALL_ACCESS);
+#else
+        fence->event = CreateEventW(NULL, 0, 0, NULL);
+#endif
         SDL_SetAtomicInt(&fence->referenceCount, 0);
     } else {
         fence = renderer->availableFences[renderer->availableFenceCount - 1];

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -6849,11 +6849,7 @@ static D3D12Fence *D3D12_INTERNAL_AcquireFence(
             return NULL;
         }
         fence->handle = handle;
-#if defined(SDL_PLATFORM_GDK) // CreateEventEx() arrived in Vista, so we need an #ifdef for XP.
-        fence->event = CreateEventEx(NULL, NULL, 0, EVENT_ALL_ACCESS);
-#else
-        fence->event = CreateEventW(NULL, 0, 0, NULL);
-#endif
+        fence->event = CreateEvent(NULL, 0, 0, NULL);
         SDL_SetAtomicInt(&fence->referenceCount, 0);
     } else {
         fence = renderer->availableFences[renderer->availableFenceCount - 1];


### PR DESCRIPTION
`CreateEventEx` is unavailable in Windows XP. The provided solution was sourced from the WASAPI backend, which had to address the same problem.

According to [official](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createeventa) [documentation](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createeventexa), both calls should be functionally identical, with calls to `CreateEvent` implicitly creating events with the `EVENT_ALL_ACCESS` access right.

This change alone is not enough to get Windows XP support working again: the usage of `CreateWaitableTimerExW` in the Windows `SDL_systimer.c` currently prevents any executables from running, due to the function being introduced in Windows Vista. If the relevant code is removed, however, executables do successfully run. I would add code to load this function at runtime, similarly to [this PR](https://github.com/libsdl-org/SDL/pull/6190), but there does not appear to be any logic for initialisation and deinitialisation that I could insert the code into.

I also corrected a null pointer argument to use `NULL` instead of `0`.