### PR TITLE
Fix warning: Static at beginning of declaration

### DIFF
--- a/src/video/n3ds/SDL_n3dsswkb.c
+++ b/src/video/n3ds/SDL_n3dsswkb.c
@@ -28,7 +28,7 @@
 #include "SDL_n3dsswkb.h"
 
 static SwkbdState sw_keyboard;
-const static size_t BUFFER_SIZE = 256;
+static const size_t BUFFER_SIZE = 256;
 
 void N3DS_SwkbInit(void)
 {

--- a/test/testsymbols.c
+++ b/test/testsymbols.c
@@ -68,7 +68,7 @@ extern SDL_DECLSPEC void SDLCALL JNI_OnLoad(void);
 
 #include <SDL3/SDL_openxr.h>
 
-const static struct {
+static const struct {
     const char *name;
     SDL_FunctionPointer address;
 } sdl_symbols[] = {


### PR DESCRIPTION
GCC: 'static' is not at beginning of declaration [-Wold-style-declaration]