### PR TITLE
Implement CONFIGURE_DEPENDS flag in our GLOBs.

### DIFF
--- a/cmake/sdlcommands.cmake
+++ b/cmake/sdlcommands.cmake
@@ -19,7 +19,7 @@ endfunction()
 # Use sdl_glob_sources to add glob sources to SDL3-shared, to SDL3-static, or to both.
 function(sdl_glob_sources)
   cmake_parse_arguments(ARGS "" "" "SHARED;STATIC" ${ARGN})
-  if (ARGS_SHARED)
+  if(ARGS_SHARED)
     file(GLOB shared_sources CONFIGURE_DEPENDS ${ARGS_SHARED})
   endif()
   if(ARGS_STATIC)


### PR DESCRIPTION
As discussed in #13704 we should likely be using `CONFIGURE_DEPENDS` to ensure that CMake will automatically reconfigure if you trigger a build but have added files that should be picked up by our GLOBs. This is a relatively minor but it's good practice when using GLOBs in CMake.

## Description
As far as implementation, in theory all we need is to add `CONFIGURE_DEPENDS` when using `file(GLOB ...)`, but we do some extra globs for simplicity based on args we get in `sdl_glob_sources`, which means sometimes we're doing a `GLOB` with no expressions, which `CONFIGURE_DEPENDS` doesn't like. So I've adjusted to make sure we check there's actually an expression before calling into it.

Regarding performance, and I should note that this is just a repeat of my comment in the previous PR when this was discussed, I did some testing locally, I'm not noticing anything that I would be able to consistently nail down without just running builds over and over again. I pushed it up to CI and while it wasn't faster than the previous run on the branch, it was faster than a different run on the same commit.

Previous Commit Run 1: https://github.com/playmer/SDL-1/actions/runs/16858095731
Previous Commit Run 2: https://github.com/playmer/SDL-1/actions/runs/16857983229
CONFIGURE_DEPENDS Commit: https://github.com/playmer/SDL-1/actions/runs/16953366708

The flag should mostly affect incremental builds, as CMake needs to insert globs to run before building your code. I did a quick run of a rebuild by inserting blank lines in `SDL.h` and again found nothing notable:

(Omitted the actual cmake/build output, but the full logs are here: https://gist.github.com/playmer/7d2c0bc75d694e582c08601f23f5b72b)

With Changes:
```
playmer@Timestar:~/SDL_test/SDL_with_change$ time cmake -B build .
real    0m48.004s
user    0m6.040s
sys     0m3.943s
playmer@Timestar:~/SDL_test/SDL_with_change$ time cmake --build build -j8
real    0m7.513s
user    0m44.668s
sys     0m6.852s
playmer@Timestar:~/SDL_test/SDL_with_change$ nano include/SDL3/SDL.h
playmer@Timestar:~/SDL_test/SDL_with_change$ time cmake --build build -j8
real    0m7.594s
user    0m44.934s
sys     0m7.024s
```

Without changes:
```
playmer@Timestar:~/SDL_test/SDL$ time cmake -B build .
real    0m46.969s
user    0m6.005s
sys     0m3.781s
playmer@Timestar:~/SDL_test/SDL$ time cmake --build build -j8
real    0m11.172s
user    0m45.076s
sys     0m7.158s
playmer@Timestar:~/SDL_test/SDL$ nano include/SDL3/SDL.h
playmer@Timestar:~/SDL_test/SDL$ time cmake --build build -j8
real    0m7.622s
user    0m44.630s
sys     0m7.069s
```

