### PR TITLE
PSP: Truncate thread name when passing to sceKernelCreateThread

### DIFF
--- a/src/thread/psp/SDL_systhread.c
+++ b/src/thread/psp/SDL_systhread.c
@@ -32,6 +32,8 @@
 #include <pspkerneltypes.h>
 #include <pspthreadman.h>
 
+#define PSP_THREAD_NAME_MAX 32
+
 static int ThreadEntry(SceSize args, void *argp)
 {
     SDL_RunThread(*(SDL_Thread **)argp);
@@ -44,6 +46,7 @@ bool SDL_SYS_CreateThread(SDL_Thread *thread,
 {
     SceKernelThreadInfo status;
     int priority = 32;
+    char thread_name[PSP_THREAD_NAME_MAX];
 
     // Set priority of new thread to the same as the current thread
     status.size = sizeof(SceKernelThreadInfo);
@@ -51,7 +54,12 @@ bool SDL_SYS_CreateThread(SDL_Thread *thread,
         priority = status.currentPriority;
     }
 
-    thread->handle = sceKernelCreateThread(thread->name, ThreadEntry,
+    SDL_strlcpy(thread_name, "SDL thread", PSP_THREAD_NAME_MAX);
+    if (thread->name) {
+        SDL_strlcpy(thread_name, thread->name, PSP_THREAD_NAME_MAX);
+    }
+
+    thread->handle = sceKernelCreateThread(thread_name, ThreadEntry,
                                            priority, thread->stacksize ? ((int)thread->stacksize) : 0x8000,
                                            PSP_THREAD_ATTR_VFPU, NULL);
     if (thread->handle < 0) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Same as #13330

## Description
<!--- Describe your changes in detail -->
Currently if you provide a NULL as thread name on the PSP, you'll see a crash. Same if the name provided is too long. This changes prevents that. I already made the same fix for SDL2 in another PR.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
