### PR TITLE
GPU/vulkan : fix indexing error for resolve attachment references

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -6065,7 +6065,6 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
         colorAttachmentReferences[colorAttachmentReferenceCount].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
         attachmentDescriptionCount += 1;
-        colorAttachmentReferenceCount += 1;
 
         if (colorTargetInfos[i].store_op == SDL_GPU_STOREOP_RESOLVE || colorTargetInfos[i].store_op == SDL_GPU_STOREOP_RESOLVE_AND_STORE) {
             VulkanTextureContainer *resolveContainer = (VulkanTextureContainer *)colorTargetInfos[i].resolve_texture;
@@ -6080,12 +6079,16 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
             attachmentDescriptions[attachmentDescriptionCount].initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
             attachmentDescriptions[attachmentDescriptionCount].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-            resolveReferences[resolveReferenceCount].attachment = attachmentDescriptionCount;
-            resolveReferences[resolveReferenceCount].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+            resolveReferences[colorAttachmentReferenceCount].attachment = attachmentDescriptionCount;
+            resolveReferences[colorAttachmentReferenceCount].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
             attachmentDescriptionCount += 1;
             resolveReferenceCount += 1;
+        } else {
+            resolveReferences[colorAttachmentReferenceCount].attachment = VK_ATTACHMENT_UNUSED;
         }
+
+        colorAttachmentReferenceCount += 1;
     }
 
     subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The [description of VkSubpassDescription](https://registry.khronos.org/vulkan/specs/latest/man/html/VkSubpassDescription.html) states that the subpass `pResolveAttachments` is an array _of the same size_ as the `pColorAttachments` array (the color attachment references), each resolve reference corresponds to the color attachment in the same index in the latter array. When a color attachment has no resolve operation, the `attachment` member of the `VkAttachmentReference` must be `VK_ATTACHMENT_UNUSED`.

The current code is incorrect as it seems to assume the `pResolveAttachments` array is of different length.

This results in the following bug when one uses multi-render targets: When there are 2 MRTs, **MRT#0** is a multisample texture with no resolve texture (and whatever store op) and **MRT#1** is a multisample texture with a resolve texture and resolve op, _the current code resolves **MRT#0** into the resolve texture of **MRT#1**_.  
This happens in my workflow because I have a forward rendering pipeline with some deferred effects, and e.g. my normals map in the G-buffer needs to be resolved before being sent to the relevant effects shaders.

This PR fixes the code in `SDL_gpu_vulkan.c` as to align to the Vulkan spec, and fixes the observed bug. If the maintainers need a MWE I could provide one.