### PR TITLE
X11TK: Add hint for prefering the toolkit over Zenity

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -3922,6 +3922,20 @@ extern "C" {
 #define SDL_HINT_VIDEO_X11_XRANDR "SDL_VIDEO_X11_XRANDR"
 
 /**
+ * A variable controlling whether the X11 built in toolkit is prefered over Zenity.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "0": Use Zenity if available.  (default)
+ * - "1": Always use the toolkit over Zenity.
+ *
+ * This hint should be set before a messagebox is created.
+ *
+ * \since This hint is available since SDL 3.4.0.
+ */
+#define SDL_HINT_VIDEO_X11_PREFER_TOOLKIT "SDL_VIDEO_X11_PREFER_TOOLKIT"
+
+/**
  * A variable controlling whether touch should be enabled on the back panel of
  * the PlayStation Vita.
  *

--- a/src/video/x11/SDL_x11messagebox.c
+++ b/src/video/x11/SDL_x11messagebox.c
@@ -235,10 +235,12 @@ static bool X11_ShowMessageBoxImpl(const SDL_MessageBoxData *messageboxdata, int
 // Display an x11 message box.
 bool X11_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonID)
 {
-    if (SDL_Zenity_ShowMessageBox(messageboxdata, buttonID)) {
-        return true;
+    if (!SDL_GetHintBoolean(SDL_HINT_VIDEO_X11_PREFER_TOOLKIT, false)) {
+        if (SDL_Zenity_ShowMessageBox(messageboxdata, buttonID)) {
+            return true;
+        }
     }
-
+    
 #if SDL_FORK_MESSAGEBOX
     // Use a child process to protect against setlocale(). Annoying.
     pid_t pid;


### PR DESCRIPTION
This PR adds a hint for prefering the toolkit over Zenity
