### PR TITLE
gpu: initialize VkDebugUtilsLabelEXT::color

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -5549,8 +5549,8 @@ static void VULKAN_InsertDebugLabel(
     VkDebugUtilsLabelEXT labelInfo;
 
     if (renderer->supportsDebugUtils) {
+        SDL_zero(labelInfo);
         labelInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
-        labelInfo.pNext = NULL;
         labelInfo.pLabelName = text;
 
         renderer->vkCmdInsertDebugUtilsLabelEXT(
@@ -5568,8 +5568,8 @@ static void VULKAN_PushDebugGroup(
     VkDebugUtilsLabelEXT labelInfo;
 
     if (renderer->supportsDebugUtils) {
+        SDL_zero(labelInfo);
         labelInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
-        labelInfo.pNext = NULL;
         labelInfo.pLabelName = name;
 
         renderer->vkCmdBeginDebugUtilsLabelEXT(


### PR DESCRIPTION
Fixes #12383.

Initialize memory that may be read later.

## Description

RenderDoc and similar tools will no longer read uninitialized memory for the color. They will instead read transparent.

## Existing Issue(s)

https://github.com/libsdl-org/SDL/issues/12383