### PR TITLE
win32: Invalidate window message mouse button flags when reading buttons from raw input or GameInput

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -701,6 +701,10 @@ static void WIN_HandleRawMouseInput(Uint64 timestamp, SDL_VideoData *data, HANDL
             float fAmount = (float)amount / WHEEL_DELTA;
             SDL_SendMouseWheel(WIN_GetEventTimestamp(), window, mouseID, fAmount, 0.0f, SDL_MOUSEWHEEL_NORMAL);
         }
+
+        /* Invalidate the mouse button flags. If we don't do this then disabling raw input
+           will cause held down mouse buttons to persist when released. */
+        windowdata->mouse_button_flags = (WPARAM)-1;
     }
 }
 

--- a/src/video/windows/SDL_windowsgameinput.cpp
+++ b/src/video/windows/SDL_windowsgameinput.cpp
@@ -279,6 +279,9 @@ static void GAMEINPUT_InitialMouseReading(WIN_GameInputData *data, SDL_Window *w
             bool down = ((state.buttons & mask) != 0);
             SDL_SendMouseButton(timestamp, window, mouseID, GAMEINPUT_button_map[i], down);
         }
+
+        // Invalidate mouse button flags
+        window->internal->mouse_button_flags = (WPARAM)-1;
     }
 }
 
@@ -308,6 +311,9 @@ static void GAMEINPUT_HandleMouseDelta(WIN_GameInputData *data, SDL_Window *wind
                     SDL_SendMouseButton(timestamp, window, mouseID, GAMEINPUT_button_map[i], down);
                 }
             }
+
+            // Invalidate mouse button flags
+            window->internal->mouse_button_flags = (WPARAM)-1;
         }
         if (delta.wheelX || delta.wheelY) {
             float fAmountX = (float)delta.wheelX / WHEEL_DELTA;


### PR DESCRIPTION
I found that if you hold down a mouse button when leaving raw input mode (usually due to relative mouse mode being disabled), then the buttons will "stick" until you press them again.
This means that if you have a game that opens a menu with escape, and you hold down a mouse button while doing so, you have to click twice in order to click a menu button.

The raw input code changed a fair bit in SDL3, and `mouse_button_flags` is no longer invalidated when reading from raw input, so I added some code that resets the variable when reading any mouse button from GameInput or raw input. Which fixed the issue in the game I was encountering it in.

I can't find any issues that report this specific bug, since it seems like a relatively hard thing to diagnose.
Lemme know if any more info would be helpful, or a test case.