### PR TITLE
make SDL_GetIOSize return -1 on SDL_InvalidParamError

### DIFF
--- a/src/io/SDL_iostream.c
+++ b/src/io/SDL_iostream.c
@@ -1513,7 +1513,8 @@ SDL_PropertiesID SDL_GetIOProperties(SDL_IOStream *context)
 Sint64 SDL_GetIOSize(SDL_IOStream *context)
 {
     CHECK_PARAM(!context) {
-        return SDL_InvalidParamError("context");
+        SDL_InvalidParamError("context");
+        return -1;
     }
 
     if (!context->iface.size) {


### PR DESCRIPTION
Fix #15129 

Judging by what similar surrounding code does, return -1.