### PR TITLE
events: Add integer wheel fields for sdl2-compat

### DIFF
--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -492,6 +492,8 @@ typedef struct SDL_MouseWheelEvent
     SDL_MouseWheelDirection direction; /**< Set to one of the SDL_MOUSEWHEEL_* defines. When FLIPPED the values in X and Y will be opposite. Multiply by -1 to change them back */
     float mouse_x;      /**< X coordinate, relative to window */
     float mouse_y;      /**< Y coordinate, relative to window */
+    Sint32 integer_x;   /**< The amount scrolled horizontally, accumulated to whole scroll "ticks" (added in 3.2.12) */
+    Sint32 integer_y;   /**< The amount scrolled vertically, accumulated to whole scroll "ticks" (added in 3.2.12) */
 } SDL_MouseWheelEvent;
 
 /**

--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -625,9 +625,10 @@ int SDL_GetEventDescription(const SDL_Event *event, char *buf, int buflen)
 #undef PRINT_MBUTTON_EVENT
 
         SDL_EVENT_CASE(SDL_EVENT_MOUSE_WHEEL)
-        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u which=%u x=%g y=%g direction=%s)",
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%u windowid=%u which=%u x=%g y=%g integer_x=%d integer_y=%d direction=%s)",
                            (uint)event->wheel.timestamp, (uint)event->wheel.windowID,
                            (uint)event->wheel.which, event->wheel.x, event->wheel.y,
+                           (int)event->wheel.integer_x, (int)event->wheel.integer_y,
                            event->wheel.direction == SDL_MOUSEWHEEL_NORMAL ? "normal" : "flipped");
         break;
 

--- a/src/events/SDL_mouse_c.h
+++ b/src/events/SDL_mouse_c.h
@@ -99,8 +99,6 @@ typedef struct
     Uint8 integer_mode_flags; // 1 to enable mouse quantization, 2 to enable wheel quantization
     float integer_mode_residual_motion_x;
     float integer_mode_residual_motion_y;
-    float integer_mode_residual_scroll_x;
-    float integer_mode_residual_scroll_y;
 
     // Data common to all mice
     SDL_Window *focus;
@@ -109,6 +107,8 @@ typedef struct
     float x_accu;
     float y_accu;
     float last_x, last_y; // the last reported x and y coordinates
+    float residual_scroll_x;
+    float residual_scroll_y;
     double click_motion_x;
     double click_motion_y;
     bool has_position;


### PR DESCRIPTION
## Description
Reintroduce integer mouse wheel x/y fields for use by sdl2-compat (and applications that don't care to support smooth scrolling). It's much easier to just have SDL3 provide these than handle it properly in all the places in sdl2-compat where we interact with events at various stages of processing.

## Existing Issue(s)
https://github.com/libsdl-org/sdl2-compat/issues/461