### PR TITLE
Link to GameController on Apple platforms when using UIKit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2605,6 +2605,7 @@ elseif(APPLE)
       set(SDL_FRAMEWORK_UIKIT 1)
       set(SDL_IPHONE_KEYBOARD 1)
       set(SDL_IPHONE_LAUNCHSCREEN 1)
+      set(SDL_FRAMEWORK_GAMECONTROLLER 1)
       sdl_glob_sources(
         "${SDL3_SOURCE_DIR}/src/video/uikit/*.m"
         "${SDL3_SOURCE_DIR}/src/video/uikit/*.h"


### PR DESCRIPTION
## Description
Currently GameController framework is linked only when `SDL_JOYSTICK = ON`. However `SDL_uikitevents.m` uses multiple symbols from GameController (eg `GCKeyboardDidConnectNotification`) so the build fails when joystick support is disabled.