### PR TITLE
Android/OpenSLES: prevent lots or error log in background

### DIFF
--- a/src/audio/openslES/SDL_openslES.c
+++ b/src/audio/openslES/SDL_openslES.c
@@ -585,7 +585,7 @@ static bool OPENSLES_CreatePCMPlayer(SDL_AudioDevice *device)
     struct SDL_PrivateAudioData *audiodata = device->hidden;
 
     // Create the audio buffer semaphore
-    audiodata->playsem = SDL_CreateSemaphore(NUM_BUFFERS - 1);
+    audiodata->playsem = SDL_CreateSemaphore(NUM_BUFFERS);
     if (!audiodata->playsem) {
         LOGE("cannot create Semaphore!");
         goto failed;


### PR DESCRIPTION
Android/OpenSLES, The while loop that handles audio playback sequence has changed from
PlayDevice(), WaitDevice()
to
WaitDevice(), PlayDevice()

( https://github.com/libsdl-org/SDL/commit/905c4fff5bb88b200701ca8ff3a8d4dff802182d )
SDL_audio.c:

```
                    current_audio.impl.PlayDevice(device);
                    current_audio.impl.WaitDevice(device);
```
to

```
    do {
        current_audio.impl.WaitDevice(device);
    } while (SDL_OutputAudioThreadIterate(device));

```
(see also https://github.com/libsdl-org/SDL_mixer/issues/684)





