### PR TITLE
Define relevant macros when `LACKS_ERRNO_H` is true

### DIFF
--- a/src/stdlib/SDL_malloc.c
+++ b/src/stdlib/SDL_malloc.c
@@ -1478,6 +1478,13 @@ DLMALLOC_EXPORT int mspace_mallopt(int, int);
 #endif /* NO_MALLOC_STATS */
 #ifndef LACKS_ERRNO_H
 #include <errno.h>       /* for MALLOC_FAILURE_ACTION */
+#else /* LACKS_ERRNO_H */
+#ifndef EINVAL
+#define EINVAL 22
+#endif
+#ifndef ENOMEM
+#define ENOMEM 12
+#endif
 #endif /* LACKS_ERRNO_H */
 #ifdef DEBUG
 #if ABORT_ON_ASSERT_FAILURE


### PR DESCRIPTION
- Related: godotengine/godot#108345
- Related: godotengine/godot#108354

When attempting a recent Godot release build, llvm-mingw failed to build for Windows arm64. This was traced back to `LACKS_ERRNO_H` being defined while the file added macros from that header; all other build combinations ended up including that header indirectly. The above PR opted to exclude the macro entirely, as all our compilers are guaranteed to have `errno.h`, but I don't know how much backwards compatibility is required for the SDL project. To err on the side of caution: this keeps the existing `LACKS_ERRNO_H`, but adds the relevant `EINVAL`/`ENOMEM` macros explicitly if they weren't previously defined.