### PR TITLE
Fix buffer overrun in ConvertAudio with different src/dst channel count

### DIFF
--- a/src/audio/SDL_audiocvt.c
+++ b/src/audio/SDL_audiocvt.c
@@ -325,7 +325,7 @@ void ConvertAudio(int num_frames,
 
     // Gain adjustment
     if (gain != 1.0f) {
-        float *buf = (float *)(dstconvert ? scratch : dst);
+        float *buf = (float *)((channelconvert || dstconvert) ? scratch : dst);
         const int total_samples = num_frames * src_channels;
         if (src == buf) {
             for (int i = 0; i < total_samples; i++) {


### PR DESCRIPTION
To trigger this bug, the source and destination channel count have to not match, and the source format also has to not be f32.

## Description
This fixes a buffer overrun (and intermittent crash) when playing audio from the opening FMV of Bloodborne in the ShadPS4 emulator. That audio is in 8 channel, s16le format, which triggers an audio conversion code path that probably isn't very common.

## Existing Issue(s)
https://github.com/shadps4-emu/shadPS4/issues/2034
