### PR TITLE
thread/windows: fix stack overflow in exception naming

### DIFF
--- a/src/thread/windows/SDL_systhread.c
+++ b/src/thread/windows/SDL_systhread.c
@@ -153,7 +153,7 @@ void SDL_SYS_SetupThread(const char *name)
             inf.dwFlags = 0;
 
             // The debugger catches this, renames the thread, continues on.
-            RaiseException(SDL_DEBUGGER_NAME_EXCEPTION_CODE, 0, sizeof(inf) / sizeof(ULONG), (const ULONG_PTR *)&inf);
+            RaiseException(SDL_DEBUGGER_NAME_EXCEPTION_CODE, 0, sizeof(inf) / sizeof(ULONG_PTR), (const ULONG_PTR *)&inf);
             RemoveVectoredExceptionHandler(exceptionHandlerHandle);
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
RaiseException expects the size in units of ULONG_PTR, rather than ULONG. The Microsoft documentation also does this: https://learn.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2015/debugger/how-to-set-a-thread-name-in-native-code?view=vs-2015

This means the size passed by SDL is double the amount expected on 64-bit systems, possibly overflowing the stack.