### PR TITLE
Fix WM_SYSKEYDOWN not being trapped by IME message handling

### DIFF
--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -1087,6 +1087,14 @@ bool WIN_HandleIMEMessage(HWND hwnd, UINT msg, WPARAM wParam, LPARAM *lParam, SD
             SDL_DebugIMELog("WM_KEYDOWN normal");
         }
         break;
+    case WM_SYSKEYDOWN:
+        if (wParam == VK_PROCESSKEY) {
+            SDL_DebugIMELog("WM_SYSKEYDOWN VK_PROCESSKEY");
+            trap = true;
+        } else {
+            SDL_DebugIMELog("WM_SYSKEYDOWN normal");
+        }
+        break;
     case WM_INPUTLANGCHANGE:
         SDL_DebugIMELog("WM_INPUTLANGCHANGE");
         IME_InputLangChanged(videodata);


### PR DESCRIPTION
This would cause <kbd>Alt</kbd> + <kbd>_something_</kbd> not trapping <kbd>_something_</kbd> if handled by the system IME. <kbd>Alt</kbd> + <kbd>Caps Lock</kbd> is used by the Japanese IME to switch to katakana.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes `WIN_HandleIMEMessage` to also trap `WM_SYSKEYDOWN` when it's `VK_PROCESSKEY`, the same way `WM_KEYDOWN` events are handled.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
- Closes https://github.com/libsdl-org/SDL/issues/14483