### PR TITLE
wasapi: Don't crash/hang if transitioning to/from a Remote Desktop Connection.

### DIFF
--- a/src/audio/wasapi/SDL_wasapi.h
+++ b/src/audio/wasapi/SDL_wasapi.h
@@ -40,6 +40,7 @@ struct SDL_PrivateAudioData
     HANDLE task;
     bool coinitialized;
     int framesize;
+    SDL_AtomicInt device_disconnecting;
     bool device_lost;
     bool device_dead;
 };


### PR DESCRIPTION

Fixes #9673.

(the branch name says 'sdl2' but this is for SDL3.)