### PR TITLE
keyboard: Fix infinite recursion during SDL_DestroyKeymap

### DIFF
--- a/src/events/SDL_keymap.c
+++ b/src/events/SDL_keymap.c
@@ -208,6 +208,7 @@ void SDL_DestroyKeymap(SDL_Keymap *keymap)
     }
 
     if (keymap == SDL_GetCurrentKeymap(true)) {
+        keymap->auto_release = false;
         SDL_SetKeymap(NULL, false);
     }
 


### PR DESCRIPTION
Recent commit 6516f7a9e8 introduced an infinite recursion, which occurs on SDL_Quit()
