### PR TITLE
emscripten: Another attempt at optionally having the canvas use whole window.

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -755,6 +755,28 @@ extern "C" {
 #define SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT "SDL_EMSCRIPTEN_KEYBOARD_ELEMENT"
 
 /**
+ * Dictate that newly-created windows will fill the whole browser window.
+ *
+ * The canvas element fills the entire document. Resize events will be
+ * generated as the browser window is resized, as that will adjust the canvas
+ * size as well. The canvas will cover anything else on the page, including
+ * any controls provided by Emscripten in its generated HTML file. Often times
+ * this is desirable for a browser-based game, but it means several things that
+ * we expect of an SDL window on other platforms might not work as expected,
+ * such as minimum window sizes and aspect ratios.
+ *
+ * This hint overrides SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_FILL_DOCUMENT_BOOLEAN
+ * properties when creating an SDL window.
+ *
+ * This hint only applies to the emscripten platform.
+ *
+ * This hint should be set before creating a window.
+ *
+ * \since This hint is available since SDL 3.4.0.
+ */
+#define SDL_HINT_EMSCRIPTEN_FILL_DOCUMENT "SDL_EMSCRIPTEN_FILL_DOCUMENT"
+
+/**
  * A variable that controls whether the on-screen keyboard should be shown
  * when text input is active.
  *

--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -1337,6 +1337,15 @@ extern SDL_DECLSPEC SDL_Window * SDLCALL SDL_CreatePopupWindow(SDL_Window *paren
  *
  * - `SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID_STRING`: the id given to the
  *   canvas element. This should start with a '#' sign
+ * - `SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_FILL_DOCUMENT_BOOLEAN`: true to make
+ *   the canvas element fill the entire document. Resize events will be
+ *   generated as the browser window is resized, as that will adjust the
+ *   canvas size as well. The canvas will cover anything else on the page,
+ *   including any controls provided by Emscripten in its generated HTML
+ *   file. Often times this is desirable for a browser-based game, but it
+ *   means several things that we expect of an SDL window on other platforms
+ *   might not work as expected, such as minimum window sizes and aspect
+ *   ratios. Default false.
  * - `SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_KEYBOARD_ELEMENT_STRING`: override the
  *   binding element for keyboard inputs for this canvas. The variable can be
  *   one of:
@@ -1410,6 +1419,7 @@ extern SDL_DECLSPEC SDL_Window * SDLCALL SDL_CreateWindowWithProperties(SDL_Prop
 #define SDL_PROP_WINDOW_CREATE_WIN32_PIXEL_FORMAT_HWND_POINTER     "SDL.window.create.win32.pixel_format_hwnd"
 #define SDL_PROP_WINDOW_CREATE_X11_WINDOW_NUMBER                   "SDL.window.create.x11.window"
 #define SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_CANVAS_ID_STRING         "SDL.window.create.emscripten.canvas_id"
+#define SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_FILL_DOCUMENT_BOOLEAN    "SDL.window.create.emscripten.fill_document"
 #define SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_KEYBOARD_ELEMENT_STRING  "SDL.window.create.emscripten.keyboard_element"
 
 /**
@@ -1579,6 +1589,9 @@ extern SDL_DECLSPEC SDL_Window * SDLCALL SDL_GetWindowParent(SDL_Window *window)
  *
  * - `SDL_PROP_WINDOW_EMSCRIPTEN_CANVAS_ID_STRING`: the id the canvas element
  *   will have
+ * - `SDL_PROP_WINDOW_EMSCRIPTEN_FILL_DOCUMENT_BOOLEAN`: true if the
+ *   canvas is set to consume the entire browser window, bypassing some SDL
+ *   window functionality.
  * - `SDL_PROP_WINDOW_EMSCRIPTEN_KEYBOARD_ELEMENT_STRING`: the keyboard
  *   element that associates keyboard events to this window
  *
@@ -1628,6 +1641,7 @@ extern SDL_DECLSPEC SDL_PropertiesID SDLCALL SDL_GetWindowProperties(SDL_Window 
 #define SDL_PROP_WINDOW_X11_SCREEN_NUMBER                           "SDL.window.x11.screen"
 #define SDL_PROP_WINDOW_X11_WINDOW_NUMBER                           "SDL.window.x11.window"
 #define SDL_PROP_WINDOW_EMSCRIPTEN_CANVAS_ID_STRING                 "SDL.window.emscripten.canvas_id"
+#define SDL_PROP_WINDOW_EMSCRIPTEN_FILL_DOCUMENT_BOOLEAN            "SDL.window.emscripten.fill_document"
 #define SDL_PROP_WINDOW_EMSCRIPTEN_KEYBOARD_ELEMENT_STRING          "SDL.window.emscripten.keyboard_element"
 
 /**

--- a/src/video/emscripten/SDL_emscriptenvideo.h
+++ b/src/video/emscripten/SDL_emscriptenvideo.h
@@ -38,6 +38,8 @@ struct SDL_WindowData
     char *canvas_id;
     char *keyboard_element;
 
+    bool fill_document;
+
     float pixel_ratio;
 
     bool external_size;


### PR DESCRIPTION

Same idea as before, but this has moved to an Emscripten-specific window property and override hint.

Normal testsprite:

<img width="1511" height="1493" alt="image" src="https://github.com/user-attachments/assets/eedc0944-970a-4f33-ae00-219ab848d0b5" />

testsprite turning on the FILL_DOCUMENT setting:

<img width="1511" height="1493" alt="image" src="https://github.com/user-attachments/assets/ab1d8aae-4269-4bdc-a685-18ccce684906" />

This takes extra steps to put everything in the DOM except the canvas into a hidden div, so nothing is seen rendering when the window resizes and there's no risk of scrollbars popping up if the document would overflow window size due to the elements behind the canvas:

<img width="1357" height="338" alt="image" src="https://github.com/user-attachments/assets/a502a324-be64-45df-a93d-fff6785f8777" />

...everything gets put back when destroying the window:

<img width="941" height="539" alt="image" src="https://github.com/user-attachments/assets/40b94b2d-2cba-45cd-b3da-bf819453af15" />

This still needs to be tested with HighDPI on Windows, as that was an issue mentioned in the original issue, so this is a Draft PR for now.

Fixes #11949.
