### PR TITLE
GPU: Special case to avoid assert on GenerateMipmaps

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -1756,7 +1756,11 @@ void SDL_BindGPUVertexSamplers(
 
     if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS
-        CHECK_SAMPLER_TEXTURES
+
+        if (!((CommandBufferCommonHeader*)RENDERPASS_COMMAND_BUFFER)->ignore_render_pass_texture_validation)
+        {
+            CHECK_SAMPLER_TEXTURES
+        }
     }
 
     RENDERPASS_DEVICE->BindVertexSamplers(
@@ -1836,7 +1840,11 @@ void SDL_BindGPUFragmentSamplers(
 
     if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS
-        CHECK_SAMPLER_TEXTURES
+
+        if (!((CommandBufferCommonHeader*)RENDERPASS_COMMAND_BUFFER)->ignore_render_pass_texture_validation)
+        {
+            CHECK_SAMPLER_TEXTURES
+        }
     }
 
     RENDERPASS_DEVICE->BindFragmentSamplers(
@@ -2605,11 +2613,19 @@ void SDL_GenerateMipmapsForGPUTexture(
             SDL_assert_release(!"GenerateMipmaps texture must be created with SAMPLER and COLOR_TARGET usage flags!");
             return;
         }
+
+        CommandBufferCommonHeader *commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
+        commandBufferHeader->ignore_render_pass_texture_validation = true;
     }
 
     COMMAND_BUFFER_DEVICE->GenerateMipmaps(
         command_buffer,
         texture);
+
+    if (COMMAND_BUFFER_DEVICE->debug_mode) {
+        CommandBufferCommonHeader *commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
+        commandBufferHeader->ignore_render_pass_texture_validation = false;
+    }
 }
 
 void SDL_BlitGPUTexture(

--- a/src/gpu/SDL_sysgpu.h
+++ b/src/gpu/SDL_sysgpu.h
@@ -66,6 +66,8 @@ typedef struct CommandBufferCommonHeader
     Pass copy_pass;
     bool swapchain_texture_acquired;
     bool submitted;
+    // used to avoid tripping assert on GenerateMipmaps
+    bool ignore_render_pass_texture_validation;
 } CommandBufferCommonHeader;
 
 typedef struct TextureCommonHeader


### PR DESCRIPTION
Resolves #12993 

99% of the time binding a texture as both a render target and sampler is a user error. Our GenerateMipmaps process is a rare exception that blits one level to another. In debug mode we set a special bool that ignores the texture validation until the generation process is complete.