### PR TITLE
Fixed Cursor Icon State for SYSTEM_CURSOR_PROGRESS

### DIFF
--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -292,7 +292,7 @@ static SDL_Cursor *WIN_CreateSystemCursor(SDL_SystemCursor id)
         name = IDC_CROSS;
         break;
     case SDL_SYSTEM_CURSOR_PROGRESS:
-        name = IDC_WAIT;
+        name = IDC_APPSTARTING;
         break;
     case SDL_SYSTEM_CURSOR_NWSE_RESIZE:
         name = IDC_SIZENWSE;


### PR DESCRIPTION
## Description
In the `WIN_CreateSystemCursor` function, the `SDL_SYSTEM_CURSOR_PROGRESS` case is using `IDC_WAIT` instead of the appropriate `IDC_APPSTARTING` cursor. Both `SDL_SYSTEM_CURSOR_WAIT` and `SDL_SYSTEM_CURSOR_PROGRESS` would display the same static hourglass cursor, failing to differentiate between waiting and in-progress states.

## Solution
Replaced `IDC_WAIT` with `IDC_APPSTARTING`.