### PR TITLE
Remove unnecessary fcitx's devel package dependency in linux doc

### DIFF
--- a/docs/README-linux.md
+++ b/docs/README-linux.md
@@ -19,7 +19,7 @@ Ubuntu 18.04, all available features enabled:
     libaudio-dev libjack-dev libsndio-dev libx11-dev libxext-dev \
     libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev \
     libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \
-    libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev fcitx-libs-dev
+    libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev
 
 Ubuntu 22.04+ can also add `libpipewire-0.3-dev libwayland-dev libdecor-0-dev liburing-dev` to that command line.
 
@@ -28,7 +28,7 @@ Fedora 35, all available features enabled:
     sudo yum install gcc git-core make cmake \
     alsa-lib-devel pulseaudio-libs-devel nas-devel pipewire-devel \
     libX11-devel libXext-devel libXrandr-devel libXcursor-devel libXfixes-devel \
-    libXi-devel libXScrnSaver-devel dbus-devel ibus-devel fcitx-devel \
+    libXi-devel libXScrnSaver-devel dbus-devel ibus-devel \
     systemd-devel mesa-libGL-devel libxkbcommon-devel mesa-libGLES-devel \
     mesa-libEGL-devel vulkan-devel wayland-devel wayland-protocols-devel \
     libdrm-devel mesa-libgbm-devel libusb-devel libdecor-devel \


### PR DESCRIPTION
## Description
Fcitx related support only relies on libdbus.
