### PR TITLE
Zero-initialize SDL_GPUDevice

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -11914,7 +11914,7 @@ static SDL_GPUDevice *VULKAN_CreateDevice(bool debugMode, bool preferLowPower, S
     }
 
     // FIXME: just move this into this function
-    result = (SDL_GPUDevice *)SDL_malloc(sizeof(SDL_GPUDevice));
+    result = (SDL_GPUDevice *)SDL_calloc(1, sizeof(SDL_GPUDevice));
     ASSIGN_DRIVER(VULKAN)
 
     result->driverData = (SDL_GPURenderer *)renderer;


### PR DESCRIPTION
## Description
`SDL_CreateGPUDeviceWithProperties()` does not always initialize some members. For example, `validate_feature_anisotropy_disabled` is not initialized if property `SDL_PROP_GPU_DEVICE_CREATE_FEATURE_ANISOTROPY_BOOLEAN` is true (default value). This causes some validation to trigger incorrectly at random.

D3D12 and Metal already create the `SDL_GPUDevice` with `calloc`. Make Vulkan do the same.

## Existing Issue(s)
None
