### PR TITLE
keyboard: Add reference to SDL_Keymod in the comments

### DIFF
--- a/include/SDL_keyboard.h
+++ b/include/SDL_keyboard.h
@@ -49,7 +49,7 @@ typedef struct SDL_Keysym
 {
     SDL_Scancode scancode;      /**< SDL physical key code - see SDL_Scancode for details */
     SDL_Keycode sym;            /**< SDL virtual key code - see SDL_Keycode for details */
-    Uint16 mod;                 /**< current key modifiers */
+    Uint16 mod;                 /**< current key modifiers - see SDL_Keymod for details */
     Uint32 unused;
 } SDL_Keysym;
 


### PR DESCRIPTION
## Description
Added a reference to SDL_Keymod for the `mod` field of `SDL_Keysym` struct. The field's type is Uint16, so you can't quickly jump to definition (I saw that this is fixed in SDL3, which is nice!)
