### PR TITLE
Fix iOS text input not working with password integration 2

### DIFF
--- a/src/video/uikit/SDL_uikitviewcontroller.m
+++ b/src/video/uikit/SDL_uikitviewcontroller.m
@@ -578,6 +578,14 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 
 - (void)textFieldTextDidChange:(NSNotification *)notification
 {
+    // When opening a password manager overlay to select a password and have it auto-filled,
+    // text input becomes stopped as a result of the keyboard being hidden or the text field losing focus.
+    // As a workaround, ensure text input is activated on any changes to the text field.
+    bool startTextInputMomentarily = !SDL_TextInputActive(window);
+
+    if (startTextInputMomentarily)
+        SDL_StartTextInput(window);
+
     if (textField.markedTextRange == nil) {
         if (isOTPMode && labs((NSInteger)textField.text.length - (NSInteger)committedText.length) != 1) {
             return;
@@ -616,6 +624,9 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
         }
         committedText = textField.text;
     }
+
+    if (startTextInputMomentarily)
+        SDL_StopTextInput(window);
 }
 
 - (void)updateKeyboard
@@ -661,7 +672,7 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 - (BOOL)textField:(UITextField *)_textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
 {
     if (!isOTPMode) {
-        if (textField.markedTextRange == nil && textField.text.length < 16) {
+        if (textField.markedTextRange == nil && [string length] == 0 && textField.text.length < 16) {
             [self resetTextState];
         }
     }


### PR DESCRIPTION
Brings back fix from https://github.com/libsdl-org/SDL/pull/11845 which got unintentionally reverted in https://github.com/libsdl-org/SDL/commit/113c7e8a5801c54dd17f9caedd6712929f7cfbd2#diff-47611140f5b7f6ec09baaa9ada4d3425cbb1be18edfbcf51d53c2c39006b3353L557-L601. See https://github.com/libsdl-org/SDL/issues/13717#issuecomment-3592628548.