### PR TITLE
Fix trailing doc comments

### DIFF
--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -2726,13 +2726,13 @@ typedef struct SDL_GPURenderStateDesc
     SDL_GPUShader *fragment_shader; /**< The fragment shader to use when this render state is active */
 
     Sint32 num_sampler_bindings;    /**< The number of additional fragment samplers to bind when this render state is active */
-    const SDL_GPUTextureSamplerBinding *sampler_bindings;   /** Additional fragment samplers to bind when this render state is active */
+    const SDL_GPUTextureSamplerBinding *sampler_bindings;   /**< Additional fragment samplers to bind when this render state is active */
 
     Sint32 num_storage_textures;    /**< The number of storage textures to bind when this render state is active */
-    SDL_GPUTexture *const *storage_textures;    /** Storage textures to bind when this render state is active */
+    SDL_GPUTexture *const *storage_textures;    /**< Storage textures to bind when this render state is active */
 
     Sint32 num_storage_buffers;    /**< The number of storage buffers to bind when this render state is active */
-    SDL_GPUBuffer *const *storage_buffers;      /** Storage buffers to bind when this render state is active */
+    SDL_GPUBuffer *const *storage_buffers;      /**< Storage buffers to bind when this render state is active */
 } SDL_GPURenderStateDesc;
 
 /* Check the size of SDL_GPURenderStateDesc


### PR DESCRIPTION
Some trailing doc comments in SDL_render.h was missing the `<`