### PR TITLE
Add check for Sequoia XBOX360 wired l-stick invert

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_xbox360.c
+++ b/src/joystick/hidapi/SDL_hidapi_xbox360.c
@@ -20,6 +20,10 @@
 */
 #include "../../SDL_internal.h"
 
+#ifdef __MACOSX__
+#include <AvailabilityMacros.h>
+#endif
+
 #ifdef SDL_JOYSTICK_HIDAPI
 
 #include "SDL_events.h"
@@ -243,7 +247,8 @@ static int HIDAPI_DriverXbox360_SetJoystickSensorsEnabled(SDL_HIDAPI_Device *dev
 static void HIDAPI_DriverXbox360_HandleStatePacket(SDL_Joystick *joystick, SDL_DriverXbox360_Context *ctx, Uint8 *data, int size)
 {
     Sint16 axis;
-#ifdef __MACOSX__
+#if (defined(__MACOSX__) && (MAC_OS_X_VERSION_MIN_REQUIRED < 150000))
+// In MacOS 15+ we are using the Apple XBox driver, instead of the 360Controller community driver. 
     const SDL_bool invert_y_axes = SDL_FALSE;
 #else
     const SDL_bool invert_y_axes = SDL_TRUE;


### PR DESCRIPTION
There is an issue with the new MacOS provided Xbox360 drivers in MacOS Sequoia, where the left stick is inverted.

Examples of people having this issue:
[reddit mac_gaming](https://www.reddit.com/r/macgaming/comments/1fqbpyz/xbox_360_controllers_are_natively_supported_in/lsf47hz/)
[reddit mac_gaming again](https://www.reddit.com/r/macgaming/comments/1g5k426/sequoia_always_inverting_y_on_xbox_360_controller/)
[stardew valley forum](https://forums.stardewvalley.net/threads/inverted-vertical-controls-on-macos-with-xbox-360-controller.33772)


This adds a check if running Sequoia or later, to not add the invert logic which is needed for the [360Controller](https://github.com/360Controller/360Controller) drivers.