### PR TITLE
Call the windows message hook for WM_ENTERSIZEMOVE and WM_ENTERMENULOOP

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1721,6 +1721,10 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
     case WM_ENTERSIZEMOVE:
     case WM_ENTERMENULOOP:
     {
+        if (!DispatchModalLoopMessageHook(&hwnd, &msg, &wParam, &lParam)) {
+            return 0;
+        }
+
         ++data->in_modal_loop;
         if (data->in_modal_loop == 1) {
             data->initial_size_rect.left = data->window->x;


### PR DESCRIPTION
Fixes https://github.com/libsdl-org/SDL/issues/12169
