### PR TITLE
win32: Use the current flags to determine if NCCALCSIZE is required

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -2175,7 +2175,7 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
 
     case WM_NCCALCSIZE:
     {
-        SDL_WindowFlags window_flags = SDL_GetWindowFlags(data->window);
+        SDL_WindowFlags window_flags = data->window->flags;
         if (wParam == TRUE && (window_flags & SDL_WINDOW_BORDERLESS) && !(window_flags & SDL_WINDOW_FULLSCREEN)) {
             // When borderless, need to tell windows that the size of the non-client area is 0
             NCCALCSIZE_PARAMS *params = (NCCALCSIZE_PARAMS *)lParam;

--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -1071,16 +1071,16 @@ void WIN_ShowWindow(SDL_VideoDevice *_this, SDL_Window *window)
         WIN_SetWindowPosition(_this, window);
     }
 
-    /* If the window will immediately become fullscreen, use the borderless style to hide the initial borders.
-     *
-     * Note: The combination of flags used in STYLE_BORDERLESS_WINDOWED will still briefly show the borders if
-     * the initial window size exactly matches the desktop, so STYLE_BORDERLESS must be used instead.
-     */
+    // If the window isn't borderless and will be fullscreen, use the borderless style to hide the initial borders.
     if (window->pending_flags & SDL_WINDOW_FULLSCREEN) {
-        style = GetWindowLong(hwnd, GWL_STYLE);
-        style &= ~STYLE_MASK;
-        style |= STYLE_BORDERLESS;
-        SetWindowLong(hwnd, GWL_STYLE, style);
+        if (!(window->flags & SDL_WINDOW_BORDERLESS)) {
+            window->flags |= SDL_WINDOW_BORDERLESS;
+            style = GetWindowLong(hwnd, GWL_STYLE);
+            style &= ~STYLE_MASK;
+            style |= GetWindowStyle(window);
+            SetWindowLong(hwnd, GWL_STYLE, style);
+            window->flags &= ~SDL_WINDOW_BORDERLESS;
+        }
     }
     style = GetWindowLong(hwnd, GWL_EXSTYLE);
     if (style & WS_EX_NOACTIVATE) {


### PR DESCRIPTION
SDL_GetWindowFlags() also ORs in pending flags, whereas the current state is needed here, particularly when creating/showing a window.

Fixes #13695 (for real this time)
