### PR TITLE
[GPU] Fix mip generation for 2x1 textures on D3D12

### DIFF
--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -6222,16 +6222,16 @@ static void D3D12_GenerateMipmaps(
             blitInfo.source.layer_or_depth_plane = layerOrDepthIndex;
             blitInfo.source.x = 0;
             blitInfo.source.y = 0;
-            blitInfo.source.w = container->header.info.width >> (levelIndex - 1);
-            blitInfo.source.h = container->header.info.height >> (levelIndex - 1);
+            blitInfo.source.w = SDL_max(container->header.info.width >> (levelIndex - 1), 1);
+            blitInfo.source.h = SDL_max(container->header.info.height >> (levelIndex - 1), 1);
 
             blitInfo.destination.texture = texture;
             blitInfo.destination.mip_level = levelIndex;
             blitInfo.destination.layer_or_depth_plane = layerOrDepthIndex;
             blitInfo.destination.x = 0;
             blitInfo.destination.y = 0;
-            blitInfo.destination.w = container->header.info.width >> levelIndex;
-            blitInfo.destination.h = container->header.info.height >> levelIndex;
+            blitInfo.destination.w = SDL_max(container->header.info.width >> levelIndex, 1);
+            blitInfo.destination.h = SDL_max(container->header.info.height >> levelIndex, 1);
 
             blitInfo.load_op = SDL_GPU_LOADOP_DONT_CARE;
             blitInfo.filter = SDL_GPU_FILTER_LINEAR;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When calculating mip sizes width and/or height can drop below 1, i.e. generating a mip from a 2x1 texture would produce a desired size of 1x0.

```
Assertion failure at SDL_BlitGPUTexture_REAL (E:\Documents\Projects\SDL3\src\gpu\SDL_gpu.c:2541), triggered 1 time:
  '!"Blit source/destination regions must have non-zero width, height, and depth"'
```

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
None I'm aware of