### PR TITLE
Android: fix: Extra parameter(s) for call to 'getCacheDir()'.

### DIFF
--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -2481,7 +2481,7 @@ const char *SDL_GetAndroidCachePath(void)
         // fileObj = context.getExternalFilesDir();
         mid = (*env)->GetMethodID(env, (*env)->GetObjectClass(env, context),
                                   "getCacheDir", "()Ljava/io/File;");
-        fileObject = (*env)->CallObjectMethod(env, context, mid, NULL);
+        fileObject = (*env)->CallObjectMethod(env, context, mid);
         if (!fileObject) {
             SDL_SetError("Couldn't get cache directory");
             LocalReferenceHolder_Cleanup(&refs);


### PR DESCRIPTION

<img width="2378" height="830" alt="Screenshot 2025-09-22 at 8 55 37 AM" src="https://github.com/user-attachments/assets/f1f6122b-eaad-49f0-bc82-6e0f9072cbd8" />
