### PR TITLE
src/io/SDL_asyncio.c:SDL_AsyncIOFromFile(): Fix null-dereference warning

### DIFF
--- a/src/io/SDL_asyncio.c
+++ b/src/io/SDL_asyncio.c
@@ -57,12 +57,14 @@ SDL_AsyncIO *SDL_AsyncIOFromFile(const char *file, const char *mode)
     }
 
     SDL_AsyncIO *asyncio = (SDL_AsyncIO *)SDL_calloc(1, sizeof(*asyncio));
-    if (asyncio) {
-        asyncio->lock = SDL_CreateMutex();
-        if (!asyncio->lock) {
-            SDL_free(asyncio);
-            return NULL;
-        }
+    if (!asyncio) {
+        return NULL;
+    }
+
+    asyncio->lock = SDL_CreateMutex();
+    if (!asyncio->lock) {
+        SDL_free(asyncio);
+        return NULL;
     }
 
     if (!SDL_SYS_AsyncIOFromFile(file, binary_mode, asyncio)) {


### PR DESCRIPTION
```shell
[ 16%] Building C object CMakeFiles/SDL3-shared.dir/src/io/SDL_asyncio.c.o
/path/to/SDL/src/io/SDL_asyncio.c:69:26: warning: Access to field 'lock' results in a dereference of a null pointer (loaded from variable 'asyncio') [clang-analyzer-core.NullDereference]
   69 |         SDL_DestroyMutex(asyncio->lock);
      |                          ^
/path/to/SDL/src/io/SDL_asyncio.c:299:9: note: Assuming 'file' is non-null
  299 |     if (!file) {
      |         ^~~~~
/path/to/SDL/src/io/SDL_asyncio.c:299:5: note: Taking false branch
  299 |     if (!file) {
      |     ^
/path/to/SDL/src/io/SDL_asyncio.c:301:16: note: Assuming 'queue' is non-null
  301 |     } else if (!queue) {
      |                ^~~~~~
/path/to/SDL/src/io/SDL_asyncio.c:301:12: note: Taking false branch
  301 |     } else if (!queue) {
      |            ^
/path/to/SDL/src/io/SDL_asyncio.c:306:28: note: Calling 'SDL_AsyncIOFromFile_REAL'
  306 |     SDL_AsyncIO *asyncio = SDL_AsyncIOFromFile(file, "r");
      |                            ^
/path/to/SDL/src/dynapi/SDL_dynapi_overrides.h:1217:29: note: expanded from macro 'SDL_AsyncIOFromFile'
 1217 | #define SDL_AsyncIOFromFile SDL_AsyncIOFromFile_REAL
      |                             ^
/path/to/SDL/src/io/SDL_asyncio.c:45:10: note: 'file' is non-null
   45 |     if (!file) {
      |          ^~~~
/path/to/SDL/src/io/SDL_asyncio.c:45:5: note: Taking false branch
   45 |     if (!file) {
      |     ^
/path/to/SDL/src/io/SDL_asyncio.c:48:17: note: 'mode' is non-null
   48 |     } else if (!mode) {
      |                 ^~~~
/path/to/SDL/src/io/SDL_asyncio.c:48:12: note: Taking false branch
   48 |     } else if (!mode) {
      |            ^
/path/to/SDL/src/io/SDL_asyncio.c:54:9: note: Assuming 'binary_mode' is non-null
   54 |     if (!binary_mode) {
      |         ^~~~~~~~~~~~
/path/to/SDL/src/io/SDL_asyncio.c:54:5: note: Taking false branch
   54 |     if (!binary_mode) {
      |     ^
/path/to/SDL/src/io/SDL_asyncio.c:59:5: note: 'asyncio' initialized here
   59 |     SDL_AsyncIO *asyncio = (SDL_AsyncIO *)SDL_calloc(1, sizeof(*asyncio));
      |     ^~~~~~~~~~~~~~~~~~~~
/path/to/SDL/src/io/SDL_asyncio.c:60:9: note: Assuming 'asyncio' is null
   60 |     if (asyncio) {
      |         ^~~~~~~
/path/to/SDL/src/io/SDL_asyncio.c:60:5: note: Taking false branch
   60 |     if (asyncio) {
      |     ^
/path/to/SDL/src/io/SDL_asyncio.c:68:9: note: Assuming the condition is true
   68 |     if (!SDL_SYS_AsyncIOFromFile(file, binary_mode, asyncio)) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/src/io/SDL_asyncio.c:68:5: note: Taking true branch
   68 |     if (!SDL_SYS_AsyncIOFromFile(file, binary_mode, asyncio)) {
      |     ^
/path/to/SDL/src/io/SDL_asyncio.c:69:26: note: Access to field 'lock' results in a dereference of a null pointer (loaded from variable 'asyncio')
   69 |         SDL_DestroyMutex(asyncio->lock);
      |                          ^~~~~~~
```