### PR TITLE
gpu: Fix MTLLibrary dispatch data destructor

### DIFF
--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -858,7 +858,7 @@ static MetalLibraryFunction METAL_INTERNAL_CompileShader(
             code,
             codeSize,
             dispatch_get_global_queue(0, 0),
-            ^{ /* do nothing */ });
+            DISPATCH_DATA_DESTRUCTOR_DEFAULT);
         library = [renderer->device newLibraryWithData:data error:&error];
     } else {
         SDL_assert(!"SDL_gpu.c should have already validated this!");


### PR DESCRIPTION
Fixes a use-after-free when creating METALLIB shaders. I was under the incorrect impression that `dispatch_data_create` implicitly copied the data passed to it, but [according to the docs](https://developer.apple.com/documentation/dispatch/1452970-dispatch_data_create) a copy is only made if the destructor is set to the constant `DISPATCH_DATA_DESTRUCTOR_DEFAULT`.

Resolves https://github.com/libsdl-org/SDL/issues/12569
