### PR TITLE
WIP: Examples: work on web output

### DIFF
--- a/build-scripts/build-web-examples.pl
+++ b/build-scripts/build-web-examples.pl
@@ -180,7 +180,7 @@ sub handle_example_dir {
 
     my $other_examples_html = "<ul>";
     foreach my $example (get_examples_for_category($category)) {
-        $other_examples_html .= "<li><a href='/$category/$example'>$category/$example</a></li>";
+        $other_examples_html .= "<li><a href='/$project/$category/$example'>$category/$example</a></li>";
     }
     $other_examples_html .= "</ul>";
 
@@ -225,7 +225,7 @@ sub handle_category_dir {
         # !!! FIXME: image
         my $example_image_url = "https://placehold.co/600x400/png";
         $examples_list_html .= "
-        <a href='/$category/$example'>
+        <a href='/$project/$category/$example'>
           <div>
             <img src='$example_image_url' />
             <div>$category/$example</div>
@@ -297,7 +297,7 @@ foreach my $category (get_categories()) {
         # !!! FIXME: image
         my $example_image_url = "https://placehold.co/600x400/png";
         $homepage_list_html .= "
-            <a href='/$category/$example'>
+            <a href='/$project/$category/$example'>
             <div>
                 <img src='$example_image_url' />
                 <div>$category/$example</div>

--- a/examples/template-category.html
+++ b/examples/template-category.html
@@ -5,7 +5,11 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>@project_name@ Examples: @category_name@</title>
-    <link rel="stylesheet" type="text/css" href="/examples.css" />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="/@project_name@/examples.css"
+    />
     <style>
       main > h1 {
         margin-top: 0;
@@ -19,8 +23,8 @@
     <main>
       <nav class="breadcrumb">
         <ul>
-          <li><a href="/">@project_name@</a></li>
-          <li><a href="/@category_name@">@category_name@</a></li>
+          <li><a href="/@project_name@/">@project_name@</a></li>
+          <li><a href="/@project_name@/@category_name@">@category_name@</a></li>
         </ul>
       </nav>
       <h1>@project_name@ examples: @category_name@</h1>

--- a/examples/template-category.html
+++ b/examples/template-category.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>@project_name@ Examples: @category_name@</title>
+    <link rel="stylesheet" type="text/css" href="/examples.css" />
+    <style>
+      main > h1 {
+        margin-top: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <a href="/">SDL Examples</a>
+    </header>
+    <main>
+      <nav class="breadcrumb">
+        <ul>
+          <li><a href="/">@project_name@</a></li>
+          <li><a href="/@category_name@">@category_name@</a></li>
+        </ul>
+      </nav>
+      <h1>@project_name@ examples: @category_name@</h1>
+      <div class="list">@examples_list_html@</div>
+    </main>
+  </body>
+</html>

--- a/examples/template-homepage.html
+++ b/examples/template-homepage.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>@project_name@ Examples</title>
+    <link rel="stylesheet" type="text/css" href="/examples.css" />
+    <style>
+      main > h1 {
+        margin-top: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <a href="/">SDL Examples</a>
+    </header>
+    <main>
+      <nav class="breadcrumb">
+        <ul>
+          <li><a href="/">@project_name@</a></li>
+        </ul>
+      </nav>
+      <h1>@project_name@ examples</h1>
+
+      <p>Check out the @project_name@ examples here!</p>
+
+      @homepage_list_html@
+    </main>
+  </body>
+</html>

--- a/examples/template-homepage.html
+++ b/examples/template-homepage.html
@@ -5,7 +5,11 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>@project_name@ Examples</title>
-    <link rel="stylesheet" type="text/css" href="/examples.css" />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="/@project_name@/examples.css"
+    />
     <style>
       main > h1 {
         margin-top: 0;
@@ -19,7 +23,7 @@
     <main>
       <nav class="breadcrumb">
         <ul>
-          <li><a href="/">@project_name@</a></li>
+          <li><a href="/@project_name@">@project_name@</a></li>
         </ul>
       </nav>
       <h1>@project_name@ examples</h1>

--- a/examples/template.css
+++ b/examples/template.css
@@ -1,0 +1,284 @@
+/** from ghwikipp.css */
+:root {
+  color-scheme: dark light; /* both supported */
+}
+
+body {
+  background-color: white;
+  padding: 2vw;
+  color: #333;
+  max-width: 1200px;
+  margin: 0 auto;
+  font-size: 16px;
+  line-height: 1.5;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans",
+    Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  overflow-wrap: break-word;
+}
+
+a {
+  color: #0969da;
+  /* text-decoration: none; */
+}
+
+a:visited {
+  color: #064998;
+}
+
+h1 {
+  border-bottom: 2px solid #efefef;
+}
+
+h2 {
+  border-bottom: 1px solid #efefef;
+}
+
+p {
+  max-width: 85ch;
+}
+
+li {
+  max-width: 85ch;
+}
+
+div.sourceCode {
+  background-color: #f6f8fa;
+  max-width: 100%;
+  padding: 16px;
+}
+
+code {
+  background-color: #f6f8fa;
+  padding: 0px;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    "Liberation Mono", monospace;
+}
+
+table {
+  border: 1px solid #808080;
+  border-collapse: collapse;
+}
+
+td {
+  border: 1px solid #808080;
+  padding: 5px;
+}
+
+tr:nth-child(even) {
+  background-color: #f6f8fa;
+}
+
+.wikitopbanner {
+  background-color: #efefef;
+  padding: 10px;
+  margin-bottom: 10px;
+  width: auto;
+}
+
+.wikibottombanner {
+  background-color: #efefef;
+  padding: 10px;
+  margin-top: 10px;
+  width: auto;
+}
+
+.alertBox {
+  background-color: #f8d7da;
+  border: 1px solid #f5c6cb;
+  max-width: 60%;
+  padding: 10;
+  margin: auto;
+}
+
+.anchorImage {
+  visibility: hidden;
+  padding-left: 0.2em;
+  color: #fff;
+}
+
+.anchorText:hover .anchorImage {
+  visibility: visible;
+}
+
+hr {
+  display: block;
+  height: 1px;
+  border: 0;
+  border-top: 1px solid #efefef;
+  margin: 1em 0;
+  padding: 0;
+}
+
+/* Text and background color for dark mode */
+@media (prefers-color-scheme: dark) {
+  body {
+    color: #e6edf3;
+    background-color: #0d1117;
+  }
+
+  h1 {
+    border-color: rgba(48, 54, 61, 0.7);
+  }
+
+  h2 {
+    border-color: rgba(48, 54, 61, 0.7);
+  }
+
+  hr {
+    border-color: rgba(48, 54, 61, 0.7);
+  }
+
+  div.sourceCode {
+    background-color: #161b22;
+  }
+
+  code {
+    background-color: #161b22;
+  }
+
+  a {
+    color: #4493f8;
+  }
+
+  a:visited {
+    color: #2f66ad;
+  }
+
+  table {
+    border-color: rgba(48, 54, 61, 0.7);
+  }
+
+  td {
+    border-color: rgba(48, 54, 61, 0.7);
+  }
+
+  tr:nth-child(even) {
+    background-color: #161b22;
+  }
+
+  .wikitopbanner {
+    background-color: #263040;
+  }
+
+  .wikibottombanner {
+    background-color: #263040;
+  }
+
+  .anchorText:hover .anchorImage {
+    filter: invert(100%);
+  }
+}
+
+@media print {
+  body {
+    font-size: 12px;
+  }
+
+  table {
+    font-size: inherit;
+  }
+
+  a:visited {
+    color: #0969da;
+  }
+
+  .wikitopbanner,
+  .anchorText,
+  .wikibottombanner {
+    display: none;
+  }
+}
+
+/** additional (& overrides) for examples */
+header {
+  background-color: #efefef;
+  padding: 10px;
+  font-size: 2rem;
+}
+
+header > a,
+header > a:hover,
+header > a:visited {
+  color: inherit;
+  text-decoration: none;
+}
+
+.breadcrumb {
+  padding: 0.75rem 0.75rem;
+}
+
+.breadcrumb ul {
+  display: flex;
+  flex-wrap: wrap;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.breadcrumb li:not(:last-child)::after {
+  display: inline-block;
+  margin: 0 0.25rem;
+  content: "»";
+}
+
+.list {
+  display: flex;
+  flex-flow: row wrap;
+  gap: 24px;
+}
+
+.list > a > div {
+  width: 200px;
+  border: 5px solid #efefef;
+  border-radius: 5px;
+  background: #efefef;
+
+  display: flex;
+  flex-flow: column nowrap;
+
+  transition: border 0.25s;
+}
+
+.list > a > div:hover {
+  border-color: #064998;
+}
+
+.list > a > div > img {
+  width: 100%;
+  border-radius: 5px;
+}
+
+.list > a > div > div {
+  text-align: center;
+}
+
+.list > a,
+.list > a:visited {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+}
+.list > a:hover {
+  color: #0969da;
+}
+
+@media (prefers-color-scheme: dark) {
+  header {
+    background-color: #263040;
+  }
+
+  .breadcrumb li:not(:last-child)::after {
+    color: #efefef;
+  }
+
+  .list > a > div {
+    border-color: #333;
+    background: #333;
+  }
+}
+
+@media only screen and (max-width: 992px) {
+  .list > a > div {
+    width: 150px;
+  }
+}

--- a/examples/template.html
+++ b/examples/template.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>@project_name@ Example: @category_name@/@example_name@</title>
-    <link rel="stylesheet" type="text/css" href="/examples.css" />
+    <link rel="stylesheet" type="text/css" href="/@project_name@/examples.css" />
     <style>
       main {
         display: flex;
@@ -182,9 +182,9 @@
       <div id="content">
         <nav class="breadcrumb">
           <ul>
-            <li><a href="/">@project_name@</a></li>
-            <li><a href="/@category_name@">@category_name@</a></li>
-            <li><a href="/@category_name@/@example_name@">@example_name@</a></li>
+            <li><a href="/@project_name@">@project_name@</a></li>
+            <li><a href="/@project_name@/@category_name@">@category_name@</a></li>
+            <li><a href="/@project_name@/@category_name@/@example_name@">@example_name@</a></li>
           </ul>
         </nav>
         <h1>@project_name@ example: @category_name@/@example_name@</h1>

--- a/examples/template.html
+++ b/examples/template.html
@@ -3,27 +3,48 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>@project_name@ Example: @category_name@/@example_name@</title>
+    <link rel="stylesheet" type="text/css" href="/examples.css" />
     <style>
-      html, body {
-        width: 100vw;
-        height: 100vh;
-        overflow: hidden;
-        font-family: 'Liberation Sans', sans-serif;
+      main {
+        display: flex;
+      }
+
+      main > #sidebar {
+        flex: 0 1 25%;
+        border-left: 2px solid #efefef;
+        padding: 1rem 1rem;
+      }
+
+      main > #content {
+        flex: 1 1 auto;
+        margin-bottom: 16px;
+      }
+
+      main > #content > h1 {
+        margin-top: 0;
+      }
+
+      main > #sidebar ul {
+        list-style-type: none;
+        padding: 0;
+        margin: 0;
+      }
+
+      main > #sidebar li {
+        padding: 2px 0;
+      }
+
+      #example-description {
+        max-width: 85ch;
+        margin-bottom: 16px;
       }
 
       .canvas-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-
         display: flex;
         align-items: center;
         justify-content: center;
-
-        background: black;
       }
 
       #canvas {
@@ -31,7 +52,7 @@
       }
 
       #output-container {
-        position: absolute;
+        position: fixed;
         top: 100%;
         left: 0;
         right: 0;
@@ -47,8 +68,8 @@
       }
 
       #output-container::before {
-        position: absolute;
-        bottom: 100%;
+        position: fixed;
+        bottom: 0;
         right: 1rem;
 
         content: 'Console';
@@ -87,11 +108,12 @@
         outline: none;
         resize: none;
 
-        font-family: 'Lucida Console', Monaco, monospace;
+        font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+          "Liberation Mono", monospace;
       }
 
       #source-code {
