### PR TITLE
Fix opening dinput haptic and joystick devices when SDL_VIDEO is off

### DIFF
--- a/src/SDL.c
+++ b/src/SDL.c
@@ -65,7 +65,7 @@
 
 // Initialization/Cleanup routines
 #include "timer/SDL_timer_c.h"
-#ifdef SDL_VIDEO_DRIVER_WINDOWS
+#ifdef SDL_PLATFORM_WINDOWS
 extern bool SDL_HelperWindowCreate(void);
 extern void SDL_HelperWindowDestroy(void);
 #endif
@@ -317,7 +317,7 @@ bool SDL_InitSubSystem(SDL_InitFlags flags)
     SDL_DBus_Init();
 #endif
 
-#ifdef SDL_VIDEO_DRIVER_WINDOWS
+#ifdef SDL_PLATFORM_WINDOWS
     if (flags & (SDL_INIT_HAPTIC | SDL_INIT_JOYSTICK)) {
         if (!SDL_HelperWindowCreate()) {
             goto quit_and_error;
@@ -653,7 +653,7 @@ void SDL_Quit(void)
     SDL_bInMainQuit = true;
 
     // Quit all subsystems
-#ifdef SDL_VIDEO_DRIVER_WINDOWS
+#ifdef SDL_PLATFORM_WINDOWS
     SDL_HelperWindowDestroy();
 #endif
     SDL_QuitSubSystem(SDL_INIT_EVERYTHING);

--- a/src/core/windows/SDL_windows.c
+++ b/src/core/windows/SDL_windows.c
@@ -53,6 +53,78 @@ typedef enum RO_INIT_TYPE
 #define WC_ERR_INVALID_CHARS 0x00000080
 #endif
 
+// Fake window to help with DirectInput events.
+HWND SDL_HelperWindow = NULL;
+static const TCHAR *SDL_HelperWindowClassName = TEXT("SDLHelperWindowInputCatcher");
+static const TCHAR *SDL_HelperWindowName = TEXT("SDLHelperWindowInputMsgWindow");
+static ATOM SDL_HelperWindowClass = 0;
+
+/*
+ * Creates a HelperWindow used for DirectInput.
+ */
+bool SDL_HelperWindowCreate(void)
+{
+    HINSTANCE hInstance = GetModuleHandle(NULL);
+    WNDCLASS wce;
+
+    // Make sure window isn't created twice.
+    if (SDL_HelperWindow != NULL) {
+        return true;
+    }
+
+    // Create the class.
+    SDL_zero(wce);
+    wce.lpfnWndProc = DefWindowProc;
+    wce.lpszClassName = SDL_HelperWindowClassName;
+    wce.hInstance = hInstance;
+
+    // Register the class.
+    SDL_HelperWindowClass = RegisterClass(&wce);
+    if (SDL_HelperWindowClass == 0 && GetLastError() != ERROR_CLASS_ALREADY_EXISTS) {
+        return WIN_SetError("Unable to create Helper Window Class");
+    }
+
+    // Create the window.
+    SDL_HelperWindow = CreateWindowEx(0, SDL_HelperWindowClassName,
+                                      SDL_HelperWindowName,
+                                      WS_OVERLAPPED, CW_USEDEFAULT,
+                                      CW_USEDEFAULT, CW_USEDEFAULT,
+                                      CW_USEDEFAULT, HWND_MESSAGE, NULL,
+                                      hInstance, NULL);
+    if (!SDL_HelperWindow) {
+        UnregisterClass(SDL_HelperWindowClassName, hInstance);
+        return WIN_SetError("Unable to create Helper Window");
+    }
+
+    return true;
+}
+
+/*
+ * Destroys the HelperWindow previously created with SDL_HelperWindowCreate.
+ */
+void SDL_HelperWindowDestroy(void)
+{
+    HINSTANCE hInstance = GetModuleHandle(NULL);
+
+    // Destroy the window.
+    if (SDL_HelperWindow != NULL) {
+        if (DestroyWindow(SDL_HelperWindow) == 0) {
+            WIN_SetError("Unable to destroy Helper Window");
+            return;
+        }
+        SDL_HelperWindow = NULL;
+    }
+
+    // Unregister the class.
+    if (SDL_HelperWindowClass != 0) {
+        if ((UnregisterClass(SDL_HelperWindowClassName, hInstance)) == 0) {
+            WIN_SetError("Unable to destroy Helper Window Class");
+            return;
+        }
+        SDL_HelperWindowClass = 0;
+    }
+}
+
 // Sets an error message based on an HRESULT
 bool WIN_SetErrorFromHRESULT(const char *prefix, HRESULT hr)
 {

--- a/src/haptic/windows/SDL_dinputhaptic.c
+++ b/src/haptic/windows/SDL_dinputhaptic.c
@@ -31,11 +31,7 @@
 /*
  * External stuff.
  */
-#ifdef SDL_VIDEO_DRIVER_WINDOWS
 extern HWND SDL_HelperWindow;
-#else
-static const HWND SDL_HelperWindow = NULL;
-#endif
 
 /*
  * Internal stuff.

--- a/src/joystick/windows/SDL_dinputjoystick.c
+++ b/src/joystick/windows/SDL_dinputjoystick.c
@@ -40,11 +40,7 @@
 #define CONVERT_MAGNITUDE(x) (((x)*10000) / 0x7FFF)
 
 // external variables referenced.
-#ifdef SDL_VIDEO_DRIVER_WINDOWS
 extern HWND SDL_HelperWindow;
-#else
-static const HWND SDL_HelperWindow = NULL;
-#endif
 
 // local variables
 static bool coinitialized = false;

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -96,12 +96,6 @@ typedef void (NTAPI *RtlGetVersion_t)(NT_OSVERSIONINFOW *);
 
 // #define HIGHDPI_DEBUG
 
-// Fake window to help with DirectInput events.
-HWND SDL_HelperWindow = NULL;
-static const TCHAR *SDL_HelperWindowClassName = TEXT("SDLHelperWindowInputCatcher");
-static const TCHAR *SDL_HelperWindowName = TEXT("SDLHelperWindowInputMsgWindow");
-static ATOM SDL_HelperWindowClass = 0;
-
 /* For borderless Windows, still want the following flag:
    - WS_MINIMIZEBOX: window will respond to Windows minimize commands sent to all windows, such as windows key + m, shaking title bar, etc.
    Additionally, non-fullscreen windows can add:
@@ -1536,72 +1530,6 @@ bool WIN_SetWindowKeyboardGrab(SDL_VideoDevice *_this, SDL_Window *window, bool 
 void WIN_DestroyWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
     CleanupWindowData(_this, window);
-}
-
-/*
- * Creates a HelperWindow used for DirectInput.
- */
-bool SDL_HelperWindowCreate(void)
-{
-    HINSTANCE hInstance = GetModuleHandle(NULL);
-    WNDCLASS wce;
-
-    // Make sure window isn't created twice.
-    if (SDL_HelperWindow != NULL) {
-        return true;
-    }
-
-    // Create the class.
-    SDL_zero(wce);
-    wce.lpfnWndProc = DefWindowProc;
-    wce.lpszClassName = SDL_HelperWindowClassName;
-    wce.hInstance = hInstance;
-
-    // Register the class.
-    SDL_HelperWindowClass = RegisterClass(&wce);
-    if (SDL_HelperWindowClass == 0 && GetLastError() != ERROR_CLASS_ALREADY_EXISTS) {
-        return WIN_SetError("Unable to create Helper Window Class");
-    }
-
-    // Create the window.
-    SDL_HelperWindow = CreateWindowEx(0, SDL_HelperWindowClassName,
-                                      SDL_HelperWindowName,
-                                      WS_OVERLAPPED, CW_USEDEFAULT,
-                                      CW_USEDEFAULT, CW_USEDEFAULT,
-                                      CW_USEDEFAULT, HWND_MESSAGE, NULL,
-                                      hInstance, NULL);
-    if (!SDL_HelperWindow) {
-        UnregisterClass(SDL_HelperWindowClassName, hInstance);
-        return WIN_SetError("Unable to create Helper Window");
-    }
-
-    return true;
-}
-
-/*
- * Destroys the HelperWindow previously created with SDL_HelperWindowCreate.
- */
-void SDL_HelperWindowDestroy(void)
-{
-    HINSTANCE hInstance = GetModuleHandle(NULL);
-
-    // Destroy the window.
-    if (SDL_HelperWindow != NULL) {
-        if (DestroyWindow(SDL_HelperWindow) == 0) {
-            WIN_SetError("Unable to destroy Helper Window");
-            return;
-        }
-        SDL_HelperWindow = NULL;
-    }
-
-    // Unregister the class.
-    if (SDL_HelperWindowClass != 0) {
-        if ((UnregisterClass(SDL_HelperWindowClassName, hInstance)) == 0) {
-            WIN_SetError("Unable to destroy Helper Window Class");
-            return;
-        }
-        SDL_HelperWindowClass = 0;
-    }
 }
 
 #if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)


### PR DESCRIPTION
## Description
When SDL_VIDEO is off, dinput joystick and haptics use a NULL value for SDL_HelperWindow. This causes an error in IDirectInputDevice8_SetCooperativeLevel that prevents opening the dinput device. This branch fixes that error by hoisting SDL_HelperWindow code outside of SDL_VIDEO_DRIVER_WINDOWS regions.

## Existing Issue(s)
#13347

