### PR TITLE
examples: Fix dead links in app metadata

### DIFF
--- a/examples/demo/01-snake/snake.c
+++ b/examples/demo/01-snake/snake.c
@@ -285,7 +285,7 @@ static const struct
     const char *value;
 } extended_metadata[] =
 {
-    { SDL_PROP_APP_METADATA_URL_STRING, "https://examples.libsdl.org/SDL3/game/01-snake/" },
+    { SDL_PROP_APP_METADATA_URL_STRING, "https://examples.libsdl.org/SDL3/demo/01-snake/" },
     { SDL_PROP_APP_METADATA_CREATOR_STRING, "SDL team" },
     { SDL_PROP_APP_METADATA_COPYRIGHT_STRING, "Placed in the public domain" },
     { SDL_PROP_APP_METADATA_TYPE_STRING, "game" }

--- a/examples/demo/02-woodeneye-008/woodeneye-008.c
+++ b/examples/demo/02-woodeneye-008/woodeneye-008.c
@@ -36,7 +36,7 @@ static const struct {
     const char *key;
     const char *value;
 } extended_metadata[] = {
-    { SDL_PROP_APP_METADATA_URL_STRING, "https://examples.libsdl.org/SDL3/game/02-woodeneye-008/" },
+    { SDL_PROP_APP_METADATA_URL_STRING, "https://examples.libsdl.org/SDL3/demo/02-woodeneye-008/" },
     { SDL_PROP_APP_METADATA_CREATOR_STRING, "SDL team" },
     { SDL_PROP_APP_METADATA_COPYRIGHT_STRING, "Placed in the public domain" },
     { SDL_PROP_APP_METADATA_TYPE_STRING, "game" }

--- a/examples/demo/04-bytepusher/bytepusher.c
+++ b/examples/demo/04-bytepusher/bytepusher.c
@@ -47,7 +47,7 @@ static const struct {
     const char *key;
     const char *value;
 } extended_metadata[] = {
-    { SDL_PROP_APP_METADATA_URL_STRING, "https://examples.libsdl.org/SDL3/game/04-bytepusher/" },
+    { SDL_PROP_APP_METADATA_URL_STRING, "https://examples.libsdl.org/SDL3/demo/04-bytepusher/" },
     { SDL_PROP_APP_METADATA_CREATOR_STRING, "SDL team" },
     { SDL_PROP_APP_METADATA_COPYRIGHT_STRING, "Placed in the public domain" },
     { SDL_PROP_APP_METADATA_TYPE_STRING, "game" }


### PR DESCRIPTION
## Description

These links were not updated when the `game` directory was renamed to `demo`.

## Existing Issue(s)

N/A
