### PR TITLE
`SDL_HINT_QUIT_ON_LAST_WINDOW_CLOSE` also considers system tray icons

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -79,6 +79,7 @@ LOCAL_SRC_FILES := \
 	$(wildcard $(LOCAL_PATH)/src/timer/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/timer/unix/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/tray/dummy/*.c) \
+	$(wildcard $(LOCAL_PATH)/src/tray/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/video/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/video/android/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/video/yuv2rgb/*.c))

--- a/VisualC-GDK/SDL/SDL.vcxproj
+++ b/VisualC-GDK/SDL/SDL.vcxproj
@@ -838,6 +838,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.XboxOne.x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.XboxOne.x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\..\src\tray\SDL_tray_utils.c" />
     <ClCompile Include="..\..\src\video\dummy\SDL_nullevents.c" />
     <ClCompile Include="..\..\src\video\dummy\SDL_nullframebuffer.c" />
     <ClCompile Include="..\..\src\video\dummy\SDL_nullvideo.c" />

--- a/VisualC-GDK/SDL/SDL.vcxproj.filters
+++ b/VisualC-GDK/SDL/SDL.vcxproj.filters
@@ -220,6 +220,7 @@
     <ClCompile Include="..\..\src\time\windows\SDL_systime.c" />
     <ClCompile Include="..\..\src\tray\dummy\SDL_tray.c" />
     <ClCompile Include="..\..\src\tray\windows\SDL_tray.c" />
+    <ClCompile Include="..\..\src\tray\SDL_tray_utils.c" />
     <ClCompile Include="..\..\src\video\yuv2rgb\yuv_rgb_lsx.c" />
     <ClCompile Include="..\..\src\video\yuv2rgb\yuv_rgb_sse.c" />
     <ClCompile Include="..\..\src\video\yuv2rgb\yuv_rgb_std.c" />

--- a/VisualC/SDL/SDL.vcxproj
+++ b/VisualC/SDL/SDL.vcxproj
@@ -673,6 +673,7 @@
     <ClCompile Include="..\..\src\time\SDL_time.c" />
     <ClCompile Include="..\..\src\time\windows\SDL_systime.c" />
     <ClCompile Include="..\..\src\tray\windows\SDL_tray.c" />
+    <ClCompile Include="..\..\src\tray\SDL_tray_utils.c" />
     <ClCompile Include="..\..\src\video\dummy\SDL_nullevents.c" />
     <ClCompile Include="..\..\src\video\dummy\SDL_nullframebuffer.c" />
     <ClCompile Include="..\..\src\video\dummy\SDL_nullvideo.c" />

--- a/VisualC/SDL/SDL.vcxproj.filters
+++ b/VisualC/SDL/SDL.vcxproj.filters
@@ -1235,6 +1235,9 @@
     <ClCompile Include="..\..\src\tray\windows\SDL_tray.c">
       <Filter>video</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\tray\SDL_tray_utils.c">
+      <Filter>video</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\video\SDL_RLEaccel.c">
       <Filter>video</Filter>
     </ClCompile>

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2775,6 +2775,10 @@ extern "C" {
  * - "1": SDL will send a quit event when the last window is requesting to
  *   close. (default)
  *
+ * If there is at least one active system tray icon, SDL_EVENT_QUIT will instead
+ * be sent when both the last window will be closed and the last tray icon will
+ * be destroyed.
+ *
  * This hint can be set anytime.
  *
  * \since This hint is available since SDL 3.1.3.

--- a/src/events/SDL_windowevents.c
+++ b/src/events/SDL_windowevents.c
@@ -24,7 +24,7 @@
 
 #include "SDL_events_c.h"
 #include "SDL_mouse_c.h"
-
+#include "../tray/SDL_tray_utils.h"
 
 static bool SDLCALL RemoveSupercededWindowEvents(void *userdata, SDL_Event *event)
 {
@@ -247,7 +247,7 @@ bool SDL_SendWindowEvent(SDL_Window *window, SDL_EventType windowevent, int data
         break;
     }
 
-    if (windowevent == SDL_EVENT_WINDOW_CLOSE_REQUESTED && !window->parent) {
+    if (windowevent == SDL_EVENT_WINDOW_CLOSE_REQUESTED && !window->parent && SDL_HasNoActiveTrays()) {
         int toplevel_count = 0;
         SDL_Window *n;
         for (n = SDL_GetVideoDevice()->windows; n; n = n->next) {

--- a/src/tray/SDL_tray_utils.c
+++ b/src/tray/SDL_tray_utils.c
@@ -1,0 +1,62 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+#include "SDL_internal.h"
+
+#include "../video/SDL_sysvideo.h"
+#include "../events/SDL_events_c.h"
+
+static int active_trays = 0;
+
+extern void SDL_IncrementTrayCount(void)
+{
+    if (++active_trays < 1) {
+        SDL_Log("Active tray count corrupted (%d < 1), this is a bug. The app may close or fail to close unexpectedly.", active_trays);
+    }
+}
+
+extern void SDL_DecrementTrayCount(void)
+{
+    int toplevel_count = 0;
+    SDL_Window *n;
+
+    if (--active_trays < 0) {
+        SDL_Log("Active tray count corrupted (%d < 0), this is a bug. The app may close or fail to close unexpectedly.", active_trays);
+    }
+
+    if (!SDL_GetHintBoolean(SDL_HINT_QUIT_ON_LAST_WINDOW_CLOSE, true)) {
+        return;
+    }
+
+    for (n = SDL_GetVideoDevice()->windows; n; n = n->next) {
+        if (!n->parent && !(n->flags & SDL_WINDOW_HIDDEN)) {
+            ++toplevel_count;
+        }
+    }
+
+    if (toplevel_count < 1) {
+        SDL_SendQuit();
+    }
+}
+
+extern bool SDL_HasNoActiveTrays(void)
+{
+    return active_trays < 1;
+}

--- a/src/tray/SDL_tray_utils.h
+++ b/src/tray/SDL_tray_utils.h
@@ -1,0 +1,25 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2024 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+#include "SDL_internal.h"
+
+extern void SDL_IncrementTrayCount(void);
+extern void SDL_DecrementTrayCount(void);
+extern bool SDL_HasNoActiveTrays(void);

--- a/src/tray/cocoa/SDL_tray.m
+++ b/src/tray/cocoa/SDL_tray.m
@@ -25,6 +25,7 @@
 
 #include <Cocoa/Cocoa.h>
 
+#include "../SDL_tray_utils.h"
 #include "../../video/SDL_surface_c.h"
 
 /* applicationDockMenu */
@@ -158,6 +159,8 @@ SDL_Tray *SDL_CreateTray(SDL_Surface *icon, const char *tooltip)
     }
 
 skip_putting_an_icon:
