### PR TITLE
x11: Filter out duplicate key presses when an IME is active

### DIFF
--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -988,8 +988,11 @@ void X11_HandleKeyEvent(SDL_VideoDevice *_this, SDL_WindowData *windowdata, SDL_
     }
 
     if (pressed) {
-        X11_HandleModifierKeys(videodata, scancode, true, true);
-        SDL_SendKeyboardKeyIgnoreModifiers(timestamp, keyboardID, keycode, scancode, true);
+        // Duplicate events may be sent when an IME is active; don't send multiple keydown events for the same serial.
+        if (videodata->last_key_down_serial != xevent->xkey.serial) {
+            X11_HandleModifierKeys(videodata, scancode, true, true);
+            SDL_SendKeyboardKeyIgnoreModifiers(timestamp, keyboardID, keycode, scancode, true);
+        }
 
         // Synthesize a text event if the IME didn't consume a printable character
         if (*text && !(SDL_GetModState() & (SDL_KMOD_CTRL | SDL_KMOD_ALT))) {
@@ -999,6 +1002,7 @@ void X11_HandleKeyEvent(SDL_VideoDevice *_this, SDL_WindowData *windowdata, SDL_
         }
 
         X11_UpdateUserTime(windowdata, xevent->xkey.time);
+        videodata->last_key_down_serial = xevent->xkey.serial;
     } else {
         if (X11_KeyRepeat(display, xevent)) {
             // We're about to get a repeated key down, ignore the key up

--- a/src/video/x11/SDL_x11video.h
+++ b/src/video/x11/SDL_x11video.h
@@ -140,6 +140,8 @@ struct SDL_VideoData
     int xinput_master_pointer_device;
     bool xinput_hierarchy_changed;
 
+    unsigned long last_key_down_serial;
+
     int xrandr_event_base;
     struct
     {


### PR DESCRIPTION
IME text events can result in sending duplicate key press events, which will result in undesired repeated key presses. Since the events are exact duplicates, compare the serials to filter out redundant key down events.

Fixes #12965
