### PR TITLE
Fix DefWindowProc called for events handled in WIN_WindowProc

### DIFF
--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -427,16 +427,14 @@ static bool SetupWindowData(SDL_VideoDevice *_this, SDL_Window *window, HWND hwn
     // Set up the window proc function
 #ifdef GWLP_WNDPROC
     data->wndproc = (WNDPROC)GetWindowLongPtr(hwnd, GWLP_WNDPROC);
-    if (data->wndproc == WIN_WindowProc) {
+    if (data->wndproc == DefWindowProc) {
         data->wndproc = NULL;
-    } else {
         SetWindowLongPtr(hwnd, GWLP_WNDPROC, (LONG_PTR)WIN_WindowProc);
     }
 #else
     data->wndproc = (WNDPROC)GetWindowLong(hwnd, GWL_WNDPROC);
-    if (data->wndproc == WIN_WindowProc) {
+    if (data->wndproc == DefWindowProc) {
         data->wndproc = NULL;
-    } else {
         SetWindowLong(hwnd, GWL_WNDPROC, (LONG_PTR)WIN_WindowProc);
     }
 #endif


### PR DESCRIPTION
DefWindowProc is now called even for window events already handled by WIN_WindowProc.

## Description
After the recent change in #14378, `data->wndproc` isn't cleared in `SetupWindowData()`, which leads to WIN_WindowProc always calling DefWindowProc, even if it already processed the event.

Note: I'm not sure I fully understand the reasoning behind the previous change - maybe the *actual* right thing to do is to set WIN_WindowProc unconditionally?
