### PR TITLE
GPU: Make SDL_SetGPUBufferName and SDL_SetGPUTextureName thread safe

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -2514,8 +2514,7 @@ extern SDL_DECLSPEC SDL_GPUTransferBuffer *SDLCALL SDL_CreateGPUTransferBuffer(
  * \param buffer a buffer to attach the name to.
  * \param text a UTF-8 string constant to mark as the name of the buffer.
  *
- * \threadsafety This function is not thread safe, you must synchronize calls
- *               to this function.
+ * \threadsafety This function is thread safe, but the name may not be immediately set if called off the main thread.
  *
  * \since This function is available since SDL 3.1.3.
  */
@@ -2533,8 +2532,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_SetGPUBufferName(
  * \param texture a texture to attach the name to.
  * \param text a UTF-8 string constant to mark as the name of the texture.
  *
- * \threadsafety This function is not thread safe, you must synchronize calls
- *               to this function.
+ * \threadsafety This function is thread safe, but the name may not be immediately set if called off the main thread.
  *
  * \since This function is available since SDL 3.1.3.
  */

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -5420,6 +5420,7 @@ static void VULKAN_INTERNAL_SetDebugObjectNameMainThreadCallback(
         context->renderer->logicalDevice,
         &context->nameInfo);
 
+    SDL_free(context->nameInfo.pObjectName);
     SDL_free(context);
 }
 
@@ -5437,7 +5438,7 @@ static void VULKAN_INTERNAL_SetBufferName(
         context->renderer = renderer;
         context->nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
         context->nameInfo.pNext = NULL;
-        context->nameInfo.pObjectName = text;
+        context->nameInfo.pObjectName = SDL_strdup(text);
         context->nameInfo.objectType = VK_OBJECT_TYPE_BUFFER;
         context->nameInfo.objectHandle = (uint64_t)buffer->buffer;
 
@@ -5487,7 +5488,7 @@ static void VULKAN_INTERNAL_SetTextureName(
         context->renderer = renderer;
         context->nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
         context->nameInfo.pNext = NULL;
-        context->nameInfo.pObjectName = text;
+        context->nameInfo.pObjectName = SDL_strdup(text);
         context->nameInfo.objectType = VK_OBJECT_TYPE_IMAGE;
         context->nameInfo.objectHandle = (uint64_t)texture->image;
 


### PR DESCRIPTION
Resolves #11927 