### PR TITLE
GPU: Add name properties to resources

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -2262,6 +2262,8 @@ extern SDL_DECLSPEC SDL_GPUComputePipeline *SDLCALL SDL_CreateGPUComputePipeline
     SDL_GPUDevice *device,
     const SDL_GPUComputePipelineCreateInfo *createinfo);
 
+#define SDL_PROP_GPU_CREATECOMPUTEPIPELINE_NAME_STRING "SDL.gpu.createcomputepipeline.name"
+
 /**
  * Creates a pipeline object to be used in a graphics workflow.
  *
@@ -2280,6 +2282,8 @@ extern SDL_DECLSPEC SDL_GPUComputePipeline *SDLCALL SDL_CreateGPUComputePipeline
 extern SDL_DECLSPEC SDL_GPUGraphicsPipeline *SDLCALL SDL_CreateGPUGraphicsPipeline(
     SDL_GPUDevice *device,
     const SDL_GPUGraphicsPipelineCreateInfo *createinfo);
+
+#define SDL_PROP_GPU_CREATEGRAPHICSPIPELINE_NAME_STRING "SDL.gpu.creategraphicspipeline.name"
 
 /**
  * Creates a sampler object to be used when binding textures in a graphics

--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -2478,6 +2478,8 @@ extern SDL_DECLSPEC SDL_GPUBuffer *SDLCALL SDL_CreateGPUBuffer(
     SDL_GPUDevice *device,
     const SDL_GPUBufferCreateInfo *createinfo);
 
+#define SDL_PROP_GPU_BUFFER_CREATE_NAME_STRING "SDL.gpu.buffer.create.name"
+
 /**
  * Creates a transfer buffer to be used when uploading to or downloading from
  * graphics resources.

--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -2304,6 +2304,8 @@ extern SDL_DECLSPEC SDL_GPUSampler *SDLCALL SDL_CreateGPUSampler(
     SDL_GPUDevice *device,
     const SDL_GPUSamplerCreateInfo *createinfo);
 
+#define SDL_PROP_GPU_CREATESAMPLER_NAME_STRING "SDL.gpu.createsampler.name"
+
 /**
  * Creates a shader to be used when creating a graphics pipeline.
  *
@@ -2374,6 +2376,8 @@ extern SDL_DECLSPEC SDL_GPUSampler *SDLCALL SDL_CreateGPUSampler(
 extern SDL_DECLSPEC SDL_GPUShader *SDLCALL SDL_CreateGPUShader(
     SDL_GPUDevice *device,
     const SDL_GPUShaderCreateInfo *createinfo);
+
+#define SDL_PROP_GPU_CREATESHADER_NAME_STRING "SDL.gpu.createshader.name"
 
 /**
  * Creates a texture object to be used in graphics or compute workflows.

--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -2247,7 +2247,7 @@ extern SDL_DECLSPEC SDL_GPUShaderFormat SDLCALL SDL_GetGPUShaderFormats(SDL_GPUD
  *
  * There are optional properties that can be provided through `props`. These are the supported properties:
  *
- * - `SDL_PROP_GPU_CREATECOMPUTEPIPELINE_NAME_STRING`: a name that can be displayed in debugging tools.
+ * - `SDL_PROP_GPU_COMPUTEPIPELINE_CREATE_NAME_STRING`: a name that can be displayed in debugging tools.
  *
  * \param device a GPU Context.
  * \param createinfo a struct describing the state of the compute pipeline to
@@ -2264,14 +2264,14 @@ extern SDL_DECLSPEC SDL_GPUComputePipeline *SDLCALL SDL_CreateGPUComputePipeline
     SDL_GPUDevice *device,
     const SDL_GPUComputePipelineCreateInfo *createinfo);
 
-#define SDL_PROP_GPU_CREATECOMPUTEPIPELINE_NAME_STRING "SDL.gpu.createcomputepipeline.name"
+#define SDL_PROP_GPU_COMPUTEPIPELINE_CREATE_NAME_STRING "SDL.gpu.computepipeline.create.name"
 
 /**
  * Creates a pipeline object to be used in a graphics workflow.
  *
  * There are optional properties that can be provided through `props`. These are the supported properties:
  *
- * - `SDL_PROP_GPU_CREATEGRAPHICSPIPELINE_NAME_STRING`: a name that can be displayed in debugging tools.
+ * - `SDL_PROP_GPU_GRAPHICSPIPELINE_CREATE_NAME_STRING`: a name that can be displayed in debugging tools.
  *
  * \param device a GPU Context.
  * \param createinfo a struct describing the state of the graphics pipeline to
@@ -2289,7 +2289,7 @@ extern SDL_DECLSPEC SDL_GPUGraphicsPipeline *SDLCALL SDL_CreateGPUGraphicsPipeli
     SDL_GPUDevice *device,
     const SDL_GPUGraphicsPipelineCreateInfo *createinfo);
 
-#define SDL_PROP_GPU_CREATEGRAPHICSPIPELINE_NAME_STRING "SDL.gpu.creategraphicspipeline.name"
+#define SDL_PROP_GPU_GRAPHICSPIPELINE_CREATE_NAME_STRING "SDL.gpu.graphicspipeline.create.name"
 
 /**
  * Creates a sampler object to be used when binding textures in a graphics
@@ -2297,7 +2297,7 @@ extern SDL_DECLSPEC SDL_GPUGraphicsPipeline *SDLCALL SDL_CreateGPUGraphicsPipeli
  *
  * There are optional properties that can be provided through `props`. These are the supported properties:
  *
- * - `SDL_PROP_GPU_CREATESAMPLER_NAME_STRING`: a name that can be displayed in debugging tools.
+ * - `SDL_PROP_GPU_SAMPLER_CREATE_NAME_STRING`: a name that can be displayed in debugging tools.
  *
  * \param device a GPU Context.
  * \param createinfo a struct describing the state of the sampler to create.
@@ -2314,7 +2314,7 @@ extern SDL_DECLSPEC SDL_GPUSampler *SDLCALL SDL_CreateGPUSampler(
     SDL_GPUDevice *device,
     const SDL_GPUSamplerCreateInfo *createinfo);
 
-#define SDL_PROP_GPU_CREATESAMPLER_NAME_STRING "SDL.gpu.createsampler.name"
+#define SDL_PROP_GPU_SAMPLER_CREATE_NAME_STRING "SDL.gpu.sampler.create.name"
 
 /**
  * Creates a shader to be used when creating a graphics pipeline.
@@ -2375,7 +2375,7 @@ extern SDL_DECLSPEC SDL_GPUSampler *SDLCALL SDL_CreateGPUSampler(
  *
  * There are optional properties that can be provided through `props`. These are the supported properties:
  *
- * - `SDL_PROP_GPU_CREATESHADER_NAME_STRING`: a name that can be displayed in debugging tools.
+ * - `SDL_PROP_GPU_SHADER_CREATE_NAME_STRING`: a name that can be displayed in debugging tools.
  *
  * \param device a GPU Context.
  * \param createinfo a struct describing the state of the shader to create.
@@ -2391,7 +2391,7 @@ extern SDL_DECLSPEC SDL_GPUShader *SDLCALL SDL_CreateGPUShader(
     SDL_GPUDevice *device,
     const SDL_GPUShaderCreateInfo *createinfo);
 
-#define SDL_PROP_GPU_CREATESHADER_NAME_STRING "SDL.gpu.createshader.name"
+#define SDL_PROP_GPU_SHADER_CREATE_NAME_STRING "SDL.gpu.shader.create.name"
 
 /**
  * Creates a texture object to be used in graphics or compute workflows.
@@ -2430,7 +2430,7 @@ extern SDL_DECLSPEC SDL_GPUShader *SDLCALL SDL_CreateGPUShader(
  * - `SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_STENCIL_UINT8`: (Direct3D 12
  *   only) if the texture usage is SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET,
  *   clear the texture to a stencil of this value. Defaults to zero.
- * - `SDL_PROP_GPU_CREATETEXTURE_NAME_STRING`: a name that can be displayed in debugging tools.
+ * - `SDL_PROP_GPU_TEXTURE_CREATE_NAME_STRING`: a name that can be displayed in debugging tools.
  *
  * \param device a GPU Context.
  * \param createinfo a struct describing the state of the texture to create.
@@ -2460,7 +2460,7 @@ extern SDL_DECLSPEC SDL_GPUTexture *SDLCALL SDL_CreateGPUTexture(
 #define SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_A_FLOAT       "SDL.gpu.createtexture.d3d12.clear.a"
 #define SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_DEPTH_FLOAT   "SDL.gpu.createtexture.d3d12.clear.depth"
 #define SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_STENCIL_UINT8 "SDL.gpu.createtexture.d3d12.clear.stencil"
-#define SDL_PROP_GPU_CREATETEXTURE_NAME_STRING               "SDL.gpu.createtexture.name"
+#define SDL_PROP_GPU_TEXTURE_CREATE_NAME_STRING              "SDL.gpu.texture.create.name"
 
 /**
  * Creates a buffer object to be used in graphics or compute workflows.
@@ -2478,7 +2478,7 @@ extern SDL_DECLSPEC SDL_GPUTexture *SDLCALL SDL_CreateGPUTexture(
  *
  * There are optional properties that can be provided through `props`. These are the supported properties:
  *
- * - `SDL_PROP_GPU_CREATEBUFFER_NAME_STRING`: a name that can be displayed in debugging tools.
+ * - `SDL_PROP_GPU_BUFFER_CREATE_NAME_STRING`: a name that can be displayed in debugging tools.
  *
  * \param device a GPU Context.
  * \param createinfo a struct describing the state of the buffer to create.
@@ -2504,7 +2504,7 @@ extern SDL_DECLSPEC SDL_GPUBuffer *SDLCALL SDL_CreateGPUBuffer(
     SDL_GPUDevice *device,
     const SDL_GPUBufferCreateInfo *createinfo);
 
-#define SDL_PROP_GPU_CREATEBUFFER_NAME_STRING "SDL.gpu.createbuffer.name"
+#define SDL_PROP_GPU_BUFFER_CREATE_NAME_STRING "SDL.gpu.buffer.create.name"
 
 /**
  * Creates a transfer buffer to be used when uploading to or downloading from
@@ -2515,7 +2515,7 @@ extern SDL_DECLSPEC SDL_GPUBuffer *SDLCALL SDL_CreateGPUBuffer(
  *
  * There are optional properties that can be provided through `props`. These are the supported properties:
  *
- * - `SDL_PROP_GPU_CREATETRANSFERBUFFER_NAME_STRING`: a name that can be displayed in debugging tools.
+ * - `SDL_PROP_GPU_TRANSFERBUFFER_CREATE_NAME_STRING`: a name that can be displayed in debugging tools.
  *
  * \param device a GPU Context.
  * \param createinfo a struct describing the state of the transfer buffer to
@@ -2535,14 +2535,14 @@ extern SDL_DECLSPEC SDL_GPUTransferBuffer *SDLCALL SDL_CreateGPUTransferBuffer(
     SDL_GPUDevice *device,
     const SDL_GPUTransferBufferCreateInfo *createinfo);
 
-#define SDL_PROP_GPU_CREATETRANSFERBUFFER_NAME_STRING "SDL.gpu.createtransferbuffer.name"
+#define SDL_PROP_GPU_TRANSFERBUFFER_CREATE_NAME_STRING "SDL.gpu.transferbuffer.create.name"
 
 /* Debug Naming */
 
 /**
  * Sets an arbitrary string constant to label a buffer.
  *
- * It is recommended to use SDL_PROP_GPU_CREATEBUFFER_NAME_STRING with SDL_CreateGPUBuffer instead of this function to avoid thread safety issues.
+ * It is recommended to use SDL_PROP_GPU_BUFFER_CREATE_NAME_STRING with SDL_CreateGPUBuffer instead of this function to avoid thread safety issues.
  *
  * \param device a GPU Context.
  * \param buffer a buffer to attach the name to.
@@ -2562,7 +2562,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_SetGPUBufferName(
 /**
  * Sets an arbitrary string constant to label a texture.
  *
- * It is recommended to use SDL_PROP_GPU_CREATETEXTURE_NAME_STRING with SDL_CreateGPUTexture instead of this function to avoid thread safety issues.
+ * It is recommended to use SDL_PROP_GPU_TEXTURE_CREATE_NAME_STRING with SDL_CreateGPUTexture instead of this function to avoid thread safety issues.
  *
  * \param device a GPU Context.
  * \param texture a texture to attach the name to.

--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -2542,7 +2542,7 @@ extern SDL_DECLSPEC SDL_GPUTransferBuffer *SDLCALL SDL_CreateGPUTransferBuffer(
 /**
  * Sets an arbitrary string constant to label a buffer.
  *
- * It is recommended to use SDL_PROP_GPU_BUFFER_CREATE_NAME_STRING with SDL_CreateGPUBuffer instead of this function to avoid thread safety issues.
+ * You should use SDL_PROP_GPU_BUFFER_CREATE_NAME_STRING with SDL_CreateGPUBuffer instead of this function to avoid thread safety issues.
  *
  * \param device a GPU Context.
  * \param buffer a buffer to attach the name to.
@@ -2562,7 +2562,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_SetGPUBufferName(
 /**
  * Sets an arbitrary string constant to label a texture.
  *
- * It is recommended to use SDL_PROP_GPU_TEXTURE_CREATE_NAME_STRING with SDL_CreateGPUTexture instead of this function to avoid thread safety issues.
+ * You should use SDL_PROP_GPU_TEXTURE_CREATE_NAME_STRING with SDL_CreateGPUTexture instead of this function to avoid thread safety issues.
  *
  * \param device a GPU Context.
  * \param texture a texture to attach the name to.

--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -2437,7 +2437,7 @@ extern SDL_DECLSPEC SDL_GPUTexture *SDLCALL SDL_CreateGPUTexture(
 #define SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_A_FLOAT       "SDL.gpu.createtexture.d3d12.clear.a"
 #define SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_DEPTH_FLOAT   "SDL.gpu.createtexture.d3d12.clear.depth"
 #define SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_STENCIL_UINT8 "SDL.gpu.createtexture.d3d12.clear.stencil"
-
+#define SDL_PROP_GPU_CREATETEXTURE_NAME_STRING               "SDL.gpu.createtexture.name"
 
 /**
  * Creates a buffer object to be used in graphics or compute workflows.
@@ -2478,7 +2478,7 @@ extern SDL_DECLSPEC SDL_GPUBuffer *SDLCALL SDL_CreateGPUBuffer(
     SDL_GPUDevice *device,
     const SDL_GPUBufferCreateInfo *createinfo);
 
-#define SDL_PROP_GPU_BUFFER_CREATE_NAME_STRING "SDL.gpu.buffer.create.name"
+#define SDL_PROP_GPU_CREATEBUFFER_NAME_STRING "SDL.gpu.createbuffer.name"
 
 /**
  * Creates a transfer buffer to be used when uploading to or downloading from

--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -334,7 +334,6 @@ typedef struct SDL_GPUDevice SDL_GPUDevice;
  * \since This struct is available since SDL 3.1.3
  *
  * \sa SDL_CreateGPUBuffer
- * \sa SDL_SetGPUBufferName
  * \sa SDL_UploadToGPUBuffer
  * \sa SDL_DownloadFromGPUBuffer
  * \sa SDL_CopyGPUBufferToBuffer
@@ -374,7 +373,6 @@ typedef struct SDL_GPUTransferBuffer SDL_GPUTransferBuffer;
  * \since This struct is available since SDL 3.1.3
  *
  * \sa SDL_CreateGPUTexture
- * \sa SDL_SetGPUTextureName
  * \sa SDL_UploadToGPUTexture
  * \sa SDL_DownloadFromGPUTexture
  * \sa SDL_CopyGPUTextureToTexture
@@ -2247,6 +2245,10 @@ extern SDL_DECLSPEC SDL_GPUShaderFormat SDLCALL SDL_GetGPUShaderFormats(SDL_GPUD
  * - [[texture]]: Sampled textures, followed by read-only storage textures,
  *   followed by read-write storage textures
  *
+ * There are optional properties that can be provided through `props`. These are the supported properties:
+ *
+ * - `SDL_PROP_GPU_CREATECOMPUTEPIPELINE_NAME_STRING`: a name that can be displayed in debugging tools.
+ *
  * \param device a GPU Context.
  * \param createinfo a struct describing the state of the compute pipeline to
  *                   create.
@@ -2266,6 +2268,10 @@ extern SDL_DECLSPEC SDL_GPUComputePipeline *SDLCALL SDL_CreateGPUComputePipeline
 
 /**
  * Creates a pipeline object to be used in a graphics workflow.
+ *
+ * There are optional properties that can be provided through `props`. These are the supported properties:
+ *
+ * - `SDL_PROP_GPU_CREATEGRAPHICSPIPELINE_NAME_STRING`: a name that can be displayed in debugging tools.
  *
  * \param device a GPU Context.
  * \param createinfo a struct describing the state of the graphics pipeline to
@@ -2288,6 +2294,10 @@ extern SDL_DECLSPEC SDL_GPUGraphicsPipeline *SDLCALL SDL_CreateGPUGraphicsPipeli
 /**
  * Creates a sampler object to be used when binding textures in a graphics
  * workflow.
+ *
+ * There are optional properties that can be provided through `props`. These are the supported properties:
+ *
+ * - `SDL_PROP_GPU_CREATESAMPLER_NAME_STRING`: a name that can be displayed in debugging tools.
  *
  * \param device a GPU Context.
  * \param createinfo a struct describing the state of the sampler to create.
@@ -2363,6 +2373,10 @@ extern SDL_DECLSPEC SDL_GPUSampler *SDLCALL SDL_CreateGPUSampler(
  * SDL_PROP_GPU_DEVICE_CREATE_D3D12_SEMANTIC_NAME_STRING with
  * SDL_CreateGPUDeviceWithProperties().
  *
+ * There are optional properties that can be provided through `props`. These are the supported properties:
+ *
+ * - `SDL_PROP_GPU_CREATESHADER_NAME_STRING`: a name that can be displayed in debugging tools.
+ *
  * \param device a GPU Context.
  * \param createinfo a struct describing the state of the shader to create.
  * \returns a shader object on success, or NULL on failure; call
@@ -2416,6 +2430,7 @@ extern SDL_DECLSPEC SDL_GPUShader *SDLCALL SDL_CreateGPUShader(
  * - `SDL_PROP_GPU_CREATETEXTURE_D3D12_CLEAR_STENCIL_UINT8`: (Direct3D 12
  *   only) if the texture usage is SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET,
  *   clear the texture to a stencil of this value. Defaults to zero.
+ * - `SDL_PROP_GPU_CREATETEXTURE_NAME_STRING`: a name that can be displayed in debugging tools.
  *
  * \param device a GPU Context.
  * \param createinfo a struct describing the state of the texture to create.
@@ -2461,6 +2476,10 @@ extern SDL_DECLSPEC SDL_GPUTexture *SDLCALL SDL_CreateGPUTexture(
  * [this blog post](https://moonside.games/posts/sdl-gpu-concepts-cycling/)
  * .
  *
+ * There are optional properties that can be provided through `props`. These are the supported properties:
+ *
+ * - `SDL_PROP_GPU_CREATEBUFFER_NAME_STRING`: a name that can be displayed in debugging tools.
+ *
  * \param device a GPU Context.
  * \param createinfo a struct describing the state of the buffer to create.
  * \returns a buffer object on success, or NULL on failure; call
@@ -2468,7 +2487,6 @@ extern SDL_DECLSPEC SDL_GPUTexture *SDLCALL SDL_CreateGPUTexture(
  *
  * \since This function is available since SDL 3.1.3.
  *
- * \sa SDL_SetGPUBufferName
  * \sa SDL_UploadToGPUBuffer
  * \sa SDL_DownloadFromGPUBuffer
  * \sa SDL_CopyGPUBufferToBuffer
@@ -2495,6 +2513,10 @@ extern SDL_DECLSPEC SDL_GPUBuffer *SDLCALL SDL_CreateGPUBuffer(
  * Download buffers can be particularly expensive to create, so it is good
  * practice to reuse them if data will be downloaded regularly.
  *
+ * There are optional properties that can be provided through `props`. These are the supported properties:
+ *
+ * - `SDL_PROP_GPU_CREATETRANSFERBUFFER_NAME_STRING`: a name that can be displayed in debugging tools.
+ *
  * \param device a GPU Context.
  * \param createinfo a struct describing the state of the transfer buffer to
  *                   create.
@@ -2520,16 +2542,17 @@ extern SDL_DECLSPEC SDL_GPUTransferBuffer *SDLCALL SDL_CreateGPUTransferBuffer(
 /**
  * Sets an arbitrary string constant to label a buffer.
  *
- * Useful for debugging.
+ * It is recommended to use SDL_PROP_GPU_CREATEBUFFER_NAME_STRING with SDL_CreateGPUBuffer instead of this function to avoid thread safety issues.
  *
  * \param device a GPU Context.
  * \param buffer a buffer to attach the name to.
  * \param text a UTF-8 string constant to mark as the name of the buffer.
  *
- * \threadsafety This function is not thread safe, you must synchronize calls
- *               to this function.
+ * \threadsafety This function is not thread safe, you must make sure the buffer is not simultaneously used by any other thread.
  *
  * \since This function is available since SDL 3.1.3.
+ *
+ * \sa SDL_CreateGPUBuffer
  */
 extern SDL_DECLSPEC void SDLCALL SDL_SetGPUBufferName(
     SDL_GPUDevice *device,
@@ -2539,16 +2562,17 @@ extern SDL_DECLSPEC void SDLCALL SDL_SetGPUBufferName(
 /**
  * Sets an arbitrary string constant to label a texture.
  *
- * Useful for debugging.
+ * It is recommended to use SDL_PROP_GPU_CREATETEXTURE_NAME_STRING with SDL_CreateGPUTexture instead of this function to avoid thread safety issues.
  *
  * \param device a GPU Context.
  * \param texture a texture to attach the name to.
  * \param text a UTF-8 string constant to mark as the name of the texture.
  *
- * \threadsafety This function is not thread safe, you must synchronize calls
- *               to this function.
+ * \threadsafety This function is not thread safe, you must make sure the texture is not simultaneously used by any other thread.
  *
  * \since This function is available since SDL 3.1.3.
+ *
+ * \sa SDL_CreateGPUTexture
  */
 extern SDL_DECLSPEC void SDLCALL SDL_SetGPUTextureName(
     SDL_GPUDevice *device,

--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -2505,6 +2505,8 @@ extern SDL_DECLSPEC SDL_GPUTransferBuffer *SDLCALL SDL_CreateGPUTransferBuffer(
     SDL_GPUDevice *device,
     const SDL_GPUTransferBufferCreateInfo *createinfo);
 
+#define SDL_PROP_GPU_CREATETRANSFERBUFFER_NAME_STRING "SDL.gpu.createtransferbuffer.name"
+
 /* Debug Naming */
 
 /**

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -1055,7 +1055,7 @@ SDL_GPUBuffer *SDL_CreateGPUBuffer(
         return NULL;
     }
 
-    const char *debugName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATEBUFFER_NAME_STRING, NULL);
+    const char *debugName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_BUFFER_CREATE_NAME_STRING, NULL);
 
     return device->CreateBuffer(
         device->driverData,
@@ -1074,7 +1074,7 @@ SDL_GPUTransferBuffer *SDL_CreateGPUTransferBuffer(
         return NULL;
     }
 
-    const char *debugName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATETRANSFERBUFFER_NAME_STRING, NULL);
+    const char *debugName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_TRANSFERBUFFER_CREATE_NAME_STRING, NULL);
 
     return device->CreateTransferBuffer(
         device->driverData,

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -1055,10 +1055,13 @@ SDL_GPUBuffer *SDL_CreateGPUBuffer(
         return NULL;
     }
 
+    char *debugName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_BUFFER_CREATE_NAME_STRING, NULL);
+
     return device->CreateBuffer(
         device->driverData,
         createinfo->usage,
-        createinfo->size);
+        createinfo->size,
+        debugName);
 }
 
 SDL_GPUTransferBuffer *SDL_CreateGPUTransferBuffer(

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -1074,10 +1074,13 @@ SDL_GPUTransferBuffer *SDL_CreateGPUTransferBuffer(
         return NULL;
     }
 
+    const char *debugName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATETRANSFERBUFFER_NAME_STRING, NULL);
+
     return device->CreateTransferBuffer(
         device->driverData,
         createinfo->usage,
-        createinfo->size);
+        createinfo->size,
+        debugName);
 }
 
 // Debug Naming

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -1055,7 +1055,7 @@ SDL_GPUBuffer *SDL_CreateGPUBuffer(
         return NULL;
     }
 
-    char *debugName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_BUFFER_CREATE_NAME_STRING, NULL);
+    const char *debugName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATEBUFFER_NAME_STRING, NULL);
 
     return device->CreateBuffer(
         device->driverData,

--- a/src/gpu/SDL_sysgpu.h
+++ b/src/gpu/SDL_sysgpu.h
@@ -474,7 +474,8 @@ struct SDL_GPUDevice
     SDL_GPUBuffer *(*CreateBuffer)(
         SDL_GPURenderer *driverData,
         SDL_GPUBufferUsageFlags usageFlags,
-        Uint32 size);
+        Uint32 size,
+        char *debugName);
 
     SDL_GPUTransferBuffer *(*CreateTransferBuffer)(
         SDL_GPURenderer *driverData,

--- a/src/gpu/SDL_sysgpu.h
+++ b/src/gpu/SDL_sysgpu.h
@@ -480,7 +480,8 @@ struct SDL_GPUDevice
     SDL_GPUTransferBuffer *(*CreateTransferBuffer)(
         SDL_GPURenderer *driverData,
         SDL_GPUTransferBufferUsage usage,
-        Uint32 size);
+        Uint32 size,
+        const char *debugName);
 
     // Debug Naming
 

--- a/src/gpu/SDL_sysgpu.h
+++ b/src/gpu/SDL_sysgpu.h
@@ -475,7 +475,7 @@ struct SDL_GPUDevice
         SDL_GPURenderer *driverData,
         SDL_GPUBufferUsageFlags usageFlags,
         Uint32 size,
-        char *debugName);
+        const char *debugName);
 
     SDL_GPUTransferBuffer *(*CreateTransferBuffer)(
         SDL_GPURenderer *driverData,

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -2785,11 +2785,11 @@ static SDL_GPUComputePipeline *D3D12_CreateComputePipeline(
     computePipeline->numUniformBuffers = createinfo->num_uniform_buffers;
     SDL_SetAtomicInt(&computePipeline->referenceCount, 0);
 
-    if (renderer->debug_mode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATECOMPUTEPIPELINE_NAME_STRING)) {
+    if (renderer->debug_mode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_COMPUTEPIPELINE_CREATE_NAME_STRING)) {
         D3D12_INTERNAL_SetPipelineStateName(
             renderer,
             computePipeline->pipelineState,
-            SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATECOMPUTEPIPELINE_NAME_STRING, NULL));
+            SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_COMPUTEPIPELINE_CREATE_NAME_STRING, NULL));
     }
 
     return (SDL_GPUComputePipeline *)computePipeline;
@@ -3077,11 +3077,11 @@ static SDL_GPUGraphicsPipeline *D3D12_CreateGraphicsPipeline(
 
     SDL_SetAtomicInt(&pipeline->referenceCount, 0);
 
-    if (renderer->debug_mode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATEGRAPHICSPIPELINE_NAME_STRING)) {
+    if (renderer->debug_mode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_GRAPHICSPIPELINE_CREATE_NAME_STRING)) {
         D3D12_INTERNAL_SetPipelineStateName(
             renderer,
             pipeline->pipelineState,
-            SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATEGRAPHICSPIPELINE_NAME_STRING, NULL));
+            SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_GRAPHICSPIPELINE_CREATE_NAME_STRING, NULL));
     }
 
     return (SDL_GPUGraphicsPipeline *)pipeline;

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -1980,6 +1980,29 @@ static bool D3D12_INTERNAL_StrToWStr(
     return true;
 }
 
+static void D3D12_INTERNAL_SetPipelineStateName(
+    D3D12Renderer *renderer,
+    ID3D12PipelineState *pipelineState,
+    const char *text
+) {
+    wchar_t wstr[256];
+    Uint32 convSize;
+
+    if (renderer->debug_mode && text != NULL) {
+        if (D3D12_INTERNAL_StrToWStr(
+            renderer,
+            text,
+            wstr,
+            sizeof(wstr),
+            &convSize
+        )) {
+            ID3D12PipelineState_SetName(
+                pipelineState,
+                wstr);
+        }
+    }
+}
+
 static void D3D12_INTERNAL_SetResourceName(
     D3D12Renderer *renderer,
     ID3D12Resource *resource,
@@ -2839,6 +2862,13 @@ static SDL_GPUComputePipeline *D3D12_CreateComputePipeline(
     computePipeline->numUniformBuffers = createinfo->num_uniform_buffers;
     SDL_SetAtomicInt(&computePipeline->referenceCount, 0);
 
+    if (renderer->debug_mode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATECOMPUTEPIPELINE_NAME_STRING)) {
+        D3D12_INTERNAL_SetPipelineStateName(
+            renderer,
+            computePipeline->pipelineState,
+            SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATECOMPUTEPIPELINE_NAME_STRING, NULL));
+    }
+
     return (SDL_GPUComputePipeline *)computePipeline;
 }
 
@@ -3123,6 +3153,14 @@ static SDL_GPUGraphicsPipeline *D3D12_CreateGraphicsPipeline(
     pipeline->fragmentUniformBufferCount = fragShader->numUniformBuffers;
 
     SDL_SetAtomicInt(&pipeline->referenceCount, 0);
+
+    if (renderer->debug_mode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATEGRAPHICSPIPELINE_NAME_STRING)) {
+        D3D12_INTERNAL_SetPipelineStateName(
+            renderer,
+            pipeline->pipelineState,
+            SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATEGRAPHICSPIPELINE_NAME_STRING, NULL));
+    }
+
     return (SDL_GPUGraphicsPipeline *)pipeline;
 }
 

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -3559,7 +3559,11 @@ static SDL_GPUTexture *D3D12_CreateTexture(
         return NULL;
     }
 
+    // Copy properties so we don't lose information when the client destroys them
     container->header.info = *createinfo;
+    container->header.info.props = SDL_CreateProperties();
+    SDL_CopyProperties(createinfo->props, container->header.info.props);
+
     container->textureCapacity = 1;
     container->textureCount = 1;
     container->textures = (D3D12Texture **)SDL_calloc(

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -2028,7 +2028,7 @@ static void D3D12_InsertDebugLabel(
         d3d12CommandBuffer->graphicsCommandList,
         0,
         wchar_text,
-        SDL_wcslen(wchar_text));
+        (UINT)SDL_wcslen(wchar_text));
 
     SDL_free(wchar_text);
 }
@@ -2044,7 +2044,7 @@ static void D3D12_PushDebugGroup(
         d3d12CommandBuffer->graphicsCommandList,
         0,
         wchar_text,
-        SDL_wcslen(wchar_text));
+        (UINT)SDL_wcslen(wchar_text));
 
     SDL_free(wchar_text);
 }

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -3829,14 +3829,15 @@ static SDL_GPUBuffer *D3D12_CreateBuffer(
 static SDL_GPUTransferBuffer *D3D12_CreateTransferBuffer(
     SDL_GPURenderer *driverData,
     SDL_GPUTransferBufferUsage usage,
-    Uint32 size)
+    Uint32 size,
+    const char *debugName)
 {
     return (SDL_GPUTransferBuffer *)D3D12_INTERNAL_CreateBufferContainer(
         (D3D12Renderer *)driverData,
         0,
         size,
         usage == SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD ? D3D12_BUFFER_TYPE_UPLOAD : D3D12_BUFFER_TYPE_DOWNLOAD,
-        NULL);
+        debugName);
 }
 
 // Disposal

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -3206,6 +3206,9 @@ static SDL_GPUSampler *D3D12_CreateSampler(
 
     sampler->createInfo = *createinfo;
     SDL_SetAtomicInt(&sampler->referenceCount, 0);
+
+    // Ignore name property because it is not applicable to D3D12.
+
     return (SDL_GPUSampler *)sampler;
 }
 
@@ -3242,6 +3245,8 @@ static SDL_GPUShader *D3D12_CreateShader(
 
     shader->bytecode = bytecode;
     shader->bytecodeSize = bytecodeSize;
+
+    // Ignore name property because it is not applicable to D3D12.
 
     return (SDL_GPUShader *)shader;
 }

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -3498,8 +3498,8 @@ static SDL_GPUTexture *D3D12_CreateTexture(
     }
 
     container->debugName = NULL;
-    if (SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATETEXTURE_NAME_STRING)) {
-        container->debugName = SDL_strdup(SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATETEXTURE_NAME_STRING, NULL));
+    if (SDL_HasProperty(createinfo->props, SDL_PROP_GPU_TEXTURE_CREATE_NAME_STRING)) {
+        container->debugName = SDL_strdup(SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_TEXTURE_CREATE_NAME_STRING, NULL));
     }
 
     container->canBeCycled = true;

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -1502,7 +1502,12 @@ static SDL_GPUTexture *METAL_CreateTexture(
 
         container = SDL_calloc(1, sizeof(MetalTextureContainer));
         container->canBeCycled = 1;
+
+        // Copy properties so we don't lose information when the client destroys them
         container->header.info = *createinfo;
+        container->header.info.props = SDL_CreateProperties();
+        SDL_CopyProperties(createinfo->props, container->header.info.props);
+
         container->activeTexture = texture;
         container->textureCapacity = 1;
         container->textureCount = 1;

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -4419,7 +4419,6 @@ static SDL_GPUDevice *METAL_CreateDevice(bool debugMode, bool preferLowPower, SD
 
 #ifdef SDL_PLATFORM_MACOS
         hasHardwareSupport = true;
-        /*
         if (@available(macOS 10.15, *)) {
             hasHardwareSupport = [device supportsFamily:MTLGPUFamilyMac2];
         } else if (@available(macOS 10.14, *)) {
@@ -4429,7 +4428,6 @@ static SDL_GPUDevice *METAL_CreateDevice(bool debugMode, bool preferLowPower, SD
         if (@available(iOS 13.0, tvOS 13.0, *)) {
             hasHardwareSupport = [device supportsFamily:MTLGPUFamilyApple3];
         }
-        */
 #endif
 
         if (!hasHardwareSupport) {

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -1046,8 +1046,8 @@ static SDL_GPUComputePipeline *METAL_CreateComputePipeline(
         MTLComputePipelineDescriptor *descriptor = [MTLComputePipelineDescriptor new];
         descriptor.computeFunction = libraryFunction.function;
 
-        if (renderer->debugMode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATECOMPUTEPIPELINE_NAME_STRING)) {
-            const char *name = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATECOMPUTEPIPELINE_NAME_STRING, NULL);
+        if (renderer->debugMode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_COMPUTEPIPELINE_CREATE_NAME_STRING)) {
+            const char *name = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_COMPUTEPIPELINE_CREATE_NAME_STRING, NULL);
             descriptor.label = @(name);
         }
 
@@ -1191,8 +1191,8 @@ static SDL_GPUGraphicsPipeline *METAL_CreateGraphicsPipeline(
             pipelineDescriptor.vertexDescriptor = vertexDescriptor;
         }
 
-        if (renderer->debugMode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATEGRAPHICSPIPELINE_NAME_STRING)) {
-            const char *name = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATEGRAPHICSPIPELINE_NAME_STRING, NULL);
+        if (renderer->debugMode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_GRAPHICSPIPELINE_CREATE_NAME_STRING)) {
+            const char *name = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_GRAPHICSPIPELINE_CREATE_NAME_STRING, NULL);
             pipelineDescriptor.label = @(name);
         }
 
