### PR TITLE
video: Don't error when setting an unbounded max window size while a …

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -3122,7 +3122,8 @@ bool SDL_SetWindowMaximumSize(SDL_Window *window, int max_w, int max_h)
         return SDL_InvalidParamError("max_h");
     }
 
-    if (max_w < window->min_w || max_h < window->min_h) {
+    if ((max_w && max_w < window->min_w) ||
+        (max_h && max_h < window->min_h)) {
         return SDL_SetError("SDL_SetWindowMaximumSize(): Tried to set maximum size smaller than minimum size");
     }
 


### PR DESCRIPTION
…minimum is set

If the maximum size was changed to 0 (unbounded) while a minimum was set, the sanity check ensuring that the max size isn't less than the minimum size would incorrectly cause the operation to error out.

Fixes #11563 
