### PR TITLE
Fix SDL_uclibc for 32-bit Windows on current Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2133,7 +2133,7 @@ elseif(WINDOWS)
     target_compile_options(SDL_uclibc PRIVATE $<$<COMPILE_LANGUAGE:C,CXX>:/GS-> $<$<COMPILE_LANGUAGE:C,CXX>:/Gs1048576>)
     if(SDL_CPU_X86)
       target_compile_options(SDL3-shared PRIVATE "/arch:SSE")
-      target_compile_options(SDL3-SDL_uclibc PRIVATE "/arch:SSE")
+      target_compile_options(SDL_uclibc PRIVATE "/arch:SSE")
     endif()
   endif()
 

--- a/src/stdlib/SDL_mslibc.c
+++ b/src/stdlib/SDL_mslibc.c
@@ -95,6 +95,39 @@ void _ftol2()
     _ftol();
 }
 
+void __declspec(naked) _ftoul2_legacy()
+{
+    static const Uint64 LLONG_MAX_PLUS_ONE = 0x43e0000000000000ULL;
+    /* *INDENT-OFF* */
+    __asm {
+        fld qword ptr [LLONG_MAX_PLUS_ONE]
+        fcom
+        fnstsw ax
+        test ah, 41h
+        jnp greater_than_int64
+
+        fstp st(0)
+        jmp _ftol
+
+greater_than_int64:
+        fsub st(1), st(0)
+        fcomp
+        fnstsw ax
+        test ah, 41h
+        jnz greater_than_uint64
+
+        call _ftol
+        add edx, 80000000h
+        ret
+
+greater_than_uint64:
+        xor eax, eax
+        mov edx, 80000000h
+        ret
+    }
+    /* *INDENT-ON* */
+}
+
 // 64-bit math operators for 32-bit systems
 void __declspec(naked) _allmul()
 {

--- a/test/testautomation_stdlib.c
+++ b/test/testautomation_stdlib.c
@@ -265,6 +265,14 @@ static int SDLCALL stdlib_snprintf(void *arg)
     SDLTest_AssertCheck(SDL_strcmp(text, expected) == 0, "Check text, expected: '%s', got: '%s'", expected, text);
     SDLTest_AssertCheck(result == 6, "Check result value, expected: 6, got: %d", result);
 
+    result = SDL_snprintf(text, sizeof(text), "%06.0f", ((double)SDL_MAX_SINT64) * 1.5);
+    predicted = SDL_snprintf(NULL, 0, "%06.0f", ((double)SDL_MAX_SINT64) * 1.5);
+    expected = "13835058055282163712";
+    SDLTest_AssertPass("Call to SDL_snprintf(\"%%06.2f\", SDL_MAX_SINT64 * 1.5)");
+    SDLTest_AssertCheck(SDL_strcmp(text, expected) == 0, "Check text, expected: '%s', got: '%s'", expected, text);
+    SDLTest_AssertCheck(result == SDL_strlen(text), "Check result value, expected: %d, got: %d", (int)SDL_strlen(text), result);
+    SDLTest_AssertCheck(predicted == result, "Check predicted value, expected: %d, got: %d", result, predicted);
+
     {
         static struct
         {


### PR DESCRIPTION
Aside from a typo in `CMakeLists.txt`, the main issue is the new _ftoul2_legacy() builtin used for `double` → `uint64_t` conversions in `cl.exe` versions ≥v19.41. SDL currently needs such conversions in:
    
* MainCallbackRateHintChanged()
* SDL_PrintFloat()
* WIN_ApplyWindowProgress()

This seems enough to justify implementing this function rather than trying to work around it, [as it was done in sdl12-compat](https://github.com/libsdl-org/sdl12-compat/issues/352).

This [implementation from ReactOS](https://git.reactos.org/?p=reactos.git;a=commitdiff;h=f637e6b809adb5e0ae420ef4f80c73b19172a2e7) passes the stdlib testautomation, and also matches the behavior of Microsoft's 64-bit libc for the currently implementation-defined case of calling SDL_PrintFloat() with values >`SDL_MAX_UINT64`.
That function's `unsigned long long` cast currently limits the uclibc version of SDL_snprintf() to values<ULLONG_MAX, but it makes sense to add a test that ensures that  SDL_snprintf() at least supports the full unsigned 64-bit range. This also covers the one defined case where a 32-bit MSVC build can't assume that _ftoul2_legacy() == _ftol2().