### PR TITLE
Fix touch screen display IDs on the 3DS

### DIFF
--- a/src/video/n3ds/SDL_n3dsvideo.c
+++ b/src/video/n3ds/SDL_n3dsvideo.c
@@ -31,7 +31,7 @@
 
 #define N3DSVID_DRIVER_NAME "n3ds"
 
-static bool AddN3DSDisplay(gfxScreen_t screen);
+static SDL_DisplayID AddN3DSDisplay(gfxScreen_t screen);
 
 static bool N3DS_VideoInit(SDL_VideoDevice *_this);
 static void N3DS_VideoQuit(SDL_VideoDevice *_this);
@@ -136,14 +136,14 @@ static bool N3DS_VideoInit(SDL_VideoDevice *_this)
     return true;
 }
 
-static bool AddN3DSDisplay(gfxScreen_t screen)
+static SDL_DisplayID AddN3DSDisplay(gfxScreen_t screen)
 {
     SDL_DisplayMode mode;
     SDL_DisplayModeData *modedata;
     SDL_VideoDisplay display;
     SDL_DisplayData *display_driver_data = SDL_calloc(1, sizeof(SDL_DisplayData));
     if (!display_driver_data) {
-        return false;
+        return 0;
     }
 
     SDL_zero(mode);
@@ -153,7 +153,7 @@ static bool AddN3DSDisplay(gfxScreen_t screen)
 
     modedata = SDL_malloc(sizeof(SDL_DisplayModeData));
     if (!modedata) {
-        return false;
+        return 0;
     }
 
     mode.w = (screen == GFX_TOP) ? GSP_SCREEN_HEIGHT_TOP : GSP_SCREEN_HEIGHT_BOTTOM;
@@ -167,10 +167,7 @@ static bool AddN3DSDisplay(gfxScreen_t screen)
     display.desktop_mode = mode;
     display.internal = display_driver_data;
 
-    if (SDL_AddVideoDisplay(&display, false) == 0) {
-        return false;
-    }
-    return true;
+    return SDL_AddVideoDisplay(&display, false);
 }
 
 static void N3DS_VideoQuit(SDL_VideoDevice *_this)

--- a/src/video/n3ds/SDL_n3dsvideo.h
+++ b/src/video/n3ds/SDL_n3dsvideo.h
@@ -29,8 +29,8 @@
 
 struct SDL_VideoData
 {
-    int top_display;
-    int touch_display;
+    SDL_DisplayID top_display;
+    SDL_DisplayID touch_display;
 };
 
 struct SDL_WindowData


### PR DESCRIPTION
This fixes a regression from 9ff3446f036094bc005ef119e0cf07fc9b503b8e that prevented the touch screen code from getting the window to associate with events.

Fixes #12498.