### PR TITLE
Bugfix: Add CHECK_WINDOW_MAGIC() to SDL_SetWindowSafeAreaInsets(), Prevent segfault at iOS

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -4256,6 +4256,8 @@ static void SDL_CheckWindowSafeAreaChanged(SDL_Window *window)
 
 void SDL_SetWindowSafeAreaInsets(SDL_Window *window, int left, int right, int top, int bottom)
 {
+    CHECK_WINDOW_MAGIC(window,);
+
     window->safe_inset_left = left;
     window->safe_inset_right = right;
     window->safe_inset_top = top;


### PR DESCRIPTION
Bugfix: Add CHECK_WINDOW_MAGIC() to SDL_SetWindowSafeAreaInsets(), Prevent segfault at iOS. On some iPhone/iPads this fix was not necessary. Maybe it depends on the iOS version. With this fix it always works

## Description
I have backport the safe area functions to SDL2 and find a bug which should also relevant for SDL3. The iPhone of my brother (i currently don't know the exact iOS and iPhone version) calls the callback function safeAreaInsetsDidChange() from uikit/SDL_uikitview.m before a valid sdlwindow pointer is set. Therefore the callback function safeAreaInsetsDidChange() calls the function SDL_SetWindowSafeAreaInsets() with a null pointer for the window. I add the `CHECK_WINDOW_MAGIC(window,);` to SDL_SetWindowSafeAreaInsets(). That the macro has no second provided argument is no mistake because the SDL_SetWindowSafeAreaInsets() function has no return type (void). Now with this fix it works perfect. It looks like the callback safeAreaInsetsDidChange() is also called again after a valid sdlwindow pointer is set because i have the correct safe insets after the app is started.

