### PR TITLE
Check for non-NULL icon for trays on Unix

### DIFF
--- a/src/tray/unix/SDL_tray.c
+++ b/src/tray/unix/SDL_tray.c
@@ -421,12 +421,14 @@ SDL_Tray *SDL_CreateTray(SDL_Surface *icon, const char *tooltip)
         return NULL;
     }
 
-    if (!new_tmp_filename(tray)) {
-        SDL_free(tray);
-        return NULL;
-    }
+    if (icon) {
+        if (!new_tmp_filename(tray)) {
+            SDL_free(tray);
+            return NULL;
+        }
 
-    SDL_SaveBMP(icon, tray->icon_path);
+        SDL_SaveBMP(icon, tray->icon_path);
+    }
 
     tray->indicator = app_indicator_new(get_appindicator_id(), tray->icon_path,
                                         APP_INDICATOR_CATEGORY_APPLICATION_STATUS);


### PR DESCRIPTION
## Description

`SDL_CreateTray` missed a check for `icon` being non-NULL before using it as the tray icon in the AppIndicator implementation. This PR adds the missing check.