### PR TITLE
[SDL3] Add SDL_HINT_JOYSTICK_HAPTIC_AXES

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2192,6 +2192,28 @@ extern "C" {
 #define SDL_HINT_JOYSTICK_ZERO_CENTERED_DEVICES "SDL_JOYSTICK_ZERO_CENTERED_DEVICES"
 
 /**
+ * A variable containing a list of devices and their desired number of haptic
+ * (force feedback) enabled axis.
+ *
+ * The format of the string is a comma separated list of USB VID/PID pairs in
+ * hexadecimal form plus the number of desired axes, e.g.
+ *
+ * `0xAAAA/0xBBBB/1,0xCCCC/0xDDDD/3`
+ *
+ * This hint supports a "wildcard" device that will set the number of haptic
+ * axes on all initialized haptic devices which were not defined explicitly
+ * in this hint.
+ *
+ * `0xFFFF/0xFFFF/1`
+ *
+ * This hint should be set before a controller is opened. The number of
+ * haptic axes won't exceed the number of real axes found on the device.
+ *
+ * \since This hint is available since SDL 3.2.5.
+*/
+#define SDL_HINT_JOYSTICK_HAPTIC_AXES "SDL_JOYSTICK_HAPTIC_AXES"
+
+/**
  * A variable that controls keycode representation in keyboard events.
  *
  * This variable is a comma separated set of options for translating keycodes


### PR DESCRIPTION
My idea is to introduce `SDL_HINT_JOYSTICK_HAPTIC_AXES` (subject to change) that could overwrite haptic->naxes for a given VID:PID similar to `SDL_HINT_JOYSTICK_DEVICE` but with added naxes value. Example: `SDL_JOYSTICK_HAPTIC_AXES="0x1234/0xABCD/0x1"`

## Description
Description can be found in the linked issue.

This will help in fixing force feedback in some rouge games like Richard Burns Rally which tries to change `cAxes` value of an already create effect which leads to direct input errors and non-functioning force feedback.

Apart from that, this isn't final form as I'd like some pointers or maybe I did it in a way that's not great. This implementation is based on hod loading VIDPID lists work. I'll clean up commits and their descriptions in the coming days.

To test, I've used a modified wine build that can generate variable number of FF-enabled axes, as wine was hardcoding two axes in the virtual joystick's PID descriptor. I'll be upstreaming these changes to wine as soon as I get fork permissions on their gitlab.

Moreover, I'd like to ask if I could introduce this into SDL2 as well. Wine won't be moving soon and not every system will switch to sdl2-compat. My reasoning is that it doesn't change any API that's already in there so it won't break any SDL2 clients.

Of course, the timing isn't great as a new SDL2 release happened just recently, but because it's not changing any existing APIs and it's not adding anything new, I suppose this maybe could be included in a hotfix release.

### TODOs:
- [x] Cap the overriden naxes to the number of axes actually found on the given joystick
- [x] Fix windows build
- [x] Add proper `\since` to the hint description (maybe it's automatic and I shouldn't?)

## Existing Issue(s)
#12341 
