### PR TITLE
don't warp mouse on exiting relative mode

### DIFF
--- a/src/events/SDL_mouse_c.h
+++ b/src/events/SDL_mouse_c.h
@@ -181,9 +181,6 @@ extern void SDL_SendMouseButtonClicks(Uint64 timestamp, SDL_Window *window, SDL_
 // Send a mouse wheel event
 extern void SDL_SendMouseWheel(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouseID, float x, float y, SDL_MouseWheelDirection direction);
 
-// Warp the mouse within the window, potentially overriding relative mode
-extern void SDL_PerformWarpMouseInWindow(SDL_Window *window, float x, float y, bool ignore_relative_mode);
-
 // Relative mouse mode
 extern bool SDL_SetRelativeMouseMode(bool enabled);
 extern bool SDL_GetRelativeMouseMode(void);


### PR DESCRIPTION
This is in response to https://github.com/libsdl-org/SDL/issues/11805 but as I didn't get a clarifying response on whether or not this behavior is desired, thought I might as well open a PR to save time and let you accept or reject it @slouken 


The real change is in the first commit (https://github.com/libsdl-org/SDL/pull/11935/commits/1f8f659dd9d40e4612373a4aa20c7e098ac55219):

```diff
@@ -1249,12 +1249,6 @@ bool SDL_SetRelativeMouseMode(bool enabled)

    if (focusWindow) {
        SDL_UpdateWindowGrab(focusWindow);
-       // Put the cursor back to where the application expects it
-       if (!enabled) {
-           SDL_PerformWarpMouseInWindow(focusWindow, mouse->x, mouse->y, true);
-       }
        SDL_UpdateMouseCapture(false);
    }
```

the second commit is purely just inlining two redundant functions.
