### PR TITLE
Avoid checking for `HAVE_POSIX_SPAWN` on Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3397,7 +3397,7 @@ if(WINDOWS)
   )
   set(SDL_PROCESS_WINDOWS 1)
   set(HAVE_SDL_PROCESS TRUE)
-else()
+elseif(NOT ANDROID)
   check_c_source_compiles("
 #include <spawn.h>
 #include <unistd.h>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This hack makes the CMake build closer to `SDL_build_config_android.h` as both will now use `SDL_PROCESS_DUMMY`.

Successful CI run that builds `SDL_dummyprocess.c` and not `SDL_posixprocess.c`: https://github.com/Susko3/SDL/actions/runs/17293554252/job/49086428379. (You can grep the raw logs to confirm.)

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->

- Closes https://github.com/libsdl-org/SDL/issues/13793#issuecomment-3221567261