### PR TITLE
[emscripten] Remove reference to Module['createContext']

### DIFF
--- a/src/video/emscripten/SDL_emscriptenframebuffer.c
+++ b/src/video/emscripten/SDL_emscriptenframebuffer.c
@@ -78,7 +78,7 @@ bool Emscripten_UpdateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *wind
         if (!Module['SDL3']) Module['SDL3'] = {};
         var SDL3 = Module['SDL3'];
         if (SDL3.ctxCanvas !== canvas) {
-            SDL3.ctx = Module['createContext'](canvas, false, true);
+            SDL3.ctx = Browser.createContext(canvas, false, true);
             SDL3.ctxCanvas = canvas;
         }
         if (SDL3.w !== w || SDL3.h !== h || SDL3.imageCtx !== SDL3.ctx) {


### PR DESCRIPTION
The Module interface is the one used by the outside world.  This code is inside the module itself so can use the internal name, avoiding the need to export this function on the Module at all.

See https://github.com/emscripten-core/emscripten/pull/24269