### PR TITLE
DirectInput FFB: Calculate appropriate update flags

### DIFF
--- a/src/haptic/windows/SDL_dinputhaptic.c
+++ b/src/haptic/windows/SDL_dinputhaptic.c
@@ -946,7 +946,7 @@ err_effectdone:
     return false;
 }
 
-BOOL DIGetDirectionUpdateFlag(DIEFFECT* before, DIEFFECT* after)
+BOOL DIGetDirectionUpdateFlag(DIEFFECT *before, DIEFFECT *after)
 {
     if (before->cAxes != after->cAxes) {
         return true;
@@ -958,11 +958,11 @@ BOOL DIGetDirectionUpdateFlag(DIEFFECT* before, DIEFFECT* after)
     if (before->rglDirection == NULL) {
         return true;
     }
-
     return SDL_memcmp(before->rglDirection, after->rglDirection, sizeof(LONG) * before->cAxes) != 0;
 }
 
-BOOL DIGetEnvelopeUpdateFlag(DIEFFECT* before, DIEFFECT* after) {
+BOOL DIGetEnvelopeUpdateFlag(DIEFFECT* before, DIEFFECT* after)
+{
     if (before->lpEnvelope == NULL && after->lpEnvelope == NULL) {
         return false;
     }
@@ -973,7 +973,7 @@ BOOL DIGetEnvelopeUpdateFlag(DIEFFECT* before, DIEFFECT* after) {
     return SDL_memcmp(before->lpEnvelope, after->lpEnvelope, sizeof(DIENVELOPE)) != 0;
 }
 
-BOOL DIGetTypeSpecificParamsUpdateFlag(DIEFFECT* before, DIEFFECT* after)
+BOOL DIGetTypeSpecificParamsUpdateFlag(DIEFFECT *before, DIEFFECT *after)
 {
     // Shouldn't happen since this implies an effect's type somehow changed, but need to check to avoid an out-of-bounds memcmp
     if (before->cbTypeSpecificParams != after->cbTypeSpecificParams) {


### PR DESCRIPTION
Hi there. Same guy, different account--It's been a while, but I finally got the time to write the PR for this.

## Context

Anecodtally, some force-feedback wheels have been reported to experience a reduced "definition", "texture", "precision", or "je ne sais quoi", which appears to be caused by sending more update flags than necessary to DirectInput.

This may be related to the fact that there are two USB PID packets that are sent when updating a device: One contains the "general" force data, and the other contains the "type-specific" data. My speculation is that many wheels expect to only receive the latter, and misbehave when receiving both.

This has been tested and validated anecdotally by others who have received a hacked-together version of PCSX2 that corrects the flags sent to DirectInput, who noted a significant improvement in the "feeling" of the FFB effects.

The only way to validate this at a technical level is to grab a wheel that uses the "generic" DirectInput FFB drivers (which map nearly 1:1 with the USB PID specification), and inspect the USB packets (e.g. with USBPcap) to check whether redundant data is being sent.

## Description
This PR adjusts the DirectInput Haptic implementation to compare the requested haptic update to the previous state of the haptic effect. Using this, it calculates which update flags to pass on to DirectInput, which prevents redundant flags from being sent. This appears to fix subjective FFB quality problems on certain specific FFB wheels.

## Existing Issue(s)
[Issue #12511: SDL_DINPUT_HapticUpdateEffect sends unnecessary flags to IDirectInputEffect_SetParameters, which harms FFB quality in certain devices/usecases ](https://github.com/libsdl-org/SDL/issues/12511)