### PR TITLE
You can't combine SDL_STRINGIFY_ARG() and SDL_FUNCTION

### DIFF
--- a/include/SDL3/SDL_assert.h
+++ b/include/SDL3/SDL_assert.h
@@ -160,7 +160,7 @@ extern "C" {
 #ifdef SDL_WIKI_DOCUMENTATION_SECTION
 
 /**
- * A macro that reports the current function being compiled.
+ * A constant that contains the current function being compiled.
  *
  * If SDL can't figure how the compiler reports this, it will use "???".
  *
@@ -168,12 +168,14 @@ extern "C" {
  */
 #define SDL_FUNCTION __FUNCTION__
 
-#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 supports __func__ as a standard. */
+#elif !defined(SDL_FUNCTION)
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) /* C99 supports __func__ as a standard. */
 #   define SDL_FUNCTION __func__
 #elif ((defined(__GNUC__) && (__GNUC__ >= 2)) || defined(_MSC_VER) || defined (__WATCOMC__))
 #   define SDL_FUNCTION __FUNCTION__
 #else
 #   define SDL_FUNCTION "???"
+#endif
 #endif
 
 #ifdef SDL_WIKI_DOCUMENTATION_SECTION

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -254,12 +254,6 @@ void *alloca(size_t);
 /**
  * Macro useful for building other macros with strings in them.
  *
- * For example:
- *
- * ```c
- * #define LOG_ERROR(X) OutputDebugString(SDL_STRINGIFY_ARG(SDL_FUNCTION) ": " X "\n")`
- * ```
- *
  * \param arg the text to turn into a string literal.
  *
  * \since This macro is available since SDL 3.2.0.

--- a/src/render/direct3d11/SDL_render_d3d11.c
+++ b/src/render/direct3d11/SDL_render_d3d11.c
@@ -39,12 +39,6 @@
 
 #include "SDL_shaders_d3d11.h"
 
-#if defined(_MSC_VER) && !defined(__clang__)
-#define SDL_COMPOSE_ERROR(str) SDL_FUNCTION ", " str
-#else
-#define SDL_COMPOSE_ERROR(str) SDL_STRINGIFY_ARG(SDL_FUNCTION) ", " str
-#endif
-
 #define SAFE_RELEASE(X)                                   \
     if ((X)) {                                            \
         IUnknown_Release(SDL_static_cast(IUnknown *, X)); \
@@ -477,7 +471,7 @@ static ID3D11BlendState *D3D11_CreateBlendState(SDL_Renderer *renderer, SDL_Blen
     blendDesc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
     result = ID3D11Device_CreateBlendState(data->d3dDevice, &blendDesc, &blendState);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateBlendState"), result);
+        WIN_SetErrorFromHRESULT("ID3D11Device1::CreateBlendState", result);
         return NULL;
     }
 
@@ -572,13 +566,13 @@ static HRESULT D3D11_CreateDeviceResources(SDL_Renderer *renderer)
 
         result = pDXGIGetDebugInterface1(0, &SDL_IID_IDXGIDebug1, (void **)&data->dxgiDebug);
         if (FAILED(result)) {
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("DXGIGetDebugInterface1"), result);
+            WIN_SetErrorFromHRESULT("DXGIGetDebugInterface1", result);
             goto done;
         }
 
         result = pDXGIGetDebugInterface1(0, &SDL_IID_IDXGIInfoQueue, (void **)&dxgiInfoQueue);
         if (FAILED(result)) {
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("DXGIGetDebugInterface1"), result);
+            WIN_SetErrorFromHRESULT("DXGIGetDebugInterface1", result);
             goto done;
         }
 
@@ -595,7 +589,7 @@ static HRESULT D3D11_CreateDeviceResources(SDL_Renderer *renderer)
         result = pCreateDXGIFactory(&SDL_IID_IDXGIFactory2, (void **)&data->dxgiFactory);
     }
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("CreateDXGIFactory"), result);
+        WIN_SetErrorFromHRESULT("CreateDXGIFactory", result);
         goto done;
     }
 
@@ -624,7 +618,7 @@ static HRESULT D3D11_CreateDeviceResources(SDL_Renderer *renderer)
         // FIXME: Should we use the default adapter?
         result = IDXGIFactory2_EnumAdapters(data->dxgiFactory, 0, &dxgiAdapter);
         if (FAILED(result)) {
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("EnumAdapters"), result);
+            WIN_SetErrorFromHRESULT("EnumAdapters", result);
             goto done;
         }
     }
@@ -658,25 +652,25 @@ static HRESULT D3D11_CreateDeviceResources(SDL_Renderer *renderer)
         &d3dContext          // Returns the device immediate context.
     );
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("D3D11CreateDevice"), result);
+        WIN_SetErrorFromHRESULT("D3D11CreateDevice", result);
         goto done;
     }
 
     result = ID3D11Device_QueryInterface(d3dDevice, &SDL_IID_ID3D11Device1, (void **)&data->d3dDevice);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device to ID3D11Device1"), result);
+        WIN_SetErrorFromHRESULT("ID3D11Device to ID3D11Device1", result);
         goto done;
     }
 
     result = ID3D11DeviceContext_QueryInterface(d3dContext, &SDL_IID_ID3D11DeviceContext1, (void **)&data->d3dContext);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11DeviceContext to ID3D11DeviceContext1"), result);
+        WIN_SetErrorFromHRESULT("ID3D11DeviceContext to ID3D11DeviceContext1", result);
         goto done;
     }
 
     result = ID3D11Device_QueryInterface(d3dDevice, &SDL_IID_IDXGIDevice1, (void **)&dxgiDevice);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device to IDXGIDevice1"), result);
+        WIN_SetErrorFromHRESULT("ID3D11Device to IDXGIDevice1", result);
         goto done;
     }
 
@@ -685,7 +679,7 @@ static HRESULT D3D11_CreateDeviceResources(SDL_Renderer *renderer)
      */
     result = IDXGIDevice1_SetMaximumFrameLatency(dxgiDevice, 1);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGIDevice1::SetMaximumFrameLatency"), result);
