### PR TITLE
filesystem: GetCurrentDirectory now falls back to GetBasePath when unsupported

### DIFF
--- a/src/filesystem/dummy/SDL_sysfilesystem.c
+++ b/src/filesystem/dummy/SDL_sysfilesystem.c
@@ -47,8 +47,12 @@ char *SDL_SYS_GetUserFolder(SDL_Folder folder)
 
 char *SDL_SYS_GetCurrentDirectory(void)
 {
-    SDL_Unsupported();
-    return NULL;
+    const char *base = SDL_GetBasePath();
+    if (!base) {
+        return NULL;
+    }
+
+    return SDL_strdup(base);
 }
 
 #endif // SDL_FILESYSTEM_DUMMY || SDL_FILESYSTEM_DISABLED

--- a/src/filesystem/gdk/SDL_sysfilesystem.cpp
+++ b/src/filesystem/gdk/SDL_sysfilesystem.cpp
@@ -137,9 +137,12 @@ char *SDL_SYS_GetUserFolder(SDL_Folder folder)
     return NULL;
 }
 
-// TODO
 char *SDL_SYS_GetCurrentDirectory(void)
 {
-    SDL_Unsupported();
-    return NULL;
+    const char *base = SDL_GetBasePath();
+    if (!base) {
+        return NULL;
+    }
+
+    return SDL_strdup(base);
 }


### PR DESCRIPTION
Fixes #13980. Affects a lot of platforms at once, so waiting for CI just in case...