### PR TITLE
Windows: Fix SDL_GlobDirectory

### DIFF
--- a/src/filesystem/SDL_filesystem.c
+++ b/src/filesystem/SDL_filesystem.c
@@ -189,11 +189,11 @@ static bool WildcardMatch(const char *pattern, const char *str, bool *matched_to
             pch = *pattern;
         }
 
-#if defined(SDL_PLATFORM_WINDOWS)
+        #ifdef SDL_PLATFORM_WINDOWS
         if (sch == '\\') {
             sch = '/';
         }
-#endif
+        #endif
     }
 
     // '*' at the end can be ignored, they are allowed to match nothing.

--- a/src/filesystem/SDL_filesystem.c
+++ b/src/filesystem/SDL_filesystem.c
@@ -188,6 +188,12 @@ static bool WildcardMatch(const char *pattern, const char *str, bool *matched_to
             sch = *str;
             pch = *pattern;
         }
+
+#if defined(SDL_PLATFORM_WINDOWS)
+        if (sch == '\\') {
+            sch = '/';
+        }
+#endif
     }
 
     // '*' at the end can be ignored, they are allowed to match nothing.


### PR DESCRIPTION
The underlying pattern matcher `WildcardMatch` does not handle Windows path separators, because of that `*` matches entire path all the way down the hierarchy.

For example, the following call will scan and match entire filesystem in Windows:
```c
SDL_GlobDirectory("C:\\", "*", 0, NULL);
```

The fix normalizes separator to `/` so that path and pattern look for the same thing.