### PR TITLE
wayland: Add support for the experimental xx-zones-v1 protocol

### DIFF
--- a/docs/README-wayland.md
+++ b/docs/README-wayland.md
@@ -6,6 +6,25 @@ encounter limitations or behavior that is different from other windowing systems
 
 ## Common issues:
 
+### ```SDL_SetWindowPosition()``` doesn't work on non-popup windows
+
+- Wayland requires the `xx-zones-v1` extension to position windows programmatically. Otherwise, toplevel windows may
+  not be positioned programmatically.\
+  \
+  Enabling this protocol requires setting the `SDL_VIDEO_WAYLAND_ENABLE_ZONES` hint to `1`. After initializing the video
+  subsystem, compositor support for the required protocol may be queried via the
+  `SDL_PROP_GLOBAL_VIDEO_WAYLAND_HAS_ZONES_BOOLEAN` global video property.\
+  \
+  This protocol allows for positioning windows within the boundaries of desktop zones, the coordinates of which may not
+  correspond 1:1 to output display coordinates. This is primarily intended for clients with multi-window interfaces that
+  need to position windows relative to one another, development environments/workflows, and embedded scenarios where
+  positioning is desired and the underlying environment and its capabilities are known. Single window clients should
+  _not_ enable this by default, as it can override compositor window positioning, and tiling window managers in
+  particular may demonstrate undesirable behavior with it.\
+  \
+  Enabling zones on KDE requires a plugin that implements the protocol, which can be found at
+  [https://invent.kde.org/automotive/kwin-zones]().
+
 ### Legacy, DPI-unaware applications are blurry
 
 - Wayland handles high-DPI displays by scaling the desktop, which causes applications that are not designed to be
@@ -33,10 +52,6 @@ encounter limitations or behavior that is different from other windowing systems
 - Wayland doesn't natively have the concept of a primary display, so SDL attempts to determine it by querying various
   system settings, and falling back to a selection algorithm if this fails. If it is incorrect, it can be manually
   overridden by setting the ```SDL_VIDEO_DISPLAY_PRIORITY``` hint.
-
-### ```SDL_SetWindowPosition()``` doesn't work on non-popup windows
-
-- Wayland does not allow toplevel windows to position themselves programmatically.
 
 ### Retrieving the global mouse cursor position when the cursor is outside a window doesn't work
 

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -4007,6 +4007,34 @@ extern "C" {
 #define SDL_HINT_VIDEO_WAYLAND_ALLOW_LIBDECOR "SDL_VIDEO_WAYLAND_ALLOW_LIBDECOR"
 
 /**
+ * A variable controlling whether to allow positioning of windows via the
+ * `ext-zones-v1` protocol.
+ *
+ * This hint requires that the compositor supports the `ext-zones-v1` protocol.
+ * Support for this protocol can be checked via the global
+ * `SDL_PROP_GLOBAL_VIDEO_WAYLAND_HAS_ZONES_BOOLEAN` property after initializing
+ * the video subsystem with this hint set.
+ *
+ * If the compositor lacks support for the required protocol, this hint does
+ * nothing.
+ *
+ * Zones are arbitrary regions that allow for limited window placement within a
+ * logical space, and should not be presumed to correlate 1:1 to display output
+ * coordinates, so care must be taken when enabling this. See
+ * docs/README-wayland.md and wayland-protocols/ext-zones-v1.xml for more details.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "0": positioning with ext-zones is disabled. (default)
+ * - "1": positioning with ext-zones is enabled.
+ *
+ * This hint should be set before SDL is initialized.
+ *
+ * \since This hint is available since SDL 3.1.6.
+ */
+#define SDL_HINT_VIDEO_WAYLAND_ENABLE_ZONES "SDL_VIDEO_WAYLAND_ENABLE_ZONES"
+
+/**
  * A variable controlling whether video mode emulation is enabled under
  * Wayland.
  *

--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -103,6 +103,16 @@ typedef Uint32 SDL_WindowID;
 #define SDL_PROP_GLOBAL_VIDEO_WAYLAND_WL_DISPLAY_POINTER "SDL.video.wayland.wl_display"
 
 /**
+ * A boolean set to true if the windowing system supports the optional
+ * ext-zones protocol for positioning windows in Wayland. Requires that the
+ * `SDL_VIDEO_WAYLAND_ENABLE_ZONES` hint be set to enable. See
+ * docs/README-wayland.md for more information.
+ *
+ * Can be queried after video subsystem initialization.
+ */
+#define SDL_PROP_GLOBAL_VIDEO_WAYLAND_HAS_ZONES_BOOLEAN "SDL.video.wayland.has_zones"
+
+/**
  * System theme.
  *
  * \since This enum is available since SDL 3.2.0.

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -70,6 +70,7 @@
 #include "pointer-warp-v1-client-protocol.h"
 #include "pointer-gestures-unstable-v1-client-protocol.h"
 #include "single-pixel-buffer-v1-client-protocol.h"
+#include "xx-zones-v1-client-protocol.h"
 
 #ifdef HAVE_LIBDECOR_H
 #include <libdecor.h>
@@ -455,6 +456,7 @@ static void handle_wl_output_done(void *data, struct wl_output *output);
 // Initialization/Query functions
 static bool Wayland_VideoInit(SDL_VideoDevice *_this);
 static bool Wayland_GetDisplayBounds(SDL_VideoDevice *_this, SDL_VideoDisplay *display, SDL_Rect *rect);
+static bool Wayland_GetDisplayUsableBounds(SDL_VideoDevice *_this, SDL_VideoDisplay *display, SDL_Rect *rect);
 static void Wayland_VideoQuit(SDL_VideoDevice *_this);
 
 static const char *SDL_WAYLAND_surface_tag = "sdl-window";
@@ -674,6 +676,7 @@ static SDL_VideoDevice *Wayland_CreateDevice(bool require_preferred_protocols)
     device->VideoInit = Wayland_VideoInit;
     device->VideoQuit = Wayland_VideoQuit;
     device->GetDisplayBounds = Wayland_GetDisplayBounds;
+    device->GetDisplayUsableBounds = Wayland_GetDisplayUsableBounds;
     device->SuspendScreenSaver = Wayland_SuspendScreenSaver;
 
     device->PumpEvents = Wayland_PumpEvents;
@@ -720,6 +723,7 @@ static SDL_VideoDevice *Wayland_CreateDevice(bool require_preferred_protocols)
     device->GetWindowSizeInPixels = Wayland_GetWindowSizeInPixels;
     device->GetWindowContentScale = Wayland_GetWindowContentScale;
     device->GetWindowICCProfile = Wayland_GetWindowICCProfile;
+    device->GetWindowBordersSize = Wayland_GetWindowBorderSize;
     device->GetDisplayForWindow = Wayland_GetDisplayForWindow;
     device->DestroyWindow = Wayland_DestroyWindow;
     device->SetWindowHitTest = Wayland_SetWindowHitTest;
@@ -790,7 +794,86 @@ VideoBootStrap Wayland_bootstrap = {
     false
 };
 
-static void handle_xdg_output_logical_position(void *data, struct zxdg_output_v1 *xdg_output, int32_t x, int32_t y)
+static void handle_zone_size(void *data, struct xx_zone_v1 *ext_zone_v1, int32_t width, int32_t height)
+{
+    SDL_DisplayData *disp = (SDL_DisplayData *)data;
+
+    // Negative size values mean that zone creation on this output was denied.
+    if (width < 0 || height < 0) {
+        xx_zone_v1_destroy(disp->ext_zone_v1);
+        disp->ext_zone_v1 = NULL;
+        return;
+    }
+
+    disp->logical.zone_width = width ? width : SDL_MAX_SINT32;
+    disp->logical.zone_height = height ? height : SDL_MAX_SINT32;
+
+    if (disp->display) {
+        SDL_VideoDisplay *display = SDL_GetVideoDisplay(disp->display);
+        if (display) {
+            SDL_SendDisplayEvent(display, SDL_EVENT_DISPLAY_USABLE_BOUNDS_CHANGED, width, height);
+        }
+    }
+}
+
+static void handle_zone_handle(void *data, struct xx_zone_v1 *ext_zone_v1, const char *handle)
+{
+    // NOP
+}
+
+static void handle_zone_done(void *data, struct xx_zone_v1 *ext_zone_v1)
+{
+    // NOP
+}
+
+static void handle_zone_item_blocked(void *data, struct xx_zone_v1 *ext_zone_v1, struct xx_zone_item_v1 *item)
+{
+    SDL_WindowData *wind = (SDL_WindowData *)xx_zone_item_v1_get_user_data(item);
+    wind->entering_new_zone = false;
+}
+
+static void handle_zone_item_entered(void *data, struct xx_zone_v1 *ext_zone_v1, struct xx_zone_item_v1 *item)
+{
+    if (item) {
+        SDL_WindowData *wind = (SDL_WindowData *)xx_zone_item_v1_get_user_data(item);
+        wind->current_ext_zone_v1 = ext_zone_v1;
+
+        if (wind->entering_new_zone) {
+            Wayland_ApplyZoneItemPosition(wind);
+        }
+
+        wind->entering_new_zone = false;
+    }
+}
+
+static void handle_zone_item_left(void *data, struct xx_zone_v1 *ext_zone_v1, struct xx_zone_item_v1 *item)
+{
+    if (item) {
+        SDL_WindowData *wind = (SDL_WindowData *)xx_zone_item_v1_get_user_data(item);
+        wind->current_ext_zone_v1 = NULL;
+
+        if (!wind->entering_new_zone) {
+            // If leaving a zone without a new join pending, find a new zone to join.
+            const SDL_DisplayData *display = Wayland_GetDisplayForWindowZone(wind, wind->sdlwindow->floating.x, wind->sdlwindow->floating.y, ext_zone_v1);
+
+            if (display) {
+                xx_zone_v1_add_item(display->ext_zone_v1, item);
+            }
+        }
+    }
+}
+
+static const struct xx_zone_v1_listener zone_listener = {
+    handle_zone_size,
+    handle_zone_handle,
+    handle_zone_done,
+    handle_zone_item_blocked,
+    handle_zone_item_entered,
+    handle_zone_item_left
+};
+
+static void handle_xdg_output_logical_position(void *data, struct zxdg_output_v1 *xdg_output,
+                                               int32_t x, int32_t y)
 {
     SDL_DisplayData *internal = (SDL_DisplayData *)data;
 
@@ -1258,6 +1341,10 @@ static bool Wayland_add_display(SDL_VideoData *d, uint32_t id, uint32_t version)
             Wayland_GetColorInfoForOutput(data, true);
         }
     }
+    if (data->videodata->ext_zone_manager_v1) {
+        data->ext_zone_v1 = xx_zone_manager_v1_get_zone(d->ext_zone_manager_v1, output);
+        xx_zone_v1_add_listener(data->ext_zone_v1, &zone_listener, data);
+    }
     return true;
 }
 
@@ -1278,6 +1365,10 @@ static void Wayland_free_display(SDL_VideoDisplay *display, bool send_event)
         if (display_data->wp_color_management_output) {
             Wayland_FreeColorInfoState(display_data->color_info_state);
             wp_color_management_output_v1_destroy(display_data->wp_color_management_output);
+        }
+
+        if (display_data->ext_zone_v1) {
+            xx_zone_v1_destroy(display_data->ext_zone_v1);
         }
 
         if (display_data->xdg_output) {
@@ -1322,6 +1413,16 @@ static void Wayland_InitColorManager(SDL_VideoData *d)
         disp->wp_color_management_output = wp_color_manager_v1_get_output(disp->videodata->wp_color_manager_v1, disp->output);
         wp_color_management_output_v1_add_listener(disp->wp_color_management_output, &wp_color_management_output_listener, disp);
         Wayland_GetColorInfoForOutput(disp, true);
+    }
+}
+
+static void Wayland_InitZoneManager(SDL_VideoData *d)
+{
+    for (int i = 0; i < d->output_count; ++i) {
+        SDL_DisplayData *disp = d->output_list[i];
+        disp->ext_zone_v1 = xx_zone_manager_v1_get_zone(d->ext_zone_manager_v1, disp->output);
+        xx_zone_v1_add_listener(disp->ext_zone_v1, &zone_listener, disp);
+
     }
 }
 
@@ -1424,6 +1525,11 @@ static void handle_registry_global(void *data, struct wl_registry *registry, uin
         Wayland_DisplayInitPointerGestureManager(d);
     } else if (SDL_strcmp(interface, wp_single_pixel_buffer_manager_v1_interface.name) == 0) {
         d->single_pixel_buffer_manager = wl_registry_bind(d->registry, id, &wp_single_pixel_buffer_manager_v1_interface, 1);
+    } else if (SDL_strcmp(interface, xx_zone_manager_v1_interface.name) == 0) {
+        if (SDL_GetHintBoolean(SDL_HINT_VIDEO_WAYLAND_ENABLE_ZONES, false)) {
+            d->ext_zone_manager_v1 = wl_registry_bind(d->registry, id, &xx_zone_manager_v1_interface, 1);
+            Wayland_InitZoneManager(d);
+        }
     }
 #ifdef SDL_WL_FIXES_VERSION
     else if (SDL_strcmp(interface, wl_fixes_interface.name) == 0) {
@@ -1632,6 +1738,8 @@ bool Wayland_VideoInit(SDL_VideoDevice *_this)
     Wayland_InitMouse(data);
     Wayland_InitKeyboard(_this);
 
+    SDL_SetBooleanProperty(SDL_GetGlobalProperties(), SDL_PROP_GLOBAL_VIDEO_WAYLAND_HAS_ZONES_BOOLEAN, !!data->ext_zone_manager_v1);
+
     if (data->primary_selection_device_manager) {
         _this->SetPrimarySelectionText = Wayland_SetPrimarySelectionText;
         _this->GetPrimarySelectionText = Wayland_GetPrimarySelectionText;
@@ -1677,6 +1785,30 @@ static bool Wayland_GetDisplayBounds(SDL_VideoDevice *_this, SDL_VideoDisplay *d
         }
     }
     return true;
+}
+
+static bool Wayland_GetDisplayUsableBounds(SDL_VideoDevice *_this, SDL_VideoDisplay *display, SDL_Rect *rect)
+{
+    SDL_VideoData *viddata = _this->internal;
+    SDL_DisplayData *internal = display->internal;
+
+    if (internal->ext_zone_v1) {
+        if (!viddata->scale_to_display_enabled) {
+            rect->x = internal->logical.x;
+            rect->y = internal->logical.y;
+            rect->w = internal->logical.zone_width;
+            rect->h = internal->logical.zone_height;
+        } else {
+            rect->x = internal->pixel.x;
+            rect->y = internal->pixel.y;
+            rect->w = internal->pixel.zone_width;
+            rect->h = internal->pixel.zone_height;
+        }
+
+        return true;
+    }
+
+    return Wayland_GetDisplayBounds(_this, display, rect);
 }
 
 static void Wayland_VideoCleanup(SDL_VideoDevice *_this)
@@ -1810,6 +1942,11 @@ static void Wayland_VideoCleanup(SDL_VideoDevice *_this)
     if (data->xdg_toplevel_icon_manager_v1) {
         xdg_toplevel_icon_manager_v1_destroy(data->xdg_toplevel_icon_manager_v1);
         data->xdg_toplevel_icon_manager_v1 = NULL;
+    }
+
+    if (data->ext_zone_manager_v1) {
+        xx_zone_manager_v1_destroy(data->ext_zone_manager_v1);
+        data->ext_zone_manager_v1 = NULL;
     }
 
     if (data->frog_color_management_factory_v1) {

--- a/src/video/wayland/SDL_waylandvideo.h
+++ b/src/video/wayland/SDL_waylandvideo.h
@@ -87,6 +87,7 @@ struct SDL_VideoData
     struct wl_fixes *wl_fixes;
     struct zwp_pointer_gestures_v1 *zwp_pointer_gestures;
     struct wp_single_pixel_buffer_manager_v1 *single_pixel_buffer_manager;
+    struct xx_zone_manager_v1 *ext_zone_manager_v1;
 
     struct xkb_context *xkb_context;
 
@@ -111,6 +112,7 @@ struct SDL_DisplayData
     struct wl_output *output;
     struct zxdg_output_v1 *xdg_output;
     struct wp_color_management_output_v1 *wp_color_management_output;
+    struct xx_zone_v1 *ext_zone_v1;
     struct Wayland_ColorInfoState *color_info_state;
     char *wl_output_name;
     double scale_factor;
@@ -122,6 +124,8 @@ struct SDL_DisplayData
         int y;
         int width;
         int height;
+        int zone_width;
+        int zone_height;
     } logical;
 
     struct
@@ -130,6 +134,8 @@ struct SDL_DisplayData
         int y;
         int width;
         int height;
+        int zone_width;
+        int zone_height;
     } pixel;
 
     struct

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -48,6 +48,7 @@
 #include "frog-color-management-v1-client-protocol.h"
 #include "xdg-toplevel-icon-v1-client-protocol.h"
 #include "color-management-v1-client-protocol.h"
+#include "xx-zones-v1-client-protocol.h"
 
 #ifdef HAVE_LIBDECOR_H
 #include <libdecor.h>
@@ -626,6 +627,73 @@ static void ConfigureWindowGeometry(SDL_Window *window)
     }
 }
 
+SDL_DisplayData *Wayland_GetDisplayForWindowZone(SDL_WindowData *wind, int x, int y, struct xx_zone_v1 *ignore_zone)
+{
+    SDL_VideoData *vid = wind->waylandData;
+
+    if (!vid->ext_zone_manager_v1) {
+        return NULL;
+    }
+
+    SDL_DisplayData *dst_display = NULL;
+    SDL_DisplayData *overlapped_display = NULL;
+    SDL_DisplayData *closest_display = NULL;
+    x -= wind->borders.left;
+    y -= wind->borders.top;
+    const SDL_Rect window_rect = { x, y,
+                                   wind->current.logical_width + wind->borders.left + wind->borders.right,
+                                   wind->current.logical_height + wind->borders.top + wind->borders.bottom };
+    int closest_distance = SDL_MAX_SINT32;
+    int overlapped_area = 0;
+
+    /* Find the best zone for window placement:
+     *  - If part of the window overlaps one or more zones, the zone most overlapped by the window is used, otherwise:
+     *    - When searching for a zone because one was left, the zone being left is ignored, and only overlapping
+     *      zones are considered. If none is found, NULL is returned.
+     *    - When searching for a zone due to an explicit position request, the closest zone will be used if the window
+     *      is completely out of bounds.
+     */
+    for (int i = 0; i < vid->output_count; i++) {
+        SDL_DisplayData *disp = vid->output_list[i];
+
+        // Don't try to reenter a zone that is being left.
+        if (ignore_zone && disp->ext_zone_v1 == ignore_zone) {
+            continue;
+        }
+
+        // Find the zone with the most window overlap.
+        const SDL_Rect display_rect = { disp->logical.x, disp->logical.y, disp->logical.zone_width, disp->logical.zone_height };
+        SDL_Rect overlap;
+        if (SDL_GetRectIntersection(&window_rect, &display_rect, &overlap)) {
+            const int area = overlap.w * overlap.h;
+            if (overlapped_area < area) {
+                overlapped_area = area;
+                overlapped_display = disp;
+            }
+        }
+
+        // Find the closest zone as a fallback if the window is completely out of bounds.
+        const int dx = disp->logical.x - x;
+        const int dy = disp->logical.y - y;
+        const int distance = SDL_abs((dx * dx) + (dy * dy));
+
+        if (distance < closest_distance) {
+            closest_distance = distance;
+            closest_display = disp;
+        }
+    }
+
+    if (!dst_display) {
+        if (overlapped_display) {
+            dst_display = overlapped_display;
+        } else if (!ignore_zone) {
+            dst_display = closest_display;
+        }
+    }
+
+    return dst_display;
+}
+
 static void CommitLibdecorFrame(SDL_Window *window)
 {
 #ifdef HAVE_LIBDECOR_H
@@ -655,6 +723,17 @@ static void pending_state_deadline_handler(void *data, struct wl_callback *callb
 static struct wl_callback_listener pending_state_deadline_listener = {
     pending_state_deadline_handler
 };
+
+static void CommitPendingState(SDL_WindowData *window_data, bool position_only)
+{
+    // Don't commit with empty geometry, as it is technically a protocol violation.
+    if (window_data->shell_surface_status == WAYLAND_SHELL_SURFACE_STATUS_SHOWN &&
+        window_data->pending_state_flags &&
+        (!position_only || (window_data->pending_state_flags & WAYLAND_PENDING_STATE_POSITION))) {
+        wl_surface_commit(window_data->surface);
+        window_data->pending_state_flags = WAYLAND_PENDING_STATE_NONE;
+    }
+}
 
 static void AddPendingStateSync(SDL_WindowData *window_data)
 {
@@ -717,12 +796,18 @@ void Wayland_UpdateWindowPosition(SDL_Window *window)
      */
     wind->last_displayID = display->display;
     if (wind->shell_surface_type != WAYLAND_SHELL_SURFACE_TYPE_XDG_POPUP) {
-        if (!wind->waylandData->scale_to_display_enabled) {
-            SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_MOVED, display->logical.x, display->logical.y);
-        } else {
-            SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_MOVED, display->pixel.x, display->pixel.y);
+        if (!wind->current_ext_zone_v1) {
+            if (!wind->waylandData->scale_to_display_enabled) {
+                SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_MOVED, display->logical.x, display->logical.y);
+            } else {
+                SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_MOVED, display->pixel.x, display->pixel.y);
+            }
         }
         SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_DISPLAY_CHANGED, wind->last_displayID, 0);
+    }
+
+    if (display->ext_zone_v1 && wind->ext_zone_item_v1 && !wind->current_ext_zone_v1) {
+        xx_zone_v1_add_item(display->ext_zone_v1, wind->ext_zone_item_v1);
     }
 }
 
