### PR TITLE
Fix "HP Deluxe Webcam KQ246AA" webcam being detected as joystick

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -445,6 +445,7 @@ static Uint32 initial_blacklist_devices[] = {
     MAKE_VIDPID(0x26ce, 0x01a2), // ASRock LED Controller
     MAKE_VIDPID(0x20d6, 0x0002), // PowerA Enhanced Wireless Controller for Nintendo Switch (charging port only)
     MAKE_VIDPID(0x3434, 0x0211), // Keychron K1 Pro System Control
+    MAKE_VIDPID(0x04f2, 0xa13c), // HP Deluxe Webcam KQ246AA
 };
 static SDL_vidpid_list blacklist_devices = {
     SDL_HINT_JOYSTICK_BLACKLIST_DEVICES, 0, 0, NULL,


### PR DESCRIPTION
## Description
While testing [this issue found in Godot Engine](https://github.com/godotengine/godot/issues/108753), one of the users (goncalo) also reproduced the issue, but by connecting their webcam, which means the webcam gets recognized as a joystick. I added its vendor and product IDs to the blacklist devices list, I hope this should fix the issue.

If this PR is acceptable, I think it should be merged after https://github.com/libsdl-org/SDL/issues/13913 is resolved, because this webcam can reproduce said issue.

I will try to create a small .exe file to test this PR easily for goncalo later when they're available (if they want, of course) after the CI for this PR finishes.

## Existing Issue(s)
Fixes https://github.com/libsdl-org/SDL/issues/13914
