### PR TITLE
Fix uninitialized variable in SDL_ReadSurfacePixel

### DIFF
--- a/src/video/SDL_surface.c
+++ b/src/video/SDL_surface.c
@@ -2686,7 +2686,7 @@ bool SDL_ReadSurfacePixel(SDL_Surface *surface, int x, int y, Uint8 *r, Uint8 *g
 {
     Uint32 pixel = 0;
     size_t bytes_per_pixel;
-    Uint8 unused;
+    Uint8 unused = 0;
     Uint8 *p;
     bool result = false;
 
@@ -2774,7 +2774,7 @@ bool SDL_ReadSurfacePixel(SDL_Surface *surface, int x, int y, Uint8 *r, Uint8 *g
 
 bool SDL_ReadSurfacePixelFloat(SDL_Surface *surface, int x, int y, float *r, float *g, float *b, float *a)
 {
-    float unused;
+    float unused = 0.0f;
     bool result = false;
 
     if (r) {


### PR DESCRIPTION
Was skimming the code for reference and noticed this variable was uninitialized. It is not used to compare the address either, meaning it is later passed to some other functions with whatever data is in it (likely just 0 anyway though on most systems, considering the follow variables).

Unsure if intended.