### PR TITLE
win32: Set error for SDL_GL_GetSwapInterval()

### DIFF
--- a/src/video/windows/SDL_windowsopengl.c
+++ b/src/video/windows/SDL_windowsopengl.c
@@ -910,7 +910,7 @@ bool WIN_GL_GetSwapInterval(SDL_VideoDevice *_this, int *interval)
         *interval = _this->gl_data->wglGetSwapIntervalEXT();
         return true;
     } else {
-        return false;
+        return SDL_Unsupported();
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

SDL_GL_GetSwapInterval() is documented to set an error on failure.

SDL_GL_GetSwapInterval() returns false in a Windows XP VM with default OpenGL 1.1 driver. However SDL_GetError() returned an unrelated earlier error.

This pull request makes it use SDL_Unsupported() to set a generic error like in the function above for SDL_GL_SetSwapInterval().