### PR TITLE
android: reduce visiblity as much as possible

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/HIDDeviceBLESteamController.java
+++ b/android-project/app/src/main/java/org/libsdl/app/HIDDeviceBLESteamController.java
@@ -44,9 +44,9 @@ class HIDDeviceBLESteamController extends BluetoothGattCallback implements HIDDe
 
     private static final int CHROMEBOOK_CONNECTION_CHECK_INTERVAL = 10000;
 
-    static public final UUID steamControllerService = UUID.fromString("100F6C32-1735-4313-B402-38567131E5F3");
-    static public final UUID inputCharacteristic = UUID.fromString("100F6C33-1735-4313-B402-38567131E5F3");
-    static public final UUID reportCharacteristic = UUID.fromString("100F6C34-1735-4313-B402-38567131E5F3");
+    static final UUID steamControllerService = UUID.fromString("100F6C32-1735-4313-B402-38567131E5F3");
+    static final UUID inputCharacteristic = UUID.fromString("100F6C33-1735-4313-B402-38567131E5F3");
+    static final UUID reportCharacteristic = UUID.fromString("100F6C34-1735-4313-B402-38567131E5F3");
     static private final byte[] enterValveMode = new byte[] { (byte)0xC0, (byte)0x87, 0x03, 0x08, 0x07, 0x00 };
 
     static class GattOperation {
@@ -156,7 +156,7 @@ class HIDDeviceBLESteamController extends BluetoothGattCallback implements HIDDe
         }
     }
 
