### PR TITLE
joystick: Fix PS5 player LED hint change callback name

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_ps5.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps5.c
@@ -952,7 +952,7 @@ static bool HIDAPI_DriverPS5_OpenJoystick(SDL_HIDAPI_Device *device, SDL_Joystic
 
     SDL_AddHintCallback(SDL_HINT_JOYSTICK_ENHANCED_REPORTS,
                         SDL_PS5EnhancedReportsChanged, ctx);
-    SDL_AddHintCallback(SDL_HINT_JOYSTICK_ENHANCED_REPORTS,
+    SDL_AddHintCallback(SDL_HINT_JOYSTICK_HIDAPI_PS5_PLAYER_LED,
                         SDL_PS5PlayerLEDHintChanged, ctx);
 
     return true;


### PR DESCRIPTION
In my application, I allow users to toggle an option which eventually ends up resetting a few of the available joystick hints. One of these options toggles the "enhanced reports" functionality for PS4/PS5 controllers (and others?)

One user reported that when these options were changed, it crashed in `SDL_SetHint -> SDL_SetHint_REAL -> SDL_SetHintWithPriority_REAL -> SDL_PS5PlayerLEDHintChanged -> HIDAPI_DriverPS5_UpdateEffects`.

This is an odd setup, and not one I encourage, but crashing here is obviously not the expected behaviour.

## Description

Some quick debugging showed that this was a use-after-free, caused by the LED callback being registered for `SDL_HINT_JOYSTICK_ENHANCED_REPORTS` instead of `SDL_HINT_JOYSTICK_HIDAPI_PS5_PLAYER_LED`.

This tiny patch changes the hint callback to match `HIDAPI_DriverPS5_CloseJoystick()`, which appears to fix the crash on my system. Please feel free to close if this is not the correct fix.

## Existing Issue(s)

I couldn't see any from a quick search, but it looks like it was introduced in commit 2c0a8363a5073bfb23ddb18d7c75f43e624db570.
