### PR TITLE
video: Use additional checks for determining on which display a windo…

### DIFF
--- a/src/events/SDL_windowevents.c
+++ b/src/events/SDL_windowevents.c
@@ -99,6 +99,12 @@ bool SDL_SendWindowEvent(SDL_Window *window, SDL_EventType windowevent, int data
     case SDL_EVENT_WINDOW_MOVED:
         window->undefined_x = false;
         window->undefined_y = false;
+        /* Clear the pending display if this move was not the result of an explicit request,
+         * and the window is not scheduled to become fullscreen when shown.
+         */
+        if (!window->last_position_pending && !(window->pending_flags & SDL_WINDOW_FULLSCREEN)) {
+            window->pending_displayID = 0;
+        }
         window->last_position_pending = false;
         if (!(window->flags & SDL_WINDOW_FULLSCREEN)) {
             window->windowed.x = data1;

--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -61,6 +61,7 @@ struct SDL_Window
     bool fullscreen_exclusive;  // The window is currently fullscreen exclusive
     SDL_DisplayID last_fullscreen_exclusive_display;  // The last fullscreen_exclusive display
     SDL_DisplayID last_displayID;
+    SDL_DisplayID pending_displayID;
 
     /* Stored position and size for the window in the non-fullscreen state,
      * including when the window is maximized or tiled.


### PR DESCRIPTION
…w should be fullscreen

Trying to determine where a window should be made fullscreen from the size and position can be unreliable if the window exceeds the display bounds. Add additional checks with the following priority:

- If the window was positioned with a macro that explicitly passes a display ID, store and use the requested display as the explicit fullscreen target.
- Check if the window position is an exact match for any display origins, and use that display if found, as positioning a fullscreen window by moving it to the origin of the destination display is common behavior.
- Fall back to the existing center point check if the previous checks were not successful, as it is known behavior, and won't risk breaking existing clients that rely on it.

Closes #13701 