### PR TITLE
pipewire: Add support for Virtual Source Nodes

### DIFF
--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -704,7 +704,7 @@ static void registry_event_global_callback(void *object, uint32_t id, uint32_t p
             // Just want sink and source
             if (!SDL_strcasecmp(media_class, "Audio/Sink")) {
                 recording = false;
-            } else if (!SDL_strcasecmp(media_class, "Audio/Source")) {
+            } else if (!SDL_strcasecmp(media_class, "Audio/Source") || !SDL_strcasecmp(media_class, "Audio/Source/Virtual")) {
                 recording = true;
             } else {
                 return;


### PR DESCRIPTION
## Description
Virtual Source Nodes behave in the same way as physical nodes inside Pipewire, they're often used with the `null-audio-sink` plugin to allow for tweaking of audio behaviours. An example of their usage can be found in the [pipewire docs](https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/master/src/daemon/minimal.conf.in#L429).

Currently SDL ignores these devices and wont list them as usable. This PR simply allows them to be used.

## Existing Issue(s)
From what I can see, there's no existing issue for this, I'm happy to open one if needed!
