### PR TITLE
SDL_LoadWAV_IO(): On error, set `*audio_buf` to NULL and `*audio_len` to 0

### DIFF
--- a/src/audio/SDL_wave.c
+++ b/src/audio/SDL_wave.c
@@ -2114,8 +2114,8 @@ bool SDL_LoadWAV_IO(SDL_IOStream *src, bool closeio, SDL_AudioSpec *spec, Uint8 
     result = WaveLoad(src, &file, spec, audio_buf, audio_len);
     if (!result) {
         SDL_free(*audio_buf);
-        audio_buf = NULL;
-        audio_len = 0;
+        *audio_buf = NULL;
+        *audio_len = 0;
     }
 
     // Cleanup


### PR DESCRIPTION
In `SDL_LoadWAV_IO()`, when an error occurres, this function sets the local arguments to NULL and 0 instead of the initial variables.

This commit fixes this.

Issue spotted with `-Wzero-as-null-pointer-constant`:
```c
[ 11%] Building C object CMakeFiles/SDL3-shared.dir/src/audio/SDL_wave.c.o
/path/to/SDL/src/audio/SDL_wave.c: In function ‘SDL_LoadWAV_IO_REAL’:
/path/to/SDL/src/audio/SDL_wave.c:2118:19: warning: zero as null pointer constant [-Wzero-as-null-pointer-constant]
 2118 |         audio_len = 0;
      |                   ^
```