### PR TITLE
Fixed building with SDL_LEAN_AND_MEAN

### DIFF
--- a/src/render/direct3d/SDL_render_d3d.c
+++ b/src/render/direct3d/SDL_render_d3d.c
@@ -1059,8 +1059,10 @@ static bool SetupTextureState(D3D_RenderData *data, SDL_Texture *texture, SDL_Sc
         } else {
             *shader = SHADER_PALETTE_NEAREST;
         }
+#ifdef SDL_HAVE_YUV
     } else if (texturedata->yuv) {
         *shader = SHADER_YUV;
+#endif // SDL_HAVE_YUV
     }
     *shader_params = texturedata->shader_params;
 


### PR DESCRIPTION
Fix build with `SDL_LEAN_AND_MEAN`.

## Description

Avoid checking `texturedata->yuv` when `SDL_HAVE_YUV` is not defined.

The condition in question checks whether `texturedata->yuv` is not a null pointer.
Thus, when SDL is compiled without YUV support, this pointer does not exist, allowing us to treat it as a null pointer by eliminating this branch.

## Existing Issue(s)

https://github.com/libsdl-org/SDL/issues/14151