### PR TITLE
GPU: Clean up copied texture create props in SDL_ReleaseGPUTexture

### DIFF
--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -1420,6 +1420,8 @@ static void D3D12_INTERNAL_ReleaseTextureContainer(
             container->textures[i]);
     }
 
+    SDL_DestroyProperties(container->header.info.props);
+
     // Containers are just client handles, so we can destroy immediately
     if (container->debugName) {
         SDL_free(container->debugName);

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -914,6 +914,7 @@ static void METAL_INTERNAL_DestroyTextureContainer(
         container->textures[i]->handle = nil;
         SDL_free(container->textures[i]);
     }
+    SDL_DestroyProperties(container->header.info.props);
     if (container->debugName != NULL) {
         SDL_free(container->debugName);
     }

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -6954,6 +6954,8 @@ static void VULKAN_ReleaseTexture(
         VULKAN_INTERNAL_ReleaseTexture(renderer, vulkanTextureContainer->textures[i]);
     }
 
+    SDL_DestroyProperties(vulkanTextureContainer->header.info.props);
+
     // Containers are just client handles, so we can destroy immediately
     if (vulkanTextureContainer->debugName != NULL) {
         SDL_free(vulkanTextureContainer->debugName);


### PR DESCRIPTION
CreateGPUTexture copies the create info struct, so it also has to copy the associated props, which we forgot to destroy in Release. 