### PR TITLE
GPU: Vulkan requires drawIndirectFirstInstance feature

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -11014,7 +11014,8 @@ static Uint8 VULKAN_INTERNAL_IsDeviceSuitable(
     if (!deviceFeatures.independentBlend ||
         !deviceFeatures.imageCubeArray ||
         !deviceFeatures.depthClamp ||
-        !deviceFeatures.shaderClipDistance) {
+        !deviceFeatures.shaderClipDistance ||
+        !deviceFeatures.drawIndirectFirstInstance) {
         return 0;
     }
 
@@ -11260,6 +11261,7 @@ static Uint8 VULKAN_INTERNAL_CreateLogicalDevice(
     desiredDeviceFeatures.imageCubeArray = VK_TRUE;
     desiredDeviceFeatures.depthClamp = VK_TRUE;
     desiredDeviceFeatures.shaderClipDistance = VK_TRUE;
+    desiredDeviceFeatures.drawIndirectFirstInstance = VK_TRUE;
 
     if (haveDeviceFeatures.fillModeNonSolid) {
         desiredDeviceFeatures.fillModeNonSolid = VK_TRUE;


### PR DESCRIPTION
Our Vulkan driver was assuming the existence of this physical device feature, but we need to explicitly enable it. This feature is universally supported on desktop, and is supported by 86% of Android devices (which is very high by Android standards).

Resolves https://github.com/libsdl-org/SDL/issues/10735