### PR TITLE
MacOS: improve scroll smoothing

### DIFF
--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -538,27 +538,17 @@ void Cocoa_HandleMouseWheel(SDL_Window *window, NSEvent *event)
     SDL_MouseWheelDirection direction;
     CGFloat x, y;
 
-    x = -[event deltaX];
-    y = [event deltaY];
+    x = -[event scrollingDeltaX];
+    y = [event scrollingDeltaY];
     direction = SDL_MOUSEWHEEL_NORMAL;
 
     if ([event isDirectionInvertedFromDevice] == YES) {
         direction = SDL_MOUSEWHEEL_FLIPPED;
     }
 
-    /* For discrete scroll events from conventional mice, always send a full tick.
-       For continuous scroll events from trackpads, send fractional deltas for smoother scrolling. */
-    if (![event hasPreciseScrollingDeltas]) {
-        if (x > 0) {
-            x = SDL_ceil(x);
-        } else if (x < 0) {
-            x = SDL_floor(x);
-        }
-        if (y > 0) {
-            y = SDL_ceil(y);
-        } else if (y < 0) {
-            y = SDL_floor(y);
-        }
+    if ([event hasPreciseScrollingDeltas]) {
+        x *= 0.1;
+        y *= 0.1;
     }
 
     SDL_SendMouseWheel(Cocoa_GetEventTimestamp([event timestamp]), window, mouseID, x, y, direction);


### PR DESCRIPTION
Use scrollingDelta instead of delta, as recommended by the Apple documentation. It gives much smoother scrolling.

---
I'm switching from glfw to sdl and I noticed the scrolling is very janky in SDL on macos (very few wheel events).

Empirically, I noticed glfw multipling by 0.1 if hasPreciseScrollingDeltas is on, and it indeed gives me similar speed to delta (but much smoother).

Note 1: I don't think the ceil/floor is needed anymore if hasPreciseScrollingDeltas is false, but I'm not 100% sure as my macbook supports hasPreciseScrollingDeltas. In the end I did the [sam as in glfw](https://github.com/glfw/glfw/blob/e7ea71be039836da3a98cea55ae5569cb5eb885c/src/cocoa_window.m#L604-L611)