### PR TITLE
test/testautomation_intrinsics.c: Free variables before returning

### DIFF
--- a/test/testautomation_intrinsics.c
+++ b/test/testautomation_intrinsics.c
@@ -323,6 +323,7 @@ static int SDLCALL intrinsics_selftest(void *arg)
         size_t size;
         Uint32 *dest, *a, *b;
         if (allocate_random_uint_arrays(&dest, &a, &b, &size) < 0) {
+            free_arrays(dest, a, b);
             return TEST_ABORTED;
         }
         kernel_uints_mul_cpu(dest, a, b, size);
@@ -333,6 +334,7 @@ static int SDLCALL intrinsics_selftest(void *arg)
         size_t size;
         Uint32 *dest, *a, *b;
         if (allocate_random_uint_arrays(&dest, &a, &b, &size) < 0) {
+            free_arrays(dest, a, b);
             return TEST_ABORTED;
         }
         kernel_uints_add_cpu(dest, a, b, size);
@@ -343,6 +345,7 @@ static int SDLCALL intrinsics_selftest(void *arg)
         size_t size;
         float *dest, *a, *b;
         if (allocate_random_float_arrays(&dest, &a, &b, &size) < 0) {
+            free_arrays(dest, a, b);
             return TEST_ABORTED;
         }
         kernel_floats_add_cpu(dest, a, b, size);
@@ -353,6 +356,7 @@ static int SDLCALL intrinsics_selftest(void *arg)
         size_t size;
         double *dest, *a, *b;
         if (allocate_random_double_arrays(&dest, &a, &b, &size) < 0) {
+            free_arrays(dest, a, b);
             return TEST_ABORTED;
         }
         kernel_doubles_add_cpu(dest, a, b, size);
@@ -373,6 +377,7 @@ static int SDLCALL intrinsics_testMMX(void *arg)
 
             SDLTest_AssertCheck(true, "Test executable uses MMX intrinsics.");
             if (allocate_random_uint_arrays(&dest, &a, &b, &size) < 0) {
+                free_arrays(dest, a, b);
                 return TEST_ABORTED;
             }
             kernel_uints_add_mmx(dest, a, b, size);
@@ -401,6 +406,7 @@ static int SDLCALL intrinsics_testSSE(void *arg)
 
             SDLTest_AssertCheck(true, "Test executable uses SSE intrinsics.");
             if (allocate_random_float_arrays(&dest, &a, &b, &size) < 0) {
+                free_arrays(dest, a, b);
                 return TEST_ABORTED;
             }
             kernel_floats_add_sse(dest, a, b, size);
@@ -429,6 +435,7 @@ static int SDLCALL intrinsics_testSSE2(void *arg)
 
             SDLTest_AssertCheck(true, "Test executable uses SSE2 intrinsics.");
             if (allocate_random_double_arrays(&dest, &a, &b, &size) < 0) {
+                free_arrays(dest, a, b);
                 return TEST_ABORTED;
             }
             kernel_doubles_add_sse2(dest, a, b, size);
@@ -457,6 +464,7 @@ static int SDLCALL intrinsics_testSSE3(void *arg)
 
             SDLTest_AssertCheck(true, "Test executable uses SSE3 intrinsics.");
             if (allocate_random_uint_arrays(&dest, &a, &b, &size) < 0) {
+                free_arrays(dest, a, b);
                 return TEST_ABORTED;
             }
             kernel_uints_add_sse3(dest, a, b, size);
@@ -485,6 +493,7 @@ static int SDLCALL intrinsics_testSSE4_1(void *arg)
 
             SDLTest_AssertCheck(true, "Test executable uses SSE4.1 intrinsics.");
             if (allocate_random_uint_arrays(&dest, &a, &b, &size) < 0) {
+                free_arrays(dest, a, b);
                 return TEST_ABORTED;
             }
             kernel_uints_mul_sse4_1(dest, a, b, size);
@@ -548,6 +557,7 @@ static int SDLCALL intrinsics_testAVX(void *arg)
 
             SDLTest_AssertCheck(true, "Test executable uses AVX intrinsics.");
             if (allocate_random_float_arrays(&dest, &a, &b, &size) < 0) {
+                free_arrays(dest, a, b);
                 return TEST_ABORTED;
             }
             kernel_floats_add_avx(dest, a, b, size);
