### PR TITLE
WIN_ShowCursor function is now capable of processing NULL as a SDL_Cursor* (repost)

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -4421,8 +4421,8 @@ extern "C" {
 #define SDL_HINT_DEBUG_LOGGING "SDL_DEBUG_LOGGING"
 
 /**
- * \brief On Windows, this hint forces SDL to call SetCursor(NULL) to hide the mouse cursor,
- *        instead of using an invisible blank cursor.
+ * On Windows, this hint forces SDL to call SetCursor(NULL) to hide the mouse cursor,
+ * instead of using an invisible blank cursor.
  *
  * This may be required in certain environments (e.g., VMware or specific RDP configurations),
  * where SetCursorPos() does not function correctly if the cursor is not truly hidden using SetCursor(NULL).

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -4421,10 +4421,28 @@ extern "C" {
 #define SDL_HINT_DEBUG_LOGGING "SDL_DEBUG_LOGGING"
 
 /**
+ * \brief On Windows, this hint forces SDL to call SetCursor(NULL) to hide the mouse cursor,
+ *        instead of using an invisible blank cursor.
+ *
+ * This may be required in certain environments (e.g., VMware or specific RDP configurations),
+ * where SetCursorPos() does not function correctly if the cursor is not truly hidden using SetCursor(NULL).
+ *
+ * By default, SDL uses a transparent cursor surface to simulate a hidden cursor,
+ * which avoids issues in some scenarios (e.g., multi-window focus handling).
+ * However, this method may not work properly in all virtualized environments.
+ *
+ * Set this hint to "1" to restore the previous behavior and force SetCursor(NULL) to be used.
+ *
+ * This hint is only applicable on Windows.
+ */
+#define SDL_HINT_WINDOWS_FORCE_NULL_CURSOR "SDL_WINDOWS_FORCE_NULL_CURSOR"
+
+/**
  * An enumeration of hint priorities.
  *
  * \since This enum is available since SDL 3.2.0.
  */
+
 typedef enum SDL_HintPriority
 {
     SDL_HINT_DEFAULT,

--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -434,20 +434,28 @@ error:
 static bool WIN_ShowCursor(SDL_Cursor *cursor)
 {
     if (!cursor) {
-        cursor = SDL_blank_cursor;
+        if (SDL_GetHintBoolean(SDL_HINT_WINDOWS_FORCE_NULL_CURSOR, true)) {
+            SDL_cursor = NULL;
+            SetCursor(NULL);
+
+            return false;
+        } else {
+            cursor = SDL_blank_cursor;
+        }
     }
+
     if (cursor) {
         if (cursor->internal->surface) {
             SDL_cursor = GetCachedCursor(cursor);
         } else {
             SDL_cursor = cursor->internal->cursor;
         }
-    } else {
-        SDL_cursor = NULL;
     }
+
     if (SDL_GetMouseFocus() != NULL) {
         SetCursor(SDL_cursor);
     }
+
     return true;
 }
 


### PR DESCRIPTION
I added an SDL Hint called "SDL_HINT_WINDOWS_FORCE_NULL_CURSOR" which lets you decide
to have a NULL windows cursor, which is the intended way to hide it in a window, or "fake" by making it invisible.
Now the issue was that since GetCursorPos wasnt working when the cursor was NULL, and for other reasons,
this commit (https://github.com/libsdl-org/SDL/commit/8fee82d1fd9d8875cca7f8bfc577c60d12a5b5b6) fixed it by putting a blank surface as the cursor (hiding it); altho this wasn't working properly on Vitual Machines such as VMWare Workstation Pro when the SDL app in fullscreen, since the cursor was effectively not there, but when moved could exit the VM, which is unwanted behaviour. With this SDL Hint you can decide that (0 for fake cursor, 1 for actual NULL pointer).

This was tested in VMWare Workstation Pro with Windows 10 64 bit, using SDL3 SDL_HideCursor() function.


Fixed issue https://github.com/libsdl-org/SDL/issues/13700
