### PR TITLE
SDL2: Fix SDL_WINDOWEVENT_RESTORED firing on macOS if the window is still miniaturized during a resize

### DIFF
--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -855,6 +855,11 @@ static NSCursor *Cocoa_GetDesiredCursor(void)
     SDL_SendWindowEvent(window, SDL_WINDOWEVENT_MOVED, x, y);
     SDL_SendWindowEvent(window, SDL_WINDOWEVENT_RESIZED, w, h);
 
+    /* The OS can resize the window automatically if the display density
+       changes while the window is miniaturized or hidden */
+    if (![nswindow isVisible])
+        return;
+
     /* isZoomed always returns true if the window is not resizable */
     if ((window->flags & SDL_WINDOW_RESIZABLE) && [nswindow isZoomed]) {
         zoomed = YES;


### PR DESCRIPTION
Check NSWindow::isVisible before sending SDL_WINDOWEVENT_RESTORED during Cocoa_WindowListener::windowDidResize

## Description

Fixes `SDL_WINDOWEVENT_RESTORED` being sent to the application while the window is still miniaturized. This can happen if macOS resizes the window as a result of a display density change.

This can happen if the user changes their display resolution settings in `System Preferences > Displays` from the default on a retina display to 2x the default.

This can also happen if the user disconnects a non-retina display and the OS needs to move all application windows to another retina display.

In either case, any miniaturized windows will be resized accordingly while remaining miniaturized. SDL was treating all window resizes as if the window was visible and not miniaturized, which is not true.
