### PR TITLE
Use Uint64 for tick_numerators when using USE_128BIT_MATH

### DIFF
--- a/src/timer/SDL_timer.c
+++ b/src/timer/SDL_timer.c
@@ -541,8 +541,8 @@ typedef unsigned __int128 Uint128;
 
 static Uint64 tick_start;
 #ifdef USE_128BIT_MATH
-static Uint128 tick_numerator_ns;
-static Uint128 tick_numerator_ms;
+static Uint64 tick_numerator_ns;
+static Uint64 tick_numerator_ms;
 #else
 static Uint32 tick_numerator_ns;
 static Uint32 tick_denominator_ns;
@@ -609,8 +609,8 @@ void SDL_InitTicks(void)
     SDL_assert(tick_freq > 0 && tick_freq <= (Uint64)SDL_MAX_UINT32);
 
 #ifdef USE_128BIT_MATH
-    tick_numerator_ns = ((Uint128)SDL_NS_PER_SECOND << 32) / tick_freq;
-    tick_numerator_ms = ((Uint128)SDL_MS_PER_SECOND << 32) / tick_freq;
+    tick_numerator_ns = ((Uint64)SDL_NS_PER_SECOND << 32) / tick_freq;
+    tick_numerator_ms = ((Uint64)SDL_MS_PER_SECOND << 32) / tick_freq;
 #else
     gcd = SDL_CalculateGCD(SDL_NS_PER_SECOND, (Uint32)tick_freq);
     tick_numerator_ns = (SDL_NS_PER_SECOND / gcd);


### PR DESCRIPTION
Avoids the 128-bit divides and 128x128 multiplies.

A basic benchmark of just hammering SDL_GetTicks() comes out to about
30 ns/call without USE_128BIT_MATH
25 ns/call with USE_128BIT_MATH
23 ns/call for just SDL_GetPerformanceCounter()
It's ultimately not a very huge difference on x64.

```
#include <SDL3/SDL.h>
#include <SDL3/SDL_main.h>

int
main(int argc, char** argv)
{
	SDL_Init(0);

	Uint64 iterations = 10000000;

	SDL_Log("testing...");

	// Do some warmup
	for (Uint64 i = 0; i < iterations; i += 1)
	{
		SDL_GetTicks();
	}


	// Actually measure
	Uint64 before = SDL_GetTicksNS();
	for (Uint64 i = 0; i < iterations; i += 1)
	{
		SDL_GetTicks();
	}
	Uint64 after = SDL_GetTicksNS();

	SDL_Log("time/call: %f ns", (double)(after - before) / (double)iterations);

	SDL_Quit();
	return 0;
}
```