+        WIN_SetErrorFromHRESULT("IDXGIDevice1::SetMaximumFrameLatency", result);
         goto done;
     }
 
@@ -709,7 +703,7 @@ static HRESULT D3D11_CreateDeviceResources(SDL_Renderer *renderer)
                                        NULL,
                                        &data->vertexShaderConstants);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateBuffer [vertex shader constants]"), result);
+        WIN_SetErrorFromHRESULT("ID3D11Device1::CreateBuffer [vertex shader constants]", result);
         goto done;
     }
 
@@ -727,14 +721,14 @@ static HRESULT D3D11_CreateDeviceResources(SDL_Renderer *renderer)
     rasterDesc.SlopeScaledDepthBias = 0.0f;
     result = ID3D11Device_CreateRasterizerState(data->d3dDevice, &rasterDesc, &data->mainRasterizer);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateRasterizerState [main rasterizer]"), result);
+        WIN_SetErrorFromHRESULT("ID3D11Device1::CreateRasterizerState [main rasterizer]", result);
         goto done;
     }
 
     rasterDesc.ScissorEnable = TRUE;
     result = ID3D11Device_CreateRasterizerState(data->d3dDevice, &rasterDesc, &data->clippedRasterizer);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateRasterizerState [clipped rasterizer]"), result);
+        WIN_SetErrorFromHRESULT("ID3D11Device1::CreateRasterizerState [clipped rasterizer]", result);
         goto done;
     }
 
@@ -878,7 +872,7 @@ static HRESULT D3D11_CreateSwapChain(SDL_Renderer *renderer, int w, int h)
                                                             NULL, // Allow on all displays.
                                                             &data->swapChain);
         if (FAILED(result)) {
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGIFactory2::CreateSwapChainForCoreWindow"), result);
+            WIN_SetErrorFromHRESULT("IDXGIFactory2::CreateSwapChainForCoreWindow", result);
             goto done;
         }
     } else {
@@ -898,7 +892,7 @@ static HRESULT D3D11_CreateSwapChain(SDL_Renderer *renderer, int w, int h)
                                                       NULL, // Allow on all displays.
                                                       &data->swapChain);
         if (FAILED(result)) {
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGIFactory2::CreateSwapChainForHwnd"), result);
+            WIN_SetErrorFromHRESULT("IDXGIFactory2::CreateSwapChainForHwnd", result);
             goto done;
         }
 
@@ -929,7 +923,7 @@ static HRESULT D3D11_CreateSwapChain(SDL_Renderer *renderer, int w, int h)
             (colorspace_support & DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG_PRESENT)) {
             result = IDXGISwapChain3_SetColorSpace1(swapChain3, colorspace);
             if (FAILED(result)) {
-                WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGISwapChain3::SetColorSpace1"), result);
+                WIN_SetErrorFromHRESULT("IDXGISwapChain3::SetColorSpace1", result);
                 goto done;
             }
         } else if (colorspace != DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709) {
@@ -1007,7 +1001,7 @@ static HRESULT D3D11_CreateWindowSizeDependentResources(SDL_Renderer *renderer)
                                               DXGI_FORMAT_UNKNOWN,
                                               data->swapChainFlags);
         if (FAILED(result)) {
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGISwapChain::ResizeBuffers"), result);
+            WIN_SetErrorFromHRESULT("IDXGISwapChain::ResizeBuffers", result);
             goto done;
         }
     } else {
@@ -1024,7 +1018,7 @@ static HRESULT D3D11_CreateWindowSizeDependentResources(SDL_Renderer *renderer)
         if (data->swapEffect == DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL) {
             result = IDXGISwapChain1_SetRotation(data->swapChain, data->rotation);
             if (FAILED(result)) {
-                WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGISwapChain1::SetRotation"), result);
+                WIN_SetErrorFromHRESULT("IDXGISwapChain1::SetRotation", result);
                 goto done;
             }
         }
@@ -1035,7 +1029,7 @@ static HRESULT D3D11_CreateWindowSizeDependentResources(SDL_Renderer *renderer)
                                       &SDL_IID_ID3D11Texture2D,
                                       (void **)&backBuffer);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGISwapChain::GetBuffer [back-buffer]"), result);
+        WIN_SetErrorFromHRESULT("IDXGISwapChain::GetBuffer [back-buffer]", result);
         goto done;
     }
 
@@ -1045,7 +1039,7 @@ static HRESULT D3D11_CreateWindowSizeDependentResources(SDL_Renderer *renderer)
                                                  NULL,
                                                  &data->mainRenderTargetView);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device::CreateRenderTargetView"), result);
+        WIN_SetErrorFromHRESULT("ID3D11Device::CreateRenderTargetView", result);
         goto done;
     }
 
@@ -1163,7 +1157,7 @@ static bool D3D11_CreatePalette(SDL_Renderer *renderer, SDL_TexturePalette *pale
 
     HRESULT result = ID3D11Device_CreateTexture2D(data->d3dDevice, &textureDesc, NULL, &palettedata->texture);
     if (FAILED(result)) {
-        return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateTexture2D"), result);
+        return WIN_SetErrorFromHRESULT("ID3D11Device1::CreateTexture2D", result);
     }
 
     D3D11_SHADER_RESOURCE_VIEW_DESC resourceViewDesc;
@@ -1177,7 +1171,7 @@ static bool D3D11_CreatePalette(SDL_Renderer *renderer, SDL_TexturePalette *pale
                                                    &resourceViewDesc,
                                                    &palettedata->resourceView);
     if (FAILED(result)) {
-        return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateShaderResourceView"), result);
+        return WIN_SetErrorFromHRESULT("ID3D11Device1::CreateShaderResourceView", result);
     }
     return true;
 }
@@ -1269,7 +1263,7 @@ static bool D3D11_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SD
                                               NULL,
                                               &textureData->mainTexture);
         if (FAILED(result)) {
-            return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateTexture2D"), result);
+            return WIN_SetErrorFromHRESULT("ID3D11Device1::CreateTexture2D", result);
         }
     }
     SDL_SetPointerProperty(SDL_GetTextureProperties(texture), SDL_PROP_TEXTURE_D3D11_TEXTURE_POINTER, textureData->mainTexture);
