### PR TITLE
Gyro degrees per second is 2000 across all 8bitdo controllers

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_8bitdo.c
+++ b/src/joystick/hidapi/SDL_hidapi_8bitdo.c
@@ -247,7 +247,8 @@ static bool HIDAPI_Driver8BitDo_OpenJoystick(SDL_HIDAPI_Device *device, SDL_Joys
 
 
         ctx->accelScale = SDL_STANDARD_GRAVITY / ABITDO_ACCEL_SCALE;
-        ctx->gyroScale = DEG2RAD(ABITDO_GYRO_MAX_DEGREES_PER_SECOND) / INT16_MAX; /* Hardware senses  +/- N Degrees per second mapped to +/- INT16_MAX */
+        // Hardware senses +/- N Degrees per second mapped to +/- INT16_MAX
+        ctx->gyroScale = DEG2RAD(ABITDO_GYRO_MAX_DEGREES_PER_SECOND) / INT16_MAX;
     }
 
     return true;

--- a/src/joystick/hidapi/SDL_hidapi_8bitdo.c
+++ b/src/joystick/hidapi/SDL_hidapi_8bitdo.c
@@ -203,7 +203,7 @@ static bool HIDAPI_Driver8BitDo_InitDevice(SDL_HIDAPI_Device *device)
         HIDAPI_SetDeviceName(device, "8BitDo SN30 Pro");
     } else if (device->product_id == USB_PRODUCT_8BITDO_PRO_2 || device->product_id == USB_PRODUCT_8BITDO_PRO_2_BT) {
         HIDAPI_SetDeviceName(device, "8BitDo Pro 2");
-    } 
+    }
 
     return HIDAPI_JoystickConnected(device, NULL);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Performed tests on new 8bitdo firmware, and all gyros are currently rated at 125hz, 2000degrees per second.

## Description
<!--- Describe your changes in detail -->
Moved certain consts to defines (sensor rate in hz, and degrees per second)
Updated some comments.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
8Bitdo controllers were slightly miscalibrated