### PR TITLE
Fix crash in UIKit indirect pointer handling

### DIFF
--- a/src/video/uikit/SDL_uikitview.m
+++ b/src/video/uikit/SDL_uikitview.m
@@ -240,7 +240,7 @@ extern int SDL_AppleTVRemoteOpenedAsJoystick;
         int i;
         SDL_MouseButtonFlags buttons = SDL_GetMouseState(NULL, NULL);
 
-        for (i = 0; i < MAX_MOUSE_BUTTONS; ++i) {
+        for (i = 1; i <= MAX_MOUSE_BUTTONS; ++i) {
             if (buttons & SDL_BUTTON_MASK(i)) {
                 SDL_SendMouseButton(UIKit_GetEventTimestamp([touch timestamp]), sdlwindow, SDL_GLOBAL_MOUSE_ID, (Uint8)i, false);
             }


### PR DESCRIPTION
This loop appears twice, with a one-off difference:
https://github.com/libsdl-org/SDL/blob/main/src/video/uikit/SDL_uikitview.m#L213
https://github.com/libsdl-org/SDL/blob/main/src/video/uikit/SDL_uikitview.m#L243

In the second case, when i is 0, SDL_BUTTON_MASK(0) attempts to shift left by a negative number, causing crashes.

This PR aligns the second loop with the first.