### PR TITLE
x11: Use XInput2 to handle pointer input while grabbed and touches ar…

### DIFF
--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -1839,7 +1839,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
 
     case MotionNotify:
     {
-        if (data->xinput2_mouse_enabled && !data->mouse_grabbed) {
+        if (X11_Xinput2HandlesMotionForWindow(data)) {
             // This input is being handled by XInput2
             break;
         }

--- a/src/video/x11/SDL_x11xinput2.h
+++ b/src/video/x11/SDL_x11xinput2.h
@@ -41,5 +41,6 @@ extern void X11_Xinput2UngrabTouch(SDL_VideoDevice *_this, SDL_Window *window);
 extern bool X11_Xinput2SelectMouseAndKeyboard(SDL_VideoDevice *_this, SDL_Window *window);
 extern void X11_Xinput2UpdateDevices(SDL_VideoDevice *_this);
 extern void X11_Xinput2UpdatePointerMapping(SDL_VideoDevice *_this);
+extern bool X11_Xinput2HandlesMotionForWindow(SDL_WindowData *window_data);
 
 #endif // SDL_x11xinput2_h_


### PR DESCRIPTION
…e active

Core X11 events are used for absolute motion while the mouse is grabbed, as XInput doesn't receive motion events from the master pointer, and the position from the slave devices lags one report behind. However, pointer events emulated from multitouch events can't be filtered out when using core events, as the XInput flags are not passed through.

Use the absolute position from slave devices in XInput motion events while the mouse is grabbed and touch events are active to allow filtering out pointer events emulated from touch events. Pointer events in this case may be a report behind the master device, but receiving input from both the pointer and touches simultaneously is not likely to be a common occurrence.

Fixes #14607