### PR TITLE
Correct the texture format used for the N-Gage

### DIFF
--- a/src/render/ngage/SDL_render_ngage.c
+++ b/src/render/ngage/SDL_render_ngage.c
@@ -119,7 +119,7 @@ static bool NGAGE_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL
     renderer->window = window;
     renderer->internal = phdata;
 
-    SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_ARGB4444);
+    SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_XRGB4444);
     SDL_SetNumberProperty(SDL_GetRendererProperties(renderer), SDL_PROP_RENDERER_MAX_TEXTURE_SIZE_NUMBER, 1024);
     SDL_SetHintWithPriority(SDL_HINT_RENDER_LINE_METHOD, "2", SDL_HINT_OVERRIDE);
 

--- a/src/video/ngage/SDL_ngagevideo.c
+++ b/src/video/ngage/SDL_ngagevideo.c
@@ -105,7 +105,7 @@ static bool NGAGE_VideoInit(SDL_VideoDevice *device)
     phdata->mode.w = 176;
     phdata->mode.h = 208;
     phdata->mode.refresh_rate = 60.0f;
-    phdata->mode.format = SDL_PIXELFORMAT_ARGB4444;
+    phdata->mode.format = SDL_PIXELFORMAT_XRGB4444;
 
     phdata->display.name = "N-Gage";
     phdata->display.desktop_mode = phdata->mode;


### PR DESCRIPTION
Since commit 2ef7944 was reverted, alpha transparency isn't supported, so this reflects that in the texture format. It should be possible to support both formats and only separate the mask for formats that have alpha.

This has not been tested.