### PR TITLE
emscripten tests: fix warning: uninitialized variable

### DIFF
--- a/test/testautomation_rect.c
+++ b/test/testautomation_rect.c
@@ -916,7 +916,7 @@ static int SDLCALL rect_testIntersectRectEmpty(void *arg)
  */
 static int SDLCALL rect_testIntersectRectParam(void *arg)
 {
-    SDL_Rect rectA;
+    SDL_Rect rectA = { 0 };
     SDL_Rect rectB = { 0 };
     SDL_Rect result;
     bool intersection;
@@ -1165,7 +1165,7 @@ static int SDLCALL rect_testHasIntersectionEmpty(void *arg)
  */
 static int SDLCALL rect_testHasIntersectionParam(void *arg)
 {
-    SDL_Rect rectA;
+    SDL_Rect rectA = { 0 };
     SDL_Rect rectB = { 0 };
     bool intersection;
 
@@ -1726,7 +1726,7 @@ static int SDLCALL rect_testUnionRectInside(void *arg)
  */
 static int SDLCALL rect_testUnionRectParam(void *arg)
 {
-    SDL_Rect rectA, rectB = { 0 };
+    SDL_Rect rectA = { 0 }, rectB = { 0 };
     SDL_Rect result;
 
     /* invalid parameter combinations */


### PR DESCRIPTION
Fixing these three warnings, which appear when building with emscripten and tests enabled:

```c
[ 54%] Building C object test/CMakeFiles/testautomation.dir/testautomation_rect.c.o
/path/to/SDL/test/testautomation_rect.c:927:45: warning: variable 'rectA' is uninitialized when passed as a const pointer argument
      here [-Wuninitialized-const-pointer]
  927 |     intersection = SDL_GetRectIntersection(&rectA, (SDL_Rect *)NULL, &result);
      |                                             ^~~~~
/path/to/SDL/test/testautomation_rect.c:1175:45: warning: variable 'rectA' is uninitialized when passed as a const pointer
      argument here [-Wuninitialized-const-pointer]
 1175 |     intersection = SDL_HasRectIntersection(&rectA, (SDL_Rect *)NULL);
      |                                             ^~~~~
/path/to/SDL/test/testautomation_rect.c:1735:23: warning: variable 'rectA' is uninitialized when passed as a const pointer
      argument here [-Wuninitialized-const-pointer]
 1735 |     SDL_GetRectUnion(&rectA, (SDL_Rect *)NULL, &result);
      |                       ^~~~~
```