### PR TITLE
Fixed a few "-Wredundant-decls" warnings

### DIFF
--- a/src/audio/alsa/SDL_alsa_audio.c
+++ b/src/audio/alsa/SDL_alsa_audio.c
@@ -98,7 +98,6 @@ static void (*ALSA_snd_pcm_info_set_device)(snd_pcm_info_t *, unsigned int);
 static void (*ALSA_snd_pcm_info_set_subdevice)(snd_pcm_info_t *, unsigned int);
 static void (*ALSA_snd_pcm_info_set_stream)(snd_pcm_info_t *, snd_pcm_stream_t);
 static int (*ALSA_snd_ctl_pcm_info)(snd_ctl_t *, snd_pcm_info_t *);
-static unsigned int (*ALSA_snd_pcm_info_get_subdevices_count)(const snd_pcm_info_t *);
 static const char *(*ALSA_snd_ctl_card_info_get_id)(const snd_ctl_card_info_t *);
 static const char *(*ALSA_snd_pcm_info_get_name)(const snd_pcm_info_t *);
 static const char *(*ALSA_snd_pcm_info_get_subdevice_name)(const snd_pcm_info_t *);

--- a/src/haptic/hidapi/SDL_hidapihaptic.c
+++ b/src/haptic/hidapi/SDL_hidapihaptic.c
@@ -27,8 +27,6 @@
 #include "SDL3/SDL_mutex.h"
 #include "SDL3/SDL_error.h"
 
-extern struct SDL_JoystickDriver SDL_HIDAPI_JoystickDriver;
-
 typedef struct haptic_list_node
 {
     SDL_Haptic *haptic;


### PR DESCRIPTION
Fixed these two warnings:
```c
[ 28%] Building C object CMakeFiles/SDL3-shared.dir/src/audio/alsa/SDL_alsa_audio.c.o
/path/to/SDL/src/audio/alsa/SDL_alsa_audio.c:101:23: warning: redundant redeclaration of ‘ALSA_snd_pcm_info_get_subdevices_count’ [-Wredundant-decls]
  101 | static unsigned int (*ALSA_snd_pcm_info_get_subdevices_count)(const snd_pcm_info_t *);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/src/audio/alsa/SDL_alsa_audio.c:96:23: note: previous declaration of ‘ALSA_snd_pcm_info_get_subdevices_count’ with type ‘unsigned int (*)(const snd_pcm_info_t *)’ {aka ‘unsigned int (*)(const struct _snd_pcm_info *)’}
   96 | static unsigned int (*ALSA_snd_pcm_info_get_subdevices_count)(const snd_pcm_info_t *);
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[ 43%] Building C object CMakeFiles/SDL3-shared.dir/src/haptic/hidapi/SDL_hidapihaptic.c.o
/path/to/SDL/src/haptic/hidapi/SDL_hidapihaptic.c:30:34: warning: redundant redeclaration of ‘SDL_HIDAPI_JoystickDriver’ [-Wredundant-decls]
   30 | extern struct SDL_JoystickDriver SDL_HIDAPI_JoystickDriver;
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /path/to/SDL/src/haptic/hidapi/SDL_hidapihaptic_c.h:29,
                 from /path/to/SDL/src/haptic/hidapi/SDL_hidapihaptic.c:26:
/path/to/SDL/src/haptic/hidapi/../../joystick/SDL_sysjoystick.h:253:27: note: previous declaration of ‘SDL_HIDAPI_JoystickDriver’ with type ‘SDL_JoystickDriver’
  253 | extern SDL_JoystickDriver SDL_HIDAPI_JoystickDriver;
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~
```