### PR TITLE
Add support for GPU RGB565 (B5G6R5_UNORM) textures with DX11

### DIFF
--- a/src/render/direct3d11/SDL_render_d3d11.c
+++ b/src/render/direct3d11/SDL_render_d3d11.c
@@ -2900,11 +2900,6 @@ static bool D3D11_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_NV21);
     SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_P010);
 
-    // DXGI_FORMAT_B5G6R5_UNORM is supported since Direct3D 11.1 on Windows 8 and later
-    if (data->featureLevel >= D3D_FEATURE_LEVEL_11_1 && WIN_IsWindows8OrGreater()) {
-        SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_RGB565);
-    }
-
     data->swapChainFlags = 0;
     data->syncInterval = 0;
     data->presentFlags = DXGI_PRESENT_DO_NOT_WAIT;
@@ -2920,6 +2915,11 @@ static bool D3D11_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL
     }
     if (FAILED(D3D11_CreateWindowSizeDependentResources(renderer))) {
         return false;
+    }
+
+    // DXGI_FORMAT_B5G6R5_UNORM is supported since Direct3D 11.1 on Windows 8 and later
+    if (data->featureLevel >= D3D_FEATURE_LEVEL_11_1 && WIN_IsWindows8OrGreater()) {
+        SDL_AddSupportedTextureFormat(renderer, SDL_PIXELFORMAT_RGB565);
     }
 
     return true;


### PR DESCRIPTION
Add support for GPU RGB565 (B5G6R5_UNORM) textures with DX11

## Description
Allows using GPU textures with the RGB56 format with the DirectX11 backend.

## Existing Issue(s)
Resolves #14357 
