### PR TITLE
SDL_TriggerBreakpoint() will default to __debugbreak() on MinGW toolchain on windows

### DIFF
--- a/include/SDL3/SDL_assert.h
+++ b/include/SDL3/SDL_assert.h
@@ -126,7 +126,7 @@ extern "C" {
  */
 #define SDL_TriggerBreakpoint() TriggerABreakpointInAPlatformSpecificManner
 
-#elif defined(_MSC_VER) && _MSC_VER >= 1310
+#elif defined(__MINGW32__) || defined(_MSC_VER) && _MSC_VER >= 1310
     /* Don't include intrin.h here because it contains C++ code */
     extern void __cdecl __debugbreak(void);
     #define SDL_TriggerBreakpoint() __debugbreak()


### PR DESCRIPTION
Forces SDL built for mingw toolchain to specify `__debugbreak()` instead of `__builtin_trap()` for `SDL_TriggerBreakpoint()`

Fixed Issue #13710
