### PR TITLE
GPU: D3D12 fails to create multisample texture

### DIFF
--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -3346,7 +3346,7 @@ static D3D12Texture *D3D12_INTERNAL_CreateTexture(
 
     if (createinfo->type != SDL_GPU_TEXTURETYPE_3D) {
         desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
-        desc.Alignment = isSwapchainTexture ? 0 : D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
+        desc.Alignment = isSwapchainTexture ? 0 : isMultisample ? D3D12_DEFAULT_MSAA_RESOURCE_PLACEMENT_ALIGNMENT : D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
         desc.Width = createinfo->width;
         desc.Height = createinfo->height;
         desc.DepthOrArraySize = (UINT16)createinfo->layer_count_or_depth;


### PR DESCRIPTION
## Description
Creating a multisample texture on an Intel iGPU `D3D12 feature set 11_1` fails with an error for incorrect alignment setting.

This is update sets the alignment of multisample textures to `D3D12_DEFAULT_MSAA_RESOURCE_PLACEMENT_ALIGNMENT`. According to Microsoft documentation the alignment could also be set to `0` and it would automatically get detected.

https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ns-d3d12-d3d12_resource_desc#alignment

> If Alignment is set to 0, the runtime will use 4MB for MSAA textures and 64KB for everything else. The application may choose smaller alignments than these defaults for a couple of texture types when the texture is small. Textures with UNKNOWN layout and MSAA may be created with 64KB alignment (if they pass the small size restriction detailed below).

I notice that it talks about small size restriction which would allow using the current 64kb alignment. Looking at the error this doesn't appear that useful as 1200x800 sample count 2 needed 494 tiles whereas 16 tiles is the maximum for the small size restriction.

Tested and working on NVidia RTX 30 series GPU and Intel iGPU.

### Error
`D3D12 WARNING: ID3D12Device::CreateCommittedResource: D3D12_RESOURCE_DESC::Alignment cannot be 64KB, since D3D12_RESOURCE_DESC::Width, D3D12_RESOURCE_DESC::Height, and/ or D3D12_RESOURCE_DESC::DepthOrArraySize are too large. 64KB alignment requires the most detailed mip level be theoretically 4MB or smaller. A 64KB tile shape for D3D12_RESOURCE_DIMENSION_TEXTURE2D and D32_FLOAT is 32 texels wide, 64 texels high, and 1 texels deep. When Width = 1200, Height = 800, and Depth = 1, the number of tiles needed is 494, while 16 tiles is the maximum. D3D12_RESOURCE_DESC::Alignment must be 0 or 4MB (aka D3D12_DEFAULT_MSAA_RESOURCE_PLACEMENT_ALIGNMENT).`