### PR TITLE
make start&length represent utf32 indices (macos)

### DIFF
--- a/src/video/cocoa/SDL_cocoakeyboard.m
+++ b/src/video/cocoa/SDL_cocoakeyboard.m
@@ -133,8 +133,12 @@
     // This key event was consumed by the IME
     [self clearPendingKey];
 
+    NSUInteger utf32SelectedRangeLocation = [[aString substringToIndex:selectedRange.location] lengthOfBytesUsingEncoding:NSUTF32StringEncoding] / 4;
+    NSUInteger utf32SelectionRangeEnd = [[aString substringToIndex:(selectedRange.location + selectedRange.length)] lengthOfBytesUsingEncoding:NSUTF32StringEncoding] / 4;
+    NSUInteger utf32SelectionRangeLength = utf32SelectionRangeEnd - utf32SelectedRangeLocation;
+
     SDL_SendEditingText([aString UTF8String],
-                        (int)selectedRange.location, (int)selectedRange.length);
+                        (int)utf32SelectedRangeLocation, (int)utf32SelectionRangeLength);
 
     DEBUG_IME(@"setMarkedText: %@, (%d, %d) replacement range (%d, %d)", _markedText,
               (int)selectedRange.location, (int)selectedRange.length,


### PR DESCRIPTION
use utf32 encoding for SDL_TextEditingEvent.start and .length (from utf16) for macos

fix #12344
