### PR TITLE
gpu: D3D12 only requires feature level 11_0 with Resource Binding Tier 2

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -224,8 +224,8 @@
  * - `drawIndirectFirstInstance`
  *
  * **D3D12:** Supported on Windows 10 or newer, Xbox One (GDK), and Xbox
- * Series X|S (GDK). Requires a GPU that supports DirectX 12 Feature Level
- * 11_1.
+ * Series X|S (GDK). Requires a GPU that supports DirectX 12 Feature Level 11_0 and
+ * Resource Binding Tier 2 or above.
  *
  * **Metal:** Supported on macOS 10.14+ and iOS/tvOS 13.0+. Hardware
  * requirements vary by operating system:

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -109,8 +109,8 @@
 #define DXGI_GET_DEBUG_INTERFACE_FUNC       "DXGIGetDebugInterface"
 #define D3D12_GET_DEBUG_INTERFACE_FUNC      "D3D12GetDebugInterface"
 #define WINDOW_PROPERTY_DATA                "SDL_GPUD3D12WindowPropertyData"
-#define D3D_FEATURE_LEVEL_CHOICE            D3D_FEATURE_LEVEL_11_1
-#define D3D_FEATURE_LEVEL_CHOICE_STR        "11_1"
+#define D3D_FEATURE_LEVEL_CHOICE            D3D_FEATURE_LEVEL_11_0
+#define D3D_FEATURE_LEVEL_CHOICE_STR        "11_0"
 #define MAX_ROOT_SIGNATURE_PARAMETERS         64
 #define D3D12_FENCE_UNSIGNALED_VALUE          0
 #define D3D12_FENCE_SIGNAL_VALUE              1
@@ -8353,6 +8353,7 @@ static bool D3D12_PrepareDriver(SDL_VideoDevice *_this)
     IDXGIFactory4 *factory4;
     IDXGIFactory6 *factory6;
     IDXGIAdapter1 *adapter;
+    bool supports_64UAVs = false;
 
     // Can we load D3D12?
 
@@ -8441,11 +8442,38 @@ static bool D3D12_PrepareDriver(SDL_VideoDevice *_this)
         return false;
     }
 
+    SDL_COMPILE_TIME_ASSERT(featurelevel, D3D_FEATURE_LEVEL_CHOICE < D3D_FEATURE_LEVEL_11_1);
+
+    // Check feature level 11_1 first, guarantees 64+ UAVs unlike 11_0 Tier1
     res = D3D12CreateDeviceFunc(
         (IUnknown *)adapter,
-        D3D_FEATURE_LEVEL_CHOICE,
+        D3D_FEATURE_LEVEL_11_1,
         D3D_GUID(D3D_IID_ID3D12Device),
         (void **)&device);
+
+    if (SUCCEEDED(res)) {
+        supports_64UAVs = true;
+    } else {
+        res = D3D12CreateDeviceFunc(
+            (IUnknown *)adapter,
+            D3D_FEATURE_LEVEL_CHOICE,
+            D3D_GUID(D3D_IID_ID3D12Device),
+            (void **)&device);
+
+        if (SUCCEEDED(res)) {
+            D3D12_FEATURE_DATA_D3D12_OPTIONS featureOptions;
+            SDL_zero(featureOptions);
+
+            res = ID3D12Device_CheckFeatureSupport(
+                device,
+                D3D12_FEATURE_D3D12_OPTIONS,
+                &featureOptions,
+                sizeof(featureOptions));
+            if (SUCCEEDED(res) && featureOptions.ResourceBindingTier >= D3D12_RESOURCE_BINDING_TIER_2) {
+                supports_64UAVs = true;
+            }
+        }
+    }
 
     if (SUCCEEDED(res)) {
         ID3D12Device_Release(device);
@@ -8455,6 +8483,11 @@ static bool D3D12_PrepareDriver(SDL_VideoDevice *_this)
 
     SDL_UnloadObject(d3d12Dll);
     SDL_UnloadObject(dxgiDll);
+
+    if (!supports_64UAVs) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "D3D12: Tier 2 Resource binding is not supported");
+        return false;
+    }
 
     if (FAILED(res)) {
         SDL_LogWarn(SDL_LOG_CATEGORY_GPU, "D3D12: Could not create D3D12Device with feature level " D3D_FEATURE_LEVEL_CHOICE_STR);


### PR DESCRIPTION
This is equivalent to https://github.com/libsdl-org/SDL/pull/13781 but it didn't cherry-pick cleanly due to differences between 3.2 and 3.4. 