### PR TITLE
SDL2: Don't crash PSP when no thread name is specified

### DIFF
--- a/src/thread/psp/SDL_systhread.c
+++ b/src/thread/psp/SDL_systhread.c
@@ -34,6 +34,8 @@
 #include <pspkerneltypes.h>
 #include <pspthreadman.h>
 
+#define PSP_THREAD_NAME_MAX 32
+
 static int ThreadEntry(SceSize args, void *argp)
 {
     SDL_RunThread(*(SDL_Thread **)argp);
@@ -44,6 +46,7 @@ int SDL_SYS_CreateThread(SDL_Thread *thread)
 {
     SceKernelThreadInfo status;
     int priority = 32;
+    char thread_name[PSP_THREAD_NAME_MAX];
 
     /* Set priority of new thread to the same as the current thread */
     status.size = sizeof(SceKernelThreadInfo);
@@ -51,7 +54,12 @@ int SDL_SYS_CreateThread(SDL_Thread *thread)
         priority = status.currentPriority;
     }
 
-    thread->handle = sceKernelCreateThread(thread->name, ThreadEntry,
+    SDL_strlcpy(thread_name, "SDL thread", PSP_THREAD_NAME_MAX);
+    if (thread->name) {
+        SDL_strlcpy(thread_name, thread->name, PSP_THREAD_NAME_MAX);
+    }
+
+    thread->handle = sceKernelCreateThread(thread_name, ThreadEntry,
                                            priority, thread->stacksize ? ((int)thread->stacksize) : 0x8000,
                                            PSP_THREAD_ATTR_VFPU, NULL);
     if (thread->handle < 0) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
At the moment creating a thread with the name set to NULL will cause a crash on PSP, this PR resolves this.

## Description
<!--- Describe your changes in detail -->
I'll create this same PR for SDL3 if it is approved. The crash is caused by sceKernelCreateThread requiring the thread name to not be NULL. Since a lot of other platforms to allow thread names to be left blank, there is code out there which will cause this crash.
 
## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
