### PR TITLE
Pass text input rect to steam deck keyboard invocation

### DIFF
--- a/src/video/x11/SDL_x11keyboard.c
+++ b/src/video/x11/SDL_x11keyboard.c
@@ -762,7 +762,9 @@ void X11_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
             break;
         }
         (void)SDL_snprintf(deeplink, sizeof(deeplink),
-                           "steam://open/keyboard?XPosition=0&YPosition=0&Width=0&Height=0&Mode=%d",
+                           "steam://open/keyboard?XPosition=%i&YPosition=%i&Width=%i&Height=%i&Mode=%d",
+                           window->text_input_rect.x, window->text_input_rect.y,
+                           window->text_input_rect.w, window->text_input_rect.h,
                            mode);
         SDL_OpenURL(deeplink);
         videodata->steam_keyboard_open = true;


### PR DESCRIPTION
## Description
The steam deck keyboard accepts a text input area for the purpose of positioning the keyboard to avoid covering the input box. This PR adds these properties to the steam deck keyboard invocation.

Text input area is represented by the white rectangle:

![gamescope-20250530135636](https://github.com/user-attachments/assets/4d0bde6e-1317-4063-9938-e22b56c6856e)