### PR TITLE
n3ds: Fix audio cracking and slowdown on Old 3DS

### DIFF
--- a/src/thread/n3ds/SDL_systhread.c
+++ b/src/thread/n3ds/SDL_systhread.c
@@ -42,7 +42,6 @@ static void ThreadEntry(void *arg)
     threadExit(0);
 }
 
-
 bool SDL_SYS_CreateThread(SDL_Thread *thread,
                           SDL_FunctionPointer pfnBeginThread,
                           SDL_FunctionPointer pfnEndThread)
@@ -53,9 +52,13 @@ bool SDL_SYS_CreateThread(SDL_Thread *thread,
 
     svcGetThreadPriority(&priority, CUR_THREAD_HANDLE);
 
-    // prefer putting audio thread on system core
-    if (thread->name && (SDL_strncmp(thread->name, "SDLAudioP", 9) == 0) && R_SUCCEEDED(APT_SetAppCpuTimeLimit(30))) {
-        cpu = 1;
+    // on New 3DS, prefer putting audio thread on system core
+    if (thread->name && (SDL_strncmp(thread->name, "SDLAudioP", 9) == 0)) {
+        bool new3ds = false;
+        APT_CheckNew3DS(&new3ds);
+        if (new3ds && R_SUCCEEDED(APT_SetAppCpuTimeLimit(30))) {
+            cpu = 1;
+        }
     }
 
     thread->handle = threadCreate(ThreadEntry,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I've found that having the audio thread on the system core causes audio to crack and slowdown on older 3DS hardware. Putting the audio thread on the main core fixes the issue.

I decided to keep the functionality on New 3DS hardware as the system core there has more available resources, and I've personally had no issues with audio there.