### PR TITLE
GPU: Make Vulkan transfer buffers dedicated allocs

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -6840,15 +6840,12 @@ static SDL_GPUTransferBuffer *VULKAN_CreateTransferBuffer(
     Uint32 size,
     const char *debugName)
 {
-    // We use dedicated allocations for download buffers to avoid an issue
-    // where a defrag is triggered after submitting a download but before
-    // waiting on the fence.
     return (SDL_GPUTransferBuffer *)VULKAN_INTERNAL_CreateBufferContainer(
         (VulkanRenderer *)driverData,
         (VkDeviceSize)size,
         0,
         VULKAN_BUFFER_TYPE_TRANSFER,
-        true,
+        true, // Dedicated allocations preserve the data even if a defrag is triggered.
         debugName);
 }
 

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -6848,7 +6848,7 @@ static SDL_GPUTransferBuffer *VULKAN_CreateTransferBuffer(
         (VkDeviceSize)size,
         0,
         VULKAN_BUFFER_TYPE_TRANSFER,
-        usage == SDL_GPU_TRANSFERBUFFERUSAGE_DOWNLOAD,
+        true,
         debugName);
 }
 


### PR DESCRIPTION
Our Vulkan memory allocation strategy is to do large heap allocations at a time (64MB or larger) and then slice out sections of them for resource binding. This means we have to defragment regularly or else holes will appear in the allocations. 

The defrag process creates a new buffer on an available unfragmented allocation and then preserves data by enqueueing a copy command to preserve the data. We do the copy for GPU buffers, but we skip it for transfer buffers. This causes an issue where persistently-used upload transfer data is corrupted. An easy solution for this is to do what we did for download transfer buffers and make them dedicated allocations, meaning that they live alone on a heap allocation. 

The only drawback is the `maxMemoryAllocationCount` limit. The most common driver limit here is 4096. Honestly, if you have that many transfer buffers you definitely need to redesign your renderer.

The alternative would be to preserve transfer contents in the defrag process. Since in the typical case transfer data does not need to be persistent, I think this would just be a waste of processing time. 

Resolves #12242 