### PR TITLE
Fix warning: Goto misses init

### DIFF
--- a/src/hidapi/windows/hid.c
+++ b/src/hidapi/windows/hid.c
@@ -1028,7 +1028,7 @@ struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned shor
 		}
 
 #ifdef HIDAPI_IGNORE_DEVICE
-		hid_bus_type bus_type = SDL_HID_API_BUS_UNKNOWN;
+		hid_bus_type bus_type = HID_API_BUS_UNKNOWN;
 		PHIDP_PREPARSED_DATA pp_data = NULL;
 		HIDP_CAPS caps = { 0 };
 #endif


### PR DESCRIPTION
Clang: jump from this goto statement to its label is incompatible with C++ [-Wjump-misses-init]