### PR TITLE
GPU Vulkan: Fix recursive Submit calls causing defrag to fail

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -5796,8 +5796,7 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
             &nameInfo);
     }
 
-    if (transitionToDefaultLayout)
-    {
+    if (transitionToDefaultLayout) {
         // Let's transition to the default barrier state, because for some reason Vulkan doesn't let us do that with initialLayout.
         VulkanCommandBuffer *barrierCommandBuffer = (VulkanCommandBuffer *)VULKAN_AcquireCommandBuffer((SDL_GPURenderer *)renderer);
         VULKAN_INTERNAL_TextureTransitionToDefaultUsage(
@@ -10421,7 +10420,7 @@ static bool VULKAN_Submit(
     Uint32 swapchainImageIndex;
     VulkanTextureSubresource *swapchainTextureSubresource;
     VulkanMemorySubAllocator *allocator;
-    bool presenting = vulkanCommandBuffer->presentDataCount > 0;
+    bool presenting = (vulkanCommandBuffer->presentDataCount > 0);
 
     SDL_LockMutex(renderer->submitLock);
 
@@ -10444,8 +10443,7 @@ static bool VULKAN_Submit(
             swapchainTextureSubresource);
     }
 
-    if (
-        presenting &&
+    if (presenting &&
         renderer->allocationsToDefragCount > 0 &&
         !renderer->defragInProgress) {
         if (!VULKAN_INTERNAL_DefragmentMemory(renderer, vulkanCommandBuffer))
@@ -10530,8 +10528,7 @@ static bool VULKAN_Submit(
     }
 
     // If presenting, check if we can perform any cleanups
-    if (presenting)
-    {
+    if (presenting) {
         for (Sint32 i = renderer->submittedCommandBufferCount - 1; i >= 0; i -= 1) {
             vulkanResult = renderer->vkGetFenceStatus(
                 renderer->logicalDevice,


### PR DESCRIPTION
While doing some testing on my project, I noticed some bad defrag behavior:

![bad_defrag](https://github.com/user-attachments/assets/c71edeae-da1d-43a5-b554-e4b66eeed7c9)

After a nightmare debugging session I finally traced the cause.

Our defrag strategy is as follows: when a resource fails to find any available memory regions with enough space to bind itself, a new block is allocated so the resource can be bound immediately. Since the failure may have been due to fragmentation, existing blocks are checked for fragmentation and marked to be defragged.

The bug:
- The defrag process causes a new block of the same size to be allocated. Every resource in the currently defragging block is copied to the new block, and then marked for destruction. 
- Defrag is triggered when a command buffer is submitted and at least one block is marked for defrag. To avoid overallocating or stalling for too long, only one block is defragged per Submit call.
- Command buffer submission is also when released resources are destroyed and their memory regions are freed, which updates the record keeping in the allocation block.
- Creating a texture requires us to transition the texture to its default image layout. Due to an awkwardness in the Vulkan spec, the only way to do this is via command buffer, so we acquire and submit a small command buffer which transitions the texture to its default layout.
- Since the defrag process creates new textures... this is recursive command submission!
- The recursive command submission causes released resources to be destroyed, which means the memory block is updated while the defrag is iterating. Stupidity ensues.

To fix this bug, I have made the following changes:

- VULKAN_INTERNAL_CreateTexture now takes a transitionToDefaultLayout bool, which is set to false when it is called by the defrag or cycle process. Since defrag and cycle use command buffers, we can just perform the memory barrier on those command buffers.
- Cleanups are only performed if the command buffer submission involves presentation. Presentation is a good time to kick off these kinds of tasks anyway since we'll often be waiting on previous frames in flight or v-sync to finish. A potential issue here is that headless setups wouldn't trigger cleanup, but those tend to just render an image and exit instead of running continuously.

![Capture](https://github.com/user-attachments/assets/33b04923-8d92-4b2c-865a-7ad2713eed67)

Much better!

I just wanted to get all these thoughts down while it was fresh in my head, but one last thing before this gets merged: I'd like to insert the defrag commands into the submitted command buffer instead of acquiring and submitting a separate command buffer. I have a feeling that re-entrancy is just asking for problems with how complex and sensitive this code is. 