### PR TITLE
wayland: Set the text input cursor rect properly

### DIFF
--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -170,7 +170,8 @@ typedef struct SDL_WaylandSeat
     struct
     {
         struct zwp_text_input_v3 *zwp_text_input;
-        SDL_Rect cursor_rect;
+        SDL_Rect text_input_rect;
+        int text_input_cursor;
         bool enabled;
         bool has_preedit;
     } text_input;


### PR DESCRIPTION
The text input cursor should reflect the cursor position, not the entire text input rect. Set it correctly so that IME chooser dialogs appear in the correct location.

Fixes #13086 