### PR TITLE
GPU: Fix wrong Vulkan swapchain size when retrying acquire

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -9951,13 +9951,6 @@ static bool VULKAN_INTERNAL_AcquireSwapchainTexture(
         }
     }
 
-    if (swapchainTextureWidth) {
-        *swapchainTextureWidth = windowData->width;
-    }
-    if (swapchainTextureHeight) {
-        *swapchainTextureHeight = windowData->height;
-    }
-
     if (windowData->inFlightFences[windowData->frameCounter] != NULL) {
         if (block) {
             // If we are blocking, just wait for the fence!
@@ -10007,6 +10000,14 @@ static bool VULKAN_INTERNAL_AcquireSwapchainTexture(
             // Edge case, texture is filled in with NULL but not an error
             return true;
         }
+    }
+
+    if (swapchainTextureWidth) {
+        *swapchainTextureWidth = windowData->width;
+    }
+
+    if (swapchainTextureHeight) {
+        *swapchainTextureHeight = windowData->height;
     }
 
     swapchainTextureContainer = &windowData->textureContainers[swapchainImageIndex];


### PR DESCRIPTION
AcquireGPUSwapchainTexture can return the wrong sizes if acquiring the image fails and the swapchain is recreated, since the window dimensions could have changed.

I ran into the same issue as https://github.com/libsdl-org/SDL/issues/12820 and I believe this is the root cause.
