### PR TITLE
[SDL3] Fix the video size matching the renderer.

### DIFF
--- a/src/video/ps2/SDL_ps2video.c
+++ b/src/video/ps2/SDL_ps2video.c
@@ -69,7 +69,7 @@ static bool PS2_VideoInit(SDL_VideoDevice *_this)
 
     SDL_zero(mode);
     mode.w = 640;
-    mode.h = 480;
+    mode.h = 448;
     mode.refresh_rate = 60.0f;
 
     // 32 bpp for default


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This fixes a bug which video image is not set correctly matching the renderer´s output