### PR TITLE
GPU: Validate that a texture format is valid for compute writes

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -186,6 +186,114 @@
 #define COPYPASS_DEVICE \
     ((CommandBufferCommonHeader *)COPYPASS_COMMAND_BUFFER)->device
 
+static bool TextureFormatIsComputeWritable[] = {
+    false, // INVALID
+    false, // A8_UNORM
+    true,  // R8_UNORM
+    true,  // R8G8_UNORM
+    true,  // R8G8B8A8_UNORM
+    true,  // R16_UNORM
+    true,  // R16G16_UNORM
+    true,  // R16G16B16A16_UNORM
+    false, // R10G10B10A2_UNORM
+    false, // B5G6R5_UNORM
+    false, // B5G5R5A1_UNORM
+    false, // B4G4R4A4_UNORM
+    false, // B8G8R8A8_UNORM
+    false, // BC1_UNORM
+    false, // BC2_UNORM
+    false, // BC3_UNORM
+    false, // BC4_UNORM
+    false, // BC5_UNORM
+    false, // BC7_UNORM
+    false, // BC6H_FLOAT
+    false, // BC6H_UFLOAT
+    true,  // R8_SNORM
+    true,  // R8G8_SNORM
+    true,  // R8G8B8A8_SNORM
+    true,  // R16_SNORM
+    true,  // R16G16_SNORM
+    true,  // R16G16B16A16_SNORM
+    true,  // R16_FLOAT
+    true,  // R16G16_FLOAT
+    true,  // R16G16B16A16_FLOAT
+    true,  // R32_FLOAT
+    true,  // R32G32_FLOAT
+    true,  // R32G32B32A32_FLOAT
+    false, // R11G11B10_UFLOAT
+    true,  // R8_UINT
+    true,  // R8G8_UINT
+    true,  // R8G8B8A8_UINT
+    true,  // R16_UINT
+    true,  // R16G16_UINT
+    true,  // R16G16B16A16_UINT
+    true,  // R32_UINT
+    true,  // R32G32_UINT
+    true,  // R32G32B32A32_UINT
+    true,  // R8_INT
+    true,  // R8G8_INT
+    true,  // R8G8B8A8_INT
+    true,  // R16_INT
+    true,  // R16G16_INT
+    true,  // R16G16B16A16_INT
+    true,  // R32_INT
+    true,  // R32G32_INT
+    true,  // R32G32B32A32_INT
+    false, // R8G8B8A8_UNORM_SRGB
+    false, // B8G8R8A8_UNORM_SRGB
+    false, // BC1_UNORM_SRGB
+    false, // BC3_UNORM_SRGB
+    false, // BC3_UNORM_SRGB
+    false, // BC7_UNORM_SRGB
+    false, // D16_UNORM
+    false, // D24_UNORM
+    false, // D32_FLOAT
+    false, // D24_UNORM_S8_UINT
+    false, // D32_FLOAT_S8_UINT
+    false, // ASTC_4x4_UNORM
+    false, // ASTC_5x4_UNORM
+    false, // ASTC_5x5_UNORM
+    false, // ASTC_6x5_UNORM
+    false, // ASTC_6x6_UNORM
+    false, // ASTC_8x5_UNORM
+    false, // ASTC_8x6_UNORM
+    false, // ASTC_8x8_UNORM
+    false, // ASTC_10x5_UNORM
+    false, // ASTC_10x6_UNORM
+    false, // ASTC_10x8_UNORM
+    false, // ASTC_10x10_UNORM
+    false, // ASTC_12x10_UNORM
+    false, // ASTC_12x12_UNORM
+    false, // ASTC_4x4_UNORM_SRGB
+    false, // ASTC_5x4_UNORM_SRGB
+    false, // ASTC_5x5_UNORM_SRGB
+    false, // ASTC_6x5_UNORM_SRGB
+    false, // ASTC_6x6_UNORM_SRGB
+    false, // ASTC_8x5_UNORM_SRGB
+    false, // ASTC_8x6_UNORM_SRGB
+    false, // ASTC_8x8_UNORM_SRGB
+    false, // ASTC_10x5_UNORM_SRGB
+    false, // ASTC_10x6_UNORM_SRGB
+    false, // ASTC_10x8_UNORM_SRGB
+    false, // ASTC_10x10_UNORM_SRGB
+    false, // ASTC_12x10_UNORM_SRGB
+    false, // ASTC_12x12_UNORM_SRGB
+    false, // ASTC_4x4_FLOAT
+    false, // ASTC_5x4_FLOAT
+    false, // ASTC_5x5_FLOAT
+    false, // ASTC_6x5_FLOAT
+    false, // ASTC_6x6_FLOAT
+    false, // ASTC_8x5_FLOAT
+    false, // ASTC_8x6_FLOAT
+    false, // ASTC_8x8_FLOAT
+    false, // ASTC_10x5_FLOAT
+    false, // ASTC_10x6_FLOAT
+    false, // ASTC_10x8_FLOAT
+    false, // ASTC_10x10_FLOAT
+    false, // ASTC_12x10_FLOAT
+    false  // ASTC_12x12_FLOAT
+};
+
 // Drivers
 
 #ifndef SDL_GPU_DISABLED
@@ -2110,6 +2218,11 @@ SDL_GPUComputePass *SDL_BeginGPUComputePass(
 
             if (storage_texture_bindings[i].mip_level >= header->info.num_levels) {
                 SDL_assert_release(!"Storage texture mip level must be less than the texture's level count!");
+                return NULL;
+            }
+
+            if (!TextureFormatIsComputeWritable[header->info.format]) {
+                SDL_assert_release(!"The format of this storage texture is invalid for writing in a compute pipeline!");
                 return NULL;
             }
         }

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -868,6 +868,13 @@ bool SDL_GPUTextureSupportsFormat(
         CHECK_TEXTUREFORMAT_ENUM_INVALID(format, false)
     }
 
+    if ((usage & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_WRITE) || 
+        (usage & SDL_GPU_TEXTUREUSAGE_COMPUTE_STORAGE_SIMULTANEOUS_READ_WRITE)) {
+        if (!TextureFormatIsComputeWritable[format]) {
+            return false;
+        }
+    }
+
     return device->SupportsTextureFormat(
         device->driverData,
         format,
@@ -2218,11 +2225,6 @@ SDL_GPUComputePass *SDL_BeginGPUComputePass(
 
             if (storage_texture_bindings[i].mip_level >= header->info.num_levels) {
                 SDL_assert_release(!"Storage texture mip level must be less than the texture's level count!");
-                return NULL;
-            }
-
-            if (!TextureFormatIsComputeWritable[header->info.format]) {
-                SDL_assert_release(!"The format of this storage texture is invalid for writing in a compute pipeline!");
                 return NULL;
             }
         }


### PR DESCRIPTION
Only certain texture formats are valid for writes in a compute shader. This patch causes an assert if the texture binding is an invalid format.

It's probably worth also exposing this to the client with some kind of Supports query API call, but we can add that in a separate patch so we can cherry-pick this one back to 3.2.x.

Resolves #13043 