### PR TITLE
Documentation: typos around float precision

### DIFF
--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -4701,7 +4701,7 @@ extern SDL_DECLSPEC double SDLCALL SDL_atan2(double y, double x);
  *
  * \since This function is available since SDL 3.2.0.
  *
- * \sa SDL_atan2f
+ * \sa SDL_atan2
  * \sa SDL_atan
  * \sa SDL_tan
  */
@@ -4810,7 +4810,7 @@ extern SDL_DECLSPEC double SDLCALL SDL_copysign(double x, double y);
  *
  * \since This function is available since SDL 3.2.0.
  *
- * \sa SDL_copysignf
+ * \sa SDL_copysign
  * \sa SDL_fabsf
  */
 extern SDL_DECLSPEC float SDLCALL SDL_copysignf(float x, float y);
@@ -4943,7 +4943,7 @@ extern SDL_DECLSPEC float SDLCALL SDL_expf(float x);
  * Range: `0 <= y <= INF`
  *
  * This function operates on double-precision floating point values, use
- * SDL_copysignf for single-precision floats.
+ * SDL_fabsf for single-precision floats.
  *
  * \param x floating point value to use as the magnitude.
  * \returns the absolute value of `x`.
@@ -4964,7 +4964,7 @@ extern SDL_DECLSPEC double SDLCALL SDL_fabs(double x);
  * Range: `0 <= y <= INF`
  *
  * This function operates on single-precision floating point values, use
- * SDL_copysignf for double-precision floats.
+ * SDL_fabs for double-precision floats.
  *
  * \param x floating point value to use as the magnitude.
  * \returns the absolute value of `x`.
@@ -5016,7 +5016,7 @@ extern SDL_DECLSPEC double SDLCALL SDL_floor(double x);
  * Range: `-INF <= y <= INF`, y integer
  *
  * This function operates on single-precision floating point values, use
- * SDL_floorf for double-precision floats.
+ * SDL_floor for double-precision floats.
  *
  * \param x floating point value.
  * \returns the floor of `x`.
@@ -5073,7 +5073,7 @@ extern SDL_DECLSPEC double SDLCALL SDL_trunc(double x);
  * Range: `-INF <= y <= INF`, y integer
  *
  * This function operates on single-precision floating point values, use
- * SDL_truncf for double-precision floats.
+ * SDL_trunc for double-precision floats.
  *
  * \param x floating point value.
  * \returns `x` truncated to an integer.
@@ -5131,7 +5131,7 @@ extern SDL_DECLSPEC double SDLCALL SDL_fmod(double x, double y);
  * Range: `-y <= z <= y`
  *
  * This function operates on single-precision floating point values, use
- * SDL_fmod for single-precision floats.
+ * SDL_fmod for double-precision floats.
  *
  * \param x the numerator.
  * \param y the denominator. Must not be 0.
@@ -5409,7 +5409,7 @@ extern SDL_DECLSPEC double SDLCALL SDL_pow(double x, double y);
  * instead.
  *
  * This function operates on single-precision floating point values, use
- * SDL_powf for double-precision floats.
+ * SDL_pow for double-precision floats.
  *
  * This function may use a different approximation across different versions,
  * platforms and configurations. i.e, it can return a different value given
@@ -5469,8 +5469,8 @@ extern SDL_DECLSPEC double SDLCALL SDL_round(double x);
  *
  * Range: `-INF <= y <= INF`, y integer
  *
- * This function operates on double-precision floating point values, use
- * SDL_roundf for single-precision floats. To get the result as an integer
+ * This function operates on single-precision floating point values, use
+ * SDL_round for double-precision floats. To get the result as an integer
  * type, use SDL_lroundf.
  *
  * \param x floating point value.
@@ -5499,7 +5499,7 @@ extern SDL_DECLSPEC float SDLCALL SDL_roundf(float x);
  * Range: `MIN_LONG <= y <= MAX_LONG`
  *
  * This function operates on double-precision floating point values, use
- * SDL_lround for single-precision floats. To get the result as a
+ * SDL_lroundf for single-precision floats. To get the result as a
  * floating-point type, use SDL_round.
  *
  * \param x floating point value.
@@ -5528,8 +5528,8 @@ extern SDL_DECLSPEC long SDLCALL SDL_lround(double x);
  * Range: `MIN_LONG <= y <= MAX_LONG`
  *
  * This function operates on single-precision floating point values, use
- * SDL_lroundf for double-precision floats. To get the result as a
- * floating-point type, use SDL_roundf,
+ * SDL_lround for double-precision floats. To get the result as a
+ * floating-point type, use SDL_roundf.
  *
  * \param x floating point value.
  * \returns the nearest integer to `x`.
@@ -5742,7 +5742,7 @@ extern SDL_DECLSPEC double SDLCALL SDL_tan(double x);
  * Range: `-INF <= y <= INF`
  *
  * This function operates on single-precision floating point values, use
- * SDL_tanf for double-precision floats.
+ * SDL_tan for double-precision floats.
  *
  * This function may use a different approximation across different versions,
  * platforms and configurations. i.e, it can return a different value given


### PR DESCRIPTION
## Description
Fixed a few documentation typos w/ regards to single- vs double- precision function variants.
