### PR TITLE
SDL3 GPU: Fix -Wbool-conversion warnings

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -2536,7 +2536,7 @@ void SDL_EndGPUComputePass(
     if (COMPUTEPASS_DEVICE->debug_mode) {
         commandBufferCommonHeader = (CommandBufferCommonHeader *)COMPUTEPASS_COMMAND_BUFFER;
         commandBufferCommonHeader->compute_pass.in_progress = false;
-        commandBufferCommonHeader->compute_pass.compute_pipeline = false;
+        commandBufferCommonHeader->compute_pass.compute_pipeline = NULL;
         SDL_zeroa(commandBufferCommonHeader->compute_pass.sampler_bound);
         SDL_zeroa(commandBufferCommonHeader->compute_pass.read_only_storage_texture_bound);
         SDL_zeroa(commandBufferCommonHeader->compute_pass.read_only_storage_buffer_bound);

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -11700,7 +11700,7 @@ static SDL_GPUDevice *VULKAN_CreateDevice(bool debugMode, bool preferLowPower, S
     renderer = (VulkanRenderer *)SDL_calloc(1, sizeof(*renderer));
     if (!renderer) {
         SDL_Vulkan_UnloadLibrary();
-        return false;
+        return NULL;
     }
 
     renderer->debugMode = debugMode;


### PR DESCRIPTION
## Description
Fixed a few `-Wbool-conversion` compilation warnings

These were just the ones I encountered in my project while upgrading from 3.2.12 to 3.2.16, not sure if there are more as I don't use all of SDL's subsystems

## Existing Issue(s)
None
