### PR TITLE
Fix double-free warning in src/hidapi/linux/hid.c

### DIFF
--- a/src/hidapi/linux/hid.c
+++ b/src/hidapi/linux/hid.c
@@ -134,7 +134,6 @@ static wchar_t *utf8_to_wchar_t(const char *utf8)
  * Use register_error_str(NULL) to free the error message completely. */
 static void register_error_str(wchar_t **error_str, const char *msg)
 {
-	free(*error_str);
 #ifdef HIDAPI_USING_SDL_RUNTIME
 	/* Thread-safe error handling */
 	if (msg) {
@@ -143,6 +142,7 @@ static void register_error_str(wchar_t **error_str, const char *msg)
 		SDL_ClearError();
 	}
 #else
+	free(*error_str);
 	*error_str = utf8_to_wchar_t(msg);
 #endif
 }


### PR DESCRIPTION
hidapi error messages are only allocated if SDL is not used by hidapi for error messages.
Therefore `free()` only needs to be called without SDL.

Gets rid of following warning:
```c
[ 15%] Building C object CMakeFiles/SDL3-shared.dir/src/hidapi/SDL_hidapi.c.o
path/to/SDL/src/hidapi/linux/hid.c:137:2: warning: Attempt to free released memory [clang-analyzer-unix.Malloc]
  137 |         free(*error_str);
      |         ^
path/to/SDL/src/hidapi/SDL_hidapi.c:1552:9: note: Assuming 'SDL_hidapi_refcount' is not equal to 0
 1552 |     if (SDL_hidapi_refcount == 0 && SDL_hid_init() < 0) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~
path/to/SDL/src/hidapi/SDL_hidapi.c:1552:34: note: Left side of '&&' is false
 1552 |     if (SDL_hidapi_refcount == 0 && SDL_hid_init() < 0) {
      |                                  ^
path/to/SDL/src/hidapi/SDL_hidapi.c:1557:9: note: Assuming 'udev_ctx' is non-null
 1557 |     if (udev_ctx) {
      |         ^~~~~~~~
path/to/SDL/src/hidapi/SDL_hidapi.c:1557:5: note: Taking true branch
 1557 |     if (udev_ctx) {
      |     ^
path/to/SDL/src/hidapi/SDL_hidapi.c:1558:19: note: Calling 'PLATFORM_hid_open_path'
 1558 |         pDevice = PLATFORM_hid_open_path(path);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
path/to/SDL/src/hidapi/linux/hid.c:1157:2: note: Calling 'PLATFORM_hid_init'
 1157 |         hid_init();
      |         ^
path/to/SDL/src/hidapi/SDL_hidapi.c:558:38: note: expanded from macro 'hid_init'
  558 | #define hid_init                     PLATFORM_hid_init
      |                                      ^
path/to/SDL/src/hidapi/linux/hid.c:991:2: note: Calling 'register_global_error'
  991 |         register_global_error(NULL);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
path/to/SDL/src/hidapi/linux/hid.c:166:2: note: Calling 'register_error_str'
  166 |         register_error_str(&last_global_error_str, msg);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
path/to/SDL/src/hidapi/linux/hid.c:137:2: note: Memory is released
  137 |         free(*error_str);
      |         ^~~~~~~~~~~~~~~~
path/to/SDL/src/hidapi/linux/hid.c:140:6: note: 'msg' is null
  140 |         if (msg) {
      |             ^~~
path/to/SDL/src/hidapi/linux/hid.c:140:2: note: Taking false branch
  140 |         if (msg) {
      |         ^
path/to/SDL/src/hidapi/linux/hid.c:166:2: note: Returning; memory was released via 1st parameter
  166 |         register_error_str(&last_global_error_str, msg);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
path/to/SDL/src/hidapi/linux/hid.c:991:2: note: Returning; memory was released
  991 |         register_global_error(NULL);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
path/to/SDL/src/hidapi/linux/hid.c:995:6: note: Assuming 'locale' is non-null
  995 |         if (!locale)
      |             ^~~~~~~
path/to/SDL/src/hidapi/linux/hid.c:995:2: note: Taking false branch
  995 |         if (!locale)
      |         ^
path/to/SDL/src/hidapi/linux/hid.c:1157:2: note: Returning; memory was released
 1157 |         hid_init();
      |         ^
path/to/SDL/src/hidapi/SDL_hidapi.c:558:38: note: expanded from macro 'hid_init'
  558 | #define hid_init                     PLATFORM_hid_init
      |                                      ^
path/to/SDL/src/hidapi/linux/hid.c:1161:7: note: 'dev' is null
 1161 |         if (!dev) {
      |              ^~~
path/to/SDL/src/hidapi/linux/hid.c:1161:2: note: Taking true branch
 1161 |         if (!dev) {
      |         ^
path/to/SDL/src/hidapi/linux/hid.c:1162:3: note: Calling 'register_global_error'
 1162 |                 register_global_error("Couldn't allocate memory");
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
path/to/SDL/src/hidapi/linux/hid.c:166:2: note: Calling 'register_error_str'
  166 |         register_error_str(&last_global_error_str, msg);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
path/to/SDL/src/hidapi/linux/hid.c:137:2: note: Attempt to free released memory
  137 |         free(*error_str);
      |         ^~~~~~~~~~~~~~~~
```