### PR TITLE
Remove newlines from log messages

### DIFF
--- a/VisualC-GDK/tests/testgdk/src/testgdk.cpp
+++ b/VisualC-GDK/tests/testgdk/src/testgdk.cpp
@@ -198,7 +198,7 @@ LoadSprite(const char *file)
             return -1;
         }
         if (!SDL_SetTextureBlendMode(sprites[i], blendMode)) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't set blend mode: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't set blend mode: %s", SDL_GetError());
             SDL_DestroyTexture(sprites[i]);
             return -1;
         }
@@ -405,7 +405,7 @@ main(int argc, char *argv[])
     sprites =
         (SDL_Texture **) SDL_malloc(state->num_windows * sizeof(*sprites));
     if (!sprites) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!");
         quit(2);
     }
     for (i = 0; i < state->num_windows; ++i) {
@@ -420,13 +420,13 @@ main(int argc, char *argv[])
     soundname = GetResourceFilename(argc > 1 ? argv[1] : NULL, "sample.wav");
 
     if (!soundname) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", SDL_GetError());
         quit(1);
     }
 
     /* Load the wave file into memory */
     if (!SDL_LoadWAV(soundname, &wave.spec, &wave.sound, &wave.soundlen)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't load %s: %s\n", soundname, SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't load %s: %s", soundname, SDL_GetError());
         quit(1);
     }
 
@@ -436,11 +436,11 @@ main(int argc, char *argv[])
         SDL_Log("%i: %s", i, SDL_GetAudioDriver(i));
     }
 
-    SDL_Log("Using audio driver: %s\n", SDL_GetCurrentAudioDriver());
+    SDL_Log("Using audio driver: %s", SDL_GetCurrentAudioDriver());
 
     stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &wave.spec, NULL, NULL);
     if (!stream) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create audio stream: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create audio stream: %s", SDL_GetError());
         return -1;
     }
     SDL_ResumeAudioDevice(SDL_GetAudioStreamDevice(stream));

--- a/cmake/test/main_cli.c
+++ b/cmake/test/main_cli.c
@@ -6,7 +6,7 @@ int main(int argc, char *argv[])
 {
     SDL_SetMainReady();
     if (!SDL_Init(0)) {
-        SDL_Log("Could not initialize SDL: %s\n", SDL_GetError());
+        SDL_Log("Could not initialize SDL: %s", SDL_GetError());
         return 1;
     }
     SDL_Delay(100);

--- a/cmake/test/main_gui.c
+++ b/cmake/test/main_gui.c
@@ -6,12 +6,12 @@ int main(int argc, char *argv[])
     SDL_Window *window = NULL;
     SDL_Surface *screenSurface = NULL;
     if (!SDL_Init(SDL_INIT_VIDEO)) {
-        SDL_Log("Could not initialize SDL: %s\n", SDL_GetError());
+        SDL_Log("Could not initialize SDL: %s", SDL_GetError());
         return 1;
     }
     window = SDL_CreateWindow("Hello SDL", 640, 480, 0);
     if (!window) {
-        SDL_Log("could not create window: %s\n", SDL_GetError());
+        SDL_Log("could not create window: %s", SDL_GetError());
         return 1;
     }
     screenSurface = SDL_GetWindowSurface(window);

--- a/cmake/test/main_lib.c
+++ b/cmake/test/main_lib.c
@@ -18,7 +18,7 @@ int MYLIBRARY_EXPORT mylibrary_work(void);
 int mylibrary_init(void) {
     SDL_SetMainReady();
     if (!SDL_Init(0)) {
-        SDL_Log("Could not initialize SDL: %s\n", SDL_GetError());
+        SDL_Log("Could not initialize SDL: %s", SDL_GetError());
         return 1;
     }
     return 0;

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -193,7 +193,7 @@ Rather than iterating over audio devices using a device index, there are new fun
         if (devices) {
             for (i = 0; i < num_devices; ++i) {
                 SDL_AudioDeviceID instance_id = devices[i];
-                SDL_Log("AudioDevice %" SDL_PRIu32 ": %s\n", instance_id, SDL_GetAudioDeviceName(instance_id));
+                SDL_Log("AudioDevice %" SDL_PRIu32 ": %s", instance_id, SDL_GetAudioDeviceName(instance_id));
             }
             SDL_free(devices);
         }
@@ -749,7 +749,7 @@ Rather than iterating over haptic devices using device index, there is a new fun
         if (haptics) {
             for (i = 0; i < num_haptics; ++i) {
                 SDL_HapticID instance_id = haptics[i];
-                SDL_Log("Haptic %" SDL_PRIu32 ": %s\n", instance_id, SDL_GetHapticNameForID(instance_id));
+                SDL_Log("Haptic %" SDL_PRIu32 ": %s", instance_id, SDL_GetHapticNameForID(instance_id));
             }
             SDL_free(haptics);
         }
@@ -917,7 +917,7 @@ Rather than iterating over joysticks using device index, there is a new function
                 const char *name = SDL_GetJoystickNameForID(instance_id);
                 const char *path = SDL_GetJoystickPathForID(instance_id);
 
-                SDL_Log("Joystick %" SDL_PRIu32 ": %s%s%s VID 0x%.4x, PID 0x%.4x\n",
+                SDL_Log("Joystick %" SDL_PRIu32 ": %s%s%s VID 0x%.4x, PID 0x%.4x",
                         instance_id, name ? name : "Unknown", path ? ", " : "", path ? path : "", SDL_GetJoystickVendorForID(instance_id), SDL_GetJoystickProductForID(instance_id));
             }
             SDL_free(joysticks);
@@ -1696,7 +1696,7 @@ Rather than iterating over sensors using device index, there is a new function S
         SDL_SensorID *sensors = SDL_GetSensors(&num_sensors);
         if (sensors) {
             for (i = 0; i < num_sensors; ++i) {
-                SDL_Log("Sensor %" SDL_PRIu32 ": %s, type %d, platform type %d\n",
+                SDL_Log("Sensor %" SDL_PRIu32 ": %s, type %d, platform type %d",
                         sensors[i],
                         SDL_GetSensorNameForID(sensors[i]),
                         SDL_GetSensorTypeForID(sensors[i]),
@@ -2121,7 +2121,7 @@ Rather than iterating over displays using display index, there is a new function
                 SDL_DisplayID instance_id = displays[i];
                 const char *name = SDL_GetDisplayName(instance_id);
 
-                SDL_Log("Display %" SDL_PRIu32 ": %s\n", instance_id, name ? name : "Unknown");
+                SDL_Log("Display %" SDL_PRIu32 ": %s", instance_id, name ? name : "Unknown");
             }
             SDL_free(displays);
         }
@@ -2167,7 +2167,7 @@ Rather than iterating over display modes using an index, there is a new function
     if (modes) {
         for (i = 0; i < num_modes; ++i) {
             SDL_DisplayMode *mode = modes[i];
-            SDL_Log("Display %" SDL_PRIu32 " mode %d: %dx%d@%gx %gHz\n",
+            SDL_Log("Display %" SDL_PRIu32 " mode %d: %dx%d@%gx %gHz",
                     display, i, mode->w, mode->h, mode->pixel_density, mode->refresh_rate);
         }
         SDL_free(modes);

--- a/docs/hello.c
+++ b/docs/hello.c
@@ -21,7 +21,7 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
 {
     /* Create the window */
     if (!SDL_CreateWindowAndRenderer("Hello World", 800, 600, SDL_WINDOW_FULLSCREEN, &window, &renderer)) {
-        SDL_Log("Couldn't create window and renderer: %s\n", SDL_GetError());
+        SDL_Log("Couldn't create window and renderer: %s", SDL_GetError());
         return SDL_APP_FAILURE;
     }
     return SDL_APP_CONTINUE;

--- a/include/SDL3/SDL_log.h
+++ b/include/SDL3/SDL_log.h
@@ -56,6 +56,15 @@
  * - Windows: debug output stream
  * - Android: log output
  * - Others: standard error output (stderr)
+ *
+ * You don't need to have a newline (`\n`) on the end of messages, the
+ * functions will do that for you. For consistent behavior cross-platform, you
+ * shouldn't have any newlines in messages, such as to log multiple lines in
+ * one call; unusual platform-specific behavior can be observed in such usage.
+ * Do one log call per line instead, with no newlines in messages.
+ *
+ * Each log call is atomic, so you won't see log messages cut off one another
+ * when logging from multiple threads.
  */
 
 #ifndef SDL_log_h_

--- a/src/SDL_properties.c
+++ b/src/SDL_properties.c
@@ -766,25 +766,25 @@ static void SDLCALL SDL_DumpPropertiesCallback(void *userdata, SDL_PropertiesID 
 {
     switch (SDL_GetPropertyType(props, name)) {
     case SDL_PROPERTY_TYPE_POINTER:
-        SDL_Log("%s: %p\n", name, SDL_GetPointerProperty(props, name, NULL));
+        SDL_Log("%s: %p", name, SDL_GetPointerProperty(props, name, NULL));
         break;
     case SDL_PROPERTY_TYPE_STRING:
-        SDL_Log("%s: \"%s\"\n", name, SDL_GetStringProperty(props, name, ""));
+        SDL_Log("%s: \"%s\"", name, SDL_GetStringProperty(props, name, ""));
         break;
     case SDL_PROPERTY_TYPE_NUMBER:
         {
             Sint64 value = SDL_GetNumberProperty(props, name, 0);
-            SDL_Log("%s: %" SDL_PRIs64 " (%" SDL_PRIx64 ")\n", name, value, value);
+            SDL_Log("%s: %" SDL_PRIs64 " (%" SDL_PRIx64 ")", name, value, value);
         }
         break;
     case SDL_PROPERTY_TYPE_FLOAT:
-        SDL_Log("%s: %g\n", name, SDL_GetFloatProperty(props, name, 0.0f));
+        SDL_Log("%s: %g", name, SDL_GetFloatProperty(props, name, 0.0f));
         break;
     case SDL_PROPERTY_TYPE_BOOLEAN:
-        SDL_Log("%s: %s\n", name, SDL_GetBooleanProperty(props, name, false) ? "true" : "false");
+        SDL_Log("%s: %s", name, SDL_GetBooleanProperty(props, name, false) ? "true" : "false");
         break;
     default:
-        SDL_Log("%s UNKNOWN TYPE\n", name);
+        SDL_Log("%s UNKNOWN TYPE", name);
         break;
     }
 }

--- a/src/SDL_utils.c
+++ b/src/SDL_utils.c
@@ -240,7 +240,7 @@ void SDL_SetObjectsInvalid(void)
                 type = "unknown object";
                 break;
             }
-            SDL_Log("Leaked %s (%p)\n", type, object);
+            SDL_Log("Leaked %s (%p)", type, object);
         }
         SDL_assert(SDL_HashTableEmpty(SDL_objects));
 

--- a/src/audio/SDL_sysaudio.h
+++ b/src/audio/SDL_sysaudio.h
@@ -28,7 +28,7 @@
 #define DEBUG_AUDIO_CONVERT 0
 
 #if DEBUG_AUDIO_CONVERT
-#define LOG_DEBUG_AUDIO_CONVERT(from, to) SDL_Log("SDL_AUDIO_CONVERT: Converting %s to %s.\n", from, to);
+#define LOG_DEBUG_AUDIO_CONVERT(from, to) SDL_Log("SDL_AUDIO_CONVERT: Converting %s to %s.", from, to);
 #else
 #define LOG_DEBUG_AUDIO_CONVERT(from, to)
 #endif

--- a/src/audio/aaudio/SDL_aaudio.c
+++ b/src/audio/aaudio/SDL_aaudio.c
@@ -315,10 +315,10 @@ static bool BuildAAudioStream(SDL_AudioDevice *device)
     ctx.AAudioStreamBuilder_setDataCallback(builder, AAUDIO_dataCallback, device);
     // Some devices have flat sounding audio when low latency mode is enabled, but this is a better experience for most people
     if (SDL_GetHintBoolean(SDL_HINT_ANDROID_LOW_LATENCY_AUDIO, true)) {
-        SDL_Log("Low latency audio enabled\n");
+        SDL_Log("Low latency audio enabled");
         ctx.AAudioStreamBuilder_setPerformanceMode(builder, AAUDIO_PERFORMANCE_MODE_LOW_LATENCY);
     } else {
-        SDL_Log("Low latency audio disabled\n");
+        SDL_Log("Low latency audio disabled");
     }
 
     LOGI("AAudio Try to open %u hz %s %u channels samples %u",

--- a/src/audio/coreaudio/SDL_coreaudio.m
+++ b/src/audio/coreaudio/SDL_coreaudio.m
@@ -31,7 +31,7 @@
 #if DEBUG_COREAUDIO
     #define CHECK_RESULT(msg) \
         if (result != noErr) { \
-            SDL_Log("COREAUDIO: Got error %d from '%s'!\n", (int)result, msg); \
+            SDL_Log("COREAUDIO: Got error %d from '%s'!", (int)result, msg); \
             return SDL_SetError("CoreAudio error (%s): %d", msg, (int)result); \
         }
 #else
@@ -224,7 +224,7 @@ static void RefreshPhysicalDevices(void)
                 name[len] = '\0';
 
                 #if DEBUG_COREAUDIO
-                SDL_Log("COREAUDIO: Found %s device #%d: '%s' (devid %d)\n", ((recording) ? "recording" : "playback"), (int)i, name, (int)dev);
+                SDL_Log("COREAUDIO: Found %s device #%d: '%s' (devid %d)", ((recording) ? "recording" : "playback"), (int)i, name, (int)dev);
                 #endif
                 SDLCoreAudioHandle *newhandle = (SDLCoreAudioHandle *) SDL_calloc(1, sizeof (*newhandle));
                 if (newhandle) {
@@ -834,7 +834,7 @@ static bool PrepareAudioQueue(SDL_AudioDevice *device)
     }
 
     #if DEBUG_COREAUDIO
-    SDL_Log("COREAUDIO: numAudioBuffers == %d\n", numAudioBuffers);
+    SDL_Log("COREAUDIO: numAudioBuffers == %d", numAudioBuffers);
     #endif
 
     for (int i = 0; i < numAudioBuffers; i++) {

--- a/src/audio/disk/SDL_diskaudio.c
+++ b/src/audio/disk/SDL_diskaudio.c
@@ -136,7 +136,7 @@ static bool DISKAUDIO_OpenDevice(SDL_AudioDevice *device)
     }
 
     SDL_LogCritical(SDL_LOG_CATEGORY_AUDIO, "You are using the SDL disk i/o audio driver!");
-    SDL_LogCritical(SDL_LOG_CATEGORY_AUDIO, " %s file [%s].\n", recording ? "Reading from" : "Writing to", fname);
+    SDL_LogCritical(SDL_LOG_CATEGORY_AUDIO, " %s file [%s].", recording ? "Reading from" : "Writing to", fname);
 
     return true;  // We're ready to rock and roll. :-)
 }

--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -847,7 +847,7 @@ void SDL_StopEventLoop(void)
     SDL_EventQ.active = false;
 
     if (report && SDL_atoi(report)) {
-        SDL_Log("SDL EVENT QUEUE: Maximum events in-flight: %d\n",
+        SDL_Log("SDL EVENT QUEUE: Maximum events in-flight: %d",
                 SDL_EventQ.max_events_seen);
     }
 

--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -220,7 +220,7 @@ void SDL_ResetKeyboard(void)
     int scancode;
 
 #ifdef DEBUG_KEYBOARD
-    SDL_Log("Resetting keyboard\n");
+    SDL_Log("Resetting keyboard");
 #endif
     for (scancode = SDL_SCANCODE_UNKNOWN; scancode < SDL_SCANCODE_COUNT; ++scancode) {
         if (keyboard->keystate[scancode]) {
@@ -517,7 +517,7 @@ static bool SDL_SendKeyboardKeyInternal(Uint64 timestamp, Uint32 flags, SDL_Keyb
     const Uint8 source = flags & KEYBOARD_SOURCE_MASK;
 
 #ifdef DEBUG_KEYBOARD
-    SDL_Log("The '%s' key has been %s\n", SDL_GetScancodeName(scancode), down ? "pressed" : "released");
+    SDL_Log("The '%s' key has been %s", SDL_GetScancodeName(scancode), down ? "pressed" : "released");
 #endif
 
     // Figure out what type of event this is

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -605,7 +605,7 @@ static bool SDL_UpdateMouseFocus(SDL_Window *window, float x, float y, Uint32 bu
     if (!inWindow) {
         if (window == mouse->focus) {
 #ifdef DEBUG_MOUSE
-            SDL_Log("Mouse left window, synthesizing move & focus lost event\n");
+            SDL_Log("Mouse left window, synthesizing move & focus lost event");
 #endif
             if (send_mouse_motion) {
                 SDL_PrivateSendMouseMotion(0, window, SDL_GLOBAL_MOUSE_ID, false, x, y);
@@ -617,7 +617,7 @@ static bool SDL_UpdateMouseFocus(SDL_Window *window, float x, float y, Uint32 bu
 
     if (window != mouse->focus) {
 #ifdef DEBUG_MOUSE
-        SDL_Log("Mouse entered window, synthesizing focus gain & move event\n");
+        SDL_Log("Mouse entered window, synthesizing focus gain & move event");
 #endif
         SDL_SetMouseFocus(window);
         if (send_mouse_motion) {
@@ -740,7 +740,7 @@ static void SDL_PrivateSendMouseMotion(Uint64 timestamp, SDL_Window *window, SDL
 
     if (mouse->has_position && xrel == 0.0f && yrel == 0.0f) { // Drop events that don't change state
 #ifdef DEBUG_MOUSE
-        SDL_Log("Mouse event didn't change state - dropped!\n");
+        SDL_Log("Mouse event didn't change state - dropped!");
 #endif
         return;
     }

--- a/src/filesystem/cocoa/SDL_sysfilesystem.m
+++ b/src/filesystem/cocoa/SDL_sysfilesystem.m
@@ -92,7 +92,7 @@ char *SDL_SYS_GetPrefPath(const char *org, const char *app)
             static bool shown = false;
             if (!shown) {
                 shown = true;
-                SDL_LogCritical(SDL_LOG_CATEGORY_SYSTEM, "tvOS does not have persistent local storage! Use iCloud storage if you want your data to persist between sessions.\n");
+                SDL_LogCritical(SDL_LOG_CATEGORY_SYSTEM, "tvOS does not have persistent local storage! Use iCloud storage if you want your data to persist between sessions.");
             }
         }
 

--- a/src/hidapi/android/hid.cpp
+++ b/src/hidapi/android/hid.cpp
@@ -1028,7 +1028,7 @@ extern "C"
 
 static void SDLCALL RequestBluetoothPermissionCallback( void *userdata, const char *permission, bool granted )
 {
-	SDL_Log( "Bluetooth permission %s\n", granted ? "granted" : "denied" );
+	SDL_Log( "Bluetooth permission %s", granted ? "granted" : "denied" );
 
 	if ( granted && g_HIDDeviceManagerCallbackHandler )
 	{

--- a/src/joystick/android/SDL_sysjoystick.c
+++ b/src/joystick/android/SDL_sysjoystick.c
@@ -329,7 +329,7 @@ void Android_AddJoystick(int device_id, const char *name, const char *desc, int 
     }
 
 #ifdef DEBUG_JOYSTICK
-    SDL_Log("Joystick: %s, descriptor %s, vendor = 0x%.4x, product = 0x%.4x, %d axes, %d hats\n", name, desc, vendor_id, product_id, naxes, nhats);
+    SDL_Log("Joystick: %s, descriptor %s, vendor = 0x%.4x, product = 0x%.4x, %d axes, %d hats", name, desc, vendor_id, product_id, naxes, nhats);
 #endif
 
     if (nhats > 0) {

--- a/src/joystick/hidapi/SDL_hidapi_ps3.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps3.c
@@ -566,7 +566,7 @@ static bool HIDAPI_DriverPS3_UpdateDevice(SDL_HIDAPI_Device *device)
             break;
         default:
 #ifdef DEBUG_JOYSTICK
-            SDL_Log("Unknown PS3 packet: 0x%.2x\n", data[0]);
+            SDL_Log("Unknown PS3 packet: 0x%.2x", data[0]);
 #endif
             break;
         }
@@ -1004,7 +1004,7 @@ static bool HIDAPI_DriverPS3ThirdParty_UpdateDevice(SDL_HIDAPI_Device *device)
             HIDAPI_DriverPS3ThirdParty_HandleStatePacket18(joystick, ctx, data, size);
         } else {
 #ifdef DEBUG_JOYSTICK
-            SDL_Log("Unknown PS3 packet, size %d\n", size);
+            SDL_Log("Unknown PS3 packet, size %d", size);
 #endif
         }
     }
@@ -1357,7 +1357,7 @@ static bool HIDAPI_DriverPS3SonySixaxis_UpdateDevice(SDL_HIDAPI_Device *device)
         break;
     default:
 #ifdef DEBUG_JOYSTICK
-        SDL_Log("Unknown PS3 packet: 0x%.2x\n", data[0]);
+        SDL_Log("Unknown PS3 packet: 0x%.2x", data[0]);
 #endif
         break;
     }

--- a/src/joystick/hidapi/SDL_hidapi_ps4.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps4.c
@@ -323,7 +323,7 @@ static bool HIDAPI_DriverPS4_InitDevice(SDL_HIDAPI_Device *device)
             if (size > 0) {
                 HIDAPI_DumpPacket("PS4 first packet: size = %d", data, size);
             } else {
-                SDL_Log("PS4 first packet: size = %d\n", size);
+                SDL_Log("PS4 first packet: size = %d", size);
             }
 #endif
             if (size > 0 &&
@@ -468,7 +468,7 @@ static bool HIDAPI_DriverPS4_LoadOfficialCalibrationData(SDL_HIDAPI_Device *devi
 
     if (!ctx->official_controller) {
 #ifdef DEBUG_PS4_CALIBRATION
-        SDL_Log("Not an official controller, ignoring calibration\n");
+        SDL_Log("Not an official controller, ignoring calibration");
 #endif
         return false;
     }
@@ -478,7 +478,7 @@ static bool HIDAPI_DriverPS4_LoadOfficialCalibrationData(SDL_HIDAPI_Device *devi
         size = ReadFeatureReport(device->dev, k_ePS4FeatureReportIdGyroCalibration_USB, data, sizeof(data));
         if (size < 35) {
 #ifdef DEBUG_PS4_CALIBRATION
-            SDL_Log("Short read of calibration data: %d, ignoring calibration\n", size);
+            SDL_Log("Short read of calibration data: %d, ignoring calibration", size);
 #endif
             return false;
         }
@@ -487,7 +487,7 @@ static bool HIDAPI_DriverPS4_LoadOfficialCalibrationData(SDL_HIDAPI_Device *devi
             size = ReadFeatureReport(device->dev, k_ePS4FeatureReportIdGyroCalibration_BT, data, sizeof(data));
             if (size < 35) {
 #ifdef DEBUG_PS4_CALIBRATION
-                SDL_Log("Short read of calibration data: %d, ignoring calibration\n", size);
+                SDL_Log("Short read of calibration data: %d, ignoring calibration", size);
 #endif
                 return false;
             }
@@ -590,19 +590,19 @@ static bool HIDAPI_DriverPS4_LoadOfficialCalibrationData(SDL_HIDAPI_Device *devi
         ctx->hardware_calibration = true;
         for (i = 0; i < 6; ++i) {
 #ifdef DEBUG_PS4_CALIBRATION
-            SDL_Log("calibration[%d] bias = %d, sensitivity = %f\n", i, ctx->calibration[i].bias, ctx->calibration[i].scale);
+            SDL_Log("calibration[%d] bias = %d, sensitivity = %f", i, ctx->calibration[i].bias, ctx->calibration[i].scale);
 #endif
             // Some controllers have a bad calibration
             if (SDL_abs(ctx->calibration[i].bias) > 1024 || SDL_fabsf(1.0f - ctx->calibration[i].scale) > 0.5f) {
 #ifdef DEBUG_PS4_CALIBRATION
-                SDL_Log("invalid calibration, ignoring\n");
+                SDL_Log("invalid calibration, ignoring");
 #endif
                 ctx->hardware_calibration = false;
             }
         }
     } else {
 #ifdef DEBUG_PS4_CALIBRATION
-        SDL_Log("Calibration data not available\n");
+        SDL_Log("Calibration data not available");
 #endif
     }
     return ctx->hardware_calibration;
@@ -1291,7 +1291,7 @@ static bool HIDAPI_DriverPS4_UpdateDevice(SDL_HIDAPI_Device *device)
             break;
         default:
 #ifdef DEBUG_JOYSTICK
-            SDL_Log("Unknown PS4 packet: 0x%.2x\n", data[0]);
+            SDL_Log("Unknown PS4 packet: 0x%.2x", data[0]);
 #endif
             break;
         }

--- a/src/joystick/hidapi/SDL_hidapi_ps5.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps5.c
@@ -402,7 +402,7 @@ static bool HIDAPI_DriverPS5_InitDevice(SDL_HIDAPI_Device *device)
     if (size > 0) {
         HIDAPI_DumpPacket("PS5 first packet: size = %d", data, size);
     } else {
-        SDL_Log("PS5 first packet: size = %d\n", size);
+        SDL_Log("PS5 first packet: size = %d", size);
     }
 #endif
     if (size == 64) {
@@ -561,7 +561,7 @@ static void HIDAPI_DriverPS5_LoadCalibrationData(SDL_HIDAPI_Device *device)
     size = ReadFeatureReport(device->dev, k_EPS5FeatureReportIdCalibration, data, sizeof(data));
     if (size < 35) {
 #ifdef DEBUG_PS5_CALIBRATION
-        SDL_Log("Short read of calibration data: %d, ignoring calibration\n", size);
+        SDL_Log("Short read of calibration data: %d, ignoring calibration", size);
 #endif
         return;
     }
@@ -631,12 +631,12 @@ static void HIDAPI_DriverPS5_LoadCalibrationData(SDL_HIDAPI_Device *device)
         for (i = 0; i < 6; ++i) {
             float divisor = (i < 3 ? 64.0f : 1.0f);
 #ifdef DEBUG_PS5_CALIBRATION
-            SDL_Log("calibration[%d] bias = %d, sensitivity = %f\n", i, ctx->calibration[i].bias, ctx->calibration[i].sensitivity);
+            SDL_Log("calibration[%d] bias = %d, sensitivity = %f", i, ctx->calibration[i].bias, ctx->calibration[i].sensitivity);
 #endif
             // Some controllers have a bad calibration
             if ((SDL_abs(ctx->calibration[i].bias) > 1024) || (SDL_fabsf(1.0f - ctx->calibration[i].sensitivity / divisor) > 0.5f)) {
 #ifdef DEBUG_PS5_CALIBRATION
-                SDL_Log("invalid calibration, ignoring\n");
+                SDL_Log("invalid calibration, ignoring");
 #endif
                 ctx->hardware_calibration = false;
             }
@@ -1531,7 +1531,7 @@ static bool HIDAPI_DriverPS5_UpdateDevice(SDL_HIDAPI_Device *device)
             break;
         default:
 #ifdef DEBUG_JOYSTICK
-            SDL_Log("Unknown PS5 packet: 0x%.2x\n", data[0]);
+            SDL_Log("Unknown PS5 packet: 0x%.2x", data[0]);
 #endif
             break;
         }

--- a/src/joystick/hidapi/SDL_hidapi_steam_hori.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam_hori.c
@@ -324,7 +324,7 @@ static void HIDAPI_DriverSteamHori_HandleStatePacket(SDL_Joystick *joystick, SDL
 
         SDL_SendJoystickSensor(timestamp, joystick, SDL_SENSOR_GYRO, sensor_timestamp, imu_data, 3);
 
-      //  SDL_Log("%u %f, %f, %f \n", data[0], imu_data[0], imu_data[1], imu_data[2] );
+      //  SDL_Log("%u %f, %f, %f ", data[0], imu_data[0], imu_data[1], imu_data[2] );
         imu_data[2] = LOAD16(data[18], data[19]) * accelScale;
         imu_data[1] = -1 * LOAD16(data[20], data[21]) * accelScale;
         imu_data[0] = LOAD16(data[22], data[23]) * accelScale;

--- a/src/joystick/hidapi/SDL_hidapi_switch.c
+++ b/src/joystick/hidapi/SDL_hidapi_switch.c
@@ -521,11 +521,11 @@ static bool WriteProprietary(SDL_DriverSwitch_Context *ctx, ESwitchProprietaryCo
         }
 
         if (!waitForReply || ReadProprietaryReply(ctx, ucCommand)) {
-            // SDL_Log("Succeeded%s after %d tries\n", ctx->m_bSyncWrite ? " (sync)" : "", nTries);
+            // SDL_Log("Succeeded%s after %d tries", ctx->m_bSyncWrite ? " (sync)" : "", nTries);
             return true;
         }
     }
-    // SDL_Log("Failed%s after %d tries\n", ctx->m_bSyncWrite ? " (sync)" : "", nTries);
+    // SDL_Log("Failed%s after %d tries", ctx->m_bSyncWrite ? " (sync)" : "", nTries);
     return false;
 }
 
@@ -579,7 +579,7 @@ static void EncodeRumble(SwitchRumbleData_t *pRumble, Uint16 usHighFreq, Uint8 u
         pRumble->rgucData[3] = usLowFreqAmp & 0xFF;
 
 #ifdef DEBUG_RUMBLE
-        SDL_Log("Freq: %.2X %.2X  %.2X, Amp: %.2X  %.2X %.2X\n",
+        SDL_Log("Freq: %.2X %.2X  %.2X, Amp: %.2X  %.2X %.2X",
                 usHighFreq & 0xFF, ((usHighFreq >> 8) & 0x01), ucLowFreq,
                 ucHighFreqAmp, ((usLowFreqAmp >> 8) & 0x80), usLowFreqAmp & 0xFF);
 #endif
@@ -1647,7 +1647,7 @@ static bool HIDAPI_DriverSwitch_SendPendingRumble(SDL_DriverSwitch_Context *ctx)
         Uint16 high_frequency_rumble = (Uint16)ctx->m_unRumblePending;
 
 #ifdef DEBUG_RUMBLE
-        SDL_Log("Sent pending rumble %d/%d, %d ms after previous rumble\n", low_frequency_rumble, high_frequency_rumble, SDL_GetTicks() - ctx->m_ulRumbleSent);
+        SDL_Log("Sent pending rumble %d/%d, %d ms after previous rumble", low_frequency_rumble, high_frequency_rumble, SDL_GetTicks() - ctx->m_ulRumbleSent);
 #endif
         ctx->m_bRumblePending = false;
         ctx->m_unRumblePending = 0;
@@ -1659,7 +1659,7 @@ static bool HIDAPI_DriverSwitch_SendPendingRumble(SDL_DriverSwitch_Context *ctx)
         ctx->m_bRumbleZeroPending = false;
 
 #ifdef DEBUG_RUMBLE
-        SDL_Log("Sent pending zero rumble, %d ms after previous rumble\n", SDL_GetTicks() - ctx->m_ulRumbleSent);
+        SDL_Log("Sent pending zero rumble, %d ms after previous rumble", SDL_GetTicks() - ctx->m_ulRumbleSent);
 #endif
         return HIDAPI_DriverSwitch_ActuallyRumbleJoystick(ctx, 0, 0);
     }
@@ -1709,7 +1709,7 @@ static bool HIDAPI_DriverSwitch_RumbleJoystick(SDL_HIDAPI_Device *device, SDL_Jo
     }
 
 #ifdef DEBUG_RUMBLE
-    SDL_Log("Sent rumble %d/%d\n", low_frequency_rumble, high_frequency_rumble);
+    SDL_Log("Sent rumble %d/%d", low_frequency_rumble, high_frequency_rumble);
 #endif
 
     return HIDAPI_DriverSwitch_ActuallyRumbleJoystick(ctx, low_frequency_rumble, high_frequency_rumble);
@@ -2719,7 +2719,7 @@ static bool HIDAPI_DriverSwitch_UpdateDevice(SDL_HIDAPI_Device *device)
         } else if (ctx->m_bRumbleActive &&
                    now >= (ctx->m_ulRumbleSent + RUMBLE_REFRESH_FREQUENCY_MS)) {
 #ifdef DEBUG_RUMBLE
-            SDL_Log("Sent continuing rumble, %d ms after previous rumble\n", now - ctx->m_ulRumbleSent);
+            SDL_Log("Sent continuing rumble, %d ms after previous rumble", now - ctx->m_ulRumbleSent);
 #endif
             WriteRumble(ctx);
         }

--- a/src/joystick/hidapi/SDL_hidapi_wii.c
+++ b/src/joystick/hidapi/SDL_hidapi_wii.c
@@ -1364,7 +1364,7 @@ static void HandleStatus(SDL_DriverWii_Context *ctx, SDL_Joystick *joystick)
     // The report data format has been reset, need to update it
     ResetButtonPacketType(ctx);
 
-    SDL_LogDebug(SDL_LOG_CATEGORY_INPUT, "HIDAPI Wii: Status update, extension %s\n", hasExtension ? "CONNECTED" : "DISCONNECTED");
+    SDL_LogDebug(SDL_LOG_CATEGORY_INPUT, "HIDAPI Wii: Status update, extension %s", hasExtension ? "CONNECTED" : "DISCONNECTED");
 
     /* When Motion Plus is active, we get extension connect/disconnect status
      * through the Motion Plus packets. Otherwise we can use the status here.
@@ -1404,7 +1404,7 @@ static void HandleResponse(SDL_DriverWii_Context *ctx, SDL_Joystick *joystick)
         if (ParseExtensionIdentifyResponse(ctx, &extension)) {
             if ((extension & WII_EXTENSION_MOTIONPLUS_MASK) == WII_EXTENSION_MOTIONPLUS_ID) {
                 // Motion Plus is currently active
-                SDL_LogDebug(SDL_LOG_CATEGORY_INPUT, "HIDAPI Wii: Motion Plus CONNECTED (stage %d)\n", ctx->m_eCommState == k_eWiiCommunicationState_CheckMotionPlusStage1 ? 1 : 2);
+                SDL_LogDebug(SDL_LOG_CATEGORY_INPUT, "HIDAPI Wii: Motion Plus CONNECTED (stage %d)", ctx->m_eCommState == k_eWiiCommunicationState_CheckMotionPlusStage1 ? 1 : 2);
 
                 if (!ctx->m_bMotionPlusPresent) {
                     // Reinitialize to get new sensor availability
@@ -1420,7 +1420,7 @@ static void HandleResponse(SDL_DriverWii_Context *ctx, SDL_Joystick *joystick)
 
             } else {
                 // Motion Plus is not present
-                SDL_LogDebug(SDL_LOG_CATEGORY_INPUT, "HIDAPI Wii: Motion Plus DISCONNECTED (stage %d)\n", ctx->m_eCommState == k_eWiiCommunicationState_CheckMotionPlusStage1 ? 1 : 2);
+                SDL_LogDebug(SDL_LOG_CATEGORY_INPUT, "HIDAPI Wii: Motion Plus DISCONNECTED (stage %d)", ctx->m_eCommState == k_eWiiCommunicationState_CheckMotionPlusStage1 ? 1 : 2);
 
                 if (ctx->m_bMotionPlusPresent) {
                     // Reinitialize to get new sensor availability
@@ -1443,7 +1443,7 @@ static void HandleButtonPacket(SDL_DriverWii_Context *ctx, SDL_Joystick *joystic
 
     // FIXME: This should see if the data format is compatible rather than equal
     if (eExpectedReport != ctx->m_rgucReadBuffer[0]) {
-        SDL_LogDebug(SDL_LOG_CATEGORY_INPUT, "HIDAPI Wii: Resetting report mode to %d\n", eExpectedReport);
+        SDL_LogDebug(SDL_LOG_CATEGORY_INPUT, "HIDAPI Wii: Resetting report mode to %d", eExpectedReport);
         RequestButtonPacketType(ctx, eExpectedReport);
     }
 

--- a/src/joystick/hidapi/SDL_hidapi_xbox360w.c
+++ b/src/joystick/hidapi/SDL_hidapi_xbox360w.c
@@ -306,7 +306,7 @@ static bool HIDAPI_DriverXbox360W_UpdateDevice(SDL_HIDAPI_Device *device)
         if (size == 2 && data[0] == 0x08) {
             bool connected = (data[1] & 0x80) ? true : false;
 #ifdef DEBUG_JOYSTICK
-            SDL_Log("Connected = %s\n", connected ? "TRUE" : "FALSE");
+            SDL_Log("Connected = %s", connected ? "TRUE" : "FALSE");
 #endif
             if (connected != ctx->connected) {
                 ctx->connected = connected;
@@ -323,14 +323,14 @@ static bool HIDAPI_DriverXbox360W_UpdateDevice(SDL_HIDAPI_Device *device)
         } else if (size == 29 && data[0] == 0x00 && data[1] == 0x0f && data[2] == 0x00 && data[3] == 0xf0) {
             // Serial number is data[7-13]
 #ifdef DEBUG_JOYSTICK
-            SDL_Log("Battery status (initial): %d\n", data[17]);
+            SDL_Log("Battery status (initial): %d", data[17]);
 #endif
             if (joystick) {
                 UpdatePowerLevel(joystick, data[17]);
             }
         } else if (size == 29 && data[0] == 0x00 && data[1] == 0x00 && data[2] == 0x00 && data[3] == 0x13) {
 #ifdef DEBUG_JOYSTICK
-            SDL_Log("Battery status: %d\n", data[4]);
+            SDL_Log("Battery status: %d", data[4]);
 #endif
             if (joystick) {
                 UpdatePowerLevel(joystick, data[4]);

--- a/src/joystick/hidapi/SDL_hidapi_xboxone.c
+++ b/src/joystick/hidapi/SDL_hidapi_xboxone.c
@@ -213,7 +213,7 @@ static void SDLCALL SDL_HomeLEDHintChanged(void *userdata, const char *name, con
 static void SetInitState(SDL_DriverXboxOne_Context *ctx, SDL_XboxOneInitState state)
 {
 #ifdef DEBUG_JOYSTICK
-    SDL_Log("Setting init state %d\n", state);
+    SDL_Log("Setting init state %d", state);
 #endif
     ctx->init_state = state;
 }
@@ -391,7 +391,7 @@ static bool HIDAPI_DriverXboxOne_InitDevice(SDL_HIDAPI_Device *device)
     }
 
 #ifdef DEBUG_JOYSTICK
-    SDL_Log("Controller version: %d (0x%.4x)\n", device->version, device->version);
+    SDL_Log("Controller version: %d (0x%.4x)", device->version, device->version);
 #endif
 
     device->type = SDL_GAMEPAD_TYPE_XBOXONE;
@@ -620,7 +620,7 @@ static void HIDAPI_DriverXboxOne_HandleUnmappedStatePacket(SDL_Joystick *joystic
         return;
     }
 #ifdef DEBUG_XBOX_PROTOCOL
-    SDL_Log(">>> Paddles: %d,%d,%d,%d mapped = %s\n",
+    SDL_Log(">>> Paddles: %d,%d,%d,%d mapped = %s",
             (data[paddle_index] & button1_bit) ? 1 : 0,
             (data[paddle_index] & button2_bit) ? 1 : 0,
             (data[paddle_index] & button3_bit) ? 1 : 0,
@@ -654,7 +654,7 @@ static void HIDAPI_DriverXboxOne_HandleStatePacket(SDL_Joystick *joystick, SDL_D
         Uint8 packet[] = { 0x4d, 0x00, 0x00, 0x02, 0x07, 0x00 };
 
 #ifdef DEBUG_JOYSTICK
-        SDL_Log("Enabling paddles on XBox Elite 2\n");
+        SDL_Log("Enabling paddles on XBox Elite 2");
 #endif
         SDL_HIDAPI_SendRumble(ctx->device, packet, sizeof(packet));
     }
@@ -787,7 +787,7 @@ static void HIDAPI_DriverXboxOne_HandleStatePacket(SDL_Joystick *joystick, SDL_D
             paddles_mapped = (data[20] != 0);
         }
 #ifdef DEBUG_XBOX_PROTOCOL
-        SDL_Log(">>> Paddles: %d,%d,%d,%d mapped = %s\n",
+        SDL_Log(">>> Paddles: %d,%d,%d,%d mapped = %s",
                 (data[paddle_index] & button1_bit) ? 1 : 0,
                 (data[paddle_index] & button2_bit) ? 1 : 0,
                 (data[paddle_index] & button3_bit) ? 1 : 0,
@@ -954,7 +954,7 @@ static void HIDAPI_DriverXboxOneBluetooth_HandleButtons(Uint64 timestamp, SDL_Jo
         }
 
 #ifdef DEBUG_XBOX_PROTOCOL
-        SDL_Log(">>> Paddles: %d,%d,%d,%d mapped = %s\n",
+        SDL_Log(">>> Paddles: %d,%d,%d,%d mapped = %s",
                 (data[paddle_index] & button1_bit) ? 1 : 0,
                 (data[paddle_index] & button2_bit) ? 1 : 0,
                 (data[paddle_index] & button3_bit) ? 1 : 0,
@@ -990,7 +990,7 @@ static void HIDAPI_DriverXboxOneBluetooth_HandleStatePacket(SDL_Joystick *joysti
         HIDAPI_DriverXboxOneBluetooth_HandleButtons(timestamp, joystick, ctx, data, size);
     } else {
 #ifdef DEBUG_XBOX_PROTOCOL
-        SDL_Log("Unknown Bluetooth state packet format\n");
+        SDL_Log("Unknown Bluetooth state packet format");
 #endif
         return;
     }
@@ -1104,7 +1104,7 @@ static void HIDAPI_DriverXboxOne_HandleSerialIDPacket(SDL_DriverXboxOne_Context 
     serial[i * 2] = '\0';
 
 #ifdef DEBUG_JOYSTICK
-    SDL_Log("Setting serial number to %s\n", serial);
+    SDL_Log("Setting serial number to %s", serial);
 #endif
     HIDAPI_SetDeviceSerial(ctx->device, serial);
 }
@@ -1129,7 +1129,7 @@ static bool HIDAPI_DriverXboxOne_UpdateInitState(SDL_DriverXboxOne_Context *ctx)
             if (SDL_GetTicks() >= (ctx->send_time + CONTROLLER_IDENTIFY_TIMEOUT_MS)) {
                 // We haven't heard anything, let's move on
 #ifdef DEBUG_JOYSTICK
-                SDL_Log("Identification request timed out after %llu ms\n", (SDL_GetTicks() - ctx->send_time));
+                SDL_Log("Identification request timed out after %llu ms", (SDL_GetTicks() - ctx->send_time));
 #endif
                 SetInitState(ctx, XBOX_ONE_INIT_STATE_STARTUP);
             }
@@ -1146,7 +1146,7 @@ static bool HIDAPI_DriverXboxOne_UpdateInitState(SDL_DriverXboxOne_Context *ctx)
         case XBOX_ONE_INIT_STATE_PREPARE_INPUT:
             if (SDL_GetTicks() >= (ctx->send_time + CONTROLLER_PREPARE_INPUT_TIMEOUT_MS)) {
 #ifdef DEBUG_JOYSTICK
-                SDL_Log("Prepare input complete after %llu ms\n", (SDL_GetTicks() - ctx->send_time));
+                SDL_Log("Prepare input complete after %llu ms", (SDL_GetTicks() - ctx->send_time));
 #endif
                 SetInitState(ctx, XBOX_ONE_INIT_STATE_COMPLETE);
             }
@@ -1397,7 +1397,7 @@ static bool HIDAPI_GIP_DispatchPacket(SDL_Joystick *joystick, SDL_DriverXboxOne_
                then 8 bytes of unknown data
             */
 #ifdef DEBUG_JOYSTICK
-            SDL_Log("Controller announce after %llu ms\n", (SDL_GetTicks() - ctx->start_time));
+            SDL_Log("Controller announce after %llu ms", (SDL_GetTicks() - ctx->start_time));
 #endif
             SetInitState(ctx, XBOX_ONE_INIT_STATE_ANNOUNCED);
             break;
@@ -1407,7 +1407,7 @@ static bool HIDAPI_GIP_DispatchPacket(SDL_Joystick *joystick, SDL_DriverXboxOne_
             break;
         case GIP_CMD_IDENTIFY:
 #ifdef DEBUG_JOYSTICK
-            SDL_Log("Identification request completed after %llu ms\n", (SDL_GetTicks() - ctx->send_time));
+            SDL_Log("Identification request completed after %llu ms", (SDL_GetTicks() - ctx->send_time));
 #endif
 #ifdef DEBUG_XBOX_PROTOCOL
             HIDAPI_DumpPacket("Xbox One identification data: size = %d", data, size);
@@ -1440,7 +1440,7 @@ static bool HIDAPI_GIP_DispatchPacket(SDL_Joystick *joystick, SDL_DriverXboxOne_
             break;
         default:
 #ifdef DEBUG_JOYSTICK
-            SDL_Log("Unknown Xbox One packet: 0x%.2x\n", hdr->command);
+            SDL_Log("Unknown Xbox One packet: 0x%.2x", hdr->command);
 #endif
             break;
         }
@@ -1452,7 +1452,7 @@ static bool HIDAPI_GIP_DispatchPacket(SDL_Joystick *joystick, SDL_DriverXboxOne_
 
                 // Ignore the first input, it may be spurious
 #ifdef DEBUG_JOYSTICK
-                SDL_Log("Controller ignoring spurious input\n");
+                SDL_Log("Controller ignoring spurious input");
 #endif
                 break;
             }
@@ -1469,7 +1469,7 @@ static bool HIDAPI_GIP_DispatchPacket(SDL_Joystick *joystick, SDL_DriverXboxOne_
             break;
         default:
 #ifdef DEBUG_JOYSTICK
-            SDL_Log("Unknown Xbox One packet: 0x%.2x\n", hdr->command);
+            SDL_Log("Unknown Xbox One packet: 0x%.2x", hdr->command);
 #endif
             break;
         }
@@ -1596,7 +1596,7 @@ static bool HIDAPI_DriverXboxOne_UpdateDevice(SDL_HIDAPI_Device *device)
                     HIDAPI_DriverXboxOneBluetooth_HandleStatePacket(joystick, ctx, data, size);
                 } else {
 #ifdef DEBUG_JOYSTICK
-                    SDL_Log("Unknown Xbox One Bluetooth packet size: %d\n", size);
+                    SDL_Log("Unknown Xbox One Bluetooth packet size: %d", size);
 #endif
                 }
                 break;
@@ -1614,7 +1614,7 @@ static bool HIDAPI_DriverXboxOne_UpdateDevice(SDL_HIDAPI_Device *device)
                 break;
             default:
 #ifdef DEBUG_JOYSTICK
-                SDL_Log("Unknown Xbox One packet: 0x%.2x\n", data[0]);
+                SDL_Log("Unknown Xbox One packet: 0x%.2x", data[0]);
 #endif
                 break;
             }

--- a/src/joystick/hidapi/SDL_hidapijoystick.c
+++ b/src/joystick/hidapi/SDL_hidapijoystick.c
@@ -955,7 +955,7 @@ static SDL_HIDAPI_Device *HIDAPI_AddDevice(const struct SDL_hid_device_info *inf
         return NULL;
     }
 
-    SDL_LogDebug(SDL_LOG_CATEGORY_INPUT, "Added HIDAPI device '%s' VID 0x%.4x, PID 0x%.4x, bluetooth %d, version %d, serial %s, interface %d, interface_class %d, interface_subclass %d, interface_protocol %d, usage page 0x%.4x, usage 0x%.4x, path = %s, driver = %s (%s)\n", device->name, device->vendor_id, device->product_id, device->is_bluetooth, device->version,
+    SDL_LogDebug(SDL_LOG_CATEGORY_INPUT, "Added HIDAPI device '%s' VID 0x%.4x, PID 0x%.4x, bluetooth %d, version %d, serial %s, interface %d, interface_class %d, interface_subclass %d, interface_protocol %d, usage page 0x%.4x, usage 0x%.4x, path = %s, driver = %s (%s)", device->name, device->vendor_id, device->product_id, device->is_bluetooth, device->version,
             device->serial ? device->serial : "NONE", device->interface_number, device->interface_class, device->interface_subclass, device->interface_protocol, device->usage_page, device->usage,
             device->path, device->driver ? device->driver->name : "NONE", device->driver && device->driver->enabled ? "ENABLED" : "DISABLED");
 
@@ -969,7 +969,7 @@ static void HIDAPI_DelDevice(SDL_HIDAPI_Device *device)
 
     SDL_AssertJoysticksLocked();
 
-    SDL_LogDebug(SDL_LOG_CATEGORY_INPUT, "Removing HIDAPI device '%s' VID 0x%.4x, PID 0x%.4x, bluetooth %d, version %d, serial %s, interface %d, interface_class %d, interface_subclass %d, interface_protocol %d, usage page 0x%.4x, usage 0x%.4x, path = %s, driver = %s (%s)\n", device->name, device->vendor_id, device->product_id, device->is_bluetooth, device->version,
+    SDL_LogDebug(SDL_LOG_CATEGORY_INPUT, "Removing HIDAPI device '%s' VID 0x%.4x, PID 0x%.4x, bluetooth %d, version %d, serial %s, interface %d, interface_class %d, interface_subclass %d, interface_protocol %d, usage page 0x%.4x, usage 0x%.4x, path = %s, driver = %s (%s)", device->name, device->vendor_id, device->product_id, device->is_bluetooth, device->version,
             device->serial ? device->serial : "NONE", device->interface_number, device->interface_class, device->interface_subclass, device->interface_protocol, device->usage_page, device->usage,
             device->path, device->driver ? device->driver->name : "NONE", device->driver && device->driver->enabled ? "ENABLED" : "DISABLED");
 
@@ -1229,7 +1229,7 @@ bool HIDAPI_IsDeviceTypePresent(SDL_GamepadType type)
     SDL_UnlockJoysticks();
 
 #ifdef DEBUG_HIDAPI
-    SDL_Log("HIDAPI_IsDeviceTypePresent() returning %s for %d\n", result ? "true" : "false", type);
+    SDL_Log("HIDAPI_IsDeviceTypePresent() returning %s for %d", result ? "true" : "false", type);
 #endif
     return result;
 }
@@ -1280,7 +1280,7 @@ bool HIDAPI_IsDevicePresent(Uint16 vendor_id, Uint16 product_id, Uint16 version,
     SDL_UnlockJoysticks();
 
 #ifdef DEBUG_HIDAPI
-    SDL_Log("HIDAPI_IsDevicePresent() returning %s for 0x%.4x / 0x%.4x\n", result ? "true" : "false", vendor_id, product_id);
+    SDL_Log("HIDAPI_IsDevicePresent() returning %s for 0x%.4x / 0x%.4x", result ? "true" : "false", vendor_id, product_id);
 #endif
     return result;
 }

--- a/src/joystick/linux/SDL_sysjoystick.c
+++ b/src/joystick/linux/SDL_sysjoystick.c
@@ -327,7 +327,7 @@ static bool IsJoystick(const char *path, int *fd, char **name_return, Uint16 *ve
     FixupDeviceInfoForMapping(*fd, &inpid);
 
 #ifdef DEBUG_JOYSTICK
-    SDL_Log("Joystick: %s, bustype = %d, vendor = 0x%.4x, product = 0x%.4x, version = %d\n", name, inpid.bustype, inpid.vendor, inpid.product, inpid.version);
+    SDL_Log("Joystick: %s, bustype = %d, vendor = 0x%.4x, product = 0x%.4x, version = %d", name, inpid.bustype, inpid.vendor, inpid.product, inpid.version);
 #endif
 
     if (SDL_ShouldIgnoreJoystick(inpid.vendor, inpid.product, inpid.version, name)) {
@@ -470,12 +470,12 @@ static void MaybeAddDevice(const char *path)
     }
 
 #ifdef DEBUG_INPUT_EVENTS
-    SDL_Log("Checking %s\n", path);
+    SDL_Log("Checking %s", path);
 #endif
 
     if (IsJoystick(path, &fd, &name, &vendor, &product, &guid)) {
 #ifdef DEBUG_INPUT_EVENTS
-        SDL_Log("found joystick: %s\n", path);
+        SDL_Log("found joystick: %s", path);
 #endif
         item = (SDL_joylist_item *)SDL_calloc(1, sizeof(SDL_joylist_item));
         if (!item) {
@@ -516,7 +516,7 @@ static void MaybeAddDevice(const char *path)
 
     if (IsSensor(path, &fd)) {
 #ifdef DEBUG_INPUT_EVENTS
-        SDL_Log("found sensor: %s\n", path);
+        SDL_Log("found sensor: %s", path);
 #endif
         item_sensor = (SDL_sensorlist_item *)SDL_calloc(1, sizeof(SDL_sensorlist_item));
         if (!item_sensor) {
@@ -1217,7 +1217,7 @@ static void ConfigJoystick(SDL_Joystick *joystick, int fd, int fd_sensor)
         for (i = BTN_JOYSTICK; i < KEY_MAX; ++i) {
             if (test_bit(i, keybit)) {
 #ifdef DEBUG_INPUT_EVENTS
-                SDL_Log("Joystick has button: 0x%x\n", i);
+                SDL_Log("Joystick has button: 0x%x", i);
 #endif
                 joystick->hwdata->key_map[i] = joystick->nbuttons;
                 joystick->hwdata->has_key[i] = true;
@@ -1227,7 +1227,7 @@ static void ConfigJoystick(SDL_Joystick *joystick, int fd, int fd_sensor)
         for (i = 0; i < BTN_JOYSTICK; ++i) {
             if (test_bit(i, keybit)) {
 #ifdef DEBUG_INPUT_EVENTS
-                SDL_Log("Joystick has button: 0x%x\n", i);
+                SDL_Log("Joystick has button: 0x%x", i);
 #endif
                 joystick->hwdata->key_map[i] = joystick->nbuttons;
                 joystick->hwdata->has_key[i] = true;
@@ -1250,14 +1250,14 @@ static void ConfigJoystick(SDL_Joystick *joystick, int fd, int fd_sensor)
                 const int hat_index = (i - ABS_HAT0X) / 2;
                 struct hat_axis_correct *correct = &joystick->hwdata->hat_correct[hat_index];
 #ifdef DEBUG_INPUT_EVENTS
-                SDL_Log("Joystick has digital hat: #%d\n", hat_index);
+                SDL_Log("Joystick has digital hat: #%d", hat_index);
                 if (hat_x >= 0) {
-                    SDL_Log("X Values = { val:%d, min:%d, max:%d, fuzz:%d, flat:%d, res:%d }\n",
+                    SDL_Log("X Values = { val:%d, min:%d, max:%d, fuzz:%d, flat:%d, res:%d }",
                             absinfo_x.value, absinfo_x.minimum, absinfo_x.maximum,
                             absinfo_x.fuzz, absinfo_x.flat, absinfo_x.resolution);
                 }
                 if (hat_y >= 0) {
-                    SDL_Log("Y Values = { val:%d, min:%d, max:%d, fuzz:%d, flat:%d, res:%d }\n",
+                    SDL_Log("Y Values = { val:%d, min:%d, max:%d, fuzz:%d, flat:%d, res:%d }",
                             absinfo_y.value, absinfo_y.minimum, absinfo_y.maximum,
                             absinfo_y.fuzz, absinfo_y.flat, absinfo_y.resolution);
                 }
@@ -1285,8 +1285,8 @@ static void ConfigJoystick(SDL_Joystick *joystick, int fd, int fd_sensor)
                     continue;
                 }
 #ifdef DEBUG_INPUT_EVENTS
-                SDL_Log("Joystick has absolute axis: 0x%.2x\n", i);
-                SDL_Log("Values = { val:%d, min:%d, max:%d, fuzz:%d, flat:%d, res:%d }\n",
+                SDL_Log("Joystick has absolute axis: 0x%.2x", i);
+                SDL_Log("Values = { val:%d, min:%d, max:%d, fuzz:%d, flat:%d, res:%d }",
                         absinfo.value, absinfo.minimum, absinfo.maximum,
                         absinfo.fuzz, absinfo.flat, absinfo.resolution);
 #endif // DEBUG_INPUT_EVENTS
@@ -1340,7 +1340,7 @@ static void ConfigJoystick(SDL_Joystick *joystick, int fd, int fd_sensor)
         for (i = 0; i < key_pam_size; ++i) {
             Uint16 code = joystick->hwdata->key_pam[i];
 #ifdef DEBUG_INPUT_EVENTS
-            SDL_Log("Joystick has button: 0x%x\n", code);
+            SDL_Log("Joystick has button: 0x%x", code);
 #endif
             joystick->hwdata->key_map[code] = joystick->nbuttons;
             joystick->hwdata->has_key[code] = true;
@@ -1366,7 +1366,7 @@ static void ConfigJoystick(SDL_Joystick *joystick, int fd, int fd_sensor)
                 int hat_index = (code - ABS_HAT0X) / 2;
                 if (!joystick->hwdata->has_hat[hat_index]) {
 #ifdef DEBUG_INPUT_EVENTS
-                    SDL_Log("Joystick has digital hat: #%d\n", hat_index);
+                    SDL_Log("Joystick has digital hat: #%d", hat_index);
 #endif
                     joystick->hwdata->hats_indices[hat_index] = joystick->nhats++;
                     joystick->hwdata->has_hat[hat_index] = true;
@@ -1377,7 +1377,7 @@ static void ConfigJoystick(SDL_Joystick *joystick, int fd, int fd_sensor)
                 }
             } else {
 #ifdef DEBUG_INPUT_EVENTS
-                SDL_Log("Joystick has absolute axis: 0x%.2x\n", code);
+                SDL_Log("Joystick has absolute axis: 0x%.2x", code);
 #endif
                 joystick->hwdata->abs_map[code] = joystick->naxes;
                 joystick->hwdata->has_abs[code] = true;
@@ -1398,8 +1398,8 @@ static void ConfigJoystick(SDL_Joystick *joystick, int fd, int fd_sensor)
                 }
                 joystick->hwdata->accelerometer_scale[i] = absinfo.resolution;
 #ifdef DEBUG_INPUT_EVENTS
-                SDL_Log("Joystick has accelerometer axis: 0x%.2x\n", ABS_X + i);
-                SDL_Log("Values = { val:%d, min:%d, max:%d, fuzz:%d, flat:%d, res:%d }\n",
+                SDL_Log("Joystick has accelerometer axis: 0x%.2x", ABS_X + i);
+                SDL_Log("Values = { val:%d, min:%d, max:%d, fuzz:%d, flat:%d, res:%d }",
                         absinfo.value, absinfo.minimum, absinfo.maximum,
                         absinfo.fuzz, absinfo.flat, absinfo.resolution);
 #endif // DEBUG_INPUT_EVENTS
@@ -1416,8 +1416,8 @@ static void ConfigJoystick(SDL_Joystick *joystick, int fd, int fd_sensor)
                 }
                 joystick->hwdata->gyro_scale[i] = absinfo.resolution;
 #ifdef DEBUG_INPUT_EVENTS
-                SDL_Log("Joystick has gyro axis: 0x%.2x\n", ABS_RX + i);
-                SDL_Log("Values = { val:%d, min:%d, max:%d, fuzz:%d, flat:%d, res:%d }\n",
+                SDL_Log("Joystick has gyro axis: 0x%.2x", ABS_RX + i);
+                SDL_Log("Values = { val:%d, min:%d, max:%d, fuzz:%d, flat:%d, res:%d }",
                         absinfo.value, absinfo.minimum, absinfo.maximum,
                         absinfo.fuzz, absinfo.flat, absinfo.resolution);
 #endif // DEBUG_INPUT_EVENTS
@@ -1522,7 +1522,7 @@ static SDL_sensorlist_item *GetSensor(SDL_joylist_item *item)
     }
     close(fd_item);
 #ifdef DEBUG_INPUT_EVENTS
-    SDL_Log("Joystick UNIQ: %s\n", uniq_item);
+    SDL_Log("Joystick UNIQ: %s", uniq_item);
 #endif // DEBUG_INPUT_EVENTS
 
     for (item_sensor = SDL_sensorlist; item_sensor; item_sensor = item_sensor->next) {
@@ -1544,7 +1544,7 @@ static SDL_sensorlist_item *GetSensor(SDL_joylist_item *item)
         }
         close(fd_sensor);
 #ifdef DEBUG_INPUT_EVENTS
-        SDL_Log("Sensor UNIQ: %s\n", uniq_sensor);
+        SDL_Log("Sensor UNIQ: %s", uniq_sensor);
 #endif // DEBUG_INPUT_EVENTS
 
         if (SDL_strcmp(uniq_item, uniq_sensor) == 0) {
@@ -1800,7 +1800,7 @@ static void PollAllValues(Uint64 timestamp, SDL_Joystick *joystick)
                 absinfo.value = AxisCorrect(joystick, i, absinfo.value);
 
 #ifdef DEBUG_INPUT_EVENTS
-                SDL_Log("Joystick : Re-read Axis %d (%d) val= %d\n",
+                SDL_Log("Joystick : Re-read Axis %d (%d) val= %d",
                         joystick->hwdata->abs_map[i], i, absinfo.value);
 #endif
                 SDL_SendJoystickAxis(timestamp, joystick,
@@ -1831,7 +1831,7 @@ static void PollAllValues(Uint64 timestamp, SDL_Joystick *joystick)
             if (joystick->hwdata->has_key[i]) {
                 bool down = test_bit(i, keyinfo);
 #ifdef DEBUG_INPUT_EVENTS
-                SDL_Log("Joystick : Re-read Button %d (%d) val= %d\n",
+                SDL_Log("Joystick : Re-read Button %d (%d) val= %d",
                         joystick->hwdata->key_map[i], i, down);
 #endif
                 SDL_SendJoystickButton(timestamp, joystick,
@@ -1858,7 +1858,7 @@ static void PollAllSensors(Uint64 timestamp, SDL_Joystick *joystick)
             if (ioctl(joystick->hwdata->fd_sensor, EVIOCGABS(ABS_RX + i), &absinfo) >= 0) {
                 data[i] = absinfo.value * (SDL_PI_F / 180.f) / joystick->hwdata->gyro_scale[i];
 #ifdef DEBUG_INPUT_EVENTS
-                SDL_Log("Joystick : Re-read Gyro (axis %d) val= %f\n", i, data[i]);
+                SDL_Log("Joystick : Re-read Gyro (axis %d) val= %f", i, data[i]);
 #endif
             }
         }
@@ -1870,7 +1870,7 @@ static void PollAllSensors(Uint64 timestamp, SDL_Joystick *joystick)
             if (ioctl(joystick->hwdata->fd_sensor, EVIOCGABS(ABS_X + i), &absinfo) >= 0) {
                 data[i] = absinfo.value * SDL_STANDARD_GRAVITY / joystick->hwdata->accelerometer_scale[i];
 #ifdef DEBUG_INPUT_EVENTS
-                SDL_Log("Joystick : Re-read Accelerometer (axis %d) val= %f\n", i, data[i]);
+                SDL_Log("Joystick : Re-read Accelerometer (axis %d) val= %f", i, data[i]);
 #endif
             }
         }
@@ -1913,7 +1913,7 @@ static void HandleInputEvents(SDL_Joystick *joystick)
             switch (event->type) {
             case EV_KEY:
 #ifdef DEBUG_INPUT_EVENTS
-                SDL_Log("Key 0x%.2x %s\n", code, event->value ? "PRESSED" : "RELEASED");
+                SDL_Log("Key 0x%.2x %s", code, event->value ? "PRESSED" : "RELEASED");
 #endif
                 SDL_SendJoystickButton(SDL_EVDEV_GetEventTimestamp(event), joystick,
                                           joystick->hwdata->key_map[code],
@@ -1932,7 +1932,7 @@ static void HandleInputEvents(SDL_Joystick *joystick)
                     hat_index = (code - ABS_HAT0X) / 2;
                     if (joystick->hwdata->has_hat[hat_index]) {
 #ifdef DEBUG_INPUT_EVENTS
-                        SDL_Log("Axis 0x%.2x = %d\n", code, event->value);
+                        SDL_Log("Axis 0x%.2x = %d", code, event->value);
 #endif
                         HandleHat(SDL_EVDEV_GetEventTimestamp(event), joystick, hat_index, code % 2, event->value);
                         break;
@@ -1940,7 +1940,7 @@ static void HandleInputEvents(SDL_Joystick *joystick)
                     SDL_FALLTHROUGH;
                 default:
 #ifdef DEBUG_INPUT_EVENTS
-                    SDL_Log("Axis 0x%.2x = %d\n", code, event->value);
+                    SDL_Log("Axis 0x%.2x = %d", code, event->value);
 #endif
                     event->value = AxisCorrect(joystick, code, event->value);
                     SDL_SendJoystickAxis(SDL_EVDEV_GetEventTimestamp(event), joystick,
@@ -1964,7 +1964,7 @@ static void HandleInputEvents(SDL_Joystick *joystick)
                 switch (code) {
                 case SYN_DROPPED:
 #ifdef DEBUG_INPUT_EVENTS
-                    SDL_Log("Event SYN_DROPPED detected\n");
+                    SDL_Log("Event SYN_DROPPED detected");
 #endif
                     joystick->hwdata->recovering_from_dropped = true;
                     break;
@@ -2047,7 +2047,7 @@ static void HandleInputEvents(SDL_Joystick *joystick)
                     switch (code) {
                     case SYN_DROPPED:
     #ifdef DEBUG_INPUT_EVENTS
-                        SDL_Log("Event SYN_DROPPED detected\n");
+                        SDL_Log("Event SYN_DROPPED detected");
     #endif
                         joystick->hwdata->recovering_from_dropped_sensor = true;
                         break;

--- a/src/joystick/windows/SDL_rawinputjoystick.c
+++ b/src/joystick/windows/SDL_rawinputjoystick.c
@@ -935,7 +935,7 @@ static void RAWINPUT_AddDevice(HANDLE hDevice)
     device->joystick_id = SDL_GetNextObjectID();
 
 #ifdef DEBUG_RAWINPUT
-    SDL_Log("Adding RAWINPUT device '%s' VID 0x%.4x, PID 0x%.4x, version %d, handle 0x%.8x\n", device->name, device->vendor_id, device->product_id, device->version, device->hDevice);
+    SDL_Log("Adding RAWINPUT device '%s' VID 0x%.4x, PID 0x%.4x, version %d, handle 0x%.8x", device->name, device->vendor_id, device->product_id, device->version, device->hDevice);
 #endif
 
     // Add it to the list
@@ -985,7 +985,7 @@ static void RAWINPUT_DelDevice(SDL_RAWINPUT_Device *device, bool send_event)
             SDL_PrivateJoystickRemoved(device->joystick_id);
 
 #ifdef DEBUG_RAWINPUT
-            SDL_Log("Removing RAWINPUT device '%s' VID 0x%.4x, PID 0x%.4x, version %d, handle %p\n", device->name, device->vendor_id, device->product_id, device->version, device->hDevice);
+            SDL_Log("Removing RAWINPUT device '%s' VID 0x%.4x, PID 0x%.4x, version %d, handle %p", device->name, device->vendor_id, device->product_id, device->version, device->hDevice);
 #endif
             RAWINPUT_ReleaseDevice(device);
             return;
@@ -1779,7 +1779,7 @@ static void RAWINPUT_UpdateOtherAPIs(SDL_Joystick *joystick)
               triggers for a frame. */
             if (ctx->wgi_uncorrelate_count >= 5) {
 #ifdef DEBUG_RAWINPUT
-                SDL_Log("UN-Correlated joystick %d to WindowsGamingInput device #%d\n", joystick->instance_id, ctx->wgi_slot);
+                SDL_Log("UN-Correlated joystick %d to WindowsGamingInput device #%d", joystick->instance_id, ctx->wgi_slot);
 #endif
                 RAWINPUT_MarkWindowsGamingInputSlotFree(ctx->wgi_slot);
                 ctx->wgi_correlated = false;
@@ -1811,7 +1811,7 @@ static void RAWINPUT_UpdateOtherAPIs(SDL_Joystick *joystick)
                             // correlation stayed steady and uncontested across multiple frames, guaranteed match
                             ctx->wgi_correlated = true;
 #ifdef DEBUG_RAWINPUT
-                            SDL_Log("Correlated joystick %d to WindowsGamingInput device #%d\n", joystick->instance_id, slot_idx);
+                            SDL_Log("Correlated joystick %d to WindowsGamingInput device #%d", joystick->instance_id, slot_idx);
 #endif
                             correlated = true;
                             RAWINPUT_MarkWindowsGamingInputSlotUsed(ctx->wgi_slot, ctx);
@@ -1875,7 +1875,7 @@ static void RAWINPUT_UpdateOtherAPIs(SDL_Joystick *joystick)
                   triggers for a frame. */
                 if (ctx->xinput_uncorrelate_count >= 5) {
 #ifdef DEBUG_RAWINPUT
-                    SDL_Log("UN-Correlated joystick %d to XInput device #%d\n", joystick->instance_id, ctx->xinput_slot);
+                    SDL_Log("UN-Correlated joystick %d to XInput device #%d", joystick->instance_id, ctx->xinput_slot);
 #endif
                     RAWINPUT_MarkXInputSlotFree(ctx->xinput_slot);
                     ctx->xinput_correlated = false;
@@ -1907,7 +1907,7 @@ static void RAWINPUT_UpdateOtherAPIs(SDL_Joystick *joystick)
                                 // correlation stayed steady and uncontested across multiple frames, guaranteed match
                                 ctx->xinput_correlated = true;
 #ifdef DEBUG_RAWINPUT
-                                SDL_Log("Correlated joystick %d to XInput device #%d\n", joystick->instance_id, slot_idx);
+                                SDL_Log("Correlated joystick %d to XInput device #%d", joystick->instance_id, slot_idx);
 #endif
                                 correlated = true;
                                 RAWINPUT_MarkXInputSlotUsed(ctx->xinput_slot);

--- a/src/render/direct3d11/SDL_render_d3d11.c
+++ b/src/render/direct3d11/SDL_render_d3d11.c
@@ -997,7 +997,7 @@ static HRESULT D3D11_CreateWindowSizeDependentResources(SDL_Renderer *renderer)
      */
     SDL_GetWindowSizeInPixels(renderer->window, &w, &h);
     data->rotation = D3D11_GetCurrentRotation();
-    // SDL_Log("%s: windowSize={%d,%d}, orientation=%d\n", __FUNCTION__, w, h, (int)data->rotation);
+    // SDL_Log("%s: windowSize={%d,%d}, orientation=%d", __FUNCTION__, w, h, (int)data->rotation);
     if (D3D11_IsDisplayRotated90Degrees(data->rotation)) {
         int tmp = w;
         w = h;
@@ -1078,7 +1078,7 @@ static bool D3D11_HandleDeviceLost(SDL_Renderer *renderer)
         SUCCEEDED(D3D11_CreateWindowSizeDependentResources(renderer))) {
         recovered = true;
     } else {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "Renderer couldn't recover from device lost: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "Renderer couldn't recover from device lost: %s", SDL_GetError());
         D3D11_ReleaseAll(renderer);
     }
 
@@ -1990,7 +1990,7 @@ static bool D3D11_UpdateViewport(SDL_Renderer *renderer)
          * SDL_CreateRenderer is calling it, and will call it again later
          * with a non-empty viewport.
          */
-        // SDL_Log("%s, no viewport was set!\n", __FUNCTION__);
+        // SDL_Log("%s, no viewport was set!", __FUNCTION__);
         return false;
     }
 
@@ -2057,7 +2057,7 @@ static bool D3D11_UpdateViewport(SDL_Renderer *renderer)
     d3dviewport.Height = orientationAlignedViewport.h;
     d3dviewport.MinDepth = 0.0f;
     d3dviewport.MaxDepth = 1.0f;
-    // SDL_Log("%s: D3D viewport = {%f,%f,%f,%f}\n", __FUNCTION__, d3dviewport.TopLeftX, d3dviewport.TopLeftY, d3dviewport.Width, d3dviewport.Height);
+    // SDL_Log("%s: D3D viewport = {%f,%f,%f,%f}", __FUNCTION__, d3dviewport.TopLeftX, d3dviewport.TopLeftY, d3dviewport.Width, d3dviewport.Height);
     ID3D11DeviceContext_RSSetViewports(data->d3dContext, 1, &d3dviewport);
 
     data->viewportDirty = false;

--- a/src/render/direct3d12/SDL_render_d3d12.c
+++ b/src/render/direct3d12/SDL_render_d3d12.c
@@ -1453,7 +1453,7 @@ static bool D3D12_HandleDeviceLost(SDL_Renderer *renderer)
         SUCCEEDED(D3D12_CreateWindowSizeDependentResources(renderer))) {
         recovered = true;
     } else {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "Renderer couldn't recover from device lost: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "Renderer couldn't recover from device lost: %s", SDL_GetError());
         D3D12_ReleaseAll(renderer);
     }
 
@@ -2430,7 +2430,7 @@ static bool D3D12_UpdateViewport(SDL_Renderer *renderer)
          * SDL_CreateRenderer is calling it, and will call it again later
          * with a non-empty viewport.
          */
-        // SDL_Log("%s, no viewport was set!\n", __FUNCTION__);
+        // SDL_Log("%s, no viewport was set!", __FUNCTION__);
         return false;
     }
 
@@ -2497,7 +2497,7 @@ static bool D3D12_UpdateViewport(SDL_Renderer *renderer)
     d3dviewport.Height = orientationAlignedViewport.h;
     d3dviewport.MinDepth = 0.0f;
     d3dviewport.MaxDepth = 1.0f;
-    // SDL_Log("%s: D3D viewport = {%f,%f,%f,%f}\n", __FUNCTION__, d3dviewport.TopLeftX, d3dviewport.TopLeftY, d3dviewport.Width, d3dviewport.Height);
+    // SDL_Log("%s: D3D viewport = {%f,%f,%f,%f}", __FUNCTION__, d3dviewport.TopLeftX, d3dviewport.TopLeftY, d3dviewport.Width, d3dviewport.Height);
     ID3D12GraphicsCommandList_RSSetViewports(data->commandList, 1, &d3dviewport);
 
     data->viewportDirty = false;

--- a/src/render/opengl/SDL_shaders_gl.c
+++ b/src/render/opengl/SDL_shaders_gl.c
@@ -350,7 +350,10 @@ static bool CompileShader(GL_ShaderContext *ctx, GLhandleARB shader, const char 
         info = SDL_small_alloc(char, length + 1, &isstack);
         if (info) {
             ctx->glGetInfoLogARB(shader, length, NULL, info);
-            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "Failed to compile shader:\n%s%s\n%s", defines, source, info);
+            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "Failed to compile shader:");
+	    SDL_LogError(SDL_LOG_CATEGORY_RENDER, "%s", defines);
+	    SDL_LogError(SDL_LOG_CATEGORY_RENDER, "%s", source);
+	    SDL_LogError(SDL_LOG_CATEGORY_RENDER, "%s", info);
             SDL_small_free(info, isstack);
         }
         return false;

--- a/src/render/opengles2/SDL_render_gles2.c
+++ b/src/render/opengles2/SDL_render_gles2.c
@@ -539,7 +539,7 @@ static GLuint GLES2_CacheShader(GLES2_RenderData *data, GLES2_ShaderType type, G
                 SDL_asprintf(&message, "%s%s", last_message, shader_src_list[i]);
                 SDL_free(last_message);
             }
-            SDL_Log("%s\n", message);
+            SDL_Log("%s", message);
             SDL_free(message);
         }
 #endif

--- a/src/render/vitagxm/SDL_render_vita_gxm.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm.c
@@ -324,11 +324,11 @@ static void VITA_GXM_SetYUVProfile(SDL_Renderer *renderer, SDL_Texture *texture)
             ret = sceGxmSetYuvProfile(data->gxm_context, 0, SCE_GXM_YUV_PROFILE_BT709_FULL_RANGE);
         }
     } else {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "Unsupported YUV colorspace\n");
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "Unsupported YUV colorspace");
     }
 
     if (ret < 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "Setting YUV profile failed: %x\n", ret);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "Setting YUV profile failed: %x", ret);
     }
 }
 

--- a/src/render/vitagxm/SDL_render_vita_gxm_tools.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm_tools.c
@@ -87,7 +87,7 @@ void *pool_malloc(VITA_GXM_RenderData *data, unsigned int size)
         data->pool_index += size;
         return addr;
     }
-    SDL_LogError(SDL_LOG_CATEGORY_RENDER, "POOL OVERFLOW\n");
+    SDL_LogError(SDL_LOG_CATEGORY_RENDER, "POOL OVERFLOW");
     return NULL;
 }
 
@@ -99,7 +99,7 @@ void *pool_memalign(VITA_GXM_RenderData *data, unsigned int size, unsigned int a
         data->pool_index = new_index + size;
         return addr;
     }
-    SDL_LogError(SDL_LOG_CATEGORY_RENDER, "POOL OVERFLOW\n");
+    SDL_LogError(SDL_LOG_CATEGORY_RENDER, "POOL OVERFLOW");
     return NULL;
 }
 
@@ -173,7 +173,7 @@ static void make_fragment_programs(VITA_GXM_RenderData *data, fragment_programs 
         &out->color);
 
     if (err != 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "Patcher create fragment failed: %d\n", err);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "Patcher create fragment failed: %d", err);
         return;
     }
 
@@ -187,7 +187,7 @@ static void make_fragment_programs(VITA_GXM_RenderData *data, fragment_programs 
         &out->texture);
 
     if (err != 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "Patcher create fragment failed: %d\n", err);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "Patcher create fragment failed: %d", err);
         return;
     }
 }
@@ -387,7 +387,7 @@ int gxm_init(SDL_Renderer *renderer)
     err = sceGxmInitialize(&initializeParams);
 
     if (err != 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "gxm init failed: %d\n", err);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "gxm init failed: %d", err);
         return err;
     }
 
@@ -433,7 +433,7 @@ int gxm_init(SDL_Renderer *renderer)
 
     err = sceGxmCreateContext(&data->contextParams, &data->gxm_context);
     if (err != 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "create context failed: %d\n", err);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "create context failed: %d", err);
         return err;
     }
 
@@ -450,7 +450,7 @@ int gxm_init(SDL_Renderer *renderer)
     // create the render target
     err = sceGxmCreateRenderTarget(&renderTargetParams, &data->renderTarget);
     if (err != 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "render target creation failed: %d\n", err);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "render target creation failed: %d", err);
         return err;
     }
 
@@ -486,14 +486,14 @@ int gxm_init(SDL_Renderer *renderer)
             data->displayBufferData[i]);
 
         if (err != 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "color surface init failed: %d\n", err);
+            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "color surface init failed: %d", err);
             return err;
         }
 
         // create a sync object that we will associate with this buffer
         err = sceGxmSyncObjectCreate(&data->displayBufferSync[i]);
         if (err != 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "sync object creation failed: %d\n", err);
+            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "sync object creation failed: %d", err);
             return err;
         }
     }
@@ -576,81 +576,81 @@ int gxm_init(SDL_Renderer *renderer)
 
     err = sceGxmShaderPatcherCreate(&patcherParams, &data->shaderPatcher);
     if (err != 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "shader patcher creation failed: %d\n", err);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "shader patcher creation failed: %d", err);
         return err;
     }
 
     // check the shaders
     err = sceGxmProgramCheck(clearVertexProgramGxp);
     if (err != 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "check program (clear vertex) failed: %d\n", err);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "check program (clear vertex) failed: %d", err);
         return err;
     }
 
     err = sceGxmProgramCheck(clearFragmentProgramGxp);
     if (err != 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "check program (clear fragment) failed: %d\n", err);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "check program (clear fragment) failed: %d", err);
         return err;
     }
 
     err = sceGxmProgramCheck(colorVertexProgramGxp);
     if (err != 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "check program (color vertex) failed: %d\n", err);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "check program (color vertex) failed: %d", err);
         return err;
     }
 
     err = sceGxmProgramCheck(colorFragmentProgramGxp);
     if (err != 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "check program (color fragment) failed: %d\n", err);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "check program (color fragment) failed: %d", err);
         return err;
     }
 
     err = sceGxmProgramCheck(textureVertexProgramGxp);
     if (err != 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "check program (texture vertex) failed: %d\n", err);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "check program (texture vertex) failed: %d", err);
         return err;
     }
 
     err = sceGxmProgramCheck(textureFragmentProgramGxp);
     if (err != 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "check program (texture fragment) failed: %d\n", err);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "check program (texture fragment) failed: %d", err);
         return err;
     }
 
     // register programs with the patcher
     err = sceGxmShaderPatcherRegisterProgram(data->shaderPatcher, clearVertexProgramGxp, &data->clearVertexProgramId);
     if (err != 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "register program (clear vertex) failed: %d\n", err);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "register program (clear vertex) failed: %d", err);
         return err;
     }
 
     err = sceGxmShaderPatcherRegisterProgram(data->shaderPatcher, clearFragmentProgramGxp, &data->clearFragmentProgramId);
     if (err != 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "register program (clear fragment) failed: %d\n", err);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "register program (clear fragment) failed: %d", err);
         return err;
     }
 
     err = sceGxmShaderPatcherRegisterProgram(data->shaderPatcher, colorVertexProgramGxp, &data->colorVertexProgramId);
     if (err != 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "register program (color vertex) failed: %d\n", err);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "register program (color vertex) failed: %d", err);
         return err;
     }
 
     err = sceGxmShaderPatcherRegisterProgram(data->shaderPatcher, colorFragmentProgramGxp, &data->colorFragmentProgramId);
     if (err != 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "register program (color fragment) failed: %d\n", err);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "register program (color fragment) failed: %d", err);
         return err;
     }
 
     err = sceGxmShaderPatcherRegisterProgram(data->shaderPatcher, textureVertexProgramGxp, &data->textureVertexProgramId);
     if (err != 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "register program (texture vertex) failed: %d\n", err);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "register program (texture vertex) failed: %d", err);
         return err;
     }
 
     err = sceGxmShaderPatcherRegisterProgram(data->shaderPatcher, textureFragmentProgramGxp, &data->textureFragmentProgramId);
     if (err != 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "register program (texture fragment) failed: %d\n", err);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "register program (texture fragment) failed: %d", err);
         return err;
     }
 
@@ -679,7 +679,7 @@ int gxm_init(SDL_Renderer *renderer)
             1,
             &data->clearVertexProgram);
         if (err != 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "create program (clear vertex) failed: %d\n", err);
+            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "create program (clear vertex) failed: %d", err);
             return err;
         }
 
@@ -692,7 +692,7 @@ int gxm_init(SDL_Renderer *renderer)
             clearVertexProgramGxp,
             &data->clearFragmentProgram);
         if (err != 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "create program (clear fragment) failed: %d\n", err);
+            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "create program (clear fragment) failed: %d", err);
             return err;
         }
 
@@ -760,7 +760,7 @@ int gxm_init(SDL_Renderer *renderer)
             1,
             &data->colorVertexProgram);
         if (err != 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "create program (color vertex) failed: %d\n", err);
+            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "create program (color vertex) failed: %d", err);
             return err;
         }
     }
@@ -805,7 +805,7 @@ int gxm_init(SDL_Renderer *renderer)
             1,
             &data->textureVertexProgram);
         if (err != 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "create program (texture vertex) failed: %x\n", err);
+            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "create program (texture vertex) failed: %x", err);
             return err;
         }
     }
@@ -1016,7 +1016,7 @@ gxm_texture *create_gxm_texture(VITA_GXM_RenderData *data, unsigned int w, unsig
 
     // Try SCE_KERNEL_MEMBLOCK_TYPE_USER_RW_UNCACHE in case we're out of VRAM
     if (!texture_data) {
-        SDL_LogWarn(SDL_LOG_CATEGORY_RENDER, "CDRAM texture allocation failed\n");
+        SDL_LogWarn(SDL_LOG_CATEGORY_RENDER, "CDRAM texture allocation failed");
         texture_data = vita_mem_alloc(
             SCE_KERNEL_MEMBLOCK_TYPE_USER_RW_UNCACHE,
             tex_size,
@@ -1040,7 +1040,7 @@ gxm_texture *create_gxm_texture(VITA_GXM_RenderData *data, unsigned int w, unsig
     ret = sceGxmTextureInitLinear(&texture->gxm_tex, texture_data, format, texture_w, h, 0);
     if (ret < 0) {
         free_gxm_texture(data, texture);
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "texture init failed: %x\n", ret);
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "texture init failed: %x", ret);
         return NULL;
     }
 
@@ -1065,7 +1065,7 @@ gxm_texture *create_gxm_texture(VITA_GXM_RenderData *data, unsigned int w, unsig
 
         if (err < 0) {
             free_gxm_texture(data, texture);
-            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "color surface init failed: %x\n", err);
+            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "color surface init failed: %x", err);
             return NULL;
         }
 
@@ -1088,7 +1088,7 @@ gxm_texture *create_gxm_texture(VITA_GXM_RenderData *data, unsigned int w, unsig
 
         if (err < 0) {
             free_gxm_texture(data, texture);
-            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "depth stencil init failed: %x\n", err);
+            SDL_LogError(SDL_LOG_CATEGORY_RENDER, "depth stencil init failed: %x", err);
             return NULL;
         }
 
@@ -1113,7 +1113,7 @@ gxm_texture *create_gxm_texture(VITA_GXM_RenderData *data, unsigned int w, unsig
 
             if (err < 0) {
                 free_gxm_texture(data, texture);
-                SDL_LogError(SDL_LOG_CATEGORY_RENDER, "create render target failed: %x\n", err);
+                SDL_LogError(SDL_LOG_CATEGORY_RENDER, "create render target failed: %x", err);
                 return NULL;
             }
         }

--- a/src/render/vulkan/SDL_render_vulkan.c
+++ b/src/render/vulkan/SDL_render_vulkan.c
@@ -41,14 +41,14 @@
 
 #define SET_ERROR_CODE(message, rc)                                                                 \
     if (SDL_GetHintBoolean(SDL_HINT_RENDER_VULKAN_DEBUG, false)) {                                  \
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "%s: %s\n", message, SDL_Vulkan_GetResultString(rc)); \
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "%s: %s", message, SDL_Vulkan_GetResultString(rc)); \
         SDL_TriggerBreakpoint();                                                                    \
     }                                                                                               \
     SDL_SetError("%s: %s", message, SDL_Vulkan_GetResultString(rc))                                 \
 
 #define SET_ERROR_MESSAGE(message)                                                                  \
     if (SDL_GetHintBoolean(SDL_HINT_RENDER_VULKAN_DEBUG, false)) {                                  \
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "%s\n", message);                                     \
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "%s", message);                                     \
         SDL_TriggerBreakpoint();                                                                    \
     }                                                                                               \
     SDL_SetError("%s", message)                                                                     \
@@ -2512,7 +2512,7 @@ static bool VULKAN_HandleDeviceLost(SDL_Renderer *renderer)
         VULKAN_CreateWindowSizeDependentResources(renderer) == VK_SUCCESS) {
         recovered = true;
     } else {
-        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "Renderer couldn't recover from device lost: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_RENDER, "Renderer couldn't recover from device lost: %s", SDL_GetError());
         VULKAN_DestroyAll(renderer);
     }
 
@@ -3296,7 +3296,7 @@ static bool VULKAN_UpdateViewport(SDL_Renderer *renderer)
          * SDL_CreateRenderer is calling it, and will call it again later
          * with a non-empty viewport.
          */
-        // SDL_Log("%s, no viewport was set!\n", __FUNCTION__);
+        // SDL_Log("%s, no viewport was set!", __FUNCTION__);
         return false;
     }
 

--- a/src/sensor/windows/SDL_windowssensor.c
+++ b/src/sensor/windows/SDL_windowssensor.c
@@ -132,7 +132,7 @@ static HRESULT STDMETHODCALLTYPE ISensorEventsVtbl_OnStateChanged(ISensorEvents 
     SDL_LockSensors();
     for (i = 0; i < SDL_num_sensors; ++i) {
         if (pSensor == SDL_sensors[i].sensor) {
-            SDL_Log("Sensor %s state changed to %d\n", SDL_sensors[i].name, state);
+            SDL_Log("Sensor %s state changed to %d", SDL_sensors[i].name, state);
         }
     }
     SDL_UnlockSensors();
@@ -156,7 +156,7 @@ static HRESULT STDMETHODCALLTYPE ISensorEventsVtbl_OnDataUpdated(ISensorEvents *
                 Uint64 sensor_timestamp;
 
 #ifdef DEBUG_SENSORS
-                SDL_Log("Sensor %s data updated\n", SDL_sensors[i].name);
+                SDL_Log("Sensor %s data updated", SDL_sensors[i].name);
 #endif
                 if (SUCCEEDED(ISensorDataReport_GetTimestamp(pNewData, &sensor_systemtime)) &&
                     SystemTimeToFileTime(&sensor_systemtime, &sensor_filetime)) {
@@ -219,7 +219,7 @@ static HRESULT STDMETHODCALLTYPE ISensorEventsVtbl_OnEvent(ISensorEvents *This, 
     SDL_LockSensors();
     for (i = 0; i < SDL_num_sensors; ++i) {
         if (pSensor == SDL_sensors[i].sensor) {
-            SDL_Log("Sensor %s event occurred\n", SDL_sensors[i].name);
+            SDL_Log("Sensor %s event occurred", SDL_sensors[i].name);
         }
     }
     SDL_UnlockSensors();
@@ -235,7 +235,7 @@ static HRESULT STDMETHODCALLTYPE ISensorEventsVtbl_OnLeave(ISensorEvents *This, 
     for (i = 0; i < SDL_num_sensors; ++i) {
         if (WIN_IsEqualIID(ID, &SDL_sensors[i].sensor_id)) {
 #ifdef DEBUG_SENSORS
-            SDL_Log("Sensor %s disconnected\n", SDL_sensors[i].name);
+            SDL_Log("Sensor %s disconnected", SDL_sensors[i].name);
 #endif
             DisconnectSensor(SDL_sensors[i].sensor);
         }

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1092,12 +1092,12 @@ static void SDLTest_PrintRenderer(SDL_Renderer *renderer)
 
     name = SDL_GetRendererName(renderer);
 
-    SDL_Log("  Renderer %s:\n", name);
+    SDL_Log("  Renderer %s:", name);
     if (SDL_strcmp(name, "gpu") == 0) {
         SDL_GPUDevice *device = SDL_GetPointerProperty(SDL_GetRendererProperties(renderer), SDL_PROP_RENDERER_GPU_DEVICE_POINTER, NULL);
-        SDL_Log("    Driver: %s\n", SDL_GetGPUDeviceDriver(device));
+        SDL_Log("    Driver: %s", SDL_GetGPUDeviceDriver(device));
     }
-    SDL_Log("    VSync: %d\n", (int)SDL_GetNumberProperty(SDL_GetRendererProperties(renderer), SDL_PROP_RENDERER_VSYNC_NUMBER, 0));
+    SDL_Log("    VSync: %d", (int)SDL_GetNumberProperty(SDL_GetRendererProperties(renderer), SDL_PROP_RENDERER_VSYNC_NUMBER, 0));
 
     texture_formats = (const SDL_PixelFormat *)SDL_GetPointerProperty(SDL_GetRendererProperties(renderer), SDL_PROP_RENDERER_TEXTURE_FORMATS_POINTER, NULL);
     if (texture_formats) {
@@ -1108,12 +1108,12 @@ static void SDLTest_PrintRenderer(SDL_Renderer *renderer)
             }
             SDLTest_PrintPixelFormat(text, sizeof(text), texture_formats[i]);
         }
-        SDL_Log("%s\n", text);
+        SDL_Log("%s", text);
     }
 
     max_texture_size = (int)SDL_GetNumberProperty(SDL_GetRendererProperties(renderer), SDL_PROP_RENDERER_MAX_TEXTURE_SIZE_NUMBER, 0);
     if (max_texture_size) {
-        SDL_Log("    Max Texture Size: %dx%d\n", max_texture_size, max_texture_size);
+        SDL_Log("    Max Texture Size: %dx%d", max_texture_size, max_texture_size);
     }
 }
 
@@ -1124,7 +1124,7 @@ static SDL_Surface *SDLTest_LoadIcon(const char *file)
     /* Load the icon surface */
     icon = SDL_LoadBMP(file);
     if (!icon) {
-        SDL_Log("Couldn't load %s: %s\n", file, SDL_GetError());
+        SDL_Log("Couldn't load %s: %s", file, SDL_GetError());
         return NULL;
     }
 
@@ -1142,40 +1142,40 @@ static SDL_HitTestResult SDLCALL SDLTest_ExampleHitTestCallback(SDL_Window *win,
     const int RESIZE_BORDER = 8;
     const int DRAGGABLE_TITLE = 32;
 
-    /*SDL_Log("Hit test point %d,%d\n", area->x, area->y);*/
+    /*SDL_Log("Hit test point %d,%d", area->x, area->y);*/
 
     SDL_GetWindowSize(win, &w, &h);
 
     if (area->x < RESIZE_BORDER) {
         if (area->y < RESIZE_BORDER) {
-            SDL_Log("SDL_HITTEST_RESIZE_TOPLEFT\n");
+            SDL_Log("SDL_HITTEST_RESIZE_TOPLEFT");
             return SDL_HITTEST_RESIZE_TOPLEFT;
         } else if (area->y >= (h - RESIZE_BORDER)) {
-            SDL_Log("SDL_HITTEST_RESIZE_BOTTOMLEFT\n");
+            SDL_Log("SDL_HITTEST_RESIZE_BOTTOMLEFT");
             return SDL_HITTEST_RESIZE_BOTTOMLEFT;
         } else {
-            SDL_Log("SDL_HITTEST_RESIZE_LEFT\n");
+            SDL_Log("SDL_HITTEST_RESIZE_LEFT");
             return SDL_HITTEST_RESIZE_LEFT;
         }
     } else if (area->x >= (w - RESIZE_BORDER)) {
         if (area->y < RESIZE_BORDER) {
-            SDL_Log("SDL_HITTEST_RESIZE_TOPRIGHT\n");
+            SDL_Log("SDL_HITTEST_RESIZE_TOPRIGHT");
             return SDL_HITTEST_RESIZE_TOPRIGHT;
         } else if (area->y >= (h - RESIZE_BORDER)) {
-            SDL_Log("SDL_HITTEST_RESIZE_BOTTOMRIGHT\n");
+            SDL_Log("SDL_HITTEST_RESIZE_BOTTOMRIGHT");
             return SDL_HITTEST_RESIZE_BOTTOMRIGHT;
         } else {
-            SDL_Log("SDL_HITTEST_RESIZE_RIGHT\n");
+            SDL_Log("SDL_HITTEST_RESIZE_RIGHT");
             return SDL_HITTEST_RESIZE_RIGHT;
         }
     } else if (area->y >= (h - RESIZE_BORDER)) {
-        SDL_Log("SDL_HITTEST_RESIZE_BOTTOM\n");
+        SDL_Log("SDL_HITTEST_RESIZE_BOTTOM");
         return SDL_HITTEST_RESIZE_BOTTOM;
     } else if (area->y < RESIZE_BORDER) {
-        SDL_Log("SDL_HITTEST_RESIZE_TOP\n");
+        SDL_Log("SDL_HITTEST_RESIZE_TOP");
         return SDL_HITTEST_RESIZE_TOP;
     } else if (area->y < DRAGGABLE_TITLE) {
-        SDL_Log("SDL_HITTEST_DRAGGABLE\n");
+        SDL_Log("SDL_HITTEST_DRAGGABLE");
         return SDL_HITTEST_DRAGGABLE;
     }
     return SDL_HITTEST_NORMAL;
@@ -1190,7 +1190,7 @@ bool SDLTest_CommonInit(SDLTest_CommonState *state)
         if (state->verbose & VERBOSE_VIDEO) {
             n = SDL_GetNumVideoDrivers();
             if (n == 0) {
-                SDL_Log("No built-in video drivers\n");
+                SDL_Log("No built-in video drivers");
             } else {
                 (void)SDL_snprintf(text, sizeof(text), "Built-in video drivers:");
                 for (i = 0; i < n; ++i) {
@@ -1199,16 +1199,16 @@ bool SDLTest_CommonInit(SDLTest_CommonState *state)
                     }
                     SDL_snprintfcat(text, sizeof(text), " %s", SDL_GetVideoDriver(i));
                 }
-                SDL_Log("%s\n", text);
+                SDL_Log("%s", text);
             }
         }
         if (!SDL_InitSubSystem(SDL_INIT_VIDEO)) {
-            SDL_Log("Couldn't initialize video driver: %s\n",
+            SDL_Log("Couldn't initialize video driver: %s",
                     SDL_GetError());
             return false;
         }
         if (state->verbose & VERBOSE_VIDEO) {
-            SDL_Log("Video driver: %s\n",
+            SDL_Log("Video driver: %s",
                     SDL_GetCurrentVideoDriver());
         }
 
@@ -1257,10 +1257,10 @@ bool SDLTest_CommonInit(SDLTest_CommonState *state)
             int outputIndex = 0;
 #endif
             displays = SDL_GetDisplays(&n);
-            SDL_Log("Number of displays: %d\n", n);
+            SDL_Log("Number of displays: %d", n);
             for (i = 0; i < n; ++i) {
                 SDL_DisplayID displayID = displays[i];
-                SDL_Log("Display %" SDL_PRIu32 ": %s\n", displayID, SDL_GetDisplayName(displayID));
+                SDL_Log("Display %" SDL_PRIu32 ": %s", displayID, SDL_GetDisplayName(displayID));
 
                 SDL_zero(bounds);
                 SDL_GetDisplayBounds(displayID, &bounds);
@@ -1268,46 +1268,46 @@ bool SDLTest_CommonInit(SDLTest_CommonState *state)
                 SDL_zero(usablebounds);
                 SDL_GetDisplayUsableBounds(displayID, &usablebounds);
 
-                SDL_Log("Bounds: %dx%d at %d,%d\n", bounds.w, bounds.h, bounds.x, bounds.y);
-                SDL_Log("Usable bounds: %dx%d at %d,%d\n", usablebounds.w, usablebounds.h, usablebounds.x, usablebounds.y);
+                SDL_Log("Bounds: %dx%d at %d,%d", bounds.w, bounds.h, bounds.x, bounds.y);
+                SDL_Log("Usable bounds: %dx%d at %d,%d", usablebounds.w, usablebounds.h, usablebounds.x, usablebounds.y);
 
                 mode = SDL_GetDesktopDisplayMode(displayID);
                 SDL_GetMasksForPixelFormat(mode->format, &bpp, &Rmask, &Gmask,
                                            &Bmask, &Amask);
-                SDL_Log("  Desktop mode: %dx%d@%gx %gHz, %d bits-per-pixel (%s)\n",
+                SDL_Log("  Desktop mode: %dx%d@%gx %gHz, %d bits-per-pixel (%s)",
                         mode->w, mode->h, mode->pixel_density, mode->refresh_rate, bpp,
                         SDL_GetPixelFormatName(mode->format));
                 if (Rmask || Gmask || Bmask) {
-                    SDL_Log("      Red Mask   = 0x%.8" SDL_PRIx32 "\n", Rmask);
-                    SDL_Log("      Green Mask = 0x%.8" SDL_PRIx32 "\n", Gmask);
-                    SDL_Log("      Blue Mask  = 0x%.8" SDL_PRIx32 "\n", Bmask);
+                    SDL_Log("      Red Mask   = 0x%.8" SDL_PRIx32, Rmask);
+                    SDL_Log("      Green Mask = 0x%.8" SDL_PRIx32, Gmask);
+                    SDL_Log("      Blue Mask  = 0x%.8" SDL_PRIx32, Bmask);
                     if (Amask) {
-                        SDL_Log("      Alpha Mask = 0x%.8" SDL_PRIx32 "\n", Amask);
+                        SDL_Log("      Alpha Mask = 0x%.8" SDL_PRIx32, Amask);
                     }
                 }
 
                 /* Print available fullscreen video modes */
                 modes = SDL_GetFullscreenDisplayModes(displayID, &m);
                 if (m == 0) {
-                    SDL_Log("No available fullscreen video modes\n");
+                    SDL_Log("No available fullscreen video modes");
                 } else {
-                    SDL_Log("  Fullscreen video modes:\n");
+                    SDL_Log("  Fullscreen video modes:");
                     for (j = 0; j < m; ++j) {
                         mode = modes[j];
                         SDL_GetMasksForPixelFormat(mode->format, &bpp, &Rmask,
                                                    &Gmask, &Bmask, &Amask);
-                        SDL_Log("    Mode %d: %dx%d@%gx %gHz, %d bits-per-pixel (%s)\n",
+                        SDL_Log("    Mode %d: %dx%d@%gx %gHz, %d bits-per-pixel (%s)",
                                 j, mode->w, mode->h, mode->pixel_density, mode->refresh_rate, bpp,
                                 SDL_GetPixelFormatName(mode->format));
                         if (Rmask || Gmask || Bmask) {
-                            SDL_Log("        Red Mask   = 0x%.8" SDL_PRIx32 "\n",
+                            SDL_Log("        Red Mask   = 0x%.8" SDL_PRIx32,
                                     Rmask);
-                            SDL_Log("        Green Mask = 0x%.8" SDL_PRIx32 "\n",
+                            SDL_Log("        Green Mask = 0x%.8" SDL_PRIx32,
                                     Gmask);
-                            SDL_Log("        Blue Mask  = 0x%.8" SDL_PRIx32 "\n",
+                            SDL_Log("        Blue Mask  = 0x%.8" SDL_PRIx32,
                                     Bmask);
                             if (Amask) {
-                                SDL_Log("        Alpha Mask = 0x%.8" SDL_PRIx32 "\n", Amask);
+                                SDL_Log("        Alpha Mask = 0x%.8" SDL_PRIx32, Amask);
                             }
                         }
                     }
@@ -1330,11 +1330,11 @@ bool SDLTest_CommonInit(SDLTest_CommonState *state)
         if (state->verbose & VERBOSE_RENDER) {
             n = SDL_GetNumRenderDrivers();
             if (n == 0) {
-                SDL_Log("No built-in render drivers\n");
+                SDL_Log("No built-in render drivers");
             } else {
-                SDL_Log("Built-in render drivers:\n");
+                SDL_Log("Built-in render drivers:");
                 for (i = 0; i < n; ++i) {
-                    SDL_Log("  %s\n", SDL_GetRenderDriver(i));
+                    SDL_Log("  %s", SDL_GetRenderDriver(i));
                 }
             }
         }
@@ -1374,7 +1374,7 @@ bool SDLTest_CommonInit(SDLTest_CommonState *state)
             (SDL_Texture **)SDL_calloc(state->num_windows,
                                        sizeof(*state->targets));
         if (!state->windows || !state->renderers) {
-            SDL_Log("Out of memory!\n");
+            SDL_Log("Out of memory!");
             return false;
         }
         for (i = 0; i < state->num_windows; ++i) {
@@ -1412,7 +1412,7 @@ bool SDLTest_CommonInit(SDLTest_CommonState *state)
             state->windows[i] = SDL_CreateWindowWithProperties(props);
             SDL_DestroyProperties(props);
             if (!state->windows[i]) {
-                SDL_Log("Couldn't create window: %s\n",
+                SDL_Log("Couldn't create window: %s",
                         SDL_GetError());
                 return false;
             }
@@ -1427,7 +1427,7 @@ bool SDLTest_CommonInit(SDLTest_CommonState *state)
             }
             SDL_GetWindowSize(state->windows[i], &w, &h);
             if (!(state->window_flags & SDL_WINDOW_RESIZABLE) && (w != r.w || h != r.h)) {
-                SDL_Log("Window requested size %dx%d, got %dx%d\n", r.w, r.h, w, h);
+                SDL_Log("Window requested size %dx%d, got %dx%d", r.w, r.h, w, h);
                 state->window_w = w;
                 state->window_h = h;
             }
@@ -1459,7 +1459,7 @@ bool SDLTest_CommonInit(SDLTest_CommonState *state)
             if (!state->skip_renderer && (state->renderdriver || !(state->window_flags & (SDL_WINDOW_OPENGL | SDL_WINDOW_VULKAN | SDL_WINDOW_METAL)))) {
                 state->renderers[i] = SDL_CreateRenderer(state->windows[i], state->renderdriver);
                 if (!state->renderers[i]) {
-                    SDL_Log("Couldn't create renderer: %s\n",
+                    SDL_Log("Couldn't create renderer: %s",
                             SDL_GetError());
                     return false;
                 }
@@ -1471,14 +1471,14 @@ bool SDLTest_CommonInit(SDLTest_CommonState *state)
                     SDL_SetRenderVSync(state->renderers[i], state->render_vsync);
                 }
                 if (!SDL_SetRenderLogicalPresentation(state->renderers[i], state->logical_w, state->logical_h, state->logical_presentation)) {
-                    SDL_Log("Couldn't set logical presentation: %s\n", SDL_GetError());
+                    SDL_Log("Couldn't set logical presentation: %s", SDL_GetError());
                     return false;
                 }
                 if (state->scale != 0.0f) {
                     SDL_SetRenderScale(state->renderers[i], state->scale, state->scale);
                 }
                 if (state->verbose & VERBOSE_RENDER) {
-                    SDL_Log("Current renderer:\n");
+                    SDL_Log("Current renderer:");
                     SDLTest_PrintRenderer(state->renderers[i]);
                 }
             }
@@ -1494,7 +1494,7 @@ bool SDLTest_CommonInit(SDLTest_CommonState *state)
         if (state->verbose & VERBOSE_AUDIO) {
             n = SDL_GetNumAudioDrivers();
             if (n == 0) {
-                SDL_Log("No built-in audio drivers\n");
+                SDL_Log("No built-in audio drivers");
             } else {
                 (void)SDL_snprintf(text, sizeof(text), "Built-in audio drivers:");
                 for (i = 0; i < n; ++i) {
@@ -1503,23 +1503,23 @@ bool SDLTest_CommonInit(SDLTest_CommonState *state)
                     }
                     SDL_snprintfcat(text, sizeof(text), " %s", SDL_GetAudioDriver(i));
                 }
-                SDL_Log("%s\n", text);
+                SDL_Log("%s", text);
             }
         }
         if (!SDL_InitSubSystem(SDL_INIT_AUDIO)) {
-            SDL_Log("Couldn't initialize audio driver: %s\n",
+            SDL_Log("Couldn't initialize audio driver: %s",
                     SDL_GetError());
             return false;
         }
         if (state->verbose & VERBOSE_AUDIO) {
-            SDL_Log("Audio driver: %s\n",
+            SDL_Log("Audio driver: %s",
                     SDL_GetCurrentAudioDriver());
         }
 
         const SDL_AudioSpec spec = { state->audio_format, state->audio_channels, state->audio_freq };
         state->audio_id = SDL_OpenAudioDevice(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec);
         if (!state->audio_id) {
-            SDL_Log("Couldn't open audio: %s\n", SDL_GetError());
+            SDL_Log("Couldn't open audio: %s", SDL_GetError());
             return false;
         }
     }
@@ -1676,7 +1676,7 @@ void SDLTest_PrintEvent(const SDL_Event *event)
         SDL_Rect rect;
 
         SDL_GetWindowSafeArea(SDL_GetWindowFromEvent(event), &rect);
-        SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " changed safe area to: %d,%d %dx%d\n",
+        SDL_Log("SDL EVENT: Window %" SDL_PRIu32 " changed safe area to: %d,%d %dx%d",
                 event->window.windowID, rect.x, rect.y, rect.w, rect.h);
         break;
     }
@@ -2058,7 +2058,7 @@ static void SDLCALL SDLTest_ScreenShotClipboardCleanup(void *context)
 {
     SDLTest_ClipboardData *data = (SDLTest_ClipboardData *)context;
 
-    SDL_Log("Cleaning up screenshot image data\n");
+    SDL_Log("Cleaning up screenshot image data");
 
     if (data->image) {
         SDL_free(data->image);
@@ -2071,14 +2071,14 @@ static const void * SDLCALL SDLTest_ScreenShotClipboardProvider(void *context, c
     SDLTest_ClipboardData *data = (SDLTest_ClipboardData *)context;
 
     if (SDL_strncmp(mime_type, "text", 4) == 0) {
-        SDL_Log("Providing screenshot title to clipboard!\n");
+        SDL_Log("Providing screenshot title to clipboard!");
 
         /* Return "Test screenshot" */
         *size = 15;
         return "Test screenshot (but this isn't part of it)";
     }
 
-    SDL_Log("Providing screenshot image to clipboard!\n");
+    SDL_Log("Providing screenshot image to clipboard!");
 
     if (!data->image) {
         SDL_IOStream *file;
@@ -2089,7 +2089,7 @@ static const void * SDLCALL SDLTest_ScreenShotClipboardProvider(void *context, c
             void *image = SDL_malloc(length);
             if (image) {
                 if (SDL_ReadIO(file, image, length) != length) {
-                    SDL_Log("Couldn't read %s: %s\n", SCREENSHOT_FILE, SDL_GetError());
+                    SDL_Log("Couldn't read %s: %s", SCREENSHOT_FILE, SDL_GetError());
                     SDL_free(image);
                     image = NULL;
                 }
@@ -2101,7 +2101,7 @@ static const void * SDLCALL SDLTest_ScreenShotClipboardProvider(void *context, c
                 data->size = length;
             }
         } else {
-            SDL_Log("Couldn't load %s: %s\n", SCREENSHOT_FILE, SDL_GetError());
+            SDL_Log("Couldn't load %s: %s", SCREENSHOT_FILE, SDL_GetError());
         }
     }
 
@@ -2124,12 +2124,12 @@ static void SDLTest_CopyScreenShot(SDL_Renderer *renderer)
 
     surface = SDL_RenderReadPixels(renderer, NULL);
     if (!surface) {
-        SDL_Log("Couldn't read screen: %s\n", SDL_GetError());
+        SDL_Log("Couldn't read screen: %s", SDL_GetError());
         return;
     }
 
     if (!SDL_SaveBMP(surface, SCREENSHOT_FILE)) {
-        SDL_Log("Couldn't save %s: %s\n", SCREENSHOT_FILE, SDL_GetError());
+        SDL_Log("Couldn't save %s: %s", SCREENSHOT_FILE, SDL_GetError());
         SDL_DestroySurface(surface);
         return;
     }
@@ -2137,11 +2137,11 @@ static void SDLTest_CopyScreenShot(SDL_Renderer *renderer)
 
     clipboard_data = (SDLTest_ClipboardData *)SDL_calloc(1, sizeof(*clipboard_data));
     if (!clipboard_data) {
-        SDL_Log("Couldn't allocate clipboard data\n");
+        SDL_Log("Couldn't allocate clipboard data");
         return;
     }
     SDL_SetClipboardData(SDLTest_ScreenShotClipboardProvider, SDLTest_ScreenShotClipboardCleanup, clipboard_data, image_formats, SDL_arraysize(image_formats));
-    SDL_Log("Saved screenshot to %s and clipboard\n", SCREENSHOT_FILE);
+    SDL_Log("Saved screenshot to %s and clipboard", SCREENSHOT_FILE);
 }
 
 static void SDLTest_PasteScreenShot(void)
@@ -2336,7 +2336,7 @@ SDL_AppResult SDLTest_CommonEventMainCallbacks(SDLTest_CommonState *state, const
                             } else {
                                 dest = displays[(current_index + num_displays + 1) % num_displays];
                             }
-                            SDL_Log("Centering on display (%" SDL_PRIu32 ")\n", dest);
+                            SDL_Log("Centering on display (%" SDL_PRIu32 ")", dest);
                             SDL_SetWindowPosition(window,
                                                   SDL_WINDOWPOS_CENTERED_DISPLAY(dest),
                                                   SDL_WINDOWPOS_CENTERED_DISPLAY(dest));
@@ -2365,7 +2365,7 @@ SDL_AppResult SDLTest_CommonEventMainCallbacks(SDLTest_CommonState *state, const
                         x += delta;
                     }
 
-                    SDL_Log("Setting position to (%d, %d)\n", x, y);
+                    SDL_Log("Setting position to (%d, %d)", x, y);
                     SDL_SetWindowPosition(window, x, y);
                 }
             }
@@ -2399,7 +2399,7 @@ SDL_AppResult SDLTest_CommonEventMainCallbacks(SDLTest_CommonState *state, const
             if (withAlt) {
                 /* Alt-C copy awesome text to the primary selection! */
                 SDL_SetPrimarySelectionText("SDL rocks!\nYou know it!");
-                SDL_Log("Copied text to primary selection\n");
+                SDL_Log("Copied text to primary selection");
 
             } else if (withControl) {
                 if (withShift) {
@@ -2415,7 +2415,7 @@ SDL_AppResult SDLTest_CommonEventMainCallbacks(SDLTest_CommonState *state, const
                 } else {
                     /* Ctrl-C copy awesome text! */
                     SDL_SetClipboardText("SDL rocks!\nYou know it!");
-                    SDL_Log("Copied text to clipboard\n");
+                    SDL_Log("Copied text to clipboard");
                 }
                 break;
             }
@@ -2425,9 +2425,9 @@ SDL_AppResult SDLTest_CommonEventMainCallbacks(SDLTest_CommonState *state, const
                 /* Alt-V paste awesome text from the primary selection! */
                 char *text = SDL_GetPrimarySelectionText();
                 if (*text) {
-                    SDL_Log("Primary selection: %s\n", text);
+                    SDL_Log("Primary selection: %s", text);
                 } else {
-                    SDL_Log("Primary selection is empty\n");
+                    SDL_Log("Primary selection is empty");
                 }
                 SDL_free(text);
 
@@ -2439,9 +2439,9 @@ SDL_AppResult SDLTest_CommonEventMainCallbacks(SDLTest_CommonState *state, const
                     /* Ctrl-V paste awesome text! */
                     char *text = SDL_GetClipboardText();
                     if (*text) {
-                        SDL_Log("Clipboard: %s\n", text);
+                        SDL_Log("Clipboard: %s", text);
                     } else {
-                        SDL_Log("Clipboard is empty\n");
+                        SDL_Log("Clipboard is empty");
                     }
                     SDL_free(text);
                 }
@@ -2498,7 +2498,7 @@ SDL_AppResult SDLTest_CommonEventMainCallbacks(SDLTest_CommonState *state, const
                 if (window) {
                     const bool shouldCapture = !(SDL_GetWindowFlags(window) & SDL_WINDOW_MOUSE_CAPTURE);
                     const bool rc = SDL_CaptureMouse(shouldCapture);
-                    SDL_Log("%sapturing mouse %s!\n", shouldCapture ? "C" : "Unc", rc ? "succeeded" : "failed");
+                    SDL_Log("%sapturing mouse %s!", shouldCapture ? "C" : "Unc", rc ? "succeeded" : "failed");
                 }
             }
             break;

--- a/src/video/SDL_egl.c
+++ b/src/video/SDL_egl.c
@@ -719,7 +719,7 @@ static void dumpconfig(SDL_VideoDevice *_this, EGLConfig config)
     for (attr = 0; attr < sizeof(all_attributes) / sizeof(Attribute); attr++) {
         EGLint value;
         _this->egl_data->eglGetConfigAttrib(_this->egl_data->egl_display, config, all_attributes[attr].attribute, &value);
-        SDL_Log("\t%-32s: %10d (0x%08x)\n", all_attributes[attr].name, value, value);
+        SDL_Log("\t%-32s: %10d (0x%08x)", all_attributes[attr].name, value, value);
     }
 }
 

--- a/src/video/cocoa/SDL_cocoakeyboard.m
+++ b/src/video/cocoa/SDL_cocoakeyboard.m
@@ -540,7 +540,7 @@ void Cocoa_HandleKeyEvent(SDL_VideoDevice *_this, NSEvent *event)
 
 #ifdef DEBUG_SCANCODES
         if (code == SDL_SCANCODE_UNKNOWN) {
-            SDL_Log("The key you just pressed is not recognized by SDL. To help get this fixed, report this to the SDL forums/mailing list <https://discourse.libsdl.org/> or to Christian Walther <cwalther@gmx.ch>. Mac virtual key code is %d.\n", scancode);
+            SDL_Log("The key you just pressed is not recognized by SDL. To help get this fixed, report this to the SDL forums/mailing list <https://discourse.libsdl.org/> or to Christian Walther <cwalther@gmx.ch>. Mac virtual key code is %d.", scancode);
         }
 #endif
         if (SDL_TextInputActive(SDL_GetKeyboardFocus())) {

--- a/src/video/kmsdrm/SDL_kmsdrmdyn.c
+++ b/src/video/kmsdrm/SDL_kmsdrmdyn.c
@@ -59,9 +59,9 @@ static void *KMSDRM_GetSym(const char *fnname, int *pHasModule, bool required)
 
 #if DEBUG_DYNAMIC_KMSDRM
     if (fn)
-        SDL_Log("KMSDRM: Found '%s' in %s (%p)\n", fnname, kmsdrmlibs[i].libname, fn);
+        SDL_Log("KMSDRM: Found '%s' in %s (%p)", fnname, kmsdrmlibs[i].libname, fn);
     else
-        SDL_Log("KMSDRM: Symbol '%s' NOT FOUND!\n", fnname);
+        SDL_Log("KMSDRM: Symbol '%s' NOT FOUND!", fnname);
 #endif
 
     if (!fn && required) {

--- a/src/video/openvr/SDL_openvrvideo.c
+++ b/src/video/openvr/SDL_openvrvideo.c
@@ -661,7 +661,7 @@ static bool OPENVR_SetupFrame(SDL_VideoDevice *_this, SDL_Window *window)
     {
         int error = ov_glGetError();
         if (error)
-            SDL_Log("Found GL Error before beginning frame: %d / (Framebuffer:%d)\n", error, ov_glCheckNamedFramebufferStatus(videodata->fbo, GL_FRAMEBUFFER));
+            SDL_Log("Found GL Error before beginning frame: %d / (Framebuffer:%d)", error, ov_glCheckNamedFramebufferStatus(videodata->fbo, GL_FRAMEBUFFER));
     }
 #endif
 
@@ -698,7 +698,7 @@ static bool OPENVR_ReleaseFrame(SDL_VideoDevice *_this)
     {
         int error = ov_glGetError();
         if (error) {
-            SDL_Log("Found GL Error before release frame: %d / (Framebuffer:%d)\n", error, ov_glCheckNamedFramebufferStatus(videodata->fbo, GL_FRAMEBUFFER));
+            SDL_Log("Found GL Error before release frame: %d / (Framebuffer:%d)", error, ov_glCheckNamedFramebufferStatus(videodata->fbo, GL_FRAMEBUFFER));
         }
     }
 #endif
@@ -895,7 +895,7 @@ static SDL_GLContext OPENVR_GL_CreateContext(SDL_VideoDevice *_this, SDL_Window 
         const char *ccc = (const char *)ov_glGetStringi(GL_EXTENSIONS, i);
         if (SDL_strcmp(ccc, "GL_KHR_debug") == 0) {
 #ifdef DEBUG_OPENVR
-            SDL_Log("Found renderdoc debug extension.\n");
+            SDL_Log("Found renderdoc debug extension.");
 #endif
             videodata->renderdoc_debugmarker_frame_end = true;
         }
@@ -968,7 +968,7 @@ static bool SDL_EGL_InitInternal(SDL_VideoData * vd)
 
     vd->eglDpy = eglGetDisplay(EGL_DEFAULT_DISPLAY);
 #ifdef DEBUG_OPENVR
-    SDL_Log("EGL Display: %p\n", vd->eglDpy);
+    SDL_Log("EGL Display: %p", vd->eglDpy);
 #endif
 
     if (vd->eglDpy == 0) {
@@ -1040,7 +1040,7 @@ static SDL_GLContext OVR_EGL_CreateContext(SDL_VideoDevice *_this, SDL_Window * 
         const char * ccc = (const char*)ov_glGetStringi(GL_EXTENSIONS, i);
         if (SDL_strcmp(ccc, "GL_KHR_debug") == 0) {
 #ifdef DEBUG_OPENVR
-           SDL_Log("Found renderdoc debug extension.\n");
+           SDL_Log("Found renderdoc debug extension.");
 #endif
            videodata->renderdoc_debugmarker_frame_end = true;
         }

--- a/src/video/wayland/SDL_waylanddyn.c
+++ b/src/video/wayland/SDL_waylanddyn.c
@@ -66,9 +66,9 @@ static void *WAYLAND_GetSym(const char *fnname, int *pHasModule, bool required)
 
 #if DEBUG_DYNAMIC_WAYLAND
     if (fn) {
-        SDL_Log("WAYLAND: Found '%s' in %s (%p)\n", fnname, dynlib->libname, fn);
+        SDL_Log("WAYLAND: Found '%s' in %s (%p)", fnname, dynlib->libname, fn);
     } else {
-        SDL_Log("WAYLAND: Symbol '%s' NOT FOUND!\n", fnname);
+        SDL_Log("WAYLAND: Symbol '%s' NOT FOUND!", fnname);
     }
 #endif
 

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -1195,7 +1195,7 @@ static void libdecor_error(struct libdecor *context,
                            enum libdecor_error error,
                            const char *message)
 {
-    SDL_LogError(SDL_LOG_CATEGORY_VIDEO, "libdecor error (%d): %s\n", error, message);
+    SDL_LogError(SDL_LOG_CATEGORY_VIDEO, "libdecor error (%d): %s", error, message);
 }
 
 static struct libdecor_interface libdecor_interface = {

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -157,17 +157,17 @@ static Uint64 WIN_GetEventTimestamp(void)
     timestamp += timestamp_offset;
     if (!timestamp_offset) {
         // Initializing timestamp offset
-        //SDL_Log("Initializing timestamp offset\n");
+        //SDL_Log("Initializing timestamp offset");
         timestamp_offset = (now - timestamp);
         timestamp = now;
     } else if ((Sint64)(now - timestamp - TIMESTAMP_WRAP_OFFSET) >= 0) {
         // The windows message tick wrapped
-        //SDL_Log("Adjusting timestamp offset for wrapping tick\n");
+        //SDL_Log("Adjusting timestamp offset for wrapping tick");
         timestamp_offset += TIMESTAMP_WRAP_OFFSET;
         timestamp += TIMESTAMP_WRAP_OFFSET;
     } else if (timestamp > now) {
         // We got a newer timestamp, but it can't be newer than now, so adjust our offset
-        //SDL_Log("Adjusting timestamp offset, %.2f ms newer\n", (double)(timestamp - now) / SDL_NS_PER_MS);
+        //SDL_Log("Adjusting timestamp offset, %.2f ms newer", (double)(timestamp - now) / SDL_NS_PER_MS);
         timestamp_offset -= (timestamp - now);
         timestamp = now;
     }
@@ -2239,7 +2239,7 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
             int w, h;
 
 #ifdef HIGHDPI_DEBUG
-            SDL_Log("WM_DPICHANGED: to %d\tsuggested rect: (%d, %d), (%dx%d)\n", newDPI,
+            SDL_Log("WM_DPICHANGED: to %d\tsuggested rect: (%d, %d), (%dx%d)", newDPI,
                     suggestedRect->left, suggestedRect->top, suggestedRect->right - suggestedRect->left, suggestedRect->bottom - suggestedRect->top);
 #endif
 
@@ -2270,7 +2270,7 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
             }
 
 #ifdef HIGHDPI_DEBUG
-            SDL_Log("WM_DPICHANGED: current SDL window size: (%dx%d)\tcalling SetWindowPos: (%d, %d), (%dx%d)\n",
+            SDL_Log("WM_DPICHANGED: current SDL window size: (%dx%d)\tcalling SetWindowPos: (%d, %d), (%dx%d)",
                     data->window->w, data->window->h,
                     suggestedRect->left, suggestedRect->top, w, h);
 #endif

--- a/src/video/windows/SDL_windowsgameinput.c
+++ b/src/video/windows/SDL_windowsgameinput.c
@@ -391,7 +391,7 @@ static void DumpKeys(const char *prefix, GameInputKeyState *keys, uint32_t count
     for (uint32_t i = 0; i < count; ++i) {
         char str[5];
         *SDL_UCS4ToUTF8(keys[i].codePoint, str) = '\0';
-        SDL_Log("    Key 0x%.2x (%s)\n", keys[i].scanCode, str);
+        SDL_Log("    Key 0x%.2x (%s)", keys[i].scanCode, str);
     }
 }
 #endif // DEBUG_KEYS
@@ -413,7 +413,7 @@ static void GAMEINPUT_HandleKeyboardDelta(WIN_GameInputData *data, SDL_Window *w
     uint32_t num_last = IGameInputReading_GetKeyState(last_reading, max_keys, last);
     uint32_t num_keys = IGameInputReading_GetKeyState(reading, max_keys, keys);
 #ifdef DEBUG_KEYS
-    SDL_Log("Timestamp: %llu\n", timestamp);
+    SDL_Log("Timestamp: %llu", timestamp);
     DumpKeys("Last keys:", last, num_last);
     DumpKeys("New keys:", keys, num_keys);
 #endif

--- a/src/video/windows/SDL_windowsmodes.c
+++ b/src/video/windows/SDL_windowsmodes.c
@@ -561,7 +561,7 @@ static void WIN_AddDisplay(SDL_VideoDevice *_this, HMONITOR hMonitor, const MONI
     float content_scale = WIN_GetContentScale(_this, hMonitor);
 
 #ifdef DEBUG_MODES
-    SDL_Log("Display: %s\n", WIN_StringToUTF8W(info->szDevice));
+    SDL_Log("Display: %s", WIN_StringToUTF8W(info->szDevice));
 #endif
 
     dxgi_output = WIN_GetDXGIOutput(_this, info->szDevice);

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -482,11 +482,11 @@ static bool WIN_VideoInit(SDL_VideoDevice *_this)
         if (SUCCEEDED(hr)) {
             data->oleinitialized = true;
         } else {
-            SDL_LogInfo(SDL_LOG_CATEGORY_VIDEO, "OleInitialize() failed: 0x%.8x, using fallback drag-n-drop functionality\n", (unsigned int)hr);
+            SDL_LogInfo(SDL_LOG_CATEGORY_VIDEO, "OleInitialize() failed: 0x%.8x, using fallback drag-n-drop functionality", (unsigned int)hr);
         }
 #endif // !(defined(SDL_PLATFORM_XBOXONE) || defined(SDL_PLATFORM_XBOXSERIES))
     } else {
-        SDL_LogInfo(SDL_LOG_CATEGORY_VIDEO, "CoInitialize() failed: 0x%.8x, using fallback drag-n-drop functionality\n", (unsigned int)hr);
+        SDL_LogInfo(SDL_LOG_CATEGORY_VIDEO, "CoInitialize() failed: 0x%.8x, using fallback drag-n-drop functionality", (unsigned int)hr);
     }
 
     WIN_InitDPIAwareness(_this);

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -430,7 +430,7 @@ void X11_ReconcileKeyboardState(SDL_VideoDevice *_this)
 static void X11_DispatchFocusIn(SDL_VideoDevice *_this, SDL_WindowData *data)
 {
 #ifdef DEBUG_XEVENTS
-    SDL_Log("window 0x%lx: Dispatching FocusIn\n", data->xwindow);
+    SDL_Log("window 0x%lx: Dispatching FocusIn", data->xwindow);
 #endif
     SDL_SetKeyboardFocus(data->window);
     X11_ReconcileKeyboardState(_this);
@@ -447,7 +447,7 @@ static void X11_DispatchFocusIn(SDL_VideoDevice *_this, SDL_WindowData *data)
 static void X11_DispatchFocusOut(SDL_VideoDevice *_this, SDL_WindowData *data)
 {
 #ifdef DEBUG_XEVENTS
-    SDL_Log("window 0x%lx: Dispatching FocusOut\n", data->xwindow);
+    SDL_Log("window 0x%lx: Dispatching FocusOut", data->xwindow);
 #endif
     /* If another window has already processed a focus in, then don't try to
      * remove focus here.  Doing so will incorrectly remove focus from that
@@ -606,7 +606,7 @@ static void X11_UpdateUserTime(SDL_WindowData *data, const unsigned long latest)
                             XA_CARDINAL, 32, PropModeReplace,
                             (const unsigned char *)&latest, 1);
 #ifdef DEBUG_XEVENTS
-        SDL_Log("window 0x%lx: updating _NET_WM_USER_TIME to %lu\n", data->xwindow, latest);
+        SDL_Log("window 0x%lx: updating _NET_WM_USER_TIME to %lu", data->xwindow, latest);
 #endif
         data->user_time = latest;
     }
@@ -636,7 +636,7 @@ static void X11_HandleClipboardEvent(SDL_VideoDevice *_this, const XEvent *xeven
 #ifdef DEBUG_XEVENTS
         char *atom_name;
         atom_name = X11_XGetAtomName(display, req->target);
-        SDL_Log("window CLIPBOARD: SelectionRequest (requestor = 0x%lx, target = 0x%lx, mime_type = %s)\n",
+        SDL_Log("window CLIPBOARD: SelectionRequest (requestor = 0x%lx, target = 0x%lx, mime_type = %s)",
                req->requestor, req->target, atom_name);
         if (atom_name) {
             X11_XFree(atom_name);
@@ -709,7 +709,7 @@ static void X11_HandleClipboardEvent(SDL_VideoDevice *_this, const XEvent *xeven
         const char *propName = xsel->property ? X11_XGetAtomName(display, xsel->property) : "None";
         const char *targetName = xsel->target ? X11_XGetAtomName(display, xsel->target) : "None";
 
-        SDL_Log("window CLIPBOARD: SelectionNotify (requestor = 0x%lx, target = %s, property = %s)\n",
+        SDL_Log("window CLIPBOARD: SelectionNotify (requestor = 0x%lx, target = %s, property = %s)",
                xsel->requestor, targetName, propName);
 #endif
         if (xsel->target == videodata->atoms.TARGETS && xsel->property == videodata->atoms.SDL_FORMATS) {
@@ -761,7 +761,7 @@ static void X11_HandleClipboardEvent(SDL_VideoDevice *_this, const XEvent *xeven
         SDLX11_ClipboardData *clipboard = NULL;
 
 #ifdef DEBUG_XEVENTS
-        SDL_Log("window CLIPBOARD: SelectionClear (requestor = 0x%lx, target = 0x%lx)\n",
+        SDL_Log("window CLIPBOARD: SelectionClear (requestor = 0x%lx, target = 0x%lx)",
                xevent->xselection.requestor, xevent->xselection.target);
 #endif
 
@@ -892,14 +892,14 @@ void X11_HandleKeyEvent(SDL_VideoDevice *_this, SDL_WindowData *windowdata, SDL_
     Uint64 timestamp = X11_GetEventTimestamp(xevent->xkey.time);
 
 #ifdef DEBUG_XEVENTS
-    SDL_Log("window 0x%lx %s (X11 keycode = 0x%X)\n", xevent->xany.window, (xevent->type == KeyPress ? "KeyPress" : "KeyRelease"), xevent->xkey.keycode);
+    SDL_Log("window 0x%lx %s (X11 keycode = 0x%X)", xevent->xany.window, (xevent->type == KeyPress ? "KeyPress" : "KeyRelease"), xevent->xkey.keycode);
 #endif
 #ifdef DEBUG_SCANCODES
     if (scancode == SDL_SCANCODE_UNKNOWN && keycode) {
         int min_keycode, max_keycode;
         X11_XDisplayKeycodes(display, &min_keycode, &max_keycode);
         keysym = X11_KeyCodeToSym(_this, keycode, xevent->xkey.state >> 13);
-        SDL_Log("The key you just pressed is not recognized by SDL. To help get this fixed, please report this to the SDL forums/mailing list <https://discourse.libsdl.org/> X11 KeyCode %d (%d), X11 KeySym 0x%lX (%s).\n",
+        SDL_Log("The key you just pressed is not recognized by SDL. To help get this fixed, please report this to the SDL forums/mailing list <https://discourse.libsdl.org/> X11 KeyCode %d (%d), X11 KeySym 0x%lX (%s).",
                 keycode, keycode - min_keycode, keysym,
                 X11_XKeysymToString(keysym));
     }
@@ -912,7 +912,7 @@ void X11_HandleKeyEvent(SDL_VideoDevice *_this, SDL_WindowData *windowdata, SDL_
         // filter events catches XIM events and sends them to the correct handler
         if (X11_XFilterEvent(xevent, None)) {
 #ifdef DEBUG_XEVENTS
-            SDL_Log("Filtered event type = %d display = %p window = 0x%lx\n",
+            SDL_Log("Filtered event type = %d display = %p window = 0x%lx",
                    xevent->type, xevent->xany.display, xevent->xany.window);
 #endif
             handled_by_ime = true;
@@ -967,7 +967,7 @@ void X11_HandleButtonPress(SDL_VideoDevice *_this, SDL_WindowData *windowdata, S
     Uint64 timestamp = X11_GetEventTimestamp(time);
 
 #ifdef DEBUG_XEVENTS
-    SDL_Log("window 0x%lx: ButtonPress (X11 button = %d)\n", windowdata->xwindow, button);
+    SDL_Log("window 0x%lx: ButtonPress (X11 button = %d)", windowdata->xwindow, button);
 #endif
 
     SDL_Mouse *mouse = SDL_GetMouse();
@@ -1015,7 +1015,7 @@ void X11_HandleButtonRelease(SDL_VideoDevice *_this, SDL_WindowData *windowdata,
     Uint64 timestamp = X11_GetEventTimestamp(time);
 
 #ifdef DEBUG_XEVENTS
-    SDL_Log("window 0x%lx: ButtonRelease (X11 button = %d)\n", windowdata->xwindow, button);
+    SDL_Log("window 0x%lx: ButtonRelease (X11 button = %d)", windowdata->xwindow, button);
 #endif
     if (!X11_IsWheelEvent(display, button, &xticks, &yticks)) {
         if (button > 7) {
@@ -1048,7 +1048,7 @@ void X11_GetBorderValues(SDL_WindowData *data)
             X11_XFree(property);
 
 #ifdef DEBUG_XEVENTS
-            SDL_Log("New _NET_FRAME_EXTENTS: left=%d right=%d, top=%d, bottom=%d\n", data->border_left, data->border_right, data->border_top, data->border_bottom);
+            SDL_Log("New _NET_FRAME_EXTENTS: left=%d right=%d, top=%d, bottom=%d", data->border_left, data->border_right, data->border_top, data->border_bottom);
 #endif
         }
     } else {
@@ -1072,7 +1072,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
     if (xevent->type != KeyPress && xevent->type != KeyRelease) {
         if (X11_XFilterEvent(xevent, None)) {
 #ifdef DEBUG_XEVENTS
-            SDL_Log("Filtered event type = %d display = %p window = 0x%lx\n",
+            SDL_Log("Filtered event type = %d display = %p window = 0x%lx",
                    xevent->type, xevent->xany.display, xevent->xany.window);
 #endif
             return;
@@ -1100,7 +1100,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
 #endif
 
 #ifdef DEBUG_XEVENTS
-    SDL_Log("X11 event type = %d display = %p window = 0x%lx\n",
+    SDL_Log("X11 event type = %d display = %p window = 0x%lx",
            xevent->type, xevent->xany.display, xevent->xany.window);
 #endif
 
@@ -1110,7 +1110,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
         XFixesSelectionNotifyEvent *ev = (XFixesSelectionNotifyEvent *)xevent;
 
 #ifdef DEBUG_XEVENTS
-        SDL_Log("window CLIPBOARD: XFixesSelectionNotify (selection = %s)\n",
+        SDL_Log("window CLIPBOARD: XFixesSelectionNotify (selection = %s)",
                X11_XGetAtomName(display, ev->selection));
 #endif
 
@@ -1154,7 +1154,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
         // The window for KeymapNotify, etc events is 0
         if (xevent->type == KeymapNotify) {
 #ifdef DEBUG_XEVENTS
-            SDL_Log("window 0x%lx: KeymapNotify!\n", xevent->xany.window);
+            SDL_Log("window 0x%lx: KeymapNotify!", xevent->xany.window);
 #endif
             if (SDL_GetKeyboardFocus() != NULL) {
 #ifdef SDL_VIDEO_DRIVER_X11_HAS_XKBLOOKUPKEYSYM
@@ -1176,7 +1176,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
             const int request = xevent->xmapping.request;
 
 #ifdef DEBUG_XEVENTS
-            SDL_Log("window 0x%lx: MappingNotify!\n", xevent->xany.window);
+            SDL_Log("window 0x%lx: MappingNotify!", xevent->xany.window);
 #endif
             if ((request == MappingKeyboard) || (request == MappingModifier)) {
                 X11_XRefreshKeyboardMapping(&xevent->xmapping);
@@ -1221,15 +1221,15 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
     {
         SDL_Mouse *mouse = SDL_GetMouse();
 #ifdef DEBUG_XEVENTS
-        SDL_Log("window 0x%lx: EnterNotify! (%d,%d,%d)\n", xevent->xany.window,
+        SDL_Log("window 0x%lx: EnterNotify! (%d,%d,%d)", xevent->xany.window,
                xevent->xcrossing.x,
                xevent->xcrossing.y,
                xevent->xcrossing.mode);
         if (xevent->xcrossing.mode == NotifyGrab) {
-            SDL_Log("Mode: NotifyGrab\n");
+            SDL_Log("Mode: NotifyGrab");
         }
         if (xevent->xcrossing.mode == NotifyUngrab) {
-            SDL_Log("Mode: NotifyUngrab\n");
+            SDL_Log("Mode: NotifyUngrab");
         }
 #endif
         SDL_SetMouseFocus(data->window);
@@ -1260,15 +1260,15 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
     case LeaveNotify:
     {
 #ifdef DEBUG_XEVENTS
-        SDL_Log("window 0x%lx: LeaveNotify! (%d,%d,%d)\n", xevent->xany.window,
+        SDL_Log("window 0x%lx: LeaveNotify! (%d,%d,%d)", xevent->xany.window,
                xevent->xcrossing.x,
                xevent->xcrossing.y,
                xevent->xcrossing.mode);
         if (xevent->xcrossing.mode == NotifyGrab) {
-            SDL_Log("Mode: NotifyGrab\n");
+            SDL_Log("Mode: NotifyGrab");
         }
         if (xevent->xcrossing.mode == NotifyUngrab) {
-            SDL_Log("Mode: NotifyUngrab\n");
+            SDL_Log("Mode: NotifyUngrab");
         }
 #endif
         if (!SDL_GetMouse()->relative_mode) {
@@ -1295,19 +1295,19 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
         if (xevent->xfocus.mode == NotifyGrab || xevent->xfocus.mode == NotifyUngrab) {
             // Someone is handling a global hotkey, ignore it
 #ifdef DEBUG_XEVENTS
-            SDL_Log("window 0x%lx: FocusIn (NotifyGrab/NotifyUngrab, ignoring)\n", xevent->xany.window);
+            SDL_Log("window 0x%lx: FocusIn (NotifyGrab/NotifyUngrab, ignoring)", xevent->xany.window);
 #endif
             break;
         }
 
         if (xevent->xfocus.detail == NotifyInferior || xevent->xfocus.detail == NotifyPointer) {
 #ifdef DEBUG_XEVENTS
-            SDL_Log("window 0x%lx: FocusIn (NotifyInferior/NotifyPointer, ignoring)\n", xevent->xany.window);
+            SDL_Log("window 0x%lx: FocusIn (NotifyInferior/NotifyPointer, ignoring)", xevent->xany.window);
 #endif
             break;
         }
 #ifdef DEBUG_XEVENTS
-        SDL_Log("window 0x%lx: FocusIn!\n", xevent->xany.window);
+        SDL_Log("window 0x%lx: FocusIn!", xevent->xany.window);
 #endif
         if (!videodata->last_mode_change_deadline) /* no recent mode changes */ {
             data->pending_focus = PENDING_FOCUS_NONE;
@@ -1326,7 +1326,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
         if (xevent->xfocus.mode == NotifyGrab || xevent->xfocus.mode == NotifyUngrab) {
             // Someone is handling a global hotkey, ignore it
 #ifdef DEBUG_XEVENTS
-            SDL_Log("window 0x%lx: FocusOut (NotifyGrab/NotifyUngrab, ignoring)\n", xevent->xany.window);
+            SDL_Log("window 0x%lx: FocusOut (NotifyGrab/NotifyUngrab, ignoring)", xevent->xany.window);
 #endif
             break;
         }
@@ -1335,12 +1335,12 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
                care about the position of the pointer when the keyboard
                focus changed. */
 #ifdef DEBUG_XEVENTS
-            SDL_Log("window 0x%lx: FocusOut (NotifyInferior/NotifyPointer, ignoring)\n", xevent->xany.window);
+            SDL_Log("window 0x%lx: FocusOut (NotifyInferior/NotifyPointer, ignoring)", xevent->xany.window);
 #endif
             break;
         }
 #ifdef DEBUG_XEVENTS
-        SDL_Log("window 0x%lx: FocusOut!\n", xevent->xany.window);
+        SDL_Log("window 0x%lx: FocusOut!", xevent->xany.window);
 #endif
         if (!videodata->last_mode_change_deadline) /* no recent mode changes */ {
             data->pending_focus = PENDING_FOCUS_NONE;
@@ -1366,7 +1366,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
         XEvent ev;
 
 #ifdef DEBUG_XEVENTS
-        SDL_Log("window 0x%lx: UnmapNotify!\n", xevent->xany.window);
+        SDL_Log("window 0x%lx: UnmapNotify!", xevent->xany.window);
 #endif
 
         if (X11_XCheckIfEvent(display, &ev, &isReparentNotify, (XPointer)&xevent->xunmap)) {
@@ -1387,7 +1387,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
     case MapNotify:
     {
 #ifdef DEBUG_XEVENTS
-        SDL_Log("window 0x%lx: MapNotify!\n", xevent->xany.window);
+        SDL_Log("window 0x%lx: MapNotify!", xevent->xany.window);
 #endif
         X11_DispatchMapNotify(data);
 
@@ -1403,7 +1403,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
     case ConfigureNotify:
     {
 #ifdef DEBUG_XEVENTS
-        SDL_Log("window 0x%lx: ConfigureNotify! (position: %d,%d, size: %dx%d)\n", xevent->xany.window,
+        SDL_Log("window 0x%lx: ConfigureNotify! (position: %d,%d, size: %dx%d)", xevent->xany.window,
                xevent->xconfigure.x, xevent->xconfigure.y,
                xevent->xconfigure.width, xevent->xconfigure.height);
 #endif
@@ -1470,9 +1470,9 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
             data->xdnd_source = xevent->xclient.data.l[0];
             xdnd_version = (xevent->xclient.data.l[1] >> 24);
 #ifdef DEBUG_XEVENTS
-            SDL_Log("XID of source window : 0x%lx\n", data->xdnd_source);
-            SDL_Log("Protocol version to use : %d\n", xdnd_version);
-            SDL_Log("More then 3 data types : %d\n", (int)use_list);
+            SDL_Log("XID of source window : 0x%lx", data->xdnd_source);
+            SDL_Log("Protocol version to use : %d", xdnd_version);
+            SDL_Log("More then 3 data types : %d", (int)use_list);
 #endif
 
             if (use_list) {
@@ -1488,7 +1488,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
             }
         } else if (xevent->xclient.message_type == videodata->atoms.XdndLeave) {
 #ifdef DEBUG_XEVENTS
-            SDL_Log("XID of source window : 0x%lx\n", xevent->xclient.data.l[0]);
+            SDL_Log("XID of source window : 0x%lx", xevent->xclient.data.l[0]);
 #endif
             SDL_SendDropComplete(data->window);
         } else if (xevent->xclient.message_type == videodata->atoms.XdndPosition) {
@@ -1498,7 +1498,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
             if (xdnd_version >= 2) {
                 act = xevent->xclient.data.l[4];
             }
-            SDL_Log("Action requested by user is : %s\n", X11_XGetAtomName(display, act));
+            SDL_Log("Action requested by user is : %s", X11_XGetAtomName(display, act));
 #endif
             {
                 // Drag and Drop position
@@ -1555,7 +1555,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
             Window root = DefaultRootWindow(display);
 
 #ifdef DEBUG_XEVENTS
-            SDL_Log("window 0x%lx: _NET_WM_PING\n", xevent->xany.window);
+            SDL_Log("window 0x%lx: _NET_WM_PING", xevent->xany.window);
 #endif
             xevent->xclient.window = root;
             X11_XSendEvent(display, root, False, SubstructureRedirectMask | SubstructureNotifyMask, xevent);
@@ -1567,7 +1567,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
                  (xevent->xclient.data.l[0] == videodata->atoms.WM_DELETE_WINDOW)) {
 
 #ifdef DEBUG_XEVENTS
-            SDL_Log("window 0x%lx: WM_DELETE_WINDOW\n", xevent->xany.window);
+            SDL_Log("window 0x%lx: WM_DELETE_WINDOW", xevent->xany.window);
 #endif
             SDL_SendWindowEvent(data->window, SDL_EVENT_WINDOW_CLOSE_REQUESTED, 0, 0);
             break;
@@ -1589,7 +1589,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
     case Expose:
     {
 #ifdef DEBUG_XEVENTS
-        SDL_Log("window 0x%lx: Expose (count = %d)\n", xevent->xany.window, xevent->xexpose.count);
+        SDL_Log("window 0x%lx: Expose (count = %d)", xevent->xany.window, xevent->xexpose.count);
 #endif
         SDL_SendWindowEvent(data->window, SDL_EVENT_WINDOW_EXPOSED, 0, 0);
     } break;
@@ -1622,7 +1622,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
         SDL_Mouse *mouse = SDL_GetMouse();
         if (!mouse->relative_mode) {
 #ifdef DEBUG_MOTION
-            SDL_Log("window 0x%lx: X11 motion: %d,%d\n", xevent->xany.window, xevent->xmotion.x, xevent->xmotion.y);
+            SDL_Log("window 0x%lx: X11 motion: %d,%d", xevent->xany.window, xevent->xmotion.x, xevent->xmotion.y);
 #endif
 
             X11_ProcessHitTest(_this, data, (float)xevent->xmotion.x, (float)xevent->xmotion.y, false);
@@ -1661,7 +1661,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
 
         char *name = X11_XGetAtomName(display, xevent->xproperty.atom);
         if (name) {
-            SDL_Log("window 0x%lx: PropertyNotify: %s %s time=%lu\n", xevent->xany.window, name, (xevent->xproperty.state == PropertyDelete) ? "deleted" : "changed", xevent->xproperty.time);
+            SDL_Log("window 0x%lx: PropertyNotify: %s %s time=%lu", xevent->xany.window, name, (xevent->xproperty.state == PropertyDelete) ? "deleted" : "changed", xevent->xproperty.time);
             X11_XFree(name);
         }
 
@@ -1674,7 +1674,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
                 for (i = 0; i < items_read; i++) {
                     SDL_Log(" %d", values[i]);
                 }
-                SDL_Log(" }\n");
+                SDL_Log(" }");
             } else if (real_type == XA_CARDINAL) {
                 if (real_format == 32) {
                     Uint32 *values = (Uint32 *)propdata;
@@ -1683,7 +1683,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
                     for (i = 0; i < items_read; i++) {
                         SDL_Log(" %d", values[i]);
                     }
-                    SDL_Log(" }\n");
+                    SDL_Log(" }");
                 } else if (real_format == 16) {
                     Uint16 *values = (Uint16 *)propdata;
 
@@ -1691,7 +1691,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
                     for (i = 0; i < items_read; i++) {
                         SDL_Log(" %d", values[i]);
                     }
-                    SDL_Log(" }\n");
+                    SDL_Log(" }");
                 } else if (real_format == 8) {
                     Uint8 *values = (Uint8 *)propdata;
 
@@ -1699,11 +1699,11 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
                     for (i = 0; i < items_read; i++) {
                         SDL_Log(" %d", values[i]);
                     }
-                    SDL_Log(" }\n");
+                    SDL_Log(" }");
                 }
             } else if (real_type == XA_STRING ||
                        real_type == videodata->atoms.UTF8_STRING) {
-                SDL_Log("{ \"%s\" }\n", propdata);
+                SDL_Log("{ \"%s\" }", propdata);
             } else if (real_type == XA_ATOM) {
                 Atom *atoms = (Atom *)propdata;
 
@@ -1715,10 +1715,10 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
                         X11_XFree(atomname);
                     }
                 }
-                SDL_Log(" }\n");
+                SDL_Log(" }");
             } else {
                 char *atomname = X11_XGetAtomName(display, real_type);
-                SDL_Log("Unknown type: 0x%lx (%s)\n", real_type, atomname ? atomname : "UNKNOWN");
+                SDL_Log("Unknown type: 0x%lx (%s)", real_type, atomname ? atomname : "UNKNOWN");
                 if (atomname) {
                     X11_XFree(atomname);
                 }
@@ -1918,7 +1918,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
     {
         Atom target = xevent->xselection.target;
 #ifdef DEBUG_XEVENTS
-        SDL_Log("window 0x%lx: SelectionNotify (requestor = 0x%lx, target = 0x%lx)\n", xevent->xany.window,
+        SDL_Log("window 0x%lx: SelectionNotify (requestor = 0x%lx, target = 0x%lx)", xevent->xany.window,
                xevent->xselection.requestor, xevent->xselection.target);
 #endif
         if (target == data->xdnd_req) {
@@ -1969,7 +1969,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
     default:
     {
 #ifdef DEBUG_XEVENTS
-        SDL_Log("window 0x%lx: Unhandled event %d\n", xevent->xany.window, xevent->type);
+        SDL_Log("window 0x%lx: Unhandled event %d", xevent->xany.window, xevent->type);
 #endif
     } break;
     }

--- a/src/video/x11/SDL_x11keyboard.c
+++ b/src/video/x11/SDL_x11keyboard.c
@@ -239,7 +239,7 @@ bool X11_InitKeyboard(SDL_VideoDevice *_this)
         const SDL_Scancode *table = SDL_GetScancodeTable(scancode_set[best_index], &table_size);
 
 #ifdef DEBUG_KEYBOARD
-        SDL_Log("Using scancode set %d, min_keycode = %d, max_keycode = %d, table_size = %d\n", best_index, min_keycode, max_keycode, table_size);
+        SDL_Log("Using scancode set %d, min_keycode = %d, max_keycode = %d, table_size = %d", best_index, min_keycode, max_keycode, table_size);
 #endif
         // This should never happen, but just in case...
         if (table_size > (SDL_arraysize(data->key_layout) - min_keycode)) {
@@ -267,14 +267,14 @@ bool X11_InitKeyboard(SDL_VideoDevice *_this)
             if ((SDL_GetKeymapKeycode(NULL, scancode, SDL_KMOD_NONE) & (SDLK_SCANCODE_MASK | SDLK_EXTENDED_MASK)) && X11_ScancodeIsRemappable(scancode)) {
                 // Not a character key and the scancode is safe to remap
 #ifdef DEBUG_KEYBOARD
-                SDL_Log("Changing scancode, was %d (%s), now %d (%s)\n", data->key_layout[i], SDL_GetScancodeName(data->key_layout[i]), scancode, SDL_GetScancodeName(scancode));
+                SDL_Log("Changing scancode, was %d (%s), now %d (%s)", data->key_layout[i], SDL_GetScancodeName(data->key_layout[i]), scancode, SDL_GetScancodeName(scancode));
 #endif
                 data->key_layout[i] = scancode;
             }
         }
     } else {
 #ifdef DEBUG_SCANCODES
-        SDL_Log("Keyboard layout unknown, please report the following to the SDL forums/mailing list (https://discourse.libsdl.org/):\n");
+        SDL_Log("Keyboard layout unknown, please report the following to the SDL forums/mailing list (https://discourse.libsdl.org/):");
 #endif
 
         // Determine key_layout - only works on US QWERTY layout
@@ -288,9 +288,9 @@ bool X11_InitKeyboard(SDL_VideoDevice *_this)
                         (unsigned int)sym, sym == NoSymbol ? "NoSymbol" : X11_XKeysymToString(sym));
             }
             if (scancode == SDL_SCANCODE_UNKNOWN) {
-                SDL_Log("scancode not found\n");
+                SDL_Log("scancode not found");
             } else {
-                SDL_Log("scancode = %d (%s)\n", scancode, SDL_GetScancodeName(scancode));
+                SDL_Log("scancode = %d (%s)", scancode, SDL_GetScancodeName(scancode));
             }
 #endif
             data->key_layout[i] = scancode;
@@ -592,12 +592,12 @@ static void preedit_draw_callback(XIC xic, XPointer client_data, XIMPreeditDrawC
 
 #ifdef DEBUG_XIM
     if (call_data->chg_length > 0) {
-        SDL_Log("Draw callback deleted %d characters at %d\n", call_data->chg_length, call_data->chg_first);
+        SDL_Log("Draw callback deleted %d characters at %d", call_data->chg_length, call_data->chg_first);
     }
     if (text) {
-        SDL_Log("Draw callback inserted %s at %d, caret: %d\n", text->string.multi_byte, call_data->chg_first, call_data->caret);
+        SDL_Log("Draw callback inserted %s at %d, caret: %d", text->string.multi_byte, call_data->chg_first, call_data->caret);
     }
-    SDL_Log("Pre-edit text: %s\n", data->preedit_text);
+    SDL_Log("Pre-edit text: %s", data->preedit_text);
 #endif
 
     X11_SendEditingEvent(data);

--- a/src/video/x11/SDL_x11xinput2.c
+++ b/src/video/x11/SDL_x11xinput2.c
@@ -584,7 +584,7 @@ bool X11_Xinput2SelectMouseAndKeyboard(SDL_VideoDevice *_this, SDL_Window *windo
         XISetMask(mask, XI_PropertyEvent); // E.g., when swapping tablet pens
 
         if (X11_XISelectEvents(data->display, windowdata->xwindow, &eventmask, 1) != Success) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_INPUT, "Could not enable XInput2 event handling\n");
+            SDL_LogWarn(SDL_LOG_CATEGORY_INPUT, "Could not enable XInput2 event handling");
             windowdata->xinput2_keyboard_enabled = false;
             windowdata->xinput2_mouse_enabled = false;
         }

--- a/test/checkkeys.c
+++ b/test/checkkeys.c
@@ -185,7 +185,7 @@ static void PrintModifierState(void)
     left = sizeof(message);
 
     print_modifiers(&spot, &left, SDL_GetModState());
-    SDL_Log("Initial state:%s\n", message);
+    SDL_Log("Initial state:%s", message);
 }
 
 static void PrintKey(SDL_KeyboardEvent *event)
@@ -218,7 +218,7 @@ static void PrintKey(SDL_KeyboardEvent *event)
     if (event->repeat) {
         print_string(&spot, &left, " (repeat)");
     }
-    SDL_Log("%s\n", message);
+    SDL_Log("%s", message);
 }
 
 static void PrintText(const char *eventtype, const char *text)
@@ -231,7 +231,7 @@ static void PrintText(const char *eventtype, const char *text)
         size_t length = SDL_strlen(expanded);
         (void)SDL_snprintf(expanded + length, sizeof(expanded) - length, "\\x%.2x", (unsigned char)*spot);
     }
-    SDL_Log("%s Text (%s): \"%s%s\"\n", eventtype, expanded, *text == '"' ? "\\" : "", text);
+    SDL_Log("%s Text (%s): \"%s%s\"", eventtype, expanded, *text == '"' ? "\\" : "", text);
 }
 
 static void CountKeysDown(void)
@@ -244,7 +244,7 @@ static void CountKeysDown(void)
             ++count;
         }
     }
-    SDL_Log("Keys down: %d\n", count);
+    SDL_Log("Keys down: %d", count);
 }
 
 static void DrawCursor(int i)
@@ -373,10 +373,10 @@ static void loop(void)
         {
             SDL_Window *window = SDL_GetWindowFromEvent(&event);
             if (SDL_TextInputActive(window)) {
-                SDL_Log("Stopping text input for window %" SDL_PRIu32 "\n", event.tfinger.windowID);
+                SDL_Log("Stopping text input for window %" SDL_PRIu32, event.tfinger.windowID);
                 SDL_StopTextInput(window);
             } else {
-                SDL_Log("Starting text input for window %" SDL_PRIu32 "\n", event.tfinger.windowID);
+                SDL_Log("Starting text input for window %" SDL_PRIu32, event.tfinger.windowID);
                 SDL_StartTextInput(window);
             }
             break;
@@ -385,16 +385,16 @@ static void loop(void)
             if (event.button.button == SDL_BUTTON_RIGHT) {
                 SDL_Window *window = SDL_GetWindowFromEvent(&event);
                 if (SDL_TextInputActive(window)) {
-                    SDL_Log("Stopping text input for window %" SDL_PRIu32 "\n", event.button.windowID);
+                    SDL_Log("Stopping text input for window %" SDL_PRIu32, event.button.windowID);
                     SDL_StopTextInput(window);
                 } else {
-                    SDL_Log("Starting text input for window %" SDL_PRIu32 "\n", event.button.windowID);
+                    SDL_Log("Starting text input for window %" SDL_PRIu32, event.button.windowID);
                     SDL_StartTextInput(window);
                 }
             }
             break;
         case SDL_EVENT_KEYMAP_CHANGED:
-            SDL_Log("Keymap changed!\n");
+            SDL_Log("Keymap changed!");
             break;
         case SDL_EVENT_QUIT:
             done = 1;
@@ -466,13 +466,13 @@ int main(int argc, char *argv[])
 
     /* Initialize SDL */
     if (!SDLTest_CommonInit(state)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
         return 1;
     }
 
     windowstates = (TextWindowState *)SDL_calloc(state->num_windows, sizeof(*windowstates));
     if (!windowstates) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't allocate text windows: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't allocate text windows: %s", SDL_GetError());
         goto done;
     }
 

--- a/test/childprocess.c
+++ b/test/childprocess.c
@@ -142,7 +142,7 @@ int main(int argc, char *argv[]) {
 #else
                     SDL_strlcpy(error, strerror(errno), sizeof(error));
 #endif
-                    SDL_Log("Error reading from stdin: %s\n", error);
+                    SDL_Log("Error reading from stdin: %s", error);
                 }
                 break;
             }

--- a/test/loopwave.c
+++ b/test/loopwave.c
@@ -78,20 +78,20 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
 
     /* Load the SDL library */
     if (!SDL_Init(SDL_INIT_AUDIO | SDL_INIT_EVENTS)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
         return SDL_APP_FAILURE;
     }
 
     filename = GetResourceFilename(filename, "sample.wav");
 
     if (!filename) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", SDL_GetError());
         return SDL_APP_FAILURE;
     }
 
     /* Load the wave file into memory */
     if (!SDL_LoadWAV(filename, &wave.spec, &wave.sound, &wave.soundlen)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't load %s: %s\n", filename, SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't load %s: %s", filename, SDL_GetError());
         SDL_free(filename);
         return SDL_APP_FAILURE;
     }
@@ -104,11 +104,11 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
         SDL_Log("%i: %s", i, SDL_GetAudioDriver(i));
     }
 
-    SDL_Log("Using audio driver: %s\n", SDL_GetCurrentAudioDriver());
+    SDL_Log("Using audio driver: %s", SDL_GetCurrentAudioDriver());
 
     stream = SDL_OpenAudioDeviceStream(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &wave.spec, NULL, NULL);
     if (!stream) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create audio stream: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create audio stream: %s", SDL_GetError());
         return SDL_APP_FAILURE;
     }
 

--- a/test/testatomic.c
+++ b/test/testatomic.c
@@ -40,39 +40,43 @@ static void RunBasicTest(void)
     SDL_AtomicInt v;
     bool tfret = false;
 
-    SDL_Log("\nspin lock---------------------------------------\n\n");
+    SDL_Log("%s", "");
+    SDL_Log("spin lock---------------------------------------");
+    SDL_Log("%s", "");
 
     SDL_LockSpinlock(&lock);
-    SDL_Log("AtomicLock                   lock=%d\n", lock);
+    SDL_Log("AtomicLock                   lock=%d", lock);
     SDL_UnlockSpinlock(&lock);
-    SDL_Log("AtomicUnlock                 lock=%d\n", lock);
+    SDL_Log("AtomicUnlock                 lock=%d", lock);
 
-    SDL_Log("\natomic -----------------------------------------\n\n");
+    SDL_Log("%s", "");
+    SDL_Log("atomic -----------------------------------------");
+    SDL_Log("%s", "");
 
     SDL_SetAtomicInt(&v, 0);
     tfret = SDL_SetAtomicInt(&v, 10) == 0;
-    SDL_Log("AtomicSet(10)        tfret=%s val=%d\n", tf(tfret), SDL_GetAtomicInt(&v));
+    SDL_Log("AtomicSet(10)        tfret=%s val=%d", tf(tfret), SDL_GetAtomicInt(&v));
     tfret = SDL_AddAtomicInt(&v, 10) == 10;
-    SDL_Log("AtomicAdd(10)        tfret=%s val=%d\n", tf(tfret), SDL_GetAtomicInt(&v));
+    SDL_Log("AtomicAdd(10)        tfret=%s val=%d", tf(tfret), SDL_GetAtomicInt(&v));
 
     SDL_SetAtomicInt(&v, 0);
     SDL_AtomicIncRef(&v);
     tfret = (SDL_GetAtomicInt(&v) == 1);
-    SDL_Log("AtomicIncRef()       tfret=%s val=%d\n", tf(tfret), SDL_GetAtomicInt(&v));
+    SDL_Log("AtomicIncRef()       tfret=%s val=%d", tf(tfret), SDL_GetAtomicInt(&v));
     SDL_AtomicIncRef(&v);
     tfret = (SDL_GetAtomicInt(&v) == 2);
-    SDL_Log("AtomicIncRef()       tfret=%s val=%d\n", tf(tfret), SDL_GetAtomicInt(&v));
+    SDL_Log("AtomicIncRef()       tfret=%s val=%d", tf(tfret), SDL_GetAtomicInt(&v));
     tfret = (SDL_AtomicDecRef(&v) == false);
-    SDL_Log("AtomicDecRef()       tfret=%s val=%d\n", tf(tfret), SDL_GetAtomicInt(&v));
+    SDL_Log("AtomicDecRef()       tfret=%s val=%d", tf(tfret), SDL_GetAtomicInt(&v));
     tfret = (SDL_AtomicDecRef(&v) == true);
-    SDL_Log("AtomicDecRef()       tfret=%s val=%d\n", tf(tfret), SDL_GetAtomicInt(&v));
+    SDL_Log("AtomicDecRef()       tfret=%s val=%d", tf(tfret), SDL_GetAtomicInt(&v));
 
     SDL_SetAtomicInt(&v, 10);
     tfret = (SDL_CompareAndSwapAtomicInt(&v, 0, 20) == false);
-    SDL_Log("AtomicCAS()          tfret=%s val=%d\n", tf(tfret), SDL_GetAtomicInt(&v));
+    SDL_Log("AtomicCAS()          tfret=%s val=%d", tf(tfret), SDL_GetAtomicInt(&v));
     value = SDL_GetAtomicInt(&v);
     tfret = (SDL_CompareAndSwapAtomicInt(&v, value, 20) == true);
-    SDL_Log("AtomicCAS()          tfret=%s val=%d\n", tf(tfret), SDL_GetAtomicInt(&v));
+    SDL_Log("AtomicCAS()          tfret=%s val=%d", tf(tfret), SDL_GetAtomicInt(&v));
 }
 
 /**************************************************************************/
@@ -115,7 +119,7 @@ static SDL_Semaphore *threadDone;
 static int SDLCALL adder(void *junk)
 {
     unsigned long N = NInter;
-    SDL_Log("Thread subtracting %d %lu times\n", CountInc, N);
+    SDL_Log("Thread subtracting %d %lu times", CountInc, N);
     while (N--) {
         SDL_AddAtomicInt(&good, -CountInc);
         bad -= CountInc;
@@ -153,7 +157,7 @@ static void runAdder(void)
 
     end = SDL_GetTicksNS();
 
-    SDL_Log("Finished in %f sec\n", (end - start) / 1000000000.0);
+    SDL_Log("Finished in %f sec", (end - start) / 1000000000.0);
 }
 
 static void RunEpicTest(void)
@@ -161,28 +165,30 @@ static void RunEpicTest(void)
     int b;
     atomicValue v;
 
-    SDL_Log("\nepic test---------------------------------------\n\n");
+    SDL_Log("%s", "");
+    SDL_Log("epic test---------------------------------------");
+    SDL_Log("%s", "");
 
-    SDL_Log("Size asserted to be >= 32-bit\n");
+    SDL_Log("Size asserted to be >= 32-bit");
     SDL_assert(sizeof(atomicValue) >= 4);
 
-    SDL_Log("Check static initializer\n");
+    SDL_Log("Check static initializer");
     v = SDL_GetAtomicInt(&good);
     SDL_assert(v == 42);
 
     SDL_assert(bad == 42);
 
-    SDL_Log("Test negative values\n");
+    SDL_Log("Test negative values");
     SDL_SetAtomicInt(&good, -5);
     v = SDL_GetAtomicInt(&good);
     SDL_assert(v == -5);
 
-    SDL_Log("Verify maximum value\n");
+    SDL_Log("Verify maximum value");
     SDL_SetAtomicInt(&good, CountTo);
     v = SDL_GetAtomicInt(&good);
     SDL_assert(v == CountTo);
 
-    SDL_Log("Test compare and exchange\n");
+    SDL_Log("Test compare and exchange");
 
     b = SDL_CompareAndSwapAtomicInt(&good, 500, 43);
     SDL_assert(!b); /* no swap since CountTo!=500 */
@@ -194,7 +200,7 @@ static void RunEpicTest(void)
     v = SDL_GetAtomicInt(&good);
     SDL_assert(v == 44);
 
-    SDL_Log("Test Add\n");
+    SDL_Log("Test Add");
 
     v = SDL_AddAtomicInt(&good, 1);
     SDL_assert(v == 44);
@@ -206,7 +212,7 @@ static void RunEpicTest(void)
     v = SDL_GetAtomicInt(&good);
     SDL_assert(v == 55);
 
-    SDL_Log("Test Add (Negative values)\n");
+    SDL_Log("Test Add (Negative values)");
 
     v = SDL_AddAtomicInt(&good, -20);
     SDL_assert(v == 55);
@@ -223,7 +229,7 @@ static void RunEpicTest(void)
     v = SDL_GetAtomicInt(&good);
     SDL_assert(v == 15);
 
-    SDL_Log("Reset before count down test\n");
+    SDL_Log("Reset before count down test");
     SDL_SetAtomicInt(&good, CountTo);
     v = SDL_GetAtomicInt(&good);
     SDL_assert(v == CountTo);
@@ -231,11 +237,11 @@ static void RunEpicTest(void)
     bad = CountTo;
     SDL_assert(bad == CountTo);
 
-    SDL_Log("Counting down from %d, Expect %d remaining\n", CountTo, Expect);
+    SDL_Log("Counting down from %d, Expect %d remaining", CountTo, Expect);
     runAdder();
 
     v = SDL_GetAtomicInt(&good);
-    SDL_Log("Atomic %d Non-Atomic %d\n", v, bad);
+    SDL_Log("Atomic %d Non-Atomic %d", v, bad);
     SDL_assert(v == Expect);
     /* We can't guarantee that bad != Expect, this would happen on a single core system, for example. */
     /*SDL_assert(bad != Expect);*/
@@ -431,7 +437,7 @@ static bool EnqueueEvent_Mutex(SDL_EventQueue *queue, const SDL_Event *event)
     } else if (delta < 0) {
         /* We ran into an old queue entry, which means it still needs to be dequeued */
     } else {
-        SDL_Log("ERROR: mutex failed!\n");
+        SDL_Log("ERROR: mutex failed!");
     }
 
     SDL_UnlockMutex(queue->mutex);
@@ -464,7 +470,7 @@ static bool DequeueEvent_Mutex(SDL_EventQueue *queue, SDL_Event *event)
     } else if (delta < 0) {
         /* We ran into an old queue entry, which means we've hit empty */
     } else {
-        SDL_Log("ERROR: mutex failed!\n");
+        SDL_Log("ERROR: mutex failed!");
     }
 
     SDL_UnlockMutex(queue->mutex);
@@ -597,8 +603,10 @@ static void RunFIFOTest(bool lock_free)
     char textBuffer[1024];
     size_t len;
 
-    SDL_Log("\nFIFO test---------------------------------------\n\n");
-    SDL_Log("Mode: %s\n", lock_free ? "LockFree" : "Mutex");
+    SDL_Log("%s", "");
+    SDL_Log("FIFO test---------------------------------------");
+    SDL_Log("%s", "");
+    SDL_Log("Mode: %s", lock_free ? "LockFree" : "Mutex");
 
     SDL_memset(&queue, 0xff, sizeof(queue));
 
@@ -617,7 +625,7 @@ static void RunFIFOTest(bool lock_free)
 #endif
 
     /* Start the readers first */
-    SDL_Log("Starting %d readers\n", NUM_READERS);
+    SDL_Log("Starting %d readers", NUM_READERS);
     SDL_zeroa(readerData);
     for (i = 0; i < NUM_READERS; ++i) {
         char name[64];
@@ -628,7 +636,7 @@ static void RunFIFOTest(bool lock_free)
     }
 
     /* Start up the writers */
-    SDL_Log("Starting %d writers\n", NUM_WRITERS);
+    SDL_Log("Starting %d writers", NUM_WRITERS);
     SDL_zeroa(writerData);
     for (i = 0; i < NUM_WRITERS; ++i) {
         char name[64];
@@ -663,16 +671,16 @@ static void RunFIFOTest(bool lock_free)
         SDL_DestroyMutex(queue.mutex);
     }
 
-    SDL_Log("Finished in %f sec\n", (end - start) / 1000000000.0);
+    SDL_Log("Finished in %f sec", (end - start) / 1000000000.0);
 
-    SDL_Log("\n");
+    SDL_Log("%s", "");
     for (i = 0; i < NUM_WRITERS; ++i) {
-        SDL_Log("Writer %d wrote %d events, had %d waits\n", i, EVENTS_PER_WRITER, writerData[i].waits);
+        SDL_Log("Writer %d wrote %d events, had %d waits", i, EVENTS_PER_WRITER, writerData[i].waits);
     }
-    SDL_Log("Writers wrote %d total events\n", NUM_WRITERS * EVENTS_PER_WRITER);
+    SDL_Log("Writers wrote %d total events", NUM_WRITERS * EVENTS_PER_WRITER);
 
     /* Print a breakdown of which readers read messages from which writer */
-    SDL_Log("\n");
+    SDL_Log("%s", "");
     grand_total = 0;
     for (i = 0; i < NUM_READERS; ++i) {
         int total = 0;
@@ -680,7 +688,7 @@ static void RunFIFOTest(bool lock_free)
             total += readerData[i].counters[j];
         }
         grand_total += total;
-        SDL_Log("Reader %d read %d events, had %d waits\n", i, total, readerData[i].waits);
+        SDL_Log("Reader %d read %d events, had %d waits", i, total, readerData[i].waits);
         (void)SDL_snprintf(textBuffer, sizeof(textBuffer), "  { ");
         for (j = 0; j < NUM_WRITERS; ++j) {
             if (j > 0) {
@@ -694,7 +702,7 @@ static void RunFIFOTest(bool lock_free)
         (void)SDL_snprintf(textBuffer + len, sizeof(textBuffer) - len, " }\n");
         SDL_Log("%s", textBuffer);
     }
-    SDL_Log("Readers read %d total events\n", grand_total);
+    SDL_Log("Readers read %d total events", grand_total);
 }
 
 /* End FIFO test */

--- a/test/testaudiohotplug.c
+++ b/test/testaudiohotplug.c
@@ -84,7 +84,7 @@ static void iteration(void)
                 if (!stream) {
                     SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create/bind an audio stream to %u ('%s'): %s", (unsigned int) which, name, SDL_GetError());
                 } else {
-                    SDL_Log("Opened '%s' as %u\n", name, (unsigned int) which);
+                    SDL_Log("Opened '%s' as %u", name, (unsigned int) which);
                     /* !!! FIXME: laziness, this used to loop the audio, but we'll just play it once for now on each connect. */
                     SDL_PutAudioStreamData(stream, sound, soundlen);
                     SDL_FlushAudioStream(stream);
@@ -94,7 +94,7 @@ static void iteration(void)
             }
         } else if (e.type == SDL_EVENT_AUDIO_DEVICE_REMOVED) {
             dev = (SDL_AudioDeviceID)e.adevice.which;
-            SDL_Log("%s device %u removed.\n", devtypestr(e.adevice.recording), (unsigned int)dev);
+            SDL_Log("%s device %u removed.", devtypestr(e.adevice.recording), (unsigned int)dev);
             /* !!! FIXME: we need to keep track of our streams and destroy them here. */
         }
     }
@@ -144,14 +144,14 @@ int main(int argc, char *argv[])
 
     /* Load the SDL library */
     if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
         return 1;
     }
 
     /* Some targets (Mac CoreAudio) need an event queue for audio hotplug, so make and immediately hide a window. */
     window = SDL_CreateWindow("testaudiohotplug", 640, 480, 0);
     if (!window) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_CreateWindow failed: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_CreateWindow failed: %s", SDL_GetError());
         quit(1);
     }
     SDL_MinimizeWindow(window);
@@ -159,13 +159,13 @@ int main(int argc, char *argv[])
     filename = GetResourceFilename(filename, "sample.wav");
 
     if (!filename) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", SDL_GetError());
         quit(1);
     }
 
     /* Load the wave file into memory */
     if (!SDL_LoadWAV(filename, &spec, &sound, &soundlen)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't load %s: %s\n", filename, SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't load %s: %s", filename, SDL_GetError());
         quit(1);
     }
 
@@ -187,8 +187,8 @@ int main(int argc, char *argv[])
         SDL_Log("%i: %s", i, SDL_GetAudioDriver(i));
     }
 
-    SDL_Log("Select a driver with the SDL_AUDIO_DRIVER environment variable.\n");
-    SDL_Log("Using audio driver: %s\n", SDL_GetCurrentAudioDriver());
+    SDL_Log("Select a driver with the SDL_AUDIO_DRIVER environment variable.");
+    SDL_Log("Using audio driver: %s", SDL_GetCurrentAudioDriver());
 
 #ifdef SDL_PLATFORM_EMSCRIPTEN
     emscripten_set_main_loop(loop, 0, 1);

--- a/test/testaudioinfo.c
+++ b/test/testaudioinfo.c
@@ -23,28 +23,30 @@ print_devices(bool recording)
     SDL_AudioDeviceID *devices = recording ? SDL_GetAudioRecordingDevices(&n) : SDL_GetAudioPlaybackDevices(&n);
 
     if (!devices) {
-        SDL_Log("  Driver failed to report %s devices: %s\n\n", typestr, SDL_GetError());
+        SDL_Log("  Driver failed to report %s devices: %s", typestr, SDL_GetError());
+        SDL_Log("%s", "");
     } else if (n == 0) {
-        SDL_Log("  No %s devices found.\n\n", typestr);
+        SDL_Log("  No %s devices found.", typestr);
+        SDL_Log("%s", "");
     } else {
         int i;
-        SDL_Log("Found %d %s device%s:\n", n, typestr, n != 1 ? "s" : "");
+        SDL_Log("Found %d %s device%s:", n, typestr, n != 1 ? "s" : "");
         for (i = 0; i < n; i++) {
             const char *name = SDL_GetAudioDeviceName(devices[i]);
             if (name) {
-                SDL_Log("  %d: %s\n", i, name);
+                SDL_Log("  %d: %s", i, name);
             } else {
-                SDL_Log("  %d Error: %s\n", i, SDL_GetError());
+                SDL_Log("  %d Error: %s", i, SDL_GetError());
             }
 
             if (SDL_GetAudioDeviceFormat(devices[i], &spec, &frames)) {
-                SDL_Log("     Sample Rate: %d\n", spec.freq);
-                SDL_Log("     Channels: %d\n", spec.channels);
-                SDL_Log("     SDL_AudioFormat: %X\n", spec.format);
-                SDL_Log("     Buffer Size: %d frames\n", frames);
+                SDL_Log("     Sample Rate: %d", spec.freq);
+                SDL_Log("     Channels: %d", spec.channels);
+                SDL_Log("     SDL_AudioFormat: %X", spec.format);
+                SDL_Log("     Buffer Size: %d frames", frames);
             }
         }
-        SDL_Log("\n");
+        SDL_Log("%s", "");
     }
     SDL_free(devices);
 }
@@ -70,45 +72,47 @@ int main(int argc, char **argv)
 
     /* Load the SDL library */
     if (!SDL_Init(SDL_INIT_AUDIO)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
         return 1;
     }
 
     /* Print available audio drivers */
     n = SDL_GetNumAudioDrivers();
     if (n == 0) {
-        SDL_Log("No built-in audio drivers\n\n");
+        SDL_Log("No built-in audio drivers");
+        SDL_Log("%s", "");
     } else {
-        SDL_Log("Built-in audio drivers:\n");
+        SDL_Log("Built-in audio drivers:");
         for (i = 0; i < n; ++i) {
-            SDL_Log("  %d: %s\n", i, SDL_GetAudioDriver(i));
+            SDL_Log("  %d: %s", i, SDL_GetAudioDriver(i));
         }
-        SDL_Log("Select a driver with the SDL_AUDIO_DRIVER environment variable.\n");
+        SDL_Log("Select a driver with the SDL_AUDIO_DRIVER environment variable.");
     }
 
-    SDL_Log("Using audio driver: %s\n\n", SDL_GetCurrentAudioDriver());
+    SDL_Log("Using audio driver: %s", SDL_GetCurrentAudioDriver());
+    SDL_Log("%s", "");
 
     print_devices(false);
     print_devices(true);
 
     if (SDL_GetAudioDeviceFormat(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec, &frames)) {
-        SDL_Log("Default Playback Device:\n");
-        SDL_Log("Sample Rate: %d\n", spec.freq);
-        SDL_Log("Channels: %d\n", spec.channels);
-        SDL_Log("SDL_AudioFormat: %X\n", spec.format);
-        SDL_Log("Buffer Size: %d frames\n", frames);
+        SDL_Log("Default Playback Device:");
+        SDL_Log("Sample Rate: %d", spec.freq);
+        SDL_Log("Channels: %d", spec.channels);
+        SDL_Log("SDL_AudioFormat: %X", spec.format);
+        SDL_Log("Buffer Size: %d frames", frames);
     } else {
-        SDL_Log("Error when calling SDL_GetAudioDeviceFormat(default playback): %s\n", SDL_GetError());
+        SDL_Log("Error when calling SDL_GetAudioDeviceFormat(default playback): %s", SDL_GetError());
     }
 
     if (SDL_GetAudioDeviceFormat(SDL_AUDIO_DEVICE_DEFAULT_RECORDING, &spec, &frames)) {
-        SDL_Log("Default Recording Device:\n");
-        SDL_Log("Sample Rate: %d\n", spec.freq);
-        SDL_Log("Channels: %d\n", spec.channels);
-        SDL_Log("SDL_AudioFormat: %X\n", spec.format);
-        SDL_Log("Buffer Size: %d frames\n", frames);
+        SDL_Log("Default Recording Device:");
+        SDL_Log("Sample Rate: %d", spec.freq);
+        SDL_Log("Channels: %d", spec.channels);
+        SDL_Log("SDL_AudioFormat: %X", spec.format);
+        SDL_Log("Buffer Size: %d frames", frames);
     } else {
-        SDL_Log("Error when calling SDL_GetAudioDeviceFormat(default recording): %s\n", SDL_GetError());
+        SDL_Log("Error when calling SDL_GetAudioDeviceFormat(default recording): %s", SDL_GetError());
     }
 
     SDL_Quit();

--- a/test/testaudiorecording.c
+++ b/test/testaudiorecording.c
@@ -62,31 +62,31 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char **argv)
 
     /* Load the SDL library */
     if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
         return SDL_APP_SUCCESS;
     }
 
     if (!SDL_CreateWindowAndRenderer("testaudiorecording", 320, 240, 0, &window, &renderer)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create SDL window and renderer: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create SDL window and renderer: %s", SDL_GetError());
         return SDL_APP_SUCCESS;
     }
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
     SDL_RenderClear(renderer);
     SDL_RenderPresent(renderer);
 
-    SDL_Log("Using audio driver: %s\n", SDL_GetCurrentAudioDriver());
+    SDL_Log("Using audio driver: %s", SDL_GetCurrentAudioDriver());
 
     devices = SDL_GetAudioRecordingDevices(NULL);
     for (i = 0; devices[i] != 0; i++) {
         const char *name = SDL_GetAudioDeviceName(devices[i]);
-        SDL_Log(" Recording device #%d: '%s'\n", i, name);
+        SDL_Log(" Recording device #%d: '%s'", i, name);
         if (devname && (SDL_strcmp(devname, name) == 0)) {
             want_device = devices[i];
         }
     }
 
     if (devname && (want_device == SDL_AUDIO_DEVICE_DEFAULT_RECORDING)) {
-        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Didn't see a recording device named '%s', using the system default instead.\n", devname);
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "Didn't see a recording device named '%s', using the system default instead.", devname);
         devname = NULL;
     }
 
@@ -96,10 +96,10 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char **argv)
        open your recording devices second in case you land in those bizarre
        circumstances. */
 
-    SDL_Log("Opening default playback device...\n");
+    SDL_Log("Opening default playback device...");
     device = SDL_OpenAudioDevice(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, NULL);
     if (!device) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't open an audio device for playback: %s!\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't open an audio device for playback: %s!", SDL_GetError());
         SDL_free(devices);
         return SDL_APP_FAILURE;
     }
@@ -107,23 +107,23 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char **argv)
     SDL_GetAudioDeviceFormat(device, &outspec, NULL);
     stream_out = SDL_CreateAudioStream(&outspec, &outspec);
     if (!stream_out) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create an audio stream for playback: %s!\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create an audio stream for playback: %s!", SDL_GetError());
         SDL_free(devices);
         return SDL_APP_FAILURE;
     } else if (!SDL_BindAudioStream(device, stream_out)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't bind an audio stream for playback: %s!\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't bind an audio stream for playback: %s!", SDL_GetError());
         SDL_free(devices);
         return SDL_APP_FAILURE;
     }
 
-    SDL_Log("Opening recording device %s%s%s...\n",
+    SDL_Log("Opening recording device %s%s%s...",
             devname ? "'" : "",
             devname ? devname : "[[default]]",
             devname ? "'" : "");
 
     device = SDL_OpenAudioDevice(want_device, NULL);
     if (!device) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't open an audio device for recording: %s!\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't open an audio device for recording: %s!", SDL_GetError());
         SDL_free(devices);
         return SDL_APP_FAILURE;
     }
@@ -132,16 +132,16 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char **argv)
     SDL_GetAudioDeviceFormat(device, &inspec, NULL);
     stream_in = SDL_CreateAudioStream(&inspec, &inspec);
     if (!stream_in) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create an audio stream for recording: %s!\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create an audio stream for recording: %s!", SDL_GetError());
         return SDL_APP_FAILURE;
     } else if (!SDL_BindAudioStream(device, stream_in)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't bind an audio stream for recording: %s!\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't bind an audio stream for recording: %s!", SDL_GetError());
         return SDL_APP_FAILURE;
     }
 
     SDL_SetAudioStreamFormat(stream_in, NULL, &outspec);  /* make sure we output at the playback format. */
 
-    SDL_Log("Ready! Hold down mouse or finger to record!\n");
+    SDL_Log("Ready! Hold down mouse or finger to record!");
 
     return SDL_APP_CONTINUE;
 }
@@ -185,10 +185,10 @@ SDL_AppResult SDL_AppIterate(void *appstate)
         Uint8 buf[1024];
         const int br = SDL_GetAudioStreamData(stream_in, buf, sizeof(buf));
         if (br < 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to read from input audio stream: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to read from input audio stream: %s", SDL_GetError());
             return SDL_APP_FAILURE;
         } else if (!SDL_PutAudioStreamData(stream_out, buf, br)) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to write to output audio stream: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to write to output audio stream: %s", SDL_GetError());
             return SDL_APP_FAILURE;
         }
     }
@@ -198,7 +198,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
 
 void SDL_AppQuit(void *appstate, SDL_AppResult result)
 {
-    SDL_Log("Shutting down.\n");
+    SDL_Log("Shutting down.");
     const SDL_AudioDeviceID devid_in = SDL_GetAudioStreamDevice(stream_in);
     const SDL_AudioDeviceID devid_out = SDL_GetAudioStreamDevice(stream_out);
     SDL_CloseAudioDevice(devid_in);  /* !!! FIXME: use SDL_OpenAudioDeviceStream instead so we can dump this. */

--- a/test/testaudiostreamdynamicresample.c
+++ b/test/testaudiostreamdynamicresample.c
@@ -396,7 +396,7 @@ int main(int argc, char *argv[])
 
     /* Load the SDL library */
     if (!SDLTest_CommonInit(state)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
         return 1;
     }
 

--- a/test/testcamera.c
+++ b/test/testcamera.c
@@ -36,10 +36,10 @@ static void PrintCameraSpecs(SDL_CameraID camera_id)
     if (specs) {
         int i;
 
-        SDL_Log("Available formats:\n");
+        SDL_Log("Available formats:");
         for (i = 0; specs[i]; ++i) {
             const SDL_CameraSpec *s = specs[i];
-            SDL_Log("    %dx%d %.2f FPS %s\n", s->width, s->height, (float)s->framerate_numerator / s->framerate_denominator, SDL_GetPixelFormatName(s->format));
+            SDL_Log("    %dx%d %.2f FPS %s", s->width, s->height, (float)s->framerate_numerator / s->framerate_denominator, SDL_GetPixelFormatName(s->format));
         }
         SDL_free(specs);
     }

--- a/test/testclipboard.c
+++ b/test/testclipboard.c
@@ -41,12 +41,12 @@ static const void *ClipboardDataCallback(void *userdata, const char *mime_type, 
 SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
 {
     if (!SDL_Init(SDL_INIT_VIDEO)) {
-        SDL_Log("Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_Log("Couldn't initialize SDL: %s", SDL_GetError());
         return SDL_APP_FAILURE;
     }
 
     if (!SDL_CreateWindowAndRenderer("testclipboard", 640, 480, 0, &window, &renderer)) {
-        SDL_Log("Couldn't create window and renderer: %s\n", SDL_GetError());
+        SDL_Log("Couldn't create window and renderer: %s", SDL_GetError());
         return SDL_APP_FAILURE;
     }
     return SDL_APP_CONTINUE;
@@ -69,12 +69,12 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
     case SDL_EVENT_CLIPBOARD_UPDATE:
         if (event->clipboard.num_mime_types > 0) {
             int i;
-            SDL_Log("Clipboard updated:\n");
+            SDL_Log("Clipboard updated:");
             for (i = 0; event->clipboard.mime_types[i]; ++i) {
-                SDL_Log("    %s\n", event->clipboard.mime_types[i]);
+                SDL_Log("    %s", event->clipboard.mime_types[i]);
             }
         } else {
-            SDL_Log("Clipboard cleared\n");
+            SDL_Log("Clipboard cleared");
         }
         break;
 

--- a/test/testcolorspace.c
+++ b/test/testcolorspace.c
@@ -64,12 +64,12 @@ static void UpdateHDRState(void)
     props = SDL_GetWindowProperties(window);
     HDR_enabled = SDL_GetBooleanProperty(props, SDL_PROP_WINDOW_HDR_ENABLED_BOOLEAN, false);
 
-    SDL_Log("HDR %s\n", HDR_enabled ? "enabled" : "disabled");
+    SDL_Log("HDR %s", HDR_enabled ? "enabled" : "disabled");
 
     if (HDR_enabled) {
         props = SDL_GetRendererProperties(renderer);
         if (SDL_GetNumberProperty(props, SDL_PROP_RENDERER_OUTPUT_COLORSPACE_NUMBER, SDL_COLORSPACE_SRGB) != SDL_COLORSPACE_SRGB_LINEAR) {
-            SDL_Log("Run with --colorspace linear to display HDR colors\n");
+            SDL_Log("Run with --colorspace linear to display HDR colors");
         }
         HDR_headroom = SDL_GetFloatProperty(props, SDL_PROP_RENDERER_HDR_HEADROOM_FLOAT, 1.0f);
     }
@@ -86,12 +86,12 @@ static void CreateRenderer(void)
     renderer = SDL_CreateRendererWithProperties(props);
     SDL_DestroyProperties(props);
     if (!renderer) {
-        SDL_Log("Couldn't create renderer: %s\n", SDL_GetError());
+        SDL_Log("Couldn't create renderer: %s", SDL_GetError());
         return;
     }
 
     renderer_name = SDL_GetRendererName(renderer);
-    SDL_Log("Created renderer %s\n", renderer_name);
+    SDL_Log("Created renderer %s", renderer_name);
 
     UpdateHDRState();
 }
@@ -159,11 +159,11 @@ static bool ReadPixel(int x, int y, SDL_Color *c)
         if (SDL_ReadSurfacePixel(surface, 0, 0, &c->r, &c->g, &c->b, &c->a)) {
             result = true;
         } else {
-            SDL_Log("Couldn't read pixel: %s\n", SDL_GetError());
+            SDL_Log("Couldn't read pixel: %s", SDL_GetError());
         }
         SDL_DestroySurface(surface);
     } else {
-        SDL_Log("Couldn't read back pixels: %s\n", SDL_GetError());
+        SDL_Log("Couldn't read back pixels: %s", SDL_GetError());
     }
     return result;
 }
@@ -662,7 +662,7 @@ static void loop(void)
 
 static void LogUsage(const char *argv0)
 {
-    SDL_Log("Usage: %s [--renderer renderer] [--colorspace colorspace]\n", argv0);
+    SDL_Log("Usage: %s [--renderer renderer] [--colorspace colorspace]", argv0);
 }
 
 int main(int argc, char *argv[])
@@ -691,7 +691,7 @@ int main(int argc, char *argv[])
                     colorspace = SDL_COLORSPACE_HDR10;
 */
                 } else {
-                    SDL_Log("Unknown colorspace %s\n", argv[i + 1]);
+                    SDL_Log("Unknown colorspace %s", argv[i + 1]);
                     goto quit;
                 }
                 ++i;
@@ -707,20 +707,20 @@ int main(int argc, char *argv[])
 
     window = SDL_CreateWindow("SDL colorspace test", WINDOW_WIDTH, WINDOW_HEIGHT, 0);
     if (!window) {
-        SDL_Log("Couldn't create window: %s\n", SDL_GetError());
+        SDL_Log("Couldn't create window: %s", SDL_GetError());
         return_code = 2;
         goto quit;
     }
 
     renderer_count = SDL_GetNumRenderDrivers();
-    SDL_Log("There are %d render drivers:\n", renderer_count);
+    SDL_Log("There are %d render drivers:", renderer_count);
     for (i = 0; i < renderer_count; ++i) {
         const char *name = SDL_GetRenderDriver(i);
 
         if (renderer_name && SDL_strcasecmp(renderer_name, name) == 0) {
             renderer_index = i;
         }
-        SDL_Log("    %s\n", name);
+        SDL_Log("    %s", name);
     }
     CreateRenderer();
 

--- a/test/testcontroller.c
+++ b/test/testcontroller.c
@@ -923,9 +923,9 @@ static void AddController(SDL_JoystickID id, bool verbose)
             const char *name = SDL_GetJoystickName(joystick);
             const char *path = SDL_GetJoystickPath(joystick);
             char guid[33];
-            SDL_Log("Opened joystick %s%s%s\n", name, path ? ", " : "", path ? path : "");
+            SDL_Log("Opened joystick %s%s%s", name, path ? ", " : "", path ? path : "");
             SDL_GUIDToString(SDL_GetJoystickGUID(joystick), guid, sizeof(guid));
-            SDL_Log("No gamepad mapping for %s\n", guid);
+            SDL_Log("No gamepad mapping for %s", guid);
         }
     } else {
         SDL_Log("Couldn't open joystick: %s", SDL_GetError());
@@ -1021,7 +1021,7 @@ static void HandleGamepadAdded(SDL_JoystickID id, bool verbose)
     if (i < 0) {
         return;
     }
-    SDL_Log("Gamepad %" SDL_PRIu32 " added\n", id);
+    SDL_Log("Gamepad %" SDL_PRIu32 " added", id);
 
     SDL_assert(!controllers[i].gamepad);
     controllers[i].gamepad = SDL_OpenGamepad(id);
@@ -1035,11 +1035,11 @@ static void HandleGamepadAdded(SDL_JoystickID id, bool verbose)
             SDL_GUID guid = SDL_GetGamepadGUIDForID(id);
             char guid_string[33];
             SDL_GUIDToString(guid, guid_string, sizeof(guid_string));
-            SDL_Log("Opened gamepad %s, guid %s%s%s\n", name, guid_string, path ? ", " : "", path ? path : "");
+            SDL_Log("Opened gamepad %s, guid %s%s%s", name, guid_string, path ? ", " : "", path ? path : "");
 
             firmware_version = SDL_GetGamepadFirmwareVersion(gamepad);
             if (firmware_version) {
-                SDL_Log("Firmware version: 0x%x (%d)\n", firmware_version, firmware_version);
+                SDL_Log("Firmware version: 0x%x (%d)", firmware_version, firmware_version);
             }
 
             if (SDL_GetBooleanProperty(props, SDL_PROP_GAMEPAD_CAP_PLAYER_LED_BOOLEAN, false)) {
@@ -1055,7 +1055,7 @@ static void HandleGamepadAdded(SDL_JoystickID id, bool verbose)
             }
 
             if (SDL_GetGamepadPlayerIndex(gamepad) >= 0) {
-                SDL_Log("Player index: %d\n", SDL_GetGamepadPlayerIndex(gamepad));
+                SDL_Log("Player index: %d", SDL_GetGamepadPlayerIndex(gamepad));
             }
         }
 
@@ -1064,7 +1064,7 @@ static void HandleGamepadAdded(SDL_JoystickID id, bool verbose)
 
             if (SDL_GamepadHasSensor(gamepad, sensor)) {
                 if (verbose) {
-                    SDL_Log("Enabling %s at %.2f Hz\n", GetSensorName(sensor), SDL_GetGamepadSensorDataRate(gamepad, sensor));
+                    SDL_Log("Enabling %s at %.2f Hz", GetSensorName(sensor), SDL_GetGamepadSensorDataRate(gamepad, sensor));
                 }
                 SDL_SetGamepadSensorEnabled(gamepad, sensor, true);
             }
@@ -1073,7 +1073,7 @@ static void HandleGamepadAdded(SDL_JoystickID id, bool verbose)
         if (verbose) {
             char *mapping = SDL_GetGamepadMapping(gamepad);
             if (mapping) {
-                SDL_Log("Mapping: %s\n", mapping);
+                SDL_Log("Mapping: %s", mapping);
                 SDL_free(mapping);
             }
         }
@@ -1093,7 +1093,7 @@ static void HandleGamepadRemoved(SDL_JoystickID id)
     if (i < 0) {
         return;
     }
-    SDL_Log("Gamepad %" SDL_PRIu32 " removed\n", id);
+    SDL_Log("Gamepad %" SDL_PRIu32 " removed", id);
 
     if (controllers[i].mapping) {
         SDL_free(controllers[i].mapping);
@@ -1137,24 +1137,24 @@ static bool ShowingFront(void)
 
 static void SDLCALL VirtualGamepadSetPlayerIndex(void *userdata, int player_index)
 {
-    SDL_Log("Virtual Gamepad: player index set to %d\n", player_index);
+    SDL_Log("Virtual Gamepad: player index set to %d", player_index);
 }
 
 static bool SDLCALL VirtualGamepadRumble(void *userdata, Uint16 low_frequency_rumble, Uint16 high_frequency_rumble)
 {
-    SDL_Log("Virtual Gamepad: rumble set to %d/%d\n", low_frequency_rumble, high_frequency_rumble);
+    SDL_Log("Virtual Gamepad: rumble set to %d/%d", low_frequency_rumble, high_frequency_rumble);
     return true;
 }
 
 static bool SDLCALL VirtualGamepadRumbleTriggers(void *userdata, Uint16 left_rumble, Uint16 right_rumble)
 {
-    SDL_Log("Virtual Gamepad: trigger rumble set to %d/%d\n", left_rumble, right_rumble);
+    SDL_Log("Virtual Gamepad: trigger rumble set to %d/%d", left_rumble, right_rumble);
     return true;
 }
 
 static bool SDLCALL VirtualGamepadSetLED(void *userdata, Uint8 red, Uint8 green, Uint8 blue)
 {
-    SDL_Log("Virtual Gamepad: LED set to RGB %d,%d,%d\n", red, green, blue);
+    SDL_Log("Virtual Gamepad: LED set to RGB %d,%d,%d", red, green, blue);
     return true;
 }
 
@@ -1184,11 +1184,11 @@ static void OpenVirtualGamepad(void)
 
     virtual_id = SDL_AttachVirtualJoystick(&desc);
     if (virtual_id == 0) {
-        SDL_Log("Couldn't attach virtual device: %s\n", SDL_GetError());
+        SDL_Log("Couldn't attach virtual device: %s", SDL_GetError());
     } else {
         virtual_joystick = SDL_OpenJoystick(virtual_id);
         if (!virtual_joystick) {
-            SDL_Log("Couldn't open virtual device: %s\n", SDL_GetError());
+            SDL_Log("Couldn't open virtual device: %s", SDL_GetError());
         }
     }
 }
@@ -1620,7 +1620,7 @@ SDL_AppResult SDLCALL SDL_AppEvent(void *appstate, SDL_Event *event)
             }
 
 #ifdef DEBUG_AXIS_MAPPING
-            SDL_Log("AXIS %d nValue %d nCurrentDistance %d nFarthestDistance %d\n", event->jaxis.axis, nValue, nCurrentDistance, nFarthestDistance);
+            SDL_Log("AXIS %d nValue %d nCurrentDistance %d nFarthestDistance %d", event->jaxis.axis, nValue, nCurrentDistance, nFarthestDistance);
 #endif
             /* If we've gone out far enough and started to come back, let's bind this axis */
             if (nFarthestDistance >= 16000 && nCurrentDistance <= 10000) {
@@ -1642,7 +1642,7 @@ SDL_AppResult SDLCALL SDL_AppEvent(void *appstate, SDL_Event *event)
                     }
                 }
 #ifdef DEBUG_AXIS_MAPPING
-                SDL_Log("AXIS %d axis_min = %d, axis_max = %d, binding = %s\n", event->jaxis.axis, axis_min, axis_max, binding);
+                SDL_Log("AXIS %d axis_min = %d, axis_max = %d, binding = %s", event->jaxis.axis, axis_min, axis_max, binding);
 #endif
                 CommitBindingElement(binding, false);
             }
@@ -1698,7 +1698,7 @@ SDL_AppResult SDLCALL SDL_AppEvent(void *appstate, SDL_Event *event)
     case SDL_EVENT_GAMEPAD_TOUCHPAD_DOWN:
     case SDL_EVENT_GAMEPAD_TOUCHPAD_MOTION:
     case SDL_EVENT_GAMEPAD_TOUCHPAD_UP:
-        SDL_Log("Gamepad %" SDL_PRIu32 " touchpad %" SDL_PRIs32 " finger %" SDL_PRIs32 " %s %.2f, %.2f, %.2f\n",
+        SDL_Log("Gamepad %" SDL_PRIu32 " touchpad %" SDL_PRIs32 " finger %" SDL_PRIs32 " %s %.2f, %.2f, %.2f",
                 event->gtouchpad.which,
                 event->gtouchpad.touchpad,
                 event->gtouchpad.finger,
@@ -1711,7 +1711,7 @@ SDL_AppResult SDLCALL SDL_AppEvent(void *appstate, SDL_Event *event)
 
 #ifdef VERBOSE_SENSORS
     case SDL_EVENT_GAMEPAD_SENSOR_UPDATE:
-        SDL_Log("Gamepad %" SDL_PRIu32 " sensor %s: %.2f, %.2f, %.2f (%" SDL_PRIu64 ")\n",
+        SDL_Log("Gamepad %" SDL_PRIu32 " sensor %s: %.2f, %.2f, %.2f (%" SDL_PRIu64 ")",
                 event->gsensor.which,
                 GetSensorName((SDL_SensorType) event->gsensor.sensor),
                 event->gsensor.data[0],
@@ -1728,7 +1728,7 @@ SDL_AppResult SDLCALL SDL_AppEvent(void *appstate, SDL_Event *event)
                 SetController(event->gaxis.which);
             }
         }
-        SDL_Log("Gamepad %" SDL_PRIu32 " axis %s changed to %d\n",
+        SDL_Log("Gamepad %" SDL_PRIu32 " axis %s changed to %d",
                 event->gaxis.which,
                 SDL_GetGamepadStringForAxis((SDL_GamepadAxis) event->gaxis.axis),
                 event->gaxis.value);
@@ -1743,7 +1743,7 @@ SDL_AppResult SDLCALL SDL_AppEvent(void *appstate, SDL_Event *event)
             }
         }
 #ifdef VERBOSE_BUTTONS
-        SDL_Log("Gamepad %" SDL_PRIu32 " button %s %s\n",
+        SDL_Log("Gamepad %" SDL_PRIu32 " button %s %s",
                 event->gbutton.which,
                 SDL_GetGamepadStringForButton((SDL_GamepadButton) event->gbutton.button),
                 event->gbutton.state ? "pressed" : "released");
@@ -1784,8 +1784,8 @@ SDL_AppResult SDLCALL SDL_AppEvent(void *appstate, SDL_Event *event)
         } else if (display_mode == CONTROLLER_MODE_BINDING) {
             if (GamepadButtonContains(done_mapping_button, event->button.x, event->button.y)) {
                 if (controller->mapping) {
-                    SDL_Log("Mapping complete:\n");
-                    SDL_Log("%s\n", controller->mapping);
+                    SDL_Log("Mapping complete:");
+                    SDL_Log("%s", controller->mapping);
                 }
                 SetDisplayMode(CONTROLLER_MODE_TESTING);
             } else if (GamepadButtonContains(cancel_button, event->button.x, event->button.y)) {
@@ -2047,7 +2047,7 @@ SDL_AppResult SDLCALL SDL_AppInit(void **appstate, int argc, char *argv[])
 
     /* Initialize SDL (Note: video is required to start event loop) */
     if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK | SDL_INIT_GAMEPAD)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
         return SDL_APP_FAILURE;
     }
 
@@ -2057,11 +2057,11 @@ SDL_AppResult SDLCALL SDL_AppInit(void **appstate, int argc, char *argv[])
         int count = 0;
         char **mappings = SDL_GetGamepadMappings(&count);
         int map_i;
-        SDL_Log("Supported mappings:\n");
+        SDL_Log("Supported mappings:");
         for (map_i = 0; map_i < count; ++map_i) {
-            SDL_Log("\t%s\n", mappings[map_i]);
+            SDL_Log("\t%s", mappings[map_i]);
         }
-        SDL_Log("\n");
+        SDL_Log("%s", "");
         SDL_free(mappings);
     }
 
@@ -2074,13 +2074,13 @@ SDL_AppResult SDLCALL SDL_AppInit(void **appstate, int argc, char *argv[])
     screen_height = (int)SDL_ceilf(SCREEN_HEIGHT * content_scale);
     window = SDL_CreateWindow("SDL Controller Test", screen_width, screen_height, 0);
     if (!window) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create window: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create window: %s", SDL_GetError());
         return SDL_APP_FAILURE;
     }
 
     screen = SDL_CreateRenderer(window, NULL);
     if (!screen) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create renderer: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create renderer: %s", SDL_GetError());
         SDL_DestroyWindow(window);
         return SDL_APP_FAILURE;
     }

--- a/test/testdialog.c
+++ b/test/testdialog.c
@@ -33,14 +33,14 @@ static void SDLCALL callback(void* userdata, const char* const* files, int filte
             }
         }
 
-        SDL_Log("Filter used: '%s'\n", filter_name);
+        SDL_Log("Filter used: '%s'", filter_name);
 
         while (*files) {
-            SDL_Log("'%s'\n", *files);
+            SDL_Log("'%s'", *files);
             files++;
         }
     } else {
-        SDL_Log("Error: %s\n", SDL_GetError());
+        SDL_Log("Error: %s", SDL_GetError());
     }
 }
 
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
         return 1;
     }
     if (!SDL_CreateWindowAndRenderer("testdialog", 640, 480, 0, &w, &r)) {
-        SDL_Log("Failed to create window and/or renderer: %s\n", SDL_GetError());
+        SDL_Log("Failed to create window and/or renderer: %s", SDL_GetError());
         SDL_Quit();
         return 1;
     }
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
     initial_path = SDL_GetUserFolder(SDL_FOLDER_HOME);
 
     if (!initial_path) {
-        SDL_Log("Will not use an initial path, couldn't get the home directory path: %s\n", SDL_GetError());
+        SDL_Log("Will not use an initial path, couldn't get the home directory path: %s", SDL_GetError());
     }
 
     while (1) {

--- a/test/testdisplayinfo.c
+++ b/test/testdisplayinfo.c
@@ -25,7 +25,7 @@ print_mode(const char *prefix, const SDL_DisplayMode *mode)
         return;
     }
 
-    SDL_Log("%s: %dx%d@%gx, %gHz, fmt=%s\n",
+    SDL_Log("%s: %dx%d@%gx, %gHz, fmt=%s",
             prefix,
             mode->w, mode->h, mode->pixel_density, mode->refresh_rate,
             SDL_GetPixelFormatName(mode->format));
@@ -52,14 +52,14 @@ int main(int argc, char *argv[])
 
     /* Load the SDL library */
     if (!SDL_Init(SDL_INIT_VIDEO)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
         return 1;
     }
 
-    SDL_Log("Using video target '%s'.\n", SDL_GetCurrentVideoDriver());
+    SDL_Log("Using video target '%s'.", SDL_GetCurrentVideoDriver());
     displays = SDL_GetDisplays(&num_displays);
 
-    SDL_Log("See %d displays.\n", num_displays);
+    SDL_Log("See %d displays.", num_displays);
 
     for (i = 0; i < num_displays; i++) {
         SDL_DisplayID dpy = displays[i];
@@ -70,20 +70,20 @@ int main(int argc, char *argv[])
 
         SDL_GetDisplayBounds(dpy, &rect);
         modes = SDL_GetFullscreenDisplayModes(dpy, &num_modes);
-        SDL_Log("%" SDL_PRIu32 ": \"%s\" (%dx%d at %d,%d), content scale %.2f, %d fullscreen modes, HDR capable: %s.\n", dpy, SDL_GetDisplayName(dpy), rect.w, rect.h, rect.x, rect.y, SDL_GetDisplayContentScale(dpy), num_modes, has_HDR ? "yes" : "no");
+        SDL_Log("%" SDL_PRIu32 ": \"%s\" (%dx%d at %d,%d), content scale %.2f, %d fullscreen modes, HDR capable: %s.", dpy, SDL_GetDisplayName(dpy), rect.w, rect.h, rect.x, rect.y, SDL_GetDisplayContentScale(dpy), num_modes, has_HDR ? "yes" : "no");
 
         mode = SDL_GetCurrentDisplayMode(dpy);
         if (mode) {
             print_mode("CURRENT", mode);
         } else {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "    CURRENT: failed to query (%s)\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "    CURRENT: failed to query (%s)", SDL_GetError());
         }
 
         mode = SDL_GetDesktopDisplayMode(dpy);
         if (mode) {
             print_mode("DESKTOP", mode);
         } else {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "    DESKTOP: failed to query (%s)\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "    DESKTOP: failed to query (%s)", SDL_GetError());
         }
 
         for (m = 0; m < num_modes; m++) {
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
         }
         SDL_free(modes);
 
-        SDL_Log("\n");
+        SDL_Log("%s", "");
     }
     SDL_free(displays);
 

--- a/test/testdraw.c
+++ b/test/testdraw.c
@@ -208,7 +208,7 @@ static void loop(void)
         /* Print out some timing information */
         const Uint64 then = next_fps_check - fps_check_delay;
         const double fps = ((double)frames * 1000) / (now - then);
-        SDL_Log("%2.2f frames per second\n", fps);
+        SDL_Log("%2.2f frames per second", fps);
         next_fps_check = now + fps_check_delay;
         frames = 0;
     }

--- a/test/testdrawchessboard.c
+++ b/test/testdrawchessboard.c
@@ -132,14 +132,14 @@ int main(int argc, char *argv[])
 
     /* Initialize SDL */
     if (!SDL_Init(SDL_INIT_VIDEO)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_Init fail : %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_Init fail : %s", SDL_GetError());
         return 1;
     }
 
     /* Create window and renderer for given surface */
     window = SDL_CreateWindow("Chess Board", 640, 480, SDL_WINDOW_RESIZABLE);
     if (!window) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Window creation fail : %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Window creation fail : %s", SDL_GetError());
         return 1;
     }
 #ifdef USE_SOFTWARE_RENDERER
@@ -149,7 +149,7 @@ int main(int argc, char *argv[])
     renderer = SDL_CreateRenderer(window, NULL);
 #endif
     if (!renderer) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Render creation for surface fail : %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Render creation for surface fail : %s", SDL_GetError());
         return 1;
     }
 

--- a/test/testerror.c
+++ b/test/testerror.c
@@ -38,10 +38,10 @@ ThreadFunc(void *data)
     SDL_SetError("Thread %s (%" SDL_PRIu64 ") had a problem: %s",
                  (char *)data, SDL_GetCurrentThreadID(), "nevermind");
     while (alive) {
-        SDL_Log("Thread '%s' is alive!\n", (char *)data);
+        SDL_Log("Thread '%s' is alive!", (char *)data);
         SDL_Delay(1 * 1000);
     }
-    SDL_Log("Child thread error string: %s\n", SDL_GetError());
+    SDL_Log("Child thread error string: %s", SDL_GetError());
     return 0;
 }
 
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
 
     /* Load the SDL library */
     if (!SDL_Init(0)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
         return 1;
     }
 
@@ -100,16 +100,16 @@ int main(int argc, char *argv[])
         alive = 1;
         thread = SDL_CreateThread(ThreadFunc, NULL, "#1");
         if (!thread) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create thread: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create thread: %s", SDL_GetError());
             quit(1);
         }
         SDL_Delay(5 * 1000);
-        SDL_Log("Waiting for thread #1\n");
+        SDL_Log("Waiting for thread #1");
         alive = 0;
         SDL_WaitThread(thread, NULL);
     }
 
-    SDL_Log("Main thread error string: %s\n", SDL_GetError());
+    SDL_Log("Main thread error string: %s", SDL_GetError());
 
     SDL_Quit();
     SDLTest_CommonDestroyState(state);

--- a/test/testffmpeg.c
+++ b/test/testffmpeg.c
@@ -171,7 +171,7 @@ static bool CreateWindowAndRenderer(SDL_WindowFlags window_flags, const char *dr
         return false;
     }
 
-    SDL_Log("Created renderer %s\n", SDL_GetRendererName(renderer));
+    SDL_Log("Created renderer %s", SDL_GetRendererName(renderer));
 
 #ifdef HAVE_EGL
     if (useEGL) {
@@ -377,9 +377,9 @@ static enum AVPixelFormat GetSupportedPixelFormat(AVCodecContext *s, const enum 
     }
 
     if (*p == AV_PIX_FMT_NONE) {
-        SDL_Log("Couldn't find a supported pixel format:\n");
+        SDL_Log("Couldn't find a supported pixel format:");
         for (p = pix_fmts; *p != AV_PIX_FMT_NONE; p++) {
-            SDL_Log("    %s\n", av_get_pix_fmt_name(*p));
+            SDL_Log("    %s", av_get_pix_fmt_name(*p));
         }
     }
 
@@ -395,7 +395,7 @@ static AVCodecContext *OpenVideoStream(AVFormatContext *ic, int stream, const AV
     int i;
     int result;
 
-    SDL_Log("Video stream: %s %dx%d\n", avcodec_get_name(codec->id), codecpar->width, codecpar->height);
+    SDL_Log("Video stream: %s %dx%d", avcodec_get_name(codec->id), codecpar->width, codecpar->height);
 
     context = avcodec_alloc_context3(NULL);
     if (!context) {
@@ -405,7 +405,7 @@ static AVCodecContext *OpenVideoStream(AVFormatContext *ic, int stream, const AV
 
     result = avcodec_parameters_to_context(context, ic->streams[stream]->codecpar);
     if (result < 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "avcodec_parameters_to_context failed: %s\n", av_err2str(result));
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "avcodec_parameters_to_context failed: %s", av_err2str(result));
         avcodec_free_context(&context);
         return NULL;
     }
@@ -416,7 +416,7 @@ static AVCodecContext *OpenVideoStream(AVFormatContext *ic, int stream, const AV
     while (!context->hw_device_ctx &&
            (config = avcodec_get_hw_config(codec, i++)) != NULL) {
 #if 0
-        SDL_Log("Found %s hardware acceleration with pixel format %s\n", av_hwdevice_get_type_name(config->device_type), av_get_pix_fmt_name(config->pix_fmt));
+        SDL_Log("Found %s hardware acceleration with pixel format %s", av_hwdevice_get_type_name(config->device_type), av_get_pix_fmt_name(config->pix_fmt));
 #endif
 
         if (!(config->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX) ||
@@ -440,7 +440,7 @@ static AVCodecContext *OpenVideoStream(AVFormatContext *ic, int stream, const AV
             if (result < 0) {
                 SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create %s hardware device context: %s", av_hwdevice_get_type_name(config->device_type), av_err2str(result));
             } else {
-                SDL_Log("Using %s hardware acceleration with pixel format %s\n", av_hwdevice_get_type_name(config->device_type), av_get_pix_fmt_name(config->pix_fmt));
+                SDL_Log("Using %s hardware acceleration with pixel format %s", av_hwdevice_get_type_name(config->device_type), av_get_pix_fmt_name(config->pix_fmt));
             }
         } else
 #endif
@@ -456,14 +456,14 @@ static AVCodecContext *OpenVideoStream(AVFormatContext *ic, int stream, const AV
             if (result < 0) {
                 SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create %s hardware device context: %s", av_hwdevice_get_type_name(config->device_type), av_err2str(result));
             } else {
-                SDL_Log("Using %s hardware acceleration with pixel format %s\n", av_hwdevice_get_type_name(config->device_type), av_get_pix_fmt_name(config->pix_fmt));
+                SDL_Log("Using %s hardware acceleration with pixel format %s", av_hwdevice_get_type_name(config->device_type), av_get_pix_fmt_name(config->pix_fmt));
             }
         } else {
             result = av_hwdevice_ctx_create(&context->hw_device_ctx, config->device_type, NULL, NULL, 0);
             if (result < 0) {
                 SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create %s hardware device context: %s", av_hwdevice_get_type_name(config->device_type), av_err2str(result));
             } else {
-                SDL_Log("Using %s hardware acceleration with pixel format %s\n", av_hwdevice_get_type_name(config->device_type), av_get_pix_fmt_name(config->pix_fmt));
+                SDL_Log("Using %s hardware acceleration with pixel format %s", av_hwdevice_get_type_name(config->device_type), av_get_pix_fmt_name(config->pix_fmt));
             }
         }
     }
@@ -498,7 +498,7 @@ static SDL_Colorspace GetFrameColorspace(AVFrame *frame)
 
     if (frame && frame->colorspace != AVCOL_SPC_RGB) {
 #ifdef DEBUG_COLORSPACE
-        SDL_Log("Frame colorspace: range: %d, primaries: %d, trc: %d, colorspace: %d, chroma_location: %d\n", frame->color_range, frame->color_primaries, frame->color_trc, frame->colorspace, frame->chroma_location);
+        SDL_Log("Frame colorspace: range: %d, primaries: %d, trc: %d, colorspace: %d, chroma_location: %d", frame->color_range, frame->color_primaries, frame->color_trc, frame->colorspace, frame->chroma_location);
 #endif
         colorspace = SDL_DEFINE_COLORSPACE(SDL_COLOR_TYPE_YCBCR,
                                            frame->color_range,
@@ -731,7 +731,7 @@ static bool GetNV12TextureForDRMFrame(AVFrame *frame, SDL_Texture **texture)
 
             EGLImage image = eglCreateImage(display, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, NULL, attr);
             if (image == EGL_NO_IMAGE) {
-                SDL_Log("Couldn't create image: %d\n", glGetError());
+                SDL_Log("Couldn't create image: %d", glGetError());
                 return false;
             }
 
@@ -916,7 +916,7 @@ static bool GetOESTextureForDRMFrame(AVFrame *frame, SDL_Texture **texture)
 
     EGLImage image = eglCreateImage(display, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, NULL, attr);
     if (image == EGL_NO_IMAGE) {
-        SDL_Log("Couldn't create image: %d\n", glGetError());
+        SDL_Log("Couldn't create image: %d", glGetError());
         return false;
     }
 
@@ -1082,7 +1082,7 @@ static void DisplayVideoTexture(AVFrame *frame)
 {
     /* Update the video texture */
     if (!GetTextureForFrame(frame, &video_texture)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't get texture for frame: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't get texture for frame: %s", SDL_GetError());
         return;
     }
 
@@ -1138,17 +1138,17 @@ static AVCodecContext *OpenAudioStream(AVFormatContext *ic, int stream, const AV
     AVCodecContext *context;
     int result;
 
-    SDL_Log("Audio stream: %s %d channels, %d Hz\n", avcodec_get_name(codec->id), codecpar->ch_layout.nb_channels, codecpar->sample_rate);
+    SDL_Log("Audio stream: %s %d channels, %d Hz", avcodec_get_name(codec->id), codecpar->ch_layout.nb_channels, codecpar->sample_rate);
 
     context = avcodec_alloc_context3(NULL);
     if (!context) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "avcodec_alloc_context3 failed\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "avcodec_alloc_context3 failed");
         return NULL;
     }
 
     result = avcodec_parameters_to_context(context, ic->streams[stream]->codecpar);
     if (result < 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "avcodec_parameters_to_context failed: %s\n", av_err2str(result));
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "avcodec_parameters_to_context failed: %s", av_err2str(result));
         avcodec_free_context(&context);
         return NULL;
     }
@@ -1471,7 +1471,7 @@ int main(int argc, char *argv[])
     positions = (SDL_FRect *)SDL_malloc(num_sprites * sizeof(*positions));
     velocities = (SDL_FRect *)SDL_malloc(num_sprites * sizeof(*velocities));
     if (!positions || !velocities) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!");
         return_code = 3;
         goto quit;
     }
@@ -1510,7 +1510,7 @@ int main(int argc, char *argv[])
         if (!flushing) {
             result = av_read_frame(ic, pkt);
             if (result < 0) {
-                SDL_Log("End of stream, finishing decode\n");
+                SDL_Log("End of stream, finishing decode");
                 if (audio_context) {
                     avcodec_flush_buffers(audio_context);
                 }

--- a/test/testfile.c
+++ b/test/testfile.c
@@ -53,7 +53,7 @@ cleanup(void)
 static void
 iostrm_error_quit(unsigned line, SDL_IOStream *iostrm)
 {
-    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "testfile.c(%d): failed\n", line);
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "testfile.c(%d): failed", line);
     if (iostrm) {
         SDL_CloseIO(iostrm);
     }
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
     if (iostrm) {
         RWOP_ERR_QUIT(iostrm);
     }
-    SDL_Log("test1 OK\n");
+    SDL_Log("test1 OK");
 
     /* test 2 : check that inexistent file is not successfully opened/created when required */
     /* modes : r, r+ imply that file MUST exist
@@ -144,7 +144,7 @@ int main(int argc, char *argv[])
     }
     SDL_CloseIO(iostrm);
     unlink(FBASENAME2);
-    SDL_Log("test2 OK\n");
+    SDL_Log("test2 OK");
 
     /* test 3 : creation, writing , reading, seeking,
                 test : w mode, r mode, w+ mode
@@ -257,7 +257,7 @@ int main(int argc, char *argv[])
         RWOP_ERR_QUIT(iostrm);
     }
     SDL_CloseIO(iostrm);
-    SDL_Log("test3 OK\n");
+    SDL_Log("test3 OK");
 
     /* test 4: same in r+ mode */
     iostrm = SDL_IOFromFile(FBASENAME1, "rb+"); /* write + read + file must exists, no truncation */
@@ -308,7 +308,7 @@ int main(int argc, char *argv[])
         RWOP_ERR_QUIT(iostrm);
     }
     SDL_CloseIO(iostrm);
-    SDL_Log("test4 OK\n");
+    SDL_Log("test4 OK");
 
     /* test5 : append mode */
     iostrm = SDL_IOFromFile(FBASENAME1, "ab+"); /* write + read + append */
@@ -365,7 +365,7 @@ int main(int argc, char *argv[])
         RWOP_ERR_QUIT(iostrm);
     }
     SDL_CloseIO(iostrm);
-    SDL_Log("test5 OK\n");
+    SDL_Log("test5 OK");
     cleanup();
     SDL_Quit();
     SDLTest_CommonDestroyState(state);

--- a/test/testfilesystem.c
+++ b/test/testfilesystem.c
@@ -106,42 +106,42 @@ int main(int argc, char *argv[])
     }
 
     if (!SDL_Init(0)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_Init() failed: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_Init() failed: %s", SDL_GetError());
         return 1;
     }
 
     base_path = SDL_GetBasePath();
     if (!base_path) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't find base path: %s\n",
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't find base path: %s",
                      SDL_GetError());
     } else {
-        SDL_Log("base path: '%s'\n", base_path);
+        SDL_Log("base path: '%s'", base_path);
     }
 
     pref_path = SDL_GetPrefPath("libsdl", "test_filesystem");
     if (!pref_path) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't find pref path: %s\n",
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't find pref path: %s",
                      SDL_GetError());
     } else {
-        SDL_Log("pref path: '%s'\n", pref_path);
+        SDL_Log("pref path: '%s'", pref_path);
     }
     SDL_free(pref_path);
 
     pref_path = SDL_GetPrefPath(NULL, "test_filesystem");
     if (!pref_path) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't find pref path without organization: %s\n",
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't find pref path without organization: %s",
                      SDL_GetError());
     } else {
-        SDL_Log("pref path: '%s'\n", pref_path);
+        SDL_Log("pref path: '%s'", pref_path);
     }
     SDL_free(pref_path);
 
     curdir = SDL_GetCurrentDirectory();
     if (!curdir) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't find current directory: %s\n",
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't find current directory: %s",
                      SDL_GetError());
     } else {
-        SDL_Log("current directory: '%s'\n", curdir);
+        SDL_Log("current directory: '%s'", curdir);
     }
     SDL_free(curdir);
 
@@ -209,13 +209,13 @@ int main(int argc, char *argv[])
 
                 textA = (char *)SDL_LoadFile("testfilesystem-A", &sizeA);
                 if (!textA || sizeA != SDL_strlen(text) || SDL_strcmp(textA, text) != 0) {
-                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Contents of testfilesystem-A didn't match, expected %s, got %s\n", text, textA);
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Contents of testfilesystem-A didn't match, expected %s, got %s", text, textA);
                 }
                 SDL_free(textA);
 
                 textB = (char *)SDL_LoadFile("testfilesystem-B", &sizeB);
                 if (!textB || sizeB != SDL_strlen(text) || SDL_strcmp(textB, text) != 0) {
-                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Contents of testfilesystem-B didn't match, expected %s, got %s\n", text, textB);
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Contents of testfilesystem-B didn't match, expected %s, got %s", text, textB);
                 }
                 SDL_free(textB);
             }

--- a/test/testgeometry.c
+++ b/test/testgeometry.c
@@ -57,7 +57,7 @@ static int LoadSprite(const char *file)
             return -1;
         }
         if (!SDL_SetTextureBlendMode(sprites[i], blendMode)) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't set blend mode: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't set blend mode: %s", SDL_GetError());
             SDL_DestroyTexture(sprites[i]);
             return -1;
         }
@@ -239,7 +239,7 @@ int main(int argc, char *argv[])
     sprites =
         (SDL_Texture **)SDL_malloc(state->num_windows * sizeof(*sprites));
     if (!sprites) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!");
         quit(2);
     }
     /* Create the windows and initialize the renderers */
@@ -274,7 +274,7 @@ int main(int argc, char *argv[])
     now = SDL_GetTicks();
     if (now > then) {
         double fps = ((double)frames * 1000) / (now - then);
-        SDL_Log("%2.2f frames per second\n", fps);
+        SDL_Log("%2.2f frames per second", fps);
     }
 
     quit(0);

--- a/test/testgl.c
+++ b/test/testgl.c
@@ -203,9 +203,9 @@ static void LogSwapInterval(void)
 {
     int interval = 0;
     if (SDL_GL_GetSwapInterval(&interval)) {
-       SDL_Log("Swap Interval : %d\n", interval);
+       SDL_Log("Swap Interval : %d", interval);
     } else {
-       SDL_Log("Swap Interval : %d error: %s\n", interval, SDL_GetError());
+       SDL_Log("Swap Interval : %d error: %s", interval, SDL_GetError());
     }
 }
 
@@ -282,13 +282,13 @@ int main(int argc, char *argv[])
     /* Create OpenGL context */
     context = SDL_GL_CreateContext(state->windows[0]);
     if (!context) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_GL_CreateContext(): %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_GL_CreateContext(): %s", SDL_GetError());
         quit(2);
     }
 
     /* Important: call this *after* creating the context */
     if (!LoadContext(&ctx)) {
-        SDL_Log("Could not load GL functions\n");
+        SDL_Log("Could not load GL functions");
         quit(2);
         return 0;
     }
@@ -298,68 +298,68 @@ int main(int argc, char *argv[])
 
     mode = SDL_GetCurrentDisplayMode(SDL_GetPrimaryDisplay());
     if (mode) {
-        SDL_Log("Screen BPP    : %d\n", SDL_BITSPERPIXEL(mode->format));
+        SDL_Log("Screen BPP    : %d", SDL_BITSPERPIXEL(mode->format));
     }
 
     LogSwapInterval();
 
     SDL_GetWindowSize(state->windows[0], &dw, &dh);
-    SDL_Log("Window Size   : %d,%d\n", dw, dh);
+    SDL_Log("Window Size   : %d,%d", dw, dh);
     SDL_GetWindowSizeInPixels(state->windows[0], &dw, &dh);
-    SDL_Log("Draw Size     : %d,%d\n", dw, dh);
-    SDL_Log("\n");
-    SDL_Log("Vendor        : %s\n", ctx.glGetString(GL_VENDOR));
-    SDL_Log("Renderer      : %s\n", ctx.glGetString(GL_RENDERER));
-    SDL_Log("Version       : %s\n", ctx.glGetString(GL_VERSION));
-    SDL_Log("Extensions    : %s\n", ctx.glGetString(GL_EXTENSIONS));
-    SDL_Log("\n");
+    SDL_Log("Draw Size     : %d,%d", dw, dh);
+    SDL_Log("%s", "");
+    SDL_Log("Vendor        : %s", ctx.glGetString(GL_VENDOR));
+    SDL_Log("Renderer      : %s", ctx.glGetString(GL_RENDERER));
+    SDL_Log("Version       : %s", ctx.glGetString(GL_VERSION));
+    SDL_Log("Extensions    : %s", ctx.glGetString(GL_EXTENSIONS));
+    SDL_Log("%s", "");
 
     if (SDL_GL_GetAttribute(SDL_GL_RED_SIZE, &value)) {
-        SDL_Log("SDL_GL_RED_SIZE: requested %d, got %d\n", 5, value);
+        SDL_Log("SDL_GL_RED_SIZE: requested %d, got %d", 5, value);
     } else {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_RED_SIZE: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_RED_SIZE: %s", SDL_GetError());
     }
     if (SDL_GL_GetAttribute(SDL_GL_GREEN_SIZE, &value)) {
-        SDL_Log("SDL_GL_GREEN_SIZE: requested %d, got %d\n", 5, value);
+        SDL_Log("SDL_GL_GREEN_SIZE: requested %d, got %d", 5, value);
     } else {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_GREEN_SIZE: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_GREEN_SIZE: %s", SDL_GetError());
     }
     if (SDL_GL_GetAttribute(SDL_GL_BLUE_SIZE, &value)) {
-        SDL_Log("SDL_GL_BLUE_SIZE: requested %d, got %d\n", 5, value);
+        SDL_Log("SDL_GL_BLUE_SIZE: requested %d, got %d", 5, value);
     } else {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_BLUE_SIZE: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_BLUE_SIZE: %s", SDL_GetError());
     }
     if (SDL_GL_GetAttribute(SDL_GL_DEPTH_SIZE, &value)) {
-        SDL_Log("SDL_GL_DEPTH_SIZE: requested %d, got %d\n", 16, value);
+        SDL_Log("SDL_GL_DEPTH_SIZE: requested %d, got %d", 16, value);
     } else {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_DEPTH_SIZE: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_DEPTH_SIZE: %s", SDL_GetError());
     }
     if (SDL_GL_GetAttribute(SDL_GL_CONTEXT_RELEASE_BEHAVIOR, &value)) {
-        SDL_Log("SDL_GL_CONTEXT_RELEASE_BEHAVIOR: requested %d, got %d\n", 0, value);
+        SDL_Log("SDL_GL_CONTEXT_RELEASE_BEHAVIOR: requested %d, got %d", 0, value);
     } else {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_CONTEXT_RELEASE_BEHAVIOR: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_CONTEXT_RELEASE_BEHAVIOR: %s", SDL_GetError());
     }
     if (fsaa) {
         if (SDL_GL_GetAttribute(SDL_GL_MULTISAMPLEBUFFERS, &value)) {
-            SDL_Log("SDL_GL_MULTISAMPLEBUFFERS: requested 1, got %d\n", value);
+            SDL_Log("SDL_GL_MULTISAMPLEBUFFERS: requested 1, got %d", value);
         } else {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_MULTISAMPLEBUFFERS: %s\n",
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_MULTISAMPLEBUFFERS: %s",
                          SDL_GetError());
         }
         if (SDL_GL_GetAttribute(SDL_GL_MULTISAMPLESAMPLES, &value)) {
-            SDL_Log("SDL_GL_MULTISAMPLESAMPLES: requested %d, got %d\n", fsaa,
+            SDL_Log("SDL_GL_MULTISAMPLESAMPLES: requested %d, got %d", fsaa,
                     value);
         } else {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_MULTISAMPLESAMPLES: %s\n",
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_MULTISAMPLESAMPLES: %s",
                          SDL_GetError());
         }
     }
     if (accel >= 0) {
         if (SDL_GL_GetAttribute(SDL_GL_ACCELERATED_VISUAL, &value)) {
-            SDL_Log("SDL_GL_ACCELERATED_VISUAL: requested %d, got %d\n", accel,
+            SDL_Log("SDL_GL_ACCELERATED_VISUAL: requested %d, got %d", accel,
                     value);
         } else {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_ACCELERATED_VISUAL: %s\n",
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_ACCELERATED_VISUAL: %s",
                          SDL_GetError());
         }
     }
@@ -398,7 +398,7 @@ int main(int argc, char *argv[])
         }
 
         if (update_swap_interval) {
-            SDL_Log("Swap interval to be set to %d\n", swap_interval);
+            SDL_Log("Swap interval to be set to %d", swap_interval);
         }
 
         for (i = 0; i < state->num_windows; ++i) {
@@ -428,7 +428,7 @@ int main(int argc, char *argv[])
     /* Print out some timing information */
     now = SDL_GetTicks();
     if (now > then) {
-        SDL_Log("%2.2f frames per second\n",
+        SDL_Log("%2.2f frames per second",
                 ((double)frames * 1000) / (now - then));
     }
     quit(0);
@@ -439,7 +439,7 @@ int main(int argc, char *argv[])
 
 int main(int argc, char *argv[])
 {
-    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "No OpenGL support on this system\n");
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "No OpenGL support on this system");
     return 1;
 }
 

--- a/test/testgles.c
+++ b/test/testgles.c
@@ -173,7 +173,7 @@ int main(int argc, char *argv[])
 
     context = (SDL_GLContext *)SDL_calloc(state->num_windows, sizeof(*context));
     if (!context) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!");
         quit(2);
     }
 
@@ -181,7 +181,7 @@ int main(int argc, char *argv[])
     for (i = 0; i < state->num_windows; i++) {
         context[i] = SDL_GL_CreateContext(state->windows[i]);
         if (!context[i]) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_GL_CreateContext(): %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_GL_CreateContext(): %s", SDL_GetError());
             quit(2);
         }
     }
@@ -190,59 +190,59 @@ int main(int argc, char *argv[])
 
     mode = SDL_GetCurrentDisplayMode(SDL_GetPrimaryDisplay());
     if (mode) {
-        SDL_Log("Screen bpp: %d\n", SDL_BITSPERPIXEL(mode->format));
-        SDL_Log("\n");
+        SDL_Log("Screen bpp: %d", SDL_BITSPERPIXEL(mode->format));
+        SDL_Log("%s", "");
     }
-    SDL_Log("Vendor     : %s\n", glGetString(GL_VENDOR));
-    SDL_Log("Renderer   : %s\n", glGetString(GL_RENDERER));
-    SDL_Log("Version    : %s\n", glGetString(GL_VERSION));
-    SDL_Log("Extensions : %s\n", glGetString(GL_EXTENSIONS));
-    SDL_Log("\n");
+    SDL_Log("Vendor     : %s", glGetString(GL_VENDOR));
+    SDL_Log("Renderer   : %s", glGetString(GL_RENDERER));
+    SDL_Log("Version    : %s", glGetString(GL_VERSION));
+    SDL_Log("Extensions : %s", glGetString(GL_EXTENSIONS));
+    SDL_Log("%s", "");
 
     if (SDL_GL_GetAttribute(SDL_GL_RED_SIZE, &value)) {
-        SDL_Log("SDL_GL_RED_SIZE: requested %d, got %d\n", 5, value);
+        SDL_Log("SDL_GL_RED_SIZE: requested %d, got %d", 5, value);
     } else {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_RED_SIZE: %s\n",
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_RED_SIZE: %s",
                      SDL_GetError());
     }
     if (SDL_GL_GetAttribute(SDL_GL_GREEN_SIZE, &value)) {
-        SDL_Log("SDL_GL_GREEN_SIZE: requested %d, got %d\n", 5, value);
+        SDL_Log("SDL_GL_GREEN_SIZE: requested %d, got %d", 5, value);
     } else {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_GREEN_SIZE: %s\n",
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_GREEN_SIZE: %s",
                      SDL_GetError());
     }
     if (SDL_GL_GetAttribute(SDL_GL_BLUE_SIZE, &value)) {
-        SDL_Log("SDL_GL_BLUE_SIZE: requested %d, got %d\n", 5, value);
+        SDL_Log("SDL_GL_BLUE_SIZE: requested %d, got %d", 5, value);
     } else {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_BLUE_SIZE: %s\n",
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_BLUE_SIZE: %s",
                      SDL_GetError());
     }
     if (SDL_GL_GetAttribute(SDL_GL_DEPTH_SIZE, &value)) {
-        SDL_Log("SDL_GL_DEPTH_SIZE: requested %d, got %d\n", depth, value);
+        SDL_Log("SDL_GL_DEPTH_SIZE: requested %d, got %d", depth, value);
     } else {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_DEPTH_SIZE: %s\n",
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_DEPTH_SIZE: %s",
                      SDL_GetError());
     }
     if (fsaa) {
         if (SDL_GL_GetAttribute(SDL_GL_MULTISAMPLEBUFFERS, &value)) {
-            SDL_Log("SDL_GL_MULTISAMPLEBUFFERS: requested 1, got %d\n", value);
+            SDL_Log("SDL_GL_MULTISAMPLEBUFFERS: requested 1, got %d", value);
         } else {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_MULTISAMPLEBUFFERS: %s\n",
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_MULTISAMPLEBUFFERS: %s",
                          SDL_GetError());
         }
         if (SDL_GL_GetAttribute(SDL_GL_MULTISAMPLESAMPLES, &value)) {
-            SDL_Log("SDL_GL_MULTISAMPLESAMPLES: requested %d, got %d\n", fsaa,
+            SDL_Log("SDL_GL_MULTISAMPLESAMPLES: requested %d, got %d", fsaa,
                     value);
         } else {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_MULTISAMPLESAMPLES: %s\n",
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_MULTISAMPLESAMPLES: %s",
                          SDL_GetError());
         }
     }
     if (accel) {
         if (SDL_GL_GetAttribute(SDL_GL_ACCELERATED_VISUAL, &value)) {
-            SDL_Log("SDL_GL_ACCELERATED_VISUAL: requested 1, got %d\n", value);
+            SDL_Log("SDL_GL_ACCELERATED_VISUAL: requested 1, got %d", value);
         } else {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_ACCELERATED_VISUAL: %s\n",
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to get SDL_GL_ACCELERATED_VISUAL: %s",
                          SDL_GetError());
         }
     }
@@ -252,7 +252,7 @@ int main(int argc, char *argv[])
         float aspectAdjust;
 
         if (!SDL_GL_MakeCurrent(state->windows[i], context[i])) {
-            SDL_Log("SDL_GL_MakeCurrent(): %s\n", SDL_GetError());
+            SDL_Log("SDL_GL_MakeCurrent(): %s", SDL_GetError());
 
             /* Continue for next window */
             continue;
@@ -282,7 +282,7 @@ int main(int argc, char *argv[])
                 for (i = 0; i < state->num_windows; ++i) {
                     if (event.window.windowID == SDL_GetWindowID(state->windows[i])) {
                         if (!SDL_GL_MakeCurrent(state->windows[i], context[i])) {
-                            SDL_Log("SDL_GL_MakeCurrent(): %s\n", SDL_GetError());
+                            SDL_Log("SDL_GL_MakeCurrent(): %s", SDL_GetError());
                             break;
                         }
                         /* Change view port to the new window dimensions */
@@ -301,7 +301,7 @@ int main(int argc, char *argv[])
                 continue;
             }
             if (!SDL_GL_MakeCurrent(state->windows[i], context[i])) {
-                SDL_Log("SDL_GL_MakeCurrent(): %s\n", SDL_GetError());
+                SDL_Log("SDL_GL_MakeCurrent(): %s", SDL_GetError());
 
                 /* Continue for next window */
                 continue;
@@ -314,7 +314,7 @@ int main(int argc, char *argv[])
     /* Print out some timing information */
     now = SDL_GetTicks();
     if (now > then) {
-        SDL_Log("%2.2f frames per second\n",
+        SDL_Log("%2.2f frames per second",
                 ((double)frames * 1000) / (now - then));
     }
 #ifndef SDL_PLATFORM_ANDROID
@@ -327,7 +327,7 @@ int main(int argc, char *argv[])
 
 int main(int argc, char *argv[])
 {
-    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "No OpenGL ES support on this system\n");
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "No OpenGL ES support on this system");
     return 1;
 }
 

--- a/test/testgles2.c
+++ b/test/testgles2.c
@@ -124,7 +124,7 @@ quit(int rc)
     {                                                                                       \
         GLenum glError = ctx.glGetError();                                                  \
         if (glError != GL_NO_ERROR) {                                                       \
-            SDL_Log("glGetError() = %i (0x%.8x) at line %i\n", glError, glError, __LINE__); \
+            SDL_Log("glGetError() = %i (0x%.8x) at line %i", glError, glError, __LINE__); \
             quit(1);                                                                        \
         }                                                                                   \
     }
@@ -551,7 +551,7 @@ render_window(int index)
     }
 
     if (!SDL_GL_MakeCurrent(state->windows[index], context[index])) {
-        SDL_Log("SDL_GL_MakeCurrent(): %s\n", SDL_GetError());
+        SDL_Log("SDL_GL_MakeCurrent(): %s", SDL_GetError());
         return;
     }
 
@@ -750,7 +750,7 @@ int main(int argc, char *argv[])
 
     context = (SDL_GLContext *)SDL_calloc(state->num_windows, sizeof(*context));
     if (!context) {
-        SDL_Log("Out of memory!\n");
+        SDL_Log("Out of memory!");
         quit(2);
     }
 
@@ -758,14 +758,14 @@ int main(int argc, char *argv[])
     for (i = 0; i < state->num_windows; i++) {
         context[i] = SDL_GL_CreateContext(state->windows[i]);
         if (!context[i]) {
-            SDL_Log("SDL_GL_CreateContext(): %s\n", SDL_GetError());
+            SDL_Log("SDL_GL_CreateContext(): %s", SDL_GetError());
             quit(2);
         }
     }
 
     /* Important: call this *after* creating the context */
     if (!LoadContext(&ctx)) {
-        SDL_Log("Could not load GLES2 functions\n");
+        SDL_Log("Could not load GLES2 functions");
         quit(2);
         return 0;
     }
@@ -773,61 +773,61 @@ int main(int argc, char *argv[])
     SDL_GL_SetSwapInterval(state->render_vsync);
 
     mode = SDL_GetCurrentDisplayMode(SDL_GetPrimaryDisplay());
-    SDL_Log("Threaded  : %s\n", threaded ? "yes" : "no");
+    SDL_Log("Threaded  : %s", threaded ? "yes" : "no");
     if (mode) {
-        SDL_Log("Screen bpp: %d\n", SDL_BITSPERPIXEL(mode->format));
-        SDL_Log("\n");
+        SDL_Log("Screen bpp: %d", SDL_BITSPERPIXEL(mode->format));
+        SDL_Log("%s", "");
     }
-    SDL_Log("Vendor     : %s\n", ctx.glGetString(GL_VENDOR));
-    SDL_Log("Renderer   : %s\n", ctx.glGetString(GL_RENDERER));
-    SDL_Log("Version    : %s\n", ctx.glGetString(GL_VERSION));
-    SDL_Log("Extensions : %s\n", ctx.glGetString(GL_EXTENSIONS));
-    SDL_Log("\n");
+    SDL_Log("Vendor     : %s", ctx.glGetString(GL_VENDOR));
+    SDL_Log("Renderer   : %s", ctx.glGetString(GL_RENDERER));
+    SDL_Log("Version    : %s", ctx.glGetString(GL_VERSION));
+    SDL_Log("Extensions : %s", ctx.glGetString(GL_EXTENSIONS));
+    SDL_Log("%s", "");
 
     if (SDL_GL_GetAttribute(SDL_GL_RED_SIZE, &value)) {
-        SDL_Log("SDL_GL_RED_SIZE: requested %d, got %d\n", 5, value);
+        SDL_Log("SDL_GL_RED_SIZE: requested %d, got %d", 5, value);
     } else {
-        SDL_Log("Failed to get SDL_GL_RED_SIZE: %s\n",
+        SDL_Log("Failed to get SDL_GL_RED_SIZE: %s",
                 SDL_GetError());
     }
     if (SDL_GL_GetAttribute(SDL_GL_GREEN_SIZE, &value)) {
-        SDL_Log("SDL_GL_GREEN_SIZE: requested %d, got %d\n", 5, value);
+        SDL_Log("SDL_GL_GREEN_SIZE: requested %d, got %d", 5, value);
     } else {
-        SDL_Log("Failed to get SDL_GL_GREEN_SIZE: %s\n",
+        SDL_Log("Failed to get SDL_GL_GREEN_SIZE: %s",
                 SDL_GetError());
     }
     if (SDL_GL_GetAttribute(SDL_GL_BLUE_SIZE, &value)) {
-        SDL_Log("SDL_GL_BLUE_SIZE: requested %d, got %d\n", 5, value);
+        SDL_Log("SDL_GL_BLUE_SIZE: requested %d, got %d", 5, value);
     } else {
-        SDL_Log("Failed to get SDL_GL_BLUE_SIZE: %s\n",
+        SDL_Log("Failed to get SDL_GL_BLUE_SIZE: %s",
                 SDL_GetError());
     }
     if (SDL_GL_GetAttribute(SDL_GL_DEPTH_SIZE, &value)) {
-        SDL_Log("SDL_GL_DEPTH_SIZE: requested %d, got %d\n", depth, value);
+        SDL_Log("SDL_GL_DEPTH_SIZE: requested %d, got %d", depth, value);
     } else {
-        SDL_Log("Failed to get SDL_GL_DEPTH_SIZE: %s\n",
+        SDL_Log("Failed to get SDL_GL_DEPTH_SIZE: %s",
                 SDL_GetError());
     }
     if (fsaa) {
         if (SDL_GL_GetAttribute(SDL_GL_MULTISAMPLEBUFFERS, &value)) {
-            SDL_Log("SDL_GL_MULTISAMPLEBUFFERS: requested 1, got %d\n", value);
+            SDL_Log("SDL_GL_MULTISAMPLEBUFFERS: requested 1, got %d", value);
         } else {
-            SDL_Log("Failed to get SDL_GL_MULTISAMPLEBUFFERS: %s\n",
+            SDL_Log("Failed to get SDL_GL_MULTISAMPLEBUFFERS: %s",
                     SDL_GetError());
         }
         if (SDL_GL_GetAttribute(SDL_GL_MULTISAMPLESAMPLES, &value)) {
-            SDL_Log("SDL_GL_MULTISAMPLESAMPLES: requested %d, got %d\n", fsaa,
+            SDL_Log("SDL_GL_MULTISAMPLESAMPLES: requested %d, got %d", fsaa,
                     value);
         } else {
-            SDL_Log("Failed to get SDL_GL_MULTISAMPLESAMPLES: %s\n",
+            SDL_Log("Failed to get SDL_GL_MULTISAMPLESAMPLES: %s",
                     SDL_GetError());
         }
     }
     if (accel) {
         if (SDL_GL_GetAttribute(SDL_GL_ACCELERATED_VISUAL, &value)) {
-            SDL_Log("SDL_GL_ACCELERATED_VISUAL: requested 1, got %d\n", value);
+            SDL_Log("SDL_GL_ACCELERATED_VISUAL: requested 1, got %d", value);
         } else {
-            SDL_Log("Failed to get SDL_GL_ACCELERATED_VISUAL: %s\n",
+            SDL_Log("Failed to get SDL_GL_ACCELERATED_VISUAL: %s",
                     SDL_GetError());
         }
     }
@@ -839,7 +839,7 @@ int main(int argc, char *argv[])
 
         int w, h;
         if (!SDL_GL_MakeCurrent(state->windows[i], context[i])) {
-            SDL_Log("SDL_GL_MakeCurrent(): %s\n", SDL_GetError());
+            SDL_Log("SDL_GL_MakeCurrent(): %s", SDL_GetError());
 
             /* Continue for next window */
             continue;
@@ -936,7 +936,7 @@ int main(int argc, char *argv[])
     /* Print out some timing information */
     now = SDL_GetTicks();
     if (now > then) {
-        SDL_Log("%2.2f frames per second\n",
+        SDL_Log("%2.2f frames per second",
                 ((double)frames * 1000) / (now - then));
     }
 #ifndef SDL_PLATFORM_ANDROID
@@ -949,7 +949,7 @@ int main(int argc, char *argv[])
 
 int main(int argc, char *argv[])
 {
-    SDL_Log("No OpenGL ES support on this system\n");
+    SDL_Log("No OpenGL ES support on this system");
     return 1;
 }
 

--- a/test/testgles2_sdf.c
+++ b/test/testgles2_sdf.c
@@ -114,7 +114,7 @@ quit(int rc)
     {                                                                                       \
         GLenum glError = ctx.glGetError();                                                  \
         if (glError != GL_NO_ERROR) {                                                       \
-            SDL_Log("glGetError() = %i (0x%.8x) at line %i\n", glError, glError, __LINE__); \
+            SDL_Log("glGetError() = %i (0x%.8x) at line %i", glError, glError, __LINE__); \
             quit(1);                                                                        \
         }                                                                                   \
     }
@@ -363,7 +363,7 @@ static void loop(void)
                 if (event.window.windowID == SDL_GetWindowID(state->windows[i])) {
                     int w, h;
                     if (!SDL_GL_MakeCurrent(state->windows[i], context[i])) {
-                        SDL_Log("SDL_GL_MakeCurrent(): %s\n", SDL_GetError());
+                        SDL_Log("SDL_GL_MakeCurrent(): %s", SDL_GetError());
                         break;
                     }
                     /* Change view port to the new window dimensions */
@@ -414,7 +414,7 @@ static void loop(void)
     if (!done) {
         for (i = 0; i < state->num_windows; ++i) {
             if (!SDL_GL_MakeCurrent(state->windows[i], context[i])) {
-                SDL_Log("SDL_GL_MakeCurrent(): %s\n", SDL_GetError());
+                SDL_Log("SDL_GL_MakeCurrent(): %s", SDL_GetError());
 
                 /* Continue for next window */
                 continue;
@@ -509,7 +509,7 @@ int main(int argc, char *argv[])
 
     context = (SDL_GLContext *)SDL_calloc(state->num_windows, sizeof(*context));
     if (!context) {
-        SDL_Log("Out of memory!\n");
+        SDL_Log("Out of memory!");
         quit(2);
     }
 
@@ -517,14 +517,14 @@ int main(int argc, char *argv[])
     for (i = 0; i < state->num_windows; i++) {
         context[i] = SDL_GL_CreateContext(state->windows[i]);
         if (!context[i]) {
-            SDL_Log("SDL_GL_CreateContext(): %s\n", SDL_GetError());
+            SDL_Log("SDL_GL_CreateContext(): %s", SDL_GetError());
             quit(2);
         }
     }
 
     /* Important: call this *after* creating the context */
     if (!LoadContext(&ctx)) {
-        SDL_Log("Could not load GLES2 functions\n");
+        SDL_Log("Could not load GLES2 functions");
         quit(2);
         return 0;
     }
@@ -554,7 +554,7 @@ int main(int argc, char *argv[])
         }
 
         if (!path) {
-            SDL_Log("out of memory\n");
+            SDL_Log("out of memory");
             exit(-1);
         }
 
@@ -605,59 +605,59 @@ int main(int argc, char *argv[])
 
     mode = SDL_GetCurrentDisplayMode(SDL_GetPrimaryDisplay());
     if (mode) {
-        SDL_Log("Screen bpp: %d\n", SDL_BITSPERPIXEL(mode->format));
-        SDL_Log("\n");
+        SDL_Log("Screen bpp: %d", SDL_BITSPERPIXEL(mode->format));
+        SDL_Log("%s", "");
     }
-    SDL_Log("Vendor     : %s\n", ctx.glGetString(GL_VENDOR));
-    SDL_Log("Renderer   : %s\n", ctx.glGetString(GL_RENDERER));
-    SDL_Log("Version    : %s\n", ctx.glGetString(GL_VERSION));
-    SDL_Log("Extensions : %s\n", ctx.glGetString(GL_EXTENSIONS));
-    SDL_Log("\n");
+    SDL_Log("Vendor     : %s", ctx.glGetString(GL_VENDOR));
+    SDL_Log("Renderer   : %s", ctx.glGetString(GL_RENDERER));
+    SDL_Log("Version    : %s", ctx.glGetString(GL_VERSION));
+    SDL_Log("Extensions : %s", ctx.glGetString(GL_EXTENSIONS));
+    SDL_Log("%s", "");
 
     if (SDL_GL_GetAttribute(SDL_GL_RED_SIZE, &value)) {
-        SDL_Log("SDL_GL_RED_SIZE: requested %d, got %d\n", 5, value);
+        SDL_Log("SDL_GL_RED_SIZE: requested %d, got %d", 5, value);
     } else {
-        SDL_Log("Failed to get SDL_GL_RED_SIZE: %s\n",
+        SDL_Log("Failed to get SDL_GL_RED_SIZE: %s",
                 SDL_GetError());
     }
     if (SDL_GL_GetAttribute(SDL_GL_GREEN_SIZE, &value)) {
-        SDL_Log("SDL_GL_GREEN_SIZE: requested %d, got %d\n", 5, value);
+        SDL_Log("SDL_GL_GREEN_SIZE: requested %d, got %d", 5, value);
     } else {
-        SDL_Log("Failed to get SDL_GL_GREEN_SIZE: %s\n",
+        SDL_Log("Failed to get SDL_GL_GREEN_SIZE: %s",
                 SDL_GetError());
     }
     if (SDL_GL_GetAttribute(SDL_GL_BLUE_SIZE, &value)) {
-        SDL_Log("SDL_GL_BLUE_SIZE: requested %d, got %d\n", 5, value);
+        SDL_Log("SDL_GL_BLUE_SIZE: requested %d, got %d", 5, value);
     } else {
-        SDL_Log("Failed to get SDL_GL_BLUE_SIZE: %s\n",
+        SDL_Log("Failed to get SDL_GL_BLUE_SIZE: %s",
                 SDL_GetError());
     }
     if (SDL_GL_GetAttribute(SDL_GL_DEPTH_SIZE, &value)) {
-        SDL_Log("SDL_GL_DEPTH_SIZE: requested %d, got %d\n", depth, value);
+        SDL_Log("SDL_GL_DEPTH_SIZE: requested %d, got %d", depth, value);
     } else {
-        SDL_Log("Failed to get SDL_GL_DEPTH_SIZE: %s\n",
+        SDL_Log("Failed to get SDL_GL_DEPTH_SIZE: %s",
                 SDL_GetError());
     }
     if (fsaa) {
         if (SDL_GL_GetAttribute(SDL_GL_MULTISAMPLEBUFFERS, &value)) {
-            SDL_Log("SDL_GL_MULTISAMPLEBUFFERS: requested 1, got %d\n", value);
+            SDL_Log("SDL_GL_MULTISAMPLEBUFFERS: requested 1, got %d", value);
         } else {
-            SDL_Log("Failed to get SDL_GL_MULTISAMPLEBUFFERS: %s\n",
+            SDL_Log("Failed to get SDL_GL_MULTISAMPLEBUFFERS: %s",
                     SDL_GetError());
         }
         if (SDL_GL_GetAttribute(SDL_GL_MULTISAMPLESAMPLES, &value)) {
-            SDL_Log("SDL_GL_MULTISAMPLESAMPLES: requested %d, got %d\n", fsaa,
+            SDL_Log("SDL_GL_MULTISAMPLESAMPLES: requested %d, got %d", fsaa,
                     value);
         } else {
-            SDL_Log("Failed to get SDL_GL_MULTISAMPLESAMPLES: %s\n",
+            SDL_Log("Failed to get SDL_GL_MULTISAMPLESAMPLES: %s",
                     SDL_GetError());
         }
     }
     if (accel) {
         if (SDL_GL_GetAttribute(SDL_GL_ACCELERATED_VISUAL, &value)) {
-            SDL_Log("SDL_GL_ACCELERATED_VISUAL: requested 1, got %d\n", value);
+            SDL_Log("SDL_GL_ACCELERATED_VISUAL: requested 1, got %d", value);
         } else {
-            SDL_Log("Failed to get SDL_GL_ACCELERATED_VISUAL: %s\n",
+            SDL_Log("Failed to get SDL_GL_ACCELERATED_VISUAL: %s",
                     SDL_GetError());
         }
     }
@@ -669,7 +669,7 @@ int main(int argc, char *argv[])
 
         int w, h;
         if (!SDL_GL_MakeCurrent(state->windows[i], context[i])) {
-            SDL_Log("SDL_GL_MakeCurrent(): %s\n", SDL_GetError());
+            SDL_Log("SDL_GL_MakeCurrent(): %s", SDL_GetError());
 
             /* Continue for next window */
             continue;
@@ -765,7 +765,7 @@ int main(int argc, char *argv[])
     /* Print out some timing information */
     now = SDL_GetTicks();
     if (now > then) {
-        SDL_Log("%2.2f frames per second\n",
+        SDL_Log("%2.2f frames per second",
                 ((double)frames * 1000) / (now - then));
     }
 #ifndef SDL_PLATFORM_ANDROID
@@ -778,7 +778,7 @@ int main(int argc, char *argv[])
 
 int main(int argc, char *argv[])
 {
-    SDL_Log("No OpenGL ES support on this system\n");
+    SDL_Log("No OpenGL ES support on this system");
     return 1;
 }
 

--- a/test/testgpu_simple_clear.c
+++ b/test/testgpu_simple_clear.c
@@ -54,13 +54,13 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
 
     mode = SDL_GetCurrentDisplayMode(SDL_GetPrimaryDisplay());
     if (mode) {
-        SDL_Log("Screen BPP    : %d\n", SDL_BITSPERPIXEL(mode->format));
+        SDL_Log("Screen BPP    : %d", SDL_BITSPERPIXEL(mode->format));
     }
     SDL_GetWindowSize(state->windows[0], &dw, &dh);
-    SDL_Log("Window Size   : %d,%d\n", dw, dh);
+    SDL_Log("Window Size   : %d,%d", dw, dh);
     SDL_GetWindowSizeInPixels(state->windows[0], &dw, &dh);
-    SDL_Log("Draw Size     : %d,%d\n", dw, dh);
-    SDL_Log("\n");
+    SDL_Log("Draw Size     : %d,%d", dw, dh);
+    SDL_Log("%s", "");
 
     then = SDL_GetTicks();
 
@@ -119,7 +119,7 @@ void SDL_AppQuit(void *appstate, SDL_AppResult result)
     /* Print out some timing information */
     const Uint64 now = SDL_GetTicks();
     if (now > then) {
-        SDL_Log("%2.2f frames per second\n", ((double)frames * 1000) / (now - then));
+        SDL_Log("%2.2f frames per second", ((double)frames * 1000) / (now - then));
     }
 
 	SDL_ReleaseWindowFromGPUDevice(gpu_device, state->windows[0]);

--- a/test/testgpu_spinning_cube.c
+++ b/test/testgpu_spinning_cube.c
@@ -27,7 +27,7 @@
 
 #define TESTGPU_SUPPORTED_FORMATS (SDL_GPU_SHADERFORMAT_SPIRV | SDL_GPU_SHADERFORMAT_DXBC | SDL_GPU_SHADERFORMAT_DXIL | SDL_GPU_SHADERFORMAT_METALLIB)
 
-#define CHECK_CREATE(var, thing) { if (!(var)) { SDL_Log("Failed to create %s: %s\n", thing, SDL_GetError()); quit(2); } }
+#define CHECK_CREATE(var, thing) { if (!(var)) { SDL_Log("Failed to create %s: %s", thing, SDL_GetError()); quit(2); } }
 
 static Uint32 frames = 0;
 
@@ -641,7 +641,7 @@ init_render_state(int msaa)
 
     window_states = (WindowState *) SDL_calloc(state->num_windows, sizeof (WindowState));
     if (!window_states) {
-        SDL_Log("Out of memory!\n");
+        SDL_Log("Out of memory!");
         quit(2);
     }
 
@@ -729,7 +729,7 @@ main(int argc, char *argv[])
     }
 
     mode = SDL_GetCurrentDisplayMode(SDL_GetDisplayForWindow(state->windows[0]));
-    SDL_Log("Screen bpp: %d\n", SDL_BITSPERPIXEL(mode->format));
+    SDL_Log("Screen bpp: %d", SDL_BITSPERPIXEL(mode->format));
 
     init_render_state(msaa);
 
@@ -749,7 +749,7 @@ main(int argc, char *argv[])
     /* Print out some timing information */
     now = SDL_GetTicks();
     if (now > then) {
-        SDL_Log("%2.2f frames per second\n",
+        SDL_Log("%2.2f frames per second",
                ((double) frames * 1000) / (now - then));
     }
 #if !defined(__ANDROID__)

--- a/test/testhaptic.c
+++ b/test/testhaptic.c
@@ -69,9 +69,9 @@ int main(int argc, char **argv)
         if (consumed <= 0) {
             static const char *options[] = { "[device]", NULL };
             SDLTest_CommonLogUsage(state, argv[0], options);
-            SDL_Log("\n");
-            SDL_Log("If device is a two-digit number it'll use it as an index, otherwise\n"
-                    "it'll use it as if it were part of the device's name.\n");
+            SDL_Log("%s", "");
+            SDL_Log("If device is a two-digit number it'll use it as an index, otherwise");
+            SDL_Log("it'll use it as if it were part of the device's name.");
             return 1;
         }
 
@@ -81,12 +81,12 @@ int main(int argc, char **argv)
     /* Initialize the force feedbackness */
     SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK | SDL_INIT_HAPTIC);
     haptics = SDL_GetHaptics(&num_haptics);
-    SDL_Log("%d Haptic devices detected.\n", num_haptics);
+    SDL_Log("%d Haptic devices detected.", num_haptics);
     for (i = 0; i < num_haptics; ++i) {
-        SDL_Log("    %s\n", SDL_GetHapticNameForID(haptics[i]));
+        SDL_Log("    %s", SDL_GetHapticNameForID(haptics[i]));
     }
     if (num_haptics == 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "No Haptic devices found!\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "No Haptic devices found!");
         SDL_free(haptics);
         return 1;
     }
@@ -96,7 +96,7 @@ int main(int argc, char **argv)
         i = (index != -1) ? index : 0;
 
         if (i >= num_haptics) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Index out of range, aborting.\n");
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Index out of range, aborting.");
             SDL_free(haptics);
             return 1;
         }
@@ -110,7 +110,7 @@ int main(int argc, char **argv)
         }
 
         if (i >= num_haptics) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to find device matching '%s', aborting.\n", name);
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to find device matching '%s', aborting.", name);
             SDL_free(haptics);
             return 1;
         }
@@ -118,11 +118,11 @@ int main(int argc, char **argv)
 
     haptic = SDL_OpenHaptic(haptics[i]);
     if (!haptic) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to create the haptic device: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to create the haptic device: %s", SDL_GetError());
         SDL_free(haptics);
         return 1;
     }
-    SDL_Log("Device: %s\n", SDL_GetHapticName(haptic));
+    SDL_Log("Device: %s", SDL_GetHapticName(haptic));
     HapticPrintSupported(haptic);
     SDL_free(haptics);
 
@@ -134,10 +134,11 @@ int main(int argc, char **argv)
     nefx = 0;
     supported = SDL_GetHapticFeatures(haptic);
 
-    SDL_Log("\nUploading effects\n");
+    SDL_Log("%s", "");
+    SDL_Log("Uploading effects");
     /* First we'll try a SINE effect. */
     if (supported & SDL_HAPTIC_SINE) {
-        SDL_Log("   effect %d: Sine Wave\n", nefx);
+        SDL_Log("   effect %d: Sine Wave", nefx);
         efx[nefx].type = SDL_HAPTIC_SINE;
         efx[nefx].periodic.period = 1000;
         efx[nefx].periodic.magnitude = -0x2000; /* Negative magnitude and ...                      */
@@ -147,14 +148,14 @@ int main(int argc, char **argv)
         efx[nefx].periodic.fade_length = 1000;
         id[nefx] = SDL_CreateHapticEffect(haptic, &efx[nefx]);
         if (id[nefx] < 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s", SDL_GetError());
             abort_execution();
         }
         nefx++;
     }
     /* Now we'll try a SAWTOOTHUP */
     if (supported & SDL_HAPTIC_SAWTOOTHUP) {
-        SDL_Log("   effect %d: Sawtooth Up\n", nefx);
+        SDL_Log("   effect %d: Sawtooth Up", nefx);
         efx[nefx].type = SDL_HAPTIC_SAWTOOTHUP;
         efx[nefx].periodic.period = 500;
         efx[nefx].periodic.magnitude = 0x5000;
@@ -163,7 +164,7 @@ int main(int argc, char **argv)
         efx[nefx].periodic.fade_length = 1000;
         id[nefx] = SDL_CreateHapticEffect(haptic, &efx[nefx]);
         if (id[nefx] < 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s", SDL_GetError());
             abort_execution();
         }
         nefx++;
@@ -171,7 +172,7 @@ int main(int argc, char **argv)
 
     /* Now the classical constant effect. */
     if (supported & SDL_HAPTIC_CONSTANT) {
-        SDL_Log("   effect %d: Constant Force\n", nefx);
+        SDL_Log("   effect %d: Constant Force", nefx);
         efx[nefx].type = SDL_HAPTIC_CONSTANT;
         efx[nefx].constant.direction.type = SDL_HAPTIC_POLAR;
         efx[nefx].constant.direction.dir[0] = 20000; /* Force comes from the south-west. */
@@ -181,7 +182,7 @@ int main(int argc, char **argv)
         efx[nefx].constant.fade_length = 1000;
         id[nefx] = SDL_CreateHapticEffect(haptic, &efx[nefx]);
         if (id[nefx] < 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s", SDL_GetError());
             abort_execution();
         }
         nefx++;
@@ -189,7 +190,7 @@ int main(int argc, char **argv)
 
     /* The cute spring effect. */
     if (supported & SDL_HAPTIC_SPRING) {
-        SDL_Log("   effect %d: Condition Spring\n", nefx);
+        SDL_Log("   effect %d: Condition Spring", nefx);
         efx[nefx].type = SDL_HAPTIC_SPRING;
         efx[nefx].condition.length = 5000;
         for (i = 0; i < SDL_GetNumHapticAxes(haptic); i++) {
@@ -201,14 +202,14 @@ int main(int argc, char **argv)
         }
         id[nefx] = SDL_CreateHapticEffect(haptic, &efx[nefx]);
         if (id[nefx] < 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s", SDL_GetError());
             abort_execution();
         }
         nefx++;
     }
     /* The interesting damper effect. */
     if (supported & SDL_HAPTIC_DAMPER) {
-        SDL_Log("   effect %d: Condition Damper\n", nefx);
+        SDL_Log("   effect %d: Condition Damper", nefx);
         efx[nefx].type = SDL_HAPTIC_DAMPER;
         efx[nefx].condition.length = 5000;
         for (i = 0; i < SDL_GetNumHapticAxes(haptic); i++) {
@@ -219,14 +220,14 @@ int main(int argc, char **argv)
         }
         id[nefx] = SDL_CreateHapticEffect(haptic, &efx[nefx]);
         if (id[nefx] < 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s", SDL_GetError());
             abort_execution();
         }
         nefx++;
     }
     /* The pretty awesome inertia effect. */
     if (supported & SDL_HAPTIC_INERTIA) {
-        SDL_Log("   effect %d: Condition Inertia\n", nefx);
+        SDL_Log("   effect %d: Condition Inertia", nefx);
         efx[nefx].type = SDL_HAPTIC_INERTIA;
         efx[nefx].condition.length = 5000;
         for (i = 0; i < SDL_GetNumHapticAxes(haptic); i++) {
@@ -238,14 +239,14 @@ int main(int argc, char **argv)
         }
         id[nefx] = SDL_CreateHapticEffect(haptic, &efx[nefx]);
         if (id[nefx] < 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s", SDL_GetError());
             abort_execution();
         }
         nefx++;
     }
     /* The hot friction effect. */
     if (supported & SDL_HAPTIC_FRICTION) {
-        SDL_Log("   effect %d: Condition Friction\n", nefx);
+        SDL_Log("   effect %d: Condition Friction", nefx);
         efx[nefx].type = SDL_HAPTIC_FRICTION;
         efx[nefx].condition.length = 5000;
         for (i = 0; i < SDL_GetNumHapticAxes(haptic); i++) {
@@ -256,7 +257,7 @@ int main(int argc, char **argv)
         }
         id[nefx] = SDL_CreateHapticEffect(haptic, &efx[nefx]);
         if (id[nefx] < 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s", SDL_GetError());
             abort_execution();
         }
         nefx++;
@@ -264,7 +265,7 @@ int main(int argc, char **argv)
 
     /* Now we'll try a ramp effect */
     if (supported & SDL_HAPTIC_RAMP) {
-        SDL_Log("   effect %d: Ramp\n", nefx);
+        SDL_Log("   effect %d: Ramp", nefx);
         efx[nefx].type = SDL_HAPTIC_RAMP;
         efx[nefx].ramp.direction.type = SDL_HAPTIC_CARTESIAN;
         efx[nefx].ramp.direction.dir[0] = 1;  /* Force comes from                 */
@@ -276,7 +277,7 @@ int main(int argc, char **argv)
         efx[nefx].ramp.fade_length = 1000;
         id[nefx] = SDL_CreateHapticEffect(haptic, &efx[nefx]);
         if (id[nefx] < 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s", SDL_GetError());
             abort_execution();
         }
         nefx++;
@@ -284,22 +285,23 @@ int main(int argc, char **argv)
 
     /* Finally we'll try a left/right effect. */
     if (supported & SDL_HAPTIC_LEFTRIGHT) {
-        SDL_Log("   effect %d: Left/Right\n", nefx);
+        SDL_Log("   effect %d: Left/Right", nefx);
         efx[nefx].type = SDL_HAPTIC_LEFTRIGHT;
         efx[nefx].leftright.length = 5000;
         efx[nefx].leftright.large_magnitude = 0x3000;
         efx[nefx].leftright.small_magnitude = 0xFFFF;
         id[nefx] = SDL_CreateHapticEffect(haptic, &efx[nefx]);
         if (id[nefx] < 0) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "UPLOADING EFFECT ERROR: %s", SDL_GetError());
             abort_execution();
         }
         nefx++;
     }
 
-    SDL_Log("\nNow playing effects for 5 seconds each with 1 second delay between\n");
+    SDL_Log("%s", "");
+    SDL_Log("Now playing effects for 5 seconds each with 1 second delay between");
     for (i = 0; i < nefx; i++) {
-        SDL_Log("   Playing effect %d\n", i);
+        SDL_Log("   Playing effect %d", i);
         SDL_RunHapticEffect(haptic, id[i], 1);
         SDL_Delay(6000); /* Effects only have length 5000 */
     }
@@ -320,7 +322,8 @@ int main(int argc, char **argv)
 static void
 abort_execution(void)
 {
-    SDL_Log("\nAborting program execution.\n");
+    SDL_Log("%s", "");
+    SDL_Log("Aborting program execution.");
 
     SDL_CloseHaptic(haptic);
     SDL_Quit();
@@ -338,54 +341,54 @@ HapticPrintSupported(SDL_Haptic *ptr)
     unsigned int supported;
 
     supported = SDL_GetHapticFeatures(ptr);
-    SDL_Log("   Supported effects [%d effects, %d playing]:\n",
+    SDL_Log("   Supported effects [%d effects, %d playing]:",
             SDL_GetMaxHapticEffects(ptr), SDL_GetMaxHapticEffectsPlaying(ptr));
     if (supported & SDL_HAPTIC_CONSTANT) {
-        SDL_Log("      constant\n");
+        SDL_Log("      constant");
     }
     if (supported & SDL_HAPTIC_SINE) {
-        SDL_Log("      sine\n");
+        SDL_Log("      sine");
     }
     if (supported & SDL_HAPTIC_SQUARE)
-        SDL_Log("      square\n");
+        SDL_Log("      square");
     if (supported & SDL_HAPTIC_TRIANGLE) {
-        SDL_Log("      triangle\n");
+        SDL_Log("      triangle");
     }
     if (supported & SDL_HAPTIC_SAWTOOTHUP) {
-        SDL_Log("      sawtoothup\n");
+        SDL_Log("      sawtoothup");
     }
     if (supported & SDL_HAPTIC_SAWTOOTHDOWN) {
-        SDL_Log("      sawtoothdown\n");
+        SDL_Log("      sawtoothdown");
     }
     if (supported & SDL_HAPTIC_RAMP) {
-        SDL_Log("      ramp\n");
+        SDL_Log("      ramp");
     }
     if (supported & SDL_HAPTIC_FRICTION) {
-        SDL_Log("      friction\n");
+        SDL_Log("      friction");
     }
     if (supported & SDL_HAPTIC_SPRING) {
-        SDL_Log("      spring\n");
+        SDL_Log("      spring");
     }
     if (supported & SDL_HAPTIC_DAMPER) {
-        SDL_Log("      damper\n");
+        SDL_Log("      damper");
     }
     if (supported & SDL_HAPTIC_INERTIA) {
-        SDL_Log("      inertia\n");
+        SDL_Log("      inertia");
     }
     if (supported & SDL_HAPTIC_CUSTOM) {
-        SDL_Log("      custom\n");
+        SDL_Log("      custom");
     }
     if (supported & SDL_HAPTIC_LEFTRIGHT) {
-        SDL_Log("      left/right\n");
+        SDL_Log("      left/right");
     }
-    SDL_Log("   Supported capabilities:\n");
+    SDL_Log("   Supported capabilities:");
     if (supported & SDL_HAPTIC_GAIN) {
-        SDL_Log("      gain\n");
+        SDL_Log("      gain");
     }
     if (supported & SDL_HAPTIC_AUTOCENTER) {
-        SDL_Log("      autocenter\n");
+        SDL_Log("      autocenter");
     }
     if (supported & SDL_HAPTIC_STATUS) {
-        SDL_Log("      status\n");
+        SDL_Log("      status");
     }
 }

--- a/test/testhittesting.c
+++ b/test/testhittesting.c
@@ -47,14 +47,14 @@ hitTest(SDL_Window *window, const SDL_Point *pt, void *data)
 
     for (i = 0; i < numareas; i++) {
         if (SDL_PointInRect(&adj_pt, &areas[i])) {
-            SDL_Log("HIT-TEST: DRAGGABLE\n");
+            SDL_Log("HIT-TEST: DRAGGABLE");
             return SDL_HITTEST_DRAGGABLE;
         }
     }
 
 #define REPORT_RESIZE_HIT(name)                  \
     {                                            \
-        SDL_Log("HIT-TEST: RESIZE_" #name "\n"); \
+        SDL_Log("HIT-TEST: RESIZE_" #name ""); \
         return SDL_HITTEST_RESIZE_##name;        \
     }
 
@@ -76,7 +76,7 @@ hitTest(SDL_Window *window, const SDL_Point *pt, void *data)
         REPORT_RESIZE_HIT(LEFT);
     }
 
-    SDL_Log("HIT-TEST: NORMAL\n");
+    SDL_Log("HIT-TEST: NORMAL");
     return SDL_HITTEST_NORMAL;
 }
 
@@ -130,15 +130,15 @@ int main(int argc, char **argv)
 
             switch (e.type) {
             case SDL_EVENT_MOUSE_BUTTON_DOWN:
-                SDL_Log("button down!\n");
+                SDL_Log("button down!");
                 break;
 
             case SDL_EVENT_MOUSE_BUTTON_UP:
-                SDL_Log("button up!\n");
+                SDL_Log("button up!");
                 break;
 
             case SDL_EVENT_WINDOW_MOVED:
-                SDL_Log("Window event moved to (%d, %d)!\n", (int)e.window.data1, (int)e.window.data2);
+                SDL_Log("Window event moved to (%d, %d)!", (int)e.window.data1, (int)e.window.data2);
                 break;
 
             case SDL_EVENT_KEY_DOWN:

--- a/test/testhotplug.c
+++ b/test/testhotplug.c
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
 
     /* Initialize SDL (Note: video is required to start event loop) */
     if (!SDL_Init(init_subsystems)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
         exit(1);
     }
 
@@ -75,18 +75,18 @@ int main(int argc, char *argv[])
     */
 
     SDL_free(SDL_GetKeyboards(&num_keyboards));
-    SDL_Log("There are %d keyboards at startup\n", num_keyboards);
+    SDL_Log("There are %d keyboards at startup", num_keyboards);
 
     SDL_free(SDL_GetMice(&num_mice));
-    SDL_Log("There are %d mice at startup\n", num_mice);
+    SDL_Log("There are %d mice at startup", num_mice);
 
     SDL_free(SDL_GetJoysticks(&num_joysticks));
-    SDL_Log("There are %d joysticks at startup\n", num_joysticks);
+    SDL_Log("There are %d joysticks at startup", num_joysticks);
 
     if (enable_haptic) {
         int num_haptics;
         SDL_free(SDL_GetHaptics(&num_haptics));
-        SDL_Log("There are %d haptic devices at startup\n", num_haptics);
+        SDL_Log("There are %d haptic devices at startup", num_haptics);
     }
 
     while (keepGoing) {
@@ -97,46 +97,46 @@ int main(int argc, char *argv[])
                 keepGoing = false;
                 break;
             case SDL_EVENT_KEYBOARD_ADDED:
-                SDL_Log("Keyboard '%s' added  : %" SDL_PRIu32 "\n", SDL_GetKeyboardNameForID(event.kdevice.which), event.kdevice.which);
+                SDL_Log("Keyboard '%s' added  : %" SDL_PRIu32, SDL_GetKeyboardNameForID(event.kdevice.which), event.kdevice.which);
                 break;
             case SDL_EVENT_KEYBOARD_REMOVED:
-                SDL_Log("Keyboard removed: %" SDL_PRIu32 "\n", event.kdevice.which);
+                SDL_Log("Keyboard removed: %" SDL_PRIu32, event.kdevice.which);
                 break;
             case SDL_EVENT_MOUSE_ADDED:
-                SDL_Log("Mouse '%s' added  : %" SDL_PRIu32 "\n", SDL_GetMouseNameForID(event.mdevice.which), event.mdevice.which);
+                SDL_Log("Mouse '%s' added  : %" SDL_PRIu32, SDL_GetMouseNameForID(event.mdevice.which), event.mdevice.which);
                 break;
             case SDL_EVENT_MOUSE_REMOVED:
-                SDL_Log("Mouse removed: %" SDL_PRIu32 "\n", event.mdevice.which);
+                SDL_Log("Mouse removed: %" SDL_PRIu32, event.mdevice.which);
                 break;
             case SDL_EVENT_JOYSTICK_ADDED:
                 if (joystick) {
-                    SDL_Log("Only one joystick supported by this test\n");
+                    SDL_Log("Only one joystick supported by this test");
                 } else {
                     joystick = SDL_OpenJoystick(event.jdevice.which);
                     instance = event.jdevice.which;
-                    SDL_Log("Joy Added  : %" SDL_PRIu32 " : %s\n", event.jdevice.which, SDL_GetJoystickName(joystick));
+                    SDL_Log("Joy Added  : %" SDL_PRIu32 " : %s", event.jdevice.which, SDL_GetJoystickName(joystick));
                     if (enable_haptic) {
                         if (SDL_IsJoystickHaptic(joystick)) {
                             haptic = SDL_OpenHapticFromJoystick(joystick);
                             if (haptic) {
-                                SDL_Log("Joy Haptic Opened\n");
+                                SDL_Log("Joy Haptic Opened");
                                 if (!SDL_InitHapticRumble(haptic)) {
-                                    SDL_Log("Could not init Rumble!: %s\n", SDL_GetError());
+                                    SDL_Log("Could not init Rumble!: %s", SDL_GetError());
                                     SDL_CloseHaptic(haptic);
                                     haptic = NULL;
                                 }
                             } else {
-                                SDL_Log("Joy haptic open FAILED!: %s\n", SDL_GetError());
+                                SDL_Log("Joy haptic open FAILED!: %s", SDL_GetError());
                             }
                         } else {
-                            SDL_Log("No haptic found\n");
+                            SDL_Log("No haptic found");
                         }
                     }
                 }
                 break;
             case SDL_EVENT_JOYSTICK_REMOVED:
                 if (instance == event.jdevice.which) {
-                    SDL_Log("Joy Removed: %" SDL_PRIs32 "\n", event.jdevice.which);
+                    SDL_Log("Joy Removed: %" SDL_PRIs32, event.jdevice.which);
                     instance = 0;
                     if (enable_haptic && haptic) {
                         SDL_CloseHaptic(haptic);
@@ -145,29 +145,29 @@ int main(int argc, char *argv[])
                     SDL_CloseJoystick(joystick);
                     joystick = NULL;
                 } else {
-                    SDL_Log("Unknown joystick disconnected\n");
+                    SDL_Log("Unknown joystick disconnected");
                 }
                 break;
             case SDL_EVENT_JOYSTICK_AXIS_MOTION:
                 /*
-                //                    SDL_Log("Axis Move: %d\n", event.jaxis.axis);
+                //                    SDL_Log("Axis Move: %d", event.jaxis.axis);
                 */
                 if (enable_haptic) {
                     SDL_PlayHapticRumble(haptic, 0.25, 250);
                 }
                 break;
             case SDL_EVENT_JOYSTICK_BUTTON_DOWN:
-                SDL_Log("Button Press: %d\n", event.jbutton.button);
+                SDL_Log("Button Press: %d", event.jbutton.button);
                 if (enable_haptic && haptic) {
                     SDL_PlayHapticRumble(haptic, 0.25, 250);
                 }
                 if (event.jbutton.button == 0) {
-                    SDL_Log("Exiting due to button press of button 0\n");
+                    SDL_Log("Exiting due to button press of button 0");
                     keepGoing = false;
                 }
                 break;
             case SDL_EVENT_JOYSTICK_BUTTON_UP:
-                SDL_Log("Button Release: %d\n", event.jbutton.button);
+                SDL_Log("Button Release: %d", event.jbutton.button);
                 break;
             default:
                 break;

--- a/test/testiconv.c
+++ b/test/testiconv.c
@@ -111,7 +111,7 @@ int main(int argc, char *argv[])
     fname = GetResourceFilename(fname, "utf8.txt");
     fdata = (Uint8 *) (fname ? SDL_LoadFile(fname, &fdatalen) : NULL);
     if (!fdata) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to load %s\n", fname);
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to load %s", fname);
         return 1;
     }
 
@@ -126,7 +126,7 @@ int main(int argc, char *argv[])
             test[0] = SDL_iconv_string(formats[i], "UCS-4", ucs4, len);
             test[1] = SDL_iconv_string("UCS-4", formats[i], test[0], len);
             if (!test[1] || SDL_memcmp(test[1], ucs4, len) != 0) {
-                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "FAIL: %s\n", formats[i]);
+                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "FAIL: %s", formats[i]);
                 ++errors;
             }
             SDL_free(test[0]);
@@ -140,7 +140,7 @@ int main(int argc, char *argv[])
     SDL_free(fdata);
     SDL_free(fname);
 
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Total errors: %d\n", errors);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Total errors: %d", errors);
     SDL_Quit();
     SDLTest_CommonDestroyState(state);
     return errors ? errors + 1 : 0;

--- a/test/testime.c
+++ b/test/testime.c
@@ -163,7 +163,7 @@ static int unifont_init(const char *fontname)
     /* Allocate memory for the glyph data so the file can be closed after initialization. */
     unifontGlyph = (struct UnifontGlyph *)SDL_malloc(unifontGlyphSize);
     if (!unifontGlyph) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Failed to allocate %d KiB for glyph data.\n", (int)(unifontGlyphSize + 1023) / 1024);
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Failed to allocate %d KiB for glyph data.", (int)(unifontGlyphSize + 1023) / 1024);
         return -1;
     }
     SDL_memset(unifontGlyph, 0, unifontGlyphSize);
@@ -171,20 +171,20 @@ static int unifont_init(const char *fontname)
     /* Allocate memory for texture pointers for all renderers. */
     unifontTexture = (SDL_Texture **)SDL_malloc(unifontTextureSize);
     if (!unifontTexture) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Failed to allocate %d KiB for texture pointer data.\n", (int)(unifontTextureSize + 1023) / 1024);
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Failed to allocate %d KiB for texture pointer data.", (int)(unifontTextureSize + 1023) / 1024);
         return -1;
     }
     SDL_memset(unifontTexture, 0, unifontTextureSize);
 
     filename = GetResourceFilename(NULL, fontname);
     if (!filename) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory");
         return -1;
     }
     hexFile = SDL_IOFromFile(filename, "rb");
     SDL_free(filename);
     if (!hexFile) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Failed to open font file: %s\n", fontname);
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Failed to open font file: %s", fontname);
         return -1;
     }
 
@@ -200,7 +200,7 @@ static int unifont_init(const char *fontname)
             break; /* EOF */
         }
         if ((numGlyphs == 0 && bytesRead == 0) || (numGlyphs > 0 && bytesRead < 9)) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Unexpected end of hex file.\n");
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Unexpected end of hex file.");
             return -1;
         }
 
@@ -214,16 +214,16 @@ static int unifont_init(const char *fontname)
         } else if (hexBuffer[8] == ':') {
             codepointHexSize = 8;
         } else {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Could not find codepoint and glyph data separator symbol in hex file on line %d.\n", lineNumber);
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Could not find codepoint and glyph data separator symbol in hex file on line %d.", lineNumber);
             return -1;
         }
 
         if (!validate_hex((const char *)hexBuffer, codepointHexSize, &codepoint)) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Malformed hexadecimal number in hex file on line %d.\n", lineNumber);
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Malformed hexadecimal number in hex file on line %d.", lineNumber);
             return -1;
         }
         if (codepoint > UNIFONT_MAX_CODEPOINT) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "unifont: Codepoint on line %d exceeded limit of 0x%x.\n", lineNumber, UNIFONT_MAX_CODEPOINT);
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "unifont: Codepoint on line %d exceeded limit of 0x%x.", lineNumber, UNIFONT_MAX_CODEPOINT);
         }
 
         /* If there was glyph data read in the last file read, move it to the front of the buffer. */
@@ -234,7 +234,7 @@ static int unifont_init(const char *fontname)
         bytesRead = SDL_ReadIO(hexFile, hexBuffer + bytesOverread, 33 - bytesOverread);
 
         if (bytesRead < (33 - bytesOverread)) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Unexpected end of hex file.\n");
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Unexpected end of hex file.");
             return -1;
         }
         if (hexBuffer[32] == '\n') {
@@ -243,19 +243,19 @@ static int unifont_init(const char *fontname)
             glyphWidth = 16;
             bytesRead = SDL_ReadIO(hexFile, hexBuffer + 33, 32);
             if (bytesRead < 32) {
-                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Unexpected end of hex file.\n");
+                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Unexpected end of hex file.");
                 return -1;
             }
         }
 
         if (!validate_hex((const char *)hexBuffer, glyphWidth * 4, NULL)) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Malformed hexadecimal glyph data in hex file on line %d.\n", lineNumber);
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Malformed hexadecimal glyph data in hex file on line %d.", lineNumber);
             return -1;
         }
 
         if (codepoint <= UNIFONT_MAX_CODEPOINT) {
             if (unifontGlyph[codepoint].width > 0) {
-                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "unifont: Ignoring duplicate codepoint 0x%08" SDL_PRIx32 " in hex file on line %d.\n", codepoint, lineNumber);
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "unifont: Ignoring duplicate codepoint 0x%08" SDL_PRIx32 " in hex file on line %d.", codepoint, lineNumber);
             } else {
                 unifontGlyph[codepoint].width = glyphWidth;
                 /* Pack the hex data into a more compact form. */
@@ -270,7 +270,7 @@ static int unifont_init(const char *fontname)
     } while (bytesRead > 0);
 
     SDL_CloseIO(hexFile);
-    SDL_Log("unifont: Loaded %" SDL_PRIu32 " glyphs.\n", numGlyphs);
+    SDL_Log("unifont: Loaded %" SDL_PRIu32 " glyphs.", numGlyphs);
     return 0;
 }
 
@@ -310,13 +310,13 @@ static int unifont_load_texture(Uint32 textureID)
     Uint8 *textureRGBA;
 
     if (textureID >= UNIFONT_NUM_TEXTURES) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Tried to load out of range texture %" SDL_PRIu32 "\n", textureID);
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Tried to load out of range texture %" SDL_PRIu32, textureID);
         return -1;
     }
 
     textureRGBA = (Uint8 *)SDL_malloc(UNIFONT_TEXTURE_SIZE);
     if (!textureRGBA) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Failed to allocate %d MiB for a texture.\n", UNIFONT_TEXTURE_SIZE / 1024 / 1024);
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Failed to allocate %d MiB for a texture.", UNIFONT_TEXTURE_SIZE / 1024 / 1024);
         return -1;
     }
     SDL_memset(textureRGBA, 0, UNIFONT_TEXTURE_SIZE);
@@ -340,13 +340,13 @@ static int unifont_load_texture(Uint32 textureID)
         }
         tex = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STATIC, UNIFONT_TEXTURE_WIDTH, UNIFONT_TEXTURE_WIDTH);
         if (tex == NULL) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Failed to create texture %" SDL_PRIu32 " for renderer %d.\n", textureID, i);
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "unifont: Failed to create texture %" SDL_PRIu32 " for renderer %d.", textureID, i);
             return -1;
         }
         unifontTexture[UNIFONT_NUM_TEXTURES * i + textureID] = tex;
         SDL_SetTextureBlendMode(tex, SDL_BLENDMODE_BLEND);
         if (!SDL_UpdateTexture(tex, NULL, textureRGBA, UNIFONT_TEXTURE_PITCH)) {
-            SDL_Log("unifont error: Failed to update texture %" SDL_PRIu32 " data for renderer %d.\n", textureID, i);
+            SDL_Log("unifont error: Failed to update texture %" SDL_PRIu32 " data for renderer %d.", textureID, i);
         }
     }
 
@@ -970,7 +970,7 @@ int main(int argc, char *argv[])
 
     windowstate = (WindowState *)SDL_calloc(state->num_windows, sizeof(*windowstate));
     if (!windowstate) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't allocate window state: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't allocate window state: %s", SDL_GetError());
         return -1;
     }
 
@@ -980,7 +980,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    SDL_Log("Using font: %s\n", fontname);
+    SDL_Log("Using font: %s", fontname);
 
     /* Initialize window state */
     for (i = 0; i < state->num_windows; ++i) {
@@ -1082,7 +1082,7 @@ int main(int argc, char *argv[])
                     break;
                 }
 
-                SDL_Log("Keyboard: scancode 0x%08X = %s, keycode 0x%08" SDL_PRIX32 " = %s\n",
+                SDL_Log("Keyboard: scancode 0x%08X = %s, keycode 0x%08" SDL_PRIX32 " = %s",
                         event.key.scancode,
                         SDL_GetScancodeName(event.key.scancode),
                         SDL_static_cast(Uint32, event.key.key),
@@ -1099,13 +1099,13 @@ int main(int argc, char *argv[])
                     break;
                 }
 
-                SDL_Log("Keyboard: text input \"%s\"\n", event.text.text);
+                SDL_Log("Keyboard: text input \"%s\"", event.text.text);
 
                 if (SDL_strlen(ctx->text) + SDL_strlen(event.text.text) < sizeof(ctx->text)) {
                     SDL_strlcat(ctx->text, event.text.text, sizeof(ctx->text));
                 }
 
-                SDL_Log("text inputted: %s\n", ctx->text);
+                SDL_Log("text inputted: %s", ctx->text);
 
                 /* After text inputted, we can clear up markedText because it */
                 /* is committed */
@@ -1118,7 +1118,7 @@ int main(int argc, char *argv[])
                     break;
                 }
 
-                SDL_Log("text editing \"%s\", selected range (%" SDL_PRIs32 ", %" SDL_PRIs32 ")\n",
+                SDL_Log("text editing \"%s\", selected range (%" SDL_PRIs32 ", %" SDL_PRIs32 ")",
                         event.edit.text, event.edit.start, event.edit.length);
 
                 SDL_strlcpy(ctx->markedText, event.edit.text, sizeof(ctx->markedText));
@@ -1132,9 +1132,9 @@ int main(int argc, char *argv[])
                     break;
                 }
 
-                SDL_Log("text candidates:\n");
+                SDL_Log("text candidates:");
                 for (i = 0; i < event.edit_candidates.num_candidates; ++i) {
-                    SDL_Log("%c%s\n", i == event.edit_candidates.selected_candidate ? '>' : ' ', event.edit_candidates.candidates[i]);
+                    SDL_Log("%c%s", i == event.edit_candidates.selected_candidate ? '>' : ' ', event.edit_candidates.candidates[i]);
                 }
 
                 ClearCandidates(ctx);

--- a/test/testintersections.c
+++ b/test/testintersections.c
@@ -92,7 +92,7 @@ static int add_line(float x1, float y1, float x2, float y2)
         return 0;
     }
 
-    SDL_Log("adding line (%g, %g), (%g, %g)\n", x1, y1, x2, y2);
+    SDL_Log("adding line (%g, %g), (%g, %g)", x1, y1, x2, y2);
     lines[num_lines].x = x1;
     lines[num_lines].y = y1;
     lines[num_lines].w = x2;
@@ -142,7 +142,7 @@ static int add_rect(float x1, float y1, float x2, float y2)
         SWAP(float, y1, y2);
     }
 
-    SDL_Log("adding rect (%g, %g), (%g, %g) [%gx%g]\n", x1, y1, x2, y2,
+    SDL_Log("adding rect (%g, %g), (%g, %g) [%gx%g]", x1, y1, x2, y2,
             x2 - x1, y2 - y1);
 
     rects[num_rects].x = x1;
@@ -385,7 +385,7 @@ int main(int argc, char *argv[])
 
     if (now > then) {
         double fps = ((double)frames * 1000) / (now - then);
-        SDL_Log("%2.2f frames per second\n", fps);
+        SDL_Log("%2.2f frames per second", fps);
     }
     return 0;
 }

--- a/test/testkeys.c
+++ b/test/testkeys.c
@@ -35,11 +35,11 @@ int main(int argc, char *argv[])
     }
 
     if (!SDL_Init(SDL_INIT_VIDEO)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
         exit(1);
     }
     for (scancode = 0; scancode < SDL_SCANCODE_COUNT; ++scancode) {
-        SDL_Log("Scancode #%d, \"%s\"\n", scancode,
+        SDL_Log("Scancode #%d, \"%s\"", scancode,
                 SDL_GetScancodeName(scancode));
     }
     SDL_Quit();

--- a/test/testloadso.c
+++ b/test/testloadso.c
@@ -24,8 +24,8 @@ typedef int (*fntype)(const char *);
 static void log_usage(char *progname, SDLTest_CommonState *state) {
     static const char *options[] = { "library", "functionname|--hello", NULL };
     SDLTest_CommonLogUsage(state, progname, options);
-    SDL_Log("USAGE: %s <library> <functionname>\n", progname);
-    SDL_Log("       %s <lib with puts()> --hello\n", progname);
+    SDL_Log("USAGE: %s <library> <functionname>", progname);
+    SDL_Log("       %s <lib with puts()> --hello", progname);
 }
 
 int main(int argc, char *argv[])
@@ -80,28 +80,28 @@ int main(int argc, char *argv[])
 
     /* Initialize SDL */
     if (!SDL_Init(0)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
         return 2;
     }
 
     lib = SDL_LoadObject(libname);
     if (!lib) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_LoadObject('%s') failed: %s\n",
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_LoadObject('%s') failed: %s",
                      libname, SDL_GetError());
         result = 3;
     } else {
         fn = (fntype)SDL_LoadFunction(lib, symname);
         if (!fn) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_LoadFunction('%s') failed: %s\n",
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_LoadFunction('%s') failed: %s",
                          symname, SDL_GetError());
             result = 4;
         } else {
-            SDL_Log("Found %s in %s at %p\n", symname, libname, fn);
+            SDL_Log("Found %s in %s at %p", symname, libname, fn);
             if (hello) {
-                SDL_Log("Calling function...\n");
+                SDL_Log("Calling function...");
                 fn("     HELLO, WORLD!\n");
-                SDL_Log("...apparently, we survived.  :)\n");
-                SDL_Log("Unloading library...\n");
+                SDL_Log("...apparently, we survived.  :)");
+                SDL_Log("Unloading library...");
             }
         }
         SDL_UnloadObject(lib);

--- a/test/testlock.c
+++ b/test/testlock.c
@@ -42,7 +42,7 @@ SDL_Quit_Wrapper(void)
 
 static void printid(void)
 {
-    SDL_Log("Thread %" SDL_PRIu64 ":  exiting\n", SDL_GetCurrentThreadID());
+    SDL_Log("Thread %" SDL_PRIu64 ":  exiting", SDL_GetCurrentThreadID());
 }
 
 static void terminate(int sig)
@@ -55,7 +55,7 @@ static void closemutex(int sig)
 {
     SDL_ThreadID id = SDL_GetCurrentThreadID();
     int i;
-    SDL_Log("Thread %" SDL_PRIu64 ":  Cleaning up...\n", id == mainthread ? 0 : id);
+    SDL_Log("Thread %" SDL_PRIu64 ":  Cleaning up...", id == mainthread ? 0 : id);
     SDL_SetAtomicInt(&doterminate, 1);
     if (threads) {
         for (i = 0; i < nb_threads; ++i) {
@@ -81,21 +81,21 @@ Run(void *data)
     }
     SDL_Log("Thread %" SDL_PRIu64 ": starting up", current_thread);
     while (!SDL_GetAtomicInt(&doterminate)) {
-        SDL_Log("Thread %" SDL_PRIu64 ": ready to work\n", current_thread);
+        SDL_Log("Thread %" SDL_PRIu64 ": ready to work", current_thread);
         SDL_LockMutex(mutex);
-        SDL_Log("Thread %" SDL_PRIu64 ": start work!\n", current_thread);
+        SDL_Log("Thread %" SDL_PRIu64 ": start work!", current_thread);
         SDL_Delay(1 * worktime);
-        SDL_Log("Thread %" SDL_PRIu64 ": work done!\n", current_thread);
+        SDL_Log("Thread %" SDL_PRIu64 ": work done!", current_thread);
         SDL_UnlockMutex(mutex);
 
         /* If this sleep isn't done, then threads may starve */
         SDL_Delay(10);
     }
     if (current_thread == mainthread && SDL_GetAtomicInt(&doterminate)) {
-        SDL_Log("Thread %" SDL_PRIu64 ": raising SIGTERM\n", current_thread);
+        SDL_Log("Thread %" SDL_PRIu64 ": raising SIGTERM", current_thread);
         (void)raise(SIGTERM);
     }
-    SDL_Log("Thread %" SDL_PRIu64 ": exiting!\n", current_thread);
+    SDL_Log("Thread %" SDL_PRIu64 ": exiting!", current_thread);
     return 0;
 }
 
@@ -174,7 +174,7 @@ int main(int argc, char *argv[])
 
     /* Load the SDL library */
     if (!SDL_Init(0)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", SDL_GetError());
         exit(1);
     }
     (void)atexit(SDL_Quit_Wrapper);
@@ -183,19 +183,19 @@ int main(int argc, char *argv[])
 
     mutex = SDL_CreateMutex();
     if (!mutex) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create mutex: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create mutex: %s", SDL_GetError());
         exit(1);
     }
 
     mainthread = SDL_GetCurrentThreadID();
-    SDL_Log("Main thread: %" SDL_PRIu64 "\n", mainthread);
+    SDL_Log("Main thread: %" SDL_PRIu64, mainthread);
     (void)atexit(printid);
     for (i = 0; i < nb_threads; ++i) {
         char name[64];
         (void)SDL_snprintf(name, sizeof(name), "Worker%d", i);
         threads[i] = SDL_CreateThread(Run, name, NULL);
         if (threads[i] == NULL) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create thread!\n");
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create thread!");
         }
     }
 

--- a/test/testmessage.c
+++ b/test/testmessage.c
@@ -64,7 +64,7 @@ button_messagebox(void *eventNumber)
 
     success = SDL_ShowMessageBox(&data, &button);
     if (success == -1) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error Presenting MessageBox: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error Presenting MessageBox: %s", SDL_GetError());
         if (eventNumber) {
             SDL_Event event;
             event.type = (Uint32)(intptr_t)eventNumber;
@@ -74,7 +74,7 @@ button_messagebox(void *eventNumber)
             quit(2);
         }
     }
-    SDL_Log("Pressed button: %d, %s\n", button, button == -1 ? "[closed]" : button == 1 ? "Cancel"
+    SDL_Log("Pressed button: %d, %s", button, button == -1 ? "[closed]" : button == 1 ? "Cancel"
                                                                                         : "OK");
 
     if (eventNumber) {
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
                                        "This is a simple error MessageBox",
                                        NULL);
     if (!success) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error Presenting MessageBox: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error Presenting MessageBox: %s", SDL_GetError());
         quit(1);
     }
 
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
                                        "This is a simple MessageBox with a newline:\r\nHello world!",
                                        NULL);
     if (!success) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error Presenting MessageBox: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error Presenting MessageBox: %s", SDL_GetError());
         quit(1);
     }
 
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
                                        "NULL Title",
                                        NULL);
     if (!success) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error Presenting MessageBox: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error Presenting MessageBox: %s", SDL_GetError());
         quit(1);
     }
 
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
                                        NULL,
                                        NULL);
     if (!success) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error Presenting MessageBox: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error Presenting MessageBox: %s", SDL_GetError());
         quit(1);
     }
 
@@ -144,7 +144,7 @@ int main(int argc, char *argv[])
                                        "Unicode text: '牛肉西蘭花' ...",
                                        NULL);
     if (!success) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error Presenting MessageBox: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error Presenting MessageBox: %s", SDL_GetError());
         quit(1);
     }
 
@@ -154,7 +154,7 @@ int main(int argc, char *argv[])
                                        "Unicode text and newline:\r\n'牛肉西蘭花'\n'牛肉西蘭花'",
                                        NULL);
     if (!success) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error Presenting MessageBox: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error Presenting MessageBox: %s", SDL_GetError());
         quit(1);
     }
 
@@ -164,7 +164,7 @@ int main(int argc, char *argv[])
                                        "Unicode text in the title.",
                                        NULL);
     if (!success) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error Presenting MessageBox: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error Presenting MessageBox: %s", SDL_GetError());
         quit(1);
     }
 
@@ -177,7 +177,7 @@ int main(int argc, char *argv[])
        subsystem on the main thread.
      */
     if (!SDL_Init(SDL_INIT_VIDEO)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL video subsystem: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL video subsystem: %s", SDL_GetError());
         return 1;
     }
     {
@@ -194,7 +194,7 @@ int main(int argc, char *argv[])
 
         SDL_WaitThread(thread, &status);
 
-        SDL_Log("Message box thread return %i\n", status);
+        SDL_Log("Message box thread return %i", status);
     }
 
     /* Test showing a message box with a parent window */
@@ -213,7 +213,7 @@ int main(int argc, char *argv[])
                                            "This is a simple error MessageBox with a parent window. Press a key or close the window after dismissing this messagebox.",
                                            window);
         if (!success) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error Presenting MessageBox: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Error Presenting MessageBox: %s", SDL_GetError());
             quit(1);
         }
 

--- a/test/testmodal.c
+++ b/test/testmodal.c
@@ -52,13 +52,13 @@ int main(int argc, char *argv[])
     }
 
     if (!SDL_CreateWindowAndRenderer("Parent Window", 640, 480, 0, &w1, &r1)) {
-        SDL_Log("Failed to create parent window and/or renderer: %s\n", SDL_GetError());
+        SDL_Log("Failed to create parent window and/or renderer: %s", SDL_GetError());
         exit_code = 1;
         goto sdl_quit;
     }
 
     if (!SDL_CreateWindowAndRenderer("Non-Modal Window", 320, 200, 0, &w2, &r2)) {
-        SDL_Log("Failed to create parent window and/or renderer: %s\n", SDL_GetError());
+        SDL_Log("Failed to create parent window and/or renderer: %s", SDL_GetError());
         exit_code = 1;
         goto sdl_quit;
     }
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
             } else if (e.type == SDL_EVENT_KEY_DOWN) {
                 if ((e.key.key == SDLK_M || e.key.key == SDLK_N) && !w2) {
                     if (!SDL_CreateWindowAndRenderer("Non-Modal Window", 320, 200, SDL_WINDOW_HIDDEN, &w2, &r2)) {
-                        SDL_Log("Failed to create modal window and/or renderer: %s\n", SDL_GetError());
+                        SDL_Log("Failed to create modal window and/or renderer: %s", SDL_GetError());
                         exit_code = 1;
                         goto sdl_quit;
                     }

--- a/test/testmouse.c
+++ b/test/testmouse.c
@@ -295,7 +295,7 @@ int main(int argc, char *argv[])
 
     /* Initialize SDL (Note: video is required to start event loop) */
     if (!SDL_Init(SDL_INIT_VIDEO)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
         exit(1);
     }
 
@@ -313,7 +313,7 @@ int main(int argc, char *argv[])
     window = SDL_CreateWindow("Mouse Test", SCREEN_WIDTH, SCREEN_HEIGHT, 0);
 #endif
     if (!window) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create window: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create window: %s", SDL_GetError());
         return 0;
     }
 
@@ -321,7 +321,7 @@ int main(int argc, char *argv[])
 
     loop_data.renderer = SDL_CreateRenderer(window, NULL);
     if (!loop_data.renderer) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create renderer: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create renderer: %s", SDL_GetError());
         SDL_DestroyWindow(window);
         return 0;
     }

--- a/test/testmultiaudio.c
+++ b/test/testmultiaudio.c
@@ -86,7 +86,7 @@ test_multi_audio(const SDL_AudioDeviceID *devices, int devcount)
     }
 
     /* note that Emscripten currently doesn't run this part (but maybe only has a single audio device anyhow?) */
-    SDL_Log("Playing on all devices...\n");
+    SDL_Log("Playing on all devices...");
     streams = (SDL_AudioStream **) SDL_calloc(devcount, sizeof (SDL_AudioStream *));
     if (!streams) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!");
@@ -130,7 +130,7 @@ test_multi_audio(const SDL_AudioDeviceID *devices, int devcount)
         SDL_free(streams);
     }
 
-    SDL_Log("All done!\n");
+    SDL_Log("All done!");
 }
 
 int main(int argc, char **argv)
@@ -169,11 +169,11 @@ int main(int argc, char **argv)
 
     /* Load the SDL library */
     if (!SDLTest_CommonInit(state)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
         return 1;
     }
 
-    SDL_Log("Using audio driver: %s\n", SDL_GetCurrentAudioDriver());
+    SDL_Log("Using audio driver: %s", SDL_GetCurrentAudioDriver());
 
     filename = GetResourceFilename(filename, "sample.wav");
 
@@ -186,7 +186,7 @@ int main(int argc, char **argv)
             test_multi_audio(devices, devcount);
             SDL_free(sound);
         } else {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't load %s: %s\n", filename,
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't load %s: %s", filename,
                          SDL_GetError());
         }
         SDL_free(devices);

--- a/test/testnative.c
+++ b/test/testnative.c
@@ -120,7 +120,7 @@ int main(int argc, char *argv[])
     }
 
     if (!SDL_Init(SDL_INIT_VIDEO)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL video: %s\n",
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL video: %s",
                      SDL_GetError());
         exit(1);
     }
@@ -134,14 +134,14 @@ int main(int argc, char *argv[])
         }
     }
     if (!factory) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't find native window code for %s driver\n",
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't find native window code for %s driver",
                      driver);
         quit(2);
     }
-    SDL_Log("Creating native window for %s driver\n", driver);
+    SDL_Log("Creating native window for %s driver", driver);
     native_window = factory->CreateNativeWindow(WINDOW_W, WINDOW_H);
     if (!native_window) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create native window\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create native window");
         quit(3);
     }
     props = SDL_CreateProperties();
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
     window = SDL_CreateWindowWithProperties(props);
     SDL_DestroyProperties(props);
     if (!window) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create SDL window: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create SDL window: %s", SDL_GetError());
         quit(4);
     }
     SDL_SetWindowTitle(window, "SDL Native Window Test");
@@ -160,7 +160,7 @@ int main(int argc, char *argv[])
     /* Create the renderer */
     renderer = SDL_CreateRenderer(window, NULL);
     if (!renderer) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create renderer: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create renderer: %s", SDL_GetError());
         quit(5);
     }
 
@@ -178,7 +178,7 @@ int main(int argc, char *argv[])
     positions = (SDL_FRect *)SDL_malloc(NUM_SPRITES * sizeof(*positions));
     velocities = (SDL_FRect *)SDL_malloc(NUM_SPRITES * sizeof(*velocities));
     if (!positions || !velocities) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!");
         quit(2);
     }
     for (i = 0; i < NUM_SPRITES; ++i) {

--- a/test/testoffscreen.c
+++ b/test/testoffscreen.c
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
     /* Force the offscreen renderer, if it cannot be created then fail out */
     SDL_SetHint(SDL_HINT_VIDEO_DRIVER, "offscreen");
     if (!SDL_InitSubSystem(SDL_INIT_VIDEO)) {
-        SDL_Log("Couldn't initialize the offscreen video driver: %s\n",
+        SDL_Log("Couldn't initialize the offscreen video driver: %s",
                 SDL_GetError());
         return 1;
     }
@@ -117,14 +117,14 @@ int main(int argc, char *argv[])
     window = SDL_CreateWindow("Offscreen Test", width, height, 0);
 
     if (!window) {
-        SDL_Log("Couldn't create window: %s\n", SDL_GetError());
+        SDL_Log("Couldn't create window: %s", SDL_GetError());
         return 1;
     }
 
     renderer = SDL_CreateRenderer(window, NULL);
 
     if (!renderer) {
-        SDL_Log("Couldn't create renderer: %s\n",
+        SDL_Log("Couldn't create renderer: %s",
                 SDL_GetError());
         return 1;
     }
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
     done = 0;
 #endif
 
-    SDL_Log("Rendering %u frames offscreen\n", max_frames);
+    SDL_Log("Rendering %u frames offscreen", max_frames);
 
 #ifdef SDL_PLATFORM_EMSCRIPTEN
     emscripten_set_main_loop(loop, 0, 1);
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
             now = SDL_GetTicks();
             if (now > then) {
                 double fps = ((double)frames * 1000) / (now - then);
-                SDL_Log("Frames remaining: %" SDL_PRIu32 " rendering at %2.2f frames per second\n", max_frames - frames, fps);
+                SDL_Log("Frames remaining: %" SDL_PRIu32 " rendering at %2.2f frames per second", max_frames - frames, fps);
             }
         }
     }

--- a/test/testoverlay.c
+++ b/test/testoverlay.c
@@ -311,7 +311,7 @@ static void loop(void)
         /* Print out some timing information */
         const Uint64 then = next_fps_check - fps_check_delay;
         const double fps = ((double)frames * 1000) / (now - then);
-        SDL_Log("%2.2f frames per second\n", fps);
+        SDL_Log("%2.2f frames per second", fps);
         next_fps_check = now + fps_check_delay;
         frames = 0;
     }
@@ -347,15 +347,15 @@ int main(int argc, char **argv)
                     consumed = 2;
                     fps = SDL_atoi(argv[i + 1]);
                     if (fps == 0) {
-                        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "The --fps option requires an argument [from 1 to 1000], default is 12.\n");
+                        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "The --fps option requires an argument [from 1 to 1000], default is 12.");
                         quit(10);
                     }
                     if ((fps < 0) || (fps > 1000)) {
-                        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "The --fps option must be in range from 1 to 1000, default is 12.\n");
+                        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "The --fps option must be in range from 1 to 1000, default is 12.");
                         quit(10);
                     }
                 } else {
-                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "The --fps option requires an argument [from 1 to 1000], default is 12.\n");
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "The --fps option requires an argument [from 1 to 1000], default is 12.");
                     quit(10);
                 }
             } else if (SDL_strcmp(argv[i], "--nodelay") == 0) {
@@ -369,15 +369,15 @@ int main(int argc, char **argv)
                 if (argv[i + 1]) {
                     scale = SDL_atoi(argv[i + 1]);
                     if (scale == 0) {
-                        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "The --scale option requires an argument [from 1 to 50], default is 5.\n");
+                        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "The --scale option requires an argument [from 1 to 50], default is 5.");
                         quit(10);
                     }
                     if ((scale < 0) || (scale > 50)) {
-                        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "The --scale option must be in range from 1 to 50, default is 5.\n");
+                        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "The --scale option must be in range from 1 to 50, default is 5.");
                         quit(10);
                     }
                 } else {
-                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "The --fps option requires an argument [from 1 to 1000], default is 12.\n");
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "The --fps option requires an argument [from 1 to 1000], default is 12.");
                     quit(10);
                 }
             } else if (SDL_strcmp(argv[i], "--yuvformat") == 0) {
@@ -400,11 +400,11 @@ int main(int argc, char **argv)
                     } else if (SDL_strcmp(fmt, "NV21") == 0) {
                         yuv_format = SDL_PIXELFORMAT_NV21;
                     } else {
-                        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "The --yuvformat option requires one of the: YV12 (default), IYUV, YUY2, UYVY, YVYU, NV12, NV21)\n");
+                        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "The --yuvformat option requires one of the: YV12 (default), IYUV, YUY2, UYVY, YVYU, NV12, NV21)");
                         quit(10);
                     }
                 } else {
-                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "The --yuvformat option requires one of the: YV12 (default), IYUV, YUY2, UYVY, YVYU, NV12, NV21)\n");
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "The --yuvformat option requires one of the: YV12 (default), IYUV, YUY2, UYVY, YVYU, NV12, NV21)");
                     quit(10);
                 }
             }
@@ -435,20 +435,20 @@ int main(int argc, char **argv)
 
     RawMooseData = (Uint8 *)SDL_malloc(MOOSEFRAME_SIZE * MOOSEFRAMES_COUNT);
     if (!RawMooseData) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Can't allocate memory for movie !\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Can't allocate memory for movie !");
         quit(1);
     }
 
     /* load the trojan moose images */
     filename = GetResourceFilename(NULL, "moose.dat");
     if (!filename) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory");
         quit(2);
     }
     handle = SDL_IOFromFile(filename, "rb");
     SDL_free(filename);
     if (!handle) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Can't find the file moose.dat !\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Can't find the file moose.dat !");
         quit(2);
     }
 
@@ -461,7 +461,7 @@ int main(int argc, char **argv)
     window_h = MOOSEPIC_H * scale;
 
     if (state->num_windows != 1) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Only one window allowed\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Only one window allowed");
         quit(1);
     }
 
@@ -471,7 +471,7 @@ int main(int argc, char **argv)
         if (streaming) {
             MooseTexture = SDL_CreateTexture(renderer, yuv_format, SDL_TEXTUREACCESS_STREAMING, MOOSEPIC_W, MOOSEPIC_H);
             if (!MooseTexture) {
-                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't set create texture: %s\n", SDL_GetError());
+                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't set create texture: %s", SDL_GetError());
                 quit(5);
             }
         }

--- a/test/testplatform.c
+++ b/test/testplatform.c
@@ -50,36 +50,36 @@ static int TestTypes(bool verbose)
 
     if (badsize(sizeof(bool), 1)) {
         if (verbose) {
-            SDL_Log("sizeof(bool) != 1, instead = %u\n", (unsigned int)sizeof(bool));
+            SDL_Log("sizeof(bool) != 1, instead = %u", (unsigned int)sizeof(bool));
         }
         ++error;
     }
     if (badsize(sizeof(Uint8), 1)) {
         if (verbose) {
-            SDL_Log("sizeof(Uint8) != 1, instead = %u\n", (unsigned int)sizeof(Uint8));
+            SDL_Log("sizeof(Uint8) != 1, instead = %u", (unsigned int)sizeof(Uint8));
         }
         ++error;
     }
     if (badsize(sizeof(Uint16), 2)) {
         if (verbose) {
-            SDL_Log("sizeof(Uint16) != 2, instead = %u\n", (unsigned int)sizeof(Uint16));
+            SDL_Log("sizeof(Uint16) != 2, instead = %u", (unsigned int)sizeof(Uint16));
         }
         ++error;
     }
     if (badsize(sizeof(Uint32), 4)) {
         if (verbose) {
-            SDL_Log("sizeof(Uint32) != 4, instead = %u\n", (unsigned int)sizeof(Uint32));
+            SDL_Log("sizeof(Uint32) != 4, instead = %u", (unsigned int)sizeof(Uint32));
         }
         ++error;
     }
     if (badsize(sizeof(Uint64), 8)) {
         if (verbose) {
-            SDL_Log("sizeof(Uint64) != 8, instead = %u\n", (unsigned int)sizeof(Uint64));
+            SDL_Log("sizeof(Uint64) != 8, instead = %u", (unsigned int)sizeof(Uint64));
         }
         ++error;
     }
     if (verbose && !error) {
-        SDL_Log("All data types are the expected size.\n");
+        SDL_Log("All data types are the expected size.");
     }
 
     return error ? 1 : 0;
@@ -112,7 +112,7 @@ static int TestEndian(bool verbose)
     value_double.d = 3.141593;
 
     if (verbose) {
-        SDL_Log("Detected a %s endian machine.\n",
+        SDL_Log("Detected a %s endian machine.",
                 (SDL_BYTEORDER == SDL_LIL_ENDIAN) ? "little" : "big");
     }
     if ((*((char *)&value) >> 4) == 0x1) {
@@ -122,13 +122,13 @@ static int TestEndian(bool verbose)
     }
     if (real_byteorder != SDL_BYTEORDER) {
         if (verbose) {
-            SDL_Log("Actually a %s endian machine!\n",
+            SDL_Log("Actually a %s endian machine!",
                     (real_byteorder == SDL_LIL_ENDIAN) ? "little" : "big");
         }
         ++error;
     }
     if (verbose) {
-        SDL_Log("Detected a %s endian float word order machine.\n",
+        SDL_Log("Detected a %s endian float word order machine.",
                 (SDL_FLOATWORDORDER == SDL_LIL_ENDIAN) ? "little" : "big");
     }
     if (value_double.ui32[0] == 0x82c2bd7f && value_double.ui32[1] == 0x400921fb) {
@@ -138,40 +138,40 @@ static int TestEndian(bool verbose)
     }
     if (real_floatwordorder != SDL_FLOATWORDORDER) {
         if (verbose) {
-            SDL_Log("Actually a %s endian float word order machine!\n",
+            SDL_Log("Actually a %s endian float word order machine!",
                     (real_floatwordorder == SDL_LIL_ENDIAN) ? "little" : (real_floatwordorder == SDL_BIG_ENDIAN) ? "big"
                                                                                                                  : "unknown");
         }
         ++error;
     }
     if (verbose) {
-        SDL_Log("Value 16 = 0x%X, swapped = 0x%X\n", value16,
+        SDL_Log("Value 16 = 0x%X, swapped = 0x%X", value16,
                 SDL_Swap16(value16));
     }
     if (SDL_Swap16(value16) != swapped16) {
         if (verbose) {
-            SDL_Log("16 bit value swapped incorrectly!\n");
+            SDL_Log("16 bit value swapped incorrectly!");
         }
         ++error;
     }
     if (verbose) {
-        SDL_Log("Value 32 = 0x%" SDL_PRIX32 ", swapped = 0x%" SDL_PRIX32 "\n",
+        SDL_Log("Value 32 = 0x%" SDL_PRIX32 ", swapped = 0x%" SDL_PRIX32,
                 value32,
                 SDL_Swap32(value32));
     }
     if (SDL_Swap32(value32) != swapped32) {
         if (verbose) {
-            SDL_Log("32 bit value swapped incorrectly!\n");
+            SDL_Log("32 bit value swapped incorrectly!");
         }
         ++error;
     }
     if (verbose) {
-        SDL_Log("Value 64 = 0x%" SDL_PRIX64 ", swapped = 0x%" SDL_PRIX64 "\n", value64,
+        SDL_Log("Value 64 = 0x%" SDL_PRIX64 ", swapped = 0x%" SDL_PRIX64, value64,
                 SDL_Swap64(value64));
     }
     if (SDL_Swap64(value64) != swapped64) {
         if (verbose) {
-            SDL_Log("64 bit value swapped incorrectly!\n");
+            SDL_Log("64 bit value swapped incorrectly!");
         }
         ++error;
     }
@@ -380,14 +380,14 @@ static int Test64Bit(bool verbose)
 
         if (!t->routine(&t->a, &t->b, t->arg, &result, &t->expected_result)) {
             if (verbose) {
-                SDL_Log("%s(0x%08X%08X, 0x%08X%08X, %3d, produced: 0x%08X%08X, expected: 0x%08X%08X\n", t->operation, al[1], al[0], bl[1], bl[0],
+                SDL_Log("%s(0x%08X%08X, 0x%08X%08X, %3d, produced: 0x%08X%08X, expected: 0x%08X%08X", t->operation, al[1], al[0], bl[1], bl[0],
                         t->arg, rl[1], rl[0], el[1], el[0]);
             }
             ++failed;
         }
     }
     if (verbose && (failed == 0)) {
-        SDL_Log("All 64bit intrinsic tests passed\n");
+        SDL_Log("All 64bit intrinsic tests passed");
     }
     return failed ? 1 : 0;
 }
@@ -395,23 +395,23 @@ static int Test64Bit(bool verbose)
 static int TestCPUInfo(bool verbose)
 {
     if (verbose) {
-        SDL_Log("Number of logical CPU cores: %d\n", SDL_GetNumLogicalCPUCores());
-        SDL_Log("CPU cache line size: %d\n", SDL_GetCPUCacheLineSize());
-        SDL_Log("AltiVec %s\n", SDL_HasAltiVec() ? "detected" : "not detected");
-        SDL_Log("MMX %s\n", SDL_HasMMX() ? "detected" : "not detected");
-        SDL_Log("SSE %s\n", SDL_HasSSE() ? "detected" : "not detected");
-        SDL_Log("SSE2 %s\n", SDL_HasSSE2() ? "detected" : "not detected");
-        SDL_Log("SSE3 %s\n", SDL_HasSSE3() ? "detected" : "not detected");
-        SDL_Log("SSE4.1 %s\n", SDL_HasSSE41() ? "detected" : "not detected");
-        SDL_Log("SSE4.2 %s\n", SDL_HasSSE42() ? "detected" : "not detected");
-        SDL_Log("AVX %s\n", SDL_HasAVX() ? "detected" : "not detected");
-        SDL_Log("AVX2 %s\n", SDL_HasAVX2() ? "detected" : "not detected");
-        SDL_Log("AVX-512F %s\n", SDL_HasAVX512F() ? "detected" : "not detected");
-        SDL_Log("ARM SIMD %s\n", SDL_HasARMSIMD() ? "detected" : "not detected");
-        SDL_Log("NEON %s\n", SDL_HasNEON() ? "detected" : "not detected");
-        SDL_Log("LSX %s\n", SDL_HasLSX() ? "detected" : "not detected");
-        SDL_Log("LASX %s\n", SDL_HasLASX() ? "detected" : "not detected");
-        SDL_Log("System RAM %d MB\n", SDL_GetSystemRAM());
+        SDL_Log("Number of logical CPU cores: %d", SDL_GetNumLogicalCPUCores());
+        SDL_Log("CPU cache line size: %d", SDL_GetCPUCacheLineSize());
+        SDL_Log("AltiVec %s", SDL_HasAltiVec() ? "detected" : "not detected");
+        SDL_Log("MMX %s", SDL_HasMMX() ? "detected" : "not detected");
+        SDL_Log("SSE %s", SDL_HasSSE() ? "detected" : "not detected");
+        SDL_Log("SSE2 %s", SDL_HasSSE2() ? "detected" : "not detected");
+        SDL_Log("SSE3 %s", SDL_HasSSE3() ? "detected" : "not detected");
+        SDL_Log("SSE4.1 %s", SDL_HasSSE41() ? "detected" : "not detected");
+        SDL_Log("SSE4.2 %s", SDL_HasSSE42() ? "detected" : "not detected");
+        SDL_Log("AVX %s", SDL_HasAVX() ? "detected" : "not detected");
+        SDL_Log("AVX2 %s", SDL_HasAVX2() ? "detected" : "not detected");
+        SDL_Log("AVX-512F %s", SDL_HasAVX512F() ? "detected" : "not detected");
+        SDL_Log("ARM SIMD %s", SDL_HasARMSIMD() ? "detected" : "not detected");
+        SDL_Log("NEON %s", SDL_HasNEON() ? "detected" : "not detected");
+        SDL_Log("LSX %s", SDL_HasLSX() ? "detected" : "not detected");
+        SDL_Log("LASX %s", SDL_HasLASX() ? "detected" : "not detected");
+        SDL_Log("System RAM %d MB", SDL_GetSystemRAM());
     }
     return 0;
 }
@@ -434,7 +434,7 @@ static int TestAssertions(bool verbose)
     {
         const SDL_AssertData *item = SDL_GetAssertionReport();
         while (item) {
-            SDL_Log("'%s', %s (%s:%d), triggered %u times, always ignore: %s.\n",
+            SDL_Log("'%s', %s (%s:%d), triggered %u times, always ignore: %s.",
                     item->condition, item->function, item->filename,
                     item->linenum, item->trigger_count,
                     item->always_ignore ? "yes" : "no");
@@ -478,7 +478,7 @@ int main(int argc, char *argv[])
     }
 
     if (verbose) {
-        SDL_Log("This system is running %s\n", SDL_GetPlatform());
+        SDL_Log("This system is running %s", SDL_GetPlatform());
     }
 
     status += TestTypes(verbose);

--- a/test/testpower.c
+++ b/test/testpower.c
@@ -22,7 +22,7 @@ report_power(void)
     const SDL_PowerState state = SDL_GetPowerInfo(&seconds, &percent);
     const char *statestr = NULL;
 
-    SDL_Log("SDL-reported power info...\n");
+    SDL_Log("SDL-reported power info...");
     switch (state) {
     case SDL_POWERSTATE_UNKNOWN:
         statestr = "Unknown";
@@ -44,18 +44,18 @@ report_power(void)
         break;
     }
 
-    SDL_Log("State: %s\n", statestr);
+    SDL_Log("State: %s", statestr);
 
     if (percent == -1) {
-        SDL_Log("Percent left: unknown\n");
+        SDL_Log("Percent left: unknown");
     } else {
-        SDL_Log("Percent left: %d%%\n", percent);
+        SDL_Log("Percent left: %d%%", percent);
     }
 
     if (seconds == -1) {
-        SDL_Log("Time left: unknown\n");
+        SDL_Log("Time left: unknown");
     } else {
-        SDL_Log("Time left: %d minutes, %d seconds\n", seconds / 60, seconds % 60);
+        SDL_Log("Time left: %d minutes, %d seconds", seconds / 60, seconds % 60);
     }
 }
 
@@ -75,7 +75,7 @@ int main(int argc, char *argv[])
     }
 
     if (!SDL_Init(0)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_Init() failed: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_Init() failed: %s", SDL_GetError());
         return 1;
     }
 

--- a/test/testqsort.c
+++ b/test/testqsort.c
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
                     seed_seen = 1;
                     consumed = 1;
                 } else {
-                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Invalid seed. Use a decimal or hexadecimal number.\n");
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Invalid seed. Use a decimal or hexadecimal number.");
                     return 1;
                 }
             }
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
     if (!seed_seen) {
         seed = SDL_GetPerformanceCounter();
     }
-    SDL_Log("Using random seed 0x%" SDL_PRIx64 "\n", seed);
+    SDL_Log("Using random seed 0x%" SDL_PRIx64, seed);
 
     for (iteration = 0; iteration < SDL_arraysize(itervals); iteration++) {
         const int arraylen = itervals[iteration];

--- a/test/testrendercopyex.c
+++ b/test/testrendercopyex.c
@@ -161,7 +161,7 @@ int main(int argc, char *argv[])
     now = SDL_GetTicks();
     if (now > then) {
         double fps = ((double)frames * 1000) / (now - then);
-        SDL_Log("%2.2f frames per second\n", fps);
+        SDL_Log("%2.2f frames per second", fps);
     }
 
     SDL_stack_free(drawstates);

--- a/test/testrendertarget.c
+++ b/test/testrendertarget.c
@@ -79,7 +79,7 @@ DrawComposite(DrawState *s)
         if (surface) {
             Uint8 r, g, b, a;
             if (SDL_ReadSurfacePixel(surface, 0, 0, &r, &g, &b, &a)) {
-                SDL_Log("Blended pixel: 0x%.2x%.2x%.2x%.2x\n", r, g, b, a);
+                SDL_Log("Blended pixel: 0x%.2x%.2x%.2x%.2x", r, g, b, a);
             }
             SDL_DestroySurface(surface);
         }
@@ -148,7 +148,7 @@ Draw(DrawState *s)
 
     target = SDL_CreateTexture(s->renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_TARGET, viewport.w, viewport.h);
     if (!target) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create render target texture: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create render target texture: %s", SDL_GetError());
         return false;
     }
     SDL_SetRenderTarget(s->renderer, target);
@@ -283,7 +283,7 @@ int main(int argc, char *argv[])
     now = SDL_GetTicks();
     if (now > then) {
         double fps = ((double)frames * 1000) / (now - then);
-        SDL_Log("%2.2f frames per second\n", fps);
+        SDL_Log("%2.2f frames per second", fps);
     }
 
     SDL_stack_free(drawstates);

--- a/test/testresample.c
+++ b/test/testresample.c
@@ -93,20 +93,20 @@ int main(int argc, char **argv)
     }
 
     if (!SDL_Init(SDL_INIT_AUDIO)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_Init() failed: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_Init() failed: %s", SDL_GetError());
         ret = 2;
         goto end;
     }
 
     if (!SDL_LoadWAV(file_in, &spec, &data, &len)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "failed to load %s: %s\n", file_in, SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "failed to load %s: %s", file_in, SDL_GetError());
         ret = 3;
         goto end;
     }
 
     cvtspec.format = spec.format;
     if (!SDL_ConvertAudioSamples(&spec, data, len, &cvtspec, &dst_buf, &dst_len)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "failed to convert samples: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "failed to convert samples: %s", SDL_GetError());
         ret = 4;
         goto end;
     }
@@ -114,7 +114,7 @@ int main(int argc, char **argv)
     /* write out a WAV header... */
     io = SDL_IOFromFile(file_out, "wb");
     if (!io) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "opening '%s' failed: %s\n", file_out, SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "opening '%s' failed: %s", file_out, SDL_GetError());
         ret = 5;
         goto end;
     }
@@ -139,7 +139,7 @@ int main(int argc, char **argv)
     SDL_WriteIO(io, dst_buf, dst_len);
 
     if (!SDL_CloseIO(io)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "closing '%s' failed: %s\n", file_out, SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "closing '%s' failed: %s", file_out, SDL_GetError());
         ret = 6;
         goto end;
     }

--- a/test/testrumble.c
+++ b/test/testrumble.c
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
         if (consumed <= 0) {
             static const char *options[] = { "[device]", NULL };
             SDLTest_CommonLogUsage(state, argv[0], options);
-            SDL_Log("\n");
+            SDL_Log("%s", "");
             SDL_Log("If device is a two-digit number it'll use it as an index, otherwise\n"
                     "it'll use it as if it were part of the device's name.\n");
             return 1;
@@ -84,9 +84,9 @@ int main(int argc, char **argv)
     /* Initialize the force feedbackness */
     SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK | SDL_INIT_HAPTIC);
     haptics = SDL_GetHaptics(&num_haptics);
-    SDL_Log("%d Haptic devices detected.\n", num_haptics);
+    SDL_Log("%d Haptic devices detected.", num_haptics);
     if (num_haptics == 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "No Haptic devices found!\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "No Haptic devices found!");
         SDL_free(haptics);
         return 1;
     }
@@ -96,7 +96,7 @@ int main(int argc, char **argv)
         i = (index != -1) ? index : 0;
 
         if (i >= num_haptics) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Index out of range, aborting.\n");
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Index out of range, aborting.");
             SDL_free(haptics);
             return 1;
         }
@@ -110,7 +110,7 @@ int main(int argc, char **argv)
         }
 
         if (i >= num_haptics) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to find device matching '%s', aborting.\n", name);
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to find device matching '%s', aborting.", name);
             SDL_free(haptics);
             return 1;
         }
@@ -118,36 +118,36 @@ int main(int argc, char **argv)
 
     haptic = SDL_OpenHaptic(haptics[i]);
     if (!haptic) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to create the haptic device: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to create the haptic device: %s", SDL_GetError());
         SDL_free(haptics);
         return 1;
     }
-    SDL_Log("Device: %s\n", SDL_GetHapticName(haptic));
+    SDL_Log("Device: %s", SDL_GetHapticName(haptic));
     SDL_free(haptics);
 
     /* We only want force feedback errors. */
     SDL_ClearError();
 
     if (!SDL_HapticRumbleSupported(haptic)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Rumble not supported!\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Rumble not supported!");
         return 1;
     }
     if (!SDL_InitHapticRumble(haptic)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to initialize rumble: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to initialize rumble: %s", SDL_GetError());
         return 1;
     }
-    SDL_Log("Playing 2 second rumble at 0.5 magnitude.\n");
+    SDL_Log("Playing 2 second rumble at 0.5 magnitude.");
     if (!SDL_PlayHapticRumble(haptic, 0.5, 5000)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to play rumble: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to play rumble: %s", SDL_GetError());
         return 1;
     }
     SDL_Delay(2000);
-    SDL_Log("Stopping rumble.\n");
+    SDL_Log("Stopping rumble.");
     SDL_StopHapticRumble(haptic);
     SDL_Delay(2000);
-    SDL_Log("Playing 2 second rumble at 0.3 magnitude.\n");
+    SDL_Log("Playing 2 second rumble at 0.3 magnitude.");
     if (!SDL_PlayHapticRumble(haptic, 0.3f, 5000)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to play rumble: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to play rumble: %s", SDL_GetError());
         return 1;
     }
     SDL_Delay(2000);

--- a/test/testrwlock.c
+++ b/test/testrwlock.c
@@ -34,16 +34,16 @@ static void DoWork(const int workticks)  /* "Work" */
     const bool is_reader = tid != mainthread;
     const char *typestr = is_reader ? "Reader" : "Writer";
 
-    SDL_Log("%s Thread %" SDL_PRIu64 ": ready to work\n", typestr, tid);
+    SDL_Log("%s Thread %" SDL_PRIu64 ": ready to work", typestr, tid);
     if (is_reader) {
         SDL_LockRWLockForReading(rwlock);
     } else {
         SDL_LockRWLockForWriting(rwlock);
     }
 
-    SDL_Log("%s Thread %" SDL_PRIu64 ": start work!\n", typestr, tid);
+    SDL_Log("%s Thread %" SDL_PRIu64 ": start work!", typestr, tid);
     SDL_Delay(workticks);
-    SDL_Log("%s Thread %" SDL_PRIu64 ": work done!\n", typestr, tid);
+    SDL_Log("%s Thread %" SDL_PRIu64 ": work done!", typestr, tid);
     SDL_UnlockRWLock(rwlock);
 
     /* If this sleep isn't done, then threads may starve */
@@ -57,7 +57,7 @@ ReaderRun(void *data)
     while (!SDL_GetAtomicInt(&doterminate)) {
         DoWork(worktime);
     }
-    SDL_Log("Reader Thread %" SDL_PRIu64 ": exiting!\n", SDL_GetCurrentThreadID());
+    SDL_Log("Reader Thread %" SDL_PRIu64 ": exiting!", SDL_GetCurrentThreadID());
     return 0;
 }
 
@@ -132,7 +132,7 @@ int main(int argc, char *argv[])
 
     /* Load the SDL library */
     if (!SDL_Init(0)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", SDL_GetError());
         return 1;
     }
 
@@ -140,20 +140,20 @@ int main(int argc, char *argv[])
 
     rwlock = SDL_CreateRWLock();
     if (!rwlock) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create rwlock: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create rwlock: %s", SDL_GetError());
         SDL_Quit();
         SDLTest_CommonDestroyState(state);
         return 1;
     }
 
     mainthread = SDL_GetCurrentThreadID();
-    SDL_Log("Writer thread: %" SDL_PRIu64 "\n", mainthread);
+    SDL_Log("Writer thread: %" SDL_PRIu64, mainthread);
     for (i = 0; i < nb_threads; ++i) {
         char name[64];
         (void)SDL_snprintf(name, sizeof(name), "Reader%d", i);
         threads[i] = SDL_CreateThread(ReaderRun, name, NULL);
         if (threads[i] == NULL) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create reader thread! %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create reader thread! %s", SDL_GetError());
         }
     }
 

--- a/test/testscale.c
+++ b/test/testscale.c
@@ -153,7 +153,7 @@ int main(int argc, char *argv[])
     now = SDL_GetTicks();
     if (now > then) {
         double fps = ((double)frames * 1000) / (now - then);
-        SDL_Log("%2.2f frames per second\n", fps);
+        SDL_Log("%2.2f frames per second", fps);
     }
 
     SDL_stack_free(drawstates);

--- a/test/testsem.c
+++ b/test/testsem.c
@@ -53,16 +53,16 @@ ThreadFuncRealWorld(void *data)
     Thread_State *state = (Thread_State *)data;
     while (alive) {
         SDL_WaitSemaphore(sem);
-        SDL_Log("Thread number %d has got the semaphore (value = %" SDL_PRIu32 ")!\n",
+        SDL_Log("Thread number %d has got the semaphore (value = %" SDL_PRIu32 ")!",
                 state->number, SDL_GetSemaphoreValue(sem));
         SDL_Delay(200);
         SDL_SignalSemaphore(sem);
-        SDL_Log("Thread number %d has released the semaphore (value = %" SDL_PRIu32 ")!\n",
+        SDL_Log("Thread number %d has released the semaphore (value = %" SDL_PRIu32 ")!",
                 state->number, SDL_GetSemaphoreValue(sem));
         ++state->loop_count;
         SDL_Delay(1); /* For the scheduler */
     }
-    SDL_Log("Thread number %d exiting.\n", state->number);
+    SDL_Log("Thread number %d exiting.", state->number);
     return 0;
 }
 
@@ -75,7 +75,7 @@ TestRealWorld(int init_sem)
 
     sem = SDL_CreateSemaphore(init_sem);
 
-    SDL_Log("Running %d threads, semaphore value = %d\n", NUM_THREADS,
+    SDL_Log("Running %d threads, semaphore value = %d", NUM_THREADS,
             init_sem);
     alive = 1;
     /* Create all the threads */
@@ -90,14 +90,15 @@ TestRealWorld(int init_sem)
     SDL_Delay(10 * 1000);
 
     /* Wait for all threads to finish */
-    SDL_Log("Waiting for threads to finish\n");
+    SDL_Log("Waiting for threads to finish");
     alive = 0;
     loop_count = 0;
     for (i = 0; i < NUM_THREADS; ++i) {
         SDL_WaitThread(thread_states[i].thread, NULL);
         loop_count += thread_states[i].loop_count;
     }
-    SDL_Log("Finished waiting for threads, ran %d loops in total\n\n", loop_count);
+    SDL_Log("Finished waiting for threads, ran %d loops in total", loop_count);
+    SDL_Log("%s", "");
 
     SDL_DestroySemaphore(sem);
 }
@@ -111,7 +112,7 @@ TestWaitTimeout(void)
     bool result;
 
     sem = SDL_CreateSemaphore(0);
-    SDL_Log("Waiting 2 seconds on semaphore\n");
+    SDL_Log("Waiting 2 seconds on semaphore");
 
     start_ticks = SDL_GetTicks();
     result = SDL_WaitSemaphoreTimeout(sem, 2000);
@@ -120,12 +121,14 @@ TestWaitTimeout(void)
     duration = end_ticks - start_ticks;
 
     /* Accept a little offset in the effective wait */
-    SDL_Log("Wait took %" SDL_PRIu64 " milliseconds\n\n", duration);
+    SDL_Log("Wait took %" SDL_PRIu64 " milliseconds", duration);
+    SDL_Log("%s", "");
     SDL_assert(duration > 1900 && duration < 2050);
 
     /* Check to make sure the return value indicates timed out */
     if (result) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_WaitSemaphoreTimeout returned: %d; expected: false\n\n", result);
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_WaitSemaphoreTimeout returned: %d; expected: false", result);
+	SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", "");
     }
 
     SDL_DestroySemaphore(sem);
@@ -140,7 +143,7 @@ TestOverheadUncontended(void)
     int i, j;
 
     sem = SDL_CreateSemaphore(0);
-    SDL_Log("Doing %d uncontended Post/Wait operations on semaphore\n", NUM_OVERHEAD_OPS * NUM_OVERHEAD_OPS_MULT);
+    SDL_Log("Doing %d uncontended Post/Wait operations on semaphore", NUM_OVERHEAD_OPS * NUM_OVERHEAD_OPS_MULT);
 
     start_ticks = SDL_GetTicks();
     for (i = 0; i < NUM_OVERHEAD_OPS_MULT; i++) {
@@ -154,7 +157,8 @@ TestOverheadUncontended(void)
     end_ticks = SDL_GetTicks();
 
     duration = end_ticks - start_ticks;
-    SDL_Log("Took %" SDL_PRIu64 " milliseconds\n\n", duration);
+    SDL_Log("Took %" SDL_PRIu64 " milliseconds", duration);
+    SDL_Log("%s", "");
 
     SDL_DestroySemaphore(sem);
 }
@@ -197,7 +201,7 @@ TestOverheadContended(bool try_wait)
     size_t len;
 
     sem = SDL_CreateSemaphore(0);
-    SDL_Log("Doing %d contended %s operations on semaphore using %d threads\n",
+    SDL_Log("Doing %d contended %s operations on semaphore using %d threads",
             NUM_OVERHEAD_OPS * NUM_OVERHEAD_OPS_MULT, try_wait ? "Post/TryWait" : "Post/WaitTimeout", NUM_THREADS);
     alive = 1;
     /* Create multiple threads to starve the semaphore and cause contention */
@@ -232,7 +236,7 @@ TestOverheadContended(bool try_wait)
     SDL_assert_release((loop_count - content_count) == NUM_OVERHEAD_OPS * NUM_OVERHEAD_OPS_MULT);
 
     duration = end_ticks - start_ticks;
-    SDL_Log("Took %" SDL_PRIu64 " milliseconds, threads %s %d out of %d times in total (%.2f%%)\n",
+    SDL_Log("Took %" SDL_PRIu64 " milliseconds, threads %s %d out of %d times in total (%.2f%%)",
             duration, try_wait ? "where contended" : "timed out", content_count,
             loop_count, ((float)content_count * 100) / loop_count);
     /* Print how many semaphores where consumed per thread */
@@ -246,8 +250,8 @@ TestOverheadContended(bool try_wait)
         (void)SDL_snprintf(textBuffer + len, sizeof(textBuffer) - len, "%d", thread_states[i].loop_count - thread_states[i].content_count);
     }
     len = SDL_strlen(textBuffer);
-    (void)SDL_snprintf(textBuffer + len, sizeof(textBuffer) - len, " }\n");
-    SDL_Log("%s\n", textBuffer);
+    (void)SDL_snprintf(textBuffer + len, sizeof(textBuffer) - len, " }");
+    SDL_Log("%s", textBuffer);
 
     SDL_DestroySemaphore(sem);
 }
@@ -300,7 +304,7 @@ int main(int argc, char **argv)
 
     /* Load the SDL library */
     if (!SDL_Init(0)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
         return 1;
     }
     (void)signal(SIGTERM, killed);

--- a/test/testsensor.c
+++ b/test/testsensor.c
@@ -39,19 +39,19 @@ static void HandleSensorEvent(SDL_SensorEvent *event)
 {
     SDL_Sensor *sensor = SDL_GetSensorFromID(event->which);
     if (!sensor) {
-        SDL_Log("Couldn't get sensor for sensor event\n");
+        SDL_Log("Couldn't get sensor for sensor event");
         return;
     }
 
     switch (SDL_GetSensorType(sensor)) {
     case SDL_SENSOR_ACCEL:
-        SDL_Log("Accelerometer update: %.2f, %.2f, %.2f\n", event->data[0], event->data[1], event->data[2]);
+        SDL_Log("Accelerometer update: %.2f, %.2f, %.2f", event->data[0], event->data[1], event->data[2]);
         break;
     case SDL_SENSOR_GYRO:
-        SDL_Log("Gyro update: %.2f, %.2f, %.2f\n", event->data[0], event->data[1], event->data[2]);
+        SDL_Log("Gyro update: %.2f, %.2f, %.2f", event->data[0], event->data[1], event->data[2]);
         break;
     default:
-        SDL_Log("Sensor update for sensor type %s\n", GetSensorTypeString(SDL_GetSensorType(sensor)));
+        SDL_Log("Sensor update for sensor type %s", GetSensorTypeString(SDL_GetSensorType(sensor)));
         break;
     }
 }
@@ -76,7 +76,7 @@ int main(int argc, char **argv)
 
     /* Load the SDL library */
     if (!SDL_Init(SDL_INIT_SENSOR)) {
-        SDL_Log("Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_Log("Couldn't initialize SDL: %s", SDL_GetError());
         SDL_Quit();
         SDLTest_CommonDestroyState(state);
         return 1;
@@ -85,10 +85,10 @@ int main(int argc, char **argv)
     sensors = SDL_GetSensors(&num_sensors);
     num_opened = 0;
 
-    SDL_Log("There are %d sensors available\n", num_sensors);
+    SDL_Log("There are %d sensors available", num_sensors);
     if (sensors) {
         for (i = 0; i < num_sensors; ++i) {
-            SDL_Log("Sensor %" SDL_PRIu32 ": %s, type %s, platform type %d\n",
+            SDL_Log("Sensor %" SDL_PRIu32 ": %s, type %s, platform type %d",
                     sensors[i],
                     SDL_GetSensorNameForID(sensors[i]),
                     GetSensorTypeString(SDL_GetSensorTypeForID(sensors[i])),
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
             if (SDL_GetSensorTypeForID(sensors[i]) != SDL_SENSOR_UNKNOWN) {
                 SDL_Sensor *sensor = SDL_OpenSensor(sensors[i]);
                 if (!sensor) {
-                    SDL_Log("Couldn't open sensor %" SDL_PRIu32 ": %s\n", sensors[i], SDL_GetError());
+                    SDL_Log("Couldn't open sensor %" SDL_PRIu32 ": %s", sensors[i], SDL_GetError());
                 } else {
                     ++num_opened;
                 }
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
         }
         SDL_free(sensors);
     }
-    SDL_Log("Opened %d sensors\n", num_opened);
+    SDL_Log("Opened %d sensors", num_opened);
 
     if (num_opened > 0) {
         bool done = false;

--- a/test/testshader.c
+++ b/test/testshader.c
@@ -145,7 +145,9 @@ static bool CompileShader(GLhandleARB shader, const char *source)
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!");
         } else {
             pglGetInfoLogARB(shader, length, NULL, info);
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to compile shader:\n%s\n%s", source, info);
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to compile shader:");
+	    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", source);
+	    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", info);
             SDL_free(info);
         }
         return false;
@@ -173,7 +175,8 @@ static bool LinkProgram(ShaderData *data)
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!");
         } else {
             pglGetInfoLogARB(data->program, length, NULL, info);
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to link program:\n%s", info);
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to link program:");
+	    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "%s", info);
             SDL_free(info);
         }
         return false;
@@ -279,7 +282,7 @@ static bool InitShaders(void)
     /* Compile all the shaders */
     for (i = 0; i < NUM_SHADERS; ++i) {
         if (!CompileShaderProgram(&shaders[i])) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to compile shader!\n");
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to compile shader!");
             return false;
         }
     }
@@ -480,20 +483,20 @@ int main(int argc, char **argv)
 
     /* Initialize SDL for video output */
     if (!SDL_Init(SDL_INIT_VIDEO)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to initialize SDL: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to initialize SDL: %s", SDL_GetError());
         exit(1);
     }
 
     /* Create a 640x480 OpenGL screen */
     window = SDL_CreateWindow("Shader Demo", 640, 480, SDL_WINDOW_OPENGL);
     if (!window) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to create OpenGL window: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to create OpenGL window: %s", SDL_GetError());
         SDL_Quit();
         exit(2);
     }
 
     if (!SDL_GL_CreateContext(window)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to create OpenGL context: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to create OpenGL context: %s", SDL_GetError());
         SDL_Quit();
         exit(2);
     }
@@ -503,7 +506,7 @@ int main(int argc, char **argv)
     SDL_free(filename);
 
     if (!surface) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to load icon.bmp: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Unable to load icon.bmp: %s", SDL_GetError());
         SDL_Quit();
         exit(3);
     }
@@ -513,9 +516,9 @@ int main(int argc, char **argv)
     /* Loop, drawing and checking events */
     InitGL(640, 480);
     if (InitShaders()) {
-        SDL_Log("Shaders supported, press SPACE to cycle them.\n");
+        SDL_Log("Shaders supported, press SPACE to cycle them.");
     } else {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Shaders not supported!\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Shaders not supported!");
     }
     done = 0;
     while (!done) {
@@ -549,7 +552,7 @@ int main(int argc, char **argv)
 
 int main(int argc, char *argv[])
 {
-    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "No OpenGL support on this system\n");
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "No OpenGL support on this system");
     return 1;
 }
 

--- a/test/testshape.c
+++ b/test/testshape.c
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
         } else if (!image_file) {
             image_file = argv[i];
         } else {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Usage: %s [--resizable] [shape.bmp]\n", argv[0]);
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Usage: %s [--resizable] [shape.bmp]", argv[0]);
             goto quit;
         }
     }
@@ -56,18 +56,18 @@ int main(int argc, char *argv[])
     if (image_file) {
         shape = SDL_LoadBMP(image_file);
         if (!shape) {
-            SDL_Log("Couldn't load %s: %s\n", image_file, SDL_GetError());
+            SDL_Log("Couldn't load %s: %s", image_file, SDL_GetError());
             goto quit;
         }
     } else {
         SDL_IOStream *stream = SDL_IOFromConstMem(glass_bmp, sizeof(glass_bmp));
         if (!stream) {
-            SDL_Log("Couldn't create iostream for glass.bmp: %s\n", SDL_GetError());
+            SDL_Log("Couldn't create iostream for glass.bmp: %s", SDL_GetError());
             goto quit;
         }
         shape = SDL_LoadBMP_IO(stream, true);
         if (!shape) {
-            SDL_Log("Couldn't load glass.bmp: %s\n", SDL_GetError());
+            SDL_Log("Couldn't load glass.bmp: %s", SDL_GetError());
             goto quit;
         }
     }
@@ -81,13 +81,13 @@ int main(int argc, char *argv[])
     }
     window = SDL_CreateWindow("SDL Shape Test", shape->w, shape->h, flags);
     if (!window) {
-        SDL_Log("Couldn't create transparent window: %s\n", SDL_GetError());
+        SDL_Log("Couldn't create transparent window: %s", SDL_GetError());
         goto quit;
     }
 
     renderer = SDL_CreateRenderer(window, NULL);
     if (!renderer) {
-        SDL_Log("Couldn't create renderer: %s\n", SDL_GetError());
+        SDL_Log("Couldn't create renderer: %s", SDL_GetError());
         goto quit;
     }
 
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
     if (!resizable) {
         /* Set the hit test callback so we can drag the window */
         if (!SDL_SetWindowHitTest(window, ShapeHitTest, shape)) {
-            SDL_Log("Couldn't set hit test callback: %s\n", SDL_GetError());
+            SDL_Log("Couldn't set hit test callback: %s", SDL_GetError());
             goto quit;
         }
     }

--- a/test/testsprite.c
+++ b/test/testsprite.c
@@ -67,7 +67,7 @@ static int LoadSprite(const char *file)
             return -1;
         }
         if (!SDL_SetTextureBlendMode(sprites[i], blendMode)) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't set blend mode: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't set blend mode: %s", SDL_GetError());
             SDL_DestroyTexture(sprites[i]);
             return -1;
         }
@@ -502,7 +502,7 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
     sprites =
         (SDL_Texture **)SDL_malloc(state->num_windows * sizeof(*sprites));
     if (!sprites) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!");
         return SDL_APP_FAILURE;
     }
     for (i = 0; i < state->num_windows; ++i) {
@@ -518,7 +518,7 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
     positions = (SDL_FRect *)SDL_malloc(num_sprites * sizeof(*positions));
     velocities = (SDL_FRect *)SDL_malloc(num_sprites * sizeof(*velocities));
     if (!positions || !velocities) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory!");
         return SDL_APP_FAILURE;
     }
 
@@ -588,7 +588,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
         /* Print out some timing information */
         const Uint64 then = next_fps_check - fps_check_delay;
         const double fps = ((double)frames * 1000) / (now - then);
-        SDL_Log("%2.2f frames per second\n", fps);
+        SDL_Log("%2.2f frames per second", fps);
         next_fps_check = now + fps_check_delay;
         frames = 0;
     }

--- a/test/testspriteminimal.c
+++ b/test/testspriteminimal.c
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
     int i;
 
     if (argc > 1) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "USAGE: %s\n", argv[0]);
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "USAGE: %s", argv[0]);
         return_code = 1;
         goto quit;
     }

--- a/test/testspritesurface.c
+++ b/test/testspritesurface.c
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
     int i;
 
     if (argc > 1) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "USAGE: %s\n", argv[0]);
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "USAGE: %s", argv[0]);
         return_code = 1;
         goto quit;
     }

--- a/test/teststreaming.c
+++ b/test/teststreaming.c
@@ -86,7 +86,7 @@ static void UpdateTexture(SDL_Texture *texture)
     int pitch;
 
     if (!SDL_LockTexture(texture, NULL, &pixels, &pitch)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't lock texture: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't lock texture: %s", SDL_GetError());
         quit(5);
     }
     src = MooseFrames[frame];
@@ -152,20 +152,20 @@ int main(int argc, char **argv)
     }
 
     if (!SDL_Init(SDL_INIT_VIDEO)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
         return 1;
     }
 
     /* load the moose images */
     filename = GetResourceFilename(NULL, "moose.dat");
     if (!filename) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Out of memory");
         return -1;
     }
     handle = SDL_IOFromFile(filename, "rb");
     SDL_free(filename);
     if (!handle) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Can't find the file moose.dat !\n");
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Can't find the file moose.dat !");
         quit(2);
     }
     SDL_ReadIO(handle, MooseFrames, MOOSEFRAME_SIZE * MOOSEFRAMES_COUNT);
@@ -174,19 +174,19 @@ int main(int argc, char **argv)
     /* Create the window and renderer */
     window = SDL_CreateWindow("Happy Moose", MOOSEPIC_W * 4, MOOSEPIC_H * 4, SDL_WINDOW_RESIZABLE);
     if (!window) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't set create window: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't set create window: %s", SDL_GetError());
         quit(3);
     }
 
     renderer = SDL_CreateRenderer(window, NULL);
     if (!renderer) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't set create renderer: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't set create renderer: %s", SDL_GetError());
         quit(4);
     }
 
     MooseTexture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, MOOSEPIC_W, MOOSEPIC_H);
     if (!MooseTexture) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't set create texture: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't set create texture: %s", SDL_GetError());
         quit(5);
     }
 

--- a/test/testsurround.c
+++ b/test/testsurround.c
@@ -209,7 +209,7 @@ int main(int argc, char *argv[])
     }
 
     if (!SDL_Init(SDL_INIT_AUDIO)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
         return 1;
     }
 
@@ -219,11 +219,11 @@ int main(int argc, char *argv[])
         SDL_Log("%i: %s", i, SDL_GetAudioDriver(i));
     }
 
-    SDL_Log("Using audio driver: %s\n", SDL_GetCurrentAudioDriver());
+    SDL_Log("Using audio driver: %s", SDL_GetCurrentAudioDriver());
 
     devices = SDL_GetAudioPlaybackDevices(&devcount);
     if (!devices) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_GetAudioPlaybackDevices() failed: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_GetAudioPlaybackDevices() failed: %s", SDL_GetError());
     }
 
     SDL_Log("Available audio devices:");
@@ -237,14 +237,14 @@ int main(int argc, char *argv[])
         int j;
         SDL_AudioSpec spec;
 
-        SDL_Log("Testing audio device: %s\n", devname);
+        SDL_Log("Testing audio device: %s", devname);
 
         if (!SDL_GetAudioDeviceFormat(devices[i], &spec, NULL)) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_GetAudioDeviceFormat() failed: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_GetAudioDeviceFormat() failed: %s", SDL_GetError());
             continue;
         }
 
-        SDL_Log("  (%d channels)\n", spec.channels);
+        SDL_Log("  (%d channels)", spec.channels);
 
         spec.freq = SAMPLE_RATE_HZ;
         spec.format = SDL_AUDIO_S16;
@@ -255,7 +255,7 @@ int main(int argc, char *argv[])
 
         stream = SDL_OpenAudioDeviceStream(devices[i], &spec, fill_buffer, NULL);
         if (!stream) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_OpenAudioDeviceStream() failed: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_OpenAudioDeviceStream() failed: %s", SDL_GetError());
             continue;
         }
         SDL_ResumeAudioStreamDevice(stream);
@@ -263,7 +263,7 @@ int main(int argc, char *argv[])
         for (j = 0; j < total_channels; j++) {
             const int sine_freq = is_lfe_channel(j, total_channels) ? LFE_SINE_FREQ_HZ : SINE_FREQ_HZ;
 
-            SDL_Log("Playing %d Hz test tone on channel: %s\n", sine_freq, get_channel_name(j, total_channels));
+            SDL_Log("Playing %d Hz test tone on channel: %s", sine_freq, get_channel_name(j, total_channels));
 
             /* fill_buffer() will increment the active channel */
             if (SDL_GetEnvironmentVariable(SDL_GetEnvironment(), "SDL_TESTS_QUICK") != NULL) {

--- a/test/testthread.c
+++ b/test/testthread.c
@@ -60,13 +60,13 @@ ThreadFunc(void *data)
     SDL_ThreadPriority prio = SDL_THREAD_PRIORITY_NORMAL;
 
     SDL_SetTLS(&tls, "baby thread", NULL);
-    SDL_Log("Started thread %s: My thread id is %" SDL_PRIu64 ", thread data = %s\n",
+    SDL_Log("Started thread %s: My thread id is %" SDL_PRIu64 ", thread data = %s",
             (char *)data, SDL_GetCurrentThreadID(), (const char *)SDL_GetTLS(&tls));
     while (SDL_GetAtomicInt(&alive)) {
-        SDL_Log("Thread '%s' is alive!\n", (char *)data);
+        SDL_Log("Thread '%s' is alive!", (char *)data);
 
         if (testprio) {
-            SDL_Log("SDL_SetCurrentThreadPriority(%s):%d\n", getprioritystr(prio), SDL_SetCurrentThreadPriority(prio));
+            SDL_Log("SDL_SetCurrentThreadPriority(%s):%d", getprioritystr(prio), SDL_SetCurrentThreadPriority(prio));
             if (++prio > SDL_THREAD_PRIORITY_TIME_CRITICAL) {
                 prio = SDL_THREAD_PRIORITY_LOW;
             }
@@ -74,14 +74,14 @@ ThreadFunc(void *data)
 
         SDL_Delay(1 * 1000);
     }
-    SDL_Log("Thread '%s' exiting!\n", (char *)data);
+    SDL_Log("Thread '%s' exiting!", (char *)data);
     return 0;
 }
 
 static void
 killed(int sig)
 {
-    SDL_Log("Killed with SIGTERM, waiting 5 seconds to exit\n");
+    SDL_Log("Killed with SIGTERM, waiting 5 seconds to exit");
     SDL_Delay(5 * 1000);
     SDL_SetAtomicInt(&alive, 0);
     SDL_WaitThread(thread, NULL);
@@ -120,7 +120,7 @@ int main(int argc, char *argv[])
 
     /* Load the SDL library */
     if (!SDL_Init(0)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());
         return 1;
     }
 
@@ -131,26 +131,26 @@ int main(int argc, char *argv[])
     }
 
     SDL_SetTLS(&tls, "main thread", NULL);
-    SDL_Log("Main thread data initially: %s\n", (const char *)SDL_GetTLS(&tls));
+    SDL_Log("Main thread data initially: %s", (const char *)SDL_GetTLS(&tls));
 
     SDL_SetAtomicInt(&alive, 1);
     thread = SDL_CreateThread(ThreadFunc, "One", "#1");
     if (!thread) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create thread: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create thread: %s", SDL_GetError());
         quit(1);
     }
     SDL_Delay(5 * 1000);
-    SDL_Log("Waiting for thread #1\n");
+    SDL_Log("Waiting for thread #1");
     SDL_SetAtomicInt(&alive, 0);
     SDL_WaitThread(thread, NULL);
 
-    SDL_Log("Main thread data finally: %s\n", (const char *)SDL_GetTLS(&tls));
+    SDL_Log("Main thread data finally: %s", (const char *)SDL_GetTLS(&tls));
 
     SDL_SetAtomicInt(&alive, 1);
     (void)signal(SIGTERM, killed);
     thread = SDL_CreateThread(ThreadFunc, "Two", "#2");
     if (!thread) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create thread: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create thread: %s", SDL_GetError());
         quit(1);
     }
     (void)raise(SIGTERM);

--- a/test/testtimer.c
+++ b/test/testtimer.c
@@ -68,7 +68,7 @@ callback(void *param, SDL_TimerID timerID, Uint32 interval)
 {
     int value = (int)(uintptr_t)param;
     SDL_assert( value == 1 || value == 2 || value == 3 );
-    SDL_Log("Timer %" SDL_PRIu32 " : param = %d\n", interval, value);
+    SDL_Log("Timer %" SDL_PRIu32 " : param = %d", interval, value);
     return interval;
 }
 
@@ -123,13 +123,13 @@ int main(int argc, char *argv[])
     }
 
     /* Verify SDL_GetTicks* acts monotonically increasing, and not erratic. */
-    SDL_Log("Sanity-checking GetTicks\n");
+    SDL_Log("Sanity-checking GetTicks");
     for (i = 0; i < 1000; ++i) {
         start = SDL_GetTicks();
         SDL_Delay(1);
         now = SDL_GetTicks() - start;
         if (now > 100) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "testtimer.c: Delta time erratic at iter %d. Delay 1ms = %d ms in ticks\n", i, (int)now);
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "testtimer.c: Delta time erratic at iter %d. Delay 1ms = %d ms in ticks", i, (int)now);
             SDL_Quit();
             return 1;
         }
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
     t1 = SDL_AddTimer(desired, ticktock, NULL);
 
     /* Wait 1 seconds */
-    SDL_Log("Waiting 1 seconds for millisecond timer\n");
+    SDL_Log("Waiting 1 seconds for millisecond timer");
     SDL_Delay(1 * 1000);
 
     /* Stop the timer */
@@ -151,7 +151,7 @@ int main(int argc, char *argv[])
 
     /* Print the results */
     if (ticks) {
-        SDL_Log("Millisecond timer resolution: desired = %d ms, actual = %f ms\n",
+        SDL_Log("Millisecond timer resolution: desired = %d ms, actual = %f ms",
                 desired, (double)(10 * 1000) / ticks);
     }
 
@@ -163,7 +163,7 @@ int main(int argc, char *argv[])
     t1 = SDL_AddTimerNS(desired, ticktockNS, NULL);
 
     /* Wait 1 seconds */
-    SDL_Log("Waiting 1 seconds for nanosecond timer\n");
+    SDL_Log("Waiting 1 seconds for nanosecond timer");
     SDL_Delay(1 * 1000);
 
     /* Stop the timer */
@@ -171,7 +171,7 @@ int main(int argc, char *argv[])
 
     /* Print the results */
     if (ticks) {
-        SDL_Log("Nanosecond timer resolution: desired = %d ns, actual = %f ns\n",
+        SDL_Log("Nanosecond timer resolution: desired = %d ns, actual = %f ns",
                 desired, (double)(10 * 1000000) / ticks);
     }
 
@@ -188,9 +188,9 @@ int main(int argc, char *argv[])
         SDL_DelayNS(1);
         now = SDL_GetTicksNS();
         actual_delay = (now - start);
-        SDL_Log("Minimum nanosecond delay: %" SDL_PRIu64 " ns\n", actual_delay);
+        SDL_Log("Minimum nanosecond delay: %" SDL_PRIu64 " ns", actual_delay);
 
-        SDL_Log("Timing 100 frames at 60 FPS\n");
+        SDL_Log("Timing 100 frames at 60 FPS");
         for (i = 0; i < 100; ++i) {
             start = SDL_GetTicksNS();
             SDL_DelayNS(desired_delay);
@@ -200,7 +200,7 @@ int main(int argc, char *argv[])
                 total_overslept += (actual_delay - desired_delay);
             }
         }
-        SDL_Log("Overslept %.2f ms\n", (double)total_overslept / SDL_NS_PER_MS);
+        SDL_Log("Overslept %.2f ms", (double)total_overslept / SDL_NS_PER_MS);
     }
 
     /* Wait for the results to be seen */
@@ -216,9 +216,9 @@ int main(int argc, char *argv[])
         SDL_DelayPrecise(1);
         now = SDL_GetTicksNS();
         actual_delay = (now - start);
-        SDL_Log("Minimum precise delay: %" SDL_PRIu64 " ns\n", actual_delay);
+        SDL_Log("Minimum precise delay: %" SDL_PRIu64 " ns", actual_delay);
 
-        SDL_Log("Timing 100 frames at 60 FPS\n");
+        SDL_Log("Timing 100 frames at 60 FPS");
         for (i = 0; i < 100; ++i) {
             start = SDL_GetTicksNS();
             SDL_DelayPrecise(desired_delay);
@@ -228,32 +228,32 @@ int main(int argc, char *argv[])
                 total_overslept += (actual_delay - desired_delay);
             }
         }
-        SDL_Log("Overslept %.2f ms\n", (double)total_overslept / SDL_NS_PER_MS);
+        SDL_Log("Overslept %.2f ms", (double)total_overslept / SDL_NS_PER_MS);
     }
 
     /* Wait for the results to be seen */
     SDL_Delay(1 * 1000);
 
     /* Test multiple timers */
-    SDL_Log("Testing multiple timers...\n");
+    SDL_Log("Testing multiple timers...");
     t1 = SDL_AddTimer(100, callback, (void *)1);
     if (!t1) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Could not create timer 1: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Could not create timer 1: %s", SDL_GetError());
     }
     t2 = SDL_AddTimer(50, callback, (void *)2);
     if (!t2) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Could not create timer 2: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Could not create timer 2: %s", SDL_GetError());
     }
     t3 = SDL_AddTimer(233, callback, (void *)3);
     if (!t3) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Could not create timer 3: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Could not create timer 3: %s", SDL_GetError());
     }
 
     /* Wait 3 seconds */
-    SDL_Log("Waiting 3 seconds\n");
+    SDL_Log("Waiting 3 seconds");
     SDL_Delay(3 * 1000);
 
-    SDL_Log("Removing timer 1 and waiting 3 more seconds\n");
+    SDL_Log("Removing timer 1 and waiting 3 more seconds");
     SDL_RemoveTimer(t1);
 
     SDL_Delay(3 * 1000);
@@ -267,15 +267,15 @@ int main(int argc, char *argv[])
         ticktock(NULL, 0, 0);
     }
     now_perf = SDL_GetPerformanceCounter();
-    SDL_Log("1 million iterations of ticktock took %f ms\n", (double)((now_perf - start_perf) * 1000) / SDL_GetPerformanceFrequency());
+    SDL_Log("1 million iterations of ticktock took %f ms", (double)((now_perf - start_perf) * 1000) / SDL_GetPerformanceFrequency());
 
-    SDL_Log("Performance counter frequency: %" SDL_PRIu64 "\n", SDL_GetPerformanceFrequency());
+    SDL_Log("Performance counter frequency: %" SDL_PRIu64, SDL_GetPerformanceFrequency());
     start = SDL_GetTicks();
     start_perf = SDL_GetPerformanceCounter();
     SDL_Delay(1000);
     now_perf = SDL_GetPerformanceCounter();
     now = SDL_GetTicks();
-    SDL_Log("Delay 1 second = %d ms in ticks, %f ms according to performance counter\n", (int)(now - start), (double)((now_perf - start_perf) * 1000) / SDL_GetPerformanceFrequency());
+    SDL_Log("Delay 1 second = %d ms in ticks, %f ms according to performance counter", (int)(now - start), (double)((now_perf - start_perf) * 1000) / SDL_GetPerformanceFrequency());
 
     if (run_interactive_tests) {
         return_code = test_sdl_delay_within_bounds();

--- a/test/testtray.c
+++ b/test/testtray.c
@@ -52,7 +52,7 @@ static void SDLCALL change_icon(void *ptr, SDL_TrayEntry *entry)
 
 static void SDLCALL print_entry(void *ptr, SDL_TrayEntry *entry)
 {
-    SDL_Log("Clicked on button '%s'\n", SDL_GetTrayEntryLabel(entry));
+    SDL_Log("Clicked on button '%s'", SDL_GetTrayEntryLabel(entry));
 }
 
 static void SDLCALL set_entry_enabled(void *ptr, SDL_TrayEntry *entry)
@@ -88,7 +88,7 @@ static void SDLCALL remove_entry(void *ptr, SDL_TrayEntry *entry)
     SDL_TrayEntry *ctrl_entry = SDL_GetTrayMenuParentEntry(ctrl_submenu);
 
     if (!ctrl_entry) {
-        SDL_Log("Attempt to remove a menu that isn't a submenu. This shouldn't happen.\n");
+        SDL_Log("Attempt to remove a menu that isn't a submenu. This shouldn't happen.");
         return;
     }
 
@@ -108,7 +108,7 @@ static void SDLCALL append_button_to(void *ptr, SDL_TrayEntry *entry)
     new_ctrl = SDL_InsertTrayEntryAt(SDL_GetTrayEntryParent(entry), -1, "New button", SDL_TRAYENTRY_SUBMENU);
 
     if (!new_ctrl) {
-        SDL_Log("Couldn't insert entry in control tray: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert entry in control tray: %s", SDL_GetError());
         return;
     }
 
@@ -117,7 +117,7 @@ static void SDLCALL append_button_to(void *ptr, SDL_TrayEntry *entry)
     submenu = SDL_CreateTraySubmenu(new_ctrl);
 
     if (!new_ctrl) {
-        SDL_Log("Couldn't create control tray entry submenu: %s\n", SDL_GetError());
+        SDL_Log("Couldn't create control tray entry submenu: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         return;
     }
@@ -127,7 +127,7 @@ static void SDLCALL append_button_to(void *ptr, SDL_TrayEntry *entry)
     new_example = SDL_InsertTrayEntryAt(menu, -1, "New button", SDL_TRAYENTRY_BUTTON);
 
     if (new_example == NULL) {
-        SDL_Log("Couldn't insert entry in example tray: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert entry in example tray: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         return;
     }
@@ -139,7 +139,7 @@ static void SDLCALL append_button_to(void *ptr, SDL_TrayEntry *entry)
     new_ctrl_remove = SDL_InsertTrayEntryAt(submenu, -1, "Remove", SDL_TRAYENTRY_BUTTON);
 
     if (new_ctrl_remove == NULL) {
-        SDL_Log("Couldn't insert new_ctrl_remove: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert new_ctrl_remove: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         SDL_RemoveTrayEntry(new_example);
         return;
@@ -152,7 +152,7 @@ static void SDLCALL append_button_to(void *ptr, SDL_TrayEntry *entry)
     new_ctrl_enabled = SDL_InsertTrayEntryAt(submenu, -1, "Enable", SDL_TRAYENTRY_BUTTON);
 
     if (new_ctrl_enabled == NULL) {
-        SDL_Log("Couldn't insert new_ctrl_enabled: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert new_ctrl_enabled: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         SDL_RemoveTrayEntry(new_example);
         return;
@@ -165,7 +165,7 @@ static void SDLCALL append_button_to(void *ptr, SDL_TrayEntry *entry)
     new_ctrl_disabled = SDL_InsertTrayEntryAt(submenu, -1, "Disable", SDL_TRAYENTRY_BUTTON);
 
     if (new_ctrl_disabled == NULL) {
-        SDL_Log("Couldn't insert new_ctrl_disabled: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert new_ctrl_disabled: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         SDL_RemoveTrayEntry(new_example);
         return;
@@ -189,7 +189,7 @@ static void SDLCALL append_checkbox_to(void *ptr, SDL_TrayEntry *entry)
     new_ctrl = SDL_InsertTrayEntryAt(SDL_GetTrayEntryParent(entry), -1, "New checkbox", SDL_TRAYENTRY_SUBMENU);
 
     if (!new_ctrl) {
-        SDL_Log("Couldn't insert entry in control tray: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert entry in control tray: %s", SDL_GetError());
         return;
     }
 
@@ -198,7 +198,7 @@ static void SDLCALL append_checkbox_to(void *ptr, SDL_TrayEntry *entry)
     submenu = SDL_CreateTraySubmenu(new_ctrl);
 
     if (!new_ctrl) {
-        SDL_Log("Couldn't create control tray entry submenu: %s\n", SDL_GetError());
+        SDL_Log("Couldn't create control tray entry submenu: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         return;
     }
@@ -208,7 +208,7 @@ static void SDLCALL append_checkbox_to(void *ptr, SDL_TrayEntry *entry)
     new_example = SDL_InsertTrayEntryAt(menu, -1, "New checkbox", SDL_TRAYENTRY_CHECKBOX);
 
     if (new_example == NULL) {
-        SDL_Log("Couldn't insert entry in example tray: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert entry in example tray: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         return;
     }
@@ -220,7 +220,7 @@ static void SDLCALL append_checkbox_to(void *ptr, SDL_TrayEntry *entry)
     new_ctrl_remove = SDL_InsertTrayEntryAt(submenu, -1, "Remove", SDL_TRAYENTRY_BUTTON);
 
     if (new_ctrl_remove == NULL) {
-        SDL_Log("Couldn't insert new_ctrl_remove: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert new_ctrl_remove: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         SDL_RemoveTrayEntry(new_example);
         return;
@@ -233,7 +233,7 @@ static void SDLCALL append_checkbox_to(void *ptr, SDL_TrayEntry *entry)
     new_ctrl_enabled = SDL_InsertTrayEntryAt(submenu, -1, "Enable", SDL_TRAYENTRY_BUTTON);
 
     if (new_ctrl_enabled == NULL) {
-        SDL_Log("Couldn't insert new_ctrl_enabled: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert new_ctrl_enabled: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         SDL_RemoveTrayEntry(new_example);
         return;
@@ -246,7 +246,7 @@ static void SDLCALL append_checkbox_to(void *ptr, SDL_TrayEntry *entry)
     new_ctrl_disabled = SDL_InsertTrayEntryAt(submenu, -1, "Disable", SDL_TRAYENTRY_BUTTON);
 
     if (new_ctrl_disabled == NULL) {
-        SDL_Log("Couldn't insert new_ctrl_disabled: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert new_ctrl_disabled: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         SDL_RemoveTrayEntry(new_example);
         return;
@@ -259,7 +259,7 @@ static void SDLCALL append_checkbox_to(void *ptr, SDL_TrayEntry *entry)
     new_ctrl_checked = SDL_InsertTrayEntryAt(submenu, -1, "Check", SDL_TRAYENTRY_BUTTON);
 
     if (new_ctrl_checked == NULL) {
-        SDL_Log("Couldn't insert new_ctrl_checked: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert new_ctrl_checked: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         SDL_RemoveTrayEntry(new_example);
         return;
@@ -272,7 +272,7 @@ static void SDLCALL append_checkbox_to(void *ptr, SDL_TrayEntry *entry)
     new_ctrl_unchecked = SDL_InsertTrayEntryAt(submenu, -1, "Uncheck", SDL_TRAYENTRY_BUTTON);
 
     if (new_ctrl_unchecked == NULL) {
-        SDL_Log("Couldn't insert new_ctrl_unchecked: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert new_ctrl_unchecked: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         SDL_RemoveTrayEntry(new_example);
         return;
@@ -292,7 +292,7 @@ static void SDLCALL append_separator_to(void *ptr, SDL_TrayEntry *entry)
     new_ctrl = SDL_InsertTrayEntryAt(SDL_GetTrayEntryParent(entry), -1, "[Separator]", SDL_TRAYENTRY_SUBMENU);
 
     if (!new_ctrl) {
-        SDL_Log("Couldn't insert entry in control tray: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert entry in control tray: %s", SDL_GetError());
         return;
     }
 
@@ -301,7 +301,7 @@ static void SDLCALL append_separator_to(void *ptr, SDL_TrayEntry *entry)
     submenu = SDL_CreateTraySubmenu(new_ctrl);
 
     if (!new_ctrl) {
-        SDL_Log("Couldn't create control tray entry submenu: %s\n", SDL_GetError());
+        SDL_Log("Couldn't create control tray entry submenu: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         return;
     }
@@ -311,7 +311,7 @@ static void SDLCALL append_separator_to(void *ptr, SDL_TrayEntry *entry)
     new_example = SDL_InsertTrayEntryAt(menu, -1, NULL, SDL_TRAYENTRY_BUTTON);
 
     if (new_example == NULL) {
-        SDL_Log("Couldn't insert separator in example tray: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert separator in example tray: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         return;
     }
@@ -321,7 +321,7 @@ static void SDLCALL append_separator_to(void *ptr, SDL_TrayEntry *entry)
     new_ctrl_remove = SDL_InsertTrayEntryAt(submenu, -1, "Remove", SDL_TRAYENTRY_BUTTON);
 
     if (new_ctrl_remove == NULL) {
-        SDL_Log("Couldn't insert new_ctrl_remove: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert new_ctrl_remove: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         SDL_RemoveTrayEntry(new_example);
         return;
@@ -344,7 +344,7 @@ static void SDLCALL append_submenu_to(void *ptr, SDL_TrayEntry *entry)
     new_ctrl = SDL_InsertTrayEntryAt(SDL_GetTrayEntryParent(entry), -1, "New submenu", SDL_TRAYENTRY_SUBMENU);
 
     if (!new_ctrl) {
-        SDL_Log("Couldn't insert entry in control tray: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert entry in control tray: %s", SDL_GetError());
         return;
     }
 
@@ -353,7 +353,7 @@ static void SDLCALL append_submenu_to(void *ptr, SDL_TrayEntry *entry)
     submenu = SDL_CreateTraySubmenu(new_ctrl);
 
     if (!new_ctrl) {
-        SDL_Log("Couldn't create control tray entry submenu: %s\n", SDL_GetError());
+        SDL_Log("Couldn't create control tray entry submenu: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         return;
     }
@@ -363,7 +363,7 @@ static void SDLCALL append_submenu_to(void *ptr, SDL_TrayEntry *entry)
     new_example = SDL_InsertTrayEntryAt(menu, -1, "New submenu", SDL_TRAYENTRY_SUBMENU);
 
     if (new_example == NULL) {
-        SDL_Log("Couldn't insert entry in example tray: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert entry in example tray: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         return;
     }
@@ -375,7 +375,7 @@ static void SDLCALL append_submenu_to(void *ptr, SDL_TrayEntry *entry)
     entry_submenu = SDL_CreateTraySubmenu(new_example);
 
     if (entry_submenu == NULL) {
-        SDL_Log("Couldn't create new entry submenu: %s\n", SDL_GetError());
+        SDL_Log("Couldn't create new entry submenu: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         SDL_RemoveTrayEntry(new_example);
         return;
@@ -386,7 +386,7 @@ static void SDLCALL append_submenu_to(void *ptr, SDL_TrayEntry *entry)
     new_ctrl_remove = SDL_InsertTrayEntryAt(submenu, -1, "Remove", SDL_TRAYENTRY_BUTTON);
 
     if (new_ctrl_remove == NULL) {
-        SDL_Log("Couldn't insert new_ctrl_remove: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert new_ctrl_remove: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         SDL_RemoveTrayEntry(new_example);
         return;
@@ -399,7 +399,7 @@ static void SDLCALL append_submenu_to(void *ptr, SDL_TrayEntry *entry)
     new_ctrl_enabled = SDL_InsertTrayEntryAt(submenu, -1, "Enable", SDL_TRAYENTRY_BUTTON);
 
     if (new_ctrl_enabled == NULL) {
-        SDL_Log("Couldn't insert new_ctrl_enabled: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert new_ctrl_enabled: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         SDL_RemoveTrayEntry(new_example);
         return;
@@ -412,7 +412,7 @@ static void SDLCALL append_submenu_to(void *ptr, SDL_TrayEntry *entry)
     new_ctrl_disabled = SDL_InsertTrayEntryAt(submenu, -1, "Disable", SDL_TRAYENTRY_BUTTON);
 
     if (new_ctrl_disabled == NULL) {
-        SDL_Log("Couldn't insert new_ctrl_disabled: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert new_ctrl_disabled: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         SDL_RemoveTrayEntry(new_example);
         return;
@@ -429,7 +429,7 @@ static void SDLCALL append_submenu_to(void *ptr, SDL_TrayEntry *entry)
     SDL_TrayEntry *entry_newbtn = SDL_InsertTrayEntryAt(submenu, -1, "Create button", SDL_TRAYENTRY_BUTTON);
 
     if (entry_newbtn == NULL) {
-        SDL_Log("Couldn't insert entry_newbtn: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert entry_newbtn: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         SDL_RemoveTrayEntry(new_example);
         return;
@@ -442,7 +442,7 @@ static void SDLCALL append_submenu_to(void *ptr, SDL_TrayEntry *entry)
     SDL_TrayEntry *entry_newchk = SDL_InsertTrayEntryAt(submenu, -1, "Create checkbox", SDL_TRAYENTRY_BUTTON);
 
     if (entry_newchk == NULL) {
-        SDL_Log("Couldn't insert entry_newchk: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert entry_newchk: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         SDL_RemoveTrayEntry(new_example);
         return;
@@ -455,7 +455,7 @@ static void SDLCALL append_submenu_to(void *ptr, SDL_TrayEntry *entry)
     SDL_TrayEntry *entry_newsub = SDL_InsertTrayEntryAt(submenu, -1, "Create submenu", SDL_TRAYENTRY_BUTTON);
 
     if (entry_newsub == NULL) {
-        SDL_Log("Couldn't insert entry_newsub: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert entry_newsub: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         SDL_RemoveTrayEntry(new_example);
         return;
@@ -468,7 +468,7 @@ static void SDLCALL append_submenu_to(void *ptr, SDL_TrayEntry *entry)
     SDL_TrayEntry *entry_newsep = SDL_InsertTrayEntryAt(submenu, -1, "Create separator", SDL_TRAYENTRY_BUTTON);
 
     if (entry_newsep == NULL) {
-        SDL_Log("Couldn't insert entry_newsep: %s\n", SDL_GetError());
+        SDL_Log("Couldn't insert entry_newsep: %s", SDL_GetError());
         SDL_RemoveTrayEntry(new_ctrl);
         SDL_RemoveTrayEntry(new_example);
         return;

--- a/test/testurl.c
+++ b/test/testurl.c
@@ -26,7 +26,7 @@ int main(int argc, char **argv)
 {
     int i;
     if (!SDL_Init(SDL_INIT_VIDEO)) {
-        SDL_Log("SDL_Init failed: %s\n", SDL_GetError());
+        SDL_Log("SDL_Init failed: %s", SDL_GetError());
         return 1;
     }
 

--- a/test/testutils.c
+++ b/test/testutils.c
@@ -127,7 +127,7 @@ SDL_Texture *LoadTexture(SDL_Renderer *renderer, const char *file, bool transpar
 
         texture = SDL_CreateTextureFromSurface(renderer, temp);
         if (!texture) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create texture: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create texture: %s", SDL_GetError());
         }
     }
     SDL_DestroySurface(temp);

--- a/test/testver.c
+++ b/test/testver.c
@@ -25,15 +25,15 @@ int main(int argc, char *argv[])
     }
 
 #if SDL_VERSION_ATLEAST(3, 0, 0)
-    SDL_Log("Compiled with SDL 3.0 or newer\n");
+    SDL_Log("Compiled with SDL 3.0 or newer");
 #else
-    SDL_Log("Compiled with SDL older than 3.0\n");
+    SDL_Log("Compiled with SDL older than 3.0");
 #endif
-    SDL_Log("Compiled version: %d.%d.%d (%s)\n",
+    SDL_Log("Compiled version: %d.%d.%d (%s)",
             SDL_MAJOR_VERSION, SDL_MINOR_VERSION, SDL_MICRO_VERSION,
             SDL_REVISION);
     int version = SDL_GetVersion();
-    SDL_Log("Runtime version: %d.%d.%d (%s)\n",
+    SDL_Log("Runtime version: %d.%d.%d (%s)",
             SDL_VERSIONNUM_MAJOR(version), SDL_VERSIONNUM_MINOR(version), SDL_VERSIONNUM_MICRO(version),
             SDL_GetRevision());
     SDL_Quit();

--- a/test/testviewport.c
+++ b/test/testviewport.c
@@ -227,7 +227,7 @@ int main(int argc, char *argv[])
     now = SDL_GetTicks();
     if (now > then) {
         double fps = ((double)frames * 1000) / (now - then);
-        SDL_Log("%2.2f frames per second\n", fps);
+        SDL_Log("%2.2f frames per second", fps);
     }
     quit(0);
     return 0;

--- a/test/testvulkan.c
+++ b/test/testvulkan.c
@@ -18,7 +18,7 @@
 
 int main(int argc, char *argv[])
 {
-    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "No Vulkan support on this system\n");
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "No Vulkan support on this system");
     return 1;
 }
 
@@ -264,7 +264,7 @@ static void createSurface(void)
 {
     if (!SDL_Vulkan_CreateSurface(vulkanContext->window, vulkanContext->instance, NULL, &vulkanContext->surface)) {
         vulkanContext->surface = VK_NULL_HANDLE;
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_Vulkan_CreateSurface(): %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_Vulkan_CreateSurface(): %s", SDL_GetError());
         quit(2);
     }
 }
@@ -478,7 +478,7 @@ static void createDevice(void)
     result = vkCreateDevice(vulkanContext->physicalDevice, &deviceCreateInfo, NULL, &vulkanContext->device);
     if (result != VK_SUCCESS) {
         vulkanContext->device = VK_NULL_HANDLE;
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "vkCreateDevice(): %s\n", getVulkanResultString(result));
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "vkCreateDevice(): %s", getVulkanResultString(result));
         quit(2);
     }
 }
@@ -1040,12 +1040,12 @@ static bool render(void)
     }
     rc = vkWaitForFences(vulkanContext->device, 1, &vulkanContext->fences[frameIndex], VK_FALSE, UINT64_MAX);
     if (rc != VK_SUCCESS) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "vkWaitForFences(): %s\n", getVulkanResultString(rc));
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "vkWaitForFences(): %s", getVulkanResultString(rc));
         quit(2);
     }
     rc = vkResetFences(vulkanContext->device, 1, &vulkanContext->fences[frameIndex]);
     if (rc != VK_SUCCESS) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "vkResetFences(): %s\n", getVulkanResultString(rc));
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "vkResetFences(): %s", getVulkanResultString(rc));
         quit(2);
     }
     currentTime = (double)SDL_GetPerformanceCounter() / SDL_GetPerformanceFrequency();
@@ -1065,7 +1065,7 @@ static bool render(void)
     rc = vkQueueSubmit(vulkanContext->graphicsQueue, 1, &submitInfo, vulkanContext->fences[frameIndex]);
 
     if (rc != VK_SUCCESS) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "vkQueueSubmit(): %s\n", getVulkanResultString(rc));
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "vkQueueSubmit(): %s", getVulkanResultString(rc));
         quit(2);
     }
     presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
@@ -1118,13 +1118,13 @@ int main(int argc, char **argv)
 
     mode = SDL_GetCurrentDisplayMode(SDL_GetPrimaryDisplay());
     if (mode) {
-        SDL_Log("Screen BPP    : %d\n", SDL_BITSPERPIXEL(mode->format));
+        SDL_Log("Screen BPP    : %d", SDL_BITSPERPIXEL(mode->format));
     }
     SDL_GetWindowSize(state->windows[0], &dw, &dh);
-    SDL_Log("Window Size   : %d,%d\n", dw, dh);
+    SDL_Log("Window Size   : %d,%d", dw, dh);
     SDL_GetWindowSizeInPixels(state->windows[0], &dw, &dh);
-    SDL_Log("Draw Size     : %d,%d\n", dw, dh);
-    SDL_Log("\n");
+    SDL_Log("Draw Size     : %d,%d", dw, dh);
+    SDL_Log("%s", "");
 
     initVulkan();
 
@@ -1159,7 +1159,7 @@ int main(int argc, char **argv)
     /* Print out some timing information */
     now = SDL_GetTicks();
     if (now > then) {
-        SDL_Log("%2.2f frames per second\n", ((double)frames * 1000) / (now - then));
+        SDL_Log("%2.2f frames per second", ((double)frames * 1000) / (now - then));
     }
 
     shutdownVulkan(true);

--- a/test/testwm.c
+++ b/test/testwm.c
@@ -157,10 +157,10 @@ static void loop(void)
     /* Wait up to 20 ms for input, as a test */
     Uint64 then = SDL_GetTicks();
     if (SDL_WaitEventTimeout(NULL, 20)) {
-        SDL_Log("Got an event!\n");
+        SDL_Log("Got an event!");
     }
     Uint64 now = SDL_GetTicks();
-    SDL_Log("Waited %d ms for events\n", (int)(now - then));
+    SDL_Log("Waited %d ms for events", (int)(now - then));
 #endif
 
     while (SDL_PollEvent(&event)) {
@@ -170,7 +170,7 @@ static void loop(void)
         if (event.type == SDL_EVENT_WINDOW_RESIZED) {
             SDL_Window *window = SDL_GetWindowFromEvent(&event);
             if (window) {
-                SDL_Log("Window %" SDL_PRIu32 " resized to %" SDL_PRIs32 "x%" SDL_PRIs32 "\n",
+                SDL_Log("Window %" SDL_PRIu32 " resized to %" SDL_PRIs32 "x%" SDL_PRIs32,
                         event.window.windowID,
                         event.window.data1,
                         event.window.data2);
@@ -179,7 +179,7 @@ static void loop(void)
         if (event.type == SDL_EVENT_WINDOW_MOVED) {
             SDL_Window *window = SDL_GetWindowFromEvent(&event);
             if (window) {
-                SDL_Log("Window %" SDL_PRIu32 " moved to %" SDL_PRIs32 ",%" SDL_PRIs32 " (display %s)\n",
+                SDL_Log("Window %" SDL_PRIu32 " moved to %" SDL_PRIs32 ",%" SDL_PRIs32 " (display %s)",
                         event.window.windowID,
                         event.window.data1,
                         event.window.data2,

--- a/test/testyuv.c
+++ b/test/testyuv.c
@@ -89,7 +89,7 @@ static bool verify_yuv_data(Uint32 format, SDL_Colorspace colorspace, const Uint
                 int deltaB = (int)actual[2] - expected[2];
                 int distance = (deltaR * deltaR + deltaG * deltaG + deltaB * deltaB);
                 if (distance > tolerance) {
-                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Pixel at %d,%d was 0x%.2x,0x%.2x,0x%.2x, expected 0x%.2x,0x%.2x,0x%.2x, distance = %d\n", x, y, actual[0], actual[1], actual[2], expected[0], expected[1], expected[2], distance);
+                    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Pixel at %d,%d was 0x%.2x,0x%.2x,0x%.2x, expected 0x%.2x,0x%.2x,0x%.2x, distance = %d", x, y, actual[0], actual[1], actual[2], expected[0], expected[1], expected[2], distance);
                     result = false;
                 }
                 actual += 3;
@@ -97,7 +97,7 @@ static bool verify_yuv_data(Uint32 format, SDL_Colorspace colorspace, const Uint
             }
         }
     } else {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't convert %s to %s: %s\n", SDL_GetPixelFormatName(format), SDL_GetPixelFormatName(surface->format), SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't convert %s to %s: %s", SDL_GetPixelFormatName(format), SDL_GetPixelFormatName(surface->format), SDL_GetError());
     }
     SDL_free(rgb);
 
@@ -138,12 +138,12 @@ static bool run_automated_tests(int pattern_size, int extra_pitch)
     /* Verify conversion from YUV formats */
     for (i = 0; i < SDL_arraysize(formats); ++i) {
         if (!ConvertRGBtoYUV(formats[i], pattern->pixels, pattern->pitch, yuv1, pattern->w, pattern->h, mode, 0, 100)) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "ConvertRGBtoYUV() doesn't support converting to %s\n", SDL_GetPixelFormatName(formats[i]));
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "ConvertRGBtoYUV() doesn't support converting to %s", SDL_GetPixelFormatName(formats[i]));
             goto done;
         }
         yuv1_pitch = CalculateYUVPitch(formats[i], pattern->w);
         if (!verify_yuv_data(formats[i], colorspace, yuv1, yuv1_pitch, pattern, tight_tolerance)) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed conversion from %s to RGB\n", SDL_GetPixelFormatName(formats[i]));
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed conversion from %s to RGB", SDL_GetPixelFormatName(formats[i]));
             goto done;
         }
     }
@@ -152,11 +152,11 @@ static bool run_automated_tests(int pattern_size, int extra_pitch)
     for (i = 0; i < SDL_arraysize(formats); ++i) {
         yuv1_pitch = CalculateYUVPitch(formats[i], pattern->w) + extra_pitch;
         if (!SDL_ConvertPixelsAndColorspace(pattern->w, pattern->h, pattern->format, SDL_COLORSPACE_SRGB, 0, pattern->pixels, pattern->pitch, formats[i], colorspace, 0, yuv1, yuv1_pitch)) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't convert %s to %s: %s\n", SDL_GetPixelFormatName(pattern->format), SDL_GetPixelFormatName(formats[i]), SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't convert %s to %s: %s", SDL_GetPixelFormatName(pattern->format), SDL_GetPixelFormatName(formats[i]), SDL_GetError());
             goto done;
         }
         if (!verify_yuv_data(formats[i], colorspace, yuv1, yuv1_pitch, pattern, tight_tolerance)) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed conversion from RGB to %s\n", SDL_GetPixelFormatName(formats[i]));
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed conversion from RGB to %s", SDL_GetPixelFormatName(formats[i]));
             goto done;
         }
     }
@@ -167,15 +167,15 @@ static bool run_automated_tests(int pattern_size, int extra_pitch)
             yuv1_pitch = CalculateYUVPitch(formats[i], pattern->w) + extra_pitch;
             yuv2_pitch = CalculateYUVPitch(formats[j], pattern->w) + extra_pitch;
             if (!SDL_ConvertPixelsAndColorspace(pattern->w, pattern->h, pattern->format, SDL_COLORSPACE_SRGB, 0, pattern->pixels, pattern->pitch, formats[i], colorspace, 0, yuv1, yuv1_pitch)) {
-                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't convert %s to %s: %s\n", SDL_GetPixelFormatName(pattern->format), SDL_GetPixelFormatName(formats[i]), SDL_GetError());
+                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't convert %s to %s: %s", SDL_GetPixelFormatName(pattern->format), SDL_GetPixelFormatName(formats[i]), SDL_GetError());
                 goto done;
             }
             if (!SDL_ConvertPixelsAndColorspace(pattern->w, pattern->h, formats[i], colorspace, 0, yuv1, yuv1_pitch, formats[j], colorspace, 0, yuv2, yuv2_pitch)) {
-                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't convert %s to %s: %s\n", SDL_GetPixelFormatName(formats[i]), SDL_GetPixelFormatName(formats[j]), SDL_GetError());
+                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't convert %s to %s: %s", SDL_GetPixelFormatName(formats[i]), SDL_GetPixelFormatName(formats[j]), SDL_GetError());
                 goto done;
             }
             if (!verify_yuv_data(formats[j], colorspace, yuv2, yuv2_pitch, pattern, tight_tolerance)) {
-                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed conversion from %s to %s\n", SDL_GetPixelFormatName(formats[i]), SDL_GetPixelFormatName(formats[j]));
+                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed conversion from %s to %s", SDL_GetPixelFormatName(formats[i]), SDL_GetPixelFormatName(formats[j]));
                 goto done;
             }
         }
@@ -192,15 +192,15 @@ static bool run_automated_tests(int pattern_size, int extra_pitch)
             yuv1_pitch = CalculateYUVPitch(formats[i], pattern->w) + extra_pitch;
             yuv2_pitch = CalculateYUVPitch(formats[j], pattern->w) + extra_pitch;
             if (!SDL_ConvertPixelsAndColorspace(pattern->w, pattern->h, pattern->format, SDL_COLORSPACE_SRGB, 0, pattern->pixels, pattern->pitch, formats[i], colorspace, 0, yuv1, yuv1_pitch)) {
-                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't convert %s to %s: %s\n", SDL_GetPixelFormatName(pattern->format), SDL_GetPixelFormatName(formats[i]), SDL_GetError());
+                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't convert %s to %s: %s", SDL_GetPixelFormatName(pattern->format), SDL_GetPixelFormatName(formats[i]), SDL_GetError());
                 goto done;
             }
             if (!SDL_ConvertPixelsAndColorspace(pattern->w, pattern->h, formats[i], colorspace, 0, yuv1, yuv1_pitch, formats[j], colorspace, 0, yuv1, yuv2_pitch)) {
-                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't convert %s to %s: %s\n", SDL_GetPixelFormatName(formats[i]), SDL_GetPixelFormatName(formats[j]), SDL_GetError());
+                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't convert %s to %s: %s", SDL_GetPixelFormatName(formats[i]), SDL_GetPixelFormatName(formats[j]), SDL_GetError());
                 goto done;
             }
             if (!verify_yuv_data(formats[j], colorspace, yuv1, yuv2_pitch, pattern, tight_tolerance)) {
-                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed conversion from %s to %s\n", SDL_GetPixelFormatName(formats[i]), SDL_GetPixelFormatName(formats[j]));
+                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed conversion from %s to %s", SDL_GetPixelFormatName(formats[i]), SDL_GetPixelFormatName(formats[j]));
                 goto done;
             }
         }
@@ -209,24 +209,24 @@ static bool run_automated_tests(int pattern_size, int extra_pitch)
     /* Verify round trip through BT.2020 */
     colorspace = SDL_COLORSPACE_BT2020_FULL;
     if (!ConvertRGBtoYUV(SDL_PIXELFORMAT_P010, pattern->pixels, pattern->pitch, yuv1, pattern->w, pattern->h, YUV_CONVERSION_BT2020, 0, 100)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "ConvertRGBtoYUV() doesn't support converting to %s\n", SDL_GetPixelFormatName(SDL_PIXELFORMAT_P010));
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "ConvertRGBtoYUV() doesn't support converting to %s", SDL_GetPixelFormatName(SDL_PIXELFORMAT_P010));
         goto done;
     }
     yuv1_pitch = CalculateYUVPitch(SDL_PIXELFORMAT_P010, pattern->w);
     if (!verify_yuv_data(SDL_PIXELFORMAT_P010, colorspace, yuv1, yuv1_pitch, pattern, tight_tolerance)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed conversion from %s to RGB\n", SDL_GetPixelFormatName(SDL_PIXELFORMAT_P010));
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed conversion from %s to RGB", SDL_GetPixelFormatName(SDL_PIXELFORMAT_P010));
         goto done;
     }
 
     /* The pitch needs to be Uint16 aligned for P010 pixels */
     yuv1_pitch = CalculateYUVPitch(SDL_PIXELFORMAT_P010, pattern->w) + ((extra_pitch + 1) & ~1);
     if (!SDL_ConvertPixelsAndColorspace(pattern->w, pattern->h, pattern->format, SDL_COLORSPACE_SRGB, 0, pattern->pixels, pattern->pitch, SDL_PIXELFORMAT_P010, colorspace, 0, yuv1, yuv1_pitch)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't convert %s to %s: %s\n", SDL_GetPixelFormatName(pattern->format), SDL_GetPixelFormatName(SDL_PIXELFORMAT_P010), SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't convert %s to %s: %s", SDL_GetPixelFormatName(pattern->format), SDL_GetPixelFormatName(SDL_PIXELFORMAT_P010), SDL_GetError());
         goto done;
     }
     /* Going through XRGB2101010 format during P010 conversion is slightly lossy, so use looser tolerance here */
     if (!verify_yuv_data(SDL_PIXELFORMAT_P010, colorspace, yuv1, yuv1_pitch, pattern, loose_tolerance)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed conversion from RGB to %s\n", SDL_GetPixelFormatName(SDL_PIXELFORMAT_P010));
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed conversion from RGB to %s", SDL_GetPixelFormatName(SDL_PIXELFORMAT_P010));
         goto done;
     }
 
@@ -265,13 +265,13 @@ static bool run_colorspace_test(void)
     int i;
 
     if (!SDL_CreateWindowAndRenderer("testyuv", 320, 240, 0, &window, &renderer)) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create window and renderer: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create window and renderer: %s", SDL_GetError());
         goto done;
     }
 
     rgb = SDL_CreateSurface(32, 32, SDL_PIXELFORMAT_XRGB8888);
     if (!rgb) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create RGB surface: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create RGB surface: %s", SDL_GetError());
         goto done;
     }
     SDL_FillSurfaceRect(rgb, NULL, SDL_MapSurfaceRGB(rgb, 255, 0, 0));
@@ -280,28 +280,28 @@ static bool run_colorspace_test(void)
         bool next = false;
         Uint8 r, g, b, a;
 
-        SDL_Log("Checking colorspace %s\n", colorspaces[i].name);
+        SDL_Log("Checking colorspace %s", colorspaces[i].name);
 
         yuv = SDL_ConvertSurfaceAndColorspace(rgb, SDL_PIXELFORMAT_NV12, NULL, colorspaces[i].colorspace, 0);
         if (!yuv) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create YUV surface: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create YUV surface: %s", SDL_GetError());
             goto done;
         }
 
         if (!SDL_ReadSurfacePixel(yuv, 0, 0, &r, &g, &b, &a)) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't read YUV surface: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't read YUV surface: %s", SDL_GetError());
             goto done;
         }
 
         if (SDL_abs((int)r - 255) > allowed_error ||
             SDL_abs((int)g - 0) > allowed_error ||
             SDL_abs((int)b - 0) > allowed_error) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed color conversion, expected 255,0,0, got %d,%d,%d\n", r, g, b);
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed color conversion, expected 255,0,0, got %d,%d,%d", r, g, b);
         }
 
         texture = SDL_CreateTextureFromSurface(renderer, yuv);
         if (!texture) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create YUV texture: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create YUV texture: %s", SDL_GetError());
             goto done;
         }
 
@@ -312,14 +312,14 @@ static bool run_colorspace_test(void)
         yuv = SDL_RenderReadPixels(renderer, NULL);
 
         if (!SDL_ReadSurfacePixel(yuv, 0, 0, &r, &g, &b, &a)) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't read YUV surface: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't read YUV surface: %s", SDL_GetError());
             goto done;
         }
 
         if (SDL_abs((int)r - 255) > allowed_error ||
             SDL_abs((int)g - 0) > allowed_error ||
             SDL_abs((int)b - 0) > allowed_error) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed renderer color conversion, expected 255,0,0, got %d,%d,%d\n", r, g, b);
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed renderer color conversion, expected 255,0,0, got %d,%d,%d", r, g, b);
         }
 
         while (!next) {
@@ -530,7 +530,7 @@ int main(int argc, char **argv)
     /* Run automated tests */
     if (should_run_automated_tests) {
         for (i = 0; i < (int)SDL_arraysize(automated_test_params); ++i) {
-            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Running automated test, pattern size %d, extra pitch %d, intrinsics %s\n",
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Running automated test, pattern size %d, extra pitch %d, intrinsics %s",
                         automated_test_params[i].pattern_size,
                         automated_test_params[i].extra_pitch,
                         automated_test_params[i].enable_intrinsics ? "enabled" : "disabled");
@@ -553,7 +553,7 @@ int main(int argc, char **argv)
     original = SDL_ConvertSurface(bmp, SDL_PIXELFORMAT_RGB24);
     SDL_DestroySurface(bmp);
     if (!original) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't load %s: %s\n", filename, SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't load %s: %s", filename, SDL_GetError());
         return 3;
     }
 
@@ -586,7 +586,7 @@ int main(int argc, char **argv)
 
     converted = SDL_CreateSurface(original->w, original->h, rgb_format);
     if (!converted) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create converted surface: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create converted surface: %s", SDL_GetError());
         return 3;
     }
 
@@ -595,17 +595,17 @@ int main(int argc, char **argv)
         SDL_ConvertPixelsAndColorspace(original->w, original->h, yuv_format, yuv_colorspace, 0, raw_yuv, pitch, rgb_format, rgb_colorspace, 0, converted->pixels, converted->pitch);
     }
     now = SDL_GetTicks();
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "%d iterations in %" SDL_PRIu64 " ms, %.2fms each\n", iterations, (now - then), (float)(now - then) / iterations);
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "%d iterations in %" SDL_PRIu64 " ms, %.2fms each", iterations, (now - then), (float)(now - then) / iterations);
 
     window = SDL_CreateWindow("YUV test", original->w, original->h, 0);
     if (!window) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create window: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create window: %s", SDL_GetError());
         return 4;
     }
 
     renderer = SDL_CreateRenderer(window, NULL);
     if (!renderer) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create renderer: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create renderer: %s", SDL_GetError());
         return 4;
     }
 
@@ -620,7 +620,7 @@ int main(int argc, char **argv)
     output[2] = SDL_CreateTextureWithProperties(renderer, props);
     SDL_DestroyProperties(props);
     if (!output[0] || !output[1] || !output[2]) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't set create texture: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't set create texture: %s", SDL_GetError());
         return 5;
     }
     SDL_UpdateTexture(output[2], NULL, raw_yuv, pitch);

--- a/test/torturethread.c
+++ b/test/torturethread.c
@@ -52,7 +52,7 @@ ThreadFunc(void *data)
     int i;
     int tid = (int)(uintptr_t)data;
 
-    SDL_Log("Creating Thread %d\n", tid);
+    SDL_Log("Creating Thread %d", tid);
 
     for (i = 0; i < NUMTHREADS; i++) {
         char name[64];
@@ -61,18 +61,18 @@ ThreadFunc(void *data)
         sub_threads[i] = SDL_CreateThread(SubThreadFunc, name, &flags[i]);
     }
 
-    SDL_Log("Thread '%d' waiting for signal\n", tid);
+    SDL_Log("Thread '%d' waiting for signal", tid);
     while (SDL_GetAtomicInt(&time_for_threads_to_die[tid]) != 1) {
         ; /* do nothing */
     }
 
-    SDL_Log("Thread '%d' sending signals to subthreads\n", tid);
+    SDL_Log("Thread '%d' sending signals to subthreads", tid);
     for (i = 0; i < NUMTHREADS; i++) {
         SDL_SetAtomicInt(&flags[i], 1);
         SDL_WaitThread(sub_threads[i], NULL);
     }
 
-    SDL_Log("Thread '%d' exiting!\n", tid);
+    SDL_Log("Thread '%d' exiting!", tid);
 
     return 0;
 }
@@ -103,7 +103,7 @@ int main(int argc, char *argv[])
         threads[i] = SDL_CreateThread(ThreadFunc, name, (void *)(uintptr_t)i);
 
         if (threads[i] == NULL) {
-            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create thread: %s\n", SDL_GetError());
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create thread: %s", SDL_GetError());
             quit(1);
         }
     }


### PR DESCRIPTION
Per my last PR documenting that newlines shouldn't even be in log messages, I've removed them across the codebase, and rewrote log code a bit where required.

Due to warnings about an empty format string, a line like `SDL_Log("%s", "");` is required for inserting empty lines, to not have the warnings.