### PR TITLE
Fix #13083 segfault in `SDL_RemoveTrayEntry()` for submenu entries

### DIFF
--- a/src/tray/unix/SDL_tray.c
+++ b/src/tray/unix/SDL_tray.c
@@ -541,7 +541,7 @@ SDL_TrayMenu *SDL_CreateTraySubmenu(SDL_TrayEntry *entry)
         return NULL;
     }
 
-    entry->submenu->menu = (GtkMenuShell *)gtk_menu_new();
+    entry->submenu->menu = g_object_ref_sink(gtk_menu_new());
     entry->submenu->parent_tray = NULL;
     entry->submenu->parent_entry = entry;
     entry->submenu->nEntries = 0;


### PR DESCRIPTION
Use `g_object_ref` in `SDL_CreateTraySubmenu()` as introduced with 3be67ced646f9d884c32ce6858f39fe9dd8d634b for the top-level menu.

## Description
`DestroySDLMenu()` which gets called by `SDL_RemoveTrayEntry()` seems to expect a `g_object_ref` now for `menu->menu`.
I think this was an oversight and should have been in the commit mentioned above.

With this change the segfault described in  #13083 no longer occurs.
I guess @Semphriss should probably review this PR.

## Existing Issue(s)
This should fix #13083
