### PR TITLE
Check nullptr before calling the windows message hook for WM_ENTERSIZEMOVE and WM_ENTERMENULOOP

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1721,8 +1721,10 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
     case WM_ENTERSIZEMOVE:
     case WM_ENTERMENULOOP:
     {
-        if (!DispatchModalLoopMessageHook(&hwnd, &msg, &wParam, &lParam)) {
-            return 0;
+        if (g_WindowsMessageHook) {
+            if (!DispatchModalLoopMessageHook(&hwnd, &msg, &wParam, &lParam)) {
+                return 0;
+            }
         }
 
         ++data->in_modal_loop;


### PR DESCRIPTION
## Description
This change ensures that the `DispatchModalLoopMessageHook` function is only called if the `g_WindowsMessageHook` is set.

## Existing Issue(s)

