### PR TITLE
Add POINTER suffix to SDL_PROP_IOSTREAM_MEMORY_FREE_FUNC

### DIFF
--- a/include/SDL3/SDL_iostream.h
+++ b/include/SDL3/SDL_iostream.h
@@ -301,7 +301,7 @@ extern SDL_DECLSPEC SDL_IOStream * SDLCALL SDL_IOFromFile(const char *file, cons
  *
  * Additionally, the following properties are recognized:
  *
- * - `SDL_PROP_IOSTREAM_MEMORY_FREE_FUNC`: if this property is set to a
+ * - `SDL_PROP_IOSTREAM_MEMORY_FREE_FUNC_POINTER`: if this property is set to a
  *   non-NULL value it will be interpreted as a function of SDL_free_func type
  *   and called with the passed `mem` pointer when closing the stream. By
  *   default it is unset, i.e., the memory will not be freed.
@@ -327,7 +327,7 @@ extern SDL_DECLSPEC SDL_IOStream * SDLCALL SDL_IOFromMem(void *mem, size_t size)
 
 #define SDL_PROP_IOSTREAM_MEMORY_POINTER "SDL.iostream.memory.base"
 #define SDL_PROP_IOSTREAM_MEMORY_SIZE_NUMBER  "SDL.iostream.memory.size"
-#define SDL_PROP_IOSTREAM_MEMORY_FREE_FUNC "SDL.iostream.memory.free"
+#define SDL_PROP_IOSTREAM_MEMORY_FREE_FUNC_POINTER "SDL.iostream.memory.free"
 
 /**
  * Use this function to prepare a read-only memory buffer for use with
@@ -354,7 +354,7 @@ extern SDL_DECLSPEC SDL_IOStream * SDLCALL SDL_IOFromMem(void *mem, size_t size)
  *
  * Additionally, the following properties are recognized:
  *
- * - `SDL_PROP_IOSTREAM_MEMORY_FREE_FUNC`: if this property is set to a
+ * - `SDL_PROP_IOSTREAM_MEMORY_FREE_FUNC_POINTER`: if this property is set to a
  *   non-NULL value it will be interpreted as a function of SDL_free_func type
  *   and called with the passed `mem` pointer when closing the stream. By
  *   default it is unset, i.e., the memory will not be freed.

--- a/src/io/SDL_iostream.c
+++ b/src/io/SDL_iostream.c
@@ -781,7 +781,7 @@ static size_t SDLCALL mem_write(void *userdata, const void *ptr, size_t size, SD
 static bool SDLCALL mem_close(void *userdata)
 {
     IOStreamMemData *iodata = (IOStreamMemData *) userdata;
-    SDL_free_func free_func = SDL_GetPointerProperty(iodata->props, SDL_PROP_IOSTREAM_MEMORY_FREE_FUNC, NULL);
+    SDL_free_func free_func = SDL_GetPointerProperty(iodata->props, SDL_PROP_IOSTREAM_MEMORY_FREE_FUNC_POINTER, NULL);
     if (free_func) {
         free_func(iodata->base);
     }

--- a/test/testautomation_iostream.c
+++ b/test/testautomation_iostream.c
@@ -342,7 +342,7 @@ static int SDLCALL iostrm_testMemWithFree(void *arg)
 
     /* Set the free function */
     free_call_count = 0;
-    result = SDL_SetPointerProperty(SDL_GetIOProperties(rw), SDL_PROP_IOSTREAM_MEMORY_FREE_FUNC, test_free);
+    result = SDL_SetPointerProperty(SDL_GetIOProperties(rw), SDL_PROP_IOSTREAM_MEMORY_FREE_FUNC_POINTER, test_free);
     SDLTest_AssertPass("Call to SDL_SetPointerProperty() succeeded");
     SDLTest_AssertCheck(result == true, "Verify result value is true; got %d", result);
 


### PR DESCRIPTION
I'm not sure if `FUNC` is considered a new property type, but if not, this property should have the `POINTER` suffix.