### PR TITLE
Don't send text event while ctrl/alt is held on X11/Wayland

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -1886,7 +1886,7 @@ static void keyboard_handle_key(void *data, struct wl_keyboard *keyboard,
     SDL_SendKeyboardKeyIgnoreModifiers(timestamp, input->keyboard_id, key, scancode, state == WL_KEYBOARD_KEY_STATE_PRESSED);
 
     if (state == WL_KEYBOARD_KEY_STATE_PRESSED) {
-        if (has_text && !(SDL_GetModState() & SDL_KMOD_CTRL)) {
+        if (has_text && !(SDL_GetModState() & (SDL_KMOD_CTRL | SDL_KMOD_ALT))) {
             if (!handled_by_ime) {
                 SDL_SendKeyboardText(text);
             }

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -977,7 +977,7 @@ void X11_HandleKeyEvent(SDL_VideoDevice *_this, SDL_WindowData *windowdata, SDL_
             X11_HandleModifierKeys(videodata, scancode, true, true);
             SDL_SendKeyboardKeyIgnoreModifiers(timestamp, keyboardID, keycode, scancode, true);
 
-            if (*text) {
+            if (*text && !(SDL_GetModState() & (SDL_KMOD_CTRL | SDL_KMOD_ALT))) {
                 text[text_length] = '\0';
                 X11_ClearComposition(windowdata);
                 SDL_SendKeyboardText(text);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This can be tested with `testime`. In other applications, Ctrl/Alt+number does not result in a text input, but SDL sends a text input event on it.

I was looking for a better solution than simply filtering, but GLFW also filters text events on [X11](https://github.com/glfw/glfw/blob/master/src/x11_window.c#L1247)/[Wayland](https://github.com/glfw/glfw/blob/master/src/wl_window.c#L1199) while Ctrl/Alt is held, so I think this should be okay.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/4695, but this also happens on X11 for me and some people on comments.
