### PR TITLE
gpu: Validate that reserved struct members are unset

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -1550,7 +1550,7 @@ typedef struct SDL_GPUVertexBufferDescription
     Uint32 slot;                        /**< The binding slot of the vertex buffer. */
     Uint32 pitch;                       /**< The byte pitch between consecutive elements of the vertex buffer. */
     SDL_GPUVertexInputRate input_rate;  /**< Whether attribute addressing is a function of the vertex index or instance index. */
-    Uint32 instance_step_rate;          /**< Ignored, reserved for future use. */
+    Uint32 instance_step_rate;          /**< Reserved for future use. Must be set to 0. */
 } SDL_GPUVertexBufferDescription;
 
 /**
@@ -1757,8 +1757,8 @@ typedef struct SDL_GPURasterizerState
 typedef struct SDL_GPUMultisampleState
 {
     SDL_GPUSampleCount sample_count;  /**< The number of samples to be used in rasterization. */
-    Uint32 sample_mask;               /**< Ignored, reserved for future use. */
-    bool enable_mask;             /**< Ignored, reserved for future use. */
+    Uint32 sample_mask;               /**< Reserved for future use. Must be set to 0. */
+    bool enable_mask;             /**< Reserved for future use. Must be set to false. */
     Uint8 padding1;
     Uint8 padding2;
     Uint8 padding3;

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -854,6 +854,12 @@ SDL_GPUGraphicsPipeline *SDL_CreateGPUGraphicsPipeline(
             SDL_assert_release(!"The number of vertex attributes in a vertex input state must not exceed 16!");
             return NULL;
         }
+        for (Uint32 i = 0; i < graphicsPipelineCreateInfo->vertex_input_state.num_vertex_buffers; i += 1) {
+            if (graphicsPipelineCreateInfo->vertex_input_state.vertex_buffer_descriptions[i].instance_step_rate != 0) {
+                SDL_assert_release(!"For all vertex buffer descriptions, instance_step_rate must be 0!");
+                return NULL;
+            }
+        }
         Uint32 locations[MAX_VERTEX_ATTRIBUTES];
         for (Uint32 i = 0; i < graphicsPipelineCreateInfo->vertex_input_state.num_vertex_attributes; i += 1) {
             CHECK_VERTEXELEMENTFORMAT_ENUM_INVALID(graphicsPipelineCreateInfo->vertex_input_state.vertex_attributes[i].format, NULL);
@@ -862,8 +868,17 @@ SDL_GPUGraphicsPipeline *SDL_CreateGPUGraphicsPipeline(
             for (Uint32 j = 0; j < i; j += 1) {
                 if (locations[j] == locations[i]) {
                     SDL_assert_release(!"Each vertex attribute location in a vertex input state must be unique!");
+                    return NULL;
                 }
             }
+        }
+        if (graphicsPipelineCreateInfo->multisample_state.enable_mask) {
+            SDL_assert_release(!"For multisample states, enable_mask must be false!");
+            return NULL;
+        }
+        if (graphicsPipelineCreateInfo->multisample_state.sample_mask != 0) {
+            SDL_assert_release(!"For multisample states, sample_mask must be 0!");
+            return NULL;
         }
         if (graphicsPipelineCreateInfo->depth_stencil_state.enable_depth_test) {
             CHECK_COMPAREOP_ENUM_INVALID(graphicsPipelineCreateInfo->depth_stencil_state.compare_op, NULL)


### PR DESCRIPTION
Adding some documentation and debug validation for the newly "reserved for future use" struct members in the GPU API. Addresses the feedback from https://github.com/libsdl-org/SDL/pull/12373. 

(In the process I also caught a validation issue where we weren't returning NULL for a failed assertion in `CreateGPUGraphicsPipeline`.)