### PR TITLE
windows: Allow OpenGL ES creation without EGL, if the WGL supports it.

### DIFF
--- a/src/video/windows/SDL_windowsopengl.c
+++ b/src/video/windows/SDL_windowsopengl.c
@@ -489,7 +489,9 @@ void WIN_GL_InitExtensions(SDL_VideoDevice *_this)
     }
 
     // Check for WGL_EXT_create_context_es2_profile
-    if (HasExtension("WGL_EXT_create_context_es2_profile", extensions)) {
+    // see if we can get at OpenGL ES profiles even if EGL isn't available.
+    _this->gl_data->HAS_WGL_EXT_create_context_es2_profile = HasExtension("WGL_EXT_create_context_es2_profile", extensions);
+    if (_this->gl_data->HAS_WGL_EXT_create_context_es2_profile) {
         SDL_GL_DeduceMaxSupportedESProfile(
             &_this->gl_data->es_profile_max_supported_version.major,
             &_this->gl_data->es_profile_max_supported_version.minor);
@@ -704,7 +706,9 @@ bool WIN_GL_UseEGL(SDL_VideoDevice *_this)
     SDL_assert(_this->gl_data != NULL);
     SDL_assert(_this->gl_config.profile_mask == SDL_GL_CONTEXT_PROFILE_ES);
 
-    return SDL_GetHintBoolean(SDL_HINT_OPENGL_ES_DRIVER, false) || _this->gl_config.major_version == 1 || _this->gl_config.major_version > _this->gl_data->es_profile_max_supported_version.major || (_this->gl_config.major_version == _this->gl_data->es_profile_max_supported_version.major && _this->gl_config.minor_version > _this->gl_data->es_profile_max_supported_version.minor); // No WGL extension for OpenGL ES 1.x profiles.
+    // (we don't need EGL to do OpenGL ES if HAS_WGL_EXT_create_context_es2_profile exists.)
+
+    return !_this->gl_data->HAS_WGL_EXT_create_context_es2_profile || SDL_GetHintBoolean(SDL_HINT_OPENGL_ES_DRIVER, false) || _this->gl_config.major_version == 1 || _this->gl_config.major_version > _this->gl_data->es_profile_max_supported_version.major || (_this->gl_config.major_version == _this->gl_data->es_profile_max_supported_version.major && _this->gl_config.minor_version > _this->gl_data->es_profile_max_supported_version.minor); // No WGL extension for OpenGL ES 1.x profiles.
 }
 
 SDL_GLContext WIN_GL_CreateContext(SDL_VideoDevice *_this, SDL_Window *window)

--- a/src/video/windows/SDL_windowsopengl.h
+++ b/src/video/windows/SDL_windowsopengl.h
@@ -65,6 +65,7 @@ struct SDL_GLDriverData
     bool HAS_WGL_ARB_create_context_robustness;
     bool HAS_WGL_ARB_create_context_no_error;
     bool HAS_WGL_ARB_pixel_format_float;
+    bool HAS_WGL_EXT_create_context_es2_profile;
 
     /* Max version of OpenGL ES context that can be created if the
        implementation supports WGL_EXT_create_context_es2_profile.


### PR DESCRIPTION
Note that this should work with GLES1, don't let the "es2" in WGL_EXT_create_context_es2_profile fool you.

Fixes #13056.
