### PR TITLE
GPU: Fix Android surface and swapchain recreation on app resume

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -9807,8 +9807,6 @@ static bool VULKAN_ClaimWindow(
             return false;
         }
 
-        windowData->needsSurfaceRecreate = false;
-
         Uint32 createSwapchainResult = VULKAN_INTERNAL_CreateSwapchain(renderer, windowData);
         if (createSwapchainResult == 1) {
             SDL_SetPointerProperty(SDL_GetWindowProperties(window), WINDOW_PROPERTY_DATA, windowData);
@@ -10016,9 +10014,9 @@ static bool VULKAN_INTERNAL_AcquireSwapchainTexture(
             return true;
         }
 
-#ifdef SDL_PLATFORM_ANDROID
+        // Unset this flag until after the swapchain has been recreated to let VULKAN_INTERNAL_CreateSwapchain()
+        // know whether it needs to pass the old swapchain or not.
         windowData->needsSurfaceRecreate = false;
-#endif
     }
 
     if (windowData->inFlightFences[windowData->frameCounter] != NULL) {


### PR DESCRIPTION
## Description
I want to put this up for review since this doesn't look very clean to me and I'm not sure about the best way to do it (for example, the pointer to `vkCreateAndroidSurfaceKHR()` is retrieved every time it's used), but the problem is (mostly) fixed.

I've found the cause of failure when switching apps with SDL GPU. Not only the swapchain needs to be recreated, the surface must be recreated, too. I'm still getting an error which I haven't managed to fix: `vkCreateSwapchainKHR VK_ERROR_NATIVE_WINDOW_IN_USE_KHR`. But at least now we can ignore it and rendering will continue the next frame after resuming the app, fixing the regression made in 1260c10.

Usage notes: In order to avoid another error, the app should stop rendering (stop calling `SDL_WaitAndAcquireGPUSwapchainTexture()`) when the event ~`SDL_EVENT_WINDOW_FOCUS_LOST`~ `SDL_EVENT_DID_ENTER_BACKGROUND` is received, and resume rendering on ~`SDL_EVENT_WINDOW_FOCUS_GAINED`~ `SDL_EVENT_DID_ENTER_FOREGROUND`.