### PR TITLE
Disable EGL in Emscripten builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1549,7 +1549,6 @@ elseif(EMSCRIPTEN)
 
     #enable gles
     if(SDL_OPENGLES)
-      set(SDL_VIDEO_OPENGL_EGL 1)
       set(HAVE_OPENGLES TRUE)
       set(SDL_VIDEO_OPENGL_ES2 1)
       set(SDL_VIDEO_RENDER_OGL_ES2 1)

--- a/src/video/SDL_egl.c
+++ b/src/video/SDL_egl.c
@@ -260,7 +260,7 @@ SDL_FunctionPointer SDL_EGL_GetProcAddressInternal(SDL_VideoDevice *_this, const
             result = _this->egl_data->eglGetProcAddress(proc);
         }
 
-#if !defined(SDL_PLATFORM_EMSCRIPTEN) && !defined(SDL_VIDEO_DRIVER_VITA) // LoadFunction isn't needed on Emscripten and will call dlsym(), causing other problems.
+#if !defined(SDL_VIDEO_DRIVER_VITA)
         // Try SDL_LoadFunction() first for EGL <= 1.4, or as a fallback for >= 1.5.
         if (!result) {
             result = SDL_LoadFunction(_this->egl_data->opengl_dll_handle, proc);


### PR DESCRIPTION
It's not used by the Emscripten video driver.