### PR TITLE
Process(windows): try sending WM_CLOSE for graceful process termination

### DIFF
--- a/src/process/windows/SDL_windowsprocess.c
+++ b/src/process/windows/SDL_windowsprocess.c
@@ -520,8 +520,23 @@ done:
     return result;
 }
 
+static BOOL CALLBACK terminate_app(HWND hwnd, LPARAM proc_id)
+{
+    DWORD current_proc_id = 0;
+    GetWindowThreadProcessId(hwnd, &current_proc_id);
+    if (current_proc_id == (DWORD) proc_id) {
+        PostMessage(hwnd, WM_CLOSE, 0, 0);
+    }
+    return TRUE;
+}
+
 bool SDL_SYS_KillProcess(SDL_Process *process, bool force)
 {
+    if (!force) {
+        EnumWindows(terminate_app, (LPARAM) process->internal->process_information.dwProcessId);
+        PostThreadMessage(process->internal->process_information.dwThreadId, WM_CLOSE, 0, 0);
+        return true;
+    }
     if (!TerminateProcess(process->internal->process_information.hProcess, 1)) {
         return WIN_SetError("TerminateProcess failed");
     }

--- a/src/process/windows/SDL_windowsprocess.c
+++ b/src/process/windows/SDL_windowsprocess.c
@@ -520,12 +520,12 @@ done:
     return result;
 }
 
-static BOOL CALLBACK terminate_app(HWND hwnd, LPARAM proc_id)
+static BOOL CALLBACK terminate_app(HWND hwnd, LPARAM lparam)
 {
-    DWORD current_proc_id = 0;
+    DWORD current_proc_id = 0, *term_info = (DWORD *) lparam;
     GetWindowThreadProcessId(hwnd, &current_proc_id);
-    if (current_proc_id == (DWORD) proc_id) {
-        PostMessage(hwnd, WM_CLOSE, 0, 0);
+    if (current_proc_id == term_info[0] && PostMessage(hwnd, WM_CLOSE, 0, 0)) {
+        term_info[1]++;
     }
     return TRUE;
 }
@@ -533,9 +533,17 @@ static BOOL CALLBACK terminate_app(HWND hwnd, LPARAM proc_id)
 bool SDL_SYS_KillProcess(SDL_Process *process, bool force)
 {
     if (!force) {
-        EnumWindows(terminate_app, (LPARAM) process->internal->process_information.dwProcessId);
-        PostThreadMessage(process->internal->process_information.dwThreadId, WM_CLOSE, 0, 0);
-        return true;
+        // term_info[0] is the process ID, term_info[1] is number of successful tries
+        DWORD term_info[2];
+        term_info[0] = process->internal->process_information.dwProcessId;
+        term_info[1] = 0;
+        EnumWindows(terminate_app, (LPARAM) &term_info);
+        if (term_info[1] || PostThreadMessage(process->internal->process_information.dwThreadId, WM_CLOSE, 0, 0)) {
+            return true;
+        }
+        if (GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, term_info[0])) {
+            return true;
+        }
     }
     if (!TerminateProcess(process->internal->process_information.hProcess, 1)) {
         return WIN_SetError("TerminateProcess failed");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

> The problem
> Windows. Windows is the problem.
> [#8129](https://github.com/libsdl-org/SDL/issues/8129)

This PR takes the [QT](https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/io/qprocess_win.cpp#n648) method of sending WM_CLOSE to all application window, then send WM_CLOSE to the main thread of the child process.

## Description
<!--- Describe your changes in detail -->
Windows always makes things more complicated.
On Windows, there are multiple ways to gracefully terminate a process.

1. Send WM_CLOSE to a Window.
2. Send Ctrl+Break event with `GenerateConsoleCtrlEvent`.

None of these two ways cover all applications - WM_CLOSE only works when the program has a message loop like in GUI programs, `GenerateConsoleCtrlEvent` has [quirks](https://github.com/microsoft/Terminal/issues/335).


## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
