### PR TITLE
X11TK: Remove text positioning hacks, use proper ascent values.

### DIFF
--- a/src/video/x11/SDL_x11messagebox.c
+++ b/src/video/x11/SDL_x11messagebox.c
@@ -235,10 +235,10 @@ static bool X11_ShowMessageBoxImpl(const SDL_MessageBoxData *messageboxdata, int
 // Display an x11 message box.
 bool X11_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonID)
 {
-  /*  if (SDL_Zenity_ShowMessageBox(messageboxdata, buttonID)) {
+    if (SDL_Zenity_ShowMessageBox(messageboxdata, buttonID)) {
         return true;
     }
-*/
+
 #if SDL_FORK_MESSAGEBOX
     // Use a child process to protect against setlocale(). Annoying.
     pid_t pid;

--- a/src/video/x11/SDL_x11messagebox.c
+++ b/src/video/x11/SDL_x11messagebox.c
@@ -235,10 +235,10 @@ static bool X11_ShowMessageBoxImpl(const SDL_MessageBoxData *messageboxdata, int
 // Display an x11 message box.
 bool X11_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonID)
 {
-    if (SDL_Zenity_ShowMessageBox(messageboxdata, buttonID)) {
+  /*  if (SDL_Zenity_ShowMessageBox(messageboxdata, buttonID)) {
         return true;
     }
-
+*/
 #if SDL_FORK_MESSAGEBOX
     // Use a child process to protect against setlocale(). Annoying.
     pid_t pid;

--- a/src/video/x11/SDL_x11toolkit.c
+++ b/src/video/x11/SDL_x11toolkit.c
@@ -115,7 +115,7 @@ static const char g_ToolkitFontLatin1Fallback[] =
     "-*-*-*-*-*--*-*-*-*-*-*-iso8859-1";    
     
 static const char *g_ToolkitFont[] = {
-    "-*-*-medium-r-normal--*-%d-*-*-*-*-iso10646-1",  // explicitly unicode (iso10646-1)
+    "-sony-*-medium-r-normal--*-%d-*-*-*-*-iso10646-1",  // explicitly unicode (iso10646-1)
     "-*-*-medium-r-*--*-%d-*-*-*-*-iso10646-1",  // explicitly unicode (iso10646-1)
     "-misc-*-*-*-*--*-*-*-*-*-*-iso10646-1",  // misc unicode (fix for some systems)
     "-*-*-*-*-*--*-*-*-*-*-*-iso10646-1",  // just give me anything Unicode.

--- a/src/video/x11/SDL_x11toolkit.c
+++ b/src/video/x11/SDL_x11toolkit.c
@@ -477,7 +477,7 @@ static void X11Toolkit_SettingsNotify(const char *name, XSettingsAction action, 
 
         /* notify controls */
         for (i = 0; i < window->controls_sz; i++) {
-            window->controls[i]->skip_size = false;
+            window->controls[i]->do_size = true;
             
             if (window->controls[i]->func_on_scale_change) {
                 window->controls[i]->func_on_scale_change(window->controls[i]);
@@ -487,7 +487,7 @@ static void X11Toolkit_SettingsNotify(const char *name, XSettingsAction action, 
                 window->controls[i]->func_calc_size(window->controls[i]);
             }
             
-            window->controls[i]->skip_size = true;
+            window->controls[i]->do_size = false;
         }
 
         /* notify cb */
@@ -1574,7 +1574,7 @@ static void X11Toolkit_CalculateButtonControl(SDL_ToolkitControlX11 *control) {
 
     button_control = (SDL_ToolkitButtonControlX11 *)control;
     X11Toolkit_GetTextWidthHeight(control->window, button_control->data->text, button_control->str_sz, &button_control->text_rect.w, &button_control->text_rect.h, &button_control->text_a, &text_d);
-    if (!control->skip_size) {
+    if (control->do_size) {
         control->rect.w = SDL_TOOLKIT_X11_ELEMENT_PADDING_3 * 2 * control->window->iscale + button_control->text_rect.w;
         control->rect.h = SDL_TOOLKIT_X11_ELEMENT_PADDING_3 * 2 * control->window->iscale + button_control->text_rect.h;
     }
@@ -1727,7 +1727,7 @@ SDL_ToolkitControlX11 *X11Toolkit_CreateButtonControl(SDL_ToolkitWindowX11 *wind
         base_control->is_default_enter = true;  
         base_control->selected = true;
     }
-    base_control->skip_size = true;
+    base_control->do_size = false;
     control->data = data;
     control->str_sz = SDL_strlen(control->data->text);
     control->cb = NULL;

--- a/src/video/x11/SDL_x11toolkit.c
+++ b/src/video/x11/SDL_x11toolkit.c
@@ -115,7 +115,7 @@ static const char g_ToolkitFontLatin1Fallback[] =
     "-*-*-*-*-*--*-*-*-*-*-*-iso8859-1";    
     
 static const char *g_ToolkitFont[] = {
-    "-sony-*-medium-r-normal--*-%d-*-*-*-*-iso10646-1",  // explicitly unicode (iso10646-1)
+    "-*-*-medium-r-normal--*-%d-*-*-*-*-iso10646-1",  // explicitly unicode (iso10646-1)
     "-*-*-medium-r-*--*-%d-*-*-*-*-iso10646-1",  // explicitly unicode (iso10646-1)
     "-misc-*-*-*-*--*-*-*-*-*-*-iso10646-1",  // misc unicode (fix for some systems)
     "-*-*-*-*-*--*-*-*-*-*-*-iso10646-1",  // just give me anything Unicode.

--- a/src/video/x11/SDL_x11toolkit.c
+++ b/src/video/x11/SDL_x11toolkit.c
@@ -505,7 +505,6 @@ static void X11Toolkit_SettingsNotify(const char *name, XSettingsAction action, 
     }
 }
 
-
 static void X11Toolkit_GetTextWidthHeightForFont(XFontStruct *font, const char *str, int nbytes, int *pwidth, int *pheight, int *ascent)
 {
     XCharStruct text_structure;

--- a/src/video/x11/SDL_x11toolkit.h
+++ b/src/video/x11/SDL_x11toolkit.h
@@ -175,7 +175,8 @@ typedef struct SDL_ToolkitControlX11
     bool dynamic;
     bool is_default_enter;
     bool is_default_esc;
-
+	bool skip_size;
+	
     /* User data */
     void *data;
 

--- a/src/video/x11/SDL_x11toolkit.h
+++ b/src/video/x11/SDL_x11toolkit.h
@@ -175,7 +175,7 @@ typedef struct SDL_ToolkitControlX11
     bool dynamic;
     bool is_default_enter;
     bool is_default_esc;
-	bool skip_size;
+	bool do_size;
 	
     /* User data */
     void *data;


### PR DESCRIPTION
This removes multiple text positoning hacks, this should fix the positoning errors on many fonts.