### PR TITLE
Fix SDL_HINT_MAC_PRESS_AND_HOLD hint documentation

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2649,8 +2649,8 @@ extern "C" {
  *
  * The variable can be set to the following values:
  *
- * - "0": Holding a key will open the accents menu for that key.
- * - "1": Holding a key will repeat the pressed key. (default)
+ * - "0": Holding a key will repeat the pressed key.
+ * - "1": Holding a key will open the accents menu for that key. (default)
  *
  * This hint needs to be set before SDL_Init().
  *


### PR DESCRIPTION
The hint is passed straight to Apple's `ApplePressAndHoldEnabled` default, where **true** shows the accent menu and **false** enables key repeat. The docs currently claim the opposite and list "repeat" as the default. This updates the hint description so the values and default match the implemented behavior.