### PR TITLE
WIN_SetWindowProgressValue(): Fix value clamp

### DIFF
--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -2298,7 +2298,7 @@ bool WIN_SetWindowProgressValue(SDL_VideoDevice *_this, SDL_Window *window, floa
         return false;
     };
 
-    SDL_clamp(value, 0.0f, 1.f);
+    value = SDL_clamp(value, 0.0f, 1.f);
     HRESULT ret = taskbar_list->lpVtbl->SetProgressValue(taskbar_list, window->internal->hwnd, (ULONGLONG)(value * 10000.f), 10000);
     if (FAILED(ret)) {
         return WIN_SetErrorFromHRESULT("ITaskbarList3::SetProgressValue()", ret);


### PR DESCRIPTION
Set `value` when calling `SDL_clamp()`.

Progress bar PR: https://github.com/libsdl-org/SDL/pull/12530