### PR TITLE
Fix rawmouse wrong timestamp

### DIFF
--- a/src/video/windows/SDL_windowsevents.h
+++ b/src/video/windows/SDL_windowsevents.h
@@ -30,7 +30,7 @@ extern HINSTANCE SDL_Instance;
 extern LRESULT CALLBACK WIN_KeyboardHookProc(int nCode, WPARAM wParam, LPARAM lParam);
 extern LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam,
                                        LPARAM lParam);
-extern void WIN_PollRawInput(SDL_VideoDevice *_this);
+extern void WIN_PollRawInput(SDL_VideoDevice *_this, Uint64 sleep_start, Uint64 sleep_end);
 extern void WIN_CheckKeyboardAndMouseHotplug(SDL_VideoDevice *_this, bool initial_check);
 extern void WIN_PumpEvents(SDL_VideoDevice *_this);
 extern void WIN_SendWakeupEvent(SDL_VideoDevice *_this, SDL_Window *window);

--- a/src/video/windows/SDL_windowsevents.h
+++ b/src/video/windows/SDL_windowsevents.h
@@ -30,7 +30,7 @@ extern HINSTANCE SDL_Instance;
 extern LRESULT CALLBACK WIN_KeyboardHookProc(int nCode, WPARAM wParam, LPARAM lParam);
 extern LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam,
                                        LPARAM lParam);
-extern void WIN_PollRawInput(SDL_VideoDevice *_this, Uint64 sleep_start, Uint64 sleep_end);
+extern void WIN_PollRawInput(SDL_VideoDevice *_this, Uint64 poll_start);
 extern void WIN_CheckKeyboardAndMouseHotplug(SDL_VideoDevice *_this, bool initial_check);
 extern void WIN_PumpEvents(SDL_VideoDevice *_this);
 extern void WIN_SendWakeupEvent(SDL_VideoDevice *_this, SDL_Window *window);


### PR DESCRIPTION
Currently, the rawinput thread incorrectly spreads the timestamps over idle time if the poll interval is less than 100ms, and abruptly switches to lumping all accumulated inputs to happen simultaneously if it exceeds 100ms. 

This means that any game which implements retroactive event handling based on timestamps will jarringly snap between the two polar opposite extremes of incorrect behaviour.

This PR replaces the arbitrary 100ms threshold with logic based on measuring the idle start and end time. 

If the thread idled for more than 125000 nanoseconds, it is considered to have not had any input in its queue before it entered idle, and the events are spread over the interval between thread wake-up and pump finish, with the final input aligned to the pump finish time. 

If the thread idled for less than 125000 nanoseconds, it is considered to have events entered at some point between last pump finish and thread entering sleep, and the events are spread over the full pump-to-pump interval. 