### PR TITLE
Update proguard-rules.pro

### DIFF
--- a/android-project/app/proguard-rules.pro
+++ b/android-project/app/proguard-rules.pro
@@ -23,7 +23,7 @@
     void clipboardSetText(java.lang.String);
     int createCustomCursor(int[], int, int, int, int);
     void destroyCustomCursor(int);
-    android.content.Context getContext();
+    android.app.Activity getContext();
     boolean getManifestEnvironmentVariables();
     android.view.Surface getNativeSurface();
     void initTouch();


### PR DESCRIPTION
getContext() now returns an Activity. getContext() is automatically kept safe anyway due to being seen to be used from Java-side, but it's best to keep this future-proof and consistent. 
