### PR TITLE
Add SDL_Joystick support to Snake demo example

### DIFF
--- a/examples/demo/01-snake/snake.c
+++ b/examples/demo/01-snake/snake.c
@@ -21,6 +21,9 @@
 #define THREE_BITS  0x7U /* ~CHAR_MAX >> (CHAR_BIT - SNAKE_CELL_MAX_BITS) */
 #define SHIFT(x, y) (((x) + ((y) * SNAKE_GAME_WIDTH)) * SNAKE_CELL_MAX_BITS)
 
+static SDL_Joystick *joystick = NULL;
+
+
 typedef enum
 {
     SNAKE_CELL_NOTHING = 0U,
@@ -238,6 +241,26 @@ static SDL_AppResult handle_key_event_(SnakeContext *ctx, SDL_Scancode key_code)
     return SDL_APP_CONTINUE;
 }
 
+static SDL_AppResult handle_hat_event_(SnakeContext *ctx, Uint8 hat) {
+		switch (hat) {
+		case SDL_HAT_RIGHT:
+			snake_redir(ctx, SNAKE_DIR_RIGHT);
+			break;
+		case SDL_HAT_UP:
+			snake_redir(ctx, SNAKE_DIR_UP);
+			break;
+		case SDL_HAT_LEFT:
+			snake_redir(ctx, SNAKE_DIR_LEFT);
+			break;
+		case SDL_HAT_DOWN:
+			snake_redir(ctx, SNAKE_DIR_DOWN);
+			break;
+		default:
+				break;
+		}
+		return SDL_APP_CONTINUE;
+}
+
 SDL_AppResult SDL_AppIterate(void *appstate)
 {
     AppState *as = (AppState *)appstate;
@@ -305,7 +328,8 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
         }
     }
 
-    if (!SDL_Init(SDL_INIT_VIDEO)) {
+    if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK)) {
+				SDL_Log("Couldn't initialize SDL: %s", SDL_GetError());
         return SDL_APP_FAILURE;
     }
 
@@ -316,7 +340,7 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
 
     *appstate = as;
 
-    if (!SDL_CreateWindowAndRenderer("examples/demo/snake", SDL_WINDOW_WIDTH, SDL_WINDOW_HEIGHT, 0, &as->window, &as->renderer)) {
+    if (!SDL_CreateWindowAndRenderer("examples/snake", SDL_WINDOW_WIDTH, SDL_WINDOW_HEIGHT, 0, &as->window, &as->renderer)) {
         return SDL_APP_FAILURE;
     }
 
@@ -333,6 +357,20 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
     switch (event->type) {
     case SDL_EVENT_QUIT:
         return SDL_APP_SUCCESS;
+		case SDL_EVENT_JOYSTICK_ADDED:
+				if (joystick == NULL) {
+					joystick = SDL_OpenJoystick(event->jdevice.which);
+					if (!joystick) {
+						SDL_Log("Failed to open joystick ID %u: %s", (unsigned int) event->jdevice.which, SDL_GetError());
+					}
+				}
+		case SDL_EVENT_JOYSTICK_REMOVED:
+				if (joystick && (SDL_GetJoystickID(joystick) == event->jdevice.which)) {
+					SDL_CloseJoystick(joystick);
+					joystick = NULL;
+				}
+		case SDL_EVENT_JOYSTICK_HAT_MOTION:
+				return handle_hat_event_(ctx, event->jhat.value);
     case SDL_EVENT_KEY_DOWN:
         return handle_key_event_(ctx, event->key.scancode);
     }
@@ -341,6 +379,9 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
 
 void SDL_AppQuit(void *appstate, SDL_AppResult result)
 {
+		if (joystick) {
+			SDL_CloseJoystick(joystick);
+		}
     if (appstate != NULL) {
         AppState *as = (AppState *)appstate;
         SDL_DestroyRenderer(as->renderer);

--- a/examples/demo/01-snake/snake.c
+++ b/examples/demo/01-snake/snake.c
@@ -188,6 +188,8 @@ void snake_step(SnakeContext *ctx)
     case SNAKE_DIR_DOWN:
         ++ctx->head_ypos;
         break;
+    default:
+        break;
     }
     wrap_around_(&ctx->head_xpos, SNAKE_GAME_WIDTH);
     wrap_around_(&ctx->head_ypos, SNAKE_GAME_HEIGHT);
@@ -217,6 +219,7 @@ static SDL_AppResult handle_key_event_(SnakeContext *ctx, SDL_Scancode key_code)
     case SDL_SCANCODE_ESCAPE:
     case SDL_SCANCODE_Q:
         return SDL_APP_SUCCESS;
+        break;
     /* Restart the game as if the program was launched. */
     case SDL_SCANCODE_R:
         snake_initialize(ctx);
@@ -356,6 +359,7 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
     switch (event->type) {
     case SDL_EVENT_QUIT:
         return SDL_APP_SUCCESS;
+        break;
     case SDL_EVENT_JOYSTICK_ADDED:
         if (joystick == NULL) {
             joystick = SDL_OpenJoystick(event->jdevice.which);
@@ -363,16 +367,22 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
                 SDL_Log("Failed to open joystick ID %u: %s", (unsigned int) event->jdevice.which, SDL_GetError());
             }
         }
+        break;
     case SDL_EVENT_JOYSTICK_REMOVED:
         if (joystick && (SDL_GetJoystickID(joystick) == event->jdevice.which)) {
             SDL_CloseJoystick(joystick);
             joystick = NULL;
         }
+        break;
     case SDL_EVENT_JOYSTICK_HAT_MOTION:
         return handle_hat_event_(ctx, event->jhat.value);
+        break;
     case SDL_EVENT_KEY_DOWN:
         return handle_key_event_(ctx, event->key.scancode);
+        break;
     }
+    default:
+        break;
     return SDL_APP_CONTINUE;
 }
 

