### PR TITLE
[SDL2] Fix leak in SDL_GameControllerTypeForIndex()

### DIFF
--- a/src/joystick/SDL_gamecontroller.c
+++ b/src/joystick/SDL_gamecontroller.c
@@ -1984,7 +1984,7 @@ const char *SDL_GameControllerPathForIndex(int joystick_index)
 SDL_GameControllerType SDL_GameControllerTypeForIndex(int joystick_index)
 {
     SDL_JoystickGUID joystick_guid = SDL_JoystickGetDeviceGUID(joystick_index);
-    const char *mapping = SDL_GameControllerMappingForGUID(joystick_guid);
+    char *mapping = SDL_GameControllerMappingForGUID(joystick_guid);
     char *type_string, *comma;
     SDL_GameControllerType type;
     if (mapping) {
@@ -1999,8 +1999,10 @@ SDL_GameControllerType SDL_GameControllerTypeForIndex(int joystick_index)
             } else {
                 type = SDL_GetGameControllerTypeFromString(type_string);
             }
+            SDL_free(mapping);
             return type;
         }
+        SDL_free(mapping);
     }
     return SDL_GetJoystickGameControllerTypeFromGUID(joystick_guid, SDL_JoystickNameForIndex(joystick_index));
 }


### PR DESCRIPTION
<details><summary>Warning 1</summary>
<p>

```
[ 23%] Building C object CMakeFiles/SDL2.dir/src/joystick/SDL_gamecontroller.c.o
SDL/src/joystick/SDL_gamecontroller.c:1991:21: warning: Potential leak of memory pointed to by 'mapping' [clang-analyzer-unix.Malloc]
 1991 |         type_string = SDL_strstr(mapping, SDL_CONTROLLER_TYPE_FIELD);
      |                     ^
SDL/src/joystick/SDL_gamecontroller.c:1987:27: note: Calling 'SDL_GameControllerMappingForGUID'
 1987 |     const char *mapping = SDL_GameControllerMappingForGUID(joystick_guid);
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1809:13: note: Assuming 'mapping' is non-null
 1809 |         if (mapping) {
      |             ^~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1809:9: note: Taking true branch
 1809 |         if (mapping) {
      |         ^
SDL/src/joystick/SDL_gamecontroller.c:1810:22: note: Calling 'CreateMappingString'
 1810 |             retval = CreateMappingString(mapping, guid);
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1734:9: note: Assuming the condition is false
 1734 |     if (!SDL_strstr(mapping->mapping, SDL_CONTROLLER_PLATFORM_FIELD)) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1734:5: note: Taking false branch
 1734 |     if (!SDL_strstr(mapping->mapping, SDL_CONTROLLER_PLATFORM_FIELD)) {
      |     ^
SDL/src/joystick/SDL_gamecontroller.c:1742:22: note: Memory is allocated
 1742 |     pMappingString = SDL_malloc(needed);
      |                      ^
include/SDL2/SDL_stdinc.h:792:20: note: expanded from macro 'SDL_malloc'
  792 | #define SDL_malloc malloc
      |                    ^
SDL/src/joystick/SDL_gamecontroller.c:1743:9: note: Assuming 'pMappingString' is non-null
 1743 |     if (!pMappingString) {
      |         ^~~~~~~~~~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1743:5: note: Taking false branch
 1743 |     if (!pMappingString) {
      |     ^
SDL/src/joystick/SDL_gamecontroller.c:1750:9: note: Assuming the condition is false
 1750 |     if (!SDL_strstr(mapping->mapping, SDL_CONTROLLER_PLATFORM_FIELD)) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1750:5: note: Taking false branch
 1750 |     if (!SDL_strstr(mapping->mapping, SDL_CONTROLLER_PLATFORM_FIELD)) {
      |     ^
SDL/src/joystick/SDL_gamecontroller.c:1760:9: note: Assuming 'pPlatformString' is null
 1760 |     if (pPlatformString) {
      |         ^~~~~~~~~~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1760:5: note: Taking false branch
 1760 |     if (pPlatformString) {
      |     ^
SDL/src/joystick/SDL_gamecontroller.c:1810:22: note: Returned allocated memory
 1810 |             retval = CreateMappingString(mapping, guid);
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1987:27: note: Returned allocated memory
 1987 |     const char *mapping = SDL_GameControllerMappingForGUID(joystick_guid);
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1990:9: note: 'mapping' is non-null
 1990 |     if (mapping) {
      |         ^~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1990:5: note: Taking true branch
 1990 |     if (mapping) {
      |     ^
SDL/src/joystick/SDL_gamecontroller.c:1991:21: note: Potential leak of memory pointed to by 'mapping'
 1991 |         type_string = SDL_strstr(mapping, SDL_CONTROLLER_TYPE_FIELD);
      |                     ^
```

</p>
</details>

<details><summary>Warning 2</summary>
<p>

