### PR TITLE
test: Fix resource paths in testtray

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -420,7 +420,7 @@ add_sdl_test_executable(testdialog SOURCES testdialog.c)
 add_sdl_test_executable(testtime SOURCES testtime.c)
 add_sdl_test_executable(testmanymouse SOURCES testmanymouse.c)
 add_sdl_test_executable(testmodal SOURCES testmodal.c)
-add_sdl_test_executable(testtray SOURCES testtray.c)
+add_sdl_test_executable(testtray NEEDS_RESOURCES TESTUTILS SOURCES testtray.c)
 
 
 add_sdl_test_executable(testprocess

--- a/test/testtray.c
+++ b/test/testtray.c
@@ -1,3 +1,4 @@
+#include "testutils.h"
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_main.h>
 #include <SDL3/SDL_test.h>
@@ -520,14 +521,17 @@ int main(int argc, char **argv)
         goto quit;
     }
 
-    /* TODO: Resource paths? */
-    SDL_Surface *icon = SDL_LoadBMP("../test/sdl-test_round.bmp");
+    char *icon1filename = GetResourceFilename(NULL, "sdl-test_round.bmp");
+    SDL_Surface *icon = SDL_LoadBMP(icon1filename);
+    SDL_free(icon1filename);
 
     if (!icon) {
         SDL_Log("Couldn't load icon 1, proceeding without: %s", SDL_GetError());
     }
 
-    SDL_Surface *icon2 = SDL_LoadBMP("../test/speaker.bmp");
+    char *icon2filename = GetResourceFilename(NULL, "speaker.bmp");
+    SDL_Surface *icon2 = SDL_LoadBMP(icon2filename);
+    SDL_free(icon2filename);
 
     if (!icon2) {
         SDL_Log("Couldn't load icon 2, proceeding without: %s", SDL_GetError());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Without this patch the installed `testtray` test points to nonexistent files.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