--- a/examples/demo/01-snake/snake.c
+++ b/examples/demo/01-snake/snake.c
@@ -23,7 +23,6 @@
 
 static SDL_Joystick *joystick = NULL;
 
-
 typedef enum
 {
     SNAKE_CELL_NOTHING = 0U,
@@ -242,23 +241,23 @@ static SDL_AppResult handle_key_event_(SnakeContext *ctx, SDL_Scancode key_code)
 }
 
 static SDL_AppResult handle_hat_event_(SnakeContext *ctx, Uint8 hat) {
-        switch (hat) {
-        case SDL_HAT_RIGHT:
-            snake_redir(ctx, SNAKE_DIR_RIGHT);
-            break;
-        case SDL_HAT_UP:
-            snake_redir(ctx, SNAKE_DIR_UP);
-            break;
-        case SDL_HAT_LEFT:
-            snake_redir(ctx, SNAKE_DIR_LEFT);
-            break;
-        case SDL_HAT_DOWN:
-            snake_redir(ctx, SNAKE_DIR_DOWN);
-            break;
-        default:
-                break;
-        }
-        return SDL_APP_CONTINUE;
+    switch (hat) {
+    case SDL_HAT_RIGHT:
+        snake_redir(ctx, SNAKE_DIR_RIGHT);
+        break;
+    case SDL_HAT_UP:
+        snake_redir(ctx, SNAKE_DIR_UP);
+        break;
+    case SDL_HAT_LEFT:
+        snake_redir(ctx, SNAKE_DIR_LEFT);
+        break;
+    case SDL_HAT_DOWN:
+        snake_redir(ctx, SNAKE_DIR_DOWN);
+        break;
+    default:
+        break;
+    }
+    return SDL_APP_CONTINUE;
 }
 
 SDL_AppResult SDL_AppIterate(void *appstate)
@@ -329,7 +328,7 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
     }
 
     if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK)) {
-                SDL_Log("Couldn't initialize SDL: %s", SDL_GetError());
+        SDL_Log("Couldn't initialize SDL: %s", SDL_GetError());
         return SDL_APP_FAILURE;
     }
 
@@ -340,7 +339,7 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
 
     *appstate = as;
 
