### PR TITLE
Added temporary workaround hint "SDL_WINDOWS_DETECT_DEVICE_HOTPLUG"

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -984,6 +984,10 @@ void WIN_CheckKeyboardAndMouseHotplug(SDL_VideoDevice *_this, bool initial_check
     int new_mouse_count = 0;
     SDL_MouseID *new_mice = NULL;
 
+    if (!_this->internal->detect_device_hotplug) {
+        return;
+    }
+
     // Check to see if anything has changed
     static Uint64 s_last_device_change;
     Uint64 last_device_change = WIN_GetLastDeviceNotification();

--- a/src/video/windows/SDL_windowsvideo.c
+++ b/src/video/windows/SDL_windowsvideo.c
@@ -631,6 +631,8 @@ static bool WIN_VideoInit(SDL_VideoDevice *_this)
         return false;
     }
 
+    _this->internal->detect_device_hotplug = SDL_GetHintBoolean("SDL_WINDOWS_DETECT_DEVICE_HOTPLUG", true);
+
     WIN_InitKeyboard(_this);
     WIN_InitMouse(_this);
     WIN_InitDeviceNotification();

--- a/src/video/windows/SDL_windowsvideo.h
+++ b/src/video/windows/SDL_windowsvideo.h
@@ -583,6 +583,8 @@ struct SDL_VideoData
 
     bool cleared;
 
+    bool detect_device_hotplug;
+
     BYTE *rawinput;
     UINT rawinput_offset;
     UINT rawinput_size;


### PR DESCRIPTION
Some devices with broken drivers hang when their name is queried, so added a workaround for applications that don't need input device details. The long term fix is to move the hotplug detection into a separate thread.
