### PR TITLE
Fix PSP_QueueGeometry funcion rendering some textures too small

### DIFF
--- a/src/render/psp/SDL_render_psp.c
+++ b/src/render/psp/SDL_render_psp.c
@@ -769,8 +769,8 @@ static bool PSP_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SD
             verts->col.b = (Uint8)SDL_roundf(SDL_clamp(col_->b * color_scale, 0.0f, 1.0f) * 255.0f);
             verts->col.a = (Uint8)SDL_roundf(SDL_clamp(col_->a, 0.0f, 1.0f) * 255.0f);
 
-            verts->u = uv_[0] * psp_texture->textureWidth;
-            verts->v = uv_[1] * psp_texture->textureHeight;
+            verts->u = uv_[0] * (float) psp_texture->width;
+            verts->v = uv_[1] * (float) psp_texture->height;
 
             verts++;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Using SDL_RenderGeometry with a texture that has dimensions that are not a power of 2, the PSP will output he image too small because of a bug in the PSP_QueueGeometry function.

## Description
<!--- Describe your changes in detail -->
We made a little example that looks like this with SDL upstream, Linux on the left , PSP on the right:
<img width="974" height="304" alt="image" src="https://github.com/user-attachments/assets/0fb41ab8-3510-4516-8fb3-0460e7b3ad2e" />

Here is the same with the fix:
<img width="964" height="317" alt="image" src="https://github.com/user-attachments/assets/7b60715d-5a7e-4bfe-8b94-3cfa5a071e17" />

The example code looks like this:
```c
#include <SDL3/SDL.h>
#include <iostream>

#ifdef __psp__
#include <pspkernel.h>
#include <pspdebug.h>

PSP_MODULE_INFO("bug", 0, 1, 0);
PSP_MAIN_THREAD_ATTR(THREAD_ATTR_USER | THREAD_ATTR_VFPU);
PSP_HEAP_SIZE_KB(20480);
#endif

void render(SDL_Renderer *renderer, SDL_Texture *texture)
{
    SDL_Vertex vertices[4];
    vertices[0] = {{220, 116}, {1, 1, 1, 1}, {0, 0}};
    vertices[1] = {{260, 116}, {1, 1, 1, 1}, {1, 0}};
    vertices[2] = {{260, 156}, {1, 1, 1, 1}, {1, 1}};
    vertices[3] = {{220, 156}, {1, 1, 1, 1}, {0, 1}};

    int indices[6] = {0, 1, 2, 2, 3, 0};

    int status = SDL_RenderGeometry(renderer, texture, vertices, 4, indices, 6);
}

int main(int argc, char *argv[])
{
    std::cout << "Hello, World!" << std::endl;

    SDL_Window *window = SDL_CreateWindow(
        "window",
        480,
        272,
        0);

    SDL_Renderer *renderer = SDL_CreateRenderer(window, NULL);

    SDL_Surface *pixels = SDL_LoadPNG("assets/sprite.png");
    SDL_Texture *sprite = SDL_CreateTextureFromSurface(renderer, pixels);
    int w = pixels->w;
    int h = pixels->h;
    SDL_DestroySurface(pixels);

    bool running = true;
    while (running)
    {
        SDL_SetRenderDrawColor(renderer, 23, 23, 23, 255);
        SDL_RenderClear(renderer);

        SDL_Event event;
        while (SDL_PollEvent(&event))
        {
            if (event.type == SDL_EVENT_QUIT)
            {
                running = false;
            }
        }

        render(renderer, sprite);
        SDL_RenderPresent(renderer);
    }

    return 0;
}
```
Which can be be build after installing upstream SDL to the PSPDEV SDK using the following CMakeLists.txt:
```
cmake_minimum_required(VERSION 3.11)

project(bug)

add_executable(${PROJECT_NAME}
    main.cpp
)

find_package(SDL3 REQUIRED)

target_link_libraries(${PROJECT_NAME} PRIVATE
    SDL3::SDL3
)

add_custom_target(copy_assets
    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_LIST_DIR}/assets ${CMAKE_CURRENT_BINARY_DIR}/assets
)
add_dependencies(${PROJECT_NAME} copy_assets)

# output stuff
if(PSP)
    create_pbp_file(
        TARGET ${PROJECT_NAME}
        ICON_PATH NULL
        BACKGROUND_PATH NULL
        PREVIEW_PATH NULL
        TITLE ${PROJECT_NAME}
        VERSION 01.00
    )
endif()
```
Command is `mkdir build && cd build && psp-cmake .. && make`.

Here is the image that should be in he assets directory:
<img width="40" height="40" alt="sprite" src="https://github.com/user-attachments/assets/4d05920c-a636-4186-bf62-e197d0b4dbf1" />

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
