### PR TITLE
Additions to progress bar comments

### DIFF
--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -2825,6 +2825,7 @@ extern SDL_DECLSPEC bool SDLCALL SDL_FlashWindow(SDL_Window *window, SDL_FlashOp
  *
  * \param window the window whose progress state is to be modified.
  * \param state the progress state.
+ *              `SDL_PROGRESS_STATE_NONE` stops displaying the progress bar.
  * \returns true on success or false on failure; call SDL_GetError() for more
  *          information.
  *
@@ -2837,8 +2838,12 @@ extern SDL_DECLSPEC bool SDLCALL SDL_SetWindowProgressState(SDL_Window *window, 
 /**
  * Sets the value of the progress bar for the given window’s taskbar icon.
  *
+ * If the state is `SDL_PROGRESS_STATE_NONE` or `SDL_PROGRESS_STATE_INDETERMINATE`,
+ * it gets changed to `SDL_PROGRESS_STATE_NORMAL`.
+ *
  * \param window the window whose progress value is to be modified.
  * \param value the progress value (0.0f - start, 1.0f - end).
+ *              If the value is outside the valid range, it gets clamped.
  * \returns true on success or false on failure; call SDL_GetError() for more
  *          information.
  *


### PR DESCRIPTION
From https://github.com/libsdl-org/SDL/pull/12616

Add comments to:

`SDL_SetWindowProgressState()`:
    - `SDL_PROGRESS_STATE_NONE` disables the progress bar.

`SDL_SetWindowProgressValue()`:
    - Parameter `value` gets clamped.
    - If the state is `SDL_PROGRESS_STATE_NONE` or `SDL_PROGRESS_STATE_INDETERMINATE`, it gets changed to `SDL_PROGRESS_STATE_NORMAL`.