### PR TITLE
mouse: Add internal integer mouse mode hint for sdl2-compat

### DIFF
--- a/src/events/SDL_mouse_c.h
+++ b/src/events/SDL_mouse_c.h
@@ -102,8 +102,13 @@ typedef struct
     float x_accu;
     float y_accu;
     float last_x, last_y; // the last reported x and y coordinates
+    float xrel_frac;
+    float yrel_frac;
+    float wheel_x_frac;
+    float wheel_y_frac;
     double click_motion_x;
     double click_motion_y;
+    bool integer_mode;
     bool has_position;
     bool relative_mode;
     bool relative_mode_warp_motion;


### PR DESCRIPTION
## Description
This adds an internal hint to be used by sdl2-compat to provide integer values in mouse events, `SDL_GetMouseState()`, `SDL_GetRelativeMouseState()`, etc. I'm assuming we don't want to expose this to regular SDL3 users, though I can move it to `SDL_hints.h` if we do want that.

This avoids a number of pitfalls with the current approach in https://github.com/libsdl-org/sdl2-compat/pull/378 like:
- Sending "duplicate" events when not enough fractional motion has accumulated to reach the next integer value
- Inconsistency between x/y and xrel/yrel values received by SDL2 apps due to the hidden fractional component (see https://github.com/libsdl-org/sdl2-compat/issues/372#issuecomment-2691888221)
- Changing global accumulator state in a function that may be called to process the same event multiple times (resulting in different values in the SDL2 event each time)

## Existing Issue(s)
https://github.com/libsdl-org/sdl2-compat/issues/372