### PR TITLE
x11: Send key events for dead keys consumed by the IME

### DIFF
--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -987,29 +987,26 @@ void X11_HandleKeyEvent(SDL_VideoDevice *_this, SDL_WindowData *windowdata, SDL_
         }
     }
 
-    if (!handled_by_ime) {
-        if (pressed) {
-            X11_HandleModifierKeys(videodata, scancode, true, true);
-            SDL_SendKeyboardKeyIgnoreModifiers(timestamp, keyboardID, keycode, scancode, true);
-
-            if (*text && !(SDL_GetModState() & (SDL_KMOD_CTRL | SDL_KMOD_ALT))) {
-                text[text_length] = '\0';
-                X11_ClearComposition(windowdata);
-                SDL_SendKeyboardText(text);
-            }
-        } else {
-            if (X11_KeyRepeat(display, xevent)) {
-                // We're about to get a repeated key down, ignore the key up
-                return;
-            }
-
-            X11_HandleModifierKeys(videodata, scancode, false, true);
-            SDL_SendKeyboardKeyIgnoreModifiers(timestamp, keyboardID, keycode, scancode, false);
-        }
-    }
-
     if (pressed) {
+        X11_HandleModifierKeys(videodata, scancode, true, true);
+        SDL_SendKeyboardKeyIgnoreModifiers(timestamp, keyboardID, keycode, scancode, true);
+
+        // Synthesize a text event if the IME didn't consume a printable character
+        if (*text && !(SDL_GetModState() & (SDL_KMOD_CTRL | SDL_KMOD_ALT))) {
+            text[text_length] = '\0';
+            X11_ClearComposition(windowdata);
+            SDL_SendKeyboardText(text);
+        }
+
         X11_UpdateUserTime(windowdata, xevent->xkey.time);
+    } else {
+        if (X11_KeyRepeat(display, xevent)) {
+            // We're about to get a repeated key down, ignore the key up
+            return;
+        }
+
+        X11_HandleModifierKeys(videodata, scancode, false, true);
+        SDL_SendKeyboardKeyIgnoreModifiers(timestamp, keyboardID, keycode, scancode, false);
     }
 }
 


### PR DESCRIPTION
## Description
In https://github.com/libsdl-org/sdl2-compat/issues/465, the affected app doesn't see key presses for dead keys when text input is enabled. While I believe this behavior is technically allowed per the documentation around text input, it's not how the Wayland video driver behaves nor what SDL2 did on the same system.

## Existing Issue(s)
Fixes https://github.com/libsdl-org/sdl2-compat/issues/465
