### PR TITLE
emscripten: move hints to window properties

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -707,6 +707,38 @@ extern "C" {
 #define SDL_HINT_EMSCRIPTEN_ASYNCIFY "SDL_EMSCRIPTEN_ASYNCIFY"
 
 /**
+ * Specify the CSS selector used for the "default" window/canvas.
+ *
+ * This hint only applies to the emscripten platform.
+ *
+ * This hint should be set before creating a window.
+ *
+ * \since This hint is available since SDL 3.2.0.
+ */
+#define SDL_HINT_EMSCRIPTEN_CANVAS_SELECTOR "SDL_EMSCRIPTEN_CANVAS_SELECTOR"
+
+/**
+ * Override the binding element for keyboard inputs for Emscripten builds.
+ *
+ * This hint only applies to the emscripten platform.
+ *
+ * The variable can be one of:
+ *
+ * - "#window": the javascript window object
+ * - "#document": the javascript document object
+ * - "#screen": the javascript window.screen object
+ * - "#canvas": the WebGL canvas element
+ * - "#none": Don't bind anything at all
+ * - any other string without a leading # sign applies to the element on the
+ *   page with that ID.
+ *
+ * This hint should be set before creating a window.
+ *
+ * \since This hint is available since SDL 3.2.0.
+ */
+#define SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT "SDL_EMSCRIPTEN_KEYBOARD_ELEMENT"
+
+/**
  * A variable that controls whether the on-screen keyboard should be shown
  * when text input is active.
  *

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -707,40 +707,6 @@ extern "C" {
 #define SDL_HINT_EMSCRIPTEN_ASYNCIFY "SDL_EMSCRIPTEN_ASYNCIFY"
 
 /**
- * Specify the CSS selector used for the "default" window/canvas.
- *
- * This hint only applies to the emscripten platform.
- *
- * The default value is "#canvas"
- *
- * This hint should be set before creating a window.
- *
- * \since This hint is available since SDL 3.2.0.
- */
-#define SDL_HINT_EMSCRIPTEN_CANVAS_SELECTOR "SDL_EMSCRIPTEN_CANVAS_SELECTOR"
-
-/**
- * Override the binding element for keyboard inputs for Emscripten builds.
- *
- * This hint only applies to the emscripten platform.
- *
- * The variable can be one of:
- *
- * - "#window": the javascript window object (default)
- * - "#document": the javascript document object
- * - "#screen": the javascript window.screen object
- * - "#canvas": the WebGL canvas element
- * - "#none": Don't bind anything at all
- * - any other string without a leading # sign applies to the element on the
- *   page with that ID.
- *
- * This hint should be set before creating a window.
- *
- * \since This hint is available since SDL 3.2.0.
- */
-#define SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT "SDL_EMSCRIPTEN_KEYBOARD_ELEMENT"
-
-/**
  * A variable that controls whether the on-screen keyboard should be shown
  * when text input is active.
  *

--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -1354,8 +1354,8 @@ extern SDL_DECLSPEC SDL_Window * SDLCALL SDL_CreateWindowWithProperties(SDL_Prop
 #define SDL_PROP_WINDOW_CREATE_WIN32_HWND_POINTER                  "SDL.window.create.win32.hwnd"
 #define SDL_PROP_WINDOW_CREATE_WIN32_PIXEL_FORMAT_HWND_POINTER     "SDL.window.create.win32.pixel_format_hwnd"
 #define SDL_PROP_WINDOW_CREATE_X11_WINDOW_NUMBER                   "SDL.window.create.x11.window"
-#define SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID                "SDL.window.create.x11.canvas_id"
-#define SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_KEYBOARD_ELEMENT         "SDL.window.create.x11.keyboard_element"
+#define SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID                "SDL.window.create.emscripten.canvas_id"
+#define SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_KEYBOARD_ELEMENT         "SDL.window.create.emscripten.keyboard_element"
 
 /**
  * Get the numeric ID of a window.

--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -1280,6 +1280,19 @@ extern SDL_DECLSPEC SDL_Window * SDLCALL SDL_CreatePopupWindow(SDL_Window *paren
  *
  * The window is implicitly shown if the "hidden" property is not set.
  *
+ * These are additional supported properties with Emscripten:
+ *
+ * - `SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID`: the id given to the canvas element.
+ *    This should start with a '#' sign
+ * - `SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_KEYBOARD_ELEMENT`: override the binding element
+ *   for keyboard inputs for this canvas. The variable can be one of:
+ * - "#window": the javascript window object (default)
+ * - "#document": the javascript document object
+ * - "#screen": the javascript window.screen object
+ * - "#canvas": the WebGL canvas element
+ * - "#none": Don't bind anything at all
+ * - any other string without a leading # sign applies to the element on the
+ *   page with that ID.
  * Windows with the "tooltip" and "menu" properties are popup windows and have
  * the behaviors and guidelines outlined in SDL_CreatePopupWindow().
  *
@@ -1341,6 +1354,8 @@ extern SDL_DECLSPEC SDL_Window * SDLCALL SDL_CreateWindowWithProperties(SDL_Prop
 #define SDL_PROP_WINDOW_CREATE_WIN32_HWND_POINTER                  "SDL.window.create.win32.hwnd"
 #define SDL_PROP_WINDOW_CREATE_WIN32_PIXEL_FORMAT_HWND_POINTER     "SDL.window.create.win32.pixel_format_hwnd"
 #define SDL_PROP_WINDOW_CREATE_X11_WINDOW_NUMBER                   "SDL.window.create.x11.window"
+#define SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID                "SDL.window.create.x11.canvas_id"
+#define SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_KEYBOARD_ELEMENT         "SDL.window.create.x11.keyboard_element"
 
 /**
  * Get the numeric ID of a window.

--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -1011,7 +1011,7 @@ static bool Emscripten_ShouldSetKeyboardElement(SDL_WindowData* data)
         return SDL_strcmp(data->keyboard_element, "#none") != 0;
     }
     else {
-        return data->keyboard_element != EMSCRIPTEN_EVENT_TARGET_INVALID;
+        return data->keyboard_target != EMSCRIPTEN_EVENT_TARGET_INVALID;
     }
 }
 

--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -1009,8 +1009,7 @@ static bool Emscripten_ShouldSetKeyboardElement(SDL_WindowData* data)
 {
     if (data->keyboard_element_is_string) {
         return SDL_strcmp(data->keyboard_element, "#none") != 0;
-    }
-    else {
+    } else {
         return data->keyboard_target != EMSCRIPTEN_EVENT_TARGET_INVALID;
     }
 }

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -317,7 +317,7 @@ static bool Emscripten_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, 
     // #define EMSCRIPTEN_EVENT_TARGET_DOCUMENT       ((const char*)1)
     // #define EMSCRIPTEN_EVENT_TARGET_WINDOW         ((const char*)2)
     // #define EMSCRIPTEN_EVENT_TARGET_SCREEN         ((const char*)3)
-    if(Emscripten_IsEventTarget(selector)) {
+    if (Emscripten_IsEventTarget(selector)) {
         wdata->keyboard_target = selector;
         wdata->keyboard_element_is_string = false;
     } else {

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -322,7 +322,7 @@ static bool Emscripten_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, 
     wdata->canvas_id = SDL_strdup(selector);
 
     selector = SDL_GetHint(SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT);
-    if(!selector) {
+    if (!selector || !*selector) {
         selector = SDL_GetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_KEYBOARD_ELEMENT, EMSCRIPTEN_EVENT_TARGET_WINDOW);
     }
     selector = Emscripten_GetKeyboardTargetElementAsString(selector);

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -423,7 +423,7 @@ static void Emscripten_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
         emscripten_set_canvas_element_size(data->canvas_id, 0, 0);
         SDL_free(data->canvas_id);
 
-        if(data->keyboard_element_is_string) {
+        if (data->keyboard_element_is_string) {
             SDL_free(data->keyboard_element);
         }
 

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -300,10 +300,16 @@ static bool Emscripten_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, 
         return false;
     }
 
-    selector = SDL_GetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID, "#canvas");
+    selector = SDL_GetHint(SDL_HINT_EMSCRIPTEN_CANVAS_SELECTOR);
+    if(!selector) {
+        selector = SDL_GetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID, "#canvas");
+    }
     wdata->canvas_id = SDL_strdup(selector);
 
-    selector = SDL_GetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_KEYBOARD_ELEMENT, EMSCRIPTEN_EVENT_TARGET_WINDOW);
+    selector = SDL_GetHint(SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT);
+    if(!selector) {
+        selector = SDL_GetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_KEYBOARD_ELEMENT, EMSCRIPTEN_EVENT_TARGET_WINDOW);
+    }
 
     // Emscripten's event targets are not defined as actual strings
     // For Clarification:

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -301,7 +301,7 @@ static bool Emscripten_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, 
     }
 
     selector = SDL_GetHint(SDL_HINT_EMSCRIPTEN_CANVAS_SELECTOR);
-    if(!selector) {
+    if (!selector || !*selector) {
         selector = SDL_GetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID, "#canvas");
     }
     wdata->canvas_id = SDL_strdup(selector);

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -320,8 +320,7 @@ static bool Emscripten_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, 
     if(Emscripten_IsEventTarget(selector)) {
         wdata->keyboard_target = selector;
         wdata->keyboard_element_is_string = false;
-    }
-    else {
+    } else {
         wdata->keyboard_element = SDL_strdup(selector);
         wdata->keyboard_element_is_string = true;
     }
@@ -423,6 +422,10 @@ static void Emscripten_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
         // We can't destroy the canvas, so resize it to zero instead
         emscripten_set_canvas_element_size(data->canvas_id, 0, 0);
         SDL_free(data->canvas_id);
+
+        if(data->keyboard_element_is_string) {
+            SDL_free(data->keyboard_element);
+        }
 
         SDL_free(window->internal);
         window->internal = NULL;

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -279,29 +279,6 @@ EMSCRIPTEN_KEEPALIVE void requestFullscreenThroughSDL(SDL_Window *window)
     SDL_SetWindowFullscreen(window, true);
 }
 
-static const char* Emscripten_GetKeyboardTargetElementAsString(const char* target)
-{
-    // Emscripten's event targets are not defined as actual strings
-    // For Clarification:
-    // #define EMSCRIPTEN_EVENT_TARGET_INVALID        0
-    // #define EMSCRIPTEN_EVENT_TARGET_DOCUMENT       ((const char*)1)
-    // #define EMSCRIPTEN_EVENT_TARGET_WINDOW         ((const char*)2)
-    // #define EMSCRIPTEN_EVENT_TARGET_SCREEN         ((const char*)3)
-    if (target == EMSCRIPTEN_EVENT_TARGET_INVALID) {
-        return "#none";
-    }
-    if (target == EMSCRIPTEN_EVENT_TARGET_DOCUMENT) {
-        return "#document";
-    }
-    if (target == EMSCRIPTEN_EVENT_TARGET_WINDOW) {
-        return "#window";
-    }
-    if (target == EMSCRIPTEN_EVENT_TARGET_SCREEN) {
-        return "#screen";
-    }
-    return target;
-}
-
 static bool Emscripten_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesID props)
 {
     SDL_WindowData *wdata;
@@ -323,9 +300,8 @@ static bool Emscripten_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, 
 
     selector = SDL_GetHint(SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT);
     if (!selector || !*selector) {
-        selector = SDL_GetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_KEYBOARD_ELEMENT, EMSCRIPTEN_EVENT_TARGET_WINDOW);
+        selector = SDL_GetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_KEYBOARD_ELEMENT, "#window");
     }
-    selector = Emscripten_GetKeyboardTargetElementAsString(selector);
     wdata->keyboard_element = SDL_strdup(selector);
 
     if (window->flags & SDL_WINDOW_HIGH_PIXEL_DENSITY) {

--- a/src/video/emscripten/SDL_emscriptenvideo.h
+++ b/src/video/emscripten/SDL_emscriptenvideo.h
@@ -36,11 +36,7 @@ struct SDL_WindowData
     SDL_GLContext gl_context;
 
     char *canvas_id;
-    union {
-      char *keyboard_element;
-      const char *keyboard_target;
-    };
-    bool keyboard_element_is_string;
+    char *keyboard_element;
 
     float pixel_ratio;
 

--- a/src/video/emscripten/SDL_emscriptenvideo.h
+++ b/src/video/emscripten/SDL_emscriptenvideo.h
@@ -36,6 +36,11 @@ struct SDL_WindowData
     SDL_GLContext gl_context;
 
     char *canvas_id;
+    union {
+      char* keyboard_element;
+      const char* keyboard_target;
+    };
+    bool keyboard_element_is_string;
 
     float pixel_ratio;
 

--- a/src/video/emscripten/SDL_emscriptenvideo.h
+++ b/src/video/emscripten/SDL_emscriptenvideo.h
@@ -38,7 +38,7 @@ struct SDL_WindowData
     char *canvas_id;
     union {
       char *keyboard_element;
-      const char* keyboard_target;
+      const char *keyboard_target;
     };
     bool keyboard_element_is_string;
 

--- a/src/video/emscripten/SDL_emscriptenvideo.h
+++ b/src/video/emscripten/SDL_emscriptenvideo.h
@@ -37,7 +37,7 @@ struct SDL_WindowData
 
     char *canvas_id;
     union {
-      char* keyboard_element;
+      char *keyboard_element;
       const char* keyboard_target;
     };
     bool keyboard_element_is_string;


### PR DESCRIPTION
Move hints used by Emscripten to window properties. This change will be necessary if multiple windows for Emscripten will be supported in the future.

- ~~Removed hint `SDL_HINT_EMSCRIPTEN_CANVAS_SELECTOR`~~
- ~~Removed hint `SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT`~~
- Added Window Create Property `SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID`
- Added Window Create Property `SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_KEYBOARD_ELEMENT`
-  Use hint `SDL_HINT_EMSCRIPTEN_CANVAS_SELECTOR` as override to `SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID`
- Use hint `SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT` as override to `SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_KEYBOARD_ELEMENT`