@@ -1362,8 +1362,8 @@ static SDL_GPUSampler *METAL_CreateSampler(
         samplerDesc.maxAnisotropy = (NSUInteger)((createinfo->enable_anisotropy) ? createinfo->max_anisotropy : 1);
         samplerDesc.compareFunction = (createinfo->enable_compare) ? SDLToMetal_CompareOp[createinfo->compare_op] : MTLCompareFunctionAlways;
 
-        if (renderer->debugMode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATESAMPLER_NAME_STRING)) {
-            const char *name = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATESAMPLER_NAME_STRING, NULL);
+        if (renderer->debugMode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_SAMPLER_CREATE_NAME_STRING)) {
+            const char *name = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_SAMPLER_CREATE_NAME_STRING, NULL);
             samplerDesc.label = @(name);
         }
 
@@ -1468,8 +1468,8 @@ static MetalTexture *METAL_INTERNAL_CreateTexture(
     metalTexture->handle = texture;
     SDL_SetAtomicInt(&metalTexture->referenceCount, 0);
 
-    if (renderer->debugMode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATETEXTURE_NAME_STRING)) {
-        metalTexture->handle.label = @(SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATETEXTURE_NAME_STRING, NULL));
+    if (renderer->debugMode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_TEXTURE_CREATE_NAME_STRING)) {
+        metalTexture->handle.label = @(SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_TEXTURE_CREATE_NAME_STRING, NULL));
     }
 
     return metalTexture;

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -1045,7 +1045,7 @@ static SDL_GPUComputePipeline *METAL_CreateComputePipeline(
 
         MTLComputePipelineDescriptor *descriptor = [MTLComputePipelineDescriptor new];
         descriptor.computeFunction = libraryFunction.function;
-        descriptor.label = @("Compute Pipeline"); // label can't be nil for some reason
+
         if (renderer->debugMode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATECOMPUTEPIPELINE_NAME_STRING)) {
             const char *name = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATECOMPUTEPIPELINE_NAME_STRING, NULL);
             descriptor.label = @(name);
