### PR TITLE
docs: fix man page return value section generation

### DIFF
--- a/build-scripts/wikiheaders.pl
+++ b/build-scripts/wikiheaders.pl
@@ -2972,10 +2972,12 @@ __EOF__
         }
 
         if (defined $returns) {
+            # Check for md link in return type: ([SDL_Renderer](SDL_Renderer) *)
+            # This would've prevented the next regex from working properly (it'd leave " *)")
+            $returns =~ s/\A\(\[.*?\]\((.*?)\)/\($1/ms;
             # Chop datatype in parentheses off the front.
-            if(!($returns =~ s/\A\([^\[]*\[[^\]]*\]\([^\)]*\)[^\)]*\) //ms)) {
-                $returns =~ s/\A\([^\)]*\) //ms;
-            }
+            $returns =~ s/\A\(.*?\) //;
+
             $returns = dewikify($wikitype, $returns);
             $str .= ".SH RETURN VALUE\n";
             $str .= "$returns\n";


### PR DESCRIPTION
Missed it last time. Previously it turned
`(bool) Returns true on success or false on failure; call [SDL_GetError](SDL_GetError)() for more information.`
into
 ` for more information.`

The previous regex matched `(ANYTHING[Link](Link)ANYTHING)` so the shorter fix would be to just remove the first `ANYTHING` part, but it looked like a complete abomination anyway.
