### PR TITLE
SDL_GetRectIntersectionFloat(): Allow rendering zero-sized srcrect

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -3985,8 +3985,7 @@ bool SDL_RenderTexture(SDL_Renderer *renderer, SDL_Texture *texture, const SDL_F
     real_srcrect.w = (float)texture->w;
     real_srcrect.h = (float)texture->h;
     if (srcrect) {
-        if (!SDL_GetRectIntersectionFloat(srcrect, &real_srcrect, &real_srcrect) ||
-            real_srcrect.w == 0.0f || real_srcrect.h == 0.0f) {
+        if (!SDL_GetRectIntersectionFloat(srcrect, &real_srcrect, &real_srcrect)) {
             return true;
         }
     }


### PR DESCRIPTION
Allowing rendering with a zero-sized `srcrect` in function `SDL_GetRectIntersectionFloat()` so that it works similar to how `SDL_RenderTextureRotated()` and `SDL_BlitSurfaceScaled()` handle zero-sized srcrects.

First PR and discussion on rendering zero-sized srcrect: https://github.com/libsdl-org/SDL/issues/8580

Related(and videos on how it looks): https://github.com/libsdl-org/SDL/pull/12850