### PR TITLE
Remove Q constraint from SDL_Swap16 on x86_64 to portably compile with TCC

### DIFF
--- a/include/SDL3/SDL_endian.h
+++ b/include/SDL3/SDL_endian.h
@@ -252,7 +252,7 @@ SDL_FORCE_INLINE Uint16 SDL_Swap16(Uint16 x)
 #elif defined(__x86_64__)
 SDL_FORCE_INLINE Uint16 SDL_Swap16(Uint16 x)
 {
-  __asm__("xchgb %b0,%h0": "=Q"(x):"0"(x));
+  __asm__("rorw $8,%0": "=r"(x):"0"(x));
     return x;
 }
 #elif (defined(__powerpc__) || defined(__ppc__))


### PR DESCRIPTION
Change SDL_Swap16's assembly implementation on x86_64 for portability to TCC.

## Description
I'm working on an equivalent to Python's UV but for C, and SDL is first class. I'm implementing TCC support, and I found that SDL is really close to compiling out of the box with TCC; there are only two things that won't compile. Both have to do with ASM.
- One is in the vendored copy of stb_image.h, but can be fixed with `STBI_NO_SIMD`. 
- One is what this PR fixes; I couldn't figure out how to hack around this without source changes.

It's a one liner. The ASM should be equivalent, but please check me on that.