### PR TITLE
miniz.h: fix PNG compression when pitch != w

### DIFF
--- a/src/video/miniz.h
+++ b/src/video/miniz.h
@@ -2987,7 +2987,7 @@ MINIZ_STATIC void *tdefl_write_image_to_png_file_in_memory_ex(const void *pImage
   data_start = out_buf.m_size;
   // compress image data
   tdefl_init(pComp, tdefl_output_buffer_putter, &out_buf, s_tdefl_png_num_probes[MZ_MIN(10, level)] | TDEFL_WRITE_ZLIB_HEADER);
-  for (y = 0; y < h; ++y) { tdefl_compress_buffer(pComp, &z, 1, TDEFL_NO_FLUSH); tdefl_compress_buffer(pComp, (mz_uint8*)pImage + (flip ? (h - 1 - y) : y) * bpl, bpl, TDEFL_NO_FLUSH); }
+  for (y = 0; y < h; ++y) { tdefl_compress_buffer(pComp, &z, 1, TDEFL_NO_FLUSH); tdefl_compress_buffer(pComp, (mz_uint8*)pImage + (flip ? (h - 1 - y) : y) * bpl, w * num_chans, TDEFL_NO_FLUSH); }
   if (tdefl_compress_buffer(pComp, NULL, 0, TDEFL_FINISH) != TDEFL_STATUS_DONE) { MZ_FREE(pComp); MZ_FREE(out_buf.m_pBuf); return NULL; }
   // write IDAT size
   data_size = out_buf.m_size-data_start;


### PR DESCRIPTION
When testing the fix for #14303 (1fa6475c90de43b378451a2cca785ab9de048f9e), 10 of 15 images in our test were corrupt.

This turned out to be because of the incorrect length argument: it was writing `pitch` pixels per line but PNG doesn't have "pitch", it expects to have `width` pixels per line.