@@ -1191,7 +1191,6 @@ static SDL_GPUGraphicsPipeline *METAL_CreateGraphicsPipeline(
             pipelineDescriptor.vertexDescriptor = vertexDescriptor;
         }
 
-        pipelineDescriptor.label = @("Graphics Pipeline"); // label can't be nil for some reason
         if (renderer->debugMode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATEGRAPHICSPIPELINE_NAME_STRING)) {
             const char *name = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATEGRAPHICSPIPELINE_NAME_STRING, NULL);
             pipelineDescriptor.label = @(name);
@@ -1362,6 +1361,11 @@ static SDL_GPUSampler *METAL_CreateSampler(
         samplerDesc.lodMaxClamp = createinfo->max_lod;
         samplerDesc.maxAnisotropy = (NSUInteger)((createinfo->enable_anisotropy) ? createinfo->max_anisotropy : 1);
         samplerDesc.compareFunction = (createinfo->enable_compare) ? SDLToMetal_CompareOp[createinfo->compare_op] : MTLCompareFunctionAlways;
+
+        if (renderer->debugMode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATESAMPLER_NAME_STRING)) {
+            const char *name = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATESAMPLER_NAME_STRING, NULL);
+            samplerDesc.label = @(name);
+        }
 
         sampler = [renderer->device newSamplerStateWithDescriptor:samplerDesc];
         if (sampler == NULL) {

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -1520,8 +1520,8 @@ static SDL_GPUTexture *METAL_CreateTexture(
         container->textures[0] = texture;
         container->debugName = NULL;
 
-        if (SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATETEXTURE_NAME_STRING)) {
-            container->debugName = SDL_strdup(SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATETEXTURE_NAME_STRING, NULL));
+        if (SDL_HasProperty(createinfo->props, SDL_PROP_GPU_TEXTURE_CREATE_NAME_STRING)) {
+            container->debugName = SDL_strdup(SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_TEXTURE_CREATE_NAME_STRING, NULL));
         }
 
         return (SDL_GPUTexture *)container;

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -5851,13 +5851,6 @@ static void VULKAN_INTERNAL_CycleActiveBuffer(
     container->bufferCount += 1;
 
     container->activeBuffer = buffer;
-
-    if (renderer->debugMode && renderer->supportsDebugUtils && container->debugName != NULL) {
-        VULKAN_INTERNAL_SetBufferName(
-            renderer,
-            container->activeBuffer,
-            container->debugName);
-    }
 }
 
 static void VULKAN_INTERNAL_CycleActiveTexture(
@@ -5898,13 +5891,6 @@ static void VULKAN_INTERNAL_CycleActiveTexture(
     container->textureCount += 1;
 
     container->activeTexture = texture;
-
-    if (renderer->debugMode && renderer->supportsDebugUtils && container->debugName != NULL) {
-        VULKAN_INTERNAL_SetTextureName(
-            renderer,
-            container->activeTexture,
-            container->debugName);
-    }
 }
 
 static VulkanBuffer *VULKAN_INTERNAL_PrepareBufferForWrite(
@@ -10707,18 +10693,6 @@ static bool VULKAN_INTERNAL_DefragmentMemory(
                 // copy subresource if necessary
                 srcSubresource = &currentRegion->vulkanTexture->subresources[subresourceIndex];
                 dstSubresource = &newTexture->subresources[subresourceIndex];
-
-                // Set debug name if it exists
-                if (
-                    renderer->debugMode &&
-                    renderer->supportsDebugUtils &&
-                    srcSubresource->parent->container != NULL &&
-                    srcSubresource->parent->container->debugName != NULL) {
-                    VULKAN_INTERNAL_SetTextureName(
-                        renderer,
-                        currentRegion->vulkanTexture,
-                        srcSubresource->parent->container->debugName);
-                }
 
                 VULKAN_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
                     renderer,

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -6506,11 +6506,11 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
 
     SDL_SetAtomicInt(&graphicsPipeline->referenceCount, 0);
 
-    if (renderer->debugMode && renderer->supportsDebugUtils && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATEGRAPHICSPIPELINE_NAME_STRING)) {
+    if (renderer->debugMode && renderer->supportsDebugUtils && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_GRAPHICSPIPELINE_CREATE_NAME_STRING)) {
         VkDebugUtilsObjectNameInfoEXT nameInfo;
         nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
         nameInfo.pNext = NULL;
-        nameInfo.pObjectName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATEGRAPHICSPIPELINE_NAME_STRING, NULL);
+        nameInfo.pObjectName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_GRAPHICSPIPELINE_CREATE_NAME_STRING, NULL);
         nameInfo.objectType = VK_OBJECT_TYPE_PIPELINE;
         nameInfo.objectHandle = (uint64_t)graphicsPipeline->pipeline;
 
@@ -6600,11 +6600,11 @@ static SDL_GPUComputePipeline *VULKAN_CreateComputePipeline(
 
     SDL_SetAtomicInt(&vulkanComputePipeline->referenceCount, 0);
 
-    if (renderer->debugMode && renderer->supportsDebugUtils && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATECOMPUTEPIPELINE_NAME_STRING)) {
+    if (renderer->debugMode && renderer->supportsDebugUtils && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_COMPUTEPIPELINE_CREATE_NAME_STRING)) {
         VkDebugUtilsObjectNameInfoEXT nameInfo;
         nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
         nameInfo.pNext = NULL;
-        nameInfo.pObjectName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATECOMPUTEPIPELINE_NAME_STRING, NULL);
+        nameInfo.pObjectName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_COMPUTEPIPELINE_CREATE_NAME_STRING, NULL);
         nameInfo.objectType = VK_OBJECT_TYPE_PIPELINE;
         nameInfo.objectHandle = (uint64_t)vulkanComputePipeline->pipeline;
 
