### PR TITLE
Add workaround to fix #14067

### DIFF
--- a/src/joystick/windows/SDL_windowsjoystick.c
+++ b/src/joystick/windows/SDL_windowsjoystick.c
@@ -634,6 +634,7 @@ static void WINDOWS_JoystickClose(SDL_Joystick *joystick)
 {
     if (!joystick->hwdata) {
         SDL_SetError("Unable to close joystick, hwdata is NULL.");
+        return;
     }
 #ifdef SDL_JOYSTICK_XINPUT
     if (joystick->hwdata->bXInputDevice) {


### PR DESCRIPTION
Adds hwdata NULL checks for JoystickRumble and JoystickClose.

Hopefully fixes #14067.
