### PR TITLE
Android: prevent concurrent access mJoystick

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLControllerManager.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLControllerManager.java
@@ -211,7 +211,7 @@ class SDLJoystickHandler {
     /**
      * Handles adding and removing of input devices.
      */
-    void pollInputDevices() {
+    synchronized void pollInputDevices() {
         int[] deviceIds = InputDevice.getDeviceIds();
 
         for (int device_id : deviceIds) {
@@ -307,7 +307,7 @@ class SDLJoystickHandler {
         }
     }
 
-    protected SDLJoystick getJoystick(int device_id) {
+    synchronized protected SDLJoystick getJoystick(int device_id) {
         for (SDLJoystick joystick : mJoysticks) {
             if (joystick.device_id == device_id) {
                 return joystick;
@@ -642,7 +642,7 @@ class SDLHapticHandler {
         }
     }
 
-    void pollHapticDevices() {
+    synchronized void pollHapticDevices() {
 
         final int deviceId_VIBRATOR_SERVICE = 999999;
         boolean hasVibratorService = false;
@@ -690,7 +690,7 @@ class SDLHapticHandler {
         }
     }
 
-    protected SDLHaptic getHaptic(int device_id) {
+    synchronized protected SDLHaptic getHaptic(int device_id) {
         for (SDLHaptic haptic : mHaptics) {
             if (haptic.device_id == device_id) {
                 return haptic;


### PR DESCRIPTION
On Android, this PR prevents SDLActivity and Main Thread to access mJoystick at the
same time.  And same for mHaptic, because of same design.


for instance: 

pollInputDevices() is called by the C Thread,
while SDLActivity triggers handleMotionEvent().

It can be easily tested that both functions can occur in the middle of one each other, by adding some appropriate Thread.sleep().
Since pollInputDevices(), can add/remove devices, it seems a good thing to get the function mutex-protected.

I've already seen some strange Crash with pollInputDevices(). Don't know if this may fix it.


```
backtrace:
  #00  pc 0x000000000006ec48  /apex/com.android.runtime/lib64/bionic/libc.so (abort+156)
  #01  pc 0x00000000008a0c74  /apex/com.android.art/lib64/libart.so (art::Runtime::Abort(char const*)+476)
  #02  pc 0x0000000000016188  /apex/com.android.art/lib64/libbase.so (android::base::SetAborter(std::__1::function<void (char const*)>&&)::$_0::__invoke(char const*)+80)
  #03  pc 0x0000000000015730  /apex/com.android.art/lib64/libbase.so (android::base::LogMessage::~LogMessage()+544)
  #04  pc 0x00000000002d7df8  /apex/com.android.art/lib64/libart.so (art::Thread::AssertNoPendingException() const+572)
  #05  pc 0x000000000046b01c  /apex/com.android.art/lib64/libart.so (art::gc::Heap::AllocateInternalWithGc(art::Thread*, art::gc::AllocatorType, bool, unsigned long, unsigned long*, unsigned long*, unsigned long*, art::ObjPtr<art::mirror::Class>*)+100)
  #06  pc 0x000000000046cc64  /apex/com.android.art/lib64/libart.so (artAllocArrayFromCodeResolvedTLAB+804)
  #07  pc 0x0000000000343a48  /apex/com.android.art/lib64/libart.so (art_quick_alloc_array_resolved32_tlab+120)
  #08  pc 0x00000000008c59e0  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.hardware.input.InputManagerGlobal.getInputDeviceIds+128)
  #09  pc 0x00000000000993d4  /data/app/~~tByko97uPgSP2PHNDJI3kQ==/..-VaNJhxgArdxWXY00uP4Trw==/oat/arm64/base.odex (org.libsdl.app.r.h+84)
  #10  pc 0x0000000000098cdc  /data/app/~~tByko97uPgSP2PHNDJI3kQ==/..-VaNJhxgArdxWXY00uP4Trw==/oat/arm64/base.odex (org.libsdl.app.SDLControllerManager.pollInputDevices+44)
  #11  pc 0x000000000032d460  /apex/com.android.art/lib64/libart.so (art_quick_invoke_static_stub+640)
  #12  pc 0x000000000032bfc8  /apex/com.android.art/lib64/libart.so (art::JValue art::InvokeWithVarArgs<_jmethodID*>(art::ScopedObjectAccessAlreadyRunnable const&, _jobject*, _jmethodID*, std::__va_list)+800)
  #13  pc 0x000000000064ce98  /apex/com.android.art/lib64/libart.so (art::JNI<false>::CallStaticVoidMethod(_JNIEnv*, _jclass*, _jmethodID*, ...)+224)
  #14  pc 0x0000000000405afc  /data/app/~~tByko97uPgSP2PHNDJI3kQ==/..-VaNJhxgArdxWXY00uP4Trw==/split_config.arm64_v8a.apk!libmain.so (SDL_UpdateJoysticks+16384) (BuildId: c89b0f569bf348d719767863fdaf85903de276f3)
  #15  pc 0x00000000003f5a98  /data/app/~~tByko97uPgSP2PHNDJI3kQ==/..-VaNJhxgArdxWXY00uP4Trw==/split_config.arm64_v8a.apk!libmain.so (SDL_PumpEventsInternal+16384) (BuildId: c89b0f569bf348d719767863fdaf85903de276f3)
  #16  pc 0x00000000003f5c00  /data/app/~~tByko97uPgSP2PHNDJI3kQ==/..-VaNJhxgArdxWXY00uP4Trw==/split_config.arm64_v8a.apk!libmain.so 

```

