### PR TITLE
SDL_asyncio_liburing.c cleanups

### DIFF
--- a/src/file/io_uring/SDL_asyncio_liburing.c
+++ b/src/file/io_uring/SDL_asyncio_liburing.c
@@ -283,7 +283,7 @@ static SDL_AsyncIOTask *liburing_asyncioqueue_wait_results(void *userdata, Sint3
     if (timeoutMS < 0) {
         liburing.io_uring_wait_cqe(&queuedata->ring, &cqe);
     } else {
-        struct __kernel_timespec ts = { (__kernel_time64_t) timeoutMS / SDL_MS_PER_SECOND, (long long) SDL_MS_TO_NS(timeoutMS % SDL_MS_PER_SECOND) };
+        struct __kernel_timespec ts = { (Sint64) timeoutMS / SDL_MS_PER_SECOND, (Sint64) SDL_MS_TO_NS(timeoutMS % SDL_MS_PER_SECOND) };
         liburing.io_uring_wait_cqe_timeout(&queuedata->ring, &cqe, &ts);
     }
     SDL_AddAtomicInt(&queuedata->num_waiting, -1);

--- a/src/file/io_uring/SDL_asyncio_liburing.c
+++ b/src/file/io_uring/SDL_asyncio_liburing.c
@@ -169,7 +169,7 @@ static bool liburing_SetError(const char *what, int err)
 
 static Sint64 liburing_asyncio_size(void *userdata)
 {
-    const int fd = (int) (size_t) userdata;
+    const int fd = (int) (intptr_t) userdata;
     struct stat statbuf;
     if (fstat(fd, &statbuf) < 0) {
         SDL_SetError("fstat failed: %s", strerror(errno));
@@ -265,6 +265,7 @@ static SDL_AsyncIOTask *liburing_asyncioqueue_get_results(void *userdata)
         SDL_UnlockMutex(queuedata->cqe_lock);
         return NULL;
     }
+
     struct io_uring_cqe cqe_copy;
     SDL_copyp(&cqe_copy, cqe);  // this is only a few bytes.
     liburing.io_uring_cqe_seen(&queuedata->ring, cqe);  // let io_uring use this slot again.
@@ -371,7 +372,7 @@ static bool SDL_SYS_CreateAsyncIOQueue_liburing(SDL_AsyncIOQueue *queue)
 static bool liburing_asyncio_read(void *userdata, SDL_AsyncIOTask *task)
 {
     LibUringAsyncIOQueueData *queuedata = (LibUringAsyncIOQueueData *) task->queue->userdata;
-    const int fd = (int) (size_t) userdata;
+    const int fd = (int) (intptr_t) userdata;
 
     // !!! FIXME: `unsigned` is likely smaller than requested_size's Uint64. If we overflow it, we could try submitting multiple SQEs
     // !!! FIXME:  and make a note in the task that there are several in sequence.
@@ -397,7 +398,7 @@ static bool liburing_asyncio_read(void *userdata, SDL_AsyncIOTask *task)
 static bool liburing_asyncio_write(void *userdata, SDL_AsyncIOTask *task)
 {
     LibUringAsyncIOQueueData *queuedata = (LibUringAsyncIOQueueData *) task->queue->userdata;
-    const int fd = (int) (size_t) userdata;
+    const int fd = (int) (intptr_t) userdata;
 
     // !!! FIXME: `unsigned` is likely smaller than requested_size's Uint64. If we overflow it, we could try submitting multiple SQEs
     // !!! FIXME:  and make a note in the task that there are several in sequence.
@@ -423,7 +424,7 @@ static bool liburing_asyncio_write(void *userdata, SDL_AsyncIOTask *task)
 static bool liburing_asyncio_close(void *userdata, SDL_AsyncIOTask *task)
 {
     LibUringAsyncIOQueueData *queuedata = (LibUringAsyncIOQueueData *) task->queue->userdata;
-    const int fd = (int) (size_t) userdata;
+    const int fd = (int) (intptr_t) userdata;
 
     // have to hold a lock because otherwise two threads could get_sqe and submit while one request isn't fully set up.
     SDL_LockMutex(queuedata->sqe_lock);
@@ -497,7 +498,7 @@ static bool SDL_SYS_AsyncIOFromFile_liburing(const char *file, const char *mode,
     };
 
     SDL_copyp(&asyncio->iface, &SDL_AsyncIOFile_liburing);
-    asyncio->userdata = (void *) (size_t) fd;
+    asyncio->userdata = (void *) (intptr_t) fd;
     return true;
 }
 


### PR DESCRIPTION
- SDL_asyncio_liburing.c: replace size_t casts on pointers with intptr_t
  sizeof(size_t) might not be the same as sizeof(intptr_t). see, e.g. the
  CHERI case: https://github.com/libsdl-org/SDL/pull/4552

- SDL_asyncio_liburing.c: replace __kernel_time64_t use with SDL's Sint64
  __kernel_time64_t might not be available and Sint64 simply is enough for
  our use here. 
