### PR TITLE
GC Ultimate Digital Trigger “Click” Mappings as Misc3 & Misc4

### DIFF
--- a/src/joystick/SDL_gamepad.c
+++ b/src/joystick/SDL_gamepad.c
@@ -810,7 +810,7 @@ static GamepadMapping_t *SDL_CreateMappingForHIDAPIGamepad(SDL_GUID guid)
 
         case USB_PRODUCT_HANDHELDLEGEND_GCULTIMATE:
             // GC Ultimate Map
-            SDL_strlcat(mapping_string, "a:b0,b:b2,back:b15,dpdown:b5,dpleft:b6,dpright:b7,dpup:b4,guide:b16,leftshoulder:b10,leftstick:b8,lefttrigger:a4,leftx:a0,lefty:a1,misc1:b17,misc2:b18,rightshoulder:b11,rightstick:b9,righttrigger:a5,rightx:a2,righty:a3,start:b14,x:b1,y:b3,hint:!SDL_GAMECONTROLLER_USE_GAMECUBE_LABELS:=1,", sizeof(mapping_string));
+            SDL_strlcat(mapping_string, "a:b0,b:b2,back:b15,dpdown:b5,dpleft:b6,dpright:b7,dpup:b4,guide:b16,leftshoulder:b10,leftstick:b8,lefttrigger:a4,leftx:a0,lefty:a1,misc1:b17,misc2:b18,rightshoulder:b11,rightstick:b9,righttrigger:a5,rightx:a2,righty:a3,start:b14,x:b1,y:b3,misc3:b12,misc4:b13,hint:!SDL_GAMECONTROLLER_USE_GAMECUBE_LABELS:=1,", sizeof(mapping_string));
             break;
 
         case USB_PRODUCT_HANDHELDLEGEND_SINPUT_GENERIC:


### PR DESCRIPTION
This patch implements the digital‑press mappings for the GameCube‑style triggers, exposing them as separate buttons (Misc3 and Misc4). When a user fully depresses L or R, the “click” event will fire independently of the analog axis.

Clear separation of input types: An analog axis and a digital “click” serve fundamentally different roles. Analog travel controls gradual values (e.g. throttle), while the full‑press click is a discrete action (e.g. boost, dash, fire, etc).

Backward‑compatible no‑op: If a user doesn’t bind the click, it simply does nothing—no unintended side effects.

For titles which bind an analog threshold to a digital press (IE titles that do not implement analog triggers), there is still utility, as the digital press is a unique button separate from this input. 

Unique utility akin to paddles/misc buttons: Many high‑end controllers expose extra front‑or‑rear buttons for advanced mappings. The trigger click is effectively another dedicated input and deserves its own mapping slot.

Flexible software bindings: With distinct Misc3/Misc4, front‑ends (Steam, RetroArch, etc.) can let users bind “full pull” separately from “analog pull,”.