### PR TITLE
If VULKAN_Submit fails during VULKAN_INTERNAL_CreateTexture, destroy the texture and return NULL

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -5886,7 +5886,10 @@ static VulkanTexture *VULKAN_INTERNAL_CreateTexture(
             VULKAN_TEXTURE_USAGE_MODE_UNINITIALIZED,
             texture);
         VULKAN_INTERNAL_TrackTexture(barrierCommandBuffer, texture);
-        VULKAN_Submit((SDL_GPUCommandBuffer *)barrierCommandBuffer);
+        if (!VULKAN_Submit((SDL_GPUCommandBuffer *)barrierCommandBuffer)) {
+            VULKAN_INTERNAL_DestroyTexture(renderer, texture);
+            return NULL;
+        }
     }
 
     return texture;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Right now if a vulkan submit fails during texture creation, we potentially return a partially initialized texture to the caller and it's not possible for them to sense that a failed submit happened other than by examining SDL log messages.

(I have an intermittent bug where my game stops rendering and SDL spams log messages like `vkQueueSubmit VK_ERROR_DEVICE_LOST` indefinitely; examining logs and SDL_gpu code suggests that it probably is happening during texture creation.)

cc @thatcosmonaut 

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
