### PR TITLE
Android: fix 'SDL_MessageBoxFlags' is not a valid JVM type.

### DIFF
--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -2227,7 +2227,7 @@ bool Android_JNI_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *b
     mid = (*env)->GetMethodID(env, clazz,
                               "messageboxShowMessageBox", "(ILjava/lang/String;Ljava/lang/String;[I[I[Ljava/lang/String;[I)I");
     *buttonID = (*env)->CallIntMethod(env, context, mid,
-                                      messageboxdata->flags,
+                                      (jint)messageboxdata->flags,
                                       title,
                                       message,
                                       button_flags,


### PR DESCRIPTION
<img width="2254" height="520" alt="Screenshot 2025-09-22 at 8 53 43 AM" src="https://github.com/user-attachments/assets/26f18cf5-02fc-47fe-8d7b-9eb49b173af0" />