@@ -576,6 +586,7 @@ static int SDLCALL intrinsics_testAVX2(void *arg)
 
             SDLTest_AssertCheck(true, "Test executable uses AVX2 intrinsics.");
             if (allocate_random_uint_arrays(&dest, &a, &b, &size) < 0) {
+                free_arrays(dest, a, b);
                 return TEST_ABORTED;
             }
             kernel_uints_add_avx2(dest, a, b, size);
@@ -604,6 +615,7 @@ static int SDLCALL intrinsics_testAVX512F(void *arg)
 
             SDLTest_AssertCheck(true, "Test executable uses AVX512F intrinsics.");
             if (allocate_random_float_arrays(&dest, &a, &b, &size) < 0) {
+                free_arrays(dest, a, b);
                 return TEST_ABORTED;
             }
             kernel_floats_add_avx512f(dest, a, b, size);


### PR DESCRIPTION
Clang-Tidy with the check `clang-analyzer-unix.Malloc` shows potential leaks in `test/testautomation_intrinsics.c`.
This would happen if the function prematurely returns when an error happens.

This commit frees variables before the function returns prematurely.

<details><summary>Warnings Log</summary>
<p>

```shell
[ 57%] Building C object test/CMakeFiles/testautomation.dir/testautomation_intrinsics.c.o
/path/to/SDL/test/testautomation_intrinsics.c:432:24: warning: Potential leak of memory pointed to by 'a' [clang-analyzer-unix.Malloc]
  432 |                 return TEST_ABORTED;
      |                        ^
/path/to/SDL/include/SDL3/SDL_test_harness.h:51:30: note: expanded from macro 'TEST_ABORTED'
   51 | #define TEST_ABORTED        -1
      |                              ^
/path/to/SDL/test/testautomation_intrinsics.c:423:9: note: Assuming the condition is true
  423 |     if (SDL_HasSSE2()) {
      |         ^~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:423:5: note: Taking true branch
  423 |     if (SDL_HasSSE2()) {
      |     ^
/path/to/SDL/test/testautomation_intrinsics.c:431:17: note: Calling 'allocate_random_double_arrays'
  431 |             if (allocate_random_double_arrays(&dest, &a, &b, &size) < 0) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:68:10: note: Memory is allocated
   68 |     *a = SDL_malloc(sizeof(double) * *size);
      |          ^
/path/to/SDL/include/SDL3/SDL_stdinc.h:5974:20: note: expanded from macro 'SDL_malloc'
 5974 | #define SDL_malloc malloc
      |                    ^
/path/to/SDL/test/testautomation_intrinsics.c:71:9: note: Assuming the condition is true
   71 |     if (!*dest || !*a || !*b) {
      |         ^~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:71:16: note: Left side of '||' is true
   71 |     if (!*dest || !*a || !*b) {
      |                ^
/path/to/SDL/test/testautomation_intrinsics.c:431:17: note: Returned allocated memory via 2nd parameter
  431 |             if (allocate_random_double_arrays(&dest, &a, &b, &size) < 0) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:431:13: note: Taking true branch
  431 |             if (allocate_random_double_arrays(&dest, &a, &b, &size) < 0) {
      |             ^
/path/to/SDL/test/testautomation_intrinsics.c:432:24: note: Potential leak of memory pointed to by 'a'
  432 |                 return TEST_ABORTED;
      |                        ^
/path/to/SDL/include/SDL3/SDL_test_harness.h:51:30: note: expanded from macro 'TEST_ABORTED'
   51 | #define TEST_ABORTED        -1
      |                              ^
/path/to/SDL/test/testautomation_intrinsics.c:432:24: warning: Potential leak of memory pointed to by 'b' [clang-analyzer-unix.Malloc]
  432 |                 return TEST_ABORTED;
      |                        ^
/path/to/SDL/include/SDL3/SDL_test_harness.h:51:30: note: expanded from macro 'TEST_ABORTED'
   51 | #define TEST_ABORTED        -1
      |                              ^
/path/to/SDL/test/testautomation_intrinsics.c:423:9: note: Assuming the condition is true
  423 |     if (SDL_HasSSE2()) {
      |         ^~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:423:5: note: Taking true branch
  423 |     if (SDL_HasSSE2()) {
      |     ^
/path/to/SDL/test/testautomation_intrinsics.c:431:17: note: Calling 'allocate_random_double_arrays'
  431 |             if (allocate_random_double_arrays(&dest, &a, &b, &size) < 0) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:69:10: note: Memory is allocated
   69 |     *b = SDL_malloc(sizeof(double) * *size);
      |          ^
/path/to/SDL/include/SDL3/SDL_stdinc.h:5974:20: note: expanded from macro 'SDL_malloc'
 5974 | #define SDL_malloc malloc
      |                    ^
/path/to/SDL/test/testautomation_intrinsics.c:71:9: note: Assuming the condition is true
   71 |     if (!*dest || !*a || !*b) {
      |         ^~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:71:16: note: Left side of '||' is true
   71 |     if (!*dest || !*a || !*b) {
      |                ^
/path/to/SDL/test/testautomation_intrinsics.c:431:17: note: Returned allocated memory via 3rd parameter
  431 |             if (allocate_random_double_arrays(&dest, &a, &b, &size) < 0) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:431:13: note: Taking true branch
  431 |             if (allocate_random_double_arrays(&dest, &a, &b, &size) < 0) {
      |             ^
/path/to/SDL/test/testautomation_intrinsics.c:432:24: note: Potential leak of memory pointed to by 'b'
  432 |                 return TEST_ABORTED;
      |                        ^
/path/to/SDL/include/SDL3/SDL_test_harness.h:51:30: note: expanded from macro 'TEST_ABORTED'
   51 | #define TEST_ABORTED        -1
      |                              ^
/path/to/SDL/test/testautomation_intrinsics.c:432:24: warning: Potential leak of memory pointed to by 'dest' [clang-analyzer-unix.Malloc]
  432 |                 return TEST_ABORTED;
      |                        ^
/path/to/SDL/include/SDL3/SDL_test_harness.h:51:30: note: expanded from macro 'TEST_ABORTED'
   51 | #define TEST_ABORTED        -1
      |                              ^
/path/to/SDL/test/testautomation_intrinsics.c:423:9: note: Assuming the condition is true
  423 |     if (SDL_HasSSE2()) {
      |         ^~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:423:5: note: Taking true branch
  423 |     if (SDL_HasSSE2()) {
      |     ^
/path/to/SDL/test/testautomation_intrinsics.c:431:17: note: Calling 'allocate_random_double_arrays'
  431 |             if (allocate_random_double_arrays(&dest, &a, &b, &size) < 0) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:67:13: note: Memory is allocated
   67 |     *dest = SDL_malloc(sizeof(double) * *size);
      |             ^
/path/to/SDL/include/SDL3/SDL_stdinc.h:5974:20: note: expanded from macro 'SDL_malloc'
 5974 | #define SDL_malloc malloc
      |                    ^
/path/to/SDL/test/testautomation_intrinsics.c:71:9: note: Assuming the condition is false
   71 |     if (!*dest || !*a || !*b) {
      |         ^~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:71:9: note: Left side of '||' is false
/path/to/SDL/test/testautomation_intrinsics.c:71:19: note: Assuming the condition is true
   71 |     if (!*dest || !*a || !*b) {
      |                   ^~~
/path/to/SDL/test/testautomation_intrinsics.c:71:23: note: Left side of '||' is true
   71 |     if (!*dest || !*a || !*b) {
      |                       ^
/path/to/SDL/test/testautomation_intrinsics.c:431:17: note: Returned allocated memory via 1st parameter
  431 |             if (allocate_random_double_arrays(&dest, &a, &b, &size) < 0) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:431:13: note: Taking true branch
  431 |             if (allocate_random_double_arrays(&dest, &a, &b, &size) < 0) {
      |             ^
/path/to/SDL/test/testautomation_intrinsics.c:432:24: note: Potential leak of memory pointed to by 'dest'
  432 |                 return TEST_ABORTED;
      |                        ^
/path/to/SDL/include/SDL3/SDL_test_harness.h:51:30: note: expanded from macro 'TEST_ABORTED'
   51 | #define TEST_ABORTED        -1
      |                              ^
/path/to/SDL/test/testautomation_intrinsics.c:579:24: warning: Potential leak of memory pointed to by 'a' [clang-analyzer-unix.Malloc]
  579 |                 return TEST_ABORTED;
      |                        ^
/path/to/SDL/include/SDL3/SDL_test_harness.h:51:30: note: expanded from macro 'TEST_ABORTED'
   51 | #define TEST_ABORTED        -1
      |                              ^
/path/to/SDL/test/testautomation_intrinsics.c:570:9: note: Assuming the condition is true
  570 |     if (SDL_HasAVX2()) {
      |         ^~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:570:5: note: Taking true branch
  570 |     if (SDL_HasAVX2()) {
      |     ^
/path/to/SDL/test/testautomation_intrinsics.c:578:17: note: Calling 'allocate_random_uint_arrays'
  578 |             if (allocate_random_uint_arrays(&dest, &a, &b, &size) < 0) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:27:10: note: Memory is allocated
   27 |     *a = SDL_malloc(sizeof(Uint32) * *size);
      |          ^
/path/to/SDL/include/SDL3/SDL_stdinc.h:5974:20: note: expanded from macro 'SDL_malloc'
 5974 | #define SDL_malloc malloc
      |                    ^
/path/to/SDL/test/testautomation_intrinsics.c:30:9: note: Assuming the condition is true
   30 |     if (!*dest || !*a || !*b) {
      |         ^~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:30:16: note: Left side of '||' is true
   30 |     if (!*dest || !*a || !*b) {
      |                ^
/path/to/SDL/test/testautomation_intrinsics.c:578:17: note: Returned allocated memory via 2nd parameter
  578 |             if (allocate_random_uint_arrays(&dest, &a, &b, &size) < 0) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:578:13: note: Taking true branch
  578 |             if (allocate_random_uint_arrays(&dest, &a, &b, &size) < 0) {
      |             ^
/path/to/SDL/test/testautomation_intrinsics.c:579:24: note: Potential leak of memory pointed to by 'a'
  579 |                 return TEST_ABORTED;
      |                        ^
/path/to/SDL/include/SDL3/SDL_test_harness.h:51:30: note: expanded from macro 'TEST_ABORTED'
   51 | #define TEST_ABORTED        -1
      |                              ^
/path/to/SDL/test/testautomation_intrinsics.c:579:24: warning: Potential leak of memory pointed to by 'b' [clang-analyzer-unix.Malloc]
  579 |                 return TEST_ABORTED;
      |                        ^
/path/to/SDL/include/SDL3/SDL_test_harness.h:51:30: note: expanded from macro 'TEST_ABORTED'
   51 | #define TEST_ABORTED        -1
      |                              ^
/path/to/SDL/test/testautomation_intrinsics.c:570:9: note: Assuming the condition is true
  570 |     if (SDL_HasAVX2()) {
      |         ^~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:570:5: note: Taking true branch
  570 |     if (SDL_HasAVX2()) {
      |     ^
/path/to/SDL/test/testautomation_intrinsics.c:578:17: note: Calling 'allocate_random_uint_arrays'
  578 |             if (allocate_random_uint_arrays(&dest, &a, &b, &size) < 0) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:28:10: note: Memory is allocated
   28 |     *b = SDL_malloc(sizeof(Uint32) * *size);
      |          ^
/path/to/SDL/include/SDL3/SDL_stdinc.h:5974:20: note: expanded from macro 'SDL_malloc'
 5974 | #define SDL_malloc malloc
      |                    ^
/path/to/SDL/test/testautomation_intrinsics.c:30:9: note: Assuming the condition is true
   30 |     if (!*dest || !*a || !*b) {
      |         ^~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:30:16: note: Left side of '||' is true
   30 |     if (!*dest || !*a || !*b) {
      |                ^
/path/to/SDL/test/testautomation_intrinsics.c:578:17: note: Returned allocated memory via 3rd parameter
  578 |             if (allocate_random_uint_arrays(&dest, &a, &b, &size) < 0) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:578:13: note: Taking true branch
  578 |             if (allocate_random_uint_arrays(&dest, &a, &b, &size) < 0) {
      |             ^
/path/to/SDL/test/testautomation_intrinsics.c:579:24: note: Potential leak of memory pointed to by 'b'
  579 |                 return TEST_ABORTED;
      |                        ^
/path/to/SDL/include/SDL3/SDL_test_harness.h:51:30: note: expanded from macro 'TEST_ABORTED'
   51 | #define TEST_ABORTED        -1
      |                              ^
/path/to/SDL/test/testautomation_intrinsics.c:579:24: warning: Potential leak of memory pointed to by 'dest' [clang-analyzer-unix.Malloc]
  579 |                 return TEST_ABORTED;
      |                        ^
/path/to/SDL/include/SDL3/SDL_test_harness.h:51:30: note: expanded from macro 'TEST_ABORTED'
   51 | #define TEST_ABORTED        -1
      |                              ^
/path/to/SDL/test/testautomation_intrinsics.c:570:9: note: Assuming the condition is true
  570 |     if (SDL_HasAVX2()) {
      |         ^~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:570:5: note: Taking true branch
  570 |     if (SDL_HasAVX2()) {
      |     ^
/path/to/SDL/test/testautomation_intrinsics.c:578:17: note: Calling 'allocate_random_uint_arrays'
  578 |             if (allocate_random_uint_arrays(&dest, &a, &b, &size) < 0) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:26:13: note: Memory is allocated
   26 |     *dest = SDL_malloc(sizeof(Uint32) * *size);
      |             ^
/path/to/SDL/include/SDL3/SDL_stdinc.h:5974:20: note: expanded from macro 'SDL_malloc'
 5974 | #define SDL_malloc malloc
      |                    ^
/path/to/SDL/test/testautomation_intrinsics.c:30:9: note: Assuming the condition is false
   30 |     if (!*dest || !*a || !*b) {
      |         ^~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:30:9: note: Left side of '||' is false
/path/to/SDL/test/testautomation_intrinsics.c:30:19: note: Assuming the condition is true
   30 |     if (!*dest || !*a || !*b) {
      |                   ^~~
/path/to/SDL/test/testautomation_intrinsics.c:30:23: note: Left side of '||' is true
   30 |     if (!*dest || !*a || !*b) {
      |                       ^
/path/to/SDL/test/testautomation_intrinsics.c:578:17: note: Returned allocated memory via 1st parameter
  578 |             if (allocate_random_uint_arrays(&dest, &a, &b, &size) < 0) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:578:13: note: Taking true branch
  578 |             if (allocate_random_uint_arrays(&dest, &a, &b, &size) < 0) {
      |             ^
/path/to/SDL/test/testautomation_intrinsics.c:579:24: note: Potential leak of memory pointed to by 'dest'
  579 |                 return TEST_ABORTED;
      |                        ^
/path/to/SDL/include/SDL3/SDL_test_harness.h:51:30: note: expanded from macro 'TEST_ABORTED'
   51 | #define TEST_ABORTED        -1
      |                              ^
/path/to/SDL/test/testautomation_intrinsics.c:607:24: warning: Potential leak of memory pointed to by 'a' [clang-analyzer-unix.Malloc]
  607 |                 return TEST_ABORTED;
      |                        ^
/path/to/SDL/include/SDL3/SDL_test_harness.h:51:30: note: expanded from macro 'TEST_ABORTED'
   51 | #define TEST_ABORTED        -1
      |                              ^
/path/to/SDL/test/testautomation_intrinsics.c:598:9: note: Assuming the condition is true
  598 |     if (SDL_HasAVX512F()) {
      |         ^~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:598:5: note: Taking true branch
  598 |     if (SDL_HasAVX512F()) {
      |     ^
/path/to/SDL/test/testautomation_intrinsics.c:606:17: note: Calling 'allocate_random_float_arrays'
  606 |             if (allocate_random_float_arrays(&dest, &a, &b, &size) < 0) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:47:10: note: Memory is allocated
   47 |     *a = SDL_malloc(sizeof(float) * *size);
      |          ^
/path/to/SDL/include/SDL3/SDL_stdinc.h:5974:20: note: expanded from macro 'SDL_malloc'
 5974 | #define SDL_malloc malloc
      |                    ^
/path/to/SDL/test/testautomation_intrinsics.c:50:9: note: Assuming the condition is true
   50 |     if (!*dest || !*a || !*b) {
      |         ^~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:50:16: note: Left side of '||' is true
   50 |     if (!*dest || !*a || !*b) {
      |                ^
/path/to/SDL/test/testautomation_intrinsics.c:606:17: note: Returned allocated memory via 2nd parameter
  606 |             if (allocate_random_float_arrays(&dest, &a, &b, &size) < 0) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:606:13: note: Taking true branch
  606 |             if (allocate_random_float_arrays(&dest, &a, &b, &size) < 0) {
      |             ^
/path/to/SDL/test/testautomation_intrinsics.c:607:24: note: Potential leak of memory pointed to by 'a'
  607 |                 return TEST_ABORTED;
      |                        ^
/path/to/SDL/include/SDL3/SDL_test_harness.h:51:30: note: expanded from macro 'TEST_ABORTED'
   51 | #define TEST_ABORTED        -1
      |                              ^
/path/to/SDL/test/testautomation_intrinsics.c:607:24: warning: Potential leak of memory pointed to by 'b' [clang-analyzer-unix.Malloc]
  607 |                 return TEST_ABORTED;
      |                        ^
/path/to/SDL/include/SDL3/SDL_test_harness.h:51:30: note: expanded from macro 'TEST_ABORTED'
   51 | #define TEST_ABORTED        -1
      |                              ^
/path/to/SDL/test/testautomation_intrinsics.c:598:9: note: Assuming the condition is true
  598 |     if (SDL_HasAVX512F()) {
      |         ^~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:598:5: note: Taking true branch
  598 |     if (SDL_HasAVX512F()) {
      |     ^
/path/to/SDL/test/testautomation_intrinsics.c:606:17: note: Calling 'allocate_random_float_arrays'
  606 |             if (allocate_random_float_arrays(&dest, &a, &b, &size) < 0) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:48:10: note: Memory is allocated
   48 |     *b = SDL_malloc(sizeof(float) * *size);
      |          ^
/path/to/SDL/include/SDL3/SDL_stdinc.h:5974:20: note: expanded from macro 'SDL_malloc'
 5974 | #define SDL_malloc malloc
      |                    ^
/path/to/SDL/test/testautomation_intrinsics.c:50:9: note: Assuming the condition is true
   50 |     if (!*dest || !*a || !*b) {
      |         ^~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:50:16: note: Left side of '||' is true
   50 |     if (!*dest || !*a || !*b) {
      |                ^
/path/to/SDL/test/testautomation_intrinsics.c:606:17: note: Returned allocated memory via 3rd parameter
  606 |             if (allocate_random_float_arrays(&dest, &a, &b, &size) < 0) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:606:13: note: Taking true branch
  606 |             if (allocate_random_float_arrays(&dest, &a, &b, &size) < 0) {
      |             ^
/path/to/SDL/test/testautomation_intrinsics.c:607:24: note: Potential leak of memory pointed to by 'b'
  607 |                 return TEST_ABORTED;
      |                        ^
/path/to/SDL/include/SDL3/SDL_test_harness.h:51:30: note: expanded from macro 'TEST_ABORTED'
   51 | #define TEST_ABORTED        -1
      |                              ^
/path/to/SDL/test/testautomation_intrinsics.c:607:24: warning: Potential leak of memory pointed to by 'dest' [clang-analyzer-unix.Malloc]
  607 |                 return TEST_ABORTED;
      |                        ^
/path/to/SDL/include/SDL3/SDL_test_harness.h:51:30: note: expanded from macro 'TEST_ABORTED'
   51 | #define TEST_ABORTED        -1
      |                              ^
/path/to/SDL/test/testautomation_intrinsics.c:598:9: note: Assuming the condition is true
  598 |     if (SDL_HasAVX512F()) {
      |         ^~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:598:5: note: Taking true branch
  598 |     if (SDL_HasAVX512F()) {
      |     ^
/path/to/SDL/test/testautomation_intrinsics.c:606:17: note: Calling 'allocate_random_float_arrays'
  606 |             if (allocate_random_float_arrays(&dest, &a, &b, &size) < 0) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:46:13: note: Memory is allocated
   46 |     *dest = SDL_malloc(sizeof(float) * *size);
      |             ^
/path/to/SDL/include/SDL3/SDL_stdinc.h:5974:20: note: expanded from macro 'SDL_malloc'
 5974 | #define SDL_malloc malloc
      |                    ^
/path/to/SDL/test/testautomation_intrinsics.c:50:9: note: Assuming the condition is false
   50 |     if (!*dest || !*a || !*b) {
      |         ^~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:50:9: note: Left side of '||' is false
/path/to/SDL/test/testautomation_intrinsics.c:50:19: note: Assuming the condition is true
   50 |     if (!*dest || !*a || !*b) {
      |                   ^~~
/path/to/SDL/test/testautomation_intrinsics.c:50:23: note: Left side of '||' is true
   50 |     if (!*dest || !*a || !*b) {
      |                       ^
/path/to/SDL/test/testautomation_intrinsics.c:606:17: note: Returned allocated memory via 1st parameter
  606 |             if (allocate_random_float_arrays(&dest, &a, &b, &size) < 0) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testautomation_intrinsics.c:606:13: note: Taking true branch
  606 |             if (allocate_random_float_arrays(&dest, &a, &b, &size) < 0) {
      |             ^
/path/to/SDL/test/testautomation_intrinsics.c:607:24: note: Potential leak of memory pointed to by 'dest'
  607 |                 return TEST_ABORTED;
      |                        ^
/path/to/SDL/include/SDL3/SDL_test_harness.h:51:30: note: expanded from macro 'TEST_ABORTED'
   51 | #define TEST_ABORTED        -1
      |                              ^
```

</p>
</details> 
