### PR TITLE
[SDL2] wayland: Apply toplevel bounds to windows

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -842,7 +842,7 @@ static void display_handle_global(void *data, struct wl_registry *registry, uint
     } else if (SDL_strcmp(interface, "wl_seat") == 0) {
         Wayland_display_add_input(d, id, version);
     } else if (SDL_strcmp(interface, "xdg_wm_base") == 0) {
-        d->shell.xdg = wl_registry_bind(d->registry, id, &xdg_wm_base_interface, SDL_min(version, 3));
+        d->shell.xdg = wl_registry_bind(d->registry, id, &xdg_wm_base_interface, SDL_min(version, 5));
         xdg_wm_base_add_listener(d->shell.xdg, &shell_listener_xdg, NULL);
     } else if (SDL_strcmp(interface, "wl_shm") == 0) {
         d->shm = wl_registry_bind(registry, id, &wl_shm_interface, 1);

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -536,6 +536,13 @@ static void handle_configure_xdg_toplevel(void *data,
              */
             width = wind->floating_width;
             height = wind->floating_height;
+
+            /* Clamp the window to the toplevel bounds, if any were sent. */
+            if ((window->flags & SDL_WINDOW_HIDDEN) &&
+                wind->toplevel_bounds_width && wind->toplevel_bounds_height) {
+                width = SDL_min(width, wind->toplevel_bounds_width);
+                height = SDL_min(height, wind->toplevel_bounds_height);
+            }
         }
 
         /* xdg_toplevel spec states that this is a suggestion.
@@ -612,9 +619,28 @@ static void handle_close_xdg_toplevel(void *data, struct xdg_toplevel *xdg_tople
     SDL_SendWindowEvent(window->sdlwindow, SDL_WINDOWEVENT_CLOSE, 0, 0);
 }
 
+static void handle_xdg_toplevel_configure_bounds(void *data,
+                                                 struct xdg_toplevel *xdg_toplevel,
+                                                 int32_t width,
+                                                 int32_t height)
+{
+    SDL_WindowData *window = (SDL_WindowData *)data;
+    window->toplevel_bounds_width = width;
+    window->toplevel_bounds_height = height;
+}
+
+static void handle_xdg_toplevel_wm_capabilities(void *data,
+                                                struct xdg_toplevel *xdg_toplevel,
+                                                struct wl_array *capabilities)
+{
+    /* NOP */
+}
+
 static const struct xdg_toplevel_listener toplevel_listener_xdg = {
     handle_configure_xdg_toplevel,
-    handle_close_xdg_toplevel
+    handle_close_xdg_toplevel,
+    handle_xdg_toplevel_configure_bounds,
+    handle_xdg_toplevel_wm_capabilities
 };
 
 static void handle_configure_xdg_popup(void *data,
@@ -1344,6 +1370,12 @@ void Wayland_ShowWindow(_THIS, SDL_Window *window)
     } else
 #endif
         if (c->shell.xdg) {
+        /* Create the window decorations */
+        if (data->shell_surface_type != WAYLAND_SURFACE_XDG_POPUP && data->shell_surface.xdg.roleobj.toplevel && c->decoration_manager) {
+            data->server_decoration = zxdg_decoration_manager_v1_get_toplevel_decoration(c->decoration_manager, data->shell_surface.xdg.roleobj.toplevel);
+            zxdg_toplevel_decoration_v1_add_listener(data->server_decoration, &decoration_listener, window);
+        }
+
         /* Unlike libdecor we need to call this explicitly to prevent a deadlock.
          * libdecor will call this as part of their configure event!
          * -flibit
@@ -1354,14 +1386,6 @@ void Wayland_ShowWindow(_THIS, SDL_Window *window)
                 WAYLAND_wl_display_flush(c->display);
                 WAYLAND_wl_display_dispatch(c->display);
             }
-        }
-
-        /* Create the window decorations */
-        if (data->shell_surface_type != WAYLAND_SURFACE_XDG_POPUP && data->shell_surface.xdg.roleobj.toplevel && c->decoration_manager) {
-            data->server_decoration = zxdg_decoration_manager_v1_get_toplevel_decoration(c->decoration_manager, data->shell_surface.xdg.roleobj.toplevel);
-            zxdg_toplevel_decoration_v1_add_listener(data->server_decoration,
-                                                     &decoration_listener,
-                                                     window);
         }
     } else {
         /* Nothing to see here, just commit. */

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -110,13 +110,15 @@ typedef struct
     int window_width, window_height;
     int system_min_required_width;
     int system_min_required_height;
+    int toplevel_bounds_width;
+    int toplevel_bounds_height;
     SDL_bool needs_resize_event;
     SDL_bool floating_resize_pending;
     SDL_bool was_floating;
     SDL_bool is_fullscreen;
     SDL_bool in_fullscreen_transition;
     Uint32 fullscreen_flags;
-    SDL_bool double_buffer; 
+    SDL_bool double_buffer;
 } SDL_WindowData;
 
 extern void Wayland_ShowWindow(_THIS, SDL_Window *window);

