### PR TITLE
 cmake: remove /RTC1 from CXX flags when building with SDL_LIBC=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,9 +189,12 @@ if(MSVC)
     # Make sure /RTC1 is disabled, otherwise it will use functions from the CRT
     foreach(flag_var
         CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
-        CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
+        CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO
+        CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+        CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
       string(REGEX REPLACE "/RTC(su|[1su])" "" ${flag_var} "${${flag_var}}")
     endforeach(flag_var)
+    set(CMAKE_MSVC_RUNTIME_CHECKS "")
   endif()
 
   if(MSVC_CLANG)


### PR DESCRIPTION
This fixes the following link error, causes by `src/video/windows/SDL_windowsgaminginput.cpp`:
```
SDL_windowsgameinput.cpp.obj : error LNK2001: unresolved external symbol _RTC_InitBase
SDL_windowsgameinput.cpp.obj : error LNK2001: unresolved external symbol _RTC_Shutdown
```

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
