### PR TITLE
Fix building joystick for OpenBSD

### DIFF
--- a/src/joystick/bsd/SDL_bsdjoystick.c
+++ b/src/joystick/bsd/SDL_bsdjoystick.c
@@ -710,10 +710,10 @@ static void BSD_JoystickUpdate(SDL_Joystick *joy)
                     //default:
                         // no-op
                     }
-                    SDL_PrivateJoystickHat(joy, 0, (dpad[0] * HAT_UP) |
-                                                   (dpad[1] * HAT_DOWN) |
-                                                   (dpad[2] * HAT_RIGHT) |
-                                                   (dpad[3] * HAT_LEFT) );
+                    SDL_SendJoystickHat(timestamp, joy, 0, (dpad[0] * HAT_UP) |
+                                                           (dpad[1] * HAT_DOWN) |
+                                                           (dpad[2] * HAT_RIGHT) |
+                                                           (dpad[3] * HAT_LEFT) );
 #endif
                     break;
                 }


### PR DESCRIPTION
https://github.com/libsdl-org/SDL/pull/7996 broke building for OpenBSD because it changed back to using `SDL_PrivateJoystickHat` which doesn't seem to exist anymore.