### PR TITLE
Fix default behaviour of VITA_TOUCH_MOUSE_DEVICE hint

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -279,6 +279,8 @@ bool SDL_PreInitMouse(void)
 #ifdef SDL_PLATFORM_VITA
     SDL_AddHintCallback(SDL_HINT_VITA_TOUCH_MOUSE_DEVICE,
                         SDL_VitaTouchMouseDeviceChanged, mouse);
+
+    mouse->vita_touch_mouse_device = 1;
 #endif
 
     SDL_AddHintCallback(SDL_HINT_MOUSE_TOUCH_EVENTS,


### PR DESCRIPTION
Follow-up from https://github.com/libsdl-org/SDL/pull/11999. I forgot to initialise the `vita_touch_mouse_device` value as 1, which is what it needs to be for the default behaviour of the front touchpad to generate synthetic mouse events when no value is explicitly set for the hint.