### PR TITLE
Removed reference to icon-alpha.bmp

### DIFF
--- a/test/testrendertarget.c
+++ b/test/testrendertarget.c
@@ -252,17 +252,17 @@ int main(int argc, char *argv[])
 
         drawstate->window = state->windows[i];
         drawstate->renderer = state->renderers[i];
-        if (test_composite) {
-            drawstate->sprite = LoadTexture(drawstate->renderer, "icon-alpha.bmp", true);
-        } else {
-            drawstate->sprite = LoadTexture(drawstate->renderer, "icon.bmp", true);
-        }
+        drawstate->sprite = LoadTexture(drawstate->renderer, "icon.bmp", true);
         drawstate->background = LoadTexture(drawstate->renderer, "sample.bmp", false);
         if (!drawstate->sprite || !drawstate->background) {
             quit(2);
         }
         SDL_GetTextureSize(drawstate->sprite, &drawstate->sprite_rect.w, &drawstate->sprite_rect.h);
         drawstate->scale_direction = 1;
+
+        if (test_composite) {
+            SDL_SetTextureAlphaMod(drawstate->sprite, 0x80);
+        }
     }
 
     /* Main render loop */


### PR DESCRIPTION
This file was never added, and I believe this just had a 50% alpha channel added to the standard icon.bmp

Fixes https://github.com/libsdl-org/SDL/issues/13394
