### PR TITLE
Emscripten: fix incorrect error check for WebGL context creation

### DIFF
--- a/src/video/emscripten/SDL_emscriptenopengles.c
+++ b/src/video/emscripten/SDL_emscriptenopengles.c
@@ -101,7 +101,7 @@ SDL_GLContext Emscripten_GLES_CreateContext(SDL_VideoDevice *_this, SDL_Window *
 
     context = emscripten_webgl_create_context(window_data->canvas_id, &attribs);
 
-    if (context < 0) {
+    if (!context) {
         SDL_SetError("Could not create webgl context");
         return NULL;
     }


### PR DESCRIPTION
## Description

According to the documentation and testing the `emscripten_webgl_create_context` function returns `0` on error as oppposed to a negative number. This was causing the error message to be empty when the later `emscripten_webgl_make_context_current` call fails given the invalid context.

See https://emscripten.org/docs/api_reference/html5.h.html#c.emscripten_webgl_create_context

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
