### PR TITLE
Fix an inverted condition in Wayland pen tip handling

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -3458,7 +3458,7 @@ static void tablet_tool_handle_frame(void *data, struct zwp_tablet_tool_v2 *tool
 
     // I don't know if this is necessary (or makes sense), but send motion before pen downs, but after pen ups, so you don't get unexpected lines drawn.
     if (sdltool->frame.have_motion && sdltool->frame.tool_state) {
-        if (sdltool->frame.tool_state == WAYLAND_TABLET_TOOL_STATE_UP) {
+        if (sdltool->frame.tool_state == WAYLAND_TABLET_TOOL_STATE_DOWN) {
             SDL_SendPenMotion(timestamp, instance_id, window, sdltool->frame.x, sdltool->frame.y);
             SDL_SendPenTouch(timestamp, instance_id, window, false, true);  // !!! FIXME: how do we know what tip is in use?
         } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
https://github.com/libsdl-org/SDL/blob/c61497b744f64806eeea1b3d8289a5c97ca862da/src/events/SDL_pen_c.h#L73

Wayland backend currently sets `down` of SDL_SendPenTouch to true when a pen is up. This PR fixes the inverted condition.