### PR TITLE
wayland: Expose wl_output objects on video displays

### DIFF
--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -631,6 +631,10 @@ extern SDL_DECLSPEC SDL_DisplayID SDLCALL SDL_GetPrimaryDisplay(void);
  *   responsible for any coordinate transformations needed to conform to the
  *   requested display orientation.
  *
+ * On Wayland:
+ *
+ * - `SDL_PROP_DISPLAY_WAYLAND_WL_OUTPUT_POINTER`: the wl_output associated with the display
+ *
  * \param displayID the instance ID of the display to query.
  * \returns a valid property ID on success or 0 on failure; call
  *          SDL_GetError() for more information.
@@ -643,6 +647,7 @@ extern SDL_DECLSPEC SDL_PropertiesID SDLCALL SDL_GetDisplayProperties(SDL_Displa
 
 #define SDL_PROP_DISPLAY_HDR_ENABLED_BOOLEAN             "SDL.display.HDR_enabled"
 #define SDL_PROP_DISPLAY_KMSDRM_PANEL_ORIENTATION_NUMBER "SDL.display.KMSDRM.panel_orientation"
+#define SDL_PROP_DISPLAY_WAYLAND_WL_OUTPUT_POINTER       "SDL.display.wayland.wl_output"
 
 /**
  * Get the name of a display in UTF-8 encoding.

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -855,6 +855,7 @@ SDL_DisplayID SDL_AddVideoDisplay(const SDL_VideoDisplay *display, bool send_eve
     SDL_copyp(new_display, display);
     new_display->id = id;
     new_display->device = _this;
+    new_display->props = display->props;
     if (display->name) {
         new_display->name = SDL_strdup(display->name);
     } else {

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -1071,6 +1071,9 @@ static void display_handle_done(void *data,
         internal->placeholder.current_orientation = internal->orientation;
         internal->placeholder.internal = internal;
 
+        internal->placeholder.props = SDL_CreateProperties();
+        SDL_SetPointerProperty(internal->placeholder.props, SDL_PROP_DISPLAY_WAYLAND_WL_OUTPUT_POINTER, internal->output);
+
         // During initialization, the displays will be added after enumeration is complete.
         if (!video->initializing) {
             internal->display = SDL_AddVideoDisplay(&internal->placeholder, true);


### PR DESCRIPTION
Some protocols take a wl_output object to function, so expose the underlying object via a property on the video displays.

Fixes #12642 
