### PR TITLE
Seperate the GLib code from GtkContext.

### DIFF
--- a/src/core/unix/SDL_glib.c
+++ b/src/core/unix/SDL_glib.c
@@ -1,0 +1,86 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2025 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+#include "SDL_internal.h"
+#include "SDL_gtk.h"
+
+// we never link directly to glib
+static const char *glib_names[] = {
+#ifdef SDL_PLATFORM_OPENBSD
+    "libglib-2.0.so",
+#else
+    "libglib-2.0.so.0",
+#endif
+    NULL
+};
+
+void *SDL_Glib_FindLib(const char **names)
+{
+    const char **name_ptr = names;
+    void *handle = NULL;
+
+    do {
+        handle = SDL_LoadObject(*name_ptr);
+    } while (*++name_ptr && !handle);
+
+    return handle;
+}
+
+bool SDL_GlibContext_Init(SDL_GlibContext *ctx, void *lib, bool do_unload, bool bypass_hint)
+{
+	ctx->library = lib;
+	ctx->do_unload = do_unload;
+	
+	if (!bypass_hint) {
+		if (!SDL_GetHintBoolean("SDL_ENABLE_GLIB", true)) {
+			return false;
+		}
+	}
+	
+	if (!ctx->library) {
+		ctx->library = SDL_Glib_FindLib(glib_names);
+		if (!ctx->library) {
+			return SDL_SetError("Could not load Glib");
+		}
+	}
+
+    SDL_GLIB_PTR_SYM(ctx, ctx->library, g, signal_connect_data);
+    SDL_GLIB_PTR_SYM(ctx, ctx->library, g, mkdtemp);
+    SDL_GLIB_PTR_SYM(ctx, ctx->library, g, object_ref);
+    SDL_GLIB_PTR_SYM(ctx, ctx->library, g, object_ref_sink);
+    SDL_GLIB_PTR_SYM(ctx, ctx->library, g, object_unref);
+    SDL_GLIB_PTR_SYM(ctx, ctx->library, g, object_get);
+    SDL_GLIB_PTR_SYM(ctx, ctx->library, g, signal_handler_disconnect);
+    SDL_GLIB_PTR_SYM(ctx, ctx->library, g, main_context_push_thread_default);
+    SDL_GLIB_PTR_SYM(ctx, ctx->library, g, main_context_pop_thread_default);
+    SDL_GLIB_PTR_SYM(ctx, ctx->library, g, main_context_new);
+    SDL_GLIB_PTR_SYM(ctx, ctx->library, g, main_context_acquire);
+    SDL_GLIB_PTR_SYM(ctx, ctx->library, g, main_context_iteration);
+    
+    return true;
+}
+
+bool SDL_GlibContext_Cleanup(SDL_GlibContext *ctx) 
+{
+	if (ctx->library && ctx->do_unload) {
+		SDL_UnloadObject(ctx->library);
+	}
+    SDL_zero(ctx);
+}

