### PR TITLE
Document need to include SDL_revision.h for SDL_REVISION

### DIFF
--- a/include/SDL3/SDL_revision.h
+++ b/include/SDL3/SDL_revision.h
@@ -44,6 +44,9 @@
  * clue in debugging forensics and not something the app will parse in any
  * way.
  *
+ * SDL_revision.h must be included in your program explicitly if you want access
+ * to the SDL_REVISION constant.
+ *
  * \since This macro is available since SDL 3.2.0.
  */
 #define SDL_REVISION "Some arbitrary string decided at SDL build time"

--- a/include/SDL3/SDL_version.h
+++ b/include/SDL3/SDL_version.h
@@ -153,7 +153,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetVersion(void);
  *
  * This value is the revision of the code you are linking against and may be
  * different from the code you are compiling with, which is found in the
- * constant SDL_REVISION.
+ * constant SDL_REVISION if you explicitly include SDL_revision.h
  *
  * The revision is an arbitrary string (a hash value) uniquely identifying the
  * exact revision of the SDL library in use, and is only useful in comparing


### PR DESCRIPTION
If you want access to the `SDL_REVISION` define, you must explicitly include this header.

Language like this was present in the [SDL2 version](https://wiki.libsdl.org/SDL2/SDL_REVISION), but disappeared in SDL3, even though it's still true.

First I intended to simply include `SDL_revision.h` from `SDL_version.h`, but since there seems to have been some conscious design decision to not do that, at least in SDL2, this is my conservative alternative [to that PR](https://github.com/libsdl-org/SDL/compare/main...eloj:SDL:version-include-revision).