### PR TITLE
[PS2SDK]: Remove EXTRA_CFLAGS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2730,7 +2730,6 @@ elseif(PSP)
   endif()
 
 elseif(PS2)
-  list(APPEND EXTRA_CFLAGS "-DPS2" "-D__PS2__" "-I$ENV{PS2SDK}/ports/include" "-I$ENV{PS2DEV}/gsKit/include")
 
   file(GLOB PS2_MAIN_SOURCES ${SDL2_SOURCE_DIR}/src/main/ps2/*.c)
   set(SDLMAIN_SOURCES ${SDLMAIN_SOURCES} ${PS2_MAIN_SOURCES})


### PR DESCRIPTION
This pr removes EXTRA_CFLAGS as we have a new cmake ported by myself on [ps2sdk repository](https://github.com/ps2dev/ps2sdk/blob/master/samples/ps2dev.cmake) superceeds #11027 
