### PR TITLE
Make WM_MOUSEMOVE queue ClipCursor refresh to end of PumpEvents instead of immediately calling

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -356,7 +356,7 @@ static void WIN_UpdateMouseCapture(void)
     }
 }
 
-static void WIN_UpdateFocus(SDL_Window *window, bool expect_focus)
+static void WIN_UpdateFocus(SDL_Window *window, bool expect_focus, DWORD pos)
 {
     SDL_WindowData *data = window->internal;
     HWND hwnd = data->hwnd;
@@ -393,7 +393,8 @@ static void WIN_UpdateFocus(SDL_Window *window, bool expect_focus)
 
         // In relative mode we are guaranteed to have mouse focus if we have keyboard focus
         if (!SDL_GetMouse()->relative_mode) {
-            GetCursorPos(&cursorPos);
+            cursorPos.x = (LONG)GET_X_LPARAM(pos);
+            cursorPos.y = (LONG)GET_Y_LPARAM(pos);
             ScreenToClient(hwnd, &cursorPos);
             SDL_SendMouseMotion(WIN_GetEventTimestamp(), window, SDL_GLOBAL_MOUSE_ID, false, (float)cursorPos.x, (float)cursorPos.y);
         }
@@ -1248,13 +1249,13 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
         /* Update the focus here, since it's possible to get WM_ACTIVATE and WM_SETFOCUS without
            actually being the foreground window, but this appears to get called in all cases where
            the global foreground window changes to and from this window. */
-        WIN_UpdateFocus(data->window, !!wParam);
+        WIN_UpdateFocus(data->window, !!wParam, GetMessagePos());
     } break;
 
     case WM_ACTIVATE:
     {
         // Update the focus in case we changed focus to a child window and then away from the application
-        WIN_UpdateFocus(data->window, !!LOWORD(wParam));
+        WIN_UpdateFocus(data->window, !!LOWORD(wParam), GetMessagePos());
     } break;
 
     case WM_MOUSEACTIVATE:
@@ -1277,14 +1278,14 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
     case WM_SETFOCUS:
     {
         // Update the focus in case it's changing between top-level windows in the same application
-        WIN_UpdateFocus(data->window, true);
+        WIN_UpdateFocus(data->window, true, GetMessagePos());
     } break;
 
     case WM_KILLFOCUS:
     case WM_ENTERIDLE:
     {
         // Update the focus in case it's changing between top-level windows in the same application
-        WIN_UpdateFocus(data->window, false);
+        WIN_UpdateFocus(data->window, false, GetMessagePos());
     } break;
 
     case WM_POINTERENTER:

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1240,11 +1240,8 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
     case WM_NCACTIVATE:
     {
         // Don't immediately clip the cursor in case we're clicking minimize/maximize buttons
-        // This is the only place that this flag is set. This causes all subsequent calls to
-        // WIN_UpdateClipCursor for this window to be no-ops in this frame's message-pumping.
-        // This flag is unset at the end of message pumping each frame for every window, and
-        // should never be carried over between frames.
-        data->skip_update_clipcursor = true;
+        data->postpone_clipcursor = true;
+        data->clipcursor_queued = true;
 
         /* Update the focus here, since it's possible to get WM_ACTIVATE and WM_SETFOCUS without
            actually being the foreground window, but this appears to get called in all cases where
@@ -1413,9 +1410,8 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
                 window->flags & (SDL_WINDOW_MOUSE_RELATIVE_MODE | SDL_WINDOW_MOUSE_GRABBED) ||
                 (window->mouse_rect.w > 0 && window->mouse_rect.h > 0)
             );
-            if (wish_clip_cursor) {
-                data->skip_update_clipcursor = false;
-                WIN_UpdateClipCursor(window);
+            if (wish_clip_cursor) { // queue clipcursor refresh on pump finish
+                data->clipcursor_queued = true;
             }
         }
 
@@ -1440,6 +1436,9 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
                 SDL_SendMouseMotion(WIN_GetEventTimestamp(), window, SDL_GLOBAL_MOUSE_ID, false, (float)GET_X_LPARAM(lParam), (float)GET_Y_LPARAM(lParam));
             }
         }
+        
+        return 0;
+        
     } break;
 
     case WM_LBUTTONUP:
@@ -2602,13 +2601,27 @@ void WIN_PumpEvents(SDL_VideoDevice *_this)
         }
     }
 
-    // Update the clipping rect in case someone else has stolen it
+    // fire queued clipcursor refreshes
     if (_this) {
         SDL_Window *window = _this->windows;
         while (window) {
+            bool refresh_clipcursor = false;
             SDL_WindowData *data = window->internal;
-            if (data && data->skip_update_clipcursor) {
-                data->skip_update_clipcursor = false;
+            if (data) {
+                refresh_clipcursor = data->clipcursor_queued;
+                data->clipcursor_queued = false;    // Must be cleared unconditionally.
+                data->postpone_clipcursor = false;  // Must be cleared unconditionally.
+                                                    // Must happen before UpdateClipCursor.
+                                                    // Although its occurrence currently
+                                                    // always coincides with the queuing of
+                                                    // clipcursor, it is logically distinct
+                                                    // and this coincidence might no longer
+                                                    // be true in the future.
+                                                    // Ergo this placement concordantly
+                                                    // conveys its unconditionality 
+                                                    // vis-a-vis the queuing of clipcursor.
+            }
+            if (refresh_clipcursor) {
                 WIN_UpdateClipCursor(window);
             }
             window = window->next;

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -1623,7 +1623,7 @@ void WIN_UnclipCursorForWindow(SDL_Window *window) {
 void WIN_UpdateClipCursor(SDL_Window *window)
 {
     SDL_WindowData *data = window->internal;
-    if (data->in_title_click || data->focus_click_pending || data->skip_update_clipcursor) {
+    if (data->in_title_click || data->focus_click_pending || data->postpone_clipcursor) {
         return;
     }
 

--- a/src/video/windows/SDL_windowswindow.h
+++ b/src/video/windows/SDL_windowswindow.h
@@ -78,7 +78,8 @@ struct SDL_WindowData
     bool in_border_change;
     bool in_title_click;
     Uint8 focus_click_pending;
-    bool skip_update_clipcursor;
+    bool postpone_clipcursor;
+    bool clipcursor_queued;
     bool windowed_mode_was_maximized;
     bool in_window_deactivation;
     bool force_ws_maximizebox;


### PR DESCRIPTION


Prior to https://github.com/libsdl-org/SDL/pull/11237 , ClipCursor is periodically refreshed on an interval set by a hint, taking place at the end of PumpEvents. 

My previous PR changed it to run as a response to WM_MOUSEMOVE instead, which is an approach that makes sense for a `GetMessage()` based application where the event loop is mostly idle, so immediately responding to clipping discrepancies would immediately stop further errant mouse movement messages

However, since SDL apps uses a pump-based event loop, this means that multiple movement events may have accumulated before the pump, the expensive calls would then be run on each of those messages redundantly. 

For pump-based apps, the correct approach for the initial idea behind the aformentioned PR is instead to respond to those messages by queuing for a refresh at the end of pump instead of refreshing it immediately.