### PR TITLE
Windows pen: handle pen eraser button as the second button

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1220,6 +1220,7 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
 
         SDL_SendPenMotion(timestamp, pen, window, (float) position.x, (float) position.y);
         SDL_SendPenButton(timestamp, pen, window, 1, (pen_info.penFlags & PEN_FLAG_BARREL) != 0);
+        SDL_SendPenButton(timestamp, pen, window, 2, (pen_info.penFlags & PEN_FLAG_ERASER) != 0);
 
         if (pen_info.penMask & PEN_MASK_PRESSURE) {
             SDL_SendPenAxis(timestamp, pen, window, SDL_PEN_AXIS_PRESSURE, ((float) pen_info.pressure) / 1024.0f);  // pen_info.pressure is in the range 0..1024.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The eraser button is a secondary button next to the barrel button on some pens (see https://learn.microsoft.com/en-us/windows-hardware/design/component-guidelines/windows-pen-designs#physical-design). It will be reported as the button `2` in [SDL_PenButtonEvent](https://wiki.libsdl.org/SDL3/SDL_PenButtonEvent).

**RFC**: We may also want to consider pressing the eraser button to function as the `eraser` in [SDL_PenTouchEvent](https://wiki.libsdl.org/SDL3/SDL_PenTouchEvent). The SDL docs specifically call out the `eraser` as the pen being inverted, but it can be changed to a generic "erase". (I would still keep the eraser as a button, as it can be used even if the pen is not touching the tablet.)

```diff
diff --git a/src/video/windows/SDL_windowsevents.c b/src/video/windows/SDL_windowsevents.c
index 54609d03d..bb47a78b5 100644
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1210,7 +1210,7 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
 
         // if lifting off, do it first, so any motion changes don't cause app issues.
         if (msg == WM_POINTERUP) {
-            SDL_SendPenTouch(timestamp, pen, window, (pen_info.penFlags & PEN_FLAG_INVERTED) != 0, false);
+            SDL_SendPenTouch(timestamp, pen, window, (pen_info.penFlags & (PEN_FLAG_INVERTED | PEN_FLAG_ERASER)) != 0, false);
         }
 
         POINT position;
@@ -1240,7 +1240,7 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
 
         // if setting down, do it last, so the pen is positioned correctly from the first contact.
         if (msg == WM_POINTERDOWN) {
-            SDL_SendPenTouch(timestamp, pen, window, (pen_info.penFlags & PEN_FLAG_INVERTED) != 0, true);
+            SDL_SendPenTouch(timestamp, pen, window, (pen_info.penFlags & (PEN_FLAG_INVERTED | PEN_FLAG_ERASER)) != 0, true);
         }
 
         returnCode = 0;
```


[Windows Pen States - Erasing](https://learn.microsoft.com/en-us/windows-hardware/design/component-guidelines/windows-pen-states)

![pen-erasing](https://github.com/user-attachments/assets/43fb411b-a7ef-449d-8f55-8bd281573dee)