### PR TITLE
[SDL2] Haiku: fix modelist double-free

### DIFF
--- a/src/video/haiku/SDL_bmodes.cc
+++ b/src/video/haiku/SDL_bmodes.cc
@@ -244,13 +244,16 @@ void HAIKU_GetDisplayModes(_THIS, SDL_VideoDisplay *display) {
     uint32 count, i;
     
     /* Get graphics-hardware supported modes */
-    if (bscreen.GetModeList(&bmodes, &count) == B_OK && bscreen.GetMode(&this_bmode) == B_OK)
+    if (bscreen.GetModeList(&bmodes, &count) == B_OK)
     {
-        for (i = 0; i < count; ++i) {
-            // FIXME: Apparently there are errors with colorspace changes
-            if (bmodes[i].space == this_bmode.space) {
-                _BDisplayModeToSdlDisplayMode(&bmodes[i], &mode);
-                SDL_AddDisplayMode(display, &mode);
+        if (bscreen.GetMode(&this_bmode) == B_OK)
+        {
+            for (i = 0; i < count; ++i) {
+                // FIXME: Apparently there are errors with colorspace changes
+                if (bmodes[i].space == this_bmode.space) {
+                    _BDisplayModeToSdlDisplayMode(&bmodes[i], &mode);
+                    SDL_AddDisplayMode(display, &mode);
+                }
             }
         }
         free(bmodes); /* This should not be SDL_free() */


### PR DESCRIPTION
The current code was not checking if GetModeList succeeded, so in some cases it would free a bogus pointer.