### PR TITLE
[SDL2] Fixed PS2 joystick analog sticks not enabled

### DIFF
--- a/src/joystick/ps2/SDL_sysjoystick.c
+++ b/src/joystick/ps2/SDL_sysjoystick.c
@@ -36,6 +36,7 @@
 
 #include "SDL_events.h"
 #include "SDL_error.h"
+#include "SDL_timer.h"
 
 #define PS2_MAX_PORT 2 /* each ps2 has 2 ports */
 #define PS2_MAX_SLOT 4 /* maximum - 4 slots in one multitap */
@@ -191,6 +192,66 @@ static SDL_JoystickID PS2_JoystickGetDeviceInstanceID(int device_index)
     return device_index;
 }
 
+static void PS2_WaitPadReady(int port, int slot)
+{
+    int state = padGetState(port, slot);
+    while ((state != PAD_STATE_STABLE) && (state != PAD_STATE_FINDCTP1)) {
+        SDL_Delay(1);
+        state = padGetState(port, slot);
+    }
+}
+
+static void PS2_InitializePad(int port, int slot)
+{
+    int modes;
+    int i;
+    char actAlign[6];
+
+    PS2_WaitPadReady(port, slot);
+
+    // How many different modes can this device operate in?
+    modes = padInfoMode(port, slot, PAD_MODETABLE, -1);
+
+    // Verify that the controller has a DUAL SHOCK mode
+    for (i = 0; i < modes; i++) {
+        if (padInfoMode(port, slot, PAD_MODETABLE, i) == PAD_TYPE_DUALSHOCK) {
+            break;
+        }
+    }
+    if (i >= modes) {
+        // This is no Dual Shock controller
+        return;
+    }
+    
+    // If ExId != 0x0 => This controller has actuator engines
+    // This check should always pass if the Dual Shock test above passed
+    if (!padInfoMode(port, slot, PAD_MODECUREXID, 0)) {
+        // This is no Dual Shock controller??
+        return;
+    }
+
+    // When using MMODE_LOCK, user cant change mode with Select button
+    padSetMainMode(port, slot, PAD_MMODE_DUALSHOCK, PAD_MMODE_LOCK);
+
+    PS2_WaitPadReady(port, slot);
+    padEnterPressMode(port, slot);
+
+    PS2_WaitPadReady(port, slot);
+    if (padInfoAct(port, slot, -1, 0)) {
+        actAlign[0] = 0;   // Enable small engine
+        actAlign[1] = 1;   // Enable big engine
+        actAlign[2] = 0xff;
+        actAlign[3] = 0xff;
+        actAlign[4] = 0xff;
+        actAlign[5] = 0xff;
+
+        PS2_WaitPadReady(port, slot);
+        padSetActAlign(port, slot, actAlign);
+    }
+
+    PS2_WaitPadReady(port, slot);
+}
+
 /*  Function to open a joystick for use.
     The joystick to open is specified by the device index.
     This should fill the nbuttons and naxes fields of the joystick structure.
@@ -208,6 +269,8 @@ static int PS2_JoystickOpen(SDL_Joystick *joystick, int device_index)
             return -1;
         }
     }
+    PS2_InitializePad(info->port, info->slot);
+    
     joystick->nbuttons = PS2_BUTTONS;
     joystick->naxes = PS2_TOTAL_AXIS;
     joystick->nhats = 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
SDL was not configuring the joystick in DualShock mode, which caused the analog sticks to never be enabled.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #14813
