### PR TITLE
SDL_enabled_assert(): Use `NULL` istead of `0` to explicity initialize the pointer members of SDL_AssertData

### DIFF
--- a/include/SDL3/SDL_assert.h
+++ b/include/SDL3/SDL_assert.h
@@ -362,7 +362,7 @@ extern SDL_DECLSPEC SDL_AssertState SDLCALL SDL_ReportAssertion(SDL_AssertData *
 #define SDL_enabled_assert(condition) \
     do { \
         while ( !(condition) ) { \
-            static struct SDL_AssertData sdl_assert_data = { 0, 0, #condition, 0, 0, 0, 0 }; \
+            static struct SDL_AssertData sdl_assert_data = { false, 0, #condition, NULL, 0, NULL, NULL }; \
             const SDL_AssertState sdl_assert_state = SDL_ReportAssertion(&sdl_assert_data, SDL_FUNCTION, SDL_FILE, SDL_LINE); \
             if (sdl_assert_state == SDL_ASSERTION_RETRY) { \
                 continue; /* go again. */ \


### PR DESCRIPTION
`SDL_assert()` and `SDL_enabled_assert()` use `0` to initialize pointer members instead of `NULL`:
```c
static struct SDL_AssertData sdl_assert_data = { 0, 0, #condition, 0, 0, 0, 0 }; \
```
instead of
```c
static struct SDL_AssertData sdl_assert_data = { false, 0, #condition, NULL, 0, NULL, NULL }; \
```
When compiling SDL with the flag `-Wzero-as-null-pointer-constant` there are 2108 warnings instead of "only" 130 because of that.

This flag could have been used to detect the issue https://github.com/libsdl-org/SDL/issues/13628 with a pre-C23 standard:
```c
/path/to/SDL/src/render/vulkan/SDL_render_vulkan.c: In function ‘VULKAN_GetSampler’:
/path/to/SDL/src/render/vulkan/SDL_render_vulkan.c:3763:20: warning: zero as null pointer constant [-Wzero-as-null-pointer-constant]
 3763 |             return false;
      |                    ^~~~~
```

and shows 130 other warnings which may be potential issues.