### PR TITLE
main: SDL_RunApp now explicitly handles NULL argv in all implementations.

### DIFF
--- a/include/SDL3/SDL_main.h
+++ b/include/SDL3/SDL_main.h
@@ -555,6 +555,9 @@ extern SDL_DECLSPEC void SDLCALL SDL_SetMainReady(void);
  * using SDL_main (like when using SDL_MAIN_HANDLED). When using this, you do
  * *not* need SDL_SetMainReady().
  *
+ * If `argv` is NULL, SDL will provide command line arguments, either by
+ * querying the OS for them if possible, or supplying a filler array if not.
+ *
  * \param argc the argc parameter from the application's main() function, or 0
  *             if the platform's main-equivalent has no argc.
  * \param argv the argv parameter from the application's main() function, or

--- a/src/main/SDL_main_callbacks.c
+++ b/src/main/SDL_main_callbacks.c
@@ -147,3 +147,13 @@ void SDL_QuitMainCallbacks(SDL_AppResult result)
     SDL_Quit();
 }
 
+void SDL_CheckDefaultArgcArgv(int *argc, char ***argv)
+{
+    if (!argv)
+    {
+        static char dummyargv0[] = { 'S', 'D', 'L', '_', 'a', 'p', 'p', '\0' };
+        static char *argvdummy[2] = { dummyargv0, NULL };
+        *argc = 1;
+        *argv = argvdummy;
+    }
+}

