### PR TITLE
wayland: send mouse motion on mouse warp using warp protocol

### DIFF
--- a/src/video/wayland/SDL_waylandmouse.c
+++ b/src/video/wayland/SDL_waylandmouse.c
@@ -871,12 +871,11 @@ void Wayland_SeatWarpMouse(SDL_WaylandSeat *seat, SDL_WindowData *window, float 
                     Wayland_SeatUpdatePointerGrab(seat);
                 }
             }
-
-            /* NOTE: There is a pending warp event under discussion that should replace this when available.
-             * https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/340
-             */
-            SDL_SendMouseMotion(0, window->sdlwindow, seat->pointer.sdl_id, false, x, y);
         }
+        /* NOTE: There is a pending warp event under discussion that should replace this when available.
+         * https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/340
+         */
+        SDL_SendMouseMotion(0, window->sdlwindow, seat->pointer.sdl_id, false, x, y);
     }
 }
 


### PR DESCRIPTION
I've noticed that [initial support PR](https://github.com/libsdl-org/SDL/pull/10922) didn't include the MouseMotion sending, but I'm not sure if it's even needed.

[This comment in the protocol](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/337#note_2579122) suggests that we should also send the mouse motion in the new protocol path, until [340](https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/340) gets merged
## Description
Send MouseMotion even after the warp protocol usage

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
