### PR TITLE
x11: Include the XTest header when needed

### DIFF
--- a/src/video/x11/SDL_x11dyn.h
+++ b/src/video/x11/SDL_x11dyn.h
@@ -71,6 +71,9 @@
 #ifdef SDL_VIDEO_DRIVER_X11_XSHAPE
 #include <X11/extensions/shape.h>
 #endif
+#ifdef SDL_VIDEO_DRIVER_X11_XTEST
+#include <X11/extensions/XTest.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Fixes building when statically linking.

Closes #13103 