### PR TITLE
GPU: Query UnrestrictedBufferTextureCopyPitchSupported to avoid D3D12 realignment copies

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -1398,11 +1398,12 @@ typedef struct SDL_GPUViewport
  * SDL_DownloadFromGPUTexture are used as default values respectively and data
  * is considered to be tightly packed.
  *
- * **WARNING**: Direct3D 12 requires texture data row pitch to be 256 byte
- * aligned, and offsets to be aligned to 512 bytes. If they are not, SDL will
- * make a temporary copy of the data that is properly aligned, but this adds
- * overhead to the transfer process. Apps can avoid this by aligning their
- * data appropriately, or using a different GPU backend than Direct3D 12.
+ * **WARNING**: On some older/integrated hardware, Direct3D 12 requires texture
+ * data row pitch to be 256 byte aligned, and offsets to be aligned to 512 bytes.
+ * If they are not, SDL will make a temporary copy of the data that is properly
+ * aligned, but this adds overhead to the transfer process. Apps can avoid this
+ * by aligning their data appropriately, or using a different GPU backend than
+ * Direct3D 12.
  *
  * \since This struct is available since SDL 3.2.0.
  *


### PR DESCRIPTION
When uploading and downloading texture data, D3D12 requires 256 byte alignment for texture data row pitch, and 512 byte aligned offsets within the source buffer. This is a restriction unique to D3D12, and it has required complicated workarounds in the SDL_GPU driver to make this transparent to the client: copying data into temporary buffers with appropriate alignment, storing metadata for texture downloads, tracking when it's safe to release the temporary buffer, etc.

However, there is an optional D3D12 feature that will allow us to bypass all of this realignment work: `UnrestrictedBufferTextureCopyPitchSupported`. If this feature is available, we can skip all the temporary copies and just upload the data directly, like we do for all the other GPU backends.

We still need to keep the workarounds for older (pre-2022) drivers and some integrated cards, but this should be a nice optimization for the GPUs that support it, particularly for upload-heavy workloads like video playback.