### PR TITLE
Windows: Prevent garbage text appearing in OpenFileDialog filters field

### DIFF
--- a/src/dialog/SDL_dialog_utils.c
+++ b/src/dialog/SDL_dialog_utils.c
@@ -59,7 +59,7 @@ char *convert_filters(const SDL_DialogFileFilter *filters, int nfilters,
             return NULL;
         }
 
-        terminator = f[1].name ? separator : suffix;
+        terminator = ((i + 1) < nfilters) ? separator : suffix;
         new_length = SDL_strlen(combined) + SDL_strlen(converted)
                    + SDL_strlen(terminator) + 1;
 


### PR DESCRIPTION
## Description
#9856 introduced an `nfilters` parameter for the filetype filter count, but missed a check where some code tests for the end of the array via a legacy "is the next item null?". This can cause the windows filetype filter string to be generated malformed, as the conversion function reads beyond the range requested by `nfilters`, and this malformed output can in turn cause garbage text to appear in the filetype dropdown menu. This out-of-bounds read could also potentially cause a segfault if the input array doesn't have at least N+1 elements.

This PR replaces the legacy nullcheck with the appropriate check against `nfilters`, preventing said garbage text from appearing.

## Existing Issue(s)
Didn't see an existing issue, and it was such a quick fix I didn't think it worth opening one.