### PR TITLE
[Windows] Report raw absolute mouse input as pen events when SDL_HINT_PEN_MOUSE_EVENTS is disabled

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -579,6 +579,11 @@ static void WIN_HandleRawMouseInput(Uint64 timestamp, SDL_VideoData *data, HANDL
         return;
     }
 
+    SDL_Mouse *mouse = SDL_GetMouse();
+    if (!mouse) {
+        return;
+    }
+
     if (GetMouseMessageSource(rawmouse->ulExtraInformation) != SDL_MOUSE_EVENT_SOURCE_MOUSE) {
         return;
     }
@@ -647,7 +652,7 @@ static void WIN_HandleRawMouseInput(Uint64 timestamp, SDL_VideoData *data, HANDL
                         }
                     }
                 }
-            } else {
+            } else if (mouse->pen_mouse_events) {
                 const int MAXIMUM_TABLET_RELATIVE_MOTION = 32;
                 if (SDL_abs(relX) > MAXIMUM_TABLET_RELATIVE_MOTION ||
                     SDL_abs(relY) > MAXIMUM_TABLET_RELATIVE_MOTION) {
@@ -655,6 +660,11 @@ static void WIN_HandleRawMouseInput(Uint64 timestamp, SDL_VideoData *data, HANDL
                 } else {
                     SDL_SendMouseMotion(timestamp, window, mouseID, true, (float)relX, (float)relY);
                 }
+            } else {
+                if (!data->raw_input_fake_pen_id) {
+                    data->raw_input_fake_pen_id = SDL_AddPenDevice(timestamp, "raw mouse input", NULL, SDL_malloc(1));
+                }
+                SDL_SendPenMotion(timestamp, data->raw_input_fake_pen_id, window, (float)(x - window->x), (float)(y - window->y));
             }
 
             data->last_raw_mouse_position.x = x;

--- a/src/video/windows/SDL_windowsrawinput.c
+++ b/src/video/windows/SDL_windowsrawinput.c
@@ -111,6 +111,11 @@ static DWORD WINAPI WIN_RawInputThread(LPVOID param)
         WIN_PollRawInput(_this, poll_start);
     }
 
+    if (_this->internal->raw_input_fake_pen_id) {
+        SDL_RemovePenDevice(0, _this->internal->raw_input_fake_pen_id);
+        _this->internal->raw_input_fake_pen_id = 0;
+    }
+
     devices[0].dwFlags |= RIDEV_REMOVE;
     devices[1].dwFlags |= RIDEV_REMOVE;
     RegisterRawInputDevices(devices, count, sizeof(devices[0]));

--- a/src/video/windows/SDL_windowsvideo.h
+++ b/src/video/windows/SDL_windowsvideo.h
@@ -440,6 +440,7 @@ struct SDL_VideoData
     bool raw_keyboard_enabled;
     bool pending_E1_key_sequence;
     Uint32 raw_input_enabled;
+    SDL_PenID raw_input_fake_pen_id;
 
     WIN_GameInputData *gameinput_context;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Raw absolute mouse input is [currently understood](https://github.com/libsdl-org/SDL/blob/31f9cb4806c1972882b933f676e550366a34050f/src/video/windows/SDL_windowsevents.c#L650-L658) as being tablet (pen) input and is converted to relative mouse input events. Raw mouse input is only reported when [relative mouse mode](https://wiki.libsdl.org/SDL3/SDL_SetWindowRelativeMouseMode) is enabled. With this change, and when [SDL_HINT_PEN_MOUSE_EVENTS](https://wiki.libsdl.org/SDL3/SDL_HINT_PEN_MOUSE_EVENTS) is disabled, this input will be reported as [pen motion events](https://wiki.libsdl.org/SDL3/SDL_PenMotionEvent).

Some caveats:
- this leaks 1 byte of memory every time relative mode is (re-)enabled and a pen comes in proximity
  - allocating a handle is required by the pen subsystem for some reason
  - fixing this in a nice way would require exposing `SDL_Pen *` from `SDL_pen.c`
  - we could also store pointer to this memory in `SDL_VideoData` but I find it silly, and the resulting code is hard to read
- the fake pen will leave proximity only when relative mode is disabled, i.e. it'll be stuck in proximity
  - unsure if detecting proximity is even possible from raw mouse input
- the reported pen position is not bounded and can be outside the window bounds

## Testing

I can confirm this fixes the [original issue](https://github.com/ppy/osu/issues/28223). Tested on Windows 11 24H2 with OpenTabletDriver and a Wacom CTL-6100WL.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
- Closes https://github.com/libsdl-org/SDL/issues/12324