### PR TITLE
Fix multiple occurences of typo "an simple" to "a simple" in audio examples

### DIFF
--- a/examples/audio/01-simple-playback/README.txt
+++ b/examples/audio/01-simple-playback/README.txt
@@ -1,5 +1,5 @@
 If you're running this in a web browser, you need to click the window before you'll hear anything!
 
-This example code creates an simple audio stream for playing sound, and
+This example code creates a simple audio stream for playing sound, and
 generates a sine wave sound effect for it to play as time goes on. This is the
 simplest way to get up and running with procedural sound.

--- a/examples/audio/01-simple-playback/simple-playback.c
+++ b/examples/audio/01-simple-playback/simple-playback.c
@@ -1,5 +1,5 @@
 /*
- * This example code creates an simple audio stream for playing sound, and
+ * This example code creates a simple audio stream for playing sound, and
  * generates a sine wave sound effect for it to play as time goes on. This
  * is the simplest way to get up and running with procedural sound.
  *

--- a/examples/audio/02-simple-playback-callback/README.txt
+++ b/examples/audio/02-simple-playback-callback/README.txt
@@ -1,5 +1,5 @@
 If you're running this in a web browser, you need to click the window before you'll hear anything!
 
-This example code creates an simple audio stream for playing sound, and
+This example code creates a simple audio stream for playing sound, and
 generates a sine wave sound effect for it to play as time goes on. Unlike
 the previous example, this uses a callback to generate sound.

--- a/examples/audio/02-simple-playback-callback/simple-playback-callback.c
+++ b/examples/audio/02-simple-playback-callback/simple-playback-callback.c
@@ -1,5 +1,5 @@
 /*
- * This example code creates an simple audio stream for playing sound, and
+ * This example code creates a simple audio stream for playing sound, and
  * generates a sine wave sound effect for it to play as time goes on. Unlike
  * the previous example, this uses a callback to generate sound.
  *

--- a/examples/audio/03-load-wav/README.txt
+++ b/examples/audio/03-load-wav/README.txt
@@ -1,5 +1,5 @@
 If you're running this in a web browser, you need to click the window before you'll hear anything!
 
-This example code creates an simple audio stream for playing sound, and
+This example code creates a simple audio stream for playing sound, and
 loads a .wav file that is pushed through the stream in a loop.
 

--- a/examples/audio/03-load-wav/load-wav.c
+++ b/examples/audio/03-load-wav/load-wav.c
@@ -1,5 +1,5 @@
 /*
- * This example code creates an simple audio stream for playing sound, and
+ * This example code creates a simple audio stream for playing sound, and
  * loads a .wav file that is pushed through the stream in a loop.
  *
  * This code is public domain. Feel free to use it for any purpose!


### PR DESCRIPTION
Fix multiple occurences of typo "an simple" to "a simple" in audio examples

## Description
<!--- Describe your changes in detail -->
There were multiple occurrences of the same typo in the audio examples section, where "an" was used instead of "a" when the next word was "simple"
