### PR TITLE
add private definitions to SDL_build_config.h.cmake

### DIFF
--- a/include/build_config/SDL_build_config.h.cmake
+++ b/include/build_config/SDL_build_config.h.cmake
@@ -31,6 +31,8 @@
 /* General platform specific identifiers */
 #include <SDL3/SDL_platform_defines.h>
 
+#cmakedefine SDL_PLATFORM_PRIVATE 1
+
 #cmakedefine HAVE_GCC_ATOMICS 1
 #cmakedefine HAVE_GCC_SYNC_LOCK_TEST_AND_SET 1
 
@@ -274,6 +276,8 @@
 #cmakedefine SDL_AUDIO_DRIVER_N3DS 1
 #cmakedefine SDL_AUDIO_DRIVER_QNX 1
 
+#cmakedefine SDL_AUDIO_DRIVER_PRIVATE 1
+
 /* Enable various input drivers */
 #cmakedefine SDL_INPUT_LINUXEV 1
 #cmakedefine SDL_INPUT_LINUXKD 1
@@ -299,11 +303,17 @@
 #cmakedefine SDL_JOYSTICK_VITA 1
 #cmakedefine SDL_JOYSTICK_WGI 1
 #cmakedefine SDL_JOYSTICK_XINPUT 1
+
+#cmakedefine SDL_JOYSTICK_PRIVATE 1
+
 #cmakedefine SDL_HAPTIC_DUMMY 1
 #cmakedefine SDL_HAPTIC_LINUX 1
 #cmakedefine SDL_HAPTIC_IOKIT 1
 #cmakedefine SDL_HAPTIC_DINPUT 1
 #cmakedefine SDL_HAPTIC_ANDROID 1
+
+#cmakedefine SDL_HAPTIC_PRIVATE 1
+
 #cmakedefine SDL_LIBUSB_DYNAMIC @SDL_LIBUSB_DYNAMIC@
 #cmakedefine SDL_UDEV_DYNAMIC @SDL_UDEV_DYNAMIC@
 
@@ -311,6 +321,8 @@
 #cmakedefine SDL_PROCESS_DUMMY 1
 #cmakedefine SDL_PROCESS_POSIX 1
 #cmakedefine SDL_PROCESS_WINDOWS 1
+
+#cmakedefine SDL_PROCESS_PRIVATE 1
 
 /* Enable various sensor drivers */
 #cmakedefine SDL_SENSOR_ANDROID 1
@@ -320,10 +332,14 @@
 #cmakedefine SDL_SENSOR_VITA 1
 #cmakedefine SDL_SENSOR_N3DS 1
 
+#cmakedefine SDL_SENSOR_PRIVATE 1
+
 /* Enable various shared object loading systems */
 #cmakedefine SDL_LOADSO_DLOPEN 1
 #cmakedefine SDL_LOADSO_DUMMY 1
 #cmakedefine SDL_LOADSO_WINDOWS 1
+
+#cmakedefine SDL_LOADSO_PRIVATE 1
 
 /* Enable various threading systems */
 #cmakedefine SDL_THREAD_GENERIC_COND_SUFFIX 1
@@ -336,6 +352,8 @@
 #cmakedefine SDL_THREAD_PSP 1
 #cmakedefine SDL_THREAD_PS2 1
 #cmakedefine SDL_THREAD_N3DS 1
+
+#cmakedefine SDL_THREAD_PRIVATE 1
 
 /* Enable various RTC systems */
 #cmakedefine SDL_TIME_UNIX 1
@@ -353,6 +371,8 @@
 #cmakedefine SDL_TIMER_PSP 1
 #cmakedefine SDL_TIMER_PS2 1
 #cmakedefine SDL_TIMER_N3DS 1
+
+#cmakedefine SDL_TIMER_PRIVATE 1
 
 /* Enable various video drivers */
 #cmakedefine SDL_VIDEO_DRIVER_ANDROID 1
@@ -403,6 +423,8 @@
 #cmakedefine SDL_VIDEO_DRIVER_X11_XSYNC 1
 #cmakedefine SDL_VIDEO_DRIVER_QNX 1
 
