### PR TITLE
Fix inverted pen Y tilt on macOS and add tilt display to example

### DIFF
--- a/examples/pen/01-drawing-lines/drawing-lines.c
+++ b/examples/pen/01-drawing-lines/drawing-lines.c
@@ -19,6 +19,8 @@ static SDL_Texture *render_target = NULL;
 static float pressure = 0.0f;
 static float previous_touch_x = -1.0f;
 static float previous_touch_y = -1.0f;
+static float tilt_x = 0.0f;
+static float tilt_y = 0.0f;
 
 /* This function runs once at startup. */
 SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
@@ -84,6 +86,10 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
     } else if (event->type == SDL_EVENT_PEN_AXIS) {
         if (event->paxis.axis == SDL_PEN_AXIS_PRESSURE) {
             pressure = event->paxis.value;  /* remember new pressure for later draws. */
+        } else if(event->paxis.axis == SDL_PEN_AXIS_XTILT) {
+            tilt_x = event->paxis.value;
+        } else if(event->paxis.axis == SDL_PEN_AXIS_YTILT) {
+            tilt_y = event->paxis.value;
         }
     }
 
@@ -93,11 +99,15 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
 /* This function runs once per frame, and is the heart of the program. */
 SDL_AppResult SDL_AppIterate(void *appstate)
 {
+    char debug_text[1024] = {};
+
     /* make sure we're drawing to the window and not the render target */
     SDL_SetRenderTarget(renderer, NULL);
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, SDL_ALPHA_OPAQUE);
     SDL_RenderClear(renderer);  /* just in case. */
     SDL_RenderTexture(renderer, render_target, NULL, NULL);
+    SDL_snprintf(debug_text, sizeof(debug_text), "Tilt: %f %f", tilt_x, tilt_y);
+    SDL_RenderDebugText(renderer, 0, 8, debug_text);
     SDL_RenderPresent(renderer);
     return SDL_APP_CONTINUE;  /* carry on with the program! */
 }

--- a/src/video/cocoa/SDL_cocoapen.m
+++ b/src/video/cocoa/SDL_cocoapen.m
@@ -135,7 +135,7 @@ static void Cocoa_HandlePenPointEvent(SDL_CocoaWindowData *_data, NSEvent *event
     SDL_SendPenAxis(timestamp, pen, window, SDL_PEN_AXIS_PRESSURE, [event pressure]);
     SDL_SendPenAxis(timestamp, pen, window, SDL_PEN_AXIS_ROTATION, [event rotation]);
     SDL_SendPenAxis(timestamp, pen, window, SDL_PEN_AXIS_XTILT, ((float) tilt.x) * 90.0f);
-    SDL_SendPenAxis(timestamp, pen, window, SDL_PEN_AXIS_YTILT, ((float) tilt.y) * 90.0f);
+    SDL_SendPenAxis(timestamp, pen, window, SDL_PEN_AXIS_YTILT, ((float) -tilt.y) * 90.0f);
     SDL_SendPenAxis(timestamp, pen, window, SDL_PEN_AXIS_TANGENTIAL_PRESSURE, event.tangentialPressure);
 }
 


### PR DESCRIPTION
- Negate tilt.y in Cocoa pen handling to correct inverted Y tilt axis
- Update drawing example to display X/Y tilt values for visualization
- see https://github.com/qt/qtbase/blob/0f128fd7c5a9ee721d1e631743f6eb61d927cf3b/src/plugins/platforms/cocoa/qnsview_tablet.mm#L63
- see https://source.chromium.org/chromium/chromium/src/+/main:components/input/web_input_event_builders_mac.mm;drc=0af5ffa1e4cc4cc4f818725f8fee93ec57855e4b;l=421
