### PR TITLE
SDL_GetTrayEntries(): Rename parameter `size` to `count`

### DIFF
--- a/include/SDL3/SDL_tray.h
+++ b/include/SDL3/SDL_tray.h
@@ -250,7 +250,7 @@ extern SDL_DECLSPEC SDL_TrayMenu * SDLCALL SDL_GetTraySubmenu(SDL_TrayEntry *ent
  * Returns a list of entries in the menu, in order.
  *
  * \param menu The menu to get entries from.
- * \param size An optional pointer to obtain the number of entries in the
+ * \param count An optional pointer to obtain the number of entries in the
  *             menu.
  * \returns a NULL-terminated list of entries within the given menu. The
  *          pointer becomes invalid when any function that inserts or deletes
@@ -264,7 +264,7 @@ extern SDL_DECLSPEC SDL_TrayMenu * SDLCALL SDL_GetTraySubmenu(SDL_TrayEntry *ent
  * \sa SDL_RemoveTrayEntry
  * \sa SDL_InsertTrayEntryAt
  */
-extern SDL_DECLSPEC const SDL_TrayEntry ** SDLCALL SDL_GetTrayEntries(SDL_TrayMenu *menu, int *size);
+extern SDL_DECLSPEC const SDL_TrayEntry ** SDLCALL SDL_GetTrayEntries(SDL_TrayMenu *menu, int *count);
 
 /**
  * Removes a tray entry.

--- a/src/tray/cocoa/SDL_tray.m
+++ b/src/tray/cocoa/SDL_tray.m
@@ -285,15 +285,15 @@ SDL_TrayMenu *SDL_GetTraySubmenu(SDL_TrayEntry *entry)
     return entry->submenu;
 }
 
-const SDL_TrayEntry **SDL_GetTrayEntries(SDL_TrayMenu *menu, int *size)
+const SDL_TrayEntry **SDL_GetTrayEntries(SDL_TrayMenu *menu, int *count)
 {
     if (!menu) {
         SDL_InvalidParamError("menu");
         return NULL;
     }
 
-    if (size) {
-        *size = menu->nEntries;
+    if (count) {
+        *count = menu->nEntries;
     }
     return (const SDL_TrayEntry **)menu->entries;
 }

--- a/src/tray/dummy/SDL_tray.c
+++ b/src/tray/dummy/SDL_tray.c
@@ -66,7 +66,7 @@ SDL_TrayMenu *SDL_GetTraySubmenu(SDL_TrayEntry *entry)
     return NULL;
 }
 
-const SDL_TrayEntry **SDL_GetTrayEntries(SDL_TrayMenu *menu, int *size)
+const SDL_TrayEntry **SDL_GetTrayEntries(SDL_TrayMenu *menu, int *count)
 {
     SDL_InvalidParamError("menu");
     return NULL;

--- a/src/tray/unix/SDL_tray.c
+++ b/src/tray/unix/SDL_tray.c
@@ -540,15 +540,15 @@ SDL_TrayMenu *SDL_GetTraySubmenu(SDL_TrayEntry *entry)
     return entry->submenu;
 }
 
-const SDL_TrayEntry **SDL_GetTrayEntries(SDL_TrayMenu *menu, int *size)
+const SDL_TrayEntry **SDL_GetTrayEntries(SDL_TrayMenu *menu, int *count)
 {
     if (!menu) {
         SDL_InvalidParamError("menu");
         return NULL;
     }
 
-    if (size) {
-        *size = menu->nEntries;
+    if (count) {
+        *count = menu->nEntries;
     }
     return (const SDL_TrayEntry **)menu->entries;
 }

--- a/src/tray/windows/SDL_tray.c
+++ b/src/tray/windows/SDL_tray.c
@@ -367,15 +367,15 @@ SDL_TrayMenu *SDL_GetTraySubmenu(SDL_TrayEntry *entry)
     return entry->submenu;
 }
 
-const SDL_TrayEntry **SDL_GetTrayEntries(SDL_TrayMenu *menu, int *size)
+const SDL_TrayEntry **SDL_GetTrayEntries(SDL_TrayMenu *menu, int *count)
 {
     if (!menu) {
         SDL_InvalidParamError("menu");
         return NULL;
     }
 
-    if (size) {
-        *size = menu->nEntries;
+    if (count) {
+        *count = menu->nEntries;
     }
     return (const SDL_TrayEntry **)menu->entries;
 }


### PR DESCRIPTION
Most parameters use the name `count` for the number of elements.

For comparison:
```c
SDL_AudioDeviceID * SDL_GetAudioPlaybackDevices(int *count);
SDL_AudioDeviceID * SDL_GetAudioRecordingDevices(int *count);
int * SDL_GetAudioDeviceChannelMap(SDL_AudioDeviceID devid, int *count);
int * SDL_GetAudioStreamInputChannelMap(SDL_AudioStream *stream, int *count);
int * SDL_GetAudioStreamOutputChannelMap(SDL_AudioStream *stream, int *count);
SDL_CameraID * SDL_GetCameras(int *count);
SDL_CameraSpec ** SDL_GetCameraSupportedFormats(SDL_CameraID instance_id, int *count);
char ** SDL_GlobDirectory(const char *path, const char *pattern, SDL_GlobFlags flags, int *count);
char ** SDL_GetGamepadMappings(int *count);
SDL_JoystickID * SDL_GetGamepads(int *count);
SDL_GamepadBinding ** SDL_GetGamepadBindings(SDL_Gamepad *gamepad, int *count);
SDL_HapticID * SDL_GetHaptics(int *count);
SDL_JoystickID * SDL_GetJoysticks(int *count);
SDL_KeyboardID * SDL_GetKeyboards(int *count);
SDL_Locale ** SDL_GetPreferredLocales(int *count);
SDL_MouseID * SDL_GetMice(int *count);
SDL_SensorID * SDL_GetSensors(int *count);
char ** SDL_GlobStorageDirectory(SDL_Storage *storage, const char *path, const char *pattern, SDL_GlobFlags flags, int *count);
SDL_Surface ** SDL_GetSurfaceImages(SDL_Surface *surface, int *count);
SDL_TouchID * SDL_GetTouchDevices(int *count);
SDL_Finger ** SDL_GetTouchFingers(SDL_TouchID touchID, int *count);
SDL_DisplayID * SDL_GetDisplays(int *count);
SDL_DisplayMode ** SDL_GetFullscreenDisplayModes(SDL_DisplayID displayID, int *count);
SDL_Window ** SDL_GetWindows(int *count);
char const * const * SDL_Vulkan_GetInstanceExtensions(Uint32 *count);
```