### PR TITLE
Fix return type in SDL_CreateGPURenderState

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -5841,7 +5841,7 @@ bool SDL_GetDefaultTextureScaleMode(SDL_Renderer *renderer, SDL_ScaleMode *scale
 
 SDL_GPURenderState *SDL_CreateGPURenderState(SDL_Renderer *renderer, SDL_GPURenderStateDesc *desc)
 {
-    CHECK_RENDERER_MAGIC(renderer, false);
+    CHECK_RENDERER_MAGIC(renderer, NULL);
 
     if (!desc) {
         SDL_InvalidParamError("desc");


### PR DESCRIPTION
## Description
Trying to return a boolean here instead of a pointer was causing compilation failure.
