### PR TITLE
tray: fix tray menu elements not running callbacks

### DIFF
--- a/src/core/unix/SDL_gtk.c
+++ b/src/core/unix/SDL_gtk.c
@@ -134,7 +134,7 @@ static bool InitGtk(void)
     SDL_GTK_SYM(gtk, libgdk, g, signal_handler_disconnect);
     SDL_GTK_SYM(gtk, libgdk, g, main_context_push_thread_default);
     SDL_GTK_SYM(gtk, libgdk, g, main_context_pop_thread_default);
-    SDL_GTK_SYM(gtk, libgdk, g, main_context_new);
+    SDL_GTK_SYM(gtk, libgdk, g, main_context_default);
     SDL_GTK_SYM(gtk, libgdk, g, main_context_acquire);
     SDL_GTK_SYM(gtk, libgdk, g, main_context_iteration);
 
@@ -145,7 +145,7 @@ static bool InitGtk(void)
         return SDL_SetError("Could not init GTK");
     }
 
-    sdl_main_context = gtk.g.main_context_new();
+    sdl_main_context = gtk.g.main_context_default();
     if (!sdl_main_context) {
         QuitGtk();
         return SDL_SetError("Could not create GTK context");

--- a/src/core/unix/SDL_gtk.h
+++ b/src/core/unix/SDL_gtk.h
@@ -74,7 +74,7 @@ typedef struct _GtkSettings GtkSettings;
 typedef struct SDL_GtkContext
 {
 	/* Glib 2.0 */
-	struct 
+	struct
 	{
 		gulong (*signal_connect)(gpointer instance, const gchar *detailed_signal, void *c_handler, gpointer data);
 		gulong (*signal_connect_data)(gpointer instance, const gchar *detailed_signal, GCallback c_handler, gpointer data, GClosureNotify destroy_data, SDL_GConnectFlags connect_flags);
@@ -86,7 +86,7 @@ typedef struct SDL_GtkContext
 		void (*signal_handler_disconnect)(gpointer instance, gulong handler_id);
 		void (*main_context_push_thread_default)(GMainContext *context);
 		void (*main_context_pop_thread_default)(GMainContext *context);
-		GMainContext *(*main_context_new)(void);
+		GMainContext *(*main_context_default)(void);
 		gboolean (*main_context_acquire)(GMainContext *context);
 		gboolean (*main_context_iteration)(GMainContext *context, gboolean may_block);
 	} g;

--- a/src/tray/unix/SDL_tray.c
+++ b/src/tray/unix/SDL_tray.c
@@ -166,7 +166,7 @@ struct SDL_Tray {
     GtkMenuShell *menu_cached;
 };
 
-static void call_callback(GtkMenuItem *item, GParamSpec *pspec, gpointer ptr)
+static void call_callback(GtkMenuItem *item, gpointer ptr)
 {
     SDL_TrayEntry *entry = ptr;
 
@@ -404,7 +404,7 @@ SDL_TrayMenu *SDL_CreateTraySubmenu(SDL_TrayEntry *entry)
         SDL_SetError("Cannot create submenu for entry not created with SDL_TRAYENTRY_SUBMENU");
         return NULL;
     }
-    
+
     SDL_GtkContext *gtk = SDL_Gtk_EnterContext();
     if (!gtk) {
         return NULL;


### PR DESCRIPTION
## Description
Tray menu elements were not running callbacks upon being clicked. This was due to two issues: `call_callbacks` was the wrong function prototype to be able to be properly called by the "activate" signal and `main_context_new` *does not* actually handle the events that GTK provides upon initialization. To fix this:
- the function was updated, removing the `pspec` param
- `main_context_new` was replaced with `main_context_default` returning a context that handles the events coming from the tray menu

## Existing Issue(s)
#13576 