### PR TITLE
SDL_getenv.c: fix dynamic loading of environ symbol on FreeBSD

### DIFF
--- a/src/stdlib/SDL_getenv.c
+++ b/src/stdlib/SDL_getenv.c
@@ -41,7 +41,12 @@
 #define environ (*_NSGetEnviron())
 #elif defined(SDL_PLATFORM_FREEBSD)
 #include <dlfcn.h>
-#define environ ((char **)dlsym(RTLD_DEFAULT, "environ"))
+static char **get_environ_rtld(void)
+{
+    char ***environ_rtld = (char ***)dlsym(RTLD_DEFAULT, "environ");
+    return environ_rtld ? *environ_rtld : NULL;
+}
+#define environ (get_environ_rtld())
 #else
 extern char **environ;
 #endif


### PR DESCRIPTION
The current implementation uses the returned address of the `dlsym` function directly to load the `environ` symbol. But this function doesn't return the address to the symbol itself, instead it returns the address to the location where the actual address is stored, i.e. it's an additional indirection. Consequently, the implementation fails to load and process the environment variables successfully.

One example where this error shows up is in the `Dialog API`: in an `X11` environment, the `zenity` driver requires access to the user's `DISPLAY` and `XAUTHORITY` environment variables. Because these variables aren't transfered to the `zenity` process, no dialogs are shown. This can be exercised in the `test/testdialog.c` testprogram.

The fix changes the indirection level of the `dlsym` call from `char **` to `char ***`, does a `NULL`-check in case the call failed, and returns the dereferenced actual adress to the `environ` symbol.