### PR TITLE
strings.h isn't available in Windows environments

### DIFF
--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -5969,7 +5969,6 @@ char *strdup(const char *str);
    their prototype defined (clang-diagnostic-implicit-function-declaration) */
 #include <stdio.h>
 #include <stdlib.h>
-#include <strings.h>
 
 #define SDL_malloc malloc
 #define SDL_calloc calloc


### PR DESCRIPTION
I believe this header isn't necessary for clang-tidy, string.h has all the functions we care about.

Fixes https://github.com/libsdl-org/SDL/issues/12238
