### PR TITLE
Prefer SDL_zero()/SDL_zerop()

### DIFF
--- a/src/SDL_guid.c
+++ b/src/SDL_guid.c
@@ -77,7 +77,7 @@ SDL_GUID SDL_StringToGUID(const char *pchGUID)
     // Make sure it's even
     len = (len) & ~0x1;
 
-    SDL_memset(&guid, 0x00, sizeof(guid));
+    SDL_zero(guid);
 
     p = (Uint8 *)&guid;
     for (i = 0; (i < len) && ((p - (Uint8 *)&guid) < maxoutputbytes); i += 2, p++) {

--- a/src/core/linux/SDL_ibus.c
+++ b/src/core/linux/SDL_ibus.c
@@ -637,7 +637,7 @@ void SDL_IBus_Quit(void)
 
     SDL_RemoveHintCallback(SDL_HINT_IME_IMPLEMENTED_UI, IBus_SetCapabilities, NULL);
 
-    SDL_memset(&ibus_cursor_rect, 0, sizeof(ibus_cursor_rect));
+    SDL_zero(ibus_cursor_rect);
 }
 
 static void IBus_SimpleMessage(const char *method)

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -11653,9 +11653,9 @@ static void VULKAN_INTERNAL_AddOptInVulkanOptions(SDL_PropertiesID props, Vulkan
             features->usesCustomVulkanOptions = true;
             features->desiredApiVersion = options->vulkan_api_version;
 
-            SDL_memset(&features->desiredVulkan11DeviceFeatures, 0, sizeof(VkPhysicalDeviceVulkan11Features));
-            SDL_memset(&features->desiredVulkan12DeviceFeatures, 0, sizeof(VkPhysicalDeviceVulkan12Features));
-            SDL_memset(&features->desiredVulkan13DeviceFeatures, 0, sizeof(VkPhysicalDeviceVulkan13Features));
+            SDL_zero(features->desiredVulkan11DeviceFeatures);
+            SDL_zero(features->desiredVulkan12DeviceFeatures);
+            SDL_zero(features->desiredVulkan13DeviceFeatures);
             features->desiredVulkan11DeviceFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
             features->desiredVulkan12DeviceFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
             features->desiredVulkan13DeviceFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES;

--- a/src/haptic/darwin/SDL_syshaptic.c
+++ b/src/haptic/darwin/SDL_syshaptic.c
@@ -1166,7 +1166,7 @@ bool SDL_SYS_HapticUpdateEffect(SDL_Haptic *haptic,
     FFEFFECT temp;
 
     // Get the effect.
-    SDL_memset(&temp, 0, sizeof(FFEFFECT));
+    SDL_zero(temp);
     if (!SDL_SYS_ToFFEFFECT(haptic, &temp, data)) {
         goto err_update;
     }

--- a/src/haptic/hidapi/SDL_hidapihaptic_lg4ff.c
+++ b/src/haptic/hidapi/SDL_hidapihaptic_lg4ff.c
@@ -694,9 +694,9 @@ static int lg4ff_init_slots(struct lg4ff_device *device)
         return -1;
     }
 
-    SDL_memset(&device->states, 0, sizeof(device->states));
-    SDL_memset(&device->slots, 0, sizeof(device->slots));
-    SDL_memset(&parameters, 0, sizeof(parameters));
+    SDL_zero(device->states);
+    SDL_zero(device->slots);
+    SDL_zero(parameters);
 
     device->slots[0].effect_type = SDL_HAPTIC_CONSTANT;
     device->slots[1].effect_type = SDL_HAPTIC_SPRING;

--- a/src/haptic/windows/SDL_dinputhaptic.c
+++ b/src/haptic/windows/SDL_dinputhaptic.c
@@ -1050,7 +1050,7 @@ bool SDL_DINPUT_HapticUpdateEffect(SDL_Haptic *haptic, struct haptic_effect *eff
     DIEFFECT temp;
 
     // Get the effect.
-    SDL_memset(&temp, 0, sizeof(DIEFFECT));
+    SDL_zero(temp);
     if (!SDL_SYS_ToDIEFFECT(haptic, &temp, data)) {
         goto err_update;
     }

--- a/src/joystick/hidapi/SDL_hidapi_gip.c
+++ b/src/joystick/hidapi/SDL_hidapi_gip.c
@@ -809,7 +809,7 @@ static void GIP_MetadataFree(GIP_Metadata *metadata)
     SDL_free(metadata->device.hid_descriptor);
 
     SDL_free(metadata->message_metadata);
-    SDL_memset(metadata, 0, sizeof(*metadata));
+    SDL_zerop(metadata);
 }
 
 static bool GIP_ParseDeviceMetadata(GIP_Metadata *metadata, const Uint8 *bytes, int num_bytes, int *offset)

--- a/src/joystick/hidapi/SDL_hidapi_switch.c
+++ b/src/joystick/hidapi/SDL_hidapi_switch.c
@@ -450,7 +450,7 @@ static bool ReadProprietaryReply(SDL_DriverSwitch_Context *ctx, ESwitchProprieta
 
 static void ConstructSubcommand(SDL_DriverSwitch_Context *ctx, ESwitchSubcommandIDs ucCommandID, const Uint8 *pBuf, Uint8 ucLen, SwitchSubcommandOutputPacket_t *outPacket)
 {
-    SDL_memset(outPacket, 0, sizeof(*outPacket));
+    SDL_zerop(outPacket);
 
     outPacket->commonData.ucPacketType = k_eSwitchOutputReportIDs_RumbleAndSubcommand;
     outPacket->commonData.ucPacketNumber = ctx->m_nCommandNumber;

--- a/src/render/vitagxm/SDL_render_vita_gxm.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm.c
@@ -1140,7 +1140,7 @@ static bool VITA_GXM_RenderPresent(SDL_Renderer *renderer)
 
     data->displayData.address = data->displayBufferData[data->backBufferIndex];
 
-    SDL_memset(&updateParam, 0, sizeof(updateParam));
+    SDL_zero(updateParam);
 
     updateParam.renderTarget.colorFormat = VITA_GXM_COLOR_FORMAT;
     updateParam.renderTarget.surfaceType = SCE_GXM_COLOR_SURFACE_LINEAR;

--- a/src/render/vitagxm/SDL_render_vita_gxm_tools.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm_tools.c
@@ -138,7 +138,7 @@ static void display_callback(const void *callback_data)
     SceDisplayFrameBuf framebuf;
     const VITA_GXM_DisplayData *display_data = (const VITA_GXM_DisplayData *)callback_data;
 
-    SDL_memset(&framebuf, 0x00, sizeof(SceDisplayFrameBuf));
+    SDL_zero(framebuf);
     framebuf.size = sizeof(SceDisplayFrameBuf);
     framebuf.base = display_data->address;
     framebuf.pitch = VITA_GXM_SCREEN_STRIDE;
@@ -377,7 +377,7 @@ int gxm_init(SDL_Renderer *renderer)
     VITA_GXM_RenderData *data = (VITA_GXM_RenderData *)renderer->internal;
 
     SceGxmInitializeParams initializeParams;
-    SDL_memset(&initializeParams, 0, sizeof(SceGxmInitializeParams));
+    SDL_zero(initializeParams);
     initializeParams.flags = 0;
     initializeParams.displayQueueMaxPendingCount = VITA_GXM_PENDING_SWAPS;
     initializeParams.displayQueueCallback = display_callback;
@@ -438,7 +438,7 @@ int gxm_init(SDL_Renderer *renderer)
     }
 
     // set up parameters
-    SDL_memset(&renderTargetParams, 0, sizeof(SceGxmRenderTargetParams));
+    SDL_zero(renderTargetParams);
     renderTargetParams.flags = 0;
     renderTargetParams.width = VITA_GXM_SCREEN_WIDTH;
     renderTargetParams.height = VITA_GXM_SCREEN_HEIGHT;
@@ -555,7 +555,7 @@ int gxm_init(SDL_Renderer *renderer)
         &patcherFragmentUsseOffset);
 
     // create a shader patcher
-    SDL_memset(&patcherParams, 0, sizeof(SceGxmShaderPatcherParams));
+    SDL_zero(patcherParams);
     patcherParams.userData = NULL;
     patcherParams.hostAllocCallback = &patcher_host_alloc;
     patcherParams.hostFreeCallback = &patcher_host_free;
@@ -1097,7 +1097,7 @@ gxm_texture *create_gxm_texture(VITA_GXM_RenderData *data, unsigned int w, unsig
 
             // set up parameters
             SceGxmRenderTargetParams renderTargetParams;
-            SDL_memset(&renderTargetParams, 0, sizeof(SceGxmRenderTargetParams));
+            SDL_zero(renderTargetParams);
             renderTargetParams.flags = 0;
             renderTargetParams.width = w;
             renderTargetParams.height = h;

--- a/src/render/vulkan/SDL_render_vulkan.c
+++ b/src/render/vulkan/SDL_render_vulkan.c
@@ -1231,7 +1231,7 @@ static VULKAN_PipelineState *VULKAN_CreatePipelineState(SDL_Renderer *renderer,
     // Shaders
     const char *name = "main";
     for (uint32_t i = 0; i < 2; i++) {
-        SDL_memset(&shaderStageCreateInfo[i], 0, sizeof(shaderStageCreateInfo[i]));
+        SDL_zero(shaderStageCreateInfo[i]);
         shaderStageCreateInfo[i].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
         shaderStageCreateInfo[i].module = (i == 0) ? rendererData->vertexShaderModules[shader] : rendererData->fragmentShaderModules[shader];
         shaderStageCreateInfo[i].stage = (i == 0) ? VK_SHADER_STAGE_VERTEX_BIT : VK_SHADER_STAGE_FRAGMENT_BIT;
@@ -4034,7 +4034,7 @@ static bool VULKAN_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cm
     VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     VkSurfaceTransformFlagBitsKHR currentRotation = VULKAN_GetRotationForCurrentRenderTarget(rendererData);
     VULKAN_DrawStateCache stateCache;
-    SDL_memset(&stateCache, 0, sizeof(stateCache));
+    SDL_zero(stateCache);
 
     if (!rendererData->device) {
         return SDL_SetError("Device lost and couldn't be recovered");

--- a/src/video/vita/SDL_vitaframebuffer.c
+++ b/src/video/vita/SDL_vitaframebuffer.c
@@ -79,7 +79,7 @@ bool VITA_CreateWindowFramebuffer(SDL_VideoDevice *_this, SDL_Window *window, SD
     // SDL_memset the buffer to black
     SDL_memset(data->buffer, 0x0, SCREEN_W * SCREEN_H * 4);
 
-    SDL_memset(&framebuf, 0x00, sizeof(SceDisplayFrameBuf));
+    SDL_zero(framebuf);
     framebuf.size = sizeof(SceDisplayFrameBuf);
     framebuf.base = data->buffer;
     framebuf.pitch = SCREEN_W;

--- a/src/video/vita/SDL_vitavideo.c
+++ b/src/video/vita/SDL_vitavideo.c
@@ -387,7 +387,7 @@ void VITA_ImeEventHandler(void *arg, const SceImeEventData *e)
             } else {
                 SDL_SendKeyboardText((const char *)utf8_buffer);
             }
-            SDL_memset(&caret_rev, 0, sizeof(SceImeCaret));
+            SDL_zero(caret_rev);
             SDL_memset(libime_out, 0, ((SCE_IME_MAX_PREEDIT_LENGTH + SCE_IME_MAX_TEXT_LENGTH + 1) * sizeof(SceWChar16)));
             caret_rev.index = 1;
             sceImeSetCaret(&caret_rev);
@@ -553,7 +553,7 @@ void VITA_PumpEvents(SDL_VideoDevice *_this)
             uint8_t utf8_buffer[SCE_IME_DIALOG_MAX_TEXT_LENGTH];
 
             SceImeDialogResult result;
-            SDL_memset(&result, 0, sizeof(SceImeDialogResult));
+            SDL_zero(result);
             sceImeDialogGetResult(&result);
 
             // Convert UTF16 to UTF8

--- a/src/video/wayland/SDL_waylanddatamanager.c
+++ b/src/video/wayland/SDL_waylanddatamanager.c
@@ -64,7 +64,7 @@ static int sigtimedwait(const sigset_t *set, siginfo_t *info, const struct times
             if (sigismember(set, signo) && sigismember(&pending, signo)) {
                 if (!sigwait(set, &signo)) {
                     if (info) {
-                        SDL_memset(info, 0, sizeof *info);
+                        SDL_zerop(info);
                         info->si_signo = signo;
                     }
                     return signo;

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -2522,7 +2522,7 @@ static void seat_handle_capabilities(void *data, struct wl_seat *wl_seat, enum w
 
     if ((capabilities & WL_SEAT_CAPABILITY_POINTER) && !seat->pointer.wl_pointer) {
         seat->pointer.wl_pointer = wl_seat_get_pointer(wl_seat);
-        SDL_memset(&seat->pointer.pending_frame.axis, 0, sizeof(seat->pointer.pending_frame.axis));
+        SDL_zero(seat->pointer.pending_frame.axis);
 
         Wayland_SeatCreateCursorShape(seat);
 

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -1731,7 +1731,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
             }
 
             // reply with status
-            SDL_memset(&m, 0, sizeof(XClientMessageEvent));
+            SDL_zero(m);
             m.type = ClientMessage;
             m.display = xevent->xclient.display;
             m.window = xevent->xclient.data.l[0];
@@ -1748,7 +1748,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
         } else if (xevent->xclient.message_type == videodata->atoms.XdndDrop) {
             if (data->xdnd_req == None) {
                 // say again - not interested!
-                SDL_memset(&m, 0, sizeof(XClientMessageEvent));
+                SDL_zero(m);
                 m.type = ClientMessage;
                 m.display = xevent->xclient.display;
                 m.window = xevent->xclient.data.l[0];
@@ -2175,7 +2175,7 @@ static void X11_DispatchEvent(SDL_VideoDevice *_this, XEvent *xevent)
             X11_XFree(p.data);
 
             // send reply
-            SDL_memset(&m, 0, sizeof(XClientMessageEvent));
+            SDL_zero(m);
             m.type = ClientMessage;
             m.display = display;
             m.window = data->xdnd_source;
@@ -2243,7 +2243,7 @@ void X11_SendWakeupEvent(SDL_VideoDevice *_this, SDL_Window *window)
     Window xwindow = window->internal->xwindow;
     XClientMessageEvent event;
 
-    SDL_memset(&event, 0, sizeof(XClientMessageEvent));
+    SDL_zero(event);
     event.type = ClientMessage;
     event.display = req_display;
     event.send_event = True;

--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -354,7 +354,7 @@ SDL_WindowFlags X11_GetNetWMState(SDL_VideoDevice *_this, SDL_Window *window, Wi
          */
         {
             XWindowAttributes attr;
-            SDL_memset(&attr, 0, sizeof(attr));
+            SDL_zero(attr);
             X11_XGetWindowAttributes(videodata->display, xwindow, &attr);
             if (attr.map_state == IsUnmapped) {
                 flags |= SDL_WINDOW_HIDDEN;


### PR DESCRIPTION
Replace uses of `SDL_memset(E, 0, sizeof(E))`, and similar, with the `SDL_zero()`/`SDL_zerop()` macros.

"Found" via a Coccinelle spatch.