--- a/src/core/unix/SDL_glib.h
+++ b/src/core/unix/SDL_glib.h
@@ -1,0 +1,106 @@
+/*
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2025 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include "SDL_internal.h"
+
+#ifndef SDL_glib_h_
+#define SDL_glib_h_
+
+/* Dynamic loading functions & macros */
+#define SDL_GLIB_SYM2_OPTIONAL(ctx, lib, fn, sym)                     \
+    ctx.fn = (void *)SDL_LoadFunction(lib, #sym)
+
+#define SDL_GLIB_SYM2(ctx, lib, fn, sym)                              \
+    if (!(ctx.fn = (void *)SDL_LoadFunction(lib, #sym))) {            \
+        return SDL_SetError("Could not load #lib functions");              \
+    }
+
+#define SDL_GLIB_SYM_OPTIONAL(ctx, lib, fn) \
+    SDL_GLIB_SYM2_OPTIONAL(ctx, lib, fn, sub##_##fn)
+
+#define SDL_GLIB_SYM(ctx, lib, sub, fn) \
+    SDL_GLIB_SYM2(ctx, lib, fn, sub##_##fn)
+    
+#define SDL_GLIB_PTR_SYM2(ctx, lib, fn, sym)                              \
+    if (!(ctx->fn = (void *)SDL_LoadFunction(lib, #sym))) {            \
+        return SDL_SetError("Could not load #lib functions");              \
+    }
+
+#define SDL_GLIB_PTR_SYM(ctx, lib, sub, fn) \
+    SDL_GLIB_PTR_SYM2(ctx, lib, fn, sub##_##fn)
+    
+extern void *SDL_Glib_FindLib(const char **names);
+
+/* Glib 2.0 */
+typedef unsigned long SDL_gulong;
+typedef void *SDL_gpointer;
+typedef char SDL_gchar;
+typedef int SDL_gint;
+typedef unsigned int SDL_guint;
+typedef double SDL_gdouble;
+typedef SDL_gint SDL_gboolean;
+
+typedef void (*SDL_GCallback)(void);
+typedef struct _SDL_GClosure SDL_GClosure;
+typedef void (*SDL_GClosureNotify) (SDL_gpointer data, SDL_GClosure *closure);
+typedef SDL_gboolean (*SDL_GSourceFunc) (SDL_gpointer user_data);
+
+typedef struct _SDL_GParamSpec SDL_GParamSpec;
+typedef struct _SDL_GMainContext SDL_GMainContext;
+
+typedef enum SDL_GConnectFlags
+{
+    SDL_G_CONNECT_DEFAULT = 0,
+    SDL_G_CONNECT_AFTER = 1 << 0,
+    SDL_G_CONNECT_SWAPPED = 1 << 1
+} SDL_GConnectFlags;
+
+#define SDL_G_CALLBACK(f) ((SDL_GCallback) (f))
+#define SDL_G_TYPE_CIC(ip, gt, ct) ((ct*) ip)
+#define SDL_G_TYPE_CHECK_INSTANCE_CAST(instance, g_type, c_type) (SDL_G_TYPE_CIC ((instance), (g_type), c_type))
+
+#define SDL_G_FALSE 0
+#define SDL_G_TRUE 1
+
+typedef struct SDL_GlibContext
+{
+	void *library;
+	bool do_unload;
+	
+	SDL_gulong (*signal_connect)(SDL_gpointer instance, const SDL_gchar *detailed_signal, void *c_handler, SDL_gpointer data);
+	SDL_gulong (*signal_connect_data)(SDL_gpointer instance, const SDL_gchar *detailed_signal, SDL_GCallback c_handler, SDL_gpointer data, SDL_GClosureNotify destroy_data, SDL_GConnectFlags connect_flags);
+	void (*object_unref)(SDL_gpointer object);
+	SDL_gchar *(*mkdtemp)(SDL_gchar *template);
+	SDL_gpointer (*object_ref_sink)(SDL_gpointer object);
+	SDL_gpointer (*object_ref)(SDL_gpointer object);
+	void (*object_get)(SDL_gpointer object, const SDL_gchar *first_property_name, ...);
+	void (*signal_handler_disconnect)(SDL_gpointer instance, SDL_gulong handler_id);
+	void (*main_context_push_thread_default)(SDL_GMainContext *context);
+	void (*main_context_pop_thread_default)(SDL_GMainContext *context);
+	SDL_GMainContext *(*main_context_new)(void);
+	SDL_gboolean (*main_context_acquire)(SDL_GMainContext *context);
+	SDL_gboolean (*main_context_iteration)(SDL_GMainContext *context, SDL_gboolean may_block);
+} SDL_GlibContext;
+
+extern bool SDL_GlibContext_Init(SDL_GlibContext *ctx, void *lib, bool do_unload, bool bypass_hint);
+extern bool SDL_GlibContext_Cleanup(SDL_GlibContext *ctx);
+
+#endif // SDL_glib_h_

--- a/src/core/unix/SDL_gtk.h
+++ b/src/core/unix/SDL_gtk.h
@@ -20,43 +20,10 @@
 */
 
 #include "SDL_internal.h"
+#include "SDL_glib.h"
 
 #ifndef SDL_gtk_h_
 #define SDL_gtk_h_
-
-/* Glib 2.0 */
-
-typedef unsigned long gulong;
-typedef void *gpointer;
-typedef char gchar;
-typedef int gint;
-typedef unsigned int guint;
-typedef double gdouble;
-typedef gint gboolean;
-typedef void (*GCallback)(void);
-typedef struct _GClosure GClosure;
-typedef void (*GClosureNotify) (gpointer data, GClosure *closure);
-typedef gboolean (*GSourceFunc) (gpointer user_data);
-
-typedef struct _GParamSpec GParamSpec;
-typedef struct _GMainContext GMainContext;
-
-typedef enum SDL_GConnectFlags
-{
-    SDL_G_CONNECT_DEFAULT = 0,
-    SDL_G_CONNECT_AFTER = 1 << 0,
-    SDL_G_CONNECT_SWAPPED = 1 << 1
-} SDL_GConnectFlags;
-
-#define SDL_G_CALLBACK(f) ((GCallback) (f))
-#define SDL_G_TYPE_CIC(ip, gt, ct) ((ct*) ip)
-#define SDL_G_TYPE_CHECK_INSTANCE_CAST(instance, g_type, c_type) (SDL_G_TYPE_CIC ((instance), (g_type), c_type))
-
-#define GTK_FALSE 0
-#define GTK_TRUE 1
-
-
-/* GTK 3.0 */
 
 typedef struct _GtkMenu GtkMenu;
 typedef struct _GtkMenuItem GtkMenuItem;
@@ -70,48 +37,27 @@ typedef struct _GtkSettings GtkSettings;
 #define GTK_CHECK_MENU_ITEM(obj) (SDL_G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_CHECK_MENU_ITEM, GtkCheckMenuItem))
 #define GTK_MENU(obj) (SDL_G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_MENU, GtkMenu))
 
-
 typedef struct SDL_GtkContext
 {
-	/* Glib 2.0 */
-	struct 
-	{
-		gulong (*signal_connect)(gpointer instance, const gchar *detailed_signal, void *c_handler, gpointer data);
-		gulong (*signal_connect_data)(gpointer instance, const gchar *detailed_signal, GCallback c_handler, gpointer data, GClosureNotify destroy_data, SDL_GConnectFlags connect_flags);
-		void (*object_unref)(gpointer object);
-		gchar *(*mkdtemp)(gchar *template);
-		gpointer (*object_ref_sink)(gpointer object);
-		gpointer (*object_ref)(gpointer object);
-		void (*object_get)(gpointer object, const gchar *first_property_name, ...);
-		void (*signal_handler_disconnect)(gpointer instance, gulong handler_id);
-		void (*main_context_push_thread_default)(GMainContext *context);
-		void (*main_context_pop_thread_default)(GMainContext *context);
-		GMainContext *(*main_context_new)(void);
-		gboolean (*main_context_acquire)(GMainContext *context);
-		gboolean (*main_context_iteration)(GMainContext *context, gboolean may_block);
-	} g;
-
-	/* GTK 3.0 */
-	struct
-	{
-		gboolean (*init_check)(int *argc, char ***argv);
-		GtkWidget *(*menu_new)(void);
-		GtkWidget *(*separator_menu_item_new)(void);
-		GtkWidget *(*menu_item_new_with_label)(const gchar *label);
-		void (*menu_item_set_submenu)(GtkMenuItem *menu_item, GtkWidget *submenu);
-		GtkWidget *(*check_menu_item_new_with_label)(const gchar *label);
-		void (*check_menu_item_set_active)(GtkCheckMenuItem *check_menu_item, gboolean is_active);
-		void (*widget_set_sensitive)(GtkWidget *widget, gboolean sensitive);
-		void (*widget_show)(GtkWidget *widget);
-		void (*menu_shell_append)(GtkMenuShell *menu_shell, GtkWidget *child);
-		void (*menu_shell_insert)(GtkMenuShell *menu_shell, GtkWidget *child, gint position);
-		void (*widget_destroy)(GtkWidget *widget);
-		const gchar *(*menu_item_get_label)(GtkMenuItem *menu_item);
-		void (*menu_item_set_label)(GtkMenuItem *menu_item, const gchar *label);
-		gboolean (*check_menu_item_get_active)(GtkCheckMenuItem *check_menu_item);
-		gboolean (*widget_get_sensitive)(GtkWidget *widget);
-		GtkSettings *(*settings_get_default)(void);
-	} gtk;
+	SDL_GlibContext g;
+	
+	SDL_gboolean (*init_check)(int *argc, char ***argv);
+	GtkWidget *(*menu_new)(void);
+	GtkWidget *(*separator_menu_item_new)(void);
+	GtkWidget *(*menu_item_new_with_label)(const SDL_gchar *label);
+	void (*menu_item_set_submenu)(GtkMenuItem *menu_item, GtkWidget *submenu);
+	GtkWidget *(*check_menu_item_new_with_label)(const SDL_gchar *label);
+	void (*check_menu_item_set_active)(GtkCheckMenuItem *check_menu_item, SDL_gboolean is_active);
+	void (*widget_set_sensitive)(GtkWidget *widget, SDL_gboolean sensitive);
+	void (*widget_show)(GtkWidget *widget);
+	void (*menu_shell_append)(GtkMenuShell *menu_shell, GtkWidget *child);
+	void (*menu_shell_insert)(GtkMenuShell *menu_shell, GtkWidget *child, SDL_gint position);
+	void (*widget_destroy)(GtkWidget *widget);
+	const SDL_gchar *(*menu_item_get_label)(GtkMenuItem *menu_item);
+	void (*menu_item_set_label)(GtkMenuItem *menu_item, const SDL_gchar *label);
+	SDL_gboolean (*check_menu_item_get_active)(GtkCheckMenuItem *check_menu_item);
+	SDL_gboolean (*widget_get_sensitive)(GtkWidget *widget);
+	GtkSettings *(*settings_get_default)(void);
 } SDL_GtkContext;
 
 extern bool SDL_Gtk_Init(void);

--- a/src/tray/unix/SDL_tray.c
+++ b/src/tray/unix/SDL_tray.c
@@ -57,9 +57,9 @@ typedef enum {
 
 typedef struct _AppIndicator AppIndicator;
 
-static AppIndicator *(*app_indicator_new)(const gchar *id, const gchar *icon_name, AppIndicatorCategory category);
+static AppIndicator *(*app_indicator_new)(const SDL_gchar *id, const SDL_gchar *icon_name, AppIndicatorCategory category);
 static void (*app_indicator_set_status)(AppIndicator *self, AppIndicatorStatus status);
-static void (*app_indicator_set_icon)(AppIndicator *self, const gchar *icon_name);
+static void (*app_indicator_set_icon)(AppIndicator *self, const SDL_gchar *icon_name);
 static void (*app_indicator_set_menu)(AppIndicator *self, GtkMenu *menu);
 
 /* ------------------------------------------------------------------------- */
@@ -166,7 +166,7 @@ struct SDL_Tray {
     GtkMenuShell *menu_cached;
 };
 
-static void call_callback(GtkMenuItem *item, GParamSpec *pspec, gpointer ptr)
+static void call_callback(GtkMenuItem *item, SDL_GParamSpec *pspec, SDL_gpointer ptr)
 {
     SDL_TrayEntry *entry = ptr;
 
@@ -299,11 +299,12 @@ SDL_Tray *SDL_CreateTray(SDL_Surface *icon, const char *tooltip)
 
     tray->indicator = app_indicator_new(get_appindicator_id(), tray->icon_path,
                                         APP_INDICATOR_CATEGORY_APPLICATION_STATUS);
+    puts("good");
 
     app_indicator_set_status(tray->indicator, APP_INDICATOR_STATUS_ACTIVE);
 
     // The tray icon isn't shown before a menu is created; create one early.
-    tray->menu_cached = (GtkMenuShell *)gtk->g.object_ref_sink(gtk->gtk.menu_new());
+    tray->menu_cached = (GtkMenuShell *)gtk->g.object_ref_sink(gtk->menu_new());
     app_indicator_set_menu(tray->indicator, GTK_MENU(tray->menu_cached));
 
     SDL_RegisterTray(tray);
@@ -416,13 +417,13 @@ SDL_TrayMenu *SDL_CreateTraySubmenu(SDL_TrayEntry *entry)
         return NULL;
     }
 
-    entry->submenu->menu = gtk->g.object_ref_sink(gtk->gtk.menu_new());
+    entry->submenu->menu = gtk->g.object_ref_sink(gtk->menu_new());
     entry->submenu->parent_tray = NULL;
     entry->submenu->parent_entry = entry;
     entry->submenu->nEntries = 0;
     entry->submenu->entries = NULL;
 
-    gtk->gtk.menu_item_set_submenu(GTK_MENU_ITEM(entry->item), GTK_WIDGET(entry->submenu->menu));
+    gtk->menu_item_set_submenu(GTK_MENU_ITEM(entry->item), GTK_WIDGET(entry->submenu->menu));
 
     SDL_Gtk_ExitContext(gtk);
 
@@ -486,7 +487,7 @@ void SDL_RemoveTrayEntry(SDL_TrayEntry *entry)
 
     SDL_GtkContext *gtk = SDL_Gtk_EnterContext();
     if (gtk) {
-        gtk->gtk.widget_destroy(entry->item);
+        gtk->widget_destroy(entry->item);
         SDL_Gtk_ExitContext(gtk);
     }
     SDL_free(entry);
@@ -528,17 +529,17 @@ SDL_TrayEntry *SDL_InsertTrayEntryAt(SDL_TrayMenu *menu, int pos, const char *la
     entry->submenu = NULL;
 
     if (label == NULL) {
-        entry->item = gtk->gtk.separator_menu_item_new();
+        entry->item = gtk->separator_menu_item_new();
     } else if (flags & SDL_TRAYENTRY_CHECKBOX) {
-        entry->item = gtk->gtk.check_menu_item_new_with_label(label);
-        gboolean active = ((flags & SDL_TRAYENTRY_CHECKED) != 0);
-        gtk->gtk.check_menu_item_set_active(GTK_CHECK_MENU_ITEM(entry->item), active);
+        entry->item = gtk->check_menu_item_new_with_label(label);
+        SDL_gboolean active = ((flags & SDL_TRAYENTRY_CHECKED) != 0);
+        gtk->check_menu_item_set_active(GTK_CHECK_MENU_ITEM(entry->item), active);
     } else {
-        entry->item = gtk->gtk.menu_item_new_with_label(label);
+        entry->item = gtk->menu_item_new_with_label(label);
     }
 
-    gboolean sensitive = ((flags & SDL_TRAYENTRY_DISABLED) == 0);
-    gtk->gtk.widget_set_sensitive(entry->item, sensitive);
+    SDL_gboolean sensitive = ((flags & SDL_TRAYENTRY_DISABLED) == 0);
+    gtk->widget_set_sensitive(entry->item, sensitive);
 
     SDL_TrayEntry **new_entries = (SDL_TrayEntry **)SDL_realloc(menu->entries, (menu->nEntries + 2) * sizeof(*new_entries));
 
@@ -556,8 +557,8 @@ SDL_TrayEntry *SDL_InsertTrayEntryAt(SDL_TrayMenu *menu, int pos, const char *la
     new_entries[pos] = entry;
     new_entries[menu->nEntries] = NULL;
 
-    gtk->gtk.widget_show(entry->item);
-    gtk->gtk.menu_shell_insert(menu->menu, entry->item, (pos == menu->nEntries) ? -1 : pos);
+    gtk->widget_show(entry->item);
+    gtk->menu_shell_insert(menu->menu, entry->item, (pos == menu->nEntries) ? -1 : pos);
 
     gtk->g.signal_connect(entry->item, "activate", call_callback, entry);
 
@@ -585,7 +586,7 @@ void SDL_SetTrayEntryLabel(SDL_TrayEntry *entry, const char *label)
 
     SDL_GtkContext *gtk = SDL_Gtk_EnterContext();
     if (gtk) {
-        gtk->gtk.menu_item_set_label(GTK_MENU_ITEM(entry->item), label);
+        gtk->menu_item_set_label(GTK_MENU_ITEM(entry->item), label);
         SDL_Gtk_ExitContext(gtk);
     }
 }
@@ -601,7 +602,7 @@ const char *SDL_GetTrayEntryLabel(SDL_TrayEntry *entry)
 
     SDL_GtkContext *gtk = SDL_Gtk_EnterContext();
     if (gtk) {
-        label = gtk->gtk.menu_item_get_label(GTK_MENU_ITEM(entry->item));
+        label = gtk->menu_item_get_label(GTK_MENU_ITEM(entry->item));
         SDL_Gtk_ExitContext(gtk);
     }
 
@@ -617,7 +618,7 @@ void SDL_SetTrayEntryChecked(SDL_TrayEntry *entry, bool checked)
     SDL_GtkContext *gtk = SDL_Gtk_EnterContext();
     if (gtk) {
         entry->ignore_signal = true;
-        gtk->gtk.check_menu_item_set_active(GTK_CHECK_MENU_ITEM(entry->item), checked);
+        gtk->check_menu_item_set_active(GTK_CHECK_MENU_ITEM(entry->item), checked);
         entry->ignore_signal = false;
         SDL_Gtk_ExitContext(gtk);
     }
@@ -633,7 +634,7 @@ bool SDL_GetTrayEntryChecked(SDL_TrayEntry *entry)
 
     SDL_GtkContext *gtk = SDL_Gtk_EnterContext();
     if (gtk) {
-        checked = gtk->gtk.check_menu_item_get_active(GTK_CHECK_MENU_ITEM(entry->item));
+        checked = gtk->check_menu_item_get_active(GTK_CHECK_MENU_ITEM(entry->item));
         SDL_Gtk_ExitContext(gtk);
     }
 
@@ -648,7 +649,7 @@ void SDL_SetTrayEntryEnabled(SDL_TrayEntry *entry, bool enabled)
 
     SDL_GtkContext *gtk = SDL_Gtk_EnterContext();
     if (gtk) {
-        gtk->gtk.widget_set_sensitive(entry->item, enabled);
+        gtk->widget_set_sensitive(entry->item, enabled);
         SDL_Gtk_ExitContext(gtk);
     }
 }
@@ -663,7 +664,7 @@ bool SDL_GetTrayEntryEnabled(SDL_TrayEntry *entry)
 
     SDL_GtkContext *gtk = SDL_Gtk_EnterContext();
     if (gtk) {
-        enabled = gtk->gtk.widget_get_sensitive(entry->item);
+        enabled = gtk->widget_get_sensitive(entry->item);
         SDL_Gtk_ExitContext(gtk);
     }
 

--- a/src/video/x11/SDL_x11modes.c
+++ b/src/video/x11/SDL_x11modes.c
@@ -68,7 +68,7 @@ static float GetGlobalContentScale(SDL_VideoDevice *_this)
         // in the Xrm database.
         SDL_GtkContext *gtk = SDL_Gtk_EnterContext();
         if (gtk) {
-            GtkSettings *gtksettings = gtk->gtk.settings_get_default();
+            GtkSettings *gtksettings = gtk->settings_get_default();
             if (gtksettings) {
                 int dpi = 0;
                 gtk->g.object_get(gtksettings, "gtk-xft-dpi", &dpi, NULL);

--- a/src/video/x11/SDL_x11settings.c
+++ b/src/video/x11/SDL_x11settings.c
@@ -67,7 +67,7 @@ static void X11_XsettingsNotify(const char *name, XSettingsAction action, XSetti
     }
 }
 
-static void OnGtkXftDpi(GtkSettings *settings, GParamSpec *pspec, gpointer ptr)
+static void OnGtkXftDpi(GtkSettings *settings, SDL_GParamSpec *pspec, SDL_gpointer ptr)
 {
     SDL_VideoDevice *_this = (SDL_VideoDevice *)ptr;
 
@@ -94,13 +94,13 @@ void X11_InitXsettings(SDL_VideoDevice *_this)
     SDLX11_SettingsData *xsettings_data = &data->xsettings_data;
 
     GtkSettings *gtksettings = NULL;
-    guint xft_dpi_signal_handler_id = 0;
+    SDL_guint xft_dpi_signal_handler_id = 0;
 
     SDL_GtkContext *gtk = SDL_Gtk_EnterContext();
     if (gtk) {
         // Prefer to listen for DPI changes from gtk. In XWayland this is necessary as XSettings
         // are not updated dynamically.
-        gtksettings = gtk->gtk.settings_get_default();
+        gtksettings = gtk->settings_get_default();
         if (gtksettings) {
             xft_dpi_signal_handler_id = gtk->g.signal_connect(gtksettings, "notify::gtk-xft-dpi", &OnGtkXftDpi, _this);
         }

--- a/src/video/x11/SDL_x11settings.h
+++ b/src/video/x11/SDL_x11settings.h
@@ -32,7 +32,7 @@
 typedef struct X11_SettingsData {
     XSettingsClient *xsettings;
     GtkSettings *gtksettings;
-    guint xft_dpi_signal_handler_id;
+    SDL_guint xft_dpi_signal_handler_id;
 } SDLX11_SettingsData;
 
 extern void X11_InitXsettings(SDL_VideoDevice *_this);


### PR DESCRIPTION
I want make IsTraySupported check if you have a tray extension installed on GNOME desktops, I have to use GSettings for that, so I want to split off the GLib code.