### PR TITLE
Change D3D12 GPU backend to respect has_depth_stencil_target

### DIFF
--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -3014,7 +3014,9 @@ static SDL_GPUGraphicsPipeline *D3D12_CreateGraphicsPipeline(
     psoDesc.SampleDesc.Count = SDLToD3D12_SampleCount[createinfo->multisample_state.sample_count];
     psoDesc.SampleDesc.Quality = (createinfo->multisample_state.sample_count > SDL_GPU_SAMPLECOUNT_1) ? D3D12_STANDARD_MULTISAMPLE_PATTERN : 0;
 
-    psoDesc.DSVFormat = SDLToD3D12_DepthFormat[createinfo->target_info.depth_stencil_format];
+    if (createinfo->target_info.has_depth_stencil_target) {
+        psoDesc.DSVFormat = SDLToD3D12_DepthFormat[createinfo->target_info.depth_stencil_format];
+    }
     psoDesc.NumRenderTargets = createinfo->target_info.num_color_targets;
     for (uint32_t i = 0; i < createinfo->target_info.num_color_targets; i += 1) {
         psoDesc.RTVFormats[i] = SDLToD3D12_TextureFormat[createinfo->target_info.color_target_descriptions[i].format];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Only set the depth texture format if the user specifies that they have a depth stencil target.

## Description
<!--- Describe your changes in detail -->

Sometimes I reuse `SDL_GPUGraphicsPipelineCreateInfo` to reduce boilerplate. If you:

1.
- Set the depth stencil format
- Set `has_depth_stencil_target` to `true`

2.
- Set `has_depth_stencil_target` to `false`

Your console will be spammed with D3D12 errors such as:
D3D12 ERROR: ID3D12CommandList::DrawInstanced: The depth stencil format does not match that specified by the current pipeline state. A null depth stencil view may only be bound when the pipeline state depth stencil format is UNKNOWN. (pipeline state = D32_FLOAT, DSV ID3D12Resource* = 0x0000000000000000:'(nullptr)') [ EXECUTION ERROR #615: DEPTH_STENCIL_FORMAT_MISMATCH_PIPELINE_STATE]