### PR TITLE
Fix using wrong variable by mistake

### DIFF
--- a/src/joystick/SDL_gamepad.c
+++ b/src/joystick/SDL_gamepad.c
@@ -2619,7 +2619,7 @@ static int SDL_PrivateAddGamepadMapping(const char *mappingString, SDL_GamepadMa
             } else {
                 const char *hint_value = SDL_GetHint(hint);
                 if (!hint_value) {
-                    hint_value = SDL_getenv_unsafe(hint_value);
+                    hint_value = SDL_getenv_unsafe(hint);
                 }
                 value = SDL_GetStringBoolean(hint_value, default_value);
                 if (negate) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Mistake added in https://github.com/libsdl-org/SDL/commit/517a3d20e8cf52cbd7bc3b9ae48349017e87c095.

Calling `SDL_getenv_unsafe(hint_value);` is basically the same as `SDL_getenv_unsafe(NULL);`