### PR TITLE
win32: Emit SDL_EVENT_WINDOW_RESIZED with correct size data when window is borderless.

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1639,11 +1639,19 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
         }
 
         // Moving the window from one display to another can change the size of the window (in the handling of SDL_EVENT_WINDOW_MOVED), so we need to re-query the bounds
-        if (GetClientRect(hwnd, &rect) && !WIN_IsRectEmpty(&rect)) {
-            w = rect.right;
-            h = rect.bottom;
-
-            SDL_SendWindowEvent(data->window, SDL_EVENT_WINDOW_RESIZED, w, h);
+        {
+            BOOL get_rect_result;
+            if (data->window->flags & SDL_WINDOW_BORDERLESS) {
+                get_rect_result = GetWindowRect(hwnd, &rect);
+            }
+            else {
+                get_rect_result = GetClientRect(hwnd, &rect);
+            }
+            if (get_rect_result && !WIN_IsRectEmpty(&rect)) {
+                w = rect.right - rect.left;
+                h = rect.bottom - rect.top;
+                SDL_SendWindowEvent(data->window, SDL_EVENT_WINDOW_RESIZED, w, h);
+            }
         }
 
         WIN_UpdateClipCursor(data->window);

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -1055,10 +1055,17 @@ void WIN_GetWindowSizeInPixels(SDL_VideoDevice *_this, SDL_Window *window, int *
     const SDL_WindowData *data = window->internal;
     HWND hwnd = data->hwnd;
     RECT rect;
-
-    if (GetClientRect(hwnd, &rect) && !WIN_IsRectEmpty(&rect)) {
-        *w = rect.right;
-        *h = rect.bottom;
+    BOOL get_rect_result;
+    
+    if (data->window->flags & SDL_WINDOW_BORDERLESS) {
+        get_rect_result = GetWindowRect(hwnd, &rect);
+    }
+    else {
+        get_rect_result = GetClientRect(hwnd, &rect);
+    }
+    if (get_rect_result && !WIN_IsRectEmpty(&rect)) {
+        *w = rect.right - rect.left;
+        *h = rect.bottom - rect.top;
     } else if (window->last_pixel_w && window->last_pixel_h) {
         *w = window->last_pixel_w;
         *h = window->last_pixel_h;

--- a/test/testautomation_video.c
+++ b/test/testautomation_video.c
@@ -24,7 +24,7 @@ static SDL_Window *createVideoSuiteTestWindow(const char *title)
     /* Standard window */
     w = SDLTest_RandomIntegerInRange(320, 1024);
     h = SDLTest_RandomIntegerInRange(320, 768);
-    flags = SDL_WINDOW_RESIZABLE | SDL_WINDOW_BORDERLESS;
+    flags = SDL_WINDOW_BORDERLESS;
 
     window = SDL_CreateWindow(title, w, h, flags);
     SDLTest_AssertPass("Call to SDL_CreateWindow('Title',%d,%d,%" SDL_PRIu64 ")", w, h, flags);
@@ -1006,10 +1006,6 @@ static int SDLCALL video_getSetWindowSize(void *arg)
     int referenceW, referenceH;
     int currentW, currentH;
     int desiredW, desiredH;
-    const bool restoreHint = SDL_GetHintBoolean("SDL_BORDERLESS_RESIZABLE_STYLE", true);
-
-    /* Win32 borderless windows are not resizable by default and need this undocumented hint */
-    SDL_SetHint("SDL_BORDERLESS_RESIZABLE_STYLE", "1");
 
     /* Get display bounds for size range */
     result = SDL_GetDisplayUsableBounds(SDL_GetPrimaryDisplay(), &display);
@@ -1026,7 +1022,7 @@ static int SDLCALL video_getSetWindowSize(void *arg)
     }
 
     SDL_GetWindowSize(window, &currentW, &currentH);
-    if (SDL_SetWindowSize(window, currentW, currentH)) {
+    if (!SDL_SetWindowSize(window, currentW, currentH)) {
         SDLTest_Log("Skipping window resize tests: %s reports window resizing as unsupported", SDL_GetCurrentVideoDriver());
         goto null_tests;
     }
@@ -1123,7 +1119,6 @@ static int SDLCALL video_getSetWindowSize(void *arg)
                 }
             }
 
-
             /* Get just width */
             currentW = desiredW + 1;
             SDL_GetWindowSize(window, &currentW, NULL);
@@ -1187,9 +1182,6 @@ null_tests:
     SDL_SetWindowSize(NULL, desiredW, desiredH);
     SDLTest_AssertPass("Call to SDL_SetWindowSize(window=NULL)");
     checkInvalidWindowError();
-
-    /* Restore the hint to the previous value */
-    SDL_SetHint("SDL_BORDERLESS_RESIZABLE_STYLE", restoreHint ? "1" : "0");
 
     return TEST_COMPLETED;
 }


### PR DESCRIPTION
After resizing (programmatically) a borderless window in windows the `SDL_Window` size remains the same and no `SDL_EVENT_WINDOW_RESIZED` event is emitted. It seems `GetClientRect` continues to return the previous window size, so `SDL_SendWindowEvent` filters the event out. `GetWindowRect` however, gives the correct size (with some additional math on the rect). So, normally we'll continue to use `GetClientRect`, but when the window is borderless we use `GetWindowRect`.

While trying to replicate this issue in tests I found that the `video_getSetWindowSize` test was incorrectly skipping resize tests on all platforms.

Turning that on caused `SDL_SetWindowSize(window, 1, 1)` to fail because of the `SDL_WINDOW_RESIZABLE` flag rendering the window frame. (tbf this may have also been because I removed the `SDL_BORDERLESS_RESIZABLE_STYLE` -- I lost track of the combinations of things I was trying 😄 ). 

I expect the changes to the tests might either expose issues on other platforms and/or require some iteration. So I'll keep an eye on CI.
