### PR TITLE
examples: use doubles to generate sine waves to avoid distortion

### DIFF
--- a/examples/audio/01-simple-playback/simple-playback.c
+++ b/examples/audio/01-simple-playback/simple-playback.c
@@ -76,9 +76,9 @@ SDL_AppResult SDL_AppIterate(void *appstate)
         for (i = 0; i < SDL_arraysize(samples); i++) {
             /* You don't have to care about this math; we're just generating a simple sine wave as we go.
                https://en.wikipedia.org/wiki/Sine_wave */
-            const float time = total_samples_generated / 8000.0f;
+            const double time = total_samples_generated / 8000.0;
             const int sine_freq = 500;   /* run the wave at 500Hz */
-            samples[i] = SDL_sinf(6.283185f * sine_freq * time);
+            samples[i] = (float)SDL_sin(6.283185 * sine_freq * time);
             total_samples_generated++;
         }
 

--- a/examples/audio/02-simple-playback-callback/simple-playback-callback.c
+++ b/examples/audio/02-simple-playback-callback/simple-playback-callback.c
@@ -36,9 +36,9 @@ static void SDLCALL FeedTheAudioStreamMore(void *userdata, SDL_AudioStream *astr
         for (i = 0; i < total; i++) {
             /* You don't have to care about this math; we're just generating a simple sine wave as we go.
                https://en.wikipedia.org/wiki/Sine_wave */
-            const float time = total_samples_generated / 8000.0f;
+            const double time = total_samples_generated / 8000.0;
             const int sine_freq = 500;   /* run the wave at 500Hz */
-            samples[i] = SDL_sinf(6.283185f * sine_freq * time);
+            samples[i] = (float)SDL_sin(6.283185 * sine_freq * time);
             total_samples_generated++;
         }
 


### PR DESCRIPTION
Audio played by sine wave examples becomes gradually distorted over time due to insufficient precision in sine wave generation, making it possible to confuse with an actual audio buffering issue.

## Description
Move to using doubles instead of floats in sine wave math

## Existing Issue(s)
Fixes https://github.com/libsdl-org/SDL/issues/11936