--- a/wayland-protocols/xdg-shell.xml
+++ b/wayland-protocols/xdg-shell.xml
@@ -29,7 +29,7 @@
     DEALINGS IN THE SOFTWARE.
   </copyright>
 
-  <interface name="xdg_wm_base" version="3">
+  <interface name="xdg_wm_base" version="6">
     <description summary="create desktop-style surfaces">
       The xdg_wm_base interface is exposed as a global object enabling clients
       to turn their wl_surfaces into windows in a desktop environment. It
@@ -50,6 +50,8 @@
 	     summary="the client provided an invalid surface state"/>
       <entry name="invalid_positioner" value="5"
 	     summary="the client provided an invalid positioner"/>
+      <entry name="unresponsive" value="6"
+	     summary="the client didn’t respond to a ping event in time"/>
     </enum>
 
     <request name="destroy" type="destructor">
@@ -58,7 +60,7 @@
 
 	Destroying a bound xdg_wm_base object while there are surfaces
 	still alive created by this xdg_wm_base object instance is illegal
-	and will result in a protocol error.
+	and will result in a defunct_surfaces error.
       </description>
     </request>
 
@@ -75,7 +77,9 @@
       <description summary="create a shell surface from a surface">
 	This creates an xdg_surface for the given surface. While xdg_surface
 	itself is not a role, the corresponding surface may only be assigned
-	a role extending xdg_surface, such as xdg_toplevel or xdg_popup.
+	a role extending xdg_surface, such as xdg_toplevel or xdg_popup. It is
+	illegal to create an xdg_surface for a wl_surface which already has an
+	assigned role and this will result in a role error.
 
 	This creates an xdg_surface for the given surface. An xdg_surface is
 	used as basis to define a role to a given surface, such as xdg_toplevel
@@ -92,7 +96,8 @@
     <request name="pong">
       <description summary="respond to a ping event">
 	A client must respond to a ping event with a pong request or
-	the client may be deemed unresponsive. See xdg_wm_base.ping.
+	the client may be deemed unresponsive. See xdg_wm_base.ping
+	and xdg_wm_base.error.unresponsive.
       </description>
       <arg name="serial" type="uint" summary="serial of the ping event"/>
     </request>
@@ -106,7 +111,9 @@
 	Compositors can use this to determine if the client is still
 	alive. It's unspecified what will happen if the client doesn't
 	respond to the ping request, or in what timeframe. Clients should
-	try to respond in a reasonable amount of time.
+	try to respond in a reasonable amount of time. The “unresponsive”
+	error is provided for compositors that wish to disconnect unresponsive
+	clients.
 
 	A compositor is free to ping in any way it wants, but a client must
 	always respond to any xdg_wm_base object it created.
@@ -115,7 +122,7 @@
     </event>
   </interface>
 
-  <interface name="xdg_positioner" version="3">
+  <interface name="xdg_positioner" version="6">
     <description summary="child surface positioner">
       The xdg_positioner provides a collection of rules for the placement of a
       child surface relative to a parent surface. Rules can be defined to ensure
