### PR TITLE
miniz.h: do not overallocate `out_buf`

### DIFF
--- a/src/video/miniz.h
+++ b/src/video/miniz.h
@@ -2920,7 +2920,7 @@ MINIZ_STATIC void *tdefl_write_image_to_png_file_in_memory_ex(const void *pImage
   tdefl_compressor *pComp = (tdefl_compressor *)MZ_MALLOC(sizeof(tdefl_compressor)); tdefl_output_buffer out_buf; int i, y, z = 0; mz_uint32 c; *pLen_out = 0; size_t data_start, data_size;
   if (!pComp) return NULL;
   MZ_CLEAR_OBJ(out_buf); out_buf.m_expandable = MZ_TRUE;
-  out_buf.m_capacity = 57+MZ_MAX(64, (1+bpl)*h);
+  out_buf.m_capacity = 57+MZ_MAX(64, (1+w*num_chans)*h);
   if (plte_size > 0)
     out_buf.m_capacity += 12+plte_size;
   if (trns_size > 0)


### PR DESCRIPTION
Follow-up to #14319.