### PR TITLE
Filesystem and Storage path politics

### DIFF
--- a/include/SDL3/SDL_filesystem.h
+++ b/include/SDL3/SDL_filesystem.h
@@ -313,6 +313,9 @@ typedef enum SDL_EnumerationResult
  * terminate the enumeration early, and dictate the return value of the
  * enumeration function itself.
  *
+ * `dirname` is guaranteed to end with a path separator ('\\' on
+ * Windows, '/' on most other platforms).
+ *
  * \param userdata an app-controlled pointer that is passed to the callback.
  * \param dirname the directory that is being enumerated.
  * \param fname the next entry in the enumeration.

--- a/include/SDL3/SDL_filesystem.h
+++ b/include/SDL3/SDL_filesystem.h
@@ -483,6 +483,9 @@ extern SDL_DECLSPEC char ** SDLCALL SDL_GlobDirectory(const char *path, const ch
  * platforms without this concept, this would cause surprises with file access
  * outside of SDL.
  *
+ * The returned path is guaranteed to end with a path separator ('\\' on
+ * Windows, '/' on most other platforms).
+ *
  * \returns a UTF-8 string of the current working directory in
  *          platform-dependent notation. NULL if there's a problem. This
  *          should be freed with SDL_free() when it is no longer needed.

--- a/include/SDL3/SDL_storage.h
+++ b/include/SDL3/SDL_storage.h
@@ -222,6 +222,22 @@
  * playing on another PC (and vice versa) with the save data fully
  * synchronized across all devices, allowing for a seamless experience without
  * having to do full restarts of the program.
+ *
+ * ## Notes on valid paths
+ *
+ * All paths in the Storage API use Unix-style path separators ('/'). Using a
+ * different path separator will not work, even if the underlying platform
+ * would otherwise accept it. This is to keep code using the Storage API
+ * portable between platforms and Storage implementations and simplify app
+ * code.
+ *
+ * Paths with relative directories ("." and "..") are forbidden by the Storage
+ * API.
+ *
+ * All valid UTF-8 strings (discounting the NULL terminator character and the
+ * '/' path separator) are usable for filenames, however, an underlying
+ * Storage implementation may not support particularly strange sequences and
+ * refuse to create files with those names, etc.
  */
 
 #ifndef SDL_storage_h_

--- a/src/filesystem/SDL_filesystem.c
+++ b/src/filesystem/SDL_filesystem.c
@@ -307,7 +307,7 @@ static SDL_EnumerationResult SDLCALL GlobDirectoryCallback(void *userdata, const
     // !!! FIXME: and only casefold the new pieces instead of allocating and folding full paths for all of this.
 
     char *fullpath = NULL;
-    if (SDL_asprintf(&fullpath, "%s/%s", dirname, fname) < 0) {
+    if (SDL_asprintf(&fullpath, "%s%s", dirname, fname) < 0) {
         return SDL_ENUM_FAILURE;
     }
 
@@ -417,7 +417,8 @@ char **SDL_InternalGlobDirectory(const char *path, const char *pattern, SDL_Glob
     data.enumerator = enumerator;
     data.getpathinfo = getpathinfo;
     data.fsuserdata = userdata;
-    data.basedirlen = SDL_strlen(path) + 1;  // +1 for the '/' we'll be adding.
+    data.basedirlen = *path ? (SDL_strlen(path) + 1) : 0;  // +1 for the '/' we'll be adding.
+
 
     char **result = NULL;
     if (data.enumerator(path, GlobDirectoryCallback, &data, data.fsuserdata)) {

--- a/src/filesystem/posix/SDL_sysfsops.c
+++ b/src/filesystem/posix/SDL_sysfsops.c
@@ -217,7 +217,7 @@ char *SDL_SYS_GetCurrentDirectory(void)
         }
         buf = (char *) ptr;
 
-        if (getcwd(buf, buflen) != NULL) {
+        if (getcwd(buf, buflen-1) != NULL) {
             break;  // we got it!
         }
 
@@ -229,6 +229,14 @@ char *SDL_SYS_GetCurrentDirectory(void)
         SDL_free(buf);
         SDL_SetError("getcwd failed: %s", strerror(errno));
         return NULL;
+    }
+
+    // make sure there's a path separator at the end.
+    SDL_assert(SDL_strlen(buf) < (buflen + 2));
+    buflen = SDL_strlen(buf);
+    if ((buflen == 0) || (buf[buflen-1] != '/')) {
+        buf[buflen] = '/';
+        buf[buflen + 1] = '\0';
     }
 
     return buf;

--- a/src/filesystem/windows/SDL_sysfilesystem.c
+++ b/src/filesystem/windows/SDL_sysfilesystem.c
@@ -355,11 +355,17 @@ char *SDL_SYS_GetCurrentDirectory(void)
         if (bw == 0) {
             WIN_SetError("GetCurrentDirectoryW failed");
             return NULL;
-        } else if (bw < buflen) {
-            break;  // we got it!
+        } else if (bw < buflen) {  // we got it!
+            // make sure there's a path separator at the end.
+            SDL_assert(bw < (buflen + 2));
+            if ((bw == 0) || (wstr[bw-1] != '\\')) {
+                wstr[bw] = '\\';
+                wstr[bw + 1] = '\0';
+            }
+            break;
         }
 
-        void *ptr = SDL_realloc(wstr, bw * sizeof (WCHAR));
+        void *ptr = SDL_realloc(wstr, (bw + 1) * sizeof (WCHAR));
         if (!ptr) {
             SDL_free(wstr);
             return NULL;

--- a/src/storage/SDL_storage.c
+++ b/src/storage/SDL_storage.c
@@ -56,6 +56,33 @@ struct SDL_Storage
         return result;                             \
     }
 
+// we don't make any effort to convert path separators here, because a)
+// everything including Windows will accept a '/' separator and b) that
+// conversion should probably happen in the storage backend anyhow.
+
+static bool ValidateStoragePath(const char *path)
+{
+    if (SDL_strchr(path, '\\')) {
+        return SDL_SetError("Windows-style path separators ('\\') not permitted, use '/' instead.");
+    }
+
+    const char *ptr;
+    const char *prev = path;
+    while ((ptr = SDL_strchr(prev, '/')) != NULL) {
+        if ((SDL_strncmp(prev, "./", 2) == 0) || (SDL_strncmp(prev, "../", 3) == 0)) {
+            return SDL_SetError("Relative paths not permitted");
+        }
+        prev = ptr + 1;
+    }
+
+    // check the last path element (or the only path element).
+    if ((SDL_strcmp(prev, ".") == 0) || (SDL_strcmp(prev, "..") == 0)) {
+        return SDL_SetError("Relative paths not permitted");
+    }
+
+    return true;
+}
+
 SDL_Storage *SDL_OpenTitleStorage(const char *override, SDL_PropertiesID props)
 {
     SDL_Storage *storage = NULL;
@@ -213,9 +240,9 @@ bool SDL_ReadStorageFile(SDL_Storage *storage, const char *path, void *destinati
 
     if (!path) {
         return SDL_InvalidParamError("path");
-    }
-
-    if (!storage->iface.read_file) {
+    } else if (!ValidateStoragePath(path)) {
+        return false;
+    } else if (!storage->iface.read_file) {
         return SDL_Unsupported();
     }
 
@@ -228,9 +255,9 @@ bool SDL_WriteStorageFile(SDL_Storage *storage, const char *path, const void *so
 
     if (!path) {
         return SDL_InvalidParamError("path");
-    }
-
-    if (!storage->iface.write_file) {
+    } else if (!ValidateStoragePath(path)) {
+        return false;
+    } else if (!storage->iface.write_file) {
         return SDL_Unsupported();
     }
 
@@ -243,9 +270,9 @@ bool SDL_CreateStorageDirectory(SDL_Storage *storage, const char *path)
 
     if (!path) {
         return SDL_InvalidParamError("path");
-    }
-
-    if (!storage->iface.mkdir) {
+    } else if (!ValidateStoragePath(path)) {
+        return false;
+    } else if (!storage->iface.mkdir) {
         return SDL_Unsupported();
     }
 
@@ -258,9 +285,9 @@ bool SDL_EnumerateStorageDirectory(SDL_Storage *storage, const char *path, SDL_E
 
     if (!path) {
         return SDL_InvalidParamError("path");
-    }
-
-    if (!storage->iface.enumerate) {
+    } else if (!ValidateStoragePath(path)) {
+        return false;
+    } else if (!storage->iface.enumerate) {
         return SDL_Unsupported();
     }
 
@@ -273,9 +300,9 @@ bool SDL_RemoveStoragePath(SDL_Storage *storage, const char *path)
 
     if (!path) {
         return SDL_InvalidParamError("path");
-    }
-
-    if (!storage->iface.remove) {
+    } else if (!ValidateStoragePath(path)) {
+        return false;
+    } else if (!storage->iface.remove) {
         return SDL_Unsupported();
     }
 
@@ -288,12 +315,13 @@ bool SDL_RenameStoragePath(SDL_Storage *storage, const char *oldpath, const char
 
     if (!oldpath) {
         return SDL_InvalidParamError("oldpath");
-    }
-    if (!newpath) {
+    } else if (!newpath) {
         return SDL_InvalidParamError("newpath");
-    }
-
-    if (!storage->iface.rename) {
+    } else if (!ValidateStoragePath(oldpath)) {
+        return false;
+    } else if (!ValidateStoragePath(newpath)) {
+        return false;
+    } else if (!storage->iface.rename) {
         return SDL_Unsupported();
     }
 
@@ -306,12 +334,13 @@ bool SDL_CopyStorageFile(SDL_Storage *storage, const char *oldpath, const char *
 
     if (!oldpath) {
         return SDL_InvalidParamError("oldpath");
-    }
-    if (!newpath) {
+    } else if (!newpath) {
         return SDL_InvalidParamError("newpath");
-    }
-
-    if (!storage->iface.copy) {
+    } else if (!ValidateStoragePath(oldpath)) {
+        return false;
+    } else if (!ValidateStoragePath(newpath)) {
+        return false;
+    } else if (!storage->iface.copy) {
         return SDL_Unsupported();
     }
 
@@ -331,9 +360,9 @@ bool SDL_GetStoragePathInfo(SDL_Storage *storage, const char *path, SDL_PathInfo
 
     if (!path) {
         return SDL_InvalidParamError("path");
-    }
-
-    if (!storage->iface.info) {
+    } else if (!ValidateStoragePath(path)) {
+        return false;
+    } else if (!storage->iface.info) {
         return SDL_Unsupported();
     }
 
@@ -365,6 +394,14 @@ static bool GlobStorageDirectoryEnumerator(const char *path, SDL_EnumerateDirect
 char **SDL_GlobStorageDirectory(SDL_Storage *storage, const char *path, const char *pattern, SDL_GlobFlags flags, int *count)
 {
     CHECK_STORAGE_MAGIC_RET(NULL)
+
+    if (!path) {
+        SDL_InvalidParamError("path");
+        return NULL;
+    } else if (!ValidateStoragePath(path)) {
+        return NULL;
+    }
+
     return SDL_InternalGlobDirectory(path, pattern, flags, count, GlobStorageDirectoryEnumerator, GlobStorageDirectoryGetPathInfo, storage);
 }
 

--- a/src/storage/generic/SDL_genericstorage.c
+++ b/src/storage/generic/SDL_genericstorage.c
@@ -236,10 +236,15 @@ static const SDL_StorageInterface GENERIC_title_iface = {
 static SDL_Storage *GENERIC_Title_Create(const char *override, SDL_PropertiesID props)
 {
     SDL_Storage *result = NULL;
-
     char *basepath = NULL;
+
     if (override != NULL) {
-        basepath = SDL_strdup(override);
+        // make sure override has a path separator at the end. If you're not on Windows and used '\\', that's on you.
+        const size_t slen = SDL_strlen(override);
+        const bool need_sep = (!slen || ((override[slen-1] != '/') && (override[slen-1] != '\\')));
+        if (SDL_asprintf(&basepath, "%s%s", override, need_sep ? "/" : "") == -1) {
+            return NULL;
+        }
     } else {
         const char *base = SDL_GetBasePath();
         basepath = base ? SDL_strdup(base) : NULL;

--- a/test/testfilesystem.c
+++ b/test/testfilesystem.c
@@ -150,6 +150,7 @@ int main(int argc, char *argv[])
         SDL_Storage *storage = NULL;
         SDL_IOStream *stream;
         const char *text = "foo\n";
+        SDL_PathInfo pathinfo;
 
         if (!SDL_EnumerateDirectory(base_path, enum_callback, NULL)) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Base path enumeration failed!");
@@ -233,7 +234,7 @@ int main(int argc, char *argv[])
         if (!storage) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to open base path storage object: %s", SDL_GetError());
         } else {
-            if (!SDL_EnumerateStorageDirectory(storage, "", enum_storage_callback, storage)) {
+            if (!SDL_EnumerateStorageDirectory(storage, "CMakeFiles", enum_storage_callback, storage)) {
                 SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Storage Base path enumeration failed!");
             }
 
@@ -247,6 +248,62 @@ int main(int argc, char *argv[])
                 }
                 SDL_free(globlist);
             }
+
+            /* these should fail: */
+            if (!SDL_GetStoragePathInfo(storage, "CMakeFiles/../testsprite.c", &pathinfo)) {
+                SDL_Log("Storage access on path with internal '..' refused correctly.");
+            } else {
+                SDL_Log("Storage access on path with internal '..' accepted INCORRECTLY.");
+            }
+
+            if (!SDL_GetStoragePathInfo(storage, "CMakeFiles/./TargetDirectories.txt", &pathinfo)) {
+                SDL_Log("Storage access on path with internal '.' refused correctly.");
+            } else {
+                SDL_Log("Storage access on path with internal '.' accepted INCORRECTLY.");
+            }
+
+            if (!SDL_GetStoragePathInfo(storage, "../test", &pathinfo)) {
+                SDL_Log("Storage access on path with leading '..' refused correctly.");
+            } else {
+                SDL_Log("Storage access on path with leading '..' accepted INCORRECTLY.");
+            }
+
+            if (!SDL_GetStoragePathInfo(storage, "./CMakeFiles", &pathinfo)) {
+                SDL_Log("Storage access on path with leading '.' refused correctly.");
+            } else {
+                SDL_Log("Storage access on path with leading '.' accepted INCORRECTLY.");
+            }
+
+            if (!SDL_GetStoragePathInfo(storage, "CMakeFiles/..", &pathinfo)) {
+                SDL_Log("Storage access on path with trailing '..' refused correctly.");
+            } else {
+                SDL_Log("Storage access on path with trailing '..' accepted INCORRECTLY.");
+            }
+
+            if (!SDL_GetStoragePathInfo(storage, "CMakeFiles/.", &pathinfo)) {
+                SDL_Log("Storage access on path with trailing '.' refused correctly.");
+            } else {
+                SDL_Log("Storage access on path with trailing '.' accepted INCORRECTLY.");
+            }
+
+            if (!SDL_GetStoragePathInfo(storage, "..", &pathinfo)) {
+                SDL_Log("Storage access on path '..' refused correctly.");
+            } else {
+                SDL_Log("Storage access on path '..' accepted INCORRECTLY.");
+            }
+
+            if (!SDL_GetStoragePathInfo(storage, ".", &pathinfo)) {
+                SDL_Log("Storage access on path '.' refused correctly.");
+            } else {
+                SDL_Log("Storage access on path '.' accepted INCORRECTLY.");
+            }
+
+            if (!SDL_GetStoragePathInfo(storage, "CMakeFiles\\TargetDirectories.txt", &pathinfo)) {
+                SDL_Log("Storage access on path with Windows separator refused correctly.");
+            } else {
+                SDL_Log("Storage access on path with Windows separator accepted INCORRECTLY.");
+            }
+
             SDL_CloseStorage(storage);
         }
 

--- a/test/testfilesystem.c
+++ b/test/testfilesystem.c
@@ -20,14 +20,7 @@ static SDL_EnumerationResult SDLCALL enum_callback(void *userdata, const char *o
     SDL_PathInfo info;
     char *fullpath = NULL;
 
-    /* you can use '/' for a path separator on Windows, but to make the log output look correct, we'll #ifdef this... */
-    #ifdef SDL_PLATFORM_WINDOWS
-    const char *pathsep = "\\";
-    #else
-    const char *pathsep = "/";
-    #endif
-
-    if (SDL_asprintf(&fullpath, "%s%s%s", origdir, *origdir ? pathsep : "", fname) < 0) {
+    if (SDL_asprintf(&fullpath, "%s%s", origdir, fname) < 0) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!");
         return SDL_ENUM_FAILURE;
     }


### PR DESCRIPTION
This addresses all of @nightmareci's bugs about paths in the Filesystem and Storage APIs.

The only one that _might_ be controversial (CC @flibitijibibo) enforces policy at the top level of the Storage API to forbid paths that have "." or ".." elements in them, or '\\' path separators; they won't even get to the backend for further processing. This is both to prevent breaking out of a storage base path, but alsoto deal with the possibility that a storage backend won't actually support ".." paths; sure, the filesystem does, but will a .zip archive exposed as a Storage object?

Forbidding '\\' just makes sure you don't accidentally hardcode a path that will be a surprising failure as soon as you port your code outside of Windows (and on the flip side, so you don't get a totally different surprise when you port _to_ Windows).

Fixes #11065.
Fixes #11427.
Fixes #11079.
Fixes #11370.
Fixes #11369.
Fixes #11299.
