### PR TITLE
Fix Wayland_DestroyWindow SEGFAULT

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -2292,7 +2292,7 @@ void Wayland_DestroyWindow(_THIS, SDL_Window *window)
     SDL_VideoData *data = _this->driverdata;
     SDL_WindowData *wind = window->driverdata;
 
-    if (data) {
+    if (data && wind) {
 #ifdef SDL_VIDEO_OPENGL_EGL
         if (wind->egl_surface) {
             SDL_EGL_DestroySurface(_this, wind->egl_surface);


### PR DESCRIPTION
Check if the wind pointer is NULL, to avoid SEGFAULT.

## Description
In some circumstances, the `wind` pointer can be NULL.

This happened for me while using LVGL (9.4.0) on Raspberry Pi 5.

Already implemented in SDL3, but not yet backported.

## Stacktrace

```
#0  Wayland_DestroyWindow (_this=0x5555d4fd4820, window=0x5555d4fd6550) at /usr/src/debug/libsdl2/2.32.10/src/video/wayland/SDL_waylandwindow.c:2297
#1  0x00007fff91cf7ae8 in SDL_RecreateWindow (window=window@entry=0x5555d4fd6550, flags=flags@entry=132) at /usr/src/debug/libsdl2/2.32.10/src/video/SDL_video.c:1970
#2  0x00007fff91c9976c in GL_CreateRenderer (renderer=0x5555d4febb00, window=0x5555d4fd6550, flags=2) at /usr/src/debug/libsdl2/2.32.10/src/render/opengl/SDL_render_gl.c:1943
#3  0x00007fff91c8f850 in SDL_CreateRenderer_REAL (window=0x5555d4fd6550, index=0, flags=2) at /usr/src/debug/libsdl2/2.32.10/src/render/SDL_render.c:1028
#4  0x00007fff91e78944 in window_create (disp=0x7fff91f01c08 <work_mem_int+5880>) at /usr/src/debug/lvgl/9.4.0/src/drivers/sdl/lv_sdl_window.c:402
#5  lv_sdl_window_create (hor_res=<optimized out>, ver_res=<optimized out>) at /usr/src/debug/lvgl/9.4.0/src/drivers/sdl/lv_sdl_window.c:118
```
