### PR TITLE
Fix warning on Android arm-v7

### DIFF
--- a/src/audio/SDL_audiotypecvt.c
+++ b/src/audio/SDL_audiotypecvt.c
@@ -537,7 +537,9 @@ static void SDL_TARGETING("ssse3") SDL_Convert_Swap32_SSSE3(Uint32 *dst, const U
 // behavior. However, the compiler support for this pragma is bad.
 #if defined(__clang__)
 #if __clang_major__ >= 12
+#if defined(__aarch64__)
 #pragma STDC FENV_ACCESS ON
+#endif
 #endif
 #elif defined(_MSC_VER)
 #pragma fenv_access (on)
@@ -814,7 +816,9 @@ static void SDL_Convert_Swap32_NEON(Uint32 *dst, const Uint32 *src, int num_samp
 
 #if defined(__clang__)
 #if __clang_major__ >= 12
+#if defined(__aarch64__)
 #pragma STDC FENV_ACCESS DEFAULT
+#endif
 #endif
 #elif defined(_MSC_VER)
 #pragma fenv_access (off)


### PR DESCRIPTION
This fixes #13432 :

Building SDL for armeabi-v7a gives this warning:
```
SDL/src/audio/SDL_audiotypecvt.c:541:14: warning: '#pragma FENV_ACCESS' is not supported on this target - ignored [-Wignored-pragmas]
  541 | #pragma STDC FENV_ACCESS ON
```