### PR TITLE
support batteries on third party PS5 controllers

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_ps5.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps5.c
@@ -469,6 +469,10 @@ static bool HIDAPI_DriverPS5_InitDevice(SDL_HIDAPI_Device *device)
                 ctx->playerled_supported = true;
             }
 
+            if (capabilities2 & 0x01) {
+                ctx->report_battery = true;
+            }
+
             switch (device_type) {
             case 0x00:
                 joystick_type = SDL_JOYSTICK_TYPE_GAMEPAD;
@@ -494,6 +498,7 @@ static bool HIDAPI_DriverPS5_InitDevice(SDL_HIDAPI_Device *device)
             }
 
             ctx->use_alternate_report = true;
+            ctx->report_battery = true;
 
             if (device->vendor_id == USB_VENDOR_NACON_ALT &&
                 (device->product_id == USB_PRODUCT_NACON_REVOLUTION_5_PRO_PS5_WIRED ||
@@ -1443,6 +1448,36 @@ static void HIDAPI_DriverPS5_HandleStatePacketAlt(SDL_Joystick *joystick, SDL_hi
         touchpad_x = packet->rgucTouchpadData2[0] | (((int)packet->rgucTouchpadData2[1] & 0x0F) << 8);
         touchpad_y = (packet->rgucTouchpadData2[1] >> 4) | ((int)packet->rgucTouchpadData2[2] << 4);
         SDL_SendJoystickTouchpad(timestamp, joystick, 0, 1, touchpad_down, touchpad_x * TOUCHPAD_SCALEX, touchpad_y * TOUCHPAD_SCALEY, touchpad_down ? 1.0f : 0.0f);
+    }
+
+    if (ctx->report_battery) {
+        SDL_PowerState state;
+        int percent;
+        Uint8 status = (packet->ucBatteryLevel >> 4) & 0x0F;
+        Uint8 level = (packet->ucBatteryLevel & 0x0F);
+
+        // 0x0C means a controller isn't reporting battery levels
+        if (level != 0x0C) {
+            switch (status) {
+            case 0:
+                state = SDL_POWERSTATE_ON_BATTERY;
+                percent = SDL_min(level * 10 + 5, 100);
+                break;
+            case 1:
+                state = SDL_POWERSTATE_CHARGING;
+                percent = SDL_min(level * 10 + 5, 100);
+                break;
+            case 2:
+                state = SDL_POWERSTATE_CHARGED;
+                percent = 100;
+                break;
+            default:
+                state = SDL_POWERSTATE_UNKNOWN;
+                percent = 0;
+                break;
+            }
+            SDL_SendJoystickPowerInfo(joystick, state, percent);
+        }
     }
 
     HIDAPI_DriverPS5_HandleStatePacketCommon(joystick, dev, ctx, (PS5StatePacketCommon_t *)packet, timestamp);

--- a/src/joystick/hidapi/SDL_hidapijoystick.c
+++ b/src/joystick/hidapi/SDL_hidapijoystick.c
@@ -174,6 +174,8 @@ bool HIDAPI_SupportsPlaystationDetection(Uint16 vendor, Uint16 product)
     }
 
     switch (vendor) {
+    case USB_VENDOR_CRKD:
+        return true;
     case USB_VENDOR_DRAGONRISE:
         return true;
     case USB_VENDOR_HORI:

--- a/src/joystick/usb_ids.h
+++ b/src/joystick/usb_ids.h
@@ -30,6 +30,7 @@
 #define USB_VENDOR_ASTRO        0x9886
 #define USB_VENDOR_ASUS         0x0b05
 #define USB_VENDOR_BACKBONE     0x358a
+#define USB_VENDOR_CRKD         0x3651
 #define USB_VENDOR_GAMESIR      0x3537
 #define USB_VENDOR_DRAGONRISE   0x0079
 #define USB_VENDOR_FLYDIGI_V1   0x04b4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Support reading back battery levels for third party PS5 controllers. Also handles the case that a controller just responds that it doesn't support battery levels.

Since the only device i had nearby was a CRKD guitar, i also added its VID to the list of devices that support playstation detection. Everything works perfectly fine with these guitars using PS4 and PS5 drivers, I did a lot of testing on that previously for another PR.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