@@ -1291,7 +1285,7 @@ static bool D3D11_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SD
                                                   NULL,
                                                   &textureData->mainTextureU);
             if (FAILED(result)) {
-                return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateTexture2D"), result);
+                return WIN_SetErrorFromHRESULT("ID3D11Device1::CreateTexture2D", result);
             }
         }
         SDL_SetPointerProperty(SDL_GetTextureProperties(texture), SDL_PROP_TEXTURE_D3D11_TEXTURE_U_POINTER, textureData->mainTextureU);
@@ -1305,7 +1299,7 @@ static bool D3D11_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SD
                                                   NULL,
                                                   &textureData->mainTextureV);
             if (FAILED(result)) {
-                return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateTexture2D"), result);
+                return WIN_SetErrorFromHRESULT("ID3D11Device1::CreateTexture2D", result);
             }
         }
         SDL_SetPointerProperty(SDL_GetTextureProperties(texture), SDL_PROP_TEXTURE_D3D11_TEXTURE_V_POINTER, textureData->mainTextureV);
@@ -1346,7 +1340,7 @@ static bool D3D11_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SD
                                                    &resourceViewDesc,
                                                    &textureData->mainTextureResourceView);
     if (FAILED(result)) {
-        return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateShaderResourceView"), result);
+        return WIN_SetErrorFromHRESULT("ID3D11Device1::CreateShaderResourceView", result);
     }
 
 #ifdef SDL_HAVE_YUV
@@ -1356,14 +1350,14 @@ static bool D3D11_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SD
                                                        &resourceViewDesc,
                                                        &textureData->mainTextureResourceViewU);
         if (FAILED(result)) {
-            return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateShaderResourceView"), result);
+            return WIN_SetErrorFromHRESULT("ID3D11Device1::CreateShaderResourceView", result);
         }
         result = ID3D11Device_CreateShaderResourceView(rendererData->d3dDevice,
                                                        (ID3D11Resource *)textureData->mainTextureV,
                                                        &resourceViewDesc,
                                                        &textureData->mainTextureResourceViewV);
         if (FAILED(result)) {
-            return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateShaderResourceView"), result);
+            return WIN_SetErrorFromHRESULT("ID3D11Device1::CreateShaderResourceView", result);
         }
     }
 
@@ -1381,7 +1375,7 @@ static bool D3D11_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SD
                                                        &nvResourceViewDesc,
                                                        &textureData->mainTextureResourceViewNV);
         if (FAILED(result)) {
-            return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateShaderResourceView"), result);
+            return WIN_SetErrorFromHRESULT("ID3D11Device1::CreateShaderResourceView", result);
         }
     }
 #endif // SDL_HAVE_YUV
@@ -1398,7 +1392,7 @@ static bool D3D11_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SD
                                                      &renderTargetViewDesc,
                                                      &textureData->mainTextureRenderTargetView);
         if (FAILED(result)) {
-            return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateRenderTargetView"), result);
+            return WIN_SetErrorFromHRESULT("ID3D11Device1::CreateRenderTargetView", result);
         }
     }
 
@@ -1459,7 +1453,7 @@ static bool D3D11_UpdateTextureInternal(D3D11_RenderData *rendererData, ID3D11Te
                                           NULL,
                                           &stagingTexture);
     if (FAILED(result)) {
-        return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateTexture2D [create staging texture]"), result);
+        return WIN_SetErrorFromHRESULT("ID3D11Device1::CreateTexture2D [create staging texture]", result);
     }
 
     // Get a write-only pointer to data in the staging texture:
@@ -1471,7 +1465,7 @@ static bool D3D11_UpdateTextureInternal(D3D11_RenderData *rendererData, ID3D11Te
                                      &textureMemory);
     if (FAILED(result)) {
         SAFE_RELEASE(stagingTexture);
-        return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11DeviceContext1::Map [map staging texture]"), result);
+        return WIN_SetErrorFromHRESULT("ID3D11DeviceContext1::Map [map staging texture]", result);
     }
 
     src = (const Uint8 *)pixels;
@@ -1656,7 +1650,7 @@ static bool D3D11_UpdateTextureNV(SDL_Renderer *renderer, SDL_Texture *texture,
                                           NULL,
                                           &stagingTexture);
     if (FAILED(result)) {
-        return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateTexture2D [create staging texture]"), result);
+        return WIN_SetErrorFromHRESULT("ID3D11Device1::CreateTexture2D [create staging texture]", result);
     }
 
     // Get a write-only pointer to data in the staging texture:
@@ -1668,7 +1662,7 @@ static bool D3D11_UpdateTextureNV(SDL_Renderer *renderer, SDL_Texture *texture,
                                      &textureMemory);
     if (FAILED(result)) {
         SAFE_RELEASE(stagingTexture);
-        return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11DeviceContext1::Map [map staging texture]"), result);
+        return WIN_SetErrorFromHRESULT("ID3D11DeviceContext1::Map [map staging texture]", result);
     }
 
     src = Yplane;
@@ -1781,7 +1775,7 @@ static bool D3D11_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                                           NULL,
                                           &textureData->stagingTexture);
     if (FAILED(result)) {
-        return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateTexture2D [create staging texture]"), result);
+        return WIN_SetErrorFromHRESULT("ID3D11Device1::CreateTexture2D [create staging texture]", result);
     }
 
     // Get a write-only pointer to data in the staging texture:
