### PR TITLE
Fix C99 trailing enum comma warning.

### DIFF
--- a/include/SDL3/SDL_thread.h
+++ b/include/SDL3/SDL_thread.h
@@ -116,7 +116,7 @@ typedef enum SDL_ThreadState
     SDL_THREAD_UNKNOWN,     /**< The thread is not valid */
     SDL_THREAD_ALIVE,       /**< The thread is currently running */
     SDL_THREAD_DETACHED,    /**< The thread is detached and can't be waited on */
-    SDL_THREAD_COMPLETE,    /**< The thread has finished and should be cleaned up with SDL_WaitThread() */
+    SDL_THREAD_COMPLETE     /**< The thread has finished and should be cleaned up with SDL_WaitThread() */
 } SDL_ThreadState;
 
 /**


### PR DESCRIPTION
```c
/path/to/SDL/include/SDL3/SDL_thread.h:119:24: warning: commas at the end of enumerator lists are a C99-specific feature [clang-diagnostic-c99-extensions]
  119 |     SDL_THREAD_COMPLETE,    /**< The thread has finished and should be cleaned up with SDL_WaitThread() */
      |                        ^
```