### PR TITLE
Renamed SDL_GPURenderStateDesc to SDL_GPURenderStateCreateInfo for consistency with GPU API conventions

### DIFF
--- a/include/SDL3/SDL_render.h
+++ b/include/SDL3/SDL_render.h
@@ -2809,18 +2809,14 @@ extern SDL_DECLSPEC bool SDLCALL SDL_SetDefaultTextureScaleMode(SDL_Renderer *re
 extern SDL_DECLSPEC bool SDLCALL SDL_GetDefaultTextureScaleMode(SDL_Renderer *renderer, SDL_ScaleMode *scale_mode);
 
 /**
- * GPU render state description.
- *
- * This structure should be initialized using SDL_INIT_INTERFACE().
+ * A structure specifying the parameters of a GPU render state.
  *
  * \since This struct is available since SDL 3.4.0.
  *
  * \sa SDL_CreateGPURenderState
  */
-typedef struct SDL_GPURenderStateDesc
+typedef struct SDL_GPURenderStateCreateInfo
 {
-    Uint32 version;                 /**< the version of this interface */
-
     SDL_GPUShader *fragment_shader; /**< The fragment shader to use when this render state is active */
 
     Sint32 num_sampler_bindings;    /**< The number of additional fragment samplers to bind when this render state is active */
@@ -2829,19 +2825,11 @@ typedef struct SDL_GPURenderStateDesc
     Sint32 num_storage_textures;    /**< The number of storage textures to bind when this render state is active */
     SDL_GPUTexture *const *storage_textures;    /**< Storage textures to bind when this render state is active */
 
-    Sint32 num_storage_buffers;    /**< The number of storage buffers to bind when this render state is active */
+    Sint32 num_storage_buffers;     /**< The number of storage buffers to bind when this render state is active */
     SDL_GPUBuffer *const *storage_buffers;      /**< Storage buffers to bind when this render state is active */
-} SDL_GPURenderStateDesc;
 
-/* Check the size of SDL_GPURenderStateDesc
- *
- * If this assert fails, either the compiler is padding to an unexpected size,
- * or the interface has been updated and this should be updated to match and
- * the code using this interface should be updated to handle the old version.
- */
-SDL_COMPILE_TIME_ASSERT(SDL_GPURenderStateDesc_SIZE,
-    (sizeof(void *) == 4 && sizeof(SDL_GPURenderStateDesc) == 32) ||
-    (sizeof(void *) == 8 && sizeof(SDL_GPURenderStateDesc) == 64));
+    SDL_PropertiesID props;         /**< A properties ID for extensions. Should be 0 if no extensions are needed. */
+} SDL_GPURenderStateCreateInfo;
 
 /**
  * A custom GPU render state.
@@ -2859,8 +2847,7 @@ typedef struct SDL_GPURenderState SDL_GPURenderState;
  * Create custom GPU render state.
  *
  * \param renderer the renderer to use.
- * \param desc GPU render state description, initialized using
- *             SDL_INIT_INTERFACE().
+ * \param createinfo a struct describing the GPU render state to create.
  * \returns a custom GPU render state or NULL on failure; call SDL_GetError()
  *          for more information.
  *
@@ -2873,7 +2860,7 @@ typedef struct SDL_GPURenderState SDL_GPURenderState;
  * \sa SDL_SetRenderGPUState
  * \sa SDL_DestroyGPURenderState
  */
