### PR TITLE
video: Unload GL/Vulkan when shutting down the video subsystem

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -4667,6 +4667,16 @@ void SDL_VideoQuit(void)
     while (_this->windows) {
         SDL_DestroyWindow(_this->windows);
     }
+
+    if (_this->gl_config.driver_loaded && _this->GL_UnloadLibrary) {
+        _this->GL_UnloadLibrary(_this);
+        _this->gl_config.driver_loaded = 0;
+    }
+    if (_this->vulkan_config.loader_loaded && _this->Vulkan_UnloadLibrary) {
+        _this->Vulkan_UnloadLibrary(_this);
+        _this->vulkan_config.loader_loaded = 0;
+    }
+
     _this->VideoQuit(_this);
 
     for (i = _this->num_displays; i--; ) {


### PR DESCRIPTION
If GL/Vulkan was loaded manually via a SDL_X_LoadLibrary() call instead of via window flags or through the GPU or renderer system, and there is no matching SDL_X_UnloadLibrary() call, the library instance won't be automatically unloaded while shutting down the video system, as the refcount won't go to zero, which can cause problems with some backends, and leaves a leaked DLL/SO handle when the global video object is destroyed.

Ensure that the libraries are unloaded after destroying the windows, but before shutting down the video backend, to prevent a leak and possible driver errors when shutting down the video backend.

In particular, Nvidia's egl-wayland2 library has issues when closing the Wayland connection without calling `eglTerminate` first. See https://github.com/NVIDIA/egl-wayland2/issues/27. They're patching around it, but SDL should be cleaning this up itself.