### PR TITLE
Unchecked Return Value in WIN_SuspendScreenSaver

### DIFF
--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -76,12 +76,13 @@ static void SDLCALL UpdateWindowFrameUsableWhileCursorHidden(void *userdata, con
 #if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
 static bool WIN_SuspendScreenSaver(SDL_VideoDevice *_this)
 {
+    DWORD result;
     if (_this->suspend_screensaver) {
-        SetThreadExecutionState(ES_CONTINUOUS | ES_DISPLAY_REQUIRED);
+        result = SetThreadExecutionState(ES_CONTINUOUS | ES_DISPLAY_REQUIRED);
     } else {
-        SetThreadExecutionState(ES_CONTINUOUS);
+        result = SetThreadExecutionState(ES_CONTINUOUS);
     }
-    return true;
+    return (result != 0);
 }
 #endif
 

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -82,7 +82,11 @@ static bool WIN_SuspendScreenSaver(SDL_VideoDevice *_this)
     } else {
         result = SetThreadExecutionState(ES_CONTINUOUS);
     }
-    return (result != 0);
+    if (result == 0) {
+        SDL_SetError("SetThreadExecutionState() failed.");
+        return false;
+    }
+    return true;
 }
 #endif
 

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -83,7 +83,7 @@ static bool WIN_SuspendScreenSaver(SDL_VideoDevice *_this)
         result = SetThreadExecutionState(ES_CONTINUOUS);
     }
     if (result == 0) {
-        SDL_SetError("SetThreadExecutionState() failed.");
+        SDL_SetError("SetThreadExecutionState() failed");
         return false;
     }
     return true;


### PR DESCRIPTION
## Description
In `WIN_SuspendScreenSaver` function, the code does not check the return value of `SetThreadExecutionState`, leading to incorrect success reporting.

## Solution
Check the return value and return `true` only if the API call succeeds.
