### PR TITLE
Fix warning: annotate no return

### DIFF
--- a/test/testfile.c
+++ b/test/testfile.c
@@ -50,7 +50,7 @@ cleanup(void)
     unlink(FBASENAME2);
 }
 
-static void
+static SDL_NORETURN void
 iostrm_error_quit(unsigned line, SDL_IOStream *iostrm)
 {
     SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "testfile.c(%d): failed", line);

--- a/test/testgpu_spinning_cube.c
+++ b/test/testgpu_spinning_cube.c
@@ -386,7 +386,7 @@ static void shutdownGPU(void)
 
 
 /* Call this instead of exit(), so we can clean up SDL: atexit() is evil. */
-static void
+static SDL_NORETURN void
 quit(int rc)
 {
     shutdownGPU();

--- a/test/testhaptic.c
+++ b/test/testhaptic.c
@@ -319,7 +319,7 @@ int main(int argc, char **argv)
 /**
  * Cleans up a bit.
  */
-static void
+static SDL_NORETURN void
 abort_execution(void)
 {
     SDL_Log("%s", "");


### PR DESCRIPTION
Clang: function could be declared with attribute 'noreturn' [-Wmissing-noreturn]