### PR TITLE
reorder Vulkan load paths on Mac to avoid issues

### DIFF
--- a/src/video/cocoa/SDL_cocoavulkan.m
+++ b/src/video/cocoa/SDL_cocoavulkan.m
@@ -36,12 +36,12 @@
 #include <dlfcn.h>
 
 const char *defaultPaths[] = {
-    "@executable_path/../Frameworks/libMoltenVK.dylib",
     "vulkan.framework/vulkan",
     "libvulkan.1.dylib",
     "libvulkan.dylib",
     "MoltenVK.framework/MoltenVK",
-    "libMoltenVK.dylib"
+    "libMoltenVK.dylib",
+    "@executable_path/../Frameworks/libMoltenVK.dylib"
 };
 
 // Since libSDL is most likely a .dylib, need RTLD_DEFAULT not RTLD_SELF.


### PR DESCRIPTION
The commit d2c6aeea7df2e2d942b76836fea5c50929a5755f (fixing #14313) adds the path `"@executable_path/../Frameworks/libMoltenVK.dylib"` to `defaultPaths` in SDL_cocoavulkan.m.

The same change which was made to volk in [zeux/volk/pull/245](https://github.com/zeux/volk/pull/262) caused an issue [zeux/volk/issues/267](https://github.com/zeux/volk/issues/267). Im worried that the same issue could happen here and so I suggest moving  `"@executable_path/../Frameworks/libMoltenVK.dylib"` to be the last path checked.

Sorry if this is a volk only issue and not actually relevant.
