### PR TITLE
GPU: Prefer D3D12 over Vulkan when available

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -627,7 +627,7 @@ static const SDL_GPUBootstrap * SDL_GPUSelectBackend(SDL_PropertiesID props)
     }
 
     for (i = 0; backends[i]; i += 1) {
-        if (backends[i] != NULL && backends[i]->PrepareDriver(_this, props)) {
+        if (backends[i]->PrepareDriver(_this, props)) {
             return backends[i];
         }
     }


### PR DESCRIPTION
Defines the order of GPU backend preference by platform. 

On Windows, we prefer D3D12, on Apple we prefer Metal, on Android we prefer Vulkan (really it's the only possible option), and on Unix/BSD we prefer Vulkan. On all other platforms we use the default preference order of Private -> Metal -> Vulkan -> D3D12. 

Resolves #14564 