### PR TITLE
Fix check_stdlib_usage.py libc call matching

### DIFF
--- a/build-scripts/check_stdlib_usage.py
+++ b/build-scripts/check_stdlib_usage.py
@@ -29,7 +29,7 @@ import sys
 
 SDL_ROOT = pathlib.Path(__file__).resolve().parents[1]
 
-STDLIB_SYMBOLS = [
+STDLIB_SYMBOLS = (
     'abs',
     'acos',
     'acosf',
@@ -147,8 +147,8 @@ STDLIB_SYMBOLS = [
     'wcsncasecmp',
     'wcsncmp',
     'wcsstr',
-]
-RE_STDLIB_SYMBOL = re.compile(rf"\b(?P<symbol>{'|'.join(STDLIB_SYMBOLS)})\b\(")
+)
+RE_STDLIB_SYMBOL = re.compile(rf"(?<!->)\b(?P<symbol>{'|'.join(STDLIB_SYMBOLS)})\b\(")
 
 
 def find_symbols_in_file(file: pathlib.Path) -> int:
@@ -220,13 +220,19 @@ def find_symbols_in_file(file: pathlib.Path) -> int:
                     line_comment += line[pos_line_comment:]
                     line = line[:pos_line_comment]
 
-                if m := RE_STDLIB_SYMBOL.match(line):
-                    override_string = f"This should NOT be SDL_{m['symbol']}()"
-                    if override_string not in line_comment:
-                        print(f"{filename}:{line_i}")
-                        print(f"    {line}")
-                        print(f"")
-                        match_count += 1
+                if matches := tuple(RE_STDLIB_SYMBOL.finditer(line)):
+                    text_string = " or ".join(f"SDL_{m.group(1)}" for m in matches)
+                    first_quote = line.find("\"")
+                    last_quote = line.rfind("\"")
+                    first_occurrence = min(m.span()[0] for m in matches)
+                    last_occurrence = max(m.span()[1] for m in matches)
+                    if first_quote == -1 or not (first_quote < first_occurrence and last_quote > last_occurrence):
+                        override_string = f"This should NOT be {text_string}"
+                        if override_string not in line_comment:
+                            print(f"{filename}:{line_i}")
+                            print(f"    {line}")
+                            print(f"")
+                            match_count += 1
 
     except UnicodeDecodeError:
         print(f"{file} is not text, skipping", file=sys.stderr)
@@ -235,7 +241,7 @@ def find_symbols_in_file(file: pathlib.Path) -> int:
 
 def find_symbols_in_dir(path: pathlib.Path) -> int:
     match_count = 0
-    for entry in path.glob("*"):
+    for entry in path.iterdir():
         if entry.is_dir():
             match_count += find_symbols_in_dir(entry)
         else:
@@ -249,7 +255,10 @@ def main():
 
     print(f"Looking for stdlib usage in {args.path}...")
 
-    match_count = find_symbols_in_dir(args.path)
+    if args.path.is_file():
+        match_count = find_symbols_in_file(args.path)
+    else:
+        match_count = find_symbols_in_dir(args.path)
 
     if match_count:
         print("If the stdlib usage is intentional, add a '// This should NOT be SDL_<symbol>()' line comment.")

--- a/src/camera/pipewire/SDL_camera_pipewire.c
+++ b/src/camera/pipewire/SDL_camera_pipewire.c
@@ -330,7 +330,7 @@ static struct param *param_add(struct spa_list *params,
         id = SPA_POD_OBJECT_ID(param);
     }
 
-    p = malloc(sizeof(*p) + (param != NULL ? SPA_POD_SIZE(param) : 0));
+    p = malloc(sizeof(*p) + (param != NULL ? SPA_POD_SIZE(param) : 0)); // This should NOT be SDL_malloc()
     if (p == NULL)
         return NULL;
 
@@ -950,7 +950,7 @@ static void hotplug_registry_global_callback(void *object, uint32_t id,
         g->permissions = permissions;
         g->props = props ? PIPEWIRE_pw_properties_new_dict(props) : NULL;
         g->proxy = proxy;
-        g->name = strdup(name);
+        g->name = strdup(name); // This should NOT be SDL_strdup()
         spa_list_init(&g->pending_list);
         spa_list_init(&g->param_list);
         spa_list_append(&hotplug.global_list, &g->link);

--- a/src/dynapi/SDL_dynapi.c
+++ b/src/dynapi/SDL_dynapi.c
@@ -515,7 +515,7 @@ static void SDL_InitDynamicAPILocked(void)
     const DWORD rc = GetEnvironmentVariableA(SDL_DYNAMIC_API_ENVVAR, envbuf, (DWORD) sizeof (envbuf));
     char *libname = ((rc != 0) && (rc < sizeof (envbuf))) ? envbuf : NULL;
 #else
-    char *libname = getenv(SDL_DYNAMIC_API_ENVVAR);
+    char *libname = getenv(SDL_DYNAMIC_API_ENVVAR); // This should NOT be SDL_getenv()
 #endif
 
     SDL_DYNAPI_ENTRYFN entry = NULL; // funcs from here by default.

--- a/src/main/emscripten/SDL_sysmain_runapp.c
+++ b/src/main/emscripten/SDL_sysmain_runapp.c
@@ -31,7 +31,7 @@ EM_JS_DEPS(sdlrunapp, "$dynCall,$stringToNewUTF8");
 // even though we reference the C runtime's free() in other places, it appears
 // to be inlined more aggressively in Emscripten 4, so we need a reference to
 // it here, too, so the inlined Javascript doesn't fail to find it.
-EMSCRIPTEN_KEEPALIVE void force_free(void *ptr) { free(ptr); }
+EMSCRIPTEN_KEEPALIVE void force_free(void *ptr) { free(ptr); } // This should NOT be SDL_free()
 
 int SDL_RunApp(int argc, char *argv[], SDL_main_func mainFunction, void * reserved)
 {

--- a/src/sensor/emscripten/SDL_emscriptensensor.c
+++ b/src/sensor/emscripten/SDL_emscriptensensor.c
@@ -45,9 +45,9 @@ static void SDL_EMSCRIPTEN_AccelerometerCallback(const EmscriptenDeviceMotionEve
 
     // Convert from browser specific gravity constant to SDL_STANDARD_GRAVITY.
     total_gravity = 0.0;
-    total_gravity += fabs(event->accelerationIncludingGravityX - event->accelerationX);
-    total_gravity += fabs(event->accelerationIncludingGravityY - event->accelerationY);
-    total_gravity += fabs(event->accelerationIncludingGravityZ - event->accelerationZ);
+    total_gravity += SDL_fabs(event->accelerationIncludingGravityX - event->accelerationX);
+    total_gravity += SDL_fabs(event->accelerationIncludingGravityY - event->accelerationY);
+    total_gravity += SDL_fabs(event->accelerationIncludingGravityZ - event->accelerationZ);
 
     gravity[0] = (event->accelerationIncludingGravityX - event->accelerationX) / total_gravity;
     gravity[1] = (event->accelerationIncludingGravityY - event->accelerationY) / total_gravity;

--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -398,7 +398,7 @@ static int get_plane_id(SDL_VideoDevice *_this, unsigned int crtc_id, uint32_t p
                 drmModePropertyPtr p = KMSDRM_drmModeGetProperty(viddata->drm_fd,
                     props->props[j]);
 
-                if ((strcmp(p->name, "type") == 0) && (props->prop_values[j] == plane_type)) {
+                if ((SDL_strcmp(p->name, "type") == 0) && (props->prop_values[j] == plane_type)) {
                     /* found our plane, use that: */
                     found = 1;
                 }

--- a/src/video/uikit/SDL_uikitappdelegate.m
+++ b/src/video/uikit/SDL_uikitappdelegate.m
@@ -53,7 +53,7 @@ int SDL_RunApp(int argc, char *argv[], SDL_main_func mainFunction, void *reserve
     forward_argc = argc;
     forward_argv = (char **)malloc((argc + 1) * sizeof(char *)); // This should NOT be SDL_malloc()
     for (int i = 0; i < argc; i++) {
-        forward_argv[i] = malloc((strlen(argv[i]) + 1) * sizeof(char)); // This should NOT be SDL_malloc()
+        forward_argv[i] = malloc((SDL_strlen(argv[i]) + 1) * sizeof(char)); // This should NOT be SDL_malloc()
         strcpy(forward_argv[i], argv[i]);
     }
     forward_argv[argc] = NULL;

--- a/test/testautomation_math.c
+++ b/test/testautomation_math.c
@@ -3051,23 +3051,23 @@ static const SDLTest_TestCaseReference modfTestBase = {
 
 static const SDLTest_TestCaseReference powTestExpInf1 = {
     pow_baseNOneExpInfCases, "pow_baseNOneExpInfCases",
-    "Checks for pow(-1, +/-inf)", TEST_ENABLED
+    "Checks for SDL_pow(-1, +/-inf)", TEST_ENABLED
 };
 static const SDLTest_TestCaseReference powTestExpInf2 = {
     pow_baseZeroExpNInfCases, "pow_baseZeroExpNInfCases",
-    "Checks for pow(+/-0, -inf)", TEST_ENABLED
+    "Checks for SDL_pow(+/-0, -inf)", TEST_ENABLED
 };
 static const SDLTest_TestCaseReference powTestExpInf3 = {
     pow_expInfCases, "pow_expInfCases",
-    "Checks for pow(x, +/-inf)", TEST_ENABLED
+    "Checks for SDL_pow(x, +/-inf)", TEST_ENABLED
 };
 static const SDLTest_TestCaseReference powTestBaseInf1 = {
     pow_basePInfCases, "pow_basePInfCases",
-    "Checks for pow(inf, x)", TEST_ENABLED
+    "Checks for SDL_pow(inf, x)", TEST_ENABLED
 };
 static const SDLTest_TestCaseReference powTestBaseInf2 = {
     pow_baseNInfCases, "pow_baseNInfCases",
-    "Checks for pow(-inf, x)", TEST_ENABLED
+    "Checks for SDL_pow(-inf, x)", TEST_ENABLED
 };
 static const SDLTest_TestCaseReference powTestNan1 = {
     pow_badOperationCase, "pow_badOperationCase",
@@ -3075,31 +3075,31 @@ static const SDLTest_TestCaseReference powTestNan1 = {
 };
 static const SDLTest_TestCaseReference powTestNan2 = {
     pow_base1ExpNanCase, "pow_base1ExpNanCase",
-    "Checks for pow(1.0, NAN)", TEST_ENABLED
+    "Checks for SDL_pow(1.0, NAN)", TEST_ENABLED
 };
 static const SDLTest_TestCaseReference powTestNan3 = {
     pow_baseNanExp0Cases, "pow_baseNanExp0Cases",
-    "Checks for pow(NAN, +/-0)", TEST_ENABLED
+    "Checks for SDL_pow(NAN, +/-0)", TEST_ENABLED
 };
 static const SDLTest_TestCaseReference powTestNan4 = {
     pow_nanArgsCases, "pow_nanArgsCases",
-    "Checks for pow(x, y) with either x or y being NAN", TEST_ENABLED
+    "Checks for SDL_pow(x, y) with either x or y being NAN", TEST_ENABLED
 };
 static const SDLTest_TestCaseReference powTestZero1 = {
     pow_baseNZeroExpOddCases, "pow_baseNZeroExpOddCases",
-    "Checks for pow(-0.0, y), with y an odd integer.", TEST_ENABLED
+    "Checks for SDL_pow(-0.0, y), with y an odd integer.", TEST_ENABLED
 };
 static const SDLTest_TestCaseReference powTestZero2 = {
     pow_basePZeroExpOddCases, "pow_basePZeroExpOddCases",
-    "Checks for pow(0.0, y), with y an odd integer.", TEST_ENABLED
+    "Checks for SDL_pow(0.0, y), with y an odd integer.", TEST_ENABLED
 };
 static const SDLTest_TestCaseReference powTestZero3 = {
     pow_baseNZeroCases, "pow_baseNZeroCases",
-    "Checks for pow(-0.0, y), with y finite and even or non-integer number", TEST_ENABLED
+    "Checks for SDL_pow(-0.0, y), with y finite and even or non-integer number", TEST_ENABLED
 };
 static const SDLTest_TestCaseReference powTestZero4 = {
     pow_basePZeroCases, "pow_basePZeroCases",
-    "Checks for pow(0.0, y), with y finite and even or non-integer number", TEST_ENABLED
+    "Checks for SDL_pow(0.0, y), with y finite and even or non-integer number", TEST_ENABLED
 };
 static const SDLTest_TestCaseReference powTestRegular = {
     pow_regularCases, "pow_regularCases",


### PR DESCRIPTION
It now matches libc usage inside statements,
and skips libc-like usage in strings or as struct members.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
