### PR TITLE
Fix vsync-off support for direct3d11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2172,6 +2172,7 @@ elseif(WINDOWS)
     #include <gameinput.h>
     int main(int argc, char **argv) { return 0; }" HAVE_GAMEINPUT_H
   )
+  check_include_file(dxgi1_5.h HAVE_DXGI1_5_H)
   check_include_file(dxgi1_6.h HAVE_DXGI1_6_H)
   check_include_file(tpcshrd.h HAVE_TPCSHRD_H)
   check_include_file(roapi.h HAVE_ROAPI_H)

--- a/include/build_config/SDL_build_config.h.cmake
+++ b/include/build_config/SDL_build_config.h.cmake
@@ -223,6 +223,7 @@
 #cmakedefine HAVE_WINDOWS_GAMING_INPUT_H 1
 #cmakedefine HAVE_GAMEINPUT_H 1
 #cmakedefine HAVE_DXGI_H 1
+#cmakedefine HAVE_DXGI1_5_H 1
 #cmakedefine HAVE_DXGI1_6_H 1
 
 #cmakedefine HAVE_MMDEVICEAPI_H 1

--- a/include/build_config/SDL_build_config_windows.h
+++ b/include/build_config/SDL_build_config_windows.h
@@ -85,6 +85,7 @@ typedef unsigned int uintptr_t;
 #define HAVE_DXGI_H 1
 #define HAVE_XINPUT_H 1
 #if defined(_WIN32_MAXVER) && _WIN32_MAXVER >= 0x0A00  /* Windows 10 SDK */
+#define HAVE_DXGI1_5_H 1
 #define HAVE_DXGI1_6_H 1
 #define HAVE_WINDOWS_GAMING_INPUT_H 1
 #endif

--- a/include/build_config/SDL_build_config_wingdk.h
+++ b/include/build_config/SDL_build_config_wingdk.h
@@ -37,6 +37,7 @@
 #define HAVE_DSOUND_H 1
 /* No SDK version checks needed for these because the SDK has to be new. */
 #define HAVE_DXGI_H 1
+#define HAVE_DXGI1_5_H 1
 #define HAVE_DXGI1_6_H 1
 #define HAVE_XINPUT_H 1
 #define HAVE_WINDOWS_GAMING_INPUT_H 1


### PR DESCRIPTION
This PR fixes vsync-off support for direct3d11 by adding the appropriate swap chain and present flags, similar to direct3d12.

## Description
There are details about the flags [here](https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/dxgi-present), under the `DXGI_PRESENT_ALLOW_TEARING` section. These flags are also a [requirement for VRR displays](https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/variable-refresh-rate-displays).

This is easy to check by running `testsprite` with an overlay like PresentMon, and then observing the framerate. Before this PR, the framerate was limited to the monitor's refresh rate. This resulted in significant input latency which is now reduced in vsync-off / high framerate conditions (measured with a hardware latency analyzer).

The `CheckFeatureSupport` method wasn't added until `dxgi1_5.h`, so an additional check is made for this header, falling back to the previous vsync-off behavior if only `dxgi1_4.h` is available.

## Existing Issue(s)
None.
