### PR TITLE
[GPU] Fix crash in nvidia user-mode win32 driver when game window is minimized during swapchain resize

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -4309,6 +4309,12 @@ static bool VULKAN_INTERNAL_QuerySwapchainSupport(
     VkResult result;
     VkBool32 supportsPresent;
 
+    // Passing a null surface into Win32 NVIDIA user-mode driver will cause a crash because it doesn't check
+    //  the surface pointer for null before dereferenccing it.
+    if (!surface) {
+        SET_STRING_ERROR_AND_RETURN("Unable to acquire surface!", false);
+    }
+
     renderer->vkGetPhysicalDeviceSurfaceSupportKHR(
         physicalDevice,
         renderer->queueFamilyIndex,

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -9473,7 +9473,7 @@ static bool VULKAN_SupportsSwapchainComposition(
 
     surface = windowData->surface;
     if (!surface) {
-        SET_STRING_ERROR_AND_RETURN("Window has no surface!", false);
+        SET_STRING_ERROR_AND_RETURN("Window has no Vulkan surface", false);
     }
 
     if (VULKAN_INTERNAL_QuerySwapchainSupport(
@@ -9521,7 +9521,7 @@ static bool VULKAN_SupportsPresentMode(
 
     surface = windowData->surface;
     if (!surface) {
-        SET_STRING_ERROR_AND_RETURN("Window has no surface!", false);
+        SET_STRING_ERROR_AND_RETURN("Window has no Vulkan surface", false);
     }
 
     if (VULKAN_INTERNAL_QuerySwapchainSupport(

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -4309,12 +4309,6 @@ static bool VULKAN_INTERNAL_QuerySwapchainSupport(
     VkResult result;
     VkBool32 supportsPresent;
 
-    // Passing a null surface into Win32 NVIDIA user-mode driver will cause a crash because it doesn't check
-    //  the surface pointer for null before dereferenccing it.
-    if (!surface) {
-        SET_STRING_ERROR_AND_RETURN("Unable to acquire surface!", false);
-    }
-
     renderer->vkGetPhysicalDeviceSurfaceSupportKHR(
         physicalDevice,
         renderer->queueFamilyIndex,
@@ -4469,6 +4463,7 @@ static Uint32 VULKAN_INTERNAL_CreateSwapchain(
             &windowData->surface)) {
         return false;
     }
+    SDL_assert(windowData->surface);
 
     if (!VULKAN_INTERNAL_QuerySwapchainSupport(
             renderer,
@@ -9477,6 +9472,9 @@ static bool VULKAN_SupportsSwapchainComposition(
     }
 
     surface = windowData->surface;
+    if (!surface) {
+        SET_STRING_ERROR_AND_RETURN("Window has no surface!", false);
+    }
 
     if (VULKAN_INTERNAL_QuerySwapchainSupport(
             renderer,
@@ -9522,6 +9520,9 @@ static bool VULKAN_SupportsPresentMode(
     }
 
     surface = windowData->surface;
+    if (!surface) {
+        SET_STRING_ERROR_AND_RETURN("Window has no surface!", false);
+    }
 
     if (VULKAN_INTERNAL_QuerySwapchainSupport(
             renderer,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
While investigating https://github.com/libsdl-org/SDL/issues/11820 I noticed that we also crash immediately if the window is minimized. This appears to be because we get a null VkSurfaceKHR pointer somewhere and then pass it in to QuerySwapchainSupport (I wasn't able to identify the source of the null pointer), and the user-mode driver just dereferences the null pointer and crashes.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
