### PR TITLE
gpu: SDL_ClaimWindowForGPUDevice should set error on failure + function-like macro's

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -247,7 +247,7 @@ SDL_GPUGraphicsPipeline *SDL_GPU_FetchBlitPipeline(
         BlitPipelineCacheEntry,
         *blit_pipeline_count + 1,
         *blit_pipeline_capacity,
-        *blit_pipeline_capacity * 2)
+        *blit_pipeline_capacity * 2);
 
     (*blit_pipelines)[*blit_pipeline_count].pipeline = pipeline;
     (*blit_pipelines)[*blit_pipeline_count].type = source_texture_type;

--- a/src/gpu/SDL_sysgpu.h
+++ b/src/gpu/SDL_sysgpu.h
@@ -391,12 +391,14 @@ static inline Uint32 BytesPerRow(
 // Internal Macros
 
 #define EXPAND_ARRAY_IF_NEEDED(arr, elementType, newCount, capacity, newCapacity) \
-    if (newCount >= capacity) {                                                   \
-        capacity = newCapacity;                                                   \
-        arr = (elementType *)SDL_realloc(                                         \
-            arr,                                                                  \
-            sizeof(elementType) * capacity);                                      \
-    }
+    do {                                                                          \
+        if ((newCount) >= (capacity)) {                                           \
+            (capacity) = (newCapacity);                                           \
+            (arr) = (elementType *)SDL_realloc(                                   \
+                (arr),                                                            \
+                sizeof(elementType) * (capacity));                                \
+        }                                                                         \
+    } while (0)
 
 // Internal Declarations
 

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -6729,7 +6729,7 @@ static bool D3D12_ClaimWindow(
             SET_STRING_ERROR_AND_RETURN("Could not create swapchain, failed to claim window!", false)
         }
     } else {
-        SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "Window already claimed!");
+        SET_STRING_ERROR_AND_RETURN("Window already claimed", false)
         return false;
     }
 }
@@ -6742,7 +6742,7 @@ static void D3D12_ReleaseWindow(
     D3D12WindowData *windowData = D3D12_INTERNAL_FetchWindowData(window);
 
     if (windowData == NULL) {
-        SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "Window already unclaimed!");
+        SET_ERROR("Window already unclaimed!")
         return;
     }
 

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -1229,7 +1229,7 @@ static void D3D12_INTERNAL_ReleaseBuffer(
         D3D12Buffer *,
         renderer->buffersToDestroyCount + 1,
         renderer->buffersToDestroyCapacity,
-        renderer->buffersToDestroyCapacity * 2)
+        renderer->buffersToDestroyCapacity * 2);
 
     renderer->buffersToDestroy[renderer->buffersToDestroyCount] = buffer;
     renderer->buffersToDestroyCount += 1;
@@ -1309,7 +1309,7 @@ static void D3D12_INTERNAL_ReleaseTexture(
         D3D12Texture *,
         renderer->texturesToDestroyCount + 1,
         renderer->texturesToDestroyCapacity,
-        renderer->texturesToDestroyCapacity * 2)
+        renderer->texturesToDestroyCapacity * 2);
 
     renderer->texturesToDestroy[renderer->texturesToDestroyCount] = texture;
     renderer->texturesToDestroyCount += 1;
@@ -3740,7 +3740,7 @@ static void D3D12_ReleaseSampler(
         D3D12Sampler *,
         renderer->samplersToDestroyCount + 1,
         renderer->samplersToDestroyCapacity,
-        renderer->samplersToDestroyCapacity * 2)
+        renderer->samplersToDestroyCapacity * 2);
 
     renderer->samplersToDestroy[renderer->samplersToDestroyCount] = d3d12Sampler;
     renderer->samplersToDestroyCount += 1;
@@ -3800,7 +3800,7 @@ static void D3D12_ReleaseComputePipeline(
         D3D12ComputePipeline *,
         renderer->computePipelinesToDestroyCount + 1,
         renderer->computePipelinesToDestroyCapacity,
-        renderer->computePipelinesToDestroyCapacity * 2)
+        renderer->computePipelinesToDestroyCapacity * 2);
 
     renderer->computePipelinesToDestroy[renderer->computePipelinesToDestroyCount] = d3d12ComputePipeline;
     renderer->computePipelinesToDestroyCount += 1;
