### PR TITLE
GDK: Handle ProjectDir containing spaces

### DIFF
--- a/VisualC-GDK/SDL/SDL.vcxproj
+++ b/VisualC-GDK/SDL/SDL.vcxproj
@@ -168,8 +168,8 @@
     </Link>
     <PreBuildEvent>
       <Command>
-        call $(ProjectDir)..\..\src\render\direct3d12\compile_shaders_xbox.bat $(ProjectDir)..\
-        call $(ProjectDir)..\..\src\gpu\d3d12\compile_shaders_xbox.bat $(ProjectDir)..\
+        call "$(ProjectDir)..\..\src\render\direct3d12\compile_shaders_xbox.bat" "$(ProjectDir)..\"
+        call "$(ProjectDir)..\..\src\gpu\d3d12\compile_shaders_xbox.bat" "$(ProjectDir)..\"
       </Command>
     </PreBuildEvent>
     <PreBuildEvent>


### PR DESCRIPTION
The call to compile_shaders_xbox.bat fails if ProjectDir contains a space. Wrapping the command in quotes fixes the issue.

## Description
If for example your ProjectDir is located at 

`C:\Users\My Name\Foo\`

Then you'll get a failed pre-build step with an error, reporting that `C:\Users\My` is not a valid command.

## Existing Issue(s)
Fixes #12897.
