### PR TITLE
Remove usages of `restrict` keyword in SDL_render.c

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -2787,7 +2787,7 @@ static void SDL_RenderLogicalPresentation(SDL_Renderer *renderer)
     }
 }
 
-static bool SDL_RenderVectorFromWindow(SDL_Renderer *renderer, float window_dx, float window_dy, float *restrict dx, float *restrict dy)
+static bool SDL_RenderVectorFromWindow(SDL_Renderer *renderer, float window_dx, float window_dy, float *dx, float *dy)
 {
     // Convert from window coordinates to pixels within the window
     window_dx *= renderer->dpi_scale.x;


### PR DESCRIPTION
I ran into the usage of `restrict` breaking builds targeting Windows XP, as the v141 MSVC toolset doesn't support the keyword.