### PR TITLE
Improve Win32 darkmode and fix title bar's context menu

### DIFF
--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -43,9 +43,6 @@ typedef HRESULT (WINAPI *DwmSetWindowAttribute_t)(HWND hwnd, DWORD dwAttribute, 
 typedef HRESULT (WINAPI *DwmGetWindowAttribute_t)(HWND hwnd, DWORD dwAttribute, PVOID pvAttribute, DWORD cbAttribute);
 
 // Dark mode support
-#ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
-#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
-#endif
 typedef enum {
     UXTHEME_APPMODE_DEFAULT,
     UXTHEME_APPMODE_ALLOW_DARK,

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -80,8 +80,8 @@ typedef void (WINAPI *RefreshImmersiveColorPolicyState_t)(void);
 typedef bool (WINAPI *ShouldSystemUseDarkMode_t)(void);
 typedef UxthemePreferredAppMode (WINAPI *SetPreferredAppMode_t)(UxthemePreferredAppMode);
 typedef bool (WINAPI *IsDarkModeAllowedForApp_t)(void);
-typedef BOOL (WINAPI *SetWindowCompositionAttribute_t)(HWND, const WINDOWCOMPOSITIONATTRIBDATA*);
-typedef void (NTAPI *RtlGetVersion_t)(NT_OSVERSIONINFOW*);
+typedef BOOL (WINAPI *SetWindowCompositionAttribute_t)(HWND, const WINDOWCOMPOSITIONATTRIBDATA *);
+typedef void (NTAPI *RtlGetVersion_t)(NT_OSVERSIONINFOW *);
 
 // Corner rounding support  (Win 11+)
 #ifndef DWMWA_WINDOW_CORNER_PREFERENCE

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -2276,9 +2276,9 @@ void WIN_UpdateDarkModeForHWND(HWND hwnd)
     SDL_SharedObject *uxtheme = SDL_LoadObject("uxtheme.dll");
     if (!uxtheme)
         return;
-    AllowDarkModeForWindow_t AllowDarkModeForWindowFunc = (AllowDarkModeForWindow_t)SDL_LoadFunction(uxtheme, MAKEINTRESOURCEA(133));
     RefreshImmersiveColorPolicyState_t RefreshImmersiveColorPolicyStateFunc = (RefreshImmersiveColorPolicyState_t)SDL_LoadFunction(uxtheme, MAKEINTRESOURCEA(104));
     ShouldAppsUseDarkMode_t ShouldAppsUseDarkModeFunc = (ShouldAppsUseDarkMode_t)SDL_LoadFunction(uxtheme, MAKEINTRESOURCEA(132));
+    AllowDarkModeForWindow_t AllowDarkModeForWindowFunc = (AllowDarkModeForWindow_t)SDL_LoadFunction(uxtheme, MAKEINTRESOURCEA(133));
     if (os_info.dwBuildNumber < 18362) {
         AllowDarkModeForApp_t AllowDarkModeForAppFunc = (AllowDarkModeForApp_t)SDL_LoadFunction(uxtheme, MAKEINTRESOURCEA(135));
         if (AllowDarkModeForAppFunc)

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -68,12 +68,11 @@ typedef struct {
     ULONG dwPlatformId;
     WCHAR szCSDVersion[128];
 } NT_OSVERSIONINFOW;
-typedef bool(WINAPI *ShouldAppsUseDarkMode_t)(void);
+typedef bool (WINAPI *ShouldAppsUseDarkMode_t)(void);
 typedef void (WINAPI *AllowDarkModeForWindow_t)(HWND, bool);
 typedef void (WINAPI *AllowDarkModeForApp_t)(bool);
 typedef void (WINAPI *FlushMenuThemes_t)(void);
 typedef void (WINAPI *RefreshImmersiveColorPolicyState_t)(void);
-// typedef bool (WINAPI *IsDarkModeAllowedForWindow_t)(HWND);
 typedef bool (WINAPI *ShouldSystemUseDarkMode_t)(void);
 typedef WinPreferredAppMode (WINAPI *SetPreferredAppMode_t)(WinPreferredAppMode);
 typedef bool (WINAPI *IsDarkModeAllowedForApp_t)(void);

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -2274,7 +2274,7 @@ void WIN_UpdateDarkModeForHWND(HWND hwnd)
     SDL_SharedObject *ntdll = SDL_LoadObject("ntdll.dll");
     if (!ntdll)
         return;
-    // There is no function to get windows build number, so let's get it here
+    // There is no function to get Windows build number, so let's get it here via RtlGetVersion
     RtlGetVersion_t RtlGetVersionFunc = (RtlGetVersion_t)SDL_LoadFunction(ntdll, "RtlGetVersion");
     NT_OSVERSIONINFOW os_info;
     os_info.dwOSVersionInfoSize = sizeof(NT_OSVERSIONINFOW);

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -2305,8 +2305,7 @@ void WIN_UpdateDarkModeForHWND(HWND hwnd)
     // Check dark mode using ShouldAppsUseDarkMode, but use SDL_GetSystemTheme as a fallback
     if (ShouldAppsUseDarkModeFunc) {
         value = ShouldAppsUseDarkModeFunc() ? TRUE : FALSE;
-    }
-    else {
+    } else {
         value = (SDL_GetSystemTheme() == SDL_SYSTEM_THEME_DARK) ? TRUE : FALSE;
     }
     SDL_UnloadObject(uxtheme);

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -47,11 +47,11 @@ typedef HRESULT (WINAPI *DwmGetWindowAttribute_t)(HWND hwnd, DWORD dwAttribute, 
 #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
 #endif
 typedef enum {
-    WIN_APPMODE_DEFAULT,
-    WIN_APPMODE_ALLOW_DARK,
-    WIN_APPMODE_FORCE_DARK,
-    WIN_APPMODE_FORCE_LIGHT,
-    WIN_APPMODE_MAX
+    UXTHEME_APPMODE_DEFAULT,
+    UXTHEME_APPMODE_ALLOW_DARK,
+    UXTHEME_APPMODE_FORCE_DARK,
+    UXTHEME_APPMODE_FORCE_LIGHT,
+    UXTHEME_APPMODE_MAX
 } WinPreferredAppMode;
 typedef enum {
     WCA_UNDEFINED = 0,
@@ -63,7 +63,16 @@ typedef struct {
     PVOID pvData;
     SIZE_T cbData;
 } WINDOWCOMPOSITIONATTRIBDATA;
-typedef bool (WINAPI *ShouldAppsUseDarkMode_t)(void);
+typedef struct
+{
+    ULONG dwOSVersionInfoSize;
+    ULONG dwMajorVersion;
+    ULONG dwMinorVersion;
+    ULONG dwBuildNumber;
+    ULONG dwPlatformId;
+    WCHAR szCSDVersion[128];
+} NT_OSVERSIONINFOW;
+typedef bool(WINAPI *ShouldAppsUseDarkMode_t)(void);
 typedef void (WINAPI *AllowDarkModeForWindow_t)(HWND, bool);
 typedef void (WINAPI *AllowDarkModeForApp_t)(bool);
 typedef void (WINAPI *FlushMenuThemes_t)(void);
@@ -73,6 +82,7 @@ typedef bool (WINAPI *ShouldSystemUseDarkMode_t)(void);
 typedef WinPreferredAppMode (WINAPI *SetPreferredAppMode_t)(WinPreferredAppMode);
 typedef bool (WINAPI *IsDarkModeAllowedForApp_t)(void);
 typedef BOOL (WINAPI *SetWindowCompositionAttribute_t)(HWND, const WINDOWCOMPOSITIONATTRIBDATA*);
+typedef void (NTAPI *RtlGetVersion_t)(NT_OSVERSIONINFOW*);
 
 // Corner rounding support  (Win 11+)
 #ifndef DWMWA_WINDOW_CORNER_PREFERENCE
@@ -2253,15 +2263,54 @@ bool WIN_SetWindowFocusable(SDL_VideoDevice *_this, SDL_Window *window, bool foc
 
 void WIN_UpdateDarkModeForHWND(HWND hwnd)
 {
-    SDL_SharedObject *handle = SDL_LoadObject("dwmapi.dll");
-    if (handle) {
-        DwmSetWindowAttribute_t DwmSetWindowAttributeFunc = (DwmSetWindowAttribute_t)SDL_LoadFunction(handle, "DwmSetWindowAttribute");
-        if (DwmSetWindowAttributeFunc) {
-            // FIXME: Do we need to traverse children?
-            BOOL value = (SDL_GetSystemTheme() == SDL_SYSTEM_THEME_DARK) ? TRUE : FALSE;
-            DwmSetWindowAttributeFunc(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &value, sizeof(value));
+    SDL_SharedObject *ntdll = SDL_LoadObject("ntdll.dll");
+    if (!ntdll)
+        return;
+    // There is no function to get windows build number, so let's get it here
+    RtlGetVersion_t RtlGetVersionFunc = (RtlGetVersion_t)SDL_LoadFunction(ntdll, "RtlGetVersion");
+    NT_OSVERSIONINFOW os_info;
+    os_info.dwOSVersionInfoSize = sizeof(NT_OSVERSIONINFOW);
+    os_info.dwBuildNumber = 0;
+    if (RtlGetVersionFunc)
+        RtlGetVersionFunc(&os_info);
+    SDL_UnloadObject(ntdll);
+    os_info.dwBuildNumber &= ~0xF0000000;
+    if (os_info.dwBuildNumber < 17763)
+        return; // Too old to support dark mode
+    SDL_SharedObject *uxtheme = SDL_LoadObject("uxtheme.dll");
+    if (!uxtheme)
+        return;
+    ShouldAppsUseDarkMode_t ShouldAppsUseDarkModeFunc = SDL_LoadFunction(uxtheme, MAKEINTRESOURCEA(132));
+    AllowDarkModeForWindow_t AllowDarkModeForWindowFunc = SDL_LoadFunction(uxtheme, MAKEINTRESOURCEA(133));
+    RefreshImmersiveColorPolicyState_t RefreshImmersiveColorPolicyStateFunc = SDL_LoadFunction(uxtheme, MAKEINTRESOURCEA(104));
+    if (os_info.dwBuildNumber < 18362) {
+        AllowDarkModeForApp_t AllowDarkModeForAppFunc = SDL_LoadFunction(uxtheme, MAKEINTRESOURCEA(135));
+        if (AllowDarkModeForAppFunc)
+            AllowDarkModeForAppFunc(true);
+    } else {
+        SetPreferredAppMode_t SetPreferredAppModeFunc = SDL_LoadFunction(uxtheme, MAKEINTRESOURCEA(135));
+        if (SetPreferredAppModeFunc)
+            SetPreferredAppModeFunc(UXTHEME_APPMODE_ALLOW_DARK);
+    }
+    if (RefreshImmersiveColorPolicyStateFunc)
+        RefreshImmersiveColorPolicyStateFunc();
+    if (AllowDarkModeForWindowFunc)
+        AllowDarkModeForWindowFunc(hwnd, true);
+    // TODO: read via uxtheme hidden functions
+    BOOL value = (SDL_GetSystemTheme() == SDL_SYSTEM_THEME_DARK) ? TRUE : FALSE;
+    SDL_UnloadObject(uxtheme);
+    if (os_info.dwBuildNumber < 18362)
+        SetPropW(hwnd, L"UseImmersiveDarkModeColors", (HANDLE)value);
+    else {
+        SDL_SharedObject *user32 = SDL_LoadObject("user32.dll");
+        if (user32) {
+            SetWindowCompositionAttribute_t SetWindowCompositionAttributeFunc = SDL_LoadFunction(user32, "SetWindowCompositionAttribute");
+            if (SetWindowCompositionAttributeFunc) {
+                WINDOWCOMPOSITIONATTRIBDATA data = { WCA_USEDARKMODECOLORS, &value, sizeof(value) };
+                SetWindowCompositionAttributeFunc(hwnd, &data);
+            }
+            SDL_UnloadObject(user32);
         }
-        SDL_UnloadObject(handle);
     }
 }
 

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -75,11 +75,8 @@ typedef struct {
 typedef bool (WINAPI *ShouldAppsUseDarkMode_t)(void);
 typedef void (WINAPI *AllowDarkModeForWindow_t)(HWND, bool);
 typedef void (WINAPI *AllowDarkModeForApp_t)(bool);
-typedef void (WINAPI *FlushMenuThemes_t)(void);
 typedef void (WINAPI *RefreshImmersiveColorPolicyState_t)(void);
-typedef bool (WINAPI *ShouldSystemUseDarkMode_t)(void);
 typedef UxthemePreferredAppMode (WINAPI *SetPreferredAppMode_t)(UxthemePreferredAppMode);
-typedef bool (WINAPI *IsDarkModeAllowedForApp_t)(void);
 typedef BOOL (WINAPI *SetWindowCompositionAttribute_t)(HWND, const WINDOWCOMPOSITIONATTRIBDATA *);
 typedef void (NTAPI *RtlGetVersion_t)(NT_OSVERSIONINFOW *);
 

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -49,17 +49,20 @@ typedef enum {
     UXTHEME_APPMODE_FORCE_DARK,
     UXTHEME_APPMODE_FORCE_LIGHT,
     UXTHEME_APPMODE_MAX
-} WinPreferredAppMode;
+} UxthemePreferredAppMode;
+
 typedef enum {
     WCA_UNDEFINED = 0,
     WCA_USEDARKMODECOLORS = 26,
     WCA_LAST = 27
 } WINDOWCOMPOSITIONATTRIB;
+
 typedef struct {
     WINDOWCOMPOSITIONATTRIB Attrib;
     PVOID pvData;
     SIZE_T cbData;
 } WINDOWCOMPOSITIONATTRIBDATA;
+
 typedef struct {
     ULONG dwOSVersionInfoSize;
     ULONG dwMajorVersion;
@@ -68,13 +71,14 @@ typedef struct {
     ULONG dwPlatformId;
     WCHAR szCSDVersion[128];
 } NT_OSVERSIONINFOW;
+
 typedef bool (WINAPI *ShouldAppsUseDarkMode_t)(void);
 typedef void (WINAPI *AllowDarkModeForWindow_t)(HWND, bool);
 typedef void (WINAPI *AllowDarkModeForApp_t)(bool);
 typedef void (WINAPI *FlushMenuThemes_t)(void);
 typedef void (WINAPI *RefreshImmersiveColorPolicyState_t)(void);
 typedef bool (WINAPI *ShouldSystemUseDarkMode_t)(void);
-typedef WinPreferredAppMode (WINAPI *SetPreferredAppMode_t)(WinPreferredAppMode);
+typedef UxthemePreferredAppMode (WINAPI *SetPreferredAppMode_t)(UxthemePreferredAppMode);
 typedef bool (WINAPI *IsDarkModeAllowedForApp_t)(void);
 typedef BOOL (WINAPI *SetWindowCompositionAttribute_t)(HWND, const WINDOWCOMPOSITIONATTRIBDATA*);
 typedef void (NTAPI *RtlGetVersion_t)(NT_OSVERSIONINFOW*);
@@ -2259,56 +2263,66 @@ bool WIN_SetWindowFocusable(SDL_VideoDevice *_this, SDL_Window *window, bool foc
 void WIN_UpdateDarkModeForHWND(HWND hwnd)
 {
     SDL_SharedObject *ntdll = SDL_LoadObject("ntdll.dll");
-    if (!ntdll)
+    if (!ntdll) {
         return;
+    }
     // There is no function to get Windows build number, so let's get it here via RtlGetVersion
     RtlGetVersion_t RtlGetVersionFunc = (RtlGetVersion_t)SDL_LoadFunction(ntdll, "RtlGetVersion");
     NT_OSVERSIONINFOW os_info;
     os_info.dwOSVersionInfoSize = sizeof(NT_OSVERSIONINFOW);
     os_info.dwBuildNumber = 0;
-    if (RtlGetVersionFunc)
+    if (RtlGetVersionFunc) {
         RtlGetVersionFunc(&os_info);
+    }
     SDL_UnloadObject(ntdll);
     os_info.dwBuildNumber &= ~0xF0000000;
-    if (os_info.dwBuildNumber < 17763)
-        return; // Too old to support dark mode
-    SDL_SharedObject *uxtheme = SDL_LoadObject("uxtheme.dll");
-    if (!uxtheme)
+    if (os_info.dwBuildNumber < 17763) {
+        // Too old to support dark mode
         return;
+    }
+    SDL_SharedObject *uxtheme = SDL_LoadObject("uxtheme.dll");
+    if (!uxtheme) {
+        return;
+    }
     RefreshImmersiveColorPolicyState_t RefreshImmersiveColorPolicyStateFunc = (RefreshImmersiveColorPolicyState_t)SDL_LoadFunction(uxtheme, MAKEINTRESOURCEA(104));
     ShouldAppsUseDarkMode_t ShouldAppsUseDarkModeFunc = (ShouldAppsUseDarkMode_t)SDL_LoadFunction(uxtheme, MAKEINTRESOURCEA(132));
     AllowDarkModeForWindow_t AllowDarkModeForWindowFunc = (AllowDarkModeForWindow_t)SDL_LoadFunction(uxtheme, MAKEINTRESOURCEA(133));
     if (os_info.dwBuildNumber < 18362) {
         AllowDarkModeForApp_t AllowDarkModeForAppFunc = (AllowDarkModeForApp_t)SDL_LoadFunction(uxtheme, MAKEINTRESOURCEA(135));
-        if (AllowDarkModeForAppFunc)
+        if (AllowDarkModeForAppFunc) {
             AllowDarkModeForAppFunc(true);
+        }
     } else {
         SetPreferredAppMode_t SetPreferredAppModeFunc = (SetPreferredAppMode_t)SDL_LoadFunction(uxtheme, MAKEINTRESOURCEA(135));
-        if (SetPreferredAppModeFunc)
+        if (SetPreferredAppModeFunc) {
             SetPreferredAppModeFunc(UXTHEME_APPMODE_ALLOW_DARK);
+        }
     }
-    if (RefreshImmersiveColorPolicyStateFunc)
+    if (RefreshImmersiveColorPolicyStateFunc) {
         RefreshImmersiveColorPolicyStateFunc();
-    if (AllowDarkModeForWindowFunc)
+    }
+    if (AllowDarkModeForWindowFunc) {
         AllowDarkModeForWindowFunc(hwnd, true);
+    }
     BOOL value;
     // Check dark mode using ShouldAppsUseDarkMode, but use SDL_GetSystemTheme as a fallback
-    if (ShouldAppsUseDarkModeFunc)
+    if (ShouldAppsUseDarkModeFunc) {
         value = ShouldAppsUseDarkModeFunc() ? TRUE : FALSE;
-    else
-        value = (SDL_GetSystemTheme() == SDL_SYSTEM_THEME_DARK) ? TRUE : FALSE;
-    SDL_UnloadObject(uxtheme);
-    if (os_info.dwBuildNumber < 18362)
-        SetProp(hwnd, TEXT("UseImmersiveDarkModeColors"), SDL_reinterpret_cast(HANDLE, SDL_static_cast(INT_PTR, value)));
+    }
     else {
-        SDL_SharedObject *user32 = SDL_LoadObject("user32.dll");
+        value = (SDL_GetSystemTheme() == SDL_SYSTEM_THEME_DARK) ? TRUE : FALSE;
+    }
+    SDL_UnloadObject(uxtheme);
+    if (os_info.dwBuildNumber < 18362) {
+        SetProp(hwnd, TEXT("UseImmersiveDarkModeColors"), SDL_reinterpret_cast(HANDLE, SDL_static_cast(INT_PTR, value)));
+    } else {
+        HMODULE user32 = GetModuleHandle(TEXT("user32.dll"));
         if (user32) {
-            SetWindowCompositionAttribute_t SetWindowCompositionAttributeFunc = (SetWindowCompositionAttribute_t)SDL_LoadFunction(user32, "SetWindowCompositionAttribute");
+            SetWindowCompositionAttribute_t SetWindowCompositionAttributeFunc = (SetWindowCompositionAttribute_t)GetProcAddress(user32, "SetWindowCompositionAttribute");
             if (SetWindowCompositionAttributeFunc) {
                 WINDOWCOMPOSITIONATTRIBDATA data = { WCA_USEDARKMODECOLORS, &value, sizeof(value) };
                 SetWindowCompositionAttributeFunc(hwnd, &data);
             }
-            SDL_UnloadObject(user32);
         }
     }
 }

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -46,6 +46,33 @@ typedef HRESULT (WINAPI *DwmGetWindowAttribute_t)(HWND hwnd, DWORD dwAttribute, 
 #ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
 #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
 #endif
+typedef enum {
+    WIN_APPMODE_DEFAULT,
+    WIN_APPMODE_ALLOW_DARK,
+    WIN_APPMODE_FORCE_DARK,
+    WIN_APPMODE_FORCE_LIGHT,
+    WIN_APPMODE_MAX
+} WinPreferredAppMode;
+typedef enum {
+    WCA_UNDEFINED = 0,
+    WCA_USEDARKMODECOLORS = 26,
+    WCA_LAST = 27
+} WINDOWCOMPOSITIONATTRIB;
+typedef struct {
+    WINDOWCOMPOSITIONATTRIB Attrib;
+    PVOID pvData;
+    SIZE_T cbData;
+} WINDOWCOMPOSITIONATTRIBDATA;
+typedef bool (WINAPI *ShouldAppsUseDarkMode_t)(void);
+typedef void (WINAPI *AllowDarkModeForWindow_t)(HWND, bool);
+typedef void (WINAPI *AllowDarkModeForApp_t)(bool);
+typedef void (WINAPI *FlushMenuThemes_t)(void);
+typedef void (WINAPI *RefreshImmersiveColorPolicyState_t)(void);
+// typedef bool (WINAPI *IsDarkModeAllowedForWindow_t)(HWND);
+typedef bool (WINAPI *ShouldSystemUseDarkMode_t)(void);
+typedef WinPreferredAppMode (WINAPI *SetPreferredAppMode_t)(WinPreferredAppMode);
+typedef bool (WINAPI *IsDarkModeAllowedForApp_t)(void);
+typedef BOOL (WINAPI *SetWindowCompositionAttribute_t)(HWND, const WINDOWCOMPOSITIONATTRIBDATA*);
 
 // Corner rounding support  (Win 11+)
 #ifndef DWMWA_WINDOW_CORNER_PREFERENCE

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -2299,7 +2299,7 @@ void WIN_UpdateDarkModeForHWND(HWND hwnd)
         value = (SDL_GetSystemTheme() == SDL_SYSTEM_THEME_DARK) ? TRUE : FALSE;
     SDL_UnloadObject(uxtheme);
     if (os_info.dwBuildNumber < 18362)
-        SetPropW(hwnd, L"UseImmersiveDarkModeColors", SDL_reinterpret_cast(HANDLE, SDL_static_cast(INT_PTR, value)));
+        SetProp(hwnd, TEXT("UseImmersiveDarkModeColors"), SDL_reinterpret_cast(HANDLE, SDL_static_cast(INT_PTR, value)));
     else {
         SDL_SharedObject *user32 = SDL_LoadObject("user32.dll");
         if (user32) {


### PR DESCRIPTION
## Description
Use hidden uxtheme.dll and user32.dll functions for darkmode instead of using DwmSetWindowAttribute.
Fixes context menu on title bar.
![image](https://github.com/user-attachments/assets/6990a489-9067-4aef-8a2e-ca824632a2c6)

## Notes
I couldn't find function to get Windows build number so I import RtlGetVersion from ntdll to get it.

## Existing Issue(s)
#11535
