### PR TITLE
fix ARM64 linkage with Visual Studio >= 17.14 when SDL_LIBC is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -755,6 +755,11 @@ if(MSVC)
   if(MSVC_VERSION GREATER 1926 AND CMAKE_GENERATOR_PLATFORM MATCHES "Win32|x64")
     list(APPEND EXTRA_LDFLAGS_BUILD "-CETCOMPAT")
   endif()
+
+  # for VS >= 17.14 targeting ARM64: inline the Interlocked funcs
+  if(MSVC_VERSION GREATER 1943 AND SDL_CPU_ARM64 AND NOT SDL_LIBC)
+    list(APPEND EXTRA_CFLAGS /forceInterlockedFunctions-)
+  endif()
 endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")


### PR DESCRIPTION
Reference issue:  https://github.com/libsdl-org/SDL/issues/13254

If accepted, should be merged to release-2.32.x, and possibly be forward-ported to SDL3.
