### PR TITLE
x11: Don't force position windows with an undefined position

### DIFF
--- a/src/video/x11/SDL_x11window.h
+++ b/src/video/x11/SDL_x11window.h
@@ -103,10 +103,15 @@ struct SDL_WindowData
         X11_PENDING_OP_RESIZE = 0x20
     } pending_operation;
 
+    enum
+    {
+        X11_SIZE_MOVE_EVENTS_DISABLE = 0x01, // Events are completely disabled.
+        X11_SIZE_MOVE_EVENTS_WAIT_FOR_BORDERS = 0x02, // Events are disabled until a _NET_FRAME_EXTENTS event arrives.
+    } size_move_event_flags;
+
     bool pending_size;
     bool pending_position;
     bool window_was_maximized;
-    bool disable_size_position_events;
     bool previous_borders_nonzero;
     bool toggle_borders;
     bool fullscreen_borders_forced_on;


### PR DESCRIPTION
An undefined position means that the window manager can handle placement, so SDL shouldn't override that by forcing a position when showing a window.

Allows for removing a fair bit of now-unnecessary code as well.

Fixes #12060