-        position: absolute;
+        position: fixed;
         top: 100%;
         left: 0;
         right: 0;
@@ -104,8 +126,8 @@
       }
 
       #source-code::before {
-        position: absolute;
-        bottom: 100%;
+        position: fixed;
+        bottom: 0;
         left: 1rem;
 
         content: 'Source code';
@@ -134,21 +156,53 @@
         overflow: scroll;
       }
 
-      #example-description {
-        color: white;
-        text-align: center;
-        position: relative; /* required for proper positioning */
+      @media (prefers-color-scheme: dark) {
+        main > #sidebar {
+          border-color: rgba(48, 54, 61, 0.7);
+        }
+      }
+
+      @media only screen and (max-width: 992px) {
+        main {
+          flex-direction: column;
+        }
+
+        main > #sidebar {
+          border: none;
+        }
       }
     </style>
     <link rel="stylesheet" type="text/css" href="highlight.css">
   </head>
   <body>
-    <div class="canvas-container">
-      <canvas id="canvas" oncontextmenu="event.preventDefault()" tabindex="-1"></canvas>
-    </div>
-    <div id="example-description">
-      @description@
-    </div>
+    <header>
+      <a href="/">SDL Examples</a>
+    </header>
+    <main>
+      <div id="content">
+        <nav class="breadcrumb">
+          <ul>
+            <li><a href="/">@project_name@</a></li>
+            <li><a href="/@category_name@">@category_name@</a></li>
+            <li><a href="/@category_name@/@example_name@">@example_name@</a></li>
+          </ul>
+        </nav>
+        <h1>@project_name@ example: @category_name@/@example_name@</h1>
+        <div id="example-description">@description@</div>
+        <div class="canvas-container">
+          <canvas
+            id="canvas"
+            oncontextmenu="event.preventDefault()"
+            tabindex="-1"
+          ></canvas>
+        </div>
+      </div>
+      <div id="sidebar">
+        <h3>Other examples:</h3>
+        @other_examples_html@
+      </div>
+    </main>
+
     <div id="output-container">
       <textarea id="output" rows="8" spellcheck="false" readonly></textarea>
     </div>


