### PR TITLE
Formatting spaces around pointer symbol.

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -2112,7 +2112,7 @@ extern SDL_DECLSPEC bool SDLCALL SDL_GPUSupportsProperties(
  * \sa SDL_DestroyGPUDevice
  * \sa SDL_GPUSupportsShaderFormats
  */
-extern SDL_DECLSPEC SDL_GPUDevice *SDLCALL SDL_CreateGPUDevice(
+extern SDL_DECLSPEC SDL_GPUDevice * SDLCALL SDL_CreateGPUDevice(
     SDL_GPUShaderFormat format_flags,
     bool debug_mode,
     const char *name);
@@ -2160,7 +2160,7 @@ extern SDL_DECLSPEC SDL_GPUDevice *SDLCALL SDL_CreateGPUDevice(
  * \sa SDL_DestroyGPUDevice
  * \sa SDL_GPUSupportsProperties
  */
-extern SDL_DECLSPEC SDL_GPUDevice *SDLCALL SDL_CreateGPUDeviceWithProperties(
+extern SDL_DECLSPEC SDL_GPUDevice * SDLCALL SDL_CreateGPUDeviceWithProperties(
     SDL_PropertiesID props);
 
 #define SDL_PROP_GPU_DEVICE_CREATE_DEBUGMODE_BOOLEAN          "SDL.gpu.device.create.debugmode"
@@ -2283,7 +2283,7 @@ extern SDL_DECLSPEC SDL_GPUShaderFormat SDLCALL SDL_GetGPUShaderFormats(SDL_GPUD
  * \sa SDL_BindGPUComputePipeline
  * \sa SDL_ReleaseGPUComputePipeline
  */
-extern SDL_DECLSPEC SDL_GPUComputePipeline *SDLCALL SDL_CreateGPUComputePipeline(
+extern SDL_DECLSPEC SDL_GPUComputePipeline * SDLCALL SDL_CreateGPUComputePipeline(
     SDL_GPUDevice *device,
     const SDL_GPUComputePipelineCreateInfo *createinfo);
 
@@ -2310,7 +2310,7 @@ extern SDL_DECLSPEC SDL_GPUComputePipeline *SDLCALL SDL_CreateGPUComputePipeline
  * \sa SDL_BindGPUGraphicsPipeline
  * \sa SDL_ReleaseGPUGraphicsPipeline
  */
-extern SDL_DECLSPEC SDL_GPUGraphicsPipeline *SDLCALL SDL_CreateGPUGraphicsPipeline(
+extern SDL_DECLSPEC SDL_GPUGraphicsPipeline * SDLCALL SDL_CreateGPUGraphicsPipeline(
     SDL_GPUDevice *device,
     const SDL_GPUGraphicsPipelineCreateInfo *createinfo);
 
@@ -2337,7 +2337,7 @@ extern SDL_DECLSPEC SDL_GPUGraphicsPipeline *SDLCALL SDL_CreateGPUGraphicsPipeli
  * \sa SDL_BindGPUFragmentSamplers
  * \sa SDL_ReleaseGPUSampler
  */
-extern SDL_DECLSPEC SDL_GPUSampler *SDLCALL SDL_CreateGPUSampler(
+extern SDL_DECLSPEC SDL_GPUSampler * SDLCALL SDL_CreateGPUSampler(
     SDL_GPUDevice *device,
     const SDL_GPUSamplerCreateInfo *createinfo);
 
@@ -2416,7 +2416,7 @@ extern SDL_DECLSPEC SDL_GPUSampler *SDLCALL SDL_CreateGPUSampler(
  * \sa SDL_CreateGPUGraphicsPipeline
  * \sa SDL_ReleaseGPUShader
  */
-extern SDL_DECLSPEC SDL_GPUShader *SDLCALL SDL_CreateGPUShader(
+extern SDL_DECLSPEC SDL_GPUShader * SDLCALL SDL_CreateGPUShader(
     SDL_GPUDevice *device,
     const SDL_GPUShaderCreateInfo *createinfo);
 
@@ -2477,7 +2477,7 @@ extern SDL_DECLSPEC SDL_GPUShader *SDLCALL SDL_CreateGPUShader(
  * \sa SDL_ReleaseGPUTexture
  * \sa SDL_GPUTextureSupportsFormat
  */
-extern SDL_DECLSPEC SDL_GPUTexture *SDLCALL SDL_CreateGPUTexture(
+extern SDL_DECLSPEC SDL_GPUTexture * SDLCALL SDL_CreateGPUTexture(
     SDL_GPUDevice *device,
     const SDL_GPUTextureCreateInfo *createinfo);
 
@@ -2533,7 +2533,7 @@ extern SDL_DECLSPEC SDL_GPUTexture *SDLCALL SDL_CreateGPUTexture(
  * \sa SDL_DispatchGPUComputeIndirect
  * \sa SDL_ReleaseGPUBuffer
  */
-extern SDL_DECLSPEC SDL_GPUBuffer *SDLCALL SDL_CreateGPUBuffer(
+extern SDL_DECLSPEC SDL_GPUBuffer * SDLCALL SDL_CreateGPUBuffer(
     SDL_GPUDevice *device,
     const SDL_GPUBufferCreateInfo *createinfo);
 
@@ -2566,7 +2566,7 @@ extern SDL_DECLSPEC SDL_GPUBuffer *SDLCALL SDL_CreateGPUBuffer(
  * \sa SDL_DownloadFromGPUTexture
  * \sa SDL_ReleaseGPUTransferBuffer
  */
-extern SDL_DECLSPEC SDL_GPUTransferBuffer *SDLCALL SDL_CreateGPUTransferBuffer(
+extern SDL_DECLSPEC SDL_GPUTransferBuffer * SDLCALL SDL_CreateGPUTransferBuffer(
     SDL_GPUDevice *device,
     const SDL_GPUTransferBufferCreateInfo *createinfo);
 
@@ -2794,7 +2794,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_ReleaseGPUGraphicsPipeline(
  * \sa SDL_SubmitGPUCommandBuffer
  * \sa SDL_SubmitGPUCommandBufferAndAcquireFence
  */
-extern SDL_DECLSPEC SDL_GPUCommandBuffer *SDLCALL SDL_AcquireGPUCommandBuffer(
+extern SDL_DECLSPEC SDL_GPUCommandBuffer * SDLCALL SDL_AcquireGPUCommandBuffer(
     SDL_GPUDevice *device);
 
 /* Uniform Data */
@@ -2892,7 +2892,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_PushGPUComputeUniformData(
  *
  * \sa SDL_EndGPURenderPass
  */
-extern SDL_DECLSPEC SDL_GPURenderPass *SDLCALL SDL_BeginGPURenderPass(
+extern SDL_DECLSPEC SDL_GPURenderPass * SDLCALL SDL_BeginGPURenderPass(
     SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUColorTargetInfo *color_target_infos,
     Uint32 num_color_targets,
@@ -3299,7 +3299,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_EndGPURenderPass(
  *
  * \sa SDL_EndGPUComputePass
  */
-extern SDL_DECLSPEC SDL_GPUComputePass *SDLCALL SDL_BeginGPUComputePass(
+extern SDL_DECLSPEC SDL_GPUComputePass * SDLCALL SDL_BeginGPUComputePass(
     SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUStorageTextureReadWriteBinding *storage_texture_bindings,
     Uint32 num_storage_texture_bindings,
@@ -3470,7 +3470,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_EndGPUComputePass(
  *
  * \since This function is available since SDL 3.2.0.
  */
-extern SDL_DECLSPEC void *SDLCALL SDL_MapGPUTransferBuffer(
+extern SDL_DECLSPEC void * SDLCALL SDL_MapGPUTransferBuffer(
     SDL_GPUDevice *device,
     SDL_GPUTransferBuffer *transfer_buffer,
     bool cycle);
@@ -3501,7 +3501,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_UnmapGPUTransferBuffer(
  *
  * \since This function is available since SDL 3.2.0.
  */
-extern SDL_DECLSPEC SDL_GPUCopyPass *SDLCALL SDL_BeginGPUCopyPass(
+extern SDL_DECLSPEC SDL_GPUCopyPass * SDLCALL SDL_BeginGPUCopyPass(
     SDL_GPUCommandBuffer *command_buffer);
 
 /**
@@ -3993,7 +3993,7 @@ extern SDL_DECLSPEC bool SDLCALL SDL_SubmitGPUCommandBuffer(
  * \sa SDL_SubmitGPUCommandBuffer
  * \sa SDL_ReleaseGPUFence
  */
-extern SDL_DECLSPEC SDL_GPUFence *SDLCALL SDL_SubmitGPUCommandBufferAndAcquireFence(
+extern SDL_DECLSPEC SDL_GPUFence * SDLCALL SDL_SubmitGPUCommandBufferAndAcquireFence(
     SDL_GPUCommandBuffer *command_buffer);
 
 /**

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -4360,7 +4360,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_ResetHints(void);
  * \sa SDL_SetHint
  * \sa SDL_SetHintWithPriority
  */
-extern SDL_DECLSPEC const char *SDLCALL SDL_GetHint(const char *name);
+extern SDL_DECLSPEC const char * SDLCALL SDL_GetHint(const char *name);
 
 /**
  * Get the boolean value of a hint variable.

--- a/include/SDL3/SDL_mouse.h
+++ b/include/SDL3/SDL_mouse.h
@@ -353,7 +353,7 @@ extern SDL_DECLSPEC SDL_MouseButtonFlags SDLCALL SDL_GetRelativeMouseState(float
  *
  * \sa SDL_WarpMouseGlobal
  */
-extern SDL_DECLSPEC void SDLCALL SDL_WarpMouseInWindow(SDL_Window * window,
+extern SDL_DECLSPEC void SDLCALL SDL_WarpMouseInWindow(SDL_Window *window,
                                                    float x, float y);
 
 /**
@@ -514,8 +514,8 @@ extern SDL_DECLSPEC bool SDLCALL SDL_CaptureMouse(bool enabled);
  * \sa SDL_DestroyCursor
  * \sa SDL_SetCursor
  */
-extern SDL_DECLSPEC SDL_Cursor * SDLCALL SDL_CreateCursor(const Uint8 * data,
-                                                     const Uint8 * mask,
+extern SDL_DECLSPEC SDL_Cursor * SDLCALL SDL_CreateCursor(const Uint8 *data,
+                                                     const Uint8 *mask,
                                                      int w, int h, int hot_x,
                                                      int hot_y);
 

--- a/include/SDL3/SDL_process.h
+++ b/include/SDL3/SDL_process.h
@@ -103,7 +103,7 @@ typedef struct SDL_Process SDL_Process;
  * \sa SDL_WaitProcess
  * \sa SDL_DestroyProcess
  */
-extern SDL_DECLSPEC SDL_Process *SDLCALL SDL_CreateProcess(const char * const *args, bool pipe_stdio);
+extern SDL_DECLSPEC SDL_Process * SDLCALL SDL_CreateProcess(const char * const *args, bool pipe_stdio);
 
 /**
  * Description of where standard I/O should be directed when creating a
@@ -215,7 +215,7 @@ typedef enum SDL_ProcessIO
  * \sa SDL_WaitProcess
  * \sa SDL_DestroyProcess
  */
-extern SDL_DECLSPEC SDL_Process *SDLCALL SDL_CreateProcessWithProperties(SDL_PropertiesID props);
+extern SDL_DECLSPEC SDL_Process * SDLCALL SDL_CreateProcessWithProperties(SDL_PropertiesID props);
 
 #define SDL_PROP_PROCESS_CREATE_ARGS_POINTER                "SDL.process.create.args"
 #define SDL_PROP_PROCESS_CREATE_ENVIRONMENT_POINTER         "SDL.process.create.environment"
@@ -320,7 +320,7 @@ extern SDL_DECLSPEC void * SDLCALL SDL_ReadProcess(SDL_Process *process, size_t 
  * \sa SDL_CreateProcessWithProperties
  * \sa SDL_GetProcessOutput
  */
-extern SDL_DECLSPEC SDL_IOStream *SDLCALL SDL_GetProcessInput(SDL_Process *process);
+extern SDL_DECLSPEC SDL_IOStream * SDLCALL SDL_GetProcessInput(SDL_Process *process);
 
 /**
  * Get the SDL_IOStream associated with process standard output.
@@ -344,7 +344,7 @@ extern SDL_DECLSPEC SDL_IOStream *SDLCALL SDL_GetProcessInput(SDL_Process *proce
  * \sa SDL_CreateProcessWithProperties
  * \sa SDL_GetProcessInput
  */
-extern SDL_DECLSPEC SDL_IOStream *SDLCALL SDL_GetProcessOutput(SDL_Process *process);
+extern SDL_DECLSPEC SDL_IOStream * SDLCALL SDL_GetProcessOutput(SDL_Process *process);
 
 /**
  * Stop a process.

--- a/include/SDL3/SDL_test_common.h
+++ b/include/SDL3/SDL_test_common.h
@@ -177,7 +177,7 @@ extern "C" {
  *
  * \returns a newly allocated common state object.
  */
-SDLTest_CommonState *SDLCALL SDLTest_CommonCreateState(char **argv, SDL_InitFlags flags);
+SDLTest_CommonState * SDLCALL SDLTest_CommonCreateState(char **argv, SDL_InitFlags flags);
 
 /**
  * Free the common state object.

--- a/include/SDL3/SDL_thread.h
+++ b/include/SDL3/SDL_thread.h
@@ -139,7 +139,7 @@ typedef enum SDL_ThreadState
  *
  * \since This datatype is available since SDL 3.2.0.
  */
-typedef int (SDLCALL * SDL_ThreadFunction) (void *data);
+typedef int (SDLCALL *SDL_ThreadFunction) (void *data);
 
 
 #ifdef SDL_WIKI_DOCUMENTATION_SECTION

--- a/include/SDL3/SDL_tray.h
+++ b/include/SDL3/SDL_tray.h
@@ -118,7 +118,7 @@ typedef void (SDLCALL *SDL_TrayCallback)(void *userdata, SDL_TrayEntry *entry);
  * \sa SDL_GetTrayMenu
  * \sa SDL_DestroyTray
  */
-extern SDL_DECLSPEC SDL_Tray *SDLCALL SDL_CreateTray(SDL_Surface *icon, const char *tooltip);
+extern SDL_DECLSPEC SDL_Tray * SDLCALL SDL_CreateTray(SDL_Surface *icon, const char *tooltip);
 
 /**
  * Updates the system tray icon's icon.
@@ -172,7 +172,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_SetTrayTooltip(SDL_Tray *tray, const char *
  * \sa SDL_GetTrayMenu
  * \sa SDL_GetTrayMenuParentTray
  */
-extern SDL_DECLSPEC SDL_TrayMenu *SDLCALL SDL_CreateTrayMenu(SDL_Tray *tray);
+extern SDL_DECLSPEC SDL_TrayMenu * SDLCALL SDL_CreateTrayMenu(SDL_Tray *tray);
 
 /**
  * Create a submenu for a system tray entry.
@@ -196,7 +196,7 @@ extern SDL_DECLSPEC SDL_TrayMenu *SDLCALL SDL_CreateTrayMenu(SDL_Tray *tray);
  * \sa SDL_GetTraySubmenu
  * \sa SDL_GetTrayMenuParentEntry
  */
-extern SDL_DECLSPEC SDL_TrayMenu *SDLCALL SDL_CreateTraySubmenu(SDL_TrayEntry *entry);
+extern SDL_DECLSPEC SDL_TrayMenu * SDLCALL SDL_CreateTraySubmenu(SDL_TrayEntry *entry);
 
 /**
  * Gets a previously created tray menu.
@@ -220,7 +220,7 @@ extern SDL_DECLSPEC SDL_TrayMenu *SDLCALL SDL_CreateTraySubmenu(SDL_TrayEntry *e
  * \sa SDL_CreateTray
  * \sa SDL_CreateTrayMenu
  */
-extern SDL_DECLSPEC SDL_TrayMenu *SDLCALL SDL_GetTrayMenu(SDL_Tray *tray);
+extern SDL_DECLSPEC SDL_TrayMenu * SDLCALL SDL_GetTrayMenu(SDL_Tray *tray);
 
 /**
  * Gets a previously created tray entry submenu.
@@ -244,7 +244,7 @@ extern SDL_DECLSPEC SDL_TrayMenu *SDLCALL SDL_GetTrayMenu(SDL_Tray *tray);
  * \sa SDL_InsertTrayEntryAt
  * \sa SDL_CreateTraySubmenu
  */
-extern SDL_DECLSPEC SDL_TrayMenu *SDLCALL SDL_GetTraySubmenu(SDL_TrayEntry *entry);
+extern SDL_DECLSPEC SDL_TrayMenu * SDLCALL SDL_GetTraySubmenu(SDL_TrayEntry *entry);
 
 /**
  * Returns a list of entries in the menu, in order.
@@ -264,7 +264,7 @@ extern SDL_DECLSPEC SDL_TrayMenu *SDLCALL SDL_GetTraySubmenu(SDL_TrayEntry *entr
  * \sa SDL_RemoveTrayEntry
  * \sa SDL_InsertTrayEntryAt
  */
-extern SDL_DECLSPEC const SDL_TrayEntry **SDLCALL SDL_GetTrayEntries(SDL_TrayMenu *menu, int *size);
+extern SDL_DECLSPEC const SDL_TrayEntry ** SDLCALL SDL_GetTrayEntries(SDL_TrayMenu *menu, int *size);
 
 /**
  * Removes a tray entry.
@@ -307,7 +307,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_RemoveTrayEntry(SDL_TrayEntry *entry);
  * \sa SDL_RemoveTrayEntry
  * \sa SDL_GetTrayEntryParent
  */
-extern SDL_DECLSPEC SDL_TrayEntry *SDLCALL SDL_InsertTrayEntryAt(SDL_TrayMenu *menu, int pos, const char *label, SDL_TrayEntryFlags flags);
+extern SDL_DECLSPEC SDL_TrayEntry * SDLCALL SDL_InsertTrayEntryAt(SDL_TrayMenu *menu, int pos, const char *label, SDL_TrayEntryFlags flags);
 
 /**
  * Sets the label of an entry.
@@ -348,7 +348,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_SetTrayEntryLabel(SDL_TrayEntry *entry, con
  * \sa SDL_InsertTrayEntryAt
  * \sa SDL_SetTrayEntryLabel
  */
-extern SDL_DECLSPEC const char *SDLCALL SDL_GetTrayEntryLabel(SDL_TrayEntry *entry);
+extern SDL_DECLSPEC const char * SDLCALL SDL_GetTrayEntryLabel(SDL_TrayEntry *entry);
 
 /**
  * Sets whether or not an entry is checked.
@@ -481,7 +481,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_DestroyTray(SDL_Tray *tray);
  *
  * \sa SDL_InsertTrayEntryAt
  */
-extern SDL_DECLSPEC SDL_TrayMenu *SDLCALL SDL_GetTrayEntryParent(SDL_TrayEntry *entry);
+extern SDL_DECLSPEC SDL_TrayMenu * SDLCALL SDL_GetTrayEntryParent(SDL_TrayEntry *entry);
 
 /**
  * Gets the entry for which the menu is a submenu, if the current menu is a
@@ -501,7 +501,7 @@ extern SDL_DECLSPEC SDL_TrayMenu *SDLCALL SDL_GetTrayEntryParent(SDL_TrayEntry *
  * \sa SDL_CreateTraySubmenu
  * \sa SDL_GetTrayMenuParentTray
  */
-extern SDL_DECLSPEC SDL_TrayEntry *SDLCALL SDL_GetTrayMenuParentEntry(SDL_TrayMenu *menu);
+extern SDL_DECLSPEC SDL_TrayEntry * SDLCALL SDL_GetTrayMenuParentEntry(SDL_TrayMenu *menu);
 
 /**
  * Gets the tray for which this menu is the first-level menu, if the current
@@ -521,7 +521,7 @@ extern SDL_DECLSPEC SDL_TrayEntry *SDLCALL SDL_GetTrayMenuParentEntry(SDL_TrayMe
  * \sa SDL_CreateTrayMenu
  * \sa SDL_GetTrayMenuParentEntry
  */
-extern SDL_DECLSPEC SDL_Tray *SDLCALL SDL_GetTrayMenuParentTray(SDL_TrayMenu *menu);
+extern SDL_DECLSPEC SDL_Tray * SDLCALL SDL_GetTrayMenuParentTray(SDL_TrayMenu *menu);
 
 /**
  * Update the trays.

--- a/include/SDL3/SDL_vulkan.h
+++ b/include/SDL3/SDL_vulkan.h
@@ -226,7 +226,7 @@ extern SDL_DECLSPEC char const * const * SDLCALL SDL_Vulkan_GetInstanceExtension
 extern SDL_DECLSPEC bool SDLCALL SDL_Vulkan_CreateSurface(SDL_Window *window,
                                                               VkInstance instance,
                                                               const struct VkAllocationCallbacks *allocator,
-                                                              VkSurfaceKHR* surface);
+                                                              VkSurfaceKHR *surface);
 
 /**
  * Destroy the Vulkan rendering surface of a window.

--- a/src/core/SDL_core_unsupported.c
+++ b/src/core/SDL_core_unsupported.c
@@ -111,14 +111,14 @@ void SDL_SendAndroidBackButton(void)
     SDL_Unsupported();
 }
 
-SDL_DECLSPEC void *SDLCALL SDL_GetAndroidActivity(void);
+SDL_DECLSPEC void * SDLCALL SDL_GetAndroidActivity(void);
 void *SDL_GetAndroidActivity(void)
 {
     SDL_Unsupported();
     return NULL;
 }
 
-SDL_DECLSPEC const char *SDLCALL SDL_GetAndroidCachePath(void);
+SDL_DECLSPEC const char * SDLCALL SDL_GetAndroidCachePath(void);
 const char* SDL_GetAndroidCachePath(void)
 {
     SDL_Unsupported();
@@ -126,7 +126,7 @@ const char* SDL_GetAndroidCachePath(void)
 }
 
 
-SDL_DECLSPEC const char *SDLCALL SDL_GetAndroidExternalStoragePath(void);
+SDL_DECLSPEC const char * SDLCALL SDL_GetAndroidExternalStoragePath(void);
 const char* SDL_GetAndroidExternalStoragePath(void)
 {
     SDL_Unsupported();
@@ -139,14 +139,14 @@ Uint32 SDL_GetAndroidExternalStorageState(void)
     SDL_Unsupported();
     return 0;
 }
-SDL_DECLSPEC const char *SDLCALL SDL_GetAndroidInternalStoragePath(void);
+SDL_DECLSPEC const char * SDLCALL SDL_GetAndroidInternalStoragePath(void);
 const char *SDL_GetAndroidInternalStoragePath(void)
 {
     SDL_Unsupported();
     return NULL;
 }
 
-SDL_DECLSPEC void *SDLCALL SDL_GetAndroidJNIEnv(void);
+SDL_DECLSPEC void * SDLCALL SDL_GetAndroidJNIEnv(void);
 void *SDL_GetAndroidJNIEnv(void)
 {
     SDL_Unsupported();
@@ -171,7 +171,7 @@ bool SDL_SendAndroidMessage(Uint32 command, int param)
     return SDL_Unsupported();
 }
 
-SDL_DECLSPEC bool SDLCALL SDL_ShowAndroidToast(const char* message, int duration, int gravity, int xoffset, int yoffset);
+SDL_DECLSPEC bool SDLCALL SDL_ShowAndroidToast(const char *message, int duration, int gravity, int xoffset, int yoffset);
 bool SDL_ShowAndroidToast(const char* message, int duration, int gravity, int xoffset, int yoffset)
 {
     (void)message;

--- a/src/stdlib/SDL_malloc.c
+++ b/src/stdlib/SDL_malloc.c
@@ -6324,10 +6324,10 @@ History:
 #endif /* !HAVE_MALLOC */
 
 #ifdef HAVE_MALLOC
-static void* SDLCALL real_malloc(size_t s) { return malloc(s); }
-static void* SDLCALL real_calloc(size_t n, size_t s) { return calloc(n, s); }
-static void* SDLCALL real_realloc(void *p, size_t s) { return realloc(p,s); }
-static void  SDLCALL real_free(void *p) { free(p); }
+static void * SDLCALL real_malloc(size_t s) { return malloc(s); }
+static void * SDLCALL real_calloc(size_t n, size_t s) { return calloc(n, s); }
+static void * SDLCALL real_realloc(void *p, size_t s) { return realloc(p,s); }
+static void   SDLCALL real_free(void *p) { free(p); }
 #else
 #define real_malloc dlmalloc
 #define real_calloc dlcalloc

--- a/src/stdlib/SDL_qsort.c
+++ b/src/stdlib/SDL_qsort.c
@@ -361,7 +361,7 @@ typedef struct { char * first; char * last; } stack_entry;
 /* ---------------------------------------------------------------------- */
 
 static char * pivot_big(char *first, char *mid, char *last, size_t size,
-                        int (SDLCALL * compare)(void *, const void *, const void *), void *userdata) {
+                        int (SDLCALL *compare)(void *, const void *, const void *), void *userdata) {
   size_t d=(((last-first)/size)>>3)*size;
 #ifdef DEBUG_QSORT
 fprintf(stderr, "pivot_big: first=%p last=%p size=%lu n=%lu\n", first, (unsigned long)last, size, (unsigned long)((last-first+1)/size));
@@ -402,7 +402,7 @@ fprintf(stderr,"-> %d %d %d @ %p %p %p\n",*(int*)m1,*(int*)m2,*(int*)m3, m1,m2,m
 /* ---------------------------------------------------------------------- */
 
 static void qsort_r_nonaligned(void *base, size_t nmemb, size_t size,
-           int (SDLCALL * compare)(void *, const void *, const void *), void *userdata) {
+           int (SDLCALL *compare)(void *, const void *, const void *), void *userdata) {
 
   stack_entry stack[STACK_SIZE];
   int stacktop=0;
@@ -433,7 +433,7 @@ static void qsort_r_nonaligned(void *base, size_t nmemb, size_t size,
 }
 
 static void qsort_r_aligned(void *base, size_t nmemb, size_t size,
-           int (SDLCALL * compare)(void *,const void *, const void *), void *userdata) {
+           int (SDLCALL *compare)(void *,const void *, const void *), void *userdata) {
 
   stack_entry stack[STACK_SIZE];
   int stacktop=0;
@@ -464,7 +464,7 @@ static void qsort_r_aligned(void *base, size_t nmemb, size_t size,
 }
 
 static void qsort_r_words(void *base, size_t nmemb,
-           int (SDLCALL * compare)(void *,const void *, const void *), void *userdata) {
+           int (SDLCALL *compare)(void *,const void *, const void *), void *userdata) {
 
   stack_entry stack[STACK_SIZE];
   int stacktop=0;

--- a/src/test/SDL_test_memory.c
+++ b/src/test/SDL_test_memory.c
@@ -229,7 +229,7 @@ static void rand_fill_memory(void* ptr, size_t start, size_t end)
     }
 }
 
-static void *SDLCALL SDLTest_TrackedMalloc(size_t size)
+static void * SDLCALL SDLTest_TrackedMalloc(size_t size)
 {
     void *mem;
 
@@ -241,7 +241,7 @@ static void *SDLCALL SDLTest_TrackedMalloc(size_t size)
     return mem;
 }
 
-static void *SDLCALL SDLTest_TrackedCalloc(size_t nmemb, size_t size)
+static void * SDLCALL SDLTest_TrackedCalloc(size_t nmemb, size_t size)
 {
     void *mem;
 
@@ -252,7 +252,7 @@ static void *SDLCALL SDLTest_TrackedCalloc(size_t nmemb, size_t size)
     return mem;
 }
 
-static void *SDLCALL SDLTest_TrackedRealloc(void *ptr, size_t size)
+static void * SDLCALL SDLTest_TrackedRealloc(void *ptr, size_t size)
 {
     void *mem;
     size_t old_size = 0;

--- a/src/thread/SDL_thread.c
+++ b/src/thread/SDL_thread.c
@@ -314,7 +314,7 @@ static bool ThreadValid(SDL_Thread *thread)
 void SDL_RunThread(SDL_Thread *thread)
 {
     void *userdata = thread->userdata;
-    int(SDLCALL * userfunc)(void *) = thread->userfunc;
+    int(SDLCALL *userfunc)(void *) = thread->userfunc;
 
     int *statusloc = &thread->status;
 

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2154,7 +2154,7 @@ void SDL_ToggleDragAndDropSupport(void)
     }
 }
 
-SDL_Window **SDLCALL SDL_GetWindows(int *count)
+SDL_Window ** SDLCALL SDL_GetWindows(int *count)
 {
     if (count) {
         *count = 0;

--- a/test/testdialog.c
+++ b/test/testdialog.c
@@ -21,7 +21,7 @@ const SDL_DialogFileFilter filters[3] = {
     { "PNG images", "png" }
 };
 
-static void SDLCALL callback(void* userdata, const char* const* files, int filter) {
+static void SDLCALL callback(void *userdata, const char * const *files, int filter) {
     if (files) {
         const char* filter_name = "(filter fetching unsupported)";
 


### PR DESCRIPTION
This commit formats the spaces around pointer symbols.

Examples:

Space between pointer and `SDLCALL`:
```c
From: void *SDLCALL SDL_SomeFunction();
To:   void * SDLCALL SDL_SomeFunction();
```

Pointer directly besides parameter:
```c
From: void SDL_SomeFunction(void* param);
To:   void SDL_SomeFunction(void *param);
```

Pointer directly besides variable name:
```
From: void(SDLCALL * SDL_SomeFunctionPointer)();
To:   void(SDLCALL *SDL_SomeFunctionPointer)();
```