### PR TITLE
video: Handle window destruction in event handlers

### DIFF
--- a/src/events/SDL_windowevents.c
+++ b/src/events/SDL_windowevents.c
@@ -252,62 +252,66 @@ bool SDL_SendWindowEvent(SDL_Window *window, SDL_EventType windowevent, int data
         posted = SDL_PushEvent(&event);
     }
 
-    switch (windowevent) {
-    case SDL_EVENT_WINDOW_SHOWN:
-        SDL_OnWindowShown(window);
-        break;
-    case SDL_EVENT_WINDOW_HIDDEN:
-        SDL_OnWindowHidden(window);
-        break;
-    case SDL_EVENT_WINDOW_MOVED:
-        SDL_OnWindowMoved(window);
-        break;
-    case SDL_EVENT_WINDOW_RESIZED:
-        SDL_OnWindowResized(window);
-        break;
-    case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
-        SDL_OnWindowPixelSizeChanged(window);
-        break;
-    case SDL_EVENT_WINDOW_MINIMIZED:
-        SDL_OnWindowMinimized(window);
-        break;
-    case SDL_EVENT_WINDOW_MAXIMIZED:
-        SDL_OnWindowMaximized(window);
-        break;
-    case SDL_EVENT_WINDOW_RESTORED:
-        SDL_OnWindowRestored(window);
-        break;
-    case SDL_EVENT_WINDOW_MOUSE_ENTER:
-        SDL_OnWindowEnter(window);
-        break;
-    case SDL_EVENT_WINDOW_MOUSE_LEAVE:
-        SDL_OnWindowLeave(window);
-        break;
-    case SDL_EVENT_WINDOW_FOCUS_GAINED:
-        SDL_OnWindowFocusGained(window);
-        break;
-    case SDL_EVENT_WINDOW_FOCUS_LOST:
-        SDL_OnWindowFocusLost(window);
-        break;
-    case SDL_EVENT_WINDOW_DISPLAY_CHANGED:
-        SDL_OnWindowDisplayChanged(window);
-        break;
-    default:
-        break;
+    // Ensure that the window is still valid, as it may have been destroyed in an event handler.
+    window = SDL_GetWindowFromID(event.window.windowID);
+
+    if (window) {
+        switch (windowevent) {
+        case SDL_EVENT_WINDOW_SHOWN:
+            SDL_OnWindowShown(window);
+            break;
+        case SDL_EVENT_WINDOW_HIDDEN:
+            SDL_OnWindowHidden(window);
+            break;
+        case SDL_EVENT_WINDOW_MOVED:
+            SDL_OnWindowMoved(window);
+            break;
+        case SDL_EVENT_WINDOW_RESIZED:
+            SDL_OnWindowResized(window);
+            break;
+        case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
+            SDL_OnWindowPixelSizeChanged(window);
+            break;
+        case SDL_EVENT_WINDOW_MINIMIZED:
+            SDL_OnWindowMinimized(window);
+            break;
+        case SDL_EVENT_WINDOW_MAXIMIZED:
+            SDL_OnWindowMaximized(window);
+            break;
+        case SDL_EVENT_WINDOW_RESTORED:
+            SDL_OnWindowRestored(window);
+            break;
+        case SDL_EVENT_WINDOW_MOUSE_ENTER:
+            SDL_OnWindowEnter(window);
+            break;
+        case SDL_EVENT_WINDOW_MOUSE_LEAVE:
+            SDL_OnWindowLeave(window);
+            break;
+        case SDL_EVENT_WINDOW_FOCUS_GAINED:
+            SDL_OnWindowFocusGained(window);
+            break;
+        case SDL_EVENT_WINDOW_FOCUS_LOST:
+            SDL_OnWindowFocusLost(window);
+            break;
+        case SDL_EVENT_WINDOW_DISPLAY_CHANGED:
+            SDL_OnWindowDisplayChanged(window);
+            break;
+        default:
+            break;
+        }
     }
 
-    if (windowevent == SDL_EVENT_WINDOW_CLOSE_REQUESTED && !window->parent && !SDL_HasActiveTrays()) {
-        int toplevel_count = 0;
-        SDL_Window *n;
-        for (n = _this->windows; n; n = n->next) {
+    if (windowevent == SDL_EVENT_WINDOW_CLOSE_REQUESTED && !SDL_HasActiveTrays()) {
+        int count = window ? 0 : 1;
+        for (SDL_Window *n = _this->windows; n; n = n->next) {
             if (!n->parent && !(n->flags & SDL_WINDOW_HIDDEN)) {
-                ++toplevel_count;
+                ++count;
             }
         }
 
-        if (toplevel_count <= 1) {
+        if (count <= 1) {
             if (SDL_GetHintBoolean(SDL_HINT_QUIT_ON_LAST_WINDOW_CLOSE, true)) {
-                SDL_SendQuit(); // This is the last toplevel window in the list so send the SDL_EVENT_QUIT event
+                SDL_SendQuit(); // This is the last window in the list, so send the SDL_EVENT_QUIT event
             }
         }
     }


### PR DESCRIPTION
Windows may be destroyed in event handlers, so check the window validity after pushing window events onto the queue to ensure that the window and its properties are still valid, and account for destroyed windows when counting windows to send a quit message.

Fixes #14630 