### PR TITLE
make sure #endif comment matches the macro name

### DIFF
--- a/include/SDL3/SDL_begin_code.h
+++ b/include/SDL3/SDL_begin_code.h
@@ -469,7 +469,7 @@
 #define NULL ((void *)0)
 #endif
 #endif /* NULL */
-#endif /* ! macOS - breaks precompiled headers */
+#endif /* __MACH__ */
 
 #ifndef SDL_FALLTHROUGH
 #if (defined(__cplusplus) && __cplusplus >= 201703L) || \

--- a/include/SDL3/SDL_endian.h
+++ b/include/SDL3/SDL_endian.h
@@ -208,7 +208,7 @@ _m_prefetch(void *__P)
 #else
 /* By default, assume that floats words follow the memory system mode. */
 #define SDL_FLOATWORDORDER   SDL_BYTEORDER
-#endif /* __FLOAT_WORD_ORDER__ */
+#endif /* SDL_WIKI_DOCUMENTATION_SECTION */
 #endif /* !SDL_FLOATWORDORDER */
 
 

--- a/include/SDL3/SDL_main.h
+++ b/include/SDL3/SDL_main.h
@@ -257,7 +257,7 @@
 #else
 /* usually this is empty */
 #define SDLMAIN_DECLSPEC
-#endif /* SDL_MAIN_EXPORTED */
+#endif /* SDL_WIKI_DOCUMENTATION_SECTION */
 
 #if defined(SDL_MAIN_NEEDED) || defined(SDL_MAIN_AVAILABLE) || defined(SDL_MAIN_USE_CALLBACKS)
 #define main SDL_main

--- a/src/SDL_assert.c
+++ b/src/SDL_assert.c
@@ -299,7 +299,7 @@ static SDL_AssertState SDLCALL SDL_PromptAssertion(const SDL_AssertData *data, v
         }
 #else
         SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_WARNING, "Assertion Failed", message, window);
-#endif // HAVE_STDIO_H
+#endif // SDL_PLATFORM_PRIVATE_ASSERT
     }
 
     // Re-enter fullscreen mode

--- a/src/events/SDL_keysym_to_keycode_c.h
+++ b/src/events/SDL_keysym_to_keycode_c.h
@@ -25,4 +25,4 @@
 // Convert a keysym to an SDL key code
 extern SDL_Keycode SDL_GetKeyCodeFromKeySym(Uint32 keysym, Uint32 keycode, SDL_Keymod modifiers);
 
-#endif // SDL_keysym_to_scancode_c_h_
+#endif // SDL_keysym_to_keycode_c_h_

--- a/src/events/SDL_quit.c
+++ b/src/events/SDL_quit.c
@@ -106,7 +106,7 @@ static void SDL_EventSignal_Quit(const int sig)
     if (ohandler != SDL_HandleSIG) {
         signal(sig, ohandler);
     }
-#endif // HAVE_SIGNAL_H
+#endif // HAVE_SIGACTION
 }
 
 // Public functions

--- a/src/io/SDL_iostream.c
+++ b/src/io/SDL_iostream.c
@@ -1135,7 +1135,7 @@ SDL_IOStream *SDL_IOFromFile(const char *file, const char *mode)
 
 #else
     SDL_SetError("SDL not compiled with stdio support");
-#endif // !HAVE_STDIO_H
+#endif // SDL_PLATFORM_ANDROID
 
     return iostr;
 }

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -1327,7 +1327,7 @@ SDL_Renderer *SDL_CreateSoftwareRenderer(SDL_Surface *surface)
 #else
     SDL_SetError("SDL not built with rendering support");
     return NULL;
-#endif // !SDL_RENDER_DISABLED
+#endif // SDL_VIDEO_RENDER_SW
 }
 
 SDL_Renderer *SDL_GetRenderer(SDL_Window *window)

--- a/src/sensor/SDL_syssensor.h
+++ b/src/sensor/SDL_syssensor.h
@@ -20,8 +20,8 @@
 */
 #include "SDL_internal.h"
 
-#ifndef SDL_syssensor_c_h_
-#define SDL_syssensor_c_h_
+#ifndef SDL_syssensor_h_
+#define SDL_syssensor_h_
 
 // This is the system specific header for the SDL sensor API
 

