### PR TITLE
testffmpeg: avutil queue family version check

### DIFF
--- a/test/testffmpeg_vulkan.c
+++ b/test/testffmpeg_vulkan.c
@@ -679,7 +679,7 @@ void SetupVulkanRenderProperties(VulkanVideoContext *context, SDL_PropertiesID p
     SDL_SetNumberProperty(props, SDL_PROP_RENDERER_CREATE_VULKAN_GRAPHICS_QUEUE_FAMILY_INDEX_NUMBER, context->graphicsQueueFamilyIndex);
 }
 
-#if LIBAVUTIL_VERSION_MAJOR >= 59
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(59, 34, 100)
 static void AddQueueFamily(AVVulkanDeviceContext *ctx, int idx, int num, VkQueueFlagBits flags)
 {
     AVVulkanDeviceQueueFamily *entry = &ctx->qf[ctx->nb_qf++];
@@ -687,7 +687,7 @@ static void AddQueueFamily(AVVulkanDeviceContext *ctx, int idx, int num, VkQueue
     entry->num = num;
     entry->flags = flags;
 }
-#endif /* LIBAVUTIL_VERSION_MAJOR */
+#endif /* LIBAVUTIL_VERSION_INT */
 
 void SetupVulkanDeviceContextData(VulkanVideoContext *context, AVVulkanDeviceContext *ctx)
 {
@@ -700,7 +700,7 @@ void SetupVulkanDeviceContextData(VulkanVideoContext *context, AVVulkanDeviceCon
     ctx->nb_enabled_inst_extensions = context->instanceExtensionsCount;
     ctx->enabled_dev_extensions = context->deviceExtensions;
     ctx->nb_enabled_dev_extensions = context->deviceExtensionsCount;
-#if LIBAVUTIL_VERSION_MAJOR >= 59
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(59, 34, 100)
     AddQueueFamily(ctx, context->graphicsQueueFamilyIndex, context->graphicsQueueCount, VK_QUEUE_GRAPHICS_BIT);
     AddQueueFamily(ctx, context->transferQueueFamilyIndex, context->transferQueueCount, VK_QUEUE_TRANSFER_BIT);
     AddQueueFamily(ctx, context->computeQueueFamilyIndex, context->computeQueueCount, VK_QUEUE_COMPUTE_BIT);
@@ -716,7 +716,7 @@ void SetupVulkanDeviceContextData(VulkanVideoContext *context, AVVulkanDeviceCon
     ctx->nb_encode_queues = 0;
     ctx->queue_family_decode_index = context->decodeQueueFamilyIndex;
     ctx->nb_decode_queues = context->decodeQueueCount;
-#endif /* LIBAVUTIL_VERSION_MAJOR */
+#endif /* LIBAVUTIL_VERSION_INT */
 }
 
 static int CreateCommandBuffers(VulkanVideoContext *context, SDL_Renderer *renderer)


### PR DESCRIPTION
The `AVVulkanDeviceQueueFamily` struct was introduced by libavutil 59.34.100: https://github.com/FFmpeg/FFmpeg/commit/13489c8a2154a2e0e8fd3c3c45f7856b4c3110b0 .

This test would fail to build with FFmpeg 7.0.3 "Dijkstra", for example flatpak `org.freedesktop.Platform//24.08`.

You can test this with:
```bash
flatpak install org.freedesktop.Sdk//24.08
flatpak run --filesystem="$(pwd)" org.freedesktop.Sdk//24.08 -c 'cmake -B _build_fp -G Ninja -DSDL_TESTS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON'
flatpak run --filesystem="$(pwd)" org.freedesktop.Sdk//24.08 -c 'cmake --build _build_fp'
SDL_LOGGING=system=debug flatpak run --devel --filesystem="$(pwd)" --device=dri --socket=wayland org.freedesktop.Sdk//24.08 -c './_build_fp/test/testffmpeg'
```