### PR TITLE
wayland: Use SDL_memcpy instead of SDL_copyp to copy the repeated tex…

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -353,7 +353,7 @@ static void keyboard_repeat_set(SDL_WaylandKeyboardRepeat *repeat_info, Uint32 k
     repeat_info->next_repeat_ns = SDL_MS_TO_NS(repeat_info->repeat_delay_ms);
     repeat_info->scancode = scancode;
     if (has_text) {
-        SDL_copyp(repeat_info->text, text);
+        SDL_memcpy(repeat_info->text, text, sizeof(repeat_info->text));
     } else {
         repeat_info->text[0] = '\0';
     }


### PR DESCRIPTION
…t string

SDL_copyp is not intended to copy arrays. Use SDL_memcpy with the explicit size instead.

Fixes #13093 
