### PR TITLE
fix off by one with tilt on ps3 guitars

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_ps3.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps3.c
@@ -349,8 +349,6 @@ static float HIDAPI_DriverPS3_ScaleAccel(Sint16 value)
 
 static float HIDAPI_DriverPS3ThirdParty_ScaleAccel(Sint16 value)
 {
-    // Accelerometer values are in big endian order
-    value = SDL_Swap16BE(value);
     return ((float)(value - 512) / 113.0f) * SDL_STANDARD_GRAVITY;
 }
 
@@ -1027,9 +1025,9 @@ static void HIDAPI_DriverPS3ThirdParty_HandleStatePacket19(SDL_Joystick *joystic
     if (ctx->report_sensors) {
         float sensor_data[3];
 
-        sensor_data[0] = -HIDAPI_DriverPS3ThirdParty_ScaleAccel(LOAD16(data[20], data[19]));
-        sensor_data[1] = -HIDAPI_DriverPS3ThirdParty_ScaleAccel(LOAD16(data[22], data[21]));
-        sensor_data[2] = -HIDAPI_DriverPS3ThirdParty_ScaleAccel(LOAD16(data[24], data[23]));
+        sensor_data[0] = -HIDAPI_DriverPS3ThirdParty_ScaleAccel(LOAD16(data[19], data[20]));
+        sensor_data[1] = -HIDAPI_DriverPS3ThirdParty_ScaleAccel(LOAD16(data[21], data[22]));
+        sensor_data[2] = -HIDAPI_DriverPS3ThirdParty_ScaleAccel(LOAD16(data[23], data[24]));
         SDL_SendJoystickSensor(timestamp, joystick, SDL_SENSOR_ACCEL, timestamp, sensor_data, SDL_arraysize(sensor_data));
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix off-by-one with tilt on PS3 instruments, turns out the games were looking for the guitars hitting a maximum value and it was never hitting that value

Also, since we are no longer using the same function for handling tilt, fix the fact that tilt on third party instruments is actually little endian, and previously we were just flipping it twice

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
