### PR TITLE
expose events originating from a live-resize set the data1 field to 1.

### DIFF
--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -135,7 +135,8 @@ typedef enum SDL_EventType
     /* 0x201 was SDL_SYSWMEVENT, reserve the number for sdl2-compat */
     SDL_EVENT_WINDOW_SHOWN = 0x202,     /**< Window has been shown */
     SDL_EVENT_WINDOW_HIDDEN,            /**< Window has been hidden */
-    SDL_EVENT_WINDOW_EXPOSED,           /**< Window has been exposed and should be redrawn, and can be redrawn directly from event watchers for this event */
+    SDL_EVENT_WINDOW_EXPOSED,           /**< Window has been exposed and should be redrawn, and can be redrawn directly from event watchers for this event.
+                                             data1 is 1 for live-resize expose events, 0 otherwise. */
     SDL_EVENT_WINDOW_MOVED,             /**< Window has been moved to data1, data2 */
     SDL_EVENT_WINDOW_RESIZED,           /**< Window has been resized to data1xdata2 */
     SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED,/**< The pixel size of the window has changed to data1xdata2 */

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -4139,7 +4139,7 @@ void SDL_OnWindowLiveResizeUpdate(SDL_Window *window)
         SDL_IterateMainCallbacks(false);
     } else {
         // Send an expose event so the application can redraw
-        SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_EXPOSED, 0, 0);
+        SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_EXPOSED, 1, 0);
     }
 
     SDL_PumpEventMaintenance();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Sometimes it's useful to know whether an expose event originated from a live resize, this allows detecting that situation from user code.

This only applies to the traditional (non-callback) app lifecycle style.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #13243.
