### PR TITLE
Allow OpenGL initialization on XB1 and XSX.

### DIFF
--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -842,6 +842,7 @@ bool WIN_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Properties
             return WIN_SetError("SetPixelFormat()");
         }
     } else {
+#endif // !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
         if (!(window->flags & SDL_WINDOW_OPENGL)) {
             return true;
         }
@@ -874,6 +875,7 @@ bool WIN_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Properties
 #else
         return SDL_SetError("Could not create GL window (WGL support not configured)");
 #endif
+#if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
     }
 #endif // !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
 


### PR DESCRIPTION
## Description
This allows an OpenGL context to be properly created on XB1 and XSX platforms. We use the OGL to DX12 wrapper in Mesa/Gallium and the ifdef'ed out code was preventing `WIN_GL_SetupWindow` from being called. That's something we caught while migrating from SDL2 to SDL3. The SDL2 code has this code active for XB1 and XSX and it still work correctly there.

## Existing Issue(s)
(None)