```
[ 61%] Building C object CMakeFiles/SDL2-static.dir/src/joystick/SDL_gamecontroller.c.o
SDL/src/joystick/SDL_gamecontroller.c:1991:21: warning: Potential leak of memory pointed to by 'mapping' [clang-analyzer-unix.Malloc]
 1991 |         type_string = SDL_strstr(mapping, SDL_CONTROLLER_TYPE_FIELD);
      |                     ^
SDL/src/joystick/SDL_gamecontroller.c:1987:27: note: Calling 'SDL_GameControllerMappingForGUID'
 1987 |     const char *mapping = SDL_GameControllerMappingForGUID(joystick_guid);
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1809:13: note: Assuming 'mapping' is non-null
 1809 |         if (mapping) {
      |             ^~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1809:9: note: Taking true branch
 1809 |         if (mapping) {
      |         ^
SDL/src/joystick/SDL_gamecontroller.c:1810:22: note: Calling 'CreateMappingString'
 1810 |             retval = CreateMappingString(mapping, guid);
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1734:9: note: Assuming the condition is false
 1734 |     if (!SDL_strstr(mapping->mapping, SDL_CONTROLLER_PLATFORM_FIELD)) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1734:5: note: Taking false branch
 1734 |     if (!SDL_strstr(mapping->mapping, SDL_CONTROLLER_PLATFORM_FIELD)) {
      |     ^
SDL/src/joystick/SDL_gamecontroller.c:1742:22: note: Memory is allocated
 1742 |     pMappingString = SDL_malloc(needed);
      |                      ^
include/SDL2/SDL_stdinc.h:792:20: note: expanded from macro 'SDL_malloc'
  792 | #define SDL_malloc malloc
      |                    ^
SDL/src/joystick/SDL_gamecontroller.c:1743:9: note: Assuming 'pMappingString' is non-null
 1743 |     if (!pMappingString) {
      |         ^~~~~~~~~~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1743:5: note: Taking false branch
 1743 |     if (!pMappingString) {
      |     ^
SDL/src/joystick/SDL_gamecontroller.c:1750:9: note: Assuming the condition is false
 1750 |     if (!SDL_strstr(mapping->mapping, SDL_CONTROLLER_PLATFORM_FIELD)) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1750:5: note: Taking false branch
 1750 |     if (!SDL_strstr(mapping->mapping, SDL_CONTROLLER_PLATFORM_FIELD)) {
      |     ^
SDL/src/joystick/SDL_gamecontroller.c:1760:9: note: Assuming 'pPlatformString' is null
 1760 |     if (pPlatformString) {
      |         ^~~~~~~~~~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1760:5: note: Taking false branch
 1760 |     if (pPlatformString) {
      |     ^
SDL/src/joystick/SDL_gamecontroller.c:1810:22: note: Returned allocated memory
 1810 |             retval = CreateMappingString(mapping, guid);
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1987:27: note: Returned allocated memory
 1987 |     const char *mapping = SDL_GameControllerMappingForGUID(joystick_guid);
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1990:9: note: 'mapping' is non-null
 1990 |     if (mapping) {
      |         ^~~~~~~
SDL/src/joystick/SDL_gamecontroller.c:1990:5: note: Taking true branch
 1990 |     if (mapping) {
      |     ^
SDL/src/joystick/SDL_gamecontroller.c:1991:21: note: Potential leak of memory pointed to by 'mapping'
 1991 |         type_string = SDL_strstr(mapping, SDL_CONTROLLER_TYPE_FIELD);
      |                     ^
```

</p>
</details>

MRE:
```c
#include <SDL2/SDL.h>

int main(void)
{
    int ret = 0;
    
    SDL_Init(SDL_INIT_GAMECONTROLLER); // or SDL_INIT_JOYSTICK
    
    SDL_Log("SDL_NumJoysticks(): %d", SDL_NumJoysticks());
    
    for (int i = 0; i < 1000; ++i) {
        for (int j = 0; j < SDL_NumJoysticks(); ++j) {
            ret += SDL_GameControllerTypeForIndex(j); // leaks ~315 bytes per call
        }
    }
    
    SDL_Quit();
    
    return ret;
}

```

`valgrind --leak-check=full ./a.out`:
```
...
...
INFO: SDL_NumJoysticks(): 1
...
...
=71342== 315,000 bytes in 1,000 blocks are definitely lost in loss record 27 of 27
==71342==    at 0x484E7A8: malloc (vg_replace_malloc.c:446)
==71342==    by 0x493EA25: real_malloc (SDL_malloc.c:5196)
==71342==    by 0x493EC8C: SDL_malloc_REAL (SDL_malloc.c:5295)
==71342==    by 0x48D3E0B: CreateMappingString (SDL_gamecontroller.c:1742)
==71342==    by 0x48D406B: SDL_GameControllerMappingForGUID_REAL (SDL_gamecontroller.c:1810)
==71342==    by 0x48D4522: SDL_GameControllerTypeForIndex_REAL (SDL_gamecontroller.c:1987)
==71342==    by 0x48B8B4A: SDL_GameControllerTypeForIndex (SDL_dynapi_procs.h:793)
==71342==    by 0x40011CA: main (main.c:13)
```