### PR TITLE
SDL_SendJoystickVirtualSensorDataInner(): Fix max_sensor_events increment

### DIFF
--- a/src/joystick/virtual/SDL_virtualjoystick.c
+++ b/src/joystick/virtual/SDL_virtualjoystick.c
@@ -471,7 +471,7 @@ bool SDL_SendJoystickVirtualSensorDataInner(SDL_Joystick *joystick, SDL_SensorTy
             return false;
         }
         hwdata->sensor_events = sensor_events;
-        hwdata->max_sensor_events = hwdata->max_sensor_events;
+        hwdata->max_sensor_events = new_max_sensor_events;
     }
 
     VirtualSensorEvent *event = &hwdata->sensor_events[hwdata->num_sensor_events++];


### PR DESCRIPTION
In `SDL_SendJoystickVirtualSensorDataInner()`, after reallocation, the variable `hwdata->max_sensor_events` gets assigned to itself instead of the incremented `new_max_sensor_events`