### PR TITLE
cocoa: Fix 1px border in fullscreen on Tahoe

### DIFF
--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -3054,6 +3054,9 @@ SDL_FullscreenResult Cocoa_SetWindowFullscreen(SDL_VideoDevice *_this, SDL_Windo
         [nswindow setContentSize:rect.size];
         [nswindow setFrameOrigin:rect.origin];
 
+        // Disable the window shadow in fullscreen to avoid a visible 1px border on Tahoe
+        nswindow.hasShadow = !fullscreen && !(window->flags & SDL_WINDOW_TRANSPARENT);
+
         // When the window style changes the title is cleared
         if (!fullscreen) {
             Cocoa_SetWindowTitle(_this, window);


### PR DESCRIPTION
## Description
macOS Tahoe introduced an issue where a 1px gray border is drawn around fullscreen apps when `SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES=0` or using fullscreen exclusive mode. It appears that earlier versions of macOS will implicitly disable the window shadow in fullscreen, but Tahoe no longer does this. Disabling the window shadow explicitly solves this problem.

Investigation of this change in Tahoe by the INNA project developers: https://github.com/iina/iina/issues/5783
Downstream bug report on Moonlight with screenshots: https://github.com/moonlight-stream/moonlight-qt/issues/1661

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
