### PR TITLE
Fix Windows dialog folder titles

### DIFF
--- a/src/dialog/windows/SDL_windowsdialog.c
+++ b/src/dialog/windows/SDL_windowsdialog.c
@@ -439,7 +439,7 @@ void windows_ShowFolderDialog(void *ptr)
             title_len = 0;
         }
 
-        int title_wlen = MultiByteToWideChar(CP_UTF8, 0, title, title_len, NULL, 0);
+        int title_wlen = MultiByteToWideChar(CP_UTF8, 0, title, -1, NULL, 0);
 
         if (title_wlen < 0) {
             title_wlen = 0;
@@ -452,7 +452,7 @@ void windows_ShowFolderDialog(void *ptr)
             return;
         }
 
-        MultiByteToWideChar(CP_UTF8, 0, title, title_len, title_w, title_wlen);
+        MultiByteToWideChar(CP_UTF8, 0, title, -1, title_w, title_wlen);
     }
 
     wchar_t buffer[MAX_PATH];


### PR DESCRIPTION
## Description

Fix titles being copied without carrying the terminating NULL byte.

Same fix as in cf946e32ba0977a87bc5c7096c304538b4f42337, which was not done for the folder implementation.

## Existing Issue(s)

Fixes https://github.com/libsdl-org/SDL/pull/12000#issuecomment-2600254520
