### PR TITLE
android: Remove SDL3-static from Android.mk

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -122,6 +122,8 @@ include $(BUILD_SHARED_LIBRARY)
 #
 ###########################
 
+include $(CLEAR_VARS)
+
 LOCAL_MODULE := SDL3_test
 
 LOCAL_MODULE_FILENAME := libSDL3_test
@@ -137,25 +139,3 @@ LOCAL_LDFLAGS :=
 LOCAL_EXPORT_LDLIBS :=
 
 include $(BUILD_STATIC_LIBRARY)
-
-
-###########################
-#
-# SDL static library
-#
-###########################
-
-LOCAL_MODULE := SDL3_static
-
-LOCAL_MODULE_FILENAME := libSDL3
-
-LOCAL_LDLIBS :=
-
-LOCAL_LDFLAGS :=
-
-LOCAL_EXPORT_LDLIBS := -ldl -lGLESv1_CM -lGLESv2 -llog -landroid
-
-include $(BUILD_STATIC_LIBRARY)
-
-$(call import-module,android/cpufeatures)
-


### PR DESCRIPTION
This removes the static SDL3 target from Android.mk

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