@@ -816,7 +901,7 @@ static void surface_frame_done(void *data, struct wl_callback *cb, uint32_t time
         wl_surface_damage(wind->surface, 0, 0, SDL_MAX_SINT32, SDL_MAX_SINT32);
     }
 
-    wind->pending_state_commit = false;
+    wind->pending_state_flags = WAYLAND_PENDING_STATE_NONE;
 
     if (wind->shell_surface_type == WAYLAND_SHELL_SURFACE_TYPE_XDG_TOPLEVEL) {
         if (wind->pending_config_ack) {
@@ -830,6 +915,13 @@ static void surface_frame_done(void *data, struct wl_callback *cb, uint32_t time
 
     if (wind->shell_surface_status == WAYLAND_SHELL_SURFACE_STATUS_WAITING_FOR_FRAME) {
         wind->shell_surface_status = WAYLAND_SHELL_SURFACE_STATUS_SHOWN;
+
+        wind->adjust_initial_position = false;
+
+        if (wind->ext_zone_item_v1 && wind->current_ext_zone_v1) {
+            // If the window is in a zone, send the initial coordinates after mapping.
+            SDL_SendWindowEvent(wind->sdlwindow, SDL_EVENT_WINDOW_MOVED, wind->last_configure.x, wind->last_configure.y);
+        }
 
         // If any child windows are waiting on this window to be shown, show them now
         for (SDL_Window *w = wind->sdlwindow->first_child; w; w = w->next_sibling) {
@@ -1805,6 +1897,15 @@ void Wayland_RemoveOutputFromWindow(SDL_WindowData *window, SDL_DisplayData *dis
         }
     }
 
+    if (window->current_ext_zone_v1 == display_data->ext_zone_v1) {
+        if (window->num_outputs) {
+            struct xx_zone_v1 *new_zone = window->outputs[window->num_outputs - 1]->ext_zone_v1;
+            if (new_zone) {
+                xx_zone_v1_add_item(new_zone, window->ext_zone_item_v1);
+            }
+        }
+    }
+
     if (window->num_outputs == 0) {
         SDL_free(window->outputs);
         window->outputs = NULL;
@@ -2074,6 +2175,211 @@ static struct zxdg_exported_v2_listener exported_v2_listener = {
     exported_handle_handler
 };
 
+void Wayland_ApplyZoneItemPosition(SDL_WindowData *wind)
+{
+    if (wind->current_ext_zone_v1) {
+        SDL_DisplayData *dst_display = xx_zone_v1_get_user_data(wind->current_ext_zone_v1);
+
+        // Part of the window must be within zone bounds (a size of 0 means that a zone is infinite in that direction).
+        const int min_x = -(wind->current.logical_width + wind->borders.left + wind->borders.right - 1);
+        const int min_y = -(wind->current.logical_height + wind->borders.top + wind->borders.bottom - 1);
+        int x = wind->requested.logical_x - wind->borders.left - dst_display->logical.x;
+        int y = wind->requested.logical_y - wind->borders.top - dst_display->logical.y;
+        x = SDL_clamp(x, min_x, dst_display->logical.zone_width - 1);
+        y = SDL_clamp(y, min_y, dst_display->logical.zone_height - 1);
+
+        xx_zone_item_v1_set_position(wind->ext_zone_item_v1, x, y);
+        wind->pending_state_flags |= WAYLAND_PENDING_STATE_POSITION;
+        AddPendingStateSync(wind);
+    }
+}
+
+static bool Wayland_PixelPositionToLogical(SDL_WindowData *wind, int pixel_x, int pixel_y, int *logical_x, int *logical_y, SDL_DisplayData **output)
+{
+    SDL_VideoData *vid = wind->waylandData;
+
+    SDL_DisplayData *dst_display = NULL;
+    SDL_DisplayData *overlapped_display = NULL;
+    SDL_DisplayData *closest_display = NULL;
+    const SDL_Rect window_rect = { pixel_x, pixel_y, wind->current.pixel_width, wind->current.pixel_height };
+    int overlapped_area = 0;
+    int closest_distance = 0;
+
+    // Find the pixel coordinates of the display
+    for (int i = 0; i < vid->output_count; i++) {
+        SDL_DisplayData *disp = vid->output_list[i];
+
+        // If the window origin is within a display, use that one.
+        if (pixel_x >= disp->pixel.x && pixel_x < disp->pixel.x + disp->pixel.width &&
+            pixel_y >= disp->pixel.y && pixel_y < disp->pixel.y + disp->pixel.height) {
+            dst_display = disp;
+            break;
+        }
+
+        // Find the display with the most window overlap.
+        const SDL_Rect display_rect = { disp->pixel.x, disp->pixel.y, disp->pixel.width, disp->pixel.height };
+        SDL_Rect overlap;
+        if (SDL_GetRectIntersection(&window_rect, &display_rect, &overlap)) {
+            const int area = overlap.w * overlap.h;
+            if (overlapped_area < area) {
+                overlapped_area = area;
+                overlapped_display = disp;
+            }
+        }
+
+        // Find the closest zone as a fallback if the window is completely out of bounds.
+        const int dx = disp->pixel.x - pixel_x;
+        const int dy = disp->pixel.y - pixel_y;
+        const int distance = SDL_abs((dx * dx) + (dy * dy));
+
+        if (distance < closest_distance) {
+            closest_distance = distance;
+            closest_display = disp;
+        }
+    }
+
+    if (!dst_display) {
+        if (overlapped_display) {
+            dst_display = overlapped_display;
+        } else {
+            dst_display = closest_display;
+        }
+    }
+
+    if (dst_display) {
+        const double dx = (double)(pixel_x - dst_display->pixel.x) / (double)dst_display->pixel.width;
+        const double dy = (double)(pixel_y - dst_display->pixel.y) / (double)dst_display->pixel.height;
+
+        *logical_x = dst_display->logical.x + (int)SDL_floor(dx * (double)dst_display->logical.width);
+        *logical_y = dst_display->logical.y + (int)SDL_floor(dy * (double)dst_display->logical.height);
+        *output = dst_display;
+
+        return true;
+    }
+
+    return false;
+}
+
+static bool Wayland_LogicalPositionToPixel(SDL_DisplayData *dst_display, int logical_x, int logical_y, int *pixel_x, int *pixel_y)
+{
+    if (dst_display) {
+        const double dx = (double)(logical_x - dst_display->logical.x) / (double)dst_display->logical.width;
+        const double dy = (double)(logical_y - dst_display->logical.y) / (double)dst_display->logical.height;
+
+        *pixel_x = dst_display->pixel.x + (int)SDL_floor(dx * (double)dst_display->pixel.width);
+        *pixel_y = dst_display->pixel.y + (int)SDL_floor(dy * (double)dst_display->pixel.height);
+
+        return true;
+    }
+
+    return false;
+}
+
+static bool Wayland_PositionWindowInZone(SDL_WindowData *wind)
+{
+    SDL_DisplayData *dst_display = NULL;
+    int x, y;
+    if (!wind->scale_to_display) {
+        x = wind->requested.logical_x;
+        y = wind->requested.logical_y;
+    } else {
+        if (!Wayland_PixelPositionToLogical(wind, wind->requested.pixel_x, wind->requested.pixel_y, &x, &y, &dst_display)) {
+            return SDL_SetError("cannot position window: cannot convert requested pixel coordinates to logical");
+        }
+
+        wind->requested.logical_x = x;
+        wind->requested.logical_y = y;
+    }
+
+    if (!dst_display) {
+        dst_display = Wayland_GetDisplayForWindowZone(wind, x, y, NULL);
+    }
+    if (dst_display) {
+        struct xx_zone_v1 *dst_zone = dst_display->ext_zone_v1;
+
+        /* If the new position is in the current zone, just change the position,
+         * otherwise, select a new zone, and the position will be set upon entry.
+         */
+        if (wind->current_ext_zone_v1 != dst_zone) {
+            wind->entering_new_zone = true;
+            xx_zone_v1_add_item(dst_zone, wind->ext_zone_item_v1);
+        } else {
+            Wayland_ApplyZoneItemPosition(wind);
+        }
+
+        return true;
+    }
+
+    return SDL_SetError("cannot position window: no zone available");
+}
+
+static void handle_ext_zone_item_v1_frame_extents(void *data, struct xx_zone_item_v1 *ext_zone_item_v1,
+                                                  int32_t top, int32_t bottom, int32_t left, int32_t right)
+{
+    SDL_WindowData *wind = (SDL_WindowData *)data;
+
+    wind->borders.top = top;
+    wind->borders.bottom = bottom;
+    wind->borders.left = left;
+    wind->borders.right = right;
+    wind->borders_changed = true;
+}
+
+static void handle_ext_zone_item_v1_position(void *data, struct xx_zone_item_v1 *item, int32_t x, int32_t y)
+{
+    if (!item) {
+        return;
+    }
+
+    SDL_WindowData *wind = (SDL_WindowData *)data;
+    SDL_DisplayData *disp = (SDL_DisplayData *)xx_zone_v1_get_user_data(wind->current_ext_zone_v1);
+
+    int w_x = disp->logical.x + x + wind->borders.left;
+    int w_y = disp->logical.y + y + wind->borders.top;
+
+    if (wind->scale_to_display) {
+        int pixel_x, pixel_y;
+        if (!Wayland_LogicalPositionToPixel(disp, w_x, w_y, &pixel_x, &pixel_y)) {
+            return;
+        }
+
+        w_x = pixel_x;
+        w_y = pixel_y;
+    }
+    wind->last_configure.x = w_x;
+    wind->last_configure.y = w_y;
+
+    if (wind->shell_surface_status == WAYLAND_SHELL_SURFACE_STATUS_SHOWN) {
+        SDL_SendWindowEvent(wind->sdlwindow, SDL_EVENT_WINDOW_MOVED, w_x, w_y);
+    } else if (wind->shell_surface_status == WAYLAND_SHELL_SURFACE_STATUS_WAITING_FOR_FRAME) {
+        /* If the window is not yet mapped, adjust the initial client area position
+         * to compensate for the borders.
+         */
+        if (wind->adjust_initial_position && wind->borders_changed) {
+            Wayland_PositionWindowInZone(wind);
+        }
+    }
+
+    wind->borders_changed = false;
+}
+
+static void handle_ext_zone_item_v1_position_failed(void *data, struct xx_zone_item_v1 *item)
+{
+    // NOP
+}
+
+static void handle_ext_zone_item_v1_closed(void *data, struct xx_zone_item_v1 *xx_zone_item_v1)
+{
+    // NOP
+}
+
+static const struct xx_zone_item_v1_listener zone_item_listener = {
+    handle_ext_zone_item_v1_frame_extents,
+    handle_ext_zone_item_v1_position,
+    handle_ext_zone_item_v1_position_failed,
+    handle_ext_zone_item_v1_closed
+};
+
 void Wayland_ShowWindow(SDL_VideoDevice *_this, SDL_Window *window)
 {
     SDL_VideoData *c = _this->internal;
@@ -2245,6 +2551,24 @@ void Wayland_ShowWindow(SDL_VideoDevice *_this, SDL_Window *window)
                                                       data->xdg_toplevel_icon_v1);
             }
 
+            if (c->ext_zone_manager_v1) {
+                data->ext_zone_item_v1 = xx_zone_manager_v1_get_zone_item(c->ext_zone_manager_v1, data->shell_surface.xdg.toplevel.xdg_toplevel);
+                xx_zone_item_v1_set_user_data(data->ext_zone_item_v1, data);
+                xx_zone_item_v1_add_listener(data->ext_zone_item_v1, &zone_item_listener, data);
+
+                if (!window->undefined_x && !window->undefined_y) {
+                    data->adjust_initial_position = true;
+                    if (!data->scale_to_display) {
+                        data->requested.logical_x = window->x;
+                        data->requested.logical_y = window->y;
+                    } else {
+                        data->requested.pixel_x = window->x;
+                        data->requested.pixel_y = window->y;
+                    }
+                    Wayland_PositionWindowInZone(data);
+                }
+            }
+
             SDL_SetPointerProperty(props, SDL_PROP_WINDOW_WAYLAND_XDG_TOPLEVEL_POINTER, data->shell_surface.xdg.toplevel.xdg_toplevel);
         }
     }
@@ -2409,6 +2733,12 @@ void Wayland_HideWindow(SDL_VideoDevice *_this, SDL_Window *window)
     }
 
     wind->shell_surface_status = WAYLAND_SHELL_SURFACE_STATUS_HIDDEN;
+
+    if (wind->ext_zone_item_v1) {
+        xx_zone_item_v1_destroy(wind->ext_zone_item_v1);
+        wind->ext_zone_item_v1 = NULL;
+        wind->current_ext_zone_v1 = NULL;
+    }
 
     if (wind->server_decoration) {
         zxdg_toplevel_decoration_v1_destroy(wind->server_decoration);
@@ -2618,9 +2948,7 @@ SDL_FullscreenResult Wayland_SetWindowFullscreen(SDL_VideoDevice *_this, SDL_Win
         }
 
         // Commit to set any pending size or limit data.
-        if (fullscreen && wind->pending_state_commit) {
-            wl_surface_commit(wind->surface);
-        }
+        CommitPendingState(wind, false);
         SetFullscreen(window, output, !!fullscreen);
     } else if (wind->is_fullscreen) {
         /*
@@ -2708,9 +3036,7 @@ void Wayland_SetWindowResizable(SDL_VideoDevice *_this, SDL_Window *window, bool
     SetMinMaxDimensions(window);
     CommitLibdecorFrame(window);
 
-    if (wind->shell_surface_status == WAYLAND_SHELL_SURFACE_STATUS_SHOWN) {
-        wind->pending_state_commit = true;
-    }
+    wind->pending_state_flags |= WAYLAND_PENDING_STATE_SIZE;
 }
 
 void Wayland_MaximizeWindow(SDL_VideoDevice *_this, SDL_Window *window)
@@ -2734,9 +3060,7 @@ void Wayland_MaximizeWindow(SDL_VideoDevice *_this, SDL_Window *window)
         }
 
         // Commit to set any pending size or limit data.
-        if (wind->pending_state_commit) {
-            wl_surface_commit(wind->surface);
-        }
+        CommitPendingState(wind, false);
         libdecor_frame_set_maximized(wind->shell_surface.libdecor.frame);
         AddPendingStateSync(wind);
     } else
@@ -2747,9 +3071,7 @@ void Wayland_MaximizeWindow(SDL_VideoDevice *_this, SDL_Window *window)
         }
 
         // Commit to set any pending size or limit data.
-        if (wind->pending_state_commit) {
-            wl_surface_commit(wind->surface);
-        }
+        CommitPendingState(wind, false);
         xdg_toplevel_set_maximized(wind->shell_surface.xdg.toplevel.xdg_toplevel);
         AddPendingStateSync(wind);
     }
@@ -3073,6 +3395,7 @@ void Wayland_SetWindowAspectRatio(SDL_VideoDevice *_this, SDL_Window *window)
 
 bool Wayland_SetWindowPosition(SDL_VideoDevice *_this, SDL_Window *window)
 {
+    SDL_VideoData *vid = _this->internal;
     SDL_WindowData *wind = window->internal;
 
     // Only popup windows can be positioned relative to the parent.
@@ -3085,9 +3408,8 @@ bool Wayland_SetWindowPosition(SDL_VideoDevice *_this, SDL_Window *window)
         RepositionPopup(window, false);
         return true;
     } else if (wind->shell_surface_type == WAYLAND_SHELL_SURFACE_TYPE_LIBDECOR || wind->shell_surface_type == WAYLAND_SHELL_SURFACE_TYPE_XDG_TOPLEVEL) {
-        /* Catch up on any pending state before attempting to change the fullscreen window
-         * display via a set fullscreen call to make sure the window doesn't have a pending
-         * leave fullscreen event that it might override.
+        /* Catch up on any pending state before attempting to change the position
+         * doesn't have pending state that doing so might override.
          */
         FlushPendingEvents(window);
 
@@ -3099,9 +3421,30 @@ bool Wayland_SetWindowPosition(SDL_VideoDevice *_this, SDL_Window *window)
 
                 return true;
             }
+        } else if (vid->ext_zone_manager_v1) {
+            if (wind->floating) {
+                wind->adjust_initial_position = wind->shell_surface_status == WAYLAND_SHELL_SURFACE_STATUS_WAITING_FOR_FRAME;
+                if (!wind->scale_to_display) {
+                    wind->requested.logical_x = window->pending.x;
+                    wind->requested.logical_y = window->pending.y;
+                } else {
+                    wind->requested.pixel_x = window->pending.x;
+                    wind->requested.pixel_y = window->pending.y;
+                }
+
+                if (wind->ext_zone_item_v1) {
+                    return Wayland_PositionWindowInZone(wind);
+                }
+
+                return true;
+            }
+
+            // Can't move the window in its current state.
+            window->last_position_pending = false;
+            return true;
         }
     }
