### PR TITLE
events: Raise keyboard keys before sending the focus lost message

### DIFF
--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -337,6 +337,11 @@ bool SDL_SetKeyboardFocus(SDL_Window *window)
         }
     }
 
+    if (keyboard->focus && !window) {
+        // We won't get anymore keyboard messages, so reset keyboard state
+        SDL_ResetKeyboard();
+    }
+
     // See if the current window has lost focus
     if (keyboard->focus && keyboard->focus != window) {
         SDL_SendWindowEvent(keyboard->focus, SDL_EVENT_WINDOW_FOCUS_LOST, 0, 0);
@@ -352,9 +357,6 @@ bool SDL_SetKeyboardFocus(SDL_Window *window)
     }
 
     if (keyboard->focus && !window) {
-        // We won't get anymore keyboard messages, so reset keyboard state
-        SDL_ResetKeyboard();
-
         // Also leave mouse relative mode
         if (mouse->relative_mode) {
             SDL_SetRelativeMouseMode(false);


### PR DESCRIPTION
Otherwise, the key raises may end up being ignored, leading to 'stuck' keys. Tested and confirmed to not regress #14350, which is what the change that caused this was fixing.

Fixes #14825