### PR TITLE
Update macOS 10.16 references to macOS 11.0

### DIFF
--- a/src/joystick/apple/SDL_mfijoystick.m
+++ b/src/joystick/apple/SDL_mfijoystick.m
@@ -320,7 +320,7 @@ static bool IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
     NSLog(@"Product name: %@\n", controller.vendorName);
     NSLog(@"Product category: %@\n", controller.productCategory);
     NSLog(@"Elements available:\n");
-    if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+    if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
         NSDictionary<NSString *, GCControllerElement *> *elements = controller.physicalInputProfile.elements;
         for (id key in controller.physicalInputProfile.buttons) {
             NSLog(@"\tButton: %@ (%s)\n", key, elements[key].analog ? "analog" : "digital");
@@ -370,7 +370,7 @@ static bool IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
         return false;
     }
 
-    if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+    if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
         if (controller.physicalInputProfile.buttons[GCInputDualShockTouchpadButton] != nil) {
             device->has_dualshock_touchpad = TRUE;
         }
@@ -425,7 +425,7 @@ static bool IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
     } else if (device->is_switch_joyconR) {
         vendor = USB_VENDOR_NINTENDO;
         product = USB_PRODUCT_NINTENDO_SWITCH_JOYCON_RIGHT;
-    } else if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+    } else if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
         vendor = USB_VENDOR_APPLE;
         product = 4;
         subtype = 4;
@@ -448,7 +448,7 @@ static bool IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
         return false;
     }
 
-    if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+    if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
         NSDictionary<NSString *, GCControllerElement *> *elements = controller.physicalInputProfile.elements;
 
         // Provide both axes and analog buttons as SDL axes
@@ -579,7 +579,7 @@ static bool IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
     }
 
     Uint16 signature;
-    if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+    if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
         signature = 0;
         signature = SDL_crc16(signature, device->name, SDL_strlen(device->name));
         for (id key in device->axes) {
@@ -733,7 +733,7 @@ static bool IOS_JoystickInit(void)
     }
 
 #ifdef SDL_PLATFORM_MACOS
-    if (@available(macOS 10.16, *)) {
+    if (@available(macOS 11.0, *)) {
         // Continue with initialization on macOS 11+
     } else {
         return true;
@@ -895,7 +895,7 @@ static bool IOS_JoystickOpen(SDL_Joystick *joystick, int device_index)
             };
         }
 
-        if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+        if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
             GCController *controller = joystick->hwdata->controller;
             GCMotion *motion = controller.motion;
             if (motion && motion.hasRotationRate) {
@@ -906,7 +906,7 @@ static bool IOS_JoystickOpen(SDL_Joystick *joystick, int device_index)
             }
         }
 
-        if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+        if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
             GCController *controller = joystick->hwdata->controller;
             for (id key in controller.physicalInputProfile.buttons) {
                 GCControllerButtonInput *button = controller.physicalInputProfile.buttons[key];
@@ -916,7 +916,7 @@ static bool IOS_JoystickOpen(SDL_Joystick *joystick, int device_index)
             }
         }
 
-        if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+        if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
             GCController *controller = device->controller;
             if (controller.light) {
                 SDL_SetBooleanProperty(SDL_GetJoystickProperties(joystick), SDL_PROP_JOYSTICK_CAP_RGB_LED_BOOLEAN, true);
@@ -977,7 +977,7 @@ static void IOS_MFIJoystickUpdate(SDL_Joystick *joystick)
         Uint64 timestamp = SDL_GetTicksNS();
 
 #ifdef DEBUG_CONTROLLER_STATE
-        if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+        if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
             if (controller.physicalInputProfile) {
                 for (id key in controller.physicalInputProfile.buttons) {
                     GCControllerButtonInput *button = controller.physicalInputProfile.buttons[key];
@@ -1003,7 +1003,7 @@ static void IOS_MFIJoystickUpdate(SDL_Joystick *joystick)
         }
 #endif // DEBUG_CONTROLLER_STATE
 
-        if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+        if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
             NSDictionary<NSString *, GCControllerElement *> *elements = controller.physicalInputProfile.elements;
             NSDictionary<NSString *, GCControllerButtonInput *> *buttons = controller.physicalInputProfile.buttons;
 
@@ -1133,7 +1133,7 @@ static void IOS_MFIJoystickUpdate(SDL_Joystick *joystick)
             }
         }
 
