### PR TITLE
dynapi: order for a reproducible build

### DIFF
--- a/src/dynapi/gendynapi.pl
+++ b/src/dynapi/gendynapi.pl
@@ -50,8 +50,13 @@ open(SDL_DYNAPI_PROCS_H, '>>', $sdl_dynapi_procs_h) or die("Can't open $sdl_dyna
 open(SDL_DYNAPI_OVERRIDES_H, '>>', $sdl_dynapi_overrides_h) or die("Can't open $sdl_dynapi_overrides_h: $!\n");
 open(SDL2_EXPORTS, '>>', $sdl2_exports) or die("Can't open $sdl2_exports: $!\n");
 
+# Ordered for reproducible builds
 opendir(HEADERS, 'include') or die("Can't open include dir: $!\n");
-while (my $d = readdir(HEADERS)) {
+my @entries = readdir(HEADERS);
+closedir(HEADERS);
+# Sort the entries
+@entries = sort @entries;
+foreach my $d (@entries) {
     next if not $d =~ /\.h\Z/;
     my $header = "include/$d";
     open(HEADER, '<', $header) or die("Can't open $header: $!\n");
@@ -142,8 +147,6 @@ while (my $d = readdir(HEADERS)) {
     }
     close(HEADER);
 }
-
-closedir(HEADERS);
 
 close(SDL_DYNAPI_PROCS_H);
 close(SDL_DYNAPI_OVERRIDES_H);


### PR DESCRIPTION
## Description
The objfiles of different builds show various differences in the calls to SDL_DYNAPI_entry elements. This is generated dynamically by gendynapi.pl which uses an unordered opendir/readdir pair. To make the build reproducible and thereby e.g. debugging easier change this to be used in an ordered fashion.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/11565
