### PR TITLE
WIP: Add support for additional Android ABI's

### DIFF
--- a/build-scripts/androidbuildlibs.sh
+++ b/build-scripts/androidbuildlibs.sh
@@ -26,7 +26,7 @@ cd $srcdir
 build=build
 buildandroid=$build/android
 platform=android-21
-abi="arm64-v8a" # "armeabi-v7a arm64-v8a x86 x86_64"
+abi="arm64-v8a armeabi-v7a x86 x86_64"
 obj=
 lib=
 ndk_args=


### PR DESCRIPTION
WIP: Will test locally after CI build passes

## Description
- Current release cannot run on x86 accelerated emulator
- Add support for `armeabi-v7a arm64-v8a x86 x86_64`
