### PR TITLE
Replaced binary integer literals with hexadecimal integer literals

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_flydigi.c
+++ b/src/joystick/hidapi/SDL_hidapi_flydigi.c
@@ -335,28 +335,28 @@ static void HIDAPI_DriverFlydigi_HandleStatePacket(SDL_Joystick *joystick, SDL_D
         Uint8 hat;
 
         switch (data[9] & 0x0F) {
-        case 0b0001:
+        case 0x01u:
             hat = SDL_HAT_UP;
             break;
-        case 0b0011:
+        case 0x02u | 0x01u:
             hat = SDL_HAT_RIGHTUP;
             break;
-        case 0b0010:
+        case 0x02u:
             hat = SDL_HAT_RIGHT;
             break;
-        case 0b0110:
+        case 0x02u | 0x04u:
             hat = SDL_HAT_RIGHTDOWN;
             break;
-        case 0b0100:
+        case 0x04u:
             hat = SDL_HAT_DOWN;
             break;
-        case 0b1100:
+        case 0x08u | 0x04u:
             hat = SDL_HAT_LEFTDOWN;
             break;
-        case 0b1000:
+        case 0x08u:
             hat = SDL_HAT_LEFT;
             break;
-        case 0b1001:
+        case 0x08u | 0x01u:
             hat = SDL_HAT_LEFTUP;
             break;
         default:


### PR DESCRIPTION
Binary integer literals are a C23 feature.

This commit turns them into hexadecimal literals.

```c
[ 40%] Building C object CMakeFiles/SDL3-shared.dir/src/joystick/hidapi/SDL_hidapi_flydigi.c.o
/path/to/SDL-git/src/joystick/hidapi/SDL_hidapi_flydigi.c:338:14: warning: binary integer literals are a C23 extension [-Wc23-extensions]
  338 |         case 0b0001:
      |              ^
/path/to/SDL-git/src/joystick/hidapi/SDL_hidapi_flydigi.c:341:14: warning: binary integer literals are a C23 extension [-Wc23-extensions]
  341 |         case 0b0011:
      |              ^
/path/to/SDL-git/src/joystick/hidapi/SDL_hidapi_flydigi.c:344:14: warning: binary integer literals are a C23 extension [-Wc23-extensions]
  344 |         case 0b0010:
      |              ^
/path/to/SDL-git/src/joystick/hidapi/SDL_hidapi_flydigi.c:347:14: warning: binary integer literals are a C23 extension [-Wc23-extensions]
  347 |         case 0b0110:
      |              ^
/path/to/SDL-git/src/joystick/hidapi/SDL_hidapi_flydigi.c:350:14: warning: binary integer literals are a C23 extension [-Wc23-extensions]
  350 |         case 0b0100:
      |              ^
/path/to/SDL-git/src/joystick/hidapi/SDL_hidapi_flydigi.c:353:14: warning: binary integer literals are a C23 extension [-Wc23-extensions]
  353 |         case 0b1100:
      |              ^
/path/to/SDL-git/src/joystick/hidapi/SDL_hidapi_flydigi.c:356:14: warning: binary integer literals are a C23 extension [-Wc23-extensions]
  356 |         case 0b1000:
      |              ^
/path/to/SDL-git/src/joystick/hidapi/SDL_hidapi_flydigi.c:359:14: warning: binary integer literals are a C23 extension [-Wc23-extensions]
  359 |         case 0b1001:
      |              ^
```