### PR TITLE
Function to change default texture scale mode per renderer

### DIFF
--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -2578,6 +2578,41 @@ extern SDL_DECLSPEC bool SDLCALL SDL_RenderDebugText(SDL_Renderer *renderer, flo
  */
 extern SDL_DECLSPEC bool SDLCALL SDL_RenderDebugTextFormat(SDL_Renderer *renderer, float x, float y, SDL_PRINTF_FORMAT_STRING const char *fmt, ...) SDL_PRINTF_VARARG_FUNC(4);
 
+/**
+ * Set default scale mode for new textures for given renderer.
+ *
+ * When a renderer is created, scale_mode defaults to SDL_SCALEMODE_LINEAR.
+ * 
+ * \param renderer the renderer to update.
+ * \param scale_mode the scale mode to change to for new textures.
+ * \returns true on success or false on failure; call SDL_GetError() for more
+ *          information.
+ *
+ * \threadsafety This function should only be called on the main thread.
+ *
+ * \since This function is available since SDL 3.4.0.
+ *
+ * \sa SDL_GetDefaultTextureScaleMode
+ */
+extern SDL_DECLSPEC bool SDLCALL SDL_SetDefaultTextureScaleMode(SDL_Renderer *renderer, SDL_ScaleMode scale_mode);
+
+/**
+ * Get default texture scale mode of the given renderer.
+ *
+ * \param renderer the renderer to get data from.
+ * \param scale_mode a SDL_ScaleMode filled with current default scale mode.
+ *          See SDL_SetDefaultTextureScaleMode() for the meaning of the value.
+ * \returns true on success or false on failure; call SDL_GetError() for more
+ *          information.
+ *
+ * \threadsafety This function should only be called on the main thread.
+ *
+ * \since This function is available since SDL 3.4.0.
+ *
+ * \sa SDL_SetDefaultTextureScaleMode
+ */
+extern SDL_DECLSPEC bool SDLCALL SDL_GetDefaultTextureScaleMode(SDL_Renderer *renderer, SDL_ScaleMode *scale_mode);
+
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus
 }

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -1083,6 +1083,8 @@ SDL_Renderer *SDL_CreateRendererWithProperties(SDL_PropertiesID props)
         renderer->line_method = SDL_GetRenderLineMethod();
     }
 
+    renderer->scale_mode = SDL_SCALEMODE_LINEAR;
+
     renderer->SDR_white_point = 1.0f;
     renderer->HDR_headroom = 1.0f;
     renderer->desired_color_scale = 1.0f;
@@ -1380,7 +1382,7 @@ SDL_Texture *SDL_CreateTextureWithProperties(SDL_Renderer *renderer, SDL_Propert
     texture->color.b = 1.0f;
     texture->color.a = 1.0f;
     texture->blendMode = SDL_ISPIXELFORMAT_ALPHA(format) ? SDL_BLENDMODE_BLEND : SDL_BLENDMODE_NONE;
-    texture->scaleMode = SDL_SCALEMODE_LINEAR;
+    texture->scaleMode = renderer->scale_mode;
     texture->view.pixel_w = w;
     texture->view.pixel_h = h;
     texture->view.viewport.w = -1;
@@ -5625,4 +5627,27 @@ bool SDL_RenderDebugTextFormat(SDL_Renderer *renderer, float x, float y, SDL_PRI
     const bool retval = SDL_RenderDebugText(renderer, x, y, str);
     SDL_free(str);
     return retval;
+}
+
+bool SDL_SetDefaultTextureScaleMode(SDL_Renderer *renderer, SDL_ScaleMode scale_mode)
+{
+    CHECK_RENDERER_MAGIC(renderer, false);
+
+    renderer->scale_mode = scale_mode;
+
+    return true;
+}
+
+bool SDL_GetDefaultTextureScaleMode(SDL_Renderer *renderer, SDL_ScaleMode *scale_mode)
+{
+    if (scale_mode) {
+        *scale_mode = SDL_SCALEMODE_LINEAR;
+    }
+
+    CHECK_RENDERER_MAGIC(renderer, false);
+
+    if (scale_mode) {
+        *scale_mode = renderer->scale_mode;
+    }
+    return true;
 }

--- a/src/render/SDL_sysrender.h
+++ b/src/render/SDL_sysrender.h
@@ -266,6 +266,9 @@ struct SDL_Renderer
     // The method of drawing lines
     SDL_RenderLineMethod line_method;
 
+    // Default scale mode for textures created with this renderer
+    SDL_ScaleMode scale_mode;
+
     // The list of textures
     SDL_Texture *textures;
     SDL_Texture *target;


### PR DESCRIPTION
New functions to set default scale mode for newly created textures per renderer and get current scale mode set for given renderer.

## Description
This will save using `SDL_SetTextureScaleMode` every time we create new texture and want to use nearest-point scale instead of linear. Helpful for pixel art games where everything should be scaled to nearest-point.
* SDL_SetDefaultTextureScaleMode(SDL_Renderer *renderer, SDL_ScaleMode scale_mode)
* SDL_GetDefaultTextureScaleMode(SDL_Renderer *renderer, SDL_ScaleMode *scale_mode)

## Existing Issue(s)
#11919 
