### PR TITLE
x11: fix compilation failure on older XInput2

### DIFF
--- a/cmake/sdlchecks.cmake
+++ b/cmake/sdlchecks.cmake
@@ -457,7 +457,7 @@ macro(CheckX11)
               #include <X11/Xproto.h>
               #include <X11/extensions/XInput2.h>
               int event_type = XI_GesturePinchBegin;
-              XITouchClassInfo *t;
+              XIGesturePinchEvent *t;
               Status XIAllowTouchEvents(Display *a,int b,unsigned int c,Window d,int f) {
                 return (Status)0;
               }


### PR DESCRIPTION
Older versions of XInput2 do not declare `struct XIGesturePinchEvent` in `XInput2.h` (nor anywhere else), causing compilation failure in `SDL_x11xinput2.c`.

Check for `XIGesturePinchEvent` in the test for enabling `SDL_VIDEO_DRIVER_X11_XINPUT2_SUPPORTS_GESTURE`
