### PR TITLE
x11: Send the _XWAYLAND_MAY_GRAB_KEYBOARD message when grabbing the k…

### DIFF
--- a/docs/README-wayland.md
+++ b/docs/README-wayland.md
@@ -59,6 +59,10 @@ encounter limitations or behavior that is different from other windowing systems
   `SDL_APP_ID` hint string, the desktop entry file name should match the application ID. For example, if your
   application ID is set to `org.my_org.sdl_app`, the desktop entry file should be named `org.my_org.sdl_app.desktop`.
 
+### Keyboard grabs don't work when running under XWayland
+
+- One GNOME based desktops, the dconf setting `org/gnome/mutter/wayland/xwayland-allow-grabs` must be enabled.
+
 ## Using custom Wayland windowing protocols with SDL windows
 
 Under normal operation, an `SDL_Window` corresponds to an XDG toplevel window, which provides a standard desktop window.


### PR DESCRIPTION
…eyboard

GNOME requires this to allow keyboard grabs on XWayland. Otherwise, XGrabKeyboard will still report success, but shortcuts won't be inhibited.

See https://gitlab.gnome.org/GNOME/mutter/-/commit/5f132f39750f684c3732b4346dec810cd218d609

Fixes #12227
