### PR TITLE
Incorrect bfOffBits Calculation in WIN_ConvertDIBtoBMP

### DIFF
--- a/src/video/windows/SDL_windowsclipboard.c
+++ b/src/video/windows/SDL_windowsclipboard.c
@@ -145,7 +145,7 @@ static void *WIN_ConvertDIBtoBMP(HANDLE hMem, size_t *size)
                     pbfh->bfSize = (DWORD)bmp_size;
                     pbfh->bfReserved1 = 0;
                     pbfh->bfReserved2 = 0;
-                    pbfh->bfOffBits = (DWORD)(sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER) + color_table_size);
+                    pbfh->bfOffBits = (DWORD)(sizeof(BITMAPFILEHEADER) + pbih->biSize + color_table_size);
                     SDL_memcpy((Uint8 *)bmp + sizeof(BITMAPFILEHEADER), dib, dib_size);
                     *size = bmp_size;
                 }


### PR DESCRIPTION
## Description
In `WIN_ConvertDIBtoBMP`, the code incorrectly uses `sizeof(BITMAPINFOHEADER)` instead of `pbih->biSize` to calculate the offset to pixel data in the BMP header. This leads to invalid BMP files when the DIB uses a header larger than BITMAPINFOHEADER.

## Solution
Replaced `sizeof(BITMAPINFOHEADER)` with `pbih->biSize` as it represents the actual size of the DIB header (e.g., 40, 108 bytes), ensuring the correct offset to pixel data.