### PR TITLE
Document SDL_malloc alignment guarantees

### DIFF
--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -1299,8 +1299,11 @@ extern "C" {
  *
  * If `size` is 0, it will be set to 1.
  *
- * If you want to allocate memory aligned to a specific alignment, consider
- * using SDL_aligned_alloc().
+ * If the allocation is successful, the returned pointer is guaranteed to be
+ * aligned to either the *fundamental alignment* (`alignof(max_align_t)` in
+ * C11 and later) or `2 * sizeof(void *)`, whichever is smaller. Use
+ * SDL_aligned_alloc() if you need to allocate memory aligned to an alignment
+ * greater than this guarantee.
  *
  * \param size the size to allocate.
  * \returns a pointer to the allocated memory, or NULL if allocation failed.
@@ -1322,6 +1325,10 @@ extern SDL_DECLSPEC SDL_MALLOC void * SDLCALL SDL_malloc(size_t size);
  * The memory returned by this function must be freed with SDL_free().
  *
  * If either of `nmemb` or `size` is 0, they will both be set to 1.
+ *
+ * If the allocation is successful, the returned pointer is guaranteed to be
+ * aligned to either the *fundamental alignment* (`alignof(max_align_t)` in
+ * C11 and later) or `2 * sizeof(void *)`, whichever is smaller.
  *
  * \param nmemb the number of elements in the array.
  * \param size the size of each element of the array.
@@ -1356,6 +1363,11 @@ extern SDL_DECLSPEC SDL_MALLOC SDL_ALLOC_SIZE2(1, 2) void * SDLCALL SDL_calloc(s
  *   and cannot be dereferenced anymore.
  * - If it returns NULL (indicating failure), then `mem` will remain valid and
  *   must still be freed with SDL_free().
+ *
+ * If the allocation is successfully resized, the returned pointer is
+ * guaranteed to be aligned to either the *fundamental alignment*
+ * (`alignof(max_align_t)` in C11 and later) or `2 * sizeof(void *)`,
+ * whichever is smaller.
  *
  * \param mem a pointer to allocated memory to reallocate, or NULL.
  * \param size the new size of the memory.


### PR DESCRIPTION
Closes #11961

`SDL_malloc()` is either implemented via `malloc()`, which implies the guarantees specified by the C runtime and by extension the C standard, or `dlmalloc()`, which aligns to 16 bytes on Apple OSes and `2 * sizeof(void *)` otherwise (unless `MALLOC_ALIGNMENT` is overridden, which isn't the case for SDL).