### PR TITLE
Fix warning: conditional expression is constant

### DIFF
--- a/test/testautomation_math.c
+++ b/test/testautomation_math.c
@@ -1060,7 +1060,8 @@ exp_overflowCase(void *args)
 {
     double result;
 
-    if (sizeof(double) > 8) {
+    const bool double_is_larger_than_64bit = sizeof(double) > 8;
+    if (double_is_larger_than_64bit) {
         return TEST_SKIPPED;
     }
 

--- a/test/testautomation_stdlib.c
+++ b/test/testautomation_stdlib.c
@@ -365,7 +365,8 @@ static int SDLCALL stdlib_snprintf(void *arg)
                         result == SDL_strlen(expected5),
         "Check result value, expected: %d, got: %d", (int)SDL_strlen(expected), result);
 
-    if (sizeof(void *) >= 8) {
+    const bool is_at_least_64bit_system = sizeof(void *) >= 8;
+    if (is_at_least_64bit_system) {
         result = SDL_snprintf(text, sizeof(text), "%p", (void *)SDL_SINT64_C(0x1ba07bddf60));
         expected = "0x1ba07bddf60";
         expected2 = "000001BA07BDDF60";
@@ -1324,7 +1325,8 @@ static int SDLCALL stdlib_wcstol(void *arg)
     WCSTOL_TEST_CASE(L" - 1", 0, 0, 0); // invalid input
 
     // values near the bounds of the type
-    if (sizeof(long) == 4) {
+    const bool long_is_32bit = sizeof(long) == 4;
+    if (long_is_32bit) {
         WCSTOL_TEST_CASE(L"2147483647", 10, 2147483647, 10);
         WCSTOL_TEST_CASE(L"2147483648", 10, 2147483647, 10);
         WCSTOL_TEST_CASE(L"-2147483648", 10, -2147483647L - 1, 11);
@@ -1383,7 +1385,8 @@ static int SDLCALL stdlib_strtox(void *arg)
     // Suppressing warnings would be difficult otherwise.
     // Since the CI runs the tests against a variety of targets, this should be fine in practice.
 
-    if (sizeof(long) == 4) {
+    const bool long_is_32bit = sizeof(long) == 4;
+    if (long_is_32bit) {
         STRTOX_TEST_CASE(SDL_strtol, long, "%ld", "0", 0, 0, 1);
         STRTOX_TEST_CASE(SDL_strtol, long, "%ld", "0", 10, 0, 1);
         STRTOX_TEST_CASE(SDL_strtol, long, "%ld", "-0", 0, 0, 2);
@@ -1399,7 +1402,8 @@ static int SDLCALL stdlib_strtox(void *arg)
         STRTOX_TEST_CASE(SDL_strtoul, unsigned long, "%lu", "-4294967295", 10, 1, 11);
     }
 
-    if (sizeof(long long) == 8) {
+    const bool long_long_is_64bit = sizeof(long long) == 8;
+    if (long_long_is_64bit) {
         STRTOX_TEST_CASE(SDL_strtoll, long long, FMT_PRILLd, "0", 0, 0LL, 1);
         STRTOX_TEST_CASE(SDL_strtoll, long long, FMT_PRILLd, "0", 10, 0LL, 1);
         STRTOX_TEST_CASE(SDL_strtoll, long long, FMT_PRILLd, "-0", 0, 0LL, 2);

--- a/test/testautomation_surface.c
+++ b/test/testautomation_surface.c
@@ -1570,7 +1570,8 @@ static int SDLCALL surface_testOverflow(void *arg)
     SDLTest_AssertCheck(SDL_strcmp(SDL_GetError(), expectedError) == 0,
                         "Expected \"%s\", got \"%s\"", expectedError, SDL_GetError());
 
-    if (sizeof(size_t) == 4 && sizeof(int) >= 4) {
+    const bool is_32bit_system_with_int_larger_32bit = sizeof(size_t) == 4 && sizeof(int) >= 4;
+    if (is_32bit_system_with_int_larger_32bit) {
         SDL_ClearError();
         expectedError = "aligning pitch would overflow";
         /* 0x5555'5555 * 3bpp = 0xffff'ffff which fits in size_t, but adding


### PR DESCRIPTION
This fixes a MSVC warning by moving the constant expression out of the if statement into a const bool variable.

MSVC: C4127: conditional expression is constant