@@ -135,7 +142,7 @@
       For an xdg_positioner object to be considered complete, it must have a
       non-zero size set by set_size, and a non-zero anchor rectangle set by
       set_anchor_rect. Passing an incomplete xdg_positioner object when
-      positioning a surface raises an error.
+      positioning a surface raises an invalid_positioner error.
     </description>
 
     <enum name="error">
@@ -223,7 +230,8 @@
 	specified (e.g. 'bottom_right' or 'top_left'), then the child surface
 	will be placed towards the specified gravity; otherwise, the child
 	surface will be centered over the anchor point on any axis that had no
-	gravity specified.
+	gravity specified. If the gravity is not in the ‘gravity’ enum, an
+	invalid_input error is raised.
       </description>
       <arg name="gravity" type="uint" enum="gravity"
 	   summary="gravity direction"/>
@@ -336,7 +344,7 @@
 
 	The default adjustment is none.
       </description>
-      <arg name="constraint_adjustment" type="uint"
+      <arg name="constraint_adjustment" type="uint" enum="constraint_adjustment"
 	   summary="bit mask of constraint adjustments"/>
     </request>
 
@@ -389,7 +397,7 @@
 
     <request name="set_parent_configure" since="3">
       <description summary="set parent configure this is a response to">
-	Set the serial of a xdg_surface.configure event this positioner will be
+	Set the serial of an xdg_surface.configure event this positioner will be
 	used in response to. The compositor may use this information together
 	with set_parent_size to determine what future state the popup should be
 	constrained using.
@@ -399,7 +407,7 @@
     </request>
   </interface>
 
-  <interface name="xdg_surface" version="3">
+  <interface name="xdg_surface" version="6">
     <description summary="desktop user interface surface base interface">
       An interface that may be implemented by a wl_surface, for
       implementations that provide a desktop-style user interface.
@@ -426,6 +434,14 @@
       manipulate a buffer prior to the first xdg_surface.configure call must
       also be treated as errors.
 
+      After creating a role-specific object and setting it up (e.g. by sending
+      the title, app ID, size constraints, parent, etc), the client must
+      perform an initial commit without any buffer attached. The compositor
+      will reply with initial wl_surface state such as
+      wl_surface.preferred_buffer_scale followed by an xdg_surface.configure
+      event. The client must acknowledge it and is then allowed to attach a
+      buffer to map the surface.
+
       Mapping an xdg_surface-based role surface is defined as making it
       possible for the surface to be shown by the compositor. Note that
       a mapped surface is not guaranteed to be visible once it is mapped.
@@ -439,19 +455,30 @@
 
       A newly-unmapped surface is considered to have met condition (1) out
       of the 3 required conditions for mapping a surface if its role surface
-      has not been destroyed.
+      has not been destroyed, i.e. the client must perform the initial commit
+      again before attaching a buffer.
     </description>
 
     <enum name="error">
-      <entry name="not_constructed" value="1"/>
-      <entry name="already_constructed" value="2"/>
-      <entry name="unconfigured_buffer" value="3"/>
+      <entry name="not_constructed" value="1"
+	     summary="Surface was not fully constructed"/>
+      <entry name="already_constructed" value="2"
+	     summary="Surface was already constructed"/>
+      <entry name="unconfigured_buffer" value="3"
+	     summary="Attaching a buffer to an unconfigured surface"/>
+      <entry name="invalid_serial" value="4"
+	     summary="Invalid serial number when acking a configure event"/>
+      <entry name="invalid_size" value="5"
+	     summary="Width or height was zero or negative"/>
+      <entry name="defunct_role_object" value="6"
+	     summary="Surface was destroyed before its role object"/>
     </enum>
 
     <request name="destroy" type="destructor">
       <description summary="destroy the xdg_surface">
 	Destroy the xdg_surface object. An xdg_surface must only be destroyed
-	after its role object has been destroyed.
+	after its role object has been destroyed, otherwise
+	a defunct_role_object error is raised.
       </description>
     </request>
 
@@ -489,8 +516,7 @@
 	portions like drop-shadows which should be ignored for the
 	purposes of aligning, placing and constraining windows.
 
