### PR TITLE
SDL_ClaimWindowForGPUDevice() should fail for transparent windows

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -2653,8 +2653,11 @@ bool SDL_ClaimWindowForGPUDevice(
 {
     CHECK_DEVICE_MAGIC(device, false);
     if (window == NULL) {
-        SDL_InvalidParamError("window");
-        return false;
+        return SDL_InvalidParamError("window");
+    }
+
+    if ((window->flags & SDL_WINDOW_TRANSPARENT) != 0) {
+        return SDL_SetError("The GPU API doesn't support transparent windows");
     }
 
     return device->ClaimWindow(


### PR DESCRIPTION
The GPU API doesn't currently support transparent windows (transparent swapchain effects doesn't seem possible on D3D12) so we should explicitly fail so users don't expect transparency and then not get it.

Fixes https://github.com/libsdl-org/SDL/issues/12410
