### PR TITLE
Fix compiling Metal renderer with SDL_LEAN_AND_MEAN

### DIFF
--- a/src/render/metal/SDL_render_metal.m
+++ b/src/render/metal/SDL_render_metal.m
@@ -795,9 +795,8 @@ static bool METAL_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SD
             texturedata.fragmentFunction = SDL_METAL_FRAGMENT_YUV;
         } else if (nv12) {
             texturedata.fragmentFunction = SDL_METAL_FRAGMENT_NV12;
-        }
 #endif
-        else {
+        } else {
             texturedata.fragmentFunction = SDL_METAL_FRAGMENT_COPY;
         }
         texturedata.mtltexture = mtltexture;


### PR DESCRIPTION
This PR fixes compiling the Metal renderer on macOS with SDL_LEAN_AND_MEAN defined (meaning SDL_HAVE_YUV is 0). There was a curly bracket on the wrong side of a preprocessor conditional causing compiler errors.