### PR TITLE
Fix incorrect angle calculation in `SDL_AppIterate`.

### DIFF
--- a/examples/renderer/03-lines/lines.c
+++ b/examples/renderer/03-lines/lines.c
@@ -77,8 +77,9 @@ SDL_AppResult SDL_AppIterate(void *appstate)
         const float size = 30.0f;
         const float x = 320.0f;
         const float y = 95.0f - (size / 2.0f);
+        const float r = (float)i * SDL_PI_F / 180.0;
         SDL_SetRenderDrawColor(renderer, SDL_rand(256), SDL_rand(256), SDL_rand(256), SDL_ALPHA_OPAQUE);
-        SDL_RenderLine(renderer, x, y, x + SDL_sinf((float) i) * size, y + SDL_cosf((float) i) * size);
+        SDL_RenderLine(renderer, x, y, x + SDL_cosf(r) * size, y + SDL_sinf(r) * size);
     }
 
     SDL_RenderPresent(renderer);  /* put it all on the screen! */


### PR DESCRIPTION
## Description
Fixes the radial line rendering in `SDL_AppIterate` by correcting the angle calculation. 
The original code incorrectly used `SDL_sinf` for X and `SDL_cosf` for Y and applied the angles as degrees instead of radians, resulting in lines being drawn at wrong orientations.
This update converts the loop index from degrees to radians and applies the standard polar-to-Cartesian conversion (_cos_ for X, _sin_ for Y).

## Existing Issue
No existing issue reported; this resolves an observed rendering bug.
