### PR TITLE
cocoa: Don't overwrite the desktop mode when changing the fullscreen …

### DIFF
--- a/src/video/cocoa/SDL_cocoamodes.m
+++ b/src/video/cocoa/SDL_cocoamodes.m
@@ -433,7 +433,7 @@ static void Cocoa_DisplayReconfigurationCallback(CGDirectDisplayID displayid, CG
         }
     }
 
-    if (flags & kCGDisplaySetModeFlag) {
+    if ((flags & kCGDisplaySetModeFlag) && !_this->setting_display_mode) {
         if (display) {
             CGDisplayModeRef moderef = CGDisplayCopyDisplayMode(displayid);
             if (moderef) {


### PR DESCRIPTION
…mode

Changing the mode triggers a display reconfiguration event, which will overwrite the desktop mode with the set fullscreen mode, preventing proper restoration when leaving fullscreen. Don't overwrite the desktop mode if the reconfiguration is due to a fullscreen mode switch.