### PR TITLE
Fix dialog filters on Windows

### DIFF
--- a/src/dialog/SDL_dialog_utils.c
+++ b/src/dialog/SDL_dialog_utils.c
@@ -78,21 +78,18 @@ char *convert_filters(const SDL_DialogFileFilter *filters, int nfilters,
         SDL_free(converted);
     }
 
-    // If the filter list is empty, put the suffix
-    if (!filters->name || !filters->pattern) {
-        new_length = SDL_strlen(combined) + SDL_strlen(suffix) + 1;
+    new_length = SDL_strlen(combined) + SDL_strlen(suffix) + 1;
 
-        new_combined = (char *)SDL_realloc(combined, new_length);
+    new_combined = (char *)SDL_realloc(combined, new_length);
 
-        if (!new_combined) {
-            SDL_free(combined);
-            return NULL;
-        }
-
-        combined = new_combined;
-
-        SDL_strlcat(combined, suffix, new_length);
+    if (!new_combined) {
+        SDL_free(combined);
+        return NULL;
     }
+
+    combined = new_combined;
+
+    SDL_strlcat(combined, suffix, new_length);
 
     return combined;
 }

--- a/src/dialog/windows/SDL_windowsdialog.c
+++ b/src/dialog/windows/SDL_windowsdialog.c
@@ -63,6 +63,24 @@ int getFilterIndex(int as_reported_by_windows)
     return as_reported_by_windows - 1;
 }
 
+char *clear_filt_names(const char *filt)
+{
+    char *cleared = SDL_strdup(filt);
+
+    for (char *c = cleared; *c; c++) {
+        /* 0x01 bytes are used as temporary replacement for the various 0x00
+           bytes required by Win32 (one null byte between each filter, two at
+           the end of the filters). Filter out these bytes from the filter names
+           to avoid early-ending the filters if someone puts two consecutive
+           0x01 bytes in their filter names. */
+        if (*c == '\x01') {
+            *c = ' ';
+        }
+    }
+
+    return cleared;
+}
+
 // TODO: The new version of file dialogs
 void windows_ShowFileDialog(void *ptr)
 {
@@ -161,7 +179,7 @@ void windows_ShowFileDialog(void *ptr)
     if (filters) {
         // '\x01' is used in place of a null byte
         // suffix needs two null bytes in case the filter list is empty
-        char *filterlist = convert_filters(filters, nfilters, NULL, "", "",
+        char *filterlist = convert_filters(filters, nfilters, clear_filt_names, "", "",
                                            "\x01\x01", "", "\x01", "\x01",
                                            "*.", ";*.", "");
 


### PR DESCRIPTION
## Description

This fixes two bugs with file filters for dialogs on Windows. The details of the bugs are in the commit messages:

- convert_filters: For some obscure reason I can't remember, I had made it so the suffix would be added only if the filter list was empty. That isn't the expected behavior and caused a mishandling of memory on Windows, which requires a two-null-bytes suffix.
- clear_filt_names: The Windows implementation of dialogs use the Win32 API, which expects the file filters to have null bytes as separator, and two null bytes at the end of the filter list. To help with string manipulation, the internal code uses 0x01 bytes instead of null bytes, and converts all 0x01 bytes into null bytes at the last moment. If someone decides to put two consecutive 0x01 bytes in their filter names, the code might mistakenly pick them up and convert them to null bytes, leading to Windows failing to pick up later filters. In practice, this is probably not so bad, since it requires someone to have control over file filters already, and allows at most ignoring the following file filters. It is also unlikely to happen by accident since 0x01 is not printable. This commit fixes that by replacing all the pre-existing 0x01 bytes with the space character.

## Existing Issue(s)

Fixes #11653 -- @AntTheAlchemist @RT2Code @adamkewley Can you confirm that the bug is fixed with this PR?
