### PR TITLE
Always convert window to Vulkan window on SDL_Vulkan_CreateSurface

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -6178,7 +6178,7 @@ bool SDL_Vulkan_CreateSurface(SDL_Window *window,
 
     if (!_this->Vulkan_CreateSurface) {
         SDL_Unsupported();
-        return NULL;
+        return false;
     }
 
     CHECK_PARAM(!instance) {


### PR DESCRIPTION
## Description
Currently function to create Metal view will automatically convert window to Metal one. Made the behaviour the same for Vulkan.
Also fixed a bug in SDL_ReconfigureWindowInternal. More information in the issue linked below.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/14142
