### PR TITLE
QNX: support Wayland backend.

### DIFF
--- a/src/video/wayland/SDL_waylandopengles.c
+++ b/src/video/wayland/SDL_waylandopengles.c
@@ -40,7 +40,6 @@ bool Wayland_GLES_LoadLibrary(SDL_VideoDevice *_this, const char *path)
     SDL_VideoData *data = _this->internal;
 
 #if defined(SDL_PLATFORM_QNXNTO)
-    //QNX needs some extra attention here to really let egl know we are wanting wayland
     SDL_GL_SetAttribute(SDL_GL_EGL_PLATFORM, EGL_PLATFORM_WAYLAND_EXT);
 #endif
 


### PR DESCRIPTION
Fixes Wayland with opengles2 on QNX

## Description
EGL considers screen to be the native platform unless we explicitly set EGL_PLATFORM_WAYLAND_EXT, even when we pass "wayland" as a hint.

## Existing Issue(s)
N/A
