### PR TITLE
Add more thorugh CRTC checks in X11TK, add exit code error checking to zenitymessagebox.

### DIFF
--- a/src/dialog/unix/SDL_zenitymessagebox.c
+++ b/src/dialog/unix/SDL_zenitymessagebox.c
@@ -158,7 +158,15 @@ bool SDL_Zenity_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *bu
         return false;
     }
     if (buttonID) {
-        char *output = SDL_ReadProcess(process, NULL, NULL);
+		int exit_code;
+        char *output = SDL_ReadProcess(process, NULL, &exit_code);
+        if (exit_code == 255) {
+            if (output) {
+                SDL_free(output);
+            }
+            SDL_DestroyProcess(process);
+            return false;
+		}
         if (output) {
             // It likes to add a newline...
             char *tmp = SDL_strrchr(output, '\n');

--- a/src/video/x11/SDL_x11messagebox.c
+++ b/src/video/x11/SDL_x11messagebox.c
@@ -235,9 +235,9 @@ static bool X11_ShowMessageBoxImpl(const SDL_MessageBoxData *messageboxdata, int
 // Display an x11 message box.
 bool X11_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonID)
 {
-    if (SDL_Zenity_ShowMessageBox(messageboxdata, buttonID)) {
+    /*if (SDL_Zenity_ShowMessageBox(messageboxdata, buttonID)) {
         return true;
-    }
+    }*/
 
 #if SDL_FORK_MESSAGEBOX
     // Use a child process to protect against setlocale(). Annoying.

--- a/src/video/x11/SDL_x11messagebox.c
+++ b/src/video/x11/SDL_x11messagebox.c
@@ -235,9 +235,9 @@ static bool X11_ShowMessageBoxImpl(const SDL_MessageBoxData *messageboxdata, int
 // Display an x11 message box.
 bool X11_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonID)
 {
-    /*if (SDL_Zenity_ShowMessageBox(messageboxdata, buttonID)) {
+    if (SDL_Zenity_ShowMessageBox(messageboxdata, buttonID)) {
         return true;
-    }*/
+    }
 
 #if SDL_FORK_MESSAGEBOX
     // Use a child process to protect against setlocale(). Annoying.

--- a/src/video/x11/SDL_x11toolkit.c
+++ b/src/video/x11/SDL_x11toolkit.c
@@ -1039,7 +1039,7 @@ bool X11Toolkit_CreateWindowRes(SDL_ToolkitWindowX11 *data, int w, int h, int cx
                             X11_XRRFreeOutputInfo(out_info);
                             goto FIRSTCRTCXRANDR;
                         }
-                                                    
+
                         x = (crtc_info->width - data->window_width) / 2;
                         y = (crtc_info->height - data->window_height) / 3;
                         X11_XRRFreeOutputInfo(out_info);

--- a/src/video/x11/SDL_x11toolkit.c
+++ b/src/video/x11/SDL_x11toolkit.c
@@ -999,7 +999,14 @@ bool X11Toolkit_CreateWindowRes(SDL_ToolkitWindowX11 *data, int w, int h, int cx
                     goto FIRSTOUTPUTXRANDR;
                 }
 
-                crtc_info = X11_XRRGetCrtcInfo(display, screen_res, out_info->crtc);
+                if (out_info->crtc != None) {
+                    crtc_info = X11_XRRGetCrtcInfo(display, screen_res, out_info->crtc);
+                } else if (out_info->ncrtc > 0) {
+                    crtc_info = X11_XRRGetCrtcInfo(display, screen_res, out_info->crtcs[0]);
+                } else {
+                    crtc_info = NULL;
+                }
+
                 if (crtc_info) {
                     x = (crtc_info->width - data->window_width) / 2;
                     y = (crtc_info->height - data->window_height) / 3;
@@ -1020,12 +1027,19 @@ bool X11Toolkit_CreateWindowRes(SDL_ToolkitWindowX11 *data, int w, int h, int cx
                             goto FIRSTCRTCXRANDR;
                         }
 
-                        crtc_info = X11_XRRGetCrtcInfo(display, screen_res, out_info->crtc);
+                        if (out_info->crtc != None) {
+                            crtc_info = X11_XRRGetCrtcInfo(display, screen_res, out_info->crtc);
+                        } else if (out_info->ncrtc > 0) {
+                            crtc_info = X11_XRRGetCrtcInfo(display, screen_res, out_info->crtcs[0]);
+                        } else {
+                            crtc_info = NULL;
+                        }
+                        
                         if (!crtc_info) {
                             X11_XRRFreeOutputInfo(out_info);
                             goto FIRSTCRTCXRANDR;
                         }
-
+                                                    
                         x = (crtc_info->width - data->window_width) / 2;
                         y = (crtc_info->height - data->window_height) / 3;
                         X11_XRRFreeOutputInfo(out_info);


### PR DESCRIPTION
This PR adds more CRTC checks to the Xrandr code path and adds exit code checking to the Zenity messagebox code to hopefully fix #14140.