### PR TITLE
MacOS: Added hint to control update of the metal layer's drawable size

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -3595,6 +3595,22 @@ extern "C" {
 #define SDL_HINT_VIDEO_MAC_FULLSCREEN_MENU_VISIBILITY "SDL_VIDEO_MAC_FULLSCREEN_MENU_VISIBILITY"
 
 /**
+ * A variable indicating whether the metal layer drawable size should be
+ * updated for the SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED event on macOS.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "0": metal view event watcher is disabled, the drawable size of the metal view
+ *   will not be updated for the SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED event.
+ * - "1": metal view event watcher is enabled, the drawable size of the metal view
+ *   will be updated for the SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED event. (default)
+ *
+ * This hint should be set before SDL_Metal_CreateView called.
+ *
+ * \since This hint is available since SDL 3.4.0. */
+#define SDL_HINT_VIDEO_MAC_ENABLE_METAL_VIEW_WATCHER "SDL_VIDEO_MAC_ENABLE_METAL_VIEW_WATCHER"
+
+/**
  * A variable controlling whether SDL will attempt to automatically set the
  * destination display to a mode most closely matching that of the previous
  * display if an exclusive fullscreen window is moved onto it.

--- a/src/video/cocoa/SDL_cocoametalview.m
+++ b/src/video/cocoa/SDL_cocoametalview.m
@@ -90,7 +90,9 @@ static bool SDLCALL SDL_MetalViewEventWatch(void *userdata, SDL_Event *event)
 
         self.layer.opaque = opaque;
 
-        SDL_AddWindowEventWatch(SDL_WINDOW_EVENT_WATCH_EARLY, SDL_MetalViewEventWatch, (__bridge void *)(self));
+        if (SDL_GetHintBoolean(SDL_HINT_VIDEO_MAC_ENABLE_METAL_VIEW_WATCHER, true)) {
+            SDL_AddWindowEventWatch(SDL_WINDOW_EVENT_WATCH_EARLY, SDL_MetalViewEventWatch, (__bridge void *)(self));
+        }
 
         [self updateDrawableSize];
     }
@@ -100,7 +102,9 @@ static bool SDLCALL SDL_MetalViewEventWatch(void *userdata, SDL_Event *event)
 
 - (void)dealloc
 {
-    SDL_RemoveWindowEventWatch(SDL_WINDOW_EVENT_WATCH_EARLY, SDL_MetalViewEventWatch, (__bridge void *)(self));
+    if (SDL_GetHintBoolean(SDL_HINT_VIDEO_MAC_ENABLE_METAL_VIEW_WATCHER, true)) {
+        SDL_RemoveWindowEventWatch(SDL_WINDOW_EVENT_WATCH_EARLY, SDL_MetalViewEventWatch, (__bridge void *)(self));
+    }
 }
 
 - (NSInteger)tag


### PR DESCRIPTION
## Motivation
This PR adds a hint to control the metal layer drawable size update.

In the codebase I'm working on, metal layer creation is performed using SDL_Metal_CreateView on the main thread. A custom renderer (not SDL) runs on a dedicated thread, and this thread is responsible for metal layer drawable size update. When resizing the window and enabled Metal API validation, I receive the following assertion:
```-[MTLDebugRenderCommandEncoder setScissorRect:]:4053: failed assertion Set Scissor Rect Validation```

To avoid this assertion, I need to disable drawable size updates on the main thread and update them on the render thread. To achieve this behaviour, I propose this hint.

As far as I understand, you previously received the same assertion [link](https://github.com/libsdl-org/SDL/commit/f8bdefe1b56afecbec45da1dfa8d3b5e4f2bd512).
