### PR TITLE
[SDL2] tests: extend testatomic timeout to 120 seconds

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -504,6 +504,7 @@ foreach(TESTCASE ${SDL_TESTS_NONINTERACTIVE})
     endif()
 endforeach()
 
+set_tests_properties(testatomic PROPERTIES TIMEOUT 120)
 set_tests_properties(testautomation PROPERTIES TIMEOUT 120)
 set_tests_properties(testthread PROPERTIES TIMEOUT 40)
 set_tests_properties(testtimer PROPERTIES TIMEOUT 60)


### PR DESCRIPTION
## Description

The default (i.e. 10 seconds) is not enough for slower architectures, such as alpha or hppa.

Raise it to 120 seconds according to the feedback of hppa porters: https://bugs.debian.org/1095774