### PR TITLE
Fix SDL_EnumerateDirectory(/) failing on POSIX and Windows.

### DIFF
--- a/src/filesystem/posix/SDL_sysfsops.c
+++ b/src/filesystem/posix/SDL_sysfsops.c
@@ -85,7 +85,7 @@ bool SDL_SYS_EnumerateDirectory(const char *path, SDL_EnumerateDirectoryCallback
 
     // trim down to a single path separator at the end, in case the caller added one or more.
     pathwithseplen--;
-    while ((pathwithseplen >= 0) && (pathwithsep[pathwithseplen] == '/')) {
+    while ((pathwithseplen > 0) && (pathwithsep[pathwithseplen] == '/')) {
         pathwithsep[pathwithseplen--] = '\0';
     }
 

--- a/src/filesystem/windows/SDL_sysfsops.c
+++ b/src/filesystem/windows/SDL_sysfsops.c
@@ -57,7 +57,7 @@ bool SDL_SYS_EnumerateDirectory(const char *path, SDL_EnumerateDirectoryCallback
 
         // trim down to a single path separator at the end, in case the caller added one or more.
         patternlen--;
-        while ((patternlen >= 0) && ((pattern[patternlen] == '\\') || (pattern[patternlen] == '/'))) {
+        while ((patternlen > 0) && ((pattern[patternlen] == '\\') || (pattern[patternlen] == '/'))) {
             pattern[patternlen--] ='\0';
         }
         pattern[++patternlen] = '\\';


### PR DESCRIPTION
## Description

Root cause was a bug in the internal `SDL_SYS_EnumerateDirectory` implementation which overtrimmed, leading to paths like `/` being read as `empty` and `/.` being read as `/`

This bug effected Linux and Mac and a similar pattern was found in the Window's codepath for this implementation but there seems to be some fallback logic there for empty strings. Nonetheless, fixed overtrimming there as well.

## Existing Issue(s)

Fixes https://github.com/libsdl-org/SDL/issues/14637