### PR TITLE
Fix n3ds/SDL_syssem.c:SDL_SignalSemaphore (libsdl-org/SDL#12411)

### DIFF
--- a/src/thread/n3ds/SDL_syssem.c
+++ b/src/thread/n3ds/SDL_syssem.c
@@ -102,7 +102,7 @@ Uint32 SDL_GetSemaphoreValue(SDL_Semaphore *sem)
 
 void SDL_SignalSemaphore(SDL_Semaphore *sem)
 {
-    if (sem) {
+    if (!sem) {
         return;
     }
 


### PR DESCRIPTION
`if (sem) return;` -> `if (!sem) return;`