### PR TITLE
Added SDL_HINT_DETECT_MICE_AND_KEYBOARDS

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -720,6 +720,22 @@ extern "C" {
 #define SDL_HINT_DISPLAY_USABLE_BOUNDS "SDL_DISPLAY_USABLE_BOUNDS"
 
 /**
+ * A variable that controls whether SDL will detect individual mice and keyboards, and send SDL_EVENT_MOUSE_ADDED, SDL_EVENT_MOUSE_REMOVED, SDL_EVENT_KEYBOARD_ADDED, and SDL_EVENT_KEYBOARD_REMOVED events.
+ *
+ * This does not affect mouse and keyboard input from the OS, just whether SDL knows about individual devices.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "0": Do not detect mice and keyboards.
+ * - "1": Detect mice and keyboards at runtime. (default)
+ *
+ * This hint must be set before initializing the video subsystem.
+ *
+ * \since This hint is available since SDL 3.6.0.
+ */
+#define SDL_HINT_DETECT_MICE_AND_KEYBOARDS "SDL_DETECT_MICE_AND_KEYBOARDS"
+
+/**
  * Set the level of checking for invalid parameters passed to SDL functions.
  *
  * The variable can be set to the following values:

--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -119,6 +119,10 @@ static int SDL_GetKeyboardIndex(SDL_KeyboardID keyboardID)
 
 void SDL_AddKeyboard(SDL_KeyboardID keyboardID, const char *name)
 {
+    if (!SDL_ShouldDetectMiceAndKeyboards()) {
+        return;
+    }
+
     int keyboard_index = SDL_GetKeyboardIndex(keyboardID);
     if (keyboard_index >= 0) {
         // We already know about this keyboard

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -348,6 +348,10 @@ static int SDL_GetMouseIndex(SDL_MouseID mouseID)
 
 void SDL_AddMouse(SDL_MouseID mouseID, const char *name)
 {
+    if (!SDL_ShouldDetectMiceAndKeyboards()) {
+        return;
+    }
+
     int mouse_index = SDL_GetMouseIndex(mouseID);
     if (mouse_index >= 0) {
         // We already know about this mouse

--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -618,4 +618,6 @@ extern bool SDL_GetTextInputMultiline(SDL_PropertiesID props);
 extern void SDL_SendScreenKeyboardShown(void);
 extern void SDL_SendScreenKeyboardHidden(void);
 
+extern bool SDL_ShouldDetectMiceAndKeyboards(void);
+
 #endif // SDL_sysvideo_h_

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -193,6 +193,13 @@ static void SDL_CheckWindowDisplayChanged(SDL_Window *window);
 static void SDL_CheckWindowDisplayScaleChanged(SDL_Window *window);
 static void SDL_CheckWindowSafeAreaChanged(SDL_Window *window);
 
+static bool SDL_detect_mice_and_keyboards = true;
+
+bool SDL_ShouldDetectMiceAndKeyboards(void)
+{
+    return SDL_detect_mice_and_keyboards;
+}
+
 // Convenience functions for reading driver flags
 static bool SDL_ModeSwitchingEmulated(SDL_VideoDevice *_this)
 {
@@ -625,6 +632,8 @@ bool SDL_VideoInit(const char *driver_name)
     }
 
     SDL_InitTicks();
+
+    SDL_detect_mice_and_keyboards = SDL_GetHintBoolean(SDL_HINT_DETECT_MICE_AND_KEYBOARDS, true);
 
     // Start the event loop
     if (!SDL_InitSubSystem(SDL_INIT_EVENTS)) {

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -2722,7 +2722,8 @@ void WIN_PumpEvents(SDL_VideoDevice *_this)
         }
     }
 
-    if (!_this->internal->gameinput_context) {
+    if (SDL_ShouldDetectMiceAndKeyboards() &&
+        !_this->internal->gameinput_context) {
         WIN_CheckKeyboardAndMouseHotplug(_this, false);
     }
 


### PR DESCRIPTION
Some devices with broken drivers hang when their name is queried, so now applications can skip that if they don't care about input device details.