### PR TITLE
wayland: Fix libdecor incompatible pointer types

### DIFF
--- a/src/video/wayland/SDL_waylandsym.h
+++ b/src/video/wayland/SDL_waylandsym.h
@@ -175,10 +175,10 @@ SDL_WAYLAND_SYM(xkb_mod_mask_t, xkb_keymap_mod_get_mask, (struct xkb_keymap *, c
 #ifdef HAVE_LIBDECOR_H
 SDL_WAYLAND_MODULE(WAYLAND_LIBDECOR)
 SDL_WAYLAND_SYM(void, libdecor_unref, (struct libdecor *))
-SDL_WAYLAND_SYM(struct libdecor *, libdecor_new, (struct wl_display *, struct libdecor_interface *))
+SDL_WAYLAND_SYM(struct libdecor *, libdecor_new, (struct wl_display *, const struct libdecor_interface *))
 SDL_WAYLAND_SYM(struct libdecor_frame *, libdecor_decorate, (struct libdecor *,\
                                                              struct wl_surface *,\
-                                                             struct libdecor_frame_interface *,\
+                                                             const struct libdecor_frame_interface *,\
                                                              void *))
 SDL_WAYLAND_SYM(void, libdecor_frame_unref, (struct libdecor_frame *))
 SDL_WAYLAND_SYM(void, libdecor_frame_set_title, (struct libdecor_frame *, const char *))

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -1476,17 +1476,13 @@ static void decoration_dismiss_popup(struct libdecor_frame *frame, const char *s
     // NOP
 }
 
+#if SDL_LIBDECOR_CHECK_VERSION(0, 3, 0)
 static void decoration_frame_bounds(struct libdecor_frame *frame, int width, int height, void *user_data)
 {
     SDL_WindowData *window = (SDL_WindowData *)user_data;
     window->toplevel_bounds.width = width;
     window->toplevel_bounds.height = height;
 }
-
-#if SDL_LIBDECOR_CHECK_VERSION(0, 3, 0)
-#define FRAME_BOUNDS_FUNC_CAST(func) func
-#else
-#define FRAME_BOUNDS_FUNC_CAST(func) (void(*)(void))func
 #endif
 
 static struct libdecor_frame_interface libdecor_frame_interface = {
@@ -1494,7 +1490,9 @@ static struct libdecor_frame_interface libdecor_frame_interface = {
     decoration_frame_close,
     decoration_frame_commit,
     decoration_dismiss_popup,
-    FRAME_BOUNDS_FUNC_CAST(decoration_frame_bounds)
+#if SDL_LIBDECOR_CHECK_VERSION(0, 3, 0)
+    decoration_frame_bounds
+#endif
 };
 #endif
 


### PR DESCRIPTION
The buildbots check out, so const-ifying those parameters should be OK.

Fixes #14347 
