### PR TITLE
hidapi: Disable hidapi LG4FF on windows

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_lg4ff.c
+++ b/src/joystick/hidapi/SDL_hidapi_lg4ff.c
@@ -116,7 +116,7 @@ static bool HIDAPI_DriverLg4ff_IsEnabled(void)
      * it enforces full length repots of 17 from the device's descriptor, which does not work on the device
      * this breaks ffb and led control, so we disable this by default
      */
-    static bool hint_default = false;
+    bool hint_default = false;
     #else
     bool hint_default = SDL_GetHintBoolean(SDL_HINT_JOYSTICK_HIDAPI, SDL_HIDAPI_DEFAULT);
     #endif


### PR DESCRIPTION
hid.dll simply cannot send 7 bytes reports unlike other platforms

It enforces full length repots of 17 from the device's descriptor, which does not work on the device.

This breaks ffb and led control, so we disable this by default on windows.

This issue was discovered during https://github.com/RPCS3/rpcs3/issues/17949#issuecomment-3710058457