### PR TITLE
`SDL_build_config_windows.h`  `HAVE_VSSCANF` fix

### DIFF
--- a/include/build_config/SDL_build_config_windows.h
+++ b/include/build_config/SDL_build_config_windows.h
@@ -114,6 +114,9 @@ typedef unsigned int uintptr_t;
 # define SDL_DISABLE_AVX 1
 #endif
 
+#define HAVE_STDARG_H 1
+#define HAVE_STDDEF_H 1
+
 /* This can be disabled to avoid C runtime dependencies and manifest requirements */
 #ifndef HAVE_LIBC
 #define HAVE_LIBC 1
@@ -125,8 +128,6 @@ typedef unsigned int uintptr_t;
 #define HAVE_LIMITS_H 1
 #define HAVE_MATH_H 1
 #define HAVE_SIGNAL_H 1
-#define HAVE_STDARG_H 1
-#define HAVE_STDDEF_H 1
 #define HAVE_STDIO_H 1
 #define HAVE_STDLIB_H 1
 #define HAVE_STRING_H 1
@@ -213,10 +214,7 @@ typedef unsigned int uintptr_t;
 #if _MSC_VER >= 1400
 #define HAVE__FSEEKI64 1
 #endif
-#endif    /* _MSC_VER */
-#else
-#define HAVE_STDARG_H 1
-#define HAVE_STDDEF_H 1
+#endif /* _MSC_VER */
 #endif
 
 /* Enable various audio drivers */

--- a/include/build_config/SDL_build_config_windows.h
+++ b/include/build_config/SDL_build_config_windows.h
@@ -156,7 +156,6 @@ typedef unsigned int uintptr_t;
 #define HAVE_STRCMP 1
 #define HAVE_STRNCMP 1
 #define HAVE_STRPBRK 1
-#define HAVE_VSSCANF 1
 #define HAVE_VSNPRINTF 1
 #define HAVE_ACOS 1
 #define HAVE_ASIN 1


### PR DESCRIPTION
Fixes `HAVE_VSSCANF` being defined regardless of the MSVC version, and does some tidying up.