### PR TITLE
win32: Use the pending size during NCCALCSIZE

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -2020,10 +2020,15 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
                         params->rgrc[0] = info.rcWork;
                     }
                 }
-            } else if (!(window_flags & SDL_WINDOW_RESIZABLE)) {
+            } else if (!(window_flags & SDL_WINDOW_RESIZABLE) && !data->force_resizable) {
                 int w, h;
-                w = data->window->floating.w;
-                h = data->window->floating.h;
+                if (data->window->last_size_pending) {
+                    w = data->window->pending.w;
+                    h = data->window->pending.h;
+                } else {
+                    w = data->window->floating.w;
+                    h = data->window->floating.h;
+                }
                 params->rgrc[0].right = params->rgrc[0].left + w;
                 params->rgrc[0].bottom = params->rgrc[0].top + h;
             }

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -162,7 +162,7 @@ static DWORD GetWindowStyle(SDL_Window *window)
     DWORD style = 0;
 
     if (SDL_WINDOW_IS_POPUP(window)) {
-        style |= WS_POPUP | WS_THICKFRAME;
+        style |= WS_POPUP;
     } else if (window->flags & SDL_WINDOW_FULLSCREEN) {
         style |= STYLE_FULLSCREEN;
     } else {


### PR DESCRIPTION
Non-resizable windows still need to apply the pending size when calculating the client rect, as they can be resized programmatically.

Fixes programmatically resizing windows without the WS_THICKFRAME style.

Closes #11883 
