### PR TITLE
Consistently use SDL_PIXELFORMAT_RGBA32 with Emscripten

### DIFF
--- a/src/video/emscripten/SDL_emscriptenframebuffer.c
+++ b/src/video/emscripten/SDL_emscriptenframebuffer.c
@@ -30,7 +30,7 @@
 bool Emscripten_CreateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, SDL_PixelFormat *format, void **pixels, int *pitch)
 {
     SDL_Surface *surface;
-    const SDL_PixelFormat surface_format = SDL_PIXELFORMAT_XBGR8888;
+    const SDL_PixelFormat surface_format = SDL_PIXELFORMAT_RGBA32;
     int w, h;
 
     // Free the old framebuffer surface
@@ -89,54 +89,13 @@ bool Emscripten_UpdateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *wind
         }
         var data = SDL3.image.data;
         var src = pixels / 4;
-        var dst = 0;
-        var num;
 
         if (SDL3.data32Data !== data) {
             SDL3.data32 = new Int32Array(data.buffer);
-            SDL3.data8 = new Uint8Array(data.buffer);
             SDL3.data32Data = data;
         }
         var data32 = SDL3.data32;
-        num = data32.length;
-        // logically we need to do
-        //      while (dst < num) {
-        //          data32[dst++] = HEAP32[src++] | 0xff000000
-        //      }
-        // the following code is faster though, because
-        // .set() is almost free - easily 10x faster due to
-        // native SDL_memcpy efficiencies, and the remaining loop
-        // just stores, not load + store, so it is faster
-        data32.set(HEAP32.subarray(src, src + num));
-        var data8 = SDL3.data8;
-        var i = 3;
-        var j = i + 4 * num;
-        if (num % 8 == 0) {
-            // unrolling gives big speedups
-            while (i < j) {
-              data8[i] = 0xff;
-              i = i + 4 | 0;
-              data8[i] = 0xff;
-              i = i + 4 | 0;
-              data8[i] = 0xff;
-              i = i + 4 | 0;
-              data8[i] = 0xff;
-              i = i + 4 | 0;
-              data8[i] = 0xff;
-              i = i + 4 | 0;
-              data8[i] = 0xff;
-              i = i + 4 | 0;
-              data8[i] = 0xff;
-              i = i + 4 | 0;
-              data8[i] = 0xff;
-              i = i + 4 | 0;
-            }
-         } else {
-            while (i < j) {
-              data8[i] = 0xff;
-              i = i + 4 | 0;
-            }
-        }
+        data32.set(HEAP32.subarray(src, src + data32.length));
 
         SDL3.ctx.putImageData(SDL3.image, 0, 0);
     }, surface->w, surface->h, surface->pixels, data->canvas_id);

--- a/src/video/emscripten/SDL_emscriptenmouse.c
+++ b/src/video/emscripten/SDL_emscriptenmouse.c
@@ -74,7 +74,7 @@ static SDL_Cursor *Emscripten_CreateCursor(SDL_Surface *surface, int hot_x, int 
     const char *cursor_url = NULL;
     SDL_Surface *conv_surf;
 
-    conv_surf = SDL_ConvertSurface(surface, SDL_PIXELFORMAT_ABGR8888);
+    conv_surf = SDL_ConvertSurface(surface, SDL_PIXELFORMAT_RGBA32);
 
     if (!conv_surf) {
         return NULL;

--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -376,7 +376,7 @@ bool Emscripten_VideoInit(SDL_VideoDevice *_this)
 
     // Use a fake 32-bpp desktop mode
     SDL_zero(mode);
-    mode.format = SDL_PIXELFORMAT_XRGB8888;
+    mode.format = SDL_PIXELFORMAT_RGBA32;
     emscripten_get_screen_size(&mode.w, &mode.h);
     mode.pixel_density = emscripten_get_device_pixel_ratio();
 


### PR DESCRIPTION
- Specifying an alpha format for the framebuffer means that the alpha channel doesn't need to be set in `Emscripten_UpdateWindowFramebuffer`.
- Using `SDL_PIXELFORMAT_RGBA32` seems to be closer to what [the documentation](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas) says, which describes pixel data in terms of bytes rather than packed words.