@@ -6657,11 +6657,11 @@ static SDL_GPUSampler *VULKAN_CreateSampler(
 
     SDL_SetAtomicInt(&vulkanSampler->referenceCount, 0);
 
-    if (renderer->debugMode && renderer->supportsDebugUtils && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATESAMPLER_NAME_STRING)) {
+    if (renderer->debugMode && renderer->supportsDebugUtils && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_SAMPLER_CREATE_NAME_STRING)) {
         VkDebugUtilsObjectNameInfoEXT nameInfo;
         nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
         nameInfo.pNext = NULL;
-        nameInfo.pObjectName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATESAMPLER_NAME_STRING, NULL);
+        nameInfo.pObjectName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_SAMPLER_CREATE_NAME_STRING, NULL);
         nameInfo.objectType = VK_OBJECT_TYPE_SAMPLER;
         nameInfo.objectHandle = (uint64_t)vulkanSampler->sampler;
 
@@ -6713,11 +6713,11 @@ static SDL_GPUShader *VULKAN_CreateShader(
 
     SDL_SetAtomicInt(&vulkanShader->referenceCount, 0);
 
-    if (renderer->debugMode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATESHADER_NAME_STRING)) {
+    if (renderer->debugMode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_SHADER_CREATE_NAME_STRING)) {
         VkDebugUtilsObjectNameInfoEXT nameInfo;
         nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
         nameInfo.pNext = NULL;
-        nameInfo.pObjectName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATESHADER_NAME_STRING, NULL);
+        nameInfo.pObjectName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_SHADER_CREATE_NAME_STRING, NULL);
         nameInfo.objectType = VK_OBJECT_TYPE_SHADER_MODULE;
         nameInfo.objectHandle = (uint64_t)vulkanShader->shaderModule;
 

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -6520,6 +6520,19 @@ static SDL_GPUGraphicsPipeline *VULKAN_CreateGraphicsPipeline(
 
     SDL_SetAtomicInt(&graphicsPipeline->referenceCount, 0);
 
+    if (renderer->debugMode && renderer->supportsDebugUtils && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATEGRAPHICSPIPELINE_NAME_STRING)) {
+        VkDebugUtilsObjectNameInfoEXT nameInfo;
+        nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+        nameInfo.pNext = NULL;
+        nameInfo.pObjectName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATEGRAPHICSPIPELINE_NAME_STRING, NULL);
+        nameInfo.objectType = VK_OBJECT_TYPE_PIPELINE;
+        nameInfo.objectHandle = (uint64_t)graphicsPipeline->pipeline;
+
+        renderer->vkSetDebugUtilsObjectNameEXT(
+            renderer->logicalDevice,
+            &nameInfo);
+    }
+
     return (SDL_GPUGraphicsPipeline *)graphicsPipeline;
 }
 
