### PR TITLE
Suppress spammy gamepad and joystick update events when SDL_HINT_EVENT_LOGGING < 2

### DIFF
--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -895,8 +895,12 @@ static void SDL_LogEvent(const SDL_Event *event)
          (event->type == SDL_EVENT_FINGER_MOTION) ||
          (event->type == SDL_EVENT_PEN_AXIS) ||
          (event->type == SDL_EVENT_PEN_MOTION) ||
-         (event->type == SDL_EVENT_GAMEPAD_TOUCHPAD_MOTION) ||
+         (event->type == SDL_EVENT_GAMEPAD_AXIS_MOTION) ||
          (event->type == SDL_EVENT_GAMEPAD_SENSOR_UPDATE) ||
+         (event->type == SDL_EVENT_GAMEPAD_TOUCHPAD_MOTION) ||
+         (event->type == SDL_EVENT_GAMEPAD_UPDATE_COMPLETE) ||
+         (event->type == SDL_EVENT_JOYSTICK_AXIS_MOTION) ||
+         (event->type == SDL_EVENT_JOYSTICK_UPDATE_COMPLETE) ||
          (event->type == SDL_EVENT_SENSOR_UPDATE))) {
         return;
     }


### PR DESCRIPTION
## Description
On the Steam Deck, axis events are extraordinarily spammy, producing on the order of 1000 log lines per second of info even when the sticks are not being moved. This PR suppresses these events when `SDL_HINT_EVENT_LOGGING` is < 2, as well as the "update complete" events because they are equally spammy.

This is the easiest solution, but a more robust solution could be to have an adjustable "deadzone" for event logs, so that axis events will only be logged if the axis is beyond a certain threshold. Or, even better, to have an adjustable axis deadzone within SDL itself, so it won't produce events at all if they are within the deadzone.

## Existing Issue(s)

See #13059.