### PR TITLE
SDL GPU: Fix features not being enabled with Vulkan 1.1

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -12278,12 +12278,14 @@ static Uint8 VULKAN_INTERNAL_CreateLogicalDevice(
     VkPhysicalDeviceFeatures2 featureList;
     int minor = VK_VERSION_MINOR(features->desiredApiVersion);
 
-    VkPhysicalDevice16BitStorageFeatures storage;
-    VkPhysicalDeviceMultiviewFeatures multiview;
-    VkPhysicalDeviceProtectedMemoryFeatures protectedMem;
-    VkPhysicalDeviceSamplerYcbcrConversionFeatures ycbcr;
-    VkPhysicalDeviceShaderDrawParametersFeatures drawParams;
-    VkPhysicalDeviceVariablePointersFeatures varPointers;
+    struct {
+        VkPhysicalDevice16BitStorageFeatures storage;
+        VkPhysicalDeviceMultiviewFeatures multiview;
+        VkPhysicalDeviceProtectedMemoryFeatures protectedMem;
+        VkPhysicalDeviceSamplerYcbcrConversionFeatures ycbcr;
+        VkPhysicalDeviceShaderDrawParametersFeatures drawParams;
+        VkPhysicalDeviceVariablePointersFeatures varPointers;
+    } legacyFeatures;
 
     if (features->usesCustomVulkanOptions && minor > 0) {
         featureList.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
@@ -12295,42 +12297,38 @@ static Uint8 VULKAN_INTERNAL_CreateLogicalDevice(
             features->desiredVulkan13DeviceFeatures.pNext = NULL;
         } else {
             // Break VkPhysicalDeviceVulkan11Features into pre 1.2 structures for Vulkan 1.1 Support
-            SDL_memset(&storage, 0, sizeof(VkPhysicalDevice16BitStorageFeatures));
-            storage.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES;
-            storage.storageBuffer16BitAccess = features->desiredVulkan11DeviceFeatures.storageBuffer16BitAccess;
-            storage.storageInputOutput16 = features->desiredVulkan11DeviceFeatures.storageInputOutput16;
-            storage.storagePushConstant16 = features->desiredVulkan11DeviceFeatures.storagePushConstant16;
-            storage.uniformAndStorageBuffer16BitAccess = features->desiredVulkan11DeviceFeatures.uniformAndStorageBuffer16BitAccess;
+            SDL_zero(legacyFeatures);
 
-            SDL_memset(&multiview, 0, sizeof(VkPhysicalDeviceMultiviewFeatures));
-            multiview.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES;
-            multiview.multiview = features->desiredVulkan11DeviceFeatures.multiview;
-            multiview.multiviewGeometryShader = features->desiredVulkan11DeviceFeatures.multiviewGeometryShader;
-            multiview.multiviewTessellationShader = features->desiredVulkan11DeviceFeatures.multiviewTessellationShader;
+            legacyFeatures.storage.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES;
+            legacyFeatures.storage.storageBuffer16BitAccess = features->desiredVulkan11DeviceFeatures.storageBuffer16BitAccess;
+            legacyFeatures.storage.storageInputOutput16 = features->desiredVulkan11DeviceFeatures.storageInputOutput16;
+            legacyFeatures.storage.storagePushConstant16 = features->desiredVulkan11DeviceFeatures.storagePushConstant16;
+            legacyFeatures.storage.uniformAndStorageBuffer16BitAccess = features->desiredVulkan11DeviceFeatures.uniformAndStorageBuffer16BitAccess;
 
-            SDL_memset(&protectedMem, 0, sizeof(VkPhysicalDeviceProtectedMemoryFeatures));
-            protectedMem.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES;
-            protectedMem.protectedMemory = features->desiredVulkan11DeviceFeatures.protectedMemory;
+            legacyFeatures.multiview.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES;
+            legacyFeatures.multiview.multiview = features->desiredVulkan11DeviceFeatures.multiview;
+            legacyFeatures.multiview.multiviewGeometryShader = features->desiredVulkan11DeviceFeatures.multiviewGeometryShader;
+            legacyFeatures.multiview.multiviewTessellationShader = features->desiredVulkan11DeviceFeatures.multiviewTessellationShader;
 
-            SDL_memset(&ycbcr, 0, sizeof(VkPhysicalDeviceSamplerYcbcrConversionFeatures));
-            ycbcr.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES;
-            ycbcr.samplerYcbcrConversion = features->desiredVulkan11DeviceFeatures.samplerYcbcrConversion;
+            legacyFeatures.protectedMem.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES;
+            legacyFeatures.protectedMem.protectedMemory = features->desiredVulkan11DeviceFeatures.protectedMemory;
 
-            SDL_memset(&drawParams, 0, sizeof(VkPhysicalDeviceShaderDrawParametersFeatures));
-            drawParams.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES;
-            drawParams.shaderDrawParameters = features->desiredVulkan11DeviceFeatures.shaderDrawParameters;
+            legacyFeatures.ycbcr.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES;
+            legacyFeatures.ycbcr.samplerYcbcrConversion = features->desiredVulkan11DeviceFeatures.samplerYcbcrConversion;
 
-            SDL_memset(&varPointers, 0, sizeof(VkPhysicalDeviceVariablePointersFeatures));
-            varPointers.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES;
-            varPointers.variablePointers = features->desiredVulkan11DeviceFeatures.variablePointers;
-            varPointers.variablePointersStorageBuffer = features->desiredVulkan11DeviceFeatures.variablePointersStorageBuffer;
+            legacyFeatures.drawParams.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES;
+            legacyFeatures.drawParams.shaderDrawParameters = features->desiredVulkan11DeviceFeatures.shaderDrawParameters;
 
-            featureList.pNext = &storage;
-            storage.pNext = &multiview;
-            multiview.pNext = &protectedMem;
-            protectedMem.pNext = &ycbcr;
-            ycbcr.pNext = &drawParams;
-            drawParams.pNext = &varPointers;
+            legacyFeatures.varPointers.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES;
+            legacyFeatures.varPointers.variablePointers = features->desiredVulkan11DeviceFeatures.variablePointers;
+            legacyFeatures.varPointers.variablePointersStorageBuffer = features->desiredVulkan11DeviceFeatures.variablePointersStorageBuffer;
+
+            featureList.pNext = &legacyFeatures.storage;
+            legacyFeatures.storage.pNext = &legacyFeatures.multiview;
+            legacyFeatures.multiview.pNext = &legacyFeatures.protectedMem;
+            legacyFeatures.protectedMem.pNext = &legacyFeatures.ycbcr;
+            legacyFeatures.ycbcr.pNext = &legacyFeatures.drawParams;
+            legacyFeatures.drawParams.pNext = &legacyFeatures.varPointers;
         }
         deviceCreateInfo.pEnabledFeatures = NULL;
         deviceCreateInfo.pNext = &featureList;


### PR DESCRIPTION
## Description

Use pre-Vulkan 1.2 structs to request features from a Vulkan 1.1 instance.

## Existing Issue(s)

I noticed this because of validation layer errors requesting shader draw parameters be enabled and after enabling it, I still got the error.

## Device Info

OS: Fedora Linux 43
Rendering device: AMD Radeon 860M Graphics (RADV GFX1152)
Driver: Mesa 25.2.7