### PR TITLE
Use XIM for IME input on X11

### DIFF
--- a/src/video/x11/SDL_x11dyn.c
+++ b/src/video/x11/SDL_x11dyn.c
@@ -104,6 +104,8 @@ static void *X11_GetSym(const char *fnname, int *pHasModule)
 #ifdef X_HAVE_UTF8_STRING
 SDL_DYNX11FN_XCreateIC X11_XCreateIC = NULL;
 SDL_DYNX11FN_XGetICValues X11_XGetICValues = NULL;
+SDL_DYNX11FN_XSetICValues X11_XSetICValues = NULL;
+SDL_DYNX11FN_XVaCreateNestedList X11_XVaCreateNestedList = NULL;
 #endif
 
 /* These SDL_X11_HAVE_* flags are here whether you have dynamic X11 or not. */
@@ -129,6 +131,8 @@ void SDL_X11_UnloadSymbols(void)
 #ifdef X_HAVE_UTF8_STRING
             X11_XCreateIC = NULL;
             X11_XGetICValues = NULL;
+            X11_XSetICValues = NULL;
+            X11_XVaCreateNestedList = NULL;
 #endif
 
 #ifdef SDL_VIDEO_DRIVER_X11_DYNAMIC
@@ -171,6 +175,10 @@ bool SDL_X11_LoadSymbols(void)
             X11_GetSym("XCreateIC", &SDL_X11_HAVE_UTF8);
         X11_XGetICValues = (SDL_DYNX11FN_XGetICValues)
             X11_GetSym("XGetICValues", &SDL_X11_HAVE_UTF8);
+        X11_XSetICValues = (SDL_DYNX11FN_XSetICValues)
+            X11_GetSym("XSetICValues", &SDL_X11_HAVE_UTF8);
+        X11_XVaCreateNestedList = (SDL_DYNX11FN_XVaCreateNestedList)
+            X11_GetSym("XVaCreateNestedList", &SDL_X11_HAVE_UTF8);
 #endif
 
         if (SDL_X11_HAVE_BASEXLIB) {
@@ -191,6 +199,8 @@ bool SDL_X11_LoadSymbols(void)
 #ifdef X_HAVE_UTF8_STRING
         X11_XCreateIC = XCreateIC;
         X11_XGetICValues = XGetICValues;
+        X11_XSetICValues = XSetICValues;
+        X11_XVaCreateNestedList = XVaCreateNestedList;
 #endif
 #endif
     }

--- a/src/video/x11/SDL_x11dyn.h
+++ b/src/video/x11/SDL_x11dyn.h
@@ -94,8 +94,12 @@ extern void SDL_X11_UnloadSymbols(void);
 #ifdef X_HAVE_UTF8_STRING
 typedef XIC (*SDL_DYNX11FN_XCreateIC)(XIM, ...);
 typedef char *(*SDL_DYNX11FN_XGetICValues)(XIC, ...);
+typedef char *(*SDL_DYNX11FN_XSetICValues)(XIC, ...);
+typedef XVaNestedList (*SDL_DYNX11FN_XVaCreateNestedList)(int, ...);
 extern SDL_DYNX11FN_XCreateIC X11_XCreateIC;
 extern SDL_DYNX11FN_XGetICValues X11_XGetICValues;
