### PR TITLE
add hint for user-managed cursor redraw

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2653,6 +2653,21 @@ extern "C" {
 #define SDL_HINT_MOUSE_RELATIVE_CURSOR_VISIBLE "SDL_MOUSE_RELATIVE_CURSOR_VISIBLE"
 
 /**
+ * A variable controlling whether SDL should leave cursor redraws to be manually
+ * issued by usercode instead of automatically refreshing on state changes.
+ *
+ * This variable can be set to the following values:
+ *
+ * - "0": SDL will issue redraws automatically when focus changes (default)
+ * - "1": The usercode is responsible for updating the cursor on focus change.
+ *
+ * This hint can be set anytime.
+ *
+ * \since This hint is available since SDL 3.4.0.
+ */
+#define SDL_HINT_MOUSE_CURSOR_SUSPEND_REDRAW "SDL_MOUSE_CURSOR_SUSPEND_REDRAW"
+
+/**
  * A variable controlling whether mouse events should generate synthetic touch
  * events.
  *

--- a/src/events/SDL_mouse_c.h
+++ b/src/events/SDL_mouse_c.h
@@ -149,6 +149,7 @@ typedef struct
     SDL_Cursor *def_cursor;
     SDL_Cursor *cur_cursor;
     bool cursor_visible;
+    bool cursor_auto_redraw;
 
     // Driver-dependent data.
     void *internal;


### PR DESCRIPTION
Fixes #12163. Sort of, as this is a naive solution that uncritically implements the request exactly as described, there may be an XY problem where a broader solution is more appropriate. It's also possible that this would still be a useful escape hatch to have regardless.

Also seeking suggestions on a more appropriate name for this hint.

