### PR TITLE
Fixed bug #13794: prevent to use the onBackPressed callback API 

### DIFF
--- a/android-project/app/src/main/AndroidManifest.xml
+++ b/android-project/app/src/main/AndroidManifest.xml
@@ -71,6 +71,7 @@
         android:icon="@mipmap/ic_launcher"
         android:allowBackup="true"
         android:theme="@style/AppTheme"
+        android:enableOnBackInvokedCallback="false"
         android:hardwareAccelerated="true" >
 
         <!-- Example of setting SDL hints from AndroidManifest.xml:

--- a/test/android/cmake/AndroidManifest.xml.cmake
+++ b/test/android/cmake/AndroidManifest.xml.cmake
@@ -44,6 +44,7 @@
         android:label="@string/label"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
+        android:enableOnBackInvokedCallback="false"
         android:hardwareAccelerated="true">
         <activity
             android:name="@ANDROID_MANIFEST_PACKAGE@.SDLTestActivity"


### PR DESCRIPTION
Fixed bug #13794: prevent to use the onBackPressed callback API that is enabled on API36
