### PR TITLE
Memory Leak in WIN_CreateHCursor When CreateColorBitmap Fails

### DIFF
--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -210,6 +210,12 @@ static HCURSOR WIN_CreateHCursor(SDL_Surface *surface, int hot_x, int hot_y)
 
     if (!ii.hbmMask || (!is_monochrome && !ii.hbmColor)) {
         SDL_SetError("Couldn't create cursor bitmaps");
+        if (ii.hbmMask) {
+            DeleteObject(ii.hbmMask);
+        }
+        if (ii.hbmColor) {
+            DeleteObject(ii.hbmColor);
+        }
         return NULL;
     }
 


### PR DESCRIPTION
## Description
There is a potential resource leak in `WIN_CreateHCursor`. If `CreateColorBitmap(surface)` fails for non-monochrome surfaces, the function exits without freeing `ii.hbmMask`, leading to a memory leak.