### PR TITLE
keyboard: Release bound keymaps during the destruction process

### DIFF
--- a/src/events/SDL_keymap.c
+++ b/src/events/SDL_keymap.c
@@ -207,6 +207,10 @@ void SDL_DestroyKeymap(SDL_Keymap *keymap)
         return;
     }
 
+    if (keymap == SDL_GetCurrentKeymap(true)) {
+        SDL_SetKeymap(NULL, false);
+    }
+
     SDL_DestroyHashTable(keymap->scancode_to_keycode);
     SDL_DestroyHashTable(keymap->keycode_to_scancode);
     SDL_free(keymap);

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -2258,7 +2258,6 @@ static void Wayland_SeatDestroyKeyboard(SDL_WaylandSeat *seat, bool send_event)
     if (seat->keyboard.sdl_keymap) {
         if (seat->keyboard.xkb.current_layout < seat->keyboard.xkb.num_layouts &&
             seat->keyboard.sdl_keymap[seat->keyboard.xkb.current_layout] == SDL_GetCurrentKeymap(true)) {
-            SDL_SetKeymap(NULL, false);
             SDL_SetModState(SDL_KMOD_NONE);
         }
         for (xkb_layout_index_t i = 0; i < seat->keyboard.xkb.num_layouts; ++i) {

--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -240,7 +240,6 @@ void WIN_QuitKeyboard(SDL_VideoDevice *_this)
     }
 #endif // !SDL_DISABLE_WINDOWS_IME
 
-    SDL_SetKeymap(NULL, false);
     for (int i = 0; i < keymap_cache_size; ++i) {
         SDL_DestroyKeymap(keymap_cache[i].keymap);
     }

--- a/src/video/x11/SDL_x11keyboard.c
+++ b/src/video/x11/SDL_x11keyboard.c
@@ -380,7 +380,6 @@ void X11_UpdateKeymap(SDL_VideoDevice *_this, bool send_event)
     if (data->keyboard.xkb_enabled) {
         XkbStateRec state;
 
-        SDL_SetKeymap(NULL, false);
         for (unsigned int i = 0; i < XkbNumKbdGroups; ++i) {
             SDL_DestroyKeymap(data->keyboard.xkb.keymaps[i]);
             data->keyboard.xkb.keymaps[i] = SDL_CreateKeymap(false);
@@ -515,7 +514,6 @@ void X11_QuitKeyboard(SDL_VideoDevice *_this)
 
 #ifdef SDL_VIDEO_DRIVER_X11_HAS_XKBLIB
     if (data->keyboard.xkb_enabled) {
-        SDL_SetKeymap(NULL, false);
         for (int i = 0; i < XkbNumKbdGroups; ++i) {
             SDL_DestroyKeymap(data->keyboard.xkb.keymaps[i]);
             data->keyboard.xkb.keymaps[i] = NULL;


### PR DESCRIPTION
If a bound keymap is being destroyed, unbind it to ensure that the keyboard state won't be left pointing to an invalid keymap. Backends now no longer need to manually do this when destroying keymaps during keyboard removal and shutdown.

Closes #13749 