-	The window geometry is double buffered, and will be applied at the
-	time wl_surface.commit of the corresponding wl_surface is called.
+	The window geometry is double-buffered state, see wl_surface.commit.
 
 	When maintaining a position, the compositor should treat the (x, y)
 	coordinate of the window geometry as the top left corner of the window.
@@ -506,13 +532,22 @@
 	commit. This unset is meant for extremely simple clients.
 
 	The arguments are given in the surface-local coordinate space of
-	the wl_surface associated with this xdg_surface.
+	the wl_surface associated with this xdg_surface, and may extend outside
+	of the wl_surface itself to mark parts of the subsurface tree as part of
+	the window geometry.
 
-	The width and height must be greater than zero. Setting an invalid size
-	will raise an error. When applied, the effective window geometry will be
-	the set window geometry clamped to the bounding rectangle of the
-	combined geometry of the surface of the xdg_surface and the associated
+	When applied, the effective window geometry will be the set window
+	geometry clamped to the bounding rectangle of the combined
+	geometry of the surface of the xdg_surface and the associated
 	subsurfaces.
+
+	The effective geometry will not be recalculated unless a new call to
+	set_window_geometry is done and the new pending surface state is
+	subsequently applied.
+
+	The width and height of the effective window geometry must be
+	greater than zero. Setting an invalid size will raise an
+	invalid_size error.
       </description>
       <arg name="x" type="int"/>
       <arg name="y" type="int"/>
@@ -533,6 +568,8 @@
 
 	If the client receives multiple configure events before it
 	can respond to one, it only has to ack the last configure event.
+	Acking a configure event that was never sent raises an invalid_serial
+	error.
 
 	A client is not required to commit immediately after sending
 	an ack_configure request - it may even ack_configure several times
@@ -541,6 +578,17 @@
 	A client may send multiple ack_configure requests before committing, but
 	only the last request sent before a commit indicates which configure
 	event the client really is responding to.
+
+	Sending an ack_configure request consumes the serial number sent with
+	the request, as well as serial numbers sent by all configure events
+	sent on this xdg_surface prior to the configure event referenced by
+	the committed serial.
+
+	It is an error to issue multiple ack_configure requests referencing a
+	serial from the same configure event, or to issue an ack_configure
+	request referencing a serial from a configure event issued before the
+	event identified by the last ack_configure request for the same
+	xdg_surface. Doing so will raise an invalid_serial error.
       </description>
       <arg name="serial" type="uint" summary="the serial from the configure event"/>
     </request>
@@ -569,7 +617,7 @@
 
   </interface>
 
-  <interface name="xdg_toplevel" version="3">
+  <interface name="xdg_toplevel" version="6">
     <description summary="toplevel surface">
       This interface defines an xdg_surface role which allows a surface to,
       among other things, set window-like properties such as maximize,
@@ -577,11 +625,19 @@
       id, and well as trigger user interactive operations such as interactive
       resize and move.
 
+      A xdg_toplevel by default is responsible for providing the full intended
+      visual representation of the toplevel, which depending on the window
+      state, may mean things like a title bar, window controls and drop shadow.
+
       Unmapping an xdg_toplevel means that the surface cannot be shown
       by the compositor until it is explicitly mapped again.
       All active operations (e.g., move, resize) are canceled and all
       attributes (e.g. title, state, stacking, ...) are discarded for
-      an xdg_toplevel surface when it is unmapped.
+      an xdg_toplevel surface when it is unmapped. The xdg_toplevel returns to
+      the state it had right after xdg_surface.get_toplevel. The client
+      can re-map the toplevel by performing a commit without any buffer
+      attached, waiting for a configure event and handling it as usual (see
+      xdg_surface description).
 
       Attaching a null buffer to a toplevel unmaps the surface.
     </description>
@@ -593,24 +649,37 @@
       </description>
     </request>
 
