### PR TITLE
[SDL2]wayland: Special-case relative warp mode to deliver accelerated relat…

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -1121,6 +1121,15 @@ int SDL_WarpMouseGlobal(int x, int y)
 
 static SDL_bool ShouldUseRelativeModeWarp(SDL_Mouse *mouse)
 {
+#ifdef SDL_VIDEO_DRIVER_WAYLAND
+    SDL_VideoDevice *vid = SDL_GetVideoDevice();
+
+    /* Wayland can't warp the mouse, but uses this hint internally to deliver accelerated motion */
+    if (SDL_strcmp(vid->name, "wayland") == 0) {
+        return SDL_FALSE;
+    }
+#endif
+
     if (!mouse->WarpMouse) {
         /* Need this functionality for relative mode warp implementation */
         return SDL_FALSE;

--- a/src/video/wayland/SDL_waylandmouse.c
+++ b/src/video/wayland/SDL_waylandmouse.c
@@ -537,6 +537,9 @@ static int Wayland_SetRelativeMouseMode(SDL_bool enabled)
     SDL_VideoData *data = (SDL_VideoData *)vd->driverdata;
 
     if (enabled) {
+        /* Clients use relative warp mode to get accelerated motion deltas, which Wayland delivers internally. */
+        data->relative_mode_accelerated = SDL_GetHintBoolean(SDL_HINT_MOUSE_RELATIVE_MODE_WARP, SDL_FALSE);
+
         /* Disable mouse warp emulation if it's enabled. */
         if (data->input->relative_mode_override) {
             data->input->relative_mode_override = SDL_FALSE;

--- a/src/video/wayland/SDL_waylandvideo.h
+++ b/src/video/wayland/SDL_waylandvideo.h
@@ -101,6 +101,7 @@ typedef struct
     char *classname;
 
     int relative_mouse_mode;
+    int relative_mode_accelerated;
     SDL_bool egl_transparency_enabled;
 } SDL_VideoData;
 


### PR DESCRIPTION
…ive motion

The Wayland backend lacks pointer warp functionality, so special-case the relative warp mode hint to deliver accelerated relative motion deltas, which is ultimately what the client wants by enabling this hint.

Fixes #14182 