@@ -1793,7 +1787,7 @@ static bool D3D11_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                                      &textureMemory);
     if (FAILED(result)) {
         SAFE_RELEASE(textureData->stagingTexture);
-        return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11DeviceContext1::Map [map staging texture]"), result);
+        return WIN_SetErrorFromHRESULT("ID3D11DeviceContext1::Map [map staging texture]", result);
     }
 
     /* Make note of where the staging texture will be written to
@@ -1980,7 +1974,7 @@ static bool D3D11_UpdateVertexBuffer(SDL_Renderer *renderer,
                                          0,
                                          &mappedResource);
         if (FAILED(result)) {
-            return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11DeviceContext1::Map [vertex buffer]"), result);
+            return WIN_SetErrorFromHRESULT("ID3D11DeviceContext1::Map [vertex buffer]", result);
         }
         SDL_memcpy(mappedResource.pData, vertexData, dataSizeInBytes);
         ID3D11DeviceContext_Unmap(rendererData->d3dContext, (ID3D11Resource *)rendererData->vertexBuffers[vbidx], 0);
@@ -2006,7 +2000,7 @@ static bool D3D11_UpdateVertexBuffer(SDL_Renderer *renderer,
                                            &vertexBufferData,
                                            &rendererData->vertexBuffers[vbidx]);
         if (FAILED(result)) {
-            return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateBuffer [vertex buffer]"), result);
+            return WIN_SetErrorFromHRESULT("ID3D11Device1::CreateBuffer [vertex buffer]", result);
         }
 
         rendererData->vertexBufferSizes[vbidx] = dataSizeInBytes;
@@ -2350,7 +2344,7 @@ static bool D3D11_SetDrawState(SDL_Renderer *renderer, const SDL_RenderCommand *
 
         HRESULT result = ID3D11Device_CreateBuffer(rendererData->d3dDevice, &desc, &data, &shader_state->constants);
         if (FAILED(result)) {
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device::CreateBuffer [create shader constants]"), result);
+            WIN_SetErrorFromHRESULT("ID3D11Device::CreateBuffer [create shader constants]", result);
             return false;
         }
         SDL_memcpy(&shader_state->shader_constants, shader_constants, sizeof(*shader_constants));
@@ -2769,7 +2763,7 @@ static SDL_Surface *D3D11_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rec
                                           NULL,
                                           &stagingTexture);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateTexture2D [create staging texture]"), result);
+        WIN_SetErrorFromHRESULT("ID3D11Device1::CreateTexture2D [create staging texture]", result);
         goto done;
     }
 
@@ -2801,7 +2795,7 @@ static SDL_Surface *D3D11_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rec
                                      0,
                                      &textureMemory);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11DeviceContext1::Map [map staging texture]"), result);
+        WIN_SetErrorFromHRESULT("ID3D11DeviceContext1::Map [map staging texture]", result);
         goto done;
     }
 
@@ -2856,9 +2850,9 @@ static bool D3D11_RenderPresent(SDL_Renderer *renderer)
         } else if (result == DXGI_ERROR_INVALID_CALL) {
             // We probably went through a fullscreen <-> windowed transition
             D3D11_CreateWindowSizeDependentResources(renderer);
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGISwapChain::Present"), result);
+            WIN_SetErrorFromHRESULT("IDXGISwapChain::Present", result);
         } else {
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGISwapChain::Present"), result);
+            WIN_SetErrorFromHRESULT("IDXGISwapChain::Present", result);
         }
         return false;
     }

--- a/src/render/direct3d11/SDL_shaders_d3d11.c
+++ b/src/render/direct3d11/SDL_shaders_d3d11.c
@@ -28,8 +28,6 @@
 
 #include "SDL_shaders_d3d11.h"
 
-#define SDL_COMPOSE_ERROR(str) SDL_STRINGIFY_ARG(SDL_FUNCTION) ", " str
-
 #if SDL_WINAPI_FAMILY_PHONE
 #error Need to build shaders with level_9_3
 #endif
@@ -82,7 +80,7 @@ bool D3D11_CreateVertexShader(ID3D11Device1 *d3dDevice, ID3D11VertexShader **ver
                                              NULL,
                                              vertexShader);
     if (FAILED(result)) {
-        return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateVertexShader"), result);
+        return WIN_SetErrorFromHRESULT("ID3D11Device1::CreateVertexShader", result);
     }
 
     // Create an input layout for SDL's vertex shader:
@@ -93,7 +91,7 @@ bool D3D11_CreateVertexShader(ID3D11Device1 *d3dDevice, ID3D11VertexShader **ver
                                             sizeof(D3D11_VertexShader),
                                             inputLayout);
     if (FAILED(result)) {
-        return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreateInputLayout"), result);
+        return WIN_SetErrorFromHRESULT("ID3D11Device1::CreateInputLayout", result);
     }
     return true;
 }
@@ -108,7 +106,7 @@ bool D3D11_CreatePixelShader(ID3D11Device1 *d3dDevice, D3D11_Shader shader, ID3D
                                             NULL,
                                             pixelShader);
     if (FAILED(result)) {
-        return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D11Device1::CreatePixelShader"), result);
+        return WIN_SetErrorFromHRESULT("ID3D11Device1::CreatePixelShader", result);
     }
     return true;
 }

--- a/src/render/direct3d12/SDL_render_d3d12.c
+++ b/src/render/direct3d12/SDL_render_d3d12.c
@@ -39,12 +39,6 @@
 
 #include "SDL_shaders_d3d12.h"
 
-#if defined(_MSC_VER) && !defined(__clang__)
-#define SDL_COMPOSE_ERROR(str) SDL_FUNCTION ", " str
-#else
-#define SDL_COMPOSE_ERROR(str) SDL_STRINGIFY_ARG(SDL_FUNCTION) ", " str
-#endif
-
 // Set up for C function definitions, even when using C++
 #ifdef __cplusplus
 extern "C" {
@@ -556,7 +550,7 @@ static HRESULT D3D12_IssueBatch(D3D12_RenderData *data)
     // Issue the command list
     result = ID3D12GraphicsCommandList2_Close(data->commandList);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("D3D12_IssueBatch"), result);
+        WIN_SetErrorFromHRESULT("D3D12_IssueBatch", result);
         return result;
     }
     ID3D12CommandQueue_ExecuteCommandLists(data->commandQueue, 1, (ID3D12CommandList *const *)&data->commandList);
@@ -695,7 +689,7 @@ static D3D12_PipelineState *D3D12_CreatePipelineState(SDL_Renderer *renderer,
                       D3D_GUID(SDL_IID_ID3D12PipelineState),
                       (void **)&pipelineState);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device::CreateGraphicsPipelineState"), result);
+        WIN_SetErrorFromHRESULT("ID3D12Device::CreateGraphicsPipelineState", result);
         return NULL;
     }
 
@@ -752,7 +746,7 @@ static HRESULT D3D12_CreateVertexBuffer(D3D12_RenderData *data, size_t vbidx, si
                       (void **)&data->vertexBuffers[vbidx].resource);
 
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device::CreatePlacedResource [vertex buffer]"), result);
+        WIN_SetErrorFromHRESULT("ID3D12Device::CreatePlacedResource [vertex buffer]", result);
         return result;
     }
 
@@ -865,13 +859,13 @@ static HRESULT D3D12_CreateDeviceResources(SDL_Renderer *renderer)
 
         result = DXGIGetDebugInterfaceFunc(0, D3D_GUID(SDL_IID_IDXGIDebug1), (void **)&data->dxgiDebug);
         if (FAILED(result)) {
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("DXGIGetDebugInterface1"), result);
+            WIN_SetErrorFromHRESULT("DXGIGetDebugInterface1", result);
             goto done;
         }
 
         result = DXGIGetDebugInterfaceFunc(0, D3D_GUID(SDL_IID_IDXGIInfoQueue), (void **)&dxgiInfoQueue);
         if (FAILED(result)) {
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("DXGIGetDebugInterface1"), result);
+            WIN_SetErrorFromHRESULT("DXGIGetDebugInterface1", result);
             goto done;
         }
 
@@ -884,7 +878,7 @@ static HRESULT D3D12_CreateDeviceResources(SDL_Renderer *renderer)
 
     result = pCreateDXGIFactory2(creationFlags, D3D_GUID(SDL_IID_IDXGIFactory6), (void **)&data->dxgiFactory);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("CreateDXGIFactory"), result);
+        WIN_SetErrorFromHRESULT("CreateDXGIFactory", result);
         goto done;
     }
 
@@ -895,7 +889,7 @@ static HRESULT D3D12_CreateDeviceResources(SDL_Renderer *renderer)
                       D3D_GUID(SDL_IID_IDXGIAdapter4),
                       (void **)&data->dxgiAdapter);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGIFactory6::EnumAdapterByGPUPreference"), result);
+        WIN_SetErrorFromHRESULT("IDXGIFactory6::EnumAdapterByGPUPreference", result);
         goto done;
     }
 
@@ -904,7 +898,7 @@ static HRESULT D3D12_CreateDeviceResources(SDL_Renderer *renderer)
                                    D3D_GUID(SDL_IID_ID3D12Device1),
                                    (void **)&d3dDevice);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("D3D12CreateDevice"), result);
+        WIN_SetErrorFromHRESULT("D3D12CreateDevice", result);
         goto done;
     }
 
@@ -916,7 +910,7 @@ static HRESULT D3D12_CreateDeviceResources(SDL_Renderer *renderer)
 
         result = ID3D12Device1_QueryInterface(d3dDevice, D3D_GUID(SDL_IID_ID3D12InfoQueue), (void **)&infoQueue);
         if (FAILED(result)) {
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device to ID3D12InfoQueue"), result);
+            WIN_SetErrorFromHRESULT("ID3D12Device to ID3D12InfoQueue", result);
             goto done;
         }
 
@@ -934,7 +928,7 @@ static HRESULT D3D12_CreateDeviceResources(SDL_Renderer *renderer)
 
     result = ID3D12Device_QueryInterface(d3dDevice, D3D_GUID(SDL_IID_ID3D12Device1), (void **)&data->d3dDevice);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device to ID3D12Device1"), result);
+        WIN_SetErrorFromHRESULT("ID3D12Device to ID3D12Device1", result);
         goto done;
     }
 
@@ -948,7 +942,7 @@ static HRESULT D3D12_CreateDeviceResources(SDL_Renderer *renderer)
                       D3D_GUID(SDL_IID_ID3D12CommandQueue),
                       (void **)&data->commandQueue);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device::CreateCommandQueue"), result);
+        WIN_SetErrorFromHRESULT("ID3D12Device::CreateCommandQueue", result);
         goto done;
     }
 
@@ -961,7 +955,7 @@ static HRESULT D3D12_CreateDeviceResources(SDL_Renderer *renderer)
                       D3D_GUID(SDL_IID_ID3D12DescriptorHeap),
                       (void **)&data->rtvDescriptorHeap);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device::CreateDescriptorHeap [rtv]"), result);
+        WIN_SetErrorFromHRESULT("ID3D12Device::CreateDescriptorHeap [rtv]", result);
         goto done;
     }
     data->rtvDescriptorSize = ID3D12Device1_GetDescriptorHandleIncrementSize(d3dDevice, D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
@@ -972,7 +966,7 @@ static HRESULT D3D12_CreateDeviceResources(SDL_Renderer *renderer)
                       D3D_GUID(SDL_IID_ID3D12DescriptorHeap),
                       (void **)&data->textureRTVDescriptorHeap);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device::CreateDescriptorHeap [texture rtv]"), result);
+        WIN_SetErrorFromHRESULT("ID3D12Device::CreateDescriptorHeap [texture rtv]", result);
         goto done;
     }
 
@@ -985,7 +979,7 @@ static HRESULT D3D12_CreateDeviceResources(SDL_Renderer *renderer)
                       D3D_GUID(SDL_IID_ID3D12DescriptorHeap),
                       (void **)&data->srvDescriptorHeap);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device::CreateDescriptorHeap  [srv]"), result);
+        WIN_SetErrorFromHRESULT("ID3D12Device::CreateDescriptorHeap  [srv]", result);
         goto done;
     }
     rootDescriptorHeaps[0] = data->srvDescriptorHeap;
@@ -1000,7 +994,7 @@ static HRESULT D3D12_CreateDeviceResources(SDL_Renderer *renderer)
                       D3D_GUID(SDL_IID_ID3D12DescriptorHeap),
                       (void **)&data->samplerDescriptorHeap);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device::CreateDescriptorHeap  [sampler]"), result);
+        WIN_SetErrorFromHRESULT("ID3D12Device::CreateDescriptorHeap  [sampler]", result);
         goto done;
     }
     rootDescriptorHeaps[1] = data->samplerDescriptorHeap;
@@ -1013,7 +1007,7 @@ static HRESULT D3D12_CreateDeviceResources(SDL_Renderer *renderer)
                           D3D_GUID(SDL_IID_ID3D12CommandAllocator),
                           (void **)&data->commandAllocators[i]);
         if (FAILED(result)) {
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device::CreateCommandAllocator"), result);
+            WIN_SetErrorFromHRESULT("ID3D12Device::CreateCommandAllocator", result);
             goto done;
         }
     }
@@ -1027,7 +1021,7 @@ static HRESULT D3D12_CreateDeviceResources(SDL_Renderer *renderer)
                       D3D_GUID(SDL_IID_ID3D12GraphicsCommandList2),
                       (void **)&data->commandList);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device::CreateCommandList"), result);
+        WIN_SetErrorFromHRESULT("ID3D12Device::CreateCommandList", result);
         goto done;
     }
 
@@ -1041,7 +1035,7 @@ static HRESULT D3D12_CreateDeviceResources(SDL_Renderer *renderer)
                       D3D_GUID(SDL_IID_ID3D12Fence),
                       (void **)&data->fence);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device::CreateFence"), result);
+        WIN_SetErrorFromHRESULT("ID3D12Device::CreateFence", result);
         goto done;
     }
 
@@ -1049,7 +1043,7 @@ static HRESULT D3D12_CreateDeviceResources(SDL_Renderer *renderer)
 
     data->fenceEvent = pCreateEventExW(NULL, NULL, 0, EVENT_MODIFY_STATE | SYNCHRONIZE);
     if (!data->fenceEvent) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("CreateEventEx"), result);
+        WIN_SetErrorFromHRESULT("CreateEventEx", result);
         goto done;
     }
 
@@ -1064,7 +1058,7 @@ static HRESULT D3D12_CreateDeviceResources(SDL_Renderer *renderer)
                           D3D_GUID(SDL_IID_ID3D12RootSignature),
                           (void **)&data->rootSignatures[i]);
         if (FAILED(result)) {
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device::CreateRootSignature"), result);
+            WIN_SetErrorFromHRESULT("ID3D12Device::CreateRootSignature", result);
             goto done;
         }
     }
@@ -1248,7 +1242,7 @@ static HRESULT D3D12_CreateSwapChain(SDL_Renderer *renderer, int w, int h)
                       NULL, // Allow on all displays.
                       &swapChain);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGIFactory2::CreateSwapChainForHwnd"), result);
+        WIN_SetErrorFromHRESULT("IDXGIFactory2::CreateSwapChainForHwnd", result);
         goto done;
     }
 
@@ -1256,7 +1250,7 @@ static HRESULT D3D12_CreateSwapChain(SDL_Renderer *renderer, int w, int h)
 
     result = IDXGISwapChain1_QueryInterface(swapChain, D3D_GUID(SDL_IID_IDXGISwapChain4), (void **)&data->swapChain);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGISwapChain1::QueryInterface"), result);
+        WIN_SetErrorFromHRESULT("IDXGISwapChain1::QueryInterface", result);
         goto done;
     }
 
@@ -1265,7 +1259,7 @@ static HRESULT D3D12_CreateSwapChain(SDL_Renderer *renderer, int w, int h)
      */
     result = IDXGISwapChain4_SetMaximumFrameLatency(data->swapChain, 1);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGISwapChain4::SetMaximumFrameLatency"), result);