-    if (!SDL_CreateWindowAndRenderer("examples/snake", SDL_WINDOW_WIDTH, SDL_WINDOW_HEIGHT, 0, &as->window, &as->renderer)) {
+    if (!SDL_CreateWindowAndRenderer("examples/demo/01-snake", SDL_WINDOW_WIDTH, SDL_WINDOW_HEIGHT, 0, &as->window, &as->renderer)) {
         return SDL_APP_FAILURE;
     }
 
@@ -357,20 +356,20 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
     switch (event->type) {
     case SDL_EVENT_QUIT:
         return SDL_APP_SUCCESS;
-        case SDL_EVENT_JOYSTICK_ADDED:
-                if (joystick == NULL) {
-                    joystick = SDL_OpenJoystick(event->jdevice.which);
-                    if (!joystick) {
-                        SDL_Log("Failed to open joystick ID %u: %s", (unsigned int) event->jdevice.which, SDL_GetError());
-                    }
-                }
-        case SDL_EVENT_JOYSTICK_REMOVED:
-                if (joystick && (SDL_GetJoystickID(joystick) == event->jdevice.which)) {
-                    SDL_CloseJoystick(joystick);
-                    joystick = NULL;
-                }
-        case SDL_EVENT_JOYSTICK_HAT_MOTION:
-                return handle_hat_event_(ctx, event->jhat.value);
+    case SDL_EVENT_JOYSTICK_ADDED:
+        if (joystick == NULL) {
+            joystick = SDL_OpenJoystick(event->jdevice.which);
+            if (!joystick) {
+                SDL_Log("Failed to open joystick ID %u: %s", (unsigned int) event->jdevice.which, SDL_GetError());
+            }
+        }
+    case SDL_EVENT_JOYSTICK_REMOVED:
+        if (joystick && (SDL_GetJoystickID(joystick) == event->jdevice.which)) {
+            SDL_CloseJoystick(joystick);
+            joystick = NULL;
+        }
+    case SDL_EVENT_JOYSTICK_HAT_MOTION:
+        return handle_hat_event_(ctx, event->jhat.value);
     case SDL_EVENT_KEY_DOWN:
         return handle_key_event_(ctx, event->key.scancode);
     }
@@ -379,8 +378,8 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
 
 void SDL_AppQuit(void *appstate, SDL_AppResult result)
 {
-        if (joystick) {
-            SDL_CloseJoystick(joystick);
+    if (joystick) {
+        SDL_CloseJoystick(joystick);
         }
     if (appstate != NULL) {
         AppState *as = (AppState *)appstate;

--- a/examples/demo/01-snake/snake.c
+++ b/examples/demo/01-snake/snake.c
@@ -242,23 +242,23 @@ static SDL_AppResult handle_key_event_(SnakeContext *ctx, SDL_Scancode key_code)
 }
 
 static SDL_AppResult handle_hat_event_(SnakeContext *ctx, Uint8 hat) {
-		switch (hat) {
-		case SDL_HAT_RIGHT:
-			snake_redir(ctx, SNAKE_DIR_RIGHT);
-			break;
-		case SDL_HAT_UP:
-			snake_redir(ctx, SNAKE_DIR_UP);
-			break;
-		case SDL_HAT_LEFT:
-			snake_redir(ctx, SNAKE_DIR_LEFT);
-			break;
-		case SDL_HAT_DOWN:
-			snake_redir(ctx, SNAKE_DIR_DOWN);
-			break;
-		default:
-				break;
-		}
-		return SDL_APP_CONTINUE;
+        switch (hat) {
+        case SDL_HAT_RIGHT:
+            snake_redir(ctx, SNAKE_DIR_RIGHT);
+            break;
+        case SDL_HAT_UP:
+            snake_redir(ctx, SNAKE_DIR_UP);
+            break;
+        case SDL_HAT_LEFT:
+            snake_redir(ctx, SNAKE_DIR_LEFT);
+            break;
+        case SDL_HAT_DOWN:
+            snake_redir(ctx, SNAKE_DIR_DOWN);
+            break;
+        default:
+                break;
+        }
+        return SDL_APP_CONTINUE;
 }
 
 SDL_AppResult SDL_AppIterate(void *appstate)
@@ -329,7 +329,7 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
     }
 
     if (!SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK)) {
-				SDL_Log("Couldn't initialize SDL: %s", SDL_GetError());
+                SDL_Log("Couldn't initialize SDL: %s", SDL_GetError());
         return SDL_APP_FAILURE;
     }
 
@@ -357,20 +357,20 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
     switch (event->type) {
     case SDL_EVENT_QUIT:
         return SDL_APP_SUCCESS;
-		case SDL_EVENT_JOYSTICK_ADDED:
-				if (joystick == NULL) {
-					joystick = SDL_OpenJoystick(event->jdevice.which);
-					if (!joystick) {
-						SDL_Log("Failed to open joystick ID %u: %s", (unsigned int) event->jdevice.which, SDL_GetError());
-					}
-				}
-		case SDL_EVENT_JOYSTICK_REMOVED:
-				if (joystick && (SDL_GetJoystickID(joystick) == event->jdevice.which)) {
-					SDL_CloseJoystick(joystick);
-					joystick = NULL;
-				}
-		case SDL_EVENT_JOYSTICK_HAT_MOTION:
-				return handle_hat_event_(ctx, event->jhat.value);
+        case SDL_EVENT_JOYSTICK_ADDED:
+                if (joystick == NULL) {
+                    joystick = SDL_OpenJoystick(event->jdevice.which);
+                    if (!joystick) {
+                        SDL_Log("Failed to open joystick ID %u: %s", (unsigned int) event->jdevice.which, SDL_GetError());
+                    }
+                }
+        case SDL_EVENT_JOYSTICK_REMOVED:
+                if (joystick && (SDL_GetJoystickID(joystick) == event->jdevice.which)) {
+                    SDL_CloseJoystick(joystick);
+                    joystick = NULL;
+                }
+        case SDL_EVENT_JOYSTICK_HAT_MOTION:
+                return handle_hat_event_(ctx, event->jhat.value);
     case SDL_EVENT_KEY_DOWN:
         return handle_key_event_(ctx, event->key.scancode);
     }
@@ -379,9 +379,9 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
 
 void SDL_AppQuit(void *appstate, SDL_AppResult result)
 {
-		if (joystick) {
-			SDL_CloseJoystick(joystick);
-		}
+        if (joystick) {
+            SDL_CloseJoystick(joystick);
+        }
     if (appstate != NULL) {
         AppState *as = (AppState *)appstate;
         SDL_DestroyRenderer(as->renderer);

--- a/examples/demo/01-snake/snake.c
+++ b/examples/demo/01-snake/snake.c
@@ -339,7 +339,7 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
 
     *appstate = as;
 
-    if (!SDL_CreateWindowAndRenderer("examples/demo/01-snake", SDL_WINDOW_WIDTH, SDL_WINDOW_HEIGHT, 0, &as->window, &as->renderer)) {
+    if (!SDL_CreateWindowAndRenderer("examples/demo/snake", SDL_WINDOW_WIDTH, SDL_WINDOW_HEIGHT, 0, &as->window, &as->renderer)) {
         return SDL_APP_FAILURE;
     }
 
@@ -380,7 +380,7 @@ void SDL_AppQuit(void *appstate, SDL_AppResult result)
 {
     if (joystick) {
         SDL_CloseJoystick(joystick);
-        }
+    }
     if (appstate != NULL) {
         AppState *as = (AppState *)appstate;
         SDL_DestroyRenderer(as->renderer);

--- a/examples/demo/01-snake/snake.c
+++ b/examples/demo/01-snake/snake.c
@@ -380,9 +380,9 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
     case SDL_EVENT_KEY_DOWN:
         return handle_key_event_(ctx, event->key.scancode);
         break;
-    }
     default:
         break;
+    }
     return SDL_APP_CONTINUE;
 }
 

--- a/examples/demo/01-snake/snake.c
+++ b/examples/demo/01-snake/snake.c
@@ -219,7 +219,6 @@ static SDL_AppResult handle_key_event_(SnakeContext *ctx, SDL_Scancode key_code)
     case SDL_SCANCODE_ESCAPE:
     case SDL_SCANCODE_Q:
         return SDL_APP_SUCCESS;
-        break;
     /* Restart the game as if the program was launched. */
     case SDL_SCANCODE_R:
         snake_initialize(ctx);
@@ -359,7 +358,6 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
     switch (event->type) {
     case SDL_EVENT_QUIT:
         return SDL_APP_SUCCESS;
-        break;
     case SDL_EVENT_JOYSTICK_ADDED:
         if (joystick == NULL) {
             joystick = SDL_OpenJoystick(event->jdevice.which);
@@ -376,10 +374,8 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
         break;
     case SDL_EVENT_JOYSTICK_HAT_MOTION:
         return handle_hat_event_(ctx, event->jhat.value);
-        break;
     case SDL_EVENT_KEY_DOWN:
         return handle_key_event_(ctx, event->key.scancode);
-        break;
     default:
         break;
     }


### PR DESCRIPTION
## Description
- add SDL_Joystick pointer
- add SDL_JOYSTICK_INIT and SDL_CLOSEJOYSTICK checks to app start and close
- add separate handler for Joystick HAT changes
- add events to main loop's switch statement
  - JOYSTICK_ADDED
  - JOYSTICK_REMOVED
  - HAT_MOTION

## Known Issue(s)
- Only D-pad HAT is implemented; stick and buttons may function but not configurable (but neither is keyboard)
- JOYSTICK_HAT_MOTION is implemented separately from KEYDOWN to control the snake. This is fine for now, but ideally, each possible input handler should be abstracted to an action to pass into the switch statement to influence the snake.
