### PR TITLE
Fix SSE 4.2 test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -751,7 +751,7 @@ if(SDL_ASSEMBLY)
   if(SDL_SSE4_2)
     cmake_push_check_state()
     if(USE_GCC OR USE_CLANG OR USE_INTELCC)
-      string(APPEND CMAKE_REQUIRED_FLAGS " -msse4.2")
+      string(APPEND CMAKE_REQUIRED_FLAGS " -msse4.2 -mcrc32")
     endif()
     check_c_source_compiles("
       #include <nmmintrin.h>


### PR DESCRIPTION
When building with zig cc I get:

```
error: always_inline function '_mm_crc32_u32' requires target feature 'crc32', but would be inlined into function 'calc_crc32c' that is compiled without support for 'crc32'
    5 |       crc32c = (unsigned)_mm_crc32_u32(crc32c, *(unsigned*)text);
      |                          ^
1 error generated.
```

This PR adds -mcrc32, another option would be to use a different SSE4.2 op