--- a/src/main/SDL_main_callbacks.h
+++ b/src/main/SDL_main_callbacks.h
@@ -27,6 +27,10 @@ SDL_AppResult SDL_InitMainCallbacks(int argc, char *argv[], SDL_AppInit_func app
 SDL_AppResult SDL_IterateMainCallbacks(bool pump_events);
 void SDL_QuitMainCallbacks(SDL_AppResult result);
 
+// (not a callback thing, but convenient to stick this in here.)
+// If *_argv is NULL, update *_argc and *_argv to point at a static array of { "SDL_app", NULL }.
+void SDL_CheckDefaultArgcArgv(int *_argc, char ***_argv);
+
 #endif // SDL_main_callbacks_h_
 
 

--- a/src/main/SDL_runapp.c
+++ b/src/main/SDL_runapp.c
@@ -19,6 +19,7 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 #include "SDL_internal.h"
+#include "SDL_main_callbacks.h"
 
 /* Most platforms that use/need SDL_main have their own SDL_RunApp() implementation.
  * If not, you can special case it here by appending || defined(__YOUR_PLATFORM__) */
@@ -27,16 +28,7 @@
 int SDL_RunApp(int argc, char *argv[], SDL_main_func mainFunction, void * reserved)
 {
     (void)reserved;
-
-    if(!argv)
-    {
-        // make sure argv isn't NULL, in case some user code doesn't like that
-        static char dummyargv0[] = { 'S', 'D', 'L', '_', 'a', 'p', 'p', '\0' };
-        static char *argvdummy[2] = { dummyargv0, NULL };
-        argc = 1;
-        argv = argvdummy;
-    }
-
+    SDL_CheckDefaultArgcArgv(&argc, &argv);
     return mainFunction(argc, argv);
 }
 

--- a/src/main/emscripten/SDL_sysmain_runapp.c
+++ b/src/main/emscripten/SDL_sysmain_runapp.c
@@ -22,6 +22,8 @@
 
 #ifdef SDL_PLATFORM_EMSCRIPTEN
 
+#include "../SDL_main_callbacks.h"
+
 #include <emscripten/emscripten.h>
 
 EM_JS_DEPS(sdlrunapp, "$dynCall,$stringToNewUTF8");
@@ -34,6 +36,8 @@ EMSCRIPTEN_KEEPALIVE void force_free(void *ptr) { free(ptr); }
 int SDL_RunApp(int argc, char *argv[], SDL_main_func mainFunction, void * reserved)
 {
     (void)reserved;
+
+    SDL_CheckDefaultArgcArgv(&argc, &argv);
 
     // Move any URL params that start with "SDL_" over to environment
     //  variables, so the hint system can pick them up, etc, much like a user

--- a/src/main/n3ds/SDL_sysmain_runapp.c
+++ b/src/main/n3ds/SDL_sysmain_runapp.c
@@ -23,11 +23,16 @@
 
 #ifdef SDL_PLATFORM_3DS
 
+#include "../SDL_main_callbacks.h"
+
 #include <3ds.h>
 
 int SDL_RunApp(int argc, char *argv[], SDL_main_func mainFunction, void * reserved)
 {
     int result;
+
+    SDL_CheckDefaultArgcArgv(&argc, &argv);
+
     // init
     osSetSpeedupEnable(true);
     romfsInit();

--- a/src/main/ps2/SDL_sysmain_runapp.c
+++ b/src/main/ps2/SDL_sysmain_runapp.c
@@ -25,6 +25,8 @@
 
 // SDL_RunApp() code for PS2 based on SDL_ps2_main.c, fjtrujy@gmail.com
 
+#include "../SDL_main_callbacks.h"
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -68,6 +70,8 @@ int SDL_RunApp(int argc, char *argv[], SDL_main_func mainFunction, void * reserv
 {
     int res;
     (void)reserved;
+
+    SDL_CheckDefaultArgcArgv(&argc, &argv);
 
     prepare_IOP();
     init_drivers();

--- a/src/main/psp/SDL_sysmain_runapp.c
+++ b/src/main/psp/SDL_sysmain_runapp.c
@@ -28,6 +28,7 @@
 #include <pspkernel.h>
 #include <pspthreadman.h>
 #include "../../events/SDL_events_c.h"
+#include "../SDL_main_callbacks.h"
 
 /* If application's main() is redefined as SDL_main, and libSDL_main is
    linked, then this file will create the standard exit callback,
@@ -72,6 +73,9 @@ int sdl_psp_setup_callbacks(void)
 int SDL_RunApp(int argc, char *argv[], SDL_main_func mainFunction, void * reserved)
 {
     (void)reserved;
+
+    SDL_CheckDefaultArgcArgv(&argc, &argv);
+
     sdl_psp_setup_callbacks();
 
     SDL_SetMainReady();

--- a/src/video/uikit/SDL_uikitappdelegate.m
+++ b/src/video/uikit/SDL_uikitappdelegate.m
@@ -29,6 +29,7 @@
 #import "SDL_uikitwindow.h"
 
 #include "../../events/SDL_events_c.h"
+#include "../../main/SDL_main_callbacks.h"
 
 #ifdef main
 #undef main
@@ -41,7 +42,7 @@ static int exit_status;
 
 int SDL_RunApp(int argc, char *argv[], SDL_main_func mainFunction, void *reserved)
 {
-    int i;
+    SDL_CheckDefaultArgcArgv(&argc, &argv);
 
     // store arguments
     /* Note that we need to be careful about how we allocate/free memory here.
@@ -51,11 +52,11 @@ int SDL_RunApp(int argc, char *argv[], SDL_main_func mainFunction, void *reserve
     forward_main = mainFunction;
     forward_argc = argc;
     forward_argv = (char **)malloc((argc + 1) * sizeof(char *)); // This should NOT be SDL_malloc()
-    for (i = 0; i < argc; i++) {
+    for (int i = 0; i < argc; i++) {
         forward_argv[i] = malloc((strlen(argv[i]) + 1) * sizeof(char)); // This should NOT be SDL_malloc()
         strcpy(forward_argv[i], argv[i]);
     }
-    forward_argv[i] = NULL;
+    forward_argv[argc] = NULL;
 
     // Give over control to run loop, SDLUIKitDelegate will handle most things from here
     @autoreleasepool {
@@ -71,7 +72,7 @@ int SDL_RunApp(int argc, char *argv[], SDL_main_func mainFunction, void *reserve
     }
 
     // free the memory we used to hold copies of argc and argv
-    for (i = 0; i < forward_argc; i++) {
+    for (int i = 0; i < forward_argc; i++) {
         free(forward_argv[i]); // This should NOT be SDL_free()
     }
     free(forward_argv); // This should NOT be SDL_free()


### PR DESCRIPTION

It'll usually replace it with `{ "SDL_app", NULL }`, but things like Win32 can query the OS for the original command line arguments.

This allows apps/scripting languages that provide their own entry points to use SDL_RunApp and not have to worry about how to compose an argv array on things like Windows, when SDL was going to do it for them anyhow.

Most things won't experience any change with this commit, including apps that that want extra control but originate in a standard main()-style entry point and can just pass the existing argc/argv through to SDL_RunApp.

Closes #12676.

