### PR TITLE
Fix D3D12 DSV creation for array/cube/cube-array depth textures

### DIFF
--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -3646,7 +3646,12 @@ static D3D12Texture *D3D12_INTERNAL_CreateTexture(
                 dsvDesc.Format = SDLToD3D12_DepthFormat[createinfo->format];
                 dsvDesc.Flags = (D3D12_DSV_FLAGS)0;
 
-                if (isMultisample) {
+                if (createinfo->type == SDL_GPU_TEXTURETYPE_2D_ARRAY || createinfo->type == SDL_GPU_TEXTURETYPE_CUBE || createinfo->type == SDL_GPU_TEXTURETYPE_CUBE_ARRAY) {
+                    dsvDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2DARRAY;
+                    dsvDesc.Texture2DArray.MipSlice = levelIndex;
+                    dsvDesc.Texture2DArray.FirstArraySlice = layerIndex;
+                    dsvDesc.Texture2DArray.ArraySize = 1;
+                } else if (isMultisample) {
                     dsvDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2DMS;
                 } else {
                     dsvDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
DSV creation was missing a TEXTURE2DARRAY branch for array, cube, and cube-array depth textures. It fell through to TEXTURE2D, so FirstArraySlice was never set and all layers' DSVs targeted layer 0. This caused incorrect rendering when using depth textures with multiple layers, such as cubemap shadow maps.

## Description
If we have a layered texture, we use `Texture2DArray` instead of `Texture2D` to create the layers.

## Existing Issue(s)
Fixes #15073 