### PR TITLE
Fix SDL GPU D3D12 Descriptor Heap leak

### DIFF
--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -4885,7 +4885,14 @@ static void D3D12_INTERNAL_SetGPUDescriptorHeaps(D3D12CommandBuffer *commandBuff
     viewHeap = D3D12_INTERNAL_AcquireGPUDescriptorHeapFromPool(commandBuffer, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
     samplerHeap = D3D12_INTERNAL_AcquireGPUDescriptorHeapFromPool(commandBuffer, D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER);
 
+    if (commandBuffer->gpuDescriptorHeaps[0] != NULL) {
+        D3D12_INTERNAL_ReturnGPUDescriptorHeapToPool(commandBuffer->renderer, commandBuffer->gpuDescriptorHeaps[0]);
+    }
     commandBuffer->gpuDescriptorHeaps[0] = viewHeap;
+
+    if (commandBuffer->gpuDescriptorHeaps[1] != NULL) {
+        D3D12_INTERNAL_ReturnGPUDescriptorHeapToPool(commandBuffer->renderer, commandBuffer->gpuDescriptorHeaps[1]);
+    }
     commandBuffer->gpuDescriptorHeaps[1] = samplerHeap;
 
     heaps[0] = viewHeap->handle;


### PR DESCRIPTION
## Description
When descriptor leaks overflow, the D3D12 SDL GPU renderer fetches more from the pool, but never returns them, which eventually causes an "out of memory" crash.

There is a similar case for Uniform buffers on `D3D12_INTERNAL_PushUniformData` but I'm not sure it also requires a "pool return" or not, I'll wait for the experts to weigh in.
