### PR TITLE
Tweak Vulkan include guard check and 64-bit platform defines

### DIFF
--- a/include/SDL3/SDL_vulkan.h
+++ b/include/SDL3/SDL_vulkan.h
@@ -51,14 +51,14 @@
 extern "C" {
 #endif
 
-/* Avoid including vulkan.h, don't define VkInstance if it's already included */
-#ifdef VULKAN_H_
+/* Avoid including vulkan_core.h, don't define VkInstance if it's already included */
+#ifdef VULKAN_CORE_H_
 #define NO_SDL_VULKAN_TYPEDEFS
 #endif
 #ifndef NO_SDL_VULKAN_TYPEDEFS
 #define VK_DEFINE_HANDLE(object) typedef struct object##_T* object;
 
-#if defined(__LP64__) || defined(_WIN64) || defined(__x86_64__) || defined(_M_X64) || defined(__ia64) || defined (_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
+#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__) ) || defined(_M_X64) || defined(__ia64) || defined (_M_IA64) || defined(__aarch64__) || defined(__powerpc64__) || (defined(__riscv) && __riscv_xlen == 64)
 #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) typedef struct object##_T *object;
 #else
 #define VK_DEFINE_NON_DISPATCHABLE_HANDLE(object) typedef uint64_t object;


### PR DESCRIPTION
## Description
This pull request fixes two minor issues in `SDL_vulkan.h`.

1. Implemented a more precise include guard check. Previously, SDL would check for `vulkan.h`  instead of `vulkan_core.h`, [which is where all the required definitions are](https://docs.vulkan.org/spec/latest/appendices/boilerplate.html). Changing this resolves a compile error in the following situation. Without the proper fix, the user is required to either change the include order or define `NO_SDL_VULKAN_TYPEDEFS`.

```cpp
#include <vulkan/vulkan_core.h>
#include <SDL3/SDL.h>
#include <SDL3/SDL_vulkan.h>
#include <vk_mem_alloc.h>
```

2. I noticed the 64-bit platform detection code was outdated relative to its latest form in the headers, so I took the liberty of updating it.

