### PR TITLE
wayland: plug mutex leak of cursor thread

### DIFF
--- a/src/video/wayland/SDL_waylandmouse.c
+++ b/src/video/wayland/SDL_waylandmouse.c
@@ -478,6 +478,7 @@ static void Wayland_DestroyCursorThread(SDL_VideoData *data)
 
         WAYLAND_wl_proxy_wrapper_destroy(cursor_thread_context.compositor_wrapper);
         WAYLAND_wl_event_queue_destroy(cursor_thread_context.queue);
+        SDL_DestroyMutex(cursor_thread_context.lock);
         SDL_zero(cursor_thread_context);
     }
 }


### PR DESCRIPTION
Fixes this leak of testsprite:
```
Allocation 0: 40 bytes
	0x7f4d47b0d43c: SDL_calloc_REAL+0x45
	0x7f4d47d149bc: SDL_CreateMutex_REAL+0x17
	0x7f4d47cab5a7: Wayland_StartCursorThread+0x9f
	0x7f4d47cae028: Wayland_InitMouse+0xa7
	0x7f4d47cb36ea: Wayland_VideoInit+0x187
	0x7f4d47bbee85: SDL_VideoInit+0x358
	0x7f4d47a01bfe: SDL_InitSubSystem_REAL+0xe8
	0x7f4d47a3cdf1: SDL_InitSubSystem+0x19
	0x407366: SDLTest_CommonInit+0x108
	0x402fd0: SDL_AppInit+0x605
	0x7f4d47a8771f: SDL_InitMainCallbacks+0x6a
	0x7f4d47d3e6cf: SDL_EnterAppMainCallbacks_REAL+0x43
	0x7f4d47a396f4: SDL_EnterAppMainCallbacks+0x48
	0x401445: SDL_main+0x33
	0x7f4d47a878c6: SDL_RunApp_REAL+0x42
	0x7f4d47a317be: SDL_RunApp_DEFAULT+0x37
	0x7f4d47a3e769: SDL_RunApp+0x32
	0x40146e: main+0x27
	0x7f4d47811575: __libc_start_call_main+0x75
	0x7f4d47811628: __libc_start_main+0x88
	0x400ff5: _start+0x25
```
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
