### PR TITLE
Fixed sscanf("#026", "#%1x%1x%1x", &r, &g, &b)

### DIFF
--- a/src/stdlib/SDL_string.c
+++ b/src/stdlib/SDL_string.c
@@ -368,14 +368,12 @@ static size_t SDL_ScanUnsignedLongLongInternal(const char *text, int count, int 
             negative = *text == '-';
             ++text;
         }
-        if ((radix == 0 || radix == 16) && *text == '0' && text[1] != '\0') {
+        if ((radix == 0 || radix == 16) && *text == '0' && (text[1] == 'x' || text[1] == 'X')) {
+            text += 2;
+            radix = 16;
+        } else if (radix == 0 && *text == '0' && (text[1] >= '0' && text[1] <= '9')) {
             ++text;
-            if (*text == 'x' || *text == 'X') {
-                radix = 16;
-                ++text;
-            } else if (radix == 0) {
-                radix = 8;
-            }
+            radix = 8;
         } else if (radix == 0) {
             radix = 10;
         }
@@ -462,14 +460,12 @@ static size_t SDL_ScanUnsignedLongLongInternalW(const wchar_t *text, int count, 
             negative = *text == '-';
             ++text;
         }
-        if ((radix == 0 || radix == 16) && *text == '0') {
+        if ((radix == 0 || radix == 16) && *text == '0' && (text[1] == 'x' || text[1] == 'X')) {
+            text += 2;
+            radix = 16;
+        } else if (radix == 0 && *text == '0' && (text[1] >= '0' && text[1] <= '9')) {
             ++text;
-            if (*text == 'x' || *text == 'X') {
-                radix = 16;
-                ++text;
-            } else if (radix == 0) {
-                radix = 8;
-            }
+            radix = 8;
         } else if (radix == 0) {
             radix = 10;
         }

--- a/test/testautomation_stdlib.c
+++ b/test/testautomation_stdlib.c
@@ -750,6 +750,7 @@ static int SDLCALL stdlib_sscanf(void *arg)
     size_t size_output, expected_size_output;
     void *ptr_output, *expected_ptr_output;
     char text[128], text2[128];
+    unsigned int r = 0, g = 0, b = 0;
 
     expected_output = output = 123;
     expected_result = -1;
@@ -784,6 +785,17 @@ static int SDLCALL stdlib_sscanf(void *arg)
     SDLTest_AssertCheck(expected_output == output, "Check output, expected: %i, got: %i", expected_output, output);
     SDLTest_AssertCheck(expected_result == result, "Check return value, expected: %i, got: %i", expected_result, result);
     SDLTest_AssertCheck(length == 1, "Check length, expected: 1, got: %i", length);
+
+    expected_result = 3;
+    result = SDL_sscanf("#026", "#%1x%1x%1x", &r, &g, &b);
+    SDLTest_AssertPass("Call to SDL_sscanf(\"#026\", \"#%%1x%%1x%%1x\", &r, &g, &b)");
+    expected_output = 0;
+    SDLTest_AssertCheck(r == expected_output, "Check output for r, expected: %i, got: %i", expected_output, r);
+    expected_output = 2;
+    SDLTest_AssertCheck(g == expected_output, "Check output for g, expected: %i, got: %i", expected_output, g);
+    expected_output = 6;
+    SDLTest_AssertCheck(b == expected_output, "Check output for b, expected: %i, got: %i", expected_output, b);
+    SDLTest_AssertCheck(expected_result == result, "Check return value, expected: %i, got: %i", expected_result, result);
 
 #define SIZED_TEST_CASE(type, var, printf_specifier, scanf_specifier)                                                                                                            \
     var##_output = 123;                                                                                                                                                          \


### PR DESCRIPTION
Fixes https://github.com/libsdl-org/SDL/issues/12510
