### PR TITLE
emscripten: Proxy to the main thread where needed

### DIFF
--- a/src/audio/emscripten/SDL_emscriptenaudio.c
+++ b/src/audio/emscripten/SDL_emscriptenaudio.c
@@ -189,7 +189,7 @@ static bool EMSCRIPTENAUDIO_OpenDevice(SDL_AudioDevice *device)
     }
 
     // limit to native freq
-    device->spec.freq = EM_ASM_INT({ return Module['SDL3'].audioContext.sampleRate; });
+    device->spec.freq = MAIN_THREAD_EM_ASM_INT({ return Module['SDL3'].audioContext.sampleRate; });
     device->sample_frames = SDL_GetDefaultSampleFramesFromFreq(device->spec.freq) * 2;  // double the buffer size, some browsers need more, and we'll just have to live with the latency.
 
     SDL_UpdatedAudioDeviceFormat(device);

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -64,7 +64,7 @@ static SDL_SystemTheme Emscripten_GetSystemTheme(void)
     /* Technically, light theme can mean explicit light theme or no preference.
        https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme#syntax */
 
-    int theme_code = EM_ASM_INT({
+    int theme_code = MAIN_THREAD_EM_ASM_INT({
         if (!window.matchMedia) {
             return -1;
         }


### PR DESCRIPTION
`Emscripten_GetSystemTheme` and `EMSCRIPTENAUDIO_OpenDevice` did not work for me when I enabled `PROXY_TO_PTHREAD` in Emscripten. Both methods access globals that are only available in the main thread. This should fix these.
