### PR TITLE
win32: Fix composition UI being displayed when IME is disabled

### DIFF
--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -1072,6 +1072,14 @@ bool WIN_HandleIMEMessage(HWND hwnd, UINT msg, WPARAM wParam, LPARAM *lParam, SD
         *lParam &= element_mask;
 
         return false;
+    } else if (msg == WM_IME_STARTCOMPOSITION) {
+        SDL_DebugIMELog("WM_IME_STARTCOMPOSITION");
+        if (videodata->ime_internal_composition) {
+            // Windows may still display a composition dialog even with
+            // ISC_SHOWUICOMPOSITIONWINDOW cleared, so trap the message
+            // here to prevent that (even when the IME is disabled).
+            return true;
+        }
     }
 
     if (!videodata->ime_initialized || !videodata->ime_available || !videodata->ime_enabled) {
@@ -1098,12 +1106,6 @@ bool WIN_HandleIMEMessage(HWND hwnd, UINT msg, WPARAM wParam, LPARAM *lParam, SD
     case WM_INPUTLANGCHANGE:
         SDL_DebugIMELog("WM_INPUTLANGCHANGE");
         IME_InputLangChanged(videodata);
-        break;
-    case WM_IME_STARTCOMPOSITION:
-        SDL_DebugIMELog("WM_IME_STARTCOMPOSITION");
-        if (videodata->ime_internal_composition) {
-            trap = true;
-        }
         break;
     case WM_IME_COMPOSITION:
         SDL_DebugIMELog("WM_IME_COMPOSITION %x", lParam);


### PR DESCRIPTION
## Description
The Windows Pinyin IME doesn't respect clearing `ISC_SHOWUICOMPOSITIONWINDOW` when handling `WM_IME_SETCONTEXT` to indicate that we would like to suppress the composition window. Instead, we must trap `WM_IME_STARTCOMPOSITION` to avoid the composition window being displayed.

We currently only trap `WM_IME_STARTCOMPOSITION` when text input is enabled, but that causes the IME's composition window to appear when typing when text input is disabled. This PR moves that handling up next to `WM_IME_SETCONTEXT` to avoid the Pinyin composition window (seen below) appearing when text input is disabled.

<img width="178" height="157" alt="image" src="https://github.com/user-attachments/assets/5bcca803-e3ab-4cff-ac26-91cef72653e7" />

## Existing Issue(s)
Downstream bug report: https://github.com/moonlight-stream/moonlight-qt/pull/1617#issuecomment-3882943568
