### PR TITLE
cpuinfo: Use auxv for AltiVec on Linux if possible

### DIFF
--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -115,7 +115,7 @@
 #define CPU_CFG2_LSX  (1 << 6)
 #define CPU_CFG2_LASX (1 << 7)
 
-#if defined(SDL_ALTIVEC_BLITTERS) && defined(HAVE_SETJMP) && !defined(SDL_PLATFORM_MACOS) && !defined(SDL_PLATFORM_OPENBSD) && !defined(SDL_PLATFORM_FREEBSD)
+#if defined(SDL_ALTIVEC_BLITTERS) && defined(HAVE_SETJMP) && !defined(SDL_PLATFORM_MACOS) && !defined(SDL_PLATFORM_OPENBSD) && !defined(SDL_PLATFORM_FREEBSD) && (defined(SDL_PLATFORM_LINUX) && !defined(HAVE_GETAUXVAL))
 /* This is the brute force way of detecting instruction sets...
    the idea is borrowed from the libmpeg2 library - thanks!
  */
@@ -344,6 +344,8 @@ static int CPU_haveAltiVec(void)
     elf_aux_info(AT_HWCAP, &cpufeatures, sizeof(cpufeatures));
     altivec = cpufeatures & PPC_FEATURE_HAS_ALTIVEC;
     return altivec;
+#elif defined(SDL_PLATFORM_LINUX) && defined(__powerpc__) && defined(HAVE_GETAUXVAL)
+    altivec = getauxval(AT_HWCAP) & PPC_FEATURE_HAS_ALTIVEC;
 #elif defined(SDL_ALTIVEC_BLITTERS) && defined(HAVE_SETJMP)
     void (*handler)(int sig);
     handler = signal(SIGILL, illegal_instruction);


### PR DESCRIPTION
## Description
The SIGILL handler is not very reliable and can cause crashes.

Linux provides the CPU's AltiVec support status in getauxval.

## Existing Issue(s)
None seem to be reported to SDL itself.  A few distro-specific bugs have been submitted.  We were notified by a user trying to run SuperTux on Wii U, which has a PPC 750 (like G3) which does not support AltiVec.  They received a crash (with SIGILL) before this patch, and a working game after this patch.

Note that SuperTux uses SDL 2, and the patch was applied to our [Espresso](https://blog.atwilcox.tech/2025/02/24/espresso-alpha-available/) [SDL 2 package](https://code.atwilcox.tech/sphen/espresso/packages/-/commit/1fe59f5309dc286b431aca1bc8b215d9a5a98bc4).  I wasn't able to find any SDL 3 clients to easily test on a Wii U, so I can't say for sure SDL 3 has the same bug nor can I say this is 100% guaranteed to work, but it seemed the right thing to submit here anyway.  I'm not sure if there is still a way to submit fixes for SDL 2, but it would be great to have this there too, if there is another patch release planned.