### PR TITLE
Fix warning: No void pointer arithmetic

### DIFF
--- a/src/render/ps2/SDL_render_ps2.c
+++ b/src/render/ps2/SDL_render_ps2.c
@@ -450,7 +450,7 @@ static bool PS2_RenderGeometry(SDL_Renderer *renderer, void *vertices, SDL_Rende
     PS2_SetBlendMode(data, cmd->data.draw.blend);
 
     if (cmd->data.draw.texture) {
-        const GSPRIMUVPOINT *verts = (GSPRIMUVPOINT *) ((char*)vertices + cmd->data.draw.first);
+        const GSPRIMUVPOINT *verts = (GSPRIMUVPOINT *) ((Uint8*)vertices + cmd->data.draw.first);
         GSTEXTURE *ps2_tex = (GSTEXTURE *)cmd->data.draw.texture->internal;
 
         switch (cmd->data.draw.texture_scale_mode) {
@@ -467,7 +467,7 @@ static bool PS2_RenderGeometry(SDL_Renderer *renderer, void *vertices, SDL_Rende
         gsKit_TexManager_bind(data->gsGlobal, ps2_tex);
         gsKit_prim_list_triangle_goraud_texture_uv_3d(data->gsGlobal, ps2_tex, count, verts);
     } else {
-        const GSPRIMPOINT *verts = (GSPRIMPOINT *)((char*)vertices + cmd->data.draw.first);
+        const GSPRIMPOINT *verts = (GSPRIMPOINT *)((Uint8*)vertices + cmd->data.draw.first);
         gsKit_prim_list_triangle_gouraud_3d(data->gsGlobal, count, verts);
     }
 
@@ -478,7 +478,7 @@ static bool PS2_RenderLines(SDL_Renderer *renderer, void *vertices, SDL_RenderCo
 {
     PS2_RenderData *data = (PS2_RenderData *)renderer->internal;
     const size_t count = cmd->data.draw.count;
-    const GSPRIMPOINT *verts = (GSPRIMPOINT *)((char*)vertices + cmd->data.draw.first);
+    const GSPRIMPOINT *verts = (GSPRIMPOINT *)((Uint8*)vertices + cmd->data.draw.first);
 
     PS2_SetBlendMode(data, cmd->data.draw.blend);
     gsKit_prim_list_line_goraud_3d(data->gsGlobal, count, verts);
@@ -491,7 +491,7 @@ static bool PS2_RenderPoints(SDL_Renderer *renderer, void *vertices, SDL_RenderC
 {
     PS2_RenderData *data = (PS2_RenderData *)renderer->internal;
     const size_t count = cmd->data.draw.count;
-    const GSPRIMPOINT *verts = (GSPRIMPOINT *)((char*)vertices + cmd->data.draw.first);
+    const GSPRIMPOINT *verts = (GSPRIMPOINT *)((Uint8*)vertices + cmd->data.draw.first);
 
     PS2_SetBlendMode(data, cmd->data.draw.blend);
     gsKit_prim_list_points(data->gsGlobal, count, verts);

--- a/src/render/vitagxm/SDL_render_vita_gxm.c
+++ b/src/render/vitagxm/SDL_render_vita_gxm.c
@@ -349,11 +349,11 @@ static bool VITA_GXM_UpdateTexture(SDL_Renderer *renderer, SDL_Texture *texture,
     length = rect->w * SDL_BYTESPERPIXEL(texture->format);
     if (length == pitch && length == dpitch) {
         SDL_memcpy(dst, pixels, length * rect->h);
-        *(Uint8**)&pixels += pitch * rect->h;
+        pixels = (const Uint8 *)pixels + pitch * rect->h;
     } else {
         for (row = 0; row < rect->h; ++row) {
             SDL_memcpy(dst, pixels, length);
-            *(Uint8**)&pixels += pitch;
+            pixels = (const Uint8 *)pixels + pitch;
             dst += dpitch;
         }
     }
@@ -377,11 +377,11 @@ static bool VITA_GXM_UpdateTexture(SDL_Renderer *renderer, SDL_Texture *texture,
         // U plane
         if (length == uv_src_pitch && length == uv_pitch) {
             SDL_memcpy(Udst, pixels, length * UVrect.h);
-            *(Uint8**)&pixels += uv_src_pitch * UVrect.h;
+            pixels = (const Uint8 *)pixels + uv_src_pitch * UVrect.h;
         } else {
             for (row = 0; row < UVrect.h; ++row) {
                 SDL_memcpy(Udst, pixels, length);
-                *(Uint8**)&pixels += uv_src_pitch;
+                pixels = (const Uint8 *)pixels + uv_src_pitch;
                 Udst += uv_pitch;
             }
         }
@@ -392,7 +392,7 @@ static bool VITA_GXM_UpdateTexture(SDL_Renderer *renderer, SDL_Texture *texture,
         } else {
             for (row = 0; row < UVrect.h; ++row) {
                 SDL_memcpy(Vdst, pixels, length);
-                *(Uint8**)&pixels += uv_src_pitch;
+                pixels = (const Uint8 *)pixels + uv_src_pitch;
                 Vdst += uv_pitch;
             }
         }
@@ -415,7 +415,7 @@ static bool VITA_GXM_UpdateTexture(SDL_Renderer *renderer, SDL_Texture *texture,
         } else {
             for (row = 0; row < UVrect.h; ++row) {
                 SDL_memcpy(UVdst, pixels, length);
-                *(Uint8**)&pixels += uv_src_pitch;
+                pixels = (const Uint8 *)pixels + uv_src_pitch;
                 UVdst += uv_pitch;
             }
         }


### PR DESCRIPTION
Clang: arithmetic on a pointer to void is a GNU extension [-Wgnu-pointer-arith]