### PR TITLE
SDL2: Fix PDP Afterglow Wireless Controller for Nintendo Switch

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -278,6 +278,7 @@ static Uint32 initial_blacklist_devices[] = {
     MAKE_VIDPID(0x1532, 0x0282), /* Razer Huntsman Mini Analog, non-functional DInput device */
     MAKE_VIDPID(0x26ce, 0x01a2), /* ASRock LED Controller */
     MAKE_VIDPID(0x20d6, 0x0002), /* PowerA Enhanced Wireless Controller for Nintendo Switch (charging port only) */
+    MAKE_VIDPID(0x0e6f, 0x0186), /* PDP Afterglow Wireless Controller for Nintendo Switch (charging port only) */
 };
 static SDL_vidpid_list blacklist_devices = {
     SDL_HINT_JOYSTICK_BLACKLIST_DEVICES, 0, 0, NULL,


### PR DESCRIPTION
## Description
I received a few reports from players that the [PDP Afterglow Wireless Controller](https://pdp.com/products/afterglow-wireless-deluxe-controller-for-nintendo-switch?srsltid=AfmBOopCtlOS-k_1KJhkE1JiLT9Aes90wQtOKiCIUA3MD1BAdF8sUMqd) caused Hades II to lock up and become nearly unresponsive. After acquiring the controller, this was readily reproducible by plugging it into a PC via cable. I noticed the same behavior on macOS, but not on Linux (via Proton).

The controller is intended for wireless use only according to the [product manual](https://support.turtlebeach.com/s/article/Afterglow-Wireless-Deluxe-Controller-for-Nintendo-Switch-Setup?language=en_US&co=en_US). When connected over USB, `BReadDeviceInfo()` fails to get a response. This kicks the can down the road to `SDL_JoystickOpen`, where the controller is equally unresponsive and procs the `Couldn't load stick calibration` error. However, the SDL_JOYDEVICEADDED event continues firing, which is the source of the lock-up. Early-outing in `HIDAPI_DriverSwitch_InitDevice()` seemed reasonable in this case.

It might be better to simply return false if `BReadDeviceInfo()` also returns false, but I don't know if that'll work with all controllers. This is similar to the PowerA controller that's ignored in `SDL_joystick.c`, which is also a "Lic Wireless Controller" in Windows. I tried ignoring the PDP controller too, but that prevented it from working over Bluetooth, which how I ended up with this fix.

(I found a similar [report](https://forums.factorio.com/viewtopic.php?t=116336) on the Factorio support forum, but I was unable to repro this on the latest Steam build.)
