### PR TITLE
SDL_test: add --no-time option to not log times

### DIFF
--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -43,6 +43,7 @@ static const char *common_usage[] = {
     "[--trackmem]",
     "[--randmem]",
     "[--no-color]",
+    "[--no-time]",
     "[--info all|video|modes|render|event|event_motion]",
     "[--log all|error|system|audio|video|render|input]",
     NULL
@@ -157,6 +158,10 @@ static int SDLCALL SDLTest_CommonStateParseCommonArguments(void *data, char **ar
     }
     if (SDL_strcasecmp(argv[index], "--no-color") == 0) {
         SDLTest_Color = false;
+        return 1;
+    }
+    if (SDL_strcasecmp(argv[index], "--no-time") == 0) {
+        SDLTest_Time = false;
         return 1;
     }
     if (SDL_strcasecmp(argv[index], "--randmem") == 0) {

--- a/src/test/SDL_test_internal.h
+++ b/src/test/SDL_test_internal.h
@@ -22,6 +22,7 @@
 #define SDL_test_internal_h
 
 extern bool SDLTest_Color;
+extern bool SDLTest_Time;
 
 #define COLOR_RAW_RED       "\033[0;31m"
 #define COLOR_RAW_GREEN     "\033[0;32m"

--- a/src/test/SDL_test_log.c
+++ b/src/test/SDL_test_log.c
@@ -31,6 +31,8 @@
 
 #include <time.h> /* Needed for localtime() */
 
+bool SDLTest_Time = true;
+
 /* work around compiler warning on older GCCs. */
 #if (defined(__GNUC__) && (__GNUC__ <= 2))
 static size_t strftime_gcc2_workaround(char *s, size_t max, const char *fmt, const struct tm *tm)
@@ -60,6 +62,10 @@ static const char *SDLTest_TimestampToString(const time_t timestamp)
     static char buffer[64];
     struct tm *local;
     size_t result = 0;
+
+    if (!SDLTest_Time) {
+        return "";
+    }
 
     SDL_memset(buffer, 0, sizeof(buffer));
     copy = timestamp;


### PR DESCRIPTION
Combining this new option with a known seed hash allows easy diff-ing between runs.

(Used in https://github.com/libsdl-org/SDL/issues/14882#issuecomment-3825073196)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
