### PR TITLE
utils: add hint to enable/disable object validity checks

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -592,6 +592,25 @@ extern "C" {
 #define SDL_HINT_CAMERA_DRIVER "SDL_CAMERA_DRIVER"
 
 /**
+ * A variable that controls whether object validity checks are enabled.
+ *
+ * Object validity checks prevent undefined behaviour when passing invalid
+ * pointers to SDL functions. A function will return invalid argument error
+ * if you pass pointer to uninitialized/freed SDL object. You may want to
+ * disable these checks to improve performance.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "0": Disable object validity checks
+ * - "1": Enable object validity checks
+ *
+ * This hint should be set before SDL is initialized.
+ *
+ * \since This hint is avaliable since ???
+ */
+#define SDL_HINT_CHECK_OBJECT_VALIDITY "SDL_CHECK_OBJECT_VALIDITY"
+
+/**
  * A variable that limits what CPU features are available.
  *
  * By default, SDL marks all features the current CPU supports as available.

--- a/src/SDL_utils.c
+++ b/src/SDL_utils.c
@@ -137,6 +137,7 @@ Uint32 SDL_GetNextObjectID(void)
 
 static SDL_InitState SDL_objects_init;
 static SDL_HashTable *SDL_objects;
+static bool check_validity = true;
 
 static Uint32 SDLCALL SDL_HashObject(void *unused, const void *key)
 {
@@ -153,6 +154,7 @@ void SDL_SetObjectValid(void *object, SDL_ObjectType type, bool valid)
     SDL_assert(object != NULL);
 
     if (SDL_ShouldInit(&SDL_objects_init)) {
+        check_validity = SDL_GetHintBoolean(SDL_HINT_CHECK_OBJECT_VALIDITY, true);
         SDL_objects = SDL_CreateHashTable(0, true, SDL_HashObject, SDL_KeyMatchObject, NULL, NULL);
         const bool initialized = (SDL_objects != NULL);
         SDL_SetInitialized(&SDL_objects_init, initialized);
@@ -161,10 +163,12 @@ void SDL_SetObjectValid(void *object, SDL_ObjectType type, bool valid)
         }
     }
 
-    if (valid) {
-        SDL_InsertIntoHashTable(SDL_objects, object, (void *)(uintptr_t)type, true);
-    } else {
-        SDL_RemoveFromHashTable(SDL_objects, object);
+    if (check_validity) {
+        if (valid) {
+            SDL_InsertIntoHashTable(SDL_objects, object, (void *)(uintptr_t)type, true);
+        } else {
+            SDL_RemoveFromHashTable(SDL_objects, object);
+        }
     }
 }
 
@@ -172,6 +176,10 @@ bool SDL_ObjectValid(void *object, SDL_ObjectType type)
 {
     if (!object) {
         return false;
+    }
+
+    if (!check_validity) {
+        return true;
     }
 
     const void *object_type;


### PR DESCRIPTION
These checks seem to affect performance, particularly they take a huge part of SDL_RenderCopy time:

```
44.54% SDL_RenderTextureRotated
   - 44.48% SDL_RenderTextureRotated_REAL
      - 43.57% SDL_RenderTexture_REAL
         + 20.38% SDL_RenderTextureInternal
         + 19.42% SDL_ObjectValid
         + 1.65% SDL_GetRectIntersectionFloat_REAL
```

This perf report is taken in debug build, as in release everything gets optimized out and perf doesn't report anything meaningful. So I've also made a simple RenderCopy benchmark:

<details>
<summary>Source</summary>

```cpp
#include <SDL3/SDL.h>
#include <SDL3_image/SDL_image.h>
#include <random>

int main() {
    SDL_Init(SDL_INIT_VIDEO);
    SDL_Window* window = SDL_CreateWindow("window", 1280, 720, SDL_WINDOW_RESIZABLE);
    SDL_Renderer* renderer = SDL_CreateRenderer(window, nullptr);
    SDL_Surface* surface = IMG_Load("image.png");
    SDL_Texture* texture = SDL_CreateTextureFromSurface(renderer, surface);
    SDL_SetRenderVSync(renderer, SDL_RENDERER_VSYNC_DISABLED);

    SDL_FRect src, dst;
    src.x = src.y = 0;
    src.w = src.h = 8;
    dst.w = 32;
    dst.h = 32;

    std::mt19937 gen(42);

    for(int it = 0; it < 500000; it++) {
        SDL_RenderClear(renderer);
        for(int i = 0; i < 500; i++) {
            dst.x = gen() % 1280;
            dst.y = gen() % 720;
            SDL_RenderTexture(renderer, texture, &src, &dst);
        }
        SDL_RenderPresent(renderer);
    }

    SDL_DestroyTexture(texture);
    SDL_DestroyRenderer(renderer);
    SDL_DestroyWindow(window);
    SDL_Quit();
}
```

image.png: ![image](https://github.com/user-attachments/assets/d4a5b75a-bf36-4c02-9ac8-300bd900a5b3)

</details>

Ran on Ryzen 9 7940HS, Gentoo Linux, performance governor. There is a noticeable performance difference (and it becomes more noticeable when increasing number of draws in single frame).

```
# with validity checks
Executed in   39.40 secs    fish           external
   usr time   26.64 secs    0.21 millis   26.64 secs
   sys time   10.08 secs    2.90 millis   10.08 secs

# without validity checks
Executed in   33.71 secs    fish           external
   usr time   22.34 secs    0.12 millis   22.34 secs
   sys time    9.70 secs    1.02 millis    9.70 secs
```

I've added a hint `SDL_HINT_CHECK_OBJECT_VALIDITY` to enable/disable validity checks at runtime.

P.S. Are these checks needed at all when there's AddressSanitizer to detect use-after-free efficiently?
