### PR TITLE
render: Render creation shouldn't set vsync if not explicitly requested.

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -1147,8 +1147,12 @@ SDL_Renderer *SDL_CreateRendererWithProperties(SDL_PropertiesID props)
         SDL_AddWindowEventWatch(SDL_WINDOW_EVENT_WATCH_NORMAL, SDL_RendererEventWatch, renderer);
     }
 
-    int vsync = (int)SDL_GetNumberProperty(props, SDL_PROP_RENDERER_CREATE_PRESENT_VSYNC_NUMBER, 0);
-    SDL_SetRenderVSync(renderer, vsync);
+    // use whatever the system default is if this property wasn't explicitly set.
+    if (SDL_HasProperty(props, SDL_PROP_RENDERER_CREATE_PRESENT_VSYNC_NUMBER)) {
+        const int vsync = (int)SDL_GetNumberProperty(props, SDL_PROP_RENDERER_CREATE_PRESENT_VSYNC_NUMBER, 0);
+        SDL_SetRenderVSync(renderer, vsync);
+    }
+
     SDL_CalculateSimulatedVSyncInterval(renderer, window);
 
     SDL_LogInfo(SDL_LOG_CATEGORY_RENDER,


### PR DESCRIPTION
This lets the platform use whatever it feels is a reasonable default (perhaps some global setting a user chose in a preference panel somewhere).

Also: it prevents Emscripten from changing its mainloop trigger if the app doesn't specifically care, preventing framerate issues and warnings in the console.

Fixes #12805.

(Posting as a PR for feedback, in case this has unforeseen circumstances.)