### PR TITLE
Fixed typo in SDL_scancode.h comment

### DIFF
--- a/include/SDL3/SDL_scancode.h
+++ b/include/SDL3/SDL_scancode.h
@@ -208,7 +208,7 @@ typedef enum SDL_Scancode
 
     SDL_SCANCODE_NONUSBACKSLASH = 100, /**< This is the additional key that ISO
                                         *   keyboards have over ANSI ones,
-                                        *   located between left shift and Y.
+                                        *   located between left shift and Z.
                                         *   Produces GRAVE ACCENT and TILDE in a
                                         *   US or UK Mac layout, REVERSE SOLIDUS
                                         *   (backslash) and VERTICAL LINE in a


### PR DESCRIPTION
The backslash/vertical line key is between the left shift and "Z" key on ISO keyboards.