### PR TITLE
Surface: Treat SDL_FlipMode as flags

### DIFF
--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -1400,6 +1400,8 @@ SDL_RenderReadPixels() returns a surface instead of filling in preallocated memo
 
 SDL_RenderSetLogicalSize() (now called SDL_SetRenderLogicalPresentation()) in SDL2 would modify the scaling and viewport state. In SDL3, logical presentation maintains its state separately, so the app can use its own viewport and scaling while also setting a logical size.
 
+SDL_RendererFlip has been renamed to SDL_FlipMode and moved to SDL_surface.h, is now Uint32 and the SDL_FLIP_* constants are now defines instead of an enum.
+
 The following functions have been renamed:
 * SDL_GetRendererOutputSize() => SDL_GetCurrentRenderOutputSize(), returns bool
 * SDL_RenderCopy() => SDL_RenderTexture(), returns bool
@@ -1448,7 +1450,7 @@ The following functions have been removed:
 * SDL_SetTextureUserData() - use SDL_GetTextureProperties() instead
 
 The following enums have been renamed:
-* SDL_RendererFlip => SDL_FlipMode - moved to SDL_surface.h
+* SDL_RendererFlip => SDL_FlipMode - moved to SDL_surface.h 
 
 The following symbols have been renamed:
 * SDL_ScaleModeLinear => SDL_SCALEMODE_LINEAR

--- a/include/SDL3/SDL_surface.h
+++ b/include/SDL3/SDL_surface.h
@@ -94,12 +94,11 @@ typedef enum SDL_ScaleMode
  *
  * \since This enum is available since SDL 3.2.0.
  */
-typedef enum SDL_FlipMode
-{
-    SDL_FLIP_NONE,          /**< Do not flip */
-    SDL_FLIP_HORIZONTAL,    /**< flip horizontally */
-    SDL_FLIP_VERTICAL       /**< flip vertically */
-} SDL_FlipMode;
+typedef Uint32 SDL_FlipMode;
+
+#define SDL_FLIP_NONE          0x00000000u  /**< Do not flip */
+#define SDL_FLIP_HORIZONTAL    0x00000001u  /**< flip horizontally */
+#define SDL_FLIP_VERTICAL      0x00000002u  /**< flip vertically */
 
 #ifndef SDL_INTERNAL
 


### PR DESCRIPTION
SDL_FlipMode is used like flags, but is defined as a enum. This PR brings the definition style in line with the other flag types.

## Description
Changed the definition of `SDL_FlipMode` in SDL_surface.h to be defines to reflect its flags-like use. Migration doc has been updated to reflect the change as well.

## Existing Issue(s)
#13273
