### PR TITLE
Emscripten: Allow for Multiple Windows

### DIFF
--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1395,13 +1395,21 @@ bool SDLTest_CommonInit(SDLTest_CommonState *state)
                 }
             }
 
+            props = SDL_CreateProperties();
             if (state->num_windows > 1) {
                 (void)SDL_snprintf(title, SDL_arraysize(title), "%s %d",
                                    state->window_title, i + 1);
+#if SDL_PLATFORM_EMSCRIPTEN
+                if (i != 0) {
+                    char id[64];
+                    SDL_snprintf(id, sizeof(id), "#canvas%d", i + 1);
+                    SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID, id);
+                    SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_KEYBOARD_ELEMENT, id);
+                }
+#endif
             } else {
                 SDL_strlcpy(title, state->window_title, SDL_arraysize(title));
             }
-            props = SDL_CreateProperties();
             SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_TITLE_STRING, title);
             SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_X_NUMBER, r.x);
             SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_Y_NUMBER, r.y);

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1403,8 +1403,8 @@ bool SDLTest_CommonInit(SDLTest_CommonState *state)
                 if (i != 0) {
                     char id[64];
                     SDL_snprintf(id, sizeof(id), "#canvas%d", i + 1);
-                    SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID, id);
-                    SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_KEYBOARD_ELEMENT, id);
+                    SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID_STRING, id);
+                    SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_KEYBOARD_ELEMENT_STRING, id);
                 }
 #endif
             } else {

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1399,7 +1399,7 @@ bool SDLTest_CommonInit(SDLTest_CommonState *state)
             if (state->num_windows > 1) {
                 (void)SDL_snprintf(title, SDL_arraysize(title), "%s %d",
                                    state->window_title, i + 1);
-#if SDL_PLATFORM_EMSCRIPTEN
+#ifdef SDL_PLATFORM_EMSCRIPTEN
                 if (i != 0) {
                     char id[64];
                     SDL_snprintf(id, sizeof(id), "#canvas%d", i + 1);

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2648,7 +2648,7 @@ bool SDL_RecreateWindow(SDL_Window *window, SDL_WindowFlags flags)
 
     // Don't actually recreate the window in Emscripten because the SDL_WindowData's
     // canvas_id and keyboard_element would be lost if destroyed
-#if !SDL_PLATFORM_EMSCRIPTEN
+#ifndef SDL_PLATFORM_EMSCRIPTEN
     if (_this->DestroyWindow && !(flags & SDL_WINDOW_EXTERNAL)) {
         _this->DestroyWindow(_this, window);
     }
@@ -2680,7 +2680,7 @@ bool SDL_RecreateWindow(SDL_Window *window, SDL_WindowFlags flags)
         window->w = window->windowed.w = window->floating.w;
         window->h = window->windowed.h = window->floating.h;
 
-#if SDL_PLATFORM_EMSCRIPTEN
+#ifdef SDL_PLATFORM_EMSCRIPTEN
         // Prevent -Wunused-but-set-variable
         (void)loaded_opengl;
         (void)loaded_vulkan;
@@ -2727,7 +2727,7 @@ bool SDL_RecreateWindow(SDL_Window *window, SDL_WindowFlags flags)
         _this->SetWindowHitTest(window, true);
     }
 
-#if !SDL_PLATFORM_EMSCRIPTEN
+#ifndef SDL_PLATFORM_EMSCRIPTEN
     SDL_FinishWindowCreation(window, flags);
 #endif
 

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2563,6 +2563,15 @@ SDL_Window *SDL_CreatePopupWindow(SDL_Window *parent, int offset_x, int offset_y
     SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, w);
     SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, h);
     SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_FLAGS_NUMBER, flags);
+#ifdef SDL_PLATFORM_EMSCRIPTEN
+    // Must ensure that popup windows have a unique canvas_id
+    const char* canvas_id = SDL_GetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID_STRING, "");
+    if (!canvas_id || !*canvas_id) {
+        char new_canvas_id[64];
+        SDL_snprintf(new_canvas_id, sizeof(new_canvas_id), "#popup%u", props);
+        SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID_STRING, new_canvas_id);
+    }
+#endif
     window = SDL_CreateWindowWithProperties(props);
     SDL_DestroyProperties(props);
     return window;

--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -690,6 +690,9 @@ static EM_BOOL Emscripten_HandleResize(int eventType, const EmscriptenUiEvent *u
         }
     }
 
