### PR TITLE
win32: replace deprecated LoadCursor api with LoadImage+LR_SHARED flag

### DIFF
--- a/src/video/windows/SDL_windowsmouse.c
+++ b/src/video/windows/SDL_windowsmouse.c
@@ -343,7 +343,7 @@ static SDL_Cursor *WIN_CreateSystemCursor(SDL_SystemCursor id)
         name = IDC_SIZEWE;
         break;
     }
-    return WIN_CreateCursorAndData(LoadCursor(NULL, name));
+    return WIN_CreateCursorAndData(LoadImage(NULL, name, IMAGE_CURSOR, 0, 0, LR_SHARED));
 }
 
 static SDL_Cursor *WIN_CreateDefaultCursor(void)


### PR DESCRIPTION
According to [MSDN:](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-loadcursora)

> This function has been superseded by the [LoadImage](https://learn.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-loadimagea) function (with LR_DEFAULTSIZE and LR_SHARED flags set).

