### PR TITLE
api: Added SDL_CreateTemporaryProperties() for more-efficient throwaway props.

### DIFF
--- a/src/dynapi/SDL_dynapi.sym
+++ b/src/dynapi/SDL_dynapi.sym
@@ -1271,6 +1271,7 @@ SDL3_0.0.0 {
     SDL_LoadSurface_IO;
     SDL_LoadSurface;
     SDL_SetWindowFillDocument;
+    SDL_CreateTemporaryProperties;
     # extra symbols go here (don't modify this line)
   local: *;
 };

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -1297,3 +1297,4 @@
 #define SDL_LoadSurface_IO SDL_LoadSurface_IO_REAL
 #define SDL_LoadSurface SDL_LoadSurface_REAL
 #define SDL_SetWindowFillDocument SDL_SetWindowFillDocument_REAL
+#define SDL_CreateTemporaryProperties SDL_CreateTemporaryProperties_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -1305,3 +1305,4 @@ SDL_DYNAPI_PROC(SDL_Surface*,SDL_RotateSurface,(SDL_Surface *a,float b),(a,b),re
 SDL_DYNAPI_PROC(SDL_Surface*,SDL_LoadSurface_IO,(SDL_IOStream *a,bool b),(a,b),return)
 SDL_DYNAPI_PROC(SDL_Surface*,SDL_LoadSurface,(const char *a),(a),return)
 SDL_DYNAPI_PROC(bool,SDL_SetWindowFillDocument,(SDL_Window *a,bool b),(a,b),return)
+SDL_DYNAPI_PROC(SDL_PropertiesID,SDL_CreateTemporaryProperties,(const SDL_TemporaryPropertyItem *a,int b),(a,b),return)


### PR DESCRIPTION

This is an attempt at a limited-but-lower-overhead Properties object that could be useful for throwaway SDL_PropertiesID...namely, the type we use for `SDL_Create*WithProperties` functions.

And example of updating testyuv.c to use it:

```diff
diff --git a/test/testyuv.c b/test/testyuv.c
index 81ed2b734..93b11f6ef 100644
--- a/test/testyuv.c
+++ b/test/testyuv.c
@@ -619,12 +619,16 @@ int main(int argc, char **argv)
 
     output[0] = SDL_CreateTextureFromSurface(renderer, original);
     output[1] = SDL_CreateTextureFromSurface(renderer, converted);
-    props = SDL_CreateProperties();
-    SDL_SetNumberProperty(props, SDL_PROP_TEXTURE_CREATE_COLORSPACE_NUMBER, yuv_colorspace);
-    SDL_SetNumberProperty(props, SDL_PROP_TEXTURE_CREATE_FORMAT_NUMBER, yuv_format);
-    SDL_SetNumberProperty(props, SDL_PROP_TEXTURE_CREATE_ACCESS_NUMBER, SDL_TEXTUREACCESS_STREAMING);
-    SDL_SetNumberProperty(props, SDL_PROP_TEXTURE_CREATE_WIDTH_NUMBER, original->w);
-    SDL_SetNumberProperty(props, SDL_PROP_TEXTURE_CREATE_HEIGHT_NUMBER, original->h);
+    {
+        const SDL_TemporaryPropertyItem texture_prop_items[] = {
+            { SDL_PROP_TEXTURE_CREATE_COLORSPACE_NUMBER, SDL_PROPERTY_TYPE_NUMBER, { .n = yuv_colorspace } },
+            { SDL_PROP_TEXTURE_CREATE_FORMAT_NUMBER, SDL_PROPERTY_TYPE_NUMBER, { .n = yuv_format } },
+            { SDL_PROP_TEXTURE_CREATE_ACCESS_NUMBER, SDL_PROPERTY_TYPE_NUMBER, { .n = SDL_TEXTUREACCESS_STREAMING } },
+            { SDL_PROP_TEXTURE_CREATE_WIDTH_NUMBER, SDL_PROPERTY_TYPE_NUMBER, { .n = original->w } },
+            { SDL_PROP_TEXTURE_CREATE_HEIGHT_NUMBER, SDL_PROPERTY_TYPE_NUMBER, { .n = original->h } }
+        };
+        props = SDL_CreateTemporaryProperties(texture_prop_items, SDL_arraysize(texture_prop_items));
+    }
     output[2] = SDL_CreateTextureWithProperties(renderer, props);
     SDL_DestroyProperties(props);
     if (!output[0] || !output[1] || !output[2]) {
```

If following the rules for these objects (read-only, thread unsafe, etc), they could be used in other situations, as they can be used anywhere an SDL_PropertiesID is expected.

Fixes #14436.
