### PR TITLE
[SDL2] test: Don't expect a specific error message

### DIFF
--- a/test/testautomation_surface.c
+++ b/test/testautomation_surface.c
@@ -768,29 +768,24 @@ int surface_testOverflow(void *arg)
 
     if (sizeof(size_t) == 4 && sizeof(int) >= 4) {
         SDL_ClearError();
-        expectedError = "Out of memory";
         /* 0x5555'5555 * 3bpp = 0xffff'ffff which fits in size_t, but adding
          * alignment padding makes it overflow */
         surface = SDL_CreateRGBSurfaceWithFormat(0, 0x55555555, 1, 24, SDL_PIXELFORMAT_RGB24);
         SDLTest_AssertCheck(surface == NULL, "Should detect overflow in width + alignment");
-        SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), expectedError) == 0,
-                            "Expected \"%s\", got \"%s\"", expectedError, SDL_GetError());
+        SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), "") != 0, "Error indicator should be set");
         SDL_ClearError();
         /* 0x4000'0000 * 4bpp = 0x1'0000'0000 which (just) overflows */
         surface = SDL_CreateRGBSurfaceWithFormat(0, 0x40000000, 1, 32, SDL_PIXELFORMAT_ARGB8888);
         SDLTest_AssertCheck(surface == NULL, "Should detect overflow in width * bytes per pixel");
-        SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), expectedError) == 0,
-                            "Expected \"%s\", got \"%s\"", expectedError, SDL_GetError());
+        SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), "") != 0, "Error indicator should be set");
         SDL_ClearError();
         surface = SDL_CreateRGBSurfaceWithFormat(0, (1 << 29) - 1, (1 << 29) - 1, 8, SDL_PIXELFORMAT_INDEX8);
         SDLTest_AssertCheck(surface == NULL, "Should detect overflow in width * height");
-        SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), expectedError) == 0,
-                            "Expected \"%s\", got \"%s\"", expectedError, SDL_GetError());
+        SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), "") != 0, "Error indicator should be set");
         SDL_ClearError();
         surface = SDL_CreateRGBSurfaceWithFormat(0, (1 << 15) + 1, (1 << 15) + 1, 32, SDL_PIXELFORMAT_ARGB8888);
         SDLTest_AssertCheck(surface == NULL, "Should detect overflow in width * height * bytes per pixel");
-        SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), expectedError) == 0,
-                            "Expected \"%s\", got \"%s\"", expectedError, SDL_GetError());
+        SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), "") != 0, "Error indicator should be set");
     } else {
         SDLTest_Log("Can't easily overflow size_t on this platform");
     }


### PR DESCRIPTION
SDL3 + sdl2-compat doesn't give precisely the same error message as "classic" SDL2 here. To facilitate the transition from "classic" SDL2 to sdl2-compat, allow either one. This allows the "classic" SDL2 test suite to be run against sdl2-compat, demonstrating that sdl2-compat is indeed compatible with the version that it's replacing.

---

I'm looking into what needs to happen for Debian (and indirectly Ubuntu) to replace "classic" SDL2 with sdl2-compat, following in the footsteps of other distros like Arch and Fedora. Specifically, the version of `sdl2-compat` in `experimental` takes over the package names `libsdl2-2.0-0` and `libsdl2-dev` previously provided by "classic" SDL2, so that it will become the default.

In Debian's automated test machinery, the "as-installed" tests for all existing packages that depend on a particular library are run against new proposed versions of that library. In the case where the package name `libsdl2-2.0-0` is taken over, the result is that we run both the "classic" SDL2 test suite `libsdl2-tests` and the sdl2-compat test suite `libsdl2-compat-tests` against the sdl2-compat library (currently only with the `dummy` audio and video backends). This might seem unexpected, but it does seem like a a good way to prove that sdl2-compat is actually compatible with "classic" SDL2 during the transition, and these error messages seem to be the only assertions that actually need relaxing.