### PR TITLE
fix wrong index in HandleStatePacket with flydigi controller

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_flydigi.c
+++ b/src/joystick/hidapi/SDL_hidapi_flydigi.c
@@ -323,7 +323,7 @@ static void HIDAPI_DriverFlydigi_HandleStatePacket(SDL_Joystick *joystick, SDL_D
 {
     Sint16 axis;
     Uint64 timestamp = SDL_GetTicksNS();
-    if (data[0] != 0x04 && data[1] != 0xFE) {
+    if (data[0] != 0x04 || data[1] != 0xFE) {
         // We don't know how to handle this report
         return;
     }


### PR DESCRIPTION
fix a wrong index checked with packet from flydigi controller.

## Description
the operation packet from flydigi controller is started with 0x04 0xfe .
when handle it in function HandleStatePacket. used wrong index for check 0xfe. so when people use flydigi official application , the response ack started with 0x04 0xff will be recongized to operation wrong.
![20250828-174832](https://github.com/user-attachments/assets/dbc1bcf4-ddb9-4ea6-baab-f6bc9f1ddec1)
