### PR TITLE
win32: Fix borderless, maximized windows

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1879,7 +1879,7 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
             WINDOWPLACEMENT placement;
             if (GetWindowPlacement(hwnd, &placement) && placement.showCmd == SW_MAXIMIZE) {
                 // Maximized borderless windows should use the monitor work area.
-                HMONITOR hMonitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONULL);
+                HMONITOR hMonitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
                 if (hMonitor) {
                     MONITORINFO info;
                     SDL_zero(info);

--- a/src/video/windows/SDL_windowswindow.h
+++ b/src/video/windows/SDL_windowswindow.h
@@ -81,6 +81,7 @@ struct SDL_WindowData
     bool skip_update_clipcursor;
     bool windowed_mode_was_maximized;
     bool in_window_deactivation;
+    bool force_resizable;
     RECT cursor_clipped_rect; // last successfully committed clipping rect for this window
     RECT cursor_ctrlock_rect; // this is Windows-specific, but probably does not need to be per-window
     UINT windowed_mode_corner_rounding;


### PR DESCRIPTION
Even if a borderless window doesn't have the resizable borders hint set, the WS_MAXIMIZEBOX property needs to be set on the window, or maximizing it will make it fullscreen, covering the taskbar, instead of only filling the usable desktop space. The style property needs to be retained until the window is no longer maximized, even if the resize flag is toggled off, or restoring from minimized can fail.

The default of the nearest monitor also needs to be used when querying it from the window, or null can be returned when the window is coming out of minimized, which results in the restored, maximized window being the wrong size.

Fixes #11714