### PR TITLE
Clean up INTERFACE_COMPILE_OPTIONS

### DIFF
--- a/Xcode/SDL/pkg-support/share/cmake/SDL3/SDL3Config.cmake
+++ b/Xcode/SDL/pkg-support/share/cmake/SDL3/SDL3Config.cmake
@@ -92,7 +92,7 @@ if(NOT TARGET SDL3::Headers)
     add_library(SDL3::Headers INTERFACE IMPORTED)
     set_target_properties(SDL3::Headers
         PROPERTIES
-            INTERFACE_COMPILE_OPTIONS "SHELL:-F \"${_sdl3_framework_parent_path}\""
+            INTERFACE_COMPILE_OPTIONS "-F${_sdl3_framework_parent_path}"
     )
 endif()
 set(SDL3_Headers_FOUND TRUE)


### PR DESCRIPTION
# Clean up the definition of `INTERFACE_COMPILE_OPTIONS`

## Description
The extra text causes Meson/Ninja builds to fail as headers are not found.

This change removes the text "SHELL" from `INTERFACE_COMPILE_OPTIONS` and cleans up the extra quotation marks.

## Existing Issue(s)
(https://github.com/libsdl-org/SDL/issues/13113)
