### PR TITLE
SDL 'null' type depending on whether C/C23/C++11 is used

### DIFF
--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -125,6 +125,20 @@ void *alloca(size_t);
 #endif
 
 /**
+ * A null-pointer constant.
+ *
+ *
+ * This macro is defined as ‘nullptr’ if you are using C++.
+ * Otherwise it is defined as a generic pointer defined as 0.
+ * \since This macro is available since SDL 3.0.0
+ */
+#if defined(__cplusplus)
+#define SDL_null (nullptr)
+#else
+#define SDL_null ((void*) 0)
+#endif
+
+/**
  * The number of elements in an array.
  *
  * This macro looks like it double-evaluates the argument, but it does so

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -128,12 +128,14 @@ void *alloca(size_t);
  * A null-pointer constant.
  *
  *
- * This macro is defined as ‘nullptr’ if you are using C++.
+ * This macro is defined as ‘nullptr’ if you are using C++/C23.
  * Otherwise it is defined as a generic pointer defined as 0.
- * \since This macro is available since SDL 3.0.0
+ * \since This macro is available since SDL 3.1.7
  */
 #if defined(__cplusplus)
 #define SDL_null (nullptr)
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 202311L)
+#define SDL_null (nullptr_t)
 #else
 #define SDL_null ((void*) 0)
 #endif

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -128,11 +128,11 @@ void *alloca(size_t);
  * A null-pointer constant.
  *
  *
- * This macro is defined as ‘nullptr’ if you are using C++/C23.
+ * This macro is defined as ‘nullptr’ if you are using C++11/C23 or later.
  * Otherwise it is defined as a generic pointer defined as 0.
  * \since This macro is available since SDL 3.1.7
  */
-#if defined(__cplusplus)
+#if defined(__cplusplus) && (__cplusplus >= 201103L)
 #define SDL_null (nullptr)
 #elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 202311L)
 #define SDL_null (nullptr_t)

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -137,7 +137,7 @@ void *alloca(size_t);
 #elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 202311L)
 #define SDL_null (nullptr_t)
 #else
-#define SDL_null ((void*) 0)
+#define SDL_null (0)
 #endif
 
 /**


### PR DESCRIPTION
A constant for null pointers called `SDL_null`. This varies depending on the standard version and the language used (C/C++).

C++11: If C++11 is used above, `SDL_null` is defined as `nullptr` so as not to spoil the improvements it offers.

C23: If C23 is used above (in the future), `SDL_null` is defined as `nullptr_t`, a new constant defined for C23.

Older versions of C/C++: If neither C23 nor C++11 is used above, `SDL_null` is defined as `0`, the classical way to represent null pointers.

It can serve to preserve the improvements of `nullptr` (in the case of C++11), `nullptr_t` for C23, and `0` (in the case of C23/C++11 above) in a single constant.
