### PR TITLE
emscripten: Fixed unregistering of key event handlers

### DIFF
--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -1095,11 +1095,11 @@ void Emscripten_UnregisterEventHandlers(SDL_WindowData *data)
     emscripten_set_pointerlockchange_callback(EMSCRIPTEN_EVENT_TARGET_DOCUMENT, NULL, 0, NULL);
 
     target = SDL_GetHint(SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT);
-    if (!target) {
+    if (!target || !*target) {
         target = EMSCRIPTEN_EVENT_TARGET_WINDOW;
     }
 
-    if (*target) {
+    if (SDL_strcmp(target, "#none") != 0) {
         emscripten_set_keydown_callback(target, NULL, 0, NULL);
         emscripten_set_keyup_callback(target, NULL, 0, NULL);
         emscripten_set_keypress_callback(target, NULL, 0, NULL);


### PR DESCRIPTION
Emscripten key input was broken by https://github.com/libsdl-org/SDL/commit/6a72d32d410b78b190828b6690ce817f81e8f677 and partially fixed by https://github.com/libsdl-org/SDL/commit/923123a52764f98bf4775b9d103c256ca27cbd95, in the second commit, key event handlers are still not properly unregistered.

Because of this, I was no longer getting text input events in my application, and I suspect this may also have been the cause of https://github.com/libsdl-org/SDL/issues/12073.

This commit applies the same fixes of https://github.com/libsdl-org/SDL/commit/923123a52764f98bf4775b9d103c256ca27cbd95 to the unregistering of event handlers, and with that text input seems to be working again.