### PR TITLE
Copy Android pen handling code from `SDLSurface` to `SDLControllerManager`

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLControllerManager.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLControllerManager.java
@@ -705,9 +705,14 @@ class SDLGenericMotionListener_API14 implements View.OnGenericMotionListener {
                         x = event.getX(i);
                         y = event.getY(i);
                         float p = event.getPressure(i);
+                        if (p > 1.0f) {
+                            // may be larger than 1.0f on some devices
+                            // see the documentation of getPressure(i)
+                            p = 1.0f;
+                        }
 
-                        // BUTTON_STYLUS_PRIMARY is 2^5, so shift by 4
-                        int buttons = event.getButtonState() >> 4;
+                        // BUTTON_STYLUS_PRIMARY is 2^5, so shift by 4, and apply SDL_PEN_INPUT_DOWN/SDL_PEN_INPUT_ERASER_TIP
+                        int buttons = (event.getButtonState() >> 4) | (1 << (toolType == MotionEvent.TOOL_TYPE_STYLUS ? 0 : 30));
 
                         SDLActivity.onNativePen(event.getPointerId(i), buttons, action, x, y, p);
                         consumed = true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Copies this fully correct pen handling code:

https://github.com/libsdl-org/SDL/blob/4231848791dae4e0a9afb32e2f9e897985b7dde2/android-project/app/src/main/java/org/libsdl/app/SDLSurface.java#L264-L278

to the existing half-correct pen handling code in `SDLControllerManager.java`.

This should probably be handled by a common function, but I was unsure where to put it. Probably in `SDLActivity` but that already has 2190 lines of code, which is discouraging.