### PR TITLE
SDL_gpu.c: Fixed deref-before-check warning

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -2242,13 +2242,13 @@ void SDL_DrawGPUIndexedPrimitivesIndirect(
 void SDL_EndGPURenderPass(
     SDL_GPURenderPass *render_pass)
 {
-    CommandBufferCommonHeader *commandBufferCommonHeader;
-    commandBufferCommonHeader = (CommandBufferCommonHeader *)RENDERPASS_COMMAND_BUFFER;
-
     if (render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
+
+    CommandBufferCommonHeader *commandBufferCommonHeader;
+    commandBufferCommonHeader = (CommandBufferCommonHeader *)RENDERPASS_COMMAND_BUFFER;
 
     if (RENDERPASS_DEVICE->debug_mode) {
         CHECK_RENDERPASS


### PR DESCRIPTION
`render_pass` gets dereferenced in `RENDERPASS_COMMAND_BUFFER` before the NULL check.
```c
/path/to/SDL/src/gpu/SDL_gpu.c:2248:8: warning: check of ‘render_pass’ for NULL after already dereferencing it [-Wanalyzer-deref-before-check]
 2248 |     if (render_pass == NULL) {
      |        ^
  ‘SDL_EndGPURenderPass_REAL’: events 1-2
 2246 |     commandBufferCommonHeader = (CommandBufferCommonHeader *)RENDERPASS_COMMAND_BUFFER;
      |                               ^
      |                               |
      |                               (1) pointer ‘render_pass’ is dereferenced here
 2247 | 
 2248 |     if (render_pass == NULL) {
      |        ~                       
      |        |
      |        (2) ⚠️  pointer ‘render_pass’ is checked for NULL here but it was already dereferenced at (1)
```