+    // Always re-sync the window when the browser window changes size
+    SDL_SyncWindow(window_data->window);
+
     if (!(window_data->window->flags & SDL_WINDOW_FULLSCREEN)) {
         // this will only work if the canvas size is set through css
         if (window_data->window->flags & SDL_WINDOW_RESIZABLE) {

--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -1186,7 +1186,6 @@ void Emscripten_RegisterEventHandlers(SDL_WindowData *data)
 {
     const char *keyElement;
 
-    // There is only one window and that window is the canvas
     emscripten_set_mousemove_callback(data->canvas_id, data, 0, Emscripten_HandleMouseMove);
 
     emscripten_set_mousedown_callback(data->canvas_id, data, 0, Emscripten_HandleMouseButton);

--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -1034,14 +1034,18 @@ static void Emscripten_set_drag_event_callbacks(SDL_WindowData *data)
             target.addEventListener("dragover", window_data.eventHandlerDropDragover);
 
             window_data.drop_count = 0;
-            try
-            {
-                FS.mkdir("/tmp/filedrop")
+            function safeCreateDir(dir){
+                try
+                {
+                    FS.mkdir(dir)
+                }
+                catch(e)
+                {
+                    // Throws if the directory already exists
+                }
             }
-            catch(e)
-            {
-                // Throws if the directory already exists
-            }
+            safeCreateDir("/tmp/filedrop");
+            safeCreateDir(`/tmp/filedrop/${id}/`);
 
             window_data.eventHandlerDropDrop = function(event) {
                 event.preventDefault();
@@ -1055,7 +1059,7 @@ static void Emscripten_set_drag_event_callbacks(SDL_WindowData *data)
                         const file_reader = new FileReader();
                         file_reader.readAsArrayBuffer(file);
                         file_reader.onload = function(event) {
-                            const fs_dropdir = `/tmp/filedrop/${window_data.drop_count}`;
+                            const fs_dropdir = `/tmp/filedrop/${id}/${window_data.drop_count}`;
                             window_data.drop_count += 1;
 
                             const fs_filepath = `${fs_dropdir}/${file.name}`;
@@ -1112,7 +1116,7 @@ static void Emscripten_unset_drag_event_callbacks(SDL_WindowData *data)
                 }
             }
 
-            const path = "/tmp/filedrop";
+            const path = `/tmp/filedrop/${id}/`;
             function recursive_remove(dirpath) {
                 FS.readdir(dirpath).forEach((filename) => {
                     const p = `${dirpath}/${filename}`;

--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -874,14 +874,26 @@ EMSCRIPTEN_KEEPALIVE void Emscripten_HandlePointerGeneric(SDL_WindowData *window
 static void Emscripten_set_pointer_event_callbacks(SDL_WindowData *data)
 {
     MAIN_THREAD_EM_ASM({
-        var target = document.querySelector(UTF8ToString($1));
+        var id = UTF8ToString($1);
+        var target = document.querySelector(id);
         if (target) {
             var data = $0;
 
-            if (typeof(Module['SDL3']) === 'undefined') {
+            if (!Module['SDL3']) {
                 Module['SDL3'] = {};
             }
+
             var SDL3 = Module['SDL3'];
+            if (!SDL3['window_data']) {
+                SDL3['window_data'] = {};
+            }
+
+            var window_datas = SDL3['window_data'];
+            if (!window_datas[id]) {
+                window_datas[id] = {};
+            }
+
+            var window_data = window_datas[id];
 
             var makePointerEventCStruct = function(event) {
                 var ptr = 0;
@@ -907,23 +919,23 @@ static void Emscripten_set_pointer_event_callbacks(SDL_WindowData *data)
                 return ptr;
             };
 
-            SDL3.eventHandlerPointerEnter = function(event) {
+            window_data.eventHandlerPointerEnter = function(event) {
                 var d = makePointerEventCStruct(event); if (d != 0) { _Emscripten_HandlePointerEnter(data, d); _SDL_free(d); }
             };
-            target.addEventListener("pointerenter", SDL3.eventHandlerPointerEnter);
+            target.addEventListener("pointerenter", window_data.eventHandlerPointerEnter);
 
-            SDL3.eventHandlerPointerLeave = function(event) {
+            window_data.eventHandlerPointerLeave = function(event) {
                 var d = makePointerEventCStruct(event); if (d != 0) { _Emscripten_HandlePointerLeave(data, d); _SDL_free(d); }
             };
-            target.addEventListener("pointerleave", SDL3.eventHandlerPointerLeave);
-            target.addEventListener("pointercancel", SDL3.eventHandlerPointerLeave);  // catch this, just in case.
+            target.addEventListener("pointerleave", window_data.eventHandlerPointerLeave);
+            target.addEventListener("pointercancel", window_data.eventHandlerPointerLeave);  // catch this, just in case.
 
-            SDL3.eventHandlerPointerGeneric = function(event) {
+            window_data.eventHandlerPointerGeneric = function(event) {
                 var d = makePointerEventCStruct(event); if (d != 0) { _Emscripten_HandlePointerGeneric(data, d); _SDL_free(d); }
             };
-            target.addEventListener("pointerdown", SDL3.eventHandlerPointerGeneric);
-            target.addEventListener("pointerup", SDL3.eventHandlerPointerGeneric);
-            target.addEventListener("pointermove", SDL3.eventHandlerPointerGeneric);
+            target.addEventListener("pointerdown", window_data.eventHandlerPointerGeneric);
+            target.addEventListener("pointerup", window_data.eventHandlerPointerGeneric);
+            target.addEventListener("pointermove", window_data.eventHandlerPointerGeneric);
         }
     }, data, data->canvas_id, sizeof (Emscripten_PointerEvent));
 }
@@ -931,18 +943,21 @@ static void Emscripten_set_pointer_event_callbacks(SDL_WindowData *data)
 static void Emscripten_unset_pointer_event_callbacks(SDL_WindowData *data)
 {
     MAIN_THREAD_EM_ASM({
-        var target = document.querySelector(UTF8ToString($0));
+        var id = UTF8ToString($0);
+        var target = document.querySelector(id);
         if (target) {
             var SDL3 = Module['SDL3'];
-            target.removeEventListener("pointerenter", SDL3.eventHandlerPointerEnter);
-            target.removeEventListener("pointerleave", SDL3.eventHandlerPointerLeave);
-            target.removeEventListener("pointercancel", SDL3.eventHandlerPointerLeave);
-            target.removeEventListener("pointerdown", SDL3.eventHandlerPointerGeneric);
-            target.removeEventListener("pointerup", SDL3.eventHandlerPointerGeneric);
-            target.removeEventListener("pointermove", SDL3.eventHandlerPointerGeneric);
-            SDL3.eventHandlerPointerEnter = undefined;
-            SDL3.eventHandlerPointerLeave = undefined;
-            SDL3.eventHandlerPointerGeneric = undefined;
+            var window_datas = SDL3['window_data'];
+            var window_data = window_datas[id];
+            target.removeEventListener("pointerenter", window_data.eventHandlerPointerEnter);
+            target.removeEventListener("pointerleave", window_data.eventHandlerPointerLeave);
+            target.removeEventListener("pointercancel", window_data.eventHandlerPointerLeave);
+            target.removeEventListener("pointerdown", window_data.eventHandlerPointerGeneric);
+            target.removeEventListener("pointerup", window_data.eventHandlerPointerGeneric);
+            target.removeEventListener("pointermove", window_data.eventHandlerPointerGeneric);
+            window_data.eventHandlerPointerEnter = undefined;
+            window_data.eventHandlerPointerLeave = undefined;
+            window_data.eventHandlerPointerGeneric = undefined;
         }
     }, data->canvas_id);
 }
@@ -979,14 +994,26 @@ EM_JS_DEPS(dragndrop, "$writeArrayToMemory");
 static void Emscripten_set_drag_event_callbacks(SDL_WindowData *data)
 {
     MAIN_THREAD_EM_ASM({
-        var target = document.querySelector(UTF8ToString($1));
+        var id = UTF8ToString($1);
+        var target = document.querySelector(id);
         if (target) {
             var data = $0;
 
-            if (typeof(Module['SDL3']) === 'undefined') {
+            if (!Module['SDL3']) {
                 Module['SDL3'] = {};
             }
+
             var SDL3 = Module['SDL3'];
+            if (!SDL3['window_data']) {
+                SDL3['window_data'] = {};
+            }
+
+            var window_datas = SDL3['window_data'];
+            if (!window_datas[id]) {
+                window_datas[id] = {};
+            }
+
+            var window_data = window_datas[id];
 
             var makeDropEventCStruct = function(event) {
                 var ptr = 0;
@@ -1000,15 +1027,23 @@ static void Emscripten_set_drag_event_callbacks(SDL_WindowData *data)
                 return ptr;
             };
 
-            SDL3.eventHandlerDropDragover = function(event) {
+            window_data.eventHandlerDropDragover = function(event) {
                 event.preventDefault();
                 var d = makeDropEventCStruct(event); if (d != 0) { _Emscripten_SendDragEvent(data, d); _SDL_free(d); }
             };
-            target.addEventListener("dragover", SDL3.eventHandlerDropDragover);
+            target.addEventListener("dragover", window_data.eventHandlerDropDragover);
 
-            SDL3.drop_count = 0;
-            FS.mkdir("/tmp/filedrop");
-            SDL3.eventHandlerDropDrop = function(event) {
+            window_data.drop_count = 0;
+            try
+            {
+                FS.mkdir("/tmp/filedrop")
+            }
+            catch(e)
+            {
+                // Throws if the directory already exists
+            }
+
+            window_data.eventHandlerDropDrop = function(event) {
                 event.preventDefault();
                 if (event.dataTransfer.types.includes("text/plain")) {
                     let plain_text = stringToNewUTF8(event.dataTransfer.getData("text/plain"));
@@ -1020,8 +1055,8 @@ static void Emscripten_set_drag_event_callbacks(SDL_WindowData *data)
                         const file_reader = new FileReader();
                         file_reader.readAsArrayBuffer(file);
                         file_reader.onload = function(event) {
-                            const fs_dropdir = `/tmp/filedrop/${SDL3.drop_count}`;
-                            SDL3.drop_count += 1;
+                            const fs_dropdir = `/tmp/filedrop/${window_data.drop_count}`;
+                            window_data.drop_count += 1;
 
                             const fs_filepath = `${fs_dropdir}/${file.name}`;
                             const c_fs_filepath = stringToNewUTF8(fs_filepath);
@@ -1040,14 +1075,14 @@ static void Emscripten_set_drag_event_callbacks(SDL_WindowData *data)
                 }
                 _Emscripten_SendDragCompleteEvent(data);
             };
-            target.addEventListener("drop", SDL3.eventHandlerDropDrop);
+            target.addEventListener("drop", window_data.eventHandlerDropDrop);
 
-            SDL3.eventHandlerDropDragend = function(event) {
+            window_data.eventHandlerDropDragend = function(event) {
                 event.preventDefault();
                 _Emscripten_SendDragCompleteEvent(data);
             };
-            target.addEventListener("dragend", SDL3.eventHandlerDropDragend);
-            target.addEventListener("dragleave", SDL3.eventHandlerDropDragend);
+            target.addEventListener("dragend", window_data.eventHandlerDropDragend);
+            target.addEventListener("dragleave", window_data.eventHandlerDropDragend);
         }
     }, data, data->canvas_id, sizeof (Emscripten_DropEvent));
 }
@@ -1055,14 +1090,29 @@ static void Emscripten_set_drag_event_callbacks(SDL_WindowData *data)
 static void Emscripten_unset_drag_event_callbacks(SDL_WindowData *data)
 {
     MAIN_THREAD_EM_ASM({
-        var target = document.querySelector(UTF8ToString($0));
+        var id = UTF8ToString($0);
+        var target = document.querySelector(id);
         if (target) {
             var SDL3 = Module['SDL3'];
-            target.removeEventListener("dragleave", SDL3.eventHandlerDropDragend);
-            target.removeEventListener("dragend", SDL3.eventHandlerDropDragend);
-            target.removeEventListener("drop", SDL3.eventHandlerDropDrop);
-            SDL3.drop_count = undefined;
+            var window_datas = SDL3['window_data'];
+            var window_data = window_datas[id];
+            target.removeEventListener("dragleave", window_data.eventHandlerDropDragend);
+            target.removeEventListener("dragend", window_data.eventHandlerDropDragend);
+            target.removeEventListener("drop", window_data.eventHandlerDropDrop);
+            window_data.drop_count = undefined;
 
+            function safeRemoveDir(path) {
+                try
+                {
+                    FS.rmdir(path);
+                }
+                catch(e)
+                {
+                    // Throws if directory doesn't exist
+                }
+            }
+
+            const path = "/tmp/filedrop";
             function recursive_remove(dirpath) {
                 FS.readdir(dirpath).forEach((filename) => {
                     const p = `${dirpath}/${filename}`;
@@ -1073,14 +1123,14 @@ static void Emscripten_unset_drag_event_callbacks(SDL_WindowData *data)
                         recursive_remove(p);
                     }
                 });
-                FS.rmdir(dirpath);
-            }("/tmp/filedrop");
+                safeRemoveDir(dirpath);
+            }(path);
 
-            FS.rmdir("/tmp/filedrop");
-            target.removeEventListener("dragover", SDL3.eventHandlerDropDragover);
-            SDL3.eventHandlerDropDragover = undefined;
-            SDL3.eventHandlerDropDrop = undefined;
-            SDL3.eventHandlerDropDragend = undefined;
+            safeRemoveDir(path);
+            target.removeEventListener("dragover", window_data.eventHandlerDropDragover);
+            window_data.eventHandlerDropDragover = undefined;
+            window_data.eventHandlerDropDrop = undefined;
+            window_data.eventHandlerDropDragend = undefined;
         }
     }, data->canvas_id);
 }

--- a/src/video/emscripten/SDL_emscriptenframebuffer.c
+++ b/src/video/emscripten/SDL_emscriptenframebuffer.c
@@ -35,6 +35,10 @@ bool Emscripten_CreateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *wind
 
     // Free the old framebuffer surface
     SDL_WindowData *data = window->internal;
+    if (!data) {
+        // No framebuffer needed for this window
+        return true;
+    }
     surface = data->surface;
     SDL_DestroySurface(surface);
 
@@ -166,9 +170,10 @@ bool Emscripten_UpdateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *wind
 void Emscripten_DestroyWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window)
 {
     SDL_WindowData *data = window->internal;
-
-    SDL_DestroySurface(data->surface);
-    data->surface = NULL;
+    if (data) {
+        SDL_DestroySurface(data->surface);
+        data->surface = NULL;
+    }
 }
 
 #endif // SDL_VIDEO_DRIVER_EMSCRIPTEN

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -856,6 +856,7 @@ static bool Emscripten_SyncWindow(SDL_VideoDevice *_this, SDL_Window *window)
         {
             // querySelector throws if id is not a valid selector
         }
+        return 0;
     }, window_data->canvas_id);
     window->y = MAIN_THREAD_EM_ASM_INT({
         var id = UTF8ToString($0);
@@ -871,6 +872,7 @@ static bool Emscripten_SyncWindow(SDL_VideoDevice *_this, SDL_Window *window)
         {
             // querySelector throws if id is not a valid selector
         }
+        return 0;
     }, window_data->canvas_id);
     return true;
 }

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -139,7 +139,7 @@ EMSCRIPTEN_KEEPALIVE void Emscripten_SendSystemThemeChangedEvent(void)
 static SDL_VideoDevice *Emscripten_CreateDevice(void)
 {
     SDL_VideoDevice *device;
-    SDL_VideoData *vdata;
+    SDL_VideoData *videodata;
 
     // Initialize all variables that we clean on shutdown
     device = (SDL_VideoDevice *)SDL_calloc(1, sizeof(SDL_VideoDevice));

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -714,7 +714,9 @@ static void Emscripten_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
                     canvas.remove();
                 } else {
                     // Since the canvas wasn't created by SDL3, just resize it to zero instead.
-                    // TODO: Is this necessary?
+                    // TODO: Is this necessary or desired. If the goal is to make the window not
+                    // visible, then the better thing to do is:
+                    // canvas.style.display = 'none';
                     canvas.width = 0;
                     canvas.height = 0;
                 }
@@ -781,15 +783,14 @@ static SDL_FullscreenResult Emscripten_SetWindowFullscreen(SDL_VideoDevice *_thi
     }
 }
 
-// Assume the first window that calls SDL_SetWindowTitle is the main window.
-static SDL_Window *mainWindow = NULL;
-
 static void Emscripten_SetWindowTitle(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    if (!mainWindow) {
-        mainWindow = window;
+    SDL_VideoData *videodata = _this->internal;
+    if (!videodata->mainWindow) {
+        // Assume that the first window to have its title set is the main window
+        videodata->mainWindow = window;
     }
-    if (mainWindow == window) {
+    if (videodata->mainWindow == window) {
         emscripten_set_window_title(window->title);
     }
 }

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -569,7 +569,9 @@ static bool Emscripten_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, 
                 // querySelector throws if id isn't a valid selector
             }
             return false;
-        }, selector, x, y, w, h, parent_id, SDL_WINDOWPOS_CENTERED_DISPLAY(x), SDL_WINDOWPOS_CENTERED_DISPLAY(y));
+        }, selector, x, y, w, h, parent_id,
+            SDL_WINDOWPOS_ISCENTERED(x),
+            SDL_WINDOWPOS_ISCENTERED(y));
     }
 
     if (!canvas_exists) {

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -772,9 +772,17 @@ static SDL_FullscreenResult Emscripten_SetWindowFullscreen(SDL_VideoDevice *_thi
     }
 }
 
+// Assume the first window that calls SDL_SetWindowTitle is the main window.
+static SDL_Window *mainWindow = NULL;
+
 static void Emscripten_SetWindowTitle(SDL_VideoDevice *_this, SDL_Window *window)
 {
-    emscripten_set_window_title(window->title);
+    if (!mainWindow) {
+        mainWindow = window;
+    }
+    if (mainWindow == window) {
+        emscripten_set_window_title(window->title);
+    }
 }
 
 static bool Emscripten_SetWindowPosition(SDL_VideoDevice *_this, SDL_Window *window)

--- a/src/video/emscripten/SDL_emscriptenvideo.h
+++ b/src/video/emscripten/SDL_emscriptenvideo.h
@@ -53,6 +53,7 @@ struct SDL_WindowData
 struct SDL_VideoData
 {
    SDL_PropertiesID window_map;
+   SDL_Window *mainWindow;
 };
 
 bool Emscripten_ShouldSetSwapInterval(int interval);

--- a/src/video/emscripten/SDL_emscriptenvideo.h
+++ b/src/video/emscripten/SDL_emscriptenvideo.h
@@ -50,6 +50,11 @@ struct SDL_WindowData
     bool mouse_focus_loss_pending;
 };
 
+struct SDL_VideoData
+{
+   SDL_PropertiesID window_map;
+};
+
 bool Emscripten_ShouldSetSwapInterval(int interval);
 
 #endif // SDL_emscriptenvideo_h_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -370,6 +370,7 @@ add_sdl_test_executable(testlocale NONINTERACTIVE SOURCES testlocale.c)
 add_sdl_test_executable(testlock NO_C90 SOURCES testlock.c)
 add_sdl_test_executable(testrwlock SOURCES testrwlock.c)
 add_sdl_test_executable(testmouse SOURCES testmouse.c)
+add_sdl_test_executable(testmultiwindow SOURCES testmultiwindow.c)
 
 add_sdl_test_executable(testoverlay NEEDS_RESOURCES TESTUTILS SOURCES testoverlay.c)
 add_sdl_test_executable(testplatform NONINTERACTIVE SOURCES testplatform.c)

--- a/test/testmouse.c
+++ b/test/testmouse.c
@@ -332,6 +332,9 @@ int main(int argc, char *argv[])
         return 0;
     }
 
+    /* Window won't show on Emscripten without this */
+    SDL_ShowWindow(window);
+
     /* Main render loop */
 #ifdef SDL_PLATFORM_EMSCRIPTEN
     emscripten_set_main_loop_arg(loop, &loop_data, 0, 1);

--- a/test/testmouse.c
+++ b/test/testmouse.c
@@ -332,9 +332,6 @@ int main(int argc, char *argv[])
         return 0;
     }
 
-    /* Window won't show on Emscripten without this */
-    SDL_ShowWindow(window);
-
     /* Main render loop */
 #ifdef SDL_PLATFORM_EMSCRIPTEN
     emscripten_set_main_loop_arg(loop, &loop_data, 0, 1);

--- a/test/testmultiwindow.c
+++ b/test/testmultiwindow.c
@@ -253,7 +253,8 @@ SDL_AppResult SDL_AppIterate(void *appstate)
   TestState *testState = appstate;
   SDL_Renderer *renderer = testState->state->renderers[0];
   const Uint64 now = SDL_GetTicks();
-  int i, textY;
+  int i;
+  float textY;
 
   for (i = 0; i < MAX_WINDOWS; ++i) {
     if (testState->testWindows[i]) {

--- a/test/testmultiwindow.c
+++ b/test/testmultiwindow.c
@@ -115,7 +115,7 @@ static TestWindow *createTestWindowAtMousePosition(SDLTest_CommonState *state)
 
   props = SDL_CreateProperties();
   SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_TITLE_STRING, title);
-  SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID, title);
+  SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID_STRING, title);
   SDL_SetFloatProperty(props, SDL_PROP_WINDOW_CREATE_X_NUMBER, rect.x);
   SDL_SetFloatProperty(props, SDL_PROP_WINDOW_CREATE_Y_NUMBER, rect.y);
   SDL_SetFloatProperty(props, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, rect.w);

--- a/test/testmultiwindow.c
+++ b/test/testmultiwindow.c
@@ -66,7 +66,7 @@ static void RenderTestWindow(TestWindow *testWindow)
 typedef struct {
   SDLTest_CommonState *state;
   TestWindow *testWindows[MAX_WINDOWS];
-  Uint32 lastCreate;
+  Uint64 lastCreate;
 } TestState;
 
 static void DestroyTestState(TestState *testState)
@@ -116,10 +116,10 @@ static TestWindow *createTestWindowAtMousePosition(SDLTest_CommonState *state)
   props = SDL_CreateProperties();
   SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_TITLE_STRING, title);
   SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID_STRING, title);
