### PR TITLE
Fix SDL_TriggerBreakpoint being undefined on slimcc

### DIFF
--- a/include/SDL3/SDL_assert.h
+++ b/include/SDL3/SDL_assert.h
@@ -136,7 +136,7 @@ extern "C" {
     #define SDL_TriggerBreakpoint() __builtin_debugtrap()
 #elif SDL_HAS_BUILTIN(__builtin_trap)
     #define SDL_TriggerBreakpoint() __builtin_trap()
-#elif (defined(__GNUC__) || defined(__clang__) || defined(__TINYC__)) && (defined(__i386__) || defined(__x86_64__))
+#elif (defined(__GNUC__) || defined(__clang__) || defined(__TINYC__) || defined(__slimcc__)) && (defined(__i386__) || defined(__x86_64__))
     #define SDL_TriggerBreakpoint() __asm__ __volatile__ ( "int $3\n\t" )
 #elif (defined(__GNUC__) || defined(__clang__)) && defined(__riscv)
     #define SDL_TriggerBreakpoint() __asm__ __volatile__ ( "ebreak\n\t" )


### PR DESCRIPTION
Ran into an issue making a debug build of my game with the [slimcc](https://github.com/fuhsnn/slimcc) compiler due to SDL_TriggerBreakpoint not being defined:

<img width="968" height="252" alt="image" src="https://github.com/user-attachments/assets/254e7875-6d9e-4f07-96d1-67f16e6bdeb6" />

Added a check for `__slimcc__` for the same codepath that GCC, clang and TCC uses on x86_64 that seems to work with slimcc too (slimcc is x86_64-only).

(Other than this, SDL seems to work fine when built with slimcc!)