### PR TITLE
Haiku: fix modelist double-free

### DIFF
--- a/src/video/haiku/SDL_bmodes.cc
+++ b/src/video/haiku/SDL_bmodes.cc
@@ -243,22 +243,26 @@ bool HAIKU_GetDisplayModes(SDL_VideoDevice *_this, SDL_VideoDisplay *display)
     display_mode this_bmode;
     display_mode *bmodes;
     uint32 count, i;
+    bool r = false;
 
     // Get graphics-hardware supported modes
-    if (bscreen.GetModeList(&bmodes, &count) == B_OK && bscreen.GetMode(&this_bmode) == B_OK)
+    if (bscreen.GetModeList(&bmodes, &count) == B_OK)
     {
-        for (i = 0; i < count; ++i) {
-            // FIXME: Apparently there are errors with colorspace changes
-            if (bmodes[i].space == this_bmode.space) {
-                _BDisplayModeToSdlDisplayMode(&bmodes[i], &mode);
-                SDL_AddFullscreenDisplayMode(display, &mode);
+        if (bscreen.GetMode(&this_bmode) == B_OK)
+        {
+            for (i = 0; i < count; ++i) {
+                // FIXME: Apparently there are errors with colorspace changes
+                if (bmodes[i].space == this_bmode.space) {
+                    _BDisplayModeToSdlDisplayMode(&bmodes[i], &mode);
+                    SDL_AddFullscreenDisplayMode(display, &mode);
+                }
             }
+            r = true;
         }
         free(bmodes); // This should NOT be SDL_free()
-        return true;
     }
 
-    return false;
+    return r;
 }
 
 


### PR DESCRIPTION
The current code was not checking if GetModeList succeeded, so in some cases it would free a bogus pointer.