+#cmakedefine SDL_VIDEO_DRIVER_PRIVATE 1
+
 #cmakedefine SDL_VIDEO_RENDER_D3D 1
 #cmakedefine SDL_VIDEO_RENDER_D3D11 1
 #cmakedefine SDL_VIDEO_RENDER_D3D12 1
@@ -415,6 +437,8 @@
 #cmakedefine SDL_VIDEO_RENDER_PSP 1
 #cmakedefine SDL_VIDEO_RENDER_VITA_GXM 1
 
+#cmakedefine SDL_VIDEO_RENDER_PRIVATE 1
+
 /* Enable OpenGL support */
 #cmakedefine SDL_VIDEO_OPENGL 1
 #cmakedefine SDL_VIDEO_OPENGL_ES 1
@@ -423,6 +447,8 @@
 #cmakedefine SDL_VIDEO_OPENGL_GLX 1
 #cmakedefine SDL_VIDEO_OPENGL_WGL 1
 #cmakedefine SDL_VIDEO_OPENGL_EGL 1
+
+#cmakedefine SDL_VIDEO_STATIC_ANGLE 1
 
 /* Enable Vulkan support */
 #cmakedefine SDL_VIDEO_VULKAN 1
@@ -449,6 +475,8 @@
 #cmakedefine SDL_POWER_PSP 1
 #cmakedefine SDL_POWER_N3DS 1
 
+#cmakedefine SDL_POWER_PRIVATE 1
+
 /* Enable system filesystem support */
 #cmakedefine SDL_FILESYSTEM_ANDROID 1
 #cmakedefine SDL_FILESYSTEM_HAIKU 1
@@ -463,6 +491,8 @@
 #cmakedefine SDL_FILESYSTEM_PS2 1
 #cmakedefine SDL_FILESYSTEM_N3DS 1
 
+#cmakedefine SDL_FILESYSTEM_PRIVATE 1
+
 /* Enable system storage support */
 #cmakedefine SDL_STORAGE_STEAM @SDL_STORAGE_STEAM@
 
@@ -470,6 +500,8 @@
 #cmakedefine SDL_FSOPS_POSIX 1
 #cmakedefine SDL_FSOPS_WINDOWS 1
 #cmakedefine SDL_FSOPS_DUMMY 1
+
+#cmakedefine SDL_FSOPS_PRIVATE 1
 
 /* Enable camera subsystem */
 #cmakedefine SDL_CAMERA_DRIVER_DUMMY 1
@@ -482,6 +514,8 @@
 #cmakedefine SDL_CAMERA_DRIVER_PIPEWIRE 1
 #cmakedefine SDL_CAMERA_DRIVER_PIPEWIRE_DYNAMIC @SDL_CAMERA_DRIVER_PIPEWIRE_DYNAMIC@
 #cmakedefine SDL_CAMERA_DRIVER_VITA 1
+
+#cmakedefine SDL_CAMERA_DRIVER_PRIVATE 1
 
 /* Enable dialog subsystem */
 #cmakedefine SDL_DIALOG_DUMMY 1
@@ -544,5 +578,9 @@ typedef unsigned int uintptr_t;
 #cmakedefine SDL_DISABLE_LSX 1
 #cmakedefine SDL_DISABLE_LASX 1
 #cmakedefine SDL_DISABLE_NEON 1
+
+#ifdef SDL_PLATFORM_PRIVATE
+#include "SDL_end_config_private.h"
+#endif
 
 #endif /* SDL_build_config_h_ */


### PR DESCRIPTION
Hi, I'm adding CMake support for some of the private targets, and for them to work with the automatically generated config file all these definitions are needed (well, at least some of them of course).

Maybe the most "controversial" one will be the last conditional include. I made it that way because that allows us to undefine certain automatically detected functions that are incorrectly detected, as well as manually add anything we need, but I'm open to suggestions about how to tackle that (without modifying the main `CMakeLists.txt` which was the whole point).

This is not the only thing needed, there are other things I needed but we can discuss them on their respective repos.