### PR TITLE
D3D12 GPU: Prevent reading out of bounds when uploading textures.

### DIFF
--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -5941,7 +5941,7 @@ static void D3D12_UploadToTexture(
                 SDL_memcpy(
                     temporaryBuffer->mapPointer + (sliceIndex * rowsPerSlice) + (rowIndex * alignedRowPitch),
                     transferBufferContainer->activeBuffer->mapPointer + source->offset + (sliceIndex * bytesPerSlice) + (rowIndex * rowPitch),
-                    alignedRowPitch);
+                    rowPitch);
             }
             Uint32 offset = source->offset + (sliceIndex * bytesPerSlice) + ((rowsPerSlice - 1) * rowPitch);
             SDL_memcpy(


### PR DESCRIPTION
## Description

When the upload needs realignment, a new buffer is created to do the upload, and the source data is copied to the new buffer. This commit fixes the issue where the memcopy can read off the end of the source buffer since it is reading based on destination pitch instead of source pitch.