### PR TITLE
wayland: Check the origin of clipboard offers before forwarding them …

### DIFF
--- a/src/core/linux/SDL_dbus.c
+++ b/src/core/linux/SDL_dbus.c
@@ -49,6 +49,7 @@ static bool LoadDBUSSyms(void)
     SDL_DBUS_SYM(dbus_bool_t (*)(DBusConnection *, DBusError *), bus_register);
     SDL_DBUS_SYM(void (*)(DBusConnection *, const char *, DBusError *), bus_add_match);
     SDL_DBUS_SYM(void (*)(DBusConnection *, const char *, DBusError *), bus_remove_match);
+    SDL_DBUS_SYM(const char *(*)(DBusConnection *), bus_get_unique_name);
     SDL_DBUS_SYM(DBusConnection *(*)(const char *, DBusError *), connection_open_private);
     SDL_DBUS_SYM(void (*)(DBusConnection *, dbus_bool_t), connection_set_exit_on_disconnect);
     SDL_DBUS_SYM(dbus_bool_t (*)(DBusConnection *), connection_get_is_connected);

--- a/src/core/linux/SDL_dbus.h
+++ b/src/core/linux/SDL_dbus.h
@@ -47,6 +47,7 @@ typedef struct SDL_DBusContext
     dbus_bool_t (*bus_register)(DBusConnection *, DBusError *);
     void (*bus_add_match)(DBusConnection *, const char *, DBusError *);
     void (*bus_remove_match)(DBusConnection *, const char *, DBusError *);
+    const char *(*bus_get_unique_name)(DBusConnection *);
     DBusConnection *(*connection_open_private)(const char *, DBusError *);
     void (*connection_set_exit_on_disconnect)(DBusConnection *, dbus_bool_t);
     dbus_bool_t (*connection_get_is_connected)(DBusConnection *);

--- a/src/events/SDL_clipboardevents.c
+++ b/src/events/SDL_clipboardevents.c
@@ -29,17 +29,7 @@
 void SDL_SendClipboardUpdate(bool owner, char **mime_types, size_t num_mime_types)
 {
     if (!owner) {
-        /* Clear our internal clipboard contents when external clipboard is set.
-         *
-         * Wayland recursively sends a data offer to the client from which the clipboard data originated,
-         * and as the client can't determine the origin of the offer, the clipboard must not be cleared,
-         * or the original data may be destroyed. Cleanup will be done in the backend when an offer
-         * cancellation event arrives.
-         */
-        if (SDL_strcmp(SDL_GetCurrentVideoDriver(), "wayland") != 0) {
-            SDL_CancelClipboardData(0);
-        }
-
+        SDL_CancelClipboardData(0);
         SDL_SaveClipboardMimeTypes((const char **)mime_types, num_mime_types);
     }
 

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -2518,6 +2518,7 @@ static void data_device_handle_data_offer(void *data, struct wl_data_device *wl_
         data_device->seat->display->last_incoming_data_offer_seat = data_device->seat;
         data_offer->offer = id;
         data_offer->data_device = data_device;
+        data_offer->read_fd = -1;
         WAYLAND_wl_list_init(&(data_offer->mimes));
         wl_data_offer_set_user_data(id, data_offer);
         wl_data_offer_add_listener(id, &data_offer_listener, data_offer);
@@ -2759,41 +2760,6 @@ static void data_device_handle_drop(void *data, struct wl_data_device *wl_data_d
     data_device->drag_offer = NULL;
 }
 
-static void notifyFromMimes(struct wl_list *mimes)
-{
-    int nformats = 0;
-    char **new_mime_types = NULL;
-    if (mimes) {
-        nformats = WAYLAND_wl_list_length(mimes);
-        size_t alloc_size = (nformats + 1) * sizeof(char *);
-
-        /* do a first pass to compute allocation size */
-        SDL_MimeDataList *item = NULL;
-        wl_list_for_each(item, mimes, link) {
-            alloc_size += SDL_strlen(item->mime_type) + 1;
-        }
-
-        new_mime_types = SDL_AllocateTemporaryMemory(alloc_size);
-        if (!new_mime_types) {
-            SDL_LogError(SDL_LOG_CATEGORY_INPUT, "unable to allocate new_mime_types");
-            return;
-        }
-
-        /* second pass to fill*/
-        char *strPtr = (char *)(new_mime_types + nformats + 1);
-        item = NULL;
-        int i = 0;
-        wl_list_for_each(item, mimes, link) {
-            new_mime_types[i] = strPtr;
-            strPtr = stpcpy(strPtr, item->mime_type) + 1;
-            i++;
-        }
-        new_mime_types[nformats] = NULL;
-    }
-
-    SDL_SendClipboardUpdate(false, new_mime_types, nformats);
-}
-
 static void data_device_handle_selection(void *data, struct wl_data_device *wl_data_device,
                                          struct wl_data_offer *id)
 {
@@ -2812,7 +2778,7 @@ static void data_device_handle_selection(void *data, struct wl_data_device *wl_d
         data_device->selection_offer = offer;
     }
 
-    notifyFromMimes(offer ? &offer->mimes : NULL);
+    Wayland_data_offer_notify_from_mimes(offer, true);
 }
 
 static const struct wl_data_device_listener data_device_listener = {
@@ -2942,6 +2908,29 @@ static const struct zwp_text_input_v3_listener text_input_listener = {
     text_input_done
 };
 
+static void Wayland_DataDeviceSetID(SDL_WaylandDataDevice *data_device)
+{
+    if (!data_device->id_str)
+#ifdef SDL_USE_LIBDBUS
+    {
+        SDL_DBusContext *dbus = SDL_DBus_GetContext();
+        if (dbus) {
+            const char *id = dbus->bus_get_unique_name(dbus->session_conn);
+            if (id) {
+                data_device->id_str = SDL_strdup(id);
+            }
+        }
+    }
+    if (!data_device->id_str)
+#endif
+    {
+        char id[24];
+        Uint64 pid = (Uint64)getpid();
+        SDL_snprintf(id, sizeof(id), "%" SDL_PRIu64, pid);
+        data_device->id_str = SDL_strdup(id);
+    }
+}
+
 static void Wayland_SeatCreateDataDevice(SDL_WaylandSeat *seat)
 {
     if (!seat->display->data_device_manager) {
@@ -2960,6 +2949,7 @@ static void Wayland_SeatCreateDataDevice(SDL_WaylandSeat *seat)
     if (!data_device->data_device) {
         SDL_free(data_device);
     } else {
+        Wayland_DataDeviceSetID(data_device);
         wl_data_device_set_user_data(data_device->data_device, data_device);
         wl_data_device_add_listener(data_device->data_device,
                                     &data_device_listener, data_device);
@@ -3449,6 +3439,7 @@ void Wayland_SeatDestroy(SDL_WaylandSeat *seat, bool send_events)
                 wl_data_device_destroy(seat->data_device->data_device);
             }
         }
+        SDL_free(seat->data_device->id_str);
         SDL_free(seat->data_device);
     }
 


### PR DESCRIPTION
…to the client

Wayland compositors may send recursive clipboard offers to the client, which need to be filtered out to avoid clearing local data. Previously this was worked around with a hack, but this caused the ownership flag to be set incorrectly, which broke some clients.

This introduces a metadata MIME type of application/x-sdl3-source-id to be sent with SDL3 selection offers, which contains an unique string that identifies the source of the offer, allowing for detection and filtering out of recursive offers.

Fixes #12557
