### PR TITLE
Checks if Xinput2 is loaded before trying to call Xinput2 functions

### DIFF
--- a/src/video/x11/SDL_x11pen.c
+++ b/src/video/x11/SDL_x11pen.c
@@ -283,6 +283,7 @@ static X11_PenHandle *X11_MaybeAddPen(SDL_VideoDevice *_this, const XIDeviceInfo
 
 X11_PenHandle *X11_MaybeAddPenByDeviceID(SDL_VideoDevice *_this, int deviceid)
 {
+    if (!X11_Xinput2IsInitialized()) return NULL;
     SDL_VideoData *data = _this->internal;
     int num_device_info = 0;
     XIDeviceInfo *device_info = X11_XIQueryDevice(data->display, deviceid, &num_device_info);
@@ -297,6 +298,7 @@ X11_PenHandle *X11_MaybeAddPenByDeviceID(SDL_VideoDevice *_this, int deviceid)
 
 void X11_RemovePenByDeviceID(int deviceid)
 {
+    if (!X11_Xinput2IsInitialized()) return;
     X11_PenHandle *handle = X11_FindPenByDeviceID(deviceid);
     if (handle) {
         SDL_RemovePenDevice(0, handle->pen);
@@ -306,6 +308,7 @@ void X11_RemovePenByDeviceID(int deviceid)
 
 void X11_InitPen(SDL_VideoDevice *_this)
 {
+    if (!X11_Xinput2IsInitialized()) return;
     SDL_VideoData *data = _this->internal;
 
     #define LOOKUP_PEN_ATOM(X) X11_XInternAtom(data->display, X, False)
@@ -335,6 +338,7 @@ static void X11_FreePenHandle(SDL_PenID instance_id, void *handle, void *userdat
 
 void X11_QuitPen(SDL_VideoDevice *_this)
 {
+    if (!X11_Xinput2IsInitialized()) return;
     SDL_RemoveAllPenDevices(X11_FreePenHandle, NULL);
 }
 


### PR DESCRIPTION
Fixes a crash if Xinput2 fails to load.

## Description
If `SDL_VIDEO_DRIVER_X11_XINPUT2` and `SDL_VIDEO_DRIVER_X11_DYNAMIC_XINPUT2` are defined, SDL will try to load Xinput2 at runtime. If this succeeds, everything works as expected.

However, if SDL fails to find Xinput2, it will attempt to call some Xinput2 functions anyway. Right now, they're guarded on the feature being enabled not on the library being loaded. Since the library failed to load, the functions will be null, so calling them typically leads to a crash.

This PR checks whether or not XInput2 was successfully initialized before calling these functions. It's possible that I didn't catch every instance of this issue--the calls in `SDL_x11pen.c` were easy to find as one of them happens at init time.

(I'm a first time contributor--if there's a better/more robust way to fix this feel free to let me know! I'm not sure how the equivalent logic is handled for the other runtime optional dependencies.)

## Existing Issue(s)
none
