### PR TITLE
[PS2] [SDL2] Fix wrong `vsync_handler` defintion type

### DIFF
--- a/src/render/ps2/SDL_render_ps2.c
+++ b/src/render/ps2/SDL_render_ps2.c
@@ -55,7 +55,7 @@ typedef struct
 static int vsync_sema_id = 0;
 
 /* PRIVATE METHODS */
-static int vsync_handler(void)
+static int vsync_handler(int reason)
 {
     iSignalSema(vsync_sema_id);
 


### PR DESCRIPTION
## Description
Fixing a wrong definition type (it will be an error with GCC 15)