### PR TITLE
Remove incorrect and useless call to SetTextureScaleMode()

### DIFF
--- a/src/render/opengl/SDL_render_gl.c
+++ b/src/render/opengl/SDL_render_gl.c
@@ -649,7 +649,6 @@ static bool GL_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SDL_P
     data->texture_address_mode_v = SDL_TEXTURE_ADDRESS_CLAMP;
     renderdata->glEnable(textype);
     renderdata->glBindTexture(textype, data->texture);
-    SetTextureAddressMode(renderdata, textype, data->texture_address_mode_u, data->texture_address_mode_v);
 #ifdef SDL_PLATFORM_MACOS
 #ifndef GL_TEXTURE_STORAGE_HINT_APPLE
 #define GL_TEXTURE_STORAGE_HINT_APPLE 0x85BC


### PR DESCRIPTION
## Description
`Format` and `textype` are swapped. A `GLenum` is passed to format but a `SDL_PixelFormat` value is expected.
SetTextureScaleMode() is called a few lines below (line 688) with correct arguments. 

## Existing Issue(s)
None
