### PR TITLE
[SDL3] [PS2] Framebuffer resolution + 240p/480p + PAL support

### DIFF
--- a/docs/README-ps2.md
+++ b/docs/README-ps2.md
@@ -16,6 +16,12 @@ cmake --build build
 cmake --install build
 ```
 
+## Hints
+- `SDL_HINT_PS2_GS_WIDTH`: Width of the framebuffer. Defaults to 640.
+- `SDL_HINT_PS2_GS_HEIGHT`: Height of the framebuffer. Defaults to 448.
+- `SDL_HINT_PS2_GS_PROGRESSIVE`: Whether to use progressive, instead of interlaced. Defaults to 0.
+- `SDL_HINT_PS2_GS_MODE`: Regional standard of the signal. "NTSC" (60hz), "PAL" (50hz) or "" (the console's region, default).
+
 ## Notes
 If you trying to debug a SDL app through [ps2client](https://github.com/ps2dev/ps2client) you need to avoid the IOP reset, otherwise you will lose the connection with your computer.
 So to avoid the reset of the IOP CPU, you need to call to the macro `SDL_PS2_SKIP_IOP_RESET();`.

--- a/docs/README-ps2.md
+++ b/docs/README-ps2.md
@@ -11,7 +11,7 @@ Credit to
 ## Building
 To build SDL library for the PS2, make sure you have the latest PS2Dev status and run:
 ```bash
-cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$PS2DEV/ps2sdk/ps2dev.cmake
+cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$PS2DEV/share/ps2dev.cmake
 cmake --build build
 cmake --install build
 ```

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -3170,6 +3170,37 @@ extern "C" {
 #define SDL_HINT_ROG_GAMEPAD_MICE_EXCLUDED "SDL_ROG_GAMEPAD_MICE_EXCLUDED"
 
 /**
+ * Variable controlling the width of the PS2's framebuffer in pixels
+ *
+ * By default, this variable is "640"
+ */
+#define SDL_HINT_PS2_GS_WIDTH    "SDL_PS2_GS_WIDTH"
+
+/**
+ * Variable controlling the height of the PS2's framebuffer in pixels
+ *
+ * By default, this variable is "448"
+ */
+#define SDL_HINT_PS2_GS_HEIGHT    "SDL_PS2_GS_HEIGHT"
+
+/**
+ * Variable controlling whether the signal is interlaced or progressive
+ *
+ * - "0": Image is interlaced. Default
+ * - "1": Image is progressive
+ */
+#define SDL_HINT_PS2_GS_PROGRESSIVE    "SDL_PS2_GS_PROGRESSIVE"
+
+/**
+ * Variable controlling the video mode of the console
+ *
+ * - "": Console-native. Default
+ * - "NTSC": 60hz region
+ * - "PAL": 50hz region
+ */
+#define SDL_HINT_PS2_GS_MODE    "SDL_PS2_GS_MODE"
+
+/**
  * A variable controlling which Dispmanx layer to use on a Raspberry PI.
  *
  * Also known as Z-order. The variable can take a negative or positive value.

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -3186,7 +3186,7 @@ extern "C" {
 /**
  * Variable controlling whether the signal is interlaced or progressive
  *
- * - "0": Image is interlaced. Default
+ * - "0": Image is interlaced. (default)
  * - "1": Image is progressive
  */
 #define SDL_HINT_PS2_GS_PROGRESSIVE    "SDL_PS2_GS_PROGRESSIVE"
@@ -3194,7 +3194,7 @@ extern "C" {
 /**
  * Variable controlling the video mode of the console
  *
- * - "": Console-native. Default
+ * - "": Console-native. (default)
  * - "NTSC": 60hz region
  * - "PAL": 50hz region
  */

--- a/src/render/ps2/SDL_render_ps2.c
+++ b/src/render/ps2/SDL_render_ps2.c
@@ -635,7 +635,6 @@ static bool PS2_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_P
     PS2_RenderData *data;
     GSGLOBAL *gsGlobal;
     ee_sema_t sema;
-    int w,h;
 
     SDL_SetupRendererColorspace(renderer, create_props);
 
@@ -657,33 +656,38 @@ static bool PS2_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_P
     gsGlobal = gsKit_init_global_custom(RENDER_QUEUE_OS_POOLSIZE, RENDER_QUEUE_PER_POOLSIZE);
 
     // GS interlaced/progressive
-    if (SDL_GetHintBoolean(SDL_HINT_PS2_GS_PROGRESSIVE,0)) {
+    if (SDL_GetHintBoolean(SDL_HINT_PS2_GS_PROGRESSIVE, false)) {
         gsGlobal->Interlace = GS_NONINTERLACED;
     } else {
         gsGlobal->Interlace = GS_INTERLACED;
     }
-
+    
     // GS width/height
-    if (
-        SDL_GetHint(SDL_HINT_PS2_GS_WIDTH) == NULL ||
-        sscanf(SDL_GetHint(SDL_HINT_PS2_GS_WIDTH),"%d",&w) != 1
-    ) { w = 640; }
-
-    if (
-        SDL_GetHint(SDL_HINT_PS2_GS_HEIGHT) == NULL ||
-        sscanf(SDL_GetHint(SDL_HINT_PS2_GS_HEIGHT),"%d",&h) != 1
-    ) { h = 448; }
-
-    gsGlobal->Width = w;
-    gsGlobal->Height = h;
+    gsGlobal->Width = 0;
+    gsGlobal->Height = 0;
+    const char *hint = SDL_GetHint(SDL_HINT_PS2_GS_WIDTH);
+    if (hint) {
+        gsGlobal->Width = SDL_atoi(hint);
+    }
+    hint = SDL_GetHint(SDL_HINT_PS2_GS_HEIGHT);
+    if (hint) {
+        gsGlobal->Height = SDL_atoi(hint);
+    }
+    if (gsGlobal->Width <= 0) {
+        gsGlobal->Width = 640;
+    }
+    if (gsGlobal->Height <= 0) {
+        gsGlobal->Height = 448;
+    }
 
     // GS region
-    if (SDL_GetHint(SDL_HINT_PS2_GS_MODE) != NULL) {
-        if (strcmp(SDL_GetHint(SDL_HINT_PS2_GS_MODE),"NTSC") == 0) {
+    hint = SDL_GetHint(SDL_HINT_PS2_GS_MODE);
+    if (hint) {
+        if (SDL_strcasecmp(SDL_GetHint(SDL_HINT_PS2_GS_MODE), "NTSC") == 0) {
             gsGlobal->Mode = GS_MODE_NTSC;
         }
 
-        if (strcmp(SDL_GetHint(SDL_HINT_PS2_GS_MODE),"PAL") == 0) {
+        if (SDL_strcasecmp(SDL_GetHint(SDL_HINT_PS2_GS_MODE), "PAL") == 0) {
             gsGlobal->Mode = GS_MODE_PAL;
         }
     }

--- a/src/render/ps2/SDL_render_ps2.c
+++ b/src/render/ps2/SDL_render_ps2.c
@@ -655,7 +655,6 @@ static bool PS2_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_P
 
     gsGlobal = gsKit_init_global_custom(RENDER_QUEUE_OS_POOLSIZE, RENDER_QUEUE_PER_POOLSIZE);
 
-    gsGlobal->Mode = GS_MODE_NTSC;
     gsGlobal->Height = 448;
 
     gsGlobal->PSM = GS_PSM_CT24;

--- a/src/render/ps2/SDL_render_ps2.c
+++ b/src/render/ps2/SDL_render_ps2.c
@@ -635,6 +635,7 @@ static bool PS2_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_P
     PS2_RenderData *data;
     GSGLOBAL *gsGlobal;
     ee_sema_t sema;
+    int w,h;
 
     SDL_SetupRendererColorspace(renderer, create_props);
 
@@ -655,7 +656,37 @@ static bool PS2_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_P
 
     gsGlobal = gsKit_init_global_custom(RENDER_QUEUE_OS_POOLSIZE, RENDER_QUEUE_PER_POOLSIZE);
 
-    gsGlobal->Height = 448;
+    // GS interlaced/progressive
+    if (SDL_GetHintBoolean(SDL_HINT_PS2_GS_PROGRESSIVE,0)) {
+        gsGlobal->Interlace = GS_NONINTERLACED;
+    } else {
+        gsGlobal->Interlace = GS_INTERLACED;
+    }
+
+    // GS width/height
+    if (
+        SDL_GetHint(SDL_HINT_PS2_GS_WIDTH) == NULL ||
+        sscanf(SDL_GetHint(SDL_HINT_PS2_GS_WIDTH),"%d",&w) != 1
+    ) { w = 640; }
+
+    if (
+        SDL_GetHint(SDL_HINT_PS2_GS_HEIGHT) == NULL ||
+        sscanf(SDL_GetHint(SDL_HINT_PS2_GS_HEIGHT),"%d",&h) != 1
+    ) { h = 448; }
+
+    gsGlobal->Width = w;
+    gsGlobal->Height = h;
+
+    // GS region
+    if (SDL_GetHint(SDL_HINT_PS2_GS_MODE) != NULL) {
+        if (strcmp(SDL_GetHint(SDL_HINT_PS2_GS_MODE),"NTSC") == 0) {
+            gsGlobal->Mode = GS_MODE_NTSC;
+        }
+
+        if (strcmp(SDL_GetHint(SDL_HINT_PS2_GS_MODE),"PAL") == 0) {
+            gsGlobal->Mode = GS_MODE_PAL;
+        }
+    }
 
     gsGlobal->PSM = GS_PSM_CT24;
     gsGlobal->PSMZ = GS_PSMZ_16S;


### PR DESCRIPTION
I've been wanting to use the lowres 240p mode on PS2 as I like to do software rendering, and the CPU is somewhat weak. These changes allow for that.

## Description
This adds the special hints: `SDL_HINT_PS2_GS_WIDTH`, `SDL_HINT_PS2_GS_HEIGHT`, `SDL_HINT_PS2_GS_PROGRESSIVE`, `SDL_HINT_PS2_GS_MODE`

They allow for the framebuffer width and height to be set, progressive to be turned on/off and to decide which regional format to use for the signal (PAL/NTSC). Furthermore, the region is no longer overridden by default, so the console will use its native region, instead of NTSC.

## Existing Issue(s)
https://github.com/ps2dev/ps2sdk-ports/issues/183
https://github.com/libsdl-org/SDL/pull/13969
