### PR TITLE
Test: variable conditionally uninitialized

### DIFF
--- a/test/testautomation_video.c
+++ b/test/testautomation_video.c
@@ -1957,7 +1957,7 @@ static int SDLCALL video_getSetWindowState(void *arg)
     SDL_Rect display;
     SDL_WindowFlags flags;
     int windowedX, windowedY;
-    int currentX, currentY;
+    int currentX = 0, currentY = 0;
     int desiredX = 0, desiredY = 0;
     int windowedW, windowedH;
     int currentW, currentH;


### PR DESCRIPTION
currentX and currentY in L2263-L2264 are marked as conditionally uninitialized by MSVC and Clang

Clang: variable may be uninitialized when used here [-Wconditional-uninitialized]

For me it looks like a false positive. There are paths with `!skipPos` before this branch that set `currentX` and `currentY`.