### PR TITLE
GPU: Document system requirements, add upfront Metal hardware support checks

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -159,6 +159,24 @@
  * and reasonable to implement across several platforms and underlying APIs.
  * So while these things are not in the "never" category, they are definitely
  * not "near future" items either.
+ *
+ * ## System Requirements
+ *
+ * **Vulkan:** Supported on Windows, Linux, Nintendo Switch, and certain Android devices. Requires Vulkan 1.0 with the following extensions and device features:
+ * - `VK_KHR_swapchain`
+ * - `VK_KHR_maintenance1`
+ * - `independentBlend`
+ * - `imageCubeArray`
+ * - `depthClamp`
+ * - `shaderClipDistance`
+ * - `drawIndirectFirstInstance`
+ *
+ * **D3D12:** Supported on Windows 10 or newer, Xbox One (GDK), and Xbox Series X|S (GDK). Requires a GPU that supports DirectX 12 Feature Level 11_1.
+ *
+ * **Metal:** Supported on macOS 10.14+ and iOS/tvOS 13.0+. Hardware requirements vary by operating system:
+ * - macOS requires an Apple Silicon or [Intel Mac2 family](https://developer.apple.com/documentation/metal/mtlfeatureset/mtlfeatureset_macos_gpufamily2_v1?language=objc) GPU
+ * - iOS/tvOS requires an A9 GPU or newer
+ * - iOS Simulator and tvOS Simulator are unsupported
  */
 
 #ifndef SDL_gpu_h_


### PR DESCRIPTION
This PR adds documentation for the OS/driver/hardware requirements for each of the SDL_GPU backends. This should hopefully clear up a lot of ambiguity around "is this device supported" and gives developers something concrete to use for their own system requirements and support.

At runtime, to ensure the device meets SDL_GPU driver's system requirements, Vulkan and D3D12 perform a series of feature support queries during the device creation process. However, for Metal, we only performed a single OS version check. This allowed apps to get pretty far into their lifecycle on unsupported devices before they crashed by using an unsupported feature.

To fix this, I've added hardware support queries as early as possible (right after MTLDevice creation) to detect if the app is running on an unsupported device, so that apps can handle the failure gracefully. I also bumped up the minimum macOS version from 10.13 to 10.14 because lower versions don't have the hardware support query we need.

Resolves https://github.com/libsdl-org/SDL/issues/11692