### PR TITLE
Fix SDL_SetRelativeMouseMode failing with software framebuffer on Haiku

### DIFF
--- a/src/video/haiku/SDL_bvideo.cc
+++ b/src/video/haiku/SDL_bvideo.cc
@@ -240,16 +240,18 @@ static bool HAIKU_SetRelativeMouseMode(bool enabled)
     }
 
 	SDL_BWin *bewin = _ToBeWin(window);
-	BGLView *_SDL_GLView = bewin->GetGLView();
-    if (!_SDL_GLView) {
-        return false;
-    }
+	BView *_SDL_View = bewin->GetGLView();
+	if (!_SDL_View) {
+		_SDL_View = bewin->GetView();
+		if (!_SDL_View)
+			return false;
+	}
 
 	bewin->Lock();
 	if (enabled)
-		_SDL_GLView->SetEventMask(B_POINTER_EVENTS, B_NO_POINTER_HISTORY);
+		_SDL_View->SetEventMask(B_POINTER_EVENTS, B_NO_POINTER_HISTORY);
 	else
-		_SDL_GLView->SetEventMask(0, 0);
+		_SDL_View->SetEventMask(0, 0);
 	bewin->Unlock();
 
     return true;


### PR DESCRIPTION
If a software rendering program is launched with `SDL_FRAMEBUFFER_ACCELERATION=0` on Haiku, any call to `SDL_SetRelativeMouseMode` would fail, which could either lead to a program error or simply that the program never enters relative mouse mode.

## Description
Inside `HAIKU_SetRelativeMouseMode`, the code only checked for the OpenGL view on the window, but if a program never uses any OpenGL code, which can happen when `SDL_FRAMEBUFFER_ACCELERATION=0`, the OpenGL view is never created. The result is that the program fails to mask the mouse as there is no view to mask.

This patch fixes this by falling back to the software view if no OpenGL view exists, and masks the software view instead.