### PR TITLE
Add hid_version and hid_version_str to renamed LIBUSB impl symbols

### DIFF
--- a/src/hidapi/SDL_hidapi.c
+++ b/src/hidapi/SDL_hidapi.c
@@ -807,6 +807,8 @@ typedef struct LIBUSB_hid_device_ LIBUSB_hid_device;
 #define hid_send_feature_report      LIBUSB_hid_send_feature_report
 #define hid_set_nonblocking          LIBUSB_hid_set_nonblocking
 #define hid_write                    LIBUSB_hid_write
+#define hid_version                  LIBUSB_hid_version
+#define hid_version_str              LIBUSB_hid_version_str
 #define input_report                 LIBUSB_input_report
 #define make_path                    LIBUSB_make_path
 #define new_hid_device               LIBUSB_new_hid_device


### PR DESCRIPTION
On our project that uses both hidapi and SDL was getting symbol conflicts:
```
ld.lld: error: duplicate symbol: hid_version
>>> defined at SDL_hidapi.c
>>>            SDL_hidapi.c.o:(hid_version) in archive ../3rdparty/libsdl-org/SDL/libSDL3.a
>>> defined at hid.c
>>>            hid.c.o:(.text+0x0) in archive ../3rdparty/hidapi/hidapi/src/linux/libhidapi-hidraw.a

ld.lld: error: duplicate symbol: hid_version_str
>>> defined at SDL_hidapi.c
>>>            SDL_hidapi.c.o:(hid_version_str) in archive ../3rdparty/libsdl-org/SDL/libSDL3.a
>>> defined at hid.c
>>>            hid.c.o:(.text+0x10) in archive ../3rdparty/hidapi/hidapi/src/linux/libhidapi-hidraw.a
```

hid_version and hid_version_str were missing from the symbol renaming for the libusb implementation.