### PR TITLE
Normalize hit testing across platforms

### DIFF
--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -1668,11 +1668,6 @@ static void Cocoa_SendMouseButtonClicks(SDL_Mouse *mouse, NSEvent *theEvent, SDL
         }
     }
 
-    if ([self processHitTest:theEvent]) {
-        SDL_SendWindowEvent(_data.window, SDL_EVENT_WINDOW_HIT_TEST, 0, 0);
-        return; // dragging, drop event.
-    }
-
     switch ([theEvent buttonNumber]) {
     case 0:
         if (([theEvent modifierFlags] & NSEventModifierFlagControl) &&
@@ -1693,6 +1688,11 @@ static void Cocoa_SendMouseButtonClicks(SDL_Mouse *mouse, NSEvent *theEvent, SDL
     default:
         button = (int)[theEvent buttonNumber] + 1;
         break;
+    }
+
+    if (button == SDL_BUTTON_LEFT && [self processHitTest:theEvent]) {
+        SDL_SendWindowEvent(_data.window, SDL_EVENT_WINDOW_HIT_TEST, 0, 0);
+        return; // dragging, drop event.
     }
 
     Cocoa_SendMouseButtonClicks(mouse, theEvent, _data.window, button, true);
@@ -1721,11 +1721,6 @@ static void Cocoa_SendMouseButtonClicks(SDL_Mouse *mouse, NSEvent *theEvent, SDL
         return;
     }
 
-    if ([self processHitTest:theEvent]) {
-        SDL_SendWindowEvent(_data.window, SDL_EVENT_WINDOW_HIT_TEST, 0, 0);
-        return; // stopped dragging, drop event.
-    }
-
     switch ([theEvent buttonNumber]) {
     case 0:
         if (wasCtrlLeft) {
@@ -1744,6 +1739,11 @@ static void Cocoa_SendMouseButtonClicks(SDL_Mouse *mouse, NSEvent *theEvent, SDL
     default:
         button = (int)[theEvent buttonNumber] + 1;
         break;
+    }
+
+    if (button == SDL_BUTTON_LEFT && [self processHitTest:theEvent]) {
+        SDL_SendWindowEvent(_data.window, SDL_EVENT_WINDOW_HIT_TEST, 0, 0);
+        return; // stopped dragging, drop event.
     }
 
     Cocoa_SendMouseButtonClicks(mouse, theEvent, _data.window, button, false);

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -2076,7 +2076,19 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
         return ret;                                                        \
     }
                 case SDL_HITTEST_DRAGGABLE:
+                {
+                    /* If the mouse button state is something other than none or left button down,
+                     * return HTCLIENT, or Windows will eat the button press.
+                     */
+                    SDL_MouseButtonFlags buttonState = SDL_GetGlobalMouseState(NULL, NULL);
+                    if (buttonState && !(buttonState & SDL_BUTTON_LMASK)) {
+                        // Set focus in case it was lost while previously moving over a draggable area.
+                        SDL_SetMouseFocus(window);
+                        return HTCLIENT;
+                    }
+
                     POST_HIT_TEST(HTCAPTION);
+                }
                 case SDL_HITTEST_RESIZE_TOPLEFT:
                     POST_HIT_TEST(HTTOPLEFT);
                 case SDL_HITTEST_RESIZE_TOP:


### PR DESCRIPTION
Previously, Win32 and Mac would eat all mouse button events when the cursor was over a draggable area. Pass non-left clicks through, so they can be used to open menus or perform other functions while over client-side title bars. Neither platform seems to do anything with non-left clicks over draggable areas anyway.

X11 and Wayland already behave in this manner.

Fixes #11974 