### PR TITLE
draft: don't use `CLOCK_MONOTONIC_RAW` on Android

### DIFF
--- a/src/timer/unix/SDL_systimer.c
+++ b/src/timer/unix/SDL_systimer.c
@@ -53,7 +53,9 @@
 
 // Use CLOCK_MONOTONIC_RAW, if available, which is not subject to adjustment by NTP
 #ifdef HAVE_CLOCK_GETTIME
-#ifdef CLOCK_MONOTONIC_RAW
+// Older Android phones have a buggy CLOCK_MONOTONIC_RAW, use CLOCK_MONOTONIC
+// See fix: https://github.com/torvalds/linux/commit/dbb236c1ceb697a559e0694ac4c9e7b9131d0b16
+#if defined(CLOCK_MONOTONIC_RAW) && !defined(__ANDROID__)
 #define SDL_MONOTONIC_CLOCK CLOCK_MONOTONIC_RAW
 #else
 #define SDL_MONOTONIC_CLOCK CLOCK_MONOTONIC


### PR DESCRIPTION
## Description

I'm marking this PR as draft since I'm not really sure this should be merged, because it fixes an issue on older Android devices. I'm opening it for discussion.

This PR works around a kernel bug described in the commit message (fixed upstream with [1]). The state of Android ecosystem is that old devices that have this bug won't ever be updated so the only possible solution is to work around the bug in SDL.

Android 8.1 (kernel 3.18.94) arm64 emulator image is the last OS version producing this bug. Judging by https://apilevels.com/ there are still ~7% of users using this OS version or lower.

I don't know if Android versions specify a minimum kernel version to be used with. If they don't, a vendor can decide to ship an older kernel with a new Android OS (for example, because the GPU driver was written against an older kernel). So in theory even newer devices can be affected.

I've made a small project to easily test for the bug: https://gitlab.com/blaztinn/android-clock-monotonic-raw-bug-reproduction
The bug is quite easily reproduced by just calling `clock_gettime(CLOCK_MONOTONIC_RAW, &ts)` and observing that nanoseconds (`ts->tv_nsec`) are larger than 999_999_999. Nanoseconds are out of range for 99%+ of the queries. The time is also not monotonically increasing but this doesn't happen as often as nanoseconds being out of range.

What follows is a copy of the commit message with more detailed explanation.

---

Older Android phones have a kernel bug where time is not properly calculated when calling `clock_gettime(CLOCK_MONOTONIC_RAW, ...)`. The returned time either has nanoseconds out of range (outside of [0, 999999999]) or the returned time is not monotonic in regards to previous call or both.

The issue is reproducible in Android Studio on arm64 emulators from at least Android 7.0 (didn't try older versions) up to including Android 8.1 (kernel 3.18.94). The issue is in the kernel, these are just the versions of Android emulator with buggy kernels.

The kernel commit that fixed this is [1]. Because this fix was backported to various LTS releases of kernels it's hard to find out exactly which kernels are buggy and which not. Therefore always use `CLOCK_MONOTONIC` on Android.

The `CLOCK_MONOTONIC` is slowly adjusted in case of NTP changes but not for more than 0.5ms per second [2]. So it should be good enough for measuring elapsed time.

---

An option would be to dynamically select
`CLOCK_MONOTONIC_RAW`/`CLOCK_MONOTONIC` at runtime by checking at init time that `clock_gettime(CLOCK_MONOTONIC_RAW, ...)` returns nanoseconds in range. Testing showed that nanosecons are out of range for 999/1000 cases. I guess this could be good enough for support on older phones.

But because this would introduce a small perf hit by always reading a global variable for first argument to `clock_gettime` and because `CLOCK_MONOTONIC` does not have that high time deviation, this commit uses `CLOCK_MONOTONIC` on Android always. It is also less burden to maintain.

---

[1] https://github.com/torvalds/linux/commit/dbb236c1ceb697a559e0694ac4c9e7b9131d0b16
[2] https://github.com/torvalds/linux/blob/master/include/linux/timex.h#L136

## Existing Issue(s)

None found.
