### PR TITLE
Fix testime to pass window coordinates to SDL_SetTextInputArea()

### DIFF
--- a/test/testime.c
+++ b/test/testime.c
@@ -473,7 +473,8 @@ static WindowState *GetWindowStateForWindowID(SDL_WindowID windowID)
 static void InitInput(WindowState *ctx)
 {
     /* Prepare a rect for text input */
-    ctx->textRect.x = ctx->textRect.y = 100.0f;
+    ctx->textRect.x = 100.0f;
+	ctx->textRect.y = 250.0f;
     ctx->textRect.w = DEFAULT_WINDOW_WIDTH - 2 * ctx->textRect.x;
     ctx->textRect.h = 50.0f;
     ctx->markedRect = ctx->textRect;
@@ -659,12 +660,23 @@ static void DrawCandidates(WindowState *ctx, SDL_FRect *cursorRect)
 static void UpdateTextInputArea(WindowState *ctx, const SDL_FRect *cursorRect)
 {
     SDL_Rect rect;
-    int cursor_offset = (int)(cursorRect->x - ctx->textRect.x);
+    float x1, y1, x2, y2;
 
-    rect.x = (int)ctx->textRect.x;
-    rect.y = (int)ctx->textRect.y;
-    rect.w = (int)ctx->textRect.w;
-    rect.h = (int)ctx->textRect.h;
+    /* Convert render coordinates to window coordinates for SDL_SetTextInputArea */
+    SDL_RenderCoordinatesToWindow(ctx->renderer, ctx->textRect.x, ctx->textRect.y, &x1, &y1);
+    SDL_RenderCoordinatesToWindow(ctx->renderer, ctx->textRect.x + ctx->textRect.w, ctx->textRect.y + ctx->textRect.h, &x2, &y2);
+
+    rect.x = (int)x1;
+    rect.y = (int)y1;
+    rect.w = (int)(x2 - x1);
+    rect.h = (int)(y2 - y1);
+
+    /* cursor_offset also needs to be in window coordinates */
+    float cursor_x_render = cursorRect->x;
+    float cursor_x_window, dummy;
+    SDL_RenderCoordinatesToWindow(ctx->renderer, cursor_x_render, 0, &cursor_x_window, &dummy);
+    int cursor_offset = (int)(cursor_x_window - x1);
+
     SDL_SetTextInputArea(ctx->window, &rect, cursor_offset);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix testime to pass window coordinates to SDL_SetTextInputArea(). As testime used SDL_SetRenderLogicalPresentation() the panning of the on screen keyboard on Android didn't happen.

Also moved the area closer to the bottom so the panning of the screen keyboard can be observed on Android and iOS.
Other tests are not affected.
## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #13166