### PR TITLE
Allow in-memory IOStreams to be of length 0

### DIFF
--- a/src/io/SDL_iostream.c
+++ b/src/io/SDL_iostream.c
@@ -925,11 +925,8 @@ SDL_IOStream *SDL_IOFromFile(const char *file, const char *mode)
 
 SDL_IOStream *SDL_IOFromMem(void *mem, size_t size)
 {
-    if (!mem) {
+    if (size && !mem) {
         SDL_InvalidParamError("mem");
-        return NULL;
-    } else if (!size) {
-        SDL_InvalidParamError("size");
         return NULL;
     }
 
@@ -966,11 +963,8 @@ SDL_IOStream *SDL_IOFromMem(void *mem, size_t size)
 
 SDL_IOStream *SDL_IOFromConstMem(const void *mem, size_t size)
 {
-    if (!mem) {
+    if (size && !mem) {
         SDL_InvalidParamError("mem");
-        return NULL;
-    } else if (!size) {
-        SDL_InvalidParamError("size");
         return NULL;
     }
 


### PR DESCRIPTION
Removed the arbitrary and unnecessarily restrictive limitation of in-memory IOStream instances being disallowed from having a length of 0. This is particularly problematic for the cases of creating a stream from a zero-length string & of creating an in-memory cache of an empty file. I looked at the internals and the implementation already prevents any access to the memory pointer if the length is zero, and even the pointer math being performed on the internal cursors work out to a correct result when the memory pointer is NULL. I even built and tested my own SDL3.dll with this change and everything worked fine.

In particular, the checks at the top of SDL_IOFromMem and SDL_IOFromConstMem have been changed to only emit an error in the case of the length being >0 *and also* the memory pointer being NULL, otherwise allowing the stream to be created as normal.