### PR TITLE
Fix crash when enumerating Steam Controllers

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1038,6 +1038,11 @@ static bool HIDAPI_DriverSteam_IsSupportedDevice(SDL_HIDAPI_Device *device, cons
         return false;
     }
 
+    if (!device) {
+        // Might be supported by this driver, enumerate and find out
+        return true;
+    }
+
     if (device->is_bluetooth) {
         return true;
     }


### PR DESCRIPTION
cherry-picking a commit from main so it will be in the next release

the issue that gets fixed wit the cherry-pick was is needed or steam controller connections can cause SDL segfaults

see
https://github.com/libsdl-org/SDL/commit/fe16c620d8722296f8956a7d27d657be65678e38
https://github.com/libsdl-org/SDL/pull/13746