### PR TITLE
Fixed wrong type of `phase`

### DIFF
--- a/examples/audio/01-simple-playback/simple-playback.c
+++ b/examples/audio/01-simple-playback/simple-playback.c
@@ -76,7 +76,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
         /* generate a 440Hz pure tone */
         for (i = 0; i < SDL_arraysize(samples); i++) {
             const int freq = 440;
-            const int phase = (total_samples_generated * freq) % 8000;
+            const float phase = (total_samples_generated * freq) % 8000;
             samples[i] = (float)SDL_sin(phase * 2 * SDL_PI_D / 8000.0);
             total_samples_generated++;
         }

--- a/examples/audio/02-simple-playback-callback/simple-playback-callback.c
+++ b/examples/audio/02-simple-playback-callback/simple-playback-callback.c
@@ -36,7 +36,7 @@ static void SDLCALL FeedTheAudioStreamMore(void *userdata, SDL_AudioStream *astr
         /* generate a 440Hz pure tone */
         for (i = 0; i < total; i++) {
             const int freq = 440;
-            const int phase = (total_samples_generated * freq) % 8000;
+            const float phase = (total_samples_generated * freq) % 8000;
             samples[i] = (float)SDL_sin(phase * 2 * SDL_PI_D / 8000.0);
             total_samples_generated++;
         }


### PR DESCRIPTION
`phase` should be a `float` value that ranges between `0` and `1`.

## Description
`phase` was `int` in the previous implementation but now it should be `float` as it ranges between `0` and `1`.

## Existing Issue(s)
FIX https://github.com/libsdl-org/SDL/pull/12013#issuecomment-2599465628
