### PR TITLE
Removing Double-free Issue

### DIFF
--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -418,10 +418,6 @@ static HCURSOR GetCachedCursor(SDL_Cursor *cursor)
 
     entry = (CachedCursor *)SDL_malloc(sizeof(*entry));
     if (!entry) {
-        if (hcursor) {
-            DestroyCursor(hcursor);
-        }
-        SDL_free(entry);
         goto error;
     }
     entry->cursor = hcursor;


### PR DESCRIPTION
> If I'm not mistaken, this code block is redundant, because `goto` jumps to `error`,  which then frees the memory.
> 
> 
> 
> In the case of the `entry` variable, its memory doesn't have to be freed at all inside this function. Either its allocation succeeded and its variable will be placed in `data->cache`, or the allocation returned `NULL` and freeing it is a noop.
> 
> 
> 
> BUT, I think this code block introduced a double-free. 
> 
> If `entry` is `NULL` it frees `hcursor`, and after the jump to `error` it does it again.
> 
>  

 _Originally posted by @Sackzement in [a513168](https://github.com/libsdl-org/SDL/commit/a51316890218c89fa3350178cbe2c79146a01d2e#r152660538)_

Based on this input from @Sackzement, we can remove the code block to prevent double-free.