### PR TITLE
SDL_cpuinfo.h: only include immintrin.h for x86 targets.

### DIFF
--- a/include/SDL_cpuinfo.h
+++ b/include/SDL_cpuinfo.h
@@ -115,7 +115,8 @@ _m_prefetch(void *__P)
 #include <lasxintrin.h>
 #define __LASX__
 #endif
-#if defined(HAVE_IMMINTRIN_H) && !defined(SDL_DISABLE_IMMINTRIN_H)
+#if defined(HAVE_IMMINTRIN_H) && !defined(SDL_DISABLE_IMMINTRIN_H) && \
+   (defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86))
 #include <immintrin.h>
 #else
 #if defined(__MMX__) && !defined(SDL_DISABLE_MMINTRIN_H)


### PR DESCRIPTION
Reference issue: https://github.com/libsdl-org/SDL_image/issues/537
Reference issue: https://github.com/libsdl-org/SDL_mixer/issues/648
