### PR TITLE
Clarify SDL_GPUVertexBufferDescription.pitch comment

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -1627,7 +1627,7 @@ typedef struct SDL_GPUSamplerCreateInfo
 typedef struct SDL_GPUVertexBufferDescription
 {
     Uint32 slot;                        /**< The binding slot of the vertex buffer. */
-    Uint32 pitch;                       /**< The byte pitch between consecutive elements of the vertex buffer. */
+    Uint32 pitch;                       /**< The size of a single element + the offset between elements. */
     SDL_GPUVertexInputRate input_rate;  /**< Whether attribute addressing is a function of the vertex index or instance index. */
     Uint32 instance_step_rate;          /**< Reserved for future use. Must be set to 0. */
 } SDL_GPUVertexBufferDescription;


### PR DESCRIPTION
## Description
The comment implies that `pitch` should only be set to the padding *between* elements, which may confuse a lot of newbies (like me..) and lead them to just set pitch to 0. Which obviously doesn't work.

This new comment is just a dumbed down version of what `pitch` actually is, it's the size of a single vertex (combined with any padding).

## Existing Issue(s)
