### PR TITLE
Fixed a few "-Wstrict-prototypes" warnings

### DIFF
--- a/src/audio/alsa/SDL_alsa_audio.c
+++ b/src/audio/alsa/SDL_alsa_audio.c
@@ -1470,7 +1470,7 @@ static void ALSA_udev_callback(SDL_UDEV_deviceevent udev_type, int udev_class, c
     }
 }
 
-static bool ALSA_start_udev()
+static bool ALSA_start_udev(void)
 {
     udev_initialized = SDL_UDEV_Init();
     if (udev_initialized) {
@@ -1483,7 +1483,7 @@ static bool ALSA_start_udev()
     return udev_initialized;
 }
 
-static void ALSA_stop_udev()
+static void ALSA_stop_udev(void)
 {
     if (udev_initialized) {
         SDL_UDEV_DelCallback(ALSA_udev_callback);
@@ -1494,12 +1494,12 @@ static void ALSA_stop_udev()
 
 #else
 
-static bool ALSA_start_udev()
+static bool ALSA_start_udev(void)
 {
     return false;
 }
 
-static void ALSA_stop_udev()
+static void ALSA_stop_udev(void)
 {
 }
 

--- a/src/core/linux/SDL_progressbar.c
+++ b/src/core/linux/SDL_progressbar.c
@@ -32,7 +32,7 @@
 #define UnityLauncherAPI_DBUS_INTERFACE "com.canonical.Unity.LauncherEntry"
 #define UnityLauncherAPI_DBUS_SIGNAL    "Update"
 
-static char *GetDBUSObjectPath()
+static char *GetDBUSObjectPath(void)
 {
     char *app_id = SDL_strdup(SDL_GetAppID());
 
@@ -62,7 +62,7 @@ static char *GetDBUSObjectPath()
     return SDL_strdup(path);
 }
 
-static char *GetAppDesktopPath()
+static char *GetAppDesktopPath(void)
 {
     const char *desktop_suffix = ".desktop";
     const char *app_id = SDL_GetAppID();

--- a/test/gamepadutils.h
+++ b/test/gamepadutils.h
@@ -161,7 +161,7 @@ typedef enum
 typedef struct Quaternion Quaternion;
 typedef struct GyroDisplay GyroDisplay;
 
-extern void InitCirclePoints3D();
+extern void InitCirclePoints3D(void);
 extern GyroDisplay *CreateGyroDisplay(SDL_Renderer *renderer);
 extern void SetGyroDisplayArea(GyroDisplay *ctx, const SDL_FRect *area);
 extern void SetGamepadDisplayIMUValues(GyroDisplay *ctx, float *gyro_drift_solution, float *euler_displacement_angles, Quaternion *gyro_quaternion, int reported_senor_rate_hz, int estimated_sensor_rate_hz, EGyroCalibrationPhase calibration_phase, float drift_calibration_progress_frac, float accelerometer_noise_sq, float accelerometer_noise_tolerance_sq);

--- a/test/testcontroller.c
+++ b/test/testcontroller.c
@@ -1439,7 +1439,7 @@ static void HandleGamepadGyroEvent(SDL_Event *event)
 #define SDL_GAMEPAD_IMU_MIN_POLLING_RATE_ESTIMATION_TIME_NS (SDL_NS_PER_SECOND * 2)
 
 
-static void EstimatePacketRate()
+static void EstimatePacketRate(void)
 {
     Uint64 now_ns = SDL_GetTicksNS();
     if (controller->imu_state->imu_packet_counter == 0) {


### PR DESCRIPTION
```c
[ 28%] Building C object CMakeFiles/SDL3-shared.dir/src/audio/alsa/SDL_alsa_audio.c.o
/path/to/SDL/src/audio/alsa/SDL_alsa_audio.c:1473:13: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
 1473 | static bool ALSA_start_udev()
      |             ^~~~~~~~~~~~~~~
/path/to/SDL/src/audio/alsa/SDL_alsa_audio.c:1486:13: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
 1486 | static void ALSA_stop_udev()
      |             ^~~~~~~~~~~~~~
/path/to/SDL/src/core/linux/SDL_progressbar.c:35:14: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
   35 | static char *GetDBUSObjectPath()
      |              ^~~~~~~~~~~~~~~~~
/path/to/SDL/src/core/linux/SDL_progressbar.c:65:14: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
   65 | static char *GetAppDesktopPath()
      |              ^~~~~~~~~~~~~~~~~
[ 66%] Building C object test/CMakeFiles/testcontroller.dir/testcontroller.c.o
In file included from /path/to/SDL/test/testcontroller.c:25:
/path/to/SDL/test/gamepadutils.h:164:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  164 | extern void InitCirclePoints3D();
      | ^~~~~~
/path/to/SDL/test/testcontroller.c:1442:13: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
 1442 | static void EstimatePacketRate()
      |             ^~~~~~~~~~~~~~~~~~
[ 66%] Building C object test/CMakeFiles/testcontroller.dir/gamepadutils.c.o
In file included from /path/to/SDL/test/gamepadutils.c:15:
/path/to/SDL/test/gamepadutils.h:164:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  164 | extern void InitCirclePoints3D();
      | ^~~~~~
```