### PR TITLE
x11: Check for a valid input context before destroying it

### DIFF
--- a/src/video/x11/SDL_x11keyboard.c
+++ b/src/video/x11/SDL_x11keyboard.c
@@ -770,7 +770,10 @@ void X11_CreateInputContext(SDL_WindowData *data)
 void X11_DestroyInputContext(SDL_WindowData *data)
 {
 #ifdef X_HAVE_UTF8_STRING
-    X11_XDestroyIC(data->ic);
+    if (data->ic) {
+        X11_XDestroyIC(data->ic);
+        data->ic = NULL;
+    }
     SDL_free(data->preedit_text);
     SDL_free(data->preedit_feedback);
     data->preedit_text = NULL;


### PR DESCRIPTION
XDestroyIC crashes if passed a null parameter.

Fixes #14089
Fixes #14076
