### PR TITLE
PSP fullscreen is the only mode

### DIFF
--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -118,7 +118,7 @@ static SDL_VideoDevice *PSP_Create(void)
 
     device->PumpEvents = PSP_PumpEvents;
 
-    device->device_caps = VIDEO_DEVICE_CAPS_FULLSCREEN_ONLY
+    device->device_caps = VIDEO_DEVICE_CAPS_FULLSCREEN_ONLY;
 
     return device;
 }


### PR DESCRIPTION
I came across the recently merged pull request https://github.com/libsdl-org/SDL/pull/13105 (Vita fullscreen only) and its associated issue https://github.com/libsdl-org/SDL/issues/13079.

As I'm currently looking into the combo of SDL and the PSP, I noticed that for this platform, I also have to specify fullscreen mode while creating a window. If I don't, my application gets rendered differently (in combination with `SDL_SetRenderLogicalPresentation`).

## Description
Just like the Nintendo 3DS and the PlayStation Vita, the PSP is also only capable of rendering in fullscreen. It cannot create separate or multiple windows so signal this through the PSP video driver.

## Existing Issue(s)
--