-  SDL_SetFloatProperty(props, SDL_PROP_WINDOW_CREATE_X_NUMBER, rect.x);
-  SDL_SetFloatProperty(props, SDL_PROP_WINDOW_CREATE_Y_NUMBER, rect.y);
-  SDL_SetFloatProperty(props, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, rect.w);
-  SDL_SetFloatProperty(props, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, rect.h);
+  SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_X_NUMBER, rect.x);
+  SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_Y_NUMBER, rect.y);
+  SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, rect.w);
+  SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, rect.h);
   SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_FLAGS_NUMBER, state->window_flags);
 
   testWindow = SDL_calloc(1, sizeof(TestWindow));
@@ -220,7 +220,7 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
 SDL_AppResult SDL_AppIterate(void *appstate)
 {
   TestState *testState = appstate;
-  const Uint32 now = SDL_GetTicks();
+  const Uint64 now = SDL_GetTicks();
   int i;
 
   for (i = 0; i < MAX_WINDOWS; ++i) {

--- a/test/testmultiwindow.c
+++ b/test/testmultiwindow.c
@@ -44,6 +44,7 @@ static bool UpdateTestWindow(TestWindow *testWindow, SDL_Rect bounds) {
     testWindow->velocity.x = -VELOCITY;
     ++testWindow->bounces;
   }
+  x = SDL_clamp(x, bounds.x, bounds.x + bounds.w - w);
 
   if (y < bounds.y) {
     testWindow->velocity.y = VELOCITY;
@@ -52,6 +53,7 @@ static bool UpdateTestWindow(TestWindow *testWindow, SDL_Rect bounds) {
     testWindow->velocity.y = -VELOCITY;
     ++testWindow->bounces;
   }
+  y = SDL_clamp(y, bounds.y, bounds.y + bounds.h - h);
 
   SDL_SetWindowPosition(window, x, y);
   return testWindow->bounces < MAX_BOUNCE;

--- a/test/testmultiwindow.c
+++ b/test/testmultiwindow.c
@@ -1,0 +1,266 @@
+/*
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely.
+*/
+
+/* Program that creates a window at the global position of the mouse */
+
+#define SDL_MAIN_USE_CALLBACKS 1
+#include <SDL3/SDL_main.h>
+#include <SDL3/SDL_test.h>
+#include <SDL3/SDL_test_common.h>
+
+typedef struct {
+  SDL_Window *window;
+  SDL_Renderer *renderer;
+  SDL_Color color;
+} TestWindow;
+
+static void DestroyTestWindow(TestWindow *testWindow)
+{
+  SDL_DestroyRenderer(testWindow->renderer);
+  SDL_DestroyWindow(testWindow->window);
+}
+
+static void RenderTestWindow(TestWindow *testWindow)
+{
+  SDL_Renderer *renderer = testWindow->renderer;
+
+  if (renderer) {
+    SDL_SetRenderDrawColor(renderer,
+      testWindow->color.r,
+      testWindow->color.g,
+      testWindow->color.b,
+      testWindow->color.a);
+    SDL_RenderClear(renderer);
+    SDL_RenderPresent(renderer);
+  }
+}
+
+#define MAX_WINDOWS 8
+
+typedef struct {
+  SDLTest_CommonState *state;
+  TestWindow *testWindows[MAX_WINDOWS];
+  Uint32 lastCreate;
+} TestState;
+
+static void DestroyTestState(TestState *testState)
+{
+  int i;
+  SDLTest_CommonDestroyState(testState->state);
+  for (i = 0; i < MAX_WINDOWS; ++i) {
+    if (testState->testWindows[i]) {
+      DestroyTestWindow(testState->testWindows[i]);
+    }
+  }
+}
+
+static bool TestStateDone(TestState *testState)
+{
+#ifdef SDL_PLATFORM_EMSCRIPTEN
+  (void)testState;
+  return false;
+#else
+  int i;
+
+  for (i = 0; i < MAX_WINDOWS; ++i) {
+    if(testState->testWindows[i]) {
+      return false;
+    }
+  }
+
+  return true;
+#endif
+}
+
+static TestWindow *createTestWindowAtMousePosition(SDLTest_CommonState *state)
+{
+  static int windowId = 0;
+
+  TestWindow *testWindow;
+
+  char title[1024];
+  SDL_Rect rect;
+  SDL_Rect bounds;
+  SDL_PropertiesID props;
+  float x, y;
+
+  SDL_GetDisplayUsableBounds(state->displayID, &bounds);
+
+  SDL_snprintf(title, SDL_arraysize(title), "#window%d", ++windowId);
+
+  SDL_GetGlobalMouseState(&x, &y);
+  rect.x = (int)SDL_ceilf(x);
+  rect.y = (int)SDL_ceilf(y);
+
+  rect.w = state->window_w;
+  rect.h = state->window_h;
+  if (state->auto_scale_content) {
+    float scale = SDL_GetDisplayContentScale(state->displayID);
+    rect.w = (int)SDL_ceilf(rect.w * scale);
+    rect.h = (int)SDL_ceilf(rect.h * scale);
+  }
+
+  /* Don't make a window if it wouldn't be visible in the display */
+  if (!SDL_HasRectIntersection(&rect, &bounds)) {
+    return NULL;
+  }
+
+  props = SDL_CreateProperties();
+  SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_TITLE_STRING, title);
+  SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID, title);
+  SDL_SetFloatProperty(props, SDL_PROP_WINDOW_CREATE_X_NUMBER, rect.x);
+  SDL_SetFloatProperty(props, SDL_PROP_WINDOW_CREATE_Y_NUMBER, rect.y);
+  SDL_SetFloatProperty(props, SDL_PROP_WINDOW_CREATE_WIDTH_NUMBER, rect.w);
+  SDL_SetFloatProperty(props, SDL_PROP_WINDOW_CREATE_HEIGHT_NUMBER, rect.h);
+  SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_FLAGS_NUMBER, state->window_flags);
+
+  testWindow = SDL_calloc(1, sizeof(TestWindow));
+  if (!testWindow) {
+    return NULL;
+  }
+  testWindow->window = SDL_CreateWindowWithProperties(props);
+  SDL_DestroyProperties(props);
+  if (!testWindow->window) {
+      SDL_Log("Couldn't create window: %s",SDL_GetError());
+      return NULL;
+  }
+  if (state->window_minW || state->window_minH) {
+      SDL_SetWindowMinimumSize(testWindow->window, state->window_minW, state->window_minH);
+  }
+  if (state->window_maxW || state->window_maxH) {
+      SDL_SetWindowMaximumSize(testWindow->window, state->window_maxW, state->window_maxH);
+  }
+  if (state->window_min_aspect != 0.f || state->window_max_aspect != 0.f) {
+      SDL_SetWindowAspectRatio(testWindow->window, state->window_min_aspect, state->window_max_aspect);
+  }
+  if (!SDL_RectEmpty(&state->confine)) {
+    SDL_SetWindowMouseRect(testWindow->window, &state->confine);
+  }
+
+  testWindow->renderer = SDL_CreateRenderer(testWindow->window, state->renderdriver);
+  if (!testWindow->renderer) {
+      SDL_Log("Couldn't create renderer: %s", SDL_GetError());
+      return NULL;
+  }
+  if (state->logical_w == 0 || state->logical_h == 0) {
+      state->logical_w = state->window_w;
+      state->logical_h = state->window_h;
+  }
+  if (state->render_vsync) {
+      SDL_SetRenderVSync(testWindow->renderer, state->render_vsync);
+  }
+  if (!SDL_SetRenderLogicalPresentation(testWindow->renderer, state->logical_w, state->logical_h, state->logical_presentation)) {
+      SDL_Log("Couldn't set logical presentation: %s", SDL_GetError());
+      return NULL;
+  }
+  if (state->scale != 0.0f) {
+      SDL_SetRenderScale(testWindow->renderer, state->scale, state->scale);
+  }
+
+  testWindow->color.r = SDL_rand(256);
+  testWindow->color.g = SDL_rand(256);
+  testWindow->color.b = SDL_rand(256);
+  testWindow->color.a = 255;
+
+  SDL_ShowWindow(testWindow->window);
+  return testWindow;
+}
+
+SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
+{
+  TestState *testState = SDL_calloc(1, sizeof(TestState));
+  if (!testState) {
+    return SDL_APP_FAILURE;
+  }
+
+  testState->state = SDLTest_CommonCreateState(argv, SDL_INIT_VIDEO);
+  if (!testState->state) {
+    return SDL_APP_FAILURE;
+  }
+
+  testState->state->num_windows = 0;
+
+  if (!SDLTest_CommonInit(testState->state)) {
+    return SDL_APP_FAILURE;
+  }
+
+  testState->testWindows[0] = createTestWindowAtMousePosition(testState->state);
+  if (!testState->testWindows[0]) {
+    return SDL_APP_FAILURE;
+  }
+  testState->lastCreate = SDL_GetTicks();
+
+  *appstate = testState;
+  return SDL_APP_CONTINUE;
+}
+
+SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
+{
+  TestState *testState = appstate;
+  SDL_Window *targetWindow = SDL_GetWindowFromEvent(event);
+  int i;
+
+  switch (event->type) {
+    case SDL_EVENT_QUIT:
+      return SDL_APP_SUCCESS;
+    case SDL_EVENT_WINDOW_CLOSE_REQUESTED:
+    case SDL_EVENT_WINDOW_DESTROYED:
+    case SDL_EVENT_MOUSE_BUTTON_DOWN:
+      if (targetWindow) {
+        for (i = 0; i < MAX_WINDOWS; ++i) {
+          if (testState->testWindows[i] && testState->testWindows[i]->window == targetWindow) {
+            DestroyTestWindow(testState->testWindows[i]);
+            SDL_zero(testState->testWindows[i]);
+            if (TestStateDone(testState)) {
+              return SDL_APP_SUCCESS;
+            }
+          }
+        }
+      }
+      break;
+    default:
+        break;
+  }
+
+  return SDLTest_CommonEventMainCallbacks(testState->state, event);
+}
+
+SDL_AppResult SDL_AppIterate(void *appstate)
+{
+  TestState *testState = appstate;
+  const Uint32 now = SDL_GetTicks();
+  int i;
+
+  for (i = 0; i < MAX_WINDOWS; ++i) {
+    if (testState->testWindows[i]) {
+      RenderTestWindow(testState->testWindows[i]);
+    }
+  }
+
+  if (now - testState->lastCreate > 1000) {
+    for (i = 0; i < MAX_WINDOWS; ++i) {
+      if (!testState->testWindows[i]) {
+        testState->testWindows[i] = createTestWindowAtMousePosition(testState->state);
+        break;
+      }
+    }
+    testState->lastCreate = now;
+  }
+  return SDL_APP_CONTINUE;
+}
+
+void SDL_AppQuit(void *appstate, SDL_AppResult result)
+{
+  TestState *testState = appstate;
+
+  if (testState) {
+    DestroyTestState(testState);
+  }
+}

