### PR TITLE
Fixed conflict when linking both SDL and hidapi statically

### DIFF
--- a/src/hidapi/SDL_hidapi_c.h
+++ b/src/hidapi/SDL_hidapi_c.h
@@ -20,6 +20,9 @@
 */
 #include "SDL_internal.h"
 
+// These functions conflict when linking both SDL and hidapi statically
+#define hid_libusb_wrap_sys_device      SDL_hid_libusb_wrap_sys_device
+#define get_usb_code_for_current_locale SDL_get_usb_code_for_current_locale
 
 /* Return true if the HIDAPI should ignore a device during enumeration */
 extern bool SDL_HIDAPI_ShouldIgnoreDevice(int bus_type, Uint16 vendor_id, Uint16 product_id, Uint16 usage_page, Uint16 usage, bool libusb);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If a parent project statically links hidapi, it currently fails with the following error:
```
alpine-nodeps-gcc  | [1595/1595] Linking CXX executable Binaries/dolphin-emu-nogui
alpine-nodeps-gcc  | ninja: job failed: : && /usr/bin/c++ -O3 -DNDEBUG -pthread Source/Core/DolphinTool/CMakeFiles/dolphin-tool.dir/ToolHeadlessPlatform.cpp.o Source/Core/DolphinTool/CMakeFiles/dolphin-tool.dir/ExtractCommand.cpp.o Source/Core/DolphinTool/CMakeFiles/dolphin-tool.dir/ConvertCommand.cpp.o Source/Core/DolphinTool/CMakeFiles/dolphin-tool.dir/VerifyCommand.cpp.o Source/Core/DolphinTool/CMakeFiles/dolphin-tool.dir/HeaderCommand.cpp.o Source/Core/DolphinTool/CMakeFiles/dolphin-tool.dir/ToolMain.cpp.o -o Binaries/dolphin-tool  Source/Core/DiscIO/libdiscio.a  Source/Core/UICommon/libuicommon.a  Externals/cpp-optparse/libcpp-optparse.a  Externals/fmt/fmt/libfmt.a  Source/Core/DiscIO/libdiscio.a  Source/Core/Core/libcore.a  Source/Core/VideoBackends/Null/libvideonull.a  Source/Core/VideoBackends/OGL/libvideoogl.a  Source/Core/VideoBackends/Software/libvideosoftware.a  Source/Core/VideoBackends/Vulkan/libvideovulkan.a  Source/Core/VideoCommon/libvideocommon.a  Source/Core/DiscIO/libdiscio.a  Source/Core/Core/libcore.a  Source/Core/VideoBackends/Null/libvideonull.a  Source/Core/VideoBackends/OGL/libvideoogl.a  Source/Core/VideoBackends/Software/libvideosoftware.a  Source/Core/VideoBackends/Vulkan/libvideovulkan.a  Source/Core/VideoCommon/libvideocommon.a  Externals/bzip2/libbzip2.a  Source/Core/AudioCommon/libaudiocommon.a  Externals/FreeSurround/libFreeSurround.a  Source/Core/InputCommon/libinputcommon.a  Externals/SDL/SDL/libSDL3.a  Externals/LZO/liblzo2.a  Externals/lz4/lz4/build/cmake/liblz4.a  Externals/cubeb/libcubeb.a  Externals/hidapi/libhidapi.a  lib/libipc.a  -lpthread  Externals/rcheevos/librcheevos.a  Externals/xxhash/libxxhash.a  Externals/implot/libimplot.a  Externals/imgui/libimgui.a  Externals/glslang/glslang/SPIRV/libSPIRV.a  Externals/glslang/glslang/glslang/libglslang.a  Externals/tinygltf/libtinygltf.a  Externals/pugixml/pugixml/libpugixml.a  Source/Core/Common/libcommon.a  Externals/fmt/fmt/libfmt.a  Externals/minizip-ng/minizip-ng/libminizip-ng.a  Externals/liblzma/liblzma.a  Externals/zstd/zstd/build/cmake/lib/libzstd.a  Externals/enet/enet/libenet.a  Externals/SFML/libsfml-network.a  Externals/SFML/libsfml-system.a  Externals/FatFs/libFatFs.a  Externals/curl/curl/lib/libcurl.a  Externals/mbedtls/library/libmbedtls.a  Externals/mbedtls/library/libmbedx509.a  Externals/mbedtls/library/libmbedcrypto.a  Externals/libspng/libspng/libspng_static.a  Externals/zlib-ng/zlib-ng/libz.a  -lm  -ldl  -lrt  Externals/libiconv/libiconv.a  Externals/libiconv/libcharset/liblibcharset.a  Externals/miniupnpc/miniupnp/miniupnpc/libminiupnpc.a  Externals/Bochs_disasm/libbdisasm.a  Externals/libusb/libusb.a && :
alpine-nodeps-gcc  | /usr/lib/gcc/x86_64-alpine-linux-musl/15.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: Externals/hidapi/CMakeFiles/hidapi.dir/hidapi-src/libusb/hid.c.o: in function `hid_libusb_wrap_sys_device':
alpine-nodeps-gcc  | hid.c:(.text+0x1570): multiple definition of `hid_libusb_wrap_sys_device'; Externals/SDL/SDL/CMakeFiles/SDL3-static.dir/src/hidapi/SDL_hidapi.c.o:SDL_hidapi.c:(.text+0x2820): first defined here
alpine-nodeps-gcc  | /usr/lib/gcc/x86_64-alpine-linux-musl/15.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: Externals/hidapi/CMakeFiles/hidapi.dir/hidapi-src/libusb/hid.c.o: in function `get_usb_code_for_current_locale':
alpine-nodeps-gcc  | hid.c:(.text+0x2130): multiple definition of `get_usb_code_for_current_locale'; Externals/SDL/SDL/CMakeFiles/SDL3-static.dir/src/hidapi/SDL_hidapi.c.o:SDL_hidapi.c:(.text+0x2830): first defined here
alpine-nodeps-gcc  | collect2: error: ld returned 1 exit status
alpine-nodeps-gcc  | ninja: job failed: : && /usr/bin/c++ -O3 -DNDEBUG -pthread Source/Core/DolphinNoGUI/CMakeFiles/dolphin-nogui.dir/Platform.cpp.o Source/Core/DolphinNoGUI/CMakeFiles/dolphin-nogui.dir/PlatformHeadless.cpp.o Source/Core/DolphinNoGUI/CMakeFiles/dolphin-nogui.dir/MainNoGUI.cpp.o Source/Core/DolphinNoGUI/CMakeFiles/dolphin-nogui.dir/PlatformFBDev.cpp.o -o Binaries/dolphin-emu-nogui  Source/Core/Core/libcore.a  Source/Core/UICommon/libuicommon.a  Externals/cpp-optparse/libcpp-optparse.a  Source/Core/Core/libcore.a  Source/Core/DiscIO/libdiscio.a  Source/Core/VideoBackends/Null/libvideonull.a  Source/Core/VideoBackends/OGL/libvideoogl.a  Source/Core/VideoBackends/Software/libvideosoftware.a  Source/Core/VideoBackends/Vulkan/libvideovulkan.a  Source/Core/VideoCommon/libvideocommon.a  Source/Core/Core/libcore.a  Source/Core/DiscIO/libdiscio.a  Source/Core/VideoBackends/Null/libvideonull.a  Source/Core/VideoBackends/OGL/libvideoogl.a  Source/Core/VideoBackends/Software/libvideosoftware.a  Source/Core/VideoBackends/Vulkan/libvideovulkan.a  Source/Core/VideoCommon/libvideocommon.a  Source/Core/AudioCommon/libaudiocommon.a  Externals/FreeSurround/libFreeSurround.a  Source/Core/InputCommon/libinputcommon.a  Externals/SDL/SDL/libSDL3.a  Externals/LZO/liblzo2.a  Externals/lz4/lz4/build/cmake/liblz4.a  Externals/cubeb/libcubeb.a  Externals/hidapi/libhidapi.a  lib/libipc.a  -lpthread  Externals/rcheevos/librcheevos.a  Externals/bzip2/libbzip2.a  Externals/xxhash/libxxhash.a  Externals/implot/libimplot.a  Externals/imgui/libimgui.a  Externals/glslang/glslang/SPIRV/libSPIRV.a  Externals/glslang/glslang/glslang/libglslang.a  Externals/tinygltf/libtinygltf.a  Source/Core/Common/libcommon.a  Externals/enet/enet/libenet.a  Externals/SFML/libsfml-network.a  Externals/SFML/libsfml-system.a  Externals/FatFs/libFatFs.a  Externals/curl/curl/lib/libcurl.a  Externals/mbedtls/library/libmbedtls.a  Externals/mbedtls/library/libmbedx509.a  Externals/mbedtls/library/libmbedcrypto.a  Externals/libspng/libspng/libspng_static.a  -lm  -ldl  -lrt  Externals/libiconv/libiconv.a  Externals/libiconv/libcharset/liblibcharset.a  Externals/miniupnpc/miniupnp/miniupnpc/libminiupnpc.a  Externals/pugixml/pugixml/libpugixml.a  Externals/fmt/fmt/libfmt.a  Externals/libusb/libusb.a  Externals/minizip-ng/minizip-ng/libminizip-ng.a  Externals/zlib-ng/zlib-ng/libz.a  Externals/liblzma/liblzma.a  Externals/zstd/zstd/build/cmake/lib/libzstd.a  Externals/Bochs_disasm/libbdisasm.a && :
alpine-nodeps-gcc  | ninja: subcommands failed
alpine-nodeps-gcc  | /usr/lib/gcc/x86_64-alpine-linux-musl/15.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: Externals/hidapi/CMakeFiles/hidapi.dir/hidapi-src/libusb/hid.c.o: in function `hid_libusb_wrap_sys_device':
alpine-nodeps-gcc  | hid.c:(.text+0x1570): multiple definition of `hid_libusb_wrap_sys_device'; Externals/SDL/SDL/CMakeFiles/SDL3-static.dir/src/hidapi/SDL_hidapi.c.o:SDL_hidapi.c:(.text+0x2820): first defined here
alpine-nodeps-gcc  | /usr/lib/gcc/x86_64-alpine-linux-musl/15.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: Externals/hidapi/CMakeFiles/hidapi.dir/hidapi-src/libusb/hid.c.o: in function `get_usb_code_for_current_locale':
alpine-nodeps-gcc  | hid.c:(.text+0x2130): multiple definition of `get_usb_code_for_current_locale'; Externals/SDL/SDL/CMakeFiles/SDL3-static.dir/src/hidapi/SDL_hidapi.c.o:SDL_hidapi.c:(.text+0x2830): first defined here
alpine-nodeps-gcc  | collect2: error: ld returned 1 exit status


```

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
None, but similar to #12790