### PR TITLE
ci+n3ds: avoid apt-get package manager

### DIFF
--- a/.github/workflows/create-test-plan.py
+++ b/.github/workflows/create-test-plan.py
@@ -175,6 +175,7 @@ class JobDetails:
     brew_packages: list[str] = dataclasses.field(default_factory=list)
     cmake_toolchain_file: str = ""
     cmake_arguments: list[str] = dataclasses.field(default_factory=list)
+    cmake_generator: str = "Ninja"
     cmake_build_arguments: list[str] = dataclasses.field(default_factory=list)
     cppflags: list[str] = dataclasses.field(default_factory=list)
     cc: str = ""
@@ -220,6 +221,7 @@ class JobDetails:
     setup_vita_gles_type: str = ""
     check_sources: bool = False
     watcom_makefile: str = ""
+    binutils_strings: str = "strings"
 
     def to_workflow(self, enable_artifacts: bool) -> dict[str, str|bool]:
         data = {
@@ -253,6 +255,7 @@ class JobDetails:
             "cflags": my_shlex_join(self.cppflags + self.cflags),
             "cxxflags": my_shlex_join(self.cppflags + self.cxxflags),
             "ldflags": my_shlex_join(self.ldflags),
+            "cmake-generator": self.cmake_generator,
             "cmake-toolchain-file": self.cmake_toolchain_file,
             "cmake-arguments": my_shlex_join(self.cmake_arguments),
             "cmake-build-arguments": my_shlex_join(self.cmake_build_arguments),
@@ -285,6 +288,7 @@ class JobDetails:
             "setup-gdk-folder": self.setup_gdk_folder,
             "check-sources": self.check_sources,
             "watcom-makefile": self.watcom_makefile,
+            "binutils-strings": self.binutils_strings,
         }
         return {k: v for k, v in data.items() if v != ""}
 
@@ -600,11 +604,14 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool) -> JobDeta
             job.shared_lib = SharedLibType.SO_0
             job.static_lib = StaticLibType.A
         case SdlPlatform.N3ds:
+            job.cmake_generator = "Unix Makefiles"
+            job.cmake_build_arguments.append("-j$(nproc)")
             job.shared = False
-            job.apt_packages = ["ninja-build", "binutils"]
+            job.apt_packages = []
             job.run_tests = False
             job.cc_from_cmake = True
             job.cmake_toolchain_file = "${DEVKITPRO}/cmake/3DS.cmake"
+            job.binutils_strings = "/opt/devkitpro/devkitARM/bin/arm-none-eabi-strings"
             job.static_lib = StaticLibType.A
         case SdlPlatform.Msys2:
             job.shell = "msys2 {0}"

--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -177,7 +177,7 @@ jobs:
         #shell: ${{ matrix.platform.shell }}
         run: |
           ${{ matrix.platform.source-cmd }}
-          ${{ matrix.platform.cmake-config-emulator }} cmake -S . -B build -GNinja \
+          ${{ matrix.platform.cmake-config-emulator }} cmake -S . -B build -G "${{ matrix.platform.cmake-generator }}" \
             -Wdeprecated -Wdev -Werror \
             ${{ matrix.platform.cmake-toolchain-file != '' && format('-DCMAKE_TOOLCHAIN_FILE={0}', matrix.platform.cmake-toolchain-file) || '' }} \
             -DSDL_WERROR=${{ matrix.platform.werror }} \
@@ -207,9 +207,9 @@ jobs:
         run: |
           echo "This should show us the SDL_REVISION"
           echo "Shared library:"
-          ${{ (matrix.platform.shared-lib && format('strings build/{0} | grep "Github Workflow"', matrix.platform.shared-lib)) || 'echo "<Shared library not supported by platform>"' }}
+          ${{ (matrix.platform.shared-lib && format('{0} build/{1} | grep "Github Workflow"', matrix.platform.binutils-strings, matrix.platform.shared-lib)) || 'echo "<Shared library not supported by platform>"' }}
           echo "Static library:"
-          ${{ (matrix.platform.static-lib && format('strings build/{0} | grep "Github Workflow"', matrix.platform.static-lib)) || 'echo "<Static library not supported by platform>"' }}
+          ${{ (matrix.platform.static-lib && format('{0} build/{1} | grep "Github Workflow"', matrix.platform.binutils-strings, matrix.platform.static-lib)) || 'echo "<Static library not supported by platform>"' }}
       - name: 'Run build-time tests (CMake)'
         id: cmake-tests
         if: ${{ !matrix.platform.no-cmake && matrix.platform.run-tests }}


### PR DESCRIPTION
- use Unix Makefiles (with parallelization) CMake generator
- use binutils strings binary from devkitpro

( Manual backport of commit e6d200e51c88a0406c770c52bf7f415181243189 )
