### PR TITLE
Fixed bug #13493: Assertion failure at SDL_AddTouch with Android API 28

### DIFF
--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -1080,7 +1080,8 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(nativeAddTouch)(
 {
     const char *utfname = (*env)->GetStringUTFChars(env, name, NULL);
 
-    SDL_AddTouch((SDL_TouchID)touchId, SDL_TOUCH_DEVICE_DIRECT, utfname);
+    SDL_AddTouch(Android_ConvertJavaTouchID(touchId),
+            SDL_TOUCH_DEVICE_DIRECT, utfname);
 
     (*env)->ReleaseStringUTFChars(env, name, utfname);
 }

--- a/src/video/android/SDL_androidtouch.c
+++ b/src/video/android/SDL_androidtouch.c
@@ -47,6 +47,25 @@ void Android_QuitTouch(void)
 {
 }
 
+
+SDL_TouchID Android_ConvertJavaTouchID(int touchID)
+{
+    SDL_TouchID retval = touchID;
+
+    if (touchID < 0) {
+        // Touch ID -1 appears when using Android emulator, eg:
+        //  adb shell input mouse tap 100 100
+        //  adb shell input touchscreen tap 100 100
+        //
+        // Prevent to be -1, since it's used in SDL internal for synthetic events:
+        retval -= 1;
+    } else {
+        // Touch ID 0 is invalid
+        retval += 1;
+    }
+    return retval;
+}
+
 void Android_OnTouch(SDL_Window *window, int touch_device_id_in, int pointer_finger_id_in, int action, float x, float y, float p)
 {
     SDL_TouchID touchDeviceId = 0;
@@ -56,11 +75,7 @@ void Android_OnTouch(SDL_Window *window, int touch_device_id_in, int pointer_fin
         return;
     }
 
-    /* Touch device -1 appears when using Android emulator, eg:
-     *  adb shell input mouse tap 100 100
-     *  adb shell input touchscreen tap 100 100
-     */
-    touchDeviceId = (SDL_TouchID)(touch_device_id_in + 2);
+    touchDeviceId = Android_ConvertJavaTouchID(touch_device_id_in);
 
     // Finger ID should be greater than 0
     fingerId = (SDL_FingerID)(pointer_finger_id_in + 1);

--- a/src/video/android/SDL_androidtouch.h
+++ b/src/video/android/SDL_androidtouch.h
@@ -25,3 +25,4 @@
 extern void Android_InitTouch(void);
 extern void Android_QuitTouch(void);
 extern void Android_OnTouch(SDL_Window *window, int touch_device_id_in, int pointer_finger_id_in, int action, float x, float y, float p);
+extern SDL_TouchID Android_ConvertJavaTouchID(int touchID);


### PR DESCRIPTION

Java touch id should be -1 because it's reserved for internal SDL synthetic events.
It should also not be 0, because this is SDL invalid value.
