### PR TITLE
tray: Don't call g_object_unref(NULL)

### DIFF
--- a/src/tray/unix/SDL_tray.c
+++ b/src/tray/unix/SDL_tray.c
@@ -671,7 +671,9 @@ void SDL_DestroyTray(SDL_Tray *tray)
         SDL_RemovePath(tray->icon_path);
     }
 
-    g_object_unref(tray->indicator);
+    if (tray->indicator) {
+        g_object_unref(tray->indicator);
+    }
 
     SDL_free(tray);
 


### PR DESCRIPTION
g_object_unref() only accepts valid object instances.