@@ -6600,6 +6613,19 @@ static SDL_GPUComputePipeline *VULKAN_CreateComputePipeline(
     }
 
     SDL_SetAtomicInt(&vulkanComputePipeline->referenceCount, 0);
+
+    if (renderer->debugMode && renderer->supportsDebugUtils && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATECOMPUTEPIPELINE_NAME_STRING)) {
+        VkDebugUtilsObjectNameInfoEXT nameInfo;
+        nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+        nameInfo.pNext = NULL;
+        nameInfo.pObjectName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATECOMPUTEPIPELINE_NAME_STRING, NULL);
+        nameInfo.objectType = VK_OBJECT_TYPE_PIPELINE;
+        nameInfo.objectHandle = (uint64_t)vulkanComputePipeline->pipeline;
+
+        renderer->vkSetDebugUtilsObjectNameEXT(
+            renderer->logicalDevice,
+            &nameInfo);
+    }
 
     return (SDL_GPUComputePipeline *)vulkanComputePipeline;
 }

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -5784,11 +5784,11 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
     }
 
     // Set debug name if applicable
-    if (renderer->debugMode && renderer->supportsDebugUtils && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATETEXTURE_NAME_STRING)) {
+    if (renderer->debugMode && renderer->supportsDebugUtils && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_TEXTURE_CREATE_NAME_STRING)) {
         VkDebugUtilsObjectNameInfoEXT nameInfo;
         nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
         nameInfo.pNext = NULL;
-        nameInfo.pObjectName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATETEXTURE_NAME_STRING, NULL);
+        nameInfo.pObjectName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_TEXTURE_CREATE_NAME_STRING, NULL);
         nameInfo.objectType = VK_OBJECT_TYPE_IMAGE;
         nameInfo.objectHandle = (uint64_t)texture->image;
 
