### PR TITLE
Use PulseAudio fragsize buffer correctly

### DIFF
--- a/src/audio/pulseaudio/SDL_pulseaudio.c
+++ b/src/audio/pulseaudio/SDL_pulseaudio.c
@@ -732,7 +732,7 @@ static bool PULSEAUDIO_OpenDevice(SDL_AudioDevice *device)
                 if (!actual_bufattr) {
                     result = SDL_SetError("Could not determine connected PulseAudio stream's buffer attributes");
                 } else {
-                    device->buffer_size = (int) recording ? actual_bufattr->tlength : actual_bufattr->fragsize;
+                    device->buffer_size = (int) recording ? actual_bufattr->fragsize : actual_bufattr->tlength;
                     device->sample_frames = device->buffer_size / SDL_AUDIO_FRAMESIZE(device->spec);
                 }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
For recording using PulseAudio, use fragsize buffer for recording to fix issues in Sober.
## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #13399 