### PR TITLE
ci: build testffmpeg on MinGW (msys2) build bots

### DIFF
--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -30,6 +30,7 @@ jobs:
           install: >-
             ${{ matrix.platform.msys2-env }}-cc
             ${{ matrix.platform.msys2-env }}-cmake
+            ${{ matrix.platform.msys2-env }}-ffmpeg
             ${{ matrix.platform.msys2-env }}-ninja
             ${{ (!matrix.platform.msys2-no-perl && format('{0}-perl', matrix.platform.msys2-env)) || '' }}
             ${{ matrix.platform.msys2-env }}-pkg-config

--- a/cmake/PkgConfigHelper.cmake
+++ b/cmake/PkgConfigHelper.cmake
@@ -1,16 +1,16 @@
 # Helper for Find modules
 
 function(get_flags_from_pkg_config _library _pc_prefix _out_prefix)
-  if("${_library}" MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$")
-    set(_cflags ${_pc_prefix}_STATIC_CFLAGS_OTHER)
-    set(_link_libraries ${_pc_prefix}_STATIC_LIBRARIES)
-    set(_link_options ${_pc_prefix}_STATIC_LDFLAGS_OTHER)
-    set(_library_dirs ${_pc_prefix}_STATIC_LIBRARY_DIRS)
-  else()
+  if(NOT "${_library}" MATCHES "${CMAKE_SHARED_LIBRARY_SUFFIX}$")
     set(_cflags ${_pc_prefix}_CFLAGS_OTHER)
     set(_link_libraries ${_pc_prefix}_LIBRARIES)
     set(_link_options ${_pc_prefix}_LDFLAGS_OTHER)
     set(_library_dirs ${_pc_prefix}_LIBRARY_DIRS)
+  else()
+    set(_cflags ${_pc_prefix}_STATIC_CFLAGS_OTHER)
+    set(_link_libraries ${_pc_prefix}_STATIC_LIBRARIES)
+    set(_link_options ${_pc_prefix}_STATIC_LDFLAGS_OTHER)
+    set(_library_dirs ${_pc_prefix}_STATIC_LIBRARY_DIRS)
   endif()
 
   # The *_LIBRARIES lists always start with the library itself

--- a/test/testffmpeg.c
+++ b/test/testffmpeg.c
@@ -93,7 +93,6 @@ static PFNGLEGLIMAGETARGETTEXTURE2DOESPROC glEGLImageTargetTexture2DOESFunc;
 #ifdef SDL_PLATFORM_WIN32
 static ID3D11Device *d3d11_device;
 static ID3D11DeviceContext *d3d11_context;
-static const GUID SDL_IID_ID3D11Resource = { 0xdc8e63f3, 0xd12b, 0x4952, { 0xb4, 0x7b, 0x5e, 0x45, 0x02, 0x6a, 0x86, 0x2d } };
 #endif
 static VulkanVideoContext *vulkan_context;
 struct SwsContextContainer


### PR DESCRIPTION
This fixes:
- unused static variable warning (`SDL_IID_ID3D11Resource` is unused)
- `.a` static suffix is also present in `.dll.a` mingw import libraries
- testffmpeg not being tested on msys2 ci


## Description

## Existing Issue(s)
