### PR TITLE
joystick: Fix MSVC errors C2099 with `/fp:strict`

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_ps4.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps4.c
@@ -1003,8 +1003,8 @@ static bool HIDAPI_DriverPS4_SetJoystickSensorsEnabled(SDL_HIDAPI_Device *device
 
 static void HIDAPI_DriverPS4_HandleStatePacket(SDL_Joystick *joystick, SDL_hid_device *dev, SDL_DriverPS4_Context *ctx, PS4StatePacket_t *packet, int size)
 {
-    static const float TOUCHPAD_SCALEX = 1.0f / 1920;
-    static const float TOUCHPAD_SCALEY = 1.0f / 920; // This is noted as being 944 resolution, but 920 feels better
+    static const float TOUCHPAD_SCALEX = 5.20833333e-4f; // 1.0f / 1920
+    static const float TOUCHPAD_SCALEY = 1.08695652e-3f; // 1.0f / 920 // This is noted as being 944 resolution, but 920 feels better
     Sint16 axis;
     bool touchpad_down;
     int touchpad_x, touchpad_y;

--- a/src/joystick/hidapi/SDL_hidapi_ps5.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps5.c
@@ -1355,8 +1355,8 @@ static void HIDAPI_DriverPS5_HandleStatePacketCommon(SDL_Joystick *joystick, SDL
 
 static void HIDAPI_DriverPS5_HandleStatePacket(SDL_Joystick *joystick, SDL_hid_device *dev, SDL_DriverPS5_Context *ctx, PS5StatePacket_t *packet, Uint64 timestamp)
 {
-    static const float TOUCHPAD_SCALEX = 1.0f / 1920;
-    static const float TOUCHPAD_SCALEY = 1.0f / 1070;
+    static const float TOUCHPAD_SCALEX = 5.20833333e-4f; // 1.0f / 1920
+    static const float TOUCHPAD_SCALEY = 9.34579439e-4f; // 1.0f / 1070
     bool touchpad_down;
     int touchpad_x, touchpad_y;
 
@@ -1406,8 +1406,8 @@ static void HIDAPI_DriverPS5_HandleStatePacket(SDL_Joystick *joystick, SDL_hid_d
 
 static void HIDAPI_DriverPS5_HandleStatePacketAlt(SDL_Joystick *joystick, SDL_hid_device *dev, SDL_DriverPS5_Context *ctx, PS5StatePacketAlt_t *packet, Uint64 timestamp)
 {
-    static const float TOUCHPAD_SCALEX = 1.0f / 1920;
-    static const float TOUCHPAD_SCALEY = 1.0f / 1070;
+    static const float TOUCHPAD_SCALEX = 5.20833333e-4f; // 1.0f / 1920
+    static const float TOUCHPAD_SCALEY = 9.34579439e-4f; // 1.0f / 1070
     bool touchpad_down;
     int touchpad_x, touchpad_y;
 


### PR DESCRIPTION
## Description

We're working on adopting SDL3 as our gamepad/joystick input driver in Godot Engine:
- https://github.com/godotengine/godot/pull/106218

We vendor a subset of the library (a bit hacked together to keep only the joystick/haptic/hidapi subsystems) and compile it with our own buildsystem using the same flags as the rest of Godot. (Would be happy to discuss this some more by email btw, SDL subsystems seem somewhat modular but there are cross-includes - e.g. `events` depending on `video` - which make it a bit tricky to just compile some parts).

This includes flags to disable floating-point contraction following this PR:
- https://github.com/godotengine/godot/pull/94655

We did this to fix precision differences on arm64 platforms with LLVM which caused bugs on macOS, but as there were signs that it would also affect modern x86_64, we disabled it consistently everywhere. Including on Windows/MSVC with `/fp:strict`, which brings the issue I'm working around here.

The static constants computed here raise MSVC error [C2099](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2099?view=msvc-170):
```
error C2099: initializer is not a constant
```

The solution seems to be either disabling `/fp:strict`, or simplifying the expressions. I chose the latter which is a more local fix for Godot, but I understand if it's not suitable for upstream.

I should note that changing these 6 constants is enough for Godot to compile its subset of SDL with `/fp:strict`, but I didn't assess whether there are more similar cases in parts of SDL we don't compile, which would also fail with `/fp:strict`. I'm working from Linux so can't easily do a test with injecting `/fp:strict` in SDL's CMake setup to compile everything, but I'd suggest this might be worth doing to also confirm the issue I'm fixing here.


## Existing Issue(s)

Didn't find any.
