### PR TITLE
proguard rules for native methods

### DIFF
--- a/android-project/app/proguard-rules.pro
+++ b/android-project/app/proguard-rules.pro
@@ -36,7 +36,6 @@
     int messageboxShowMessageBox(int, java.lang.String, java.lang.String, int[], int[], java.lang.String[], int[]);
     void minimizeWindow();
     boolean openURL(java.lang.String);
-    void onNativePen(int, int, int , float , float , float);
     void requestPermission(java.lang.String, int);
     boolean showToast(java.lang.String, int, int, int, int);
     boolean sendMessage(int, int);

--- a/android-project/app/src/main/java/org/libsdl/app/SDLAudioManager.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLAudioManager.java
@@ -26,14 +26,14 @@ class SDLAudioManager {
                 @Override
                 public void onAudioDevicesAdded(AudioDeviceInfo[] addedDevices) {
                     for (AudioDeviceInfo deviceInfo : addedDevices) {
-                        addAudioDevice(deviceInfo.isSink(), deviceInfo.getProductName().toString(), deviceInfo.getId());
+                        nativeAddAudioDevice(deviceInfo.isSink(), deviceInfo.getProductName().toString(), deviceInfo.getId());
                     }
                 }
 
                 @Override
                 public void onAudioDevicesRemoved(AudioDeviceInfo[] removedDevices) {
                     for (AudioDeviceInfo deviceInfo : removedDevices) {
-                        removeAudioDevice(deviceInfo.isSink(), deviceInfo.getId());
+                        nativeRemoveAudioDevice(deviceInfo.isSink(), deviceInfo.getId());
                     }
                 }
             };
@@ -82,10 +82,10 @@ class SDLAudioManager {
                 if (dev.getType() == AudioDeviceInfo.TYPE_TELEPHONY) {
                     continue;  // Device cannot be opened
                 }
-                addAudioDevice(dev.isSink(), dev.getProductName().toString(), dev.getId());
+                nativeAddAudioDevice(dev.isSink(), dev.getProductName().toString(), dev.getId());
             }
             for (AudioDeviceInfo dev : audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS)) {
-                addAudioDevice(dev.isSink(), dev.getProductName().toString(), dev.getId());
+                nativeAddAudioDevice(dev.isSink(), dev.getProductName().toString(), dev.getId());
             }
             audioManager.registerAudioDeviceCallback(mAudioDeviceCallback, null);
         }
@@ -119,8 +119,8 @@ class SDLAudioManager {
 
     static native int nativeSetupJNI();
 
-    static native void removeAudioDevice(boolean recording, int deviceId);
+    static native void nativeRemoveAudioDevice(boolean recording, int deviceId);
 
-    static native void addAudioDevice(boolean recording, String name, int deviceId);
+    static native void nativeAddAudioDevice(boolean recording, String name, int deviceId);
 
 }


### PR DESCRIPTION
remove un-needed proguard rule: onNativePen()
rename audio native function to have prefix "native" in their name