### PR TITLE
Fix SDL_SetWindowIcon on singlethreaded Emscripten builds

### DIFF
--- a/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/src/video/emscripten/SDL_emscriptenvideo.c
@@ -794,11 +794,9 @@ static bool Emscripten_SetWindowIcon(SDL_VideoDevice *_this, SDL_Window *window,
 
     // Pass PNG data to JavaScript
     MAIN_THREAD_EM_ASM({
-        var pngData = HEAPU8.subarray($0, $0 + $1);
-        if ("SharedArrayBuffer" in window && pngData.buffer instanceof SharedArrayBuffer) {
-            // explicitly create a copy
-            pngData = new Uint8Array(pngData);
-        }
+        // Use `.slice` to make a copy of the data if we are dealing with a SharedArrayBuffer, or `.subarray` to create a
+        // view into the existing buffer if its non-shared.
+        var pngData = HEAPU8.buffer instanceof ArrayBuffer ? HEAPU8.subarray($0, $0 + $1) : HEAPU8.slice($0, $0 + $1);
 
         var blob = new Blob([pngData], {type: 'image/png'});
         var url = URL.createObjectURL(blob);


### PR DESCRIPTION
Fixes error about SharedArrayBuffer not being defined in SDL_SetWindowIcon's JavaScript code by checking for its existence first. This would be a typical situation if deploying a singlethreaded SDL app somewhere you don't have COEP/COOP headers set that makes SharedArrayBuffer available.

Closes #14840.