### PR TITLE
Fix potential memory leak in SDL_HIDAPI_HapticOpenFromJoystick() on error

### DIFF
--- a/src/haptic/hidapi/SDL_hidapihaptic.c
+++ b/src/haptic/hidapi/SDL_hidapihaptic.c
@@ -147,6 +147,7 @@ bool SDL_HIDAPI_HapticOpenFromJoystick(SDL_Haptic *haptic, SDL_Joystick *joystic
             haptic->neffects = device->driver->NumEffects(device);
             haptic->effects = (struct haptic_effect *)SDL_malloc(sizeof(struct haptic_effect) * haptic->neffects);
             if (haptic->effects == NULL) {
+                SDL_free(list_node);
                 device->driver->Close(device);
                 SDL_free(device);
                 return SDL_OutOfMemory();


### PR DESCRIPTION
Freeing `list_node` before returning.

<details><summary>Warning</summary>
<p>

```
SDL/src/haptic/hidapi/SDL_hidapihaptic.c:150:17: warning: Potential leak of memory pointed to by 'list_node' [clang-analyzer-unix.Malloc]
  150 |                 device->driver->Close(device);
      |                 ^
SDL/src/haptic/hidapi/SDL_hidapihaptic.c:103:9: note: Assuming the condition is false
  103 |     if (joystick->driver != &SDL_HIDAPI_JoystickDriver) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL/src/haptic/hidapi/SDL_hidapihaptic.c:103:5: note: Taking false branch
  103 |     if (joystick->driver != &SDL_HIDAPI_JoystickDriver) {
      |     ^
SDL/src/haptic/hidapi/SDL_hidapihaptic.c:107:5: note: Loop condition is true.  Entering loop body
  107 |     for (i = 0; i < numdrivers; ++i) {
      |     ^
SDL/src/haptic/hidapi/SDL_hidapihaptic.c:108:13: note: Assuming the condition is true
  108 |         if (drivers[i]->JoystickSupported(joystick)) {
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL/src/haptic/hidapi/SDL_hidapihaptic.c:108:9: note: Taking true branch
  108 |         if (drivers[i]->JoystickSupported(joystick)) {
      |         ^
SDL/src/haptic/hidapi/SDL_hidapihaptic.c:113:17: note: Assuming 'ctx' is not equal to NULL
  113 |             if (ctx == NULL) {
      |                 ^~~~~~~~~~~
SDL/src/haptic/hidapi/SDL_hidapihaptic.c:113:13: note: Taking false branch
  113 |             if (ctx == NULL) {
      |             ^
SDL/src/haptic/hidapi/SDL_hidapihaptic.c:118:17: note: Assuming 'device' is not equal to NULL
  118 |             if (device == NULL) {
      |                 ^~~~~~~~~~~~~~
SDL/src/haptic/hidapi/SDL_hidapihaptic.c:118:13: note: Taking false branch
  118 |             if (device == NULL) {
      |             ^
SDL/src/haptic/hidapi/SDL_hidapihaptic.c:132:25: note: Memory is allocated
  132 |             list_node = SDL_malloc(sizeof(haptic_list_node));
      |                         ^
SDL/include/SDL3/SDL_stdinc.h:6037:20: note: expanded from macro 'SDL_malloc'
 6037 | #define SDL_malloc malloc
      |                    ^
SDL/src/haptic/hidapi/SDL_hidapihaptic.c:133:17: note: Assuming 'list_node' is not equal to NULL
  133 |             if (list_node == NULL) {
      |                 ^~~~~~~~~~~~~~~~~
SDL/src/haptic/hidapi/SDL_hidapihaptic.c:133:13: note: Taking false branch
  133 |             if (list_node == NULL) {
      |             ^
SDL/src/haptic/hidapi/SDL_hidapihaptic.c:149:17: note: Assuming field 'effects' is equal to NULL
  149 |             if (haptic->effects == NULL) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~
SDL/src/haptic/hidapi/SDL_hidapihaptic.c:149:13: note: Taking true branch
  149 |             if (haptic->effects == NULL) {
      |             ^
SDL/src/haptic/hidapi/SDL_hidapihaptic.c:150:17: note: Potential leak of memory pointed to by 'list_node'
  150 |                 device->driver->Close(device);
      |                 ^
```

</p>
</details> 