### PR TITLE
Include Android IME in Window Inset calculation

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLSurface.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLSurface.java
@@ -199,7 +199,8 @@ public class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
                                                WindowInsets.Type.systemGestures() |
                                                WindowInsets.Type.mandatorySystemGestures() |
                                                WindowInsets.Type.tappableElement() |
-                                               WindowInsets.Type.displayCutout());
+                                               WindowInsets.Type.displayCutout() |
+                                               WindowInsets.Type.ime());
 
             SDLActivity.onNativeInsetsChanged(combined.left, combined.right, combined.top, combined.bottom);
         }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Android's IME (software keyboard) reports its covered region of the screen via the Window Insets functionality. When it is open, it is displayed over the application - so there needs to be a way for the application to determine what area is uncovered. The window insets (and `SDL_GetWindowSafeArea`) mechanism seems to be the best avenue for this.
