### PR TITLE
Fix the "redundant redeclaration" warning for `__debugbreak` when using MinGW

### DIFF
--- a/include/SDL3/SDL_assert.h
+++ b/include/SDL3/SDL_assert.h
@@ -126,9 +126,11 @@ extern "C" {
  */
 #define SDL_TriggerBreakpoint() TriggerABreakpointInAPlatformSpecificManner
 
-#elif defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER >= 1310)
+#elif defined(_MSC_VER) && _MSC_VER >= 1310
     /* Don't include intrin.h here because it contains C++ code */
     extern void __cdecl __debugbreak(void);
+    #define SDL_TriggerBreakpoint() __debugbreak()
+#elif defined(__MINGW32__) && (SDL_HAS_BUILTIN(__debugbreak) || __MINGW_DEBUGBREAK_IMPL)
     #define SDL_TriggerBreakpoint() __debugbreak()
 #elif defined(_MSC_VER) && defined(_M_IX86)
     #define SDL_TriggerBreakpoint() { _asm { int 0x03 }  }

--- a/include/SDL3/SDL_assert.h
+++ b/include/SDL3/SDL_assert.h
@@ -130,7 +130,8 @@ extern "C" {
     /* Don't include intrin.h here because it contains C++ code */
     extern void __cdecl __debugbreak(void);
     #define SDL_TriggerBreakpoint() __debugbreak()
-#elif defined(__MINGW32__) && (SDL_HAS_BUILTIN(__debugbreak) || __MINGW_DEBUGBREAK_IMPL)
+#elif defined(__MINGW32__)
+    #include <intrin.h>
     #define SDL_TriggerBreakpoint() __debugbreak()
 #elif defined(_MSC_VER) && defined(_M_IX86)
     #define SDL_TriggerBreakpoint() { _asm { int 0x03 }  }


### PR DESCRIPTION
The MinGW header implementation of [`__debugbreak`](https://github.com/mingw-w64/mingw-w64/blob/1243c4e62e6f0c4814e70c6f3832a2428b37327e/mingw-w64-headers/crt/_mingw.h.in#L605) triggers a warning when built with the "-Wredundant-decls" option. This has been tested with MSYS2 UCRT64 GCC.

Test program:
```c
#include <stdlib.h>
#include <SDL3/SDL.h>
#include <SDL3/SDL_main.h>
int main(int argc, char **argv)
{
    return 0;
}
```

## Existing Issue(s)
#14263
