### PR TITLE
SDL_endian.h: extend Linux way for GNU libc

### DIFF
--- a/include/SDL3/SDL_endian.h
+++ b/include/SDL3/SDL_endian.h
@@ -128,7 +128,7 @@ _m_prefetch(void *__P)
  * \sa SDL_BIG_ENDIAN
  */
 #define SDL_BYTEORDER   SDL_LIL_ENDIAN___or_maybe___SDL_BIG_ENDIAN
-#elif defined(SDL_PLATFORM_LINUX)
+#elif defined(SDL_PLATFORM_LINUX) || defined(__GLIBC__)
 #include <endian.h>
 #define SDL_BYTEORDER  __BYTE_ORDER
 #elif defined(SDL_PLATFORM_SOLARIS)


### PR DESCRIPTION
## Description

The currently used way to determine the endianness (i.e. include `<endian.h>` and use the `__BYTE_ORDER` macro) is provided in general by GNU libc. Thus, extend that to any platform/OS based on GNU libc.
