### PR TITLE
Fix iOS text input not working with password integration

### DIFF
--- a/src/video/uikit/SDL_uikitviewcontroller.m
+++ b/src/video/uikit/SDL_uikitviewcontroller.m
@@ -578,6 +578,14 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 
 - (void)textFieldTextDidChange:(NSNotification *)notification
 {
+    // When opening a password manager overlay to select a password and have it auto-filled,
+    // text input becomes stopped as a result of the keyboard being hidden or the text field losing focus.
+    // As a workaround, ensure text input is activated on any changes to the text field.
+    bool startTextInputMomentarily = !SDL_TextInputActive(window);
+
+    if (startTextInputMomentarily)
+        SDL_StartTextInput(window);
+
     if (textField.markedTextRange == nil) {
         NSUInteger compareLength = SDL_min(textField.text.length, committedText.length);
         NSUInteger matchLength;
@@ -612,6 +620,9 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
         }
         committedText = textField.text;
     }
+
+    if (startTextInputMomentarily)
+        SDL_StopTextInput(window);
 }
 
 - (void)updateKeyboard

--- a/src/video/uikit/SDL_uikitviewcontroller.m
+++ b/src/video/uikit/SDL_uikitviewcontroller.m
@@ -657,7 +657,7 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 - (BOOL)textField:(UITextField *)_textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
 {
     if (textField.markedTextRange == nil) {
-        if (textField.text.length < 16) {
+        if ([string length] == 0 && textField.text.length < 16) {
             [self resetTextState];
         }
     }


### PR DESCRIPTION
- Alternative to / closes #11699 

### [Fix text field resetting text when replaced with a short string](https://github.com/libsdl-org/SDL/pull/11845/commits/75b6f92e111fcb97c32f6979a03895de6e2770e3)

When selecting a password to auto-fill in the current text field, the `textField.text` property is overwritten with that password, and if the password is less than 16 characters, it triggers the code that resets the text content and messes up the entire logic that is supposed to perform backspaces and such.

The fix is to simply reset the text (i.e. fill back the "obligatory for backspace" text) when the event is triggered with a `string` of length zero, i.e. when the user deletes characters (see [docs](https://developer.apple.com/documentation/uikit/uitextfielddelegate/textfield(_:shouldchangecharactersin:replacementstring:)?language=objc)).

The fix above can be argued to be more of a band-aid than a solid fix, but there's no better fix than to rewrite the iOS text input system from top to bottom and introduce text input events when a text is reset or replaced etc. It's a tough task to go through as an external contributor.

### [Work around password integrations hiding software keyboard and preventing autofill](https://github.com/libsdl-org/SDL/pull/11845/commits/d3062e35db4eb96ef0a2f64d820df3993ad6efd8) 

When pressing the "Passwords" button on the keyboard to pick a password from the keychain/vault, the keyboard hides, which triggers the `keyboardWillHide` animation, and incorrectly stop text input, ultimately not accepting any character entered from the selected password due to the text input being inactive.

My previous attempt in https://github.com/libsdl-org/SDL/pull/11699 and also the attempt of using `textFieldDidEndEditing` both do not work most of the time. For some reason, when the password integration overlay opens, and the user taps the search bar to search for their password, the SDL text field becomes unfocused and the `textFieldDidEndEditing` gets triggered, without being accompanied with a `textFieldDidBeginEditing` or the text field gaining focus again. Therefore the text input state becomes deactivated at the point of searching and is never activated back, ignoring any password selected for auto-fill.

As a last resort, this PR makes the assumption that any changes to the text field content could not have happened without the user having text input already active, and so it forcibly activates text input in `textFieldTextDidChange` momentarily until all relevant text input events are sent out to the game, then text input is disabled again.