### PR TITLE
Vita: Fix off-by-one error for synthetic mouse events

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -143,13 +143,13 @@ static void SDLCALL SDL_VitaTouchMouseDeviceChanged(void *userdata, const char *
         switch (*hint) {
         default:
         case '0':
-            mouse->vita_touch_mouse_device = 0;
-            break;
-        case '1':
             mouse->vita_touch_mouse_device = 1;
             break;
-        case '2':
+        case '1':
             mouse->vita_touch_mouse_device = 2;
+            break;
+        case '2':
+            mouse->vita_touch_mouse_device = 3;
             break;
         }
     }

--- a/src/events/SDL_touch.c
+++ b/src/events/SDL_touch.c
@@ -267,7 +267,7 @@ void SDL_SendTouch(Uint64 timestamp, SDL_TouchID id, SDL_FingerID fingerid, SDL_
         // FIXME: maybe we should only restrict to a few SDL_TouchDeviceType
         if ((id != SDL_MOUSE_TOUCHID) && (id != SDL_PEN_TOUCHID)) {
 #ifdef SDL_PLATFORM_VITA
-            if (mouse->touch_mouse_events && ((mouse->vita_touch_mouse_device == id) || (mouse->vita_touch_mouse_device == 2))) {
+            if (mouse->touch_mouse_events && ((mouse->vita_touch_mouse_device == id) || (mouse->vita_touch_mouse_device == 3))) {
 #else
             if (mouse->touch_mouse_events) {
 #endif


### PR DESCRIPTION
This PR fixes an off-by-one error for controlling what synthetic mouse events are generated on PSVita using `SDL_HINT_VITA_TOUCH_MOUSE_DEVICE`.

## Description
The touch IDs for the front and back touchscreen on Vita appear to have changed within SDL from 0 and 1 respectively to 1 and 2 in https://github.com/libsdl-org/SDL/commit/a31dc6dfcb8b3a50a9713702271aeaa7c5930131. This made the behaviour of `SDL_HINT_VITA_TOUCH_MOUSE_DEVICE` values off-by-one compared to what it should be.

I've fixed it so that the behaviour of the hint values properly match [what is documented in the wiki](https://wiki.libsdl.org/SDL3/SDL_HINT_VITA_TOUCH_MOUSE_DEVICE), shifting the internal `vita_touch_mouse_device` by one. I do not have a Vita so I can't test on real hardware, but I have tested it on an emulator (Vita3K) that can send input for front and back touchscreen with left and right mouse button respectively and it works as intended there now. 

I have not checked if this issue also applies to SDL2, but it likely does based on looking at https://github.com/libsdl-org/SDL/issues/11441 & related commits changing the touch IDs there too.

## Existing Issue(s)
N/A