### PR TITLE
Fix NULL pointer dereference in SDL_RenderGeometryRaw with NPOT textures

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -5356,12 +5356,12 @@ bool SDL_RenderGeometryRaw(SDL_Renderer *renderer,
         }
     }
 
-    if (renderer->npot_texture_wrap_unsupported && IsNPOT(texture->w)) {
+    if (!texture || (renderer->npot_texture_wrap_unsupported && IsNPOT(texture->w))) {
         texture_address_mode_u = SDL_TEXTURE_ADDRESS_CLAMP;
     } else {
         texture_address_mode_u = renderer->texture_address_mode_u;
     }
-    if (renderer->npot_texture_wrap_unsupported && IsNPOT(texture->h)) {
+    if (!texture || (renderer->npot_texture_wrap_unsupported && IsNPOT(texture->h))) {
         texture_address_mode_v = SDL_TEXTURE_ADDRESS_CLAMP;
     } else {
         texture_address_mode_v = renderer->texture_address_mode_v;


### PR DESCRIPTION
Problem:
SDL_RenderGeometryRaw crashes when passed a NULL texture on systems where the renderer has npot_texture_wrap_unsupported set to true.
The code attempts to check texture dimensions without verifying the texture pointer is non-NULL first.

Solution:
Add NULL checks before accessing texture width and height. When texture is NULL, 
use SDL_TEXTURE_ADDRESS_CLAMP for both address  modes, 
which is consistent with how other parts of the codebase  handle NULL textures. 
The fix uses short-circuit evaluation to prevent dereferencing the NULL pointer.

Happy to hear any feedback you might have. 
Hope you're having a great day!

Fixes #14329
