### PR TITLE
Fix #13057 - macOS: fix bug with mouse move events not occuring after an window exit event 

### DIFF
--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -450,12 +450,18 @@ void Cocoa_HandleMouseEvent(SDL_VideoDevice *_this, NSEvent *event)
     // All events except NSEventTypeMouseExited can only happen if the window
     // has mouse focus, so we'll always set the focus even if we happen to miss
     // NSEventTypeMouseEntered, which apparently happens if the window is
-    // created under the mouse on macOS 12.7
+    // created under the mouse on macOS 12.7.  But, only set the focus if
+    // the event acutally has a non-NULL window, otherwise what would happen
+    // is that after an NSEventTypeMouseEntered there would sometimes be
+    // NSEventTypeMouseMoved without a window causing us to suppress subsequent
+    // mouse move events.
     NSEventType event_type = [event type];
     if (event_type == NSEventTypeMouseExited) {
         Cocoa_MouseFocus = NULL;
     } else {
-        Cocoa_MouseFocus = [event window];
+        if ([event window] != NULL) {
+            Cocoa_MouseFocus = [event window];
+        }
     }
 
     switch (event_type) {


### PR DESCRIPTION
macOS: Fixes bug with NSEventTypeMouseMoved having a NULL window causing us to suppress future mouse move events because the window was considered out of focus.  This was causing Dota to infinitely pan the camera because it would stop getting mouse move events.
