### PR TITLE
Fix memory leak when X11 toolkit window locale SDL_strdup() fails

### DIFF
--- a/src/video/x11/SDL_x11toolkit.c
+++ b/src/video/x11/SDL_x11toolkit.c
@@ -976,6 +976,7 @@ SDL_ToolkitWindowX11 *X11Toolkit_CreateWindowStruct(SDL_Window *parent, SDL_Tool
         if (window->origlocale) {
             window->origlocale = SDL_strdup(window->origlocale);
             if (!window->origlocale) {
+                SDL_free(window);
                 return NULL;
             }
             (void)setlocale(LC_ALL, "");


### PR DESCRIPTION
Freeing dynamically allocated `window` before returning `NULL`.

It's unlikely that `SDL_strdup` would fail, but this at least gets rid of one more clang-tidy `clang-analyzer-unix.Malloc` warning.

<details><summary>Warning</summary>
<p>

```
SDL/src/video/x11/SDL_x11toolkit.c:979:24: warning: Potential leak of memory pointed to by 'window' [clang-analyzer-unix.Malloc]
  979 |                 return NULL;
      |                        ^
/usr/lib/clang/21/include/__stddef_null.h:26:22: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |                      ^
SDL/src/video/x11/SDL_x11toolkit.c:957:9: note: Assuming the condition is false
  957 |     if (!SDL_X11_LoadSymbols()) {
      |         ^~~~~~~~~~~~~~~~~~~~~~
SDL/src/video/x11/SDL_x11toolkit.c:957:5: note: Taking false branch
  957 |     if (!SDL_X11_LoadSymbols()) {
      |     ^
SDL/src/video/x11/SDL_x11toolkit.c:964:38: note: Memory is allocated
  964 |     window = (SDL_ToolkitWindowX11 *)SDL_malloc(sizeof(SDL_ToolkitWindowX11));
      |                                      ^
SDL/include/SDL3/SDL_stdinc.h:6037:20: note: expanded from macro 'SDL_malloc'
 6037 | #define SDL_malloc malloc
      |                    ^
SDL/src/video/x11/SDL_x11toolkit.c:965:9: note: Assuming 'window' is non-null
  965 |     if (!window) {
      |         ^~~~~~~
SDL/src/video/x11/SDL_x11toolkit.c:965:5: note: Taking false branch
  965 |     if (!window) {
      |     ^
SDL/src/video/x11/SDL_x11toolkit.c:974:9: note: Assuming 'mode' is equal to SDL_TOOLKIT_WINDOW_MODE_X11_DIALOG
  974 |     if (mode == SDL_TOOLKIT_WINDOW_MODE_X11_DIALOG) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL/src/video/x11/SDL_x11toolkit.c:974:5: note: Taking true branch
  974 |     if (mode == SDL_TOOLKIT_WINDOW_MODE_X11_DIALOG) {
      |     ^
SDL/src/video/x11/SDL_x11toolkit.c:976:13: note: Assuming field 'origlocale' is non-null
  976 |         if (window->origlocale) {
      |             ^~~~~~~~~~~~~~~~~~
SDL/src/video/x11/SDL_x11toolkit.c:976:9: note: Taking true branch
  976 |         if (window->origlocale) {
      |         ^
SDL/src/video/x11/SDL_x11toolkit.c:978:17: note: Assuming field 'origlocale' is null
  978 |             if (!window->origlocale) {
      |                 ^~~~~~~~~~~~~~~~~~~
SDL/src/video/x11/SDL_x11toolkit.c:978:13: note: Taking true branch
  978 |             if (!window->origlocale) {
      |             ^
SDL/src/video/x11/SDL_x11toolkit.c:979:24: note: Potential leak of memory pointed to by 'window'
  979 |                 return NULL;
      |                        ^
/usr/lib/clang/21/include/__stddef_null.h:26:22: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |                      ^
```

</p>
</details>
