### PR TITLE
Feature add hint to remap option as alt key

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2347,7 +2347,6 @@ extern "C" {
  */
 #define SDL_HINT_MAC_OPENGL_ASYNC_DISPATCH "SDL_MAC_OPENGL_ASYNC_DISPATCH"
 
-// TODO: finish the ... parts
 /**
  * A variable controlling whether the Option (⌥) key on macOS should be remapped
  * to act as the Alt key.
@@ -2355,17 +2354,19 @@ extern "C" {
  * The variable can be set to the following values:
  *
  * - "none": The Option key is not remapped to Alt. (default)
- * - "left_only": Only the left Option key is remapped to Alt.
- * - "right_only": Only the right Option key is remapped to Alt.
+ * - "only_left": Only the left Option key is remapped to Alt.
+ * - "only_right": Only the right Option key is remapped to Alt.
  * - "both": Both Option keys are remapped to Alt.
  *
- * This will prevent the Option key from triggering special characters like `å`
- * or key compositions that rely on the Option key, but will still send the Alt
- * modifier signal to the application. This is particularly useful for
- * applications like terminal emulators and graphical user interfaces (GUIs)
- * that rely on Alt key functionality for shortcuts or navigation.
+ * This will prevent the triggering of key compositions that rely on the Option
+ * key, but will still send the Alt modifier for keyboard events. In the case
+ * that both Alt and Option are pressed, the Option key will be ignored. This is
+ * particularly useful for applications like terminal emulators and graphical
+ * user interfaces (GUIs) that rely on Alt key functionality for shortcuts or
+ * navigation. This does not apply to SDL_GetKeyFromScancode and only has an
+ * effect if IME is enabled.
  *
- * This hint ...
+ * This hint can be set anytime.
  *
  * \since This hint is avaliable since ...
  */

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2347,6 +2347,31 @@ extern "C" {
  */
 #define SDL_HINT_MAC_OPENGL_ASYNC_DISPATCH "SDL_MAC_OPENGL_ASYNC_DISPATCH"
 
+// TODO: finish the ... parts
+/**
+ * A variable controlling whether the Option (⌥) key on macOS should be remapped
+ * to act as the Alt key.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "none": The Option key is not remapped to Alt. (default)
+ * - "left_only": Only the left Option key is remapped to Alt.
+ * - "right_only": Only the right Option key is remapped to Alt.
+ * - "both": Both Option keys are remapped to Alt.
+ *
+ * This will prevent the Option key from triggering special characters like `å`
+ * or key compositions that rely on the Option key, but will still send the Alt
+ * modifier signal to the application. This is particularly useful for
+ * applications like terminal emulators and graphical user interfaces (GUIs)
+ * that rely on Alt key functionality for shortcuts or navigation.
+ *
+ * This hint ...
+ *
+ * \since This hint is avaliable since ...
+ */
+
+#define SDL_HINT_MAC_OPT_AS_ALT "SDL_MAC_OPT_AS_ALT"
+
 /**
  * A variable controlling whether SDL_EVENT_MOUSE_WHEEL event values will have
  * momentum on macOS.

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2370,7 +2370,6 @@ extern "C" {
  *
  * \since This hint is avaliable since ...
  */
-
 #define SDL_HINT_MAC_OPT_AS_ALT "SDL_MAC_OPT_AS_ALT"
 
 /**

--- a/src/video/cocoa/SDL_cocoakeyboard.m
+++ b/src/video/cocoa/SDL_cocoakeyboard.m
@@ -443,6 +443,9 @@ static NSEvent *ReplaceEvent(NSEvent *event)
     const unsigned int modflags = (unsigned int)[event modifierFlags];
 
     const char *option_as_alt = SDL_GetHint(SDL_HINT_MAC_OPT_AS_ALT);
+    if (!(option_as_alt && *option_as_alt)) {
+        return event;
+    }
 
     bool ignore_alt_characters = false;
 
@@ -451,9 +454,9 @@ static NSEvent *ReplaceEvent(NSEvent *event)
     bool ralt_pressed = IsModifierKeyPressed(modflags, NX_DEVICERALTKEYMASK,
                                              NX_DEVICELALTKEYMASK, NX_ALTERNATEMASK);
 
-    if (SDL_strcmp(option_as_alt, "left_only") == 0 && lalt_pressed) {
+    if (SDL_strcmp(option_as_alt, "only_left") == 0 && lalt_pressed) {
         ignore_alt_characters = true;
-    } else if (SDL_strcmp(option_as_alt, "right_only") == 0 && ralt_pressed) {
+    } else if (SDL_strcmp(option_as_alt, "only_right") == 0 && ralt_pressed) {
         ignore_alt_characters = true;
     } else if (SDL_strcmp(option_as_alt, "both") == 0 && (lalt_pressed || ralt_pressed)) {
         ignore_alt_characters = true;
@@ -471,7 +474,7 @@ static NSEvent *ReplaceEvent(NSEvent *event)
                            modifierFlags:modflags
                                timestamp:[event timestamp]
                             windowNumber:[event windowNumber]
-                                 context:[event context]
+                                 context:nil
                               characters:charactersIgnoringModifiers
              charactersIgnoringModifiers:charactersIgnoringModifiers
                                isARepeat:[event isARepeat]
@@ -490,7 +493,9 @@ void Cocoa_HandleKeyEvent(SDL_VideoDevice *_this, NSEvent *event)
         return; // can happen when returning from fullscreen Space on shutdown
     }
 
-    // event = ReplaceEvent(event);
+    if ([event type] == NSEventTypeKeyDown || [event type] == NSEventTypeKeyUp) {
+        event = ReplaceEvent(event);
+    }
 
     scancode = [event keyCode];
 


### PR DESCRIPTION
Adds option `SDL_HINT_MAC_OPT_AS_ALT` which disables key compositions that rely on the Option key.

For the comment `\since This hint is avaliable since` I left it as `...`

Implements #12007
