### PR TITLE
More prefer SDL_zero*()

### DIFF
--- a/src/SDL.c
+++ b/src/SDL.c
@@ -706,7 +706,7 @@ void SDL_Quit(void)
     /* Now that every subsystem has been quit, we reset the subsystem refcount
      * and the list of initialized subsystems.
      */
-    SDL_memset(SDL_SubsystemRefCount, 0x0, sizeof(SDL_SubsystemRefCount));
+    SDL_zeroa(SDL_SubsystemRefCount);
 
     SDL_QuitLog();
     SDL_QuitHints();

--- a/src/core/linux/SDL_ibus.c
+++ b/src/core/linux/SDL_ibus.c
@@ -371,7 +371,7 @@ static char *IBus_GetDBusAddressFilename(void)
         }
     }
 
-    SDL_memset(config_dir, 0, sizeof(config_dir));
+    SDL_zeroa(config_dir);
 
     conf_env = SDL_getenv("XDG_CONFIG_HOME");
     if (conf_env && *conf_env) {
@@ -392,7 +392,7 @@ static char *IBus_GetDBusAddressFilename(void)
         return NULL;
     }
 
-    SDL_memset(file_path, 0, sizeof(file_path));
+    SDL_zeroa(file_path);
     (void)SDL_snprintf(file_path, sizeof(file_path), "%s/ibus/bus/%s-%s-%s",
                        config_dir, key, host, disp_num);
     dbus->free(key);

--- a/src/haptic/darwin/SDL_syshaptic.c
+++ b/src/haptic/darwin/SDL_syshaptic.c
@@ -785,7 +785,7 @@ static bool SDL_SYS_ToFFEFFECT(SDL_Haptic *haptic, FFEFFECT *dest, const SDL_Hap
     DWORD *axes = NULL;
 
     // Set global stuff.
-    SDL_memset(dest, 0, sizeof(FFEFFECT));
+    SDL_zerop(dest);
     dest->dwSize = sizeof(FFEFFECT);     // Set the structure size.
     dest->dwSamplePeriod = 0;            // Not used by us.
     dest->dwGain = 10000;                // Gain is set globally, not locally.

--- a/src/haptic/hidapi/SDL_hidapihaptic_lg4ff.c
+++ b/src/haptic/hidapi/SDL_hidapihaptic_lg4ff.c
@@ -737,7 +737,7 @@ static int lg4ff_timer(struct lg4ff_device *device)
 
     // XXX how to detect stacked up effects here?
 
-    SDL_memset(parameters, 0, sizeof(parameters));
+    SDL_zeroa(parameters);
 
     gain = (Uint16)((Uint32)device->gain * device->app_gain / 0xffff);
 
@@ -895,7 +895,7 @@ static void *SDL_HIDAPI_HapticDriverLg4ff_Open(SDL_Joystick *joystick)
         SDL_OutOfMemory();
         return NULL;
     }
-    SDL_memset(ctx, 0, sizeof(lg4ff_device));
+    SDL_zerop(ctx);
 
     ctx->hid_handle = joystick;
     if (lg4ff_init_slots(ctx) != 0) {
@@ -1200,7 +1200,7 @@ static bool SDL_HIDAPI_HapticDriverLg4ff_SetAutocenter(SDL_HIDAPI_HapticDevice *
         }
         expand_a = expand_a >> 1;
 
-        SDL_memset(cmd, 0x00, 7);
+        SDL_zeroa(cmd);
         cmd[0] = 0xfe;
         cmd[1] = 0x0d;
         cmd[2] = (Uint8)(expand_a / 0xaaaa);
@@ -1215,7 +1215,7 @@ static bool SDL_HIDAPI_HapticDriverLg4ff_SetAutocenter(SDL_HIDAPI_HapticDevice *
         }
 
         // enable
-        SDL_memset(cmd, 0x00, 7);
+        SDL_zeroa(cmd);
         cmd[0] = 0x14;
 
         ret = SDL_SendJoystickEffect(ctx->hid_handle, cmd, sizeof(cmd));

--- a/src/haptic/linux/SDL_syshaptic.c
+++ b/src/haptic/linux/SDL_syshaptic.c
@@ -603,7 +603,7 @@ void SDL_SYS_HapticClose(SDL_Haptic *haptic)
     }
 
     // Clear the rest.
