### PR TITLE
Fix Axis Inputs for Generic SInput Device

### DIFF
--- a/src/joystick/SDL_gamepad.c
+++ b/src/joystick/SDL_gamepad.c
@@ -819,7 +819,7 @@ static GamepadMapping_t *SDL_CreateMappingForHIDAPIGamepad(SDL_GUID guid)
             default:
             case 0:
                 // Default Fully Exposed Mapping
-                SDL_strlcat(mapping_string, "b:b0,a:b1,y:b2,x:b3,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftstick:b4,rightstick:b5,leftshoulder:b6,rightshoulder:b7,lefttrigger:b8,righttrigger:b9,paddle1:b10,paddle2:b11,start:b12,back:b13,guide:b14,misc1:b15,paddle3:b16,paddle4:b17,touchpad:b18,misc2:b19,misc3:b20,misc4:b21,misc5:b22,misc6:b23", sizeof(mapping_string));
+                SDL_strlcat(mapping_string, "leftx:a0,lefty:a1,rightx:a2,righty:a3,lefttrigger:a4,righttrigger:a5,b:b0,a:b1,y:b2,x:b3,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,leftstick:b4,rightstick:b5,leftshoulder:b6,rightshoulder:b7,paddle1:b10,paddle2:b11,start:b12,back:b13,guide:b14,misc1:b15,paddle3:b16,paddle4:b17,touchpad:b18,misc2:b19,misc3:b20,misc4:b21,misc5:b22,misc6:b23", sizeof(mapping_string));
                 break;
             }
 

--- a/src/joystick/hidapi/SDL_hidapi_sinput.c
+++ b/src/joystick/hidapi/SDL_hidapi_sinput.c
@@ -533,6 +533,16 @@ static bool HIDAPI_DriverSInput_OpenJoystick(SDL_HIDAPI_Device *device, SDL_Joys
         ++axes;
     }
 
+    if ((device->product_id == USB_PRODUCT_HANDHELDLEGEND_SINPUT_GENERIC) && (device->vendor_id == USB_VENDOR_RASPBERRYPI)) {
+        switch (ctx->sub_type) {
+        // Default generic device, exposes all axes
+        default:
+        case 0:
+            axes = 6;
+            break;
+        }
+    } 
+
     joystick->naxes = axes;
 
     if (ctx->dpad_supported) {


### PR DESCRIPTION
- Implement correct SInput generic mapping string to map analog axes
- Implement 6 axis count fallback for generic SInput Device

Reported-by: Antheas Kapenekakis <git@antheas.dev>