### PR TITLE
Support third party PS3 controllers that don't use report IDs

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_ps3.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps3.c
@@ -635,7 +635,14 @@ static bool HIDAPI_DriverPS3ThirdParty_IsSupportedDevice(SDL_HIDAPI_Device *devi
                 // Supported third party controller
                 return true;
             } else {
-                return false;
+                // Some third party controllers don't have report ids
+                size = ReadFeatureReport(device->dev, 0x00, data, sizeof(data));
+                if (size == 9 && data[2] == 0x26) {
+                    // Supported third party controller
+                    return true;
+                } else {
+                    return false;
+                }
             }
         } else {
             // Might be supported by this driver, enumerate and find out


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Some third party controllers use a single report id for the entire device.
With these, we need to do a feature report read on report id 0, not 3

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
