### PR TITLE
X11: Center Message Box on Multi Monitor Displays

### DIFF
--- a/src/video/x11/SDL_x11messagebox.c
+++ b/src/video/x11/SDL_x11messagebox.c
@@ -425,6 +425,11 @@ static bool X11_MessageBoxCreateWindow(SDL_MessageBoxDataX11 *data)
     Display *display = data->display;
     SDL_WindowData *windowdata = NULL;
     const SDL_MessageBoxData *messageboxdata = data->messageboxdata;
+#ifdef XRANDR_DISABLED_BY_DEFAULT
+    const bool use_xrandr_by_default = false;
+#else
+    const bool use_xrandr_by_default = true;
+#endif
 
     if (messageboxdata->window) {
         SDL_DisplayData *displaydata = SDL_GetDisplayDriverDataForWindow(messageboxdata->window);
@@ -497,7 +502,13 @@ static bool X11_MessageBoxCreateWindow(SDL_MessageBoxDataX11 *data)
             const SDL_DisplayData *dpydata = dpy->internal;
             x = dpydata->x + ((dpy->current_mode->w - data->dialog_width) / 2);
             y = dpydata->y + ((dpy->current_mode->h - data->dialog_height) / 3);
-        } else { // oh well. This will misposition on a multi-head setup. Init first next time.
+        } else if(SDL_GetHintBoolean(SDL_HINT_VIDEO_X11_XRANDR, use_xrandr_by_default)) {
+            XRRScreenResources *screen = X11_XRRGetScreenResourcesCurrent(display, DefaultRootWindow(display));
+            XRRCrtcInfo *crtc_info = X11_XRRGetCrtcInfo(display, screen, screen->crtcs[0]);
+            x = (crtc_info->width - data->dialog_width) / 2;
+            y = (crtc_info->height - data->dialog_height) / 3;
+        } else {
+            // oh well. This will misposition on a multi-head setup. Init first next time.
             x = (DisplayWidth(display, data->screen) - data->dialog_width) / 2;
             y = (DisplayHeight(display, data->screen) - data->dialog_height) / 3;
         }

--- a/src/video/x11/SDL_x11messagebox.c
+++ b/src/video/x11/SDL_x11messagebox.c
@@ -502,7 +502,7 @@ static bool X11_MessageBoxCreateWindow(SDL_MessageBoxDataX11 *data)
             const SDL_DisplayData *dpydata = dpy->internal;
             x = dpydata->x + ((dpy->current_mode->w - data->dialog_width) / 2);
             y = dpydata->y + ((dpy->current_mode->h - data->dialog_height) / 3);
-        } else if(SDL_GetHintBoolean(SDL_HINT_VIDEO_X11_XRANDR, use_xrandr_by_default)) {
+        } else if (SDL_GetHintBoolean(SDL_HINT_VIDEO_X11_XRANDR, use_xrandr_by_default)) {
             XRRScreenResources *screen = X11_XRRGetScreenResourcesCurrent(display, DefaultRootWindow(display));
             XRRCrtcInfo *crtc_info = X11_XRRGetCrtcInfo(display, screen, screen->crtcs[0]);
             x = (crtc_info->width - data->dialog_width) / 2;


### PR DESCRIPTION
Message boxes, when using X11, were not centered on a monitor if there were multiple monitors connected and the parent window was `NULL`. This PR fixes that if XRandr is available.