### PR TITLE
emscripten: Don't use legacy JS library functions for assertions

### DIFF
--- a/src/SDL_assert.c
+++ b/src/SDL_assert.c
@@ -34,15 +34,7 @@
 #endif
 
 #ifdef SDL_PLATFORM_EMSCRIPTEN
-    #include <emscripten.h>
-    // older Emscriptens don't have this, but we need to for wasm64 compatibility.
-    #ifndef MAIN_THREAD_EM_ASM_PTR
-        #ifdef __wasm64__
-            #error You need to upgrade your Emscripten compiler to support wasm64
-        #else
-            #define MAIN_THREAD_EM_ASM_PTR MAIN_THREAD_EM_ASM_INT
-        #endif
-    #endif
+#include <emscripten.h>
 #endif
 
 // The size of the stack buffer to use for rendering assert messages.
@@ -252,7 +244,7 @@ static SDL_AssertState SDLCALL SDL_PromptAssertion(const SDL_AssertData *data, v
         for (;;) {
             bool okay = true;
             /* *INDENT-OFF* */ // clang-format off
-            char *buf = (char *) MAIN_THREAD_EM_ASM_PTR({
+            int reply = MAIN_THREAD_EM_ASM_INT({
                 var str =
                     UTF8ToString($0) + '\n\n' +
                     'Abort/Retry/Ignore/AlwaysIgnore? [ariA] :';
@@ -260,26 +252,32 @@ static SDL_AssertState SDLCALL SDL_PromptAssertion(const SDL_AssertData *data, v
                 if (reply === null) {
                     reply = "i";
                 }
-                return allocate(intArrayFromString(reply), 'i8', ALLOC_NORMAL);
+                return reply.length === 1 ? reply.charCodeAt(0) : -1;
             }, message);
             /* *INDENT-ON* */ // clang-format on
 
-            if (SDL_strcmp(buf, "a") == 0) {
+            switch (reply) {
+            case 'a':
                 state = SDL_ASSERTION_ABORT;
+                break;
 #if 0 // (currently) no break functionality on Emscripten
-            } else if (SDL_strcmp(buf, "b") == 0) {
+            case 'b':
                 state = SDL_ASSERTION_BREAK;
+                break;
 #endif
-            } else if (SDL_strcmp(buf, "r") == 0) {
+            case 'r':
                 state = SDL_ASSERTION_RETRY;
-            } else if (SDL_strcmp(buf, "i") == 0) {
+                break;
+            case 'i':
                 state = SDL_ASSERTION_IGNORE;
-            } else if (SDL_strcmp(buf, "A") == 0) {
+                break;
+            case 'A':
                 state = SDL_ASSERTION_ALWAYS_IGNORE;
-            } else {
+                break;
+            default:
                 okay = false;
+                break;
             }
-            free(buf);  // This should NOT be SDL_free()
 
             if (okay) {
                 break;


### PR DESCRIPTION
Downstream issue: https://github.com/emscripten-core/emscripten/issues/21732

On Emscripten, `SDL_PromptAssertion()` uses `allocate()`, which is considered a legacy JS library function and is no longer included by default, which may result in JavaScript errors if legacy symbols are not included in the build (e.g. by passing `-sLEGACY_RUNTIME` to `emcc`). In addition to runtime errors, it will also prevent passing `--closure 1` to `emcc` to minify JS from working, see the issue linked above.

This is a simple fix that rewrites the relevant `SDL_PromptAssertion()` parts to avoid the need for allocations entirely.

The same problem is present in SDL2, so if this PR is merged, the fix should be backported to SDL2 as well.