### PR DESCRIPTION
Hello,

Following conversation in #10350 ; here are some changes:

- added CSS similar to the wiki
- added an homepage for project
- added a page for each category
- modified the example page: added a sidebar (I put on the right side, I thought it was less distracting that way), fixed source/console buttons that were fixed and prevented the page from scrolling
- added a simple breadcrumb on pages

I've tested the changes on Safari/Chrome/Firefox (and also on Safari's iPhone) in dark and light modes. I apologise in advance for my Perl code (I haven't wrote any perl in my life) — but that was easier to work with real data than on HTML mockups.

The big missing thing is to generate images for all examples, and make the HTML use those images instead of the placeholder ones (that's why the PR is marked as WIP).

Feel free to tell me if you want some changes!

Here are some screenshots:

<img width="1392" alt="Capture d’écran 2024-12-04 à 17 15 53" src="https://github.com/user-attachments/assets/df22afa1-8e29-436b-a837-1d7e465d96d9">

<img width="1392" alt="Capture d’écran 2024-12-04 à 17 16 01" src="https://github.com/user-attachments/assets/0028a99c-9da4-4044-b58a-713e6494e30e">

<img width="1392" alt="Capture d’écran 2024-12-04 à 17 16 06" src="https://github.com/user-attachments/assets/3e009fef-fb03-4bb9-8781-6b1bed41e87d">

<img width="1392" alt="Capture d’écran 2024-12-04 à 17 20 58" src="https://github.com/user-attachments/assets/faf67a6d-e33c-447f-a97d-5c4b0494e7cb">


Have a good day!
