### PR TITLE
fix type redefinition errors after commit 24ed947cc

### DIFF
--- a/src/video/SDL_egl_c.h
+++ b/src/video/SDL_egl_c.h
@@ -27,8 +27,6 @@
 
 #include <SDL3/SDL_egl.h>
 
-#include "SDL_sysvideo.h"
-
 #define SDL_EGL_MAX_DEVICES 8
 
 // For systems that don't define these
@@ -115,32 +113,34 @@ typedef enum SDL_EGL_ExtensionType
     SDL_EGL_CLIENT_EXTENSION
 } SDL_EGL_ExtensionType;
 
-extern bool SDL_EGL_HasExtension(SDL_VideoDevice *_this, SDL_EGL_ExtensionType type, const char *ext);
+struct SDL_VideoDevice; // detailed in SDL_sysvideo.h
 
-extern bool SDL_EGL_GetAttribute(SDL_VideoDevice *_this, SDL_GLAttr attrib, int *value);
+extern bool SDL_EGL_HasExtension(struct SDL_VideoDevice *_this, SDL_EGL_ExtensionType type, const char *ext);
+
+extern bool SDL_EGL_GetAttribute(struct SDL_VideoDevice *_this, SDL_GLAttr attrib, int *value);
 /* SDL_EGL_LoadLibrary can get a display for a specific platform (EGL_PLATFORM_*)
  * or, if 0 is passed, let the implementation decide.
  */
-extern bool SDL_EGL_LoadLibraryOnly(SDL_VideoDevice *_this, const char *path);
-extern bool SDL_EGL_LoadLibrary(SDL_VideoDevice *_this, const char *path, NativeDisplayType native_display, EGLenum platform);
-extern SDL_FunctionPointer SDL_EGL_GetProcAddressInternal(SDL_VideoDevice *_this, const char *proc);
-extern void SDL_EGL_UnloadLibrary(SDL_VideoDevice *_this);
-extern void SDL_EGL_SetRequiredVisualId(SDL_VideoDevice *_this, int visual_id);
-extern bool SDL_EGL_ChooseConfig(SDL_VideoDevice *_this);
-extern bool SDL_EGL_SetSwapInterval(SDL_VideoDevice *_this, int interval);
-extern bool SDL_EGL_GetSwapInterval(SDL_VideoDevice *_this, int *interval);
-extern bool SDL_EGL_DestroyContext(SDL_VideoDevice *_this, SDL_GLContext context);
-extern EGLSurface SDL_EGL_CreateSurface(SDL_VideoDevice *_this, SDL_Window *window, NativeWindowType nw);
-extern void SDL_EGL_DestroySurface(SDL_VideoDevice *_this, EGLSurface egl_surface);
+extern bool SDL_EGL_LoadLibraryOnly(struct SDL_VideoDevice *_this, const char *path);
+extern bool SDL_EGL_LoadLibrary(struct SDL_VideoDevice *_this, const char *path, NativeDisplayType native_display, EGLenum platform);
+extern SDL_FunctionPointer SDL_EGL_GetProcAddressInternal(struct SDL_VideoDevice *_this, const char *proc);
+extern void SDL_EGL_UnloadLibrary(struct SDL_VideoDevice *_this);
+extern void SDL_EGL_SetRequiredVisualId(struct SDL_VideoDevice *_this, int visual_id);
+extern bool SDL_EGL_ChooseConfig(struct SDL_VideoDevice *_this);
+extern bool SDL_EGL_SetSwapInterval(struct SDL_VideoDevice *_this, int interval);
+extern bool SDL_EGL_GetSwapInterval(struct SDL_VideoDevice *_this, int *interval);
+extern bool SDL_EGL_DestroyContext(struct SDL_VideoDevice *_this, SDL_GLContext context);
+extern EGLSurface SDL_EGL_CreateSurface(struct SDL_VideoDevice *_this, SDL_Window *window, NativeWindowType nw);
+extern void SDL_EGL_DestroySurface(struct SDL_VideoDevice *_this, EGLSurface egl_surface);
 
-extern EGLSurface SDL_EGL_CreateOffscreenSurface(SDL_VideoDevice *_this, int width, int height);
+extern EGLSurface SDL_EGL_CreateOffscreenSurface(struct SDL_VideoDevice *_this, int width, int height);
 // Assumes that LoadLibraryOnly() has succeeded
