### PR TITLE
Add write buffering to Windows SDL_IOStream (#12424)

### DIFF
--- a/src/io/SDL_iostream.c
+++ b/src/io/SDL_iostream.c
@@ -72,10 +72,7 @@ typedef struct IOStreamWindowsData
     size_t left;
     void *write_data;
     size_t write_pos;
-<<<<<<< Updated upstream
-=======
     bool writable;
->>>>>>> Stashed changes
     bool append;
     bool autoclose;
 } IOStreamWindowsData;
@@ -325,14 +322,11 @@ static size_t SDLCALL windows_file_write(void *userdata, const void *ptr, size_t
     size_t remaining = size;
     size_t total_written = 0;
 
-<<<<<<< Updated upstream
-=======
     if (!iodata->writable) {
         *status = SDL_IO_STATUS_READONLY;
         return 0;
     }
 
->>>>>>> Stashed changes
     // Invalidate read-ahead buffer if it has data
     if (iodata->left) {
         if (!SetFilePointer(iodata->h, -(LONG)iodata->left,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -373,7 +373,6 @@ add_sdl_test_executable(testasyncio MAIN_CALLBACKS NEEDS_RESOURCES TESTUTILS SOU
 add_sdl_test_executable(testaudio MAIN_CALLBACKS NEEDS_RESOURCES TESTUTILS SOURCES testaudio.c)
 add_sdl_test_executable(testcolorspace SOURCES testcolorspace.c)
 add_sdl_test_executable(testfile NONINTERACTIVE SOURCES testfile.c)
-add_sdl_test_executable(benchmark_iostream_write NONINTERACTIVE SOURCES benchmark_iostream_write.c)
 add_sdl_test_executable(testcontroller TESTUTILS SOURCES testcontroller.c gamepadutils.c ${gamepad_image_headers} DEPENDS generate-gamepad_image_headers)
 add_sdl_test_executable(testdlopennote TESTUTILS SOURCES testdlopennote.c)
 add_sdl_test_executable(testgeometry TESTUTILS SOURCES testgeometry.c)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Original implementation for SDL_IOStream write file API was incredibly slow on Windows due to not having basic buffering. A write up at https://github.com/nmlgc/ssg/issues/93 details critical performance issues due to this.

This PR adds basic buffering of size 1024 (same as `windows_file_read` read buffer) to `windows_file_write` and also implemented auto flushing for the new write buffer before read and seek operations. This adds safety by default. Users don't need to manually call `SDL_FlushIO()` between write to reads and write to seek transactions at the cost of (very) minimal speed overhead, which is negligible given the buffer massively improves write speed on Windows.

## Existing Issue(s)

Fixes #12424

## Tested

Built SDL3 locally and on this branch and wrote a minimal benchmark test for the following scenarios:

- Small writes (1 byte)
- Medium writes (100 bytes)
- Large writes (2048 bytes)
- SDL_SaveBMP_IO usage (~300 bytes)

With **no** write buffer:

```
Starting...

Running 5 iterations of each benchmark...

BENCHMARK 1 - Small Writes (1 byte x 10,000): Average: 62.899 ms

BENCHMARK 2 - Medium Writes (100 bytes x 1,000): Average: 6.104 ms

BENCHMARK 3 - Large Writes (2048 bytes x 500): Average: 5.775 ms

BENCHMARK 4 - SDL_SaveBMP_IO: Average: 17.973 ms
```

With write buffer:

```
Starting...

Running 5 iterations of each benchmark...

BENCHMARK 1 - Small Writes (1 byte x 10,000): Average: 0.657 ms

BENCHMARK 2 - Medium Writes (100 bytes x 1,000): Average: 1.481 ms

BENCHMARK 3 - Large Writes (2048 bytes x 500): Average: 7.009 ms

BENCHMARK 4 - SDL_SaveBMP_IO: Average: 3.161 ms
```

Small writes ~95x faster, medium writes ~4x faster, large writes *slightly* slower but expected, SDL_SaveBMP_IO ~6x faster.