### PR TITLE
configure.ac: Fix AC_DEFINE HAVE_LIBUSB

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3635,7 +3635,7 @@ CheckHIDAPI()
 
         if test x$hidapi_support = xyes; then
             if test x$have_libusb_h = xyes; then
-                AC_DEFINE(HAVE_LIBUSB)
+                AC_DEFINE(HAVE_LIBUSB, 1, [ ])
                 EXTRA_CFLAGS="$EXTRA_CFLAGS $LIBUSB_CFLAGS"
                 if test x$require_hidapi_libusb = xyes; then
                     EXTRA_LDFLAGS="$EXTRA_LDFLAGS $LIBUSB_LIBS"


### PR DESCRIPTION
Fixes an error with autoconf 2.72

autoreconf previously failed with:

```
autoheader: warning: missing template: HAVE_LIBUSB
autoheader: warning: Use AC_DEFINE([HAVE_LIBUSB], [], [Description])
autoreconf: error: /usr/bin/autoheader failed with exit status: 1
```