### PR TITLE
render: Fix texture format selection for color-keyed indexed surfaces

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -1844,10 +1844,13 @@ SDL_Texture *SDL_CreateTextureFromSurface(SDL_Renderer *renderer, SDL_Surface *s
             }
         }
 
+        // Indexed formats don't support the transparency needed for color-keyed surfaces
+        bool preferIndexed = SDL_ISPIXELFORMAT_INDEXED(surface->format) && !needAlpha;
+
         for (i = 0; i < renderer->num_texture_formats; ++i) {
             if (!SDL_ISPIXELFORMAT_FOURCC(renderer->texture_formats[i]) &&
                 SDL_ISPIXELFORMAT_ALPHA(renderer->texture_formats[i]) == needAlpha &&
-                SDL_ISPIXELFORMAT_INDEXED(renderer->texture_formats[i]) == SDL_ISPIXELFORMAT_INDEXED(surface->format)) {
+                SDL_ISPIXELFORMAT_INDEXED(renderer->texture_formats[i]) == preferIndexed) {
                 format = renderer->texture_formats[i];
                 break;
             }


### PR DESCRIPTION
015cc6a broke texture format selection for this kind of surface if the renderer's first texture format doesn't happen to have an alpha channel. This happens for on-screen software renderers on Windows, whose preferred format is the window's own `SDL_PIXELFORMAT_XRGB8888`.\
This check also covers the intent behind 015cc6a, assuming that indexed and alpha formats are mutually exclusive.