### PR TITLE
Fix divide-by-zero when scale results in zero-sized tiles

### DIFF
--- a/src/video/SDL_surface.c
+++ b/src/video/SDL_surface.c
@@ -1523,6 +1523,11 @@ bool SDL_BlitSurfaceTiledWithScale(SDL_Surface *src, const SDL_Rect *srcrect, fl
 
     int tile_width = (int)(r_src.w * scale);
     int tile_height = (int)(r_src.h * scale);
+
+    if (tile_width <= 0 || tile_height <= 0) {
+        return SDL_SetError("Invalid scale: scaled tile size would be zero");
+    }
+
     int rows = r_dst.h / tile_height;
     int cols = r_dst.w / tile_width;
     int remaining_dst_w = (r_dst.w - cols * tile_width);

--- a/test/testautomation_surface.c
+++ b/test/testautomation_surface.c
@@ -442,6 +442,15 @@ static int SDLCALL surface_testBlitTiled(void *arg)
         SDLTest_AssertCheck(ret == 0, "Validate result from SDLTest_CompareSurfaces, expected: 0, got: %i", ret);
     }
 
+    /* Tiled blit - very small scale (should fail gracefully) */
+    {
+        float tiny_scale = 0.01f;
+        ret = SDL_BlitSurfaceTiledWithScale(face, NULL, tiny_scale, SDL_SCALEMODE_NEAREST, testSurface, NULL);
+        SDLTest_AssertCheck(ret == false, "Expected SDL_BlitSurfaceTiledWithScale to fail with very small scale: %f, got: %i", tiny_scale, ret);
+        const char *err = SDL_GetError();
+        SDLTest_AssertCheck(err && SDL_strstr(err, "Invalid scale") != NULL, "Expected SDL_GetError() to contain 'Invalid scale', got: %s", err ? err : "NULL");
+    }
+
     /* Clean up. */
     SDL_DestroySurface(face);
     SDL_DestroySurface(testSurface2x);


### PR DESCRIPTION
Problem:
When calling SDL_BlitSurfaceTiledWithScale() with a very small positive scale (e.g. 0.01f), the computed tile size becomes zero after integer truncation, leading to a division by zero and a crash.

Changes:
Added a guard to detect zero-sized tiles caused by extremely small scales. The function now safely reports an error using SDL_SetError("Invalid scale: scaled tile size would be zero") instead of crashing.

Before:
Calling with very small scales caused a floating point exception (core dumped).

After:
The function now fails gracefully and returns false with a clear error message.


I’m fairly new to contributing to SDL
any feedback or suggestions for improvement are very welcome. Thank you

fixes #14057