### PR TITLE
Fix #12142 - VB being overwritten during Present

### DIFF
--- a/src/render/vulkan/SDL_render_vulkan.c
+++ b/src/render/vulkan/SDL_render_vulkan.c
@@ -3253,7 +3253,7 @@ static bool VULKAN_UpdateVertexBuffer(SDL_Renderer *renderer,
 
     stateCache->vertexBuffer = vertexBuffer->buffer;
 
-    rendererData->currentVertexBuffer++;
+    rendererData->currentVertexBuffer = vbidx + 1;
     if (rendererData->currentVertexBuffer >= SDL_VULKAN_NUM_VERTEX_BUFFERS) {
         rendererData->currentVertexBuffer = 0;
         rendererData->issueBatch = true;


### PR DESCRIPTION
The problem was if the size of the vertex buffer was exceeded, the currentVertexBuffer would be reset to zero and thus we'd leave it pointing to an in-use VB that would get overwritten on the next present before the vkQueueSubmit occurred.

## Description
Fixed to make sure the currentVertexBuffer is always set correctly.

## Existing Issue(s)
#12142 