### PR TITLE
Let SDL_IM_MODULE=fcitx override Wayland as a workaround to fix key repetition detection

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -2184,6 +2184,18 @@ void Wayland_add_primary_selection_device_manager(SDL_VideoData *d, uint32_t id,
 
 void Wayland_add_text_input_manager(SDL_VideoData *d, uint32_t id, uint32_t version)
 {
+#ifdef HAVE_FCITX
+    const char *im_module = SDL_getenv("SDL_IM_MODULE");
+    if (im_module && SDL_strcmp(im_module, "fcitx") == 0) {
+        /* Override the Wayland text-input protocol when Fcitx is enabled, like how GTK_IM_MODULE does.
+         *
+         * The Fcitx wiki discourages enabling it under Wayland via SDL_IM_MODULE, so its presence must
+         * be intentional, and this workaround is needed for fixing key repeat detection.
+         */
+        return;
+    }
+#endif
+
     d->text_input_manager = wl_registry_bind(d->registry, id, &zwp_text_input_manager_v3_interface, 1);
 
     if (d->input) {


### PR DESCRIPTION
## Description
This adds an opt-in workaround for intermittent unplayably stuck keys in https://github.com/jtothebell/fake-08 . While Fcitx5 is running in Wayland mode, my character suddenly falls like a brick when flying midair. Upon respawning, it runs in one direction without any (arrow) keys pressed until pressing and releasing all keys. Things were working fine until I added `export SDL_VIDEODRIVER=wayland`. This emulator has a `#define KB_ENABLED` but the games I play don't use it. However, I want to keep the input method running for other apps.

Per https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland , `SDL_IM_MODULE=fcitx` is discouraged, therefore setting it must be intentional. Fcitx also suggests running SDL on X11, which I won't so that DOSBox is readable on HiDPI. This PR makes SDL match Gtk's `GTK_IM_MODULE=fcitx`—a workaround I'm using to fix an identical bug in Firefox ([demo](https://developer.mozilla.org/en-US/docs/Web/API/Element/keyup_event#examples)).

## Existing Issue(s)
* This is continued from https://github.com/fcitx/fcitx5/issues/1227
* As [requested](https://github.com/fcitx/fcitx5/issues/1227#issuecomment-2570483366), I will open a bug later at https://gitlab.freedesktop.org/wayland/wayland-protocols/-/tree/main

> This is very true. However, it is also unsolvable if input method is enabled under current protocol.
> https://www.csslayer.info/wordpress/linux/key-repetition-and-key-event-handling-issue-with-wayland-input-method-protocols/
> Under X, key repetition is generated on x server, and input method doesn't do anything special.
> Under wayland, key repetition is generated on client. However, if input method is used, input method have to generate key repetition and by pass the original key client side key repetition logic. Thus, it will never work.

CC @wengxt