### PR TITLE
Define the behavior of a negative width or height passed to SDL_RenderFillRect()

### DIFF
--- a/src/render/software/SDL_render_sw.c
+++ b/src/render/software/SDL_render_sw.c
@@ -220,9 +220,17 @@ static bool SW_QueueFillRects(SDL_Renderer *renderer, SDL_RenderCommand *cmd, co
 
     for (i = 0; i < count; i++, verts++, rects++) {
         verts->x = (int)rects->x;
+        verts->w = (int)rects->w;
+        if (verts->w < 0) {
+            verts->w = -verts->w;
+            verts->x -= verts->w;
+        }
         verts->y = (int)rects->y;
-        verts->w = SDL_max((int)rects->w, 1);
-        verts->h = SDL_max((int)rects->h, 1);
+        verts->h = (int)rects->h;
+        if (verts->h < 0) {
+            verts->h = -verts->h;
+            verts->y -= verts->h;
+        }
     }
 
     return true;

--- a/test/testautomation_render.c
+++ b/test/testautomation_render.c
@@ -124,16 +124,23 @@ static int SDLCALL render_testPrimitives(void *arg)
     rect.y = 0.0f;
     rect.w = 40.0f;
     rect.h = 80.0f;
-
     CHECK_FUNC(SDL_SetRenderDrawColor, (renderer, 13, 73, 200, SDL_ALPHA_OPAQUE))
     CHECK_FUNC(SDL_RenderFillRect, (renderer, &rect))
 
-    /* Draw a rectangle. */
+    /* Draw a rectangle with negative width and height. */
+    rect.x = 10.0f + 60.0f;
+    rect.y = 10.0f + 40.0f;
+    rect.w = -60.0f;
+    rect.h = -40.0f;
+    CHECK_FUNC(SDL_SetRenderDrawColor, (renderer, 200, 0, 100, SDL_ALPHA_OPAQUE))
+    CHECK_FUNC(SDL_RenderFillRect, (renderer, &rect))
+
+    /* Draw a rectangle with zero width and height. */
     rect.x = 10.0f;
     rect.y = 10.0f;
-    rect.w = 60.0f;
-    rect.h = 40.0f;
-    CHECK_FUNC(SDL_SetRenderDrawColor, (renderer, 200, 0, 100, SDL_ALPHA_OPAQUE))
+    rect.w = 0.0f;
+    rect.h = 0.0f;
+    CHECK_FUNC(SDL_SetRenderDrawColor, (renderer, 255, 0, 0, SDL_ALPHA_OPAQUE))
     CHECK_FUNC(SDL_RenderFillRect, (renderer, &rect))
 
     /* Draw some points like so:


### PR DESCRIPTION
The software renderer now matches the 3D renderer behavior by rendering a reversed rectangle (extending width or height in the opposite direction) when width or height is negative. It also now renders no rectangle if the width and height are 0.

Fixes https://github.com/libsdl-org/SDL/issues/13400