### PR TITLE
cmake: Disable SDL_GPU on RISC OS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2891,6 +2891,7 @@ elseif(RISCOS)
       "${SDL3_SOURCE_DIR}/src/video/riscos/*.h"
     )
     set(HAVE_SDL_VIDEO TRUE)
+    set(SDL_GPU OFF)
   endif()
 
   set(SDL_FILESYSTEM_RISCOS 1)


### PR DESCRIPTION
Not much to see here, just waiting for the riscos CI task to come out green before merging.

Unblocks #14837