### PR TITLE
GPU: Fix non-triangle D3D12 primitive topology types

### DIFF
--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -568,6 +568,14 @@ static D3D12_PRIMITIVE_TOPOLOGY SDLToD3D12_PrimitiveType[] = {
     D3D_PRIMITIVE_TOPOLOGY_POINTLIST      // POINTLIST
 };
 
+static D3D12_PRIMITIVE_TOPOLOGY_TYPE SDLToD3D12_PrimitiveTopologyType[] = {
+    D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE, // TRIANGLELIST
+    D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE, // TRIANGLESTRIP
+    D3D12_PRIMITIVE_TOPOLOGY_TYPE_LINE,     // LINELIST
+    D3D12_PRIMITIVE_TOPOLOGY_TYPE_LINE,     // LINESTRIP
+    D3D12_PRIMITIVE_TOPOLOGY_TYPE_POINT     // POINTLIST
+};
+
 static D3D12_TEXTURE_ADDRESS_MODE SDLToD3D12_SamplerAddressMode[] = {
     D3D12_TEXTURE_ADDRESS_MODE_WRAP,   // REPEAT
     D3D12_TEXTURE_ADDRESS_MODE_MIRROR, // MIRRORED_REPEAT
@@ -2864,7 +2872,7 @@ static SDL_GPUGraphicsPipeline *D3D12_CreateGraphicsPipeline(
         D3D12_INTERNAL_ConvertVertexInputState(createinfo->vertex_input_state, inputElementDescs, renderer->semantic);
     }
 
-    psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+    psoDesc.PrimitiveTopologyType = SDLToD3D12_PrimitiveTopologyType[createinfo->primitive_type];
 
     if (!D3D12_INTERNAL_ConvertRasterizerState(createinfo->rasterizer_state, &psoDesc.RasterizerState)) {
         return NULL;


### PR DESCRIPTION
This PR removes the hardcoded TRIANGLE primitive topology type from D3D12 pipeline creation and replaces it with a lookup into a new translation array.

Confusingly, D3D12 has "primitive topology" and "primitive topology type" as different types. The latter represents the general class of primitive topologies that a pipeline can support, and the former is the specific topology used for a given set of draw calls.

Resolves https://github.com/libsdl-org/SDL/issues/11680