### PR TITLE
tray: Only load known-good SONAMEs for libappindicator

### DIFF
--- a/src/tray/unix/SDL_tray.c
+++ b/src/tray/unix/SDL_tray.c
@@ -176,11 +176,8 @@ static void quit_gtk(void)
 const char *appindicator_names[] = {
     "libayatana-appindicator3.so",
     "libayatana-appindicator3.so.1",
-    "libayatana-appindicator.so",
     "libappindicator3.so",
     "libappindicator3.so.1",
-    "libappindicator.so",
-    "libappindicator.so.1",
     NULL
 };
 

--- a/src/tray/unix/SDL_tray.c
+++ b/src/tray/unix/SDL_tray.c
@@ -174,22 +174,31 @@ static void quit_gtk(void)
 }
 
 const char *appindicator_names[] = {
+#ifdef SDL_PLATFORM_OPENBSD
     "libayatana-appindicator3.so",
-    "libayatana-appindicator3.so.1",
     "libappindicator3.so",
+#else
+    "libayatana-appindicator3.so.1",
     "libappindicator3.so.1",
+#endif
     NULL
 };
 
 const char *gtk_names[] = {
+#ifdef SDL_PLATFORM_OPENBSD
     "libgtk-3.so",
+#else
     "libgtk-3.so.0",
+#endif
     NULL
 };
 
 const char *gdk_names[] = {
+#ifdef SDL_PLATFORM_OPENBSD
     "libgdk-3.so",
+#else
     "libgdk-3.so.0",
+#endif
     NULL
 };
 


### PR DESCRIPTION
* tray: Don't try to use GTK 2 versions of libappindicator
    
    We use GTK 3 functions in this file, so we cannot load a libappindicator
    whose SONAME indicates that it is using GTK 2.

* tray: Load GTK and libappindicator by versioned names, except on OpenBSD
    
    We are expecting a specific ABI (we can see that from the declarations
    listed in this file) and the whole point of SONAME versioning is to
    say that the library conforms to a specific ABI. If the SONAME is not
    the one we expect, then calling its functions is likely to crash.
    
    As usual, an exception to this is that OpenBSD does not use SONAME
    versioning.

---

Similar to #10776, but for the new "system tray" code.