### PR TITLE
Free XIDeviceInfo in X11_MaybeAddPenByDeviceID

### DIFF
--- a/src/video/x11/SDL_x11pen.c
+++ b/src/video/x11/SDL_x11pen.c
@@ -285,7 +285,9 @@ X11_PenHandle *X11_MaybeAddPenByDeviceID(SDL_VideoDevice *_this, int deviceid)
     XIDeviceInfo *device_info = X11_XIQueryDevice(data->display, deviceid, &num_device_info);
     if (device_info) {
         SDL_assert(num_device_info == 1);
-        return X11_MaybeAddPen(_this, device_info);
+        X11_PenHandle *handle = X11_MaybeAddPen(_this, device_info);
+        X11_XIFreeDeviceInfo(device_info);
+        return handle;
     }
     return NULL;
 }


### PR DESCRIPTION
I noticed this when running with ASAN on my own project. X11_MaybeAddPenByDeviceID doesn't free the device info. The documentation for XIQueryDevice says that it should be freed and the other callsite in X11_InitPen does, so I figure this is a pretty safe change. Tested against my own project for sanity.