### PR TITLE
GPU: Correctly recycle D3D12 descriptor heaps

### DIFF
--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -2292,7 +2292,7 @@ static void D3D12_INTERNAL_TrackGPUDescriptorHeap(
     }
 
     commandBuffer->usedDescriptorHeaps[commandBuffer->usedDescriptorHeapCount] = descriptorHeap;
-    commandBuffer->usedDescriptorHeaps += 1;
+    commandBuffer->usedDescriptorHeapCount += 1;
 }
 
 static D3D12DescriptorHeap *D3D12_INTERNAL_AcquireGPUDescriptorHeapFromPool(


### PR DESCRIPTION
Fixes #14190 