### PR TITLE
Don't cleanup clipboard in SDL_SendClipboardUpdate

### DIFF
--- a/src/events/SDL_clipboardevents.c
+++ b/src/events/SDL_clipboardevents.c
@@ -30,7 +30,11 @@ void SDL_SendClipboardUpdate(bool owner, char **mime_types, size_t num_mime_type
 {
     if (!owner) {
         // Clear our internal clipboard contents when external clipboard is set
-        // Wayland: https://github.com/libsdl-org/SDL/issues/12152
+        /* Wayland sends a data offer to the client from which the clipboard data originated, and as there is no way
+         * to determine the origin of the offer, the clipboard must not be cleared in the case of a recursive offer,
+         * or the original data may be destroyed. Cleanup will be done in the backend when an offer cancellation
+         * event arrives.
+         */
         if (SDL_strcmp(SDL_GetCurrentVideoDriver(), "wayland") != 0)
             SDL_CancelClipboardData(0);
 

--- a/src/events/SDL_clipboardevents.c
+++ b/src/events/SDL_clipboardevents.c
@@ -30,7 +30,10 @@ void SDL_SendClipboardUpdate(bool owner, char **mime_types, size_t num_mime_type
 {
     if (!owner) {
         // Clear our internal clipboard contents when external clipboard is set
-        SDL_CancelClipboardData(0);
+        // Wayland: https://github.com/libsdl-org/SDL/issues/12152
+        if (SDL_strcmp(SDL_GetCurrentVideoDriver(), "wayland") != 0)
+            SDL_CancelClipboardData(0);
+
         SDL_SaveClipboardMimeTypes((const char **)mime_types, num_mime_types);
     }
 


### PR DESCRIPTION
## Description
[This issue](https://github.com/libsdl-org/SDL/issues/12152) happens because SDL receives a data offer that was sent by itself.

https://github.com/libsdl-org/SDL/blob/69803253100111f870c068300d336edac19783b4/src/video/wayland/SDL_waylandevents.c#L2500

Then it assumes that the received event is from another client, and cleans up our clipboard contents.

https://github.com/libsdl-org/SDL/blob/69803253100111f870c068300d336edac19783b4/src/events/SDL_clipboardevents.c#L29-L35

I'm not sure if this is a right way to fix, because `owner` field of `SDL_ClipboardEvent` becomes basically useless on Wayland, but I couldn't find out a way to confirm that `wl_data_offer` did not come from SDL itself.

This PR fixes it by not cleaning up clipboard until the app sets clipboard next time, but I know that this isn't a best solution. I'm happy to close this PR if a better solution is found.

## Existing Issue(s)
- Closes https://github.com/libsdl-org/SDL/issues/12152
