### PR TITLE
Fix v4l2 camera

### DIFF
--- a/src/camera/v4l2/SDL_camera_v4l2.c
+++ b/src/camera/v4l2/SDL_camera_v4l2.c
@@ -438,10 +438,10 @@ static Uint32 format_sdl_to_v4l2(SDL_PixelFormat fmt)
     switch (fmt) {
         #define CASE(y, x)  case x: return y
         CASE(V4L2_PIX_FMT_YUYV, SDL_PIXELFORMAT_YUY2);
-        CASE(V4L2_PIX_FMT_MJPEG, SDL_PIXELFORMAT_UNKNOWN);
+        CASE(V4L2_PIX_FMT_MJPEG, SDL_PIXELFORMAT_MJPG);
         #undef CASE
         default:
-            return true;
+            return 0;
     }
 }
 

--- a/test/testcamera.c
+++ b/test/testcamera.c
@@ -97,8 +97,6 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
                 NULL,
             };
             SDLTest_CommonLogUsage(state, argv[0], options);
-            SDL_Quit();
-            SDLTest_CommonDestroyState(state);
             return SDL_APP_FAILURE;
         }
         i += consumed;


### PR DESCRIPTION
`format_sdl_to_v4l2` did not map `SDL_PIXELFORMAT_MJPG` to `V4L2_PIX_FMT_MJPEG`.

I also changed the return value to `0` when it get an unknown pixel format. I'm not sure what's appropriate here.

Fixes #12358

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