+        WIN_SetErrorFromHRESULT("IDXGISwapChain4::SetMaximumFrameLatency", result);
         goto done;
     }
 
@@ -1290,7 +1284,7 @@ static HRESULT D3D12_CreateSwapChain(SDL_Renderer *renderer, int w, int h)
         (colorspace_support & DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG_PRESENT)) {
         result = IDXGISwapChain3_SetColorSpace1(data->swapChain, colorspace);
         if (FAILED(result)) {
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGISwapChain3::SetColorSpace1"), result);
+            WIN_SetErrorFromHRESULT("IDXGISwapChain3::SetColorSpace1", result);
             goto done;
         }
     } else {
@@ -1346,7 +1340,7 @@ static HRESULT D3D12_CreateWindowSizeDependentResources(SDL_Renderer *renderer)
                           DXGI_FORMAT_UNKNOWN,
                           data->swapFlags);
         if (FAILED(result)) {
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGISwapChain::ResizeBuffers"), result);
+            WIN_SetErrorFromHRESULT("IDXGISwapChain::ResizeBuffers", result);
             goto done;
         }
     } else {
@@ -1361,7 +1355,7 @@ static HRESULT D3D12_CreateWindowSizeDependentResources(SDL_Renderer *renderer)
         if (data->swapEffect == DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL) {
             result = IDXGISwapChain4_SetRotation(data->swapChain, data->rotation); // NOLINT(clang-analyzer-core.NullDereference)
             if (FAILED(result)) {
-                WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGISwapChain4::SetRotation"), result);
+                WIN_SetErrorFromHRESULT("IDXGISwapChain4::SetRotation", result);
                 goto done;
             }
         }
@@ -1373,7 +1367,7 @@ static HRESULT D3D12_CreateWindowSizeDependentResources(SDL_Renderer *renderer)
 #if defined(SDL_PLATFORM_XBOXONE) || defined(SDL_PLATFORM_XBOXSERIES)
         result = D3D12_XBOX_CreateBackBufferTarget(data->d3dDevice, renderer->window->w, renderer->window->h, (void **)&data->renderTargets[i]);
         if (FAILED(result)) {
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("D3D12_XBOX_CreateBackBufferTarget"), result);
+            WIN_SetErrorFromHRESULT("D3D12_XBOX_CreateBackBufferTarget", result);
             goto done;
         }
 #else
