### PR TITLE
Rename parameter of type SDL_CameraID from devid to instance_id

### DIFF
--- a/include/SDL3/SDL_camera.h
+++ b/include/SDL3/SDL_camera.h
@@ -239,7 +239,7 @@ extern SDL_DECLSPEC SDL_CameraID * SDLCALL SDL_GetCameras(int *count);
  * there _is_ a camera until the user has given you permission to check
  * through a scary warning popup.
  *
- * \param devid the camera device instance ID to query.
+ * \param instance_id the camera device instance ID.
  * \param count a pointer filled in with the number of elements in the list,
  *              may be NULL.
  * \returns a NULL terminated array of pointers to SDL_CameraSpec or NULL on
@@ -254,7 +254,7 @@ extern SDL_DECLSPEC SDL_CameraID * SDLCALL SDL_GetCameras(int *count);
  * \sa SDL_GetCameras
  * \sa SDL_OpenCamera
  */
-extern SDL_DECLSPEC SDL_CameraSpec ** SDLCALL SDL_GetCameraSupportedFormats(SDL_CameraID devid, int *count);
+extern SDL_DECLSPEC SDL_CameraSpec ** SDLCALL SDL_GetCameraSupportedFormats(SDL_CameraID instance_id, int *count);
 
 /**
  * Get the human-readable device name for a camera.


### PR DESCRIPTION
In `include/SDL3/SDL_camera.h` almost all parameters of type `SDL_CameraID` are named `instance_id`:
```c
const char *       SDL_GetCameraName    (SDL_CameraID instance_id)
SDL_CameraPosition SDL_GetCameraPosition(SDL_CameraID instance_id)
SDL_Camera *       SDL_OpenCamera       (SDL_CameraID instance_id, const SDL_CameraSpec *spec)
```

But there is one function, which uses the parameter name `devid`:
```c
SDL_CameraSpec ** SDL_GetCameraSupportedFormats(SDL_CameraID devid, int *count)
```

This commit renames it to `instance_id`.
Also adjusts the comment a bit to be the same as the other ones.

_This PR is not AI generated :)_