### PR TITLE
Add ZUIKI EVOTOP controller support with gyroscope and accelerometer sensor capabilities.

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_zuiki.c
+++ b/src/joystick/hidapi/SDL_hidapi_zuiki.c
@@ -56,7 +56,7 @@ typedef struct
     MedianFilter_t filter_gyro_z;
 } SDL_DriverZUIKI_Context;
 
-float median_filter_update(MedianFilter_t* mf, float input) {
+static float median_filter_update(MedianFilter_t* mf, float input) {
     mf->buffer[mf->index] = input;
     mf->index = (mf->index + 1) % FILTER_SIZE;
     if (mf->count < FILTER_SIZE) mf->count++;

--- a/src/joystick/hidapi/SDL_hidapijoystick_c.h
+++ b/src/joystick/hidapi/SDL_hidapijoystick_c.h
@@ -174,7 +174,6 @@ extern SDL_HIDAPI_DeviceDriver SDL_HIDAPI_DriverGameSir;
 extern SDL_HIDAPI_DeviceDriver SDL_HIDAPI_DriverSInput;
 extern SDL_HIDAPI_DeviceDriver SDL_HIDAPI_DriverZUIKI;
 
-
 #define LOAD16(A, B)       (Sint16)((Uint16)(A) | (((Uint16)(B)) << 8))
 #define LOAD32(A, B, C, D) ((((Uint32)(A)) << 0) |  \
                             (((Uint32)(B)) << 8) |  \


### PR DESCRIPTION
## Description                                                                                                             
                                         
  Add ZUIKI EVOTOP controller support with gyroscope and accelerometer sensor capabilities.                                  
                                                            
  This PR extends the existing ZUIKI HIDAPI driver to support the EVOTOP controller across three connection modes, each with 
  its own product ID and sensor reporting rate:             

  | Mode | PID | Sensor Rate |
  |------|-----|-------------|
  | PC DINPUT (USB) | `0x001d` | 200 Hz |
  | UWB DINPUT | `0x001c` | 100 Hz |
  | PC Bluetooth | `0x0017` | 50 Hz |

  ### Changes

  - **EVOTOP controller support**: Added a new packet handler (`HIDAPI_DriverZUIKI_Handle_EVOTOP_PCBT_StatePacket`) for the
  PC Bluetooth mode, which uses a different data frame format (16-bit axis values, different button/hat mappings) from the
  existing DINPUT-based modes.
  - **Gyroscope and accelerometer sensors**: Report 3-axis gyroscope and 3-axis accelerometer data via
  `SDL_SendJoystickSensor` for all supported EVOTOP connection modes.
  - **Median filtering**: Apply an 11-sample median filter to gyroscope data to reduce sensor noise and improve stability.
  - **PC Bluetooth gyroscope detection**: In PC BT mode, the gyroscope availability is determined at initialization by
  inspecting the first data frame, since the controller can operate with or without gyroscope enabled.

  ## Existing Issue(s)

  Follow-up to #13770 (Support ZUIKI MasconPro), extending the driver with EVOTOP controller and sensor support.