### PR TITLE
Don't divide by zero in slow blitter

### DIFF
--- a/src/video/SDL_blit_slow.c
+++ b/src/video/SDL_blit_slow.c
@@ -85,8 +85,8 @@ void SDL_Blit_Slow(SDL_BlitInfo *info)
         last_index = SDL_LookupRGBAColor(palette_map, last_pixel, dst_pal);
     }
 
-    incy = ((Uint64)info->src_h << 16) / info->dst_h;
-    incx = ((Uint64)info->src_w << 16) / info->dst_w;
+    incy = info->dst_h ? ((Uint64)info->src_h << 16) / info->dst_h : 0;
+    incx = info->dst_w ? ((Uint64)info->src_w << 16) / info->dst_w : 0;
     posy = incy / 2; // start at the middle of pixel
 
     while (info->dst_h--) {


### PR DESCRIPTION
Other blitters seem to handle zero width/height destinations correctly.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is causing FPE in one of the `pygame` tests.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
