### PR TITLE
Fix duplicate event dispatch in Cocoa event pump

### DIFF
--- a/src/video/cocoa/SDL_cocoaevents.m
+++ b/src/video/cocoa/SDL_cocoaevents.m
@@ -97,6 +97,14 @@ static void Cocoa_DispatchEvent(NSEvent *theEvent)
 {
     if (s_bShouldHandleEventsInSDLApplication) {
         Cocoa_DispatchEvent(theEvent);
+
+        // Avoid double-dispatching mouse and keyboard events. They are already handled in Cocoa_DispatchEvent.
+        // Other event types should still go through AppKit's normal handling.
+        NSEventType type = [theEvent type];
+        if ((type >= NSEventTypeLeftMouseDown && type <= NSEventTypeMouseExited) ||
+            (type >= NSEventTypeKeyDown && type <= NSEventTypeFlagsChanged)) {
+            return;
+        }
     }
 
     [super sendEvent:theEvent];


### PR DESCRIPTION
Prevent mouse and keyboard events from being processed twice by skipping [super sendEvent:] for events SDL has already handled via Cocoa_DispatchEvent. Other event types still go through AppKit's normal handling.

## Description
Mouse and keyboard events were being processed twice in the macOS Cocoa backend when s_bShouldHandleEventsInSDLApplication is true (the normal case).

First dispatch: SDL's Cocoa_DispatchEvent()
Second dispatch: [super sendEvent:]

This caused unnecessary overhead (~10-15 μs per event).
