### PR TITLE
Fixed vulkan gpu backend android orientation behaviour to just work l…

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -4634,7 +4634,7 @@ static Uint32 VULKAN_INTERNAL_CreateSwapchain(
     swapchainCreateInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
     swapchainCreateInfo.queueFamilyIndexCount = 0;
     swapchainCreateInfo.pQueueFamilyIndices = NULL;
-    swapchainCreateInfo.preTransform = swapchainSupportDetails.capabilities.currentTransform;
+    swapchainCreateInfo.preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
     swapchainCreateInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
     swapchainCreateInfo.presentMode = SDLToVK_PresentMode[windowData->presentMode];
     swapchainCreateInfo.clipped = VK_TRUE;


### PR DESCRIPTION
…ike on iOS.

I changed it so that the OS does the orientation change itself with a potential performance penalty. This makes it automatically do the right thing, just like on iOS which would make the orientation change behaviour more consistent across different platforms.

But without adding an option to the user, this would disallow the user solving the problem in his app/shaders and saving some performance.

It's up to you to decide what to do. But I changed this in my local copy of the source for my use case.
