### PR TITLE
SDL2: Fix mingw32 makefile

### DIFF
--- a/mingw/pkg-support/Makefile
+++ b/mingw/pkg-support/Makefile
@@ -30,7 +30,7 @@ install-package:
 	    	-e "s|^set[(]libdir \".*|set(libdir \"$(prefix)/lib\")|" <$(arch)/lib/cmake/SDL2/sdl2-config.cmake >$(prefix)/lib/cmake/SDL2/sdl2-config.cmake; \
 	    sed -e "s|^prefix=.*|prefix=$(prefix)|" \
 	    	-e "s|^includedir=.*|includedir=$(prefix)/include|" \
-	    	-e "s|^libdir=.*|prefix=$(prefix)/lib|" <$(arch)/lib/pkgconfig/sdl2.pc >$(prefix)/lib/pkgconfig/sdl2.pc; \
+	    	-e "s|^libdir=.*|libdir=$(prefix)/lib|" <$(arch)/lib/pkgconfig/sdl2.pc >$(prefix)/lib/pkgconfig/sdl2.pc; \
 	else \
 	    echo "*** ERROR: $(arch) or $(prefix) does not exist!"; \
 	    exit 1; \

--- a/mingw/pkg-support/Makefile
+++ b/mingw/pkg-support/Makefile
@@ -5,18 +5,18 @@ CROSS_PATH := /usr/local
 ARCHITECTURES := i686-w64-mingw32 x86_64-w64-mingw32
 
 all install:
-	@echo "Type \"make native\" to install 32-bit to /usr"
-	@echo "Type \"make cross\" to install 32-bit and 64-bit to $(CROSS_PATH)"
+	@echo "Type \"$(MAKE) native\" to install 32-bit to /usr"
+	@echo "Type \"$(MAKE) cross\" to install 32-bit and 64-bit to $(CROSS_PATH)"
 
 native:
-	make install-package arch=i686-w64-mingw32 prefix=/usr
+	$(MAKE) install-package arch=i686-w64-mingw32 prefix=/usr
 
 cross:
 	mkdir -p $(CROSS_PATH)/cmake
 	cp -rv cmake/* $(CROSS_PATH)/cmake
 	for arch in $(ARCHITECTURES); do \
 	    mkdir -p $(CROSS_PATH)/$$arch; \
-	    make install-package arch=$$arch prefix=$(CROSS_PATH)/$$arch; \
+	    $(MAKE) install-package arch=$$arch prefix=$(CROSS_PATH)/$$arch; \
 	done
 
 install-package:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fix the  sdl2.pc produced by the mingw32 devel package Makefile. (bug introduced in 2.30.10)

Also use $(MAKE) instead of assuming make

Note : this PR is for SDL2 branch

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
see #12191