### PR TITLE
GPU Vulkan: set correct destination usage mode for storage buffer read/write bindings

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -8157,7 +8157,7 @@ static void VULKAN_BeginComputePass(
             vulkanCommandBuffer,
             bufferContainer,
             storageBufferBindings[i].cycle,
-            VULKAN_BUFFER_USAGE_MODE_COMPUTE_STORAGE_READ);
+            VULKAN_BUFFER_USAGE_MODE_COMPUTE_STORAGE_READ_WRITE);
 
         vulkanCommandBuffer->readWriteComputeStorageBuffers[i] = buffer;
 


### PR DESCRIPTION
## Description

Currently, read/write buffers used in compute pipelines can produce various sync validation errors, such as the following:
```
vkQueueSubmit(): WRITE_AFTER_WRITE hazard detected. vkCmdDispatchIndirect (from VkCommandBuffer 0x1984545e2d0 submitted on the current VkQueue 0x1983c426b50) writes to VkBuffer 0x61a000000061a, which was previously written by another vkCmdDispatchIndirect command (from VkCommandBuffer 0x1988a31c320 submitted on VkQueue 0x1983c426b50).
The current synchronization allows VK_ACCESS_2_SHADER_READ_BIT accesses at VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT|VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT|VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT, but to prevent this hazard, it must allow VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT accesses at VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT.
```

This resolves the issue by setting the destination usage mode to VULKAN_BUFFER_USAGE_MODE_COMPUTE_STORAGE_READ_WRITE instead of VULKAN_BUFFER_USAGE_MODE_COMPUTE_STORAGE_READ.