### PR TITLE
Remove non-ASCII character from public header SDL_hints.h

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2349,7 +2349,7 @@ extern "C" {
 #define SDL_HINT_MAC_OPENGL_ASYNC_DISPATCH "SDL_MAC_OPENGL_ASYNC_DISPATCH"
 
 /**
- * A variable controlling whether the Option (⌥) key on macOS should be
+ * A variable controlling whether the Option key on macOS should be
  * remapped to act as the Alt key.
  *
  * The variable can be set to the following values:


### PR DESCRIPTION
This is currently the only non-ASCII character in the public headers.