### PR TITLE
gpu: Add SDL_PROP_GPU_DEVICE_CREATE_METAL_ALLOW_MACFAMILY1 property

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -2321,6 +2321,15 @@ extern SDL_DECLSPEC SDL_GPUDevice * SDLCALL SDL_CreateGPUDevice(
  *   increasing the API version and opting into extensions aside from the
  *   minimal set SDL requires.
  *
+ * With the Metal backend:
+ * - `SDL_PROP_GPU_DEVICE_CREATE_METAL_ALLOW_MACFAMILY1`: By default, macOS
+ *   support requires what Apple calls "MTLGPUFamilyMac2" hardware or newer.
+ *   However, an application can set this property to true to enable support
+ *   for "MTLGPUFamilyMac1" hardware, if (and only if) the application does
+ *   not write to sRGB textures. (For history's sake: MacFamily1 also does not
+ *   support indirect command buffers, MSAA depth resolve, and stencil
+ *   resolve/feedback, but these are not exposed features in SDL_GPU.)
+ *
  * \param props the properties to use.
  * \returns a GPU context on success or NULL on failure; call SDL_GetError()
  *          for more information.
@@ -2353,6 +2362,7 @@ extern SDL_DECLSPEC SDL_GPUDevice * SDLCALL SDL_CreateGPUDeviceWithProperties(
 #define SDL_PROP_GPU_DEVICE_CREATE_D3D12_SEMANTIC_NAME_STRING                   "SDL.gpu.device.create.d3d12.semantic"
 #define SDL_PROP_GPU_DEVICE_CREATE_VULKAN_REQUIRE_HARDWARE_ACCELERATION_BOOLEAN         "SDL.gpu.device.create.vulkan.requirehardwareacceleration"
 #define SDL_PROP_GPU_DEVICE_CREATE_VULKAN_OPTIONS_POINTER                       "SDL.gpu.device.create.vulkan.options"
+#define SDL_PROP_GPU_DEVICE_CREATE_METAL_ALLOW_MACFAMILY1                       "SDL.gpu.device.create.metal.allowmacfamily1"
 
 
 /**

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -4527,10 +4527,18 @@ static SDL_GPUDevice *METAL_CreateDevice(bool debugMode, bool preferLowPower, SD
 
 #ifdef SDL_PLATFORM_MACOS
         hasHardwareSupport = true;
+        bool allowMacFamily1 = SDL_GetBooleanProperty(
+            props,
+            SDL_PROP_GPU_DEVICE_CREATE_METAL_ALLOW_MACFAMILY1,
+            false);
         if (@available(macOS 10.15, *)) {
-            hasHardwareSupport = [device supportsFamily:MTLGPUFamilyMac2];
+            hasHardwareSupport = allowMacFamily1 ?
+                [device supportsFamily:MTLGPUFamilyMac1] :
+                [device supportsFamily:MTLGPUFamilyMac2];
         } else if (@available(macOS 10.14, *)) {
-            hasHardwareSupport = [device supportsFeatureSet:MTLFeatureSet_macOS_GPUFamily2_v1];
+            hasHardwareSupport = allowMacFamily1 ?
+                [device supportsFeatureSet:MTLFeatureSet_macOS_GPUFamily1_v4] :
+                [device supportsFeatureSet:MTLFeatureSet_macOS_GPUFamily2_v1];
         }
 #elif defined(SDL_PLATFORM_VISIONOS)
         hasHardwareSupport = true;


### PR DESCRIPTION
We got a support ticket from someone using a 2017 MacBook that didn't support SDL_GPU - similar to D3D12 it appears to be Intel Broadwell hardware, so we did what all Apple graphics developers do: Google "Metal feature tables" and pray that a PDF still exists and makes any kind of sense at all. This time, we found this table:

https://metalbyexample.com/wp-content/uploads/Metal-Feature-Set-Tables-2018.pdf

Looking over the SDL_GPU features one more time, it seems the only issue we have left is sRGB writes - all the other stuff either got cut from the final API or is actually supported but was written differently in one of the many other PDFs out there (indirect drawing support was a surprise for me). So, as long as you don't do sRGB writes, you can support all Macs with Metal support on 10.14 or newer.

I chose the name based on what we describe in the system requirements in SDL_GPU's documentation, and I'm almost positive we're going to find a contradicting PDF some day, so I'm hesitant to label this anything _other_ than Mac1 without a really good reason.