### PR TITLE
AddPulseAudioDevice(): Fix use-after-free

### DIFF
--- a/src/audio/pulseaudio/SDL_pulseaudio.c
+++ b/src/audio/pulseaudio/SDL_pulseaudio.c
@@ -778,8 +778,8 @@ static void AddPulseAudioDevice(const bool recording, const char *description, c
             SDL_free(handle);
         } else {
             handle->device_index = index;
+            SDL_AddAudioDevice(recording, description, &spec, handle);
         }
-        SDL_AddAudioDevice(recording, description, &spec, handle);
     }
 }
 


### PR DESCRIPTION
Moving the `SDL_AddAudioDevice(recording, description, &spec, handle);` call
so it only gets executed if `handle->device_path` is valid and therefore `handle` wasn't freed.
```shell
[ 30%] Building C object CMakeFiles/SDL3-shared.dir/src/audio/pulseaudio/SDL_pulseaudio.c.o
path/to/SDL/src/audio/pulseaudio/SDL_pulseaudio.c:782:9: warning: Use of memory after it is freed [clang-analyzer-unix.Malloc]
  782 |         SDL_AddAudioDevice(recording, description, &spec, handle);
      |         ^
path/to/SDL/src/audio/pulseaudio/SDL_pulseaudio.c:789:9: note: Assuming 'i' is non-null
  789 |     if (i) {
      |         ^
path/to/SDL/src/audio/pulseaudio/SDL_pulseaudio.c:789:5: note: Taking true branch
  789 |     if (i) {
      |     ^
path/to/SDL/src/audio/pulseaudio/SDL_pulseaudio.c:790:9: note: Calling 'AddPulseAudioDevice'
  790 |         AddPulseAudioDevice(false, i->description, i->name, i->index, &i->sample_spec);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
path/to/SDL/src/audio/pulseaudio/SDL_pulseaudio.c:774:55: note: Memory is allocated
  774 |     PulseDeviceHandle *handle = (PulseDeviceHandle *) SDL_malloc(sizeof (PulseDeviceHandle));
      |                                                       ^
path/to/SDL/include/SDL3/SDL_stdinc.h:5974:20: note: expanded from macro 'SDL_malloc'
 5974 | #define SDL_malloc malloc
      |                    ^
path/to/SDL/src/audio/pulseaudio/SDL_pulseaudio.c:775:9: note: Assuming 'handle' is non-null
  775 |     if (handle) {
      |         ^~~~~~
path/to/SDL/src/audio/pulseaudio/SDL_pulseaudio.c:775:5: note: Taking true branch
  775 |     if (handle) {
      |     ^
path/to/SDL/src/audio/pulseaudio/SDL_pulseaudio.c:777:13: note: Assuming field 'device_path' is null
  777 |         if (!handle->device_path) {
      |             ^~~~~~~~~~~~~~~~~~~~
path/to/SDL/src/audio/pulseaudio/SDL_pulseaudio.c:777:9: note: Taking true branch
  777 |         if (!handle->device_path) {
      |         ^
path/to/SDL/src/audio/pulseaudio/SDL_pulseaudio.c:778:13: note: Memory is released
  778 |             SDL_free(handle);
      |             ^
path/to/SDL/include/SDL3/SDL_stdinc.h:5977:18: note: expanded from macro 'SDL_free'
 5977 | #define SDL_free free
      |                  ^
path/to/SDL/src/audio/pulseaudio/SDL_pulseaudio.c:782:9: note: Use of memory after it is freed
  782 |         SDL_AddAudioDevice(recording, description, &spec, handle);
      |         ^                                                 ~~~~~~
```