### PR TITLE
Change DBUS introspection timer from INFINITE -> DEFAULT when introspecting available dialog services

### DIFF
--- a/src/dialog/unix/SDL_portaldialog.c
+++ b/src/dialog/unix/SDL_portaldialog.c
@@ -497,7 +497,7 @@ bool SDL_Portal_detect(void)
         goto done;
     }
 
-    reply = dbus->connection_send_with_reply_and_block(dbus->session_conn, msg, DBUS_TIMEOUT_INFINITE, NULL);
+    reply = dbus->connection_send_with_reply_and_block(dbus->session_conn, msg, DBUS_TIMEOUT_USE_DEFAULT, NULL);
     dbus->message_unref(msg);
     if (!reply) {
         goto done;


### PR DESCRIPTION
## Description

Fixes practical deadlock situation that arises when using SDL dialogs on a machine that doesn't have a session dbus booted.

My downstream application is using `SDL_ShowOpenFileDialog` from the main (UI) thread to prompt the user to select some files. Here's a gist of the usage, which I think conforms to the documentation (the lifetimes of the arguments are held in the callback closure, etc.):

- https://gist.github.com/adamkewley/d0847228e93dcdb2a1d9a5c679f170a5

This works fine on Windows/Mac, but I encountered a deadlock when using it from Ubuntu on WSL2, `gdb` indicated the main thread was waiting on `connection_send_with_reply_and_block` (the line changed by this PR) but, because this call can't timeout, it locks the entire application if (e.g.) dbus doesn't respond.

In this specific case, the reason it deadlocks is because WSL2 doesn't boot a session `dbus`. This remains true even if dependencies like `xdg-desktop-portal-gtk` (needed for SDL3's dialog implementation) are installed onto the system. In order to prevent the deadlock, I have to add an additional environment setup step: `eval $(dbus-launch --sh-syntax)` (from what I understand, this is a separate dbus from the system-wide one).

As a quick fix, I have changed the timeout from `INFINITE` to `DEFAULT` so that the UI thread has a chance to wake up. In my opinion, this is preferable because it gives the application a chance to print the error to a log or similar. Sure, the user's going to be miffed that hey can't select a file, but at least the application didn't deadlock. From what I understand, `INFINITE` is required when the UI is waiting for user input (e.g. when the dialog is actually shown to the user), but `DEFAULT` might be acceptable in this enumeration case?

A more robust fix would be to check if the session dbus is alive during this initialization/enumeration phase. I haven't had a chance to look into that yet, but I do recall that Qt applications perform this check and print something useful to the console like `"hey, I've noticed you're running without dbus, maybe try writing `eval $(dbus-launch --sh-syntax)` and try this app again?".

<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
