### PR TITLE
zenity dialog: make sure that --modal --attach switches are supported. 

### DIFF
--- a/src/dialog/unix/SDL_zenitydialog.c
+++ b/src/dialog/unix/SDL_zenitydialog.c
@@ -21,6 +21,8 @@
 #include "SDL_internal.h"
 
 #include "../SDL_dialog_utils.h"
+#include "SDL_zenitydialog.h"
+#include "SDL_zenitymessagebox.h"
 
 #define X11_HANDLE_MAX_WIDTH 28
 typedef struct
@@ -88,6 +90,7 @@ static bool get_x11_window_handle(SDL_PropertiesID props, char *out)
 static zenityArgs *create_zenity_args(SDL_FileDialogType type, SDL_DialogFileCallback callback, void *userdata, SDL_PropertiesID props)
 {
     zenityArgs *args = SDL_calloc(1, sizeof(*args));
+    int zenity_major = 0, zenity_minor = 0;
     if (!args) {
         return NULL;
     }
@@ -109,6 +112,8 @@ static zenityArgs *create_zenity_args(SDL_FileDialogType type, SDL_DialogFileCal
         goto cleanup;
     }
     args->argv = argv;
+
+    SDL_get_zenity_version(&zenity_major, &zenity_minor);
 
     /* Properties can be destroyed as soon as the function returns; copy over what we need. */
 #define COPY_STRING_PROPERTY(dst, prop)                             \
@@ -158,7 +163,8 @@ static zenityArgs *create_zenity_args(SDL_FileDialogType type, SDL_DialogFileCal
         argv[argc++] = args->filename;
     }
 
-    if (get_x11_window_handle(props, args->x11_window_handle)) {
+    if (get_x11_window_handle(props, args->x11_window_handle) &&
+        (zenity_major > 3 || (zenity_major == 3 && zenity_minor >= 6))) {
         argv[argc++] = "--modal";
         argv[argc++] = "--attach";
         argv[argc++] = args->x11_window_handle;

--- a/src/dialog/unix/SDL_zenitymessagebox.c
+++ b/src/dialog/unix/SDL_zenitymessagebox.c
@@ -53,7 +53,7 @@ static bool parse_zenity_version(const char *version, int *major, int *minor)
     return true;
 }
 
-static bool get_zenity_version(int *major, int *minor)
+bool SDL_get_zenity_version(int *major, int *minor)
 {
     const char *argv[] = { "zenity", "--version", NULL };
     bool result = false;
@@ -87,7 +87,7 @@ bool SDL_Zenity_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *bu
     }
 
     // get zenity version so we know which arg to use
-    if (!get_zenity_version(&zenity_major, &zenity_minor)) {
+    if (!SDL_get_zenity_version(&zenity_major, &zenity_minor)) {
         return false; // get_zenity_version() calls SDL_SetError(), so message is already set
     }
 

--- a/src/dialog/unix/SDL_zenitymessagebox.h
+++ b/src/dialog/unix/SDL_zenitymessagebox.h
@@ -23,5 +23,6 @@
 #define SDL_zenitymessagebox_h_
 
 extern bool SDL_Zenity_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonID);
+extern bool SDL_get_zenity_version(int *major, int *minor);
 
 #endif // SDL_waylandmessagebox_h_


### PR DESCRIPTION
Reference issue: https://github.com/libsdl-org/SDL/issues/14140

~This doesn't detect pressed button id, limited to the 'OK' button,~
~and potentially does not use (correct) user-provided button label.~

~However, current distros all provide new-enough zenity versions,~
~so the issues mentioned above are actually non-issues.~
