### PR TITLE
[SDL2] Fix uninitialized variable warning when compiling tests with clang compiler

### DIFF
--- a/test/testautomation_rect.c
+++ b/test/testautomation_rect.c
@@ -733,8 +733,8 @@ int rect_testIntersectRectEmpty(void *arg)
  */
 int rect_testIntersectRectParam(void *arg)
 {
-    SDL_Rect rectA;
-    SDL_Rect rectB = { 0 };
+    const SDL_Rect rectA = { 0, 0, 32, 32 };
+    const SDL_Rect rectB = { 0, 0, 32, 32 };
     SDL_Rect result;
     SDL_bool intersection;
 
@@ -988,8 +988,8 @@ int rect_testHasIntersectionEmpty(void *arg)
  */
 int rect_testHasIntersectionParam(void *arg)
 {
-    SDL_Rect rectA;
-    SDL_Rect rectB = { 0 };
+    const SDL_Rect rectA = { 0, 0, 32, 32 };
+    const SDL_Rect rectB = { 0, 0, 32, 32 };
     SDL_bool intersection;
 
     /* invalid parameter combinations */
@@ -1524,7 +1524,8 @@ int rect_testUnionRectInside(void *arg)
  */
 int rect_testUnionRectParam(void *arg)
 {
-    SDL_Rect rectA, rectB = { 0 };
+    const SDL_Rect rectA = { 0, 0, 32, 32 };
+    const SDL_Rect rectB = { 0, 0, 32, 32 };
     SDL_Rect result;
 
     /* invalid parameter combinations */


### PR DESCRIPTION
Similar warnings to https://github.com/libsdl-org/sdl2-compat/pull/547

```
[ 81%] Building C object test/CMakeFiles/testautomation.dir/testautomation_rect.c.o
SDL-2/test/testautomation_rect.c:744:39: warning: variable 'rectA' is uninitialized when passed as a const pointer
      argument here [-Wuninitialized-const-pointer]
  744 |     intersection = SDL_IntersectRect(&rectA, (SDL_Rect *)NULL, &result);
      |                                       ^~~~~
SDL-2/test/testautomation_rect.c:998:41: warning: variable 'rectA' is uninitialized when passed as a const pointer
      argument here [-Wuninitialized-const-pointer]
  998 |     intersection = SDL_HasIntersection(&rectA, (SDL_Rect *)NULL);
      |                                         ^~~~~
SDL-2/test/testautomation_rect.c:1533:20: warning: variable 'rectA' is uninitialized when passed as a const pointer
      argument here [-Wuninitialized-const-pointer]
 1533 |     SDL_UnionRect(&rectA, (SDL_Rect *)NULL, &result);
      |                    ^~~~~
```