### PR TITLE
undefine ADD_TRIANGLE macro definition

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -3904,6 +3904,8 @@ bool SDL_RenderLines(SDL_Renderer *renderer, const SDL_FPoint *points, int count
                     }
                 }
 
+#undef ADD_TRIANGLE
+
                 p = q;
                 cur_index += 4;
             }


### PR DESCRIPTION
ADD_TRIANGLE macro function in SDL_RenderLines() was never being undefined even after it's purpose was resolved.