-        if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+        if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
             if (device->has_dualshock_touchpad) {
                 GCControllerDirectionPad *dpad;
 
@@ -1153,7 +1153,7 @@ static void IOS_MFIJoystickUpdate(SDL_Joystick *joystick)
             }
         }
 
-        if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+        if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
             GCMotion *motion = controller.motion;
             if (motion && motion.sensorsActive) {
                 float data[3];
@@ -1175,7 +1175,7 @@ static void IOS_MFIJoystickUpdate(SDL_Joystick *joystick)
             }
         }
 
-        if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+        if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
             GCDeviceBattery *battery = controller.battery;
             if (battery) {
                 SDL_PowerState state = SDL_POWERSTATE_UNKNOWN;
@@ -1204,8 +1204,8 @@ static void IOS_MFIJoystickUpdate(SDL_Joystick *joystick)
 
 #ifdef SDL_JOYSTICK_MFI
 @interface SDL3_RumbleMotor : NSObject
-@property(nonatomic, strong) CHHapticEngine *engine API_AVAILABLE(macos(10.16), ios(13.0), tvos(14.0));
-@property(nonatomic, strong) id<CHHapticPatternPlayer> player API_AVAILABLE(macos(10.16), ios(13.0), tvos(14.0));
+@property(nonatomic, strong) CHHapticEngine *engine API_AVAILABLE(macos(11.0), ios(13.0), tvos(14.0));
+@property(nonatomic, strong) id<CHHapticPatternPlayer> player API_AVAILABLE(macos(11.0), ios(13.0), tvos(14.0));
 @property bool active;
 @end
 
@@ -1216,7 +1216,7 @@ static void IOS_MFIJoystickUpdate(SDL_Joystick *joystick)
 - (void)cleanup
 {
     @autoreleasepool {
-        if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+        if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
             if (self.player != nil) {
                 [self.player cancelAndReturnError:nil];
                 self.player = nil;
@@ -1232,7 +1232,7 @@ static void IOS_MFIJoystickUpdate(SDL_Joystick *joystick)
 - (bool)setIntensity:(float)intensity
 {
     @autoreleasepool {
-        if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+        if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
             NSError *error = nil;
             CHHapticDynamicParameter *param;
 
@@ -1279,7 +1279,7 @@ static void IOS_MFIJoystickUpdate(SDL_Joystick *joystick)
     }
 }
 
-- (id)initWithController:(GCController *)controller locality:(GCHapticsLocality)locality API_AVAILABLE(macos(10.16), ios(14.0), tvos(14.0))
+- (id)initWithController:(GCController *)controller locality:(GCHapticsLocality)locality API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0))
 {
     @autoreleasepool {
         NSError *error;
@@ -1381,7 +1381,7 @@ static void IOS_MFIJoystickUpdate(SDL_Joystick *joystick)
 static SDL3_RumbleContext *IOS_JoystickInitRumble(GCController *controller)
 {
     @autoreleasepool {
-        if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+        if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
             SDL3_RumbleMotor *low_frequency_motor = [[SDL3_RumbleMotor alloc] initWithController:controller locality:GCHapticsLocalityLeftHandle];
             SDL3_RumbleMotor *high_frequency_motor = [[SDL3_RumbleMotor alloc] initWithController:controller locality:GCHapticsLocalityRightHandle];
             SDL3_RumbleMotor *left_trigger_motor = [[SDL3_RumbleMotor alloc] initWithController:controller locality:GCHapticsLocalityLeftTrigger];
@@ -1408,7 +1408,7 @@ static bool IOS_JoystickRumble(SDL_Joystick *joystick, Uint16 low_frequency_rumb
         return SDL_SetError("Controller is no longer connected");
     }
 
-    if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+    if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
         if (!device->rumble && device->controller && device->controller.haptics) {
             SDL3_RumbleContext *rumble = IOS_JoystickInitRumble(device->controller);
             if (rumble) {
@@ -1434,7 +1434,7 @@ static bool IOS_JoystickRumbleTriggers(SDL_Joystick *joystick, Uint16 left_rumbl
         return SDL_SetError("Controller is no longer connected");
     }
 
-    if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+    if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
         if (!device->rumble && device->controller && device->controller.haptics) {
             SDL3_RumbleContext *rumble = IOS_JoystickInitRumble(device->controller);
             if (rumble) {
@@ -1460,7 +1460,7 @@ static bool IOS_JoystickSetLED(SDL_Joystick *joystick, Uint8 red, Uint8 green, U
             return SDL_SetError("Controller is no longer connected");
         }
 
-        if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+        if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
             GCController *controller = device->controller;
             GCDeviceLight *light = controller.light;
             if (light) {
@@ -1488,7 +1488,7 @@ static bool IOS_JoystickSetSensorsEnabled(SDL_Joystick *joystick, bool enabled)
             return SDL_SetError("Controller is no longer connected");
         }
 
-        if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+        if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
             GCController *controller = device->controller;
             GCMotion *motion = controller.motion;
             if (motion) {
@@ -1539,7 +1539,7 @@ static void IOS_JoystickClose(SDL_Joystick *joystick)
             controller.controllerPausedHandler = nil;
             controller.playerIndex = -1;
 
-            if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+            if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
                 for (id key in controller.physicalInputProfile.buttons) {
                     GCControllerButtonInput *button = controller.physicalInputProfile.buttons[key];
                     if ([button isBoundToSystemGesture]) {
@@ -1593,7 +1593,7 @@ static bool IOS_JoystickGetGamepadMapping(int device_index, SDL_GamepadMapping *
         return false;
     }
 
-    if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+    if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
         int axis = 0;
         for (id key in device->axes) {
             if ([(NSString *)key isEqualToString:@"Left Thumbstick X Axis"] ||
@@ -1730,7 +1730,7 @@ bool IOS_SupportedHIDDevice(IOHIDDeviceRef device)
         return false;
     }
 
-    if (@available(macOS 10.16, *)) {
+    if (@available(macOS 11.0, *)) {
         const int MAX_ATTEMPTS = 3;
         for (int attempt = 0; attempt < MAX_ATTEMPTS; ++attempt) {
             if ([GCController supportsHIDDevice:device]) {
@@ -1749,7 +1749,7 @@ bool IOS_SupportedHIDDevice(IOHIDDeviceRef device)
 /* NOLINTNEXTLINE(readability-non-const-parameter): getCString takes a non-const char* */
 static void GetAppleSFSymbolsNameForElement(GCControllerElement *element, char *name)
 {
-    if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+    if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
         if (element) {
             [element.sfSymbolsName getCString:name maxLength:255 encoding:NSASCIIStringEncoding];
         }
@@ -1758,7 +1758,7 @@ static void GetAppleSFSymbolsNameForElement(GCControllerElement *element, char *
 
 static GCControllerDirectionPad *GetDirectionalPadForController(GCController *controller)
 {
-    if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+    if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
         return controller.physicalInputProfile.dpads[GCInputDirectionPad];
     }
 
@@ -1781,7 +1781,7 @@ const char *IOS_GetAppleSFSymbolsNameForButton(SDL_Gamepad *gamepad, SDL_Gamepad
 
 #ifdef SDL_JOYSTICK_MFI
     if (gamepad && SDL_GetGamepadJoystick(gamepad)->driver == &SDL_IOS_JoystickDriver) {
-        if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+        if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
             GCController *controller = SDL_GetGamepadJoystick(gamepad)->hwdata->controller;
             NSDictionary<NSString *, GCControllerElement *> *elements = controller.physicalInputProfile.elements;
             switch (button) {
@@ -1897,7 +1897,7 @@ const char *IOS_GetAppleSFSymbolsNameForAxis(SDL_Gamepad *gamepad, SDL_GamepadAx
 
 #ifdef SDL_JOYSTICK_MFI
     if (gamepad && SDL_GetGamepadJoystick(gamepad)->driver == &SDL_IOS_JoystickDriver) {
-        if (@available(macOS 10.16, iOS 14.0, tvOS 14.0, *)) {
+        if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {
             GCController *controller = SDL_GetGamepadJoystick(gamepad)->hwdata->controller;
             NSDictionary<NSString *, GCControllerElement *> *elements = controller.physicalInputProfile.elements;
             switch (axis) {


### PR DESCRIPTION
Fixes api availability compiler warnings when building the joystick subsystem for macOS versions older than 11.0. The compiler expects the version number passed into @available and API_AVAILABLE macros to be greater than or equal to 11.0, which 10.16 is not. (Even though 10.16 and 11.0 are semantically equivalent, the compiler doesn't know this.)

## Description
- Simply text-replace "10.16" with "11.0" in the joystick submodule. (Coincidentally the only remaining place in SDL3 matching that string.)

## Existing Issue(s)
- None