-    return SDL_SetError("wayland cannot position non-popup windows");
+    return SDL_SetError("cannot position non-popup windows; compositor lacks support for the ext-zone-manager-v1 protocol");
 }
 
 void Wayland_SetWindowSize(SDL_VideoDevice *_this, SDL_Window *window)
@@ -3140,9 +3483,7 @@ void Wayland_SetWindowSize(SDL_VideoDevice *_this, SDL_Window *window)
     }
 
     wind->limits_changed = false;
-    if (wind->shell_surface_status == WAYLAND_SHELL_SURFACE_STATUS_SHOWN) {
-        wind->pending_state_commit = true;
-    }
+    wind->pending_state_flags |= WAYLAND_PENDING_STATE_SIZE;
 
     // Always recalculate the geometry, as this may be in response to a min/max limit change.
     ConfigureWindowGeometry(window);
@@ -3166,6 +3507,29 @@ float Wayland_GetWindowContentScale(SDL_VideoDevice *_this, SDL_Window *window)
     }
 
     return 1.0f;
+}
+
+bool Wayland_GetWindowBorderSize(SDL_VideoDevice *_this, SDL_Window *window, int *top, int *left, int *bottom, int *right)
+{
+    SDL_WindowData *wind = window->internal;
+
+    if (wind->ext_zone_item_v1) {
+        *top = wind->borders.top;
+        *bottom = wind->borders.bottom;
+        *left = wind->borders.left;
+        *right = wind->borders.right;
+
+        if (wind->scale_to_display) {
+            *top = (int)SDL_lround((double)*top * wind->scale_factor);
+            *bottom = (int)SDL_lround((double)*bottom * wind->scale_factor);
+            *left = (int)SDL_lround((double)*left * wind->scale_factor);
+            *right = (int)SDL_lround((double)*right * wind->scale_factor);
+        }
+
+        return true;
+    }
+
+    return SDL_SetError("window border sizes require the ext_zones_v1 protocol");
 }
 
 SDL_DisplayID Wayland_GetDisplayForWindow(SDL_VideoDevice *_this, SDL_Window *window)
