### PR TITLE
Fix IsDeviceSupported for Steam Controller

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1038,7 +1038,7 @@ static bool HIDAPI_DriverSteam_IsSupportedDevice(SDL_HIDAPI_Device *device, cons
         return false;
     }
 
-    if (device->is_bluetooth) {
+    if (device && device->is_bluetooth) {
         return true;
     }
 

--- a/src/joystick/hidapi/SDL_hidapijoystick.c
+++ b/src/joystick/hidapi/SDL_hidapijoystick.c
@@ -334,7 +334,7 @@ static bool HIDAPI_IsDeviceSupported(Uint16 vendor_id, Uint16 product_id, Uint16
 
     for (i = 0; i < SDL_arraysize(SDL_HIDAPI_drivers); ++i) {
         SDL_HIDAPI_DeviceDriver *driver = SDL_HIDAPI_drivers[i];
-        if (driver->enabled && driver->IsSupportedDevice(NULL, name, type, vendor_id, product_id, version, -1, 0, 0, 0)) {
+        if (driver->enabled && driver->IsSupportedDevice(driver, name, type, vendor_id, product_id, version, -1, 0, 0, 0)) {
             return true;
         }
     }


### PR DESCRIPTION
In a test I ran on Linux, `device->bluetooth` was being called when `device` was NULL

<img width="1193" height="855" alt="Screenshot from 2025-08-14 12-32-55" src="https://github.com/user-attachments/assets/6408ffdb-6fcd-4496-97a6-6a3a4fe8f292" />

![IMG20250814123052 (1)](https://github.com/user-attachments/assets/8c392863-5109-4cc4-8773-bcf1b485d6fb)

![IMG20250814123106](https://github.com/user-attachments/assets/b34b7ad8-47f7-4250-afa5-ceefadf2d392)