+    SDL_IncrementTrayCount();
+
     return tray;
 }
 
@@ -445,6 +448,8 @@ void SDL_DestroyTray(SDL_Tray *tray)
     }
 
     SDL_free(tray);
+
+    SDL_DecrementTrayCount();
 }
 
 #endif // SDL_PLATFORM_MACOS

--- a/src/tray/dummy/SDL_tray.c
+++ b/src/tray/dummy/SDL_tray.c
@@ -23,6 +23,8 @@
 
 #ifndef SDL_PLATFORM_MACOS
 
+#include "../SDL_tray_utils.h"
+
 SDL_Tray *SDL_CreateTray(SDL_Surface *icon, const char *tooltip)
 {
     SDL_Unsupported();

--- a/src/tray/windows/SDL_tray.c
+++ b/src/tray/windows/SDL_tray.c
@@ -21,7 +21,9 @@
 
 #include "SDL_internal.h"
 
+#include "../SDL_tray_utils.h"
 #include "../../core/windows/SDL_windows.h"
+
 #include <windowsx.h>
 #include <shellapi.h>
 #include <stdlib.h> /* FIXME: for mbstowcs_s, wcslen */
@@ -227,6 +229,8 @@ SDL_Tray *SDL_CreateTray(SDL_Surface *icon, const char *tooltip)
     Shell_NotifyIconW(NIM_SETVERSION, &tray->nid);
 
     SetWindowLongPtr(tray->hwnd, GWLP_USERDATA, (LONG_PTR) tray);
+
+    SDL_IncrementTrayCount();
 
     return tray;
 }
@@ -568,4 +572,6 @@ void SDL_DestroyTray(SDL_Tray *tray)
     }
 
     SDL_free(tray);
+
+    SDL_DecrementTrayCount();
 }


### PR DESCRIPTION
## Description

`SDL_HINT_QUIT_ON_LAST_WINDOW_CLOSE` will not fire if there are active tray icons. This impacts only applications that create tray icons, and that at least one icon outlives the last visible top-level window. `SDL_EVENT_QUIT` will fire when the last active tray is destroyed if there are no active windows.

This effectively means that `SDL_HINT_QUIT_ON_LAST_WINDOW_CLOSE` actually means "Quit when last _window or tray_ is closed". It does not affect any application that does not use system tray icons.

I've added a dummy window to `testtray` to help observe this behavior.

## Existing Issue(s)

Closes #11722
