### PR TITLE
Support accelerometers on 3rd party ps3 controllers

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_ps3.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps3.c
@@ -742,7 +742,6 @@ static bool HIDAPI_DriverPS3ThirdParty_SendJoystickEffect(SDL_HIDAPI_Device *dev
 
 static bool HIDAPI_DriverPS3ThirdParty_SetJoystickSensorsEnabled(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, bool enabled)
 {
-    
     SDL_DriverPS3_Context *ctx = (SDL_DriverPS3_Context *)device->context;
 
     ctx->report_sensors = enabled;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add support for accelerometers on 3rd party ps3 controllers

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
