### PR TITLE
Added display link feature for better latency on OSX, fix for AllowedFramesInFlight & SDL_WaitForGPUSwapchain

### DIFF
--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -3919,6 +3919,14 @@ static void METAL_ReleaseWindow(
         }
 
         METAL_Wait(driverData);
+#ifdef SDL_DISPLAY_LINK_AVAILABLE
+        if(renderer->useDisplayLink)
+            METAL_INTERNAL_ReleaseDisplayLink(window);
+
+        while(SDL_GetAtomicInt(&windowData->undisplayedFrameCount) != 0) {
+            // spin
+        }
+#endif
         SDL_Metal_DestroyView(windowData->view);
         for (int i = 0; i < MAX_FRAMES_IN_FLIGHT; i += 1) {
             if (windowData->inFlightFences[i] != NULL) {
@@ -3937,10 +3945,6 @@ static void METAL_ReleaseWindow(
             }
         }
         SDL_UnlockMutex(renderer->windowLock);
-#ifdef SDL_DISPLAY_LINK_AVAILABLE
-        if(renderer->useDisplayLink)
-            METAL_INTERNAL_ReleaseDisplayLink(window);
-#endif
         SDL_free(windowData);
 
         SDL_ClearProperty(SDL_GetWindowProperties(window), WINDOW_PROPERTY_DATA);


### PR DESCRIPTION
## Description
Added SDL_WaitCondition in METAL_WaitForSwapchain and AcquireSwapchainTexture to wait for a callback from CVDisplayLink and to wait for presentation of previous frames. A conventional game while loop like while(!quit) { sample_input(); present(); } quickly overflows CAMetalLayer* with four frames, and then there's a four frame queue to everything.
The difference is especially stark in imgui, please try the imgui demo with this patch), but remember to call SDL_WaitForGPUSwapchain or SDL_WaitAndAcquireGPUSwapchainTexture before sampling input

## Existing Issue(s)
issue #14456
https://github.com/libsdl-org/SDL/issues/14456
