### PR TITLE
Fix reallocation of GPU renderer vertex buffer

### DIFF
--- a/src/render/gpu/SDL_render_gpu.c
+++ b/src/render/gpu/SDL_render_gpu.c
@@ -722,6 +722,8 @@ static bool InitVertexBuffer(GPU_RenderData *data, Uint32 size)
         return false;
     }
 
+    data->vertices.buffer_size = size;
+
     return true;
 }
 


### PR DESCRIPTION
Creating buffers in GPU is very expensive (NSight clocked around 1.5 ms in Debug for the CPU/GPU buffer). We need to make sure to set the size so that we don't reallocate each frame.

<img width="519" height="191" alt="image" src="https://github.com/user-attachments/assets/85007575-2977-431c-ba72-79885fa349f8" />
