### PR TITLE
Fix undefined behavior in SDL_windowsmouse.c

### DIFF
--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -710,7 +710,7 @@ void WIN_UpdateMouseSystemScale(void)
     int v = 10;
     if (SystemParametersInfo(SPI_GETMOUSESPEED, 0, &v, 0)) {
         v = SDL_max(1, SDL_min(v, 20));
-        data->dpiscale = SDL_max(SDL_max(v, (v - 2) << 2), (v - 6) << 3);
+        data->dpiscale = SDL_max(SDL_max(v, (v - 2) * 4), (v - 6) * 8);
     }
 
     int params[3];


### PR DESCRIPTION
This fix prevents C undefined behavior from being invoked on Windows if the user's configured cursor speed is below 6.

Reported by https://github.com/castholm/zig-examples/issues/1

I have a fork of SDL that builds SDL using Zig as a drop-in C compiler, which uses Clang under the hood. In debug and "safe" release modes, it enables Clang's [UBSan](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) and inserts traps to guard against undefined behavior.

On the line affected by this PR, if the user's cursor speed is lower than 6, it will result in an attempt to left-shift a negative value, which is UB in C.

Swapping out `<< 2` and `<< 3` for `* 4` and `* 8` respectively is a simple fix. You could also use something like `SDL_max(0, v - 2) << 2` but I would argue using multiplication makes the intent of this line more clear.