### PR TITLE
[SDL3][3.2.x] Fixing compilation issues with C23

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -2543,7 +2543,7 @@ void SDL_EndGPUComputePass(
     if (COMPUTEPASS_DEVICE->debug_mode) {
         commandBufferCommonHeader = (CommandBufferCommonHeader *)COMPUTEPASS_COMMAND_BUFFER;
         commandBufferCommonHeader->compute_pass.in_progress = false;
-        commandBufferCommonHeader->compute_pass.compute_pipeline = nullptr;
+        commandBufferCommonHeader->compute_pass.compute_pipeline = NULL;
         SDL_zeroa(commandBufferCommonHeader->compute_pass.sampler_bound);
         SDL_zeroa(commandBufferCommonHeader->compute_pass.read_only_storage_texture_bound);
         SDL_zeroa(commandBufferCommonHeader->compute_pass.read_only_storage_buffer_bound);

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -2543,7 +2543,7 @@ void SDL_EndGPUComputePass(
     if (COMPUTEPASS_DEVICE->debug_mode) {
         commandBufferCommonHeader = (CommandBufferCommonHeader *)COMPUTEPASS_COMMAND_BUFFER;
         commandBufferCommonHeader->compute_pass.in_progress = false;
-        commandBufferCommonHeader->compute_pass.compute_pipeline = false;
+        commandBufferCommonHeader->compute_pass.compute_pipeline = nullptr;
         SDL_zeroa(commandBufferCommonHeader->compute_pass.sampler_bound);
         SDL_zeroa(commandBufferCommonHeader->compute_pass.read_only_storage_texture_bound);
         SDL_zeroa(commandBufferCommonHeader->compute_pass.read_only_storage_buffer_bound);

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -11686,7 +11686,7 @@ static SDL_GPUDevice *VULKAN_CreateDevice(bool debugMode, bool preferLowPower, S
     renderer = (VulkanRenderer *)SDL_calloc(1, sizeof(*renderer));
     if (!renderer) {
         SDL_Vulkan_UnloadLibrary();
-        return false;
+        return NULL;
     }
 
     renderer->debugMode = debugMode;


### PR DESCRIPTION
I ran into some compilation errors using C23 which seems related to the way "false /_False" is casting to 0 in C99, making it legal and working C99 but not legal C23 code (since in C23 it's a "real" boolean) 

That said, I believe those are probably typos since using 0/false as NULL is kinda sus in the first place :)

```
/home/anthony/Desktop/sdl2-test/vendor/SDL/src/gpu/SDL_gpu.c:2546:68: error: incompatible types when assigning to type ‘SDL_GPUComputePipeline *’ from type ‘_Bool’
 2546 |         commandBufferCommonHeader->compute_pass.compute_pipeline = false;
```

```
/home/anthony/Desktop/sdl2-test/vendor/SDL/src/gpu/vulkan/SDL_gpu_vulkan.c:11689:16: error: incompatible types when returning type ‘_Bool’ but ‘SDL_GPUDevice *’ was expected
11689 |         return false;
      |                ^~~~~
```
## Description
Changed instances of false to NULL while keeping it C99 legal. 
The change is a plus for legibility anyway imho.

