### PR TITLE
X11: Check for invalid opcodes in SHM error handler

### DIFF
--- a/src/video/x11/SDL_x11framebuffer.c
+++ b/src/video/x11/SDL_x11framebuffer.c
@@ -33,7 +33,7 @@ static int shm_error;
 static int (*X_handler)(Display *, XErrorEvent *) = NULL;
 static int shm_errhandler(Display *d, XErrorEvent *e)
 {
-    if (e->error_code == BadAccess) {
+    if (e->error_code == BadAccess || e->error_code == BadRequest) {
         shm_error = True;
         return 0;
     }


### PR DESCRIPTION
An alternative to #13747. Can you confirm if this fixes it @allelomorph?