### PR TITLE
GPU: Ensure Vulkan doesn't pass unsupported feature structures for requested vulkan version

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -12254,12 +12254,14 @@ static Uint8 VULKAN_INTERNAL_CreateLogicalDevice(
     deviceCreateInfo.ppEnabledExtensionNames = deviceExtensions;
 
     VkPhysicalDeviceFeatures2 featureList;
-    if (features->usesCustomVulkanOptions) {
+    int minor = VK_VERSION_MINOR(features->desiredApiVersion);
+
+    if (features->usesCustomVulkanOptions && minor > 0) {
         featureList.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
         featureList.features = features->desiredVulkan10DeviceFeatures;
-        featureList.pNext = &features->desiredVulkan11DeviceFeatures;
+        featureList.pNext = minor > 1 ? &features->desiredVulkan11DeviceFeatures : (void *)deviceCreateInfo.pNext;
         features->desiredVulkan11DeviceFeatures.pNext = &features->desiredVulkan12DeviceFeatures;
-        features->desiredVulkan12DeviceFeatures.pNext = &features->desiredVulkan13DeviceFeatures;
+        features->desiredVulkan12DeviceFeatures.pNext = minor > 2 ? &features->desiredVulkan13DeviceFeatures : (void *)deviceCreateInfo.pNext;
         features->desiredVulkan13DeviceFeatures.pNext = (void *)deviceCreateInfo.pNext;
         deviceCreateInfo.pEnabledFeatures = NULL;
         deviceCreateInfo.pNext = &featureList;

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -12259,10 +12259,10 @@ static Uint8 VULKAN_INTERNAL_CreateLogicalDevice(
     if (features->usesCustomVulkanOptions && minor > 0) {
         featureList.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
         featureList.features = features->desiredVulkan10DeviceFeatures;
-        featureList.pNext = minor > 1 ? &features->desiredVulkan11DeviceFeatures : (void *)deviceCreateInfo.pNext;
+        featureList.pNext = minor > 1 ? &features->desiredVulkan11DeviceFeatures : NULL;
         features->desiredVulkan11DeviceFeatures.pNext = &features->desiredVulkan12DeviceFeatures;
-        features->desiredVulkan12DeviceFeatures.pNext = minor > 2 ? &features->desiredVulkan13DeviceFeatures : (void *)deviceCreateInfo.pNext;
-        features->desiredVulkan13DeviceFeatures.pNext = (void *)deviceCreateInfo.pNext;
+        features->desiredVulkan12DeviceFeatures.pNext = minor > 2 ? &features->desiredVulkan13DeviceFeatures : NULL;
+        features->desiredVulkan13DeviceFeatures.pNext = NULL;
         deviceCreateInfo.pEnabledFeatures = NULL;
         deviceCreateInfo.pNext = &featureList;
     } else {


### PR DESCRIPTION
Passing unsupported vulkan structs, even if empty, can cause crashes with debug layers

## Description
When using the GPU Vulkan Options structure, the current code will pass the vulkan feature list for each version of Vulkan regardless of the requested version.

This is causing a crash on debug layers, at least in my case. Requesting a Vulkan version >= 1.3 will cause the crash to not happen.

Simple solution is to simply check if we can pass the structs for each specific version.

For context:

* `VkPhysicalDeviceFeatures2` is only available from Vulkan 1.1 onwards
* `VkPhysicalDeviceVulkan11Features` and `VkPhysicalDeviceVulkan11Features` are only available from Vulkan 1.2 onwards
* `VkPhysicalDeviceVulkan13Features` is only available from vulkan 1.3 onwards
