### PR TITLE
Add option "--exit-after-ms N" to automatically exit tests after N ms

### DIFF
--- a/include/SDL3/SDL_test_common.h
+++ b/include/SDL3/SDL_test_common.h
@@ -153,6 +153,10 @@ typedef struct
     SDL_Rect confine;
     bool hide_cursor;
 
+    /* Misc. */
+    int quit_after_ms_interval;
+    SDL_TimerID quit_after_ms_timer;
+
     /* Options info */
     SDLTest_ArgumentParser common_argparser;
     SDLTest_ArgumentParser video_argparser;


### PR DESCRIPTION
Add option "--exit-after-ms N" to automatically exit tests after N ms

so that it's easier to automate tests by running suite of programs 