### PR TITLE
Fix error handling of X11Toolkit_InitWindowPixmap

### DIFF
--- a/src/video/x11/SDL_x11toolkit.c
+++ b/src/video/x11/SDL_x11toolkit.c
@@ -212,6 +212,7 @@ static void X11Toolkit_InitWindowPixmap(SDL_ToolkitWindowX11 *data) {
                     XDestroyImage(data->image);
                     data->image = NULL;
                     data->shm = false;
+                    return;
                 }
 
                 data->shm_info.readOnly = False;
@@ -220,6 +221,7 @@ static void X11Toolkit_InitWindowPixmap(SDL_ToolkitWindowX11 *data) {
                     XDestroyImage(data->image);
                     data->shm = false;
                     data->image = NULL;
+                    return;
                 }
 
                 g_shm_error = False;
@@ -233,6 +235,7 @@ static void X11Toolkit_InitWindowPixmap(SDL_ToolkitWindowX11 *data) {
                     shmctl(data->shm_info.shmid, IPC_RMID, 0);
                     data->image = NULL;
                     data->shm = false;
+                    return;
                 }
 
                 if (data->shm_pixmap) {


### PR DESCRIPTION
## Description
It does not make sense to continue after an error. The second call to `XDestroyImage(data->image)` dereference a NULL pointer if there was an error before.

## Existing Issue(s)
None
