### PR TITLE
src/test/SDL_test_harness.c: Free variables before returning

### DIFF
--- a/src/test/SDL_test_harness.c
+++ b/src/test/SDL_test_harness.c
@@ -515,6 +515,7 @@ int SDLTest_ExecuteTestSuiteRunner(SDLTest_TestSuiteRunner *runner)
 
     arraySuites = SDL_malloc(nbSuites * sizeof(int));
     if (!arraySuites) {
+        SDL_free(failedTests);
         return SDL_OutOfMemory();
     }
     for (i = 0; i < nbSuites; i++) {
@@ -586,6 +587,8 @@ int SDLTest_ExecuteTestSuiteRunner(SDLTest_TestSuiteRunner *runner)
 
             arrayTestCases = SDL_malloc(nbTestCases * sizeof(int));
             if (!arrayTestCases) {
+                SDL_free(arraySuites);
+                SDL_free(failedTests);
                 return SDL_OutOfMemory();
             }
             for (j = 0; j < nbTestCases; j++) {


### PR DESCRIPTION
Clang-Tidy with the check `clang-analyzer-unix.Malloc` shows a potential leak in `src/test/SDL_test_harness.c`.
This would happen if the function prematurely returns when an error happens.

This commit frees the variables before the function returns prematurely.

Warning:
```shell
[ 49%] Building C object CMakeFiles/SDL3_test.dir/src/test/SDL_test_harness.c.o
/path/to/SDL/src/test/SDL_test_harness.c:518:16: warning: Potential leak of memory pointed to by 'failedTests' [clang-analyzer-unix.Malloc]
  518 |         return SDL_OutOfMemory();
      |                ^
/path/to/SDL/src/test/SDL_test_harness.c:407:9: note: Assuming field 'testIterations' is >= 1
  407 |     if (runner->user.testIterations < 1) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/src/test/SDL_test_harness.c:407:5: note: Taking false branch
  407 |     if (runner->user.testIterations < 1) {
      |     ^
/path/to/SDL/src/test/SDL_test_harness.c:412:9: note: Assuming field 'runSeed' is null
  412 |     if (!runner->user.runSeed || runner->user.runSeed[0] == '\0') {
      |         ^~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/src/test/SDL_test_harness.c:412:31: note: Left side of '||' is true
  412 |     if (!runner->user.runSeed || runner->user.runSeed[0] == '\0') {
      |                               ^
/path/to/SDL/src/test/SDL_test_harness.c:414:13: note: Assuming 'runSeed' is non-null
  414 |         if (!runSeed) {
      |             ^~~~~~~~
/path/to/SDL/src/test/SDL_test_harness.c:414:9: note: Taking false branch
  414 |         if (!runSeed) {
      |         ^
/path/to/SDL/src/test/SDL_test_harness.c:435:5: note: Loop condition is true.  Entering loop body
  435 |     while (runner->user.testSuites[suiteCounter]) {
      |     ^
/path/to/SDL/src/test/SDL_test_harness.c:439:9: note: Loop condition is true.  Entering loop body
  439 |         while (testSuite->testCases[testCounter]) {
      |         ^
/path/to/SDL/src/test/SDL_test_harness.c:439:9: note: Loop condition is false. Execution continues on line 435
/path/to/SDL/src/test/SDL_test_harness.c:435:5: note: Loop condition is false. Execution continues on line 445
  435 |     while (runner->user.testSuites[suiteCounter]) {
      |     ^
/path/to/SDL/src/test/SDL_test_harness.c:445:9: note: 'totalNumberOfTests' is not equal to 0
  445 |     if (totalNumberOfTests == 0) {
      |         ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/test/SDL_test_harness.c:445:5: note: Taking false branch
  445 |     if (totalNumberOfTests == 0) {
      |     ^
/path/to/SDL/src/test/SDL_test_harness.c:451:55: note: Memory is allocated
  451 |     failedTests = (const SDLTest_TestCaseReference **)SDL_malloc(totalNumberOfTests * sizeof(SDLTest_TestCaseReference *));
      |                                                       ^
/path/to/SDL/include/SDL3/SDL_stdinc.h:5974:20: note: expanded from macro 'SDL_malloc'
 5974 | #define SDL_malloc malloc
      |                    ^
/path/to/SDL/src/test/SDL_test_harness.c:452:9: note: Assuming 'failedTests' is non-null
  452 |     if (!failedTests) {
      |         ^~~~~~~~~~~~
/path/to/SDL/src/test/SDL_test_harness.c:452:5: note: Taking false branch
  452 |     if (!failedTests) {
      |     ^
/path/to/SDL/src/test/SDL_test_harness.c:458:9: note: Assuming field 'filter' is null
  458 |     if (runner->user.filter && runner->user.filter[0] != '\0') {
      |         ^~~~~~~~~~~~~~~~~~~
/path/to/SDL/src/test/SDL_test_harness.c:458:29: note: Left side of '&&' is false
  458 |     if (runner->user.filter && runner->user.filter[0] != '\0') {
      |                             ^
/path/to/SDL/src/test/SDL_test_harness.c:512:5: note: Loop condition is true.  Entering loop body
  512 |     while (runner->user.testSuites[nbSuites]) {
      |     ^
/path/to/SDL/src/test/SDL_test_harness.c:512:5: note: Loop condition is false. Execution continues on line 516
/path/to/SDL/src/test/SDL_test_harness.c:517:9: note: Assuming 'arraySuites' is null
  517 |     if (!arraySuites) {
      |         ^~~~~~~~~~~~
/path/to/SDL/src/test/SDL_test_harness.c:517:5: note: Taking true branch
  517 |     if (!arraySuites) {
      |     ^
/path/to/SDL/src/test/SDL_test_harness.c:518:16: note: Potential leak of memory pointed to by 'failedTests'
  518 |         return SDL_OutOfMemory();
      |                ^
```