### PR TITLE
wayland: Don't close an externally owned display on init failure

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -529,14 +529,18 @@ static SDL_VideoDevice *Wayland_CreateDevice(bool require_preferred_protocols)
      * swapchain starvation.
      */
     if (require_preferred_protocols && !Wayland_IsPreferred(display)) {
-        WAYLAND_wl_display_disconnect(display);
+        if (!display_is_external) {
+            WAYLAND_wl_display_disconnect(display);
+        }
         SDL_WAYLAND_UnloadSymbols();
         return NULL;
     }
 
     data = SDL_calloc(1, sizeof(*data));
     if (!data) {
-        WAYLAND_wl_display_disconnect(display);
+        if (!display_is_external) {
+            WAYLAND_wl_display_disconnect(display);
+        }
         SDL_WAYLAND_UnloadSymbols();
         return NULL;
     }
@@ -544,7 +548,9 @@ static SDL_VideoDevice *Wayland_CreateDevice(bool require_preferred_protocols)
     input = SDL_calloc(1, sizeof(*input));
     if (!input) {
         SDL_free(data);
-        WAYLAND_wl_display_disconnect(display);
+        if (!display_is_external) {
+            WAYLAND_wl_display_disconnect(display);
+        }
         SDL_WAYLAND_UnloadSymbols();
         return NULL;
     }
@@ -566,7 +572,9 @@ static SDL_VideoDevice *Wayland_CreateDevice(bool require_preferred_protocols)
     if (!device) {
         SDL_free(input);
         SDL_free(data);
-        WAYLAND_wl_display_disconnect(display);
+        if (!display_is_external) {
+            WAYLAND_wl_display_disconnect(display);
+        }
         SDL_WAYLAND_UnloadSymbols();
         return NULL;
     }


### PR DESCRIPTION
Fixes #11642