### PR TITLE
Add performance disclaimer in `SDL_GetPowerInfo` documentation

### DIFF
--- a/include/SDL3/SDL_power.h
+++ b/include/SDL3/SDL_power.h
@@ -79,8 +79,7 @@ typedef enum SDL_PowerState
  * It's possible a platform can only report battery percentage or time left
  * but not both.
  *
- * On some platforms, retrieving power supply details might be expensive. It
- * is not recommended to invoke this function every frame.
+ * On some platforms, retrieving power supply details might be expensive. If you want to display continuous status you could call this function every minute or so.
  *
  * \param seconds a pointer filled in with the seconds of battery life left,
  *                or NULL to ignore. This will be filled in with -1 if we

--- a/include/SDL3/SDL_power.h
+++ b/include/SDL3/SDL_power.h
@@ -79,6 +79,9 @@ typedef enum SDL_PowerState
  * It's possible a platform can only report battery percentage or time left
  * but not both.
  *
+ * On some platforms, retrieving power supply details might be expensive. It
+ * is not recommended to invoke this function every frame.
+ *
  * \param seconds a pointer filled in with the seconds of battery life left,
  *                or NULL to ignore. This will be filled in with -1 if we
  *                can't determine a value or there is no battery.


### PR DESCRIPTION
As reported by "BackMode" on Discord, it is tempting to invoke this function every frame to show the real-time status of the battery (e.g. as part of drawing ImGui), but this function can actually be quite expensive on some platforms (e.g. due to opening file handles).

Example flamegraph on Ubuntu:
![image](https://github.com/user-attachments/assets/96aa5a97-97d7-4ab2-b7c9-5ef16311dc3d)

This PR adds a performance disclaimer to its documentation.