### PR TITLE
Plug testcustomcursor leaks

### DIFF
--- a/test/testcustomcursor.c
+++ b/test/testcustomcursor.c
@@ -304,7 +304,12 @@ static SDL_Cursor *init_animated_cursor(const char *image[], bool oneshot)
         frame_count = 6;
     }
 
-    return SDL_CreateAnimatedCursor(frames, frame_count, hot_x, hot_y);
+    SDL_Cursor *cursor = SDL_CreateAnimatedCursor(frames, frame_count, hot_x, hot_y);
+
+    SDL_DestroySurface(surface);
+    SDL_DestroySurface(invsurface);
+
+    return cursor;
 }
 
 static SDLTest_CommonState *state;


### PR DESCRIPTION
- Currently  `testcustomcursor` accepts a `frame0.bmp;frame1.bmp;frame2.bmp` argument with a semicolon separated argument. This pr changes this into an optional multi-arg: `--frames frame0.bmp frame1.bmp frame2.bmp`.
- Plug a surface memory leak.

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
