### PR TITLE
Don't use assert(0) for SDL_TriggerBreak

### DIFF
--- a/include/SDL3/SDL_assert.h
+++ b/include/SDL3/SDL_assert.h
@@ -132,9 +132,6 @@ extern "C" {
     #define SDL_TriggerBreakpoint() __debugbreak()
 #elif defined(_MSC_VER) && defined(_M_IX86)
     #define SDL_TriggerBreakpoint() { _asm { int 0x03 }  }
-#elif defined(ANDROID) || defined(__SYMBIAN32__)
-    #include <assert.h>
-    #define SDL_TriggerBreakpoint() assert(0)
 #elif SDL_HAS_BUILTIN(__builtin_debugtrap)
     #define SDL_TriggerBreakpoint() __builtin_debugtrap()
 #elif SDL_HAS_BUILTIN(__builtin_trap)


### PR DESCRIPTION
- The assert macro is disabled when building with -DNDEBUG.
- On Android, the debugger stopped in the wrong frame.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
Fixes #13972