### PR TITLE
video: use `WS_OVERLAPPED` style for borderless windows (DRAFT)

### DIFF
--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -762,6 +762,10 @@ bool WIN_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Properties
             return WIN_SetError("Couldn't create window");
         }
 
+        if (window->flags & SDL_WINDOW_BORDERLESS) {
+            SetWindowLongPtr(hwnd, GWL_STYLE, WS_OVERLAPPED);
+        }
+
         WIN_UpdateDarkModeForHWND(hwnd);
 
         WIN_PumpEvents(_this);


### PR DESCRIPTION
This PR fixes #12791. Fullscreen borderless is now "windowed" (not exclusive fullscreen anymore), and windowed borderless seems to display correctly.

I don't think this is the correct way of fixing the issue, but I want to get the discussion started and move towards a possible better fix.

The core issue *might* be that Windows is deciding to apply aggressive fullscreen optimizations when it sees this specific combination:
- Window covering the entire screen resolution.
- OpenGL rendering (which might have specific pathways).
- SwapBuffers (SDL_GL_SwapWindow) being called.
- Having the WS_POPUP style (implicitly set by SDL for SDL_WINDOW_BORDERLESS).
