### PR TITLE
Add 'const' to pointer parameters

### DIFF
--- a/src/audio/SDL_audioresample.c
+++ b/src/audio/SDL_audioresample.c
@@ -444,7 +444,7 @@ static void SincTable(float *table, int len)
 }
 
 // Calculate Sinc(x/y), using a lookup table
-static float Sinc(float *table, int x, int y)
+static float Sinc(const float *table, int x, int y)
 {
     float s = table[x % y];
     s = ((x / y) & 1) ? -s : s;

--- a/src/audio/alsa/SDL_alsa_audio.c
+++ b/src/audio/alsa/SDL_alsa_audio.c
@@ -566,7 +566,7 @@ static enum snd_pcm_chmap_position sdl_channel_maps[SDL_AUDIO_ALSA__SDL_CHMAPS_N
 };
 
 // Helper for the function right below.
-static bool has_pos(unsigned int *chmap, unsigned int pos)
+static bool has_pos(const unsigned int *chmap, unsigned int pos)
 {
     for (unsigned int chan_idx = 0; ; chan_idx++) {
         if (chan_idx == 6) {
@@ -586,7 +586,7 @@ static bool has_pos(unsigned int *chmap, unsigned int pos)
 #define HAVE_REAR 1
 #define HAVE_SIDE 2
 #define HAVE_BOTH 3
-static void sdl_6chans_set_rear_or_side_channels_from_alsa_6chans(unsigned int *sdl_6chans, unsigned int *alsa_6chans)
+static void sdl_6chans_set_rear_or_side_channels_from_alsa_6chans(unsigned int *sdl_6chans, const unsigned int *alsa_6chans)
 {
     // For alsa channel maps with 6 channels and with SND_CHMAP_FL,SND_CHMAP_FR,SND_CHMAP_FC,
     // SND_CHMAP_LFE, reduce our 6 channels maps to a uniq one.
@@ -638,7 +638,7 @@ static void sdl_6chans_set_rear_or_side_channels_from_alsa_6chans(unsigned int *
 #undef HAVE_SIDE
 #undef HAVE_BOTH
 
-static void swizzle_map_compute_alsa_subscan(struct ALSA_pcm_cfg_ctx *ctx, int *swizzle_map, unsigned int sdl_pos_idx)
+static void swizzle_map_compute_alsa_subscan(const struct ALSA_pcm_cfg_ctx *ctx, int *swizzle_map, unsigned int sdl_pos_idx)
 {
     swizzle_map[sdl_pos_idx] = -1;
     for (unsigned int alsa_pos_idx = 0; ; alsa_pos_idx++) {
@@ -652,7 +652,7 @@ static void swizzle_map_compute_alsa_subscan(struct ALSA_pcm_cfg_ctx *ctx, int *
 }
 
 // XXX: this must stay playback/recording symetric.
-static void swizzle_map_compute(struct ALSA_pcm_cfg_ctx *ctx, int *swizzle_map, bool *needs_swizzle)
+static void swizzle_map_compute(const struct ALSA_pcm_cfg_ctx *ctx, int *swizzle_map, bool *needs_swizzle)
 {
     *needs_swizzle = false;
     for (unsigned int sdl_pos_idx = 0; sdl_pos_idx != ctx->chans_n; sdl_pos_idx++) {
@@ -668,7 +668,7 @@ static void swizzle_map_compute(struct ALSA_pcm_cfg_ctx *ctx, int *swizzle_map, 
 #define CHMAP_NOT_FOUND 2
 // Should always be a queried alsa channel map unless the queried alsa channel map was of type VAR,
 // namely we can program the channel positions directly from the SDL channel map.
-static int alsa_chmap_install(struct ALSA_pcm_cfg_ctx *ctx, unsigned int *chmap)
+static int alsa_chmap_install(struct ALSA_pcm_cfg_ctx *ctx, const unsigned int *chmap)
 {
     bool isstack;
     snd_pcm_chmap_t *chmap_to_install = (snd_pcm_chmap_t*)SDL_small_alloc(unsigned int, 1 + ctx->chans_n, &isstack);
@@ -698,7 +698,7 @@ static int alsa_chmap_install(struct ALSA_pcm_cfg_ctx *ctx, unsigned int *chmap)
 
 // We restrict the alsa channel maps because in the unordered matches we do only simple accounting.
 // In the end, this will handle mostly alsa channel maps with more than one SND_CHMAP_NA position fillers.
-static bool alsa_chmap_has_duplicate_position(struct ALSA_pcm_cfg_ctx *ctx, unsigned int *pos)
+static bool alsa_chmap_has_duplicate_position(const struct ALSA_pcm_cfg_ctx *ctx, const unsigned int *pos)
 {
     if (ctx->chans_n < 2) {// we need at least 2 positions
         LOGDEBUG("channel map:no duplicate");

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -1586,7 +1586,7 @@ static void VULKAN_INTERNAL_RemoveMemoryUsedRegion(
 
 static bool VULKAN_INTERNAL_CheckMemoryTypeArrayUnique(
     Uint32 memoryTypeIndex,
-    Uint32 *memoryTypeIndexArray,
+    const Uint32 *memoryTypeIndexArray,
     Uint32 count)
 {
     Uint32 i = 0;
@@ -4448,7 +4448,7 @@ static bool VULKAN_INTERNAL_VerifySwapSurfaceFormat(
 
 static bool VULKAN_INTERNAL_VerifySwapPresentMode(
     VkPresentModeKHR presentMode,
-    VkPresentModeKHR *availablePresentModes,
+    const VkPresentModeKHR *availablePresentModes,
     Uint32 availablePresentModesLength)
 {
     Uint32 i;

--- a/src/joystick/SDL_gamepad.c
+++ b/src/joystick/SDL_gamepad.c
@@ -428,7 +428,7 @@ static bool SDLCALL SDL_GamepadEventWatcher(void *userdata, SDL_Event *event)
    orientation, so when it's changed orientation to be used as a
    gamepad, change the sensor orientation to match.
  */
-static void AdjustSensorOrientation(SDL_Joystick *joystick, float *src, float *dst)
+static void AdjustSensorOrientation(const SDL_Joystick *joystick, const float *src, float *dst)
 {
     unsigned int i, j;
 

--- a/src/video/wayland/SDL_waylanddatamanager.c
+++ b/src/video/wayland/SDL_waylanddatamanager.c
@@ -272,7 +272,7 @@ void Wayland_primary_selection_source_set_callback(SDL_WaylandPrimarySelectionSo
     }
 }
 
-static void *Wayland_clone_data_buffer(const void *buffer, size_t *len)
+static void *Wayland_clone_data_buffer(const void *buffer, const size_t *len)
 {
     void *clone = NULL;
     if (*len > 0 && buffer) {

--- a/test/testgpu_spinning_cube.c
+++ b/test/testgpu_spinning_cube.c
@@ -152,7 +152,7 @@ perspective_matrix(float fovy, float aspect, float znear, float zfar, float *r)
  * major. In-place multiplication is supported.
  */
 static void
-multiply_matrix(float *lhs, float *rhs, float *r)
+multiply_matrix(const float *lhs, const float *rhs, float *r)
 {
     int i, j, k;
     float tmp[16];


### PR DESCRIPTION
Add 'const' to pointer parameters under src/ and test/ which are not modified in the function definitions.
```shell
[ 12%] Building C object CMakeFiles/SDL3-shared.dir/src/audio/SDL_audioresample.c.o
/path/to/SDL/src/audio/SDL_audioresample.c:447:26: warning: pointer parameter 'table' can be pointer to const [readability-non-const-parameter]
  447 | static float Sinc(float *table, int x, int y)
      |                          ^
      |                   const 
[ 16%] Building C object CMakeFiles/SDL3-shared.dir/src/joystick/SDL_gamepad.c.o
/path/to/SDL/src/joystick/SDL_gamepad.c:431:68: warning: pointer parameter 'src' can be pointer to const [readability-non-const-parameter]
  431 | static void AdjustSensorOrientation(SDL_Joystick *joystick, float *src, float *dst)
      |                                                                    ^
      |                                                             const 
[ 29%] Building C object CMakeFiles/SDL3-shared.dir/src/audio/alsa/SDL_alsa_audio.c.o
/path/to/SDL/src/audio/alsa/SDL_alsa_audio.c:569:35: warning: pointer parameter 'chmap' can be pointer to const [readability-non-const-parameter]
  569 | static bool has_pos(unsigned int *chmap, unsigned int pos)
      |                                   ^
      |                     const 
/path/to/SDL/src/audio/alsa/SDL_alsa_audio.c:701:91: warning: pointer parameter 'pos' can be pointer to const [readability-non-const-parameter]
  701 | static bool alsa_chmap_has_duplicate_position(struct ALSA_pcm_cfg_ctx *ctx, unsigned int *pos)
      |                                                                                           ^
      |                                                                             const 
[ 34%] Building C object CMakeFiles/SDL3-shared.dir/src/video/wayland/SDL_waylanddatamanager.c.o
/path/to/SDL/src/video/wayland/SDL_waylanddatamanager.c:275:68: warning: pointer parameter 'len' can be pointer to const [readability-non-const-parameter]
  275 | static void *Wayland_clone_data_buffer(const void *buffer, size_t *len)
      |                                                                    ^
      |                                                            const 
[ 48%] Building C object CMakeFiles/SDL3-shared.dir/src/gpu/vulkan/SDL_gpu_vulkan.c.o
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:1589:13: warning: pointer parameter 'memoryTypeIndexArray' can be pointer to const [readability-non-const-parameter]
 1589 |     Uint32 *memoryTypeIndexArray,
      |             ^
      |     const 
/path/to/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:4451:23: warning: pointer parameter 'availablePresentModes' can be pointer to const [readability-non-const-parameter]
 4451 |     VkPresentModeKHR *availablePresentModes,
      |                       ^
      |     const 
[ 72%] Building C object test/CMakeFiles/testgpu_spinning_cube.dir/testgpu_spinning_cube.c.o
/path/to/SDL/test/testgpu_spinning_cube.c:155:24: warning: pointer parameter 'lhs' can be pointer to const [readability-non-const-parameter]
  155 | multiply_matrix(float *lhs, float *rhs, float *r)
      |                        ^
      |                 const 
/path/to/SDL/test/testgpu_spinning_cube.c:155:36: warning: pointer parameter 'rhs' can be pointer to const [readability-non-const-parameter]
  155 | multiply_matrix(float *lhs, float *rhs, float *r)
      |                                    ^
      |                             const 
```

Following warnings were not fixed because the function is in the public API and has a supported counterpart which does modify the argument:
```shell
[ 27%] Building C object CMakeFiles/SDL3-shared.dir/src/video/SDL_video_unsupported.c.o
/path/to/SDL/src/video/SDL_video_unsupported.c:46:58: warning: pointer parameter 'adapterIndex' can be pointer to const [readability-non-const-parameter]
   45 | SDL_DECLSPEC bool SDLCALL SDL_GetDXGIOutputInfo(SDL_DisplayID displayID, int *adapterIndex, int *outputIndex);
      |                                                                          const 
   46 | bool SDL_GetDXGIOutputInfo(SDL_DisplayID displayID, int *adapterIndex, int *outputIndex)
      |                                                          ^
      |                                                     const 
/path/to/SDL/src/video/SDL_video_unsupported.c:46:77: warning: pointer parameter 'outputIndex' can be pointer to const [readability-non-const-parameter]
   45 | SDL_DECLSPEC bool SDLCALL SDL_GetDXGIOutputInfo(SDL_DisplayID displayID, int *adapterIndex, int *outputIndex);
      |                                                                                             const 
   46 | bool SDL_GetDXGIOutputInfo(SDL_DisplayID displayID, int *adapterIndex, int *outputIndex)
      |                                                                             ^
      |                                                                        const 
```