### PR TITLE
disable use of X11 extension MIT-SHM when using remote X server(#8956)

### DIFF
--- a/src/video/x11/SDL_x11framebuffer.c
+++ b/src/video/x11/SDL_x11framebuffer.c
@@ -42,6 +42,16 @@ static int shm_errhandler(Display *d, XErrorEvent *e)
 static SDL_bool have_mitshm(Display *dpy)
 {
     /* Only use shared memory on local X servers */
+    /* Given that Windows 10 and 11 now offer use of OpenSSH, checking for a
+       SSH_TTY value (man ssh(1)) is potentially an OS-agnostic means of
+       detecting a common case of using a remote X server: when accessing via
+       X11 forwarding over `ssh -X`. */
+    /* (Linux-specific alternative: checking if XDG_SESSION_TYPE == "tty" (see
+       man pam_systemd(8))) */
+    const char *ssh_tty = SDL_getenv("SSH_TTY");
+    if (ssh_tty != NULL && SDL_strlen(ssh_tty) > 0) {
+        return SDL_FALSE;
+    }
     return X11_XShmQueryExtension(dpy) ? SDL_X11_HAVE_SHM : SDL_FALSE;
 }
 


### PR DESCRIPTION
## Description
After some research into the [X11 protocol and its extensions](https://www.x.org/releases/X11R7.7/doc/), here's my understanding of the problem:
1. the user's SDL app, using Xlib, acts as an X client and asks the X server if the extension MIT-SHM is available
2. the server, not detecting whether the client is remote or local, answers yes if the extension is implemented
3. having permission to do so, at some point the client attempts to start sharing memory via [X11_XShmAttach](https://github.com/libsdl-org/SDL/blob/1f21aae242ba7e1e040d93d1932e64d3e4246438/src/video/x11/SDL_x11framebuffer.c#L96)
4. memory sharing is doomed to fail, as the X client and server are not running on the same hardware, but the X server reports that the request has an invalid opcode (confusing given that it approved use of the extension earlier)

I could try to compile SDL with NO_SHARED_MEMORY defined, but thought it would be nice to retain use of shared memory for when it was appropriate. This PR is my attempt at creating a reasonably cross-platform way to detect at runtime the use of a remote X server, and disable memory sharing via MIT-SHM.

## Existing Issue(s)
This is a workaround to #8956, but does not address the original request for cleaner SDL exit on relevant Xlib errors.
