### PR TITLE
cocoawindow: fix wrong content scale with ANGLE EGL context

### DIFF
--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -1375,6 +1375,8 @@ static NSCursor *Cocoa_GetDesiredCursor(void)
 
 - (void)windowDidChangeBackingProperties:(NSNotification *)aNotification
 {
+    SDL_CocoaWindowData *windata = (__bridge SDL_CocoaWindowData *)_data.window->internal;
+    NSView *contentView = windata.sdlContentView;
     NSNumber *oldscale = [[aNotification userInfo] objectForKey:NSBackingPropertyOldScaleFactorKey];
 
     if (inFullscreenTransition) {
@@ -1382,6 +1384,9 @@ static NSCursor *Cocoa_GetDesiredCursor(void)
     }
 
     if ([oldscale doubleValue] != [_data.nswindow backingScaleFactor]) {
+        // Update the content scale on the window layer
+        // This is required to keep content scale in sync with ANGLE
+        contentView.layer.contentsScale = [_data.nswindow backingScaleFactor];
         // Send a resize event when the backing scale factor changes.
         [self windowDidResize:aNotification];
     }


### PR DESCRIPTION
ANGLE expects that the surface layer content scale is updated accordingly.

<https://github.com/google/angle/blob/b406401e42080c2f8fe479e6c5fa48dfae97c482/src/libANGLE/renderer/metal/SurfaceMtl.mm#L597-L636>

## Description

Without this patch, if you move the window to a display with different scale the content either shrinks or grows.

<img width="1418" height="904" alt="image" src="https://github.com/user-attachments/assets/3f6363d8-b02d-428b-b48f-20cc69b224b1" />

## Existing Issue(s)
#14790 
