### PR TITLE
Fix broken link inside README-cmake.md

### DIFF
--- a/docs/README-cmake.md
+++ b/docs/README-cmake.md
@@ -328,7 +328,7 @@ Configure your project with `-DSDL_LIBC=ON` to make use of sanitizers.
 ### CMake fails to build without X11 or Wayland support
 
 Install the required system packages prior to running CMake.
-See [README-linux](linux#build-dependencies) for the list of dependencies on Linux.
+See [README-linux.md](README-linux.md#build-dependencies) for the list of dependencies on Linux.
 Other unix operating systems should provide similar packages.
 
 If you **really** don't need to show windows, add `-DSDL_UNIX_CONSOLE_BUILD=ON` to the CMake configure command.


### PR DESCRIPTION
Fix a broken link inside README-cmake.md that's meant to send to README-linux.md
also made said link more consistent with other links by adding .md suffix



## Description
I fixed a broken link in README-cmake.md that was meant to link to the dependencies part of README-linux.md but instead gave a 404 error page as the path was incorrect.
I also added the .md suffix to that link as most links to document pages also have that suffix
