### PR TITLE
GPU: Nitpicks

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -2268,6 +2268,96 @@ extern SDL_DECLSPEC SDL_GPUShaderFormat SDLCALL SDL_GetGPUShaderFormats(SDL_GPUD
  *
  * The following properties are provided by SDL:
  *
+ * - `SDL_PROP_GPU_DEVICE_NAME_STRING`:
+ *
+ * > Contains the name of the underlying device as reported by the system
+ * > driver. This string has no standardized format, is highly inconsistent
+ * > between hardware devices and drivers, and is able to change at any time. Do
+ * > not attempt to parse this string as it is bound to fail at some point in
+ * > the future when system drivers are updated, new hardware devices are
+ * > introduced, or when SDL adds new GPU backends or modifies existing ones.
+ * >
+ * > Strings that have been found in the wild include:
+ * >
+ * > - GTX 970
+ * > - GeForce GTX 970
+ * > - NVIDIA GeForce GTX 970
+ * > - Microsoft Direct3D12 (NVIDIA GeForce GTX 970)
+ * > - NVIDIA Graphics Device
+ * > - GeForce GPU
+ * > - P106-100
+ * > - AMD 15D8:C9
+ * > - AMD Custom GPU 0405
+ * > - AMD Radeon (TM) Graphics
+ * > - ASUS Radeon RX 470 Series
+ * > - Intel(R) Arc(tm) A380 Graphics (DG2)
+ * > - Virtio-GPU Venus (NVIDIA TITAN V)
+ * > - SwiftShader Device (LLVM 16.0.0)
+ * > - llvmpipe (LLVM 15.0.4, 256 bits)
+ * > - Microsoft Basic Render Driver
+ * > - unknown device
+ * >
+ * > The above list shows that the same device can have different formats, the
+ * > vendor name may or may not appear in the string, the included vendor name
+ * > may not be the vendor of the chipset on the device, some manufacturers
+ * > include pseudo-legal marks while others don't, some devices may not use a
+ * > marketing name in the string, the device string may be wrapped by the name
+ * > of a translation interface, the device may be emulated in software, or the
+ * > string may contain generic text that does not identify the device at all.
+ *
+ * - `SDL_PROP_GPU_DEVICE_DRIVER_NAME_STRING`:
+ *
+ * > Contains the self-reported name of the underlying system driver.
+ * >
+ * > Strings that have been found in the wild include:
+ * >
+ * > - Intel Corporation
+ * > - Intel open-source Mesa driver
+ * > - Qualcomm Technologies Inc. Adreno Vulkan Driver
+ * > - MoltenVK
+ * > - Mali-G715
+ * > - venus
+ *
+ * - `SDL_PROP_GPU_DEVICE_DRIVER_VERSION_STRING`:
+ *
+ * > Contains the self-reported version of the underlying system driver. This is
+ * > a relatively short version string in an unspecified format. If
+ * > SDL_PROP_GPU_DEVICE_DRIVER_INFO_STRING is available then that
+ * > property should be preferred over this one as it may contain additional
+ * > information that is useful for identifying the exact driver version used.
+ * >
+ * > Strings that have been found in the wild include:
+ * >
+ * > - 53.0.0
+ * > - 0.405.2463
+ * > - 32.0.15.6614
+ *
+ * - `SDL_PROP_GPU_DEVICE_DRIVER_INFO_STRING`:
+ *
+ * > Contains the detailed version information of the underlying system driver
+ * > as reported by the driver. This is an arbitrary string with no standardized
+ * > format and it may contain newlines. This property should be preferred over
+ * > SDL_PROP_GPU_DEVICE_DRIVER_VERSION_STRING if it is available as it
+ * > usually contains the same information but in a format that is easier to
+ * > read.
+ * >
+ * > Strings that have been found in the wild include:
+ * >
+ * > - 101.6559
+ * > - 1.2.11
+ * > - Mesa 21.2.2 (LLVM 12.0.1)
+ * > - Mesa 22.2.0-devel (git-f226222 2022-04-14 impish-oibaf-ppa)
+ * > - v1.r53p0-00eac0.824c4f31403fb1fbf8ee1042422c2129
+ * >
+ * > As well as the multiline string (which has a trailing newline):
+ * >
+ * > > ```
+ * > > Driver Build: 85da404, I46ff5fc46f, 1606794520
+ * > > Date: 11/30/20
+ * > > Compiler Version: EV031.31.04.01
+ * > > Driver Branch: promo490_3_Google
+ * > > ```
+ *
  * \param device a GPU context to query.
  * \returns a valid property ID on success or 0 on failure; call
  *          SDL_GetError() for more information.

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -8066,7 +8066,7 @@ static void D3D12_INTERNAL_InitBlitResources(
     shaderCreateInfo.code = (Uint8 *)D3D12_FullscreenVert;
     shaderCreateInfo.code_size = sizeof(D3D12_FullscreenVert);
     shaderCreateInfo.stage = SDL_GPU_SHADERSTAGE_VERTEX;
-    shaderCreateInfo.format = SDL_GPU_SHADERFORMAT_DXBC;
+    shaderCreateInfo.format = SDL_GPU_SHADERFORMAT_DXIL;
 
     renderer->blitVertexShader = D3D12_CreateShader(
         (SDL_GPURenderer *)renderer,

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -3454,7 +3454,9 @@ static SDL_GPUTexture *D3D12_CreateTexture(
     // Copy properties so we don't lose information when the client destroys them
     container->header.info = *createinfo;
     container->header.info.props = SDL_CreateProperties();
-    SDL_CopyProperties(createinfo->props, container->header.info.props);
+    if (createinfo->props) {
+        SDL_CopyProperties(createinfo->props, container->header.info.props);
+    }
 
     container->textureCapacity = 1;
     container->textureCount = 1;

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -1508,7 +1508,9 @@ static SDL_GPUTexture *METAL_CreateTexture(
         // Copy properties so we don't lose information when the client destroys them
         container->header.info = *createinfo;
         container->header.info.props = SDL_CreateProperties();
-        SDL_CopyProperties(createinfo->props, container->header.info.props);
+        if (createinfo->props) {
+            SDL_CopyProperties(createinfo->props, container->header.info.props);
+        }
 
         container->activeTexture = texture;
         container->textureCapacity = 1;

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -1227,6 +1227,7 @@ static inline const char *VkErrorMessages(VkResult code)
         ERR_TO_STR(VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT)
         ERR_TO_STR(VK_SUBOPTIMAL_KHR)
         ERR_TO_STR(VK_ERROR_NATIVE_WINDOW_IN_USE_KHR)
+        ERR_TO_STR(VK_ERROR_INVALID_SHADER_NV)
     default:
         return "Unhandled VkResult!";
     }

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -6750,7 +6750,9 @@ static SDL_GPUTexture *VULKAN_CreateTexture(
     // Copy properties so we don't lose information when the client destroys them
     container->header.info = *createinfo;
     container->header.info.props = SDL_CreateProperties();
-    SDL_CopyProperties(createinfo->props, container->header.info.props);
+    if (createinfo->props) {
+        SDL_CopyProperties(createinfo->props, container->header.info.props);
+    }
 
     container->canBeCycled = true;
     container->activeTexture = texture;


### PR DESCRIPTION
This PR contains four independent changes:

1. SDL_CreateGPUTexture() incorrectly uses SDL_CopyProperties() which results in a harmless "`Parameter 'src' is invalid`" error being registered if `SDL_GPUTextureCreateInfo.props` is null. While SDL_CreateGPUTexture() returns successfully and therefore the error should be ignored multiple users have incorrectly used SDL_GetError() to see the error and have made support requests relating to it. E.g. #12638. This PR corrects the usage.
2. A user managed to receive the error message "`vkCreateGraphicsPipelines Unhandled VkResult!`" While I'm not sure what the VkResult value actually was the Vulkan docs do mention that VK_ERROR_INVALID_SHADER_NV can be returned from vkCreateGraphicsPipelines() and that value wasn't being stringified. This PR adds the value to the stringifier.
3. The internal D3D12 blit shader was incorrectly being recorded as being DXBC even though it is actually DXIL. This PR corrects the format flag.
4. The wiki bridge doesn't like subheadings in function docs. This PR reformats the docs of SDL_GetGPUDeviceProperties() to something that the bot might like more.

Fixes: #12638