@@ -3822,7 +3822,7 @@ static void D3D12_ReleaseGraphicsPipeline(
         D3D12GraphicsPipeline *,
         renderer->graphicsPipelinesToDestroyCount + 1,
         renderer->graphicsPipelinesToDestroyCapacity,
-        renderer->graphicsPipelinesToDestroyCapacity * 2)
+        renderer->graphicsPipelinesToDestroyCapacity * 2);
 
     renderer->graphicsPipelinesToDestroy[renderer->graphicsPipelinesToDestroyCount] = d3d12GraphicsPipeline;
     renderer->graphicsPipelinesToDestroyCount += 1;

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -34,31 +34,35 @@
 #define WINDOW_PROPERTY_DATA           "SDL_GPUMetalWindowPropertyData"
 #define SDL_GPU_SHADERSTAGE_COMPUTE    2
 
-#define TRACK_RESOURCE(resource, type, array, count, capacity) \
-    Uint32 i;                                                  \
-                                                               \
-    for (i = 0; i < commandBuffer->count; i += 1) {            \
-        if (commandBuffer->array[i] == resource) {             \
-            return;                                            \
-        }                                                      \
-    }                                                          \
-                                                               \
-    if (commandBuffer->count == commandBuffer->capacity) {     \
-        commandBuffer->capacity += 1;                          \
-        commandBuffer->array = SDL_realloc(                    \
-            commandBuffer->array,                              \
-            commandBuffer->capacity * sizeof(type));           \
-    }                                                          \
-    commandBuffer->array[commandBuffer->count] = resource;     \
-    commandBuffer->count += 1;                                 \
-    SDL_AtomicIncRef(&resource->referenceCount);
+#define TRACK_RESOURCE(resource, type, array, count, capacity)   \
+    do {                                                         \
+        Uint32 i;                                                \
+                                                                 \
+        for (i = 0; i < commandBuffer->count; i += 1) {          \
+            if (commandBuffer->array[i] == (resource)) {         \
+                return;                                          \
+            }                                                    \
+        }                                                        \
+                                                                 \
+        if (commandBuffer->count == commandBuffer->capacity) {   \
+            commandBuffer->capacity += 1;                        \
+            commandBuffer->array = SDL_realloc(                  \
+                commandBuffer->array,                            \
+                commandBuffer->capacity * sizeof(type));         \
+        }                                                        \
+        commandBuffer->array[commandBuffer->count] = (resource); \
+        commandBuffer->count += 1;                               \
+        SDL_AtomicIncRef(&(resource)->referenceCount);           \
+    } while (0)
 
-#define SET_ERROR_AND_RETURN(fmt, msg, ret)           \
-    if (renderer->debugMode) {                        \
-        SDL_LogError(SDL_LOG_CATEGORY_GPU, fmt, msg); \
-    }                                                 \
-    SDL_SetError(fmt, msg);                           \
-    return ret;                                       \
+#define SET_ERROR_AND_RETURN(fmt, msg, ret)               \
+    do {                                                  \
+        if (renderer->debugMode) {                        \
+            SDL_LogError(SDL_LOG_CATEGORY_GPU, fmt, msg); \
+        }                                                 \
+        SDL_SetError(fmt, msg);                           \
+        return ret;                                       \
+    } while (0)
 
 #define SET_STRING_ERROR_AND_RETURN(msg, ret) SET_ERROR_AND_RETURN("%s", msg, ret)
 
@@ -3624,7 +3628,7 @@ static bool METAL_ClaimWindow(
                 SET_STRING_ERROR_AND_RETURN("Could not create swapchain, failed to claim window", false);
             }
         } else {
-            SET_ERROR_AND_RETURN("Window already claimed!", false)
+            SET_ERROR_AND_RETURN("%s", "Window already claimed!", false);
         }
     }
 }

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -3624,8 +3624,7 @@ static bool METAL_ClaimWindow(
                 SET_STRING_ERROR_AND_RETURN("Could not create swapchain, failed to claim window", false);
             }
         } else {
-            SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "Window already claimed!");
-            return false;
+            SET_ERROR_AND_RETURN("Window already claimed!", false)
         }
     }
 }

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -9585,8 +9585,7 @@ static bool VULKAN_ClaimWindow(
             return false;
         }
     } else {
-        SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "Window already claimed!");
-        return false;
+        SET_STRING_ERROR_AND_RETURN("Window already claimed!", false)
     }
 }
 

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -97,14 +97,6 @@ typedef struct VulkanExtensions
             arr->capacity * sizeof(type));                 \
     }
 
