### PR TITLE
examples: web output: fix canvas size for small screens

### DIFF
--- a/examples/template.html
+++ b/examples/template.html
@@ -48,6 +48,7 @@
       }
 
       #canvas {
+        max-width: 100%;
         box-shadow: 0 0 0.5rem #7787;
       }
 


### PR DESCRIPTION
Hello,

This follows previous PR #11581 ; I just realised I've missed a `max-width` on the canvas to make sure it still displays nicely on mobile, sorry!

Before this PR:

![IMG_4858](https://github.com/user-attachments/assets/78378dfa-95c3-4452-a3db-754d5311015f)

After this PR:

![IMG_4859](https://github.com/user-attachments/assets/2d3b28ef-f8e6-4083-a585-471ef7ac11c8)
