### PR TITLE
Improve OpenGL detection checks in CMake

### DIFF
--- a/cmake/sdlchecks.cmake
+++ b/cmake/sdlchecks.cmake
@@ -806,9 +806,9 @@ macro(FindOpenGLHeaders)
   find_package(OpenGL MODULE)
   # OPENGL_INCLUDE_DIRS is preferred over OPENGL_INCLUDE_DIR, but was only added in 3.29,
   # If the CMake minimum version is changed to be >= 3.29, the second check should be removed.
-  if(DEFINED OPENGL_INCLUDE_DIRS)
+  if(OPENGL_INCLUDE_DIRS)
     list(APPEND CMAKE_REQUIRED_INCLUDES ${OPENGL_INCLUDE_DIRS})
-  elseif(DEFINED OPENGL_INCLUDE_DIR)
+  elseif(OPENGL_INCLUDE_DIR)
     list(APPEND CMAKE_REQUIRED_INCLUDES ${OPENGL_INCLUDE_DIR})
   endif()
 endmacro()


### PR DESCRIPTION
Adds code to automatically find the OpenGL headers for the `CheckGLX`, `CheckOpenGL`, and `CheckOpenGLES` tests.

<!--- Provide a general summary of your changes in the Title above -->

## Description
The OpenGL headers are not always implicitly available, so this improves the check by calling `find_package` and using the `OPENGL_INCLUDE_DIRS` or `OPENGL_INCLUDE_DIR` var for the `check_c_source_compiles` test. 
The minimum CMake version currently set is 3.16, `OPENGL_INCLUDE_DIRS` was only added in 3.29, so the code is set to choose `OPENGL_INCLUDE_DIRS` if it exists. If the minimum CMake version is ever set to >= 3.29 this check can be removed and just the `OPENGL_INCLUDE_DIRS` variable can be used.

I use Bazzite, which is built on top of Fedora Silverblue, an immutable Linux distro. As such, despite being Fedora, `dnf` does not work, there are 3 alternatives: add `dnf` packages as layers with `rpm-ostree`, use a `distrobox` container for development, or use `brew` to install the packages. The first goes against the purpose of the immutable OS, the second works, but the OpenGL driver ends up being llvmpipe, and I'm now using the third which places packages into `/var/home/linuxbrew/.linuxbrew`. I've set my `CMAKE_PREFIX_PATH` to include brew, so CMake is capable of finding the OpenGL package, but it is not implicitly in my path.

This change allows for a cross platform improvement ensuring that so long as the user has setup their environment for CMake to find the requisite packages, their paths will be correctly included to make sure the OpenGL tests pass.

On my system, SDL builds with OpenGL support without any additional changes. 

I've tested this change on Bazzite, and on Bazzite in a `distrobox` (it's just a container that would ostensibly appear no different than regular Fedora). This change doesn't affect anything besides Unix that is not Apple, RISC OS or Haiku; that said, I've successfully tested it on macOS.
