### PR TITLE
Fix backspace on android with api 30+

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLInputConnection.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLInputConnection.java
@@ -65,17 +65,15 @@ class SDLInputConnection extends BaseInputConnection
 
     @Override
     public boolean deleteSurroundingText(int beforeLength, int afterLength) {
-        if (Build.VERSION.SDK_INT <= 29 /* Android 10.0 (Q) */) {
-            // Workaround to capture backspace key. Ref: http://stackoverflow.com/questions>/14560344/android-backspace-in-webview-baseinputconnection
-            // and https://bugzilla.libsdl.org/show_bug.cgi?id=2265
-            if (beforeLength > 0 && afterLength == 0) {
-                // backspace(s)
-                while (beforeLength-- > 0) {
-                    nativeGenerateScancodeForUnichar('\b');
-                }
-                return true;
-           }
-        }
+        // Workaround to capture backspace key. Ref: http://stackoverflow.com/questions>/14560344/android-backspace-in-webview-baseinputconnection
+        // and https://bugzilla.libsdl.org/show_bug.cgi?id=2265
+        if (beforeLength > 0 && afterLength == 0) {
+            // backspace(s)
+            while (beforeLength-- > 0) {
+                nativeGenerateScancodeForUnichar('\b');
+            }
+            return true;
+       }
 
         if (!super.deleteSurroundingText(beforeLength, afterLength)) {
             return false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Apply the same workaround used for 29 and below when running on android api 30+.

## Description
<!--- Describe your changes in detail -->
Pressing the backspace key would not work properly for text added prior to restarting the text input. For android 29 and below uses a workaround for this case.

The workaround used to be applied for all android versions, but it was removed in 82e341bc9e914e753fe7842834d37b16aebc4ad5. When it was added back in c971795954bc85086cd20cfc71b45a311b7ba0d1, it was added only for apis 29 and below, but I cannot find any evidence online that the behaviour changed in api 30 and my api 35 device still exhibits the broken behaviour without the workaround applied.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #15067