### PR TITLE
SDL_Get*Driver() functions: Set error message on failure

### DIFF
--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -136,6 +136,7 @@ const char *SDL_GetAudioDriver(int index)
     if (index >= 0 && index < SDL_GetNumAudioDrivers()) {
         return deduped_bootstrap[index]->name;
     }
+    SDL_InvalidParamError("index");
     return NULL;
 }
 

--- a/src/camera/SDL_camera.c
+++ b/src/camera/SDL_camera.c
@@ -74,6 +74,7 @@ const char *SDL_GetCameraDriver(int index)
     if (index >= 0 && index < SDL_GetNumCameraDrivers()) {
         return bootstrap[index]->name;
     }
+    SDL_InvalidParamError("index");
     return NULL;
 }
 

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -810,8 +810,7 @@ const char *SDL_GetRenderDriver(int index)
 {
 #ifndef SDL_RENDER_DISABLED
     if (index < 0 || index >= SDL_GetNumRenderDrivers()) {
-        SDL_SetError("index must be in the range of 0 - %d",
-                            SDL_GetNumRenderDrivers() - 1);
+        SDL_InvalidParamError("index");
         return NULL;
     }
     return render_drivers[index]->name;

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -596,6 +596,7 @@ const char *SDL_GetVideoDriver(int index)
     if (index >= 0 && index < SDL_GetNumVideoDrivers()) {
         return deduped_bootstrap[index]->name;
     }
+    SDL_InvalidParamError("index");
     return NULL;
 }
 


### PR DESCRIPTION
When passing an invalid index to `SDL_GetNumVideoDrivers()` it returns NULL.

This commit adds an error message.