### PR TITLE
x11: request available clipboard mime-types on video init

### DIFF
--- a/src/video/x11/SDL_x11video.c
+++ b/src/video/x11/SDL_x11video.c
@@ -475,6 +475,10 @@ static bool X11_VideoInit(SDL_VideoDevice *_this)
 
     X11_InitPen(_this);
 
+    // Request currently available mime-types in the clipboard.
+    X11_XConvertSelection(data->display, data->atoms.CLIPBOARD, data->atoms.TARGETS,
+            data->atoms.SDL_FORMATS, GetWindow(_this), CurrentTime);
+
     return true;
 }
 


### PR DESCRIPTION
## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/12481
##
Note, I just copied the stuff from here. I don't know if that's the right way to fix this - I have not worked with X11 previously. But it seems to do the trick.
https://github.com/libsdl-org/SDL/blob/6c61a94a4b6683ed7117685a21a5c8dbc1558fa9/src/video/x11/SDL_x11events.c#L1215-L1222