### PR TITLE
SDL_SetWindowProgressState(): Add parameter validation check for `state`

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -3926,6 +3926,10 @@ bool SDL_SetWindowProgressState(SDL_Window *window, SDL_ProgressState state)
     CHECK_WINDOW_MAGIC(window, false);
     CHECK_WINDOW_NOT_POPUP(window, false);
 
+    if (state < SDL_PROGRESS_STATE_NONE || state > SDL_PROGRESS_STATE_ERROR) {
+        return SDL_InvalidParamError("state");
+    }
+
     if (_this->SetWindowProgressState) {
         return _this->SetWindowProgressState(_this, window, state);
     }


### PR DESCRIPTION
From https://github.com/libsdl-org/SDL/pull/12616

`SDL_SetWindowProgressState()`:
    - Check if `state` is a valid parameter, return `SDL_InvalidParamError()`.

This adds a check if the `state` argument even exists before calling the platform specific function(where `SDL_Unsupported()` can be returned if a specific state is not supported on a platform)
