### PR TITLE
Fix incorrect hotspot calculation for cursor positioning

### DIFF
--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -390,7 +390,7 @@ static HCURSOR GetCachedCursor(SDL_Cursor *cursor)
     }
 
     int hot_x = (int)SDL_round(data->hot_x * scale);
-    int hot_y = (int)SDL_round(data->hot_x * scale);
+    int hot_y = (int)SDL_round(data->hot_y * scale);
     hcursor = WIN_CreateHCursor(surface, hot_x, hot_y);
     if (!hcursor) {
         goto error;


### PR DESCRIPTION
## Description
Corrected the calculation of the vertical hotspot position in the `GetCachedCursor` function.

Changed the variable from `data->hot_x` to `data->hot_y` to ensure the correct vertical position of the cursor's hotspot is used when scaling.