### PR TITLE
Fix: GameCube controller adapter hotplug not working

### DIFF
--- a/src/joystick/hidapi/SDL_hidapijoystick.c
+++ b/src/joystick/hidapi/SDL_hidapijoystick.c
@@ -764,11 +764,12 @@ bool HIDAPI_JoystickConnected(SDL_HIDAPI_Device *device, SDL_JoystickID *pJoysti
 
     ++SDL_HIDAPI_numjoysticks;
 
-    SDL_PrivateJoystickAdded(joystickID);
-
     if (pJoystickID) {
         *pJoystickID = joystickID;
     }
+
+    SDL_PrivateJoystickAdded(joystickID);
+
     return true;
 }
 


### PR DESCRIPTION
`SDL_PrivateJoystickAdded` was called before setting the InstanceId in the adapter's `ctx->joysticks` array.  This would eventually broadcast the `SDL_EVENT_JOYSTICK_ADDED` event with the new InstanceId, if your program listens for the added events and opens joysticks at that point it would always fail because there would be no matching InstanceId in the joysticks array.


