### PR TITLE
Add SDL_SENSOR_COUNT to SDL_SensorType

### DIFF
--- a/include/SDL3/SDL_sensor.h
+++ b/include/SDL3/SDL_sensor.h
@@ -138,7 +138,8 @@ typedef enum SDL_SensorType
     SDL_SENSOR_ACCEL_L,         /**< Accelerometer for left Joy-Con controller and Wii nunchuk */
     SDL_SENSOR_GYRO_L,          /**< Gyroscope for left Joy-Con controller */
     SDL_SENSOR_ACCEL_R,         /**< Accelerometer for right Joy-Con controller */
-    SDL_SENSOR_GYRO_R           /**< Gyroscope for right Joy-Con controller */
+    SDL_SENSOR_GYRO_R,          /**< Gyroscope for right Joy-Con controller */
+    SDL_SENSOR_COUNT
 } SDL_SensorType;
 
 


### PR DESCRIPTION
Matches the convention set by other enum types within SDL, such as SDL_GamepadButton

## Description
This allows people to iterate over all sensor types explicitly. For me, this is to create a fast array lookup for each sensor type.
