### PR TITLE
GPU: Add error message to Vulkan buffer creation error path

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -4168,9 +4168,8 @@ static VulkanBuffer *VULKAN_INTERNAL_CreateBuffer(
             renderer->logicalDevice,
             buffer->buffer,
             NULL);
-
         SDL_free(buffer);
-        return NULL;
+        SET_STRING_ERROR_AND_RETURN("Failed to bind memory for buffer!", NULL);
     }
 
     buffer->usedRegion->vulkanBuffer = buffer; // lol


### PR DESCRIPTION
This PR adds a missing error message to a failure path that can occur when attempting to create a large amount of transfer buffers. Currently the creation function will fail without an error message which is confusing to users.

Ideally a more detailed message should be provided inside VULKAN_INTERNAL_BindMemoryForBuffer() but that would require a more involved PR that I am not able to do at this time.