### PR TITLE
x11: Ensure that parent windows for a dialog are from the X11 driver

### DIFF
--- a/src/video/x11/SDL_x11messagebox.c
+++ b/src/video/x11/SDL_x11messagebox.c
@@ -288,6 +288,8 @@ static void X11_OnMessageBoxScaleChange(SDL_ToolkitWindowX11 *window, void *data
 
 static bool X11_ShowMessageBoxImpl(const SDL_MessageBoxData *messageboxdata, int *buttonID)
 {
+    SDL_VideoDevice *video = SDL_GetVideoDevice();
+    SDL_Window *parent_window = NULL;
     SDL_MessageBoxControlsX11 controls;
     SDL_MessageBoxCallbackDataX11 data;
     const SDL_MessageBoxColor *colorhints;
@@ -305,10 +307,14 @@ static bool X11_ShowMessageBoxImpl(const SDL_MessageBoxData *messageboxdata, int
     }
 
     /* Create window */
+    if (messageboxdata->window && SDL_strcmp(video->name, "x11") == 0) {
+        // Only use the window as a parent if it is from the X11 driver.
+        parent_window = messageboxdata->window;
+    }
 #if SDL_FORK_MESSAGEBOX
-    controls.window = X11Toolkit_CreateWindowStruct(messageboxdata->window, NULL, SDL_TOOLKIT_WINDOW_MODE_X11_DIALOG, colorhints, true);
+    controls.window = X11Toolkit_CreateWindowStruct(parent_window, NULL, SDL_TOOLKIT_WINDOW_MODE_X11_DIALOG, colorhints, true);
 #else 
-    controls.window = X11Toolkit_CreateWindowStruct(messageboxdata->window, NULL, SDL_TOOLKIT_WINDOW_MODE_X11_DIALOG, colorhints, false);
+    controls.window = X11Toolkit_CreateWindowStruct(parent_window, NULL, SDL_TOOLKIT_WINDOW_MODE_X11_DIALOG, colorhints, false);
 #endif
     controls.window->cb_data = &controls;
     controls.window->cb_on_scale_change = X11_OnMessageBoxScaleChange;


### PR DESCRIPTION
If the system doesn't have Zenity installed, message boxes can fall back to the X11 toolkit while the Wayland driver is in use, in which case, a Wayland window may be set as a parent to an X11 dialog. Ensure that the parent window for an X11 dialog is actually an X11 window.

Fixes #14273