### PR TITLE
clipboard: Ensure SDL_ClearClipboardData clears data even when no data has been set by SDL

### DIFF
--- a/src/video/SDL_clipboard.c
+++ b/src/video/SDL_clipboard.c
@@ -99,11 +99,6 @@ bool SDL_SetClipboardData(SDL_ClipboardDataCallback callback, SDL_ClipboardClean
         return SDL_SetError("Invalid parameters");
     }
 
-    if (!callback && !_this->clipboard_callback) {
-        // Nothing to do, don't modify the system clipboard
-        return true;
-    }
-
     SDL_CancelClipboardData(0);
 
     ++_this->clipboard_sequence;

--- a/test/testautomation_clipboard.c
+++ b/test/testautomation_clipboard.c
@@ -108,6 +108,13 @@ static int SDLCALL clipboard_testClipboardDataFunctions(void *arg)
         result == true,
         "Validate SDL_ClearClipboardData result, expected true, got %i",
         result);
+    expected_text = "";
+    text = SDL_GetClipboardText();
+    SDLTest_AssertCheck(
+        text && SDL_strcmp(text, expected_text) == 0,
+        "Verify clipboard text, expected \"%s\", got \"%s\"",
+        expected_text, text);
+    SDL_free(text);
 
     /* Test clearing clipboard data when it's already clear */
     last_clipboard_update_count = clipboard_update_count;
@@ -117,8 +124,8 @@ static int SDLCALL clipboard_testClipboardDataFunctions(void *arg)
         "Validate SDL_ClearClipboardData result, expected true, got %i",
         result);
     SDLTest_AssertCheck(
-        clipboard_update_count == last_clipboard_update_count,
-        "Verify clipboard update unchanged, got %d",
+        clipboard_update_count != last_clipboard_update_count,
+        "Verify clipboard update count changed, got %d",
         clipboard_update_count - last_clipboard_update_count);
 
     /* Validate error handling */
@@ -430,8 +437,8 @@ static int SDLCALL clipboard_testClipboardTextFunctions(void *arg)
         "Verify SDL_HasClipboardText returned false, got %s",
         (boolResult) ? "true" : "false");
     SDLTest_AssertCheck(
-        clipboard_update_count == last_clipboard_update_count,
-        "Verify clipboard update unchanged, got %d",
+        clipboard_update_count == last_clipboard_update_count + 1,
+        "Verify clipboard update count incremented by 1, got %d",
         clipboard_update_count - last_clipboard_update_count);
 
 


### PR DESCRIPTION
Don't skip setting clipboard data when no callbacks are supplied so that the clipboard may be cleared before SDL sets clipboard data (there may be data in the clipboard not set by SDL)

## Existing Issue(s)
#11814
