### PR TITLE
Fix for 500ms hang after user clicks on the title bar, but before moving

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1525,6 +1525,15 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
     case WM_NCLBUTTONDOWN:
     {
         data->in_title_click = true;
+
+        // Fix for 500ms hang after user clicks on the title bar, but before moving mouse
+        if (SendMessage(hwnd, WM_NCHITTEST, wParam, lParam) == HTCAPTION)
+        {
+            POINT point;
+            GetCursorPos(&point);
+            ScreenToClient(hwnd, &point);
+            PostMessage(hwnd, WM_MOUSEMOVE, 0, point.x | point.y << 16);
+        }
     } break;
 
     case WM_CAPTURECHANGED:

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1527,8 +1527,8 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
         data->in_title_click = true;
 
         // Fix for 500ms hang after user clicks on the title bar, but before moving mouse
-        if (SendMessage(hwnd, WM_NCHITTEST, wParam, lParam) == HTCAPTION)
-        {
+        // Reference: https://gamedev.net/forums/topic/672094-keeping-things-moving-during-win32-moveresize-events/5254386/
+        if (SendMessage(hwnd, WM_NCHITTEST, wParam, lParam) == HTCAPTION) {
             POINT cursorPos;
             GetCursorPos(&cursorPos);
             ScreenToClient(hwnd, &cursorPos);

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1529,10 +1529,10 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
         // Fix for 500ms hang after user clicks on the title bar, but before moving mouse
         if (SendMessage(hwnd, WM_NCHITTEST, wParam, lParam) == HTCAPTION)
         {
-            POINT point;
-            GetCursorPos(&point);
-            ScreenToClient(hwnd, &point);
-            PostMessage(hwnd, WM_MOUSEMOVE, 0, point.x | point.y << 16);
+            POINT cursorPos;
+            GetCursorPos(&cursorPos);
+            ScreenToClient(hwnd, &cursorPos);
+            PostMessage(hwnd, WM_MOUSEMOVE, 0, cursorPos.x | cursorPos.y << 16);
         }
     } break;
 


### PR DESCRIPTION
This is for Windows.

Reference: https://gamedev.net/forums/topic/672094-keeping-things-moving-during-win32-moveresize-events/5254386/

Based on the above reference, this change fixes the hang for me. The expose event fires immediately upon clicking, instead of hanging for 0.5 seconds.