@@ -1382,7 +1376,7 @@ static HRESULT D3D12_CreateWindowSizeDependentResources(SDL_Renderer *renderer)
                           D3D_GUID(SDL_IID_ID3D12Resource),
                           (void **)&data->renderTargets[i]);
         if (FAILED(result)) {
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGISwapChain4::GetBuffer"), result);
+            WIN_SetErrorFromHRESULT("IDXGISwapChain4::GetBuffer", result);
             goto done;
         }
 #endif
@@ -1561,7 +1555,7 @@ static bool D3D12_CreatePalette(SDL_Renderer *renderer, SDL_TexturePalette *pale
                       D3D_GUID(SDL_IID_ID3D12Resource),
                       (void **)&palettedata->texture);
     if (FAILED(result)) {
-        return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device::CreateCommittedResource [texture]"), result);
+        return WIN_SetErrorFromHRESULT("ID3D12Device::CreateCommittedResource [texture]", result);
     }
     palettedata->resourceState = D3D12_RESOURCE_STATE_COPY_DEST;
 
@@ -1672,7 +1666,7 @@ static bool D3D12_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SD
                           D3D_GUID(SDL_IID_ID3D12Resource),
                           (void **)&textureData->mainTexture);
         if (FAILED(result)) {
-            return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device::CreateCommittedResource [texture]"), result);
+            return WIN_SetErrorFromHRESULT("ID3D12Device::CreateCommittedResource [texture]", result);
         }
     }
     textureData->mainResourceState = D3D12_RESOURCE_STATE_COPY_DEST;
