### PR TITLE
x11: Check axis labels when searching for relative axes

### DIFF
--- a/src/video/x11/SDL_x11mouse.h
+++ b/src/video/x11/SDL_x11mouse.h
@@ -26,6 +26,7 @@
 typedef struct SDL_XInput2DeviceInfo
 {
     int device_id;
+    int number[2];
     bool relative[2];
     double minval[2];
     double maxval[2];


### PR DESCRIPTION
Prefer axes with the 'Rel X'/'Rel Y' labels, followed by 'Abs X'/'Abs Y', and only fall back to the old behavior of using the first two enumerated, unknown axes if no others are found.

Fixes a FIXME when determining which axes to use for relative motion.