@@ -3414,6 +3778,8 @@ bool Wayland_SyncWindow(SDL_VideoDevice *_this, SDL_Window *window)
     SDL_WindowData *wind = window->internal;
 
     do {
+        // Pending size only needs to be committed when entering a fixed-size state, and is not necessary here.
+        CommitPendingState(wind, true);
         WAYLAND_wl_display_roundtrip(_this->internal->display);
     } while (wind->pending_state_deadline_count);
 

--- a/src/video/wayland/SDL_waylandwindow.h
+++ b/src/video/wayland/SDL_waylandwindow.h
@@ -116,10 +116,13 @@ struct SDL_WindowData
     struct xdg_dialog_v1 *xdg_dialog_v1;
     struct wp_alpha_modifier_surface_v1 *wp_alpha_modifier_surface_v1;
     struct xdg_toplevel_icon_v1 *xdg_toplevel_icon_v1;
+    struct xx_zone_item_v1 *ext_zone_item_v1;
     struct frog_color_managed_surface *frog_color_managed_surface;
     struct wp_color_management_surface_feedback_v1 *wp_color_management_surface_feedback;
 
     struct Wayland_ColorInfoState *color_info_state;
+
+    struct xx_zone_v1 *current_ext_zone_v1;
 
     SDL_AtomicInt swap_interval_ready;
 
