### PR TITLE
Xcode-iOS/Demos/src/fireworks.c: Make rendering CPU efficient

### DIFF
--- a/Xcode-iOS/Demos/src/fireworks.c
+++ b/Xcode-iOS/Demos/src/fireworks.c
@@ -456,7 +456,10 @@ main(int argc, char *argv[])
     while (!done) {
         SDL_Event event;
         double deltaTime = updateDeltaTime();
+        SDL_bool hasEvents = SDL_FALSE;
+        
         while (SDL_PollEvent(&event)) {
+            hasEvents = SDL_TRUE;
             if (event.type == SDL_QUIT) {
                 done = 1;
             }
@@ -466,10 +469,17 @@ main(int argc, char *argv[])
                 spawnEmitterParticle(x, y);
             }
         }
-        stepParticles(deltaTime);
-        drawParticles();
-        SDL_GL_SwapWindow(window);
-        SDL_Delay(1);
+        
+        /* Only update and render if we have active particles or just received events */
+        if (num_active_particles > 0 || hasEvents) {
+            stepParticles(deltaTime);
+            drawParticles();
+            SDL_GL_SwapWindow(window);
+            SDL_Delay(16); // Target 60 FPS when active
+        } else {
+            /* Idle state - wait for events with longer delay to save CPU */
+            SDL_Delay(100); // Much longer delay when idle
+        }
     }
 
     /* delete textures */


### PR DESCRIPTION
Significantly reduces CPU usage in the iOS fireworks demo by implementing proper frame rate limiting and idle state management.

## Description
- Replaced `SDL_Delay(1)` (targeting ~1000 FPS) with conditional rendering (targeting 60 fps or 10 fps depending on state)
- Added idle state detection to skip expensive operations when no particles are active.

**Performance improvements:**
- **Idle**: 120%+ CPU → 0-1% CPU  
- **Active**: 200%+ CPU → around 50% CPU
- Maintains full responsiveness and visual quality


## Existing Issue(s)
I explored this as we are having significant performance issues with XCSoar on iOS, using SDL2 and OpenGLES (see https://github.com/XCSoar/XCSoar/issues/1693).
After checking your example, I thought this might be normal for OpenGLES on iOS since it was officially deprecated by Apple (and might not properly support hardware acceleration anymore, etc.). After making your example decently efficient, I am more confident now that we can also solve the XCSoar issue (without switching from OpenGLES to Metal)...