### PR TITLE
Fix NULL pointer dereference in SDL_GlobStorageDirectory

### DIFF
--- a/src/storage/generic/SDL_genericstorage.c
+++ b/src/storage/generic/SDL_genericstorage.c
@@ -79,7 +79,7 @@ static bool GENERIC_EnumerateStorageDirectory(void *userdata, const char *path, 
 
     char *fullpath = GENERIC_INTERNAL_CreateFullPath((char *)userdata, path);
     if (fullpath) {
-        wrap_data.base_len = SDL_strlen((char *)userdata);
+        wrap_data.base_len = userdata ? SDL_strlen((char *)userdata) : 0;
         wrap_data.real_callback = callback;
         wrap_data.real_userdata = callback_userdata;
 


### PR DESCRIPTION
Problem:
When SDL_OpenFileStorage(NULL) is called with a NULL base path (which is explicitly allowed by the API), 
calling SDL_GlobStorageDirectory on that storage causes a segmentation fault. 
The crash occurs in GENERIC_EnumerateStorageDirectory at line 82 where SDL_strlen is called on the NULL userdata pointer without checking if it's NULL first.

Solution:
Add a NULL check before calling SDL_strlen on the userdata pointer.
If userdata is NULL, set base_len to 0, otherwise calculate the  length normally. 
This matches the pattern used by GENERIC_INTERNAL_CreateFullPath which already handles NULL base paths correctly.

Happy to hear any feedback you might have. 
Hope you're having a great day!

Fixes #14060