### PR TITLE
For save file dialogs, make setting default file name on MacOS functional

### DIFF
--- a/src/dialog/cocoa/SDL_cocoadialog.m
+++ b/src/dialog/cocoa/SDL_cocoadialog.m
@@ -158,7 +158,14 @@ void SDL_SYS_ShowFileDialogWithProperties(SDL_FileDialogType type, SDL_DialogFil
     [dialog setAllowsOtherFileTypes:YES];
 
     if (default_location) {
-        [dialog setDirectoryURL:[NSURL fileURLWithPath:[NSString stringWithUTF8String:default_location]]];
+        char last = default_location[SDL_strlen(default_location) - 1];
+        NSURL* url = [NSURL fileURLWithPath:[NSString stringWithUTF8String:default_location]];
+        if (last == '/') {
+            [dialog setDirectoryURL:url];
+        } else {
+            [dialog setDirectoryURL:[url URLByDeletingLastPathComponent]];
+            [dialog setNameFieldStringValue:[url lastPathComponent]];
+        }
     }
 
     NSWindow *w = NULL;


### PR DESCRIPTION
## Description
Uses the correct action `setNameFieldStringValue` of `NSSavePanel` to set the default file name. Originally, `setDirectoryURL` was used instead, which did not set the default file name.

## Existing Issue(s)
Fixes issue #13014.
