### PR TITLE
Added SDL_GetWindowIDFromEvent

### DIFF
--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -1588,6 +1588,23 @@ extern SDL_DECLSPEC bool SDLCALL SDL_EventEnabled(Uint32 type);
 extern SDL_DECLSPEC Uint32 SDLCALL SDL_RegisterEvents(int numevents);
 
 /**
+ * Get the numeric ID of the window associated with an event.
+ *
+ * \param event an event containing a `windowID`.
+ * \returns the numeric ID of the associated window on success or 0 if there is none.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL 3.3.0.
+ *
+ * \sa SDL_GetWindowFromEvent
+ * \sa SDL_PollEvent
+ * \sa SDL_WaitEvent
+ * \sa SDL_WaitEventTimeout
+ */
+extern SDL_DECLSPEC SDL_WindowID SDLCALL SDL_GetWindowIDFromEvent(const SDL_Event *event);
+
+/**
  * Get window associated with an event.
  *
  * \param event an event containing a `windowID`.
@@ -1597,6 +1614,7 @@ extern SDL_DECLSPEC Uint32 SDLCALL SDL_RegisterEvents(int numevents);
  *
  * \since This function is available since SDL 3.2.0.
  *
+ * \sa SDL_GetWindowIDFromEvent
  * \sa SDL_PollEvent
  * \sa SDL_WaitEvent
  * \sa SDL_WaitEventTimeout

--- a/src/dynapi/SDL_dynapi.sym
+++ b/src/dynapi/SDL_dynapi.sym
@@ -527,6 +527,7 @@ SDL3_0.0.0 {
     SDL_GetWindowBordersSize;
     SDL_GetWindowDisplayScale;
     SDL_GetWindowFlags;
+    SDL_GetWindowIDFromEvent;
     SDL_GetWindowFromEvent;
     SDL_GetWindowFromID;
     SDL_GetWindowFullscreenMode;

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -552,6 +552,7 @@
 #define SDL_GetWindowBordersSize SDL_GetWindowBordersSize_REAL
 #define SDL_GetWindowDisplayScale SDL_GetWindowDisplayScale_REAL
 #define SDL_GetWindowFlags SDL_GetWindowFlags_REAL
+#define SDL_GetWindowIDFromEvent SDL_GetWindowIDFromEvent_REAL
 #define SDL_GetWindowFromEvent SDL_GetWindowFromEvent_REAL
 #define SDL_GetWindowFromID SDL_GetWindowFromID_REAL
 #define SDL_GetWindowFullscreenMode SDL_GetWindowFullscreenMode_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -573,6 +573,7 @@ SDL_DYNAPI_PROC(bool,SDL_GetWindowAspectRatio,(SDL_Window *a, float *b, float *c
 SDL_DYNAPI_PROC(bool,SDL_GetWindowBordersSize,(SDL_Window *a, int *b, int *c, int *d, int *e),(a,b,c,d,e),return)
 SDL_DYNAPI_PROC(float,SDL_GetWindowDisplayScale,(SDL_Window *a),(a),return)
 SDL_DYNAPI_PROC(SDL_WindowFlags,SDL_GetWindowFlags,(SDL_Window *a),(a),return)
+SDL_DYNAPI_PROC(SDL_WindowID,SDL_GetWindowIDFromEvent,(const SDL_Event *a),(a),return)
 SDL_DYNAPI_PROC(SDL_Window*,SDL_GetWindowFromEvent,(const SDL_Event *a),(a),return)
 SDL_DYNAPI_PROC(SDL_Window*,SDL_GetWindowFromID,(SDL_WindowID a),(a),return)
 SDL_DYNAPI_PROC(const SDL_DisplayMode*,SDL_GetWindowFullscreenMode,(SDL_Window *a),(a),return)

--- a/src/events/SDL_categories.c
+++ b/src/events/SDL_categories.c
@@ -184,6 +184,50 @@ SDL_EventCategory SDL_GetEventCategory(Uint32 type)
     }
 }
 
+SDL_WindowID SDL_GetWindowIDFromEvent(const SDL_Event *event)
+{
+    switch (SDL_GetEventCategory(event->type)) {
+    case SDL_EVENTCATEGORY_USER:
+        return event->user.windowID;
+    case SDL_EVENTCATEGORY_WINDOW:
+        return event->window.windowID;
+    case SDL_EVENTCATEGORY_KEY:
+        return event->key.windowID;
+    case SDL_EVENTCATEGORY_EDIT:
+        return event->edit.windowID;
+    case SDL_EVENTCATEGORY_TEXT:
+        return event->text.windowID;
+    case SDL_EVENTCATEGORY_EDIT_CANDIDATES:
+        return event->edit_candidates.windowID;
+    case SDL_EVENTCATEGORY_MOTION:
+        return event->motion.windowID;
+    case SDL_EVENTCATEGORY_BUTTON:
+        return event->button.windowID;
+    case SDL_EVENTCATEGORY_WHEEL:
+        return event->wheel.windowID;
+    case SDL_EVENTCATEGORY_TFINGER:
+        return event->tfinger.windowID;
+    case SDL_EVENTCATEGORY_PPROXIMITY:
+        return event->pproximity.windowID;
+    case SDL_EVENTCATEGORY_PTOUCH:
+        return event->ptouch.windowID;
+    case SDL_EVENTCATEGORY_PBUTTON:
+        return event->pbutton.windowID;
+    case SDL_EVENTCATEGORY_PMOTION:
+        return event->pmotion.windowID;
+    case SDL_EVENTCATEGORY_PAXIS:
+        return event->paxis.windowID;
+    case SDL_EVENTCATEGORY_DROP:
+        return event->drop.windowID;
+    case SDL_EVENTCATEGORY_RENDER:
+        return event->render.windowID;
+    default:
+        // < 0  -> invalid event type (error is set by SDL_GetEventCategory)
+        // else -> event has no associated window (not an error)
+        return 0;
+    }
+}
+
 SDL_Window *SDL_GetWindowFromEvent(const SDL_Event *event)
 {
     SDL_WindowID windowID;


### PR DESCRIPTION
Adds `SDL_GetWindowIDFromEvent`, for the usecases where you can avoid the linear cost of `SDL_GetWindowFromEvent` because you don't immediately need the window handle.

```c
extern SDL_Window *imgui_sdl_window;
SDL_Event event;
SDL_WindowID event_window = SDL_GetWindowIDFromEvent(&event);
if (event_window == SDL_GetWindowID(imgui_sdl_window) || event_window == 0) {
    ImGui_ImplSDL3_ProcessEvent(&event);
}
```

## Description