### PR TITLE
x11: Fix build with -DSDL_X11_SHARED=OFF

### DIFF
--- a/src/video/x11/SDL_x11dyn.h
+++ b/src/video/x11/SDL_x11dyn.h
@@ -23,6 +23,11 @@
 #ifndef SDL_x11dyn_h_
 #define SDL_x11dyn_h_
 
+// Tell Xutil.h to provide symbol prototypes for external functions,
+// instead of just a #define for calling virtual methods through a pointer.
+// Otherwise we won't be able to take the address of XDestroyImage()
+#define XUTIL_DEFINE_FUNCTIONS
+
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/Xatom.h>

--- a/src/video/x11/SDL_x11framebuffer.c
+++ b/src/video/x11/SDL_x11framebuffer.c
@@ -239,7 +239,7 @@ void X11_DestroyWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window)
     display = data->videodata->display;
 
     if (data->ximage) {
-        XDestroyImage(data->ximage);
+        X11_XDestroyImage(data->ximage);
 
 #ifndef NO_SHARED_MEMORY
         if (data->use_mitshm) {


### PR DESCRIPTION
When linking directly to libX11 as a hard dependency, we assign the addresses of functions like XDestroyImage to function pointers like X11_XDestroyImage. However, by default Xutils.h doesn't declare XDestroyImage as a function: it only provides a macro which looks into the XImage struct and calls a function pointer directly, similar to a virtual method.

Tell the header to declare an exported function instead, the same as we would do via dlopen() or in a language that uses FFI, so that we can store a function pointer in the same way as all the other functions we call.

Having done this, we have to be consistent about always calling
X11_XDestroyImage() and never XDestroyImage(), so do that in
`SDL_x11framebuffer.c` as well.

Fixes: d14cbd7b "Introduce X11 toolkit and make message dialogs use it"