### PR TITLE
JNI_Unload must return the JNI version needed by the native library

### DIFF
--- a/src/core/SDL_core_unsupported.c
+++ b/src/core/SDL_core_unsupported.c
@@ -184,7 +184,6 @@ Sint32 JNI_OnLoad(JavaVM *vm, void *reserved)
 {
     (void)vm;
     (void)reserved;
-    SDL_Unsupported();
-    return -1; // JNI_ERR
+    return 0x00010004; // JNI_VERSION_1_4
 }
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
Fixes #14536
