### PR TITLE
Disable SDL_DYNAMIC_API when using ReSharper

### DIFF
--- a/src/dynapi/SDL_dynapi.h
+++ b/src/dynapi/SDL_dynapi.h
@@ -57,7 +57,7 @@
 #define SDL_DYNAMIC_API 0
 #elif defined(SDL_PLATFORM_RISCOS) // probably not useful on RISC OS, since dlopen() can't be used when using static linking.
 #define SDL_DYNAMIC_API 0
-#elif defined(__clang_analyzer__) || defined(__INTELLISENSE__) || defined(SDL_THREAD_SAFETY_ANALYSIS)
+#elif defined(__clang_analyzer__) || defined(__INTELLISENSE__) || defined(SDL_THREAD_SAFETY_ANALYSIS) || defined(__RESHARPER__)
 #define SDL_DYNAMIC_API 0 // Turn off for static analysis, so reports are more clear.
 #elif defined(SDL_PLATFORM_VITA)
 #define SDL_DYNAMIC_API 0 // vitasdk doesn't support dynamic linking


### PR DESCRIPTION
## Description
Disables SDL_dynapi when using the [ReSharper C++ extension](https://www.jetbrains.com/resharper-cpp/) in Visual Studio, or ReSharper built-into [Rider](https://www.jetbrains.com/rider/). This caused spurious errors and made symbol navigation lengthy (had to go trough SDL_FunctionName_REAL).

The `__RESHARPER__` symbol is defined in https://www.jetbrains.com/help/resharper/Languages_CPP.html#macro and works as expected.

`main`:

![slika](https://github.com/user-attachments/assets/17aad971-a11e-4d2d-b8a5-36c001fcf0e5)

This PR:

![slika](https://github.com/user-attachments/assets/5dd97dce-9a5f-47b6-96ce-ffb61b3f75dc)

