### PR TITLE
gpu/d3d12: Mark vertex buffers as bound

### DIFF
--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -4957,6 +4957,8 @@ static void D3D12_INTERNAL_BindGraphicsResources(
             0,
             commandBuffer->vertexBufferCount,
             vertexBufferViews);
+
+        commandBuffer->needVertexBufferBind = false;
     }
 
     if (commandBuffer->needVertexSamplerBind) {


### PR DESCRIPTION
## Description
In the D3D12 backend, needVertexBufferBind was never marked false, meaning that they would be rebound every time.

This PR just sets needVertexBufferBind to false after vertex buffers have been bound.