### PR TITLE
test/testaudio.c: Fix use-after-free warning

### DIFF
--- a/test/testaudio.c
+++ b/test/testaudio.c
@@ -300,6 +300,7 @@ static void DestroyThing(Thing *thing)
     }
 
     if (thing->prev) {
+        SDL_assert(thing != things);
         thing->prev->next = thing->next;
     } else {
         SDL_assert(thing == things);


### PR DESCRIPTION

Adding an assert, that a list node, with a pointer to a previous node, is not the start of the list.

This gets rid of a clang-tidy "use after free" warning:

```shell
[ 65%] Building C object test/CMakeFiles/testaudio.dir/testaudio.c.o
/path/to/SDL/test/testaudio.c:1262:9: warning: Use of memory after it is freed [clang-analyzer-unix.Malloc]
 1262 |         DestroyThing(things);  /* make sure all the audio devices are closed, etc. */
      |         ^            ~~~~~~
/path/to/SDL/test/testaudio.c:1261:5: note: Loop condition is true.  Entering loop body
 1261 |     while (things) {
      |     ^
/path/to/SDL/test/testaudio.c:1262:9: note: Calling 'DestroyThing'
 1262 |         DestroyThing(things);  /* make sure all the audio devices are closed, etc. */
      |         ^~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testaudio.c:257:10: note: 'thing' is non-null
  257 |     if (!thing) {
      |          ^~~~~
/path/to/SDL/test/testaudio.c:257:5: note: Taking false branch
  257 |     if (!thing) {
      |     ^
/path/to/SDL/test/testaudio.c:261:9: note: Assuming 'mouseover_thing' is not equal to 'thing'
  261 |     if (mouseover_thing == thing) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testaudio.c:261:5: note: Taking false branch
  261 |     if (mouseover_thing == thing) {
      |     ^
/path/to/SDL/test/testaudio.c:265:9: note: Assuming 'droppable_highlighted_thing' is not equal to 'thing'
  265 |     if (droppable_highlighted_thing == thing) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testaudio.c:265:5: note: Taking false branch
  265 |     if (droppable_highlighted_thing == thing) {
      |     ^
/path/to/SDL/test/testaudio.c:269:9: note: Assuming 'dragging_thing' is not equal to 'thing'
  269 |     if (dragging_thing == thing) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testaudio.c:269:5: note: Taking false branch
  269 |     if (dragging_thing == thing) {
      |     ^
/path/to/SDL/test/testaudio.c:273:5: note: Control jumps to 'case THING_TRASHCAN:'  at line 276
  273 |     switch (thing->what) {
      |     ^
/path/to/SDL/test/testaudio.c:276:30: note:  Execution continues on line 302
  276 |         case THING_TRASHCAN: break;
      |                              ^
/path/to/SDL/test/testaudio.c:302:9: note: Assuming field 'prev' is non-null
  302 |     if (thing->prev) {
      |         ^~~~~~~~~~~
/path/to/SDL/test/testaudio.c:302:5: note: Taking true branch
  302 |     if (thing->prev) {
      |     ^
/path/to/SDL/test/testaudio.c:309:9: note: Assuming field 'next' is null
  309 |     if (thing->next) {
      |         ^~~~~~~~~~~
/path/to/SDL/test/testaudio.c:309:5: note: Taking false branch
  309 |     if (thing->next) {
      |     ^
/path/to/SDL/test/testaudio.c:314:5: note: Memory is released
  314 |     SDL_free(thing);
      |     ^
/path/to/SDL/include/SDL3/SDL_stdinc.h:5977:18: note: expanded from macro 'SDL_free'
 5977 | #define SDL_free free
      |                  ^
/path/to/SDL/test/testaudio.c:1262:9: note: Returning; memory was released via 1st parameter
 1262 |         DestroyThing(things);  /* make sure all the audio devices are closed, etc. */
      |         ^~~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testaudio.c:1261:5: note: Loop condition is true.  Entering loop body
 1261 |     while (things) {
      |     ^
/path/to/SDL/test/testaudio.c:1262:9: note: Use of memory after it is freed
 1262 |         DestroyThing(things);  /* make sure all the audio devices are closed, etc. */
      |         ^            ~~~~~~
```