### PR TITLE
check for backslashes as well as the forward slash

### DIFF
--- a/src/filesystem/SDL_filesystem.c
+++ b/src/filesystem/SDL_filesystem.c
@@ -363,16 +363,16 @@ char **SDL_InternalGlobDirectory(const char *path, const char *pattern, SDL_Glob
         return NULL;
     }
 
-    // if path ends with any '/', chop them off, so we don't confuse the pattern matcher later.
+    // if path ends with any slash, chop them off, so we don't confuse the pattern matcher later.
     char *pathcpy = NULL;
     size_t pathlen = SDL_strlen(path);
-    if ((pathlen > 1) && (path[pathlen-1] == '/')) {
+    if ((pathlen > 1) && ((path[pathlen-1] == '/') || (path[pathlen-1] == '\\'))) {
         pathcpy = SDL_strdup(path);
         if (!pathcpy) {
             return NULL;
         }
         char *ptr = &pathcpy[pathlen-1];
-        while ((ptr >= pathcpy) && (*ptr == '/')) {
+        while ((ptr >= pathcpy) && ((*ptr == '/') || (*ptr == '\\'))) {
             *(ptr--) = '\0';
         }
         path = pathcpy;


### PR DESCRIPTION
## Description
Checking for the backslash in addition to the forward slash. Tested on linux and windows via wine, with the code from the issue. Here is the outputs for each, before and after:

wine before fix:
  0.  xplorer.exe
  1.  h.exe
...
 54.  otepad.exe
 55.  egedit.exe
 56.  undll.exe
 57.  ystem.ini
 58.  wain.dll
 59.  wain_32.dll
 60.  in.ini
 61.  inhelp.exe
 62.  inhlp32.exe
 
 wine after fix:
   0.  explorer.exe
  1.  hh.exe
...
 54.  notepad.exe
 55.  regedit.exe
 56.  rundll.exe
 57.  system.ini
 58.  twain.dll
 59.  twain_32.dll
 60.  win.ini
 61.  winhelp.exe
 62.  winhlp32.exe

linux before fix:
  0.  libSDL3.dll.a
  1.  libSDL3_test.a
  2.  libjerry-core.a
  3.  libSDL3_test.a:Zone.Identifier
  4.  libjerry-port.a
  5.  libSDL3.dll.a:Zone.Identifier
  6.  libdxil.so
  7.  libjerry-ext.a
  8.  libdxcompiler.so
  
linux after fix:
  0.  libSDL3.dll.a
  1.  libSDL3_test.a
  2.  libjerry-core.a
  3.  libSDL3_test.a:Zone.Identifier
  4.  libjerry-port.a
  5.  libSDL3.dll.a:Zone.Identifier
  6.  libdxil.so
  7.  libjerry-ext.a
  8.  libdxcompiler.so

## Existing Issue(s)
resolves #12135 
