### PR TITLE
Proggress bar functions: Return false/INVALID/-1.0f on unsupported platforms.

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -3930,21 +3930,24 @@ bool SDL_SetWindowProgressState(SDL_Window *window, SDL_ProgressState state)
         return SDL_InvalidParamError("state");
     }
 
-    window->progress_state = state;
-
-    if (_this->ApplyWindowProgress) {
-        if (!_this->ApplyWindowProgress(_this, window)) {
-            return false;
-        }
+    if (!_this->ApplyWindowProgress) {
+        return SDL_Unsupported();
     }
 
-    return true;
+    window->progress_state = state;
+
+    return _this->ApplyWindowProgress(_this, window);
 }
 
 SDL_ProgressState SDL_GetWindowProgressState(SDL_Window *window)
 {
     CHECK_WINDOW_MAGIC(window, SDL_PROGRESS_STATE_INVALID);
     CHECK_WINDOW_NOT_POPUP(window, SDL_PROGRESS_STATE_INVALID);
+
+    if (!_this->ApplyWindowProgress) {
+        SDL_Unsupported();
+        return SDL_PROGRESS_STATE_INVALID;
+    }
 
     return window->progress_state;
 }
@@ -3954,23 +3957,24 @@ bool SDL_SetWindowProgressValue(SDL_Window *window, float value)
     CHECK_WINDOW_MAGIC(window, false);
     CHECK_WINDOW_NOT_POPUP(window, false);
 
-    value = SDL_clamp(value, 0.0f, 1.f);
-
-    window->progress_value = value;
-
-    if (_this->ApplyWindowProgress) {
-        if (!_this->ApplyWindowProgress(_this, window)) {
-            return false;
-        }
+    if (!_this->ApplyWindowProgress) {
+        return SDL_Unsupported();
     }
 
-    return true;
+    window->progress_value = SDL_clamp(value, 0.0f, 1.0f);
+
+    return _this->ApplyWindowProgress(_this, window);
 }
 
 float SDL_GetWindowProgressValue(SDL_Window *window)
 {
     CHECK_WINDOW_MAGIC(window, -1.0f);
     CHECK_WINDOW_NOT_POPUP(window, -1.0f);
+
+    if (!_this->ApplyWindowProgress) {
+        SDL_Unsupported();
+        return -1.0f;
+    }
 
     return window->progress_value;
 }


### PR DESCRIPTION
Currently the progress bar functions always return true or a valid value on unsupported platforms.

This commit adds a check for `ApplyWindowProgress` in all functions and lets unsupported platforms fail graciously.