### PR TITLE
emscripten: Fix undefined behavior in opengles2 renderer

### DIFF
--- a/src/render/opengles2/SDL_render_gles2.c
+++ b/src/render/opengles2/SDL_render_gles2.c
@@ -1022,8 +1022,8 @@ static bool SetDrawState(GLES2_RenderData *data, const SDL_RenderCommand *cmd, c
     }
 
     if (texture) {
-        SDL_Vertex *verts = (SDL_Vertex *)(((Uint8 *)vertices) + cmd->data.draw.first);
-        data->glVertexAttribPointer(GLES2_ATTRIBUTE_TEXCOORD, 2, GL_FLOAT, GL_FALSE, stride, (const GLvoid *)&verts->tex_coord);
+        uintptr_t base = (uintptr_t)vertices + cmd->data.draw.first; // address of first vertex, or base offset when using VBOs.
+        data->glVertexAttribPointer(GLES2_ATTRIBUTE_TEXCOORD, 2, GL_FLOAT, GL_FALSE, stride, (const GLvoid *)(base + offsetof(SDL_Vertex, tex_coord)));
     }
 
     SDL_Colorspace colorspace = texture ? texture->colorspace : SDL_COLORSPACE_SRGB;
@@ -1057,9 +1057,9 @@ static bool SetDrawState(GLES2_RenderData *data, const SDL_RenderCommand *cmd, c
 
     // all drawing commands use this
     {
-        SDL_VertexSolid *verts = (SDL_VertexSolid *)(((Uint8 *)vertices) + cmd->data.draw.first);
-        data->glVertexAttribPointer(GLES2_ATTRIBUTE_POSITION, 2, GL_FLOAT, GL_FALSE, stride, (const GLvoid *)&verts->position);
-        data->glVertexAttribPointer(GLES2_ATTRIBUTE_COLOR, 4, GL_FLOAT, GL_TRUE /* Normalized */, stride, (const GLvoid *)&verts->color);
+        uintptr_t base = (uintptr_t)vertices + cmd->data.draw.first; // address of first vertex, or base offset when using VBOs.
+        data->glVertexAttribPointer(GLES2_ATTRIBUTE_POSITION, 2, GL_FLOAT, GL_FALSE, stride, (const GLvoid *)(base + offsetof(SDL_VertexSolid, position)));
+        data->glVertexAttribPointer(GLES2_ATTRIBUTE_COLOR, 4, GL_FLOAT, GL_TRUE /* Normalized */, stride, (const GLvoid *)(base + offsetof(SDL_VertexSolid, color)));
     }
 
     return true;
@@ -1375,7 +1375,8 @@ static bool GLES2_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd
     if (data->current_vertex_buffer >= SDL_arraysize(data->vertex_buffers)) {
         data->current_vertex_buffer = 0;
     }
-    vertices = NULL; // attrib pointers will be offsets into the VBO.
+    // attrib pointers will be offsets into the VBO.
+    vertices = (void *)(uintptr_t)0; // must be the exact value 0, not NULL (the representation of NULL is not guaranteed to be 0).
 #endif
 
     while (cmd) {


### PR DESCRIPTION
Discovered this while building SDL3 and the Snake example for Emscripten with [UBSan](https://emscripten.org/docs/debugging/Sanitizers.html). With the sanitizer enabled, running the example logs:

```
<omitted>/src/render/opengles2/SDL_render_gles2.c:1024:74: runtime error: subtraction of unsigned offset from 0x00000000 overflowed to 0x00000000
<omitted>/src/render/opengles2/SDL_render_gles2.c:1025:118: runtime error: member access within null pointer of type 'SDL_VertexSolid' (aka 'struct SDL_VertexSolid')
<omitted>/src/render/opengles2/SDL_render_gles2.c:1026:131: runtime error: member access within null pointer of type 'SDL_VertexSolid' (aka 'struct SDL_VertexSolid')
```

The first error happens because the program is adding an offset to a null pointer, which is UB.
The second and third happen because expressions like `&foo->bar` invoke UB when `foo` is a null pointer.

These only occur on Emscripten, because on Emscripten the renderer uses VBOs instead of client-side arrays and reassigns `vertices` to 0 after uploading the data.

By rewriting relevant code to use `uintptr_t` and `offsetof` we get the same results but without invoking UB.

From quickly skimming over `SDL_render_gles2.c` in the SDL2 branch it looks like the affected code is present there as well, so if merged this could probably be backported to SDL2 as well.