-extern SDL_DECLSPEC SDL_GPURenderState * SDLCALL SDL_CreateGPURenderState(SDL_Renderer *renderer, SDL_GPURenderStateDesc *desc);
+extern SDL_DECLSPEC SDL_GPURenderState * SDLCALL SDL_CreateGPURenderState(SDL_Renderer *renderer, SDL_GPURenderStateCreateInfo *createinfo);
 
 /**
  * Set fragment shader uniform variables in a custom GPU render state.

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -1271,7 +1271,7 @@ SDL_DYNAPI_PROC(bool,SDL_SetRelativeMouseTransform,(SDL_MouseMotionTransformCall
 SDL_DYNAPI_PROC(bool,SDL_RenderTexture9GridTiled,(SDL_Renderer *a,SDL_Texture *b,const SDL_FRect *c,float d,float e,float f,float g,float h,const SDL_FRect *i,float j),(a,b,c,d,e,f,g,h,i,j),return)
 SDL_DYNAPI_PROC(bool,SDL_SetDefaultTextureScaleMode,(SDL_Renderer *a,SDL_ScaleMode b),(a,b),return)
 SDL_DYNAPI_PROC(bool,SDL_GetDefaultTextureScaleMode,(SDL_Renderer *a,SDL_ScaleMode *b),(a,b),return)
-SDL_DYNAPI_PROC(SDL_GPURenderState*,SDL_CreateGPURenderState,(SDL_Renderer *a,SDL_GPURenderStateDesc *b),(a,b),return)
+SDL_DYNAPI_PROC(SDL_GPURenderState*,SDL_CreateGPURenderState,(SDL_Renderer *a,SDL_GPURenderStateCreateInfo *b),(a,b),return)
 SDL_DYNAPI_PROC(bool,SDL_SetGPURenderStateFragmentUniforms,(SDL_GPURenderState *a,Uint32 b,const void *c,Uint32 d),(a,b,c,d),return)
 SDL_DYNAPI_PROC(bool,SDL_SetRenderGPUState,(SDL_Renderer *a,SDL_GPURenderState *b),(a,b),return)
 SDL_DYNAPI_PROC(void,SDL_DestroyGPURenderState,(SDL_GPURenderState *a),(a),)

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -5948,23 +5948,17 @@ bool SDL_GetDefaultTextureScaleMode(SDL_Renderer *renderer, SDL_ScaleMode *scale
     return true;
 }
 
-SDL_GPURenderState *SDL_CreateGPURenderState(SDL_Renderer *renderer, SDL_GPURenderStateDesc *desc)
+SDL_GPURenderState *SDL_CreateGPURenderState(SDL_Renderer *renderer, SDL_GPURenderStateCreateInfo *createinfo)
 {
     CHECK_RENDERER_MAGIC(renderer, NULL);
 
-    if (!desc) {
-        SDL_InvalidParamError("desc");
+    if (!createinfo) {
+        SDL_InvalidParamError("createinfo");
         return NULL;
     }
 
-    if (desc->version < sizeof(*desc)) {
-        // Update this to handle older versions of this interface
-        SDL_SetError("Invalid desc, should be initialized with SDL_INIT_INTERFACE()");
-        return NULL;
-    }
-
-    if (!desc->fragment_shader) {
-        SDL_SetError("desc->fragment_shader is required");
+    if (!createinfo->fragment_shader) {
+        SDL_SetError("A fragment_shader is required");
         return NULL;
     }
 
@@ -5980,36 +5974,36 @@ SDL_GPURenderState *SDL_CreateGPURenderState(SDL_Renderer *renderer, SDL_GPURend
     }
 
     state->renderer = renderer;
-    state->fragment_shader = desc->fragment_shader;
+    state->fragment_shader = createinfo->fragment_shader;
 
-    if (desc->num_sampler_bindings > 0) {
-        state->sampler_bindings = (SDL_GPUTextureSamplerBinding *)SDL_calloc(desc->num_sampler_bindings, sizeof(*state->sampler_bindings));
+    if (createinfo->num_sampler_bindings > 0) {
+        state->sampler_bindings = (SDL_GPUTextureSamplerBinding *)SDL_calloc(createinfo->num_sampler_bindings, sizeof(*state->sampler_bindings));
         if (!state->sampler_bindings) {
             SDL_DestroyGPURenderState(state);
             return NULL;
         }
-        SDL_memcpy(state->sampler_bindings, desc->sampler_bindings, desc->num_sampler_bindings * sizeof(*state->sampler_bindings));
-        state->num_sampler_bindings = desc->num_sampler_bindings;
+        SDL_memcpy(state->sampler_bindings, createinfo->sampler_bindings, createinfo->num_sampler_bindings * sizeof(*state->sampler_bindings));
+        state->num_sampler_bindings = createinfo->num_sampler_bindings;
     }
 
-    if (desc->num_storage_textures > 0) {
-        state->storage_textures = (SDL_GPUTexture **)SDL_calloc(desc->num_storage_textures, sizeof(*state->storage_textures));
+    if (createinfo->num_storage_textures > 0) {
+        state->storage_textures = (SDL_GPUTexture **)SDL_calloc(createinfo->num_storage_textures, sizeof(*state->storage_textures));
         if (!state->storage_textures) {
             SDL_DestroyGPURenderState(state);
             return NULL;
         }
-        SDL_memcpy(state->storage_textures, desc->storage_textures, desc->num_storage_textures * sizeof(*state->storage_textures));
-        state->num_storage_textures = desc->num_storage_textures;
+        SDL_memcpy(state->storage_textures, createinfo->storage_textures, createinfo->num_storage_textures * sizeof(*state->storage_textures));
+        state->num_storage_textures = createinfo->num_storage_textures;
     }
 
-    if (desc->num_storage_buffers > 0) {
-        state->storage_buffers = (SDL_GPUBuffer **)SDL_calloc(desc->num_storage_buffers, sizeof(*state->storage_buffers));
+    if (createinfo->num_storage_buffers > 0) {
+        state->storage_buffers = (SDL_GPUBuffer **)SDL_calloc(createinfo->num_storage_buffers, sizeof(*state->storage_buffers));
         if (!state->storage_buffers) {
             SDL_DestroyGPURenderState(state);
             return NULL;
         }
-        SDL_memcpy(state->storage_buffers, desc->storage_buffers, desc->num_storage_buffers * sizeof(*state->storage_buffers));
-        state->num_storage_buffers = desc->num_storage_buffers;
+        SDL_memcpy(state->storage_buffers, createinfo->storage_buffers, createinfo->num_storage_buffers * sizeof(*state->storage_buffers));
+        state->num_storage_buffers = createinfo->num_storage_buffers;
     }
 
     return state;

--- a/test/testgpurender_effects.c
+++ b/test/testgpurender_effects.c
@@ -46,7 +46,7 @@ typedef enum
     NUM_EFFECTS
 } FullscreenEffect;
 
-typedef struct 
+typedef struct
 {
     const char *name;
     const unsigned char *dxil_shader_source;
@@ -61,7 +61,7 @@ typedef struct
     SDL_GPURenderState *state;
 } FullscreenEffectData;
 
-typedef struct  
+typedef struct
 {
     float texture_width;
     float texture_height;
@@ -145,7 +145,7 @@ static bool InitGPURenderState(void)
 {
     SDL_GPUShaderFormat formats;
     SDL_GPUShaderCreateInfo info;
-    SDL_GPURenderStateDesc desc;
+    SDL_GPURenderStateCreateInfo createinfo;
     int i;
 
     formats = SDL_GetGPUShaderFormats(device);
@@ -187,9 +187,9 @@ static bool InitGPURenderState(void)
             return false;
         }
 
-        SDL_INIT_INTERFACE(&desc);
-        desc.fragment_shader = data->shader;
-        data->state = SDL_CreateGPURenderState(renderer, &desc);
+        SDL_zero(createinfo);
+        createinfo.fragment_shader = data->shader;
+        data->state = SDL_CreateGPURenderState(renderer, &createinfo);
         if (!data->state) {
             SDL_Log("Couldn't create render state: %s", SDL_GetError());
             return false;

--- a/test/testgpurender_msdf.c
+++ b/test/testgpurender_msdf.c
@@ -164,7 +164,7 @@ static bool InitGPURenderState(void)
 {
     SDL_GPUShaderFormat formats;
     SDL_GPUShaderCreateInfo info;
-    SDL_GPURenderStateDesc desc;
+    SDL_GPURenderStateCreateInfo createinfo;
     MSDFShaderUniforms uniforms;
 
     device = (SDL_GPUDevice *)SDL_GetPointerProperty(SDL_GetRendererProperties(renderer), SDL_PROP_RENDERER_GPU_DEVICE_POINTER, NULL);
@@ -205,9 +205,9 @@ static bool InitGPURenderState(void)
         return false;
     }
 
-    SDL_INIT_INTERFACE(&desc);
-    desc.fragment_shader = shader;
-    render_state = SDL_CreateGPURenderState(renderer, &desc);
+    SDL_zero(createinfo);
+    createinfo.fragment_shader = shader;
+    render_state = SDL_CreateGPURenderState(renderer, &createinfo);
     if (!render_state) {
         SDL_Log("Couldn't create render state: %s", SDL_GetError());
         return false;


### PR DESCRIPTION
Fixes https://github.com/libsdl-org/SDL/issues/12817