+extern SDL_DYNX11FN_XSetICValues X11_XSetICValues;
+extern SDL_DYNX11FN_XVaCreateNestedList X11_XVaCreateNestedList;
 #endif
 
 /* These SDL_X11_HAVE_* flags are here whether you have dynamic X11 or not. */

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -939,6 +939,7 @@ void X11_HandleKeyEvent(SDL_VideoDevice *_this, SDL_WindowData *windowdata, SDL_
 
             if (*text) {
                 text[text_length] = '\0';
+                X11_ClearComposition(windowdata);
                 SDL_SendKeyboardText(text);
             }
         } else {

--- a/src/video/x11/SDL_x11keyboard.h
+++ b/src/video/x11/SDL_x11keyboard.h
@@ -26,6 +26,8 @@
 extern bool X11_InitKeyboard(SDL_VideoDevice *_this);
 extern void X11_UpdateKeymap(SDL_VideoDevice *_this, bool send_event);
 extern void X11_QuitKeyboard(SDL_VideoDevice *_this);
+extern void X11_CreateInputContext(SDL_WindowData *data);
+extern void X11_ClearComposition(SDL_WindowData *data);
 extern bool X11_StartTextInput(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesID props);
 extern bool X11_StopTextInput(SDL_VideoDevice *_this, SDL_Window *window);
 extern bool X11_UpdateTextInputArea(SDL_VideoDevice *_this, SDL_Window *window);

--- a/src/video/x11/SDL_x11sym.h
+++ b/src/video/x11/SDL_x11sym.h
@@ -223,6 +223,8 @@ SDL_X11_SYM(int,Xutf8LookupString,(XIC a,XKeyPressedEvent* b,char* c,int d,KeySy
 // SDL_X11_SYM(XIC,XCreateIC,(XIM, ...),return)  !!! ARGH!
 SDL_X11_SYM(void,XDestroyIC,(XIC a),(a),)
 /* SDL_X11_SYM(char*,XGetICValues,(XIC, ...),return)  !!! ARGH! */
+/* SDL_X11_SYM(char*,XSetICValues,(XIC, ...),return)  !!! ARGH! */
+/* SDL_X11_SYM(XVaNestedList,XVaCreateNestedList,(int, ...),return)  !!! ARGH! */
 SDL_X11_SYM(void,XSetICFocus,(XIC a),(a),)
 SDL_X11_SYM(void,XUnsetICFocus,(XIC a),(a),)
 SDL_X11_SYM(XIM,XOpenIM,(Display* a,struct _XrmHashBucketRec* b,char* c,char* d),(a,b,c,d),return)

--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -356,19 +356,12 @@ static bool SetupWindowData(SDL_VideoDevice *_this, SDL_Window *window, Window w
     if (!data) {
         return false;
     }
+    data->videodata = videodata;
     data->window = window;
     data->xwindow = w;
     data->hit_test_result = SDL_HITTEST_NORMAL;
 
-#ifdef X_HAVE_UTF8_STRING
-    if (SDL_X11_HAVE_UTF8 && videodata->im) {
-        data->ic =
-            X11_XCreateIC(videodata->im, XNClientWindow, w, XNFocusWindow, w,
-                          XNInputStyle, XIMPreeditNothing | XIMStatusNothing,
-                          NULL);
-    }
-#endif
-    data->videodata = videodata;
+    X11_CreateInputContext(data);
 
     // Associate the data with the window
 
@@ -2044,6 +2037,8 @@ void X11_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
 #ifdef X_HAVE_UTF8_STRING
         if (data->ic) {
             X11_XDestroyIC(data->ic);
+            SDL_free(data->preedit_text);
+            SDL_free(data->preedit_feedback);
         }
 #endif
 

--- a/src/video/x11/SDL_x11window.h
+++ b/src/video/x11/SDL_x11window.h
@@ -111,6 +111,13 @@ struct SDL_WindowData
     bool toggle_borders;
     bool fullscreen_borders_forced_on;
     SDL_HitTestResult hit_test_result;
+
+    XPoint xim_spot;
+    char *preedit_text;
+    XIMFeedback *preedit_feedback;
+    int preedit_length;
+    int preedit_cursor;
+    bool ime_needs_clear_composition;
 };
 
 extern void X11_SetNetWMState(SDL_VideoDevice *_this, Window xwindow, SDL_WindowFlags flags);


### PR DESCRIPTION
Tested with fcitx5 and ibus on Xorg and Xwayland
* Used US English with dead keys and verified that ` followed by a results in à
* Used Hangul to enter Korean and got text in the expected order
* Used the mozc IM to enter Japanese and was able to generate candidates and so forth

Fixes https://github.com/libsdl-org/SDL/issues/3907
Fixes https://github.com/libsdl-org/SDL/issues/6164
Fixes https://github.com/libsdl-org/SDL/issues/11894