### PR TITLE
add `SDL_SetRelativeMouseTransform`

### DIFF
--- a/include/SDL3/SDL_mouse.h
+++ b/include/SDL3/SDL_mouse.h
@@ -147,6 +147,38 @@ typedef enum SDL_MouseWheelDirection
  */
 typedef Uint32 SDL_MouseButtonFlags;
 
+/**
+ * A callback used to transform mouse motion delta from raw values.
+ *
+ * This is called during SDL's handling of platform mouse events to
+ * scale the values of the resulting motion delta. 
+ *
+ * \param userdata what was passed as `userdata` to SDL_SetRelativeMouseTransform().
+ * \param timestamp the associated time at which this mouse motion event was received.
+ * \param window the associated window to which this mouse motion event was addressed.
+ * \param mouseID the associated mouse from which this mouse motion event was emitted.
+ * \param x pointer to a variable that will be treated as the resulting x-axis motion.
+ * \param y pointer to a variable that will be treated as the resulting y-axis motion.
+ *
+ * \threadsafety This callback is called by SDL's internal mouse input processing
+ *               procedure, which may be a thread separate from the main event loop
+ *               that is run at realtime priority. Stalling this thread with too much
+ *               work in the callback can therefore potentially freeze the entire
+ *               system. Care should be taken with proper synchronization practices 
+ *               when adding other side effects beyond mutation of the x and y values.
+ *
+ * \since This datatype is available since SDL 3.2.6.
+ *
+ * \sa SDL_SetRelativeMouseTransform
+ */
+typedef void (SDLCALL *SDL_MouseMotionTransformCallback)(
+    void *userdata, 
+    Uint64 timestamp, 
+    SDL_Window *window, 
+    SDL_MouseID mouseID, 
+    float *x, float *y
+);
+
 #define SDL_BUTTON_LEFT     1
 #define SDL_BUTTON_MIDDLE   2
 #define SDL_BUTTON_RIGHT    3