--- a/test/testmultiwindow.c
+++ b/test/testmultiwindow.c
@@ -27,17 +27,36 @@ static void DestroyTestWindow(TestWindow *testWindow)
   SDL_DestroyWindow(testWindow->window);
 }
 
+static bool ColorIsBright(SDL_Color color)
+{
+  return (color.r * 0.2126 + color.g * 0.7152 + color.b * 0.0722) > 128.0;
+}
+
 static void RenderTestWindow(TestWindow *testWindow)
 {
+  SDL_Window *window = testWindow->window;
   SDL_Renderer *renderer = testWindow->renderer;
+  SDL_Color color = testWindow->color;
 
   if (renderer) {
-    SDL_SetRenderDrawColor(renderer,
-      testWindow->color.r,
-      testWindow->color.g,
-      testWindow->color.b,
-      testWindow->color.a);
+    SDL_SetRenderDrawColor(renderer, color.r, color.g, color.b, color.a);
     SDL_RenderClear(renderer);
+
+    if (ColorIsBright(color)) {
+      color.r = 0;
+      color.g = 0;
+      color.b = 0;
+    }
+    else {
+      color.r = 255;
+      color.g = 255;
+      color.b = 255;
+    }
+    SDL_SetRenderDrawColor(renderer, color.r, color.g, color.b, color.a);
+
+    int x, y;
+    SDL_GetWindowPosition(window, &x, &y);
+    SDL_RenderDebugTextFormat(renderer, 0, 0, "Global Window Position: %d %d", x, y);
     SDL_RenderPresent(renderer);
   }
 }

