### PR TITLE
Remove redundant casts

### DIFF
--- a/examples/input/01-joystick-polling/joystick-polling.c
+++ b/examples/input/01-joystick-polling/joystick-polling.c
@@ -105,7 +105,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
 
         /* draw axes as bars going across middle of screen. We don't know if it's an X or Y or whatever axis, so we can't do more than this. */
         total = SDL_GetNumJoystickAxes(joystick);
-        y = (float) ((winh - (total * size)) / 2);
+        y = (winh - (total * size)) / 2;
         x = ((float) winw) / 2.0f;
         for (i = 0; i < total; i++) {
             const SDL_Color *color = &colors[i % SDL_arraysize(colors)];
@@ -119,7 +119,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
 
         /* draw buttons as blocks across top of window. We only know the button numbers, but not where they are on the device. */
         total = SDL_GetNumJoystickButtons(joystick);
-        x = (float) ((winw - (total * size)) / 2);
+        x = (winw - (total * size)) / 2;
         for (i = 0; i < total; i++) {
             const SDL_Color *color = &colors[i % SDL_arraysize(colors)];
             const SDL_FRect dst = { x, 0.0f, size, size };
@@ -136,7 +136,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
 
         /* draw hats across the bottom of the screen. */
         total = SDL_GetNumJoystickHats(joystick);
-        x = ((float) ((winw - (total * (size * 2.0f))) / 2.0f)) + (size / 2.0f);
+        x = ((winw - (total * (size * 2.0f))) / 2.0f) + (size / 2.0f);
         y = ((float) winh) - size;
         for (i = 0; i < total; i++) {
             const SDL_Color *color = &colors[i % SDL_arraysize(colors)];

--- a/examples/renderer/09-scaling-textures/scaling-textures.c
+++ b/examples/renderer/09-scaling-textures/scaling-textures.c
@@ -92,8 +92,8 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     /* center this one and make it grow and shrink. */
     dst_rect.w = (float) texture_width + (texture_width * scale);
     dst_rect.h = (float) texture_height + (texture_height * scale);
-    dst_rect.x = ((float) (WINDOW_WIDTH - dst_rect.w)) / 2.0f;
-    dst_rect.y = ((float) (WINDOW_HEIGHT - dst_rect.h)) / 2.0f;
+    dst_rect.x = (WINDOW_WIDTH - dst_rect.w) / 2.0f;
+    dst_rect.y = (WINDOW_HEIGHT - dst_rect.h) / 2.0f;
     SDL_RenderTexture(renderer, texture, NULL, &dst_rect);
 
     SDL_RenderPresent(renderer);  /* put it all on the screen! */

--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -889,7 +889,7 @@ static bool SDLCALL FindLowestDeviceID(void *userdata, const SDL_HashTable *tabl
 
 static SDL_AudioDevice *GetFirstAddedAudioDevice(const bool recording)
 {
-    const SDL_AudioDeviceID highest = (SDL_AudioDeviceID) SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK;  // According to AssignAudioDeviceInstanceId, nothing can have a value this large.
+    const SDL_AudioDeviceID highest = SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK;  // According to AssignAudioDeviceInstanceId, nothing can have a value this large.
 
     // (Device IDs increase as new devices are added, so the first device added has the lowest SDL_AudioDeviceID value.)
     FindLowestDeviceIDData data = { recording, highest, NULL };

--- a/src/camera/SDL_camera.c
+++ b/src/camera/SDL_camera.c
@@ -649,7 +649,7 @@ SDL_Camera *SDL_FindPhysicalCameraByCallback(bool (*callback)(SDL_Camera *device
 
 void SDL_CloseCamera(SDL_Camera *camera)
 {
-    SDL_Camera *device = (SDL_Camera *) camera;  // currently there's no separation between physical and logical device.
+    SDL_Camera *device = camera;  // currently there's no separation between physical and logical device.
     ClosePhysicalCamera(device);
 }
 
@@ -663,7 +663,7 @@ bool SDL_GetCameraFormat(SDL_Camera *camera, SDL_CameraSpec *spec)
         return SDL_InvalidParamError("spec");
     }
 
-    SDL_Camera *device = (SDL_Camera *) camera;  // currently there's no separation between physical and logical device.
+    SDL_Camera *device = camera;  // currently there's no separation between physical and logical device.
     ObtainPhysicalCameraObj(device);
     if (device->permission > 0) {
         SDL_copyp(spec, &device->spec);
@@ -1208,7 +1208,7 @@ SDL_Camera *SDL_OpenCamera(SDL_CameraID instance_id, const SDL_CameraSpec *spec)
 
     ReleaseCamera(device);  // unlock, we're good to go!
 
-    return (SDL_Camera *) device;  // currently there's no separation between physical and logical device.
+    return device;  // currently there's no separation between physical and logical device.
 }
 
 SDL_Surface *SDL_AcquireCameraFrame(SDL_Camera *camera, Uint64 *timestampNS)
@@ -1222,7 +1222,7 @@ SDL_Surface *SDL_AcquireCameraFrame(SDL_Camera *camera, Uint64 *timestampNS)
         return NULL;
     }
 
-    SDL_Camera *device = (SDL_Camera *) camera;  // currently there's no separation between physical and logical device.
+    SDL_Camera *device = camera;  // currently there's no separation between physical and logical device.
 
     ObtainPhysicalCameraObj(device);
 
@@ -1264,7 +1264,7 @@ void SDL_ReleaseCameraFrame(SDL_Camera *camera, SDL_Surface *frame)
         return;
     }
 
-    SDL_Camera *device = (SDL_Camera *) camera;  // currently there's no separation between physical and logical device.
+    SDL_Camera *device = camera;  // currently there's no separation between physical and logical device.
     ObtainPhysicalCameraObj(device);
 
     SurfaceList *slistprev = &device->app_held_output_surfaces;
@@ -1306,7 +1306,7 @@ SDL_CameraID SDL_GetCameraID(SDL_Camera *camera)
     if (!camera) {
         SDL_InvalidParamError("camera");
     } else {
-        SDL_Camera *device = (SDL_Camera *) camera;  // currently there's no separation between physical and logical device.
+        SDL_Camera *device = camera;  // currently there's no separation between physical and logical device.
         ObtainPhysicalCameraObj(device);
         result = device->instance_id;
         ReleaseCamera(device);
@@ -1321,7 +1321,7 @@ SDL_PropertiesID SDL_GetCameraProperties(SDL_Camera *camera)
     if (!camera) {
         SDL_InvalidParamError("camera");
     } else {
-        SDL_Camera *device = (SDL_Camera *) camera;  // currently there's no separation between physical and logical device.
+        SDL_Camera *device = camera;  // currently there's no separation between physical and logical device.
         ObtainPhysicalCameraObj(device);
         if (device->props == 0) {
             device->props = SDL_CreateProperties();
@@ -1340,7 +1340,7 @@ int SDL_GetCameraPermissionState(SDL_Camera *camera)
         SDL_InvalidParamError("camera");
         result = -1;
     } else {
-        SDL_Camera *device = (SDL_Camera *) camera;  // currently there's no separation between physical and logical device.
+        SDL_Camera *device = camera;  // currently there's no separation between physical and logical device.
         ObtainPhysicalCameraObj(device);
         result = device->permission;
         ReleaseCamera(device);

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -484,7 +484,7 @@ SDL_SystemCursor SDL_GetDefaultSystemCursor(void)
     const char *value = SDL_GetHint(SDL_HINT_MOUSE_DEFAULT_SYSTEM_CURSOR);
     if (value) {
         int index = SDL_atoi(value);
-        if (0 <= index && index < (int)SDL_SYSTEM_CURSOR_COUNT) {
+        if (0 <= index && index < SDL_SYSTEM_CURSOR_COUNT) {
             id = (SDL_SystemCursor)index;
         }
     }

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -5337,7 +5337,7 @@ static void VULKAN_DrawIndexedPrimitives(
     Uint32 firstInstance)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_BindGraphicsDescriptorSets(renderer, vulkanCommandBuffer);
 
@@ -5358,7 +5358,7 @@ static void VULKAN_DrawPrimitives(
     Uint32 firstInstance)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_BindGraphicsDescriptorSets(renderer, vulkanCommandBuffer);
 
@@ -5377,7 +5377,7 @@ static void VULKAN_DrawPrimitivesIndirect(
     Uint32 drawCount)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanBuffer *vulkanBuffer = ((VulkanBufferContainer *)buffer)->activeBuffer;
     Uint32 pitch = sizeof(SDL_GPUIndirectDrawCommand);
     Uint32 i;
@@ -5414,7 +5414,7 @@ static void VULKAN_DrawIndexedPrimitivesIndirect(
     Uint32 drawCount)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanBuffer *vulkanBuffer = ((VulkanBufferContainer *)buffer)->activeBuffer;
     Uint32 pitch = sizeof(SDL_GPUIndexedIndirectDrawCommand);
     Uint32 i;
@@ -5547,7 +5547,7 @@ static void VULKAN_InsertDebugLabel(
     const char *text)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VkDebugUtilsLabelEXT labelInfo;
 
     if (renderer->supportsDebugUtils) {
@@ -5566,7 +5566,7 @@ static void VULKAN_PushDebugGroup(
     const char *name)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VkDebugUtilsLabelEXT labelInfo;
 
     if (renderer->supportsDebugUtils) {
@@ -5584,7 +5584,7 @@ static void VULKAN_PopDebugGroup(
     SDL_GPUCommandBuffer *commandBuffer)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
 
     if (renderer->supportsDebugUtils) {
         renderer->vkCmdEndDebugUtilsLabelEXT(vulkanCommandBuffer->commandBuffer);
@@ -7307,8 +7307,8 @@ static void VULKAN_INTERNAL_SetCurrentViewport(
     VulkanCommandBuffer *commandBuffer,
     const SDL_GPUViewport *viewport)
 {
-    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanCommandBuffer *vulkanCommandBuffer = commandBuffer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
 
     vulkanCommandBuffer->currentViewport.x = viewport->x;
     vulkanCommandBuffer->currentViewport.width = viewport->w;
@@ -7341,7 +7341,7 @@ static void VULKAN_INTERNAL_SetCurrentScissor(
     VulkanCommandBuffer *vulkanCommandBuffer,
     const SDL_Rect *scissor)
 {
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
 
     vulkanCommandBuffer->currentScissor.offset.x = scissor->x;
     vulkanCommandBuffer->currentScissor.offset.y = scissor->y;
@@ -7370,7 +7370,7 @@ static void VULKAN_INTERNAL_SetCurrentBlendConstants(
     VulkanCommandBuffer *vulkanCommandBuffer,
     SDL_FColor blendConstants)
 {
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
 
     vulkanCommandBuffer->blendConstants[0] = blendConstants.r;
     vulkanCommandBuffer->blendConstants[1] = blendConstants.g;
@@ -7397,7 +7397,7 @@ static void VULKAN_INTERNAL_SetCurrentStencilReference(
     VulkanCommandBuffer *vulkanCommandBuffer,
     Uint8 reference)
 {
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
 
     vulkanCommandBuffer->stencilRef = reference;
 
@@ -7706,7 +7706,7 @@ static void VULKAN_BeginRenderPass(
     const SDL_GPUDepthStencilTargetInfo *depthStencilTargetInfo)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VkRenderPass renderPass;
     VulkanFramebuffer *framebuffer;
 
@@ -7918,7 +7918,7 @@ static void VULKAN_BindGraphicsPipeline(
     SDL_GPUGraphicsPipeline *graphicsPipeline)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanGraphicsPipeline *pipeline = (VulkanGraphicsPipeline *)graphicsPipeline;
 
     renderer->vkCmdBindPipeline(
@@ -7983,7 +7983,7 @@ static void VULKAN_BindIndexBuffer(
     SDL_GPUIndexElementSize indexElementSize)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanBuffer *vulkanBuffer = ((VulkanBufferContainer *)binding->buffer)->activeBuffer;
 
     VULKAN_INTERNAL_TrackBuffer(vulkanCommandBuffer, vulkanBuffer);
@@ -8031,7 +8031,7 @@ static void VULKAN_EndRenderPass(
     SDL_GPUCommandBuffer *commandBuffer)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     Uint32 i;
 
     renderer->vkCmdEndRenderPass(
@@ -8146,7 +8146,7 @@ static void VULKAN_BindComputePipeline(
     SDL_GPUComputePipeline *computePipeline)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanComputePipeline *vulkanComputePipeline = (VulkanComputePipeline *)computePipeline;
 
     renderer->vkCmdBindPipeline(
@@ -8541,7 +8541,7 @@ static void VULKAN_DispatchCompute(
     Uint32 groupcountZ)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
 
     VULKAN_INTERNAL_BindComputeDescriptorSets(renderer, vulkanCommandBuffer);
 
@@ -8558,7 +8558,7 @@ static void VULKAN_DispatchComputeIndirect(
     Uint32 offset)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanBuffer *vulkanBuffer = ((VulkanBufferContainer *)buffer)->activeBuffer;
 
     VULKAN_INTERNAL_BindComputeDescriptorSets(renderer, vulkanCommandBuffer);
@@ -8680,7 +8680,7 @@ static void VULKAN_UploadToTexture(
     bool cycle)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)source->transfer_buffer;
     VulkanTextureContainer *vulkanTextureContainer = (VulkanTextureContainer *)destination->texture;
     VulkanTextureSubresource *vulkanTextureSubresource;
@@ -8736,7 +8736,7 @@ static void VULKAN_UploadToBuffer(
     bool cycle)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanBufferContainer *transferBufferContainer = (VulkanBufferContainer *)source->transfer_buffer;
     VulkanBufferContainer *bufferContainer = (VulkanBufferContainer *)destination->buffer;
     VkBufferCopy bufferCopy;
@@ -8879,7 +8879,7 @@ static void VULKAN_CopyTextureToTexture(
     bool cycle)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanTextureSubresource *srcSubresource;
     VulkanTextureSubresource *dstSubresource;
     VkImageCopy imageCopy;
@@ -8955,7 +8955,7 @@ static void VULKAN_CopyBufferToBuffer(
     bool cycle)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanBufferContainer *srcContainer = (VulkanBufferContainer *)source->buffer;
     VulkanBufferContainer *dstContainer = (VulkanBufferContainer *)destination->buffer;
     VkBufferCopy bufferCopy;
@@ -9005,7 +9005,7 @@ static void VULKAN_GenerateMipmaps(
     SDL_GPUTexture *texture)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VulkanTextureContainer *container = (VulkanTextureContainer *)texture;
     VulkanTextureSubresource *srcTextureSubresource;
     VulkanTextureSubresource *dstTextureSubresource;
@@ -9106,7 +9106,7 @@ static void VULKAN_Blit(
     const SDL_GPUBlitInfo *info)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     TextureCommonHeader *srcHeader = (TextureCommonHeader *)info->source.texture;
     TextureCommonHeader *dstHeader = (TextureCommonHeader *)info->destination.texture;
     VkImageBlit region;
@@ -9839,7 +9839,7 @@ static bool VULKAN_INTERNAL_AcquireSwapchainTexture(
     Uint32 *swapchainTextureHeight)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     Uint32 swapchainImageIndex;
     WindowData *windowData;
     VkResult acquireResult = VK_SUCCESS;
@@ -10457,7 +10457,7 @@ static bool VULKAN_Submit(
     SDL_GPUCommandBuffer *commandBuffer)
 {
     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
-    VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
     VkSubmitInfo submitInfo;
     VkPresentInfoKHR presentInfo;
     VulkanPresentData *presentData;
@@ -11230,7 +11230,7 @@ static Uint8 VULKAN_INTERNAL_IsDeviceSuitable(
         &queueFamilyCount,
         NULL);
 
-    queueProps = (VkQueueFamilyProperties *)SDL_stack_alloc(
+    queueProps = SDL_stack_alloc(
         VkQueueFamilyProperties,
         queueFamilyCount);
     renderer->vkGetPhysicalDeviceQueueFamilyProperties(

--- a/src/render/vulkan/SDL_render_vulkan.c
+++ b/src/render/vulkan/SDL_render_vulkan.c
@@ -1235,7 +1235,7 @@ static VULKAN_PipelineState *VULKAN_CreatePipelineState(SDL_Renderer *renderer,
 
     // Input assembly
     inputAssemblyStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
-    inputAssemblyStateCreateInfo.topology = ( VkPrimitiveTopology ) topology;
+    inputAssemblyStateCreateInfo.topology = topology;
     inputAssemblyStateCreateInfo.primitiveRestartEnable = VK_FALSE;
 
     viewportStateCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;

--- a/src/test/SDL_test_fuzzer.c
+++ b/src/test/SDL_test_fuzzer.c
@@ -144,7 +144,7 @@ Sint32 SDLTest_RandomIntegerInRange(Sint32 min, Sint32 max)
 
     Uint64 range = (Sint64)max - (Sint64)min;
     if (range < SDL_MAX_SINT32) {
-        return min + (Sint32) SDL_rand_r(&rndContext, (Sint32) range + 1);
+        return min + SDL_rand_r(&rndContext, (Sint32) range + 1);
     } else {
         Uint64 add = SDL_rand_bits_r(&rndContext) | ((Uint64) SDL_rand_bits_r(&rndContext) << 32);
         return (Sint32) (min + (Sint64) (add % (range + 1)));

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -727,7 +727,7 @@ static void xdg_output_handle_logical_size(void *data, struct zxdg_output_v1 *xd
 
 static void xdg_output_handle_done(void *data, struct zxdg_output_v1 *xdg_output)
 {
-    SDL_DisplayData *internal = (void *)data;
+    SDL_DisplayData *internal = data;
 
     /*
      * xdg-output.done events are deprecated and only apply below version 3 of the protocol.

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -233,7 +233,7 @@ void SDL_SetX11EventHook(SDL_X11EventHook callback, void *userdata)
 #ifdef SDL_VIDEO_DRIVER_X11_SUPPORTS_GENERIC_EVENTS
 static void X11_HandleGenericEvent(SDL_VideoDevice *_this, XEvent *xev)
 {
-    SDL_VideoData *videodata = (SDL_VideoData *)_this->internal;
+    SDL_VideoData *videodata = _this->internal;
 
     // event is a union, so cookie == &event, but this is type safe.
     XGenericEventCookie *cookie = &xev->xcookie;
@@ -897,7 +897,7 @@ static int XLookupStringAsUTF8(XKeyEvent *event_struct, char *buffer_return, int
 
 SDL_WindowData *X11_FindWindow(SDL_VideoDevice *_this, Window window)
 {
-    const SDL_VideoData *videodata = (SDL_VideoData *)_this->internal;
+    const SDL_VideoData *videodata = _this->internal;
     int i;
 
     if (videodata && videodata->windowlist) {
@@ -919,7 +919,7 @@ Uint64 X11_GetEventTimestamp(unsigned long time)
 
 void X11_HandleKeyEvent(SDL_VideoDevice *_this, SDL_WindowData *windowdata, SDL_KeyboardID keyboardID, XEvent *xevent)
 {
-    SDL_VideoData *videodata = (SDL_VideoData *)_this->internal;
+    SDL_VideoData *videodata = _this->internal;
     Display *display = videodata->display;
     KeyCode keycode = xevent->xkey.keycode;
     KeySym keysym = NoSymbol;
@@ -1001,7 +1001,7 @@ void X11_HandleKeyEvent(SDL_VideoDevice *_this, SDL_WindowData *windowdata, SDL_
 void X11_HandleButtonPress(SDL_VideoDevice *_this, SDL_WindowData *windowdata, SDL_MouseID mouseID, int button, float x, float y, unsigned long time)
 {
     SDL_Window *window = windowdata->window;
-    const SDL_VideoData *videodata = (SDL_VideoData *)_this->internal;
+    const SDL_VideoData *videodata = _this->internal;
     Display *display = videodata->display;
     int xticks = 0, yticks = 0;
     Uint64 timestamp = X11_GetEventTimestamp(time);
@@ -1048,7 +1048,7 @@ void X11_HandleButtonPress(SDL_VideoDevice *_this, SDL_WindowData *windowdata, S
 void X11_HandleButtonRelease(SDL_VideoDevice *_this, SDL_WindowData *windowdata, SDL_MouseID mouseID, int button, unsigned long time)
 {
     SDL_Window *window = windowdata->window;
-    const SDL_VideoData *videodata = (SDL_VideoData *)_this->internal;
+    const SDL_VideoData *videodata = _this->internal;
     Display *display = videodata->display;
     // The X server sends a Release event for each Press for wheels. Ignore them.
     int xticks = 0, yticks = 0;

--- a/src/video/x11/SDL_x11pen.c
+++ b/src/video/x11/SDL_x11pen.c
@@ -31,7 +31,7 @@
 // Does this device have a valuator for pressure sensitivity?
 static bool X11_XInput2DeviceIsPen(SDL_VideoDevice *_this, const XIDeviceInfo *dev)
 {
-    const SDL_VideoData *data = (SDL_VideoData *)_this->internal;
+    const SDL_VideoData *data = _this->internal;
     for (int i = 0; i < dev->num_classes; i++) {
         const XIAnyClassInfo *classinfo = dev->classes[i];
         if (classinfo->type == XIValuatorClass) {
@@ -49,7 +49,7 @@ static bool X11_XInput2DeviceIsPen(SDL_VideoDevice *_this, const XIDeviceInfo *d
 static bool X11_XInput2PenIsEraser(SDL_VideoDevice *_this, int deviceid, char *devicename)
 {
     #define PEN_ERASER_NAME_TAG  "eraser" // String constant to identify erasers
-    SDL_VideoData *data = (SDL_VideoData *)_this->internal;
+    SDL_VideoData *data = _this->internal;
 
     if (data->atoms.pen_atom_wacom_tool_type != None) {
         Atom type_return;
@@ -105,7 +105,7 @@ static bool X11_XInput2PenIsEraser(SDL_VideoDevice *_this, int deviceid, char *d
 // Returns number of Sint32s written (<= max_words), or 0 on error.
 static size_t X11_XInput2PenGetIntProperty(SDL_VideoDevice *_this, int deviceid, Atom property, Sint32 *dest, size_t max_words)
 {
-    const SDL_VideoData *data = (SDL_VideoData *)_this->internal;
+    const SDL_VideoData *data = _this->internal;
     Atom type_return;
     int format_return;
     unsigned long num_items_return;
@@ -153,7 +153,7 @@ static size_t X11_XInput2PenGetIntProperty(SDL_VideoDevice *_this, int deviceid,
 // Identify Wacom devices (if true is returned) and extract their device type and serial IDs
 static bool X11_XInput2PenWacomDeviceID(SDL_VideoDevice *_this, int deviceid, Uint32 *wacom_devicetype_id, Uint32 *wacom_serial)
 {
-    SDL_VideoData *data = (SDL_VideoData *)_this->internal;
+    SDL_VideoData *data = _this->internal;
     Sint32 serial_id_buf[3];
     int result;
 
@@ -196,7 +196,7 @@ X11_PenHandle *X11_FindPenByDeviceID(int deviceid)
 
 static X11_PenHandle *X11_MaybeAddPen(SDL_VideoDevice *_this, const XIDeviceInfo *dev)
 {
-    SDL_VideoData *data = (SDL_VideoData *)_this->internal;
+    SDL_VideoData *data = _this->internal;
     SDL_PenCapabilityFlags capabilities = 0;
     X11_PenHandle *handle = NULL;
 
@@ -283,7 +283,7 @@ static X11_PenHandle *X11_MaybeAddPen(SDL_VideoDevice *_this, const XIDeviceInfo
 
 X11_PenHandle *X11_MaybeAddPenByDeviceID(SDL_VideoDevice *_this, int deviceid)
 {
-    SDL_VideoData *data = (SDL_VideoData *)_this->internal;
+    SDL_VideoData *data = _this->internal;
     int num_device_info = 0;
     XIDeviceInfo *device_info = X11_XIQueryDevice(data->display, deviceid, &num_device_info);
     if (device_info) {
@@ -306,7 +306,7 @@ void X11_RemovePenByDeviceID(int deviceid)
 
 void X11_InitPen(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = (SDL_VideoData *)_this->internal;
+    SDL_VideoData *data = _this->internal;
 
     #define LOOKUP_PEN_ATOM(X) X11_XInternAtom(data->display, X, False)
     data->atoms.pen_atom_device_product_id = LOOKUP_PEN_ATOM("Device Product ID");

--- a/src/video/x11/SDL_x11shape.c
+++ b/src/video/x11/SDL_x11shape.c
@@ -31,7 +31,7 @@ static Uint8 *GenerateShapeMask(SDL_Surface *shape)
 {
     int x, y;
     const size_t ppb = 8;
-    const size_t bytes_per_scanline = (size_t)(shape->w + (ppb - 1)) / ppb;
+    const size_t bytes_per_scanline = (shape->w + (ppb - 1)) / ppb;
     const Uint8 *a;
     Uint8 *mask;
     Uint8 *mask_scanline;

--- a/src/video/x11/SDL_x11xinput2.c
+++ b/src/video/x11/SDL_x11xinput2.c
@@ -284,7 +284,7 @@ static SDL_XInput2DeviceInfo *xinput2_get_device_info(SDL_VideoData *videodata, 
 void X11_HandleXinput2Event(SDL_VideoDevice *_this, XGenericEventCookie *cookie)
 {
 #ifdef SDL_VIDEO_DRIVER_X11_XINPUT2
-    SDL_VideoData *videodata = (SDL_VideoData *)_this->internal;
+    SDL_VideoData *videodata = _this->internal;
 
     if (cookie->extension != xinput2_opcode) {
         return;
@@ -555,10 +555,10 @@ bool X11_Xinput2IsInitialized(void)
 
 bool X11_Xinput2SelectMouseAndKeyboard(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    SDL_WindowData *windowdata = (SDL_WindowData *)window->internal;
+    SDL_WindowData *windowdata = window->internal;
 
 #ifdef SDL_VIDEO_DRIVER_X11_XINPUT2
-    const SDL_VideoData *data = (SDL_VideoData *)_this->internal;
+    const SDL_VideoData *data = _this->internal;
 
     if (X11_Xinput2IsInitialized()) {
         XIEventMask eventmask;

--- a/src/video/x11/SDL_x11xsync.c
+++ b/src/video/x11/SDL_x11xsync.c
@@ -42,7 +42,7 @@ static bool xsync_version_atleast(const int version, const int wantmajor, const 
 
 void X11_InitXsync(SDL_VideoDevice *_this)
 {
-    SDL_VideoData *data = (SDL_VideoData *) _this->internal;
+    SDL_VideoData *data =  _this->internal;
 
     int version = 0;
     int event, error;
@@ -70,7 +70,7 @@ int X11_XsyncIsInitialized(void)
 int X11_InitResizeSync(SDL_Window *window)
 {
     SDL_assert(window != NULL);
-    SDL_WindowData *data = (SDL_WindowData *) window->internal;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
     Atom counter_prop = data->videodata->atoms._NET_WM_SYNC_REQUEST_COUNTER;
     XSyncCounter counter;
@@ -99,7 +99,7 @@ int X11_InitResizeSync(SDL_Window *window)
 
 void X11_TermResizeSync(SDL_Window *window)
 {
-    SDL_WindowData *data = (SDL_WindowData *) window->internal;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
     Atom counter_prop = data->videodata->atoms._NET_WM_SYNC_REQUEST_COUNTER;
     XSyncCounter counter = data->resize_counter;
@@ -112,7 +112,7 @@ void X11_TermResizeSync(SDL_Window *window)
 
 void X11_HandleSyncRequest(SDL_Window *window, XClientMessageEvent *event)
 {
-    SDL_WindowData *data = (SDL_WindowData *) window->internal;
+    SDL_WindowData *data = window->internal;
 
     data->resize_id.lo = event->data.l[2];
     data->resize_id.hi = event->data.l[3];
@@ -121,7 +121,7 @@ void X11_HandleSyncRequest(SDL_Window *window, XClientMessageEvent *event)
 
 void X11_HandleConfigure(SDL_Window *window, XConfigureEvent *event)
 {
-    SDL_WindowData *data = (SDL_WindowData *) window->internal;
+    SDL_WindowData *data = window->internal;
 
     if (data->resize_id.lo || data->resize_id.hi) {
         data->resize_in_progress = true;
@@ -130,7 +130,7 @@ void X11_HandleConfigure(SDL_Window *window, XConfigureEvent *event)
 
 void X11_HandlePresent(SDL_Window *window)
 {
-    SDL_WindowData *data = (SDL_WindowData *) window->internal;
+    SDL_WindowData *data = window->internal;
     Display *display = data->videodata->display;
     XSyncCounter counter = data->resize_counter;
 

--- a/test/testaudiohotplug.c
+++ b/test/testaudiohotplug.c
@@ -69,7 +69,7 @@ static void iteration(void)
                 done = 1;
             }
         } else if (e.type == SDL_EVENT_AUDIO_DEVICE_ADDED) {
-            const SDL_AudioDeviceID which = (SDL_AudioDeviceID) e.adevice.which;
+            const SDL_AudioDeviceID which = e.adevice.which;
             const bool recording = e.adevice.recording ? true : false;
             const char *name = SDL_GetAudioDeviceName(which);
             if (name) {
@@ -93,7 +93,7 @@ static void iteration(void)
                 }
             }
         } else if (e.type == SDL_EVENT_AUDIO_DEVICE_REMOVED) {
-            dev = (SDL_AudioDeviceID)e.adevice.which;
+            dev = e.adevice.which;
             SDL_Log("%s device %u removed.", devtypestr(e.adevice.recording), (unsigned int)dev);
             /* !!! FIXME: we need to keep track of our streams and destroy them here. */
         }

--- a/test/testautomation_render.c
+++ b/test/testautomation_render.c
@@ -1439,8 +1439,8 @@ static int SDLCALL render_testUVWrapping(void *arg)
 
     rect.w = (float)tface->w * 2;
     rect.h = (float)tface->h * 2;
-    rect.x = (float)(TESTRENDER_SCREEN_W - rect.w) / 2;
-    rect.y = (float)(TESTRENDER_SCREEN_H - rect.h) / 2;
+    rect.x = (TESTRENDER_SCREEN_W - rect.w) / 2;
+    rect.y = (TESTRENDER_SCREEN_H - rect.h) / 2;
 
     /*
      *   0--1

--- a/test/testdraw.c
+++ b/test/testdraw.c
@@ -167,8 +167,8 @@ static void DrawRects(SDL_Renderer *renderer)
 
         rect.w = (float)SDL_rand(viewport.h / 2);
         rect.h = (float)SDL_rand(viewport.h / 2);
-        rect.x = (float)((SDL_rand(viewport.w * 2) - viewport.w) - (rect.w / 2));
-        rect.y = (float)((SDL_rand(viewport.h * 2) - viewport.h) - (rect.h / 2));
+        rect.x = (SDL_rand(viewport.w * 2) - viewport.w) - (rect.w / 2);
+        rect.y = (SDL_rand(viewport.h * 2) - viewport.h) - (rect.h / 2);
         SDL_RenderFillRect(renderer, &rect);
     }
 }

--- a/test/testdrawchessboard.c
+++ b/test/testdrawchessboard.c
@@ -50,8 +50,8 @@ static void DrawChessBoard(void)
 
             rect.w = (float)(darea.w / 8);
             rect.h = (float)(darea.h / 8);
-            rect.x = (float)(x * rect.w);
-            rect.y = (float)(row * rect.h);
+            rect.x = x * rect.w;
+            rect.y = row * rect.h;
             x = x + 2;
             SDL_RenderFillRect(renderer, &rect);
 

--- a/test/testrendercopyex.c
+++ b/test/testrendercopyex.c
@@ -75,8 +75,8 @@ static void Draw(DrawState *s)
             s->scale_direction = 1;
         }
     }
-    s->sprite_rect.x = (float)((viewport.w - s->sprite_rect.w) / 2);
-    s->sprite_rect.y = (float)((viewport.h - s->sprite_rect.h) / 2);
+    s->sprite_rect.x = (viewport.w - s->sprite_rect.w) / 2;
+    s->sprite_rect.y = (viewport.h - s->sprite_rect.h) / 2;
 
     SDL_RenderTextureRotated(s->renderer, s->sprite, NULL, &s->sprite_rect, (double)s->sprite_rect.w, center, SDL_FLIP_NONE);
 

--- a/test/testrendertarget.c
+++ b/test/testrendertarget.c
@@ -113,8 +113,8 @@ DrawComposite(DrawState *s)
             s->scale_direction = 1;
         }
     }
-    s->sprite_rect.x = (float)((viewport.w - s->sprite_rect.w) / 2);
-    s->sprite_rect.y = (float)((viewport.h - s->sprite_rect.h) / 2);
+    s->sprite_rect.x = (viewport.w - s->sprite_rect.w) / 2;
+    s->sprite_rect.y = (viewport.h - s->sprite_rect.h) / 2;
 
     SDL_RenderTexture(s->renderer, s->sprite, NULL, &s->sprite_rect);
 
@@ -168,8 +168,8 @@ Draw(DrawState *s)
             s->scale_direction = 1;
         }
     }
-    s->sprite_rect.x = (float)((viewport.w - s->sprite_rect.w) / 2);
-    s->sprite_rect.y = (float)((viewport.h - s->sprite_rect.h) / 2);
+    s->sprite_rect.x = (viewport.w - s->sprite_rect.w) / 2;
+    s->sprite_rect.y = (viewport.h - s->sprite_rect.h) / 2;
 
     SDL_RenderTexture(s->renderer, s->sprite, NULL, &s->sprite_rect);
 

--- a/test/testscale.c
+++ b/test/testscale.c
@@ -68,8 +68,8 @@ static void Draw(DrawState *s)
             s->scale_direction = 1;
         }
     }
-    s->sprite_rect.x = (float)((viewport.w - s->sprite_rect.w) / 2);
-    s->sprite_rect.y = (float)((viewport.h - s->sprite_rect.h) / 2);
+    s->sprite_rect.x = (viewport.w - s->sprite_rect.w) / 2;
+    s->sprite_rect.y = (viewport.h - s->sprite_rect.h) / 2;
 
     SDL_RenderTexture(s->renderer, s->sprite, NULL, &s->sprite_rect);
 

--- a/test/testviewport.c
+++ b/test/testviewport.c
@@ -85,7 +85,7 @@ static void DrawOnViewport(SDL_Renderer *renderer)
     /* Add a box at the top */
     rect.w = 8.0f;
     rect.h = 8.0f;
-    rect.x = (float)((viewport.w - rect.w) / 2);
+    rect.x = (viewport.w - rect.w) / 2;
     rect.y = 0.0f;
     SDL_RenderFillRect(renderer, &rect);
 


### PR DESCRIPTION
^^ vv
```shell
[ 12%] Building C object CMakeFiles/SDL3-shared.dir/src/audio/SDL_audio.c.o
/path/to/SDL/src/audio/SDL_audio.c:892:39: warning: redundant cast to the same type [google-readability-casting]
  892 |     const SDL_AudioDeviceID highest = (SDL_AudioDeviceID) SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK;  // According to AssignAudioDeviceInstanceId, nothing can have a value this large.
      |                                       ^~~~~~~~~~~~~~~~~~~
[ 13%] Building C object CMakeFiles/SDL3-shared.dir/src/camera/SDL_camera.c.o
/path/to/SDL/src/camera/SDL_camera.c:652:26: warning: redundant cast to the same type [google-readability-casting]
  652 |     SDL_Camera *device = (SDL_Camera *) camera;  // currently there's no separation between physical and logical device.
      |                          ^~~~~~~~~~~~~~
/path/to/SDL/src/camera/SDL_camera.c:666:26: warning: redundant cast to the same type [google-readability-casting]
  666 |     SDL_Camera *device = (SDL_Camera *) camera;  // currently there's no separation between physical and logical device.
      |                          ^~~~~~~~~~~~~~
/path/to/SDL/src/camera/SDL_camera.c:1211:12: warning: redundant cast to the same type [google-readability-casting]
 1211 |     return (SDL_Camera *) device;  // currently there's no separation between physical and logical device.
      |            ^~~~~~~~~~~~~~
/path/to/SDL/src/camera/SDL_camera.c:1225:26: warning: redundant cast to the same type [google-readability-casting]
 1225 |     SDL_Camera *device = (SDL_Camera *) camera;  // currently there's no separation between physical and logical device.
      |                          ^~~~~~~~~~~~~~
/path/to/SDL/src/camera/SDL_camera.c:1267:26: warning: redundant cast to the same type [google-readability-casting]
 1267 |     SDL_Camera *device = (SDL_Camera *) camera;  // currently there's no separation between physical and logical device.
      |                          ^~~~~~~~~~~~~~
/path/to/SDL/src/camera/SDL_camera.c:1309:30: warning: redundant cast to the same type [google-readability-casting]
 1309 |         SDL_Camera *device = (SDL_Camera *) camera;  // currently there's no separation between physical and logical device.
      |                              ^~~~~~~~~~~~~~
/path/to/SDL/src/camera/SDL_camera.c:1324:30: warning: redundant cast to the same type [google-readability-casting]
 1324 |         SDL_Camera *device = (SDL_Camera *) camera;  // currently there's no separation between physical and logical device.
      |                              ^~~~~~~~~~~~~~
/path/to/SDL/src/camera/SDL_camera.c:1343:30: warning: redundant cast to the same type [google-readability-casting]
 1343 |         SDL_Camera *device = (SDL_Camera *) camera;  // currently there's no separation between physical and logical device.
      |                              ^~~~~~~~~~~~~~
[ 14%] Building C object CMakeFiles/SDL3-shared.dir/src/events/SDL_mouse.c.o
/path/to/SDL/src/events/SDL_mouse.c:487:35: warning: redundant cast to the same type [google-readability-casting]
  487 |         if (0 <= index && index < (int)SDL_SYSTEM_CURSOR_COUNT) {
      |                                   ^~~~~
[ 22%] Building C object CMakeFiles/SDL3-shared.dir/src/render/vulkan/SDL_render_vulkan.c.o
/path/to/SDL/src/render/vulkan/SDL_render_vulkan.c:1238:45: warning: redundant cast to the same type [google-readability-casting]
 1238 |     inputAssemblyStateCreateInfo.topology = ( VkPrimitiveTopology ) topology;
      |                                             ^~~~~~~~~~~~~~~~~~~~~~~
[ 30%] Building C object CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11events.c.o
/path/to/SDL/src/video/x11/SDL_x11events.c:236:32: warning: redundant cast to the same type [google-readability-casting]
  236 |     SDL_VideoData *videodata = (SDL_VideoData *)_this->internal;
      |                                ^~~~~~~~~~~~~~~~~
/path/to/SDL/src/video/x11/SDL_x11events.c:900:38: warning: redundant cast to the same type [google-readability-casting]
  900 |     const SDL_VideoData *videodata = (SDL_VideoData *)_this->internal;
      |                                      ^~~~~~~~~~~~~~~~~
/path/to/SDL/src/video/x11/SDL_x11events.c:922:32: warning: redundant cast to the same type [google-readability-casting]
  922 |     SDL_VideoData *videodata = (SDL_VideoData *)_this->internal;
      |                                ^~~~~~~~~~~~~~~~~
/path/to/SDL/src/video/x11/SDL_x11events.c:1004:38: warning: redundant cast to the same type [google-readability-casting]
 1004 |     const SDL_VideoData *videodata = (SDL_VideoData *)_this->internal;
      |                                      ^~~~~~~~~~~~~~~~~
/path/to/SDL/src/video/x11/SDL_x11events.c:1051:38: warning: redundant cast to the same type [google-readability-casting]
 1051 |     const SDL_VideoData *videodata = (SDL_VideoData *)_this->internal;
      |                                      ^~~~~~~~~~~~~~~~~
[ 31%] Building C object CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11pen.c.o
/path/to/SDL/src/video/x11/SDL_x11pen.c:34:33: warning: redundant cast to the same type [google-readability-casting]
   34 |     const SDL_VideoData *data = (SDL_VideoData *)_this->internal;
      |                                 ^~~~~~~~~~~~~~~~~
/path/to/SDL/src/video/x11/SDL_x11pen.c:52:27: warning: redundant cast to the same type [google-readability-casting]
   52 |     SDL_VideoData *data = (SDL_VideoData *)_this->internal;
      |                           ^~~~~~~~~~~~~~~~~
/path/to/SDL/src/video/x11/SDL_x11pen.c:108:33: warning: redundant cast to the same type [google-readability-casting]
  108 |     const SDL_VideoData *data = (SDL_VideoData *)_this->internal;
      |                                 ^~~~~~~~~~~~~~~~~
/path/to/SDL/src/video/x11/SDL_x11pen.c:156:27: warning: redundant cast to the same type [google-readability-casting]
  156 |     SDL_VideoData *data = (SDL_VideoData *)_this->internal;
      |                           ^~~~~~~~~~~~~~~~~
/path/to/SDL/src/video/x11/SDL_x11pen.c:199:27: warning: redundant cast to the same type [google-readability-casting]
  199 |     SDL_VideoData *data = (SDL_VideoData *)_this->internal;
      |                           ^~~~~~~~~~~~~~~~~
/path/to/SDL/src/video/x11/SDL_x11pen.c:286:27: warning: redundant cast to the same type [google-readability-casting]
  286 |     SDL_VideoData *data = (SDL_VideoData *)_this->internal;
      |                           ^~~~~~~~~~~~~~~~~
/path/to/SDL/src/video/x11/SDL_x11pen.c:309:27: warning: redundant cast to the same type [google-readability-casting]
  309 |     SDL_VideoData *data = (SDL_VideoData *)_this->internal;
      |                           ^~~~~~~~~~~~~~~~~
[ 32%] Building C object CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11shape.c.o
/path/to/SDL/src/video/x11/SDL_x11shape.c:34:39: warning: redundant cast to the same type [google-readability-casting]
   34 |     const size_t bytes_per_scanline = (size_t)(shape->w + (ppb - 1)) / ppb;
      |                                       ^~~~~~~~
[ 33%] Building C object CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11xinput2.c.o
/path/to/SDL/src/video/x11/SDL_x11xinput2.c:287:32: warning: redundant cast to the same type [google-readability-casting]
  287 |     SDL_VideoData *videodata = (SDL_VideoData *)_this->internal;
      |                                ^~~~~~~~~~~~~~~~~
/path/to/SDL/src/video/x11/SDL_x11xinput2.c:558:34: warning: redundant cast to the same type [google-readability-casting]
  558 |     SDL_WindowData *windowdata = (SDL_WindowData *)window->internal;
      |                                  ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/video/x11/SDL_x11xinput2.c:561:33: warning: redundant cast to the same type [google-readability-casting]
  561 |     const SDL_VideoData *data = (SDL_VideoData *)_this->internal;
      |                                 ^~~~~~~~~~~~~~~~~
[ 33%] Building C object CMakeFiles/SDL3-shared.dir/src/video/x11/SDL_x11xsync.c.o
/path/to/SDL/src/video/x11/SDL_x11xsync.c:45:27: warning: redundant cast to the same type [google-readability-casting]
   45 |     SDL_VideoData *data = (SDL_VideoData *) _this->internal;
      |                           ^~~~~~~~~~~~~~~~~
/path/to/SDL/src/video/x11/SDL_x11xsync.c:73:28: warning: redundant cast to the same type [google-readability-casting]
   73 |     SDL_WindowData *data = (SDL_WindowData *) window->internal;
      |                            ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/video/x11/SDL_x11xsync.c:102:28: warning: redundant cast to the same type [google-readability-casting]
  102 |     SDL_WindowData *data = (SDL_WindowData *) window->internal;
      |                            ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/video/x11/SDL_x11xsync.c:115:28: warning: redundant cast to the same type [google-readability-casting]
  115 |     SDL_WindowData *data = (SDL_WindowData *) window->internal;
      |                            ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/video/x11/SDL_x11xsync.c:124:28: warning: redundant cast to the same type [google-readability-casting]
  124 |     SDL_WindowData *data = (SDL_WindowData *) window->internal;
      |                            ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/video/x11/SDL_x11xsync.c:133:28: warning: redundant cast to the same type [google-readability-casting]
  133 |     SDL_WindowData *data = (SDL_WindowData *) window->internal;
      |                            ^~~~~~~~~~~~~~~~~~
[ 35%] Building C object CMakeFiles/SDL3-shared.dir/src/video/wayland/SDL_waylandvideo.c.o
/path/to/SDL/src/video/wayland/SDL_waylandvideo.c:730:33: warning: redundant cast to the same type [google-readability-casting]
  730 |     SDL_DisplayData *internal = (void *)data;
      |                                 ^~~~~~~~
[ 48%] Building C object CMakeFiles/SDL3-shared.dir/src/gpu/vulkan/SDL_gpu_vulkan.c.o
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:5340:32: warning: redundant cast to the same type [google-readability-casting]
 5340 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:5361:32: warning: redundant cast to the same type [google-readability-casting]
 5361 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:5380:32: warning: redundant cast to the same type [google-readability-casting]
 5380 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:5417:32: warning: redundant cast to the same type [google-readability-casting]
 5417 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:5550:32: warning: redundant cast to the same type [google-readability-casting]
 5550 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:5569:32: warning: redundant cast to the same type [google-readability-casting]
 5569 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:5587:32: warning: redundant cast to the same type [google-readability-casting]
 5587 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:7310:48: warning: redundant cast to the same type [google-readability-casting]
 7310 |     VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
      |                                                ^~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:7311:32: warning: redundant cast to the same type [google-readability-casting]
 7311 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:7344:32: warning: redundant cast to the same type [google-readability-casting]
 7344 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:7373:32: warning: redundant cast to the same type [google-readability-casting]
 7373 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:7400:32: warning: redundant cast to the same type [google-readability-casting]
 7400 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:7709:32: warning: redundant cast to the same type [google-readability-casting]
 7709 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:7921:32: warning: redundant cast to the same type [google-readability-casting]
 7921 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:7986:32: warning: redundant cast to the same type [google-readability-casting]
 7986 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:8034:32: warning: redundant cast to the same type [google-readability-casting]
 8034 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:8149:32: warning: redundant cast to the same type [google-readability-casting]
 8149 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:8544:32: warning: redundant cast to the same type [google-readability-casting]
 8544 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:8561:32: warning: redundant cast to the same type [google-readability-casting]
 8561 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:8683:32: warning: redundant cast to the same type [google-readability-casting]
 8683 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:8739:32: warning: redundant cast to the same type [google-readability-casting]
 8739 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:8882:32: warning: redundant cast to the same type [google-readability-casting]
 8882 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:8958:32: warning: redundant cast to the same type [google-readability-casting]
 8958 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:9008:32: warning: redundant cast to the same type [google-readability-casting]
 9008 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:9109:32: warning: redundant cast to the same type [google-readability-casting]
 9109 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:9842:32: warning: redundant cast to the same type [google-readability-casting]
 9842 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
      |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:10460:32: warning: redundant cast to the same type [google-readability-casting]
 10460 |     VulkanRenderer *renderer = (VulkanRenderer *)vulkanCommandBuffer->renderer;
       |                                ^~~~~~~~~~~~~~~~~~
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:11233:18: warning: redundant cast to the same type [google-readability-casting]
 11233 |     queueProps = (VkQueueFamilyProperties *)SDL_stack_alloc(
       |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 49%] Building C object CMakeFiles/SDL3_test.dir/src/test/SDL_test_fuzzer.c.o
/path/to/SDL/src/test/SDL_test_fuzzer.c:147:22: warning: redundant cast to the same type [google-readability-casting]
  147 |         return min + (Sint32) SDL_rand_r(&rndContext, (Sint32) range + 1);
      |                      ^~~~~~~~
[ 59%] Building C object test/CMakeFiles/testautomation.dir/testautomation_render.c.o
/path/to/SDL/test/testautomation_render.c:1442:14: warning: redundant cast to the same type [google-readability-casting]
 1442 |     rect.x = (float)(TESTRENDER_SCREEN_W - rect.w) / 2;
      |              ^~~~~~~
/path/to/SDL/test/testautomation_render.c:1443:14: warning: redundant cast to the same type [google-readability-casting]
 1443 |     rect.y = (float)(TESTRENDER_SCREEN_H - rect.h) / 2;
      |              ^~~~~~~
[ 60%] Building C object test/CMakeFiles/testaudiohotplug.dir/testaudiohotplug.c.o
/path/to/SDL/test/testaudiohotplug.c:72:45: warning: redundant cast to the same type [google-readability-casting]
   72 |             const SDL_AudioDeviceID which = (SDL_AudioDeviceID) e.adevice.which;
      |                                             ^~~~~~~~~~~~~~~~~~~
/path/to/SDL/test/testaudiohotplug.c:96:19: warning: redundant cast to the same type [google-readability-casting]
   96 |             dev = (SDL_AudioDeviceID)e.adevice.which;
      |                   ^~~~~~~~~~~~~~~~~~~
[ 62%] Building C object test/CMakeFiles/testdraw.dir/testdraw.c.o
/path/to/SDL/test/testdraw.c:170:18: warning: redundant cast to the same type [google-readability-casting]
  170 |         rect.x = (float)((SDL_rand(viewport.w * 2) - viewport.w) - (rect.w / 2));
      |                  ^~~~~~~
/path/to/SDL/test/testdraw.c:171:18: warning: redundant cast to the same type [google-readability-casting]
  171 |         rect.y = (float)((SDL_rand(viewport.h * 2) - viewport.h) - (rect.h / 2));
      |                  ^~~~~~~
[ 62%] Building C object test/CMakeFiles/testdrawchessboard.dir/testdrawchessboard.c.o
/path/to/SDL/test/testdrawchessboard.c:53:22: warning: redundant cast to the same type [google-readability-casting]
   53 |             rect.x = (float)(x * rect.w);
      |                      ^~~~~~~
/path/to/SDL/test/testdrawchessboard.c:54:22: warning: redundant cast to the same type [google-readability-casting]
   54 |             rect.y = (float)(row * rect.h);
      |                      ^~~~~~~
[ 75%] Building C object test/CMakeFiles/testrendertarget.dir/testrendertarget.c.o
/path/to/SDL/test/testrendertarget.c:116:24: warning: redundant cast to the same type [google-readability-casting]
  116 |     s->sprite_rect.x = (float)((viewport.w - s->sprite_rect.w) / 2);
      |                        ^~~~~~~
/path/to/SDL/test/testrendertarget.c:117:24: warning: redundant cast to the same type [google-readability-casting]
  117 |     s->sprite_rect.y = (float)((viewport.h - s->sprite_rect.h) / 2);
      |                        ^~~~~~~
/path/to/SDL/test/testrendertarget.c:171:24: warning: redundant cast to the same type [google-readability-casting]
  171 |     s->sprite_rect.x = (float)((viewport.w - s->sprite_rect.w) / 2);
      |                        ^~~~~~~
/path/to/SDL/test/testrendertarget.c:172:24: warning: redundant cast to the same type [google-readability-casting]
  172 |     s->sprite_rect.y = (float)((viewport.h - s->sprite_rect.h) / 2);
      |                        ^~~~~~~
[ 75%] Building C object test/CMakeFiles/testscale.dir/testscale.c.o
/path/to/SDL/test/testscale.c:71:24: warning: redundant cast to the same type [google-readability-casting]
   71 |     s->sprite_rect.x = (float)((viewport.w - s->sprite_rect.w) / 2);
      |                        ^~~~~~~
/path/to/SDL/test/testscale.c:72:24: warning: redundant cast to the same type [google-readability-casting]
   72 |     s->sprite_rect.y = (float)((viewport.h - s->sprite_rect.h) / 2);
      |                        ^~~~~~~
[ 80%] Building C object test/CMakeFiles/testviewport.dir/testviewport.c.o
/path/to/SDL/test/testviewport.c:88:14: warning: redundant cast to the same type [google-readability-casting]
   88 |     rect.x = (float)((viewport.w - rect.w) / 2);
      |              ^~~~~~~
[ 81%] Building C object test/CMakeFiles/testrendercopyex.dir/testrendercopyex.c.o
/path/to/SDL/test/testrendercopyex.c:78:24: warning: redundant cast to the same type [google-readability-casting]
   78 |     s->sprite_rect.x = (float)((viewport.w - s->sprite_rect.w) / 2);
      |                        ^~~~~~~
/path/to/SDL/test/testrendercopyex.c:79:24: warning: redundant cast to the same type [google-readability-casting]
   79 |     s->sprite_rect.y = (float)((viewport.h - s->sprite_rect.h) / 2);
      |                        ^~~~~~~
[ 94%] Building C object examples/CMakeFiles/renderer-scaling-textures.dir/renderer/09-scaling-textures/scaling-textures.c.o
/path/to/SDL/examples/renderer/09-scaling-textures/scaling-textures.c:95:19: warning: redundant cast to the same type [google-readability-casting]
   95 |     dst_rect.x = ((float) (WINDOW_WIDTH - dst_rect.w)) / 2.0f;
      |                   ^~~~~~~
/path/to/SDL/examples/renderer/09-scaling-textures/scaling-textures.c:96:19: warning: redundant cast to the same type [google-readability-casting]
   96 |     dst_rect.y = ((float) (WINDOW_HEIGHT - dst_rect.h)) / 2.0f;
      |                   ^~~~~~~
[ 97%] Building C object examples/CMakeFiles/input-joystick-polling.dir/input/01-joystick-polling/joystick-polling.c.o
/path/to/SDL/examples/input/01-joystick-polling/joystick-polling.c:108:13: warning: redundant cast to the same type [google-readability-casting]
  108 |         y = (float) ((winh - (total * size)) / 2);
      |             ^~~~~~~
/path/to/SDL/examples/input/01-joystick-polling/joystick-polling.c:122:13: warning: redundant cast to the same type [google-readability-casting]
  122 |         x = (float) ((winw - (total * size)) / 2);
      |             ^~~~~~~
/path/to/SDL/examples/input/01-joystick-polling/joystick-polling.c:139:14: warning: redundant cast to the same type [google-readability-casting]
  139 |         x = ((float) ((winw - (total * (size * 2.0f))) / 2.0f)) + (size / 2.0f);
      |              ^~~~~~~
```