### PR TITLE
Remove #undef __3DS__

### DIFF
--- a/include/SDL3/SDL_platform_defines.h
+++ b/include/SDL3/SDL_platform_defines.h
@@ -471,8 +471,6 @@
  * \since This macro is available since SDL 3.2.0.
  */
 #define SDL_PLATFORM_3DS 1
-
-#undef __3DS__
 #endif
 
 #endif /* SDL_platform_defines_h_ */


### PR DESCRIPTION
I spotted this when reviewing the N-Gage PR - `__3DS__` is defined by the toolchain, meaning that undefining is likely to cause problems for other projects where the SDL headers are included.