### PR TITLE
Fix iOS text input not working well with password auto-fill integration

### DIFF
--- a/src/video/uikit/SDL_uikitviewcontroller.h
+++ b/src/video/uikit/SDL_uikitviewcontroller.h
@@ -32,6 +32,9 @@
 #endif
 
 @interface SDLUITextField : UITextField
+
+@property(nonatomic, assign) SDL_Window *sdlWindow;
+
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender;
 @end
 

--- a/src/video/uikit/SDL_uikitviewcontroller.m
+++ b/src/video/uikit/SDL_uikitviewcontroller.m
@@ -656,7 +656,7 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 - (BOOL)textField:(UITextField *)_textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
 {
     if (textField.markedTextRange == nil) {
-        if (textField.text.length < 16) {
+        if ([string length] == 0 && textField.text.length < 16) {
             textField.text = obligateForBackspace;
             committedText = textField.text;
         }


### PR DESCRIPTION
This PR includes two separate fixes focusing towards the same goal, I'm not sure how to split them as they can't make sense on their own. My Objective-C coding skills are not that well so I apologise in advance if I made an idiotic mistake somewhere in the code 😅

### [Fix text field resetting text when replaced with a short string](https://github.com/libsdl-org/SDL/commit/6b77fbe3d68812d57fa1e4713d8ecc3e3c034670)

When selecting a password to auto-fill in the current text field, the `textField.text` property is overwritten with that password, and if the password is less than 16 characters, it triggers the code that resets the text content and messes up the entire logic that is supposed to perform backspaces and such.

The fix is to simply reset the text (i.e. fill back the "obligatory for backspace" text) when the event is triggered with a `string` of length zero, i.e. when the user deletes characters (see [docs](https://developer.apple.com/documentation/uikit/uitextfielddelegate/textfield(_:shouldchangecharactersin:replacementstring:)?language=objc)).

The fix above can be argued to be more of a band-aid than a solid fix, as there's probably no better fix than to rewrite the iOS text input system from top to bottom and introduce text input events when a text is reset or replaced etc. It's a heavy one to discuss and my take on the matter may probably be biased towards iOS or not well thought of, but either way the fix above will do for now.

### [Associate text input state with the UITextField's focus state instead](https://github.com/libsdl-org/SDL/commit/518be1e7e0dae004ab50573ce345a56847d5c7f6)

When pressing the "Passwords" button on the keyboard to pick a keychain/vault, the keyboard hides, which triggers the `keyboardWillHide` animation, and incorrectly stop text input, ultimately not accepting any character entered from the selected password due to the text input being inactive.

That issue made me try to "think out of the box", and I've noticed that UIKit synchronises the text field's "is first responder" state when the user dismisses the keyboard or otherwise, and correctly maintains it when the user presses the "Passwords" button and picks a password, as well as also keeping the text field focused when connecting a hardware keyboard or changing orientation. So overall it was a better state to associate with SDL text input's state rather than the on-screen keyboard's visibility.