### PR TITLE
Fix memory management for Windows dialog title

### DIFF
--- a/src/dialog/windows/SDL_windowsdialog.c
+++ b/src/dialog/windows/SDL_windowsdialog.c
@@ -221,7 +221,7 @@ void windows_ShowFileDialog(void *ptr)
             title_len = 0;
         }
 
-        int title_wlen = MultiByteToWideChar(CP_UTF8, 0, title, title_len, NULL, 0);
+        int title_wlen = MultiByteToWideChar(CP_UTF8, 0, title, -1, NULL, 0);
 
         if (title_wlen < 0) {
             title_wlen = 0;
@@ -236,7 +236,7 @@ void windows_ShowFileDialog(void *ptr)
             return;
         }
 
-        MultiByteToWideChar(CP_UTF8, 0, title, title_len, title_w, title_wlen);
+        MultiByteToWideChar(CP_UTF8, 0, title, -1, title_w, title_wlen);
     }
 
     OPENFILENAMEW dialog;


### PR DESCRIPTION
## Description

This fixes memory management with the title of the dialog.

**Note:** I've noticed that Windows suffers from the same issue as the Unix implementation did; the parameters are not copied over from the properties before passing them to a new thread, making it necessary to track their lifetime until the callback is invoked. I did not fix that yet.

## Existing Issue(s)

Fixes #11661
