### PR TITLE
[SDL3] Translate conditional effects direction instead of hardcoding it to 0

### DIFF
--- a/include/SDL3/SDL_haptic.h
+++ b/include/SDL3/SDL_haptic.h
@@ -710,7 +710,7 @@ typedef struct SDL_HapticCondition
     /* Header */
     Uint16 type;            /**< SDL_HAPTIC_SPRING, SDL_HAPTIC_DAMPER,
                                  SDL_HAPTIC_INERTIA or SDL_HAPTIC_FRICTION */
-    SDL_HapticDirection direction;  /**< Direction of the effect - Not used ATM. */
+    SDL_HapticDirection direction;  /**< Direction of the effect. */
 
     /* Replay */
     Uint32 length;          /**< Duration of the effect. */

--- a/src/haptic/linux/SDL_syshaptic.c
+++ b/src/haptic/linux/SDL_syshaptic.c
@@ -892,7 +892,7 @@ static bool SDL_SYS_ToFFEffect(struct ff_effect *dest, const SDL_HapticEffect *s
 
         // Header
         dest->type = FF_RUMBLE;
-        dest->direction = 0;
+        dest->direction = 0x4000;
 
         // Replay
         dest->replay.length = (leftright->length == SDL_HAPTIC_INFINITY) ? 0 : CLAMP(leftright->length);

--- a/src/haptic/linux/SDL_syshaptic.c
+++ b/src/haptic/linux/SDL_syshaptic.c
@@ -824,7 +824,9 @@ static bool SDL_SYS_ToFFEffect(struct ff_effect *dest, const SDL_HapticEffect *s
             dest->type = FF_FRICTION;
         }
 
-        dest->direction = 0; // Handled by the condition-specifics.
+        if (!SDL_SYS_ToDirection(&dest->direction, &condition->direction)) {
+            return false;
+        }
 
         // Replay
         dest->replay.length = (condition->length == SDL_HAPTIC_INFINITY) ? 0 : CLAMP(condition->length);


### PR DESCRIPTION
## Description
Previous code wrongly assumed that direction is not an important part of conditional effect. Moreover, if there's need to hardcode polar direction, the default should be `0x4000` (North).

For one axis affects, a direction of 0 means complete lack of force, if a FFB-enabled device takes direction into force calculation. A sine function graph can be used to represent the resulting forces where X is the input direction and Y is the force multiplier (360 degrees equals to 1).

This fixes conditional effect playback on Moza Racing devices, which do not ignore direction field.