### PR TITLE
Only emit dlopen note for SDL_FRIBIDI_DYNAMIC if not a hard dependency

### DIFF
--- a/src/core/unix/SDL_fribidi.c
+++ b/src/core/unix/SDL_fribidi.c
@@ -25,12 +25,14 @@
 #include "SDL_fribidi.h"
 #include <fribidi.h>
 
+#ifdef SDL_FRIBIDI_DYNAMIC
 SDL_ELF_NOTE_DLOPEN(
     "fribidi",
     "Bidirectional text support",
     SDL_ELF_NOTE_DLOPEN_PRIORITY_SUGGESTED,
     SDL_FRIBIDI_DYNAMIC
 );
+#endif
 
 SDL_FriBidi *SDL_FriBidi_Create(void) {
 	SDL_FriBidi *fribidi;


### PR DESCRIPTION
Fixes: 65b36721 "unix: Mark SDL_FRIBIDI_DYNAMIC as a weak dependency"
Thanks: Anonymous Maarten

---

cc @madebr @sezero 