### PR TITLE
Fix for Message Box failing to init on X11

### DIFF
--- a/src/video/x11/SDL_x11messagebox.c
+++ b/src/video/x11/SDL_x11messagebox.c
@@ -48,15 +48,17 @@
 static const char g_MessageBoxFontLatin1[] =
     "-*-*-medium-r-normal--0-120-*-*-p-0-iso8859-1";
 
-static const char g_MessageBoxFont[] =
-    "-*-*-medium-r-normal--*-120-*-*-*-*-iso10646-1,"  // explicitly unicode (iso10646-1)
-    "-*-*-medium-r-*--*-120-*-*-*-*-iso10646-1,"  // explicitly unicode (iso10646-1)
-    "-misc-*-*-*-*--*-*-*-*-*-*-iso10646-1,"  // misc unicode (fix for some systems)
-    "-*-*-*-*-*--*-*-*-*-*-*-iso10646-1,"  // just give me anything Unicode.
-    "-*-*-medium-r-normal--*-120-*-*-*-*-iso8859-1,"  // explicitly latin1, in case low-ASCII works out.
-    "-*-*-medium-r-*--*-120-*-*-*-*-iso8859-1,"  // explicitly latin1, in case low-ASCII works out.
-    "-misc-*-*-*-*--*-*-*-*-*-*-iso8859-1,"  // misc latin1 (fix for some systems)
-    "-*-*-*-*-*--*-*-*-*-*-*-iso8859-1";  // just give me anything latin1.
+static const char* g_MessageBoxFont[] = {
+    "-*-*-medium-r-normal--*-120-*-*-*-*-iso10646-1",  // explicitly unicode (iso10646-1)
+    "-*-*-medium-r-*--*-120-*-*-*-*-iso10646-1",  // explicitly unicode (iso10646-1)
+    "-misc-*-*-*-*--*-*-*-*-*-*-iso10646-1",  // misc unicode (fix for some systems)
+    "-*-*-*-*-*--*-*-*-*-*-*-iso10646-1",  // just give me anything Unicode.
+    "-*-*-medium-r-normal--*-120-*-*-*-*-iso8859-1",  // explicitly latin1, in case low-ASCII works out.
+    "-*-*-medium-r-*--*-120-*-*-*-*-iso8859-1",  // explicitly latin1, in case low-ASCII works out.
+    "-misc-*-*-*-*--*-*-*-*-*-*-iso8859-1",  // misc latin1 (fix for some systems)
+    "-*-*-*-*-*--*-*-*-*-*-*-iso8859-1",  // just give me anything latin1.
+    NULL
+};
 
 static const SDL_MessageBoxColor g_default_colors[SDL_MESSAGEBOX_COLOR_COUNT] = {
     { 56, 54, 53 },    // SDL_MESSAGEBOX_COLOR_BACKGROUND,
@@ -202,13 +204,19 @@ static bool X11_MessageBoxInit(SDL_MessageBoxDataX11 *data, const SDL_MessageBox
     if (SDL_X11_HAVE_UTF8) {
         char **missing = NULL;
         int num_missing = 0;
-        data->font_set = X11_XCreateFontSet(data->display, g_MessageBoxFont,
-                                            &missing, &num_missing, NULL);
-        if (missing) {
-            X11_XFreeStringList(missing);
+        int i_font;
+        for (i = 0; g_MessageBoxFont[i]; ++i) {
+            data->font_set = X11_XCreateFontSet(data->display, g_MessageBoxFont[i],
+                                                &missing, &num_missing, NULL);
+            if (missing) {
+                X11_XFreeStringList(missing);
+            }
+            if (!data->font_set) {
+                break;
+            }
         }
         if (!data->font_set) {
-            return SDL_SetError("Couldn't load font %s", g_MessageBoxFont);
+            return SDL_SetError("Couldn't load x11 message box font");
         }
     } else
 #endif

--- a/src/video/x11/SDL_x11messagebox.c
+++ b/src/video/x11/SDL_x11messagebox.c
@@ -51,9 +51,11 @@ static const char g_MessageBoxFontLatin1[] =
 static const char g_MessageBoxFont[] =
     "-*-*-medium-r-normal--*-120-*-*-*-*-iso10646-1,"  // explicitly unicode (iso10646-1)
     "-*-*-medium-r-*--*-120-*-*-*-*-iso10646-1,"  // explicitly unicode (iso10646-1)
+    "-misc-*-*-*-*--*-*-*-*-*-*-iso10646-1,"  // misc unicode (fix for some systems)
     "-*-*-*-*-*--*-*-*-*-*-*-iso10646-1,"  // just give me anything Unicode.
     "-*-*-medium-r-normal--*-120-*-*-*-*-iso8859-1,"  // explicitly latin1, in case low-ASCII works out.
     "-*-*-medium-r-*--*-120-*-*-*-*-iso8859-1,"  // explicitly latin1, in case low-ASCII works out.
+    "-misc-*-*-*-*--*-*-*-*-*-*-iso8859-1,";  // misc latin1 (fix for some systems)
     "-*-*-*-*-*--*-*-*-*-*-*-iso8859-1";  // just give me anything latin1.
 
 static const SDL_MessageBoxColor g_default_colors[SDL_MESSAGEBOX_COLOR_COUNT] = {

--- a/src/video/x11/SDL_x11messagebox.c
+++ b/src/video/x11/SDL_x11messagebox.c
@@ -205,7 +205,7 @@ static bool X11_MessageBoxInit(SDL_MessageBoxDataX11 *data, const SDL_MessageBox
         char **missing = NULL;
         int num_missing = 0;
         int i_font;
-        for (i_font = 0; g_MessageBoxFont[i]; ++i_font) {
+        for (i_font = 0; g_MessageBoxFont[i_font]; ++i_font) {
             data->font_set = X11_XCreateFontSet(data->display, g_MessageBoxFont[i_font],
                                                 &missing, &num_missing, NULL);
             if (missing) {

--- a/src/video/x11/SDL_x11messagebox.c
+++ b/src/video/x11/SDL_x11messagebox.c
@@ -205,8 +205,8 @@ static bool X11_MessageBoxInit(SDL_MessageBoxDataX11 *data, const SDL_MessageBox
         char **missing = NULL;
         int num_missing = 0;
         int i_font;
-        for (i = 0; g_MessageBoxFont[i]; ++i) {
-            data->font_set = X11_XCreateFontSet(data->display, g_MessageBoxFont[i],
+        for (i_font = 0; g_MessageBoxFont[i]; ++i_font) {
+            data->font_set = X11_XCreateFontSet(data->display, g_MessageBoxFont[i_font],
                                                 &missing, &num_missing, NULL);
             if (missing) {
                 X11_XFreeStringList(missing);

--- a/src/video/x11/SDL_x11messagebox.c
+++ b/src/video/x11/SDL_x11messagebox.c
@@ -211,7 +211,7 @@ static bool X11_MessageBoxInit(SDL_MessageBoxDataX11 *data, const SDL_MessageBox
             if (missing) {
                 X11_XFreeStringList(missing);
             }
-            if (!data->font_set) {
+            if (data->font_set) {
                 break;
             }
         }

--- a/src/video/x11/SDL_x11messagebox.c
+++ b/src/video/x11/SDL_x11messagebox.c
@@ -55,7 +55,7 @@ static const char g_MessageBoxFont[] =
     "-*-*-*-*-*--*-*-*-*-*-*-iso10646-1,"  // just give me anything Unicode.
     "-*-*-medium-r-normal--*-120-*-*-*-*-iso8859-1,"  // explicitly latin1, in case low-ASCII works out.
     "-*-*-medium-r-*--*-120-*-*-*-*-iso8859-1,"  // explicitly latin1, in case low-ASCII works out.
-    "-misc-*-*-*-*--*-*-*-*-*-*-iso8859-1,";  // misc latin1 (fix for some systems)
+    "-misc-*-*-*-*--*-*-*-*-*-*-iso8859-1,"  // misc latin1 (fix for some systems)
     "-*-*-*-*-*--*-*-*-*-*-*-iso8859-1";  // just give me anything latin1.
 
 static const SDL_MessageBoxColor g_default_colors[SDL_MESSAGEBOX_COLOR_COUNT] = {


### PR DESCRIPTION
I noticed that using SDL_ShowSimpleMessageBox doesn't work on my system, by using valgrind to track the issue, I noticed that XCreateFontSet fails and noticed that
1. All of font descriptions included in SDL3's g_MessageBoxFont don't work on my system
2. Using comma separated list of font descriptions may still fail even if valid font description is present in the list

## Description
I fixed the first problem by adding "misc" to the font description list for both Unicode and Latin1.
I fixed the second problem by iterating over all font descriptions, instead of using comma separated list, which can fail.

I managed to fix the issue and message boxes now appear on my screen! (Screenshot included):
![message_box](https://github.com/user-attachments/assets/93420d91-1e81-4b7e-bd85-1488d97defd5)
