### PR TITLE
x11: Better handle XInput2 mouse tracking outside the window

### DIFF
--- a/src/video/x11/SDL_x11window.h
+++ b/src/video/x11/SDL_x11window.h
@@ -118,6 +118,7 @@ struct SDL_WindowData
     bool fullscreen_borders_forced_on;
     bool was_shown;
     bool emit_size_move_after_property_notify;
+    bool tracking_mouse_outside_window;
     SDL_HitTestResult hit_test_result;
 
     XPoint xim_spot;


### PR DESCRIPTION
There is a quirk with XInput2 mouse capture that causes a leave event to be sent if the pointer moves out->in->out, which breaks mouse tracking outside the window. If the mouse leaves the window with buttons pressed, continue tracking it until the buttons are released.

Fixes #12723
