### PR TITLE
wayland: Update the HDR data on placeholder displays

### DIFF
--- a/src/video/wayland/SDL_waylandcolor.c
+++ b/src/video/wayland/SDL_waylandcolor.c
@@ -110,6 +110,15 @@ static void image_description_info_handle_done(void *data,
         case WAYLAND_COLOR_OBJECT_TYPE_DISPLAY:
         {
             SDL_copyp(&state->display_data->HDR, &state->HDR);
+
+            if (state->display_data->display) {
+                SDL_VideoDisplay *disp = SDL_GetVideoDisplay(state->display_data->display);
+                if (disp) {
+                    SDL_SetDisplayHDRProperties(disp, &state->HDR);
+                }
+            } else {
+                SDL_copyp(&state->display_data->placeholder.HDR, &state->HDR);
+            }
         } break;
     }
 }

--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -1069,8 +1069,6 @@ static void handle_wl_output_done(void *data, struct wl_output *output)
         AddEmulatedModes(internal, native_mode.w, native_mode.h);
     }
 
-    SDL_SetDisplayHDRProperties(dpy, &internal->HDR);
-
     if (internal->display == 0) {
         // First time getting display info, initialize the VideoDisplay
         if (internal->physical_width_mm >= internal->physical_height_mm) {
@@ -1086,6 +1084,9 @@ static void handle_wl_output_done(void *data, struct wl_output *output)
 
         // During initialization, the displays will be added after enumeration is complete.
         if (!video->initializing) {
+            if (video->wp_color_manager_v1) {
+                Wayland_GetColorInfoForOutput(internal, false);
+            }
             internal->display = SDL_AddVideoDisplay(&internal->placeholder, true);
             SDL_free(internal->placeholder.name);
             SDL_zero(internal->placeholder);
@@ -1133,7 +1134,6 @@ static void handle_output_image_description_changed(void *data,
                                                     struct wp_color_management_output_v1 *wp_color_management_output_v1)
 {
     SDL_DisplayData *display = (SDL_DisplayData *)data;
-    // wl_display.done is called after this event, so the display HDR status will be updated there.
     Wayland_GetColorInfoForOutput(display, false);
 }
 
@@ -1173,7 +1173,11 @@ static bool Wayland_add_display(SDL_VideoData *d, uint32_t id, uint32_t version)
     if (data->videodata->wp_color_manager_v1) {
         data->wp_color_management_output = wp_color_manager_v1_get_output(data->videodata->wp_color_manager_v1, output);
         wp_color_management_output_v1_add_listener(data->wp_color_management_output, &wp_color_management_output_listener, data);
-        Wayland_GetColorInfoForOutput(data, true);
+
+        // If not initializing, this will be queried synchronously in wl_output.done.
+        if (d->initializing) {
+            Wayland_GetColorInfoForOutput(data, true);
+        }
     }
     return true;
 }


### PR DESCRIPTION
Update the HDR data on a placeholder display if it hasn't been finalized and added yet, or the HDR data on the added display will be incorrect.

Fixes #14666