### PR TITLE
win32: Ensure that text input is initially disabled when creating a w…

### DIFF
--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -33,6 +33,7 @@
 #include "../SDL_sysvideo.h"
 
 #include "SDL_windowsvideo.h"
+#include "SDL_windowskeyboard.h"
 #include "SDL_windowswindow.h"
 
 // Dropfile support
@@ -779,6 +780,9 @@ bool WIN_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Properties
             }
             return false;
         }
+
+        // Ensure that the IME isn't active on the new window until explicitly requested.
+        WIN_StopTextInput(_this, window);
 
         // Inform Windows of the frame change so we can respond to WM_NCCALCSIZE
         SetWindowPos(hwnd, NULL, 0, 0, 0, 0, SWP_FRAMECHANGED | SWP_NOSIZE | SWP_NOMOVE | SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOACTIVATE);


### PR DESCRIPTION
…indow

Windows seems to implicitly enable IME text input on windows created while an IME is active, which causes the IME suggestion window to pop up when keys are pressed, even if a client never explicitly enabled it. Ensure that IME support is initially disabled on new windows; SDL will enable it at a later time, if required.

Fixes #13172 
