### PR TITLE
chore: rename internal cursor visibility fields

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -229,7 +229,7 @@ static void SDLCALL SDL_MouseRelativeCursorVisibleChanged(void *userdata, const 
 {
     SDL_Mouse *mouse = (SDL_Mouse *)userdata;
 
-    mouse->relative_mode_cursor_visible = SDL_GetStringBoolean(hint, false);
+    mouse->relative_mode_hide_cursor = !(SDL_GetStringBoolean(hint, false));
 
     SDL_SetCursor(NULL); // Update cursor visibility
 }
@@ -1635,7 +1635,7 @@ bool SDL_SetCursor(SDL_Cursor *cursor)
         }
     }
 
-    if (cursor && (!mouse->focus || (mouse->cursor_visible && (!mouse->relative_mode || mouse->relative_mode_cursor_visible)))) {
+    if (cursor && (!mouse->focus || (mouse->cursor_visible && (!mouse->relative_mode || !mouse->relative_mode_hide_cursor)))) {
         if (mouse->ShowCursor) {
             mouse->ShowCursor(cursor);
         }

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -1607,7 +1607,7 @@ bool SDL_SetCursor(SDL_Cursor *cursor)
 {
     SDL_Mouse *mouse = SDL_GetMouse();
 
-    // Return immediately if setting the cursor to the currently set one (fixes #7151)
+    // already on this cursor, no further action required
     if (cursor == mouse->cur_cursor) {
         return true;
     }
@@ -1627,23 +1627,20 @@ bool SDL_SetCursor(SDL_Cursor *cursor)
             }
         }
         mouse->cur_cursor = cursor;
+    } else if (mouse->focus) {
+        cursor = mouse->cur_cursor;
     } else {
-        if (mouse->focus) {
-            cursor = mouse->cur_cursor;
-        } else {
-            cursor = mouse->def_cursor;
-        }
+        cursor = mouse->def_cursor;
     }
 
-    if (cursor && (!mouse->focus || (mouse->cursor_visible && (!mouse->relative_mode || !mouse->relative_mode_hide_cursor)))) {
-        if (mouse->ShowCursor) {
-            mouse->ShowCursor(cursor);
-        }
-    } else {
-        if (mouse->ShowCursor) {
-            mouse->ShowCursor(NULL);
-        }
+    if (mouse->focus && (!mouse->cursor_visible || (mouse->relative_mode && mouse->relative_mode_hide_cursor))) {
+        cursor = NULL;
     }
+
+    if (mouse->ShowCursor) {
+        mouse->ShowCursor(cursor);
+    }
+
     return true;
 }
 

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -304,7 +304,7 @@ bool SDL_PreInitMouse(void)
 
     mouse->was_touch_mouse_events = false; // no touch to mouse movement event pending
 
-    mouse->cursor_shown = true;
+    mouse->cursor_visible = true;
 
     return true;
 }
@@ -812,7 +812,7 @@ static void SDL_PrivateSendMouseMotion(Uint64 timestamp, SDL_Window *window, SDL
     }
 
     // Move the mouse cursor, if needed
