### PR TITLE
GPU: Fix validation warning in D3D12 blit code

### DIFF
--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -7940,7 +7940,7 @@ static void D3D12_INTERNAL_InitBlitResources(
     samplerCreateInfo.min_lod = 0;
     samplerCreateInfo.max_lod = 1000;
     samplerCreateInfo.max_anisotropy = 1.0f;
-    samplerCreateInfo.compare_op = SDL_GPU_COMPAREOP_ALWAYS;
+    samplerCreateInfo.compare_op = SDL_GPU_COMPAREOP_NEVER;
 
     renderer->blitNearestSampler = D3D12_CreateSampler(
         (SDL_GPURenderer *)renderer,


### PR DESCRIPTION
Fixes the following D3D12 debug layer warnings:

```
D3D12 WARNING: ID3D12Device::CreateSampler2: ComparisonFunc is D3D12_COMPARISON_FUNC_ALWAYS, but D3D12_FILTER_MIN_MAG_MIP_POINT is not a comparison filter. This is OK, as the ComparisonFunc will simply be ignored, but is was likely not the intent. [ STATE_CREATION WARNING #1361: CREATE_SAMPLER_COMPARISON_FUNC_IGNORED]
D3D12 WARNING: ID3D12Device::CreateSampler2: ComparisonFunc is D3D12_COMPARISON_FUNC_ALWAYS, but D3D12_FILTER_MIN_MAG_MIP_LINEAR is not a comparison filter. This is OK, as the ComparisonFunc will simply be ignored, but is was likely not the intent. [ STATE_CREATION WARNING #1361: CREATE_SAMPLER_COMPARISON_FUNC_IGNORED]
```
