### PR TITLE
Joystick: Add trigger rumble resend

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -1986,6 +1986,14 @@ bool SDL_RumbleJoystickTriggers(SDL_Joystick *joystick, Uint16 left_rumble, Uint
             result = true;
         } else {
             result = joystick->driver->RumbleTriggers(joystick, left_rumble, right_rumble);
+            if (result) {
+                joystick->trigger_rumble_resend = SDL_GetTicks() + SDL_RUMBLE_RESEND_MS;
+                if (joystick->trigger_rumble_resend == 0) {
+                    joystick->trigger_rumble_resend = 1;
+                }
+            } else {
+                joystick->trigger_rumble_resend = 0;
+            }
         }
 
         if (result) {
@@ -1996,6 +2004,7 @@ bool SDL_RumbleJoystickTriggers(SDL_Joystick *joystick, Uint16 left_rumble, Uint
                 joystick->trigger_rumble_expiration = SDL_GetTicks() + SDL_min(duration_ms, SDL_MAX_RUMBLE_DURATION_MS);
             } else {
                 joystick->trigger_rumble_expiration = 0;
+                joystick->trigger_rumble_resend = 0;
             }
         }
     }
@@ -2651,6 +2660,15 @@ void SDL_UpdateJoysticks(void)
 
         if (joystick->trigger_rumble_expiration && now >= joystick->trigger_rumble_expiration) {
             SDL_RumbleJoystickTriggers(joystick, 0, 0, 0);
+            joystick->trigger_rumble_resend = 0;
+        }
+
+        if (joystick->trigger_rumble_resend && now >= joystick->trigger_rumble_resend) {
+            joystick->driver->RumbleTriggers(joystick, joystick->left_trigger_rumble, joystick->right_trigger_rumble);
+            joystick->trigger_rumble_resend = now + SDL_RUMBLE_RESEND_MS;
+            if (joystick->trigger_rumble_resend == 0) {
+                joystick->trigger_rumble_resend = 1;
+            }
         }
     }
 

--- a/src/joystick/SDL_sysjoystick.h
+++ b/src/joystick/SDL_sysjoystick.h
@@ -113,6 +113,7 @@ struct SDL_Joystick
     Uint16 left_trigger_rumble _guarded;
     Uint16 right_trigger_rumble _guarded;
     Uint64 trigger_rumble_expiration _guarded;
+    Uint64 trigger_rumble_resend _guarded;
 
     Uint8 led_red _guarded;
     Uint8 led_green _guarded;


### PR DESCRIPTION
This was already present for regular rumble to ensure that controllers would continue rumbling for extended periods, but was missing for trigger rumble. I don't know if this affects any controllers at the moment, but it's helpful for future-proofing.