### PR TITLE
Improved handling of function parameter validation

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -686,6 +686,20 @@ extern "C" {
 #define SDL_HINT_DISPLAY_USABLE_BOUNDS "SDL_DISPLAY_USABLE_BOUNDS"
 
 /**
+ * Set the level of checking for invalid parameters passed to SDL functions.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "1": Enable fast parameter error checking, e.g. quick NULL checks, etc. (default)
+ * - "2": Enable full parameter error checking, e.g. validating objects are the correct type, etc.
+ *
+ * This hint can be set anytime.
+ *
+ * \since This hint is available since SDL 3.4.0.
+ */
+#define SDL_HINT_INVALID_PARAM_CHECKS "SDL_INVALID_PARAM_CHECKS"
+
+/**
  * Disable giving back control to the browser automatically when running with
  * asyncify.
  *

--- a/src/SDL.c
+++ b/src/SDL.c
@@ -148,7 +148,7 @@ static bool SDL_ValidMetadataProperty(const char *name)
 
 bool SDL_SetAppMetadataProperty(const char *name, const char *value)
 {
-    if (!SDL_ValidMetadataProperty(name)) {
+    CHECK_PARAM(!SDL_ValidMetadataProperty(name)) {
         return SDL_InvalidParamError("name");
     }
 
@@ -157,7 +157,7 @@ bool SDL_SetAppMetadataProperty(const char *name, const char *value)
 
 const char *SDL_GetAppMetadataProperty(const char *name)
 {
-    if (!SDL_ValidMetadataProperty(name)) {
+    CHECK_PARAM(!SDL_ValidMetadataProperty(name)) {
         SDL_InvalidParamError("name");
         return NULL;
     }

--- a/src/SDL_hashtable.c
+++ b/src/SDL_hashtable.c
@@ -292,7 +292,7 @@ static bool maybe_resize(SDL_HashTable *ht)
 
 bool SDL_InsertIntoHashTable(SDL_HashTable *table, const void *key, const void *value, bool replace)
 {
-    if (!table) {
+    CHECK_PARAM(!table) {
         return SDL_InvalidParamError("table");
     }
 
@@ -338,7 +338,7 @@ bool SDL_InsertIntoHashTable(SDL_HashTable *table, const void *key, const void *
 
 bool SDL_FindInHashTable(const SDL_HashTable *table, const void *key, const void **value)
 {
-    if (!table) {
+    CHECK_PARAM(!table) {
         if (value) {
             *value = NULL;
         }
@@ -364,7 +364,7 @@ bool SDL_FindInHashTable(const SDL_HashTable *table, const void *key, const void
 
 bool SDL_RemoveFromHashTable(SDL_HashTable *table, const void *key)
 {
-    if (!table) {
+    CHECK_PARAM(!table) {
         return SDL_InvalidParamError("table");
     }
 
@@ -384,9 +384,10 @@ bool SDL_RemoveFromHashTable(SDL_HashTable *table, const void *key)
 
 bool SDL_IterateHashTable(const SDL_HashTable *table, SDL_HashTableIterateCallback callback, void *userdata)
 {
-    if (!table) {
+    CHECK_PARAM(!table) {
         return SDL_InvalidParamError("table");
-    } else if (!callback) {
+    }
+    CHECK_PARAM(!callback) {
         return SDL_InvalidParamError("callback");
     }
 
@@ -410,7 +411,7 @@ bool SDL_IterateHashTable(const SDL_HashTable *table, SDL_HashTableIterateCallba
 
 bool SDL_HashTableEmpty(SDL_HashTable *table)
 {
-    if (!table) {
+    CHECK_PARAM(!table) {
         return SDL_InvalidParamError("table");
     }
 

--- a/src/SDL_hints.c
+++ b/src/SDL_hints.c
@@ -104,7 +104,7 @@ static const char *GetHintEnvironmentVariable(const char *name)
 
 bool SDL_SetHintWithPriority(const char *name, const char *value, SDL_HintPriority priority)
 {
-    if (!name || !*name) {
+    CHECK_PARAM(!name || !*name) {
         return SDL_InvalidParamError("name");
     }
 
@@ -165,7 +165,7 @@ bool SDL_SetHintWithPriority(const char *name, const char *value, SDL_HintPriori
 
 bool SDL_ResetHint(const char *name)
 {
-    if (!name || !*name) {
+    CHECK_PARAM(!name || !*name) {
         return SDL_InvalidParamError("name");
     }
 
@@ -316,9 +316,10 @@ bool SDL_GetHintBoolean(const char *name, bool default_value)
 
 bool SDL_AddHintCallback(const char *name, SDL_HintCallback callback, void *userdata)
 {
-    if (!name || !*name) {
+    CHECK_PARAM(!name || !*name) {
         return SDL_InvalidParamError("name");
-    } else if (!callback) {
+    }
+    CHECK_PARAM(!callback) {
         return SDL_InvalidParamError("callback");
     }
 

--- a/src/SDL_internal.h
+++ b/src/SDL_internal.h
@@ -290,6 +290,21 @@ extern SDL_NORETURN void SDL_ExitProcess(int exitcode);
 #define POP_SDL_ERROR() \
     SDL_SetError("%s", _error); SDL_free(_error); }
 
+#if defined(SDL_DISABLE_INVALID_PARAMS)
+#ifdef DEBUG
+// If you define SDL_DISABLE_INVALID_PARAMS, you're promising that you'll
+// never pass an invalid parameter to SDL, since it may crash or lead to
+// hard to diagnose bugs. Let's assert that this is true in debug builds.
+#define CHECK_PARAM(invalid) SDL_assert_always(!(invalid)); if (false)
+#else
+#define CHECK_PARAM(invalid) if (false)
+#endif
+#elif defined(SDL_ASSERT_INVALID_PARAMS)
+#define CHECK_PARAM(invalid) SDL_assert_always(!(invalid)); if (invalid)
+#else
+#define CHECK_PARAM(invalid) if (invalid)
+#endif
+
 // Do any initialization that needs to happen before threads are started
 extern void SDL_InitMainThread(void);
 

--- a/src/SDL_log.c
+++ b/src/SDL_log.c
@@ -461,7 +461,7 @@ bool SDL_SetLogPriorityPrefix(SDL_LogPriority priority, const char *prefix)
 {
     char *prefix_copy;
 
-    if (priority <= SDL_LOG_PRIORITY_INVALID || priority >= SDL_LOG_PRIORITY_COUNT) {
+    CHECK_PARAM(priority <= SDL_LOG_PRIORITY_INVALID || priority >= SDL_LOG_PRIORITY_COUNT) {
         return SDL_InvalidParamError("priority");
     }
 

--- a/src/SDL_properties.c
+++ b/src/SDL_properties.c
@@ -250,10 +250,10 @@ static bool SDLCALL CopyOneProperty(void *userdata, const SDL_HashTable *table, 
 
 bool SDL_CopyProperties(SDL_PropertiesID src, SDL_PropertiesID dst)
 {
-    if (!src) {
+    CHECK_PARAM(!src) {
         return SDL_InvalidParamError("src");
     }
-    if (!dst) {
+    CHECK_PARAM(!dst) {
         return SDL_InvalidParamError("dst");
     }
 
@@ -261,11 +261,11 @@ bool SDL_CopyProperties(SDL_PropertiesID src, SDL_PropertiesID dst)
     SDL_Properties *dst_properties = NULL;
 
     SDL_FindInHashTable(SDL_properties, (const void *)(uintptr_t)src, (const void **)&src_properties);
-    if (!src_properties) {
+    CHECK_PARAM(!src_properties) {
         return SDL_InvalidParamError("src");
     }
     SDL_FindInHashTable(SDL_properties, (const void *)(uintptr_t)dst, (const void **)&dst_properties);
-    if (!dst_properties) {
+    CHECK_PARAM(!dst_properties) {
         return SDL_InvalidParamError("dst");
     }
 
@@ -287,12 +287,12 @@ bool SDL_LockProperties(SDL_PropertiesID props)
 {
     SDL_Properties *properties = NULL;
 
-    if (!props) {
+    CHECK_PARAM(!props) {
         return SDL_InvalidParamError("props");
     }
 
     SDL_FindInHashTable(SDL_properties, (const void *)(uintptr_t)props, (const void **)&properties);
-    if (!properties) {
+    CHECK_PARAM(!properties) {
         return SDL_InvalidParamError("props");
     }
 
@@ -321,17 +321,17 @@ static bool SDL_PrivateSetProperty(SDL_PropertiesID props, const char *name, SDL
     SDL_Properties *properties = NULL;
     bool result = true;
 
-    if (!props) {
+    CHECK_PARAM(!props) {
         SDL_FreePropertyWithCleanup(NULL, property, NULL, true);
         return SDL_InvalidParamError("props");
     }
-    if (!name || !*name) {
+    CHECK_PARAM(!name || !*name) {
         SDL_FreePropertyWithCleanup(NULL, property, NULL, true);
         return SDL_InvalidParamError("name");
     }
 
     SDL_FindInHashTable(SDL_properties, (const void *)(uintptr_t)props, (const void **)&properties);
-    if (!properties) {
+    CHECK_PARAM(!properties) {
         SDL_FreePropertyWithCleanup(NULL, property, NULL, true);
         return SDL_InvalidParamError("props");
     }
@@ -755,15 +755,15 @@ bool SDL_EnumerateProperties(SDL_PropertiesID props, SDL_EnumeratePropertiesCall
 {
     SDL_Properties *properties = NULL;
 
-    if (!props) {
+    CHECK_PARAM(!props) {
         return SDL_InvalidParamError("props");
     }
-    if (!callback) {
+    CHECK_PARAM(!callback) {
         return SDL_InvalidParamError("callback");
     }
 
     SDL_FindInHashTable(SDL_properties, (const void *)(uintptr_t)props, (const void **)&properties);
-    if (!properties) {
+    CHECK_PARAM(!properties) {
         return SDL_InvalidParamError("props");
     }
 

--- a/src/SDL_utils.c
+++ b/src/SDL_utils.c
@@ -137,7 +137,7 @@ Uint32 SDL_GetNextObjectID(void)
 
 static SDL_InitState SDL_objects_init;
 static SDL_HashTable *SDL_objects;
-static bool SDL_object_validation;
+bool SDL_object_validation = false;
 
 static void SDLCALL SDL_InvalidParamChecksChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
 {
@@ -195,16 +195,8 @@ void SDL_SetObjectValid(void *object, SDL_ObjectType type, bool valid)
     }
 }
 
-bool SDL_ObjectValid(void *object, SDL_ObjectType type)
+bool SDL_FindObject(void *object, SDL_ObjectType type)
 {
-    if (!object) {
-        return false;
-    }
-
-    if (!SDL_object_validation) {
-        return true;
-    }
-
     const void *object_type;
     if (!SDL_FindInHashTable(SDL_objects, object, &object_type)) {
         return false;

--- a/src/SDL_utils.c
+++ b/src/SDL_utils.c
@@ -137,6 +137,32 @@ Uint32 SDL_GetNextObjectID(void)
 
 static SDL_InitState SDL_objects_init;
 static SDL_HashTable *SDL_objects;
+static bool SDL_object_validation;
+
+static void SDLCALL SDL_InvalidParamChecksChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
+{
+    bool validation_enabled = false;
+
+#ifdef SDL_ASSERT_INVALID_PARAMS
+    // Full validation is enabled by default
+    validation_enabled = true;
+#endif
+
+    if (hint) {
+        switch (*hint) {
+        case '0':
+        case '1':
+            validation_enabled = false;
+            break;
+        case '2':
+            validation_enabled = true;
+            break;
+        default:
+            break;
+        }
+    }
+    SDL_object_validation = validation_enabled;
+}
 
 static Uint32 SDLCALL SDL_HashObject(void *unused, const void *key)
 {
@@ -159,6 +185,7 @@ void SDL_SetObjectValid(void *object, SDL_ObjectType type, bool valid)
         if (!initialized) {
             return;
         }
+        SDL_AddHintCallback(SDL_HINT_INVALID_PARAM_CHECKS, SDL_InvalidParamChecksChanged, NULL);
     }
 
     if (valid) {
@@ -172,6 +199,10 @@ bool SDL_ObjectValid(void *object, SDL_ObjectType type)
 {
     if (!object) {
         return false;
+    }
+
+    if (!SDL_object_validation) {
+        return true;
     }
 
     const void *object_type;
@@ -242,6 +273,7 @@ void SDL_SetObjectsInvalid(void)
         SDL_DestroyHashTable(SDL_objects);
         SDL_objects = NULL;
         SDL_SetInitialized(&SDL_objects_init, false);
+        SDL_RemoveHintCallback(SDL_HINT_INVALID_PARAM_CHECKS, SDL_InvalidParamChecksChanged, NULL);
     }
 }
 

--- a/src/SDL_utils_c.h
+++ b/src/SDL_utils_c.h
@@ -67,9 +67,24 @@ typedef enum
 
 extern Uint32 SDL_GetNextObjectID(void);
 extern void SDL_SetObjectValid(void *object, SDL_ObjectType type, bool valid);
-extern bool SDL_ObjectValid(void *object, SDL_ObjectType type);
+extern bool SDL_FindObject(void *object, SDL_ObjectType type);
 extern int SDL_GetObjects(SDL_ObjectType type, void **objects, int count);
 extern void SDL_SetObjectsInvalid(void);
+
+extern bool SDL_object_validation;
+
+SDL_FORCE_INLINE bool SDL_ObjectValid(void *object, SDL_ObjectType type)
+{
+    if (!object) {
+        return false;
+    }
+
+    if (!SDL_object_validation) {
+        return true;
+    }
+
+    return SDL_FindObject(object, type);
+}
 
 extern const char *SDL_GetPersistentString(const char *string);
 

--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -136,11 +136,11 @@ int SDL_GetNumAudioDrivers(void)
 
 const char *SDL_GetAudioDriver(int index)
 {
-    if (index >= 0 && index < SDL_GetNumAudioDrivers()) {
-        return deduped_bootstrap[index]->name;
+    CHECK_PARAM(index < 0 || index >= SDL_GetNumAudioDrivers()) {
+        SDL_InvalidParamError("index");
+        return NULL;
     }
-    SDL_InvalidParamError("index");
-    return NULL;
+    return deduped_bootstrap[index]->name;
 }
 
 const char *SDL_GetCurrentAudioDriver(void)
@@ -1576,7 +1576,7 @@ const char *SDL_GetAudioDeviceName(SDL_AudioDeviceID devid)
 
 bool SDL_GetAudioDeviceFormat(SDL_AudioDeviceID devid, SDL_AudioSpec *spec, int *sample_frames)
 {
-    if (!spec) {
+    CHECK_PARAM(!spec) {
         return SDL_InvalidParamError("spec");
     }
 
@@ -1937,7 +1937,7 @@ float SDL_GetAudioDeviceGain(SDL_AudioDeviceID devid)
 
 bool SDL_SetAudioDeviceGain(SDL_AudioDeviceID devid, float gain)
 {
-    if (gain < 0.0f) {
+    CHECK_PARAM(gain < 0.0f) {
         return SDL_InvalidParamError("gain");
     }
 
@@ -1986,11 +1986,15 @@ bool SDL_BindAudioStreams(SDL_AudioDeviceID devid, SDL_AudioStream * const *stre
 
     if (num_streams == 0) {
         return true;  // nothing to do
-    } else if (num_streams < 0) {
+    }
+
+    CHECK_PARAM(num_streams < 0) {
         return SDL_InvalidParamError("num_streams");
-    } else if (!streams) {
+    }
+    CHECK_PARAM(!streams) {
         return SDL_InvalidParamError("streams");
-    } else if (SDL_IsAudioDevicePhysical(devid)) {
+    }
+    CHECK_PARAM(SDL_IsAudioDevicePhysical(devid)) {
         return SDL_SetError("Audio streams are bound to device ids from SDL_OpenAudioDevice, not raw physical devices");
     }
 
@@ -2150,7 +2154,7 @@ SDL_AudioDeviceID SDL_GetAudioStreamDevice(SDL_AudioStream *stream)
 {
     SDL_AudioDeviceID result = 0;
 
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         SDL_InvalidParamError("stream");
         return 0;
     }

--- a/src/audio/SDL_audiocvt.c
+++ b/src/audio/SDL_audiocvt.c
@@ -474,10 +474,11 @@ SDL_AudioStream *SDL_CreateAudioStream(const SDL_AudioSpec *src_spec, const SDL_
 
 SDL_PropertiesID SDL_GetAudioStreamProperties(SDL_AudioStream *stream)
 {
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         SDL_InvalidParamError("stream");
         return 0;
     }
+
     SDL_LockMutex(stream->lock);
     if (stream->props == 0) {
         stream->props = SDL_CreateProperties();
@@ -488,9 +489,10 @@ SDL_PropertiesID SDL_GetAudioStreamProperties(SDL_AudioStream *stream)
 
 bool SDL_SetAudioStreamGetCallback(SDL_AudioStream *stream, SDL_AudioStreamCallback callback, void *userdata)
 {
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         return SDL_InvalidParamError("stream");
     }
+
     SDL_LockMutex(stream->lock);
     stream->get_callback = callback;
     stream->get_callback_userdata = userdata;
@@ -500,9 +502,10 @@ bool SDL_SetAudioStreamGetCallback(SDL_AudioStream *stream, SDL_AudioStreamCallb
 
 bool SDL_SetAudioStreamPutCallback(SDL_AudioStream *stream, SDL_AudioStreamCallback callback, void *userdata)
 {
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         return SDL_InvalidParamError("stream");
     }
+
     SDL_LockMutex(stream->lock);
     stream->put_callback = callback;
     stream->put_callback_userdata = userdata;
@@ -512,25 +515,27 @@ bool SDL_SetAudioStreamPutCallback(SDL_AudioStream *stream, SDL_AudioStreamCallb
 
 bool SDL_LockAudioStream(SDL_AudioStream *stream)
 {
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         return SDL_InvalidParamError("stream");
     }
+
     SDL_LockMutex(stream->lock);
     return true;
 }
 
 bool SDL_UnlockAudioStream(SDL_AudioStream *stream)
 {
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         return SDL_InvalidParamError("stream");
     }
+
     SDL_UnlockMutex(stream->lock);
     return true;
 }
 
 bool SDL_GetAudioStreamFormat(SDL_AudioStream *stream, SDL_AudioSpec *src_spec, SDL_AudioSpec *dst_spec)
 {
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         if (src_spec) {
             SDL_zerop(src_spec);
         }
@@ -560,7 +565,7 @@ bool SDL_GetAudioStreamFormat(SDL_AudioStream *stream, SDL_AudioSpec *src_spec, 
 
 bool SDL_SetAudioStreamFormat(SDL_AudioStream *stream, const SDL_AudioSpec *src_spec, const SDL_AudioSpec *dst_spec)
 {
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         return SDL_InvalidParamError("stream");
     }
 
@@ -569,21 +574,25 @@ bool SDL_SetAudioStreamFormat(SDL_AudioStream *stream, const SDL_AudioSpec *src_
     // like 196608000Hz. File a bug.  :P
 
     if (src_spec) {
-        if (!SDL_IsSupportedAudioFormat(src_spec->format)) {
+        CHECK_PARAM(!SDL_IsSupportedAudioFormat(src_spec->format)) {
             return SDL_InvalidParamError("src_spec->format");
-        } else if (!SDL_IsSupportedChannelCount(src_spec->channels)) {
+        }
+        CHECK_PARAM(!SDL_IsSupportedChannelCount(src_spec->channels)) {
             return SDL_InvalidParamError("src_spec->channels");
-        } else if (src_spec->freq <= 0) {
+        }
+        CHECK_PARAM(src_spec->freq <= 0) {
             return SDL_InvalidParamError("src_spec->freq");
         }
     }
 
     if (dst_spec) {
-        if (!SDL_IsSupportedAudioFormat(dst_spec->format)) {
+        CHECK_PARAM(!SDL_IsSupportedAudioFormat(dst_spec->format)) {
             return SDL_InvalidParamError("dst_spec->format");
-        } else if (!SDL_IsSupportedChannelCount(dst_spec->channels)) {
+        }
+        CHECK_PARAM(!SDL_IsSupportedChannelCount(dst_spec->channels)) {
             return SDL_InvalidParamError("dst_spec->channels");
-        } else if (dst_spec->freq <= 0) {
+        }
+        CHECK_PARAM(dst_spec->freq <= 0) {
             return SDL_InvalidParamError("dst_spec->freq");
         }
     }
@@ -622,7 +631,7 @@ bool SDL_SetAudioStreamFormat(SDL_AudioStream *stream, const SDL_AudioSpec *src_
 
 bool SetAudioStreamChannelMap(SDL_AudioStream *stream, const SDL_AudioSpec *spec, int **stream_chmap, const int *chmap, int channels, int isinput)
 {
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         return SDL_InvalidParamError("stream");
     }
 
@@ -708,7 +717,7 @@ int *SDL_GetAudioStreamOutputChannelMap(SDL_AudioStream *stream, int *count)
 
 float SDL_GetAudioStreamFrequencyRatio(SDL_AudioStream *stream)
 {
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         SDL_InvalidParamError("stream");
         return 0.0f;
     }
@@ -722,7 +731,7 @@ float SDL_GetAudioStreamFrequencyRatio(SDL_AudioStream *stream)
 
 bool SDL_SetAudioStreamFrequencyRatio(SDL_AudioStream *stream, float freq_ratio)
 {
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         return SDL_InvalidParamError("stream");
     }
 
@@ -745,7 +754,7 @@ bool SDL_SetAudioStreamFrequencyRatio(SDL_AudioStream *stream, float freq_ratio)
 
 float SDL_GetAudioStreamGain(SDL_AudioStream *stream)
 {
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         SDL_InvalidParamError("stream");
         return -1.0f;
     }
@@ -759,9 +768,10 @@ float SDL_GetAudioStreamGain(SDL_AudioStream *stream)
 
 bool SDL_SetAudioStreamGain(SDL_AudioStream *stream, float gain)
 {
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         return SDL_InvalidParamError("stream");
-    } else if (gain < 0.0f) {
+    }
+    CHECK_PARAM(gain < 0.0f) {
         return SDL_InvalidParamError("gain");
     }
 
@@ -847,13 +857,17 @@ static void SDLCALL FreeAllocatedAudioBuffer(void *userdata, const void *buf, in
 
 bool SDL_PutAudioStreamData(SDL_AudioStream *stream, const void *buf, int len)
 {
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         return SDL_InvalidParamError("stream");
-    } else if (!buf) {
+    }
+    CHECK_PARAM(!buf) {
         return SDL_InvalidParamError("buf");
-    } else if (len < 0) {
+    }
+    CHECK_PARAM(len < 0) {
         return SDL_InvalidParamError("len");
-    } else if (len == 0) {
+    }
+
+    if (len == 0) {
         return true; // nothing to do.
     }
 
@@ -965,13 +979,17 @@ static void InterleaveAudioChannels(void *output, const void * const *channel_bu
 
 bool SDL_PutAudioStreamPlanarData(SDL_AudioStream *stream, const void * const *channel_buffers, int num_channels, int num_samples)
 {
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         return SDL_InvalidParamError("stream");
-    } else if (!channel_buffers) {
+    }
+    CHECK_PARAM(!channel_buffers) {
         return SDL_InvalidParamError("channel_buffers");
-    } else if (num_samples < 0) {
+    }
+    CHECK_PARAM(num_samples < 0) {
         return SDL_InvalidParamError("num_samples");
-    } else if (num_samples == 0) {
+    }
+
+    if (num_samples == 0) {
         return true; // nothing to do.
     }
 
@@ -1039,13 +1057,17 @@ static void SDLCALL DontFreeThisAudioBuffer(void *userdata, const void *buf, int
 
 bool SDL_PutAudioStreamDataNoCopy(SDL_AudioStream *stream, const void *buf, int len, SDL_AudioStreamDataCompleteCallback callback, void *userdata)
 {
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         return SDL_InvalidParamError("stream");
-    } else if (!buf) {
+    }
+    CHECK_PARAM(!buf) {
         return SDL_InvalidParamError("buf");
-    } else if (len < 0) {
+    }
+    CHECK_PARAM(len < 0) {
         return SDL_InvalidParamError("len");
-    } else if (len == 0) {
+    }
+
+    if (len == 0) {
         if (callback) {
             callback(userdata, buf, len);
         }
@@ -1057,7 +1079,7 @@ bool SDL_PutAudioStreamDataNoCopy(SDL_AudioStream *stream, const void *buf, int 
 
 bool SDL_FlushAudioStream(SDL_AudioStream *stream)
 {
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         return SDL_InvalidParamError("stream");
     }
 
@@ -1320,16 +1342,20 @@ int SDL_GetAudioStreamDataAdjustGain(SDL_AudioStream *stream, void *voidbuf, int
     SDL_Log("AUDIOSTREAM: want to get %d converted bytes", len);
 #endif
 
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         SDL_InvalidParamError("stream");
         return -1;
-    } else if (!buf) {
+    }
+    CHECK_PARAM(!buf) {
         SDL_InvalidParamError("buf");
         return -1;
-    } else if (len < 0) {
+    }
+    CHECK_PARAM(len < 0) {
         SDL_InvalidParamError("len");
         return -1;
-    } else if (len == 0) {
+    }
+
+    if (len == 0) {
         return 0; // nothing to do.
     }
 
@@ -1427,7 +1453,7 @@ int SDL_GetAudioStreamData(SDL_AudioStream *stream, void *voidbuf, int len)
 // number of converted/resampled bytes available for output
 int SDL_GetAudioStreamAvailable(SDL_AudioStream *stream)
 {
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         SDL_InvalidParamError("stream");
         return -1;
     }
@@ -1453,7 +1479,7 @@ int SDL_GetAudioStreamAvailable(SDL_AudioStream *stream)
 // number of sample frames that are currently queued as input.
 int SDL_GetAudioStreamQueued(SDL_AudioStream *stream)
 {
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         SDL_InvalidParamError("stream");
         return -1;
     }
@@ -1470,7 +1496,7 @@ int SDL_GetAudioStreamQueued(SDL_AudioStream *stream)
 
 bool SDL_ClearAudioStream(SDL_AudioStream *stream)
 {
-    if (!stream) {
+    CHECK_PARAM(!stream) {
         return SDL_InvalidParamError("stream");
     }
 
@@ -1522,13 +1548,16 @@ bool SDL_ConvertAudioSamples(const SDL_AudioSpec *src_spec, const Uint8 *src_dat
         *dst_len = 0;
     }
 
-    if (!src_data) {
+    CHECK_PARAM(!src_data) {
         return SDL_InvalidParamError("src_data");
-    } else if (src_len < 0) {
+    }
+    CHECK_PARAM(src_len < 0) {
         return SDL_InvalidParamError("src_len");
-    } else if (!dst_data) {
+    }
+    CHECK_PARAM(!dst_data) {
         return SDL_InvalidParamError("dst_data");
-    } else if (!dst_len) {
+    }
+    CHECK_PARAM(!dst_len) {
         return SDL_InvalidParamError("dst_len");
     }
 

--- a/src/audio/SDL_wave.c
+++ b/src/audio/SDL_wave.c
@@ -2092,16 +2092,19 @@ bool SDL_LoadWAV_IO(SDL_IOStream *src, bool closeio, SDL_AudioSpec *spec, Uint8 
     }
 
     // Make sure we are passed a valid data source
-    if (!src) {
+    CHECK_PARAM(!src) {
         SDL_InvalidParamError("src");
         goto done;
-    } else if (!spec) {
+    }
+    CHECK_PARAM(!spec) {
         SDL_InvalidParamError("spec");
         goto done;
-    } else if (!audio_buf) {
+    }
+    CHECK_PARAM(!audio_buf) {
         SDL_InvalidParamError("audio_buf");
         goto done;
-    } else if (!audio_len) {
+    }
+    CHECK_PARAM(!audio_len) {
         SDL_InvalidParamError("audio_len");
         goto done;
     }

--- a/src/camera/SDL_camera.c
+++ b/src/camera/SDL_camera.c
@@ -69,11 +69,11 @@ int SDL_GetNumCameraDrivers(void)
 
 const char *SDL_GetCameraDriver(int index)
 {
-    if (index >= 0 && index < SDL_GetNumCameraDrivers()) {
-        return bootstrap[index]->name;
+    CHECK_PARAM(index < 0 || index >= SDL_GetNumCameraDrivers()) {
+        SDL_InvalidParamError("index");
+        return NULL;
     }
-    SDL_InvalidParamError("index");
-    return NULL;
+    return bootstrap[index]->name;
 }
 
 const char *SDL_GetCurrentCameraDriver(void)
@@ -657,9 +657,10 @@ bool SDL_GetCameraFormat(SDL_Camera *camera, SDL_CameraSpec *spec)
 {
     bool result;
 
-    if (!camera) {
+    CHECK_PARAM(!camera) {
         return SDL_InvalidParamError("camera");
-    } else if (!spec) {
+    }
+    CHECK_PARAM(!spec) {
         return SDL_InvalidParamError("spec");
     }
 
@@ -1255,7 +1256,7 @@ SDL_Surface *SDL_AcquireCameraFrame(SDL_Camera *camera, Uint64 *timestampNS)
         *timestampNS = 0;
     }
 
-    if (!camera) {
+    CHECK_PARAM(!camera) {
         SDL_InvalidParamError("camera");
         return NULL;
     }
@@ -1340,33 +1341,37 @@ void SDL_ReleaseCameraFrame(SDL_Camera *camera, SDL_Surface *frame)
 
 SDL_CameraID SDL_GetCameraID(SDL_Camera *camera)
 {
-    SDL_CameraID result = 0;
-    if (!camera) {
+    SDL_CameraID result;
+
+    CHECK_PARAM(!camera) {
         SDL_InvalidParamError("camera");
-    } else {
-        SDL_Camera *device = camera;  // currently there's no separation between physical and logical device.
-        ObtainPhysicalCameraObj(device);
-        result = device->instance_id;
-        ReleaseCamera(device);
+        return 0;
     }
+
+    SDL_Camera *device = camera;  // currently there's no separation between physical and logical device.
+    ObtainPhysicalCameraObj(device);
+    result = device->instance_id;
+    ReleaseCamera(device);
 
     return result;
 }
 
 SDL_PropertiesID SDL_GetCameraProperties(SDL_Camera *camera)
 {
-    SDL_PropertiesID result = 0;
-    if (!camera) {
+    SDL_PropertiesID result;
+
+    CHECK_PARAM(!camera) {
         SDL_InvalidParamError("camera");
-    } else {
-        SDL_Camera *device = camera;  // currently there's no separation between physical and logical device.
-        ObtainPhysicalCameraObj(device);
-        if (device->props == 0) {
-            device->props = SDL_CreateProperties();
-        }
-        result = device->props;
-        ReleaseCamera(device);
+        return 0;
     }
+
+    SDL_Camera *device = camera;  // currently there's no separation between physical and logical device.
+    ObtainPhysicalCameraObj(device);
+    if (device->props == 0) {
+        device->props = SDL_CreateProperties();
+    }
+    result = device->props;
+    ReleaseCamera(device);
 
     return result;
 }
@@ -1374,15 +1379,17 @@ SDL_PropertiesID SDL_GetCameraProperties(SDL_Camera *camera)
 SDL_CameraPermissionState SDL_GetCameraPermissionState(SDL_Camera *camera)
 {
     SDL_CameraPermissionState result;
-    if (!camera) {
+
+    CHECK_PARAM(!camera) {
         SDL_InvalidParamError("camera");
-        result = SDL_CAMERA_PERMISSION_STATE_DENIED;
-    } else {
-        SDL_Camera *device = camera;  // currently there's no separation between physical and logical device.
-        ObtainPhysicalCameraObj(device);
-        result = device->permission;
-        ReleaseCamera(device);
+        return SDL_CAMERA_PERMISSION_STATE_DENIED;
     }
+
+    SDL_Camera *device = camera;  // currently there's no separation between physical and logical device.
+    ObtainPhysicalCameraObj(device);
+    result = device->permission;
+    ReleaseCamera(device);
+
     return result;
 }
 

--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -2113,7 +2113,7 @@ void Android_JNI_HapticStop(int device_id)
 
 bool SDL_SendAndroidMessage(Uint32 command, int param)
 {
-    if (command < 0x8000) {
+    CHECK_PARAM(command < 0x8000) {
         return SDL_InvalidParamError("command");
     }
     return Android_JNI_SendMessage(command, param);

--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -1131,7 +1131,7 @@ static int SDL_PeepEventsInternal(SDL_Event *events, int numevents, SDL_EventAct
             return -1;
         }
         if (action == SDL_ADDEVENT) {
-            if (!events) {
+            CHECK_PARAM(!events) {
                 SDL_UnlockMutex(SDL_EventQ.lock);
                 return SDL_InvalidParamError("events");
             }

--- a/src/events/SDL_keymap.c
+++ b/src/events/SDL_keymap.c
@@ -290,7 +290,7 @@ static const struct
 
 static SDL_Keycode SDL_GetDefaultKeyFromScancode(SDL_Scancode scancode, SDL_Keymod modstate)
 {
-    if (((int)scancode) < SDL_SCANCODE_UNKNOWN || scancode >= SDL_SCANCODE_COUNT) {
+    CHECK_PARAM(((int)scancode) < SDL_SCANCODE_UNKNOWN || scancode >= SDL_SCANCODE_COUNT) {
         SDL_InvalidParamError("scancode");
         return SDLK_UNKNOWN;
     }
@@ -1053,7 +1053,7 @@ static const char *SDL_extended_key_names[] = {
 
 bool SDL_SetScancodeName(SDL_Scancode scancode, const char *name)
 {
-    if (((int)scancode) < SDL_SCANCODE_UNKNOWN || scancode >= SDL_SCANCODE_COUNT) {
+    CHECK_PARAM(((int)scancode) < SDL_SCANCODE_UNKNOWN || scancode >= SDL_SCANCODE_COUNT) {
         return SDL_InvalidParamError("scancode");
     }
 
@@ -1064,7 +1064,8 @@ bool SDL_SetScancodeName(SDL_Scancode scancode, const char *name)
 const char *SDL_GetScancodeName(SDL_Scancode scancode)
 {
     const char *name;
-    if (((int)scancode) < SDL_SCANCODE_UNKNOWN || scancode >= SDL_SCANCODE_COUNT) {
+
+    CHECK_PARAM(((int)scancode) < SDL_SCANCODE_UNKNOWN || scancode >= SDL_SCANCODE_COUNT) {
         SDL_InvalidParamError("scancode");
         return "";
     }
@@ -1081,7 +1082,7 @@ SDL_Scancode SDL_GetScancodeFromName(const char *name)
 {
     int i;
 
-    if (!name || !*name) {
+    CHECK_PARAM(!name || !*name) {
         SDL_InvalidParamError("name");
         return SDL_SCANCODE_UNKNOWN;
     }

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -1558,7 +1558,7 @@ SDL_Cursor *SDL_CreateColorCursor(SDL_Surface *surface, int hot_x, int hot_y)
     SDL_Surface *temp = NULL;
     SDL_Cursor *cursor;
 
-    if (!surface) {
+    CHECK_PARAM(!surface) {
         SDL_InvalidParamError("surface");
         return NULL;
     }
@@ -1569,8 +1569,8 @@ SDL_Cursor *SDL_CreateColorCursor(SDL_Surface *surface, int hot_x, int hot_y)
     hot_y = (int)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_HOTSPOT_Y_NUMBER, hot_y);
 
     // Sanity check the hot spot
-    if ((hot_x < 0) || (hot_y < 0) ||
-        (hot_x >= surface->w) || (hot_y >= surface->h)) {
+    CHECK_PARAM((hot_x < 0) || (hot_y < 0) ||
+                (hot_x >= surface->w) || (hot_y >= surface->h)) {
         SDL_SetError("Cursor hot spot doesn't lie within cursor");
         return NULL;
     }

--- a/src/filesystem/SDL_filesystem.c
+++ b/src/filesystem/SDL_filesystem.c
@@ -27,7 +27,7 @@
 
 bool SDL_RemovePath(const char *path)
 {
-    if (!path) {
+    CHECK_PARAM(!path) {
         return SDL_InvalidParamError("path");
     }
     return SDL_SYS_RemovePath(path);
@@ -35,9 +35,10 @@ bool SDL_RemovePath(const char *path)
 
 bool SDL_RenamePath(const char *oldpath, const char *newpath)
 {
-    if (!oldpath) {
+    CHECK_PARAM(!oldpath) {
         return SDL_InvalidParamError("oldpath");
-    } else if (!newpath) {
+    }
+    CHECK_PARAM(!newpath) {
         return SDL_InvalidParamError("newpath");
     }
     return SDL_SYS_RenamePath(oldpath, newpath);
@@ -45,9 +46,10 @@ bool SDL_RenamePath(const char *oldpath, const char *newpath)
 
 bool SDL_CopyFile(const char *oldpath, const char *newpath)
 {
-    if (!oldpath) {
+    CHECK_PARAM(!oldpath) {
         return SDL_InvalidParamError("oldpath");
-    } else if (!newpath) {
+    }
+    CHECK_PARAM(!newpath) {
         return SDL_InvalidParamError("newpath");
     }
     return SDL_SYS_CopyFile(oldpath, newpath);
@@ -55,7 +57,7 @@ bool SDL_CopyFile(const char *oldpath, const char *newpath)
 
 bool SDL_CreateDirectory(const char *path)
 {
-    if (!path) {
+    CHECK_PARAM(!path) {
         return SDL_InvalidParamError("path");
     }
 
@@ -116,9 +118,10 @@ bool SDL_CreateDirectory(const char *path)
 
 bool SDL_EnumerateDirectory(const char *path, SDL_EnumerateDirectoryCallback callback, void *userdata)
 {
-    if (!path) {
+    CHECK_PARAM(!path) {
         return SDL_InvalidParamError("path");
-    } else if (!callback) {
+    }
+    CHECK_PARAM(!callback) {
         return SDL_InvalidParamError("callback");
     }
     return SDL_SYS_EnumerateDirectory(path, callback, userdata);
@@ -133,10 +136,9 @@ bool SDL_GetPathInfo(const char *path, SDL_PathInfo *info)
     }
     SDL_zerop(info);
 
-    if (!path) {
+    CHECK_PARAM(!path) {
         return SDL_InvalidParamError("path");
     }
-
     return SDL_SYS_GetPathInfo(path, info);
 }
 
@@ -364,7 +366,7 @@ char **SDL_InternalGlobDirectory(const char *path, const char *pattern, SDL_Glob
     }
     *count = 0;
 
-    if (!path) {
+    CHECK_PARAM(!path) {
         SDL_InvalidParamError("path");
         return NULL;
     }
@@ -488,7 +490,8 @@ static char *CachedUserFolders[SDL_FOLDER_COUNT];
 const char *SDL_GetUserFolder(SDL_Folder folder)
 {
     const int idx = (int) folder;
-    if ((idx < 0) || (idx >= SDL_arraysize(CachedUserFolders))) {
+
+    CHECK_PARAM((idx < 0) || (idx >= SDL_arraysize(CachedUserFolders))) {
         SDL_InvalidParamError("folder");
         return NULL;
     }
@@ -502,7 +505,7 @@ const char *SDL_GetUserFolder(SDL_Folder folder)
 
 char *SDL_GetPrefPath(const char *org, const char *app)
 {
-    if (!app) {
+    CHECK_PARAM(!app) {
         SDL_InvalidParamError("app");
         return NULL;
     }

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -23,7 +23,7 @@
 
 // FIXME: This could probably use SDL_ObjectValid
 #define CHECK_DEVICE_MAGIC(device, retval)  \
-    if (device == NULL) {                   \
+    CHECK_PARAM(device == NULL) {           \
         SDL_SetError("Invalid GPU device"); \
         return retval;                      \
     }
@@ -731,7 +731,6 @@ SDL_GPUDevice *SDL_CreateGPUDeviceWithProperties(SDL_PropertiesID props)
 void SDL_DestroyGPUDevice(SDL_GPUDevice *device)
 {
     CHECK_DEVICE_MAGIC(device, );
-
     device->DestroyDevice(device);
 }
 
@@ -746,7 +745,7 @@ int SDL_GetNumGPUDrivers(void)
 
 const char * SDL_GetGPUDriver(int index)
 {
-    if (index < 0 || index >= SDL_GetNumGPUDrivers()) {
+    CHECK_PARAM(index < 0 || index >= SDL_GetNumGPUDrivers()) {
         SDL_InvalidParamError("index");
         return NULL;
     }
@@ -760,21 +759,18 @@ const char * SDL_GetGPUDriver(int index)
 const char * SDL_GetGPUDeviceDriver(SDL_GPUDevice *device)
 {
     CHECK_DEVICE_MAGIC(device, NULL);
-
     return device->backend;
 }
 
 SDL_GPUShaderFormat SDL_GetGPUShaderFormats(SDL_GPUDevice *device)
 {
     CHECK_DEVICE_MAGIC(device, SDL_GPU_SHADERFORMAT_INVALID);
-
     return device->shader_formats;
 }
 
 SDL_PropertiesID SDL_GetGPUDeviceProperties(SDL_GPUDevice *device)
 {
     CHECK_DEVICE_MAGIC(device, 0);
-
     return device->GetDeviceProperties(device);
 }
 
@@ -951,6 +947,7 @@ SDL_GPUComputePipeline *SDL_CreateGPUComputePipeline(
     const SDL_GPUComputePipelineCreateInfo *createinfo)
 {
     CHECK_DEVICE_MAGIC(device, NULL);
+
     if (createinfo == NULL) {
         SDL_InvalidParamError("createinfo");
         return NULL;
@@ -991,7 +988,8 @@ SDL_GPUGraphicsPipeline *SDL_CreateGPUGraphicsPipeline(
     const SDL_GPUGraphicsPipelineCreateInfo *graphicsPipelineCreateInfo)
 {
     CHECK_DEVICE_MAGIC(device, NULL);
-    if (graphicsPipelineCreateInfo == NULL) {
+
+    CHECK_PARAM(graphicsPipelineCreateInfo == NULL) {
         SDL_InvalidParamError("graphicsPipelineCreateInfo");
         return NULL;
     }
@@ -1118,7 +1116,8 @@ SDL_GPUSampler *SDL_CreateGPUSampler(
     const SDL_GPUSamplerCreateInfo *createinfo)
 {
     CHECK_DEVICE_MAGIC(device, NULL);
-    if (createinfo == NULL) {
+
+    CHECK_PARAM(createinfo == NULL) {
         SDL_InvalidParamError("createinfo");
         return NULL;
     }
@@ -1133,7 +1132,8 @@ SDL_GPUShader *SDL_CreateGPUShader(
     const SDL_GPUShaderCreateInfo *createinfo)
 {
     CHECK_DEVICE_MAGIC(device, NULL);
-    if (createinfo == NULL) {
+
+    CHECK_PARAM(createinfo == NULL) {
         SDL_InvalidParamError("createinfo");
         return NULL;
     }
@@ -1159,7 +1159,8 @@ SDL_GPUTexture *SDL_CreateGPUTexture(
     const SDL_GPUTextureCreateInfo *createinfo)
 {
     CHECK_DEVICE_MAGIC(device, NULL);
-    if (createinfo == NULL) {
+
+    CHECK_PARAM(createinfo == NULL) {
         SDL_InvalidParamError("createinfo");
         return NULL;
     }
@@ -1301,7 +1302,8 @@ SDL_GPUBuffer *SDL_CreateGPUBuffer(
     const SDL_GPUBufferCreateInfo *createinfo)
 {
     CHECK_DEVICE_MAGIC(device, NULL);
-    if (createinfo == NULL) {
+
+    CHECK_PARAM(createinfo == NULL) {
         SDL_InvalidParamError("createinfo");
         return NULL;
     }
@@ -1320,7 +1322,8 @@ SDL_GPUTransferBuffer *SDL_CreateGPUTransferBuffer(
     const SDL_GPUTransferBufferCreateInfo *createinfo)
 {
     CHECK_DEVICE_MAGIC(device, NULL);
-    if (createinfo == NULL) {
+
+    CHECK_PARAM(createinfo == NULL) {
         SDL_InvalidParamError("createinfo");
         return NULL;
     }
@@ -1342,11 +1345,12 @@ void SDL_SetGPUBufferName(
     const char *text)
 {
     CHECK_DEVICE_MAGIC(device, );
-    if (buffer == NULL) {
+
+    CHECK_PARAM(buffer == NULL) {
         SDL_InvalidParamError("buffer");
         return;
     }
-    if (text == NULL) {
+    CHECK_PARAM(text == NULL) {
         SDL_InvalidParamError("text");
     }
 
@@ -1362,11 +1366,12 @@ void SDL_SetGPUTextureName(
     const char *text)
 {
     CHECK_DEVICE_MAGIC(device, );
-    if (texture == NULL) {
+
+    CHECK_PARAM(texture == NULL) {
         SDL_InvalidParamError("texture");
         return;
     }
-    if (text == NULL) {
+    CHECK_PARAM(text == NULL) {
         SDL_InvalidParamError("text");
     }
 
@@ -1380,11 +1385,11 @@ void SDL_InsertGPUDebugLabel(
     SDL_GPUCommandBuffer *command_buffer,
     const char *text)
 {
-    if (command_buffer == NULL) {
+    CHECK_PARAM(command_buffer == NULL) {
         SDL_InvalidParamError("command_buffer");
         return;
     }
-    if (text == NULL) {
+    CHECK_PARAM(text == NULL) {
         SDL_InvalidParamError("text");
         return;
     }
@@ -1402,11 +1407,11 @@ void SDL_PushGPUDebugGroup(
     SDL_GPUCommandBuffer *command_buffer,
     const char *name)
 {
-    if (command_buffer == NULL) {
+    CHECK_PARAM(command_buffer == NULL) {
         SDL_InvalidParamError("command_buffer");
         return;
     }
-    if (name == NULL) {
+    CHECK_PARAM(name == NULL) {
         SDL_InvalidParamError("name");
         return;
     }
@@ -1423,7 +1428,7 @@ void SDL_PushGPUDebugGroup(
 void SDL_PopGPUDebugGroup(
     SDL_GPUCommandBuffer *command_buffer)
 {
-    if (command_buffer == NULL) {
+    CHECK_PARAM(command_buffer == NULL) {
         SDL_InvalidParamError("command_buffer");
         return;
     }
@@ -1443,7 +1448,8 @@ void SDL_ReleaseGPUTexture(
     SDL_GPUTexture *texture)
 {
     CHECK_DEVICE_MAGIC(device, );
-    if (texture == NULL) {
+
+    CHECK_PARAM(texture == NULL) {
         return;
     }
 
@@ -1457,7 +1463,8 @@ void SDL_ReleaseGPUSampler(
     SDL_GPUSampler *sampler)
 {
     CHECK_DEVICE_MAGIC(device, );
-    if (sampler == NULL) {
+
+    CHECK_PARAM(sampler == NULL) {
         return;
     }
 
@@ -1471,7 +1478,8 @@ void SDL_ReleaseGPUBuffer(
     SDL_GPUBuffer *buffer)
 {
     CHECK_DEVICE_MAGIC(device, );
-    if (buffer == NULL) {
+
+    CHECK_PARAM(buffer == NULL) {
         return;
     }
 
@@ -1485,7 +1493,8 @@ void SDL_ReleaseGPUTransferBuffer(
     SDL_GPUTransferBuffer *transfer_buffer)
 {
     CHECK_DEVICE_MAGIC(device, );
-    if (transfer_buffer == NULL) {
+
+    CHECK_PARAM(transfer_buffer == NULL) {
         return;
     }
 
@@ -1499,7 +1508,8 @@ void SDL_ReleaseGPUShader(
     SDL_GPUShader *shader)
 {
     CHECK_DEVICE_MAGIC(device, );
-    if (shader == NULL) {
+
+    CHECK_PARAM(shader == NULL) {
         return;
     }
 
@@ -1513,7 +1523,8 @@ void SDL_ReleaseGPUComputePipeline(
     SDL_GPUComputePipeline *compute_pipeline)
 {
     CHECK_DEVICE_MAGIC(device, );
-    if (compute_pipeline == NULL) {
+
+    CHECK_PARAM(compute_pipeline == NULL) {
         return;
     }
 
@@ -1527,7 +1538,8 @@ void SDL_ReleaseGPUGraphicsPipeline(
     SDL_GPUGraphicsPipeline *graphics_pipeline)
 {
     CHECK_DEVICE_MAGIC(device, );
-    if (graphics_pipeline == NULL) {
+
+    CHECK_PARAM(graphics_pipeline == NULL) {
         return;
     }
 
@@ -1592,11 +1604,11 @@ void SDL_PushGPUVertexUniformData(
     const void *data,
     Uint32 length)
 {
-    if (command_buffer == NULL) {
+    CHECK_PARAM(command_buffer == NULL) {
         SDL_InvalidParamError("command_buffer");
         return;
     }
-    if (data == NULL) {
+    CHECK_PARAM(data == NULL) {
         SDL_InvalidParamError("data");
         return;
     }
@@ -1618,11 +1630,11 @@ void SDL_PushGPUFragmentUniformData(
     const void *data,
     Uint32 length)
 {
-    if (command_buffer == NULL) {
+    CHECK_PARAM(command_buffer == NULL) {
         SDL_InvalidParamError("command_buffer");
         return;
     }
-    if (data == NULL) {
+    CHECK_PARAM(data == NULL) {
         SDL_InvalidParamError("data");
         return;
     }
@@ -1644,11 +1656,11 @@ void SDL_PushGPUComputeUniformData(
     const void *data,
     Uint32 length)
 {
-    if (command_buffer == NULL) {
+    CHECK_PARAM(command_buffer == NULL) {
         SDL_InvalidParamError("command_buffer");
         return;
     }
-    if (data == NULL) {
+    CHECK_PARAM(data == NULL) {
         SDL_InvalidParamError("data");
         return;
     }
@@ -1674,26 +1686,18 @@ SDL_GPURenderPass *SDL_BeginGPURenderPass(
 {
     CommandBufferCommonHeader *commandBufferHeader;
 
-    if (command_buffer == NULL) {
+    CHECK_PARAM(command_buffer == NULL) {
         SDL_InvalidParamError("command_buffer");
         return NULL;
     }
-    if (color_target_infos == NULL && num_color_targets > 0) {
+    CHECK_PARAM(color_target_infos == NULL && num_color_targets > 0) {
         SDL_InvalidParamError("color_target_infos");
         return NULL;
     }
 
-    if (num_color_targets > MAX_COLOR_TARGET_BINDINGS) {
+    CHECK_PARAM(num_color_targets > MAX_COLOR_TARGET_BINDINGS) {
         SDL_SetError("num_color_targets exceeds MAX_COLOR_TARGET_BINDINGS");
         return NULL;
-    }
-
-    if (depth_stencil_target_info != NULL) {
-        TextureCommonHeader *depthTextureCommonHeader = (TextureCommonHeader *) depth_stencil_target_info->texture;
-        if (depthTextureCommonHeader->info.layer_count_or_depth > 255) {
-            SDL_SetError("Cannot bind a depth texture with more than 255 layers!");
-            return NULL;
-        }
     }
 
     if (COMMAND_BUFFER_DEVICE->debug_mode) {
@@ -1749,10 +1753,14 @@ SDL_GPURenderPass *SDL_BeginGPURenderPass(
         }
 
         if (depth_stencil_target_info != NULL) {
-
             TextureCommonHeader *textureHeader = (TextureCommonHeader *)depth_stencil_target_info->texture;
             if (!(textureHeader->info.usage & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET)) {
                 SDL_assert_release(!"Depth target must have been created with the DEPTH_STENCIL_TARGET usage flag!");
+                return NULL;
+            }
+
+            if (textureHeader->info.layer_count_or_depth > 255) {
+                SDL_assert_release("Cannot bind a depth texture with more than 255 layers!");
                 return NULL;
             }
 
@@ -1799,11 +1807,11 @@ void SDL_BindGPUGraphicsPipeline(
     SDL_GPURenderPass *render_pass,
     SDL_GPUGraphicsPipeline *graphics_pipeline)
 {
-    if (render_pass == NULL) {
+    CHECK_PARAM(render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
-    if (graphics_pipeline == NULL) {
+    CHECK_PARAM(graphics_pipeline == NULL) {
         SDL_InvalidParamError("graphics_pipeline");
         return;
     }
@@ -1822,11 +1830,11 @@ void SDL_SetGPUViewport(
     SDL_GPURenderPass *render_pass,
     const SDL_GPUViewport *viewport)
 {
-    if (render_pass == NULL) {
+    CHECK_PARAM(render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
-    if (viewport == NULL) {
+    CHECK_PARAM(viewport == NULL) {
         SDL_InvalidParamError("viewport");
         return;
     }
@@ -1844,11 +1852,11 @@ void SDL_SetGPUScissor(
     SDL_GPURenderPass *render_pass,
     const SDL_Rect *scissor)
 {
-    if (render_pass == NULL) {
+    CHECK_PARAM(render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
-    if (scissor == NULL) {
+    CHECK_PARAM(scissor == NULL) {
         SDL_InvalidParamError("scissor");
         return;
     }
@@ -1866,7 +1874,7 @@ void SDL_SetGPUBlendConstants(
     SDL_GPURenderPass *render_pass,
     SDL_FColor blend_constants)
 {
-    if (render_pass == NULL) {
+    CHECK_PARAM(render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
@@ -1884,7 +1892,7 @@ void SDL_SetGPUStencilReference(
     SDL_GPURenderPass *render_pass,
     Uint8 reference)
 {
-    if (render_pass == NULL) {
+    CHECK_PARAM(render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
@@ -1904,7 +1912,7 @@ void SDL_BindGPUVertexBuffers(
     const SDL_GPUBufferBinding *bindings,
     Uint32 num_bindings)
 {
-    if (render_pass == NULL) {
+    CHECK_PARAM(render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
@@ -1929,7 +1937,7 @@ void SDL_BindGPUIndexBuffer(
     const SDL_GPUBufferBinding *binding,
     SDL_GPUIndexElementSize index_element_size)
 {
-    if (render_pass == NULL) {
+    CHECK_PARAM(render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
@@ -1954,11 +1962,11 @@ void SDL_BindGPUVertexSamplers(
     const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
     Uint32 num_bindings)
 {
-    if (render_pass == NULL) {
+    CHECK_PARAM(render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
-    if (texture_sampler_bindings == NULL && num_bindings > 0) {
+    CHECK_PARAM(texture_sampler_bindings == NULL && num_bindings > 0) {
         SDL_InvalidParamError("texture_sampler_bindings");
         return;
     }
@@ -1989,11 +1997,11 @@ void SDL_BindGPUVertexStorageTextures(
     SDL_GPUTexture *const *storage_textures,
     Uint32 num_bindings)
 {
-    if (render_pass == NULL) {
+    CHECK_PARAM(render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
-    if (storage_textures == NULL && num_bindings > 0) {
+    CHECK_PARAM(storage_textures == NULL && num_bindings > 0) {
         SDL_InvalidParamError("storage_textures");
         return;
     }
@@ -2020,11 +2028,11 @@ void SDL_BindGPUVertexStorageBuffers(
     SDL_GPUBuffer *const *storage_buffers,
     Uint32 num_bindings)
 {
-    if (render_pass == NULL) {
+    CHECK_PARAM(render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
-    if (storage_buffers == NULL && num_bindings > 0) {
+    CHECK_PARAM(storage_buffers == NULL && num_bindings > 0) {
         SDL_InvalidParamError("storage_buffers");
         return;
     }
@@ -2050,11 +2058,11 @@ void SDL_BindGPUFragmentSamplers(
     const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
     Uint32 num_bindings)
 {
-    if (render_pass == NULL) {
+    CHECK_PARAM(render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
-    if (texture_sampler_bindings == NULL && num_bindings > 0) {
+    CHECK_PARAM(texture_sampler_bindings == NULL && num_bindings > 0) {
         SDL_InvalidParamError("texture_sampler_bindings");
         return;
     }
@@ -2084,11 +2092,11 @@ void SDL_BindGPUFragmentStorageTextures(
     SDL_GPUTexture *const *storage_textures,
     Uint32 num_bindings)
 {
-    if (render_pass == NULL) {
+    CHECK_PARAM(render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
-    if (storage_textures == NULL && num_bindings > 0) {
+    CHECK_PARAM(storage_textures == NULL && num_bindings > 0) {
         SDL_InvalidParamError("storage_textures");
         return;
     }
@@ -2115,11 +2123,11 @@ void SDL_BindGPUFragmentStorageBuffers(
     SDL_GPUBuffer *const *storage_buffers,
     Uint32 num_bindings)
 {
-    if (render_pass == NULL) {
+    CHECK_PARAM(render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
-    if (storage_buffers == NULL && num_bindings > 0) {
+    CHECK_PARAM(storage_buffers == NULL && num_bindings > 0) {
         SDL_InvalidParamError("storage_buffers");
         return;
     }
@@ -2147,7 +2155,7 @@ void SDL_DrawGPUIndexedPrimitives(
     Sint32 vertex_offset,
     Uint32 first_instance)
 {
-    if (render_pass == NULL) {
+    CHECK_PARAM(render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
@@ -2174,7 +2182,7 @@ void SDL_DrawGPUPrimitives(
     Uint32 first_vertex,
     Uint32 first_instance)
 {
-    if (render_pass == NULL) {
+    CHECK_PARAM(render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
@@ -2199,11 +2207,11 @@ void SDL_DrawGPUPrimitivesIndirect(
     Uint32 offset,
     Uint32 draw_count)
 {
-    if (render_pass == NULL) {
+    CHECK_PARAM(render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
-    if (buffer == NULL) {
+    CHECK_PARAM(buffer == NULL) {
         SDL_InvalidParamError("buffer");
         return;
     }
@@ -2227,11 +2235,11 @@ void SDL_DrawGPUIndexedPrimitivesIndirect(
     Uint32 offset,
     Uint32 draw_count)
 {
-    if (render_pass == NULL) {
+    CHECK_PARAM(render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
-    if (buffer == NULL) {
+    CHECK_PARAM(buffer == NULL) {
         SDL_InvalidParamError("buffer");
         return;
     }
@@ -2252,7 +2260,7 @@ void SDL_DrawGPUIndexedPrimitivesIndirect(
 void SDL_EndGPURenderPass(
     SDL_GPURenderPass *render_pass)
 {
-    if (render_pass == NULL) {
+    CHECK_PARAM(render_pass == NULL) {
         SDL_InvalidParamError("render_pass");
         return;
     }
@@ -2296,26 +2304,27 @@ SDL_GPUComputePass *SDL_BeginGPUComputePass(
 {
     CommandBufferCommonHeader *commandBufferHeader;
 
-    if (command_buffer == NULL) {
+    CHECK_PARAM(command_buffer == NULL) {
         SDL_InvalidParamError("command_buffer");
         return NULL;
     }
-    if (storage_texture_bindings == NULL && num_storage_texture_bindings > 0) {
+    CHECK_PARAM(storage_texture_bindings == NULL && num_storage_texture_bindings > 0) {
         SDL_InvalidParamError("storage_texture_bindings");
         return NULL;
     }
-    if (storage_buffer_bindings == NULL && num_storage_buffer_bindings > 0) {
+    CHECK_PARAM(storage_buffer_bindings == NULL && num_storage_buffer_bindings > 0) {
         SDL_InvalidParamError("storage_buffer_bindings");
         return NULL;
     }
-    if (num_storage_texture_bindings > MAX_COMPUTE_WRITE_TEXTURES) {
+    CHECK_PARAM(num_storage_texture_bindings > MAX_COMPUTE_WRITE_TEXTURES) {
         SDL_InvalidParamError("num_storage_texture_bindings");
         return NULL;
     }
-    if (num_storage_buffer_bindings > MAX_COMPUTE_WRITE_BUFFERS) {
+    CHECK_PARAM(num_storage_buffer_bindings > MAX_COMPUTE_WRITE_BUFFERS) {
         SDL_InvalidParamError("num_storage_buffer_bindings");
         return NULL;
     }
+
     if (COMMAND_BUFFER_DEVICE->debug_mode) {
         CHECK_COMMAND_BUFFER_RETURN_NULL
         CHECK_ANY_PASS_IN_PROGRESS("Cannot begin compute pass during another pass!", NULL)
@@ -2369,11 +2378,11 @@ void SDL_BindGPUComputePipeline(
     SDL_GPUComputePass *compute_pass,
     SDL_GPUComputePipeline *compute_pipeline)
 {
-    if (compute_pass == NULL) {
+    CHECK_PARAM(compute_pass == NULL) {
         SDL_InvalidParamError("compute_pass");
         return;
     }
-    if (compute_pipeline == NULL) {
+    CHECK_PARAM(compute_pipeline == NULL) {
         SDL_InvalidParamError("compute_pipeline");
         return;
     }
@@ -2398,11 +2407,11 @@ void SDL_BindGPUComputeSamplers(
     const SDL_GPUTextureSamplerBinding *texture_sampler_bindings,
     Uint32 num_bindings)
 {
-    if (compute_pass == NULL) {
+    CHECK_PARAM(compute_pass == NULL) {
         SDL_InvalidParamError("compute_pass");
         return;
     }
-    if (texture_sampler_bindings == NULL && num_bindings > 0) {
+    CHECK_PARAM(texture_sampler_bindings == NULL && num_bindings > 0) {
         SDL_InvalidParamError("texture_sampler_bindings");
         return;
     }
@@ -2428,11 +2437,11 @@ void SDL_BindGPUComputeStorageTextures(
     SDL_GPUTexture *const *storage_textures,
     Uint32 num_bindings)
 {
-    if (compute_pass == NULL) {
+    CHECK_PARAM(compute_pass == NULL) {
         SDL_InvalidParamError("compute_pass");
         return;
     }
-    if (storage_textures == NULL && num_bindings > 0) {
+    CHECK_PARAM(storage_textures == NULL && num_bindings > 0) {
         SDL_InvalidParamError("storage_textures");
         return;
     }
@@ -2458,11 +2467,11 @@ void SDL_BindGPUComputeStorageBuffers(
     SDL_GPUBuffer *const *storage_buffers,
     Uint32 num_bindings)
 {
-    if (compute_pass == NULL) {
+    CHECK_PARAM(compute_pass == NULL) {
         SDL_InvalidParamError("compute_pass");
         return;
     }
-    if (storage_buffers == NULL && num_bindings > 0) {
+    CHECK_PARAM(storage_buffers == NULL && num_bindings > 0) {
         SDL_InvalidParamError("storage_buffers");
         return;
     }
@@ -2488,7 +2497,7 @@ void SDL_DispatchGPUCompute(
     Uint32 groupcount_y,
     Uint32 groupcount_z)
 {
-    if (compute_pass == NULL) {
+    CHECK_PARAM(compute_pass == NULL) {
         SDL_InvalidParamError("compute_pass");
         return;
     }
@@ -2511,7 +2520,7 @@ void SDL_DispatchGPUComputeIndirect(
     SDL_GPUBuffer *buffer,
     Uint32 offset)
 {
-    if (compute_pass == NULL) {
+    CHECK_PARAM(compute_pass == NULL) {
         SDL_InvalidParamError("compute_pass");
         return;
     }
@@ -2533,7 +2542,7 @@ void SDL_EndGPUComputePass(
 {
     CommandBufferCommonHeader *commandBufferCommonHeader;
 
-    if (compute_pass == NULL) {
+    CHECK_PARAM(compute_pass == NULL) {
         SDL_InvalidParamError("compute_pass");
         return;
     }
@@ -2565,7 +2574,8 @@ void *SDL_MapGPUTransferBuffer(
     bool cycle)
 {
     CHECK_DEVICE_MAGIC(device, NULL);
-    if (transfer_buffer == NULL) {
+
+    CHECK_PARAM(transfer_buffer == NULL) {
         SDL_InvalidParamError("transfer_buffer");
         return NULL;
     }
@@ -2581,7 +2591,8 @@ void SDL_UnmapGPUTransferBuffer(
     SDL_GPUTransferBuffer *transfer_buffer)
 {
     CHECK_DEVICE_MAGIC(device, );
-    if (transfer_buffer == NULL) {
+
+    CHECK_PARAM(transfer_buffer == NULL) {
         SDL_InvalidParamError("transfer_buffer");
         return;
     }
@@ -2598,7 +2609,7 @@ SDL_GPUCopyPass *SDL_BeginGPUCopyPass(
 {
     CommandBufferCommonHeader *commandBufferHeader;
 
-    if (command_buffer == NULL) {
+    CHECK_PARAM(command_buffer == NULL) {
         SDL_InvalidParamError("command_buffer");
         return NULL;
     }
@@ -2626,11 +2637,11 @@ void SDL_UploadToGPUTexture(
     const SDL_GPUTextureRegion *destination,
     bool cycle)
 {
-    if (copy_pass == NULL) {
+    CHECK_PARAM(copy_pass == NULL) {
         SDL_InvalidParamError("copy_pass");
         return;
     }
-    if (source == NULL) {
+    CHECK_PARAM(source == NULL) {
         SDL_InvalidParamError("source");
         return;
     }
@@ -2664,15 +2675,15 @@ void SDL_UploadToGPUBuffer(
     const SDL_GPUBufferRegion *destination,
     bool cycle)
 {
-    if (copy_pass == NULL) {
+    CHECK_PARAM(copy_pass == NULL) {
         SDL_InvalidParamError("copy_pass");
         return;
     }
-    if (source == NULL) {
+    CHECK_PARAM(source == NULL) {
         SDL_InvalidParamError("source");
         return;
     }
-    if (destination == NULL) {
+    CHECK_PARAM(destination == NULL) {
         SDL_InvalidParamError("destination");
         return;
     }
@@ -2705,15 +2716,15 @@ void SDL_CopyGPUTextureToTexture(
     Uint32 d,
     bool cycle)
 {
-    if (copy_pass == NULL) {
+    CHECK_PARAM(copy_pass == NULL) {
         SDL_InvalidParamError("copy_pass");
         return;
     }
-    if (source == NULL) {
+    CHECK_PARAM(source == NULL) {
         SDL_InvalidParamError("source");
         return;
     }
-    if (destination == NULL) {
+    CHECK_PARAM(destination == NULL) {
         SDL_InvalidParamError("destination");
         return;
     }
@@ -2754,15 +2765,15 @@ void SDL_CopyGPUBufferToBuffer(
     Uint32 size,
     bool cycle)
 {
-    if (copy_pass == NULL) {
+    CHECK_PARAM(copy_pass == NULL) {
         SDL_InvalidParamError("copy_pass");
         return;
     }
-    if (source == NULL) {
+    CHECK_PARAM(source == NULL) {
         SDL_InvalidParamError("source");
         return;
     }
-    if (destination == NULL) {
+    CHECK_PARAM(destination == NULL) {
         SDL_InvalidParamError("destination");
         return;
     }
@@ -2792,15 +2803,15 @@ void SDL_DownloadFromGPUTexture(
     const SDL_GPUTextureRegion *source,
     const SDL_GPUTextureTransferInfo *destination)
 {
-    if (copy_pass == NULL) {
+    CHECK_PARAM(copy_pass == NULL) {
         SDL_InvalidParamError("copy_pass");
         return;
     }
-    if (source == NULL) {
+    CHECK_PARAM(source == NULL) {
         SDL_InvalidParamError("source");
         return;
     }
-    if (destination == NULL) {
+    CHECK_PARAM(destination == NULL) {
         SDL_InvalidParamError("destination");
         return;
     }
@@ -2828,15 +2839,15 @@ void SDL_DownloadFromGPUBuffer(
     const SDL_GPUBufferRegion *source,
     const SDL_GPUTransferBufferLocation *destination)
 {
-    if (copy_pass == NULL) {
+    CHECK_PARAM(copy_pass == NULL) {
         SDL_InvalidParamError("copy_pass");
         return;
     }
-    if (source == NULL) {
+    CHECK_PARAM(source == NULL) {
         SDL_InvalidParamError("source");
         return;
     }
-    if (destination == NULL) {
+    CHECK_PARAM(destination == NULL) {
         SDL_InvalidParamError("destination");
         return;
     }
@@ -2862,7 +2873,7 @@ void SDL_DownloadFromGPUBuffer(
 void SDL_EndGPUCopyPass(
     SDL_GPUCopyPass *copy_pass)
 {
-    if (copy_pass == NULL) {
+    CHECK_PARAM(copy_pass == NULL) {
         SDL_InvalidParamError("copy_pass");
         return;
     }
@@ -2883,11 +2894,11 @@ void SDL_GenerateMipmapsForGPUTexture(
     SDL_GPUCommandBuffer *command_buffer,
     SDL_GPUTexture *texture)
 {
-    if (command_buffer == NULL) {
+    CHECK_PARAM(command_buffer == NULL) {
         SDL_InvalidParamError("command_buffer");
         return;
     }
-    if (texture == NULL) {
+    CHECK_PARAM(texture == NULL) {
         SDL_InvalidParamError("texture");
         return;
     }
@@ -2925,11 +2936,11 @@ void SDL_BlitGPUTexture(
     SDL_GPUCommandBuffer *command_buffer,
     const SDL_GPUBlitInfo *info)
 {
-    if (command_buffer == NULL) {
+    CHECK_PARAM(command_buffer == NULL) {
         SDL_InvalidParamError("command_buffer");
         return;
     }
-    if (info == NULL) {
+    CHECK_PARAM(info == NULL) {
         SDL_InvalidParamError("info");
         return;
     }
@@ -2990,7 +3001,8 @@ bool SDL_WindowSupportsGPUSwapchainComposition(
     SDL_GPUSwapchainComposition swapchain_composition)
 {
     CHECK_DEVICE_MAGIC(device, false);
-    if (window == NULL) {
+
+    CHECK_PARAM(window == NULL) {
         SDL_InvalidParamError("window");
         return false;
     }
@@ -3011,7 +3023,8 @@ bool SDL_WindowSupportsGPUPresentMode(
     SDL_GPUPresentMode present_mode)
 {
     CHECK_DEVICE_MAGIC(device, false);
-    if (window == NULL) {
+
+    CHECK_PARAM(window == NULL) {
         SDL_InvalidParamError("window");
         return false;
     }
@@ -3031,7 +3044,8 @@ bool SDL_ClaimWindowForGPUDevice(
     SDL_Window *window)
 {
     CHECK_DEVICE_MAGIC(device, false);
-    if (window == NULL) {
+
+    CHECK_PARAM(window == NULL) {
         return SDL_InvalidParamError("window");
     }
 
@@ -3049,7 +3063,8 @@ void SDL_ReleaseWindowFromGPUDevice(
     SDL_Window *window)
 {
     CHECK_DEVICE_MAGIC(device, );
-    if (window == NULL) {
+
+    CHECK_PARAM(window == NULL) {
         SDL_InvalidParamError("window");
         return;
     }
@@ -3066,7 +3081,8 @@ bool SDL_SetGPUSwapchainParameters(
     SDL_GPUPresentMode present_mode)
 {
     CHECK_DEVICE_MAGIC(device, false);
-    if (window == NULL) {
+
+    CHECK_PARAM(window == NULL) {
         SDL_InvalidParamError("window");
         return false;
     }
@@ -3107,7 +3123,8 @@ SDL_GPUTextureFormat SDL_GetGPUSwapchainTextureFormat(
     SDL_Window *window)
 {
     CHECK_DEVICE_MAGIC(device, SDL_GPU_TEXTUREFORMAT_INVALID);
-    if (window == NULL) {
+
+    CHECK_PARAM(window == NULL) {
         SDL_InvalidParamError("window");
         return SDL_GPU_TEXTUREFORMAT_INVALID;
     }
@@ -3126,13 +3143,13 @@ bool SDL_AcquireGPUSwapchainTexture(
 {
     CommandBufferCommonHeader *commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
 
-    if (command_buffer == NULL) {
+    CHECK_PARAM(command_buffer == NULL) {
         return SDL_InvalidParamError("command_buffer");
     }
-    if (window == NULL) {
+    CHECK_PARAM(window == NULL) {
         return SDL_InvalidParamError("window");
     }
-    if (swapchain_texture == NULL) {
+    CHECK_PARAM(swapchain_texture == NULL) {
         return SDL_InvalidParamError("swapchain_texture");
     }
 
@@ -3161,7 +3178,7 @@ bool SDL_WaitForGPUSwapchain(
 {
     CHECK_DEVICE_MAGIC(device, false);
 
-    if (window == NULL) {
+    CHECK_PARAM(window == NULL) {
         return SDL_InvalidParamError("window");
     }
 
@@ -3179,13 +3196,13 @@ bool SDL_WaitAndAcquireGPUSwapchainTexture(
 {
     CommandBufferCommonHeader *commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
 
-    if (command_buffer == NULL) {
+    CHECK_PARAM(command_buffer == NULL) {
         return SDL_InvalidParamError("command_buffer");
     }
-    if (window == NULL) {
+    CHECK_PARAM(window == NULL) {
         return SDL_InvalidParamError("window");
     }
-    if (swapchain_texture == NULL) {
+    CHECK_PARAM(swapchain_texture == NULL) {
         return SDL_InvalidParamError("swapchain_texture");
     }
 
@@ -3213,7 +3230,7 @@ bool SDL_SubmitGPUCommandBuffer(
 {
     CommandBufferCommonHeader *commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
 
-    if (command_buffer == NULL) {
+    CHECK_PARAM(command_buffer == NULL) {
         SDL_InvalidParamError("command_buffer");
         return false;
     }
@@ -3240,7 +3257,7 @@ SDL_GPUFence *SDL_SubmitGPUCommandBufferAndAcquireFence(
 {
     CommandBufferCommonHeader *commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
 
-    if (command_buffer == NULL) {
+    CHECK_PARAM(command_buffer == NULL) {
         SDL_InvalidParamError("command_buffer");
         return NULL;
     }
@@ -3267,7 +3284,7 @@ bool SDL_CancelGPUCommandBuffer(
 {
     CommandBufferCommonHeader *commandBufferHeader = (CommandBufferCommonHeader *)command_buffer;
 
-    if (command_buffer == NULL) {
+    CHECK_PARAM(command_buffer == NULL) {
         SDL_InvalidParamError("command_buffer");
         return false;
     }
@@ -3299,7 +3316,8 @@ bool SDL_WaitForGPUFences(
     Uint32 num_fences)
 {
     CHECK_DEVICE_MAGIC(device, false);
-    if (fences == NULL && num_fences > 0) {
+
+    CHECK_PARAM(fences == NULL && num_fences > 0) {
         SDL_InvalidParamError("fences");
         return false;
     }
@@ -3316,7 +3334,8 @@ bool SDL_QueryGPUFence(
     SDL_GPUFence *fence)
 {
     CHECK_DEVICE_MAGIC(device, false);
-    if (fence == NULL) {
+
+    CHECK_PARAM(fence == NULL) {
         SDL_InvalidParamError("fence");
         return false;
     }
@@ -3331,7 +3350,8 @@ void SDL_ReleaseGPUFence(
     SDL_GPUFence *fence)
 {
     CHECK_DEVICE_MAGIC(device, );
-    if (fence == NULL) {
+
+    CHECK_PARAM(fence == NULL) {
         return;
     }
 

--- a/src/io/SDL_asyncio.c
+++ b/src/io/SDL_asyncio.c
@@ -42,10 +42,11 @@ static const char *AsyncFileModeValid(const char *mode)
 
 SDL_AsyncIO *SDL_AsyncIOFromFile(const char *file, const char *mode)
 {
-    if (!file) {
+    CHECK_PARAM(!file) {
         SDL_InvalidParamError("file");
         return NULL;
-    } else if (!mode) {
+    }
+    CHECK_PARAM(!mode) {
         SDL_InvalidParamError("mode");
         return NULL;
     }
@@ -78,7 +79,7 @@ SDL_AsyncIO *SDL_AsyncIOFromFile(const char *file, const char *mode)
 
 Sint64 SDL_GetAsyncIOSize(SDL_AsyncIO *asyncio)
 {
-    if (!asyncio) {
+    CHECK_PARAM(!asyncio) {
         SDL_InvalidParamError("asyncio");
         return -1;
     }
@@ -87,11 +88,13 @@ Sint64 SDL_GetAsyncIOSize(SDL_AsyncIO *asyncio)
 
 static bool RequestAsyncIO(bool reading, SDL_AsyncIO *asyncio, void *ptr, Uint64 offset, Uint64 size, SDL_AsyncIOQueue *queue, void *userdata)
 {
-    if (!asyncio) {
+    CHECK_PARAM(!asyncio) {
         return SDL_InvalidParamError("asyncio");
-    } else if (!ptr) {
+    }
+    CHECK_PARAM(!ptr) {
         return SDL_InvalidParamError("ptr");
-    } else if (!queue) {
+    }
+    CHECK_PARAM(!queue) {
         return SDL_InvalidParamError("queue");
     }
 
@@ -143,9 +146,10 @@ bool SDL_WriteAsyncIO(SDL_AsyncIO *asyncio, void *ptr, Uint64 offset, Uint64 siz
 
 bool SDL_CloseAsyncIO(SDL_AsyncIO *asyncio, bool flush, SDL_AsyncIOQueue *queue, void *userdata)
 {
-    if (!asyncio) {
+    CHECK_PARAM(!asyncio) {
         return SDL_InvalidParamError("asyncio");
-    } else if (!queue) {
+    }
+    CHECK_PARAM(!queue) {
         return SDL_InvalidParamError("queue");
     }
 
@@ -298,9 +302,10 @@ void SDL_QuitAsyncIO(void)
 
 bool SDL_LoadFileAsync(const char *file, SDL_AsyncIOQueue *queue, void *userdata)
 {
-    if (!file) {
+    CHECK_PARAM(!file) {
         return SDL_InvalidParamError("file");
-    } else if (!queue) {
+    }
+    CHECK_PARAM(!queue) {
         return SDL_InvalidParamError("queue");
     }
 

--- a/src/io/SDL_iostream.c
+++ b/src/io/SDL_iostream.c
@@ -875,11 +875,11 @@ SDL_IOStream *SDL_IOFromFile(const char *file, const char *mode)
 {
     SDL_IOStream *iostr = NULL;
 
-    if (!file || !*file) {
+    CHECK_PARAM(!file || !*file) {
         SDL_InvalidParamError("file");
         return NULL;
     }
-    if (!mode || !*mode) {
+    CHECK_PARAM(!mode || !*mode) {
         SDL_InvalidParamError("mode");
         return NULL;
     }
@@ -991,10 +991,11 @@ SDL_IOStream *SDL_IOFromFile(const char *file, const char *mode)
 
 SDL_IOStream *SDL_IOFromMem(void *mem, size_t size)
 {
-    if (!mem) {
+    CHECK_PARAM(!mem) {
         SDL_InvalidParamError("mem");
         return NULL;
-    } else if (!size) {
+    }
+    CHECK_PARAM(!size) {
         SDL_InvalidParamError("size");
         return NULL;
     }
@@ -1032,10 +1033,11 @@ SDL_IOStream *SDL_IOFromMem(void *mem, size_t size)
 
 SDL_IOStream *SDL_IOFromConstMem(const void *mem, size_t size)
 {
-    if (!mem) {
+    CHECK_PARAM(!mem) {
         SDL_InvalidParamError("mem");
         return NULL;
-    } else if (!size) {
+    }
+    CHECK_PARAM(!size) {
         SDL_InvalidParamError("size");
         return NULL;
     }
@@ -1178,7 +1180,7 @@ SDL_IOStream *SDL_IOFromDynamicMem(void)
 
 SDL_IOStatus SDL_GetIOStatus(SDL_IOStream *context)
 {
-    if (!context) {
+    CHECK_PARAM(!context) {
         SDL_InvalidParamError("context");
         return SDL_IO_STATUS_ERROR;
     }
@@ -1187,11 +1189,11 @@ SDL_IOStatus SDL_GetIOStatus(SDL_IOStream *context)
 
 SDL_IOStream *SDL_OpenIO(const SDL_IOStreamInterface *iface, void *userdata)
 {
-    if (!iface) {
+    CHECK_PARAM(!iface) {
         SDL_InvalidParamError("iface");
         return NULL;
     }
-    if (iface->version < sizeof(*iface)) {
+    CHECK_PARAM(iface->version < sizeof(*iface)) {
         // Update this to handle older versions of this interface
         SDL_SetError("Invalid interface, should be initialized with SDL_INIT_INTERFACE()");
         return NULL;
@@ -1227,7 +1229,7 @@ void *SDL_LoadFile_IO(SDL_IOStream *src, size_t *datasize, bool closeio)
     char *data = NULL, *newdata;
     bool loading_chunks = false;
 
-    if (!src) {
+    CHECK_PARAM(!src) {
         SDL_InvalidParamError("src");
         goto done;
     }
@@ -1308,12 +1310,12 @@ bool SDL_SaveFile_IO(SDL_IOStream *src, const void *data, size_t datasize, bool 
     size_t size_total = 0;
     bool success = true;
 
-    if (!src) {
+    CHECK_PARAM(!src) {
         SDL_InvalidParamError("src");
         goto done;
     }
 
-    if (!data && datasize > 0) {
+    CHECK_PARAM(!data && datasize > 0) {
         SDL_InvalidParamError("data");
         goto done;
     }
@@ -1356,7 +1358,7 @@ bool SDL_SaveFile(const char *file, const void *data, size_t datasize)
 
 SDL_PropertiesID SDL_GetIOProperties(SDL_IOStream *context)
 {
-    if (!context) {
+    CHECK_PARAM(!context) {
         SDL_InvalidParamError("context");
         return 0;
     }
@@ -1369,9 +1371,10 @@ SDL_PropertiesID SDL_GetIOProperties(SDL_IOStream *context)
 
 Sint64 SDL_GetIOSize(SDL_IOStream *context)
 {
-    if (!context) {
+    CHECK_PARAM(!context) {
         return SDL_InvalidParamError("context");
     }
+
     if (!context->iface.size) {
         Sint64 pos, size;
 
@@ -1389,10 +1392,12 @@ Sint64 SDL_GetIOSize(SDL_IOStream *context)
 
 Sint64 SDL_SeekIO(SDL_IOStream *context, Sint64 offset, SDL_IOWhence whence)
 {
-    if (!context) {
+    CHECK_PARAM(!context) {
         SDL_InvalidParamError("context");
         return -1;
-    } else if (!context->iface.seek) {
+    }
+
+    if (!context->iface.seek) {
         SDL_Unsupported();
         return -1;
     }
@@ -1406,14 +1411,18 @@ Sint64 SDL_TellIO(SDL_IOStream *context)
 
 size_t SDL_ReadIO(SDL_IOStream *context, void *ptr, size_t size)
 {
-    if (!context) {
+    CHECK_PARAM(!context) {
         SDL_InvalidParamError("context");
         return 0;
-    } else if (!context->iface.read) {
+    }
+
+    if (!context->iface.read) {
         context->status = SDL_IO_STATUS_WRITEONLY;
         SDL_Unsupported();
         return 0;
-    } else if (size == 0) {
+    }
+
+    if (size == 0) {
         return 0;  // context->status doesn't change for this.
     }
 
@@ -1425,14 +1434,18 @@ size_t SDL_ReadIO(SDL_IOStream *context, void *ptr, size_t size)
 
 size_t SDL_WriteIO(SDL_IOStream *context, const void *ptr, size_t size)
 {
-    if (!context) {
+    CHECK_PARAM(!context) {
         SDL_InvalidParamError("context");
         return 0;
-    } else if (!context->iface.write) {
+    }
+
+    if (!context->iface.write) {
         context->status = SDL_IO_STATUS_READONLY;
         SDL_Unsupported();
         return 0;
-    } else if (size == 0) {
+    }
+
+    if (size == 0) {
         return 0;  // context->status doesn't change for this.
     }
 
@@ -1481,7 +1494,7 @@ bool SDL_FlushIO(SDL_IOStream *context)
 {
     bool result = true;
 
-    if (!context) {
+    CHECK_PARAM(!context) {
         return SDL_InvalidParamError("context");
     }
 

--- a/src/joystick/SDL_gamepad.c
+++ b/src/joystick/SDL_gamepad.c
@@ -147,12 +147,12 @@ struct SDL_Gamepad
 
 #undef _guarded
 
-#define CHECK_GAMEPAD_MAGIC(gamepad, result)                    \
-    if (!SDL_ObjectValid(gamepad, SDL_OBJECT_TYPE_GAMEPAD) ||   \
-        !SDL_IsJoystickValid(gamepad->joystick)) {              \
-        SDL_InvalidParamError("gamepad");                       \
-        SDL_UnlockJoysticks();                                  \
-        return result;                                          \
+#define CHECK_GAMEPAD_MAGIC(gamepad, result)                            \
+    CHECK_PARAM(!SDL_ObjectValid(gamepad, SDL_OBJECT_TYPE_GAMEPAD) ||   \
+        !SDL_IsJoystickValid(gamepad->joystick)) {                      \
+        SDL_InvalidParamError("gamepad");                               \
+        SDL_UnlockJoysticks();                                          \
+        return result;                                                  \
     }
 
 static SDL_vidpid_list SDL_allowed_gamepads = {
@@ -2455,7 +2455,7 @@ static int SDL_PrivateAddGamepadMapping(const char *mappingString, SDL_GamepadMa
 
     SDL_AssertJoysticksLocked();
 
-    if (!mappingString) {
+    CHECK_PARAM(!mappingString) {
         SDL_InvalidParamError("mappingString");
         return -1;
     }
@@ -2790,7 +2790,7 @@ bool SDL_SetGamepadMapping(SDL_JoystickID instance_id, const char *mapping)
     SDL_GUID guid = SDL_GetJoystickGUIDForID(instance_id);
     bool result = false;
 
-    if (SDL_memcmp(&guid, &s_zeroGUID, sizeof(guid)) == 0) {
+    CHECK_PARAM(SDL_memcmp(&guid, &s_zeroGUID, sizeof(guid)) == 0) {
         return SDL_InvalidParamError("instance_id");
     }
 

--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -615,18 +615,18 @@ static SDL_vidpid_list zero_centered_devices = {
     false
 };
 
-#define CHECK_JOYSTICK_MAGIC(joystick, result)                  \
-    if (!SDL_ObjectValid(joystick, SDL_OBJECT_TYPE_JOYSTICK)) { \
-        SDL_InvalidParamError("joystick");                      \
-        SDL_UnlockJoysticks();                                  \
-        return result;                                          \
+#define CHECK_JOYSTICK_MAGIC(joystick, result)                          \
+    CHECK_PARAM(!SDL_ObjectValid(joystick, SDL_OBJECT_TYPE_JOYSTICK)) { \
+        SDL_InvalidParamError("joystick");                              \
+        SDL_UnlockJoysticks();                                          \
+        return result;                                                  \
     }
 
-#define CHECK_JOYSTICK_VIRTUAL(joystick, result)                \
-    if (!joystick->is_virtual) {                                \
-        SDL_SetError("joystick isn't virtual");                 \
-        SDL_UnlockJoysticks();                                  \
-        return result;                                          \
+#define CHECK_JOYSTICK_VIRTUAL(joystick, result)                        \
+    CHECK_PARAM(!joystick->is_virtual) {                                \
+        SDL_SetError("joystick isn't virtual");                         \
+        SDL_UnlockJoysticks();                                          \
+        return result;                                                  \
     }
 
 bool SDL_JoysticksInitialized(void)

--- a/src/joystick/virtual/SDL_virtualjoystick.c
+++ b/src/joystick/virtual/SDL_virtualjoystick.c
@@ -138,11 +138,11 @@ SDL_JoystickID SDL_JoystickAttachVirtualInner(const SDL_VirtualJoystickDesc *des
 
     SDL_AssertJoysticksLocked();
 
-    if (!desc) {
+    CHECK_PARAM(!desc) {
         SDL_InvalidParamError("desc");
         return 0;
     }
-    if (desc->version < sizeof(*desc)) {
+    CHECK_PARAM(desc->version < sizeof(*desc)) {
         // Update this to handle older versions of this interface
         SDL_SetError("Invalid desc, should be initialized with SDL_INIT_INTERFACE()");
         return 0;

--- a/src/loadso/windows/SDL_sysloadso.c
+++ b/src/loadso/windows/SDL_sysloadso.c
@@ -29,7 +29,7 @@
 
 SDL_SharedObject *SDL_LoadObject(const char *sofile)
 {
-    if (!sofile) {
+    CHECK_PARAM(!sofile) {
         SDL_InvalidParamError("sofile");
         return NULL;
     }

--- a/src/misc/SDL_url.c
+++ b/src/misc/SDL_url.c
@@ -24,7 +24,7 @@
 
 bool SDL_OpenURL(const char *url)
 {
-    if (!url) {
+    CHECK_PARAM(!url) {
         return SDL_InvalidParamError("url");
     }
     return SDL_SYS_OpenURL(url);

--- a/src/process/SDL_process.c
+++ b/src/process/SDL_process.c
@@ -25,7 +25,7 @@
 
 SDL_Process *SDL_CreateProcess(const char * const *args, bool pipe_stdio)
 {
-    if (!args || !args[0] || !args[0][0]) {
+    CHECK_PARAM(!args || !args[0] || !args[0][0]) {
         SDL_InvalidParamError("args");
         return NULL;
     }
@@ -47,12 +47,12 @@ SDL_Process *SDL_CreateProcessWithProperties(SDL_PropertiesID props)
     const char * const *args = SDL_GetPointerProperty(props, SDL_PROP_PROCESS_CREATE_ARGS_POINTER, NULL);
 #if defined(SDL_PLATFORM_WINDOWS)
     const char *cmdline = SDL_GetStringProperty(props, SDL_PROP_PROCESS_CREATE_CMDLINE_STRING, NULL);
-    if ((!args || !args[0] || !args[0][0]) && (!cmdline || !cmdline[0])) {
+    CHECK_PARAM((!args || !args[0] || !args[0][0]) && (!cmdline || !cmdline[0])) {
         SDL_SetError("Either SDL_PROP_PROCESS_CREATE_ARGS_POINTER or SDL_PROP_PROCESS_CREATE_CMDLINE_STRING must be valid");
         return NULL;
     }
 #else
-    if (!args || !args[0] || !args[0][0]) {
+    CHECK_PARAM(!args || !args[0] || !args[0][0]) {
         SDL_InvalidParamError("SDL_PROP_PROCESS_CREATE_ARGS_POINTER");
         return NULL;
     }
@@ -81,7 +81,7 @@ SDL_Process *SDL_CreateProcessWithProperties(SDL_PropertiesID props)
 
 SDL_PropertiesID SDL_GetProcessProperties(SDL_Process *process)
 {
-    if (!process) {
+    CHECK_PARAM(!process) {
         return SDL_InvalidParamError("process");
     }
     return process->props;
@@ -98,7 +98,7 @@ void *SDL_ReadProcess(SDL_Process *process, size_t *datasize, int *exitcode)
         *exitcode = -1;
     }
 
-    if (!process) {
+    CHECK_PARAM(!process) {
         SDL_InvalidParamError("process");
         return NULL;
     }
@@ -118,7 +118,7 @@ void *SDL_ReadProcess(SDL_Process *process, size_t *datasize, int *exitcode)
 
 SDL_IOStream *SDL_GetProcessInput(SDL_Process *process)
 {
-    if (!process) {
+    CHECK_PARAM(!process) {
         SDL_InvalidParamError("process");
         return NULL;
     }
@@ -134,7 +134,7 @@ SDL_IOStream *SDL_GetProcessInput(SDL_Process *process)
 
 SDL_IOStream *SDL_GetProcessOutput(SDL_Process *process)
 {
-    if (!process) {
+    CHECK_PARAM(!process) {
         SDL_InvalidParamError("process");
         return NULL;
     }
@@ -150,7 +150,7 @@ SDL_IOStream *SDL_GetProcessOutput(SDL_Process *process)
 
 bool SDL_KillProcess(SDL_Process *process, bool force)
 {
-    if (!process) {
+    CHECK_PARAM(!process) {
         return SDL_InvalidParamError("process");
     }
 
@@ -163,7 +163,7 @@ bool SDL_KillProcess(SDL_Process *process, bool force)
 
 bool SDL_WaitProcess(SDL_Process *process, bool block, int *exitcode)
 {
-    if (!process) {
+    CHECK_PARAM(!process) {
         return SDL_InvalidParamError("process");
     }
 

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -832,11 +832,9 @@ int SDL_GetNumRenderDrivers(void)
 const char *SDL_GetRenderDriver(int index)
 {
 #ifndef SDL_RENDER_DISABLED
-    PARAMETER_CHECKS {
-        CHECK_PARAM(index < 0 || index >= SDL_GetNumRenderDrivers()) {
-            SDL_InvalidParamError("index");
-            return NULL;
-        }
+    CHECK_PARAM(index < 0 || index >= SDL_GetNumRenderDrivers()) {
+        SDL_InvalidParamError("index");
+        return NULL;
     }
     return render_drivers[index]->name;
 #else
@@ -887,14 +885,12 @@ static bool SDL_RendererEventWatch(void *userdata, SDL_Event *event)
 
 bool SDL_CreateWindowAndRenderer(const char *title, int width, int height, SDL_WindowFlags window_flags, SDL_Window **window, SDL_Renderer **renderer)
 {
-    PARAMETER_CHECKS {
-        CHECK_PARAM(!window) {
-            return SDL_InvalidParamError("window");
-        }
+    CHECK_PARAM(!window) {
+        return SDL_InvalidParamError("window");
+    }
 
-        CHECK_PARAM(!renderer) {
-            return SDL_InvalidParamError("renderer");
-        }
+    CHECK_PARAM(!renderer) {
+        return SDL_InvalidParamError("renderer");
     }
 
     // Hide the window so if the renderer recreates it, we don't get a visual flash on screen
@@ -988,21 +984,19 @@ SDL_Renderer *SDL_CreateRendererWithProperties(SDL_PropertiesID props)
     const char *hint;
     SDL_PropertiesID new_props;
 
-    PARAMETER_CHECKS {
-        CHECK_PARAM((!window && !surface) || (window && surface)) {
-            SDL_InvalidParamError("window");
-            return NULL;
-        }
+    CHECK_PARAM((!window && !surface) || (window && surface)) {
+        SDL_InvalidParamError("window");
+        return NULL;
+    }
 
-        CHECK_PARAM(window && SDL_WindowHasSurface(window)) {
-            SDL_SetError("Surface already associated with window");
-            return NULL;
-        }
+    CHECK_PARAM(window && SDL_WindowHasSurface(window)) {
+        SDL_SetError("Surface already associated with window");
+        return NULL;
+    }
 
-        CHECK_PARAM(window && SDL_GetRenderer(window)) {
-            SDL_SetError("Renderer already associated with window");
-            return NULL;
-        }
+    CHECK_PARAM(window && SDL_GetRenderer(window)) {
+        SDL_SetError("Renderer already associated with window");
+        return NULL;
     }
 
 #ifdef SDL_PLATFORM_ANDROID
@@ -1207,11 +1201,9 @@ SDL_Renderer *SDL_CreateRenderer(SDL_Window *window, const char *name)
 
 SDL_Renderer *SDL_CreateGPURenderer(SDL_Window *window, SDL_GPUShaderFormat format_flags, SDL_GPUDevice **device)
 {
-    PARAMETER_CHECKS {
-        CHECK_PARAM(!device) {
-            SDL_InvalidParamError("device");
-            return NULL;
-        }
+    CHECK_PARAM(!device) {
+        SDL_InvalidParamError("device");
+        return NULL;
     }
 
     *device = NULL;
@@ -1243,11 +1235,9 @@ SDL_Renderer *SDL_CreateSoftwareRenderer(SDL_Surface *surface)
 #ifdef SDL_VIDEO_RENDER_SW
     SDL_Renderer *renderer;
 
-    PARAMETER_CHECKS {
-        CHECK_PARAM(!surface) {
-            SDL_InvalidParamError("surface");
-            return NULL;
-        }
+    CHECK_PARAM(!surface) {
+        SDL_InvalidParamError("surface");
+        return NULL;
     }
 
     SDL_PropertiesID props = SDL_CreateProperties();
@@ -1268,26 +1258,20 @@ SDL_Renderer *SDL_GetRenderer(SDL_Window *window)
 
 SDL_Window *SDL_GetRenderWindow(SDL_Renderer *renderer)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, NULL);
-    }
+    CHECK_RENDERER_MAGIC(renderer, NULL);
     return renderer->window;
 }
 
 const char *SDL_GetRendererName(SDL_Renderer *renderer)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, NULL);
-    }
+    CHECK_RENDERER_MAGIC(renderer, NULL);
 
     return SDL_GetPersistentString(renderer->name);
 }
 
 SDL_PropertiesID SDL_GetRendererProperties(SDL_Renderer *renderer)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, 0);
-    }
+    CHECK_RENDERER_MAGIC(renderer, 0);
 
     if (renderer->props == 0) {
         renderer->props = SDL_CreateProperties();
@@ -1297,16 +1281,14 @@ SDL_PropertiesID SDL_GetRendererProperties(SDL_Renderer *renderer)
 
 bool SDL_GetRenderOutputSize(SDL_Renderer *renderer, int *w, int *h)
 {
-    PARAMETER_CHECKS {
-        if (w) {
-            *w = 0;
-        }
-        if (h) {
-            *h = 0;
-        }
-
-        CHECK_RENDERER_MAGIC(renderer, false);
+    if (w) {
+        *w = 0;
     }
+    if (h) {
+        *h = 0;
+    }
+
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     if (renderer->GetOutputSize) {
         return renderer->GetOutputSize(renderer, w, h);
@@ -1320,16 +1302,14 @@ bool SDL_GetRenderOutputSize(SDL_Renderer *renderer, int *w, int *h)
 
 bool SDL_GetCurrentRenderOutputSize(SDL_Renderer *renderer, int *w, int *h)
 {
-    PARAMETER_CHECKS {
-        if (w) {
-            *w = 0;
-        }
-        if (h) {
-            *h = 0;
-        }
-
-        CHECK_RENDERER_MAGIC(renderer, false);
+    if (w) {
+        *w = 0;
     }
+    if (h) {
+        *h = 0;
+    }
+
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     const SDL_RenderViewState *view = renderer->view;
     if (w) {
@@ -1431,32 +1411,28 @@ SDL_Texture *SDL_CreateTextureWithProperties(SDL_Renderer *renderer, SDL_Propert
     SDL_Colorspace default_colorspace;
     bool texture_is_fourcc_and_target;
 
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, NULL);
-    }
+    CHECK_RENDERER_MAGIC(renderer, NULL);
 
     if (!format) {
         format = renderer->texture_formats[0];
     }
 
-    PARAMETER_CHECKS {
-        CHECK_PARAM(SDL_BYTESPERPIXEL(format) == 0) {
-            SDL_SetError("Invalid texture format");
-            return NULL;
-        }
-        CHECK_PARAM(SDL_ISPIXELFORMAT_INDEXED(format) && !IsSupportedFormat(renderer, format)) {
-            SDL_SetError("Palettized textures are not supported");
-            return NULL;
-        }
-        CHECK_PARAM(w <= 0 || h <= 0) {
-            SDL_SetError("Texture dimensions can't be 0");
-            return NULL;
-        }
-        int max_texture_size = (int)SDL_GetNumberProperty(SDL_GetRendererProperties(renderer), SDL_PROP_RENDERER_MAX_TEXTURE_SIZE_NUMBER, 0);
-        CHECK_PARAM(max_texture_size && (w > max_texture_size || h > max_texture_size)) {
-            SDL_SetError("Texture dimensions are limited to %dx%d", max_texture_size, max_texture_size);
-            return NULL;
-        }
+    CHECK_PARAM(SDL_BYTESPERPIXEL(format) == 0) {
+        SDL_SetError("Invalid texture format");
+        return NULL;
+    }
+    CHECK_PARAM(SDL_ISPIXELFORMAT_INDEXED(format) && !IsSupportedFormat(renderer, format)) {
+        SDL_SetError("Palettized textures are not supported");
+        return NULL;
+    }
+    CHECK_PARAM(w <= 0 || h <= 0) {
+        SDL_SetError("Texture dimensions can't be 0");
+        return NULL;
+    }
+    int max_texture_size = (int)SDL_GetNumberProperty(SDL_GetRendererProperties(renderer), SDL_PROP_RENDERER_MAX_TEXTURE_SIZE_NUMBER, 0);
+    CHECK_PARAM(max_texture_size && (w > max_texture_size || h > max_texture_size)) {
+        SDL_SetError("Texture dimensions are limited to %dx%d", max_texture_size, max_texture_size);
+        return NULL;
     }
 
     default_colorspace = SDL_GetDefaultColorspaceForFormat(format);
@@ -1719,13 +1695,11 @@ SDL_Texture *SDL_CreateTextureFromSurface(SDL_Renderer *renderer, SDL_Surface *s
     SDL_Colorspace surface_colorspace = SDL_COLORSPACE_UNKNOWN;
     SDL_Colorspace texture_colorspace = SDL_COLORSPACE_UNKNOWN;
 
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, NULL);
+    CHECK_RENDERER_MAGIC(renderer, NULL);
 
-        CHECK_PARAM(!SDL_SurfaceValid(surface)) {
-            SDL_InvalidParamError("SDL_CreateTextureFromSurface(): surface");
-            return NULL;
-        }
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
+        SDL_InvalidParamError("SDL_CreateTextureFromSurface(): surface");
+        return NULL;
     }
 
     // See what the best texture format is
@@ -1848,18 +1822,14 @@ SDL_Texture *SDL_CreateTextureFromSurface(SDL_Renderer *renderer, SDL_Surface *s
 
 SDL_Renderer *SDL_GetRendererFromTexture(SDL_Texture *texture)
 {
-    PARAMETER_CHECKS {
-        CHECK_TEXTURE_MAGIC(texture, NULL);
-    }
+    CHECK_TEXTURE_MAGIC(texture, NULL);
 
     return texture->renderer;
 }
 
 SDL_PropertiesID SDL_GetTextureProperties(SDL_Texture *texture)
 {
-    PARAMETER_CHECKS {
-        CHECK_TEXTURE_MAGIC(texture, 0);
-    }
+    CHECK_TEXTURE_MAGIC(texture, 0);
 
     if (texture->props == 0) {
         texture->props = SDL_CreateProperties();
@@ -1869,16 +1839,14 @@ SDL_PropertiesID SDL_GetTextureProperties(SDL_Texture *texture)
 
 bool SDL_GetTextureSize(SDL_Texture *texture, float *w, float *h)
 {
-    PARAMETER_CHECKS {
-        if (w) {
-            *w = 0;
-        }
-        if (h) {
-            *h = 0;
-        }
-
-        CHECK_TEXTURE_MAGIC(texture, false);
+    if (w) {
+        *w = 0;
     }
+    if (h) {
+        *h = 0;
+    }
+
+    CHECK_TEXTURE_MAGIC(texture, false);
 
     if (w) {
         *w = (float)texture->w;
@@ -1900,9 +1868,7 @@ bool SDL_SetTextureColorMod(SDL_Texture *texture, Uint8 r, Uint8 g, Uint8 b)
 
 bool SDL_SetTextureColorModFloat(SDL_Texture *texture, float r, float g, float b)
 {
-    PARAMETER_CHECKS {
-        CHECK_TEXTURE_MAGIC(texture, false);
-    }
+    CHECK_TEXTURE_MAGIC(texture, false);
 
     texture->color.r = r;
     texture->color.g = g;
@@ -1946,19 +1912,17 @@ bool SDL_GetTextureColorModFloat(SDL_Texture *texture, float *r, float *g, float
 {
     SDL_FColor color;
 
-    PARAMETER_CHECKS {
-        if (r) {
-            *r = 1.0f;
-        }
-        if (g) {
-            *g = 1.0f;
-        }
-        if (b) {
-            *b = 1.0f;
-        }
-
-        CHECK_TEXTURE_MAGIC(texture, false);
+    if (r) {
+        *r = 1.0f;
     }
+    if (g) {
+        *g = 1.0f;
+    }
+    if (b) {
+        *b = 1.0f;
+    }
+
+    CHECK_TEXTURE_MAGIC(texture, false);
 
     color = texture->color;
 
@@ -1983,9 +1947,7 @@ bool SDL_SetTextureAlphaMod(SDL_Texture *texture, Uint8 alpha)
 
 bool SDL_SetTextureAlphaModFloat(SDL_Texture *texture, float alpha)
 {
-    PARAMETER_CHECKS {
-        CHECK_TEXTURE_MAGIC(texture, false);
-    }
+    CHECK_TEXTURE_MAGIC(texture, false);
 
     texture->color.a = alpha;
     if (texture->native) {
@@ -2013,13 +1975,11 @@ bool SDL_GetTextureAlphaMod(SDL_Texture *texture, Uint8 *alpha)
 
 bool SDL_GetTextureAlphaModFloat(SDL_Texture *texture, float *alpha)
 {
-    PARAMETER_CHECKS {
-        if (alpha) {
-            *alpha = 1.0f;
-        }
-
-        CHECK_TEXTURE_MAGIC(texture, false);
+    if (alpha) {
+        *alpha = 1.0f;
     }
+
+    CHECK_TEXTURE_MAGIC(texture, false);
 
     if (alpha) {
         *alpha = texture->color.a;
@@ -2031,12 +1991,10 @@ bool SDL_SetTextureBlendMode(SDL_Texture *texture, SDL_BlendMode blendMode)
 {
     SDL_Renderer *renderer;
 
-    PARAMETER_CHECKS {
-        CHECK_TEXTURE_MAGIC(texture, false);
+    CHECK_TEXTURE_MAGIC(texture, false);
 
-        CHECK_PARAM(blendMode == SDL_BLENDMODE_INVALID) {
-            return SDL_InvalidParamError("blendMode");
-        }
+    CHECK_PARAM(blendMode == SDL_BLENDMODE_INVALID) {
+        return SDL_InvalidParamError("blendMode");
     }
 
     renderer = texture->renderer;
@@ -2052,13 +2010,11 @@ bool SDL_SetTextureBlendMode(SDL_Texture *texture, SDL_BlendMode blendMode)
 
 bool SDL_GetTextureBlendMode(SDL_Texture *texture, SDL_BlendMode *blendMode)
 {
-    PARAMETER_CHECKS {
-        if (blendMode) {
-            *blendMode = SDL_BLENDMODE_INVALID;
-        }
-
-        CHECK_TEXTURE_MAGIC(texture, false);
+    if (blendMode) {
+        *blendMode = SDL_BLENDMODE_INVALID;
     }
+
+    CHECK_TEXTURE_MAGIC(texture, false);
 
     if (blendMode) {
         *blendMode = texture->blendMode;
@@ -2068,17 +2024,15 @@ bool SDL_GetTextureBlendMode(SDL_Texture *texture, SDL_BlendMode *blendMode)
 
 bool SDL_SetTextureScaleMode(SDL_Texture *texture, SDL_ScaleMode scaleMode)
 {
-    PARAMETER_CHECKS {
-        CHECK_TEXTURE_MAGIC(texture, false);
+    CHECK_TEXTURE_MAGIC(texture, false);
 
-        switch (scaleMode) {
-        case SDL_SCALEMODE_NEAREST:
-        case SDL_SCALEMODE_LINEAR:
-        case SDL_SCALEMODE_PIXELART:
-            break;
-        default:
-            return SDL_InvalidParamError("scaleMode");
-        }
+    switch (scaleMode) {
+    case SDL_SCALEMODE_NEAREST:
+    case SDL_SCALEMODE_LINEAR:
+    case SDL_SCALEMODE_PIXELART:
+        break;
+    default:
+        return SDL_InvalidParamError("scaleMode");
     }
 
     texture->scaleMode = scaleMode;
@@ -2091,13 +2045,11 @@ bool SDL_SetTextureScaleMode(SDL_Texture *texture, SDL_ScaleMode scaleMode)
 
 bool SDL_GetTextureScaleMode(SDL_Texture *texture, SDL_ScaleMode *scaleMode)
 {
-    PARAMETER_CHECKS {
-        if (scaleMode) {
-            *scaleMode = SDL_SCALEMODE_LINEAR;
-        }
-
-        CHECK_TEXTURE_MAGIC(texture, false);
+    if (scaleMode) {
+        *scaleMode = SDL_SCALEMODE_LINEAR;
     }
+
+    CHECK_TEXTURE_MAGIC(texture, false);
 
     if (scaleMode) {
         *scaleMode = texture->scaleMode;
@@ -2197,15 +2149,13 @@ bool SDL_UpdateTexture(SDL_Texture *texture, const SDL_Rect *rect, const void *p
 {
     SDL_Rect real_rect;
 
-    PARAMETER_CHECKS {
-        CHECK_TEXTURE_MAGIC(texture, false);
+    CHECK_TEXTURE_MAGIC(texture, false);
 
-        CHECK_PARAM(!pixels) {
-            return SDL_InvalidParamError("pixels");
-        }
-        CHECK_PARAM(!pitch) {
-            return SDL_InvalidParamError("pitch");
-        }
+    CHECK_PARAM(!pixels) {
+        return SDL_InvalidParamError("pixels");
+    }
+    CHECK_PARAM(!pitch) {
+        return SDL_InvalidParamError("pitch");
     }
 
     real_rect.x = 0;
@@ -2350,32 +2300,30 @@ bool SDL_UpdateYUVTexture(SDL_Texture *texture, const SDL_Rect *rect,
     SDL_Renderer *renderer;
     SDL_Rect real_rect;
 
-    PARAMETER_CHECKS {
-        CHECK_TEXTURE_MAGIC(texture, false);
+    CHECK_TEXTURE_MAGIC(texture, false);
 
-        CHECK_PARAM(!Yplane) {
-            return SDL_InvalidParamError("Yplane");
-        }
-        CHECK_PARAM(!Ypitch) {
-            return SDL_InvalidParamError("Ypitch");
-        }
-        CHECK_PARAM(!Uplane) {
-            return SDL_InvalidParamError("Uplane");
-        }
-        CHECK_PARAM(!Upitch) {
-            return SDL_InvalidParamError("Upitch");
-        }
-        CHECK_PARAM(!Vplane) {
-            return SDL_InvalidParamError("Vplane");
-        }
-        CHECK_PARAM(!Vpitch) {
-            return SDL_InvalidParamError("Vpitch");
-        }
+    CHECK_PARAM(!Yplane) {
+        return SDL_InvalidParamError("Yplane");
+    }
+    CHECK_PARAM(!Ypitch) {
+        return SDL_InvalidParamError("Ypitch");
+    }
+    CHECK_PARAM(!Uplane) {
+        return SDL_InvalidParamError("Uplane");
+    }
+    CHECK_PARAM(!Upitch) {
+        return SDL_InvalidParamError("Upitch");
+    }
+    CHECK_PARAM(!Vplane) {
+        return SDL_InvalidParamError("Vplane");
+    }
+    CHECK_PARAM(!Vpitch) {
+        return SDL_InvalidParamError("Vpitch");
+    }
 
-        CHECK_PARAM(texture->format != SDL_PIXELFORMAT_YV12 &&
-                    texture->format != SDL_PIXELFORMAT_IYUV) {
-            return SDL_SetError("Texture format must by YV12 or IYUV");
-        }
+    CHECK_PARAM(texture->format != SDL_PIXELFORMAT_YV12 &&
+                texture->format != SDL_PIXELFORMAT_IYUV) {
+        return SDL_SetError("Texture format must by YV12 or IYUV");
     }
 
     real_rect.x = 0;
@@ -2418,26 +2366,24 @@ bool SDL_UpdateNVTexture(SDL_Texture *texture, const SDL_Rect *rect,
     SDL_Renderer *renderer;
     SDL_Rect real_rect;
 
-    PARAMETER_CHECKS {
-        CHECK_TEXTURE_MAGIC(texture, false);
+    CHECK_TEXTURE_MAGIC(texture, false);
 
-        CHECK_PARAM(!Yplane) {
-            return SDL_InvalidParamError("Yplane");
-        }
-        CHECK_PARAM(!Ypitch) {
-            return SDL_InvalidParamError("Ypitch");
-        }
-        CHECK_PARAM(!UVplane) {
-            return SDL_InvalidParamError("UVplane");
-        }
-        CHECK_PARAM(!UVpitch) {
-            return SDL_InvalidParamError("UVpitch");
-        }
+    CHECK_PARAM(!Yplane) {
+        return SDL_InvalidParamError("Yplane");
+    }
+    CHECK_PARAM(!Ypitch) {
+        return SDL_InvalidParamError("Ypitch");
+    }
+    CHECK_PARAM(!UVplane) {
+        return SDL_InvalidParamError("UVplane");
+    }
+    CHECK_PARAM(!UVpitch) {
+        return SDL_InvalidParamError("UVpitch");
+    }
 
-        CHECK_PARAM(texture->format != SDL_PIXELFORMAT_NV12 &&
-                    texture->format != SDL_PIXELFORMAT_NV21) {
-            return SDL_SetError("Texture format must by NV12 or NV21");
-        }
+    CHECK_PARAM(texture->format != SDL_PIXELFORMAT_NV12 &&
+                texture->format != SDL_PIXELFORMAT_NV21) {
+        return SDL_SetError("Texture format must by NV12 or NV21");
     }
 
     real_rect.x = 0;
@@ -2495,12 +2441,10 @@ bool SDL_LockTexture(SDL_Texture *texture, const SDL_Rect *rect, void **pixels, 
 {
     SDL_Rect full_rect;
 
-    PARAMETER_CHECKS {
-        CHECK_TEXTURE_MAGIC(texture, false);
+    CHECK_TEXTURE_MAGIC(texture, false);
 
-        CHECK_PARAM(texture->access != SDL_TEXTUREACCESS_STREAMING) {
-            return SDL_SetError("SDL_LockTexture(): texture must be streaming");
-        }
+    CHECK_PARAM(texture->access != SDL_TEXTUREACCESS_STREAMING) {
+        return SDL_SetError("SDL_LockTexture(): texture must be streaming");
     }
 
     if (!rect) {
@@ -2537,12 +2481,10 @@ bool SDL_LockTextureToSurface(SDL_Texture *texture, const SDL_Rect *rect, SDL_Su
     void *pixels = NULL;
     int pitch = 0; // fix static analysis
 
-    PARAMETER_CHECKS {
-        CHECK_TEXTURE_MAGIC(texture, false);
+    CHECK_TEXTURE_MAGIC(texture, false);
 
-        CHECK_PARAM(!surface) {
-            return SDL_InvalidParamError("surface");
-        }
+    CHECK_PARAM(!surface) {
+        return SDL_InvalidParamError("surface");
     }
 
     real_rect.x = 0;
@@ -2611,12 +2553,10 @@ static void SDL_UnlockTextureNative(SDL_Texture *texture)
 
 void SDL_UnlockTexture(SDL_Texture *texture)
 {
-    PARAMETER_CHECKS {
-        CHECK_TEXTURE_MAGIC(texture,);
+    CHECK_TEXTURE_MAGIC(texture,);
 
-        if (texture->access != SDL_TEXTUREACCESS_STREAMING) {
-            return;
-        }
+    if (texture->access != SDL_TEXTUREACCESS_STREAMING) {
+        return;
     }
 
 #ifdef SDL_HAVE_YUV
@@ -2637,21 +2577,17 @@ void SDL_UnlockTexture(SDL_Texture *texture)
 
 bool SDL_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-    }
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     // texture == NULL is valid and means reset the target to the window
     if (texture) {
-        PARAMETER_CHECKS {
-            CHECK_TEXTURE_MAGIC(texture, false);
+        CHECK_TEXTURE_MAGIC(texture, false);
 
-            CHECK_PARAM(renderer != texture->renderer) {
-                return SDL_SetError("Texture was not created with this renderer");
-            }
-            CHECK_PARAM(texture->access != SDL_TEXTUREACCESS_TARGET) {
-                return SDL_SetError("Texture not created with SDL_TEXTUREACCESS_TARGET");
-            }
+        CHECK_PARAM(renderer != texture->renderer) {
+            return SDL_SetError("Texture was not created with this renderer");
+        }
+        CHECK_PARAM(texture->access != SDL_TEXTUREACCESS_TARGET) {
+            return SDL_SetError("Texture not created with SDL_TEXTUREACCESS_TARGET");
         }
 
         if (texture->native) {
@@ -2697,9 +2633,7 @@ bool SDL_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture)
 
 SDL_Texture *SDL_GetRenderTarget(SDL_Renderer *renderer)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, NULL);
-    }
+    CHECK_RENDERER_MAGIC(renderer, NULL);
 
     if (!renderer->target) {
         return NULL;
@@ -2855,13 +2789,11 @@ bool SDL_GetRenderLogicalPresentation(SDL_Renderer *renderer, int *w, int *h, SD
 {
     #define SETVAL(ptr, val) if (ptr) { *ptr = val; }
 
-    PARAMETER_CHECKS {
-        SETVAL(w, 0);
-        SETVAL(h, 0);
-        SETVAL(mode, SDL_LOGICAL_PRESENTATION_DISABLED);
+    SETVAL(w, 0);
+    SETVAL(h, 0);
+    SETVAL(mode, SDL_LOGICAL_PRESENTATION_DISABLED);
 
-        CHECK_RENDERER_MAGIC(renderer, false);
-    }
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     const SDL_RenderViewState *view = renderer->view;
     SETVAL(w, view->logical_w);
@@ -2875,13 +2807,11 @@ bool SDL_GetRenderLogicalPresentation(SDL_Renderer *renderer, int *w, int *h, SD
 
 bool SDL_GetRenderLogicalPresentationRect(SDL_Renderer *renderer, SDL_FRect *rect)
 {
-    PARAMETER_CHECKS {
-        if (rect) {
-            SDL_zerop(rect);
-        }
-
-        CHECK_RENDERER_MAGIC(renderer, false);
+    if (rect) {
+        SDL_zerop(rect);
     }
+
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     if (rect) {
         SDL_copyp(rect, &renderer->view->logical_dst_rect);
@@ -2916,9 +2846,7 @@ bool SDL_RenderCoordinatesFromWindow(SDL_Renderer *renderer, float window_x, flo
 {
     float render_x, render_y;
 
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-    }
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     // Convert from window coordinates to pixels within the window
     render_x = window_x * renderer->dpi_scale.x;
@@ -2947,9 +2875,7 @@ bool SDL_RenderCoordinatesFromWindow(SDL_Renderer *renderer, float window_x, flo
 
 bool SDL_RenderCoordinatesToWindow(SDL_Renderer *renderer, float x, float y, float *window_x, float *window_y)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-    }
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     const SDL_RenderViewState *view = &renderer->main_view;
     x = (view->viewport.x + x) * view->scale.x;
@@ -2978,9 +2904,7 @@ bool SDL_RenderCoordinatesToWindow(SDL_Renderer *renderer, float x, float y, flo
 
 bool SDL_ConvertEventToRenderCoordinates(SDL_Renderer *renderer, SDL_Event *event)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-    }
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     if (event->type == SDL_EVENT_MOUSE_MOTION) {
         SDL_Window *window = SDL_GetWindowFromID(event->motion.windowID);
@@ -3049,9 +2973,7 @@ bool SDL_ConvertEventToRenderCoordinates(SDL_Renderer *renderer, SDL_Event *even
 
 bool SDL_SetRenderViewport(SDL_Renderer *renderer, const SDL_Rect *rect)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-    }
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     SDL_RenderViewState *view = renderer->view;
     if (rect) {
@@ -3070,13 +2992,11 @@ bool SDL_SetRenderViewport(SDL_Renderer *renderer, const SDL_Rect *rect)
 
 bool SDL_GetRenderViewport(SDL_Renderer *renderer, SDL_Rect *rect)
 {
-    PARAMETER_CHECKS {
-        if (rect) {
-            SDL_zerop(rect);
-        }
-
-        CHECK_RENDERER_MAGIC(renderer, false);
+    if (rect) {
+        SDL_zerop(rect);
     }
+
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     if (rect) {
         const SDL_RenderViewState *view = renderer->view;
@@ -3098,9 +3018,7 @@ bool SDL_GetRenderViewport(SDL_Renderer *renderer, SDL_Rect *rect)
 
 bool SDL_RenderViewportSet(SDL_Renderer *renderer)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-    }
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     const SDL_RenderViewState *view = renderer->view;
     return (view->viewport.w >= 0 && view->viewport.h >= 0);
@@ -3130,13 +3048,11 @@ static void GetRenderViewportSize(SDL_Renderer *renderer, SDL_FRect *rect)
 
 bool SDL_GetRenderSafeArea(SDL_Renderer *renderer, SDL_Rect *rect)
 {
-    PARAMETER_CHECKS {
-        if (rect) {
-            SDL_zerop(rect);
-        }
-
-        CHECK_RENDERER_MAGIC(renderer, false);
+    if (rect) {
+        SDL_zerop(rect);
     }
+
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     if (renderer->target || !renderer->window) {
         // The entire viewport is safe for rendering
@@ -3179,9 +3095,7 @@ bool SDL_GetRenderSafeArea(SDL_Renderer *renderer, SDL_Rect *rect)
 
 bool SDL_SetRenderClipRect(SDL_Renderer *renderer, const SDL_Rect *rect)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false)
-    }
+    CHECK_RENDERER_MAGIC(renderer, false)
 
     SDL_RenderViewState *view = renderer->view;
     if (rect && rect->w >= 0 && rect->h >= 0) {
@@ -3198,13 +3112,11 @@ bool SDL_SetRenderClipRect(SDL_Renderer *renderer, const SDL_Rect *rect)
 
 bool SDL_GetRenderClipRect(SDL_Renderer *renderer, SDL_Rect *rect)
 {
-    PARAMETER_CHECKS {
-        if (rect) {
-            SDL_zerop(rect);
-        }
-
-        CHECK_RENDERER_MAGIC(renderer, false)
+    if (rect) {
+        SDL_zerop(rect);
     }
+
+    CHECK_RENDERER_MAGIC(renderer, false)
 
     if (rect) {
         SDL_copyp(rect, &renderer->view->clip_rect);
@@ -3214,9 +3126,7 @@ bool SDL_GetRenderClipRect(SDL_Renderer *renderer, SDL_Rect *rect)
 
 bool SDL_RenderClipEnabled(SDL_Renderer *renderer)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false)
-    }
+    CHECK_RENDERER_MAGIC(renderer, false)
     return renderer->view->clipping_enabled;
 }
 
@@ -3224,9 +3134,7 @@ bool SDL_SetRenderScale(SDL_Renderer *renderer, float scaleX, float scaleY)
 {
     bool result = true;
 
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-    }
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     SDL_RenderViewState *view = renderer->view;
 
@@ -3249,16 +3157,14 @@ bool SDL_SetRenderScale(SDL_Renderer *renderer, float scaleX, float scaleY)
 
 bool SDL_GetRenderScale(SDL_Renderer *renderer, float *scaleX, float *scaleY)
 {
-    PARAMETER_CHECKS {
-        if (scaleX) {
-            *scaleX = 1.0f;
-        }
-        if (scaleY) {
-            *scaleY = 1.0f;
-        }
-
-        CHECK_RENDERER_MAGIC(renderer, false);
+    if (scaleX) {
+        *scaleX = 1.0f;
     }
+    if (scaleY) {
+        *scaleY = 1.0f;
+    }
+
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     const SDL_RenderViewState *view = renderer->view;
 
@@ -3283,9 +3189,7 @@ bool SDL_SetRenderDrawColor(SDL_Renderer *renderer, Uint8 r, Uint8 g, Uint8 b, U
 
 bool SDL_SetRenderDrawColorFloat(SDL_Renderer *renderer, float r, float g, float b, float a)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-    }
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     renderer->color.r = r;
     renderer->color.g = g;
@@ -3333,22 +3237,20 @@ bool SDL_GetRenderDrawColorFloat(SDL_Renderer *renderer, float *r, float *g, flo
 {
     SDL_FColor color;
 
-    PARAMETER_CHECKS {
-        if (r) {
-            *r = 0.0f;
-        }
-        if (g) {
-            *g = 0.0f;
-        }
-        if (b) {
-            *b = 0.0f;
-        }
-        if (a) {
-            *a = 0.0f;
-        }
-
-        CHECK_RENDERER_MAGIC(renderer, false);
+    if (r) {
+        *r = 0.0f;
     }
+    if (g) {
+        *g = 0.0f;
+    }
+    if (b) {
+        *b = 0.0f;
+    }
+    if (a) {
+        *a = 0.0f;
+    }
+
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     color = renderer->color;
 
@@ -3369,9 +3271,7 @@ bool SDL_GetRenderDrawColorFloat(SDL_Renderer *renderer, float *r, float *g, flo
 
 bool SDL_SetRenderColorScale(SDL_Renderer *renderer, float scale)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-    }
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     renderer->desired_color_scale = scale;
     UpdateColorScale(renderer);
@@ -3380,13 +3280,11 @@ bool SDL_SetRenderColorScale(SDL_Renderer *renderer, float scale)
 
 bool SDL_GetRenderColorScale(SDL_Renderer *renderer, float *scale)
 {
-    PARAMETER_CHECKS {
-        if (scale) {
-            *scale = 1.0f;
-        }
-
-        CHECK_RENDERER_MAGIC(renderer, false);
+    if (scale) {
+        *scale = 1.0f;
     }
+
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     if (scale) {
         *scale = renderer->desired_color_scale;
@@ -3396,12 +3294,10 @@ bool SDL_GetRenderColorScale(SDL_Renderer *renderer, float *scale)
 
 bool SDL_SetRenderDrawBlendMode(SDL_Renderer *renderer, SDL_BlendMode blendMode)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
+    CHECK_RENDERER_MAGIC(renderer, false);
 
-        CHECK_PARAM(blendMode == SDL_BLENDMODE_INVALID) {
-            return SDL_InvalidParamError("blendMode");
-        }
+    CHECK_PARAM(blendMode == SDL_BLENDMODE_INVALID) {
+        return SDL_InvalidParamError("blendMode");
     }
 
     if (!IsSupportedBlendMode(renderer, blendMode)) {
@@ -3414,13 +3310,11 @@ bool SDL_SetRenderDrawBlendMode(SDL_Renderer *renderer, SDL_BlendMode blendMode)
 
 bool SDL_GetRenderDrawBlendMode(SDL_Renderer *renderer, SDL_BlendMode *blendMode)
 {
-    PARAMETER_CHECKS {
-        if (blendMode) {
-            *blendMode = SDL_BLENDMODE_INVALID;
-        }
-
-        CHECK_RENDERER_MAGIC(renderer, false);
+    if (blendMode) {
+        *blendMode = SDL_BLENDMODE_INVALID;
     }
+
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     if (blendMode) {
         *blendMode = renderer->blendMode;
@@ -3430,9 +3324,7 @@ bool SDL_GetRenderDrawBlendMode(SDL_Renderer *renderer, SDL_BlendMode *blendMode
 
 bool SDL_RenderClear(SDL_Renderer *renderer)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-    }
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     return QueueCmdClear(renderer);
 }
@@ -3482,12 +3374,10 @@ bool SDL_RenderPoints(SDL_Renderer *renderer, const SDL_FPoint *points, int coun
 {
     bool result;
 
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
+    CHECK_RENDERER_MAGIC(renderer, false);
 
-        CHECK_PARAM(!points) {
-            return SDL_InvalidParamError("SDL_RenderPoints(): points");
-        }
+    CHECK_PARAM(!points) {
+        return SDL_InvalidParamError("SDL_RenderPoints(): points");
     }
 
     if (count < 1) {
@@ -3691,12 +3581,10 @@ bool SDL_RenderLines(SDL_Renderer *renderer, const SDL_FPoint *points, int count
 {
     bool result = true;
 
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
+    CHECK_RENDERER_MAGIC(renderer, false);
 
-        CHECK_PARAM(!points) {
-            return SDL_InvalidParamError("SDL_RenderLines(): points");
-        }
+    CHECK_PARAM(!points) {
+        return SDL_InvalidParamError("SDL_RenderLines(): points");
     }
 
     if (count < 2) {
@@ -3848,9 +3736,7 @@ bool SDL_RenderRect(SDL_Renderer *renderer, const SDL_FRect *rect)
     SDL_FRect frect;
     SDL_FPoint points[5];
 
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-    }
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     // If 'rect' == NULL, then outline the whole surface
     if (!rect) {
@@ -3875,12 +3761,10 @@ bool SDL_RenderRects(SDL_Renderer *renderer, const SDL_FRect *rects, int count)
 {
     int i;
 
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
+    CHECK_RENDERER_MAGIC(renderer, false);
 
-        CHECK_PARAM(!rects) {
-            return SDL_InvalidParamError("SDL_RenderRects(): rects");
-        }
+    CHECK_PARAM(!rects) {
+        return SDL_InvalidParamError("SDL_RenderRects(): rects");
     }
 
     if (count < 1) {
@@ -3906,9 +3790,7 @@ bool SDL_RenderFillRect(SDL_Renderer *renderer, const SDL_FRect *rect)
 {
     SDL_FRect frect;
 
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-    }
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     // If 'rect' == NULL, then fill the whole surface
     if (!rect) {
@@ -3925,12 +3807,10 @@ bool SDL_RenderFillRects(SDL_Renderer *renderer, const SDL_FRect *rects, int cou
     bool result;
     bool isstack;
 
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
+    CHECK_RENDERER_MAGIC(renderer, false);
 
-        CHECK_PARAM(!rects) {
-            return SDL_InvalidParamError("SDL_RenderFillRects(): rects");
-        }
+    CHECK_PARAM(!rects) {
+        return SDL_InvalidParamError("SDL_RenderFillRects(): rects");
     }
 
     if (count < 1) {
@@ -4027,13 +3907,11 @@ static bool SDL_RenderTextureInternal(SDL_Renderer *renderer, SDL_Texture *textu
 
 bool SDL_RenderTexture(SDL_Renderer *renderer, SDL_Texture *texture, const SDL_FRect *srcrect, const SDL_FRect *dstrect)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-        CHECK_TEXTURE_MAGIC(texture, false);
+    CHECK_RENDERER_MAGIC(renderer, false);
+    CHECK_TEXTURE_MAGIC(texture, false);
 
-        CHECK_PARAM(renderer != texture->renderer) {
-            return SDL_SetError("Texture was not created with this renderer");
-        }
+    CHECK_PARAM(renderer != texture->renderer) {
+        return SDL_SetError("Texture was not created with this renderer");
     }
 
 #if DONT_DRAW_WHILE_HIDDEN
@@ -4076,13 +3954,11 @@ bool SDL_RenderTextureAffine(SDL_Renderer *renderer, SDL_Texture *texture,
     SDL_FRect real_dstrect;
     bool result;
 
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-        CHECK_TEXTURE_MAGIC(texture, false);
+    CHECK_RENDERER_MAGIC(renderer, false);
+    CHECK_TEXTURE_MAGIC(texture, false);
 
-        CHECK_PARAM(renderer != texture->renderer) {
-            return SDL_SetError("Texture was not created with this renderer");
-        }
+    CHECK_PARAM(renderer != texture->renderer) {
+        return SDL_SetError("Texture was not created with this renderer");
     }
     if (!renderer->QueueCopyEx && !renderer->QueueGeometry) {
         return SDL_SetError("Renderer does not support RenderCopyEx");
@@ -4201,13 +4077,11 @@ bool SDL_RenderTextureRotated(SDL_Renderer *renderer, SDL_Texture *texture,
         return SDL_RenderTexture(renderer, texture, srcrect, dstrect);
     }
 
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-        CHECK_TEXTURE_MAGIC(texture, false);
+    CHECK_RENDERER_MAGIC(renderer, false);
+    CHECK_TEXTURE_MAGIC(texture, false);
 
-        CHECK_PARAM(renderer != texture->renderer) {
-            return SDL_SetError("Texture was not created with this renderer");
-        }
+    CHECK_PARAM(renderer != texture->renderer) {
+        return SDL_SetError("Texture was not created with this renderer");
     }
     if (!renderer->QueueCopyEx && !renderer->QueueGeometry) {
         return SDL_SetError("Renderer does not support RenderCopyEx");
@@ -4459,17 +4333,15 @@ bool SDL_RenderTextureTiled(SDL_Renderer *renderer, SDL_Texture *texture, const 
 {
     SDL_FRect real_srcrect;
 
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-        CHECK_TEXTURE_MAGIC(texture, false);
+    CHECK_RENDERER_MAGIC(renderer, false);
+    CHECK_TEXTURE_MAGIC(texture, false);
 
-        CHECK_PARAM(renderer != texture->renderer) {
-            return SDL_SetError("Texture was not created with this renderer");
-        }
+    CHECK_PARAM(renderer != texture->renderer) {
+        return SDL_SetError("Texture was not created with this renderer");
+    }
 
-        CHECK_PARAM(scale <= 0.0f) {
-            return SDL_InvalidParamError("scale");
-        }
+    CHECK_PARAM(scale <= 0.0f) {
+        return SDL_InvalidParamError("scale");
     }
 
 #if DONT_DRAW_WHILE_HIDDEN
@@ -4528,13 +4400,11 @@ bool SDL_RenderTexture9Grid(SDL_Renderer *renderer, SDL_Texture *texture, const 
     float dst_top_height;
     float dst_bottom_height;
 
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-        CHECK_TEXTURE_MAGIC(texture, false);
+    CHECK_RENDERER_MAGIC(renderer, false);
+    CHECK_TEXTURE_MAGIC(texture, false);
 
-        CHECK_PARAM(renderer != texture->renderer) {
-            return SDL_SetError("Texture was not created with this renderer");
-        }
+    CHECK_PARAM(renderer != texture->renderer) {
+        return SDL_SetError("Texture was not created with this renderer");
     }
 
     if (!srcrect) {
@@ -4667,13 +4537,11 @@ bool SDL_RenderTexture9GridTiled(SDL_Renderer *renderer, SDL_Texture *texture, c
     float dst_top_height;
     float dst_bottom_height;
 
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-        CHECK_TEXTURE_MAGIC(texture, false);
+    CHECK_RENDERER_MAGIC(renderer, false);
+    CHECK_TEXTURE_MAGIC(texture, false);
 
-        CHECK_PARAM(renderer != texture->renderer) {
-            return SDL_SetError("Texture was not created with this renderer");
-        }
+    CHECK_PARAM(renderer != texture->renderer) {
+        return SDL_SetError("Texture was not created with this renderer");
     }
 
     if (!srcrect) {
@@ -5217,37 +5085,36 @@ bool SDL_RenderGeometryRaw(SDL_Renderer *renderer,
     SDL_TextureAddressMode texture_address_mode_u;
     SDL_TextureAddressMode texture_address_mode_v;
 
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
+    CHECK_RENDERER_MAGIC(renderer, false);
 
-        if (texture) {
-            CHECK_TEXTURE_MAGIC(texture, false);
+    if (texture) {
+        CHECK_TEXTURE_MAGIC(texture, false);
 
-            CHECK_PARAM(renderer != texture->renderer) {
-                return SDL_SetError("Texture was not created with this renderer");
-            }
+        CHECK_PARAM(renderer != texture->renderer) {
+            return SDL_SetError("Texture was not created with this renderer");
         }
+    }
 
-        CHECK_PARAM(!xy) {
-            return SDL_InvalidParamError("xy");
-        }
+    CHECK_PARAM(!xy) {
+        return SDL_InvalidParamError("xy");
+    }
 
-        CHECK_PARAM(!color) {
-            return SDL_InvalidParamError("color");
-        }
+    CHECK_PARAM(!color) {
+        return SDL_InvalidParamError("color");
+    }
 
-        CHECK_PARAM(texture && !uv) {
-            return SDL_InvalidParamError("uv");
-        }
+    CHECK_PARAM(texture && !uv) {
+        return SDL_InvalidParamError("uv");
+    }
 
-        CHECK_PARAM(count % 3 != 0) {
-            return SDL_InvalidParamError(indices ? "num_indices" : "num_vertices");
-        }
+    (void)count;    // In case parameter checking is disabled
+    CHECK_PARAM(count % 3 != 0) {
+        return SDL_InvalidParamError(indices ? "num_indices" : "num_vertices");
+    }
 
-        if (indices) {
-            CHECK_PARAM(size_indices != 1 && size_indices != 2 && size_indices != 4) {
-                return SDL_InvalidParamError("size_indices");
-            }
+    if (indices) {
+        CHECK_PARAM(size_indices != 1 && size_indices != 2 && size_indices != 4) {
+            return SDL_InvalidParamError("size_indices");
         }
     }
 
@@ -5349,9 +5216,7 @@ bool SDL_RenderGeometryRaw(SDL_Renderer *renderer,
 
 bool SDL_SetRenderTextureAddressMode(SDL_Renderer *renderer, SDL_TextureAddressMode u_mode, SDL_TextureAddressMode v_mode)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-    }
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     renderer->texture_address_mode_u = u_mode;
     renderer->texture_address_mode_v = v_mode;
@@ -5360,16 +5225,14 @@ bool SDL_SetRenderTextureAddressMode(SDL_Renderer *renderer, SDL_TextureAddressM
 
 bool SDL_GetRenderTextureAddressMode(SDL_Renderer *renderer, SDL_TextureAddressMode *u_mode, SDL_TextureAddressMode *v_mode)
 {
-    PARAMETER_CHECKS {
-        if (u_mode) {
-            *u_mode = SDL_TEXTURE_ADDRESS_INVALID;
-        }
-        if (v_mode) {
-            *v_mode = SDL_TEXTURE_ADDRESS_INVALID;
-        }
-
-        CHECK_RENDERER_MAGIC(renderer, false);
+    if (u_mode) {
+        *u_mode = SDL_TEXTURE_ADDRESS_INVALID;
     }
+    if (v_mode) {
+        *v_mode = SDL_TEXTURE_ADDRESS_INVALID;
+    }
+
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     if (u_mode) {
         *u_mode = renderer->texture_address_mode_u;
@@ -5382,9 +5245,7 @@ bool SDL_GetRenderTextureAddressMode(SDL_Renderer *renderer, SDL_TextureAddressM
 
 SDL_Surface *SDL_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rect *rect)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, NULL);
-    }
+    CHECK_RENDERER_MAGIC(renderer, NULL);
 
     if (!renderer->RenderReadPixels) {
         SDL_Unsupported();
@@ -5487,12 +5348,10 @@ bool SDL_RenderPresent(SDL_Renderer *renderer)
 {
     bool presented = true;
 
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
+    CHECK_RENDERER_MAGIC(renderer, false);
 
-        CHECK_PARAM(renderer->target) {
-            return SDL_SetError("You can't present on a render target");
-        }
+    CHECK_PARAM(renderer->target) {
+        return SDL_SetError("You can't present on a render target");
     }
 
     if (renderer->transparent_window) {
@@ -5566,9 +5425,7 @@ static void SDL_DestroyTextureInternal(SDL_Texture *texture, bool is_destroying)
 
 void SDL_DestroyTexture(SDL_Texture *texture)
 {
-    PARAMETER_CHECKS {
-        CHECK_TEXTURE_MAGIC(texture, );
-    }
+    CHECK_TEXTURE_MAGIC(texture, );
 
     if (--texture->refcount > 0) {
         return;
@@ -5660,9 +5517,7 @@ void SDL_DestroyRendererWithoutFreeing(SDL_Renderer *renderer)
 
 void SDL_DestroyRenderer(SDL_Renderer *renderer)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC_BUT_NOT_DESTROYED_FLAG(renderer,);
-    }
+    CHECK_RENDERER_MAGIC_BUT_NOT_DESTROYED_FLAG(renderer,);
 
     // if we've already destroyed the renderer through SDL_DestroyWindow, we just need
     // to free the renderer pointer. This lets apps destroy the window and renderer
@@ -5693,9 +5548,7 @@ void SDL_DestroyRenderer(SDL_Renderer *renderer)
 
 void *SDL_GetRenderMetalLayer(SDL_Renderer *renderer)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, NULL);
-    }
+    CHECK_RENDERER_MAGIC(renderer, NULL);
 
     if (renderer->GetMetalLayer) {
         FlushRenderCommands(renderer); // in case the app is going to mess with it.
@@ -5706,9 +5559,7 @@ void *SDL_GetRenderMetalLayer(SDL_Renderer *renderer)
 
 void *SDL_GetRenderMetalCommandEncoder(SDL_Renderer *renderer)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, NULL);
-    }
+    CHECK_RENDERER_MAGIC(renderer, NULL);
 
     if (renderer->GetMetalCommandEncoder) {
         FlushRenderCommands(renderer); // in case the app is going to mess with it.
@@ -5719,9 +5570,7 @@ void *SDL_GetRenderMetalCommandEncoder(SDL_Renderer *renderer)
 
 bool SDL_AddVulkanRenderSemaphores(SDL_Renderer *renderer, Uint32 wait_stage_mask, Sint64 wait_semaphore, Sint64 signal_semaphore)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-    }
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     if (!renderer->AddVulkanRenderSemaphores) {
         return SDL_Unsupported();
@@ -5829,9 +5678,7 @@ SDL_BlendOperation SDL_GetBlendModeAlphaOperation(SDL_BlendMode blendMode)
 
 bool SDL_SetRenderVSync(SDL_Renderer *renderer, int vsync)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-    }
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     renderer->wanted_vsync = vsync ? true : false;
 
@@ -5871,13 +5718,11 @@ bool SDL_SetRenderVSync(SDL_Renderer *renderer, int vsync)
 
 bool SDL_GetRenderVSync(SDL_Renderer *renderer, int *vsync)
 {
-    PARAMETER_CHECKS {
-        if (vsync) {
-            *vsync = 0;
-        }
-
-        CHECK_RENDERER_MAGIC(renderer, false);
+    if (vsync) {
+        *vsync = 0;
     }
+
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     if (vsync) {
         *vsync = (int)SDL_GetNumberProperty(SDL_GetRendererProperties(renderer), SDL_PROP_RENDERER_VSYNC_NUMBER, 0);
@@ -5978,9 +5823,7 @@ static bool DrawDebugCharacter(SDL_Renderer *renderer, float x, float y, Uint32 
 
 bool SDL_RenderDebugText(SDL_Renderer *renderer, float x, float y, const char *s)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-    }
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     // Allocate a texture atlas for this renderer if needed.
     if (!renderer->debug_char_texture_atlas) {
@@ -6035,9 +5878,7 @@ bool SDL_RenderDebugTextFormat(SDL_Renderer *renderer, float x, float y, SDL_PRI
 
 bool SDL_SetDefaultTextureScaleMode(SDL_Renderer *renderer, SDL_ScaleMode scale_mode)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-    }
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     renderer->scale_mode = scale_mode;
 
@@ -6046,13 +5887,11 @@ bool SDL_SetDefaultTextureScaleMode(SDL_Renderer *renderer, SDL_ScaleMode scale_
 
 bool SDL_GetDefaultTextureScaleMode(SDL_Renderer *renderer, SDL_ScaleMode *scale_mode)
 {
-    PARAMETER_CHECKS {
-        if (scale_mode) {
-            *scale_mode = SDL_SCALEMODE_LINEAR;
-        }
-
-        CHECK_RENDERER_MAGIC(renderer, false);
+    if (scale_mode) {
+        *scale_mode = SDL_SCALEMODE_LINEAR;
     }
+
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     if (scale_mode) {
         *scale_mode = renderer->scale_mode;
@@ -6062,18 +5901,16 @@ bool SDL_GetDefaultTextureScaleMode(SDL_Renderer *renderer, SDL_ScaleMode *scale
 
 SDL_GPURenderState *SDL_CreateGPURenderState(SDL_Renderer *renderer, SDL_GPURenderStateCreateInfo *createinfo)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, NULL);
+    CHECK_RENDERER_MAGIC(renderer, NULL);
 
-        CHECK_PARAM(!createinfo) {
-            SDL_InvalidParamError("createinfo");
-            return NULL;
-        }
+    CHECK_PARAM(!createinfo) {
+        SDL_InvalidParamError("createinfo");
+        return NULL;
+    }
 
-        CHECK_PARAM(!createinfo->fragment_shader) {
-            SDL_SetError("A fragment_shader is required");
-            return NULL;
-        }
+    CHECK_PARAM(!createinfo->fragment_shader) {
+        SDL_SetError("A fragment_shader is required");
+        return NULL;
     }
 
     SDL_GPUDevice *device = (SDL_GPUDevice *)SDL_GetPointerProperty(renderer->props, SDL_PROP_RENDERER_GPU_DEVICE_POINTER, NULL);
@@ -6169,9 +6006,7 @@ bool SDL_SetGPURenderStateFragmentUniforms(SDL_GPURenderState *state, Uint32 slo
 
 bool SDL_SetRenderGPUState(SDL_Renderer *renderer, SDL_GPURenderState *state)
 {
-    PARAMETER_CHECKS {
-        CHECK_RENDERER_MAGIC(renderer, false);
-    }
+    CHECK_RENDERER_MAGIC(renderer, false);
 
     renderer->gpu_render_state = state;
     return true;

--- a/src/render/software/SDL_blendfillrect.c
+++ b/src/render/software/SDL_blendfillrect.c
@@ -238,7 +238,7 @@ bool SDL_BlendFillRect(SDL_Surface *dst, const SDL_Rect *rect, SDL_BlendMode ble
 {
     SDL_Rect clipped;
 
-    if (!SDL_SurfaceValid(dst)) {
+    CHECK_PARAM(!SDL_SurfaceValid(dst)) {
         return SDL_InvalidParamError("SDL_BlendFillRect(): dst");
     }
 
@@ -306,7 +306,7 @@ bool SDL_BlendFillRects(SDL_Surface *dst, const SDL_Rect *rects, int count, SDL_
     bool (*func)(SDL_Surface * dst, const SDL_Rect *rect, SDL_BlendMode blendMode, Uint8 r, Uint8 g, Uint8 b, Uint8 a) = NULL;
     bool result = true;
 
-    if (!SDL_SurfaceValid(dst)) {
+    CHECK_PARAM(!SDL_SurfaceValid(dst)) {
         return SDL_InvalidParamError("SDL_BlendFillRects(): dst");
     }
 

--- a/src/render/software/SDL_blendline.c
+++ b/src/render/software/SDL_blendline.c
@@ -923,7 +923,7 @@ bool SDL_BlendLine(SDL_Surface *dst, int x1, int y1, int x2, int y2, SDL_BlendMo
 {
     BlendLineFunc func;
 
-    if (!SDL_SurfaceValid(dst)) {
+    CHECK_PARAM(!SDL_SurfaceValid(dst)) {
         return SDL_InvalidParamError("SDL_BlendLine(): dst");
     }
 

--- a/src/render/software/SDL_blendpoint.c
+++ b/src/render/software/SDL_blendpoint.c
@@ -236,7 +236,7 @@ static bool SDL_BlendPoint_RGBA(SDL_Surface *dst, int x, int y, SDL_BlendMode bl
 
 bool SDL_BlendPoint(SDL_Surface *dst, int x, int y, SDL_BlendMode blendMode, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
-    if (!SDL_SurfaceValid(dst)) {
+    CHECK_PARAM(!SDL_SurfaceValid(dst)) {
         return SDL_InvalidParamError("SDL_BlendPoint(): dst");
     }
 
@@ -302,7 +302,7 @@ bool SDL_BlendPoints(SDL_Surface *dst, const SDL_Point *points, int count, SDL_B
     bool (*func)(SDL_Surface * dst, int x, int y, SDL_BlendMode blendMode, Uint8 r, Uint8 g, Uint8 b, Uint8 a) = NULL;
     bool result = true;
 
-    if (!SDL_SurfaceValid(dst)) {
+    CHECK_PARAM(!SDL_SurfaceValid(dst)) {
         return SDL_InvalidParamError("SDL_BlendPoints(): dst");
     }
 

--- a/src/render/software/SDL_drawline.c
+++ b/src/render/software/SDL_drawline.c
@@ -137,7 +137,7 @@ bool SDL_DrawLine(SDL_Surface *dst, int x1, int y1, int x2, int y2, Uint32 color
 {
     DrawLineFunc func;
 
-    if (!SDL_SurfaceValid(dst)) {
+    CHECK_PARAM(!SDL_SurfaceValid(dst)) {
         return SDL_InvalidParamError("SDL_DrawLine(): dst");
     }
 
@@ -164,7 +164,7 @@ bool SDL_DrawLines(SDL_Surface *dst, const SDL_Point *points, int count, Uint32 
     bool draw_end;
     DrawLineFunc func;
 
-    if (!SDL_SurfaceValid(dst)) {
+    CHECK_PARAM(!SDL_SurfaceValid(dst)) {
         return SDL_InvalidParamError("SDL_DrawLines(): dst");
     }
 

--- a/src/render/software/SDL_drawpoint.c
+++ b/src/render/software/SDL_drawpoint.c
@@ -27,7 +27,7 @@
 
 bool SDL_DrawPoint(SDL_Surface *dst, int x, int y, Uint32 color)
 {
-    if (!SDL_SurfaceValid(dst)) {
+    CHECK_PARAM(!SDL_SurfaceValid(dst)) {
         return SDL_InvalidParamError("SDL_DrawPoint(): dst");
     }
 
@@ -66,7 +66,7 @@ bool SDL_DrawPoints(SDL_Surface *dst, const SDL_Point *points, int count, Uint32
     int i;
     int x, y;
 
-    if (!SDL_SurfaceValid(dst)) {
+    CHECK_PARAM(!SDL_SurfaceValid(dst)) {
         return SDL_InvalidParamError("SDL_DrawPoints(): dst");
     }
 

--- a/src/render/software/SDL_render_sw.c
+++ b/src/render/software/SDL_render_sw.c
@@ -1121,12 +1121,12 @@ bool SW_CreateRendererForSurface(SDL_Renderer *renderer, SDL_Surface *surface, S
 {
     SW_RenderData *data;
 
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         return SDL_InvalidParamError("surface");
     }
 
-    if (SDL_BITSPERPIXEL(surface->format) < 8 ||
-        SDL_BITSPERPIXEL(surface->format) > 32) {
+    CHECK_PARAM(SDL_BITSPERPIXEL(surface->format) < 8 ||
+                SDL_BITSPERPIXEL(surface->format) > 32) {
         return SDL_SetError("Unsupported surface format");
     }
 

--- a/src/render/software/SDL_triangle.c
+++ b/src/render/software/SDL_triangle.c
@@ -502,10 +502,10 @@ bool SDL_SW_BlitTriangle(
 
     bool has_modulation;
 
-    if (!SDL_SurfaceValid(src)) {
+    CHECK_PARAM(!SDL_SurfaceValid(src)) {
         return SDL_InvalidParamError("src");
     }
-    if (!SDL_SurfaceValid(dst)) {
+    CHECK_PARAM(!SDL_SurfaceValid(dst)) {
         return SDL_InvalidParamError("dst");
     }
 

--- a/src/sensor/SDL_sensor.c
+++ b/src/sensor/SDL_sensor.c
@@ -57,11 +57,11 @@ static int SDL_sensors_locked;
 static bool SDL_sensors_initialized;
 static SDL_Sensor *SDL_sensors SDL_GUARDED_BY(SDL_sensor_lock) = NULL;
 
-#define CHECK_SENSOR_MAGIC(sensor, result)                  \
-    if (!SDL_ObjectValid(sensor, SDL_OBJECT_TYPE_SENSOR)) { \
-        SDL_InvalidParamError("sensor");                    \
-        SDL_UnlockSensors();                                \
-        return result;                                      \
+#define CHECK_SENSOR_MAGIC(sensor, result)                          \
+    CHECK_PARAM(!SDL_ObjectValid(sensor, SDL_OBJECT_TYPE_SENSOR)) { \
+        SDL_InvalidParamError("sensor");                            \
+        SDL_UnlockSensors();                                        \
+        return result;                                              \
     }
 
 bool SDL_SensorsInitialized(void)

--- a/src/stdlib/SDL_getenv.c
+++ b/src/stdlib/SDL_getenv.c
@@ -222,7 +222,7 @@ char **SDL_GetEnvironmentVariables(SDL_Environment *env)
 {
     char **result = NULL;
 
-    if (!env) {
+    CHECK_PARAM(!env) {
         SDL_InvalidParamError("env");
         return NULL;
     }
@@ -253,11 +253,13 @@ bool SDL_SetEnvironmentVariable(SDL_Environment *env, const char *name, const ch
 {
     bool result = false;
 
-    if (!env) {
+    CHECK_PARAM(!env) {
         return SDL_InvalidParamError("env");
-    } else if (!name || *name == '\0' || SDL_strchr(name, '=') != NULL) {
+    }
+    CHECK_PARAM(!name || *name == '\0' || SDL_strchr(name, '=') != NULL) {
         return SDL_InvalidParamError("name");
-    } else if (!value) {
+    }
+    CHECK_PARAM(!value) {
         return SDL_InvalidParamError("value");
     }
 
@@ -292,9 +294,10 @@ bool SDL_UnsetEnvironmentVariable(SDL_Environment *env, const char *name)
 {
     bool result = false;
 
-    if (!env) {
+    CHECK_PARAM(!env) {
         return SDL_InvalidParamError("env");
-    } else if (!name || *name == '\0' || SDL_strchr(name, '=') != NULL) {
+    }
+    CHECK_PARAM(!name || *name == '\0' || SDL_strchr(name, '=') != NULL) {
         return SDL_InvalidParamError("name");
     }
 

--- a/src/stdlib/SDL_malloc.c
+++ b/src/stdlib/SDL_malloc.c
@@ -6419,16 +6419,16 @@ bool SDL_SetMemoryFunctions(SDL_malloc_func malloc_func,
                                 SDL_realloc_func realloc_func,
                                 SDL_free_func free_func)
 {
-    if (!malloc_func) {
+    CHECK_PARAM(!malloc_func) {
         return SDL_InvalidParamError("malloc_func");
     }
-    if (!calloc_func) {
+    CHECK_PARAM(!calloc_func) {
         return SDL_InvalidParamError("calloc_func");
     }
-    if (!realloc_func) {
+    CHECK_PARAM(!realloc_func) {
         return SDL_InvalidParamError("realloc_func");
     }
-    if (!free_func) {
+    CHECK_PARAM(!free_func) {
         return SDL_InvalidParamError("free_func");
     }
 

--- a/src/storage/SDL_storage.c
+++ b/src/storage/SDL_storage.c
@@ -49,12 +49,12 @@ struct SDL_Storage
 };
 
 #define CHECK_STORAGE_MAGIC()                             \
-    if (!storage) {                                       \
+    CHECK_PARAM(!storage) {                               \
         return SDL_SetError("Invalid storage container"); \
     }
 
 #define CHECK_STORAGE_MAGIC_RET(result)            \
-    if (!storage) {                                \
+    CHECK_PARAM(!storage) {                        \
         SDL_SetError("Invalid storage container"); \
         return result;                             \
     }
@@ -183,11 +183,11 @@ SDL_Storage *SDL_OpenStorage(const SDL_StorageInterface *iface, void *userdata)
 {
     SDL_Storage *storage;
 
-    if (!iface) {
+    CHECK_PARAM(!iface) {
         SDL_InvalidParamError("iface");
         return NULL;
     }
-    if (iface->version < sizeof(*iface)) {
+    CHECK_PARAM(iface->version < sizeof(*iface)) {
         // Update this to handle older versions of this interface
         SDL_SetError("Invalid interface, should be initialized with SDL_INIT_INTERFACE()");
         return NULL;
@@ -245,11 +245,14 @@ bool SDL_ReadStorageFile(SDL_Storage *storage, const char *path, void *destinati
 {
     CHECK_STORAGE_MAGIC()
 
-    if (!path) {
+    CHECK_PARAM(!path) {
         return SDL_InvalidParamError("path");
-    } else if (!ValidateStoragePath(path)) {
+    }
+    CHECK_PARAM(!ValidateStoragePath(path)) {
         return false;
-    } else if (!storage->iface.read_file) {
+    }
+
+    if (!storage->iface.read_file) {
         return SDL_Unsupported();
     }
 
@@ -260,11 +263,14 @@ bool SDL_WriteStorageFile(SDL_Storage *storage, const char *path, const void *so
 {
     CHECK_STORAGE_MAGIC()
 
-    if (!path) {
+    CHECK_PARAM(!path) {
         return SDL_InvalidParamError("path");
-    } else if (!ValidateStoragePath(path)) {
+    }
+    CHECK_PARAM(!ValidateStoragePath(path)) {
         return false;
-    } else if (!storage->iface.write_file) {
+    }
+
+    if (!storage->iface.write_file) {
         return SDL_Unsupported();
     }
 
@@ -275,11 +281,14 @@ bool SDL_CreateStorageDirectory(SDL_Storage *storage, const char *path)
 {
     CHECK_STORAGE_MAGIC()
 
-    if (!path) {
+    CHECK_PARAM(!path) {
         return SDL_InvalidParamError("path");
-    } else if (!ValidateStoragePath(path)) {
+    }
+    CHECK_PARAM(!ValidateStoragePath(path)) {
         return false;
-    } else if (!storage->iface.mkdir) {
+    }
+
+    if (!storage->iface.mkdir) {
         return SDL_Unsupported();
     }
 
@@ -307,11 +316,14 @@ bool SDL_RemoveStoragePath(SDL_Storage *storage, const char *path)
 {
     CHECK_STORAGE_MAGIC()
 
-    if (!path) {
+    CHECK_PARAM(!path) {
         return SDL_InvalidParamError("path");
-    } else if (!ValidateStoragePath(path)) {
+    }
+    CHECK_PARAM(!ValidateStoragePath(path)) {
         return false;
-    } else if (!storage->iface.remove) {
+    }
+
+    if (!storage->iface.remove) {
         return SDL_Unsupported();
     }
 
@@ -322,15 +334,20 @@ bool SDL_RenameStoragePath(SDL_Storage *storage, const char *oldpath, const char
 {
     CHECK_STORAGE_MAGIC()
 
-    if (!oldpath) {
+    CHECK_PARAM(!oldpath) {
         return SDL_InvalidParamError("oldpath");
-    } else if (!newpath) {
+    }
+    CHECK_PARAM(!newpath) {
         return SDL_InvalidParamError("newpath");
-    } else if (!ValidateStoragePath(oldpath)) {
+    }
+
+    if (!ValidateStoragePath(oldpath)) {
         return false;
-    } else if (!ValidateStoragePath(newpath)) {
+    }
+    if (!ValidateStoragePath(newpath)) {
         return false;
-    } else if (!storage->iface.rename) {
+    }
+    if (!storage->iface.rename) {
         return SDL_Unsupported();
     }
 
@@ -341,15 +358,20 @@ bool SDL_CopyStorageFile(SDL_Storage *storage, const char *oldpath, const char *
 {
     CHECK_STORAGE_MAGIC()
 
-    if (!oldpath) {
+    CHECK_PARAM(!oldpath) {
         return SDL_InvalidParamError("oldpath");
-    } else if (!newpath) {
+    }
+    CHECK_PARAM(!newpath) {
         return SDL_InvalidParamError("newpath");
-    } else if (!ValidateStoragePath(oldpath)) {
+    }
+
+    if (!ValidateStoragePath(oldpath)) {
         return false;
-    } else if (!ValidateStoragePath(newpath)) {
+    }
+    if (!ValidateStoragePath(newpath)) {
         return false;
-    } else if (!storage->iface.copy) {
+    }
+    if (!storage->iface.copy) {
         return SDL_Unsupported();
     }
 
@@ -367,11 +389,14 @@ bool SDL_GetStoragePathInfo(SDL_Storage *storage, const char *path, SDL_PathInfo
 
     CHECK_STORAGE_MAGIC()
 
-    if (!path) {
+    CHECK_PARAM(!path) {
         return SDL_InvalidParamError("path");
-    } else if (!ValidateStoragePath(path)) {
+    }
+    CHECK_PARAM(!ValidateStoragePath(path)) {
         return false;
-    } else if (!storage->iface.info) {
+    }
+
+    if (!storage->iface.info) {
         return SDL_Unsupported();
     }
 

--- a/src/thread/SDL_thread.c
+++ b/src/thread/SDL_thread.c
@@ -41,7 +41,7 @@ void *SDL_GetTLS(SDL_TLSID *id)
     SDL_TLSData *storage;
     int storage_index;
 
-    if (id == NULL) {
+    CHECK_PARAM(id == NULL) {
         SDL_InvalidParamError("id");
         return NULL;
     }
@@ -59,7 +59,7 @@ bool SDL_SetTLS(SDL_TLSID *id, const void *value, SDL_TLSDestructorCallback dest
     SDL_TLSData *storage;
     int storage_index;
 
-    if (id == NULL) {
+    CHECK_PARAM(id == NULL) {
         return SDL_InvalidParamError("id");
     }
 

--- a/src/time/SDL_time.c
+++ b/src/time/SDL_time.c
@@ -168,13 +168,13 @@ bool SDL_DateTimeToTime(const SDL_DateTime *dt, SDL_Time *ticks)
     static const Sint64 min_seconds = SDL_NS_TO_SECONDS(SDL_MIN_TIME) + 1;
     bool result = true;
 
-    if (!dt) {
+    CHECK_PARAM(!dt) {
         return SDL_InvalidParamError("dt");
     }
-    if (!ticks) {
+    CHECK_PARAM(!ticks) {
         return SDL_InvalidParamError("ticks");
     }
-    if (!SDL_DateTimeIsValid(dt)) {
+    CHECK_PARAM(!SDL_DateTimeIsValid(dt)) {
         // The validation function sets the error string.
         return false;
     }

--- a/src/time/n3ds/SDL_systime.c
+++ b/src/time/n3ds/SDL_systime.c
@@ -108,7 +108,7 @@ void SDL_GetSystemTimeLocalePreferences(SDL_DateFormat *df, SDL_TimeFormat *tf)
 
 bool SDL_GetCurrentTime(SDL_Time *ticks)
 {
-    if (!ticks) {
+    CHECK_PARAM(!ticks) {
         return SDL_InvalidParamError("ticks");
     }
 
@@ -123,7 +123,7 @@ bool SDL_GetCurrentTime(SDL_Time *ticks)
 
 bool SDL_TimeToDateTime(SDL_Time ticks, SDL_DateTime *dt, bool localTime)
 {
-    if (!dt) {
+    CHECK_PARAM(!dt) {
         return SDL_InvalidParamError("dt");
     }
 

--- a/src/time/ngage/SDL_systime.cpp
+++ b/src/time/ngage/SDL_systime.cpp
@@ -152,7 +152,7 @@ void SDL_GetSystemTimeLocalePreferences(SDL_DateFormat *df, SDL_TimeFormat *tf)
 
 bool SDL_GetCurrentTime(SDL_Time *ticks)
 {
-    if (!ticks) {
+    CHECK_PARAM(!ticks) {
         return SDL_InvalidParamError("ticks");
     }
 

--- a/src/time/ps2/SDL_systime.c
+++ b/src/time/ps2/SDL_systime.c
@@ -34,7 +34,7 @@ void SDL_GetSystemTimeLocalePreferences(SDL_DateFormat *df, SDL_TimeFormat *tf)
 
 bool SDL_GetCurrentTime(SDL_Time *ticks)
 {
-    if (!ticks) {
+    CHECK_PARAM(!ticks) {
         return SDL_InvalidParamError("ticks");
     }
 
@@ -45,7 +45,7 @@ bool SDL_GetCurrentTime(SDL_Time *ticks)
 
 bool SDL_TimeToDateTime(SDL_Time ticks, SDL_DateTime *dt, bool localTime)
 {
-    if (!dt) {
+    CHECK_PARAM(!dt) {
         return SDL_InvalidParamError("dt");
     }
 

--- a/src/time/psp/SDL_systime.c
+++ b/src/time/psp/SDL_systime.c
@@ -69,7 +69,7 @@ bool SDL_GetCurrentTime(SDL_Time *ticks)
 {
     u64 sceTicks;
 
-    if (!ticks) {
+    CHECK_PARAM(!ticks) {
         return SDL_InvalidParamError("ticks");
     }
 
@@ -99,7 +99,7 @@ bool SDL_TimeToDateTime(SDL_Time ticks, SDL_DateTime *dt, bool localTime)
     u64 local;
     int ret = 0;
 
-    if (!dt) {
+    CHECK_PARAM(!dt) {
         return SDL_InvalidParamError("dt");
     }
 

--- a/src/time/unix/SDL_systime.c
+++ b/src/time/unix/SDL_systime.c
@@ -101,7 +101,7 @@ found_date:
 
 bool SDL_GetCurrentTime(SDL_Time *ticks)
 {
-    if (!ticks) {
+    CHECK_PARAM(!ticks) {
         return SDL_InvalidParamError("ticks");
     }
 #ifdef HAVE_CLOCK_GETTIME
@@ -158,7 +158,7 @@ bool SDL_TimeToDateTime(SDL_Time ticks, SDL_DateTime *dt, bool localTime)
 #endif
     struct tm *tm = NULL;
 
-    if (!dt) {
+    CHECK_PARAM(!dt) {
         return SDL_InvalidParamError("dt");
     }
 

--- a/src/time/vita/SDL_systime.c
+++ b/src/time/vita/SDL_systime.c
@@ -75,7 +75,7 @@ bool SDL_GetCurrentTime(SDL_Time *ticks)
 {
     SceRtcTick sceTicks;
 
-    if (!ticks) {
+    CHECK_PARAM(!ticks) {
         return SDL_InvalidParamError("ticks");
     }
 
@@ -104,7 +104,7 @@ bool SDL_TimeToDateTime(SDL_Time ticks, SDL_DateTime *dt, bool localTime)
     SceRtcTick sceTicks, sceLocalTicks;
     int ret = 0;
 
-    if (!dt) {
+    CHECK_PARAM(!dt) {
         return SDL_InvalidParamError("dt");
     }
 

--- a/src/time/windows/SDL_systime.c
+++ b/src/time/windows/SDL_systime.c
@@ -79,7 +79,7 @@ bool SDL_GetCurrentTime(SDL_Time *ticks)
 {
     FILETIME ft;
 
-    if (!ticks) {
+    CHECK_PARAM(!ticks) {
         return SDL_InvalidParamError("ticks");
     }
 
@@ -115,7 +115,7 @@ bool SDL_TimeToDateTime(SDL_Time ticks, SDL_DateTime *dt, bool localTime)
     SYSTEMTIME *st = NULL;
     Uint32 low, high;
 
-    if (!dt) {
+    CHECK_PARAM(!dt) {
         return SDL_InvalidParamError("dt");
     }
 

--- a/src/timer/SDL_timer.c
+++ b/src/timer/SDL_timer.c
@@ -301,7 +301,7 @@ static SDL_TimerID SDL_CreateTimer(Uint64 interval, SDL_TimerCallback callback_m
     SDL_Timer *timer;
     SDL_TimerMap *entry;
 
-    if (!callback_ms && !callback_ns) {
+    CHECK_PARAM(!callback_ms && !callback_ns) {
         SDL_InvalidParamError("callback");
         return 0;
     }
@@ -374,7 +374,7 @@ bool SDL_RemoveTimer(SDL_TimerID id)
     SDL_TimerMap *prev, *entry;
     bool canceled = false;
 
-    if (!id) {
+    CHECK_PARAM(!id) {
         return SDL_InvalidParamError("id");
     }
 
@@ -467,7 +467,7 @@ static SDL_TimerID SDL_CreateTimer(Uint64 interval, SDL_TimerCallback callback_m
     SDL_TimerData *data = &SDL_timer_data;
     SDL_TimerMap *entry;
 
-    if (!callback_ms && !callback_ns) {
+    CHECK_PARAM(!callback_ms && !callback_ns) {
         SDL_InvalidParamError("callback");
         return 0;
     }
@@ -507,7 +507,7 @@ bool SDL_RemoveTimer(SDL_TimerID id)
     SDL_TimerData *data = &SDL_timer_data;
     SDL_TimerMap *prev, *entry;
 
-    if (!id) {
+    CHECK_PARAM(!id) {
         return SDL_InvalidParamError("id");
     }
 

--- a/src/tray/cocoa/SDL_tray.m
+++ b/src/tray/cocoa/SDL_tray.m
@@ -203,7 +203,7 @@ void SDL_SetTrayTooltip(SDL_Tray *tray, const char *tooltip)
 
 SDL_TrayMenu *SDL_CreateTrayMenu(SDL_Tray *tray)
 {
-    if (!SDL_ObjectValid(tray, SDL_OBJECT_TYPE_TRAY)) {
+    CHECK_PARAM(!SDL_ObjectValid(tray, SDL_OBJECT_TYPE_TRAY)) {
         SDL_InvalidParamError("tray");
         return NULL;
     }
@@ -230,7 +230,7 @@ SDL_TrayMenu *SDL_CreateTrayMenu(SDL_Tray *tray)
 
 SDL_TrayMenu *SDL_GetTrayMenu(SDL_Tray *tray)
 {
-    if (!SDL_ObjectValid(tray, SDL_OBJECT_TYPE_TRAY)) {
+    CHECK_PARAM(!SDL_ObjectValid(tray, SDL_OBJECT_TYPE_TRAY)) {
         SDL_InvalidParamError("tray");
         return NULL;
     }
@@ -240,7 +240,7 @@ SDL_TrayMenu *SDL_GetTrayMenu(SDL_Tray *tray)
 
 SDL_TrayMenu *SDL_CreateTraySubmenu(SDL_TrayEntry *entry)
 {
-    if (!entry) {
+    CHECK_PARAM(!entry) {
         SDL_InvalidParamError("entry");
         return NULL;
     }
@@ -277,7 +277,7 @@ SDL_TrayMenu *SDL_CreateTraySubmenu(SDL_TrayEntry *entry)
 
 SDL_TrayMenu *SDL_GetTraySubmenu(SDL_TrayEntry *entry)
 {
-    if (!entry) {
+    CHECK_PARAM(!entry) {
         SDL_InvalidParamError("entry");
         return NULL;
     }
@@ -287,7 +287,7 @@ SDL_TrayMenu *SDL_GetTraySubmenu(SDL_TrayEntry *entry)
 
 const SDL_TrayEntry **SDL_GetTrayEntries(SDL_TrayMenu *menu, int *count)
 {
-    if (!menu) {
+    CHECK_PARAM(!menu) {
         SDL_InvalidParamError("menu");
         return NULL;
     }
@@ -337,12 +337,12 @@ void SDL_RemoveTrayEntry(SDL_TrayEntry *entry)
 
 SDL_TrayEntry *SDL_InsertTrayEntryAt(SDL_TrayMenu *menu, int pos, const char *label, SDL_TrayEntryFlags flags)
 {
-    if (!menu) {
+    CHECK_PARAM(!menu) {
         SDL_InvalidParamError("menu");
         return NULL;
     }
 
-    if (pos < -1 || pos > menu->nEntries) {
+    CHECK_PARAM(pos < -1 || pos > menu->nEntries) {
         SDL_InvalidParamError("pos");
         return NULL;
     }
@@ -405,7 +405,7 @@ void SDL_SetTrayEntryLabel(SDL_TrayEntry *entry, const char *label)
 
 const char *SDL_GetTrayEntryLabel(SDL_TrayEntry *entry)
 {
-    if (!entry) {
+    CHECK_PARAM(!entry) {
         SDL_InvalidParamError("entry");
         return NULL;
     }
@@ -476,7 +476,7 @@ void SDL_ClickTrayEntry(SDL_TrayEntry *entry)
 
 SDL_TrayMenu *SDL_GetTrayEntryParent(SDL_TrayEntry *entry)
 {
-    if (!entry) {
+    CHECK_PARAM(!entry) {
         SDL_InvalidParamError("entry");
         return NULL;
     }
@@ -486,7 +486,7 @@ SDL_TrayMenu *SDL_GetTrayEntryParent(SDL_TrayEntry *entry)
 
 SDL_TrayEntry *SDL_GetTrayMenuParentEntry(SDL_TrayMenu *menu)
 {
-    if (!menu) {
+    CHECK_PARAM(!menu) {
         SDL_InvalidParamError("menu");
         return NULL;
     }
@@ -496,7 +496,7 @@ SDL_TrayEntry *SDL_GetTrayMenuParentEntry(SDL_TrayMenu *menu)
 
 SDL_Tray *SDL_GetTrayMenuParentTray(SDL_TrayMenu *menu)
 {
-    if (!menu) {
+    CHECK_PARAM(!menu) {
         SDL_InvalidParamError("menu");
         return NULL;
     }

--- a/src/tray/unix/SDL_tray.c
+++ b/src/tray/unix/SDL_tray.c
@@ -359,7 +359,7 @@ void SDL_SetTrayTooltip(SDL_Tray *tray, const char *tooltip)
 
 SDL_TrayMenu *SDL_CreateTrayMenu(SDL_Tray *tray)
 {
-    if (!SDL_ObjectValid(tray, SDL_OBJECT_TYPE_TRAY)) {
+    CHECK_PARAM(!SDL_ObjectValid(tray, SDL_OBJECT_TYPE_TRAY)) {
         SDL_InvalidParamError("tray");
         return NULL;
     }
@@ -388,7 +388,7 @@ SDL_TrayMenu *SDL_CreateTrayMenu(SDL_Tray *tray)
 
 SDL_TrayMenu *SDL_GetTrayMenu(SDL_Tray *tray)
 {
-    if (!SDL_ObjectValid(tray, SDL_OBJECT_TYPE_TRAY)) {
+    CHECK_PARAM(!SDL_ObjectValid(tray, SDL_OBJECT_TYPE_TRAY)) {
         SDL_InvalidParamError("tray");
         return NULL;
     }
@@ -398,7 +398,7 @@ SDL_TrayMenu *SDL_GetTrayMenu(SDL_Tray *tray)
 
 SDL_TrayMenu *SDL_CreateTraySubmenu(SDL_TrayEntry *entry)
 {
-    if (!entry) {
+    CHECK_PARAM(!entry) {
         SDL_InvalidParamError("entry");
         return NULL;
     }
@@ -439,7 +439,7 @@ SDL_TrayMenu *SDL_CreateTraySubmenu(SDL_TrayEntry *entry)
 
 SDL_TrayMenu *SDL_GetTraySubmenu(SDL_TrayEntry *entry)
 {
-    if (!entry) {
+    CHECK_PARAM(!entry) {
         SDL_InvalidParamError("entry");
         return NULL;
     }
@@ -449,7 +449,7 @@ SDL_TrayMenu *SDL_GetTraySubmenu(SDL_TrayEntry *entry)
 
 const SDL_TrayEntry **SDL_GetTrayEntries(SDL_TrayMenu *menu, int *count)
 {
-    if (!menu) {
+    CHECK_PARAM(!menu) {
         SDL_InvalidParamError("menu");
         return NULL;
     }
@@ -502,12 +502,12 @@ void SDL_RemoveTrayEntry(SDL_TrayEntry *entry)
 
 SDL_TrayEntry *SDL_InsertTrayEntryAt(SDL_TrayMenu *menu, int pos, const char *label, SDL_TrayEntryFlags flags)
 {
-    if (!menu) {
+    CHECK_PARAM(!menu) {
         SDL_InvalidParamError("menu");
         return NULL;
     }
 
-    if (pos < -1 || pos > menu->nEntries) {
+    CHECK_PARAM(pos < -1 || pos > menu->nEntries) {
         SDL_InvalidParamError("pos");
         return NULL;
     }
@@ -600,7 +600,7 @@ void SDL_SetTrayEntryLabel(SDL_TrayEntry *entry, const char *label)
 
 const char *SDL_GetTrayEntryLabel(SDL_TrayEntry *entry)
 {
-    if (!entry) {
+    CHECK_PARAM(!entry) {
         SDL_InvalidParamError("entry");
         return NULL;
     }
@@ -705,7 +705,7 @@ void SDL_ClickTrayEntry(SDL_TrayEntry *entry)
 
 SDL_TrayMenu *SDL_GetTrayEntryParent(SDL_TrayEntry *entry)
 {
-    if (!entry) {
+    CHECK_PARAM(!entry) {
         SDL_InvalidParamError("entry");
         return NULL;
     }
@@ -720,7 +720,7 @@ SDL_TrayEntry *SDL_GetTrayMenuParentEntry(SDL_TrayMenu *menu)
 
 SDL_Tray *SDL_GetTrayMenuParentTray(SDL_TrayMenu *menu)
 {
-    if (!menu) {
+    CHECK_PARAM(!menu) {
         SDL_InvalidParamError("menu");
         return NULL;
     }

--- a/src/tray/windows/SDL_tray.c
+++ b/src/tray/windows/SDL_tray.c
@@ -311,7 +311,7 @@ void SDL_SetTrayTooltip(SDL_Tray *tray, const char *tooltip)
 
 SDL_TrayMenu *SDL_CreateTrayMenu(SDL_Tray *tray)
 {
-    if (!SDL_ObjectValid(tray, SDL_OBJECT_TYPE_TRAY)) {
+    CHECK_PARAM(!SDL_ObjectValid(tray, SDL_OBJECT_TYPE_TRAY)) {
         SDL_InvalidParamError("tray");
         return NULL;
     }
@@ -331,7 +331,7 @@ SDL_TrayMenu *SDL_CreateTrayMenu(SDL_Tray *tray)
 
 SDL_TrayMenu *SDL_GetTrayMenu(SDL_Tray *tray)
 {
-    if (!SDL_ObjectValid(tray, SDL_OBJECT_TYPE_TRAY)) {
+    CHECK_PARAM(!SDL_ObjectValid(tray, SDL_OBJECT_TYPE_TRAY)) {
         SDL_InvalidParamError("tray");
         return NULL;
     }
@@ -341,7 +341,7 @@ SDL_TrayMenu *SDL_GetTrayMenu(SDL_Tray *tray)
 
 SDL_TrayMenu *SDL_CreateTraySubmenu(SDL_TrayEntry *entry)
 {
-    if (!entry) {
+    CHECK_PARAM(!entry) {
         SDL_InvalidParamError("entry");
         return NULL;
     }
@@ -356,7 +356,7 @@ SDL_TrayMenu *SDL_CreateTraySubmenu(SDL_TrayEntry *entry)
 
 SDL_TrayMenu *SDL_GetTraySubmenu(SDL_TrayEntry *entry)
 {
-    if (!entry) {
+    CHECK_PARAM(!entry) {
         SDL_InvalidParamError("entry");
         return NULL;
     }
@@ -366,7 +366,7 @@ SDL_TrayMenu *SDL_GetTraySubmenu(SDL_TrayEntry *entry)
 
 const SDL_TrayEntry **SDL_GetTrayEntries(SDL_TrayMenu *menu, int *count)
 {
-    if (!menu) {
+    CHECK_PARAM(!menu) {
         SDL_InvalidParamError("menu");
         return NULL;
     }
@@ -419,12 +419,12 @@ void SDL_RemoveTrayEntry(SDL_TrayEntry *entry)
 
 SDL_TrayEntry *SDL_InsertTrayEntryAt(SDL_TrayMenu *menu, int pos, const char *label, SDL_TrayEntryFlags flags)
 {
-    if (!menu) {
+    CHECK_PARAM(!menu) {
         SDL_InvalidParamError("menu");
         return NULL;
     }
 
-    if (pos < -1 || pos > menu->nEntries) {
+    CHECK_PARAM(pos < -1 || pos > menu->nEntries) {
         SDL_InvalidParamError("pos");
         return NULL;
     }
@@ -550,7 +550,7 @@ void SDL_SetTrayEntryLabel(SDL_TrayEntry *entry, const char *label)
 
 const char *SDL_GetTrayEntryLabel(SDL_TrayEntry *entry)
 {
-    if (!entry) {
+    CHECK_PARAM(!entry) {
         SDL_InvalidParamError("entry");
         return NULL;
     }
@@ -633,7 +633,7 @@ void SDL_ClickTrayEntry(SDL_TrayEntry *entry)
 
 SDL_TrayMenu *SDL_GetTrayEntryParent(SDL_TrayEntry *entry)
 {
-    if (!entry) {
+    CHECK_PARAM(!entry) {
         SDL_InvalidParamError("entry");
         return NULL;
     }
@@ -643,7 +643,7 @@ SDL_TrayMenu *SDL_GetTrayEntryParent(SDL_TrayEntry *entry)
 
 SDL_TrayEntry *SDL_GetTrayMenuParentEntry(SDL_TrayMenu *menu)
 {
-    if (!menu) {
+    CHECK_PARAM(!menu) {
         SDL_InvalidParamError("menu");
         return NULL;
     }
@@ -653,7 +653,7 @@ SDL_TrayEntry *SDL_GetTrayMenuParentEntry(SDL_TrayMenu *menu)
 
 SDL_Tray *SDL_GetTrayMenuParentTray(SDL_TrayMenu *menu)
 {
-    if (!menu) {
+    CHECK_PARAM(!menu) {
         SDL_InvalidParamError("menu");
         return NULL;
     }

--- a/src/video/SDL_bmp.c
+++ b/src/video/SDL_bmp.c
@@ -216,7 +216,7 @@ SDL_Surface *SDL_LoadBMP_IO(SDL_IOStream *src, bool closeio)
 
     // Make sure we are passed a valid data source
     surface = NULL;
-    if (!src) {
+    CHECK_PARAM(!src) {
         SDL_InvalidParamError("src");
         goto done;
     }
@@ -630,11 +630,11 @@ bool SDL_SaveBMP_IO(SDL_Surface *surface, SDL_IOStream *dst, bool closeio)
     Uint32 bV5Reserved = 0;
 
     // Make sure we have somewhere to save
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         SDL_InvalidParamError("surface");
         goto done;
     }
-    if (!dst) {
+    CHECK_PARAM(!dst) {
         SDL_InvalidParamError("dst");
         goto done;
     }

--- a/src/video/SDL_clipboard.c
+++ b/src/video/SDL_clipboard.c
@@ -196,7 +196,7 @@ void *SDL_GetClipboardData(const char *mime_type, size_t *size)
         return NULL;
     }
 
-    if (!mime_type) {
+    CHECK_PARAM(!mime_type) {
         SDL_InvalidParamError("mime_type");
         return NULL;
     }
@@ -245,7 +245,7 @@ bool SDL_HasClipboardData(const char *mime_type)
         return SDL_UninitializedVideo();
     }
 
-    if (!mime_type) {
+    CHECK_PARAM(!mime_type) {
         return SDL_InvalidParamError("mime_type");
     }
 

--- a/src/video/SDL_fillrect.c
+++ b/src/video/SDL_fillrect.c
@@ -238,7 +238,7 @@ static void SDL_FillSurfaceRect4(Uint8 *pixels, int pitch, Uint32 color, int w, 
  */
 bool SDL_FillSurfaceRect(SDL_Surface *dst, const SDL_Rect *rect, Uint32 color)
 {
-    if (!SDL_SurfaceValid(dst)) {
+    CHECK_PARAM(!SDL_SurfaceValid(dst)) {
         return SDL_InvalidParamError("SDL_FillSurfaceRect(): dst");
     }
 
@@ -262,22 +262,22 @@ bool SDL_FillSurfaceRects(SDL_Surface *dst, const SDL_Rect *rects, int count, Ui
     void (*fill_function)(Uint8 * pixels, int pitch, Uint32 color, int w, int h) = NULL;
     int i;
 
-    if (!SDL_SurfaceValid(dst)) {
+    CHECK_PARAM(!SDL_SurfaceValid(dst)) {
         return SDL_InvalidParamError("SDL_FillSurfaceRects(): dst");
+    }
+
+    // Perform software fill
+    CHECK_PARAM(!dst->pixels) {
+        return SDL_SetError("SDL_FillSurfaceRects(): You must lock the surface");
+    }
+
+    CHECK_PARAM(!rects) {
+        return SDL_InvalidParamError("SDL_FillSurfaceRects(): rects");
     }
 
     // Nothing to do
     if (dst->w == 0 || dst->h == 0) {
         return true;
-    }
-
-    // Perform software fill
-    if (!dst->pixels) {
-        return SDL_SetError("SDL_FillSurfaceRects(): You must lock the surface");
-    }
-
-    if (!rects) {
-        return SDL_InvalidParamError("SDL_FillSurfaceRects(): rects");
     }
 
     /* This function doesn't usually work on surfaces < 8 bpp

--- a/src/video/SDL_pixels.c
+++ b/src/video/SDL_pixels.c
@@ -1035,7 +1035,7 @@ SDL_Palette *SDL_CreatePalette(int ncolors)
     SDL_Palette *palette;
 
     // Input validation
-    if (ncolors < 1) {
+    CHECK_PARAM(ncolors < 1) {
         SDL_InvalidParamError("ncolors");
         return NULL;
     }
@@ -1219,13 +1219,13 @@ void SDL_DetectPalette(const SDL_Palette *pal, bool *is_opaque, bool *has_alpha_
 // Find the opaque pixel value corresponding to an RGB triple
 Uint32 SDL_MapRGB(const SDL_PixelFormatDetails *format, const SDL_Palette *palette, Uint8 r, Uint8 g, Uint8 b)
 {
-    if (!format) {
+    CHECK_PARAM(!format) {
         SDL_InvalidParamError("format");
         return 0;
     }
 
     if (SDL_ISPIXELFORMAT_INDEXED(format->format)) {
-        if (!palette) {
+        CHECK_PARAM(!palette) {
             SDL_InvalidParamError("palette");
             return 0;
         }
@@ -1248,13 +1248,13 @@ Uint32 SDL_MapRGB(const SDL_PixelFormatDetails *format, const SDL_Palette *palet
 // Find the pixel value corresponding to an RGBA quadruple
 Uint32 SDL_MapRGBA(const SDL_PixelFormatDetails *format, const SDL_Palette *palette, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
-    if (!format) {
+    CHECK_PARAM(!format) {
         SDL_InvalidParamError("format");
         return 0;
     }
 
     if (SDL_ISPIXELFORMAT_INDEXED(format->format)) {
-        if (!palette) {
+        CHECK_PARAM(!palette) {
             SDL_InvalidParamError("palette");
             return 0;
         }

--- a/src/video/SDL_rect.c
+++ b/src/video/SDL_rect.c
@@ -31,19 +31,23 @@ bool SDL_GetSpanEnclosingRect(int width, int height,
     int span_y1, span_y2;
     int rect_y1, rect_y2;
 
-    if (width < 1) {
+    CHECK_PARAM(width < 1) {
         SDL_InvalidParamError("width");
         return false;
-    } else if (height < 1) {
+    }
+    CHECK_PARAM(height < 1) {
         SDL_InvalidParamError("height");
         return false;
-    } else if (!rects) {
+    }
+    CHECK_PARAM(!rects) {
         SDL_InvalidParamError("rects");
         return false;
-    } else if (!span) {
+    }
+    CHECK_PARAM(!span) {
         SDL_InvalidParamError("span");
         return false;
-    } else if (numrects < 1) {
+    }
+    CHECK_PARAM(numrects < 1) {
         SDL_InvalidParamError("numrects");
         return false;
     }

--- a/src/video/SDL_rect_impl.h
+++ b/src/video/SDL_rect_impl.h
@@ -38,17 +38,20 @@ bool SDL_HASINTERSECTION(const RECTTYPE *A, const RECTTYPE *B)
 {
     SCALARTYPE Amin, Amax, Bmin, Bmax;
 
-    if (!A) {
+    CHECK_PARAM(!A) {
         SDL_InvalidParamError("A");
         return false;
-    } else if (!B) {
+    }
+    CHECK_PARAM(!B) {
         SDL_InvalidParamError("B");
         return false;
-    } else if (SDL_RECT_CAN_OVERFLOW(A) ||
-               SDL_RECT_CAN_OVERFLOW(B)) {
+    }
+    CHECK_PARAM(SDL_RECT_CAN_OVERFLOW(A) || SDL_RECT_CAN_OVERFLOW(B)) {
         SDL_SetError("Potential rect math overflow");
         return false;
-    } else if (SDL_RECTEMPTY(A) || SDL_RECTEMPTY(B)) {
+    }
+
+    if (SDL_RECTEMPTY(A) || SDL_RECTEMPTY(B)) {
         return false; // Special cases for empty rects
     }
 
@@ -87,20 +90,24 @@ bool SDL_INTERSECTRECT(const RECTTYPE *A, const RECTTYPE *B, RECTTYPE *result)
 {
     SCALARTYPE Amin, Amax, Bmin, Bmax;
 
-    if (!A) {
+    CHECK_PARAM(!A) {
         SDL_InvalidParamError("A");
         return false;
-    } else if (!B) {
+    }
+    CHECK_PARAM(!B) {
         SDL_InvalidParamError("B");
         return false;
-    } else if (SDL_RECT_CAN_OVERFLOW(A) ||
-               SDL_RECT_CAN_OVERFLOW(B)) {
+    }
+    CHECK_PARAM(SDL_RECT_CAN_OVERFLOW(A) || SDL_RECT_CAN_OVERFLOW(B)) {
         SDL_SetError("Potential rect math overflow");
         return false;
-    } else if (!result) {
+    }
+    CHECK_PARAM(!result) {
         SDL_InvalidParamError("result");
         return false;
-    } else if (SDL_RECTEMPTY(A) || SDL_RECTEMPTY(B)) { // Special cases for empty rects
+    }
+
+    if (SDL_RECTEMPTY(A) || SDL_RECTEMPTY(B)) { // Special cases for empty rects
         result->w = 0;
         result->h = 0;
         return false;
@@ -141,16 +148,20 @@ bool SDL_UNIONRECT(const RECTTYPE *A, const RECTTYPE *B, RECTTYPE *result)
 {
     SCALARTYPE Amin, Amax, Bmin, Bmax;
 
-    if (!A) {
+    CHECK_PARAM(!A) {
         return SDL_InvalidParamError("A");
-    } else if (!B) {
+    }
+    CHECK_PARAM(!B) {
         return SDL_InvalidParamError("B");
-    } else if (SDL_RECT_CAN_OVERFLOW(A) ||
-               SDL_RECT_CAN_OVERFLOW(B)) {
+    }
+    CHECK_PARAM(SDL_RECT_CAN_OVERFLOW(A) || SDL_RECT_CAN_OVERFLOW(B)) {
         return SDL_SetError("Potential rect math overflow");
-    } else if (!result) {
+    }
+    CHECK_PARAM(!result) {
         return SDL_InvalidParamError("result");
-    } else if (SDL_RECTEMPTY(A)) { // Special cases for empty Rects
+    }
+
+    if (SDL_RECTEMPTY(A)) { // Special cases for empty Rects
         if (SDL_RECTEMPTY(B)) {    // A and B empty
             SDL_zerop(result);
         } else { // A empty, B not empty
@@ -201,10 +212,11 @@ bool SDL_ENCLOSEPOINTS(const POINTTYPE *points, int count, const RECTTYPE *clip,
     SCALARTYPE x, y;
     int i;
 
-    if (!points) {
+    CHECK_PARAM(!points) {
         SDL_InvalidParamError("points");
         return false;
-    } else if (count < 1) {
+    }
+    CHECK_PARAM(count < 1) {
         SDL_InvalidParamError("count");
         return false;
     }
@@ -320,25 +332,32 @@ bool SDL_INTERSECTRECTANDLINE(const RECTTYPE *rect, SCALARTYPE *X1, SCALARTYPE *
     SCALARTYPE recty2;
     int outcode1, outcode2;
 
-    if (!rect) {
+    CHECK_PARAM(!rect) {
         SDL_InvalidParamError("rect");
         return false;
-    } else if (SDL_RECT_CAN_OVERFLOW(rect)) {
+    }
+    CHECK_PARAM(SDL_RECT_CAN_OVERFLOW(rect)) {
         SDL_SetError("Potential rect math overflow");
         return false;
-    } else if (!X1) {
+    }
+    CHECK_PARAM(!X1) {
         SDL_InvalidParamError("X1");
         return false;
-    } else if (!Y1) {
+    }
+    CHECK_PARAM(!Y1) {
         SDL_InvalidParamError("Y1");
         return false;
-    } else if (!X2) {
+    }
+    CHECK_PARAM(!X2) {
         SDL_InvalidParamError("X2");
         return false;
-    } else if (!Y2) {
+    }
+    CHECK_PARAM(!Y2) {
         SDL_InvalidParamError("Y2");
         return false;
-    } else if (SDL_RECTEMPTY(rect)) {
+    }
+
+    if (SDL_RECTEMPTY(rect)) {
         return false; // Special case for empty rect
     }
 

--- a/src/video/SDL_stb.c
+++ b/src/video/SDL_stb.c
@@ -140,11 +140,11 @@ bool SDL_SavePNG_IO(SDL_Surface *surface, SDL_IOStream *dst, bool closeio)
     bool retval = true;
 
     // Make sure we have somewhere to save
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         retval = SDL_InvalidParamError("surface");
         goto done;
     }
-    if (!dst) {
+    CHECK_PARAM(!dst) {
         retval = SDL_InvalidParamError("dst");
         goto done;
     }

--- a/src/video/SDL_stretch.c
+++ b/src/video/SDL_stretch.c
@@ -33,10 +33,10 @@ bool SDL_StretchSurface(SDL_Surface *src, const SDL_Rect *srcrect, SDL_Surface *
     SDL_Rect full_src;
     SDL_Rect full_dst;
 
-    if (!src) {
+    CHECK_PARAM(!src) {
         return SDL_InvalidParamError("src");
     }
-    if (!dst) {
+    CHECK_PARAM(!dst) {
         return SDL_InvalidParamError("dst");
     }
 

--- a/src/video/SDL_surface.c
+++ b/src/video/SDL_surface.c
@@ -194,17 +194,17 @@ SDL_Surface *SDL_CreateSurface(int width, int height, SDL_PixelFormat format)
     size_t pitch, size;
     SDL_Surface *surface;
 
-    if (width < 0) {
+    CHECK_PARAM(width < 0) {
         SDL_InvalidParamError("width");
         return NULL;
     }
 
-    if (height < 0) {
+    CHECK_PARAM(height < 0) {
         SDL_InvalidParamError("height");
         return NULL;
     }
 
-    if (format == SDL_PIXELFORMAT_UNKNOWN) {
+    CHECK_PARAM(format == SDL_PIXELFORMAT_UNKNOWN) {
         SDL_InvalidParamError("format");
         return NULL;
     }
@@ -245,17 +245,17 @@ SDL_Surface *SDL_CreateSurface(int width, int height, SDL_PixelFormat format)
  */
 SDL_Surface *SDL_CreateSurfaceFrom(int width, int height, SDL_PixelFormat format, void *pixels, int pitch)
 {
-    if (width < 0) {
+    CHECK_PARAM(width < 0) {
         SDL_InvalidParamError("width");
         return NULL;
     }
 
-    if (height < 0) {
+    CHECK_PARAM(height < 0) {
         SDL_InvalidParamError("height");
         return NULL;
     }
 
-    if (format == SDL_PIXELFORMAT_UNKNOWN) {
+    CHECK_PARAM(format == SDL_PIXELFORMAT_UNKNOWN) {
         SDL_InvalidParamError("format");
         return NULL;
     }
@@ -270,7 +270,7 @@ SDL_Surface *SDL_CreateSurfaceFrom(int width, int height, SDL_PixelFormat format
             return NULL;
         }
 
-        if (pitch < 0 || (size_t)pitch < minimalPitch) {
+        CHECK_PARAM(pitch < 0 || (size_t)pitch < minimalPitch) {
             SDL_InvalidParamError("pitch");
             return NULL;
         }
@@ -287,7 +287,7 @@ SDL_Surface *SDL_CreateSurfaceFrom(int width, int height, SDL_PixelFormat format
 
 SDL_PropertiesID SDL_GetSurfaceProperties(SDL_Surface *surface)
 {
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         SDL_InvalidParamError("surface");
         return 0;
     }
@@ -300,7 +300,7 @@ SDL_PropertiesID SDL_GetSurfaceProperties(SDL_Surface *surface)
 
 bool SDL_SetSurfaceColorspace(SDL_Surface *surface, SDL_Colorspace colorspace)
 {
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         return SDL_InvalidParamError("surface");
     }
 
@@ -378,12 +378,12 @@ SDL_Palette *SDL_CreateSurfacePalette(SDL_Surface *surface)
 {
     SDL_Palette *palette;
 
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         SDL_InvalidParamError("surface");
         return NULL;
     }
 
-    if (!SDL_ISPIXELFORMAT_INDEXED(surface->format)) {
+    CHECK_PARAM(!SDL_ISPIXELFORMAT_INDEXED(surface->format)) {
         SDL_SetError("The surface is not indexed format");
         return NULL;
     }
@@ -416,11 +416,11 @@ SDL_Palette *SDL_CreateSurfacePalette(SDL_Surface *surface)
 
 bool SDL_SetSurfacePalette(SDL_Surface *surface, SDL_Palette *palette)
 {
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         return SDL_InvalidParamError("surface");
     }
 
-    if (palette && palette->ncolors > (1 << SDL_BITSPERPIXEL(surface->format))) {
+    CHECK_PARAM(palette && palette->ncolors > (1 << SDL_BITSPERPIXEL(surface->format))) {
         return SDL_SetError("SDL_SetSurfacePalette() passed a palette that doesn't match the surface format");
     }
 
@@ -452,11 +452,11 @@ SDL_Palette *SDL_GetSurfacePalette(SDL_Surface *surface)
 
 bool SDL_AddSurfaceAlternateImage(SDL_Surface *surface, SDL_Surface *image)
 {
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         return SDL_InvalidParamError("surface");
     }
 
-    if (!SDL_SurfaceValid(image)) {
+    CHECK_PARAM(!SDL_SurfaceValid(image)) {
         return SDL_InvalidParamError("image");
     }
 
@@ -486,7 +486,7 @@ SDL_Surface **SDL_GetSurfaceImages(SDL_Surface *surface, int *count)
         *count = 0;
     }
 
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         SDL_InvalidParamError("surface");
         return NULL;
     }
@@ -510,7 +510,7 @@ SDL_Surface **SDL_GetSurfaceImages(SDL_Surface *surface, int *count)
 
 SDL_Surface *SDL_GetSurfaceImage(SDL_Surface *surface, float display_scale)
 {
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         SDL_InvalidParamError("surface");
         return NULL;
     }
@@ -598,7 +598,7 @@ bool SDL_SetSurfaceRLE(SDL_Surface *surface, bool enabled)
 {
     int flags;
 
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         return SDL_InvalidParamError("surface");
     }
 
@@ -631,11 +631,11 @@ bool SDL_SetSurfaceColorKey(SDL_Surface *surface, bool enabled, Uint32 key)
 {
     int flags;
 
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         return SDL_InvalidParamError("surface");
     }
 
-    if (surface->palette && key >= ((Uint32)surface->palette->ncolors)) {
+    CHECK_PARAM(surface->palette && key >= ((Uint32)surface->palette->ncolors)) {
         return SDL_InvalidParamError("key");
     }
 
@@ -672,11 +672,11 @@ bool SDL_GetSurfaceColorKey(SDL_Surface *surface, Uint32 *key)
         *key = 0;
     }
 
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         return SDL_InvalidParamError("surface");
     }
 
-    if (!(surface->map.info.flags & SDL_COPY_COLORKEY)) {
+    CHECK_PARAM(!(surface->map.info.flags & SDL_COPY_COLORKEY)) {
         return SDL_SetError("Surface doesn't have a colorkey");
     }
 
@@ -781,7 +781,7 @@ bool SDL_SetSurfaceColorMod(SDL_Surface *surface, Uint8 r, Uint8 g, Uint8 b)
 {
     int flags;
 
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         return SDL_InvalidParamError("surface");
     }
 
@@ -803,7 +803,7 @@ bool SDL_SetSurfaceColorMod(SDL_Surface *surface, Uint8 r, Uint8 g, Uint8 b)
 
 bool SDL_GetSurfaceColorMod(SDL_Surface *surface, Uint8 *r, Uint8 *g, Uint8 *b)
 {
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         if (r) {
             *r = 255;
         }
@@ -832,7 +832,7 @@ bool SDL_SetSurfaceAlphaMod(SDL_Surface *surface, Uint8 alpha)
 {
     int flags;
 
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         return SDL_InvalidParamError("surface");
     }
 
@@ -852,7 +852,7 @@ bool SDL_SetSurfaceAlphaMod(SDL_Surface *surface, Uint8 alpha)
 
 bool SDL_GetSurfaceAlphaMod(SDL_Surface *surface, Uint8 *alpha)
 {
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         if (alpha) {
             *alpha = 255;
         }
@@ -870,11 +870,11 @@ bool SDL_SetSurfaceBlendMode(SDL_Surface *surface, SDL_BlendMode blendMode)
     int flags;
     bool result = true;
 
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         return SDL_InvalidParamError("surface");
     }
 
-    if (blendMode == SDL_BLENDMODE_INVALID) {
+    CHECK_PARAM(blendMode == SDL_BLENDMODE_INVALID) {
         return SDL_InvalidParamError("blendMode");
     }
 
@@ -919,7 +919,7 @@ bool SDL_GetSurfaceBlendMode(SDL_Surface *surface, SDL_BlendMode *blendMode)
         *blendMode = SDL_BLENDMODE_INVALID;
     }
 
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         return SDL_InvalidParamError("surface");
     }
 
@@ -978,13 +978,13 @@ bool SDL_SetSurfaceClipRect(SDL_Surface *surface, const SDL_Rect *rect)
 
 bool SDL_GetSurfaceClipRect(SDL_Surface *surface, SDL_Rect *rect)
 {
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         if (rect) {
             SDL_zerop(rect);
         }
         return SDL_InvalidParamError("surface");
     }
-    if (!rect) {
+    CHECK_PARAM(!rect) {
         return SDL_InvalidParamError("rect");
     }
     *rect = surface->clip_rect;
@@ -1017,11 +1017,13 @@ bool SDL_BlitSurface(SDL_Surface *src, const SDL_Rect *srcrect, SDL_Surface *dst
     SDL_Rect r_src, r_dst;
 
     // Make sure the surfaces aren't locked
-    if (!SDL_SurfaceValid(src)) {
+    CHECK_PARAM(!SDL_SurfaceValid(src)) {
         return SDL_InvalidParamError("src");
-    } else if (!SDL_SurfaceValid(dst)) {
+    }
+    CHECK_PARAM(!SDL_SurfaceValid(dst)) {
         return SDL_InvalidParamError("dst");
-    } else if ((src->flags & SDL_SURFACE_LOCKED) || (dst->flags & SDL_SURFACE_LOCKED)) {
+    }
+    CHECK_PARAM((src->flags & SDL_SURFACE_LOCKED) || (dst->flags & SDL_SURFACE_LOCKED)) {
         return SDL_SetError("Surfaces must not be locked during blit");
     }
 
@@ -1127,11 +1129,13 @@ bool SDL_BlitSurfaceScaled(SDL_Surface *src, const SDL_Rect *srcrect, SDL_Surfac
     SDL_Rect r_src, r_dst;
 
     // Make sure the surfaces aren't locked
-    if (!SDL_SurfaceValid(src) || !src->pixels) {
+    CHECK_PARAM(!SDL_SurfaceValid(src) || !src->pixels) {
         return SDL_InvalidParamError("src");
-    } else if (!SDL_SurfaceValid(dst) || !dst->pixels) {
+    }
+    CHECK_PARAM(!SDL_SurfaceValid(dst) || !dst->pixels) {
         return SDL_InvalidParamError("dst");
-    } else if ((src->flags & SDL_SURFACE_LOCKED) || (dst->flags & SDL_SURFACE_LOCKED)) {
+    }
+    CHECK_PARAM((src->flags & SDL_SURFACE_LOCKED) || (dst->flags & SDL_SURFACE_LOCKED)) {
         return SDL_SetError("Surfaces must not be locked during blit");
     }
 
@@ -1342,11 +1346,13 @@ bool SDL_BlitSurfaceTiled(SDL_Surface *src, const SDL_Rect *srcrect, SDL_Surface
     SDL_Rect r_src, r_dst;
 
     // Make sure the surfaces aren't locked
-    if (!SDL_SurfaceValid(src)) {
+    CHECK_PARAM(!SDL_SurfaceValid(src)) {
         return SDL_InvalidParamError("src");
-    } else if (!SDL_SurfaceValid(dst)) {
+    }
+    CHECK_PARAM(!SDL_SurfaceValid(dst)) {
         return SDL_InvalidParamError("dst");
-    } else if ((src->flags & SDL_SURFACE_LOCKED) || (dst->flags & SDL_SURFACE_LOCKED)) {
+    }
+    CHECK_PARAM((src->flags & SDL_SURFACE_LOCKED) || (dst->flags & SDL_SURFACE_LOCKED)) {
         return SDL_SetError("Surfaces must not be locked during blit");
     }
 
@@ -1447,15 +1453,16 @@ bool SDL_BlitSurfaceTiledWithScale(SDL_Surface *src, const SDL_Rect *srcrect, fl
     SDL_Rect r_src, r_dst;
 
     // Make sure the surfaces aren't locked
-    if (!SDL_SurfaceValid(src)) {
+    CHECK_PARAM(!SDL_SurfaceValid(src)) {
         return SDL_InvalidParamError("src");
-    } else if (!SDL_SurfaceValid(dst)) {
+    }
+    CHECK_PARAM(!SDL_SurfaceValid(dst)) {
         return SDL_InvalidParamError("dst");
-    } else if ((src->flags & SDL_SURFACE_LOCKED) || (dst->flags & SDL_SURFACE_LOCKED)) {
+    }
+    CHECK_PARAM((src->flags & SDL_SURFACE_LOCKED) || (dst->flags & SDL_SURFACE_LOCKED)) {
         return SDL_SetError("Surfaces must not be locked during blit");
     }
-
-    if (scale <= 0.0f) {
+    CHECK_PARAM(scale <= 0.0f) {
         return SDL_InvalidParamError("scale");
     }
 
@@ -1565,9 +1572,10 @@ bool SDL_BlitSurface9Grid(SDL_Surface *src, const SDL_Rect *srcrect, int left_wi
     int dst_bottom_height;
 
     // Make sure the surfaces aren't locked
-    if (!SDL_SurfaceValid(src)) {
+    CHECK_PARAM(!SDL_SurfaceValid(src)) {
         return SDL_InvalidParamError("src");
-    } else if (!SDL_SurfaceValid(dst)) {
+    }
+    CHECK_PARAM(!SDL_SurfaceValid(dst)) {
         return SDL_InvalidParamError("dst");
     }
 
@@ -1698,7 +1706,7 @@ bool SDL_BlitSurface9Grid(SDL_Surface *src, const SDL_Rect *srcrect, int left_wi
  */
 bool SDL_LockSurface(SDL_Surface *surface)
 {
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         return SDL_InvalidParamError("surface");
     }
 
@@ -1816,7 +1824,7 @@ static bool SDL_FlipSurfaceVertical(SDL_Surface *surface)
 
 bool SDL_FlipSurface(SDL_Surface *surface, SDL_FlipMode flip)
 {
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         return SDL_InvalidParamError("surface");
     }
     if (!surface->pixels) {
@@ -1857,12 +1865,12 @@ SDL_Surface *SDL_ConvertSurfaceAndColorspace(SDL_Surface *surface, SDL_PixelForm
     Uint8 *palette_saved_alpha = NULL;
     int palette_saved_alpha_ncolors = 0;
 
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         SDL_InvalidParamError("surface");
         goto error;
     }
 
-    if (format == SDL_PIXELFORMAT_UNKNOWN) {
+    CHECK_PARAM(format == SDL_PIXELFORMAT_UNKNOWN) {
         SDL_InvalidParamError("format");
         goto error;
     }
@@ -2129,7 +2137,7 @@ error:
 
 SDL_Surface *SDL_DuplicateSurface(SDL_Surface *surface)
 {
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         SDL_InvalidParamError("surface");
         return NULL;
     }
@@ -2144,7 +2152,7 @@ SDL_Surface *SDL_ScaleSurface(SDL_Surface *surface, int width, int height, SDL_S
     SDL_Color copy_color;
     bool rc;
 
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         SDL_InvalidParamError("surface");
         goto error;
     }
@@ -2221,7 +2229,7 @@ error:
 
 SDL_Surface *SDL_ConvertSurface(SDL_Surface *surface, SDL_PixelFormat format)
 {
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         SDL_InvalidParamError("surface");
         return NULL;
     }
@@ -2258,16 +2266,16 @@ bool SDL_ConvertPixelsAndColorspace(int width, int height,
     void *nonconst_src = (void *)src;
     bool result;
 
-    if (!src) {
+    CHECK_PARAM(!src) {
         return SDL_InvalidParamError("src");
     }
-    if (!src_pitch) {
+    CHECK_PARAM(!src_pitch) {
         return SDL_InvalidParamError("src_pitch");
     }
-    if (!dst) {
+    CHECK_PARAM(!dst) {
         return SDL_InvalidParamError("dst");
     }
-    if (!dst_pitch) {
+    CHECK_PARAM(!dst_pitch) {
         return SDL_InvalidParamError("dst_pitch");
     }
 
@@ -2450,16 +2458,16 @@ static bool SDL_PremultiplyAlphaPixelsAndColorspace(int width, int height, SDL_P
     SDL_Colorspace colorspace;
     bool result = false;
 
-    if (!src) {
+    CHECK_PARAM(!src) {
         return SDL_InvalidParamError("src");
     }
-    if (!src_pitch) {
+    CHECK_PARAM(!src_pitch) {
         return SDL_InvalidParamError("src_pitch");
     }
-    if (!dst) {
+    CHECK_PARAM(!dst) {
         return SDL_InvalidParamError("dst");
     }
-    if (!dst_pitch) {
+    CHECK_PARAM(!dst_pitch) {
         return SDL_InvalidParamError("dst_pitch");
     }
 
@@ -2558,7 +2566,7 @@ bool SDL_PremultiplySurfaceAlpha(SDL_Surface *surface, bool linear)
 {
     SDL_Colorspace colorspace;
 
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         return SDL_InvalidParamError("surface");
     }
 
@@ -2572,7 +2580,7 @@ bool SDL_ClearSurface(SDL_Surface *surface, float r, float g, float b, float a)
     SDL_Rect clip_rect;
     bool result = false;
 
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         return SDL_InvalidParamError("surface");
     }
 
@@ -2632,7 +2640,7 @@ Uint32 SDL_MapSurfaceRGB(SDL_Surface *surface, Uint8 r, Uint8 g, Uint8 b)
 
 Uint32 SDL_MapSurfaceRGBA(SDL_Surface *surface, Uint8 r, Uint8 g, Uint8 b, Uint8 a)
 {
-    if (!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
         SDL_InvalidParamError("surface");
         return true;
     }
@@ -2672,15 +2680,15 @@ bool SDL_ReadSurfacePixel(SDL_Surface *surface, int x, int y, Uint8 *r, Uint8 *g
         a = &unused;
     }
 
-    if (!SDL_SurfaceValid(surface) || !surface->format || !surface->pixels) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface) || !surface->format || !surface->pixels) {
         return SDL_InvalidParamError("surface");
     }
 
-    if (x < 0 || x >= surface->w) {
+    CHECK_PARAM(x < 0 || x >= surface->w) {
         return SDL_InvalidParamError("x");
     }
 
-    if (y < 0 || y >= surface->h) {
+    CHECK_PARAM(y < 0 || y >= surface->h) {
         return SDL_InvalidParamError("y");
     }
 
@@ -2759,15 +2767,15 @@ bool SDL_ReadSurfacePixelFloat(SDL_Surface *surface, int x, int y, float *r, flo
         a = &unused;
     }
 
-    if (!SDL_SurfaceValid(surface) || !surface->format || !surface->pixels) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface) || !surface->format || !surface->pixels) {
         return SDL_InvalidParamError("surface");
     }
 
-    if (x < 0 || x >= surface->w) {
+    CHECK_PARAM(x < 0 || x >= surface->w) {
         return SDL_InvalidParamError("x");
     }
 
-    if (y < 0 || y >= surface->h) {
+    CHECK_PARAM(y < 0 || y >= surface->h) {
         return SDL_InvalidParamError("y");
     }
 
@@ -2834,15 +2842,15 @@ bool SDL_WriteSurfacePixel(SDL_Surface *surface, int x, int y, Uint8 r, Uint8 g,
     Uint8 *p;
     bool result = false;
 
-    if (!SDL_SurfaceValid(surface) || !surface->format || !surface->pixels) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface) || !surface->format || !surface->pixels) {
         return SDL_InvalidParamError("surface");
     }
 
-    if (x < 0 || x >= surface->w) {
+    CHECK_PARAM(x < 0 || x >= surface->w) {
         return SDL_InvalidParamError("x");
     }
 
-    if (y < 0 || y >= surface->h) {
+    CHECK_PARAM(y < 0 || y >= surface->h) {
         return SDL_InvalidParamError("y");
     }
 
@@ -2887,15 +2895,15 @@ bool SDL_WriteSurfacePixelFloat(SDL_Surface *surface, int x, int y, float r, flo
 {
     bool result = false;
 
-    if (!SDL_SurfaceValid(surface) || !surface->format || !surface->pixels) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface) || !surface->format || !surface->pixels) {
         return SDL_InvalidParamError("surface");
     }
 
-    if (x < 0 || x >= surface->w) {
+    CHECK_PARAM(x < 0 || x >= surface->w) {
         return SDL_InvalidParamError("x");
     }
 
-    if (y < 0 || y >= surface->h) {
+    CHECK_PARAM(y < 0 || y >= surface->h) {
         return SDL_InvalidParamError("y");
     }
 

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -157,22 +157,22 @@ static VideoBootStrap *bootstrap[] = {
 };
 
 #define CHECK_WINDOW_MAGIC(window, result)                              \
-    if (!_this) {                                                       \
+    CHECK_PARAM(!_this) {                                               \
         SDL_UninitializedVideo();                                       \
         return result;                                                  \
     }                                                                   \
-    if (!SDL_ObjectValid(window, SDL_OBJECT_TYPE_WINDOW)) {             \
+    CHECK_PARAM(!SDL_ObjectValid(window, SDL_OBJECT_TYPE_WINDOW)) {     \
         SDL_SetError("Invalid window");                                 \
         return result;                                                  \
     }
 
 #define CHECK_DISPLAY_MAGIC(display, result)                            \
-    if (!display) {                                                     \
+    CHECK_PARAM(!display) {                                             \
         return result;                                                  \
     }                                                                   \
 
 #define CHECK_WINDOW_NOT_POPUP(window, result)                          \
-    if (SDL_WINDOW_IS_POPUP(window)) {                                  \
+    CHECK_PARAM(SDL_WINDOW_IS_POPUP(window)) {                          \
         SDL_SetError("Operation invalid on popup windows");             \
         return result;                                                  \
     }
@@ -598,11 +598,11 @@ int SDL_GetNumVideoDrivers(void)
 
 const char *SDL_GetVideoDriver(int index)
 {
-    if (index >= 0 && index < SDL_GetNumVideoDrivers()) {
-        return deduped_bootstrap[index]->name;
+    CHECK_PARAM(index < 0 || index >= SDL_GetNumVideoDrivers()) {
+        SDL_InvalidParamError("index");
+        return NULL;
     }
-    SDL_InvalidParamError("index");
-    return NULL;
+    return deduped_bootstrap[index]->name;
 }
 
 /*
@@ -1059,7 +1059,7 @@ bool SDL_GetDisplayBounds(SDL_DisplayID displayID, SDL_Rect *rect)
 
     CHECK_DISPLAY_MAGIC(display, false);
 
-    if (!rect) {
+    CHECK_PARAM(!rect) {
         return SDL_InvalidParamError("rect");
     }
 
@@ -1094,7 +1094,7 @@ bool SDL_GetDisplayUsableBounds(SDL_DisplayID displayID, SDL_Rect *rect)
 
     CHECK_DISPLAY_MAGIC(display, false);
 
-    if (!rect) {
+    CHECK_PARAM(!rect) {
         return SDL_InvalidParamError("rect");
     }
 
@@ -1362,7 +1362,7 @@ SDL_DisplayMode **SDL_GetFullscreenDisplayModes(SDL_DisplayID displayID, int *co
 
 bool SDL_GetClosestFullscreenDisplayMode(SDL_DisplayID displayID, int w, int h, float refresh_rate, bool include_high_density_modes, SDL_DisplayMode *result)
 {
-    if (!result) {
+    CHECK_PARAM(!result) {
         return SDL_InvalidParamError("closest"); // Parameter `result` is called `closest` in the header.
     }
 
@@ -1652,7 +1652,7 @@ void SDL_GlobalToRelativeForWindow(SDL_Window *window, int abs_x, int abs_y, int
 
 SDL_DisplayID SDL_GetDisplayForPoint(const SDL_Point *point)
 {
-    if (!point) {
+    CHECK_PARAM(!point) {
         SDL_InvalidParamError("point");
         return 0;
     }
@@ -1662,7 +1662,7 @@ SDL_DisplayID SDL_GetDisplayForPoint(const SDL_Point *point)
 
 SDL_DisplayID SDL_GetDisplayForRect(const SDL_Rect *rect)
 {
-    if (!rect) {
+    CHECK_PARAM(!rect) {
         SDL_InvalidParamError("rect");
         return 0;
     }
@@ -2924,7 +2924,7 @@ bool SDL_SetWindowIcon(SDL_Window *window, SDL_Surface *icon)
 {
     CHECK_WINDOW_MAGIC(window, false);
 
-    if (!icon) {
+    CHECK_PARAM(!icon) {
         return SDL_InvalidParamError("icon");
     }
 
@@ -3118,10 +3118,10 @@ bool SDL_SetWindowSize(SDL_Window *window, int w, int h)
 {
     CHECK_WINDOW_MAGIC(window, false);
 
-    if (w <= 0) {
+    CHECK_PARAM(w <= 0) {
         return SDL_InvalidParamError("w");
     }
-    if (h <= 0) {
+    CHECK_PARAM(h <= 0) {
         return SDL_InvalidParamError("h");
     }
 
@@ -3266,15 +3266,14 @@ bool SDL_GetWindowSizeInPixels(SDL_Window *window, int *w, int *h)
 bool SDL_SetWindowMinimumSize(SDL_Window *window, int min_w, int min_h)
 {
     CHECK_WINDOW_MAGIC(window, false);
-    if (min_w < 0) {
+    CHECK_PARAM(min_w < 0) {
         return SDL_InvalidParamError("min_w");
     }
-    if (min_h < 0) {
+    CHECK_PARAM(min_h < 0) {
         return SDL_InvalidParamError("min_h");
     }
 
-    if ((window->max_w && min_w > window->max_w) ||
-        (window->max_h && min_h > window->max_h)) {
+    CHECK_PARAM((window->max_w && min_w > window->max_w) || (window->max_h && min_h > window->max_h)) {
         return SDL_SetError("SDL_SetWindowMinimumSize(): Tried to set minimum size larger than maximum size");
     }
 
@@ -3308,10 +3307,10 @@ bool SDL_GetWindowMinimumSize(SDL_Window *window, int *min_w, int *min_h)
 bool SDL_SetWindowMaximumSize(SDL_Window *window, int max_w, int max_h)
 {
     CHECK_WINDOW_MAGIC(window, false);
-    if (max_w < 0) {
+    CHECK_PARAM(max_w < 0) {
         return SDL_InvalidParamError("max_w");
     }
-    if (max_h < 0) {
+    CHECK_PARAM(max_h < 0) {
         return SDL_InvalidParamError("max_h");
     }
 
@@ -4092,7 +4091,7 @@ bool SDL_SetWindowProgressState(SDL_Window *window, SDL_ProgressState state)
     CHECK_WINDOW_MAGIC(window, false);
     CHECK_WINDOW_NOT_POPUP(window, false);
 
-    if (state < SDL_PROGRESS_STATE_NONE || state > SDL_PROGRESS_STATE_ERROR) {
+    CHECK_PARAM(state < SDL_PROGRESS_STATE_NONE || state > SDL_PROGRESS_STATE_ERROR) {
         return SDL_InvalidParamError("state");
     }
 
@@ -5048,7 +5047,7 @@ bool SDL_GL_GetAttribute(SDL_GLAttr attr, int *value)
     GLenum attachmentattrib = 0;
 #endif
 
-    if (!value) {
+    CHECK_PARAM(!value) {
         return SDL_InvalidParamError("value");
     }
 
@@ -5457,7 +5456,7 @@ bool SDL_GL_SetSwapInterval(int interval)
 
 bool SDL_GL_GetSwapInterval(int *interval)
 {
-    if (!interval) {
+    CHECK_PARAM(!interval) {
        return SDL_InvalidParamError("interval");
     }
 
@@ -5491,10 +5490,10 @@ bool SDL_GL_SwapWindow(SDL_Window *window)
 
 bool SDL_GL_DestroyContext(SDL_GLContext context)
 {
-    if (!_this) {
+    CHECK_PARAM(!_this) {
         return SDL_UninitializedVideo();
     }
-    if (!context) {
+    CHECK_PARAM(!context) {
         return SDL_InvalidParamError("context");
     }
 
@@ -5805,9 +5804,10 @@ bool SDL_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonID)
     SDL_Window *current_window;
     SDL_MessageBoxData mbdata;
 
-    if (!messageboxdata) {
+    CHECK_PARAM(!messageboxdata) {
         return SDL_InvalidParamError("messageboxdata");
-    } else if (messageboxdata->numbuttons < 0) {
+    }
+    CHECK_PARAM(messageboxdata->numbuttons < 0) {
         return SDL_SetError("Invalid number of buttons");
     }
 
@@ -6146,11 +6146,11 @@ bool SDL_Vulkan_CreateSurface(SDL_Window *window,
         return SDL_SetError(NOT_A_VULKAN_WINDOW);
     }
 
-    if (!instance) {
+    CHECK_PARAM(!instance) {
         return SDL_InvalidParamError("instance");
     }
 
-    if (!surface) {
+    CHECK_PARAM(!surface) {
         return SDL_InvalidParamError("surface");
     }
 
@@ -6170,17 +6170,17 @@ bool SDL_Vulkan_GetPresentationSupport(VkInstance instance,
                                            VkPhysicalDevice physicalDevice,
                                            Uint32 queueFamilyIndex)
 {
-    if (!_this) {
+    CHECK_PARAM(!_this) {
         SDL_UninitializedVideo();
         return false;
     }
 
-    if (!instance) {
+    CHECK_PARAM(!instance) {
         SDL_InvalidParamError("instance");
         return false;
     }
 
-    if (!physicalDevice) {
+    CHECK_PARAM(!physicalDevice) {
         SDL_InvalidParamError("physicalDevice");
         return false;
     }
@@ -6231,12 +6231,11 @@ void SDL_Metal_DestroyView(SDL_MetalView view)
 void *SDL_Metal_GetLayer(SDL_MetalView view)
 {
     if (_this && _this->Metal_GetLayer) {
-        if (view) {
-            return _this->Metal_GetLayer(_this, view);
-        } else {
+        CHECK_PARAM(!view) {
             SDL_InvalidParamError("view");
             return NULL;
         }
+        return _this->Metal_GetLayer(_this, view);
     } else {
         SDL_SetError("Metal is not supported.");
         return NULL;

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -4429,6 +4429,8 @@ void SDL_DestroyWindow(SDL_Window *window)
 
     SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_DESTROYED, 0, 0);
 
+    SDL_DestroyWindowSurface(window);
+
     SDL_Renderer *renderer = SDL_GetRenderer(window);
     if (renderer) {
         SDL_DestroyRendererWithoutFreeing(renderer);
@@ -4468,8 +4470,6 @@ void SDL_DestroyWindow(SDL_Window *window)
     if (SDL_GetMouseFocus() == window) {
         SDL_SetMouseFocus(NULL);
     }
-
-    SDL_DestroyWindowSurface(window);
 
     // Make no context current if this is the current context window
     if (window->flags & SDL_WINDOW_OPENGL) {

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -70,7 +70,7 @@ typedef enum THUMBBUTTONFLAGS
     THBF_HIDDEN = 0x8,
     THBF_NONINTERACTIVE = 0x10
 } THUMBBUTTONFLAGS;
- 
+
 #if defined(_MSC_VER)
 #pragma warning(disable: 4103)
 #endif
@@ -801,11 +801,11 @@ bool SDL_GetDXGIOutputInfo(SDL_DisplayID displayID, int *adapterIndex, int *outp
     IDXGIAdapter *pDXGIAdapter;
     IDXGIOutput *pDXGIOutput;
 
-    if (!adapterIndex) {
+    CHECK_PARAM(!adapterIndex) {
         return SDL_InvalidParamError("adapterIndex");
     }
 
-    if (!outputIndex) {
+    CHECK_PARAM(!outputIndex) {
         return SDL_InvalidParamError("outputIndex");
     }
 


### PR DESCRIPTION
Special thanks to @mechakotik for their investigation and first pass of this PR.

SDL supports the following use cases:
 * Normal operation with fast parameter checks (default):
    `SDL_SetHint(SDL_HINT_INVALID_PARAM_CHECKS, "1");`
 * Object parameters are checked for use-after-free issues:
    `SDL_SetHint(SDL_HINT_INVALID_PARAM_CHECKS, "2");`
 * Enable full validation, plus assert on invalid parameters:
    `#define SDL_ASSERT_INVALID_PARAMS`
 * Disable all parameter validation:
    `#define SDL_DISABLE_INVALID_PARAMS`

Closes https://github.com/libsdl-org/SDL/pull/13213
Closes https://github.com/libsdl-org/SDL/pull/13943
