### PR TITLE
camera: Fix crash when setting frame rate and improve FPS precision

### DIFF
--- a/src/camera/coremedia/SDL_camera_coremedia.m
+++ b/src/camera/coremedia/SDL_camera_coremedia.m
@@ -371,8 +371,7 @@ static bool COREMEDIA_OpenDevice(SDL_Camera *device, const SDL_CameraSpec *spec)
     avdevice.activeFormat = spec_format;
 
     // Try to set the frame duration to enforce the requested frame rate
-    const float frameRate = (float)spec->framerate_numerator / spec->framerate_denominator;
-    const CMTime frameDuration = CMTimeMake(1, (int32_t)frameRate);
+    const CMTime frameDuration = CMTimeMake(spec->framerate_denominator, spec->framerate_numerator);
 
     // Check if the device supports setting frame duration
     if ([avdevice respondsToSelector:@selector(setActiveVideoMinFrameDuration:)] &&
@@ -442,8 +441,12 @@ static bool COREMEDIA_OpenDevice(SDL_Camera *device, const SDL_CameraSpec *spec)
 
     // Try to set the frame rate on the device (preferred modern approach)
     if ([avdevice lockForConfiguration:nil]) {
-        avdevice.activeVideoMinFrameDuration = frameDuration;
-        avdevice.activeVideoMaxFrameDuration = frameDuration;
+        @try {
+            avdevice.activeVideoMinFrameDuration = frameDuration;
+            avdevice.activeVideoMaxFrameDuration = frameDuration;
+        } @catch (NSException *exception) {
+            // Some devices don't support setting frame duration, that's okay
+        }
         [avdevice unlockForConfiguration];
     }
 


### PR DESCRIPTION
Fix a crash in the CoreMedia camera backend on macOS and improves the precision of hardware frame rate requests.

Strict camera drivers throw an NSInvalidArgumentException if a requested frame rate duration is not an exact match or is unsupported. Commit 0270da4d1f introduced an unprotected call to activeVideoMinFrameDuration that causes a hard crash on these devices.

The fix calculates CMTime durations using the exact spec numerator/denominator to avoid rounding errors and hardware rejection and wraps frame rate settings in a @try-catch block to ensure safety on all drivers.

Crash reason:
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[AVCaptureDevice_Tundra setActiveVideoMinFrameDuration:] Not supported - Supported ranges: (
    "<AVFrameRateRange: 0x6000030fdbb0 60.00 - 60.00 (1000000 / 60000240 - 1000000 / 60000240)>",
    "<AVFrameRateRange: 0x6000030fdbc0 50.00 - 50.00 (1000000 / 50000000 - 1000000 / 50000000)>",
    "<AVFrameRateRange: 0x6000030fdbd0 30.00 - 30.00 (1000000 / 30000030 - 1000000 / 30000030)>",
    "<AVFrameRateRange: 0x6000030fdbe0 20.00 - 20.00 (1000000 / 20000000 - 1000000 / 20000000)>",
    "<AVFrameRateRange: 0x6000030fdbf0 10.00 - 10.00 (1000000 / 10000000 - 1000000 / 10000000)>"
), tried to set maxFrameRate to 60.000000 (1 / 60)'
