### PR TITLE
SDL_waylanddatamanager.c:Wayland_data_offer_check_source(): Return when `offer` is NULL

### DIFF
--- a/src/video/wayland/SDL_waylanddatamanager.c
+++ b/src/video/wayland/SDL_waylanddatamanager.c
@@ -393,6 +393,7 @@ static void Wayland_data_offer_check_source(SDL_WaylandDataOffer *offer, const c
 
     if (!offer) {
         SDL_SetError("Invalid data offer");
+        return;
     }
     data_device = offer->data_device;
     if (!data_device) {


### PR DESCRIPTION
@Kontrabant

Here, if the parameter `offer` is NULL, an error message is only set but nothing else is done.
Is it good enough to just return?

```c
/path/to/SDL/src/video/wayland/SDL_waylanddatamanager.c:397:19: warning: Access to field 'data_device' results in a dereference of a null pointer (loaded from variable 'offer') [clang-analyzer-core.NullDereference]
  397 |     data_device = offer->data_device;
      |                   ^~~~~
/path/to/SDL/src/video/wayland/SDL_waylanddatamanager.c:394:9: note: Assuming 'offer' is null
  394 |     if (!offer) {
      |         ^~~~~~
/path/to/SDL/src/video/wayland/SDL_waylanddatamanager.c:394:5: note: Taking true branch
  394 |     if (!offer) {
      |     ^
/path/to/SDL/src/video/wayland/SDL_waylanddatamanager.c:397:19: note: Access to field 'data_device' results in a dereference of a null pointer (loaded from variable 'offer')
  397 |     data_device = offer->data_device;
      |                   ^~~~~
```