### PR TITLE
Eliminate contention between HIDAPI controller reads and writes

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_rumble.c
+++ b/src/joystick/hidapi/SDL_hidapi_rumble.c
@@ -77,14 +77,12 @@ static int SDLCALL SDL_HIDAPI_RumbleThread(void *data)
         SDL_UnlockMutex(SDL_HIDAPI_rumble_lock);
 
         if (request) {
-            SDL_LockMutex(request->device->dev_lock);
             if (request->device->dev) {
 #ifdef DEBUG_RUMBLE
                 HIDAPI_DumpPacket("Rumble packet: size = %d", request->data, request->size);
 #endif
                 SDL_hid_write(request->device->dev, request->data, request->size);
             }
-            SDL_UnlockMutex(request->device->dev_lock);
             if (request->callback) {
                 request->callback(request->userdata);
             }

--- a/src/joystick/hidapi/SDL_hidapi_switch.c
+++ b/src/joystick/hidapi/SDL_hidapi_switch.c
@@ -2726,17 +2726,7 @@ static void HandleFullControllerState(SDL_Joystick *joystick, SDL_DriverSwitch_C
             Uint64 now = SDL_GetTicks();
 
             if (now >= (ctx->m_ulLastIMUReset + IMU_RESET_DELAY_MS)) {
-                SDL_HIDAPI_Device *device = ctx->device;
-
-                if (device->updating) {
-                    SDL_UnlockMutex(device->dev_lock);
-                }
-
                 SetIMUEnabled(ctx, true);
-
-                if (device->updating) {
-                    SDL_LockMutex(device->dev_lock);
-                }
                 ctx->m_ulLastIMUReset = now;
             }
 

--- a/src/joystick/hidapi/SDL_hidapijoystick_c.h
+++ b/src/joystick/hidapi/SDL_hidapijoystick_c.h
@@ -100,7 +100,6 @@ typedef struct SDL_HIDAPI_Device
 
     struct SDL_HIDAPI_DeviceDriver *driver;
     void *context;
-    SDL_Mutex *dev_lock;
     SDL_hid_device *dev;
     SDL_AtomicInt rumble_pending;
     int num_joysticks;
@@ -108,9 +107,6 @@ typedef struct SDL_HIDAPI_Device
 
     // Used during scanning for device changes
     bool seen;
-
-    // Used to flag that the device is being updated
-    bool updating;
 
     // Used to flag devices that failed open
     // This can happen on Windows with Bluetooth devices that have turned off


### PR DESCRIPTION
Rumble can often take a long time, and it is theoretically safe to simultaneously read and write hidapi devices on all platforms.

Fixes https://github.com/libsdl-org/SDL/issues/9441