### PR TITLE
SDL_SetCursor shouldn't skip focus check when setting new cursor 

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -1627,7 +1627,9 @@ bool SDL_SetCursor(SDL_Cursor *cursor)
             }
         }
         mouse->cur_cursor = cursor;
-    } else if (mouse->focus) {
+    }
+
+    if (mouse->focus) {
         cursor = mouse->cur_cursor;
     } else {
         cursor = mouse->def_cursor;

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -231,7 +231,7 @@ static void SDLCALL SDL_MouseRelativeCursorVisibleChanged(void *userdata, const 
 
     mouse->relative_mode_hide_cursor = !(SDL_GetStringBoolean(hint, false));
 
-    SDL_SetCursor(NULL); // Update cursor visibility
+    SDL_RedrawCursor(); // Update cursor visibility
 }
 
 static void SDLCALL SDL_MouseIntegerModeChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
@@ -606,7 +606,7 @@ void SDL_SetMouseFocus(SDL_Window *window)
     }
 
     // Update cursor visibility
-    SDL_SetCursor(NULL);
+    SDL_RedrawCursor();
 }
 
 bool SDL_MousePositionInWindow(SDL_Window *window, float x, float y)
@@ -1360,7 +1360,7 @@ bool SDL_SetRelativeMouseMode(bool enabled)
 
     if (enabled) {
         // Update cursor visibility before we potentially warp the mouse
-        SDL_SetCursor(NULL);
+        SDL_RedrawCursor();
     }
 
     if (enabled && focusWindow) {
@@ -1380,7 +1380,7 @@ bool SDL_SetRelativeMouseMode(bool enabled)
 
     if (!enabled) {
         // Update cursor visibility after we restore the mouse position
-        SDL_SetCursor(NULL);
+        SDL_RedrawCursor();
     }
 
     // Flush pending mouse motion - ideally we would pump events, but that's not always safe
@@ -1720,7 +1720,7 @@ bool SDL_ShowCursor(void)
 
     if (!mouse->cursor_visible) {
         mouse->cursor_visible = true;
-        SDL_SetCursor(NULL);
+        SDL_RedrawCursor();
     }
     return true;
 }
@@ -1731,7 +1731,7 @@ bool SDL_HideCursor(void)
 
     if (mouse->cursor_visible) {
         mouse->cursor_visible = false;
-        SDL_SetCursor(NULL);
+        SDL_RedrawCursor();
     }
     return true;
 }

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -1599,6 +1599,26 @@ SDL_Cursor *SDL_CreateSystemCursor(SDL_SystemCursor id)
     return cursor;
 }
 
+void SDL_RedrawCursor(void)
+{
+    SDL_Mouse *mouse = SDL_GetMouse();
+    SDL_Cursor *cursor;
+
+    if (mouse->focus) {
+        cursor = mouse->cur_cursor;
+    } else {
+        cursor = mouse->def_cursor;
+    }
+
+    if (mouse->focus && (!mouse->cursor_visible || (mouse->relative_mode && mouse->relative_mode_hide_cursor))) {
+        cursor = NULL;
+    }
+
+    if (mouse->ShowCursor) {
+        mouse->ShowCursor(cursor);
+    }
+}
+
 /* SDL_SetCursor(NULL) can be used to force the cursor redraw,
    if this is desired for any reason.  This is used when setting
    the video mode and when the SDL window gains the mouse focus.
@@ -1629,19 +1649,7 @@ bool SDL_SetCursor(SDL_Cursor *cursor)
         mouse->cur_cursor = cursor;
     }
 
-    if (mouse->focus) {
-        cursor = mouse->cur_cursor;
-    } else {
-        cursor = mouse->def_cursor;
-    }
-
-    if (mouse->focus && (!mouse->cursor_visible || (mouse->relative_mode && mouse->relative_mode_hide_cursor))) {
-        cursor = NULL;
-    }
-
-    if (mouse->ShowCursor) {
-        mouse->ShowCursor(cursor);
-    }
+    SDL_RedrawCursor();
 
     return true;
 }

--- a/src/events/SDL_mouse_c.h
+++ b/src/events/SDL_mouse_c.h
@@ -176,6 +176,9 @@ extern void SDL_SetMouseName(SDL_MouseID mouseID, const char *name);
 extern SDL_Mouse *SDL_GetMouse(void);
 
 // Set the default mouse cursor
+extern void SDL_RedrawCursor(void);
+
+// Set the default mouse cursor
 extern void SDL_SetDefaultCursor(SDL_Cursor *cursor);
 
 // Get the preferred default system cursor

--- a/src/video/riscos/SDL_riscosmodes.c
+++ b/src/video/riscos/SDL_riscosmodes.c
@@ -302,7 +302,7 @@ bool RISCOS_SetDisplayMode(SDL_VideoDevice *_this, SDL_VideoDisplay *display, SD
     }
 
     // Update cursor visibility, since it may have been disabled by the mode change.
-    SDL_SetCursor(NULL);
+    SDL_RedrawCursor();
 
     return true;
 }

--- a/src/video/wayland/SDL_waylandmouse.c
+++ b/src/video/wayland/SDL_waylandmouse.c
@@ -196,7 +196,7 @@ static DBusHandlerResult Wayland_DBusCursorMessageFilter(DBusConnection *conn, D
 
             if (dbus_cursor_size != new_cursor_size) {
                 dbus_cursor_size = new_cursor_size;
-                SDL_SetCursor(NULL); // Force cursor update
+                SDL_RedrawCursor(); // Force cursor update
             }
         } else if (SDL_strcmp(CURSOR_THEME_KEY, key) == 0) {
             const char *new_cursor_theme = NULL;
@@ -223,7 +223,7 @@ static DBusHandlerResult Wayland_DBusCursorMessageFilter(DBusConnection *conn, D
 
                 // Purge the current cached themes and force a cursor refresh.
                 Wayland_FreeCursorThemes(vdata);
-                SDL_SetCursor(NULL);
+                SDL_RedrawCursor();
             }
         } else {
             goto not_our_signal;

--- a/src/video/x11/SDL_x11mouse.c
+++ b/src/video/x11/SDL_x11mouse.c
@@ -552,7 +552,7 @@ void X11_QuitMouse(SDL_VideoDevice *_this)
 void X11_SetHitTestCursor(SDL_HitTestResult rc)
 {
     if (rc == SDL_HITTEST_NORMAL || rc == SDL_HITTEST_DRAGGABLE) {
-        SDL_SetCursor(NULL);
+        SDL_RedrawCursor();
     } else {
         X11_ShowCursor(sys_cursors[rc]);
     }


### PR DESCRIPTION
Likely the last preparatory change before attempting a solution at #12163.

This introduces one minor behavior change and one minor internal symbol change, the changes are split into individual commits as atomic units.

Before, calling SDL_SetCursor with a new cursor will unconditionally set the displayed cursor to the one requested regardless of focus, which means that if this is called while unfocused the cursor will flash to the requested on for one frame before correcting back to the default non-focused cursor.

Now, the side effect of actually setting the displayed cursor is split to its own `SDL_RedrawCursor()` procedure which always checks focus, and SDL's internal usage of `SDL_SetCursor(NULL)` is replaced with this for better clarity.