### PR TITLE
dbus: fix spurious leak reports with SDL_SHUTDOWN_DBUS_ON_QUIT=0

### DIFF
--- a/src/core/linux/SDL_dbus.c
+++ b/src/core/linux/SDL_dbus.c
@@ -189,10 +189,16 @@ void SDL_DBus_Quit(void)
         if (dbus.shutdown) {
             dbus.shutdown();
         }
+
+        UnloadDBUSLibrary();
+    } else {
+        /* Leaving libdbus loaded when skipping dbus_shutdown() avoids
+         * spurious leak warnings from LeakSanitizer on internal D-Bus
+         * allocations that would be freed by dbus_shutdown(). */
+        dbus_handle = NULL;
     }
 
     SDL_zero(dbus);
-    UnloadDBUSLibrary();
     if (inhibit_handle) {
         SDL_free(inhibit_handle);
         inhibit_handle = NULL;


### PR DESCRIPTION
## Description
This is somewhat of an RFC PR to address the D-Bus related leak reports mentioned in various bug reports here and in sdl2-compat. LeakSanitizer is detecting these leaks because `libdbus-1.so` was unloaded by `SDL_DBus_Quit()` without calling `dbus_shutdown()`. This will be the case for most SDL-based apps that don't also use D-Bus themselves or set `SDL_SHUTDOWN_DBUS_ON_QUIT=1` to ask us to call `dbus_shutdown()` ourselves. We can avoid these false warnings by leaving `libdbus-1.so` loaded in cases that we don't do a `dbus_shutdown()` to clean it up properly.

Since many shared libraries remain loaded throughout the whole process lifetime, LeakSanitizer does not perform leak checks for loaded shared libraries (they may have legitimate allocations that are managed internally and not expected to be freed until they unload). We can take advantage of this to avoid the spurious LeakSanitizer warnings and allow SDL apps to be LSan-clean out of the box.

No longer unloading `libdbus-1.so` seems unlikely to cause any trouble because:
- It's likely that apps are calling `SDL_Quit()` shortly before termination, where the memory is going to be freed regardless of what we do
- Apps that repeatedly quit and reinitialize SDL for whatever reason would benefit from not continuously loading and unloading `libdbus-1.so`
- Apps that use D-Bus themselves (and thus need `SDL_SHUTDOWN_DBUS_ON_QUIT=0`) will see no behavior change since the library would remain loaded in that case anyway
- `libdbus-1.so` is small (~350 KB as found on my Fedora 41 system) so even if it does hang around for a while, it's unlikely to noticably increase application memory usage

## Existing Issue(s)
https://github.com/libsdl-org/sdl2-compat/issues/255