### PR TITLE
asyncio: don't report failures on closing read-only files with Windows IoRing

### DIFF
--- a/src/io/SDL_sysasyncio.h
+++ b/src/io/SDL_sysasyncio.h
@@ -124,6 +124,7 @@ struct SDL_AsyncIO
     SDL_AsyncIOTask tasks;
     SDL_AsyncIOTask *closing;  // The close task, which isn't queued until all pending work for this file is done.
     bool oneshot;  // true if this is a SDL_LoadFileAsync open.
+    bool readonly;  // true if this file is opened read-only.
 };
 
 // This is implemented for various platforms; param validation is done before calling this. Open file, fill in iface and userdata.


### PR DESCRIPTION

We still need the task to go through the IoRing, even though the flush operation we use to get it there will always fail on a read-only file. So check for this specific case and don't report failure.

Fixes #14878.

(This is going through a PR to make sure the buildbots like it.)