### PR TITLE
(Emscripten / bug fix) Handle SharedArrayBuffer for PNG data in `SDL_SetWindowIcon`

### DIFF
--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -812,6 +812,11 @@ static bool Emscripten_SetWindowIcon(SDL_VideoDevice *_this, SDL_Window *window,
     // Pass PNG data to JavaScript
     MAIN_THREAD_EM_ASM({
         var pngData = HEAPU8.subarray($0, $0 + $1);
+        if (pngData.buffer instanceof SharedArrayBuffer) {
+            // explicitly create a copy
+            pngData = new Uint8Array(pngData);
+        }
+
         var blob = new Blob([pngData], {type: 'image/png'});
         var url = URL.createObjectURL(blob);
 


### PR DESCRIPTION
The Emscripten support for setting window icons introduced in #14490 does not work when using pthreads. Using `SDL_SetWindowIcon` will cause the program to crash. The reason for that is that the `Blob` constructor does not accept shared memory (`SharedArrayBuffer`).

<img width="714" height="384" alt="image" src="https://github.com/user-attachments/assets/7412d60f-df24-4cfa-924b-d25c107c401a" />

We need to create a local copy of the icon data if necessary.
