### PR TITLE
begin_code: Added SDL_ALIGNED macro.

### DIFF
--- a/include/SDL3/SDL_begin_code.h
+++ b/include/SDL3/SDL_begin_code.h
@@ -281,6 +281,48 @@
  */
 #define SDL_HAS_BUILTIN(x) __has_builtin(x)
 
+/**
+ * A macro to specify data alignment.
+ *
+ * This informs the compiler that a given datatype or variable must be aligned
+ * to a specific byte count.
+ *
+ * For example:
+ *
+ * ```c
+ * // make sure this is struct is aligned to 16 bytes for SIMD access.
+ * typedef struct {
+ *    float x, y, z, w;
+ * } SDL_ALIGNED(16) MySIMDAlignedData;
+ *
+
+ * // make sure this one field in a struct is aligned to 16 bytes for SIMD access.
+ * typedef struct {
+ *    SomeStuff stuff;
+ *    float position[4] SDL_ALIGNED(16);
+ *    SomeOtherStuff other_stuff;
+ * } MyStruct;
+ *
+ * // make sure this variable is aligned to 32 bytes.
+ * int SDL_ALIGNED(32) myval = 0;
+ * ```
+ *
+ * Alignment is only guaranteed for things the compiler places: local
+ * variables on the stack and global/static variables. To dynamically allocate
+ * something that respects this alignment, use SDL_aligned_alloc() or some
+ * other mechanism.
+ *
+ * On compilers without alignment support, this macro is defined to an
+ * invalid symbol, to make it clear that the current compiler is likely to
+ * generate incorrect code when it sees this macro.
+ *
+ * \param x the byte count to align to, so the data's address will be a
+ *          multiple of this value.
+ *
+ * \since This macro is available since SDL 3.4.0.
+ */
+#define SDL_ALIGNED(x) __attribute__((aligned(x)))
+
 /* end of wiki documentation section. */
 #endif
 
@@ -484,3 +526,18 @@
 #define SDL_ALLOC_SIZE2(p1, p2)
 #endif
 #endif /* SDL_ALLOC_SIZE2 not defined */
+
+#ifndef SDL_ALIGNED
+#if defined(__clang__) || defined(__GNUC__)
+#define SDL_ALIGNED(x) __attribute__((aligned(x)))
+#elif defined(_MSC_VER)
+#define SDL_ALIGNED(x) __declspec(align(x))
+#elif defined(__cplusplus) && (__cplusplus >= 201103L)
+#define SDL_ALIGNED(x) alignas(x)
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#define SDL_ALIGNED(x) _Alignas(x)
+#else
+#define SDL_ALIGNED(x) PLEASE_DEFINE_SDL_ALIGNED
+#endif
+#endif /* SDL_ALIGNED not defined */
+


### PR DESCRIPTION
I'm running into places where I want to define data that is aligned for SSE or NEON access, so being able to tell the compiler "this struct (or struct member) needs to be aligned to 16 bytes" or "this stack variable needs to be aligned" becomes _essential_.

All compilers supporting C11 or C++11 support a keyword for this, and GCC/Clang/MSVC all have their own syntax to handle it, long before those standards.

I'm torn about what to do on compilers that don't support it (which is...possible no significant compilers). Seeing as they will definitely miscompile code in that case, I have it intentionally generate an error; the docs currently say it the macro defined in this case, the code currently defines it to something like an error message. It's not clear to me which approach is better, or if defining it to nothing is better to let the compiler roll the dice.