### PR TITLE
Fix directory globbing on Android

### DIFF
--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -1855,7 +1855,7 @@ bool Android_JNI_FileClose(void *userdata)
 
 bool Android_JNI_EnumerateAssetDirectory(const char *path, SDL_EnumerateDirectoryCallback cb, void *userdata)
 {
-    SDL_assert((*path == '\0') || (path[SDL_strlen(path) - 1] == '/'));  // SDL_SYS_EnumerateDirectory() should have verified this.
+    SDL_assert(path != NULL);
 
     if (!asset_manager) {
         Internal_Android_Create_AssetManager();


### PR DESCRIPTION
This PR fixes `SDL_GlobDirectory` on Android.

When regular `opendir` fails, it proceeds to check asset manager. The offending assertion checks for empty path (top-level asset bundle directory), or that the path ends with a separator. The supplied comment reads `SDL_SYS_EnumerateDirectory() should have verified this.`, but in fact `SDL_SYS_EnumerateDirectory` guarantees there would no trailing slash:

https://github.com/libsdl-org/SDL/blob/483b8d4d984a66e6e4b063828743afd768683fc3/src/filesystem/posix/SDL_sysfsops.c#L44-L54

Assertion is still required to handle `NULL` (`AAssetManager_openDir` will cause segmentation fault if path is `NULL`).