### PR TITLE
wayland: Only require fifo-v1 for Wayland by default

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -449,7 +449,6 @@ static void Wayland_DeleteDevice(SDL_VideoDevice *device)
 typedef struct
 {
     bool has_fifo_v1;
-    bool has_commit_timing_v1;
 } SDL_WaylandPreferredData;
 
 static void wayland_preferred_check_handle_global(void *data, struct wl_registry *registry, uint32_t id,
@@ -459,8 +458,6 @@ static void wayland_preferred_check_handle_global(void *data, struct wl_registry
 
     if (SDL_strcmp(interface, "wp_fifo_manager_v1") == 0) {
         d->has_fifo_v1 = true;
-    } else if (SDL_strcmp(interface, "wp_commit_timing_manager_v1") == 0) {
-        d->has_commit_timing_v1 = true;
     }
 }
 
@@ -490,7 +487,7 @@ static bool Wayland_IsPreferred(struct wl_display *display)
 
     wl_registry_destroy(registry);
 
-    return preferred_data.has_fifo_v1 && preferred_data.has_commit_timing_v1;
+    return preferred_data.has_fifo_v1;
 }
 
 static SDL_VideoDevice *Wayland_CreateDevice(bool require_preferred_protocols)
@@ -524,9 +521,8 @@ static SDL_VideoDevice *Wayland_CreateDevice(bool require_preferred_protocols)
 
     /*
      * If we are checking for preferred Wayland, then let's query for
-     * fifo-v1 and commit-timing-v1's existence, so we don't regress
-     * GPU-bound performance and frame-pacing by default due to
-     * swapchain starvation.
+     * fifo-v1's existence, so we don't regress GPU-bound performance
+     * and frame-pacing by default due to swapchain starvation.
      */
     if (require_preferred_protocols && !Wayland_IsPreferred(display)) {
         WAYLAND_wl_display_disconnect(display);


### PR DESCRIPTION
Some compositors [may not implement commit-timing-v1 in addition to fifo-v1](https://invent.kde.org/plasma/kwin/-/merge_requests/6474), at least not immediately, and [Mesa doesn't require commit-timing for FIFO behavior](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/32556#note_2694119).

Only check for fifo-v1 to enable Wayland by default, as that should be enough to get the desired behavior (no pacing with dodgy frame callbacks or risk of blocking forever).

Quick check with @misyltoad that this is ok?
