### PR TITLE
Add ProGuard rule for joystickSetLED method in SDLControllerManager

### DIFF
--- a/android-project/app/proguard-rules.pro
+++ b/android-project/app/proguard-rules.pro
@@ -69,6 +69,7 @@
 
 -keep,includedescriptorclasses,allowoptimization class org.libsdl.app.SDLControllerManager {
     void pollInputDevices();
+    void joystickSetLED(int, int, int, int);
     void pollHapticDevices();
     void hapticRun(int, float, int);
     void hapticRumble(int, float, float, int);


### PR DESCRIPTION
Keep SDL joystickSetLED method in ProGuard for Android.

The `joystickSetLED` method is added to the ProGuard keep rules for `SDLControllerManager` to prevent it from being stripped during release builds to fix error message:

java.lang.NoSuchMethodError: no static method "Lorg/libsdl/app/SDLControllerManager;.joystickSetLED(IIII)V"
