### PR TITLE
make sure #endif comment matches the macro name

### DIFF
--- a/src/dialog/unix/SDL_zenitymessagebox.h
+++ b/src/dialog/unix/SDL_zenitymessagebox.h
@@ -25,4 +25,4 @@
 extern bool SDL_Zenity_ShowMessageBox(const SDL_MessageBoxData *messageboxdata, int *buttonID);
 extern bool SDL_get_zenity_version(int *major, int *minor);
 
-#endif // SDL_waylandmessagebox_h_
+#endif // SDL_zenitymessagebox_h_

--- a/src/haptic/hidapi/SDL_hidapihaptic_c.h
+++ b/src/haptic/hidapi/SDL_hidapihaptic_c.h
@@ -67,4 +67,4 @@ struct SDL_HIDAPI_HapticDriver
 
 extern SDL_HIDAPI_HapticDriver SDL_HIDAPI_HapticDriverLg4ff;
 
-#endif //SDL_joystick_c_h_
+#endif //SDL_hidapihaptic_c_h_

--- a/src/joystick/hidapi/steam/controller_constants.h
+++ b/src/joystick/hidapi/steam/controller_constants.h
@@ -585,4 +585,4 @@ typedef enum
 }
 #endif
 
-#endif // _CONTROLLER_CONSTANTS_H
+#endif // _CONTROLLER_CONSTANTS_

--- a/src/joystick/hidapi/steam/controller_structs.h
+++ b/src/joystick/hidapi/steam/controller_structs.h
@@ -664,4 +664,4 @@ typedef struct
 
 #pragma pack()
 
-#endif // _CONTROLLER_STRUCTS
+#endif // _CONTROLLER_STRUCTS_

--- a/src/thread/n3ds/SDL_sysmutex_c.h
+++ b/src/thread/n3ds/SDL_sysmutex_c.h
@@ -30,4 +30,4 @@ struct SDL_Mutex
     RecursiveLock lock;
 };
 
-#endif // SDL_sysmutex_c_h
+#endif // SDL_sysmutex_c_h_

--- a/src/video/openvr/SDL_openvrvideo.c
+++ b/src/video/openvr/SDL_openvrvideo.c
@@ -1667,5 +1667,5 @@ VideoBootStrap OPENVR_bootstrap = {
     "openvr", "SDL OpenVR video driver", OPENVR_CreateDevice, NULL, false
 };
 
-#endif // SDL_VIDEO_DRIVER_WINDOWS
+#endif // SDL_VIDEO_DRIVER_OPENVR
 

--- a/src/video/vita/SDL_vitavideo.h
+++ b/src/video/vita/SDL_vitavideo.h
@@ -117,4 +117,4 @@ extern void VITA_HideScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window);
 
 extern void VITA_PumpEvents(SDL_VideoDevice *_this);
 
-#endif // SDL_pspvideo_h
+#endif // SDL_vitavideo_h


### PR DESCRIPTION
Fix the #endif comment doesn't match the macro name warning in several SDL files.
