### PR TITLE
uikit: Don't copy argv; the original lives the whole time we need it.

### DIFF
--- a/src/video/uikit/SDL_uikitappdelegate.m
+++ b/src/video/uikit/SDL_uikitappdelegate.m
@@ -45,18 +45,9 @@ int SDL_RunApp(int argc, char *argv[], SDL_main_func mainFunction, void *reserve
     SDL_CheckDefaultArgcArgv(&argc, &argv);
 
     // store arguments
-    /* Note that we need to be careful about how we allocate/free memory here.
-     * If the application calls SDL_SetMemoryFunctions(), we can't rely on
-     * SDL_free() to use the same allocator after SDL_main() returns.
-     */
     forward_main = mainFunction;
     forward_argc = argc;
-    forward_argv = (char **)malloc((argc + 1) * sizeof(char *)); // This should NOT be SDL_malloc()
-    for (int i = 0; i < argc; i++) {
-        forward_argv[i] = malloc((SDL_strlen(argv[i]) + 1) * sizeof(char)); // This should NOT be SDL_malloc()
-        strcpy(forward_argv[i], argv[i]);
-    }
-    forward_argv[argc] = NULL;
+    forward_argv = argv;
 
     // Give over control to run loop, SDLUIKitDelegate will handle most things from here
     @autoreleasepool {
@@ -70,12 +61,6 @@ int SDL_RunApp(int argc, char *argv[], SDL_main_func mainFunction, void *reserve
         }
         UIApplicationMain(argc, argv, nil, name);
     }
-
-    // free the memory we used to hold copies of argc and argv
-    for (int i = 0; i < forward_argc; i++) {
-        free(forward_argv[i]); // This should NOT be SDL_free()
-    }
-    free(forward_argv); // This should NOT be SDL_free()
 
     return exit_status;
 }


### PR DESCRIPTION
Reference Issue #14510.

This is untested at the moment.