### PR TITLE
Fix thread safety attributes for TryLock functions

### DIFF
--- a/include/SDL3/SDL_mutex.h
+++ b/include/SDL3/SDL_mutex.h
@@ -360,7 +360,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_LockMutex(SDL_Mutex *mutex) SDL_ACQUIRE(mut
  * \sa SDL_LockMutex
  * \sa SDL_UnlockMutex
  */
-extern SDL_DECLSPEC bool SDLCALL SDL_TryLockMutex(SDL_Mutex *mutex) SDL_TRY_ACQUIRE(0, mutex);
+extern SDL_DECLSPEC bool SDLCALL SDL_TryLockMutex(SDL_Mutex *mutex) SDL_TRY_ACQUIRE(true, mutex);
 
 /**
  * Unlock the mutex.
@@ -559,7 +559,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_LockRWLockForWriting(SDL_RWLock *rwlock) SD
  * \sa SDL_TryLockRWLockForWriting
  * \sa SDL_UnlockRWLock
  */
-extern SDL_DECLSPEC bool SDLCALL SDL_TryLockRWLockForReading(SDL_RWLock *rwlock) SDL_TRY_ACQUIRE_SHARED(0, rwlock);
+extern SDL_DECLSPEC bool SDLCALL SDL_TryLockRWLockForReading(SDL_RWLock *rwlock) SDL_TRY_ACQUIRE_SHARED(true, rwlock);
 
 /**
  * Try to lock a read/write lock _for writing_ without blocking.
@@ -589,7 +589,7 @@ extern SDL_DECLSPEC bool SDLCALL SDL_TryLockRWLockForReading(SDL_RWLock *rwlock)
  * \sa SDL_TryLockRWLockForReading
  * \sa SDL_UnlockRWLock
  */
-extern SDL_DECLSPEC bool SDLCALL SDL_TryLockRWLockForWriting(SDL_RWLock *rwlock) SDL_TRY_ACQUIRE(0, rwlock);
+extern SDL_DECLSPEC bool SDLCALL SDL_TryLockRWLockForWriting(SDL_RWLock *rwlock) SDL_TRY_ACQUIRE(true, rwlock);
 
 /**
  * Unlock the read/write lock.

--- a/src/joystick/hidapi/SDL_hidapi_rumble.h
+++ b/src/joystick/hidapi/SDL_hidapi_rumble.h
@@ -28,7 +28,7 @@
 #ifdef SDL_THREAD_SAFETY_ANALYSIS
 extern SDL_Mutex *SDL_HIDAPI_rumble_lock;
 #endif
-bool SDL_HIDAPI_LockRumble(void) SDL_TRY_ACQUIRE(0, SDL_HIDAPI_rumble_lock);
+bool SDL_HIDAPI_LockRumble(void) SDL_TRY_ACQUIRE(true, SDL_HIDAPI_rumble_lock);
 bool SDL_HIDAPI_GetPendingRumbleLocked(SDL_HIDAPI_Device *device, Uint8 **data, int **size, int *maximum_size);
 int SDL_HIDAPI_SendRumbleAndUnlock(SDL_HIDAPI_Device *device, const Uint8 *data, int size) SDL_RELEASE(SDL_HIDAPI_rumble_lock);
 typedef void (*SDL_HIDAPI_RumbleSentCallback)(void *userdata);


### PR DESCRIPTION
## Description
Changed `SDL_TRY_ACQUIRE` and `SDL_TRY_ACQUIRE_SHARED` (`SDL_mutex.h`) success value from 0 to `true` for functions that now return `bool` instead of `int`/`SDL_bool`. This fixes false positives/negatives in Clang's thread safety analysis. See #14236.

## Details

The regression was introduced in commit [9ff3446f](https://github.com/libsdl-org/SDL/commit/9ff3446f036094bc005ef119e0cf07fc9b503b8e) ("Use SDL_bool instead an int return code in the SDL API").

There are very few places where the `TryLock` API is used (half of them are macros/dynapi):
```
grep -rE "(SDL_TryLockMutex|SDL_TryLockRWLockForReading|SDL_TryLockRWLockForWriting|SDL_HIDAPI_LockRumble)" src/

src/dynapi/SDL_dynapi.sym:    SDL_TryLockMutex;
src/dynapi/SDL_dynapi.sym:    SDL_TryLockRWLockForReading;
src/dynapi/SDL_dynapi.sym:    SDL_TryLockRWLockForWriting;
src/dynapi/SDL_dynapi_overrides.h:#define SDL_TryLockMutex SDL_TryLockMutex_REAL
src/dynapi/SDL_dynapi_overrides.h:#define SDL_TryLockRWLockForReading SDL_TryLockRWLockForReading_REAL
src/dynapi/SDL_dynapi_overrides.h:#define SDL_TryLockRWLockForWriting SDL_TryLockRWLockForWriting_REAL
src/dynapi/SDL_dynapi_procs.h:SDL_DYNAPI_PROC(bool,SDL_TryLockMutex,(SDL_Mutex *a),(a),return)
src/dynapi/SDL_dynapi_procs.h:SDL_DYNAPI_PROC(bool,SDL_TryLockRWLockForReading,(SDL_RWLock *a),(a),return)
src/dynapi/SDL_dynapi_procs.h:SDL_DYNAPI_PROC(bool,SDL_TryLockRWLockForWriting,(SDL_RWLock *a),(a),return)
src/joystick/hidapi/SDL_hidapi_rumble.h:bool SDL_HIDAPI_LockRumble(void) SDL_TRY_ACQUIRE(true, SDL_HIDAPI_rumble_lock);
src/joystick/hidapi/SDL_hidapi_ps4.c:        if (SDL_HIDAPI_LockRumble()) {
src/joystick/hidapi/SDL_hidapijoystick.c:                if (SDL_TryLockMutex(device->dev_lock)) {
src/joystick/hidapi/SDL_hidapi_shield.c:    if (!SDL_HIDAPI_LockRumble()) {
src/joystick/hidapi/SDL_hidapi_gip.c:        if (!SDL_HIDAPI_LockRumble()) {
src/joystick/hidapi/SDL_hidapi_xboxone.c:    if (!SDL_HIDAPI_LockRumble()) {
src/joystick/hidapi/SDL_hidapi_xboxone.c:    if (!SDL_HIDAPI_LockRumble()) {
src/joystick/hidapi/SDL_hidapi_rumble.c:bool SDL_HIDAPI_LockRumble(void)
src/joystick/hidapi/SDL_hidapi_rumble.c:    if (!SDL_HIDAPI_LockRumble()) {
src/joystick/hidapi/SDL_hidapi_switch.c:    if (!SDL_HIDAPI_LockRumble()) {
src/joystick/hidapi/SDL_hidapi_wii.c:        if (!SDL_HIDAPI_LockRumble()) {
src/joystick/hidapi/SDL_hidapi_ps5.c:        if (SDL_HIDAPI_LockRumble()) {
src/joystick/hidapi/SDL_hidapi_ps5.c:    if (!SDL_HIDAPI_LockRumble()) {
src/joystick/hidapi/SDL_hidapi_switch2.c:    if (!SDL_HIDAPI_LockRumble()) {
src/thread/vita/SDL_sysmutex.c:bool SDL_TryLockMutex(SDL_Mutex *mutex)
src/thread/psp/SDL_sysmutex.c:bool SDL_TryLockMutex(SDL_Mutex *mutex)
src/thread/pthread/SDL_sysrwlock.c:bool SDL_TryLockRWLockForReading(SDL_RWLock *rwlock)
src/thread/pthread/SDL_sysrwlock.c:bool SDL_TryLockRWLockForWriting(SDL_RWLock *rwlock)
src/thread/pthread/SDL_sysmutex.c:bool SDL_TryLockMutex(SDL_Mutex *mutex)
src/thread/generic/SDL_sysrwlock.c:bool SDL_TryLockRWLockForReading_generic(SDL_RWLock *rwlock)
src/thread/generic/SDL_sysrwlock.c:        if (!SDL_TryLockMutex(rwlock->lock)) {
src/thread/generic/SDL_sysrwlock.c:bool SDL_TryLockRWLockForReading(SDL_RWLock *rwlock)
src/thread/generic/SDL_sysrwlock.c:    return SDL_TryLockRWLockForReading_generic(rwlock);
src/thread/generic/SDL_sysrwlock.c:bool SDL_TryLockRWLockForWriting_generic(SDL_RWLock *rwlock)
src/thread/generic/SDL_sysrwlock.c:        if (!SDL_TryLockMutex(rwlock->lock)) {
src/thread/generic/SDL_sysrwlock.c:bool SDL_TryLockRWLockForWriting(SDL_RWLock *rwlock)
src/thread/generic/SDL_sysrwlock.c:    return SDL_TryLockRWLockForWriting_generic(rwlock);
src/thread/generic/SDL_sysmutex.c:bool SDL_TryLockMutex(SDL_Mutex *mutex)
src/thread/generic/SDL_sysrwlock_c.h:bool SDL_TryLockRWLockForReading_generic(SDL_RWLock *rwlock);
src/thread/generic/SDL_sysrwlock_c.h:bool SDL_TryLockRWLockForWriting_generic(SDL_RWLock *rwlock);
src/thread/windows/SDL_sysrwlock_srw.c:typedef bool (*pfnSDL_TryLockRWLockForReading)(SDL_RWLock *);
src/thread/windows/SDL_sysrwlock_srw.c:typedef bool (*pfnSDL_TryLockRWLockForWriting)(SDL_RWLock *);
src/thread/windows/SDL_sysrwlock_srw.c:    pfnSDL_TryLockRWLockForReading TryLockForReading;
src/thread/windows/SDL_sysrwlock_srw.c:    pfnSDL_TryLockRWLockForWriting TryLockForWriting;
src/thread/windows/SDL_sysrwlock_srw.c:static bool SDL_TryLockRWLockForReading_srw(SDL_RWLock *_rwlock)
src/thread/windows/SDL_sysrwlock_srw.c:static bool SDL_TryLockRWLockForWriting_srw(SDL_RWLock *_rwlock)
src/thread/windows/SDL_sysrwlock_srw.c:    &SDL_TryLockRWLockForReading_srw,
src/thread/windows/SDL_sysrwlock_srw.c:    &SDL_TryLockRWLockForWriting_srw,
src/thread/windows/SDL_sysrwlock_srw.c:    &SDL_TryLockRWLockForReading_generic,
src/thread/windows/SDL_sysrwlock_srw.c:    &SDL_TryLockRWLockForWriting_generic,
src/thread/windows/SDL_sysrwlock_srw.c:bool SDL_TryLockRWLockForReading(SDL_RWLock *rwlock)
src/thread/windows/SDL_sysrwlock_srw.c:bool SDL_TryLockRWLockForWriting(SDL_RWLock *rwlock)
src/thread/windows/SDL_sysmutex.c:static bool SDL_TryLockMutex_srw(SDL_Mutex *_mutex)
src/thread/windows/SDL_sysmutex.c:    &SDL_TryLockMutex_srw,
src/thread/windows/SDL_sysmutex.c:static bool SDL_TryLockMutex_cs(SDL_Mutex *mutex_)
src/thread/windows/SDL_sysmutex.c:    &SDL_TryLockMutex_cs,
src/thread/windows/SDL_sysmutex.c:bool SDL_TryLockMutex(SDL_Mutex *mutex)
src/thread/windows/SDL_sysmutex_c.h:typedef bool (*pfnSDL_TryLockMutex)(SDL_Mutex *);
src/thread/windows/SDL_sysmutex_c.h:    pfnSDL_TryLockMutex TryLock;
src/thread/n3ds/SDL_sysmutex.c:bool SDL_TryLockMutex(SDL_Mutex *mutex)
```

Anyways, the PR eliminates 25 warnings from code that uses try-locks (140 before vs 115 now):
```
src/joystick/hidapi/SDL_hidapi_gip.c:750:16: warning: releasing mutex 'SDL_HIDAPI_rumble_lock' that was not held
src/joystick/hidapi/SDL_hidapi_gip.c:754:1: warning: mutex 'SDL_HIDAPI_rumble_lock' is not held on every path through here
src/joystick/hidapi/SDL_hidapi_ps4.c:694:13: warning: releasing mutex 'SDL_HIDAPI_rumble_lock' that was not held
src/joystick/hidapi/SDL_hidapi_ps4.c:706:1: warning: mutex 'SDL_HIDAPI_rumble_lock' is not held on every path through here
src/joystick/hidapi/SDL_hidapi_ps5.c:1100:13: warning: releasing mutex 'SDL_HIDAPI_rumble_lock' that was not held
src/joystick/hidapi/SDL_hidapi_ps5.c:1105:9: warning: releasing mutex 'SDL_HIDAPI_rumble_lock' that was not held
src/joystick/hidapi/SDL_hidapi_ps5.c:1110:1: warning: mutex 'SDL_HIDAPI_rumble_lock' is not held on every path through here
src/joystick/hidapi/SDL_hidapi_ps5.c:801:13: warning: releasing mutex 'SDL_HIDAPI_rumble_lock' that was not held
src/joystick/hidapi/SDL_hidapi_ps5.c:809:1: warning: mutex 'SDL_HIDAPI_rumble_lock' is not held on every path through here
src/joystick/hidapi/SDL_hidapi_rumble.c:269:9: warning: releasing mutex 'SDL_HIDAPI_rumble_lock' that was not held
src/joystick/hidapi/SDL_hidapi_rumble.c:273:12: warning: releasing mutex 'SDL_HIDAPI_rumble_lock' that was not held
src/joystick/hidapi/SDL_hidapi_rumble.c:274:1: warning: mutex 'SDL_HIDAPI_rumble_lock' is not held on every path through here
src/joystick/hidapi/SDL_hidapi_shield.c:164:9: warning: releasing mutex 'SDL_HIDAPI_rumble_lock' that was not held
src/joystick/hidapi/SDL_hidapi_shield.c:169:1: warning: mutex 'SDL_HIDAPI_rumble_lock' is not held on every path through here
src/joystick/hidapi/SDL_hidapi_switch.c:391:12: warning: releasing mutex 'SDL_HIDAPI_rumble_lock' that was not held
src/joystick/hidapi/SDL_hidapi_switch.c:393:1: warning: mutex 'SDL_HIDAPI_rumble_lock' is not held on every path through here
src/joystick/hidapi/SDL_hidapi_wii.c:224:16: warning: releasing mutex 'SDL_HIDAPI_rumble_lock' that was not held
src/joystick/hidapi/SDL_hidapi_wii.c:226:1: warning: mutex 'SDL_HIDAPI_rumble_lock' is not held on every path through here
src/joystick/hidapi/SDL_hidapi_xboxone.c:241:9: warning: releasing mutex 'SDL_HIDAPI_rumble_lock' that was not held
src/joystick/hidapi/SDL_hidapi_xboxone.c:245:1: warning: mutex 'SDL_HIDAPI_rumble_lock' is not held on every path through here
src/joystick/hidapi/SDL_hidapi_xboxone.c:487:13: warning: releasing mutex 'SDL_HIDAPI_rumble_lock' that was not held
src/joystick/hidapi/SDL_hidapi_xboxone.c:498:13: warning: releasing mutex 'SDL_HIDAPI_rumble_lock' that was not held
src/joystick/hidapi/SDL_hidapi_xboxone.c:506:1: warning: mutex 'SDL_HIDAPI_rumble_lock' is not held on every path through here
src/joystick/hidapi/SDL_hidapijoystick.c:1416:60: warning: mutex 'device->dev_lock' is not held on every path through here
src/joystick/hidapi/SDL_hidapijoystick.c:1425:21: warning: releasing mutex 'device->dev_lock' that was not held
```

## Testing
I tested the changes on macOS with `Apple clang version 17.0.0 (clang-1700.0.13.5)`:
```
export CC=clang
export CFLAGS="-DSDL_THREAD_SAFETY_ANALYSIS -Wthread-safety"
mkdir _build
cd _build
cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON
ninja
```

