### PR TITLE
Fix lost KEY_UP events with multiple keyboards using shared scancode state

### DIFF
--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -570,10 +570,8 @@ static bool SDL_SendKeyboardKeyInternal(Uint64 timestamp, Uint32 flags, SDL_Keyb
         // Update internal keyboard state
         if (down) {
             keyboard->keystate[scancode] = true;
-        } else {
-            if (keyboard->keyrefcount[scancode] == 0) {
-                keyboard->keystate[scancode] = false;
-            }
+        } else if (last_release) {
+            keyboard->keystate[scancode] = false;
         }
 
         keycode = SDL_GetKeyFromScancode(scancode, keyboard->modstate, true);


### PR DESCRIPTION
## Description
SDL was keeping a single boolean keystate per scancode. When two physical keyboards pressed the same key and then released it at roughly the same time, the first KEY_UP cleared the global state and the second KEY_UP was dropped. 

This change adds a per-scancode reference count (`keyrefcount[]`) to track how many devices currently hold that key, updates `SDL_SendKeyboardKeyInternal` to decrement the count on key up, and only clears `keystate` and modifier state when the last device releases the key. 

This matches the behavior expected in #12920 and works regardless of whether the events came from Windows raw input or other backends, because the drop was happening in the shared keyboard layer.

## Existing Issue(s)
Fixes https://github.com/libsdl-org/SDL/issues/12920