@@ -379,6 +411,17 @@ extern SDL_DECLSPEC void SDLCALL SDL_WarpMouseInWindow(SDL_Window *window,
  * \sa SDL_WarpMouseInWindow
  */
 extern SDL_DECLSPEC bool SDLCALL SDL_WarpMouseGlobal(float x, float y);
+
+/**
+ * Set a user-defined function by which to transform relative mouse inputs.
+ * This overrides the relative system scale and relative speed scale hints.
+ *
+ * \param callback a callback used to transform relative mouse motion, or NULL for default behavior.
+ * \param userdata a pointer that is passed to `callback`.
+ *
+ * \since This function is available since SDL 3.2.6.
+ */
+extern SDL_DECLSPEC void SDLCALL SDL_SetRelativeMouseTransform(SDL_MouseMotionTransformCallback callback, void *userdata);
 
 /**
  * Set relative mouse mode for a window.

--- a/include/SDL3/SDL_mouse.h
+++ b/include/SDL3/SDL_mouse.h
@@ -415,13 +415,19 @@ extern SDL_DECLSPEC bool SDLCALL SDL_WarpMouseGlobal(float x, float y);
 /**
  * Set a user-defined function by which to transform relative mouse inputs.
  * This overrides the relative system scale and relative speed scale hints.
+ * Should be called prior to enabling relative mouse mode, fails otherwise.
+ * 
+ * \param callback a callback used to transform relative mouse motion, 
+                   or NULL for default behavior.
+ * \param userdata a pointer that will be passed to `callback`.
+ * \returns true on success or false on failure; call SDL_GetError() for more
+ *          information.
  *
- * \param callback a callback used to transform relative mouse motion, or NULL for default behavior.
- * \param userdata a pointer that is passed to `callback`.
+ * \threadsafety This function should only be called on the main thread.
  *
  * \since This function is available since SDL 3.2.6.
  */
-extern SDL_DECLSPEC void SDLCALL SDL_SetRelativeMouseTransform(SDL_MouseMotionTransformCallback callback, void *userdata);
+extern SDL_DECLSPEC bool SDLCALL SDL_SetRelativeMouseTransform(SDL_MouseMotionTransformCallback callback, void *userdata);
 
 /**
  * Set relative mouse mode for a window.

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -1120,11 +1120,15 @@ void SDL_QuitMouse(void)
     SDL_mice = NULL;
 }
 
-void SDL_SetRelativeMouseTransform(SDL_MouseMotionTransformCallback transform, void *userdata)
+bool SDL_SetRelativeMouseTransform(SDL_MouseMotionTransformCallback transform, void *userdata)
 {
     SDL_Mouse *mouse = SDL_GetMouse();
+    if (mouse->relative_mode) {
+        return SDL_SetError("Can't set mouse transform while relative mode is active");
+    }
     mouse->InputTransform = transform;
     mouse->input_transform_data = userdata;
+    return true;
 }
 
 SDL_MouseButtonFlags SDL_GetMouseState(float *x, float *y)

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -705,14 +705,19 @@ static void SDL_PrivateSendMouseMotion(Uint64 timestamp, SDL_Window *window, SDL
 
     if (relative) {
         if (mouse->relative_mode) {
-            if (mouse->enable_relative_system_scale) {
-                if (mouse->ApplySystemScale) {
-                    mouse->ApplySystemScale(mouse->system_scale_data, timestamp, window, mouseID, &x, &y);
+            if (mouse->InputTransform) {
+                void *data = mouse->input_transform_data;
+                mouse->InputTransform(data, timestamp, window, mouseID, &x, &y);
+            } else {
+                if (mouse->enable_relative_system_scale) {
+                    if (mouse->ApplySystemScale) {
+                        mouse->ApplySystemScale(mouse->system_scale_data, timestamp, window, mouseID, &x, &y);
+                    }
                 }
-            }
-            if (mouse->enable_relative_speed_scale) {
-                x *= mouse->relative_speed_scale;
-                y *= mouse->relative_speed_scale;
+                if (mouse->enable_relative_speed_scale) {
+                    x *= mouse->relative_speed_scale;
+                    y *= mouse->relative_speed_scale;
+                }
             }
         } else {
             if (mouse->enable_normal_speed_scale) {
@@ -1113,6 +1118,13 @@ void SDL_QuitMouse(void)
     }
     SDL_free(SDL_mice);
     SDL_mice = NULL;
+}
+
+void SDL_SetRelativeMouseTransform(SDL_MouseMotionTransformCallback transform, void *userdata)
+{
+    SDL_Mouse *mouse = SDL_GetMouse();
+    mouse->InputTransform = transform;
+    mouse->input_transform_data = userdata;
 }
 
 SDL_MouseButtonFlags SDL_GetMouseState(float *x, float *y)

--- a/src/events/SDL_mouse_c.h
+++ b/src/events/SDL_mouse_c.h
@@ -87,9 +87,13 @@ typedef struct
     // Get absolute mouse coordinates. (x) and (y) are never NULL and set to zero before call.
     SDL_MouseButtonFlags (*GetGlobalMouseState)(float *x, float *y);
 
-    // Platform-specific system mouse transform
-    void (*ApplySystemScale)(void *internal, Uint64 timestamp, SDL_Window *window, SDL_MouseID mouseID, float *x, float *y);
+    // Platform-specific system mouse transform applied in relative mode
+    SDL_MouseMotionTransformCallback ApplySystemScale;
     void *system_scale_data;
+
+    // User-defined mouse input transform applied in relative mode
+    SDL_MouseMotionTransformCallback InputTransform;
+    void *input_transform_data;
 
     // Data common to all mice
     SDL_Window *focus;

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -1012,6 +1012,7 @@ static void relative_pointer_handle_relative_motion(void *data,
     struct SDL_WaylandInput *input = data;
     SDL_VideoData *d = input->display;
     SDL_WindowData *window = input->pointer_focus;
+    SDL_Mouse *mouse = SDL_GetMouse();
 
     // Relative pointer event times are in microsecond granularity.
     const Uint64 timestamp = Wayland_GetEventTimestamp(SDL_US_TO_NS(((Uint64)time_hi << 32) | (Uint64)time_lo));
@@ -1019,7 +1020,7 @@ static void relative_pointer_handle_relative_motion(void *data,
     if (input->pointer_focus && d->relative_mouse_mode) {
         double dx;
         double dy;
-        if (!SDL_GetMouse()->enable_relative_system_scale) {
+        if (mouse->InputTransform || !mouse->enable_relative_system_scale) {
             dx = wl_fixed_to_double(dx_unaccel_w);
             dy = wl_fixed_to_double(dy_unaccel_w);
         } else {


### PR DESCRIPTION
This PR introduces a new API function `SDL_SetRelativeMouseTransform`, which lets app developers add a callback that hooks into SDL's relative mouse input processing to modify the resultant delta value. When set, this overrides the default relative speed/system scaling functionality, giving full control to the developer to scale from raw deltas.

Because this is a callback, developers can also do their own bookkeeping on incoming mouse deltas inside their function, potentially enabling usecases such as a userland implementation of per-device relative mouse accumulator states leveraging the multithreaded setup of some platforms for low-latency asynchronous writes instead of needing to go through the event queue.

(For the record, the refactor of this PR was also partially motivated by me conceptualizing a `SDL_PeekRelativeMouseState` function, finding that no matter how I construct the API contract it remains a janky arbitrary appendage, and realizing that it might be better to just provide the escape hatch to let users implement their own relative mouse state accumulator.)


<details><summary>Old PR Description:</summary>

This is an accompanying Proof-of-Concept for #11449, requesting discussion on what to do with the relative speed scale hint (relative system scale hint should be replaced outright regardless):

### Option 1: remove relative speed scale (this implementation)
This is my preference, as the scaling functionality can easily be folded into the developer-defined function. and the main problem raised in the issue is that developer may be surprised by the end-user being able to alter the behavior from environment variables, so it is necessary to move the control exclusively to the developer instead.

### Option 2: apply relative speed scale if no custom transform
This is essentially the inverse of the current behavior but with custom rather than system transform. The end user alterable relative speed scale taking a lower precedence than developer-controlled transform function removes a large portion of the element of surprise for the developer. However, the issue might still exist for developers that want specific scaling values and expected to use the events system exclusively without knowing about this new callback functionality.

### Option 3a: apply relative speed scale before custom transform
Essentially, this is a philosophical assertion that the end-user wants to have precedence over the behavior, that the inputs are uniformly scaled according to their specification before the developer code is made aware of it.

### Option 3b: apply relative speed scale after custom transform
I cannot think of any good reason to do this, considering that this causes a divergence between what the developer expected from their transform output and when they receive the event by inserting an end-user configurable step in between.

</details>