### PR TITLE
docs(gpu): document depth texture limitation in SDL_CopyGPUTextureToTexture

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -3903,8 +3903,8 @@ extern SDL_DECLSPEC void SDLCALL SDL_UploadToGPUBuffer(
  * This copy occurs on the GPU timeline. You may assume the copy has finished
  * in subsequent commands.
  *
- * This function does not support depth or depth-stencil textures. For those,
- * you must manually manage multiple depth textures.
+ * This function does not support copying between depth and color textures. For
+ * those, copy the texture to a buffer and then to the destination texture.
  *
  * \param copy_pass a copy pass handle.
  * \param source a source texture region.


### PR DESCRIPTION
## Description
Add clarifying comment regarding **not** supporting copying between depth and color aspects.

## Existing Issue(s)
Fixes #14518

Happy holidays! 🎅❄️