### PR TITLE
Add more keychron devices to the joystick blacklist

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -449,6 +449,7 @@ static Uint32 initial_blacklist_devices[] = {
     MAKE_VIDPID(0x31e3, 0x1310), // Wooting 60HE (ARM)
     MAKE_VIDPID(0x3297, 0x1969), // Moonlander MK1 Keyboard
     MAKE_VIDPID(0x3434, 0x0211), // Keychron K1 Pro System Control
+    MAKE_VIDPID(0x3434, 0x0353), // Keychron V5 System Control
     MAKE_VIDPID(0x3434, 0xd030), // Keychron Link
 };
 static SDL_vidpid_list blacklist_devices = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added the keychron link receiver and the V5 keyboard to the joystick blacklist

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/PCSX2/pcsx2/issues/12133#event-20895739643 (PCSX2 uses sdl for controller support)
