### PR TITLE
Windows trays: Fix fetching parent entry from submenu, allow enabling and disabling entries that aren't checkboxes

### DIFF
--- a/src/tray/windows/SDL_tray.c
+++ b/src/tray/windows/SDL_tray.c
@@ -420,6 +420,7 @@ SDL_TrayEntry *SDL_InsertTrayEntryAt(SDL_TrayMenu *menu, int pos, const char *la
         entry->submenu->hMenu = CreatePopupMenu();
         entry->submenu->nEntries = 0;
         entry->submenu->entries = NULL;
+        entry->submenu->parent_entry = entry;
 
         entry->id = (UINT_PTR) entry->submenu->hMenu;
     } else {
@@ -528,21 +529,11 @@ bool SDL_GetTrayEntryChecked(SDL_TrayEntry *entry)
 
 void SDL_SetTrayEntryEnabled(SDL_TrayEntry *entry, bool enabled)
 {
-    if (!(entry->flags & SDL_TRAYENTRY_CHECKBOX)) {
-        SDL_SetError("Cannot update check for entry not created with SDL_TRAYENTRY_CHECKBOX");
-        return;
-    }
-
     EnableMenuItem(entry->parent->hMenu, (UINT) entry->id, MF_BYCOMMAND | (enabled ? MF_ENABLED : (MF_DISABLED | MF_GRAYED)));
 }
 
 bool SDL_GetTrayEntryEnabled(SDL_TrayEntry *entry)
 {
-    if (!(entry->flags & SDL_TRAYENTRY_CHECKBOX)) {
-        SDL_SetError("Cannot fetch check for entry not created with SDL_TRAYENTRY_CHECKBOX");
-        return false;
-    }
-
     MENUITEMINFOW mii;
     mii.cbSize = sizeof(MENUITEMINFOW);
     mii.fMask = MIIM_STATE;

--- a/src/tray/windows/SDL_tray.c
+++ b/src/tray/windows/SDL_tray.c
@@ -304,6 +304,7 @@ SDL_TrayMenu *SDL_CreateTrayMenu(SDL_Tray *tray)
 
     tray->menu->hMenu = CreatePopupMenu();
     tray->menu->parent_tray = tray;
+    tray->menu->parent_entry = NULL;
 
     return tray->menu;
 }
@@ -395,6 +396,8 @@ SDL_TrayEntry *SDL_InsertTrayEntryAt(SDL_TrayMenu *menu, int pos, const char *la
         return NULL;
     }
 
+    SDL_memset((void *) entry, 0, sizeof(*entry));
+
     wchar_t *label_w = NULL;
 
     if (label && (label_w = escape_label(label)) == NULL) {
@@ -417,10 +420,13 @@ SDL_TrayEntry *SDL_InsertTrayEntryAt(SDL_TrayMenu *menu, int pos, const char *la
             return NULL;
         }
 
+        SDL_memset((void *) entry->submenu, 0, sizeof(*entry->submenu));
+
         entry->submenu->hMenu = CreatePopupMenu();
         entry->submenu->nEntries = 0;
         entry->submenu->entries = NULL;
         entry->submenu->parent_entry = entry;
+        entry->submenu->parent_tray = NULL;
 
         entry->id = (UINT_PTR) entry->submenu->hMenu;
     } else {


### PR DESCRIPTION
## Description

The `test/testtray` program would crash on Windows when adding any item and then removing it, because a submenu's parent_entry field was not set.

Additionally, I noticed that some extraneous code copied from the `{G,S}etTrayEntryChecked` made `{G,S}etTrayEntryEnabled` work only for checkboxes, which is not the desired behavior.

Both issues were fixed in this commit.

---

Relatedly, it may be worth to take some time before the first full release to exhaustively test trays and dialogs on all platforms. I did some summary testing on Windows, but I can write extensive unit tests that can quickly be run on all platforms, so that we won't need to manually try every possible combination to find embarrassing mistakes like these two.

## Existing Issue(s)

Fixes #12002 
