### PR TITLE
GPU: Enable Metal validation in debug mode

### DIFF
--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -4344,6 +4344,11 @@ static SDL_GPUDevice *METAL_CreateDevice(bool debugMode, bool preferLowPower, SD
         id<MTLDevice> device = NULL;
 
         if (debugMode) {
+            /* Due to a Metal driver quirk, once a MTLDevice has been created
+             * with this environment variable set, the Metal validation layers
+             * will remain enabled for the rest of the application's lifespan,
+             * even if the device is destroyed and recreated.
+             */
             SDL_setenv_unsafe("MTL_DEBUG_LAYER", "1", 0);
         }
 

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -4343,6 +4343,10 @@ static SDL_GPUDevice *METAL_CreateDevice(bool debugMode, bool preferLowPower, SD
         MetalRenderer *renderer;
         id<MTLDevice> device = NULL;
 
+        if (debugMode) {
+            SDL_setenv_unsafe("MTL_DEBUG_LAYER", "1", 0);
+        }
+
         // Create the Metal device and command queue
 #ifdef SDL_PLATFORM_MACOS
         if (preferLowPower) {


### PR DESCRIPTION
When creating a GPU device in debug mode, we should enable Metal validation like we do for Vulkan and D3D12. This native validation helps catch errors that are difficult or impossible to detect from SDL's side (like malformed shaders). Unlike other APIs, Metal's validation layers are enabled via an environment variable that must be set before device creation.