### PR TITLE
Fixed issue #11643 (Null pointer dereference in SDL_audio.c)

### DIFF
--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -234,6 +234,7 @@ static bool AudioDeviceCanUseSimpleCopy(SDL_AudioDevice *device)
 // should hold device->lock before calling.
 static void UpdateAudioStreamFormatsPhysical(SDL_AudioDevice *device)
 {
+    SDL_assert(device != NULL);
     if (device->recording) {  // for recording devices, we only want to move to float32 for postmix and gain, which we'll handle elsewhere.
         // we _do_ need to make sure the channel map is correct, though...
         for (SDL_LogicalAudioDevice *logdev = device->logical_devices; logdev; logdev = logdev->next) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If a certain series of conditions are met, we may try to de-reference a null pointer here:https://github.com/libsdl-org/SDL/blob/1944bc74071451f165adf09b1a79fc1b1dc422a9/src/audio/SDL_audio.c#L237

The fix consists in asserting that device is not NULL before accessing its property "recording".

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/11643
