### PR TITLE
Adding SDL_HINT_IME_PAN_PADDING "SDL_IME_PAN_PADDING".

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -1389,14 +1389,18 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
          * method (soft keyboard)
          */
         static int getPanPadding() {
+            /* The hint is in window coordinates. Convert to pixels by
+             * multiplying by density. */
+            int defaultPadding = 10;
             try {
                 String hint = nativeGetHint("SDL_IME_PAN_PADDING");
                 if (hint != null) {
-                    return Integer.parseInt(hint);
+                    defaultPadding = Integer.parseInt(hint);
                 }
             } catch (NumberFormatException ignored) {
             }
-            return 15;
+            float density = getContext().getResources().getDisplayMetrics().density;
+            return (int)(defaultPadding * density);
         }
 
         public int input_type;

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -1227,8 +1227,10 @@ extern "C" {
  * to ensure there is extra breathing room between the text input area and
  * the top of the keyboard when panning the view.
  *
- * The variable can be set to a number representing the padding in pixels.
- * The default value is "15".
+ * The variable can be set to a number representing the padding in window
+ * coordinates.
+ * 
+ * The default value is "10".
  *
  * This hint can be set anytime.
  *

--- a/src/video/uikit/SDL_uikitviewcontroller.m
+++ b/src/video/uikit/SDL_uikitviewcontroller.m
@@ -642,12 +642,9 @@ static void SDLCALL SDL_HideHomeIndicatorHintChanged(void *userdata, const char 
 #endif
 
     if (self.keyboardHeight && self.textInputRect.h) {
-        /* Get the pan padding from the hint (in pixels). The text input rect
-         * and view bounds are in UIKit points, so divide by the scale factor
-         * to keep the visual gap consistent across platforms.*/
+        /// Get the pan padding from the hint (in window coordinates).
         const char *hint = SDL_GetHint(SDL_HINT_IME_PAN_PADDING);
-        int panPadding = (hint && *hint) ? SDL_atoi(hint) : 15;
-        int padding = (int)(panPadding / self.view.contentScaleFactor);
+        int padding = (hint && *hint) ? SDL_atoi(hint) : 10;
         int rectbottom = (int)(self.textInputRect.y + self.textInputRect.h + padding);
         int keybottom = (int)(self.view.bounds.size.height - self.keyboardHeight);
         if (keybottom < rectbottom) {


### PR DESCRIPTION
Controls the padding between TextInputArea and the on screen keyboard on iOS and Android (and defaults to 0).

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When the SDL_SetTextInputArea is obscured by the on screen keyboard on Android and iOS, the screen pans upward to have a clear view of the input area.
Previously a padding of 15 pixels between IME and input area was hardcoded on Android and it seems to me as if the iOS on screen keyboard applies a 15 pixels padding (or reports the keyboard to be 15 pixels taller than it really is).
In the Android code the default padding is set to 0 and on iOS the 15 pixels get subtracted to have a default 0 pixel padding.

When PR #15046 is applied, testime.c could need an `SDL_SetHint(SDL_HINT_IME_PAN_PADDING, "15");` around line 662.

Let me know if you want the hint to have another name.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
