### PR TITLE
WIN_SetWindowProgressState(): Unsupported parameter error message

### DIFF
--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -2276,7 +2276,7 @@ bool WIN_SetWindowProgressState(SDL_VideoDevice *_this, SDL_Window *window, SDL_
         tbpFlags = TBPF_ERROR;
         break;
     default:
-        return SDL_Unsupported();
+        return SDL_SetError("Parameter 'state' is not supported");
     }
 
     HRESULT ret = taskbar_list->lpVtbl->SetProgressState(taskbar_list, window->internal->hwnd, tbpFlags);


### PR DESCRIPTION
Currently, if `state` is a valid/existing parameter, but it not supported on a platform(in this case Windows) the error message is: "That operation is not supported" (from SDL_Unsupported())

This could be misinterpreted as: "This function is not supported"

This commit changes the function call `SDL_Unsupported()` into `SDL_SetError("Parameter 'state' is not supported")`.

A mixture of `SDL_InvalidParamError("state")` and `SDL_Unsupported()`.