### PR TITLE
emscripten: Only use EM_JS_DEPS when available

### DIFF
--- a/src/SDL_internal.h
+++ b/src/SDL_internal.h
@@ -217,6 +217,12 @@
 #define SDL_EndThreadFunction NULL
 #endif
 
+#ifdef EM_JS_DEPS
+#define SDL_EM_JS_DEPS(name, deps) EM_JS_DEPS(name, deps)
+#else
+#define SDL_EM_JS_DEPS(name, deps)
+#endif
+
 /* Enable internal definitions in SDL API headers */
 #define SDL_INTERNAL
 

--- a/src/audio/emscripten/SDL_emscriptenaudio.c
+++ b/src/audio/emscripten/SDL_emscriptenaudio.c
@@ -143,7 +143,7 @@ static void EMSCRIPTENAUDIO_CloseDevice(SDL_AudioDevice *device)
     SDL_AudioThreadFinalize(device);
 }
 
-EM_JS_DEPS(sdlaudio, "$autoResumeAudioContext,$dynCall");
+SDL_EM_JS_DEPS(sdlaudio, "$autoResumeAudioContext,$dynCall");
 
 static bool EMSCRIPTENAUDIO_OpenDevice(SDL_AudioDevice *device)
 {

--- a/src/camera/emscripten/SDL_camera_emscripten.c
+++ b/src/camera/emscripten/SDL_camera_emscripten.c
@@ -33,7 +33,7 @@
 //  each EM_ASM section is ugly.
 /* *INDENT-OFF* */ // clang-format off
 
-EM_JS_DEPS(sdlcamera, "$dynCall");
+SDL_EM_JS_DEPS(sdlcamera, "$dynCall");
 
 static bool EMSCRIPTENCAMERA_WaitDevice(SDL_Camera *device)
 {

--- a/src/main/emscripten/SDL_sysmain_runapp.c
+++ b/src/main/emscripten/SDL_sysmain_runapp.c
@@ -24,7 +24,7 @@
 
 #include <emscripten/emscripten.h>
 
-EM_JS_DEPS(sdlrunapp, "$dynCall,$stringToNewUTF8");
+SDL_EM_JS_DEPS(sdlrunapp, "$dynCall,$stringToNewUTF8");
 
 int SDL_RunApp(int argc, char* argv[], SDL_main_func mainFunction, void * reserved)
 {

--- a/src/misc/emscripten/SDL_sysurl.c
+++ b/src/misc/emscripten/SDL_sysurl.c
@@ -24,7 +24,7 @@
 
 #include <emscripten/emscripten.h>
 
-EM_JS_DEPS(sdlsysurl, "$UTF8ToString");
+SDL_EM_JS_DEPS(sdlsysurl, "$UTF8ToString");
 
 bool SDL_SYS_OpenURL(const char *url)
 {

--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -836,7 +836,7 @@ EMSCRIPTEN_KEEPALIVE void Emscripten_SendDragFileEvent(SDL_WindowData *window_da
     SDL_SendDropFile(window_data->window, NULL, filename);
 }
 
-EM_JS_DEPS(dragndrop, "$writeArrayToMemory");
+SDL_EM_JS_DEPS(dragndrop, "$writeArrayToMemory");
 
 static void Emscripten_set_drag_event_callbacks(SDL_WindowData *data)
 {

--- a/src/video/emscripten/SDL_emscriptenmouse.c
+++ b/src/video/emscripten/SDL_emscriptenmouse.c
@@ -67,7 +67,7 @@ static SDL_Cursor *Emscripten_CreateDefaultCursor(void)
     return Emscripten_CreateCursorFromString(cursor_name, false);
 }
 
-EM_JS_DEPS(sdlmouse, "$stringToUTF8,$UTF8ToString");
+SDL_EM_JS_DEPS(sdlmouse, "$stringToUTF8,$UTF8ToString");
 
 static SDL_Cursor *Emscripten_CreateCursor(SDL_Surface *surface, int hot_x, int hot_y)
 {


### PR DESCRIPTION
To be backwards compaitble with older emscripten version, EM_JS_DEPS is only used when available.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
