### PR TITLE
Return early instead of goto

### DIFF
--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -266,13 +266,11 @@ static bool pipewire_core_version_at_least(int major, int minor, int patch)
 static bool io_list_check_add(struct io_node *node)
 {
     struct io_node *n;
-    bool ret = true;
 
     // See if the node is already in the list
     spa_list_for_each (n, &hotplug_io_list, link) {
         if (n->id == node->id) {
-            ret = false;
-            goto dup_found;
+            return false;
         }
     }
 
@@ -283,9 +281,7 @@ static bool io_list_check_add(struct io_node *node)
         SDL_AddAudioDevice(node->recording, node->name, &node->spec, PW_ID_TO_HANDLE(node->id));
     }
 
-dup_found:
-
-    return ret;
+    return true;
 }
 
 static void io_list_remove(Uint32 id)


### PR DESCRIPTION
## Description

I would argue that returning early is considerably simpler then jumping to section in this sample. It avoids variable assignment and `goto` logic.