### PR TITLE
Rename parameters of type SDL_AudioDeviceID from dev to devid

### DIFF
--- a/include/SDL3/SDL_audio.h
+++ b/include/SDL3/SDL_audio.h
@@ -781,7 +781,7 @@ extern SDL_DECLSPEC bool SDLCALL SDL_IsAudioDevicePlayback(SDL_AudioDeviceID dev
  * Physical devices can not be paused or unpaused, only logical devices
  * created through SDL_OpenAudioDevice() can be.
  *
- * \param dev a device opened by SDL_OpenAudioDevice().
+ * \param devid a device opened by SDL_OpenAudioDevice().
  * \returns true on success or false on failure; call SDL_GetError() for more
  *          information.
  *
@@ -792,7 +792,7 @@ extern SDL_DECLSPEC bool SDLCALL SDL_IsAudioDevicePlayback(SDL_AudioDeviceID dev
  * \sa SDL_ResumeAudioDevice
  * \sa SDL_AudioDevicePaused
  */
-extern SDL_DECLSPEC bool SDLCALL SDL_PauseAudioDevice(SDL_AudioDeviceID dev);
+extern SDL_DECLSPEC bool SDLCALL SDL_PauseAudioDevice(SDL_AudioDeviceID devid);
 
 /**
  * Use this function to unpause audio playback on a specified device.
@@ -809,7 +809,7 @@ extern SDL_DECLSPEC bool SDLCALL SDL_PauseAudioDevice(SDL_AudioDeviceID dev);
  * Physical devices can not be paused or unpaused, only logical devices
  * created through SDL_OpenAudioDevice() can be.
  *
- * \param dev a device opened by SDL_OpenAudioDevice().
+ * \param devid a device opened by SDL_OpenAudioDevice().
  * \returns true on success or false on failure; call SDL_GetError() for more
  *          information.
  *
@@ -820,7 +820,7 @@ extern SDL_DECLSPEC bool SDLCALL SDL_PauseAudioDevice(SDL_AudioDeviceID dev);
  * \sa SDL_AudioDevicePaused
  * \sa SDL_PauseAudioDevice
  */
-extern SDL_DECLSPEC bool SDLCALL SDL_ResumeAudioDevice(SDL_AudioDeviceID dev);
+extern SDL_DECLSPEC bool SDLCALL SDL_ResumeAudioDevice(SDL_AudioDeviceID devid);
 
 /**
  * Use this function to query if an audio device is paused.
@@ -832,7 +832,7 @@ extern SDL_DECLSPEC bool SDLCALL SDL_ResumeAudioDevice(SDL_AudioDeviceID dev);
  * created through SDL_OpenAudioDevice() can be. Physical and invalid device
  * IDs will report themselves as unpaused here.
  *
- * \param dev a device opened by SDL_OpenAudioDevice().
+ * \param devid a device opened by SDL_OpenAudioDevice().
  * \returns true if device is valid and paused, false otherwise.
  *
  * \threadsafety It is safe to call this function from any thread.
@@ -842,7 +842,7 @@ extern SDL_DECLSPEC bool SDLCALL SDL_ResumeAudioDevice(SDL_AudioDeviceID dev);
  * \sa SDL_PauseAudioDevice
  * \sa SDL_ResumeAudioDevice
  */
-extern SDL_DECLSPEC bool SDLCALL SDL_AudioDevicePaused(SDL_AudioDeviceID dev);
+extern SDL_DECLSPEC bool SDLCALL SDL_AudioDevicePaused(SDL_AudioDeviceID devid);
 
 /**
  * Get the gain of an audio device.


### PR DESCRIPTION
In `include/SDL3/SDL_audio.h` almost all parameters of type `SDL_AudioDeviceID` are named `devid`:
```c
const char *      SDL_GetAudioDeviceName      (SDL_AudioDeviceID devid)
bool              SDL_GetAudioDeviceFormat    (SDL_AudioDeviceID devid, SDL_AudioSpec *spec, int *sample_frames)
int *             SDL_GetAudioDeviceChannelMap(SDL_AudioDeviceID devid, int *count)
SDL_AudioDeviceID SDL_OpenAudioDevice         (SDL_AudioDeviceID devid, const SDL_AudioSpec *spec)
bool              SDL_IsAudioDevicePhysical   (SDL_AudioDeviceID devid)
bool              SDL_IsAudioDevicePlayback   (SDL_AudioDeviceID devid)
float             SDL_GetAudioDeviceGain      (SDL_AudioDeviceID devid)
bool              SDL_SetAudioDeviceGain      (SDL_AudioDeviceID devid, float gain)
void              SDL_CloseAudioDevice        (SDL_AudioDeviceID devid)
bool              SDL_BindAudioStreams        (SDL_AudioDeviceID devid, SDL_AudioStream * const *streams, int num_streams)
bool              SDL_BindAudioStream         (SDL_AudioDeviceID devid, SDL_AudioStream *stream)
SDL_AudioStream * SDL_OpenAudioDeviceStream   (SDL_AudioDeviceID devid, const SDL_AudioSpec *spec, SDL_AudioStreamCallback callback, void *userdata)
bool              SDL_SetAudioPostmixCallback (SDL_AudioDeviceID devid, SDL_AudioPostmixCallback callback, void *userdata)
```

But there are three functions, which use the parameter name `dev`:
```c
bool              SDL_PauseAudioDevice        (SDL_AudioDeviceID dev)
bool              SDL_ResumeAudioDevice       (SDL_AudioDeviceID dev)
bool              SDL_AudioDevicePaused       (SDL_AudioDeviceID dev)
```

This commit renames those to `devid`.