--- a/src/stdlib/SDL_string.c
+++ b/src/stdlib/SDL_string.c
@@ -718,7 +718,7 @@ int SDL_memcmp(const void *s1, const void *s2, size_t len)
         ++s2p;
     }
     return 0;
-#endif // HAVE_MEMCMP
+#endif // SDL_PLATFORM_VITA
 }
 
 size_t SDL_strlen(const char *string)
@@ -1119,7 +1119,7 @@ char *SDL_strnstr(const char *haystack, const char *needle, size_t maxlen)
         --maxlen;
     }
     return NULL;
-#endif // HAVE_STRSTR
+#endif // HAVE_STRNSTR
 }
 
 char *SDL_strstr(const char *haystack, const char *needle)

--- a/src/video/SDL_fillrect.c
+++ b/src/video/SDL_fillrect.c
@@ -131,7 +131,7 @@ DEFINE_SSE_FILLRECT(2, Uint16)
 DEFINE_SSE_FILLRECT(4, Uint32)
 
 /* *INDENT-ON* */ // clang-format on
-#endif            // __SSE__
+#endif            // SDL_SSE_INTRINSICS
 
 #ifdef SDL_LSX_INTRINSICS
 /* *INDENT-OFF* */ // clang-format off
@@ -194,7 +194,7 @@ static void SDL_TARGETING("lsx") SDL_FillSurfaceRect##bpp##LSX(Uint8 *pixels, in
 DEFINE_LSX_FILLRECT(4, Uint32)
 
 /* *INDENT-ON* */ // clang-format on
-#endif /* __LSX__ */
+#endif // SDL_LSX_INTRINSICS
 
 static void SDL_FillSurfaceRect1(Uint8 *pixels, int pitch, Uint32 color, int w, int h)
 {

--- a/src/video/miniz.h
+++ b/src/video/miniz.h
@@ -228,14 +228,14 @@
 // Set MINIZ_LITTLE_ENDIAN to 1 if the processor is little endian.
 #define MINIZ_LITTLE_ENDIAN 1
 #endif
-#endif /**/
+#endif // MINIZ_LITTLE_ENDIAN /* if not defined by SDL */
 
 #ifndef MINIZ_USE_UNALIGNED_LOADS_AND_STORES
 #if MINIZ_X86_OR_X64_CPU
 // Set MINIZ_USE_UNALIGNED_LOADS_AND_STORES to 1 on CPU's that permit efficient integer loads and stores from unaligned addresses.
 #define MINIZ_USE_UNALIGNED_LOADS_AND_STORES 1
 #endif
-#endif /**/
+#endif // MINIZ_USE_UNALIGNED_LOADS_AND_STORES
 
 #if defined(_M_X64) || defined(_WIN64) || defined(__MINGW64__) || defined(_LP64) || defined(__LP64__) || defined(__ia64__) || defined(__x86_64__)
 // Set MINIZ_HAS_64BIT_REGISTERS to 1 if operations on 64-bit integers are reasonably fast (and don't involve compiler generated calls to helper functions).

--- a/src/video/stb_image.h
+++ b/src/video/stb_image.h
@@ -3694,7 +3694,7 @@ static stbi_uc *stbi__resample_row_hv_2(stbi_uc *out, stbi_uc *in_near, stbi_uc 
 #define TARGETING_SSE2 SDL_TARGETING("sse2") /* Added by SDL */
 #else
 #define TARGETING_SSE2
-#endif /* Added by SDL */
+#endif // STBI_SSE2 /* Added by SDL */
 static stbi_uc *TARGETING_SSE2 stbi__resample_row_hv_2_simd(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs) /* Changed by SDL: TARGETING_SSE2 */
 {
    // need to generate 2x2 samples for every one in input


### PR DESCRIPTION
Fix the `#endif comment doesn't match the macro name` warning in several SDL files.

<img width="1100" height="222" alt="Screenshot 2026-02-24 at 11 43 32 AM" src="https://github.com/user-attachments/assets/a28efb80-a372-4f0d-ab9d-509fef67c45f" />
