### PR TITLE
x11: Fixes for fullscreen

### DIFF
--- a/src/video/x11/SDL_x11video.c
+++ b/src/video/x11/SDL_x11video.c
@@ -77,23 +77,6 @@ static bool X11_IsXWayland(Display *d)
     return X11_XQueryExtension(d, "XWAYLAND", &opcode, &event, &error) == True;
 }
 
-static bool X11_CheckCurrentDesktop(const char *name)
-{
-    SDL_Environment *env = SDL_GetEnvironment();
-
-    const char *desktopVar = SDL_GetEnvironmentVariable(env, "DESKTOP_SESSION");
-    if (desktopVar && SDL_strcasecmp(desktopVar, name) == 0) {
-        return true;
-    }
-
-    desktopVar = SDL_GetEnvironmentVariable(env, "XDG_CURRENT_DESKTOP");
-    if (desktopVar && SDL_strcasestr(desktopVar, name)) {
-        return true;
-    }
-
-    return false;
-}
-
 static SDL_VideoDevice *X11_CreateDevice(void)
 {
     SDL_VideoDevice *device;
@@ -275,19 +258,13 @@ static SDL_VideoDevice *X11_CreateDevice(void)
 
     device->device_caps = VIDEO_DEVICE_CAPS_HAS_POPUP_WINDOW_SUPPORT;
 
-    /* Openbox doesn't send the new window dimensions when entering fullscreen, so the events must be synthesized.
-     * This is otherwise not wanted, as it can break fullscreen window positioning on multi-monitor configurations.
-     */
-    if (!X11_CheckCurrentDesktop("openbox")) {
-        device->device_caps |= VIDEO_DEVICE_CAPS_SENDS_FULLSCREEN_DIMENSIONS;
-    }
-
     data->is_xwayland = X11_IsXWayland(x11_display);
     if (data->is_xwayland) {
         SDL_LogInfo(SDL_LOG_CATEGORY_VIDEO, "Detected XWayland");
 
         device->device_caps |= VIDEO_DEVICE_CAPS_MODE_SWITCHING_EMULATED |
-                               VIDEO_DEVICE_CAPS_DISABLE_MOUSE_WARP_ON_FULLSCREEN_TRANSITIONS;
+                               VIDEO_DEVICE_CAPS_DISABLE_MOUSE_WARP_ON_FULLSCREEN_TRANSITIONS |
+                               VIDEO_DEVICE_CAPS_SENDS_FULLSCREEN_DIMENSIONS;
     }
 
     return device;

--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -1584,6 +1584,12 @@ void X11_ShowWindow(SDL_VideoDevice *_this, SDL_Window *window)
     X11_PumpEvents(_this);
     data->size_move_event_flags = 0;
 
+    /* A MapNotify or PropertyNotify may not have arrived, so ensure that the shown event is dispatched
+     * to apply pending state before clearing the flag.
+     */
+    SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_SHOWN, 0, 0);
+    data->was_shown = true;
+
     // If a configure event was received (type is non-zero), send the final window size and coordinates.
     if (data->last_xconfigure.type) {
         int x, y;


### PR DESCRIPTION
Non-compositing window managers seem to always need the fullscreen dimensions sent, so do this universally, except on XWayland, where doing so seems to cause hitching in certain cases.

Some compositors/window managers don't actually send MapNotify or PropertyNotify when mapping the window, which didn't clear the flag used to prevent the initial state from being mangled, and could keep windows from leaving fullscreen.

Fixes #13104 
Fixes libsdl-org/sdl2-compat#491