### PR TITLE
Automatically detect SDL_main_private.h

### DIFF
--- a/include/SDL3/SDL_main.h
+++ b/include/SDL3/SDL_main.h
@@ -133,6 +133,12 @@
 
 #endif
 
+#if defined(__has_include)
+    #if __has_include("SDL_main_private.h") && __has_include("SDL_main_impl_private.h")
+        #define SDL_PLATFORM_PRIVATE_MAIN
+    #endif
+#endif
+
 #ifndef SDL_MAIN_HANDLED
     #if defined(SDL_PLATFORM_PRIVATE_MAIN)
         /* Private platforms may have their own ideas about entry points. */


### PR DESCRIPTION
In order for `SDL_main.h` to function properly, we need some way of detecting which platform we're building for. For most platforms this is a simple `#if SDL_PLATFORM_*` check, but private platforms complicate matters. Since even their preprocessor symbols may be under NDA, we can't check for private platforms in `SDL_platform_defines.h`. To work around this in my initial pass on improving private platform support (https://github.com/libsdl-org/SDL/pull/11220), I required that applications themselves define `SDL_PLATFORM_PRIVATE_MAIN` either in their code or their build system in order to use `SDL_main.h`.

This ended up being annoying in practice, so @icculus pitched the idea of using `__has_include` instead. This way we can auto-detect the existence of header files containing the secret main-related code, and the client doesn't have to do anything special on their end. With this change, SDL_main will "just work" even on private platforms.