### PR TITLE
Android: fix 'JVM object referenced by 'context' is of type 'Context' and it d…

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDL.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDL.java
@@ -28,12 +28,12 @@ public class SDL {
     }
 
     // This function stores the current activity (SDL or not)
-    static public void setContext(Context context) {
+    static public void setContext(SDLActivity context) {
         SDLAudioManager.setContext(context);
         mContext = context;
     }
 
-    static public Context getContext() {
+    static public SDLActivity getContext() {
         return mContext;
     }
 
@@ -86,5 +86,5 @@ public class SDL {
         }
     }
 
-    protected static Context mContext;
+    protected static SDLActivity mContext;
 }

--- a/android-project/app/src/main/java/org/libsdl/app/SDL.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDL.java
@@ -1,8 +1,8 @@
 package org.libsdl.app;
 
+import android.app.Activity;
 import android.content.Context;
 
-import java.lang.Class;
 import java.lang.reflect.Method;
 
 /**
@@ -28,12 +28,12 @@ public class SDL {
     }
 
     // This function stores the current activity (SDL or not)
-    static public void setContext(SDLActivity context) {
+    static public void setContext(Activity context) {
         SDLAudioManager.setContext(context);
         mContext = context;
     }
 
-    static public SDLActivity getContext() {
+    static public Activity getContext() {
         return mContext;
     }
 
@@ -86,5 +86,5 @@ public class SDL {
         }
     }
 
-    protected static SDLActivity mContext;
+    protected static Activity mContext;
 }

--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -1262,7 +1262,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     /**
      * This method is called by SDL using JNI.
      */
-    public static Context getContext() {
+    public static SDLActivity getContext() {
         return SDL.getContext();
     }
 

--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -1262,7 +1262,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     /**
      * This method is called by SDL using JNI.
      */
-    public static SDLActivity getContext() {
+    public static Activity getContext() {
         return SDL.getContext();
     }
 

--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -635,7 +635,7 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(nativeSetupJNI)(JNIEnv *env, jclass cl
     midClipboardSetText = (*env)->GetStaticMethodID(env, mActivityClass, "clipboardSetText", "(Ljava/lang/String;)V");
     midCreateCustomCursor = (*env)->GetStaticMethodID(env, mActivityClass, "createCustomCursor", "([IIIII)I");
     midDestroyCustomCursor = (*env)->GetStaticMethodID(env, mActivityClass, "destroyCustomCursor", "(I)V");
-    midGetContext = (*env)->GetStaticMethodID(env, mActivityClass, "getContext", "()Lorg/libsdl/app/SDLActivity;");
+    midGetContext = (*env)->GetStaticMethodID(env, mActivityClass, "getContext", "()Landroid/app/Activity;");
     midGetManifestEnvironmentVariables = (*env)->GetStaticMethodID(env, mActivityClass, "getManifestEnvironmentVariables", "()Z");
     midGetNativeSurface = (*env)->GetStaticMethodID(env, mActivityClass, "getNativeSurface", "()Landroid/view/Surface;");
     midInitTouch = (*env)->GetStaticMethodID(env, mActivityClass, "initTouch", "()V");

--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -635,7 +635,7 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(nativeSetupJNI)(JNIEnv *env, jclass cl
     midClipboardSetText = (*env)->GetStaticMethodID(env, mActivityClass, "clipboardSetText", "(Ljava/lang/String;)V");
     midCreateCustomCursor = (*env)->GetStaticMethodID(env, mActivityClass, "createCustomCursor", "([IIIII)I");
     midDestroyCustomCursor = (*env)->GetStaticMethodID(env, mActivityClass, "destroyCustomCursor", "(I)V");
-    midGetContext = (*env)->GetStaticMethodID(env, mActivityClass, "getContext", "()Landroid/content/Context;");
+    midGetContext = (*env)->GetStaticMethodID(env, mActivityClass, "getContext", "()Lorg/libsdl/app/SDLActivity;");
     midGetManifestEnvironmentVariables = (*env)->GetStaticMethodID(env, mActivityClass, "getManifestEnvironmentVariables", "()Z");
     midGetNativeSurface = (*env)->GetStaticMethodID(env, mActivityClass, "getNativeSurface", "()Landroid/view/Surface;");
     midInitTouch = (*env)->GetStaticMethodID(env, mActivityClass, "initTouch", "()V");


### PR DESCRIPTION
…oes not have access to method 'registerReceiver(BroadcastReceiver, IntentFilter)' declared in class 'ContextWrapper'.'


This replaces `Context` with `SDLActivity` and fixes the error in the screenshot from Android Studio.


<img width="2632" height="248" alt="Screenshot 2025-09-22 at 8 44 57 AM" src="https://github.com/user-attachments/assets/d4a1b535-e169-4620-8842-7d6e8e1b6911" />


This may not be the preferred fix, but it is what I would do.