--- a/test/testpopup.c
+++ b/test/testpopup.c
@@ -196,6 +196,7 @@ static void loop(void)
     if (SDL_GetTicks() > tooltip_timer) {
         if (!tooltip.win) {
             create_popup(&tooltip, false);
+            tooltip_timer = SDL_GetTicks();
         }
     }
 
@@ -210,6 +211,10 @@ static void loop(void)
     for (i = 0; i < num_menus; ++i) {
         const SDL_Color *c = &colors[i % SDL_arraysize(colors)];
         SDL_Renderer *renderer = menus[i].renderer;
+
+#ifdef SDL_PLATFORM_EMSCRIPTEN
+        SDL_SyncWindow(menus[i].win);
+#endif
 
         SDL_SetRenderDrawColor(renderer, c->r, c->g, c->b, c->a);
         SDL_RenderClear(renderer);
@@ -241,6 +246,10 @@ static void loop(void)
 int main(int argc, char *argv[])
 {
     int i;
+
+#ifdef SDL_PLATFORM_EMSCRIPTEN
+    SDL_SetHint(SDL_HINT_VIDEO_SYNC_WINDOW_OPERATIONS, "1");
+#endif
 
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, SDL_INIT_VIDEO);

--- a/test/testscale.c
+++ b/test/testscale.c
@@ -132,6 +132,11 @@ int main(int argc, char *argv[])
             quit(2);
         }
         SDL_GetTextureSize(drawstate->sprite, &drawstate->sprite_rect.w, &drawstate->sprite_rect.h);
+
+        /* Ensure each window will have a different scale to make each window have a unique display */
+        drawstate->sprite_rect.w *= i * 2.f;
+        drawstate->sprite_rect.h *= i * 2.f;
+
         SDL_SetTextureScaleMode(drawstate->sprite, SDL_SCALEMODE_PIXELART);
         drawstate->scale_direction = 1;
     }


### PR DESCRIPTION
- Updated the software renderer to store each canvas and context in a separate object
- Updated drag and pointer event handlers to store each event listener function in a separate object
- Added hash table to store which canvas ID has been mapped to an `SDL_Window`
- Updated `Emscripten_GLES_MakeCurrent` to point `Module['canvas']` to the canvas of the renderer's window that is currently being drawn to
- Allow SDL tests applications to show multiple windows on Emscripten builds
- Detect if the canvas doesn't already exist in the DOM and create and manage the canvas if it doesn't
- Add support for `SDL_ShowWindow`, `SDL_HideWindow`, and `SDL_SetWindowPosition` for Emscripten windows

Closes #12512