### PR TITLE
Add support for floating point main callback rates

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2500,6 +2500,10 @@ extern "C" {
  * This defaults to 0, and specifying NULL for the hint's value will restore
  * the default.
  *
+ * This doesn't have to be an integer value. For example, "59.94" won't be
+ * rounded to an integer rate; the digits after the decimal are actually
+ * respected.
+ *
  * This hint can be set anytime.
  *
  * \since This hint is available since SDL 3.2.0.

--- a/src/main/generic/SDL_sysmain_callbacks.c
+++ b/src/main/generic/SDL_sysmain_callbacks.c
@@ -34,9 +34,9 @@ static void SDLCALL MainCallbackRateHintChanged(void *userdata, const char *name
     if (iterate_after_waitevent) {
         callback_rate_increment = 0;
     } else {
-        const int callback_rate = newValue ? SDL_atoi(newValue) : 0;
-        if (callback_rate > 0) {
-            callback_rate_increment = ((Uint64) 1000000000) / ((Uint64) callback_rate);
+        const double callback_rate = newValue ? SDL_atof(newValue) : 0.0;
+        if (callback_rate > 0.0) {
+            callback_rate_increment = (Uint64) ((double) SDL_NS_PER_SECOND / callback_rate);
         } else {
             callback_rate_increment = 0;
         }

--- a/src/main/generic/SDL_sysmain_callbacks.c
+++ b/src/main/generic/SDL_sysmain_callbacks.c
@@ -25,7 +25,7 @@
 
 #ifndef SDL_PLATFORM_IOS
 
-static int callback_rate_increment = 0;
+static Uint64 callback_rate_increment = 0;
 static bool iterate_after_waitevent = false;
 
 static void SDLCALL MainCallbackRateHintChanged(void *userdata, const char *name, const char *oldValue, const char *newValue)


### PR DESCRIPTION
A use case where supporting floating point callback rates is useful is when setting the callback rate to the display's refresh rate, which isn't always an exact integer. So, I've added such support to the callback rate hint.

The change of `callback_rate_increment`'s type to `Uint64` is actually necessary now, because a nonzero less-than-one callback rate results in the increment being multiple seconds, so it's best to have as much room as possible for the increment in such a use case.

As `SDL_atof()` parses integer strings as expected, this PR doesn't introduce ABI breakage.