### PR TITLE
vulkan: Potential copy paste issue fix in VULKAN_INTERNAL_BindComputeDescriptorSets

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -8594,7 +8594,7 @@ static void VULKAN_INTERNAL_BindComputeDescriptorSets(
         dynamicOffsetCount,
         dynamicOffsets);
 
-    commandBuffer->needNewVertexUniformOffsets = false;
+    commandBuffer->needNewComputeUniformOffsets = false;
 }
 
 static void VULKAN_DispatchCompute(


### PR DESCRIPTION
## Description
Went through the code because I had an issue with something unrelated (was my own stuff that was the problem). I did however notice this in the function for binding compute descriptor sets that it reset the _Vertex_ uniform offsets instead of the _Compute_ one. No idea if there was an issue with this but made a pull request anyway for it. Go ahead and close it if it is not an issue.