@@ -6772,8 +6772,8 @@ static SDL_GPUTexture *VULKAN_CreateTexture(
     container->textures[0] = container->activeTexture;
     container->debugName = NULL;
 
-    if (SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATETEXTURE_NAME_STRING)) {
-        container->debugName = SDL_strdup(SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATETEXTURE_NAME_STRING, NULL));
+    if (SDL_HasProperty(createinfo->props, SDL_PROP_GPU_TEXTURE_CREATE_NAME_STRING)) {
+        container->debugName = SDL_strdup(SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_TEXTURE_CREATE_NAME_STRING, NULL));
     }
 
     texture->container = container;

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -6657,6 +6657,19 @@ static SDL_GPUSampler *VULKAN_CreateSampler(
 
     SDL_SetAtomicInt(&vulkanSampler->referenceCount, 0);
 
+    if (renderer->debugMode && renderer->supportsDebugUtils && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATESAMPLER_NAME_STRING)) {
+        VkDebugUtilsObjectNameInfoEXT nameInfo;
+        nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+        nameInfo.pNext = NULL;
+        nameInfo.pObjectName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATESAMPLER_NAME_STRING, NULL);
+        nameInfo.objectType = VK_OBJECT_TYPE_SAMPLER;
+        nameInfo.objectHandle = (uint64_t)vulkanSampler->sampler;
+
+        renderer->vkSetDebugUtilsObjectNameEXT(
+            renderer->logicalDevice,
+            &nameInfo);
+    }
+
     return (SDL_GPUSampler *)vulkanSampler;
 }
 
