### PR TITLE
Added support for custom tray icon on Windows via SDL hints.

### DIFF
--- a/src/tray/windows/SDL_tray.c
+++ b/src/tray/windows/SDL_tray.c
@@ -187,6 +187,28 @@ static wchar_t *escape_label(const char *in)
     return out;
 }
 
+static HICON load_default_icon()
+{
+    HINSTANCE hInstance = GetModuleHandle(NULL);
+    if (!hInstance) {
+        return LoadIcon(NULL, IDI_APPLICATION);
+    }
+
+    const char *hint = SDL_GetHint(SDL_HINT_WINDOWS_INTRESOURCE_ICON_SMALL);
+    if (hint && *hint) {
+        HICON icon = LoadIcon(hInstance, MAKEINTRESOURCE(SDL_atoi(hint)));
+        return icon ? icon : LoadIcon(NULL, IDI_APPLICATION);
+    }
+
+    hint = SDL_GetHint(SDL_HINT_WINDOWS_INTRESOURCE_ICON);
+    if (hint && *hint) {
+        HICON icon = LoadIcon(hInstance, MAKEINTRESOURCE(SDL_atoi(hint)));
+        return icon ? icon : LoadIcon(NULL, IDI_APPLICATION);
+    }
+
+    return LoadIcon(NULL, IDI_APPLICATION);
+}
+
 SDL_Tray *SDL_CreateTray(SDL_Surface *icon, const char *tooltip)
 {
     SDL_Tray *tray = (SDL_Tray *)SDL_malloc(sizeof(*tray));
@@ -216,12 +238,12 @@ SDL_Tray *SDL_CreateTray(SDL_Surface *icon, const char *tooltip)
         tray->nid.hIcon = CreateIconFromSurface(icon);
 
         if (!tray->nid.hIcon) {
-            tray->nid.hIcon = LoadIcon(NULL, IDI_APPLICATION);
+            tray->nid.hIcon = load_default_icon();
         }
 
         tray->icon = tray->nid.hIcon;
     } else {
-        tray->nid.hIcon = LoadIcon(NULL, IDI_APPLICATION);
+        tray->nid.hIcon = load_default_icon();
         tray->icon = tray->nid.hIcon;
     }
 
@@ -245,12 +267,12 @@ void SDL_SetTrayIcon(SDL_Tray *tray, SDL_Surface *icon)
         tray->nid.hIcon = CreateIconFromSurface(icon);
 
         if (!tray->nid.hIcon) {
-            tray->nid.hIcon = LoadIcon(NULL, IDI_APPLICATION);
+            tray->nid.hIcon = load_default_icon();
         }
 
         tray->icon = tray->nid.hIcon;
     } else {
-        tray->nid.hIcon = LoadIcon(NULL, IDI_APPLICATION);
+        tray->nid.hIcon = load_default_icon();
         tray->icon = tray->nid.hIcon;
     }
 


### PR DESCRIPTION
SDL_CreateTray now respects SDL_HINT_WINDOWS_INTRESOURCE_ICON_SMALL and SDL_HINT_WINDOWS_INTRESOURCE_ICON hints and uses the specified icon as the tray icon.

Previously `SDL_CreateTray` loaded the default application icon `LoadIcon(NULL, IDI_APPLICATION)`
if icon argument was NULL. With this change it now checks if there was a hint specified.
SDL_HINT_WINDOWS_INTRESOURCE_ICON_SMALL has priority over SDL_HINT_WINDOWS_INTRESOURCE_ICON,
because it is more suited to be a small tray icon. If loading the icon fails it loads the default application icon like before.

## Description
This change significantly simplifies setting tray icons for applications that use
icon resources in their program. These hints are already used for setting window icons,
so extending their functionality to the tray icon API would make sense.

note: `SDL_CreateTray` could also use `EnumResourceNames` to find the icon resource automatically,
(same as `SDL_RegisterApp` on Windows), but for now it is left as an opt-in behavior.
