### PR TITLE
GPU: Validate that textures are not bound for both read and write on render passes

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -1576,7 +1576,7 @@ SDL_GPURenderPass *SDL_BeginGPURenderPass(
 
     commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
     commandBufferHeader->render_pass.in_progress = true;
-    for (Sint32 i = 0; i < num_color_targets; i += 1) {
+    for (Uint32 i = 0; i < num_color_targets; i += 1) {
         commandBufferHeader->render_pass.color_targets[i] = color_target_infos[i].texture;
     }
     commandBufferHeader->render_pass.num_color_targets = num_color_targets;
@@ -2024,7 +2024,7 @@ void SDL_EndGPURenderPass(
 
     commandBufferCommonHeader = (CommandBufferCommonHeader *)RENDERPASS_COMMAND_BUFFER;
     commandBufferCommonHeader->render_pass.in_progress = false;
-    for (Sint32 i = 0; i < MAX_COLOR_TARGET_BINDINGS; i += 1)
+    for (Uint32 i = 0; i < MAX_COLOR_TARGET_BINDINGS; i += 1)
     {
         commandBufferCommonHeader->render_pass.color_targets[i] = NULL;
     }

--- a/src/gpu/SDL_sysgpu.h
+++ b/src/gpu/SDL_sysgpu.h
@@ -24,6 +24,21 @@
 #ifndef SDL_GPU_DRIVER_H
 #define SDL_GPU_DRIVER_H
 
+// GraphicsDevice Limits
+
+#define MAX_TEXTURE_SAMPLERS_PER_STAGE 16
+#define MAX_STORAGE_TEXTURES_PER_STAGE 8
+#define MAX_STORAGE_BUFFERS_PER_STAGE  8
+#define MAX_UNIFORM_BUFFERS_PER_STAGE  4
+#define MAX_COMPUTE_WRITE_TEXTURES     8
+#define MAX_COMPUTE_WRITE_BUFFERS      8
+#define UNIFORM_BUFFER_SIZE            32768
+#define MAX_VERTEX_BUFFERS             16
+#define MAX_VERTEX_ATTRIBUTES          16
+#define MAX_COLOR_TARGET_BINDINGS      4
+#define MAX_PRESENT_COUNT              16
+#define MAX_FRAMES_IN_FLIGHT           3
+
 // Common Structs
 
 typedef struct Pass
@@ -36,7 +51,7 @@ typedef struct RenderPass
 {
     SDL_GPUCommandBuffer *command_buffer;
     bool in_progress;
-    SDL_GPUTexture *color_targets[4];
+    SDL_GPUTexture *color_targets[MAX_COLOR_TARGET_BINDINGS];
     Uint32 num_color_targets;
     SDL_GPUTexture *depth_stencil_target;
 } RenderPass;
@@ -543,21 +558,6 @@ static inline Uint32 BytesPerRow(
     Uint32 blocksPerRow = (width + blockWidth - 1) / blockWidth;
     return blocksPerRow * SDL_GPUTextureFormatTexelBlockSize(format);
 }
-
-// GraphicsDevice Limits
-
-#define MAX_TEXTURE_SAMPLERS_PER_STAGE 16
-#define MAX_STORAGE_TEXTURES_PER_STAGE 8
-#define MAX_STORAGE_BUFFERS_PER_STAGE  8
-#define MAX_UNIFORM_BUFFERS_PER_STAGE  4
-#define MAX_COMPUTE_WRITE_TEXTURES     8
-#define MAX_COMPUTE_WRITE_BUFFERS      8
-#define UNIFORM_BUFFER_SIZE            32768
-#define MAX_VERTEX_BUFFERS             16
-#define MAX_VERTEX_ATTRIBUTES          16
-#define MAX_COLOR_TARGET_BINDINGS      4
-#define MAX_PRESENT_COUNT              16
-#define MAX_FRAMES_IN_FLIGHT           3
 
 // Internal Macros
 

--- a/src/gpu/SDL_sysgpu.h
+++ b/src/gpu/SDL_sysgpu.h
@@ -32,10 +32,19 @@ typedef struct Pass
     bool in_progress;
 } Pass;
 
+typedef struct RenderPass
+{
+    SDL_GPUCommandBuffer *command_buffer;
+    bool in_progress;
+    SDL_GPUTexture *color_targets[4];
+    Uint32 num_color_targets;
+    SDL_GPUTexture *depth_stencil_target;
+} RenderPass;
+
 typedef struct CommandBufferCommonHeader
 {
     SDL_GPUDevice *device;
-    Pass render_pass;
+    RenderPass render_pass;
     bool graphics_pipeline_bound;
     Pass compute_pass;
     bool compute_pipeline_bound;


### PR DESCRIPTION
A very common user error is to bind the same texture as both a render target and a sampler texture or storage texture. This is undefined behavior on every backend, so our spec shouldn't allow it. This patch causes SDL to assert if a client does this when the GPU device is in debug mode.

Fixes #12762 