@@ -1699,7 +1693,7 @@ static bool D3D12_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SD
                               D3D_GUID(SDL_IID_ID3D12Resource),
                               (void **)&textureData->mainTextureU);
             if (FAILED(result)) {
-                return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device::CreateCommittedResource [texture]"), result);
+                return WIN_SetErrorFromHRESULT("ID3D12Device::CreateCommittedResource [texture]", result);
             }
         }
         textureData->mainResourceStateU = D3D12_RESOURCE_STATE_COPY_DEST;
@@ -1718,7 +1712,7 @@ static bool D3D12_CreateTexture(SDL_Renderer *renderer, SDL_Texture *texture, SD
                               D3D_GUID(SDL_IID_ID3D12Resource),
                               (void **)&textureData->mainTextureV);
             if (FAILED(result)) {
-                return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device::CreateCommittedResource [texture]"), result);
+                return WIN_SetErrorFromHRESULT("ID3D12Device::CreateCommittedResource [texture]", result);
             }
         }
         textureData->mainResourceStateV = D3D12_RESOURCE_STATE_COPY_DEST;
@@ -1924,7 +1918,7 @@ static bool D3D12_UpdateTextureInternal(D3D12_RenderData *rendererData, ID3D12Re
                       D3D_GUID(SDL_IID_ID3D12Resource),
                       (void **)&rendererData->uploadBuffers[rendererData->currentUploadBuffer]);
     if (FAILED(result)) {
-        return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device::CreateCommittedResource [create upload buffer]"), result);
+        return WIN_SetErrorFromHRESULT("ID3D12Device::CreateCommittedResource [create upload buffer]", result);
     }
 
     // Get a write-only pointer to data in the upload buffer:
@@ -1935,7 +1929,7 @@ static bool D3D12_UpdateTextureInternal(D3D12_RenderData *rendererData, ID3D12Re
                       (void **)&textureMemory);
     if (FAILED(result)) {
         D3D_SAFE_RELEASE(rendererData->uploadBuffers[rendererData->currentUploadBuffer]);
-        return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Resource::Map [map staging texture]"), result);
+        return WIN_SetErrorFromHRESULT("ID3D12Resource::Map [map staging texture]", result);
     }
 
     src = (const Uint8 *)pixels;
@@ -2185,7 +2179,7 @@ static bool D3D12_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                       D3D_GUID(SDL_IID_ID3D12Resource),
                       (void **)&textureData->stagingBuffer);
     if (FAILED(result)) {
-        return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device::CreateCommittedResource [create upload buffer]"), result);
+        return WIN_SetErrorFromHRESULT("ID3D12Device::CreateCommittedResource [create upload buffer]", result);
     }
 
     // Get a write-only pointer to data in the upload buffer:
@@ -2195,7 +2189,7 @@ static bool D3D12_LockTexture(SDL_Renderer *renderer, SDL_Texture *texture,
                       (void **)&textureMemory);
     if (FAILED(result)) {
         D3D_SAFE_RELEASE(rendererData->uploadBuffers[rendererData->currentUploadBuffer]);
-        return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Resource::Map [map staging texture]"), result);
+        return WIN_SetErrorFromHRESULT("ID3D12Resource::Map [map staging texture]", result);
     }
 
     SDL_zero(pitchedDesc);
@@ -2456,7 +2450,7 @@ static bool D3D12_UpdateVertexBuffer(SDL_Renderer *renderer,
     vertexBuffer = rendererData->vertexBuffers[vbidx].resource;
     result = ID3D12Resource_Map(vertexBuffer, 0, &range, (void **)&vertexBufferData);
     if (FAILED(result)) {
-        return WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Resource::Map [vertex buffer]"), result);
+        return WIN_SetErrorFromHRESULT("ID3D12Resource::Map [vertex buffer]", result);
     }
     SDL_memcpy(vertexBufferData, vertexData, dataSizeInBytes);
     ID3D12Resource_Unmap(vertexBuffer, 0, NULL);
@@ -3272,7 +3266,7 @@ static SDL_Surface *D3D12_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rec
                       D3D_GUID(SDL_IID_ID3D12Resource),
                       (void **)&readbackBuffer);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Device::CreateTexture2D [create staging texture]"), result);
+        WIN_SetErrorFromHRESULT("ID3D12Device::CreateTexture2D [create staging texture]", result);
         goto done;
     }
 
@@ -3332,7 +3326,7 @@ static SDL_Surface *D3D12_RenderReadPixels(SDL_Renderer *renderer, const SDL_Rec
                       NULL,
                       (void **)&textureMemory);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("ID3D12Resource::Map [map staging texture]"), result);
