### PR TITLE
Fixed crash in Cocoa path when SDL_RedrawCursor sends NULL to ShowCursor

### DIFF
--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -275,11 +275,13 @@ static bool Cocoa_ShowCursor(SDL_Cursor *cursor)
         SDL_VideoDevice *device = SDL_GetVideoDevice();
         SDL_Window *window = (device ? device->windows : NULL);
 
-        SDL_CursorData *cdata = cursor->internal;
-        cdata->current_frame = 0;
-        if (cdata->frameTimer) {
-            [cdata->frameTimer invalidate];
-            cdata->frameTimer = nil;
+        if (cursor != NULL) {
+            SDL_CursorData *cdata = cursor->internal;
+            cdata->current_frame = 0;
+            if (cdata->frameTimer) {
+                [cdata->frameTimer invalidate];
+                cdata->frameTimer = nil;
+            }
         }
 
         for (; window != NULL; window = window->next) {


### PR DESCRIPTION
A recent [patch](https://github.com/libsdl-org/SDL/pull/14241) introduced a crash in the Cocoa path when using relative cursor mode.

In `SDL_RedrawCursor`, there is a code path that sets the cursor to `NULL` and calls `mouse->ShowCursor(cursor)`. The Cocoa path then attempts to read cursor fields from a `NULL` pointer and crashes.
https://github.com/libsdl-org/SDL/blob/3669920fddcc418c5f9aca97e77a3f380308d9c0/src/events/SDL_mouse.c#L1809
https://github.com/libsdl-org/SDL/blob/3669920fddcc418c5f9aca97e77a3f380308d9c0/src/video/cocoa/SDL_cocoamouse.m#L278

I simply added a NULL check. 