### PR TITLE
[SDL2] DirectFB: fix DirectFB_SetTextureScaleMode() declaration (fixes gcc-14.x compile)

### DIFF
--- a/src/video/directfb/SDL_DirectFB_render.c
+++ b/src/video/directfb/SDL_DirectFB_render.c
@@ -561,7 +561,7 @@ static void DirectFB_UnlockTexture(SDL_Renderer * renderer, SDL_Texture * textur
     }
 }
 
-static void DirectFB_SetTextureScaleMode(void)
+static void DirectFB_SetTextureScaleMode(SDL_Renderer * renderer, SDL_Texture * texture, SDL_ScaleMode scaleMode)
 {
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
DirectFB: fix DirectFB_SetTextureScaleMode() declaration
    
Fixes:
```
     src/video/directfb/SDL_DirectFB_render.c: In function ‘DirectFB_CreateRenderer’:
     src/video/directfb/SDL_DirectFB_render.c:1153:35: error: assignment to ‘void (*)(SDL_Renderer *, SDL_Texture *, SDL_ScaleMode)’ from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
     1153 |     renderer->SetTextureScaleMode = DirectFB_SetTextureScaleMode;
          |                                   ^

```

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
