### PR TITLE
Allow Android to ignore unnecessary joysticks (like fingerprint sensors)

### DIFF
--- a/src/joystick/SDL_gamepad.c
+++ b/src/joystick/SDL_gamepad.c
@@ -2863,8 +2863,8 @@ bool SDL_ShouldIgnoreGamepad(Uint16 vendor_id, Uint16 product_id, Uint16 version
     }
 #endif
 
-    if (name && SDL_strcmp(name, "uinput-fpc") == 0) {
-        // The Google Pixel fingerprint sensor reports itself as a joystick
+    if (name && SDL_startswith(name, "uinput-")) {
+        // The Google Pixel fingerprint sensor, as well as other fingerprint sensors, reports itself as a joystick
         return true;
     }
 

--- a/src/joystick/android/SDL_sysjoystick.c
+++ b/src/joystick/android/SDL_sysjoystick.c
@@ -328,6 +328,10 @@ void Android_AddJoystick(int device_id, const char *name, const char *desc, int 
         goto done;
     }
 
+    if (SDL_ShouldIgnoreJoystick(vendor_id, product_id, 0, name)) {
+        goto done;
+    }
+
 #ifdef DEBUG_JOYSTICK
     SDL_Log("Joystick: %s, descriptor %s, vendor = 0x%.4x, product = 0x%.4x, %d axes, %d hats", name, desc, vendor_id, product_id, naxes, nhats);
 #endif


### PR DESCRIPTION
## Description
Previously, `SDL_ShouldIgnoreJoystick` wasn't being called for Android, and fingerprint sensors were recognized as joysticks. I also decided to change the code a little bit so other fingerprint sensors (possible fingerprint sensors list here: https://github.com/godotengine/godot/issues/47656#issuecomment-2200419158) are ignored too. This change was tested using Godot Engine in my fork in a separate branch: https://github.com/Nintorch/godot/tree/sdl-test and I can confirm it works as expected.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/4971
