### PR TITLE
proposed fix: set curr_src.h to bottom_height before drawing bottom edges / corners in SDL_RenderTexture9Grid

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -4426,6 +4426,7 @@ bool SDL_RenderTexture9Grid(SDL_Renderer *renderer, SDL_Texture *texture, const 
 
     // Lower-right corner
     curr_src.y = srcrect->y + srcrect->h - bottom_height;
+    curr_src.h = bottom_height;
     curr_dst.y = dstrect->y + dstrect->h - dst_bottom_height;
     curr_dst.h = dst_bottom_height;
     if (!SDL_RenderTexture(renderer, texture, &curr_src, &curr_dst)) {
@@ -4474,6 +4475,7 @@ bool SDL_RenderTexture9Grid(SDL_Renderer *renderer, SDL_Texture *texture, const 
 
     // Bottom
     curr_src.y = srcrect->y + srcrect->h - bottom_height;
+    curr_src.h = bottom_height;
     curr_dst.y = dstrect->y + dstrect->h - dst_bottom_height;
     curr_dst.h = dst_bottom_height;
     if (!SDL_RenderTexture(renderer, texture, &curr_src, &curr_dst)) {


### PR DESCRIPTION
(...in order to avoid issue where inadvertently using top height, if the npatch existed on a larger texture than the drawn edge, would cause too many pixels to be included in the bottom part of the render.)

## Description

There is a bug currently with `SDL_RenderTexture9Grid`, its hard to notice. 

Two (2) conditions are needed to trigger, that I noticed.

a) The 9Grid texture is larger in height than the full size of the 9Grid, for example, if there is empty space bellow due to the 9Grid being stored on a spritesheet (streaming texture in minimal reproduce provided).

b) The 9Grid texture has different top and bottom margins. 

Then when drawing the 9Grid, `top_height` was inadvertently used as `curr_src.h` _when drawing `lower_left` and `lower_right`, as well as bottom of the 9Grid,_  causing either extra pixels to be drawn (resulting in squished bottom part of the 9Grid) or cropped _(haven't tested that second case)_. `curr_src.h` should have been set to `bottom_height` before these operations. If the 9Grid is stored on a perfectly sized texture, and `top_height> bottom_height`, then even if the issue was technically occuring, it wasn't having any visual impact due to the texture naturally "ending" when problem should arise...

Anyway, hope I make myself clear. The fix is pretty simple.

This is a minimal example which demonstrates the problem: 
https://pastecode.io/s/pi5qo9o1

I used a 50x50 image with margins L=10, R=10, T=14, B=10, placed on a larger 100x100 sheet, which demonstrates the problem.
Image if you want to test it :
![ngrid](https://github.com/user-attachments/assets/4cf13d27-4c2c-44a3-a153-372f7a7bdd2d)
