### PR TITLE
Introduce enum for SDL_AddGamepadMapping result

### DIFF
--- a/include/SDL3/SDL_gamepad.h
+++ b/include/SDL3/SDL_gamepad.h
@@ -298,6 +298,20 @@ typedef struct SDL_GamepadBinding
     } output;
 } SDL_GamepadBinding;
 
+/**
+ * Possible return values from calling SDL_AddGamepadMapping.
+ *
+ * \since This enum is available since SDL 3.4.0.
+ *
+ * \sa SDL_AddGamepadMapping
+ */
+typedef enum SDL_GamepadAddMappingResult
+{
+    SDL_GAMEPAD_ADD_MAPPING_FAILED = -1,
+    SDL_GAMEPAD_ADD_MAPPING_UPDATED,
+    SDL_GAMEPAD_ADD_MAPPING_ADDED,
+} SDL_GamepadAddMappingResult;
+
 
 /**
  * Add support for gamepads that SDL is unaware of or change the binding of an
@@ -325,13 +339,16 @@ typedef struct SDL_GamepadBinding
  * ```
  *
  * \param mapping the mapping string.
- * \returns 1 if a new mapping is added, 0 if an existing mapping is updated,
- *          -1 on failure; call SDL_GetError() for more information.
+ * \returns SDL_GAMEPAD_ADD_MAPPING_ADDED if a new mapping is added,
+ *          SDL_GAMEPAD_ADD_MAPPING_UPDATED if an existing mapping is updated,
+ *          SDL_GAMEPAD_ADD_MAPPING_FAILED on failure; call SDL_GetError() for
+ *          more information.
  *
  * \threadsafety It is safe to call this function from any thread.
  *
  * \since This function is available since SDL 3.2.0.
  *
+ * \sa SDL_GamepadAddMappingResult
  * \sa SDL_AddGamepadMappingsFromFile
  * \sa SDL_AddGamepadMappingsFromIO
  * \sa SDL_GetGamepadMapping
@@ -340,7 +357,7 @@ typedef struct SDL_GamepadBinding
  * \sa SDL_HINT_GAMECONTROLLERCONFIG_FILE
  * \sa SDL_EVENT_GAMEPAD_ADDED
  */
-extern SDL_DECLSPEC int SDLCALL SDL_AddGamepadMapping(const char *mapping);
+extern SDL_DECLSPEC SDL_GamepadAddMappingResult SDLCALL SDL_AddGamepadMapping(const char *mapping);
 
 /**
  * Load a set of gamepad mappings from an SDL_IOStream.

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -53,7 +53,7 @@ SDL_DYNAPI_PROC(SDL_GPUCommandBuffer*,SDL_AcquireGPUCommandBuffer,(SDL_GPUDevice
 SDL_DYNAPI_PROC(bool,SDL_AcquireGPUSwapchainTexture,(SDL_GPUCommandBuffer *a, SDL_Window *b, SDL_GPUTexture **c, Uint32 *d, Uint32 *e),(a,b,c,d,e),return)
 SDL_DYNAPI_PROC(int,SDL_AddAtomicInt,(SDL_AtomicInt *a, int b),(a,b),return)
 SDL_DYNAPI_PROC(bool,SDL_AddEventWatch,(SDL_EventFilter a, void *b),(a,b),return)
-SDL_DYNAPI_PROC(int,SDL_AddGamepadMapping,(const char *a),(a),return)
+SDL_DYNAPI_PROC(SDL_GamepadAddMappingResult,SDL_AddGamepadMapping,(const char *a),(a),return)
 SDL_DYNAPI_PROC(int,SDL_AddGamepadMappingsFromFile,(const char *a),(a),return)
 SDL_DYNAPI_PROC(int,SDL_AddGamepadMappingsFromIO,(SDL_IOStream *a, bool b),(a,b),return)
 SDL_DYNAPI_PROC(bool,SDL_AddHintCallback,(const char *a, SDL_HintCallback b, void *c),(a,b,c),return)

--- a/src/joystick/SDL_gamepad.c
+++ b/src/joystick/SDL_gamepad.c
@@ -2440,7 +2440,7 @@ static char *SDL_ConvertMappingToPositionalBAXY(const char *mapping)
 /*
  * Add or update an entry into the Mappings Database with a priority
  */
-static int SDL_PrivateAddGamepadMapping(const char *mappingString, SDL_GamepadMappingPriority priority)
+static SDL_GamepadAddMappingResult SDL_PrivateAddGamepadMapping(const char *mappingString, SDL_GamepadMappingPriority priority)
 {
     char *appended = NULL;
     char *remapped = NULL;
@@ -2451,19 +2451,19 @@ static int SDL_PrivateAddGamepadMapping(const char *mappingString, SDL_GamepadMa
     bool is_xinput_mapping = false;
     bool existing = false;
     GamepadMapping_t *pGamepadMapping;
-    int result = -1;
+    SDL_GamepadAddMappingResult result = SDL_GAMEPAD_ADD_MAPPING_FAILED;
 
     SDL_AssertJoysticksLocked();
 
     if (!mappingString) {
         SDL_InvalidParamError("mappingString");
-        return -1;
+        return SDL_GAMEPAD_ADD_MAPPING_FAILED;
     }
 
     pchGUID = SDL_PrivateGetGamepadGUIDFromMappingString(mappingString);
     if (!pchGUID) {
         SDL_SetError("Couldn't parse GUID from %s", mappingString);
-        return -1;
+        return SDL_GAMEPAD_ADD_MAPPING_FAILED;
     }
     if (!SDL_strcasecmp(pchGUID, "default")) {
         is_default_mapping = true;
@@ -2544,7 +2544,7 @@ static int SDL_PrivateAddGamepadMapping(const char *mappingString, SDL_GamepadMa
                     value = !value;
                 }
                 if (!value) {
-                    result = 0;
+                    result = SDL_GAMEPAD_ADD_MAPPING_UPDATED;
                     goto done;
                 }
             }
@@ -2580,14 +2580,14 @@ static int SDL_PrivateAddGamepadMapping(const char *mappingString, SDL_GamepadMa
     }
 
     if (existing) {
-        result = 0;
+        result = SDL_GAMEPAD_ADD_MAPPING_UPDATED;
     } else {
         if (is_default_mapping) {
             s_pDefaultMapping = pGamepadMapping;
         } else if (is_xinput_mapping) {
             s_pXInputMapping = pGamepadMapping;
         }
-        result = 1;
+        result = SDL_GAMEPAD_ADD_MAPPING_ADDED;
     }
 done:
     SDL_free(appended);
@@ -2598,9 +2598,9 @@ done:
 /*
  * Add or update an entry into the Mappings Database
  */
-int SDL_AddGamepadMapping(const char *mapping)
+SDL_GamepadAddMappingResult SDL_AddGamepadMapping(const char *mapping)
 {
-    int result;
+    SDL_GamepadAddMappingResult result;
 
     SDL_LockJoysticks();
     {


### PR DESCRIPTION
## Description
The values returned from `SDL_AddGamepadMapping` are a small set (-1, 0, 1).

Those integer values are defined and set directly within SDL code, and not pulled from system APIs, and the values match the original ones so this shouldn't break binary compatibility.

After the PR for `SDL_GetCameraPermissionState` was accepted, I audited to see if any other return values could be converted to enums. This was the only other function that I found.

## Existing Issue(s)
n/a