### PR TITLE
Remove busy loops in SDL_GPUFence

### DIFF
--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -3602,8 +3602,7 @@ static bool METAL_WaitForFences(
             waiting = 1;
             while (waiting) {
                 for (Uint32 i = 0; i < numFences; i += 1) {
-                    MetalFence *fence = (MetalFence *)fences[i];
-                    if (METAL_INTERNAL_FenceComplete(fence)) {
+                    if (METAL_INTERNAL_FenceComplete((MetalFence *)fences[i])) {
                         waiting = 0;
                         break;
                     }
@@ -4152,7 +4151,7 @@ static bool METAL_Wait(
          * Sort of equivalent to vkDeviceWaitIdle.
          */
         for (Uint32 i = 0; i < renderer->submittedCommandBufferCount; i += 1) {
-            METAL_WaitForFences(renderer, true, (SDL_GPUFence **)&renderer->submittedCommandBuffers[i]->fence, 1);
+            METAL_WaitForFences(driverData, true, (SDL_GPUFence **)&renderer->submittedCommandBuffers[i]->fence, 1);
         }
 
         SDL_LockMutex(renderer->submitLock);


### PR DESCRIPTION
SDL_GPUFence is implemented as just a busy loop on an atomic int, a SDL_GPUCondition gives the cpu some rest