### PR TITLE
wikiheaders: Escape backslash in man pages

### DIFF
--- a/build-scripts/wikiheaders.pl
+++ b/build-scripts/wikiheaders.pl
@@ -426,6 +426,7 @@ sub dewikify_chunk {
         }
     } elsif ($dewikify_mode eq 'manpage') {
         # make sure these can't become part of roff syntax.
+        $str =~ s/\\/\\(rs/gms;
         $str =~ s/\./\\[char46]/gms;
         $str =~ s/"/\\(dq/gms;
         $str =~ s/'/\\(aq/gms;


### PR DESCRIPTION
Otherwise, groff will interpret it as a macro, causing the man page for SDL_GetPrefPath() to be mis-rendered. Escape unescaped backslashes as `\(rs` ("reverse solidus") before escaping other characters with macros that, themselves, contain backslashes.

Resolves: https://github.com/libsdl-org/SDL/issues/13039