### PR TITLE
[SDL2] Disable SDL_HINT_JOYSTICK_RAWINPUT by default

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -1262,8 +1262,8 @@ extern "C" {
  *
  * This variable can be set to the following values:
  *
- * - "0": RAWINPUT drivers are not used
- * - "1": RAWINPUT drivers are used (the default)
+ * - "0": RAWINPUT drivers are not used (the default)
+ * - "1": RAWINPUT drivers are used
  */
 #define SDL_HINT_JOYSTICK_RAWINPUT "SDL_JOYSTICK_RAWINPUT"
 

--- a/src/joystick/windows/SDL_rawinputjoystick.c
+++ b/src/joystick/windows/SDL_rawinputjoystick.c
@@ -1027,7 +1027,7 @@ static int RAWINPUT_JoystickInit(void)
 {
     SDL_assert(!SDL_RAWINPUT_inited);
 
-    if (!SDL_GetHintBoolean(SDL_HINT_JOYSTICK_RAWINPUT, SDL_TRUE)) {
+    if (!SDL_GetHintBoolean(SDL_HINT_JOYSTICK_RAWINPUT, SDL_FALSE)) {
         return 0;
     }
 


### PR DESCRIPTION
## Description
backported SDL3 commit [`aa870d5`](https://github.com/libsdl-org/SDL/commit/aa870d511e988061748ec9717fc2f8a80b8797d4) over to SDL2. 

This commit addresses #13047, where a Windows Update created a regression on RawInput drivers when using Xbox Controller. As programs uses SDL2 to handle Inputs, such https://github.com/libsdl-org/SDL/issues/13047#issuecomment-2946279733. they can't fix that problem unless they set the SDL_Hints themselves-- but for convenience: I decided to backport the SDL3-specific fix into SDL2.