### PR TITLE
Prefer SDL_arraysize()

### DIFF
--- a/src/core/freebsd/SDL_evdev_kbd_freebsd.c
+++ b/src/core/freebsd/SDL_evdev_kbd_freebsd.c
@@ -162,7 +162,7 @@ static void kbd_unregister_emerg_cleanup(void)
     }
     kbd_cleanup_sigactions_installed = 0;
 
-    for (tabidx = 0; tabidx < sizeof(fatal_signals) / sizeof(fatal_signals[0]); ++tabidx) {
+    for (tabidx = 0; tabidx < SDL_arraysize(fatal_signals); ++tabidx) {
         struct sigaction *old_action_p;
         struct sigaction cur_action;
         int signum = fatal_signals[tabidx];
@@ -215,7 +215,7 @@ static void kbd_register_emerg_cleanup(SDL_EVDEV_keyboard_state *kbd)
     }
     kbd_cleanup_sigactions_installed = 1;
 
-    for (tabidx = 0; tabidx < sizeof(fatal_signals) / sizeof(fatal_signals[0]); ++tabidx) {
+    for (tabidx = 0; tabidx < SDL_arraysize(fatal_signals); ++tabidx) {
         struct sigaction *old_action_p;
         struct sigaction new_action;
         int signum = fatal_signals[tabidx];

--- a/src/core/linux/SDL_evdev_kbd.c
+++ b/src/core/linux/SDL_evdev_kbd.c
@@ -224,7 +224,7 @@ static void kbd_unregister_emerg_cleanup(void)
     }
     kbd_cleanup_sigactions_installed = 0;
 
-    for (tabidx = 0; tabidx < sizeof(fatal_signals) / sizeof(fatal_signals[0]); ++tabidx) {
+    for (tabidx = 0; tabidx < SDL_arraysize(fatal_signals); ++tabidx) {
         struct sigaction *old_action_p;
         struct sigaction cur_action;
         int signum = fatal_signals[tabidx];
@@ -277,7 +277,7 @@ static void kbd_register_emerg_cleanup(SDL_EVDEV_keyboard_state *kbd)
     }
     kbd_cleanup_sigactions_installed = 1;
 
-    for (tabidx = 0; tabidx < sizeof(fatal_signals) / sizeof(fatal_signals[0]); ++tabidx) {
+    for (tabidx = 0; tabidx < SDL_arraysize(fatal_signals); ++tabidx) {
         struct sigaction *old_action_p;
         struct sigaction new_action;
         int signum = fatal_signals[tabidx];

--- a/src/haptic/hidapi/SDL_hidapihaptic_lg4ff.c
+++ b/src/haptic/hidapi/SDL_hidapihaptic_lg4ff.c
@@ -836,7 +836,7 @@ static bool SDL_HIDAPI_HapticDriverLg4ff_JoystickSupported(SDL_Joystick *joystic
     if (vendor_id != USB_VENDOR_ID_LOGITECH) {
         return false;
     }
-    for (int i = 0;i < sizeof(supported_device_ids) / sizeof(Uint32);i++) {
+    for (int i = 0;i < SDL_arraysize(supported_device_ids);i++) {
         if (supported_device_ids[i] == product_id) {
             return true;
         }

--- a/src/joystick/hidapi/SDL_hidapi_lg4ff.c
+++ b/src/joystick/hidapi/SDL_hidapi_lg4ff.c
@@ -263,12 +263,12 @@ static bool HIDAPI_DriverLg4ff_IsSupportedDevice(
     if (vendor_id != USB_VENDOR_ID_LOGITECH) {
         return false;
     }
-    for (i = 0;i < sizeof(supported_device_ids) / sizeof(Uint32);i++) {
+    for (i = 0;i < SDL_arraysize(supported_device_ids);i++) {
         if (supported_device_ids[i] == product_id) {
             break;
         }
     }
-    if (i == sizeof(supported_device_ids) / sizeof(Uint32)) {
+    if (i == SDL_arraysize(supported_device_ids)) {
         return false;
     }
     Uint16 real_id = HIDAPI_DriverLg4ff_IdentifyWheel(product_id, version);

--- a/src/time/windows/SDL_systime.c
+++ b/src/time/windows/SDL_systime.c
@@ -36,7 +36,7 @@ void SDL_GetSystemTimeLocalePreferences(SDL_DateFormat *df, SDL_TimeFormat *tf)
 {
     WCHAR str[80]; // Per the docs, the time and short date format strings can be a max of 80 characters.
 
-    if (df && GetLocaleInfoW(LOCALE_USER_DEFAULT, LOCALE_SSHORTDATE, str, sizeof(str) / sizeof(WCHAR))) {
+    if (df && GetLocaleInfoW(LOCALE_USER_DEFAULT, LOCALE_SSHORTDATE, str, SDL_arraysize(str))) {
         LPWSTR s = str;
         while (*s) {
             switch (*s++) {
@@ -58,7 +58,7 @@ void SDL_GetSystemTimeLocalePreferences(SDL_DateFormat *df, SDL_TimeFormat *tf)
 found_date:
 
     // Figure out the preferred system date format.
-    if (tf && GetLocaleInfoW(LOCALE_USER_DEFAULT, LOCALE_STIMEFORMAT, str, sizeof(str) / sizeof(WCHAR))) {
+    if (tf && GetLocaleInfoW(LOCALE_USER_DEFAULT, LOCALE_STIMEFORMAT, str, SDL_arraysize(str))) {
         LPWSTR s = str;
         while (*s) {
             switch (*s++) {

--- a/src/video/SDL_egl.c
+++ b/src/video/SDL_egl.c
@@ -745,7 +745,7 @@ static Attribute all_attributes[] = {
 static void dumpconfig(SDL_VideoDevice *_this, EGLConfig config)
 {
     int attr;
-    for (attr = 0; attr < sizeof(all_attributes) / sizeof(Attribute); attr++) {
+    for (attr = 0; attr < SDL_arraysize(all_attributes); attr++) {
         EGLint value;
         _this->egl_data->eglGetConfigAttrib(_this->egl_data->egl_display, config, all_attributes[attr].attribute, &value);
         SDL_Log("\t%-32s: %10d (0x%08x)", all_attributes[attr].name, value, value);
@@ -1065,7 +1065,7 @@ SDL_GLContext SDL_EGL_CreateContext(SDL_VideoDevice *_this, EGLSurface egl_surfa
 #endif
 
     if (_this->egl_contextattrib_callback) {
-        const int maxAttribs = sizeof(attribs) / sizeof(attribs[0]);
+        const int maxAttribs = SDL_arraysize(attribs);
         EGLint *userAttribs, *userAttribP;
         userAttribs = _this->egl_contextattrib_callback(_this->egl_attrib_callback_userdata, _this->egl_data->egl_display, _this->egl_data->egl_config);
         if (!userAttribs) {
@@ -1298,7 +1298,7 @@ EGLSurface SDL_EGL_CreateSurface(SDL_VideoDevice *_this, SDL_Window *window, Nat
 #endif
 
     if (_this->egl_surfaceattrib_callback) {
-        const int maxAttribs = sizeof(attribs) / sizeof(attribs[0]);
+        const int maxAttribs = SDL_arraysize(attribs);
         EGLint *userAttribs, *userAttribP;
         userAttribs = _this->egl_surfaceattrib_callback(_this->egl_attrib_callback_userdata, _this->egl_data->egl_display, _this->egl_data->egl_config);
         if (!userAttribs) {

--- a/src/video/openvr/SDL_openvrvideo.c
+++ b/src/video/openvr/SDL_openvrvideo.c
@@ -505,7 +505,7 @@ static bool OPENVR_SetupJoystickBasedOnLoadedActionManifest(SDL_VideoData * vide
         return SDL_SetError("Failed to get action set handle");
     }
 
-    videodata->input_action_handles_buttons_count = sizeof(k_pchBooleanActionPaths) / sizeof(k_pchBooleanActionPaths[0]);
+    videodata->input_action_handles_buttons_count = SDL_arraysize(k_pchBooleanActionPaths);
     videodata->input_action_handles_buttons = SDL_malloc(videodata->input_action_handles_buttons_count * sizeof(VRActionHandle_t));
 
     for (int i = 0; i < videodata->input_action_handles_buttons_count; i++)
@@ -518,7 +518,7 @@ static bool OPENVR_SetupJoystickBasedOnLoadedActionManifest(SDL_VideoData * vide
         }
     }
 
-    videodata->input_action_handles_axes_count = sizeof(k_pchAnalogActionPaths) / sizeof(k_pchAnalogActionPaths[0]);
+    videodata->input_action_handles_axes_count = SDL_arraysize(k_pchAnalogActionPaths);
     videodata->input_action_handles_axes = SDL_malloc(videodata->input_action_handles_axes_count * sizeof(VRActionHandle_t));
 
     for (int i = 0; i < videodata->input_action_handles_axes_count; i++)

--- a/src/video/psp/SDL_pspevents.c
+++ b/src/video/psp/SDL_pspevents.c
@@ -88,7 +88,7 @@ void PSP_PumpEvents(SDL_VideoDevice *_this)
     changed = old_keys ^ keys;
     old_keys = keys;
     if (changed) {
-        for (i = 0; i < sizeof(keymap_psp) / sizeof(keymap_psp[0]); i++) {
+        for (i = 0; i < SDL_arraysize(keymap_psp); i++) {
             if (changed & keymap_psp[i].id) {
                 bool down = ((keys & keymap_psp[i].id) != 0);
                 SDL_SendKeyboardKey(0, SDL_GLOBAL_KEYBOARD_ID, keymap_psp[i].id, keymap_psp[i].scancode, down);

--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -606,7 +606,7 @@ static DWORD IME_GetId(SDL_VideoData *videodata, UINT uIndex)
     char szTemp[256];
     HKL hkl = 0;
     DWORD dwLang = 0;
-    SDL_assert(uIndex < sizeof(dwRet) / sizeof(dwRet[0]));
+    SDL_assert(uIndex < SDL_arraysize(dwRet));
 
     hkl = videodata->ime_hkl;
     if (hklprev == hkl) {

--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -864,7 +864,7 @@ bool X11_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Properties
         }
 #endif /* SDL_VIDEO_DRIVER_X11_XSYNC */
 
-        SDL_assert(proto_count <= sizeof(protocols) / sizeof(protocols[0]));
+        SDL_assert(proto_count <= SDL_arraysize(protocols));
 
         X11_XSetWMProtocols(display, w, protocols, proto_count);
     }


### PR DESCRIPTION
Replace uses of the `(sizeof(arr)/sizeof(arr[0])` and similar patterns, with the `SDL_arraysize()` macro.

"Found" via a Coccinelle spatch.