-extern bool SDL_EGL_InitializeOffscreen(SDL_VideoDevice *_this, int device);
+extern bool SDL_EGL_InitializeOffscreen(struct SDL_VideoDevice *_this, int device);
 
 // These need to be wrapped to get the surface for the window by the platform GLES implementation
-extern SDL_GLContext SDL_EGL_CreateContext(SDL_VideoDevice *_this, EGLSurface egl_surface);
-extern bool SDL_EGL_MakeCurrent(SDL_VideoDevice *_this, EGLSurface egl_surface, SDL_GLContext context);
-extern bool SDL_EGL_SwapBuffers(SDL_VideoDevice *_this, EGLSurface egl_surface);
+extern SDL_GLContext SDL_EGL_CreateContext(struct SDL_VideoDevice *_this, EGLSurface egl_surface);
+extern bool SDL_EGL_MakeCurrent(struct SDL_VideoDevice *_this, EGLSurface egl_surface, SDL_GLContext context);
+extern bool SDL_EGL_SwapBuffers(struct SDL_VideoDevice *_this, EGLSurface egl_surface);
 
 // SDL Error-reporting
 extern bool SDL_EGL_SetErrorEx(const char *message, const char *eglFunctionName, EGLint eglErrorCode);

--- a/src/video/android/SDL_androidwindow.h
+++ b/src/video/android/SDL_androidwindow.h
@@ -25,6 +25,7 @@
 
 #include "../../core/android/SDL_android.h"
 #include "../SDL_egl_c.h"
+#include "../SDL_sysvideo.h"
 
 extern bool Android_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesID create_props);
 extern void Android_SetWindowTitle(SDL_VideoDevice *_this, SDL_Window *window);

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -27,7 +27,7 @@
  * Wayland headers, which pull in EGL headers with EGL types defined as Wayland
  * types, which causes warnings when building with strict-aliasing and LTO.
  */
-#include "SDL_kmsdrmopengles.h"
+#include "../SDL_egl_c.h"
 
 /* include this here before SDL_sysvideo.h to avoid vulkan type
  * redefinition errors.  it already includes SDL_sysvideo.h.  */
@@ -49,6 +49,7 @@
 #include "SDL_kmsdrmevents.h"
 #include "SDL_kmsdrmmouse.h"
 #include "SDL_kmsdrmvideo.h"
+#include "SDL_kmsdrmopengles.h"
 #include <dirent.h>
 #include <errno.h>
 #include <poll.h>

--- a/src/video/windows/SDL_windowswindow.h
+++ b/src/video/windows/SDL_windowswindow.h
@@ -25,9 +25,8 @@
 
 #ifdef SDL_VIDEO_OPENGL_EGL
 #include "../SDL_egl_c.h"
-#else
-#include "../SDL_sysvideo.h"
 #endif
+#include "../SDL_sysvideo.h"
 
 // Set up for C function definitions, even when using C++
 #ifdef __cplusplus


### PR DESCRIPTION
```
In file included from /tmp/SDL3/src/video/kmsdrm/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/kmsdrm/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/kmsdrm/SDL_kmsdrmvulkan.h:32,
                 from /tmp/SDL3/src/video/kmsdrm/SDL_kmsdrmvideo.c:34:
/tmp/SDL3/src/video/kmsdrm/.././khronos/vulkan/vulkan_core.h:101: error: redefinition of typedef ‘VkInstance’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:67: note: previous declaration of ‘VkInstance’ was here
/tmp/SDL3/src/video/kmsdrm/.././khronos/vulkan/vulkan_core.h:102: error: redefinition of typedef ‘VkPhysicalDevice’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:68: note: previous declaration of ‘VkPhysicalDevice’ was here
In file included from /tmp/SDL3/src/video/kmsdrm/.././khronos/vulkan/vulkan.h:11,
                 from /tmp/SDL3/src/video/kmsdrm/../SDL_vulkan_internal.h:52,
                 from /tmp/SDL3/src/video/kmsdrm/SDL_kmsdrmvulkan.h:32,
                 from /tmp/SDL3/src/video/kmsdrm/SDL_kmsdrmvideo.c:34:
/tmp/SDL3/src/video/kmsdrm/.././khronos/vulkan/vulkan_core.h:7549: error: redefinition of typedef ‘VkSurfaceKHR’
/tmp/SDL3/include/SDL3/SDL_vulkan.h:69: note: previous declaration of ‘VkSurfaceKHR’ was here
make[2]: *** [CMakeFiles/SDL3-shared.dir/src/video/kmsdrm/SDL_kmsdrmvideo.c.o] Error 1
```

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
