### PR TITLE
Allow overriding SDL_FORK_MESSAGEBOX in build environment

### DIFF
--- a/src/video/x11/SDL_x11messagebox.c
+++ b/src/video/x11/SDL_x11messagebox.c
@@ -30,7 +30,10 @@
 #include <X11/keysym.h>
 #include <locale.h>
 
+#ifndef SDL_FORK_MESSAGEBOX
 #define SDL_FORK_MESSAGEBOX 1
+#endif
+
 #define SDL_SET_LOCALE      1
 
 #if SDL_FORK_MESSAGEBOX


### PR DESCRIPTION
## Description
In Factorio, we disable `SDL_FORK_MESSAGEBOX` because `Otherwise, when the game crashes, about 50% of the time it just sits there, hung in a call to waitpid for some reason` (direct quote from the blame).

In SDL2, we did this by editing the define in the source file, but I am attempting to avoid editing SDL3 source code, so I'd rather define it in our fastbuild configuration.

This PR allows that by only defining `SDL_FORK_MESSAGEBOX` if it is not already defined.