### PR TITLE
Add Fribidi and libthai packages to README-linux.md

### DIFF
--- a/docs/README-linux.md
+++ b/docs/README-linux.md
@@ -19,7 +19,7 @@ Ubuntu 18.04, all available features enabled:
     libaudio-dev libfribidi-dev libjack-dev libsndio-dev libx11-dev libxext-dev \
     libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libxtst-dev \
     libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \
-    libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev
+    libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev libthai-dev
 
 Ubuntu 22.04+ can also add `libpipewire-0.3-dev libwayland-dev libdecor-0-dev liburing-dev` to that command line.
 
@@ -32,7 +32,7 @@ Fedora 35, all available features enabled:
     systemd-devel mesa-libGL-devel libxkbcommon-devel mesa-libGLES-devel \
     mesa-libEGL-devel vulkan-devel wayland-devel wayland-protocols-devel \
     libdrm-devel mesa-libgbm-devel libusb1-devel libdecor-devel \
-    pipewire-jack-audio-connection-kit-devel
+    pipewire-jack-audio-connection-kit-devel libthai-devel
 
 Fedora 39+ can also add `liburing-devel` to that command line.
 
@@ -44,11 +44,11 @@ openSUSE Tumbleweed:
 
     sudo zypper in libunwind-devel libusb-1_0-devel Mesa-libGL-devel libxkbcommon-devel libdrm-devel \
     libgbm-devel pipewire-devel libpulse-devel sndio-devel Mesa-libEGL-devel alsa-devel xwayland-devel \
-    wayland-devel wayland-protocols-devel
+    wayland-devel wayland-protocols-devel libthai-devel fribidi-devel
 
 Arch:
 
-    sudo pacman -S alsa-lib cmake hidapi ibus jack libdecor libgl libpulse libusb libx11 libxcursor libxext libxinerama libxkbcommon libxrandr libxrender libxss libxtst mesa ninja pipewire sndio vulkan-driver vulkan-headers wayland wayland-protocols
+    sudo pacman -S alsa-lib cmake hidapi ibus jack libdecor libthai fribidi libgl libpulse libusb libx11 libxcursor libxext libxinerama libxkbcommon libxrandr libxrender libxss libxtst mesa ninja pipewire sndio vulkan-driver vulkan-headers wayland wayland-protocols
 
 
 Joystick does not work


### PR DESCRIPTION
The Debuntu and Fedora commands were lacking the packages for libthai, the SUSE and Arch ones lacked both Fribidi and libthai package names.