### PR TITLE
Reset text field content when stopping text input on iOS

### DIFF
--- a/src/video/uikit/SDL_uikitviewcontroller.m
+++ b/src/video/uikit/SDL_uikitviewcontroller.m
@@ -528,6 +528,7 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
         return true;
     }
 
+    [self resetTextState];
     return [textField resignFirstResponder];
 }
 
@@ -657,8 +658,7 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 {
     if (textField.markedTextRange == nil) {
         if (textField.text.length < 16) {
-            textField.text = obligateForBackspace;
-            committedText = textField.text;
+            [self resetTextState];
         }
     }
     return YES;
@@ -673,6 +673,12 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
         SDL_StopTextInput(window);
     }
     return YES;
+}
+
+- (void)resetTextState
+{
+    textField.text = obligateForBackspace;
+    committedText = textField.text;
 }
 
 #endif


### PR DESCRIPTION
This fixes the text prediction bar showing text from a previous text input session and also potentially overwriting text:

https://github.com/user-attachments/assets/11324eef-a161-4e8b-af6e-ce4857886e47

Eventually it would probably be nice to allow SDL to request the current text content from the consumer as a `SDL_TEXTINPUT_...` property and fill that to the internal text field to make the prediction synchronise with the current content. That would probably also get rid of the entire `obligateForBackspace` string. Wouldn't mind implementing that if it's fine to implement only for iOS, not quite experienced to deal with other platforms.