### PR TITLE
Make small improvement to SDL_PropertiesID documentation

### DIFF
--- a/include/SDL3/SDL_properties.h
+++ b/include/SDL3/SDL_properties.h
@@ -59,7 +59,11 @@ extern "C" {
 #endif
 
 /**
- * SDL properties ID
+ * The SDL_PropertiesID is an ID for a properties group
+ * created with SDL_CreateProperties.
+ *
+ * See [CategoryProperties](CategoryProperties) for detailed
+ * usage information.
  *
  * \since This datatype is available since SDL 3.2.0.
  */


### PR DESCRIPTION
## Description
Some places in the documentation (e.g. `SDL_CreateProcessWithProperties`) will show that the function takes an `SDL_PropertiesID` argument, then link to the `SDL_PropertiesID` type which helpfully informs you that it is an int. That's it.

I added links to places that can help people get started with understanding how to create property groups that can be passed to these functions, in case people end up at this page via some other API documentation that assumes they understand property groups already.