### PR TITLE
SDL_render.h: enum SDL_TextureAddressMode: Removed trailing comma

### DIFF
--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -110,7 +110,7 @@ typedef enum SDL_TextureAddressMode
     SDL_TEXTURE_ADDRESS_INVALID = -1,
     SDL_TEXTURE_ADDRESS_AUTO,   /**< Wrapping is enabled if texture coordinates are outside [0, 1], this is the default */
     SDL_TEXTURE_ADDRESS_CLAMP,  /**< Texture coordinates are clamped to the [0, 1] range */
-    SDL_TEXTURE_ADDRESS_WRAP,   /**< The texture is repeated (tiled) */
+    SDL_TEXTURE_ADDRESS_WRAP    /**< The texture is repeated (tiled) */
 } SDL_TextureAddressMode;
 
 /**


### PR DESCRIPTION
Compiling with `gcc` and the flags `-std=c89 -Wpedantic` shows this warning:
```c
/path/to/SDL-git/include/SDL3/SDL_render.h:113:29: warning: comma at end of enumerator list [-Wpedantic]
  113 |     SDL_TEXTURE_ADDRESS_WRAP,   /**< The texture is repeated (tiled) */
      |                             ^
```

This commit removes the trailing comma.