### PR TITLE
Emscripten: Move global event handlers

### DIFF
--- a/src/video/emscripten/SDL_emscriptenevents.h
+++ b/src/video/emscripten/SDL_emscriptenevents.h
@@ -24,6 +24,8 @@
 
 #include "SDL_emscriptenvideo.h"
 
+extern void Emscripten_RegisterGlobalEventHandlers(SDL_VideoDevice *device);
+extern void Emscripten_UnregisterGlobalEventHandlers(SDL_VideoDevice *device);
 extern void Emscripten_RegisterEventHandlers(SDL_WindowData *data);
 extern void Emscripten_UnregisterEventHandlers(SDL_WindowData *data);
 extern EM_BOOL Emscripten_HandleCanvasResize(int eventType, const void *reserved, void *userData);

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -390,6 +390,8 @@ bool Emscripten_VideoInit(SDL_VideoDevice *_this)
     SDL_AddKeyboard(SDL_DEFAULT_KEYBOARD_ID, NULL, false);
     SDL_AddMouse(SDL_DEFAULT_MOUSE_ID, NULL, false);
 
+    Emscripten_RegisterGlobalEventHandlers(_this);
+
     // We're done!
     return true;
 }
@@ -402,6 +404,7 @@ static bool Emscripten_SetDisplayMode(SDL_VideoDevice *_this, SDL_VideoDisplay *
 
 static void Emscripten_VideoQuit(SDL_VideoDevice *_this)
 {
+    Emscripten_UnregisterGlobalEventHandlers(_this);
     Emscripten_QuitMouse();
     Emscripten_UnlistenSystemTheme();
     pumpevents_has_run = false;


### PR DESCRIPTION
Moved global event handlers from `SDL_CreateWindow` to `SDL_VideoInit`

- `emscripten_set_mouseup_callback`
- `emscripten_set_focus_callback`
- `emscripten_set_blur_callback`
- `emscripten_set_pointerlockchange_callback`
- `emscripten_set_fullscreenchange_callback`
- `emscripten_set_resize_callback`

This change will be necessary for #12575