### PR TITLE
Add support for including SDL3 headers in older toolchains

### DIFF
--- a/include/SDL3/SDL_assert.h
+++ b/include/SDL3/SDL_assert.h
@@ -127,7 +127,7 @@ extern "C" {
  */
 #define SDL_TriggerBreakpoint() TriggerABreakpointInAPlatformSpecificManner
 
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && _MSC_VER >= 1310
     /* Don't include intrin.h here because it contains C++ code */
     extern void __cdecl __debugbreak(void);
     #define SDL_TriggerBreakpoint() __debugbreak()

--- a/include/SDL3/SDL_bits.h
+++ b/include/SDL3/SDL_bits.h
@@ -78,7 +78,7 @@ SDL_FORCE_INLINE int SDL_MostSignificantBitIndex32(Uint32 x)
         return -1;
     }
     return _SDL_bsr_watcom(x);
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && _MSC_VER >= 1400
     unsigned long index;
     if (_BitScanReverse(&index, x)) {
         return (int)index;

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -753,7 +753,9 @@ typedef Sint64 SDL_Time;
 #endif
 /* Specifically for the `long long` -- SDL-specific. */
 #ifdef SDL_PLATFORM_WINDOWS
+#ifndef SDL_NOLONGLONG
 SDL_COMPILE_TIME_ASSERT(longlong_size64, sizeof(long long) == 8); /* using I64 for windows - make sure `long long` is 64 bits. */
+#endif
 #define SDL_PRILL_PREFIX "I64"
 #else
 #define SDL_PRILL_PREFIX "ll"
@@ -1126,8 +1128,10 @@ SDL_COMPILE_TIME_ASSERT(uint32_size, sizeof(Uint32) == 4);
 SDL_COMPILE_TIME_ASSERT(sint32_size, sizeof(Sint32) == 4);
 SDL_COMPILE_TIME_ASSERT(uint64_size, sizeof(Uint64) == 8);
 SDL_COMPILE_TIME_ASSERT(sint64_size, sizeof(Sint64) == 8);
+#ifndef SDL_NOLONGLONG
 SDL_COMPILE_TIME_ASSERT(uint64_longlong, sizeof(Uint64) <= sizeof(unsigned long long));
 SDL_COMPILE_TIME_ASSERT(size_t_longlong, sizeof(size_t) <= sizeof(unsigned long long));
+#endif
 typedef struct SDL_alignment_test
 {
     Uint8 a;
@@ -3492,6 +3496,7 @@ extern SDL_DECLSPEC char * SDLCALL SDL_ltoa(long value, char *str, int radix);
  */
 extern SDL_DECLSPEC char * SDLCALL SDL_ultoa(unsigned long value, char *str, int radix);
 
+#ifndef SDL_NOLONGLONG
 /**
  * Convert a long long integer into a string.
  *
@@ -3547,6 +3552,7 @@ extern SDL_DECLSPEC char * SDLCALL SDL_lltoa(long long value, char *str, int rad
  * \sa SDL_ultoa
  */
 extern SDL_DECLSPEC char * SDLCALL SDL_ulltoa(unsigned long long value, char *str, int radix);
+#endif
 
 /**
  * Parse an `int` from a string.
@@ -3660,6 +3666,7 @@ extern SDL_DECLSPEC long SDLCALL SDL_strtol(const char *str, char **endp, int ba
  */
 extern SDL_DECLSPEC unsigned long SDLCALL SDL_strtoul(const char *str, char **endp, int base);
 
+#ifndef SDL_NOLONGLONG
 /**
  * Parse a `long long` from a string.
  *
@@ -3726,6 +3733,7 @@ extern SDL_DECLSPEC long long SDLCALL SDL_strtoll(const char *str, char **endp, 
  * \sa SDL_ulltoa
  */
 extern SDL_DECLSPEC unsigned long long SDLCALL SDL_strtoull(const char *str, char **endp, int base);
+#endif
 
 /**
  * Parse a `double` from a string.

--- a/src/SDL_internal.h
+++ b/src/SDL_internal.h
@@ -217,6 +217,10 @@
 #define SDL_EndThreadFunction NULL
 #endif
 
+#ifdef SDL_NOLONGLONG
+#error We cannot build a valid SDL3 library without long long support
+#endif
+
 /* Enable internal definitions in SDL API headers */
 #define SDL_INTERNAL
 


### PR DESCRIPTION
With these patches, I can successfully use the SDL3 headers with MSVC 6 (from 1998).

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
