### PR TITLE
Fix strpbrk() discarded const qualifier

### DIFF
--- a/src/stdlib/SDL_string.c
+++ b/src/stdlib/SDL_string.c
@@ -2479,7 +2479,7 @@ int SDL_vasprintf(char **strp, SDL_PRINTF_FORMAT_STRING const char *fmt, va_list
 char * SDL_strpbrk(const char *str, const char *breakset)
 {
 #ifdef HAVE_STRPBRK
-    return strpbrk(str, breakset);
+    return SDL_const_cast(char *, strpbrk(str, breakset));
 #else
 
     for (; *str; str++) {


### PR DESCRIPTION
## Description
Some recent system update (Arch Linux), likely GCC or glibc, now seems to do the same for `strpbrk()` as was already done for `strstr()` and a bunch of other `string.h` functions. These functions that return a pointer within a buffer passed by the user now return it as const if the buffer was passed as const by the user. Like was done in SDL for `strstr()` and other string.h friends, added a `const_cast()` to discard it and fix the compilation failure.

## Existing Issue(s)
None that i could find.
