### PR TITLE
Fix potential memory leak in SDL_render_gles2.c

### DIFF
--- a/src/render/opengles2/SDL_render_gles2.c
+++ b/src/render/opengles2/SDL_render_gles2.c
@@ -1699,6 +1699,8 @@ static bool GLES2_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SD
         } else {
             renderdata->glGenTextures(1, &data->texture_v);
             if (!GL_CheckError("glGenTexures()", renderer)) {
+                SDL_free(data->pixel_data);
+                SDL_free(data);
                 return false;
             }
         }
@@ -1713,6 +1715,8 @@ static bool GLES2_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SD
         } else {
             renderdata->glGenTextures(1, &data->texture_u);
             if (!GL_CheckError("glGenTexures()", renderer)) {
+                SDL_free(data->pixel_data);
+                SDL_free(data);
                 return false;
             }
         }
@@ -1720,11 +1724,15 @@ static bool GLES2_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SD
         renderdata->glBindTexture(data->texture_type, data->texture_u);
         renderdata->glTexImage2D(data->texture_type, 0, format, (texture->w + 1) / 2, (texture->h + 1) / 2, 0, format, type, NULL);
         if (!GL_CheckError("glTexImage2D()", renderer)) {
+            SDL_free(data->pixel_data);
+            SDL_free(data);
             return false;
         }
         SDL_SetNumberProperty(SDL_GetTextureProperties(texture), SDL_PROP_TEXTURE_OPENGLES2_TEXTURE_U_NUMBER, data->texture_u);
 
         if (!SDL_GetYCbCRtoRGBConversionMatrix(texture->colorspace, texture->w, texture->h, 8)) {
+            SDL_free(data->pixel_data);
+            SDL_free(data);
             return SDL_SetError("Unsupported YUV colorspace");
         }
     } else if (data->nv12) {
@@ -1734,6 +1742,8 @@ static bool GLES2_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SD
         } else {
             renderdata->glGenTextures(1, &data->texture_u);
             if (!GL_CheckError("glGenTexures()", renderer)) {
+                SDL_free(data->pixel_data);
+                SDL_free(data);
                 return false;
             }
         }
@@ -1741,11 +1751,15 @@ static bool GLES2_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SD
         renderdata->glBindTexture(data->texture_type, data->texture_u);
         renderdata->glTexImage2D(data->texture_type, 0, GL_LUMINANCE_ALPHA, (texture->w + 1) / 2, (texture->h + 1) / 2, 0, GL_LUMINANCE_ALPHA, GL_UNSIGNED_BYTE, NULL);
         if (!GL_CheckError("glTexImage2D()", renderer)) {
+            SDL_free(data->pixel_data);
+            SDL_free(data);
             return false;
         }
         SDL_SetNumberProperty(SDL_GetTextureProperties(texture), SDL_PROP_TEXTURE_OPENGLES2_TEXTURE_UV_NUMBER, data->texture_u);
 
         if (!SDL_GetYCbCRtoRGBConversionMatrix(texture->colorspace, texture->w, texture->h, 8)) {
+            SDL_free(data->pixel_data);
+            SDL_free(data);
             return SDL_SetError("Unsupported YUV colorspace");
         }
     }
@@ -1757,6 +1771,8 @@ static bool GLES2_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SD
     } else {
         renderdata->glGenTextures(1, &data->texture);
         if (!GL_CheckError("glGenTexures()", renderer)) {
+            SDL_free(data->pixel_data);
+            SDL_free(data);
             return false;
         }
     }


### PR DESCRIPTION
<details><summary>Warning</summary>
<p>