+    <enum name="error">
+      <entry name="invalid_resize_edge" value="0" summary="provided value is
+        not a valid variant of the resize_edge enum"/>
+      <entry name="invalid_parent" value="1"
+        summary="invalid parent toplevel"/>
+      <entry name="invalid_size" value="2"
+	summary="client provided an invalid min or max size"/>
+    </enum>
+
     <request name="set_parent">
       <description summary="set the parent of this surface">
 	Set the "parent" of this surface. This surface should be stacked
 	above the parent surface and all other ancestor surfaces.
 
-	Parent windows should be set on dialogs, toolboxes, or other
+	Parent surfaces should be set on dialogs, toolboxes, or other
 	"auxiliary" surfaces, so that the parent is raised when the dialog
 	is raised.
 
-	Setting a null parent for a child window removes any parent-child
-	relationship for the child. Setting a null parent for a window which
-	currently has no parent is a no-op.
+	Setting a null parent for a child surface unsets its parent. Setting
+	a null parent for a surface which currently has no parent is a no-op.
 
-	If the parent is unmapped then its children are managed as
-	though the parent of the now-unmapped parent has become the
-	parent of this surface. If no parent exists for the now-unmapped
-	parent then the children are managed as though they have no
-	parent surface.
+	Only mapped surfaces can have child surfaces. Setting a parent which
+	is not mapped is equivalent to setting a null parent. If a surface
+	becomes unmapped, its children's parent is set to the parent of
+	the now-unmapped surface. If the now-unmapped surface has no parent,
+	its children's parent is unset. If the now-unmapped surface becomes
+	mapped again, its parent-child relationship is not restored.
+
+	The parent toplevel must not be one of the child toplevel's
+	descendants, and the parent must be different from the child toplevel,
+	otherwise the invalid_parent protocol error is raised.
       </description>
       <arg name="parent" type="object" interface="xdg_toplevel" allow-null="true"/>
     </request>
@@ -652,7 +721,7 @@
 	application identifiers and how they relate to well-known D-Bus
 	names and .desktop files.
 
-	[0] http://standards.freedesktop.org/desktop-entry-spec/
+	[0] https://standards.freedesktop.org/desktop-entry-spec/
       </description>
       <arg name="app_id" type="string"/>
     </request>
@@ -666,7 +735,8 @@
 	This request asks the compositor to pop up such a window menu at
 	the given position, relative to the local surface coordinates of
 	the parent surface. There are no guarantees as to what menu items
-	the window menu contains.
+	the window menu contains, or even if a window menu will be drawn
+	at all.
 
 	This request must be used in response to some sort of user action
 	like a button press, key press, or touch down event.
@@ -742,12 +812,13 @@
 	guarantee that the device focus will return when the resize is
 	completed.
 
-	The edges parameter specifies how the surface should be resized,
-	and is one of the values of the resize_edge enum. The compositor
-	may use this information to update the surface position for
-	example when dragging the top left corner. The compositor may also
-	use this information to adapt its behavior, e.g. choose an
-	appropriate cursor image.
+	The edges parameter specifies how the surface should be resized, and
+	is one of the values of the resize_edge enum. Values not matching
+	a variant of the enum will cause the invalid_resize_edge protocol error.
+	The compositor may use this information to update the surface position
+	for example when dragging the top left corner. The compositor may also
+	use this information to adapt its behavior, e.g. choose an appropriate
+	cursor image.
       </description>
       <arg name="seat" type="object" interface="wl_seat" summary="the wl_seat of the user event"/>
       <arg name="serial" type="uint" summary="the serial of the user event"/>
@@ -761,13 +832,13 @@
 	configure event to ensure that both the client and the compositor
 	setting the state can be synchronized.
 
-	States set in this way are double-buffered. They will get applied on
-	the next commit.
+	States set in this way are double-buffered, see wl_surface.commit.
       </description>
       <entry name="maximized" value="1" summary="the surface is maximized">
 	<description summary="the surface is maximized">
 	  The surface is maximized. The window geometry specified in the configure
-	  event must be obeyed by the client.
+	  event must be obeyed by the client, or the xdg_wm_base.invalid_surface_state
+	  error is raised.
 
 	  The client should draw without shadow or other
 	  decoration outside of the window geometry.
@@ -798,27 +869,46 @@
 	</description>
       </entry>
       <entry name="tiled_left" value="5" since="2">
