### PR TITLE
Update comment in `SDL_UserEvent` for member `type`

### DIFF
--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -992,7 +992,7 @@ typedef struct SDL_QuitEvent
  */
 typedef struct SDL_UserEvent
 {
-    Uint32 type;        /**< SDL_EVENT_USER through SDL_EVENT_LAST-1, Uint32 because these are not in the SDL_EventType enumeration */
+    Uint32 type;        /**< SDL_EVENT_USER through SDL_EVENT_LAST, Uint32 because these are not in the SDL_EventType enumeration */
     Uint32 reserved;
     Uint64 timestamp;   /**< In nanoseconds, populated using SDL_GetTicksNS() */
     SDL_WindowID windowID; /**< The associated window if any */


### PR DESCRIPTION
A user event type can have a value from `SDL_EVENT_USER` through `SDL_EVENT_LAST` (inclusive).

https://github.com/libsdl-org/SDL/blob/474d38b14fe6e59b904ebe583c23bb84742a26fe/src/events/SDL_events.c#L461

This commit fixes the comment in `SDL_UserEvent` that says `SDL_EVENT_USER through SDL_EVENT_LAST-1` (exclusive).

---

There is another minor issue with the `SDL_RegisterEvents()` function:

The function only fails(returns 0), if there are no more free user event numbers.
When there is at least one free user event number, then the parameter can be a number that is higher than the maximum possible user events.

example 1, register `SDL_MAX_SINT32` number of user events:
```c
#include <SDL3/SDL.h>

int main()
{
    int numevents;
    Uint32 event_base;
    
    numevents = SDL_MAX_SINT32;
    event_base = SDL_RegisterEvents(numevents);
    SDL_Log("SDL_RegisterEvents(%d): %"SDL_PRIu32, numevents, event_base);
    
    numevents = 1;
    event_base = SDL_RegisterEvents(numevents);
    SDL_Log("SDL_RegisterEvents(%d): %"SDL_PRIu32, numevents, event_base);
    
    return 0;
}
```
output:
```
SDL_RegisterEvents(2147483647): 32768
SDL_RegisterEvents(1): 0
```

---

example 2, register `SDL_EVENT_LAST - SDL_EVENT_USER` number of user events (so that there is still one free user event number)
and then register `SDL_MAX_SINT32` user events:
```c
#include <SDL3/SDL.h>

int main()
{
    int numevents;
    Uint32 event_base;
    
    numevents = SDL_EVENT_LAST - SDL_EVENT_USER;
    event_base = SDL_RegisterEvents(numevents);
    SDL_Log("SDL_RegisterEvents(%d): %"SDL_PRIu32, numevents, event_base);
    
    numevents = SDL_MAX_SINT32;
    event_base = SDL_RegisterEvents(numevents);
    SDL_Log("SDL_RegisterEvents(%d): %"SDL_PRIu32, numevents, event_base);
    
    numevents = 1;
    event_base = SDL_RegisterEvents(numevents);
    SDL_Log("SDL_RegisterEvents(%d): %"SDL_PRIu32, numevents, event_base);
    
    return 0;
}
```
output:
```c
SDL_RegisterEvents(32767): 32768
SDL_RegisterEvents(2147483647): 65535
SDL_RegisterEvents(1): 0
```