### PR TITLE
GPU: Request sampleRateShading feature on Vulkan

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -222,6 +222,7 @@
  * - `depthClamp`
  * - `shaderClipDistance`
  * - `drawIndirectFirstInstance`
+ * - `sampleRateShading`
  *
  * **D3D12:** Supported on Windows 10 or newer, Xbox One (GDK), and Xbox
  * Series X|S (GDK). Requires a GPU that supports DirectX 12 Feature Level

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -11126,7 +11126,8 @@ static Uint8 VULKAN_INTERNAL_IsDeviceSuitable(
         !deviceFeatures.imageCubeArray ||
         !deviceFeatures.depthClamp ||
         !deviceFeatures.shaderClipDistance ||
-        !deviceFeatures.drawIndirectFirstInstance) {
+        !deviceFeatures.drawIndirectFirstInstance ||
+        !deviceFeatures.sampleRateShading) {
         return 0;
     }
 
@@ -11373,6 +11374,7 @@ static Uint8 VULKAN_INTERNAL_CreateLogicalDevice(
     desiredDeviceFeatures.depthClamp = VK_TRUE;
     desiredDeviceFeatures.shaderClipDistance = VK_TRUE;
     desiredDeviceFeatures.drawIndirectFirstInstance = VK_TRUE;
+    desiredDeviceFeatures.sampleRateShading = VK_TRUE;
 
     if (haveDeviceFeatures.fillModeNonSolid) {
         desiredDeviceFeatures.fillModeNonSolid = VK_TRUE;


### PR DESCRIPTION
Enable the `sampleRateShading` feature on Vulkan to allow running fragment shaders per-sample when using MSAA (i.e. effectively doing SSAA).

## Description
As support for this feature is nearly universal (99.1% in GPU info database), having it be mandatory shouldn't cause problems. Additionally, DirectX and Metal backends already provide it without needing any extra flags, so this seems like an easy addition bringing Vulkan to parity.

To activate per-sample shading you need to reference `gl_SampleID`/`SV_SampleIndex` in your fragment shader (correction: it seems that using a `sample` interpolation qualifier on your inputs is normally sufficient); this is consistent across all (public) GPU backends. Vulkan also allows to activate per-sample shading during pipeline creation, which would be nice to expose, but this is not available in other backends (MoltenVK implements it by injecting a dummy variable into a shader as part of transpilation).

## Existing Issue(s)
Fixes #12535.