-#define EXPAND_ARRAY_IF_NEEDED(arr, elementType, newCount, capacity, newCapacity) \
-    if (newCount >= capacity) {                                                   \
-        capacity = newCapacity;                                                   \
-        arr = (elementType *)SDL_realloc(                                         \
-            arr,                                                                  \
-            sizeof(elementType) * capacity);                                      \
-    }
-
 #define MOVE_ARRAY_CONTENTS_AND_RESET(i, dstArr, dstCount, srcArr, srcCount) \
     for (i = 0; i < srcCount; i += 1) {                                      \
         dstArr[i] = srcArr[i];                                               \
@@ -2897,7 +2889,7 @@ static void VULKAN_INTERNAL_ReleaseFramebuffer(
         VulkanFramebuffer *,
         renderer->framebuffersToDestroyCount + 1,
         renderer->framebuffersToDestroyCapacity,
-        renderer->framebuffersToDestroyCapacity * 2)
+        renderer->framebuffersToDestroyCapacity * 2);
 
     renderer->framebuffersToDestroy[renderer->framebuffersToDestroyCount] = framebuffer;
     renderer->framebuffersToDestroyCount += 1;
@@ -4940,7 +4932,7 @@ static void VULKAN_INTERNAL_ReturnDescriptorSetCacheToPool(
         DescriptorSetCache *,
         renderer->descriptorSetCachePoolCount + 1,
         renderer->descriptorSetCachePoolCapacity,
-        renderer->descriptorSetCachePoolCapacity * 2)
+        renderer->descriptorSetCachePoolCapacity * 2);
 
     renderer->descriptorSetCachePool[renderer->descriptorSetCachePoolCount] = descriptorSetCache;
     renderer->descriptorSetCachePoolCount += 1;
@@ -6752,7 +6744,7 @@ static void VULKAN_INTERNAL_ReleaseTexture(
         VulkanTexture *,
         renderer->texturesToDestroyCount + 1,
         renderer->texturesToDestroyCapacity,
-        renderer->texturesToDestroyCapacity * 2)
+        renderer->texturesToDestroyCapacity * 2);
 
     renderer->texturesToDestroy[renderer->texturesToDestroyCount] = vulkanTexture;
     renderer->texturesToDestroyCount += 1;
@@ -6800,7 +6792,7 @@ static void VULKAN_ReleaseSampler(
         VulkanSampler *,
         renderer->samplersToDestroyCount + 1,
         renderer->samplersToDestroyCapacity,
-        renderer->samplersToDestroyCapacity * 2)
+        renderer->samplersToDestroyCapacity * 2);
 
     renderer->samplersToDestroy[renderer->samplersToDestroyCount] = vulkanSampler;
     renderer->samplersToDestroyCount += 1;
@@ -6823,7 +6815,7 @@ static void VULKAN_INTERNAL_ReleaseBuffer(
         VulkanBuffer *,
         renderer->buffersToDestroyCount + 1,
         renderer->buffersToDestroyCapacity,
-        renderer->buffersToDestroyCapacity * 2)
+        renderer->buffersToDestroyCapacity * 2);
 
     renderer->buffersToDestroy[renderer->buffersToDestroyCount] = vulkanBuffer;
     renderer->buffersToDestroyCount += 1;
@@ -6893,7 +6885,7 @@ static void VULKAN_ReleaseShader(
         VulkanShader *,
         renderer->shadersToDestroyCount + 1,
         renderer->shadersToDestroyCapacity,
-        renderer->shadersToDestroyCapacity * 2)
+        renderer->shadersToDestroyCapacity * 2);
 
     renderer->shadersToDestroy[renderer->shadersToDestroyCount] = vulkanShader;
     renderer->shadersToDestroyCount += 1;
@@ -6915,7 +6907,7 @@ static void VULKAN_ReleaseComputePipeline(
         VulkanComputePipeline *,
         renderer->computePipelinesToDestroyCount + 1,
         renderer->computePipelinesToDestroyCapacity,
-        renderer->computePipelinesToDestroyCapacity * 2)
+        renderer->computePipelinesToDestroyCapacity * 2);
 
     renderer->computePipelinesToDestroy[renderer->computePipelinesToDestroyCount] = vulkanComputePipeline;
     renderer->computePipelinesToDestroyCount += 1;
@@ -6937,7 +6929,7 @@ static void VULKAN_ReleaseGraphicsPipeline(
         VulkanGraphicsPipeline *,
         renderer->graphicsPipelinesToDestroyCount + 1,
         renderer->graphicsPipelinesToDestroyCapacity,
-        renderer->graphicsPipelinesToDestroyCapacity * 2)
+        renderer->graphicsPipelinesToDestroyCapacity * 2);
 
     renderer->graphicsPipelinesToDestroy[renderer->graphicsPipelinesToDestroyCount] = vulkanGraphicsPipeline;
     renderer->graphicsPipelinesToDestroyCount += 1;


### PR DESCRIPTION
- SDL_ClaimWindowForGPUDevice should set an error on failure
- define `EXPAND_ARRAY_IF_NEEDED` once (remove duplicate in vulkan driver)
- make GPU macros function-like by doing `do { ... } while (0)`

/cc @thatcosmonaut 
## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
