### PR TITLE
Removed redundant information in example pages

### DIFF
--- a/examples/template.html
+++ b/examples/template.html
@@ -207,7 +207,7 @@
             <li><a href="/@project_name@/@category_name@/@example_name@">@example_name@</a></li>
           </ul>
         </nav>
-        <h1>@project_name@ example: @category_name@/@example_name@</h1>
+        <hr/>
         <div id="example-description">@description@</div>
         <div class="canvas-container">
           <canvas


### PR DESCRIPTION
This is large text and is already covered by the header and breadcrumb