### PR TITLE
SDL_SetWindowProgressValue(): Move value clamp from `WIN_SetWindowProgressValue()` to `SDL_SetWindowProgressValue()`

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -3938,6 +3938,8 @@ bool SDL_SetWindowProgressValue(SDL_Window *window, float value)
     CHECK_WINDOW_MAGIC(window, false);
     CHECK_WINDOW_NOT_POPUP(window, false);
 
+    value = SDL_clamp(value, 0.0f, 1.f);
+
     if (_this->SetWindowProgressValue) {
         return _this->SetWindowProgressValue(_this, window, value);
     }

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -2298,7 +2298,6 @@ bool WIN_SetWindowProgressValue(SDL_VideoDevice *_this, SDL_Window *window, floa
         return false;
     };
 
-    value = SDL_clamp(value, 0.0f, 1.f);
     HRESULT ret = taskbar_list->lpVtbl->SetProgressValue(taskbar_list, window->internal->hwnd, (ULONGLONG)(value * 10000.f), 10000);
     if (FAILED(ret)) {
         return WIN_SetErrorFromHRESULT("ITaskbarList3::SetProgressValue()", ret);


### PR DESCRIPTION
From https://github.com/libsdl-org/SDL/pull/12616

- Move `value` clamp from `WIN_SetWindowProgressValue()` to `SDL_SetWindowProgressValue()`, so it doesn't need to be implemented for every platform.