### PR TITLE
[Windows]: dialog: Add `OFN_OVERWRITEPROMPT` to save dialogs

### DIFF
--- a/src/dialog/windows/SDL_windowsdialog.c
+++ b/src/dialog/windows/SDL_windowsdialog.c
@@ -517,13 +517,11 @@ static void ShowFileDialog(SDL_DialogFileCallback callback, void *userdata, SDL_
     filters_str = win_get_filters(filters, nfilters);
 
     DWORD flags = 0;
-    {
-        if (allow_many) {
-            flags |= OFN_ALLOWMULTISELECT;
-        }
-        if (is_save) {
-            flags |= OFN_OVERWRITEPROMPT;
-        }
+    if (allow_many) {
+        flags |= OFN_ALLOWMULTISELECT;
+    }
+    if (is_save) {
+        flags |= OFN_OVERWRITEPROMPT;
     }
 
     if (!filters_str && filters) {

--- a/src/dialog/windows/SDL_windowsdialog.c
+++ b/src/dialog/windows/SDL_windowsdialog.c
@@ -516,6 +516,16 @@ static void ShowFileDialog(SDL_DialogFileCallback callback, void *userdata, SDL_
 
     filters_str = win_get_filters(filters, nfilters);
 
+    DWORD flags = 0;
+    {
+        if (allow_many) {
+            flags |= OFN_ALLOWMULTISELECT;
+        }
+        if (is_save) {
+            flags |= OFN_OVERWRITEPROMPT;
+        }
+    }
+
     if (!filters_str && filters) {
         callback(userdata, NULL, -1);
         SDL_free(args);
@@ -526,7 +536,7 @@ static void ShowFileDialog(SDL_DialogFileCallback callback, void *userdata, SDL_
     args->filters_str = filters_str;
     args->default_file = default_location ? SDL_strdup(default_location) : NULL;
     args->parent = window;
-    args->flags = allow_many ? OFN_ALLOWMULTISELECT : 0;
+    args->flags = flags;
     args->callback = callback;
     args->userdata = userdata;
     args->title = title ? SDL_strdup(title) : NULL;


### PR DESCRIPTION
This changeset causes the save dialog spawned by `SDL_ShowOpenFileDialog` in Windows to prompt a user if they try to save over an existing file.

## Description

This is a "maybe you'd like this, maybe not" PR of a patch I plan on using in [opensim-creator](https://www.opensimcreator.com/). I was previously using [nativefiledialog](https://github.com/mlabbe/nativefiledialog) which, by default, prompts the user if they open a save dialog in Windows and try to overwrite an existing file. I personally like this behavior (prevents a little accident 😄 ), but it's up to the SDL team if you agree!

The documentation for the `OFN_OVERWRITEPROMPT` flag is available in the docs for the `OPENFILENAMEA` struct, [here](https://learn.microsoft.com/en-us/windows/win32/api/commdlg/ns-commdlg-openfilenamea). Here's a copy-paste of that documentation:

> `OFN_OVERWRITEPROMPT` (`0x00000002`)
>
> Causes the Save As dialog box to generate a message box if the selected file already exists. The user must confirm whether to overwrite the file. 

## Existing Issue(s)

Couldn't find any after searching open issues for "dialog" or "overwrite".