### PR TITLE
dialog: Add more xdg portal fields for saving

### DIFF
--- a/include/SDL3/SDL_dialog.h
+++ b/include/SDL3/SDL_dialog.h
@@ -323,14 +323,17 @@ typedef enum SDL_FileDialogType
  */
 extern SDL_DECLSPEC void SDLCALL SDL_ShowFileDialogWithProperties(SDL_FileDialogType type, SDL_DialogFileCallback callback, void *userdata, SDL_PropertiesID props);
 
-#define SDL_PROP_FILE_DIALOG_FILTERS_POINTER     "SDL.filedialog.filters"
-#define SDL_PROP_FILE_DIALOG_NFILTERS_NUMBER     "SDL.filedialog.nfilters"
-#define SDL_PROP_FILE_DIALOG_WINDOW_POINTER      "SDL.filedialog.window"
-#define SDL_PROP_FILE_DIALOG_LOCATION_STRING     "SDL.filedialog.location"
-#define SDL_PROP_FILE_DIALOG_MANY_BOOLEAN        "SDL.filedialog.many"
-#define SDL_PROP_FILE_DIALOG_TITLE_STRING        "SDL.filedialog.title"
-#define SDL_PROP_FILE_DIALOG_ACCEPT_STRING       "SDL.filedialog.accept"
-#define SDL_PROP_FILE_DIALOG_CANCEL_STRING       "SDL.filedialog.cancel"
+#define SDL_PROP_FILE_DIALOG_FILTERS_POINTER       "SDL.filedialog.filters"
+#define SDL_PROP_FILE_DIALOG_NFILTERS_NUMBER       "SDL.filedialog.nfilters"
+#define SDL_PROP_FILE_DIALOG_CURRENT_FILTER_NUMBER "SDL.filedialog.current_filter"
+#define SDL_PROP_FILE_DIALOG_WINDOW_POINTER        "SDL.filedialog.window"
+#define SDL_PROP_FILE_DIALOG_LOCATION_STRING       "SDL.filedialog.location"
+#define SDL_PROP_FILE_DIALOG_CURRENT_NAME_STRING   "SDL.filedialog.current_name"
+#define SDL_PROP_FILE_DIALOG_CURRENT_FILE_STRING   "SDL.filedialog.current_file"
+#define SDL_PROP_FILE_DIALOG_MANY_BOOLEAN          "SDL.filedialog.many"
+#define SDL_PROP_FILE_DIALOG_TITLE_STRING          "SDL.filedialog.title"
+#define SDL_PROP_FILE_DIALOG_ACCEPT_STRING         "SDL.filedialog.accept"
+#define SDL_PROP_FILE_DIALOG_CANCEL_STRING         "SDL.filedialog.cancel"
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/src/dialog/unix/SDL_portaldialog.c
+++ b/src/dialog/unix/SDL_portaldialog.c
@@ -137,6 +137,20 @@ static void DBus_AppendFilters(SDL_DBusContext *dbus, DBusMessageIter *options, 
     dbus->message_iter_close_container(options, &options_pair);
 }
 
