### PR TITLE
Normalize case of environment variable names on windows

### DIFF
--- a/src/stdlib/SDL_getenv.c
+++ b/src/stdlib/SDL_getenv.c
@@ -114,6 +114,14 @@ SDL_Environment *SDL_CreateEnvironment(bool populated)
                 }
                 *value++ = '\0';
 
+                // Environment variable names on Windows are case insensitive, but we're using a case sensitive hash table,
+                //  so normalize the case of the variable name.
+                char *p = variable;
+                while (p < value) {
+                    *p = toupper(*p);
+                    p++;
+                }
+
                 SDL_InsertIntoHashTable(env->strings, variable, value);
             }
             FreeEnvironmentStringsW(strings);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If you try to set environment variables in Visual Studio's debugger configuration, i.e. a SDL hint like `SDL_GPU_DRIVER`, the name of the variable gets lowercased by VS, like so:
![image](https://github.com/user-attachments/assets/6804e2af-dfe3-447f-af9f-a97a17821cb5)
It does this for all environment variables. Because SDL_CreateEnvironment uses a case sensitive hash, this means any environment vars set by visual studio or other tools that assume case insensitive environment variables will be invisible to SDL.

SDL's current behavior is correct on non-Windows platforms, but as supported by https://learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-environment-getenvironmentvariable it is not correct for Windows.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
I didn't find any open issues for this
