### PR TITLE
Revert "Don't enable the text-input protocol when using Fcitx"

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -3235,22 +3235,8 @@ static void Wayland_SeatCreateTextInput(SDL_WaylandSeat *seat)
     }
 }
 
-void Wayland_DisplayCreateTextInputManager(SDL_VideoData *d, uint32_t id)
+void Wayland_DisplayInitTextInputManager(SDL_VideoData *d, uint32_t id)
 {
-#ifdef HAVE_FCITX
-    const char *im_module = SDL_getenv("SDL_IM_MODULE");
-    if (im_module && SDL_strcmp(im_module, "fcitx") == 0) {
-        /* Override the Wayland text-input protocol when Fcitx is enabled, like how GTK_IM_MODULE does.
-         *
-         * The Fcitx wiki discourages enabling it under Wayland via SDL_IM_MODULE, so its presence must
-         * be intentional, and this workaround is needed for fixing key repeat detection.
-         */
-        return;
-    }
-#endif
-
-    d->text_input_manager = wl_registry_bind(d->registry, id, &zwp_text_input_manager_v3_interface, 1);
-
     SDL_WaylandSeat *seat;
     wl_list_for_each(seat, &d->seat_list, link) {
         Wayland_SeatCreateTextInput(seat);

--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -277,7 +277,7 @@ extern void Wayland_DisplayInitTabletManager(SDL_VideoData *display);
 extern void Wayland_DisplayInitDataDeviceManager(SDL_VideoData *display);
 extern void Wayland_DisplayInitPrimarySelectionDeviceManager(SDL_VideoData *display);
 
-extern void Wayland_DisplayCreateTextInputManager(SDL_VideoData *d, uint32_t id);
+extern void Wayland_DisplayInitTextInputManager(SDL_VideoData *d, uint32_t id);
 
 extern void Wayland_DisplayCreateSeat(SDL_VideoData *display, struct wl_seat *wl_seat, Uint32 id);
 extern void Wayland_SeatDestroy(SDL_WaylandSeat *seat, bool shutting_down);

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -1293,7 +1293,8 @@ static void handle_registry_global(void *data, struct wl_registry *registry, uin
     } else if (SDL_strcmp(interface, "xdg_activation_v1") == 0) {
         d->activation_manager = wl_registry_bind(d->registry, id, &xdg_activation_v1_interface, 1);
     } else if (SDL_strcmp(interface, "zwp_text_input_manager_v3") == 0) {
-        Wayland_DisplayCreateTextInputManager(d, id);
+        d->text_input_manager = wl_registry_bind(d->registry, id, &zwp_text_input_manager_v3_interface, 1);
+        Wayland_DisplayInitTextInputManager(d, id);
     } else if (SDL_strcmp(interface, "wl_data_device_manager") == 0) {
         d->data_device_manager = wl_registry_bind(d->registry, id, &wl_data_device_manager_interface, SDL_min(3, version));
         Wayland_DisplayInitDataDeviceManager(d);


### PR DESCRIPTION
It turns out that some distros set SDL_IM_MODULE globally, which leads to broken text input with this check, and there really is no reason not to use the text input protocol when available.

I suspect that the main reason for the pull that originally added this was as a roundabout way of disabling text input in an SDL2 game that left it enabled by default, and exhibited problems when the system was set to a locale that used an IME. Unfortunate, but I think that leaving this check in will break things for many more people, so the best course of action is to revert this.

Reverts 2b375d9704d23dfa72eff1260451050208026413
Fixes #14493