### PR TITLE
SDL_SetRenderDrawBlendMode(): Remove redundant param check

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -3366,10 +3366,6 @@ bool SDL_SetRenderDrawBlendMode(SDL_Renderer *renderer, SDL_BlendMode blendMode)
         return SDL_InvalidParamError("blendMode");
     }
 
-    if (blendMode == SDL_BLENDMODE_INVALID) {
-        return SDL_InvalidParamError("blendMode");
-    }
-
     if (!IsSupportedBlendMode(renderer, blendMode)) {
         return SDL_Unsupported();
     }


### PR DESCRIPTION
In `SDL_SetRenderDrawBlendMode()` the parameter `blendMode` is checked twice.

This commit removes one check.