### PR TITLE
Fix up controller types for various playstation and wii instruments

### DIFF
--- a/src/joystick/usb_ids.h
+++ b/src/joystick/usb_ids.h
@@ -52,7 +52,6 @@
 #define USB_VENDOR_QANBA        0x2c22
 #define USB_VENDOR_RAZER        0x1532
 #define USB_VENDOR_SAITEK       0x06a3
-#define USB_VENDOR_SCEA         0x12ba
 #define USB_VENDOR_SHANWAN      0x2563
 #define USB_VENDOR_SHANWAN_ALT  0x20bc
 #define USB_VENDOR_SONY         0x054c


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add IDs for a bunch of controllers that use the PS3 third party protocol

The Wii instruments were identical to the PS3 counterparts, they just used different ids
