### PR TITLE
[apple] Use productCategory instead of vendorName for joypad name

### DIFF
--- a/src/joystick/apple/SDL_mfijoystick.m
+++ b/src/joystick/apple/SDL_mfijoystick.m
@@ -300,8 +300,14 @@ static bool IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
      * struct, and ARC doesn't work with structs. */
     device->controller = (__bridge GCController *)CFBridgingRetain(controller);
 
-    if (controller.vendorName) {
-        name = controller.vendorName.UTF8String;
+    if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, *)) {
+        if (controller.productCategory) {
+            name = controller.productCategory.UTF8String;
+        }
+    } else {
+        if (controller.vendorName) {
+            name = controller.vendorName.UTF8String;
+        }
     }
 
     if (!name) {


### PR DESCRIPTION
The current macos joypad implementation uses vendorName as the joy name.

The vendorName on macos is just the local device name of the controller. This name can also be changed by the user by simply changing the name of the device in the Bluetooth settings. productCategory on the other hand always returns a more fitting unchanging device name.

So for example: If I connect my Switch Pro Controller that I renamed to "My amazing controller" to my laptop, vendorName is "My amazing controller", whereas e.g. on Windows it is set to "Nintendo Switch Pro Controller" (iirc). If the joy name was set to productCategory instead the result would be "Switch Pro Controller", which would help properly identify which controller is actually connected to the computer.

[Relevant Apple Docs](https://developer.apple.com/documentation/gamecontroller/gcdevice)