### PR TITLE
emscripten: Allow SDL_HINT_EMSCRIPTEN_FILL_DOCUMENT to be toggled on a window.

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -788,22 +788,26 @@ extern "C" {
 #define SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT "SDL_EMSCRIPTEN_KEYBOARD_ELEMENT"
 
 /**
- * Dictate that newly-created windows will fill the whole browser window.
+ * Dictate that windows on Emscripten will fill the whole browser window.
  *
- * The canvas element fills the entire document. Resize events will be
- * generated as the browser window is resized, as that will adjust the canvas
- * size as well. The canvas will cover anything else on the page, including
- * any controls provided by Emscripten in its generated HTML file. Often times
- * this is desirable for a browser-based game, but it means several things
- * that we expect of an SDL window on other platforms might not work as
- * expected, such as minimum window sizes and aspect ratios.
+ * When enabled, the canvas element fills the entire document. Resize events
+ * will be generated as the browser window is resized, as that will adjust the
+ * canvas size as well. The canvas will cover anything else on the page,
+ * including any controls provided by Emscripten in its generated HTML file
+ * (in fact, any elements on the page that aren't the canvas will be moved
+ * into a hidden `div` element).
+ *
+ * Often times this is desirable for a browser-based game, but it means
+ * several things that we expect of an SDL window on other platforms might not
+ * work as expected, such as minimum window sizes and aspect ratios.
  *
  * This hint overrides SDL_PROP_WINDOW_CREATE_EMSCRIPTEN_FILL_DOCUMENT_BOOLEAN
  * properties when creating an SDL window.
  *
- * This hint only applies to the emscripten platform.
+ * This hint only applies to the Emscripten platform.
  *
- * This hint should be set before creating a window.
+ * This hint can be set at any time (before creating the window, or to toggle
+ * its state later). Only one window can fill the document at a time.
  *
  * \since This hint is available since SDL 3.4.0.
  */

--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -518,10 +518,10 @@ static EM_BOOL Emscripten_HandleResize(int eventType, const EmscriptenUiEvent *u
                 force = true;
             }
         }
-
-        if (window_data->fill_document || (window_data->window->flags & SDL_WINDOW_RESIZABLE)) {
+        const bool fill_document = (Emscripten_fill_document_window == window_data->window);
+        if (fill_document || (window_data->window->flags & SDL_WINDOW_RESIZABLE)) {
             double w, h;
-            if (window_data->fill_document) {
+            if (fill_document) {
                 w = (double) uiEvent->windowInnerWidth;
                 h = (double) uiEvent->windowInnerHeight;
             } else {

--- a/src/video/emscripten/SDL_emscriptenvideo.h
+++ b/src/video/emscripten/SDL_emscriptenvideo.h
@@ -35,10 +35,11 @@ struct SDL_WindowData
 
     SDL_GLContext gl_context;
 
+    int non_fill_document_width;
+    int non_fill_document_height;
+
     char *canvas_id;
     char *keyboard_element;
-
-    bool fill_document;
 
     float pixel_ratio;
 
@@ -52,6 +53,8 @@ struct SDL_WindowData
 
     bool mouse_focus_loss_pending;
 };
+
+extern SDL_Window *Emscripten_fill_document_window;
 
 bool Emscripten_ShouldSetSwapInterval(int interval);
 


### PR DESCRIPTION

Fixes #14567.

