### PR TITLE
Add "/usr/local/lib/libvulkan.dylib" as a path checked when loading Vulkan on MacOS

### DIFF
--- a/src/video/cocoa/SDL_cocoavulkan.m
+++ b/src/video/cocoa/SDL_cocoavulkan.m
@@ -41,7 +41,8 @@ const char *defaultPaths[] = {
     "libvulkan.1.dylib",
     "libvulkan.dylib",
     "MoltenVK.framework/MoltenVK",
-    "libMoltenVK.dylib"
+    "libMoltenVK.dylib",
+	"/usr/local/lib/libvulkan.dylib"
 };
 
 // Since libSDL is most likely a .dylib, need RTLD_DEFAULT not RTLD_SELF.

--- a/src/video/cocoa/SDL_cocoavulkan.m
+++ b/src/video/cocoa/SDL_cocoavulkan.m
@@ -42,7 +42,7 @@ const char *defaultPaths[] = {
     "libvulkan.dylib",
     "MoltenVK.framework/MoltenVK",
     "libMoltenVK.dylib",
-	"/usr/local/lib/libvulkan.dylib"
+    "/usr/local/lib/libvulkan.dylib"
 };
 
 // Since libSDL is most likely a .dylib, need RTLD_DEFAULT not RTLD_SELF.


### PR DESCRIPTION
I was having a issue where SDL was not loading with the error of `SDL could not create window! SDL_Error: Failed to load Vulkan Portability library`. I am also using volk and I saw volk was loading Vulkan from "/usr/local/lib/libvulkan.dylib". SDL does not check this path and so I added it as the last path checked.

This fixed my issues and based on the comments in volk `// modern versions of macOS don't search /usr/local/lib automatically contrary to what man dlopen says` this may not have been a problem in the past.

Old:
```c
const char *defaultPaths[] = {
    "@executable_path/../Frameworks/libMoltenVK.dylib",
    "vulkan.framework/vulkan",
    "libvulkan.1.dylib",
    "libvulkan.dylib",
    "MoltenVK.framework/MoltenVK",
    "libMoltenVK.dylib"
};
```
New:
```c
const char *defaultPaths[] = {
    "@executable_path/../Frameworks/libMoltenVK.dylib",
    "vulkan.framework/vulkan",
    "libvulkan.1.dylib",
    "libvulkan.dylib",
    "MoltenVK.framework/MoltenVK",
    "libMoltenVK.dylib",
    "/usr/local/lib/libvulkan.dylib"
};
```