### PR TITLE
Implement SDL_GL_GetAttribute for SDL_GL_FLOATBUFFERS

### DIFF
--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -455,6 +455,7 @@ struct SDL_VideoDevice
         int retained_backing;
         int egl_platform;
         int driver_loaded;
+        int HAS_GL_ARB_color_buffer_float;
         char driver_path[256];
         SDL_SharedObject *dll_handle;
     } gl_config;

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -75,6 +75,10 @@
 #include <unistd.h>
 #endif
 
+#ifndef GL_RGBA_FLOAT_MODE_ARB
+#define GL_RGBA_FLOAT_MODE_ARB 0x8820
+#endif /* GL_RGBA_FLOAT_MODE_ARB */
+
 // Available video drivers
 static VideoBootStrap *bootstrap[] = {
 #ifdef SDL_VIDEO_DRIVER_PRIVATE
@@ -5123,6 +5127,15 @@ bool SDL_GL_GetAttribute(SDL_GLAttr attr, int *value)
     {
         *value = _this->gl_config.egl_platform;
         return true;
+    }
+    case SDL_GL_FLOATBUFFERS:
+    {
+        if (_this->gl_config.HAS_GL_ARB_color_buffer_float) {
+            attrib = GL_RGBA_FLOAT_MODE_ARB;
+            break;
+        } else {
+            return 0;
+        }
     }
     default:
         return SDL_SetError("Unknown OpenGL attribute");

--- a/src/video/windows/SDL_windowsopengl.c
+++ b/src/video/windows/SDL_windowsopengl.c
@@ -510,6 +510,10 @@ void WIN_GL_InitExtensions(SDL_VideoDevice *_this)
         _this->gl_data->HAS_WGL_ARB_create_context_no_error = true;
     }
 
+    /* Check for WGL_ARB_pixel_format_float */
+    _this->gl_data->HAS_WGL_ARB_pixel_format_float =
+        HasExtension("WGL_ARB_pixel_format_float", extensions);
+
     _this->gl_data->wglMakeCurrent(hdc, NULL);
     _this->gl_data->wglDeleteContext(hglrc);
     ReleaseDC(hwnd, hdc);
@@ -640,7 +644,7 @@ static bool WIN_GL_SetupWindowInternal(SDL_VideoDevice *_this, SDL_Window *windo
         *iAttr++ = _this->gl_config.multisamplesamples;
     }
 
-    if (_this->gl_config.floatbuffers) {
+    if (_this->gl_data->HAS_WGL_ARB_pixel_format_float && _this->gl_config.floatbuffers) {
         *iAttr++ = WGL_PIXEL_TYPE_ARB;
         *iAttr++ = WGL_TYPE_RGBA_FLOAT_ARB;
     }
@@ -824,6 +828,9 @@ SDL_GLContext WIN_GL_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)
         WIN_GL_DestroyContext(_this, (SDL_GLContext)context);
         return NULL;
     }
+
+    _this->gl_config.HAS_GL_ARB_color_buffer_float =
+        SDL_GL_ExtensionSupported("GL_ARB_color_buffer_float");
 
     return (SDL_GLContext)context;
 }

--- a/src/video/windows/SDL_windowsopengl.h
+++ b/src/video/windows/SDL_windowsopengl.h
@@ -64,6 +64,7 @@ struct SDL_GLDriverData
     bool HAS_WGL_ARB_context_flush_control;
     bool HAS_WGL_ARB_create_context_robustness;
     bool HAS_WGL_ARB_create_context_no_error;
+    bool HAS_WGL_ARB_pixel_format_float;
 
     /* Max version of OpenGL ES context that can be created if the
        implementation supports WGL_EXT_create_context_es2_profile.


### PR DESCRIPTION
Implements attribute SDL_GL_FLOATBUFFERS for SDL_GL_GetAttribute using [GL_ARB_color_buffer_float](https://registry.khronos.org/OpenGL/extensions/ARB/ARB_color_buffer_float.txt) extension.

Also, sets WGL_PIXEL_TYPE_ARB attribute to WGL_TYPE_RGBA_FLOAT_ARB only if extension WGL_ARB_pixel_format_float is available.