-	<description summary="the surface is tiled">
+	<description summary="the surface’s left edge is tiled">
 	  The window is currently in a tiled layout and the left edge is
 	  considered to be adjacent to another part of the tiling grid.
+
+	  The client should draw without shadow or other decoration outside of
+	  the window geometry on the left edge.
 	</description>
       </entry>
       <entry name="tiled_right" value="6" since="2">
-	<description summary="the surface is tiled">
+	<description summary="the surface’s right edge is tiled">
 	  The window is currently in a tiled layout and the right edge is
 	  considered to be adjacent to another part of the tiling grid.
+
+	  The client should draw without shadow or other decoration outside of
+	  the window geometry on the right edge.
 	</description>
       </entry>
       <entry name="tiled_top" value="7" since="2">
-	<description summary="the surface is tiled">
+	<description summary="the surface’s top edge is tiled">
 	  The window is currently in a tiled layout and the top edge is
 	  considered to be adjacent to another part of the tiling grid.
+
+	  The client should draw without shadow or other decoration outside of
+	  the window geometry on the top edge.
 	</description>
       </entry>
       <entry name="tiled_bottom" value="8" since="2">
-	<description summary="the surface is tiled">
+	<description summary="the surface’s bottom edge is tiled">
 	  The window is currently in a tiled layout and the bottom edge is
 	  considered to be adjacent to another part of the tiling grid.
+
+	  The client should draw without shadow or other decoration outside of
+	  the window geometry on the bottom edge.
+	</description>
+      </entry>
+      <entry name="suspended" value="9" since="6">
+        <description summary="surface repaint is suspended">
+	  The surface is currently not ordinarily being repainted; for
+	  example because its content is occluded by another window, or its
+	  outputs are switched off due to screen locking.
 	</description>
       </entry>
     </enum>
@@ -833,8 +923,7 @@
 	The width and height arguments are in window geometry coordinates.
 	See xdg_surface.set_window_geometry.
 
-	Values set in this way are double-buffered. They will get applied
-	on the next commit.
+	Values set in this way are double-buffered, see wl_surface.commit.
 
 	The compositor can use this information to allow or disallow
 	different states like maximize or fullscreen and draw accurate
@@ -854,11 +943,11 @@
 	request.
 
 	Requesting a maximum size to be smaller than the minimum size of
-	a surface is illegal and will result in a protocol error.
+	a surface is illegal and will result in an invalid_size error.
 
 	The width and height must be greater than or equal to zero. Using
-	strictly negative values for width and height will result in a
-	protocol error.
+	strictly negative values for width or height will result in a
+	invalid_size error.
       </description>
       <arg name="width" type="int"/>
       <arg name="height" type="int"/>
@@ -874,8 +963,7 @@
 	The width and height arguments are in window geometry coordinates.
 	See xdg_surface.set_window_geometry.
 
-	Values set in this way are double-buffered. They will get applied
-	on the next commit.
+	Values set in this way are double-buffered, see wl_surface.commit.
 
 	The compositor can use this information to allow or disallow
 	different states like maximize or fullscreen and draw accurate
@@ -895,11 +983,11 @@
 	request.
 
 	Requesting a minimum size to be larger than the maximum size of
-	a surface is illegal and will result in a protocol error.
+	a surface is illegal and will result in an invalid_size error.
 
 	The width and height must be greater than or equal to zero. Using
 	strictly negative values for width and height will result in a
-	protocol error.
+	invalid_size error.
       </description>
       <arg name="width" type="int"/>
       <arg name="height" type="int"/>
@@ -1058,9 +1146,68 @@
 	a dialog to ask the user to save their data, etc.
       </description>
     </event>
