### PR TITLE
Added a default case to the switch statement in the HEADER FILE to pr…

### DIFF
--- a/include/SDL_stdinc.h
+++ b/include/SDL_stdinc.h
@@ -584,6 +584,7 @@ SDL_FORCE_INLINE void SDL_memset4(void *dst, Uint32 val, size_t dwords)
         return;
     }
     switch (dwords % 4) {
+        default:
         case 0: do {    *_p++ = _val;   SDL_FALLTHROUGH;
         case 3:         *_p++ = _val;   SDL_FALLTHROUGH;
         case 2:         *_p++ = _val;   SDL_FALLTHROUGH;


### PR DESCRIPTION
Added a default case to the switch statement in the HEADER FILE to prevent compiler warnings about missing defaults. This change helps avoid compilation breaks when warnings are treated as errors. I could not compile my personal SDL based project because some very smart guy decides to implement such thing. 
