### PR TITLE
Improve log documentation

### DIFF
--- a/include/SDL3/SDL_log.h
+++ b/include/SDL3/SDL_log.h
@@ -56,6 +56,15 @@
  * - Windows: debug output stream
  * - Android: log output
  * - Others: standard error output (stderr)
+ *
+ * You don't need to have a newline (`\n`) on the end of messages, the
+ * functions will do that for you. For consistent behavior cross-platform, you
+ * shouldn't have any newlines in messages, such as to log multiple lines in
+ * one call; unusual platform-specific behavior can be observed in such usage.
+ * Do one log call per line instead, with no newlines in messages.
+ *
+ * Each log call is atomic, so you won't see log messages cut off one another
+ * when logging from multiple threads.
  */
 
 #ifndef SDL_log_h_


### PR DESCRIPTION
I noticed in the SDL3 source code there's inconsistency in whether a `\n` is put on the end of log messages or not, but discussing with @slouken elsewhere, it seems it's valid to not have `\n` on the end of messages, so I've documented that. I also documented that you really shouldn't even have `\n` in messages for consistent/expected cross-platform behavior.

Maybe the bit about log messages being atomic isn't needed, since the log functions are documented as thread-safe, but I think it's good for helping new users.

If this PR is accepted, the log calls in the SDL source code maybe should be changed to match it, not having `\n` on the end of log messages.