### PR TITLE
Flydigi Vader 4 Pro IMU rate correction

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_flydigi.c
+++ b/src/joystick/hidapi/SDL_hidapi_flydigi.c
@@ -48,6 +48,7 @@ enum
 /* Rate of IMU Sensor Packets over wired observed in testcontroller tool connection at 500hz */
 #define SENSOR_INTERVAL_VADER_PRO4_WIRED_RATE_HZ  500
 #define SENSOR_INTERVAL_VADER_PRO4_WIRED_NS     (SDL_NS_PER_SECOND / SENSOR_INTERVAL_VADER_PRO4_WIRED_RATE_HZ)
+
 #define FLYDIGI_CMD_REPORT_ID 0x05
 #define FLYDIGI_HAPTIC_COMMAND 0x0F
 #define FLYDIGI_GET_CONFIG_COMMAND 0xEB
@@ -205,6 +206,9 @@ static void UpdateDeviceIdentity(SDL_HIDAPI_Device *device)
     case 81:
         HIDAPI_SetDeviceName(device, "Flydigi Vader 3 Pro");
         ctx->has_cz = true;
+        ctx->sensors_supported = true;
+        ctx->accelScale = SDL_STANDARD_GRAVITY / 256.0f;
+        ctx->sensor_timestamp_step_ns = ctx->wireless ? SENSOR_INTERVAL_VADER4_PRO_DONGLE_NS : SENSOR_INTERVAL_VADER_PRO4_WIRED_NS;
         break;
     case 85:
         HIDAPI_SetDeviceName(device, "Flydigi Vader 4 Pro");

--- a/src/joystick/hidapi/SDL_hidapi_flydigi.c
+++ b/src/joystick/hidapi/SDL_hidapi_flydigi.c
@@ -270,7 +270,7 @@ static bool HIDAPI_DriverFlydigi_OpenJoystick(SDL_HIDAPI_Device *device, SDL_Joy
 
     if (ctx->sensors_supported) {
 
-        const float flSensorRate = (float)(SDL_NS_PER_SECOND / ctx->sensor_timestamp_step_ns);
+        const float flSensorRate = ctx->wireless ? (float)SENSOR_INTERVAL_VADER4_PRO_DONGLE_RATE_HZ : (float)SENSOR_INTERVAL_VADER_PRO4_WIRED_RATE_HZ;
         SDL_PrivateJoystickAddSensor(joystick, SDL_SENSOR_GYRO, flSensorRate);
         SDL_PrivateJoystickAddSensor(joystick, SDL_SENSOR_ACCEL, flSensorRate);
     }


### PR DESCRIPTION
Flydigi IMU rate now matches observed rate of packets in both dongle and wired connection.

## Description
Flydigi Vader 4 Pro IMU rate correction was set at a fixed 125hz. In actuality rate is 1000hz over dongle and 500hz when wired.

## Existing Issue(s)
This fixes issues in downstream programs which relied on accurate time stamps for the gyro values.

Note: There is still some question over the gyro pitch and yaw speed rate - it may have a some sensor "deadzoning" or other response curves applied.