### PR TITLE
Assert that `SDL_FlipMode` can be used as flags

### DIFF
--- a/include/SDL3/SDL_surface.h
+++ b/include/SDL3/SDL_surface.h
@@ -102,6 +102,8 @@ typedef enum SDL_FlipMode
     SDL_FLIP_HORIZONTAL_AND_VERTICAL,   /**< flip horizontally and vertically (not a diagonal flip) */
 } SDL_FlipMode;
 
+SDL_COMPILE_TIME_ASSERT(SDL_FlipMode_is_flags, (SDL_FLIP_HORIZONTAL | SDL_FLIP_VERTICAL) == SDL_FLIP_HORIZONTAL_AND_VERTICAL);
+
 #ifndef SDL_INTERNAL
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`SDL_FlipMode` is used internally in SDL rendering code as flags. Just grep for `SDL_FLIP_HORIZONTAL` and see all the `&` and `|=`. This assert just adds a check so that this won't break in the future.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->

- Fully addresses https://github.com/libsdl-org/SDL/issues/13273