### PR TITLE
Fix missing AVFoundation in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2192,6 +2192,7 @@ elseif(APPLE)
       set(SDL_CAMERA_DRIVER_COREMEDIA 1)
       set(HAVE_CAMERA TRUE)
       sdl_glob_sources("${SDL3_SOURCE_DIR}/src/camera/coremedia/*.m")
+      set(SDL_FRAMEWORK_AVFOUNDATION 1)
     endif()
   endif()
 


### PR DESCRIPTION
On Apple platforms, when `SDL_AUDIO` is disabled, the current CMakeLists.txt does not set `SDL_FRAMEWORK_AVFOUNDATION` which results in a link error if `SDL_CAMERA` is enabled.

## Description
This pull request modifies CMakeLists to enable `SDL_FRAMEWORK_AVFOUNDATION` when `SDL_CAMERA` is enabled.

