### PR TITLE
Fixed sine wave distortion over time.

### DIFF
--- a/examples/audio/01-simple-playback/simple-playback.c
+++ b/examples/audio/01-simple-playback/simple-playback.c
@@ -14,7 +14,7 @@
 static SDL_Window *window = NULL;
 static SDL_Renderer *renderer = NULL;
 static SDL_AudioStream *stream = NULL;
-static int total_samples_generated = 0;
+static int current_sine_sample = 0;
 
 /* This function runs once at startup. */
 SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
@@ -76,10 +76,13 @@ SDL_AppResult SDL_AppIterate(void *appstate)
         /* generate a 440Hz pure tone */
         for (i = 0; i < SDL_arraysize(samples); i++) {
             const int freq = 440;
-            const int phase = (total_samples_generated * freq) % 8000;
-            samples[i] = (float)SDL_sin(phase * 2 * SDL_PI_D / 8000.0);
-            total_samples_generated++;
+            const int phase = current_sine_sample * freq / 8000.0f;
+            samples[i] = SDL_sinf(phase * 2 * SDL_PI_F);
+            current_sine_sample++;
         }
+
+        /* wrapping around to avoid floating-point errors */
+        current_sine_sample %= 8000;
 
         /* feed the new data to the stream. It will queue at the end, and trickle out as the hardware needs more data. */
         SDL_PutAudioStreamData(stream, samples, sizeof (samples));

--- a/examples/audio/02-simple-playback-callback/simple-playback-callback.c
+++ b/examples/audio/02-simple-playback-callback/simple-playback-callback.c
@@ -17,7 +17,7 @@
 static SDL_Window *window = NULL;
 static SDL_Renderer *renderer = NULL;
 static SDL_AudioStream *stream = NULL;
-static int total_samples_generated = 0;
+static int current_sine_sample = 0;
 
 /* this function will be called (usually in a background thread) when the audio stream is consuming data. */
 static void SDLCALL FeedTheAudioStreamMore(void *userdata, SDL_AudioStream *astream, int additional_amount, int total_amount)
@@ -36,10 +36,13 @@ static void SDLCALL FeedTheAudioStreamMore(void *userdata, SDL_AudioStream *astr
         /* generate a 440Hz pure tone */
         for (i = 0; i < total; i++) {
             const int freq = 440;
-            const int phase = (total_samples_generated * freq) % 8000;
-            samples[i] = (float)SDL_sin(phase * 2 * SDL_PI_D / 8000.0);
-            total_samples_generated++;
+            const int phase = current_sine_sample * freq / 8000.0f;
+            samples[i] = SDL_sinf(phase * 2 * SDL_PI_F);
+            current_sine_sample++;
         }
+
+        /* wrapping around to avoid floating-point errors */
+        current_sine_sample %= 8000;
 
         /* feed the new data to the stream. It will queue at the end, and trickle out as the hardware needs more data. */
         SDL_PutAudioStreamData(astream, samples, total * sizeof (float));


### PR DESCRIPTION
Audio distortion after a while caused by loss of precision in dividing a large floating point number resolved by keeping `current_sine_sample` (formelly named `total_samples_generated`) between `0` and `spec.freq - 1`.

## Description
We are wrapping around `current_sine_sample` by the number of samples per second so that `current_sine_sample * freq` always results in a small number while also making the `phase` go between `0` and `1`, avoiding discontinuity in the signal. This removes the necessity of using a `double` to dealy the amount of time until we get distortion.

## Existing Issue(s)
Fixes https://github.com/libsdl-org/SDL/issues/11936
