### PR TITLE
wayland: Send exposure events when deferring resize events

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -752,6 +752,9 @@ static void handle_xdg_surface_configure(void *data, struct xdg_surface *xdg, ui
         xdg_surface_ack_configure(xdg, serial);
     } else {
         wind->pending_config_ack = true;
+
+        // Send an exposure event so that clients doing deferred updates will trigger a frame callback and make guaranteed forward progress when resizing.
+        SDL_SendWindowEvent(window, SDL_EVENT_WINDOW_EXPOSED, 0, 0);
     }
 
     if (wind->shell_surface_status == WAYLAND_SHELL_SURFACE_STATUS_WAITING_FOR_CONFIGURE) {


### PR DESCRIPTION
Clients that defer repainting may hang in SDL_WaitEvent() while interactively resizing if they only redraw when an appropriate event is received, as resizing defers the new state until a frame callback is received, and if too much time elapsed since the last redraw, the last frame callback may have already occurred. Send an exposure event when deferring resizes so the client will make forward progress and trigger a frame callback to ack the pending configure state.

Fixes #14811 