### PR TITLE
Fix GTK tray icons without menu

### DIFF
--- a/src/tray/unix/SDL_tray.c
+++ b/src/tray/unix/SDL_tray.c
@@ -326,6 +326,8 @@ struct SDL_Tray {
     SDL_TrayMenu *menu;
     char icon_dir[sizeof(ICON_DIR_TEMPLATE)];
     char icon_path[256];
+
+    GtkMenuShell *menu_cached;
 };
 
 static void call_callback(GtkMenuItem *item, gpointer ptr)
@@ -433,6 +435,10 @@ SDL_Tray *SDL_CreateTray(SDL_Surface *icon, const char *tooltip)
 
     app_indicator_set_status(tray->indicator, APP_INDICATOR_STATUS_ACTIVE);
 
+    // The tray icon isn't shown before a menu is created; create one early.
+    tray->menu_cached = (GtkMenuShell *) gtk_menu_new();
+    app_indicator_set_menu(tray->indicator, GTK_MENU(tray->menu_cached));
+
     SDL_RegisterTray(tray);
 
     return tray;
@@ -476,13 +482,11 @@ SDL_TrayMenu *SDL_CreateTrayMenu(SDL_Tray *tray)
         return NULL;
     }
 
-    tray->menu->menu = (GtkMenuShell *)gtk_menu_new();
+    tray->menu->menu = tray->menu_cached;
     tray->menu->parent_tray = tray;
     tray->menu->parent_entry = NULL;
     tray->menu->nEntries = 0;
     tray->menu->entries = NULL;
-
-    app_indicator_set_menu(tray->indicator, GTK_MENU(tray->menu->menu));
 
     return tray->menu;
 }


### PR DESCRIPTION
## Description

Trays without menu on Unix (using GTK) were not shown in the system tray bar if they did not have a menu. This has been fixed by creating a tray's menu early.

Trays with an empty menu showed an undesired warning when they were "About to Show"; all GTK warnings have been silenced by setting a custom logging function that does nothing.

---

Additionally, there was a small issue: GTK was init'ed only in the non-`APPINDICATOR_HEADER` implementation of `init_gtk`. This currently does not cause any problem in practice since the macro is unused, but it may result in problems with future maintenance. I've copied over the relevant code to the other implementation, and I added comments to avoid similar future mistakes.

## Existing Issue(s)

Fixes #12092 (both bugs)
