### PR TITLE
Fix Switch and Switch 2 player LED patterns

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_switch.c
+++ b/src/joystick/hidapi/SDL_hidapi_switch.c
@@ -778,9 +778,10 @@ static void UpdateSlotLED(SDL_DriverSwitch_Context *ctx)
 {
     if (!ctx->m_bInputOnly) {
         Uint8 led_data = 0;
+        const Uint8 player_pattern[] = { 0x1, 0x3, 0x7, 0xf, 0x9, 0x5, 0xd, 0x6 };
 
         if (ctx->m_bPlayerLights && ctx->m_nPlayerIndex >= 0) {
-            led_data = (1 << (ctx->m_nPlayerIndex % 4));
+            led_data = player_pattern[ctx->m_nPlayerIndex % 8];
         }
         WriteSubcommand(ctx, k_eSwitchSubcommandIDs_SetPlayerLights, &led_data, sizeof(led_data), NULL);
     }

--- a/src/joystick/hidapi/SDL_hidapi_switch2.c
+++ b/src/joystick/hidapi/SDL_hidapi_switch2.c
@@ -232,16 +232,17 @@ static void MapTriggerAxis(Uint64 timestamp, SDL_Joystick *joystick, Uint8 axis,
 
 static bool UpdateSlotLED(SDL_DriverSwitch2_Context *ctx)
 {
-    unsigned char SET_LED_DATA[] = {
+    Uint8 set_led_data[] = {
         0x09, 0x91, 0x00, 0x07, 0x00, 0x08, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
     };
-    unsigned char reply[8] = {0};
+    Uint8 reply[8] = {0};
+    const Uint8 player_pattern[] = { 0x1, 0x3, 0x7, 0xf, 0x9, 0x5, 0xd, 0x6 };
 
     if (ctx->player_lights && ctx->player_index >= 0) {
-        SET_LED_DATA[8] = (1 << (ctx->player_index % 4));
+        set_led_data[8] = player_pattern[ctx->player_index % 8];
     }
-    int res = SendBulkData(ctx, SET_LED_DATA, sizeof(SET_LED_DATA));
+    int res = SendBulkData(ctx, set_led_data, sizeof(set_led_data));
     if (res < 0) {
         return SDL_SetError("Couldn't set LED data: %d\n", res);
     }


### PR DESCRIPTION
The patterns we were using don't match the official patterns, which fill up as many lights as players instead of just using the nth player LED. Above 4, there are some special patterns, as documented on Nintendo's Singaporean site: https://www.nintendo.com/sg/support/qa/detail/33822