### PR TITLE
Fix pen generated mouse events not having SDL_PEN_MOUSEID 

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -777,7 +777,7 @@ static void SDL_PrivateSendMouseMotion(Uint64 timestamp, SDL_Window *window, SDL
 
     // Post the event, if desired
     if (SDL_EventEnabled(SDL_EVENT_MOUSE_MOTION)) {
-        if ((!mouse->relative_mode || mouse->warp_emulation_active) && mouseID != SDL_TOUCH_MOUSEID) {
+        if ((!mouse->relative_mode || mouse->warp_emulation_active) && mouseID != SDL_TOUCH_MOUSEID && mouseID != SDL_PEN_MOUSEID) {
             // We're not in relative mode, so all mouse events are global mouse events
             mouseID = SDL_GLOBAL_MOUSE_ID;
         }
@@ -948,7 +948,7 @@ static void SDL_PrivateSendMouseButton(Uint64 timestamp, SDL_Window *window, SDL
 
     // Post the event, if desired
     if (SDL_EventEnabled(type)) {
-        if ((!mouse->relative_mode || mouse->warp_emulation_active) && mouseID != SDL_TOUCH_MOUSEID) {
+        if ((!mouse->relative_mode || mouse->warp_emulation_active) && mouseID != SDL_TOUCH_MOUSEID && mouseID != SDL_PEN_MOUSEID) {
             // We're not in relative mode, so all mouse events are global mouse events
             mouseID = SDL_GLOBAL_MOUSE_ID;
         } else {

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -689,7 +689,7 @@ static void SDL_PrivateSendMouseMotion(Uint64 timestamp, SDL_Window *window, SDL
 
     // SDL_HINT_MOUSE_TOUCH_EVENTS: controlling whether mouse events should generate synthetic touch events
     if (mouse->mouse_touch_events) {
-        if (mouseID != SDL_TOUCH_MOUSEID && !relative && track_mouse_down) {
+        if (mouseID != SDL_TOUCH_MOUSEID && mouseID != SDL_PEN_MOUSEID && !relative && track_mouse_down) {
             if (window) {
                 float normalized_x = x / (float)window->w;
                 float normalized_y = y / (float)window->h;
@@ -880,7 +880,7 @@ static void SDL_PrivateSendMouseButton(Uint64 timestamp, SDL_Window *window, SDL
 
     // SDL_HINT_MOUSE_TOUCH_EVENTS: controlling whether mouse events should generate synthetic touch events
     if (mouse->mouse_touch_events) {
-        if (mouseID != SDL_TOUCH_MOUSEID && button == SDL_BUTTON_LEFT) {
+        if (mouseID != SDL_TOUCH_MOUSEID && mouseID != SDL_PEN_MOUSEID && button == SDL_BUTTON_LEFT) {
             if (down) {
                 track_mouse_down = true;
             } else {

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -631,7 +631,7 @@ void SDL_SendMouseMotion(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouse
 {
     if (window && !relative) {
         SDL_Mouse *mouse = SDL_GetMouse();
-        if (!SDL_UpdateMouseFocus(window, x, y, SDL_GetMouseButtonState(mouse, mouseID, true), (mouseID != SDL_TOUCH_MOUSEID))) {
+        if (!SDL_UpdateMouseFocus(window, x, y, SDL_GetMouseButtonState(mouse, mouseID, true), (mouseID != SDL_TOUCH_MOUSEID && mouseID != SDL_PEN_MOUSEID))) {
             return;
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The functions which dispatch mouse events were not taking into account that a pen may be the source of an event, so I've added tests for `SDL_PEN_MOUSEID` in places where they already check for `SDL_TOUCH_MOUSEID` so that pen and touch will behave the same when generating mouse events.

Commit [680ac7](https://github.com/libsdl-org/SDL/commit/680ac762584b2be9059af8849721797a40f37200) then fixes a related issue I found that isn't listed that requires the previous commits to function:

If `SDL_HINT_PEN_MOUSE_EVENTS` and `SDL_HINT_MOUSE_TOUCH_EVENTS` are both enabled, the pen generated synthetic mouse event will then produce a touch event with `SDL_MOUSE_TOUCHID` without this additional check to identify a pen as the source. It can't identify a pen as a source without `SDL_PEN_MOUSEID` being supplied.

## Existing Issue(s)
Fixes #12322 

<!--- If it fixes an open issue, please link to the issue here. -->
## Testing
Windows 10 with a Wacom Cintiq 16 (DTK-1660) on driver 6.4.9-2

Comparing to SDL 3.2.4 all pen generated mouse events now have `SDL_PEN_MOUSEID` and I don't see any problems in the event data that SDL expects*.

*Now I know the horrors of [Windows randomly sending `WM_MOUSEMOVE`](https://devblogs.microsoft.com/oldnewthing/20031001-00/?p=42343) with `GetMessageExtraInfo() == 0` regardless of what else you are doing. I made a program to find out if these popping up mid pen stroke was my doing but no, it's always there, SDL just has to do something with those because they look like regular mouse moves...