-    SDL_memset(haptic, 0, sizeof(SDL_Haptic));
+    SDL_zerop(haptic);
 }
 
 /*
@@ -725,7 +725,7 @@ static bool SDL_SYS_ToFFEffect(struct ff_effect *dest, const SDL_HapticEffect *s
     const SDL_HapticLeftRight *leftright;
 
     // Clear up
-    SDL_memset(dest, 0, sizeof(struct ff_effect));
+    SDL_zerop(dest);
 
     switch (src->type) {
     case SDL_HAPTIC_CONSTANT:

--- a/src/haptic/windows/SDL_dinputhaptic.c
+++ b/src/haptic/windows/SDL_dinputhaptic.c
@@ -599,7 +599,7 @@ static bool SDL_SYS_ToDIEFFECT(SDL_Haptic *haptic, DIEFFECT *dest,
     DWORD *axes;
 
     // Set global stuff.
-    SDL_memset(dest, 0, sizeof(DIEFFECT));
+    SDL_zerop(dest);
     dest->dwSize = sizeof(DIEFFECT);     // Set the structure size.
     dest->dwSamplePeriod = 0;            // Not used by us.
     dest->dwGain = 10000;                // Gain is set globally, not locally.

--- a/src/joystick/hidapi/SDL_hidapi_lg4ff.c
+++ b/src/joystick/hidapi/SDL_hidapi_lg4ff.c
@@ -450,7 +450,7 @@ static bool HIDAPI_DriverLg4ff_SetAutoCenter(SDL_HIDAPI_Device *device, int magn
         // TODO do not adjust for MOMO wheels, when support is added
         expand_a = expand_a >> 1;
 
-        SDL_memset(cmd, 0x00, sizeof(cmd));
+        SDL_zeroa(cmd);
         cmd[0] = 0xfe;
         cmd[1] = 0x0d;
         cmd[2] = (Uint8)(expand_a / 0xaaaa);
@@ -463,7 +463,7 @@ static bool HIDAPI_DriverLg4ff_SetAutoCenter(SDL_HIDAPI_Device *device, int magn
         }
 
         // enable
-        SDL_memset(cmd, 0x00, sizeof(cmd));
+        SDL_zeroa(cmd);
         cmd[0] = 0x14;
 
         ret = SDL_hid_write(device->dev, cmd, sizeof(cmd));
@@ -490,7 +490,7 @@ static bool HIDAPI_DriverLg4ff_InitDevice(SDL_HIDAPI_Device *device)
         SDL_OutOfMemory();
         return false;
     }
-    SDL_memset(ctx, 0, sizeof(SDL_DriverLg4ff_Context));
+    SDL_zerop(ctx);
 
     device->context = ctx;
     device->joystick_type = SDL_JOYSTICK_TYPE_WHEEL;

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -221,7 +221,7 @@ static void hexdump(const uint8_t *ptr, int len)
 
 static void ResetSteamControllerPacketAssembler(SteamControllerPacketAssembler *pAssembler)
 {
-    SDL_memset(pAssembler->uBuffer, 0, sizeof(pAssembler->uBuffer));
+    SDL_zeroa(pAssembler->uBuffer);
     pAssembler->nExpectedSegmentNumber = 0;
 }
 
@@ -320,7 +320,7 @@ static int SetFeatureReport(SDL_HIDAPI_Device *dev, const unsigned char uBuffer[
             nActualDataLen -= nBytesInPacket;
 
             // Construct packet
-            SDL_memset(uPacketBuffer, 0, sizeof(uPacketBuffer));
+            SDL_zeroa(uPacketBuffer);
             uPacketBuffer[0] = BLE_REPORT_NUMBER;
             uPacketBuffer[1] = GetSegmentHeader(nSegmentNumber, nActualDataLen == 0);
             SDL_memcpy(&uPacketBuffer[2], pBufferPtr, nBytesInPacket);
@@ -370,7 +370,7 @@ static int GetFeatureReport(SDL_HIDAPI_Device *dev, unsigned char uBuffer[65])
 #endif
 
         while (nRetries < BLE_MAX_READ_RETRIES) {
-            SDL_memset(uSegmentBuffer, 0, sizeof(uSegmentBuffer));
+            SDL_zeroa(uSegmentBuffer);
             uSegmentBuffer[0] = BLE_REPORT_NUMBER;
             nRet = SDL_hid_get_feature_report(dev->dev, uSegmentBuffer, ucBytesToRead);
 

--- a/src/joystick/hidapi/SDL_hidapi_steamdeck.c
+++ b/src/joystick/hidapi/SDL_hidapi_steamdeck.c
@@ -343,7 +343,7 @@ static bool HIDAPI_DriverSteamDeck_UpdateDevice(SDL_HIDAPI_Device *device)
             return false;
     }
 
-    SDL_memset(data, 0, sizeof(data));
+    SDL_zeroa(data);
 
     do {
         r = SDL_hid_read(device->dev, data, sizeof(data));

--- a/src/joystick/linux/SDL_sysjoystick.c
+++ b/src/joystick/linux/SDL_sysjoystick.c
@@ -1539,7 +1539,7 @@ static SDL_sensorlist_item *GetSensor(SDL_joylist_item *item)
         return NULL;
     }
 
-    SDL_memset(uniq_item, 0, sizeof(uniq_item));
+    SDL_zeroa(uniq_item);
     fd_item = open(item->path, O_RDONLY | O_CLOEXEC, 0);
     if (fd_item < 0) {
         return NULL;
@@ -1561,7 +1561,7 @@ static SDL_sensorlist_item *GetSensor(SDL_joylist_item *item)
             continue;
         }
 
-        SDL_memset(uniq_sensor, 0, sizeof(uniq_sensor));
+        SDL_zeroa(uniq_sensor);
         fd_sensor = open(item_sensor->path, O_RDONLY | O_CLOEXEC, 0);
         if (fd_sensor < 0) {
             continue;

--- a/src/power/haiku/SDL_syspower.c
+++ b/src/power/haiku/SDL_syspower.c
@@ -56,7 +56,7 @@ bool SDL_GetPowerInfo_Haiku(SDL_PowerState *state, int *seconds, int *percent)
         return false; // maybe some other method will work?
     }
 
-    SDL_memset(regs, '\0', sizeof(regs));
+    SDL_zeroa(regs);
     regs[0] = APM_FUNC_OFFSET + APM_FUNC_GET_POWER_STATUS;
     regs[1] = APM_DEVICE_ALL;
     rc = ioctl(fd, APM_BIOS_CALL, regs);

--- a/src/render/vulkan/SDL_render_vulkan.c
+++ b/src/render/vulkan/SDL_render_vulkan.c
@@ -587,7 +587,7 @@ static void VULKAN_DestroyAll(SDL_Renderer *renderer)
     for (uint32_t i = 0; i < SDL_arraysize(rendererData->vertexBuffers); i++ ) {
         VULKAN_DestroyBuffer(rendererData, &rendererData->vertexBuffers[i]);
     }
-    SDL_memset(rendererData->vertexBuffers, 0, sizeof(rendererData->vertexBuffers));
+    SDL_zeroa(rendererData->vertexBuffers);
     for (uint32_t i = 0; i < VULKAN_RENDERPASS_COUNT; i++) {
         if (rendererData->renderPasses[i] != VK_NULL_HANDLE) {
             vkDestroyRenderPass(rendererData->device, rendererData->renderPasses[i], NULL);
@@ -714,7 +714,7 @@ static void VULKAN_DestroyBuffer(VULKAN_RenderData *rendererData, VULKAN_Buffer 
         vkFreeMemory(rendererData->device, vulkanBuffer->deviceMemory, NULL);
         vulkanBuffer->deviceMemory = VK_NULL_HANDLE;
     }
-    SDL_memset(vulkanBuffer, 0, sizeof(VULKAN_Buffer));
+    SDL_zerop(vulkanBuffer);
 }
 
 static VkResult VULKAN_AllocateBuffer(VULKAN_RenderData *rendererData, VkDeviceSize size, VkBufferUsageFlags usage, VkMemoryPropertyFlags requiredMemoryProps, VkMemoryPropertyFlags desiredMemoryProps, VULKAN_Buffer *bufferOut)
@@ -790,7 +790,7 @@ static void VULKAN_DestroyImage(VULKAN_RenderData *rendererData, VULKAN_Image *v
         }
         vulkanImage->deviceMemory = VK_NULL_HANDLE;
     }
-    SDL_memset(vulkanImage, 0, sizeof(VULKAN_Image));
+    SDL_zerop(vulkanImage);
 }
 
 static VkResult VULKAN_AllocateImage(VULKAN_RenderData *rendererData, SDL_PropertiesID create_props, uint32_t width, uint32_t height, VkFormat format, VkImageUsageFlags imageUsage, VkComponentMapping swizzle, VkSamplerYcbcrConversionKHR samplerYcbcrConversion, VULKAN_Image *imageOut)
@@ -798,7 +798,7 @@ static VkResult VULKAN_AllocateImage(VULKAN_RenderData *rendererData, SDL_Proper
     VkResult result;
     VkSamplerYcbcrConversionInfoKHR samplerYcbcrConversionInfo = { 0 };
 
-    SDL_memset(imageOut, 0, sizeof(VULKAN_Image));
+    SDL_zerop(imageOut);
     imageOut->format = format;
     imageOut->image = (VkImage)SDL_GetNumberProperty(create_props, SDL_PROP_TEXTURE_CREATE_VULKAN_TEXTURE_NUMBER, 0);
 

--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -243,7 +243,7 @@ void WIN_QuitKeyboard(SDL_VideoDevice *_this)
     for (int i = 0; i < keymap_cache_size; ++i) {
         SDL_DestroyKeymap(keymap_cache[i].keymap);
     }
-    SDL_memset(keymap_cache, 0, sizeof(keymap_cache));
+    SDL_zeroa(keymap_cache);
     keymap_cache_size = 0;
 }
 

--- a/src/video/x11/SDL_x11toolkit.c
+++ b/src/video/x11/SDL_x11toolkit.c
@@ -622,7 +622,7 @@ SDL_ListNode *X11Toolkit_MakeTextElements(SDL_ToolkitWindowX11 *data, char *txt,
         size_t csz;
         bool cond;
 
-        SDL_memset(utf8, 0, 5);
+        SDL_zeroa(utf8);
         cp = SDL_StepUTF8((const char **)&str, &sz);
         cond = (0xe00 <= cp && cp <= 0xe7f) ? true : false;
         if (cp == 0 || cond == (thai ? false : true)) {


### PR DESCRIPTION
## Description

Transform memset clearing of arrays into `SDL_zeroa()`, and clearing through a T* with size(T) into `SDL_zerop()`.
    
Extends commit 83fb7b6636d9eb (PR #14894) with two patterns I missed. I also manually edited a few locations that hardcoded the size, for the spatch to capture them too.

Inspecting the output of `grep -Rn "SDL_memset.*0" src/` I believe the vast majority of relevant cases (that are not in tests), have now been captured.

Hopefully I didn't mess anything up. Coccinelle patch file available upon request.