### PR TITLE
docs: added "gpu" to the list of possible values of SDL_HINT_RENDER_DRIVER in SDL_hints.h

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2862,6 +2862,7 @@ extern "C" {
  * - "opengles"
  * - "metal"
  * - "vulkan"
+ * - "gpu"
  * - "software"
  *
  * The default varies by platform, but it's the first one in the list that is


### PR DESCRIPTION
Hello,

"gpu" value is currently missing in docs of "SDL_HINT_RENDER_DRIVER". I put it just before "software" as it looks like it's the correct order.

See issue #11572

Have a good day