### PR TITLE
Optimize SDL_FillSurfaceRect(2|4)SSE for "full surface fills"

### DIFF
--- a/src/video/SDL_fillrect.c
+++ b/src/video/SDL_fillrect.c
@@ -59,6 +59,13 @@ static void SDL_TARGETING("sse") SDL_FillSurfaceRect##bpp##SSE(Uint8 *pixels, in
 { \
     int i, n; \
     Uint8 *p = NULL; \
+  \
+    /* If the number of bytes per row is equal to the pitch, treat */ \
+    /* all rows as one long continuous row (for better performance) */ \
+    if ((w) * (bpp) == pitch) { \
+        w = w * h; \
+        h = 1; \
+    } \
  \
     SSE_BEGIN; \
  \


### PR DESCRIPTION
## Description
Hello, I work on pygame-ce, and I've noticed in profiling various games that Surface.fill(), our Python interface to SDL_FillRect, is a significant part of runtime for most pygame-ce games (most pygame-ce games are software rendered).

I tested out fill() at various surface resolutions with a 32 bit surface and found that the performance of this function is very spiky. I found that surfaces with widths divisible by 16 had the best performance by far.

Looking into the SSE FillRect implementation I found that the function has to do a lot of work to adjust into a 16 byte aligned state, run several 64 byte chunks, then finish any extra pixels at the end. The algorithm considers each row separately (as you need for fills that take a smaller region of the surface). However, there is a common scenario, a full surface fill, where the algorithm can consider all pixels together.* This is a great performance boost because it no longer has to worry about alignment book keeping before and after any 64 byte chunks (per row), and can run 64 byte chunks over row boundaries.

If this patch is accepted for SDL3 I would like to backport it to SDL2.

*Unless the pitch of the surface is greater than the width * bytes_per_pixel

## Existing Issue(s)
I haven't opened an SDL issue, but I did discuss with other pygame-ce contributors in https://github.com/pygame-community/pygame-ce/issues/3227
