### PR TITLE
video: Check video backend initialization when querying the grabbed w…

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -4055,7 +4055,7 @@ bool SDL_GetWindowMouseGrab(SDL_Window *window)
 
 SDL_Window *SDL_GetGrabbedWindow(void)
 {
-    if (_this->grabbed_window &&
+    if (_this && _this->grabbed_window &&
         (_this->grabbed_window->flags & (SDL_WINDOW_MOUSE_GRABBED | SDL_WINDOW_KEYBOARD_GRABBED)) != 0) {
         return _this->grabbed_window;
     } else {


### PR DESCRIPTION
…indow

SDL_GetGrabbedWindow() can be called when the video system is uninitialized, and, since there is no window parameter, _this must be checked for validity to avoid a segfault.

Fixes libsdl-org/sdl2-compat#578