@@ -6699,6 +6712,19 @@ static SDL_GPUShader *VULKAN_CreateShader(
     vulkanShader->numUniformBuffers = createinfo->num_uniform_buffers;
 
     SDL_SetAtomicInt(&vulkanShader->referenceCount, 0);
+
+    if (renderer->debugMode && SDL_HasProperty(createinfo->props, SDL_PROP_GPU_CREATESHADER_NAME_STRING)) {
+        VkDebugUtilsObjectNameInfoEXT nameInfo;
+        nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+        nameInfo.pNext = NULL;
+        nameInfo.pObjectName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_CREATESHADER_NAME_STRING, NULL);
+        nameInfo.objectType = VK_OBJECT_TYPE_SHADER_MODULE;
+        nameInfo.objectHandle = (uint64_t)vulkanShader->shaderModule;
+
+        renderer->vkSetDebugUtilsObjectNameEXT(
+            renderer->logicalDevice,
+            &nameInfo);
+    }
 
     return (SDL_GPUShader *)vulkanShader;
 }

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -6778,7 +6778,8 @@ static VulkanUniformBuffer *VULKAN_INTERNAL_CreateUniformBuffer(
 static SDL_GPUTransferBuffer *VULKAN_CreateTransferBuffer(
     SDL_GPURenderer *driverData,
     SDL_GPUTransferBufferUsage usage,
-    Uint32 size)
+    Uint32 size,
+    const char *debugName)
 {
     // We use dedicated allocations for download buffers to avoid an issue
     // where a defrag is triggered after submitting a download but before
@@ -6789,7 +6790,7 @@ static SDL_GPUTransferBuffer *VULKAN_CreateTransferBuffer(
         0,
         VULKAN_BUFFER_TYPE_TRANSFER,
         usage == SDL_GPU_TRANSFERBUFFERUSAGE_DOWNLOAD,
-        NULL);
+        debugName);
 }
 
 static void VULKAN_INTERNAL_ReleaseTexture(

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -6757,7 +6757,12 @@ static SDL_GPUTexture *VULKAN_CreateTexture(
     }
 
     container = SDL_malloc(sizeof(VulkanTextureContainer));
+
+    // Copy properties so we don't lose information when the client destroys them
     container->header.info = *createinfo;
+    container->header.info.props = SDL_CreateProperties();
+    SDL_CopyProperties(createinfo->props, container->header.info.props);
+
     container->canBeCycled = true;
     container->activeTexture = texture;
     container->textureCapacity = 1;

--- a/test/testgpu_spinning_cube.c
+++ b/test/testgpu_spinning_cube.c
@@ -538,23 +538,25 @@ init_render_state(int msaa)
 
     buffer_desc.usage = SDL_GPU_BUFFERUSAGE_VERTEX;
     buffer_desc.size = sizeof(vertex_data);
-    buffer_desc.props = 0;
+    buffer_desc.props = SDL_CreateProperties();
+    SDL_SetStringProperty(buffer_desc.props, SDL_PROP_GPU_CREATEBUFFER_NAME_STRING, "космонавт");
     render_state.buf_vertex = SDL_CreateGPUBuffer(
         gpu_device,
         &buffer_desc
     );
     CHECK_CREATE(render_state.buf_vertex, "Static vertex buffer")
-
-    SDL_SetGPUBufferName(gpu_device, render_state.buf_vertex, "космонавт");
+    SDL_DestroyProperties(buffer_desc.props);
 
     transfer_buffer_desc.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
     transfer_buffer_desc.size = sizeof(vertex_data);
-    transfer_buffer_desc.props = 0;
+    transfer_buffer_desc.props = SDL_CreateProperties();
+    SDL_SetStringProperty(transfer_buffer_desc.props, SDL_PROP_GPU_CREATETRANSFERBUFFER_NAME_STRING, "Transfer Buffer");
     buf_transfer = SDL_CreateGPUTransferBuffer(
         gpu_device,
         &transfer_buffer_desc
     );
     CHECK_CREATE(buf_transfer, "Vertex transfer buffer")
+    SDL_DestroyProperties(transfer_buffer_desc.props);
 
     /* We just need to upload the static data once. */
     map = SDL_MapGPUTransferBuffer(gpu_device, buf_transfer, false);

--- a/test/testgpu_spinning_cube.c
+++ b/test/testgpu_spinning_cube.c
@@ -539,7 +539,7 @@ init_render_state(int msaa)
     buffer_desc.usage = SDL_GPU_BUFFERUSAGE_VERTEX;
     buffer_desc.size = sizeof(vertex_data);
     buffer_desc.props = SDL_CreateProperties();
-    SDL_SetStringProperty(buffer_desc.props, SDL_PROP_GPU_CREATEBUFFER_NAME_STRING, "космонавт");
+    SDL_SetStringProperty(buffer_desc.props, SDL_PROP_GPU_BUFFER_CREATE_NAME_STRING, "космонавт");
     render_state.buf_vertex = SDL_CreateGPUBuffer(
         gpu_device,
         &buffer_desc
@@ -550,7 +550,7 @@ init_render_state(int msaa)
     transfer_buffer_desc.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
     transfer_buffer_desc.size = sizeof(vertex_data);
     transfer_buffer_desc.props = SDL_CreateProperties();
-    SDL_SetStringProperty(transfer_buffer_desc.props, SDL_PROP_GPU_CREATETRANSFERBUFFER_NAME_STRING, "Transfer Buffer");
+    SDL_SetStringProperty(transfer_buffer_desc.props, SDL_PROP_GPU_TRANSFERBUFFER_CREATE_NAME_STRING, "Transfer Buffer");
     buf_transfer = SDL_CreateGPUTransferBuffer(
         gpu_device,
         &transfer_buffer_desc


### PR DESCRIPTION
All GPU resources now implement a name property in their create functions. These are only set in debug mode.

The header docs now encourage users to use these properties instead of the `SDL_SetGPUBufferName` and `SDL_SetGPUTextureName` functions due to thread safety issues.

Resolves #11927 