### PR TITLE
psp: fix audio not playing

### DIFF
--- a/src/audio/psp/SDL_pspaudio.c
+++ b/src/audio/psp/SDL_pspaudio.c
@@ -114,7 +114,7 @@ static bool PSPAUDIO_PlayDevice(SDL_AudioDevice *device, const Uint8 *buffer, in
     } else {
         rc = sceAudioOutputPannedBlocking(device->hidden->channel, PSP_AUDIO_VOLUME_MAX, PSP_AUDIO_VOLUME_MAX, (void *) buffer);
     }
-    return (rc == 0);
+    return (rc >= 0);
 }
 
 static bool PSPAUDIO_WaitDevice(SDL_AudioDevice *device)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
It turns out rc can be higher than 0, which does not mean it failed. I will make an issue for it, since it seems our documentation does not mention this.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
This resolves #13411
