### PR TITLE
Document SDL's policy on setuid/setgid executables

### DIFF
--- a/docs/README-bsd.md
+++ b/docs/README-bsd.md
@@ -4,3 +4,4 @@ SDL is fully supported on BSD platforms, and is built using [CMake](README-cmake
 
 If you want to run on the console, you can take a look at [KMSDRM support on BSD](README-kmsbsd.md)
 
+SDL is [not designed to be used in setuid or setgid executables](README-platforms.md#setuid).

--- a/docs/README-linux.md
+++ b/docs/README-linux.md
@@ -8,6 +8,7 @@ system does not have the XRandR libraries installed, it will be disabled
 at runtime, and you won't get a missing library error, at least with the
 default configuration parameters.
 
+SDL is [not designed to be used in setuid or setgid executables](README-platforms.md#setuid).
 
 Build Dependencies
 --------------------------------------------------------------------------------

--- a/docs/README-macos.md
+++ b/docs/README-macos.md
@@ -73,6 +73,8 @@ NSApplicationDelegate implementation:
 }
 ```
 
+SDL is [not designed to be used in setuid or setgid executables](README-platforms.md#setuid).
+
 # Using the Simple DirectMedia Layer with a traditional Makefile
 
 An existing build system for your SDL app has good chances to work almost

--- a/docs/README-platforms.md
+++ b/docs/README-platforms.md
@@ -45,3 +45,18 @@ All of these still work with [SDL2](/SDL2), which is an incompatible API, but an
 - OS/2
 - WinPhone
 - WinRT/UWP
+
+## General notes for Unix platforms
+
+Some aspects of SDL functionality are common to all Unix-based platforms.
+
+### <a name=setuid></a>Privileged processes (setuid, setgid, setcap)
+
+SDL is not designed to be used in programs with elevated privileges,
+such as setuid (`chmod u+s`) or setgid (`chmod g+s`) executables,
+or executables with file-based capabilities
+(`setcap cap_sys_nice+ep` or similar).
+It does not make any attempt to avoid trusting environment variables
+or other aspects of the inherited execution environment.
+Programs running with elevated privileges in an attacker-controlled
+execution environment should not call SDL functions.


### PR DESCRIPTION
Stated briefly, the policy is: don't.

Resolves: https://github.com/libsdl-org/SDL/issues/14717