### PR TITLE
Proper Resource Cleanup in WIN_UpdateWindowShape

### DIFF
--- a/src/video/windows/SDL_windowsshape.c
+++ b/src/video/windows/SDL_windowsshape.c
@@ -116,6 +116,7 @@ bool WIN_UpdateWindowShape(SDL_VideoDevice *_this, SDL_Window *window, SDL_Surfa
         }
     }
     if (!SetWindowRgn(data->hwnd, mask, TRUE)) {
+        DeleteObject(mask);
         return WIN_SetError("SetWindowRgn failed");
     }
     return true;


### PR DESCRIPTION
## Description
`mask` is created but never deleted if `SetWindowRgn()` fails. This may lead to resource leaks, as the allocated region remains in memory. To fix this, we should call DeleteObject(mask); before returning in case of failure.
