### PR TITLE
win32: Use the size in the WINDOWPOS data while handling popup window…

### DIFF
--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -1053,7 +1053,11 @@ void WIN_GetWindowSizeInPixels(SDL_VideoDevice *_this, SDL_Window *window, int *
     HWND hwnd = data->hwnd;
     RECT rect;
 
-    if (GetClientRect(hwnd, &rect) && !WIN_IsRectEmpty(&rect)) {
+    // GetClientRect() returns the wrong size for popup windows if called while handling WM_WINDOWPOSCHANGED.
+    if (data->use_last_popup_size) {
+        *w = data->last_popup_width;
+        *h = data->last_popup_height;
+    } else if (GetClientRect(hwnd, &rect) && !WIN_IsRectEmpty(&rect)) {
         *w = rect.right;
         *h = rect.bottom;
     } else if (window->last_pixel_w && window->last_pixel_h) {

--- a/src/video/windows/SDL_windowswindow.h
+++ b/src/video/windows/SDL_windowswindow.h
@@ -82,6 +82,8 @@ struct SDL_WindowData
     bool windowed_mode_was_maximized;
     bool in_window_deactivation;
     bool force_resizable;
+    bool use_last_popup_size;
+    int last_popup_width, last_popup_height;
     RECT cursor_clipped_rect; // last successfully committed clipping rect for this window
     RECT cursor_ctrlock_rect; // this is Windows-specific, but probably does not need to be per-window
     UINT windowed_mode_corner_rounding;


### PR DESCRIPTION
…s in the WM_WINDOWPOSCHANGED message

GetClientRect() returns old, incorrect size data for popup windows when called while processing the WM_WINDOWPOSCHANGED message, so use the WINDOWPOS data instead.

Popups can't be maximized or fullscreen, so no need to worry about a move event resizing them.

Fixes #11786