### PR TITLE
SDL2: compatibility fixes for macOS < 10.15

### DIFF
--- a/src/audio/coreaudio/SDL_coreaudio.m
+++ b/src/audio/coreaudio/SDL_coreaudio.m
@@ -880,14 +880,25 @@ static int prepare_audioqueue(_THIS)
         //  L R C LFE Ls Rs
         layout.mChannelLayoutTag = kAudioChannelLayoutTag_DVD_12;
         break;
+#if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000) || \
+    (defined(MAC_OS_X_VERSION_MAX_ALLOWED) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101500)
     case 7:
         // L R C LFE Cs Ls Rs
-        layout.mChannelLayoutTag = kAudioChannelLayoutTag_WAVE_6_1;
+        if (@available(macOS 10.15, iOS 13, *)) {
+            layout.mChannelLayoutTag = kAudioChannelLayoutTag_WAVE_6_1;
+        } else {
+            return SDL_SetError("Unsupported audio channels");
+        }
         break;
     case 8:
         // L R C LFE Rls Rrs Ls Rs
-        layout.mChannelLayoutTag = kAudioChannelLayoutTag_WAVE_7_1;
+        if (@available(macOS 10.15, iOS 13, *)) {
+            layout.mChannelLayoutTag = kAudioChannelLayoutTag_WAVE_7_1;
+        } else {
+            return SDL_SetError("Unsupported audio channels");
+        }
         break;
+#endif
     default:
         return SDL_SetError("Unsupported audio channels");
     }

--- a/src/video/cocoa/SDL_cocoamessagebox.m
+++ b/src/video/cocoa/SDL_cocoamessagebox.m
@@ -33,6 +33,9 @@
     NSWindow *nswindow;
 }
 - (id)initWithParentWindow:(SDL_Window *)window;
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 1090
+- (void)alertDidEnd:(NSAlert *)alert returnCode:(NSInteger)returnCode contextInfo:(void *)contextInfo;
+#endif
 @end
 
 @implementation SDLMessageBoxPresenter
@@ -56,16 +59,32 @@
 - (void)showAlert:(NSAlert*)alert
 {
     if (nswindow) {
-        [alert beginSheetModalForWindow:nswindow
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1090
+        if ([alert respondsToSelector:@selector(beginSheetModalForWindow:completionHandler:)]) {
+            [alert beginSheetModalForWindow:nswindow
                       completionHandler:^(NSModalResponse returnCode) {
                         [NSApp stopModalWithCode:returnCode];
                       }];
+        } else
+#endif
+        {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 1090
+            [alert beginSheetModalForWindow:nswindow modalDelegate:self didEndSelector:@selector(alertDidEnd:returnCode:contextInfo:) contextInfo:nil];
+#endif
+        }
         clicked = [NSApp runModalForWindow:nswindow];
         nswindow = nil;
     } else {
         clicked = [alert runModal];
     }
 }
+
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 1090
+- (void) alertDidEnd:(NSAlert *)alert returnCode:(NSInteger)returnCode contextInfo:(void *)contextInfo
+{
+    [NSApp stopModalWithCode:returnCode];
+}
+#endif
 @end
 
 

--- a/src/video/cocoa/SDL_cocoawindow.h
+++ b/src/video/cocoa/SDL_cocoawindow.h
@@ -78,6 +78,7 @@ typedef enum
 /* Window delegate functionality */
 -(BOOL) windowShouldClose:(id) sender;
 -(void) windowDidExpose:(NSNotification *) aNotification;
+-(void) onLiveResizeTimerFire:(id) sender;
 -(void) windowWillStartLiveResize:(NSNotification *)aNotification;
 -(void) windowDidEndLiveResize:(NSNotification *)aNotification;
 -(void) windowDidMove:(NSNotification *) aNotification;

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -743,16 +743,26 @@ static NSCursor *Cocoa_GetDesiredCursor(void)
     SDL_SendWindowEvent(_data.window, SDL_WINDOWEVENT_EXPOSED, 0, 0);
 }
 
+- (void)onLiveResizeTimerFire:(id)sender
+{
+    SDL_OnWindowLiveResizeUpdate(_data.window);
+}
+
 - (void)windowWillStartLiveResize:(NSNotification *)aNotification
 {
     // We'll try to maintain 60 FPS during live resizing
     const NSTimeInterval interval = 1.0 / 60.0;
+
+    NSMethodSignature *invocationSig = [Cocoa_WindowListener
+        instanceMethodSignatureForSelector:@selector(onLiveResizeTimerFire:)];
+    NSInvocation *invocation = [NSInvocation
+        invocationWithMethodSignature:invocationSig];
+    [invocation setTarget:self];
+    [invocation setSelector:@selector(onLiveResizeTimerFire:)];
+
     liveResizeTimer = [NSTimer scheduledTimerWithTimeInterval:interval
-                                                      repeats:TRUE
-                                                        block:^(NSTimer *unusedTimer)
-    {
-        SDL_OnWindowLiveResizeUpdate(_data.window);
-    }];
+                                                      invocation:invocation
+                                                      repeats:TRUE];
 
     [[NSRunLoop currentRunLoop] addTimer:liveResizeTimer forMode:NSRunLoopCommonModes];
 }


### PR DESCRIPTION
## Description
Several recent changes inadvertently broke SDL2 on various macOS versions older than 10.15. These changes restore compatibility.

With the `kAudioChannelLayoutTag_*` enum values, when on an OS version that doesn't support the correct layout, I'm not sure if it's better to error out as I'm currently doing, or to use a not quite right channel layout as in previous versions.