### PR TITLE
Make sure the blit mapping is cleared when undoing RLE encoding

### DIFF
--- a/src/video/SDL_RLEaccel.c
+++ b/src/video/SDL_RLEaccel.c
@@ -89,6 +89,7 @@
 
 #include "SDL_sysvideo.h"
 #include "SDL_surface_c.h"
+#include "SDL_pixels_c.h"
 #include "SDL_RLEaccel_c.h"
 
 #define PIXEL_COPY(to, from, len, bpp) \
@@ -1384,6 +1385,8 @@ void SDL_UnRLESurface(SDL_Surface *surface)
 
         SDL_free(surface->map.data);
         surface->map.data = NULL;
+
+        SDL_InvalidateMap(&surface->map);
 
         SDL_UpdateSurfaceLockFlag(surface);
     }


### PR DESCRIPTION
This fixes a crash if a surface is RLE encoded, then locked and unlocked.

We also mark the surface as no longer needing to be locked after undoing RLE encoding