### PR TITLE
Fix C23 empty initializer warning.

### DIFF
--- a/src/audio/alsa/SDL_alsa_audio.c
+++ b/src/audio/alsa/SDL_alsa_audio.c
@@ -497,6 +497,7 @@ struct ALSA_pcm_cfg_ctx {
 static enum snd_pcm_chmap_position sdl_channel_maps[SDL_AUDIO_ALSA__SDL_CHMAPS_N][SDL_AUDIO_ALSA__CHMAP_CHANS_N_MAX] = {
     // 0 channels
     {
+        0
     },
     // 1 channel
     {


### PR DESCRIPTION

```bash
[ 28%] Building C object CMakeFiles/SDL3-shared.dir/src/audio/alsa/SDL_alsa_audio.c.o
/mnt/devel/dev/projects-NEW/external/libs/c/SDL/sources/SDL-git-Sackzement/src/audio/alsa/SDL_alsa_audio.c:499:5: warning: use of an empty initializer is a C23 extension [-Wc23-extensions]
  499 |     {
      |     ^
1 warning generated.
```