### PR TITLE
SDL_GlobDirectory(): Two fixes when the path is root  `"/"`

### DIFF
--- a/src/filesystem/SDL_filesystem.c
+++ b/src/filesystem/SDL_filesystem.c
@@ -426,8 +426,15 @@ char **SDL_InternalGlobDirectory(const char *path, const char *pattern, SDL_Glob
     data.enumerator = enumerator;
     data.getpathinfo = getpathinfo;
     data.fsuserdata = userdata;
-    data.basedirlen = *path ? (pathlen + 1) : 0;  // +1 for the '/' we'll be adding.
 
+    data.basedirlen = 0;
+    if (*path) {
+        if (SDL_strcmp(path, "/") == 0 || SDL_strcmp(path, "\\") == 0) {
+            data.basedirlen = 1;
+        } else {
+            data.basedirlen = pathlen + 1; // +1 for the '/' we'll be adding.
+        }
+    }
 
     char **result = NULL;
     if (data.enumerator(path, GlobDirectoryCallback, &data, data.fsuserdata)) {


### PR DESCRIPTION
- First commit fixes an issue where a path with multiple slashes `"/////"` gets chopped down to an empty string `""`, instead of a string with just one slash `"/"`.

- Second commit (,just a bit refactoring,) updates the variable `pathlen` when the path gets chopped, so that this variable can be used, instead of calling `SDL_strlen()` again.

- Third commit addresses the issue #15168
where, if the globbed dir is the root directory `"/"`, it choppes of the first character from sub-entries, because it thinks the root path has another path separator. (Fixes #15168)

@icculus, could you look into the third commit?
Especially, if I understood the use of the `data->basedirlen` variable correctly:
https://github.com/libsdl-org/SDL/blob/0c57e99b4a47a48f1110764252247d024a4f5abd/src/filesystem/SDL_filesystem.c#L331-L338