### PR TITLE
[SDL3] Vita: Fixed absence of clipping when viewport is set

### DIFF
--- a/src/render/vitagxm/SDL_render_vita_gxm_types.h
+++ b/src/render/vitagxm/SDL_render_vita_gxm_types.h
@@ -105,6 +105,7 @@ typedef struct
 {
     SDL_Rect viewport;
     bool viewport_dirty;
+    bool viewport_is_set;
     SDL_Texture *texture;
     SDL_Texture *target;
     SDL_FColor color;


### PR DESCRIPTION
The same as https://github.com/libsdl-org/SDL/pull/13194 but for SDL3

Backported by a cherry-picking with a conflict resolution and adjusting of the code.