### PR TITLE
x11: Use the master pointer device for absolute motion

### DIFF
--- a/src/video/x11/SDL_x11video.h
+++ b/src/video/x11/SDL_x11video.h
@@ -137,6 +137,7 @@ struct SDL_VideoData
     Uint32 global_mouse_buttons;
 
     SDL_XInput2DeviceInfo *mouse_device_info;
+    int xinput_master_pointer_device;
     bool xinput_hierarchy_changed;
 
     int xrandr_event_base;


### PR DESCRIPTION
Slave pointer devices can seemingly lag behind the master for some reason, so use the master pointer coordinates for absolute motion.

Master events are now only filtered out on the pen path to avoid duplicates.

Fixes #11646 
