### PR TITLE
cocoa: Ignore both clicks and motion on tooltip windows

### DIFF
--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -2211,6 +2211,7 @@ static bool SetupWindowData(SDL_VideoDevice *_this, SDL_Window *window, NSWindow
         } else {
             if (window->flags & SDL_WINDOW_TOOLTIP) {
                 [nswindow setIgnoresMouseEvents:YES];
+                [nswindow setAcceptsMouseMovedEvents:NO];
             } else if (window->flags & SDL_WINDOW_POPUP_MENU) {
                 Cocoa_SetKeyboardFocus(window, window->parent == SDL_GetKeyboardFocus());
             }


### PR DESCRIPTION
Fixes #12488 