### PR TITLE
[GPU] D3D12 backend debug markers were being cut

### DIFF
--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -2028,7 +2028,7 @@ static void D3D12_InsertDebugLabel(
         d3d12CommandBuffer->graphicsCommandList,
         0,
         wchar_text,
-        (UINT)SDL_wcslen(wchar_text));
+        (UINT)SDL_wcslen(wchar_text) * sizeof(WCHAR));
 
     SDL_free(wchar_text);
 }
@@ -2044,7 +2044,7 @@ static void D3D12_PushDebugGroup(
         d3d12CommandBuffer->graphicsCommandList,
         0,
         wchar_text,
-        (UINT)SDL_wcslen(wchar_text));
+        (UINT)SDL_wcslen(wchar_text) * sizeof(WCHAR));
 
     SDL_free(wchar_text);
 }


### PR DESCRIPTION
Code used wcslen that return number of characters, but D3D12 debug layer uses bytes + wide chars