@@ -153,6 +156,12 @@ struct SDL_WindowData
         // The size of the window in pixels, when using screen space scaling.
         int pixel_width;
         int pixel_height;
+
+        int logical_x;
+        int logical_y;
+
+        int pixel_x;
+        int pixel_y;
     } requested;
 
     // The current size of the window and drawable backing store.
@@ -176,6 +185,9 @@ struct SDL_WindowData
     {
         int width;
         int height;
+
+        int x;
+        int y;
     } last_configure;
 
     // System enforced window size limits.
@@ -213,6 +225,21 @@ struct SDL_WindowData
         bool active;
     } text_input_props;
 
+    struct
+    {
+        int top;
+        int bottom;
+        int left;
+        int right;
+    } borders;
+
+    enum
+    {
+        WAYLAND_PENDING_STATE_NONE = 0,
+        WAYLAND_PENDING_STATE_SIZE = 0x01,
+        WAYLAND_PENDING_STATE_POSITION = 0x02,
+    } pending_state_flags;
+
     SDL_DisplayID last_displayID;
     int pending_state_deadline_count;
     Uint64 last_focus_event_time_ns;
@@ -223,7 +250,6 @@ struct SDL_WindowData
     bool resizing;
     bool active;
     bool pending_config_ack;
-    bool pending_state_commit;
     bool limits_changed;
     bool is_fullscreen;
     bool fullscreen_exclusive;
