### PR TITLE
Allow 01-joystick-polling example to be resizable

### DIFF
--- a/examples/input/01-joystick-polling/joystick-polling.c
+++ b/examples/input/01-joystick-polling/joystick-polling.c
@@ -41,7 +41,7 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
         return SDL_APP_FAILURE;
     }
 
-    if (!SDL_CreateWindowAndRenderer("examples/input/joystick-polling", 640, 480, 0, &window, &renderer)) {
+    if (!SDL_CreateWindowAndRenderer("examples/input/joystick-polling", 640, 480, SDL_WINDOW_RESIZABLE, &window, &renderer)) {
         SDL_Log("Couldn't create window/renderer: %s", SDL_GetError());
         return SDL_APP_FAILURE;
     }


### PR DESCRIPTION
Necessary when you have a joystick with 30+ buttons 
