### PR TITLE
GPU: Remove erroneous buffer usage flag from defrag process

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -10810,8 +10810,6 @@ static bool VULKAN_INTERNAL_DefragmentMemory(
         VulkanMemoryUsedRegion *currentRegion = allocation->usedRegions[i];
 
         if (currentRegion->isBuffer && !currentRegion->vulkanBuffer->markedForDestroy) {
-            currentRegion->vulkanBuffer->usage |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-
             VulkanBuffer *newBuffer = VULKAN_INTERNAL_CreateBuffer(
                 renderer,
                 currentRegion->vulkanBuffer->size,


### PR DESCRIPTION
This line is bogus and mixes two different enum types. It's unnecessary anyway because all GPU buffers have the destination bit set, transfer buffers do not get defragged, and uniform buffers don't preserve their contents. 

This fix can be safely brought into 3.2.x. 