### PR TITLE
Fix libusb get_port_numbers signature for FreeBSD

### DIFF
--- a/src/misc/SDL_libusb.c
+++ b/src/misc/SDL_libusb.c
@@ -65,7 +65,11 @@ bool SDL_InitLibUSB(SDL_LibUSBContext **ctx)
             LOAD_LIBUSB_SYMBOL(int (LIBUSB_CALL *)(libusb_device *, uint8_t, struct libusb_config_descriptor **), get_config_descriptor)
             LOAD_LIBUSB_SYMBOL(void (LIBUSB_CALL *)(struct libusb_config_descriptor *), free_config_descriptor)
             LOAD_LIBUSB_SYMBOL(uint8_t (LIBUSB_CALL *)(libusb_device *), get_bus_number)
+#ifdef SDL_PLATFORM_FREEBSD
+            LOAD_LIBUSB_SYMBOL(int (LIBUSB_CALL *)(libusb_device *dev, uint8_t *port_numbers, uint8_t port_numbers_len), get_port_numbers)
+#else
             LOAD_LIBUSB_SYMBOL(int (LIBUSB_CALL *)(libusb_device *dev, uint8_t *port_numbers, int port_numbers_len), get_port_numbers)
+#endif
             LOAD_LIBUSB_SYMBOL(uint8_t (LIBUSB_CALL *)(libusb_device *), get_device_address)
             LOAD_LIBUSB_SYMBOL(int (LIBUSB_CALL *)(libusb_device *, libusb_device_handle **), open)
             LOAD_LIBUSB_SYMBOL(void (LIBUSB_CALL *)(libusb_device_handle *), close)

--- a/src/misc/SDL_libusb.h
+++ b/src/misc/SDL_libusb.h
@@ -43,7 +43,11 @@ typedef struct SDL_LibUSBContext
     );
     void (LIBUSB_CALL *free_config_descriptor)(struct libusb_config_descriptor *config);
     uint8_t (LIBUSB_CALL *get_bus_number)(libusb_device *dev);
+#ifdef SDL_PLATFORM_FREEBSD
+    int (LIBUSB_CALL *get_port_numbers)(libusb_device *dev, uint8_t *port_numbers, uint8_t port_numbers_len);
+#else
     int (LIBUSB_CALL *get_port_numbers)(libusb_device *dev, uint8_t *port_numbers, int port_numbers_len);
+#endif
     uint8_t (LIBUSB_CALL *get_device_address)(libusb_device *dev);
     int (LIBUSB_CALL *open)(libusb_device *dev, libusb_device_handle **dev_handle);
     void (LIBUSB_CALL *close)(libusb_device_handle *dev_handle);


### PR DESCRIPTION
On FreeBSD, third argument on `get_port_numbers` is `uint8_t`
 
https://github.com/freebsd/freebsd-src/blob/c1135b2b54bf46709120d98c90ff4d28a77b896c/lib/libusb/libusb.h#L512

Take this into account