### PR TITLE
Add missing include

### DIFF
--- a/include/SDL3/SDL_hidapi.h
+++ b/include/SDL3/SDL_hidapi.h
@@ -55,6 +55,7 @@
 
 #include <SDL3/SDL_stdinc.h>
 #include <SDL3/SDL_error.h>
+#include <SDL3/SDL_properties.h>
 
 #include <SDL3/SDL_begin_code.h>
 /* Set up for C function definitions, even when using C++ */


### PR DESCRIPTION
This is needed after 65c1fc1b425c0459094e5bc7a8ed8411b5c13c11 which added a function that returns SDL_PropertiesID to SDL_hidapi.h