### PR TITLE
Fix Emscripten joystick rumble being swapped

### DIFF
--- a/src/joystick/emscripten/SDL_sysjoystick.c
+++ b/src/joystick/emscripten/SDL_sysjoystick.c
@@ -583,8 +583,8 @@ static bool EMSCRIPTEN_JoystickRumble(SDL_Joystick *joystick, Uint16 low_frequen
         gamepad['vibrationActuator']['playEffect']('dual-rumble', {
             'startDelay': 0,
             'duration': 3000,
-            'weakMagnitude': $1 / 0xFFFF,
-            'strongMagnitude': $2 / 0xFFFF,
+            'weakMagnitude': $2 / 0xFFFF,
+            'strongMagnitude': $1 / 0xFFFF,
         });
         return 1;
         }, item->index, low_frequency_rumble, high_frequency_rumble);


### PR DESCRIPTION
## Description
Due to me being confused about the "weak/strong" vs "low/high frequency" terminology, Emscripten joystick rumble ended up being swapped when I coded it in https://github.com/libsdl-org/SDL/pull/13757 . This PR should fix this issue. See also https://github.com/godotengine/godot/pull/111191 .

## Existing Issue(s)
None in SDL's repository.
