### PR TITLE
Vita: Fix mouse front touch events not being automatically translated by default

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -277,6 +277,8 @@ bool SDL_PreInitMouse(void)
                         SDL_TouchMouseEventsChanged, mouse);
 
 #ifdef SDL_PLATFORM_VITA
+    mouse->vita_touch_mouse_device = 1;
+
     SDL_AddHintCallback(SDL_HINT_VITA_TOUCH_MOUSE_DEVICE,
                         SDL_VitaTouchMouseDeviceChanged, mouse);
 #endif


### PR DESCRIPTION
This issue was a leftover of the touch id changes in the vita backend, before the front touch id was `0`, so when zeroing the mouse struct with `SDL_zerop(mouse);` the variable had a proper default.
After the touch ids on the vita were updated, now the valid values are 1,2 and 3, so the internal variable needs to be set to the proper default value (in which case 1, for the front touch screen).