-    if (mouse->cursor_shown && !mouse->relative_mode &&
+    if (mouse->cursor_visible && !mouse->relative_mode &&
         mouse->MoveCursor && mouse->cur_cursor) {
         mouse->MoveCursor(mouse->cur_cursor);
     }
@@ -1289,7 +1289,7 @@ static void SDL_MaybeEnableWarpEmulation(SDL_Window *window, float x, float y)
 {
     SDL_Mouse *mouse = SDL_GetMouse();
 
-    if (!mouse->warp_emulation_prohibited && mouse->warp_emulation_hint && !mouse->cursor_shown && !mouse->warp_emulation_active) {
+    if (!mouse->warp_emulation_prohibited && mouse->warp_emulation_hint && !mouse->cursor_visible && !mouse->warp_emulation_active) {
         if (!window) {
             window = mouse->focus;
         }
@@ -1635,7 +1635,7 @@ bool SDL_SetCursor(SDL_Cursor *cursor)
         }
     }
 
-    if (cursor && (!mouse->focus || (mouse->cursor_shown && (!mouse->relative_mode || mouse->relative_mode_cursor_visible)))) {
+    if (cursor && (!mouse->focus || (mouse->cursor_visible && (!mouse->relative_mode || mouse->relative_mode_cursor_visible)))) {
         if (mouse->ShowCursor) {
             mouse->ShowCursor(cursor);
         }
@@ -1711,8 +1711,8 @@ bool SDL_ShowCursor(void)
         mouse->warp_emulation_active = false;
     }
 
-    if (!mouse->cursor_shown) {
-        mouse->cursor_shown = true;
+    if (!mouse->cursor_visible) {
+        mouse->cursor_visible = true;
         SDL_SetCursor(NULL);
     }
     return true;
@@ -1722,8 +1722,8 @@ bool SDL_HideCursor(void)
 {
     SDL_Mouse *mouse = SDL_GetMouse();
 
-    if (mouse->cursor_shown) {
-        mouse->cursor_shown = false;
+    if (mouse->cursor_visible) {
+        mouse->cursor_visible = false;
         SDL_SetCursor(NULL);
     }
     return true;
@@ -1733,5 +1733,5 @@ bool SDL_CursorVisible(void)
 {
     SDL_Mouse *mouse = SDL_GetMouse();
 
-    return mouse->cursor_shown;
+    return mouse->cursor_visible;
 }

--- a/src/events/SDL_mouse_c.h
+++ b/src/events/SDL_mouse_c.h
@@ -148,7 +148,7 @@ typedef struct
     SDL_Cursor *cursors;
     SDL_Cursor *def_cursor;
     SDL_Cursor *cur_cursor;
-    bool cursor_shown;
+    bool cursor_visible;
 
     // Driver-dependent data.
     void *internal;

--- a/src/events/SDL_mouse_c.h
+++ b/src/events/SDL_mouse_c.h
@@ -114,7 +114,7 @@ typedef struct
     bool has_position;
     bool relative_mode;
     bool relative_mode_warp_motion;
-    bool relative_mode_cursor_visible;
+    bool relative_mode_hide_cursor;
     bool relative_mode_center;
     bool warp_emulation_hint;
     bool warp_emulation_active;

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -743,7 +743,7 @@ static NSCursor *Cocoa_GetDesiredCursor(void)
 {
     SDL_Mouse *mouse = SDL_GetMouse();
 
-    if (mouse->cursor_shown && mouse->cur_cursor && !mouse->relative_mode) {
+    if (mouse->cursor_visible && mouse->cur_cursor && !mouse->relative_mode) {
         return (__bridge NSCursor *)mouse->cur_cursor->internal;
     }
 

--- a/src/video/kmsdrm/SDL_kmsdrmmouse.c
+++ b/src/video/kmsdrm/SDL_kmsdrmmouse.c
@@ -50,7 +50,7 @@ static void KMSDRM_FreeCursor(SDL_Cursor *cursor);
 // KMSDRM_ShowCursor() simply shows or hides the cursor it receives: it does NOT
 // mind if it's mouse->cur_cursor, etc.
 // -If KMSDRM_ShowCursor() returns successfully, that cursor becomes
-// mouse->cur_cursor and mouse->cursor_shown is 1.
+// mouse->cur_cursor and mouse->cursor_visible is 1.
 /**************************************************************************************/
 
 static SDL_Cursor *KMSDRM_CreateDefaultCursor(void)

--- a/src/video/wayland/SDL_waylandmouse.c
+++ b/src/video/wayland/SDL_waylandmouse.c
@@ -1025,7 +1025,7 @@ void Wayland_RecreateCursors(void)
     }
     if (mouse->cur_cursor) {
         Wayland_RecreateCursor(mouse->cur_cursor, vdata);
-        if (mouse->cursor_shown) {
+        if (mouse->cursor_visible) {
             Wayland_ShowCursor(mouse->cur_cursor);
         }
     }

--- a/src/video/wayland/SDL_waylandmouse.c
+++ b/src/video/wayland/SDL_waylandmouse.c
@@ -1118,7 +1118,7 @@ void Wayland_SeatUpdateCursor(SDL_WaylandSeat *seat)
     if (pointer_focus) {
         const bool has_relative_focus = Wayland_SeatHasRelativePointerFocus(seat);
 
-        if (!seat->display->relative_mode_enabled || !has_relative_focus || mouse->relative_mode_cursor_visible) {
+        if (!seat->display->relative_mode_enabled || !has_relative_focus || !mouse->relative_mode_hide_cursor) {
             const SDL_HitTestResult rc = pointer_focus->hit_test_result;
 
             if ((seat->display->relative_mode_enabled && has_relative_focus) ||


### PR DESCRIPTION
was trying to tackle #12163, but the adhoc additions accumulated over the years made it hard to reason about the cursor visibility logic, so this PR is just a preamble cleanup split into self-contained commits