### PR TITLE
video: fix surface leak when duplicating mjpeg

### DIFF
--- a/src/video/SDL_surface.c
+++ b/src/video/SDL_surface.c
@@ -1948,6 +1948,7 @@ SDL_Surface *SDL_ConvertSurfaceAndColorspace(SDL_Surface *surface, SDL_PixelForm
             if (!convert->pixels) {
                 goto error;
             }
+            convert->flags &= ~SDL_SURFACE_PREALLOCATED;
             convert->pitch = surface->pitch;
             SDL_memcpy(convert->pixels, surface->pixels, size);
 


### PR DESCRIPTION
#12479 introduced a memory leak when you duplicate a surface of the mjpeg type.
Yes, this leak gets massive fast.

## Description
Unset `SDL_SURFACE_PREALLOCATED` when allocating the memory for the jpeg data, so that `SDL_DestorySurface()` frees the memory again.