### PR TITLE
avoid UB (left shift of negative number) in SDL_windowsevents.c

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1640,7 +1640,7 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
             POINT cursorPos;
             GetCursorPos(&cursorPos);
             ScreenToClient(hwnd, &cursorPos);
-            PostMessage(hwnd, WM_MOUSEMOVE, 0, cursorPos.x | cursorPos.y << 16);
+            PostMessage(hwnd, WM_MOUSEMOVE, 0, cursorPos.x | (((unsigned int)((short)cursorPos.y)) << 16));
         }
     } break;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes undefined behavior introduced in https://github.com/libsdl-org/SDL/commit/69d28027adb70daf962621bb5e8ab00a069cbe30, reported downstream in https://github.com/david-vanderson/dvui/issues/198 :
If `cursorPos.y` is negative (which it is when clicking on a window's title bar), the left shift is undefined behavior.
(for reference: https://learn.microsoft.com/en-us/cpp/code-quality/c26453?view=msvc-170).
This was caught downstream by a panic when using LLVM's ubsan (undefined behavior sanitizer).

The code formulation in this PR first asserts that the value is in bounds for `short` (16-bit),
then converts & promotes the value to `unsigned int` (32-bit) to ensure the shift is legal.

The alternative would be to simply `& 0xFFFF` the operand.
This would hide any out-of-bounds values for (`< SHRT_MIN` or `> SHRT_MAX`), which I didn't like as much.

From my testing, this fixes the reported crash (detected UB) when clicking on a window's title bar.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
No issue in this repository. (downstream report in https://github.com/david-vanderson/dvui/issues/198 )