### PR TITLE
Fix libusb handling on FreeBSD

### DIFF
--- a/cmake/FindLibUSB.cmake
+++ b/cmake/FindLibUSB.cmake
@@ -10,7 +10,7 @@ if(PKG_CONFIG_FOUND)
 endif()
 
 find_library(LibUSB_LIBRARY
-  NAMES usb-1.0 libusb-1.0
+  NAMES usb-1.0 libusb-1.0 usb
   HINTS ${PC_LibUSB_LIBRARY_DIRS}
 )
 

--- a/src/hidapi/SDL_hidapi.c
+++ b/src/hidapi/SDL_hidapi.c
@@ -710,7 +710,11 @@ static struct
     );
     void (LIBUSB_CALL *free_config_descriptor)(struct libusb_config_descriptor *config);
     uint8_t (LIBUSB_CALL *get_bus_number)(libusb_device *dev);
+#ifdef SDL_PLATFORM_FREEBSD
+    int (LIBUSB_CALL *get_port_numbers)(libusb_device *dev, uint8_t *port_numbers, uint8_t port_numbers_len);
+#else
     int (LIBUSB_CALL *get_port_numbers)(libusb_device *dev, uint8_t *port_numbers, int port_numbers_len);
+#endif
     uint8_t (LIBUSB_CALL *get_device_address)(libusb_device *dev);
     int (LIBUSB_CALL *open)(libusb_device *dev, libusb_device_handle **dev_handle);
     void (LIBUSB_CALL *close)(libusb_device_handle *dev_handle);
@@ -1188,7 +1192,11 @@ int SDL_hid_init(void)
             LOAD_LIBUSB_SYMBOL(int (LIBUSB_CALL *)(libusb_device *, uint8_t, struct libusb_config_descriptor **), get_config_descriptor)
             LOAD_LIBUSB_SYMBOL(void (LIBUSB_CALL *)(struct libusb_config_descriptor *), free_config_descriptor)
             LOAD_LIBUSB_SYMBOL(uint8_t (LIBUSB_CALL *)(libusb_device *), get_bus_number)
+#ifdef SDL_PLATFORM_FREEBSD
+            LOAD_LIBUSB_SYMBOL(int (LIBUSB_CALL *)(libusb_device *dev, uint8_t *port_numbers, uint8_t port_numbers_len), get_port_numbers)
+#else
             LOAD_LIBUSB_SYMBOL(int (LIBUSB_CALL *)(libusb_device *dev, uint8_t *port_numbers, int port_numbers_len), get_port_numbers)
+#endif
             LOAD_LIBUSB_SYMBOL(uint8_t (LIBUSB_CALL *)(libusb_device *), get_device_address)
             LOAD_LIBUSB_SYMBOL(int (LIBUSB_CALL *)(libusb_device *, libusb_device_handle **), open)
             LOAD_LIBUSB_SYMBOL(void (LIBUSB_CALL *)(libusb_device_handle *), close)


### PR DESCRIPTION
- The library is named libusb.so, not libusb-1.0.so
- Type of third argument to get_port_numbers differs (int vs uint8_t)

Note that this currently fails CI on FreeBSD because it cannot find symbols from libusb. I have no idea on how to fix that, however FreeBSD port of SDL3 is not affected as it's built with `SDL_DEPS_SHARED` which avoids this and many others issues caused by runtime dependency linking.