### PR TITLE
Fix #13276: Crash in SDL_GetAudioDeviceChannelMap

### DIFF
--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -1588,7 +1588,9 @@ int *SDL_GetAudioDeviceChannelMap(SDL_AudioDeviceID devid, int *count)
     SDL_AudioDevice *device = ObtainPhysicalAudioDeviceDefaultAllowed(devid);
     if (device) {
         channels = device->spec.channels;
-        result = SDL_ChannelMapDup(device->chmap, channels);
+        if (channels > 0 && device->chmap) {
+            result = SDL_ChannelMapDup(device->chmap, channels);
+        }
     }
     ReleaseAudioDevice(device);
 


### PR DESCRIPTION
`SDL_GetAudioDeviceChannelMap` will AV trying to memcpy from a `NULL` pointer if there is no channel map for the device.

## Existing Issue(s)
#13276
