### PR TITLE
video: Send pending coordinates for moved, hidden windows

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2924,11 +2924,12 @@ bool SDL_GetWindowPosition(SDL_Window *window, int *x, int *y)
             }
         }
     } else {
+        const bool use_current = !(window->flags & SDL_WINDOW_HIDDEN) && !window->last_position_pending;
         if (x) {
-            *x = window->x;
+            *x = use_current ? window->x : window->pending.x;
         }
         if (y) {
-            *y = window->y;
+            *y = use_current ? window->y : window->pending.y;
         }
     }
     return true;


### PR DESCRIPTION
Some backends can't actually position a window until it is shown/mapped, so assume that it will be where it was asked to be as long as it is hidden.

Fixes libsdl-org/sdl2-compat#415
