### PR TITLE
docs: Fix link in CMake readme

### DIFF
--- a/docs/README-cmake.md
+++ b/docs/README-cmake.md
@@ -328,7 +328,7 @@ Configure your project with `-DSDL_LIBC=ON` to make use of sanitizers.
 ### CMake fails to build without X11 or Wayland support
 
 Install the required system packages prior to running CMake.
-See [README-linux](linux#build-dependencies) for the list of dependencies on Linux.
+See [README-linux](README-linux.md) for the list of dependencies on Linux.
 Other unix operationg systems should provide similar packages.
 
 If you **really** don't need to show windows, add `-DSDL_UNIX_CONSOLE_BUILD=ON` to the CMake configure command.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes deadlink to linux readme in cmake build docs
