### PR TITLE
Wayland: Use raw keycode for the spacebar

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -1668,6 +1668,9 @@ static void Wayland_KeymapIterator(struct xkb_keymap *keymap, xkb_keycode_t key,
                         case SDL_SCANCODE_DELETE:
                             keycode = SDLK_DELETE;
                             break;
+                        case SDL_SCANCODE_SPACE:
+                            keycode = SDLK_SPACE;
+                            break;
                         default:
                             keycode = SDL_SCANCODE_TO_KEYCODE(scancode);
                             break;


### PR DESCRIPTION
## Description

sdl12-compat in its default configuration reports the spacebar as an unknown key otherwise (which means keycode scanning for that key won't work)

This was observed while testing one of the last applications made with SDL1 (in the same year as SDL2)
