### PR TITLE
sinput: refactor to make unknown controllers fully dynamic

### DIFF
--- a/src/joystick/SDL_gamepad.c
+++ b/src/joystick/SDL_gamepad.c
@@ -812,7 +812,8 @@ static GamepadMapping_t *SDL_CreateMappingForHIDAPIGamepad(SDL_GUID guid)
             // GC Ultimate Map
             SDL_strlcat(mapping_string, "a:b0,b:b2,back:b11,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b12,leftshoulder:b6,leftstick:b4,lefttrigger:a4,leftx:a0,lefty:a1,misc1:b13,misc2:b14,rightshoulder:b7,rightstick:b5,righttrigger:a5,rightx:a2,righty:a3,start:b10,x:b1,y:b3,misc3:b8,misc4:b9,hint:!SDL_GAMECONTROLLER_USE_GAMECUBE_LABELS:=1,", sizeof(mapping_string));
             break;
-
+        default:
+        case USB_PRODUCT_BONJIRICHANNEL_FIREBIRD:
         case USB_PRODUCT_HANDHELDLEGEND_SINPUT_GENERIC:
             // Apply mapping profile for type
             switch (sinput_id) {
@@ -840,11 +841,6 @@ static GamepadMapping_t *SDL_CreateMappingForHIDAPIGamepad(SDL_GUID guid)
                 break;
             }
             break;
-
-        default:
-        case USB_PRODUCT_BONJIRICHANNEL_FIREBIRD:
-            // Unmapped devices
-            return NULL;
         }
     } else {
         // All other gamepads have the standard set of 19 buttons and 6 axes


### PR DESCRIPTION
Currently, the generic raspberry pi vid:pid pair must be used for generic mask functionality. Moreover, the axes and buttons are hardcoded in different places in the hid driver, making them difficult to use.

First, refactor SDL_gamepad.c to always use autodetection for unknown controllers. Then, in the HID driver, generate valid masks based on a given subtype that will always match the output SDL string and compare them to the ones in the HID descriptor. If they are different, emit a warning but use the ones from the subtype anyway.

For already known controllers, add a path to skip the check and load the masks from firmware, assuming what is there matches SDL. This is done on faith, so it should be avoided for future controllers.

Moving forward, this commit allows following the same procedure. Assume company X releases controller Y. If the controller uses a completely new layout, company asks for a sub_type. Company gets sub_type and puts it into the controller firmware and releases the controller.

In the period that the bundled Steam SDL does not have that sub_type, it uses the full mapping which is correct for the controller and quite useable, but misses a capability match. If it does have the sub_type, capabilities are correct without any additions to SDL. And in the scenario that a controller is too obscure to warrant a sub_type, 0 can be used, and a mapping can be added to its vid:pid pair for proper capabilities to avoid using sub_types.

cc @mitchellcairns 
