### PR TITLE
Fix setting RGB without a player led

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_sinput.c
+++ b/src/joystick/hidapi/SDL_hidapi_sinput.c
@@ -633,8 +633,6 @@ static bool HIDAPI_DriverSInput_SetJoystickLED(SDL_HIDAPI_Device *device, SDL_Jo
     SDL_DriverSInput_Context *ctx = (SDL_DriverSInput_Context *)device->context;
 
     if (ctx->joystick_rgb_supported) {
-
-        // Set player number, finalizing the setup
         Uint8 joystickRGBCommand[SINPUT_DEVICE_REPORT_COMMAND_SIZE] = { SINPUT_DEVICE_REPORT_ID_OUTPUT_CMDDAT, SINPUT_DEVICE_COMMAND_JOYSTICKRGB, red, green, blue };
         int joystickRGBBytesWritten = SDL_hid_write(device->dev, joystickRGBCommand, SINPUT_DEVICE_REPORT_COMMAND_SIZE);
 


### PR DESCRIPTION
There is a bug where SInput checks for player led capability before setting RGB. This means that if a controller does not have a player led, RGB commands are not sent.

cc @mitchellcairns 