### PR TITLE
Change the default YUV colorspace to SDL_COLORSPACE_BT601_LIMITED

### DIFF
--- a/include/SDL3/SDL_pixels.h
+++ b/include/SDL3/SDL_pixels.h
@@ -1096,7 +1096,7 @@ typedef enum SDL_Colorspace
                                  SDL_CHROMA_LOCATION_LEFT), */
 
     SDL_COLORSPACE_RGB_DEFAULT = SDL_COLORSPACE_SRGB, /**< The default colorspace for RGB surfaces if no colorspace is specified */
-    SDL_COLORSPACE_YUV_DEFAULT = SDL_COLORSPACE_JPEG  /**< The default colorspace for YUV surfaces if no colorspace is specified */
+    SDL_COLORSPACE_YUV_DEFAULT = SDL_COLORSPACE_BT601_LIMITED  /**< The default colorspace for YUV surfaces if no colorspace is specified */
 } SDL_Colorspace;
 
 /**


### PR DESCRIPTION
This was the default for SDL2 and what people expect, migrating code.

Fixes https://github.com/libsdl-org/SDL/issues/13796