### PR TITLE
Fix support for F21 to F24 scancodes on Linux

### DIFF
--- a/src/events/scancodes_xfree86.h
+++ b/src/events/scancodes_xfree86.h
@@ -371,10 +371,10 @@ static const SDL_Scancode xfree86_scancode_table2[] = {
     /* 188, 0x0bc */   SDL_SCANCODE_F18,                // XF86Launch9
     /* 189, 0x0bd */   SDL_SCANCODE_F19,                // NoSymbol
     /* 190, 0x0be */   SDL_SCANCODE_F20,                // XF86AudioMicMute
-    /* 191, 0x0bf */   SDL_SCANCODE_UNKNOWN,            // XF86TouchpadToggle
-    /* 192, 0x0c0 */   SDL_SCANCODE_UNKNOWN,            // XF86TouchpadOn
-    /* 193, 0x0c1 */   SDL_SCANCODE_UNKNOWN,            // XF86TouchpadOff
-    /* 194, 0x0c2 */   SDL_SCANCODE_UNKNOWN,            // NoSymbol
+    /* 191, 0x0bf */   SDL_SCANCODE_F21,                // XF86TouchpadToggle
+    /* 192, 0x0c0 */   SDL_SCANCODE_F22,                // XF86TouchpadOn
+    /* 193, 0x0c1 */   SDL_SCANCODE_F23,                // XF86TouchpadOff
+    /* 194, 0x0c2 */   SDL_SCANCODE_F24,                // NoSymbol
     /* 195, 0x0c3 */   SDL_SCANCODE_MODE,               // Mode_switch
     /* 196, 0x0c4 */   SDL_SCANCODE_UNKNOWN,            // NoSymbol
     /* 197, 0x0c5 */   SDL_SCANCODE_UNKNOWN,            // NoSymbol


### PR DESCRIPTION
Fixes the scancodes of F21-F24 keys being reported as `SDL_SCANCODE_UNKNOWN` in Linux distributions.

Because of this those keys were unsupported, whatever the keysyms bound to it.

## Description
Add `SDL_SCANCODE_F21` to `SDL_SCANCODE_F24` in `xfree86_scancode_table2`, so these keys are recognized. SDL now sends events with `key.scancode` set to those scancodes, and `e->key.key` set to the corresponding keycode in the current keyboard layout.

The text input for those keys was already working and is unaffected.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/13238
