### PR TITLE
SDL_GetRelativeMouseState(): Get relative mouse position also when relative mouse mode is disabled

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -748,10 +748,8 @@ static void SDL_PrivateSendMouseMotion(Uint64 timestamp, SDL_Window *window, SDL
 
     // modify internal state
     {
-        if (relative) {
-            mouse->x_accu += xrel;
-            mouse->y_accu += yrel;
-        }
+        mouse->x_accu += xrel;
+        mouse->y_accu += yrel;
 
         if (relative && mouse->has_position) {
             mouse->x += xrel;


### PR DESCRIPTION
Currently the relative mouse position is only set if relative mouse mode is enabled.
That makes `SDL_GetRelativeMouseState()` only work in relative mouse mode.

This commit removes the check for relative mouse mode and lets the variables be always set.

Fixes #12286