+
+    <!-- Version 4 additions -->
+
+    <event name="configure_bounds" since="4">
+      <description summary="recommended window geometry bounds">
+	The configure_bounds event may be sent prior to a xdg_toplevel.configure
+	event to communicate the bounds a window geometry size is recommended
+	to constrain to.
+
+	The passed width and height are in surface coordinate space. If width
+	and height are 0, it means bounds is unknown and equivalent to as if no
+	configure_bounds event was ever sent for this surface.
+
+	The bounds can for example correspond to the size of a monitor excluding
+	any panels or other shell components, so that a surface isn't created in
+	a way that it cannot fit.
+
+	The bounds may change at any point, and in such a case, a new
+	xdg_toplevel.configure_bounds will be sent, followed by
+	xdg_toplevel.configure and xdg_surface.configure.
+      </description>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </event>
+
+    <!-- Version 5 additions -->
+
+    <enum name="wm_capabilities" since="5">
+      <entry name="window_menu" value="1" summary="show_window_menu is available"/>
+      <entry name="maximize" value="2" summary="set_maximized and unset_maximized are available"/>
+      <entry name="fullscreen" value="3" summary="set_fullscreen and unset_fullscreen are available"/>
+      <entry name="minimize" value="4" summary="set_minimized is available"/>
+    </enum>
+
+    <event name="wm_capabilities" since="5">
+      <description summary="compositor capabilities">
+	This event advertises the capabilities supported by the compositor. If
+	a capability isn't supported, clients should hide or disable the UI
+	elements that expose this functionality. For instance, if the
+	compositor doesn't advertise support for minimized toplevels, a button
+	triggering the set_minimized request should not be displayed.
+
+	The compositor will ignore requests it doesn't support. For instance,
+	a compositor which doesn't advertise support for minimized will ignore
+	set_minimized requests.
+
+	Compositors must send this event once before the first
+	xdg_surface.configure event. When the capabilities change, compositors
+	must send this event again and then send an xdg_surface.configure
+	event.
+
+	The configured state should not be applied immediately. See
+	xdg_surface.configure for details.
+
+	The capabilities are sent as an array of 32-bit unsigned integers in
+	native endianness.
+      </description>
+      <arg name="capabilities" type="array" summary="array of 32-bit capabilities"/>
+    </event>
   </interface>
 
-  <interface name="xdg_popup" version="3">
+  <interface name="xdg_popup" version="6">
     <description summary="short-lived, popup surfaces for menus">
       A popup surface is a short-lived, temporary surface. It can be used to
       implement for example menus, popovers, tooltips and other similar user
@@ -1098,8 +1245,8 @@
 	This destroys the popup. Explicitly destroying the xdg_popup
 	object will also dismiss the popup, and unmap the surface.
 
-	If this xdg_popup is not the "topmost" popup, a protocol error
-	will be sent.
+	If this xdg_popup is not the "topmost" popup, the
+	xdg_wm_base.not_the_topmost_popup protocol error will be sent.
       </description>
     </request>
 
@@ -1130,10 +1277,6 @@
 	When compositors choose to dismiss a popup, they may dismiss every
 	nested grabbing popup as well. When a compositor dismisses popups, it
 	will follow the same dismissing order as required from the client.
-
-	The parent of a grabbing popup must either be another xdg_popup with an
-	active explicit grab, or an xdg_popup or xdg_toplevel, if there are no
-	explicit grabs already taken.
 
 	If the topmost grabbing popup is destroyed, the grab will be returned to
 	the parent of the popup, if that parent previously had an explicit grab.
@@ -1204,12 +1347,12 @@
 
 	If the popup is repositioned in response to a configure event for its
 	parent, the client should send an xdg_positioner.set_parent_configure
-	and possibly a xdg_positioner.set_parent_size request to allow the
+	and possibly an xdg_positioner.set_parent_size request to allow the
 	compositor to properly constrain the popup.
 
 	If the popup is repositioned together with a parent that is being
 	resized, but not in response to a configure event, the client should
-	send a xdg_positioner.set_parent_size request.
+	send an xdg_positioner.set_parent_size request.
       </description>
       <arg name="positioner" type="object" interface="xdg_positioner"/>
       <arg name="token" type="uint" summary="reposition request token"/>


### PR DESCRIPTION
Apply the supplied xdg-toplevel bounds to resizable windows during initial mapping. Libdecor functionality will have to be added separately, as the functionality needs to be added to the library first.

Fixes #11747 
