### PR TITLE
Removed SDL_FILE from source code

### DIFF
--- a/src/SDL_internal.h
+++ b/src/SDL_internal.h
@@ -244,6 +244,10 @@
 #define SDL_EndThreadFunction NULL
 #endif
 
+// Don't hardcode full file paths in SDL binaries
+#undef SDL_FILE
+#define SDL_FILE DO_NOT_USE_SDL_FILE
+
 #ifdef SDL_NOLONGLONG
 #error We cannot build a valid SDL3 library without long long support
 #endif

--- a/src/render/opengl/SDL_render_gl.c
+++ b/src/render/opengl/SDL_render_gl.c
@@ -243,7 +243,7 @@ static bool GL_CheckAllErrors(const char *prefix, SDL_Renderer *renderer, const 
 #if 0
 #define GL_CheckError(prefix, renderer)
 #else
-#define GL_CheckError(prefix, renderer) GL_CheckAllErrors(prefix, renderer, SDL_FILE, SDL_LINE, SDL_FUNCTION)
+#define GL_CheckError(prefix, renderer) GL_CheckAllErrors(prefix, renderer, "SDL_render_gl.c", SDL_LINE, SDL_FUNCTION)
 #endif
 
 static bool GL_LoadFunctions(GL_RenderData *data)

--- a/src/render/opengles2/SDL_render_gles2.c
+++ b/src/render/opengles2/SDL_render_gles2.c
@@ -264,7 +264,7 @@ static bool GL_CheckAllErrors(const char *prefix, SDL_Renderer *renderer, const 
 #if 0
 #define GL_CheckError(prefix, renderer)
 #else
-#define GL_CheckError(prefix, renderer) GL_CheckAllErrors(prefix, renderer, SDL_FILE, SDL_LINE, SDL_FUNCTION)
+#define GL_CheckError(prefix, renderer) GL_CheckAllErrors(prefix, renderer, "SDL_render_gles2.c", SDL_LINE, SDL_FUNCTION)
 #endif
 
 /*************************************************************************************************


### PR DESCRIPTION
We don't want to include full source file paths in release binaries, there might be sensitive information in the file path.

Reference: https://github.com/libsdl-org/SDL/issues/14290