```c
[ 19%] Building C object CMakeFiles/SDL3-shared.dir/src/render/opengles2/SDL_render_gles2.c.o
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1744:20: warning: Potential leak of memory pointed to by 'data' [clang-analyzer-unix.Malloc]
 1744 |             return false;
      |                    ^
/usr/lib/clang/20/include/stdbool.h:26:15: note: expanded from macro 'false'
   26 | #define false 0
      |               ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1607:5: note: Control jumps to 'case SDL_PIXELFORMAT_NV12:'  at line 1618
 1607 |     switch (texture->format) {
      |     ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1622:9: note:  Execution continues on line 1637
 1622 |         break;
      |         ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1637:18: note: Field 'format' is not equal to SDL_PIXELFORMAT_EXTERNAL_OES
 1637 |     if (texture->format == SDL_PIXELFORMAT_EXTERNAL_OES &&
      |                  ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1637:57: note: Left side of '&&' is false
 1637 |     if (texture->format == SDL_PIXELFORMAT_EXTERNAL_OES &&
      |                                                         ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1643:33: note: Memory is allocated
 1643 |     data = (GLES2_TextureData *)SDL_calloc(1, sizeof(GLES2_TextureData));
      |                                 ^
/path/to/SDL/include/SDL3/SDL_stdinc.h:5990:20: note: expanded from macro 'SDL_calloc'
 5990 | #define SDL_calloc calloc
      |                    ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1644:9: note: Assuming 'data' is non-null
 1644 |     if (!data) {
      |         ^~~~~
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1644:5: note: Taking false branch
 1644 |     if (!data) {
      |     ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1649:36: note: Field 'format' is not equal to SDL_PIXELFORMAT_EXTERNAL_OES
 1649 |     data->texture_type = (texture->format == SDL_PIXELFORMAT_EXTERNAL_OES) ? GL_TEXTURE_EXTERNAL_OES : GL_TEXTURE_2D;
      |                                    ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1649:26: note: '?' condition is false
 1649 |     data->texture_type = (texture->format == SDL_PIXELFORMAT_EXTERNAL_OES) ? GL_TEXTURE_EXTERNAL_OES : GL_TEXTURE_2D;
      |                          ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1656:28: note: Field 'format' is not equal to SDL_PIXELFORMAT_IYUV
 1656 |     data->yuv = ((texture->format == SDL_PIXELFORMAT_IYUV) || (texture->format == SDL_PIXELFORMAT_YV12));
      |                            ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1656:18: note: Left side of '||' is false
 1656 |     data->yuv = ((texture->format == SDL_PIXELFORMAT_IYUV) || (texture->format == SDL_PIXELFORMAT_YV12));
      |                  ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1657:29: note: Field 'format' is equal to SDL_PIXELFORMAT_NV12
 1657 |     data->nv12 = ((texture->format == SDL_PIXELFORMAT_NV12) || (texture->format == SDL_PIXELFORMAT_NV21));
      |                             ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1657:61: note: Left side of '||' is true
 1657 |     data->nv12 = ((texture->format == SDL_PIXELFORMAT_NV12) || (texture->format == SDL_PIXELFORMAT_NV21));
      |                                                             ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1666:9: note: Assuming field 'access' is not equal to SDL_TEXTUREACCESS_STREAMING
 1666 |     if (texture->access == SDL_TEXTUREACCESS_STREAMING) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1666:5: note: Taking false branch
 1666 |     if (texture->access == SDL_TEXTUREACCESS_STREAMING) {
      |     ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1695:15: note: Field 'yuv' is false
 1695 |     if (data->yuv) {
      |               ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1695:5: note: Taking false branch
 1695 |     if (data->yuv) {
      |     ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1730:22: note: Field 'nv12' is true
 1730 |     } else if (data->nv12) {
      |                      ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1730:12: note: Taking true branch
 1730 |     } else if (data->nv12) {
      |            ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1732:13: note: Assuming field 'texture_u' is not equal to 0
 1732 |         if (data->texture_u) {
      |             ^~~~~~~~~~~~~~~
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1732:9: note: Taking true branch
 1732 |         if (data->texture_u) {
      |         ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1743:13: note: Assuming the condition is true
 1743 |         if (!GL_CheckError("glTexImage2D()", renderer)) {
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1743:9: note: Taking true branch
 1743 |         if (!GL_CheckError("glTexImage2D()", renderer)) {
      |         ^
/path/to/SDL/src/render/opengles2/SDL_render_gles2.c:1744:20: note: Potential leak of memory pointed to by 'data'
 1744 |             return false;
      |                    ^
/usr/lib/clang/20/include/stdbool.h:26:15: note: expanded from macro 'false'
   26 | #define false 0
      |               ^
```

</p>
</details>

In the function `GLES2_CreateTexture()`: This commit adds `SDL_free()` calls for the variables `data` and `data->pixel_data` when the function prematurely returns.

`data` is allocated here:
https://github.com/libsdl-org/SDL/blob/6d580d74f2b5035005463997ef24fed5dcc67f83/src/render/opengles2/SDL_render_gles2.c#L1643
`data->pixel_data` is allocated here:
https://github.com/libsdl-org/SDL/blob/6d580d74f2b5035005463997ef24fed5dcc67f83/src/render/opengles2/SDL_render_gles2.c#L1679

Here the address is given to `texture->internal` and we can stop deallocating it?:
https://github.com/libsdl-org/SDL/blob/6d580d74f2b5035005463997ef24fed5dcc67f83/src/render/opengles2/SDL_render_gles2.c#L1763