### PR TITLE
Remove "-mwindows" flag from MinGW/Cygwin link options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2162,9 +2162,6 @@ elseif(WINDOWS)
 
   enable_language(RC)
   sdl_glob_sources(SHARED "${SDL3_SOURCE_DIR}/src/core/windows/*.rc")
-  if(MINGW OR CYGWIN)
-    sdl_pc_link_options("-mwindows")
-  endif()
 
 elseif(APPLE)
   # TODO: rework this all for proper macOS, iOS and Darwin support


### PR DESCRIPTION
## Description
This PR removes the "-mwindows" link option from the MinGW/Cygwin PkgConfig. This flag is problematic as it redirects `stdout` and `stderr` to NULL.

This behavior is unintuitive, as one would not expect adding a new library to break console output. It should be up to the consumer to decide if they want to use the flag, rather than the library making assumptions about the project.

This has been previously discussed ([and fixed](https://github.com/libsdl-org/SDL/issues/5948#issuecomment-1193144456)) in this thread: https://github.com/libsdl-org/SDL/issues/5948.

**EDIT:**

It's also good to note that the documentation already covers adding the "WIN32" parameter in CMake, which will pass "-mwindows" by default: https://github.com/libsdl-org/SDL/blob/main/docs/INTRO-cmake.md https://github.com/libsdl-org/SDL/blob/main/docs/README-windows.md