### PR TITLE
remove relative speed scale

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2515,16 +2515,6 @@ extern "C" {
 #define SDL_HINT_MOUSE_RELATIVE_MODE_CENTER "SDL_MOUSE_RELATIVE_MODE_CENTER"
 
 /**
- * A variable setting the scale for mouse motion, in floating point, when the
- * mouse is in relative mode.
- *
- * This hint can be set anytime.
- *
- * \since This hint is available since SDL 3.1.3.
- */
-#define SDL_HINT_MOUSE_RELATIVE_SPEED_SCALE "SDL_MOUSE_RELATIVE_SPEED_SCALE"
-
-/**
  * A variable controlling whether the system mouse acceleration curve is used
  * for relative mouse motion.
  *

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -89,19 +89,6 @@ static void SDLCALL SDL_MouseNormalSpeedScaleChanged(void *userdata, const char 
     }
 }
 
-static void SDLCALL SDL_MouseRelativeSpeedScaleChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
-{
-    SDL_Mouse *mouse = (SDL_Mouse *)userdata;
-
-    if (hint && *hint) {
-        mouse->enable_relative_speed_scale = true;
-        mouse->relative_speed_scale = (float)SDL_atof(hint);
-    } else {
-        mouse->enable_relative_speed_scale = false;
-        mouse->relative_speed_scale = 1.0f;
-    }
-}
-
 static void SDLCALL SDL_MouseRelativeModeCenterChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
 {
     SDL_Mouse *mouse = (SDL_Mouse *)userdata;
@@ -215,9 +202,6 @@ bool SDL_PreInitMouse(void)
 
     SDL_AddHintCallback(SDL_HINT_MOUSE_NORMAL_SPEED_SCALE,
                         SDL_MouseNormalSpeedScaleChanged, mouse);
-
-    SDL_AddHintCallback(SDL_HINT_MOUSE_RELATIVE_SPEED_SCALE,
-                        SDL_MouseRelativeSpeedScaleChanged, mouse);
 
     SDL_AddHintCallback(SDL_HINT_MOUSE_RELATIVE_SYSTEM_SCALE,
                         SDL_MouseRelativeSystemScaleChanged, mouse);
@@ -669,10 +653,7 @@ static void SDL_PrivateSendMouseMotion(Uint64 timestamp, SDL_Window *window, SDL
 
     if (relative) {
         if (mouse->relative_mode) {
-            if (mouse->enable_relative_speed_scale) {
-                x *= mouse->relative_speed_scale;
-                y *= mouse->relative_speed_scale;
-            } else if (mouse->enable_relative_system_scale) {
+            if (mouse->enable_relative_system_scale) {
                 if (mouse->ApplySystemScale) {
                     mouse->ApplySystemScale(mouse->system_scale_data, timestamp, window, mouseID, &x, &y);
                 }
@@ -1023,9 +1004,6 @@ void SDL_QuitMouse(void)
 
     SDL_RemoveHintCallback(SDL_HINT_MOUSE_NORMAL_SPEED_SCALE,
                         SDL_MouseNormalSpeedScaleChanged, mouse);
-
-    SDL_RemoveHintCallback(SDL_HINT_MOUSE_RELATIVE_SPEED_SCALE,
-                        SDL_MouseRelativeSpeedScaleChanged, mouse);
 
     SDL_RemoveHintCallback(SDL_HINT_MOUSE_RELATIVE_SYSTEM_SCALE,
                         SDL_MouseRelativeSystemScaleChanged, mouse);

--- a/src/events/SDL_mouse_c.h
+++ b/src/events/SDL_mouse_c.h
@@ -111,8 +111,6 @@ typedef struct
     Uint64 last_center_warp_time_ns;
     bool enable_normal_speed_scale;
     float normal_speed_scale;
-    bool enable_relative_speed_scale;
-    float relative_speed_scale;
     bool enable_relative_system_scale;
     Uint32 double_click_time;
     int double_click_radius;


### PR DESCRIPTION
Relative Speed Scale is a hint added only in SDL3 ~~and only implemented on Windows.~~ (EDIT: brainfart, for some reason was thinking of systemscale, which also isn't the case anymore as of recently)

It is therefore unlikely to have had any notable adoption at this point, if at all.

If anything, it is probably treated as a nuisance that needs to be mitigated.

Deleting it for 3.2.0 removes the temptation for people to potentially depend on it, whether it be developers or tinkerers, before a potentially more suitable interface is conceived.

(aside: @slouken I see that 3.2.0 has a due date of Jan 15, is that a hard date or just an approximate projection?)