### PR TITLE
Fixed crash when trying to disconnect secondary display on iOS

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -695,7 +695,9 @@ void SDL_DelVideoDisplay(int index)
     SDL_SendDisplayEvent(&_this->displays[index], SDL_DISPLAYEVENT_DISCONNECTED, 0);
 
     SDL_free(_this->displays[index].driverdata);
+    _this->displays[index].driverdata = NULL;
     SDL_free(_this->displays[index].name);
+    _this->displays[index].name = NULL;
     if (index < (_this->num_displays - 1)) {
         SDL_memmove(&_this->displays[index], &_this->displays[index + 1], (_this->num_displays - index - 1) * sizeof(_this->displays[index]));
     }

--- a/src/video/uikit/SDL_uikitmodes.m
+++ b/src/video/uikit/SDL_uikitmodes.m
@@ -344,6 +344,7 @@ void UIKit_DelDisplay(UIScreen *uiscreen)
 
         if (data && data.uiscreen == uiscreen) {
             CFRelease(SDL_GetDisplayDriverData(i));
+            SDL_GetDisplay(i)->driverdata = NULL;
             SDL_DelVideoDisplay(i);
             return;
         }


### PR DESCRIPTION
It's a regression since https://github.com/libsdl-org/SDL/commit/20f1061cc86b07146ba410e551d4994cd430e209

Based on what you do in main branch, I just set driverdata to NULL after both SDL_free() and CFRelease().

Code from main branch for reference:

SDL_video.c:
```
void SDL_DelVideoDisplay(SDL_DisplayID displayID, bool send_event)
{
    SDL_VideoDisplay *display;
    int display_index = SDL_GetDisplayIndex(displayID);
    if (display_index < 0) {
        return;
    }

    display = _this->displays[display_index];

    if (send_event) {
        SDL_SendDisplayEvent(display, SDL_EVENT_DISPLAY_REMOVED, 0, 0);
    }

    SDL_DestroyProperties(display->props);
    SDL_free(display->name);
    SDL_ResetFullscreenDisplayModes(display);
    SDL_free(display->desktop_mode.internal);
    display->desktop_mode.internal = NULL;
    SDL_free(display->internal);
    display->internal = NULL;
    SDL_free(display);

    if (display_index < (_this->num_displays - 1)) {
        SDL_memmove(&_this->displays[display_index], &_this->displays[display_index + 1], (_this->num_displays - display_index - 1) * sizeof(_this->displays[display_index]));
    }
    --_this->num_displays;

    SDL_UpdateDesktopBounds();
}
```

SDL_uikitmodes.m:
```
void UIKit_DelDisplay(UIScreen *uiscreen, bool send_event)
{
    SDL_DisplayID *displays;
    int i;

    displays = SDL_GetDisplays(NULL);
    if (displays) {
        for (i = 0; displays[i]; ++i) {
            SDL_VideoDisplay *display = SDL_GetVideoDisplay(displays[i]);
            SDL_UIKitDisplayData *data = (__bridge SDL_UIKitDisplayData *)display->internal;

            if (data && data.uiscreen == uiscreen) {
                CFRelease(display->internal);
                display->internal = NULL;
                SDL_DelVideoDisplay(displays[i], send_event);
                break;
            }
        }
        SDL_free(displays);
    }
}
```