### PR TITLE
keyboard_handle_keymap(): Return when keymap creation fails

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -1593,7 +1593,7 @@ static void keyboard_handle_keymap(void *data, struct wl_keyboard *keyboard,
         seat->keyboard.sdl_keymap = SDL_calloc(seat->keyboard.xkb.num_layouts, sizeof(SDL_Keymap *));
         for (xkb_layout_index_t i = 0; i < seat->keyboard.xkb.num_layouts; ++i) {
             seat->keyboard.sdl_keymap[i] = SDL_CreateKeymap(false);
-            if (!seat->keyboard.sdl_keymap) {
+            if (!seat->keyboard.sdl_keymap[i]) {
                 return;
             }
         }


### PR DESCRIPTION
**Problem:**
In `keyboard_handle_keymap()` when keymaps get created, it is checked if `seat->keyboard.sdl_keymap` is NULL inside the loop and not if the individual entry `seat->keyboard.sdl_keymap[i]` is NULL, which is created. This doesn't seem right because `seat->keyboard.sdl_keymap` was already dereferenced.

If it was intended to check every entry after creation, this commit does this.
But maybe the intention was to actually validate `seat->keyboard.sdl_keymap` after the `SDL_calloc()`, then the check needs to be moved outside the loop after the allocation.

cc @Kontrabant