### PR TITLE
Merge some things from the SupportedPlatforms Wiki page

### DIFF
--- a/docs/README-platforms.md
+++ b/docs/README-platforms.md
@@ -2,28 +2,36 @@
 
 ## Supported Platforms
 
+SDL3 has been known to work on the following platforms at some point:
+
 - [Android](README-android.md)
-- [Emscripten](README-emscripten.md)
+- [Emscripten](README-emscripten.md) (Web browsers)
 - [FreeBSD](README-bsd.md)
 - [Haiku OS](README-haiku.md)
 - [iOS](README-ios.md)
 - [Linux](README-linux.md)
-- [macOS](README-macos.md)
+- [macOS](README-macos.md) (10.14 and later)
 - [NetBSD](README-bsd.md)
-- [Nintendo Switch](README-switch.md)
-- [Nintendo 3DS](README-3ds.md)
+- [Nintendo Switch](README-switch.md) (Separate NDA-only fork)
+- [Nintendo 3DS](README-3ds.md) (Homebrew)
 - [OpenBSD](README-bsd.md)
-- [PlayStation 2](README-ps2.md)
-- [PlayStation 4](README-ps4.md)
-- [PlayStation 5](README-ps5.md)
-- [PlayStation Portable](README-psp.md)
-- [PlayStation Vita](README-vita.md)
+- [PlayStation 2](README-ps2.md) (Homebrew)
+- [PlayStation 4](README-ps4.md) (Separate NDA-only fork)
+- [PlayStation 5](README-ps5.md) (Separate NDA-only fork)
+- [PlayStation Portable](README-psp.md) (Homebrew)
+- [PlayStation Vita](README-vita.md) (Homebrew)
+- QNX
 - [RISC OS](README-riscos.md)
 - [SteamOS](README-steamos.md)
 - [tvOS](README-ios.md)
-- [Windows](README-windows.md)
+- [visionOS](README-ios.md)
+- [Windows](README-windows.md) (XP and later)
 - [Windows GDK](README-gdk.md)
 - [Xbox](README-gdk.md)
+
+Note that the SDL maintainers do not test on all these platforms; if a less-common system breaks, [please let us know](https://github.com/libsdl-org/SDL/issues/new) and send patches if you can.
+
+If you'd like to port SDL to a new platform, feel free to get in touch! [A guide to porting SDL2](https://discourse.libsdl.org/t/port-sdl-2-0-to-bios/25453/2) was written a while ago, and most of it still applies to SDL3.
 
 ## Unsupported Platforms
 
@@ -35,6 +43,5 @@ All of these still work with [SDL2](/SDL2), which is an incompatible API, but an
 - NaCL
 - Nokia N-Gage
 - OS/2
-- QNX
 - WinPhone
 - WinRT/UWP


### PR DESCRIPTION
While adding a link to the `README-platforms` page on the main page of the wiki, I later rediscovered that [there is a second SupportedPlatforms page](https://wiki.libsdl.org/SDL3/SupportedPlatforms) that is located directly on the wiki. I feel like this shouldn't be duplicated across two places, so I decided to merge some of the things that is mentioned in SupportedPlatforms but not in this docs page so this could become the only one.