### PR TITLE
cmake: only need cpu-feature.c from ndk on 32-bit ARM and when getauxval is unavailable

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -112,8 +112,6 @@ ifeq ($(NDK_DEBUG),1)
     cmd-strip :=
 endif
 
-LOCAL_STATIC_LIBRARIES := cpufeatures
-
 include $(BUILD_SHARED_LIBRARY)
 
 
@@ -145,4 +143,3 @@ LOCAL_EXPORT_LDLIBS :=
 
 include $(BUILD_STATIC_LIBRARY)
 
-$(call import-module,android/cpufeatures)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1407,11 +1407,6 @@ if(ANDROID)
     "${SDL3_SOURCE_DIR}/src/core/android/*.c"
     "${SDL3_SOURCE_DIR}/src/core/android/*.h"
   )
-  if(SDL_CPU_ARM32 AND NOT HAVE_GETAUXVAL)
-    sdl_sources("${CMAKE_ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c")
-    set_property(SOURCE "${CMAKE_ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c" APPEND PROPERTY COMPILE_OPTIONS "-Wno-declaration-after-statement")
-    sdl_include_directories(PRIVATE SYSTEM "${CMAKE_ANDROID_NDK}/sources/android/cpufeatures")
-  endif()
 
   sdl_glob_sources(
     "${SDL3_SOURCE_DIR}/src/misc/android/*.c"

--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -76,10 +76,6 @@
 #include <sys/param.h>
 #endif
 
-#if defined(SDL_PLATFORM_ANDROID) && defined(__arm__) && !defined(HAVE_GETAUXVAL)
-#include <cpu-features.h>
-#endif
-
 #if defined(HAVE_GETAUXVAL) || defined(HAVE_ELF_AUX_INFO)
 #include <sys/auxv.h>
 #endif


### PR DESCRIPTION
It is used in `src/cpuinfo/SDL_cpuinfo.c`:
https://github.com/libsdl-org/SDL/blob/7073cfc58eea9123206995ff881737401036a837/src/cpuinfo/SDL_cpuinfo.c#L79-L81


## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
