### PR TITLE
GPU: Fix Vulkan backend never checking deallocations

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -1106,6 +1106,7 @@ struct VulkanRenderer
 
     VulkanMemoryAllocator *memoryAllocator;
     VkPhysicalDeviceMemoryProperties memoryProperties;
+    bool checkEmptyAllocations;
 
     WindowData **claimedWindows;
     Uint32 claimedWindowCount;
@@ -1547,6 +1548,8 @@ static void VULKAN_INTERNAL_RemoveMemoryUsedRegion(
         usedRegion->size);
 
     SDL_free(usedRegion);
+
+    renderer->checkEmptyAllocations = 1;
 
     SDL_UnlockMutex(renderer->allocatorLock);
 }
@@ -10375,7 +10378,6 @@ static bool VULKAN_Submit(
     VkPipelineStageFlags waitStages[MAX_PRESENT_COUNT];
     Uint32 swapchainImageIndex;
     VulkanTextureSubresource *swapchainTextureSubresource;
-    Uint8 commandBufferCleaned = 0;
     VulkanMemorySubAllocator *allocator;
     bool presenting = false;
 
@@ -10491,12 +10493,10 @@ static bool VULKAN_Submit(
                 renderer,
                 renderer->submittedCommandBuffers[i],
                 false);
-
-            commandBufferCleaned = 1;
         }
     }
 
-    if (commandBufferCleaned) {
+    if (renderer->checkEmptyAllocations) {
         SDL_LockMutex(renderer->allocatorLock);
 
         for (Uint32 i = 0; i < VK_MAX_MEMORY_TYPES; i += 1) {
@@ -10511,6 +10511,8 @@ static bool VULKAN_Submit(
                 }
             }
         }
+
+        renderer->checkEmptyAllocations = 0;
 
         SDL_UnlockMutex(renderer->allocatorLock);
     }

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -1547,8 +1547,7 @@ static void VULKAN_INTERNAL_RemoveMemoryUsedRegion(
         usedRegion->offset,
         usedRegion->size);
 
-    if (usedRegion->allocation->usedRegionCount == 0)
-    {
+    if (usedRegion->allocation->usedRegionCount == 0) {
         renderer->checkEmptyAllocations = true;
     }
 

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -1549,11 +1549,10 @@ static void VULKAN_INTERNAL_RemoveMemoryUsedRegion(
 
     if (usedRegion->allocation->usedRegionCount == 0)
     {
-        renderer->checkEmptyAllocations = 1;
+        renderer->checkEmptyAllocations = true;
     }
 
     SDL_free(usedRegion);
-
 
     SDL_UnlockMutex(renderer->allocatorLock);
 }
@@ -10516,7 +10515,7 @@ static bool VULKAN_Submit(
             }
         }
 
-        renderer->checkEmptyAllocations = 0;
+        renderer->checkEmptyAllocations = false;
 
         SDL_UnlockMutex(renderer->allocatorLock);
     }

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -1547,9 +1547,13 @@ static void VULKAN_INTERNAL_RemoveMemoryUsedRegion(
         usedRegion->offset,
         usedRegion->size);
 
+    if (usedRegion->allocation->usedRegionCount == 0)
+    {
+        renderer->checkEmptyAllocations = 1;
+    }
+
     SDL_free(usedRegion);
 
-    renderer->checkEmptyAllocations = 1;
 
     SDL_UnlockMutex(renderer->allocatorLock);
 }


### PR DESCRIPTION
Since we restructured presentation, in the typical path Wait is called before acquiring a swapchain texture to prevent the GPU from getting too far ahead. Wait triggers command buffer cleanup. However, originally the backend assumed that command buffers were always cleaned up inside of Submit, and if a command buffer was cleaned this triggered the deallocation check. In light workloads command buffers tend to be cleaned up inside of Wait. This meant that the deallocation was never triggered.

The fix is to set a flag on VulkanRenderer that is triggered when a memory region is freed and the allocation has 0 remaining used regions. If this flag is set to 1, we check for empty allocations and deallocate them in Submit. 

Resolves #12507 