### PR TITLE
joystick: Fix linker error when building without virtual joystick support

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -1142,7 +1142,11 @@ SDL_Joystick *SDL_OpenJoystick(SDL_JoystickID instance_id)
     joystick->attached = true;
     joystick->led_expiration = SDL_GetTicks();
     joystick->battery_percent = -1;
+#ifdef SDL_JOYSTICK_VIRTUAL
     joystick->is_virtual = (driver == &SDL_VIRTUAL_JoystickDriver);
+#else
+    joystick->is_virtual = false;
+#endif
 
     if (!driver->Open(joystick, device_index)) {
         SDL_SetObjectValid(joystick, SDL_OBJECT_TYPE_JOYSTICK, false);


### PR DESCRIPTION
SDL_VIRTUAL_JoystickDriver was referenced outside an #ifdef when setting is_virtual, which caused a linker error. I modified it so that is_virtual is set to false if virtual joystick support is not enabled.

This fixes #13008 
