### PR TITLE
gpu: D3D12 only requires feature level 11_0.

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -235,7 +235,8 @@
  * SDL driver name: "direct3d12"
  *
  * Supported on Windows 10 or newer, Xbox One (GDK), and Xbox Series X|S
- * (GDK). Requires a GPU that supports DirectX 12 Feature Level 11_1.
+ * (GDK). Requires a GPU that supports DirectX 12 Feature Level 11_0 and
+ * Resource Binding Tier 2 or above.
  *
  * ### Metal
  *


### PR DESCRIPTION
We previously thought this wasn't possible because constant buffer offsets and partial updates were unavailable, but we were reading the wrong table - this is only the case for D3D11...

https://learn.microsoft.com/en-us/windows/win32/direct3d11/overviews-direct3d-11-devices-downlevel-intro

... while 12 doesn't list this feature at all:

https://learn.microsoft.com/en-us/windows/win32/direct3d12/hardware-feature-levels

We double checked and Jesse Natalie confirmed that this feature is required for D3D12 even for 11_0 drivers. (Thanks Jesse!)