### PR TITLE
cocoa: clear mouse focus based on NSEventTypeMouseExited events

### DIFF
--- a/src/video/cocoa/SDL_cocoaevents.m
+++ b/src/video/cocoa/SDL_cocoaevents.m
@@ -76,6 +76,8 @@ static void Cocoa_DispatchEvent(NSEvent *theEvent)
     case NSEventTypeOtherMouseDragged: // usually middle mouse dragged
     case NSEventTypeMouseMoved:
     case NSEventTypeScrollWheel:
+    case NSEventTypeMouseEntered:
+    case NSEventTypeMouseExited:
         Cocoa_HandleMouseEvent(_this, theEvent);
         break;
     case NSEventTypeKeyDown:

--- a/src/video/cocoa/SDL_cocoamouse.h
+++ b/src/video/cocoa/SDL_cocoamouse.h
@@ -26,6 +26,7 @@
 #include "SDL_cocoavideo.h"
 
 extern bool Cocoa_InitMouse(SDL_VideoDevice *_this);
+extern NSWindow *Cocoa_GetMouseFocus();
 extern void Cocoa_HandleMouseEvent(SDL_VideoDevice *_this, NSEvent *event);
 extern void Cocoa_HandleMouseWheel(SDL_Window *window, NSEvent *event);
 extern void Cocoa_HandleMouseWarp(CGFloat x, CGFloat y);

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -1776,6 +1776,12 @@ static void Cocoa_SendMouseButtonClicks(SDL_Mouse *mouse, NSEvent *theEvent, SDL
         return;
     }
 
+    if (!Cocoa_GetMouseFocus()) {
+        // The mouse is no longer over any window in the application
+        SDL_SetMouseFocus(NULL);
+        return;
+    }
+
     window = _data.window;
     contentView = _data.sdlContentView;
     point = [theEvent locationInWindow];


### PR DESCRIPTION
We can't directly set the mouse focus since we may get spammed by entered/exited events, but we can process the current focus later in the mouseMoved handler in line with the mouse motion event sequence.

Fixes https://github.com/libsdl-org/SDL/issues/8188