-    public HIDDeviceBLESteamController(HIDDeviceManager manager, BluetoothDevice device) {
+    HIDDeviceBLESteamController(HIDDeviceManager manager, BluetoothDevice device) {
         mManager = manager;
         mDevice = device;
         mDeviceId = mManager.getDeviceIDForIdentifier(getIdentifier());
@@ -169,17 +169,17 @@ class HIDDeviceBLESteamController extends BluetoothGattCallback implements HIDDe
         // final HIDDeviceBLESteamController finalThis = this;
         // mHandler.postDelayed(new Runnable() {
         //     @Override
-        //     public void run() {
+        //     void run() {
         //         finalThis.checkConnectionForChromebookIssue();
         //     }
         // }, CHROMEBOOK_CONNECTION_CHECK_INTERVAL);
     }
 
-    public String getIdentifier() {
+    String getIdentifier() {
         return String.format("SteamController.%s", mDevice.getAddress());
     }
 
-    public BluetoothGatt getGatt() {
+    BluetoothGatt getGatt() {
         return mGatt;
     }
 
@@ -219,7 +219,7 @@ class HIDDeviceBLESteamController extends BluetoothGattCallback implements HIDDe
         return btManager.getConnectionState(mDevice, BluetoothProfile.GATT);
     }
 
-    public void reconnect() {
+    void reconnect() {
 
         if (getConnectionState() != BluetoothProfile.STATE_CONNECTED) {
             mGatt.disconnect();
@@ -401,12 +401,12 @@ class HIDDeviceBLESteamController extends BluetoothGattCallback implements HIDDe
         queueGattOperation(op);
     }
 
-    public void writeCharacteristic(UUID uuid, byte[] value) {
+    void writeCharacteristic(UUID uuid, byte[] value) {
         GattOperation op = HIDDeviceBLESteamController.GattOperation.writeCharacteristic(mGatt, uuid, value);
         queueGattOperation(op);
     }
 
-    public void readCharacteristic(UUID uuid) {
+    void readCharacteristic(UUID uuid) {
         GattOperation op = HIDDeviceBLESteamController.GattOperation.readCharacteristic(mGatt, uuid);
         queueGattOperation(op);
     }
@@ -415,6 +415,7 @@ class HIDDeviceBLESteamController extends BluetoothGattCallback implements HIDDe
     //////////////  BluetoothGattCallback overridden methods
     //////////////////////////////////////////////////////////////////////////////////////////////////////
 
+    @Override
     public void onConnectionStateChange(BluetoothGatt g, int status, int newState) {
         //Log.v(TAG, "onConnectionStateChange status=" + status + " newState=" + newState);
         mIsReconnecting = false;
@@ -437,6 +438,7 @@ class HIDDeviceBLESteamController extends BluetoothGattCallback implements HIDDe
         // Disconnection is handled in SteamLink using the ACTION_ACL_DISCONNECTED Intent.
     }
 
+    @Override
     public void onServicesDiscovered(BluetoothGatt gatt, int status) {
         //Log.v(TAG, "onServicesDiscovered status=" + status);
         if (status == 0) {
@@ -453,6 +455,7 @@ class HIDDeviceBLESteamController extends BluetoothGattCallback implements HIDDe
         }
     }
 
+    @Override
     public void onCharacteristicRead(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
         //Log.v(TAG, "onCharacteristicRead status=" + status + " uuid=" + characteristic.getUuid());
 
@@ -463,6 +466,7 @@ class HIDDeviceBLESteamController extends BluetoothGattCallback implements HIDDe
         finishCurrentGattOperation();
     }
 
+    @Override
     public void onCharacteristicWrite(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {
         //Log.v(TAG, "onCharacteristicWrite status=" + status + " uuid=" + characteristic.getUuid());
 
@@ -478,6 +482,7 @@ class HIDDeviceBLESteamController extends BluetoothGattCallback implements HIDDe
         finishCurrentGattOperation();
     }
 
+    @Override
     public void onCharacteristicChanged(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic) {
     // Enable this for verbose logging of controller input reports
         //Log.v(TAG, "onCharacteristicChanged uuid=" + characteristic.getUuid() + " data=" + HexDump.dumpHexString(characteristic.getValue()));
@@ -487,10 +492,12 @@ class HIDDeviceBLESteamController extends BluetoothGattCallback implements HIDDe
         }
     }
 
+    @Override
     public void onDescriptorRead(BluetoothGatt gatt, BluetoothGattDescriptor descriptor, int status) {
         //Log.v(TAG, "onDescriptorRead status=" + status);
     }
 
+    @Override
     public void onDescriptorWrite(BluetoothGatt gatt, BluetoothGattDescriptor descriptor, int status) {
         BluetoothGattCharacteristic chr = descriptor.getCharacteristic();
         //Log.v(TAG, "onDescriptorWrite status=" + status + " uuid=" + chr.getUuid() + " descriptor=" + descriptor.getUuid());
@@ -508,14 +515,17 @@ class HIDDeviceBLESteamController extends BluetoothGattCallback implements HIDDe
         finishCurrentGattOperation();
     }
 
+    @Override
     public void onReliableWriteCompleted(BluetoothGatt gatt, int status) {
         //Log.v(TAG, "onReliableWriteCompleted status=" + status);
     }
 
+    @Override
     public void onReadRemoteRssi(BluetoothGatt gatt, int rssi, int status) {
         //Log.v(TAG, "onReadRemoteRssi status=" + status);
     }
 
+    @Override
     public void onMtuChanged(BluetoothGatt gatt, int mtu, int status) {
         //Log.v(TAG, "onMtuChanged status=" + status);
     }

--- a/android-project/app/src/main/java/org/libsdl/app/HIDDeviceManager.java
+++ b/android-project/app/src/main/java/org/libsdl/app/HIDDeviceManager.java
@@ -25,14 +25,14 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
-public class HIDDeviceManager {
+class HIDDeviceManager {
     private static final String TAG = "hidapi";
     private static final String ACTION_USB_PERMISSION = "org.libsdl.app.USB_PERMISSION";
 
     private static HIDDeviceManager sManager;
     private static int sManagerRefCount = 0;
 
-    public static HIDDeviceManager acquire(Context context) {
+    static HIDDeviceManager acquire(Context context) {
         if (sManagerRefCount == 0) {
             sManager = new HIDDeviceManager(context);
         }
@@ -40,7 +40,7 @@ public class HIDDeviceManager {
         return sManager;
     }
 
-    public static void release(HIDDeviceManager manager) {
+    static void release(HIDDeviceManager manager) {
         if (manager == sManager) {
             --sManagerRefCount;
             if (sManagerRefCount == 0) {
@@ -121,11 +121,11 @@ public class HIDDeviceManager {
         }
     }
 
-    public Context getContext() {
+    Context getContext() {
         return mContext;
     }
 
-    public int getDeviceIDForIdentifier(String identifier) {
+    int getDeviceIDForIdentifier(String identifier) {
         SharedPreferences.Editor spedit = mSharedPreferences.edit();
 
         int result = mSharedPreferences.getInt(identifier, 0);
@@ -439,7 +439,7 @@ public class HIDDeviceManager {
     // Chromebooks do not pass along ACTION_ACL_CONNECTED / ACTION_ACL_DISCONNECTED properly.
     // This function provides a sort of dummy version of that, watching for changes in the
     // connected devices and attempting to add controllers as things change.
-    public void chromebookConnectionHandler() {
+    void chromebookConnectionHandler() {
         if (!mIsChromebook) {
             return;
         }
@@ -478,7 +478,7 @@ public class HIDDeviceManager {
         }, 10000);
     }
 
-    public boolean connectBluetoothDevice(BluetoothDevice bluetoothDevice) {
+    boolean connectBluetoothDevice(BluetoothDevice bluetoothDevice) {
         Log.v(TAG, "connectBluetoothDevice device=" + bluetoothDevice);
         synchronized (this) {
             if (mBluetoothDevices.containsKey(bluetoothDevice)) {
@@ -499,7 +499,7 @@ public class HIDDeviceManager {
         return true;
     }
 
-    public void disconnectBluetoothDevice(BluetoothDevice bluetoothDevice) {
+    void disconnectBluetoothDevice(BluetoothDevice bluetoothDevice) {
         synchronized (this) {
             HIDDeviceBLESteamController device = mBluetoothDevices.get(bluetoothDevice);
             if (device == null)
@@ -513,7 +513,7 @@ public class HIDDeviceManager {
         }
     }
 
-    public boolean isSteamController(BluetoothDevice bluetoothDevice) {
+    boolean isSteamController(BluetoothDevice bluetoothDevice) {
         // Sanity check.  If you pass in a null device, by definition it is never a Steam Controller.
         if (bluetoothDevice == null) {
             return false;
@@ -540,7 +540,7 @@ public class HIDDeviceManager {
         }
     }
 
-    public void setFrozen(boolean frozen) {
+    void setFrozen(boolean frozen) {
         synchronized (this) {
             for (HIDDevice device : mDevicesById.values()) {
                 device.setFrozen(frozen);
@@ -567,7 +567,7 @@ public class HIDDeviceManager {
     ////////// JNI interface functions
     //////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    public boolean initialize(boolean usb, boolean bluetooth) {
+    boolean initialize(boolean usb, boolean bluetooth) {
         Log.v(TAG, "initialize(" + usb + ", " + bluetooth + ")");
 
         if (usb) {
@@ -579,7 +579,7 @@ public class HIDDeviceManager {
         return true;
     }
 
-    public boolean openDevice(int deviceID) {
+    boolean openDevice(int deviceID) {
         Log.v(TAG, "openDevice deviceID=" + deviceID);
         HIDDevice device = getDevice(deviceID);
         if (device == null) {
@@ -621,7 +621,7 @@ public class HIDDeviceManager {
         return false;
     }
 
-    public int writeReport(int deviceID, byte[] report, boolean feature) {
+    int writeReport(int deviceID, byte[] report, boolean feature) {
         try {
             //Log.v(TAG, "writeReport deviceID=" + deviceID + " length=" + report.length);
             HIDDevice device;
@@ -638,7 +638,7 @@ public class HIDDeviceManager {
         return -1;
     }
 
-    public boolean readReport(int deviceID, byte[] report, boolean feature) {
+    boolean readReport(int deviceID, byte[] report, boolean feature) {
         try {
             //Log.v(TAG, "readReport deviceID=" + deviceID);
             HIDDevice device;
@@ -655,7 +655,7 @@ public class HIDDeviceManager {
         return false;
     }
 
-    public void closeDevice(int deviceID) {
+    void closeDevice(int deviceID) {
         try {
             Log.v(TAG, "closeDevice deviceID=" + deviceID);
             HIDDevice device;

--- a/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
+++ b/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
@@ -30,7 +30,7 @@ class HIDDeviceUSB implements HIDDevice {
         mRunning = false;
     }
 
-    public String getIdentifier() {
+    String getIdentifier() {
         return String.format("%s/%x/%x/%d", mDevice.getDeviceName(), mDevice.getVendorId(), mDevice.getProductId(), mInterfaceIndex);
     }
 
@@ -100,7 +100,7 @@ class HIDDeviceUSB implements HIDDevice {
         return mDevice;
     }
 
-    public String getDeviceName() {
+    String getDeviceName() {
         return getManufacturerName() + " " + getProductName() + "(0x" + String.format("%x", getVendorId()) + "/0x" + String.format("%x", getProductId()) + ")";
     }
 

--- a/android-project/app/src/main/java/org/libsdl/app/SDL.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDL.java
@@ -8,18 +8,18 @@ import java.lang.reflect.Method;
 /**
     SDL library initialization
 */
-public class SDL {
+class SDL {
 
     // This function should be called first and sets up the native code
     // so it can call into the Java classes
-    public static void setupJNI() {
+    static void setupJNI() {
         SDLActivity.nativeSetupJNI();
         SDLAudioManager.nativeSetupJNI();
         SDLControllerManager.nativeSetupJNI();
     }
 
     // This function should be called each time the activity is started
-    public static void initialize() {
+    static void initialize() {
         setContext(null);
 
         SDLActivity.initialize();
@@ -28,20 +28,20 @@ public class SDL {
     }
 
     // This function stores the current activity (SDL or not)
-    public static void setContext(Context context) {
+    static void setContext(Context context) {
         SDLAudioManager.setContext(context);
         mContext = context;
     }
 
-    public static Context getContext() {
+    static Context getContext() {
         return mContext;
     }
 
-    public static void loadLibrary(String libraryName) throws UnsatisfiedLinkError, SecurityException, NullPointerException {
+    static void loadLibrary(String libraryName) throws UnsatisfiedLinkError, SecurityException, NullPointerException {
         loadLibrary(libraryName, mContext);
     }
 
-    public static void loadLibrary(String libraryName, Context context) throws UnsatisfiedLinkError, SecurityException, NullPointerException {
+    static void loadLibrary(String libraryName, Context context) throws UnsatisfiedLinkError, SecurityException, NullPointerException {
 
         if (libraryName == null) {
             throw new NullPointerException("No library name provided.");

--- a/android-project/app/src/main/java/org/libsdl/app/SDLAudioManager.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLAudioManager.java
@@ -10,14 +10,14 @@ import android.util.Log;
 import java.util.Arrays;
 import java.util.ArrayList;
 
-public class SDLAudioManager {
+class SDLAudioManager {
     protected static final String TAG = "SDLAudio";
 
     protected static Context mContext;
 
     private static AudioDeviceCallback mAudioDeviceCallback;
 
-    public static void initialize() {
+    static void initialize() {
         mAudioDeviceCallback = null;
 
         if(Build.VERSION.SDK_INT >= 24 /* Android 7.0 (N) */)
@@ -40,11 +40,11 @@ public class SDLAudioManager {
         }
     }
 
-    public static void setContext(Context context) {
+    static void setContext(Context context) {
         mContext = context;
     }
 
-    public static void release(Context context) {
+    static void release(Context context) {
         // no-op atm
     }
 
@@ -74,7 +74,7 @@ public class SDLAudioManager {
         return null;
     }
 
-    public static void registerAudioDeviceCallback() {
+    static void registerAudioDeviceCallback() {
         if (Build.VERSION.SDK_INT >= 24 /* Android 7.0 (N) */) {
             AudioManager audioManager = (AudioManager) mContext.getSystemService(Context.AUDIO_SERVICE);
             // get an initial list now, before hotplug callbacks fire.
@@ -91,7 +91,7 @@ public class SDLAudioManager {
         }
     }
 
-    public static void unregisterAudioDeviceCallback() {
+    static void unregisterAudioDeviceCallback() {
         if (Build.VERSION.SDK_INT >= 24 /* Android 7.0 (N) */) {
             AudioManager audioManager = (AudioManager) mContext.getSystemService(Context.AUDIO_SERVICE);
             audioManager.unregisterAudioDeviceCallback(mAudioDeviceCallback);
@@ -99,7 +99,7 @@ public class SDLAudioManager {
     }
 
     /** This method is called by SDL using JNI. */
-    public static void audioSetThreadPriority(boolean recording, int device_id) {
+    static void audioSetThreadPriority(boolean recording, int device_id) {
         try {
 
             /* Set thread name */
@@ -117,10 +117,10 @@ public class SDLAudioManager {
         }
     }
 
-    public static native int nativeSetupJNI();
+    static native int nativeSetupJNI();
 
-    public static native void removeAudioDevice(boolean recording, int deviceId);
+    static native void removeAudioDevice(boolean recording, int deviceId);
 
-    public static native void addAudioDevice(boolean recording, String name, int deviceId);
+    static native void addAudioDevice(boolean recording, String name, int deviceId);
 
 }

--- a/android-project/app/src/main/java/org/libsdl/app/SDLControllerManager.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLControllerManager.java
@@ -17,23 +17,23 @@ import android.view.MotionEvent;
 import android.view.View;
 
 
-public class SDLControllerManager
+class SDLControllerManager
 {
 
-    public static native int nativeSetupJNI();
+    static native int nativeSetupJNI();
 
-    public static native void nativeAddJoystick(int device_id, String name, String desc,
+    static native void nativeAddJoystick(int device_id, String name, String desc,
                                                 int vendor_id, int product_id,
                                                 int button_mask,
                                                 int naxes, int axis_mask, int nhats, boolean can_rumble);
-    public static native void nativeRemoveJoystick(int device_id);
-    public static native void nativeAddHaptic(int device_id, String name);
-    public static native void nativeRemoveHaptic(int device_id);
-    public static native boolean onNativePadDown(int device_id, int keycode);
-    public static native boolean onNativePadUp(int device_id, int keycode);
-    public static native void onNativeJoy(int device_id, int axis,
+    static native void nativeRemoveJoystick(int device_id);
+    static native void nativeAddHaptic(int device_id, String name);
+    static native void nativeRemoveHaptic(int device_id);
+    static native boolean onNativePadDown(int device_id, int keycode);
+    static native boolean onNativePadUp(int device_id, int keycode);
+    static native void onNativeJoy(int device_id, int axis,
                                           float value);
-    public static native void onNativeHat(int device_id, int hat_id,
+    static native void onNativeHat(int device_id, int hat_id,
                                           int x, int y);
 
     protected static SDLJoystickHandler mJoystickHandler;
@@ -41,7 +41,7 @@ public class SDLControllerManager
 
     private static final String TAG = "SDLControllerManager";
 
-    public static void initialize() {
+    static void initialize() {
         if (mJoystickHandler == null) {
             if (Build.VERSION.SDK_INT >= 19 /* Android 4.4 (KITKAT) */) {
                 mJoystickHandler = new SDLJoystickHandler_API19();
@@ -62,48 +62,48 @@ public class SDLControllerManager
     }
 
     // Joystick glue code, just a series of stubs that redirect to the SDLJoystickHandler instance
-    public static boolean handleJoystickMotionEvent(MotionEvent event) {
+    static boolean handleJoystickMotionEvent(MotionEvent event) {
         return mJoystickHandler.handleMotionEvent(event);
     }
 
     /**
      * This method is called by SDL using JNI.
      */
-    public static void pollInputDevices() {
+    static void pollInputDevices() {
         mJoystickHandler.pollInputDevices();
     }
 
     /**
      * This method is called by SDL using JNI.
      */
-    public static void pollHapticDevices() {
+    static void pollHapticDevices() {
         mHapticHandler.pollHapticDevices();
     }
 
     /**
      * This method is called by SDL using JNI.
      */
-    public static void hapticRun(int device_id, float intensity, int length) {
+    static void hapticRun(int device_id, float intensity, int length) {
         mHapticHandler.run(device_id, intensity, length);
     }
 
     /**
      * This method is called by SDL using JNI.
      */
-    public static void hapticRumble(int device_id, float low_frequency_intensity, float high_frequency_intensity, int length) {
+    static void hapticRumble(int device_id, float low_frequency_intensity, float high_frequency_intensity, int length) {
         mHapticHandler.rumble(device_id, low_frequency_intensity, high_frequency_intensity, length);
     }
 
     /**
      * This method is called by SDL using JNI.
      */
-    public static void hapticStop(int device_id)
+    static void hapticStop(int device_id)
     {
         mHapticHandler.stop(device_id);
     }
 
     // Check if a given device is considered a possible SDL joystick
-    public static boolean isDeviceSDLJoystick(int deviceId) {
+    static boolean isDeviceSDLJoystick(int deviceId) {
         InputDevice device = InputDevice.getDevice(deviceId);
         // We cannot use InputDevice.isVirtual before API 16, so let's accept
         // only nonnegative device ids (VIRTUAL_KEYBOARD equals -1)
@@ -140,14 +140,14 @@ class SDLJoystickHandler {
      * @param event the event to be handled.
      * @return if given event was processed.
      */
-    public boolean handleMotionEvent(MotionEvent event) {
+    boolean handleMotionEvent(MotionEvent event) {
         return false;
     }
 
     /**
      * Handles adding and removing of input devices.
      */
-    public void pollInputDevices() {
+    void pollInputDevices() {
     }
 }
 
@@ -155,11 +155,11 @@ class SDLJoystickHandler {
 class SDLJoystickHandler_API16 extends SDLJoystickHandler {
 
     static class SDLJoystick {
-        public int device_id;
-        public String name;
-        public String desc;
-        public ArrayList<InputDevice.MotionRange> axes;
-        public ArrayList<InputDevice.MotionRange> hats;
+        int device_id;
+        String name;
+        String desc;
+        ArrayList<InputDevice.MotionRange> axes;
+        ArrayList<InputDevice.MotionRange> hats;
     }
     static class RangeComparator implements Comparator<InputDevice.MotionRange> {
         @Override
@@ -210,13 +210,13 @@ class SDLJoystickHandler_API16 extends SDLJoystickHandler {
 
     private final ArrayList<SDLJoystick> mJoysticks;
 
-    public SDLJoystickHandler_API16() {
+    SDLJoystickHandler_API16() {
 
         mJoysticks = new ArrayList<SDLJoystick>();
     }
 
     @Override
-    public void pollInputDevices() {
+    void pollInputDevices() {
         int[] deviceIds = InputDevice.getDeviceIds();
 
         for (int device_id : deviceIds) {
@@ -299,7 +299,7 @@ class SDLJoystickHandler_API16 extends SDLJoystickHandler {
     }
 
     @Override
-    public boolean handleMotionEvent(MotionEvent event) {
+    boolean handleMotionEvent(MotionEvent event) {
         int actionPointerIndex = event.getActionIndex();
         int action = event.getActionMasked();
         if (action == MotionEvent.ACTION_MOVE) {
@@ -321,7 +321,7 @@ class SDLJoystickHandler_API16 extends SDLJoystickHandler {
         return true;
     }
 
-    public String getJoystickDescriptor(InputDevice joystickDevice) {
+    String getJoystickDescriptor(InputDevice joystickDevice) {
         String desc = joystickDevice.getDescriptor();
 
         if (desc != null && !desc.isEmpty()) {
@@ -330,16 +330,16 @@ class SDLJoystickHandler_API16 extends SDLJoystickHandler {
 
         return joystickDevice.getName();
     }
-    public int getProductId(InputDevice joystickDevice) {
+    int getProductId(InputDevice joystickDevice) {
         return 0;
     }
-    public int getVendorId(InputDevice joystickDevice) {
+    int getVendorId(InputDevice joystickDevice) {
         return 0;
     }
-    public int getAxisMask(List<InputDevice.MotionRange> ranges) {
+    int getAxisMask(List<InputDevice.MotionRange> ranges) {
         return -1;
     }
-    public int getButtonMask(InputDevice joystickDevice) {
+    int getButtonMask(InputDevice joystickDevice) {
         return -1;
     }
 }
@@ -347,17 +347,17 @@ class SDLJoystickHandler_API16 extends SDLJoystickHandler {
 class SDLJoystickHandler_API19 extends SDLJoystickHandler_API16 {
 
     @Override
-    public int getProductId(InputDevice joystickDevice) {
+    int getProductId(InputDevice joystickDevice) {
         return joystickDevice.getProductId();
     }
 
     @Override
-    public int getVendorId(InputDevice joystickDevice) {
+    int getVendorId(InputDevice joystickDevice) {
         return joystickDevice.getVendorId();
     }
 
     @Override
-    public int getAxisMask(List<InputDevice.MotionRange> ranges) {
+    int getAxisMask(List<InputDevice.MotionRange> ranges) {
         // For compatibility, keep computing the axis mask like before,
         // only really distinguishing 2, 4 and 6 axes.
         int axis_mask = 0;
@@ -394,7 +394,7 @@ class SDLJoystickHandler_API19 extends SDLJoystickHandler_API16 {
     }
 
     @Override
-    public int getButtonMask(InputDevice joystickDevice) {
+    int getButtonMask(InputDevice joystickDevice) {
         int button_mask = 0;
         int[] keys = new int[] {
             KeyEvent.KEYCODE_BUTTON_A,
@@ -491,7 +491,7 @@ class SDLJoystickHandler_API19 extends SDLJoystickHandler_API16 {
 
 class SDLHapticHandler_API31 extends SDLHapticHandler {
     @Override
-    public void run(int device_id, float intensity, int length) {
+    void run(int device_id, float intensity, int length) {
         SDLHaptic haptic = getHaptic(device_id);
         if (haptic != null) {
             vibrate(haptic.vib, intensity, length);
@@ -499,7 +499,7 @@ class SDLHapticHandler_API31 extends SDLHapticHandler {
     }
 
     @Override
-    public void rumble(int device_id, float low_frequency_intensity, float high_frequency_intensity, int length) {
+    void rumble(int device_id, float low_frequency_intensity, float high_frequency_intensity, int length) {
         InputDevice device = InputDevice.getDevice(device_id);
         if (device == null) {
             return;
@@ -543,7 +543,7 @@ class SDLHapticHandler_API31 extends SDLHapticHandler {
 
 class SDLHapticHandler_API26 extends SDLHapticHandler {
     @Override
-    public void run(int device_id, float intensity, int length) {
+    void run(int device_id, float intensity, int length) {
         SDLHaptic haptic = getHaptic(device_id);
         if (haptic != null) {
             if (intensity == 0.0f) {
@@ -575,36 +575,36 @@ class SDLHapticHandler_API26 extends SDLHapticHandler {
 class SDLHapticHandler {
 
     static class SDLHaptic {
-        public int device_id;
-        public String name;
-        public Vibrator vib;
+        int device_id;
+        String name;
+        Vibrator vib;
     }
 
     private final ArrayList<SDLHaptic> mHaptics;
 
-    public SDLHapticHandler() {
+    SDLHapticHandler() {
         mHaptics = new ArrayList<SDLHaptic>();
     }
 
-    public void run(int device_id, float intensity, int length) {
+    void run(int device_id, float intensity, int length) {
         SDLHaptic haptic = getHaptic(device_id);
         if (haptic != null) {
             haptic.vib.vibrate(length);
         }
     }
 
-    public void rumble(int device_id, float low_frequency_intensity, float high_frequency_intensity, int length) {
+    void rumble(int device_id, float low_frequency_intensity, float high_frequency_intensity, int length) {
         // Not supported in older APIs
     }
 
-    public void stop(int device_id) {
+    void stop(int device_id) {
         SDLHaptic haptic = getHaptic(device_id);
         if (haptic != null) {
             haptic.vib.cancel();
         }
     }
 
-    public void pollHapticDevices() {
+    void pollHapticDevices() {
 
         final int deviceId_VIBRATOR_SERVICE = 999999;
         boolean hasVibratorService = false;
@@ -724,31 +724,31 @@ class SDLGenericMotionListener_API14 implements View.OnGenericMotionListener {
         return consumed;
     }
 
-    public boolean supportsRelativeMouse() {
+    boolean supportsRelativeMouse() {
         return false;
     }
 
-    public boolean inRelativeMode() {
+    boolean inRelativeMode() {
         return false;
     }
 
-    public boolean setRelativeMouseEnabled(boolean enabled) {
+    boolean setRelativeMouseEnabled(boolean enabled) {
         return false;
     }
 
-    public void reclaimRelativeMouseModeIfNeeded() {
+    void reclaimRelativeMouseModeIfNeeded() {
 
     }
 
-    public boolean checkRelativeEvent(MotionEvent event) {
+    boolean checkRelativeEvent(MotionEvent event) {
         return inRelativeMode();
     }
 
-    public float getEventX(MotionEvent event, int pointerIndex) {
+    float getEventX(MotionEvent event, int pointerIndex) {
         return event.getX(pointerIndex);
     }
 
-    public float getEventY(MotionEvent event, int pointerIndex) {
+    float getEventY(MotionEvent event, int pointerIndex) {
         return event.getY(pointerIndex);
     }
 
@@ -760,23 +760,23 @@ class SDLGenericMotionListener_API24 extends SDLGenericMotionListener_API14 {
     private boolean mRelativeModeEnabled;
 
     @Override
-    public boolean supportsRelativeMouse() {
+    boolean supportsRelativeMouse() {
         return true;
     }
 
     @Override
-    public boolean inRelativeMode() {
+    boolean inRelativeMode() {
         return mRelativeModeEnabled;
     }
 
     @Override
-    public boolean setRelativeMouseEnabled(boolean enabled) {
+    boolean setRelativeMouseEnabled(boolean enabled) {
         mRelativeModeEnabled = enabled;
         return true;
     }
 
     @Override
-    public float getEventX(MotionEvent event, int pointerIndex) {
+    float getEventX(MotionEvent event, int pointerIndex) {
         if (mRelativeModeEnabled && event.getToolType(pointerIndex) == MotionEvent.TOOL_TYPE_MOUSE) {
             return event.getAxisValue(MotionEvent.AXIS_RELATIVE_X, pointerIndex);
         } else {
@@ -785,7 +785,7 @@ class SDLGenericMotionListener_API24 extends SDLGenericMotionListener_API14 {
     }
 
     @Override
-    public float getEventY(MotionEvent event, int pointerIndex) {
+    float getEventY(MotionEvent event, int pointerIndex) {
         if (mRelativeModeEnabled && event.getToolType(pointerIndex) == MotionEvent.TOOL_TYPE_MOUSE) {
             return event.getAxisValue(MotionEvent.AXIS_RELATIVE_Y, pointerIndex);
         } else {
@@ -799,17 +799,17 @@ class SDLGenericMotionListener_API26 extends SDLGenericMotionListener_API24 {
     private boolean mRelativeModeEnabled;
 
     @Override
-    public boolean supportsRelativeMouse() {
+    boolean supportsRelativeMouse() {
         return (!SDLActivity.isDeXMode() || Build.VERSION.SDK_INT >= 27 /* Android 8.1 (O_MR1) */);
     }
 
     @Override
-    public boolean inRelativeMode() {
+    boolean inRelativeMode() {
         return mRelativeModeEnabled;
     }
 
     @Override
-    public boolean setRelativeMouseEnabled(boolean enabled) {
+    boolean setRelativeMouseEnabled(boolean enabled) {
         if (!SDLActivity.isDeXMode() || Build.VERSION.SDK_INT >= 27 /* Android 8.1 (O_MR1) */) {
             if (enabled) {
                 SDLActivity.getContentView().requestPointerCapture();
@@ -824,25 +824,25 @@ class SDLGenericMotionListener_API26 extends SDLGenericMotionListener_API24 {
     }
 
     @Override
-    public void reclaimRelativeMouseModeIfNeeded() {
+    void reclaimRelativeMouseModeIfNeeded() {
         if (mRelativeModeEnabled && !SDLActivity.isDeXMode()) {
             SDLActivity.getContentView().requestPointerCapture();
         }
     }
 
     @Override
-    public boolean checkRelativeEvent(MotionEvent event) {
+    boolean checkRelativeEvent(MotionEvent event) {
         return event.getSource() == InputDevice.SOURCE_MOUSE_RELATIVE;
     }
 
     @Override
-    public float getEventX(MotionEvent event, int pointerIndex) {
+    float getEventX(MotionEvent event, int pointerIndex) {
         // Relative mouse in capture mode will only have relative for X/Y
         return event.getX(pointerIndex);
     }
 
     @Override
-    public float getEventY(MotionEvent event, int pointerIndex) {
+    float getEventY(MotionEvent event, int pointerIndex) {
         // Relative mouse in capture mode will only have relative for X/Y
         return event.getY(pointerIndex);
     }

--- a/android-project/app/src/main/java/org/libsdl/app/SDLDummyEdit.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLDummyEdit.java
@@ -14,14 +14,14 @@ public class SDLDummyEdit extends View implements View.OnKeyListener
     InputConnection ic;
     int input_type;
 
-    public SDLDummyEdit(Context context) {
+    SDLDummyEdit(Context context) {
         super(context);
         setFocusableInTouchMode(true);
         setFocusable(true);
         setOnKeyListener(this);
     }
 
-    public void setInputType(int input_type) {
+    void setInputType(int input_type) {
         this.input_type = input_type;
     }
 

--- a/android-project/app/src/main/java/org/libsdl/app/SDLInputConnection.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLInputConnection.java
@@ -7,12 +7,12 @@ import android.view.*;
 import android.view.inputmethod.BaseInputConnection;
 import android.widget.EditText;
 
-public class SDLInputConnection extends BaseInputConnection
+class SDLInputConnection extends BaseInputConnection
 {
     protected EditText mEditText;
     protected String mCommittedText = "";
 
-    public SDLInputConnection(View targetView, boolean fullEditor) {
+    SDLInputConnection(View targetView, boolean fullEditor) {
         super(targetView, fullEditor);
         mEditText = new EditText(SDL.getContext());
     }

--- a/android-project/app/src/main/java/org/libsdl/app/SDLSurface.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLSurface.java
@@ -40,10 +40,10 @@ public class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
     protected float mWidth, mHeight;
 
     // Is SurfaceView ready for rendering
-    public boolean mIsSurfaceReady;
+    protected boolean mIsSurfaceReady;
 
     // Startup
-    public SDLSurface(Context context) {
+    protected SDLSurface(Context context) {
         super(context);
         getHolder().addCallback(this);
 
@@ -66,11 +66,11 @@ public class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
         mIsSurfaceReady = false;
     }
 
-    public void handlePause() {
+    protected void handlePause() {
         enableSensor(Sensor.TYPE_ACCELEROMETER, false);
     }
 
-    public void handleResume() {
+    protected void handleResume() {
         setFocusable(true);
         setFocusableInTouchMode(true);
         requestFocus();
@@ -80,7 +80,7 @@ public class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
         enableSensor(Sensor.TYPE_ACCELEROMETER, true);
     }
 
-    public Surface getNativeSurface() {
+    protected Surface getNativeSurface() {
         return getHolder().getSurface();
     }
 
@@ -299,7 +299,7 @@ public class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
     }
 
     // Sensor events
-    public void enableSensor(int sensortype, boolean enabled) {
+    protected void enableSensor(int sensortype, boolean enabled) {
         // TODO: This uses getDefaultSensor - what if we have >1 accels?
         if (enabled) {
             mSensorManager.registerListener(this,
@@ -363,6 +363,7 @@ public class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
     }
 
     // Captured pointer events for API 26.
+    @Override
     public boolean onCapturedPointerEvent(MotionEvent event)
     {
         int action = event.getActionMasked();
@@ -401,7 +402,7 @@ public class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
                     SDLActivity.onNativeMouse(button, action, x, y, true);
                     return true;
             }
-        }      
+        }
 
         return false;
     }

--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -1459,7 +1459,7 @@ The following symbols have been removed:
 * SDL_RENDERER_PRESENTVSYNC - replaced with SDL_PROP_RENDERER_CREATE_PRESENT_VSYNC_NUMBER during renderer creation and SDL_PROP_RENDERER_VSYNC_NUMBER after renderer creation
 * SDL_RENDERER_SOFTWARE - you can check whether the name of the renderer is `SDL_SOFTWARE_RENDERER`
 * SDL_RENDERER_TARGETTEXTURE - all renderers support target texture functionality
-* SDL_ScaleModeBest = use SDL_SCALEMODE_LINEAR instead
+* SDL_ScaleModeBest - use SDL_SCALEMODE_LINEAR instead
 
 ## SDL_rwops.h
 

--- a/test/android/cmake/SDLEntryTestActivity.java.cmake
+++ b/test/android/cmake/SDLEntryTestActivity.java.cmake
@@ -8,7 +8,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 
-import org.libsdl.app.SDL;
 import org.libsdl.app.SDLActivity;
 
 import android.widget.Button;


### PR DESCRIPTION
Most of SDL internals are already private by default (using `-fvisibility=hidden` and the version script).
So I think it makes sense to also reduce the visibility of the Java helper classes.

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
