### PR TITLE
Clarify migration for GetWindowData and SetWindowData

### DIFF
--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -2216,8 +2216,8 @@ The following functions have been removed:
 * SDL_GetNumVideoDisplays() - replaced with SDL_GetDisplays()
 * SDL_SetWindowGrab() - use SDL_SetWindowMouseGrab() instead, along with SDL_SetWindowKeyboardGrab() if you also set SDL_HINT_GRAB_KEYBOARD.
 * SDL_GetWindowGrab() - use SDL_GetWindowMouseGrab() instead, along with SDL_GetWindowKeyboardGrab() if you also set SDL_HINT_GRAB_KEYBOARD.
-* SDL_GetWindowData() - use SDL_GetWindowProperties() instead
-* SDL_SetWindowData() - use SDL_GetWindowProperties() instead
+* SDL_GetWindowData() - use SDL_GetPointerProperty() instead, along with SDL_GetWindowProperties()
+* SDL_SetWindowData() - use SDL_SetPointerProperty() instead, along with SDL_GetWindowProperties()
 * SDL_CreateWindowFrom() - use SDL_CreateWindowWithProperties() with the properties that allow you to wrap an existing window
 * SDL_SetWindowInputFocus() - use SDL_RaiseWindow() instead
 * SDL_SetWindowModalFor() - use SDL_SetWindowParent() with SDL_SetWindowModal() instead


### PR DESCRIPTION
I was confused on how to migrate SDL_GetWindowData and SDL_SetWindowData by the migration guide, this pr aims to show the functions to migrate to instead of just insinuating to use Properties which people unfamiliar with SDL might not understand.

## Description
Change migration guide for SDL_GetWindowData and SDL_SetWindowData to show usage of SDL_SetPointerProperty with SDL_GetWindowProperties intead of just SDL_GetWindowProperties.  
