### PR TITLE
Fix not setting graphics pipeline primitive type for Metal

### DIFF
--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -2371,6 +2371,19 @@ static void METAL_BeginRenderPass(
             METAL_INTERNAL_TrackTexture(metalCommandBuffer, texture);
         }
 
+        Uint32 layerCount = 0;
+        for (Uint32 i = 0; i < numColorTargets; i += 1) {
+            MetalTextureContainer *container = (MetalTextureContainer *)colorTargetInfos[i].texture;
+            if (container->header.info.type == SDL_GPU_TEXTURETYPE_2D_ARRAY) {
+                layerCount = SDL_max(layerCount, container->header.info.layer_count_or_depth);
+            } else if (container->header.info.type == SDL_GPU_TEXTURETYPE_CUBE) {
+                layerCount = SDL_max(layerCount, 6);
+            } else if (container->header.info.type == SDL_GPU_TEXTURETYPE_CUBE_ARRAY) {
+                layerCount = SDL_max(layerCount, 6 * container->header.info.layer_count_or_depth);
+            }
+        }
+        passDescriptor.renderTargetArrayLength = layerCount;
+
         metalCommandBuffer->renderEncoder = [metalCommandBuffer->handle renderCommandEncoderWithDescriptor:passDescriptor];
 
         // The viewport cannot be larger than the smallest target.


### PR DESCRIPTION
This information is needed when a vertex shader outputs `[[render_target_array_index]]` for a 2D texture array.

The GPU needs to know the primitive topology at pipeline compile time to determine which vertex's array index value to use when routing fragments to the layered texture.

Fixes this pipeline creation error:
> ERROR: Creating render pipeline failed: Error Domain=AGXMetal13_3 Code=3 "Vertex shader writes render_target_array_index but inputPrimitiveTopology is not specified" UserInfo={NSLocalizedDescription=Vertex shader writes render_target_array_index but inputPrimitiveTopology is not specified}

## Existing Issue(s)
None found.

## Other platforms

I haven't checked D3D12, Vulkan and XR because I'm only running macOS. Would someone be able to check other other [GPU backends](https://github.com/libsdl-org/SDL/tree/main/src/gpu) and apply the same patch there if needed? Thanks!

## Reproduction

```c
#include <SDL3/SDL.h>

static const char *VERT_MSL =
  "#include <metal_stdlib>\n"
  "using namespace metal;\n"
  "struct VSOut {\n"
  "    float4 position [[position]];\n"
  "    uint   layer    [[render_target_array_index]];\n"
  "};\n"
  "struct VSIn {\n"
  "    float2 position [[attribute(0)]];\n"
  "    uint   layer    [[attribute(1)]];\n"
  "};\n"
  "vertex VSOut vert_main(VSIn in [[stage_in]]) {\n"
  "    VSOut out;\n"
  "    out.position = float4(in.position, 0.0, 1.0);\n"
  "    out.layer    = in.layer;\n"
  "    return out;\n"
  "}\n";

static const char *FRAG_MSL =
  "#include <metal_stdlib>\n"
  "using namespace metal;\n"
  "struct FSIn {\n"
  "    float4 position [[position]];\n"
  "};\n"
  "fragment float4 frag_main(FSIn in [[stage_in]]) {\n"
  "    return float4(1.0, 1.0, 1.0, 1.0);\n"
  "}\n";

int main(int argc, char *argv[]) {
  SDL_Init(SDL_INIT_VIDEO);
  SDL_Window *window = SDL_CreateWindow("SDL3 Metal Repro", 640, 480, 0);
  SDL_GPUDevice *device = SDL_CreateGPUDevice(SDL_GPU_SHADERFORMAT_MSL, false, NULL);
  SDL_ClaimWindowForGPUDevice(device, window);

  SDL_GPUTexture *array_texture = SDL_CreateGPUTexture(device, &(SDL_GPUTextureCreateInfo){
    .type = SDL_GPU_TEXTURETYPE_2D_ARRAY,
    .format = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM,
    .usage = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET,
    .width = 500,
    .height = 500,
    .layer_count_or_depth = 4,
    .num_levels = 1,
    .sample_count = SDL_GPU_SAMPLECOUNT_1,
  });

  SDL_GPUShader *vert = SDL_CreateGPUShader(device, &(SDL_GPUShaderCreateInfo){
    .stage = SDL_GPU_SHADERSTAGE_VERTEX,
    .format = SDL_GPU_SHADERFORMAT_MSL,
    .code = (const Uint8 *)VERT_MSL,
    .code_size = SDL_strlen(VERT_MSL),
    .entrypoint = "vert_main"
  });

  SDL_GPUShader *frag = SDL_CreateGPUShader(device, &(SDL_GPUShaderCreateInfo){
    .stage = SDL_GPU_SHADERSTAGE_FRAGMENT,
    .format = SDL_GPU_SHADERFORMAT_MSL,
    .code = (const Uint8 *)FRAG_MSL,
    .code_size = SDL_strlen(FRAG_MSL),
    .entrypoint = "frag_main"
  });

  SDL_GPUGraphicsPipeline *pipeline = SDL_CreateGPUGraphicsPipeline(device, &(SDL_GPUGraphicsPipelineCreateInfo){
    .vertex_shader   = vert,
    .fragment_shader = frag,
    .primitive_type  = SDL_GPU_PRIMITIVETYPE_LINELIST,
    .vertex_input_state = {
      .num_vertex_buffers = 1,
      .vertex_buffer_descriptions = (SDL_GPUVertexBufferDescription[]){
        { .slot = 0, .pitch = sizeof(float) * 2 + sizeof(Uint32), .input_rate = SDL_GPU_VERTEXINPUTRATE_VERTEX },
      },
      .num_vertex_attributes = 2,
      .vertex_attributes = (SDL_GPUVertexAttribute[]){
        { .buffer_slot = 0, .location = 0, .format = SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2, .offset = 0 },
        { .buffer_slot = 0, .location = 1, .format = SDL_GPU_VERTEXELEMENTFORMAT_UINT, .offset = sizeof(float) * 2 },
      },
    },
    .target_info = {
      .num_color_targets = 1,
      .color_target_descriptions = (SDL_GPUColorTargetDescription[]){
        { .format = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM },
      },
    },
  });

  if (pipeline) {
    SDL_Log("PASS: pipeline created successfully (SDL3 is patched)");
    SDL_ReleaseGPUGraphicsPipeline(device, pipeline);
  } else {
    SDL_Log("FAIL (expected on unpatched SDL3): %s", SDL_GetError());
  }

  SDL_ReleaseGPUShader(device, vert);
  SDL_ReleaseGPUShader(device, frag);
  SDL_ReleaseGPUTexture(device, array_texture);
  SDL_ReleaseWindowFromGPUDevice(device, window);
  SDL_DestroyGPUDevice(device);
  SDL_DestroyWindow(window);
  SDL_Quit();
}
```