+static void DBus_AppendCurrentFilter(SDL_DBusContext *dbus, DBusMessageIter *options, const SDL_DialogFileFilter filter)
+{
+    DBusMessageIter options_pair, options_value;
+    static const char *current_filter_name = "current_filter";
+
+    dbus->message_iter_open_container(options, DBUS_TYPE_DICT_ENTRY, NULL, &options_pair);
+    dbus->message_iter_append_basic(&options_pair, DBUS_TYPE_STRING, &current_filter_name);
+    dbus->message_iter_open_container(&options_pair, DBUS_TYPE_VARIANT, "(sa(us))", &options_value);
+    DBus_AppendFilter(dbus, &options_value, filter);
+    dbus->message_iter_close_container(&options_pair, &options_value);
+    dbus->message_iter_close_container(options, &options_pair);
+
+}
+
 static void DBus_AppendByteArray(SDL_DBusContext *dbus, DBusMessageIter *options, const char *key, const char *value)
 {
     DBusMessageIter options_pair, options_value, options_array;
@@ -291,8 +305,11 @@ void SDL_Portal_ShowFileDialogWithProperties(SDL_FileDialogType type, SDL_Dialog
     SDL_Window* window = SDL_GetPointerProperty(props, SDL_PROP_FILE_DIALOG_WINDOW_POINTER, NULL);
     SDL_DialogFileFilter *filters = SDL_GetPointerProperty(props, SDL_PROP_FILE_DIALOG_FILTERS_POINTER, NULL);
     int nfilters = (int) SDL_GetNumberProperty(props, SDL_PROP_FILE_DIALOG_NFILTERS_NUMBER, 0);
+    int current_filter = (int) SDL_GetNumberProperty(props, SDL_PROP_FILE_DIALOG_CURRENT_FILTER_NUMBER, -1);
     bool allow_many = SDL_GetBooleanProperty(props, SDL_PROP_FILE_DIALOG_MANY_BOOLEAN, false);
     const char* default_location = SDL_GetStringProperty(props, SDL_PROP_FILE_DIALOG_LOCATION_STRING, NULL);
+    const char* current_name = SDL_GetStringProperty(props, SDL_PROP_FILE_DIALOG_CURRENT_NAME_STRING, NULL);
+    const char* current_file = SDL_GetStringProperty(props, SDL_PROP_FILE_DIALOG_CURRENT_FILE_STRING, NULL);
     const char* accept = SDL_GetStringProperty(props, SDL_PROP_FILE_DIALOG_ACCEPT_STRING, NULL);
     bool open_folders = false;
 
@@ -408,9 +425,18 @@ void SDL_Portal_ShowFileDialogWithProperties(SDL_FileDialogType type, SDL_Dialog
     }
     if (filters) {
         DBus_AppendFilters(dbus, &options, filters, nfilters);
+        if (current_filter >= 0 && current_filter < nfilters) {
+            DBus_AppendCurrentFilter(dbus, &options, filters[current_filter]);
+        }
     }
     if (default_location) {
         DBus_AppendByteArray(dbus, &options, "current_folder", default_location);
+    }
+    if (current_file) {
+        DBus_AppendByteArray(dbus, &options, "current_file", current_file);
+    }
+    if (current_name) {
+        DBus_AppendStringOption(dbus, &options, "current_name", current_name);
     }
     if (accept) {
         DBus_AppendStringOption(dbus, &options, "accept_label", accept);

--- a/test/testdialog.c
+++ b/test/testdialog.c
@@ -23,6 +23,8 @@ const SDL_DialogFileFilter filters[] = {
 };
 
 static void SDLCALL callback(void *userdata, const char * const *files, int filter) {
+    char **save_path = userdata;
+
     if (files) {
         const char* filter_name = "(filter fetching unsupported)";
 
@@ -35,6 +37,11 @@ static void SDLCALL callback(void *userdata, const char * const *files, int filt
         }
 
         SDL_Log("Filter used: '%s'", filter_name);
+
+        if (save_path && *files) {
+            SDL_free(*save_path);
+            *save_path = SDL_strdup(*files);
+        }
 
         while (*files) {
             SDL_Log("'%s'", *files);
@@ -52,9 +59,11 @@ int main(int argc, char *argv[])
     SDLTest_CommonState *state;
     const SDL_FRect open_file_rect = { 50, 50, 220, 140 };
     const SDL_FRect save_file_rect = { 50, 290, 220, 140 };
+    const SDL_FRect save_adv_file_rect = { 370, 290, 220, 140 };
     const SDL_FRect open_folder_rect = { 370, 50, 220, 140 };
     int i;
     const char *initial_path = NULL;
+    char *save_path = NULL;
 
     /* Initialize test framework */
     state = SDLTest_CommonCreateState(argv, 0);
@@ -117,6 +126,18 @@ int main(int argc, char *argv[])
                     SDL_ShowOpenFolderDialog(callback, NULL, w, initial_path, 1);
                 } else if (SDL_PointInRectFloat(&p, &save_file_rect)) {
                     SDL_ShowSaveFileDialog(callback, NULL, w, filters, SDL_arraysize(filters), initial_path);
+                } else if (SDL_PointInRectFloat(&p, &save_adv_file_rect)) {
+                    SDL_PropertiesID props = SDL_CreateProperties();
+                    SDL_SetNumberProperty(props, SDL_PROP_FILE_DIALOG_NFILTERS_NUMBER, SDL_arraysize(filters));
+                    SDL_SetPointerProperty(props, SDL_PROP_FILE_DIALOG_FILTERS_POINTER, (void *) filters);
+                    SDL_SetNumberProperty(props, SDL_PROP_FILE_DIALOG_CURRENT_FILTER_NUMBER, 1);
+                    if(save_path) {
+                        SDL_SetStringProperty(props, SDL_PROP_FILE_DIALOG_CURRENT_FILE_STRING, save_path);
+                    } else {
+                        SDL_SetStringProperty(props, SDL_PROP_FILE_DIALOG_LOCATION_STRING, initial_path);
+                        SDL_SetStringProperty(props, SDL_PROP_FILE_DIALOG_CURRENT_NAME_STRING, "Untitled.index");
+                    }
+                    SDL_ShowFileDialogWithProperties(SDL_FILEDIALOG_SAVEFILE, callback, &save_path, props);
                 }
             }
         }
@@ -134,12 +155,16 @@ int main(int argc, char *argv[])
         SDL_SetRenderDrawColor(r, 0, 255, 0, SDL_ALPHA_OPAQUE);
         SDL_RenderFillRect(r, &save_file_rect);
 
+        SDL_SetRenderDrawColor(r, 0, 255, 0, SDL_ALPHA_OPAQUE);
+        SDL_RenderFillRect(r, &save_adv_file_rect);
+
         SDL_SetRenderDrawColor(r, 0, 0, 255, SDL_ALPHA_OPAQUE);
         SDL_RenderFillRect(r, &open_folder_rect);
 
         SDL_SetRenderDrawColor(r, 0, 0, 0, SDL_ALPHA_OPAQUE);
         SDLTest_DrawString(r, open_file_rect.x+5, open_file_rect.y+open_file_rect.h/2, "Open File...");
         SDLTest_DrawString(r, save_file_rect.x+5, save_file_rect.y+save_file_rect.h/2, "Save File...");
+        SDLTest_DrawString(r, save_adv_file_rect.x+5, save_adv_file_rect.y+save_adv_file_rect.h/2, "Save File with props...");
         SDLTest_DrawString(r, open_folder_rect.x+5, open_folder_rect.y+open_folder_rect.h/2, "Open Folder...");
 
         SDL_RenderPresent(r);


### PR DESCRIPTION
This reduces the likelyhood of the user saving a file without an extension.

## Description

In the case of flatpaks portals provide the application with a virtual path to the user selected file exclusively. As the name of this file cannot be changed (e.g. to fix the extension) it is important to give the dialog enough hints so that the user will name it something sensible.

The following are added from the [xdg-portal](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.FileChooser.html#org-freedesktop-portal-filechooser-savefile) spec:
* `current_filter`: Index of the filter to show on dialog creation
* `current_name`: Placeholder for a save file operation
* `current_file`: Path to an existing file to save over

Here's an abandoned attempted to infer the values from `SDL_PROP_FILE_DIALOG_LOCATION_STRING`:
https://github.com/libsdl-org/SDL/compare/main...ColinKinloch:SDL:save_dialog_location_hack

There are discrepancies 

Bellow are some examples of the behaviours of the different portals tested in gnome by [forcing the portal](https://wiki.archlinux.org/title/XDG_Desktop_Portal#Force_desktop_environment):

### [GNOME](https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/blob/main/src/filechooser.c) ([nautilus](https://gitlab.gnome.org/GNOME/nautilus/-/blob/main/src/nautilus-portal.c))

https://github.com/user-attachments/assets/a9a7cce6-35ab-4dff-8323-8238d36cb19b

### [KDE](https://invent.kde.org/plasma/xdg-desktop-portal-kde/-/blob/master/src/filechooser.cpp)

https://github.com/user-attachments/assets/f8525e2e-1b25-4fc5-a712-a1e3919665f4

Using `current_file` with the kde portal to save over an existing file removes the extension, setting `current_filter` hides this issue as the kde file chooser with automatically add the extension.

### [GTK](https://github.com/flatpak/xdg-desktop-portal-gtk/blob/main/src/filechooser.c)

https://github.com/user-attachments/assets/b04bd53f-115b-4b10-9b55-994e5f52e753

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
