### PR TITLE
do not build camera drivers if camera support is disabled

### DIFF
--- a/src/camera/SDL_camera.c
+++ b/src/camera/SDL_camera.c
@@ -32,6 +32,7 @@
 
 // Available camera drivers
 static const CameraBootStrap *const bootstrap[] = {
+#ifndef SDL_CAMERA_DISABLED
 #ifdef SDL_CAMERA_DRIVER_V4L2
     &V4L2_bootstrap,
 #endif
@@ -55,6 +56,7 @@ static const CameraBootStrap *const bootstrap[] = {
 #endif
 #ifdef SDL_CAMERA_DRIVER_DUMMY
     &DUMMYCAMERA_bootstrap,
+#endif
 #endif
     NULL
 };


### PR DESCRIPTION
## Description

The drivers are not needed if camera support as a whole is disabled.

## Existing Issue(s)

Also fixes a problem in our internal builds failing to build the (not needed) camera drivers.

cc @slouken 