@@ -234,6 +260,9 @@ struct SDL_WindowData
     bool scale_to_display;
     bool reparenting_required;
     bool double_buffer;
+    bool entering_new_zone;
+    bool borders_changed;
+    bool adjust_initial_position;
 
     SDL_HitTestResult hit_test_result;
 
@@ -271,6 +300,8 @@ extern bool Wayland_SetWindowIcon(SDL_VideoDevice *_this, SDL_Window *window, SD
 extern bool Wayland_SetWindowFocusable(SDL_VideoDevice *_this, SDL_Window *window, bool focusable);
 extern float Wayland_GetWindowContentScale(SDL_VideoDevice *_this, SDL_Window *window);
 extern void *Wayland_GetWindowICCProfile(SDL_VideoDevice *_this, SDL_Window *window, size_t *size);
+extern bool Wayland_GetWindowBorderSize(SDL_VideoDevice *_this, SDL_Window *window, int *top, int *left, int *bottom, int *right);
+extern void Wayland_SetWindowAlwaysOnTop(SDL_VideoDevice *_this, SDL_Window *window, bool on_top);
 
 extern bool Wayland_SetWindowHitTest(SDL_Window *window, bool enabled);
 extern bool Wayland_FlashWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_FlashOperation operation);
@@ -279,5 +310,7 @@ extern bool Wayland_ReconfigureWindow(SDL_VideoDevice *_this, SDL_Window *window
 
 extern void Wayland_RemoveOutputFromWindow(SDL_WindowData *window, SDL_DisplayData *display_data);
 extern void Wayland_UpdateWindowPosition(SDL_Window *window);
+extern SDL_DisplayData *Wayland_GetDisplayForWindowZone(SDL_WindowData *wind, int x, int y, struct xx_zone_v1 *ignore_zone);
+extern void Wayland_ApplyZoneItemPosition(SDL_WindowData *wind);
 
 #endif // SDL_waylandwindow_h_

--- a/wayland-protocols/xx-zones-v1.xml
+++ b/wayland-protocols/xx-zones-v1.xml
@@ -1,0 +1,493 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="xx_zones_v1">
+
+  <copyright>
+    Copyright © 2023-2026 Matthias Klumpp
+    Copyright © 2024-2025 Frank Praznik
+    Copyright ©      2024 Victoria Brekenfeld
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="protocol to manage client-specific zones for explicit window placement">
+    This protocol provides a way for clients to create and add toplevel windows
+    to "zones".
+
+    A zone is an environment with its own coordinate space where clients can
+    add and arrange windows that logically belong and relate to each other.
+    It provides means for, among other things, requesting that windows are
+    placed at specific coordinates within the zone coordinate space.
+    See the description of "xx_zone_v1" for more details.
+
+    This document adheres to RFC 2119 when using words like "must",
+    "should", "may", etc.
+
+    Warning! The protocol described in this file is currently in the testing
+    phase. Backward compatible changes may be added together with the
+    corresponding interface version bump. Backward incompatible changes can
+    only be done by creating a new major version of the extension.
+  </description>
+
+  <interface name="xx_zone_manager_v1" version="1">
+    <description summary="manage zones for clients">
+      The 'xx_zone_manager' interface defines base requests for obtaining and
+      managing zones for a client.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="Destroy this object">
+       This has no effect other than to destroy the xx_zone_manager object.
+      </description>
+    </request>
+
+    <request name="get_zone_item">
+      <description summary="create a positionable item representing a toplevel">
+        Create a new positionable zone item from an 'xdg_toplevel'.
+        The resulting wrapper object can then be used to position the
+        toplevel window in a zone.
+      </description>
+      <arg name="id" type="new_id" interface="xx_zone_item_v1"/>
+      <arg name="toplevel" type="object" interface="xdg_toplevel" summary="the toplevel window"/>
+    </request>
+
+    <request name="get_zone">
+      <description summary="join a zone or request a new one">
+        Create a new zone. While the zone object exists, the compositor
+        must consider it "used" and keep track of it.
+
+        A zone is represented by a string 'handle'.
+
+        The compositor must keep zone handles valid while any client is
+        referencing the corresponding zone.
+        The compositor may always give a client the same zone for a given
+        output, and remember its position and size for the client, but
+        clients should not rely on this behavior.
+
+        A client can request a zone to be placed on a specific
+        output by passing a wl_output as 'output'. If a valid output
+        is set, the compositor should place the zone on that output.
+        If NULL is passed, the compositor decides the output.
+
+        The compositor should provide the biggest reasonable zone space
+        for the client, governed by its own policy.
+
+        If the compositor wants to deny zone creation (e.g. on a specific
+        output), the returned zone must be "invalid". A zone is invalid
+        if it has a negative size, in which case the client is forbidden
+        to place items in it.
+      </description>
+      <arg name="id" type="new_id" interface="xx_zone_v1"/>
+      <arg name="output" type="object" interface="wl_output"
+           summary="the preferred output to place the zone on, or NULL"
+           allow-null="true"/>
+    </request>
+
+    <request name="get_zone_from_handle">
+      <description summary="join a zone via its handle">
+        Create a new zone object using the zone's handle.
+        For the returned zone, the same rules as described in
+        'get_zone' apply.
+
+        This request returns a reference to an existing or remembered zone
+        that is represented by 'handle'.
+        The zone may potentially have been created by a different client.
+
+        This allows cooperating clients to share the same coordinate space.
+
+        If the zone handle was invalid or unknown, a new zone must
+        be created and returned instead, following the rules outlined
+        in 'get_zone' and assuming no output preference.
+
+        Every new zone object created by this request emits its initial event
+        sequence, including the 'handle' event, which must return a different
+        handle from the one passed to this request in case the existing zone
+        could not be joined.
+      </description>
+      <arg name="id" type="new_id" interface="xx_zone_v1"/>
+      <arg name="handle" type="string" summary="the handle of a zone"/>
+    </request>
+  </interface>
+
+  <interface name="xx_zone_item_v1" version="1">
+    <description summary="opaque surface object that can be positioned in a zone">
+      The zone item object is an opaque descriptor for a positionable
+      element, such as a toplevel window.
+      It currently can only be created from an 'xdg_toplevel' via the
+      'get_zone_item' request on a 'xx_zone_manager'.
+
+      The lifetime of a zone item is tied to its referenced item (usually
+      a toplevel).
+      When the reference is destroyed, the compositor must send a 'closed'
+      event and the zone item becomes inert.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object">
+        Destroys the zone item. This request may be sent at any time by the
+        client.
+        By destroying the object, the respective item surface remains at its
+        last position, but its association with its zone is lost.
+        This will also cause it to lose any other attached state described by
+        this protocol.
+
+        If the item was associated with a zone when this request is sent,
+        the compositor must emit 'item_left' on the respective zone, unless
+        it had already been emitted before a 'closed' event.
+      </description>
+    </request>
+
+    <event name="frame_extents">
+      <description summary="the extents of the frame bordering the item">
+        The 'frame_extents' event describes the current extents of the frame
+        bordering the item's content area.
+
+        This event is sent immediately after the item joins a zone, or if
+        the item frame extents have been changed by other means (e.g. toggled
+        by a client request, or compositor involvement). The dimensions are in
+        the same coordinate space as the item's zone (the surface coordinate
+        space).
+
+        This event must be followed by a 'position' event, even if the item's
+        coordinates did not change as a result of the frame extents changing.
+
+        If the item has no associated frame, the event should still be sent,
+        but extents must be set to zero.
+
+        This event can only be emitted if the item is currently associated
+        with a zone.
+      </description>
+      <arg name="top" type="int" summary="current height of the frame bordering the top of the item"/>
+      <arg name="bottom" type="int" summary="current height of the frame bordering the bottom of the item"/>
+      <arg name="left" type="int" summary="current width of the frame bordering the left of the item"/>
+      <arg name="right" type="int" summary="current width of the frame bordering the right of the item"/>
+    </event>
+
+    <request name="set_position">
+      <description summary="set a preferred item surface position">
+        Request a preferred position (x, y) for the specified item
+        surface to be placed at, relative to its associated zone.
+        This state is double-buffered and is applied on the next
+        wl_surface.commit of the surface represented by 'item'.
+
+        X and Y coordinates are relative to the zone this item is associated
+        with, and must not be larger than the dimensions set by the zone size.
+        They may be smaller than zero, if the item's top-left edge is to be
+        placed beyond the zone's top-left sides, but clients should expect the
+        compositor to more aggressively sanitize the coordinate values in that
+        case.
+        If a coordinate exceeds the zone's maximum bounds, the compositor must
+        sanitize it to more appropriate values (e.g. by clamping the values to
+        the maximum size).
+        For infinite zones, the client may pick any coordinate.
+
+        Compositors implementing this protocol should try to place an item
+        at the requested coordinates relative to the item's zone, unless doing
+        so is not allowed by compositor policy (because e.g. the user has set
+        custom rules for the surface represented by the respective item, the
+        surface overlaps with a protected shell component, session management
+        has loaded previous surface positions or the placement request would
+        send the item out of bounds).
+
+        Clients should be aware that their placement preferences might not
+        always be followed and must be prepared to handle the case where the
+        item is placed at a different position by the compositor.
+
+        Once an item has been mapped, a change to its preferred placement can
+        still be requested and should be applied, but must not be followed
+        by the compositor while the user is interacting with the affected item
+        surface (e.g. clicking &amp; dragging within the window, or resizing it).
+
+        After a call to this request, a 'position' event must be emitted with the
+        item's new actual position.
+        If the current item has no zone associated with it, a 'position_failed'
+        event must be emitted.
+        If the compositor did not move the item at all, not even with sanitized
+        values, a 'position_failed' event must be emitted as well.
+      </description>
+      <arg name="x" type="int" summary="x position relative to zone"/>
+      <arg name="y" type="int" summary="y position relative to zone"/>
+    </request>
+
+    <event name="position">
+      <description summary="notify about the position of an item">
+        This event notifies the client of the current position (x, y) of
+        the item relative to its zone.
+        Coordinates are relative to the zone this item belongs to, and only
+        valid within it.
+        Negative coordinates are possible, if the user has moved an item
+        surface beyond the zone's top-left boundary.
+
+        This event is sent in response to a 'set_position' request,
+        or if the item position has been changed by other means
+        (e.g. user interaction or compositor involvement).
+
+        This event can only be emitted if the item is currently associated
+        with a zone.
+      </description>
+      <arg name="x" type="int" summary="current x position relative to zone"/>
+      <arg name="y" type="int" summary="current y position relative to zone"/>
+    </event>
+
+    <event name="position_failed">
+      <description summary="a set_position request has failed">
+        The compositor was unable to set the position of this item entirely,
+        and could not even find sanitized coordinates to place the item at
+        instead.
+
+        This event will also be emitted if 'set_position' was called while the
+        item had no zone associated with it.
+      </description>
+    </event>
+
+    <event name="closed">
+      <description summary="the underlying surface has been destroyed">
+        This event indicates that the surface wrapped by this
+        zone item has been destroyed.
+
+        The 'xx_zone_item_v1' object becomes inert and the client should
+        destroy it. Any requests made on an inert zone item must be silently
+        ignored by the compositor, and no further events will be sent for this
+        item.
+
+        If the item was associated with a zone when this event is sent,
+        the compositor must also emit 'item_left' on the respective zone
+        before sending this event.
+      </description>
+    </event>
+  </interface>
+
+  <interface name="xx_zone_v1" version="1">
+    <description summary="area for a client in which it can set window positioning preferences">
+      An 'xx_zone' describes a display area provided by the compositor in
+      which a client can place windows and move them around.
+
+      A zone's area could, for example, correspond to the space usable for
+      placing windows on a specific output (space without panels or other
+      restricted elements) or it could be an area of the output the compositor
+      has specifically chosen for a client to place its surfaces in.
+
+      Clients should make no assumptions about how a zone is presented to the
+      user (e.g. compositors may visually distinguish what makes up a zone).
+
+      Items are added to a zone as 'xx_zone_item' objects.
+
+      All item surface position coordinates (x, y) are relative to the selected
+      zone.
+      They are using the 'size' of the respective zone as coordinate system,
+      with (0, 0) being in the top left corner.
+
+      If a zone item is moved out of the top/left boundaries of the zone by
+      user interaction, its coordinates must become negative, relative to the
+      zone's top-left coordinate origin. A client may position an item at negative
+      coordinates.
+
+      The compositor must ensure that any item positioned by the client is
+      visible and accessible to the user, and is not moved into invisible space
+      outside of a zone.
+      Positioning requests may be rejected or altered by the compositor, depending
+      on its policy.
+
+      The absolute position of the zone within the compositor's coordinate space
+      is opaque to the client and the compositor may move the entire zone without
+      the client noticing it. A zone may also be arbitrarily resized, in which
+      case the respective 'size' event must be emitted again to notify the client.
+
+      A zone is always tied to an output and does not extend beyond it.
+
+      A zone may be "invalid". An invalid zone is created with a negative
+      'size' and must not be used for item arrangement.
+
+      Upon creation the compositor must emit 'size' and 'handle' events for the
+      newly created 'xx_zone', followed by 'done'.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xx_zone object">
+        Using this request a client can tell the compositor that it is not
+        going to use the 'xx_zone' object anymore.
+        The zone itself must only be destroyed if no other client
+        is currently referencing it, so this request may only destroy the
+        object reference owned by the client.
+      </description>
+    </request>
+
+    <event name="size">
+      <description summary="size of the zone">
+        The 'size' event describes the size of this zone.
+
+        It is a rectangle with its origin in the top-left corner, using
+        the surface coordinate space (device pixels divided by the scaling
+        factor of the output this zone is attached to).
+
+        If a width or height value is zero, the zone is infinite
+        in that direction.
+
+        If the width and height values are negative, the zone is considered
+        "invalid" and must not be used.
+        A size event declaring the zone invalid may only be emitted immediately
+        after the zone was created.
+        A zone must not become invalid at a later time by sending a negative
+        'size' after the zone has been established.
+
+        The 'size' event is sent immediately after creating an 'xx_zone_v1',
+        and whenever the size of the zone changes. A zone size can change at
+        any time, for any reason, for example due to output size or scaling
+        changes, or by compositor policy.
+
+        Upon subsequent emissions of 'size' after 'xx_zone' has already
+        been created, the 'done' event does not have to be sent again.
+      </description>
+      <arg name="width" type="int"
+           summary="zone width in logical pixels"/>
+      <arg name="height" type="int"
+           summary="zone height in logical pixels"/>
+    </event>
+
+    <event name="handle">
+      <description summary="the zone handle">
+        The handle event provides the unique handle of this zone.
+        The handle may be shared with any client, which then can use it to
+        join this client's zone by calling
+        'xx_zone_manager.get_zone_from_handle'.
+
+        This event must only be emitted once after the zone was created.
+        If this zone is invalid, the handle must be an empty string.
+      </description>
+      <arg name="handle" type="string" summary="the exported zone handle"/>
+    </event>
+
+    <event name="done">
+      <description summary="all information about the zone has been sent">
+        This event is sent after all other properties (size, handle) of an
+        'xx_zone' have been sent.
+
+        This allows changes to the xx_zone properties to be seen as
+        atomic, even if they happen via multiple events.
+      </description>
+    </event>
+
+    <enum name="error">
+      <entry name="invalid" summary="an invalid value has been submitted"
+             value="0"/>
+    </enum>
+
+    <request name="add_item">
+      <description summary="associate an item with this zone">
+        Make 'item' a member of this zone.
+        This state is double-buffered and is applied on the next
+        'wl_surface.commit' of the surface represented by 'item'.
+
+        This request associates an item with this zone.
+        If this request is called on an item that already has a zone
+        association with a different zone, the item must leave its old zone
+        (with 'item_left' being emitted on its old zone) and will instead
+        be associated with this zone.
+
+        Upon receiving this request and if the target zone is allowed for 'item',
+        a compositor must emit 'item_entered' to confirm the zone association.
+        It must even emit this event if the item was already associated with this
+        zone before.
+
+        The compositor must move the surface represented by 'item' into the
+        boundary of this zone upon receiving this request and accepting it
+        (either by extending the zone size, or by moving the item surface).
+
+        If the compositor does not allow the item to switch zone associations,
+        and wants it to remain in its previous zone, it must emit
+        'item_blocked' instead.
+        Compositors might want to prevent zone associations if they
+        perform specialized window management (e.g. autotiling) that would
+        make clients moving items between certain zones undesirable.
+
+        Once the 'item' is added to its zone, the compositor must first send
+        a 'frame_extents' event on the item, followed by an initial 'position'
+        event with the item's current position.
+        The compositor must then send 'position' events when the position
+        of the item in its zone is changed, for as long as the item is
+        associated with a zone.
+
+        If the zone is invalid, an 'invalid' error must be raised and the item
+        must not be associated with the invalid zone.
+        If the referenced item is inert (its underlying surface has been
+        destroyed), the request must be silently ignored.
+      </description>
+      <arg name="item" type="object" interface="xx_zone_item_v1" summary="the zone item"/>
+    </request>
+
+    <request name="remove_item">
+      <description summary="disassociate an item from this zone">
+        Remove 'item' as a member of this zone.
+        This state is double-buffered and is applied on the next
+        'wl_surface.commit' of the surface represented by 'item'.
+
+        This request removes the item from this zone explicitly,
+        making the client unable to retrieve coordinates again.
+
+        Upon receiving this request, the compositor should not change the
+        item surface position on screen, and must emit 'item_left' to confirm
+        the item's removal. It must even emit this event if the
+        item was never associated with this zone.
+
+        If the referenced item is inert (its underlying surface has been
+        destroyed), the request must be silently ignored.
+      </description>
+      <arg name="item" type="object" interface="xx_zone_item_v1" summary="the zone item"/>
+    </request>
+
+    <event name="item_blocked">
+      <description summary="an item could not be associated with this zone">
+        This event notifies the client that an item was prevented from
+        joining this zone.
+
+        It is emitted as a response to 'add_item' if the compositor did not
+        allow the item to join this particular zone.
+      </description>
+      <arg name="item" type="object" interface="xx_zone_item_v1" summary="the item that was prevented from joining this zone"/>
+    </event>
+
+    <event name="item_entered">
+      <description summary="notify about an item having joined this zone">
+        This event notifies the client of an item joining this zone.
+
+        It is emitted as a response to 'add_item' or if the compositor
+        automatically had the item surface (re)join an existing zone.
+      </description>
+      <arg name="item" type="object" interface="xx_zone_item_v1" summary="the item that has joined the zone"/>
+    </event>
+
+    <event name="item_left">
+      <description summary="notify about an item having left this zone">
+        This event notifies the client of an item leaving this zone, and
+        therefore the client will no longer receive updated coordinates
+        or frame extents for this item.
+        If the client still wishes to adjust the item surface coordinates, it
+        may associate the item with a zone again by calling 'add_item'.
+
+        This event is emitted for example if the user moved an item surface out
+        of a smaller zone's boundaries, or onto a different screen where the
+        previous zone can not expand to. It is also emitted in response to
+        explicitly removing an item via 'remove_item'.
+      </description>
+      <arg name="item" type="object" interface="xx_zone_item_v1" summary="the item that has left the zone"/>
+    </event>
+
+  </interface>
+
+</protocol>


### PR DESCRIPTION
Adds experimental support for the pending [ext-zones-v1 protocol](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/264) for positioning windows in zones.

Testing requires KDE and installing the zones_update branch of the kwin plugin at https://invent.kde.org/kontrabant/kwin-zones:
```
git clone https://invent.kde.org/kontrabant/kwin-zones.git
cd kwin-zones
git switch zones_update
```

Note that the kwin-zones plugin found at https://invent.kde.org/automotive/kwin-zones tracks an older version of the work-in-progress protocol, and won't work with this.