### PR TITLE
[SDL2] Implement SDL_GL_GetAttribute for SDL_GL_FLOATBUFFERS

### DIFF
--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -399,6 +399,7 @@ struct SDL_VideoDevice
         int no_error;
         int retained_backing;
         int driver_loaded;
+        int HAS_GL_ARB_color_buffer_float;
         char driver_path[256];
         void *dll_handle;
     } gl_config;

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -70,6 +70,10 @@
 #include <dlfcn.h>
 #endif
 
+#ifndef GL_RGBA_FLOAT_MODE_ARB
+#define GL_RGBA_FLOAT_MODE_ARB 0x8820
+#endif /* GL_RGBA_FLOAT_MODE_ARB */
+
 /* Available video drivers */
 static VideoBootStrap *bootstrap[] = {
 #ifdef SDL_VIDEO_DRIVER_COCOA
@@ -4036,6 +4040,15 @@ int SDL_GL_GetAttribute(SDL_GLattr attr, int *value)
             *value = _this->gl_config.no_error;
             return 0;
         }
+    case SDL_GL_FLOATBUFFERS:
+    {
+        if (_this->gl_config.HAS_GL_ARB_color_buffer_float) {
+            attrib = GL_RGBA_FLOAT_MODE_ARB;
+            break;
+        } else {
+            return 0;
+        }
+    }
     default:
         return SDL_SetError("Unknown OpenGL attribute");
     }

--- a/src/video/windows/SDL_windowsopengl.c
+++ b/src/video/windows/SDL_windowsopengl.c
@@ -511,6 +511,10 @@ void WIN_GL_InitExtensions(_THIS)
         _this->gl_data->HAS_WGL_ARB_create_context_no_error = SDL_TRUE;
     }
 
+    /* Check for WGL_ARB_pixel_format_float */
+    _this->gl_data->HAS_WGL_ARB_pixel_format_float =
+        HasExtension("WGL_ARB_pixel_format_float", extensions);
+
     _this->gl_data->wglMakeCurrent(hdc, NULL);
     _this->gl_data->wglDeleteContext(hglrc);
     ReleaseDC(hwnd, hdc);
@@ -641,7 +645,7 @@ static int WIN_GL_SetupWindowInternal(_THIS, SDL_Window *window)
         *iAttr++ = _this->gl_config.multisamplesamples;
     }
 
-    if (_this->gl_config.floatbuffers) {
+    if (_this->gl_data->HAS_WGL_ARB_pixel_format_float && _this->gl_config.floatbuffers) {
         *iAttr++ = WGL_PIXEL_TYPE_ARB;
         *iAttr++ = WGL_TYPE_RGBA_FLOAT_ARB;
     }
@@ -824,6 +828,9 @@ SDL_GLContext WIN_GL_CreateContext(_THIS, SDL_Window *window)
         WIN_GL_DeleteContext(_this, context);
         return NULL;
     }
+
+    _this->gl_config.HAS_GL_ARB_color_buffer_float =
+        SDL_GL_ExtensionSupported("GL_ARB_color_buffer_float");
 
     return context;
 }

--- a/src/video/windows/SDL_windowsopengl.h
+++ b/src/video/windows/SDL_windowsopengl.h
@@ -64,6 +64,7 @@ struct SDL_GLDriverData
     SDL_bool HAS_WGL_ARB_context_flush_control;
     SDL_bool HAS_WGL_ARB_create_context_robustness;
     SDL_bool HAS_WGL_ARB_create_context_no_error;
+    SDL_bool HAS_WGL_ARB_pixel_format_float;
 
     /* Max version of OpenGL ES context that can be created if the
        implementation supports WGL_EXT_create_context_es2_profile.


### PR DESCRIPTION
Implements attribute SDL_GL_FLOATBUFFERS for SDL_GL_GetAttribute using [GL_ARB_color_buffer_float](https://registry.khronos.org/OpenGL/extensions/ARB/ARB_color_buffer_float.txt) extension.

Also, sets WGL_PIXEL_TYPE_ARB attribute to WGL_TYPE_RGBA_FLOAT_ARB only if extension WGL_ARB_pixel_format_float is available.