+        WIN_SetErrorFromHRESULT("ID3D12Resource::Map [map staging texture]", result);
         goto done;
     }
 
@@ -3392,9 +3386,9 @@ static bool D3D12_RenderPresent(SDL_Renderer *renderer)
         } else if (result == DXGI_ERROR_INVALID_CALL) {
             // We probably went through a fullscreen <-> windowed transition
             D3D12_CreateWindowSizeDependentResources(renderer);
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGISwapChain::Present"), result);
+            WIN_SetErrorFromHRESULT("IDXGISwapChain::Present", result);
         } else {
-            WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("IDXGISwapChain::Present"), result);
+            WIN_SetErrorFromHRESULT("IDXGISwapChain::Present", result);
         }
         return false;
     } else {

--- a/src/render/direct3d12/SDL_render_d3d12_xbox.cpp
+++ b/src/render/direct3d12/SDL_render_d3d12_xbox.cpp
@@ -25,12 +25,6 @@
 #include "../../core/windows/SDL_windows.h"
 #include <XGameRuntime.h>
 
-#if defined(_MSC_VER) && !defined(__clang__)
-#define SDL_COMPOSE_ERROR(str) SDL_FUNCTION ", " str
-#else
-#define SDL_COMPOSE_ERROR(str) SDL_STRINGIFY_ARG(SDL_FUNCTION) ", " str
-#endif
-
 static const GUID SDL_IID_ID3D12Device1 = { 0x77acce80, 0x638e, 0x4e65, { 0x88, 0x95, 0xc1, 0xf2, 0x33, 0x86, 0x86, 0x3e } };
 static const GUID SDL_IID_ID3D12Resource = { 0x696442be, 0xa72e, 0x4059, { 0xbc, 0x79, 0x5b, 0x5c, 0x98, 0x04, 0x0f, 0xad } };
 static const GUID SDL_IID_IDXGIDevice1 = { 0x77db970f, 0x6276, 0x48ba, { 0xba, 0x28, 0x07, 0x01, 0x43, 0xb4, 0x39, 0x2c } };
@@ -53,38 +47,38 @@ HRESULT D3D12_XBOX_CreateDevice(ID3D12Device **device, bool createDebug)
 
     result = D3D12XboxCreateDevice(NULL, &params, SDL_IID_ID3D12Device1, (void **) device);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("[xbox] D3D12XboxCreateDevice"), result);
+        WIN_SetErrorFromHRESULT("D3D12XboxCreateDevice", result);
         goto done;
     }
 
     result = (*device)->QueryInterface(SDL_IID_IDXGIDevice1, (void **) &dxgiDevice);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("[xbox] ID3D12Device to IDXGIDevice1"), result);
+        WIN_SetErrorFromHRESULT("ID3D12Device to IDXGIDevice1", result);
         goto done;
     }
 
     result = dxgiDevice->GetAdapter(&dxgiAdapter);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("[xbox] dxgiDevice->GetAdapter"), result);
+        WIN_SetErrorFromHRESULT("dxgiDevice->GetAdapter", result);
         goto done;
     }
 
     result = dxgiAdapter->EnumOutputs(0, &dxgiOutput);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("[xbox] dxgiAdapter->EnumOutputs"), result);
+        WIN_SetErrorFromHRESULT("dxgiAdapter->EnumOutputs", result);
         goto done;
     }
 
     // Set frame interval
     result = (*device)->SetFrameIntervalX(dxgiOutput, D3D12XBOX_FRAME_INTERVAL_60_HZ, 1, D3D12XBOX_FRAME_INTERVAL_FLAG_NONE);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("[xbox] SetFrameIntervalX"), result);
+        WIN_SetErrorFromHRESULT("SetFrameIntervalX", result);
         goto done;
     }
 
     result = (*device)->ScheduleFrameEventX(D3D12XBOX_FRAME_EVENT_ORIGIN, 0, NULL, D3D12XBOX_SCHEDULE_FRAME_EVENT_FLAG_NONE);
     if (FAILED(result)) {
-        WIN_SetErrorFromHRESULT(SDL_COMPOSE_ERROR("[xbox] ScheduleFrameEventX"), result);
+        WIN_SetErrorFromHRESULT("ScheduleFrameEventX", result);
         goto done;
     }
 

--- a/src/render/direct3d12/SDL_shaders_d3d12.c
+++ b/src/render/direct3d12/SDL_shaders_d3d12.c
@@ -27,8 +27,6 @@
 
 #include "SDL_shaders_d3d12.h"
 
-#define SDL_COMPOSE_ERROR(str) SDL_STRINGIFY_ARG(SDL_FUNCTION) ", " str
-
 // The shaders here were compiled with compile_shaders.bat
 
 #define g_main D3D12_PixelShader_Colors

--- a/src/render/direct3d12/SDL_shaders_d3d12_xboxone.cpp
+++ b/src/render/direct3d12/SDL_shaders_d3d12_xboxone.cpp
@@ -29,8 +29,6 @@
 
 #include "SDL_shaders_d3d12.h"
 
-#define SDL_COMPOSE_ERROR(str) SDL_STRINGIFY_ARG(SDL_FUNCTION) ", " str
-
 // Shader blob headers are generated with a pre-build step using compile_shaders_xbox.bat
 
 #define g_main D3D12_PixelShader_Colors

--- a/src/render/direct3d12/SDL_shaders_d3d12_xboxseries.cpp
+++ b/src/render/direct3d12/SDL_shaders_d3d12_xboxseries.cpp
@@ -29,8 +29,6 @@
 
 #include "SDL_shaders_d3d12.h"
 
-#define SDL_COMPOSE_ERROR(str) SDL_STRINGIFY_ARG(SDL_FUNCTION) ", " str
-
 
 // Shader blob headers are generated with a pre-build step using compile_shaders_xbox.bat
 


### PR DESCRIPTION
Removed obsolete documentation that shows this usage and macros that attempt it.

Also allow SDL_FUNCTION to be redefined by the application.

Fixes https://github.com/libsdl-org/SDL/issues/15004