### PR TITLE
Add SDL_(Get|Set)ClipRect automation test

### DIFF
--- a/test/testautomation_surface.c
+++ b/test/testautomation_surface.c
@@ -806,12 +806,12 @@ static int surface_testSetGetClipRect(void *args)
         SDL_bool cmpval;
     } rect_list[] = {
         { {   0,   0,   0,   0}, SDL_FALSE, SDL_TRUE},
-        { {   2,   2,   0,   0}, SDL_FALSE, SDL_FALSE},
+        { {   2,   2,   0,   0}, SDL_FALSE, SDL_TRUE},
         { {   2,   2,   5,   1}, SDL_TRUE,  SDL_TRUE},
         { {   6,   5,  10,   3}, SDL_TRUE,  SDL_FALSE},
         { {   0,   0,  10,  10}, SDL_TRUE,  SDL_TRUE},
-        { {   0,   0, -10,  10}, SDL_FALSE, SDL_FALSE},
-        { {   0,   0, -10, -10}, SDL_FALSE, SDL_FALSE},
+        { {   0,   0, -10,  10}, SDL_FALSE, SDL_TRUE},
+        { {   0,   0, -10, -10}, SDL_FALSE, SDL_TRUE},
         { { -10, -10,  10,  10}, SDL_FALSE, SDL_FALSE},
         { {  10, -10,  10,  10}, SDL_FALSE, SDL_FALSE},
         { {  10,  10,  10,  10}, SDL_TRUE,  SDL_FALSE}


### PR DESCRIPTION
This is a port of py-sdl2's sdl2.test.surface_test.test_SDL_GetSetClipRect test

When fixed/merged, this test should be copied to sdl2-compat, and then ported to sdl3.

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
