### PR TITLE
wayland: Silence unused variable warning

### DIFF
--- a/src/video/wayland/SDL_waylandmouse.c
+++ b/src/video/wayland/SDL_waylandmouse.c
@@ -1050,8 +1050,6 @@ void Wayland_RecreateCursors(void)
 void Wayland_InitMouse(void)
 {
     SDL_Mouse *mouse = SDL_GetMouse();
-    SDL_VideoDevice *vd = SDL_GetVideoDevice();
-    SDL_VideoData *d = vd->internal;
 
     mouse->CreateCursor = Wayland_CreateCursor;
     mouse->CreateSystemCursor = Wayland_CreateSystemCursor;
@@ -1100,7 +1098,10 @@ void Wayland_InitMouse(void)
     }
 
 #ifdef SDL_USE_LIBDBUS
-    /* The DBus cursor properties are only needed when manually loading themes and cursors.
+    SDL_VideoDevice *vd = SDL_GetVideoDevice();
+    SDL_VideoData *d = vd->internal;
+
+    /* The D-Bus cursor properties are only needed when manually loading themes and system cursors.
      * If the cursor shape protocol is present, the compositor will handle it internally.
      */
     if (!d->cursor_shape_manager) {


### PR DESCRIPTION
'vd' and 'd' are only used if SDL_USE_LIBDBUS is set.

```console
../src/video/wayland/SDL_waylandmouse.c: In function 'Wayland_InitMouse':
../src/video/wayland/SDL_waylandmouse.c:1054:20: warning: unused variable 'd' [-Wunused-variable]
 1054 |     SDL_VideoData *d = vd->internal;
      |                    ^
```