### PR TITLE
pthread: add call to pthread_mutexattr_destroy

### DIFF
--- a/src/thread/pthread/SDL_sysmutex.c
+++ b/src/thread/pthread/SDL_sysmutex.c
@@ -46,7 +46,7 @@ SDL_Mutex *SDL_CreateMutex(void)
             SDL_free(mutex);
             mutex = NULL;
         }
-	pthread_mutexattr_destroy(&attr);
+	    pthread_mutexattr_destroy(&attr);
     }
     return mutex;
 }


### PR DESCRIPTION
Added a call to pthread_mutexattr_destroy to SDL_CreateMutex: necessary to free memory allocated from call to pthread_mutexattr_init. 
see: https://pubs.opengroup.org/onlinepubs/9799919799/
After a mutex attributes object has been used to initialize one or more mutexes, any function affecting the attributes object (including destruction) shall not affect any previously initialized mutexes.