### PR TITLE
Fix SDL_GL_GetAttribute(SDL_GL_CONTEXT_RELEASE_BEHAVIOR)

### DIFF
--- a/include/SDL3/SDL_test_common.h
+++ b/include/SDL3/SDL_test_common.h
@@ -139,6 +139,7 @@ typedef struct
     int gl_accum_blue_size;
     int gl_accum_alpha_size;
     int gl_stereo;
+    int gl_release_behavior;
     int gl_multisamplebuffers;
     int gl_multisamplesamples;
     int gl_retained_backing;

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1226,6 +1226,7 @@ bool SDLTest_CommonInit(SDLTest_CommonState *state)
         SDL_GL_SetAttribute(SDL_GL_ACCUM_BLUE_SIZE, state->gl_accum_blue_size);
         SDL_GL_SetAttribute(SDL_GL_ACCUM_ALPHA_SIZE, state->gl_accum_alpha_size);
         SDL_GL_SetAttribute(SDL_GL_STEREO, state->gl_stereo);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_RELEASE_BEHAVIOR, state->gl_release_behavior);
         SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, state->gl_multisamplebuffers);
         SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, state->gl_multisamplesamples);
         if (state->gl_accelerated >= 0) {

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -4931,6 +4931,19 @@ bool SDL_GL_GetAttribute(SDL_GLAttr attr, int *value)
         }
         return SDL_SetError("OpenGL error: %08X", error);
     }
+
+    // convert GL_CONTEXT_RELEASE_BEHAVIOR values back to SDL_GL_CONTEXT_RELEASE_BEHAVIOR values
+#ifdef SDL_VIDEO_OPENGL
+    if (attr == SDL_GL_CONTEXT_RELEASE_BEHAVIOR) {
+        *value = *value == GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH ? SDL_GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH : SDL_GL_CONTEXT_RELEASE_BEHAVIOR_NONE;
+    }
+#else
+    if (attr == GL_CONTEXT_RELEASE_BEHAVIOR_KHR) {
+        *value = *value == GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH_KHR ? SDL_GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH : SDL_GL_CONTEXT_RELEASE_BEHAVIOR_NONE;
+    }
+    attrib = GL_CONTEXT_RELEASE_BEHAVIOR_KHR;
+#endif
+
     return true;
 #else
     return SDL_Unsupported();

--- a/test/testgl.c
+++ b/test/testgl.c
@@ -263,6 +263,9 @@ int main(int argc, char *argv[])
     state->gl_green_size = 5;
     state->gl_blue_size = 5;
     state->gl_depth_size = 16;
+    // For release_behavior to work, at least on Windows, you'll most likely need to set state->gl_major_version = 3
+    // state->gl_major_version = 3;
+    state->gl_release_behavior = 0;
     state->gl_double_buffer = 1;
     if (fsaa) {
         state->gl_multisamplebuffers = 1;
@@ -330,6 +333,11 @@ int main(int argc, char *argv[])
         SDL_Log("SDL_GL_DEPTH_SIZE: requested %d, got %d\n", 16, value);
     } else {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_DEPTH_SIZE: %s\n", SDL_GetError());
+    }
+    if (SDL_GL_GetAttribute(SDL_GL_CONTEXT_RELEASE_BEHAVIOR, &value)) {
+        SDL_Log("SDL_GL_CONTEXT_RELEASE_BEHAVIOR: requested %d, got %d\n", 0, value);
+    } else {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_CONTEXT_RELEASE_BEHAVIOR: %s\n", SDL_GetError());
     }
     if (fsaa) {
         if (SDL_GL_GetAttribute(SDL_GL_MULTISAMPLEBUFFERS, &value)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This addresses the issue https://github.com/libsdl-org/SDL/issues/11697 by converting
GL_CONTEXT_RELEASE_BEHAVIOR_<NONE|FLUSH> to
SDL_GL_CONTEXT_RELEASE_BEHAVIOR_<NONE|FLUSH>

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
#11697